### PR TITLE
3117: Fix crash after AI revisits teleporter

### DIFF
--- a/AI/VCAI/VCAI.cpp
+++ b/AI/VCAI/VCAI.cpp
@@ -1806,6 +1806,8 @@ bool VCAI::moveHeroToTile(int3 dst, HeroPtr h)
 		assert(cb->getVisitableObjs(dst).size() > 1); //there's no point in revisiting tile where there is no visitable object
 		cb->moveHero(*h, CGHeroInstance::convertPosition(dst, true));
 		afterMovementCheck(); // TODO: is it feasible to hero get killed there if game work properly?
+		// If revisiting, teleport probing is never done, and so the entries into the list would remain unused and uncleared
+		teleportChannelProbingList.clear();
 		// not sure if AI can currently reconsider to attack bank while staying on it. Check issue 2084 on mantis for more information.
 		ret = true;
 	}


### PR DESCRIPTION
**	Behavioral change: Fix AI heroes sometimes attempting to probe
teleport exits using data from a previously processed hero, causing
nullptr dereferences.

VCAI::moveHeroToTile has special case logic for revisiting tiles. This
logic could cause teleport exits to be stored in
teleportChannelProbingList, without the list subsequently being
cleared. If the processing of that hero ended immediately after that,
the next hero would believe that the list is accurate for them and
attempt to teleport while not standing on a teleporter.