### PR TITLE
Hide "this statement may fall through" warnings

### DIFF
--- a/Global.h
+++ b/Global.h
@@ -86,6 +86,21 @@ static_assert(sizeof(bool) == 1, "Bool needs to be 1 byte in size.");
 #  error "iOS system isn't yet supported."
 #endif
 
+// Each compiler uses own way to supress fall through warning. Try to find it.
+#ifdef __has_cpp_attribute
+#  if __has_cpp_attribute(fallthrough)
+#    define FALLTHROUGH [[fallthrough]];
+#  elif __has_cpp_attribute(gnu::fallthrough)
+#    define FALLTHROUGH [[gnu::fallthrough]];
+#  elif __has_cpp_attribute(clang::fallthrough)
+#    define FALLTHROUGH [[clang::fallthrough]];
+#  else
+#    define FALLTHROUGH
+#  endif
+#else
+#  define FALLTHROUGH
+#endif
+
 /* ---------------------------------------------------------------------------- */
 /* Commonly used C++, Boost headers */
 /* ---------------------------------------------------------------------------- */

--- a/lib/CGameState.cpp
+++ b/lib/CGameState.cpp
@@ -2090,6 +2090,7 @@ void CGameState::updateRumor()
 			}
 			else
 				rumor.type = RumorState::TYPE_RAND;
+			FALLTHROUGH
 
 		case RumorState::TYPE_RAND:
 			do

--- a/lib/CPathfinder.cpp
+++ b/lib/CPathfinder.cpp
@@ -527,6 +527,7 @@ CGPathNode::ENodeAction CPathfinder::getDestAction() const
 		}
 
 		/// don't break - next case shared for both land and sail layers
+		FALLTHROUGH
 
 	case ELayer::SAIL:
 		if(isDestVisitableObj())

--- a/lib/battle/BattleInfo.cpp
+++ b/lib/battle/BattleInfo.cpp
@@ -462,18 +462,22 @@ BattleInfo * BattleInfo::setupBattle(int3 tile, ETerrainType terrain, BFieldType
 		{
 			bonusSubtype = 0;
 		}
+		FALLTHROUGH
 	case BFieldType::FIERY_FIELDS:
 		{
 			if(bonusSubtype == -1) bonusSubtype = 1;
 		}
+		FALLTHROUGH
 	case BFieldType::ROCKLANDS:
 		{
 			if(bonusSubtype == -1) bonusSubtype = 8;
 		}
+		FALLTHROUGH
 	case BFieldType::MAGIC_CLOUDS:
 		{
 			if(bonusSubtype == -1) bonusSubtype = 2;
 		}
+		FALLTHROUGH
 	case BFieldType::LUCID_POOLS:
 		{
 			if(bonusSubtype == -1) bonusSubtype = 4;

--- a/lib/mapObjects/CGTownInstance.cpp
+++ b/lib/mapObjects/CGTownInstance.cpp
@@ -754,7 +754,7 @@ void CGTownInstance::initObj(CRandomGenerator & rand)
 			break;
 		case ETownType::DUNGEON:
 			bonusingBuildings.push_back (new COPWBonus(BuildingID::MANA_VORTEX, this));
-			//fallthrough
+			FALLTHROUGH
 		case ETownType::TOWER: case ETownType::INFERNO: case ETownType::STRONGHOLD:
 			bonusingBuildings.push_back (new CTownBonus(BuildingID::SPECIAL_4, this));
 			break;

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -4130,6 +4130,7 @@ bool CGameHandler::makeBattleAction(BattleAction &ba)
 
 			//don't break - we share code with next case
 		}
+		FALLTHROUGH
 	case EActionType::WAIT:
 		{
 			auto wrapper = wrapAction(ba);


### PR DESCRIPTION
Hide false-positive warnings like

```
/home/taurus/develop/vcmi/lib/battle/BattleInfo.cpp: In static member function ‘static BattleInfo* BattleInfo::setupBattle(int3, ETerrainType, BFieldType, const CArmedInstance**, const CGHeroInstance**, bool, const CGTownInstance*)’:
/home/taurus/develop/vcmi/lib/battle/BattleInfo.cpp:463:17: warning: this statement may fall through [-Wimplicit-fallthrough=]
    bonusSubtype = 0;
    ~~~~~~~~~~~~~^~~
/home/taurus/develop/vcmi/lib/battle/BattleInfo.cpp:465:2: note: here
  case BFieldType::FIERY_FIELDS:
  ^~~~

```