### PR TITLE
Add missing header

### DIFF
--- a/client/widgets/AdventureMapClasses.cpp
+++ b/client/widgets/AdventureMapClasses.cpp
@@ -23,6 +23,7 @@
 #include "../CMessage.h"
 
 #include "../gui/CGuiHandler.h"
+#include "../gui/SDL_Compat.h"
 #include "../gui/SDL_Pixels.h"
 
 #include "../widgets/Images.h"


### PR DESCRIPTION
This fixes the error I got while trying to build from source:
```
client/widgets/AdventureMapClasses.cpp:195:28: error: ‘SDLX_Size’ was not declared in this scope
```