### PR TITLE
Fix zero-cost teleports

### DIFF
--- a/AI/VCAI/VCAI.cpp
+++ b/AI/VCAI/VCAI.cpp
@@ -1956,7 +1956,7 @@ bool VCAI::moveHeroToTile(int3 dst, HeroPtr h)
 }
 void VCAI::tryRealize(Goals::Explore & g)
 {
-	throw cannotFulfillGoalException("EXPLORE is not a elementar goal!");
+	throw cannotFulfillGoalException("EXPLORE is not an elementary goal!");
 }
 
 void VCAI::tryRealize(Goals::RecruitHero & g)

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -1880,6 +1880,8 @@ bool CGameHandler::moveHero( ObjectInstanceID hid, int3 dst, ui8 teleporting, bo
 		return doMove(TryMoveHero::DISEMBARK, CHECK_FOR_GUARDS, VISIT_DEST, LEAVING_TILE);
 	}
 
+	tmh.movePoints = h->movement >= cost ? h->movement - cost : 0;
+
 	if(teleporting)
 	{
 		if(blockingVisit()) // e.g. hero on the other side of teleporter
@@ -1901,10 +1903,6 @@ bool CGameHandler::moveHero( ObjectInstanceID hid, int3 dst, ui8 teleporting, bo
 
 	//still here? it is standard movement!
 	{
-		tmh.movePoints = h->movement >= cost
-						? h->movement - cost
-						: 0;
-
 		if(blockingVisit())
 			return true;
 


### PR DESCRIPTION
Using teleports and subterranean passages currently costs nothing. This can lead to infinite cycles in AI when a hero teleports, changes his/her mind, goes back, changes his/her mind, and again.