### PR TITLE
Disable tactical advantage engine until rework

### DIFF
--- a/AI/VCAI/FuzzyEngines.cpp
+++ b/AI/VCAI/FuzzyEngines.cpp
@@ -203,7 +203,7 @@ TacticalAdvantageEngine::TacticalAdvantageEngine()
 float TacticalAdvantageEngine::getTacticalAdvantage(const CArmedInstance * we, const CArmedInstance * enemy)
 {
 	float output = 1;
-	try
+	/*try //TODO: rework this engine, it tends to produce nonsense output
 	{
 		armyStructure ourStructure = evaluateArmyStructure(we);
 		armyStructure enemyStructure = evaluateArmyStructure(enemy);
@@ -248,7 +248,7 @@ float TacticalAdvantageEngine::getTacticalAdvantage(const CArmedInstance * we, c
 			log << names[i] << ": " << tab[i]->getValue() << " ";
 		logAi->error(log.str());
 		assert(false);
-	}
+	}*/
 
 	return output;
 }

--- a/AI/VCAI/FuzzyEngines.h
+++ b/AI/VCAI/FuzzyEngines.h
@@ -24,7 +24,7 @@ public:
 	engineBase();
 };
 
-class TacticalAdvantageEngine : public engineBase
+class TacticalAdvantageEngine : public engineBase //TODO: rework this engine, it does not work well (example: AI hero with 140 beholders attacked 150 beholders - engine lowered danger 50000 -> 35000)
 {
 public:
 	TacticalAdvantageEngine();


### PR DESCRIPTION
As discussed on slack it'd be good idea to disable TA engine for now.