### PR TITLE
Fix CGHeroInstance::isInitialized implementation

### DIFF
--- a/lib/mapObjects/CGHeroInstance.h
+++ b/lib/mapObjects/CGHeroInstance.h
@@ -129,7 +129,7 @@ public:
 
 	inline bool isInitialized() const
 	{ // has this hero been on the map at least once?
-		return movement == UNINITIALIZED_MOVEMENT && mana == UNINITIALIZED_MANA;
+		return movement != UNINITIALIZED_MOVEMENT && mana != UNINITIALIZED_MANA;
 	}
 
 	//int3 getSightCenter() const; //"center" tile from which the sight distance is calculated


### PR DESCRIPTION
As noted by @alexvins at https://github.com/vcmi/vcmi/pull/173#discussion_r50899585, isInitialized() is all wrong. Funny thing, recruiting new heroes as well as existing ones still works correctly and need not to be adjusted.
Before:
```
return a == U && b == U;
```
After:
```
return a != U && b != U;
```

I think it worked previously because fresh heroes have movement == -1 but mana == some meaningful value.