### PR TITLE
Fix morale widget update after dismissing a creature in garrison

### DIFF
--- a/client/windows/CHeroWindow.cpp
+++ b/client/windows/CHeroWindow.cpp
@@ -344,6 +344,12 @@ void CHeroWindow::commanderWindow()
 
 }
 
+void CHeroWindow::updateGarrisons()
+{
+	CWindowWithGarrison::updateGarrisons();
+	morale->set(&heroWArt);
+}
+
 void CHeroWindow::showAll(SDL_Surface * to)
 {
 	CIntObject::showAll(to);

--- a/client/windows/CHeroWindow.h
+++ b/client/windows/CHeroWindow.h
@@ -91,6 +91,7 @@ public:
 	void questlog(); //show quest log in hero window
 	void commanderWindow();
 	void switchHero(); //changes displayed hero
+	virtual void updateGarrisons() override;  //updates the morale widget and calls the parent
 
 	//friends
 	friend void CArtPlace::clickLeft(tribool down, bool previousState);


### PR DESCRIPTION
If you open the Hero window and dismiss a creature, the morale widget is not updated. E.g. if you dismiss an undead or a third confession.