### PR TITLE
Code style: serialize everything on own lines for easier debugging

### DIFF
--- a/AI/VCAI/AIUtility.h
+++ b/AI/VCAI/AIUtility.h
@@ -62,7 +62,9 @@ public:
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & this->h & hid & name;
+		h & this->h;
+		h & hid;
+		h & name;
 	}
 };
 

--- a/AI/VCAI/Goals.h
+++ b/AI/VCAI/Goals.h
@@ -121,8 +121,18 @@ public:
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & goalType & isElementar & isAbstract & priority;
-		h & value & resID & objid & aid & tile & hero & town & bid;
+		h & goalType;
+		h & isElementar;
+		h & isAbstract;
+		h & priority;
+		h & value;
+		h & resID;
+		h & objid;
+		h & aid;
+		h & tile;
+		h & hero;
+		h & town;
+		h & bid;
 	}
 };
 

--- a/AI/VCAI/VCAI.h
+++ b/AI/VCAI/VCAI.h
@@ -63,7 +63,10 @@ public:
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & battle & remainingQueries & requestToQueryID & havingTurn;
+		h & battle;
+		h & remainingQueries;
+		h & requestToQueryID;
+		h & havingTurn;
 	}
 };
 
@@ -350,10 +353,18 @@ public:
 
 	template <typename Handler> void serializeInternal(Handler &h, const int version)
 	{
-		h & knownTeleportChannels & knownSubterraneanGates & destinationTeleport;
-		h & townVisitsThisWeek & lockedHeroes & reservedHeroesMap; //FIXME: cannot instantiate abstract class
-		h & visitableObjs & alreadyVisited & reservedObjs;
-		h & saving & status & battlename;
+		h & knownTeleportChannels;
+		h & knownSubterraneanGates;
+		h & destinationTeleport;
+		h & townVisitsThisWeek;
+		h & lockedHeroes;
+		h & reservedHeroesMap; //FIXME: cannot instantiate abstract class
+		h & visitableObjs;
+		h & alreadyVisited;
+		h & reservedObjs;
+		h & saving;
+		h & status;
+		h & battlename;
 		h & heroesUnableToExplore;
 
 		//myCB is restored after load by init call

--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -1350,7 +1350,9 @@ template <typename Handler> void CPlayerInterface::serializeTempl( Handler &h, c
 		h & observerInDuelMode;
 	}
 
-	h & wanderingHeroes & towns & sleepingHeroes;
+	h & wanderingHeroes;
+	h & towns;
+	h & sleepingHeroes;
 
 	std::map<const CGHeroInstance *, int3> pathsMap; //hero -> dest
 	if (h.saving)

--- a/client/CPlayerInterface.h
+++ b/client/CPlayerInterface.h
@@ -125,7 +125,10 @@ public:
 		SpellbookLastSetting();
 		template <typename Handler> void serialize( Handler &h, const int version )
 		{
-			h & spellbookLastPageBattle & spellbokLastPageAdvmap & spellbookLastTabBattle & spellbookLastTabAdvmap;
+			h & spellbookLastPageBattle;
+			h & spellbokLastPageAdvmap;
+			h & spellbookLastTabBattle;
+			h & spellbookLastTabAdvmap;
 		}
 	} spellbookSettings;
 

--- a/client/Client.cpp
+++ b/client/Client.cpp
@@ -504,7 +504,9 @@ void CClient::serialize(BinarySerializer & h, const int version)
 		{
 			LOG_TRACE_PARAMS(logGlobal, "Saving player %s interface", i->first);
 			assert(i->first == i->second->playerID);
-			h & i->first & i->second->dllName & i->second->human;
+			h & i->first;
+			h & i->second->dllName;
+			h & i->second->human;
 			i->second->saveGame(h, version);
 		}
 	}
@@ -524,7 +526,9 @@ void CClient::serialize(BinaryDeserializer & h, const int version)
 			PlayerColor pid;
 			bool isHuman = false;
 
-			h & pid & dllname & isHuman;
+			h & pid;
+			h & dllname;
+			h & isHuman;
 			LOG_TRACE_PARAMS(logGlobal, "Loading player %s interface", pid);
 
 			std::shared_ptr<CGameInterface> nInt;
@@ -573,7 +577,9 @@ void CClient::serialize(BinarySerializer & h, const int version, const std::set<
 		{
 			LOG_TRACE_PARAMS(logGlobal, "Saving player %s interface", i->first);
 			assert(i->first == i->second->playerID);
-			h & i->first & i->second->dllName & i->second->human;
+			h & i->first;
+			h & i->second->dllName;
+			h & i->second->human;
 			i->second->saveGame(h, version);
 		}
 	}
@@ -593,7 +599,9 @@ void CClient::serialize(BinaryDeserializer & h, const int version, const std::se
 			PlayerColor pid;
 			bool isHuman = false;
 
-			h & pid & dllname & isHuman;
+			h & pid;
+			h & dllname;
+			h & isHuman;
 			LOG_TRACE_PARAMS(logGlobal, "Loading player %s interface", pid);
 
 			std::shared_ptr<CGameInterface> nInt;

--- a/lib/CArtHandler.h
+++ b/lib/CArtHandler.h
@@ -77,9 +77,20 @@ public:
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
 		h & static_cast<CBonusSystemNode&>(*this);
-		h & name & description & eventText & image & large & advMapDef & iconIndex &
-			price & possibleSlots & constituents & constituentOf & aClass & id;
-		if(version>=759)
+		h & name;
+		h & description;
+		h & eventText;
+		h & image;
+		h & large;
+		h & advMapDef;
+		h & iconIndex;
+		h & price;
+		h & possibleSlots;
+		h & constituents;
+		h & constituentOf;
+		h & aClass;
+		h & id;
+		if(version >= 759)
 		{
 			h & identifier;
 		}
@@ -113,7 +124,8 @@ public:
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
 		h & static_cast<CArtifact&>(*this);
-		h & bonusesPerLevel & thresholdBonuses;
+		h & bonusesPerLevel;
+		h & thresholdBonuses;
 	}
 };
 
@@ -154,7 +166,8 @@ public:
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
 		h & static_cast<CBonusSystemNode&>(*this);
-		h & artType & id;
+		h & artType;
+		h & id;
 		BONUS_TREE_DESERIALIZATION_FIX
 	}
 
@@ -183,7 +196,8 @@ public:
 		ArtifactPosition slot;
 		template <typename Handler> void serialize(Handler &h, const int version)
 		{
-			h & art & slot;
+			h & art;
+			h & slot;
 		}
 
 		bool operator==(const ConstituentInfo &rhs) const;
@@ -265,8 +279,13 @@ public:
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & artifacts & allowedArtifacts & treasures & minors & majors & relics
-			& growingArtifacts;
+		h & artifacts;
+		h & allowedArtifacts;
+		h & treasures;
+		h & minors;
+		h & majors;
+		h & relics;
+		h & growingArtifacts;
 	}
 
 private:
@@ -295,7 +314,8 @@ struct DLL_LINKAGE ArtSlotInfo
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & artifact & locked;
+		h & artifact;
+		h & locked;
 	}
 };
 
@@ -330,7 +350,8 @@ public:
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & artifactsInBackpack & artifactsWorn;
+		h & artifactsInBackpack;
+		h & artifactsWorn;
 	}
 
 	void artDeserializationFix(CBonusSystemNode *node);

--- a/lib/CBonusTypeHandler.h
+++ b/lib/CBonusTypeHandler.h
@@ -50,7 +50,10 @@ public:
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & icon & nameTemplate & descriptionTemplate & hidden;
+		h & icon;
+		h & nameTemplate;
+		h & descriptionTemplate;
+		h & hidden;
 
 		if (!h.saving)
 			buildMacros();

--- a/lib/CCreatureHandler.h
+++ b/lib/CCreatureHandler.h
@@ -69,11 +69,20 @@ public:
 
 		template <typename Handler> void serialize(Handler &h, const int version)
 		{
-			h & timeBetweenFidgets & idleAnimationTime;
-			h & walkAnimationTime & attackAnimationTime & flightAnimationDistance;
-			h & upperRightMissleOffsetX & rightMissleOffsetX & lowerRightMissleOffsetX;
-			h & upperRightMissleOffsetY & rightMissleOffsetY & lowerRightMissleOffsetY;
-			h & missleFrameAngles & troopCountLocationOffset & attackClimaxFrame;
+			h & timeBetweenFidgets;
+			h & idleAnimationTime;
+			h & walkAnimationTime;
+			h & attackAnimationTime;
+			h & flightAnimationDistance;
+			h & upperRightMissleOffsetX;
+			h & rightMissleOffsetX;
+			h & lowerRightMissleOffsetX;
+			h & upperRightMissleOffsetY;
+			h & rightMissleOffsetY;
+			h & lowerRightMissleOffsetY;
+			h & missleFrameAngles;
+			h & troopCountLocationOffset;
+			h & attackClimaxFrame;
 			h & projectileImageName;
 		}
 	} animation;
@@ -92,7 +101,14 @@ public:
 
 		template <typename Handler> void serialize(Handler &h, const int version)
 		{
-			h & attack & defend & killed & move & shoot & wince & startMoving & endMoving;
+			h & attack;
+			h & defend;
+			h & killed;
+			h & move;
+			h & shoot;
+			h & wince;
+			h & startMoving;
+			h & endMoving;
 		}
 	} sounds;
 
@@ -128,16 +144,32 @@ public:
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
 		h & static_cast<CBonusSystemNode&>(*this);
-		h & namePl & nameSing & nameRef
-			& cost & upgrades
-			& fightValue & AIValue & growth & hordeGrowth
-			& ammMin & ammMax & level
-			& abilityText & animDefName & advMapDef;
-		h & iconIndex & smallIconName & largeIconName;
+		h & namePl;
+		h & nameSing;
+		h & nameRef;
+		h & cost;
+		h & upgrades;
+		h & fightValue;
+		h & AIValue;
+		h & growth;
+		h & hordeGrowth;
+		h & ammMin;
+		h & ammMax;
+		h & level;
+		h & abilityText;
+		h & animDefName;
+		h & advMapDef;
+		h & iconIndex;
+		h & smallIconName;
+		h & largeIconName;
 
-		h & idNumber & faction & sounds & animation;
+		h & idNumber;
+		h & faction;
+		h & sounds;
+		h & animation;
 
-		h & doubleWide & special;
+		h & doubleWide;
+		h & special;
 		if(version>=759)
 		{
 			h & identifier;
@@ -236,9 +268,14 @@ public:
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
 		//TODO: should be optimized, not all these informations needs to be serialized (same for ccreature)
-		h & doubledCreatures & creatures;
-		h & expRanks & maxExpPerBattle & expAfterUpgrade;
-		h & skillLevels & skillRequirements & commanderLevelPremy;
+		h & doubledCreatures;
+		h & creatures;
+		h & expRanks;
+		h & maxExpPerBattle;
+		h & expAfterUpgrade;
+		h & skillLevels;
+		h & skillRequirements;
+		h & commanderLevelPremy;
 		h & allCreatures;
 		h & creaturesOfLevel;
 		BONUS_TREE_DESERIALIZATION_FIX

--- a/lib/CCreatureSet.h
+++ b/lib/CCreatureSet.h
@@ -35,7 +35,8 @@ public:
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & type & count;
+		h & type;
+		h & count;
 	}
 
 	void serializeJson(JsonSerializeFormat & handler);
@@ -60,7 +61,8 @@ public:
 		h & static_cast<CBonusSystemNode&>(*this);
 		h & static_cast<CStackBasicDescriptor&>(*this);
 		h & static_cast<CArtifactSet&>(*this);
-		h & _armyObj & experience;
+		h & _armyObj;
+		h & experience;
 		BONUS_TREE_DESERIALIZATION_FIX
 	}
 
@@ -124,7 +126,11 @@ public:
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
 		h & static_cast<CStackInstance&>(*this);
-		h & alive & level & name & secondarySkills & specialSKills;
+		h & alive;
+		h & level;
+		h & name;
+		h & secondarySkills;
+		h & specialSKills;
 	}
 };
 
@@ -217,7 +223,8 @@ public:
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & stacks & formation;
+		h & stacks;
+		h & formation;
 	}
 
 	void serializeJson(JsonSerializeFormat & handler, const std::string & fieldName, const boost::optional<int> fixedSize = boost::none);

--- a/lib/CGameState.h
+++ b/lib/CGameState.h
@@ -72,11 +72,22 @@ struct DLL_LINKAGE SThievesGuildInfo
     std::map<PlayerColor, EAiTactic::EAiTactic> personality; // color to personality // ai tactic
 	std::map<PlayerColor, si32> bestCreature; // color to ID // id or -1 if not known
 
-// 	template <typename Handler> void serialize(Handler &h, const int version)
-// 	{
-// 		h & playerColors & numOfTowns & numOfHeroes & gold & woodOre & mercSulfCrystGems & obelisks & artifacts & army & income;
-// 		h & colorToBestHero & personality & bestCreature;
-// 	}
+//	template <typename Handler> void serialize(Handler &h, const int version)
+//	{
+//		h & playerColors;
+//		h & numOfTowns;
+//		h & numOfHeroes;
+//		h & gold;
+//		h & woodOre;
+//		h & mercSulfCrystGems;
+//		h & obelisks;
+//		h & artifacts;
+//		h & army;
+//		h & income;
+//		h & colorToBestHero;
+//		h & personality;
+//		h & bestCreature;
+//	}
 
 };
 
@@ -104,7 +115,8 @@ struct DLL_LINKAGE RumorState
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & type & last;
+		h & type;
+		h & last;
 	}
 };
 
@@ -133,7 +145,8 @@ public:
 
 		template <typename Handler> void serialize(Handler &h, const int version)
 		{
-			h & heroesPool & pavailable;
+			h & heroesPool;
+			h & pavailable;
 		}
 	} hpool; //we have here all heroes available on this map that are not hired
 
@@ -194,13 +207,24 @@ public:
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & scenarioOps & initialOpts & currentPlayer & day & map & players & teams & hpool & globalEffects & rand;
+		h & scenarioOps;
+		h & initialOpts;
+		h & currentPlayer;
+		h & day;
+		h & map;
+		h & players;
+		h & teams;
+		h & hpool;
+		h & globalEffects;
+		h & rand;
 		if(version >= 755) //save format backward compatibility
 		{
 			h & rumor;
 		}
 		else if(!h.saving)
+		{
 			rumor = RumorState();
+		}
 
 		BONUS_TREE_DESERIALIZATION_FIX
 	}

--- a/lib/CGameStateFwd.h
+++ b/lib/CGameStateFwd.h
@@ -140,7 +140,9 @@ public:
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & intValue & messageToSelf & messageToOthers;
+		h & intValue;
+		h & messageToSelf;
+		h & messageToOthers;
 	}
 private:
 	enum EResult
@@ -196,6 +198,8 @@ struct DLL_LINKAGE QuestInfo //universal interface for human and AI
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & quest & obj & tile;
+		h & quest;
+		h & obj;
+		h & tile;
 	}
 };

--- a/lib/CHeroHandler.h
+++ b/lib/CHeroHandler.h
@@ -28,7 +28,10 @@ struct SSpecialtyInfo
 	si32 additionalinfo;
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & type & val & subtype & additionalinfo;
+		h & type;
+		h & val;
+		h & subtype;
+		h & additionalinfo;
 	}
 };
 
@@ -39,7 +42,8 @@ struct SSpecialtyBonus
 	BonusList bonuses;
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & growsWithLevel & bonuses;
+		h & growsWithLevel;
+		h & bonuses;
 	}
 };
 
@@ -54,7 +58,9 @@ public:
 
 		template <typename Handler> void serialize(Handler &h, const int version)
 		{
-			h & minAmount & maxAmount & creature;
+			h & minAmount;
+			h & maxAmount;
+			h & creature;
 		}
 	};
 	std::string identifier;
@@ -87,10 +93,27 @@ public:
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & ID & imageIndex & initialArmy & heroClass & secSkillsInit & spec & specialty & spells & haveSpellBook & sex & special;
-		h & name & biography & specName & specDescr & specTooltip;
-		h & iconSpecSmall & iconSpecLarge & portraitSmall & portraitLarge;
-		if(version>=759)
+		h & ID;
+		h & imageIndex;
+		h & initialArmy;
+		h & heroClass;
+		h & secSkillsInit;
+		h & spec;
+		h & specialty;
+		h & spells;
+		h & haveSpellBook;
+		h & sex;
+		h & special;
+		h & name;
+		h & biography;
+		h & specName;
+		h & specDescr;
+		h & specTooltip;
+		h & iconSpecSmall;
+		h & iconSpecLarge;
+		h & portraitSmall;
+		h & portraitLarge;
+		if(version >= 759)
 		{
 			h & identifier;
 		}
@@ -139,11 +162,22 @@ public:
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & identifier & name & faction & id & defaultTavernChance;// & aggression;
-		h & primarySkillInitial   & primarySkillLowLevel;
-		h & primarySkillHighLevel & secSkillProbability;
-		h & selectionProbability & affinity & commander;
-		h & imageBattleMale & imageBattleFemale & imageMapMale & imageMapFemale;
+		h & identifier;
+		h & name;
+		h & faction;
+		h & id;
+		h & defaultTavernChance;
+		h & primarySkillInitial;
+		h & primarySkillLowLevel;
+		h & primarySkillHighLevel;
+		h & secSkillProbability;
+		h & selectionProbability;
+		h & affinity;
+		h & commander;
+		h & imageBattleMale;
+		h & imageBattleFemale;
+		h & imageMapMale;
+		h & imageMapFemale;
 	}
 	EAlignment::EAlignment getAlignment() const;
 };
@@ -165,7 +199,14 @@ struct DLL_LINKAGE CObstacleInfo
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & ID & defName & allowedTerrains & allowedSpecialBfields & isAbsoluteObstacle & width & height & blockedTiles;
+		h & ID;
+		h & defName;
+		h & allowedTerrains;
+		h & allowedSpecialBfields;
+		h & isAbsoluteObstacle;
+		h & width;
+		h & height;
+		h & blockedTiles;
 	}
 };
 
@@ -227,7 +268,15 @@ public:
 		ui8 sum; //I don't know if it is useful for anything, but it's in config file
 		template <typename Handler> void serialize(Handler &h, const int version)
 		{
-			h & keep & tower & gate & wall & shots & noDmg & oneDmg & twoDmg & sum;
+			h & keep;
+			h & tower;
+			h & gate;
+			h & wall;
+			h & shots;
+			h & noDmg;
+			h & oneDmg;
+			h & twoDmg;
+			h & sum;
 		}
 	};
 	std::vector<SBallisticsLevelInfo> ballistics; //info about ballistics ability per level; [0] - none; [1] - basic; [2] - adv; [3] - expert
@@ -269,7 +318,12 @@ public:
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & classes & heroes & expPerLevel & ballistics & terrCosts;
-		h & obstacles & absoluteObstacles;
+		h & classes;
+		h & heroes;
+		h & expPerLevel;
+		h & ballistics;
+		h & terrCosts;
+		h & obstacles;
+		h & absoluteObstacles;
 	}
 };

--- a/lib/CModHandler.h
+++ b/lib/CModHandler.h
@@ -54,7 +54,8 @@ class CIdentifierStorage
 
 		template <typename Handler> void serialize(Handler &h, const int version)
 		{
-			h & id & scope;
+			h & id;
+			h & scope;
 		}
 	};
 
@@ -98,7 +99,8 @@ public:
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & registeredObjects & state;
+		h & registeredObjects;
+		h & state;
 	}
 };
 
@@ -205,9 +207,15 @@ public:
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & identifier & description & name;
-		h & dependencies & conflicts & config;
-		h & checksum & validation & enabled;
+		h & identifier;
+		h & description;
+		h & name;
+		h & dependencies;
+		h & conflicts;
+		h & config;
+		h & checksum;
+		h & validation;
+		h & enabled;
 	}
 private:
 	void loadLocalData(const JsonNode & data);
@@ -271,9 +279,15 @@ public:
 
 		template <typename Handler> void serialize(Handler &h, const int version)
 		{
-			h & data & CREEP_SIZE & WEEKLY_GROWTH & NEUTRAL_STACK_EXP & MAX_BUILDING_PER_TURN;
-			h & DWELLINGS_ACCUMULATE_CREATURES & ALL_CREATURES_GET_DOUBLE_MONTHS &
-			MAX_HEROES_AVAILABLE_PER_PLAYER & MAX_HEROES_ON_MAP_PER_PLAYER;
+			h & data;
+			h & CREEP_SIZE;
+			h & WEEKLY_GROWTH;
+			h & NEUTRAL_STACK_EXP;
+			h & MAX_BUILDING_PER_TURN;
+			h & DWELLINGS_ACCUMULATE_CREATURES;
+			h & ALL_CREATURES_GET_DOUBLE_MONTHS;
+			h & MAX_HEROES_AVAILABLE_PER_PLAYER;
+			h & MAX_HEROES_ON_MAP_PER_PLAYER;
 			if(version >= 756)
 			{
 				h & WINNING_HERO_WITH_NO_TROOPS_RETREATS;
@@ -303,7 +317,10 @@ public:
 
 		template <typename Handler> void serialize(Handler &h, const int version)
 		{
-			h & STACK_EXP & STACK_ARTIFACT & COMMANDERS & MITHRIL;
+			h & STACK_EXP;
+			h & STACK_ARTIFACT;
+			h & COMMANDERS;
+			h & MITHRIL;
 		}
 	} modules;
 
@@ -318,6 +335,10 @@ public:
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & allMods & activeMods & settings & modules & identifiers;
+		h & allMods;
+		h & activeMods;
+		h & settings;
+		h & modules;
+		h & identifiers;
 	}
 };

--- a/lib/CPlayerState.h
+++ b/lib/CPlayerState.h
@@ -40,8 +40,17 @@ public:
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & color & human & team & resources & status;
-		h & heroes & towns & availableHeroes & dwellings & quests & visitedObjects;
+		h & color;
+		h & human;
+		h & team;
+		h & resources;
+		h & status;
+		h & heroes;
+		h & towns;
+		h & availableHeroes;
+		h & dwellings;
+		h & quests;
+		h & visitedObjects;
 
 		if(version < 760)
 		{
@@ -50,8 +59,10 @@ public:
 			h & junk;
 		}
 
-		h & status & daysWithoutCastle;
-		h & enteredLosingCheatCode & enteredWinningCheatCode;
+		h & status;
+		h & daysWithoutCastle;
+		h & enteredLosingCheatCode;
+		h & enteredWinningCheatCode;
 		h & static_cast<CBonusSystemNode&>(*this);
 	}
 };
@@ -69,7 +80,9 @@ public:
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & id & players & fogOfWarMap;
+		h & id;
+		h & players;
+		h & fogOfWarMap;
 		h & static_cast<CBonusSystemNode&>(*this);
 	}
 

--- a/lib/CStack.h
+++ b/lib/CStack.h
@@ -117,7 +117,9 @@ public:
 	{
 		if(!h.saving)
 			reset();
-		h & firstHPleft & fullUnits & resurrected;
+		h & firstHPleft;
+		h & fullUnits;
+		h & resurrected;
 	}
 private:
 	void addResurrected(int32_t amount);
@@ -251,21 +253,32 @@ public:
 	template <typename Handler> void serialize(Handler & h, const int version)
 	{
 		assert(isIndependentNode());
-		h & static_cast<CBonusSystemNode &>(*this);
+		h & static_cast<CBonusSystemNode&>(*this);
 		h & type;
-		h & ID & baseAmount & owner & slot & side & position & state;
-		h & shots & casts & counterAttacks & health;
+		h & ID;
+		h & baseAmount;
+		h & owner;
+		h & slot;
+		h & side;
+		h & position;
+		h & state;
+		h & shots;
+		h & casts;
+		h & counterAttacks;
+		h & health;
 
 		const CArmedInstance * army = (base ? base->armyObj : nullptr);
 		SlotID extSlot = (base ? base->armyObj->findStack(base) : SlotID());
 
 		if(h.saving)
 		{
-			h & army & extSlot;
+			h & army;
+			h & extSlot;
 		}
 		else
 		{
-			h & army & extSlot;
+			h & army;
+			h & extSlot;
 			if(extSlot == SlotID::COMMANDER_SLOT_PLACEHOLDER)
 			{
 				auto hero = dynamic_cast<const CGHeroInstance *>(army);

--- a/lib/CTownHandler.h
+++ b/lib/CTownHandler.h
@@ -68,7 +68,16 @@ public:
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & identifier & town & bid & resources & produce & name & description & requirements & upgrade & mode;
+		h & identifier;
+		h & town;
+		h & bid;
+		h & resources;
+		h & produce;
+		h & name;
+		h & description;
+		h & requirements;
+		h & upgrade;
+		h & mode;
 	}
 
 	friend class CTownHandler;
@@ -88,7 +97,14 @@ struct DLL_LINKAGE CStructure
 	bool hiddenUpgrade; // used only if "building" is upgrade, if true - structure on town screen will behave exactly like parent (mouse clicks, hover texts, etc)
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & pos & defName & borderName & areaName & identifier & building & buildable & hiddenUpgrade;
+		h & pos;
+		h & defName;
+		h & borderName;
+		h & areaName;
+		h & identifier;
+		h & building;
+		h & buildable;
+		h & hiddenUpgrade;
 	}
 };
 
@@ -101,7 +117,11 @@ struct DLL_LINKAGE SPuzzleInfo
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & number & x & y & whenUncovered & filename;
+		h & number;
+		h & x;
+		h & y;
+		h & whenUncovered;
+		h & filename;
 	}
 };
 
@@ -130,7 +150,15 @@ public:
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & name & identifier & index & nativeTerrain & alignment & town & creatureBg120 & creatureBg130 & puzzleMap;
+		h & name;
+		h & identifier;
+		h & index;
+		h & nativeTerrain;
+		h & alignment;
+		h & town;
+		h & creatureBg120;
+		h & creatureBg130;
+		h & puzzleMap;
 	}
 };
 
@@ -179,7 +207,10 @@ public:
 			si32 y;
 
 			template <typename Handler> void serialize(Handler &h, const int version)
-			{ h & x & y; }
+			{
+				h & x;
+				h & y;
+			}
 		};
 
 		//icons [fort is present?][build limit reached?] -> index of icon in def files
@@ -206,16 +237,38 @@ public:
 
 		template <typename Handler> void serialize(Handler &h, const int version)
 		{
-			h & icons & iconSmall & iconLarge & tavernVideo & musicTheme & townBackground & guildBackground & guildWindow & buildingsIcons & hallBackground;
-			h & hallSlots & structures;
-			h & siegePrefix & siegePositions & siegeShooter;
+			h & icons;
+			h & iconSmall;
+			h & iconLarge;
+			h & tavernVideo;
+			h & musicTheme;
+			h & townBackground;
+			h & guildBackground;
+			h & guildWindow;
+			h & buildingsIcons;
+			h & hallBackground;
+			h & hallSlots;
+			h & structures;
+			h & siegePrefix;
+			h & siegePositions;
+			h & siegeShooter;
 		}
 	} clientInfo;
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & names & faction & creatures & dwellings & dwellingNames & buildings & hordeLvl & mageLevel
-			& primaryRes & warMachine & clientInfo & moatDamage;
+		h & names;
+		h & faction;
+		h & creatures;
+		h & dwellings;
+		h & dwellingNames;
+		h & buildings;
+		h & hordeLvl;
+		h & mageLevel;
+		h & primaryRes;
+		h & warMachine;
+		h & clientInfo;
+		h & moatDamage;
 		if(version >= 758)
 		{
 			h & moatHexes;

--- a/lib/HeroBonus.h
+++ b/lib/HeroBonus.h
@@ -335,7 +335,19 @@ struct DLL_LINKAGE Bonus : public std::enable_shared_from_this<Bonus>
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & duration & type & subtype & source & val & sid & description & additionalInfo & turnsRemain & valType & effectRange & limiter & propagator;
+		h & duration;
+		h & type;
+		h & subtype;
+		h & source;
+		h & val;
+		h & sid;
+		h & description;
+		h & additionalInfo;
+		h & turnsRemain;
+		h & valType;
+		h & effectRange;
+		h & limiter;
+		h & propagator;
 	}
 
 	template <typename Ptr>
@@ -692,7 +704,8 @@ public:
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & /*bonuses & */nodeType;
+//		h & bonuses;
+		h & nodeType;
 		h & exportedBonuses;
 		h & description;
 		BONUS_TREE_DESERIALIZATION_FIX
@@ -816,7 +829,8 @@ public:
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
 		h & static_cast<ILimiter&>(*this);
-		h & creature & includeUpgrades;
+		h & creature;
+		h & includeUpgrades;
 	}
 };
 
@@ -835,7 +849,9 @@ public:
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
 		h & static_cast<ILimiter&>(*this);
-		h & type & subtype & isSubtypeRelevant;
+		h & type;
+		h & subtype;
+		h & isSubtypeRelevant;
 	}
 };
 
@@ -915,7 +931,8 @@ public:
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
 		h & static_cast<ILimiter&>(*this);
-		h & minRank & maxRank;
+		h & minRank;
+		h & maxRank;
 	}
 };
 

--- a/lib/NetPacks.h
+++ b/lib/NetPacks.h
@@ -92,7 +92,8 @@ struct StackLocation
 	DLL_LINKAGE const CStackInstance *getStack();
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & army & slot;
+		h & army;
+		h & slot;
 	}
 };
 
@@ -116,7 +117,10 @@ struct PackageApplied : public CPackForClient
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & result & packType & requestID & player;
+		h & result;
+		h & packType;
+		h & requestID;
+		h & player;
 	}
 };
 
@@ -148,7 +152,9 @@ struct PlayerBlocked : public CPackForClient
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & reason & startOrEnd & player;
+		h & reason;
+		h & startOrEnd;
+		h & player;
 	}
 };
 
@@ -163,7 +169,9 @@ struct PlayerCheated : public CPackForClient
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & player & losingCheatCode & winningCheatCode;
+		h & player;
+		h & losingCheatCode;
+		h & winningCheatCode;
 	}
 };
 
@@ -178,7 +186,8 @@ struct YourTurn : public CPackForClient
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & player & daysWithoutCastle;
+		h & player;
+		h & daysWithoutCastle;
 	}
 };
 
@@ -194,7 +203,9 @@ struct SetResources : public CPackForClient
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & abs & player & res;
+		h & abs;
+		h & player;
+		h & res;
 	}
 };
 
@@ -213,7 +224,10 @@ struct SetPrimSkill : public CPackForClient
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & abs & id & which & val;
+		h & abs;
+		h & id;
+		h & which;
+		h & val;
 	}
 };
 
@@ -232,7 +246,10 @@ struct SetSecSkill : public CPackForClient
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & abs & id & which & val;
+		h & abs;
+		h & id;
+		h & which;
+		h & val;
 	}
 };
 
@@ -252,7 +269,9 @@ struct HeroVisitCastle : public CPackForClient
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & flags & tid & hid;
+		h & flags;
+		h & tid;
+		h & hid;
 	}
 };
 
@@ -268,7 +287,9 @@ struct ChangeSpells : public CPackForClient
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & learn & hid & spells;
+		h & learn;
+		h & hid;
+		h & spells;
 	}
 };
 
@@ -285,7 +306,9 @@ struct SetMana : public CPackForClient
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & val & hid & absolute;
+		h & val;
+		h & hid;
+		h & absolute;
 	}
 };
 
@@ -301,7 +324,9 @@ struct SetMovePoints : public CPackForClient
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & val & hid & absolute;
+		h & val;
+		h & hid;
+		h & absolute;
 	}
 };
 
@@ -317,7 +342,10 @@ struct FoWChange : public CPackForClient
 	bool waitForDialogs;
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & tiles & player & mode & waitForDialogs;
+		h & tiles;
+		h & player;
+		h & mode;
+		h & waitForDialogs;
 	}
 };
 
@@ -336,7 +364,9 @@ struct SetAvailableHeroes : public CPackForClient
 	CSimpleArmy army[GameConstants::AVAILABLE_HEROES_PER_PLAYER];
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & player & hid & army;
+		h & player;
+		h & hid;
+		h & army;
 	}
 };
 
@@ -359,7 +389,10 @@ struct GiveBonus :  public CPackForClient
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & bonus & id & bdescr & who;
+		h & bonus;
+		h & id;
+		h & bdescr;
+		h & who;
 		assert( id != -1);
 	}
 };
@@ -380,7 +413,9 @@ struct ChangeObjPos : public CPackForClient
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & objid & nPos & flags;
+		h & objid;
+		h & nPos;
+		h & flags;
 	}
 };
 
@@ -398,7 +433,8 @@ struct PlayerEndsGame : public CPackForClient
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & player & victoryLossCheckResult;
+		h & player;
+		h & victoryLossCheckResult;
 	}
 };
 
@@ -428,7 +464,10 @@ struct RemoveBonus :  public CPackForClient
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & source & id & who & whoID;
+		h & source;
+		h & id;
+		h & who;
+		h & whoID;
 	}
 };
 
@@ -464,7 +503,12 @@ struct SetCommanderProperty : public CPackForClient
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & heroid & sl & which & amount & additionalInfo & accumulatedBonus;
+		h & heroid;
+		h & sl;
+		h & which;
+		h & amount;
+		h & additionalInfo;
+		h & accumulatedBonus;
 	}
 };
 
@@ -479,7 +523,8 @@ struct AddQuest : public CPackForClient
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & player & quest;
+		h & player;
+		h & quest;
 	}
 };
 
@@ -501,7 +546,10 @@ struct UpdateArtHandlerLists : public CPackForClient
 	DLL_LINKAGE void applyGs(CGameState *gs);
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & treasures & minors & majors & relics;
+		h & treasures;
+		h & minors;
+		h & majors;
+		h & relics;
 	}
 };
 
@@ -527,7 +575,8 @@ struct UpdateCastleEvents : public CPackForClient
 	DLL_LINKAGE void applyGs(CGameState *gs);
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & town & events;
+		h & town;
+		h & events;
 	}
 };
 
@@ -541,7 +590,8 @@ struct ChangeFormation : public CPackForClient
 	DLL_LINKAGE void applyGs(CGameState *gs);
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & hid & formation;
+		h & hid;
+		h & formation;
 	}
 };
 
@@ -586,7 +636,13 @@ struct TryMoveHero : public CPackForClient
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & id & result & start & end & movePoints & fowRevealed & attackedFrom;
+		h & id;
+		h & result;
+		h & start;
+		h & end;
+		h & movePoints;
+		h & fowRevealed;
+		h & attackedFrom;
 	}
 };
 
@@ -602,7 +658,9 @@ struct NewStructures : public CPackForClient
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & tid & bid & builded;
+		h & tid;
+		h & bid;
+		h & builded;
 	}
 };
 
@@ -618,7 +676,9 @@ struct RazeStructures : public CPackForClient
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & tid & bid & destroyed;
+		h & tid;
+		h & bid;
+		h & destroyed;
 	}
 };
 
@@ -633,7 +693,8 @@ struct SetAvailableCreatures : public CPackForClient
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & tid & creatures;
+		h & tid;
+		h & creatures;
 	}
 };
 
@@ -647,7 +708,9 @@ struct SetHeroesInTown : public CPackForClient
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & tid & visiting & garrison;
+		h & tid;
+		h & visiting;
+		h & garrison;
 	}
 };
 
@@ -664,7 +727,10 @@ struct HeroRecruited : public CPackForClient
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & hid & tid & tile & player;
+		h & hid;
+		h & tid;
+		h & tile;
+		h & player;
 	}
 };
 
@@ -680,7 +746,8 @@ struct GiveHero : public CPackForClient
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & id & player;
+		h & id;
+		h & player;
 	}
 };
 
@@ -696,7 +763,9 @@ struct OpenWindow : public CPackForClient
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & window & id1 & id2;
+		h & window;
+		h & id1;
+		h & id2;
 	}
 };
 
@@ -714,7 +783,9 @@ struct NewObject  : public CPackForClient
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & ID & subID & pos;
+		h & ID;
+		h & subID;
+		h & pos;
 	}
 };
 
@@ -729,7 +800,8 @@ struct SetAvailableArtifacts  : public CPackForClient
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & id & arts;
+		h & id;
+		h & arts;
 	}
 };
 
@@ -766,7 +838,9 @@ struct ChangeStackCount : CGarrisonOperationPack
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & sl & count & absoluteValue;
+		h & sl;
+		h & count;
+		h & absoluteValue;
 	}
 };
 
@@ -780,7 +854,8 @@ struct SetStackType : CGarrisonOperationPack
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & sl & type;
+		h & sl;
+		h & type;
 	}
 };
 
@@ -806,7 +881,8 @@ struct SwapStacks : CGarrisonOperationPack
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & sl1 & sl2;
+		h & sl1;
+		h & sl2;
 	}
 };
 
@@ -820,7 +896,8 @@ struct InsertNewStack : CGarrisonOperationPack
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & sl & stack;
+		h & sl;
+		h & stack;
 	}
 };
 
@@ -835,7 +912,9 @@ struct RebalanceStacks : CGarrisonOperationPack
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & src & dst & count;
+		h & src;
+		h & dst;
+		h & count;
 	}
 };
 
@@ -863,7 +942,8 @@ struct PutArtifact : CArtifactOperationPack
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & al & art;
+		h & al;
+		h & art;
 	}
 };
 
@@ -889,7 +969,8 @@ struct MoveArtifact : CArtifactOperationPack
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & src & dst;
+		h & src;
+		h & dst;
 	}
 };
 
@@ -903,7 +984,8 @@ struct AssembledArtifact : CArtifactOperationPack
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & al & builtArt/* & constituents*/;
+		h & al;
+		h & builtArt;
 	}
 };
 
@@ -932,7 +1014,10 @@ struct HeroVisit : CPackForClient
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & hero & obj & player & starting;
+		h & hero;
+		h & obj;
+		h & player;
+		h & starting;
 	}
 };
 
@@ -949,7 +1034,9 @@ struct NewTurn : public CPackForClient
 		ui32 move, mana; //id is a general serial id
 		template <typename Handler> void serialize(Handler &h, const int version)
 		{
-			h & id & move & mana;
+			h & id;
+			h & move;
+			h & mana;
 		}
 		bool operator<(const Hero&h)const{return id < h.id;}
 	};
@@ -965,7 +1052,12 @@ struct NewTurn : public CPackForClient
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & heroes & cres & res & day & specialWeek & creatureid;
+		h & heroes;
+		h & cres;
+		h & res;
+		h & day;
+		h & specialWeek;
+		h & creatureid;
 	}
 };
 
@@ -980,7 +1072,10 @@ struct InfoWindow : public CPackForClient //103  - displays simple info window
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & text & components & player & soundID;
+		h & text;
+		h & components;
+		h & player;
+		h & soundID;
 	}
 	InfoWindow()
 	{
@@ -1018,7 +1113,9 @@ struct SetObjectProperty : public CPackForClient
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & id & what & val;
+		h & id;
+		h & what;
+		h & val;
 	}
 };
 
@@ -1049,7 +1146,9 @@ struct ChangeObjectVisitors : public CPackForClient
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & object & hero & mode;
+		h & object;
+		h & hero;
+		h & mode;
 	}
 };
 
@@ -1083,7 +1182,10 @@ struct HeroLevelUp : public Query
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & queryID & hero & primskill & skills;
+		h & queryID;
+		h & hero;
+		h & primskill;
+		h & skills;
 	}
 };
 
@@ -1100,7 +1202,9 @@ struct CommanderLevelUp : public Query
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & queryID & hero & skills;
+		h & queryID;
+		h & hero;
+		h & skills;
 	}
 };
 
@@ -1143,7 +1247,12 @@ struct BlockingDialog : public Query
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & queryID & text & components & player & flags & soundID;
+		h & queryID;
+		h & text;
+		h & components;
+		h & player;
+		h & flags;
+		h & soundID;
 	}
 };
 
@@ -1156,7 +1265,10 @@ struct GarrisonDialog : public Query
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & queryID & objid & hid & removableUnits;
+		h & queryID;
+		h & objid;
+		h & hid;
+		h & removableUnits;
 	}
 };
 
@@ -1172,7 +1284,8 @@ struct ExchangeDialog : public Query
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & queryID & heroes;
+		h & queryID;
+		h & heroes;
 	}
 };
 
@@ -1195,7 +1308,11 @@ struct TeleportDialog : public Query
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & queryID & hero & channel & exits & impassable;
+		h & queryID;
+		h & hero;
+		h & channel;
+		h & exits;
+		h & impassable;
 	}
 };
 
@@ -1213,7 +1330,12 @@ struct MapObjectSelectDialog : public Query
 
 	template <typename Handler> void serialize(Handler & h, const int version)
 	{
-		h & queryID & player & icon & title & description & objects;
+		h & queryID;
+		h & player;
+		h & icon;
+		h & title;
+		h & description;
+		h & objects;
 	}
 };
 
@@ -1267,7 +1389,8 @@ struct BattleSetActiveStack : public CPackForClient
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & stack & askPlayerInterface;
+		h & stack;
+		h & askPlayerInterface;
 	}
 };
 
@@ -1292,7 +1415,12 @@ struct BattleResult : public CPackForClient
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & result & winner & casualties[0] & casualties[1] & exp & artifacts;
+		h & result;
+		h & winner;
+		h & casualties[0];
+		h & casualties[1];
+		h & exp;
+		h & artifacts;
 	}
 };
 
@@ -1308,7 +1436,9 @@ struct BattleStackMoved : public CPackForClient
 	void applyGs(CGameState *gs);
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & stack & tilesToMove & distance;
+		h & stack;
+		h & tilesToMove;
+		h & distance;
 	}
 };
 
@@ -1329,7 +1459,10 @@ struct StacksHealedOrResurrected : public CPackForClient
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & healedStacks & lifeDrain & tentHealing & drainedFrom;
+		h & healedStacks;
+		h & lifeDrain;
+		h & tentHealing;
+		h & drainedFrom;
 		h & cure;
 	}
 };
@@ -1387,8 +1520,14 @@ struct BattleStackAttacked : public CPackForClient
 	}
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & stackAttacked & attackerID & newHealth & flags & killedAmount & damageAmount & effect
-			& healedStacks;
+		h & stackAttacked;
+		h & attackerID;
+		h & newHealth;
+		h & flags;
+		h & killedAmount;
+		h & damageAmount;
+		h & effect;
+		h & healedStacks;
 		h & spellID;
 	}
 	bool operator<(const BattleStackAttacked &b) const
@@ -1443,7 +1582,10 @@ struct BattleAttack : public CPackForClient
 	}
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & bsa & stackAttacking & flags & spellID;
+		h & bsa;
+		h & stackAttacking;
+		h & flags;
+		h & spellID;
 	}
 };
 
@@ -1481,7 +1623,8 @@ struct BattleSpellCast : public CPackForClient
 		ui32 stack;
 		template <typename Handler> void serialize(Handler &h, const int version)
 		{
-			h & effect & stack;
+			h & effect;
+			h & stack;
 		}
 	};
 
@@ -1510,7 +1653,15 @@ struct BattleSpellCast : public CPackForClient
 	std::vector<MetaString> battleLog;
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & side & id & skill & manaGained & tile & customEffects & affectedCres & casterStack & castByHero;
+		h & side;
+		h & id;
+		h & skill;
+		h & manaGained;
+		h & tile;
+		h & customEffects;
+		h & affectedCres;
+		h & casterStack;
+		h & castByHero;
 		h & battleLog;
 	}
 };
@@ -1534,8 +1685,11 @@ struct SetStackEffect : public CPackForClient
 	std::vector<MetaString> battleLog;
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & stacks & effect & uniqueBonuses;
-		h & cumulativeEffects & cumulativeUniqueBonuses;
+		h & stacks;
+		h & effect;
+		h & uniqueBonuses;
+		h & cumulativeEffects;
+		h & cumulativeUniqueBonuses;
 		h & battleLog;
 	}
 };
@@ -1562,7 +1716,8 @@ struct BattleResultsApplied : public CPackForClient
 	void applyCl(CClient *cl);
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & player1 & player2;
+		h & player1;
+		h & player2;
 	}
 };
 
@@ -1593,7 +1748,9 @@ struct ELF_VISIBILITY CatapultAttack : public CPackForClient
 
 		template <typename Handler> void serialize(Handler &h, const int version)
 		{
-			h & destinationTile & attackedPart & damageDealt;
+			h & destinationTile;
+			h & attackedPart;
+			h & damageDealt;
 		}
 	};
 
@@ -1609,7 +1766,8 @@ struct ELF_VISIBILITY CatapultAttack : public CPackForClient
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & attackedParts & attacker;
+		h & attackedParts;
+		h & attacker;
 	}
 };
 
@@ -1650,7 +1808,11 @@ struct BattleStackAdded : public CPackForClient
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & side & creID & amount & pos & summoned;
+		h & side;
+		h & creID;
+		h & amount;
+		h & pos;
+		h & summoned;
 	}
 };
 
@@ -1671,7 +1833,10 @@ struct BattleSetStackProperty : public CPackForClient
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & stackID & which & val & absolute;
+		h & stackID;
+		h & which;
+		h & val;
+		h & absolute;
 	}
 };
 
@@ -1692,7 +1857,10 @@ struct BattleTriggerEffect : public CPackForClient
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & stackID & effect & val & additionalInfo;
+		h & stackID;
+		h & effect;
+		h & val;
+		h & additionalInfo;
 	}
 };
 
@@ -1736,7 +1904,9 @@ struct ShowInInfobox : public CPackForClient
 	void applyCl(CClient *cl);
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & player & c & text;
+		h & player;
+		h & c;
+		h & text;
 	}
 };
 
@@ -1749,7 +1919,8 @@ struct AdvmapSpellCast : public CPackForClient
 	void applyCl(CClient *cl);
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & caster & spellID;
+		h & caster;
+		h & spellID;
 	}
 };
 
@@ -1765,7 +1936,8 @@ struct ShowWorldViewEx : public CPackForClient
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & player & objectPositions;
+		h & player;
+		h & objectPositions;
 	}
 };
 
@@ -1840,7 +2012,9 @@ struct MoveHero : public CPackForServer
 	bool applyGh(CGameHandler *gh);
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & dest & hid & transit;
+		h & dest;
+		h & hid;
+		h & transit;
 	}
 };
 
@@ -1855,7 +2029,8 @@ struct CastleTeleportHero : public CPackForServer
 	bool applyGh(CGameHandler *gh);
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & dest & hid;
+		h & dest;
+		h & hid;
 	}
 };
 
@@ -1872,7 +2047,12 @@ struct ArrangeStacks : public CPackForServer
 	bool applyGh(CGameHandler *gh);
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & what & p1 & p2 & id1 & id2 & val;
+		h & what;
+		h & p1;
+		h & p2;
+		h & id1;
+		h & id2;
+		h & val;
 	}
 };
 
@@ -1886,7 +2066,8 @@ struct DisbandCreature : public CPackForServer
 	bool applyGh(CGameHandler *gh);
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & pos & id;
+		h & pos;
+		h & id;
 	}
 };
 
@@ -1900,7 +2081,8 @@ struct BuildStructure : public CPackForServer
 	bool applyGh(CGameHandler *gh);
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & tid & bid;
+		h & tid;
+		h & bid;
 	}
 };
 
@@ -1924,7 +2106,11 @@ struct RecruitCreatures : public CPackForServer
 	bool applyGh(CGameHandler *gh);
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & tid & dst & crid & amount & level;
+		h & tid;
+		h & dst;
+		h & crid;
+		h & amount;
+		h & level;
 	}
 };
 
@@ -1939,7 +2125,9 @@ struct UpgradeCreature : public CPackForServer
 	bool applyGh(CGameHandler *gh);
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & pos & id & cid;
+		h & pos;
+		h & id;
+		h & cid;
 	}
 };
 
@@ -1965,7 +2153,8 @@ struct ExchangeArtifacts : public CPackForServer
 	bool applyGh(CGameHandler *gh);
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & src & dst;
+		h & src;
+		h & dst;
 	}
 };
 
@@ -1982,7 +2171,10 @@ struct AssembleArtifacts : public CPackForServer
 	bool applyGh(CGameHandler *gh);
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & heroID & artifactSlot & assemble & assembleTo;
+		h & heroID;
+		h & artifactSlot;
+		h & assemble;
+		h & assembleTo;
 	}
 };
 
@@ -1996,7 +2188,8 @@ struct BuyArtifact : public CPackForServer
 	bool applyGh(CGameHandler *gh);
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & hid & aid;
+		h & hid;
+		h & aid;
 	}
 };
 
@@ -2015,7 +2208,12 @@ struct TradeOnMarketplace : public CPackForServer
 	bool applyGh(CGameHandler *gh);
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & market & hero & mode & r1 & r2 & val;
+		h & market;
+		h & hero;
+		h & mode;
+		h & r1;
+		h & r2;
+		h & val;
 	}
 };
 
@@ -2029,7 +2227,8 @@ struct SetFormation : public CPackForServer
 	bool applyGh(CGameHandler *gh);
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & hid & formation;
+		h & hid;
+		h & formation;
 	}
 };
 
@@ -2044,7 +2243,9 @@ struct HireHero : public CPackForServer
 	bool applyGh(CGameHandler *gh);
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & hid & tid & player;
+		h & hid;
+		h & tid;
+		h & player;
 	}
 };
 
@@ -2072,7 +2273,9 @@ struct QueryReply : public CPackForServer
 	bool applyGh(CGameHandler *gh);
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & qid & player & reply;
+		h & qid;
+		h & player;
+		h & reply;
 	}
 };
 
@@ -2124,7 +2327,9 @@ struct CastAdvSpell : public CPackForServer
 	bool applyGh(CGameHandler *gh);
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & hid & sid & pos;
+		h & hid;
+		h & sid;
+		h & pos;
 	}
 };
 
@@ -2161,7 +2366,9 @@ struct PlayerMessage : public CPackForClient, public CPackForServer
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & text & player & currObj;
+		h & text;
+		h & player;
+		h & currObj;
 	}
 };
 
@@ -2176,7 +2383,9 @@ struct CenterView : public CPackForClient
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & pos & player & focusTime;
+		h & pos;
+		h & player;
+		h & focusTime;
 	}
 };
 
@@ -2200,7 +2409,8 @@ struct ChatMessage : public CPregamePackToPropagate
 	void apply(CSelectionScreen *selScreen);
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & playerName & message;
+		h & playerName;
+		h & message;
 	}
 };
 
@@ -2221,7 +2431,8 @@ struct PlayerJoined : public CPregamePackToHost
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & playerName & connectionID;
+		h & playerName;
+		h & connectionID;
 	}
 };
 
@@ -2292,7 +2503,9 @@ struct RequestOptionsChange : public CPregamePackToHost
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & what & direction & playerID;
+		h & what;
+		h & direction;
+		h & playerID;
 	}
 };
 

--- a/lib/NetPacksBase.h
+++ b/lib/NetPacksBase.h
@@ -53,7 +53,10 @@ public:
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & exactStrings & localStrings & message & numbers;
+		h & exactStrings;
+		h & localStrings;
+		h & message;
+		h & numbers;
 	}
 	void addTxt(ui8 type, ui32 serial)
 	{
@@ -124,7 +127,10 @@ struct Component
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & id & subtype & val & when;
+		h & id;
+		h & subtype;
+		h & val;
+		h & when;
 	}
 	Component()
 		:id(0), subtype(0), val(0), when(0)
@@ -185,7 +191,8 @@ struct ArtifactLocation
 	DLL_LINKAGE const ArtSlotInfo *getSlot() const;
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & artHolder & slot;
+		h & artHolder;
+		h & slot;
 	}
 };
 
@@ -204,6 +211,10 @@ public:
 
 	template <typename Handler> void serialize(Handler & h, const int version)
 	{
-		h & stackId & delta & firstHPleft & fullUnits & resurrected;
+		h & stackId;
+		h & delta;
+		h & firstHPleft;
+		h & fullUnits;
+		h & resurrected;
 	}
 };

--- a/lib/StartInfo.h
+++ b/lib/StartInfo.h
@@ -112,7 +112,8 @@ struct StartInfo
 		h & mode;
 		h & difficulty;
 		h & playerInfos;
-		h & seedToBeUsed & seedPostInit;
+		h & seedToBeUsed;
+		h & seedPostInit;
 		h & mapfileChecksum;
 		h & turnTime;
 		h & mapname;

--- a/lib/VCMI_Lib.h
+++ b/lib/VCMI_Lib.h
@@ -59,7 +59,15 @@ public:
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & heroh & arth & creh & townh & objh & objtypeh & spellh & modh & IS_AI_ENABLED;
+		h & heroh;
+		h & arth;
+		h & creh;
+		h & townh;
+		h & objh;
+		h & objtypeh;
+		h & spellh;
+		h & modh;
+		h & IS_AI_ENABLED;
 		h & bth;
 		if(!h.saving)
 		{

--- a/lib/battle/BattleAction.h
+++ b/lib/battle/BattleAction.h
@@ -25,7 +25,12 @@ struct DLL_LINKAGE BattleAction
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & side & stackNumber & actionType & destinationTile & additionalInfo & selectedStack;
+		h & side;
+		h & stackNumber;
+		h & actionType;
+		h & destinationTile;
+		h & additionalInfo;
+		h & selectedStack;
 	}
 
 	BattleAction();

--- a/lib/battle/BattleInfo.h
+++ b/lib/battle/BattleInfo.h
@@ -37,9 +37,18 @@ struct DLL_LINKAGE BattleInfo : public CBonusSystemNode, public CBattleInfoCallb
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
 		h & sides;
-		h & round & activeStack & selectedStack & town & tile & stacks & obstacles
-			& si & battlefieldType & terrainType;
-		h & tacticsSide & tacticDistance;
+		h & round;
+		h & activeStack;
+		h & selectedStack;
+		h & town;
+		h & tile;
+		h & stacks;
+		h & obstacles;
+		h & si;
+		h & battlefieldType;
+		h & terrainType;
+		h & tacticsSide;
+		h & tacticDistance;
 		h & static_cast<CBonusSystemNode&>(*this);
 	}
 

--- a/lib/battle/CBattleInfoCallback.h
+++ b/lib/battle/CBattleInfoCallback.h
@@ -26,7 +26,8 @@ struct DLL_LINKAGE AttackableTiles
 	std::set<BattleHex> friendlyCreaturePositions; //for Dragon Breath
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & hostileCreaturePositions & friendlyCreaturePositions;
+		h & hostileCreaturePositions;
+		h & friendlyCreaturePositions;
 	}
 };
 

--- a/lib/battle/CObstacleInstance.h
+++ b/lib/battle/CObstacleInstance.h
@@ -49,7 +49,10 @@ struct DLL_LINKAGE CObstacleInstance
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & ID & pos & obstacleType & uniqueID;
+		h & ID;
+		h & pos;
+		h & obstacleType;
+		h & uniqueID;
 	}
 };
 
@@ -76,6 +79,10 @@ struct DLL_LINKAGE SpellCreatedObstacle : CObstacleInstance
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
 		h & static_cast<CObstacleInstance&>(*this);
-		h & turnsRemaining & casterSpellPower & spellLevel & casterSide & visibleForAnotherSide;
+		h & turnsRemaining;
+		h & casterSpellPower;
+		h & spellLevel;
+		h & casterSide;
+		h & visibleForAnotherSide;
 	}
 };

--- a/lib/battle/SideInBattle.h
+++ b/lib/battle/SideInBattle.h
@@ -29,7 +29,11 @@ struct DLL_LINKAGE SideInBattle
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & color & hero & armyObject;
-		h & castSpellsCount & usedSpellsHistory & enchanterCounter;
+		h & color;
+		h & hero;
+		h & armyObject;
+		h & castSpellsCount;
+		h & usedSpellsHistory;
+		h & enchanterCounter;
 	}
 };

--- a/lib/battle/SiegeInfo.h
+++ b/lib/battle/SiegeInfo.h
@@ -23,6 +23,7 @@ struct DLL_LINKAGE SiegeInfo
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & wallState & gateState;
+		h & wallState;
+		h & gateState;
 	}
 };

--- a/lib/int3.h
+++ b/lib/int3.h
@@ -133,7 +133,9 @@ public:
 	template <typename Handler>
 	void serialize(Handler &h, const int version)
 	{
-		h & x & y & z;
+		h & x;
+		h & y;
+		h & z;
 	}
 
 	static std::array<int3, 8> getDirs()

--- a/lib/mapObjects/CBank.h
+++ b/lib/mapObjects/CBank.h
@@ -41,7 +41,9 @@ public:
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
 		h & static_cast<CArmedInstance&>(*this);
-		h & daycounter & bc & resetDuration;
+		h & daycounter;
+		h & bc;
+		h & resetDuration;
 	}
 
 	friend class CBankInstanceConstructor;

--- a/lib/mapObjects/CGHeroInstance.h
+++ b/lib/mapObjects/CGHeroInstance.h
@@ -125,7 +125,9 @@ public:
 
 		template <typename Handler> void serialize(Handler &h, const int version)
 		{
-			h & magicSchoolCounter & wisdomCounter & rand;
+			h & magicSchoolCounter;
+			h & wisdomCounter;
+			h & rand;
 		}
 	} skillsInfo;
 
@@ -278,10 +280,26 @@ public:
 	{
 		h & static_cast<CArmedInstance&>(*this);
 		h & static_cast<CArtifactSet&>(*this);
-		h & exp & level & name & biography & portrait & mana & secSkills & movement
-			& sex & inTownGarrison & spells & patrol & moveDir & skillsInfo;
-		h & visitedTown & boat;
-		h & type & specialty & commander & visitedObjects;
+		h & exp;
+		h & level;
+		h & name;
+		h & biography;
+		h & portrait;
+		h & mana;
+		h & secSkills;
+		h & movement;
+		h & sex;
+		h & inTownGarrison;
+		h & spells;
+		h & patrol;
+		h & moveDir;
+		h & skillsInfo;
+		h & visitedTown;
+		h & boat;
+		h & type;
+		h & specialty;
+		h & commander;
+		h & visitedObjects;
 		BONUS_TREE_DESERIALIZATION_FIX
 		//visitied town pointer will be restored by map serialization method
 	}

--- a/lib/mapObjects/CGPandoraBox.h
+++ b/lib/mapObjects/CGPandoraBox.h
@@ -44,8 +44,19 @@ public:
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
 		h & static_cast<CArmedInstance&>(*this);
-		h & message & hasGuardians & gainedExp & manaDiff & moraleDiff & luckDiff & resources & primskills
-			& abilities & abilityLevels & artifacts & spells & creatures;
+		h & message;
+		h & hasGuardians;
+		h & gainedExp;
+		h & manaDiff;
+		h & moraleDiff;
+		h & luckDiff;
+		h & resources;
+		h & primskills;
+		h & abilities;
+		h & abilityLevels;
+		h & artifacts;
+		h & spells;
+		h & creatures;
 	}
 protected:
 	void giveContentsUpToExp(const CGHeroInstance *h) const;
@@ -68,7 +79,10 @@ public:
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
 		h & static_cast<CGPandoraBox &>(*this);
-		h & removeAfterVisit & availableFor & computerActivate & humanActivate;
+		h & removeAfterVisit;
+		h & availableFor;
+		h & computerActivate;
+		h & humanActivate;
 	}
 
 	CGEvent();

--- a/lib/mapObjects/CGTownInstance.h
+++ b/lib/mapObjects/CGTownInstance.h
@@ -88,7 +88,8 @@ private:
 public:
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & static_cast<CArmedInstance&>(*this) & creatures;
+		h & static_cast<CArmedInstance&>(*this);
+		h & creatures;
 	}
 };
 
@@ -102,7 +103,8 @@ public:
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & ID & id;
+		h & ID;
+		h & id;
 	}
 };
 class DLL_LINKAGE COPWBonus : public CGTownBuilding
@@ -189,15 +191,27 @@ public:
 		h & static_cast<CGDwelling&>(*this);
 		h & static_cast<IShipyard&>(*this);
 		h & static_cast<IMarket&>(*this);
-		h & name & builded & destroyed & identifier;
-		h & garrisonHero & visitingHero;
-		h & alignment & forbiddenBuildings & builtBuildings & bonusValue
-			& possibleSpells & obligatorySpells & spells & /*strInfo & */events & bonusingBuildings;
+		h & name;
+		h & builded;
+		h & destroyed;
+		h & identifier;
+		h & garrisonHero;
+		h & visitingHero;
+		h & alignment;
+		h & forbiddenBuildings;
+		h & builtBuildings;
+		h & bonusValue;
+		h & possibleSpells;
+		h & obligatorySpells;
+		h & spells;
+		h & events;
+		h & bonusingBuildings;
 
 		for (std::vector<CGTownBuilding*>::iterator i = bonusingBuildings.begin(); i!=bonusingBuildings.end(); i++)
 			(*i)->town = this;
 
-		h & town & townAndVis;
+		h & town;
+		h & townAndVis;
 		BONUS_TREE_DESERIALIZATION_FIX
 
 		vstd::erase_if(builtBuildings, [this](BuildingID building) -> bool

--- a/lib/mapObjects/CObjectClassesHandler.h
+++ b/lib/mapObjects/CObjectClassesHandler.h
@@ -43,7 +43,10 @@ struct DLL_LINKAGE RandomMapInfo
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & value & mapLimit & zoneLimit & rarity;
+		h & value;
+		h & mapLimit;
+		h & zoneLimit;
+		h & rarity;
 	}
 };
 
@@ -159,10 +162,15 @@ public:
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & type & subtype & templates & rmgInfo & objectName;
+		h & type;
+		h & subtype;
+		h & templates;
+		h & rmgInfo;
+		h & objectName;
 		if(version >= 759)
 		{
-			h & typeName & subTypeName;
+			h & typeName;
+			h & subTypeName;
 		}
 	}
 };
@@ -186,10 +194,14 @@ class DLL_LINKAGE CObjectClassesHandler : public IHandlerBase
 
 		template <typename Handler> void serialize(Handler &h, const int version)
 		{
-			h & name & handlerName & base & subObjects;
+			h & name;
+			h & handlerName;
+			h & base;
+			h & subObjects;
 			if(version >= 759)
 			{
-				h & identifier & subIds;
+				h & identifier;
+				h & subIds;
 			}
 		}
 	};

--- a/lib/mapObjects/CObjectHandler.h
+++ b/lib/mapObjects/CObjectHandler.h
@@ -179,10 +179,18 @@ public:
 	{
 		if(version >= 759)
 		{
-			h & instanceName & typeName & subTypeName;
+			h & instanceName;
+			h & typeName;
+			h & subTypeName;
 		}
 
-		h & pos & ID & subID & id & tempOwner & blockVisit & appearance;
+		h & pos;
+		h & ID;
+		h & subID;
+		h & id;
+		h & tempOwner;
+		h & blockVisit;
+		h & appearance;
 		//definfo is handled by map serializer
 	}
 

--- a/lib/mapObjects/CQuest.h
+++ b/lib/mapObjects/CQuest.h
@@ -66,10 +66,26 @@ public:
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & qid & missionType & progress & lastDay & m13489val & m2stats & m5arts & m6creatures & m7resources
-			& textOption & stackToKill & stackDirection & heroName & heroPortrait
-			& firstVisitText & nextVisitText & completedText & isCustomFirst
-			& isCustomNext & isCustomComplete;
+		h & qid;
+		h & missionType;
+		h & progress;
+		h & lastDay;
+		h & m13489val;
+		h & m2stats;
+		h & m5arts;
+		h & m6creatures;
+		h & m7resources;
+		h & textOption;
+		h & stackToKill;
+		h & stackDirection;
+		h & heroName;
+		h & heroPortrait;
+		h & firstVisitText;
+		h & nextVisitText;
+		h & completedText;
+		h & isCustomFirst;
+		h & isCustomNext;
+		h & isCustomComplete;
 		if(version >= 757)
 		{
 			h & completedOption;
@@ -131,8 +147,12 @@ public:
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & static_cast<CArmedInstance&>(*this) & static_cast<IQuestObject&>(*this);
-		h & rewardType & rID & rVal & seerName;
+		h & static_cast<CArmedInstance&>(*this);
+		h & static_cast<IQuestObject&>(*this);
+		h & rewardType;
+		h & rID;
+		h & rVal;
+		h & seerName;
 	}
 protected:
 	static const int OBJPROP_VISITED = 10;

--- a/lib/mapObjects/CRewardableObject.h
+++ b/lib/mapObjects/CRewardableObject.h
@@ -57,8 +57,14 @@ public:
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & numOfGrants & dayOfWeek & minLevel & resources;
-		h & primary & secondary & artifacts & creatures;
+		h & numOfGrants;
+		h & dayOfWeek;
+		h & minLevel;
+		h & resources;
+		h & primary;
+		h & secondary;
+		h & artifacts;
+		h & creatures;
 	}
 };
 
@@ -121,11 +127,21 @@ public:
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & resources & extraComponents & removeObject;
-		h & manaPercentage & movePercentage;
-		h & gainedExp & gainedLevels & manaDiff & movePoints;
-		h & primary & secondary & bonuses;
-		h & artifacts & spells & creatures;
+		h & resources;
+		h & extraComponents;
+		h & removeObject;
+		h & manaPercentage;
+		h & movePercentage;
+		h & gainedExp;
+		h & gainedLevels;
+		h & manaDiff;
+		h & movePoints;
+		h & primary;
+		h & secondary;
+		h & bonuses;
+		h & artifacts;
+		h & spells;
+		h & creatures;
 	}
 };
 
@@ -151,7 +167,11 @@ public:
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & limiter & reward & message & selectChance & numOfGrants;
+		h & limiter;
+		h & reward;
+		h & message;
+		h & selectChance;
+		h & numOfGrants;
 	}
 };
 
@@ -244,9 +264,16 @@ public:
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
 		h & static_cast<CArmedInstance&>(*this);
-		h & info & canRefuse & resetDuration;
-		h & onSelect & onVisited & onEmpty & visitMode;
-		h & soundID & selectMode & selectedReward;
+		h & info;
+		h & canRefuse;
+		h & resetDuration;
+		h & onSelect;
+		h & onVisited;
+		h & onEmpty;
+		h & visitMode;
+		h & soundID;
+		h & selectMode;
+		h & selectedReward;
 	}
 
 	// for configuration/object setup

--- a/lib/mapObjects/CommonConstructors.h
+++ b/lib/mapObjects/CommonConstructors.h
@@ -76,7 +76,9 @@ public:
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & filtersJson & faction & filters;
+		h & filtersJson;
+		h & faction;
+		h & filters;
 		h & static_cast<CDefaultObjectTypeHandler<CGTownInstance>&>(*this);
 	}
 };
@@ -99,7 +101,9 @@ public:
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & filtersJson & heroClass & filters;
+		h & filtersJson;
+		h & heroClass;
+		h & filters;
 		h & static_cast<CDefaultObjectTypeHandler<CGHeroInstance>&>(*this);
 	}
 };
@@ -125,7 +129,8 @@ public:
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & availableCreatures & guards;
+		h & availableCreatures;
+		h & guards;
 		h & static_cast<CDefaultObjectTypeHandler<CGDwelling>&>(*this);
 	}
 };
@@ -145,7 +150,15 @@ struct BankConfig
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & chance & upgradeChance & guards & combatValue & resources & creatures & artifacts & value & spells;
+		h & chance;
+		h & upgradeChance;
+		h & guards;
+		h & combatValue;
+		h & resources;
+		h & creatures;
+		h & artifacts;
+		h & value;
+		h & spells;
 	}
 };
 
@@ -190,7 +203,8 @@ public:
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & levels & bankResetDuration;
+		h & levels;
+		h & bankResetDuration;
 		h & static_cast<CDefaultObjectTypeHandler<CBank>&>(*this);
 	}
 };

--- a/lib/mapObjects/MiscObjects.h
+++ b/lib/mapObjects/MiscObjects.h
@@ -74,15 +74,24 @@ public:
 		ui8 upgrade; //random seed used to determine number of stacks and is there's upgraded stack
 		template <typename Handler> void serialize(Handler &h, const int version)
 		{
-			h & basicType & upgrade;
+			h & basicType;
+			h & upgrade;
 		}
 	} formation;
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
 		h & static_cast<CArmedInstance&>(*this);
-		h & identifier & character & message & resources & gainedArtifact & neverFlees & notGrowingTeam & temppower;
-		h & refusedJoining & formation;
+		h & identifier;
+		h & character;
+		h & message;
+		h & resources;
+		h & gainedArtifact;
+		h & neverFlees;
+		h & notGrowingTeam;
+		h & temppower;
+		h & refusedJoining;
+		h & formation;
 	}
 protected:
 	void setPropertyDer(ui8 what, ui32 val) override;
@@ -129,7 +138,8 @@ public:
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
 		h & static_cast<CTeamVisited&>(*this);
-		h & allowedAbilities & ability;
+		h & allowedAbilities;
+		h & ability;
 	}
 protected:
 	void serializeJsonOptions(JsonSerializeFormat & handler) override;
@@ -148,7 +158,8 @@ public:
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
 		h & static_cast<CGObjectInstance&>(*this);
-		h & bonusType & bonusID;
+		h & bonusType;
+		h & bonusID;
 	}
 protected:
 	void serializeJsonOptions(JsonSerializeFormat & handler) override;
@@ -194,7 +205,8 @@ public:
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
 		h & static_cast<CArmedInstance&>(*this);
-		h & message & storedArtifact;
+		h & message;
+		h & storedArtifact;
 	}
 protected:
 	void serializeJsonOptions(JsonSerializeFormat & handler) override;
@@ -218,7 +230,8 @@ public:
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
 		h & static_cast<CArmedInstance&>(*this);
-		h & amount & message;
+		h & amount;
+		h & message;
 	}
 protected:
 	void serializeJsonOptions(JsonSerializeFormat & handler) override;
@@ -265,7 +278,8 @@ public:
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
 		h & static_cast<CArmedInstance&>(*this);
-		h & producedResource & producedQuantity;
+		h & producedResource;
+		h & producedQuantity;
 	}
 	ui32 defaultResProduction();
 protected:
@@ -284,7 +298,9 @@ struct DLL_LINKAGE TeleportChannel
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & entrances & exits & passability;
+		h & entrances;
+		h & exits;
+		h & passability;
 	}
 };
 
@@ -320,7 +336,9 @@ public:
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & type & channel & static_cast<CGObjectInstance&>(*this);
+		h & type;
+		h & channel;
+		h & static_cast<CGObjectInstance&>(*this);
 	}
 };
 
@@ -418,7 +436,9 @@ public:
 	}
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & static_cast<CGObjectInstance&>(*this) & direction & hero;
+		h & static_cast<CGObjectInstance&>(*this);
+		h & direction;
+		h & hero;
 	}
 };
 

--- a/lib/mapObjects/ObjectTemplate.h
+++ b/lib/mapObjects/ObjectTemplate.h
@@ -88,8 +88,14 @@ public:
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & usedTiles & allowedTerrains & animationFile & stringID;
-		h & id & subid & printPriority & visitDir;
+		h & usedTiles;
+		h & allowedTerrains;
+		h & animationFile;
+		h & stringID;
+		h & id;
+		h & subid;
+		h & printPriority;
+		h & visitDir;
 		if(version >= 770)
 		{
 			h & editorAnimationFile;

--- a/lib/mapping/CCampaignHandler.h
+++ b/lib/mapping/CCampaignHandler.h
@@ -42,7 +42,14 @@ public:
 
 	template <typename Handler> void serialize(Handler &h, const int formatVersion)
 	{
-		h & version & mapVersion & name & description & difficultyChoosenByPlayer & music & filename & loadFromLod;
+		h & version;
+		h & mapVersion;
+		h & name;
+		h & description;
+		h & difficultyChoosenByPlayer;
+		h & music;
+		h & filename;
+		h & loadFromLod;
 	}
 };
 
@@ -70,7 +77,10 @@ public:
 
 		template <typename Handler> void serialize(Handler &h, const int formatVersion)
 		{
-			h & type & info1 & info2 & info3;
+			h & type;
+			h & info1;
+			h & info2;
+			h & info3;
 		}
 	};
 
@@ -80,7 +90,12 @@ public:
 
 	template <typename Handler> void serialize(Handler &h, const int formatVersion)
 	{
-		h & whatHeroKeeps & monstersKeptByHero & artifsKeptByHero & startOptions & playerColor & bonusesToChoose;
+		h & whatHeroKeeps;
+		h & monstersKeptByHero;
+		h & artifsKeptByHero;
+		h & startOptions;
+		h & playerColor;
+		h & bonusesToChoose;
 	}
 
 };
@@ -99,7 +114,10 @@ public:
 
 		template <typename Handler> void serialize(Handler &h, const int formatVersion)
 		{
-			h & hasPrologEpilog & prologVideo & prologMusic & prologText;
+			h & hasPrologEpilog;
+			h & prologVideo;
+			h & prologMusic;
+			h & prologText;
 		}
 	};
 
@@ -128,8 +146,20 @@ public:
 
 	template <typename Handler> void serialize(Handler &h, const int formatVersion)
 	{
-		h & mapName & scenarioName & packedMapSize & preconditionRegions & regionColor & difficulty & conquered & regionText &
-			prolog & epilog & travelOptions & crossoverHeroes & placedCrossoverHeroes & keepHeroes;
+		h & mapName;
+		h & scenarioName;
+		h & packedMapSize;
+		h & preconditionRegions;
+		h & regionColor;
+		h & difficulty;
+		h & conquered;
+		h & regionText;
+		h & prolog;
+		h & epilog;
+		h & travelOptions;
+		h & crossoverHeroes;
+		h & placedCrossoverHeroes;
+		h & keepHeroes;
 	}
 };
 
@@ -142,7 +172,9 @@ public:
 
 	template <typename Handler> void serialize(Handler &h, const int formatVersion)
 	{
-		h & header & scenarios & mapPieces;
+		h & header;
+		h & scenarios;
+		h & mapPieces;
 	}
 
 	bool conquerable(int whichScenario) const;
@@ -173,7 +205,11 @@ public:
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & camp & campaignName & mapsRemaining & mapsConquered & currentMap;
+		h & camp;
+		h & campaignName;
+		h & mapsRemaining;
+		h & mapsConquered;
+		h & currentMap;
 		h & chosenCampaignBonuses;
 	}
 };

--- a/lib/mapping/CMap.h
+++ b/lib/mapping/CMap.h
@@ -43,7 +43,8 @@ struct DLL_LINKAGE SHeroName
 	template <typename Handler>
 	void serialize(Handler & h, const int version)
 	{
-		h & heroId & heroName;
+		h & heroId;
+		h & heroName;
 	}
 };
 
@@ -93,9 +94,22 @@ struct DLL_LINKAGE PlayerInfo
 	template <typename Handler>
 	void serialize(Handler & h, const int version)
 	{
-		h & p7 & hasRandomHero & mainCustomHeroId & canHumanPlay & canComputerPlay & aiTactic & allowedFactions & isFactionRandom &
-				mainCustomHeroPortrait & mainCustomHeroName & heroesNames & hasMainTown & generateHeroAtMainTown &
-				posOfMainTown & team & generateHero;
+		h & p7;
+		h & hasRandomHero;
+		h & mainCustomHeroId;
+		h & canHumanPlay;
+		h & canComputerPlay;
+		h & aiTactic;
+		h & allowedFactions;
+		h & isFactionRandom;
+		h & mainCustomHeroPortrait;
+		h & mainCustomHeroName;
+		h & heroesNames;
+		h & hasMainTown;
+		h & generateHeroAtMainTown;
+		h & posOfMainTown;
+		h & team;
+		h & generateHero;
 
 		if(version >= 770)
 		{
@@ -156,7 +170,9 @@ struct DLL_LINKAGE EventCondition
 			h & objectInstanceName;
 		}
 		if(version >= 770)
+		{
 			h & metaType;
+		}
 	}
 };
 
@@ -179,7 +195,8 @@ struct DLL_LINKAGE EventEffect
 	template <typename Handler>
 	void serialize(Handler & h, const int version)
 	{
-		h & type & toOtherMessage;
+		h & type;
+		h & toOtherMessage;
 	}
 };
 
@@ -206,7 +223,8 @@ struct DLL_LINKAGE TriggeredEvent
 		h & identifier;
 		h & trigger;
 		h & description;
-		h & onFulfill & effect;
+		h & onFulfill;
+		h & effect;
 	}
 };
 
@@ -222,7 +240,8 @@ struct DLL_LINKAGE Rumor
 	template <typename Handler>
 	void serialize(Handler & h, const int version)
 	{
-		h & name & text;
+		h & name;
+		h & text;
 	}
 
 	void serializeJson(JsonSerializeFormat & handler);
@@ -241,7 +260,10 @@ struct DLL_LINKAGE DisposedHero
 	template <typename Handler>
 	void serialize(Handler & h, const int version)
 	{
-		h & heroId & portrait & name & players;
+		h & heroId;
+		h & portrait;
+		h & name;
+		h & players;
 	}
 };
 
@@ -301,9 +323,23 @@ public:
 	template <typename Handler>
 	void serialize(Handler & h, const int Version)
 	{
-		h & version & name & description & width & height & twoLevel & difficulty & levelLimit & areAnyPlayers;
-		h & players & howManyTeams & allowedHeroes & triggeredEvents;
-		h & victoryMessage & victoryIconIndex & defeatMessage & defeatIconIndex;
+		h & version;
+		h & name;
+		h & description;
+		h & width;
+		h & height;
+		h & twoLevel;
+		h & difficulty;
+		h & levelLimit;
+		h & areAnyPlayers;
+		h & players;
+		h & howManyTeams;
+		h & allowedHeroes;
+		h & triggeredEvents;
+		h & victoryMessage;
+		h & victoryIconIndex;
+		h & defeatMessage;
+		h & defeatIconIndex;
 	}
 };
 
@@ -385,8 +421,15 @@ public:
 	void serialize(Handler &h, const int formatVersion)
 	{
 		h & static_cast<CMapHeader&>(*this);
-		h & rumors & allowedSpell & allowedAbilities & allowedArtifact & events & grailPos;
-		h & artInstances & quests & allHeroes;
+		h & rumors;
+		h & allowedSpell;
+		h & allowedAbilities;
+		h & allowedArtifact;
+		h & events;
+		h & grailPos;
+		h & artInstances;
+		h & quests;
+		h & allHeroes;
 		h & questIdentifierToId;
 
 		//TODO: viccondetails
@@ -435,12 +478,16 @@ public:
 		}
 
 		h & objects;
-		h & heroesOnMap & teleportChannels & towns & artInstances;
+		h & heroesOnMap;
+		h & teleportChannels;
+		h & towns;
+		h & artInstances;
 
 		// static members
 		h & CGKeys::playerKeyMap;
 		h & CGMagi::eyelist;
-		h & CGObelisk::obeliskCount & CGObelisk::visited;
+		h & CGObelisk::obeliskCount;
+		h & CGObelisk::visited;
 		h & CGTownInstance::merchantArtifacts;
 		h & CGTownInstance::universitySkills;
 

--- a/lib/mapping/CMapDefines.h
+++ b/lib/mapping/CMapDefines.h
@@ -32,8 +32,14 @@ public:
 	template <typename Handler>
 	void serialize(Handler & h, const int version)
 	{
-		h & name & message & resources
-				& players & humanAffected & computerAffected & firstOccurence & nextOccurence;
+		h & name;
+		h & message;
+		h & resources;
+		h & players;
+		h & humanAffected;
+		h & computerAffected;
+		h & firstOccurence;
+		h & nextOccurence;
 	}
 };
 
@@ -51,7 +57,8 @@ public:
 	void serialize(Handler & h, const int version)
 	{
 		h & static_cast<CMapEvent &>(*this);
-		h & buildings & creatures;
+		h & buildings;
+		h & creatures;
 	}
 };
 
@@ -91,8 +98,16 @@ struct DLL_LINKAGE TerrainTile
 	template <typename Handler>
 	void serialize(Handler & h, const int version)
 	{
-		h & terType & terView & riverType & riverDir & roadType &roadDir & extTileFlags;
-		h & visitable & blocked;
-		h & visitableObjects & blockingObjects;
+		h & terType;
+		h & terView;
+		h & riverType;
+		h & riverDir;
+		h & roadType;
+		h & roadDir;
+		h & extTileFlags;
+		h & visitable;
+		h & blocked;
+		h & visitableObjects;
+		h & blockingObjects;
 	}
 };

--- a/lib/mapping/CMapInfo.h
+++ b/lib/mapping/CMapInfo.h
@@ -51,7 +51,14 @@ public:
 
 	template <typename Handler> void serialize(Handler &h, const int Version)
 	{
-		h & mapHeader & campaignHeader & scenarioOpts & fileURI & date & playerAmnt & humanPlayers;
-		h & actualHumanPlayers & isRandomMap;
+		h & mapHeader;
+		h & campaignHeader;
+		h & scenarioOpts;
+		h & fileURI;
+		h & date;
+		h & playerAmnt;
+		h & humanPlayers;
+		h & actualHumanPlayers;
+		h & isRandomMap;
 	}
 };

--- a/lib/rmg/CMapGenOptions.h
+++ b/lib/rmg/CMapGenOptions.h
@@ -87,7 +87,9 @@ public:
 		template <typename Handler>
 		void serialize(Handler & h, const int version)
 		{
-			h & color & startingTown & playerType;
+			h & color;
+			h & startingTown;
+			h & playerType;
 		}
 	};
 
@@ -174,8 +176,17 @@ public:
 	template <typename Handler>
 	void serialize(Handler & h, const int version)
 	{
-		h & width & height & hasTwoLevels & playerCount & teamCount & compOnlyPlayerCount;
-		h & compOnlyTeamCount & waterContent & monsterStrength & players & humanPlayersCount;
+		h & width;
+		h & height;
+		h & hasTwoLevels;
+		h & playerCount;
+		h & teamCount;
+		h & compOnlyPlayerCount;
+		h & compOnlyTeamCount;
+		h & waterContent;
+		h & monsterStrength;
+		h & players;
+		h & humanPlayersCount;
 		//TODO add name of template to class, enables selection of a template by a user
 	}
 };

--- a/lib/rmg/float3.h
+++ b/lib/rmg/float3.h
@@ -145,7 +145,9 @@ public:
 
 	template <typename Handler> void serialize(Handler &h, const float version)
 	{
-		h & x & y & z;
+		h & x;
+		h & y;
+		h & z;
 	}
 };
 

--- a/lib/spells/CSpellHandler.h
+++ b/lib/spells/CSpellHandler.h
@@ -61,7 +61,8 @@ public:
 
 		template <typename Handler> void serialize(Handler & h, const int version)
 		{
-			h & minimumAngle & resourceName;
+			h & minimumAngle;
+			h & resourceName;
 		}
 	};
 
@@ -75,7 +76,8 @@ public:
 
 		template <typename Handler> void serialize(Handler & h, const int version)
 		{
-			h & resourceName & verticalPosition;
+			h & resourceName;
+			h & verticalPosition;
 			if(version >= 754) //save format backward compatibility
 			{
 				h & pause;
@@ -110,9 +112,13 @@ public:
 
 		template <typename Handler> void serialize(Handler & h, const int version)
 		{
-			h & projectile & hit & cast;
+			h & projectile;
+			h & hit;
+			h & cast;
 			if(version >= 762)
+			{
 				h & affect;
+			}
 		}
 
 		std::string selectProjectile(const double angle) const;
@@ -138,11 +144,17 @@ public:
 
 		template <typename Handler> void serialize(Handler &h, const int version)
 		{
-			h & description & cost & power & AIValue & smartTarget & range;
+			h & description;
+			h & cost;
+			h & power;
+			h & AIValue;
+			h & smartTarget;
+			h & range;
 
 			if(version >= 773)
 			{
-				h & effects & cumulativeEffects;
+				h & effects;
+				h & cumulativeEffects;
 			}
 			else
 			{
@@ -159,7 +171,8 @@ public:
 				}
 			}
 
-			h & clearTarget & clearAffected;
+			h & clearTarget;
+			h & clearAffected;
 		}
 	};
 
@@ -267,27 +280,49 @@ public:
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & identifier & id & name & level & power
-		  & probabilities  & attributes & combatSpell & creatureAbility & positiveness & counteredSpells;
-		h & isRising & isDamage & isOffensive;
+		h & identifier;
+		h & id;
+		h & name;
+		h & level;
+		h & power;
+		h & probabilities;
+		h & attributes;
+		h & combatSpell;
+		h & creatureAbility;
+		h & positiveness;
+		h & counteredSpells;
+		h & isRising;
+		h & isDamage;
+		h & isOffensive;
 		h & targetType;
-		h & immunities & limiters & absoluteImmunities & absoluteLimiters;
+		h & immunities;
+		h & limiters;
+		h & absoluteImmunities;
+		h & absoluteLimiters;
 		h & iconImmune;
 		h & defaultProbability;
 		h & isSpecial;
-		h & castSound & iconBook & iconEffect & iconScenarioBonus & iconScroll;
+		h & castSound;
+		h & iconBook;
+		h & iconEffect;
+		h & iconScenarioBonus;
+		h & iconScroll;
 		h & levels;
 		h & school;
 		h & animationInfo;
 
 		if(!h.saving)
+		{
 			setup();
+		}
 		//backward compatibility
 		//can not be added to level structure as level structure does not know spell id
 		if(!h.saving && version < 773)
+		{
 			if(id == SpellID::DISRUPTING_RAY || id == SpellID::ACID_BREATH_DEFENSE)
 				for(auto & level : levels)
 					std::swap(level.effects, level.cumulativeEffects);
+		}
 	}
 	friend class CSpellHandler;
 	friend class Graphics;

--- a/lib/spells/ViewSpellInt.h
+++ b/lib/spells/ViewSpellInt.h
@@ -26,7 +26,10 @@
 
 	template <typename Handler> void serialize(Handler & h, const int version)
 	{
-		h & pos & id & subId & owner;
+		h & pos;
+		h & id;
+		h & subId;
+		h & owner;
 	}
  };
 

--- a/server/CGameHandler.h
+++ b/server/CGameHandler.h
@@ -235,7 +235,9 @@ public:
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & QID & states & finishingBattle;
+		h & QID;
+		h & states;
+		h & finishingBattle;
 		if(version >= 761)
 		{
 			h & getRandomGenerator();
@@ -263,7 +265,10 @@ public:
 
 		template <typename Handler> void serialize(Handler &h, const int version)
 		{
-			h & winnerHero & loserHero & victor & loser;
+			h & winnerHero;
+			h & loserHero;
+			h & victor;
+			h & loser;
 			if(version < 774 && !h.saving)
 			{
 				bool duel;


### PR DESCRIPTION
This is helpful change for debugging both save breakages and sync problems between different compilers.

New rules added to wiki as well:
https://wiki.vcmi.eu/index.php?title=Coding_guidelines#Serialization

Some of used regexps:
```
(\s+)(h & [^ &]+) ([^;]+);
(\s+)(h & [^ &>\)]+) ([^;>\)]+);
\1\2;\n\1h \3;
```