### PR TITLE
Improve .spec file

### DIFF
--- a/rpm/vcmi.spec
+++ b/rpm/vcmi.spec
@@ -1,52 +1,76 @@
-Summary:			VCMI is an open-source project aiming to reimplement HoMM3 game engine, giving it new and extended possibilities.
-Name:				vcmi
-Version:			0.99
-Release:			1%{?dist}
-License:			GPLv2+
-Group:				Amusements/Games
-
-%define _unpackaged_files_terminate_build 0
-
-# The source for this package was pulled from upstream's vcs.  Use the
-# following commands to generate the tarball:
-#  wget https://github.com/vcmi/vcmi/archive/0.98.tar.gz
-#  tar -xzf 0.98.tar.gz vcmi-0.98-1
-Source:				vcmi-0.98-1.tar.gz
-
-URL:				http://forum.vcmi.eu/portal.php
-
-BuildRequires:		cmake
-BuildRequires:		gcc-c++ >= 4.7.2
-BuildRequires:		SDL2-devel
-BuildRequires:		SDL2_image-devel
-BuildRequires:		SDL2_ttf-devel
-BuildRequires:		SDL2_mixer-devel
-BuildRequires:		boost >= 1.51
-BuildRequires:		boost-devel >= 1.51
-BuildRequires:		boost-filesystem >= 1.51
-BuildRequires:		boost-iostreams >= 1.51
-BuildRequires:		boost-system >= 1.51
-BuildRequires:		boost-thread >= 1.51
-BuildRequires:		boost-program-options >= 1.51
-BuildRequires:		boost-locale >= 1.51
-BuildRequires:		zlib-devel
-BuildRequires:		ffmpeg-devel
-BuildRequires:		ffmpeg-libs
-BuildRequires:		qt5-qtbase-devel
+Summary:            Rewrite of the Heroes of Might and Magic 3 engine
+Name:               vcmi
+Version:            0.99
+Release:            2%{?dist}
+License:            GPLv2+
+Source:             https://github.com/vcmi/%{name}/archive/%{version}/%{name}-%{version}.tar.gz
+URL:                http://forum.vcmi.eu/portal.php
+BuildRequires:      cmake
+BuildRequires:      pkgconfig(sdl2)
+BuildRequires:      pkgconfig(SDL2_image)
+BuildRequires:      pkgconfig(SDL2_ttf)
+BuildRequires:      pkgconfig(SDL2_mixer)
+BuildRequires:      boost-devel >= 1.51
+BuildRequires:      pkgconfig(zlib)
+BuildRequires:      pkgconfig(libavcodec)
+BuildRequires:      pkgconfig(libavformat)
+BuildRequires:      pkgconfig(libavdevice)
+BuildRequires:      pkgconfig(libavutil)
+BuildRequires:      pkgconfig(libswscale)
+BuildRequires:      pkgconfig(libpostproc)
+BuildRequires:      pkgconfig(minizip)
+BuildRequires:      pkgconfig(Qt5Core)
+BuildRequires:      pkgconfig(Qt5Gui)
+BuildRequires:      pkgconfig(Qt5Widgets)
+BuildRequires:      pkgconfig(Qt5Network)
+BuildRequires:      desktop-file-utils
 
 %description
-VCMI is an open-source project aiming to reimplement HoMM3 game engine, giving it new and extended possibilities.
+The purpose of VCMI project is to rewrite entire HOMM 3: WoG engine from
+scratch, giving it new and extended possibilities. It will help to support
+mods and new towns already made by fans but abandoned because of game code
+limitations.
+
+In its current state it already supports maps of any sizes, higher
+resolutions and extended engine limits.
 
 %prep
-%setup -q -n %{name}-%{version}-1
+%autosetup -p1
 
 %build
-cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=/usr -DENABLE_TEST=0 ./
+%cmake -DENABLE_TEST=0 -DCMAKE_SKIP_RPATH=OFF -UCMAKE_INSTALL_LIBDIR
 make %{?_smp_mflags}
 
 %install
-rm -rf %{buildroot}
-make DESTDIR=%{buildroot} install
+%if 0%{?suse_version}
+%cmake_install
+%else
+%make_install
+%endif
+
+# drop fuzzylite artifacts
+rm -fr %{buildroot}%{_includedir}
+rm -f %{buildroot}%{_libdir}/*.a
+
+%check
+# Menu file is being installed when make install
+# so it need only to check this allready installed file
+desktop-file-validate %{buildroot}%{_datadir}/applications/vcmiclient.desktop
+desktop-file-validate %{buildroot}%{_datadir}/applications/vcmilauncher.desktop
+
+%post
+/bin/touch --no-create %{_datadir}/icons/hicolor &>/dev/null || :
+/usr/bin/update-desktop-database &> /dev/null || :
+
+%postun
+if [ $1 -eq 0 ] ; then
+    /bin/touch --no-create %{_datadir}/icons/hicolor &>/dev/null
+    /usr/bin/gtk-update-icon-cache %{_datadir}/icons/hicolor &>/dev/null || :
+fi
+/usr/bin/update-desktop-database &> /dev/null || :
+
+%posttrans
+/usr/bin/gtk-update-icon-cache %{_datadir}/icons/hicolor &>/dev/null || :
 
 %files
 %doc README.md README.linux license.txt AUTHORS ChangeLog
@@ -54,13 +78,25 @@ make DESTDIR=%{buildroot} install
 %{_bindir}/vcmiserver
 %{_bindir}/vcmibuilder
 %{_bindir}/vcmilauncher
-%{_libdir}/%{name}/*
-
-%{_datadir}/%{name}/*
+%{_libdir}/%{name}
+%{_datadir}/%{name}
 %{_datadir}/applications/*
-%{_datadir}/icons/*
+%{_datadir}/icons/hicolor/*/apps/*
+%if 0%{?suse_version}
+%dir %{_datadir}/icons/hicolor
+%dir %{_datadir}/icons/hicolor/32x32
+%dir %{_datadir}/icons/hicolor/32x32/apps
+%dir %{_datadir}/icons/hicolor/48x48
+%dir %{_datadir}/icons/hicolor/48x48/apps
+%dir %{_datadir}/icons/hicolor/64x64
+%dir %{_datadir}/icons/hicolor/64x64/apps
+%dir %{_datadir}/icons/hicolor/256x256
+%dir %{_datadir}/icons/hicolor/256x256/apps
+%endif
 
 %changelog
+* Fri Feb 17 2017 - 0.99-2
+- Common spec for openSUSE and Fedora
 
 * Tue Nov 01 2016 VCMI - 0.99-1
 - New upstream release


### PR DESCRIPTION
Now rpm can be build for Fedora and openSUSE.