### PR TITLE
Dimension door movement points fix

### DIFF
--- a/lib/spells/AdventureSpellMechanics.cpp
+++ b/lib/spells/AdventureSpellMechanics.cpp
@@ -322,7 +322,10 @@ ESpellCastResult DimensionDoorMechanics::applyAdventureEffects(const SpellCastEn
 	{
 		SetMovePoints smp;
 		smp.hid = parameters.caster->id;
-		smp.val = std::max<ui32>(0, parameters.caster->movement - movementCost);
+		if(movementCost < parameters.caster->movement)
+			smp.val = parameters.caster->movement - movementCost;
+		else
+			smp.val = 0;
 		env->sendAndApply(&smp);
 	}
 	return ESpellCastResult::OK;


### PR DESCRIPTION
When hero with one move point make dimension doors then he can have on
graphics full move points. Caused by substraction that make unsigned
variable < 0.