### PR TITLE
Cleanup ffmpeg up to 2.2.3

### DIFF
--- a/client/CVideoHandler.cpp
+++ b/client/CVideoHandler.cpp
@@ -142,14 +142,9 @@ bool CVideoPlayer::open(std::string fname, bool loop, bool useOverlay, bool scal
 		return false;
 	}
 	// Allocate video frame
-#ifdef VCMI_USE_OLD_AVUTIL 
- 	frame = avcodec_alloc_frame();
-#else
 	frame = av_frame_alloc();
-#endif
 	
 	//setup scaling
-	
 	if(scale)
 	{
 		pos.w = screen->w;		
@@ -362,12 +357,7 @@ void CVideoPlayer::close()
 
 	if (frame)
 	{
-#ifdef VCMI_USE_OLD_AVUTIL
-		av_free(frame);
-		frame = nullptr;
-#else
 		av_frame_free(&frame);//will be set to null		
-#endif		
 	}
 
 	if (codec)

--- a/client/CVideoHandler.cpp
+++ b/client/CVideoHandler.cpp
@@ -104,11 +104,7 @@ bool CVideoPlayer::open(std::string fname, bool loop, bool useOverlay, bool scal
 		return false;
 	}
 	// Retrieve stream information
-#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(53, 17, 0)
-	if (av_find_stream_info(format) < 0)
-#else
 	if (avformat_find_stream_info(format, nullptr) < 0)
-#endif
 		return false;
 
 	// Find the first video stream
@@ -139,11 +135,7 @@ bool CVideoPlayer::open(std::string fname, bool loop, bool useOverlay, bool scal
 	}
 
 	// Open codec
-#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(53, 6, 0)
-	if ( avcodec_open(codecContext, codec) < 0 )
-#else
 	if ( avcodec_open2(codecContext, codec, nullptr) < 0 )
-#endif
 	{
 		// Could not open codec
 		codec = nullptr;
@@ -151,12 +143,7 @@ bool CVideoPlayer::open(std::string fname, bool loop, bool useOverlay, bool scal
 	}
 
 	// Allocate video frame
-#if LIBAVUTIL_VERSION_MAJOR > 51
 	frame = av_frame_alloc();
-#else
-	frame = avcodec_alloc_frame();
-#endif
-
 	
 	//setup scaling
 	
@@ -191,35 +178,20 @@ bool CVideoPlayer::open(std::string fname, bool loop, bool useOverlay, bool scal
 	{ // Convert the image into YUV format that SDL uses
 		sws = sws_getContext(codecContext->width, codecContext->height, codecContext->pix_fmt, 
 							 pos.w, pos.h,
-#if LIBAVUTIL_VERSION_MAJOR > 51
 							 AV_PIX_FMT_YUV420P,
-#else
-							 PIX_FMT_YUV420P,
-#endif
 							 SWS_BICUBIC, nullptr, nullptr, nullptr);
 	}
 	else
 	{
-
-#if LIBAVUTIL_VERSION_MAJOR > 51
 		AVPixelFormat screenFormat = AV_PIX_FMT_NONE;
-#else
-		PixelFormat screenFormat = PIX_FMT_NONE;
-#endif
 		if (screen->format->Bshift > screen->format->Rshift)
 		{
 			// this a BGR surface
 			switch (screen->format->BytesPerPixel)
 			{
-#if LIBAVUTIL_VERSION_MAJOR > 51
 				case 2: screenFormat = AV_PIX_FMT_BGR565; break;
 				case 3: screenFormat = AV_PIX_FMT_BGR24; break;
 				case 4: screenFormat = AV_PIX_FMT_BGR32; break;
-#else
-				case 2: screenFormat = PIX_FMT_BGR565; break;
-				case 3: screenFormat = PIX_FMT_BGR24; break;
-				case 4: screenFormat = PIX_FMT_BGR32; break;
-#endif
 				default: return false;
 			}
 		}
@@ -228,15 +200,9 @@ bool CVideoPlayer::open(std::string fname, bool loop, bool useOverlay, bool scal
 			// this a RGB surface
 			switch (screen->format->BytesPerPixel)
 			{
-#if LIBAVUTIL_VERSION_MAJOR > 51
 				case 2: screenFormat = AV_PIX_FMT_RGB565; break;
 				case 3: screenFormat = AV_PIX_FMT_RGB24; break;
 				case 4: screenFormat = AV_PIX_FMT_RGB32; break;
-#else
-				case 2: screenFormat = PIX_FMT_RGB565; break;
-				case 3: screenFormat = PIX_FMT_RGB24; break;
-				case 4: screenFormat = PIX_FMT_RGB32; break;
-#endif
 				default: return false;
 			}
 		}
@@ -393,12 +359,7 @@ void CVideoPlayer::close()
 
 	if (frame)
 	{
-#if LIBAVUTIL_VERSION_MAJOR > 51
 		av_frame_free(&frame);//will be set to null
-#else
-		av_free(frame);
-		frame = nullptr;		
-#endif
 	}
 
 	if (codec)
@@ -410,12 +371,7 @@ void CVideoPlayer::close()
 
 	if (format)
 	{
-#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(53, 17, 0)
-		av_close_input_file(format);
-		format = nullptr;
-#else
 		avformat_close_input(&format);
-#endif
 	}
 
 	if (context)

--- a/client/CVideoHandler.cpp
+++ b/client/CVideoHandler.cpp
@@ -141,9 +141,12 @@ bool CVideoPlayer::open(std::string fname, bool loop, bool useOverlay, bool scal
 		codec = nullptr;
 		return false;
 	}
-
 	// Allocate video frame
+#ifdef VCMI_USE_OLD_AVUTIL 
+ 	frame = avcodec_alloc_frame();
+#else
 	frame = av_frame_alloc();
+#endif
 	
 	//setup scaling
 	
@@ -359,7 +362,12 @@ void CVideoPlayer::close()
 
 	if (frame)
 	{
-		av_frame_free(&frame);//will be set to null
+#ifdef VCMI_USE_OLD_AVUTIL
+		av_free(frame);
+		frame = nullptr;
+#else
+		av_frame_free(&frame);//will be set to null		
+#endif		
 	}
 
 	if (codec)

--- a/client/CVideoHandler.h
+++ b/client/CVideoHandler.h
@@ -53,6 +53,11 @@ extern "C" {
 #include <libswscale/swscale.h>
 }
 
+//compatibility for libav 9.18 in ubuntu 14.04, 52.66.100 is ffmpeg 2.2.3
+#if LIBAVUTIL_VERSION_INT < AV_VERSION_INT(52, 66, 100) 
+#define VCMI_USE_OLD_AVUTIL
+#endif // LIBSWSCALE_VERSION_INT
+
 class CVideoPlayer : public IMainVideoPlayer
 {
 	int stream;					// stream index in video

--- a/client/CVideoHandler.h
+++ b/client/CVideoHandler.h
@@ -61,6 +61,7 @@ extern "C" {
 #ifdef VCMI_USE_OLD_AVUTIL
 
 #define AVPixelFormat PixelFormat 
+#define AV_PIX_FMT_NONE PIX_FMT_NONE
 #define AV_PIX_FMT_YUV420P PIX_FMT_YUV420P
 #define AV_PIX_FMT_BGR565 PIX_FMT_BGR565
 #define AV_PIX_FMT_BGR24 PIX_FMT_BGR24

--- a/client/CVideoHandler.h
+++ b/client/CVideoHandler.h
@@ -58,6 +58,30 @@ extern "C" {
 #define VCMI_USE_OLD_AVUTIL
 #endif // LIBSWSCALE_VERSION_INT
 
+#ifdef VCMI_USE_OLD_AVUTIL
+
+#define AVPixelFormat PixelFormat 
+#define AV_PIX_FMT_YUV420P PIX_FMT_YUV420P
+#define AV_PIX_FMT_BGR565 PIX_FMT_BGR565
+#define AV_PIX_FMT_BGR24 PIX_FMT_BGR24
+#define AV_PIX_FMT_BGR32 PIX_FMT_BGR32
+#define AV_PIX_FMT_RGB565 PIX_FMT_RGB565
+#define AV_PIX_FMT_RGB24 PIX_FMT_RGB24
+#define AV_PIX_FMT_RGB32 PIX_FMT_RGB32
+
+inline AVFrame * av_frame_alloc()
+{
+	return avcodec_alloc_frame();
+}
+
+inline void av_frame_free(AVFrame ** frame)
+{
+	av_free(*frame);
+	*frame = nullptr;
+}
+
+#endif // VCMI_USE_OLD_AVUTIL
+
 class CVideoPlayer : public IMainVideoPlayer
 {
 	int stream;					// stream index in video

--- a/client/CVideoHandler.h
+++ b/client/CVideoHandler.h
@@ -51,18 +51,6 @@ public:
 extern "C" {
 #include <libavformat/avformat.h>
 #include <libswscale/swscale.h>
-
-// compatibility with different versions od libavutil
-#if (LIBAVUTIL_VERSION_INT < AV_VERSION_INT(51, 42, 0)) || \
-    (LIBAVUTIL_VERSION_INT == AV_VERSION_INT(51, 73, 101))
-
-#define AV_PIX_FMT_NONE         PIX_FMT_NONE
-#define AV_PIX_FMT_NV12         PIX_FMT_NV12
-#define AV_PIX_FMT_YUV420P      PIX_FMT_YUV420P
-#define AV_PIX_FMT_UYVY422      PIX_FMT_UYVY422
-#define AV_PIX_FMT_YUYV422      PIX_FMT_YUYV422
-
-#endif 
 }
 
 class CVideoPlayer : public IMainVideoPlayer


### PR DESCRIPTION
All "old" APIs are deprecated in ffmpeg 2.2.3 - remove them entirely.
Should work for 2.2.3+ including upcoming 2.9. Please test.