### PR TITLE
Extend creature siege support. Fix bug #2600

### DIFF
--- a/config/bonuses_texts.json
+++ b/config/bonuses_texts.json
@@ -17,6 +17,12 @@
 		"name": "Additional retaliations",
 		"description": "May Retaliate ${val} extra times"
 	},
+	
+	"ADVANCED_CATAPULT":
+	{
+		"name": "Advanced wall breaker",
+		"description": "Can hit siege walls ${val} extra times per attack"
+	},
 
 	"AIR_IMMUNITY":
 	{

--- a/config/bonuses_texts.json
+++ b/config/bonuses_texts.json
@@ -18,9 +18,9 @@
 		"description": "May Retaliate ${val} extra times"
 	},
 	
-	"ADVANCED_CATAPULT":
+	"CATAPULT_EXTRA_SHOTS":
 	{
-		"name": "Advanced wall breaker",
+		"name": "Additional siege attacks",
 		"description": "Can hit siege walls ${val} extra times per attack"
 	},
 

--- a/config/creatures/stronghold.json
+++ b/config/creatures/stronghold.json
@@ -273,7 +273,7 @@
 		{
 			"siegeDoubleAttack" :
 			{
-				"type" : "ADVANCED_CATAPULT",
+				"type" : "CATAPULT_EXTRA_SHOTS",
 				"val" : 1
 			}
 		},

--- a/config/creatures/stronghold.json
+++ b/config/creatures/stronghold.json
@@ -269,6 +269,14 @@
 		"index": 95,
 		"level": 6,
 		"faction": "stronghold",
+		"abilities":
+		{
+			"siegeDoubleAttack" :
+			{
+				"type" : "ADVANCED_CATAPULT",
+				"val" : 1
+			}
+		},
 		"graphics" :
 		{
 			"animation": "CCYCLLOR.DEF",

--- a/lib/HeroBonus.h
+++ b/lib/HeroBonus.h
@@ -216,6 +216,7 @@ public:
 	BONUS_NAME(DISGUISED) /* subtype - spell level */\
 	BONUS_NAME(VISIONS) /* subtype - spell level */\
 	BONUS_NAME(NO_TERRAIN_PENALTY) /* subtype - terrain type */\
+	BONUS_NAME(ADVANCED_CATAPULT) /*val - number of additional shots, requires CATAPULT bonus to work*/\
 	/* end of list */
 
 

--- a/lib/HeroBonus.h
+++ b/lib/HeroBonus.h
@@ -216,7 +216,7 @@ public:
 	BONUS_NAME(DISGUISED) /* subtype - spell level */\
 	BONUS_NAME(VISIONS) /* subtype - spell level */\
 	BONUS_NAME(NO_TERRAIN_PENALTY) /* subtype - terrain type */\
-	BONUS_NAME(ADVANCED_CATAPULT) /*val - number of additional shots, requires CATAPULT bonus to work*/\
+	BONUS_NAME(CATAPULT_EXTRA_SHOTS) /*val - number of additional shots, requires CATAPULT bonus to work*/\
 	/* end of list */
 
 

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -3954,7 +3954,15 @@ bool CGameHandler::makeBattleAction(BattleAction &ba)
 			auto wrapper = wrapAction(ba);
 
 			const CGHeroInstance * attackingHero = gs->curB->battleGetFightingHero(ba.side);
-			CHeroHandler::SBallisticsLevelInfo sbi = VLC->heroh->ballistics.at(attackingHero->getSecSkillLevel(SecondarySkill::BALLISTICS));
+
+			CHeroHandler::SBallisticsLevelInfo sbi;
+			if(stack->getCreature()->idNumber == CreatureID::CATAPULT)
+				sbi = VLC->heroh->ballistics.at(attackingHero->getSecSkillLevel(SecondarySkill::BALLISTICS));
+			else //may need to use higher ballistics level for creatures in future for some cases to match original H3 (upgraded cyclops etc)
+			{
+				sbi = VLC->heroh->ballistics.at(1);
+				sbi.shots += std::max(stack->valOfBonuses(Bonus::ADVANCED_CATAPULT), 0);
+			}
 
 			auto wallPart = gs->curB->battleHexToWallPart(ba.destinationTile);
 			if (!gs->curB->isWallPartPotentiallyAttackable(wallPart))

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -3961,7 +3961,7 @@ bool CGameHandler::makeBattleAction(BattleAction &ba)
 			else //may need to use higher ballistics level for creatures in future for some cases to match original H3 (upgraded cyclops etc)
 			{
 				sbi = VLC->heroh->ballistics.at(1);
-				sbi.shots += std::max(stack->valOfBonuses(Bonus::ADVANCED_CATAPULT), 0);
+				sbi.shots += std::max(stack->valOfBonuses(Bonus::CATAPULT_EXTRA_SHOTS), 0);
 			}
 
 			auto wallPart = gs->curB->battleHexToWallPart(ba.destinationTile);


### PR DESCRIPTION
Make ballistics skill apply only to catapult, add new skill to handle multi attack on siege walls for creatures, fix cyclop kings