### PR TITLE
Do not generate GatherArmy goal as result of GatherArmy decomposition

### DIFF
--- a/AI/VCAI/Goals/GatherArmy.cpp
+++ b/AI/VCAI/Goals/GatherArmy.cpp
@@ -126,13 +126,13 @@ TGoalVec GatherArmy::getAllPossibleSubgoals()
 		// Go to the other hero if we are faster
 		if(!vstd::contains(ai->visitedHeroes[hero], h))
 		{
-			vstd::concatenate(ret, ai->ah->howToVisitObj(hero, h));
+			vstd::concatenate(ret, ai->ah->howToVisitObj(hero, h, false));
 		}
 
 		// Go to the other hero if we are faster
 		if(!vstd::contains(ai->visitedHeroes[h], hero))
 		{
-			vstd::concatenate(ret, ai->ah->howToVisitObj(h, hero.get()));
+			vstd::concatenate(ret, ai->ah->howToVisitObj(h, hero.get(), false));
 		}
 	}
 


### PR DESCRIPTION
May be discussable if generating another "GatherArmy" that requires smaller army which is needed to clear way to gather bigger army makes sense. Anyway with original design this was not intended (changed lines of code were generating VisitTile goal before being replaced with AI pathfinder).