### PR TITLE
Allow the creation of new secondary skills

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -25,7 +25,7 @@ SPELLS:
 
 MODS:
 * Improve support for WoG commander artifacts and skill descriptions
-* Added basic support for secondary skill modding
+* Added support for modding of original secondary skills and creation of new ones.
 * Map object sounds can now be configured via json
 * Added bonus updaters for hero specialties
 

--- a/client/Graphics.cpp
+++ b/client/Graphics.cpp
@@ -24,6 +24,7 @@
 #include "../lib/CGeneralTextHandler.h"
 #include "../lib/CCreatureHandler.h"
 #include "CBitmapHandler.h"
+#include "../lib/CSkillHandler.h"
 #include "../lib/spells/CSpellHandler.h"
 #include "../lib/CGameState.h"
 #include "../lib/JsonNode.h"
@@ -442,5 +443,17 @@ void Graphics::initializeImageLists()
 		addImageListEntry(spell->id+1, "SPELLINT", spell->iconEffect);
 		addImageListEntry(spell->id, "SPELLBON", spell->iconScenarioBonus);
 		addImageListEntry(spell->id, "SPELLSCR", spell->iconScroll);
+	}
+
+	for(const CSkill * skill : CGI->skillh->objects)
+	{
+		for(int level = 1; level <= 3; level++)
+		{
+			int frame = 2 + level + 3 * skill->id;
+			const CSkill::LevelInfo & skillAtLevel = skill->at(level);
+			addImageListEntry(frame, "SECSK32", skillAtLevel.iconSmall);
+			addImageListEntry(frame, "SECSKILL", skillAtLevel.iconMedium);
+			addImageListEntry(frame, "SECSK82", skillAtLevel.iconLarge);
+		}
 	}
 }

--- a/config/schemas/skill.json
+++ b/config/schemas/skill.json
@@ -13,6 +13,27 @@
 			"description" : "Set of bonuses provided by skill at given level",
 			"required" : ["description", "effects"],
 			"properties" : {
+				"images" : {
+					"type" : "object",
+					"description" : "skill icons of varying size",
+					"properties" : {
+						"small" : {
+							"type" : "string",
+							"description" : "32x32 skill icon",
+							"format" : "imageFile"
+						},
+						"medium" : {
+							"type" : "string",
+							"description" : "44x44 skill icon",
+							"format" : "imageFile"
+						},
+						"large" : {
+							"type" : "string",
+							"description" : "82x93 skill icon",
+							"format" : "imageFile"
+						}
+					}
+				},
 				"description" : {
 					"type" : "string",
 					"description" : "localizable description"
@@ -38,6 +59,28 @@
 		"name" : {
 			"type": "string",
 			"description": "localizable skill name"
+		},
+		"gainChance" : {
+			"description" : "Chance for the skill to be offered on level-up (heroClass may override)",
+			"anyOf" : [
+				{
+					"type" : "number"
+				},
+				{
+					"type" : "object",
+					"required" : ["might", "magic"],
+					"properties" : {
+						"might" : {
+							"type" : "number",
+							"description" : "Chance for hero classes with might affinity"
+						},
+						"magic" : {
+							"type" : "number",
+							"description" : "Chance for hero classes with magic affinity"
+						}
+					}
+				}
+			]
 		},
 		"base" : {
 			"type" : "object",

--- a/lib/CHeroHandler.h
+++ b/lib/CHeroHandler.h
@@ -311,24 +311,11 @@ public:
 
 	std::vector<bool> getDefaultAllowed() const override;
 
-	/**
-	 * Gets a list of default allowed abilities. OH3 abilities/skills are all allowed by default.
-	 *
-	 * @return a list of allowed abilities, the index is the ability id
-	 */
-	std::vector<bool> getDefaultAllowedAbilities() const;
-
 	///json serialization helper
 	static si32 decodeHero(const std::string & identifier);
 
 	///json serialization helper
 	static std::string encodeHero(const si32 index);
-
-	///json serialization helper
-	static si32 decodeSkill(const std::string & identifier);
-
-	///json serialization helper
-	static std::string encodeSkill(const si32 index);
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{

--- a/lib/CModHandler.cpp
+++ b/lib/CModHandler.cpp
@@ -240,7 +240,7 @@ std::vector<CIdentifierStorage::ObjectData> CIdentifierStorage::getPossibleIdent
 		{
 			// allow only available to all core mod or dependencies
 			auto myDeps = VLC->modh->getModData(request.localScope).dependencies;
-			if (request.remoteScope == "core" || myDeps.count(request.remoteScope))
+			if(request.remoteScope == "core" || request.remoteScope == request.localScope || myDeps.count(request.remoteScope))
 				allowedScopes.insert(request.remoteScope);
 		}
 	}

--- a/lib/HeroBonus.cpp
+++ b/lib/HeroBonus.cpp
@@ -1274,7 +1274,7 @@ JsonNode subtypeToJson(Bonus::BonusType type, int subtype)
 	case Bonus::PRIMARY_SKILL:
 		return JsonUtils::stringNode("primSkill." + PrimarySkill::names[subtype]);
 	case Bonus::SECONDARY_SKILL_PREMY:
-		return JsonUtils::stringNode("skill." + NSecondarySkill::names[subtype]);
+		return JsonUtils::stringNode(CSkillHandler::encodeSkillWithType(subtype));
 	case Bonus::SPECIAL_SPELL_LEV:
 	case Bonus::SPECIFIC_SPELL_DAMAGE:
 	case Bonus::SPECIAL_BLESS_DAMAGE:
@@ -1362,7 +1362,7 @@ std::string Bonus::nameForBonus() const
 	case Bonus::PRIMARY_SKILL:
 		return PrimarySkill::names[subtype];
 	case Bonus::SECONDARY_SKILL_PREMY:
-		return NSecondarySkill::names[subtype];
+		return CSkillHandler::encodeSkill(subtype);
 	case Bonus::SPECIAL_SPELL_LEV:
 	case Bonus::SPECIFIC_SPELL_DAMAGE:
 	case Bonus::SPECIAL_BLESS_DAMAGE:

--- a/lib/IHandlerBase.h
+++ b/lib/IHandlerBase.h
@@ -67,22 +67,22 @@ public:
 	}
 	void loadObject(std::string scope, std::string name, const JsonNode & data) override
 	{
-		auto type_name = getTypeName();
 		auto object = loadFromJson(data, normalizeIdentifier(scope, "core", name), objects.size());
 
 		objects.push_back(object);
 
-		registerObject(scope, type_name, name, object->id);
+		for(auto type_name : getTypeNames())
+			registerObject(scope, type_name, name, object->id);
 	}
 	void loadObject(std::string scope, std::string name, const JsonNode & data, size_t index) override
 	{
-		auto type_name = getTypeName();
 		auto object = loadFromJson(data, normalizeIdentifier(scope, "core", name), index);
 
 		assert(objects[index] == nullptr); // ensure that this id was not loaded before
 		objects[index] = object;
 
-		registerObject(scope,type_name, name, object->id);
+		for(auto type_name : getTypeNames())
+			registerObject(scope, type_name, name, object->id);
 	}
 
 	ConstTransitivePtr<_Object> operator[] (const _ObjectID id) const
@@ -91,15 +91,19 @@ public:
 
 		if (raw_id < 0 || raw_id >= objects.size())
 		{
-			logMod->error("%s id %d is invalid", getTypeName(), static_cast<si64>(raw_id));
+			logMod->error("%s id %d is invalid", getTypeNames()[0], static_cast<si64>(raw_id));
 			throw std::runtime_error("internal error");
 		}
 
 		return objects[raw_id];
 	}
+	size_t size() const
+	{
+		return objects.size();
+	}
 protected:
 	virtual _Object * loadFromJson(const JsonNode & json, const std::string & identifier, size_t index) = 0;
-	virtual const std::string getTypeName() const = 0;
+	virtual const std::vector<std::string> & getTypeNames() const = 0;
 public: //todo: make private
 	std::vector<ConstTransitivePtr<_Object>> objects;
 };

--- a/lib/mapObjects/CGHeroInstance.cpp
+++ b/lib/mapObjects/CGHeroInstance.cpp
@@ -560,7 +560,7 @@ void CGHeroInstance::recreateSpecialtyBonuses(std::vector<HeroSpecial *> & speci
 void CGHeroInstance::updateSkillBonus(SecondarySkill which, int val)
 {
 	removeBonuses(Selector::source(Bonus::SECONDARY_SKILL, which));
-	auto skillBonus = (*VLC->skillh)[which]->getBonus(val);
+	auto skillBonus = (*VLC->skillh)[which]->at(val).effects;
 	for (auto b : skillBonus)
 		addNewBonus(std::make_shared<Bonus>(*b));
 }
@@ -1107,7 +1107,7 @@ std::vector<SecondarySkill> CGHeroInstance::getLevelUpProposedSecondarySkills() 
 	std::vector<SecondarySkill> skills;
 	//picking sec. skills for choice
 	std::set<SecondarySkill> basicAndAdv, expert, none;
-	for(int i=0;i<GameConstants::SKILL_QUANTITY;i++)
+	for(int i = 0; i < VLC->skillh->size(); i++)
 		if (cb->isAllowed(2,i))
 			none.insert(SecondarySkill(i));
 
@@ -1450,10 +1450,10 @@ void CGHeroInstance::serializeCommonOptions(JsonSerializeFormat & handler)
 			{
 				const si32 rawId = p.first.num;
 
-				if(rawId < 0 || rawId >= GameConstants::SKILL_QUANTITY)
+				if(rawId < 0 || rawId >= VLC->skillh->size())
 					logGlobal->error("Invalid secondary skill %d", rawId);
 
-				handler.serializeEnum(NSecondarySkill::names[rawId], p.second, 0, NSecondarySkill::levels);
+				handler.serializeEnum((*VLC->skillh)[SecondarySkill(rawId)]->identifier, p.second, 0, NSecondarySkill::levels);
 			}
 		}
 	}
@@ -1474,7 +1474,7 @@ void CGHeroInstance::serializeCommonOptions(JsonSerializeFormat & handler)
 				const std::string skillId = p.first;
 				const std::string levelId =  p.second.String();
 
-				const int rawId = vstd::find_pos(NSecondarySkill::names, skillId);
+				const int rawId = CSkillHandler::decodeSkill(skillId);
 				if(rawId < 0)
 				{
 					logGlobal->error("Invalid secondary skill %s", skillId);

--- a/lib/mapObjects/CGMarket.cpp
+++ b/lib/mapObjects/CGMarket.cpp
@@ -18,6 +18,7 @@
 #include "../CGameState.h"
 #include "CGTownInstance.h"
 #include "../CModHandler.h"
+#include "../CSkillHandler.h"
 
 ///helpers
 static void openWindow(const OpenWindow::EWindow type, const int id1, const int id2 = -1)
@@ -299,7 +300,7 @@ void CGBlackMarket::newTurn(CRandomGenerator & rand) const
 void CGUniversity::initObj(CRandomGenerator & rand)
 {
 	std::vector<int> toChoose;
-	for(int i = 0; i < GameConstants::SKILL_QUANTITY; ++i)
+	for(int i = 0; i < VLC->skillh->size(); ++i)
 	{
 		if(cb->isAllowed(2, i))
 		{

--- a/lib/mapObjects/CGPandoraBox.cpp
+++ b/lib/mapObjects/CGPandoraBox.cpp
@@ -15,6 +15,7 @@
 #include "../CSoundBase.h"
 
 #include "../spells/CSpellHandler.h"
+#include "../CSkillHandler.h"
 #include "../StartInfo.h"
 #include "../IGameCallback.h"
 #include "../StringConstants.h"
@@ -419,7 +420,7 @@ void CGPandoraBox::serializeJsonOptions(JsonSerializeFormat & handler)
 
 			for(size_t idx = 0; idx < abilities.size(); idx++)
 			{
-				handler.serializeEnum(NSecondarySkill::names[abilities[idx]], abilityLevels[idx], NSecondarySkill::levels);
+				handler.serializeEnum(CSkillHandler::encodeSkill(abilities[idx]), abilityLevels[idx], NSecondarySkill::levels);
 			}
 		}
 	}
@@ -437,7 +438,7 @@ void CGPandoraBox::serializeJsonOptions(JsonSerializeFormat & handler)
 			const std::string skillName = p.first;
 			const std::string levelId = p.second.String();
 
-			const int rawId = vstd::find_pos(NSecondarySkill::names, skillName);
+			const int rawId = CSkillHandler::decodeSkill(skillName);
 			if(rawId < 0)
 			{
 				logGlobal->error("Invalid secondary skill %s", skillName);

--- a/lib/mapObjects/CQuest.cpp
+++ b/lib/mapObjects/CQuest.cpp
@@ -24,6 +24,7 @@
 #include "../GameConstants.h"
 #include "../StringConstants.h"
 #include "../spells/CSpellHandler.h"
+#include "../CSkillHandler.h"
 #include "../mapping/CMap.h"
 
 
@@ -920,7 +921,7 @@ void CGSeerHut::serializeJsonOptions(JsonSerializeFormat & handler)
 			identifier = PrimarySkill::names[rID];
 			break;
 		case SECONDARY_SKILL:
-			identifier = NSecondarySkill::names[rID];
+			identifier = CSkillHandler::encodeSkill(rID);
 			break;
 		case ARTIFACT:
 			identifier = ArtifactID(rID).toArtifact()->identifier;

--- a/lib/mapObjects/MiscObjects.cpp
+++ b/lib/mapObjects/MiscObjects.cpp
@@ -1439,7 +1439,7 @@ void CGWitchHut::initObj(CRandomGenerator & rand)
 {
 	if (allowedAbilities.empty()) //this can happen for RMG. regular maps load abilities from map file
 	{
-		for (int i = 0; i < GameConstants::SKILL_QUANTITY; i++)
+		for(int i = 0; i < VLC->skillh->size(); i++)
 			allowedAbilities.push_back(i);
 	}
 	ability = *RandomGeneratorUtil::nextItem(allowedAbilities, rand);
@@ -1496,23 +1496,24 @@ void CGWitchHut::serializeJsonOptions(JsonSerializeFormat & handler)
 	//TODO: unify allowed abilities with others - make them std::vector<bool>
 
 	std::vector<bool> temp;
-	temp.resize(GameConstants::SKILL_QUANTITY, false);
+	size_t skillCount = VLC->skillh->size();
+	temp.resize(skillCount, false);
 
-	auto standard = VLC->heroh->getDefaultAllowedAbilities(); //todo: for WitchHut default is all except Leadership and Necromancy
+	auto standard = VLC->skillh->getDefaultAllowed(); //todo: for WitchHut default is all except Leadership and Necromancy
 
 	if(handler.saving)
 	{
-		for(si32 i = 0; i < GameConstants::SKILL_QUANTITY; ++i)
+		for(si32 i = 0; i < skillCount; ++i)
 			if(vstd::contains(allowedAbilities, i))
 				temp[i] = true;
 	}
 
-	handler.serializeLIC("allowedSkills", &CHeroHandler::decodeSkill, &CHeroHandler::encodeSkill, standard, temp);
+	handler.serializeLIC("allowedSkills", &CSkillHandler::decodeSkill, &CSkillHandler::encodeSkill, standard, temp);
 
 	if(!handler.saving)
 	{
 		allowedAbilities.clear();
-		for (si32 i=0; i<temp.size(); i++)
+		for(si32 i = 0; i < skillCount; ++i)
 			if(temp[i])
 				allowedAbilities.push_back(i);
 	}
@@ -1746,7 +1747,7 @@ void CGScholar::initObj(CRandomGenerator & rand)
 			bonusID = rand.nextInt(GameConstants::PRIMARY_SKILLS -1);
 			break;
 		case SECONDARY_SKILL:
-			bonusID = rand.nextInt(GameConstants::SKILL_QUANTITY -1);
+			bonusID = rand.nextInt(VLC->skillh->size() - 1);
 			break;
 		case SPELL:
 			std::vector<SpellID> possibilities;
@@ -1770,7 +1771,7 @@ void CGScholar::serializeJsonOptions(JsonSerializeFormat & handler)
 			handler.serializeString("rewardPrimSkill", value);
 			break;
 		case SECONDARY_SKILL:
-			value = NSecondarySkill::names[bonusID];
+			value = CSkillHandler::encodeSkill(bonusID);
 			handler.serializeString("rewardSkill", value);
 			break;
 		case SPELL:

--- a/lib/mapping/CMap.cpp
+++ b/lib/mapping/CMap.cpp
@@ -19,6 +19,7 @@
 #include "../mapObjects/CGHeroInstance.h"
 #include "../CGeneralTextHandler.h"
 #include "../spells/CSpellHandler.h"
+#include "../CSkillHandler.h"
 #include "CMapEditManager.h"
 #include "../serializer/JsonSerializeFormat.h"
 
@@ -240,7 +241,7 @@ CMap::CMap()
 	guardingCreaturePositions(nullptr)
 {
 	allHeroes.resize(allowedHeroes.size());
-	allowedAbilities = VLC->heroh->getDefaultAllowedAbilities();
+	allowedAbilities = VLC->skillh->getDefaultAllowed();
 	allowedArtifact = VLC->arth->getDefaultAllowed();
 	allowedSpell = VLC->spellh->getDefaultAllowed();
 }

--- a/lib/mapping/MapFormatH3M.cpp
+++ b/lib/mapping/MapFormatH3M.cpp
@@ -17,6 +17,7 @@
 #include "../CStopWatch.h"
 #include "../filesystem/Filesystem.h"
 #include "../spells/CSpellHandler.h"
+#include "../CSkillHandler.h"
 #include "../CCreatureHandler.h"
 #include "../CGeneralTextHandler.h"
 #include "../CHeroHandler.h"
@@ -1144,14 +1145,18 @@ void CMapLoaderH3M::readObjects()
 							}
 						}
 					}
+					// enable new (modded) skills
+					if(wh->allowedAbilities.size() != 1)
+					{
+						for(int skillID = GameConstants::SKILL_QUANTITY; skillID < VLC->skillh->size(); ++skillID)
+							wh->allowedAbilities.push_back(skillID);
+					}
 				}
 				else
 				{
 					// RoE map
-					for(int gg = 0; gg < GameConstants::SKILL_QUANTITY; ++gg)
-					{
-						wh->allowedAbilities.push_back(gg);
-					}
+					for(int skillID = 0; skillID < VLC->skillh->size(); ++skillID)
+						wh->allowedAbilities.push_back(skillID);
 				}
 				break;
 			}

--- a/lib/mapping/MapFormatJson.cpp
+++ b/lib/mapping/MapFormatJson.cpp
@@ -25,6 +25,7 @@
 #include "../mapObjects/CGHeroInstance.h"
 #include "../mapObjects/CGTownInstance.h"
 #include "../spells/CSpellHandler.h"
+#include "../CSkillHandler.h"
 #include "../StringConstants.h"
 #include "../serializer/JsonDeserializer.h"
 #include "../serializer/JsonSerializer.h"
@@ -807,7 +808,7 @@ void CMapFormatJson::serializeOptions(JsonSerializeFormat & handler)
 
 	serializePredefinedHeroes(handler);
 
-	handler.serializeLIC("allowedAbilities", &CHeroHandler::decodeSkill, &CHeroHandler::encodeSkill, VLC->heroh->getDefaultAllowedAbilities(), map->allowedAbilities);
+	handler.serializeLIC("allowedAbilities", &CSkillHandler::decodeSkill, &CSkillHandler::encodeSkill, VLC->skillh->getDefaultAllowed(), map->allowedAbilities);
 
 	handler.serializeLIC("allowedArtifacts",  &ArtifactID::decode, &ArtifactID::encode, VLC->arth->getDefaultAllowed(), map->allowedArtifact);
 

--- a/lib/serializer/CSerializer.h
+++ b/lib/serializer/CSerializer.h
@@ -12,7 +12,7 @@
 #include "../ConstTransitivePtr.h"
 #include "../GameConstants.h"
 
-const ui32 SERIALIZATION_VERSION = 784;
+const ui32 SERIALIZATION_VERSION = 785;
 const ui32 MINIMAL_SERIALIZATION_VERSION = 753;
 const std::string SAVEGAME_MAGIC = "VCMISVG";
 

--- a/lib/spells/CSpellHandler.cpp
+++ b/lib/spells/CSpellHandler.cpp
@@ -707,9 +707,10 @@ std::vector<JsonNode> CSpellHandler::loadLegacyData(size_t dataSize)
 	return legacyData;
 }
 
-const std::string CSpellHandler::getTypeName() const
+const std::vector<std::string> & CSpellHandler::getTypeNames() const
 {
-	return "spell";
+	static const std::vector<std::string> typeNames = { "spell" };
+	return typeNames;
 }
 
 CSpell * CSpellHandler::loadFromJson(const JsonNode & json, const std::string & identifier, size_t index)

--- a/lib/spells/CSpellHandler.h
+++ b/lib/spells/CSpellHandler.h
@@ -441,7 +441,7 @@ public:
 	 */
 	std::vector<bool> getDefaultAllowed() const override;
 
-	const std::string getTypeName() const override;
+	const std::vector<std::string> & getTypeNames() const override;
 
 	template <typename Handler> void serialize(Handler & h, const int version)
 	{


### PR DESCRIPTION
Skills gain the following new attributes (required for new skills, auto-populated for existing):
* Images used for basic, advanced and expert level
* Default probabilities to gain them for might/magic heroes (heroClass can override)

Mod for testing is available at https://github.com/henningkoehlernz/vcmi-mods (new_skills)