### PR TITLE
Restart button hacky fix

### DIFF
--- a/client/CMT.cpp
+++ b/client/CMT.cpp
@@ -1179,7 +1179,8 @@ static void handleEvent(SDL_Event & ev)
 			{
 				StartInfo si = *client->getStartInfo(true);
 				endGame();
-				startGame(&si);
+				boost::this_thread::sleep_for(boost::chrono::seconds(1)); //TODO: replace with check if game closed on server side and delay until it is done
+				startGame(&si); //it seems without above line it is likely for game to start before server is fully closed, and that causes game quit on some machines
 			}
 			break;
 		case PREPARE_RESTART_CAMPAIGN:

--- a/client/CMT.cpp
+++ b/client/CMT.cpp
@@ -1178,6 +1178,7 @@ static void handleEvent(SDL_Event & ev)
 		case RESTART_GAME:
 			{
 				StartInfo si = *client->getStartInfo(true);
+				si.seedToBeUsed = 0; //server gives new random generator seed if 0
 				endGame();
 				boost::this_thread::sleep_for(boost::chrono::seconds(1)); //TODO: replace with check if game closed on server side and delay until it is done
 				startGame(&si); //it seems without above line it is likely for game to start before server is fully closed, and that causes game quit on some machines


### PR DESCRIPTION
On some machines restart scenario button closes VCMI. This happens probably because server is not fully closed when code assumes it is (game not completely ended when starting it again). Added 1 second delay on restart, which should cause the button to work correctly most of the time.