### PR TITLE
Fix CGBonusingObject serialization

### DIFF
--- a/lib/Connection.h
+++ b/lib/Connection.h
@@ -27,7 +27,7 @@
 #include "mapping/CCampaignHandler.h" //for CCampaignState
 #include "rmg/CMapGenerator.h" // for CMapGenOptions
 
-const ui32 version = 750;
+const ui32 version = 751;
 const ui32 minSupportedVersion = version;
 
 class CConnection;

--- a/lib/mapObjects/CRewardableObject.h
+++ b/lib/mapObjects/CRewardableObject.h
@@ -269,7 +269,7 @@ public:
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & static_cast<CGObjectInstance&>(*this);
+		h & static_cast<CRewardableObject&>(*this);
 	}
 };
 

--- a/lib/registerTypes/RegisterTypes.h
+++ b/lib/registerTypes/RegisterTypes.h
@@ -38,7 +38,6 @@ void registerTypesMapObjects1(Serializer &s)
 	s.template registerType<CGObjectInstance, CGTeleport>();
 	s.template registerType<CGObjectInstance, CGSignBottle>();
 	s.template registerType<CGObjectInstance, CGScholar>();
-	s.template registerType<CGObjectInstance, CGBonusingObject>();
 	s.template registerType<CGObjectInstance, CGMagicWell>();
 	s.template registerType<CGObjectInstance, CGObservatory>();
 	s.template registerType<CGObjectInstance, CGKeys>();
@@ -142,6 +141,7 @@ void registerTypesMapObjects2(Serializer &s)
 
 	s.template registerType<CGObjectInstance, CRewardableObject>();
 		s.template registerType<CRewardableObject, CGPickable>();
+		s.template registerType<CRewardableObject, CGBonusingObject>();
 		s.template registerType<CRewardableObject, CGVisitableOPH>();
 		s.template registerType<CRewardableObject, CGVisitableOPW>();
 		s.template registerType<CRewardableObject, CGOnceVisitable>();


### PR DESCRIPTION
Now state of adventure map objects that use this handler will be saved properly and they'll work as indended after save loaded. Affect following objects: Buoy, Swan Pond, Faerie Ring, etc.

http://bugs.vcmi.eu/view.php?id=1912

PS: This one does break saves.
