### PR TITLE
Fix segfault/assertion failure during battle

### DIFF
--- a/server/CGameHandler.h
+++ b/server/CGameHandler.h
@@ -279,7 +279,7 @@ public:
 
 	void run(bool resume);
 	void newTurn();
-	void handleAttackBeforeCasting (const BattleAttack & bat);
+	void handleAttackBeforeCasting(BattleAttack *bat);
 	void handleAfterAttackCasting (const BattleAttack & bat);
 	void attackCasting(const BattleAttack & bat, Bonus::BonusType attackMode, const CStack * attacker);
 	bool sacrificeArtifact(const IMarket * m, const CGHeroInstance * hero, ArtifactPosition slot);


### PR DESCRIPTION
The cause of the assertion failure at BattleStackAttacked::applyGs "at"
was shooting and casting some spell in handleAttackBeforeCasting() and
eventually killing the whole stack. Fix: filter dead stacks in the end of
handleAttackBeforeCasting().