### PR TITLE
Tweak effect / spell animation speed

### DIFF
--- a/client/battle/CCreatureAnimation.cpp
+++ b/client/battle/CCreatureAnimation.cpp
@@ -115,7 +115,7 @@ float AnimationControls::getProjectileSpeed()
 
 float AnimationControls::getSpellEffectSpeed()
 {
-	return settings["battle"]["animationSpeed"].Float() * 60;
+	return settings["battle"]["animationSpeed"].Float() * 30;
 }
 
 float AnimationControls::getMovementDuration(const CCreature * creature)


### PR DESCRIPTION
After reducing the value by half, effect / spell projectile speed is really close to original H3 compared to other actions on same speed setting.