### PR TITLE
support for music streaming

### DIFF
--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -57,6 +57,7 @@ set(client_SRCS
 		Graphics.cpp
 		mapHandler.cpp
 		NetPacksClient.cpp
+		SDLRWwrapper.cpp
 )
 
 set(client_HEADERS

--- a/client/CMusicHandler.h
+++ b/client/CMusicHandler.h
@@ -80,10 +80,8 @@ class CMusicHandler;
 //Class for handling one music file
 class MusicEntry
 {
-	std::pair<std::unique_ptr<ui8[]>, size_t> data;
 	CMusicHandler *owner;
 	Mix_Music *music;
-	SDL_RWops *musicFile;
 
 	int loop; // -1 = indefinite
 	//if not null - set from which music will be randomly selected
@@ -116,7 +114,7 @@ private:
 
 	std::unique_ptr<MusicEntry> current;
 	std::unique_ptr<MusicEntry> next;
-	
+
 	void queueNext(CMusicHandler *owner, std::string setName, std::string musicURI, bool looped);
 	void queueNext(std::unique_ptr<MusicEntry> queued);
 

--- a/client/SDLRWwrapper.cpp
+++ b/client/SDLRWwrapper.cpp
@@ -1,3 +1,13 @@
+/*
+ * SDLRWwrapper.cpp, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
+
 #include "StdInc.h"
 #include "SDLRWwrapper.h"
 #include "../lib/filesystem/CInputStream.h"

--- a/client/SDLRWwrapper.cpp
+++ b/client/SDLRWwrapper.cpp
@@ -1,0 +1,85 @@
+#include "StdInc.h"
+#include "SDLRWwrapper.h"
+#include "../lib/filesystem/CInputStream.h"
+#include <SDL_rwops.h>
+
+static inline CInputStream* get_stream(SDL_RWops* context)
+{
+	return static_cast<CInputStream*>(context->hidden.unknown.data1);
+}
+
+static Sint64 impl_size(SDL_RWops* context)
+{
+    return get_stream(context)->getSize();
+}
+
+static Sint64 impl_seek(SDL_RWops* context, Sint64 offset, int whence)
+{
+	auto stream = get_stream(context);
+	switch (whence)
+	{
+	case RW_SEEK_SET:
+		return stream->seek(offset);
+		break;
+	case RW_SEEK_CUR:
+		return stream->seek(stream->tell() + offset);
+		break;
+	case RW_SEEK_END:
+		return stream->seek(stream->getSize() + offset);
+		break;
+	default:
+		return -1;
+	}
+
+}
+
+static std::size_t impl_read(SDL_RWops* context, void *ptr, size_t size, size_t maxnum)
+{
+    auto stream = get_stream(context);
+    auto oldpos = stream->tell();
+
+    auto count = stream->read(static_cast<ui8*>(ptr), size*maxnum);
+
+	if (count != 0 && count != size*maxnum)
+	{
+		// if not a whole amount of objects of size has been read, we need to seek
+		stream->seek(oldpos + size * (count / size));
+	}
+
+    return count / size;
+}
+
+static std::size_t impl_write(SDL_RWops* context, const void *ptr, size_t size, size_t num)
+{
+	// writing is not supported
+    return 0;
+}
+
+static int impl_close(SDL_RWops* context)
+{
+	if (context == nullptr)
+		return 0;
+
+    delete get_stream(context);
+    SDL_FreeRW(context);
+    return 0;
+}
+
+
+SDL_RWops* MakeSDLRWops(std::unique_ptr<CInputStream> in)
+{
+	SDL_RWops* result = SDL_AllocRW();
+	if (!result)
+		return nullptr;
+
+	result->size  = &impl_size;
+	result->seek  = &impl_seek;
+	result->read  = &impl_read;
+	result->write = &impl_write;
+	result->close = &impl_close;
+
+	result->type = SDL_RWOPS_UNKNOWN;
+	result->hidden.unknown.data1 = in.release();
+
+	return result;
+}

--- a/client/SDLRWwrapper.h
+++ b/client/SDLRWwrapper.h
@@ -1,0 +1,6 @@
+#pragma once
+
+struct SDL_RWops;
+class CInputStream;
+
+SDL_RWops* MakeSDLRWops(std::unique_ptr<CInputStream> in);

--- a/client/SDLRWwrapper.h
+++ b/client/SDLRWwrapper.h
@@ -1,5 +1,15 @@
 #pragma once
 
+/*
+ * SDLRWwrapper.h, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
+
 struct SDL_RWops;
 class CInputStream;
 

--- a/client/VCMI_client.cbp
+++ b/client/VCMI_client.cbp
@@ -126,6 +126,8 @@
 		<Unit filename="Graphics.h" />
 		<Unit filename="NetPacksClient.cpp" />
 		<Unit filename="SDLMain.h" />
+		<Unit filename="SDLRWwrapper.cpp" />
+		<Unit filename="SDLRWwrapper.h" />
 		<Unit filename="StdInc.h">
 			<Option weight="0" />
 		</Unit>


### PR DESCRIPTION
I have implemented music streaming, as discussed [here](https://github.com/vcmi/vcmi/pull/180). Implemented through a wrapper for SDL around CInputStream. It can be used for inputs to SDL other than music, if needed in the future.

I also fixed a memory leak (and a bug) in MusicEntry.