### PR TITLE
Fix crystal dragon ability to match H3

### DIFF
--- a/config/creatures/neutral.json
+++ b/config/creatures/neutral.json
@@ -122,10 +122,7 @@
 			},
 			"crystals" :
 			{
-				"type" : "GENERATE_RESOURCE",
-				"subtype" : "resource.crystal",
-				"val" : 1,
-				"propagator" : "HERO"
+				"type" : "SPECIAL_CRYSTAL_GENERATION"
 			},
 			"FLYING_ARMY" : null
 		},

--- a/lib/HeroBonus.h
+++ b/lib/HeroBonus.h
@@ -269,6 +269,7 @@ public:
 	BONUS_NAME(SHOOTS_ALL_ADJACENT) /* H4 Cyclops-like shoot (attacks all hexes neighboring with target) without spell-like mechanics */\
 	BONUS_NAME(BLOCK_MAGIC_BELOW) /*blocks casting spells of the level < value */ \
 	BONUS_NAME(DESTRUCTION) /*kills extra units after hit, subtype = 0 - kill percentage of units, 1 - kill amount, val = chance in percent to trigger, additional info - amount/percentage to kill*/ \
+	BONUS_NAME(SPECIAL_CRYSTAL_GENERATION) /*crystal dragon crystal generation*/ \
 
 	/* end of list */
 

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -1739,6 +1739,38 @@ void CGameHandler::newTurn()
 
 		n.res[elem.first] = elem.second.resources;
 
+		if(!firstTurn && newWeek) //weekly crystal generation if 1 or more crystal dragons in any hero army or town garrison
+		{
+			bool hasCrystalGenCreature = false;
+			for(CGHeroInstance * hero : elem.second.heroes)
+			{
+				for(auto stack : hero->stacks)
+				{
+					if(stack.second->hasBonusOfType(Bonus::SPECIAL_CRYSTAL_GENERATION))
+					{
+						hasCrystalGenCreature = true;
+						break;
+					}
+				}
+			}
+			if(!hasCrystalGenCreature) //not found in armies, check towns
+			{
+				for(CGTownInstance * town : elem.second.towns)
+				{
+					for(auto stack : town->stacks)
+					{
+						if(stack.second->hasBonusOfType(Bonus::SPECIAL_CRYSTAL_GENERATION))
+						{
+							hasCrystalGenCreature = true;
+							break;
+						}
+					}
+				}
+			}
+			if(hasCrystalGenCreature)
+				n.res[elem.first][Res::CRYSTAL] += 3;
+		}
+
 		for (CGHeroInstance *h : (elem).second.heroes)
 		{
 			if (h->visitedTown)


### PR DESCRIPTION
Existence of at least 1 crystal dragon in any town or hero army should generate 3 crystals on first day of the  week. Hiding all crystal dragons in garrison, mine etc. stops crystal generation. More dragons in stack or dragon stacks do not change amount of crystals generated. I find the ability fairly "arbitrary" and "existing for compatibility with H3 mechanics" so I think it's OK not to make it flexible for modding.