### PR TITLE
Tweak battle creatures amount box hiding

### DIFF
--- a/client/battle/CBattleInterface.cpp
+++ b/client/battle/CBattleInterface.cpp
@@ -3275,7 +3275,7 @@ void CBattleInterface::showAliveStacks(SDL_Surface *to, std::vector<const CStack
 {
 	auto isAmountBoxVisible = [&](const CStack *stack) -> bool
 	{
-		if(stack->hasBonusOfType(Bonus::SIEGE_WEAPON)) // siege weapons are always singular
+		if(stack->hasBonusOfType(Bonus::SIEGE_WEAPON) && stack->count == 1) //do not show box for singular war machines, stacked war machines with box shown are supported as extension feature
 			return false;
 
 		if(stack->count == 0) //hide box when target is going to die anyway - do not display "0 creatures"


### PR DESCRIPTION
While new implementation is not perfect, it follows OH3 behavior more closely. Should also be more player-friendly.

Box should not be invisible for whole attack + counterattack action. Also does not get displayed when amount is 0. In most cases box number should go invisible before changing now (though the timing when it changes is different from OH3 yet).