### PR TITLE
Fix exception while calculating paths

### DIFF
--- a/AI/VCAI/AIUtility.cpp
+++ b/AI/VCAI/AIUtility.cpp
@@ -191,7 +191,7 @@ bool CDistanceSorter::operator()(const CGObjectInstance * lhs, const CGObjectIns
 	const CGPathNode * ln = ai->myCb->getPathsInfo(hero)->getPathInfo(lhs->visitablePos());
 	const CGPathNode * rn = ai->myCb->getPathsInfo(hero)->getPathInfo(rhs->visitablePos());
 
-	return ln->cost < rn->cost;
+	return ln->getCost() < rn->getCost();
 }
 
 bool isSafeToVisit(HeroPtr h, crint3 tile)

--- a/AI/VCAI/FuzzyEngines.cpp
+++ b/AI/VCAI/FuzzyEngines.cpp
@@ -98,7 +98,7 @@ float HeroMovementGoalEngineBase::calculateTurnDistanceInputValue(const Goals::A
 	else
 	{
 		auto pathInfo = ai->myCb->getPathsInfo(goal.hero.h)->getPathInfo(goal.tile);
-		return pathInfo->cost;
+		return pathInfo->getCost();
 	}
 }
 

--- a/AI/VCAI/Pathfinding/AINodeStorage.cpp
+++ b/AI/VCAI/Pathfinding/AINodeStorage.cpp
@@ -119,7 +119,7 @@ CGPathNode * AINodeStorage::getInitialNode()
 	initialNode->turns = 0;
 	initialNode->moveRemains = hero->movement;
 	initialNode->danger = 0;
-	initialNode->cost = 0.0;
+	initialNode->setCost(0.0);
 
 	return initialNode;
 }
@@ -146,7 +146,7 @@ void AINodeStorage::commit(CDestinationNodeInfo & destination, const PathNodeInf
 	{
 		dstNode->moveRemains = destination.movementLeft;
 		dstNode->turns = destination.turn;
-		dstNode->cost = destination.cost;
+		dstNode->setCost(destination.cost);
 		dstNode->danger = srcNode->danger;
 		dstNode->action = destination.action;
 		dstNode->theNodeBefore = srcNode->theNodeBefore;
@@ -305,7 +305,7 @@ bool AINodeStorage::hasBetterChain(const PathNodeInfo & source, CDestinationNode
 
 		if(node.danger <= destinationNode->danger && destinationNode->chainMask == 1 && node.chainMask == 0)
 		{
-			if(node.cost < destinationNode->cost)
+			if(node.getCost() < destinationNode->getCost())
 			{
 #ifdef VCMI_TRACE_PATHFINDER
 				logAi->trace(
@@ -349,7 +349,7 @@ std::vector<AIPath> AINodeStorage::getChainInfo(const int3 & pos, bool isOnLand)
 		while(current != nullptr && current->coord != initialPos)
 		{
 			AIPathNodeInfo pathNode;
-			pathNode.cost = current->cost;
+			pathNode.cost = current->getCost();
 			pathNode.turns = current->turns;
 			pathNode.danger = current->danger;
 			pathNode.coord = current->coord;


### PR DESCRIPTION
I 've found out that nodes which are already in the queue are subject to change after the rules are applied to them and the cost field is recalculated. This will lead to an "invalid heap" error. So, my  conclusion that the boost priority queue does not fit this goal.

