### PR TITLE
Fix crash in battle I introduced in 8a697f2

### DIFF
--- a/client/windows/CCreatureWindow.cpp
+++ b/client/windows/CCreatureWindow.cpp
@@ -528,7 +528,7 @@ void CStackWindow::CWindowSection::createButtonPanel()
 	OBJ_CONSTRUCTION_CAPTURING_ALL;
 	createBackground("button-panel");
 
-	if (parent->info->dismissInfo->callback)
+	if (parent->info->dismissInfo && parent->info->dismissInfo->callback)
 	{
 		auto onDismiss = [=]()
 		{


### PR DESCRIPTION
Sadly, but when I pulled 8a697f2 I didn't expect that dismissInfo do not present when createButtonPanel used inside the battle.
