### PR TITLE
Minor fix: Apply Monday bonuses to heroes who have slept overnight

### DIFF
--- a/client/Client.h
+++ b/client/Client.h
@@ -194,6 +194,7 @@ public:
 
 	void showCompInfo(ShowInInfobox * comp) override {};
 	void heroVisitCastle(const CGTownInstance * obj, const CGHeroInstance * hero) override {};
+	void visitCastleObjects(const CGTownInstance * obj, const CGHeroInstance * hero) override {};
 	void stopHeroVisitCastle(const CGTownInstance * obj, const CGHeroInstance * hero) override {};
 	void startBattlePrimary(const CArmedInstance * army1, const CArmedInstance * army2, int3 tile, const CGHeroInstance * hero1, const CGHeroInstance * hero2, bool creatureBank = false, const CGTownInstance * town = nullptr) override {}; //use hero=nullptr for no hero
 	void startBattleI(const CArmedInstance * army1, const CArmedInstance * army2, int3 tile, bool creatureBank = false) override {}; //if any of armies is hero, hero will be used

--- a/lib/CPathfinder.h
+++ b/lib/CPathfinder.h
@@ -118,11 +118,11 @@ struct DLL_LINKAGE CGPathNode
 		{
 			if(getUpNode)
 			{
-				pq->increase(this->pqHandle, this);
+				pq->increase(this->pqHandle);
 			}
 			else
 			{
-				pq->decrease(this->pqHandle, this);
+				pq->decrease(this->pqHandle);
 			}
 		}
 	}

--- a/lib/IGameCallback.h
+++ b/lib/IGameCallback.h
@@ -80,6 +80,7 @@ public:
 
 	virtual void showCompInfo(ShowInInfobox * comp)=0;
 	virtual void heroVisitCastle(const CGTownInstance * obj, const CGHeroInstance * hero)=0;
+	virtual void visitCastleObjects(const CGTownInstance * obj, const CGHeroInstance * hero)=0;
 	virtual void stopHeroVisitCastle(const CGTownInstance * obj, const CGHeroInstance * hero)=0;
 	virtual void startBattlePrimary(const CArmedInstance *army1, const CArmedInstance *army2, int3 tile, const CGHeroInstance *hero1, const CGHeroInstance *hero2, bool creatureBank = false, const CGTownInstance *town = nullptr)=0; //use hero=nullptr for no hero
 	virtual void startBattleI(const CArmedInstance *army1, const CArmedInstance *army2, int3 tile, bool creatureBank = false)=0; //if any of armies is hero, hero will be used

--- a/lib/mapObjects/CGTownInstance.cpp
+++ b/lib/mapObjects/CGTownInstance.cpp
@@ -798,6 +798,14 @@ void CGTownInstance::newTurn(CRandomGenerator & rand) const
 				cb->setObjProperty (id, ObjProperty::STRUCTURE_CLEAR_VISITORS, (elem)->id); //reset visitors for Mana Vortex
 		}
 
+		//get Mana Vortex or Stables bonuses
+		//same code is in the CGameHandler::buildStructure method
+		if (visitingHero != nullptr)
+			cb->visitCastleObjects(this, visitingHero);
+
+		if (garrisonHero != nullptr)
+			cb->visitCastleObjects(this, garrisonHero);
+
 		if (tempOwner == PlayerColor::NEUTRAL) //garrison growth for neutral towns
 			{
 				std::vector<SlotID> nativeCrits; //slots
@@ -1536,13 +1544,15 @@ void COPWBonus::onHeroVisit (const CGHeroInstance * h) const
 				}
 				break;
 			case ETownType::DUNGEON: //Mana Vortex
-				if (visitors.empty() && h->mana <= h->manaLimit() * 2)
+				if (visitors.empty())
 				{
-					cb->setManaPoints (heroID, 2 * h->manaLimit());
+					if (h->mana < h->manaLimit() * 2)
+						cb->setManaPoints(heroID, 2 * h->manaLimit());
 					//TODO: investigate line below
 					//cb->setObjProperty (town->id, ObjProperty::VISITED, true);
 					iw.text << VLC->generaltexth->allTexts[579];
 					cb->showInfoDialog(&iw);
+					//extra visit penalty if hero alredy had double mana points (or even more?!)
 					town->addHeroToStructureVisitors(h, id);
 				}
 				break;

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -2508,13 +2508,13 @@ void CGameHandler::heroVisitCastle(const CGTownInstance * obj, const CGHeroInsta
 	vc.tid = obj->id;
 	vc.flags |= 1;
 	sendAndApply(&vc);
-	vistiCastleObjects (obj, hero);
-	giveSpells (obj, hero);
+	visitCastleObjects(obj, hero);
+	giveSpells(obj, hero);
 
 	checkVictoryLossConditionsForPlayer(hero->tempOwner); //transported artifact?
 }
 
-void CGameHandler::vistiCastleObjects (const CGTownInstance *t, const CGHeroInstance *h)
+void CGameHandler::visitCastleObjects(const CGTownInstance * t, const CGHeroInstance * h)
 {
 	std::vector<CGTownBuilding*>::const_iterator i;
 	for (i = t->bonusingBuildings.begin(); i != t->bonusingBuildings.end(); i++)
@@ -3161,9 +3161,9 @@ bool CGameHandler::buildStructure(ObjectInstanceID tid, BuildingID requestedID, 
 	sendAndApply(&fw);
 
 	if (t->visitingHero)
-		vistiCastleObjects (t, t->visitingHero);
+		visitCastleObjects(t, t->visitingHero);
 	if (t->garrisonHero)
-		vistiCastleObjects (t, t->garrisonHero);
+		visitCastleObjects(t, t->garrisonHero);
 
 	checkVictoryLossConditionsForPlayer(t->tempOwner);
 	return true;
@@ -3828,7 +3828,7 @@ bool CGameHandler::hireHero(const CGObjectInstance *obj, ui8 hid, PlayerColor pl
 
 	if (t)
 	{
-		vistiCastleObjects (t, nh);
+		visitCastleObjects(t, nh);
 		giveSpells (t,nh);
 	}
 	return true;

--- a/server/CGameHandler.h
+++ b/server/CGameHandler.h
@@ -181,7 +181,7 @@ public:
 	void setPortalDwelling(const CGTownInstance * town, bool forced, bool clear);
 	void visitObjectOnTile(const TerrainTile &t, const CGHeroInstance * h);
 	bool teleportHero(ObjectInstanceID hid, ObjectInstanceID dstid, ui8 source, PlayerColor asker = PlayerColor::NEUTRAL);
-	void vistiCastleObjects (const CGTownInstance *t, const CGHeroInstance *h);
+	void visitCastleObjects(const CGTownInstance * obj, const CGHeroInstance * hero);
 	void levelUpHero(const CGHeroInstance * hero, SecondarySkill skill);//handle client respond and send one more request if needed
 	void levelUpHero(const CGHeroInstance * hero);//initial call - check if hero have remaining levelups & handle them
 	void levelUpCommander (const CCommanderInstance * c, int skill); //secondary skill 1 to 6, special skill : skill - 100

--- a/server/CGameHandler.h
+++ b/server/CGameHandler.h
@@ -181,7 +181,7 @@ public:
 	void setPortalDwelling(const CGTownInstance * town, bool forced, bool clear);
 	void visitObjectOnTile(const TerrainTile &t, const CGHeroInstance * h);
 	bool teleportHero(ObjectInstanceID hid, ObjectInstanceID dstid, ui8 source, PlayerColor asker = PlayerColor::NEUTRAL);
-	void visitCastleObjects(const CGTownInstance * obj, const CGHeroInstance * hero);
+	void visitCastleObjects(const CGTownInstance * obj, const CGHeroInstance * hero) override;
 	void levelUpHero(const CGHeroInstance * hero, SecondarySkill skill);//handle client respond and send one more request if needed
 	void levelUpHero(const CGHeroInstance * hero);//initial call - check if hero have remaining levelups & handle them
 	void levelUpCommander (const CCommanderInstance * c, int skill); //secondary skill 1 to 6, special skill : skill - 100

--- a/test/mock/mock_IGameCallback.h
+++ b/test/mock/mock_IGameCallback.h
@@ -70,6 +70,7 @@ public:
 	void showCompInfo(ShowInInfobox * comp) override {};
 	void heroVisitCastle(const CGTownInstance * obj, const CGHeroInstance * hero) override {};
 	void stopHeroVisitCastle(const CGTownInstance * obj, const CGHeroInstance * hero) override {};
+	void visitCastleObjects(const CGTownInstance * obj, const CGHeroInstance * hero) override {};
 	void startBattlePrimary(const CArmedInstance *army1, const CArmedInstance *army2, int3 tile, const CGHeroInstance *hero1, const CGHeroInstance *hero2, bool creatureBank = false, const CGTownInstance *town = nullptr) override {}; //use hero=nullptr for no hero
 	void startBattleI(const CArmedInstance *army1, const CArmedInstance *army2, int3 tile, bool creatureBank = false) override {}; //if any of armies is hero, hero will be used
 	void startBattleI(const CArmedInstance *army1, const CArmedInstance *army2, bool creatureBank = false) override {}; //if any of armies is hero, hero will be used, visitable tile of second obj is place of battle


### PR DESCRIPTION
Issue:
The Mana Vortex does not work for heroes, who were in the castle from 7 to 1 day.
Hero needs go out and back in to double mana points.

Solution:
Call some code, which works on the "OnHeroVisit" event to update weekly bonuses

Side effect: Popups from bonus buildings will appear on the adventure map.