### PR TITLE
Mantis#1230

### DIFF
--- a/config/bonuses.json
+++ b/config/bonuses.json
@@ -368,6 +368,11 @@
 			"icon":  "zvs/Lib1.res/E_OBST"
 		}
 	},
+	
+	"NO_TERRAIN_PENALTY":
+	{
+		"hidden": true
+	},
 
 	"NON_LIVING":
 	{

--- a/config/creatures/neutral.json
+++ b/config/creatures/neutral.json
@@ -475,6 +475,15 @@
 		"index": 142,
 		"level": 3,
 		"faction": "neutral",
+		"abilities":
+		{
+			"sandWalker" :
+			{
+				"type" : "NO_TERRAIN_PENALTY",
+				"subtype" : 1,
+				"propagator" : "HERO"
+			}
+		},
 		"doubleWide" : true,
 		"graphics" :
 		{

--- a/lib/GameConstants.h
+++ b/lib/GameConstants.h
@@ -51,6 +51,7 @@ namespace GameConstants
 	const int SPELLS_QUANTITY=70;
 	const int CREATURES_COUNT = 197;
 
+	const ui32 BASE_MOVEMENT_COST = 100; //default cost for non-diagonal movement
 }
 
 class CArtifact;

--- a/lib/HeroBonus.h
+++ b/lib/HeroBonus.h
@@ -218,6 +218,7 @@ public:
 	BONUS_NAME(DISGUISED) /* subtype - spell level */\
 	BONUS_NAME(VISIONS) /* subtype - spell level */\
 	BONUS_NAME(NO_TERRAIN_PENALTY) /* subtype - terrain type */\
+	/* end of list */
 	
 
 #define BONUS_SOURCE_LIST \

--- a/lib/HeroBonus.h
+++ b/lib/HeroBonus.h
@@ -215,9 +215,9 @@ public:
 	BONUS_NAME(ADDITIONAL_UNITS) /*val of units with id = subtype will be added to hero's army at the beginning of battle */\
 	BONUS_NAME(SPOILS_OF_WAR) /*val * 10^-6 * gained exp resources of subtype will be given to hero after battle*/\
 	BONUS_NAME(BLOCK)\
-	BONUS_NAME(NO_TERRAIN_PENALTY) /* subtype - terrain type */\
 	BONUS_NAME(DISGUISED) /* subtype - spell level */\
-	BONUS_NAME(VISIONS) /* subtype - spell level */
+	BONUS_NAME(VISIONS) /* subtype - spell level */\
+	BONUS_NAME(NO_TERRAIN_PENALTY) /* subtype - terrain type */\
 	
 
 #define BONUS_SOURCE_LIST \

--- a/lib/HeroBonus.h
+++ b/lib/HeroBonus.h
@@ -215,6 +215,7 @@ public:
 	BONUS_NAME(ADDITIONAL_UNITS) /*val of units with id = subtype will be added to hero's army at the beginning of battle */\
 	BONUS_NAME(SPOILS_OF_WAR) /*val * 10^-6 * gained exp resources of subtype will be given to hero after battle*/\
 	BONUS_NAME(BLOCK)\
+	BONUS_NAME(NO_TERRAIN_PENALTY) /* subtype - terrain type */\
 	BONUS_NAME(DISGUISED) /* subtype - spell level */\
 	BONUS_NAME(VISIONS) /* subtype - spell level */
 	

--- a/lib/mapObjects/CGHeroInstance.cpp
+++ b/lib/mapObjects/CGHeroInstance.cpp
@@ -62,50 +62,44 @@ ui32 CGHeroInstance::getTileCost(const TerrainTile &dest, const TerrainTile &fro
 	unsigned ret = 100;
 
 	//if there is road both on dest and src tiles - use road movement cost
-    if(dest.roadType != ERoadType::NO_ROAD && from.roadType != ERoadType::NO_ROAD)
+	if(dest.roadType != ERoadType::NO_ROAD && from.roadType != ERoadType::NO_ROAD)
 	{
-        int road = std::min(dest.roadType,from.roadType); //used road ID
+		int road = std::min(dest.roadType,from.roadType); //used road ID
 		switch(road)
 		{
-        case ERoadType::DIRT_ROAD:
+		case ERoadType::DIRT_ROAD:
 			ret = 75;
 			break;
-        case ERoadType::GRAVEL_ROAD:
+		case ERoadType::GRAVEL_ROAD:
 			ret = 65;
 			break;
-        case ERoadType::COBBLESTONE_ROAD:
+		case ERoadType::COBBLESTONE_ROAD:
 			ret = 50;
 			break;
 		default:
-            logGlobal->errorStream() << "Unknown road type: " << road << "... Something wrong!";
+			logGlobal->errorStream() << "Unknown road type: " << road << "... Something wrong!";
 			break;
 		}
 	}
-	else
+	else if(!hasBonusOfType(Bonus::NO_TERRAIN_PENALTY, from.terType))
 	{
 		// NOTE: in H3 neutral stacks will ignore terrain penalty only if placed as topmost stack(s) in hero army.
 		// This is clearly bug in H3 however intended behaviour is not clear.
 		// Current VCMI behaviour will ignore neutrals in calculations so army in VCMI
 		// will always have best penalty without any influence from player-defined stacks order
 
-		bool nativeArmy = true;
 		for(auto stack : stacks)
 		{
 			int nativeTerrain = VLC->townh->factions[stack.second->type->faction]->nativeTerrain;
-
-            if (nativeTerrain != -1 && nativeTerrain != from.terType)
+			if(nativeTerrain != -1 && nativeTerrain != from.terType)
 			{
-				nativeArmy = false;
+				ret = VLC->heroh->terrCosts[from.terType];
+				ret -= getSecSkillLevel(SecondarySkill::PATHFINDING) * 25;
+				ret = ret < 100 ? 100 : ret;
 				break;
 			}
 		}
-		if(!nativeArmy && !hasBonusOfType(Bonus::NO_TERRAIN_PENALTY, from.terType))
-        {
-            ret = VLC->heroh->terrCosts[from.terType];
-            ret-=getSecSkillLevel(SecondarySkill::PATHFINDING)*25;
-            ret = ret < 100 ? 100 : ret;
-        }
- 	}
+	}
 	return ret;
 }
 

--- a/lib/mapObjects/CGHeroInstance.cpp
+++ b/lib/mapObjects/CGHeroInstance.cpp
@@ -58,8 +58,7 @@ static int lowestSpeed(const CGHeroInstance * chi)
 
 ui32 CGHeroInstance::getTileCost(const TerrainTile &dest, const TerrainTile &from) const
 {
-	//base move cost
-	unsigned ret = 100;
+	unsigned ret = GameConstants::BASE_MOVEMENT_COST;
 
 	//if there is road both on dest and src tiles - use road movement cost
 	if(dest.roadType != ERoadType::NO_ROAD && from.roadType != ERoadType::NO_ROAD)
@@ -95,7 +94,9 @@ ui32 CGHeroInstance::getTileCost(const TerrainTile &dest, const TerrainTile &fro
 			{
 				ret = VLC->heroh->terrCosts[from.terType];
 				ret -= getSecSkillLevel(SecondarySkill::PATHFINDING) * 25;
-				ret = ret < 100 ? 100 : ret;
+				if(ret < GameConstants::BASE_MOVEMENT_COST)
+					ret = GameConstants::BASE_MOVEMENT_COST;
+
 				break;
 			}
 		}

--- a/lib/mapObjects/CGHeroInstance.cpp
+++ b/lib/mapObjects/CGHeroInstance.cpp
@@ -83,8 +83,6 @@ ui32 CGHeroInstance::getTileCost(const TerrainTile &dest, const TerrainTile &fro
 	}
 	else
 	{
-		//FIXME: in H3 presence of Nomad in army will remove terrain penalty for sand. Bonus not implemented in VCMI
-
 		// NOTE: in H3 neutral stacks will ignore terrain penalty only if placed as topmost stack(s) in hero army.
 		// This is clearly bug in H3 however intended behaviour is not clear.
 		// Current VCMI behaviour will ignore neutrals in calculations so army in VCMI
@@ -101,7 +99,7 @@ ui32 CGHeroInstance::getTileCost(const TerrainTile &dest, const TerrainTile &fro
 				break;
 			}
 		}
-		if (!nativeArmy)
+		if(!nativeArmy && !hasBonusOfType(Bonus::NO_TERRAIN_PENALTY, from.terType))
         {
             ret = VLC->heroh->terrCosts[from.terType];
             ret-=getSecSkillLevel(SecondarySkill::PATHFINDING)*25;


### PR DESCRIPTION
Nomads bonus implementation:
http://bugs.vcmi.eu/view.php?id=1230

There is still related issue that bonus changes not applied on client when army changes similar to artifacts changes. So if you dismiss Nomads stack path won't be updated automatically until hero move or change path.

I'm looking into that, but likely appropriate fix would require changes in unrelated areas (as artifacts need fixing too) so probably it's will go to separate branch. 