### PR TITLE
Fixed Gargoyles immunity, issue 3112.

### DIFF
--- a/config/artifacts.json
+++ b/config/artifacts.json
@@ -1924,23 +1924,35 @@
 				"type" : "STACK_HEALTH",
 				"val" : 25,
 				"valueType" : "PERCENT_TO_BASE",
-			},
-			{
-				"type" : "STACK_HEALTH",
-				"val" : -25,
-				"valueType" : "PERCENT_TO_BASE",
-				"limiters" : ["IS_UNDEAD"]
+				"limiters" : [
+					"noneOf",
+					"IS_UNDEAD",
+					{
+						"type" : "HAS_ANOTHER_BONUS_LIMITER",
+						"parameters" : [ "NON_LIVING" ]
+					},
+					{
+						"type" : "HAS_ANOTHER_BONUS_LIMITER",
+						"parameters" : [ "GARGOYLE" ]
+					}
+				]
 			},
 			{
 				"type" : "HP_REGENERATION",
 				"val" : 50,
-				"valueType" : "BASE_NUMBER"
-			},
-			{
-				"type" : "HP_REGENERATION",
-				"val" : -50,
-				"valueType" : "BASE_NUMBER",
-				"limiters" : ["IS_UNDEAD"]
+				"valueType" : "PERCENT_TO_BASE",
+				"limiters" : [
+					"noneOf",
+					"IS_UNDEAD",
+					{
+						"type" : "HAS_ANOTHER_BONUS_LIMITER",
+						"parameters" : [ "NON_LIVING" ]
+					},
+					{
+						"type" : "HAS_ANOTHER_BONUS_LIMITER",
+						"parameters" : [ "GARGOYLE" ]
+					}
+				]
 			}
 		],
 		"index" : 131,

--- a/config/spells/ability.json
+++ b/config/spells/ability.json
@@ -87,9 +87,10 @@
 		},
 		"targetCondition" : {
 			"noneOf" : {
-				"bonus.NON_LIVING" : "normal",
+				"bonus.NON_LIVING" : "absolute",
 				"bonus.SIEGE_WEAPON" : "absolute",
-				"bonus.UNDEAD" : "normal"
+				"bonus.UNDEAD" : "absolute",
+				"bonus.GARGOYLE" : "absolute"
 			}
 		}
 	},
@@ -235,9 +236,10 @@
 		},
 		"targetCondition" : {
 			"noneOf" : {
-				"bonus.NON_LIVING" : "normal",
+				"bonus.NON_LIVING" : "absolute",
 				"bonus.SIEGE_WEAPON" : "absolute",
-				"bonus.UNDEAD" : "normal"
+				"bonus.UNDEAD" : "absolute",
+				"bonus.GARGOYLE" : "absolute"
 			}
 		}
 	},
@@ -266,9 +268,10 @@
 		},
 		"targetCondition" : {
 			"noneOf" : {
-				"bonus.NON_LIVING" : "normal",
+				"bonus.NON_LIVING" : "absolute",
 				"bonus.SIEGE_WEAPON" : "absolute",
-				"bonus.UNDEAD" : "normal"
+				"bonus.UNDEAD" : "absolute",
+				"bonus.GARGOYLE" : "absolute"
 			}
 		}
 	},
@@ -354,7 +357,8 @@
 			"noneOf" : {
 				"bonus.NON_LIVING" : "absolute",
 				"bonus.SIEGE_WEAPON" : "absolute",
-				"bonus.UNDEAD" : "absolute"
+				"bonus.UNDEAD" : "absolute",
+				"bonus.GARGOYLE" : "absolute"
 			}
 		}
 	},

--- a/config/spells/other.json
+++ b/config/spells/other.json
@@ -442,7 +442,8 @@
 			"noneOf" : {
 				"bonus.NON_LIVING" : "absolute",
 				"bonus.SIEGE_WEAPON" : "absolute",
-				"bonus.UNDEAD" : "absolute"
+				"bonus.UNDEAD" : "absolute",
+				"bonus.GARGOYLE" : "absolute"
 			}
 		}
 	},
@@ -512,7 +513,8 @@
 			"noneOf" : {
 				"bonus.NON_LIVING" : "absolute",
 				"bonus.SIEGE_WEAPON" : "absolute",
-				"bonus.UNDEAD" : "absolute"
+				"bonus.UNDEAD" : "absolute",
+				"bonus.GARGOYLE" : "absolute"
 			}
 		}
 	},


### PR DESCRIPTION
Gargoyles should be resistant to the same effects that NON_LIVING creature are, minus mind spells. It also shouldn't be affected by Resurrection and Sacrifice spells, and Elixir of Life.