### PR TITLE
Acid dragon / acid breath fix

### DIFF
--- a/config/creatures/neutral.json
+++ b/config/creatures/neutral.json
@@ -254,7 +254,7 @@
 			{
 				"type" : "ACID_BREATH",
 				"val" : 25,
-				"addInfo" : 20
+				"addInfo" : 30
 			},
 			"fireBreath" :
 			{

--- a/config/spells/ability.json
+++ b/config/spells/ability.json
@@ -362,6 +362,12 @@
 		"index" : 80,
 		"targetType": "NO_TARGET",
 
+		"animation":{
+			"affect":["C17SPW0"]
+		},
+		"sounds": {
+			"cast": "ACID"
+		},
 		"levels" : {
 			"base":{
 				"battleEffects":{


### PR DESCRIPTION
Corrected chance for additional acid damage, added missing animation (and yeah, acid breath animation should play two times if additional acid damage occures).