### PR TITLE
fix travis osx build

### DIFF
--- a/CI/mac/before_install.sh
+++ b/CI/mac/before_install.sh
@@ -1,8 +1,7 @@
 #!/bin/sh
 
 brew update
-brew unlink boost
-brew install boost smpeg2 innoextract libpng freetype sdl2 sdl2_ttf sdl2_image qt5 ffmpeg
+brew install smpeg2 libpng freetype sdl2 sdl2_ttf sdl2_image qt5 ffmpeg
 brew install sdl2_mixer --with-smpeg2
 
 export CMAKE_PREFIX_PATH="/usr/local/opt/qt5:$CMAKE_PREFIX_PATH"


### PR DESCRIPTION
Looks like boost 1.66 cause some problems on osx.
Travis [updated default osx image](https://blog.travis-ci.com/2017-11-21-xcode8-3-default-image-announce), it comes with boost 1.65.1(that one worked for vcmi), so we can leave it not updated. Also removed `innoextract` which require boost 1.66, build seems to work without it, but better someone who know osx check it.
