### PR TITLE
RandGen change type

### DIFF
--- a/client/windows/QuickRecruitmentWindow.cpp
+++ b/client/windows/QuickRecruitmentWindow.cpp
@@ -73,7 +73,7 @@ void QuickRecruitmentWindow::initWindow(Rect startupPosition)
 		pos.x -= 55 * (creaturesAmount - 3);
 	}
 	backgroundTexture = std::make_shared<CFilledTexture>("DIBOXBCK.pcx", Rect(0, 0, pos.w, pos.h));
-	costBackground = std::make_shared<CPicture>("QuickRecruitmentWindow/costBackground.png", pos.w/2-113, pos.y+290);
+	costBackground = std::make_shared<CPicture>("QuickRecruitmentWindow/costBackground.png", pos.w/2-113, 335);
 }
 
 void QuickRecruitmentWindow::maxAllCards(std::vector<std::shared_ptr<CreaturePurchaseCard> > cards)


### PR DESCRIPTION
Since map created by editor can have dimensions 1024x1024, "seed" can go out for the
range. So this can give us after radical counting
srand(int3(1024,1024,0)); rand(); number like 60961129830000 when
int32_t can have maximum 2147483647. In that case we need use int64_t
whose maximal value is 9223372036854775807.