### PR TITLE
More mouse scrolling fixes

### DIFF
--- a/client/windows/CAdvmapInterface.cpp
+++ b/client/windows/CAdvmapInterface.cpp
@@ -1455,7 +1455,8 @@ void CAdvMapInt::mouseMoved( const SDL_MouseMotionEvent & sEvent )
 #endif
 	// adventure map scrolling with mouse
 	// currently disabled in world view mode (as it is in OH3), but should work correctly if mode check is removed
-	if(!isCtrlKeyDown() &&  isActive() && mode == EAdvMapMode::NORMAL)
+	// don't scroll if there is no window in focus - these events don't seem to correspond to the actual mouse movement
+	if(!isCtrlKeyDown() && isActive() && sEvent.windowID != 0 && mode == EAdvMapMode::NORMAL)
 	{
 		if(sEvent.x<15)
 		{


### PR DESCRIPTION
Defect:
After my previous change that enabled the map layer (`CAdvMapInt`) to listen to all mouse move events via `strongInterest` bool, I noticed that there are a few scenarios that start scrolling the map unexpectedly. The two that were the easiest to reproduce were using keyboard arrows to move the hero or dismissing a popup dialog.

I traced this down to unexpected mouse move event (`SDL_MouseMotionEvent`) that SDL seems to dispatch in this situation. The windowID that comes with the event in this scenario is 0 (so no window with mouse focus). I don't know why SDL dispatches this mysterious (to me) mouse move event in that case (note that there is no actual mouse movement in either repro case).

Fix:
Don't handle the mouse move event if the windowID of the mouse motion event is 0. In a good case (actual mouse movement over the map that should result in a scroll), the windowID is non-zero.

Notes:
Impacts scrolling of the game map. Did some play testing and didn't notice the scrolling not working when expected. The two specific cases where the map would scroll unexpectedly (move a hero with keyboard arrows or dismiss a popup dialog) no longer move the map.