### PR TITLE
Hero specialty scaling

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -68,4 +68,4 @@ Piotr Wójcik aka Chocimier, <chocimier@tlen.pl>
    * Various bug fixes
 
 Henning Koehler, <henning.koehler.nz@gmail.com>
-   * skill modding
+   * skill modding, bonus updaters

--- a/ChangeLog
+++ b/ChangeLog
@@ -27,6 +27,7 @@ MODS:
 * Improve support for WoG commander artifacts and skill descriptions
 * Added basic support for secondary skill modding
 * Map object sounds can now be configured via json
+* Added bonus updaters for hero specialties
 
 SOUND:
 * Fixed many mising or wrong pickup and visit sounds for map objects

--- a/Global.h
+++ b/Global.h
@@ -376,8 +376,14 @@ namespace vstd
 		for(auto iter = map.cbegin(); iter != map.cend(); iter++)
 		{
 			if(iter->second == value)
+			{
+				if(found)
+					*found = true;
 				return iter->first;
+			}
 		}
+		if(found)
+			*found = false;
 		return Key();
 	}
 

--- a/Global.h
+++ b/Global.h
@@ -369,6 +369,18 @@ namespace vstd
 		return std::find(c.begin(),c.end(),i);
 	}
 
+	//returns first key that maps to given value if present, returns success via found if provided
+	template <typename Key, typename T>
+	Key findKey(const std::map<Key, T> & map, const T & value, bool * found = nullptr)
+	{
+		for(auto iter = map.cbegin(); iter != map.cend(); iter++)
+		{
+			if(iter->second == value)
+				return iter->first;
+		}
+		return Key();
+	}
+
 	//removes element i from container c, returns false if c does not contain i
 	template <typename Container, typename Item>
 	typename Container::size_type operator-=(Container &c, const Item &i)

--- a/config/heroes/castle.json
+++ b/config/heroes/castle.json
@@ -125,7 +125,7 @@
 					"subtype" : "skill.navigation",
 					"type" : "SECONDARY_SKILL_PREMY",
 					"updater" : {
-						"parameters" : [ 40 ],
+						"parameters" : [ 100 ],
 						"type" : "GROWS_WITH_LEVEL"
 					},
 					"valueType" : "PERCENT_TO_BASE"

--- a/config/heroes/castle.json
+++ b/config/heroes/castle.json
@@ -234,36 +234,7 @@
 			{ "skill" : "mysticism", "level": "basic" }
 		],
 		"specialty" : {
-			"base" : {
-				"limiters" : [
-					{
-						"parameters" : [ "monk", true ],
-						"type" : "CREATURE_TYPE_LIMITER"
-					}
-				]
-			},
-			"bonuses" : {
-				"attack" : {
-					"subtype" : "primSkill.attack",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 12, 5 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"defence" : {
-					"subtype" : "primSkill.defence",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 7, 5 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"speed" : {
-					"type" : "STACKS_SPEED",
-					"val" : 1
-				}
-			}
+			"creature" : "monk"
 		}
 	},
 	"sanya":

--- a/config/heroes/castle.json
+++ b/config/heroes/castle.json
@@ -176,6 +176,7 @@
 					"addInfo" : 0,
 					"subtype" : "spell.bless",
 					"type" : "SPECIAL_BLESS_DAMAGE",
+                    "updater" : "TIMES_HERO_LEVEL",
 					"val" : 3
 				}
 			}
@@ -217,6 +218,7 @@
 				"frostRing" : {
 					"subtype" : "spell.frostRing",
 					"type" : "SPECIAL_SPELL_LEV",
+                    "updater" : "TIMES_HERO_LEVEL",
 					"val" : 3
 				}
 			}

--- a/config/heroes/castle.json
+++ b/config/heroes/castle.json
@@ -17,7 +17,7 @@
 					"valueType" : "PERCENT_TO_BASE",
 					"updater" : {
 						"type" : "GROWS_WITH_LEVEL",
-						"parameters" : [100]
+						"parameters" : [ 100 ]
 					}
 				}
 			}
@@ -36,10 +36,7 @@
 		"specialty" : {
 			"base" : {
 				"limiter" : {
-					"parameters" : [
-						"archer",
-						true
-					],
+					"parameters" : [ "archer", true ],
 					"type" : "CREATURE_TYPE_LIMITER"
 				}
 			},
@@ -48,10 +45,7 @@
 					"subtype" : "primSkill.attack",
 					"type" : "PRIMARY_SKILL",
 					"updater" : {
-						"parameters" : [
-							6,
-							2
-						],
+						"parameters" : [ 6, 2 ],
 						"type" : "GROWS_WITH_LEVEL"
 					}
 				},
@@ -59,10 +53,7 @@
 					"subtype" : "primSkill.defence",
 					"type" : "PRIMARY_SKILL",
 					"updater" : {
-						"parameters" : [
-							3,
-							2
-						],
+						"parameters" : [ 3, 2 ],
 						"type" : "GROWS_WITH_LEVEL"
 					}
 				},

--- a/config/heroes/castle.json
+++ b/config/heroes/castle.json
@@ -31,9 +31,54 @@
 			{ "skill" : "leadership", "level": "basic" },
 			{ "skill" : "archery", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":1, "val": 0, "subtype": 0, "info": 2 }
+		"specialty" : [
+			{
+				"limiter" : {
+					"parameters" : [
+						"archer",
+						true
+					],
+					"type" : "CREATURE_TYPE_LIMITER"
+				},
+				"type" : "STACKS_SPEED",
+				"val" : 1
+			},
+			{
+				"limiter" : {
+					"parameters" : [
+						"archer",
+						true
+					],
+					"type" : "CREATURE_TYPE_LIMITER"
+				},
+				"subtype" : "attack",
+				"type" : "PRIMARY_SKILL",
+				"updater" : {
+					"parameters" : [
+						6,
+						2
+					],
+					"type" : "GROWS_WITH_LEVEL"
+				}
+			},
+			{
+				"limiter" : {
+					"parameters" : [
+						"archer",
+						true
+					],
+					"type" : "CREATURE_TYPE_LIMITER"
+				},
+				"subtype" : "defence",
+				"type" : "PRIMARY_SKILL",
+				"updater" : {
+					"parameters" : [
+						3,
+						2
+					],
+					"type" : "GROWS_WITH_LEVEL"
+				}
+			}
 		]
 	},
 	"edric":

--- a/config/heroes/castle.json
+++ b/config/heroes/castle.json
@@ -51,7 +51,7 @@
 					],
 					"type" : "CREATURE_TYPE_LIMITER"
 				},
-				"subtype" : "attack",
+				"subtype" : "primSkill.attack",
 				"type" : "PRIMARY_SKILL",
 				"updater" : {
 					"parameters" : [
@@ -69,7 +69,7 @@
 					],
 					"type" : "CREATURE_TYPE_LIMITER"
 				},
-				"subtype" : "defence",
+				"subtype" : "primSkill.defence",
 				"type" : "PRIMARY_SKILL",
 				"updater" : {
 					"parameters" : [

--- a/config/heroes/castle.json
+++ b/config/heroes/castle.json
@@ -122,10 +122,8 @@
 				"navigation" : {
 					"subtype" : "skill.navigation",
 					"type" : "SECONDARY_SKILL_PREMY",
-					"updater" : {
-						"parameters" : [ 100 ],
-						"type" : "GROWS_WITH_LEVEL"
-					},
+					"updater" : "TIMES_HERO_LEVEL",
+					"val" : 5,
 					"valueType" : "PERCENT_TO_BASE"
 				}
 			}
@@ -147,10 +145,8 @@
 				"estates" : {
 					"subtype" : "skill.estates",
 					"type" : "SECONDARY_SKILL_PREMY",
-					"updater" : {
-						"parameters" : [ 100 ],
-						"type" : "GROWS_WITH_LEVEL"
-					},
+					"updater" : "TIMES_HERO_LEVEL",
+					"val" : 5,
 					"valueType" : "PERCENT_TO_BASE"
 				}
 			}
@@ -301,10 +297,8 @@
 				"firstAid" : {
 					"subtype" : "skill.firstAid",
 					"type" : "SECONDARY_SKILL_PREMY",
-					"updater" : {
-						"parameters" : [ 100 ],
-						"type" : "GROWS_WITH_LEVEL"
-					},
+					"updater" : "TIMES_HERO_LEVEL",
+					"val" : 5,
 					"valueType" : "PERCENT_TO_BASE"
 				}
 			}
@@ -433,10 +427,8 @@
 				"eagleEye" : {
 					"subtype" : "skill.eagleEye",
 					"type" : "SECONDARY_SKILL_PREMY",
-					"updater" : {
-						"parameters" : [ 100 ],
-						"type" : "GROWS_WITH_LEVEL"
-					},
+					"updater" : "TIMES_HERO_LEVEL",
+					"val" : 5,
 					"valueType" : "PERCENT_TO_BASE"
 				}
 			}

--- a/config/heroes/castle.json
+++ b/config/heroes/castle.json
@@ -32,36 +32,7 @@
 			{ "skill" : "archery", "level": "basic" }
 		],
 		"specialty" : {
-			"base" : {
-				"limiters" : [
-					{
-						"parameters" : [ "archer", true ],
-						"type" : "CREATURE_TYPE_LIMITER"
-					}
-				]
-			},
-			"bonuses" : {
-				"attack" : {
-					"subtype" : "primSkill.attack",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 6, 2 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"defence" : {
-					"subtype" : "primSkill.defence",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 3, 2 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"speed" : {
-					"type" : "STACKS_SPEED",
-					"val" : 1
-				}
-			}
+			"creature" : "archer"
 		}
 	},
 	"edric":
@@ -134,36 +105,7 @@
 			{ "skill" : "offence", "level": "basic" }
 		],
 		"specialty" : {
-			"base" : {
-				"limiters" : [
-					{
-						"parameters" : [ "swordsman", true ],
-						"type" : "CREATURE_TYPE_LIMITER"
-					}
-				]
-			},
-			"bonuses" : {
-				"attack" : {
-					"subtype" : "primSkill.attack",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 10, 4 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"defence" : {
-					"subtype" : "primSkill.defence",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 12, 4 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"speed" : {
-					"type" : "STACKS_SPEED",
-					"val" : 1
-				}
-			}
+			"creature" : "swordsman"
 		}
 	},
 	"christian":
@@ -177,36 +119,7 @@
 			{ "skill" : "artillery", "level": "basic" }
 		],
 		"specialty" : {
-			"base" : {
-				"limiters" : [
-					{
-						"parameters" : [ "ballista", true ],
-						"type" : "CREATURE_TYPE_LIMITER"
-					}
-				]
-			},
-			"bonuses" : {
-				"attack" : {
-					"subtype" : "primSkill.attack",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 10, 5 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"defence" : {
-					"subtype" : "primSkill.defence",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 10, 5 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"speed" : {
-					"type" : "STACKS_SPEED",
-					"val" : 1
-				}
-			}
+			"creature" : "ballista"
 		}
 	},
 	"tyris":
@@ -220,36 +133,7 @@
 			{ "skill" : "tactics", "level": "basic" }
 		],
 		"specialty" : {
-			"base" : {
-				"limiters" : [
-					{
-						"parameters" : [ "cavalier", true ],
-						"type" : "CREATURE_TYPE_LIMITER"
-					}
-				]
-			},
-			"bonuses" : {
-				"attack" : {
-					"subtype" : "primSkill.attack",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 15, 6 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"defence" : {
-					"subtype" : "primSkill.defence",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 15, 6 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"speed" : {
-					"type" : "STACKS_SPEED",
-					"val" : 1
-				}
-			}
+			"creature" : "cavalier"
 		}
 	},
 	"rion":

--- a/config/heroes/castle.json
+++ b/config/heroes/castle.json
@@ -14,10 +14,8 @@
 				"archery" : {
 					"subtype" : "skill.archery",
 					"type" : "SECONDARY_SKILL_PREMY",
-					"updater" : {
-						"parameters" : [ 100 ],
-						"type" : "GROWS_WITH_LEVEL"
-					},
+					"updater" : "TIMES_HERO_LEVEL",
+					"val" : 5,
 					"valueType" : "PERCENT_TO_BASE"
 				}
 			}

--- a/config/heroes/castle.json
+++ b/config/heroes/castle.json
@@ -9,17 +9,19 @@
 			{ "skill" : "leadership", "level": "basic" },
 			{ "skill" : "archery", "level": "basic" }
 		],
-		"specialty" : [
-			{
-				"type" : "SECONDARY_SKILL_PREMY",
-				"subtype" : "skill.archery",
-				"valueType" : "PERCENT_TO_BASE",
-				"updater" : {
-					"type" : "GROWS_WITH_LEVEL",
-					"parameters" : [100]
+		"specialty" : {
+			"bonuses" : {
+				"archery" : {
+					"type" : "SECONDARY_SKILL_PREMY",
+					"subtype" : "skill.archery",
+					"valueType" : "PERCENT_TO_BASE",
+					"updater" : {
+						"type" : "GROWS_WITH_LEVEL",
+						"parameters" : [100]
+					}
 				}
 			}
-		]
+		}
 	},
 	"valeska":
 	{
@@ -31,55 +33,45 @@
 			{ "skill" : "leadership", "level": "basic" },
 			{ "skill" : "archery", "level": "basic" }
 		],
-		"specialty" : [
-			{
+		"specialty" : {
+			"base" : {
 				"limiter" : {
 					"parameters" : [
 						"archer",
 						true
 					],
 					"type" : "CREATURE_TYPE_LIMITER"
-				},
-				"type" : "STACKS_SPEED",
-				"val" : 1
-			},
-			{
-				"limiter" : {
-					"parameters" : [
-						"archer",
-						true
-					],
-					"type" : "CREATURE_TYPE_LIMITER"
-				},
-				"subtype" : "primSkill.attack",
-				"type" : "PRIMARY_SKILL",
-				"updater" : {
-					"parameters" : [
-						6,
-						2
-					],
-					"type" : "GROWS_WITH_LEVEL"
 				}
 			},
-			{
-				"limiter" : {
-					"parameters" : [
-						"archer",
-						true
-					],
-					"type" : "CREATURE_TYPE_LIMITER"
+			"bonuses" : {
+				"attack" : {
+					"subtype" : "primSkill.attack",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [
+							6,
+							2
+						],
+						"type" : "GROWS_WITH_LEVEL"
+					}
 				},
-				"subtype" : "primSkill.defence",
-				"type" : "PRIMARY_SKILL",
-				"updater" : {
-					"parameters" : [
-						3,
-						2
-					],
-					"type" : "GROWS_WITH_LEVEL"
+				"defence" : {
+					"subtype" : "primSkill.defence",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [
+							3,
+							2
+						],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"speed" : {
+					"type" : "STACKS_SPEED",
+					"val" : 1
 				}
 			}
-		]
+		}
 	},
 	"edric":
 	{

--- a/config/heroes/castle.json
+++ b/config/heroes/castle.json
@@ -35,10 +35,12 @@
 		],
 		"specialty" : {
 			"base" : {
-				"limiter" : {
-					"parameters" : [ "archer", true ],
-					"type" : "CREATURE_TYPE_LIMITER"
-				}
+				"limiters" : [
+					{
+						"parameters" : [ "archer", true ],
+						"type" : "CREATURE_TYPE_LIMITER"
+					}
+				]
 			},
 			"bonuses" : {
 				"attack" : {

--- a/config/heroes/castle.json
+++ b/config/heroes/castle.json
@@ -75,36 +75,7 @@
 			{ "skill" : "armorer", "level": "basic" }
 		],
 		"specialty" : {
-			"base" : {
-				"limiters" : [
-					{
-						"parameters" : [ "griffin", true ],
-						"type" : "CREATURE_TYPE_LIMITER"
-					}
-				]
-			},
-			"bonuses" : {
-				"attack" : {
-					"subtype" : "primSkill.attack",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 8, 3 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"defence" : {
-					"subtype" : "primSkill.defence",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 8, 3 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"speed" : {
-					"type" : "STACKS_SPEED",
-					"val" : 1
-				}
-			}
+			"creature" : "griffin"
 		}
 	},
 	"sylvia":

--- a/config/heroes/castle.json
+++ b/config/heroes/castle.json
@@ -9,9 +9,16 @@
 			{ "skill" : "leadership", "level": "basic" },
 			{ "skill" : "archery", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":2, "val": 5, "subtype": 1, "info": 0 }
+		"specialty" : [
+			{
+				"type" : "SECONDARY_SKILL_PREMY",
+				"subtype" : "skill.archery",
+				"valueType" : "PERCENT_TO_BASE",
+				"updater" : {
+					"type" : "GROWS_WITH_LEVEL",
+					"parameters" : [100]
+				}
+			}
 		]
 	},
 	"valeska":

--- a/config/heroes/castle.json
+++ b/config/heroes/castle.json
@@ -12,13 +12,13 @@
 		"specialty" : {
 			"bonuses" : {
 				"archery" : {
-					"type" : "SECONDARY_SKILL_PREMY",
 					"subtype" : "skill.archery",
-					"valueType" : "PERCENT_TO_BASE",
+					"type" : "SECONDARY_SKILL_PREMY",
 					"updater" : {
-						"type" : "GROWS_WITH_LEVEL",
-						"parameters" : [ 100 ]
-					}
+						"parameters" : [ 100 ],
+						"type" : "GROWS_WITH_LEVEL"
+					},
+					"valueType" : "PERCENT_TO_BASE"
 				}
 			}
 		}
@@ -76,10 +76,38 @@
 			{ "skill" : "leadership", "level": "basic" },
 			{ "skill" : "armorer", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":1, "val": 0, "subtype": 0, "info": 4 }
-		]
+		"specialty" : {
+			"base" : {
+				"limiters" : [
+					{
+						"parameters" : [ "griffin", true ],
+						"type" : "CREATURE_TYPE_LIMITER"
+					}
+				]
+			},
+			"bonuses" : {
+				"attack" : {
+					"subtype" : "primSkill.attack",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 8, 3 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"defence" : {
+					"subtype" : "primSkill.defence",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 8, 3 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"speed" : {
+					"type" : "STACKS_SPEED",
+					"val" : 1
+				}
+			}
+		}
 	},
 	"sylvia":
 	{
@@ -91,10 +119,19 @@
 			{ "skill" : "leadership", "level": "basic" },
 			{ "skill" : "navigation", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":2, "val": 2, "subtype": 5, "info": 1 }
-		]
+		"specialty" : {
+			"bonuses" : {
+				"navigation" : {
+					"subtype" : "skill.navigation",
+					"type" : "SECONDARY_SKILL_PREMY",
+					"updater" : {
+						"parameters" : [ 40 ],
+						"type" : "GROWS_WITH_LEVEL"
+					},
+					"valueType" : "PERCENT_TO_BASE"
+				}
+			}
+		}
 	},
 	"lordHaart":
 	{
@@ -107,10 +144,19 @@
 			{ "skill" : "leadership", "level": "basic" },
 			{ "skill" : "estates", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":2, "val": 5, "subtype": 13, "info": 0 }
-		]
+		"specialty" : {
+			"bonuses" : {
+				"estates" : {
+					"subtype" : "skill.estates",
+					"type" : "SECONDARY_SKILL_PREMY",
+					"updater" : {
+						"parameters" : [ 100 ],
+						"type" : "GROWS_WITH_LEVEL"
+					},
+					"valueType" : "PERCENT_TO_BASE"
+				}
+			}
+		}
 	},
 	"sorsha":
 	{
@@ -122,10 +168,38 @@
 			{ "skill" : "leadership", "level": "basic" },
 			{ "skill" : "offence", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":1, "val": 0, "subtype": 0, "info": 6 }
-		]
+		"specialty" : {
+			"base" : {
+				"limiters" : [
+					{
+						"parameters" : [ "swordsman", true ],
+						"type" : "CREATURE_TYPE_LIMITER"
+					}
+				]
+			},
+			"bonuses" : {
+				"attack" : {
+					"subtype" : "primSkill.attack",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 10, 4 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"defence" : {
+					"subtype" : "primSkill.defence",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 12, 4 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"speed" : {
+					"type" : "STACKS_SPEED",
+					"val" : 1
+				}
+			}
+		}
 	},
 	"christian":
 	{
@@ -137,10 +211,38 @@
 			{ "skill" : "leadership", "level": "basic" },
 			{ "skill" : "artillery", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":1, "val": 0, "subtype": 0, "info": 146 }
-		]
+		"specialty" : {
+			"base" : {
+				"limiters" : [
+					{
+						"parameters" : [ "ballista", true ],
+						"type" : "CREATURE_TYPE_LIMITER"
+					}
+				]
+			},
+			"bonuses" : {
+				"attack" : {
+					"subtype" : "primSkill.attack",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 10, 5 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"defence" : {
+					"subtype" : "primSkill.defence",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 10, 5 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"speed" : {
+					"type" : "STACKS_SPEED",
+					"val" : 1
+				}
+			}
+		}
 	},
 	"tyris":
 	{
@@ -152,10 +254,38 @@
 			{ "skill" : "leadership", "level": "basic" },
 			{ "skill" : "tactics", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":1, "val": 0, "subtype": 0, "info": 10 }
-		]
+		"specialty" : {
+			"base" : {
+				"limiters" : [
+					{
+						"parameters" : [ "cavalier", true ],
+						"type" : "CREATURE_TYPE_LIMITER"
+					}
+				]
+			},
+			"bonuses" : {
+				"attack" : {
+					"subtype" : "primSkill.attack",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 15, 6 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"defence" : {
+					"subtype" : "primSkill.defence",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 15, 6 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"speed" : {
+					"type" : "STACKS_SPEED",
+					"val" : 1
+				}
+			}
+		}
 	},
 	"rion":
 	{
@@ -168,10 +298,19 @@
 			{ "skill" : "wisdom", "level": "basic" },
 			{ "skill" : "firstAid", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":2, "val": 5, "subtype": 27, "info": 0 }
-		]
+		"specialty" : {
+			"bonuses" : {
+				"firstAid" : {
+					"subtype" : "skill.firstAid",
+					"type" : "SECONDARY_SKILL_PREMY",
+					"updater" : {
+						"parameters" : [ 100 ],
+						"type" : "GROWS_WITH_LEVEL"
+					},
+					"valueType" : "PERCENT_TO_BASE"
+				}
+			}
+		}
 	},
 	"adela":
 	{
@@ -184,10 +323,16 @@
 			{ "skill" : "wisdom", "level": "basic" },
 			{ "skill" : "diplomacy", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":6, "val": 3, "subtype": 41, "info": 0 }
-		]
+		"specialty" : {
+			"bonuses" : {
+				"bless" : {
+					"addInfo" : 0,
+					"subtype" : "spell.bless",
+					"type" : "SPECIAL_BLESS_DAMAGE",
+					"val" : 3
+				}
+			}
+		}
 	},
 	"cuthbert":
 	{
@@ -200,10 +345,15 @@
 			{ "skill" : "wisdom", "level": "basic" },
 			{ "skill" : "estates", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":8, "val": 0, "subtype": 45, "info": 0 }
-		]
+		"specialty" : {
+			"bonuses" : {
+				"weakness" : {
+					"addInfo" : 0,
+					"subtype" : "spell.weakness",
+					"type" : "SPECIAL_PECULIAR_ENCHANT"
+				}
+			}
+		}
 	},
 	"adelaide":
 	{
@@ -215,10 +365,15 @@
 		[
 			{ "skill" : "wisdom", "level": "advanced" }
 		],
-		"specialties":
-		[
-			{ "type":3, "val": 3, "subtype": 20, "info": 0 }
-		]
+		"specialty" : {
+			"bonuses" : {
+				"frostRing" : {
+					"subtype" : "spell.frostRing",
+					"type" : "SPECIAL_SPELL_LEV",
+					"val" : 3
+				}
+			}
+		}
 	},
 	"ingham":
 	{
@@ -231,10 +386,38 @@
 			{ "skill" : "wisdom", "level": "basic" },
 			{ "skill" : "mysticism", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":1, "val": 0, "subtype": 0, "info": 8 }
-		]
+		"specialty" : {
+			"base" : {
+				"limiters" : [
+					{
+						"parameters" : [ "monk", true ],
+						"type" : "CREATURE_TYPE_LIMITER"
+					}
+				]
+			},
+			"bonuses" : {
+				"attack" : {
+					"subtype" : "primSkill.attack",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 12, 5 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"defence" : {
+					"subtype" : "primSkill.defence",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 7, 5 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"speed" : {
+					"type" : "STACKS_SPEED",
+					"val" : 1
+				}
+			}
+		}
 	},
 	"sanya":
 	{
@@ -247,10 +430,19 @@
 			{ "skill" : "wisdom", "level": "basic" },
 			{ "skill" : "eagleEye", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":2, "val": 5, "subtype": 11, "info": 0 }
-		]
+		"specialty" : {
+			"bonuses" : {
+				"eagleEye" : {
+					"subtype" : "skill.eagleEye",
+					"type" : "SECONDARY_SKILL_PREMY",
+					"updater" : {
+						"parameters" : [ 100 ],
+						"type" : "GROWS_WITH_LEVEL"
+					},
+					"valueType" : "PERCENT_TO_BASE"
+				}
+			}
+		}
 	},
 	"loynis":
 	{
@@ -263,10 +455,15 @@
 			{ "skill" : "wisdom", "level": "basic" },
 			{ "skill" : "learning", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":8, "val": 0, "subtype": 48, "info": 0 }
-		]
+		"specialty" : {
+			"bonuses" : {
+				"prayer" : {
+					"addInfo" : 0,
+					"subtype" : "spell.prayer",
+					"type" : "SPECIAL_PECULIAR_ENCHANT"
+				}
+			}
+		}
 	},
 	"caitlin":
 	{
@@ -279,9 +476,14 @@
 			{ "skill" : "wisdom", "level": "basic" },
 			{ "skill" : "intelligence", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":10, "val": 350, "subtype": 6, "info": 0 }
-		]
+		"specialty" : {
+			"bonuses" : {
+				"gold" : {
+					"subtype" : "resource.gold",
+					"type" : "GENERATE_RESOURCE",
+					"val" : 350
+				}
+			}
+		}
 	}
 }

--- a/config/heroes/castle.json
+++ b/config/heroes/castle.json
@@ -176,7 +176,7 @@
 					"addInfo" : 0,
 					"subtype" : "spell.bless",
 					"type" : "SPECIAL_BLESS_DAMAGE",
-                    "updater" : "TIMES_HERO_LEVEL",
+					"updater" : "TIMES_HERO_LEVEL",
 					"val" : 3
 				}
 			}
@@ -218,7 +218,7 @@
 				"frostRing" : {
 					"subtype" : "spell.frostRing",
 					"type" : "SPECIAL_SPELL_LEV",
-                    "updater" : "TIMES_HERO_LEVEL",
+					"updater" : "TIMES_HERO_LEVEL",
 					"val" : 3
 				}
 			}

--- a/config/heroes/conflux.json
+++ b/config/heroes/conflux.json
@@ -93,8 +93,8 @@
 					"type" : "PRIMARY_SKILL",
 					"val" : 1
 				},
-				"attack2" : {
-					"subtype" : "primSkill.attack",
+				"defence" : {
+					"subtype" : "primSkill.defence",
 					"type" : "PRIMARY_SKILL",
 					"val" : 2
 				}

--- a/config/heroes/conflux.json
+++ b/config/heroes/conflux.json
@@ -9,11 +9,22 @@
 			{ "skill" : "artillery", "level": "basic" },
 			{ "skill" : "offence", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":4, "val": 3, "subtype": 1, "info": 120 },
-			{ "type":4, "val": 3, "subtype": 2, "info": 120 }
-		]
+		"specialty" : {
+			"base" : {
+				"limiters" : [
+					{
+						"parameters" : [ "psychicElemental", true ],
+						"type" : "CREATURE_TYPE_LIMITER"
+					}
+				],
+				"type" : "PRIMARY_SKILL",
+				"val" : 3
+			},
+			"bonuses" : {
+				"attack" : { "subtype" : "primSkill.attack" },
+				"defence" : { "subtype" : "primSkill.defence" }
+			}
+		}
 	},
 	"thunar":
 	{
@@ -25,12 +36,32 @@
 			{ "skill" : "estates", "level": "basic" },
 			{ "skill" : "tactics", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":4, "val": 2, "subtype": 1, "info": 113 },
-			{ "type":4, "val": 1, "subtype": 2, "info": 113 },
-			{ "type":4, "val": 5, "subtype": 4, "info": 113 }
-		]
+		"specialty" : {
+			"base" : {
+				"limiters" : [
+					{
+						"parameters" : [ "earthElemental", true ],
+						"type" : "CREATURE_TYPE_LIMITER"
+					}
+				]
+			},
+			"bonuses" : {
+				"health" : {
+					"type" : "STACK_HEALTH",
+					"val" : 5
+				},
+				"attack" : {
+					"subtype" : "primSkill.attack",
+					"type" : "PRIMARY_SKILL",
+					"val" : 2
+				},
+				"defence" : {
+					"subtype" : "primSkill.defence",
+					"type" : "PRIMARY_SKILL",
+					"val" : 1
+				}
+			}
+		}
 	},
 	"ignissa":
 	{
@@ -42,12 +73,33 @@
 			{ "skill" : "artillery", "level": "basic" },
 			{ "skill" : "offence", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":4, "val": 1, "subtype": 1, "info": 114 },
-			{ "type":4, "val": 2, "subtype": 1, "info": 114 },
-			{ "type":4, "val": 2, "subtype": 3, "info": 114 }
-		]
+		"specialty" : {
+			"base" : {
+				"limiters" : [
+					{
+						"parameters" : [ "fireElemental", true ],
+						"type" : "CREATURE_TYPE_LIMITER"
+					}
+				]
+			},
+			"bonuses" : {
+				"damage" : {
+					"subtype" : 0,
+					"type" : "CREATURE_DAMAGE",
+					"val" : 2
+				},
+				"attack" : {
+					"subtype" : "primSkill.attack",
+					"type" : "PRIMARY_SKILL",
+					"val" : 1
+				},
+				"attack2" : {
+					"subtype" : "primSkill.attack",
+					"type" : "PRIMARY_SKILL",
+					"val" : 2
+				}
+			}
+		}
 	},
 	"lacus":
 	{
@@ -58,10 +110,21 @@
 		[
 			{ "skill" : "tactics", "level": "advanced" }
 		],
-		"specialties":
-		[
-			{ "type":4, "val": 2, "subtype": 1, "info": 115 }
-		]
+		"specialty" : {
+			"bonuses" : {
+				"attack" : {
+					"limiters" : [
+						{
+							"parameters" : [ "waterElemental", true ],
+							"type" : "CREATURE_TYPE_LIMITER"
+						}
+					],
+					"subtype" : "primSkill.attack",
+					"type" : "PRIMARY_SKILL",
+					"val" : 2
+				}
+			}
+		}
 	},
 	"monere":
 	{
@@ -73,11 +136,22 @@
 			{ "skill" : "logistics", "level": "basic" },
 			{ "skill" : "offence", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":4, "val": 3, "subtype": 1, "info": 120 },
-			{ "type":4, "val": 3, "subtype": 2, "info": 120 }
-		]
+		"specialty" : {
+			"base" : {
+				"limiters" : [
+					{
+						"parameters" : [ "psychicElemental", true ],
+						"type" : "CREATURE_TYPE_LIMITER"
+					}
+				],
+				"type" : "PRIMARY_SKILL",
+				"val" : 3
+			},
+			"bonuses" : {
+				"attack" : { "subtype" : "primSkill.attack" },
+				"defence" : { "subtype" : "primSkill.defence" }
+			}
+		}
 	},
 	"erdamon":
 	{
@@ -89,12 +163,32 @@
 			{ "skill" : "estates", "level": "basic" },
 			{ "skill" : "tactics", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":4, "val": 2, "subtype": 1, "info": 113 },
-			{ "type":4, "val": 1, "subtype": 2, "info": 113 },
-			{ "type":4, "val": 5, "subtype": 4, "info": 113 }
-		]
+		"specialty" : {
+			"base" : {
+				"limiters" : [
+					{
+						"parameters" : [ "earthElemental", true ],
+						"type" : "CREATURE_TYPE_LIMITER"
+					}
+				]
+			},
+			"bonuses" : {
+				"health" : {
+					"type" : "STACK_HEALTH",
+					"val" : 5
+				},
+				"attack" : {
+					"subtype" : "primSkill.attack",
+					"type" : "PRIMARY_SKILL",
+					"val" : 2
+				},
+				"defence" : {
+					"subtype" : "primSkill.defence",
+					"type" : "PRIMARY_SKILL",
+					"val" : 1
+				}
+			}
+		}
 	},
 	"fiur":
 	{
@@ -105,12 +199,33 @@
 		[
 			{ "skill" : "offence", "level": "advanced" }
 		],
-		"specialties":
-		[
-			{ "type":4, "val": 1, "subtype": 1, "info": 114 },
-			{ "type":4, "val": 2, "subtype": 1, "info": 114 },
-			{ "type":4, "val": 2, "subtype": 3, "info": 114 }
-		]
+		"specialty" : {
+			"base" : {
+				"limiters" : [
+					{
+						"parameters" : [ "fireElemental", true ],
+						"type" : "CREATURE_TYPE_LIMITER"
+					}
+				]
+			},
+			"bonuses" : {
+				"damage" : {
+					"subtype" : 0,
+					"type" : "CREATURE_DAMAGE",
+					"val" : 2
+				},
+				"attack" : {
+					"subtype" : "primSkill.attack",
+					"type" : "PRIMARY_SKILL",
+					"val" : 1
+				},
+				"attack2" : {
+					"subtype" : "primSkill.attack",
+					"type" : "PRIMARY_SKILL",
+					"val" : 2
+				}
+			}
+		}
 	},
 	"kalt":
 	{
@@ -122,10 +237,21 @@
 			{ "skill" : "tactics", "level": "basic" },
 			{ "skill" : "learning", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":4, "val": 2, "subtype": 1, "info": 115 }
-		]
+		"specialty" : {
+			"bonuses" : {
+				"attack" : {
+					"limiters" : [
+						{
+							"parameters" : [ "waterElemental", true ],
+							"type" : "CREATURE_TYPE_LIMITER"
+						}
+					],
+					"subtype" : "primSkill.attack",
+					"type" : "PRIMARY_SKILL",
+					"val" : 2
+				}
+			}
+		}
 	},
 	"luna":
 	{
@@ -138,10 +264,16 @@
 			{ "skill" : "wisdom", "level": "basic" },
 			{ "skill" : "fireMagic", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":5, "val": 100, "subtype": 13, "info": 0 }
-		]
+		"specialty" : {
+			"bonuses" : {
+				"fireWall" : {
+					"subtype" : "spell.fireWall",
+					"type" : "SPECIFIC_SPELL_DAMAGE",
+					"val" : 100,
+					"valueType" : "BASE_NUMBER"
+				}
+			}
+		}
 	},
 	"brissa":
 	{
@@ -154,10 +286,15 @@
 			{ "skill" : "wisdom", "level": "basic" },
 			{ "skill" : "airMagic", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":8, "val": 0, "subtype": 53, "info": 0 }
-		]
+		"specialty" : {
+			"bonuses" : {
+				"haste" : {
+					"addInfo" : 0,
+					"subtype" : "spell.haste",
+					"type" : "SPECIAL_PECULIAR_ENCHANT"
+				}
+			}
+		}
 	},
 	"ciele":
 	{
@@ -170,10 +307,16 @@
 			{ "skill" : "wisdom", "level": "basic" },
 			{ "skill" : "waterMagic", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":5, "val": 50, "subtype": 15, "info": 0 }
-		]
+		"specialty" : {
+			"bonuses" : {
+				"magicArrow" : {
+					"subtype" : "spell.magicArrow",
+					"type" : "SPECIFIC_SPELL_DAMAGE",
+					"val" : 50,
+					"valueType" : "BASE_NUMBER"
+				}
+			}
+		}
 	},
 	"labetha":
 	{
@@ -186,10 +329,15 @@
 			{ "skill" : "wisdom", "level": "basic" },
 			{ "skill" : "earthMagic", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":8, "val": 0, "subtype": 46, "info": 0 }
-		]
+		"specialty" : {
+			"bonuses" : {
+				"stoneSkin" : {
+					"addInfo" : 0,
+					"subtype" : "spell.stoneSkin",
+					"type" : "SPECIAL_PECULIAR_ENCHANT"
+				}
+			}
+		}
 	},
 	"inteus":
 	{
@@ -202,10 +350,15 @@
 			{ "skill" : "wisdom", "level": "basic" },
 			{ "skill" : "fireMagic", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":8, "val": 0, "subtype": 43, "info": 0 }
-		]
+		"specialty" : {
+			"bonuses" : {
+				"bloodlust" : {
+					"addInfo" : 0,
+					"subtype" : "spell.bloodlust",
+					"type" : "SPECIAL_PECULIAR_ENCHANT"
+				}
+			}
+		}
 	},
 	"aenain":
 	{
@@ -218,10 +371,15 @@
 			{ "skill" : "wisdom", "level": "basic" },
 			{ "skill" : "airMagic", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":8, "val": 0, "subtype": 47, "info": 0 }
-		]
+		"specialty" : {
+			"bonuses" : {
+				"disruptingRay" : {
+					"addInfo" : 0,
+					"subtype" : "spell.disruptingRay",
+					"type" : "SPECIAL_PECULIAR_ENCHANT"
+				}
+			}
+		}
 	},
 	"gelare":
 	{
@@ -234,10 +392,15 @@
 			{ "skill" : "wisdom", "level": "basic" },
 			{ "skill" : "waterMagic", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":10, "val": 350, "subtype": 6, "info": 0 }
-		]
+		"specialty" : {
+			"bonuses" : {
+				"gold" : {
+					"subtype" : "resource.gold",
+					"type" : "GENERATE_RESOURCE",
+					"val" : 350
+				}
+			}
+		}
 	},
 	"grindan":
 	{
@@ -250,9 +413,14 @@
 			{ "skill" : "wisdom", "level": "basic" },
 			{ "skill" : "earthMagic", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":10, "val": 350, "subtype": 6, "info": 0 }
-		]
+		"specialty" : {
+			"bonuses" : {
+				"gold" : {
+					"subtype" : "resource.gold",
+					"type" : "GENERATE_RESOURCE",
+					"val" : 350
+				}
+			}
+		}
 	}
 }

--- a/config/heroes/conflux.json
+++ b/config/heroes/conflux.json
@@ -219,8 +219,8 @@
 					"type" : "PRIMARY_SKILL",
 					"val" : 1
 				},
-				"attack2" : {
-					"subtype" : "primSkill.attack",
+				"defence" : {
+					"subtype" : "primSkill.defence",
 					"type" : "PRIMARY_SKILL",
 					"val" : 2
 				}

--- a/config/heroes/dungeon.json
+++ b/config/heroes/dungeon.json
@@ -140,6 +140,7 @@
 				"resurrection" : {
 					"subtype" : "spell.resurrection",
 					"type" : "SPECIAL_SPELL_LEV",
+                    "updater" : "TIMES_HERO_LEVEL",
 					"val" : 3
 				}
 			}
@@ -206,6 +207,7 @@
 				"resurrection" : {
 					"subtype" : "spell.resurrection",
 					"type" : "SPECIAL_SPELL_LEV",
+                    "updater" : "TIMES_HERO_LEVEL",
 					"val" : 3
 				}
 			}
@@ -250,6 +252,7 @@
 				"meteorShower" : {
 					"subtype" : "spell.meteorShower",
 					"type" : "SPECIAL_SPELL_LEV",
+                    "updater" : "TIMES_HERO_LEVEL",
 					"val" : 3
 				}
 			}

--- a/config/heroes/dungeon.json
+++ b/config/heroes/dungeon.json
@@ -10,36 +10,7 @@
 			{ "skill" : "leadership", "level": "basic" }
 		],
 		"specialty" : {
-			"base" : {
-				"limiters" : [
-					{
-						"parameters" : [ "harpy", true ],
-						"type" : "CREATURE_TYPE_LIMITER"
-					}
-				]
-			},
-			"bonuses" : {
-				"attack" : {
-					"subtype" : "primSkill.attack",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 6, 2 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"defence" : {
-					"subtype" : "primSkill.defence",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 5, 2 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"speed" : {
-					"type" : "STACKS_SPEED",
-					"val" : 1
-				}
-			}
+			"creature" : "harpy"
 		}
 	},
 	"arlach":
@@ -53,36 +24,7 @@
 			{ "skill" : "offence", "level": "basic" }
 		],
 		"specialty" : {
-			"base" : {
-				"limiters" : [
-					{
-						"parameters" : [ "ballista", true ],
-						"type" : "CREATURE_TYPE_LIMITER"
-					}
-				]
-			},
-			"bonuses" : {
-				"attack" : {
-					"subtype" : "primSkill.attack",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 10, 5 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"defence" : {
-					"subtype" : "primSkill.defence",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 10, 5 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"speed" : {
-					"type" : "STACKS_SPEED",
-					"val" : 1
-				}
-			}
+			"creature" : "ballista"
 		}
 	},
 	"dace":
@@ -96,36 +38,7 @@
 			{ "skill" : "offence", "level": "basic" }
 		],
 		"specialty" : {
-			"base" : {
-				"limiters" : [
-					{
-						"parameters" : [ "minotaur", true ],
-						"type" : "CREATURE_TYPE_LIMITER"
-					}
-				]
-			},
-			"bonuses" : {
-				"attack" : {
-					"subtype" : "primSkill.attack",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 14, 5 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"defence" : {
-					"subtype" : "primSkill.defence",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 12, 5 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"speed" : {
-					"type" : "STACKS_SPEED",
-					"val" : 1
-				}
-			}
+			"creature" : "minotaur"
 		}
 	},
 	"ajit":
@@ -139,36 +52,7 @@
 			{ "skill" : "resistance", "level": "basic" }
 		],
 		"specialty" : {
-			"base" : {
-				"limiters" : [
-					{
-						"parameters" : [ "beholder", true ],
-						"type" : "CREATURE_TYPE_LIMITER"
-					}
-				]
-			},
-			"bonuses" : {
-				"attack" : {
-					"subtype" : "primSkill.attack",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 9, 3 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"defence" : {
-					"subtype" : "primSkill.defence",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 7, 3 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"speed" : {
-					"type" : "STACKS_SPEED",
-					"val" : 1
-				}
-			}
+			"creature" : "beholder"
 		}
 	},
 	"damacon":
@@ -223,36 +107,7 @@
 			{ "skill" : "scholar", "level": "basic" }
 		],
 		"specialty" : {
-			"base" : {
-				"limiters" : [
-					{
-						"parameters" : [ "manticore", true ],
-						"type" : "CREATURE_TYPE_LIMITER"
-					}
-				]
-			},
-			"bonuses" : {
-				"attack" : {
-					"subtype" : "primSkill.attack",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 15, 6 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"defence" : {
-					"subtype" : "primSkill.defence",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 13, 6 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"speed" : {
-					"type" : "STACKS_SPEED",
-					"val" : 1
-				}
-			}
+			"creature" : "manticore"
 		}
 	},
 	"shakti":
@@ -266,36 +121,7 @@
 			{ "skill" : "offence", "level": "basic" }
 		],
 		"specialty" : {
-			"base" : {
-				"limiters" : [
-					{
-						"parameters" : [ "troglodyte", true ],
-						"type" : "CREATURE_TYPE_LIMITER"
-					}
-				]
-			},
-			"bonuses" : {
-				"attack" : {
-					"subtype" : "primSkill.attack",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 4 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"defence" : {
-					"subtype" : "primSkill.defence",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 3 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"speed" : {
-					"type" : "STACKS_SPEED",
-					"val" : 1
-				}
-			}
+			"creature" : "troglodyte"
 		}
 	},
 	"alamar":

--- a/config/heroes/dungeon.json
+++ b/config/heroes/dungeon.json
@@ -140,7 +140,7 @@
 				"resurrection" : {
 					"subtype" : "spell.resurrection",
 					"type" : "SPECIAL_SPELL_LEV",
-                    "updater" : "TIMES_HERO_LEVEL",
+					"updater" : "TIMES_HERO_LEVEL",
 					"val" : 3
 				}
 			}
@@ -207,7 +207,7 @@
 				"resurrection" : {
 					"subtype" : "spell.resurrection",
 					"type" : "SPECIAL_SPELL_LEV",
-                    "updater" : "TIMES_HERO_LEVEL",
+					"updater" : "TIMES_HERO_LEVEL",
 					"val" : 3
 				}
 			}
@@ -252,7 +252,7 @@
 				"meteorShower" : {
 					"subtype" : "spell.meteorShower",
 					"type" : "SPECIAL_SPELL_LEV",
-                    "updater" : "TIMES_HERO_LEVEL",
+					"updater" : "TIMES_HERO_LEVEL",
 					"val" : 3
 				}
 			}

--- a/config/heroes/dungeon.json
+++ b/config/heroes/dungeon.json
@@ -9,10 +9,38 @@
 			{ "skill" : "scouting", "level": "basic" },
 			{ "skill" : "leadership", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":1, "val": 0, "subtype": 0, "info": 72 }
-		]
+		"specialty" : {
+			"base" : {
+				"limiters" : [
+					{
+						"parameters" : [ "harpy", true ],
+						"type" : "CREATURE_TYPE_LIMITER"
+					}
+				]
+			},
+			"bonuses" : {
+				"attack" : {
+					"subtype" : "primSkill.attack",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 6, 2 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"defence" : {
+					"subtype" : "primSkill.defence",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 5, 2 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"speed" : {
+					"type" : "STACKS_SPEED",
+					"val" : 1
+				}
+			}
+		}
 	},
 	"arlach":
 	{
@@ -24,10 +52,38 @@
 			{ "skill" : "artillery", "level": "basic" },
 			{ "skill" : "offence", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":1, "val": 0, "subtype": 0, "info": 146 }
-		]
+		"specialty" : {
+			"base" : {
+				"limiters" : [
+					{
+						"parameters" : [ "ballista", true ],
+						"type" : "CREATURE_TYPE_LIMITER"
+					}
+				]
+			},
+			"bonuses" : {
+				"attack" : {
+					"subtype" : "primSkill.attack",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 10, 5 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"defence" : {
+					"subtype" : "primSkill.defence",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 10, 5 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"speed" : {
+					"type" : "STACKS_SPEED",
+					"val" : 1
+				}
+			}
+		}
 	},
 	"dace":
 	{
@@ -39,10 +95,38 @@
 			{ "skill" : "tactics", "level": "basic" },
 			{ "skill" : "offence", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":1, "val": 0, "subtype": 0, "info": 78 }
-		]
+		"specialty" : {
+			"base" : {
+				"limiters" : [
+					{
+						"parameters" : [ "minotaur", true ],
+						"type" : "CREATURE_TYPE_LIMITER"
+					}
+				]
+			},
+			"bonuses" : {
+				"attack" : {
+					"subtype" : "primSkill.attack",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 14, 5 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"defence" : {
+					"subtype" : "primSkill.defence",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 12, 5 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"speed" : {
+					"type" : "STACKS_SPEED",
+					"val" : 1
+				}
+			}
+		}
 	},
 	"ajit":
 	{
@@ -54,10 +138,38 @@
 			{ "skill" : "leadership", "level": "basic" },
 			{ "skill" : "resistance", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":1, "val": 0, "subtype": 0, "info": 74 }
-		]
+		"specialty" : {
+			"base" : {
+				"limiters" : [
+					{
+						"parameters" : [ "beholder", true ],
+						"type" : "CREATURE_TYPE_LIMITER"
+					}
+				]
+			},
+			"bonuses" : {
+				"attack" : {
+					"subtype" : "primSkill.attack",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 9, 3 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"defence" : {
+					"subtype" : "primSkill.defence",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 7, 3 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"speed" : {
+					"type" : "STACKS_SPEED",
+					"val" : 1
+				}
+			}
+		}
 	},
 	"damacon":
 	{
@@ -68,10 +180,15 @@
 		[
 			{ "skill" : "offence", "level": "advanced" }
 		],
-		"specialties":
-		[
-			{ "type":10, "val": 350, "subtype": 6, "info": 0 }
-		]
+		"specialty" : {
+			"bonuses" : {
+				"gold" : {
+					"subtype" : "resource.gold",
+					"type" : "GENERATE_RESOURCE",
+					"val" : 350
+				}
+			}
+		}
 	},
 	"gunnar":
 	{
@@ -83,10 +200,19 @@
 			{ "skill" : "logistics", "level": "basic" },
 			{ "skill" : "tactics", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":2, "val": 5, "subtype": 2, "info": 0 }
-		]
+		"specialty" : {
+			"bonuses" : {
+				"logistics" : {
+					"subtype" : "skill.logistics",
+					"type" : "SECONDARY_SKILL_PREMY",
+					"updater" : {
+						"parameters" : [ 100 ],
+						"type" : "GROWS_WITH_LEVEL"
+					},
+					"valueType" : "PERCENT_TO_BASE"
+				}
+			}
+		}
 	},
 	"synca":
 	{
@@ -98,10 +224,38 @@
 			{ "skill" : "leadership", "level": "basic" },
 			{ "skill" : "scholar", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":1, "val": 0, "subtype": 0, "info": 80 }
-		]
+		"specialty" : {
+			"base" : {
+				"limiters" : [
+					{
+						"parameters" : [ "manticore", true ],
+						"type" : "CREATURE_TYPE_LIMITER"
+					}
+				]
+			},
+			"bonuses" : {
+				"attack" : {
+					"subtype" : "primSkill.attack",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 15, 6 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"defence" : {
+					"subtype" : "primSkill.defence",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 13, 6 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"speed" : {
+					"type" : "STACKS_SPEED",
+					"val" : 1
+				}
+			}
+		}
 	},
 	"shakti":
 	{
@@ -113,10 +267,38 @@
 			{ "skill" : "tactics", "level": "basic" },
 			{ "skill" : "offence", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":1, "val": 0, "subtype": 0, "info": 70 }
-		]
+		"specialty" : {
+			"base" : {
+				"limiters" : [
+					{
+						"parameters" : [ "troglodyte", true ],
+						"type" : "CREATURE_TYPE_LIMITER"
+					}
+				]
+			},
+			"bonuses" : {
+				"attack" : {
+					"subtype" : "primSkill.attack",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 4 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"defence" : {
+					"subtype" : "primSkill.defence",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 3 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"speed" : {
+					"type" : "STACKS_SPEED",
+					"val" : 1
+				}
+			}
+		}
 	},
 	"alamar":
 	{
@@ -129,10 +311,15 @@
 			{ "skill" : "wisdom", "level": "basic" },
 			{ "skill" : "scholar", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":3, "val": 3, "subtype": 38, "info": 0 }
-		]
+		"specialty" : {
+			"bonuses" : {
+				"resurrection" : {
+					"subtype" : "spell.resurrection",
+					"type" : "SPECIAL_SPELL_LEV",
+					"val" : 3
+				}
+			}
+		}
 	},
 	"jaegar":
 	{
@@ -145,10 +332,19 @@
 			{ "skill" : "wisdom", "level": "basic" },
 			{ "skill" : "mysticism", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":2, "val": 5, "subtype": 8, "info": 1 }
-		]
+		"specialty" : {
+			"bonuses" : {
+				"mysticism" : {
+					"subtype" : "skill.mysticism",
+					"type" : "SECONDARY_SKILL_PREMY",
+					"updater" : {
+						"parameters" : [ 100 ],
+						"type" : "GROWS_WITH_LEVEL"
+					},
+					"valueType" : "PERCENT_TO_BASE"
+				}
+			}
+		}
 	},
 	"malekith":
 	{
@@ -161,10 +357,19 @@
 			{ "skill" : "wisdom", "level": "basic" },
 			{ "skill" : "sorcery", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":2, "val": 5, "subtype": 25, "info": 0 }
-		]
+		"specialty" : {
+			"bonuses" : {
+				"sorcery" : {
+					"subtype" : "skill.sorcery",
+					"type" : "SECONDARY_SKILL_PREMY",
+					"updater" : {
+						"parameters" : [ 100 ],
+						"type" : "GROWS_WITH_LEVEL"
+					},
+					"valueType" : "PERCENT_TO_BASE"
+				}
+			}
+		}
 	},
 	"jeddite":
 	{
@@ -176,10 +381,15 @@
 		[
 			{ "skill" : "wisdom", "level": "advanced" }
 		],
-		"specialties":
-		[
-			{ "type":3, "val": 3, "subtype": 38, "info": 0 }
-		]
+		"specialty" : {
+			"bonuses" : {
+				"resurrection" : {
+					"subtype" : "spell.resurrection",
+					"type" : "SPECIAL_SPELL_LEV",
+					"val" : 3
+				}
+			}
+		}
 	},
 	"geon":
 	{
@@ -192,10 +402,19 @@
 			{ "skill" : "wisdom", "level": "basic" },
 			{ "skill" : "eagleEye", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":2, "val": 5, "subtype": 11, "info": 1 }
-		]
+		"specialty" : {
+			"bonuses" : {
+				"eagleEye" : {
+					"subtype" : "skill.eagleEye",
+					"type" : "SECONDARY_SKILL_PREMY",
+					"updater" : {
+						"parameters" : [ 100 ],
+						"type" : "GROWS_WITH_LEVEL"
+					},
+					"valueType" : "PERCENT_TO_BASE"
+				}
+			}
+		}
 	},
 	"deemer":
 	{
@@ -208,10 +427,15 @@
 			{ "skill" : "wisdom", "level": "basic" },
 			{ "skill" : "scouting", "level": "advanced" }
 		],
-		"specialties":
-		[
-			{ "type":3, "val": 3, "subtype": 23, "info": 0 }
-		]
+		"specialty" : {
+			"bonuses" : {
+				"meteorShower" : {
+					"subtype" : "spell.meteorShower",
+					"type" : "SPECIAL_SPELL_LEV",
+					"val" : 3
+				}
+			}
+		}
 	},
 	"sephinroth":
 	{
@@ -224,10 +448,15 @@
 			{ "skill" : "wisdom", "level": "basic" },
 			{ "skill" : "intelligence", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":10, "val": 1, "subtype": 4, "info": 0 }
-		]
+		"specialty" : {
+			"bonuses" : {
+				"crystal" : {
+					"subtype" : "resource.crystal",
+					"type" : "GENERATE_RESOURCE",
+					"val" : 1
+				}
+			}
+		}
 	},
 	"darkstorn":
 	{
@@ -240,9 +469,14 @@
 			{ "skill" : "wisdom", "level": "basic" },
 			{ "skill" : "learning", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":8, "val": 0, "subtype": 46, "info": 0 }
-		]
+		"specialty" : {
+			"bonuses" : {
+				"stoneSkin" : {
+					"addInfo" : 0,
+					"subtype" : "spell.stoneSkin",
+					"type" : "SPECIAL_PECULIAR_ENCHANT"
+				}
+			}
+		}
 	}
 }

--- a/config/heroes/dungeon.json
+++ b/config/heroes/dungeon.json
@@ -205,10 +205,8 @@
 				"logistics" : {
 					"subtype" : "skill.logistics",
 					"type" : "SECONDARY_SKILL_PREMY",
-					"updater" : {
-						"parameters" : [ 100 ],
-						"type" : "GROWS_WITH_LEVEL"
-					},
+					"updater" : "TIMES_HERO_LEVEL",
+					"val" : 5,
 					"valueType" : "PERCENT_TO_BASE"
 				}
 			}
@@ -337,10 +335,8 @@
 				"mysticism" : {
 					"subtype" : "skill.mysticism",
 					"type" : "SECONDARY_SKILL_PREMY",
-					"updater" : {
-						"parameters" : [ 100 ],
-						"type" : "GROWS_WITH_LEVEL"
-					},
+					"updater" : "TIMES_HERO_LEVEL",
+					"val" : 5,
 					"valueType" : "PERCENT_TO_BASE"
 				}
 			}
@@ -362,10 +358,8 @@
 				"sorcery" : {
 					"subtype" : "skill.sorcery",
 					"type" : "SECONDARY_SKILL_PREMY",
-					"updater" : {
-						"parameters" : [ 100 ],
-						"type" : "GROWS_WITH_LEVEL"
-					},
+					"updater" : "TIMES_HERO_LEVEL",
+					"val" : 5,
 					"valueType" : "PERCENT_TO_BASE"
 				}
 			}
@@ -407,10 +401,8 @@
 				"eagleEye" : {
 					"subtype" : "skill.eagleEye",
 					"type" : "SECONDARY_SKILL_PREMY",
-					"updater" : {
-						"parameters" : [ 100 ],
-						"type" : "GROWS_WITH_LEVEL"
-					},
+					"updater" : "TIMES_HERO_LEVEL",
+					"val" : 5,
 					"valueType" : "PERCENT_TO_BASE"
 				}
 			}

--- a/config/heroes/fortress.json
+++ b/config/heroes/fortress.json
@@ -400,7 +400,7 @@
 					"subtype" : "skill.navigation",
 					"type" : "SECONDARY_SKILL_PREMY",
 					"updater" : {
-						"parameters" : [ 40 ],
+						"parameters" : [ 100 ],
 						"type" : "GROWS_WITH_LEVEL"
 					},
 					"valueType" : "PERCENT_TO_BASE"

--- a/config/heroes/fortress.json
+++ b/config/heroes/fortress.json
@@ -157,10 +157,8 @@
 				"armorer" : {
 					"subtype" : "skill.armorer",
 					"type" : "SECONDARY_SKILL_PREMY",
-					"updater" : {
-						"parameters" : [ 100 ],
-						"type" : "GROWS_WITH_LEVEL"
-					},
+					"updater" : "TIMES_HERO_LEVEL",
+					"val" : 5,
 					"valueType" : "PERCENT_TO_BASE"
 				}
 			}
@@ -374,10 +372,8 @@
 				"mysticism" : {
 					"subtype" : "skill.mysticism",
 					"type" : "SECONDARY_SKILL_PREMY",
-					"updater" : {
-						"parameters" : [ 100 ],
-						"type" : "GROWS_WITH_LEVEL"
-					},
+					"updater" : "TIMES_HERO_LEVEL",
+					"val" : 5,
 					"valueType" : "PERCENT_TO_BASE"
 				}
 			}
@@ -399,10 +395,8 @@
 				"navigation" : {
 					"subtype" : "skill.navigation",
 					"type" : "SECONDARY_SKILL_PREMY",
-					"updater" : {
-						"parameters" : [ 100 ],
-						"type" : "GROWS_WITH_LEVEL"
-					},
+					"updater" : "TIMES_HERO_LEVEL",
+					"val" : 5,
 					"valueType" : "PERCENT_TO_BASE"
 				}
 			}
@@ -424,10 +418,8 @@
 				"firstAid" : {
 					"subtype" : "skill.firstAid",
 					"type" : "SECONDARY_SKILL_PREMY",
-					"updater" : {
-						"parameters" : [ 100 ],
-						"type" : "GROWS_WITH_LEVEL"
-					},
+					"updater" : "TIMES_HERO_LEVEL",
+					"val" : 5,
 					"valueType" : "PERCENT_TO_BASE"
 				}
 			}
@@ -470,10 +462,8 @@
 				"sorcery" : {
 					"subtype" : "skill.sorcery",
 					"type" : "SECONDARY_SKILL_PREMY",
-					"updater" : {
-						"parameters" : [ 100 ],
-						"type" : "GROWS_WITH_LEVEL"
-					},
+					"updater" : "TIMES_HERO_LEVEL",
+					"val" : 5,
 					"valueType" : "PERCENT_TO_BASE"
 				}
 			}
@@ -495,10 +485,8 @@
 				"intelligence" : {
 					"subtype" : "skill.intelligence",
 					"type" : "SECONDARY_SKILL_PREMY",
-					"updater" : {
-						"parameters" : [ 100 ],
-						"type" : "GROWS_WITH_LEVEL"
-					},
+					"updater" : "TIMES_HERO_LEVEL",
+					"val" : 5,
 					"valueType" : "PERCENT_TO_BASE"
 				}
 			}
@@ -520,10 +508,8 @@
 				"eagleEye" : {
 					"subtype" : "skill.eagleEye",
 					"type" : "SECONDARY_SKILL_PREMY",
-					"updater" : {
-						"parameters" : [ 100 ],
-						"type" : "GROWS_WITH_LEVEL"
-					},
+					"updater" : "TIMES_HERO_LEVEL",
+					"val" : 5,
 					"valueType" : "PERCENT_TO_BASE"
 				}
 			}

--- a/config/heroes/fortress.json
+++ b/config/heroes/fortress.json
@@ -10,36 +10,7 @@
 			{ "skill" : "resistance", "level": "basic" }
 		],
 		"specialty" : {
-			"base" : {
-				"limiters" : [
-					{
-						"parameters" : [ "basilisk", true ],
-						"type" : "CREATURE_TYPE_LIMITER"
-					}
-				]
-			},
-			"bonuses" : {
-				"attack" : {
-					"subtype" : "primSkill.attack",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 11, 4 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"defence" : {
-					"subtype" : "primSkill.defence",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 11, 4 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"speed" : {
-					"type" : "STACKS_SPEED",
-					"val" : 1
-				}
-			}
+			"creature" : "basilisk"
 		},
 		"army" :
 		[
@@ -68,36 +39,7 @@
 			{ "skill" : "leadership", "level": "basic" }
 		],
 		"specialty" : {
-			"base" : {
-				"limiters" : [
-					{
-						"parameters" : [ "gnoll", true ],
-						"type" : "CREATURE_TYPE_LIMITER"
-					}
-				]
-			},
-			"bonuses" : {
-				"attack" : {
-					"subtype" : "primSkill.attack",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 3 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"defence" : {
-					"subtype" : "primSkill.defence",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 5 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"speed" : {
-					"type" : "STACKS_SPEED",
-					"val" : 1
-				}
-			}
+			"creature" : "gnoll"
 		}
 	},
 	"wystan":
@@ -111,36 +53,7 @@
 			{ "skill" : "archery", "level": "basic" }
 		],
 		"specialty" : {
-			"base" : {
-				"limiters" : [
-					{
-						"parameters" : [ "lizardman", true ],
-						"type" : "CREATURE_TYPE_LIMITER"
-					}
-				]
-			},
-			"bonuses" : {
-				"attack" : {
-					"subtype" : "primSkill.attack",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 5, 2 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"defence" : {
-					"subtype" : "primSkill.defence",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 6, 2 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"speed" : {
-					"type" : "STACKS_SPEED",
-					"val" : 1
-				}
-			}
+			"creature" : "lizardman"
 		}
 	},
 	"tazar":
@@ -175,36 +88,7 @@
 			{ "skill" : "offence", "level": "basic" }
 		],
 		"specialty" : {
-			"base" : {
-				"limiters" : [
-					{
-						"parameters" : [ "gorgon", true ],
-						"type" : "CREATURE_TYPE_LIMITER"
-					}
-				]
-			},
-			"bonuses" : {
-				"attack" : {
-					"subtype" : "primSkill.attack",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 10, 5 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"defence" : {
-					"subtype" : "primSkill.defence",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 14, 5 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"speed" : {
-					"type" : "STACKS_SPEED",
-					"val" : 1
-				}
-			}
+			"creature" : "gorgon"
 		}
 	},
 	"korbac":
@@ -218,36 +102,7 @@
 			{ "skill" : "pathfinding", "level": "basic" }
 		],
 		"specialty" : {
-			"base" : {
-				"limiters" : [
-					{
-						"parameters" : [ "serpentFly", true ],
-						"type" : "CREATURE_TYPE_LIMITER"
-					}
-				]
-			},
-			"bonuses" : {
-				"attack" : {
-					"subtype" : "primSkill.attack",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 7, 3 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"defence" : {
-					"subtype" : "primSkill.defence",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 9, 3 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"speed" : {
-					"type" : "STACKS_SPEED",
-					"val" : 1
-				}
-			}
+			"creature" : "serpentFly"
 		}
 	},
 	"gerwulf":
@@ -261,36 +116,7 @@
 			{ "skill" : "artillery", "level": "basic" }
 		],
 		"specialty" : {
-			"base" : {
-				"limiters" : [
-					{
-						"parameters" : [ "ballista", true ],
-						"type" : "CREATURE_TYPE_LIMITER"
-					}
-				]
-			},
-			"bonuses" : {
-				"attack" : {
-					"subtype" : "primSkill.attack",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 10, 5 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"defence" : {
-					"subtype" : "primSkill.defence",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 10, 5 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"speed" : {
-					"type" : "STACKS_SPEED",
-					"val" : 1
-				}
-			}
+			"creature" : "ballista"
 		}
 	},
 	"broghild":
@@ -304,36 +130,7 @@
 			{ "skill" : "scouting", "level": "basic" }
 		],
 		"specialty" : {
-			"base" : {
-				"limiters" : [
-					{
-						"parameters" : [ "wyvern", true ],
-						"type" : "CREATURE_TYPE_LIMITER"
-					}
-				]
-			},
-			"bonuses" : {
-				"attack" : {
-					"subtype" : "primSkill.attack",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 14, 6 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"defence" : {
-					"subtype" : "primSkill.defence",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 14, 6 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"speed" : {
-					"type" : "STACKS_SPEED",
-					"val" : 1
-				}
-			}
+			"creature" : "wyvern"
 		}
 	},
 	"mirlanda":

--- a/config/heroes/fortress.json
+++ b/config/heroes/fortress.json
@@ -9,10 +9,38 @@
 			{ "skill" : "armorer", "level": "basic" },
 			{ "skill" : "resistance", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":1, "val": 0, "subtype": 0, "info": 106 }
-		],		
+		"specialty" : {
+			"base" : {
+				"limiters" : [
+					{
+						"parameters" : [ "basilisk", true ],
+						"type" : "CREATURE_TYPE_LIMITER"
+					}
+				]
+			},
+			"bonuses" : {
+				"attack" : {
+					"subtype" : "primSkill.attack",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 11, 4 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"defence" : {
+					"subtype" : "primSkill.defence",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 11, 4 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"speed" : {
+					"type" : "STACKS_SPEED",
+					"val" : 1
+				}
+			}
+		},
 		"army" :
 		[
 			{
@@ -39,10 +67,38 @@
 			{ "skill" : "armorer", "level": "basic" },
 			{ "skill" : "leadership", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":1, "val": 0, "subtype": 0, "info": 98 }
-		]
+		"specialty" : {
+			"base" : {
+				"limiters" : [
+					{
+						"parameters" : [ "gnoll", true ],
+						"type" : "CREATURE_TYPE_LIMITER"
+					}
+				]
+			},
+			"bonuses" : {
+				"attack" : {
+					"subtype" : "primSkill.attack",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 3 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"defence" : {
+					"subtype" : "primSkill.defence",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 5 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"speed" : {
+					"type" : "STACKS_SPEED",
+					"val" : 1
+				}
+			}
+		}
 	},
 	"wystan":
 	{
@@ -54,10 +110,38 @@
 			{ "skill" : "armorer", "level": "basic" },
 			{ "skill" : "archery", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":1, "val": 0, "subtype": 0, "info": 100 }
-		]
+		"specialty" : {
+			"base" : {
+				"limiters" : [
+					{
+						"parameters" : [ "lizardman", true ],
+						"type" : "CREATURE_TYPE_LIMITER"
+					}
+				]
+			},
+			"bonuses" : {
+				"attack" : {
+					"subtype" : "primSkill.attack",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 5, 2 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"defence" : {
+					"subtype" : "primSkill.defence",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 6, 2 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"speed" : {
+					"type" : "STACKS_SPEED",
+					"val" : 1
+				}
+			}
+		}
 	},
 	"tazar":
 	{
@@ -68,10 +152,19 @@
 		[
 			{ "skill" : "armorer", "level": "advanced" }
 		],
-		"specialties":
-		[
-			{ "type":2, "val": 5, "subtype": 23, "info": 0 }
-		]
+		"specialty" : {
+			"bonuses" : {
+				"armorer" : {
+					"subtype" : "skill.armorer",
+					"type" : "SECONDARY_SKILL_PREMY",
+					"updater" : {
+						"parameters" : [ 100 ],
+						"type" : "GROWS_WITH_LEVEL"
+					},
+					"valueType" : "PERCENT_TO_BASE"
+				}
+			}
+		}
 	},
 	"alkin":
 	{
@@ -83,10 +176,38 @@
 			{ "skill" : "armorer", "level": "basic" },
 			{ "skill" : "offence", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":1, "val": 0, "subtype": 0, "info": 102 }
-		]
+		"specialty" : {
+			"base" : {
+				"limiters" : [
+					{
+						"parameters" : [ "gorgon", true ],
+						"type" : "CREATURE_TYPE_LIMITER"
+					}
+				]
+			},
+			"bonuses" : {
+				"attack" : {
+					"subtype" : "primSkill.attack",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 10, 5 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"defence" : {
+					"subtype" : "primSkill.defence",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 14, 5 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"speed" : {
+					"type" : "STACKS_SPEED",
+					"val" : 1
+				}
+			}
+		}
 	},
 	"korbac":
 	{
@@ -98,10 +219,38 @@
 			{ "skill" : "armorer", "level": "basic" },
 			{ "skill" : "pathfinding", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":1, "val": 0, "subtype": 0, "info": 104 }
-		]
+		"specialty" : {
+			"base" : {
+				"limiters" : [
+					{
+						"parameters" : [ "serpentFly", true ],
+						"type" : "CREATURE_TYPE_LIMITER"
+					}
+				]
+			},
+			"bonuses" : {
+				"attack" : {
+					"subtype" : "primSkill.attack",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 7, 3 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"defence" : {
+					"subtype" : "primSkill.defence",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 9, 3 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"speed" : {
+					"type" : "STACKS_SPEED",
+					"val" : 1
+				}
+			}
+		}
 	},
 	"gerwulf":
 	{
@@ -113,10 +262,38 @@
 			{ "skill" : "armorer", "level": "basic" },
 			{ "skill" : "artillery", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":1, "val": 0, "subtype": 0, "info": 146 }
-		]
+		"specialty" : {
+			"base" : {
+				"limiters" : [
+					{
+						"parameters" : [ "ballista", true ],
+						"type" : "CREATURE_TYPE_LIMITER"
+					}
+				]
+			},
+			"bonuses" : {
+				"attack" : {
+					"subtype" : "primSkill.attack",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 10, 5 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"defence" : {
+					"subtype" : "primSkill.defence",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 10, 5 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"speed" : {
+					"type" : "STACKS_SPEED",
+					"val" : 1
+				}
+			}
+		}
 	},
 	"broghild":
 	{
@@ -128,10 +305,38 @@
 			{ "skill" : "armorer", "level": "basic" },
 			{ "skill" : "scouting", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":1, "val": 0, "subtype": 0, "info": 108 }
-		]
+		"specialty" : {
+			"base" : {
+				"limiters" : [
+					{
+						"parameters" : [ "wyvern", true ],
+						"type" : "CREATURE_TYPE_LIMITER"
+					}
+				]
+			},
+			"bonuses" : {
+				"attack" : {
+					"subtype" : "primSkill.attack",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 14, 6 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"defence" : {
+					"subtype" : "primSkill.defence",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 14, 6 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"speed" : {
+					"type" : "STACKS_SPEED",
+					"val" : 1
+				}
+			}
+		}
 	},
 	"mirlanda":
 	{
@@ -143,10 +348,15 @@
 		[
 			{ "skill" : "wisdom", "level": "advanced" }
 		],
-		"specialties":
-		[
-			{ "type":8, "val": 0, "subtype": 45, "info": 0 }
-		]
+		"specialty" : {
+			"bonuses" : {
+				"weakness" : {
+					"addInfo" : 0,
+					"subtype" : "spell.weakness",
+					"type" : "SPECIAL_PECULIAR_ENCHANT"
+				}
+			}
+		}
 	},
 	"rosic":
 	{
@@ -159,10 +369,19 @@
 			{ "skill" : "wisdom", "level": "basic" },
 			{ "skill" : "mysticism", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":2, "val": 5, "subtype": 8, "info": 1 }
-		]
+		"specialty" : {
+			"bonuses" : {
+				"mysticism" : {
+					"subtype" : "skill.mysticism",
+					"type" : "SECONDARY_SKILL_PREMY",
+					"updater" : {
+						"parameters" : [ 100 ],
+						"type" : "GROWS_WITH_LEVEL"
+					},
+					"valueType" : "PERCENT_TO_BASE"
+				}
+			}
+		}
 	},
 	"voy":
 	{
@@ -175,10 +394,19 @@
 			{ "skill" : "wisdom", "level": "basic" },
 			{ "skill" : "navigation", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":2, "val": 2, "subtype": 5, "info": 1 }
-		]
+		"specialty" : {
+			"bonuses" : {
+				"navigation" : {
+					"subtype" : "skill.navigation",
+					"type" : "SECONDARY_SKILL_PREMY",
+					"updater" : {
+						"parameters" : [ 40 ],
+						"type" : "GROWS_WITH_LEVEL"
+					},
+					"valueType" : "PERCENT_TO_BASE"
+				}
+			}
+		}
 	},
 	"verdish":
 	{
@@ -191,10 +419,19 @@
 			{ "skill" : "wisdom", "level": "basic" },
 			{ "skill" : "firstAid", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":2, "val": 5, "subtype": 27, "info": 1 }
-		]
+		"specialty" : {
+			"bonuses" : {
+				"firstAid" : {
+					"subtype" : "skill.firstAid",
+					"type" : "SECONDARY_SKILL_PREMY",
+					"updater" : {
+						"parameters" : [ 100 ],
+						"type" : "GROWS_WITH_LEVEL"
+					},
+					"valueType" : "PERCENT_TO_BASE"
+				}
+			}
+		}
 	},
 	"merist":
 	{
@@ -207,10 +444,15 @@
 			{ "skill" : "wisdom", "level": "basic" },
 			{ "skill" : "learning", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":8, "val": 0, "subtype": 46, "info": 0 }
-		]
+		"specialty" : {
+			"bonuses" : {
+				"stoneSkin" : {
+					"addInfo" : 0,
+					"subtype" : "spell.stoneSkin",
+					"type" : "SPECIAL_PECULIAR_ENCHANT"
+				}
+			}
+		}
 	},
 	"styg":
 	{
@@ -223,10 +465,19 @@
 			{ "skill" : "wisdom", "level": "basic" },
 			{ "skill" : "sorcery", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":2, "val": 5, "subtype": 25, "info": 0 }
-		]
+		"specialty" : {
+			"bonuses" : {
+				"sorcery" : {
+					"subtype" : "skill.sorcery",
+					"type" : "SECONDARY_SKILL_PREMY",
+					"updater" : {
+						"parameters" : [ 100 ],
+						"type" : "GROWS_WITH_LEVEL"
+					},
+					"valueType" : "PERCENT_TO_BASE"
+				}
+			}
+		}
 	},
 	"andra":
 	{
@@ -239,10 +490,19 @@
 			{ "skill" : "wisdom", "level": "basic" },
 			{ "skill" : "intelligence", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":2, "val": 5, "subtype": 24, "info": 0 }
-		]
+		"specialty" : {
+			"bonuses" : {
+				"intelligence" : {
+					"subtype" : "skill.intelligence",
+					"type" : "SECONDARY_SKILL_PREMY",
+					"updater" : {
+						"parameters" : [ 100 ],
+						"type" : "GROWS_WITH_LEVEL"
+					},
+					"valueType" : "PERCENT_TO_BASE"
+				}
+			}
+		}
 	},
 	"tiva":
 	{
@@ -255,9 +515,18 @@
 			{ "skill" : "wisdom", "level": "basic" },
 			{ "skill" : "eagleEye", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":2, "val": 5, "subtype": 11, "info": 1 }
-		]
+		"specialty" : {
+			"bonuses" : {
+				"eagleEye" : {
+					"subtype" : "skill.eagleEye",
+					"type" : "SECONDARY_SKILL_PREMY",
+					"updater" : {
+						"parameters" : [ 100 ],
+						"type" : "GROWS_WITH_LEVEL"
+					},
+					"valueType" : "PERCENT_TO_BASE"
+				}
+			}
+		}
 	}
 }

--- a/config/heroes/inferno.json
+++ b/config/heroes/inferno.json
@@ -8,10 +8,38 @@
 		[
 			{ "skill" : "scouting", "level": "advanced" }
 		],
-		"specialties":
-		[
-			{ "type":1, "val": 0, "subtype": 0, "info": 46 }
-		]
+		"specialty" : {
+			"base" : {
+				"limiters" : [
+					{
+						"parameters" : [ "hellHound", true ],
+						"type" : "CREATURE_TYPE_LIMITER"
+					}
+				]
+			},
+			"bonuses" : {
+				"attack" : {
+					"subtype" : "primSkill.attack",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 10, 3 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"defence" : {
+					"subtype" : "primSkill.defence",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 6, 3 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"speed" : {
+					"type" : "STACKS_SPEED",
+					"val" : 1
+				}
+			}
+		}
 	},
 	"rashka":
 	{
@@ -23,10 +51,38 @@
 			{ "skill" : "wisdom", "level": "basic" },
 			{ "skill" : "scholar", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":1, "val": 0, "subtype": 0, "info": 52 }
-		]
+		"specialty" : {
+			"base" : {
+				"limiters" : [
+					{
+						"parameters" : [ "efreet", true ],
+						"type" : "CREATURE_TYPE_LIMITER"
+					}
+				]
+			},
+			"bonuses" : {
+				"attack" : {
+					"subtype" : "primSkill.attack",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 16, 6 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"defence" : {
+					"subtype" : "primSkill.defence",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 12, 6 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"speed" : {
+					"type" : "STACKS_SPEED",
+					"val" : 1
+				}
+			}
+		}
 	},
 	"marius":
 	{
@@ -37,10 +93,38 @@
 		[
 			{ "skill" : "armorer", "level": "advanced" }
 		],
-		"specialties":
-		[
-			{ "type":1, "val": 0, "subtype": 0, "info": 48 }
-		]
+		"specialty" : {
+			"base" : {
+				"limiters" : [
+					{
+						"parameters" : [ "demon", true ],
+						"type" : "CREATURE_TYPE_LIMITER"
+					}
+				]
+			},
+			"bonuses" : {
+				"attack" : {
+					"subtype" : "primSkill.attack",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 10, 4 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"defence" : {
+					"subtype" : "primSkill.defence",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 10, 4 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"speed" : {
+					"type" : "STACKS_SPEED",
+					"val" : 1
+				}
+			}
+		}
 	},
 	"ignatius":
 	{
@@ -52,10 +136,38 @@
 			{ "skill" : "tactics", "level": "basic" },
 			{ "skill" : "resistance", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":1, "val": 0, "subtype": 0, "info": 42 }
-		]
+		"specialty" : {
+			"base" : {
+				"limiters" : [
+					{
+						"parameters" : [ "imp", true ],
+						"type" : "CREATURE_TYPE_LIMITER"
+					}
+				]
+			},
+			"bonuses" : {
+				"attack" : {
+					"subtype" : "primSkill.attack",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 2 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"defence" : {
+					"subtype" : "primSkill.defence",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 3 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"speed" : {
+					"type" : "STACKS_SPEED",
+					"val" : 1
+				}
+			}
+		}
 	},
 	"octavia":
 	{
@@ -67,10 +179,15 @@
 			{ "skill" : "scholar", "level": "basic" },
 			{ "skill" : "offence", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":10, "val": 350, "subtype": 6, "info": 0 }
-		]
+		"specialty" : {
+			"bonuses" : {
+				"gold" : {
+					"subtype" : "resource.gold",
+					"type" : "GENERATE_RESOURCE",
+					"val" : 350
+				}
+			}
+		}
 	},
 	"calh":
 	{
@@ -82,10 +199,38 @@
 			{ "skill" : "archery", "level": "basic" },
 			{ "skill" : "scouting", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":1, "val": 0, "subtype": 0, "info": 42 }
-		]
+		"specialty" : {
+			"base" : {
+				"limiters" : [
+					{
+						"parameters" : [ "imp", true ],
+						"type" : "CREATURE_TYPE_LIMITER"
+					}
+				]
+			},
+			"bonuses" : {
+				"attack" : {
+					"subtype" : "primSkill.attack",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 2 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"defence" : {
+					"subtype" : "primSkill.defence",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 3 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"speed" : {
+					"type" : "STACKS_SPEED",
+					"val" : 1
+				}
+			}
+		}
 	},
 	"pyre":
 	{
@@ -97,10 +242,38 @@
 			{ "skill" : "artillery", "level": "basic" },
 			{ "skill" : "logistics", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":1, "val": 0, "subtype": 0, "info": 146 }
-		]
+		"specialty" : {
+			"base" : {
+				"limiters" : [
+					{
+						"parameters" : [ "ballista", true ],
+						"type" : "CREATURE_TYPE_LIMITER"
+					}
+				]
+			},
+			"bonuses" : {
+				"attack" : {
+					"subtype" : "primSkill.attack",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 10, 5 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"defence" : {
+					"subtype" : "primSkill.defence",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 10, 5 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"speed" : {
+					"type" : "STACKS_SPEED",
+					"val" : 1
+				}
+			}
+		}
 	},
 	"nymus":
 	{
@@ -111,10 +284,38 @@
 		[
 			{ "skill" : "offence", "level": "advanced" }
 		],
-		"specialties":
-		[
-			{ "type":1, "val": 0, "subtype": 0, "info": 50 }
-		]
+		"specialty" : {
+			"base" : {
+				"limiters" : [
+					{
+						"parameters" : [ "pitFiend", true ],
+						"type" : "CREATURE_TYPE_LIMITER"
+					}
+				]
+			},
+			"bonuses" : {
+				"attack" : {
+					"subtype" : "primSkill.attack",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 13, 5 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"defence" : {
+					"subtype" : "primSkill.defence",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 13, 5 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"speed" : {
+					"type" : "STACKS_SPEED",
+					"val" : 1
+				}
+			}
+		}
 	},
 	"ayden":
 	{
@@ -127,10 +328,19 @@
 			{ "skill" : "wisdom", "level": "basic" },
 			{ "skill" : "intelligence", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":2, "val": 5, "subtype": 24, "info": 0 }
-		]
+		"specialty" : {
+			"bonuses" : {
+				"intelligence" : {
+					"subtype" : "skill.intelligence",
+					"type" : "SECONDARY_SKILL_PREMY",
+					"updater" : {
+						"parameters" : [ 100 ],
+						"type" : "GROWS_WITH_LEVEL"
+					},
+					"valueType" : "PERCENT_TO_BASE"
+				}
+			}
+		}
 	},
 	"xyron":
 	{
@@ -143,10 +353,15 @@
 			{ "skill" : "wisdom", "level": "basic" },
 			{ "skill" : "scholar", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":3, "val": 3, "subtype": 22, "info": 0 }
-		]
+		"specialty" : {
+			"bonuses" : {
+				"inferno" : {
+					"subtype" : "spell.inferno",
+					"type" : "SPECIAL_SPELL_LEV",
+					"val" : 3
+				}
+			}
+		}
 	},
 	"axsis":
 	{
@@ -159,10 +374,19 @@
 			{ "skill" : "wisdom", "level": "basic" },
 			{ "skill" : "mysticism", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":2, "val": 5, "subtype": 8, "info": 1 }
-		]
+		"specialty" : {
+			"bonuses" : {
+				"mysticism" : {
+					"subtype" : "skill.mysticism",
+					"type" : "SECONDARY_SKILL_PREMY",
+					"updater" : {
+						"parameters" : [ 100 ],
+						"type" : "GROWS_WITH_LEVEL"
+					},
+					"valueType" : "PERCENT_TO_BASE"
+				}
+			}
+		}
 	},
 	"olema":
 	{
@@ -175,10 +399,15 @@
 			{ "skill" : "wisdom", "level": "basic" },
 			{ "skill" : "ballistics", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":8, "val": 0, "subtype": 45, "info": 0 }
-		]
+		"specialty" : {
+			"bonuses" : {
+				"weakness" : {
+					"addInfo" : 0,
+					"subtype" : "spell.weakness",
+					"type" : "SPECIAL_PECULIAR_ENCHANT"
+				}
+			}
+		}
 	},
 	"calid":
 	{
@@ -191,10 +420,15 @@
 			{ "skill" : "wisdom", "level": "basic" },
 			{ "skill" : "learning", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":10, "val": 1, "subtype": 3, "info": 0 }
-		]
+		"specialty" : {
+			"bonuses" : {
+				"sulfur" : {
+					"subtype" : "resource.sulfur",
+					"type" : "GENERATE_RESOURCE",
+					"val" : 1
+				}
+			}
+		}
 	},
 	"ash":
 	{
@@ -207,10 +441,15 @@
 			{ "skill" : "wisdom", "level": "basic" },
 			{ "skill" : "eagleEye", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":8, "val": 0, "subtype": 43, "info": 0 }
-		]
+		"specialty" : {
+			"bonuses" : {
+				"bloodlust" : {
+					"addInfo" : 0,
+					"subtype" : "spell.bloodlust",
+					"type" : "SPECIAL_PECULIAR_ENCHANT"
+				}
+			}
+		}
 	},
 	"zydar":
 	{
@@ -223,10 +462,19 @@
 			{ "skill" : "wisdom", "level": "basic" },
 			{ "skill" : "sorcery", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":2, "val": 5, "subtype": 25, "info": 0 }
-		]
+		"specialty" : {
+			"bonuses" : {
+				"sorcery" : {
+					"subtype" : "skill.sorcery",
+					"type" : "SECONDARY_SKILL_PREMY",
+					"updater" : {
+						"parameters" : [ 100 ],
+						"type" : "GROWS_WITH_LEVEL"
+					},
+					"valueType" : "PERCENT_TO_BASE"
+				}
+			}
+		}
 	},
 	"xarfax":
 	{
@@ -239,9 +487,14 @@
 			{ "skill" : "wisdom", "level": "basic" },
 			{ "skill" : "leadership", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":3, "val": 3, "subtype": 21, "info": 0 }
-		]
+		"specialty" : {
+			"bonuses" : {
+				"fireball" : {
+					"subtype" : "spell.fireball",
+					"type" : "SPECIAL_SPELL_LEV",
+					"val" : 3
+				}
+			}
+		}
 	}
 }

--- a/config/heroes/inferno.json
+++ b/config/heroes/inferno.json
@@ -333,10 +333,8 @@
 				"intelligence" : {
 					"subtype" : "skill.intelligence",
 					"type" : "SECONDARY_SKILL_PREMY",
-					"updater" : {
-						"parameters" : [ 100 ],
-						"type" : "GROWS_WITH_LEVEL"
-					},
+					"updater" : "TIMES_HERO_LEVEL",
+					"val" : 5,
 					"valueType" : "PERCENT_TO_BASE"
 				}
 			}
@@ -379,10 +377,8 @@
 				"mysticism" : {
 					"subtype" : "skill.mysticism",
 					"type" : "SECONDARY_SKILL_PREMY",
-					"updater" : {
-						"parameters" : [ 100 ],
-						"type" : "GROWS_WITH_LEVEL"
-					},
+					"updater" : "TIMES_HERO_LEVEL",
+					"val" : 5,
 					"valueType" : "PERCENT_TO_BASE"
 				}
 			}
@@ -467,10 +463,8 @@
 				"sorcery" : {
 					"subtype" : "skill.sorcery",
 					"type" : "SECONDARY_SKILL_PREMY",
-					"updater" : {
-						"parameters" : [ 100 ],
-						"type" : "GROWS_WITH_LEVEL"
-					},
+					"updater" : "TIMES_HERO_LEVEL",
+					"val" : 5,
 					"valueType" : "PERCENT_TO_BASE"
 				}
 			}

--- a/config/heroes/inferno.json
+++ b/config/heroes/inferno.json
@@ -9,36 +9,7 @@
 			{ "skill" : "scouting", "level": "advanced" }
 		],
 		"specialty" : {
-			"base" : {
-				"limiters" : [
-					{
-						"parameters" : [ "hellHound", true ],
-						"type" : "CREATURE_TYPE_LIMITER"
-					}
-				]
-			},
-			"bonuses" : {
-				"attack" : {
-					"subtype" : "primSkill.attack",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 10, 3 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"defence" : {
-					"subtype" : "primSkill.defence",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 6, 3 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"speed" : {
-					"type" : "STACKS_SPEED",
-					"val" : 1
-				}
-			}
+			"creature" : "hellHound"
 		}
 	},
 	"rashka":
@@ -52,36 +23,7 @@
 			{ "skill" : "scholar", "level": "basic" }
 		],
 		"specialty" : {
-			"base" : {
-				"limiters" : [
-					{
-						"parameters" : [ "efreet", true ],
-						"type" : "CREATURE_TYPE_LIMITER"
-					}
-				]
-			},
-			"bonuses" : {
-				"attack" : {
-					"subtype" : "primSkill.attack",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 16, 6 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"defence" : {
-					"subtype" : "primSkill.defence",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 12, 6 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"speed" : {
-					"type" : "STACKS_SPEED",
-					"val" : 1
-				}
-			}
+			"creature" : "efreet"
 		}
 	},
 	"marius":
@@ -94,36 +36,7 @@
 			{ "skill" : "armorer", "level": "advanced" }
 		],
 		"specialty" : {
-			"base" : {
-				"limiters" : [
-					{
-						"parameters" : [ "demon", true ],
-						"type" : "CREATURE_TYPE_LIMITER"
-					}
-				]
-			},
-			"bonuses" : {
-				"attack" : {
-					"subtype" : "primSkill.attack",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 10, 4 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"defence" : {
-					"subtype" : "primSkill.defence",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 10, 4 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"speed" : {
-					"type" : "STACKS_SPEED",
-					"val" : 1
-				}
-			}
+			"creature" : "demon"
 		}
 	},
 	"ignatius":
@@ -137,36 +50,7 @@
 			{ "skill" : "resistance", "level": "basic" }
 		],
 		"specialty" : {
-			"base" : {
-				"limiters" : [
-					{
-						"parameters" : [ "imp", true ],
-						"type" : "CREATURE_TYPE_LIMITER"
-					}
-				]
-			},
-			"bonuses" : {
-				"attack" : {
-					"subtype" : "primSkill.attack",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 2 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"defence" : {
-					"subtype" : "primSkill.defence",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 3 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"speed" : {
-					"type" : "STACKS_SPEED",
-					"val" : 1
-				}
-			}
+			"creature" : "imp"
 		}
 	},
 	"octavia":
@@ -200,36 +84,7 @@
 			{ "skill" : "scouting", "level": "basic" }
 		],
 		"specialty" : {
-			"base" : {
-				"limiters" : [
-					{
-						"parameters" : [ "gog", true ],
-						"type" : "CREATURE_TYPE_LIMITER"
-					}
-				]
-			},
-			"bonuses" : {
-				"attack" : {
-					"subtype" : "primSkill.attack",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 6, 2 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"defence" : {
-					"subtype" : "primSkill.defence",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 4, 2 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"speed" : {
-					"type" : "STACKS_SPEED",
-					"val" : 1
-				}
-			}
+			"creature" : "gog"
 		}
 	},
 	"pyre":
@@ -243,36 +98,7 @@
 			{ "skill" : "logistics", "level": "basic" }
 		],
 		"specialty" : {
-			"base" : {
-				"limiters" : [
-					{
-						"parameters" : [ "ballista", true ],
-						"type" : "CREATURE_TYPE_LIMITER"
-					}
-				]
-			},
-			"bonuses" : {
-				"attack" : {
-					"subtype" : "primSkill.attack",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 10, 5 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"defence" : {
-					"subtype" : "primSkill.defence",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 10, 5 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"speed" : {
-					"type" : "STACKS_SPEED",
-					"val" : 1
-				}
-			}
+			"creature" : "ballista"
 		}
 	},
 	"nymus":
@@ -285,36 +111,7 @@
 			{ "skill" : "offence", "level": "advanced" }
 		],
 		"specialty" : {
-			"base" : {
-				"limiters" : [
-					{
-						"parameters" : [ "pitFiend", true ],
-						"type" : "CREATURE_TYPE_LIMITER"
-					}
-				]
-			},
-			"bonuses" : {
-				"attack" : {
-					"subtype" : "primSkill.attack",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 13, 5 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"defence" : {
-					"subtype" : "primSkill.defence",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 13, 5 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"speed" : {
-					"type" : "STACKS_SPEED",
-					"val" : 1
-				}
-			}
+			"creature" : "pitFiend"
 		}
 	},
 	"ayden":

--- a/config/heroes/inferno.json
+++ b/config/heroes/inferno.json
@@ -153,6 +153,7 @@
 				"inferno" : {
 					"subtype" : "spell.inferno",
 					"type" : "SPECIAL_SPELL_LEV",
+                    "updater" : "TIMES_HERO_LEVEL",
 					"val" : 3
 				}
 			}
@@ -283,6 +284,7 @@
 				"fireball" : {
 					"subtype" : "spell.fireball",
 					"type" : "SPECIAL_SPELL_LEV",
+                    "updater" : "TIMES_HERO_LEVEL",
 					"val" : 3
 				}
 			}

--- a/config/heroes/inferno.json
+++ b/config/heroes/inferno.json
@@ -153,7 +153,7 @@
 				"inferno" : {
 					"subtype" : "spell.inferno",
 					"type" : "SPECIAL_SPELL_LEV",
-                    "updater" : "TIMES_HERO_LEVEL",
+					"updater" : "TIMES_HERO_LEVEL",
 					"val" : 3
 				}
 			}
@@ -284,7 +284,7 @@
 				"fireball" : {
 					"subtype" : "spell.fireball",
 					"type" : "SPECIAL_SPELL_LEV",
-                    "updater" : "TIMES_HERO_LEVEL",
+					"updater" : "TIMES_HERO_LEVEL",
 					"val" : 3
 				}
 			}

--- a/config/heroes/inferno.json
+++ b/config/heroes/inferno.json
@@ -203,7 +203,7 @@
 			"base" : {
 				"limiters" : [
 					{
-						"parameters" : [ "imp", true ],
+						"parameters" : [ "gog", true ],
 						"type" : "CREATURE_TYPE_LIMITER"
 					}
 				]
@@ -213,7 +213,7 @@
 					"subtype" : "primSkill.attack",
 					"type" : "PRIMARY_SKILL",
 					"updater" : {
-						"parameters" : [ 2 ],
+						"parameters" : [ 6, 2 ],
 						"type" : "GROWS_WITH_LEVEL"
 					}
 				},
@@ -221,7 +221,7 @@
 					"subtype" : "primSkill.defence",
 					"type" : "PRIMARY_SKILL",
 					"updater" : {
-						"parameters" : [ 3 ],
+						"parameters" : [ 4, 2 ],
 						"type" : "GROWS_WITH_LEVEL"
 					}
 				},

--- a/config/heroes/necropolis.json
+++ b/config/heroes/necropolis.json
@@ -234,10 +234,8 @@
 				"necromancy" : {
 					"subtype" : "skill.necromancy",
 					"type" : "SECONDARY_SKILL_PREMY",
-					"updater" : {
-						"parameters" : [ 100 ],
-						"type" : "GROWS_WITH_LEVEL"
-					},
+					"updater" : "TIMES_HERO_LEVEL",
+					"val" : 5,
 					"valueType" : "PERCENT_TO_BASE"
 				}
 			}
@@ -366,10 +364,8 @@
 				"sorcery" : {
 					"subtype" : "skill.sorcery",
 					"type" : "SECONDARY_SKILL_PREMY",
-					"updater" : {
-						"parameters" : [ 100 ],
-						"type" : "GROWS_WITH_LEVEL"
-					},
+					"updater" : "TIMES_HERO_LEVEL",
+					"val" : 5,
 					"valueType" : "PERCENT_TO_BASE"
 				}
 			}
@@ -391,10 +387,8 @@
 				"eagleEye" : {
 					"subtype" : "skill.eagleEye",
 					"type" : "SECONDARY_SKILL_PREMY",
-					"updater" : {
-						"parameters" : [ 100 ],
-						"type" : "GROWS_WITH_LEVEL"
-					},
+					"updater" : "TIMES_HERO_LEVEL",
+					"val" : 5,
 					"valueType" : "PERCENT_TO_BASE"
 				}
 			}
@@ -457,10 +451,8 @@
 				"necromancy" : {
 					"subtype" : "skill.necromancy",
 					"type" : "SECONDARY_SKILL_PREMY",
-					"updater" : {
-						"parameters" : [ 100 ],
-						"type" : "GROWS_WITH_LEVEL"
-					},
+					"updater" : "TIMES_HERO_LEVEL",
+					"val" : 5,
 					"valueType" : "PERCENT_TO_BASE"
 				}
 			}

--- a/config/heroes/necropolis.json
+++ b/config/heroes/necropolis.json
@@ -148,7 +148,7 @@
 				"deathRipple" : {
 					"subtype" : "spell.deathRipple",
 					"type" : "SPECIAL_SPELL_LEV",
-                    "updater" : "TIMES_HERO_LEVEL",
+					"updater" : "TIMES_HERO_LEVEL",
 					"val" : 3
 				}
 			}
@@ -170,7 +170,7 @@
 				"meteorShower" : {
 					"subtype" : "spell.meteorShower",
 					"type" : "SPECIAL_SPELL_LEV",
-                    "updater" : "TIMES_HERO_LEVEL",
+					"updater" : "TIMES_HERO_LEVEL",
 					"val" : 3
 				}
 			}
@@ -238,7 +238,7 @@
 				"animateDead" : {
 					"subtype" : "spell.animateDead",
 					"type" : "SPECIAL_SPELL_LEV",
-                    "updater" : "TIMES_HERO_LEVEL",
+					"updater" : "TIMES_HERO_LEVEL",
 					"val" : 3
 				}
 			}

--- a/config/heroes/necropolis.json
+++ b/config/heroes/necropolis.json
@@ -11,36 +11,7 @@
 			{ "skill" : "resistance", "level": "basic" }
 		],
 		"specialty" : {
-			"base" : {
-				"limiters" : [
-					{
-						"parameters" : [ "walkingDead", true ],
-						"type" : "CREATURE_TYPE_LIMITER"
-					}
-				]
-			},
-			"bonuses" : {
-				"attack" : {
-					"subtype" : "primSkill.attack",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 5, 2 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"defence" : {
-					"subtype" : "primSkill.defence",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 5, 2 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"speed" : {
-					"type" : "STACKS_SPEED",
-					"val" : 1
-				}
-			}
+			"creature" : "walkingDead"
 		}
 	},
 	"vokial":
@@ -55,36 +26,7 @@
 			{ "skill" : "artillery", "level": "basic" }
 		],
 		"specialty" : {
-			"base" : {
-				"limiters" : [
-					{
-						"parameters" : [ "vampire", true ],
-						"type" : "CREATURE_TYPE_LIMITER"
-					}
-				]
-			},
-			"bonuses" : {
-				"attack" : {
-					"subtype" : "primSkill.attack",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 10, 4 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"defence" : {
-					"subtype" : "primSkill.defence",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 9, 4 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"speed" : {
-					"type" : "STACKS_SPEED",
-					"val" : 1
-				}
-			}
+			"creature" : "vampire"
 		}
 	},
 	"moandor":
@@ -99,36 +41,7 @@
 			{ "skill" : "learning", "level": "basic" }
 		],
 		"specialty" : {
-			"base" : {
-				"limiters" : [
-					{
-						"parameters" : [ "lich", true ],
-						"type" : "CREATURE_TYPE_LIMITER"
-					}
-				]
-			},
-			"bonuses" : {
-				"attack" : {
-					"subtype" : "primSkill.attack",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 13, 5 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"defence" : {
-					"subtype" : "primSkill.defence",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 10, 5 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"speed" : {
-					"type" : "STACKS_SPEED",
-					"val" : 1
-				}
-			}
+			"creature" : "lich"
 		}
 	},
 	"charna":
@@ -143,36 +56,7 @@
 			{ "skill" : "tactics", "level": "basic" }
 		],
 		"specialty" : {
-			"base" : {
-				"limiters" : [
-					{
-						"parameters" : [ "wight", true ],
-						"type" : "CREATURE_TYPE_LIMITER"
-					}
-				]
-			},
-			"bonuses" : {
-				"attack" : {
-					"subtype" : "primSkill.attack",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 7, 3 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"defence" : {
-					"subtype" : "primSkill.defence",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 7, 3 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"speed" : {
-					"type" : "STACKS_SPEED",
-					"val" : 1
-				}
-			}
+			"creature" : "wight"
 		}
 	},
 	"tamika":
@@ -187,36 +71,7 @@
 			{ "skill" : "offence", "level": "basic" }
 		],
 		"specialty" : {
-			"base" : {
-				"limiters" : [
-					{
-						"parameters" : [ "blackKnight", true ],
-						"type" : "CREATURE_TYPE_LIMITER"
-					}
-				]
-			},
-			"bonuses" : {
-				"attack" : {
-					"subtype" : "primSkill.attack",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 16, 6 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"defence" : {
-					"subtype" : "primSkill.defence",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 16, 6 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"speed" : {
-					"type" : "STACKS_SPEED",
-					"val" : 1
-				}
-			}
+			"creature" : "blackKnight"
 		}
 	},
 	"isra":
@@ -274,36 +129,7 @@
 			{ "skill" : "armorer", "level": "basic" }
 		],
 		"specialty" : {
-			"base" : {
-				"limiters" : [
-					{
-						"parameters" : [ "skeleton", true ],
-						"type" : "CREATURE_TYPE_LIMITER"
-					}
-				]
-			},
-			"bonuses" : {
-				"attack" : {
-					"subtype" : "primSkill.attack",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 5 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"defence" : {
-					"subtype" : "primSkill.defence",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 4 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"speed" : {
-					"type" : "STACKS_SPEED",
-					"val" : 1
-				}
-			}
+			"creature" : "skeleton"
 		}
 	},
 	"septienna":

--- a/config/heroes/necropolis.json
+++ b/config/heroes/necropolis.json
@@ -10,10 +10,38 @@
 			{ "skill" : "necromancy", "level": "basic" },
 			{ "skill" : "resistance", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":1, "val": 0, "subtype": 0, "info": 58 }
-		]
+		"specialty" : {
+			"base" : {
+				"limiters" : [
+					{
+						"parameters" : [ "walkingDead", true ],
+						"type" : "CREATURE_TYPE_LIMITER"
+					}
+				]
+			},
+			"bonuses" : {
+				"attack" : {
+					"subtype" : "primSkill.attack",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 5, 2 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"defence" : {
+					"subtype" : "primSkill.defence",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 5, 2 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"speed" : {
+					"type" : "STACKS_SPEED",
+					"val" : 1
+				}
+			}
+		}
 	},
 	"vokial":
 	{
@@ -26,10 +54,38 @@
 			{ "skill" : "necromancy", "level": "basic" },
 			{ "skill" : "artillery", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":1, "val": 0, "subtype": 0, "info": 62 }
-		]
+		"specialty" : {
+			"base" : {
+				"limiters" : [
+					{
+						"parameters" : [ "vampire", true ],
+						"type" : "CREATURE_TYPE_LIMITER"
+					}
+				]
+			},
+			"bonuses" : {
+				"attack" : {
+					"subtype" : "primSkill.attack",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 10, 4 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"defence" : {
+					"subtype" : "primSkill.defence",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 9, 4 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"speed" : {
+					"type" : "STACKS_SPEED",
+					"val" : 1
+				}
+			}
+		}
 	},
 	"moandor":
 	{
@@ -42,10 +98,38 @@
 			{ "skill" : "necromancy", "level": "basic" },
 			{ "skill" : "learning", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":1, "val": 0, "subtype": 0, "info": 64 }
-		]
+		"specialty" : {
+			"base" : {
+				"limiters" : [
+					{
+						"parameters" : [ "lich", true ],
+						"type" : "CREATURE_TYPE_LIMITER"
+					}
+				]
+			},
+			"bonuses" : {
+				"attack" : {
+					"subtype" : "primSkill.attack",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 13, 5 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"defence" : {
+					"subtype" : "primSkill.defence",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 10, 5 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"speed" : {
+					"type" : "STACKS_SPEED",
+					"val" : 1
+				}
+			}
+		}
 	},
 	"charna":
 	{
@@ -58,10 +142,38 @@
 			{ "skill" : "necromancy", "level": "basic" },
 			{ "skill" : "tactics", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":1, "val": 0, "subtype": 0, "info": 60 }
-		]
+		"specialty" : {
+			"base" : {
+				"limiters" : [
+					{
+						"parameters" : [ "wight", true ],
+						"type" : "CREATURE_TYPE_LIMITER"
+					}
+				]
+			},
+			"bonuses" : {
+				"attack" : {
+					"subtype" : "primSkill.attack",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 7, 3 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"defence" : {
+					"subtype" : "primSkill.defence",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 7, 3 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"speed" : {
+					"type" : "STACKS_SPEED",
+					"val" : 1
+				}
+			}
+		}
 	},
 	"tamika":
 	{
@@ -74,10 +186,38 @@
 			{ "skill" : "necromancy", "level": "basic" },
 			{ "skill" : "offence", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":1, "val": 0, "subtype": 0, "info": 66 }
-		]
+		"specialty" : {
+			"base" : {
+				"limiters" : [
+					{
+						"parameters" : [ "blackKnight", true ],
+						"type" : "CREATURE_TYPE_LIMITER"
+					}
+				]
+			},
+			"bonuses" : {
+				"attack" : {
+					"subtype" : "primSkill.attack",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 16, 6 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"defence" : {
+					"subtype" : "primSkill.defence",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 16, 6 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"speed" : {
+					"type" : "STACKS_SPEED",
+					"val" : 1
+				}
+			}
+		}
 	},
 	"isra":
 	{
@@ -89,10 +229,19 @@
 		[
 			{ "skill" : "necromancy", "level": "advanced" }
 		],
-		"specialties":
-		[
-			{ "type":2, "val": 5, "subtype": 12, "info": 0 }
-		]
+		"specialty" : {
+			"bonuses" : {
+				"necromancy" : {
+					"subtype" : "skill.necromancy",
+					"type" : "SECONDARY_SKILL_PREMY",
+					"updater" : {
+						"parameters" : [ 100 ],
+						"type" : "GROWS_WITH_LEVEL"
+					},
+					"valueType" : "PERCENT_TO_BASE"
+				}
+			}
+		}
 	},
 	"clavius":
 	{
@@ -105,10 +254,15 @@
 			{ "skill" : "necromancy", "level": "basic" },
 			{ "skill" : "offence", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":10, "val": 350, "subtype": 6, "info": 0 }
-		]
+		"specialty" : {
+			"bonuses" : {
+				"gold" : {
+					"subtype" : "resource.gold",
+					"type" : "GENERATE_RESOURCE",
+					"val" : 350
+				}
+			}
+		}
 	},
 	"galthran":
 	{
@@ -121,10 +275,38 @@
 			{ "skill" : "necromancy", "level": "basic" },
 			{ "skill" : "armorer", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":1, "val": 0, "subtype": 0, "info": 56 }
-		]
+		"specialty" : {
+			"base" : {
+				"limiters" : [
+					{
+						"parameters" : [ "skeleton", true ],
+						"type" : "CREATURE_TYPE_LIMITER"
+					}
+				]
+			},
+			"bonuses" : {
+				"attack" : {
+					"subtype" : "primSkill.attack",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 5 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"defence" : {
+					"subtype" : "primSkill.defence",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 4 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"speed" : {
+					"type" : "STACKS_SPEED",
+					"val" : 1
+				}
+			}
+		}
 	},
 	"septienna":
 	{
@@ -137,10 +319,15 @@
 			{ "skill" : "necromancy", "level": "basic" },
 			{ "skill" : "scholar", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":3, "val": 3, "subtype": 24, "info": 0 }
-		]
+		"specialty" : {
+			"bonuses" : {
+				"deathRipple" : {
+					"subtype" : "spell.deathRipple",
+					"type" : "SPECIAL_SPELL_LEV",
+					"val" : 3
+				}
+			}
+		}
 	},
 	"aislinn":
 	{
@@ -153,10 +340,15 @@
 			{ "skill" : "necromancy", "level": "basic" },
 			{ "skill" : "wisdom", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":3, "val": 3, "subtype": 23, "info": 0 }
-		]
+		"specialty" : {
+			"bonuses" : {
+				"meteorShower" : {
+					"subtype" : "spell.meteorShower",
+					"type" : "SPECIAL_SPELL_LEV",
+					"val" : 3
+				}
+			}
+		}
 	},
 	"sandro":
 	{
@@ -169,10 +361,19 @@
 			{ "skill" : "necromancy", "level": "basic" },
 			{ "skill" : "sorcery", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":2, "val": 5, "subtype": 25, "info": 0 }
-		]
+		"specialty" : {
+			"bonuses" : {
+				"sorcery" : {
+					"subtype" : "skill.sorcery",
+					"type" : "SECONDARY_SKILL_PREMY",
+					"updater" : {
+						"parameters" : [ 100 ],
+						"type" : "GROWS_WITH_LEVEL"
+					},
+					"valueType" : "PERCENT_TO_BASE"
+				}
+			}
+		}
 	},
 	"nimbus":
 	{
@@ -185,10 +386,19 @@
 			{ "skill" : "necromancy", "level": "basic" },
 			{ "skill" : "eagleEye", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":2, "val": 5, "subtype": 11, "info": 1 }
-		]
+		"specialty" : {
+			"bonuses" : {
+				"eagleEye" : {
+					"subtype" : "skill.eagleEye",
+					"type" : "SECONDARY_SKILL_PREMY",
+					"updater" : {
+						"parameters" : [ 100 ],
+						"type" : "GROWS_WITH_LEVEL"
+					},
+					"valueType" : "PERCENT_TO_BASE"
+				}
+			}
+		}
 	},
 	"thant":
 	{
@@ -201,10 +411,15 @@
 			{ "skill" : "necromancy", "level": "basic" },
 			{ "skill" : "mysticism", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":3, "val": 39, "subtype": 0, "info": 3 }
-		]
+		"specialty" : {
+			"bonuses" : {
+				"summonBoat" : {
+					"subtype" : "spell.summonBoat",
+					"type" : "SPECIAL_SPELL_LEV",
+					"val" : 39
+				}
+			}
+		}
 	},
 	"xsi":
 	{
@@ -217,10 +432,15 @@
 			{ "skill" : "necromancy", "level": "basic" },
 			{ "skill" : "learning", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":8, "val": 0, "subtype": 46, "info": 0 }
-		]
+		"specialty" : {
+			"bonuses" : {
+				"stoneSkin" : {
+					"addInfo" : 0,
+					"subtype" : "spell.stoneSkin",
+					"type" : "SPECIAL_PECULIAR_ENCHANT"
+				}
+			}
+		}
 	},
 	"vidomina":
 	{
@@ -232,10 +452,19 @@
 		[
 			{ "skill" : "necromancy", "level": "advanced" }
 		],
-		"specialties":
-		[
-			{ "type":2, "val": 5, "subtype": 12, "info": 0 }
-		]
+		"specialty" : {
+			"bonuses" : {
+				"necromancy" : {
+					"subtype" : "skill.necromancy",
+					"type" : "SECONDARY_SKILL_PREMY",
+					"updater" : {
+						"parameters" : [ 100 ],
+						"type" : "GROWS_WITH_LEVEL"
+					},
+					"valueType" : "PERCENT_TO_BASE"
+				}
+			}
+		}
 	},
 	"nagash":
 	{
@@ -248,9 +477,14 @@
 			{ "skill" : "necromancy", "level": "basic" },
 			{ "skill" : "intelligence", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":10, "val": 350, "subtype": 6, "info": 0 }
-		]
+		"specialty" : {
+			"bonuses" : {
+				"gold" : {
+					"subtype" : "resource.gold",
+					"type" : "GENERATE_RESOURCE",
+					"val" : 350
+				}
+			}
+		}
 	}
 }

--- a/config/heroes/necropolis.json
+++ b/config/heroes/necropolis.json
@@ -413,10 +413,10 @@
 		],
 		"specialty" : {
 			"bonuses" : {
-				"summonBoat" : {
-					"subtype" : "spell.summonBoat",
+				"animateDead" : {
+					"subtype" : "spell.animateDead",
 					"type" : "SPECIAL_SPELL_LEV",
-					"val" : 39
+					"val" : 3
 				}
 			}
 		}

--- a/config/heroes/necropolis.json
+++ b/config/heroes/necropolis.json
@@ -148,6 +148,7 @@
 				"deathRipple" : {
 					"subtype" : "spell.deathRipple",
 					"type" : "SPECIAL_SPELL_LEV",
+                    "updater" : "TIMES_HERO_LEVEL",
 					"val" : 3
 				}
 			}
@@ -169,6 +170,7 @@
 				"meteorShower" : {
 					"subtype" : "spell.meteorShower",
 					"type" : "SPECIAL_SPELL_LEV",
+                    "updater" : "TIMES_HERO_LEVEL",
 					"val" : 3
 				}
 			}
@@ -236,6 +238,7 @@
 				"animateDead" : {
 					"subtype" : "spell.animateDead",
 					"type" : "SPECIAL_SPELL_LEV",
+                    "updater" : "TIMES_HERO_LEVEL",
 					"val" : 3
 				}
 			}

--- a/config/heroes/rampart.json
+++ b/config/heroes/rampart.json
@@ -32,36 +32,7 @@
 			{ "skill" : "resistance", "level": "basic" }
 		],
 		"specialty" : {
-			"base" : {
-				"limiters" : [
-					{
-						"parameters" : [ "dwarf", true ],
-						"type" : "CREATURE_TYPE_LIMITER"
-					}
-				]
-			},
-			"bonuses" : {
-				"attack" : {
-					"subtype" : "primSkill.attack",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 6, 2 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"defence" : {
-					"subtype" : "primSkill.defence",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 7, 2 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"speed" : {
-					"type" : "STACKS_SPEED",
-					"val" : 1
-				}
-			}
+			"creature" : "dwarf"
 		}
 	},
 	"jenova":
@@ -94,36 +65,7 @@
 			{ "skill" : "leadership", "level": "basic" }
 		],
 		"specialty" : {
-			"base" : {
-				"limiters" : [
-					{
-						"parameters" : [ "dendroidGuard", true ],
-						"type" : "CREATURE_TYPE_LIMITER"
-					}
-				]
-			},
-			"bonuses" : {
-				"attack" : {
-					"subtype" : "primSkill.attack",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 9, 5 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"defence" : {
-					"subtype" : "primSkill.defence",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 12, 5 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"speed" : {
-					"type" : "STACKS_SPEED",
-					"val" : 1
-				}
-			}
+			"creature" : "dendroidGuard"
 		}
 	},
 	"thorgrim":
@@ -158,36 +100,7 @@
 			{ "skill" : "offence", "level": "basic" }
 		],
 		"specialty" : {
-			"base" : {
-				"limiters" : [
-					{
-						"parameters" : [ "woodElf", true ],
-						"type" : "CREATURE_TYPE_LIMITER"
-					}
-				]
-			},
-			"bonuses" : {
-				"attack" : {
-					"subtype" : "primSkill.attack",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 9, 3 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"defence" : {
-					"subtype" : "primSkill.defence",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 5, 3 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"speed" : {
-					"type" : "STACKS_SPEED",
-					"val" : 1
-				}
-			}
+			"creature" : "woodElf"
 		}
 	},
 	"clancy":
@@ -201,36 +114,7 @@
 			{ "skill" : "resistance", "level": "basic" }
 		],
 		"specialty" : {
-			"base" : {
-				"limiters" : [
-					{
-						"parameters" : [ "unicorn", true ],
-						"type" : "CREATURE_TYPE_LIMITER"
-					}
-				]
-			},
-			"bonuses" : {
-				"attack" : {
-					"subtype" : "primSkill.attack",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 15, 6 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"defence" : {
-					"subtype" : "primSkill.defence",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 14, 6 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"speed" : {
-					"type" : "STACKS_SPEED",
-					"val" : 1
-				}
-			}
+			"creature" : "unicorn"
 		}
 	},
 	"kyrre":
@@ -419,36 +303,7 @@
 			{ "skill" : "scouting", "level": "basic" }
 		],
 		"specialty" : {
-			"base" : {
-				"limiters" : [
-					{
-						"parameters" : [ "pegasus", true ],
-						"type" : "CREATURE_TYPE_LIMITER"
-					}
-				]
-			},
-			"bonuses" : {
-				"attack" : {
-					"subtype" : "primSkill.attack",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 9, 4 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"defence" : {
-					"subtype" : "primSkill.defence",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 8, 4 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"speed" : {
-					"type" : "STACKS_SPEED",
-					"val" : 1
-				}
-			}
+			"creature" : "pegasus"
 		}
 	}
 }

--- a/config/heroes/rampart.json
+++ b/config/heroes/rampart.json
@@ -14,10 +14,8 @@
 				"armorer" : {
 					"subtype" : "skill.armorer",
 					"type" : "SECONDARY_SKILL_PREMY",
-					"updater" : {
-						"parameters" : [ 100 ],
-						"type" : "GROWS_WITH_LEVEL"
-					},
+					"updater" : "TIMES_HERO_LEVEL",
+					"val" : 5,
 					"valueType" : "PERCENT_TO_BASE"
 				}
 			}
@@ -142,10 +140,8 @@
 				"resistance" : {
 					"subtype" : "skill.resistance",
 					"type" : "SECONDARY_SKILL_PREMY",
-					"updater" : {
-						"parameters" : [ 100 ],
-						"type" : "GROWS_WITH_LEVEL"
-					},
+					"updater" : "TIMES_HERO_LEVEL",
+					"val" : 5,
 					"valueType" : "PERCENT_TO_BASE"
 				}
 			}
@@ -252,10 +248,8 @@
 				"logistics" : {
 					"subtype" : "skill.logistics",
 					"type" : "SECONDARY_SKILL_PREMY",
-					"updater" : {
-						"parameters" : [ 100 ],
-						"type" : "GROWS_WITH_LEVEL"
-					},
+					"updater" : "TIMES_HERO_LEVEL",
+					"val" : 5,
 					"valueType" : "PERCENT_TO_BASE"
 				}
 			}
@@ -319,10 +313,8 @@
 				"intelligence" : {
 					"subtype" : "skill.intelligence",
 					"type" : "SECONDARY_SKILL_PREMY",
-					"updater" : {
-						"parameters" : [ 100 ],
-						"type" : "GROWS_WITH_LEVEL"
-					},
+					"updater" : "TIMES_HERO_LEVEL",
+					"val" : 5,
 					"valueType" : "PERCENT_TO_BASE"
 				}
 			}
@@ -344,10 +336,8 @@
 				"firstAid" : {
 					"subtype" : "skill.firstAid",
 					"type" : "SECONDARY_SKILL_PREMY",
-					"updater" : {
-						"parameters" : [ 100 ],
-						"type" : "GROWS_WITH_LEVEL"
-					},
+					"updater" : "TIMES_HERO_LEVEL",
+					"val" : 5,
 					"valueType" : "PERCENT_TO_BASE"
 				}
 			}
@@ -369,10 +359,8 @@
 				"eagleEye" : {
 					"subtype" : "skill.eagleEye",
 					"type" : "SECONDARY_SKILL_PREMY",
-					"updater" : {
-						"parameters" : [ 100 ],
-						"type" : "GROWS_WITH_LEVEL"
-					},
+					"updater" : "TIMES_HERO_LEVEL",
+					"val" : 5,
 					"valueType" : "PERCENT_TO_BASE"
 				}
 			}

--- a/config/heroes/rampart.json
+++ b/config/heroes/rampart.json
@@ -176,7 +176,7 @@
 				"cure" : {
 					"subtype" : "spell.cure",
 					"type" : "SPECIAL_SPELL_LEV",
-                    "updater" : "TIMES_HERO_LEVEL",
+					"updater" : "TIMES_HERO_LEVEL",
 					"val" : 3
 				}
 			}
@@ -287,7 +287,7 @@
 				"iceBolt" : {
 					"subtype" : "spell.iceBolt",
 					"type" : "SPECIAL_SPELL_LEV",
-                    "updater" : "TIMES_HERO_LEVEL",
+					"updater" : "TIMES_HERO_LEVEL",
 					"val" : 3
 				}
 			}

--- a/config/heroes/rampart.json
+++ b/config/heroes/rampart.json
@@ -9,10 +9,19 @@
 			{ "skill" : "leadership", "level": "basic" },
 			{ "skill" : "armorer", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":2, "val": 5, "subtype": 23, "info": 0 }
-		]
+		"specialty" : {
+			"bonuses" : {
+				"armorer" : {
+					"subtype" : "skill.armorer",
+					"type" : "SECONDARY_SKILL_PREMY",
+					"updater" : {
+						"parameters" : [ 100 ],
+						"type" : "GROWS_WITH_LEVEL"
+					},
+					"valueType" : "PERCENT_TO_BASE"
+				}
+			}
+		}
 	},
 	"ufretin":
 	{
@@ -24,10 +33,38 @@
 			{ "skill" : "luck", "level": "basic" },
 			{ "skill" : "resistance", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":1, "val": 0, "subtype": 0, "info": 16 }
-		]
+		"specialty" : {
+			"base" : {
+				"limiters" : [
+					{
+						"parameters" : [ "dwarf", true ],
+						"type" : "CREATURE_TYPE_LIMITER"
+					}
+				]
+			},
+			"bonuses" : {
+				"attack" : {
+					"subtype" : "primSkill.attack",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 6, 2 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"defence" : {
+					"subtype" : "primSkill.defence",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 7, 2 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"speed" : {
+					"type" : "STACKS_SPEED",
+					"val" : 1
+				}
+			}
+		}
 	},
 	"jenova":
 	{
@@ -38,10 +75,15 @@
 		[
 			{ "skill" : "archery", "level": "advanced" }
 		],
-		"specialties":
-		[
-			{ "type":10, "val": 350, "subtype": 6, "info": 0 }
-		]
+		"specialty" : {
+			"bonuses" : {
+				"gold" : {
+					"subtype" : "resource.gold",
+					"type" : "GENERATE_RESOURCE",
+					"val" : 350
+				}
+			}
+		}
 	},
 	"ryland":
 	{
@@ -53,10 +95,38 @@
 			{ "skill" : "diplomacy", "level": "basic" },
 			{ "skill" : "leadership", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":1, "val": 0, "subtype": 0, "info": 22 }
-		]
+		"specialty" : {
+			"base" : {
+				"limiters" : [
+					{
+						"parameters" : [ "dendroidGuard", true ],
+						"type" : "CREATURE_TYPE_LIMITER"
+					}
+				]
+			},
+			"bonuses" : {
+				"attack" : {
+					"subtype" : "primSkill.attack",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 9, 5 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"defence" : {
+					"subtype" : "primSkill.defence",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 12, 5 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"speed" : {
+					"type" : "STACKS_SPEED",
+					"val" : 1
+				}
+			}
+		}
 	},
 	"thorgrim":
 	{
@@ -67,10 +137,19 @@
 		[
 			{ "skill" : "resistance", "level": "advanced" }
 		],
-		"specialties":
-		[
-			{ "type":2, "val": 5, "subtype": 26, "info": 0 }
-		]
+		"specialty" : {
+			"bonuses" : {
+				"resistance" : {
+					"subtype" : "skill.resistance",
+					"type" : "SECONDARY_SKILL_PREMY",
+					"updater" : {
+						"parameters" : [ 100 ],
+						"type" : "GROWS_WITH_LEVEL"
+					},
+					"valueType" : "PERCENT_TO_BASE"
+				}
+			}
+		}
 	},
 	"ivor":
 	{
@@ -82,10 +161,38 @@
 			{ "skill" : "archery", "level": "basic" },
 			{ "skill" : "offence", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":1, "val": 0, "subtype": 0, "info": 18 }
-		]
+		"specialty" : {
+			"base" : {
+				"limiters" : [
+					{
+						"parameters" : [ "woodElf", true ],
+						"type" : "CREATURE_TYPE_LIMITER"
+					}
+				]
+			},
+			"bonuses" : {
+				"attack" : {
+					"subtype" : "primSkill.attack",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 9, 3 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"defence" : {
+					"subtype" : "primSkill.defence",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 5, 3 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"speed" : {
+					"type" : "STACKS_SPEED",
+					"val" : 1
+				}
+			}
+		}
 	},
 	"clancy":
 	{
@@ -97,10 +204,38 @@
 			{ "skill" : "pathfinding", "level": "basic" },
 			{ "skill" : "resistance", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":1, "val": 0, "subtype": 0, "info": 24 }
-		]
+		"specialty" : {
+			"base" : {
+				"limiters" : [
+					{
+						"parameters" : [ "unicorn", true ],
+						"type" : "CREATURE_TYPE_LIMITER"
+					}
+				]
+			},
+			"bonuses" : {
+				"attack" : {
+					"subtype" : "primSkill.attack",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 15, 6 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"defence" : {
+					"subtype" : "primSkill.defence",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 14, 6 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"speed" : {
+					"type" : "STACKS_SPEED",
+					"val" : 1
+				}
+			}
+		}
 	},
 	"kyrre":
 	{
@@ -112,10 +247,19 @@
 			{ "skill" : "archery", "level": "basic" },
 			{ "skill" : "logistics", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":2, "val": 5, "subtype": 2, "info": 0 }
-		]
+		"specialty" : {
+			"bonuses" : {
+				"logistics" : {
+					"subtype" : "skill.logistics",
+					"type" : "SECONDARY_SKILL_PREMY",
+					"updater" : {
+						"parameters" : [ 100 ],
+						"type" : "GROWS_WITH_LEVEL"
+					},
+					"valueType" : "PERCENT_TO_BASE"
+				}
+			}
+		}
 	},
 	"coronius":
 	{
@@ -128,10 +272,15 @@
 			{ "skill" : "wisdom", "level": "basic" },
 			{ "skill" : "scholar", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":8, "val": 0, "subtype": 55, "info": 1 }
-		]
+		"specialty" : {
+			"bonuses" : {
+				"slayer" : {
+					"addInfo" : 1,
+					"subtype" : "spell.slayer",
+					"type" : "SPECIAL_PECULIAR_ENCHANT"
+				}
+			}
+		}
 	},
 	"uland":
 	{
@@ -144,10 +293,15 @@
 			{ "skill" : "wisdom", "level": "advanced" },
 			{ "skill" : "ballistics", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":3, "val": 3, "subtype": 37, "info": 0 }
-		]
+		"specialty" : {
+			"bonuses" : {
+				"cure" : {
+					"subtype" : "spell.cure",
+					"type" : "SPECIAL_SPELL_LEV",
+					"val" : 3
+				}
+			}
+		}
 	},
 	"elleshar":
 	{
@@ -160,10 +314,19 @@
 			{ "skill" : "wisdom", "level": "basic" },
 			{ "skill" : "intelligence", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":2, "val": 5, "subtype": 24, "info": 0 }
-		]
+		"specialty" : {
+			"bonuses" : {
+				"intelligence" : {
+					"subtype" : "skill.intelligence",
+					"type" : "SECONDARY_SKILL_PREMY",
+					"updater" : {
+						"parameters" : [ 100 ],
+						"type" : "GROWS_WITH_LEVEL"
+					},
+					"valueType" : "PERCENT_TO_BASE"
+				}
+			}
+		}
 	},
 	"gem":
 	{
@@ -176,10 +339,19 @@
 			{ "skill" : "wisdom", "level": "basic" },
 			{ "skill" : "firstAid", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":2, "val": 5, "subtype": 27, "info": 0 }
-		]
+		"specialty" : {
+			"bonuses" : {
+				"firstAid" : {
+					"subtype" : "skill.firstAid",
+					"type" : "SECONDARY_SKILL_PREMY",
+					"updater" : {
+						"parameters" : [ 100 ],
+						"type" : "GROWS_WITH_LEVEL"
+					},
+					"valueType" : "PERCENT_TO_BASE"
+				}
+			}
+		}
 	},
 	"malcom":
 	{
@@ -192,10 +364,19 @@
 			{ "skill" : "wisdom", "level": "basic" },
 			{ "skill" : "eagleEye", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":2, "val": 5, "subtype": 11, "info": 0 }
-		]
+		"specialty" : {
+			"bonuses" : {
+				"eagleEye" : {
+					"subtype" : "skill.eagleEye",
+					"type" : "SECONDARY_SKILL_PREMY",
+					"updater" : {
+						"parameters" : [ 100 ],
+						"type" : "GROWS_WITH_LEVEL"
+					},
+					"valueType" : "PERCENT_TO_BASE"
+				}
+			}
+		}
 	},
 	"melodia":
 	{
@@ -208,10 +389,14 @@
 			{ "skill" : "wisdom", "level": "basic" },
 			{ "skill" : "luck", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":7, "val": 0, "subtype": 51, "info": 0 }
-		]
+		"specialty" : {
+			"bonuses" : {
+				"fortune" : {
+					"subtype" : "spell.fortune",
+					"type" : "MAXED_SPELL"
+				}
+			}
+		}
 	},
 	"alagar":
 	{
@@ -224,10 +409,15 @@
 			{ "skill" : "wisdom", "level": "basic" },
 			{ "skill" : "sorcery", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":3, "val": 3, "subtype": 16, "info": 0 }
-		]
+		"specialty" : {
+			"bonuses" : {
+				"iceBolt" : {
+					"subtype" : "spell.iceBolt",
+					"type" : "SPECIAL_SPELL_LEV",
+					"val" : 3
+				}
+			}
+		}
 	},
 	"aeris":
 	{
@@ -240,9 +430,37 @@
 			{ "skill" : "wisdom", "level": "basic" },
 			{ "skill" : "scouting", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":1, "val": 0, "subtype": 0, "info": 20 }
-		]
+		"specialty" : {
+			"base" : {
+				"limiters" : [
+					{
+						"parameters" : [ "pegasus", true ],
+						"type" : "CREATURE_TYPE_LIMITER"
+					}
+				]
+			},
+			"bonuses" : {
+				"attack" : {
+					"subtype" : "primSkill.attack",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 9, 4 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"defence" : {
+					"subtype" : "primSkill.defence",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 8, 4 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"speed" : {
+					"type" : "STACKS_SPEED",
+					"val" : 1
+				}
+			}
+		}
 	}
 }

--- a/config/heroes/rampart.json
+++ b/config/heroes/rampart.json
@@ -176,6 +176,7 @@
 				"cure" : {
 					"subtype" : "spell.cure",
 					"type" : "SPECIAL_SPELL_LEV",
+                    "updater" : "TIMES_HERO_LEVEL",
 					"val" : 3
 				}
 			}
@@ -286,6 +287,7 @@
 				"iceBolt" : {
 					"subtype" : "spell.iceBolt",
 					"type" : "SPECIAL_SPELL_LEV",
+                    "updater" : "TIMES_HERO_LEVEL",
 					"val" : 3
 				}
 			}

--- a/config/heroes/special.json
+++ b/config/heroes/special.json
@@ -10,10 +10,14 @@
 		[
 			{ "skill" : "leadership", "level": "advanced" }
 		],
-		"specialties":
-		[
-			{ "type":12, "val": 2, "subtype": 0, "info": 0 }
-		]
+		"specialty" : {
+			"bonuses" : {
+				"speed" : {
+					"type" : "STACKS_SPEED",
+					"val" : 2
+				}
+			}
+		}
 	},
 	"adrienne":
 	{
@@ -25,11 +29,9 @@
 		"skills":
 		[
 			{ "skill" : "wisdom", "level": "basic" },
-			{ "skill" : "fireMagic", "level": "expert" } ],
-		"specialties":
-		[
-			{ "type":11, "val": 14, "subtype": 0, "info": 3 }
-		]
+			{ "skill" : "fireMagic", "level": "expert" }
+		],
+		"specialty" : { "bonuses" : {  } }
 	},
 	"catherine":
 	{
@@ -42,10 +44,38 @@
 			{ "skill" : "leadership", "level": "basic" },
 			{ "skill" : "offence", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":1, "val": 0, "subtype": 0, "info": 4 }
-		]
+		"specialty" : {
+			"base" : {
+				"limiters" : [
+					{
+						"parameters" : [ "griffin", true ],
+						"type" : "CREATURE_TYPE_LIMITER"
+					}
+				]
+			},
+			"bonuses" : {
+				"attack" : {
+					"subtype" : "primSkill.attack",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 8, 3 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"defence" : {
+					"subtype" : "primSkill.defence",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 8, 3 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"speed" : {
+					"type" : "STACKS_SPEED",
+					"val" : 1
+				}
+			}
+		}
 	},
 	"dracon":
 	{
@@ -58,11 +88,18 @@
 		[
 			{ "skill" : "wisdom", "level": "advanced" }
 		],
-		"specialties":
-		[
-			{ "type":9, "val": 0, "subtype": 8, "info": 136 },
-			{ "type":9, "val": 0, "subtype": 34, "info": 136 }
-		]
+		"specialty" : {
+			"base" : {
+				"addInfo" : "creature.enchanter",
+				"type" : "SPECIAL_UPGRADE"
+			},
+			"bonuses" : {
+				"archMage2enchanter" : { "subtype" : "creature.archMage" },
+				"mage2enchanter" : { "subtype" : "creature.mage" },
+				"monk2enchanter" : { "subtype" : "creature.monk" },
+				"zealot2enchanter" : { "subtype" : "creature.zealot" }
+			}
+		}
 	},
 	"gelu":
 	{
@@ -75,11 +112,18 @@
 			{ "skill" : "archery", "level": "basic" },
 			{ "skill" : "leadership", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":9, "val": 0, "subtype": 2, "info": 137 },
-			{ "type":9, "val": 0, "subtype": 18, "info": 137 }
-		]
+		"specialty" : {
+			"base" : {
+				"addInfo" : "creature.sharpshooter",
+				"type" : "SPECIAL_UPGRADE"
+			},
+			"bonuses" : {
+				"archer2sharpshooter" : { "subtype" : "creature.archer" },
+				"grandElf2sharpshooter" : { "subtype" : "creature.grandElf" },
+				"marksman2sharpshooter" : { "subtype" : "creature.marksman" },
+				"woodElf2sharpshooter" : { "subtype" : "creature.woodElf" }
+			}
+		}
 	},
 	"kilgor":
 	{
@@ -91,12 +135,33 @@
 		[
 			{ "skill" : "offence", "level": "advanced" }
 		],
-		"specialties":
-		[
-			{ "type":4, "val": 5,  "subtype": 1, "info": 96 },
-			{ "type":4, "val": 5,  "subtype": 2, "info": 96 },
-			{ "type":4, "val": 10, "subtype": 3, "info": 96 }
-		]
+		"specialty" : {
+			"base" : {
+				"limiters" : [
+					{
+						"parameters" : [ "behemoth", true ],
+						"type" : "CREATURE_TYPE_LIMITER"
+					}
+				]
+			},
+			"bonuses" : {
+				"damage" : {
+					"subtype" : 0,
+					"type" : "CREATURE_DAMAGE",
+					"val" : 10
+				},
+				"attack" : {
+					"subtype" : "primSkill.attack",
+					"type" : "PRIMARY_SKILL",
+					"val" : 5
+				},
+				"defence" : {
+					"subtype" : "primSkill.defence",
+					"type" : "PRIMARY_SKILL",
+					"val" : 5
+				}
+			}
+		}
 	},
 	"undeadHaart": // undead version of Lord Haart
 	{
@@ -109,12 +174,33 @@
 		[
 			{ "skill" : "necromancy", "level": "advanced" }
 		],
-		"specialties":
-		[
-			{ "type":4, "val": 5,  "subtype": 1, "info": 66 },
-			{ "type":4, "val": 5,  "subtype": 2, "info": 66 },
-			{ "type":4, "val": 10, "subtype": 3, "info": 66 }
-		]
+		"specialty" : {
+			"base" : {
+				"limiters" : [
+					{
+						"parameters" : [ "blackKnight", true ],
+						"type" : "CREATURE_TYPE_LIMITER"
+					}
+				]
+			},
+			"bonuses" : {
+				"damage" : {
+					"subtype" : 0,
+					"type" : "CREATURE_DAMAGE",
+					"val" : 10
+				},
+				"attack" : {
+					"subtype" : "primSkill.attack",
+					"type" : "PRIMARY_SKILL",
+					"val" : 5
+				},
+				"defence" : {
+					"subtype" : "primSkill.defence",
+					"type" : "PRIMARY_SKILL",
+					"val" : 5
+				}
+			}
+		}
 	},
 	"mutare":
 	{
@@ -128,11 +214,22 @@
 			{ "skill" : "estates", "level": "basic" },
 			{ "skill" : "tactics", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":13, "val": 5, "subtype": 1, "info": 0 },
-			{ "type":13, "val": 5, "subtype": 2, "info": 0 }
-		]
+		"specialty" : {
+			"base" : {
+				"limiters" : [
+					{
+						"parameters" : [ "DRAGON_NATURE" ],
+						"type" : "HAS_ANOTHER_BONUS_LIMITER"
+					}
+				],
+				"type" : "PRIMARY_SKILL",
+				"val" : 5
+			},
+			"bonuses" : {
+				"attack" : { "subtype" : "primSkill.attack" },
+				"defence" : { "subtype" : "primSkill.defence" }
+			}
+		}
 	},
 	"roland":
 	{
@@ -145,10 +242,38 @@
 			{ "skill" : "leadership", "level": "basic" },
 			{ "skill" : "armorer", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":1, "val": 0, "subtype": 0, "info": 4 }
-		]
+		"specialty" : {
+			"base" : {
+				"limiters" : [
+					{
+						"parameters" : [ "griffin", true ],
+						"type" : "CREATURE_TYPE_LIMITER"
+					}
+				]
+			},
+			"bonuses" : {
+				"attack" : {
+					"subtype" : "primSkill.attack",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 8, 3 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"defence" : {
+					"subtype" : "primSkill.defence",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 8, 3 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"speed" : {
+					"type" : "STACKS_SPEED",
+					"val" : 1
+				}
+			}
+		}
 	},
 	"mutareDrake":
 	{
@@ -162,11 +287,23 @@
 			{ "skill" : "estates", "level": "basic" },
 			{ "skill" : "tactics", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":13, "val": 1, "subtype": 1, "info": 5 },
-			{ "type":13, "val": 1, "subtype": 1, "info": 5 }
-		],
+		"specialty" : {
+			"base" : {
+				"limiters" : [
+					{
+						"parameters" : [ "DRAGON_NATURE" ],
+						"type" : "HAS_ANOTHER_BONUS_LIMITER"
+					}
+				],
+				"subtype" : "primSkill.attack",
+				"type" : "PRIMARY_SKILL",
+				"val" : 1
+			},
+			"bonuses" : {
+				"attack" : {  },
+				"attack2" : {  }
+			}
+		},
 		"army" :
 		[
 			{
@@ -194,44 +331,38 @@
 			{ "skill" : "tactics", "level": "basic" },
 			{ "skill" : "offence", "level": "basic" }
 		],
-		"specialty" :
-		[
-			{
-				"growsWithLevel" : true,
-				"bonuses" : [
+		"specialty" : {
+			"base" : {
+				"limiters" : [
 					{
-						"limiters" : [
-							{
-								"parameters" : [ "ogre", true ],
-								"type" : "CREATURE_TYPE_LIMITER"
-							}
-						],
-						"subtype" : "primSkill.attack",
-						"type" : "PRIMARY_SKILL",
-					},
-					{
-						"limiters" : [
-							{
-								"parameters" : [ "ogre", true ],
-								"type" : "CREATURE_TYPE_LIMITER"
-							}
-						],
-						"subtype" : "primSkill.defence",
-						"type" : "PRIMARY_SKILL",
-					},
-					{
-						"limiters" : [
-							{
-								"parameters" : [ "ogre", true ],
-								"type" : "CREATURE_TYPE_LIMITER"
-							}
-						],
-						"type" : "STACKS_SPEED",
-						"val" : 1
+						"parameters" : [ "ogre", true ],
+						"type" : "CREATURE_TYPE_LIMITER"
 					}
 				]
+			},
+			"bonuses" : {
+				"attack" : {
+					"subtype" : "primSkill.attack",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 13, 4 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"defence" : {
+					"subtype" : "primSkill.defence",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 7, 4 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"speed" : {
+					"type" : "STACKS_SPEED",
+					"val" : 1
+				}
 			}
-		],
+		},
 		"army" :
 		[
 			{
@@ -259,12 +390,32 @@
 			{ "skill" : "leadership", "level": "basic" },
 			{ "skill" : "tactics", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":4, "val": 4, "subtype": 1, "info": 54 },
-			{ "type":4, "val": 2, "subtype": 2, "info": 54 },
-			{ "type":4, "val": 1, "subtype": 5, "info": 54 }
-		],
+		"specialty" : {
+			"base" : {
+				"limiters" : [
+					{
+						"parameters" : [ "devil", true ],
+						"type" : "CREATURE_TYPE_LIMITER"
+					}
+				]
+			},
+			"bonuses" : {
+				"attack" : {
+					"subtype" : "primSkill.attack",
+					"type" : "PRIMARY_SKILL",
+					"val" : 4
+				},
+				"defence" : {
+					"subtype" : "primSkill.defence",
+					"type" : "PRIMARY_SKILL",
+					"val" : 2
+				},
+				"speed" : {
+					"type" : "STACKS_SPEED",
+					"val" : 1
+				}
+			}
+		},
 		"army" :
 		[
 			{

--- a/config/heroes/special.json
+++ b/config/heroes/special.json
@@ -194,9 +194,43 @@
 			{ "skill" : "tactics", "level": "basic" },
 			{ "skill" : "offence", "level": "basic" }
 		],
-		"specialties":
+		"specialty" :
 		[
-			{ "type":1, "val": 0, "subtype": 0, "info": 90 }
+			{
+				"growsWithLevel" : true,
+				"bonuses" : [
+					{
+						"limiters" : [
+							{
+								"parameters" : [ "ogre", true ],
+								"type" : "CREATURE_TYPE_LIMITER"
+							}
+						],
+						"subtype" : "primSkill.attack",
+						"type" : "PRIMARY_SKILL",
+					},
+					{
+						"limiters" : [
+							{
+								"parameters" : [ "ogre", true ],
+								"type" : "CREATURE_TYPE_LIMITER"
+							}
+						],
+						"subtype" : "primSkill.defence",
+						"type" : "PRIMARY_SKILL",
+					},
+					{
+						"limiters" : [
+							{
+								"parameters" : [ "ogre", true ],
+								"type" : "CREATURE_TYPE_LIMITER"
+							}
+						],
+						"type" : "STACKS_SPEED",
+						"val" : 1
+					}
+				]
+			}
 		],
 		"army" :
 		[

--- a/config/heroes/special.json
+++ b/config/heroes/special.json
@@ -295,13 +295,12 @@
 						"type" : "HAS_ANOTHER_BONUS_LIMITER"
 					}
 				],
-				"subtype" : "primSkill.attack",
 				"type" : "PRIMARY_SKILL",
-				"val" : 1
+				"val" : 5
 			},
 			"bonuses" : {
-				"attack" : {  },
-				"attack2" : {  }
+				"attack" : { "subtype" : "primSkill.attack" },
+				"defence" : { "subtype" : "primSkill.defence" }
 			}
 		},
 		"army" :

--- a/config/heroes/special.json
+++ b/config/heroes/special.json
@@ -31,7 +31,7 @@
 			{ "skill" : "wisdom", "level": "basic" },
 			{ "skill" : "fireMagic", "level": "expert" }
 		],
-		"specialty" : { "bonuses" : {  } }
+		"specialty" : { "bonuses" : {  } } // has expert fire magic as "specialty"
 	},
 	"catherine":
 	{

--- a/config/heroes/special.json
+++ b/config/heroes/special.json
@@ -45,36 +45,7 @@
 			{ "skill" : "offence", "level": "basic" }
 		],
 		"specialty" : {
-			"base" : {
-				"limiters" : [
-					{
-						"parameters" : [ "griffin", true ],
-						"type" : "CREATURE_TYPE_LIMITER"
-					}
-				]
-			},
-			"bonuses" : {
-				"attack" : {
-					"subtype" : "primSkill.attack",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 8, 3 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"defence" : {
-					"subtype" : "primSkill.defence",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 8, 3 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"speed" : {
-					"type" : "STACKS_SPEED",
-					"val" : 1
-				}
-			}
+			"creature" : "griffin"
 		}
 	},
 	"dracon":
@@ -243,36 +214,7 @@
 			{ "skill" : "armorer", "level": "basic" }
 		],
 		"specialty" : {
-			"base" : {
-				"limiters" : [
-					{
-						"parameters" : [ "griffin", true ],
-						"type" : "CREATURE_TYPE_LIMITER"
-					}
-				]
-			},
-			"bonuses" : {
-				"attack" : {
-					"subtype" : "primSkill.attack",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 8, 3 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"defence" : {
-					"subtype" : "primSkill.defence",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 8, 3 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"speed" : {
-					"type" : "STACKS_SPEED",
-					"val" : 1
-				}
-			}
+			"creature" : "griffin"
 		}
 	},
 	"mutareDrake":
@@ -331,36 +273,7 @@
 			{ "skill" : "offence", "level": "basic" }
 		],
 		"specialty" : {
-			"base" : {
-				"limiters" : [
-					{
-						"parameters" : [ "ogre", true ],
-						"type" : "CREATURE_TYPE_LIMITER"
-					}
-				]
-			},
-			"bonuses" : {
-				"attack" : {
-					"subtype" : "primSkill.attack",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 13, 4 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"defence" : {
-					"subtype" : "primSkill.defence",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 7, 4 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"speed" : {
-					"type" : "STACKS_SPEED",
-					"val" : 1
-				}
-			}
+			"creature" : "ogre"
 		},
 		"army" :
 		[

--- a/config/heroes/special.json
+++ b/config/heroes/special.json
@@ -45,7 +45,7 @@
 			{ "skill" : "offence", "level": "basic" }
 		],
 		"specialty" : {
-			"creature" : "griffin"
+			"creature" : "swordsman"
 		}
 	},
 	"dracon":

--- a/config/heroes/stronghold.json
+++ b/config/heroes/stronghold.json
@@ -271,10 +271,8 @@
 				"offence" : {
 					"subtype" : "skill.offence",
 					"type" : "SECONDARY_SKILL_PREMY",
-					"updater" : {
-						"parameters" : [ 100 ],
-						"type" : "GROWS_WITH_LEVEL"
-					},
+					"updater" : "TIMES_HERO_LEVEL",
+					"val" : 5,
 					"valueType" : "PERCENT_TO_BASE"
 				}
 			}
@@ -339,10 +337,8 @@
 				"sorcery" : {
 					"subtype" : "skill.sorcery",
 					"type" : "SECONDARY_SKILL_PREMY",
-					"updater" : {
-						"parameters" : [ 100 ],
-						"type" : "GROWS_WITH_LEVEL"
-					},
+					"updater" : "TIMES_HERO_LEVEL",
+					"val" : 5,
 					"valueType" : "PERCENT_TO_BASE"
 				}
 			}
@@ -408,10 +404,8 @@
 				"logistics" : {
 					"subtype" : "skill.logistics",
 					"type" : "SECONDARY_SKILL_PREMY",
-					"updater" : {
-						"parameters" : [ 100 ],
-						"type" : "GROWS_WITH_LEVEL"
-					},
+					"updater" : "TIMES_HERO_LEVEL",
+					"val" : 5,
 					"valueType" : "PERCENT_TO_BASE"
 				}
 			}
@@ -475,10 +469,8 @@
 				"sorcery" : {
 					"subtype" : "skill.sorcery",
 					"type" : "SECONDARY_SKILL_PREMY",
-					"updater" : {
-						"parameters" : [ 100 ],
-						"type" : "GROWS_WITH_LEVEL"
-					},
+					"updater" : "TIMES_HERO_LEVEL",
+					"val" : 5,
 					"valueType" : "PERCENT_TO_BASE"
 				}
 			}
@@ -500,10 +492,8 @@
 				"eagleEye" : {
 					"subtype" : "skill.eagleEye",
 					"type" : "SECONDARY_SKILL_PREMY",
-					"updater" : {
-						"parameters" : [ 100 ],
-						"type" : "GROWS_WITH_LEVEL"
-					},
+					"updater" : "TIMES_HERO_LEVEL",
+					"val" : 5,
 					"valueType" : "PERCENT_TO_BASE"
 				}
 			}

--- a/config/heroes/stronghold.json
+++ b/config/heroes/stronghold.json
@@ -9,10 +9,38 @@
 			{ "skill" : "offence", "level": "basic" },
 			{ "skill" : "ballistics", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":1, "val": 0, "subtype": 0, "info": 94 }
-		]
+		"specialty" : {
+			"base" : {
+				"limiters" : [
+					{
+						"parameters" : [ "cyclop", true ],
+						"type" : "CREATURE_TYPE_LIMITER"
+					}
+				]
+			},
+			"bonuses" : {
+				"attack" : {
+					"subtype" : "primSkill.attack",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 15, 6 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"defence" : {
+					"subtype" : "primSkill.defence",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 12, 6 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"speed" : {
+					"type" : "STACKS_SPEED",
+					"val" : 1
+				}
+			}
+		}
 	},
 	"gurnisson":
 	{
@@ -24,10 +52,38 @@
 			{ "skill" : "offence", "level": "basic" },
 			{ "skill" : "artillery", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":1, "val": 0, "subtype": 0, "info": 146 }
-		]
+		"specialty" : {
+			"base" : {
+				"limiters" : [
+					{
+						"parameters" : [ "ballista", true ],
+						"type" : "CREATURE_TYPE_LIMITER"
+					}
+				]
+			},
+			"bonuses" : {
+				"attack" : {
+					"subtype" : "primSkill.attack",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 10, 5 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"defence" : {
+					"subtype" : "primSkill.defence",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 10, 5 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"speed" : {
+					"type" : "STACKS_SPEED",
+					"val" : 1
+				}
+			}
+		}
 	},
 	"jabarkas":
 	{
@@ -39,10 +95,38 @@
 			{ "skill" : "offence", "level": "basic" },
 			{ "skill" : "archery", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":1, "val": 0, "subtype": 0, "info": 88 }
-		]
+		"specialty" : {
+			"base" : {
+				"limiters" : [
+					{
+						"parameters" : [ "orc", true ],
+						"type" : "CREATURE_TYPE_LIMITER"
+					}
+				]
+			},
+			"bonuses" : {
+				"attack" : {
+					"subtype" : "primSkill.attack",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 8, 3 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"defence" : {
+					"subtype" : "primSkill.defence",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 4, 3 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"speed" : {
+					"type" : "STACKS_SPEED",
+					"val" : 1
+				}
+			}
+		}
 	},
 	"shiva":
 	{
@@ -54,10 +138,38 @@
 			{ "skill" : "offence", "level": "basic" },
 			{ "skill" : "scouting", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":1, "val": 0, "subtype": 0, "info": 92 }
-		]
+		"specialty" : {
+			"base" : {
+				"limiters" : [
+					{
+						"parameters" : [ "roc", true ],
+						"type" : "CREATURE_TYPE_LIMITER"
+					}
+				]
+			},
+			"bonuses" : {
+				"attack" : {
+					"subtype" : "primSkill.attack",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 13, 5 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"defence" : {
+					"subtype" : "primSkill.defence",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 11, 5 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"speed" : {
+					"type" : "STACKS_SPEED",
+					"val" : 1
+				}
+			}
+		}
 	},
 	"gretchin":
 	{
@@ -69,10 +181,38 @@
 			{ "skill" : "offence", "level": "basic" },
 			{ "skill" : "pathfinding", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":1, "val": 0, "subtype": 0, "info": 84 }
-		]
+		"specialty" : {
+			"base" : {
+				"limiters" : [
+					{
+						"parameters" : [ "goblin", true ],
+						"type" : "CREATURE_TYPE_LIMITER"
+					}
+				]
+			},
+			"bonuses" : {
+				"attack" : {
+					"subtype" : "primSkill.attack",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 4 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"defence" : {
+					"subtype" : "primSkill.defence",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 2 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"speed" : {
+					"type" : "STACKS_SPEED",
+					"val" : 1
+				}
+			}
+		}
 	},
 	"krellion":
 	{
@@ -84,10 +224,38 @@
 			{ "skill" : "offence", "level": "basic" },
 			{ "skill" : "resistance", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":1, "val": 0, "subtype": 0, "info": 90 }
-		]
+		"specialty" : {
+			"base" : {
+				"limiters" : [
+					{
+						"parameters" : [ "ogre", true ],
+						"type" : "CREATURE_TYPE_LIMITER"
+					}
+				]
+			},
+			"bonuses" : {
+				"attack" : {
+					"subtype" : "primSkill.attack",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 13, 4 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"defence" : {
+					"subtype" : "primSkill.defence",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 7, 4 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"speed" : {
+					"type" : "STACKS_SPEED",
+					"val" : 1
+				}
+			}
+		}
 	},
 	"cragHack":
 	{
@@ -98,10 +266,19 @@
 		[
 			{ "skill" : "offence", "level": "advanced" }
 		],
-		"specialties":
-		[
-			{ "type":2, "val": 5, "subtype": 22, "info": 0 }
-		]
+		"specialty" : {
+			"bonuses" : {
+				"offence" : {
+					"subtype" : "skill.offence",
+					"type" : "SECONDARY_SKILL_PREMY",
+					"updater" : {
+						"parameters" : [ 100 ],
+						"type" : "GROWS_WITH_LEVEL"
+					},
+					"valueType" : "PERCENT_TO_BASE"
+				}
+			}
+		}
 	},
 	"tyraxor":
 	{
@@ -113,10 +290,38 @@
 			{ "skill" : "offence", "level": "basic" },
 			{ "skill" : "tactics", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":1, "val": 0, "subtype": 0, "info": 86 }
-		]
+		"specialty" : {
+			"base" : {
+				"limiters" : [
+					{
+						"parameters" : [ "goblinWolfRider", true ],
+						"type" : "CREATURE_TYPE_LIMITER"
+					}
+				]
+			},
+			"bonuses" : {
+				"attack" : {
+					"subtype" : "primSkill.attack",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 7, 2 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"defence" : {
+					"subtype" : "primSkill.defence",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 5, 2 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"speed" : {
+					"type" : "STACKS_SPEED",
+					"val" : 1
+				}
+			}
+		}
 	},
 	"gird":
 	{
@@ -129,10 +334,19 @@
 			{ "skill" : "wisdom", "level": "basic" },
 			{ "skill" : "sorcery", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":2, "val": 5, "subtype": 25, "info": 0 }
-		]
+		"specialty" : {
+			"bonuses" : {
+				"sorcery" : {
+					"subtype" : "skill.sorcery",
+					"type" : "SECONDARY_SKILL_PREMY",
+					"updater" : {
+						"parameters" : [ 100 ],
+						"type" : "GROWS_WITH_LEVEL"
+					},
+					"valueType" : "PERCENT_TO_BASE"
+				}
+			}
+		}
 	},
 	"vey":
 	{
@@ -145,10 +359,38 @@
 			{ "skill" : "wisdom", "level": "basic" },
 			{ "skill" : "leadership", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":1, "val": 0, "subtype": 0, "info": 90 }
-		]
+		"specialty" : {
+			"base" : {
+				"limiters" : [
+					{
+						"parameters" : [ "ogre", true ],
+						"type" : "CREATURE_TYPE_LIMITER"
+					}
+				]
+			},
+			"bonuses" : {
+				"attack" : {
+					"subtype" : "primSkill.attack",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 13, 4 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"defence" : {
+					"subtype" : "primSkill.defence",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 7, 4 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"speed" : {
+					"type" : "STACKS_SPEED",
+					"val" : 1
+				}
+			}
+		}
 	},
 	"dessa":
 	{
@@ -161,10 +403,19 @@
 			{ "skill" : "wisdom", "level": "basic" },
 			{ "skill" : "logistics", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":2, "val": 5, "subtype": 2, "info": 0 }
-		]
+		"specialty" : {
+			"bonuses" : {
+				"logistics" : {
+					"subtype" : "skill.logistics",
+					"type" : "SECONDARY_SKILL_PREMY",
+					"updater" : {
+						"parameters" : [ 100 ],
+						"type" : "GROWS_WITH_LEVEL"
+					},
+					"valueType" : "PERCENT_TO_BASE"
+				}
+			}
+		}
 	},
 	"terek":
 	{
@@ -177,10 +428,15 @@
 			{ "skill" : "wisdom", "level": "basic" },
 			{ "skill" : "tactics", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":8, "val": 0, "subtype": 53, "info": 0 }
-		]
+		"specialty" : {
+			"bonuses" : {
+				"haste" : {
+					"addInfo" : 0,
+					"subtype" : "spell.haste",
+					"type" : "SPECIAL_PECULIAR_ENCHANT"
+				}
+			}
+		}
 	},
 	"zubin":
 	{
@@ -193,10 +449,15 @@
 			{ "skill" : "wisdom", "level": "basic" },
 			{ "skill" : "artillery", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":8, "val": 0, "subtype": 44, "info": 0 }
-		]
+		"specialty" : {
+			"bonuses" : {
+				"precision" : {
+					"addInfo" : 0,
+					"subtype" : "spell.precision",
+					"type" : "SPECIAL_PECULIAR_ENCHANT"
+				}
+			}
+		}
 	},
 	"gundula":
 	{
@@ -209,10 +470,19 @@
 			{ "skill" : "wisdom", "level": "basic" },
 			{ "skill" : "offence", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":2, "val": 5, "subtype": 25, "info": 0 }
-		]
+		"specialty" : {
+			"bonuses" : {
+				"sorcery" : {
+					"subtype" : "skill.sorcery",
+					"type" : "SECONDARY_SKILL_PREMY",
+					"updater" : {
+						"parameters" : [ 100 ],
+						"type" : "GROWS_WITH_LEVEL"
+					},
+					"valueType" : "PERCENT_TO_BASE"
+				}
+			}
+		}
 	},
 	"oris":
 	{
@@ -225,10 +495,19 @@
 			{ "skill" : "wisdom", "level": "basic" },
 			{ "skill" : "eagleEye", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":2, "val": 5, "subtype": 11, "info": 0 }
-		]
+		"specialty" : {
+			"bonuses" : {
+				"eagleEye" : {
+					"subtype" : "skill.eagleEye",
+					"type" : "SECONDARY_SKILL_PREMY",
+					"updater" : {
+						"parameters" : [ 100 ],
+						"type" : "GROWS_WITH_LEVEL"
+					},
+					"valueType" : "PERCENT_TO_BASE"
+				}
+			}
+		}
 	},
 	"saurug":
 	{
@@ -241,9 +520,14 @@
 			{ "skill" : "wisdom", "level": "basic" },
 			{ "skill" : "resistance", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":10, "val": 1, "subtype": 5, "info": 0 }
-		]
+		"specialty" : {
+			"bonuses" : {
+				"gems" : {
+					"subtype" : "resource.gems",
+					"type" : "GENERATE_RESOURCE",
+					"val" : 1
+				}
+			}
+		}
 	}
 }

--- a/config/heroes/stronghold.json
+++ b/config/heroes/stronghold.json
@@ -10,36 +10,7 @@
 			{ "skill" : "ballistics", "level": "basic" }
 		],
 		"specialty" : {
-			"base" : {
-				"limiters" : [
-					{
-						"parameters" : [ "cyclop", true ],
-						"type" : "CREATURE_TYPE_LIMITER"
-					}
-				]
-			},
-			"bonuses" : {
-				"attack" : {
-					"subtype" : "primSkill.attack",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 15, 6 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"defence" : {
-					"subtype" : "primSkill.defence",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 12, 6 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"speed" : {
-					"type" : "STACKS_SPEED",
-					"val" : 1
-				}
-			}
+			"creature" : "cyclop"
 		}
 	},
 	"gurnisson":
@@ -53,36 +24,7 @@
 			{ "skill" : "artillery", "level": "basic" }
 		],
 		"specialty" : {
-			"base" : {
-				"limiters" : [
-					{
-						"parameters" : [ "ballista", true ],
-						"type" : "CREATURE_TYPE_LIMITER"
-					}
-				]
-			},
-			"bonuses" : {
-				"attack" : {
-					"subtype" : "primSkill.attack",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 10, 5 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"defence" : {
-					"subtype" : "primSkill.defence",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 10, 5 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"speed" : {
-					"type" : "STACKS_SPEED",
-					"val" : 1
-				}
-			}
+			"creature" : "ballista"
 		}
 	},
 	"jabarkas":
@@ -96,36 +38,7 @@
 			{ "skill" : "archery", "level": "basic" }
 		],
 		"specialty" : {
-			"base" : {
-				"limiters" : [
-					{
-						"parameters" : [ "orc", true ],
-						"type" : "CREATURE_TYPE_LIMITER"
-					}
-				]
-			},
-			"bonuses" : {
-				"attack" : {
-					"subtype" : "primSkill.attack",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 8, 3 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"defence" : {
-					"subtype" : "primSkill.defence",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 4, 3 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"speed" : {
-					"type" : "STACKS_SPEED",
-					"val" : 1
-				}
-			}
+			"creature" : "orc"
 		}
 	},
 	"shiva":
@@ -139,36 +52,7 @@
 			{ "skill" : "scouting", "level": "basic" }
 		],
 		"specialty" : {
-			"base" : {
-				"limiters" : [
-					{
-						"parameters" : [ "roc", true ],
-						"type" : "CREATURE_TYPE_LIMITER"
-					}
-				]
-			},
-			"bonuses" : {
-				"attack" : {
-					"subtype" : "primSkill.attack",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 13, 5 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"defence" : {
-					"subtype" : "primSkill.defence",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 11, 5 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"speed" : {
-					"type" : "STACKS_SPEED",
-					"val" : 1
-				}
-			}
+			"creature" : "roc"
 		}
 	},
 	"gretchin":
@@ -182,36 +66,7 @@
 			{ "skill" : "pathfinding", "level": "basic" }
 		],
 		"specialty" : {
-			"base" : {
-				"limiters" : [
-					{
-						"parameters" : [ "goblin", true ],
-						"type" : "CREATURE_TYPE_LIMITER"
-					}
-				]
-			},
-			"bonuses" : {
-				"attack" : {
-					"subtype" : "primSkill.attack",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 4 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"defence" : {
-					"subtype" : "primSkill.defence",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 2 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"speed" : {
-					"type" : "STACKS_SPEED",
-					"val" : 1
-				}
-			}
+			"creature" : "goblin"
 		}
 	},
 	"krellion":
@@ -225,36 +80,7 @@
 			{ "skill" : "resistance", "level": "basic" }
 		],
 		"specialty" : {
-			"base" : {
-				"limiters" : [
-					{
-						"parameters" : [ "ogre", true ],
-						"type" : "CREATURE_TYPE_LIMITER"
-					}
-				]
-			},
-			"bonuses" : {
-				"attack" : {
-					"subtype" : "primSkill.attack",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 13, 4 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"defence" : {
-					"subtype" : "primSkill.defence",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 7, 4 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"speed" : {
-					"type" : "STACKS_SPEED",
-					"val" : 1
-				}
-			}
+			"creature" : "ogre"
 		}
 	},
 	"cragHack":
@@ -289,36 +115,7 @@
 			{ "skill" : "tactics", "level": "basic" }
 		],
 		"specialty" : {
-			"base" : {
-				"limiters" : [
-					{
-						"parameters" : [ "goblinWolfRider", true ],
-						"type" : "CREATURE_TYPE_LIMITER"
-					}
-				]
-			},
-			"bonuses" : {
-				"attack" : {
-					"subtype" : "primSkill.attack",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 7, 2 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"defence" : {
-					"subtype" : "primSkill.defence",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 5, 2 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"speed" : {
-					"type" : "STACKS_SPEED",
-					"val" : 1
-				}
-			}
+			"creature" : "goblinWolfRider"
 		}
 	},
 	"gird":
@@ -356,36 +153,7 @@
 			{ "skill" : "leadership", "level": "basic" }
 		],
 		"specialty" : {
-			"base" : {
-				"limiters" : [
-					{
-						"parameters" : [ "ogre", true ],
-						"type" : "CREATURE_TYPE_LIMITER"
-					}
-				]
-			},
-			"bonuses" : {
-				"attack" : {
-					"subtype" : "primSkill.attack",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 13, 4 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"defence" : {
-					"subtype" : "primSkill.defence",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 7, 4 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"speed" : {
-					"type" : "STACKS_SPEED",
-					"val" : 1
-				}
-			}
+			"creature" : "ogre"
 		}
 	},
 	"dessa":

--- a/config/heroes/tower.json
+++ b/config/heroes/tower.json
@@ -147,6 +147,7 @@
 				"hypnotize" : {
 					"subtype" : "spell.hypnotize",
 					"type" : "SPECIAL_SPELL_LEV",
+                    "updater" : "TIMES_HERO_LEVEL",
 					"val" : 3
 				}
 			}
@@ -249,6 +250,7 @@
 				"chainLightning" : {
 					"subtype" : "spell.chainLightning",
 					"type" : "SPECIAL_SPELL_LEV",
+                    "updater" : "TIMES_HERO_LEVEL",
 					"val" : 3
 				}
 			}

--- a/config/heroes/tower.json
+++ b/config/heroes/tower.json
@@ -146,10 +146,8 @@
 				"armorer" : {
 					"subtype" : "skill.armorer",
 					"type" : "SECONDARY_SKILL_PREMY",
-					"updater" : {
-						"parameters" : [ 100 ],
-						"type" : "GROWS_WITH_LEVEL"
-					},
+					"updater" : "TIMES_HERO_LEVEL",
+					"val" : 5,
 					"valueType" : "PERCENT_TO_BASE"
 				}
 			}
@@ -344,10 +342,8 @@
 				"mysticism" : {
 					"subtype" : "skill.mysticism",
 					"type" : "SECONDARY_SKILL_PREMY",
-					"updater" : {
-						"parameters" : [ 100 ],
-						"type" : "GROWS_WITH_LEVEL"
-					},
+					"updater" : "TIMES_HERO_LEVEL",
+					"val" : 5,
 					"valueType" : "PERCENT_TO_BASE"
 				}
 			}
@@ -369,10 +365,8 @@
 				"eagleEye" : {
 					"subtype" : "skill.eagleEye",
 					"type" : "SECONDARY_SKILL_PREMY",
-					"updater" : {
-						"parameters" : [ 100 ],
-						"type" : "GROWS_WITH_LEVEL"
-					},
+					"updater" : "TIMES_HERO_LEVEL",
+					"val" : 5,
 					"valueType" : "PERCENT_TO_BASE"
 				}
 			}

--- a/config/heroes/tower.json
+++ b/config/heroes/tower.json
@@ -147,7 +147,7 @@
 				"hypnotize" : {
 					"subtype" : "spell.hypnotize",
 					"type" : "SPECIAL_SPELL_LEV",
-                    "updater" : "TIMES_HERO_LEVEL",
+					"updater" : "TIMES_HERO_LEVEL",
 					"val" : 3
 				}
 			}
@@ -250,7 +250,7 @@
 				"chainLightning" : {
 					"subtype" : "spell.chainLightning",
 					"type" : "SPECIAL_SPELL_LEV",
-                    "updater" : "TIMES_HERO_LEVEL",
+					"updater" : "TIMES_HERO_LEVEL",
 					"val" : 3
 				}
 			}

--- a/config/heroes/tower.json
+++ b/config/heroes/tower.json
@@ -11,36 +11,7 @@
 			{ "skill" : "mysticism", "level": "basic" }
 		],
 		"specialty" : {
-			"base" : {
-				"limiters" : [
-					{
-						"parameters" : [ "stoneGargoyle", true ],
-						"type" : "CREATURE_TYPE_LIMITER"
-					}
-				]
-			},
-			"bonuses" : {
-				"attack" : {
-					"subtype" : "primSkill.attack",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 6, 2 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"defence" : {
-					"subtype" : "primSkill.defence",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 6, 2 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"speed" : {
-					"type" : "STACKS_SPEED",
-					"val" : 1
-				}
-			}
+			"creature" : "stoneGargoyle"
 		}
 	},
 	"thane":
@@ -54,36 +25,7 @@
 			{ "skill" : "scholar", "level": "advanced" }
 		],
 		"specialty" : {
-			"base" : {
-				"limiters" : [
-					{
-						"parameters" : [ "genie", true ],
-						"type" : "CREATURE_TYPE_LIMITER"
-					}
-				]
-			},
-			"bonuses" : {
-				"attack" : {
-					"subtype" : "primSkill.attack",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 12, 5 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"defence" : {
-					"subtype" : "primSkill.defence",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 12, 5 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"speed" : {
-					"type" : "STACKS_SPEED",
-					"val" : 1
-				}
-			}
+			"creature" : "genie"
 		}
 	},
 	"josephine":
@@ -98,36 +40,7 @@
 			{ "skill" : "sorcery", "level": "basic" }
 		],
 		"specialty" : {
-			"base" : {
-				"limiters" : [
-					{
-						"parameters" : [ "ironGolem", true ],
-						"type" : "CREATURE_TYPE_LIMITER"
-					}
-				]
-			},
-			"bonuses" : {
-				"attack" : {
-					"subtype" : "primSkill.attack",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 7, 3 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"defence" : {
-					"subtype" : "primSkill.defence",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 10, 3 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"speed" : {
-					"type" : "STACKS_SPEED",
-					"val" : 1
-				}
-			}
+			"creature" : "ironGolem"
 		}
 	},
 	"neela":
@@ -165,36 +78,7 @@
 			{ "skill" : "tactics", "level": "basic" }
 		],
 		"specialty" : {
-			"base" : {
-				"limiters" : [
-					{
-						"parameters" : [ "ballista", true ],
-						"type" : "CREATURE_TYPE_LIMITER"
-					}
-				]
-			},
-			"bonuses" : {
-				"attack" : {
-					"subtype" : "primSkill.attack",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 10, 5 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"defence" : {
-					"subtype" : "primSkill.defence",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 10, 5 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"speed" : {
-					"type" : "STACKS_SPEED",
-					"val" : 1
-				}
-			}
+			"creature" : "ballista"
 		}
 	},
 	"fafner":
@@ -209,36 +93,7 @@
 			{ "skill" : "resistance", "level": "basic" }
 		],
 		"specialty" : {
-			"base" : {
-				"limiters" : [
-					{
-						"parameters" : [ "naga", true ],
-						"type" : "CREATURE_TYPE_LIMITER"
-					}
-				]
-			},
-			"bonuses" : {
-				"attack" : {
-					"subtype" : "primSkill.attack",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 16, 6 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"defence" : {
-					"subtype" : "primSkill.defence",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 13, 6 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"speed" : {
-					"type" : "STACKS_SPEED",
-					"val" : 1
-				}
-			}
+			"creature" : "naga"
 		}
 	},
 	"rissa":
@@ -274,36 +129,7 @@
 			{ "skill" : "intelligence", "level": "basic" }
 		],
 		"specialty" : {
-			"base" : {
-				"limiters" : [
-					{
-						"parameters" : [ "genie", true ],
-						"type" : "CREATURE_TYPE_LIMITER"
-					}
-				]
-			},
-			"bonuses" : {
-				"attack" : {
-					"subtype" : "primSkill.attack",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 12, 5 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"defence" : {
-					"subtype" : "primSkill.defence",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 12, 5 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"speed" : {
-					"type" : "STACKS_SPEED",
-					"val" : 1
-				}
-			}
+			"creature" : "genie"
 		}
 	},
 	"astral":
@@ -404,36 +230,7 @@
 			{ "skill" : "ballistics", "level": "basic" }
 		],
 		"specialty" : {
-			"base" : {
-				"limiters" : [
-					{
-						"parameters" : [ "mage", true ],
-						"type" : "CREATURE_TYPE_LIMITER"
-					}
-				]
-			},
-			"bonuses" : {
-				"attack" : {
-					"subtype" : "primSkill.attack",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 11, 4 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"defence" : {
-					"subtype" : "primSkill.defence",
-					"type" : "PRIMARY_SKILL",
-					"updater" : {
-						"parameters" : [ 8, 4 ],
-						"type" : "GROWS_WITH_LEVEL"
-					}
-				},
-				"speed" : {
-					"type" : "STACKS_SPEED",
-					"val" : 1
-				}
-			}
+			"creature" : "mage"
 		}
 	},
 	"solmyr":

--- a/config/heroes/tower.json
+++ b/config/heroes/tower.json
@@ -10,10 +10,38 @@
 			{ "skill" : "scouting", "level": "basic" },
 			{ "skill" : "mysticism", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":1, "val": 0, "subtype": 0, "info": 30 }
-		]
+		"specialty" : {
+			"base" : {
+				"limiters" : [
+					{
+						"parameters" : [ "stoneGargoyle", true ],
+						"type" : "CREATURE_TYPE_LIMITER"
+					}
+				]
+			},
+			"bonuses" : {
+				"attack" : {
+					"subtype" : "primSkill.attack",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 6, 2 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"defence" : {
+					"subtype" : "primSkill.defence",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 6, 2 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"speed" : {
+					"type" : "STACKS_SPEED",
+					"val" : 1
+				}
+			}
+		}
 	},
 	"thane":
 	{
@@ -25,10 +53,38 @@
 		[
 			{ "skill" : "scholar", "level": "advanced" }
 		],
-		"specialties":
-		[
-			{ "type":1, "val": 0, "subtype": 0, "info": 36 }
-		]
+		"specialty" : {
+			"base" : {
+				"limiters" : [
+					{
+						"parameters" : [ "genie", true ],
+						"type" : "CREATURE_TYPE_LIMITER"
+					}
+				]
+			},
+			"bonuses" : {
+				"attack" : {
+					"subtype" : "primSkill.attack",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 12, 5 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"defence" : {
+					"subtype" : "primSkill.defence",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 12, 5 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"speed" : {
+					"type" : "STACKS_SPEED",
+					"val" : 1
+				}
+			}
+		}
 	},
 	"josephine":
 	{
@@ -41,10 +97,38 @@
 			{ "skill" : "mysticism", "level": "basic" },
 			{ "skill" : "sorcery", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":1, "val": 0, "subtype": 0, "info": 32 }
-		]
+		"specialty" : {
+			"base" : {
+				"limiters" : [
+					{
+						"parameters" : [ "ironGolem", true ],
+						"type" : "CREATURE_TYPE_LIMITER"
+					}
+				]
+			},
+			"bonuses" : {
+				"attack" : {
+					"subtype" : "primSkill.attack",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 7, 3 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"defence" : {
+					"subtype" : "primSkill.defence",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 10, 3 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"speed" : {
+					"type" : "STACKS_SPEED",
+					"val" : 1
+				}
+			}
+		}
 	},
 	"neela":
 	{
@@ -57,10 +141,19 @@
 			{ "skill" : "scholar", "level": "basic" },
 			{ "skill" : "armorer", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":2, "val": 5, "subtype": 23, "info": 0 }
-		]
+		"specialty" : {
+			"bonuses" : {
+				"armorer" : {
+					"subtype" : "skill.armorer",
+					"type" : "SECONDARY_SKILL_PREMY",
+					"updater" : {
+						"parameters" : [ 100 ],
+						"type" : "GROWS_WITH_LEVEL"
+					},
+					"valueType" : "PERCENT_TO_BASE"
+				}
+			}
+		}
 	},
 	"torosar ":
 	{
@@ -73,10 +166,38 @@
 			{ "skill" : "mysticism", "level": "basic" },
 			{ "skill" : "tactics", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":1, "val": 0, "subtype": 0, "info": 146 }
-		]
+		"specialty" : {
+			"base" : {
+				"limiters" : [
+					{
+						"parameters" : [ "ballista", true ],
+						"type" : "CREATURE_TYPE_LIMITER"
+					}
+				]
+			},
+			"bonuses" : {
+				"attack" : {
+					"subtype" : "primSkill.attack",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 10, 5 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"defence" : {
+					"subtype" : "primSkill.defence",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 10, 5 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"speed" : {
+					"type" : "STACKS_SPEED",
+					"val" : 1
+				}
+			}
+		}
 	},
 	"fafner":
 	{
@@ -89,10 +210,38 @@
 			{ "skill" : "scholar", "level": "basic" },
 			{ "skill" : "resistance", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":1, "val": 0, "subtype": 0, "info": 38 }
-		]
+		"specialty" : {
+			"base" : {
+				"limiters" : [
+					{
+						"parameters" : [ "naga", true ],
+						"type" : "CREATURE_TYPE_LIMITER"
+					}
+				]
+			},
+			"bonuses" : {
+				"attack" : {
+					"subtype" : "primSkill.attack",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 16, 6 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"defence" : {
+					"subtype" : "primSkill.defence",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 13, 6 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"speed" : {
+					"type" : "STACKS_SPEED",
+					"val" : 1
+				}
+			}
+		}
 	},
 	"rissa":
 	{
@@ -105,10 +254,15 @@
 			{ "skill" : "mysticism", "level": "basic" },
 			{ "skill" : "offence", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":10, "val": 1, "subtype": 1, "info": 0 }
-		]
+		"specialty" : {
+			"bonuses" : {
+				"mercury" : {
+					"subtype" : "resource.mercury",
+					"type" : "GENERATE_RESOURCE",
+					"val" : 1
+				}
+			}
+		}
 	},
 	"iona":
 	{
@@ -121,10 +275,38 @@
 			{ "skill" : "scholar", "level": "basic" },
 			{ "skill" : "intelligence", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":1, "val": 0, "subtype": 0, "info": 36 }
-		]
+		"specialty" : {
+			"base" : {
+				"limiters" : [
+					{
+						"parameters" : [ "genie", true ],
+						"type" : "CREATURE_TYPE_LIMITER"
+					}
+				]
+			},
+			"bonuses" : {
+				"attack" : {
+					"subtype" : "primSkill.attack",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 12, 5 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"defence" : {
+					"subtype" : "primSkill.defence",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 12, 5 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"speed" : {
+					"type" : "STACKS_SPEED",
+					"val" : 1
+				}
+			}
+		}
 	},
 	"astral":
 	{
@@ -136,10 +318,15 @@
 		[
 			{ "skill" : "wisdom", "level": "advanced" }
 		],
-		"specialties":
-		[
-			{ "type":3, "val": 3, "subtype": 60, "info": 0 }
-		]
+		"specialty" : {
+			"bonuses" : {
+				"hypnotize" : {
+					"subtype" : "spell.hypnotize",
+					"type" : "SPECIAL_SPELL_LEV",
+					"val" : 3
+				}
+			}
+		}
 	},
 	"halon":
 	{
@@ -152,10 +339,19 @@
 			{ "skill" : "wisdom", "level": "basic" },
 			{ "skill" : "mysticism", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":2, "val": 5, "subtype": 8, "info": 1 }
-		]
+		"specialty" : {
+			"bonuses" : {
+				"mysticism" : {
+					"subtype" : "skill.mysticism",
+					"type" : "SECONDARY_SKILL_PREMY",
+					"updater" : {
+						"parameters" : [ 100 ],
+						"type" : "GROWS_WITH_LEVEL"
+					},
+					"valueType" : "PERCENT_TO_BASE"
+				}
+			}
+		}
 	},
 	"serena":
 	{
@@ -168,10 +364,19 @@
 			{ "skill" : "wisdom", "level": "basic" },
 			{ "skill" : "eagleEye", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":2, "val": 5, "subtype": 11, "info": 0 }
-		]
+		"specialty" : {
+			"bonuses" : {
+				"eagleEye" : {
+					"subtype" : "skill.eagleEye",
+					"type" : "SECONDARY_SKILL_PREMY",
+					"updater" : {
+						"parameters" : [ 100 ],
+						"type" : "GROWS_WITH_LEVEL"
+					},
+					"valueType" : "PERCENT_TO_BASE"
+				}
+			}
+		}
 	},
 	"daremyth":
 	{
@@ -184,10 +389,14 @@
 			{ "skill" : "wisdom", "level": "basic" },
 			{ "skill" : "intelligence", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":7, "val": 0, "subtype": 51, "info": 0 }
-		]
+		"specialty" : {
+			"bonuses" : {
+				"fortune" : {
+					"subtype" : "spell.fortune",
+					"type" : "MAXED_SPELL"
+				}
+			}
+		}
 	},
 	"theodorus":
 	{
@@ -200,10 +409,38 @@
 			{ "skill" : "wisdom", "level": "basic" },
 			{ "skill" : "ballistics", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":1, "val": 0, "subtype": 0, "info": 34 }
-		]
+		"specialty" : {
+			"base" : {
+				"limiters" : [
+					{
+						"parameters" : [ "mage", true ],
+						"type" : "CREATURE_TYPE_LIMITER"
+					}
+				]
+			},
+			"bonuses" : {
+				"attack" : {
+					"subtype" : "primSkill.attack",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 11, 4 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"defence" : {
+					"subtype" : "primSkill.defence",
+					"type" : "PRIMARY_SKILL",
+					"updater" : {
+						"parameters" : [ 8, 4 ],
+						"type" : "GROWS_WITH_LEVEL"
+					}
+				},
+				"speed" : {
+					"type" : "STACKS_SPEED",
+					"val" : 1
+				}
+			}
+		}
 	},
 	"solmyr":
 	{
@@ -216,10 +453,15 @@
 			{ "skill" : "wisdom", "level": "basic" },
 			{ "skill" : "sorcery", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":3, "val": 3, "subtype": 19, "info": 0 }
-		]
+		"specialty" : {
+			"bonuses" : {
+				"chainLightning" : {
+					"subtype" : "spell.chainLightning",
+					"type" : "SPECIAL_SPELL_LEV",
+					"val" : 3
+				}
+			}
+		}
 	},
 	"cyra":
 	{
@@ -232,10 +474,15 @@
 			{ "skill" : "wisdom", "level": "basic" },
 			{ "skill" : "diplomacy", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":8, "val": 0, "subtype": 53, "info": 0 }
-		]
+		"specialty" : {
+			"bonuses" : {
+				"haste" : {
+					"addInfo" : 0,
+					"subtype" : "spell.haste",
+					"type" : "SPECIAL_PECULIAR_ENCHANT"
+				}
+			}
+		}
 	},
 	"aine":
 	{
@@ -248,9 +495,14 @@
 			{ "skill" : "wisdom", "level": "basic" },
 			{ "skill" : "scholar", "level": "basic" }
 		],
-		"specialties":
-		[
-			{ "type":10, "val": 350, "subtype": 6, "info": 0 }
-		]
+		"specialty" : {
+			"bonuses" : {
+				"gold" : {
+					"subtype" : "resource.gold",
+					"type" : "GENERATE_RESOURCE",
+					"val" : 350
+				}
+			}
+		}
 	}
 }

--- a/config/schemas/bonus.json
+++ b/config/schemas/bonus.json
@@ -71,21 +71,28 @@
 			]
 		},
 		"updater" : {
-			"description" : "updater",
-			"type" : "object",
-			"required" : ["type", "parameters"],
-			"additionalProperties" : false,
-			"properties" : {
-				"type" : {
-					"type" : "string",
-					"description" : "type"
+			"anyOf" : [
+				{
+					"type" : "string"
 				},
-				"parameters": {
-					"type" : "array",
-					"description" : "parameters",
-					"additionalItems" : true
+				{
+					"description" : "updater",
+					"type" : "object",
+					"required" : ["type", "parameters"],
+					"additionalProperties" : false,
+					"properties" : {
+						"type" : {
+							"type" : "string",
+							"description" : "type"
+						},
+						"parameters": {
+							"type" : "array",
+							"description" : "parameters",
+							"additionalItems" : true
+						}
+					}
 				}
-			}
+			]
 		},
 		"sourceID": {
 			"type":"number",

--- a/config/schemas/bonus.json
+++ b/config/schemas/bonus.json
@@ -70,6 +70,23 @@
 				}
 			]
 		},
+		"updater" : {
+			"description" : "updater",
+			"type" : "object",
+			"required" : ["type", "parameters"],
+			"additionalProperties" : false,
+			"properties" : {
+				"type" : {
+					"type" : "string",
+					"description" : "type"
+				},
+				"parameters": {
+					"type" : "array",
+					"description" : "parameters",
+					"additionalItems" : true
+				}
+			}
+		},
 		"sourceID": {
 			"type":"number",
 			"description": "sourceID"

--- a/config/schemas/hero.json
+++ b/config/schemas/hero.json
@@ -140,7 +140,6 @@
 					"type" : "object",
 					"description": "Description of hero specialty using bonus system",
 					"additionalProperties" : false,
-					"required" : [ "bonuses" ],
 					"properties" : { 
 						"base" : {
 							"type" : "object",
@@ -150,6 +149,10 @@
 							"type" : "object",
 							"description" : "Set of bonuses",
 							"additionalProperties" : { "$ref" : "vcmi:bonus" }
+						},
+						"creature" : {
+							"type" : "string",
+							"description" : "Name of base creature to grant standard specialty to."
 						}
 					}
 				}

--- a/config/schemas/hero.json
+++ b/config/schemas/hero.json
@@ -118,20 +118,29 @@
 			"type":"array",
 			"description": "Description of hero specialty using bonus system",	
 			"items": {
-				"type":"object",
-				"additionalProperties" : false,
-				"required" : [ "bonuses" ],
-				"properties":{
-					"growsWithLevel" : {
-						"type" : "boolean",
-						"description" : "Specialty growth with level, so far only SECONDARY_SKILL_PREMY and PRIMATY SKILL with creature limiter can grow"
+				"oneOf" : [
+					{
+						"type" : "object",
+						"additionalProperties" : false,
+						"required" : [ "bonuses" ],
+						"properties" : {
+							"growsWithLevel" : {
+								"type" : "boolean",
+								"description" : "Specialty growth with level. Deprecated, use bonuses with updaters instead."
+							},
+							"bonuses" : {
+								"type" : "array",
+								"description" : "List of bonuses",
+								"items" : { "$ref" : "vcmi:bonus" }
+							}
+						}
 					},
-					"bonuses": {
-						"type":"array",
-						"description": "List of bonuses",
-						"items": { "$ref" : "vcmi:bonus" }
+					{
+						"type" : "object",
+						"description" : "List of bonuses",
+						"items" : { "$ref" : "vcmi:bonus" }
 					}
-				}
+				]
 			}
 		},
 		"spellbook": {

--- a/config/schemas/hero.json
+++ b/config/schemas/hero.json
@@ -115,11 +115,11 @@
 			"additionalItems" : true
 		},
 		"specialty": {
-			"type":"array",
-			"description": "Description of hero specialty using bonus system",	
-			"items": {
-				"oneOf" : [
-					{
+			"oneOf" : [
+				{
+					"type":"array",
+					"description": "Description of hero specialty using bonus system (deprecated)",
+					"items": {
 						"type" : "object",
 						"additionalProperties" : false,
 						"required" : [ "bonuses" ],
@@ -134,14 +134,26 @@
 								"items" : { "$ref" : "vcmi:bonus" }
 							}
 						}
-					},
-					{
-						"type" : "object",
-						"description" : "List of bonuses",
-						"items" : { "$ref" : "vcmi:bonus" }
 					}
-				]
-			}
+				},
+				{
+					"type" : "object",
+					"description": "Description of hero specialty using bonus system",
+					"additionalProperties" : false,
+					"required" : [ "bonuses" ],
+					"properties" : { 
+						"base" : {
+							"type" : "object",
+							"description" : "Will be merged with all bonuses."
+						},
+						"bonuses" : {
+							"type" : "object",
+							"description" : "Set of bonuses",
+							"additionalProperties" : { "$ref" : "vcmi:bonus" }
+						}
+					}
+				}
+			]
 		},
 		"spellbook": {
 			"type":"array",

--- a/config/schemas/hero.json
+++ b/config/schemas/hero.json
@@ -115,7 +115,7 @@
 			"additionalItems" : true
 		},
 		"specialty": {
-			"oneOf" : [
+			"anyOf" : [
 				{
 					"type":"array",
 					"description": "Description of hero specialty using bonus system (deprecated)",

--- a/config/skills.json
+++ b/config/skills.json
@@ -226,7 +226,8 @@
 		"base" : {
 			"effects" : {
 				"main" : {
-					"type" : "MANA_REGENERATION",
+					"subtype" : "skill.mysticism",
+					"type" : "SECONDARY_SKILL_PREMY",
 					"valueType" : "BASE_NUMBER"
 				}
 			}

--- a/lib/CHeroHandler.cpp
+++ b/lib/CHeroHandler.cpp
@@ -442,6 +442,7 @@ std::vector<std::shared_ptr<Bonus>> SpecialtyInfoToBonuses(const SSpecialtyInfo 
 	case 3: //spell damage bonus, level dependent but calculated elsewhere
 		bonus->type = Bonus::SPECIAL_SPELL_LEV;
 		bonus->subtype = spec.subtype;
+		bonus->updater.reset(new TimesHeroLevelUpdater());
 		result.push_back(bonus);
 		break;
 	case 4: //creature stat boost
@@ -483,6 +484,7 @@ std::vector<std::shared_ptr<Bonus>> SpecialtyInfoToBonuses(const SSpecialtyInfo 
 		bonus->type = Bonus::SPECIAL_BLESS_DAMAGE;
 		bonus->subtype = spec.subtype; //spell id if you ever wanted to use it otherwise
 		bonus->additionalInfo = spec.additionalinfo; //damage factor
+		bonus->updater.reset(new TimesHeroLevelUpdater());
 		result.push_back(bonus);
 		break;
 	case 7: //maxed mastery for spell
@@ -553,7 +555,14 @@ std::vector<std::shared_ptr<Bonus>> SpecialtyBonusToBonuses(const SSpecialtyBonu
 	std::vector<std::shared_ptr<Bonus>> result;
 	for(std::shared_ptr<Bonus> oldBonus : spec.bonuses)
 	{
-		if(spec.growsWithLevel)
+		if(oldBonus->type == Bonus::SPECIAL_SPELL_LEV || oldBonus->type == Bonus::SPECIAL_BLESS_DAMAGE)
+		{
+			// these bonuses used to auto-scale with hero level
+			std::shared_ptr<Bonus> newBonus = std::make_shared<Bonus>(*oldBonus);
+			newBonus->updater = std::make_shared<TimesHeroLevelUpdater>();
+			result.push_back(newBonus);
+		}
+		else if(spec.growsWithLevel)
 		{
 			std::shared_ptr<Bonus> newBonus = std::make_shared<Bonus>(*oldBonus);
 			switch(newBonus->type)

--- a/lib/CHeroHandler.cpp
+++ b/lib/CHeroHandler.cpp
@@ -536,14 +536,15 @@ std::vector<std::shared_ptr<Bonus>> SpecialtyInfoToBonuses(const SSpecialtyInfo 
 void CHeroHandler::beforeValidate(JsonNode & object)
 {
 	//handle "base" specialty info
-	const JsonNode & specialtyNode = object["specialty"];
+	JsonNode & specialtyNode = object["specialty"];
 	if(specialtyNode.getType() == JsonNode::JsonType::DATA_STRUCT)
 	{
 		const JsonNode & base = specialtyNode["base"];
 		if(!base.isNull())
 		{
-			for(auto keyValue : specialtyNode["bonuses"].Struct())
-				JsonUtils::inherit(keyValue.second, base);
+			JsonMap & bonuses = specialtyNode["bonuses"].Struct();
+			for(std::pair<std::string, JsonNode> keyValue : bonuses)
+				JsonUtils::inherit(bonuses[keyValue.first], base);
 		}
 	}
 }

--- a/lib/CHeroHandler.cpp
+++ b/lib/CHeroHandler.cpp
@@ -542,18 +542,28 @@ void CHeroHandler::loadHeroSpecialty(CHero * hero, const JsonNode & node)
 		return bonus;
 	};
 
-	//deprecated, used only for original spciealties
-	for(const JsonNode &specialty : node["specialties"].Vector())
+	//deprecated, used only for original specialties
+	const JsonNode & specialties = node["specialties"];
+	if (!specialties.isNull())
 	{
-		SSpecialtyInfo spec;
+		logMod->warn("Hero %s has deprecated specialties format. New format:", hero->identifier);
+		JsonNode specVec(JsonNode::DATA_VECTOR);
+		for(const JsonNode &specialty : node["specialties"].Vector())
+		{
+			SSpecialtyInfo spec;
 
-		spec.type = specialty["type"].Float();
-		spec.val = specialty["val"].Float();
-		spec.subtype = specialty["subtype"].Float();
-		spec.additionalinfo = specialty["info"].Float();
+			spec.type = specialty["type"].Float();
+			spec.val = specialty["val"].Float();
+			spec.subtype = specialty["subtype"].Float();
+			spec.additionalinfo = specialty["info"].Float();
 
-		for(std::shared_ptr<Bonus> bonus : SpecialtyInfoToBonuses(spec, sid))
-			hero->specialty.push_back(bonus);
+			for(std::shared_ptr<Bonus> bonus : SpecialtyInfoToBonuses(spec, sid))
+			{
+				hero->specialty.push_back(bonus);
+				specVec.Vector().push_back(bonus->toJsonNode());
+			}
+		}
+		logMod->info("\"specialty\" = %s", specVec.toJson());
 	}
 	//new format, using bonus system
 	for(const JsonNode & specialty : node["specialty"].Vector())

--- a/lib/CHeroHandler.cpp
+++ b/lib/CHeroHandler.cpp
@@ -537,7 +537,7 @@ void CHeroHandler::beforeValidate(JsonNode & object)
 {
 	//handle "base" specialty info
 	const JsonNode & specialtyNode = object["specialty"];
-	if(specialtyNode.getType() == JsonNode::DATA_STRUCT)
+	if(specialtyNode.getType() == JsonNode::JsonType::DATA_STRUCT)
 	{
 		const JsonNode & base = specialtyNode["base"];
 		if(!base.isNull())
@@ -577,7 +577,7 @@ void CHeroHandler::loadHeroSpecialty(CHero * hero, const JsonNode & node)
 	}
 	//new(er) format, using bonus system
 	const JsonNode & specialtyNode = node["specialty"];
-	if(specialtyNode.getType() == JsonNode::DATA_VECTOR)
+	if(specialtyNode.getType() == JsonNode::JsonType::DATA_VECTOR)
 	{
 		//deprecated middle-aged format
 		for(const JsonNode & specialty : node["specialty"].Vector())
@@ -586,7 +586,7 @@ void CHeroHandler::loadHeroSpecialty(CHero * hero, const JsonNode & node)
 				hero->specialty.push_back(prepSpec(JsonUtils::parseBonus(bonus)));
 		}
 	}
-	else if(specialtyNode.getType() == JsonNode::DATA_STRUCT)
+	else if(specialtyNode.getType() == JsonNode::JsonType::DATA_STRUCT)
 	{
 		//proper new format
 		for(auto keyValue : specialtyNode["bonuses"].Struct())
@@ -792,7 +792,7 @@ void CHeroHandler::afterLoadFinalization()
 			specNode["bonuses"].Struct();
 			for(int i = 0; i < specVec.size(); i++)
 				specNode["bonuses"][specNames[i]] = specVec[i];
-			logMod->trace("\"specialty\" : %s", specNode.toJson());
+			logMod->trace("\"specialty\" : %s", specNode.toJson(true));
 		}
 	}
 }

--- a/lib/CHeroHandler.cpp
+++ b/lib/CHeroHandler.cpp
@@ -766,7 +766,8 @@ void CHeroHandler::afterLoadFinalization()
 				if(!base.isEmpty())
 				{
 					specNode["base"] = base;
-					//TODO: subtract base from bonuses
+					for(JsonNode & node : specVec)
+						node = JsonUtils::difference(node, base);
 				}
 			}
 			// add json for bonuses

--- a/lib/CHeroHandler.cpp
+++ b/lib/CHeroHandler.cpp
@@ -492,9 +492,9 @@ std::vector<std::shared_ptr<Bonus>> SpecialtyInfoToBonuses(const SSpecialtyInfo 
 			//propagate for regular upgrades of base creature
 			for(auto cre_id : creatures[spec.subtype]->upgrades)
 			{
-				bonus = std::make_shared<Bonus>(*bonus);
-				bonus->subtype = cre_id;
-				result.push_back(bonus);
+				std::shared_ptr<Bonus> upgradeUpgradedVersion = std::make_shared<Bonus>(*bonus);
+				upgradeUpgradedVersion->subtype = cre_id;
+				result.push_back(upgradeUpgradedVersion);
 			}
 		}
 		break;
@@ -613,10 +613,10 @@ void CHeroHandler::loadHeroSpecialty(CHero * hero, const JsonNode & node)
 		for(const JsonNode &specialty : specialtiesNode.Vector())
 		{
 			SSpecialtyInfo spec;
-			spec.type = specialty["type"].Float();
-			spec.val = specialty["val"].Float();
-			spec.subtype = specialty["subtype"].Float();
-			spec.additionalinfo = specialty["info"].Float();
+			spec.type = specialty["type"].Integer();
+			spec.val = specialty["val"].Integer();
+			spec.subtype = specialty["subtype"].Integer();
+			spec.additionalinfo = specialty["info"].Integer();
 			//we convert after loading completes, to have all identifiers for json logging
 			hero->specDeprecated.push_back(spec);
 		}

--- a/lib/CHeroHandler.cpp
+++ b/lib/CHeroHandler.cpp
@@ -549,7 +549,7 @@ void CHeroHandler::loadHeroSpecialty(CHero * hero, const JsonNode & node)
 	if (!specialties.isNull())
 	{
 		logMod->warn("Hero %s has deprecated specialties format. New format:", hero->identifier);
-		JsonNode specVec(JsonNode::DATA_VECTOR);
+		JsonNode specVec(JsonNode::JsonType::DATA_VECTOR);
 		for(const JsonNode &specialty : node["specialties"].Vector())
 		{
 			SSpecialtyInfo spec;

--- a/lib/CHeroHandler.cpp
+++ b/lib/CHeroHandler.cpp
@@ -408,12 +408,12 @@ std::vector<std::shared_ptr<Bonus>> SpecialtyInfoToBonuses(const SSpecialtyInfo 
 			int stepSize = specCreature.level ? specCreature.level : 5;
 
 			bonus->subtype = PrimarySkill::ATTACK;
-			bonus->updater.reset(new ScalingUpdater(specCreature.getAttack(false), stepSize));
+			bonus->updater.reset(new GrowsWithLevelUpdater(specCreature.getAttack(false), stepSize));
 			result.push_back(bonus);
 
 			bonus = std::make_shared<Bonus>(*bonus);
 			bonus->subtype = PrimarySkill::DEFENSE;
-			bonus->updater.reset(new ScalingUpdater(specCreature.getDefence(false), stepSize));
+			bonus->updater.reset(new GrowsWithLevelUpdater(specCreature.getDefence(false), stepSize));
 			result.push_back(bonus);
 		}
 		break;
@@ -421,8 +421,7 @@ std::vector<std::shared_ptr<Bonus>> SpecialtyInfoToBonuses(const SSpecialtyInfo 
 		bonus->type = Bonus::SECONDARY_SKILL_PREMY;
 		bonus->valType = Bonus::PERCENT_TO_BASE;
 		bonus->subtype = spec.subtype;
-		bonus->val = 0;
-		bonus->updater.reset(new ScalingUpdater(spec.val * 20));
+		bonus->updater.reset(new TimesHeroLevelUpdater());
 		result.push_back(bonus);
 		break;
 	case 3: //spell damage bonus, level dependent but calculated elsewhere
@@ -548,8 +547,7 @@ std::vector<std::shared_ptr<Bonus>> SpecialtyBonusToBonuses(const SSpecialtyBonu
 				break; // ignore - used to be overwritten based on SPECIAL_SECONDARY_SKILL
 			case Bonus::SPECIAL_SECONDARY_SKILL:
 				newBonus->type = Bonus::SECONDARY_SKILL_PREMY;
-				newBonus->updater = std::make_shared<ScalingUpdater>(newBonus->val * 20);
-				newBonus->val = 0; // for json printing
+				newBonus->updater = std::make_shared<TimesHeroLevelUpdater>();
 				result.push_back(newBonus);
 				break;
 			case Bonus::PRIMARY_SKILL:
@@ -561,7 +559,7 @@ std::vector<std::shared_ptr<Bonus>> SpecialtyBonusToBonuses(const SSpecialtyBonu
 						const CCreature * cre = creatureLimiter->creature;
 						int creStat = newBonus->subtype == PrimarySkill::ATTACK ? cre->getAttack(false) : cre->getDefence(false);
 						int creLevel = cre->level ? cre->level : 5;
-						newBonus->updater = std::make_shared<ScalingUpdater>(creStat, creLevel);
+						newBonus->updater = std::make_shared<GrowsWithLevelUpdater>(creStat, creLevel);
 					}
 					result.push_back(newBonus);
 				}

--- a/lib/CHeroHandler.cpp
+++ b/lib/CHeroHandler.cpp
@@ -392,142 +392,142 @@ std::vector<std::shared_ptr<Bonus>> SpecialtyInfoToBonuses(const SSpecialtyInfo 
 
 	switch (spec.type)
 	{
-		case 1: //creature specialty
-			{
-				const CCreature &specCreature = *VLC->creh->creatures[spec.additionalinfo]; //creature in which we have specialty
-				bonus->limiter.reset(new CCreatureTypeLimiter(specCreature, true));
+	case 1: //creature specialty
+		{
+			const CCreature &specCreature = *VLC->creh->creatures[spec.additionalinfo]; //creature in which we have specialty
+			bonus->limiter.reset(new CCreatureTypeLimiter(specCreature, true));
 
-				bonus->type = Bonus::STACKS_SPEED;
-				bonus->valType = Bonus::ADDITIVE_VALUE;
-				bonus->val = 1;
-				result.push_back(bonus);
-
-				bonus = std::make_shared<Bonus>(*bonus);
-				bonus->type = Bonus::PRIMARY_SKILL;
-				bonus->val = 0;
-				int stepSize = specCreature.level ? specCreature.level : 5;
-
-				bonus->subtype = PrimarySkill::ATTACK;
-				bonus->updater.reset(new ScalingUpdater(specCreature.getAttack(false), stepSize));
-				result.push_back(bonus);
-
-				bonus = std::make_shared<Bonus>(*bonus);
-				bonus->subtype = PrimarySkill::DEFENSE;
-				bonus->updater.reset(new ScalingUpdater(specCreature.getDefence(false), stepSize));
-				result.push_back(bonus);
-			}
-			break;
-		case 2: //secondary skill
-			bonus->type = Bonus::SECONDARY_SKILL_PREMY;
-			bonus->valType = Bonus::PERCENT_TO_BASE;
-			bonus->subtype = spec.subtype;
-			bonus->val = 0;
-			bonus->updater.reset(new ScalingUpdater(spec.val * 20));
-			result.push_back(bonus);
-			break;
-		case 3: //spell damage bonus, level dependent but calculated elsewhere
-			bonus->type = Bonus::SPECIAL_SPELL_LEV;
-			bonus->subtype = spec.subtype;
-			result.push_back(bonus);
-			break;
-		case 4: //creature stat boost
-			switch (spec.subtype)
-			{
-				case 1:
-					bonus->type = Bonus::PRIMARY_SKILL;
-					bonus->subtype = PrimarySkill::ATTACK;
-					break;
-				case 2:
-					bonus->type = Bonus::PRIMARY_SKILL;
-					bonus->subtype = PrimarySkill::DEFENSE;
-					break;
-				case 3:
-					bonus->type = Bonus::CREATURE_DAMAGE;
-					bonus->subtype = 0; //both min and max
-					break;
-				case 4:
-					bonus->type = Bonus::STACK_HEALTH;
-					break;
-				case 5:
-					bonus->type = Bonus::STACKS_SPEED;
-					break;
-				default:
-					logMod->warn("Unknown subtype for specialty 4");
-					return result;
-			}
-			bonus->valType = Bonus::ADDITIVE_VALUE;
-			bonus->limiter.reset(new CCreatureTypeLimiter(*VLC->creh->creatures[spec.additionalinfo], true));
-			result.push_back(bonus);
-			break;
-		case 5: //spell damage bonus in percent
-			bonus->type = Bonus::SPECIFIC_SPELL_DAMAGE;
-			bonus->valType = Bonus::BASE_NUMBER; //current spell system is screwed
-			bonus->subtype = spec.subtype; //spell id
-			result.push_back(bonus);
-			break;
-		case 6: //damage bonus for bless (Adela)
-			bonus->type = Bonus::SPECIAL_BLESS_DAMAGE;
-			bonus->subtype = spec.subtype; //spell id if you ever wanted to use it otherwise
-			bonus->additionalInfo = spec.additionalinfo; //damage factor
-			result.push_back(bonus);
-			break;
-		case 7: //maxed mastery for spell
-			bonus->type = Bonus::MAXED_SPELL;
-			bonus->subtype = spec.subtype; //spell id
-			result.push_back(bonus);
-			break;
-		case 8: //peculiar spells - enchantments
-			bonus->type = Bonus::SPECIAL_PECULIAR_ENCHANT;
-			bonus->subtype = spec.subtype; //spell id
-			bonus->additionalInfo = spec.additionalinfo; //0, 1 for Coronius
-			result.push_back(bonus);
-			break;
-		case 9: //upgrade creatures
-			{
-				const auto &creatures = VLC->creh->creatures;
-				bonus->type = Bonus::SPECIAL_UPGRADE;
-				bonus->subtype = spec.subtype; //base id
-				bonus->additionalInfo = spec.additionalinfo; //target id
-				result.push_back(bonus);
-				//propagate for regular upgrades of base creature
-				for(auto cre_id : creatures[spec.subtype]->upgrades)
-				{
-					bonus = std::make_shared<Bonus>(*bonus);
-					bonus->subtype = cre_id;
-					result.push_back(bonus);
-				}
-			}
-			break;
-		case 10: //resource generation
-			bonus->type = Bonus::GENERATE_RESOURCE;
-			bonus->subtype = spec.subtype;
-			result.push_back(bonus);
-			break;
-		case 11: //starting skill with mastery (Adrienne)
-			logMod->warn("Secondary skill mastery is no longer supported as specialty.");
-			break;
-		case 12: //army speed
 			bonus->type = Bonus::STACKS_SPEED;
-			result.push_back(bonus);
-			break;
-		case 13: //Dragon bonuses (Mutare)
-			bonus->type = Bonus::PRIMARY_SKILL;
 			bonus->valType = Bonus::ADDITIVE_VALUE;
-			switch (spec.subtype)
-			{
-				case 1:
-					bonus->subtype = PrimarySkill::ATTACK;
-					break;
-				case 2:
-					bonus->subtype = PrimarySkill::DEFENSE;
-					break;
-			}
-			bonus->limiter.reset(new HasAnotherBonusLimiter(Bonus::DRAGON_NATURE));
+			bonus->val = 1;
 			result.push_back(bonus);
+
+			bonus = std::make_shared<Bonus>(*bonus);
+			bonus->type = Bonus::PRIMARY_SKILL;
+			bonus->val = 0;
+			int stepSize = specCreature.level ? specCreature.level : 5;
+
+			bonus->subtype = PrimarySkill::ATTACK;
+			bonus->updater.reset(new ScalingUpdater(specCreature.getAttack(false), stepSize));
+			result.push_back(bonus);
+
+			bonus = std::make_shared<Bonus>(*bonus);
+			bonus->subtype = PrimarySkill::DEFENSE;
+			bonus->updater.reset(new ScalingUpdater(specCreature.getDefence(false), stepSize));
+			result.push_back(bonus);
+		}
+		break;
+	case 2: //secondary skill
+		bonus->type = Bonus::SECONDARY_SKILL_PREMY;
+		bonus->valType = Bonus::PERCENT_TO_BASE;
+		bonus->subtype = spec.subtype;
+		bonus->val = 0;
+		bonus->updater.reset(new ScalingUpdater(spec.val * 20));
+		result.push_back(bonus);
+		break;
+	case 3: //spell damage bonus, level dependent but calculated elsewhere
+		bonus->type = Bonus::SPECIAL_SPELL_LEV;
+		bonus->subtype = spec.subtype;
+		result.push_back(bonus);
+		break;
+	case 4: //creature stat boost
+		switch (spec.subtype)
+		{
+		case 1:
+			bonus->type = Bonus::PRIMARY_SKILL;
+			bonus->subtype = PrimarySkill::ATTACK;
+			break;
+		case 2:
+			bonus->type = Bonus::PRIMARY_SKILL;
+			bonus->subtype = PrimarySkill::DEFENSE;
+			break;
+		case 3:
+			bonus->type = Bonus::CREATURE_DAMAGE;
+			bonus->subtype = 0; //both min and max
+			break;
+		case 4:
+			bonus->type = Bonus::STACK_HEALTH;
+			break;
+		case 5:
+			bonus->type = Bonus::STACKS_SPEED;
 			break;
 		default:
-			logMod->warn("Unknown hero specialty %d", spec.type);
+			logMod->warn("Unknown subtype for specialty 4");
+			return result;
+		}
+		bonus->valType = Bonus::ADDITIVE_VALUE;
+		bonus->limiter.reset(new CCreatureTypeLimiter(*VLC->creh->creatures[spec.additionalinfo], true));
+		result.push_back(bonus);
+		break;
+	case 5: //spell damage bonus in percent
+		bonus->type = Bonus::SPECIFIC_SPELL_DAMAGE;
+		bonus->valType = Bonus::BASE_NUMBER; //current spell system is screwed
+		bonus->subtype = spec.subtype; //spell id
+		result.push_back(bonus);
+		break;
+	case 6: //damage bonus for bless (Adela)
+		bonus->type = Bonus::SPECIAL_BLESS_DAMAGE;
+		bonus->subtype = spec.subtype; //spell id if you ever wanted to use it otherwise
+		bonus->additionalInfo = spec.additionalinfo; //damage factor
+		result.push_back(bonus);
+		break;
+	case 7: //maxed mastery for spell
+		bonus->type = Bonus::MAXED_SPELL;
+		bonus->subtype = spec.subtype; //spell id
+		result.push_back(bonus);
+		break;
+	case 8: //peculiar spells - enchantments
+		bonus->type = Bonus::SPECIAL_PECULIAR_ENCHANT;
+		bonus->subtype = spec.subtype; //spell id
+		bonus->additionalInfo = spec.additionalinfo; //0, 1 for Coronius
+		result.push_back(bonus);
+		break;
+	case 9: //upgrade creatures
+		{
+			const auto &creatures = VLC->creh->creatures;
+			bonus->type = Bonus::SPECIAL_UPGRADE;
+			bonus->subtype = spec.subtype; //base id
+			bonus->additionalInfo = spec.additionalinfo; //target id
+			result.push_back(bonus);
+			//propagate for regular upgrades of base creature
+			for(auto cre_id : creatures[spec.subtype]->upgrades)
+			{
+				bonus = std::make_shared<Bonus>(*bonus);
+				bonus->subtype = cre_id;
+				result.push_back(bonus);
+			}
+		}
+		break;
+	case 10: //resource generation
+		bonus->type = Bonus::GENERATE_RESOURCE;
+		bonus->subtype = spec.subtype;
+		result.push_back(bonus);
+		break;
+	case 11: //starting skill with mastery (Adrienne)
+		logMod->warn("Secondary skill mastery is no longer supported as specialty.");
+		break;
+	case 12: //army speed
+		bonus->type = Bonus::STACKS_SPEED;
+		result.push_back(bonus);
+		break;
+	case 13: //Dragon bonuses (Mutare)
+		bonus->type = Bonus::PRIMARY_SKILL;
+		bonus->valType = Bonus::ADDITIVE_VALUE;
+		switch(spec.subtype)
+		{
+		case 1:
+			bonus->subtype = PrimarySkill::ATTACK;
 			break;
+		case 2:
+			bonus->subtype = PrimarySkill::DEFENSE;
+			break;
+		}
+		bonus->limiter.reset(new HasAnotherBonusLimiter(Bonus::DRAGON_NATURE));
+		result.push_back(bonus);
+		break;
+	default:
+		logMod->warn("Unknown hero specialty %d", spec.type);
+		break;
 	}
 
 	return result;

--- a/lib/CHeroHandler.cpp
+++ b/lib/CHeroHandler.cpp
@@ -815,6 +815,8 @@ void CHeroHandler::afterLoadFinalization()
 				for(std::shared_ptr<Bonus> b : SpecialtyBonusToBonuses(spec))
 					convertedBonuses.push_back(b);
 			}
+			hero->specDeprecated.clear();
+			hero->specialtyDeprecated.clear();
 			// store and create json for logging
 			std::vector<JsonNode> specVec;
 			std::vector<std::string> specNames;
@@ -833,7 +835,6 @@ void CHeroHandler::afterLoadFinalization()
 				}
 				specNames.push_back(bonusName);
 			}
-			hero->specDeprecated.clear();
 			// log new format for easy copy-and-paste
 			JsonNode specNode(JsonNode::JsonType::DATA_STRUCT);
 			if(specVec.size() > 1)

--- a/lib/CHeroHandler.cpp
+++ b/lib/CHeroHandler.cpp
@@ -840,7 +840,7 @@ void CHeroHandler::afterLoadFinalization()
 			if(specVec.size() > 1)
 			{
 				JsonNode base = JsonUtils::intersect(specVec);
-				if(!base.isEmpty())
+				if(base.containsBaseData())
 				{
 					specNode["base"] = base;
 					for(JsonNode & node : specVec)

--- a/lib/CHeroHandler.cpp
+++ b/lib/CHeroHandler.cpp
@@ -404,6 +404,7 @@ std::vector<std::shared_ptr<Bonus>> SpecialtyInfoToBonuses(const SSpecialtyInfo 
 
 				bonus = std::make_shared<Bonus>(*bonus);
 				bonus->type = Bonus::PRIMARY_SKILL;
+				bonus->val = 0;
 				int stepSize = specCreature.level ? specCreature.level : 5;
 
 				bonus->subtype = PrimarySkill::ATTACK;
@@ -420,6 +421,7 @@ std::vector<std::shared_ptr<Bonus>> SpecialtyInfoToBonuses(const SSpecialtyInfo 
 			bonus->type = Bonus::SECONDARY_SKILL_PREMY;
 			bonus->valType = Bonus::PERCENT_TO_BASE;
 			bonus->subtype = spec.subtype;
+			bonus->val = 0;
 			bonus->updater.reset(new ScalingUpdater(spec.val * 20));
 			result.push_back(bonus);
 			break;

--- a/lib/CHeroHandler.cpp
+++ b/lib/CHeroHandler.cpp
@@ -559,7 +559,7 @@ std::vector<std::shared_ptr<Bonus>> SpecialtyBonusToBonuses(const SSpecialtyBonu
 					if(creatureLimiter)
 					{
 						const CCreature * cre = creatureLimiter->creature;
-						int creStat = newBonus->subtype == PrimarySkill::ATTACK ? cre->Attack() : cre->Defense();
+						int creStat = newBonus->subtype == PrimarySkill::ATTACK ? cre->getAttack(false) : cre->getDefence(false);
 						int creLevel = cre->level ? cre->level : 5;
 						newBonus->updater = std::make_shared<ScalingUpdater>(creStat, creLevel);
 					}
@@ -823,7 +823,7 @@ void CHeroHandler::afterLoadFinalization()
 				hero->specialty.push_back(bonus);
 				specVec.push_back(bonus->toJsonNode());
 				// find fitting & unique bonus name
-				std::string bonusName = nameForBonus(*bonus);
+				std::string bonusName = bonus->nameForBonus();
 				if(vstd::contains(specNames, bonusName))
 				{
 					int suffix = 2;

--- a/lib/CHeroHandler.cpp
+++ b/lib/CHeroHandler.cpp
@@ -747,7 +747,7 @@ void CHeroHandler::afterLoadFinalization()
 				}
 			}
 			hero->specDeprecated.clear();
-			logMod->trace("\"specialty\" = %s", specVec.toJson());
+			logMod->trace("\"specialty\" : %s", specVec.toJson());
 		}
 	}
 }

--- a/lib/CHeroHandler.h
+++ b/lib/CHeroHandler.h
@@ -71,8 +71,9 @@ public:
 
 	CHeroClass * heroClass;
 	std::vector<std::pair<SecondarySkill, ui8> > secSkillsInit; //initial secondary skills; first - ID of skill, second - level of skill (1 - basic, 2 - adv., 3 - expert)
-	std::vector<SSpecialtyInfo> spec;
-	std::vector<SSpecialtyBonus> specialty;
+	std::vector<SSpecialtyInfo> specDeprecated;
+	std::vector<SSpecialtyBonus> specialtyDeprecated;
+	BonusList specialty;
 	std::set<SpellID> spells;
 	bool haveSpellBook;
 	bool special; // hero is special and won't be placed in game (unless preset on map), e.g. campaign heroes
@@ -98,7 +99,8 @@ public:
 		h & initialArmy;
 		h & heroClass;
 		h & secSkillsInit;
-		h & spec;
+		//h & specDeprecated;
+		//h & specialtyDeprecated;
 		h & specialty;
 		h & spells;
 		h & haveSpellBook;
@@ -119,6 +121,9 @@ public:
 		}
 	}
 };
+
+// convert deprecated format
+std::vector<std::shared_ptr<Bonus>> SpecialtyInfoToBonuses(const SSpecialtyInfo & spec, int sid);
 
 class DLL_LINKAGE CHeroClass
 {

--- a/lib/CHeroHandler.h
+++ b/lib/CHeroHandler.h
@@ -300,6 +300,7 @@ public:
 
 	std::vector<JsonNode> loadLegacyData(size_t dataSize) override;
 
+	void beforeValidate(JsonNode & object);
 	void loadObject(std::string scope, std::string name, const JsonNode & data) override;
 	void loadObject(std::string scope, std::string name, const JsonNode & data, size_t index) override;
 	void afterLoadFinalization() override;

--- a/lib/CHeroHandler.h
+++ b/lib/CHeroHandler.h
@@ -302,6 +302,7 @@ public:
 
 	void loadObject(std::string scope, std::string name, const JsonNode & data) override;
 	void loadObject(std::string scope, std::string name, const JsonNode & data, size_t index) override;
+	void afterLoadFinalization() override;
 
 	CHeroHandler();
 	~CHeroHandler();

--- a/lib/CHeroHandler.h
+++ b/lib/CHeroHandler.h
@@ -99,7 +99,7 @@ public:
 		h & initialArmy;
 		h & heroClass;
 		h & secSkillsInit;
-		if(version >= 778)
+		if(version >= 781)
 		{
 			h & specialty;
 		}

--- a/lib/CHeroHandler.h
+++ b/lib/CHeroHandler.h
@@ -130,6 +130,7 @@ public:
 
 // convert deprecated format
 std::vector<std::shared_ptr<Bonus>> SpecialtyInfoToBonuses(const SSpecialtyInfo & spec, int sid);
+std::vector<std::shared_ptr<Bonus>> SpecialtyBonusToBonuses(const SSpecialtyBonus & spec);
 
 class DLL_LINKAGE CHeroClass
 {

--- a/lib/CHeroHandler.h
+++ b/lib/CHeroHandler.h
@@ -99,9 +99,15 @@ public:
 		h & initialArmy;
 		h & heroClass;
 		h & secSkillsInit;
-		//h & specDeprecated;
-		//h & specialtyDeprecated;
-		h & specialty;
+		if(version >= 778)
+		{
+			h & specialty;
+		}
+		else
+		{
+			h & specDeprecated;
+			h & specialtyDeprecated;
+		}
 		h & spells;
 		h & haveSpellBook;
 		h & sex;

--- a/lib/HeroBonus.cpp
+++ b/lib/HeroBonus.cpp
@@ -1327,6 +1327,9 @@ DLL_LINKAGE std::ostream & operator<<(std::ostream &out, const Bonus &bonus)
 	printField(effectRange);
 #undef printField
 
+	if(bonus.updater)
+		out << "\tUpdater: " << bonus.updater->toString() << "\n";
+
 	return out;
 }
 
@@ -1571,6 +1574,11 @@ IUpdater::~IUpdater()
 {
 }
 
+std::string IUpdater::toString() const
+{
+	return typeid(*this).name();
+}
+
 ScalingUpdater::ScalingUpdater() : valPer20(0), stepSize(1)
 {
 }
@@ -1594,6 +1602,13 @@ bool ScalingUpdater::update(Bonus & b, const CBonusSystemNode & context) const
 		}
 	}
 	return false;
+}
+
+std::string ScalingUpdater::toString() const
+{
+	char buf[100];
+	sprintf(buf, "ScalingUpdater(valPer20=%d, stepSize=%d)", valPer20, stepSize);
+	return std::string(buf);
 }
 
 std::shared_ptr<Bonus> Bonus::addUpdater(TUpdaterPtr Updater)

--- a/lib/HeroBonus.cpp
+++ b/lib/HeroBonus.cpp
@@ -1169,17 +1169,17 @@ JsonNode subtypeToJson(Bonus::BonusType type, int subtype)
 	switch(type)
 	{
 	case Bonus::PRIMARY_SKILL:
-		return JsonUtils::stringNode(PrimarySkill::names[subtype]);
+		return JsonUtils::stringNode("primSkill." + PrimarySkill::names[subtype]);
 	case Bonus::SECONDARY_SKILL_PREMY:
-		return JsonUtils::stringNode(NSecondarySkill::names[subtype]);
+		return JsonUtils::stringNode("skill." + NSecondarySkill::names[subtype]);
 	case Bonus::SPECIAL_SPELL_LEV:
 	case Bonus::SPECIFIC_SPELL_DAMAGE:
 	case Bonus::SPECIAL_BLESS_DAMAGE:
 	case Bonus::MAXED_SPELL:
 	case Bonus::SPECIAL_PECULIAR_ENCHANT:
-		return JsonUtils::stringNode((*VLC->spellh)[SpellID::ESpellID(subtype)]->identifier);
+		return JsonUtils::stringNode("spell." + (*VLC->spellh)[SpellID::ESpellID(subtype)]->identifier);
 	case Bonus::SPECIAL_UPGRADE:
-		return JsonUtils::stringNode(CreatureID::encode(subtype));
+		return JsonUtils::stringNode("creature." + CreatureID::encode(subtype));
 	case Bonus::GENERATE_RESOURCE:
 		return JsonUtils::stringNode(GameConstants::RESOURCE_NAMES[subtype]);
 	default:
@@ -1192,7 +1192,7 @@ JsonNode additionalInfoToJson(Bonus::BonusType type, int addInfo)
 	switch(type)
 	{
 	case Bonus::SPECIAL_UPGRADE:
-		return JsonUtils::stringNode(CreatureID::encode(addInfo));
+		return JsonUtils::stringNode("creature." + CreatureID::encode(addInfo));
 	default:
 		return JsonUtils::intNode(addInfo);
 	}
@@ -1716,4 +1716,27 @@ JsonNode ScalingUpdater::toJsonNode() const
 		root["parameters"].Vector().push_back(JsonUtils::intNode(stepSize));
 
 	return root;
+}
+
+std::string nameForBonus(const Bonus & bonus)
+{
+	switch(bonus.type)
+	{
+	case Bonus::PRIMARY_SKILL:
+		return PrimarySkill::names[bonus.subtype];
+	case Bonus::SECONDARY_SKILL_PREMY:
+		return NSecondarySkill::names[bonus.subtype];
+	case Bonus::SPECIAL_SPELL_LEV:
+	case Bonus::SPECIFIC_SPELL_DAMAGE:
+	case Bonus::SPECIAL_BLESS_DAMAGE:
+	case Bonus::MAXED_SPELL:
+	case Bonus::SPECIAL_PECULIAR_ENCHANT:
+		return (*VLC->spellh)[SpellID::ESpellID(bonus.subtype)]->identifier;
+	case Bonus::SPECIAL_UPGRADE:
+		return CreatureID::encode(bonus.subtype) + "2" + CreatureID::encode(bonus.additionalInfo);
+	case Bonus::GENERATE_RESOURCE:
+		return GameConstants::RESOURCE_NAMES[bonus.subtype];
+	default:
+		return vstd::findKey(bonusNameMap, bonus.type);
+	}
 }

--- a/lib/HeroBonus.cpp
+++ b/lib/HeroBonus.cpp
@@ -1173,7 +1173,7 @@ JsonNode subtypeToJson(Bonus::BonusType type, int subtype)
 	case Bonus::SPECIAL_UPGRADE:
 		return JsonUtils::stringNode("creature." + CreatureID::encode(subtype));
 	case Bonus::GENERATE_RESOURCE:
-		return JsonUtils::stringNode(GameConstants::RESOURCE_NAMES[subtype]);
+		return JsonUtils::stringNode("resource." + GameConstants::RESOURCE_NAMES[subtype]);
 	default:
 		return JsonUtils::intNode(subtype);
 	}
@@ -1202,7 +1202,7 @@ JsonNode Bonus::toJsonNode() const
 	if(val != 0)
 		root["val"].Integer() = val;
 	if(valType != ADDITIVE_VALUE)
-		root["valType"].String() = vstd::findKey(bonusValueMap, valType);
+		root["valueType"].String() = vstd::findKey(bonusValueMap, valType);
 	if(limiter)
 		root["limiters"].Vector().push_back(limiter->toJsonNode());
 	if(updater)

--- a/lib/HeroBonus.cpp
+++ b/lib/HeroBonus.cpp
@@ -1177,8 +1177,7 @@ JsonNode subtypeToJson(Bonus::BonusType type, int subtype)
 	case Bonus::SPECIAL_BLESS_DAMAGE:
 	case Bonus::MAXED_SPELL:
 	case Bonus::SPECIAL_PECULIAR_ENCHANT:
-		//return JsonUtils::stringNode((*VLC->spellh)[SpellID::ESpellID(subtype)]->identifier);
-		return JsonUtils::intNode(subtype); //Issue 2790
+		return JsonUtils::stringNode((*VLC->spellh)[SpellID::ESpellID(subtype)]->identifier);
 	case Bonus::SPECIAL_UPGRADE:
 		return JsonUtils::stringNode(CreatureID::encode(subtype));
 	case Bonus::GENERATE_RESOURCE:

--- a/lib/HeroBonus.cpp
+++ b/lib/HeroBonus.cpp
@@ -827,6 +827,8 @@ void CBonusSystemNode::addNewBonus(const std::shared_ptr<Bonus>& b)
 	assert(!vstd::contains(exportedBonuses, b));
 	exportedBonuses.push_back(b);
 	exportBonus(b);
+	if(b->updater)
+		b->updater->update(*b, *this);
 	CBonusSystemNode::treeHasChanged();
 }
 
@@ -1563,7 +1565,11 @@ void LimiterList::add( TLimiterPtr limiter )
 	limiters.push_back(limiter);
 }
 
-bool ScalingUpdater::update(Bonus & b, const CBonusSystemNode & context)
+ScalingUpdater::ScalingUpdater(int valPer20, int stepSize) : valPer20(valPer20), stepSize(stepSize)
+{
+}
+
+bool ScalingUpdater::update(Bonus & b, const CBonusSystemNode & context) const
 {
 	if(context.getNodeType() == CBonusSystemNode::HERO)
 	{

--- a/lib/HeroBonus.cpp
+++ b/lib/HeroBonus.cpp
@@ -1565,6 +1565,16 @@ void LimiterList::add( TLimiterPtr limiter )
 	limiters.push_back(limiter);
 }
 
+// Updaters
+
+IUpdater::~IUpdater()
+{
+}
+
+ScalingUpdater::ScalingUpdater() : valPer20(0), stepSize(1)
+{
+}
+
 ScalingUpdater::ScalingUpdater(int valPer20, int stepSize) : valPer20(valPer20), stepSize(stepSize)
 {
 }

--- a/lib/HeroBonus.cpp
+++ b/lib/HeroBonus.cpp
@@ -1218,6 +1218,31 @@ JsonNode Bonus::toJsonNode() const
 	return root;
 }
 
+std::string Bonus::nameForBonus() const
+{
+	switch(type)
+	{
+	case Bonus::PRIMARY_SKILL:
+		return PrimarySkill::names[subtype];
+	case Bonus::SECONDARY_SKILL_PREMY:
+		return NSecondarySkill::names[subtype];
+	case Bonus::SPECIAL_SPELL_LEV:
+	case Bonus::SPECIFIC_SPELL_DAMAGE:
+	case Bonus::SPECIAL_BLESS_DAMAGE:
+	case Bonus::MAXED_SPELL:
+	case Bonus::SPECIAL_PECULIAR_ENCHANT:
+		return (*VLC->spellh)[SpellID::ESpellID(subtype)]->identifier;
+	case Bonus::SPECIAL_UPGRADE:
+		return CreatureID::encode(subtype) + "2" + CreatureID::encode(additionalInfo);
+	case Bonus::GENERATE_RESOURCE:
+		return GameConstants::RESOURCE_NAMES[subtype];
+	case Bonus::STACKS_SPEED:
+		return "speed";
+	default:
+		return vstd::findKey(bonusNameMap, type);
+	}
+}
+
 Bonus::Bonus(ui16 Dur, BonusType Type, BonusSource Src, si32 Val, ui32 ID, std::string Desc, si32 Subtype)
 	: duration(Dur), type(Type), subtype(Subtype), source(Src), val(Val), sid(ID), description(Desc)
 {
@@ -1716,29 +1741,4 @@ JsonNode ScalingUpdater::toJsonNode() const
 		root["parameters"].Vector().push_back(JsonUtils::intNode(stepSize));
 
 	return root;
-}
-
-std::string nameForBonus(const Bonus & bonus)
-{
-	switch(bonus.type)
-	{
-	case Bonus::PRIMARY_SKILL:
-		return PrimarySkill::names[bonus.subtype];
-	case Bonus::SECONDARY_SKILL_PREMY:
-		return NSecondarySkill::names[bonus.subtype];
-	case Bonus::SPECIAL_SPELL_LEV:
-	case Bonus::SPECIFIC_SPELL_DAMAGE:
-	case Bonus::SPECIAL_BLESS_DAMAGE:
-	case Bonus::MAXED_SPELL:
-	case Bonus::SPECIAL_PECULIAR_ENCHANT:
-		return (*VLC->spellh)[SpellID::ESpellID(bonus.subtype)]->identifier;
-	case Bonus::SPECIAL_UPGRADE:
-		return CreatureID::encode(bonus.subtype) + "2" + CreatureID::encode(bonus.additionalInfo);
-	case Bonus::GENERATE_RESOURCE:
-		return GameConstants::RESOURCE_NAMES[bonus.subtype];
-	case Bonus::STACKS_SPEED:
-		return "speed";
-	default:
-		return vstd::findKey(bonusNameMap, bonus.type);
-	}
 }

--- a/lib/HeroBonus.cpp
+++ b/lib/HeroBonus.cpp
@@ -20,6 +20,7 @@
 #include "CSkillHandler.h"
 #include "CStack.h"
 #include "CArtHandler.h"
+#include "StringConstants.h"
 
 #define FOREACH_PARENT(pname) 	TNodes lparents; getParents(lparents); for(CBonusSystemNode *pname : lparents)
 #define FOREACH_CPARENT(pname) 	TCNodes lparents; getParents(lparents); for(const CBonusSystemNode *pname : lparents)
@@ -1163,17 +1164,37 @@ std::string Bonus::Description() const
 	return str.str();
 }
 
+JsonNode subtypeToJson(Bonus::BonusType type, int subtype)
+{
+	JsonNode node;
+
+	switch(type)
+	{
+	case Bonus::PRIMARY_SKILL:
+		node.String() = PrimarySkill::names[subtype];
+		break;
+	case Bonus::SECONDARY_SKILL_PREMY:
+		node.String() = NSecondarySkill::names[subtype];
+		break;
+	default:
+		node.Integer() = subtype;
+		break;
+	}
+
+	return node;
+}
+
 JsonNode Bonus::toJsonNode() const
 {
 	JsonNode root(JsonNode::DATA_STRUCT);
 
-	root["type"].Float() = type;
+	root["type"].String() = vstd::findKey(bonusNameMap, type);
 	if(subtype != -1)
-		root["subtype"].Float() = subtype;
+		root["subtype"] = subtypeToJson(type, subtype);
 	if(val != 0)
-		root["val"].Float() = val;
+		root["val"].Integer() = val;
 	if(valType != ADDITIVE_VALUE)
-		root["valType"].Float() = valType;
+		root["valType"].String() = vstd::findKey(bonusValueMap, valType);
 	if(limiter)
 		root["limiter"] = limiter->toJsonNode();
 	if(updater)

--- a/lib/HeroBonus.cpp
+++ b/lib/HeroBonus.cpp
@@ -1759,9 +1759,7 @@ const std::shared_ptr<Bonus> GrowsWithLevelUpdater::update(const std::shared_ptr
 
 std::string GrowsWithLevelUpdater::toString() const
 {
-	char buf[100];
-	sprintf(buf, "GrowsWithLevelUpdater(valPer20=%d, stepSize=%d)", valPer20, stepSize);
-	return std::string(buf);
+	return boost::str(boost::format("GrowsWithLevelUpdater(valPer20=%d, stepSize=%d)") % valPer20 % stepSize);
 }
 
 JsonNode GrowsWithLevelUpdater::toJsonNode() const

--- a/lib/HeroBonus.cpp
+++ b/lib/HeroBonus.cpp
@@ -1543,3 +1543,20 @@ void LimiterList::add( TLimiterPtr limiter )
 {
 	limiters.push_back(limiter);
 }
+
+void ScalingUpdater::update(BonusUpdateContext & context)
+{
+	if(context.node.getNodeType() == CBonusSystemNode::HERO)
+	{
+		int level = static_cast<const CGHeroInstance &>(context.node).level;
+		int steps = stepSize ? level / stepSize : level;
+		//rounding follows format for HMM3 creature specialty bonus
+		context.b->val = (valPer20 * steps + 19) / 20;
+	}
+}
+
+std::shared_ptr<Bonus> Bonus::addUpdater(TUpdaterPtr Updater)
+{
+	updater = Updater;
+	return this->shared_from_this();
+}

--- a/lib/HeroBonus.cpp
+++ b/lib/HeroBonus.cpp
@@ -1166,31 +1166,48 @@ std::string Bonus::Description() const
 
 JsonNode subtypeToJson(Bonus::BonusType type, int subtype)
 {
-	JsonNode node;
-
 	switch(type)
 	{
 	case Bonus::PRIMARY_SKILL:
-		node.String() = PrimarySkill::names[subtype];
-		break;
+		return JsonUtils::stringNode(PrimarySkill::names[subtype]);
 	case Bonus::SECONDARY_SKILL_PREMY:
-		node.String() = NSecondarySkill::names[subtype];
-		break;
+		return JsonUtils::stringNode(NSecondarySkill::names[subtype]);
+	case Bonus::SPECIAL_SPELL_LEV:
+	case Bonus::SPECIFIC_SPELL_DAMAGE:
+	case Bonus::SPECIAL_BLESS_DAMAGE:
+	case Bonus::MAXED_SPELL:
+	case Bonus::SPECIAL_PECULIAR_ENCHANT:
+		//return JsonUtils::stringNode((*VLC->spellh)[SpellID::ESpellID(subtype)]->identifier);
+		return JsonUtils::intNode(subtype); //Issue 2790
+	case Bonus::SPECIAL_UPGRADE:
+		return JsonUtils::stringNode(CreatureID::encode(subtype));
+	case Bonus::GENERATE_RESOURCE:
+		return JsonUtils::stringNode(GameConstants::RESOURCE_NAMES[subtype]);
 	default:
-		node.Integer() = subtype;
-		break;
+		return JsonUtils::intNode(subtype);
 	}
+}
 
-	return node;
+JsonNode additionalInfoToJson(Bonus::BonusType type, int addInfo)
+{
+	switch(type)
+	{
+	case Bonus::SPECIAL_UPGRADE:
+		return JsonUtils::stringNode(CreatureID::encode(addInfo));
+	default:
+		return JsonUtils::intNode(addInfo);
+	}
 }
 
 JsonNode Bonus::toJsonNode() const
 {
-	JsonNode root(JsonNode::DATA_STRUCT);
+	JsonNode root(JsonNode::JsonType::DATA_STRUCT);
 
 	root["type"].String() = vstd::findKey(bonusNameMap, type);
 	if(subtype != -1)
 		root["subtype"] = subtypeToJson(type, subtype);
+	if(additionalInfo != -1)
+		root["addInfo"] = additionalInfoToJson(type, additionalInfo);
 	if(val != 0)
 		root["val"].Integer() = val;
 	if(valType != ADDITIVE_VALUE)
@@ -1413,7 +1430,7 @@ std::string ILimiter::toString() const
 
 JsonNode ILimiter::toJsonNode() const
 {
-	JsonNode root(JsonNode::DATA_STRUCT);
+	JsonNode root(JsonNode::JsonType::DATA_STRUCT);
 	root["type"].String() = toString();
 	return root;
 }
@@ -1454,7 +1471,7 @@ std::string CCreatureTypeLimiter::toString() const
 
 JsonNode CCreatureTypeLimiter::toJsonNode() const
 {
-	JsonNode root(JsonNode::DATA_STRUCT);
+	JsonNode root(JsonNode::JsonType::DATA_STRUCT);
 
 	root["type"].String() = "CREATURE_TYPE_LIMITER";
 	root["parameters"].Vector().push_back(JsonUtils::stringNode(creature->identifier));
@@ -1692,7 +1709,7 @@ std::string ScalingUpdater::toString() const
 
 JsonNode ScalingUpdater::toJsonNode() const
 {
-	JsonNode root(JsonNode::DATA_STRUCT);
+	JsonNode root(JsonNode::JsonType::DATA_STRUCT);
 
 	root["type"].String() = "GROWS_WITH_LEVEL";
 	root["parameters"].Vector().push_back(JsonUtils::intNode(valPer20));

--- a/lib/HeroBonus.cpp
+++ b/lib/HeroBonus.cpp
@@ -1736,6 +1736,8 @@ std::string nameForBonus(const Bonus & bonus)
 		return CreatureID::encode(bonus.subtype) + "2" + CreatureID::encode(bonus.additionalInfo);
 	case Bonus::GENERATE_RESOURCE:
 		return GameConstants::RESOURCE_NAMES[bonus.subtype];
+	case Bonus::STACKS_SPEED:
+		return "speed";
 	default:
 		return vstd::findKey(bonusNameMap, bonus.type);
 	}

--- a/lib/HeroBonus.cpp
+++ b/lib/HeroBonus.cpp
@@ -1163,6 +1163,22 @@ std::string Bonus::Description() const
 	return str.str();
 }
 
+JsonNode Bonus::toJsonNode() const
+{
+	JsonNode root(JsonNode::DATA_STRUCT);
+
+	root["type"].Float() = type;
+	if(subtype != -1)
+		root["subtype"].Float() = subtype;
+	if(val != 0)
+		root["val"].Float() = val;
+	if(valType != ADDITIVE_VALUE)
+		root["valType"].Float() = valType;
+	if(updater)
+		root["updater"] = updater->toJsonNode();
+	return root;
+}
+
 Bonus::Bonus(ui16 Dur, BonusType Type, BonusSource Src, si32 Val, ui32 ID, std::string Desc, si32 Subtype)
 	: duration(Dur), type(Type), subtype(Subtype), source(Src), val(Val), sid(ID), description(Desc)
 {
@@ -1609,6 +1625,24 @@ std::string ScalingUpdater::toString() const
 	char buf[100];
 	sprintf(buf, "ScalingUpdater(valPer20=%d, stepSize=%d)", valPer20, stepSize);
 	return std::string(buf);
+}
+
+JsonNode ScalingUpdater::toJsonNode() const
+{
+	JsonNode root(JsonNode::DATA_STRUCT);
+	auto addParam = [&](int param)
+	{
+		JsonNode paramNode(JsonNode::DATA_INTEGER);
+		paramNode.Integer() = param;
+		root["parameters"].Vector().push_back(paramNode);
+	};
+
+	root["type"].String() = "GROWS_WITH_LEVEL";
+	addParam(valPer20);
+	if(stepSize > 1)
+		addParam(stepSize);
+
+	return root;
 }
 
 std::shared_ptr<Bonus> Bonus::addUpdater(TUpdaterPtr Updater)

--- a/lib/HeroBonus.cpp
+++ b/lib/HeroBonus.cpp
@@ -83,7 +83,8 @@ const std::map<std::string, TPropagatorPtr> bonusPropagatorMap =
 
 const std::map<std::string, TUpdaterPtr> bonusUpdaterMap =
 {
-	{"TIMES_HERO_LEVEL", std::make_shared<TimesHeroLevelUpdater>()}
+	{"TIMES_HERO_LEVEL", std::make_shared<TimesHeroLevelUpdater>()},
+	{"TIMES_STACK_LEVEL", std::make_shared<TimesStackLevelUpdater>()}
 };
 
 ///CBonusProxy
@@ -1799,4 +1800,43 @@ std::string TimesHeroLevelUpdater::toString() const
 JsonNode TimesHeroLevelUpdater::toJsonNode() const
 {
 	return JsonUtils::stringNode("TIMES_HERO_LEVEL");
+}
+
+TimesStackLevelUpdater::TimesStackLevelUpdater()
+{
+}
+
+const std::shared_ptr<Bonus> TimesStackLevelUpdater::update(const std::shared_ptr<Bonus> b, const CBonusSystemNode & context) const
+{
+	if(context.getNodeType() == CBonusSystemNode::STACK_INSTANCE)
+	{
+		int level = static_cast<const CStackInstance &>(context).getLevel();
+		std::shared_ptr<Bonus> newBonus = std::make_shared<Bonus>(*b);
+		newBonus->val *= level;
+		return newBonus;
+	}
+	else if(context.getNodeType() == CBonusSystemNode::STACK_BATTLE)
+	{
+		const CStack & stack = static_cast<const CStack &>(context);
+		//only update if stack doesn't have an instance (summons, war machines)
+		//otherwise we'd end up multiplying twice
+		if(stack.base == nullptr)
+		{
+			int level = stack.type->level;
+			std::shared_ptr<Bonus> newBonus = std::make_shared<Bonus>(*b);
+			newBonus->val *= level;
+			return newBonus;
+		}
+	}
+	return b;
+}
+
+std::string TimesStackLevelUpdater::toString() const
+{
+	return "TimesStackLevelUpdater";
+}
+
+JsonNode TimesStackLevelUpdater::toJsonNode() const
+{
+	return JsonUtils::stringNode("TIMES_STACK_LEVEL");
 }

--- a/lib/HeroBonus.cpp
+++ b/lib/HeroBonus.cpp
@@ -1520,6 +1520,32 @@ int HasAnotherBonusLimiter::limit(const BonusLimitationContext &context) const
 	return NOT_SURE;
 }
 
+std::string HasAnotherBonusLimiter::toString() const
+{
+	char buf[100];
+
+	std::string typeName = vstd::findKey(bonusNameMap, type);
+	if(isSubtypeRelevant)
+		sprintf(buf, "HasAnotherBonusLimiter(type=%s, subtype=%d)",	typeName.c_str(), subtype);
+	else
+		sprintf(buf, "HasAnotherBonusLimiter(type=%s)",	typeName.c_str());
+
+	return std::string(buf);
+}
+
+JsonNode HasAnotherBonusLimiter::toJsonNode() const
+{
+	JsonNode root(JsonNode::JsonType::DATA_STRUCT);
+	std::string typeName = vstd::findKey(bonusNameMap, type);
+
+	root["type"].String() = "HAS_ANOTHER_BONUS_LIMITER";
+	root["parameters"].Vector().push_back(JsonUtils::stringNode(typeName));
+	if(isSubtypeRelevant)
+		root["parameters"].Vector().push_back(JsonUtils::intNode(subtype));
+
+	return root;
+}
+
 IPropagator::~IPropagator()
 {
 

--- a/lib/HeroBonus.cpp
+++ b/lib/HeroBonus.cpp
@@ -1212,7 +1212,7 @@ JsonNode Bonus::toJsonNode() const
 	if(valType != ADDITIVE_VALUE)
 		root["valType"].String() = vstd::findKey(bonusValueMap, valType);
 	if(limiter)
-		root["limiter"] = limiter->toJsonNode();
+		root["limiters"].Vector().push_back(limiter->toJsonNode());
 	if(updater)
 		root["updater"] = updater->toJsonNode();
 	return root;

--- a/lib/HeroBonus.h
+++ b/lib/HeroBonus.h
@@ -485,6 +485,7 @@ public:
 	int valOfBonuses(const CSelector &select) const;
 
 	void eliminateDuplicates();
+	void updateBonuses(const CBonusSystemNode & node);
 
 	// remove_if implementation for STL vector types
 	template <class Predicate>
@@ -707,7 +708,9 @@ public:
 	///removes bonuses by selector
 	void popBonuses(const CSelector &s);
 	///updates count of remaining turns and removes outdated bonuses by selector
-	void updateBonuses(const CSelector &s);
+	void reduceBonusDurations(const CSelector &s);
+	//run update decorators
+	void updateBonuses();
 	virtual std::string bonusToString(const std::shared_ptr<Bonus>& bonus, bool description) const {return "";}; //description or bonus name
 	virtual std::string nodeName() const;
 
@@ -1013,16 +1016,10 @@ void BonusList::insert(const int position, InputIterator first, InputIterator la
 
 // bonus decorators for updating bonuses based on events (e.g. hero gaining level)
 
-struct BonusUpdateContext
-{
-	std::shared_ptr<Bonus> b;
-	const CBonusSystemNode & node;
-};
-
 class DLL_LINKAGE IUpdater
 {
 public:
-	virtual void update(BonusUpdateContext & context) const = 0;
+	virtual void update(Bonus & b, const CBonusSystemNode & context) const = 0;
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
@@ -1041,5 +1038,5 @@ struct DLL_LINKAGE ScalingUpdater : public IUpdater
 		h & stepSize;
 	}
 
-	void update(BonusUpdateContext & context);
+	void update(Bonus & b, const CBonusSystemNode & context);
 };

--- a/lib/HeroBonus.h
+++ b/lib/HeroBonus.h
@@ -365,7 +365,8 @@ struct DLL_LINKAGE Bonus : public std::enable_shared_from_this<Bonus>
 		h & effectRange;
 		h & limiter;
 		h & propagator;
-		h & updater;
+		if(version >= 778)
+			h & updater;
 	}
 
 	template <typename Ptr>

--- a/lib/HeroBonus.h
+++ b/lib/HeroBonus.h
@@ -592,6 +592,8 @@ public:
 	virtual ~ILimiter();
 
 	virtual int limit(const BonusLimitationContext &context) const; //0 - accept bonus; 1 - drop bonus; 2 - delay (drops eventually)
+	virtual std::string toString() const;
+	virtual JsonNode toJsonNode() const;
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
@@ -858,6 +860,8 @@ public:
 	void setCreature (CreatureID id);
 
 	int limit(const BonusLimitationContext &context) const override;
+	virtual std::string toString() const override;
+	virtual JsonNode toJsonNode() const override;
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{

--- a/lib/HeroBonus.h
+++ b/lib/HeroBonus.h
@@ -1020,6 +1020,8 @@ void BonusList::insert(const int position, InputIterator first, InputIterator la
 class DLL_LINKAGE IUpdater
 {
 public:
+	virtual ~IUpdater();
+
 	virtual bool update(Bonus & b, const CBonusSystemNode & context) const = 0;
 
 	template <typename Handler> void serialize(Handler &h, const int version)
@@ -1032,11 +1034,12 @@ struct DLL_LINKAGE ScalingUpdater : public IUpdater
 	int valPer20;
 	int stepSize;
 
+	ScalingUpdater();
 	ScalingUpdater(int valPer20, int stepSize = 1);
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		IUpdater::serialize(h, version);
+		h & static_cast<IUpdater &>(*this);
 		h & valPer20;
 		h & stepSize;
 	}

--- a/lib/HeroBonus.h
+++ b/lib/HeroBonus.h
@@ -208,7 +208,7 @@ private:
 	BONUS_NAME(NO_MORALE) /*eg. when fighting on cursed ground*/ \
 	BONUS_NAME(DARKNESS) /*val = radius */ \
 	BONUS_NAME(SPECIAL_SECONDARY_SKILL) /*subtype = id, val = value per level in percent*/ \
-	BONUS_NAME(SPECIAL_SPELL_LEV) /*val = id, additionalInfo = value per level in percent*/\
+	BONUS_NAME(SPECIAL_SPELL_LEV) /*subtype = id, val = value per level in percent*/\
 	BONUS_NAME(SPELL_DAMAGE) /*val = value*/\
 	BONUS_NAME(SPECIFIC_SPELL_DAMAGE) /*subtype = id of spell, val = value*/\
 	BONUS_NAME(SPECIAL_BLESS_DAMAGE) /*val = spell (bless), additionalInfo = value per level in percent*/\

--- a/lib/HeroBonus.h
+++ b/lib/HeroBonus.h
@@ -1074,3 +1074,18 @@ public:
 	virtual std::string toString() const override;
 	virtual JsonNode toJsonNode() const override;
 };
+
+class DLL_LINKAGE TimesStackLevelUpdater : public IUpdater
+{
+public:
+	TimesStackLevelUpdater();
+
+	template <typename Handler> void serialize(Handler & h, const int version)
+	{
+		h & static_cast<IUpdater &>(*this);
+	}
+
+	const std::shared_ptr<Bonus> update(const std::shared_ptr<Bonus> b, const CBonusSystemNode & context) const override;
+	virtual std::string toString() const override;
+	virtual JsonNode toJsonNode() const override;
+};

--- a/lib/HeroBonus.h
+++ b/lib/HeroBonus.h
@@ -365,6 +365,7 @@ struct DLL_LINKAGE Bonus : public std::enable_shared_from_this<Bonus>
 		h & effectRange;
 		h & limiter;
 		h & propagator;
+		h & updater;
 	}
 
 	template <typename Ptr>
@@ -709,7 +710,7 @@ public:
 	void popBonuses(const CSelector &s);
 	///updates count of remaining turns and removes outdated bonuses by selector
 	void reduceBonusDurations(const CSelector &s);
-	//run update decorators
+	//run updaters attached to bonuses
 	void updateBonuses();
 	virtual std::string bonusToString(const std::shared_ptr<Bonus>& bonus, bool description) const {return "";}; //description or bonus name
 	virtual std::string nodeName() const;
@@ -1014,7 +1015,7 @@ void BonusList::insert(const int position, InputIterator first, InputIterator la
 	changed();
 }
 
-// bonus decorators for updating bonuses based on events (e.g. hero gaining level)
+// observers for updating bonuses based on certain events (e.g. hero gaining level)
 
 class DLL_LINKAGE IUpdater
 {
@@ -1028,8 +1029,10 @@ public:
 
 struct DLL_LINKAGE ScalingUpdater : public IUpdater
 {
-	int valPer20 = 0;
-	int stepSize = 1;
+	int valPer20;
+	int stepSize;
+
+	ScalingUpdater(int valPer20, int stepSize = 1);
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
@@ -1038,5 +1041,5 @@ struct DLL_LINKAGE ScalingUpdater : public IUpdater
 		h & stepSize;
 	}
 
-	bool update(Bonus & b, const CBonusSystemNode & context);
+	bool update(Bonus & b, const CBonusSystemNode & context) const override;
 };

--- a/lib/HeroBonus.h
+++ b/lib/HeroBonus.h
@@ -1034,7 +1034,7 @@ public:
 	virtual std::string toString() const;
 	virtual JsonNode toJsonNode() const = 0;
 
-	template <typename Handler> void serialize(Handler &h, const int version)
+	template <typename Handler> void serialize(Handler & h, const int version)
 	{
 	}
 };
@@ -1048,7 +1048,7 @@ public:
 	ScalingUpdater();
 	ScalingUpdater(int valPer20, int stepSize = 1);
 
-	template <typename Handler> void serialize(Handler &h, const int version)
+	template <typename Handler> void serialize(Handler & h, const int version)
 	{
 		h & static_cast<IUpdater &>(*this);
 		h & valPer20;

--- a/lib/HeroBonus.h
+++ b/lib/HeroBonus.h
@@ -490,7 +490,6 @@ public:
 	int valOfBonuses(const CSelector &select) const;
 
 	void eliminateDuplicates();
-	bool updateBonuses(const CBonusSystemNode & node);
 
 	// remove_if implementation for STL vector types
 	template <class Predicate>
@@ -675,6 +674,7 @@ private:
 	void getBonusesRec(BonusList &out, const CSelector &selector, const CSelector &limit) const;
 	void getAllBonusesRec(BonusList &out) const;
 	const TBonusListPtr getAllBonusesWithoutCaching(const CSelector &selector, const CSelector &limit, const CBonusSystemNode *root = nullptr) const;
+	const std::shared_ptr<Bonus> update(const std::shared_ptr<Bonus> b) const;
 
 public:
 	explicit CBonusSystemNode();
@@ -716,8 +716,6 @@ public:
 	void popBonuses(const CSelector &s);
 	///updates count of remaining turns and removes outdated bonuses by selector
 	void reduceBonusDurations(const CSelector &s);
-	//run updaters attached to bonuses
-	void updateBonuses();
 	virtual std::string bonusToString(const std::shared_ptr<Bonus>& bonus, bool description) const {return "";}; //description or bonus name
 	virtual std::string nodeName() const;
 
@@ -1030,7 +1028,7 @@ class DLL_LINKAGE IUpdater
 public:
 	virtual ~IUpdater();
 
-	virtual bool update(Bonus & b, const CBonusSystemNode & context) const = 0;
+	virtual const std::shared_ptr<Bonus> update(const std::shared_ptr<Bonus> b, const CBonusSystemNode & context) const = 0;
 	virtual std::string toString() const;
 	virtual JsonNode toJsonNode() const = 0;
 
@@ -1055,7 +1053,7 @@ public:
 		h & stepSize;
 	}
 
-	bool update(Bonus & b, const CBonusSystemNode & context) const override;
+	const std::shared_ptr<Bonus> update(const std::shared_ptr<Bonus> b, const CBonusSystemNode & context) const override;
 	virtual std::string toString() const override;
 	virtual JsonNode toJsonNode() const override;
 };

--- a/lib/HeroBonus.h
+++ b/lib/HeroBonus.h
@@ -367,7 +367,9 @@ struct DLL_LINKAGE Bonus : public std::enable_shared_from_this<Bonus>
 		h & limiter;
 		h & propagator;
 		if(version >= 781)
+		{
 			h & updater;
+		}
 	}
 
 	template <typename Ptr>

--- a/lib/HeroBonus.h
+++ b/lib/HeroBonus.h
@@ -426,6 +426,7 @@ struct DLL_LINKAGE Bonus : public std::enable_shared_from_this<Bonus>
 
 	std::string Description() const;
 	JsonNode toJsonNode() const;
+	std::string nameForBonus() const; // generate suitable name for bonus - e.g. for storing in json struct
 
 	std::shared_ptr<Bonus> addLimiter(TLimiterPtr Limiter); //returns this for convenient chain-calls
 	std::shared_ptr<Bonus> addPropagator(TPropagatorPtr Propagator); //returns this for convenient chain-calls
@@ -1057,6 +1058,3 @@ struct DLL_LINKAGE ScalingUpdater : public IUpdater
 	virtual std::string toString() const override;
 	virtual JsonNode toJsonNode() const override;
 };
-
-// generate suitable name for bonus - e.g. for storing in json struct
-DLL_LINKAGE std::string nameForBonus(const Bonus & bonus);

--- a/lib/HeroBonus.h
+++ b/lib/HeroBonus.h
@@ -1024,6 +1024,7 @@ public:
 	virtual ~IUpdater();
 
 	virtual bool update(Bonus & b, const CBonusSystemNode & context) const = 0;
+	virtual std::string toString() const;
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
@@ -1046,4 +1047,5 @@ struct DLL_LINKAGE ScalingUpdater : public IUpdater
 	}
 
 	bool update(Bonus & b, const CBonusSystemNode & context) const override;
+	virtual std::string toString() const override;
 };

--- a/lib/HeroBonus.h
+++ b/lib/HeroBonus.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "GameConstants.h"
+#include "JsonNode.h"
 
 class CCreature;
 struct Bonus;
@@ -424,6 +425,7 @@ struct DLL_LINKAGE Bonus : public std::enable_shared_from_this<Bonus>
 	}
 
 	std::string Description() const;
+	JsonNode toJsonNode() const;
 
 	std::shared_ptr<Bonus> addLimiter(TLimiterPtr Limiter); //returns this for convenient chain-calls
 	std::shared_ptr<Bonus> addPropagator(TPropagatorPtr Propagator); //returns this for convenient chain-calls
@@ -1025,6 +1027,7 @@ public:
 
 	virtual bool update(Bonus & b, const CBonusSystemNode & context) const = 0;
 	virtual std::string toString() const;
+	virtual JsonNode toJsonNode() const = 0;
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
@@ -1048,4 +1051,5 @@ struct DLL_LINKAGE ScalingUpdater : public IUpdater
 
 	bool update(Bonus & b, const CBonusSystemNode & context) const override;
 	virtual std::string toString() const override;
+	virtual JsonNode toJsonNode() const override;
 };

--- a/lib/HeroBonus.h
+++ b/lib/HeroBonus.h
@@ -485,7 +485,7 @@ public:
 	int valOfBonuses(const CSelector &select) const;
 
 	void eliminateDuplicates();
-	void updateBonuses(const CBonusSystemNode & node);
+	bool updateBonuses(const CBonusSystemNode & node);
 
 	// remove_if implementation for STL vector types
 	template <class Predicate>
@@ -1019,7 +1019,7 @@ void BonusList::insert(const int position, InputIterator first, InputIterator la
 class DLL_LINKAGE IUpdater
 {
 public:
-	virtual void update(Bonus & b, const CBonusSystemNode & context) const = 0;
+	virtual bool update(Bonus & b, const CBonusSystemNode & context) const = 0;
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
@@ -1038,5 +1038,5 @@ struct DLL_LINKAGE ScalingUpdater : public IUpdater
 		h & stepSize;
 	}
 
-	void update(Bonus & b, const CBonusSystemNode & context);
+	bool update(Bonus & b, const CBonusSystemNode & context);
 };

--- a/lib/HeroBonus.h
+++ b/lib/HeroBonus.h
@@ -1039,8 +1039,9 @@ public:
 	}
 };
 
-struct DLL_LINKAGE ScalingUpdater : public IUpdater
+class DLL_LINKAGE ScalingUpdater : public IUpdater
 {
+public:
 	int valPer20;
 	int stepSize;
 

--- a/lib/HeroBonus.h
+++ b/lib/HeroBonus.h
@@ -1057,3 +1057,6 @@ struct DLL_LINKAGE ScalingUpdater : public IUpdater
 	virtual std::string toString() const override;
 	virtual JsonNode toJsonNode() const override;
 };
+
+// generate suitable name for bonus - e.g. for storing in json struct
+DLL_LINKAGE std::string nameForBonus(const Bonus & bonus);

--- a/lib/HeroBonus.h
+++ b/lib/HeroBonus.h
@@ -214,7 +214,7 @@ private:
 	BONUS_NAME(SPECIAL_BLESS_DAMAGE) /*val = spell (bless), additionalInfo = value per level in percent*/\
 	BONUS_NAME(MAXED_SPELL) /*val = id*/\
 	BONUS_NAME(SPECIAL_PECULIAR_ENCHANT) /*blesses and curses with id = val dependent on unit's level, subtype = 0 or 1 for Coronius*/\
-	BONUS_NAME(SPECIAL_UPGRADE) /*val = base, additionalInfo = target */\
+	BONUS_NAME(SPECIAL_UPGRADE) /*subtype = base, additionalInfo = target */\
 	BONUS_NAME(DRAGON_NATURE) \
 	BONUS_NAME(CREATURE_DAMAGE)/*subtype 0 = both, 1 = min, 2 = max*/\
 	BONUS_NAME(EXP_MULTIPLIER)/* val - percent of additional exp gained by stack/commander (base value 100)*/\

--- a/lib/HeroBonus.h
+++ b/lib/HeroBonus.h
@@ -366,7 +366,7 @@ struct DLL_LINKAGE Bonus : public std::enable_shared_from_this<Bonus>
 		h & effectRange;
 		h & limiter;
 		h & propagator;
-		if(version >= 778)
+		if(version >= 781)
 			h & updater;
 	}
 

--- a/lib/HeroBonus.h
+++ b/lib/HeroBonus.h
@@ -1013,7 +1013,7 @@ extern DLL_LINKAGE const std::map<std::string, ui16> bonusDurationMap;
 extern DLL_LINKAGE const std::map<std::string, Bonus::LimitEffect> bonusLimitEffect;
 extern DLL_LINKAGE const std::map<std::string, TLimiterPtr> bonusLimiterMap;
 extern DLL_LINKAGE const std::map<std::string, TPropagatorPtr> bonusPropagatorMap;
-
+extern DLL_LINKAGE const std::map<std::string, TUpdaterPtr> bonusUpdaterMap;
 
 // BonusList template that requires full interface of CBonusSystemNode
 template <class InputIterator>
@@ -1030,29 +1030,44 @@ class DLL_LINKAGE IUpdater
 public:
 	virtual ~IUpdater();
 
-	virtual const std::shared_ptr<Bonus> update(const std::shared_ptr<Bonus> b, const CBonusSystemNode & context) const = 0;
+	virtual const std::shared_ptr<Bonus> update(const std::shared_ptr<Bonus> b, const CBonusSystemNode & context) const;
 	virtual std::string toString() const;
-	virtual JsonNode toJsonNode() const = 0;
+	virtual JsonNode toJsonNode() const;
 
 	template <typename Handler> void serialize(Handler & h, const int version)
 	{
 	}
 };
 
-class DLL_LINKAGE ScalingUpdater : public IUpdater
+class DLL_LINKAGE GrowsWithLevelUpdater : public IUpdater
 {
 public:
 	int valPer20;
 	int stepSize;
 
-	ScalingUpdater();
-	ScalingUpdater(int valPer20, int stepSize = 1);
+	GrowsWithLevelUpdater();
+	GrowsWithLevelUpdater(int valPer20, int stepSize = 1);
 
 	template <typename Handler> void serialize(Handler & h, const int version)
 	{
 		h & static_cast<IUpdater &>(*this);
 		h & valPer20;
 		h & stepSize;
+	}
+
+	const std::shared_ptr<Bonus> update(const std::shared_ptr<Bonus> b, const CBonusSystemNode & context) const override;
+	virtual std::string toString() const override;
+	virtual JsonNode toJsonNode() const override;
+};
+
+class DLL_LINKAGE TimesHeroLevelUpdater : public IUpdater
+{
+public:
+	TimesHeroLevelUpdater();
+
+	template <typename Handler> void serialize(Handler & h, const int version)
+	{
+		h & static_cast<IUpdater &>(*this);
 	}
 
 	const std::shared_ptr<Bonus> update(const std::shared_ptr<Bonus> b, const CBonusSystemNode & context) const override;

--- a/lib/HeroBonus.h
+++ b/lib/HeroBonus.h
@@ -881,6 +881,8 @@ public:
 	HasAnotherBonusLimiter(Bonus::BonusType bonus, TBonusSubtype _subtype);
 
 	int limit(const BonusLimitationContext &context) const override;
+	virtual std::string toString() const override;
+	virtual JsonNode toJsonNode() const override;
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{

--- a/lib/HeroBonus.h
+++ b/lib/HeroBonus.h
@@ -207,7 +207,7 @@ private:
 	BONUS_NAME(NO_LUCK) /*eg. when fighting on cursed ground*/	\
 	BONUS_NAME(NO_MORALE) /*eg. when fighting on cursed ground*/ \
 	BONUS_NAME(DARKNESS) /*val = radius */ \
-	BONUS_NAME(SPECIAL_SECONDARY_SKILL) /*val = id, additionalInfo = value per level in percent*/ \
+	BONUS_NAME(SPECIAL_SECONDARY_SKILL) /*subtype = id, val = value per level in percent*/ \
 	BONUS_NAME(SPECIAL_SPELL_LEV) /*val = id, additionalInfo = value per level in percent*/\
 	BONUS_NAME(SPELL_DAMAGE) /*val = value*/\
 	BONUS_NAME(SPECIFIC_SPELL_DAMAGE) /*subtype = id of spell, val = value*/\

--- a/lib/JsonDetail.h
+++ b/lib/JsonDetail.h
@@ -16,6 +16,10 @@ class JsonWriter
 	//prefix for each line (tabulation)
 	std::string prefix;
 	std::ostream & out;
+	//sets whether compact nodes are written in single-line format
+	bool compact;
+	//tracks whether we are currently using single-line format
+	bool compactMode = false;
 public:
 	template<typename Iterator>
 	void writeContainer(Iterator begin, Iterator end);
@@ -23,7 +27,7 @@ public:
 	void writeEntry(JsonVector::const_iterator entry);
 	void writeString(const std::string & string);
 	void writeNode(const JsonNode & node);
-	JsonWriter(std::ostream & output);
+	JsonWriter(std::ostream & output, bool compact = false);
 };
 
 //Tiny string class that uses const char* as data for speed, members are private

--- a/lib/JsonNode.cpp
+++ b/lib/JsonNode.cpp
@@ -899,6 +899,36 @@ JsonNode JsonUtils::intersect(const JsonNode & a, const JsonNode & b, bool prune
 	return nullNode;
 }
 
+JsonNode JsonUtils::difference(const JsonNode & node, const JsonNode & base)
+{
+	if(node.getType() == JsonNode::DATA_STRUCT && base.getType() == JsonNode::DATA_STRUCT)
+	{
+		// subtract individual properties
+		JsonNode result(JsonNode::DATA_STRUCT);
+		for(auto property : node.Struct())
+		{
+			if(vstd::contains(base.Struct(), property.first))
+			{
+				JsonNode propertyDifference = JsonUtils::difference(property.second, base.Struct().find(property.first)->second);
+				if(propertyDifference.isEmpty())
+					continue;
+				result[property.first] = propertyDifference;
+			}
+			else
+			{
+				result[property.first] = property.second;
+			}
+		}
+		return result;
+	}
+	else
+	{
+		if(node == base)
+			return nullNode;
+	}
+	return node;
+}
+
 JsonNode JsonUtils::assembleFromFiles(std::vector<std::string> files)
 {
 	bool isValid;

--- a/lib/JsonNode.cpp
+++ b/lib/JsonNode.cpp
@@ -648,7 +648,7 @@ bool JsonUtils::parseBonus(const JsonNode &ability, Bonus *b)
 		b->propagator = parseByMap(bonusPropagatorMap, value, "propagator type ");
 
 	value = &ability["updater"];
-	if (!value->isNull())
+	if(!value->isNull())
 	{
 		const JsonNode & updaterJson = *value;
 		if(updaterJson["type"].String() == "GROWS_WITH_LEVEL")

--- a/lib/JsonNode.cpp
+++ b/lib/JsonNode.cpp
@@ -237,24 +237,24 @@ bool JsonNode::isCompact() const
 {
 	switch(type)
 	{
-		case JsonType::DATA_VECTOR:
-			for(JsonNode & elem : *data.Vector)
-			{
-				if(!elem.isCompact())
-					return false;
-			}
-			return true;
-		case JsonType::DATA_STRUCT:
-			{
-				int propertyCount = data.Struct->size();
-				if(propertyCount == 0)
-					return true;
-				else if(propertyCount == 1)
-					return data.Struct->begin()->second.isCompact();
-			}
-			return false;
-		default:
-			return true;
+	case JsonType::DATA_VECTOR:
+		for(JsonNode & elem : *data.Vector)
+		{
+			if(!elem.isCompact())
+				return false;
+		}
+		return true;
+	case JsonType::DATA_STRUCT:
+		{
+			int propertyCount = data.Struct->size();
+			if(propertyCount == 0)
+				return true;
+			else if(propertyCount == 1)
+				return data.Struct->begin()->second.isCompact();
+		}
+		return false;
+	default:
+		return true;
 	}
 }
 

--- a/lib/JsonNode.cpp
+++ b/lib/JsonNode.cpp
@@ -651,17 +651,25 @@ bool JsonUtils::parseBonus(const JsonNode &ability, Bonus *b)
 	if(!value->isNull())
 	{
 		const JsonNode & updaterJson = *value;
-		if(updaterJson["type"].String() == "GROWS_WITH_LEVEL")
+		switch(updaterJson.getType())
 		{
-			std::shared_ptr<ScalingUpdater> updater = std::make_shared<ScalingUpdater>();
-			const JsonVector param = updaterJson["parameters"].Vector();
-			updater->valPer20 = param[0].Integer();
-			if(param.size() > 1)
-				updater->stepSize = param[1].Integer();
-			b->addUpdater(updater);
+		case JsonNode::JsonType::DATA_STRING:
+			b->addUpdater(parseByMap(bonusUpdaterMap, &updaterJson, "updater type "));
+			break;
+		case JsonNode::JsonType::DATA_STRUCT:
+			if(updaterJson["type"].String() == "GROWS_WITH_LEVEL")
+			{
+				std::shared_ptr<GrowsWithLevelUpdater> updater = std::make_shared<GrowsWithLevelUpdater>();
+				const JsonVector param = updaterJson["parameters"].Vector();
+				updater->valPer20 = param[0].Integer();
+				if(param.size() > 1)
+					updater->stepSize = param[1].Integer();
+				b->addUpdater(updater);
+			}
+			else
+				logMod->warn("Unknown updater type \"%s\"", updaterJson["type"].String());
+			break;
 		}
-		else
-			logMod->warn("Unknown updater type \"%s\"", updaterJson["type"].String());
 	}
 
 	return true;

--- a/lib/JsonNode.cpp
+++ b/lib/JsonNode.cpp
@@ -603,6 +603,23 @@ bool JsonUtils::parseBonus(const JsonNode &ability, Bonus *b)
 	if (!value->isNull())
 		b->propagator = parseByMap(bonusPropagatorMap, value, "propagator type ");
 
+	value = &ability["updater"];
+	if (!value->isNull())
+	{
+		const JsonNode & updaterJson = *value;
+		if(updaterJson["type"].String() == "GROWS_WITH_LEVEL")
+		{
+			std::shared_ptr<ScalingUpdater> updater = std::make_shared<ScalingUpdater>();
+			const JsonVector param = updaterJson["parameters"].Vector();
+			updater->valPer20 = param[0].Float();
+			if(param.size() > 1)
+				updater->stepSize = param[1].Float();
+			b->addUpdater(updater);
+		}
+		else
+			logMod->warn("Unknown updater type \"%s\"", updaterJson["type"].String());
+	}
+
 	return true;
 }
 

--- a/lib/JsonNode.cpp
+++ b/lib/JsonNode.cpp
@@ -877,3 +877,31 @@ JsonNode JsonUtils::assembleFromFiles(std::string filename)
 	}
 	return result;
 }
+
+DLL_LINKAGE JsonNode JsonUtils::boolNode(bool value)
+{
+	JsonNode node;
+	node.Bool() = value;
+	return node;
+}
+
+DLL_LINKAGE JsonNode JsonUtils::floatNode(double value)
+{
+	JsonNode node;
+	node.Float() = value;
+	return node;
+}
+
+DLL_LINKAGE JsonNode JsonUtils::stringNode(std::string value)
+{
+	JsonNode node;
+	node.String() = value;
+	return node;
+}
+
+DLL_LINKAGE JsonNode JsonUtils::intNode(si64 value)
+{
+	JsonNode node;
+	node.Integer() = value;
+	return node;
+}

--- a/lib/JsonNode.cpp
+++ b/lib/JsonNode.cpp
@@ -218,17 +218,17 @@ bool JsonNode::isEmpty() const
 {
 	switch(type)
 	{
-		case JsonType::DATA_NULL:
-			return true;
-		case JsonType::DATA_STRUCT:
-			for(auto elem : *data.Struct)
-			{
-				if(!elem.second.isEmpty())
-					return false;
-			}
-			return true;
-		default:
-			return false;
+	case JsonType::DATA_NULL:
+		return true;
+	case JsonType::DATA_STRUCT:
+		for(auto elem : *data.Struct)
+		{
+			if(!elem.second.isEmpty())
+				return false;
+		}
+		return true;
+	default:
+		return false;
 	}
 }
 

--- a/lib/JsonNode.cpp
+++ b/lib/JsonNode.cpp
@@ -611,9 +611,9 @@ bool JsonUtils::parseBonus(const JsonNode &ability, Bonus *b)
 		{
 			std::shared_ptr<ScalingUpdater> updater = std::make_shared<ScalingUpdater>();
 			const JsonVector param = updaterJson["parameters"].Vector();
-			updater->valPer20 = param[0].Float();
+			updater->valPer20 = param[0].Integer();
 			if(param.size() > 1)
-				updater->stepSize = param[1].Float();
+				updater->stepSize = param[1].Integer();
 			b->addUpdater(updater);
 		}
 		else

--- a/lib/JsonNode.cpp
+++ b/lib/JsonNode.cpp
@@ -439,7 +439,7 @@ std::shared_ptr<Bonus> JsonUtils::parseBonus (const JsonVector &ability_vec) //T
 	auto it = bonusNameMap.find(type);
 	if (it == bonusNameMap.end())
 	{
-		logMod->error("Error: invalid ability type %s", type);
+		logMod->error("Error: invalid ability type %s.", type);
 		return b;
 	}
 	b->type = it->second;
@@ -457,7 +457,7 @@ const T & parseByMap(const std::map<std::string, T> & map, const JsonNode * val,
 		auto it = map.find(type);
 		if (it == map.end())
 		{
-			logMod->error("Error: invalid %s%s", err, type);
+			logMod->error("Error: invalid %s%s.", err, type);
 			return defaultValue;
 		}
 		else
@@ -489,7 +489,7 @@ void JsonUtils::resolveIdentifier(si32 &var, const JsonNode &node, std::string n
 				});
 				break;
 			default:
-				logMod->error("Error! Wrong identifier used for value of %s", name);
+				logMod->error("Error! Wrong identifier used for value of %s.", name);
 		}
 	}
 }
@@ -533,7 +533,7 @@ bool JsonUtils::parseBonus(const JsonNode &ability, Bonus *b)
 	auto it = bonusNameMap.find(type);
 	if (it == bonusNameMap.end())
 	{
-		logMod->error("Error: invalid ability type %s", type);
+		logMod->error("Error: invalid ability type %s.", type);
 		return false;
 	}
 	b->type = it->second;
@@ -624,7 +624,7 @@ bool JsonUtils::parseBonus(const JsonNode &ability, Bonus *b)
 							auto it = bonusNameMap.find(anotherBonusType);
 							if (it == bonusNameMap.end())
 							{
-								logMod->error("Error: invalid ability type %s", anotherBonusType);
+								logMod->error("Error: invalid ability type %s.", anotherBonusType);
 								continue;
 							}
 							l2->type = it->second;
@@ -794,6 +794,7 @@ bool JsonUtils::validate(const JsonNode &node, std::string schemaName, std::stri
 	{
 		logMod->warn("Data in %s is invalid!", dataName);
 		logMod->warn(log);
+		logMod->trace("%s json: %s", dataName, node.toJson(true));
 	}
 	return log.empty();
 }

--- a/lib/JsonNode.cpp
+++ b/lib/JsonNode.cpp
@@ -927,6 +927,19 @@ JsonNode JsonUtils::intersect(const JsonNode & a, const JsonNode & b, bool prune
 
 JsonNode JsonUtils::difference(const JsonNode & node, const JsonNode & base)
 {
+	auto addsInfo = [](JsonNode diff) -> bool
+	{
+		switch(diff.getType())
+		{
+		case JsonNode::JsonType::DATA_NULL:
+			return false;
+		case JsonNode::JsonType::DATA_STRUCT:
+			return diff.Struct().size() > 0;
+		default:
+			return true;
+		}
+	};
+
 	if(node.getType() == JsonNode::JsonType::DATA_STRUCT && base.getType() == JsonNode::JsonType::DATA_STRUCT)
 	{
 		// subtract individual properties
@@ -936,7 +949,7 @@ JsonNode JsonUtils::difference(const JsonNode & node, const JsonNode & base)
 			if(vstd::contains(base.Struct(), property.first))
 			{
 				const JsonNode propertyDifference = JsonUtils::difference(property.second, base.Struct().find(property.first)->second);
-				if(!propertyDifference.isNull())
+				if(addsInfo(propertyDifference))
 					result[property.first] = propertyDifference;
 			}
 			else
@@ -944,8 +957,6 @@ JsonNode JsonUtils::difference(const JsonNode & node, const JsonNode & base)
 				result[property.first] = property.second;
 			}
 		}
-		if(result.Struct().empty())
-			return nullNode;
 		return result;
 	}
 	else

--- a/lib/JsonNode.h
+++ b/lib/JsonNode.h
@@ -76,6 +76,7 @@ public:
 	bool isNull() const;
 	bool isNumber() const;
 	bool isEmpty() const;
+	bool isCompact() const;
 	/// removes all data from node and sets type to null
 	void clear();
 
@@ -111,7 +112,7 @@ public:
 	JsonNode & operator[](std::string child);
 	const JsonNode & operator[](std::string child) const;
 
-	std::string toJson() const;
+	std::string toJson(bool compact = false) const;
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{

--- a/lib/JsonNode.h
+++ b/lib/JsonNode.h
@@ -75,7 +75,9 @@ public:
 
 	bool isNull() const;
 	bool isNumber() const;
-	bool isEmpty() const;
+	/// true if node contains not-null data that cannot be extended via merging
+	/// used for generating common base node from multiple nodes (e.g. bonuses)
+	bool containsBaseData() const;
 	bool isCompact() const;
 	/// removes all data from node and sets type to null
 	void clear();

--- a/lib/JsonNode.h
+++ b/lib/JsonNode.h
@@ -220,6 +220,12 @@ namespace JsonUtils
 	/// get schema by json URI: vcmi:<name of file in schemas directory>#<entry in file, optional>
 	/// example: schema "vcmi:settings" is used to check user settings
 	DLL_LINKAGE const JsonNode & getSchema(std::string URI);
+
+	/// for easy construction of JsonNodes; helps with inserting primitives into vector node
+	DLL_LINKAGE JsonNode boolNode(bool value);
+	DLL_LINKAGE JsonNode floatNode(double value);
+	DLL_LINKAGE JsonNode stringNode(std::string value);
+	DLL_LINKAGE JsonNode intNode(si64 value);
 }
 
 namespace JsonDetail

--- a/lib/JsonNode.h
+++ b/lib/JsonNode.h
@@ -75,6 +75,7 @@ public:
 
 	bool isNull() const;
 	bool isNumber() const;
+	bool isEmpty() const;
 	/// removes all data from node and sets type to null
 	void clear();
 
@@ -187,6 +188,16 @@ namespace JsonUtils
      *
      */
 	DLL_LINKAGE void inherit(JsonNode & descendant, const JsonNode & base);
+
+	/**
+	 * @brief construct node representing the common structure of input nodes
+	 * @param pruneEmpty - omit common properties whose intersection is empty
+	 * different types: null
+	 * struct: recursive intersect on common properties
+	 * other: input if equal, null otherwise
+	 */
+	DLL_LINKAGE JsonNode intersect(const JsonNode & a, const JsonNode & b, bool pruneEmpty = true);
+	DLL_LINKAGE JsonNode intersect(const std::vector<JsonNode> & nodes, bool pruneEmpty = true);
 
 	/**
 	 * @brief generate one Json structure from multiple files

--- a/lib/JsonNode.h
+++ b/lib/JsonNode.h
@@ -200,6 +200,12 @@ namespace JsonUtils
 	DLL_LINKAGE JsonNode intersect(const std::vector<JsonNode> & nodes, bool pruneEmpty = true);
 
 	/**
+	 * @brief construct node representing the difference "node - base"
+	 * merging difference with base gives node
+	 */
+	DLL_LINKAGE JsonNode difference(const JsonNode & node, const JsonNode & base);
+
+	/**
 	 * @brief generate one Json structure from multiple files
 	 * @param files - list of filenames with parts of json structure
 	 */

--- a/lib/NetPacksLib.cpp
+++ b/lib/NetPacksLib.cpp
@@ -1085,8 +1085,8 @@ DLL_LINKAGE void NewTurn::applyGs(CGameState *gs)
 
 	// Update bonuses before doing anything else so hero don't get more MP than needed
 	gs->globalEffects.popBonuses(Bonus::OneDay); //works for children -> all game objs
-	gs->globalEffects.updateBonuses(Bonus::NDays);
-	gs->globalEffects.updateBonuses(Bonus::OneWeek);
+	gs->globalEffects.reduceBonusDurations(Bonus::NDays);
+	gs->globalEffects.reduceBonusDurations(Bonus::OneWeek);
 	//TODO not really a single root hierarchy, what about bonuses placed elsewhere? [not an issue with H3 mechanics but in the future...]
 
 	for(NewTurn::Hero h : heroes) //give mana/movement point

--- a/lib/battle/BattleInfo.cpp
+++ b/lib/battle/BattleInfo.cpp
@@ -765,7 +765,7 @@ void BattleInfo::nextRound(int32_t roundNr)
 	for(CStack * s : stacks)
 	{
 		// new turn effects
-		s->updateBonuses(Bonus::NTurns);
+		s->reduceBonusDurations(Bonus::NTurns);
 
 		s->afterNewRound();
 	}

--- a/lib/mapObjects/CGHeroInstance.cpp
+++ b/lib/mapObjects/CGHeroInstance.cpp
@@ -651,7 +651,7 @@ int64_t CGHeroInstance::getSpellBonus(const spells::Spell * spell, int64_t base,
 	});
 
 	if(affectedStack && affectedStack->creatureLevel() > 0) //Hero specials like Solmyr, Deemer
-		base *= (100. + ((valOfBonuses(Bonus::SPECIAL_SPELL_LEV, spell->getIndex()) * level) / affectedStack->creatureLevel())) / 100.0;
+		base *= (100. + valOfBonuses(Bonus::SPECIAL_SPELL_LEV, spell->getIndex()) / affectedStack->creatureLevel()) / 100.0;
 
 	return base;
 }

--- a/lib/mapObjects/CGHeroInstance.cpp
+++ b/lib/mapObjects/CGHeroInstance.cpp
@@ -540,7 +540,7 @@ void CGHeroInstance::recreateSecondarySkillsBonuses()
 			updateSkill(SecondarySkill(skill_info.first), level);
 }
 
-void CGHeroInstance::recreateSpecialtyBonuses(std::vector<HeroSpecial*> & specialtyDeprecated)
+void CGHeroInstance::recreateSpecialtyBonuses(std::vector<HeroSpecial *> & specialtyDeprecated)
 {
 	auto HeroSpecialToSpecialtyBonus = [](HeroSpecial & hs) -> SSpecialtyBonus
 	{

--- a/lib/mapObjects/CGHeroInstance.cpp
+++ b/lib/mapObjects/CGHeroInstance.cpp
@@ -496,8 +496,6 @@ void CGHeroInstance::SecondarySkillsInfo::resetWisdomCounter()
 void CGHeroInstance::initObj(CRandomGenerator & rand)
 {
 	blockVisit = true;
-	specialty.setNodeType(CBonusSystemNode::SPECIALTY);
-	attachTo(&specialty); //do we ever need to detach it?
 
 	if(!type)
 		initHero(rand); //TODO: set up everything for prison before specialties are configured
@@ -515,14 +513,14 @@ void CGHeroInstance::initObj(CRandomGenerator & rand)
 
 	//copy active (probably growing) bonuses from hero prototype to hero object
 	for(std::shared_ptr<Bonus> b : type->specialty)
-		specialty.addNewBonus(b);
+		addNewBonus(b);
 	//dito for old-style bonuses -> compatibility for old savegames
 	for(SSpecialtyBonus & sb : type->specialtyDeprecated)
 		for(std::shared_ptr<Bonus> b : sb.bonuses)
-			specialty.addNewBonus(b);
+			addNewBonus(b);
 	for(SSpecialtyInfo & spec : type->specDeprecated)
 		for(std::shared_ptr<Bonus> b : SpecialtyInfoToBonuses(spec, type->ID.getNum()))
-			specialty.addNewBonus(b);
+			addNewBonus(b);
 
 	//initialize bonuses
 	recreateSecondarySkillsBonuses();
@@ -988,7 +986,6 @@ int CGHeroInstance::maxSpellLevel() const
 void CGHeroInstance::deserializationFix()
 {
 	artDeserializationFix(this);
-	attachTo(&specialty);
 }
 
 CBonusSystemNode * CGHeroInstance::whereShouldBeAttached(CGameState *gs)

--- a/lib/mapObjects/CGHeroInstance.cpp
+++ b/lib/mapObjects/CGHeroInstance.cpp
@@ -524,7 +524,6 @@ void CGHeroInstance::initObj(CRandomGenerator & rand)
 
 	//initialize bonuses
 	recreateSecondarySkillsBonuses();
-	updateBonuses();
 
 	mana = manaLimit(); //after all bonuses are taken into account, make sure this line is the last one
 	type->name = name;
@@ -1255,8 +1254,8 @@ void CGHeroInstance::levelUp(std::vector<SecondarySkill> skills)
 		}
 	}
 
-	//specialty and other bonuses that scale with level
-	updateBonuses();
+	//update specialty and other bonuses that scale with level
+	treeHasChanged();
 }
 
 void CGHeroInstance::levelUpAutomatically(CRandomGenerator & rand)

--- a/lib/mapObjects/CGHeroInstance.cpp
+++ b/lib/mapObjects/CGHeroInstance.cpp
@@ -541,6 +541,23 @@ void CGHeroInstance::recreateSecondarySkillsBonuses()
 			updateSkill(SecondarySkill(skill_info.first), level);
 }
 
+void CGHeroInstance::recreateSpecialtyBonuses(std::vector<HeroSpecial*> & specialtyDeprecated)
+{
+	auto HeroSpecialToSpecialtyBonus = [](HeroSpecial & hs) -> SSpecialtyBonus
+	{
+		SSpecialtyBonus sb;
+		sb.growsWithLevel = hs.growsWithLevel;
+		sb.bonuses = hs.getBonusList();
+		return sb;
+	};
+
+	for(HeroSpecial * hs : specialtyDeprecated)
+	{
+		for(std::shared_ptr<Bonus> b : SpecialtyBonusToBonuses(HeroSpecialToSpecialtyBonus(*hs)))
+			addNewBonus(b);
+	}
+}
+
 void CGHeroInstance::updateSkill(SecondarySkill which, int val)
 {
 	auto skillBonus = (*VLC->skillh)[which]->getBonus(val);

--- a/lib/mapObjects/CGHeroInstance.h
+++ b/lib/mapObjects/CGHeroInstance.h
@@ -39,21 +39,6 @@ public:
 
 class DLL_LINKAGE CGHeroInstance : public CArmedInstance, public IBoatGenerator, public CArtifactSet, public spells::Caster
 {
-private:
-	// deprecated - used only for loading of old saves
-	struct HeroSpecial : CBonusSystemNode
-	{
-		bool growsWithLevel;
-
-		HeroSpecial(){growsWithLevel = false;};
-
-		template <typename Handler> void serialize(Handler &h, const int version)
-		{
-			h & static_cast<CBonusSystemNode&>(*this);
-			h & growsWithLevel;
-		}
-	};
-
 public:
 	//////////////////////////////////////////////////////////////////////////
 
@@ -109,6 +94,20 @@ public:
 			h & patrolRadius;
 		}
 	} patrol;
+
+	// deprecated - used only for loading of old saves
+	struct HeroSpecial : CBonusSystemNode
+	{
+		bool growsWithLevel;
+
+		HeroSpecial(){growsWithLevel = false;};
+
+		template <typename Handler> void serialize(Handler &h, const int version)
+		{
+			h & static_cast<CBonusSystemNode&>(*this);
+			h & growsWithLevel;
+		}
+	};
 
 	struct DLL_LINKAGE SecondarySkillsInfo
 	{

--- a/lib/mapObjects/CGHeroInstance.h
+++ b/lib/mapObjects/CGHeroInstance.h
@@ -297,7 +297,10 @@ public:
 		h & visitedTown;
 		h & boat;
 		h & type;
-		h & specialty;
+		if(version >= 778)
+			h & specialty;
+		else
+			h & specialtyDeprecated;
 		h & commander;
 		h & visitedObjects;
 		BONUS_TREE_DESERIALIZATION_FIX

--- a/lib/mapObjects/CGHeroInstance.h
+++ b/lib/mapObjects/CGHeroInstance.h
@@ -109,7 +109,6 @@ public:
 	};
 
 	std::vector<HeroSpecial*> specialtyDeprecated;
-	CBonusSystemNode specialty;
 
 	struct DLL_LINKAGE SecondarySkillsInfo
 	{

--- a/lib/mapObjects/CGHeroInstance.h
+++ b/lib/mapObjects/CGHeroInstance.h
@@ -296,7 +296,7 @@ public:
 		h & visitedTown;
 		h & boat;
 		h & type;
-		if(version < 778)
+		if(version < 781)
 		{
 			std::vector<HeroSpecial*> specialtyDeprecated;
 			h & specialtyDeprecated;

--- a/lib/mapObjects/CGHeroInstance.h
+++ b/lib/mapObjects/CGHeroInstance.h
@@ -108,7 +108,8 @@ public:
 		}
 	};
 
-	std::vector<HeroSpecial*> specialty;
+	std::vector<HeroSpecial*> specialtyDeprecated;
+	CBonusSystemNode specialty;
 
 	struct DLL_LINKAGE SecondarySkillsInfo
 	{
@@ -215,7 +216,6 @@ public:
 	void pushPrimSkill(PrimarySkill::PrimarySkill which, int val);
 	ui8 maxlevelsToMagicSchool() const;
 	ui8 maxlevelsToWisdom() const;
-	void Updatespecialty();
 	void recreateSecondarySkillsBonuses();
 	void updateSkill(SecondarySkill which, int val);
 

--- a/lib/mapObjects/CGHeroInstance.h
+++ b/lib/mapObjects/CGHeroInstance.h
@@ -297,9 +297,7 @@ public:
 		h & visitedTown;
 		h & boat;
 		h & type;
-		if(version >= 778)
-			h & specialty;
-		else
+		if(version < 778)
 			h & specialtyDeprecated;
 		h & commander;
 		h & visitedObjects;

--- a/lib/registerTypes/RegisterTypes.h
+++ b/lib/registerTypes/RegisterTypes.h
@@ -136,7 +136,8 @@ void registerTypesMapObjectTypes(Serializer &s)
 
 #undef REGISTER_GENERIC_HANDLER
 
-	s.template registerType<IUpdater, ScalingUpdater>();
+	s.template registerType<IUpdater, GrowsWithLevelUpdater>();
+	s.template registerType<IUpdater, TimesHeroLevelUpdater>();
 	//new types (other than netpacks) must register here
 	//order of type registration is critical for loading old savegames
 }

--- a/lib/registerTypes/RegisterTypes.h
+++ b/lib/registerTypes/RegisterTypes.h
@@ -138,6 +138,7 @@ void registerTypesMapObjectTypes(Serializer &s)
 
 	s.template registerType<IUpdater, GrowsWithLevelUpdater>();
 	s.template registerType<IUpdater, TimesHeroLevelUpdater>();
+	s.template registerType<IUpdater, TimesStackLevelUpdater>();
 	//new types (other than netpacks) must register here
 	//order of type registration is critical for loading old savegames
 }

--- a/lib/registerTypes/RegisterTypes.h
+++ b/lib/registerTypes/RegisterTypes.h
@@ -181,6 +181,9 @@ void registerTypesMapObjects2(Serializer &s)
 	s.template registerType<ILimiter, RankRangeLimiter>();
 	s.template registerType<ILimiter, StackOwnerLimiter>();
 
+	// Updaters
+	s.template registerType<IUpdater, ScalingUpdater>();
+
 //	s.template registerType<CBonusSystemNode>();
 	s.template registerType<CBonusSystemNode, CArtifact>();
 	s.template registerType<CArtifact, CGrowingArtifact>();

--- a/lib/registerTypes/RegisterTypes.h
+++ b/lib/registerTypes/RegisterTypes.h
@@ -181,9 +181,6 @@ void registerTypesMapObjects2(Serializer &s)
 	s.template registerType<ILimiter, RankRangeLimiter>();
 	s.template registerType<ILimiter, StackOwnerLimiter>();
 
-	// Updaters
-	s.template registerType<IUpdater, ScalingUpdater>();
-
 //	s.template registerType<CBonusSystemNode>();
 	s.template registerType<CBonusSystemNode, CArtifact>();
 	s.template registerType<CArtifact, CGrowingArtifact>();
@@ -204,6 +201,9 @@ void registerTypesMapObjects2(Serializer &s)
 	//s.template registerType<CObstacleInstance>();
 		s.template registerType<CObstacleInstance, MoatObstacle>();
 		s.template registerType<CObstacleInstance, SpellCreatedObstacle>();
+
+	// Updaters
+	s.template registerType<IUpdater, ScalingUpdater>();
 }
 template<typename Serializer>
 void registerTypesClientPacks1(Serializer &s)

--- a/lib/registerTypes/RegisterTypes.h
+++ b/lib/registerTypes/RegisterTypes.h
@@ -135,6 +135,10 @@ void registerTypesMapObjectTypes(Serializer &s)
 	REGISTER_GENERIC_HANDLER(CGWitchHut);
 
 #undef REGISTER_GENERIC_HANDLER
+
+	s.template registerType<IUpdater, ScalingUpdater>();
+	//new types (other than netpacks) must register here
+	//order of type registration is critical for loading old savegames
 }
 
 template<typename Serializer>
@@ -201,9 +205,6 @@ void registerTypesMapObjects2(Serializer &s)
 	//s.template registerType<CObstacleInstance>();
 		s.template registerType<CObstacleInstance, MoatObstacle>();
 		s.template registerType<CObstacleInstance, SpellCreatedObstacle>();
-
-	// Updaters
-	s.template registerType<IUpdater, ScalingUpdater>();
 }
 template<typename Serializer>
 void registerTypesClientPacks1(Serializer &s)

--- a/lib/serializer/CSerializer.h
+++ b/lib/serializer/CSerializer.h
@@ -12,7 +12,7 @@
 #include "../ConstTransitivePtr.h"
 #include "../GameConstants.h"
 
-const ui32 SERIALIZATION_VERSION = 780;
+const ui32 SERIALIZATION_VERSION = 781;
 const ui32 MINIMAL_SERIALIZATION_VERSION = 753;
 const std::string SAVEGAME_MAGIC = "VCMISVG";
 

--- a/lib/spells/effects/Timed.cpp
+++ b/lib/spells/effects/Timed.cpp
@@ -219,7 +219,7 @@ void Timed::prepareEffects(SetStackEffect & sse, const Mechanics * m, const Effe
 		}
 		if(casterHero && casterHero->hasBonusOfType(Bonus::SPECIAL_BLESS_DAMAGE, m->getSpellIndex())) //TODO: better handling of bonus percentages
 		{
-			int damagePercent = casterHero->level * casterHero->valOfBonuses(Bonus::SPECIAL_BLESS_DAMAGE, m->getSpellIndex()) / tier;
+			int damagePercent = casterHero->valOfBonuses(Bonus::SPECIAL_BLESS_DAMAGE, m->getSpellIndex()) / tier;
 			Bonus specialBonus(Bonus::N_TURNS, Bonus::CREATURE_DAMAGE, Bonus::SPELL_EFFECT, damagePercent, m->getSpellIndex(), 0, Bonus::PERCENT_TO_ALL);
 			specialBonus.turnsRemain = duration;
 			buffer.push_back(specialBonus);


### PR DESCRIPTION
The current way hero specialties can scale is very restricted. This change introduces updaters to bonuses, which perform updates (currently val recalculation) based on bearer attributes, and simplifies the json specialties format. It also converts the old

	[ { "type":13, "val": 1, "subtype": 1, "info": 5 } ]
and

	[ { "growsWithLevel" : true, "bonuses" : [...] } ]
formats to new format.

Notes:
* Updates to bonuses are performed during inheritance. So e.g. an artifact could grant a scaling bonus to centaurs, which would then be updated when inherited by the hero wearing it. This updated bonus is only used during bonus calculations, and never stored at Bonus System nodes - so using "bonuses" command-line command will show un-updated bonuses, and multiple heroes wearing the same artifact won't interfere with each other.
* The following updaters are currently available:
  * GrowsWithLevelUpdater ("GROWS_WITH_LEVEL"). Parameters are valPer20 and stepSize, and it updates val to ceil(valPer20 * floor(level / stepSize) / 20). StepSize is optional and defaults to 1.
  * TimesHeroLevelUpdater ("TIMES_HERO_LEVEL"). Multiplies val with the level of the hero.
  * TimesStackLevelUpdater ("TIMES_STACK_LEVEL"). Multiplies val with the level of the stack. Works for stacks without instance (summons, war machines), but war machines currently have level 0.
* Set logging of domain "mod" to "trace" to see result of old format conversion.

New format preview:

	"specialty" : {
		"bonuses" : {
			"archery" : {
				"subtype" : "skill.archery",
				"type" : "SECONDARY_SKILL_PREMY",
				"updater" : "TIMES_HERO_LEVEL",
				"val" : 5,
				"valueType" : "PERCENT_TO_BASE"
			}
		}
	}

	"specialty" : {
		"base" : {
			"limiters" : [
				{
					"parameters" : [ "archer", true ],
					"type" : "CREATURE_TYPE_LIMITER"
				}
			]
		},
		"bonuses" : {
			"attack" : {
				"subtype" : "primSkill.attack",
				"type" : "PRIMARY_SKILL",
				"updater" : {
					"parameters" : [ 6, 2 ],
					"type" : "GROWS_WITH_LEVEL"
				}
			},
			"defence" : {
				"subtype" : "primSkill.defence",
				"type" : "PRIMARY_SKILL",
				"updater" : {
					"parameters" : [ 3, 2 ],
					"type" : "GROWS_WITH_LEVEL"
				}
			},
			"speed" : {
				"type" : "STACKS_SPEED",
				"val" : 1
			}
		}
	}

Alternatively the latter specialty can be written short as follows, which will be converted internally using creature stats to follow the HMM3 default formula:

	"specialty" : {
		"creature" : "archer"
	}
