### PR TITLE
Fix CMake MSVS build problem

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,6 +132,7 @@ if(WIN32)
 
 	if(MSVC)
 		add_definitions(-DBOOST_ALL_NO_LIB)
+		add_definitions(-DBOOST_ALL_DYN_LINK)
 		set(Boost_USE_STATIC_LIBS OFF)
 
 		# Don't link with SDLMain

--- a/Global.h
+++ b/Global.h
@@ -154,7 +154,7 @@ static_assert(sizeof(bool) == 1, "Bool needs to be 1 byte in size.");
 #define BOOST_THREAD_DONT_PROVIDE_THREAD_DESTRUCTOR_CALLS_TERMINATE_IF_JOINABLE 1
 #define BOOST_BIND_NO_PLACEHOLDERS
 
-#if defined(_MSC_VER) && (_MSC_VER == 1900 || _MSC_VER == 1910)
+#if defined(_MSC_VER) && (_MSC_VER == 1900 || _MSC_VER == 1910 || _MSC_VER == 1911)
 #define BOOST_NO_CXX11_VARIADIC_TEMPLATES //Variadic templates are buggy in VS2015 and VS2017, so turn this off to avoid compile errors
 #endif
 


### PR DESCRIPTION
Same errors as here when building vcmi client and server: https://stackoverflow.com/questions/27196312/boost-1-57-0-program-options-msvs-2013-linker-error
Fix based on: https://groups.google.com/forum/#!topic/boost-list/Lhqvoet8N18