### PR TITLE
attribute for battle image added on hero class, allowing on hero sche…

### DIFF
--- a/client/Graphics.cpp
+++ b/client/Graphics.cpp
@@ -449,7 +449,6 @@ void Graphics::initializeImageLists()
 		addImageListEntry(hero->imageIndex, "UN44", hero->iconSpecLarge);
 		addImageListEntry(hero->imageIndex, "PORTRAITSLARGE", hero->portraitLarge);
 		addImageListEntry(hero->imageIndex, "PORTRAITSSMALL", hero->portraitSmall);
-		addImageListEntry(hero->imageIndex, "BATTLEIMAGE", hero->battleImage);
 	}
 
 	for(const CArtifact * art : CGI->arth->artifacts)

--- a/client/Graphics.cpp
+++ b/client/Graphics.cpp
@@ -449,6 +449,7 @@ void Graphics::initializeImageLists()
 		addImageListEntry(hero->imageIndex, "UN44", hero->iconSpecLarge);
 		addImageListEntry(hero->imageIndex, "PORTRAITSLARGE", hero->portraitLarge);
 		addImageListEntry(hero->imageIndex, "PORTRAITSSMALL", hero->portraitSmall);
+		addImageListEntry(hero->imageIndex, "BATTLEIMAGE", hero->battleImage);
 	}
 
 	for(const CArtifact * art : CGI->arth->artifacts)

--- a/client/battle/CBattleInterface.cpp
+++ b/client/battle/CBattleInterface.cpp
@@ -256,10 +256,17 @@ CBattleInterface::CBattleInterface(const CCreatureSet *army1, const CCreatureSet
 	if(hero1) // attacking hero
 	{
 		std::string battleImage;
-		if(hero1->sex)
-			battleImage = hero1->type->heroClass->imageBattleFemale;
+		if(!hero1->type->battleImage.empty())
+		{
+			battleImage = hero1->type->battleImage;
+		}
 		else
-			battleImage = hero1->type->heroClass->imageBattleMale;
+		{
+			if(hero1->sex)
+				battleImage = hero1->type->heroClass->imageBattleFemale;
+			else
+				battleImage = hero1->type->heroClass->imageBattleMale;
+		}
 
 		attackingHero = std::make_shared<CBattleHero>(battleImage, false, hero1->tempOwner, hero1->tempOwner == curInt->playerID ? hero1 : nullptr, this);
 
@@ -272,10 +279,18 @@ CBattleInterface::CBattleInterface(const CCreatureSet *army1, const CCreatureSet
 	if(hero2) // defending hero
 	{
 		std::string battleImage;
-		if(hero2->sex)
-			battleImage = hero2->type->heroClass->imageBattleFemale;
+
+		if(!hero2->type->battleImage.empty())
+		{
+			battleImage = hero2->type->battleImage;
+		}
 		else
-			battleImage = hero2->type->heroClass->imageBattleMale;
+		{
+			if(hero2->sex)
+				battleImage = hero2->type->heroClass->imageBattleFemale;
+			else
+				battleImage = hero2->type->heroClass->imageBattleMale;
+		}
 
 		defendingHero = std::make_shared<CBattleHero>(battleImage, true, hero2->tempOwner, hero2->tempOwner == curInt->playerID ? hero2 : nullptr, this);
 

--- a/config/schemas/hero.json
+++ b/config/schemas/hero.json
@@ -84,6 +84,11 @@
 					"type":"string",
 					"description": "Small image of hero specialty for use in exchange screen",
 					"format" : "imageFile"
+				},
+				"battleImage": {
+					"type":"string",
+					"description": "Custom def used on battle",
+					"format" : "defFile"
 				}
 			}
 		},

--- a/lib/CHeroHandler.cpp
+++ b/lib/CHeroHandler.cpp
@@ -322,6 +322,7 @@ CHero * CHeroHandler::loadFromJson(const JsonNode & node, const std::string & id
 	hero->iconSpecLarge = node["images"]["specialtyLarge"].String();
 	hero->portraitSmall = node["images"]["small"].String();
 	hero->portraitLarge = node["images"]["large"].String();
+	hero->battleImage = node["images"]["battleImage"].String();
 
 	loadHeroArmy(hero, node);
 	loadHeroSkills(hero, node);

--- a/lib/CHeroHandler.h
+++ b/lib/CHeroHandler.h
@@ -124,8 +124,11 @@ public:
 		h & portraitLarge;
 		if(version >= 759)
 		{
-			h & battleImage;
 			h & identifier;
+		}
+		if(version >= 790)
+		{
+			h & battleImage;
 		}
 	}
 };

--- a/lib/CHeroHandler.h
+++ b/lib/CHeroHandler.h
@@ -91,6 +91,7 @@ public:
 	std::string iconSpecLarge;
 	std::string portraitSmall;
 	std::string portraitLarge;
+	std::string battleImage;
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
@@ -121,6 +122,7 @@ public:
 		h & iconSpecLarge;
 		h & portraitSmall;
 		h & portraitLarge;
+		h & battleImage;
 		if(version >= 759)
 		{
 			h & identifier;

--- a/lib/CHeroHandler.h
+++ b/lib/CHeroHandler.h
@@ -122,9 +122,9 @@ public:
 		h & iconSpecLarge;
 		h & portraitSmall;
 		h & portraitLarge;
-		h & battleImage;
 		if(version >= 759)
 		{
+			h & battleImage;
 			h & identifier;
 		}
 	}

--- a/lib/serializer/CSerializer.h
+++ b/lib/serializer/CSerializer.h
@@ -12,7 +12,7 @@
 #include "../ConstTransitivePtr.h"
 #include "../GameConstants.h"
 
-const ui32 SERIALIZATION_VERSION = 789;
+const ui32 SERIALIZATION_VERSION = 790;
 const ui32 MINIMAL_SERIALIZATION_VERSION = 753;
 const std::string SAVEGAME_MAGIC = "VCMISVG";
 


### PR DESCRIPTION
Added support for unique battle defs for heroes configurable via .json with format:

"images" : {"large" : "portrait.bmp", "small" : "portrait.bmp","specialtyLarge" : "specialty.bmp","specialtySmall" : "specialty.bmp","battleImage" : "custom.def"}

That feature allow create semi-neutral heroes in pre-existante classes with different graphicals.

The map adventure object is avaiable with filters om 'map object' attribute via json