### PR TITLE
minor Debian packaging fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 *.pro.user
 *.pro.user.*
 /CMakeLists.txt.user
+CMakeLists.txt.user.*
 CMakeCache.txt
 CMakeFiles
 Makefile
@@ -27,4 +28,9 @@ ui_*.h
 /CPackConfig.cmake
 /CPackSourceConfig.cmake
 build-*
-CMakeLists.txt.user.*
+obj-*
+debian/*.log
+debian/*.substvars
+debian/files
+debian/vcmi
+debian/vcmi-dbg

--- a/debian/control
+++ b/debian/control
@@ -2,14 +2,31 @@ Source: vcmi
 Section: games
 Priority: optional
 Maintainer: Ivan Savenko <saven.ivan@gmail.com>
-Build-Depends: debhelper (>= 8), cmake, libsdl2-dev, libsdl2-image-dev, libsdl2-ttf-dev, libsdl2-mixer-dev, zlib1g-dev, libavformat-dev, libswscale-dev, libboost-dev (>=1.48), libboost-program-options-dev (>=1.48), libboost-filesystem-dev (>=1.48), libboost-system-dev (>=1.48), libboost-locale-dev (>=1.48), libboost-thread-dev (>=1.48), qtbase5-dev
-Standards-Version: 3.9.1
+Build-Depends:
+ debhelper (>= 9),
+ cmake (>= 2.8.12~),
+ libsdl2-dev,
+ libsdl2-image-dev,
+ libsdl2-ttf-dev,
+ libsdl2-mixer-dev,
+ zlib1g-dev,
+ libavformat-dev,
+ libswscale-dev,
+ libboost-dev (>= 1.48),
+ libboost-program-options-dev (>= 1.48),
+ libboost-filesystem-dev (>= 1.48),
+ libboost-system-dev (>= 1.48),
+ libboost-locale-dev (>= 1.48),
+ libboost-thread-dev (>= 1.48),
+ qtbase5-dev
+Standards-Version: 3.9.6
 Homepage: http://vcmi.eu
 Vcs-Git: git://github.com/vcmi/vcmi.git
 Vcs-Browser: https://github.com/vcmi/vcmi
 
 Package: vcmi
 Architecture: any
+Pre-Depends: ${misc:Pre-Depends}
 Depends: ${shlibs:Depends}, ${misc:Depends}
 Description: Rewrite of the Heroes of Might and Magic 3 engine
  The purpose of VCMI project is to rewrite entire HOMM 3: WoG engine from
@@ -22,6 +39,13 @@ Description: Rewrite of the Heroes of Might and Magic 3 engine
 
 Package: vcmi-dbg
 Architecture: any
+Priority: extra
 Section: debug
-Depends: vcmi (= ${binary:Version}),    ${misc:Depends} 
+Depends: vcmi (= ${binary:Version}), ${misc:Depends}
 Description: Debug symbols for vcmi package
+ The purpose of VCMI project is to rewrite entire HOMM 3: WoG engine from
+ scratch, giving it new and extended possibilities. It will help to support
+ mods and new towns already made by fans but abandoned because of game code
+ limitations.
+ .
+ This package will install debug symbols for the vcmi package.

--- a/debian/rules
+++ b/debian/rules
@@ -1,16 +1,19 @@
 #! /usr/bin/make -f
 
+
 %:
-	dh $@
+	dh $@ --parallel
 
 # override disabled by default rpath - we need to find libvcmi.so with it:
 override_dh_auto_configure:
 	dh_auto_configure -- -DCMAKE_SKIP_RPATH=OFF -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBIN_DIR=games
-.PHONY: override_dh_strip
-override_dh_strip:
-	dh_strip --dbg-package=vcmi-dbg
+
 override_dh_auto_install:
 	dh_auto_install --destdir=debian/vcmi
+
 override_dh_installdocs:
 	dh_installdocs --link-doc=vcmi
+
+override_dh_strip:
+	dh_strip --dbg-package=vcmi-dbg
 


### PR DESCRIPTION
debian/control:
Add versioned cmake build-depends (version number taken from CMakeLists.txt).
Add missing Pre-Depends line for vcmi package.

debian/rules:
Enable parallel building.
Remove useless .PHONY

Fixing the following Lintian tags:
W: vcmi source: package-needs-versioned-debhelper-build-depends 9
W: vcmi source: ancient-standards-version 3.9.1 (current is 3.9.6)
E: vcmi-dbg: extended-description-is-empty
W: vcmi-dbg: debug-package-should-be-priority-extra vcmi-dbg