### PR TITLE
Eliminate warnings/errors found by PVS-Studio analyzer

### DIFF
--- a/AI/VCAI/Goals.cpp
+++ b/AI/VCAI/Goals.cpp
@@ -1151,7 +1151,7 @@ TGoalVec GatherArmy::getAllPossibleSubgoals()
 
 	if (ret.empty())
 	{
-		if (hero == ai->primaryHero() || value >= 1.1f)
+		if (hero == ai->primaryHero() || value > 1)
 			ret.push_back (sptr(Goals::Explore()));
 		else //workaround to break loop - seemingly there are no ways to explore left
 			throw goalFulfilledException (sptr(Goals::GatherArmy(0).sethero(hero)));

--- a/client/CPreGame.cpp
+++ b/client/CPreGame.cpp
@@ -2261,7 +2261,7 @@ void InfoCard::changeSelection( const CMapInfo *to )
 void InfoCard::clickRight( tribool down, bool previousState )
 {
 	static const Rect flagArea(19, 397, 335, 23);
-	if(SEL->current && down && SEL->current && isItInLoc(flagArea, GH.current->motion.x, GH.current->motion.y))
+	if(SEL->current && down && isItInLoc(flagArea, GH.current->motion.x, GH.current->motion.y))
 		showTeamsPopup();
 }
 

--- a/client/battle/CBattleInterface.cpp
+++ b/client/battle/CBattleInterface.cpp
@@ -593,8 +593,8 @@ void CBattleInterface::setBattleCursor(const int myNumber)
 	CCursorHandler *cursor = CCS->curh;
 
 	const double subdividingAngle = 2.0*M_PI/6.0; // Divide a hex into six sectors.
-	const double hexMidX = hoveredHex.pos.x + hoveredHex.pos.w/2;
-	const double hexMidY = hoveredHex.pos.y + hoveredHex.pos.h/2;
+	const double hexMidX = hoveredHex.pos.x + hoveredHex.pos.w/2.0;
+	const double hexMidY = hoveredHex.pos.y + hoveredHex.pos.h/2.0;
 	const double cursorHexAngle = M_PI - atan2(hexMidY - cursor->ypos, cursor->xpos - hexMidX) + subdividingAngle/2; //TODO: refactor this nightmare
 	const double sector = fmod(cursorHexAngle/subdividingAngle, 6.0);
 	const int zigzagCorrection = !((myNumber/GameConstants::BFIELD_WIDTH)%2); // Off-by-one correction needed to deal with the odd battlefield rows.

--- a/client/battle/CBattleInterfaceClasses.cpp
+++ b/client/battle/CBattleInterfaceClasses.cpp
@@ -566,7 +566,7 @@ void CClickableHex::hover(bool on)
 	}
 }
 
-CClickableHex::CClickableHex() : setAlterText(false), myNumber(-1), accessible(true), hovered(false), strictHovered(false), myInterface(nullptr)
+CClickableHex::CClickableHex() : setAlterText(false), myNumber(-1), accessible(true), strictHovered(false), myInterface(nullptr)
 {
 	addUsedEvents(LCLICK | RCLICK | HOVER | MOVE);
 }

--- a/client/battle/CBattleInterfaceClasses.h
+++ b/client/battle/CBattleInterfaceClasses.h
@@ -121,7 +121,7 @@ public:
 	ui32 myNumber; //number of hex in commonly used format
 	bool accessible; //if true, this hex is accessible for units
 	//CStack * ourStack;
-	bool hovered, strictHovered; //for determining if hex is hovered by mouse (this is different problem than hex's graphic hovering)
+	bool strictHovered; //for determining if hex is hovered by mouse (this is different problem than hex's graphic hovering)
 	CBattleInterface * myInterface; //interface that owns me
 	static Point getXYUnitAnim(BattleHex hexNum, const CStack * creature, CBattleInterface * cbi); //returns (x, y) of left top corner of animation
 

--- a/client/mapHandler.cpp
+++ b/client/mapHandler.cpp
@@ -69,7 +69,7 @@ struct NeighborTilesInfo
 
 	bool areAllHidden() const
 	{
-		return !(d1 || d2 || d3 || d4 || d5 || d6 || d7 || d8 || d8 );
+		return !(d1 || d2 || d3 || d4 || d5 || d6 || d7 || d8 || d9 );
 	}
 
 	int getBitmapID() const

--- a/client/widgets/AdventureMapClasses.cpp
+++ b/client/widgets/AdventureMapClasses.cpp
@@ -1062,7 +1062,7 @@ void CInGameConsole::keyPressed (const SDL_KeyboardEvent & key)
 				captureAllKeys = false;
 				endEnteringText(false);
 			}
-			else if(SDLK_TAB)
+			else if(SDLK_TAB == key.keysym.sym)
 			{
 				captureAllKeys = true;
 				startEnteringText();

--- a/client/widgets/CArtifactHolder.cpp
+++ b/client/widgets/CArtifactHolder.cpp
@@ -237,7 +237,7 @@ bool CHeroArtPlace::askToAssemble(const CArtifactInstance *art, ArtifactPosition
 
 void CHeroArtPlace::clickRight(tribool down, bool previousState)
 {
-	if(ourArt && down && ourArt && !locked && text.size() && !picked)  //if there is no description or it's a lock, do nothing ;]
+	if(ourArt && down && !locked && text.size() && !picked)  //if there is no description or it's a lock, do nothing ;]
 	{
 		if (slotID < GameConstants::BACKPACK_START)
 		{

--- a/client/widgets/MiscWidgets.cpp
+++ b/client/widgets/MiscWidgets.cpp
@@ -93,8 +93,9 @@ void LRClickableAreaWTextComp::clickLeft(tribool down, bool previousState)
 }
 
 LRClickableAreaWTextComp::LRClickableAreaWTextComp(const Rect &Pos, int BaseType)
-	: LRClickableAreaWText(Pos), baseType(BaseType), bonusValue(-1), type(-1)
+	: LRClickableAreaWText(Pos), baseType(BaseType), bonusValue(-1)
 {
+	type = -1;
 }
 
 CComponent * LRClickableAreaWTextComp::createComponent() const

--- a/client/widgets/MiscWidgets.h
+++ b/client/widgets/MiscWidgets.h
@@ -123,7 +123,7 @@ class LRClickableAreaWTextComp: public LRClickableAreaWText
 {
 public:
 	int baseType;
-	int bonusValue, type;
+	int bonusValue;
 	virtual void clickLeft(tribool down, bool previousState) override;
 	virtual void clickRight(tribool down, bool previousState) override;
 

--- a/lib/JsonNode.h
+++ b/lib/JsonNode.h
@@ -118,11 +118,12 @@ public:
 		h & type;
 		switch (type) {
 			break; case DATA_NULL:
-			break; case DATA_BOOL:   h & data.Bool;
-			break; case DATA_FLOAT:  h & data.Float;
-			break; case DATA_STRING: h & data.String;
-			break; case DATA_VECTOR: h & data.Vector;
-			break; case DATA_STRUCT: h & data.Struct;
+			break; case DATA_BOOL:    h & data.Bool;
+			break; case DATA_INTEGER: h & data.Integer;
+			break; case DATA_FLOAT:   h & data.Float;
+			break; case DATA_STRING:  h & data.String;
+			break; case DATA_VECTOR:  h & data.Vector;
+			break; case DATA_STRUCT:  h & data.Struct;
 		}
 		if(version >= 770)
 		{

--- a/lib/JsonNode.h
+++ b/lib/JsonNode.h
@@ -118,12 +118,11 @@ public:
 		h & type;
 		switch (type) {
 			break; case DATA_NULL:
-			break; case DATA_BOOL:    h & data.Bool;
-			break; case DATA_INTEGER: h & data.Integer;
-			break; case DATA_FLOAT:   h & data.Float;
-			break; case DATA_STRING:  h & data.String;
-			break; case DATA_VECTOR:  h & data.Vector;
-			break; case DATA_STRUCT:  h & data.Struct;
+			break; case DATA_BOOL:   h & data.Bool;
+			break; case DATA_FLOAT:  h & data.Float;
+			break; case DATA_STRING: h & data.String;
+			break; case DATA_VECTOR: h & data.Vector;
+			break; case DATA_STRUCT: h & data.Struct;
 		}
 		if(version >= 770)
 		{

--- a/lib/battle/CBattleInfoCallback.cpp
+++ b/lib/battle/CBattleInfoCallback.cpp
@@ -514,6 +514,9 @@ bool CBattleInfoCallback::battleCanShoot(const CStack * stack, BattleHex dest) c
 
 	if(!stack || !dst)
 		return false;
+	
+	if(stack->getCreature()->idNumber == CreatureID::CATAPULT) //catapult cannot attack creatures
+		return false;
 
 	//forgetfulness
 	TBonusListPtr forgetfulList = stack->getBonuses(Selector::type(Bonus::FORGETFULL),"");
@@ -525,9 +528,6 @@ bool CBattleInfoCallback::battleCanShoot(const CStack * stack, BattleHex dest) c
 		if(forgetful > 1)
 			return false;
 	}
-
-	if(stack->getCreature()->idNumber == CreatureID::CATAPULT) //catapult cannot attack creatures
-		return false;
 
 	if(stack->canShoot()
 		&& battleMatchOwner(stack, dst)

--- a/lib/battle/CBattleInfoCallback.cpp
+++ b/lib/battle/CBattleInfoCallback.cpp
@@ -526,7 +526,7 @@ bool CBattleInfoCallback::battleCanShoot(const CStack * stack, BattleHex dest) c
 			return false;
 	}
 
-	if(stack->getCreature()->idNumber == CreatureID::CATAPULT && dst) //catapult cannot attack creatures
+	if(stack->getCreature()->idNumber == CreatureID::CATAPULT) //catapult cannot attack creatures
 		return false;
 
 	if(stack->canShoot()
@@ -626,7 +626,7 @@ TDmgRange CBattleInfoCallback::calculateDmgRange(const BattleAttackInfo & info) 
 	}
 
 	//applying jousting bonus
-	if(info.attackerBonuses->hasBonusOfType(Bonus::JOUSTING) && !info.defenderBonuses->hasBonusOfType(Bonus::CHARGE_IMMUNITY))
+	if(info.attackerBonuses->hasBonusOfType(Bonus::JOUSTING) && info.defenderBonuses && !info.defenderBonuses->hasBonusOfType(Bonus::CHARGE_IMMUNITY))
 		additiveBonus += info.chargedFields * 0.05;
 
 	//handling secondary abilities and artifacts giving premies to them

--- a/lib/mapping/MapFormatH3M.cpp
+++ b/lib/mapping/MapFormatH3M.cpp
@@ -2201,7 +2201,7 @@ void CMapLoaderH3M::readBitmask(std::vector<bool>& dest, const int byteCount, co
 			if(byte * 8 + bit < limit)
 			{
 				const bool flag = mask & (1 << bit);
-				if((negate && flag) || (!negate && !flag))
+				if(negate == flag)
 					dest[byte * 8 + bit] = false;
 			}
 		}

--- a/lib/rmg/CMapGenerator.h
+++ b/lib/rmg/CMapGenerator.h
@@ -29,7 +29,7 @@ class CTileInfo;
 
 typedef std::vector<JsonNode> JsonVector;
 
-class rmgException : std::exception
+class rmgException : public std::exception
 {
 	std::string msg;
 public:

--- a/lib/rmg/CRmgTemplateStorage.cpp
+++ b/lib/rmg/CRmgTemplateStorage.cpp
@@ -117,7 +117,10 @@ void CRmgTemplateStorage::loadObject(std::string scope, std::string name, const 
 			else if (monsterStrength == "strong")
 				zone->setMonsterStrength(EMonsterStrength::ZONE_STRONG);
 			else
+			{
+				delete zone;
 				throw (rmgException("incorrect monster power"));
+			}
 
 			if (!zoneNode["mines"].isNull())
 			{

--- a/lib/rmg/CZonePlacer.cpp
+++ b/lib/rmg/CZonePlacer.cpp
@@ -287,7 +287,7 @@ void CZonePlacer::attractConnectedZones(TZoneMap &zones, TForceVector &forces, T
 			{
 				//WARNING: compiler used to 'optimize' that line so it never actually worked
 				float overlapMultiplier = (pos.z == otherZoneCenter.z) ? (minDistance / distance) : 1.0f;
-				forceVector += (((otherZoneCenter - pos)* overlapMultiplier / getDistance(distance))) * gravityConstant; //positive value
+				forceVector += ((otherZoneCenter - pos)* overlapMultiplier / getDistance(distance)) * gravityConstant; //positive value
 				totalDistance += (distance - minDistance);
 			}
 		}

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -5930,7 +5930,8 @@ void CGameHandler::runBattle()
 					}
 					else
 					{
-						logGlobal->trace("Activating %s", next->nodeName());
+						if(next)
+							logGlobal->trace("Activating %s", next->nodeName());
 						auto nextId = next->ID;
 						BattleSetActiveStack sas;
 						sas.stack = nextId;

--- a/server/CVCMIServer.cpp
+++ b/server/CVCMIServer.cpp
@@ -161,7 +161,8 @@ void CPregameServer::run()
 			if(state != RUNNING)
 			{
 				logNetwork->info("Stopping listening for connections...");
-				acceptor->close();
+				if(acceptor)
+					acceptor->close();
 			}
 
 			if(acceptor)


### PR DESCRIPTION
Hello!
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A list of bugs, found using PVS-Studio analyzer:

- [V595](https://www.viva64.com/en/w/v595/) The 'info.defenderBonuses' pointer was utilized before it was verified against nullptr. Check lines: 629, 638. cbattleinfocallback.cpp 629
- [V702](https://www.viva64.com/en/w/v702/) Classes should always be derived from std::exception (and alike) as 'public' (no keyword was specified, so compiler defaults it to 'private'). cmapgenerator.h 32
- [V773](https://www.viva64.com/en/w/v773/) The exception was thrown without releasing the 'zone' pointer. A memory leak is possible. crmgtemplatestorage.cpp 120
- [V674](https://www.viva64.com/en/w/v674/) The '1.1f' literal of the 'float' type is compared to a value of the 'int' type. Consider inspecting the 'value >= 1.1f' expression. goals.cpp 1154
- [V768](https://www.viva64.com/en/w/v768/) The enumeration constant 'SDLK_TAB' is used as a variable of a Boolean-type. adventuremapclasses.cpp 1065
- [V501](https://www.viva64.com/en/w/v501/) There are identical sub-expressions to the left and to the right of the '&&' operator: ourArt && down && ourArt cartifactholder.cpp 240
- [V501](https://www.viva64.com/en/w/v501/) There are identical sub-expressions to the left and to the right of the '&&' operator: SEL->current && down && SEL->current cpregame.cpp 2264
- [V501](https://www.viva64.com/en/w/v501/) There are identical sub-expressions 'd8' to the left and to the right of the '||' operator. maphandler.cpp 72
- [V595](https://www.viva64.com/en/w/v595/) The 'next' pointer was utilized before it was verified against nullptr. Check lines: 5933, 5945. cgamehandler.cpp 5933
- [V595](https://www.viva64.com/en/w/v595/) The 'acceptor' pointer was utilized before it was verified against nullptr. Check lines: 164, 167. cvcmiserver.cpp 164
- [V501](https://www.viva64.com/en/w/v501/) There are identical sub-expressions to the left and to the right of the '&&' operator: SEL->current && down && SEL->current cpregame.cpp 2264
- [V719](https://www.viva64.com/en/w/v719/) The switch statement does not cover all values of the 'JsonType' enum: DATA_INTEGER. jsonnode.h 119
- [V560](https://www.viva64.com/en/w/v560/) A part of conditional expression is always true: dst. cbattleinfocallback.cpp 529
- [V728](https://www.viva64.com/en/w/v728/) An excessive check can be simplified. The '(A && B) || (!A && !B)' expression is equivalent to the 'bool(A) == bool(B)' expression. mapformath3m.cpp 2204
- [V592](https://www.viva64.com/en/w/v592/) The expression was enclosed by parentheses twice: ((expression)). One pair of parentheses is unnecessary or misprint is present. czoneplacer.cpp 290
- [V703](https://www.viva64.com/en/w/v703/) It is odd that the 'hovered' field in derived class 'CClickableHex' overwrites field in base class 'CIntObject'. Check lines: cbattleinterfaceclasses.h:124, cintobject.h:118. cbattleinterfaceclasses.h 124
- [V703](https://www.viva64.com/en/w/v703/) It is odd that the 'type' field in derived class 'LRClickableAreaWTextComp' overwrites field in base class 'IShowActivatable'. Check lines: miscwidgets.h:126, cintobject.h:58. miscwidgets.h 126
- [V636](https://www.viva64.com/en/w/v636/) The 'hoveredHex.pos.w / 2' expression was implicitly cast from 'int' type to 'double' type. Consider utilizing an explicit type cast to avoid the loss of a fractional part. An example: double A = (double)(X) / Y;. cbattleinterface.cpp 596
- [V636](https://www.viva64.com/en/w/v636/) The 'hoveredHex.pos.h / 2' expression was implicitly cast from 'int' type to 'double' type. Consider utilizing an explicit type cast to avoid the loss of a fractional part. An example: double A = (double)(X) / Y;. cbattleinterface.cpp 597

Probably false positive warnings, but please take a look:

- [V773 ](https://www.viva64.com/en/w/v773/) Visibility scope of the 'bg' pointer was exited without releasing the memory. A memory leak is possible. cbattleinterfaceclasses.cpp 472
- [V773 ](https://www.viva64.com/en/w/v773/) Visibility scope of the 'image' pointer was exited without releasing the memory. A memory leak is possible. adventuremapclasses.cpp 818
- [V773 ](https://www.viva64.com/en/w/v773/) Visibility scope of the 'image' pointer was exited without releasing the memory. A memory leak is possible. adventuremapclasses.cpp 825
- [V773 ](https://www.viva64.com/en/w/v773/) Visibility scope of the 'allyLabel' pointer was exited without releasing the memory. A memory leak is possible. adventuremapclasses.cpp 833
- [V773 ](https://www.viva64.com/en/w/v773/) Visibility scope of the 'enemyLabel' pointer was exited without releasing the memory. A memory leak is possible. adventuremapclasses.cpp 833
- [V773 ](https://www.viva64.com/en/w/v773/) Visibility scope of the 'label' pointer was exited without releasing the memory. A memory leak is possible. ccomponent.cpp 85
- [V773 ](https://www.viva64.com/en/w/v773/) Visibility scope of the 'cancel' pointer was exited without releasing the memory. A memory leak is possible. ccastleinterface.cpp 1448
- [V773 ](https://www.viva64.com/en/w/v773/) Visibility scope of the 'background' pointer was exited without releasing the memory. A memory leak is possible. ccreaturewindow.cpp 107
- [V773 ](https://www.viva64.com/en/w/v773/) Visibility scope of the 'pic' pointer was exited without releasing the memory. A memory leak is possible. ccreaturewindow.cpp 330
- [V773 ](https://www.viva64.com/en/w/v773/) Visibility scope of the 'morale' pointer was exited without releasing the memory. A memory leak is possible. ccreaturewindow.cpp 330
- [V773 ](https://www.viva64.com/en/w/v773/) Visibility scope of the 'luck' pointer was exited without releasing the memory. A memory leak is possible. ccreaturewindow.cpp 330
- [V773 ](https://www.viva64.com/en/w/v773/) Visibility scope of the 'icon' pointer was exited without releasing the memory. A memory leak is possible. ccreaturewindow.cpp 487
- [V773 ](https://www.viva64.com/en/w/v773/) Visibility scope of the 'bg2' pointer was exited without releasing the memory. A memory leak is possible. ccreaturewindow.cpp 542
- [V773 ](https://www.viva64.com/en/w/v773/) Visibility scope of the 'upgradeBtn' pointer was exited without releasing the memory. A memory leak is possible. ccreaturewindow.cpp 657
- [V773 ](https://www.viva64.com/en/w/v773/) Visibility scope of the 'exitBtn' pointer was exited without releasing the memory. A memory leak is possible. ccreaturewindow.cpp 682
- [V773 ](https://www.viva64.com/en/w/v773/) Visibility scope of the 'changeMode' pointer was exited without releasing the memory. A memory leak is possible. ctradewindow.cpp 1180
- [V773 ](https://www.viva64.com/en/w/v773/) Visibility scope of the 'changeMode' pointer was exited without releasing the memory. A memory leak is possible. ctradewindow.cpp 1186
- [V773 ](https://www.viva64.com/en/w/v773/) Visibility scope of the 'hideChat' pointer was exited without releasing the memory. A memory leak is possible. cpregame.cpp 671
- [V773 ](https://www.viva64.com/en/w/v773/) Visibility scope of the 'select' pointer was exited without releasing the memory. A memory leak is possible. cpregame.cpp 672
- [V773 ](https://www.viva64.com/en/w/v773/) Visibility scope of the 'opts' pointer was exited without releasing the memory. A memory leak is possible. cpregame.cpp 672
- [V773 ](https://www.viva64.com/en/w/v773/) Visibility scope of the 'randomBtn' pointer was exited without releasing the memory. A memory leak is possible. cpregame.cpp 672
- [V773 ](https://www.viva64.com/en/w/v773/) The function was exited without releasing the 'gh' pointer. A memory leak is possible. cvcmiserver.cpp 369
- [V768](https://www.viva64.com/en/w/v768/) The expression 'battleGetMySide()' is of enum type. It is odd that it is used as an expression of a Boolean-type. cplayerbattlecallback.cpp 52
- [V768](https://www.viva64.com/en/w/v768/) The expression 'owner.cb->battleGetMySide()' is of enum type. It is odd that it is used as an expression of a Boolean-type. cbattleinterfaceclasses.cpp 420
- [V768](https://www.viva64.com/en/w/v768/) The expression is of enum type. It is odd that it is used as an expression of a Boolean-type. cadvmapinterface.cpp 1563
- [V768](https://www.viva64.com/en/w/v768/) Instantiate CondSh < EMoveState >: The variable 'data' is of enum type. It is odd that it is used as a variable of a Boolean-type. condsh.h 46
- [V768](https://www.viva64.com/en/w/v768/) The expression 'sp->isImmuneByStack(hero, curStack)' is of enum type. It is odd that it is used as an expression of a Boolean-type. cgamehandler.cpp 4644
- [V768](https://www.viva64.com/en/w/v768/) The expression 'sp->isImmuneByStack(hero, curStack)' is of enum type. It is odd that it is used as an expression of a Boolean-type. cgamehandler.cpp 4657

There are actually way more warnings were found but you can inspect them on your own using PVS-Studio analyzer.