### PR TITLE
Bugfix for last CAddInfo bugfix

### DIFF
--- a/lib/HeroBonus.cpp
+++ b/lib/HeroBonus.cpp
@@ -180,7 +180,7 @@ bool CAddInfo::operator!=(si32 value) const
 
 si32 & CAddInfo::operator[](size_type pos)
 {
-	if(pos <= size())
+	if(pos >= size())
 		resize(pos + 1, CAddInfo::NONE);
 	return vector::operator[](pos);
 }


### PR DESCRIPTION
Typo was screwing up any addInfo values other than first (e.g. improved necromancy).