### PR TITLE
[WIP] CMake: fixing of macOS package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,9 +46,9 @@ if (APPLE)
 	set(CMAKE_FRAMEWORK_PATH "../Frameworks")
 	set(BOOST_ROOT "../")
 
-	set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_HOME_DIRECTORY}/bin")
-	set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_HOME_DIRECTORY}/bin")
-	set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_HOME_DIRECTORY}/bin")
+	set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_HOME_DIRECTORY}/build")
+	set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_HOME_DIRECTORY}/build")
+	set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_HOME_DIRECTORY}/build")
 
 	set(CMAKE_XCODE_ATTRIBUTE_CONFIGURATION_BUILD_DIR "${CMAKE_HOME_DIRECTORY}/bin/$(CONFIGURATION)")
 	set(CMAKE_XCODE_ATTRIBUTE_LD_RUNPATH_SEARCH_PATHS "@executable_path/../Frameworks @executable_path/")
@@ -264,7 +264,7 @@ endif()
 if(WIN32)
 	file(GLOB dep_files
 		${dep_files}
-		"${CMAKE_FIND_ROOT_PATH}/bin/*.dll")
+		"${CMAKE_FIND_ROOT_PATH}/build/*.dll")
 
 	#Copy debug versions of libraries if build type is debug. Doesn't work in MSVC!
 	if(CMAKE_BUILD_TYPE MATCHES DEBUG)
@@ -359,9 +359,23 @@ if(WIN32)
 	configure_file("${CMAKE_SOURCE_DIR}/cmake_modules/CMakeCPackOptions.cmake.in" "${CMAKE_BINARY_DIR}/CMakeCPackOptions.cmake" @ONLY)
 	set(CPACK_PROJECT_CONFIG_FILE "${CMAKE_BINARY_DIR}/CMakeCPackOptions.cmake")
 elseif(APPLE)
-	set(CPACK_GENERATOR DragNDrop)
+	set(CPACK_GENERATOR "DragNDrop")
 	set(CPACK_DMG_BACKGROUND_IMAGE "${CMAKE_SOURCE_DIR}/osx/dmg_background.png")
 	set(CPACK_DMG_DS_STORE "${CMAKE_SOURCE_DIR}/osx/dmg_DS_Store")
+
+	get_property(QT_COCOA_PLUGIN_PATH TARGET Qt5::QCocoaIntegrationPlugin PROPERTY LOCATION_RELEASE)
+	get_filename_component(QT_COCOA_PLUGIN_DIR "${QT_COCOA_PLUGIN_PATH}" DIRECTORY)
+	get_filename_component(QT_COCOA_PLUGIN_GROUP "${QT_COCOA_PLUGIN_DIR}" NAME)
+	get_filename_component(QT_COCOA_PLUGIN_NAME "${QT_COCOA_PLUGIN_PATH}" NAME)
+	configure_file("${QT_COCOA_PLUGIN_PATH}" "${CMAKE_BINARY_DIR}/build/vcmiclient.app/Contents/MacOS/${QT_COCOA_PLUGIN_GROUP}/${QT_COCOA_PLUGIN_NAME}" COPYONLY)
+
+	SET(LIBS ${SDL2_IMAGE_LIBRARIES} ${SDL2_IMAGE_LIBRARIES} ${SDL2_MIXER_LIBRARIES} ${SDL2_TTF_LIBRARY} ${FFMPEG_LIBRARIES} ${Boost_LIBRARIES})
+	INSTALL(CODE "
+	set(BU_CHMOD_BUNDLE_ITEMS ON)
+	include(BundleUtilities)
+	fixup_bundle(\"${CMAKE_BINARY_DIR}/build/vcmiclient.app\"   \"\"   \"${DIRS}\")
+	" COMPONENT Runtime)
+
 else()
 	set(CPACK_GENERATOR TGZ)
 endif()

--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -145,7 +145,7 @@ if(APPLE)
 	add_dependencies(vcmiclient vcmiserver VCAI EmptyAI StupidAI BattleAI minizip)
 
 	# Custom Info.plist
-	set_target_properties(vcmiclient PROPERTIES MACOSX_BUNDLE_INFO_PLIST ${CMAKE_CURRENT_SOURCE_DIR}/Info.plist)
+	set_target_properties(vcmiclient PROPERTIES MACOSX_BUNDLE_INFO_PLIST ${CMAKE_SOURCE_DIR}/client/Info.plist)
 
 	# Copy icon file and public key for Sparkle
 	set_source_files_properties(vcmi.icns PROPERTIES MACOSX_PACKAGE_LOCATION Resources)
@@ -154,21 +154,21 @@ if(APPLE)
 	set_target_properties(vcmiclient PROPERTIES XCODE_ATTRIBUTE_LD_RUNPATH_SEARCH_PATHS "@executable_path/../Frameworks @executable_path/")
 
 	# Copy server executable, libs and game data to bundle
-	set(BUNDLE_PATH ${CMAKE_HOME_DIRECTORY}/bin/$(CONFIGURATION)/vcmiclient.app/Contents)
+	set(BUNDLE_PATH ${CMAKE_BINARY_DIR}/build/vcmiclient.app/Contents)
 
 	set(CopyVendoredMinizip
-		mkdir -p ${BUNDLE_PATH}/MacOS && cp ${CMAKE_BINARY_DIR}/build/$(CONFIGURATION)/lib/libminizip.dylib ${BUNDLE_PATH}/MacOS/libminizip.dylib)
+		mkdir -p ${BUNDLE_PATH}/MacOS &&cp ${CMAKE_BINARY_DIR}/build/lib/libminizip.dylib ${BUNDLE_PATH}/MacOS/libminizip.dylib)
 
 	set(MakeVCMIBundle
 		# Copy all needed binaries
 		mkdir -p ${BUNDLE_PATH}/MacOS/AI &&
-		cp ${CMAKE_BINARY_DIR}/build/$(CONFIGURATION)/vcmiserver ${BUNDLE_PATH}/MacOS/vcmiserver &&
-		cp ${CMAKE_BINARY_DIR}/build/$(CONFIGURATION)/vcmiclient.app/Contents/MacOS/vcmiclient ${BUNDLE_PATH}/MacOS/vcmiclient &&
-		cp ${CMAKE_BINARY_DIR}/build/$(CONFIGURATION)/libvcmi.dylib ${BUNDLE_PATH}/MacOS/libvcmi.dylib &&
-		cp ${CMAKE_BINARY_DIR}/build/$(CONFIGURATION)/AI/libVCAI.dylib ${BUNDLE_PATH}/MacOS/AI/libVCAI.dylib &&
-		cp ${CMAKE_BINARY_DIR}/build/$(CONFIGURATION)/AI/libStupidAI.dylib ${BUNDLE_PATH}/MacOS/AI/libStupidAI.dylib &&
-		cp ${CMAKE_BINARY_DIR}/build/$(CONFIGURATION)/AI/libEmptyAI.dylib ${BUNDLE_PATH}/MacOS/AI/libEmptyAI.dylib &&
-		cp ${CMAKE_BINARY_DIR}/build/$(CONFIGURATION)/AI/libBattleAI.dylib ${BUNDLE_PATH}/MacOS/AI/libBattleAI.dylib &&
+		cp ${CMAKE_BINARY_DIR}/build/vcmilauncher ${BUNDLE_PATH}/MacOS/vcmilauncher &&
+		cp ${CMAKE_BINARY_DIR}/build/vcmiserver ${BUNDLE_PATH}/MacOS/vcmiserver &&
+		cp ${CMAKE_BINARY_DIR}/build/libvcmi.dylib ${BUNDLE_PATH}/MacOS/libvcmi.dylib &&
+		cp ${CMAKE_BINARY_DIR}/build/AI/libVCAI.dylib ${BUNDLE_PATH}/MacOS/AI/libVCAI.dylib &&
+		cp ${CMAKE_BINARY_DIR}/build/AI/libStupidAI.dylib ${BUNDLE_PATH}/MacOS/AI/libStupidAI.dylib &&
+		cp ${CMAKE_BINARY_DIR}/build/AI/libEmptyAI.dylib ${BUNDLE_PATH}/MacOS/AI/libEmptyAI.dylib &&
+		cp ${CMAKE_BINARY_DIR}/build/AI/libBattleAI.dylib ${BUNDLE_PATH}/MacOS/AI/libBattleAI.dylib &&
 		cp -r ${CMAKE_HOME_DIRECTORY}/osx/vcmibuilder.app ${BUNDLE_PATH}/MacOS/vcmibuilder.app &&
 
 		# Copy frameworks
@@ -178,11 +178,9 @@ if(APPLE)
 		mkdir -p ${BUNDLE_PATH}/Data &&
 		mkdir -p ${BUNDLE_PATH}/Data/Mods &&
 		mkdir -p ${BUNDLE_PATH}/Data/launcher &&
-		cp -r ${CMAKE_HOME_DIRECTORY}/config/ ${BUNDLE_PATH}/Data/config/ &&
-		cp -r ${CMAKE_HOME_DIRECTORY}/Mods/vcmi/ ${BUNDLE_PATH}/Data/Mods/vcmi/ &&
-		sh -c 'cp -r ${CMAKE_HOME_DIRECTORY}/Mods/WoG/ ${BUNDLE_PATH}/Data/Mods/WoG/ || echo "Download WoG mod from http://wiki.vcmi.eu/index.php?title=Mod_list" ' &&
-		sh -c 'cp -r ${CMAKE_HOME_DIRECTORY}/Mods/hota/ ${BUNDLE_PATH}/Data/Mods/hota/ || echo "Download HOTA mod from http://wiki.vcmi.eu/index.php?title=Mod_list" ' &&
-		cp -r ${CMAKE_HOME_DIRECTORY}/launcher/icons/ ${BUNDLE_PATH}/Data/launcher/icons/)
+		cp -r ${CMAKE_SOURCE_DIR}/config/ ${BUNDLE_PATH}/Data/config/ &&
+		cp -r ${CMAKE_SOURCE_DIR}/Mods/vcmi/ ${BUNDLE_PATH}/Data/Mods/vcmi/ &&
+		cp -r ${CMAKE_SOURCE_DIR}/launcher/icons/ ${BUNDLE_PATH}/Data/launcher/icons/)
 
 	if(NOT MINIZIP_FOUND)
 		add_custom_command(TARGET vcmiclient POST_BUILD COMMAND ${CopyVendoredMinizip})
@@ -199,7 +197,7 @@ if(WIN32)
 	set_target_properties(vcmiclient PROPERTIES OUTPUT_NAME VCMI_client)
 endif()
 
-target_link_libraries(vcmiclient vcmi ${Boost_LIBRARIES} ${SDL_LIBRARY} ${SDLIMAGE_LIBRARY} ${SDLMIXER_LIBRARY} ${SDLTTF_LIBRARY} ${ZLIB_LIBRARIES} ${FFMPEG_LIBRARIES} ${SYSTEM_LIBS})
+target_link_libraries(vcmiclient vcmi ${Boost_LIBRARIES} ${SDL_LIBRARY} ${SDLIMAGE_LIBRARY} ${SDLMIXER_LIBRARY} ${SDLTTF_LIBRARY} ${ZLIB_LIBRARIES} ${FFMPEG_LIBRARIES} ${FFMPEG_EXTRA_LINKING_OPTIONS} ${SYSTEM_LIBS})
 
 vcmi_set_output_dir(vcmiclient "")
 

--- a/client/Info.plist
+++ b/client/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CFBundleExecutable</key>
+	<string>vcmiclient</string>
 	<key>CFBundleIconFile</key>
 	<string>vcmi.icns</string>
 	<key>CFBundleVersion</key>

--- a/cmake_modules/FindFFmpeg.cmake
+++ b/cmake_modules/FindFFmpeg.cmake
@@ -156,7 +156,7 @@ endforeach ()
 
 # On OS X we ffmpeg libraries depend on VideoDecodeAcceleration and CoreVideo frameworks
 IF (APPLE)
-    SET(FFMPEG_LIBRARIES ${FFMPEG_LIBRARIES} "-framework VideoDecodeAcceleration -framework CoreVideo -lbz2")
+	SET(FFMPEG_EXTRA_LINKING_OPTIONS "-framework VideoDecodeAcceleration -framework CoreVideo -lbz2")
 ENDIF()
 
 # Give a nice error message if some of the required vars are missing.


### PR DESCRIPTION
Our CMake config is horrible, but before I going to improve it I want to find out about quirks of Mac build. Once I get builds working I'll start to change configuration heavily for all platforms. All improvements should be reusable for both Windows and likely MXE builds.

TODO:

- Fix Qt libraries bundling since CMake / BundleUtilities fail this OOTB. Thanks to @light2yellow for pointing me [this project](https://github.com/OpenChemistry/avogadroapp) on IRC. 
- Make sure launcher dependencies not conflict with system Qt libraries installed from brew.
- Decide what to do with Mac-specific vcmibuilder and Sparkle integration.