### PR TITLE
Added option for saving generated maps on client side

### DIFF
--- a/client/Client.cpp
+++ b/client/Client.cpp
@@ -408,10 +408,9 @@ void CClient::newGame( CConnection *con, StartInfo *si )
 
 	// Initialize game state
 	gs = new CGameState();
-	logNetwork->infoStream() <<"\tCreating gamestate: "<<tmh.getDiff();
+	logNetwork->info("\tCreating gamestate: %i",tmh.getDiff());
 
-	gs->scenarioOps = si;
-	gs->init(si);
+	gs->init(si, settings["general"]["saveRandomMaps"].Bool());
 	logNetwork->infoStream() <<"Initializing GameState (together): "<<tmh.getDiff();
 
 	// Now after possible random map gen, we know exact player count.

--- a/config/schemas/settings.json
+++ b/config/schemas/settings.json
@@ -5,8 +5,8 @@
 	"$schema": "http://json-schema.org/draft-04/schema",
 	"required" : [ "general", "video", "adventure", "pathfinder", "battle", "server", "logging", "launcher" ],
 	"definitions" : {
-		"logLevelEnum" : { 
-			"type" : "string", 
+		"logLevelEnum" : {
+			"type" : "string",
 			"enum" : [ "trace", "debug", "info", "warn", "error" ]
 		}
 	},
@@ -17,7 +17,7 @@
 			"type" : "object",
 			"default": {},
 			"additionalProperties" : false,
-			"required" : [ "playerName", "showfps", "music", "sound", "encoding", "swipe" ],
+			"required" : [ "playerName", "showfps", "music", "sound", "encoding", "swipe", "saveRandomMaps" ],
 			"properties" : {
 				"playerName" : {
 					"type":"string",
@@ -43,6 +43,10 @@
 					"type" : "boolean",
 					"default" : false
 				},
+				"saveRandomMaps" : {
+					"type" : "boolean",
+					"default" : false
+				}
 			}
 		},
 		"video" : {

--- a/lib/CGameState.h
+++ b/lib/CGameState.h
@@ -201,7 +201,7 @@ public:
 	CGameState();
 	virtual ~CGameState();
 
-	void init(StartInfo * si);
+	void init(StartInfo * si, bool allowSavingRandomMap = false);
 
 	ConstTransitivePtr<StartInfo> scenarioOps, initialOpts; //second one is a copy of settings received from pregame (not randomized)
 	PlayerColor currentPlayer; //ID of player currently having turn
@@ -283,7 +283,7 @@ private:
 
 	// ----- initialization -----
 
-	void initNewGame();
+	void initNewGame(bool allowSavingRandomMap);
 	void initCampaign();
 	void initDuel();
 	void checkMapChecksum();

--- a/lib/mapping/CMapService.h
+++ b/lib/mapping/CMapService.h
@@ -69,6 +69,7 @@ public:
 	 */
 	static std::unique_ptr<CMapHeader> loadMapHeader(const ui8 * buffer, int size, const std::string & name);
 
+	static void saveMap(const std::unique_ptr<CMap> & map, boost::filesystem::path fullPath);
 private:
 	/**
 	 * Gets a map input stream object specified by a map name.

--- a/lib/mapping/MapFormatJson.cpp
+++ b/lib/mapping/MapFormatJson.cpp
@@ -1212,6 +1212,8 @@ void CMapSaverJson::saveMap(const std::unique_ptr<CMap>& map)
 
 void CMapSaverJson::writeHeader()
 {
+	logGlobal->trace("Saving header");
+
 	JsonNode header;
 	JsonSerializer handler(mapObjectResolver.get(), header);
 
@@ -1283,6 +1285,7 @@ JsonNode CMapSaverJson::writeTerrainLevel(const int index)
 
 void CMapSaverJson::writeTerrain()
 {
+	logGlobal->trace("Saving terrain");
 	//todo: multilevel map save support
 
 	JsonNode surface = writeTerrainLevel(0);
@@ -1297,12 +1300,14 @@ void CMapSaverJson::writeTerrain()
 
 void CMapSaverJson::writeObjects()
 {
+	logGlobal->trace("Saving objects");
 	JsonNode data(JsonNode::DATA_STRUCT);
 
 	JsonSerializer handler(mapObjectResolver.get(), data);
 
 	for(CGObjectInstance * obj : map->objects)
 	{
+		logGlobal->trace("\t%s", obj->instanceName);
 		auto temp = handler.enterStruct(obj->instanceName);
 
 		obj->serializeJson(handler);


### PR DESCRIPTION
* new configuration option 'general.saveRandomMaps'
* maps being saved to 'userCachePath/RandomMaps'
* no deletion of old random maps
* map filename generated based on template name and random seed