### PR TITLE
Minor: fixed full advmap redraw in swipe mode

### DIFF
--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -1707,12 +1707,10 @@ void CPlayerInterface::update()
 	GH.updateTime();
 	GH.handleEvents();
 
-#ifdef VCMI_ANDROID
-	if (adventureInt && !adventureInt->isActive() && (adventureInt->swipeTargetPosition.x >= 0 || adventureInt->swipeTargetPosition.y >= 0))
-#else // !VCMI_ANDROID
-	if (adventureInt && !adventureInt->isActive() && adventureInt->scrollingDir) //player forces map scrolling though interface is disabled
-#endif // !VCMI_ANDROID
-		GH.totalRedraw();
+	if (!adventureInt || adventureInt->isActive())
+		GH.simpleRedraw();
+	else if((adventureInt->swipeEnabled && adventureInt->swipeMovementRequested) || adventureInt->scrollingDir)
+		GH.totalRedraw(); //player forces map scrolling though interface is disabled
 	else
 		GH.simpleRedraw();
 }


### PR DESCRIPTION
Something I wrote long ago and forgot to push. ;)

Basically: 
* removes unnecessary leftover ifdefs that could choose incorrect condition, since swipe is supported on desktop as well,
* fixes current swipe detection: swipeTargetPosition isn't necessarily set to 0, so the previous implementation caused full redraws "forever" (no noticeable changes for me, but I suspect it might've been the cause of slow fight in https://forum.vcmi.eu/t/vcmi-for-android/784/278 )