### PR TITLE
Bug fix for berserk:

### DIFF
--- a/lib/CBattleCallback.cpp
+++ b/lib/CBattleCallback.cpp
@@ -1366,7 +1366,7 @@ std::pair<const CStack *, BattleHex> CBattleInfoCallback::getNearestStack(const 
 		for(BattleHex hex : avHexes)
 			if(CStack::isMeleeAttackPossible(closest, st, hex))
 			{
-				DistStack hlp = {reachability.distances[st->position], hex, st};
+				DistStack hlp = {reachability.distances[hex], hex, st};
 				stackPairs.push_back(hlp);
 			}
 


### PR DESCRIPTION
Fixed the issue that the berserk affected stack won't attack the nearest live stack. (The distance should be calculated as the distance between affected stack's position and the hex position reachable for this stack)