### PR TITLE
Revert 5cd4e852d49a988157d04349db6350322de59342 "Use portable cast in…

### DIFF
--- a/server/CQuery.cpp
+++ b/server/CQuery.cpp
@@ -321,7 +321,8 @@ CBlockingDialogQuery::CBlockingDialogQuery(const BlockingDialog &bd)
 
 void CTeleportDialogQuery::notifyObjectAboutRemoval(const CObjectVisitQuery &objectVisit) const
 {
-	auto obj = dynamic_ptr_cast<const CGTeleport>(objectVisit.visitedObject);
+	// do not change to dynamic_ptr_cast - SIGSEGV!
+	auto obj = dynamic_cast<const CGTeleport*>(objectVisit.visitedObject);
 	obj->teleportDialogAnswered(objectVisit.visitingHero, *answer, td.exits);
 }
 


### PR DESCRIPTION
… CTeleportDialogQuery also"

Actually, this leads to crash on MacOSX, I specially left that intact.