### PR TITLE
Share visited status of CPlayersVisited objects across team

### DIFF
--- a/lib/mapObjects/MiscObjects.cpp
+++ b/lib/mapObjects/MiscObjects.cpp
@@ -60,18 +60,18 @@ static std::string & visitedTxt(const bool visited)
 	return VLC->generaltexth->allTexts[id];
 }
 
-void CPlayersVisited::setPropertyDer( ui8 what, ui32 val )
+void CTeamVisited::setPropertyDer( ui8 what, ui32 val )
 {
-	if(what == CPlayersVisited::OBJPROP_VISITED)
+	if(what == CTeamVisited::OBJPROP_VISITED)
 		players.insert(PlayerColor(val));
 }
 
-bool CPlayersVisited::wasVisited( PlayerColor player ) const
+bool CTeamVisited::wasVisited( PlayerColor player ) const
 {
 	return wasVisited(cb->getPlayer(player)->team);
 }
 
-bool CPlayersVisited::wasVisited( TeamID team ) const
+bool CTeamVisited::wasVisited( TeamID team ) const
 {
 	for(auto i : players)
 	{
@@ -2127,7 +2127,7 @@ void CGObelisk::setPropertyDer( ui8 what, ui32 val )
 				break;
 			}
 		default:
-			CPlayersVisited::setPropertyDer(what, val);
+			CTeamVisited::setPropertyDer(what, val);
 			break;
 	}
 }

--- a/lib/mapObjects/MiscObjects.cpp
+++ b/lib/mapObjects/MiscObjects.cpp
@@ -68,7 +68,7 @@ void CPlayersVisited::setPropertyDer( ui8 what, ui32 val )
 
 bool CPlayersVisited::wasVisited( PlayerColor player ) const
 {
-	return vstd::contains(players,player);
+	return wasVisited(cb->getPlayer(player)->team);
 }
 
 bool CPlayersVisited::wasVisited( TeamID team ) const

--- a/lib/mapObjects/MiscObjects.h
+++ b/lib/mapObjects/MiscObjects.h
@@ -16,7 +16,8 @@
 
 class CMap;
 
-class DLL_LINKAGE CPlayersVisited: public CGObjectInstance
+/// Legacy class, use CRewardableObject instead
+class DLL_LINKAGE CTeamVisited: public CGObjectInstance
 {
 public:
 	std::set<PlayerColor> players; //players that visited this object
@@ -116,7 +117,7 @@ protected:
 	void serializeJsonOptions(JsonSerializeFormat & handler) override;
 };
 
-class DLL_LINKAGE CGWitchHut : public CPlayersVisited
+class DLL_LINKAGE CGWitchHut : public CTeamVisited
 {
 public:
 	std::vector<si32> allowedAbilities;
@@ -128,7 +129,7 @@ public:
 	void initObj(CRandomGenerator & rand) override;
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & static_cast<CPlayersVisited&>(*this);
+		h & static_cast<CTeamVisited&>(*this);
 		h & allowedAbilities & ability;
 	}
 protected:
@@ -224,7 +225,7 @@ protected:
 	void serializeJsonOptions(JsonSerializeFormat & handler) override;
 };
 
-class DLL_LINKAGE CGShrine : public CPlayersVisited
+class DLL_LINKAGE CGShrine : public CTeamVisited
 {
 public:
 	SpellID spell; //id of spell or NONE if random
@@ -235,7 +236,7 @@ public:
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & static_cast<CPlayersVisited&>(*this);;
+		h & static_cast<CTeamVisited&>(*this);;
 		h & spell;
 	}
 protected:
@@ -454,7 +455,7 @@ public:
 	}
 };
 
-class DLL_LINKAGE CCartographer : public CPlayersVisited
+class DLL_LINKAGE CCartographer : public CTeamVisited
 {
 ///behaviour varies depending on surface and  floor
 public:
@@ -463,7 +464,7 @@ public:
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & static_cast<CPlayersVisited&>(*this);
+		h & static_cast<CTeamVisited&>(*this);
 	}
 };
 
@@ -472,7 +473,7 @@ class DLL_LINKAGE CGDenOfthieves : public CGObjectInstance
 	void onHeroVisit(const CGHeroInstance * h) const override;
 };
 
-class DLL_LINKAGE CGObelisk : public CPlayersVisited
+class DLL_LINKAGE CGObelisk : public CTeamVisited
 {
 public:
 	static const int OBJPROP_INC = 20;
@@ -486,7 +487,7 @@ public:
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & static_cast<CPlayersVisited&>(*this);
+		h & static_cast<CTeamVisited&>(*this);
 	}
 protected:
 	void setPropertyDer(ui8 what, ui32 val) override;

--- a/lib/registerTypes/RegisterTypes.h
+++ b/lib/registerTypes/RegisterTypes.h
@@ -153,11 +153,11 @@ void registerTypesMapObjects2(Serializer &s)
 		s.template registerType<CRewardableObject, CGOnceVisitable>();
 			s.template registerType<CGVisitableOPW, CGMagicSpring>();
 
-	s.template registerType<CGObjectInstance, CPlayersVisited>();
-		s.template registerType<CPlayersVisited, CGWitchHut>();
-		s.template registerType<CPlayersVisited, CGShrine>();
-		s.template registerType<CPlayersVisited, CCartographer>();
-		s.template registerType<CPlayersVisited, CGObelisk>();
+	s.template registerType<CGObjectInstance, CTeamVisited>();
+		s.template registerType<CTeamVisited, CGWitchHut>();
+		s.template registerType<CTeamVisited, CGShrine>();
+		s.template registerType<CTeamVisited, CCartographer>();
+		s.template registerType<CTeamVisited, CGObelisk>();
 
 	//s.template registerType<CQuest>();
 	//s.template registerType<IQuestObject>();


### PR DESCRIPTION
It makes sense for all such objects - cartographer, obelisk, shrine and witch hut. 
Should it be renamed to CTeamVisited?