### PR TITLE
Fix crash caused by FuzzyLite destructor

### DIFF
--- a/AI/VCAI/FuzzyEngines.cpp
+++ b/AI/VCAI/FuzzyEngines.cpp
@@ -23,7 +23,8 @@ extern FuzzyHelper * fh;
 
 engineBase::engineBase()
 {
-	engine.addRuleBlock(&rules);
+	rules = new fl::RuleBlock();
+	engine.addRuleBlock(rules);
 }
 
 void engineBase::configure()
@@ -34,7 +35,7 @@ void engineBase::configure()
 
 void engineBase::addRule(const std::string & txt)
 {
-	rules.addRule(fl::Rule::parse(txt, &engine));
+	rules->addRule(fl::Rule::parse(txt, &engine));
 }
 
 struct armyStructure

--- a/AI/VCAI/FuzzyEngines.h
+++ b/AI/VCAI/FuzzyEngines.h
@@ -17,7 +17,7 @@ class engineBase //subclasses create fuzzylite variables with "new" that are not
 {
 protected:
 	fl::Engine engine;
-	fl::RuleBlock rules;
+	fl::RuleBlock * rules;
 	virtual void configure();
 	void addRule(const std::string & txt);
 public:


### PR DESCRIPTION
Crash was happening on map restart request after AI passes its turn. Initiated by AIPathfinder::init() - clearing of vectors holding AINodeStorage variable. AINodeStorage contains std::unique_ptr<FuzzyHelper> dangerEvaluator, which couldn't be cleared properly, and the top frames of call stack pointed to FuzzyLite's destructors. I think I solved problem, the solution I submit is based on analyzing Engine class destructor - https://github.com/fuzzylite/fuzzylite/blob/release/fuzzylite/src/Engine.cpp#L96 (I used FuzzyLite without debug info). Playtesting shows me that there is no ingame crash anymore after this change.

I did not perform memory leak testing though to confirm if the fix is correct.