### PR TITLE
Change output path for cmake builds

### DIFF
--- a/AI/BattleAI/CMakeLists.txt
+++ b/AI/BattleAI/CMakeLists.txt
@@ -34,6 +34,8 @@ endif()
 add_library(BattleAI SHARED ${battleAI_SRCS} ${battleAI_HEADERS})
 target_link_libraries(BattleAI vcmi)
 
+vcmi_set_output_dir(BattleAI "AI")
+
 set_target_properties(BattleAI PROPERTIES ${PCH_PROPERTIES})
 cotire(BattleAI)
 

--- a/AI/EmptyAI/CMakeLists.txt
+++ b/AI/EmptyAI/CMakeLists.txt
@@ -19,6 +19,8 @@ set(emptyAI_HEADERS
 add_library(EmptyAI SHARED ${emptyAI_SRCS} ${emptyAI_HEADERS})
 target_link_libraries(EmptyAI vcmi)
 
+vcmi_set_output_dir(EmptyAI "AI")
+
 if (NOT APPLE) # Already inside vcmiclient bundle
     install(TARGETS EmptyAI RUNTIME DESTINATION ${AI_LIB_DIR} LIBRARY DESTINATION ${AI_LIB_DIR})
 endif()

--- a/AI/StupidAI/CMakeLists.txt
+++ b/AI/StupidAI/CMakeLists.txt
@@ -19,6 +19,8 @@ set(stupidAI_HEADERS
 add_library(StupidAI SHARED ${stupidAI_SRCS} ${stupidAI_HEADERS})
 target_link_libraries(StupidAI vcmi)
 
+vcmi_set_output_dir(StupidAI "AI")
+
 set_target_properties(StupidAI PROPERTIES ${PCH_PROPERTIES})
 cotire(StupidAI)
 

--- a/AI/VCAI/CMakeLists.txt
+++ b/AI/VCAI/CMakeLists.txt
@@ -38,6 +38,8 @@ else()
 	target_link_libraries(VCAI fl-static vcmi)
 endif()
 
+vcmi_set_output_dir(VCAI "AI")
+
 set_target_properties(VCAI PROPERTIES ${PCH_PROPERTIES})
 cotire(VCAI)
 

--- a/CI/appveyor.yml
+++ b/CI/appveyor.yml
@@ -40,27 +40,13 @@ build_script:
 
     mkdir dist_%BUILD_PLATFORM%
 
-    cp launcher\%BUILD_CONFIGURATION%\VCMI_launcher.exe dist_%BUILD_PLATFORM%
+    copy %BUILD_CONFIGURATION%\*.exe dist_%BUILD_PLATFORM%
 
-    cp client\%BUILD_CONFIGURATION%\VCMI_client.exe dist_%BUILD_PLATFORM%
-
-    cp server\%BUILD_CONFIGURATION%\VCMI_server.exe dist_%BUILD_PLATFORM%
-
-    cp lib\%BUILD_CONFIGURATION%\VCMI_lib.dll dist_%BUILD_PLATFORM%
-
-    cp lib\minizip\%BUILD_CONFIGURATION%\minizip.dll dist_%BUILD_PLATFORM%
-
+    copy %BUILD_CONFIGURATION%\*.dll dist_%BUILD_PLATFORM%
 
     mkdir dist_%BUILD_PLATFORM%\AI
 
-    cp AI\VCAI\%BUILD_CONFIGURATION%\VCAI.dll dist_%BUILD_PLATFORM%\AI
-
-    cp AI\EmptyAI\%BUILD_CONFIGURATION%\EmptyAI.dll dist_%BUILD_PLATFORM%\AI
-
-    cp AI\BattleAI\%BUILD_CONFIGURATION%\BattleAI.dll dist_%BUILD_PLATFORM%\AI
-
-    cp AI\StupidAI\%BUILD_CONFIGURATION%\StupidAI.dll dist_%BUILD_PLATFORM%\AI
-
+    copy %BUILD_CONFIGURATION%\AI\*.dll dist_%BUILD_PLATFORM%\AI
 
     cd dist_%BUILD_PLATFORM%
 

--- a/CI/appveyor.yml
+++ b/CI/appveyor.yml
@@ -44,6 +44,8 @@ build_script:
 
     copy %BUILD_CONFIGURATION%\*.dll dist_%BUILD_PLATFORM%
 
+    copy %BUILD_CONFIGURATION%\lib\*.dll dist_%BUILD_PLATFORM%
+
     mkdir dist_%BUILD_PLATFORM%\AI
 
     copy %BUILD_CONFIGURATION%\AI\*.dll dist_%BUILD_PLATFORM%\AI

--- a/CI/appveyor.yml
+++ b/CI/appveyor.yml
@@ -64,9 +64,9 @@ build_script:
 
     copy %QTDIR%\plugins\platforms\qwindows.dll platforms
 
-    7z a c:\projects\vcmi\source\vcmi-%BUILD_PLATFORM%-%BUILD_CONFIGURATION%.zip * -r -x!*.exp -x!*.lib
+    7z a c:\projects\vcmi\source\vcmi-%BUILD_PLATFORM%-%BUILD_CONFIGURATION%.zip * -mx=7 -r -x!*.exp -x!*.lib
 
-    7z a c:\projects\vcmi\source\vcmi-%BUILD_PLATFORM%-%BUILD_CONFIGURATION%.zip c:\projects\vcmi\depends\bin\*.dll
+    7z a c:\projects\vcmi\source\vcmi-%BUILD_PLATFORM%-%BUILD_CONFIGURATION%.zip c:\projects\vcmi\depends\bin\*.dll -mx=7
 artifacts:
 - path: vcmi-x86-Release.zip
 notifications:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,8 @@ cmake_minimum_required(VERSION 2.8.12)
 # where to look for cmake modules
 set(CMAKE_MODULE_PATH ${CMAKE_HOME_DIRECTORY}/cmake_modules)
 
+include(VCMIUtils)
+
 # enable Release mode but only if it was not set
 if (NOT CMAKE_BUILD_TYPE)
 		set(CMAKE_BUILD_TYPE RelWithDebInfo)
@@ -362,7 +364,6 @@ elseif(APPLE)
 else()
 	set(CPACK_GENERATOR TGZ)
 endif()
-
 
 include(GetGitRevisionDescription)
 get_git_head_revision(GIT_REFSPEC GIT_SHA1)

--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -156,19 +156,18 @@ if(APPLE)
 	# Copy server executable, libs and game data to bundle
 	set(BUNDLE_PATH ${CMAKE_HOME_DIRECTORY}/bin/$(CONFIGURATION)/vcmiclient.app/Contents)
 
-  set(CopyVendoredMinizip
-		mkdir -p ${BUNDLE_PATH}/MacOS &&
-    cp ${CMAKE_HOME_DIRECTORY}/bin/$(CONFIGURATION)/libminizip.dylib ${BUNDLE_PATH}/MacOS/libminizip.dylib)
+	set(CopyVendoredMinizip
+		mkdir -p ${BUNDLE_PATH}/MacOS && cp ${CMAKE_BINARY_DIR}/build/$(CONFIGURATION)/lib/libminizip.dylib ${BUNDLE_PATH}/MacOS/libminizip.dylib)
 
 	set(MakeVCMIBundle
 		# Copy all needed binaries
 		mkdir -p ${BUNDLE_PATH}/MacOS/AI &&
-		cp ${CMAKE_HOME_DIRECTORY}/bin/$(CONFIGURATION)/vcmiserver ${BUNDLE_PATH}/MacOS/vcmiserver &&
-		cp ${CMAKE_HOME_DIRECTORY}/bin/$(CONFIGURATION)/libvcmi.dylib ${BUNDLE_PATH}/MacOS/libvcmi.dylib &&
-		cp ${CMAKE_HOME_DIRECTORY}/bin/$(CONFIGURATION)/libVCAI.dylib ${BUNDLE_PATH}/MacOS/AI/libVCAI.dylib &&
-		cp ${CMAKE_HOME_DIRECTORY}/bin/$(CONFIGURATION)/libStupidAI.dylib ${BUNDLE_PATH}/MacOS/AI/libStupidAI.dylib &&
-		cp ${CMAKE_HOME_DIRECTORY}/bin/$(CONFIGURATION)/libEmptyAI.dylib ${BUNDLE_PATH}/MacOS/AI/libEmptyAI.dylib &&
-		cp ${CMAKE_HOME_DIRECTORY}/bin/$(CONFIGURATION)/libBattleAI.dylib ${BUNDLE_PATH}/MacOS/AI/libBattleAI.dylib &&
+		cp ${CMAKE_BINARY_DIR}/build/$(CONFIGURATION)/vcmiserver ${BUNDLE_PATH}/MacOS/vcmiserver &&
+		cp ${CMAKE_BINARY_DIR}/build/$(CONFIGURATION)/libvcmi.dylib ${BUNDLE_PATH}/MacOS/libvcmi.dylib &&
+		cp ${CMAKE_BINARY_DIR}/build/$(CONFIGURATION)/AI/libVCAI.dylib ${BUNDLE_PATH}/MacOS/AI/libVCAI.dylib &&
+		cp ${CMAKE_BINARY_DIR}/build/$(CONFIGURATION)/AI/libStupidAI.dylib ${BUNDLE_PATH}/MacOS/AI/libStupidAI.dylib &&
+		cp ${CMAKE_BINARY_DIR}/build/$(CONFIGURATION)/AI/libEmptyAI.dylib ${BUNDLE_PATH}/MacOS/AI/libEmptyAI.dylib &&
+		cp ${CMAKE_BINARY_DIR}/build/$(CONFIGURATION)/AI/libBattleAI.dylib ${BUNDLE_PATH}/MacOS/AI/libBattleAI.dylib &&
 		cp -r ${CMAKE_HOME_DIRECTORY}/osx/vcmibuilder.app ${BUNDLE_PATH}/MacOS/vcmibuilder.app &&
 
 		# Copy frameworks
@@ -184,9 +183,10 @@ if(APPLE)
 		sh -c 'cp -r ${CMAKE_HOME_DIRECTORY}/Mods/hota/ ${BUNDLE_PATH}/Data/Mods/hota/ || echo "Download HOTA mod from http://wiki.vcmi.eu/index.php?title=Mod_list" ' &&
 		cp -r ${CMAKE_HOME_DIRECTORY}/launcher/icons/ ${BUNDLE_PATH}/Data/launcher/icons/)
 
-  if(NOT MINIZIP_FOUND)
-    add_custom_command(TARGET vcmiclient POST_BUILD COMMAND ${CopyVendoredMinizip})
-  endif()
+	if(NOT MINIZIP_FOUND)
+		add_custom_command(TARGET vcmiclient POST_BUILD COMMAND ${CopyVendoredMinizip})
+	endif()
+
 	add_custom_command(TARGET vcmiclient POST_BUILD COMMAND ${MakeVCMIBundle})
 elseif(WIN32)
 	add_executable(vcmiclient ${client_SRCS} ${client_HEADERS} VCMI_client.rc)

--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -200,6 +200,8 @@ endif()
 
 target_link_libraries(vcmiclient vcmi ${Boost_LIBRARIES} ${SDL_LIBRARY} ${SDLIMAGE_LIBRARY} ${SDLMIXER_LIBRARY} ${SDLTTF_LIBRARY} ${ZLIB_LIBRARIES} ${FFMPEG_LIBRARIES} ${SYSTEM_LIBS})
 
+vcmi_set_output_dir(vcmiclient "")
+
 set_target_properties(vcmiclient PROPERTIES ${PCH_PROPERTIES})
 cotire(vcmiclient)
 

--- a/cmake_modules/VCMIUtils.cmake
+++ b/cmake_modules/VCMIUtils.cmake
@@ -1,0 +1,18 @@
+#######################################
+#       Output directories            #
+#######################################
+
+macro(vcmi_set_output_dir name dir)
+	# multi-config builds (e.g. msvc)
+	foreach (OUTPUTCONFIG ${CMAKE_CONFIGURATION_TYPES})
+		string(TOUPPER ${OUTPUTCONFIG} OUTPUTCONFIGUPPERCASE)
+		set_target_properties(${name} PROPERTIES RUNTIME_OUTPUT_DIRECTORY_${OUTPUTCONFIGUPPERCASE} ${CMAKE_BINARY_DIR}/${OUTPUTCONFIG}/${dir})
+		set_target_properties(${name} PROPERTIES LIBRARY_OUTPUT_DIRECTORY_${OUTPUTCONFIGUPPERCASE} ${CMAKE_BINARY_DIR}/${OUTPUTCONFIG}/${dir})
+		set_target_properties(${name} PROPERTIES ARCHIVE_OUTPUT_DIRECTORY_${OUTPUTCONFIGUPPERCASE} ${CMAKE_BINARY_DIR}/${OUTPUTCONFIG}/${dir})
+	endforeach()
+
+	# generic no-config case (e.g. with mingw)
+	set_target_properties(${name} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/build/${dir})
+	set_target_properties(${name} PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/build/${dir})
+	set_target_properties(${name} PROPERTIES ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/build/${dir})
+endmacro()

--- a/cmake_modules/VCMIUtils.cmake
+++ b/cmake_modules/VCMIUtils.cmake
@@ -11,7 +11,7 @@ macro(vcmi_set_output_dir name dir)
 		set_target_properties(${name} PROPERTIES ARCHIVE_OUTPUT_DIRECTORY_${OUTPUTCONFIGUPPERCASE} ${CMAKE_BINARY_DIR}/${OUTPUTCONFIG}/${dir})
 	endforeach()
 
-	# generic no-config case (e.g. with mingw)
+	# generic no-config case (e.g. with mingw or MacOS)
 	set_target_properties(${name} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/build/${dir})
 	set_target_properties(${name} PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/build/${dir})
 	set_target_properties(${name} PROPERTIES ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/build/${dir})

--- a/launcher/CMakeLists.txt
+++ b/launcher/CMakeLists.txt
@@ -68,6 +68,8 @@ else()
 	target_link_libraries(vcmilauncher vcmi ${Qt5Widgets_LIBRARIES} ${Qt5Network_LIBRARIES} ${SDL_LIBRARY})
 endif()
 
+vcmi_set_output_dir(vcmilauncher "")
+
 # temporary(?) disabled - generation of PCH takes too much time since cotire is trying to collect all Qt headers
 #set_target_properties(vcmilauncher PROPERTIES ${PCH_PROPERTIES})
 #cotire(vcmilauncher)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -301,6 +301,8 @@ if (ANDROID)
 	return()
 endif()
 
+vcmi_set_output_dir(vcmi "")
+
 set_target_properties(vcmi PROPERTIES ${PCH_PROPERTIES})
 cotire(vcmi)
 

--- a/lib/minizip/CMakeLists.txt
+++ b/lib/minizip/CMakeLists.txt
@@ -18,6 +18,19 @@ elseif(APPLE)
     set_target_properties(minizip PROPERTIES XCODE_ATTRIBUTE_LD_DYLIB_INSTALL_NAME "@rpath/libminizip.dylib")
 endif()
 
+# multi-config builds (e.g. msvc)
+foreach (OUTPUTCONFIG ${CMAKE_CONFIGURATION_TYPES})
+	string(TOUPPER ${OUTPUTCONFIG} OUTPUTCONFIGUPPERCASE)
+	set_target_properties(minizip PROPERTIES RUNTIME_OUTPUT_DIRECTORY_${OUTPUTCONFIGUPPERCASE} ${CMAKE_BINARY_DIR}/${OUTPUTCONFIG}/lib)
+	set_target_properties(minizip PROPERTIES LIBRARY_OUTPUT_DIRECTORY_${OUTPUTCONFIGUPPERCASE} ${CMAKE_BINARY_DIR}/${OUTPUTCONFIG}/lib)
+	set_target_properties(minizip PROPERTIES ARCHIVE_OUTPUT_DIRECTORY_${OUTPUTCONFIGUPPERCASE} ${CMAKE_BINARY_DIR}/${OUTPUTCONFIG}/lib)
+endforeach()
+
+# generic no-config case (e.g. with mingw)
+set_target_properties(minizip PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/build/lib)
+set_target_properties(minizip PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/build/lib)
+set_target_properties(minizip PROPERTIES ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/build/lib)
+
 target_link_libraries(minizip ${ZLIB_LIBRARIES})
 
 if (NOT APPLE) # Already inside vcmiclient bundle

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -32,6 +32,8 @@ if(WIN32)
 	set_target_properties(vcmiserver PROPERTIES OUTPUT_NAME VCMI_server)
 endif()
 
+vcmi_set_output_dir(vcmiserver "")
+
 set_target_properties(vcmiserver PROPERTIES ${PCH_PROPERTIES})
 set_target_properties(vcmiserver PROPERTIES XCODE_ATTRIBUTE_LD_RUNPATH_SEARCH_PATHS "@executable_path/../Frameworks @executable_path/")
 cotire(vcmiserver)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -26,6 +26,8 @@ add_executable(vcmitest ${test_SRCS} ${test_HEADERS})
 target_link_libraries(vcmitest vcmi ${Boost_LIBRARIES} ${RT_LIB} ${DL_LIB})
 add_test(vcmitest vcmitest)
 
+vcmi_set_output_dir(vcmitest "")
+
 set_target_properties(vcmitest PROPERTIES ${PCH_PROPERTIES})
 cotire(vcmitest)
 


### PR DESCRIPTION
All binary and libraries files will now go into the same directory, suitable for runtime linking.