### PR TITLE
Fix Neutral Creatures Weekly Growth

### DIFF
--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -1673,8 +1673,12 @@ void CGameHandler::newTurn()
 				if (monthType < 25)
 				{
 					n.specialWeek = NewTurn::BONUS_GROWTH; //+5
-					std::pair<int, CreatureID> newMonster(54, VLC->creh->pickRandomMonster(getRandomGenerator()));
-					//TODO do not pick neutrals
+					std::pair<int, CreatureID> newMonster(54, CreatureID());
+					do
+					{
+						newMonster.second = VLC->creh->pickRandomMonster(getRandomGenerator());
+					} while (VLC->creh->creatures[newMonster.second] &&
+						VLC->townh->factions[VLC->creh->creatures[newMonster.second]->faction]->town == nullptr); // find first non neutral creature
 					n.creatureid = newMonster.second;
 				}
 			}


### PR DESCRIPTION
Made it so neutral creatures could not be picked as "Flavour of the Week".
It is checking neutral creatures hometown to do so.

Fixes [#3046](https://bugs.vcmi.eu/view.php?id=3046).