### PR TITLE
Fixing bugs for external dwelling bonus of Golem Factory.

### DIFF
--- a/lib/mapObjects/CGTownInstance.cpp
+++ b/lib/mapObjects/CGTownInstance.cpp
@@ -570,13 +570,15 @@ GrowthInfo CGTownInstance::getGrowthInfo(int level) const
 
 int CGTownInstance::getDwellingBonus(const std::vector<CreatureID>& creatureIds, const std::vector<ConstTransitivePtr<CGDwelling> >& dwellings) const
 {
-	return std::accumulate(dwellings.cbegin(), dwellings.cend(), 0,
-			[&creatureIds] (int count, decltype(dwellings[0])& dwelling) -> int {
-				return count + std::count_if(dwelling->creatures.cbegin(), dwelling->creatures.cend(),
-					[&creatureIds](decltype(dwelling->creatures[0])& creature) -> bool {
-						return vstd::contains(creatureIds, creature.second[0]);
-					});
-			});
+	int totalBonus = 0;
+	for (const auto& dwelling : dwellings)
+	{
+		for (const auto& creature : dwelling->creatures)
+		{
+			totalBonus += vstd::contains(creatureIds, creature.second[0]) ? 1 : 0;
+		}
+	}
+	return totalBonus;
 }
 
 TResources CGTownInstance::dailyIncome() const

--- a/lib/mapObjects/CGTownInstance.cpp
+++ b/lib/mapObjects/CGTownInstance.cpp
@@ -157,7 +157,8 @@ void CGDwelling::setPropertyDer(ui8 what, ui32 val)
 	switch (what)
 	{
 		case ObjProperty::OWNER: //change owner
-			if (ID == Obj::CREATURE_GENERATOR1 || ID == Obj::CREATURE_GENERATOR4)
+			if (ID == Obj::CREATURE_GENERATOR1 || ID == Obj::CREATURE_GENERATOR2
+				|| ID == Obj::CREATURE_GENERATOR3 || ID == Obj::CREATURE_GENERATOR4)
 			{
 				if (tempOwner != PlayerColor::NEUTRAL)
 				{

--- a/lib/mapObjects/CGTownInstance.h
+++ b/lib/mapObjects/CGTownInstance.h
@@ -294,4 +294,6 @@ public:
 protected:
 	void setPropertyDer(ui8 what, ui32 val) override;
 	void serializeJsonOptions(JsonSerializeFormat & handler) override;
+private:
+	int getDwellingBonus(const std::vector<CreatureID>& creatureIds, const std::vector<ConstTransitivePtr<CGDwelling> >& dwellings) const;
 };


### PR DESCRIPTION
[Problem]
  The occupied Golem Factory on adventure map doesn't give
  the player corresponding weekly growth bonus.

[Solution]
  1. Add the dwelling (of multiple generators) to a player's dewelling set.
  2. Created helper function to calculate external dwelling bonus
  points.

[Test]
  Manual testing on the map, works fine.

https://bugs.vcmi.eu/view.php?id=2789