### PR TITLE
Updated apt-get parameter list

### DIFF
--- a/README.linux
+++ b/README.linux
@@ -28,7 +28,7 @@ To compile, the following packages (and their development counterparts) are need
 		- locale
 
 On Debian-based systems (e.g. Ubuntu) run:
-  sudo apt-get install cmake g++ libsdl2-dev libsdl2-image-dev libsdl2-ttf-dev libsdl2-mixer-dev zlib1g-dev libavformat-dev libswscale-dev libboost-dev libboost-filesystem-dev libboost-system-dev libboost-thread-dev libboost-program-options-dev libboost-locale-dev qtbase5-dev
+  sudo apt-get install cmake g++ libsdl2-dev libsdl2-image-dev libsdl2-ttf-dev libsdl2-mixer-dev zlib1g-dev libavformat-dev libswscale-dev libboost-dev libboost-filesystem-dev libboost-system-dev libboost-thread-dev libboost-program-options-dev libboost-locale-dev libboost-test-dev qtbase5-dev
 
 On RPM-based distributions (e.g. Fedora) run:
   sudo yum install cmake gcc-c++ SDL2-devel SDL2_image-devel SDL2_ttf-devel SDL2_mixer-devel boost boost-devel boost-filesystem boost-system boost-thread boost-program-options boost-locale zlib-devel ffmpeg-devel ffmpeg-libs qt5-qtbase-devel 


### PR DESCRIPTION
Added "libboost-test-dev" to sudo apt-get install for Debian-based systems.