### PR TITLE
Fixed tmp resources destination

### DIFF
--- a/vcmibuilder
+++ b/vcmibuilder
@@ -177,12 +177,12 @@ mkdir -p "$temp_dir"
 
 if [[ -n "$gog_file" ]]
 then
+	data_dir="$temp_dir"/app
+
 	# innoextract always reports error (iconv 84 error). Just test file for presence
 	test -f "$gog_file" || fail "Error: gog.com executable was not found!"
         gog_file="$(cd "$(dirname "$gog_file")"; pwd)/$(basename "$gog_file")"
-	cd "$temp_dir" && innoextract "$gog_file"
-
-	data_dir="$temp_dir"/app
+	cd "$data_dir" && innoextract "$gog_file"
 fi
 
 if [[ -n "$cd1_dir" ]]


### PR DESCRIPTION
**Vcmibuild** puts the resources (Data, Maps, Mp3, etc) in /home/libertypaul/.local/share/vcmi/buildertmp/:
```
$ ls /home/libertypaul/.local/share/vcmi/buildertmp/
app            goggame-1207658787.hashdb  h3ccmped.cnt  H3MAPED.HLP            Heroes3_Manual.pdf      Mp3         SMACKW32.DLL
BINKW32.DLL    goggame-1207658787.ico     h3ccmped.exe  Heroes3_AB_Manual.pdf  Heroes3_SoD_Manual.pdf  MP3DEC.ASI  tmp
commonappdata  goggame-1207658787.info    H3CCMPED.HLP  Heroes3.cnt            Heroes3_Tutorial.pdf    MSS32.DLL
Data           goggame-1207658787.script  h3maped.cnt   Heroes3.exe            IFC20.dll               README.TXT
EULA           goggame.sdb                h3maped.exe   HEROES3.HLP            Maps                    __redist
```


Later on, it tries to take them from /home/libertypaul/.local/share/vcmi/buildertmp/**app**:
```
 - "tmp/slideshow.ini" [temp]
 - "commonappdata/GOG.com/supportInstaller/uninstall.dll"
Done.
cp: cannot stat '/home/libertypaul/.local/share/vcmi/buildertmp/app/[Dd][Aa][Tt][Aa]': No such file or directory
```

I fixed the destination for all these directories so that they both created and taken from ./app/ subdirectory.


