### PR TITLE
use system version of minizip

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -198,12 +198,27 @@ SET(PCH_PROPERTIES
 	COTIRE_CXX_PREFIX_HEADER_INIT "StdInc.h"
 )
 
+find_path(MINIZIP_INCLUDE_PATH NAMES minizip/unzip.h)
+find_library(MINIZIP_LIB NAMES minizip PATH_SUFFIXES dynamic)
+mark_as_advanced(MINIZIP_INCLUDE_PATH MINIZIP_LIB)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(MINIZIP MINIZIP_INCLUDE_PATH MINIZIP_LIB)
+if (MINIZIP_FOUND)
+    set(MINIZIP_INCLUDE_DIR ${MINIZIP_INCLUDE_PATH})
+    set(MINIZIP_LIBRARIES ${MINIZIP_LIB})
+    add_definitions(-DUSE_SYSTEM_MINIZIP)
+endif()
+
 if (ENABLE_ERM)
 		add_subdirectory(scripting/erm)
 endif()
+if (NOT MINIZIP_FOUND)
+	add_subdirectory(lib/minizip)
+	set(MINIZIP_LIBRARIES minizip)
+endif()
 add_subdirectory(lib)
 add_subdirectory(client)
-add_subdirectory(lib/minizip)
 add_subdirectory(server)
 add_subdirectory(AI)
 if (ENABLE_EDITOR)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -133,7 +133,7 @@ set(lib_HEADERS
 add_library(vcmi SHARED ${lib_SRCS} ${lib_HEADERS})
 set_target_properties(vcmi PROPERTIES XCODE_ATTRIBUTE_LD_DYLIB_INSTALL_NAME "@rpath/libvcmi.dylib")
 set_target_properties(vcmi PROPERTIES COMPILE_DEFINITIONS "VCMI_DLL=1")
-target_link_libraries(vcmi minizip ${Boost_LIBRARIES} ${SDL_LIBRARY} ${ZLIB_LIBRARIES} ${SYSTEM_LIBS})
+target_link_libraries(vcmi ${MINIZIP_LIBRARIES} ${Boost_LIBRARIES} ${SDL_LIBRARY} ${ZLIB_LIBRARIES} ${SYSTEM_LIBS})
 
 if(WIN32)
 	set_target_properties(vcmi PROPERTIES OUTPUT_NAME VCMI_lib)

--- a/lib/filesystem/CZipLoader.h
+++ b/lib/filesystem/CZipLoader.h
@@ -16,7 +16,11 @@
 #include "CCompressedStream.h"
 
 // Necessary here in order to get all types
+#ifdef USE_SYSTEM_MINIZIP
+#include <minizip/unzip.h>
+#else
 #include "../minizip/unzip.h"
+#endif
 
 class DLL_LINKAGE CZipStream : public CBufferedStream
 {


### PR DESCRIPTION
If minizip is installed on the system, use that version instead of the embedded one.
