### PR TITLE
Fix bug #2476 (2nd solution)

### DIFF
--- a/client/gui/CGuiHandler.cpp
+++ b/client/gui/CGuiHandler.cpp
@@ -370,7 +370,7 @@ void CGuiHandler::handleMoveInterested(const SDL_MouseMotionEvent & motion)
 	std::list<CIntObject*> miCopy = motioninterested;
 	for(auto & elem : miCopy)
 	{
-		if ((elem)->strongInterest || isItIn(&(elem)->pos, motion.x, motion.y))
+		if ((elem)->strongInterest || isItIn(&(elem)->pos, motion.x-1, motion.y-1)) //-1 offset to include lower bound, fixes bug #2476
 		{
 			(elem)->mouseMoved(motion);
 		}


### PR DESCRIPTION
This commit allows lower position bounds to raise mouseMoved events for interface objects (there aren't many objects which use that). This fixes bug #2476. It even improves battle hex behavior when mouse is between two of them.