### PR TITLE
Fixes

### DIFF
--- a/launcher/jsonutils.cpp
+++ b/launcher/jsonutils.cpp
@@ -58,7 +58,7 @@ QVariant toVariant(const JsonNode & node)
 {
 	switch (node.getType())
 	{
-		break; case JsonNode::DATA_NULL:   return QVariant();
+		case JsonNode::DATA_NULL:   return QVariant();
 		break; case JsonNode::DATA_BOOL:   return QVariant(node.Bool());
 		break; case JsonNode::DATA_FLOAT:  return QVariant(node.Float());
 		break; case JsonNode::DATA_STRING: return QVariant(QString::fromUtf8(node.String().c_str()));

--- a/lib/battle/CBattleInfoCallback.cpp
+++ b/lib/battle/CBattleInfoCallback.cpp
@@ -360,11 +360,7 @@ void CBattleInfoCallback::battleGetStackQueue(std::vector<const CStack *> &out, 
 	{
 		if(active)
 		{
-			//FIXME: both branches contain same code!!!
-			if(out.size() && out.front() == active)
-				lastMoved = active->side;
-			else
-				lastMoved = active->side;
+			lastMoved = active->side;
 		}
 		else
 		{


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. Warnings, found using PVS-Studio:
vcmi/lib/battle/CBattleInfoCallback.cpp	367	err	V523 The 'then' statement is equivalent to the 'else' statement.
vcmi/launcher/jsonutils.cpp	60	err	V622 Consider inspecting the 'switch' statement. It's possible that the first 'case' operator is missing.