### PR TITLE
Garrison fixes

### DIFF
--- a/client/widgets/CGarrisonInt.cpp
+++ b/client/widgets/CGarrisonInt.cpp
@@ -299,10 +299,22 @@ void CGarrisonSlot::clickLeft(tribool down, bool previousState)
 			refr = split();
 		// swap
 		else if(creature != selection->creature)
-			LOCPLINT->cb->swapCreatures(owner->armedObjs[upg], owner->armedObjs[selection->upg], ID, selection->ID);
+		{
+			const CArmedInstance * selectedObj = owner->armedObjs[selection->upg];
+			if (!creature && selectedObj->stacksCount() == 1)
+				LOCPLINT->cb->splitStack(selectedObj, owner->armedObjs[upg], selection->ID, ID, myStack->count - 1);
+			else
+				LOCPLINT->cb->swapCreatures(owner->armedObjs[upg], owner->armedObjs[selection->upg], ID, selection->ID);
+		}
 		// merge
 		else
-			LOCPLINT->cb->mergeStacks(owner->armedObjs[selection->upg], owner->armedObjs[upg], selection->ID, ID);
+		{
+			const CArmedInstance * selectedObj = owner->armedObjs[selection->upg];
+			if (selectedObj->stacksCount() == 1)
+				LOCPLINT->cb->splitStack(owner->armedObjs[upg], selectedObj, selection->ID, ID, 1);
+			else
+				LOCPLINT->cb->mergeStacks(owner->armedObjs[selection->upg], owner->armedObjs[upg], selection->ID, ID);
+		}
 		if(refr)
 		{
 			// Refresh Statusbar

--- a/client/widgets/CGarrisonInt.cpp
+++ b/client/widgets/CGarrisonInt.cpp
@@ -272,7 +272,7 @@ void CGarrisonSlot::clickLeft(tribool down, bool previousState)
 				if(creature)
 				{
 					for(auto & elem : owner->splitButtons)
-						elem->block(false);
+						elem->block(!our());
 				}
 			}
 			redraw();
@@ -455,7 +455,7 @@ void CGarrisonInt::selectSlot(CGarrisonSlot *slot)
 
 		highlighted = slot;
 		for (auto button : splitButtons)
-			button->block(highlighted == nullptr);
+			button->block(highlighted == nullptr || !slot->our());
 
 		if (highlighted)
 			highlighted->setHighlight(true);

--- a/client/widgets/CGarrisonInt.cpp
+++ b/client/widgets/CGarrisonInt.cpp
@@ -122,11 +122,13 @@ const CArmedInstance * CGarrisonSlot::getObj() const
 	return 	(!upg)?(owner->armedObjs[0]):(owner->armedObjs[1]);
 }
 
+/// @return Whether the unit in the slot belongs to the current player.
 bool CGarrisonSlot::our() const
 {
 	return 	upg?(owner->owned[1]):(owner->owned[0]);
 }
 
+/// @return Whether the unit in the slot belongs to an ally but not to the current player.
 bool CGarrisonSlot::ally() const
 {
 	if(!getObj())

--- a/client/widgets/CGarrisonInt.cpp
+++ b/client/widgets/CGarrisonInt.cpp
@@ -149,9 +149,10 @@ void CGarrisonSlot::clickLeft(tribool down, bool previousState)
 	if(down)
 	{
 		bool refr = false;
-		if(owner->getSelection())
+		const CGarrisonSlot * selection = owner->getSelection();
+		if(selection)
 		{
-			if(owner->getSelection() == this) //view info
+			if(selection == this) //view info
 			{
 				UpgradeInfo pom;
 				LOCPLINT->cb->getUpgradeInfo(getObj(), ID, pom);
@@ -176,16 +177,16 @@ void CGarrisonSlot::clickLeft(tribool down, bool previousState)
 			else
 			{
 				// Only allow certain moves if troops aren't removable or not ours.
-				if (  ( owner->getSelection()->our()//our creature is selected
-				     || owner->getSelection()->creature == creature )//or we are rebalancing army
+				if (  ( selection->our()//our creature is selected
+				     || selection->creature == creature )//or we are rebalancing army
 				   && ( owner->removableUnits
-				     || (upg == 0 &&  ( owner->getSelection()->upg == 1 && !creature ) )
-					 || (upg == 1 &&    owner->getSelection()->upg == 1 ) ) )
+				     || (upg == 0 &&  ( selection->upg == 1 && !creature ) )
+					 || (upg == 1 &&    selection->upg == 1 ) ) )
 				{
 					//we want to split
 					if((owner->getSplittingMode() || LOCPLINT->shiftPressed())
 						&& (!creature
-							|| (creature == owner->getSelection()->creature)))
+							|| (creature == selection->creature)))
 					{
 						owner->p2 = ID; //store the second stack pos
 						owner->pb = upg;//store the second stack owner (up or down army)
@@ -193,41 +194,41 @@ void CGarrisonSlot::clickLeft(tribool down, bool previousState)
 
 						int minLeft=0, minRight=0;
 
-						if(upg != owner->getSelection()->upg) //not splitting within same army
+						if(upg != selection->upg) //not splitting within same army
 						{
-							if(owner->getSelection()->getObj()->stacksCount() == 1 //we're splitting away the last stack
-								&& owner->getSelection()->getObj()->needsLastStack() )
+							if(selection->getObj()->stacksCount() == 1 //we're splitting away the last stack
+								&& selection->getObj()->needsLastStack() )
 							{
 								minLeft = 1;
 							}
 							if(getObj()->stacksCount() == 1 //destination army can't be emptied, unless we're rebalancing two stacks of same creature
-								&& owner->getSelection()->creature == creature
+								&& selection->creature == creature
 								&& getObj()->needsLastStack() )
 							{
 								minRight = 1;
 							}
 						}
 
-						int countLeft = owner->getSelection()->myStack ? owner->getSelection()->myStack->count : 0;
+						int countLeft = selection->myStack ? selection->myStack->count : 0;
 						int countRight = myStack ? myStack->count : 0;
 
-						GH.pushInt(new CSplitWindow(owner->getSelection()->creature, std::bind(&CGarrisonInt::splitStacks, owner, _1, _2),
+						GH.pushInt(new CSplitWindow(selection->creature, std::bind(&CGarrisonInt::splitStacks, owner, _1, _2),
 						                            minLeft, minRight, countLeft, countRight));
 						refr = true;
 					}
-					else if(creature != owner->getSelection()->creature) //swap
+					else if(creature != selection->creature) //swap
 					{
 						LOCPLINT->cb->swapCreatures(
 							(!upg)?(owner->armedObjs[0]):(owner->armedObjs[1]),
-							(!owner->getSelection()->upg)?(owner->armedObjs[0]):(owner->armedObjs[1]),
-							ID,owner->getSelection()->ID);
+							(!selection->upg)?(owner->armedObjs[0]):(owner->armedObjs[1]),
+							ID,selection->ID);
 					}
 					else //merge
 					{
 						LOCPLINT->cb->mergeStacks(
-							(!owner->getSelection()->upg)?(owner->armedObjs[0]):(owner->armedObjs[1]),
+							(!selection->upg)?(owner->armedObjs[0]):(owner->armedObjs[1]),
 							(!upg)?(owner->armedObjs[0]):(owner->armedObjs[1]),
-							owner->getSelection()->ID,ID);
+							selection->ID,ID);
 					}
 				}
 				else // Highlight

--- a/client/widgets/CGarrisonInt.cpp
+++ b/client/widgets/CGarrisonInt.cpp
@@ -144,141 +144,142 @@ void CGarrisonSlot::clickRight(tribool down, bool previousState)
 		GH.pushInt(new CStackWindow(myStack, true));
 	}
 }
+
+bool CGarrisonSlot::viewInfo()
+{
+	UpgradeInfo pom;
+	LOCPLINT->cb->getUpgradeInfo(getObj(), ID, pom);
+
+	bool canUpgrade = getObj()->tempOwner == LOCPLINT->playerID && pom.oldID>=0; //upgrade is possible
+	bool canDismiss = getObj()->tempOwner == LOCPLINT->playerID && (getObj()->stacksCount()>1  || !getObj()->needsLastStack());
+	std::function<void(CreatureID)> upgr = nullptr;
+	std::function<void()> dism = nullptr;
+	if(canUpgrade) upgr = [=] (CreatureID newID) { LOCPLINT->cb->upgradeCreature(getObj(), ID, newID); };
+	if(canDismiss) dism = [=] { LOCPLINT->cb->dismissCreature(getObj(), ID); };
+
+	owner->selectSlot(nullptr);
+	owner->setSplittingMode(false);
+
+	for(auto & elem : owner->splitButtons)
+		elem->block(true);
+
+	redraw();
+	GH.pushInt(new CStackWindow(myStack, dism, pom, upgr));
+	return true;
+}
+
+bool CGarrisonSlot::highlightOrDropArtifact()
+{
+	bool artSelected = false;
+	if (CWindowWithArtifacts* chw = dynamic_cast<CWindowWithArtifacts*>(GH.topInt())) //dirty solution
+	{
+		const CArtifactsOfHero::SCommonPart *commonInfo = chw->artSets.front()->commonInfo;
+		if (const CArtifactInstance *art = commonInfo->src.art)
+		{
+			const CGHeroInstance *srcHero = commonInfo->src.AOH->getHero();
+			artSelected = true;
+			if (myStack) // try dropping the artifact only if the slot isn't empty
+			{
+				ArtifactLocation src(srcHero, commonInfo->src.slotID);
+				ArtifactLocation dst(myStack, ArtifactPosition::CREATURE_SLOT);
+				if (art->canBePutAt(dst, true))
+				{	//equip clicked stack
+					if(dst.getArt())
+					{
+						//creature can wear only one active artifact
+						//if we are placing a new one, the old one will be returned to the hero's backpack
+						LOCPLINT->cb->swapArtifacts(dst, ArtifactLocation(srcHero, dst.getArt()->firstBackpackSlot(srcHero)));
+					}
+					LOCPLINT->cb->swapArtifacts(src, dst);
+				}
+			}
+		}
+	}
+	if (!artSelected && creature)
+	{
+		owner->selectSlot(this);
+		if(creature)
+		{
+			for(auto & elem : owner->splitButtons)
+				elem->block(!our());
+		}
+	}
+	redraw();
+	return true;
+}
+
+bool CGarrisonSlot::split()
+{
+	const CGarrisonSlot * selection = owner->getSelection();
+	owner->p2 = ID;   // store the second stack pos
+	owner->pb = upg;  // store the second stack owner (up or down army)
+	owner->setSplittingMode(false);
+
+	int minLeft=0, minRight=0;
+
+	if(upg != selection->upg) // not splitting within same army
+	{
+		if(selection->getObj()->stacksCount() == 1 // we're splitting away the last stack
+			&& selection->getObj()->needsLastStack() )
+		{
+			minLeft = 1;
+		}
+		// destination army can't be emptied, unless we're rebalancing two stacks of same creature
+		if(getObj()->stacksCount() == 1
+			&& selection->creature == creature
+			&& getObj()->needsLastStack() )
+		{
+			minRight = 1;
+		}
+	}
+
+	int countLeft = selection->myStack ? selection->myStack->count : 0;
+	int countRight = myStack ? myStack->count : 0;
+
+	GH.pushInt(new CSplitWindow(selection->creature, std::bind(&CGarrisonInt::splitStacks, owner, _1, _2),
+	                            minLeft, minRight, countLeft, countRight));
+	return true;
+}
+
 void CGarrisonSlot::clickLeft(tribool down, bool previousState)
 {
 	if(down)
 	{
 		bool refr = false;
 		const CGarrisonSlot * selection = owner->getSelection();
-		if(selection)
+		if(!selection)
+			refr = highlightOrDropArtifact();
+		else if(selection == this)
+			refr = viewInfo();
+		// Only allow certain moves if troops aren't removable or not ours.
+		else if (!(  ( selection->our()//our creature is selected
+		         || selection->creature == creature )//or we are rebalancing army
+		       && ( owner->removableUnits
+		         || (upg == 0 &&  ( selection->upg == 1 && !creature ) )
+		         || (upg == 1 &&    selection->upg == 1 ) ) ))
 		{
-			if(selection == this) //view info
-			{
-				UpgradeInfo pom;
-				LOCPLINT->cb->getUpgradeInfo(getObj(), ID, pom);
-
-				bool canUpgrade = getObj()->tempOwner == LOCPLINT->playerID && pom.oldID>=0; //upgrade is possible
-				bool canDismiss = getObj()->tempOwner == LOCPLINT->playerID && (getObj()->stacksCount()>1  || !getObj()->needsLastStack());
-				std::function<void(CreatureID)> upgr = nullptr;
-				std::function<void()> dism = nullptr;
-				if(canUpgrade) upgr = [=] (CreatureID newID) { LOCPLINT->cb->upgradeCreature(getObj(), ID, newID); };
-				if(canDismiss) dism = [=] { LOCPLINT->cb->dismissCreature(getObj(), ID); };
-
-				owner->selectSlot(nullptr);
-				owner->setSplittingMode(false);
-
-				for(auto & elem : owner->splitButtons)
-					elem->block(true);
-
-				redraw();
-				refr = true;
-				GH.pushInt(new CStackWindow(myStack, dism, pom, upgr));
-			}
-			else
-			{
-				// Only allow certain moves if troops aren't removable or not ours.
-				if (  ( selection->our()//our creature is selected
-				     || selection->creature == creature )//or we are rebalancing army
-				   && ( owner->removableUnits
-				     || (upg == 0 &&  ( selection->upg == 1 && !creature ) )
-					 || (upg == 1 &&    selection->upg == 1 ) ) )
-				{
-					//we want to split
-					if((owner->getSplittingMode() || LOCPLINT->shiftPressed())
-						&& (!creature
-							|| (creature == selection->creature)))
-					{
-						owner->p2 = ID; //store the second stack pos
-						owner->pb = upg;//store the second stack owner (up or down army)
-						owner->setSplittingMode(false);
-
-						int minLeft=0, minRight=0;
-
-						if(upg != selection->upg) //not splitting within same army
-						{
-							if(selection->getObj()->stacksCount() == 1 //we're splitting away the last stack
-								&& selection->getObj()->needsLastStack() )
-							{
-								minLeft = 1;
-							}
-							if(getObj()->stacksCount() == 1 //destination army can't be emptied, unless we're rebalancing two stacks of same creature
-								&& selection->creature == creature
-								&& getObj()->needsLastStack() )
-							{
-								minRight = 1;
-							}
-						}
-
-						int countLeft = selection->myStack ? selection->myStack->count : 0;
-						int countRight = myStack ? myStack->count : 0;
-
-						GH.pushInt(new CSplitWindow(selection->creature, std::bind(&CGarrisonInt::splitStacks, owner, _1, _2),
-						                            minLeft, minRight, countLeft, countRight));
-						refr = true;
-					}
-					else if(creature != selection->creature) //swap
-					{
-						LOCPLINT->cb->swapCreatures(
-							(!upg)?(owner->armedObjs[0]):(owner->armedObjs[1]),
-							(!selection->upg)?(owner->armedObjs[0]):(owner->armedObjs[1]),
-							ID,selection->ID);
-					}
-					else //merge
-					{
-						LOCPLINT->cb->mergeStacks(
-							(!selection->upg)?(owner->armedObjs[0]):(owner->armedObjs[1]),
-							(!upg)?(owner->armedObjs[0]):(owner->armedObjs[1]),
-							selection->ID,ID);
-					}
-				}
-				else // Highlight
-				{
-					if(creature)
-						owner->selectSlot(this);
-					redraw();
-					refr = true;
-				}
-			}
-		}
-		else //highlight or drop artifact
-		{
-			bool artSelected = false;
-			if (CWindowWithArtifacts* chw = dynamic_cast<CWindowWithArtifacts*>(GH.topInt())) //dirty solution
-			{
-				const CArtifactsOfHero::SCommonPart *commonInfo = chw->artSets.front()->commonInfo;
-				if (const CArtifactInstance *art = commonInfo->src.art)
-				{
-					const CGHeroInstance *srcHero = commonInfo->src.AOH->getHero();
-					artSelected = true;
-					if (myStack) // try dropping the artifact only if the slot isn't empty
-					{
-						ArtifactLocation src(srcHero, commonInfo->src.slotID);
-						ArtifactLocation dst(myStack, ArtifactPosition::CREATURE_SLOT);
-						if (art->canBePutAt(dst, true))
-						{	//equip clicked stack
-							if(dst.getArt())
-							{
-								//creature can wear only one active artifact
-								//if we are placing a new one, the old one will be returned to the hero's backpack
-								LOCPLINT->cb->swapArtifacts(dst, ArtifactLocation(srcHero, dst.getArt()->firstBackpackSlot(srcHero)));
-							}
-							LOCPLINT->cb->swapArtifacts(src, dst);
-						}
-					}
-				}
-			}
-			if (!artSelected && creature)
-			{
+			// Highlight
+			if(creature)
 				owner->selectSlot(this);
-				if(creature)
-				{
-					for(auto & elem : owner->splitButtons)
-						elem->block(!our());
-				}
-			}
 			redraw();
 			refr = true;
 		}
+		// we want to split
+		else if(  (owner->getSplittingMode() || LOCPLINT->shiftPressed())
+		       && (!creature || creature == selection->creature) )
+			refr = split();
+		// swap
+		else if(creature != selection->creature)
+			LOCPLINT->cb->swapCreatures(
+				(!upg)?(owner->armedObjs[0]):(owner->armedObjs[1]),
+				(!selection->upg)?(owner->armedObjs[0]):(owner->armedObjs[1]),
+				ID,selection->ID);
+		// merge
+		else
+			LOCPLINT->cb->mergeStacks(
+				(!selection->upg)?(owner->armedObjs[0]):(owner->armedObjs[1]),
+				(!upg)?(owner->armedObjs[0]):(owner->armedObjs[1]),
+				selection->ID,ID);
 		if(refr) {hover(false);	hover(true); } //to refresh statusbar
 	}
 }

--- a/client/widgets/CGarrisonInt.cpp
+++ b/client/widgets/CGarrisonInt.cpp
@@ -241,14 +241,21 @@ bool CGarrisonSlot::split()
 
 /// If certain creates cannot be moved, the selection should change
 /// Force reselection in these cases
+///     * When attempting to take creatures from ally
 ///     * When attempting to swap creatures with an ally
 ///     * When attempting to take unremovable units
 /// @return Whether reselection must be done
 bool CGarrisonSlot::mustForceReselection() const
 {
 	const CGarrisonSlot * selection = owner->getSelection();
-	// Attempt to swap creatures with ally
-	if (selection->creature != creature && !selection->our())
+	bool withAlly = selection->our() ^ our();
+	if (!creature || !selection->creature)
+		return false;
+	// Attempt to take creatures from ally (select theirs first)
+	if (!selection->our())
+		return true;
+	// Attempt to swap creatures with ally (select ours first)
+	if (selection->creature != creature && withAlly)
 		return true;
 	if (!owner->removableUnits)
 	{

--- a/client/widgets/CGarrisonInt.cpp
+++ b/client/widgets/CGarrisonInt.cpp
@@ -75,7 +75,7 @@ void CGarrisonSlot::hover (bool on)
 				{
 					temp = CGI->generaltexth->tcommands[32]; //Select %s (visiting)
 				}
-				else if(owner->armedObjs[0] && owner->armedObjs[0]->ID == Obj::TOWN)
+				else if(owner->armedObjs[0] && (owner->armedObjs[0]->ID == Obj::TOWN || owner->armedObjs[0]->ID == Obj::HERO))
 				{
 					temp = CGI->generaltexth->tcommands[12]; //Select %s (in garrison)
 				}

--- a/client/widgets/CGarrisonInt.h
+++ b/client/widgets/CGarrisonInt.h
@@ -43,6 +43,7 @@ class CGarrisonSlot : public CIntObject
 	bool viewInfo();
 	bool highlightOrDropArtifact();
 	bool split();
+	bool mustForceReselection() const;
 
 	void setHighlight(bool on);
 public:

--- a/client/widgets/CGarrisonInt.h
+++ b/client/widgets/CGarrisonInt.h
@@ -51,34 +51,35 @@ public:
 /// Class which manages slots of upper and lower garrison, splitting of units
 class CGarrisonInt :public CIntObject
 {
-	CGarrisonSlot *highlighted; //chosen slot. Should be changed only via selectSlot
+	/// Chosen slot. Should be changed only via selectSlot.
+	CGarrisonSlot *highlighted;
 	bool inSplittingMode;
 
 public:
-	void selectSlot(CGarrisonSlot * slot); //null = deselect
+	void selectSlot(CGarrisonSlot * slot); ///< @param slot null = deselect
 	const CGarrisonSlot * getSelection();
 
 	void setSplittingMode(bool on);
 	bool getSplittingMode();
 
-	int interx; //space between slots
-	Point garOffset; //offset between garrisons (not used if only one hero)
-	std::vector<CButton *> splitButtons; //may be empty if no buttons
+	int interx;  ///< Space between slots
+	Point garOffset;  ///< Offset between garrisons (not used if only one hero)
+	std::vector<CButton *> splitButtons;  ///< May be empty if no buttons
 
-	SlotID p2; //TODO: comment me
-	int	shiftPos;//1st slot of the second row, set shiftPoint for effect
+	SlotID p2; ///< TODO: comment me
+	int	shiftPos; ///< 1st slot of the second row, set shiftPoint for effect
 	bool pb,
-		 smallIcons, //true - 32x32 imgs, false - 58x64
-		 removableUnits,//player can remove units from up
-		 twoRows,//slots will be placed in 2 rows
-		 owned[2];//player owns up or down army [0] upper, [1] lower
+		 smallIcons,      ///< true - 32x32 imgs, false - 58x64
+		 removableUnits,  ///< player Can remove units from up
+		 twoRows,         ///< slots Will be placed in 2 rows
+		 owned[2];        ///< player Owns up or down army ([0] upper, [1] lower)
 
-// 	const CCreatureSet *set1; //top set of creatures
-// 	const CCreatureSet *set2; //bottom set of creatures
+// 	const CCreatureSet *set1;  ///< Top set of creatures
+// 	const CCreatureSet *set2;  ///< Bottom set of creatures
 
-	std::vector<CGarrisonSlot*> slotsUp, slotsDown; //slots of upper and lower garrison
-	const CArmedInstance *armedObjs[2]; //[0] is upper, [1] is down
-	//const CArmedInstance *oup, *odown; //upper and lower garrisons (heroes or towns)
+	std::vector<CGarrisonSlot*> slotsUp, slotsDown;  ///< Slots of upper and lower garrison
+	const CArmedInstance *armedObjs[2];  ///< [0] is upper, [1] is down
+	//const CArmedInstance *oup, *odown;  ///< Upper and lower garrisons (heroes or towns)
 
 	void setArmy(const CArmedInstance *army, bool bottomGarrison);
 	void addSplitBtn(CButton * button);
@@ -87,16 +88,26 @@ public:
 	void createSlots();
 	void recreateSlots();
 
-	void splitClick(); //handles click on split button
-	void splitStacks(int amountLeft, int amountRight); //TODO: comment me
-	//x, y - position;
-	//inx - distance between slots;
-	//pomsur, SurOffset - UNUSED
-	//s1, s2 - top and bottom armies;
-	//removableUnits - you can take units from top;
-	//smallImgs - units images size 64x58 or 32x32;
-	//twoRows - display slots in 2 row (1st row = 4 slots, 2nd = 3 slots)
-	CGarrisonInt(int x, int y, int inx, const Point &garsOffset, SDL_Surface *pomsur, const Point &SurOffset, const CArmedInstance *s1, const CArmedInstance *s2=nullptr, bool _removableUnits = true, bool smallImgs = false, bool _twoRows=false); //c-tor
+	void splitClick();  ///< handles click on split button
+	void splitStacks(int amountLeft, int amountRight);  ///< TODO: comment me
+
+	/// Constructor
+	/// @param x, y Position
+	/// @param inx Distance between slots;
+	/// @param garsOffset
+	/// @param pomsur, SurOffset UNUSED
+	/// @param s1, s2 Top and bottom armies
+	/// @param _removableUnits You can take units from top
+	/// @param smallImgs Units images size 64x58 or 32x32
+	/// @param _twoRows Display slots in 2 row (1st row = 4 slots, 2nd = 3 slots)
+	CGarrisonInt(int x, int y,
+	             int inx,
+	             const Point &garsOffset,
+	             SDL_Surface *pomsur, const Point &SurOffset,
+	             const CArmedInstance *s1, const CArmedInstance *s2=nullptr,
+	             bool _removableUnits = true,
+	             bool smallImgs = false,
+	             bool _twoRows=false);
 };
 
 class CGarrisonHolder

--- a/client/widgets/CGarrisonInt.h
+++ b/client/widgets/CGarrisonInt.h
@@ -34,6 +34,10 @@ class CGarrisonSlot : public CIntObject
 	CAnimImage * selectionImage; // image for selection, not always visible
 	CLabel * stackCount;
 
+	bool viewInfo();
+	bool highlightOrDropArtifact();
+	bool split();
+
 	void setHighlight(bool on);
 public:
 	virtual void hover (bool on); //call-in

--- a/client/widgets/CGarrisonInt.h
+++ b/client/widgets/CGarrisonInt.h
@@ -28,7 +28,13 @@ class CGarrisonSlot : public CIntObject
 	CGarrisonInt *owner;
 	const CStackInstance *myStack; //nullptr if slot is empty
 	const CCreature *creature;
-	int upg; //0 - up garrison, 1 - down garrison
+
+	/// Type of Garrison for slot (up or down)
+	enum EGarrisonType
+	{
+		UP=0,  ///< 0 - up garrison (Garrisoned)
+		DOWN,  ///< 1 - down garrison (Visiting)
+	} upg; ///< Flag indicating if it is the up or down garrison
 
 	CAnimImage * creatureImage;
 	CAnimImage * selectionImage; // image for selection, not always visible
@@ -47,7 +53,7 @@ public:
 	void clickRight(tribool down, bool previousState);
 	void clickLeft(tribool down, bool previousState);
 	void update();
-	CGarrisonSlot(CGarrisonInt *Owner, int x, int y, SlotID IID, int Upg=0, const CStackInstance * Creature=nullptr);
+	CGarrisonSlot(CGarrisonInt *Owner, int x, int y, SlotID IID, EGarrisonType Upg=EGarrisonType::UP, const CStackInstance * Creature=nullptr);
 
 	friend class CGarrisonInt;
 };
@@ -87,7 +93,7 @@ public:
 
 	void setArmy(const CArmedInstance *army, bool bottomGarrison);
 	void addSplitBtn(CButton * button);
-	void createSet(std::vector<CGarrisonSlot*> &ret, const CCreatureSet * set, int posX, int distance, int posY, int Upg );
+	void createSet(std::vector<CGarrisonSlot*> &ret, const CCreatureSet * set, int posX, int distance, int posY, CGarrisonSlot::EGarrisonType Upg );
 
 	void createSlots();
 	void recreateSlots();

--- a/client/windows/CCastleInterface.cpp
+++ b/client/windows/CCastleInterface.cpp
@@ -381,7 +381,10 @@ void CHeroGSlot::clickLeft(tribool down, bool previousState)
 			other->setHighlight(false);
 
 			if(allow)
+			{
 				owner->swapArmies();
+				hero = other->hero;
+			}
 		}
 		else if(hero)
 		{


### PR DESCRIPTION
Fix tooltip for in garrison creatures
Show tooltip after moving hero to garrison
Disable creature split button for garrisoned ally
Refactor and simplify Left Click in Garrison
Fix selection as default when action is made
Implement moving all but last creature mechanic
Various documentation addition
