### PR TITLE
Fix attack cursor on guarded visitable object

### DIFF
--- a/lib/CPathfinder.cpp
+++ b/lib/CPathfinder.cpp
@@ -577,7 +577,7 @@ CGPathNode::ENodeAction CPathfinder::getDestAction() const
 
 			if(action == CGPathNode::NORMAL)
 			{
-				if(options.originalMovementRules && isDestinationGuarded())
+				if(isDestinationGuarded())
 					action = CGPathNode::BATTLE;
 				else
 					action = CGPathNode::VISIT;


### PR DESCRIPTION
There is good chance that options.originalMovementRules check should not exist in first place. After using fly spell in OH3 you get attacked immediately when visiting guarded object.