### PR TITLE
Unittest improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -302,6 +302,7 @@ if(ENABLE_LAUNCHER)
 	add_subdirectory(launcher)
 endif()
 if(ENABLE_TEST)
+	enable_testing()
 	add_subdirectory(test)
 endif()
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,3 @@
-enable_testing()
-
 set(googleTest_Dir ${CMAKE_CURRENT_SOURCE_DIR}/googletest)
 if(EXISTS ${googleTest_Dir})
 	set(GTestSrc ${googleTest_Dir}/googletest)
@@ -98,7 +96,9 @@ add_subdirectory_with_folder("3rdparty" googletest EXCLUDE_FROM_ALL)
 
 add_executable(vcmitest ${test_SRCS} ${test_HEADERS} ${mock_HEADERS} ${GTestSrc}/src/gtest-all.cc ${GMockSrc}/src/gmock-all.cc)
 target_link_libraries(vcmitest vcmi ${RT_LIB} ${DL_LIB})
-add_test(vcmitest vcmitest)
+add_test(NAME tests
+	COMMAND vcmitest
+	WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/bin/")
 
 vcmi_set_output_dir(vcmitest "")
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -105,19 +105,18 @@ vcmi_set_output_dir(vcmitest "")
 set_target_properties(vcmitest PROPERTIES ${PCH_PROPERTIES})
 cotire(vcmitest)
 
-# Files to copy to the build directory
-set(vcmitest_FILES
-		testdata/TerrainViewTest.h3m
-		testdata/terrainViewMappings.json
-		testdata/ObjectPropertyTest/header.json
-		testdata/ObjectPropertyTest/objects.json
-		testdata/ObjectPropertyTest/surface_terrain.json
-		testdata/ObjectPropertyTest/underground_terrain.json
-)
-
-foreach(file ${vcmitest_FILES})
-	add_custom_command(TARGET vcmitest POST_BUILD
-		COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_SOURCE_DIR}/${file}" ${CMAKE_CURRENT_BINARY_DIR}
-	)
+file (GLOB_RECURSE testdata "testdata/*.*")
+foreach(resource ${testdata})
+	get_filename_component(filename ${resource} NAME)
+	get_filename_component(dir ${resource} DIRECTORY)
+	get_filename_component(dirname ${dir} NAME)
+	set (output "")
+	while(NOT ${dirname} STREQUAL testdata)
+		get_filename_component(path_component ${dir} NAME)
+		set (output "${path_component}/${output}")
+		get_filename_component(dir ${dir} DIRECTORY)
+		get_filename_component(dirname ${dir} NAME)
+	endwhile()
+	set(output "${CMAKE_BINARY_DIR}/bin/test/testdata/${output}/${filename}")
+	configure_file(${resource} ${output} COPYONLY)
 endforeach()
-

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -101,14 +101,17 @@ add_subdirectory_with_folder("3rdparty" googletest EXCLUDE_FROM_ALL)
 add_executable(vcmitest ${test_SRCS} ${test_HEADERS} ${mock_HEADERS} ${GTestSrc}/src/gtest-all.cc ${GMockSrc}/src/gmock-all.cc)
 target_link_libraries(vcmitest vcmi ${RT_LIB} ${DL_LIB})
 
-if(NOT ${CMAKE_VERSION} VERSION_LESS "3.10.0")
+if(FALSE AND NOT ${CMAKE_VERSION} VERSION_LESS "3.10.0")
+	# Running tests one by one using ctest not recommended due to vcmi having
+	# slow global initialization.
 	gtest_discover_tests(vcmitest
+		WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/bin/")
+else()
+	add_test(NAME tests
+		COMMAND vcmitest
 		WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/bin/")
 endif()
 
-add_test(NAME tests
-	COMMAND vcmitest
-	WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/bin/")
 
 vcmi_set_output_dir(vcmitest "")
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,3 +1,7 @@
+if(NOT ${CMAKE_VERSION} VERSION_LESS "3.10.0")
+	include(GoogleTest)
+endif()
+
 set(googleTest_Dir ${CMAKE_CURRENT_SOURCE_DIR}/googletest)
 if(EXISTS ${googleTest_Dir})
 	set(GTestSrc ${googleTest_Dir}/googletest)
@@ -96,6 +100,12 @@ add_subdirectory_with_folder("3rdparty" googletest EXCLUDE_FROM_ALL)
 
 add_executable(vcmitest ${test_SRCS} ${test_HEADERS} ${mock_HEADERS} ${GTestSrc}/src/gtest-all.cc ${GMockSrc}/src/gmock-all.cc)
 target_link_libraries(vcmitest vcmi ${RT_LIB} ${DL_LIB})
+
+if(NOT ${CMAKE_VERSION} VERSION_LESS "3.10.0")
+	gtest_discover_tests(vcmitest
+		WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/bin/")
+endif()
+
 add_test(NAME tests
 	COMMAND vcmitest
 	WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/bin/")

--- a/test/CVcmiTestConfig.cpp
+++ b/test/CVcmiTestConfig.cpp
@@ -21,7 +21,7 @@
 #include "../lib/filesystem/CFilesystemLoader.h"
 #include "../lib/filesystem/AdapterLoaders.h"
 
-CVcmiTestConfig::CVcmiTestConfig()
+void CVcmiTestConfig::SetUp()
 {
 	console = new CConsoleHandler();
 	preinitDLL(console, true);
@@ -39,7 +39,7 @@ CVcmiTestConfig::CVcmiTestConfig()
 	}
 }
 
-CVcmiTestConfig::~CVcmiTestConfig()
+void CVcmiTestConfig::TearDown()
 {
 	std::cout << "Ending global test tear-down." << std::endl;
 }

--- a/test/CVcmiTestConfig.h
+++ b/test/CVcmiTestConfig.h
@@ -9,10 +9,12 @@
  */
 #pragma once
 
+#include "StdInc.h"
+
 /// Global setup/tear down class for unit tests.
-class CVcmiTestConfig
+class CVcmiTestConfig : public ::testing::Environment
 {
 public:
-	CVcmiTestConfig();
-	~CVcmiTestConfig();
+	virtual void SetUp() override;
+	virtual void TearDown() override;
 };

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -15,6 +15,6 @@
 int main(int argc, char * argv[])
 {
 	::testing::InitGoogleTest(&argc, argv);
-	CVcmiTestConfig test;
+	::testing::AddGlobalTestEnvironment(new CVcmiTestConfig());
 	return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
Added the testdata copying as suggested by @FeniksFire  and made some changes for better ctest integration.
TODO:
- [x] investigate how QT Creator test discovery works
- [x] decide what to do with ctest running tests one by one (slow)

Cmake 3.10 added automatic google test discovery.  It is optional but results in nicer report and allows completing the testing even when some of the test cases crash . Downside is that it runs each test case in separate executable which is quite slow due to SetUp and TearDown taking most of the time.

 