### PR TITLE
Hackfix crash on "victory by town capture"

### DIFF
--- a/lib/mapObjects/CGTownInstance.cpp
+++ b/lib/mapObjects/CGTownInstance.cpp
@@ -679,6 +679,11 @@ void CGTownInstance::onHeroVisit(const CGHeroInstance * h) const
 		else
 		{
 			cb->setOwner(this, h->tempOwner);
+			if(cb->gameState()->getPlayerStatus(h->getOwner()) == EPlayerStatus::WINNER)
+			{
+				return; //we just won game, we do not need to perform any extra actions
+				//TODO: check how does H3 behave, visiting town on victory can affect campaigns (spells learned, +1 stat building visited)
+			}
 			removeCapitols(h->getOwner());
 			cb->heroVisitCastle(this, h);
 		}


### PR DESCRIPTION
I have no idea for better fix for this issue (separation of concerns is messed up anyway). The problem makes it impossible to properly win maps that rely on town capture to finish them. The reason is that town visit request is sent straight after request to end gameplay.