### PR TITLE
Reflect changes in boost::asio released in Boost 1.66.

### DIFF
--- a/lib/serializer/Connection.cpp
+++ b/lib/serializer/Connection.cpp
@@ -14,6 +14,9 @@
 #include "../mapping/CMap.h"
 #include "../CGameState.h"
 
+#if BOOST_VERSION >= 106600
+#define BOOST_ASIO_ENABLE_OLD_SERVICES
+#endif
 #include <boost/asio.hpp>
 
 using namespace boost;

--- a/lib/serializer/Connection.h
+++ b/lib/serializer/Connection.h
@@ -22,7 +22,13 @@ namespace boost
 		{
 			class tcp;
 		}
+
+#if BOOST_VERSION >= 106600  // Boost version >= 1.66
+		class io_context;
+		typedef io_context io_service;
+#else
 		class io_service;
+#endif
 
 		template <typename Protocol> class stream_socket_service;
 		template <typename Protocol,typename StreamSocketService>

--- a/server/CVCMIServer.cpp
+++ b/server/CVCMIServer.cpp
@@ -9,6 +9,9 @@
  */
 #include "StdInc.h"
 
+#if BOOST_VERSION >= 106600
+#define BOOST_ASIO_ENABLE_OLD_SERVICES
+#endif
 #include <boost/asio.hpp>
 
 #include "../lib/filesystem/Filesystem.h"

--- a/server/CVCMIServer.h
+++ b/server/CVCMIServer.h
@@ -26,7 +26,13 @@ namespace boost
 		{
 			class tcp;
 		}
+
+#if BOOST_VERSION >= 106600  // Boost version >= 1.66
+		class io_context;
+		typedef io_context io_service;
+#else
 		class io_service;
+#endif
 
 		template <typename Protocol> class stream_socket_service;
 		template <typename Protocol,typename StreamSocketService>


### PR DESCRIPTION
The service template parameters, and the corresponding classes,
are disabled by default for now. For example,
basic_socket<Protocol, SocketService> => basic_socket<Protocol>