### PR TITLE
Add keyboard shortcuts for splitting army from HD mod.

### DIFF
--- a/client/widgets/CGarrisonInt.h
+++ b/client/widgets/CGarrisonInt.h
@@ -55,6 +55,9 @@ public:
 	void update();
 	CGarrisonSlot(CGarrisonInt *Owner, int x, int y, SlotID IID, EGarrisonType Upg=EGarrisonType::UP, const CStackInstance * Creature=nullptr);
 
+	void splitIntoParts(EGarrisonType type, int amount, int maxOfSplittedSlots);
+	void handleSplittingShortcuts();
+
 	friend class CGarrisonInt;
 };
 
@@ -83,7 +86,8 @@ public:
 		 twoRows,         ///< slots Will be placed in 2 rows
 		 owned[2];        ///< player Owns up or down army ([0] upper, [1] lower)
 
-	std::vector<CGarrisonSlot*> availableSlots;  ///< Slots of upper and lower garrison
+	std::vector<CGarrisonSlot *> availableSlots;  ///< Slots of upper and lower garrison
+	std::vector<CGarrisonSlot *> getEmptySlots(CGarrisonSlot::EGarrisonType type);
 
 	const CArmedInstance *armedObjs[2];  ///< [0] is upper, [1] is down
 


### PR DESCRIPTION
 Add keyboard shortcuts for quick army management from HD mod.

Just want add fast some really nice shortcuts from HD mod.
1) [LShift] + LClick – splits a half units from the selected stack into
an empty slot. WARNING: The second behaviour ("smart split, ignores
single creatures") of this HD mod option is not done.
2) [LCtrl] + LClick – splits a single unit from the selected stack into
an empty slot.
3) [LCtrl] + [LShift] + LClick – split single units from the selected
stack into all empty hero/garrison slots