### PR TITLE
AI: fix freeze when AI has a win condition  to control own town

### DIFF
--- a/AI/VCAI/Goals.cpp
+++ b/AI/VCAI/Goals.cpp
@@ -422,7 +422,17 @@ TSubgoal Win::whatToDoToAchieve()
 		{
 			if(goal.object)
 			{
-				return sptr(Goals::VisitObj(goal.object->id.getNum()));
+				auto objRelations = cb->getPlayerRelations(ai->playerID, goal.object->tempOwner);
+				
+				if(objRelations == PlayerRelations::ENEMIES)
+				{
+					return sptr(Goals::VisitObj(goal.object->id.getNum()));
+				}
+				else
+				{
+					// TODO: Defance
+					break;
+				}
 			}
 			else
 			{


### PR DESCRIPTION
There is an issue reported by Povelitel that game hangs during AI turn. It was found out that the issue is in a win condition to control own town.