### PR TITLE
Fix game crash after autofight in the battle.

### DIFF
--- a/client/battle/CBattleInterface.cpp
+++ b/client/battle/CBattleInterface.cpp
@@ -1234,8 +1234,8 @@ void CBattleInterface::battleFinished(const BattleResult& br)
 		auto unlockPim = vstd::makeUnlockGuard(*CPlayerInterface::pim);
 		animsAreDisplayed.waitUntil(false);
 	}
-	displayBattleFinished();
 	setActiveStack(nullptr);
+	displayBattleFinished();
 }
 
 void CBattleInterface::displayBattleFinished()


### PR DESCRIPTION
Vcmi makes crash when I turn on autofight in the battle and wait until I
close result battle window.