### PR TITLE
Fix: Random map generator crashes when nativeTerrain is not specified in the town mod

### DIFF
--- a/lib/CTownHandler.h
+++ b/lib/CTownHandler.h
@@ -298,6 +298,11 @@ class DLL_LINKAGE CTownHandler : public IHandlerBase
 
 	std::map<CTown *, JsonNode> warMachinesToLoad;
 	std::vector<BuildingRequirementsHelper> requirementsToLoad;
+
+	const static ETerrainType::EETerrainType defaultGoodTerrain = ETerrainType::EETerrainType::GRASS;
+	const static ETerrainType::EETerrainType defaultEvilTerrain = ETerrainType::EETerrainType::LAVA;
+	const static ETerrainType::EETerrainType defaultNeutralTerrain = ETerrainType::EETerrainType::ROUGH;
+
 	void initializeRequirements();
 	void initializeWarMachines();
 
@@ -319,6 +324,8 @@ class DLL_LINKAGE CTownHandler : public IHandlerBase
 	void loadTown(CTown * town, const JsonNode & source);
 
 	void loadPuzzle(CFaction & faction, const JsonNode & source);
+
+	ETerrainType::EETerrainType getDefaultTerrainForAlignment(EAlignment::EAlignment aligment) const;
 
 	CFaction * loadFromJson(const JsonNode & data, const std::string & identifier);
 

--- a/lib/GameConstants.h
+++ b/lib/GameConstants.h
@@ -776,6 +776,12 @@ public:
 	ETerrainType(EETerrainType _num = WRONG) : num(_num)
 	{}
 
+	ETerrainType& operator=(EETerrainType _num)
+	{
+		num = _num;
+		return *this;
+	}
+
 	ID_LIKE_CLASS_COMMON(ETerrainType, EETerrainType)
 
 	EETerrainType num;


### PR DESCRIPTION
Reproduction steps:
1. Setup "Ruins" town mod 
2. Try to generate some random map with "Ruins" player.

Expected result: 
Random map should be generated.

Actual result:
Server crashes.

RCA: 
When the "nativeTerrain" parameter is not specified in the faction mod, random map generator assumes, that the native terrain for this faction is a Border (-1), then it tries to create game objects on the border and crashes.

Solution: 
Let's assume, that the default faction terrain will be a grass...