### PR TITLE
[WIP] Experimental FoW refactoring

### DIFF
--- a/lib/CGameState.cpp
+++ b/lib/CGameState.cpp
@@ -1520,6 +1520,7 @@ void CGameState::removeSightnObj(const CGObjectInstance * obj)
 
 void CGameState::addSightObj(const CGObjectInstance * obj, bool add)
 {
+	assert(obj);
 	if(!vstd::contains(players, obj->tempOwner))
 		return;
 
@@ -1537,6 +1538,9 @@ void CGameState::addSightObj(TeamID team, const CGObjectInstance * obj, bool add
 	getTilesInRange(tiles, obj->getSightCenter(), obj->getSightRadius());
 	for(int3 t : tiles)
 	{
+		/// This code expect that tile can't be within sight range of more than 254 player-owned objects
+		/// Assert is best way to do these checks since if they fail that's mean code is broken
+		assert(ts->fogOfWarMap[t.x][t.y][t.z] != 255);
 		if(add)
 		{
 			if(ts->fogOfWarMap[t.x][t.y][t.z] == FoWChange::HIDDEN)
@@ -1546,6 +1550,9 @@ void CGameState::addSightObj(TeamID team, const CGObjectInstance * obj, bool add
 		}
 		else
 		{
+			/// There was no objects with sight over this tile, but for some reason we try to remove sight anyway
+			/// That's mean when ownership or sight radius of object changed sight map wasn't appropriately updated
+			assert(ts->fogOfWarMap[t.x][t.y][t.z] == FoWChange::REVEALED);
 			ts->fogOfWarMap[t.x][t.y][t.z]--;
 		}
 	}

--- a/lib/CGameState.cpp
+++ b/lib/CGameState.cpp
@@ -1539,10 +1539,10 @@ void CGameState::addSightObj(TeamID team, const CGObjectInstance * obj, bool add
 	{
 		if(add)
 		{
-			if(ts->fogOfWarMap[t.x][t.y][t.z] == 0)
-				ts->fogOfWarMap[t.x][t.y][t.z] = 2;
+			if(ts->fogOfWarMap[t.x][t.y][t.z] == FoWChange::HIDDEN)
+				ts->fogOfWarMap[t.x][t.y][t.z] = FoWChange::WITHIN_SIGHT_RANGE; //Object revealed tile
 			else
-				ts->fogOfWarMap[t.x][t.y][t.z]++;
+				ts->fogOfWarMap[t.x][t.y][t.z]++; //One more object have sight over tile
 		}
 		else
 		{

--- a/lib/CGameState.h
+++ b/lib/CGameState.h
@@ -178,6 +178,10 @@ public:
 	std::vector<CGObjectInstance*> guardingCreatures (int3 pos) const;
 	void updateRumor();
 
+	void initSightMap();
+	void addSightObj(const CGObjectInstance * obj, bool add = true);
+	void removeSightnObj(const CGObjectInstance * obj);
+
 	// ----- victory, loss condition checks -----
 
 	EVictoryLossCheckResult checkForVictoryAndLoss(PlayerColor player) const;
@@ -268,6 +272,7 @@ private:
 	void initStartingResources();
 	void initHeroes();
 	void giveCampaignBonusToHero(CGHeroInstance * hero);
+	void addSightObj(TeamID team, const CGObjectInstance * obj, bool add = true);
 	void initFogOfWar();
 	void initStartingBonus();
 	void initTowns();

--- a/lib/IGameCallback.cpp
+++ b/lib/IGameCallback.cpp
@@ -59,7 +59,7 @@ void CPrivilagedInfoCallback::getTilesInRange(std::unordered_set<int3, ShashInt3
 		logGlobal->error("Illegal call to getTilesInRange!");
 		return;
 	}
-	if (radious == -1) //reveal entire map
+	if (radious > 5000) //reveal entire map
 		getAllTiles (tiles, player, -1, 0);
 	else
 	{

--- a/lib/IGameCallback.cpp
+++ b/lib/IGameCallback.cpp
@@ -78,8 +78,8 @@ void CPrivilagedInfoCallback::getTilesInRange(std::unordered_set<int3, ShashInt3
 				if(distance <= radious)
 				{
 					if(!player
-						|| (mode == 1  && team->fogOfWarMap[xd][yd][pos.z]==0)
-						|| (mode == -1 && team->fogOfWarMap[xd][yd][pos.z]==1)
+						|| (mode == 1  && team->fogOfWarMap[xd][yd][pos.z] == 0)
+						|| (mode == -1 && team->fogOfWarMap[xd][yd][pos.z] > 0)
 					)
 						tiles.insert(int3(xd,yd,pos.z));
 				}

--- a/lib/NetPacks.h
+++ b/lib/NetPacks.h
@@ -336,6 +336,13 @@ struct FoWChange : public CPackForClient
 	void applyCl(CClient *cl);
 	DLL_LINKAGE void applyGs(CGameState *gs);
 
+	enum : ui8
+	{
+		HIDDEN = 0, //tile is hidden in fog of war
+		REVEALED = 1, //tile is visible for player
+		WITHIN_SIGHT_RANGE = 2 //at least one player-owned object have sight over tile
+	};
+
 	std::unordered_set<int3, struct ShashInt3 > tiles;
 	PlayerColor player;
 	ui8 mode; //mode==0 - hide, mode==1 - reveal

--- a/lib/NetPacksLib.cpp
+++ b/lib/NetPacksLib.cpp
@@ -218,12 +218,15 @@ DLL_LINKAGE void SetMovePoints::applyGs(CGameState *gs)
 
 DLL_LINKAGE void FoWChange::applyGs(CGameState *gs)
 {
+	assert(mode < WITHIN_SIGHT_RANGE); //Not valid mode
 	TeamState * team = gs->getPlayerTeam(player);
 	for(int3 t : tiles)
 	{
-		if(mode == 0 && team->fogOfWarMap[t.x][t.y][t.z] > 1)
+		//Tile within sight range of player-owned objects cannot be hidden
+		if(mode == HIDDEN && team->fogOfWarMap[t.x][t.y][t.z] >= WITHIN_SIGHT_RANGE)
 			continue;
-		else if(mode == 1 && team->fogOfWarMap[t.x][t.y][t.z])
+		//Don't do anything if tile is already revealed
+		if(mode == REVEALED && team->fogOfWarMap[t.x][t.y][t.z])
 			continue;
 
 		team->fogOfWarMap[t.x][t.y][t.z] = mode;

--- a/lib/mapObjects/CGTownInstance.cpp
+++ b/lib/mapObjects/CGTownInstance.cpp
@@ -1329,7 +1329,7 @@ void CGTownInstance::battleFinished(const CGHeroInstance *hero, const BattleResu
 		cb->setOwner (this, hero->tempOwner); //give control after checkout is done
 		FoWChange fw;
 		fw.player = hero->tempOwner;
-		fw.mode = 1;
+		fw.mode = FoWChange::REVEALED;
 		cb->getTilesInRange(fw.tiles, getSightCenter(), getSightRadius(), tempOwner, 1);
 		cb->sendAndApply (&fw);
 	}

--- a/lib/mapObjects/CGTownInstance.cpp
+++ b/lib/mapObjects/CGTownInstance.cpp
@@ -434,14 +434,7 @@ void CGDwelling::serializeJsonOptions(JsonSerializeFormat & handler)
 
 int CGTownInstance::getSightRadius() const //returns sight distance
 {
-	if (subID == ETownType::TOWER)
-	{
-		if (hasBuilt(BuildingID::GRAIL)) //skyship
-			return -1; //entire map
-		if (hasBuilt(BuildingID::LOOKOUT_TOWER)) //lookout tower
-			return 20;
-	}
-	return 5;
+	return 5 + valOfBonuses(Bonus::SIGHT_RADIOUS);
 }
 
 void CGTownInstance::setPropertyDer(ui8 what, ui32 val)
@@ -1089,6 +1082,8 @@ void CGTownInstance::recreateBuildingsBonuses()
 	}
 	else if(subID == ETownType::TOWER) //tower
 	{
+		addBonusIfBuilt(BuildingID::LOOKOUT_TOWER, Bonus::SIGHT_RADIOUS, +20);
+		addBonusIfBuilt(BuildingID::GRAIL, Bonus::SIGHT_RADIOUS, +5001); //more than 5000 reveal entire map
 		addBonusIfBuilt(BuildingID::GRAIL, Bonus::PRIMARY_SKILL, +15, PrimarySkill::KNOWLEDGE); //grail
 	}
 	else if(subID == ETownType::INFERNO) //Inferno

--- a/lib/mapObjects/MiscObjects.cpp
+++ b/lib/mapObjects/MiscObjects.cpp
@@ -1557,7 +1557,7 @@ void CGObservatory::onHeroVisit( const CGHeroInstance * h ) const
 
 		FoWChange fw;
 		fw.player = h->tempOwner;
-		fw.mode = 1;
+		fw.mode = FoWChange::REVEALED;
 		cb->getTilesInRange (fw.tiles, pos, 20, h->tempOwner, 1);
 		cb->sendAndApply (&fw);
 		break;
@@ -1884,7 +1884,7 @@ void CGMagi::onHeroVisit(const CGHeroInstance * h) const
 
 			FoWChange fw;
 			fw.player = h->tempOwner;
-			fw.mode = 1;
+			fw.mode = FoWChange::REVEALED;
 			fw.waitForDialogs = true;
 
 			for(auto it : eyelist[subID])
@@ -2051,7 +2051,7 @@ void CCartographer::blockingDialogAnswered(const CGHeroInstance *hero, ui32 answ
 	{
 		cb->giveResource (hero->tempOwner, Res::GOLD, -1000);
 		FoWChange fw;
-		fw.mode = 1;
+		fw.mode = FoWChange::REVEALED;
 		fw.player = hero->tempOwner;
 
 		//subIDs of different types of cartographers:

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -6291,21 +6291,6 @@ void CGameHandler::changeFogOfWar(int3 center, ui32 radius, PlayerColor player, 
 {
 	std::unordered_set<int3, ShashInt3> tiles;
 	getTilesInRange(tiles, center, radius, player, hide? -1 : 1);
-	if (hide)
-	{
-		std::unordered_set<int3, ShashInt3> observedTiles; //do not hide tiles observed by heroes. May lead to disastrous AI problems
-		auto p = getPlayer(player);
-		for (auto h : p->heroes)
-		{
-			getTilesInRange(observedTiles, h->getSightCenter(), h->getSightRadius(), h->tempOwner, -1);
-		}
-		for (auto t : p->towns)
-		{
-			getTilesInRange(observedTiles, t->getSightCenter(), t->getSightRadius(), t->tempOwner, -1);
-		}
-		for (auto tile : observedTiles)
-			vstd::erase_if_present (tiles, tile);
-	}
 	changeFogOfWar(tiles, player, hide);
 }
 

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -1698,26 +1698,6 @@ void CGameHandler::newTurn()
 		{
 			n.res[player] = n.res[player] + t->dailyIncome();
 		}
-		if (t->hasBuilt(BuildingID::GRAIL, ETownType::TOWER))
-		{
-			// Skyship, probably easier to handle same as Veil of darkness
-			//do it every new day after veils apply
-			if (player != PlayerColor::NEUTRAL) //do not reveal fow for neutral player
-			{
-				FoWChange fw;
-				fw.mode = FoWChange::REVEALED;
-				fw.player = player;
-				// find all hidden tiles
-				const auto & fow = getPlayerTeam(player)->fogOfWarMap;
-				for (size_t i=0; i<fow.size(); i++)
-					for (size_t j=0; j<fow.at(i).size(); j++)
-						for (size_t k=0; k<fow.at(i).at(j).size(); k++)
-							if (!fow.at(i).at(j).at(k))
-								fw.tiles.insert(int3(i,j,k));
-
-				sendAndApply (&fw);
-			}
-		}
 		if (t->hasBonusOfType (Bonus::DARKNESS))
 		{
 			for (auto & player : gs->players)

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -1705,7 +1705,7 @@ void CGameHandler::newTurn()
 			if (player != PlayerColor::NEUTRAL) //do not reveal fow for neutral player
 			{
 				FoWChange fw;
-				fw.mode = 1;
+				fw.mode = FoWChange::REVEALED;
 				fw.player = player;
 				// find all hidden tiles
 				const auto & fow = getPlayerTeam(player)->fogOfWarMap;
@@ -3020,7 +3020,7 @@ bool CGameHandler::buildStructure(ObjectInstanceID tid, BuildingID requestedID, 
 	// now when everything is built - reveal tiles for lookout tower
 	FoWChange fw;
 	fw.player = t->tempOwner;
-	fw.mode = 1;
+	fw.mode = FoWChange::REVEALED;
 	getTilesInRange(fw.tiles, t->getSightCenter(), t->getSightRadius(), t->tempOwner, 1);
 	sendAndApply(&fw);
 
@@ -6299,7 +6299,7 @@ void CGameHandler::changeFogOfWar(std::unordered_set<int3, ShashInt3> &tiles, Pl
 	FoWChange fow;
 	fow.tiles = tiles;
 	fow.player = player;
-	fow.mode = hide? 0 : 1;
+	fow.mode = hide ? FoWChange::HIDDEN : FoWChange::REVEALED;
 	sendAndApply(&fow);
 }
 


### PR DESCRIPTION
FoW code we have now is bad and solution I see for this is to have sight map for each team. So tiles within sight radius of owned objects would never ever covered by darkness and we don't need to re-check owned objects every time unless object themself changed.

How this should be implemented is another story. First I thought to store all tiles with sight in vector with duplicates and just add / remove them. Then I find out that current fogOfWarMap can be also used for storage since it's unlikely that we'll ever get to situation where ui8 limit wouldn't be enough.
