### PR TITLE
Exposed existing limiters for modders

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -69,3 +69,6 @@ Piotr Wójcik aka Chocimier, <chocimier@tlen.pl>
 
 Henning Koehler, <henning.koehler.nz@gmail.com>
    * skill modding, bonus updaters
+
+Andrzej Żak aka godric3
+   * minor bug fixes and modding features

--- a/ChangeLog
+++ b/ChangeLog
@@ -34,6 +34,7 @@ MODS:
 * Map object sounds can now be configured via json
 * Added bonus updaters for hero specialties
 * Added allOf, anyOf and noneOf qualifiers for bonus limiters
+* Added bonus limiters: alignment, faction and terrain
 
 SOUND:
 * Fixed many mising or wrong pickup and visit sounds for map objects

--- a/lib/CStack.cpp
+++ b/lib/CStack.cpp
@@ -282,6 +282,13 @@ bool CStack::canBeHealed() const
 		   && !hasBonusOfType(Bonus::SIEGE_WEAPON);
 }
 
+bool CStack::isOnNativeTerrain() const
+{
+	if(base)
+		return type->isItNativeTerrain(base->armyObj->battle->terrainType);
+	return false;
+}
+
 const CCreature * CStack::unitType() const
 {
 	return type;

--- a/lib/CStack.cpp
+++ b/lib/CStack.cpp
@@ -284,9 +284,12 @@ bool CStack::canBeHealed() const
 
 bool CStack::isOnNativeTerrain() const
 {
-	if(base)
-		return type->isItNativeTerrain(base->armyObj->battle->terrainType);
-	return false;
+	return type->isItNativeTerrain(battle->getTerrainType());
+}
+
+bool CStack::isOnTerrain(int terrain) const
+{
+	return battle->getTerrainType() == terrain;
 }
 
 const CCreature * CStack::unitType() const

--- a/lib/CStack.h
+++ b/lib/CStack.h
@@ -47,6 +47,7 @@ public:
 	std::string getName() const; //plural or singular
 
 	bool canBeHealed() const; //for first aid tent - only harmed stacks that are not war machines
+	bool isOnNativeTerrain() const;
 
 	ui32 level() const;
 	si32 magicResistance() const override; //include aura of resistance

--- a/lib/CStack.h
+++ b/lib/CStack.h
@@ -48,6 +48,7 @@ public:
 
 	bool canBeHealed() const; //for first aid tent - only harmed stacks that are not war machines
 	bool isOnNativeTerrain() const;
+	bool isOnTerrain(int terrain) const;
 
 	ui32 level() const;
 	si32 magicResistance() const override; //include aura of resistance

--- a/lib/HeroBonus.cpp
+++ b/lib/HeroBonus.cpp
@@ -1626,11 +1626,9 @@ void CCreatureTypeLimiter::setCreature (CreatureID id)
 
 std::string CCreatureTypeLimiter::toString() const
 {
-	char buf[100];
-	sprintf(buf, "CCreatureTypeLimiter(creature=%s, includeUpgrades=%s)",
-		creature->identifier.c_str(),
-		(includeUpgrades ? "true" : "false"));
-	return std::string(buf);
+	boost::format fmt("CCreatureTypeLimiter(creature=%s, includeUpgrades=%s)");
+	fmt % creature->identifier % (includeUpgrades ? "true" : "false");
+	return fmt.str();
 }
 
 JsonNode CCreatureTypeLimiter::toJsonNode() const
@@ -1674,15 +1672,19 @@ int HasAnotherBonusLimiter::limit(const BonusLimitationContext &context) const
 
 std::string HasAnotherBonusLimiter::toString() const
 {
-	char buf[100];
-
 	std::string typeName = vstd::findKey(bonusNameMap, type);
 	if(isSubtypeRelevant)
-		sprintf(buf, "HasAnotherBonusLimiter(type=%s, subtype=%d)",	typeName.c_str(), subtype);
+	{
+		boost::format fmt("HasAnotherBonusLimiter(type=%s, subtype=%d)");
+		fmt % typeName % subtype;
+		return fmt.str();
+	}
 	else
-		sprintf(buf, "HasAnotherBonusLimiter(type=%s)",	typeName.c_str());
-
-	return std::string(buf);
+	{
+		boost::format fmt("HasAnotherBonusLimiter(type=%s)");
+		fmt % typeName;
+		return fmt.str();
+	}
 }
 
 JsonNode HasAnotherBonusLimiter::toJsonNode() const
@@ -1750,10 +1752,9 @@ int CreatureTerrainLimiter::limit(const BonusLimitationContext &context) const
 
 std::string CreatureTerrainLimiter::toString() const
 {
-	char buf[100];
-	sprintf(buf, "CreatureTerrainLimiter(terrainType=%s)",
-		terrainType >= 0 ? GameConstants::TERRAIN_NAMES[terrainType].c_str() : "native");
-	return std::string(buf);
+	boost::format fmt("CreatureTerrainLimiter(terrainType=%s)");
+	fmt % (terrainType >= 0 ? GameConstants::TERRAIN_NAMES[terrainType] : "native");
+	return fmt.str();
 }
 
 JsonNode CreatureTerrainLimiter::toJsonNode() const
@@ -1785,9 +1786,9 @@ int CreatureFactionLimiter::limit(const BonusLimitationContext &context) const
 
 std::string CreatureFactionLimiter::toString() const
 {
-	char buf[100];
-	sprintf(buf, "CreatureFactionLimiter(faction=%s)", VLC->townh->factions[faction]->identifier.c_str());
-	return std::string(buf);
+	boost::format fmt("CreatureFactionLimiter(faction=%s)");
+	fmt %  VLC->townh->factions[faction]->identifier;
+	return fmt.str();
 }
 
 JsonNode CreatureFactionLimiter::toJsonNode() const
@@ -1831,9 +1832,9 @@ int CreatureAlignmentLimiter::limit(const BonusLimitationContext &context) const
 
 std::string CreatureAlignmentLimiter::toString() const
 {
-	char buf[100];
-	sprintf(buf, "CreatureAlignmentLimiter(alignment=%s)", EAlignment::names[alignment].c_str());
-	return std::string(buf);
+	boost::format fmt("CreatureAlignmentLimiter(alignment=%s)");
+	fmt % EAlignment::names[alignment];
+	return fmt.str();
 }
 
 JsonNode CreatureAlignmentLimiter::toJsonNode() const

--- a/lib/HeroBonus.cpp
+++ b/lib/HeroBonus.cpp
@@ -16,6 +16,7 @@
 #include "CCreatureHandler.h"
 #include "CCreatureSet.h"
 #include "CHeroHandler.h"
+#include "CTownHandler.h"
 #include "CGeneralTextHandler.h"
 #include "CSkillHandler.h"
 #include "CStack.h"
@@ -1755,6 +1756,23 @@ int CreatureFactionLimiter::limit(const BonusLimitationContext &context) const
 	return !c || c->faction != faction; //drop bonus for non-creatures or non-native residents
 }
 
+std::string CreatureFactionLimiter::toString() const
+{
+	char buf[100];
+	sprintf(buf, "CreatureFactionLimiter(faction=%s)", VLC->townh->factions[faction]->identifier.c_str());
+	return std::string(buf);
+}
+
+JsonNode CreatureFactionLimiter::toJsonNode() const
+{
+	JsonNode root(JsonNode::JsonType::DATA_STRUCT);
+
+	root["type"].String() = "CREATURE_FACTION_LIMITER";
+	root["parameters"].Vector().push_back(JsonUtils::stringNode(VLC->townh->factions[faction]->identifier));
+
+	return root;
+}
+
 CreatureAlignmentLimiter::CreatureAlignmentLimiter()
 	: alignment(-1)
 {
@@ -1782,6 +1800,23 @@ int CreatureAlignmentLimiter::limit(const BonusLimitationContext &context) const
 		logBonus->warn("Warning: illegal alignment in limiter!");
 		return true;
 	}
+}
+
+std::string CreatureAlignmentLimiter::toString() const
+{
+	char buf[100];
+	sprintf(buf, "CreatureAlignmentLimiter(alignment=%s)", EAlignment::names[alignment].c_str());
+	return std::string(buf);
+}
+
+JsonNode CreatureAlignmentLimiter::toJsonNode() const
+{
+	JsonNode root(JsonNode::JsonType::DATA_STRUCT);
+
+	root["type"].String() = "CREATURE_ALIGNMENT_LIMITER";
+	root["parameters"].Vector().push_back(JsonUtils::stringNode(EAlignment::names[alignment]));
+
+	return root;
 }
 
 RankRangeLimiter::RankRangeLimiter(ui8 Min, ui8 Max)

--- a/lib/HeroBonus.cpp
+++ b/lib/HeroBonus.cpp
@@ -1738,11 +1738,11 @@ CreatureTerrainLimiter::CreatureTerrainLimiter()
 int CreatureTerrainLimiter::limit(const BonusLimitationContext &context) const
 {
 	const CStack *stack = retrieveStackBattle(&context.node);
-	if(stack && stack->base)
+	if(stack)
 	{
 		if(terrainType == -1)//terrainType not specified = native
 			return !stack->isOnNativeTerrain();
-		return stack->base->armyObj->battle->terrainType != terrainType;
+		return !stack->isOnTerrain(terrainType);
 	}
 	return true;
 	//TODO neutral creatues

--- a/lib/HeroBonus.h
+++ b/lib/HeroBonus.h
@@ -965,14 +965,16 @@ public:
 	}
 };
 
-class DLL_LINKAGE CreatureNativeTerrainLimiter : public ILimiter //applies only to creatures that are on their native terrain
+class DLL_LINKAGE CreatureTerrainLimiter : public ILimiter //applies only to creatures that are on specified terrain, default native terrain
 {
 public:
 	int terrainType;
-	CreatureNativeTerrainLimiter();
-	CreatureNativeTerrainLimiter(int TerrainType);
+	CreatureTerrainLimiter();
+	CreatureTerrainLimiter(int TerrainType);
 
 	int limit(const BonusLimitationContext &context) const override;
+	virtual std::string toString() const override;
+	virtual JsonNode toJsonNode() const override;
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{

--- a/lib/HeroBonus.h
+++ b/lib/HeroBonus.h
@@ -989,6 +989,8 @@ public:
 	CreatureFactionLimiter(int TerrainType);
 
 	int limit(const BonusLimitationContext &context) const override;
+	virtual std::string toString() const override;
+	virtual JsonNode toJsonNode() const override;
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
@@ -1005,6 +1007,8 @@ public:
 	CreatureAlignmentLimiter(si8 Alignment);
 
 	int limit(const BonusLimitationContext &context) const override;
+	virtual std::string toString() const override;
+	virtual JsonNode toJsonNode() const override;
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{

--- a/lib/JsonNode.cpp
+++ b/lib/JsonNode.cpp
@@ -19,6 +19,7 @@
 #include "CModHandler.h"
 #include "CGeneralTextHandler.h"
 #include "JsonDetail.h"
+#include "StringConstants.h"
 
 using namespace JsonDetail;
 
@@ -644,6 +645,23 @@ std::shared_ptr<ILimiter> JsonUtils::parseLimiter(const JsonNode & limiter)
 					}
 					return bonusLimiter;
 				}
+			}
+			else if(limiterType == "CREATURE_ALIGNMENT_LIMITER")
+			{
+				int alignment = vstd::find_pos(EAlignment::names, parameters[0].String());
+				if(alignment == -1)
+					logMod->error("Error: invalid alignment %s.", parameters[0].String());
+				else
+					return std::make_shared<CreatureAlignmentLimiter>(alignment);
+			}
+			else if(limiterType == "CREATURE_FACTION_LIMITER")
+			{
+				std::shared_ptr<CreatureFactionLimiter> factionLimiter = std::make_shared<CreatureFactionLimiter>();
+				VLC->modh->identifiers.requestIdentifier("faction", parameters[0], [=](si32 faction)
+				{
+					factionLimiter->faction = faction;
+				});
+				return factionLimiter;
 			}
 			else
 			{

--- a/lib/JsonNode.cpp
+++ b/lib/JsonNode.cpp
@@ -663,6 +663,18 @@ std::shared_ptr<ILimiter> JsonUtils::parseLimiter(const JsonNode & limiter)
 				});
 				return factionLimiter;
 			}
+			else if(limiterType == "CREATURE_TERRAIN_LIMITER")
+			{
+				std::shared_ptr<CreatureTerrainLimiter> terrainLimiter = std::make_shared<CreatureTerrainLimiter>();
+				if(parameters.size())
+				{
+					int terrain = vstd::find_pos(GameConstants::TERRAIN_NAMES, parameters[0].String());
+					if(terrain == -1)
+						logMod->error("Error: invalid terrain %s. Fallback to native terrain", parameters[0].String());
+					terrainLimiter->terrainType = terrain;
+				}
+				return terrainLimiter;
+			}
 			else
 			{
 				logMod->error("Error: invalid customizable limiter type %s.", limiterType);

--- a/lib/JsonNode.cpp
+++ b/lib/JsonNode.cpp
@@ -668,10 +668,10 @@ std::shared_ptr<ILimiter> JsonUtils::parseLimiter(const JsonNode & limiter)
 				std::shared_ptr<CreatureTerrainLimiter> terrainLimiter = std::make_shared<CreatureTerrainLimiter>();
 				if(parameters.size())
 				{
-					int terrain = vstd::find_pos(GameConstants::TERRAIN_NAMES, parameters[0].String());
-					if(terrain == -1)
-						logMod->error("Error: invalid terrain %s. Fallback to native terrain", parameters[0].String());
-					terrainLimiter->terrainType = terrain;
+					VLC->modh->identifiers.requestIdentifier("terrain", parameters[0], [=](si32 terrain)
+					{
+						terrainLimiter->terrainType = terrain;
+					});
 				}
 				return terrainLimiter;
 			}

--- a/lib/battle/BattleInfo.cpp
+++ b/lib/battle/BattleInfo.cpp
@@ -525,7 +525,7 @@ BattleInfo * BattleInfo::setupBattle(int3 tile, ETerrainType terrain, BFieldType
 	//overlay premies given
 
 	//native terrain bonuses
-	auto nativeTerrain = std::make_shared<CreatureNativeTerrainLimiter>(curB->terrainType);
+	auto nativeTerrain = std::make_shared<CreatureTerrainLimiter>();
 
 	curB->addNewBonus(std::make_shared<Bonus>(Bonus::ONE_BATTLE, Bonus::STACKS_SPEED, Bonus::TERRAIN_NATIVE, 1, 0, 0)->addLimiter(nativeTerrain));
 	curB->addNewBonus(std::make_shared<Bonus>(Bonus::ONE_BATTLE, Bonus::PRIMARY_SKILL, Bonus::TERRAIN_NATIVE, 1, 0, PrimarySkill::ATTACK)->addLimiter(nativeTerrain));

--- a/lib/registerTypes/RegisterTypes.h
+++ b/lib/registerTypes/RegisterTypes.h
@@ -185,7 +185,7 @@ void registerTypesMapObjects2(Serializer &s)
 	s.template registerType<ILimiter, AllOfLimiter>();
 	s.template registerType<ILimiter, CCreatureTypeLimiter>();
 	s.template registerType<ILimiter, HasAnotherBonusLimiter>();
-	s.template registerType<ILimiter, CreatureNativeTerrainLimiter>();
+	s.template registerType<ILimiter, CreatureTerrainLimiter>();
 	s.template registerType<ILimiter, CreatureFactionLimiter>();
 	s.template registerType<ILimiter, CreatureAlignmentLimiter>();
 	s.template registerType<ILimiter, RankRangeLimiter>();


### PR DESCRIPTION
Exposed limiters:
-  `CREATURE_NATIVE_TERRAIN` - predefined, works if creature is on its native terrain
- `CREATURE_FACTION_LIMITER` - customizable, creature is from specified faction
- `CREATURE_ALIGNMENT_LIMITER` - customizable, creature is from specified alignment
- `CREATURE_TERRAIN_LIMITER`  - customizable, creature is on specified terrain, if not specified then works like `CREATURE_NATIVE_TERRAIN` 