### PR TITLE
AI: fix freeze while endlesly trying to recruit hero

### DIFF
--- a/AI/VCAI/VCAI.cpp
+++ b/AI/VCAI/VCAI.cpp
@@ -823,6 +823,7 @@ void VCAI::makeTurn()
 	}
 	markHeroAbleToExplore(primaryHero());
 	visitedHeroes.clear();
+	ai->ah->resetPaths();
 
 	try
 	{
@@ -1006,6 +1007,9 @@ void VCAI::mainLoop()
 				//erase base goal if we failed to execute decomposed goal
 				for (auto basicGoal : ultimateGoalsFromBasic[goalToRealize])
 					goalsToRemove.push_back(basicGoal);
+
+				// sometimes resource manager contains an elementar goal which is not able to execute anymore and just fails each turn.
+				ai->ah->notifyGoalCompleted(goalToRealize);
 
 				//we failed to realize best goal, but maybe others are still possible?
 			}
@@ -2055,6 +2059,10 @@ void VCAI::tryRealize(Goals::RecruitHero & g)
 		recruitHero(t, true);
 		//TODO try to free way to blocked town
 		//TODO: adventure map tavern or prison?
+	}
+	else
+	{
+		throw cannotFulfillGoalException("No town to recruit hero!");
 	}
 }
 


### PR DESCRIPTION
Conquer goal sometimes want to recruit a hero. If it is possible but is declined by ResourceManager because it has something more important or wants to save money it stores RecruitHero goal in its own cache and waits for a better time. When the better time happens we just want to execute RecruitHero elementar version as it was stored in elementar form in ResourceManager. The last more or less blindly tries to recruit hero and fails with cannotCompleteGoal exception. But the one path which checks presence of any tavern does not. It just does nothing and exits. So we try to recruit hero again and again and goal does nothing. It is not completed because it did not throw goalCompletedException nor it canceled because it did not threw cannotCompleteGoalException.