### PR TITLE
Fixed schemas for battle animation on preexistant heroes

### DIFF
--- a/config/schemas/hero.json
+++ b/config/schemas/hero.json
@@ -59,6 +59,11 @@
 			"type":"boolean",
 			"description": "This hero is female (changeable via editor)"
 		},
+		"battleImage": {
+			"type":"string",
+			"description": "Custom def used on battle",
+			"format" : "defFile"
+		},
 		"images": {
 			"type":"object",
 			"additionalProperties" : false,
@@ -84,11 +89,6 @@
 					"type":"string",
 					"description": "Small image of hero specialty for use in exchange screen",
 					"format" : "imageFile"
-				},
-				"battleImage": {
-					"type":"string",
-					"description": "Custom def used on battle",
-					"format" : "defFile"
 				}
 			}
 		},

--- a/lib/CHeroHandler.cpp
+++ b/lib/CHeroHandler.cpp
@@ -322,7 +322,7 @@ CHero * CHeroHandler::loadFromJson(const JsonNode & node, const std::string & id
 	hero->iconSpecLarge = node["images"]["specialtyLarge"].String();
 	hero->portraitSmall = node["images"]["small"].String();
 	hero->portraitLarge = node["images"]["large"].String();
-	hero->battleImage = node["images"]["battleImage"].String();
+	hero->battleImage = node["battleImage"].String();
 
 	loadHeroArmy(hero, node);
 	loadHeroSkills(hero, node);


### PR DESCRIPTION
Changed hero schema to using a lonely tag instead images attribute dependant. Now working for replacing battle sprites on pre-existant heroes too without replacing any other attribute