### PR TITLE
AI: blind fix for 3062

### DIFF
--- a/AI/VCAI/Goals/GatherTroops.cpp
+++ b/AI/VCAI/Goals/GatherTroops.cpp
@@ -138,7 +138,8 @@ TGoalVec GatherTroops::getAllPossibleSubgoals()
 
 	CreatureID creID = CreatureID(objid);
 
-	vstd::erase_if(solutions, [&](TSubgoal goal)->bool{
+	vstd::erase_if(solutions, [&](TSubgoal goal)->bool
+	{
 		return goal->hero && !goal->hero->getSlotFor(creID).validSlot() && !goal->hero->getFreeSlot().validSlot();
 	});
 

--- a/AI/VCAI/Goals/GatherTroops.cpp
+++ b/AI/VCAI/Goals/GatherTroops.cpp
@@ -115,6 +115,7 @@ TGoalVec GatherTroops::getAllPossibleSubgoals()
 			}*/
 		}
 	}
+
 	for(auto obj : ai->visitableObjs)
 	{
 		auto d = dynamic_cast<const CGDwelling *>(obj);
@@ -134,6 +135,12 @@ TGoalVec GatherTroops::getAllPossibleSubgoals()
 			}
 		}
 	}
+
+	CreatureID creID = CreatureID(objid);
+
+	vstd::erase_if(solutions, [&](TSubgoal goal)->bool{
+		return goal->hero && !goal->hero->getSlotFor(creID).validSlot() && !goal->hero->getFreeSlot().validSlot();
+	});
 
 	return solutions;
 	//TODO: exchange troops between heroes


### PR DESCRIPTION
Blind fix. According to the logs mechanic of the bug is the next
GatherTroops checks towns for required creature
GatherTroops selects a hero to pick creatures
Hero goes to required target for instance town
Town->Hero exchange logic refuses to pick required creatures because it knows nothing about the quest and the stack is weak and there is no free slot
Infinite loop