### PR TITLE
Fixed build error due to missing FFMpeg include path

### DIFF
--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -187,6 +187,10 @@ target_include_directories(vcmi
 	PRIVATE ${FFMPEG_INCLUDE_DIRS}
 )
 
+target_include_directories(vcmiclient
+	PRIVATE ${FFMPEG_INCLUDE_DIRS}
+)
+
 vcmi_set_output_dir(vcmiclient "")
 
 set_target_properties(vcmiclient PROPERTIES ${PCH_PROPERTIES})


### PR DESCRIPTION
On systems where ffmpeg includes are not directly in under global include path such as /usr/include/, client/CVideoHandler.h needs the FFMpeg include path in order to include libavformat/avformat.h