### PR TITLE
[WIP] Path calculation in separate thread

### DIFF
--- a/lib/CGameState.cpp
+++ b/lib/CGameState.cpp
@@ -2164,8 +2164,11 @@ void CGameState::apply(CPack *pack)
 
 void CGameState::calculatePaths(const CGHeroInstance *hero, CPathsInfo &out)
 {
+	if(pathfinderWorking)
+		pathfinderWorking->interrupt();
+
 	CPathfinder pathfinder(out, this, hero);
-	pathfinder.calculatePaths();
+	pathfinderWorking = make_unique<boost::thread>(&CPathfinder::startPathfinder, pathfinder);
 }
 
 /**

--- a/lib/CGameState.h
+++ b/lib/CGameState.h
@@ -314,6 +314,8 @@ public:
 
 	boost::shared_mutex *mx;
 
+	unique_ptr<boost::thread> pathfinderWorking;
+
 	void giveHeroArtifact(CGHeroInstance *h, ArtifactID aid);
 
 	void apply(CPack *pack);

--- a/lib/CPathfinder.cpp
+++ b/lib/CPathfinder.cpp
@@ -7,6 +7,7 @@
 #include "mapObjects/CGHeroInstance.h"
 #include "GameConstants.h"
 #include "CStopWatch.h"
+#include "CThreadHelper.h"
 
 /*
  * CPathfinder.cpp, part of VCMI engine
@@ -53,6 +54,24 @@ CPathfinder::CPathfinder(CPathsInfo &_out, CGameState *_gs, const CGHeroInstance
 
 	neighbours.reserve(16);
 }
+
+void CPathfinder::startPathfinder()
+{
+	try
+	{
+		setThreadName("CPathfinder::startPathfinder");
+
+		calculatePaths();
+	}
+	catch(boost::thread_interrupted &e)
+	{
+		gs->pathfinderWorking.reset();
+		return;
+	}
+
+	gs->pathfinderWorking.reset();
+}
+
 
 void CPathfinder::calculatePaths()
 {
@@ -153,6 +172,8 @@ void CPathfinder::calculatePaths()
 				}
 			}
 		}
+
+		boost::this_thread::interruption_point();
 	} //queue loop
 }
 

--- a/lib/CPathfinder.h
+++ b/lib/CPathfinder.h
@@ -70,6 +70,7 @@ class CPathfinder : private CGameInfoCallback
 {
 public:
 	CPathfinder(CPathsInfo &_out, CGameState *_gs, const CGHeroInstance *_hero);
+	void startPathfinder();
 	void calculatePaths(); //calculates possible paths for hero, uses current hero position and movement left; returns pointer to newly allocated CPath or nullptr if path does not exists
 
 private:


### PR DESCRIPTION
This one is depend on #133, but as @DjWarmonger requested it can go into separate branch. Main advantages that separate thread give are:

* No client locking while path calculation going.
* Client may instantly start using path data even if thread not finished.
* Should improve VCAI "explore" goal performance. Currently AI has to wait till full graph rebuilt after each 1-tile movement even if everything it's need is 3x3 area around hero.

Still once #133 completed and merged  some work would be needed:

* On client side we should make UI automatically update cursor if tile under cursor wasn't marked as "locked" when we rendered it first time.
* VCAI should be also aware of how path calculation work. In some cases it's may want to wait till pathfinder thread finished.
