### PR TITLE
let vcmiserver handle commandline options first

### DIFF
--- a/server/CVCMIServer.cpp
+++ b/server/CVCMIServer.cpp
@@ -599,13 +599,13 @@ int main(int argc, char** argv)
 	CBasicLogConfigurator logConfig(VCMIDirs::get().userCachePath() + "/VCMI_Server_log.txt", console);
 	logConfig.configureDefault();
 
-	preinitDLL(console);
-    settings.init();
-	logConfig.configure();
-
 	handleCommandOptions(argc, argv);
 	port = cmdLineOptions["port"].as<int>();
 	logNetwork->infoStream() << "Port " << port << " will be used.";
+
+	preinitDLL(console);
+	settings.init();
+	logConfig.configure();
 
 	loadDLLClasses();
 	srand ( (ui32)time(nullptr) );


### PR DESCRIPTION
The vcmiserver application will first try to initialize various things
before parsing the commandline arguments. This leads to the program only
outputting an initialization error when it cannot initialize instead of
parsing arguments like --help. This patch moves the argument parsing to
earlier in program execution to avoid this behaviour.
