### PR TITLE
Add proper handling for ship-to-ship battlefield

### DIFF
--- a/lib/battle/BattleInfo.cpp
+++ b/lib/battle/BattleInfo.cpp
@@ -352,6 +352,7 @@ BattleInfo * BattleInfo::setupBattle(int3 tile, ETerrainType terrain, BFieldType
 			catch(RangeGenerator::ExhaustedPossibilities &)
 			{
 				//silently ignore, if we can't place absolute obstacle, we'll go with the usual ones
+				logGlobal->debug("RangeGenerator::ExhaustedPossibilities exception occured - cannot place absolute obstacle");
 			}
 		}
 
@@ -359,7 +360,8 @@ BattleInfo * BattleInfo::setupBattle(int3 tile, ETerrainType terrain, BFieldType
 		try
 		{
 			while(tilesToBlock > 0)
-			{
+			{				
+				auto tileAccessibility = curB->getAccesibility();
 				const int obid = obidgen.getSuchNumber(appropriateUsualObstacle);
 				const CObstacleInfo &obi = VLC->heroh->obstacles[obid];
 
@@ -376,6 +378,8 @@ BattleInfo * BattleInfo::setupBattle(int3 tile, ETerrainType terrain, BFieldType
 
 					for(BattleHex blocked : obi.getBlocked(pos))
 					{
+						if(tileAccessibility[blocked] == EAccessibility::UNAVAILABLE) //for ship-to-ship battlefield - exclude hardcoded unavailable tiles
+							return false;
 						if(vstd::contains(blockedTiles, blocked))
 							return false;
 						int x = blocked.getX();
@@ -401,6 +405,7 @@ BattleInfo * BattleInfo::setupBattle(int3 tile, ETerrainType terrain, BFieldType
 		}
 		catch(RangeGenerator::ExhaustedPossibilities &)
 		{
+			logGlobal->debug("RangeGenerator::ExhaustedPossibilities exception occured - cannot place usual obstacle");
 		}
 	}
 

--- a/lib/battle/CBattleInfoCallback.cpp
+++ b/lib/battle/CBattleInfoCallback.cpp
@@ -857,9 +857,7 @@ AccessibilityInfo CBattleInfoCallback::getAccesibility() const
 
 	//special battlefields with logically unavailable tiles
 	std::vector<BattleHex> impassableHexes;
-	switch(battleGetBattlefieldType().num)
-	{
-	case BFieldType::SHIP_TO_SHIP:
+	if(battleGetBattlefieldType().num == BFieldType::SHIP_TO_SHIP)
 		impassableHexes = 
 		{ 
 			6, 7, 8, 9,
@@ -872,8 +870,6 @@ AccessibilityInfo CBattleInfoCallback::getAccesibility() const
 			159, 160, 161, 162, 163,
 			176, 177, 178, 179, 180
 		};
-		break;
-	}
 	for(auto hex : impassableHexes)
 		ret[hex] = EAccessibility::UNAVAILABLE;
 

--- a/lib/battle/CBattleInfoCallback.cpp
+++ b/lib/battle/CBattleInfoCallback.cpp
@@ -860,7 +860,18 @@ AccessibilityInfo CBattleInfoCallback::getAccesibility() const
 	switch(battleGetBattlefieldType().num)
 	{
 	case BFieldType::SHIP_TO_SHIP:
-		impassableHexes = { 6, 7, 8, 9, 24, 25, 26, 58, 59, 60, 75, 76, 77, 92, 93, 94, 109, 110, 111, 126, 127, 128, 159, 160, 161, 162, 163, 176, 177, 178, 179, 180 };
+		impassableHexes = 
+		{ 
+			6, 7, 8, 9,
+			24, 25, 26, 
+			58, 59, 60,
+			75, 76, 77,
+			92, 93, 94,
+			109, 110, 111,
+			126, 127, 128,
+			159, 160, 161, 162, 163,
+			176, 177, 178, 179, 180
+		};
 		break;
 	}
 	for(auto hex : impassableHexes)

--- a/lib/battle/CBattleInfoCallback.cpp
+++ b/lib/battle/CBattleInfoCallback.cpp
@@ -855,6 +855,17 @@ AccessibilityInfo CBattleInfoCallback::getAccesibility() const
 		ret[BattleHex(0, y)] = EAccessibility::SIDE_COLUMN;
 	}
 
+	//special battlefields with logically unavailable tiles
+	std::vector<BattleHex> impassableHexes;
+	switch(battleGetBattlefieldType().num)
+	{
+	case BFieldType::SHIP_TO_SHIP:
+		impassableHexes = { 6, 7, 8, 9, 24, 25, 26, 58, 59, 60, 75, 76, 77, 92, 93, 94, 109, 110, 111, 126, 127, 128, 159, 160, 161, 162, 163, 176, 177, 178, 179, 180 };
+		break;
+	}
+	for(auto hex : impassableHexes)
+		ret[hex] = EAccessibility::UNAVAILABLE;
+
 	//gate -> should be before stacks
 	if(battleGetSiegeLevel() > 0)
 	{

--- a/lib/battle/CBattleInfoCallback.cpp
+++ b/lib/battle/CBattleInfoCallback.cpp
@@ -858,6 +858,7 @@ AccessibilityInfo CBattleInfoCallback::getAccesibility() const
 	//special battlefields with logically unavailable tiles
 	std::vector<BattleHex> impassableHexes;
 	if(battleGetBattlefieldType().num == BFieldType::SHIP_TO_SHIP)
+	{	
 		impassableHexes = 
 		{ 
 			6, 7, 8, 9,
@@ -870,6 +871,7 @@ AccessibilityInfo CBattleInfoCallback::getAccesibility() const
 			159, 160, 161, 162, 163,
 			176, 177, 178, 179, 180
 		};
+	}	
 	for(auto hex : impassableHexes)
 		ret[hex] = EAccessibility::UNAVAILABLE;
 


### PR DESCRIPTION
* When this battlefield type is detected proper hexes are marked as inaccessible
* Do not allow obstacle placing on inaccessible tiles