### PR TITLE
Bonus system: add turnsRemain support for ONE_WEEK duration

### DIFF
--- a/lib/HeroBonus.cpp
+++ b/lib/HeroBonus.cpp
@@ -780,6 +780,12 @@ void CBonusSystemNode::updateBonuses(const CSelector &s)
 
 void CBonusSystemNode::addNewBonus(Bonus *b)
 {
+	//turnsRemain shouldn't be zero for following durations
+	if(Bonus::NTurns(b) || Bonus::NDays(b) || Bonus::OneWeek(b))
+	{
+		assert(b->turnsRemain);
+	}
+
 	assert(!vstd::contains(exportedBonuses,b));
 	exportedBonuses.push_back(b);
 	exportBonus(b);

--- a/lib/HeroBonus.h
+++ b/lib/HeroBonus.h
@@ -811,7 +811,7 @@ public:
 	bool operator()(const Bonus *bonus) const
 	{
 		return turnsRequested <= 0					//every present effect will last zero (or "less") turns
-			|| !(bonus->duration & Bonus::N_TURNS)	//so do every not expriing after N-turns effect
+			|| !Bonus::NTurns(bonus) //so do every not expriing after N-turns effect
 			|| bonus->turnsRemain > turnsRequested;
 	}
 	CWillLastTurns& operator()(const int &setVal)
@@ -828,11 +828,11 @@ public:
 
 	bool operator()(const Bonus *bonus) const
 	{
-		if(daysRequested <= 0 || bonus->duration & Bonus::PERMANENT || bonus->duration & Bonus::ONE_BATTLE)
+		if(daysRequested <= 0 || Bonus::Permanent(bonus) || Bonus::OneBattle(bonus))
 			return true;
-		else if(bonus->duration & Bonus::ONE_DAY)
+		else if(Bonus::OneDay(bonus))
 			return false;
-		else if(bonus->duration & Bonus::N_DAYS || bonus->duration & Bonus::ONE_WEEK)
+		else if(Bonus::NDays(bonus) || Bonus::OneWeek(bonus))
 		{
 			return bonus->turnsRemain > daysRequested;
 		}

--- a/lib/HeroBonus.h
+++ b/lib/HeroBonus.h
@@ -294,7 +294,7 @@ struct DLL_LINKAGE Bonus
 	};
 
 	ui16 duration; //uses BonusDuration values
-	si16 turnsRemain; //used if duration is N_TURNS or N_DAYS
+	si16 turnsRemain; //used if duration is N_TURNS, N_DAYS or ONE_WEEK
 
 	BonusType type; //uses BonusType values - says to what is this bonus - 1 byte
 	TBonusSubtype subtype; //-1 if not applicable - 4 bytes
@@ -828,13 +828,11 @@ public:
 
 	bool operator()(const Bonus *bonus) const
 	{
-		if(daysRequested <= 0)
+		if(daysRequested <= 0 || bonus->duration & Bonus::PERMANENT || bonus->duration & Bonus::ONE_BATTLE)
 			return true;
 		else if(bonus->duration & Bonus::ONE_DAY)
 			return false;
-		else if(bonus->duration & Bonus::PERMANENT || bonus->duration & Bonus::ONE_BATTLE)
-			return true;
-		else if(bonus->duration & Bonus::N_DAYS)
+		else if(bonus->duration & Bonus::N_DAYS || bonus->duration & Bonus::ONE_WEEK)
 		{
 			return bonus->turnsRemain > daysRequested;
 		}

--- a/lib/NetPacksLib.cpp
+++ b/lib/NetPacksLib.cpp
@@ -263,6 +263,9 @@ DLL_LINKAGE void GiveBonus::applyGs( CGameState *gs )
 
 	assert(cbsn);
 
+	if(Bonus::OneWeek(&bonus))
+		bonus.turnsRemain = 8 - gs->getDate(Date::DAY_OF_WEEK); // set correct number of days before adding bonus
+
 	auto b = new Bonus(bonus);
 	cbsn->addNewBonus(b);
 
@@ -1023,10 +1026,8 @@ DLL_LINKAGE void NewTurn::applyGs( CGameState *gs )
 		creatureSet.second.applyGs(gs);
 
 	gs->globalEffects.popBonuses(Bonus::OneDay); //works for children -> all game objs
-	if(gs->getDate(Date::DAY_OF_WEEK) == 1) //new week
-		gs->globalEffects.popBonuses(Bonus::OneWeek); //works for children -> all game objs
-
 	gs->globalEffects.updateBonuses(Bonus::NDays);
+	gs->globalEffects.updateBonuses(Bonus::OneWeek);
 	//TODO not really a single root hierarchy, what about bonuses placed elsewhere? [not an issue with H3 mechanics but in the future...]
 
 	for(CGTownInstance* t : gs->map->towns)


### PR DESCRIPTION
It's little, but controversial change so It's goes into pull request. Situation is simple: pathfinding branch depend on CWillLastDays selector and it's going to break ONE_WEEK bonuses in saved games one way or another.

This commit going to fix it, but as result when loading save game old ONE_WEEK bonuses (stables) going to be removed on next turn because they all would have zero "turnsRemain" and updateBonuses remove such entries.

There is two ways this can be handled:

* Push it as is. This way previously set stables bonuses in loaded games wouldn't work.
* Add bunch of dirty hacks in code to make it work not break exist bonuses.

Personally I think it's tiny breakage and we can live with it, but it's still has to be documented.