### PR TITLE
Fix memory leak

### DIFF
--- a/client/CMusicHandler.cpp
+++ b/client/CMusicHandler.cpp
@@ -128,8 +128,8 @@ void CSoundHandler::release()
 
 		for (auto &chunk : soundChunks)
 		{
-			if (chunk.second)
-				Mix_FreeChunk(chunk.second);
+			if (chunk.second.first)
+				Mix_FreeChunk(chunk.second.first);
 		}
 	}
 
@@ -142,14 +142,14 @@ Mix_Chunk *CSoundHandler::GetSoundChunk(std::string &sound, bool cache)
 	try
 	{
 		if (cache && soundChunks.find(sound) != soundChunks.end())
-			return soundChunks[sound];
+			return soundChunks[sound].first;
 
 		auto data = CResourceHandler::get()->load(ResourceID(std::string("SOUNDS/") + sound, EResType::SOUND))->readAll();
-		SDL_RWops *ops = SDL_RWFromMem(data.first.release(), data.second);
+		SDL_RWops *ops = SDL_RWFromMem(data.first.get(), data.second);
 		Mix_Chunk *chunk = Mix_LoadWAV_RW(ops, 1);	// will free ops
 
 		if (cache)
-			soundChunks.insert(std::pair<std::string, Mix_Chunk *>(sound, chunk));
+			soundChunks.insert(std::pair<std::string, CachedChunk>(sound, std::make_pair (chunk, std::move (data.first))));
 
 		return chunk;
 	}

--- a/client/CMusicHandler.h
+++ b/client/CMusicHandler.h
@@ -41,7 +41,8 @@ private:
 	SettingsListener listener;
 	void onVolumeChange(const JsonNode &volumeNode);
 
-	std::map<std::string, Mix_Chunk *> soundChunks;
+	using CachedChunk = std::pair<Mix_Chunk *, std::unique_ptr<ui8[]>>;
+	std::map<std::string, CachedChunk> soundChunks;
 
 	Mix_Chunk *GetSoundChunk(std::string &sound, bool cache);
 


### PR DESCRIPTION
SDL_RWFromMem does not take the ownership of the passed memory, so we
have to free it ourselves.