### PR TITLE
crash in VCAI::completeGoal() fixed

### DIFF
--- a/AI/VCAI/VCAI.cpp
+++ b/AI/VCAI/VCAI.cpp
@@ -1415,14 +1415,15 @@ void VCAI::completeGoal (Goals::TSubgoal goal)
 	}
 	else //complete goal for all heroes maybe?
 	{
-		for (auto p : lockedHeroes)
+		vstd::erase_if(lockedHeroes, [goal](std::pair<HeroPtr, Goals::TSubgoal> p)
 		{
 			if (*(p.second) == *goal || p.second->fulfillsMe(goal)) //we could have fulfilled goals of other heroes by chance
 			{
 				logAi->debugStream() << boost::format("%s") % p.second->completeMessage();
-				lockedHeroes.erase (lockedHeroes.find(p.first)); //is it safe?
+				return true;
 			}
-		}
+			return false;
+		});
 	}
 
 }


### PR DESCRIPTION
there was a crash in line `for (auto p : lockedHeroes)` after incorrect modifying of map inside `for`

`lockedHeroes.erase (lockedHeroes.find(p.first)); //is it safe?`
no, it was not :)

Can be reproduced after loading saves:
https://www.dropbox.com/s/jrl4p6mlrj4h17w/completeGoal_crash.vcgm1
https://www.dropbox.com/s/rs1u0ypikhaazi3/completeGoal_crash.vsgm1
and pressing "End turn"
