### PR TITLE
Victory crash/freeze fix

### DIFF
--- a/client/CMT.cpp
+++ b/client/CMT.cpp
@@ -1265,6 +1265,7 @@ static void handleEvent(SDL_Event & ev)
 			break;
 		case EUserEvent::CAMPAIGN_START_SCENARIO:
 			{
+				CSH->campaignServerRestartLock.set(true);
 				CSH->endGameplay();
 				auto ourCampaign = std::shared_ptr<CCampaignState>(reinterpret_cast<CCampaignState *>(ev.user.data1));
 				auto & epilogue = ourCampaign->camp->scenarios[ourCampaign->mapsConquered.back()].epilog;
@@ -1281,7 +1282,7 @@ static void handleEvent(SDL_Event & ev)
 				}
 				else
 				{
-					boost::this_thread::sleep(boost::posix_time::milliseconds(1000)); //TODO: thread sync and execute this after server closes
+					CSH->campaignServerRestartLock.waitUntil(false);
 					finisher();
 				}
 			}

--- a/client/CMT.cpp
+++ b/client/CMT.cpp
@@ -1281,6 +1281,7 @@ static void handleEvent(SDL_Event & ev)
 				}
 				else
 				{
+					boost::this_thread::sleep(boost::posix_time::milliseconds(1000)); //TODO: thread sync and execute this after server closes
 					finisher();
 				}
 			}

--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -2467,12 +2467,16 @@ void CPlayerInterface::showShipyardDialogOrProblemPopup(const IShipyard *obj)
 
 void CPlayerInterface::requestReturningToMainMenu(bool won)
 {
-	CSH->state = EClientState::DISCONNECTING;
 	CCS->soundh->ambientStopAllChannels();
 	if(won && cb->getStartInfo()->campState)
+	{
+		CSH->state = EClientState::DISCONNECTING; // do not close server, it's not intended for campaign continuation
 		CSH->startCampaignScenario(cb->getStartInfo()->campState);
+	}
 	else
+	{
 		sendCustomEvent(EUserEvent::RETURN_TO_MAIN_MENU);
+	}
 }
 
 void CPlayerInterface::sendCustomEvent( int code )

--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -2469,14 +2469,9 @@ void CPlayerInterface::requestReturningToMainMenu(bool won)
 {
 	CCS->soundh->ambientStopAllChannels();
 	if(won && cb->getStartInfo()->campState)
-	{
-		CSH->state = EClientState::DISCONNECTING; // do not close server, it's not intended for campaign continuation
 		CSH->startCampaignScenario(cb->getStartInfo()->campState);
-	}
 	else
-	{
 		sendCustomEvent(EUserEvent::RETURN_TO_MAIN_MENU);
-	}
 }
 
 void CPlayerInterface::sendCustomEvent( int code )

--- a/client/CServerHandler.cpp
+++ b/client/CServerHandler.cpp
@@ -101,7 +101,7 @@ public:
 extern std::string NAME;
 
 CServerHandler::CServerHandler()
-	: state(EClientState::NONE), mx(std::make_shared<boost::recursive_mutex>()), client(nullptr), loadMode(0), campaignStateToSend(nullptr)
+	: state(EClientState::NONE), mx(std::make_shared<boost::recursive_mutex>()), client(nullptr), loadMode(0), campaignStateToSend(nullptr), campaignServerRestartLock(false)
 {
 	uuid = boost::uuids::to_string(boost::uuids::random_generator()());
 	applier = std::make_shared<CApplier<CBaseForLobbyApply>>();
@@ -692,6 +692,7 @@ void CServerHandler::threadRunServer()
 		logNetwork->error("Check %s for more info", logName);
 	}
 	threadRunLocalServer.reset();
+	CSH->campaignServerRestartLock.setn(false);
 #endif
 }
 

--- a/client/CServerHandler.cpp
+++ b/client/CServerHandler.cpp
@@ -495,6 +495,7 @@ void CServerHandler::endGameplay(bool closeConnection, bool restart)
 	{
 		if(CMM)
 		{
+			GH.terminate_cond->setn(false);
 			GH.curInt = CMM.get();
 			CMM->enable();
 		}
@@ -644,6 +645,7 @@ void CServerHandler::threadHandleConnection()
 			logNetwork->error(e.what());
 			if(client)
 			{
+				state = EClientState::DISCONNECTING;
 				CGuiHandler::pushSDLEvent(SDL_USEREVENT, EUserEvent::RETURN_TO_MAIN_MENU);
 			}
 			else

--- a/client/CServerHandler.h
+++ b/client/CServerHandler.h
@@ -12,6 +12,7 @@
 #include "../lib/CStopWatch.h"
 
 #include "../lib/StartInfo.h"
+#include "../lib/CondSh.h"
 
 struct SharedMemory;
 class CConnection;
@@ -94,6 +95,8 @@ public:
 
 	std::shared_ptr<CConnection> c;
 	CClient * client;
+
+	CondSh<bool> campaignServerRestartLock;
 
 	CServerHandler();
 

--- a/client/mainmenu/CMainMenu.cpp
+++ b/client/mainmenu/CMainMenu.cpp
@@ -352,7 +352,7 @@ std::shared_ptr<CMainMenu> CMainMenu::create()
 	if(!CMM)
 		CMM = std::shared_ptr<CMainMenu>(new CMainMenu());
 
-	GH.terminate_cond->set(false);
+	GH.terminate_cond->setn(false);
 	return CMM;
 }
 

--- a/server/CVCMIServer.cpp
+++ b/server/CVCMIServer.cpp
@@ -191,6 +191,8 @@ void CVCMIServer::run()
 	{
 		gh->run(si->mode == StartInfo::LOAD_GAME);
 	}
+	while(state == EServerState::GAMEPLAY_ENDED)
+		boost::this_thread::sleep(boost::posix_time::milliseconds(50));
 }
 
 void CVCMIServer::threadAnnounceLobby()


### PR DESCRIPTION
This PR fixes bugs that cause crashes/freezes on scenario/campaign map win. Default handling for lost connection changed to avoid crash (do not try to close server). Changing server state to GAMEPLAY_ENDED is properly handled, it left server in unstable state before, causing unavoidable assert failure. And last, thread synchronization has been made between closing server and restarting it for next campaign mission. I guess it can be implemented to work for every server close/start case in the code, so client cannot join exiting server, but I did not dig into it.

Tl;dr: Map finish problems fixed, campaigns work again.