### PR TITLE
Compilation fix for VS 2017

### DIFF
--- a/Global.h
+++ b/Global.h
@@ -154,8 +154,8 @@ static_assert(sizeof(bool) == 1, "Bool needs to be 1 byte in size.");
 #define BOOST_THREAD_DONT_PROVIDE_THREAD_DESTRUCTOR_CALLS_TERMINATE_IF_JOINABLE 1
 #define BOOST_BIND_NO_PLACEHOLDERS
 
-#if defined(_MSC_VER) && (_MSC_VER == 1900)
-#define BOOST_NO_CXX11_VARIADIC_TEMPLATES //Variadic templates are buggy in VS2015, so turn this off to avoid compile errors
+#if defined(_MSC_VER) && (_MSC_VER == 1900 || _MSC_VER == 1910)
+#define BOOST_NO_CXX11_VARIADIC_TEMPLATES //Variadic templates are buggy in VS2015 and VS2017, so turn this off to avoid compile errors
 #endif
 
 #include <boost/algorithm/string.hpp>


### PR DESCRIPTION
Related to: https://developercommunity.visualstudio.com/content/problem/69009/compilation-error-on-msvc2015-on-boostbase-from-me.html