### PR TITLE
Fix Client requested Server shutdown

### DIFF
--- a/server/NetPacksLobbyServer.cpp
+++ b/server/NetPacksLobbyServer.cpp
@@ -93,7 +93,6 @@ void LobbyClientDisconnected::applyOnServerAfterAnnounce(CVCMIServer * srv)
 	{
 		logNetwork->info("Client requested shutdown, server will close itself...");
 		srv->state = EServerState::SHUTDOWN;
-		return;
 	}
 	else if(srv->connections.empty())
 	{


### PR DESCRIPTION
* CVCMIServer::updateAndPropagateLobbyState() must be called to actually
  shut down the server after setting state to EServerState::SHUTDOWN, this
  was not done due to a premature return, leading to the Server hanging
  running.