### PR TITLE
Ensure no freeze on AI interruption

### DIFF
--- a/AI/VCAI/VCAI.cpp
+++ b/AI/VCAI/VCAI.cpp
@@ -2447,6 +2447,8 @@ void VCAI::recruitHero(const CGTownInstance * t, bool throwing)
 
 void VCAI::finish()
 {
+	//we want to lock to avoid multiple threads from calling makingTurn->join() at same time
+	boost::lock_guard<boost::mutex> multipleCleanupGuard(turnInterruptionMutex);
 	if(makingTurn)
 	{
 		makingTurn->interrupt();

--- a/AI/VCAI/VCAI.h
+++ b/AI/VCAI/VCAI.h
@@ -112,6 +112,9 @@ public:
 	std::shared_ptr<CCallback> myCb;
 
 	std::unique_ptr<boost::thread> makingTurn;
+private:
+	boost::mutex turnInterruptionMutex;
+public:
 	ObjectInstanceID selectedObject;
 
 	AIhelper * ah;

--- a/Global.h
+++ b/Global.h
@@ -167,6 +167,8 @@ static_assert(sizeof(bool) == 1, "Bool needs to be 1 byte in size.");
 #  define BOOST_THREAD_VERSION 3
 #endif
 #define BOOST_THREAD_DONT_PROVIDE_THREAD_DESTRUCTOR_CALLS_TERMINATE_IF_JOINABLE 1
+//need to link boost thread dynamically to avoid https://stackoverflow.com/questions/35978572/boost-thread-interupt-does-not-work-when-crossing-a-dll-boundary
+#define BOOST_THREAD_USE_DLL //for example VCAI::finish() may freeze on thread join after interrupt when linking this statically
 #define BOOST_BIND_NO_PLACEHOLDERS
 
 #if defined(_MSC_VER) && (_MSC_VER == 1900 || _MSC_VER == 1910 || _MSC_VER == 1911)


### PR DESCRIPTION
1. Force linking boost thread dynamically to avoid https://stackoverflow.com/questions/35978572/boost-thread-interupt-does-not-work-when-crossing-a-dll-boundary

2. Fix theoretical possible freeze on two threads trying to join AI makingTurn thread.