### PR TITLE
Fix mingw build and Random Map Generator Option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,7 +160,7 @@ if(WIN32)
 	endif(MSVC)
 
 	if(MINGW)
-		set(SYSTEM_LIBS ${SYSTEM_LIBS} ole32 oleaut32 ws2_32 mswsock dbghelp)
+		set(SYSTEM_LIBS ${SYSTEM_LIBS} ole32 oleaut32 ws2_32 mswsock dbghelp bcrypt)
 
 		# Check for iconv (may be needed for Boost.Locale)
 		include(CheckLibraryExists)

--- a/client/lobby/RandomMapTab.cpp
+++ b/client/lobby/RandomMapTab.cpp
@@ -80,7 +80,10 @@ RandomMapTab::RandomMapTab()
 	{
 		mapGenOptions->setPlayerCount(btnId);
 		deactivateButtonsFrom(groupMaxTeams.get(), btnId);
-		deactivateButtonsFrom(groupCompOnlyPlayers.get(), btnId);
+
+		// deactive some CompOnlyPlayers buttons to prevent total number of players exceeds PlayerColor::PLAYER_LIMIT_I
+		deactivateButtonsFrom(groupCompOnlyPlayers.get(), PlayerColor::PLAYER_LIMIT_I - btnId + 1);
+
 		validatePlayersCnt(btnId);
 		updateMapInfoByHost();
 	});
@@ -175,7 +178,14 @@ void RandomMapTab::updateMapInfoByHost()
 	mapInfo->mapHeader->players.clear();
 	int playersToGen = PlayerColor::PLAYER_LIMIT_I;
 	if(mapGenOptions->getPlayerCount() != CMapGenOptions::RANDOM_SIZE)
-		playersToGen = mapGenOptions->getPlayerCount();
+	{
+		if(mapGenOptions->getCompOnlyPlayerCount() != CMapGenOptions::RANDOM_SIZE)
+			playersToGen = mapGenOptions->getPlayerCount() + mapGenOptions->getCompOnlyPlayerCount();
+		else
+			playersToGen = mapGenOptions->getPlayerCount();
+	}
+
+
 	mapInfo->mapHeader->howManyTeams = playersToGen;
 
 	for(int i = 0; i < playersToGen; ++i)
@@ -183,7 +193,7 @@ void RandomMapTab::updateMapInfoByHost()
 		PlayerInfo player;
 		player.isFactionRandom = true;
 		player.canComputerPlay = true;
-		if(mapGenOptions->getCompOnlyPlayerCount() != CMapGenOptions::RANDOM_SIZE && i >= mapGenOptions->getHumanOnlyPlayerCount())
+		if(mapGenOptions->getCompOnlyPlayerCount() != CMapGenOptions::RANDOM_SIZE && i >= mapGenOptions->getPlayerCount())
 		{
 			player.canHumanPlay = false;
 		}
@@ -268,9 +278,10 @@ void RandomMapTab::validatePlayersCnt(int playersCnt)
 		mapGenOptions->setTeamCount(playersCnt - 1);
 		groupMaxTeams->setSelected(mapGenOptions->getTeamCount());
 	}
-	if(mapGenOptions->getCompOnlyPlayerCount() >= playersCnt)
+	// total players should not exceed PlayerColor::PLAYER_LIMIT_I (8 in homm3)
+	if(mapGenOptions->getCompOnlyPlayerCount() + playersCnt > PlayerColor::PLAYER_LIMIT_I)
 	{
-		mapGenOptions->setCompOnlyPlayerCount(playersCnt - 1);
+		mapGenOptions->setCompOnlyPlayerCount(PlayerColor::PLAYER_LIMIT_I - playersCnt);
 		groupCompOnlyPlayers->setSelected(mapGenOptions->getCompOnlyPlayerCount());
 	}
 

--- a/client/lobby/RandomMapTab.h
+++ b/client/lobby/RandomMapTab.h
@@ -12,6 +12,7 @@
 #include "CSelectionBase.h"
 
 #include "../../lib/FunctionList.h"
+#include "../../lib/GameConstants.h"
 
 class CMapGenOptions;
 class CToggleButton;

--- a/client/widgets/AdventureMapClasses.cpp
+++ b/client/widgets/AdventureMapClasses.cpp
@@ -24,6 +24,7 @@
 
 #include "../gui/CGuiHandler.h"
 #include "../gui/SDL_Pixels.h"
+#include "../gui/SDL_Compat.h"
 
 #include "../widgets/Images.h"
 

--- a/lib/rmg/CMapGenOptions.cpp
+++ b/lib/rmg/CMapGenOptions.cpp
@@ -19,7 +19,7 @@
 
 CMapGenOptions::CMapGenOptions()
 	: width(CMapHeader::MAP_SIZE_MIDDLE), height(CMapHeader::MAP_SIZE_MIDDLE), hasTwoLevels(true),
-	playerCount(RANDOM_SIZE), teamCount(RANDOM_SIZE), compOnlyPlayerCount(RANDOM_SIZE), compOnlyTeamCount(RANDOM_SIZE), humanPlayersCount(0),
+	playerCount(RANDOM_SIZE), teamCount(RANDOM_SIZE), compOnlyPlayerCount(RANDOM_SIZE), compOnlyTeamCount(RANDOM_SIZE),
 	waterContent(EWaterContent::RANDOM), monsterStrength(EMonsterStrength::RANDOM), mapTemplate(nullptr)
 {
 	resetPlayersMap();
@@ -71,20 +71,7 @@ void CMapGenOptions::setPlayerCount(si8 value)
 	if (compOnlyPlayerCount > possibleCompPlayersCount)
 		setCompOnlyPlayerCount(possibleCompPlayersCount);
 
-	if (getPlayerCount() != RANDOM_SIZE)
-	{
-		if (getCompOnlyPlayerCount() != RANDOM_SIZE)
-			humanPlayersCount = getPlayerCount() - getCompOnlyPlayerCount();
-		else
-			humanPlayersCount = getPlayerCount();
-	}
-
 	resetPlayersMap();
-}
-
-si8 CMapGenOptions::getHumanOnlyPlayerCount() const
-{
-	return humanPlayersCount;
 }
 
 si8 CMapGenOptions::getTeamCount() const
@@ -105,11 +92,8 @@ si8 CMapGenOptions::getCompOnlyPlayerCount() const
 
 void CMapGenOptions::setCompOnlyPlayerCount(si8 value)
 {
-	assert(value == RANDOM_SIZE || (getPlayerCount() == RANDOM_SIZE || (value >= 0 && value <= getPlayerCount())));
+	assert(value == RANDOM_SIZE || (getPlayerCount() == RANDOM_SIZE || (value >= 0 && value <= PlayerColor::PLAYER_LIMIT_I - getPlayerCount())));
 	compOnlyPlayerCount = value;
-
-	if (getPlayerCount() != RANDOM_SIZE && getCompOnlyPlayerCount() != RANDOM_SIZE)
-		humanPlayersCount = getPlayerCount() - getCompOnlyPlayerCount();
 
 	resetPlayersMap();
 }
@@ -159,7 +143,7 @@ void CMapGenOptions::resetPlayersMap()
 
 
 	players.clear();
-	int realPlayersCnt = humanPlayersCount;
+	int realPlayersCnt = playerCount;
 	int realCompOnlyPlayersCnt = (compOnlyPlayerCount == RANDOM_SIZE) ? (PlayerColor::PLAYER_LIMIT_I - realPlayersCnt) : compOnlyPlayerCount;
 	int totalPlayersLimit = realPlayersCnt + realCompOnlyPlayersCnt;
 	if (getPlayerCount() == RANDOM_SIZE || compOnlyPlayerCount == RANDOM_SIZE)

--- a/lib/rmg/CMapGenOptions.h
+++ b/lib/rmg/CMapGenOptions.h
@@ -109,8 +109,6 @@ public:
 	si8 getPlayerCount() const;
 	void setPlayerCount(si8 value);
 
-	si8 getHumanOnlyPlayerCount() const;
-
 	/// The count of the teams ranging from 0 to <players count - 1> or RANDOM_SIZE for random.
 	si8 getTeamCount() const;
 	void setTeamCount(si8 value);
@@ -166,7 +164,7 @@ private:
 
 	si32 width, height;
 	bool hasTwoLevels;
-	si8 playerCount, teamCount, humanPlayersCount, compOnlyPlayerCount, compOnlyTeamCount;
+	si8 playerCount, teamCount, compOnlyPlayerCount, compOnlyTeamCount;
 	EWaterContent::EWaterContent waterContent;
 	EMonsterStrength::EMonsterStrength monsterStrength;
 	std::map<PlayerColor, CPlayerSettings> players;
@@ -186,7 +184,6 @@ public:
 		h & waterContent;
 		h & monsterStrength;
 		h & players;
-		h & humanPlayersCount;
 		//TODO add name of template to class, enables selection of a template by a user
 	}
 };


### PR DESCRIPTION
This PR has done 2 things

1. fix mingw build

2. As mentioned in https://forum.vcmi.eu/t/rmg-options-different-from-homm3/5275, I think allowing arbitrary combination of “Computer only players” and “Human or Computer players” while limiting the total number to be less than 8 should be the correct behavior, following the original homm3. With this PR, I can generate 2 human players as a team and 6 cpu players as 3 teams with the "Clash of Dragons" template.