### PR TITLE
Fix 1569 winning hero with no troops shall retreat

### DIFF
--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -741,7 +741,7 @@ void CGameHandler::battleAfterLevelUp( const BattleResult &result )
 
 		sendAndApply(&sah);
 	}
-	if(finishingBattle->winnerHero && finishingBattle->winnerHero->stacks.empty())
+	if(result.winner != 2 && finishingBattle->winnerHero && finishingBattle->winnerHero->stacks.empty())
 	{
 		RemoveObject ro(finishingBattle->winnerHero->id);
 		sendAndApply(&ro);

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -712,7 +712,7 @@ void CGameHandler::battleAfterLevelUp( const BattleResult &result )
 
 	setBattle(nullptr);
 
-	if(visitObjectAfterVictory && result.winner==0)
+	if(visitObjectAfterVictory && result.winner==0 && !finishingBattle->winnerHero->stacks.empty())
 	{
 		logGlobal->traceStream() << "post-victory visit";
 		visitObjectOnTile(*getTile(finishingBattle->winnerHero->getPosition()), finishingBattle->winnerHero);
@@ -735,6 +735,24 @@ void CGameHandler::battleAfterLevelUp( const BattleResult &result )
 		}
 
 		if(const CGHeroInstance *another =  getPlayer(finishingBattle->loser)->availableHeroes.at(1))
+			sah.hid[1] = another->subID;
+		else
+			sah.hid[1] = -1;
+
+		sendAndApply(&sah);
+	}
+	if(finishingBattle->winnerHero->stacks.empty())
+	{
+		RemoveObject ro(finishingBattle->winnerHero->id);
+		sendAndApply(&ro);
+
+		SetAvailableHeroes sah;
+		sah.player = finishingBattle->victor;
+		sah.hid[0] = finishingBattle->winnerHero->subID;
+		sah.army[0].clear();
+		sah.army[0].setCreature(SlotID(0), finishingBattle->winnerHero->type->initialArmy.at(0).creature, 1);
+
+		if(const CGHeroInstance *another =  getPlayer(finishingBattle->victor)->availableHeroes.at(1))
 			sah.hid[1] = another->subID;
 		else
 			sah.hid[1] = -1;

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -741,7 +741,7 @@ void CGameHandler::battleAfterLevelUp( const BattleResult &result )
 
 		sendAndApply(&sah);
 	}
-	if(finishingBattle->winnerHero->stacks.empty())
+	if(finishingBattle->winnerHero && finishingBattle->winnerHero->stacks.empty())
 	{
 		RemoveObject ro(finishingBattle->winnerHero->id);
 		sendAndApply(&ro);

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -734,7 +734,7 @@ void CGameHandler::battleAfterLevelUp( const BattleResult &result )
 			sah.army[0].setCreature(SlotID(0), finishingBattle->loserHero->type->initialArmy.at(0).creature, 1);
 		}
 
-		if(const CGHeroInstance *another =  getPlayer(finishingBattle->loser)->availableHeroes.at(1))
+		if(const CGHeroInstance *another =  getPlayer(finishingBattle->loser)->availableHeroes.at(0))
 			sah.hid[1] = another->subID;
 		else
 			sah.hid[1] = -1;
@@ -752,7 +752,7 @@ void CGameHandler::battleAfterLevelUp( const BattleResult &result )
 		sah.army[0].clear();
 		sah.army[0].setCreature(SlotID(0), finishingBattle->winnerHero->type->initialArmy.at(0).creature, 1);
 
-		if(const CGHeroInstance *another =  getPlayer(finishingBattle->victor)->availableHeroes.at(1))
+		if(const CGHeroInstance *another =  getPlayer(finishingBattle->victor)->availableHeroes.at(0))
 			sah.hid[1] = another->subID;
 		else
 			sah.hid[1] = -1;


### PR DESCRIPTION
Try to fix http://bugs.vcmi.eu/view.php?id=1569
The following assumptions were made:
1) Winning hero with no army still gains XP, new levels, etc.
2) Raised dead with Necromancery skill are added before the check, so hero remains alive in such cases