### PR TITLE
Code style: remove default value hints in definitions

### DIFF
--- a/AI/BattleAI/PotentialTargets.cpp
+++ b/AI/BattleAI/PotentialTargets.cpp
@@ -10,7 +10,7 @@
 #include "StdInc.h"
 #include "PotentialTargets.h"
 
-PotentialTargets::PotentialTargets(const CStack *attacker, const HypotheticChangesToBattleState &state /*= HypotheticChangesToBattleState()*/)
+PotentialTargets::PotentialTargets(const CStack * attacker, const HypotheticChangesToBattleState & state)
 {
 	auto dists = getCbc()->battleGetDistances(attacker);
 	auto avHexes = getCbc()->battleGetAvailableHexes(attacker, false);

--- a/AI/BattleAI/StackWithBonuses.cpp
+++ b/AI/BattleAI/StackWithBonuses.cpp
@@ -13,7 +13,7 @@
 
 
 const TBonusListPtr StackWithBonuses::getAllBonuses(const CSelector &selector, const CSelector &limit,
-						    const CBonusSystemNode *root /*= nullptr*/, const std::string &cachingStr /*= ""*/) const
+							const CBonusSystemNode * root, const std::string & cachingStr) const
 {
 	TBonusListPtr ret = std::make_shared<BonusList>();
 	const TBonusListPtr originalList = stack->getAllBonuses(selector, limit, root, cachingStr);

--- a/AI/VCAI/AIUtility.cpp
+++ b/AI/VCAI/AIUtility.cpp
@@ -85,7 +85,7 @@ bool HeroPtr::operator<(const HeroPtr &rhs) const
 	return hid < rhs.hid;
 }
 
-const CGHeroInstance * HeroPtr::get(bool doWeExpectNull /*= false*/) const
+const CGHeroInstance * HeroPtr::get(bool doWeExpectNull) const
 {
 	//TODO? check if these all assertions every time we get info about hero affect efficiency
 	//

--- a/AI/VCAI/VCAI.cpp
+++ b/AI/VCAI/VCAI.cpp
@@ -275,7 +275,7 @@ void VCAI::heroVisit(const CGHeroInstance *visitor, const CGObjectInstance *visi
 	status.heroVisit(visitedObj, start);
 }
 
-void VCAI::availableArtifactsChanged(const CGBlackMarket *bm /*= nullptr*/)
+void VCAI::availableArtifactsChanged(const CGBlackMarket * bm)
 {
 	LOG_TRACE(logAi);
 	NET_EVENT_HANDLER;
@@ -1784,7 +1784,7 @@ void VCAI::validateVisitableObjs()
 	vstd::erase_if(alreadyVisited, shouldBeErased);
 }
 
-void VCAI::retreiveVisitableObjs(std::vector<const CGObjectInstance *> &out, bool includeOwned /*= false*/) const
+void VCAI::retreiveVisitableObjs(std::vector<const CGObjectInstance *> &out, bool includeOwned) const
 {
 	foreach_tile_pos([&](const int3 &pos)
 	{
@@ -1875,7 +1875,7 @@ const CGObjectInstance * VCAI::getUnvisitedObj(const std::function<bool(const CG
 	return nullptr;
 }
 
-bool VCAI::isAccessibleForHero(const int3 & pos, HeroPtr h, bool includeAllies /*= false*/) const
+bool VCAI::isAccessibleForHero(const int3 & pos, HeroPtr h, bool includeAllies) const
 {
 	if (!includeAllies)
 	{ //don't visit tile occupied by allied hero

--- a/CCallback.cpp
+++ b/CCallback.cpp
@@ -64,7 +64,7 @@ int CCallback::sendQueryReply(const JsonNode & reply, QueryID queryID)
 	return sendRequest(&pack);
 }
 
-void CCallback::recruitCreatures(const CGDwelling *obj, const CArmedInstance * dst, CreatureID ID, ui32 amount, si32 level/*=-1*/)
+void CCallback::recruitCreatures(const CGDwelling * obj, const CArmedInstance * dst, CreatureID ID, ui32 amount, si32 level)
 {
 	// TODO exception for neutral dwellings shouldn't be hardcoded
 	if(player != obj->tempOwner && obj->ID != Obj::WAR_MACHINE_FACTORY && obj->ID != Obj::REFUGEE_CAMP)
@@ -212,7 +212,7 @@ void CCallback::buyArtifact(const CGHeroInstance *hero, ArtifactID aid)
 	sendRequest(&pack);
 }
 
-void CCallback::trade(const CGObjectInstance *market, EMarketMode::EMarketMode mode, int id1, int id2, int val1, const CGHeroInstance *hero/* = nullptr*/)
+void CCallback::trade(const CGObjectInstance *market, EMarketMode::EMarketMode mode, int id1, int id2, int val1, const CGHeroInstance *hero)
 {
 	TradeOnMarketplace pack;
 	pack.market = market;

--- a/client/CMT.cpp
+++ b/client/CMT.cpp
@@ -1314,7 +1314,7 @@ static void mainLoop()
 	}
 }
 
-void startGame(StartInfo * options, CConnection *serv/* = nullptr*/)
+void startGame(StartInfo * options, CConnection *serv)
 {
 	if(!settings["session"]["donotstartserver"].Bool())
 	{
@@ -1366,7 +1366,7 @@ void endGame()
 	vstd::clear_pointer(client);
 }
 
-void handleQuit(bool ask/* = true*/)
+void handleQuit(bool ask)
 {
 	auto quitApplication = []()
 	{

--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -1588,7 +1588,7 @@ void CPlayerInterface::showRecruitmentDialog(const CGDwelling *dwelling, const C
 	GH.pushInt(cr);
 }
 
-void CPlayerInterface::waitWhileDialog(bool unlockPim /*= true*/)
+void CPlayerInterface::waitWhileDialog(bool unlockPim)
 {
 	if (GH.amIGuiThread())
 	{
@@ -2281,7 +2281,7 @@ void CPlayerInterface::advmapSpellCast(const CGHeroInstance * caster, int spellI
 		CCS->soundh->playSound(castSoundPath);
 }
 
-void CPlayerInterface::eraseCurrentPathOf( const CGHeroInstance * ho, bool checkForExistanceOfPath /*= true */ )
+void CPlayerInterface::eraseCurrentPathOf(const CGHeroInstance * ho, bool checkForExistanceOfPath)
 {
 	if (checkForExistanceOfPath)
 	{
@@ -2495,7 +2495,7 @@ void CPlayerInterface::showHillFortWindow(const CGObjectInstance *object, const 
 	GH.pushInt(chfw);
 }
 
-void CPlayerInterface::availableArtifactsChanged(const CGBlackMarket *bm /*= nullptr*/)
+void CPlayerInterface::availableArtifactsChanged(const CGBlackMarket * bm)
 {
 	EVENT_HANDLER_CALLED_BY_CLIENT;
 	if (CMarketplaceWindow *cmw = dynamic_cast<CMarketplaceWindow*>(GH.topInt()))
@@ -2693,7 +2693,7 @@ void CPlayerInterface::playerStartsTurn(PlayerColor player)
 	}
 }
 
-void CPlayerInterface::waitForAllDialogs(bool unlockPim /*= true*/)
+void CPlayerInterface::waitForAllDialogs(bool unlockPim)
 {
 	while(!dialogs.empty())
 	{

--- a/client/CPreGame.cpp
+++ b/client/CPreGame.cpp
@@ -484,7 +484,7 @@ CGPreGame::~CGPreGame()
 		GH.curInt = nullptr;
 }
 
-void CGPreGame::openSel(CMenuScreen::EState screenType, CMenuScreen::EGameMode gameMode /*= CMenuScreen::SINGLE_PLAYER*/)
+void CGPreGame::openSel(CMenuScreen::EState screenType, CMenuScreen::EGameMode gameMode)
 {
 	GH.pushInt(new CSelectionScreen(screenType, gameMode));
 }
@@ -558,7 +558,7 @@ void CGPreGame::removeFromGui()
 	GH.popInt(GH.topInt()); //remove background
 }
 
-CSelectionScreen::CSelectionScreen(CMenuScreen::EState Type, CMenuScreen::EGameMode GameMode /*= CMenuScreen::SINGLE_PLAYER*/, const std::map<ui8, std::string> * Names /*= nullptr*/, const std::string & Address /*=""*/, const ui16 Port)
+CSelectionScreen::CSelectionScreen(CMenuScreen::EState Type, CMenuScreen::EGameMode GameMode, const std::map<ui8, std::string> * Names, const std::string & Address, const ui16 Port)
 	: ISelectionScreenInfo(Names), serverHandlingThread(nullptr), mx(new boost::recursive_mutex),
 	  serv(nullptr), ongoingClosing(false), myNameID(255)
 {
@@ -1201,7 +1201,7 @@ void SelectionTab::parseCampaigns(const std::unordered_set<ResourceID> &files )
 	}
 }
 
-SelectionTab::SelectionTab(CMenuScreen::EState Type, const std::function<void(CMapInfo *)> &OnSelect, CMenuScreen::EGameMode GameMode /*= CMenuScreen::SINGLE_PLAYER*/)
+SelectionTab::SelectionTab(CMenuScreen::EState Type, const std::function<void(CMapInfo *)> &OnSelect, CMenuScreen::EGameMode GameMode)
 	:bg(nullptr), onSelect(OnSelect)
 {
 	OBJ_CONSTRUCTION;
@@ -3809,7 +3809,7 @@ void CBonusSelection::decreaseDifficulty()
 	startInfo.difficulty = std::max(startInfo.difficulty - 1, 0);
 }
 
-void CBonusSelection::updateStartButtonState(int selected /*= -1*/)
+void CBonusSelection::updateStartButtonState(int selected)
 {
 	if(selected == -1)
 	{
@@ -3920,7 +3920,7 @@ CSavingScreen::~CSavingScreen()
 
 }
 
-ISelectionScreenInfo::ISelectionScreenInfo(const std::map<ui8, std::string> *Names /*= nullptr*/)
+ISelectionScreenInfo::ISelectionScreenInfo(const std::map<ui8, std::string> * Names)
 {
 	gameMode = CMenuScreen::SINGLE_PLAYER;
 	screenType = CMenuScreen::mainMenu;

--- a/client/CVideoHandler.cpp
+++ b/client/CVideoHandler.cpp
@@ -79,14 +79,14 @@ CVideoPlayer::CVideoPlayer()
 	av_register_all();
 }
 
-bool CVideoPlayer::open(std::string fname, bool scale/* = false*/)
+bool CVideoPlayer::open(std::string fname, bool scale)
 {
 	return open(fname, true, false);
 }
 
 // loop = to loop through the video
 // useOverlay = directly write to the screen.
-bool CVideoPlayer::open(std::string fname, bool loop, bool useOverlay, bool scale /*= false*/)
+bool CVideoPlayer::open(std::string fname, bool loop, bool useOverlay, bool scale)
 {
 	close();
 
@@ -423,7 +423,7 @@ bool CVideoPlayer::playVideo(int x, int y, SDL_Surface *dst, bool stopOnKey)
 	return true;
 }
 
-bool CVideoPlayer::openAndPlayVideo(std::string name, int x, int y, SDL_Surface *dst, bool stopOnKey, bool scale/* = false*/)
+bool CVideoPlayer::openAndPlayVideo(std::string name, int x, int y, SDL_Surface *dst, bool stopOnKey, bool scale)
 {
 	open(name, false, true, scale);
 	bool ret = playVideo(x, y, dst, stopOnKey);

--- a/client/Client.cpp
+++ b/client/Client.cpp
@@ -210,7 +210,7 @@ void CClient::save(const std::string & fname)
 	sendRequest((CPackForClient*)&save_game, PlayerColor::NEUTRAL);
 }
 
-void CClient::endGame(bool closeConnection /*= true*/)
+void CClient::endGame(bool closeConnection)
 {
 	//suggest interfaces to finish their stuff (AI should interrupt any bg working threads)
 	for (auto& i : playerint)
@@ -927,7 +927,7 @@ void CClient::installNewPlayerInterface(std::shared_ptr<CGameInterface> gameInte
 	installNewBattleInterface(gameInterface, color, battlecb);
 }
 
-void CClient::installNewBattleInterface(std::shared_ptr<CBattleGameInterface> battleInterface, boost::optional<PlayerColor> color, bool needCallback /*= true*/)
+void CClient::installNewBattleInterface(std::shared_ptr<CBattleGameInterface> battleInterface, boost::optional<PlayerColor> color, bool needCallback)
 {
 	boost::unique_lock<boost::recursive_mutex> un(*CPlayerInterface::pim);
 	PlayerColor colorUsed = color.get_value_or(PlayerColor::UNFLAGGABLE);
@@ -1047,7 +1047,7 @@ std::string CServerHandler::getDefaultPortStr()
 	return boost::lexical_cast<std::string>(getDefaultPort());
 }
 
-CServerHandler::CServerHandler(bool runServer /*= false*/)
+CServerHandler::CServerHandler(bool runServer)
 {
 	serverThread = nullptr;
 	shared = nullptr;

--- a/client/battle/CBattleInterface.cpp
+++ b/client/battle/CBattleInterface.cpp
@@ -1974,7 +1974,7 @@ static bool immobile(const CStack *s)
 	return !s->Speed(0, true); //should bound stacks be immobile?
 }
 
-void CBattleInterface::bTacticNextStack(const CStack *current /*= nullptr*/)
+void CBattleInterface::bTacticNextStack(const CStack * current)
 {
 	if (!current)
 		current = activeStack;

--- a/client/gui/CAnimation.cpp
+++ b/client/gui/CAnimation.cpp
@@ -1567,7 +1567,7 @@ CFadeAnimation::~CFadeAnimation()
 		SDL_FreeSurface(fadingSurface);
 }
 
-void CFadeAnimation::init(EMode mode, SDL_Surface * sourceSurface, bool freeSurfaceAtEnd /* = false */, float animDelta /* = DEFAULT_DELTA */)
+void CFadeAnimation::init(EMode mode, SDL_Surface * sourceSurface, bool freeSurfaceAtEnd, float animDelta)
 {
 	if (fading)
 	{

--- a/client/gui/CIntObject.cpp
+++ b/client/gui/CIntObject.cpp
@@ -160,17 +160,17 @@ void CIntObject::click(EIntObjMouseBtnType btn, tribool down, bool previousState
 	}
 }
 
-void CIntObject::printAtLoc( const std::string & text, int x, int y, EFonts font, SDL_Color kolor/*=Colors::WHITE*/, SDL_Surface * dst/*=screen*/ )
+void CIntObject::printAtLoc(const std::string & text, int x, int y, EFonts font, SDL_Color kolor, SDL_Surface * dst)
 {
 	graphics->fonts[font]->renderTextLeft(dst, text, kolor, Point(pos.x + x, pos.y + y));
 }
 
-void CIntObject::printAtRightLoc( const std::string & text, int x, int y, EFonts font, SDL_Color kolor/*=Colors::WHITE*/, SDL_Surface * dst/*=screen*/ )
+void CIntObject::printAtRightLoc(const std::string & text, int x, int y, EFonts font, SDL_Color kolor, SDL_Surface * dst)
 {
 	graphics->fonts[font]->renderTextRight(dst, text, kolor, Point(pos.x + x, pos.y + y));
 }
 
-void CIntObject::printAtMiddleLoc( const std::string & text, int x, int y, EFonts font, SDL_Color kolor/*=Colors::WHITE*/, SDL_Surface * dst/*=screen*/ )
+void CIntObject::printAtMiddleLoc(const std::string & text, int x, int y, EFonts font, SDL_Color kolor, SDL_Surface * dst)
 {
 	printAtMiddleLoc(text, Point(x,y), font, kolor, dst);
 }
@@ -251,7 +251,7 @@ void CIntObject::fitToScreen(int borderWidth, bool propagate)
 		moveTo(newPos, propagate);
 }
 
-void CIntObject::moveBy( const Point &p, bool propagate /*= true*/ )
+void CIntObject::moveBy(const Point & p, bool propagate)
 {
 	pos.x += p.x;
 	pos.y += p.y;
@@ -260,12 +260,12 @@ void CIntObject::moveBy( const Point &p, bool propagate /*= true*/ )
 			elem->moveBy(p, propagate);
 }
 
-void CIntObject::moveTo( const Point &p, bool propagate /*= true*/ )
+void CIntObject::moveTo(const Point & p, bool propagate)
 {
 	moveBy(Point(p.x - pos.x, p.y - pos.y), propagate);
 }
 
-void CIntObject::addChild(CIntObject *child, bool adjustPosition /*= false*/)
+void CIntObject::addChild(CIntObject * child, bool adjustPosition)
 {
 	if (vstd::contains(children, child))
 	{
@@ -286,7 +286,7 @@ void CIntObject::addChild(CIntObject *child, bool adjustPosition /*= false*/)
 		child->activate();
 }
 
-void CIntObject::removeChild(CIntObject *child, bool adjustPosition /*= false*/)
+void CIntObject::removeChild(CIntObject * child, bool adjustPosition)
 {
 	if (!child)
 		return;
@@ -335,7 +335,7 @@ const Rect & CIntObject::center( bool propagate )
 	return center(pos, propagate);
 }
 
-const Rect & CIntObject::center(const Point &p, bool propagate /*= true*/)
+const Rect & CIntObject::center(const Point & p, bool propagate)
 {
 	moveBy(Point(p.x - pos.w/2 - pos.x,
 		p.y - pos.h/2 - pos.y),

--- a/client/gui/Geometries.cpp
+++ b/client/gui/Geometries.cpp
@@ -21,7 +21,7 @@ Rect Rect::createCentered( int w, int h )
 	return Rect(screen->w/2 - w/2, screen->h/2 - h/2, w, h);
 }
 
-Rect Rect::around(const Rect &r, int width /*= 1*/) /*creates rect around another */
+Rect Rect::around(const Rect &r, int width) /*creates rect around another */
 {
 	return Rect(r.x - width, r.y - width, r.w + width * 2, r.h + width * 2);
 }

--- a/client/gui/SDL_Extensions.cpp
+++ b/client/gui/SDL_Extensions.cpp
@@ -496,7 +496,7 @@ void CSDL_Ext::VflipSurf(SDL_Surface * surf)
 	}
 }
 
-void CSDL_Ext::SDL_PutPixelWithoutRefresh(SDL_Surface *ekran, const int & x, const int & y, const Uint8 & R, const Uint8 & G, const Uint8 & B, Uint8 A /*= 255*/)
+void CSDL_Ext::SDL_PutPixelWithoutRefresh(SDL_Surface *ekran, const int & x, const int & y, const Uint8 & R, const Uint8 & G, const Uint8 & B, Uint8 A)
 {
 	Uint8 *p = getPxPtr(ekran, x, y);
 	getPutterFor(ekran, false)(p, R, G, B);
@@ -509,7 +509,7 @@ void CSDL_Ext::SDL_PutPixelWithoutRefresh(SDL_Surface *ekran, const int & x, con
 	}
 }
 
-void CSDL_Ext::SDL_PutPixelWithoutRefreshIfInSurf(SDL_Surface *ekran, const int & x, const int & y, const Uint8 & R, const Uint8 & G, const Uint8 & B, Uint8 A /*= 255*/)
+void CSDL_Ext::SDL_PutPixelWithoutRefreshIfInSurf(SDL_Surface *ekran, const int & x, const int & y, const Uint8 & R, const Uint8 & G, const Uint8 & B, Uint8 A)
 {
 	const SDL_Rect & rect = ekran->clip_rect;
 

--- a/client/mapHandler.cpp
+++ b/client/mapHandler.cpp
@@ -131,7 +131,7 @@ void CMapHandler::prepareFOWDefs()
 		FoWpartialHide[frame] = graphics->fogOfWarPartialHide->getImage(frame);
 }
 
-EMapAnimRedrawStatus CMapHandler::drawTerrainRectNew(SDL_Surface * targetSurface, const MapDrawingInfo * info, bool redrawOnlyAnim /* = false */)
+EMapAnimRedrawStatus CMapHandler::drawTerrainRectNew(SDL_Surface * targetSurface, const MapDrawingInfo * info, bool redrawOnlyAnim)
 {
 	assert(info);
 	bool hasActiveFade = updateObjectsFade();
@@ -1193,7 +1193,7 @@ bool CMapHandler::startObjectFade(TerrainTileObject & obj, bool in, int3 pos)
 	return false;
 }
 
-bool CMapHandler::printObject(const CGObjectInstance *obj, bool fadein /* = false */)
+bool CMapHandler::printObject(const CGObjectInstance * obj, bool fadein)
 {
 	auto animation = graphics->getAnimation(obj);
 
@@ -1248,7 +1248,7 @@ bool CMapHandler::printObject(const CGObjectInstance *obj, bool fadein /* = fals
 	return true;
 }
 
-bool CMapHandler::hideObject(const CGObjectInstance *obj, bool fadeout /* = false */)
+bool CMapHandler::hideObject(const CGObjectInstance * obj, bool fadeout)
 {
 	//optimized version which reveals weird bugs with missing def name
 	//auto pos = obj->pos;

--- a/client/widgets/AdventureMapClasses.cpp
+++ b/client/widgets/AdventureMapClasses.cpp
@@ -1255,7 +1255,7 @@ void CAdvMapPanel::showAll(SDL_Surface * to)
 	CIntObject::showAll(to);
 }
 
-void CAdvMapPanel::addChildToPanel(CIntObject * obj, ui8 actions /* = 0 */)
+void CAdvMapPanel::addChildToPanel(CIntObject * obj, ui8 actions)
 {
 	obj->recActions |= actions | SHOWALL;
 	addChild(obj, false);

--- a/client/widgets/CArtifactHolder.cpp
+++ b/client/widgets/CArtifactHolder.cpp
@@ -371,7 +371,7 @@ bool CHeroArtPlace::fitsHere(const CArtifactInstance * art) const
 	return art->canBePutAt(ArtifactLocation(ourOwner->curHero, slotID), true);
 }
 
-void CHeroArtPlace::setMeAsDest(bool backpackAsVoid /*= true*/)
+void CHeroArtPlace::setMeAsDest(bool backpackAsVoid)
 {
 	ourOwner->commonInfo->dst.setTo(this, backpackAsVoid);
 }
@@ -528,7 +528,7 @@ void CArtifactsOfHero::markPossibleSlots(const CArtifactInstance* art)
 /**
  * Unamarks all slots.
  */
-void CArtifactsOfHero::unmarkSlots(bool withRedraw /*= true*/)
+void CArtifactsOfHero::unmarkSlots(bool withRedraw)
 {
 	if(commonInfo)
 		for(CArtifactsOfHero *aoh : commonInfo->participants)
@@ -540,7 +540,7 @@ void CArtifactsOfHero::unmarkSlots(bool withRedraw /*= true*/)
 		safeRedraw();
 }
 
-void CArtifactsOfHero::unmarkLocalSlots(bool withRedraw /*= true*/)
+void CArtifactsOfHero::unmarkLocalSlots(bool withRedraw)
 {
 	for(auto p : artWorn)
 		p.second->selectSlot(false);
@@ -616,7 +616,7 @@ CArtifactsOfHero::CArtifactsOfHero(std::map<ArtifactPosition, CHeroArtPlace *> A
 	rightArtRoll->addCallback(std::bind(&CArtifactsOfHero::scrollBackpack,this,+1));
 }
 
-CArtifactsOfHero::CArtifactsOfHero(const Point& position, bool createCommonPart /*= false*/)
+CArtifactsOfHero::CArtifactsOfHero(const Point& position, bool createCommonPart)
  : curHero(nullptr), backpackPos(0), commonInfo(nullptr), updateState(false), allowedAssembling(true), highlightModeCallback(nullptr)
 {
 	if(createCommonPart)
@@ -848,7 +848,7 @@ void CArtifactsOfHero::artifactDisassembled(const ArtifactLocation &al)
 		updateWornSlots();
 }
 
-void CArtifactsOfHero::updateWornSlots(bool redrawParent /*= true*/)
+void CArtifactsOfHero::updateWornSlots(bool redrawParent)
 {
 	for(auto p : artWorn)
 		updateSlot(p.first);

--- a/client/widgets/Images.cpp
+++ b/client/widgets/Images.cpp
@@ -63,19 +63,19 @@ CPicture::CPicture( const std::string &bmpname, int x, int y )
 	}
 }
 
-CPicture::CPicture(const Rect &r, const SDL_Color &color, bool screenFormat /*= false*/)
+CPicture::CPicture(const Rect &r, const SDL_Color &color, bool screenFormat)
 {
 	init();
 	createSimpleRect(r, screenFormat, SDL_MapRGB(bg->format, color.r, color.g,color.b));
 }
 
-CPicture::CPicture(const Rect &r, ui32 color, bool screenFormat /*= false*/)
+CPicture::CPicture(const Rect &r, ui32 color, bool screenFormat)
 {
 	init();
 	createSimpleRect(r, screenFormat, color);
 }
 
-CPicture::CPicture(SDL_Surface *BG, const Rect &SrcRect, int x /*= 0*/, int y /*= 0*/, bool free /*= false*/)
+CPicture::CPicture(SDL_Surface * BG, const Rect &SrcRect, int x, int y, bool free)
 {
 	visible = true;
 	needRefresh = false;

--- a/client/widgets/MiscWidgets.cpp
+++ b/client/widgets/MiscWidgets.cpp
@@ -66,7 +66,7 @@ LRClickableAreaWText::LRClickableAreaWText()
 	init();
 }
 
-LRClickableAreaWText::LRClickableAreaWText(const Rect &Pos, const std::string &HoverText /*= ""*/, const std::string &ClickText /*= ""*/)
+LRClickableAreaWText::LRClickableAreaWText(const Rect &Pos, const std::string &HoverText, const std::string &ClickText)
 {
 	init();
 	pos = Pos + pos;

--- a/client/widgets/TextControls.cpp
+++ b/client/widgets/TextControls.cpp
@@ -32,7 +32,7 @@ void CLabel::showAll(SDL_Surface * to)
 
 }
 
-CLabel::CLabel(int x, int y, EFonts Font /*= FONT_SMALL*/, EAlignment Align, const SDL_Color &Color /*= Colors::WHITE*/, const std::string &Text /*= ""*/)
+CLabel::CLabel(int x, int y, EFonts Font, EAlignment Align, const SDL_Color &Color, const std::string &Text)
 :CTextContainer(Align, Font, Color), text(Text)
 {
 	type |= REDRAW_PARENT;
@@ -243,7 +243,7 @@ void CLabelGroup::add(int x, int y, const std::string &text)
 	new CLabel(x, y, font, align, color, text);
 }
 
-CTextBox::CTextBox(std::string Text, const Rect &rect, int SliderStyle, EFonts Font /*= FONT_SMALL*/, EAlignment Align /*= TOPLEFT*/, const SDL_Color &Color /*= Colors::WHITE*/):
+CTextBox::CTextBox(std::string Text, const Rect &rect, int SliderStyle, EFonts Font, EAlignment Align, const SDL_Color &Color):
 	sliderStyle(SliderStyle),
 	slider(nullptr)
 {
@@ -317,7 +317,7 @@ void CGStatusBar::clear()
 	setText("");
 }
 
-CGStatusBar::CGStatusBar(CPicture *BG, EFonts Font /*= FONT_SMALL*/, EAlignment Align /*= CENTER*/, const SDL_Color &Color /*= Colors::WHITE*/)
+CGStatusBar::CGStatusBar(CPicture *BG, EFonts Font, EAlignment Align, const SDL_Color &Color)
 : CLabel(BG->pos.x, BG->pos.y, Font, Align, Color, "")
 {
 	init();
@@ -328,7 +328,7 @@ CGStatusBar::CGStatusBar(CPicture *BG, EFonts Font /*= FONT_SMALL*/, EAlignment 
 	textLock = false;
 }
 
-CGStatusBar::CGStatusBar(int x, int y, std::string name/*="ADROLLVR.bmp"*/, int maxw/*=-1*/)
+CGStatusBar::CGStatusBar(int x, int y, std::string name, int maxw)
 : CLabel(x, y, FONT_SMALL, CENTER)
 {
 	OBJ_CONSTRUCTION_CAPTURING_ALL;

--- a/client/windows/CAdvmapInterface.cpp
+++ b/client/windows/CAdvmapInterface.cpp
@@ -1122,7 +1122,7 @@ void CAdvMapInt::selectionChanged()
 		select(to);
 }
 
-void CAdvMapInt::centerOn(int3 on, bool fade /* = false */)
+void CAdvMapInt::centerOn(int3 on, bool fade)
 {
 	bool switchedLevels = on.z != position.z;
 
@@ -1161,7 +1161,7 @@ void CAdvMapInt::centerOn(int3 on, bool fade /* = false */)
 		terrain.redraw();
 }
 
-void CAdvMapInt::centerOn(const CGObjectInstance *obj, bool fade /* = false */)
+void CAdvMapInt::centerOn(const CGObjectInstance * obj, bool fade)
 {
 	centerOn(obj->getSightCenter(), fade);
 }
@@ -1380,7 +1380,7 @@ int3 CAdvMapInt::verifyPos(int3 ver)
 	return ver;
 }
 
-void CAdvMapInt::select(const CArmedInstance *sel, bool centerView /*= true*/)
+void CAdvMapInt::select(const CArmedInstance *sel, bool centerView)
 {
 	assert(sel);
 	LOCPLINT->setSelection(sel);
@@ -1793,7 +1793,7 @@ void CAdvMapInt::enterCastingMode(const CSpell * sp)
 	GH.fakeMouseMove();
 }
 
-void CAdvMapInt::leaveCastingMode(bool cast /*= false*/, int3 dest /*= int3(-1, -1, -1)*/)
+void CAdvMapInt::leaveCastingMode(bool cast, int3 dest)
 {
 	assert(spellBeingCasted);
 	SpellID id = spellBeingCasted->id;
@@ -1868,7 +1868,7 @@ void CAdvMapInt::quickCombatUnlock()
 		activate();
 }
 
-void CAdvMapInt::changeMode(EAdvMapMode newMode, float newScale /* = 0.4f */)
+void CAdvMapInt::changeMode(EAdvMapMode newMode, float newScale)
 {
 	if (mode != newMode)
 	{

--- a/client/windows/CHeroWindow.cpp
+++ b/client/windows/CHeroWindow.cpp
@@ -38,7 +38,7 @@
 #include "../mapHandler.h"
 
 
-const TBonusListPtr CHeroWithMaybePickedArtifact::getAllBonuses(const CSelector &selector, const CSelector &limit, const CBonusSystemNode *root /*= nullptr*/, const std::string &cachingStr /*= ""*/) const
+const TBonusListPtr CHeroWithMaybePickedArtifact::getAllBonuses(const CSelector &selector, const CSelector &limit, const CBonusSystemNode *root, const std::string & cachingStr) const
 {
 	TBonusListPtr out(new BonusList);
 	TBonusListPtr heroBonuses = hero->getAllBonuses(selector, limit, hero);
@@ -177,7 +177,7 @@ CHeroWindow::CHeroWindow(const CGHeroInstance *hero):
 	update(hero);
 }
 
-void CHeroWindow::update(const CGHeroInstance * hero, bool redrawNeeded /*= false*/)
+void CHeroWindow::update(const CGHeroInstance * hero, bool redrawNeeded)
 {
 	auto & heroscrn = CGI->generaltexth->heroscrn;
 

--- a/client/windows/CTradeWindow.cpp
+++ b/client/windows/CTradeWindow.cpp
@@ -274,7 +274,7 @@ void CTradeWindow::CTradeableItem::clickRight(tribool down, bool previousState)
 	}
 }
 
-std::string CTradeWindow::CTradeableItem::getName(int number /*= -1*/) const
+std::string CTradeWindow::CTradeableItem::getName(int number) const
 {
 	switch(type)
 	{
@@ -1110,7 +1110,7 @@ void CMarketplaceWindow::updateTraderText()
 	traderText->setText(CGI->generaltexth->allTexts[gnrtxtnr]);
 }
 
-CAltarWindow::CAltarWindow(const IMarket *Market, const CGHeroInstance *Hero /*= nullptr*/, EMarketMode::EMarketMode Mode)
+CAltarWindow::CAltarWindow(const IMarket * Market, const CGHeroInstance * Hero, EMarketMode::EMarketMode Mode)
 	:CTradeWindow((Mode == EMarketMode::CREATURE_EXP ? "ALTARMON.bmp" : "ALTRART2.bmp"), Market, Hero, Mode)
 {
 	OBJ_CONSTRUCTION_CAPTURING_ALL;

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -675,7 +675,7 @@ void CSystemOptionsWindow::brestartf()
 	LOCPLINT->showYesNoDialog(CGI->generaltexth->allTexts[67], [this]{ closeAndPushEvent(SDL_USEREVENT, RESTART_GAME); }, 0);
 }
 
-void CSystemOptionsWindow::closeAndPushEvent(int eventType, int code /*= 0*/)
+void CSystemOptionsWindow::closeAndPushEvent(int eventType, int code)
 {
 	GH.popIntTotally(this);
 	GH.pushSDLEvent(eventType, code);

--- a/client/windows/InfoWindows.cpp
+++ b/client/windows/InfoWindows.cpp
@@ -218,7 +218,7 @@ void CInfoWindow::showOkDialog(const std::string & text, const std::vector<CComp
 	GH.pushInt(temp);
 }
 
-CInfoWindow * CInfoWindow::create(const std::string &text, PlayerColor playerID /*= 1*/, const std::vector<CComponent*> *components /*= nullptr*/, bool DelComps)
+CInfoWindow * CInfoWindow::create(const std::string &text, PlayerColor playerID, const std::vector<CComponent*> *components, bool DelComps)
 {
 	std::vector<std::pair<std::string,CFunctionList<void()> > > pom;
 	pom.push_back(std::pair<std::string,CFunctionList<void()> >("IOKAY.DEF",0));
@@ -250,7 +250,7 @@ CInfoPopup::CInfoPopup(SDL_Surface * Bitmap, int x, int y, bool Free)
 }
 
 
-CInfoPopup::CInfoPopup(SDL_Surface * Bitmap, const Point &p, EAlignment alignment, bool Free/*=false*/)
+CInfoPopup::CInfoPopup(SDL_Surface * Bitmap, const Point &p, EAlignment alignment, bool Free)
  : free(Free),bitmap(Bitmap)
 {
 	switch(alignment)
@@ -352,7 +352,7 @@ void CRClickPopup::createAndPush(const std::string &txt, CComponent * component)
 	createAndPush(txt, intComps);
 }
 
-void CRClickPopup::createAndPush(const CGObjectInstance *obj, const Point &p, EAlignment alignment /*= BOTTOMRIGHT*/)
+void CRClickPopup::createAndPush(const CGObjectInstance *obj, const Point &p, EAlignment alignment)
 {
 	CIntObject *iWin = createInfoWin(p, obj); //try get custom infowindow for this obj
 	if(iWin)

--- a/lib/CAndroidVMHelper.cpp
+++ b/lib/CAndroidVMHelper.cpp
@@ -65,7 +65,7 @@ jclass CAndroidVMHelper::findClassloadedClass(const std::string & name)
 }
 
 void CAndroidVMHelper::callStaticVoidMethod(const std::string & cls, const std::string & method,
-											bool classloaded /*=false*/)
+											bool classloaded)
 {
 	auto env = get();
 	auto javaHelper = findClass(cls, classloaded);
@@ -74,7 +74,7 @@ void CAndroidVMHelper::callStaticVoidMethod(const std::string & cls, const std::
 }
 
 std::string CAndroidVMHelper::callStaticStringMethod(const std::string & cls, const std::string & method,
-													 bool classloaded /*=false*/)
+													 bool classloaded)
 {
 	auto env = get();
 	auto javaHelper = findClass(cls, classloaded);

--- a/lib/CArtHandler.cpp
+++ b/lib/CArtHandler.cpp
@@ -572,7 +572,7 @@ void CArtHandler::giveArtBonus( ArtifactID aid, Bonus::BonusType type, int val, 
 	giveArtBonus(aid, createBonus(type, val, subtype, valType, limiter, additionalInfo));
 }
 
-void CArtHandler::giveArtBonus(ArtifactID aid, Bonus::BonusType type, int val, int subtype, std::shared_ptr<IPropagator> propagator /*= nullptr*/, int additionalInfo)
+void CArtHandler::giveArtBonus(ArtifactID aid, Bonus::BonusType type, int val, int subtype, std::shared_ptr<IPropagator> propagator, int additionalInfo)
 {
 	giveArtBonus(aid, createBonus(type, val, subtype, propagator, additionalInfo));
 }
@@ -587,7 +587,7 @@ void CArtHandler::giveArtBonus(ArtifactID aid, std::shared_ptr<Bonus> bonus)
 
 	artifacts[aid]->addNewBonus(bonus);
 }
-void CArtHandler::makeItCreatureArt (CArtifact * a, bool onlyCreature /*=true*/)
+void CArtHandler::makeItCreatureArt(CArtifact * a, bool onlyCreature)
 {
 	if (onlyCreature)
 	{
@@ -597,13 +597,13 @@ void CArtHandler::makeItCreatureArt (CArtifact * a, bool onlyCreature /*=true*/)
 	a->possibleSlots[ArtBearer::CREATURE].push_back(ArtifactPosition::CREATURE_SLOT);
 }
 
-void CArtHandler::makeItCreatureArt (ArtifactID aid, bool onlyCreature /*=true*/)
+void CArtHandler::makeItCreatureArt(ArtifactID aid, bool onlyCreature)
 {
 	CArtifact *a = artifacts[aid];
 	makeItCreatureArt (a, onlyCreature);
 }
 
-void CArtHandler::makeItCommanderArt (CArtifact * a, bool onlyCommander /*= true*/ )
+void CArtHandler::makeItCommanderArt(CArtifact * a, bool onlyCommander)
 {
 	if (onlyCommander)
 	{
@@ -614,7 +614,7 @@ void CArtHandler::makeItCommanderArt (CArtifact * a, bool onlyCommander /*= true
 		a->possibleSlots[ArtBearer::COMMANDER].push_back(ArtifactPosition(i));
 }
 
-void CArtHandler::makeItCommanderArt( ArtifactID aid, bool onlyCommander /*= true*/ )
+void CArtHandler::makeItCommanderArt(ArtifactID aid, bool onlyCommander)
 {
 	CArtifact *a = artifacts[aid];
 	makeItCommanderArt (a, onlyCommander);
@@ -850,12 +850,12 @@ ArtifactPosition CArtifactInstance::firstBackpackSlot(const CArtifactSet *h) con
 	return ArtifactPosition::PRE_FIRST;
 }
 
-bool CArtifactInstance::canBePutAt(const ArtifactLocation & al, bool assumeDestRemoved /*= false*/) const
+bool CArtifactInstance::canBePutAt(const ArtifactLocation & al, bool assumeDestRemoved) const
 {
 	return canBePutAt(al.getHolderArtSet(), al.slot, assumeDestRemoved);
 }
 
-bool CArtifactInstance::canBePutAt(const CArtifactSet *artSet, ArtifactPosition slot, bool assumeDestRemoved /*= false*/) const
+bool CArtifactInstance::canBePutAt(const CArtifactSet *artSet, ArtifactPosition slot, bool assumeDestRemoved) const
 {
 	if(slot >= GameConstants::BACKPACK_START)
 	{
@@ -1019,7 +1019,7 @@ bool CArtifactInstance::isPart(const CArtifactInstance *supposedPart) const
 	return supposedPart == this;
 }
 
-bool CCombinedArtifactInstance::canBePutAt(const CArtifactSet *artSet, ArtifactPosition slot, bool assumeDestRemoved /*= false*/) const
+bool CCombinedArtifactInstance::canBePutAt(const CArtifactSet *artSet, ArtifactPosition slot, bool assumeDestRemoved) const
 {
 	bool canMainArtifactBePlaced = CArtifactInstance::canBePutAt(artSet, slot, assumeDestRemoved);
 	if(!canMainArtifactBePlaced)
@@ -1191,7 +1191,7 @@ bool CCombinedArtifactInstance::isPart(const CArtifactInstance *supposedPart) co
 	return false;
 }
 
-CCombinedArtifactInstance::ConstituentInfo::ConstituentInfo(CArtifactInstance *Art /*= nullptr*/, ArtifactPosition Slot /*= -1*/)
+CCombinedArtifactInstance::ConstituentInfo::ConstituentInfo(CArtifactInstance *Art, ArtifactPosition Slot)
 {
 	art = Art;
 	slot = Slot;
@@ -1204,7 +1204,7 @@ bool CCombinedArtifactInstance::ConstituentInfo::operator==(const ConstituentInf
 
 CArtifactSet::~CArtifactSet() = default;
 
-const CArtifactInstance* CArtifactSet::getArt(ArtifactPosition pos, bool excludeLocked /*= true*/) const
+const CArtifactInstance* CArtifactSet::getArt(ArtifactPosition pos, bool excludeLocked) const
 {
 	if(const ArtSlotInfo *si = getSlot(pos))
 	{
@@ -1215,12 +1215,12 @@ const CArtifactInstance* CArtifactSet::getArt(ArtifactPosition pos, bool exclude
 	return nullptr;
 }
 
-CArtifactInstance* CArtifactSet::getArt(ArtifactPosition pos, bool excludeLocked /*= true*/)
+CArtifactInstance* CArtifactSet::getArt(ArtifactPosition pos, bool excludeLocked)
 {
 	return const_cast<CArtifactInstance*>((const_cast<const CArtifactSet*>(this))->getArt(pos, excludeLocked));
 }
 
-ArtifactPosition CArtifactSet::getArtPos(int aid, bool onlyWorn /*= true*/) const
+ArtifactPosition CArtifactSet::getArtPos(int aid, bool onlyWorn) const
 {
 	for(auto i = artifactsWorn.cbegin(); i != artifactsWorn.cend(); i++)
 		if(i->second.artifact->artType->id == aid)
@@ -1262,8 +1262,8 @@ const CArtifactInstance * CArtifactSet::getArtByInstanceId( ArtifactInstanceID a
 	return nullptr;
 }
 
-bool CArtifactSet::hasArt(ui32 aid, bool onlyWorn /*= false*/,
-                          bool searchBackpackAssemblies /*= false*/) const
+bool CArtifactSet::hasArt(ui32 aid, bool onlyWorn,
+                          bool searchBackpackAssemblies) const
 {
 	return getArtPos(aid, onlyWorn) != ArtifactPosition::PRE_FIRST ||
 	       (searchBackpackAssemblies && getHiddenArt(aid));
@@ -1316,7 +1316,7 @@ const ArtSlotInfo * CArtifactSet::getSlot(ArtifactPosition pos) const
 	return nullptr;
 }
 
-bool CArtifactSet::isPositionFree(ArtifactPosition pos, bool onlyLockCheck /*= false*/) const
+bool CArtifactSet::isPositionFree(ArtifactPosition pos, bool onlyLockCheck) const
 {
 	if(const ArtSlotInfo *s = getSlot(pos))
 		return (onlyLockCheck || !s->artifact) && !s->locked;

--- a/lib/CCreatureHandler.cpp
+++ b/lib/CCreatureHandler.cpp
@@ -113,7 +113,7 @@ CCreature::CCreature()
 	iconIndex = -1;
 }
 
-void CCreature::addBonus(int val, Bonus::BonusType type, int subtype /*= -1*/)
+void CCreature::addBonus(int val, Bonus::BonusType type, int subtype)
 {
 	auto added = std::make_shared<Bonus>(Bonus::PERMANENT, type, Bonus::CREATURE_ABILITY, val, idNumber, subtype, Bonus::BASE_NUMBER);
 	addNewBonus(added);

--- a/lib/CCreatureSet.cpp
+++ b/lib/CCreatureSet.cpp
@@ -62,12 +62,12 @@ bool CCreatureSet::setCreature(SlotID slot, CreatureID type, TQuantity quantity)
 	return true;
 }
 
-SlotID CCreatureSet::getSlotFor(CreatureID creature, ui32 slotsAmount/*=7*/) const /*returns -1 if no slot available */
+SlotID CCreatureSet::getSlotFor(CreatureID creature, ui32 slotsAmount) const /*returns -1 if no slot available */
 {
 	return getSlotFor(VLC->creh->creatures[creature], slotsAmount);
 }
 
-SlotID CCreatureSet::getSlotFor(const CCreature *c, ui32 slotsAmount/*=ARMY_SIZE*/) const
+SlotID CCreatureSet::getSlotFor(const CCreature *c, ui32 slotsAmount) const
 {
 	assert(c->valid());
 	for(auto & elem : stacks)
@@ -81,7 +81,7 @@ SlotID CCreatureSet::getSlotFor(const CCreature *c, ui32 slotsAmount/*=ARMY_SIZE
 	return getFreeSlot(slotsAmount);
 }
 
-SlotID CCreatureSet::getFreeSlot(ui32 slotsAmount/*=ARMY_SIZE*/) const
+SlotID CCreatureSet::getFreeSlot(ui32 slotsAmount) const
 {
 	for(ui32 i=0; i<slotsAmount; i++)
 	{
@@ -112,7 +112,7 @@ TExpType CCreatureSet::getStackExperience(SlotID slot) const
 }
 
 
-bool CCreatureSet::mergableStacks(std::pair<SlotID, SlotID> &out, SlotID preferable /*= -1*/) const /*looks for two same stacks, returns slot positions */
+bool CCreatureSet::mergableStacks(std::pair<SlotID, SlotID> &out, SlotID preferable) const /*looks for two same stacks, returns slot positions */
 {
 	//try to match creature to our preferred stack
 	if(preferable.validSlot() &&  vstd::contains(stacks, preferable))
@@ -157,7 +157,7 @@ void CCreatureSet::sweep()
 	}
 }
 
-void CCreatureSet::addToSlot(SlotID slot, CreatureID cre, TQuantity count, bool allowMerging/* = true*/)
+void CCreatureSet::addToSlot(SlotID slot, CreatureID cre, TQuantity count, bool allowMerging)
 {
 	const CCreature *c = VLC->creh->creatures[cre];
 
@@ -175,7 +175,7 @@ void CCreatureSet::addToSlot(SlotID slot, CreatureID cre, TQuantity count, bool 
 	}
 }
 
-void CCreatureSet::addToSlot(SlotID slot, CStackInstance *stack, bool allowMerging/* = true*/)
+void CCreatureSet::addToSlot(SlotID slot, CStackInstance *stack, bool allowMerging)
 {
 	assert(stack->valid(true));
 
@@ -193,7 +193,7 @@ void CCreatureSet::addToSlot(SlotID slot, CStackInstance *stack, bool allowMergi
 	}
 }
 
-bool CCreatureSet::validTypes(bool allowUnrandomized /*= false*/) const
+bool CCreatureSet::validTypes(bool allowUnrandomized) const
 {
 	for(auto & elem : stacks)
 	{
@@ -674,7 +674,7 @@ void CStackInstance::setArmyObj(const CArmedInstance *ArmyObj)
 	}
 }
 
-std::string CStackInstance::getQuantityTXT(bool capitalized /*= true*/) const
+std::string CStackInstance::getQuantityTXT(bool capitalized) const
 {
 	int quantity = getQuantityID();
 

--- a/lib/CGameInfoCallback.cpp
+++ b/lib/CGameInfoCallback.cpp
@@ -168,7 +168,7 @@ void CGameInfoCallback::getUpgradeInfo(const CArmedInstance *obj, SlotID stackPo
 	//return gs->getUpgradeInfo(obj->getStack(stackPos));
 }
 
-const StartInfo * CGameInfoCallback::getStartInfo(bool beforeRandomization /*= false*/) const
+const StartInfo * CGameInfoCallback::getStartInfo(bool beforeRandomization) const
 {
 	//boost::shared_lock<boost::shared_mutex> lock(*gs->mx);
 	if(beforeRandomization)
@@ -231,7 +231,7 @@ int CGameInfoCallback::howManyTowns(PlayerColor Player) const
 	return gs->players[Player].towns.size();
 }
 
-bool CGameInfoCallback::getTownInfo(const CGObjectInstance * town, InfoAboutTown & dest, const CGObjectInstance * selectedObject/* = nullptr*/) const
+bool CGameInfoCallback::getTownInfo(const CGObjectInstance * town, InfoAboutTown & dest, const CGObjectInstance * selectedObject) const
 {
 	ERROR_RET_VAL_IF(!isVisible(town, player), "Town is not visible!", false);  //it's not a town or it's not visible for layer
 	bool detailed = hasAccess(town->tempOwner);
@@ -271,7 +271,7 @@ std::vector<const CGObjectInstance*> CGameInfoCallback::getGuardingCreatures (in
 	return ret;
 }
 
-bool CGameInfoCallback::getHeroInfo(const CGObjectInstance * hero, InfoAboutHero & dest, const CGObjectInstance * selectedObject/* = nullptr*/) const
+bool CGameInfoCallback::getHeroInfo(const CGObjectInstance * hero, InfoAboutHero & dest, const CGObjectInstance * selectedObject) const
 {
 	const CGHeroInstance *h = dynamic_cast<const CGHeroInstance *>(hero);
 
@@ -438,7 +438,7 @@ std::vector < const CGObjectInstance * > CGameInfoCallback::getBlockingObjs( int
 	return ret;
 }
 
-std::vector <const CGObjectInstance * > CGameInfoCallback::getVisitableObjs(int3 pos, bool verbose /*= true*/) const
+std::vector <const CGObjectInstance * > CGameInfoCallback::getVisitableObjs(int3 pos, bool verbose) const
 {
 	std::vector<const CGObjectInstance *> ret;
 	const TerrainTile *t = getTile(pos, verbose);

--- a/lib/CGameState.cpp
+++ b/lib/CGameState.cpp
@@ -312,7 +312,7 @@ static CGObjectInstance * createObject(Obj id, int subid, int3 pos, PlayerColor 
 }
 
 CGHeroInstance * CGameState::HeroesPool::pickHeroFor(bool native, PlayerColor player, const CTown *town,
-	std::map<ui32, ConstTransitivePtr<CGHeroInstance> > &available, CRandomGenerator & rand, const CHeroClass * bannedClass /*= nullptr*/) const
+	std::map<ui32, ConstTransitivePtr<CGHeroInstance> > &available, CRandomGenerator & rand, const CHeroClass * bannedClass) const
 {
 	CGHeroInstance *ret = nullptr;
 
@@ -2694,7 +2694,7 @@ void CGameState::giveHeroArtifact(CGHeroInstance *h, ArtifactID aid)
 	 ai->putAt(ArtifactLocation(h, ai->firstAvailableSlot(h)));
 }
 
-std::set<HeroTypeID> CGameState::getUnusedAllowedHeroes(bool alsoIncludeNotAllowed /*= false*/) const
+std::set<HeroTypeID> CGameState::getUnusedAllowedHeroes(bool alsoIncludeNotAllowed) const
 {
 	std::set<HeroTypeID> ret;
 	for(int i = 0; i < map->allowedHeroes.size(); i++)

--- a/lib/CGeneralTextHandler.cpp
+++ b/lib/CGeneralTextHandler.cpp
@@ -125,7 +125,7 @@ std::string Unicode::fromUnicode(const std::string &text, const std::string &enc
 	return boost::locale::conv::from_utf<char>(text, encoding);
 }
 
-void Unicode::trimRight(std::string & text, const size_t amount/* =1 */)
+void Unicode::trimRight(std::string & text, const size_t amount)
 {
 	if(text.empty())
 		return;

--- a/lib/CHeroHandler.cpp
+++ b/lib/CHeroHandler.cpp
@@ -87,7 +87,7 @@ std::vector<BattleHex> CObstacleInfo::getBlocked(BattleHex hex) const
 	return ret;
 }
 
-bool CObstacleInfo::isAppropriate(ETerrainType terrainType, int specialBattlefield /*= -1*/) const
+bool CObstacleInfo::isAppropriate(ETerrainType terrainType, int specialBattlefield) const
 {
 	if(specialBattlefield != -1)
 		return vstd::contains(allowedSpecialBfields, specialBattlefield);

--- a/lib/CStack.cpp
+++ b/lib/CStack.cpp
@@ -395,14 +395,14 @@ si32 CStack::magicResistance() const
 	return magicResistance;
 }
 
-bool CStack::willMove(int turn /*= 0*/) const
+bool CStack::willMove(int turn) const
 {
 	return (turn ? true : !vstd::contains(state, EBattleStackState::DEFENDING))
 		   && !moved(turn)
 		   && canMove(turn);
 }
 
-bool CStack::canMove(int turn /*= 0*/) const
+bool CStack::canMove(int turn) const
 {
 	return alive()
 		   && !hasBonus(Selector::type(Bonus::NOT_ACTIVE).And(Selector::turns(turn))); //eg. Ammo Cart or blinded creature
@@ -428,7 +428,7 @@ bool CStack::isShooter() const
 	return shots.total() > 0 && hasBonusOfType(Bonus::SHOOTER);
 }
 
-bool CStack::moved(int turn /*= 0*/) const
+bool CStack::moved(int turn) const
 {
 	if(!turn)
 		return vstd::contains(state, EBattleStackState::MOVED);
@@ -436,7 +436,7 @@ bool CStack::moved(int turn /*= 0*/) const
 		return false;
 }
 
-bool CStack::waited(int turn /*= 0*/) const
+bool CStack::waited(int turn) const
 {
 	if(!turn)
 		return vstd::contains(state, EBattleStackState::WAITING);
@@ -702,7 +702,7 @@ void CStack::prepareAttacked(BattleStackAttacked & bsa, CRandomGenerator & rand,
 	}
 }
 
-bool CStack::isMeleeAttackPossible(const CStack * attacker, const CStack * defender, BattleHex attackerPos /*= BattleHex::INVALID*/, BattleHex defenderPos /*= BattleHex::INVALID*/)
+bool CStack::isMeleeAttackPossible(const CStack * attacker, const CStack * defender, BattleHex attackerPos, BattleHex defenderPos)
 {
 	if(!attackerPos.isValid())
 		attackerPos = attacker->position;
@@ -734,7 +734,7 @@ std::string CStack::getName() const
 	return (health.getCount() == 1) ? type->nameSing : type->namePl; //War machines can't use base
 }
 
-bool CStack::isValidTarget(bool allowDead/* = false*/) const
+bool CStack::isValidTarget(bool allowDead) const
 {
 	return (alive() || (allowDead && isDead())) && position.isValid() && !isTurret();
 }

--- a/lib/CTownHandler.cpp
+++ b/lib/CTownHandler.cpp
@@ -834,7 +834,7 @@ std::vector<bool> CTownHandler::getDefaultAllowed() const
 	return allowedFactions;
 }
 
-std::set<TFaction> CTownHandler::getAllowedFactions(bool withTown /*=true*/) const
+std::set<TFaction> CTownHandler::getAllowedFactions(bool withTown) const
 {
 	std::set<TFaction> allowedFactions;
 	std::vector<bool> allowed;

--- a/lib/HeroBonus.cpp
+++ b/lib/HeroBonus.cpp
@@ -108,7 +108,7 @@ const BonusList * CBonusProxy::operator->() const
 int CBonusSystemNode::treeChanged = 1;
 const bool CBonusSystemNode::cachingEnabled = true;
 
-BonusList::BonusList(bool BelongsToTree /* =false */) : belongsToTree(BelongsToTree)
+BonusList::BonusList(bool BelongsToTree) : belongsToTree(BelongsToTree)
 {
 
 }
@@ -325,7 +325,7 @@ int IBonusBearer::valOfBonuses(Bonus::BonusType type, const CSelector &selector)
 	return valOfBonuses(Selector::type(type).And(selector));
 }
 
-int IBonusBearer::valOfBonuses(Bonus::BonusType type, int subtype /*= -1*/) const
+int IBonusBearer::valOfBonuses(Bonus::BonusType type, int subtype) const
 {
 	std::stringstream cachingStr;
 	cachingStr << "type_" << type << "s_" << subtype;
@@ -343,17 +343,17 @@ int IBonusBearer::valOfBonuses(const CSelector &selector, const std::string &cac
 	TBonusListPtr hlp = getAllBonuses(selector, limit, nullptr, cachingStr);
 	return hlp->totalValue();
 }
-bool IBonusBearer::hasBonus(const CSelector &selector, const std::string &cachingStr /*= ""*/) const
+bool IBonusBearer::hasBonus(const CSelector &selector, const std::string &cachingStr) const
 {
 	return getBonuses(selector, cachingStr)->size() > 0;
 }
 
-bool IBonusBearer::hasBonus(const CSelector &selector, const CSelector &limit, const std::string &cachingStr /*= ""*/) const
+bool IBonusBearer::hasBonus(const CSelector &selector, const CSelector &limit, const std::string &cachingStr) const
 {
 	return getBonuses(selector, limit, cachingStr)->size() > 0;
 }
 
-bool IBonusBearer::hasBonusOfType(Bonus::BonusType type, int subtype /*= -1*/) const
+bool IBonusBearer::hasBonusOfType(Bonus::BonusType type, int subtype) const
 {
 	std::stringstream cachingStr;
 	cachingStr << "type_" << type << "s_" << subtype;
@@ -365,12 +365,12 @@ bool IBonusBearer::hasBonusOfType(Bonus::BonusType type, int subtype /*= -1*/) c
 	return hasBonus(s, cachingStr.str());
 }
 
-const TBonusListPtr IBonusBearer::getBonuses(const CSelector &selector, const std::string &cachingStr /*= ""*/) const
+const TBonusListPtr IBonusBearer::getBonuses(const CSelector &selector, const std::string &cachingStr) const
 {
 	return getAllBonuses(selector, nullptr, nullptr, cachingStr);
 }
 
-const TBonusListPtr IBonusBearer::getBonuses(const CSelector &selector, const CSelector &limit, const std::string &cachingStr /*= ""*/) const
+const TBonusListPtr IBonusBearer::getBonuses(const CSelector &selector, const CSelector &limit, const std::string &cachingStr) const
 {
 	return getAllBonuses(selector, limit, nullptr, cachingStr);
 }
@@ -422,7 +422,7 @@ si32 IBonusBearer::Attack() const
 	return ret;
 }
 
-si32 IBonusBearer::Defense(bool withFrenzy /*= true*/) const
+si32 IBonusBearer::Defense(bool withFrenzy) const
 {
 	si32 ret = valOfBonuses(Bonus::PRIMARY_SKILL, PrimarySkill::DEFENSE);
 
@@ -479,7 +479,7 @@ si32 IBonusBearer::magicResistance() const
 	return valOfBonuses(Bonus::MAGIC_RESISTANCE);
 }
 
-ui32 IBonusBearer::Speed( int turn /*= 0*/ , bool useBind /* = false*/) const
+ui32 IBonusBearer::Speed(int turn, bool useBind ) const
 {
 	//war machines cannot move
 	if(hasBonus(Selector::type(Bonus::SIEGE_WEAPON).And(Selector::turns(turn))))
@@ -569,7 +569,7 @@ void CBonusSystemNode::getAllBonusesRec(BonusList &out) const
 	bonuses.getAllBonuses(out);
 }
 
-const TBonusListPtr CBonusSystemNode::getAllBonuses(const CSelector &selector, const CSelector &limit, const CBonusSystemNode *root /*= nullptr*/, const std::string &cachingStr /*= ""*/) const
+const TBonusListPtr CBonusSystemNode::getAllBonuses(const CSelector &selector, const CSelector &limit, const CBonusSystemNode *root, const std::string &cachingStr) const
 {
 	bool limitOnUs = (!root || root == this); //caching won't work when we want to limit bonuses against an external node
 	if (CBonusSystemNode::cachingEnabled && limitOnUs)
@@ -622,7 +622,7 @@ const TBonusListPtr CBonusSystemNode::getAllBonuses(const CSelector &selector, c
 	}
 }
 
-const TBonusListPtr CBonusSystemNode::getAllBonusesWithoutCaching(const CSelector &selector, const CSelector &limit, const CBonusSystemNode *root /*= nullptr*/) const
+const TBonusListPtr CBonusSystemNode::getAllBonusesWithoutCaching(const CSelector &selector, const CSelector &limit, const CBonusSystemNode *root) const
 {
 	auto ret = std::make_shared<BonusList>();
 
@@ -1050,14 +1050,14 @@ void CBonusSystemNode::treeHasChanged()
 	treeChanged++;
 }
 
-int NBonus::valOf(const CBonusSystemNode *obj, Bonus::BonusType type, int subtype /*= -1*/)
+int NBonus::valOf(const CBonusSystemNode *obj, Bonus::BonusType type, int subtype)
 {
 	if(obj)
 		return obj->valOfBonuses(type, subtype);
 	return 0;
 }
 
-bool NBonus::hasOfType(const CBonusSystemNode *obj, Bonus::BonusType type, int subtype /*= -1*/)
+bool NBonus::hasOfType(const CBonusSystemNode *obj, Bonus::BonusType type, int subtype)
 {
 	if(obj)
 		return obj->hasBonusOfType(type, subtype);
@@ -1097,7 +1097,7 @@ std::string Bonus::Description() const
 	return str.str();
 }
 
-Bonus::Bonus(ui16 Dur, BonusType Type, BonusSource Src, si32 Val, ui32 ID, std::string Desc, si32 Subtype/*=-1*/)
+Bonus::Bonus(ui16 Dur, BonusType Type, BonusSource Src, si32 Val, ui32 ID, std::string Desc, si32 Subtype)
 	: duration(Dur), type(Type), subtype(Subtype), source(Src), val(Val), sid(ID), description(Desc)
 {
 	additionalInfo = -1;
@@ -1107,7 +1107,7 @@ Bonus::Bonus(ui16 Dur, BonusType Type, BonusSource Src, si32 Val, ui32 ID, std::
 	boost::algorithm::trim(description);
 }
 
-Bonus::Bonus(ui16 Dur, BonusType Type, BonusSource Src, si32 Val, ui32 ID, si32 Subtype/*=-1*/, ValueType ValType /*= ADDITIVE_VALUE*/)
+Bonus::Bonus(ui16 Dur, BonusType Type, BonusSource Src, si32 Val, ui32 ID, si32 Subtype, ValueType ValType)
 	: duration(Dur), type(Type), subtype(Subtype), source(Src), val(Val), sid(ID), valType(ValType)
 {
 	additionalInfo = -1;
@@ -1298,7 +1298,7 @@ int CCreatureTypeLimiter::limit(const BonusLimitationContext &context) const
 	//drop bonus if it's not our creature and (we don`t check upgrades or its not our upgrade)
 }
 
-CCreatureTypeLimiter::CCreatureTypeLimiter(const CCreature &Creature, bool IncludeUpgrades /*= true*/)
+CCreatureTypeLimiter::CCreatureTypeLimiter(const CCreature &Creature, bool IncludeUpgrades)
 	:creature(&Creature), includeUpgrades(IncludeUpgrades)
 {
 }

--- a/lib/IGameCallback.cpp
+++ b/lib/IGameCallback.cpp
@@ -51,7 +51,7 @@ void CPrivilagedInfoCallback::getFreeTiles (std::vector<int3> &tiles) const
 	}
 }
 
-void CPrivilagedInfoCallback::getTilesInRange( std::unordered_set<int3, ShashInt3> &tiles, int3 pos, int radious, boost::optional<PlayerColor> player/*=uninit*/, int mode/*=0*/, bool patrolDistance/*=false*/) const
+void CPrivilagedInfoCallback::getTilesInRange(std::unordered_set<int3, ShashInt3> &tiles, int3 pos, int radious, boost::optional<PlayerColor> player, int mode, bool patrolDistance) const
 {
 	if(!!player && *player >= PlayerColor::PLAYER_LIMIT)
 	{
@@ -87,7 +87,7 @@ void CPrivilagedInfoCallback::getTilesInRange( std::unordered_set<int3, ShashInt
 	}
 }
 
-void CPrivilagedInfoCallback::getAllTiles (std::unordered_set<int3, ShashInt3> &tiles, boost::optional<PlayerColor> Player/*=uninit*/, int level, int surface ) const
+void CPrivilagedInfoCallback::getAllTiles(std::unordered_set<int3, ShashInt3> &tiles, boost::optional<PlayerColor> Player, int level, int surface ) const
 {
 	if(!!Player && *Player >= PlayerColor::PLAYER_LIMIT)
 	{

--- a/lib/battle/BattleAction.cpp
+++ b/lib/battle/BattleAction.cpp
@@ -44,7 +44,7 @@ BattleAction BattleAction::makeDefend(const CStack * stack)
 }
 
 
-BattleAction BattleAction::makeMeleeAttack(const CStack * stack, const CStack * attacked, BattleHex attackFrom /*= BattleHex::INVALID*/)
+BattleAction BattleAction::makeMeleeAttack(const CStack * stack, const CStack * attacked, BattleHex attackFrom)
 {
 	BattleAction ba;
 	ba.side = stack->side;

--- a/lib/battle/BattleInfo.cpp
+++ b/lib/battle/BattleInfo.cpp
@@ -710,7 +710,7 @@ BattlefieldBI::BattlefieldBI BattleInfo::battlefieldTypeToBI(BFieldType bfieldTy
 	return BattlefieldBI::NONE;
 }
 
-CStack * BattleInfo::getStack(int stackID, bool onlyAlive /*= true*/)
+CStack * BattleInfo::getStack(int stackID, bool onlyAlive)
 {
 	return const_cast<CStack *>(battleGetStackByID(stackID, onlyAlive));
 }
@@ -766,7 +766,7 @@ bool CMP_stack::operator()(const CStack* a, const CStack* b)
 
 }
 
-CMP_stack::CMP_stack(int Phase /*= 1*/, int Turn)
+CMP_stack::CMP_stack(int Phase, int Turn)
 {
 	phase = Phase;
 	turn = Turn;

--- a/lib/battle/CBattleInfoCallback.cpp
+++ b/lib/battle/CBattleInfoCallback.cpp
@@ -182,7 +182,7 @@ si8 CBattleInfoCallback::battleCanTeleportTo(const CStack * stack, BattleHex des
 	return true;
 }
 
-std::set<BattleHex> CBattleInfoCallback::battleGetAttackedHexes(const CStack* attacker, BattleHex destinationTile, BattleHex attackerPos /*= BattleHex::INVALID*/) const
+std::set<BattleHex> CBattleInfoCallback::battleGetAttackedHexes(const CStack* attacker, BattleHex destinationTile, BattleHex attackerPos) const
 {
 	std::set<BattleHex> attackedHexes;
 	RETURN_IF_NOT_BATTLE(attackedHexes);
@@ -233,7 +233,7 @@ const CStack* CBattleInfoCallback::battleGetStackByPos(BattleHex pos, bool onlyA
 	return nullptr;
 }
 
-void CBattleInfoCallback::battleGetStackQueue(std::vector<const CStack *> &out, const int howMany, const int turn /*= 0*/, int lastMoved /*= -1*/) const
+void CBattleInfoCallback::battleGetStackQueue(std::vector<const CStack *> &out, const int howMany, const int turn, int lastMoved) const
 {
 	RETURN_IF_NOT_BATTLE();
 
@@ -774,7 +774,7 @@ TDmgRange CBattleInfoCallback::battleEstimateDamage(CRandomGenerator & rand, con
 	return battleEstimateDamage(rand, bai, retaliationDmg);
 }
 
-std::pair<ui32, ui32> CBattleInfoCallback::battleEstimateDamage(CRandomGenerator & rand, const BattleAttackInfo & bai, std::pair<ui32, ui32> * retaliationDmg /*= nullptr*/) const
+std::pair<ui32, ui32> CBattleInfoCallback::battleEstimateDamage(CRandomGenerator & rand, const BattleAttackInfo & bai, std::pair<ui32, ui32> * retaliationDmg) const
 {
 	RETURN_IF_NOT_BATTLE(std::make_pair(0, 0));
 
@@ -1183,7 +1183,7 @@ AttackableTiles CBattleInfoCallback::getPotentiallyAttackableHexes (const CStack
 	return at;
 }
 
-std::set<const CStack*> CBattleInfoCallback::getAttackedCreatures(const CStack* attacker, BattleHex destinationTile, BattleHex attackerPos /*= BattleHex::INVALID*/) const
+std::set<const CStack*> CBattleInfoCallback::getAttackedCreatures(const CStack* attacker, BattleHex destinationTile, BattleHex attackerPos) const
 {
 	std::set<const CStack*> attackedCres;
 	RETURN_IF_NOT_BATTLE(attackedCres);
@@ -1264,7 +1264,7 @@ bool CBattleInfoCallback::isToReverse (BattleHex hexFrom, BattleHex hexTo, bool 
 	}
 }
 
-ReachabilityInfo::TDistances CBattleInfoCallback::battleGetDistances(const CStack * stack, BattleHex hex /*= BattleHex::INVALID*/, BattleHex * predecessors /*= nullptr*/) const
+ReachabilityInfo::TDistances CBattleInfoCallback::battleGetDistances(const CStack * stack, BattleHex hex, BattleHex * predecessors) const
 {
 	ReachabilityInfo::TDistances ret;
 	ret.fill(-1);

--- a/lib/battle/CBattleInfoEssentials.cpp
+++ b/lib/battle/CBattleInfoEssentials.cpp
@@ -26,7 +26,7 @@ BFieldType CBattleInfoEssentials::battleGetBattlefieldType() const
 	return getBattle()->battlefieldType;
 }
 
-std::vector<std::shared_ptr<const CObstacleInstance> > CBattleInfoEssentials::battleGetAllObstacles(boost::optional<BattlePerspective::BattlePerspective> perspective /*= boost::none*/) const
+std::vector<std::shared_ptr<const CObstacleInstance>> CBattleInfoEssentials::battleGetAllObstacles(boost::optional<BattlePerspective::BattlePerspective> perspective) const
 {
 	std::vector<std::shared_ptr<const CObstacleInstance> > ret;
 	RETURN_IF_NOT_BATTLE(ret);
@@ -74,7 +74,7 @@ bool CBattleInfoEssentials::battleHasNativeStack(ui8 side) const
 	return false;
 }
 
-TStacks CBattleInfoEssentials::battleGetAllStacks(bool includeTurrets /*= false*/) const
+TStacks CBattleInfoEssentials::battleGetAllStacks(bool includeTurrets) const
 {
 	return battleGetStacksIf([=](const CStack * s)
 	{
@@ -353,7 +353,7 @@ const CGHeroInstance * CBattleInfoEssentials::battleGetOwnerHero(const CStack * 
 	return getBattle()->sides.at(side.get()).hero;
 }
 
-bool CBattleInfoEssentials::battleMatchOwner(const CStack * attacker, const CStack * defender, const boost::logic::tribool positivness /* = false*/) const
+bool CBattleInfoEssentials::battleMatchOwner(const CStack * attacker, const CStack * defender, const boost::logic::tribool positivness ) const
 {
 	RETURN_IF_NOT_BATTLE(false);
 	if(boost::logic::indeterminate(positivness))
@@ -364,7 +364,7 @@ bool CBattleInfoEssentials::battleMatchOwner(const CStack * attacker, const CSta
 		return battleMatchOwner(battleGetOwner(attacker), defender, positivness);
 }
 
-bool CBattleInfoEssentials::battleMatchOwner(const PlayerColor & attacker, const CStack * defender, const boost::logic::tribool positivness /* = false*/) const
+bool CBattleInfoEssentials::battleMatchOwner(const PlayerColor & attacker, const CStack * defender, const boost::logic::tribool positivness ) const
 {
 	RETURN_IF_NOT_BATTLE(false);
 	if(boost::logic::indeterminate(positivness))

--- a/lib/battle/CPlayerBattleCallback.cpp
+++ b/lib/battle/CPlayerBattleCallback.cpp
@@ -19,7 +19,7 @@ bool CPlayerBattleCallback::battleCanFlee() const
 			return CBattleInfoEssentials::battleCanFlee(*player);
 }
 
-TStacks CPlayerBattleCallback::battleGetStacks(EStackOwnership whose /*= MINE_AND_ENEMY*/, bool onlyAlive /*= true*/) const
+TStacks CPlayerBattleCallback::battleGetStacks(EStackOwnership whose, bool onlyAlive) const
 {
 	if(whose != MINE_AND_ENEMY)
 	{

--- a/lib/logging/CLogger.cpp
+++ b/lib/logging/CLogger.cpp
@@ -388,7 +388,7 @@ void CLogConsoleTarget::setFormatter(const CLogFormatter & formatter) { this->fo
 const CColorMapping & CLogConsoleTarget::getColorMapping() const { return colorMapping; }
 void CLogConsoleTarget::setColorMapping(const CColorMapping & colorMapping) { this->colorMapping = colorMapping; }
 
-CLogFileTarget::CLogFileTarget(boost::filesystem::path filePath, bool append /*= true*/)
+CLogFileTarget::CLogFileTarget(boost::filesystem::path filePath, bool append)
 	: file(std::move(filePath), append ? std::ios_base::app : std::ios_base::out)
 {
 	formatter.setPattern("%d %l %n [%t] - %m");

--- a/lib/mapObjects/CGHeroInstance.cpp
+++ b/lib/mapObjects/CGHeroInstance.cpp
@@ -328,7 +328,7 @@ void CGHeroInstance::initHero(CRandomGenerator & rand)
 		mana = manaLimit();
 }
 
-void CGHeroInstance::initArmy(CRandomGenerator & rand, IArmyDescriptor *dst /*= nullptr*/)
+void CGHeroInstance::initArmy(CRandomGenerator & rand, IArmyDescriptor * dst)
 {
 	if(!dst)
 		dst = this;
@@ -1275,7 +1275,7 @@ CBonusSystemNode * CGHeroInstance::whereShouldBeAttached(CGameState *gs)
 		return CArmedInstance::whereShouldBeAttached(gs);
 }
 
-int CGHeroInstance::movementPointsAfterEmbark(int MPsBefore, int basicCost, bool disembark /*= false*/, const TurnInfo * ti) const
+int CGHeroInstance::movementPointsAfterEmbark(int MPsBefore, int basicCost, bool disembark, const TurnInfo * ti) const
 {
 	int ret = 0; //take all MPs by default
 	bool localTi = false;

--- a/lib/mapObjects/CGMarket.cpp
+++ b/lib/mapObjects/CGMarket.cpp
@@ -163,7 +163,7 @@ std::vector<int> IMarket::availableItemsIds(EMarketMode::EMarketMode mode) const
 	return ret;
 }
 
-const IMarket * IMarket::castFrom(const CGObjectInstance *obj, bool verbose /*= true*/)
+const IMarket * IMarket::castFrom(const CGObjectInstance *obj, bool verbose)
 {
 	switch(obj->ID)
 	{

--- a/lib/mapObjects/CGTownInstance.cpp
+++ b/lib/mapObjects/CGTownInstance.cpp
@@ -1122,13 +1122,13 @@ void CGTownInstance::recreateBuildingsBonuses()
 	}
 }
 
-bool CGTownInstance::addBonusIfBuilt(BuildingID building, Bonus::BonusType type, int val, int subtype /*= -1*/)
+bool CGTownInstance::addBonusIfBuilt(BuildingID building, Bonus::BonusType type, int val, int subtype)
 {
 	static auto emptyPropagator = TPropagatorPtr();
 	return addBonusIfBuilt(building, type, val, emptyPropagator, subtype);
 }
 
-bool CGTownInstance::addBonusIfBuilt(BuildingID building, Bonus::BonusType type, int val, TPropagatorPtr & prop, int subtype /*= -1*/)
+bool CGTownInstance::addBonusIfBuilt(BuildingID building, Bonus::BonusType type, int val, TPropagatorPtr & prop, int subtype)
 {
 	if(hasBuilt(building))
 	{

--- a/lib/mapping/CMap.cpp
+++ b/lib/mapping/CMap.cpp
@@ -129,7 +129,7 @@ TerrainTile::TerrainTile() : terType(ETerrainType::BORDER), terView(0), riverTyp
 
 }
 
-bool TerrainTile::entrableTerrain(const TerrainTile * from /*= nullptr*/) const
+bool TerrainTile::entrableTerrain(const TerrainTile * from) const
 {
 	return entrableTerrain(from ? from->terType != ETerrainType::WATER : true, from ? from->terType == ETerrainType::WATER : true);
 }
@@ -140,7 +140,7 @@ bool TerrainTile::entrableTerrain(bool allowLand, bool allowSea) const
 			&& ((allowSea && terType == ETerrainType::WATER)  ||  (allowLand && terType != ETerrainType::WATER));
 }
 
-bool TerrainTile::isClear(const TerrainTile *from /*= nullptr*/) const
+bool TerrainTile::isClear(const TerrainTile * from) const
 {
 	return entrableTerrain(from) && !blocked;
 }

--- a/lib/mapping/CMapEditManager.cpp
+++ b/lib/mapping/CMapEditManager.cpp
@@ -238,12 +238,12 @@ CMap * CMapEditManager::getMap()
 	return map;
 }
 
-void CMapEditManager::clearTerrain(CRandomGenerator * gen/* = nullptr*/)
+void CMapEditManager::clearTerrain(CRandomGenerator * gen)
 {
 	execute(make_unique<CClearTerrainOperation>(map, gen ? gen : &(this->gen)));
 }
 
-void CMapEditManager::drawTerrain(ETerrainType terType, CRandomGenerator * gen/* = nullptr*/)
+void CMapEditManager::drawTerrain(ETerrainType terType, CRandomGenerator * gen)
 {
 	execute(make_unique<CDrawTerrainOperation>(map, terrainSel, terType, gen ? gen : &(this->gen)));
 	terrainSel.clearSelection();
@@ -782,7 +782,7 @@ ETerrainGroup::ETerrainGroup CDrawTerrainOperation::getTerrainGroup(ETerrainType
 	}
 }
 
-CDrawTerrainOperation::ValidationResult CDrawTerrainOperation::validateTerrainView(const int3 & pos, const std::vector<TerrainViewPattern> * pattern, int recDepth /*= 0*/) const
+CDrawTerrainOperation::ValidationResult CDrawTerrainOperation::validateTerrainView(const int3 & pos, const std::vector<TerrainViewPattern> * pattern, int recDepth) const
 {
 	for(int flip = 0; flip < 4; ++flip)
 	{
@@ -796,7 +796,7 @@ CDrawTerrainOperation::ValidationResult CDrawTerrainOperation::validateTerrainVi
 	return ValidationResult(false);
 }
 
-CDrawTerrainOperation::ValidationResult CDrawTerrainOperation::validateTerrainViewInner(const int3 & pos, const TerrainViewPattern & pattern, int recDepth /*= 0*/) const
+CDrawTerrainOperation::ValidationResult CDrawTerrainOperation::validateTerrainViewInner(const int3 & pos, const TerrainViewPattern & pattern, int recDepth) const
 {
 	auto centerTerType = map->getTile(pos).terType;
 	auto centerTerGroup = getTerrainGroup(centerTerType);
@@ -1025,7 +1025,7 @@ CDrawTerrainOperation::InvalidTiles CDrawTerrainOperation::getInvalidTiles(const
 	return tiles;
 }
 
-CDrawTerrainOperation::ValidationResult::ValidationResult(bool result, const std::string & transitionReplacement /*= ""*/)
+CDrawTerrainOperation::ValidationResult::ValidationResult(bool result, const std::string & transitionReplacement)
 	: result(result), transitionReplacement(transitionReplacement), flip(0)
 {
 

--- a/lib/mapping/MapFormatH3M.cpp
+++ b/lib/mapping/MapFormatH3M.cpp
@@ -2059,7 +2059,7 @@ CGTownInstance * CMapLoaderH3M::readTown(int castleID)
 	return nt;
 }
 
-std::set<BuildingID> CMapLoaderH3M::convertBuildings(const std::set<BuildingID> h3m, int castleID, bool addAuxiliary /*= true*/)
+std::set<BuildingID> CMapLoaderH3M::convertBuildings(const std::set<BuildingID> h3m, int castleID, bool addAuxiliary)
 {
 	std::map<int, BuildingID> mapa;
 	std::set<BuildingID> ret;

--- a/lib/rmg/CMapGenerator.cpp
+++ b/lib/rmg/CMapGenerator.cpp
@@ -122,7 +122,7 @@ void CMapGenerator::initQuestArtsRemaining()
 	}
 }
 
-std::unique_ptr<CMap> CMapGenerator::generate(CMapGenOptions * mapGenOptions, int randomSeed /*= std::time(nullptr)*/)
+std::unique_ptr<CMap> CMapGenerator::generate(CMapGenOptions * mapGenOptions, int randomSeed)
 {
 	this->mapGenOptions = mapGenOptions;
 	this->randomSeed = randomSeed;

--- a/lib/serializer/BinaryDeserializer.cpp
+++ b/lib/serializer/BinaryDeserializer.cpp
@@ -14,7 +14,7 @@
 
 extern template void registerTypes<BinaryDeserializer>(BinaryDeserializer & s);
 
-CLoadFile::CLoadFile(const boost::filesystem::path & fname, int minimalVersion /*= version*/)
+CLoadFile::CLoadFile(const boost::filesystem::path & fname, int minimalVersion)
 	: serializer(this)
 {
 	registerTypes(serializer);

--- a/lib/serializer/CLoadIntegrityValidator.cpp
+++ b/lib/serializer/CLoadIntegrityValidator.cpp
@@ -12,7 +12,7 @@
 
 #include "../registerTypes/RegisterTypes.h"
 
-CLoadIntegrityValidator::CLoadIntegrityValidator(const boost::filesystem::path &primaryFileName, const boost::filesystem::path &controlFileName, int minimalVersion /*= version*/)
+CLoadIntegrityValidator::CLoadIntegrityValidator(const boost::filesystem::path &primaryFileName, const boost::filesystem::path &controlFileName, int minimalVersion)
 	: serializer(this), foundDesync(false)
 {
 	registerTypes(serializer);

--- a/lib/spells/CDefaultSpellMechanics.cpp
+++ b/lib/spells/CDefaultSpellMechanics.cpp
@@ -773,7 +773,7 @@ void DefaultSpellMechanics::doDispell(BattleInfo * battle, const BattleSpellCast
 	}
 }
 
-bool DefaultSpellMechanics::canDispell(const IBonusBearer * obj, const CSelector & selector, const std::string & cachingStr/* = "" */) const
+bool DefaultSpellMechanics::canDispell(const IBonusBearer * obj, const CSelector & selector, const std::string & cachingStr) const
 {
 	return obj->hasBonus(selector.And(dispellSelector), Selector::all, cachingStr);
 }

--- a/lib/spells/CSpellHandler.cpp
+++ b/lib/spells/CSpellHandler.cpp
@@ -365,7 +365,7 @@ si32 CSpell::getProbability(const TFaction factionId) const
 	return probabilities.at(factionId);
 }
 
-void CSpell::getEffects(std::vector<Bonus> & lst, const int level, const bool cumulative, const si32 duration, boost::optional<si32 *> maxDuration/* = boost::none*/) const
+void CSpell::getEffects(std::vector<Bonus> & lst, const int level, const bool cumulative, const si32 duration, boost::optional<si32 *> maxDuration) const
 {
 	if(level < 0 || level >= GameConstants::SPELL_SCHOOL_LEVELS)
 	{

--- a/scripting/erm/ERMInterpreter.cpp
+++ b/scripting/erm/ERMInterpreter.cpp
@@ -398,7 +398,7 @@ void ERMInterpreter::scanForScripts()
 	}
 }
 
-void ERMInterpreter::printScripts( EPrintMode mode /*= EPrintMode::ALL*/ )
+void ERMInterpreter::printScripts(EPrintMode mode)
 {
 	std::map< LinePointer, ERM::TLine >::const_iterator prevIt;
 	for(std::map< LinePointer, ERM::TLine >::const_iterator it = scripts.begin(); it != scripts.end(); ++it)
@@ -473,7 +473,7 @@ ERMInterpreter::ERMInterpreter()
 	topDyn = globalEnv;
 }
 
-void ERMInterpreter::executeTrigger( VERMInterpreter::Trigger & trig, int funNum /*= -1*/, std::vector<int> funParams/*=std::vector<int>()*/ )
+void ERMInterpreter::executeTrigger(VERMInterpreter::Trigger & trig, int funNum, std::vector<int> funParams)
 {
 	//function-related logic
 	if(funNum != -1)
@@ -1774,7 +1774,7 @@ IexpValStr ERMInterpreter::getIexp( const ERM::TBodyOptionItem & opit ) const
 	return ret;
 }
 
-void ERMInterpreter::executeTriggerType( VERMInterpreter::TriggerType tt, bool pre, const TIDPattern & identifier, const std::vector<int> &funParams/*=std::vector<int>()*/ )
+void ERMInterpreter::executeTriggerType(VERMInterpreter::TriggerType tt, bool pre, const TIDPattern & identifier, const std::vector<int> &funParams)
 {
 	struct HLP
 	{
@@ -2716,7 +2716,7 @@ struct VEvaluator : boost::static_visitor<VOption>
 	}
 };
 
-VOption ERMInterpreter::eval( VOption line, Environment * env /*= nullptr*/ )
+VOption ERMInterpreter::eval(VOption line, Environment * env)
 {
 // 	if(line.children.isNil())
 // 		return;
@@ -2727,7 +2727,7 @@ VOption ERMInterpreter::eval( VOption line, Environment * env /*= nullptr*/ )
 	return boost::apply_visitor(VEvaluator(env ? *env : *topDyn), line);
 }
 
-VOptionList ERMInterpreter::evalEach( VermTreeIterator list, Environment * env /*= nullptr*/ )
+VOptionList ERMInterpreter::evalEach(VermTreeIterator list, Environment * env)
 {
 	VOptionList ret;
 	for(int g=0; g<list.size(); ++g)

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -515,7 +515,7 @@ void CGameHandler::changePrimSkill(const CGHeroInstance * hero, PrimarySkill::Pr
 	}
 }
 
-void CGameHandler::changeSecSkill(const CGHeroInstance * hero, SecondarySkill which, int val, bool abs/*=false*/)
+void CGameHandler::changeSecSkill(const CGHeroInstance * hero, SecondarySkill which, int val, bool abs)
 {
 	if(!hero)
 	{
@@ -2025,7 +2025,7 @@ void CGameHandler::setAmount(ObjectInstanceID objid, ui32 val)
 	sendAndApply(&sop);
 }
 
-bool CGameHandler::moveHero(ObjectInstanceID hid, int3 dst, ui8 teleporting, bool transit, PlayerColor asker /*= 255*/)
+bool CGameHandler::moveHero(ObjectInstanceID hid, int3 dst, ui8 teleporting, bool transit, PlayerColor asker)
 {
 	const CGHeroInstance *h = getHero(hid);
 	// not turn of that hero or player can't simply teleport hero (at least not with this function)
@@ -2211,7 +2211,7 @@ bool CGameHandler::moveHero(ObjectInstanceID hid, int3 dst, ui8 teleporting, boo
 	}
 }
 
-bool CGameHandler::teleportHero(ObjectInstanceID hid, ObjectInstanceID dstid, ui8 source, PlayerColor asker/* = 255*/)
+bool CGameHandler::teleportHero(ObjectInstanceID hid, ObjectInstanceID dstid, ui8 source, PlayerColor asker)
 {
 	const CGHeroInstance *h = getHero(hid);
 	const CGTownInstance *t = getTown(dstid);
@@ -2870,7 +2870,7 @@ bool CGameHandler::disbandCreature(ObjectInstanceID id, SlotID pos)
 	return true;
 }
 
-bool CGameHandler::buildStructure(ObjectInstanceID tid, BuildingID requestedID, bool force /*=false*/)
+bool CGameHandler::buildStructure(ObjectInstanceID tid, BuildingID requestedID, bool force)
 {
 	const CGTownInstance * t = getTown(tid);
 	if (!t)
@@ -5493,7 +5493,7 @@ bool CGameHandler::insertNewStack(const StackLocation &sl, const CCreature *c, T
 	return true;
 }
 
-bool CGameHandler::eraseStack(const StackLocation &sl, bool forceRemoval/* = false*/)
+bool CGameHandler::eraseStack(const StackLocation &sl, bool forceRemoval)
 {
 	if (!sl.army->hasStackAtSlot(sl.slot))
 		COMPLAIN_RET("Cannot find a stack to erase");
@@ -5511,7 +5511,7 @@ bool CGameHandler::eraseStack(const StackLocation &sl, bool forceRemoval/* = fal
 	return true;
 }
 
-bool CGameHandler::changeStackCount(const StackLocation &sl, TQuantity count, bool absoluteValue /*= false*/)
+bool CGameHandler::changeStackCount(const StackLocation &sl, TQuantity count, bool absoluteValue)
 {
 	TQuantity currentCount = sl.army->getStackCount(sl.slot);
 	if ((absoluteValue && count < 0)

--- a/server/CVCMIServer.cpp
+++ b/server/CVCMIServer.cpp
@@ -61,7 +61,7 @@ static void vaccept(boost::asio::ip::tcp::acceptor *ac, boost::asio::ip::tcp::so
 
 
 
-CPregameServer::CPregameServer(CConnection *Host, TAcceptor *Acceptor /*= nullptr*/)
+CPregameServer::CPregameServer(CConnection * Host, TAcceptor * Acceptor)
 	: host(Host), listeningThreads(0), acceptor(Acceptor), upcomingConnection(nullptr),
 	  curmap(nullptr), curStartInfo(nullptr), state(RUNNING)
 {
@@ -241,7 +241,7 @@ void CPregameServer::start_async_accept()
 	acceptor->async_accept(*upcomingConnection, std::bind(&CPregameServer::connectionAccepted, this, _1));
 }
 
-void CPregameServer::announceTxt(const std::string &txt, const std::string &playerName /*= "system"*/)
+void CPregameServer::announceTxt(const std::string &txt, const std::string &playerName)
 {
 	logNetwork->info("%s says: %s", playerName, txt);
 	ChatMessage cm;


### PR DESCRIPTION
This is not good practice anyway since it's require additional maintenance where any IDE can jump to declaration or show default values instantly. And yeah I did not fixed formatting everywhere in this case and that was intended.