### PR TITLE
Flexible necromancy

### DIFF
--- a/config/artifacts.json
+++ b/config/artifacts.json
@@ -1884,9 +1884,19 @@
 	{
 		"bonuses" : [
 			{
-				"type" : "IMPROVED_NECROMANCY", //TODO: more flexible?
-				"val" : 0,
-				"valueType" : "BASE_NUMBER"
+				"type" : "IMPROVED_NECROMANCY",
+				"subtype" : "creature.walkingDead",
+				"addInfo" : 1
+			},
+			{
+				"type" : "IMPROVED_NECROMANCY",
+				"subtype" : "creature.wight",
+				"addInfo" : 2
+			},
+			{
+				"type" : "IMPROVED_NECROMANCY",
+				"subtype" : "creature.lich",
+				"addInfo" : 3
 			}
 		],
 		"index" : 130,

--- a/lib/HeroBonus.h
+++ b/lib/HeroBonus.h
@@ -147,7 +147,7 @@ public:
 	BONUS_NAME(MAGIC_SCHOOL_SKILL) /* //eg. for magic plains terrain, subtype: school of magic (0 - all, 1 - fire, 2 - air, 4 - water, 8 - earth), value - level*/ \
 	BONUS_NAME(FREE_SHOOTING) /*stacks can shoot even if otherwise blocked (sharpshooter's bow effect)*/ \
 	BONUS_NAME(OPENING_BATTLE_SPELL) /*casts a spell at expert level at beginning of battle, val - spell power, subtype - spell id*/ \
-	BONUS_NAME(IMPROVED_NECROMANCY) /*allows Necropolis units other than skeletons to be raised by necromancy*/ \
+	BONUS_NAME(IMPROVED_NECROMANCY) /* raise more powerful creatures: subtype - creature type raised, addInfo - [required necromancy level, required stack level] */ \
 	BONUS_NAME(CREATURE_GROWTH_PERCENT) /*increases growth of all units in all towns, val - percentage*/ \
 	BONUS_NAME(FREE_SHIP_BOARDING) /*movement points preserved with ship boarding and landing*/  \
 	BONUS_NAME(NO_TYPE)									\

--- a/lib/ResourceSet.cpp
+++ b/lib/ResourceSet.cpp
@@ -88,11 +88,11 @@ bool Res::canAfford(const ResourceSet &res, const ResourceSet &price)
 	return true;
 }
 
-int Res::ResourceSet::marketValue() const
+TResourceCap Res::ResourceSet::marketValue() const
 {
-	int total = 0;
+	TResourceCap total = 0;
 	for(int i = 0; i < GameConstants::RESOURCE_QUANTITY; i++)
-		total += VLC->objh->resVals[i] * operator[](i);
+		total += static_cast<TResourceCap>(VLC->objh->resVals[i]) * static_cast<TResourceCap>(operator[](i));
 	return total;
 }
 

--- a/lib/ResourceSet.cpp
+++ b/lib/ResourceSet.cpp
@@ -13,6 +13,8 @@
 #include "StringConstants.h"
 #include "JsonNode.h"
 #include "serializer/JsonSerializeFormat.h"
+#include "VCMI_Lib.h"
+#include "mapObjects/CObjectHandler.h"
 
 Res::ResourceSet::ResourceSet()
 {
@@ -84,6 +86,14 @@ bool Res::canAfford(const ResourceSet &res, const ResourceSet &price)
 			return false;
 
 	return true;
+}
+
+int Res::ResourceSet::marketValue() const
+{
+	int total = 0;
+	for(int i = 0; i < GameConstants::RESOURCE_QUANTITY; i++)
+		total += VLC->objh->resVals[i] * operator[](i);
+	return total;
 }
 
 std::string Res::ResourceSet::toString() const

--- a/lib/ResourceSet.h
+++ b/lib/ResourceSet.h
@@ -133,6 +133,7 @@ namespace Res
 		DLL_LINKAGE bool nonZero() const; //returns true if at least one value is non-zero;
 		DLL_LINKAGE bool canAfford(const ResourceSet &price) const;
 		DLL_LINKAGE bool canBeAfforded(const ResourceSet &res) const;
+		DLL_LINKAGE int marketValue() const;
 
 		DLL_LINKAGE std::string toString() const;
 

--- a/lib/ResourceSet.h
+++ b/lib/ResourceSet.h
@@ -133,7 +133,7 @@ namespace Res
 		DLL_LINKAGE bool nonZero() const; //returns true if at least one value is non-zero;
 		DLL_LINKAGE bool canAfford(const ResourceSet &price) const;
 		DLL_LINKAGE bool canBeAfforded(const ResourceSet &res) const;
-		DLL_LINKAGE int marketValue() const;
+		DLL_LINKAGE TResourceCap marketValue() const;
 
 		DLL_LINKAGE std::string toString() const;
 

--- a/lib/mapObjects/CGHeroInstance.cpp
+++ b/lib/mapObjects/CGHeroInstance.cpp
@@ -803,10 +803,11 @@ bool CGHeroInstance::canLearnSpell(const CSpell * spell) const
  */
 CStackBasicDescriptor CGHeroInstance::calculateNecromancy (const BattleResult &battleResult) const
 {
-	double necromancySkill = valOfBonuses(Bonus::SECONDARY_SKILL_PREMY, SecondarySkill::NECROMANCY) / 100.0;
-
-	if (necromancySkill > 0)
+	const ui8 necromancyLevel = getSecSkillLevel(SecondarySkill::NECROMANCY);
+	// need skill or cloak of undead king - lesser artifacts don't work without skill
+	if (necromancyLevel > 0 || hasBonusOfType(Bonus::IMPROVED_NECROMANCY))
 	{
+		double necromancySkill = valOfBonuses(Bonus::SECONDARY_SKILL_PREMY, SecondarySkill::NECROMANCY) / 100.0;
 		vstd::amin(necromancySkill, 1.0); //it's impossible to raise more creatures than all...
 		const std::map<ui32,si32> &casualties = battleResult.casualties[!battleResult.winner];
 		// figure out what to raise - pick strongest creature meeting requirements
@@ -815,7 +816,6 @@ CStackBasicDescriptor CGHeroInstance::calculateNecromancy (const BattleResult &b
 		const TBonusListPtr improvedNecromancy = getBonuses(Selector::type(Bonus::IMPROVED_NECROMANCY));
 		if(!improvedNecromancy->empty())
 		{
-			const ui8 necromancyLevel = getSecSkillLevel(SecondarySkill::NECROMANCY);
 			auto legacyCreatureID = [necromancyLevel](int id) -> CreatureID
 			{
 				const CreatureID legacyTypes[] = {CreatureID::SKELETON, CreatureID::WALKING_DEAD, CreatureID::WIGHTS, CreatureID::LICHES};

--- a/lib/mapObjects/CGHeroInstance.cpp
+++ b/lib/mapObjects/CGHeroInstance.cpp
@@ -803,46 +803,81 @@ bool CGHeroInstance::canLearnSpell(const CSpell * spell) const
  */
 CStackBasicDescriptor CGHeroInstance::calculateNecromancy (const BattleResult &battleResult) const
 {
-	const ui8 necromancyLevel = getSecSkillLevel(SecondarySkill::NECROMANCY);
+	double necromancySkill = valOfBonuses(Bonus::SECONDARY_SKILL_PREMY, SecondarySkill::NECROMANCY) / 100.0;
 
-	// Hero knows necromancy or has Necromancer Cloak
-	if (necromancyLevel > 0 || hasBonusOfType(Bonus::IMPROVED_NECROMANCY))
+	if (necromancySkill > 0)
 	{
-		double necromancySkill = valOfBonuses(Bonus::SECONDARY_SKILL_PREMY, SecondarySkill::NECROMANCY)/100.0;
 		vstd::amin(necromancySkill, 1.0); //it's impossible to raise more creatures than all...
 		const std::map<ui32,si32> &casualties = battleResult.casualties[!battleResult.winner];
-		ui32 raisedUnits = 0;
-
-		// Figure out what to raise and how many.
-		const CreatureID creatureTypes[] = {CreatureID::SKELETON, CreatureID::WALKING_DEAD, CreatureID::WIGHTS, CreatureID::LICHES};
-		const bool improvedNecromancy = hasBonusOfType(Bonus::IMPROVED_NECROMANCY);
-		const CCreature *raisedUnitType = VLC->creh->creatures[creatureTypes[improvedNecromancy ? necromancyLevel : 0]];
-		const ui32 raisedUnitHP = raisedUnitType->MaxHealth();
-
-		//calculate creatures raised from each defeated stack
-		for (auto & casualtie : casualties)
+		// figure out what to raise - pick strongest creature meeting requirements
+		CreatureID creatureTypeRaised = CreatureID::SKELETON;
+		int requiredCasualtyLevel = 1;
+		const TBonusListPtr improvedNecromancy = getBonuses(Selector::type(Bonus::IMPROVED_NECROMANCY));
+		if(!improvedNecromancy->empty())
 		{
-			// Get lost enemy hit points convertible to units.
-			CCreature * c = VLC->creh->creatures[casualtie.first];
-
-			const ui32 raisedHP = c->MaxHealth() * casualtie.second * necromancySkill;
-			raisedUnits += std::min<ui32>(raisedHP / raisedUnitHP, casualtie.second * necromancySkill); //limit to % of HP and % of original stack count
+			const ui8 necromancyLevel = getSecSkillLevel(SecondarySkill::NECROMANCY);
+			auto legacyCreatureID = [necromancyLevel](int id) -> CreatureID
+			{
+				const CreatureID legacyTypes[] = {CreatureID::SKELETON, CreatureID::WALKING_DEAD, CreatureID::WIGHTS, CreatureID::LICHES};
+				return CreatureID(id > 0 ? id : legacyTypes[necromancyLevel]);
+			};
+			int maxCasualtyLevel = 1;
+			for (auto & casualty : casualties)
+				vstd::amax(maxCasualtyLevel, VLC->creh->creatures[casualty.first]->level);
+			// pick best bonus available
+			std::shared_ptr<Bonus> topPick = NULL;
+			for(std::shared_ptr<Bonus> newPick : *improvedNecromancy)
+			{
+				// addInfo[0] = required necromancy skill, addInfo[1] = required casualty level
+				if(newPick->additionalInfo[0] > necromancyLevel || newPick->additionalInfo[1] > maxCasualtyLevel)
+					continue;
+				if(topPick == NULL)
+				{
+					topPick = newPick;
+				}
+				else
+				{
+					auto quality = [legacyCreatureID](std::shared_ptr<Bonus> pick) -> std::vector<int>
+					{
+						CCreature * c = VLC->creh->creatures[legacyCreatureID(pick->subtype)];
+						std::vector<int> v = {c->level, c->cost.marketValue(), -pick->additionalInfo[1]};
+						return v;
+					};
+					if(quality(topPick) < quality(newPick))
+						topPick = newPick;
+				}
+			}
+			if(topPick != NULL)
+			{
+				creatureTypeRaised = legacyCreatureID(topPick->subtype);
+				requiredCasualtyLevel = std::max(topPick->additionalInfo[1], 1);
+			}
 		}
-
-		// Make room for new units.
-		SlotID slot = getSlotFor(raisedUnitType->idNumber);
-		if (slot == SlotID())
+		// raise upgraded creature (at 2/3 rate) if no space available otherwise
+		if(getSlotFor(creatureTypeRaised) == SlotID())
 		{
-			// If there's no room for unit, try it's upgraded version 2/3rds the size.
-			raisedUnitType = VLC->creh->creatures[*raisedUnitType->upgrades.begin()];
-			raisedUnits = (raisedUnits*2)/3;
-
-			slot = getSlotFor(raisedUnitType->idNumber);
+			for(CreatureID upgraded : VLC->creh->creatures[creatureTypeRaised]->upgrades)
+			{
+				if(getSlotFor(upgraded) != SlotID())
+				{
+					creatureTypeRaised = upgraded;
+					necromancySkill *= 2/3.0;
+					break;
+				}
+			}
 		}
-		if (raisedUnits <= 0)
-			raisedUnits = 1;
-
-		return CStackBasicDescriptor(raisedUnitType->idNumber, raisedUnits);
+		// calculate number of creatures raised - low level units contribute at 50% rate
+		const double raisedUnitHealth = VLC->creh->creatures[creatureTypeRaised]->MaxHealth();
+		double raisedUnits = 0;
+		for(auto & casualty : casualties)
+		{
+			CCreature * c = VLC->creh->creatures[casualty.first];
+			double raisedFromCasualty = std::min(c->MaxHealth() / raisedUnitHealth, 1.0) * casualty.second * necromancySkill;
+			if(c->level < requiredCasualtyLevel)
+				raisedFromCasualty *= 0.5;
+			raisedUnits += raisedFromCasualty;
+		}
+		return CStackBasicDescriptor(creatureTypeRaised, std::max(static_cast<int>(raisedUnits), 1));
 	}
 
 	return CStackBasicDescriptor();

--- a/lib/mapObjects/CGHeroInstance.cpp
+++ b/lib/mapObjects/CGHeroInstance.cpp
@@ -847,7 +847,7 @@ CStackBasicDescriptor CGHeroInstance::calculateNecromancy (const BattleResult &b
 						topPick = newPick;
 				}
 			}
-			if(topPick != NULL)
+			if(topPick)
 			{
 				creatureTypeRaised = getCreatureID(topPick);
 				requiredCasualtyLevel = std::max(topPick->additionalInfo[1], 1);


### PR DESCRIPTION
Extends IMPROVED_NECROMANCY with parameters for greater flexibility:
* subtype = ID of creature raised
* addInfo[0] = required necromancy skill level (0-3)
* addInfo[1] = required level of creature killed

The addInfo parameters are optional. E.g.

```
"cloakOfTheUndeadKing":
{
    "bonuses" : [
        {
            "type" : "IMPROVED_NECROMANCY",
            "subtype" : "creature.walkingDead",
            "addInfo" : 1
        },
        {
            "type" : "IMPROVED_NECROMANCY",
            "subtype" : "creature.wight",
            "addInfo" : 2
        },
        {
            "type" : "IMPROVED_NECROMANCY",
            "subtype" : "creature.lich",
            "addInfo" : 3
        }
    ],
    ...
}
```
```
"core:necromancy" : {
    "basic" : {
        "description" : "{Basic Necromancy}\n\nReanimates 5% of enemy creatures killed as skeletons.",
        "effects" : {
            "main" : { "val" : 5 }
        }
    },
    "advanced" : {
        "description" : "{Advanced Necromancy}\n\nReanimates 10% of enemy creatures killed.\nLevel 1-2: Skeletons\nLevel 3+: Walking Dead",
        "effects" : {
            "main" : { "val" : 10 },
            "xtra" : {
                "type" : "IMPROVED_NECROMANCY",
                "subtype" : "creature.walkingDead",
                "addInfo" : [0,3]
            }
        }
    },
    "expert" : {
        "description" : "{Expert Necromancy}\n\nReanimates 15% of enemy creatures killed.\nLevel 1-2: Skeletons\nLevel 3-4: Walking Dead\nLevel 5+: Wights",
        "effects" : {
            "main" : { "val" : 15 },
            "xtra" : {
                "type" : "IMPROVED_NECROMANCY",
                "subtype" : "creature.walkingDead",
                "addInfo" : [0,3]
            },
            "xtra2" : {
                "type" : "IMPROVED_NECROMANCY",
                "subtype" : "creature.wight",
                "addInfo" : [0,5]
            }
        }
    }
}
```
When multiple IMPROVED_NECROMANCY bonuses are provided, the most powerful creature (based on level and cost) meeting the requirements is raised. For casualties of mixed levels, the highest casualty level determines the type of creature raised, and casualties not meeting the level requirement only contribute half to number of creatures raised.