### PR TITLE
Fix CMP_stack to follow strict weak ordering of elements

### DIFF
--- a/lib/battle/BattleInfo.cpp
+++ b/lib/battle/BattleInfo.cpp
@@ -1071,14 +1071,14 @@ bool CMP_stack::operator()(const battle::Unit * a, const battle::Unit * b)
 			int as = a->getInitiative(turn), bs = b->getInitiative(turn);
 			if(as != bs)
 				return as > bs;
-			else
-			{
-				if(a->unitSide() == b->unitSide())
-					return a->unitSlot() < b->unitSlot();
-				else
-					return a->unitSide() == side ? false : true;
-			}
+
+			if (a->unitSide() == b->unitSide())
+				return a->unitSlot() < b->unitSlot();
+			else if (a->unitSide() == side || b->unitSide() == side)
+				return a->unitSide() != side;
 			//FIXME: what about summoned stacks
+
+			return std::addressof(a) > std::addressof(b);
 		}	
 	case 2: //fastest last, upper slot first
 	case 3: //fastest last, upper slot first
@@ -1086,18 +1086,21 @@ bool CMP_stack::operator()(const battle::Unit * a, const battle::Unit * b)
 			int as = a->getInitiative(turn), bs = b->getInitiative(turn);
 			if(as != bs)
 				return as > bs;
-			else
-			{
-				if(a->unitSide() == b->unitSide())
-					return a->unitSlot() < b->unitSlot();
-				else
-					return a->unitSide() == side ? false : true;
-			}
+
+			if(a->unitSide() == b->unitSide())
+				return a->unitSlot() < b->unitSlot();
+			else if (a->unitSide() == side || b->unitSide() == side)
+				return a->unitSide() != side;
+
+			return std::addressof(a) > std::addressof(b);
 		}
 	default:
-		assert(0);
+		assert(false);
 		return false;
 	}
+
+	assert(false);
+	return false;
 }
 
 CMP_stack::CMP_stack(int Phase, int Turn, uint8_t Side)


### PR DESCRIPTION
Introduced in ab1c598d4e7fd4e89184b0c5d55ff418db8f7d27, spotted here: https://github.com/vcmi/vcmi/pull/609#issuecomment-624036482

![image](https://user-images.githubusercontent.com/1173058/81577344-f78e1600-93b1-11ea-8404-799f7adb602e.png)

While working on a separate issue I was hitting an assertion in CBattleInfoCallback.cpp on the line
```
boost::sort(phase[i], CMP_stack(i, actualTurn, lastMoved));
```

Turns out `CMP_stack::operator()` failed to follow the strict weak ordering rule when the side is -1. Now using std:addressof may seem like a hack but it does the trick when comparing two unit stack that are otherwise identical.

Also, the following comments  seem dubious because as the code works, faster units receive their turn first and cases 1, 2, 3 may actually be merged. This needs to be investigated by someone more knowledgeable than myself.

```
	case 2: //fastest last, upper slot first
	case 3: //fastest last, upper slot first
```
