### PR TITLE
Counterattack correction. Fixes bug #2501

### DIFF
--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -3953,7 +3953,7 @@ bool CGameHandler::makeBattleAction(BattleAction &ba)
 				}
 
 				//counterattack
-				if (destinationStack
+				if (i == 0 && destinationStack
 					&& !stack->hasBonusOfType(Bonus::BLOCKS_RETALIATION)
 					&& destinationStack->ableToRetaliate()
 					&& stack->alive()) //attacker may have died (fire shield)


### PR DESCRIPTION
Creatures should not be able to counterattack multiple times during one opponent attack under any circumstances.