### PR TITLE
macOS: use HTTPS for appcast 

### DIFF
--- a/client/Info.plist
+++ b/client/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleIdentifier</key>
 	<string>com.vcmi.vcmiclient</string>
 	<key>SUFeedURL</key>
-	<string>http://vcmi.eu/sparkle_appcast.xml</string>
+	<string>https://vcmi.eu/sparkle_appcast.xml</string>
 	<key>SUPublicDSAKeyFile</key>
 	<string>vcmi_dsa_public.pem</string>
 </dict>

--- a/osx/sparkle_appcast.xml
+++ b/osx/sparkle_appcast.xml
@@ -2,9 +2,9 @@
 <rss version="2.0" xmlns:sparkle="http://vcmi.eu/xml-namespaces/sparkle"  xmlns:dc="http://purl.org/dc/elements/1.1/">
    <channel>
       <title>VCMI App Changelog</title>
-      <link>http://vcmi.eu/sparkle_appcast.xml</link>
+      <link>https://vcmi.eu/sparkle_appcast.xml</link>
       <description>Most recent changes with links to updates.</description>
-      <language>en</language>      
+      <language>en</language>
          <item>
             <title>Version 0.94</title>
             <description>Version 0.94</description>


### PR DESCRIPTION
Otherwise a warning pops up at each launch (until http://vcmi.eu/sparkle_appcast.xml is upgraded to HTTPS).

See https://sparkle-project.org/documentation/app-transport-security/