### PR TITLE
Fix magic school gold payment (bug #3043)

### DIFF
--- a/lib/mapObjects/CRewardableObject.cpp
+++ b/lib/mapObjects/CRewardableObject.cpp
@@ -988,7 +988,9 @@ void CGVisitableOPH::initObj(CRandomGenerator & rand)
 			info.resize(2);
 			info[0].reward.primary[PrimarySkill::SPELL_POWER] = 1;
 			info[1].reward.primary[PrimarySkill::KNOWLEDGE] = 1;
+			info[0].limiter.resources[Res::GOLD] = 1000;
 			info[0].reward.resources[Res::GOLD] = -1000;
+			info[1].limiter.resources[Res::GOLD] = 1000;
 			info[1].reward.resources[Res::GOLD] = -1000;
 			onSelect.addTxt(MetaString::ADVOB_TXT, 71);
 			onVisited.addTxt(MetaString::ADVOB_TXT, 72);


### PR DESCRIPTION
Magic school was always "usable" in case player got not enough gold, and in that case it reduced gold to 0 on successful visit.