### PR TITLE
Fix bug: LandMine is not exploding when enemy steps on it.

### DIFF
--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -4843,7 +4843,7 @@ bool CGameHandler::handleDamageFromObstacle(const CStack * curStack, bool stackI
 				const bool oneTimeObstacle = spellObstacle->removeOnTrigger;
 
 				//hidden obstacle triggers effects until revealed
-				if(!(spellObstacle->hidden && gs->curB->battleIsObstacleVisibleForSide(*obstacle, (BattlePerspective::BattlePerspective)side)))
+				if(!(spellObstacle->hidden && !spellObstacle->revealed && gs->curB->battleIsObstacleVisibleForSide(*obstacle, (BattlePerspective::BattlePerspective)side)))
 				{
 					const CGHeroInstance * hero = gs->curB->battleGetFightingHero(spellObstacle->casterSide);
 					spells::ObstacleCasterProxy caster(gs->curB->sides.at(spellObstacle->casterSide).color, hero, spellObstacle);


### PR DESCRIPTION
The reason is,
1) the mine has attribute hidden=true;
2) when enemy unit moves, the code in BattleInfo.cpp MoveUnit()  (line 817) will update the revealed to true;
3) then in the CGameHandler.cpp handleDamageFromObstacle() (line 4846) is checking , and the condition battleIsObstacleVisibleForSide() will return true, so the effect will not be triggerred.

I think there are multiple ways to fix it, but if my understanding is correct, from the comment of line 4845 in CGameHandler.cpp, "hidden obstacle triggers effects until revealed", here we should add a condition should add a "!revealed", which means:

IF (hidden && ! revealed && visitable) THEN NOT Trigger effect.