### PR TITLE
Fix NodeComparer::operator() to provide strict weak ordering

### DIFF
--- a/lib/CPathfinder.h
+++ b/lib/CPathfinder.h
@@ -177,7 +177,7 @@ private:
 		{
 			if(rhs->turns > lhs->turns)
 				return false;
-			else if(rhs->turns == lhs->turns && rhs->moveRemains < lhs->moveRemains)
+			else if(rhs->turns == lhs->turns && rhs->moveRemains <= lhs->moveRemains)
 				return false;
 
 			return true;


### PR DESCRIPTION
This fixes annoying assertion failures in MSVC builds