### PR TITLE
Fix saving of player's quests - break saves

### DIFF
--- a/lib/CGameState.h
+++ b/lib/CGameState.h
@@ -183,7 +183,7 @@ public:
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
 		h & color & human & team & resources & status;
-		h & heroes & towns & availableHeroes & dwellings & visitedObjects;
+		h & heroes & towns & availableHeroes & dwellings & quests & visitedObjects;
 		h & getBonusList(); //FIXME FIXME FIXME
 		h & status & daysWithoutCastle;
 		h & enteredLosingCheatCode & enteredWinningCheatCode;

--- a/lib/Connection.h
+++ b/lib/Connection.h
@@ -27,7 +27,7 @@
 #include "mapping/CCampaignHandler.h" //for CCampaignState
 #include "rmg/CMapGenerator.h" // for CMapGenOptions
 
-const ui32 version = 752;
+const ui32 version = 753;
 const ui32 minSupportedVersion = version;
 
 class CISer;


### PR DESCRIPTION
Currently doing minor bug fixing and improvements for Quest Log window.
Find out that after loading quests for player are missing.

This commit break saves compatibility so it's only for merge when we're ready!