### PR TITLE
Make bonus stacking configurable + fix duplicate propagation/inheritance

### DIFF
--- a/client/CMT.cpp
+++ b/client/CMT.cpp
@@ -802,7 +802,7 @@ void processCommand(const std::string &message)
 		adventureInt->selection->getParents(parents);
 		for(const CBonusSystemNode *parent : parents)
 		{
-			std::cout << "\nBonuses from " << typeid(*parent).name() << std::endl << parent->getBonusList() << std::endl;
+			std::cout << "\nBonuses from " << typeid(*parent).name() << std::endl << *parent->getAllBonuses(Selector::all, Selector::all) << std::endl;
 		}
 	}
 	else if(cn == "not dialog")

--- a/client/CMT.cpp
+++ b/client/CMT.cpp
@@ -794,15 +794,24 @@ void processCommand(const std::string &message)
 	}
 	else if(cn == "bonuses")
 	{
+		bool jsonFormat = (message == "bonuses json");
+		auto format = [jsonFormat](const BonusList & b) -> std::string
+		{
+			if(jsonFormat)
+				return b.toJsonNode().toJson(true);
+			std::ostringstream ss;
+			ss << b;
+			return ss.str();
+		};
 		std::cout << "Bonuses of " << adventureInt->selection->getObjectName() << std::endl
-			<< adventureInt->selection->getBonusList() << std::endl;
+			<< format(adventureInt->selection->getBonusList()) << std::endl;
 
 		std::cout << "\nInherited bonuses:\n";
 		TCNodes parents;
 		adventureInt->selection->getParents(parents);
 		for(const CBonusSystemNode *parent : parents)
 		{
-			std::cout << "\nBonuses from " << typeid(*parent).name() << std::endl << *parent->getAllBonuses(Selector::all, Selector::all) << std::endl;
+			std::cout << "\nBonuses from " << typeid(*parent).name() << std::endl << format(*parent->getAllBonuses(Selector::all, Selector::all)) << std::endl;
 		}
 	}
 	else if(cn == "not dialog")

--- a/client/widgets/MiscWidgets.cpp
+++ b/client/widgets/MiscWidgets.cpp
@@ -365,7 +365,7 @@ void MoraleLuckBox::set(const IBonusBearer *node)
 
 	if (node)
 	{
-		modifierList = node->getBonuses(Selector::type(bonusType[morale]))->stackingBonuses();
+		modifierList = node->getBonuses(Selector::type(bonusType[morale]));
 		bonusValue = (node->*getValue[morale])();
 	}
 	else

--- a/client/widgets/MiscWidgets.cpp
+++ b/client/widgets/MiscWidgets.cpp
@@ -365,7 +365,7 @@ void MoraleLuckBox::set(const IBonusBearer *node)
 
 	if (node)
 	{
-		modifierList = node->getBonuses(Selector::type(bonusType[morale]));
+		modifierList = node->getBonuses(Selector::type(bonusType[morale]))->stackingBonuses();
 		bonusValue = (node->*getValue[morale])();
 	}
 	else

--- a/config/artifacts.json
+++ b/config/artifacts.json
@@ -1549,7 +1549,8 @@
 				"subtype" : "resource.crystal",
 				"type" : "GENERATE_RESOURCE",
 				"val" : 1,
-				"valueType" : "BASE_NUMBER"
+				"valueType" : "BASE_NUMBER",
+				"stacking" : "ALWAYS"
 			}
 		],
 		"index" : 109,
@@ -1562,7 +1563,8 @@
 				"subtype" : "resource.gems",
 				"type" : "GENERATE_RESOURCE",
 				"val" : 1,
-				"valueType" : "BASE_NUMBER"
+				"valueType" : "BASE_NUMBER",
+				"stacking" : "ALWAYS"
 			}
 		],
 		"index" : 110,
@@ -1575,7 +1577,8 @@
 				"subtype" : "resource.mercury",
 				"type" : "GENERATE_RESOURCE",
 				"val" : 1,
-				"valueType" : "BASE_NUMBER"
+				"valueType" : "BASE_NUMBER",
+				"stacking" : "ALWAYS"
 			}
 		],
 		"index" : 111,
@@ -1588,7 +1591,8 @@
 				"subtype" : "resource.ore",
 				"type" : "GENERATE_RESOURCE",
 				"val" : 1,
-				"valueType" : "BASE_NUMBER"
+				"valueType" : "BASE_NUMBER",
+				"stacking" : "ALWAYS"
 			}
 		],
 		"index" : 112,
@@ -1601,7 +1605,8 @@
 				"subtype" : "resource.sulfur",
 				"type" : "GENERATE_RESOURCE",
 				"val" : 1,
-				"valueType" : "BASE_NUMBER"
+				"valueType" : "BASE_NUMBER",
+				"stacking" : "ALWAYS"
 			}
 		],
 		"index" : 113,
@@ -1614,7 +1619,8 @@
 				"subtype" : "resource.wood",
 				"type" : "GENERATE_RESOURCE",
 				"val" : 1,
-				"valueType" : "BASE_NUMBER"
+				"valueType" : "BASE_NUMBER",
+				"stacking" : "ALWAYS"
 			}
 		],
 		"index" : 114,
@@ -1627,7 +1633,8 @@
 				"subtype" : "resource.gold",
 				"type" : "GENERATE_RESOURCE",
 				"val" : 1000,
-				"valueType" : "BASE_NUMBER"
+				"valueType" : "BASE_NUMBER",
+				"stacking" : "ALWAYS"
 			}
 		],
 		"index" : 115,
@@ -1640,7 +1647,8 @@
 				"subtype" : "resource.gold",
 				"type" : "GENERATE_RESOURCE",
 				"val" : 750,
-				"valueType" : "BASE_NUMBER"
+				"valueType" : "BASE_NUMBER",
+				"stacking" : "ALWAYS"
 			}
 		],
 		"index" : 116,
@@ -1653,7 +1661,8 @@
 				"subtype" : "resource.gold",
 				"type" : "GENERATE_RESOURCE",
 				"val" : 500,
-				"valueType" : "BASE_NUMBER"
+				"valueType" : "BASE_NUMBER",
+				"stacking" : "ALWAYS"
 			}
 		],
 		"index" : 117,

--- a/config/creatures/castle.json
+++ b/config/creatures/castle.json
@@ -309,7 +309,7 @@
 			},
 			"const_raises_morale" :
 			{
-				"stacking" : "angel"
+				"stacking" : "Angels"
 			}
 		},
 		"upgrades": ["archangel"],
@@ -364,7 +364,7 @@
 			},
 			"const_raises_morale" :
 			{
-				"stacking" : "angel"
+				"stacking" : "Angels"
 			}
 		},
 		"graphics" :

--- a/config/creatures/castle.json
+++ b/config/creatures/castle.json
@@ -306,6 +306,10 @@
 				"type" : "HATE",
 				"subtype" : "creature.archDevil",
 				"val" : 50
+			},
+			"const_raises_morale" :
+			{
+				"stacking" : "creature.angel"
 			}
 		},
 		"upgrades": ["archangel"],
@@ -357,6 +361,10 @@
 				"type" : "HATE",
 				"subtype" : "creature.archDevil",
 				"val" : 50
+			},
+			"const_raises_morale" :
+			{
+				"stacking" : "creature.angel"
 			}
 		},
 		"graphics" :

--- a/config/creatures/castle.json
+++ b/config/creatures/castle.json
@@ -309,7 +309,7 @@
 			},
 			"const_raises_morale" :
 			{
-				"stacking" : "creature.angel"
+				"stacking" : "angel"
 			}
 		},
 		"upgrades": ["archangel"],
@@ -364,7 +364,7 @@
 			},
 			"const_raises_morale" :
 			{
-				"stacking" : "creature.angel"
+				"stacking" : "angel"
 			}
 		},
 		"graphics" :

--- a/config/creatures/inferno.json
+++ b/config/creatures/inferno.json
@@ -361,7 +361,8 @@
 			{
 				"type" : "LUCK",
 				"effectRange" : "ONLY_ENEMY_ARMY",
-				"val" : -1
+				"val" : -1,
+				"stacking" : "Devils"
 			},
 			"blockRetaliation" :
 			{
@@ -412,7 +413,8 @@
 			{
 				"type" : "LUCK",
 				"effectRange" : "ONLY_ENEMY_ARMY",
-				"val" : -1
+				"val" : -1,
+				"stacking" : "Devils"
 			},
 			"blockRetaliation" :
 			{

--- a/config/creatures/necropolis.json
+++ b/config/creatures/necropolis.json
@@ -338,6 +338,10 @@
 			"dragon" :
 			{
 				"type" : "DRAGON_NATURE"
+			},
+			"const_lowers_morale" :
+			{
+				"stacking" : "Undead Dragons"
 			}
 		},
 		"upgrades": ["ghostDragon"],
@@ -364,6 +368,10 @@
 			"dragon" :
 			{
 				"type" : "DRAGON_NATURE"
+			},
+			"const_lowers_morale" :
+			{
+				"stacking" : "Undead Dragons"
 			},
 			"age" :
 			{

--- a/config/schemas/bonus.json
+++ b/config/schemas/bonus.json
@@ -112,10 +112,7 @@
 			"description": "sourceType"
 		},
 		"stacking" : {
-			"anyOf" : [
-				{ "type" : "string" },
-				{ "type" : "number" }
-			],
+			"type" : "string",
 			"description" : "stacking"
 		},
 		"subtype": {

--- a/config/schemas/bonus.json
+++ b/config/schemas/bonus.json
@@ -111,6 +111,13 @@
 			"type":"string",
 			"description": "sourceType"
 		},
+		"stacking" : {
+			"anyOf" : [
+				{ "type" : "string" },
+				{ "type" : "number" }
+			],
+			"description" : "stacking"
+		},
 		"subtype": {
 			"anyOf" : [
 				{ "type" : "string" },

--- a/lib/HeroBonus.cpp
+++ b/lib/HeroBonus.cpp
@@ -260,7 +260,7 @@ void BonusList::stackBonuses()
 		return b1->val > b2->val;
 	});
 	// remove non-stacking
-	int next = 1;
+	size_t next = 1;
 	while(next < bonuses.size())
 	{
 		bool remove;

--- a/lib/HeroBonus.cpp
+++ b/lib/HeroBonus.cpp
@@ -416,6 +416,14 @@ int BonusList::valOfBonuses(const CSelector &select) const
 	return ret.totalValue();
 }
 
+JsonNode BonusList::toJsonNode() const
+{
+	JsonNode node(JsonNode::JsonType::DATA_VECTOR);
+	for(std::shared_ptr<Bonus> b : bonuses)
+		node.Vector().push_back(b->toJsonNode());
+	return node;
+}
+
 void BonusList::push_back(std::shared_ptr<Bonus> x)
 {
 	bonuses.push_back(x);
@@ -1294,6 +1302,27 @@ JsonNode additionalInfoToJson(Bonus::BonusType type, CAddInfo addInfo)
 	}
 }
 
+JsonNode durationToJson(ui16 duration)
+{
+	std::vector<std::string> durationNames;
+	for(ui16 durBit = 1; durBit; durBit = durBit << 1)
+	{
+		if(duration & durBit)
+			durationNames.push_back(vstd::findKey(bonusDurationMap, durBit));
+	}
+	if(durationNames.size() == 1)
+	{
+		return JsonUtils::stringNode(durationNames[0]);
+	}
+	else
+	{
+		JsonNode node(JsonNode::JsonType::DATA_VECTOR);
+		for(std::string dur : durationNames)
+			node.Vector().push_back(JsonUtils::stringNode(dur));
+		return node;
+	}
+}
+
 JsonNode Bonus::toJsonNode() const
 {
 	JsonNode root(JsonNode::JsonType::DATA_STRUCT);
@@ -1314,7 +1343,7 @@ JsonNode Bonus::toJsonNode() const
 	if(effectRange != NO_LIMIT)
 		root["effectRange"].String() = vstd::findKey(bonusLimitEffect, effectRange);
 	if(duration != PERMANENT)
-		root["duration"].String() = vstd::findKey(bonusDurationMap, duration);
+		root["duration"] = durationToJson(duration);
 	if(turnsRemain)
 		root["turns"].Integer() = turnsRemain;
 	if(limiter)

--- a/lib/HeroBonus.cpp
+++ b/lib/HeroBonus.cpp
@@ -1267,13 +1267,8 @@ JsonNode Bonus::toJsonNode() const
 		root["val"].Integer() = val;
 	if(valType != ADDITIVE_VALUE)
 		root["valueType"].String() = vstd::findKey(bonusValueMap, valType);
-	if(stacking != STACKING_OTHER)
-	{
-		if(stacking == STACKING_ALWAYS)
-			root["stacking"].String() = "ALWAYS";
-		else
-			root["stacking"].Integer() = stacking;
-	}
+	if(stacking != "")
+		root["stacking"].String() = stacking;
 	if(limiter)
 		root["limiters"].Vector().push_back(limiter->toJsonNode());
 	if(updater)
@@ -1311,7 +1306,6 @@ Bonus::Bonus(ui16 Dur, BonusType Type, BonusSource Src, si32 Val, ui32 ID, std::
 {
 	turnsRemain = 0;
 	valType = ADDITIVE_VALUE;
-	stacking = STACKING_OTHER;
 	effectRange = NO_LIMIT;
 	boost::algorithm::trim(description);
 }
@@ -1320,7 +1314,6 @@ Bonus::Bonus(ui16 Dur, BonusType Type, BonusSource Src, si32 Val, ui32 ID, si32 
 	: duration(Dur), type(Type), subtype(Subtype), source(Src), val(Val), sid(ID), valType(ValType)
 {
 	turnsRemain = 0;
-	stacking = STACKING_OTHER;
 	effectRange = NO_LIMIT;
 }
 
@@ -1332,7 +1325,6 @@ Bonus::Bonus()
 	subtype = -1;
 
 	valType = ADDITIVE_VALUE;
-	stacking = STACKING_OTHER;
 	effectRange = NO_LIMIT;
 	val = 0;
 	source = OTHER;
@@ -1468,7 +1460,8 @@ DLL_LINKAGE std::ostream & operator<<(std::ostream &out, const Bonus &bonus)
 		out << "\taddInfo: " << bonus.additionalInfo.toString() << "\n";
 	printField(turnsRemain);
 	printField(valType);
-	printField(stacking);
+	if(bonus.stacking != "")
+		out << "\tstacking: \"" << bonus.stacking << "\"\n";
 	printField(effectRange);
 #undef printField
 

--- a/lib/HeroBonus.cpp
+++ b/lib/HeroBonus.cpp
@@ -139,7 +139,6 @@ TBonusListPtr CBonusProxy::get() const
 	{
 		//TODO: support limiters
 		data = target->getAllBonuses(selector, Selector::all);
-		data->eliminateDuplicates();
 		cachedLast = target->getTreeVersion();
 	}
 	return data;
@@ -375,14 +374,7 @@ int BonusList::valOfBonuses(const CSelector &select) const
 	BonusList ret;
 	CSelector limit = nullptr;
 	getBonuses(ret, select, limit);
-	ret.eliminateDuplicates();
 	return ret.totalValue();
-}
-
-void BonusList::eliminateDuplicates()
-{
-	sort( bonuses.begin(), bonuses.end() );
-	bonuses.erase( unique( bonuses.begin(), bonuses.end() ), bonuses.end() );
 }
 
 void BonusList::push_back(std::shared_ptr<Bonus> x)
@@ -688,7 +680,6 @@ const TBonusListPtr CBonusSystemNode::getAllBonuses(const CSelector &selector, c
 
 			BonusList allBonuses;
 			getAllBonusesRec(allBonuses);
-			allBonuses.eliminateDuplicates();
 			limitBonuses(allBonuses, cachedBonuses);
 
 			cachedLast = treeChanged;
@@ -730,7 +721,6 @@ const TBonusListPtr CBonusSystemNode::getAllBonusesWithoutCaching(const CSelecto
 	// Get bonus results without caching enabled.
 	BonusList beforeLimiting, afterLimiting;
 	getAllBonusesRec(beforeLimiting);
-	beforeLimiting.eliminateDuplicates();
 
 	if(!root || root == this)
 	{
@@ -747,7 +737,6 @@ const TBonusListPtr CBonusSystemNode::getAllBonusesWithoutCaching(const CSelecto
 		for(auto b : beforeLimiting)
 			rootBonuses.push_back(b);
 
-		rootBonuses.eliminateDuplicates();
 		root->limitBonuses(rootBonuses, limitedRootBonuses);
 
 		for(auto b : beforeLimiting)
@@ -944,11 +933,6 @@ void CBonusSystemNode::unpropagateBonus(std::shared_ptr<Bonus> b)
 	if(b->propagator->shouldBeAttached(this))
 	{
 		bonuses -= b;
-		while(vstd::contains(bonuses, b))
-		{
-			logBonus->error("Bonus was duplicated (%s) at %s", b->Description(), nodeName());
-			bonuses -= b;
-		}
 		logBonus->trace("#$# %s #is no longer propagated to# %s",  b->Description(), nodeName());
 	}
 

--- a/lib/HeroBonus.cpp
+++ b/lib/HeroBonus.cpp
@@ -1283,6 +1283,13 @@ JsonNode Bonus::toJsonNode() const
 		root["val"].Integer() = val;
 	if(valType != ADDITIVE_VALUE)
 		root["valueType"].String() = vstd::findKey(bonusValueMap, valType);
+	if(stacking != STACKING_OTHER)
+	{
+		if(stacking == STACKING_ALWAYS)
+			root["stacking"].String() = "ALWAYS";
+		else
+			root["stacking"].Integer() = stacking;
+	}
 	if(limiter)
 		root["limiters"].Vector().push_back(limiter->toJsonNode());
 	if(updater)
@@ -1320,6 +1327,7 @@ Bonus::Bonus(ui16 Dur, BonusType Type, BonusSource Src, si32 Val, ui32 ID, std::
 {
 	turnsRemain = 0;
 	valType = ADDITIVE_VALUE;
+	stacking = STACKING_OTHER;
 	effectRange = NO_LIMIT;
 	boost::algorithm::trim(description);
 }
@@ -1328,6 +1336,7 @@ Bonus::Bonus(ui16 Dur, BonusType Type, BonusSource Src, si32 Val, ui32 ID, si32 
 	: duration(Dur), type(Type), subtype(Subtype), source(Src), val(Val), sid(ID), valType(ValType)
 {
 	turnsRemain = 0;
+	stacking = STACKING_OTHER;
 	effectRange = NO_LIMIT;
 }
 
@@ -1339,6 +1348,7 @@ Bonus::Bonus()
 	subtype = -1;
 
 	valType = ADDITIVE_VALUE;
+	stacking = STACKING_OTHER;
 	effectRange = NO_LIMIT;
 	val = 0;
 	source = OTHER;
@@ -1474,6 +1484,7 @@ DLL_LINKAGE std::ostream & operator<<(std::ostream &out, const Bonus &bonus)
 		out << "\taddInfo: " << bonus.additionalInfo.toString() << "\n";
 	printField(turnsRemain);
 	printField(valType);
+	printField(stacking);
 	printField(effectRange);
 #undef printField
 

--- a/lib/HeroBonus.h
+++ b/lib/HeroBonus.h
@@ -345,6 +345,12 @@ struct DLL_LINKAGE Bonus : public std::enable_shared_from_this<Bonus>
 #undef BONUS_VALUE
 	};
 
+	enum Stacking
+	{
+		STACKING_OTHER = -1,
+		STACKING_ALWAYS = -2
+	};
+
 	ui16 duration; //uses BonusDuration values
 	si16 turnsRemain; //used if duration is N_TURNS, N_DAYS or ONE_WEEK
 
@@ -355,6 +361,7 @@ struct DLL_LINKAGE Bonus : public std::enable_shared_from_this<Bonus>
 	si32 val;
 	ui32 sid; //source id: id of object/artifact/spell
 	ValueType valType;
+	si32 stacking; //bonuses with the same (positive) stacking value don't stack (e.g. Angel/Archangel morale bonus)
 
 	CAddInfo additionalInfo;
 	LimitEffect effectRange; //if not NO_LIMIT, bonus will be omitted by default
@@ -389,6 +396,10 @@ struct DLL_LINKAGE Bonus : public std::enable_shared_from_this<Bonus>
 		}
 		h & turnsRemain;
 		h & valType;
+		if(version >= 784)
+		{
+			h & stacking;
+		}
 		h & effectRange;
 		h & limiter;
 		h & propagator;

--- a/lib/HeroBonus.h
+++ b/lib/HeroBonus.h
@@ -528,8 +528,6 @@ public:
 	const std::shared_ptr<Bonus> getFirst(const CSelector &select) const;
 	int valOfBonuses(const CSelector &select) const;
 
-	void eliminateDuplicates();
-
 	// remove_if implementation for STL vector types
 	template <class Predicate>
 	void remove_if(Predicate pred)

--- a/lib/HeroBonus.h
+++ b/lib/HeroBonus.h
@@ -511,7 +511,7 @@ public:
 	TInternalContainer::size_type operator-=(std::shared_ptr<Bonus> const &i);
 
 	// BonusList functions
-	TBonusListPtr stackingBonuses() const;
+	void stackBonuses();
 	int totalValue() const;
 	void getBonuses(BonusList &out, const CSelector &selector, const CSelector &limit) const;
 	void getAllBonuses(BonusList &out) const;

--- a/lib/HeroBonus.h
+++ b/lib/HeroBonus.h
@@ -523,6 +523,9 @@ public:
 	const std::shared_ptr<Bonus> getFirst(const CSelector &select) const;
 	int valOfBonuses(const CSelector &select) const;
 
+	// conversion / output
+	JsonNode toJsonNode() const;
+
 	// remove_if implementation for STL vector types
 	template <class Predicate>
 	void remove_if(Predicate pred)

--- a/lib/HeroBonus.h
+++ b/lib/HeroBonus.h
@@ -511,7 +511,7 @@ public:
 	TInternalContainer::size_type operator-=(std::shared_ptr<Bonus> const &i);
 
 	// BonusList functions
-	BonusList stackingBonuses() const;
+	TBonusListPtr stackingBonuses() const;
 	int totalValue() const;
 	void getBonuses(BonusList &out, const CSelector &selector, const CSelector &limit) const;
 	void getAllBonuses(BonusList &out) const;

--- a/lib/HeroBonus.h
+++ b/lib/HeroBonus.h
@@ -511,6 +511,7 @@ public:
 	TInternalContainer::size_type operator-=(std::shared_ptr<Bonus> const &i);
 
 	// BonusList functions
+	BonusList stackingBonuses() const;
 	int totalValue() const;
 	void getBonuses(BonusList &out, const CSelector &selector, const CSelector &limit) const;
 	void getAllBonuses(BonusList &out) const;

--- a/lib/HeroBonus.h
+++ b/lib/HeroBonus.h
@@ -345,12 +345,6 @@ struct DLL_LINKAGE Bonus : public std::enable_shared_from_this<Bonus>
 #undef BONUS_VALUE
 	};
 
-	enum Stacking
-	{
-		STACKING_OTHER = -1,
-		STACKING_ALWAYS = -2
-	};
-
 	ui16 duration; //uses BonusDuration values
 	si16 turnsRemain; //used if duration is N_TURNS, N_DAYS or ONE_WEEK
 
@@ -361,7 +355,7 @@ struct DLL_LINKAGE Bonus : public std::enable_shared_from_this<Bonus>
 	si32 val;
 	ui32 sid; //source id: id of object/artifact/spell
 	ValueType valType;
-	si32 stacking; //bonuses with the same (positive) stacking value don't stack (e.g. Angel/Archangel morale bonus)
+	std::string stacking; // bonuses with the same stacking value don't stack (e.g. Angel/Archangel morale bonus)
 
 	CAddInfo additionalInfo;
 	LimitEffect effectRange; //if not NO_LIMIT, bonus will be omitted by default

--- a/lib/JsonNode.cpp
+++ b/lib/JsonNode.cpp
@@ -598,6 +598,27 @@ bool JsonUtils::parseBonus(const JsonNode &ability, Bonus *b)
 	if (!value->isNull())
 		b->valType = static_cast<Bonus::ValueType>(parseByMap(bonusValueMap, value, "value type "));
 
+	value = &ability["stacking"];
+	switch(value->getType())
+	{
+	case JsonNode::JsonType::DATA_INTEGER:
+		b->stacking = value->Integer();
+		break;
+	case JsonNode::JsonType::DATA_STRING:
+		if(value->String() == "ALWAYS")
+			b->stacking = Bonus::STACKING_ALWAYS;
+		else if(value->String() == "OTHER")
+			b->stacking = Bonus::STACKING_OTHER;
+		else
+			VLC->modh->identifiers.requestIdentifier(*value, [b](si32 stacking_id)
+			{
+				b->stacking = stacking_id;
+			});
+		break;
+	default: // must be null
+		break;
+	}
+
 	resolveAddInfo(b->additionalInfo, ability);
 
 	b->turnsRemain = ability["turns"].Float();

--- a/lib/JsonNode.cpp
+++ b/lib/JsonNode.cpp
@@ -598,9 +598,7 @@ bool JsonUtils::parseBonus(const JsonNode &ability, Bonus *b)
 	if (!value->isNull())
 		b->valType = static_cast<Bonus::ValueType>(parseByMap(bonusValueMap, value, "value type "));
 
-	value = &ability["stacking"];
-	if (!value->isNull())
-		b->stacking = value->String();
+	b->stacking = ability["stacking"].String();
 
 	resolveAddInfo(b->additionalInfo, ability);
 

--- a/lib/JsonNode.cpp
+++ b/lib/JsonNode.cpp
@@ -744,29 +744,6 @@ Key reverseMapFirst(const Val & val, const std::map<Key, Val> & map)
 	return "";
 }
 
-void JsonUtils::unparseBonus( JsonNode &node, const std::shared_ptr<Bonus>& bonus )
-{
-	node["type"].String() = reverseMapFirst<std::string, Bonus::BonusType>(bonus->type, bonusNameMap);
-	node["subtype"].Float() = bonus->subtype;
-	node["val"].Float() = bonus->val;
-	node["valueType"].String() = reverseMapFirst<std::string, Bonus::ValueType>(bonus->valType, bonusValueMap);
-	node["additionalInfo"] = bonus->additionalInfo.toJsonNode();
-	node["turns"].Float() = bonus->turnsRemain;
-	node["sourceID"].Float() = bonus->source;
-	node["description"].String() = bonus->description;
-	node["effectRange"].String() = reverseMapFirst<std::string, Bonus::LimitEffect>(bonus->effectRange, bonusLimitEffect);
-	node["duration"].String() = reverseMapFirst<std::string, ui16>(bonus->duration, bonusDurationMap);
-	node["source"].String() = reverseMapFirst<std::string, Bonus::BonusSource>(bonus->source, bonusSourceMap);
-	if(bonus->limiter)
-	{
-		node["limiter"].String() = reverseMapFirst<std::string, TLimiterPtr>(bonus->limiter, bonusLimiterMap);
-	}
-	if(bonus->propagator)
-	{
-		node["propagator"].String() = reverseMapFirst<std::string, TPropagatorPtr>(bonus->propagator, bonusPropagatorMap);
-	}
-}
-
 void minimizeNode(JsonNode & node, const JsonNode & schema)
 {
 	if (schema["type"].String() == "object")

--- a/lib/JsonNode.cpp
+++ b/lib/JsonNode.cpp
@@ -599,25 +599,8 @@ bool JsonUtils::parseBonus(const JsonNode &ability, Bonus *b)
 		b->valType = static_cast<Bonus::ValueType>(parseByMap(bonusValueMap, value, "value type "));
 
 	value = &ability["stacking"];
-	switch(value->getType())
-	{
-	case JsonNode::JsonType::DATA_INTEGER:
-		b->stacking = value->Integer();
-		break;
-	case JsonNode::JsonType::DATA_STRING:
-		if(value->String() == "ALWAYS")
-			b->stacking = Bonus::STACKING_ALWAYS;
-		else if(value->String() == "OTHER")
-			b->stacking = Bonus::STACKING_OTHER;
-		else
-			VLC->modh->identifiers.requestIdentifier(*value, [b](si32 stacking_id)
-			{
-				b->stacking = stacking_id;
-			});
-		break;
-	default: // must be null
-		break;
-	}
+	if (!value->isNull())
+		b->stacking = value->String();
 
 	resolveAddInfo(b->additionalInfo, ability);
 

--- a/lib/JsonNode.h
+++ b/lib/JsonNode.h
@@ -168,7 +168,6 @@ namespace JsonUtils
 	DLL_LINKAGE std::shared_ptr<Bonus> parseBonus(const JsonVector &ability_vec);
 	DLL_LINKAGE std::shared_ptr<Bonus> parseBonus(const JsonNode &ability);
 	DLL_LINKAGE bool parseBonus(const JsonNode &ability, Bonus *placement);
-	DLL_LINKAGE void unparseBonus (JsonNode &node, const std::shared_ptr<Bonus>& bonus);
 	DLL_LINKAGE void resolveIdentifier(si32 &var, const JsonNode &node, std::string name);
 	DLL_LINKAGE void resolveIdentifier(const JsonNode &node, si32 &var);
 	DLL_LINKAGE void resolveAddInfo(CAddInfo & var, const JsonNode & node);

--- a/lib/serializer/CSerializer.h
+++ b/lib/serializer/CSerializer.h
@@ -12,7 +12,7 @@
 #include "../ConstTransitivePtr.h"
 #include "../GameConstants.h"
 
-const ui32 SERIALIZATION_VERSION = 783;
+const ui32 SERIALIZATION_VERSION = 784;
 const ui32 MINIMAL_SERIALIZATION_VERSION = 753;
 const std::string SAVEGAME_MAGIC = "VCMISVG";
 

--- a/test/mock/mock_BonusBearer.cpp
+++ b/test/mock/mock_BonusBearer.cpp
@@ -28,10 +28,7 @@ void BonusBearerMock::addNewBonus(const std::shared_ptr<Bonus> & b)
 const TBonusListPtr BonusBearerMock::getAllBonuses(const CSelector & selector, const CSelector & limit, const CBonusSystemNode * root, const std::string & cachingStr) const
 {
 	if(cachedLast != treeVersion)
-	{
-		bonuses.eliminateDuplicates();
 		cachedLast = treeVersion;
-	}
 
 	auto ret = std::make_shared<BonusList>();
 	bonuses.getBonuses(*ret, selector, limit);

--- a/test/mock/mock_BonusBearer.cpp
+++ b/test/mock/mock_BonusBearer.cpp
@@ -28,7 +28,10 @@ void BonusBearerMock::addNewBonus(const std::shared_ptr<Bonus> & b)
 const TBonusListPtr BonusBearerMock::getAllBonuses(const CSelector & selector, const CSelector & limit, const CBonusSystemNode * root, const std::string & cachingStr) const
 {
 	if(cachedLast != treeVersion)
+	{
+		bonuses.stackBonuses();
 		cachedLast = treeVersion;
+	}
 
 	auto ret = std::make_shared<BonusList>();
 	bonuses.getBonuses(*ret, selector, limit);


### PR DESCRIPTION
Addresses several related problems:
- Propagation / unpropagation of duplicate bonuses is inconsistent, causing bugs
- Duplicate bonuses never stack, which is not always intended behaviour (e.g. multiple copies of resource generating artifacts)
- Different bonuses always stack, which is not always intended behaviour (e.g. Angel + Archangel morale bonuses)

This is addressed as follows:
- Duplicate bonuses are never eliminated during propagation/inheritance.
- Unpropagation eliminates only a single copy of duplicated bonus
- Bonus receives a new field `stacking` that determines stacking behaviour:
-- empty string = no stacking with duplicates (default)
-- `"ALWAYS"` = stacks with duplicates & everything else
-- some other value = no stacking with bonuses with same stacking value

Example usage:
```
"angel" : {
    ...
    "const_raises_morale" : {
        "propagator" : "HERO",
        "type" : "MORALE",
        "val" : 1,
        "stacking" : "angel"
    },
    ...
},
"archAngel" : {
    ...
    "const_raises_morale" : {
        "propagator" : "HERO",
        "type" : "MORALE",
        "val" : 1,
        "stacking" : "angel"
    },
    ...
}
```
```
"endlessSackOfGold" : {
    ...
    {
        "subtype" : "resource.gold",
        "type" : "GENERATE_RESOURCE",
        "val" : 1000,
        "valueType" : "BASE_NUMBER",
        "stacking" : "ALWAYS"
    }
    ...
}
```