### PR TITLE
Add Korean encoding(CP949)

### DIFF
--- a/launcher/settingsView/csettingsview_moc.cpp
+++ b/launcher/settingsView/csettingsview_moc.cpp
@@ -26,7 +26,9 @@ static const std::string knownEncodingsList[] = //TODO: remove hardcode
 	"CP1252", // Latin/East European, covers most of latin languages
 	// Chinese encodings
 	"GBK", // extension of GB2312, also known as CP936
-	"GB2312" // basic set for Simplified Chinese. Separate from GBK to allow proper detection of H3 fonts
+	"GB2312", // basic set for Simplified Chinese. Separate from GBK to allow proper detection of H3 fonts
+	// Korean encodings
+	"CP949" // extension of EUC-KR.
 };
 
 void CSettingsView::setDisplayList()

--- a/launcher/settingsView/csettingsview_moc.ui
+++ b/launcher/settingsView/csettingsview_moc.ui
@@ -549,6 +549,11 @@
        <string>Simplified Chinese (GB2312)</string>
       </property>
      </item>
+     <item>
+      <property name="text">
+       <string>Korean (Windows 949)</string>
+      </property>
+     </item>
     </widget>
    </item>
    <item row="10" column="1">


### PR DESCRIPTION
This patch adds Korean encoding(cp949) to settings of VCMI.
It makes Korean version HoMM3 show properly.
And It needs a CJK or Korean font in VCMI. 
`True type fonts` mod does not work when character set is CJK, so I made a [Korean font mod](https://github.com/hwiorn/vcmi-mod-korean-truetype-fonts) for this.

<img width="400" alt="sc1" src="https://user-images.githubusercontent.com/1394254/77041570-7ba0ce80-69fd-11ea-9657-a3769fae3da6.png">


<img width="400" alt="sc2" src="https://user-images.githubusercontent.com/1394254/77041577-80fe1900-69fd-11ea-9984-2635c4931b63.png">




