### PR TITLE
Configure JSON merge behaviour via #override flag

### DIFF
--- a/lib/JsonDetail.cpp
+++ b/lib/JsonDetail.cpp
@@ -397,6 +397,13 @@ bool JsonParser::extractStruct(JsonNode &node)
 		std::vector<std::string> keyAndFlags;
 		boost::split(keyAndFlags, key, boost::is_any_of("#"));
 		key = keyAndFlags[0];
+		// check for unknown flags - helps with debugging
+		std::vector<std::string> knownFlags = { "override" };
+		for(int i = 1; i < keyAndFlags.size(); i++)
+		{
+			if(!vstd::contains(knownFlags, keyAndFlags[i]))
+				error("Encountered unknown flag #" + keyAndFlags[i], true);
+		}
 
 		if (node.Struct().find(key) != node.Struct().end())
 			error("Dublicated element encountered!", true);

--- a/lib/JsonNode.cpp
+++ b/lib/JsonNode.cpp
@@ -70,7 +70,8 @@ JsonNode::JsonNode(ResourceID && fileURI, bool &isValidSyntax):
 
 JsonNode::JsonNode(const JsonNode &copy):
 	type(JsonType::DATA_NULL),
-	meta(copy.meta)
+	meta(copy.meta),
+	flags(copy.flags)
 {
 	setType(copy.getType());
 	switch(type)
@@ -96,6 +97,7 @@ void JsonNode::swap(JsonNode &b)
 	swap(meta, b.meta);
 	swap(data, b.data);
 	swap(type, b.type);
+	swap(flags, b.flags);
 }
 
 JsonNode & JsonNode::operator =(JsonNode node)
@@ -846,7 +848,7 @@ const JsonNode & JsonUtils::getSchema(std::string URI)
 		return getSchemaByName(filename).resolvePointer(URI.substr(posHash + 1));
 }
 
-void JsonUtils::merge(JsonNode & dest, JsonNode & source)
+void JsonUtils::merge(JsonNode & dest, JsonNode & source, bool noOverride)
 {
 	if (dest.getType() == JsonNode::JsonType::DATA_NULL)
 	{
@@ -872,23 +874,42 @@ void JsonUtils::merge(JsonNode & dest, JsonNode & source)
 		}
 		case JsonNode::JsonType::DATA_STRUCT:
 		{
-			//recursively merge all entries from struct
-			for(auto & node : source.Struct())
-				merge(dest[node.first], node.second);
+			bool override = false;
+			if(!noOverride)
+			{
+				for(std::string flag : source.flags)
+				{
+					if(flag.compare("override") == 0)
+					{
+						override = true;
+						break;
+					}
+				}
+			}
+			if(override)
+			{
+				std::swap(dest, source);
+			}
+			else
+			{
+				//recursively merge all entries from struct
+				for(auto & node : source.Struct())
+					merge(dest[node.first], node.second, noOverride);
+			}
 		}
 	}
 }
 
-void JsonUtils::mergeCopy(JsonNode & dest, JsonNode source)
+void JsonUtils::mergeCopy(JsonNode & dest, JsonNode source, bool noOverride)
 {
 	// uses copy created in stack to safely merge two nodes
-	merge(dest, source);
+	merge(dest, source, noOverride);
 }
 
 void JsonUtils::inherit(JsonNode & descendant, const JsonNode & base)
 {
 	JsonNode inheritedNode(base);
-	merge(inheritedNode,descendant);
+	merge(inheritedNode, descendant, true);
 	descendant.swap(inheritedNode);
 }
 

--- a/lib/JsonNode.cpp
+++ b/lib/JsonNode.cpp
@@ -874,19 +874,7 @@ void JsonUtils::merge(JsonNode & dest, JsonNode & source, bool noOverride)
 		}
 		case JsonNode::JsonType::DATA_STRUCT:
 		{
-			bool override = false;
-			if(!noOverride)
-			{
-				for(std::string flag : source.flags)
-				{
-					if(flag.compare("override") == 0)
-					{
-						override = true;
-						break;
-					}
-				}
-			}
-			if(override)
+			if(!noOverride && vstd::contains(source.flags, "override"))
 			{
 				std::swap(dest, source);
 			}

--- a/lib/JsonNode.h
+++ b/lib/JsonNode.h
@@ -121,6 +121,10 @@ public:
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
 		h & meta;
+		if(version >= 782)
+		{
+			h & flags;
+		}
 		h & type;
 		switch(type)
 		{

--- a/lib/JsonNode.h
+++ b/lib/JsonNode.h
@@ -45,8 +45,10 @@ private:
 	JsonData data;
 
 public:
-	/// free to use metadata field
+	/// free to use metadata fields
 	std::string meta;
+	// meta-flags like override
+	std::vector<std::string> flags;
 
 	//Create empty node
 	JsonNode(JsonType Type = JsonType::DATA_NULL);
@@ -173,7 +175,7 @@ namespace JsonUtils
 	 * null   : if value in source is present but set to null it will delete entry in dest
 	 * @note this function will destroy data in source
 	 */
-	DLL_LINKAGE void merge(JsonNode & dest, JsonNode & source);
+	DLL_LINKAGE void merge(JsonNode & dest, JsonNode & source, bool noOverride = false);
 
 	/**
 	 * @brief recursively merges source into dest, replacing identical fields
@@ -183,7 +185,7 @@ namespace JsonUtils
 	 * null   : if value in source is present but set to null it will delete entry in dest
 	 * @note this function will preserve data stored in source by creating copy
 	 */
-	DLL_LINKAGE void mergeCopy(JsonNode & dest, JsonNode source);
+	DLL_LINKAGE void mergeCopy(JsonNode & dest, JsonNode source, bool noOverride = false);
 
     /** @brief recursively merges descendant into copy of base node
      * Result emulates inheritance semantic

--- a/lib/serializer/CSerializer.h
+++ b/lib/serializer/CSerializer.h
@@ -12,7 +12,7 @@
 #include "../ConstTransitivePtr.h"
 #include "../GameConstants.h"
 
-const ui32 SERIALIZATION_VERSION = 781;
+const ui32 SERIALIZATION_VERSION = 782;
 const ui32 MINIMAL_SERIALIZATION_VERSION = 753;
 const std::string SAVEGAME_MAGIC = "VCMISVG";
 


### PR DESCRIPTION
By default, JSON structs from mods are always merged with an existing struct. This is troublesome when the new data is not intended to be an extension of the old data. E.g.

	"valeska":
	{
		...
		"specialty" : {
			"creature" : "archer"
		}
	},

patched with

	"core:valeska":
	{
		"specialty" : {
			"base" : { ... },
			"bonuses" : { ... }
		}
	},

will result in duplicate bonuses:

	"valeska":
	{
		...
		"specialty" : {
			"base" : { ... },
			"bonuses" : { ... },
			"creature" : "archer"
		}
	},

With this change it is now possible to specify the patch as

	"core:valeska":
	{
		"specialty#override" : {
			"base" : { ... },
			"bonuses" : { ... }
		}
	},

which completely replaces (overrides) the specialty field:

	"valeska":
	{
		...
		"specialty" : {
			"base" : { ... },
			"bonuses" : { ... }
		}
	},

A side-effect is that the # character can no longer be used in naming fields.