### PR TITLE
Restore VCMI client saving settings.json

### DIFF
--- a/launcher/mainwindow_moc.cpp
+++ b/launcher/mainwindow_moc.cpp
@@ -36,7 +36,7 @@ void MainWindow::load()
 		QDir::addSearchPath("icons", pathToQString(string / "launcher" / "icons"));
 	QDir::addSearchPath("icons", pathToQString(VCMIDirs::get().userDataPath() / "launcher" / "icons"));
 
-	settings.init(true);
+	settings.init();
 }
 
 MainWindow::MainWindow(QWidget * parent)

--- a/lib/CConfigHandler.cpp
+++ b/lib/CConfigHandler.cpp
@@ -51,12 +51,11 @@ SettingsStorage::NodeAccessor<Accessor> SettingsStorage::NodeAccessor<Accessor>:
 
 SettingsStorage::SettingsStorage():
 	write(NodeAccessor<Settings>(*this, std::vector<std::string>() )),
-	listen(NodeAccessor<SettingsListener>(*this, std::vector<std::string>() )),
-	autoSaveConfig(false)
+	listen(NodeAccessor<SettingsListener>(*this, std::vector<std::string>() ))
 {
 }
 
-void SettingsStorage::init(bool autoSave)
+void SettingsStorage::init()
 {
 	std::string confName = "config/settings.json";
 
@@ -68,7 +67,6 @@ void SettingsStorage::init(bool autoSave)
 
 	JsonUtils::maximize(config, "vcmi:settings");
 	JsonUtils::validate(config, "vcmi:settings", "settings");
-	autoSaveConfig = autoSave;
 }
 
 void SettingsStorage::invalidateNode(const std::vector<std::string> &changedPath)
@@ -76,14 +74,12 @@ void SettingsStorage::invalidateNode(const std::vector<std::string> &changedPath
 	for(SettingsListener * listener : listeners)
 		listener->nodeInvalidated(changedPath);
 
-	if(autoSaveConfig)
-	{
-		JsonNode savedConf = config;
-		JsonUtils::minimize(savedConf, "vcmi:settings");
+	JsonNode savedConf = config;
+	savedConf.Struct().erase("session");
+	JsonUtils::minimize(savedConf, "vcmi:settings");
 
-		FileStream file(*CResourceHandler::get()->getResourceName(ResourceID("config/settings.json")), std::ofstream::out | std::ofstream::trunc);
-		file << savedConf.toJson();
-	}
+	FileStream file(*CResourceHandler::get()->getResourceName(ResourceID("config/settings.json")), std::ofstream::out | std::ofstream::trunc);
+	file << savedConf.toJson();
 }
 
 JsonNode & SettingsStorage::getNode(std::vector<std::string> path)

--- a/lib/CConfigHandler.h
+++ b/lib/CConfigHandler.h
@@ -32,7 +32,6 @@ class DLL_LINKAGE SettingsStorage
 
 	std::set<SettingsListener*> listeners;
 	JsonNode config;
-	bool autoSaveConfig;
 
 	JsonNode & getNode(std::vector<std::string> path);
 
@@ -43,7 +42,7 @@ class DLL_LINKAGE SettingsStorage
 public:
 	// Initialize config structure
 	SettingsStorage();
-	void init(bool autoSave=false);
+	void init();
 	
 	// Get write access to config node at path
 	const NodeAccessor<Settings> write;


### PR DESCRIPTION
It turned out leaving settings.json saving to be launcher-exclusive is undesired and it collides with current client code when ingame non-launcher settings are attempted to be saved. This PR reverts these changes, while leaving rest of PR #441 "as is".