### PR TITLE
Do not use atexit

### DIFF
--- a/client/CMT.cpp
+++ b/client/CMT.cpp
@@ -290,7 +290,6 @@ int main(int argc, char** argv)
 	console = new CConsoleHandler;
 	*console->cb = processCommand;
 	console->start();
-	atexit(dispose);
 
 	const bfs::path logPath = VCMIDirs::get().userCachePath() / "VCMI_Client_log.txt";
 	CBasicLogConfigurator logConfig(logPath, console);
@@ -363,7 +362,6 @@ int main(int argc, char** argv)
 			exit(-1);
 		}
 		GH.mainFPSmng->init(); //(!)init here AFTER SDL_Init() while using SDL for FPS management
-		atexit(SDL_Quit);
 
 		SDL_LogSetOutputFunction(&SDLLogCallback, nullptr);
 
@@ -1278,6 +1276,8 @@ void handleQuit(bool ask/* = true*/)
 			SDL_Quit();
 
 		std::cout << "Ending...\n";
+		dispose();
+		SDL_Quit();
 		exit(0);
 	};
 


### PR DESCRIPTION
Just call these functions directly in the handleQuit function.

std::atexit generally does not play nice with static objects in other
translation units/libraries - there are no guarantees about the order
of destruction of static objects and atexit functions coming from
different translation units/libraries. Removing calls to atexit fixes
crashes when quitting the game. The crash happened during the dispose
function somewhere inside boost's locale library that is used
indirectly by the logger - some locale function tried to lock a static
mutex that was already destroyed.