### PR TITLE
Catapult rework

### DIFF
--- a/client/battle/CBattleInterface.cpp
+++ b/client/battle/CBattleInterface.cpp
@@ -2905,9 +2905,13 @@ std::string CBattleInterface::SiegeHelper::getSiegeName(ui16 what, int state) co
 		switch (state)
 		{
 		case EWallState::INTACT : return 1;
-		case EWallState::DAMAGED : return 2;
+		case EWallState::DAMAGED :
+			if(what == 2 || what == 3 || what == 8) // towers don't have separate image here - INTACT and DAMAGED is 1, DESTROYED is 2
+				return 1;
+			else
+				return 2;
 		case EWallState::DESTROYED :
-			if (what == 2 || what == 3 || what == 8) // towers don't have separate image here
+			if (what == 2 || what == 3 || what == 8)
 				return 2;
 			else
 				return 3;

--- a/lib/spells/effects/Catapult.cpp
+++ b/lib/spells/effects/Catapult.cpp
@@ -86,6 +86,8 @@ void Catapult::apply(BattleStateProxy * battleState, RNG & rng, const Mechanics 
 	CatapultAttack ca;
 	ca.attacker = -1;
 
+	BattleUnitsChanged removeUnits;
+
 	for(int i = 0; i < targetsToAttack; i++)
 	{
 		//Any destructible part can be hit regardless of its HP. Multiple hit on same target is allowed.
@@ -120,9 +122,8 @@ void Catapult::apply(BattleStateProxy * battleState, RNG & rng, const Mechanics 
 			break;
 		}
 
-		if(posRemove != BattleHex::INVALID)
+		if(posRemove != BattleHex::INVALID && state - attackInfo.damageDealt <= 0) //HP enum subtraction not intuitive, consider using SiegeInfo::applyDamage
 		{
-			BattleUnitsChanged removeUnits;
 			auto all = m->cb->battleGetUnitsIf([=](const battle::Unit * unit)
 			{
 				return !unit->isGhost();
@@ -136,12 +137,13 @@ void Catapult::apply(BattleStateProxy * battleState, RNG & rng, const Mechanics 
 					break;
 				}
 			}
-			if(!removeUnits.changedStacks.empty())
-				battleState->apply(&removeUnits);
 		}
 	}
 
 	battleState->apply(&ca);
+
+	if(!removeUnits.changedStacks.empty())
+		battleState->apply(&removeUnits);
 }
 
 void Catapult::serializeJsonEffect(JsonSerializeFormat & handler)

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -4340,6 +4340,7 @@ bool CGameHandler::makeBattleAction(BattleAction &ba)
 				attack.attackedPart = attackedPart;
 				attack.destinationTile = destination;
 				attack.damageDealt = 0;
+				BattleUnitsChanged removeUnits;
 
 				int dmgChance[] = { stackBallisticsParameters.noDmg, stackBallisticsParameters.oneDmg, stackBallisticsParameters.twoDmg }; //dmgChance[i] - chance for doing i dmg when hit is successful
 
@@ -4379,7 +4380,6 @@ bool CGameHandler::makeBattleAction(BattleAction &ba)
 						break;
 					}
 
-					BattleUnitsChanged removeUnits;
 					for(auto & elem : gs->curB->stacks)
 					{
 						if(elem->initialPosition == posRemove)
@@ -4388,13 +4388,14 @@ bool CGameHandler::makeBattleAction(BattleAction &ba)
 							break;
 						}
 					}
-					if(!removeUnits.changedStacks.empty())
-						sendAndApply(&removeUnits);
 				}
 				ca.attacker = ba.stackNumber;
 				ca.attackedParts.push_back(attack);
 
 				sendAndApply(&ca);
+
+				if(!removeUnits.changedStacks.empty())
+					sendAndApply(&removeUnits);
 			}
 			//finish by scope guard
 			break;

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -4362,7 +4362,7 @@ bool CGameHandler::makeBattleAction(BattleAction &ba)
 				logGlobal->trace("Catapult attacks %d dealing %d damage", (int)attack.attackedPart, (int)attack.damageDealt);
 
 				//removing creatures in turrets / keep if one is destroyed
-				if (attack.damageDealt > 0 && (attackedPart == EWallPart::KEEP ||
+				if (currentHP.at(attackedPart) - attack.damageDealt <= 0 && (attackedPart == EWallPart::KEEP ||
 					attackedPart == EWallPart::BOTTOM_TOWER || attackedPart == EWallPart::UPPER_TOWER))
 				{
 					int posRemove = -1;

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -4363,7 +4363,7 @@ bool CGameHandler::makeBattleAction(BattleAction &ba)
 				logGlobal->trace("Catapult attacks %d dealing %d damage", (int)attack.attackedPart, (int)attack.damageDealt);
 
 				//removing creatures in turrets / keep if one is destroyed
-				if (currentHP.at(attackedPart) - attack.damageDealt <= 0 && (attackedPart == EWallPart::KEEP ||
+				if (currentHP.at(attackedPart) - attack.damageDealt <= 0 && (attackedPart == EWallPart::KEEP || //HP enum subtraction not intuitive, consider using SiegeInfo::applyDamage
 					attackedPart == EWallPart::BOTTOM_TOWER || attackedPart == EWallPart::UPPER_TOWER))
 				{
 					int posRemove = -1;


### PR DESCRIPTION
Fix for catapult/walls mechanics to match H3.

Done:
- Fixed cyclops wall destruction to match H3 completely
- Repaired arrow towers buggy state while half-destroyed
- Visual fix for arrow tower destruction - before changes it was very ugly from player's point of view (shooters disappearing before stone hit etc.)
- Check hitchance/target randomization
- Fix Catapult spell effect