### PR TITLE
Fix freshly recruited hero phantom in castle entrance

### DIFF
--- a/client/NetPacksClient.cpp
+++ b/client/NetPacksClient.cpp
@@ -494,13 +494,19 @@ void HeroRecruited::applyCl( CClient *cl )
 		logNetwork->errorStream() << "Something wrong with hero recruited!";
 	}
 
-	CGI->mh->printObject(h);
-
-	if(vstd::contains(cl->playerint,h->tempOwner))
+	bool needsPrinting = true;
+	if(vstd::contains(cl->playerint, h->tempOwner))
 	{
 		cl->playerint[h->tempOwner]->heroCreated(h);
 		if(const CGTownInstance *t = GS(cl)->getTown(tid))
+		{
 			cl->playerint[h->tempOwner]->heroInGarrisonChange(t);
+			needsPrinting = false;
+		}
+	}
+	if (needsPrinting)
+	{
+		CGI->mh->printObject(h);
 	}
 }
 

--- a/client/mapHandler.h
+++ b/client/mapHandler.h
@@ -386,7 +386,7 @@ public:
 
 	void getTerrainDescr(const int3 &pos, std::string & out, bool terName); //if tername == false => empty string when tile is clear
 	CGObjectInstance * createObject(int id, int subid, int3 pos, int owner=254); //creates a new object with a certain id and subid
-	bool printObject(const CGObjectInstance * obj, bool fadein = false); //puts appropriate things to ttiles, so obj will be visible on map
+	bool printObject(const CGObjectInstance * obj, bool fadein = false); //puts appropriate things to tiles, so obj will be visible on map
 	bool hideObject(const CGObjectInstance * obj, bool fadeout = false); //removes appropriate things from ttiles, so obj will be no longer visible on map (but still will exist)
 	bool removeObject(CGObjectInstance * obj, bool fadeout = false); //removes object from each place in VCMI (I hope)
 	void init();


### PR DESCRIPTION
Currently if you hire a hero and go out from the castle, there will be a phantom hero in the entrance which copies the state and movement of the real one. This is because of the double printing. heroInGarrisonChange() prints the new hero for the second time, so we should check if heroInGarrisonChange() is called and not print in applyCl() then.