### PR TITLE
Fixed Battle Creature Ordering

### DIFF
--- a/lib/battle/BattleInfo.cpp
+++ b/lib/battle/BattleInfo.cpp
@@ -804,7 +804,6 @@ void BattleInfo::addUnit(uint32_t id, const JsonNode & data)
 void BattleInfo::moveUnit(uint32_t id, BattleHex destination)
 {
 	auto sta = getStack(id);
-
 	if(!sta)
 	{
 		logGlobal->error("Cannot find stack %d", id);
@@ -1063,28 +1062,38 @@ bool CMP_stack::operator()(const battle::Unit * a, const battle::Unit * b)
 			int as = a->getInitiative(turn), bs = b->getInitiative(turn);
 			if(as != bs)
 				return as > bs;
-			else
-				return a->unitSlot() < b->unitSlot(); //FIXME: what about summoned stacks?
-		}
+			else if(as == bs)
+			{
+				if(a->unitSide() == b->unitSide())
+					return a->unitSlot() < b->unitSlot();
+				else
+					return a->unitSide() == side ? false : true;
+			}
+			//FIXME: what about summoned stacks
+		}	
 	case 2: //fastest last, upper slot first
-		//TODO: should be replaced with order of receiving morale!
 	case 3: //fastest last, upper slot first
 		{
 			int as = a->getInitiative(turn), bs = b->getInitiative(turn);
 			if(as != bs)
-				return as < bs;
-			else
-				return a->unitSlot() < b->unitSlot();
+				return as > bs;
+			else if(as == bs)
+			{
+				if(a->unitSide() == b->unitSide())
+					return a->unitSlot() < b->unitSlot();
+				else
+					return a->unitSide() == side ? false : true;
+			}
 		}
 	default:
 		assert(0);
 		return false;
 	}
-
 }
 
-CMP_stack::CMP_stack(int Phase, int Turn)
+CMP_stack::CMP_stack(int Phase, int Turn, int Side)
 {
 	phase = Phase;
 	turn = Turn;
+	side = Side;
 }

--- a/lib/battle/BattleInfo.cpp
+++ b/lib/battle/BattleInfo.cpp
@@ -1062,7 +1062,7 @@ bool CMP_stack::operator()(const battle::Unit * a, const battle::Unit * b)
 			int as = a->getInitiative(turn), bs = b->getInitiative(turn);
 			if(as != bs)
 				return as > bs;
-			else if(as == bs)
+			else
 			{
 				if(a->unitSide() == b->unitSide())
 					return a->unitSlot() < b->unitSlot();
@@ -1077,7 +1077,7 @@ bool CMP_stack::operator()(const battle::Unit * a, const battle::Unit * b)
 			int as = a->getInitiative(turn), bs = b->getInitiative(turn);
 			if(as != bs)
 				return as > bs;
-			else if(as == bs)
+			else
 			{
 				if(a->unitSide() == b->unitSide())
 					return a->unitSlot() < b->unitSlot();
@@ -1091,7 +1091,7 @@ bool CMP_stack::operator()(const battle::Unit * a, const battle::Unit * b)
 	}
 }
 
-CMP_stack::CMP_stack(int Phase, int Turn, int Side)
+CMP_stack::CMP_stack(int Phase, int Turn, uint8_t Side)
 {
 	phase = Phase;
 	turn = Turn;

--- a/lib/battle/BattleInfo.h
+++ b/lib/battle/BattleInfo.h
@@ -144,9 +144,9 @@ class DLL_LINKAGE CMP_stack
 {
 	int phase; //rules of which phase will be used
 	int turn;
-	bool side;
+	uint8_t side;
 public:
 
 	bool operator ()(const battle::Unit * a, const battle::Unit * b);
-	CMP_stack(int Phase = 1, int Turn = 0, int Side = BattleSide::ATTACKER);
+	CMP_stack(int Phase = 1, int Turn = 0, uint8_t Side = BattleSide::ATTACKER);
 };

--- a/lib/battle/BattleInfo.h
+++ b/lib/battle/BattleInfo.h
@@ -144,8 +144,9 @@ class DLL_LINKAGE CMP_stack
 {
 	int phase; //rules of which phase will be used
 	int turn;
+	bool side;
 public:
 
 	bool operator ()(const battle::Unit * a, const battle::Unit * b);
-	CMP_stack(int Phase = 1, int Turn = 0);
+	CMP_stack(int Phase = 1, int Turn = 0, int Side = BattleSide::ATTACKER);
 };

--- a/lib/battle/CBattleInfoCallback.cpp
+++ b/lib/battle/CBattleInfoCallback.cpp
@@ -367,7 +367,7 @@ const T * takeOneUnit(std::vector<const T*> & all, const int turn, int8_t & last
 		if(all[i])
 		{
 			currentUnitSpeed = all[i]->getInitiative(turn);
-			switch (phase)
+			switch(phase)
 			{
 			case 1: // Faster first, attacker priority, higher slot first
 				if(returnedUnit == nullptr || currentUnitSpeed > returnedUnitSpeed)
@@ -513,7 +513,9 @@ void CBattleInfoCallback::battleGetTurnOrder(std::vector<battle::Units> & out, c
 		{
 			current = takeOneUnit(phase[pi], actualTurn, lastMoved, pi);
 			if(!current)
+			{
 				pi++;
+			}
 			else
 			{
 				out.back().push_back(current);
@@ -522,7 +524,7 @@ void CBattleInfoCallback::battleGetTurnOrder(std::vector<battle::Units> & out, c
 		}
 	}
 
-	if (lastMoved < 0)
+	if(lastMoved < 0)
 		lastMoved = BattleSide::ATTACKER;
 
 	if(!outputFull() && (maxTurns == 0 || out.size() < maxTurns))


### PR DESCRIPTION
Fixed the messy creature order. It now follows correct ordering.

Fixes [#2837](https://bugs.vcmi.eu/view.php?id=2837).

(PS : I also removed a TODO that was wrong. Waiting moraled creatures follow the same "Slower first higher slot first" pattern as waiting creatures.)