### PR TITLE
Fix crash when generating random map with random number of players

### DIFF
--- a/client/Client.cpp
+++ b/client/Client.cpp
@@ -321,7 +321,7 @@ void CClient::initMapHandler()
 
 void CClient::initPlayerInterfaces()
 {
-	for(auto & elem : CSH->si->playerInfos)
+	for(auto & elem : gs->scenarioOps->playerInfos)
 	{
 		PlayerColor color = elem.first;
 		if(!vstd::contains(CSH->getAllClientPlayers(CSH->c->connectionID), color))

--- a/lib/rmg/CMapGenOptions.cpp
+++ b/lib/rmg/CMapGenOptions.cpp
@@ -71,8 +71,13 @@ void CMapGenOptions::setPlayerCount(si8 value)
 	if (compOnlyPlayerCount > possibleCompPlayersCount)
 		setCompOnlyPlayerCount(possibleCompPlayersCount);
 
-	if (getPlayerCount() != RANDOM_SIZE && getCompOnlyPlayerCount() != RANDOM_SIZE)
-		humanPlayersCount = getPlayerCount() - getCompOnlyPlayerCount();
+	if (getPlayerCount() != RANDOM_SIZE)
+	{
+		if (getCompOnlyPlayerCount() != RANDOM_SIZE)
+			humanPlayersCount = getPlayerCount() - getCompOnlyPlayerCount();
+		else
+			humanPlayersCount = getPlayerCount();
+	}
 
 	resetPlayersMap();
 }
@@ -167,7 +172,10 @@ void CMapGenOptions::resetPlayersMap()
 		auto pc = PlayerColor(color);
 		player.setColor(pc);
 		auto playerType = EPlayerType::AI;
-		if ((getPlayerCount() != RANDOM_SIZE && color >= realPlayersCnt)
+		if (getPlayerCount() != RANDOM_SIZE && color < realPlayersCnt)
+		{
+			playerType = EPlayerType::HUMAN;
+		}else if ((getPlayerCount() != RANDOM_SIZE && color >= realPlayersCnt)
 		   || (compOnlyPlayerCount != RANDOM_SIZE && color >= (PlayerColor::PLAYER_LIMIT_I-compOnlyPlayerCount)))
 		{
 			playerType = EPlayerType::COMP_ONLY;

--- a/lib/rmg/CMapGenOptions.cpp
+++ b/lib/rmg/CMapGenOptions.cpp
@@ -175,7 +175,8 @@ void CMapGenOptions::resetPlayersMap()
 		if (getPlayerCount() != RANDOM_SIZE && color < realPlayersCnt)
 		{
 			playerType = EPlayerType::HUMAN;
-		}else if ((getPlayerCount() != RANDOM_SIZE && color >= realPlayersCnt)
+		}
+		else if((getPlayerCount() != RANDOM_SIZE && color >= realPlayersCnt)
 		   || (compOnlyPlayerCount != RANDOM_SIZE && color >= (PlayerColor::PLAYER_LIMIT_I-compOnlyPlayerCount)))
 		{
 			playerType = EPlayerType::COMP_ONLY;


### PR DESCRIPTION
Changes  in CMapGenOptions are required, because without them generated map have only AI players(it will start, but after saving you couldn't load it)