### PR TITLE
Improve Volume widgets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@
 *.layout
 *.pro.user
 *.pro.user.*
+*.swp
+*~
 /CMakeLists.txt.user
 CMakeCache.txt
 CMakeFiles

--- a/client/CMT.cpp
+++ b/client/CMT.cpp
@@ -419,8 +419,6 @@ int main(int argc, char** argv)
 #endif // defined
 
 	//initializing audio
-	// Note: because of interface button range, volume can only be a
-	// multiple of 11, from 0 to 99.
 	CCS->soundh = new CSoundHandler;
 	CCS->soundh->init();
 	CCS->soundh->setVolume(settings["general"]["sound"].Float());

--- a/client/gui/CGuiHandler.cpp
+++ b/client/gui/CGuiHandler.cpp
@@ -274,8 +274,11 @@ void CGuiHandler::handleEvent(SDL_Event *sEvent)
 		for(auto i=hlp.begin(); i != hlp.end() && current; i++)
 		{
 			if(!vstd::contains(wheelInterested,*i)) continue;
-			(*i)->wheelScrolled(sEvent->wheel.y < 0, isItIn(&(*i)->pos,sEvent->motion.x,sEvent->motion.y));
-		}		
+			// SDL doesn't have the proper values for mouse positions on SDL_MOUSEWHEEL, refetch them
+			int x = 0, y = 0;
+			SDL_GetMouseState(&x, &y);
+			(*i)->wheelScrolled(sEvent->wheel.y < 0, isItIn(&(*i)->pos, x, y));
+		}
 	}
 	else if(sEvent->type == SDL_TEXTINPUT)
 	{

--- a/client/widgets/Buttons.cpp
+++ b/client/widgets/Buttons.cpp
@@ -209,8 +209,8 @@ void CButton::hover (bool on)
 		setState(PRESSED);*/
 
 	std::string name = hoverTexts[getState()].empty()
-		? hoverTexts[getState()]
-		: hoverTexts[0];
+		? hoverTexts[0]
+		: hoverTexts[getState()];
 
 	if(!name.empty() && !isBlocked()) //if there is no name, there is nohing to display also
 	{

--- a/client/widgets/Buttons.cpp
+++ b/client/widgets/Buttons.cpp
@@ -212,7 +212,7 @@ void CButton::hover (bool on)
 		? hoverTexts[0]
 		: hoverTexts[getState()];
 
-	if(!name.empty() && !isBlocked()) //if there is no name, there is nohing to display also
+	if(!name.empty() && !isBlocked()) //if there is no name, there is nothing to display also
 	{
 		if (LOCPLINT && LOCPLINT->battleInt) //for battle buttons
 		{

--- a/client/widgets/Buttons.cpp
+++ b/client/widgets/Buttons.cpp
@@ -419,8 +419,8 @@ void CToggleGroup::addToggle(int identifier, CToggleBase* bt)
 	buttons[identifier] = bt;
 }
 
-CToggleGroup::CToggleGroup(const CFunctionList<void(int)> &OnChange, bool musicLikeButtons)
-: onChange(OnChange), selectedID(-2), musicLike(musicLikeButtons)
+CToggleGroup::CToggleGroup(const CFunctionList<void(int)> &OnChange)
+: onChange(OnChange), selectedID(-2)
 {}
 
 void CToggleGroup::setSelected(int id)
@@ -445,28 +445,6 @@ void CToggleGroup::selectionChanged(int to)
 	onChange(to);
 	if (parent)
 		parent->redraw();
-}
-
-void CToggleGroup::show(SDL_Surface * to)
-{
-	if (musicLike)
-	{
-		if (auto intObj = dynamic_cast<CIntObject*>(buttons[selectedID])) // hack-ish workagound to avoid diamond problem with inheritance
-			intObj->show(to);
-	}
-	else
-		CIntObject::show(to);
-}
-
-void CToggleGroup::showAll(SDL_Surface * to)
-{
-	if (musicLike)
-	{
-		if (auto intObj = dynamic_cast<CIntObject*>(buttons[selectedID])) // hack-ish workagound to avoid diamond problem with inheritance
-			intObj->showAll(to);
-	}
-	else
-		CIntObject::showAll(to);
 }
 
 CVolumeSlider::CVolumeSlider(const Point &position, const std::string &defName, const int value,

--- a/client/widgets/Buttons.h
+++ b/client/widgets/Buttons.h
@@ -178,12 +178,11 @@ class CToggleGroup : public CIntObject
 	CFunctionList<void(int)> onChange; //called when changing selected button with new button's id
 
 	int selectedID;
-	bool musicLike; //determines the behaviour of this group
 	void selectionChanged(int to);
 public:
 	std::map<int, CToggleBase*> buttons;
 
-	CToggleGroup(const CFunctionList<void(int)> & OnChange, bool musicLikeButtons = false);
+	CToggleGroup(const CFunctionList<void(int)> & OnChange);
 
 	void addCallback(std::function<void(int)> callback);
 
@@ -191,9 +190,6 @@ public:
 	void addToggle(int index, CToggleBase * button);
 	/// Changes selection to specific value. Will select toggle with this ID, if present
 	void setSelected(int id);
-
-	void show(SDL_Surface * to);
-	void showAll(SDL_Surface * to);
 };
 
 /// A typical slider for volume with an animated indicator

--- a/client/widgets/Buttons.h
+++ b/client/widgets/Buttons.h
@@ -196,6 +196,32 @@ public:
 	void showAll(SDL_Surface * to);
 };
 
+/// A typical slider for volume with an animated indicator
+class CVolumeSlider : public CIntObject
+{
+	int value;
+	CFunctionList<void(int)> onChange;
+	CAnimImage * animImage;
+	const std::pair<std::string, std::string> * const helpHandlers;
+	void setVolume(const int v);
+public:
+
+	/// @param position coordinates of slider
+	/// @param defName name of def animation for slider
+	/// @param value initial value for volume
+	/// @param help pointer to first helptext of slider
+	CVolumeSlider(const Point &position, const std::string &defName, const int value,
+	              const std::pair<std::string, std::string> * const help);
+
+	void moveTo(int id);
+	void addCallback(std::function<void(int)> callback);
+
+
+	void clickLeft(tribool down, bool previousState) override;
+	void clickRight(tribool down, bool previousState) override;
+	void wheelScrolled(bool down, bool in);
+};
+
 /// A typical slider which can be orientated horizontally/vertically.
 class CSlider : public CIntObject
 {

--- a/client/widgets/Buttons.h
+++ b/client/widgets/Buttons.h
@@ -248,14 +248,12 @@ public:
 	void mouseMoved (const SDL_MouseMotionEvent & sEvent);
 	void showAll(SDL_Surface * to);	
 
-	/**
-	 * @param position, coordinates of slider
-	 * @param length, length of slider ribbon, including left/right buttons
-	 * @param Moved, function that will be called whenever slider moves
-	 * @param Capacity, maximal number of visible at once elements
-	 * @param Amount, total amount of elements, including not visible
-	 * @param Value, starting position
-	 */
+	 /// @param position coordinates of slider
+	 /// @param length length of slider ribbon, including left/right buttons
+	 /// @param Moved function that will be called whenever slider moves
+	 /// @param Capacity maximal number of visible at once elements
+	 /// @param Amount total amount of elements, including not visible
+	 /// @param Value starting position
 	CSlider(Point position, int length, std::function<void(int)> Moved, int Capacity, int Amount,
 		int Value=0, bool Horizontal=true, EStyle style = BROWN);
 	~CSlider();

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -575,18 +575,10 @@ CSystemOptionsWindow::CSystemOptionsWindow():
 	mapScrollSpeed->setSelected(settings["adventure"]["scrollSpeed"].Float());
 	mapScrollSpeed->addCallback(std::bind(&setIntSetting, "adventure", "scrollSpeed", _1));
 
-	musicVolume = new CToggleGroup(0, true);
-	for(int i=0; i<10; ++i)
-		musicVolume->addToggle(i*11, new CToggleButton(Point(29 + 19*i, 359), "syslb.def", CGI->generaltexth->zelp[326+i]));
-
-	musicVolume->setSelected(CCS->musich->getVolume());
+	musicVolume = new CVolumeSlider(Point(29, 359), "syslb.def", CCS->musich->getVolume(), &CGI->generaltexth->zelp[326]);
 	musicVolume->addCallback(std::bind(&setIntSetting, "general", "music", _1));
 
-	effectsVolume = new CToggleGroup(0, true);
-	for(int i=0; i<10; ++i)
-		effectsVolume->addToggle(i*11, new CToggleButton(Point(29 + 19*i, 425), "syslb.def", CGI->generaltexth->zelp[336+i]));
-
-	effectsVolume->setSelected(CCS->soundh->getVolume());
+	effectsVolume = new CVolumeSlider(Point(29, 425), "syslb.def", CCS->soundh->getVolume(), &CGI->generaltexth->zelp[336]);
 	effectsVolume->addCallback(std::bind(&setIntSetting, "general", "sound", _1));
 
 	showReminder = new CToggleButton(Point(246, 87), "sysopchk.def", CGI->generaltexth->zelp[361],

--- a/client/windows/GUIClasses.h
+++ b/client/windows/GUIClasses.h
@@ -31,6 +31,7 @@ class CListBox;
 class CLabelGroup;
 class CToggleButton;
 class CToggleGroup;
+class CVolumeSlider;
 class CGStatusBar;
 
 /// Recruitment window where you can recruit creatures
@@ -192,7 +193,7 @@ private:
 	CToggleGroup * heroMoveSpeed;
 	CToggleGroup * enemyMoveSpeed;
 	CToggleGroup * mapScrollSpeed;
-	CToggleGroup * musicVolume, * effectsVolume;
+	CVolumeSlider * musicVolume, * effectsVolume;
 
 	//CHighlightableButton * showPath;
 	CToggleButton * showReminder;


### PR DESCRIPTION
Add new widget specifically for volume settings.
Replace previous implementation which was using 10 toggle buttons.
Enable indicator animation
Fix indicator ghosting when drag and releasing
Add scroll capability to volume
Volume now can be adjusted from 0 - 99 by increments of ~5 with the mouse: where you click on the widget (right of it or left of it) determines the value. No longer by increments of 11. Clicking on right side and the left side of an increment of the widget will have different effects.
The scroll wheel will also adjust the volume by increments of 3

### Vanilla
1. Click and hold: widget doesn't change place
2. Drag and hold: widget doesn't change place
3. Release: widget changes place towards where it was clicked at 1

Indicator changes frames to have a transparent look

### Previous to the PR
1. Click and hold: widget adds another indicator with frame 0, current indicator doesn't disappear
2. Drag and hold: widget doesn't change place
3. Release: widget doesn't change place and there are now two indicators unless released on the same spot as 1, in which case the other indicator disappears and the current indicator switches to frame 3 despite the position.

Indicator only shows frame 3 or frame 0.

![screenshot from 2015-08-21 23-20-59](https://cloud.githubusercontent.com/assets/1013356/9422277/5e471b14-485b-11e5-8e84-c1dd743042dd.png)


### This PR
1. Click and hold: change place to where it was clicked
2. Drag and hold: widget doesn't change place
3. Release: widget doesn't change place

Indicator changes frames to have a transparent look

You can also scroll on the widget and it will update the indicator as soon as it changes threshold