### PR TITLE
Add myself to AUTHORS

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -5,7 +5,7 @@ Michał Urbańczyk aka Tow,        <impono@gmail.com>
 maintenance, reverse engineering, general support.
 
 Mateusz B. aka Tow dragon,                <matcio1@gmail.com>
-   * general suport, battle support, support for many Heroes 3 config files, reverse engineering, ERM/VERM parser and interpreter
+   * general support, battle support, support for many Heroes 3 config files, reverse engineering, ERM/VERM parser and interpreter
 
 Stefan Pavlov aka Ste,            <mailste@gmail.com>
    * minor fixes in pregame
@@ -54,3 +54,6 @@ Alexander Shishkin aka alexvins,
 
 Arseniy Shestakov aka SXX,      <me@arseniyshestakov.com>
    * pathfinding improvements, programming
+
+Vadim Markovtsev, <gmarkhor@gmail.com>
+   * resolving problems with macOS, bug fixes


### PR DESCRIPTION
Suggested in #220.

Spelling Mac OS X as "macOS" because it was renamed in 2016: https://en.wikipedia.org/wiki/Mac_OS 