### PR TITLE
Launcher: do not automatically check remote repositories

### DIFF
--- a/config/schemas/settings.json
+++ b/config/schemas/settings.json
@@ -242,7 +242,7 @@
 			"type" : "object",
 			"default": {},
 			"additionalProperties" : false,
-			"required" : [ "repositoryURL", "enableInstalledMods" ],
+			"required" : [ "repositoryURL", "enableInstalledMods", "autoCheckRepositories" ],
 			"properties" : {
 				"repositoryURL" : {
 					"type" : "array",
@@ -254,6 +254,10 @@
 					},
 				},
 				"enableInstalledMods" : {
+					"type" : "boolean",
+					"default" : true
+				},
+				"autoCheckRepositories" : {
 					"type" : "boolean",
 					"default" : true
 				}

--- a/launcher/modManager/cmodlistview_moc.cpp
+++ b/launcher/modManager/cmodlistview_moc.cpp
@@ -70,7 +70,10 @@ CModListView::CModListView(QWidget *parent) :
 	ui->progressWidget->setVisible(false);
 	dlManager = nullptr;
 	disableModInfo();
-	loadRepositories();
+	if (settings["launcher"]["autoCheckRepositories"].Bool())
+	{
+		loadRepositories();
+	}
 }
 
 void CModListView::loadRepositories()
@@ -99,7 +102,10 @@ void CModListView::showEvent(QShowEvent * event)
 	if (repositoriesChanged)
 	{
 		repositoriesChanged = false;
-		loadRepositories();
+		if (settings["launcher"]["autoCheckRepositories"].Bool())
+		{
+			loadRepositories();
+		}
 	}
 }
 
@@ -618,6 +624,11 @@ void CModListView::installMods(QStringList archives)
 		QFile::remove(archive);
 
 	checkManagerErrors();
+}
+
+void CModListView::on_refreshButton_clicked()
+{
+	loadRepositories();
 }
 
 void CModListView::on_pushButton_clicked()

--- a/launcher/modManager/cmodlistview_moc.h
+++ b/launcher/modManager/cmodlistview_moc.h
@@ -91,6 +91,8 @@ private slots:
 
 	void on_pushButton_clicked();
 
+	void on_refreshButton_clicked();
+
 	void on_allModsView_activated(const QModelIndex &index);
 
 	void on_tabWidget_currentChanged(int index);

--- a/launcher/modManager/cmodlistview_moc.ui
+++ b/launcher/modManager/cmodlistview_moc.ui
@@ -34,7 +34,7 @@
      <property name="spacing">
       <number>6</number>
      </property>
-     <item row="0" column="0">
+     <item row="0" column="1">
       <widget class="QLineEdit" name="lineEdit">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -62,7 +62,7 @@
        </property>
       </widget>
      </item>
-     <item row="0" column="1">
+     <item row="0" column="2">
       <widget class="QComboBox" name="comboBox">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -111,7 +111,20 @@
        </item>
       </widget>
      </item>
-     <item row="1" column="0" colspan="2">
+     <item row="0" column="3">
+      <widget class="QPushButton" name="refreshButton">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Download &amp;&amp; refresh repositories</string>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="1" colspan="3">
       <widget class="QTreeView" name="allModsView">
        <property name="selectionMode">
         <enum>QAbstractItemView::SingleSelection</enum>

--- a/launcher/settingsView/csettingsview_moc.cpp
+++ b/launcher/settingsView/csettingsview_moc.cpp
@@ -39,6 +39,7 @@ void CSettingsView::loadSettings()
 
 	ui->spinBoxNetworkPort->setValue(settings["server"]["port"].Float());
 
+	ui->comboBoxAutoCheck->setCurrentIndex(settings["launcher"]["autoCheckRepositories"].Bool());
 	// all calls to plainText will trigger textChanged() signal overwriting config. Create backup before editing widget
 	JsonNode urls = settings["launcher"]["repositoryURL"];
 
@@ -82,6 +83,12 @@ void CSettingsView::on_comboBoxResolution_currentIndexChanged(const QString &arg
 void CSettingsView::on_comboBoxFullScreen_currentIndexChanged(int index)
 {
 	Settings node = settings.write["video"]["fullscreen"];
+	node->Bool() = index;
+}
+
+void CSettingsView::on_comboBoxAutoCheck_currentIndexChanged(int index)
+{
+	Settings node = settings.write["launcher"]["autoCheckRepositories"];
 	node->Bool() = index;
 }
 

--- a/launcher/settingsView/csettingsview_moc.h
+++ b/launcher/settingsView/csettingsview_moc.h
@@ -39,6 +39,8 @@ private slots:
 
 	void on_changeGameDataDir_clicked();
 
+	void on_comboBoxAutoCheck_currentIndexChanged(int index);
+
 private:
 	Ui::CSettingsView *ui;
 };

--- a/launcher/settingsView/csettingsview_moc.ui
+++ b/launcher/settingsView/csettingsview_moc.ui
@@ -26,7 +26,20 @@
    <property name="bottomMargin">
     <number>0</number>
    </property>
-   <item row="5" column="3" colspan="4">
+   <item row="9" column="1" colspan="4">
+    <widget class="QLabel" name="LauncherSettings">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>Launcher Settings</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="6" colspan="4">
     <widget class="QLabel" name="labelGeneral">
      <property name="font">
       <font>
@@ -39,14 +52,14 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="3">
+   <item row="2" column="6">
     <widget class="QLabel" name="labelUserDataDir">
      <property name="text">
       <string>User data directory</string>
      </property>
     </widget>
    </item>
-   <item row="6" column="4" colspan="3">
+   <item row="6" column="7" colspan="3">
     <widget class="QSpinBox" name="spinBoxNetworkPort">
      <property name="minimum">
       <number>1024</number>
@@ -59,7 +72,7 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="5">
+   <item row="1" column="8">
     <widget class="QPushButton" name="changeGameDataDir">
      <property name="enabled">
       <bool>false</bool>
@@ -69,7 +82,7 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="1">
+   <item row="2" column="4">
     <widget class="QComboBox" name="comboBoxFullScreen">
      <property name="currentIndex">
       <number>0</number>
@@ -86,7 +99,7 @@
      </item>
     </widget>
    </item>
-   <item row="5" column="0" colspan="2">
+   <item row="5" column="1" colspan="4">
     <widget class="QLabel" name="labelAISettings">
      <property name="font">
       <font>
@@ -99,21 +112,21 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="6">
+   <item row="1" column="9">
     <widget class="QPushButton" name="openGameDataDir">
      <property name="text">
       <string>Open</string>
      </property>
     </widget>
    </item>
-   <item row="1" column="3">
+   <item row="1" column="6">
     <widget class="QLabel" name="labelGameDir">
      <property name="text">
       <string>Extra data directory</string>
      </property>
     </widget>
    </item>
-   <item row="1" column="1">
+   <item row="1" column="4">
     <widget class="QComboBox" name="comboBoxResolution">
      <item>
       <property name="text">
@@ -172,14 +185,14 @@
      </item>
     </widget>
    </item>
-   <item row="2" column="0">
+   <item row="2" column="1">
     <widget class="QLabel" name="labelFullScreen">
      <property name="text">
       <string>Fullscreen</string>
      </property>
     </widget>
    </item>
-   <item row="11" column="0" colspan="7">
+   <item row="13" column="1" colspan="9">
     <widget class="QPlainTextEdit" name="plainTextEditRepos">
      <property name="lineWrapMode">
       <enum>QPlainTextEdit::NoWrap</enum>
@@ -189,14 +202,14 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="6">
+   <item row="2" column="9">
     <widget class="QPushButton" name="openUserDataDir">
      <property name="text">
       <string>Open</string>
      </property>
     </widget>
    </item>
-   <item row="1" column="4">
+   <item row="1" column="7">
     <widget class="QLineEdit" name="lineEditGameDir">
      <property name="minimumSize">
       <size>
@@ -209,7 +222,7 @@
      </property>
     </widget>
    </item>
-   <item row="7" column="1">
+   <item row="7" column="4">
     <widget class="QComboBox" name="comboBoxNeutralAI">
      <item>
       <property name="text">
@@ -223,35 +236,35 @@
      </item>
     </widget>
    </item>
-   <item row="3" column="6">
+   <item row="3" column="9">
     <widget class="QPushButton" name="openTempDir">
      <property name="text">
       <string>Open</string>
      </property>
     </widget>
    </item>
-   <item row="1" column="0">
+   <item row="1" column="1">
     <widget class="QLabel" name="labelResolution">
      <property name="text">
       <string>Resolution</string>
      </property>
     </widget>
    </item>
-   <item row="7" column="0">
+   <item row="7" column="1">
     <widget class="QLabel" name="labelNeutralAI">
      <property name="text">
       <string>Neutral AI</string>
      </property>
     </widget>
    </item>
-   <item row="7" column="3">
+   <item row="7" column="6">
     <widget class="QLabel" name="labelEncoding">
      <property name="text">
       <string>Heroes III character set</string>
      </property>
     </widget>
    </item>
-   <item row="6" column="1">
+   <item row="6" column="4">
     <widget class="QComboBox" name="comboBoxPlayerAI">
      <item>
       <property name="text">
@@ -260,14 +273,14 @@
      </item>
     </widget>
    </item>
-   <item row="6" column="0">
+   <item row="6" column="1">
     <widget class="QLabel" name="labelPlayerAI">
      <property name="text">
       <string>Player AI</string>
      </property>
     </widget>
    </item>
-   <item row="7" column="4" colspan="3">
+   <item row="7" column="7" colspan="3">
     <widget class="QComboBox" name="comboBoxEncoding">
      <item>
       <property name="text">
@@ -296,14 +309,14 @@
      </item>
     </widget>
    </item>
-   <item row="6" column="3">
+   <item row="6" column="6">
     <widget class="QLabel" name="labelNetworkPort">
      <property name="text">
       <string>Network port</string>
      </property>
     </widget>
    </item>
-   <item row="0" column="0" colspan="2">
+   <item row="0" column="1" colspan="4">
     <widget class="QLabel" name="labelVideo">
      <property name="font">
       <font>
@@ -316,7 +329,7 @@
      </property>
     </widget>
    </item>
-   <item row="9" column="0" colspan="2">
+   <item row="11" column="1" colspan="4">
     <widget class="QLabel" name="labelRepositories">
      <property name="font">
       <font>
@@ -329,14 +342,14 @@
      </property>
     </widget>
    </item>
-   <item row="3" column="3">
+   <item row="3" column="6">
     <widget class="QLabel" name="labelTempDir">
      <property name="text">
       <string>Log files directory</string>
      </property>
     </widget>
    </item>
-   <item row="2" column="4" colspan="2">
+   <item row="2" column="7" colspan="2">
     <widget class="QLineEdit" name="lineEditUserDataDir">
      <property name="enabled">
       <bool>false</bool>
@@ -355,7 +368,7 @@
      </property>
     </widget>
    </item>
-   <item row="3" column="4" colspan="2">
+   <item row="3" column="7" colspan="2">
     <widget class="QLineEdit" name="lineEditTempDir">
      <property name="enabled">
       <bool>false</bool>
@@ -374,14 +387,14 @@
      </property>
     </widget>
    </item>
-   <item row="3" column="0">
+   <item row="3" column="1">
     <widget class="QLabel" name="labelShowIntro">
      <property name="text">
       <string>Show intro</string>
      </property>
     </widget>
    </item>
-   <item row="3" column="1">
+   <item row="3" column="4">
     <widget class="QComboBox" name="comboBoxShowIntro">
      <property name="currentIndex">
       <number>1</number>
@@ -398,7 +411,7 @@
      </item>
     </widget>
    </item>
-   <item row="4" column="0" colspan="2">
+   <item row="4" column="1" colspan="4">
     <spacer name="spacerSections">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -414,7 +427,7 @@
      </property>
     </spacer>
    </item>
-   <item row="8" column="0" colspan="2">
+   <item row="8" column="1" colspan="4">
     <spacer name="spacerRepos">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -430,7 +443,7 @@
      </property>
     </spacer>
    </item>
-   <item row="0" column="3" colspan="4">
+   <item row="0" column="6" colspan="4">
     <widget class="QLabel" name="labelDataDirs">
      <property name="font">
       <font>
@@ -443,7 +456,7 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="2" rowspan="3">
+   <item row="1" column="5" rowspan="3">
     <spacer name="spacerColumns">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -458,6 +471,30 @@
       </size>
      </property>
     </spacer>
+   </item>
+   <item row="10" column="6">
+    <widget class="QComboBox" name="comboBoxAutoCheck">
+     <property name="currentIndex">
+      <number>1</number>
+     </property>
+     <item>
+      <property name="text">
+       <string>Off</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>On</string>
+      </property>
+     </item>
+    </widget>
+   </item>
+   <item row="10" column="1" colspan="4">
+    <widget class="QLabel" name="labelAutoCheck">
+     <property name="text">
+      <string>Check repositories on startup</string>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>


### PR DESCRIPTION
- instead, add a button to the launcher which allows manual downloading
- add a configuration option autoCheckRepositories to get the old
  behaviour

This feature disables the automatic check on every startup of the vcmilauncher but allows to get back the old behaviour by setting the configuration variable autoCheckRepositories to true.

This feature is important for Debian because no program should access a remote server without consent of the user. I imagine that a user might not be aware that vcmilauncher will automatically contact download.vcmi.eu until they run the program and see the progress bar (at which point it is too late). Also in its current form, vcmilauncher forces contacting download.vcmi.eu on every program start-up. So right now, it is impossible to start the launcher without informing the server behind download.vcmi.eu that you are now gonna play the game.

At the very least, please add this patch but set the default value of autoCheckRepositories to true. That way, I can easily set the value to false for the Debian packaging. This would already help a lot, thanks!
