### PR TITLE
Fix broken build on libboost 1.69.0

### DIFF
--- a/client/windows/CAdvmapInterface.cpp
+++ b/client/windows/CAdvmapInterface.cpp
@@ -880,7 +880,7 @@ void CAdvMapInt::updateMoveHero(const CGHeroInstance *h, tribool hasPath)
 	if(boost::logic::indeterminate(hasPath))
 		hasPath = LOCPLINT->paths[h].nodes.size() ? true : false;
 
-	moveHero->block(!hasPath || (h->movement == 0));
+	moveHero->block(!(bool)hasPath || (h->movement == 0));
 }
 
 void CAdvMapInt::updateSpellbook(const CGHeroInstance *h)

--- a/client/windows/CAdvmapInterface.cpp
+++ b/client/windows/CAdvmapInterface.cpp
@@ -162,7 +162,7 @@ void CTerrainRect::clickRight(tribool down, bool previousState)
 
 void CTerrainRect::clickMiddle(tribool down, bool previousState)
 {
-	handleSwipeStateChange(down == true);
+	handleSwipeStateChange((bool)down == true);
 }
 
 void CTerrainRect::mouseMoved(const SDL_MouseMotionEvent & sEvent)

--- a/client/windows/CAdvmapInterface.cpp
+++ b/client/windows/CAdvmapInterface.cpp
@@ -126,7 +126,7 @@ void CTerrainRect::clickLeft(tribool down, bool previousState)
 #ifdef VCMI_ANDROID
 	if(adventureInt->swipeEnabled)
 	{
-		if(handleSwipeStateChange(down == true))
+		if(handleSwipeStateChange((bool)down == true))
 		{
 			return; // if swipe is enabled, we don't process "down" events and wait for "up" (to make sure this wasn't a swiping gesture)
 		}

--- a/lib/battle/CBattleInfoEssentials.cpp
+++ b/lib/battle/CBattleInfoEssentials.cpp
@@ -411,7 +411,7 @@ bool CBattleInfoEssentials::battleMatchOwner(const battle::Unit * attacker, cons
 	if(boost::logic::indeterminate(positivness))
 		return true;
 	else if(attacker->unitId() == defender->unitId())
-		return positivness;
+		return (bool)positivness;
 	else
 		return battleMatchOwner(battleGetOwner(attacker), defender, positivness);
 }
@@ -425,5 +425,5 @@ bool CBattleInfoEssentials::battleMatchOwner(const PlayerColor & attacker, const
 	if(boost::logic::indeterminate(positivness))
 		return true;
 	else
-		return (attacker == initialOwner) == positivness;
+		return (attacker == initialOwner) == (bool)positivness;
 }

--- a/lib/serializer/JsonSerializer.cpp
+++ b/lib/serializer/JsonSerializer.cpp
@@ -21,7 +21,7 @@ JsonSerializer::JsonSerializer(const IInstanceResolver * instanceResolver_, Json
 void JsonSerializer::serializeInternal(const std::string & fieldName, boost::logic::tribool & value)
 {
 	if(!boost::logic::indeterminate(value))
-		currentObject->operator[](fieldName).Bool() = value;
+		currentObject->operator[](fieldName).Bool() = (bool)value;
 }
 
 void JsonSerializer::serializeInternal(const std::string & fieldName, si32 & value, const boost::optional<si32> & defaultValue, const TDecoder & decoder, const TEncoder & encoder)

--- a/lib/spells/ISpellMechanics.cpp
+++ b/lib/spells/ISpellMechanics.cpp
@@ -607,7 +607,7 @@ bool BaseMechanics::isSmart() const
 	}
 	else
 	{
-		return smart;
+		return (bool)smart;
 	}
 }
 
@@ -620,7 +620,7 @@ bool BaseMechanics::isMassive() const
 	}
 	else
 	{
-		return massive;
+		return (bool)massive;
 	}
 }
 


### PR DESCRIPTION
The build seems to be broken with the new boost library.
This is caused by the implicit conversions of boost::logic::tribool into bool in the files below.
Explicit casting seems to fix the issue; PR to fix the build.

Built on: g++ 8.2.1 20181127
Libboost version: 1.69.0