### PR TITLE
Fix warnings produced by recent Clang build

### DIFF
--- a/AI/VCAI/AIUtility.cpp
+++ b/AI/VCAI/AIUtility.cpp
@@ -432,7 +432,7 @@ bool boundaryBetweenTwoPoints (int3 pos1, int3 pos2, CCallback * cbp) //determin
 		for (int y = yMin; y <= yMax; ++y)
 		{
 			int3 tile = int3(x, y, pos1.z); //use only on same level, ofc
-			if (abs(pos1.dist2d(tile) - pos2.dist2d(tile)) < 1.5)
+			if (std::abs(pos1.dist2d(tile) - pos2.dist2d(tile)) < 1.5)
 			{
 				if (!(cbp->isVisible(tile) && cbp->getTile(tile)->blocked)) //if there's invisible or unblocked tile between, it's good
 					return false;

--- a/CCallback.h
+++ b/CCallback.h
@@ -119,34 +119,34 @@ public:
 	void unregisterAllInterfaces(); //stops delivering information about game events to player interfaces -> can be called ONLY after victory/loss
 
 //commands
-	bool moveHero(const CGHeroInstance *h, int3 dst, bool transit = false); //dst must be free, neighbouring tile (this function can move hero only by one tile)
+	bool moveHero(const CGHeroInstance *h, int3 dst, bool transit = false) override; //dst must be free, neighbouring tile (this function can move hero only by one tile)
 	bool teleportHero(const CGHeroInstance *who, const CGTownInstance *where);
-	int selectionMade(int selection, QueryID queryID);
-	int swapCreatures(const CArmedInstance *s1, const CArmedInstance *s2, SlotID p1, SlotID p2);
-	int mergeOrSwapStacks(const CArmedInstance *s1, const CArmedInstance *s2, SlotID p1, SlotID p2); //first goes to the second
-	int mergeStacks(const CArmedInstance *s1, const CArmedInstance *s2, SlotID p1, SlotID p2); //first goes to the second
-	int splitStack(const CArmedInstance *s1, const CArmedInstance *s2, SlotID p1, SlotID p2, int val);
-	bool dismissHero(const CGHeroInstance * hero);
+	int selectionMade(int selection, QueryID queryID) override;
+	int swapCreatures(const CArmedInstance *s1, const CArmedInstance *s2, SlotID p1, SlotID p2) override;
+	int mergeOrSwapStacks(const CArmedInstance *s1, const CArmedInstance *s2, SlotID p1, SlotID p2) override; //first goes to the second
+	int mergeStacks(const CArmedInstance *s1, const CArmedInstance *s2, SlotID p1, SlotID p2) override; //first goes to the second
+	int splitStack(const CArmedInstance *s1, const CArmedInstance *s2, SlotID p1, SlotID p2, int val) override;
+	bool dismissHero(const CGHeroInstance * hero) override;
 	//bool swapArtifacts(const CGHeroInstance * hero1, ui16 pos1, const CGHeroInstance * hero2, ui16 pos2);
-	bool swapArtifacts(const ArtifactLocation &l1, const ArtifactLocation &l2);
+	bool swapArtifacts(const ArtifactLocation &l1, const ArtifactLocation &l2) override;
 	//bool moveArtifact(const CGHeroInstance * hero, ui16 src, const CStackInstance * stack, ui16 dest); // TODO: unify classes
 	//bool moveArtifact(const CStackInstance * stack, ui16 src , const CGHeroInstance * hero, ui16 dest); // TODO: unify classes
-	bool assembleArtifacts(const CGHeroInstance * hero, ArtifactPosition artifactSlot, bool assemble, ArtifactID assembleTo);
+	bool assembleArtifacts(const CGHeroInstance * hero, ArtifactPosition artifactSlot, bool assemble, ArtifactID assembleTo) override;
 	bool buildBuilding(const CGTownInstance *town, BuildingID buildingID) override;
-	void recruitCreatures(const CGDwelling * obj, const CArmedInstance * dst, CreatureID ID, ui32 amount, si32 level=-1);
-	bool dismissCreature(const CArmedInstance *obj, SlotID stackPos);
+	void recruitCreatures(const CGDwelling * obj, const CArmedInstance * dst, CreatureID ID, ui32 amount, si32 level=-1) override;
+	bool dismissCreature(const CArmedInstance *obj, SlotID stackPos) override;
 	bool upgradeCreature(const CArmedInstance *obj, SlotID stackPos, CreatureID newID=CreatureID::NONE) override;
-	void endTurn();
-	void swapGarrisonHero(const CGTownInstance *town);
+	void endTurn() override;
+	void swapGarrisonHero(const CGTownInstance *town) override;
 	void buyArtifact(const CGHeroInstance *hero, ArtifactID aid) override;
-	void trade(const CGObjectInstance *market, EMarketMode::EMarketMode mode, int id1, int id2, int val1, const CGHeroInstance *hero = nullptr);
-	void setFormation(const CGHeroInstance * hero, bool tight);
-	void recruitHero(const CGObjectInstance *townOrTavern, const CGHeroInstance *hero);
-	void save(const std::string &fname);
-	void sendMessage(const std::string &mess, const CGObjectInstance * currentObject = nullptr);
-	void buildBoat(const IShipyard *obj);
-	void dig(const CGObjectInstance *hero);
-	void castSpell(const CGHeroInstance *hero, SpellID spellID, const int3 &pos = int3(-1, -1, -1));
+	void trade(const CGObjectInstance *market, EMarketMode::EMarketMode mode, int id1, int id2, int val1, const CGHeroInstance *hero = nullptr) override;
+	void setFormation(const CGHeroInstance * hero, bool tight) override;
+	void recruitHero(const CGObjectInstance *townOrTavern, const CGHeroInstance *hero) override;
+	void save(const std::string &fname) override;
+	void sendMessage(const std::string &mess, const CGObjectInstance * currentObject = nullptr) override;
+	void buildBoat(const IShipyard *obj) override;
+	void dig(const CGObjectInstance *hero) override;
+	void castSpell(const CGHeroInstance *hero, SpellID spellID, const int3 &pos = int3(-1, -1, -1)) override;
 
 //friends
 	friend class CClient;

--- a/client/CMessage.cpp
+++ b/client/CMessage.cpp
@@ -45,7 +45,7 @@ public:
 	CComponent *comp;
 
 	//blit component with image centered at this position
-	void showAll(SDL_Surface * to);
+	void showAll(SDL_Surface * to) override;
 
 	//ComponentResolved(); //c-tor
 	ComponentResolved(CComponent *Comp); //c-tor

--- a/client/CMusicHandler.h
+++ b/client/CMusicHandler.h
@@ -52,10 +52,10 @@ private:
 public:
 	CSoundHandler();
 
-	void init();
-	void release();
+	void init() override;
+	void release() override;
 
-	void setVolume(ui32 percent);
+	void setVolume(ui32 percent) override;
 
 	// Sounds
 	int playSound(soundBase::soundID soundID, int repeats=0);
@@ -127,9 +127,9 @@ public:
 	/// add entry with URI musicURI in set. Track will have ID musicID
 	void addEntryToSet(std::string set, int musicID, std::string musicURI);
 
-	void init();
-	void release();
-	void setVolume(ui32 percent);
+	void init() override;
+	void release() override;
+	void setVolume(ui32 percent) override;
 
 	/// play track by URI, if loop = true music will be looped
 	void playMusic(std::string musicURI, bool loop);

--- a/client/CPlayerInterface.h
+++ b/client/CPlayerInterface.h
@@ -147,11 +147,11 @@ public:
 	void newStackInserted(const StackLocation &location, const CStackInstance &stack) override; //new stack inserted at given (previously empty position)
 	void stacksRebalanced(const StackLocation &src, const StackLocation &dst, TQuantity count) override; //moves creatures from src stack to dst slot, may be used for merging/splittint/moving stacks
 
-	void artifactPut(const ArtifactLocation &al);
-	void artifactRemoved(const ArtifactLocation &al);
-	void artifactMoved(const ArtifactLocation &src, const ArtifactLocation &dst);
-	void artifactAssembled(const ArtifactLocation &al);
-	void artifactDisassembled(const ArtifactLocation &al);
+	void artifactPut(const ArtifactLocation &al) override;
+	void artifactRemoved(const ArtifactLocation &al) override;
+	void artifactMoved(const ArtifactLocation &src, const ArtifactLocation &dst) override;
+	void artifactAssembled(const ArtifactLocation &al) override;
+	void artifactDisassembled(const ArtifactLocation &al) override;
 
 	void heroCreated(const CGHeroInstance* hero) override;
 	void heroGotLevel(const CGHeroInstance *hero, PrimarySkill::PrimarySkill pskill, std::vector<SecondarySkill> &skills, QueryID queryID) override;
@@ -236,7 +236,7 @@ public:
 	void openTownWindow(const CGTownInstance * town); //shows townscreen
 	void openHeroWindow(const CGHeroInstance * hero); //shows hero window with given hero
 	void updateInfo(const CGObjectInstance * specific);
-	void init(shared_ptr<CCallback> CB);
+	void init(shared_ptr<CCallback> CB) override;
 	int3 repairScreenPos(int3 pos); //returns position closest to pos we can center screen on
 
 	// show dialogs

--- a/client/CPreGame.cpp
+++ b/client/CPreGame.cpp
@@ -207,7 +207,7 @@ public:
 template <typename T> class CApplyOnPG : public CBaseForPGApply
 {
 public:
-	void applyOnPG(CSelectionScreen *selScr, void *pack) const
+	void applyOnPG(CSelectionScreen *selScr, void *pack) const override
 	{
 		T *ptr = static_cast<T*>(pack);
 		ptr->apply(selScr);
@@ -217,7 +217,7 @@ public:
 template <> class CApplyOnPG<CPack> : public CBaseForPGApply
 {
 public:
-	void applyOnPG(CSelectionScreen *selScr, void *pack) const
+	void applyOnPG(CSelectionScreen *selScr, void *pack) const override
 	{
 			logGlobal->errorStream() << "Cannot apply on PG plain CPack!";
 			assert(0);

--- a/client/CPreGame.h
+++ b/client/CPreGame.h
@@ -75,10 +75,10 @@ public:
 	};
 	CMenuScreen(const JsonNode& configNode);
 
-	void showAll(SDL_Surface * to);
-	void show(SDL_Surface * to);
-	void activate();
-	void deactivate();
+	void showAll(SDL_Surface * to) override;
+	void show(SDL_Surface * to) override;
+	void activate() override;
+	void deactivate() override;
 
 	void switchToTab(size_t index);
 };
@@ -100,10 +100,10 @@ class CreditsScreen : public CIntObject
 public:
 	CreditsScreen();
 
-	void show(SDL_Surface * to);
+	void show(SDL_Surface * to) override;
 
-	void clickLeft(tribool down, bool previousState);
-	void clickRight(tribool down, bool previousState);
+	void clickLeft(tribool down, bool previousState) override;
+	void clickRight(tribool down, bool previousState) override;
 };
 
 /// Implementation of the chat box
@@ -115,7 +115,7 @@ public:
 
 	CChatBox(const Rect &rect);
 
-	void keyPressed(const SDL_KeyboardEvent & key);
+	void keyPressed(const SDL_KeyboardEvent & key) override;
 
 	void addNewMessage(const std::string &text);
 };
@@ -136,8 +136,8 @@ public:
 	CDefHandler *sizes, *sFlags;
 
 	void changeSelection(const CMapInfo *to);
-	void showAll(SDL_Surface * to);
-	void clickRight(tribool down, bool previousState);
+	void showAll(SDL_Surface * to) override;
+	void clickRight(tribool down, bool previousState) override;
 	void showTeamsPopup();
 	void toggleChat();
 	void setChat(bool activateChat);
@@ -184,10 +184,10 @@ public:
 	void selectFName(std::string fname);
 	const CMapInfo * getSelectedMapInfo() const;
 
-	void showAll(SDL_Surface * to);
-	void clickLeft(tribool down, bool previousState);
-	void keyPressed(const SDL_KeyboardEvent & key);
-	void onDoubleClick();
+	void showAll(SDL_Surface * to) override;
+	void clickLeft(tribool down, bool previousState) override;
+	void keyPressed(const SDL_KeyboardEvent & key) override;
+	void onDoubleClick() override;
 	SelectionTab(CMenuScreen::EState Type, const std::function<void(CMapInfo *)> &OnSelect, CMenuScreen::EMultiMode MultiPlayer = CMenuScreen::SINGLE_PLAYER);
     ~SelectionTab();
 };
@@ -235,7 +235,7 @@ public:
 		CLabel *subtitle;
 
 		SelectedBox(Point position, PlayerSettings & settings, SelType type);
-		void clickRight(tribool down, bool previousState);
+		void clickRight(tribool down, bool previousState) override;
 
 		void update();
 	};
@@ -254,7 +254,7 @@ public:
 
 		PlayerOptionsEntry(OptionsTab *owner, PlayerSettings &S);
 		void selectButtons(); //hides unavailable buttons
-		void showAll(SDL_Surface * to);
+		void showAll(SDL_Surface * to) override;
 		void update();
 	};
 
@@ -282,7 +282,7 @@ public:
 	void recreate();
 	OptionsTab();
 	~OptionsTab();
-	void showAll(SDL_Surface * to);
+	void showAll(SDL_Surface * to) override;
 
 	int nextAllowedHero(PlayerColor player, int min, int max, int incl, int dir );
 
@@ -295,7 +295,7 @@ class CRandomMapTab : public CIntObject
 public:
 	CRandomMapTab();
 
-    void showAll(SDL_Surface * to);
+    void showAll(SDL_Surface * to) override;
 	void updateMapInfo();
 	CFunctionList<void (const CMapInfo *)> & getMapInfoChanged();
 	const CMapInfo * getMapInfo() const;
@@ -385,7 +385,7 @@ public:
 	void postRequest(ui8 what, ui8 dir) override;
 	void postChatMessage(const std::string &txt) override;
 	void propagateNames();
-	void showAll(SDL_Surface *to);
+	void showAll(SDL_Surface *to) override;
 };
 
 /// Save game screen
@@ -454,8 +454,8 @@ class CPrologEpilogVideo : public CWindowObject
 public:
 	CPrologEpilogVideo(CCampaignScenario::SScenarioPrologEpilog _spe, std::function<void()> callback);
 
-	void clickLeft(tribool down, bool previousState);
-	void show(SDL_Surface * to);
+	void clickLeft(tribool down, bool previousState) override;
+	void show(SDL_Surface * to) override;
 };
 
 /// Campaign screen where you can choose one out of three starting bonuses
@@ -498,9 +498,9 @@ private:
 		CRegion(CBonusSelection * _owner, bool _accessible, bool _selectable, int _myNumber);
 		~CRegion();
 
-		void clickLeft(tribool down, bool previousState);
-		void clickRight(tribool down, bool previousState);
-		void show(SDL_Surface * to);
+		void clickLeft(tribool down, bool previousState) override;
+		void clickRight(tribool down, bool previousState) override;
+		void show(SDL_Surface * to) override;
 	};
 
 	void init();
@@ -560,12 +560,12 @@ private:
 		std::string video; // the resource name of the video
 		std::string hoverText;
 
-		void clickLeft(tribool down, bool previousState);
-		void hover(bool on);
+		void clickLeft(tribool down, bool previousState) override;
+		void hover(bool on) override;
 
 	public:
 		CCampaignButton(const JsonNode &config );
-		void show(SDL_Surface * to);
+		void show(SDL_Surface * to) override;
 	};
 
 	CButton *back;
@@ -578,7 +578,7 @@ public:
 	enum CampaignSet {ROE, AB, SOD, WOG};
 
 	CCampaignScreen(const JsonNode &config);
-	void showAll(SDL_Surface *to);
+	void showAll(SDL_Surface *to) override;
 };
 
 /// Manages the configuration of pregame GUI elements like campaign screen, main menu, loading screen,...
@@ -629,7 +629,7 @@ public:
 	CLoadingScreen(std::function<void()> loader);
 	~CLoadingScreen();
 
-	void showAll(SDL_Surface *to);
+	void showAll(SDL_Surface *to) override;
 };
 
 /// Simple window to enter the server's address.

--- a/client/Client.cpp
+++ b/client/Client.cpp
@@ -72,12 +72,12 @@ public:
 template <typename T> class CApplyOnCL : public CBaseForCLApply
 {
 public:
-	void applyOnClAfter(CClient *cl, void *pack) const
+	void applyOnClAfter(CClient *cl, void *pack) const override
 	{
 		T *ptr = static_cast<T*>(pack);
 		ptr->applyCl(cl);
 	}
-	void applyOnClBefore(CClient *cl, void *pack) const
+	void applyOnClBefore(CClient *cl, void *pack) const override
 	{
 		T *ptr = static_cast<T*>(pack);
 		ptr->applyFirstCl(cl);
@@ -87,12 +87,12 @@ public:
 template <> class CApplyOnCL<CPack> : public CBaseForCLApply
 {
 public:
-	void applyOnClAfter(CClient *cl, void *pack) const
+	void applyOnClAfter(CClient *cl, void *pack) const override
 	{
 		logGlobal->errorStream() << "Cannot apply on CL plain CPack!";
 		assert(0);
 	}
-	void applyOnClBefore(CClient *cl, void *pack) const
+	void applyOnClBefore(CClient *cl, void *pack) const override
 	{
 		logGlobal->errorStream() << "Cannot apply on CL plain CPack!";
 		assert(0);

--- a/client/Client.h
+++ b/client/Client.h
@@ -189,7 +189,7 @@ public:
 	bool changeStackType(const StackLocation &sl, const CCreature *c) override {return false;};
 	bool changeStackCount(const StackLocation &sl, TQuantity count, bool absoluteValue = false) override {return false;};
 	bool insertNewStack(const StackLocation &sl, const CCreature *c, TQuantity count) override {return false;};
-	bool eraseStack(const StackLocation &sl, bool forceRemoval = false){return false;};
+	bool eraseStack(const StackLocation &sl, bool forceRemoval = false) override{return false;};
 	bool swapStacks(const StackLocation &sl1, const StackLocation &sl2) override {return false;}
 	bool addToSlot(const StackLocation &sl, const CCreature *c, TQuantity count) override {return false;}
 	void tryJoiningArmy(const CArmedInstance *src, const CArmedInstance *dst, bool removeObjWhenFinished, bool allowMerging) override {}

--- a/client/battle/CBattleAnimations.cpp
+++ b/client/battle/CBattleAnimations.cpp
@@ -782,7 +782,7 @@ bool CShootingAnimation::init()
 		spi.catapultInfo.reset(new CatapultProjectileInfo(Point(spi.x, spi.y), destPos));
 
 		double animSpeed = AnimationControls::getProjectileSpeed() / 10;
-		spi.lastStep = abs((destPos.x - spi.x) / animSpeed);
+		spi.lastStep = std::abs((destPos.x - spi.x) / animSpeed);
 		spi.dx = animSpeed;
 		spi.dy = 0;
 

--- a/client/battle/CBattleAnimations.h
+++ b/client/battle/CBattleAnimations.h
@@ -59,8 +59,8 @@ protected:
 	const CStack *attackingStack;
 	int attackingStackPosBeforeReturn; //for stacks with return_after_strike feature
 public:
-	void nextFrame();
-	void endAnim();
+	void nextFrame() override;
+	void endAnim() override;
 	bool checkInitialConditions();
 
 	CAttackAnimation(CBattleInterface *_owner, const CStack *attacker, BattleHex _dest, const CStack *defender);
@@ -80,9 +80,9 @@ class CDefenceAnimation : public CBattleStackAnimation
 
 	float timeToWait; // for how long this animation should be paused
 public:
-	bool init();
-	void nextFrame();
-	void endAnim();
+	bool init() override;
+	void nextFrame() override;
+	void endAnim() override;
 
 	CDefenceAnimation(StackAttackedInfo _attackedInfo, CBattleInterface * _owner);
 	virtual ~CDefenceAnimation(){};
@@ -94,9 +94,9 @@ private:
 	int counter;
 	int howMany;
 public:
-	bool init();
-	void nextFrame();
-	void endAnim();
+	bool init() override;
+	void nextFrame() override;
+	void endAnim() override;
 
 	CDummyAnimation(CBattleInterface * _owner, int howManyFrames);
 	virtual ~CDummyAnimation(){}
@@ -106,8 +106,8 @@ public:
 class CMeleeAttackAnimation : public CAttackAnimation
 {
 public:
-	bool init();
-	void endAnim();
+	bool init() override;
+	void endAnim() override;
 
 	CMeleeAttackAnimation(CBattleInterface * _owner, const CStack * attacker, BattleHex _dest, const CStack * _attacked);
 	virtual ~CMeleeAttackAnimation(){};
@@ -133,9 +133,9 @@ private:
 public:
 	BattleHex nextHex; // next hex, to which creature move right now
 
-	bool init();
-	void nextFrame();
-	void endAnim();
+	bool init() override;
+	void nextFrame() override;
+	void endAnim() override;
 
 	CMovementAnimation(CBattleInterface *_owner, const CStack *_stack, std::vector<BattleHex> _destTiles, int _distance);
 	virtual ~CMovementAnimation(){};
@@ -147,8 +147,8 @@ class CMovementEndAnimation : public CBattleStackAnimation
 private:
 	BattleHex destinationTile;
 public:
-	bool init();
-	void endAnim();
+	bool init() override;
+	void endAnim() override;
 
 	CMovementEndAnimation(CBattleInterface * _owner, const CStack * _stack, BattleHex destTile);
 	virtual ~CMovementEndAnimation(){};
@@ -158,8 +158,8 @@ public:
 class CMovementStartAnimation : public CBattleStackAnimation
 {
 public:
-	bool init();
-	void endAnim();
+	bool init() override;
+	void endAnim() override;
 
 	CMovementStartAnimation(CBattleInterface * _owner, const CStack * _stack);
 	virtual ~CMovementStartAnimation(){};
@@ -171,12 +171,12 @@ class CReverseAnimation : public CBattleStackAnimation
 	BattleHex hex;
 public:
 	bool priority; //true - high, false - low
-	bool init();
+	bool init() override;
 
 	static void rotateStack(CBattleInterface * owner, const CStack * stack, BattleHex hex);
 
 	void setupSecondPart();
-	void endAnim();
+	void endAnim() override;
 
 	CReverseAnimation(CBattleInterface * _owner, const CStack * stack, BattleHex dest, bool _priority);
 	virtual ~CReverseAnimation(){};
@@ -204,9 +204,9 @@ class CShootingAnimation : public CAttackAnimation
 private:
 	int catapultDamage;
 public:
-	bool init();
-	void nextFrame();
-	void endAnim();
+	bool init() override;
+	void nextFrame() override;
+	void endAnim() override;
 
 	//last two params only for catapult attacks
 	CShootingAnimation(CBattleInterface * _owner, const CStack * attacker, BattleHex _dest, 
@@ -225,9 +225,9 @@ private:
 	bool Vflip;
 	bool alignToBottom;
 public:
-	bool init();
-	void nextFrame();
-	void endAnim();
+	bool init() override;
+	void nextFrame() override;
+	void endAnim() override;
 
 	CSpellEffectAnimation(CBattleInterface * _owner, ui32 _effect, BattleHex _destTile, int _dx = 0, int _dy = 0, bool _Vflip = false, bool _alignToBottom = false);
 	CSpellEffectAnimation(CBattleInterface * _owner, std::string _customAnim, int _x, int _y, int _dx = 0, int _dy = 0, bool _Vflip = false, bool _alignToBottom = false);

--- a/client/battle/CBattleInterface.h
+++ b/client/battle/CBattleInterface.h
@@ -291,14 +291,14 @@ public:
 	void bEndTacticPhase();
 	//end of button handle funcs
 	//napisz tu klase odpowiadajaca za wyswietlanie bitwy i obsluge uzytkownika, polecenia ma przekazywac callbackiem
-	void activate();
-	void deactivate();
-	void keyPressed(const SDL_KeyboardEvent & key);
-	void mouseMoved(const SDL_MouseMotionEvent &sEvent);
-	void clickRight(tribool down, bool previousState);
+	void activate() override;
+	void deactivate() override;
+	void keyPressed(const SDL_KeyboardEvent & key) override;
+	void mouseMoved(const SDL_MouseMotionEvent &sEvent) override;
+	void clickRight(tribool down, bool previousState) override;
 
-	void show(SDL_Surface *to);
-	void showAll(SDL_Surface *to);
+	void show(SDL_Surface *to) override;
+	void showAll(SDL_Surface *to) override;
 
 	//call-ins
 	void startAction(const BattleAction* action);

--- a/client/battle/CBattleInterfaceClasses.h
+++ b/client/battle/CBattleInterfaceClasses.h
@@ -38,7 +38,7 @@ public:
 	std::string ingcAlter; //alternative text set by in-game console - very important!
 	int whoSetAlter; //who set alter text; 0 - battle interface or none, 1 - button
 	CBattleConsole();
-	void showAll(SDL_Surface * to = 0);
+	void showAll(SDL_Surface * to = 0) override;
 	bool addText(const std::string &text); //adds text at the last position; returns false if failed (e.g. text longer than 70 characters)
 	void alterText(const std::string &text); //place string at alterTxt
 	void eraseText(ui32 pos); //erases added text at position pos
@@ -60,9 +60,9 @@ public:
 	int nextPhase; //stage of animation to be set after current phase is fully displayed
 	int currentFrame, firstFrame, lastFrame; //frame of animation
 	ui8 flagAnim, animCount; //for flag animation
-	void show(SDL_Surface * to); //prints next frame of animation to to
+	void show(SDL_Surface * to) override; //prints next frame of animation to to
 	void setPhase(int newPhase); //sets phase of hero animation
-	void clickLeft(tribool down, bool previousState); //call-in
+	void clickLeft(tribool down, bool previousState) override; //call-in
 	CBattleHero(const std::string &defName, bool filpG, PlayerColor player, const CGHeroInstance *hero, const CBattleInterface *owner); //c-tor
 	~CBattleHero(); //d-tor
 };
@@ -96,8 +96,8 @@ public:
 
 	void bExitf(); //exit button callback
 
-	void activate();
-	void show(SDL_Surface * to = 0);
+	void activate() override;
+	void show(SDL_Surface * to = 0) override;
 };
 
 /// Class which stands for a single hex field on a battlefield
@@ -114,10 +114,10 @@ public:
 	static Point getXYUnitAnim(BattleHex hexNum, const CStack * creature, CBattleInterface * cbi); //returns (x, y) of left top corner of animation
 
 	//for user interactions
-	void hover (bool on);
-	void mouseMoved (const SDL_MouseMotionEvent &sEvent);
-	void clickLeft(tribool down, bool previousState);
-	void clickRight(tribool down, bool previousState);
+	void hover (bool on) override;
+	void mouseMoved (const SDL_MouseMotionEvent &sEvent) override;
+	void clickLeft(tribool down, bool previousState) override;
+	void clickRight(tribool down, bool previousState) override;
 	CClickableHex();
 };
 
@@ -132,7 +132,7 @@ class CStackQueue : public CIntObject
 		const CStack *stack;
 		bool small;
 
-		void showAll(SDL_Surface * to);
+		void showAll(SDL_Surface * to) override;
 		void setStack(const CStack *nStack);
 		StackBox(bool small);
 	};
@@ -150,6 +150,6 @@ public:
 	CStackQueue(bool Embedded, CBattleInterface * _owner);
 	~CStackQueue();
 	void update();
-	void showAll(SDL_Surface *to);
+	void showAll(SDL_Surface *to) override;
 	void blitBg(SDL_Surface * to);
 };

--- a/client/gui/CAnimation.h
+++ b/client/gui/CAnimation.h
@@ -98,10 +98,10 @@ public:
 	SDLImage(SDL_Surface * from, bool extraRef);
 	~SDLImage();
 
-	void draw(SDL_Surface *where, int posX=0, int posY=0, Rect *src=nullptr,  ui8 alpha=255) const;
-	void playerColored(PlayerColor player);
-	int width() const;
-	int height() const;
+	void draw(SDL_Surface *where, int posX=0, int posY=0, Rect *src=nullptr,  ui8 alpha=255) const override;
+	void playerColored(PlayerColor player) override;
+	int width() const override;
+	int height() const override;
 
 	friend class SDLImageLoader;
 };
@@ -144,10 +144,10 @@ public:
 	CompImage(SDL_Surface * surf);
 	~CompImage();
 
-	void draw(SDL_Surface *where, int posX=0, int posY=0, Rect *src=nullptr, ui8 alpha=255) const;
-	void playerColored(PlayerColor player);
-	int width() const;
-	int height() const;
+	void draw(SDL_Surface *where, int posX=0, int posY=0, Rect *src=nullptr, ui8 alpha=255) const override;
+	void playerColored(PlayerColor player) override;
+	int width() const override;
+	int height() const override;
 
 	friend class CompImageLoader;
 };

--- a/client/gui/CIntObject.h
+++ b/client/gui/CIntObject.h
@@ -157,15 +157,15 @@ public:
 
 	// activate or deactivate object. Inactive object won't receive any input events (keyboard\mouse)
 	// usually used automatically by parent
-	void activate();
-	void deactivate();
+	void activate() override;
+	void deactivate() override;
 
 	//called each frame to update screen
-	void show(SDL_Surface * to);
+	void show(SDL_Surface * to) override;
 	//called on complete redraw only
-	void showAll(SDL_Surface * to);
+	void showAll(SDL_Surface * to) override;
 	//request complete redraw of this object
-	void redraw();
+	void redraw() override;
 
 	enum EAlignment {TOPLEFT, CENTER, BOTTOMRIGHT};
 
@@ -212,5 +212,5 @@ public:
 	CKeyShortcut();
 	CKeyShortcut(int key);
 	CKeyShortcut(std::set<int> Keys);
-	virtual void keyPressed(const SDL_KeyboardEvent & key); //call-in
+	virtual void keyPressed(const SDL_KeyboardEvent & key) override; //call-in
 };

--- a/client/gui/SDL_Extensions.h
+++ b/client/gui/SDL_Extensions.h
@@ -113,7 +113,7 @@ template<typename IntType>
 std::string makeNumberShort(IntType number, IntType maxLength = 3) //the output is a string containing at most 5 characters [4 if positive] (eg. intead 10000 it gives 10k)
 {
 	IntType max = pow(10, maxLength);
-	if (abs(number) < max)
+	if (std::abs(number) < max)
 		return boost::lexical_cast<std::string>(number);
 
 	std::string symbols = " kMGTPE";

--- a/client/mapHandler.h
+++ b/client/mapHandler.h
@@ -312,7 +312,7 @@ class CMapHandler
 		void drawHeroFlag(SDL_Surface * targetSurf, SDL_Surface * sourceSurf, SDL_Rect * sourceRect, SDL_Rect * destRect, bool moving) const override;
 		void drawObject(SDL_Surface * targetSurf, SDL_Surface * sourceSurf, SDL_Rect * sourceRect, bool moving) const override;
 		void drawFrame(SDL_Surface * targetSurf) const override {}
-		void drawOverlayEx(SDL_Surface * targetSurf);
+		void drawOverlayEx(SDL_Surface * targetSurf) override;
 		void init(const MapDrawingInfo * info) override;
 		SDL_Rect clip(SDL_Surface * targetSurf) const override;
 

--- a/client/widgets/AdventureMapClasses.h
+++ b/client/widgets/AdventureMapClasses.h
@@ -37,9 +37,9 @@ protected:
 		CListItem(CList * parent);
 		~CListItem();
 
-		void clickRight(tribool down, bool previousState);
-		void clickLeft(tribool down, bool previousState);
-		void hover(bool on);
+		void clickRight(tribool down, bool previousState) override;
+		void clickLeft(tribool down, bool previousState) override;
+		void hover(bool on) override;
 		void onSelect(bool on);
 
 		/// create object with selection rectangle
@@ -118,12 +118,12 @@ class CHeroList	: public CList
 
 		CHeroItem(CHeroList *parent, const CGHeroInstance * hero);
 
-		CIntObject * genSelection();
+		CIntObject * genSelection() override;
 		void update();
-		void select(bool on);
-		void open();
-		void showTooltip();
-		std::string getHoverText();
+		void select(bool on) override;
+		void open() override;
+		void showTooltip() override;
+		std::string getHoverText() override;
 	};
 
 	CIntObject * createHeroItem(size_t index);
@@ -152,12 +152,12 @@ class CTownList	: public CList
 
 		CTownItem(CTownList *parent, const CGTownInstance * town);
 
-		CIntObject * genSelection();
+		CIntObject * genSelection() override;
 		void update();
-		void select(bool on);
-		void open();
-		void showTooltip();
-		std::string getHoverText();
+		void select(bool on) override;
+		void open() override;
+		void showTooltip() override;
+		std::string getHoverText() override;
 	};
 
 	CIntObject * createTownItem(size_t index);
@@ -195,7 +195,7 @@ public:
 	CMinimapInstance(CMinimap * parent, int level);
 	~CMinimapInstance();
 
-	void showAll(SDL_Surface *to);
+	void showAll(SDL_Surface *to) override;
 	void tileToPixels (const int3 &tile, int &x, int &y,int toX = 0, int toY = 0);
 
 	void refreshTile(const int3 &pos);
@@ -213,10 +213,10 @@ protected:
 	//to initialize colors
 	std::map<int, std::pair<SDL_Color, SDL_Color> > loadColors(std::string from);
 
-	void clickLeft(tribool down, bool previousState);
-	void clickRight(tribool down, bool previousState);
-	void hover (bool on);
-	void mouseMoved (const SDL_MouseMotionEvent & sEvent);
+	void clickLeft(tribool down, bool previousState) override;
+	void clickRight(tribool down, bool previousState) override;
+	void hover (bool on) override;
+	void mouseMoved (const SDL_MouseMotionEvent & sEvent) override;
 
 	void moveAdvMapSelection();
 
@@ -232,7 +232,7 @@ public:
 	void setLevel(int level);
 	void setAIRadar(bool on);
 
-	void showAll(SDL_Surface * to);
+	void showAll(SDL_Surface * to) override;
 
 	void hideTile(const int3 &pos); //puts FoW
 	void showTile(const int3 &pos); //removes FoW
@@ -256,7 +256,7 @@ class CInfoBar : public CIntObject
 	public:
 		CVisibleInfo(Point position);
 
-		void show(SDL_Surface *to);
+		void show(SDL_Surface *to) override;
 
 		//functions that must be called only once
 		void loadHero(const CGHeroInstance * hero);
@@ -283,11 +283,11 @@ class CInfoBar : public CIntObject
 	//removes all information about current state, deactivates timer (if any)
 	void reset(EState newState);
 
-	void tick();
+	void tick() override;
 
-	void clickLeft(tribool down, bool previousState);
-	void clickRight(tribool down, bool previousState);
-	void hover(bool on);
+	void clickLeft(tribool down, bool previousState) override;
+	void clickRight(tribool down, bool previousState) override;
+	void hover(bool on) override;
 
 public:
 	CInfoBar(const Rect & pos);
@@ -331,7 +331,7 @@ public:
 	/// recolors all buttons to given player color
 	void setPlayerColor(const PlayerColor & clr);
 
-	void showAll(SDL_Surface * to);
+	void showAll(SDL_Surface * to) override;
 };
 
 /// specialized version of CAdvMapPanel that handles recolorable def-based pictures for world view info panel
@@ -351,7 +351,7 @@ public:
 	void addChildIcon(std::pair<int, Point> data, const CDefHandler *def, int indexOffset);
 	/// recreates all pictures from given def to recolor them according to current player color
 	void recolorIcons(const PlayerColor &color, const CDefHandler *def, int indexOffset);
-	void showAll(SDL_Surface * to);
+	void showAll(SDL_Surface * to) override;
 };
 
 class CInGameConsole : public CIntObject
@@ -365,9 +365,9 @@ private:
 	int maxDisplayedTexts; //hiw many texts can be displayed simultaneously
 public:
 	std::string enteredText;
-	void show(SDL_Surface * to);
+	void show(SDL_Surface * to) override;
 	void print(const std::string &txt);
-	void keyPressed (const SDL_KeyboardEvent & key); //call-in
+	void keyPressed (const SDL_KeyboardEvent & key) override; //call-in
 
 	void textInputed(const SDL_TextInputEvent & event) override;
 	void textEdited(const SDL_TextEditingEvent & event) override;

--- a/client/widgets/Buttons.h
+++ b/client/widgets/Buttons.h
@@ -215,7 +215,7 @@ public:
 
 	void clickLeft(tribool down, bool previousState) override;
 	void clickRight(tribool down, bool previousState) override;
-	void wheelScrolled(bool down, bool in);
+	void wheelScrolled(bool down, bool in) override;
 };
 
 /// A typical slider which can be orientated horizontally/vertically.
@@ -264,11 +264,11 @@ public:
 
 	void addCallback(std::function<void(int)> callback);
 
-	void keyPressed(const SDL_KeyboardEvent & key);
-	void wheelScrolled(bool down, bool in);
-	void clickLeft(tribool down, bool previousState);
-	void mouseMoved (const SDL_MouseMotionEvent & sEvent);
-	void showAll(SDL_Surface * to);	
+	void keyPressed(const SDL_KeyboardEvent & key) override;
+	void wheelScrolled(bool down, bool in) override;
+	void clickLeft(tribool down, bool previousState) override;
+	void mouseMoved (const SDL_MouseMotionEvent & sEvent) override;
+	void showAll(SDL_Surface * to) override;	
 
 	 /// @param position coordinates of slider
 	 /// @param length length of slider ribbon, including left/right buttons

--- a/client/widgets/CArtifactHolder.h
+++ b/client/widgets/CArtifactHolder.h
@@ -35,10 +35,10 @@ class CWindowWithArtifacts : public CArtifactHolder
 public:
 	std::vector<CArtifactsOfHero *> artSets;
 
-	void artifactRemoved(const ArtifactLocation &artLoc);
-	void artifactMoved(const ArtifactLocation &artLoc, const ArtifactLocation &destLoc);
-	void artifactDisassembled(const ArtifactLocation &artLoc);
-	void artifactAssembled(const ArtifactLocation &artLoc);
+	void artifactRemoved(const ArtifactLocation &artLoc) override;
+	void artifactMoved(const ArtifactLocation &artLoc, const ArtifactLocation &destLoc) override;
+	void artifactDisassembled(const ArtifactLocation &artLoc) override;
+	void artifactAssembled(const ArtifactLocation &artLoc) override;
 };
 
 /// Artifacts can be placed there. Gets shown at the hero window
@@ -65,11 +65,11 @@ public:
 	const CArtifactInstance * ourArt; // should be changed only with setArtifact()
 
 	CArtPlace(Point position, const CArtifactInstance * Art = nullptr); //c-tor
-	void clickLeft(tribool down, bool previousState);
-	void clickRight(tribool down, bool previousState);
+	void clickLeft(tribool down, bool previousState) override;
+	void clickRight(tribool down, bool previousState) override;
 	void select ();
 	void deselect ();
-	void showAll(SDL_Surface * to);
+	void showAll(SDL_Surface * to) override;
 	bool fitsHere (const CArtifactInstance * art) const; //returns true if given artifact can be placed here
 
 	void setMeAsDest(bool backpackAsVoid = true);

--- a/client/widgets/CComponent.h
+++ b/client/widgets/CComponent.h
@@ -57,7 +57,7 @@ public:
 	CComponent(Etype Type, int Subtype, int Val = 0, ESize imageSize=large);//c-tor
 	CComponent(const Component &c, ESize imageSize=large); //c-tor
 
-	void clickRight(tribool down, bool previousState); //call-in
+	void clickRight(tribool down, bool previousState) override; //call-in
 };
 
 /// component that can be selected or deselected
@@ -68,10 +68,10 @@ public:
 	bool selected; //if true, this component is selected
 	std::function<void()> onSelect; //function called on selection change
 
-	void showAll(SDL_Surface * to);
+	void showAll(SDL_Surface * to) override;
 	void select(bool on);
 
-	void clickLeft(tribool down, bool previousState); //call-in
+	void clickLeft(tribool down, bool previousState) override; //call-in
 	CSelectableComponent(Etype Type, int Sub, int Val, ESize imageSize=large, std::function<void()> OnSelect = nullptr); //c-tor
 	CSelectableComponent(const Component &c, std::function<void()> OnSelect = nullptr); //c-tor
 };

--- a/client/widgets/CGarrisonInt.h
+++ b/client/widgets/CGarrisonInt.h
@@ -47,12 +47,12 @@ class CGarrisonSlot : public CIntObject
 
 	void setHighlight(bool on);
 public:
-	virtual void hover (bool on); //call-in
+	virtual void hover (bool on) override; //call-in
 	const CArmedInstance * getObj() const;
 	bool our() const;
 	bool ally() const;
-	void clickRight(tribool down, bool previousState);
-	void clickLeft(tribool down, bool previousState);
+	void clickRight(tribool down, bool previousState) override;
+	void clickLeft(tribool down, bool previousState) override;
 	void update();
 	CGarrisonSlot(CGarrisonInt *Owner, int x, int y, SlotID IID, EGarrisonType Upg=EGarrisonType::UP, const CStackInstance * Creature=nullptr);
 
@@ -132,7 +132,7 @@ class CWindowWithGarrison : public virtual CGarrisonHolder
 {
 public:
 	CGarrisonInt *garr;
-	virtual void updateGarrisons();
+	virtual void updateGarrisons() override;
 };
 
 /// Garrison window where you can take creatures out of the hero to place it on the garrison

--- a/client/widgets/Images.h
+++ b/client/widgets/Images.h
@@ -49,8 +49,8 @@ public:
 
 	void scaleTo(Point size);
 	void createSimpleRect(const Rect &r, bool screenFormat, ui32 color);
-	void show(SDL_Surface * to);
-	void showAll(SDL_Surface * to);
+	void show(SDL_Surface * to) override;
+	void showAll(SDL_Surface * to) override;
 	void convertToScreenBPP();
 	void colorizeAndConvert(PlayerColor player);
 	void colorize(PlayerColor player);
@@ -64,7 +64,7 @@ class CFilledTexture : CIntObject
 public:
 	CFilledTexture(std::string imageName, Rect position);
 	~CFilledTexture();
-	void showAll(SDL_Surface *to);
+	void showAll(SDL_Surface *to) override;
 };
 
 /// Class for displaying one image from animation
@@ -94,7 +94,7 @@ public:
 	//makes image player-colored
 	void playerColored(PlayerColor player);
 
-	void showAll(SDL_Surface * to);
+	void showAll(SDL_Surface * to) override;
 };
 
 /// Base class for displaying animation, used as superclass for different animations
@@ -155,8 +155,8 @@ public:
 	virtual void reset();
 
 	//show current frame and increase counter
-	void show(SDL_Surface * to);
-	void showAll(SDL_Surface * to);
+	void show(SDL_Surface * to) override;
+	void showAll(SDL_Surface * to) override;
 };
 
 /// Creature-dependend animations like attacking, moving,...
@@ -210,7 +210,7 @@ private:
 
 public:
 	//change anim to next if queue is not empty, call callback othervice
-	void reset();
+	void reset() override;
 
 	//add sequence to the end of queue
 	void addLast(EAnimType newType);

--- a/client/widgets/MiscWidgets.h
+++ b/client/widgets/MiscWidgets.h
@@ -28,7 +28,7 @@ class CHoverableArea: public virtual CIntObject
 public:
 	std::string hoverText;
 
-	virtual void hover (bool on);
+	virtual void hover (bool on) override;
 
 	CHoverableArea();
 	virtual ~CHoverableArea();
@@ -45,8 +45,8 @@ public:
 	virtual ~LRClickableAreaWText();
 	void init();
 
-	virtual void clickLeft(tribool down, bool previousState);
-	virtual void clickRight(tribool down, bool previousState);
+	virtual void clickLeft(tribool down, bool previousState) override;
+	virtual void clickRight(tribool down, bool previousState) override;
 };
 
 /// base class for hero/town/garrison tooltips
@@ -88,7 +88,7 @@ private:
 	CCreatureAnim *anim; //displayed animation
 	CLabel * amount;
 
-	void show(SDL_Surface *to);
+	void show(SDL_Surface *to) override;
 public:
 	CCreaturePic(int x, int y, const CCreature *cre, bool Big=true, bool Animated=true); //c-tor
 
@@ -100,8 +100,8 @@ class CMinorResDataBar : public CIntObject
 {
 public:
 	SDL_Surface *bg; //background bitmap
-	void show(SDL_Surface * to);
-	void showAll(SDL_Surface * to);
+	void show(SDL_Surface * to) override;
+	void showAll(SDL_Surface * to) override;
 	CMinorResDataBar(); //c-tor
 	~CMinorResDataBar(); //d-tor
 };
@@ -114,9 +114,9 @@ public:
 
 	CHeroArea(int x, int y, const CGHeroInstance * _hero);
 
-	void clickLeft(tribool down, bool previousState);
-	void clickRight(tribool down, bool previousState);
-	void hover(bool on);
+	void clickLeft(tribool down, bool previousState) override;
+	void clickRight(tribool down, bool previousState) override;
+	void hover(bool on) override;
 };
 
 /// Can interact on left and right mouse clicks
@@ -125,8 +125,8 @@ class LRClickableAreaWTextComp: public LRClickableAreaWText
 public:
 	int baseType;
 	int bonusValue, type;
-	virtual void clickLeft(tribool down, bool previousState);
-	virtual void clickRight(tribool down, bool previousState);
+	virtual void clickLeft(tribool down, bool previousState) override;
+	virtual void clickRight(tribool down, bool previousState) override;
 
 	LRClickableAreaWTextComp(const Rect &Pos = Rect(0,0,0,0), int BaseType = -1);
 	CComponent * createComponent() const;
@@ -137,8 +137,8 @@ class LRClickableAreaOpenTown: public LRClickableAreaWTextComp
 {
 public:
 	const CGTownInstance * town;
-	void clickLeft(tribool down, bool previousState);
-	void clickRight(tribool down, bool previousState);
+	void clickLeft(tribool down, bool previousState) override;
+	void clickRight(tribool down, bool previousState) override;
 	LRClickableAreaOpenTown();
 };
 

--- a/client/widgets/TextControls.h
+++ b/client/widgets/TextControls.h
@@ -52,7 +52,7 @@ public:
 
 	CLabel(int x=0, int y=0, EFonts Font = FONT_SMALL, EAlignment Align = TOPLEFT,
 	       const SDL_Color &Color = Colors::WHITE, const std::string &Text =  "");
-	void showAll(SDL_Surface * to); //shows statusbar (with current text)
+	void showAll(SDL_Surface * to) override; //shows statusbar (with current text)
 };
 
 /// Small helper class to manage group of similar labels
@@ -85,8 +85,8 @@ public:
 
 	CMultiLineLabel(Rect position, EFonts Font = FONT_SMALL, EAlignment Align = TOPLEFT, const SDL_Color &Color = Colors::WHITE, const std::string &Text =  "");
 
-	void setText(const std::string &Txt);
-	void showAll(SDL_Surface * to);
+	void setText(const std::string &Txt) override;
+	void showAll(SDL_Surface * to) override;
 
 	void setVisibleSize(Rect visibleSize);
 	// scrolls text visible in widget. Positive value will move text up
@@ -125,7 +125,7 @@ public:
 	void clear();//clears statusbar and refreshes
 	void setText(const std::string & Text) override; //prints text and refreshes statusbar
 
-	void show(SDL_Surface * to); //shows statusbar (with current text)
+	void show(SDL_Surface * to) override; //shows statusbar (with current text)
 
 	CGStatusBar(CPicture *BG, EFonts Font = FONT_SMALL, EAlignment Align = CENTER, const SDL_Color &Color = Colors::WHITE); //given CPicture will be captured by created sbar and it's pos will be used as pos for sbar
 	CGStatusBar(int x, int y, std::string name, int maxw=-1);

--- a/client/windows/CAdvmapInterface.h
+++ b/client/windows/CAdvmapInterface.h
@@ -65,13 +65,13 @@ public:
 	CTerrainRect();
 	virtual ~CTerrainRect();
 	CGPath * currentPath;
-	void deactivate();
-	void clickLeft(tribool down, bool previousState);
-	void clickRight(tribool down, bool previousState);
-	void hover(bool on);
-	void mouseMoved (const SDL_MouseMotionEvent & sEvent);
-	void show(SDL_Surface * to);
-	void showAll(SDL_Surface * to);
+	void deactivate() override;
+	void clickLeft(tribool down, bool previousState) override;
+	void clickRight(tribool down, bool previousState) override;
+	void hover(bool on) override;
+	void mouseMoved (const SDL_MouseMotionEvent & sEvent) override;
+	void show(SDL_Surface * to) override;
+	void showAll(SDL_Surface * to) override;
 	void showAnim(SDL_Surface * to);
 	void showPath(const SDL_Rect * extRect, SDL_Surface * to);
 	int3 whichTileIsIt(const int & x, const int & y); //x,y are cursor position
@@ -92,14 +92,14 @@ public:
 	std::vector<std::pair<int,int> > txtpos;
 	std::string datetext;
 
-	void clickRight(tribool down, bool previousState);
+	void clickRight(tribool down, bool previousState) override;
 	CResDataBar();
 	CResDataBar(const std::string &defname, int x, int y, int offx, int offy, int resdist, int datedist);
 	~CResDataBar();
 
 	void draw(SDL_Surface * to);
-	void show(SDL_Surface * to);
-	void showAll(SDL_Surface * to);
+	void show(SDL_Surface * to) override;
+	void showAll(SDL_Surface * to) override;
 };
 
 /// That's a huge class which handles general adventure map actions and
@@ -197,11 +197,11 @@ public:
 	void fnextHero();
 	void fendTurn();
 
-	void activate();
-	void deactivate();
+	void activate() override;
+	void deactivate() override;
 
-	void show(SDL_Surface * to); //redraws terrain
-	void showAll(SDL_Surface * to); //shows and activates adv. map interface
+	void show(SDL_Surface * to) override; //redraws terrain
+	void showAll(SDL_Surface * to) override; //shows and activates adv. map interface
 
 	void select(const CArmedInstance *sel, bool centerView = true);
 	void selectionChanged();
@@ -209,8 +209,8 @@ public:
 	void centerOn(const CGObjectInstance *obj, bool fade = false);
 	int3 verifyPos(int3 ver);
 	void handleRightClick(std::string text, tribool down);
-	void keyPressed(const SDL_KeyboardEvent & key);
-	void mouseMoved (const SDL_MouseMotionEvent & sEvent);
+	void keyPressed(const SDL_KeyboardEvent & key) override;
+	void mouseMoved (const SDL_MouseMotionEvent & sEvent) override;
 	bool isActive();
 
 	bool isHeroSleeping(const CGHeroInstance *hero);

--- a/client/windows/CCastleInterface.h
+++ b/client/windows/CCastleInterface.h
@@ -51,12 +51,12 @@ public:
 	CBuildingRect(CCastleBuildings * Par, const CGTownInstance *Town, const CStructure *Str); //c-tor
 	~CBuildingRect(); //d-tor
 	bool operator<(const CBuildingRect & p2) const;
-	void hover(bool on);
-	void clickLeft(tribool down, bool previousState);
-	void clickRight(tribool down, bool previousState);
-	void mouseMoved (const SDL_MouseMotionEvent & sEvent);
-	void show(SDL_Surface * to);
-	void showAll(SDL_Surface * to);
+	void hover(bool on) override;
+	void clickLeft(tribool down, bool previousState) override;
+	void clickRight(tribool down, bool previousState) override;
+	void mouseMoved (const SDL_MouseMotionEvent & sEvent) override;
+	void show(SDL_Surface * to) override;
+	void showAll(SDL_Surface * to) override;
 };
 
 /// Dwelling info box - right-click screen for dwellings
@@ -88,10 +88,10 @@ public:
 	void setHighlight(bool on);
 	void set(const CGHeroInstance *newHero);
 
-	void hover (bool on);
-	void clickLeft(tribool down, bool previousState);
-	void clickRight(tribool down, bool previousState);
-	void deactivate();
+	void hover (bool on) override;
+	void clickLeft(tribool down, bool previousState) override;
+	void clickRight(tribool down, bool previousState) override;
+	void deactivate() override;
 	CHeroGSlot(int x, int y, int updown, const CGHeroInstance *h, HeroSlots * Owner); //c-tor
 	~CHeroGSlot(); //d-tor
 };
@@ -150,8 +150,8 @@ public:
 	void addBuilding(BuildingID building);
 	void removeBuilding(BuildingID building);//FIXME: not tested!!!
 	
-	void show(SDL_Surface * to);
-	void showAll(SDL_Surface * to);
+	void show(SDL_Surface * to) override;
+	void showAll(SDL_Surface * to) override;
 };
 
 /// Creature info window
@@ -172,9 +172,9 @@ public:
 	CCreaInfo(Point position, const CGTownInstance *Town, int Level, bool compact=false, bool showAvailable=false);
 	
 	void update();
-	void hover(bool on);
-	void clickLeft(tribool down, bool previousState);
-	void clickRight(tribool down, bool previousState);
+	void hover(bool on) override;
+	void clickLeft(tribool down, bool previousState) override;
+	void clickRight(tribool down, bool previousState) override;
 };
 
 /// Town hall and fort icons for town screen
@@ -187,8 +187,8 @@ public:
 	//if (townHall) hall-capital else fort - castle
 	CTownInfo(int posX, int posY, const CGTownInstance* town, bool townHall);
 	
-	void hover(bool on);
-	void clickRight(tribool down, bool previousState);
+	void hover(bool on) override;
+	void clickRight(tribool down, bool previousState) override;
 };
 
 /// Class which manages the castle window
@@ -226,7 +226,7 @@ public:
 
 	void castleTeleport(int where);
 	void townChange();
-	void keyPressed(const SDL_KeyboardEvent & key);
+	void keyPressed(const SDL_KeyboardEvent & key) override;
 	void close();
 	void addBuilding(BuildingID bid);
 	void removeBuilding(BuildingID bid);
@@ -251,9 +251,9 @@ class CHallInterface : public CWindowObject
 
 	public:
 		CBuildingBox(int x, int y, const CGTownInstance * Town, const CBuilding * Building);
-		void hover(bool on);
-		void clickLeft(tribool down, bool previousState);
-		void clickRight(tribool down, bool previousState);
+		void hover(bool on) override;
+		void clickLeft(tribool down, bool previousState) override;
+		void clickRight(tribool down, bool previousState) override;
 	};
 	const CGTownInstance * town;
 	
@@ -294,7 +294,7 @@ class LabeledValue : public CIntObject
 public:
 	LabeledValue(Rect size, std::string name, std::string descr, int min, int max);
 	LabeledValue(Rect size, std::string name, std::string descr, int val);
-	void hover(bool on);
+	void hover(bool on) override;
 };
 
 /// The fort screen where you can afford units
@@ -321,9 +321,9 @@ class CFortScreen : public CWindowObject
 		RecruitArea(int posX, int posY, const CGTownInstance *town, int level);
 		
 		void creaturesChanged();
-		void hover(bool on);
-		void clickLeft(tribool down, bool previousState);
-		void clickRight(tribool down, bool previousState);
+		void hover(bool on) override;
+		void clickLeft(tribool down, bool previousState) override;
+		void clickRight(tribool down, bool previousState) override;
 	};
 	CLabel *title;
 	std::vector<RecruitArea*> recAreas;
@@ -349,9 +349,9 @@ class CMageGuildScreen : public CWindowObject
 
 	public:
 		Scroll(Point position, const CSpell *Spell);
-		void clickLeft(tribool down, bool previousState);
-		void clickRight(tribool down, bool previousState);
-		void hover(bool on);
+		void clickLeft(tribool down, bool previousState) override;
+		void clickRight(tribool down, bool previousState) override;
+		void hover(bool on) override;
 	};
 	CPicture *window;
 	CButton *exit;

--- a/client/windows/CHeroWindow.h
+++ b/client/windows/CHeroWindow.h
@@ -35,7 +35,7 @@ class CHeroSwitcher : public CIntObject
 	const CGHeroInstance * hero;
 	CAnimImage *image;
 public:
-	virtual void clickLeft(tribool down, bool previousState);
+	virtual void clickLeft(tribool down, bool previousState) override;
 
 	CHeroSwitcher(Point pos, const CGHeroInstance * hero);
 };
@@ -85,7 +85,7 @@ public:
 	CHeroWindow(const CGHeroInstance *hero); //c-tor
 
 	void update(const CGHeroInstance * hero, bool redrawNeeded = false); //sets main displayed hero
-	void showAll(SDL_Surface * to);
+	void showAll(SDL_Surface * to) override;
 
 	void dismissCurrent(); //dissmissed currently displayed hero (curHero)
 	void questlog(); //show quest log in hero window

--- a/client/windows/CKingdomInterface.h
+++ b/client/windows/CKingdomInterface.h
@@ -74,8 +74,8 @@ public:
 	InfoBox(Point position, InfoPos Pos, InfoSize Size, IInfoBoxData *Data);
 	~InfoBox();
 
-	void clickRight(tribool down, bool previousState);
-	void clickLeft(tribool down, bool previousState);
+	void clickRight(tribool down, bool previousState) override;
+	void clickLeft(tribool down, bool previousState) override;
 
 	//Update object if data may have changed
 	//void update();
@@ -121,13 +121,13 @@ protected:
 public:
 	InfoBoxAbstractHeroData(InfoType Type);
 
-	std::string getValueText();
-	std::string getNameText();
-	std::string getImageName(InfoBox::InfoSize size);
-	std::string getHoverText();
-	size_t getImageIndex();
+	std::string getValueText() override;
+	std::string getNameText() override;
+	std::string getImageName(InfoBox::InfoSize size) override;
+	std::string getHoverText() override;
+	size_t getImageIndex() override;
 
-	bool prepareMessage(std::string &text, CComponent **comp);
+	bool prepareMessage(std::string &text, CComponent **comp) override;
 };
 
 class InfoBoxHeroData : public InfoBoxAbstractHeroData
@@ -135,17 +135,17 @@ class InfoBoxHeroData : public InfoBoxAbstractHeroData
 	const CGHeroInstance * hero;
 	int index;//index of data in hero (0-7 for sec. skill, 0-3 for pr. skill)
 
-	int  getSubID();
-	si64 getValue();
+	int  getSubID() override;
+	si64 getValue() override;
 
 public:
 	InfoBoxHeroData(InfoType Type, const CGHeroInstance *Hero, int Index=0);
 
 	//To get a bit different texts for hero window
-	std::string getHoverText();
-	std::string getValueText();
+	std::string getHoverText() override;
+	std::string getValueText() override;
 
-	bool prepareMessage(std::string &text, CComponent **comp);
+	bool prepareMessage(std::string &text, CComponent **comp) override;
 };
 
 class InfoBoxCustomHeroData : public InfoBoxAbstractHeroData
@@ -153,8 +153,8 @@ class InfoBoxCustomHeroData : public InfoBoxAbstractHeroData
 	int subID;//subID of data (0=attack...)
 	si64 value;//actual value of data, 64-bit to fit experience and negative values
 
-	int  getSubID();
-	si64 getValue();
+	int  getSubID() override;
+	si64 getValue() override;
 
 public:
 	InfoBoxCustomHeroData(InfoType Type, int subID, si64 value);
@@ -171,13 +171,13 @@ public:
 
 	InfoBoxCustom(std::string ValueText, std::string NameText, std::string ImageName, size_t ImageIndex, std::string HoverText="");
 
-	std::string getValueText();
-	std::string getNameText();
-	std::string getImageName(InfoBox::InfoSize size);
-	std::string getHoverText();
-	size_t getImageIndex();
+	std::string getValueText() override;
+	std::string getNameText() override;
+	std::string getImageName(InfoBox::InfoSize size) override;
+	std::string getHoverText() override;
+	size_t getImageIndex() override;
 
-	bool prepareMessage(std::string &text, CComponent **comp);
+	bool prepareMessage(std::string &text, CComponent **comp) override;
 };
 
 //TODO!!!
@@ -191,11 +191,11 @@ public:
 	InfoBoxTownData(InfoType Type, const CGTownInstance * Town, int Index);
 	InfoBoxTownData(InfoType Type, int SubID, int Value);
 
-	std::string getValueText();
-	std::string getNameText();
-	std::string getImageName(InfoBox::InfoSize size);
-	std::string getHoverText();
-	size_t getImageIndex();
+	std::string getValueText() override;
+	std::string getNameText() override;
+	std::string getImageName(InfoBox::InfoSize size) override;
+	std::string getHoverText() override;
+	size_t getImageIndex() override;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -250,11 +250,11 @@ public:
 	CKingdomInterface();
 
 	void townChanged(const CGTownInstance *town);
-	void updateGarrisons();
-	void artifactRemoved(const ArtifactLocation &artLoc);
-	void artifactMoved(const ArtifactLocation &artLoc, const ArtifactLocation &destLoc);
-	void artifactDisassembled(const ArtifactLocation &artLoc);
-	void artifactAssembled(const ArtifactLocation &artLoc);
+	void updateGarrisons() override;
+	void artifactRemoved(const ArtifactLocation &artLoc) override;
+	void artifactMoved(const ArtifactLocation &artLoc, const ArtifactLocation &destLoc) override;
+	void artifactDisassembled(const ArtifactLocation &artLoc) override;
+	void artifactAssembled(const ArtifactLocation &artLoc) override;
 };
 
 /// List item with town
@@ -277,7 +277,7 @@ public:
 
 	CTownItem(const CGTownInstance* town);
 
-	void updateGarrisons();
+	void updateGarrisons() override;
 	void update();
 };
 
@@ -325,7 +325,7 @@ private:
 public:
 	CKingdHeroList(size_t maxSize);
 
-	void updateGarrisons();
+	void updateGarrisons() override;
 };
 
 /// Tab with all town-specific data
@@ -344,5 +344,5 @@ public:
 	CKingdTownList(size_t maxSize);
 	
 	void townChanged(const CGTownInstance *town);
-	void updateGarrisons();
+	void updateGarrisons() override;
 };

--- a/client/windows/CQuestLog.h
+++ b/client/windows/CQuestLog.h
@@ -41,8 +41,8 @@ public:
 
 	CQuestLabel (Rect position, EFonts Font = FONT_SMALL, EAlignment Align = TOPLEFT, const SDL_Color &Color = Colors::WHITE, const std::string &Text =  "")
 		: CMultiLineLabel (position, FONT_SMALL, TOPLEFT, Colors::WHITE, Text){};
-	void clickLeft(tribool down, bool previousState);
-	void showAll(SDL_Surface * to);
+	void clickLeft(tribool down, bool previousState) override;
+	void showAll(SDL_Surface * to) override;
 };
 
 class CQuestIcon : public CAnimImage
@@ -52,17 +52,17 @@ public:
 
 	CQuestIcon (const std::string &defname, int index, int x=0, int y=0);
 
-	void clickLeft(tribool down, bool previousState);
-	void showAll(SDL_Surface * to);
+	void clickLeft(tribool down, bool previousState) override;
+	void showAll(SDL_Surface * to) override;
 };
 
 class CQuestMinimap : public CMinimap
 {
 	std::vector <shared_ptr<CQuestIcon>> icons;
 
-	void clickLeft(tribool down, bool previousState){}; //minimap ignores clicking on its surface
+	void clickLeft(tribool down, bool previousState) override{}; //minimap ignores clicking on its surface
 	void iconClicked();
-	void mouseMoved (const SDL_MouseMotionEvent & sEvent){};
+	void mouseMoved (const SDL_MouseMotionEvent & sEvent) override{};
 
 public:
 
@@ -73,7 +73,7 @@ public:
 	void update();
 	void addQuestMarks (const QuestInfo * q);
 
-	void showAll(SDL_Surface * to);
+	void showAll(SDL_Surface * to) override;
 };
 
 class CQuestLog : public CWindowObject
@@ -106,5 +106,5 @@ public:
 	void recreateLabelList();
 	void recreateQuestList (int pos);
 	void toggleComplete(bool on);
-	void showAll (SDL_Surface * to);
+	void showAll (SDL_Surface * to) override;
 };

--- a/client/windows/CTradeWindow.h
+++ b/client/windows/CTradeWindow.h
@@ -50,10 +50,10 @@ public:
 
 		void showAllAt(const Point &dstPos, const std::string &customSub, SDL_Surface * to);
 
-		void clickRight(tribool down, bool previousState);
-		void hover (bool on);
-		void showAll(SDL_Surface * to);
-		void clickLeft(tribool down, bool previousState);
+		void clickRight(tribool down, bool previousState) override;
+		void hover (bool on) override;
+		void showAll(SDL_Surface * to) override;
+		void clickLeft(tribool down, bool previousState) override;
 		std::string getName(int number = -1) const;
 		CTradeableItem(Point pos, EType Type, int ID, bool Left, int Serial);
 	};
@@ -74,7 +74,7 @@ public:
 
 	CTradeWindow(std::string bgName, const IMarket *Market, const CGHeroInstance *Hero, EMarketMode::EMarketMode Mode); //c
 
-	void showAll(SDL_Surface * to);
+	void showAll(SDL_Surface * to) override;
 
 	void initSubs(bool Left);
 	void initTypes();
@@ -109,19 +109,19 @@ public:
 	void setMax();
 	void sliderMoved(int to);
 	void makeDeal();
-	void selectionChanged(bool side); //true == left
+	void selectionChanged(bool side) override; //true == left
 	CMarketplaceWindow(const IMarket *Market, const CGHeroInstance *Hero = nullptr, EMarketMode::EMarketMode Mode = EMarketMode::RESOURCE_RESOURCE); //c-tor
 	~CMarketplaceWindow(); //d-tor
 
-	Point selectionOffset(bool Left) const;
-	std::string selectionSubtitle(bool Left) const;
+	Point selectionOffset(bool Left) const override;
+	std::string selectionSubtitle(bool Left) const override;
 
 
-	void garrisonChanged(); //removes creatures with count 0 from the list (apparently whole stack has been sold)
-	void artifactsChanged(bool left);
+	void garrisonChanged() override; //removes creatures with count 0 from the list (apparently whole stack has been sold)
+	void artifactsChanged(bool left) override;
 	void resourceChanged(int type, int val);
 
-	void getBaseForPositions(EType type, int &dx, int &dy, int &x, int &y, int &h, int &w, bool Right, int &leftToRightOffset) const;
+	void getBaseForPositions(EType type, int &dx, int &dy, int &x, int &y, int &h, int &w, bool Right, int &leftToRightOffset) const override;
 	void updateTraderText();
 };
 
@@ -141,24 +141,24 @@ public:
 	CLabel *expToLevel, *expOnAltar;
 
 
-	void selectionChanged(bool side); //true == left
+	void selectionChanged(bool side) override; //true == left
 	void SacrificeAll();
 	void SacrificeBackpack();
 
 	void putOnAltar(int backpackIndex);
 	bool putOnAltar(CTradeableItem* altarSlot, const CArtifactInstance *art);
 	void makeDeal();
-	void showAll(SDL_Surface * to);
+	void showAll(SDL_Surface * to) override;
 
 	void blockTrade();
 	void sliderMoved(int to);
-	void getBaseForPositions(EType type, int &dx, int &dy, int &x, int &y, int &h, int &w, bool Right, int &leftToRightOffset) const;
+	void getBaseForPositions(EType type, int &dx, int &dy, int &x, int &y, int &h, int &w, bool Right, int &leftToRightOffset) const override;
 	void mimicCres();
 
-	Point selectionOffset(bool Left) const;
-	std::string selectionSubtitle(bool Left) const;
-	void garrisonChanged();
-	void artifactsChanged(bool left);
+	Point selectionOffset(bool Left) const override;
+	std::string selectionSubtitle(bool Left) const override;
+	void garrisonChanged() override;
+	void artifactsChanged(bool left) override;
 	void calcTotalExp();
 	void setExpToLevel();
 	void updateRight(CTradeableItem *toUpdate);

--- a/client/windows/CWindowObject.h
+++ b/client/windows/CWindowObject.h
@@ -39,9 +39,9 @@ protected:
 	//Simple function with call to GH.popInt
 	void close();
 	//Used only if RCLICK_POPUP was set
-	void clickRight(tribool down, bool previousState);
+	void clickRight(tribool down, bool previousState) override;
 	//To display border
-	void showAll(SDL_Surface *to);
+	void showAll(SDL_Surface *to) override;
 	//change or set background image
 	void setBackground(std::string filename);
 	void updateShadow();

--- a/client/windows/GUIClasses.h
+++ b/client/windows/GUIClasses.h
@@ -43,9 +43,9 @@ class CRecruitmentWindow : public CWindowObject
 		CCreaturePic *pic; //creature's animation
 		bool selected;
 
-		void clickLeft(tribool down, bool previousState);
-		void clickRight(tribool down, bool previousState);
-		void showAll(SDL_Surface *to);
+		void clickLeft(tribool down, bool previousState) override;
+		void clickRight(tribool down, bool previousState) override;
+		void showAll(SDL_Surface *to) override;
 	public:
 		const CCreature * creature;
 		si32 amount;
@@ -88,7 +88,7 @@ class CRecruitmentWindow : public CWindowObject
 	void buy();
 	void sliderMoved(int to);
 
-	void showAll(SDL_Surface *to);
+	void showAll(SDL_Surface *to) override;
 public:
 	const CGDwelling * const dwelling;
 	CRecruitmentWindow(const CGDwelling *Dwelling, int Level, const CArmedInstance *Dst, const std::function<void(CreatureID,int)> & Recruit, int y_offset = 0); //creatures - pairs<creature_ID,amount> //c-tor
@@ -153,7 +153,7 @@ class CObjectListWindow : public CWindowObject
 		CItem(CObjectListWindow *parent, size_t id, std::string text);
 
 		void select(bool on);
-		void clickLeft(tribool down, bool previousState);
+		void clickLeft(tribool down, bool previousState) override;
 	};
 
 	std::function<void(int)> onSelect;//called when OK button is pressed, returns id of selected item.
@@ -180,7 +180,7 @@ public:
 	CIntObject *genItem(size_t index);
 	void elementSelected();//call callback and close this window
 	void changeSelection(size_t which);
-	void keyPressed (const SDL_KeyboardEvent & key);
+	void keyPressed (const SDL_KeyboardEvent & key) override;
 };
 
 class CSystemOptionsWindow : public CWindowObject
@@ -232,9 +232,9 @@ public:
 		std::string description; // "XXX is a level Y ZZZ with N artifacts"
 		const CGHeroInstance *h;
 
-		void clickLeft(tribool down, bool previousState);
-		void clickRight(tribool down, bool previousState);
-		void hover (bool on);
+		void clickLeft(tribool down, bool previousState) override;
+		void clickRight(tribool down, bool previousState) override;
+		void hover (bool on) override;
 		HeroPortrait(int &sel, int id, int x, int y, const CGHeroInstance *H);
 
 	private:
@@ -255,7 +255,7 @@ public:
 
 	void recruitb();
 	void thievesguildb();
-	void show(SDL_Surface * to);
+	void show(SDL_Surface * to) override;
 };
 
 class CExchangeWindow : public CWindowObject, public CWindowWithGarrison, public CWindowWithArtifacts
@@ -319,8 +319,8 @@ private:
 	ui8 currentAlpha;
 
 public:
-	void showAll(SDL_Surface * to);
-	void show(SDL_Surface * to);
+	void showAll(SDL_Surface * to) override;
+	void show(SDL_Surface * to) override;
 
 	CPuzzleWindow(const int3 &grailPos, double discoveredRatio);
 };
@@ -339,7 +339,7 @@ public:
 		CAnimImage *icon;
 
 		void move();
-		void clickLeft(tribool down, bool previousState);
+		void clickLeft(tribool down, bool previousState) override;
 		void update();
 		CItem(CTransformerWindow * parent, int size, int id);
 	};
@@ -353,7 +353,7 @@ public:
 	CGStatusBar *bar;
 	void makeDeal();
 	void addAll();
-	void updateGarrisons();
+	void updateGarrisons() override;
 	CTransformerWindow(const CGHeroInstance * _hero, const CGTownInstance * _town); //c-tor
 };
 
@@ -365,10 +365,10 @@ class CUniversityWindow : public CWindowObject
 		int ID;//id of selected skill
 		CUniversityWindow * parent;
 
-		void showAll(SDL_Surface * to);
-		void clickLeft(tribool down, bool previousState);
-		void clickRight(tribool down, bool previousState);
-		void hover(bool on);
+		void showAll(SDL_Surface * to) override;
+		void clickLeft(tribool down, bool previousState) override;
+		void clickRight(tribool down, bool previousState) override;
+		void hover(bool on) override;
 		int state();//0=can't learn, 1=learned, 2=can learn
 		CItem(CUniversityWindow * _parent, int _ID, int X, int Y);
 	};
@@ -419,12 +419,12 @@ public:
 
 	CHillFortWindow(const CGHeroInstance *visitor, const CGObjectInstance *object); //c-tor
 
-	void showAll (SDL_Surface *to);
+	void showAll (SDL_Surface *to) override;
 	std::string getDefForSlot(SlotID slot);//return def name for this slot
 	std::string getTextForSlot(SlotID slot);//return hover text for this slot
 	void makeDeal(SlotID slot);//-1 for upgrading all creatures
 	int getState(SlotID slot); //-1 = no creature 0=can't upgrade, 1=upgraded, 2=can upgrade
-	void updateGarrisons();//update buttons after garrison changes
+	void updateGarrisons() override;//update buttons after garrison changes
 };
 
 class CThievesGuildWindow : public CWindowObject

--- a/client/windows/InfoWindows.h
+++ b/client/windows/InfoWindows.h
@@ -31,7 +31,7 @@ class CSimpleWindow : public CIntObject
 {
 public:
 	SDL_Surface * bitmap; //background
-	virtual void show(SDL_Surface * to);
+	virtual void show(SDL_Surface * to) override;
 	CSimpleWindow():bitmap(nullptr){}; //c-tor
 	virtual ~CSimpleWindow(); //d-tor
 };
@@ -53,8 +53,8 @@ public:
 	void setDelComps(bool DelComps);
 	virtual void close();
 
-	void show(SDL_Surface * to);
-	void showAll(SDL_Surface * to);
+	void show(SDL_Surface * to) override;
+	void showAll(SDL_Surface * to) override;
 	void sliderMoved(int to);
 
 	CInfoWindow(std::string Text, PlayerColor player, const TCompsInfo &comps = TCompsInfo(), const TButtonsInfo &Buttons = TButtonsInfo(), bool delComps = true); //c-tor
@@ -76,7 +76,7 @@ class CRClickPopup : public CIntObject
 {
 public:
 	virtual void close();
-	void clickRight(tribool down, bool previousState);
+	void clickRight(tribool down, bool previousState) override;
 
 	CRClickPopup();
 	virtual ~CRClickPopup(); //d-tor
@@ -94,8 +94,8 @@ public:
 	IShowActivatable *inner;
 	bool delInner;
 
-	void show(SDL_Surface * to);
-	void showAll(SDL_Surface * to);
+	void show(SDL_Surface * to) override;
+	void showAll(SDL_Surface * to) override;
 	CRClickPopupInt(IShowActivatable *our, bool deleteInt); //c-tor
 	virtual ~CRClickPopupInt(); //d-tor
 };
@@ -105,8 +105,8 @@ class CInfoPopup : public CRClickPopup
 public:
 	bool free; //TODO: comment me
 	SDL_Surface * bitmap; //popup background
-	void close();
-	void show(SDL_Surface * to);
+	void close() override;
+	void show(SDL_Surface * to) override;
 	CInfoPopup(SDL_Surface * Bitmap, int x, int y, bool Free=false); //c-tor
 	CInfoPopup(SDL_Surface * Bitmap, const Point &p, EAlignment alignment, bool Free=false); //c-tor
 	CInfoPopup(SDL_Surface * Bitmap = nullptr, bool Free = false); //default c-tor

--- a/lib/CArtHandler.h
+++ b/lib/CArtHandler.h
@@ -93,7 +93,7 @@ public:
 	std::vector <std::pair <ui16, Bonus> > bonusesPerLevel; //bonus given each n levels
 	std::vector <std::pair <ui16, Bonus> > thresholdBonuses; //after certain level they will be added once
 
-	void levelUpArtifact (CArtifactInstance * art);
+	void levelUpArtifact (CArtifactInstance * art) override;
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{

--- a/lib/CCreatureHandler.h
+++ b/lib/CCreatureHandler.h
@@ -199,7 +199,7 @@ public:
 	/// generates tier-specific bonus tree entries
 	void buildBonusTreeForTiers();
 
-	void afterLoadFinalization();
+	void afterLoadFinalization() override;
 
 	std::vector<JsonNode> loadLegacyData(size_t dataSize) override;
 

--- a/lib/CCreatureSet.h
+++ b/lib/CCreatureSet.h
@@ -68,7 +68,7 @@ public:
 	std::string getQuantityTXT(bool capitalized = true) const;
 	virtual int getExpRank() const;
 	virtual int getLevel() const; //different for regular stack and commander
-	si32 magicResistance() const;
+	si32 magicResistance() const override;
 	CreatureID getCreatureID() const; //-1 if not available
 	std::string getName() const; //plural or singular
 	virtual void init();
@@ -104,12 +104,12 @@ public:
 	CCommanderInstance (CreatureID id);
 	~CCommanderInstance();
 	void setAlive (bool alive);
-	void giveStackExp (TExpType exp);
+	void giveStackExp (TExpType exp) override;
 	void levelUp ();
 
 	bool gainsLevel() const; //true if commander has lower level than should upon his experience
-	ui64 getPower() const {return 0;};
-	int getExpRank() const;
+	ui64 getPower() const override {return 0;};
+	int getExpRank() const override;
 	int getLevel() const override; 
 	ArtBearer::ArtBearer bearerType() const override; //from CArtifactSet
 

--- a/lib/CGameInterface.h
+++ b/lib/CGameInterface.h
@@ -127,26 +127,26 @@ public:
 	virtual std::string getBattleAIName() const = 0; //has to return name of the battle AI to be used
 
 	//battle interface
-	virtual BattleAction activeStack(const CStack * stack);
-	virtual void yourTacticPhase(int distance);
-	virtual void battleNewRound(int round);
-	virtual void battleCatapultAttacked(const CatapultAttack & ca);
-	virtual void battleStart(const CCreatureSet *army1, const CCreatureSet *army2, int3 tile, const CGHeroInstance *hero1, const CGHeroInstance *hero2, bool side);
-	virtual void battleStacksAttacked(const std::vector<BattleStackAttacked> & bsa);
-	virtual void actionStarted(const BattleAction &action);
-	virtual void battleNewRoundFirst(int round);
-	virtual void actionFinished(const BattleAction &action);
-	virtual void battleStacksEffectsSet(const SetStackEffect & sse);
+	virtual BattleAction activeStack(const CStack * stack) override;
+	virtual void yourTacticPhase(int distance) override;
+	virtual void battleNewRound(int round) override;
+	virtual void battleCatapultAttacked(const CatapultAttack & ca) override;
+	virtual void battleStart(const CCreatureSet *army1, const CCreatureSet *army2, int3 tile, const CGHeroInstance *hero1, const CGHeroInstance *hero2, bool side) override;
+	virtual void battleStacksAttacked(const std::vector<BattleStackAttacked> & bsa) override;
+	virtual void actionStarted(const BattleAction &action) override;
+	virtual void battleNewRoundFirst(int round) override;
+	virtual void actionFinished(const BattleAction &action) override;
+	virtual void battleStacksEffectsSet(const SetStackEffect & sse) override;
 	//virtual void battleTriggerEffect(const BattleTriggerEffect & bte);
-	virtual void battleStacksRemoved(const BattleStacksRemoved & bsr);
-	virtual void battleObstaclesRemoved(const std::set<si32> & removedObstacles);
-	virtual void battleNewStackAppeared(const CStack * stack);
-	virtual void battleStackMoved(const CStack * stack, std::vector<BattleHex> dest, int distance);
-	virtual void battleAttack(const BattleAttack *ba);
-	virtual void battleSpellCast(const BattleSpellCast *sc);
-	virtual void battleEnd(const BattleResult *br);
-	virtual void battleStacksHealedRes(const std::vector<std::pair<ui32, ui32> > & healedStacks, bool lifeDrain, bool tentHeal, si32 lifeDrainFrom);
+	virtual void battleStacksRemoved(const BattleStacksRemoved & bsr) override;
+	virtual void battleObstaclesRemoved(const std::set<si32> & removedObstacles) override;
+	virtual void battleNewStackAppeared(const CStack * stack) override;
+	virtual void battleStackMoved(const CStack * stack, std::vector<BattleHex> dest, int distance) override;
+	virtual void battleAttack(const BattleAttack *ba) override;
+	virtual void battleSpellCast(const BattleSpellCast *sc) override;
+	virtual void battleEnd(const BattleResult *br) override;
+	virtual void battleStacksHealedRes(const std::vector<std::pair<ui32, ui32> > & healedStacks, bool lifeDrain, bool tentHeal, si32 lifeDrainFrom) override;
 
-	virtual void saveGame(COSer & h, const int version); //saving
-	virtual void loadGame(CISer & h, const int version); //loading
+	virtual void saveGame(COSer & h, const int version) override; //saving
+	virtual void loadGame(CISer & h, const int version) override; //loading
 };

--- a/lib/CGameState.cpp
+++ b/lib/CGameState.cpp
@@ -63,7 +63,7 @@ public:
 template <typename T> class CApplyOnGS : public CBaseForGSApply
 {
 public:
-	void applyOnGS(CGameState *gs, void *pack) const
+	void applyOnGS(CGameState *gs, void *pack) const override
 	{
 		T *ptr = static_cast<T*>(pack);
 

--- a/lib/CGeneralTextHandler.cpp
+++ b/lib/CGeneralTextHandler.cpp
@@ -159,7 +159,7 @@ void Unicode::trimRight(std::string & text, const size_t amount/* =1 */)
 class LocaleWithComma: public std::numpunct<char>
 {
 protected:
-	char do_decimal_point() const
+	char do_decimal_point() const override
 	{
 		return ',';
 	}

--- a/lib/CHeroHandler.h
+++ b/lib/CHeroHandler.h
@@ -178,9 +178,9 @@ public:
 	void loadObject(std::string scope, std::string name, const JsonNode & data) override;
 	void loadObject(std::string scope, std::string name, const JsonNode & data, size_t index) override;
 
-	void afterLoadFinalization();
+	void afterLoadFinalization() override;
 
-	std::vector<bool> getDefaultAllowed() const;
+	std::vector<bool> getDefaultAllowed() const override;
 
 	~CHeroClassHandler();
 
@@ -244,7 +244,7 @@ public:
 	CHeroHandler(); //c-tor
 	~CHeroHandler(); //d-tor
 
-	std::vector<bool> getDefaultAllowed() const;
+	std::vector<bool> getDefaultAllowed() const override;
 
 	/**
 	 * Gets a list of default allowed abilities. OH3 abilities/skills are all allowed by default.

--- a/lib/Connection.h
+++ b/lib/Connection.h
@@ -1551,7 +1551,7 @@ public:
 
 	void openNextFile(const std::string &fname); //throws!
 	void clear();
-    void reportState(CLogger * out);
+    void reportState(CLogger * out) override;
 
 	void putMagicBytes(const std::string &text);
 	
@@ -1578,7 +1578,7 @@ public:
 
 	void openNextFile(const boost::filesystem::path & fname, int minimalVersion); //throws!
 	void clear();
-    void reportState(CLogger * out);
+    void reportState(CLogger * out) override;
 
 	void checkMagicBytes(const std::string & text);
 	
@@ -1616,7 +1616,7 @@ class DLL_LINKAGE CConnection
 	CConnection(void);
 
 	void init();
-    void reportState(CLogger * out);
+    void reportState(CLogger * out) override;
 public:
 	CISer iser;
 	COSer oser;

--- a/lib/HeroBonus.cpp
+++ b/lib/HeroBonus.cpp
@@ -504,7 +504,7 @@ const TBonusListPtr IBonusBearer::getSpellBonuses() const
 	CSelector selector = Selector::sourceType(Bonus::SPELL_EFFECT)
 		.And(CSelector([](const Bonus * b)->bool
 		{
-			return !b->type == Bonus::NONE;
+			return b->type != Bonus::NONE;
 		})); 
 	return getBonuses(selector, Selector::anyRange(), cachingStr.str());
 }

--- a/lib/HeroBonus.h
+++ b/lib/HeroBonus.h
@@ -539,7 +539,7 @@ class DLL_LINKAGE CPropagatorNodeType : public IPropagator
 public:
 	CPropagatorNodeType();
 	CPropagatorNodeType(int NodeType);
-	bool shouldBeAttached(CBonusSystemNode *dest);
+	bool shouldBeAttached(CBonusSystemNode *dest) override;
 	//CBonusSystemNode *getDestNode(CBonusSystemNode *source, CBonusSystemNode *redParent, CBonusSystemNode *redChild) override;
 
 	template <typename Handler> void serialize(Handler &h, const int version)
@@ -651,7 +651,7 @@ public:
 
 	void limitBonuses(const BonusList &allBonuses, BonusList &out) const; //out will bo populed with bonuses that are not limited here
 	TBonusListPtr limitBonuses(const BonusList &allBonuses) const; //same as above, returns out by val for convienence
-	const TBonusListPtr getAllBonuses(const CSelector &selector, const CSelector &limit, const CBonusSystemNode *root = nullptr, const std::string &cachingStr = "") const;
+	const TBonusListPtr getAllBonuses(const CSelector &selector, const CSelector &limit, const CBonusSystemNode *root = nullptr, const std::string &cachingStr = "") const override;
 	void getParents(TCNodes &out) const;  //retrieves list of parent nodes (nodes to inherit bonuses from),
 	const Bonus *getBonusLocalFirst(const CSelector &selector) const;
 

--- a/lib/NetPacksBase.h
+++ b/lib/NetPacksBase.h
@@ -115,7 +115,7 @@ public:
 		numbers.clear();
 	}
 	void toString(std::string &dst) const;
-	std::string toString() const;
+	std::string toString() const override;
 	void getLocalString(const std::pair<ui8,ui32> &txt, std::string &dst) const;
 
 	MetaString()

--- a/lib/filesystem/AdapterLoaders.h
+++ b/lib/filesystem/AdapterLoaders.h
@@ -42,7 +42,7 @@ public:
 	bool existsResource(const ResourceID & resourceName) const override;
 	std::string getMountPoint() const override;
 	boost::optional<std::string> getResourceName(const ResourceID & resourceName) const override;
-	std::unordered_set<ResourceID> getFilteredFiles(std::function<bool(const ResourceID &)> filter) const;
+	std::unordered_set<ResourceID> getFilteredFiles(std::function<bool(const ResourceID &)> filter) const override;
 
 private:
 	/** A list of files in this map

--- a/lib/filesystem/CArchiveLoader.h
+++ b/lib/filesystem/CArchiveLoader.h
@@ -62,7 +62,7 @@ public:
 	std::unique_ptr<CInputStream> load(const ResourceID & resourceName) const override;
 	bool existsResource(const ResourceID & resourceName) const override;
 	std::string getMountPoint() const override;
-	std::unordered_set<ResourceID> getFilteredFiles(std::function<bool(const ResourceID &)> filter) const;
+	std::unordered_set<ResourceID> getFilteredFiles(std::function<bool(const ResourceID &)> filter) const override;
 
 private:
 	/**

--- a/lib/filesystem/CCompressedStream.h
+++ b/lib/filesystem/CCompressedStream.h
@@ -116,7 +116,7 @@ private:
 	/**
 	 * Decompresses data to ensure that buffer has newSize bytes or end of stream was reached
 	 */
-	si64 readMore(ui8 * data, si64 size);
+	si64 readMore(ui8 * data, si64 size) override;
 
 	/** The file stream with compressed data. */
 	std::unique_ptr<CInputStream> gzipStream;

--- a/lib/mapObjects/CGHeroInstance.h
+++ b/lib/mapObjects/CGHeroInstance.h
@@ -117,18 +117,18 @@ public:
 	} skillsInfo;
 
 	//int3 getSightCenter() const; //"center" tile from which the sight distance is calculated
-	int getSightRadious() const; //sight distance (should be used if player-owned structure)
+	int getSightRadious() const override; //sight distance (should be used if player-owned structure)
 	//////////////////////////////////////////////////////////////////////////
 
-	int getBoatType() const; //0 - evil (if a ship can be evil...?), 1 - good, 2 - neutral
-	void getOutOffsets(std::vector<int3> &offsets) const; //offsets to obj pos when we boat can be placed
+	int getBoatType() const override; //0 - evil (if a ship can be evil...?), 1 - good, 2 - neutral
+	void getOutOffsets(std::vector<int3> &offsets) const override; //offsets to obj pos when we boat can be placed
 
 	//////////////////////////////////////////////////////////////////////////
 
 	bool hasSpellbook() const;
 	EAlignment::EAlignment getAlignment() const;
 	const std::string &getBiography() const;
-	bool needsLastStack()const;
+	bool needsLastStack()const override;
 	ui32 getTileCost(const TerrainTile &dest, const TerrainTile &from) const; //move cost - applying pathfinding skill, road and terrain modifiers. NOT includes diagonal move penalty, last move levelling
 	ui32 getLowestCreatureSpeed() const;
 	int3 getPosition(bool h3m = false) const; //h3m=true - returns position of hero object; h3m=false - returns position of hero 'manifestation'
@@ -177,7 +177,7 @@ public:
 
 	//////////////////////////////////////////////////////////////////////////
 
-	void setType(si32 ID, si32 subID);
+	void setType(si32 ID, si32 subID) override;
 
 	void initHero();
 	void initHero(HeroTypeID SUBID);

--- a/lib/mapObjects/CGMarket.h
+++ b/lib/mapObjects/CGMarket.h
@@ -76,7 +76,7 @@ class DLL_LINKAGE CGUniversity : public CGMarket
 public:
 	std::vector<int> skills; //available skills
 
-	std::vector<int> availableItemsIds(EMarketMode::EMarketMode mode) const;
+	std::vector<int> availableItemsIds(EMarketMode::EMarketMode mode) const override;
 	void initObj() override;//set skills for trade
 	void onHeroVisit(const CGHeroInstance * h) const override; //open window
 

--- a/lib/mapObjects/CGTownInstance.h
+++ b/lib/mapObjects/CGTownInstance.h
@@ -203,21 +203,21 @@ public:
 
 	//////////////////////////////////////////////////////////////////////////
 
-	bool passableFor(PlayerColor color) const;
+	bool passableFor(PlayerColor color) const override;
 	//int3 getSightCenter() const override; //"center" tile from which the sight distance is calculated
 	int getSightRadious() const override; //returns sight distance
-	int getBoatType() const; //0 - evil (if a ship can be evil...?), 1 - good, 2 - neutral
-	void getOutOffsets(std::vector<int3> &offsets) const; //offsets to obj pos when we boat can be placed. Parameter will be cleared
+	int getBoatType() const override; //0 - evil (if a ship can be evil...?), 1 - good, 2 - neutral
+	void getOutOffsets(std::vector<int3> &offsets) const override; //offsets to obj pos when we boat can be placed. Parameter will be cleared
 	int getMarketEfficiency() const override; //=market count
-	bool allowsTrade(EMarketMode::EMarketMode mode) const;
-	std::vector<int> availableItemsIds(EMarketMode::EMarketMode mode) const;
+	bool allowsTrade(EMarketMode::EMarketMode mode) const override;
+	std::vector<int> availableItemsIds(EMarketMode::EMarketMode mode) const override;
 
-	void setType(si32 ID, si32 subID);
+	void setType(si32 ID, si32 subID) override;
 	void updateAppearance();
 
 	//////////////////////////////////////////////////////////////////////////
 
-	bool needsLastStack() const;
+	bool needsLastStack() const override;
 	CGTownInstance::EFortLevel fortLevel() const;
 	int hallLevel() const; // -1 - none, 0 - village, 1 - town, 2 - city, 3 - capitol
 	int mageGuildLevel() const; // -1 - none, 0 - village, 1 - town, 2 - city, 3 - capitol

--- a/lib/mapObjects/CQuest.h
+++ b/lib/mapObjects/CQuest.h
@@ -156,7 +156,7 @@ protected:
 class DLL_LINKAGE CGKeymasterTent : public CGKeys
 {
 public:
-	bool wasVisited (PlayerColor player) const;
+	bool wasVisited (PlayerColor player) const override;
 	void onHeroVisit(const CGHeroInstance * h) const override;
 
 	template <typename Handler> void serialize(Handler &h, const int version)
@@ -173,9 +173,9 @@ public:
 	void onHeroVisit(const CGHeroInstance * h) const override;
 	void blockingDialogAnswered(const CGHeroInstance *hero, ui32 answer) const override;
 
-	void getVisitText (MetaString &text, std::vector<Component> &components, bool isCustom, bool FirstVisit, const CGHeroInstance * h = nullptr) const;
+	void getVisitText (MetaString &text, std::vector<Component> &components, bool isCustom, bool FirstVisit, const CGHeroInstance * h = nullptr) const override;
 	void getRolloverText (MetaString &text, bool onHover) const;
-	bool checkQuest (const CGHeroInstance * h) const;
+	bool checkQuest (const CGHeroInstance * h) const override;
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{

--- a/lib/mapObjects/CommonConstructors.h
+++ b/lib/mapObjects/CommonConstructors.h
@@ -39,16 +39,16 @@ protected:
 public:
 	CDefaultObjectTypeHandler(){}
 
-	CGObjectInstance * create(ObjectTemplate tmpl) const
+	CGObjectInstance * create(ObjectTemplate tmpl) const override
 	{
 		return createTyped(tmpl);
 	}
 
-	virtual void configureObject(CGObjectInstance * object, CRandomGenerator & rng) const
+	virtual void configureObject(CGObjectInstance * object, CRandomGenerator & rng) const override
 	{
 	}
 
-	virtual std::unique_ptr<IObjectInfo> getObjectInfo(ObjectTemplate tmpl) const
+	virtual std::unique_ptr<IObjectInfo> getObjectInfo(ObjectTemplate tmpl) const override
 	{
 		return nullptr;
 	}
@@ -58,24 +58,24 @@ class CObstacleConstructor : public CDefaultObjectTypeHandler<CGObjectInstance>
 {
 public:
 	CObstacleConstructor();
-	bool isStaticObject();
+	bool isStaticObject() override;
 };
 
 class CTownInstanceConstructor : public CDefaultObjectTypeHandler<CGTownInstance>
 {
 	JsonNode filtersJson;
 protected:
-	bool objectFilter(const CGObjectInstance *, const ObjectTemplate &) const;
-	void initTypeData(const JsonNode & input);
+	bool objectFilter(const CGObjectInstance *, const ObjectTemplate &) const override;
+	void initTypeData(const JsonNode & input) override;
 
 public:
 	CFaction * faction;
 	std::map<std::string, LogicalExpression<BuildingID>> filters;
 
 	CTownInstanceConstructor();
-	CGObjectInstance * create(ObjectTemplate tmpl) const;
-	void configureObject(CGObjectInstance * object, CRandomGenerator & rng) const;
-	void afterLoadFinalization();
+	CGObjectInstance * create(ObjectTemplate tmpl) const override;
+	void configureObject(CGObjectInstance * object, CRandomGenerator & rng) const override;
+	void afterLoadFinalization() override;
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
@@ -88,17 +88,17 @@ class CHeroInstanceConstructor : public CDefaultObjectTypeHandler<CGHeroInstance
 {
 	JsonNode filtersJson;
 protected:
-	bool objectFilter(const CGObjectInstance *, const ObjectTemplate &) const;
-	void initTypeData(const JsonNode & input);
+	bool objectFilter(const CGObjectInstance *, const ObjectTemplate &) const override;
+	void initTypeData(const JsonNode & input) override;
 
 public:
 	CHeroClass * heroClass;
 	std::map<std::string, LogicalExpression<HeroTypeID>> filters;
 
 	CHeroInstanceConstructor();
-	CGObjectInstance * create(ObjectTemplate tmpl) const;
-	void configureObject(CGObjectInstance * object, CRandomGenerator & rng) const;
-	void afterLoadFinalization();
+	CGObjectInstance * create(ObjectTemplate tmpl) const override;
+	void configureObject(CGObjectInstance * object, CRandomGenerator & rng) const override;
+	void afterLoadFinalization() override;
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
@@ -114,14 +114,14 @@ class CDwellingInstanceConstructor : public CDefaultObjectTypeHandler<CGDwelling
 	JsonNode guards;
 
 protected:
-	bool objectFilter(const CGObjectInstance *, const ObjectTemplate &) const;
-	void initTypeData(const JsonNode & input);
+	bool objectFilter(const CGObjectInstance *, const ObjectTemplate &) const override;
+	void initTypeData(const JsonNode & input) override;
 
 public:
 
 	CDwellingInstanceConstructor();
-	CGObjectInstance * create(ObjectTemplate tmpl) const;
-	void configureObject(CGObjectInstance * object, CRandomGenerator & rng) const;
+	CGObjectInstance * create(ObjectTemplate tmpl) const override;
+	void configureObject(CGObjectInstance * object, CRandomGenerator & rng) const override;
 
 	bool producesCreature(const CCreature * crea) const;
 	std::vector<const CCreature *> getProducedCreatures() const;
@@ -163,13 +163,13 @@ public:
 	TPossibleGuards getPossibleGuards() const;
 
 	// These functions should try to evaluate minimal possible/max possible guards to give provide information on possible thread to AI
-	CArmyStructure minGuards() const;
-	CArmyStructure maxGuards() const;
+	CArmyStructure minGuards() const override;
+	CArmyStructure maxGuards() const override;
 
-	bool givesResources() const;
-	bool givesArtifacts() const;
-	bool givesCreatures() const;
-	bool givesSpells() const;
+	bool givesResources() const override;
+	bool givesArtifacts() const override;
+	bool givesCreatures() const override;
+	bool givesSpells() const override;
 };
 
 class CBankInstanceConstructor : public CDefaultObjectTypeHandler<CBank>
@@ -178,7 +178,7 @@ class CBankInstanceConstructor : public CDefaultObjectTypeHandler<CBank>
 
 	JsonVector levels;
 protected:
-	void initTypeData(const JsonNode & input);
+	void initTypeData(const JsonNode & input) override;
 
 public:
 	// all banks of this type will be reset N days after clearing,
@@ -186,10 +186,10 @@ public:
 
 	CBankInstanceConstructor();
 
-	CGObjectInstance *create(ObjectTemplate tmpl) const;
-	void configureObject(CGObjectInstance * object, CRandomGenerator & rng) const;
+	CGObjectInstance *create(ObjectTemplate tmpl) const override;
+	void configureObject(CGObjectInstance * object, CRandomGenerator & rng) const override;
 
-	std::unique_ptr<IObjectInfo> getObjectInfo(ObjectTemplate tmpl) const;
+	std::unique_ptr<IObjectInfo> getObjectInfo(ObjectTemplate tmpl) const override;
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{

--- a/lib/mapObjects/MiscObjects.h
+++ b/lib/mapObjects/MiscObjects.h
@@ -19,7 +19,7 @@ class DLL_LINKAGE CPlayersVisited: public CGObjectInstance
 public:
 	std::set<PlayerColor> players; //players that visited this object
 
-	bool wasVisited(PlayerColor player) const;
+	bool wasVisited(PlayerColor player) const override;
 	bool wasVisited(TeamID team) const;
 	void setPropertyDer(ui8 what, ui32 val) override;
 
@@ -394,7 +394,7 @@ public:
 class CGShipyard : public CGObjectInstance, public IShipyard
 {
 public:
-	void getOutOffsets(std::vector<int3> &offsets) const; //offsets to obj pos when we boat can be placed
+	void getOutOffsets(std::vector<int3> &offsets) const override; //offsets to obj pos when we boat can be placed
 	CGShipyard();
 	void onHeroVisit(const CGHeroInstance * h) const override;
 

--- a/lib/mapping/MapFormatH3M.h
+++ b/lib/mapping/MapFormatH3M.h
@@ -50,14 +50,14 @@ public:
 	 *
 	 * @return a unique ptr of the loaded map class
 	 */
-	std::unique_ptr<CMap> loadMap();
+	std::unique_ptr<CMap> loadMap() override;
 
 	/**
 	 * Loads the VCMI/H3 map header.
 	 *
 	 * @return a unique ptr of the loaded map header class
 	 */
-	std::unique_ptr<CMapHeader> loadMapHeader();
+	std::unique_ptr<CMapHeader> loadMapHeader() override;
 
 	/** true if you want to enable the map loader profiler to see how long a specific part took; default=false */
 	static const bool IS_PROFILING_ENABLED;

--- a/lib/mapping/MapFormatJson.h
+++ b/lib/mapping/MapFormatJson.h
@@ -31,20 +31,20 @@ public:
 	 *
 	 * @return a unique ptr of the loaded map class
 	 */
-	std::unique_ptr<CMap> loadMap();
+	std::unique_ptr<CMap> loadMap() override;
 
 	/**
 	 * Loads the VCMI/Json map header.
 	 *
 	 * @return a unique ptr of the loaded map header class
 	 */
-	std::unique_ptr<CMapHeader> loadMapHeader();
+	std::unique_ptr<CMapHeader> loadMapHeader() override;
 
 	/**
 	 * Modifies supplied map header using Json data
 	 *
 	 */
-	void patchMapHeader(std::unique_ptr<CMapHeader> & header);
+	void patchMapHeader(std::unique_ptr<CMapHeader> & header) override;
 
 private:
 	/**

--- a/lib/rmg/CRmgTemplateStorage.h
+++ b/lib/rmg/CRmgTemplateStorage.h
@@ -28,12 +28,12 @@ public:
 
 	const std::map<std::string, CRmgTemplate *> & getTemplates() const;
 
-	std::vector<bool> getDefaultAllowed() const;
-	std::vector<JsonNode> loadLegacyData(size_t dataSize);
+	std::vector<bool> getDefaultAllowed() const override;
+	std::vector<JsonNode> loadLegacyData(size_t dataSize) override;
 
 	/// loads single object into game. Scope is namespace of this object, same as name of source mod
-	virtual void loadObject(std::string scope, std::string name, const JsonNode & data);
-	virtual void loadObject(std::string scope, std::string name, const JsonNode & data, size_t index);
+	virtual void loadObject(std::string scope, std::string name, const JsonNode & data) override;
+	virtual void loadObject(std::string scope, std::string name, const JsonNode & data, size_t index) override;
 
 private:
 	CRmgTemplate::CSize parseMapTemplateSize(const std::string & text) const;

--- a/server/CGameHandler.h
+++ b/server/CGameHandler.h
@@ -250,7 +250,7 @@ public:
 	void sendMessageToAll(const std::string &message);
 	void sendMessageTo(CConnection &c, const std::string &message);
 	void sendToAllClients(CPackForClient * info);
-	void sendAndApply(CPackForClient * info);
+	void sendAndApply(CPackForClient * info) override;
 	void applyAndSend(CPackForClient * info);
 	void sendAndApply(CGarrisonOperationPack * info);
 	void sendAndApply(SetResource * info);

--- a/server/CQuery.h
+++ b/server/CQuery.h
@@ -94,7 +94,7 @@ public:
 	bool visitDestAfterVictory; //if hero moved to guarded tile and it should be visited once guard is defeated
 	const CGHeroInstance *hero;
 
-	virtual void onExposure(CGameHandler *gh, QueryPtr topQuery);
+	virtual void onExposure(CGameHandler *gh, QueryPtr topQuery) override;
 
 	CHeroMovementQuery(const TryMoveHero &Tmh, const CGHeroInstance *Hero, bool VisitDestAfterVictory = false);
 	virtual void onAdding(CGameHandler *gh, PlayerColor color) override;


### PR DESCRIPTION
1) Mark overridden methods with "override"
2) std::abs
3) Invalid comparison

As proposed in https://github.com/vcmi/vcmi/pull/121