### PR TITLE
Fix Clang 3.2 and Clang 3.4 travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_install:
   - sudo apt-get install -qq cmake libboost1.55-all-dev zlib1g-dev
   - sudo apt-get install -qq libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev libsdl2-ttf-dev
   - sudo apt-get install -qq libavformat-dev libswscale-dev
-  - sudo apt-get install -qq qtdeclarative5-dev
+  - sudo apt-get install -qq qt53declarative
   
   #setup compiler
   - source /opt/qt53/bin/qt53-env.sh


### PR DESCRIPTION
Fix Clang 3.2 and Clang 3.4 launcher builds by updating Qt from 5.0 to 5.3
