### PR TITLE
Fix crash on game quit

### DIFF
--- a/client/CMusicHandler.cpp
+++ b/client/CMusicHandler.cpp
@@ -61,11 +61,10 @@ void CAudioBase::init()
 
 void CAudioBase::release()
 {
-	if (initialized)
-	{
+	if(!(CCS->soundh->initialized && CCS->musich->initialized))
 		Mix_CloseAudio();
-		initialized = false;
-	}
+
+	initialized = false;
 }
 
 void CAudioBase::setVolume(ui32 percent)


### PR DESCRIPTION
With recent version of SDL mixer game still crashes. This PR contains fix, crash was caused by using mixer functions when releasing soundhandler after callling Mix_CloseAudio, which should be last mixer function used in application.