### PR TITLE
let data, maps and mp3 directory be truly case insensitive

### DIFF
--- a/vcmibuilder
+++ b/vcmibuilder
@@ -209,17 +209,13 @@ fi
 
 if [[ -n "$data_dir" ]]
 then
-	cp -r "$data_dir"/Data "$dest_dir" 
-	cp -r "$data_dir"/Maps "$dest_dir"
-
 	# this folder is named differently from time to time
-	# vcmi can handle any case but script can't
-	if [ -d "$data_dir"/MP3 ] 
-	then
-		cp -r "$data_dir"/MP3 "$dest_dir"
-	else
-		cp -r "$data_dir"/Mp3 "$dest_dir"
-	fi
+	# bash also has `shopt -s nocaseglob` but we don't want this to
+	# accidentally influence other parts of this script
+	# since the directory names are short, we use this pattern matching
+	cp -r "$data_dir"/[Dd][Aa][Tt][Aa] "$dest_dir" 
+	cp -r "$data_dir"/[Mm][Aa][Pp][Ss] "$dest_dir"
+	cp -r "$data_dir"/[Mm][Pp]3 "$dest_dir"
 fi
 
 if [[ -n "$download" ]]


### PR DESCRIPTION
A user of the Debian vcmi package [reported](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=771300) that the french version of the GOG installer contains the data, maps and mp3 directories in lower case. `vcmibuilder` was not able to handle this, so this patch makes the matching truly case insensitive to prevent any further issue like this.
