### PR TITLE
[3085] - MapObjectEvaluator crashes on custom monolith

### DIFF
--- a/AI/VCAI/MapObjectsEvaluator.cpp
+++ b/AI/VCAI/MapObjectsEvaluator.cpp
@@ -26,7 +26,7 @@ MapObjectsEvaluator::MapObjectsEvaluator()
 		for(auto secondaryID : VLC->objtypeh->knownSubObjects(primaryID))
 		{
 			auto handler = VLC->objtypeh->getHandlerFor(primaryID, secondaryID);
-			if(!handler->isStaticObject())
+			if(handler && !handler->isStaticObject())
 			{
 				if(handler->getAiValue() != boost::none)
 				{


### PR DESCRIPTION
MapObjectEvaluator crashes on custom monolith because
VLC->objtypeh->getHandlerFor(primaryID, secondaryID)
returns NULL
Primary ID: 45, Secondary ID: 8