### PR TITLE
redefined lctrl to lgui for macs

### DIFF
--- a/client/widgets/CGarrisonInt.cpp
+++ b/client/widgets/CGarrisonInt.cpp
@@ -27,6 +27,10 @@
 
 #include "../../lib/CGameState.h"
 
+#ifdef VCMI_MAC
+#define SDL_SCANCODE_LCTRL SDL_SCANCODE_LGUI
+#endif
+
 void CGarrisonSlot::setHighlight(bool on)
 {
 	if (on)


### PR DESCRIPTION
The reason for my PR is Macs use ctrl + click shortcut for popping up a context menu. It can't be turned off.
I changed the code so that the cool shortcuts for splitting armies use the command key, rather than control.

Keep up the good work guys!
Regards