### PR TITLE
Improve creature upgrade handling. Fix issue #2172

### DIFF
--- a/client/windows/CCreatureWindow.cpp
+++ b/client/windows/CCreatureWindow.cpp
@@ -580,14 +580,17 @@ void CStackWindow::CWindowSection::createButtonPanel()
 				{
 					resComps.push_back(new CComponent(CComponent::resource, i->resType, i->resVal));
 				}
-				LOCPLINT->showYesNoDialog(CGI->generaltexth->allTexts[207], onUpgrade, nullptr, true, resComps);
+
+				if(LOCPLINT->cb->getResourceAmount().canAfford(totalCost))
+				{	
+					LOCPLINT->showYesNoDialog(CGI->generaltexth->allTexts[207], onUpgrade, nullptr, true, resComps);
+				}
+				else
+					LOCPLINT->showInfoDialog(CGI->generaltexth->allTexts[314], resComps);
 			};
 			auto upgradeBtn = new CButton(Point(221 + i * 40, 5), "stackWindow/upgradeButton", CGI->generaltexth->zelp[446], onClick, SDLK_1);
 
 			upgradeBtn->addOverlay(new CAnimImage("CPRSMALL", VLC->creh->creatures[upgradeInfo.info.newID[i]]->iconIndex));
-
-			if (!LOCPLINT->cb->getResourceAmount().canAfford(totalCost))
-				upgradeBtn->block(true);
 		}
 	}
 


### PR DESCRIPTION
Now when clicking upgrade button while insufficient resources, information dialog will show up, saying that upgrade is impossible and upgrade cost gets displayed.