### PR TITLE
Fix issue #2068 - maps list update

### DIFF
--- a/client/CPreGame.cpp
+++ b/client/CPreGame.cpp
@@ -1103,6 +1103,10 @@ void SelectionTab::filter( int size, bool selectFirst )
 std::unordered_set<ResourceID> SelectionTab::getFiles(std::string dirURI, int resType)
 {
 	boost::to_upper(dirURI);
+	CResourceHandler::get()->updateFilteredFiles([&](const std::string & mount)
+	{
+		return boost::algorithm::starts_with(mount, dirURI);
+	});
 
 	std::unordered_set<ResourceID> ret = CResourceHandler::get()->getFilteredFiles([&](const ResourceID & ident)
 	{
@@ -1115,6 +1119,7 @@ std::unordered_set<ResourceID> SelectionTab::getFiles(std::string dirURI, int re
 
 void SelectionTab::parseMaps(const std::unordered_set<ResourceID> &files)
 {
+	logGlobal->debug("Parsing %d maps", files.size());
 	allItems.clear();
 	for(auto & file : files)
 	{

--- a/client/CPreGame.h
+++ b/client/CPreGame.h
@@ -153,7 +153,7 @@ class SelectionTab : public CIntObject
 private:
 	std::unique_ptr<CAnimation> formatIcons;
 
-    void parseMaps(const std::unordered_set<ResourceID> &files);
+	void parseMaps(const std::unordered_set<ResourceID> &files);
 	void parseGames(const std::unordered_set<ResourceID> &files, bool multi);
 	void parseCampaigns(const std::unordered_set<ResourceID> & files );
 	std::unordered_set<ResourceID> getFiles(std::string dirURI, int resType);

--- a/lib/filesystem/AdapterLoaders.cpp
+++ b/lib/filesystem/AdapterLoaders.cpp
@@ -102,6 +102,12 @@ std::set<boost::filesystem::path> CFilesystemList::getResourceNames(const Resour
 	return std::move(paths);
 }
 
+void CFilesystemList::updateFilteredFiles(std::function<bool(const std::string &)> filter) const
+{
+	for (auto & loader : loaders)
+		loader->updateFilteredFiles(filter);
+}
+
 std::unordered_set<ResourceID> CFilesystemList::getFilteredFiles(std::function<bool(const ResourceID &)> filter) const
 {
 	std::unordered_set<ResourceID> ret;

--- a/lib/filesystem/AdapterLoaders.h
+++ b/lib/filesystem/AdapterLoaders.h
@@ -41,6 +41,7 @@ public:
 	bool existsResource(const ResourceID & resourceName) const override;
 	std::string getMountPoint() const override;
 	boost::optional<boost::filesystem::path> getResourceName(const ResourceID & resourceName) const override;
+	void updateFilteredFiles(std::function<bool(const std::string &)> filter) const override {}
 	std::unordered_set<ResourceID> getFilteredFiles(std::function<bool(const ResourceID &)> filter) const override;
 
 private:
@@ -71,6 +72,7 @@ public:
 	std::string getMountPoint() const override;
 	boost::optional<boost::filesystem::path> getResourceName(const ResourceID & resourceName) const override;
 	std::set<boost::filesystem::path> getResourceNames(const ResourceID & resourceName) const override;
+	void updateFilteredFiles(std::function<bool(const std::string &)> filter) const override;
 	std::unordered_set<ResourceID> getFilteredFiles(std::function<bool(const ResourceID &)> filter) const override;
 	bool createResource(std::string filename, bool update = false) override;
 	std::vector<const ISimpleResourceLoader *> getResourcesWithName(const ResourceID & resourceName) const override;

--- a/lib/filesystem/CArchiveLoader.h
+++ b/lib/filesystem/CArchiveLoader.h
@@ -61,6 +61,7 @@ public:
 	std::unique_ptr<CInputStream> load(const ResourceID & resourceName) const override;
 	bool existsResource(const ResourceID & resourceName) const override;
 	std::string getMountPoint() const override;
+	void updateFilteredFiles(std::function<bool(const std::string &)> filter) const override {}
 	std::unordered_set<ResourceID> getFilteredFiles(std::function<bool(const ResourceID &)> filter) const override;
 
 private:

--- a/lib/filesystem/CFilesystemLoader.cpp
+++ b/lib/filesystem/CFilesystemLoader.cpp
@@ -8,10 +8,10 @@ namespace bfs = boost::filesystem;
 
 CFilesystemLoader::CFilesystemLoader(std::string _mountPoint, bfs::path baseDirectory, size_t depth, bool initial):
     baseDirectory(std::move(baseDirectory)),
-	mountPoint(std::move(_mountPoint)),
+    mountPoint(std::move(_mountPoint)),
     fileList(listFiles(mountPoint, depth, initial))
 {
-	logGlobal->traceStream() << "Filesystem loaded, " << fileList.size() << " files found";
+	logGlobal->traceStream() << "File system loaded, " << fileList.size() << " files found";
 }
 
 std::unique_ptr<CInputStream> CFilesystemLoader::load(const ResourceID & resourceName) const
@@ -36,6 +36,14 @@ boost::optional<boost::filesystem::path> CFilesystemLoader::getResourceName(cons
 	assert(existsResource(resourceName));
 
 	return baseDirectory / fileList.at(resourceName);
+}
+
+void CFilesystemLoader::updateFilteredFiles(std::function<bool(const std::string &)> filter) const
+{
+	if (filter(mountPoint))
+	{
+		fileList = listFiles(mountPoint, 1, false);
+	}
 }
 
 std::unordered_set<ResourceID> CFilesystemLoader::getFilteredFiles(std::function<bool(const ResourceID &)> filter) const

--- a/lib/filesystem/CFilesystemLoader.h
+++ b/lib/filesystem/CFilesystemLoader.h
@@ -38,6 +38,7 @@ public:
 	std::string getMountPoint() const override;
 	bool createResource(std::string filename, bool update = false) override;
 	boost::optional<boost::filesystem::path> getResourceName(const ResourceID & resourceName) const override;
+	void updateFilteredFiles(std::function<bool(const std::string &)> filter) const override;
 	std::unordered_set<ResourceID> getFilteredFiles(std::function<bool(const ResourceID &)> filter) const override;
 
 private:
@@ -50,7 +51,7 @@ private:
 	 * key = ResourceID for resource loader
 	 * value = name that can be used to access file
 	*/
-	std::unordered_map<ResourceID, boost::filesystem::path> fileList;
+	mutable std::unordered_map<ResourceID, boost::filesystem::path> fileList;
 
 	/**
 	 * Returns a list of pathnames denoting the files in the directory denoted by this pathname.

--- a/lib/filesystem/CZipLoader.h
+++ b/lib/filesystem/CZipLoader.h
@@ -56,6 +56,7 @@ public:
 	std::unique_ptr<CInputStream> load(const ResourceID & resourceName) const override;
 	bool existsResource(const ResourceID & resourceName) const override;
 	std::string getMountPoint() const override;
+	void updateFilteredFiles(std::function<bool(const std::string &)> filter) const override {}
 	std::unordered_set<ResourceID> getFilteredFiles(std::function<bool(const ResourceID &)> filter) const override;
 };
 

--- a/lib/filesystem/ISimpleResourceLoader.h
+++ b/lib/filesystem/ISimpleResourceLoader.h
@@ -70,7 +70,14 @@ public:
 	}
 
 	/**
-	 * Get list of files that matches filter function
+	 * Update lists of files that match filter function
+	 *
+	 * @param filter Filter that returns true if specified mount point matches filter
+	 */
+	virtual void updateFilteredFiles(std::function<bool(const std::string &)> filter) const = 0;
+
+	/**
+	 * Get list of files that match filter function
 	 *
 	 * @param filter Filter that returns true if specified ID matches filter
 	 * @return Returns list of flies


### PR DESCRIPTION
http://bugs.vcmi.eu/view.php?id=2068#c6839

I have no idea why the maps list was updated on Windows - I see no way it could. Added explicit rescan with filtering. It allows updating ZIP archive contents on the fly (not implemented).