### PR TITLE
Fix color change of highlighted hex borders

### DIFF
--- a/client/battle/CBattleInterface.cpp
+++ b/client/battle/CBattleInterface.cpp
@@ -3082,6 +3082,31 @@ void CBattleInterface::showAbsoluteObstacles(SDL_Surface *to)
 
 void CBattleInterface::showHighlightedHexes(SDL_Surface *to)
 {
+	bool delayedBlit = false; //workaround for blitting enemy stack hex without mouse shadow with stack range on
+	if(activeStack && settings["battle"]["stackRange"].Bool())
+	{
+		std::set<BattleHex> set = curInt->cb->battleGetAttackedHexes(activeStack, currentlyHoveredHex, attackingHex);
+		for(BattleHex hex : set)
+			if(hex != currentlyHoveredHex)
+				showHighlightedHex(to, hex);
+
+		// display the movement shadow of the stack at b (i.e. stack under mouse)
+		const CStack * const shere = curInt->cb->battleGetStackByPos(currentlyHoveredHex, false);
+		if(shere && shere != activeStack && shere->alive())
+		{
+			std::vector<BattleHex> v = curInt->cb->battleGetAvailableHexes(shere, true);
+			for(BattleHex hex : v)
+			{
+				if(hex != currentlyHoveredHex)
+					showHighlightedHex(to, hex);
+				else if(!settings["battle"]["mouseShadow"].Bool())
+					delayedBlit = true; //blit at the end of method to avoid graphic artifacts
+				else
+					showHighlightedHex(to, hex, true); //blit now and blit 2nd time later for darker shadow - avoids graphic artifacts
+			}
+		}
+	}
+
 	for(int b=0; b<GameConstants::BFIELD_SIZE; ++b)
 	{
 		if(bfield[b]->strictHovered && bfield[b]->hovered)
@@ -3096,7 +3121,7 @@ void CBattleInterface::showHighlightedHexes(SDL_Surface *to)
 				previouslyHoveredHex = currentlyHoveredHex;
 				currentlyHoveredHex = b;
 			}
-			if(settings["battle"]["mouseShadow"].Bool())
+			if(settings["battle"]["mouseShadow"].Bool() || delayedBlit)
 			{
 				const ISpellCaster *caster = nullptr;
 				const CSpell *spell = nullptr;
@@ -3122,42 +3147,28 @@ void CBattleInterface::showHighlightedHexes(SDL_Surface *to)
 					for(BattleHex shadedHex : shaded)
 					{
 						if((shadedHex.getX() != 0) && (shadedHex.getX() != GameConstants::BFIELD_WIDTH - 1))
-							showHighlightedHex(to, shadedHex);
+							showHighlightedHex(to, shadedHex, true);
 					}
 				}
-				else if(active)//always highlight pointed hex
+				else if(active || delayedBlit) //always highlight pointed hex, keep this condition last in this method for correct behavior
 				{
 					if(currentlyHoveredHex.getX() != 0
 					 && currentlyHoveredHex.getX() != GameConstants::BFIELD_WIDTH - 1)
-						showHighlightedHex(to, currentlyHoveredHex);
+						showHighlightedHex(to, currentlyHoveredHex, true); //keep true for OH3 behavior: hovered hex frame "thinner"
 				}
 			}
 		}
 	}
-
-	if(activeStack && settings["battle"]["stackRange"].Bool())
-	{
-		std::set<BattleHex> set = curInt->cb->battleGetAttackedHexes(activeStack, currentlyHoveredHex, attackingHex);
-		for(BattleHex hex : set)
-			showHighlightedHex(to, hex);
-
-		// display the movement shadow of the stack at b (i.e. stack under mouse)
-		const CStack * const shere = curInt->cb->battleGetStackByPos(currentlyHoveredHex, false);
-		if(shere && shere != activeStack && shere->alive())
-		{
-			std::vector<BattleHex> v = curInt->cb->battleGetAvailableHexes(shere, true );
-			for(BattleHex hex : v)
-				showHighlightedHex(to, hex);
-		}
-	}
 }
 
-void CBattleInterface::showHighlightedHex(SDL_Surface *to, BattleHex hex)
+void CBattleInterface::showHighlightedHex(SDL_Surface *to, BattleHex hex, bool darkBorder)
 {
 	int x = 14 + (hex.getY() % 2 == 0 ? 22 : 0) + 44 *(hex.getX()) + pos.x;
 	int y = 86 + 42 *hex.getY() + pos.y;
 	SDL_Rect temp_rect = genRect (cellShade->h, cellShade->w, x, y);
 	CSDL_Ext::blit8bppAlphaTo24bpp (cellShade, nullptr, to, &temp_rect);
+	if(!darkBorder && settings["battle"]["cellBorders"].Bool())
+		CSDL_Ext::blit8bppAlphaTo24bpp(cellBorder, nullptr, to, &temp_rect); //redraw border to make it light green instead of shaded
 }
 
 void CBattleInterface::showProjectiles(SDL_Surface *to)
@@ -3656,9 +3667,6 @@ void CBattleInterface::redrawBackgroundWithHexes(const CStack *activeStack)
                    oi->getInfo().height, backgroundWithHexes);
 	}
 
-	if (settings["battle"]["cellBorders"].Bool())
-		CSDL_Ext::blit8bppAlphaTo24bpp(cellBorders, nullptr, backgroundWithHexes, nullptr);
-
 	if (settings["battle"]["stackRange"].Bool())
 	{
 		std::vector<BattleHex> hexesToShade = occupyableHexes;
@@ -3673,6 +3681,9 @@ void CBattleInterface::redrawBackgroundWithHexes(const CStack *activeStack)
 			CSDL_Ext::blit8bppAlphaTo24bpp(cellShade, nullptr, backgroundWithHexes, &temp_rect);
 		}
 	}
+
+	if(settings["battle"]["cellBorders"].Bool())
+		CSDL_Ext::blit8bppAlphaTo24bpp(cellBorders, nullptr, backgroundWithHexes, nullptr);
 }
 
 void CBattleInterface::showPiecesOfWall(SDL_Surface *to, std::vector<int> pieces)

--- a/client/battle/CBattleInterface.h
+++ b/client/battle/CBattleInterface.h
@@ -241,7 +241,7 @@ private:
 	void showBackgroundImage(SDL_Surface *to);
 	void showAbsoluteObstacles(SDL_Surface *to);
 	void showHighlightedHexes(SDL_Surface *to);
-	void showHighlightedHex(SDL_Surface *to, BattleHex hex);
+	void showHighlightedHex(SDL_Surface *to, BattleHex hex, bool darkBorder = false);
 	void showInterface(SDL_Surface *to);
 
 	void showBattlefieldObjects(SDL_Surface *to);


### PR DESCRIPTION
Behavior is exactly same as in OH3 now except for behavior non existing in H3 (showing enemy unit range on mouse hover).
Battlefield hex green border color doesn't get darker when highlighted with this change. Visually, hex frames consist of borders of "this pixel and neighbour pixels". In OH3 when highlighting pixel with mouse, border gets thinner as part of it belonging to "current hex" gets replaced by hex highlight graphics. Hexes highlighted not by mouse should have full border width.