### PR TITLE
Revert old statusbar hackfix

### DIFF
--- a/client/widgets/TextControls.cpp
+++ b/client/widgets/TextControls.cpp
@@ -376,11 +376,6 @@ CGStatusBar::CGStatusBar(int x, int y, std::string name, int maxw)
 	autoRedraw = false;
 }
 
-CGStatusBar::~CGStatusBar()
-{
-	GH.statusbar = oldStatusBar;
-}
-
 void CGStatusBar::show(SDL_Surface * to)
 {
 	showAll(to);
@@ -388,7 +383,6 @@ void CGStatusBar::show(SDL_Surface * to)
 
 void CGStatusBar::init()
 {
-	oldStatusBar = GH.statusbar;
 	GH.statusbar = shared_from_this();
 }
 

--- a/client/widgets/TextControls.h
+++ b/client/widgets/TextControls.h
@@ -119,8 +119,6 @@ class CGStatusBar : public CLabel, public std::enable_shared_from_this<CGStatusB
 	bool textLock; //Used for blocking changes to the text
 	void init();
 
-	std::shared_ptr<CGStatusBar> oldStatusBar;
-
 	CGStatusBar(std::shared_ptr<CPicture> background_, EFonts Font = FONT_SMALL, EAlignment Align = CENTER, const SDL_Color & Color = Colors::WHITE);
 	CGStatusBar(int x, int y, std::string name, int maxw = -1);
 protected:
@@ -138,8 +136,6 @@ public:
 	void setText(const std::string & Text) override; //prints text and refreshes statusbar
 
 	void show(SDL_Surface * to) override; //shows statusbar (with current text)
-
-	~CGStatusBar();
 
 	void lock(bool shouldLock); //If true, current text cannot be changed until lock(false) is called
 };


### PR DESCRIPTION
My old fix started crashing the game, probably because some code at some point magically fixed statusbar to make it work as intended.