### PR TITLE
Forced advmap recreation

### DIFF
--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -141,10 +141,10 @@ void CPlayerInterface::init(shared_ptr<CCallback> CB)
 	if(!towns.size() && !wanderingHeroes.size())
 		initializeHeroTownList();
 
-	if(!adventureInt)
-		adventureInt = new CAdvMapInt();
-	else
-		adventureInt->restoreState();
+	// always recreate advmap interface to avoid possible memory-corruption bugs
+	if(adventureInt)
+		delete adventureInt;
+	adventureInt = new CAdvMapInt();
 }
 void CPlayerInterface::yourTurn()
 {

--- a/client/windows/CAdvmapInterface.cpp
+++ b/client/windows/CAdvmapInterface.cpp
@@ -550,19 +550,13 @@ CAdvMapInt::CAdvMapInt():
 											Colors::WHITE, CGI->generaltexth->allTexts[618]));
 
 	activeMapPanel = panelMain;
-	restoreState();
-
-	addUsedEvents(MOVE);
-}
-
-void CAdvMapInt::restoreState()
-{
+	
 	changeMode(EAdvMapMode::NORMAL);
 
 	underground->block(!CGI->mh->map->twoLevel);
 	worldViewUnderground->block(!CGI->mh->map->twoLevel);
-	
-	terrain.currentPath = nullptr; // invalidate previously visible path after game reload
+
+	addUsedEvents(MOVE);
 }
 
 CAdvMapInt::~CAdvMapInt()

--- a/client/windows/CAdvmapInterface.h
+++ b/client/windows/CAdvmapInterface.h
@@ -208,9 +208,6 @@ public:
 	void updateMoveHero(const CGHeroInstance *h, tribool hasPath = boost::logic::indeterminate);
 	void updateNextHero(const CGHeroInstance *h);
 
-	/// called by player interface if it wants to reuse this object for new/loaded map
-	void restoreState();
-
 	/// changes current adventure map mode; used to switch between default view and world view; scale is ignored if EAdvMapMode == NORMAL
 	void changeMode(EAdvMapMode newMode, float newScale = 0.36f);
 };


### PR DESCRIPTION
As discussed in http://bugs.vcmi.eu/view.php?id=2048 I changed the player interface to recreate advmap interface every time it's initialized.
I tested it a bit (single/hotseat/campaign) and I didn't encounter any errors. However I'm still not sure if it's safe. ;)

Currently previous advmap instance is deleted only when a new one is about to be created. It wastes some memory by keeping it while in menus etc., but is safer in case something tries to use it from there (haven't checked if it actually happens).