### PR TITLE
Adventure map swipe support for non-android platforms

### DIFF
--- a/client/VCMI_client.vcxproj
+++ b/client/VCMI_client.vcxproj
@@ -292,6 +292,4 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
-  <ImportGroup Label="ExtensionTargets">
-  </ImportGroup>
 </Project>

--- a/client/VCMI_client.vcxproj.filters
+++ b/client/VCMI_client.vcxproj.filters
@@ -109,17 +109,10 @@
       <Filter>gui</Filter>
     </ClCompile>
     <ClCompile Include="..\CCallback.cpp" />
-  </ItemGroup>
-  <ItemGroup>
-    <ClCompile Include="CQuestLog.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
+    <ClCompile Include="SDLRWwrapper.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="VCMI_client.rc" />
-    <ClInclude Include="CQuestLog.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="vcmi.ico" />
@@ -254,5 +247,6 @@
       <Filter>gui</Filter>
     </ClInclude>
     <ClInclude Include="..\CCallback.h" />
+    <ClInclude Include="SDLRWwrapper.h" />
   </ItemGroup>
 </Project>

--- a/client/gui/CGuiHandler.h
+++ b/client/gui/CGuiHandler.h
@@ -10,6 +10,7 @@ class CIntObject;
 class IUpdateable;
 class IShowActivatable;
 class IShowable;
+enum class EIntObjMouseBtnType;
 template <typename T> struct CondSh;
 
 /*
@@ -53,6 +54,7 @@ private:
 	//active GUI elements (listening for events
 	CIntObjectList lclickable,
 				   rclickable,
+				   mclickable,
 				   hoverable,
 				   keyinterested,
 				   motioninterested,
@@ -62,6 +64,7 @@ private:
 	               textInterested;
 
 
+	void handleMouseButtonClick(CIntObjectList &interestedObjs, EIntObjMouseBtnType btn, bool isPressed);
 	void processLists(const ui16 activityFlag, std::function<void (std::list<CIntObject*> *)> cb);
 public:
 	void handleElementActivate(CIntObject * elem, ui16 activityFlag);

--- a/client/gui/CGuiHandler.h
+++ b/client/gui/CGuiHandler.h
@@ -64,7 +64,7 @@ private:
 	               textInterested;
 
 
-	void handleMouseButtonClick(CIntObjectList &interestedObjs, EIntObjMouseBtnType btn, bool isPressed);
+	void handleMouseButtonClick(CIntObjectList & interestedObjs, EIntObjMouseBtnType btn, bool isPressed);
 	void processLists(const ui16 activityFlag, std::function<void (std::list<CIntObject*> *)> cb);
 public:
 	void handleElementActivate(CIntObject * elem, ui16 activityFlag);

--- a/client/gui/CIntObject.cpp
+++ b/client/gui/CIntObject.cpp
@@ -16,7 +16,7 @@ CIntObject::CIntObject(int used_, Point pos_):
 	parent(parent_m),
 	active(active_m)
 {
-	pressedL = pressedR = hovered = captureAllKeys = strongInterest = false;
+	hovered = captureAllKeys = strongInterest = false;
 	toNextTick = timerDelay = 0;
 	used = used_;
 
@@ -132,6 +132,23 @@ CIntObject::~CIntObject()
 
 	if(parent_m)
 		parent_m->removeChild(this);
+}
+
+void CIntObject::click(EIntObjMouseBtnType btn, tribool down, bool previousState)
+{
+	switch(btn)
+	{
+	default:
+	case EIntObjMouseBtnType::LEFT:
+		clickLeft(down, previousState);
+		break;
+	case EIntObjMouseBtnType::MIDDLE:
+		clickMiddle(down, previousState);
+		break;
+	case EIntObjMouseBtnType::RIGHT:
+		clickRight(down, previousState);
+		break;
+	}
 }
 
 void CIntObject::printAtLoc( const std::string & text, int x, int y, EFonts font, SDL_Color kolor/*=Colors::WHITE*/, SDL_Surface * dst/*=screen*/ )
@@ -340,16 +357,9 @@ void CKeyShortcut::keyPressed(const SDL_KeyboardEvent & key)
 	if(vstd::contains(assignedKeys,key.keysym.sym)
 	 || vstd::contains(assignedKeys, CGuiHandler::numToDigit(key.keysym.sym)))
 	{
-		bool prev = pressedL;
-		if(key.state == SDL_PRESSED)
-		{
-			pressedL = true;
-			clickLeft(true, prev);
-		}
-		else
-		{
-			pressedL = false;
-			clickLeft(false, prev);
-		}
+		bool prev = mouseState(EIntObjMouseBtnType::LEFT);		
+		updateMouseState(EIntObjMouseBtnType::LEFT, key.state == SDL_PRESSED);
+		clickLeft(key.state == SDL_PRESSED, prev);
+		
 	}
 }

--- a/client/gui/CIntObject.h
+++ b/client/gui/CIntObject.h
@@ -61,6 +61,7 @@ public:
 	virtual ~IShowActivatable(){}; //d-tor
 };
 
+enum class EIntObjMouseBtnType { LEFT, MIDDLE, RIGHT };
 //typedef ui16 ActivityFlag;
 
 // Base UI element
@@ -72,6 +73,8 @@ class CIntObject : public IShowActivatable //interface object
 	//time handling
 	int toNextTick;
 	int timerDelay;
+
+	std::map<EIntObjMouseBtnType, bool> currentMouseState;
 
 	void onTimer(int timePassed);
 
@@ -104,13 +107,13 @@ public:
 	CIntObject(int used=0, Point offset=Point());
 	virtual ~CIntObject(); //d-tor
 
-	//l-clicks handling
-	/*const*/ bool pressedL; //for determining if object is L-pressed
-	virtual void clickLeft(tribool down, bool previousState){}
+	void updateMouseState(EIntObjMouseBtnType btn, bool state) { currentMouseState[btn] = state; }
+	bool mouseState(EIntObjMouseBtnType btn) const { return currentMouseState.count(btn) ? currentMouseState.at(btn) : false; }
 
-	//r-clicks handling
-	/*const*/ bool pressedR; //for determining if object is R-pressed
-	virtual void clickRight(tribool down, bool previousState){}
+	virtual void click(EIntObjMouseBtnType btn, tribool down, bool previousState);
+	virtual void clickLeft(tribool down, bool previousState) {}
+	virtual void clickRight(tribool down, bool previousState) {}
+	virtual void clickMiddle(tribool down, bool previousState) {}
 
 	//hover handling
 	/*const*/ bool hovered;  //for determining if object is hovered
@@ -138,7 +141,7 @@ public:
 	//double click
 	virtual void onDoubleClick(){}
 
-	enum {LCLICK=1, RCLICK=2, HOVER=4, MOVE=8, KEYBOARD=16, TIME=32, GENERAL=64, WHEEL=128, DOUBLECLICK=256, TEXTINPUT=512, ALL=0xffff};
+	enum {LCLICK=1, RCLICK=2, HOVER=4, MOVE=8, KEYBOARD=16, TIME=32, GENERAL=64, WHEEL=128, DOUBLECLICK=256, TEXTINPUT=512, MCLICK=1024, ALL=0xffff};
 	const ui16 & active;
 	void addUsedEvents(ui16 newActions);
 	void removeUsedEvents(ui16 newActions);

--- a/client/widgets/AdventureMapClasses.cpp
+++ b/client/widgets/AdventureMapClasses.cpp
@@ -587,7 +587,7 @@ void CMinimap::hover(bool on)
 
 void CMinimap::mouseMoved(const SDL_MouseMotionEvent & sEvent)
 {
-	if (mouseState(EIntObjMouseBtnType::LEFT))
+	if(mouseState(EIntObjMouseBtnType::LEFT))
 		moveAdvMapSelection();
 }
 

--- a/client/widgets/AdventureMapClasses.cpp
+++ b/client/widgets/AdventureMapClasses.cpp
@@ -587,7 +587,7 @@ void CMinimap::hover(bool on)
 
 void CMinimap::mouseMoved(const SDL_MouseMotionEvent & sEvent)
 {
-	if (pressedL)
+	if (mouseState(EIntObjMouseBtnType::LEFT))
 		moveAdvMapSelection();
 }
 

--- a/client/widgets/Buttons.cpp
+++ b/client/widgets/Buttons.cpp
@@ -623,7 +623,7 @@ void CSlider::clickLeft(tribool down, bool previousState)
 			return;
 		// 		if (rw>1) return;
 		// 		if (rw<0) return;
-		slider->clickLeft(true, slider->pressedL);
+		slider->clickLeft(true, slider->mouseState(EIntObjMouseBtnType::LEFT));
 		moveTo(rw * positions  +  0.5);
 		return;
 	}

--- a/client/windows/CAdvmapInterface.h
+++ b/client/windows/CAdvmapInterface.h
@@ -63,9 +63,9 @@ class CTerrainRect
 	static constexpr float SwipeTouchSlop = 16.0f;
 
 	void handleHover(const SDL_MouseMotionEvent &sEvent);
-#ifdef VCMI_ANDROID
 	void handleSwipeMove(const SDL_MouseMotionEvent &sEvent);
-#endif // VCMI_ANDROID
+	/// handles start/finish of swipe (press/release of corresponding button); returns true if state change was handled
+	bool handleSwipeStateChange(bool btnPressed);
 public:
 	int tilesw, tilesh; //width and height of terrain to blit in tiles
 	int3 curHoveredTile;
@@ -77,6 +77,7 @@ public:
 	void deactivate() override;
 	void clickLeft(tribool down, bool previousState) override;
 	void clickRight(tribool down, bool previousState) override;
+	void clickMiddle(tribool down, bool previousState) override;
 	void hover(bool on) override;
 	void mouseMoved (const SDL_MouseMotionEvent & sEvent) override;
 	void show(SDL_Surface * to) override;
@@ -132,11 +133,9 @@ public:
 	enum{LEFT=1, RIGHT=2, UP=4, DOWN=8};
 	ui8 scrollingDir; //uses enum: LEFT RIGHT, UP, DOWN
 	bool scrollingState;
-#ifdef VCMI_ANDROID
 	bool swipeEnabled;
 	bool swipeMovementRequested;
 	int3 swipeTargetPosition;
-#endif // !VCMI_ANDROID
 
 	enum{NA, INGAME, WAITING} state;
 
@@ -260,9 +259,7 @@ public:
 	void changeMode(EAdvMapMode newMode, float newScale = 0.36f);
 
 	void handleMapScrollingUpdate();
-#ifdef VCMI_ANDROID
 	void handleSwipeUpdate();
-#endif
 
 };
 

--- a/client/windows/CAdvmapInterface.h
+++ b/client/windows/CAdvmapInterface.h
@@ -62,8 +62,8 @@ class CTerrainRect
 	bool isSwiping;
 	static constexpr float SwipeTouchSlop = 16.0f;
 
-	void handleHover(const SDL_MouseMotionEvent &sEvent);
-	void handleSwipeMove(const SDL_MouseMotionEvent &sEvent);
+	void handleHover(const SDL_MouseMotionEvent & sEvent);
+	void handleSwipeMove(const SDL_MouseMotionEvent & sEvent);
 	/// handles start/finish of swipe (press/release of corresponding button); returns true if state change was handled
 	bool handleSwipeStateChange(bool btnPressed);
 public:

--- a/config/schemas/settings.json
+++ b/config/schemas/settings.json
@@ -41,7 +41,7 @@
 				},
 				"swipe" : {
 					"type" : "boolean",
-					"default" : false
+					"default" : true
 				},
 				"saveRandomMaps" : {
 					"type" : "boolean",


### PR DESCRIPTION
This PR adds support for swiping adventure map, partially reusing recent android implementation.
Currently "desktop" version of swipe uses middle mouse button (default "left" button on android) and can be enabled simultaneously with normal map scrolling (these modes are currently exclusive in android version).

First commit is a minor refactor of handling mouse button events in CGuiHandler (removes some duplicated code) + middle mouse button handling.
Second is actual swipe logic (updated version tested on windows and on android).

The setting that controls swipe (general -> swipe) can't be modified in-game so I changed it to be enabled by default (just for now?).