### PR TITLE
Mantis#2124: prevents first aid tents from attacking enemies at melee range

### DIFF
--- a/client/battle/CBattleInterface.cpp
+++ b/client/battle/CBattleInterface.cpp
@@ -2153,9 +2153,9 @@ void CBattleInterface::handleHex(BattleHex myNumber, int eventType)
 			case WALK_AND_ATTACK:
 			case ATTACK_AND_RETURN:
 			{
-				if (shere && !ourStack && shere->alive())
+				if (curInt->cb->battleCanAttack(sactive, shere, myNumber))
 				{
-					if (isTileAttackable(myNumber))
+					if (isTileAttackable(myNumber)) // move isTileAttackable to be part of battleCanAttack?
 					{
 						setBattleCursor(myNumber); // temporary - needed for following function :(
 						BattleHex attackFromHex = fromWhichHexAttack(myNumber);

--- a/lib/CBattleCallback.cpp
+++ b/lib/CBattleCallback.cpp
@@ -775,6 +775,29 @@ std::vector<BattleHex> CBattleInfoCallback::battleGetAvailableHexes(const CStack
 	return ret;
 }
 
+bool CBattleInfoCallback::battleCanAttack(const CStack * stack, const CStack * target, BattleHex dest) const
+{
+	RETURN_IF_NOT_BATTLE(false);
+	
+	if(battleTacticDist())
+		return false;
+	
+	if (!stack || !target)
+		return false;
+	
+	if (stack->owner == target->owner)
+		return false;
+	
+	auto &id = stack->getCreature()->idNumber;
+	if (id == CreatureID::FIRST_AID_TENT || id == CreatureID::CATAPULT)
+		return false;
+	
+	if (!target->alive())
+		return false;
+	
+	return true;
+}
+
 bool CBattleInfoCallback::battleCanShoot(const CStack * stack, BattleHex dest) const
 {
 	RETURN_IF_NOT_BATTLE(false);

--- a/lib/CBattleCallback.h
+++ b/lib/CBattleCallback.h
@@ -252,6 +252,8 @@ public:
 	int battleGetSurrenderCost(PlayerColor Player) const; //returns cost of surrendering battle, -1 if surrendering is not possible
 	ReachabilityInfo::TDistances battleGetDistances(const CStack * stack, BattleHex hex = BattleHex::INVALID, BattleHex * predecessors = nullptr) const; //returns vector of distances to [dest hex number]
 	std::set<BattleHex> battleGetAttackedHexes(const CStack* attacker, BattleHex destinationTile, BattleHex attackerPos = BattleHex::INVALID) const;
+	
+	bool battleCanAttack(const CStack * stack, const CStack * target, BattleHex dest) const; //determines if stack with given ID can attack target at the selected destination
 	bool battleCanShoot(const CStack * stack, BattleHex dest) const; //determines if stack with given ID shoot at the selected destination
 	bool battleIsStackBlocked(const CStack * stack) const; //returns true if there is neighboring enemy stack
 	std::set<const CStack*>  batteAdjacentCreatures (const CStack * stack) const;


### PR DESCRIPTION
Additionally moves melee attack possibility checks to battle callback (for consistency with shooting checks).