### PR TITLE
Feature: allow hero to properly give "shooter" bonus to units that usually dont shoot

### DIFF
--- a/client/battle/CBattleAnimations.cpp
+++ b/client/battle/CBattleAnimations.cpp
@@ -798,6 +798,9 @@ bool CShootingAnimation::init()
 	auto & angles = shooterInfo->animation.missleFrameAngles;
 	double pi = boost::math::constants::pi<double>();
 
+	if (owner->idToProjectile.count(spi.creID) == 0) //in some cases (known one: hero grants shooter bonus to unit) the shooter stack's projectile may not be properly initialized
+		owner->initStackProjectile(shooter);
+
 	// only frames below maxFrame are usable: anything  higher is either no present or we don't know when it should be used
 	size_t maxFrame = std::min<size_t>(angles.size(), owner->idToProjectile.at(spi.creID)->ourImages.size());
 

--- a/client/battle/CBattleInterface.cpp
+++ b/client/battle/CBattleInterface.cpp
@@ -985,20 +985,25 @@ void CBattleInterface::newStack(const CStack *stack)
 	//loading projectiles for units
 	if (stack->getCreature()->isShooting())
 	{
-		CDefHandler *&projectile = idToProjectile[stack->getCreature()->idNumber];
+		initStackProjectile(stack);
+	}
+}
 
-		const CCreature *creature;//creature whose shots should be loaded
-		if (stack->getCreature()->idNumber == CreatureID::ARROW_TOWERS)
-			creature = CGI->creh->creatures[siegeH->town->town->clientInfo.siegeShooter];
-		else
-			creature = stack->getCreature();
+void CBattleInterface::initStackProjectile(const CStack * stack)
+{
+	CDefHandler *&projectile = idToProjectile[stack->getCreature()->idNumber];
 
-		projectile = CDefHandler::giveDef(creature->animation.projectileImageName);
+	const CCreature *creature;//creature whose shots should be loaded
+	if (stack->getCreature()->idNumber == CreatureID::ARROW_TOWERS)
+		creature = CGI->creh->creatures[siegeH->town->town->clientInfo.siegeShooter];
+	else
+		creature = stack->getCreature();
 
-		for (auto & elem : projectile->ourImages) //alpha transforming
-		{
-			CSDL_Ext::alphaTransform(elem.bitmap);
-		}
+	projectile = CDefHandler::giveDef(creature->animation.projectileImageName);
+
+	for (auto & elem : projectile->ourImages) //alpha transforming
+	{
+		CSDL_Ext::alphaTransform(elem.bitmap);
 	}
 }
 

--- a/client/battle/CBattleInterface.h
+++ b/client/battle/CBattleInterface.h
@@ -363,6 +363,8 @@ public:
 
 	void gateStateChanged(const EGateState state);
 
+	void initStackProjectile(const CStack *stack);
+
 	const CGHeroInstance *currentHero() const;
 	InfoAboutHero enemyHero() const;
 


### PR DESCRIPTION
Currently when unit can shoot because of hero bonus, the projectile is not properly initialized and that causes game to crash. This code tries to force load projectile data before crash can occur.