### PR TITLE
Enable right mouse button click emulation on MacOSX

### DIFF
--- a/client/CMT.cpp
+++ b/client/CMT.cpp
@@ -79,7 +79,7 @@ extern boost::thread_specific_ptr<bool> inGuiThread;
 SDL_Surface *screen = nullptr, //main screen surface
 	*screen2 = nullptr, //and hlp surface (used to store not-active interfaces layer)
 	*screenBuf = screen; //points to screen (if only advmapint is present) or screen2 (else) - should be used when updating controls which are not regularly redrawed
-	
+
 std::queue<SDL_Event> events;
 boost::mutex eventsM;
 
@@ -187,7 +187,7 @@ static void SDLLogCallback(void*           userdata,
 {
 	//todo: convert SDL log priority to vcmi log priority
 	//todo: make separate log domain for SDL
-	
+
 	logGlobal->debugStream() << "SDL(category " << category << "; priority " <<priority <<") "<<message;
 }
 
@@ -363,21 +363,21 @@ int main(int argc, char** argv)
 		}
 		GH.mainFPSmng->init(); //(!)init here AFTER SDL_Init() while using SDL for FPS management
 		atexit(SDL_Quit);
-		
+
 		SDL_LogSetOutputFunction(&SDLLogCallback, nullptr);
-		
+
 		int driversCount = SDL_GetNumRenderDrivers();
 		std::string preferredDriverName = video["driver"].String();
-		
+
 		logGlobal->infoStream() << "Found " << driversCount << " render drivers";
-		
+
 		for(int it = 0; it < driversCount; it++)
 		{
 			SDL_RendererInfo info;
 			SDL_GetRenderDriverInfo(it,&info);
-			
+
 			std::string driverName(info.name);
-			
+
 			if(!preferredDriverName.empty() && driverName == preferredDriverName)
 			{
 				preferredDriverIndex = it;
@@ -385,8 +385,8 @@ int main(int argc, char** argv)
 			}
 			else
 				logGlobal->infoStream() << "\t" << driverName;
-		}			
-		
+		}
+
 		config::CConfigHandler::GuiOptionsMap::key_type resPair(res["width"].Float(), res["height"].Float());
 		if (conf.guiOptions.count(resPair) == 0)
 		{
@@ -440,10 +440,15 @@ int main(int argc, char** argv)
 	CCS->musich->setVolume(settings["general"]["music"].Float());
     logGlobal->infoStream()<<"Initializing screen and sound handling: "<<pomtime.getDiff();
 
+#ifdef __APPLE__
+	// Ctrl+click should be treated as a right click on Mac OS X
+	SDL_SetHint(SDL_HINT_MAC_CTRL_CLICK_EMULATE_RIGHT_CLICK, "1");
+#endif
+
 #ifndef VCMI_NO_THREADED_LOAD
 	//we can properly play intro only in the main thread, so we have to move loading to the separate thread
 	boost::thread loading(init);
-#else	 
+#else
 	init();
 #endif
 
@@ -632,7 +637,7 @@ void processCommand(const std::string &message)
 		for (auto & filename : list)
 		{
 			const bfs::path filePath = outPath / (filename.getName() + ".TXT");
-			
+
 			bfs::create_directories(filePath.parent_path());
 
 			bfs::ofstream file(filePath);
@@ -845,25 +850,25 @@ static bool checkVideoMode(int monitorIndex, int w, int h, int& bpp, bool fullsc
 			return true;
 		}
 	}
-	return false;	
+	return false;
 }
 
 static bool recreateWindow(int w, int h, int bpp, bool fullscreen)
 {
-	// VCMI will only work with 2 or 4 bytes per pixel	
+	// VCMI will only work with 2 or 4 bytes per pixel
 	vstd::amax(bpp, 16);
 	vstd::amin(bpp, 32);
 	if(bpp>16)
 		bpp = 32;
-	
+
 	int suggestedBpp = bpp;
 
 	if(!checkVideoMode(0,w,h,suggestedBpp,fullscreen))
 	{
 		logGlobal->errorStream() << "Error: SDL says that " << w << "x" << h << " resolution is not available!";
 		return false;
-	}	
-	
+	}
+
 	bool bufOnScreen = (screenBuf == screen);
 
 	screenBuf = nullptr; //it`s a link - just nullify
@@ -873,34 +878,34 @@ static bool recreateWindow(int w, int h, int bpp, bool fullscreen)
 		SDL_FreeSurface(screen2);
 		screen2 = nullptr;
 	}
-		
-		
+
+
 	if(nullptr != screen)
 	{
 		SDL_FreeSurface(screen);
 		screen = nullptr;
-	}	
-		
-	
+	}
+
+
 	if(nullptr != screenTexture)
 	{
 		SDL_DestroyTexture(screenTexture);
 		screenTexture = nullptr;
 	}
-	
-	if(nullptr != mainRenderer)	
+
+	if(nullptr != mainRenderer)
 	{
 		SDL_DestroyRenderer(mainRenderer);
 		mainRenderer = nullptr;
 	}
-		
+
 	if(nullptr != mainWindow)
 	{
 		SDL_DestroyWindow(mainWindow);
 		mainWindow = nullptr;
-	}	
-	
-	
+	}
+
+
 	if(fullscreen)
 	{
 		//in full-screen mode always use desktop resolution
@@ -911,33 +916,33 @@ static bool recreateWindow(int w, int h, int bpp, bool fullscreen)
 	{
 		mainWindow = SDL_CreateWindow(NAME.c_str(), SDL_WINDOWPOS_CENTERED,SDL_WINDOWPOS_CENTERED, w, h, 0);
 	}
-	
-	
-	
+
+
+
 	if(nullptr == mainWindow)
 	{
 		throw std::runtime_error("Unable to create window\n");
 	}
-	
-	
+
+
 	//create first available renderer if preferred not set. Use no flags, so HW accelerated will be preferred but SW renderer also will possible
 	mainRenderer = SDL_CreateRenderer(mainWindow,preferredDriverIndex,0);
 
 	if(nullptr == mainRenderer)
 	{
 		throw std::runtime_error("Unable to create renderer\n");
-	}	
-	
+	}
+
 	SDL_RendererInfo info;
 	SDL_GetRendererInfo(mainRenderer,&info);
-	logGlobal->infoStream() << "Created renderer " << info.name;	
-	
+	logGlobal->infoStream() << "Created renderer " << info.name;
+
 	SDL_RenderSetLogicalSize(mainRenderer, w, h);
-	
+
 	SDL_RenderSetViewport(mainRenderer, nullptr);
 
 
-	
+
 	#if (SDL_BYTEORDER == SDL_BIG_ENDIAN)
 		int bmask = 0xff000000;
 		int gmask = 0x00ff0000;
@@ -955,13 +960,13 @@ static bool recreateWindow(int w, int h, int bpp, bool fullscreen)
 	{
 		logGlobal->errorStream() << "Unable to create surface";
 		logGlobal->errorStream() << w << " "<<  h << " "<< bpp;
-		
+
 		logGlobal->errorStream() << SDL_GetError();
 		throw std::runtime_error("Unable to create surface");
-	}	
+	}
 	//No blending for screen itself. Required for proper cursor rendering.
 	SDL_SetSurfaceBlendMode(screen, SDL_BLENDMODE_NONE);
-	
+
 	screenTexture = SDL_CreateTexture(mainRenderer,
                                             SDL_PIXELFORMAT_ARGB8888,
                                             SDL_TEXTUREACCESS_STREAMING,
@@ -972,23 +977,23 @@ static bool recreateWindow(int w, int h, int bpp, bool fullscreen)
 		logGlobal->errorStream() << "Unable to create screen texture";
 		logGlobal->errorStream() << SDL_GetError();
 		throw std::runtime_error("Unable to create screen texture");
-	}	
-		
+	}
+
 	screen2 = CSDL_Ext::copySurface(screen);
 
 
 	if(nullptr == screen2)
 	{
 		throw std::runtime_error("Unable to copy surface\n");
-	}			
-	
+	}
+
 	screenBuf = bufOnScreen ? screen : screen2;
 
 	SDL_SetRenderDrawColor(mainRenderer, 0, 0, 0, 0);
 	SDL_RenderClear(mainRenderer);
 	SDL_RenderPresent(mainRenderer);
-		
-	return true;	
+
+	return true;
 }
 
 //used only once during initialization
@@ -997,7 +1002,7 @@ static void setScreenRes(int w, int h, int bpp, bool fullscreen, bool resetVideo
 	if(!recreateWindow(w,h,bpp,fullscreen))
 	{
 		throw std::runtime_error("Requested screen resolution is not available\n");
-	}	
+	}
 }
 
 static void fullScreenChanged()
@@ -1008,16 +1013,16 @@ static void fullScreenChanged()
 	const bool toFullscreen = full->Bool();
 
 	auto bitsPerPixel = screen->format->BitsPerPixel;
-	
+
 	auto w = screen->w;
 	auto h = screen->h;
-	
+
 	if(!recreateWindow(w,h,bitsPerPixel,toFullscreen))
 	{
 		//will return false and report error if video mode is not supported
-		return;	
-	}	
-	
+		return;
+	}
+
 	GH.totalRedraw();
 }
 
@@ -1025,7 +1030,7 @@ static void handleEvent(SDL_Event & ev)
 {
 	if((ev.type==SDL_QUIT) ||(ev.type == SDL_KEYDOWN && ev.key.keysym.sym==SDLK_F4 && (ev.key.keysym.mod & KMOD_ALT)))
 	{
-		handleQuit();	
+		handleQuit();
 		return;
 	}
 	else if(ev.type == SDL_KEYDOWN && ev.key.keysym.sym==SDLK_F4)
@@ -1040,8 +1045,8 @@ static void handleEvent(SDL_Event & ev)
 		{
 		case FORCE_QUIT:
 			{
-				handleQuit(false);	
-				return;			
+				handleQuit(false);
+				return;
 			}
 		    break;
 		case RETURN_TO_MAIN_MENU:
@@ -1080,8 +1085,8 @@ static void handleEvent(SDL_Event & ev)
 			fullScreenChanged();
 			break;
 		default:
-			logGlobal->errorStream() << "Unknown user event. Code " << ev.user.code;		
-			break;	
+			logGlobal->errorStream() << "Unknown user event. Code " << ev.user.code;
+			break;
 		}
 
 		return;
@@ -1098,8 +1103,8 @@ static void handleEvent(SDL_Event & ev)
 	{
 		boost::unique_lock<boost::mutex> lock(eventsM);
 		events.push(ev);
-	}	
-	
+	}
+
 }
 
 
@@ -1114,12 +1119,12 @@ static void mainLoop()
 	while(1) //main SDL events loop
 	{
 		SDL_Event ev;
-		
+
 		while(1 == SDL_PollEvent(&ev))
 		{
 			handleEvent(ev);
 		}
-		
+
 		GH.renderFrame();
 
 	}


### PR DESCRIPTION
Currently, there is no way to right mouse button click on Apple single-button devices. The corresponding SDL hint is disabled by default, as stated in the docs.