### PR TITLE
AI pathfinding: fix getPathsToTile for water tiles

### DIFF
--- a/AI/VCAI/Pathfinding/AINodeStorage.cpp
+++ b/AI/VCAI/Pathfinding/AINodeStorage.cpp
@@ -181,10 +181,10 @@ bool AINodeStorage::hasBetterChain(const PathNodeInfo & source, CDestinationNode
 	return false;
 }
 
-std::vector<AIPath> AINodeStorage::getChainInfo(int3 pos) const
+std::vector<AIPath> AINodeStorage::getChainInfo(int3 pos, bool isOnLand) const
 {
 	std::vector<AIPath> paths;
-	auto chains = nodes[pos.x][pos.y][pos.z][EPathfindingLayer::LAND];
+	auto chains = nodes[pos.x][pos.y][pos.z][isOnLand ? EPathfindingLayer::LAND : EPathfindingLayer::SAIL];
 
 	for(const AIPathNode & node : chains)
 	{

--- a/AI/VCAI/Pathfinding/AINodeStorage.h
+++ b/AI/VCAI/Pathfinding/AINodeStorage.h
@@ -98,7 +98,7 @@ public:
 	bool isBattleNode(const CGPathNode * node) const;
 	bool hasBetterChain(const PathNodeInfo & source, CDestinationNodeInfo & destination) const;
 	boost::optional<AIPathNode *> getOrCreateNode(const int3 & coord, const EPathfindingLayer layer, int chainNumber);
-	std::vector<AIPath> getChainInfo(int3 pos) const;
+	std::vector<AIPath> getChainInfo(int3 pos, bool isOnLand) const;
 
 	void setHero(HeroPtr heroPtr)
 	{

--- a/AI/VCAI/Pathfinding/AIPathfinder.cpp
+++ b/AI/VCAI/Pathfinding/AIPathfinder.cpp
@@ -11,6 +11,7 @@
 #include "AIPathfinder.h"
 #include "AIPathfinderConfig.h"
 #include "../../../CCallback.h"
+#include "../../../lib/mapping/CMap.h"
 
 std::vector<std::shared_ptr<AINodeStorage>> AIPathfinder::storagePool;
 std::map<HeroPtr, std::shared_ptr<AINodeStorage>> AIPathfinder::storageMap;
@@ -58,5 +59,12 @@ std::vector<AIPath> AIPathfinder::getPathInfo(HeroPtr hero, int3 tile)
 		nodeStorage = storageMap.at(hero);
 	}
 
-	return nodeStorage->getChainInfo(tile);
+	const TerrainTile * tileInfo = cb->getTile(tile, false);
+
+	if(!tileInfo)
+	{
+		return std::vector<AIPath>();
+	}
+
+	return nodeStorage->getChainInfo(tile, !tileInfo->isWater());
 }


### PR DESCRIPTION
AI was not able to attack water tiles because paths were always asked for land.