### PR TITLE
Fix for failing vcmi-android build

### DIFF
--- a/lib/CAndroidVMHelper.h
+++ b/lib/CAndroidVMHelper.h
@@ -9,6 +9,8 @@
  */
 #pragma once
 
+#include "Global.h"
+
 #ifdef VCMI_ANDROID
 #include <jni.h>
 #include <string>


### PR DESCRIPTION
(android vm helper didn't see VCMI_ANDROID define because apparently it got included before global)