### PR TITLE
Add Gargoyle Bonus Type

### DIFF
--- a/client/battle/CBattleInterface.cpp
+++ b/client/battle/CBattleInterface.cpp
@@ -2237,6 +2237,7 @@ void CBattleInterface::handleHex(BattleHex myNumber, int eventType)
 				{
 					if (!(shere->hasBonusOfType(Bonus::UNDEAD)
 						|| shere->hasBonusOfType(Bonus::NON_LIVING)
+						|| shere->hasBonusOfType(Bonus::GARGOYLE)
 						|| shere->summoned
 						|| shere->isClone()
 						|| shere->hasBonusOfType(Bonus::SIEGE_WEAPON)

--- a/config/bonuses.json
+++ b/config/bonuses.json
@@ -230,7 +230,15 @@
 			"icon":  "zvs/Lib1.res/E_TROLL"
 		}
 	},
-	
+
+	"GARGOYLE":
+	{
+		"graphics":
+		{
+			"icon":  "zvs/Lib1.res/NonLiving"	// Just use the NonLiving icon for now
+		}
+	},
+
 	"GENERAL_DAMAGE_REDUCTION":
 	{
 		"graphics":

--- a/config/bonuses_texts.json
+++ b/config/bonuses_texts.json
@@ -144,12 +144,6 @@
 		"description": "Ignores part of Defence for the attack"
 	},
 
-	"GENERAL_DAMAGE_REDUCTION":
-	{
-		"name": "Reduce Damage (${val}%)",
-		"description": "Reduces physical damage from ranged or melee"
-	},
-
 	"FIRE_IMMUNITY":
 	{
 		"name": "Fire immunity",
@@ -196,6 +190,18 @@
 	{
 		"name": "Regeneration",
 		"description": "May Regenerate to full Health"
+	},
+
+	"GARGOYLE":
+	{
+		"name": "Gargoyle",
+		"description": "Cannot be rised or healed"
+	},
+
+	"GENERAL_DAMAGE_REDUCTION":
+	{
+		"name": "Reduce Damage (${val}%)",
+		"description": "Reduces physical damage from ranged or melee"
 	},
 
 	"HATE":

--- a/config/creatures/tower.json
+++ b/config/creatures/tower.json
@@ -392,7 +392,7 @@
 			{
 				"type" : "MIND_IMMUNITY"
 			},
-			"hateBlackDragon" : 
+			"hateArchAngels" : 
 			{
 				"type" : "HATE",
 				"subtype" : "creature.blackDragon",

--- a/config/creatures/tower.json
+++ b/config/creatures/tower.json
@@ -51,9 +51,9 @@
 		"faction": "tower",
 		"abilities":
 		{
-			"nonliving" :
+			"gargoyle" :
 			{
-				"type" : "NON_LIVING"
+				"type" : "GARGOYLE"
 			}
 		},
 		"upgrades": ["obsidianGargoyle"],
@@ -77,9 +77,9 @@
 		"faction": "tower",
 		"abilities":
 		{
-			"nonliving" :
+			"gargoyle" :
 			{
-				"type" : "NON_LIVING"
+				"type" : "GARGOYLE"
 			}
 		},
 		"graphics" :
@@ -392,7 +392,7 @@
 			{
 				"type" : "MIND_IMMUNITY"
 			},
-			"hateArchAngels" : 
+			"hateBlackDragon" : 
 			{
 				"type" : "HATE",
 				"subtype" : "creature.blackDragon",

--- a/lib/HeroBonus.cpp
+++ b/lib/HeroBonus.cpp
@@ -643,6 +643,7 @@ bool IBonusBearer::isLiving() const //TODO: theoreticaly there exists "LIVING" b
 	static const std::string cachingStr = "IBonusBearer::isLiving";
 	static const CSelector selector = Selector::type(Bonus::UNDEAD)
 		.Or(Selector::type(Bonus::NON_LIVING))
+		.Or(Selector::type(Bonus::GARGOYLE))
 		.Or(Selector::type(Bonus::SIEGE_WEAPON));
 
 	return !hasBonus(selector, cachingStr);

--- a/lib/HeroBonus.h
+++ b/lib/HeroBonus.h
@@ -175,7 +175,7 @@ public:
 	BONUS_NAME(SPELL_DAMAGE_REDUCTION) /*eg. golems; value - reduction in %, subtype - spell school; -1 - all, 0 - air, 1 - fire, 2 - water, 3 - earth*/ \
 	BONUS_NAME(NO_WALL_PENALTY)							\
 	BONUS_NAME(NON_LIVING) /*eg. golems, cannot be rised or healed, only neutral morale */				\
-    BONUS_NAME(RANDOM_SPELLCASTER) /*eg. master genie, val - level*/ \
+	BONUS_NAME(RANDOM_SPELLCASTER) /*eg. master genie, val - level*/ \
 	BONUS_NAME(BLOCKS_RETALIATION) /*eg. naga*/			\
 	BONUS_NAME(SPELL_IMMUNITY) /*subid - spell id*/		\
 	BONUS_NAME(MANA_CHANNELING) /*value in %, eg. familiar*/ \

--- a/lib/HeroBonus.h
+++ b/lib/HeroBonus.h
@@ -174,8 +174,9 @@ public:
 	BONUS_NAME(TWO_HEX_ATTACK_BREATH) /*eg. dragons*/	\
 	BONUS_NAME(SPELL_DAMAGE_REDUCTION) /*eg. golems; value - reduction in %, subtype - spell school; -1 - all, 0 - air, 1 - fire, 2 - water, 3 - earth*/ \
 	BONUS_NAME(NO_WALL_PENALTY)							\
-	BONUS_NAME(NON_LIVING) /*eg. gargoyle*/				\
-	BONUS_NAME(RANDOM_SPELLCASTER) /*eg. master genie, val - level*/ \
+	BONUS_NAME(NON_LIVING) /*eg. golems, cannot be rised or healed, only neutral morale */				\
+    BONUS_NAME(GARGOYLE) /* gargoyle is special than NON_LIVING, cannot be rised or healed */ \
+    BONUS_NAME(RANDOM_SPELLCASTER) /*eg. master genie, val - level*/ \
 	BONUS_NAME(BLOCKS_RETALIATION) /*eg. naga*/			\
 	BONUS_NAME(SPELL_IMMUNITY) /*subid - spell id*/		\
 	BONUS_NAME(MANA_CHANNELING) /*value in %, eg. familiar*/ \
@@ -271,7 +272,7 @@ public:
 	BONUS_NAME(DESTRUCTION) /*kills extra units after hit, subtype = 0 - kill percentage of units, 1 - kill amount, val = chance in percent to trigger, additional info - amount/percentage to kill*/ \
 	BONUS_NAME(SPECIAL_CRYSTAL_GENERATION) /*crystal dragon crystal generation*/ \
 	BONUS_NAME(NO_SPELLCAST_BY_DEFAULT) /*spellcast will not be default attack option for this creature*/ \
-
+	
 	/* end of list */
 
 

--- a/lib/HeroBonus.h
+++ b/lib/HeroBonus.h
@@ -175,7 +175,6 @@ public:
 	BONUS_NAME(SPELL_DAMAGE_REDUCTION) /*eg. golems; value - reduction in %, subtype - spell school; -1 - all, 0 - air, 1 - fire, 2 - water, 3 - earth*/ \
 	BONUS_NAME(NO_WALL_PENALTY)							\
 	BONUS_NAME(NON_LIVING) /*eg. golems, cannot be rised or healed, only neutral morale */				\
-    BONUS_NAME(GARGOYLE) /* gargoyle is special than NON_LIVING, cannot be rised or healed */ \
     BONUS_NAME(RANDOM_SPELLCASTER) /*eg. master genie, val - level*/ \
 	BONUS_NAME(BLOCKS_RETALIATION) /*eg. naga*/			\
 	BONUS_NAME(SPELL_IMMUNITY) /*subid - spell id*/		\
@@ -272,7 +271,8 @@ public:
 	BONUS_NAME(DESTRUCTION) /*kills extra units after hit, subtype = 0 - kill percentage of units, 1 - kill amount, val = chance in percent to trigger, additional info - amount/percentage to kill*/ \
 	BONUS_NAME(SPECIAL_CRYSTAL_GENERATION) /*crystal dragon crystal generation*/ \
 	BONUS_NAME(NO_SPELLCAST_BY_DEFAULT) /*spellcast will not be default attack option for this creature*/ \
-	
+	BONUS_NAME(GARGOYLE) /* gargoyle is special than NON_LIVING, cannot be rised or healed */ \
+
 	/* end of list */
 
 


### PR DESCRIPTION
Adding a bonus type called GARGOYLE according to document:

Unliving creatures always have neutral morale (except Gargoyles). They are composed of Gargoyles, Golems and Elementals. 
All unliving creatures are immune to Destroy Undead, Animate Dead, Resurrection, and Sacrifice. 
They are also immune to the regeneration ability of the Elixir of Life. 
Of creature abilities they are immune to Archangel’s Resurrection, Ghost Dragon's Aging, Mighty Gorgon's Death Stare, Pit Lord's Demon Summoning, Power Lich's Death Cloud (only adjacent splash damage), Vampire Lord's Life Drain, Wyvern Monarch's Poison.
Gargoyles don't have any other immunities or resistances, but Golems and Elementals do.
