### PR TITLE
Fixed wrongCursorOnFriendlyDwelling

### DIFF
--- a/client/windows/CAdvmapInterface.cpp
+++ b/client/windows/CAdvmapInterface.cpp
@@ -1755,6 +1755,8 @@ void CAdvMapInt::tileHovered(const int3 &mapPos)
 					CCS->curh->changeGraphic(ECursor::ADVENTURE, 3);
 				else if(objAtTile->ID == Obj::HERO && objRelations == PlayerRelations::SAME_PLAYER)
 					CCS->curh->changeGraphic(ECursor::ADVENTURE, 2);
+				else
+					CCS->curh->changeGraphic(ECursor::ADVENTURE, 0);
 			}
 			else
 				CCS->curh->changeGraphic(ECursor::ADVENTURE, 0);


### PR DESCRIPTION
Added `else` condition that covers cases "ObjectAtTile that is not enemy nor is Town nor is current Hero". 
This should cover all cases of friendly dwellings/mines not having the correct cursor.