### PR TITLE
Correcting random amount of gold in gold piles

### DIFF
--- a/lib/mapObjects/MiscObjects.cpp
+++ b/lib/mapObjects/MiscObjects.cpp
@@ -868,7 +868,7 @@ void CGResource::initObj(CRandomGenerator & rand)
 		switch(subID)
 		{
 		case 6:
-			amount = rand.nextInt(500, 1000);
+			amount = rand.nextInt(5, 10) * 100;
 			break;
 		case 0: case 2:
 			amount = rand.nextInt(6, 10);


### PR DESCRIPTION
In original H3 allowed amounts of gold in treasure piles are multipliers of 100. Before this fix gold amount can be any value from range 500-1000.