### PR TITLE
Toneyisnow/fixbug putback artifact

### DIFF
--- a/AI/BattleAI/StackWithBonuses.cpp
+++ b/AI/BattleAI/StackWithBonuses.cpp
@@ -177,7 +177,7 @@ void StackWithBonuses::removeUnitBonus(const std::vector<Bonus> & bonus)
 
 void StackWithBonuses::removeUnitBonus(const CSelector & selector)
 {
-	TBonusListPtr toRemove = origBearer->getBonuses(selector);
+	auto toRemove = origBearer->getBonuses(selector);
 
 	for(auto b : *toRemove)
 		bonusesToRemove.insert(b);

--- a/client/widgets/CArtifactHolder.cpp
+++ b/client/widgets/CArtifactHolder.cpp
@@ -312,7 +312,6 @@ void CHeroArtPlace::deselect ()
 {
 	pickSlot(false);
 	selectSlot(false);
-	CBonusSystemNode::treeHasChanged();
 
 	if(ourArt && ourArt->canBeDisassembled()) //combined art returned to its slot -> restore locks
 	{

--- a/client/widgets/CArtifactHolder.cpp
+++ b/client/widgets/CArtifactHolder.cpp
@@ -311,6 +311,9 @@ void CHeroArtPlace::select ()
 void CHeroArtPlace::deselect ()
 {
 	pickSlot(false);
+	selectSlot(false);
+	CBonusSystemNode::treeHasChanged();
+
 	if(ourArt && ourArt->canBeDisassembled()) //combined art returned to its slot -> restore locks
 	{
 		for(int i = 0; i < GameConstants::BACKPACK_START; i++)

--- a/client/windows/CHeroWindow.cpp
+++ b/client/windows/CHeroWindow.cpp
@@ -43,7 +43,9 @@
 const TBonusListPtr CHeroWithMaybePickedArtifact::getAllBonuses(const CSelector & selector, const CSelector & limit, const CBonusSystemNode * root, const std::string & cachingStr) const
 {
 	TBonusListPtr out(new BonusList());
-	TBonusListPtr heroBonuses = hero->getAllBonuses(selector, limit, hero, cachingStr);
+
+	// Fix bug: we are ignoring the cachingStr here, since when pick up and put back the artifact we want to refresh the cache
+	TBonusListPtr heroBonuses = hero->getAllBonuses(selector, limit, hero); 
 	TBonusListPtr bonusesFromPickedUpArtifact;
 
 	std::shared_ptr<CArtifactsOfHero::SCommonPart> cp = cww->getCommonPart();

--- a/client/windows/CHeroWindow.cpp
+++ b/client/windows/CHeroWindow.cpp
@@ -45,7 +45,7 @@ const TBonusListPtr CHeroWithMaybePickedArtifact::getAllBonuses(const CSelector 
 	TBonusListPtr out(new BonusList());
 
 	// Fix bug: we are ignoring the cachingStr here, since when pick up and put back the artifact we want to refresh the cache
-	TBonusListPtr heroBonuses = hero->getAllBonuses(selector, limit, hero); 
+	TBonusListPtr heroBonuses = hero->getAllBonuses(selector, limit, hero);
 	TBonusListPtr bonusesFromPickedUpArtifact;
 
 	std::shared_ptr<CArtifactsOfHero::SCommonPart> cp = cww->getCommonPart();
@@ -54,10 +54,10 @@ const TBonusListPtr CHeroWithMaybePickedArtifact::getAllBonuses(const CSelector 
 	else
 		bonusesFromPickedUpArtifact = TBonusListPtr(new BonusList());
 
-	for(auto b : *bonusesFromPickedUpArtifact)
-		*heroBonuses -= b;
 	for(auto b : *heroBonuses)
 		out->push_back(b);
+	for(auto b : *bonusesFromPickedUpArtifact)
+		*out -= b;
 	return out;
 }
 

--- a/client/windows/CHeroWindow.cpp
+++ b/client/windows/CHeroWindow.cpp
@@ -45,7 +45,7 @@ const TBonusListPtr CHeroWithMaybePickedArtifact::getAllBonuses(const CSelector 
 	TBonusListPtr out(new BonusList());
 
 	// Fix bug: we are ignoring the cachingStr here, since when pick up and put back the artifact we want to refresh the cache
-	TBonusListPtr heroBonuses = hero->getAllBonuses(selector, limit, hero);
+	const TBonusListPtr heroBonuses = hero->getAllBonuses(selector, limit, hero);
 	TBonusListPtr bonusesFromPickedUpArtifact;
 
 	std::shared_ptr<CArtifactsOfHero::SCommonPart> cp = cww->getCommonPart();
@@ -53,7 +53,7 @@ const TBonusListPtr CHeroWithMaybePickedArtifact::getAllBonuses(const CSelector 
 		bonusesFromPickedUpArtifact = cp->src.art->getAllBonuses(selector, limit, hero);
 	else
 		bonusesFromPickedUpArtifact = TBonusListPtr(new BonusList());
-
+	
 	for(auto b : *heroBonuses)
 		out->push_back(b);
 	for(auto b : *bonusesFromPickedUpArtifact)

--- a/lib/CGameState.cpp
+++ b/lib/CGameState.cpp
@@ -1897,7 +1897,7 @@ UpgradeInfo CGameState::getUpgradeInfo(const CStackInstance &stack)
 		t = static_cast<const CGTownInstance *>(stack.armyObj);
 	else if(h)
 	{	//hero specialty
-		TBonusListPtr lista = h->getBonuses(Selector::typeSubtype(Bonus::SPECIAL_UPGRADE, base->idNumber));
+		auto lista = h->getBonuses(Selector::typeSubtype(Bonus::SPECIAL_UPGRADE, base->idNumber));
 		for(const std::shared_ptr<Bonus> it : *lista)
 		{
 			auto nid = CreatureID(it->additionalInfo[0]);

--- a/lib/CStack.cpp
+++ b/lib/CStack.cpp
@@ -141,7 +141,7 @@ std::vector<si32> CStack::activeSpells() const
 		return b->type != Bonus::NONE;
 	}));
 
-	TBonusListPtr spellEffects = getBonuses(selector, Selector::all, cachingStr.str());
+	auto spellEffects = getBonuses(selector, Selector::all, cachingStr.str());
 	for(const std::shared_ptr<Bonus> it : *spellEffects)
 	{
 		if(!vstd::contains(ret, it->sid))  //do not duplicate spells with multiple effects

--- a/lib/battle/CBattleInfoCallback.cpp
+++ b/lib/battle/CBattleInfoCallback.cpp
@@ -680,7 +680,7 @@ bool CBattleInfoCallback::battleCanShoot(const battle::Unit * attacker, BattleHe
 		return false;
 
 	//forgetfulness
-	TBonusListPtr forgetfulList = attacker->getBonuses(Selector::type(Bonus::FORGETFULL));
+	auto forgetfulList = attacker->getBonuses(Selector::type(Bonus::FORGETFULL));
 	if(!forgetfulList->empty())
 	{
 		int forgetful = forgetfulList->valOfBonuses(Selector::type(Bonus::FORGETFULL));
@@ -855,7 +855,7 @@ TDmgRange CBattleInfoCallback::calculateDmgRange(const BattleAttackInfo & info) 
 		//todo: set actual percentage in spell bonus configuration instead of just level; requires non trivial backward compatibility handling
 
 		//get list first, total value of 0 also counts
-		TBonusListPtr forgetfulList = attackerBonuses->getBonuses(Selector::type(Bonus::FORGETFULL),"type_FORGETFULL");
+		auto forgetfulList = attackerBonuses->getBonuses(Selector::type(Bonus::FORGETFULL),"type_FORGETFULL");
 
 		if(!forgetfulList->empty())
 		{
@@ -875,8 +875,8 @@ TDmgRange CBattleInfoCallback::calculateDmgRange(const BattleAttackInfo & info) 
 	const std::string cachingStrForcedMaxDamage = "type_ALWAYS_MAXIMUM_DAMAGE";
 	static const auto selectorForcedMaxDamage = Selector::type(Bonus::ALWAYS_MAXIMUM_DAMAGE);
 
-	TBonusListPtr curseEffects = attackerBonuses->getBonuses(selectorForcedMinDamage, cachingStrForcedMinDamage);
-	TBonusListPtr blessEffects = attackerBonuses->getBonuses(selectorForcedMaxDamage, cachingStrForcedMaxDamage);
+	auto curseEffects = attackerBonuses->getBonuses(selectorForcedMinDamage, cachingStrForcedMinDamage);
+	auto blessEffects = attackerBonuses->getBonuses(selectorForcedMaxDamage, cachingStrForcedMaxDamage);
 
 	int curseBlessAdditiveModifier = blessEffects->totalValue() - curseEffects->totalValue();
 	double curseMultiplicativePenalty = curseEffects->size() ? (*std::max_element(curseEffects->begin(), curseEffects->end(), &Bonus::compareByAdditionalInfo<std::shared_ptr<Bonus>>))->additionalInfo[0] : 0;
@@ -1814,7 +1814,7 @@ SpellID CBattleInfoCallback::getRandomCastedSpell(CRandomGenerator & rand,const 
 {
 	RETURN_IF_NOT_BATTLE(SpellID::NONE);
 
-	TBonusListPtr bl = caster->getBonuses(Selector::type(Bonus::SPELLCASTER));
+	auto bl = caster->getBonuses(Selector::type(Bonus::SPELLCASTER));
 	if (!bl->size())
 		return SpellID::NONE;
 	int totalWeight = 0;

--- a/lib/mapObjects/CGHeroInstance.cpp
+++ b/lib/mapObjects/CGHeroInstance.cpp
@@ -816,7 +816,7 @@ CStackBasicDescriptor CGHeroInstance::calculateNecromancy (const BattleResult &b
 		// figure out what to raise - pick strongest creature meeting requirements
 		CreatureID creatureTypeRaised = CreatureID::SKELETON;
 		int requiredCasualtyLevel = 1;
-		const TBonusListPtr improvedNecromancy = getBonuses(Selector::type(Bonus::IMPROVED_NECROMANCY));
+		auto improvedNecromancy = getBonuses(Selector::type(Bonus::IMPROVED_NECROMANCY));
 		if(!improvedNecromancy->empty())
 		{
 			auto getCreatureID = [necromancyLevel](std::shared_ptr<Bonus> bonus) -> CreatureID

--- a/lib/mapObjects/CGTownInstance.cpp
+++ b/lib/mapObjects/CGTownInstance.cpp
@@ -556,12 +556,12 @@ GrowthInfo CGTownInstance::getGrowthInfo(int level) const
 		ret.entries.push_back(GrowthInfo::Entry(VLC->generaltexth->allTexts[591], dwellingBonus));// \nExternal dwellings %+d
 
 	//other *-of-legion-like bonuses (%d to growth cumulative with grail)
-	TBonusListPtr bonuses = getBonuses(Selector::type(Bonus::CREATURE_GROWTH).And(Selector::subtype(level)));
+	auto bonuses = getBonuses(Selector::type(Bonus::CREATURE_GROWTH).And(Selector::subtype(level)));
 	for(const std::shared_ptr<Bonus> b : *bonuses)
 		ret.entries.push_back(GrowthInfo::Entry(b->val, b->Description()));
 
 	//statue-of-legion-like bonus: % to base+castle
-	TBonusListPtr bonuses2 = getBonuses(Selector::type(Bonus::CREATURE_GROWTH_PERCENT));
+	auto bonuses2 = getBonuses(Selector::type(Bonus::CREATURE_GROWTH_PERCENT));
 	for(const std::shared_ptr<Bonus> b : *bonuses2)
 		ret.entries.push_back(GrowthInfo::Entry(b->val * (base + castleBonus) / 100, b->Description()));
 

--- a/lib/spells/TargetCondition.cpp
+++ b/lib/spells/TargetCondition.cpp
@@ -115,7 +115,7 @@ protected:
 		std::stringstream cachingStr;
 		cachingStr << "type_" << Bonus::LEVEL_SPELL_IMMUNITY << "addInfo_1";
 
-		TBonusListPtr levelImmunities = target->getBonuses(Selector::type(Bonus::LEVEL_SPELL_IMMUNITY).And(Selector::info(1)), cachingStr.str());
+		auto levelImmunities = target->getBonuses(Selector::type(Bonus::LEVEL_SPELL_IMMUNITY).And(Selector::info(1)), cachingStr.str());
 		
 		return levelImmunities->size() == 0 ||
 		levelImmunities->totalValue() < m->getSpellLevel() ||
@@ -190,7 +190,7 @@ public:
 protected:
 	bool check(const Mechanics * m, const battle::Unit * target) const override
 	{
-		TBonusListPtr levelImmunities = target->getBonuses(Selector::type(Bonus::LEVEL_SPELL_IMMUNITY));
+		auto levelImmunities = target->getBonuses(Selector::type(Bonus::LEVEL_SPELL_IMMUNITY));
 		return levelImmunities->size() == 0 ||
 		levelImmunities->totalValue() < m->getSpellLevel() ||
 		m->getSpellLevel() <= 0;

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -5390,7 +5390,7 @@ void CGameHandler::attackCasting(bool ranged, Bonus::BonusType attackMode, const
 	if(attacker->hasBonusOfType(attackMode))
 	{
 		std::set<SpellID> spellsToCast;
-		TBonusListPtr spells = attacker->getBonuses(Selector::type(attackMode));
+		auto spells = attacker->getBonuses(Selector::type(attackMode));
 		for(const std::shared_ptr<Bonus> sf : *spells)
 		{
 			spellsToCast.insert(SpellID(sf->subtype));
@@ -5404,7 +5404,7 @@ void CGameHandler::attackCasting(bool ranged, Bonus::BonusType attackMode, const
 				return;
 			}
 			int32_t spellLevel = 0;
-			TBonusListPtr spellsByType = attacker->getBonuses(Selector::typeSubtype(attackMode, spellID));
+			auto spellsByType = attacker->getBonuses(Selector::typeSubtype(attackMode, spellID));
 			for(const std::shared_ptr<Bonus> sf : *spellsByType)
 			{
 				int meleeRanged;
@@ -5500,7 +5500,7 @@ void CGameHandler::handleAfterAttackCasting(bool ranged, const CStack * attacker
 		return;
 
 	int64_t acidDamage = 0;
-	TBonusListPtr acidBreath = attacker->getBonuses(Selector::type(Bonus::ACID_BREATH));
+	auto acidBreath = attacker->getBonuses(Selector::type(Bonus::ACID_BREATH));
 	for(const std::shared_ptr<Bonus> b : *acidBreath)
 	{
 		if(b->additionalInfo[0] > getRandomGenerator().nextInt(99))
@@ -5939,7 +5939,7 @@ void CGameHandler::runBattle()
 		auto h = gs->curB->battleGetFightingHero(i);
 		if (h)
 		{
-			TBonusListPtr bl = h->getBonuses(Selector::type(Bonus::OPENING_BATTLE_SPELL));
+			auto bl = h->getBonuses(Selector::type(Bonus::OPENING_BATTLE_SPELL));
 
 			for (auto b : *bl)
 			{


### PR DESCRIPTION
Fix bug for deselect artifact: when putting artifact back, call treeHasChanged() to update the cached values.
Also update the variables with type TBonusListPtr to auto for better code change in future.
