### PR TITLE
Remove empty branch from LobbyClientConnected::applyOnLobbyScreen

### DIFF
--- a/client/NetPacksLobbyClient.cpp
+++ b/client/NetPacksLobbyClient.cpp
@@ -44,9 +44,6 @@ bool LobbyClientConnected::applyOnLobbyHandler(CServerHandler * handler)
 
 void LobbyClientConnected::applyOnLobbyScreen(CLobbyScreen * lobby, CServerHandler * handler)
 {
-	if(uuid == handler->c->uuid)
-	{
-	}
 }
 
 bool LobbyClientDisconnected::applyOnLobbyHandler(CServerHandler * handler)


### PR DESCRIPTION
It was empty ever since introduction in ac66fc7f42f50ad961cf8a0656be0d9b5415180d

[ci skip]