### PR TITLE
Use boost::make_optional for Boost 1.64 compatibility

### DIFF
--- a/client/CPreGame.cpp
+++ b/client/CPreGame.cpp
@@ -3697,7 +3697,7 @@ void CBonusSelection::updateBonusSelection()
 		anim->setCustom(picName, 0);
 		bonusButton->setImage(anim);
 		const SDL_Color brightYellow = { 242, 226, 110, 0 };
-		bonusButton->borderColor = brightYellow;
+		bonusButton->borderColor = boost::make_optional(brightYellow);
 		bonuses->addToggle(i, bonusButton);
 	}
 
@@ -3710,7 +3710,7 @@ void CBonusSelection::updateBonusSelection()
 
 void CBonusSelection::updateCampaignState()
 {
-	ourCampaign->currentMap = selectedMap;
+	ourCampaign->currentMap = boost::make_optional(selectedMap);
 	if (selectedBonus)
 		ourCampaign->chosenCampaignBonuses[selectedMap] = *selectedBonus;
 }
@@ -3777,7 +3777,7 @@ void CBonusSelection::selectBonus(int id)
 	// have to be undrawn/drawn.
 	if (!selectedBonus || *selectedBonus != id)
 	{
-		selectedBonus = id;
+		selectedBonus = boost::make_optional(id);
 		GH.totalRedraw();
 
 		updateStartButtonState(id);

--- a/client/NetPacksClient.cpp
+++ b/client/NetPacksClient.cpp
@@ -701,7 +701,7 @@ void BattleAttack::applyCl(CClient *cl)
 
 void StartAction::applyFirstCl(CClient *cl)
 {
-	cl->curbaction = ba;
+	cl->curbaction = boost::make_optional(ba);
 	BATTLE_INTERFACE_CALL_IF_PRESENT_FOR_BOTH_SIDES(actionStarted, ba);
 }
 

--- a/client/battle/CBattleInterfaceClasses.cpp
+++ b/client/battle/CBattleInterfaceClasses.cpp
@@ -350,7 +350,7 @@ CBattleResultWindow::CBattleResultWindow(const BattleResult &br, const SDL_Rect 
 	bg->colorize(owner.playerID);
 
 	exit = new CButton (Point(384, 505), "iok6432.def", std::make_pair("", ""), [&](){ bExitf();}, SDLK_RETURN);
-	exit->borderColor = Colors::METALLIC_GOLD;
+	exit->borderColor = boost::make_optional(Colors::METALLIC_GOLD);
 
 	if(br.winner==0) //attacker won
 	{

--- a/client/windows/CCastleInterface.cpp
+++ b/client/windows/CCastleInterface.cpp
@@ -1432,11 +1432,11 @@ CBuildWindow::CBuildWindow(const CGTownInstance *Town, const CBuilding * Buildin
 		std::string tooltipNo  = boost::str(boost::format(CGI->generaltexth->allTexts[596]) % building->Name());
 
 		CButton * buy = new CButton(Point(45, 446), "IBUY30", CButton::tooltip(tooltipYes), [&](){ buyFunc(); }, SDLK_RETURN);
-		buy->borderColor = Colors::METALLIC_GOLD;
+		buy->borderColor = boost::make_optional(Colors::METALLIC_GOLD);
 		buy->block(state!=7 || LOCPLINT->playerID != town->tempOwner);
 
 		CButton * cancel = new CButton(Point(290, 445), "ICANCEL", CButton::tooltip(tooltipNo), [&](){ close();}, SDLK_ESCAPE);
-		cancel->borderColor = Colors::METALLIC_GOLD;
+		cancel->borderColor = boost::make_optional(Colors::METALLIC_GOLD);
 	}
 }
 

--- a/client/windows/CCreatureWindow.cpp
+++ b/client/windows/CCreatureWindow.cpp
@@ -920,8 +920,8 @@ CStackWindow::CStackWindow(const CStackInstance * stack, std::function<void()> d
 	info->creature = stack->type;
 	info->creatureCount = stack->count;
 
-	info->upgradeInfo = StackWindowInfo::StackUpgradeInfo();
-	info->dismissInfo = StackWindowInfo::StackDismissInfo();
+	info->upgradeInfo = boost::make_optional(StackWindowInfo::StackUpgradeInfo());
+	info->dismissInfo = boost::make_optional(StackWindowInfo::StackDismissInfo());
 	info->upgradeInfo->info = upgradeInfo;
 	info->upgradeInfo->callback = callback;
 	info->dismissInfo->callback = dismiss;
@@ -950,7 +950,7 @@ CStackWindow::CStackWindow(const CCommanderInstance * commander, std::vector<ui3
 	info->creature = commander->type;
 	info->commander = commander;
 	info->creatureCount = 1;
-	info->levelupInfo = StackWindowInfo::CommanderLevelInfo();
+	info->levelupInfo = boost::make_optional(StackWindowInfo::CommanderLevelInfo());
 	info->levelupInfo->skills = skills;
 	info->levelupInfo->callback = callback;
 	info->owner = dynamic_cast<const CGHeroInstance *> (commander->armyObj);

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -1057,7 +1057,7 @@ CPuzzleWindow::CPuzzleWindow(const int3 &GrailPos, double discoveredRatio):
 
 	quitb = new CButton(Point(670, 538), "IOK6432.DEF", CButton::tooltip(CGI->generaltexth->allTexts[599]), std::bind(&CPuzzleWindow::close, this), SDLK_RETURN);
 	quitb->assignedKeys.insert(SDLK_ESCAPE);
-	quitb->borderColor = Colors::METALLIC_GOLD;
+	quitb->borderColor = boost::make_optional(Colors::METALLIC_GOLD);
 
 	new CPicture("PUZZLOGO", 607, 3);
 	new CLabel(700, 95, FONT_BIG, CENTER, Colors::YELLOW, CGI->generaltexth->allTexts[463]);

--- a/client/windows/InfoWindows.cpp
+++ b/client/windows/InfoWindows.cpp
@@ -126,7 +126,7 @@ CInfoWindow::CInfoWindow(std::string Text, PlayerColor player, const TCompsInfo 
 	for(auto & Button : Buttons)
 	{
 		CButton *button = new CButton(Point(0,0), Button.first, CButton::tooltip(), std::bind(&CInfoWindow::close,this));
-		button->borderColor = Colors::METALLIC_GOLD;
+		button->borderColor = boost::make_optional(Colors::METALLIC_GOLD);
 		button->addCallback(Button.second); //each button will close the window apart from call-defined actions
 		buttons.push_back(button);
 	}

--- a/lib/NetPacksLib.cpp
+++ b/lib/NetPacksLib.cpp
@@ -1146,7 +1146,8 @@ DLL_LINKAGE void NewTurn::applyGs(CGameState *gs)
 			{
 				if (playerState.daysWithoutCastle)
 					++(*playerState.daysWithoutCastle);
-				else playerState.daysWithoutCastle = 0;
+				else
+					playerState.daysWithoutCastle = boost::make_optional(0);
 			}
 			else
 			{

--- a/lib/battle/CBattleInfoEssentials.cpp
+++ b/lib/battle/CBattleInfoEssentials.cpp
@@ -34,7 +34,7 @@ std::vector<std::shared_ptr<const CObstacleInstance>> CBattleInfoEssentials::bat
 	if(!perspective)
 	{
 		//if no particular perspective request, use default one
-		perspective = battleGetMySide();
+		perspective = boost::make_optional(battleGetMySide());
 	}
 	else
 	{

--- a/lib/mapObjects/CGHeroInstance.cpp
+++ b/lib/mapObjects/CGHeroInstance.cpp
@@ -1441,12 +1441,12 @@ boost::optional<SecondarySkill> CGHeroInstance::nextSecondarySkill(CRandomGenera
 		if(learnedSecondarySkills.empty())
 		{
 			// there are only new skills to learn, so choose anyone of them
-			chosenSecondarySkill = *RandomGeneratorUtil::nextItem(proposedSecondarySkills, rand);
+			chosenSecondarySkill = boost::make_optional(*RandomGeneratorUtil::nextItem(proposedSecondarySkills, rand));
 		}
 		else
 		{
 			// preferably upgrade a already learned secondary skill
-			chosenSecondarySkill = *RandomGeneratorUtil::nextItem(learnedSecondarySkills, rand);
+			chosenSecondarySkill = boost::make_optional(*RandomGeneratorUtil::nextItem(learnedSecondarySkills, rand));
 		}
 	}
 	return chosenSecondarySkill;

--- a/lib/serializer/BinaryDeserializer.h
+++ b/lib/serializer/BinaryDeserializer.h
@@ -496,9 +496,10 @@ public:
 		load( present );
 		if(present)
 		{
+			//TODO: replace with emplace once we start request Boost 1.56+, see PR360
 			T t;
 			load(t);
-			data = std::move(t);
+			data = boost::make_optional(std::move(t));
 		}
 		else
 		{

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -579,7 +579,7 @@ void CGameHandler::endBattle(int3 tile, const CGHeroInstance *hero1, const CGHer
 	if (battleQuery != queries.topQuery(gs->curB->sides[0].color))
 		complain("Player " + boost::lexical_cast<std::string>(gs->curB->sides[0].color) + " although in battle has no battle query at the top!");
 
-	battleQuery->result = *battleResult.data;
+	battleQuery->result = boost::make_optional(*battleResult.data);
 
 	//Check how many battle queries were created (number of players blocked by battle)
 	const int queriedPlayers = battleQuery ? boost::count(queries.allQueries(), battleQuery) : 0;
@@ -2120,7 +2120,7 @@ bool CGameHandler::moveHero(ObjectInstanceID hid, int3 dst, ui8 teleporting, boo
 		}
 		else if (lookForGuards == CHECK_FOR_GUARDS && this->isInTheMap(guardPos))
 		{
-			tmh.attackedFrom = guardPos;
+			tmh.attackedFrom = boost::make_optional(guardPos);
 
 			const TerrainTile &guardTile = *gs->getTile(guardPos);
 			objectVisited(guardTile.visitableObjects.back(), h);


### PR DESCRIPTION
I certainly unsure this it the right way to fix this issue. Shortly in Boost 1.63 there is breaking change in Boost::optional supposedly related [to this fix](https://svn.boost.org/trac10/ticket/12652). So when VCMI compiled with Boost 1.64 and newer in MSVS 2015 following error occur:
```
D:\DEV\vcmi\lib\mapObjects\CGHeroInstance.cpp(1449): error C2593: 'operator =' is ambiguous [D:\DEV\vcmi2\lib\vcmi.vcxproj]
d:\dev\vcmi\lib\registertypes\../serializer/BinaryDeserializer.h(501): error C2593: 'operator =' is ambiguous [D:\DEV\vcmi2\lib\vcmi.vcxproj]
```
They're not limited to following case, but affect every single assignment to boost::optional in our code.

If anyone have idea for the better way handle this then it's would be great.