### PR TITLE
Fix "unmutable" game

### DIFF
--- a/client/CMusicHandler.cpp
+++ b/client/CMusicHandler.cpp
@@ -175,7 +175,7 @@ int CSoundHandler::ambientDistToVolume(int distance) const
 void CSoundHandler::ambientStopSound(std::string soundId)
 {
 	stopSound(ambientChannels[soundId]);
-	setChannelVolume(ambientChannels[soundId], 100);
+	setChannelVolume(ambientChannels[soundId], volume);
 }
 
 // Plays a sound, and return its channel so we can fade it out later


### PR DESCRIPTION
After a background music change, now set volume correctly instead of setting it to 100.

Fixes [#3050](https://bugs.vcmi.eu/view.php?id=3050).