### PR TITLE
Creature spellcast refactor

### DIFF
--- a/AI/BattleAI/BattleAI.cpp
+++ b/AI/BattleAI/BattleAI.cpp
@@ -143,7 +143,7 @@ BattleAction CBattleAI::activeStack( const CStack * stack )
 					possibleCasts.push_back(ps);
 				}
 
-				std::sort(possibleCasts.begin(), possibleCasts.end(), [&](PossibleSpellcast & lhs, PossibleSpellcast & rhs) { return lhs.value > rhs.value; });
+				std::sort(possibleCasts.begin(), possibleCasts.end(), [&](const PossibleSpellcast & lhs, const PossibleSpellcast & rhs) { return lhs.value > rhs.value; });
 				if(!possibleCasts.empty() && possibleCasts.front().value > 0)
 				{
 					bestSpellcast = possibleCasts.front();

--- a/AI/BattleAI/BattleAI.cpp
+++ b/AI/BattleAI/BattleAI.cpp
@@ -555,6 +555,7 @@ void CBattleAI::attemptCastingSpell()
 	}
 }
 
+//Below method works only for offensive spells
 void CBattleAI::evaluateCreatureSpellcast(const CStack * stack, PossibleSpellcast & ps)
 {
 	using ValueMap = PossibleSpellcast::ValueMap;
@@ -563,15 +564,12 @@ void CBattleAI::evaluateCreatureSpellcast(const CStack * stack, PossibleSpellcas
 	HypotheticBattle state(getCbc());
 	TStacks all = getCbc()->battleGetAllStacks(false);
 	
-	ValueMap valueOfStack;
 	ValueMap healthOfStack;
 	ValueMap newHealthOfStack;
-	ValueMap newValueOfStack;
 
 	for(auto unit : all)
 	{
 		healthOfStack[unit->unitId()] = unit->getAvailableHealth();
-		valueOfStack[unit->unitId()] = 0;
 	}
 
 	spells::BattleCast cast(&state, stack, spells::Mode::CREATURE_ACTIVE, ps.spell);
@@ -583,7 +581,6 @@ void CBattleAI::evaluateCreatureSpellcast(const CStack * stack, PossibleSpellcas
 		auto unitId = unit->unitId();
 		auto localUnit = state.battleGetUnitByID(unitId);
 		newHealthOfStack[unitId] = localUnit->getAvailableHealth();
-		newValueOfStack[unitId] = 0;
 	}
 
 	int64_t totalGain = 0;
@@ -592,9 +589,6 @@ void CBattleAI::evaluateCreatureSpellcast(const CStack * stack, PossibleSpellcas
 	{
 		auto unitId = unit->unitId();
 		auto localUnit = state.battleGetUnitByID(unitId);
-
-		auto newValue = getValOr(newValueOfStack, unitId, 0);
-		auto oldValue = getValOr(valueOfStack, unitId, 0);
 
 		auto healthDiff = newHealthOfStack[unitId] - healthOfStack[unitId];
 
@@ -607,7 +601,7 @@ void CBattleAI::evaluateCreatureSpellcast(const CStack * stack, PossibleSpellcas
 			return; //do not damage own units at all
 		}
 
-		totalGain += (newValue - oldValue + healthDiff);
+		totalGain += healthDiff;
 	}
 
 	ps.value = totalGain;

--- a/AI/BattleAI/BattleAI.cpp
+++ b/AI/BattleAI/BattleAI.cpp
@@ -146,7 +146,7 @@ BattleAction CBattleAI::activeStack( const CStack * stack )
 				std::sort(possibleCasts.begin(), possibleCasts.end(), [&](const PossibleSpellcast & lhs, const PossibleSpellcast & rhs) { return lhs.value > rhs.value; });
 				if(!possibleCasts.empty() && possibleCasts.front().value > 0)
 				{
-					bestSpellcast = possibleCasts.front();
+					bestSpellcast = boost::optional<PossibleSpellcast>(possibleCasts.front());
 				}
 			}
 		}

--- a/AI/BattleAI/BattleAI.cpp
+++ b/AI/BattleAI/BattleAI.cpp
@@ -124,6 +124,7 @@ BattleAction CBattleAI::activeStack( const CStack * stack )
 	
 		//evaluate casting spell for spellcasting stack
 		boost::optional<PossibleSpellcast> bestSpellcast = boost::none;
+		//TODO: faerie dragon type spell should be selected by server
 		SpellID creatureSpellToCast = cb->battleGetRandomStackSpell(CRandomGenerator::getDefault(), stack, CBattleInfoCallback::RANDOM_AIMED);
 		if(stack->hasBonusOfType(Bonus::SPELLCASTER) && stack->canCast() && creatureSpellToCast != SpellID::NONE)
 		{

--- a/AI/BattleAI/BattleAI.h
+++ b/AI/BattleAI/BattleAI.h
@@ -9,6 +9,7 @@
  */
 #pragma once
 #include "../../lib/AI_Base.h"
+#include "PossibleSpellcast.h"
 #include "PotentialTargets.h"
 
 class CSpell;
@@ -59,6 +60,8 @@ public:
 
 	void init(std::shared_ptr<CBattleCallback> CB) override;
 	void attemptCastingSpell();
+
+	void evaluateCreatureSpellcast(const CStack * stack, PossibleSpellcast & ps); //for offensive damaging spells only
 
 	BattleAction activeStack(const CStack * stack) override; //called when it's turn of that stack
 	BattleAction goTowards(const CStack * stack, BattleHex hex );

--- a/client/battle/CBattleInterface.cpp
+++ b/client/battle/CBattleInterface.cpp
@@ -1757,7 +1757,7 @@ void CBattleInterface::reorderPossibleActionsPriority(const CStack * stack, Mous
 		case NO_LOCATION:
 		case FREE_LOCATION:
 		case OBSTACLE:
-			if(stack->hasBonusOfType(Bonus::SPELLCAST_BY_DEFAULT) && context == MouseHoveredHexContext::OCCUPIED_HEX)
+			if(!stack->hasBonusOfType(Bonus::NO_SPELLCAST_BY_DEFAULT) && context == MouseHoveredHexContext::OCCUPIED_HEX)
 				return 1;
 			else
 				return 100;//bottom priority

--- a/client/battle/CBattleInterface.cpp
+++ b/client/battle/CBattleInterface.cpp
@@ -1740,7 +1740,6 @@ void CBattleInterface::getPossibleActionsForStack(const CStack *stack)
 	BattleClientInterfaceData data;
 	data.creatureSpellToCast = creatureSpellToCast;
 	data.tacticsMode = tacticsMode;
-	data.siegeH = siegeH ? true : false;
 	auto allActions = curInt->cb->getClientActionsForStack(stack, data);
 
 	possibleActions = std::vector<PossiblePlayerBattleAction>(allActions);

--- a/client/battle/CBattleInterface.h
+++ b/client/battle/CBattleInterface.h
@@ -183,7 +183,7 @@ private:
 
 	void requestAutofightingAIToTakeAction();
 
-	void getPossibleActionsForStack (const CStack *stack, const bool forceCast); //called when stack gets its turn
+	void getPossibleActionsForStack (const CStack *stack); //called when stack gets its turn
 	void endCastingSpell(); //ends casting spell (eg. when spell has been cast or canceled)
 
 	//force active stack to cast a spell if possible

--- a/client/battle/CBattleInterface.h
+++ b/client/battle/CBattleInterface.h
@@ -105,6 +105,12 @@ struct CatapultProjectileInfo
 	double calculateY(double x);
 };
 
+enum class MouseHoveredHexContext
+{
+	UNOCCUPIED_HEX,
+	OCCUPIED_HEX
+};
+
 /// Big class which handles the overall battle interface actions and it is also responsible for
 /// drawing everything correctly.
 class CBattleInterface : public WindowBase
@@ -176,6 +182,7 @@ private:
 
 	void getPossibleActionsForStack (const CStack *stack); //called when stack gets its turn
 	void endCastingSpell(); //ends casting spell (eg. when spell has been cast or canceled)
+	void reorderPossibleActionsPriority(const CStack * stack, MouseHoveredHexContext context);
 
 	//force active stack to cast a spell if possible
 	void enterCreatureCastingMode();

--- a/client/battle/CBattleInterface.h
+++ b/client/battle/CBattleInterface.h
@@ -180,7 +180,7 @@ private:
 
 	void requestAutofightingAIToTakeAction();
 
-	void getPossibleActionsForStack (const CStack *stack); //called when stack gets its turn
+	std::vector<PossiblePlayerBattleAction> getPossibleActionsForStack (const CStack *stack); //called when stack gets its turn
 	void endCastingSpell(); //ends casting spell (eg. when spell has been cast or canceled)
 	void reorderPossibleActionsPriority(const CStack * stack, MouseHoveredHexContext context);
 

--- a/client/battle/CBattleInterface.h
+++ b/client/battle/CBattleInterface.h
@@ -15,6 +15,7 @@
 #include "CBattleAnimations.h"
 
 #include "../../lib/spells/CSpellHandler.h" //CSpell::TAnimation
+#include "../../lib/battle/CBattleInfoCallback.h"
 
 class CLabel;
 class CCreatureSet;
@@ -108,16 +109,6 @@ struct CatapultProjectileInfo
 /// drawing everything correctly.
 class CBattleInterface : public WindowBase
 {
-	enum PossibleActions // actions performed at l-click
-	{
-		INVALID = -1, CREATURE_INFO,
-		MOVE_TACTICS, CHOOSE_TACTICS_STACK,
-		MOVE_STACK, ATTACK, WALK_AND_ATTACK, ATTACK_AND_RETURN, SHOOT, //OPEN_GATE, //we can open castle gate during siege
-		NO_LOCATION, ANY_LOCATION, OBSTACLE, TELEPORT, SACRIFICE, RANDOM_GENIE_SPELL,
-		FREE_LOCATION, //used with Force Field and Fire Wall - all tiles affected by spell must be free
-		CATAPULT, HEAL, RISE_DEMONS,
-		AIMED_SPELL_CREATURE
-	};
 private:
 	SDL_Surface *background, *menu, *amountNormal, *amountNegative, *amountPositive, *amountEffNeutral, *cellBorders, *backgroundWithHexes;
 
@@ -169,12 +160,12 @@ private:
 	std::shared_ptr<BattleAction> spellToCast; //spell for which player is choosing destination
 	const CSpell *sp; //spell pointer for convenience
 	si32 creatureSpellToCast;
-	std::vector<PossibleActions> possibleActions; //all actions possible to call at the moment by player
-	std::vector<PossibleActions> localActions; //actions possible to take on hovered hex
-	std::vector<PossibleActions> illegalActions; //these actions display message in case of illegal target
-	PossibleActions currentAction; //action that will be performed on l-click
-	PossibleActions selectedAction; //last action chosen (and saved) by player
-	PossibleActions illegalAction; //most likely action that can't be performed here
+	std::vector<PossiblePlayerBattleAction> possibleActions; //all actions possible to call at the moment by player
+	std::vector<PossiblePlayerBattleAction> localActions; //actions possible to take on hovered hex
+	std::vector<PossiblePlayerBattleAction> illegalActions; //these actions display message in case of illegal target
+	PossiblePlayerBattleAction currentAction; //action that will be performed on l-click
+	PossiblePlayerBattleAction selectedAction; //last action chosen (and saved) by player
+	PossiblePlayerBattleAction illegalAction; //most likely action that can't be performed here
 	bool battleActionsStarted; //used for delaying battle actions until intro sound stops
 	int battleIntroSoundChannel; //required as variable for disabling it via ESC key
 
@@ -274,8 +265,6 @@ private:
 
 	void redrawBackgroundWithHexes(const CStack *activeStack);
 	/** End of battle screen blitting methods */
-
-	PossibleActions getCasterAction(const CSpell *spell, const spells::Caster *caster, spells::Mode mode) const;
 
 	void setHeroAnimation(ui8 side, int phase);
 public:

--- a/lib/HeroBonus.h
+++ b/lib/HeroBonus.h
@@ -270,6 +270,7 @@ public:
 	BONUS_NAME(BLOCK_MAGIC_BELOW) /*blocks casting spells of the level < value */ \
 	BONUS_NAME(DESTRUCTION) /*kills extra units after hit, subtype = 0 - kill percentage of units, 1 - kill amount, val = chance in percent to trigger, additional info - amount/percentage to kill*/ \
 	BONUS_NAME(SPECIAL_CRYSTAL_GENERATION) /*crystal dragon crystal generation*/ \
+	BONUS_NAME(SPELLCAST_BY_DEFAULT) /*spellcast will be default attack option for this creature*/ \
 
 	/* end of list */
 

--- a/lib/HeroBonus.h
+++ b/lib/HeroBonus.h
@@ -270,7 +270,7 @@ public:
 	BONUS_NAME(BLOCK_MAGIC_BELOW) /*blocks casting spells of the level < value */ \
 	BONUS_NAME(DESTRUCTION) /*kills extra units after hit, subtype = 0 - kill percentage of units, 1 - kill amount, val = chance in percent to trigger, additional info - amount/percentage to kill*/ \
 	BONUS_NAME(SPECIAL_CRYSTAL_GENERATION) /*crystal dragon crystal generation*/ \
-	BONUS_NAME(SPELLCAST_BY_DEFAULT) /*spellcast will be default attack option for this creature*/ \
+	BONUS_NAME(NO_SPELLCAST_BY_DEFAULT) /*spellcast will not be default attack option for this creature*/ \
 
 	/* end of list */
 

--- a/lib/battle/BattleAction.cpp
+++ b/lib/battle/BattleAction.cpp
@@ -74,6 +74,17 @@ BattleAction BattleAction::makeShotAttack(const battle::Unit * shooter, const ba
 	return ba;
 }
 
+BattleAction BattleAction::makeCreatureSpellcast(const battle::Unit * stack, const battle::Target & target, SpellID spellID)
+{
+	BattleAction ba;
+	ba.actionType = EActionType::MONSTER_SPELL;
+	ba.actionSubtype = spellID;
+	ba.setTarget(target);
+	ba.side = stack->unitSide();
+	ba.stackNumber = stack->unitId();
+	return ba;
+}
+
 BattleAction BattleAction::makeMove(const battle::Unit * stack, BattleHex dest)
 {
 	BattleAction ba;

--- a/lib/battle/BattleAction.h
+++ b/lib/battle/BattleAction.h
@@ -35,6 +35,7 @@ public:
 	static BattleAction makeWait(const battle::Unit * stack);
 	static BattleAction makeMeleeAttack(const battle::Unit * stack, BattleHex destination, BattleHex attackFrom, bool returnAfterAttack = true);
 	static BattleAction makeShotAttack(const battle::Unit * shooter, const battle::Unit * target);
+	static BattleAction makeCreatureSpellcast(const battle::Unit * stack, const battle::Target & target, SpellID spellID);
 	static BattleAction makeMove(const battle::Unit * stack, BattleHex dest);
 	static BattleAction makeEndOFTacticPhase(ui8 side);
 

--- a/lib/battle/CBattleInfoCallback.cpp
+++ b/lib/battle/CBattleInfoCallback.cpp
@@ -238,7 +238,8 @@ std::vector<PossiblePlayerBattleAction> CBattleInfoCallback::getClientActionsFor
 		if(stack->canMove() && stack->Speed(0, true)) //probably no reason to try move war machines or bound stacks
 			allowedActionList.push_back(MOVE_STACK);
 
-		if(data.siegeH && stack->hasBonusOfType(Bonus::CATAPULT)) //TODO: check shots
+		auto siegedTown = battleGetDefendedTown();
+		if(siegedTown && siegedTown->hasFort() && stack->hasBonusOfType(Bonus::CATAPULT)) //TODO: check shots
 			allowedActionList.push_back(CATAPULT);
 		if(stack->hasBonusOfType(Bonus::HEALER))
 			allowedActionList.push_back(HEAL);

--- a/lib/battle/CBattleInfoCallback.cpp
+++ b/lib/battle/CBattleInfoCallback.cpp
@@ -209,8 +209,8 @@ std::vector<PossiblePlayerBattleAction> CBattleInfoCallback::getClientActionsFor
 	std::vector<PossiblePlayerBattleAction> allowedActionList;
 	if(data.tacticsMode) //would "if(battleGetTacticDist() > 0)" work?
 	{
-		allowedActionList.push_back(MOVE_TACTICS);
-		allowedActionList.push_back(CHOOSE_TACTICS_STACK);
+		allowedActionList.push_back(PossiblePlayerBattleAction::MOVE_TACTICS);
+		allowedActionList.push_back(PossiblePlayerBattleAction::CHOOSE_TACTICS_STACK);
 	}
 	else
 	{
@@ -223,26 +223,26 @@ std::vector<PossiblePlayerBattleAction> CBattleInfoCallback::getClientActionsFor
 				allowedActionList.push_back(act);
 			}
 			if(stack->hasBonusOfType(Bonus::RANDOM_SPELLCASTER))
-				allowedActionList.push_back(RANDOM_GENIE_SPELL);
+				allowedActionList.push_back(PossiblePlayerBattleAction::RANDOM_GENIE_SPELL);
 			if(stack->hasBonusOfType(Bonus::DAEMON_SUMMONING))
-				allowedActionList.push_back(RISE_DEMONS);
+				allowedActionList.push_back(PossiblePlayerBattleAction::RISE_DEMONS);
 		}
 		if(stack->canShoot())
-			allowedActionList.push_back(SHOOT);
+			allowedActionList.push_back(PossiblePlayerBattleAction::SHOOT);
 		if(stack->hasBonusOfType(Bonus::RETURN_AFTER_STRIKE))
-			allowedActionList.push_back(ATTACK_AND_RETURN);
+			allowedActionList.push_back(PossiblePlayerBattleAction::ATTACK_AND_RETURN);
 
-		allowedActionList.push_back(ATTACK); //all active stacks can attack
-		allowedActionList.push_back(WALK_AND_ATTACK); //not all stacks can always walk, but we will check this elsewhere
+		allowedActionList.push_back(PossiblePlayerBattleAction::ATTACK); //all active stacks can attack
+		allowedActionList.push_back(PossiblePlayerBattleAction::WALK_AND_ATTACK); //not all stacks can always walk, but we will check this elsewhere
 
 		if(stack->canMove() && stack->Speed(0, true)) //probably no reason to try move war machines or bound stacks
-			allowedActionList.push_back(MOVE_STACK);
+			allowedActionList.push_back(PossiblePlayerBattleAction::MOVE_STACK);
 
 		auto siegedTown = battleGetDefendedTown();
 		if(siegedTown && siegedTown->hasFort() && stack->hasBonusOfType(Bonus::CATAPULT)) //TODO: check shots
-			allowedActionList.push_back(CATAPULT);
+			allowedActionList.push_back(PossiblePlayerBattleAction::CATAPULT);
 		if(stack->hasBonusOfType(Bonus::HEALER))
-			allowedActionList.push_back(HEAL);
+			allowedActionList.push_back(PossiblePlayerBattleAction::HEAL);
 	}
 
 	return allowedActionList;
@@ -251,18 +251,18 @@ std::vector<PossiblePlayerBattleAction> CBattleInfoCallback::getClientActionsFor
 PossiblePlayerBattleAction CBattleInfoCallback::getCasterAction(const CSpell * spell, const spells::Caster * caster, spells::Mode mode) const
 {
 	RETURN_IF_NOT_BATTLE(PossiblePlayerBattleAction::INVALID);
-	PossiblePlayerBattleAction spellSelMode = ANY_LOCATION;
+	PossiblePlayerBattleAction spellSelMode = PossiblePlayerBattleAction::ANY_LOCATION;
 
 	const CSpell::TargetInfo ti(spell, caster->getSpellSchoolLevel(spell), mode);
 
 	if(ti.massive || ti.type == spells::AimType::NO_TARGET)
-		spellSelMode = NO_LOCATION;
+		spellSelMode = PossiblePlayerBattleAction::NO_LOCATION;
 	else if(ti.type == spells::AimType::LOCATION && ti.clearAffected)
-		spellSelMode = FREE_LOCATION;
+		spellSelMode = PossiblePlayerBattleAction::FREE_LOCATION;
 	else if(ti.type == spells::AimType::CREATURE)
-		spellSelMode = AIMED_SPELL_CREATURE;
+		spellSelMode = PossiblePlayerBattleAction::AIMED_SPELL_CREATURE;
 	else if(ti.type == spells::AimType::OBSTACLE)
-		spellSelMode = OBSTACLE;
+		spellSelMode = PossiblePlayerBattleAction::OBSTACLE;
 
 	return spellSelMode;
 }

--- a/lib/battle/CBattleInfoCallback.h
+++ b/lib/battle/CBattleInfoCallback.h
@@ -47,7 +47,6 @@ struct DLL_LINKAGE BattleClientInterfaceData
 {
 	si32 creatureSpellToCast;
 	ui8 tacticsMode;
-	ui8 siegeH;
 };
 
 class DLL_LINKAGE CBattleInfoCallback : public virtual CBattleInfoEssentials

--- a/lib/battle/CBattleInfoCallback.h
+++ b/lib/battle/CBattleInfoCallback.h
@@ -32,6 +32,24 @@ struct DLL_LINKAGE AttackableTiles
 	}
 };
 
+enum PossiblePlayerBattleAction // actions performed at l-click
+{
+	INVALID = -1, CREATURE_INFO,
+	MOVE_TACTICS, CHOOSE_TACTICS_STACK,
+	MOVE_STACK, ATTACK, WALK_AND_ATTACK, ATTACK_AND_RETURN, SHOOT, //OPEN_GATE, //we can open castle gate during siege
+	NO_LOCATION, ANY_LOCATION, OBSTACLE, TELEPORT, SACRIFICE, RANDOM_GENIE_SPELL,
+	FREE_LOCATION, //used with Force Field and Fire Wall - all tiles affected by spell must be free
+	CATAPULT, HEAL, RISE_DEMONS,
+	AIMED_SPELL_CREATURE
+};
+
+struct DLL_LINKAGE BattleClientInterfaceData
+{
+	si32 creatureSpellToCast;
+	ui8 tacticsMode;
+	ui8 siegeH;
+};
+
 class DLL_LINKAGE CBattleInfoCallback : public virtual CBattleInfoEssentials
 {
 public:
@@ -99,6 +117,8 @@ public:
 	SpellID getRandomCastedSpell(CRandomGenerator & rand, const CStack * caster) const; //called at the beginning of turn for Faerie Dragon
 
 	si8 battleCanTeleportTo(const battle::Unit * stack, BattleHex destHex, int telportLevel) const; //checks if teleportation of given stack to given position can take place
+	std::vector<PossiblePlayerBattleAction> getClientActionsForStack(const CStack * stack, const BattleClientInterfaceData & data);
+	PossiblePlayerBattleAction getCasterAction(const CSpell * spell, const spells::Caster * caster, spells::Mode mode) const;
 
 	//convenience methods using the ones above
 	bool isInTacticRange(BattleHex dest) const;

--- a/lib/battle/CBattleInfoCallback.h
+++ b/lib/battle/CBattleInfoCallback.h
@@ -32,7 +32,7 @@ struct DLL_LINKAGE AttackableTiles
 	}
 };
 
-enum PossiblePlayerBattleAction // actions performed at l-click
+enum class PossiblePlayerBattleAction // actions performed at l-click
 {
 	INVALID = -1, CREATURE_INFO,
 	MOVE_TACTICS, CHOOSE_TACTICS_STACK,


### PR DESCRIPTION
- Somewhat improved cursor handling for battle hexes for client
- Spellcast is now default action for stacks able to perform it (bonus NO_SPELLCAST_BY_DEFAULT negates that)
- Creatures with damaging spells are now able to use them if controlled by BattleAI

Things I am not sure about:
- new method CBattleInfoCallback::getClientActionsForStack - is it proper place for this code?
- what to do with StupidAI spellcasting?