### PR TITLE
Allow AI to be aware of invisible heroes deletion

### DIFF
--- a/AI/VCAI/VCAI.cpp
+++ b/AI/VCAI/VCAI.cpp
@@ -404,6 +404,8 @@ void VCAI::newObject(const CGObjectInstance * obj)
 	ah->resetPaths();
 }
 
+//to prevent AI from accessing objects that got deleted while they became invisible (Cover of Darkness, enemy hero moved etc.) below code allows AI to know deletion of objects out of sight
+//see: RemoveObject::applyFirstCl, to keep AI "not cheating" do not use advantage of this and use this function just to prevent crashes
 void VCAI::objectRemoved(const CGObjectInstance * obj)
 {
 	LOG_TRACE(logAi);

--- a/client/NetPacksClient.cpp
+++ b/client/NetPacksClient.cpp
@@ -368,7 +368,9 @@ void RemoveObject::applyFirstCl(CClient *cl)
 	//notify interfaces about removal
 	for(auto i=cl->playerint.begin(); i!=cl->playerint.end(); i++)
 	{
-		if(GS(cl)->isVisible(o, i->first))
+		//below line contains little cheat for AI so it will be aware of deletion of enemy heroes that moved or got re-covered by FoW
+		//TODO: loose requirements as next AI related crashes appear, for example another player collects object that got re-covered by FoW, unsure if AI code workarounds this
+		if(GS(cl)->isVisible(o, i->first) || (!cl->getPlayer(i->first)->human && o->ID == Obj::HERO && o->tempOwner != i->first))
 			i->second->objectRemoved(o);
 	}
 }


### PR DESCRIPTION
CHANGES GAMESTATE ACCESS PERMISSIONS!
Potential proper fix for bug #3021 without guessing things in AI code. Additional information for AI is as minimal as possible for now.

Needs to be re-tested a lot on bug #3021 map to make sure bug does not appear.