### PR TITLE
Fix crash on stalagmite Cartographer if there is no underground level

### DIFF
--- a/lib/mapObjects/MiscObjects.cpp
+++ b/lib/mapObjects/MiscObjects.cpp
@@ -1445,7 +1445,8 @@ void CGShipyard::onHeroVisit( const CGHeroInstance * h ) const
 
 void CCartographer::onHeroVisit( const CGHeroInstance * h ) const
 {
-	if (!wasVisited (h->getOwner()) ) //if hero has not visited yet this cartographer
+	//if player has not bought map of this subtype yet and underground exist for stalagmite cartographer
+	if (!wasVisited(h->getOwner()) && (subID != 2 || cb->gameState()->map->twoLevel))
 	{
 		if (cb->getResource(h->tempOwner, Res::GOLD) >= 1000) //if he can afford a map
 		{


### PR DESCRIPTION
Show "already visited" text for stalagmite cartographer if map don't have underground level.

More details available on bug tracker:
http://bugs.vcmi.eu/view.php?id=1985
