### PR TITLE
[WIP] New mods repository

### DIFF
--- a/client/CServerHandler.cpp
+++ b/client/CServerHandler.cpp
@@ -25,6 +25,7 @@
 #endif
 #include "../lib/CConfigHandler.h"
 #include "../lib/CGeneralTextHandler.h"
+#include "../lib/CModHandler.h"
 #include "../lib/CThreadHelper.h"
 #include "../lib/NetPacks.h"
 #include "../lib/StartInfo.h"
@@ -110,6 +111,8 @@ void CServerHandler::resetStateForLobby(const StartInfo::EMode mode, const std::
 	c.reset();
 	si.reset(new StartInfo());
 	playerNames.clear();
+	si->mods.clear();
+
 	si->difficulty = 1;
 	si->mode = mode;
 	myNames.clear();

--- a/client/CServerHandler.cpp
+++ b/client/CServerHandler.cpp
@@ -441,9 +441,9 @@ void CServerHandler::sendGuiAction(ui8 action) const
 	sendLobbyPack(lga);
 }
 
-void CServerHandler::sendStartGame(bool allowOnlyAI) const
+void CServerHandler::sendStartGame(ui8 startOptions) const
 {
-	verifyStateBeforeStart(allowOnlyAI ? true : settings["session"]["onlyai"].Bool());
+	verifyStateBeforeStart(settings["session"]["onlyai"].Bool() ? startOptions | StartInfo::IGNORE_ONLY_AI : startOptions);
 	LobbyStartGame lsg;
 	sendLobbyPack(lsg);
 }

--- a/client/CServerHandler.h
+++ b/client/CServerHandler.h
@@ -60,7 +60,7 @@ public:
 	virtual void setTurnLength(int npos) const = 0;
 	virtual void sendMessage(const std::string & txt) const = 0;
 	virtual void sendGuiAction(ui8 action) const = 0; // TODO: possibly get rid of it?
-	virtual void sendStartGame(bool allowOnlyAI = false) const = 0;
+	virtual void sendStartGame(ui8 startOptions = StartInfo::NO_OPTIONS) const = 0;
 };
 
 /// structure to handle running server and connecting to it
@@ -129,7 +129,7 @@ public:
 	void setTurnLength(int npos) const override;
 	void sendMessage(const std::string & txt) const override;
 	void sendGuiAction(ui8 action) const override;
-	void sendStartGame(bool allowOnlyAI = false) const override;
+	void sendStartGame(ui8 startOptions = StartInfo::NO_OPTIONS) const override;
 
 	void startGameplay();
 	void endGameplay(bool closeConnection = true);

--- a/client/lobby/CLobbyScreen.h
+++ b/client/lobby/CLobbyScreen.h
@@ -12,6 +12,7 @@
 #include "CSelectionBase.h"
 
 class CBonusSelection;
+class CMultiLineLabel;
 
 class CLobbyScreen : public CSelectionBase
 {
@@ -23,7 +24,7 @@ public:
 	~CLobbyScreen();
 	void toggleTab(std::shared_ptr<CIntObject> tab) override;
 	void startCampaign();
-	void startScenario(bool allowOnlyAI = false);
+	void startScenario(ui8 startOptions = 0);
 	void toggleMode(bool host);
 	void toggleChat();
 
@@ -35,12 +36,16 @@ public:
 	CBonusSelection * bonusSel;
 };
 
-class CModsBox : public CWindowObject
+class CModStatusBox : public CWindowObject
 {
 	std::shared_ptr<CLabel> labelTitle;
-	std::shared_ptr<CLabelGroup> labelGroupStatus;
 	std::shared_ptr<CLabelGroup> labelGroupMods;
+	std::shared_ptr<CLabelGroup> labelGroupStatusWorking;
+	std::shared_ptr<CLabelGroup> labelGroupStatusMissing;
+	std::shared_ptr<CLabelGroup> labelGroupStatusIncompatible;
+	std::shared_ptr<CMultiLineLabel> labelErrorMessage;
+	std::shared_ptr<CButton> buttonOk;
 	std::shared_ptr<CButton> buttonCancel;
 public:
-	CModsBox();
+	CModStatusBox(bool showError = false, ui8 startOptions = 0);
 };

--- a/client/lobby/CLobbyScreen.h
+++ b/client/lobby/CLobbyScreen.h
@@ -17,6 +17,7 @@ class CLobbyScreen : public CSelectionBase
 {
 public:
 	std::shared_ptr<CButton> buttonChat;
+	std::shared_ptr<CButton> buttonMods;
 
 	CLobbyScreen(ESelectionScreen type);
 	~CLobbyScreen();
@@ -32,4 +33,14 @@ public:
 	const StartInfo * getStartInfo() override;
 
 	CBonusSelection * bonusSel;
+};
+
+class CModsBox : public CWindowObject
+{
+	std::shared_ptr<CLabel> labelTitle;
+	std::shared_ptr<CLabelGroup> labelGroupStatus;
+	std::shared_ptr<CLabelGroup> labelGroupMods;
+	std::shared_ptr<CButton> buttonCancel;
+public:
+	CModsBox();
 };

--- a/config/schemas/settings.json
+++ b/config/schemas/settings.json
@@ -360,7 +360,7 @@
 				"repositoryURL" : {
 					"type" : "array",
 					"default" : [
-						"http://download.vcmi.eu/mods/repository/repository.json"
+						"https://mods.vcmi.download/repository/develop.json"
 					],
 					"items" : {
 						"type" : "string"

--- a/config/translate.json
+++ b/config/translate.json
@@ -1,5 +1,23 @@
 // This file contains all translateable strings added in VCMI
 {
+	"lobby" :
+	{
+		"windowMods" :
+		{
+			"title" : "Mods status",
+			"groups" :
+			{
+				"working" : "Available",
+				"missing" : "Missing",
+				"incompatible" : "Wrong version"
+			}
+		},
+		"buttonMods" :
+		{
+			"default" : "Show mods",
+			"error" : "Mods error!"
+		}
+	},
 	"adventureMap":
 	{
 		"monsterThreat" :

--- a/config/translate.json
+++ b/config/translate.json
@@ -5,11 +5,12 @@
 		"windowMods" :
 		{
 			"title" : "Mods status",
+			"errorMessage" : "Missing or changed mods might cause crashes. Would you like to continue?"
 			"groups" :
 			{
-				"working" : "Available",
-				"missing" : "Missing",
-				"incompatible" : "Wrong version"
+				"compatible" : "Same version",
+				"incompatible" : "Wrong version",
+				"missing" : "Not installed"
 			}
 		},
 		"buttonMods" :

--- a/launcher/modManager/cdownloadmanager_moc.cpp
+++ b/launcher/modManager/cdownloadmanager_moc.cpp
@@ -21,6 +21,8 @@ CDownloadManager::CDownloadManager()
 void CDownloadManager::downloadFile(const QUrl & url, const QString & file)
 {
 	QNetworkRequest request(url);
+	// TODO: Workaround lack of redirect support for Qt older than 5.6
+	request.setAttribute(QNetworkRequest::FollowRedirectsAttribute, true);
 	FileEntry entry;
 	entry.file.reset(new QFile(CLauncherDirs::get().downloadsPath() + '/' + file));
 	entry.bytesReceived = 0;

--- a/launcher/settingsView/csettingsview_moc.ui
+++ b/launcher/settingsView/csettingsview_moc.ui
@@ -244,7 +244,7 @@
       <enum>QPlainTextEdit::NoWrap</enum>
      </property>
      <property name="plainText">
-      <string>http://downloads.vcmi.eu/Mods/repository.json</string>
+      <string>https://mods.vcmi.download/repository/develop.json</string>
      </property>
     </widget>
    </item>

--- a/lib/CModHandler.cpp
+++ b/lib/CModHandler.cpp
@@ -861,7 +861,7 @@ void CModHandler::loadMods(bool onlyEssential)
 	coreMod.name = "Original game files";
 }
 
-std::vector<std::string> CModHandler::getAllMods()
+std::vector<std::string> CModHandler::getAllMods() const
 {
 	std::vector<std::string> modlist;
 	for (auto & entry : allMods)
@@ -869,9 +869,23 @@ std::vector<std::string> CModHandler::getAllMods()
 	return modlist;
 }
 
-std::vector<std::string> CModHandler::getActiveMods()
+std::vector<std::string> CModHandler::getActiveMods() const
 {
 	return activeMods;
+}
+
+std::map<TModID, CModInfo::EModCheckError> CModHandler::checkModsPresent(const std::vector<CModInfo> & mods) const
+{
+	std::map<TModID, CModInfo::EModCheckError> erroredMods;
+	for(auto & mod : mods)
+	{
+		if(!vstd::contains(allMods, mod.identifier))
+			erroredMods.insert(std::make_pair(mod.identifier, CModInfo::MISSING));
+		else if(allMods.at(mod.identifier).config["version"].String() != mod.config["version"].String())
+			erroredMods.insert(std::make_pair(mod.identifier, CModInfo::INCOMPATIBLE));
+	}
+
+	return erroredMods;
 }
 
 static JsonNode genDefaultFS()
@@ -939,7 +953,7 @@ void CModHandler::loadModFilesystems()
 	}
 }
 
-CModInfo & CModHandler::getModData(TModID modId)
+const CModInfo & CModHandler::getModData(TModID modId) const
 {
 	auto it = allMods.find(modId);
 

--- a/lib/CModHandler.h
+++ b/lib/CModHandler.h
@@ -178,6 +178,12 @@ public:
 		PASSED
 	};
 
+	enum EModCheckError
+	{
+		MISSING,
+		INCOMPATIBLE
+	};
+
 	/// identifier, identical to name of folder with mod
 	std::string identifier;
 
@@ -260,11 +266,13 @@ public:
 	void loadMods(bool onlyEssential = false);
 	void loadModFilesystems();
 
-	CModInfo & getModData(TModID modId);
+	const CModInfo & getModData(TModID modId) const;
 
 	/// returns list of all (active) mods
-	std::vector<std::string> getAllMods();
-	std::vector<std::string> getActiveMods();
+	std::vector<std::string> getAllMods() const;
+	std::vector<std::string> getActiveMods() const;
+
+	std::map<TModID, CModInfo::EModCheckError> checkModsPresent(const std::vector<CModInfo> & mods) const;
 
 	/// load content from all available mods
 	void load();

--- a/lib/StartInfo.cpp
+++ b/lib/StartInfo.cpp
@@ -61,7 +61,7 @@ std::string StartInfo::getCampaignName() const
 		return VLC->generaltexth->allTexts[508];
 }
 
-void LobbyInfo::verifyStateBeforeStart(bool ignoreNoHuman) const
+void LobbyInfo::verifyStateBeforeStart(ui8 startOptions) const
 {
 	if(!mi)
 		throw ExceptionMapMissing();
@@ -72,8 +72,15 @@ void LobbyInfo::verifyStateBeforeStart(bool ignoreNoHuman) const
 		if(i->second.isControlledByHuman())
 			break;
 
-	if(i == si->playerInfos.cend() && !ignoreNoHuman)
+	if(i == si->playerInfos.cend() && !(startOptions & StartInfo::IGNORE_ONLY_AI))
 		throw ExceptionNoHuman();
+
+	if(mi->scenarioOptionsOfSave)
+	{
+		auto erroredMods = VLC->modh->checkModsPresent(mi->scenarioOptionsOfSave->mods);
+		if(erroredMods.size() && !(startOptions & StartInfo::IGNORE_WRONG_MODS))
+			throw ExceptionWrongMods();
+	}
 
 	if(si->mapGenOptions && si->mode == StartInfo::NEW_GAME)
 	{

--- a/lib/StartInfo.h
+++ b/lib/StartInfo.h
@@ -82,6 +82,13 @@ struct DLL_LINKAGE PlayerSettings
 /// Struct which describes the difficulty, the turn time,.. of a heroes match.
 struct DLL_LINKAGE StartInfo
 {
+	enum EStartOptions : ui8
+	{
+		NO_OPTIONS = 0,
+		IGNORE_ONLY_AI = 1,
+		IGNORE_WRONG_MODS = 2
+	};
+
 	enum EMode {NEW_GAME, LOAD_GAME, CAMPAIGN, INVALID = 255};
 
 	EMode mode;
@@ -179,7 +186,7 @@ struct DLL_LINKAGE LobbyInfo : public LobbyState
 
 	LobbyInfo() {}
 
-	void verifyStateBeforeStart(bool ignoreNoHuman = false) const;
+	void verifyStateBeforeStart(ui8 startOptions = StartInfo::NO_OPTIONS) const;
 
 	bool isClientHost(int clientId) const;
 	std::set<PlayerColor> getAllClientPlayers(int clientId);
@@ -196,4 +203,5 @@ struct DLL_LINKAGE LobbyInfo : public LobbyState
 
 class ExceptionMapMissing : public std::exception {};
 class ExceptionNoHuman : public std::exception {};
+class ExceptionWrongMods : public std::exception {};
 class ExceptionNoTemplate : public std::exception {};

--- a/lib/StartInfo.h
+++ b/lib/StartInfo.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "GameConstants.h"
+#include "CModHandler.h"
 
 class CMapGenOptions;
 class CCampaignState;
@@ -99,6 +100,8 @@ struct DLL_LINKAGE StartInfo
 
 	std::shared_ptr<CCampaignState> campState;
 
+	std::vector<CModInfo> mods;
+
 	PlayerSettings & getIthPlayersSettings(PlayerColor no);
 	const PlayerSettings & getIthPlayersSettings(PlayerColor no) const;
 	PlayerSettings * getPlayersSettings(const ui8 connectedPlayerId);
@@ -119,6 +122,10 @@ struct DLL_LINKAGE StartInfo
 		h & mapname;
 		h & mapGenOptions;
 		h & campState;
+		if(version >= 788)
+		{
+			h & mods;
+		}
 	}
 
 	StartInfo() : mode(INVALID), difficulty(0), seedToBeUsed(0), seedPostInit(0),

--- a/lib/serializer/CSerializer.h
+++ b/lib/serializer/CSerializer.h
@@ -12,7 +12,7 @@
 #include "../ConstTransitivePtr.h"
 #include "../GameConstants.h"
 
-const ui32 SERIALIZATION_VERSION = 787;
+const ui32 SERIALIZATION_VERSION = 788;
 const ui32 MINIMAL_SERIALIZATION_VERSION = 753;
 const std::string SAVEGAME_MAGIC = "VCMISVG";
 

--- a/server/CVCMIServer.cpp
+++ b/server/CVCMIServer.cpp
@@ -224,6 +224,8 @@ void CVCMIServer::prepareToStartGame()
 		// FIXME: dirry hack to make sure old CGameHandler::run is finished
 		boost::this_thread::sleep(boost::posix_time::milliseconds(1000));
 	}
+	for(auto modId: VLC->modh->getActiveMods())
+		si->mods.push_back(VLC->modh->getModData(modId));
 
 	gh = std::make_shared<CGameHandler>(this);
 	switch(si->mode)

--- a/server/NetPacksLobbyServer.cpp
+++ b/server/NetPacksLobbyServer.cpp
@@ -165,7 +165,7 @@ bool LobbyStartGame::applyOnServer(CVCMIServer * srv)
 {
 	try
 	{
-		srv->verifyStateBeforeStart(true);
+		srv->verifyStateBeforeStart(StartInfo::IGNORE_ONLY_AI | StartInfo::IGNORE_WRONG_MODS);
 	}
 	catch(...)
 	{


### PR DESCRIPTION
More information on repository is available on wiki:
https://wiki.vcmi.eu/Mods_repository

Changes:

- Mods game started with now serialized inside StartInfo. So list of mods available in save file header.
- New "Show mods" button for loading screen. Text changes to orange "Mods error!" when some mods missing or have different version.
- Player will also get warning on attempt to start game while mods check did not pass.

TODO:

- [ ] Lib and Launcher: store commit hash for mods in addition to version.  
- [ ] Client: implement VLC reload when gameplay is finished.
- [ ] Launcher: Implement command-line interface for mod management.
- [ ] Client: feature to run launcher in background to get missing mods and then reload VLC.
- [ ] Launcher: Implement redirection support for Qt 5.5 and older.
- [ ] Mods repository: implement checking of ```repository.json``` against schema on Travis.

IDEAS:

- Another nice advantage of git. Any mod might have own "repository.json" inside repo so player will be able to add this single mod to his launcher even if mod not included in main VCMI repository, or if only older version is included.