### PR TITLE
Fix fullscreen map mouse scrolling

### DIFF
--- a/client/windows/CAdvmapInterface.cpp
+++ b/client/windows/CAdvmapInterface.cpp
@@ -568,6 +568,7 @@ CAdvMapInt::CAdvMapInt():
 	pos.x = pos.y = 0;
 	pos.w = screen->w;
 	pos.h = screen->h;
+	strongInterest = true; // handle all mouse move events to prevent dead mouse move space in fullscreen mode
 	townList.onSelect = std::bind(&CAdvMapInt::selectionChanged,this);
 	bg = BitmapHandler::loadBitmap(ADVOPT.mainGraphic);
 	if (ADVOPT.worldViewGraphic != "")


### PR DESCRIPTION
Defect:
In fullscreen mode, when the adventure window size does not fill the entire monitor (leaving black bars on each side), mouse movement is ignored in these areas. This results in difficulty scrolling the map in fullscreen mode, since you have to be exactly within [0,15] of the edge of the adventure window (black bars on each side are dead mouse space).

Fix:
Have the adventure map element, CAdvMapInt, subscribe to all mouse move events by setting the `strongInterest` bool to true. This will extend the scroll region to [min, 15] on the left and [texture_width-15, max] on the right, eliminating the dead mouse move space on the side of the window.

Notes:
Impacts adventure window mouse move event handling. Manually validated the scrolling the map now works without having to precisely aim for the edge of the window.