### PR TITLE
Fixed crash, "pure virtual method called", when calling doUpdate lambda from CGPreGame

### DIFF
--- a/client/gui/CIntObject.h
+++ b/client/gui/CIntObject.h
@@ -38,7 +38,7 @@ public:
 	virtual ~IUpdateable(){}; //d-tor
 };
 
-class ILockedUpdatable: protected IUpdateable
+class ILockedUpdatable: public IUpdateable
 {
 	boost::recursive_mutex updateGuard;
 public:


### PR DESCRIPTION
Stack trace:

```
pure virtual method called
terminate called without an active exception

Program received signal SIGABRT, Aborted.
0x00007ffff1f39967 in raise () from /usr/lib/libc.so.6
(gdb) bt
#0  0x00007ffff1f39967 in raise () from /usr/lib/libc.so.6
#1  0x00007ffff1f3ad3a in abort () from /usr/lib/libc.so.6
#2  0x00007ffff2825085 in __gnu_cxx::__verbose_terminate_handler() () from /usr/lib/libstdc++.so.6
#3  0x00007ffff2822f06 in __cxxabiv1::__terminate(void (*)()) () from /usr/lib/libstdc++.so.6
#4  0x00007ffff2822f51 in std::terminate() () from /usr/lib/libstdc++.so.6
#5  0x00007ffff2823a8f in __cxa_pure_virtual () from /usr/lib/libstdc++.so.6
#6  0x00000000006f73b3 in CGuiHandler::<lambda(IUpdateable*)>::operator()(IUpdateable *) const (__closure=0x101ab40, target=0x1546a88) at /home/xyz/vcmi-original/client/gui/CGuiHandler.cpp:417
#7  0x00000000006f8246 in std::_Function_handler<void(IUpdateable*), CGuiHandler::renderFrame()::<lambda(IUpdateable*)> >::_M_invoke(const std::_Any_data &, IUpdateable *) (__functor=..., __args#0=0x1546a88) at /usr/include/c++/4.9.1/functional:2039
#8  0x00000000006fe7a3 in std::function<void (IUpdateable*)>::operator()(IUpdateable*) const (this=0x7fffffffdaf0, __args#0=0x1546a88) at /usr/include/c++/4.9.1/functional:2439
#9  0x0000000000a38cb6 in CGPreGame::runLocked(std::function<void (IUpdateable*)>) (this=0x1546a10, cb=...) at /home/xyz/vcmi-original/client/CPreGame.cpp:549
#10 0x00000000006f74da in CGuiHandler::renderFrame (this=0xfc6880 <GH>) at /home/xyz/vcmi-original/client/gui/CGuiHandler.cpp:431
#11 0x000000000098e296 in mainLoop () at /home/xyz/vcmi-original/client/CMT.cpp:1197
#12 0x0000000000988fee in main (argc=1, argv=0x7fffffffe6f8) at /home/xyz/vcmi-original/client/CMT.cpp:485

```

This is reproducible for me when starting any campaign.
