### PR TITLE
Setting policy CMP0071 for launcher cmake

### DIFF
--- a/launcher/CMakeLists.txt
+++ b/launcher/CMakeLists.txt
@@ -60,6 +60,10 @@ assign_source_group(${launcher_SRCS} ${launcher_HEADERS} VCMI_launcher.rc)
 # Tell CMake to run moc when necessary:
 set(CMAKE_AUTOMOC ON)
 
+if(POLICY CMP0071)
+	cmake_policy(SET CMP0071 NEW)
+endif()
+
 # As moc files are generated in the binary dir, tell CMake
 # to always look for includes there:
 set(CMAKE_INCLUDE_CURRENT_DIR ON)


### PR DESCRIPTION
CMake from version 3.10.2 warns when the policy is not set.
Reference: https://cmake.org/cmake/help/v3.10/policy/CMP0071.html