### PR TITLE
AI: fix visit obj crash

### DIFF
--- a/AI/VCAI/FuzzyEngines.cpp
+++ b/AI/VCAI/FuzzyEngines.cpp
@@ -378,7 +378,11 @@ float VisitObjEngine::evaluate(Goals::VisitObj & goal)
 		return 0;
 
 	auto obj = ai->myCb->getObj(ObjectInstanceID(goal.objid));
-
+	if(!obj)
+	{
+		logAi->error("Goals::VisitObj objid " + std::to_string(goal.objid) + " no longer visible, probably goal used for something it's not intended");
+		return -100; // FIXME: Added check when goal was used for hero instead of VisitHero, but crashes are bad anyway
+	}
 
 	boost::optional<int> objValueKnownByAI = MapObjectsEvaluator::getInstance().getObjectValue(obj);
 	int objValue = 0;

--- a/AI/VCAI/Pathfinding/PathfindingManager.cpp
+++ b/AI/VCAI/Pathfinding/PathfindingManager.cpp
@@ -88,7 +88,7 @@ Goals::TGoalVec PathfindingManager::howToVisitObj(HeroPtr hero, ObjectIdRef obj,
 
 	auto result = findPath(hero, dest, allowGatherArmy, [&](int3 firstTileToGet) -> Goals::TSubgoal
 	{
-		if(obj->ID.num == Obj::HERO && obj->getOwner() == hero->getOwner())
+		if(obj->ID == Obj::HERO)
 			return sptr(Goals::VisitHero(obj->id.getNum()).sethero(hero).setisAbstract(true));
 		else
 			return sptr(Goals::VisitObj(obj->id.getNum()).sethero(hero).setisAbstract(true));
@@ -96,7 +96,10 @@ Goals::TGoalVec PathfindingManager::howToVisitObj(HeroPtr hero, ObjectIdRef obj,
 
 	for(Goals::TSubgoal solution : result)
 	{
-		solution->setparent(sptr(Goals::VisitObj(obj->id.getNum()).sethero(hero).setevaluationContext(solution->evaluationContext)));
+		if(obj->ID == Obj::HERO)
+			solution->setparent(sptr(Goals::VisitHero(obj->id.getNum()).sethero(hero).setevaluationContext(solution->evaluationContext)));
+		else
+			solution->setparent(sptr(Goals::VisitObj(obj->id.getNum()).sethero(hero).setevaluationContext(solution->evaluationContext)));
 	}
 
 	return result;


### PR DESCRIPTION
So this is very dumb fix, but I need some confirmation from AI guys before I merge it to develop.

UPD: to clarify what exactly I trying to fix. Problem is that VCAI use VisitObj goal to visit hero and when hero become invisible after FoW change it's cause crash since apparently ```VCAI::heroMoved``` used ```validateObject``` for enemy heroes. Apparently ```validateObject``` doesn't remove ```lockedHeroes``` goals when ebemt hero is no longer visible.