### PR TITLE
[WIP] Temporary fix Video button crash

### DIFF
--- a/client/CVideoHandler.cpp
+++ b/client/CVideoHandler.cpp
@@ -88,7 +88,8 @@ bool CVideoPlayer::open(std::string fname, bool scale)
 // useOverlay = directly write to the screen.
 bool CVideoPlayer::open(std::string fname, bool loop, bool useOverlay, bool scale)
 {
-	close();
+	// Commment out to prevent crash, may lead to memory leak
+	// close();
 
 	this->fname = fname;
 	refreshWait = 3;

--- a/client/mainmenu/CCampaignScreen.cpp
+++ b/client/mainmenu/CCampaignScreen.cpp
@@ -129,7 +129,8 @@ void CCampaignScreen::CCampaignButton::show(SDL_Surface * to)
 	}
 	else if(CCS->videoh->fname == video) // When you got out of the bounds of the button then close the video
 	{
-		CCS->videoh->close();
+		// Don't close the video to prevent crash, may lead to memory leak
+		// CCS->videoh->close();
 		redraw();
 	}
 }


### PR DESCRIPTION
The crash happens when I hover my mouse on the campaigns button. Windows only, seems like Linux build works find. After my investigation, it is related to the `close()` function in `CVideoHandler.cpp`. It  seems like if it has already loaded and opened a video resource, and `close()` is called, it will crash. The `close()` function call libraries' function like `sws_freeContext(sws)` to release (supposedly) unused resource.

I believe it is related to improper resource management, maybe also thread related, but I cannot find what exactly the problem is. This PR disable the `close()` function to prevent the crash, but it may lead to memory leak.

Hopefully someone will have some ideas on this, or maybe I will eventually figure the proper fix to this issue.