### PR TITLE
Configure session parameters in settings.json

### DIFF
--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -165,6 +165,7 @@ void CPlayerInterface::yourTurn()
 		adventureInt->selection = nullptr;
 
 		std::string prefix = settings["session"]["saveprefix"].String();
+		int frequency = settings["general"]["saveFrequency"].Integer();
 		if (firstCall)
 		{
 			if(CSH->howManyPlayerInterfaces() == 1)
@@ -180,7 +181,7 @@ void CPlayerInterface::yourTurn()
 			}
 			firstCall = 0;
 		}
-		else if (cb->getDate() % static_cast<int>(settings["session"]["savefrequency"].Integer()) == 0)
+		else if(frequency > 0 && cb->getDate() % frequency == 0)
 		{
 			LOCPLINT->cb->save("Saves/" + prefix + "Autosave_" + boost::lexical_cast<std::string>(autosaveCount++ + 1));
 			autosaveCount %= 5;

--- a/config/schemas/settings.json
+++ b/config/schemas/settings.json
@@ -17,7 +17,7 @@
 			"type" : "object",
 			"default": {},
 			"additionalProperties" : false,
-			"required" : [ "playerName", "showfps", "music", "sound", "encoding", "swipe", "saveRandomMaps" ],
+			"required" : [ "playerName", "showfps", "music", "sound", "encoding", "swipe", "saveRandomMaps", "saveFrequency" ],
 			"properties" : {
 				"playerName" : {
 					"type":"string",
@@ -58,6 +58,10 @@
 				"lastCampaign" : {
 					"type":"string",
 					"default" : ""
+				},
+				"saveFrequency" : {
+					"type" : "number",
+					"default" : 1
 				}
 			}
 		},

--- a/include/vstd/StringUtils.h
+++ b/include/vstd/StringUtils.h
@@ -1,0 +1,6 @@
+namespace vstd
+{
+
+	DLL_LINKAGE std::vector<std::string> split(std::string s, std::string separators);
+
+}

--- a/launcher/mainwindow_moc.cpp
+++ b/launcher/mainwindow_moc.cpp
@@ -36,7 +36,7 @@ void MainWindow::load()
 		QDir::addSearchPath("icons", pathToQString(string / "launcher" / "icons"));
 	QDir::addSearchPath("icons", pathToQString(VCMIDirs::get().userDataPath() / "launcher" / "icons"));
 
-	settings.init();
+	settings.init(true);
 }
 
 MainWindow::MainWindow(QWidget * parent) :

--- a/launcher/settingsView/csettingsview_moc.cpp
+++ b/launcher/settingsView/csettingsview_moc.cpp
@@ -94,6 +94,7 @@ void CSettingsView::loadSettings()
 	size_t encodingIndex = boost::range::find(knownEncodingsList, encoding) - knownEncodingsList;
 	if (encodingIndex < ui->comboBoxEncoding->count())
 		ui->comboBoxEncoding->setCurrentIndex(encodingIndex);
+	ui->comboBoxAutoSave->setCurrentIndex(settings["general"]["saveFrequency"].Integer() > 0 ? 1 : 0);
 }
 
 CSettingsView::CSettingsView(QWidget *parent) :
@@ -222,4 +223,10 @@ void CSettingsView::on_comboBoxShowIntro_currentIndexChanged(int index)
 void CSettingsView::on_changeGameDataDir_clicked()
 {
 
+}
+
+void CSettingsView::on_comboBoxAutoSave_currentIndexChanged(int index)
+{
+	Settings node = settings.write["general"]["saveFrequency"];
+	node->Integer() = index;
 }

--- a/launcher/settingsView/csettingsview_moc.h
+++ b/launcher/settingsView/csettingsview_moc.h
@@ -59,6 +59,8 @@ private slots:
 
 	void on_comboBoxDisplayIndex_currentIndexChanged(int index);
 
+	void on_comboBoxAutoSave_currentIndexChanged(int index);
+
 private:
 	Ui::CSettingsView *ui;
 };

--- a/launcher/settingsView/csettingsview_moc.ui
+++ b/launcher/settingsView/csettingsview_moc.ui
@@ -603,6 +603,30 @@
      </property>
     </widget>
    </item>
+   <item row="11" column="6">
+    <widget class="QLabel" name="labelAutoSave">
+     <property name="text">
+      <string>Autosave</string>
+     </property>
+    </widget>
+   </item>
+   <item row="11" column="7">
+    <widget class="QComboBox" name="comboBoxAutoSave">
+     <property name="currentIndex">
+      <number>1</number>
+     </property>
+     <item>
+      <property name="text">
+       <string>Off</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>On</string>
+      </property>
+     </item>
+    </widget>
+   </item>
   </layout>
  </widget>
  <resources/>

--- a/lib/CConfigHandler.cpp
+++ b/lib/CConfigHandler.cpp
@@ -42,7 +42,7 @@ SettingsStorage::NodeAccessor<Accessor>::operator Accessor() const
 }
 
 template<typename Accessor>
-SettingsStorage::NodeAccessor<Accessor> SettingsStorage::NodeAccessor<Accessor>::operator () (std::vector<std::string> _path)
+SettingsStorage::NodeAccessor<Accessor> SettingsStorage::NodeAccessor<Accessor>::operator () (std::vector<std::string> _path) const
 {
 	std::vector<std::string> newPath = path;
 	newPath.insert( newPath.end(), _path.begin(), _path.end());
@@ -51,11 +51,12 @@ SettingsStorage::NodeAccessor<Accessor> SettingsStorage::NodeAccessor<Accessor>:
 
 SettingsStorage::SettingsStorage():
 	write(NodeAccessor<Settings>(*this, std::vector<std::string>() )),
-	listen(NodeAccessor<SettingsListener>(*this, std::vector<std::string>() ))
+	listen(NodeAccessor<SettingsListener>(*this, std::vector<std::string>() )),
+	autoSaveConfig(false)
 {
 }
 
-void SettingsStorage::init()
+void SettingsStorage::init(bool autoSave)
 {
 	std::string confName = "config/settings.json";
 
@@ -67,6 +68,7 @@ void SettingsStorage::init()
 
 	JsonUtils::maximize(config, "vcmi:settings");
 	JsonUtils::validate(config, "vcmi:settings", "settings");
+	autoSaveConfig = autoSave;
 }
 
 void SettingsStorage::invalidateNode(const std::vector<std::string> &changedPath)
@@ -74,14 +76,14 @@ void SettingsStorage::invalidateNode(const std::vector<std::string> &changedPath
 	for(SettingsListener * listener : listeners)
 		listener->nodeInvalidated(changedPath);
 
-	JsonNode savedConf = config;
-	JsonNode schema(ResourceID("config/schemas/settings.json"));
+	if(autoSaveConfig)
+	{
+		JsonNode savedConf = config;
+		JsonUtils::minimize(savedConf, "vcmi:settings");
 
-	savedConf.Struct().erase("session");
-	JsonUtils::minimize(savedConf, "vcmi:settings");
-
-	FileStream file(*CResourceHandler::get()->getResourceName(ResourceID("config/settings.json")), std::ofstream::out | std::ofstream::trunc);
-	file << savedConf.toJson();
+		FileStream file(*CResourceHandler::get()->getResourceName(ResourceID("config/settings.json")), std::ofstream::out | std::ofstream::trunc);
+		file << savedConf.toJson();
+	}
 }
 
 JsonNode & SettingsStorage::getNode(std::vector<std::string> path)
@@ -98,9 +100,14 @@ Settings SettingsStorage::get(std::vector<std::string> path)
 	return Settings(*this, path);
 }
 
-const JsonNode& SettingsStorage::operator [](std::string value)
+const JsonNode & SettingsStorage::operator [](std::string value) const
 {
 	return config[value];
+}
+
+const JsonNode & SettingsStorage::toJsonNode() const
+{
+	return config;
 }
 
 SettingsListener::SettingsListener(SettingsStorage &_parent, const std::vector<std::string> &_path):

--- a/lib/CConfigHandler.h
+++ b/lib/CConfigHandler.h
@@ -26,12 +26,14 @@ class DLL_LINKAGE SettingsStorage
 
 		NodeAccessor(SettingsStorage & _parent, std::vector<std::string> _path);
 		NodeAccessor<Accessor> operator [] (std::string nextNode) const;
-		NodeAccessor<Accessor> operator () (std::vector<std::string> _path);
+		NodeAccessor<Accessor> operator () (std::vector<std::string> _path) const;
 		operator Accessor() const;
 	};
 
 	std::set<SettingsListener*> listeners;
 	JsonNode config;
+	bool autoSaveConfig;
+
 	JsonNode & getNode(std::vector<std::string> path);
 
 	// Calls all required listeners
@@ -41,7 +43,7 @@ class DLL_LINKAGE SettingsStorage
 public:
 	// Initialize config structure
 	SettingsStorage();
-	void init();
+	void init(bool autoSave=false);
 	
 	// Get write access to config node at path
 	const NodeAccessor<Settings> write;
@@ -50,7 +52,8 @@ public:
 	const NodeAccessor<SettingsListener> listen;
 
 	//Read access, see JsonNode::operator[]
-	const JsonNode& operator [](std::string value);
+	const JsonNode & operator [](std::string value) const;
+	const JsonNode & toJsonNode() const;
 
 	friend class SettingsListener;
 	friend class Settings;

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -124,6 +124,8 @@ set(lib_SRCS
 		spells/effects/RemoveObstacle.cpp
 		spells/effects/Sacrifice.cpp
 
+		vstd/StringUtils.cpp
+
 		CAndroidVMHelper.cpp
 		CArtHandler.cpp
 		CBonusTypeHandler.cpp
@@ -169,6 +171,7 @@ set(lib_HEADERS
 		${CMAKE_HOME_DIRECTORY}/include/vstd/CLoggerBase.h
 		${CMAKE_HOME_DIRECTORY}/include/vstd/ContainerUtils.h
 		${CMAKE_HOME_DIRECTORY}/include/vstd/RNG.h
+		${CMAKE_HOME_DIRECTORY}/include/vstd/StringUtils.h
 		StdInc.h
 		../Global.h
 

--- a/lib/vstd/StringUtils.cpp
+++ b/lib/vstd/StringUtils.cpp
@@ -1,0 +1,14 @@
+#include "StdInc.h"
+#include <vstd/StringUtils.h>
+
+namespace vstd
+{
+
+	DLL_LINKAGE std::vector<std::string> split(std::string s, std::string separators)
+	{
+		std::vector<std::string> result;
+		boost::split(result, s, boost::is_any_of(separators));
+		return result;
+	}
+
+}


### PR DESCRIPTION
Allows specification of session parameters (in particular `savefrequency`) in settings.json.

- command-line arguments, if present, override settings in settings.json
- changes to session parameters via command-line arguments do not change settings.json
- setting savefrequence to a value <= 0 disables autosaves

Note: currently `savefrequency` is the only parameters to be configured in settings.json (can easily add more though by adding them to config/schema/settings.json)