### PR TITLE
Fix wrong savefiles shown while playing Hotseat Mode

### DIFF
--- a/client/CServerHandler.cpp
+++ b/client/CServerHandler.cpp
@@ -541,7 +541,7 @@ ui8 CServerHandler::getLoadMode()
 			if(pn.second.connection != c->connectionID)
 				return ELoadMode::MULTI;
 		}
-		if (howManyPlayerInterfaces() > 1)  //this condition will work for hotseat mode OR multiplayer with allowed more than 1 color per player to control
+		if(howManyPlayerInterfaces() > 1)  //this condition will work for hotseat mode OR multiplayer with allowed more than 1 color per player to control
 			return ELoadMode::MULTI;
 
 		return ELoadMode::SINGLE;

--- a/client/CServerHandler.cpp
+++ b/client/CServerHandler.cpp
@@ -541,6 +541,8 @@ ui8 CServerHandler::getLoadMode()
 			if(pn.second.connection != c->connectionID)
 				return ELoadMode::MULTI;
 		}
+		if (howManyPlayerInterfaces() > 1)  //this condition will work for hotseat mode OR multiplayer with allowed more than 1 color per player to control
+			return ELoadMode::MULTI;
 
 		return ELoadMode::SINGLE;
 	}


### PR DESCRIPTION
Previous condition only checked for players' connection ID. 
HotSeat mode does not use multiple connection IDs, so `getLoadMode()` thought it was SPMode.
Now checking number of interfaces to cover offline-multiplayer.