### PR TITLE
Ewilhan fix neutral creatures growth week

### DIFF
--- a/lib/CCreatureHandler.cpp
+++ b/lib/CCreatureHandler.cpp
@@ -92,6 +92,16 @@ bool CCreature::isEvil () const
 	return VLC->townh->factions[faction]->alignment == EAlignment::EVIL;
 }
 
+/**
+ * Determines if the creature is of a neutral alignment.
+ * @return true if the creature is neutral, false otherwise.
+ */
+bool CCreature::isNeutral() const
+{
+	return VLC->townh->factions[faction]->alignment == EAlignment::NEUTRAL;
+}
+
+
 si32 CCreature::maxAmount(const std::vector<si32> &res) const //how many creatures can be bought
 {
 	int ret = 2147483645;

--- a/lib/CCreatureHandler.h
+++ b/lib/CCreatureHandler.h
@@ -121,6 +121,7 @@ public:
 	bool isUndead() const; //returns true if unit is undead
 	bool isGood () const;
 	bool isEvil () const;
+	bool isNeutral() const;
 	si32 maxAmount(const std::vector<si32> &res) const; //how many creatures can be bought
 	static int getQuantityID(const int & quantity); //1 - a few, 2 - several, 3 - pack, 4 - lots, 5 - horde, 6 - throng, 7 - swarm, 8 - zounds, 9 - legion
 	static int estimateCreatureCount(ui32 countID); //reverse version of above function, returns middle of range

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -1673,8 +1673,11 @@ void CGameHandler::newTurn()
 				if (monthType < 25)
 				{
 					n.specialWeek = NewTurn::BONUS_GROWTH; //+5
-					std::pair<int, CreatureID> newMonster(54, VLC->creh->pickRandomMonster(getRandomGenerator()));
-					//TODO do not pick neutrals
+					std::pair<int, CreatureID> newMonster(54, 0);
+					do
+					{
+						newMonster.second = VLC->creh->pickRandomMonster(getRandomGenerator());
+					} while (VLC->creh->creatures[newMonster.second] && VLC->creh->creatures[newMonster.second]->isNeutral()); // find first non neutral creature
 					n.creatureid = newMonster.second;
 				}
 			}


### PR DESCRIPTION
Changed the RNG so that Neutral Creatures cannot have Growth Weeks.
Made it so a new monster is generated until a non-neutral monster is chosen.
Also, added a `isNeutral()` function to `CCreature`, in line with already existing `isGood()` and `isEvil()`.

Fixes [#3046](https://bugs.vcmi.eu/view.php?id=3046).