### PR TITLE
Add support for the Android App to notify if the server has been closed

### DIFF
--- a/client/Client.cpp
+++ b/client/Client.cpp
@@ -646,6 +646,14 @@ PlayerColor CClient::getLocalPlayer() const
 }
 
 #ifdef VCMI_ANDROID
+extern "C" JNIEXPORT void JNICALL Java_eu_vcmi_vcmi_NativeMethods_notifyServerClosed(JNIEnv * env, jobject cls)
+{
+	logNetwork->info("Received server closed signal");
+	if (CSH) {
+		CSH->campaignServerRestartLock.setn(false);
+	}
+}
+
 extern "C" JNIEXPORT void JNICALL Java_eu_vcmi_vcmi_NativeMethods_notifyServerReady(JNIEnv * env, jobject cls)
 {
 	logNetwork->info("Received server ready signal");


### PR DESCRIPTION
When winning the campaign there is a lock that waits for the old server to stop before allowing to continue with restarting the server. While the lock was released on PC builds as the server runs differently on Android this was missed making campaigns always hang the app when you win.

This change adds a new native method that can be called from the Android app to signal that the server has stopped, so the client can continue with requesting a new server and showing the new campaign scenatio screen.

Note: this change alone doesn't fix the bug but it's required for a fix on vcmi-android's side. It doesn't break anything and can be merged before the vcmi-android changes. PR for that is https://github.com/vcmi/vcmi-android/pull/9