### PR TITLE
Remove false warning indicating something is wrong

### DIFF
--- a/client/battle/CBattleInterface.cpp
+++ b/client/battle/CBattleInterface.cpp
@@ -792,8 +792,11 @@ void CBattleInterface::bSurrenderf()
 	if (cost >= 0)
 	{
 		std::string enemyHeroName = curInt->cb->battleGetEnemyHero().name;
-		if (enemyHeroName.empty())
-			enemyHeroName = "#ENEMY#"; //TODO: should surrendering without enemy hero be enabled?
+		if(enemyHeroName.empty())
+		{
+			logGlobal->warn("Surrender performed without enemy hero, should not happen!");
+			enemyHeroName = "#ENEMY#";
+		}
 
 		std::string surrenderMessage = boost::str(boost::format(CGI->generaltexth->allTexts[32]) % enemyHeroName % cost); //%s states: "I will accept your surrender and grant you and your troops safe passage for the price of %d gold."
 		curInt->showYesNoDialog(surrenderMessage, [this](){ reallySurrender(); }, nullptr);

--- a/lib/battle/CBattleInfoEssentials.cpp
+++ b/lib/battle/CBattleInfoEssentials.cpp
@@ -241,7 +241,6 @@ InfoAboutHero CBattleInfoEssentials::battleGetHeroInfo(ui8 side) const
 	auto hero = getBattle()->getSideHero(side);
 	if(!hero)
 	{
-		logGlobal->warn("%s: side %d does not have hero!", __FUNCTION__, static_cast<int>(side));
 		return InfoAboutHero();
 	}
 	InfoAboutHero::EInfoLevel infoLevel = battleDoWeKnowAbout(side) ? InfoAboutHero::EInfoLevel::DETAILED : InfoAboutHero::EInfoLevel::BASIC;


### PR DESCRIPTION
Removed unnecessary warning, and added new one in place where old warning could theoretically make sense. Warning was spamming console after each battle without enemy hero due to casualties window deciding who to put as enemy on upper corner based on presence of enemy hero info.