### PR TITLE
Add UseDoxygen to cmake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ ui_*.h
 /CPackSourceConfig.cmake
 build-*
 CMakeLists.txt.user.*
+Doxyfile
+doc/*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,12 @@ option(ENABLE_TEST "Enable compilation of unit tests" OFF)
 option(ENABLE_PCH "Enable compilation using precompiled headers" ON)
 
 ############################################
+#        Documentation section             #
+############################################
+
+include(UseDoxygen OPTIONAL)
+
+############################################
 #        Building section                  #
 ############################################
 

--- a/README.linux
+++ b/README.linux
@@ -93,3 +93,14 @@ Go to /LIB_PATH/vcmi/AI, and type:
 Go to /DATA_PATH/vcmi, and type:
   ln -s .../trunk/source/config
   ln -s .../trunk/source/Mods
+
+IV. Compiling documentation
+
+To compile using Doxygen, the UseDoxygen CMake module must be installed. It can
+be fetched from: http://tobias.rautenkranz.ch/cmake/doxygen/
+
+Once UseDoxygen is installed, run:
+    cmake .
+    make doc
+
+The built documentation will be available from ./doc


### PR DESCRIPTION
Enable use of `cmake . && make doc` to generate a Doxygen tree in doc/
Requires UseDoxygen.cmake from http://tobias.rautenkranz.ch/cmake/doxygen/

I couldn't find any documentation on the wiki or the forum on how to generate the documentation for the project. I did find some codeblocks configuration in the source, but it didn't yield much.

If there is more configuration to be added, let me know.