### PR TITLE
Only remove extension if it belongs to specified file type

### DIFF
--- a/lib/filesystem/ResourceID.cpp
+++ b/lib/filesystem/ResourceID.cpp
@@ -33,6 +33,7 @@ ResourceID::ResourceID()
 }
 
 ResourceID::ResourceID(std::string name)
+	:type(EResType::UNDEFINED)
 {
 	CFileInfo info(std::move(name));
 	setType(info.getType());
@@ -40,6 +41,7 @@ ResourceID::ResourceID(std::string name)
 }
 
 ResourceID::ResourceID(std::string name, EResType::Type type)
+	:type(EResType::UNDEFINED)
 {
 	setType(type);
 	setName(std::move(name));
@@ -57,6 +59,9 @@ EResType::Type ResourceID::getType() const
 
 void ResourceID::setName(std::string name)
 {
+	// setName shouldn't be used if type is UNDEFINED
+	assert(type != EResType::UNDEFINED);
+
 	this->name = std::move(name);
 
 	size_t dotPos = this->name.find_last_of("/.");

--- a/lib/filesystem/ResourceID.cpp
+++ b/lib/filesystem/ResourceID.cpp
@@ -35,14 +35,14 @@ ResourceID::ResourceID()
 ResourceID::ResourceID(std::string name)
 {
 	CFileInfo info(std::move(name));
-	setName(info.getStem());
 	setType(info.getType());
+	setName(info.getStem());
 }
 
 ResourceID::ResourceID(std::string name, EResType::Type type)
 {
-	setName(std::move(name));
 	setType(type);
+	setName(std::move(name));
 }
 
 std::string ResourceID::getName() const
@@ -61,8 +61,11 @@ void ResourceID::setName(std::string name)
 
 	size_t dotPos = this->name.find_last_of("/.");
 
-	if(dotPos != std::string::npos && this->name[dotPos] == '.')
+	if(dotPos != std::string::npos && this->name[dotPos] == '.'
+		&& this->type == EResTypeHelper::getTypeFromExtension(this->name.substr(dotPos)))
+	{
 		this->name.erase(dotPos);
+	}
 
 #ifdef ENABLE_TRIVIAL_TOUPPER
 	toUpper(this->name);

--- a/lib/filesystem/ResourceID.h
+++ b/lib/filesystem/ResourceID.h
@@ -56,7 +56,8 @@ namespace EResType
 		ERM,
 		ERT,
 		ERS,
-		OTHER
+		OTHER,
+		UNDEFINED
 	};
 }
 


### PR DESCRIPTION
This one fixes issue 1557:
http://bugs.vcmi.eu/view.php?id=1557

It's tiny change and I tested it, but I feel there may be consequences so more eyes on it will be useful. E.g if there is some resource loading code that set incorrect EResType or any other code that expect to get filename without extension.