### PR TITLE
Fix 2331 save menu keyboard event leak

### DIFF
--- a/client/windows/CAdvmapInterface.cpp
+++ b/client/windows/CAdvmapInterface.cpp
@@ -1069,7 +1069,7 @@ void CAdvMapInt::keyPressed(const SDL_KeyboardEvent & key)
 			LOCPLINT->proposeLoadingGame();
 		return;
 	case SDLK_s:
-		if(isActive())
+		if(isActive() && key.type == SDL_KEYUP)
 			GH.pushInt(new CSavingScreen(CPlayerInterface::howManyPeople > 1));
 		return;
 	case SDLK_d:


### PR DESCRIPTION
The control flows the following way:
- we receive SDL_KEYDOWN with letter 's' in the adventure map interface
- save dialog opens
- text input receives focus
- text input enables receiving SDL_KeyboardEvent-s which go between DOWN and UP
- the button on keyboard becomes UP (the menu opens very fast)
- text input receives SDL_KeyboardEvent and inserts 's'
- text input receives SDL_KEYUP

So the apparent fix is to open the save dialog on SDL_KEYUP event