### PR TITLE
add FL_CPP11 preprocessor define independent of which fuzzylite is used

### DIFF
--- a/AI/CMakeLists.txt
+++ b/AI/CMakeLists.txt
@@ -3,13 +3,14 @@ cmake_minimum_required(VERSION 2.8)
 
 find_package(Fuzzylite)
 
+if(NOT MSVC)
+    add_definitions(-DFL_CPP11)
+    set(FL_CPP11 ON CACHE BOOL "")
+endif()
+
 if (NOT FL_FOUND)
     set(FL_BUILD_BINARY OFF CACHE BOOL "")
     set(FL_BUILD_SHARED OFF CACHE BOOL "")
-    if(NOT MSVC)
-        add_definitions(-DFL_CPP11)
-        set(FL_CPP11 ON CACHE BOOL "")
-    endif()
     add_subdirectory(FuzzyLite/fuzzylite)
 endif()
 add_subdirectory(BattleAI)


### PR DESCRIPTION
The preprocessor variable `FL_CPP11` should be added independent of whether the system version or the embedded version of fuzzylite is used because the functionality of the fuzzylite header depends on `FL_CPP11` being set for vcmi.
