### PR TITLE
CastleInterface: Exclude previous building upgrade in reqs

### DIFF
--- a/client/windows/CCastleInterface.cpp
+++ b/client/windows/CCastleInterface.cpp
@@ -1364,7 +1364,7 @@ std::string CBuildWindow::getTextForState(int state)
 			};
 
 			ret = CGI->generaltexth->allTexts[52];
-			ret += "\n" + town->genBuildingRequirements(building->bid).toString(toStr);
+			ret += "\n" + town->genBuildingRequirements(building->bid, false).toString(toStr);
 			break;
 		}
 	case EBuildingState::MISSING_BASE:

--- a/lib/mapObjects/CGTownInstance.cpp
+++ b/lib/mapObjects/CGTownInstance.cpp
@@ -1046,7 +1046,7 @@ bool CGTownInstance::hasBuilt(BuildingID buildingID) const
 	return vstd::contains(builtBuildings, buildingID);
 }
 
-CBuilding::TRequired CGTownInstance::genBuildingRequirements(BuildingID buildID) const
+CBuilding::TRequired CGTownInstance::genBuildingRequirements(BuildingID buildID, bool includeUpgrade) const
 {
 	const CBuilding * building = town->buildings.at(buildID);
 
@@ -1069,7 +1069,8 @@ CBuilding::TRequired CGTownInstance::genBuildingRequirements(BuildingID buildID)
 	{
 		const CBuilding * upgr = town->buildings.at(building->upgrade);
 
-		requirements.expressions.push_back(upgr->bid);
+		if (includeUpgrade)
+			requirements.expressions.push_back(upgr->bid);
 		requirements.expressions.push_back(upgr->requirements.morph(dependTest));
 	}
 	requirements.expressions.push_back(building->requirements.morph(dependTest));

--- a/lib/mapObjects/CGTownInstance.h
+++ b/lib/mapObjects/CGTownInstance.h
@@ -233,7 +233,7 @@ public:
 	bool armedGarrison() const; //true if town has creatures in garrison or garrisoned hero
 	int getTownLevel() const;
 
-	CBuilding::TRequired genBuildingRequirements(BuildingID build) const;
+	CBuilding::TRequired genBuildingRequirements(BuildingID build, bool includeUpgrade=true) const;
 
 	void removeCapitols (PlayerColor owner) const;
 	void addHeroToStructureVisitors(const CGHeroInstance *h, si32 structureInstanceID) const; //hero must be visiting or garrisoned in town


### PR DESCRIPTION
Hide CityHall from Capitol prerequisites in Capitol build window

### Issue

In the prerequisite menu, upgraded buildings show previous upgrades of the building as unmet prerequisites.

### To reproduce

* Start a new scenario
* On first day, upgrade Town Hall to City Hall
* Check the prerequisites box of Capitol

### Before (vcmi on the left, vanilla on the right):
![vcmi-pre](https://cloud.githubusercontent.com/assets/1013356/9361898/badb2312-466b-11e5-9fe7-a55b527d10a8.png)

### After (vcmi on the left, vanilla on the right):
![vcmi-post-upgr](https://cloud.githubusercontent.com/assets/1013356/9361903/c1c6db30-466b-11e5-808b-74d0cc74256a.png)

