### PR TITLE
Break Visual Studio 2015 support

### DIFF
--- a/CI/appveyor.yml
+++ b/CI/appveyor.yml
@@ -74,9 +74,9 @@ for:
       - coverity_scan
   environment:
     matrix:
-      - NAME: Coverity - MSVS 2015 x86 - Release
-        APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-        VCMI_GENERATOR: Visual Studio 14 2015
+      - NAME: Coverity - MSVS 2017 x86 - Release
+        APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+        VCMI_GENERATOR: Visual Studio 15 2017
         VCMI_BUILD_PLATFORM: x86
         VCMI_BUILD_CONFIGURATION: Release
         environment:
@@ -93,9 +93,9 @@ for:
 -
   environment:
     matrix:
-      - NAME: MSVS 2015 x86 - Release
-        APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-        VCMI_GENERATOR: Visual Studio 14 2015
+      - NAME: MSVS 2017 x86 - Release
+        APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+        VCMI_GENERATOR: Visual Studio 15 2017
         VCMI_BUILD_PLATFORM: x86
         VCMI_BUILD_CONFIGURATION: Release
       - NAME: MSVS 2017 x64 - Release

--- a/CI/msvc/install.sh
+++ b/CI/msvc/install.sh
@@ -4,7 +4,7 @@ git submodule update --init --recursive
 cd ..
 
 curl -LfsS -o "vcpkg-export-${VCMI_BUILD_PLATFORM}-windows-v140.7z" \
-	"https://github.com/vcmi/vcmi-deps-windows/releases/download/v1/vcpkg-export-${VCMI_BUILD_PLATFORM}-windows-v140.7z"
+	"https://github.com/vcmi/vcmi-deps-windows/releases/download/v1.2/vcpkg-export-${VCMI_BUILD_PLATFORM}-windows-v140.7z"
 7z x "vcpkg-export-${VCMI_BUILD_PLATFORM}-windows-v140.7z"
 
 cd $APPVEYOR_BUILD_FOLDER


### PR DESCRIPTION
There are various reasons to stop trying to keep Visual Studio 2015 compatibility currently. One of them is uncompilable and "hard to fix" code in incoming scripting branch. This branch swaps appveyor 32 bit build compiler to VS 2017 for relevant use cases.

After this branch gets merged there are two things to do:
1. Update wiki to match removing VS 2015 support in "how to build" instructions
2. Consider upgrading allowed C++ standard, currently we support C++11, though without explicit mentioning of some C++11 features that are still broken in some toolsets such as VS 2015. I created some notes here, which will help in deciding when extending allowed C++ features for VCMI code: https://wiki.vcmi.eu/User:Dydzio/cpp_standard_upgrade

Adding VS 2019 to appveyor is out of scope of this PR, it should be done separately later, also requires updating Qt in dependencies package since VS 2019 finds code error in currently provided Qt version.

This branch is supposed to be merged into develop before handlersAbstraction branch