### PR TITLE
Android: better CTextInput handling

### DIFF
--- a/client/widgets/TextControls.h
+++ b/client/widgets/TextControls.h
@@ -160,6 +160,10 @@ protected:
 
 	void focusGot() override;
 	void focusLost() override;
+
+#ifdef VCMI_ANDROID
+	void notifyAndroidTextInputChanged(std::string & text);
+#endif
 public:
 	CFunctionList<void(const std::string &)> cb;
 	CFunctionList<void(std::string &, const std::string &)> filters;

--- a/lib/CAndroidVMHelper.cpp
+++ b/lib/CAndroidVMHelper.cpp
@@ -83,6 +83,16 @@ std::string CAndroidVMHelper::callStaticStringMethod(const std::string & cls, co
 	return std::string(env->GetStringUTFChars(jres, nullptr));
 }
 
+void CAndroidVMHelper::callCustomMethod(const std::string & cls, const std::string & method,
+										const std::string & signature,
+										std::function<void(JNIEnv *, jclass, jmethodID)> fun, bool classloaded)
+{
+	auto env = get();
+	auto javaHelper = findClass(cls, classloaded);
+	auto methodId = env->GetStaticMethodID(javaHelper, method.c_str(), signature.c_str());
+	fun(env, javaHelper, methodId);
+}
+
 jclass CAndroidVMHelper::findClass(const std::string & name, bool classloaded)
 {
 	if(classloaded)

--- a/lib/CAndroidVMHelper.h
+++ b/lib/CAndroidVMHelper.h
@@ -12,6 +12,7 @@
 #include "Global.h"
 
 #ifdef VCMI_ANDROID
+
 #include <jni.h>
 #include <string>
 
@@ -35,6 +36,9 @@ public:
 	void callStaticVoidMethod(const std::string & cls, const std::string & method, bool classloaded = false);
 
 	std::string callStaticStringMethod(const std::string & cls, const std::string & method, bool classloaded = false);
+
+	void callCustomMethod(const std::string & cls, const std::string & method, const std::string & signature,
+						  std::function<void(JNIEnv *, jclass, jmethodID)> fun, bool classloaded = false);
 
 	static void cacheVM(JNIEnv * env);
 


### PR DESCRIPTION
(not sure how we should handle features that need to modify both vcmi and vcmi-android projects -- in any case, I pushed vcmi-android's counterpart to https://github.com/Fayth/vcmi-android/tree/better-textinput )

The (main) problem with input handling in vcmi+android is that when SDL opens phone's software keyboard, the screen is partially hidden and, in most cases, the keyboard hides the CTextInput. In this scenario, the user doesn't see what is the content of the textbox until he closes the keyboard.

This PR (along with vcmi-android's part) allows vcmi to send CTextInput text changed events to android java code. Then we display an overlay showing what is being typed into the textbox (example: http://i.imgur.com/XOi7Sbd.png ). The overlay is visible while the soft keyboard is opened.

Additionally, I noticed 2 more problems with the text input (not really in scope of this PR):
- pressing enter on the soft keyboard might execute a hotkey action (e.g. in hotseat players list, pressing enter changes the displayed window) but it never unfocuses the textbox so the soft keyboard remains opened; should be relatively easy to fix -- manually unfocusing the control in the callback should work
- closing the soft keyboard (via phone's back button) doesn't unfocus the CTextInput, which prevents from opening the keyboard again until the field gets unfocused due to some other action; this might be hard to fix -- from what I checked, SDL eats this event and doesn't pass it to vcmi; possible solution is to create jni callback and notify about closing the keyboard manually