### PR TITLE
lib: fix CPathfinder build error on GCC 10.2

### DIFF
--- a/lib/CPathfinder.h
+++ b/lib/CPathfinder.h
@@ -149,22 +149,13 @@ struct DLL_LINKAGE CGPathNode
 		return turns < 255;
 	}
 
-	boost::heap::detail::node_handle
-	<
-		boost::heap::detail::marked_heap_node<CGPathNode *>*,
-		boost::heap::detail::make_fibonacci_heap_base
-		<
-			CGPathNode *,
-			boost::parameter::aux::arg_list
-			<
-				boost::heap::compare<NodeComparer<CGPathNode>>,
-				boost::parameter::aux::empty_arg_list
-			>
-		>::type,
-		CGPathNode *&
-	> pqHandle;
+	typedef boost::heap::fibonacci_heap<
+		CGPathNode *,
+		boost::heap::compare<NodeComparer<CGPathNode>>
+	> TFibHeap;
 
-	boost::heap::fibonacci_heap< CGPathNode *, boost::heap::compare<NodeComparer<CGPathNode>> >* pq;
+	TFibHeap::handle_type pqHandle;
+	TFibHeap* pq;
 
 private:
 	float cost; //total cost of the path to this tile measured in turns with fractions


### PR DESCRIPTION
CPathfinder constructs boost::fibbonacci_heap handle manually using
private primitives. This stopped working with newer GCC and boost.
Replace this with proper handle_type from container's public typedef.