### PR TITLE
Mantis#2016 fix + minor one-liners

### DIFF
--- a/client/CPreGame.cpp
+++ b/client/CPreGame.cpp
@@ -2318,7 +2318,7 @@ void OptionsTab::nextCastle( PlayerColor player, int dir )
 
 	if(s.hero >= 0 && !SEL->current->mapHeader->players[s.color.getNum()].hasCustomMainHero()) // remove hero unless it set to fixed one in map editor
 	{
-		usedHeroes.erase(s.hero);
+		usedHeroes.erase(s.hero); // restore previously selected hero back to available pool
 		s.hero =  PlayerSettings::RANDOM;
 	}
 	if(cur < 0  &&  s.bonus == PlayerSettings::RESOURCE)
@@ -2355,7 +2355,7 @@ void OptionsTab::nextHero( PlayerColor player, int dir )
 		if(dir > 0)
 			s.hero = nextAllowedHero(player, s.hero, CGI->heroh->heroes.size(), 1, dir);
 		else
-			s.hero = nextAllowedHero(player, -1, s.hero, 1, dir);
+			s.hero = nextAllowedHero(player, -1, s.hero, 1, dir); // min needs to be -1 -- hero at index 0 would be skipped otherwise
 	}
 
 	if(old != s.hero)
@@ -2533,7 +2533,7 @@ void OptionsTab::flagPressed( PlayerColor color )
 			usedHeroes.erase(old->hero);
 
 		old->hero = entries[old->color]->pi.defaultHero();
-		entries[old->color]->update();
+		entries[old->color]->update(); // update previous frame images in case entries were auto-updated
 	}
 
 	SEL->propagateOptions();

--- a/client/CPreGame.cpp
+++ b/client/CPreGame.cpp
@@ -2317,7 +2317,10 @@ void OptionsTab::nextCastle( PlayerColor player, int dir )
 	}
 
 	if(s.hero >= 0 && !SEL->current->mapHeader->players[s.color.getNum()].hasCustomMainHero()) // remove hero unless it set to fixed one in map editor
+	{
+		usedHeroes.erase(s.hero);
 		s.hero =  PlayerSettings::RANDOM;
+	}
 	if(cur < 0  &&  s.bonus == PlayerSettings::RESOURCE)
 		s.bonus = PlayerSettings::RANDOM;
 
@@ -2352,7 +2355,7 @@ void OptionsTab::nextHero( PlayerColor player, int dir )
 		if(dir > 0)
 			s.hero = nextAllowedHero(player, s.hero, CGI->heroh->heroes.size(), 1, dir);
 		else
-			s.hero = nextAllowedHero(player,  0, s.hero, 1, dir);
+			s.hero = nextAllowedHero(player, -1, s.hero, 1, dir);
 	}
 
 	if(old != s.hero)
@@ -2530,6 +2533,7 @@ void OptionsTab::flagPressed( PlayerColor color )
 			usedHeroes.erase(old->hero);
 
 		old->hero = entries[old->color]->pi.defaultHero();
+		entries[old->color]->update();
 	}
 
 	SEL->propagateOptions();


### PR DESCRIPTION
@ 2321 restores currently used hero to available pool after changing towns;
@ 2358 fixes skipping first hero when cycling left (e.g. for [R]andom and heroes A,B it was R>A>B<R (skipped hero A at the last step); 
@ 2536 fixes correct display of current [random] hero after pressing the flag to switch that player to AI (mechnically it worked, but the portrait didn't refresh); 