### PR TITLE
Fixed incorrect usage of const std::shared_ptr. Resolves 0003142.

### DIFF
--- a/AI/BattleAI/StackWithBonuses.cpp
+++ b/AI/BattleAI/StackWithBonuses.cpp
@@ -97,11 +97,11 @@ SlotID StackWithBonuses::unitSlot() const
 	return slot;
 }
 
-const TBonusListPtr StackWithBonuses::getAllBonuses(const CSelector & selector, const CSelector & limit,
+TConstBonusListPtr StackWithBonuses::getAllBonuses(const CSelector & selector, const CSelector & limit,
 	const CBonusSystemNode * root, const std::string & cachingStr) const
 {
 	TBonusListPtr ret = std::make_shared<BonusList>();
-	const TBonusListPtr originalList = origBearer->getAllBonuses(selector, limit, root, cachingStr);
+	TConstBonusListPtr originalList = origBearer->getAllBonuses(selector, limit, root, cachingStr);
 
 	vstd::copy_if(*originalList, std::back_inserter(*ret), [this](const std::shared_ptr<Bonus> & b)
 	{
@@ -177,7 +177,7 @@ void StackWithBonuses::removeUnitBonus(const std::vector<Bonus> & bonus)
 
 void StackWithBonuses::removeUnitBonus(const CSelector & selector)
 {
-	TBonusListPtr toRemove = origBearer->getBonuses(selector);
+	TConstBonusListPtr toRemove = origBearer->getBonuses(selector);
 
 	for(auto b : *toRemove)
 		bonusesToRemove.insert(b);

--- a/AI/BattleAI/StackWithBonuses.h
+++ b/AI/BattleAI/StackWithBonuses.h
@@ -42,7 +42,7 @@ public:
 	SlotID unitSlot() const override;
 
 	///IBonusBearer
-	const TBonusListPtr getAllBonuses(const CSelector & selector, const CSelector & limit,
+	TConstBonusListPtr getAllBonuses(const CSelector & selector, const CSelector & limit,
 		const CBonusSystemNode * root = nullptr, const std::string & cachingStr = "") const override;
 
 	int64_t getTreeVersion() const override;

--- a/client/widgets/CGarrisonInt.cpp
+++ b/client/widgets/CGarrisonInt.cpp
@@ -172,7 +172,7 @@ bool CGarrisonSlot::highlightOrDropArtifact()
 	bool artSelected = false;
 	if (CWindowWithArtifacts* chw = dynamic_cast<CWindowWithArtifacts*>(GH.topInt().get())) //dirty solution
 	{
-		const std::shared_ptr<CArtifactsOfHero::SCommonPart> commonInfo = chw->getCommonPart();
+		std::shared_ptr<CArtifactsOfHero::SCommonPart> commonInfo = chw->getCommonPart();
 		const CArtifactInstance * art = nullptr;
 		if(commonInfo)
 			art = commonInfo->src.art;

--- a/client/widgets/MiscWidgets.cpp
+++ b/client/widgets/MiscWidgets.cpp
@@ -369,7 +369,7 @@ void MoraleLuckBox::set(const IBonusBearer * node)
 	const int hoverTextBase[] = {7, 4};
 	const Bonus::BonusType bonusType[] = {Bonus::LUCK, Bonus::MORALE};
 	int (IBonusBearer::*getValue[])() const = {&IBonusBearer::LuckVal, &IBonusBearer::MoraleVal};
-	TBonusListPtr modifierList(new BonusList());
+	TConstBonusListPtr modifierList(new BonusList());
 
 	if(node)
 	{

--- a/client/windows/CHeroWindow.cpp
+++ b/client/windows/CHeroWindow.cpp
@@ -40,11 +40,11 @@
 #include "../mapHandler.h"
 
 
-const TBonusListPtr CHeroWithMaybePickedArtifact::getAllBonuses(const CSelector & selector, const CSelector & limit, const CBonusSystemNode * root, const std::string & cachingStr) const
+TConstBonusListPtr CHeroWithMaybePickedArtifact::getAllBonuses(const CSelector & selector, const CSelector & limit, const CBonusSystemNode * root, const std::string & cachingStr) const
 {
 	TBonusListPtr out(new BonusList());
-	TBonusListPtr heroBonuses = hero->getAllBonuses(selector, limit, hero, cachingStr);
-	TBonusListPtr bonusesFromPickedUpArtifact;
+	TConstBonusListPtr heroBonuses = hero->getAllBonuses(selector, limit, hero, cachingStr);
+	TConstBonusListPtr bonusesFromPickedUpArtifact;
 
 	std::shared_ptr<CArtifactsOfHero::SCommonPart> cp = cww->getCommonPart();
 	if(cp && cp->src.art && cp->src.valid() && cp->src.AOH && cp->src.AOH->getHero() == hero)
@@ -52,10 +52,10 @@ const TBonusListPtr CHeroWithMaybePickedArtifact::getAllBonuses(const CSelector 
 	else
 		bonusesFromPickedUpArtifact = TBonusListPtr(new BonusList());
 
-	for(auto b : *heroBonuses)
+	for(const auto & b : *heroBonuses)
 		out->push_back(b);
 
-	for(auto b : *bonusesFromPickedUpArtifact)
+	for(const auto & b : *bonusesFromPickedUpArtifact)
 		*out -= b;
 	return out;
 }
@@ -352,7 +352,7 @@ void CHeroWindow::dismissCurrent()
 void CHeroWindow::commanderWindow()
 {
 	//bool artSelected = false;
-	const std::shared_ptr<CArtifactsOfHero::SCommonPart> commonInfo = getCommonPart();
+	std::shared_ptr<CArtifactsOfHero::SCommonPart> commonInfo = getCommonPart();
 
 	if(const CArtifactInstance *art = commonInfo->src.art)
 	{

--- a/client/windows/CHeroWindow.h
+++ b/client/windows/CHeroWindow.h
@@ -48,7 +48,7 @@ public:
 	CWindowWithArtifacts * cww;
 
 	CHeroWithMaybePickedArtifact(CWindowWithArtifacts * Cww, const CGHeroInstance * Hero);
-	const TBonusListPtr getAllBonuses(const CSelector & selector, const CSelector & limit, const CBonusSystemNode * root = nullptr, const std::string & cachingStr = "") const override;
+	TConstBonusListPtr getAllBonuses(const CSelector & selector, const CSelector & limit, const CBonusSystemNode * root = nullptr, const std::string & cachingStr = "") const override;
 
 	int64_t getTreeVersion() const override;
 };

--- a/lib/CGameState.cpp
+++ b/lib/CGameState.cpp
@@ -1897,8 +1897,8 @@ UpgradeInfo CGameState::getUpgradeInfo(const CStackInstance &stack)
 		t = static_cast<const CGTownInstance *>(stack.armyObj);
 	else if(h)
 	{	//hero specialty
-		TBonusListPtr lista = h->getBonuses(Selector::typeSubtype(Bonus::SPECIAL_UPGRADE, base->idNumber));
-		for(const std::shared_ptr<Bonus> it : *lista)
+		TConstBonusListPtr lista = h->getBonuses(Selector::typeSubtype(Bonus::SPECIAL_UPGRADE, base->idNumber));
+		for(const auto & it : *lista)
 		{
 			auto nid = CreatureID(it->additionalInfo[0]);
 			if (nid != base->idNumber) //in very specific case the upgrade is available by default (?)

--- a/lib/CHeroHandler.cpp
+++ b/lib/CHeroHandler.cpp
@@ -592,7 +592,7 @@ std::vector<std::shared_ptr<Bonus>> SpecialtyBonusToBonuses(const SSpecialtyBonu
 			case Bonus::PRIMARY_SKILL:
 				if((newBonus->subtype == PrimarySkill::ATTACK || newBonus->subtype == PrimarySkill::DEFENSE) && newBonus->limiter)
 				{
-					const std::shared_ptr<CCreatureTypeLimiter> creatureLimiter = std::dynamic_pointer_cast<CCreatureTypeLimiter>(newBonus->limiter);
+					std::shared_ptr<CCreatureTypeLimiter> creatureLimiter = std::dynamic_pointer_cast<CCreatureTypeLimiter>(newBonus->limiter);
 					if(creatureLimiter)
 					{
 						const CCreature * cre = creatureLimiter->creature;

--- a/lib/CPathfinder.cpp
+++ b/lib/CPathfinder.cpp
@@ -1015,7 +1015,7 @@ bool CPathfinderHelper::passOneTurnLimitCheck(const PathNodeInfo & source) const
 	return true;
 }
 
-TurnInfo::BonusCache::BonusCache(TBonusListPtr bl)
+TurnInfo::BonusCache::BonusCache(TConstBonusListPtr bl)
 {
 	noTerrainPenalty.reserve(ETerrainType::ROCK);
 	for(int i = 0; i < ETerrainType::ROCK; i++)

--- a/lib/CPathfinder.h
+++ b/lib/CPathfinder.h
@@ -507,12 +507,12 @@ struct DLL_LINKAGE TurnInfo
 		bool waterWalking;
 		int waterWalkingVal;
 
-		BonusCache(TBonusListPtr bonusList);
+		BonusCache(TConstBonusListPtr bonusList);
 	};
 	std::unique_ptr<BonusCache> bonusCache;
 
 	const CGHeroInstance * hero;
-	TBonusListPtr bonuses;
+	TConstBonusListPtr bonuses;
 	mutable int maxMovePointsLand;
 	mutable int maxMovePointsWater;
 	int nativeTerrain;

--- a/lib/CStack.cpp
+++ b/lib/CStack.cpp
@@ -141,8 +141,8 @@ std::vector<si32> CStack::activeSpells() const
 		return b->type != Bonus::NONE;
 	}));
 
-	TBonusListPtr spellEffects = getBonuses(selector, Selector::all, cachingStr.str());
-	for(const std::shared_ptr<Bonus> it : *spellEffects)
+	TConstBonusListPtr spellEffects = getBonuses(selector, Selector::all, cachingStr.str());
+	for(const auto & it : *spellEffects)
 	{
 		if(!vstd::contains(ret, it->sid))  //do not duplicate spells with multiple effects
 			ret.push_back(it->sid);

--- a/lib/HeroBonus.cpp
+++ b/lib/HeroBonus.cpp
@@ -136,7 +136,7 @@ CBonusProxy & CBonusProxy::operator=(CBonusProxy && other)
 	return *this;
 }
 
-TBonusListPtr CBonusProxy::get() const
+TConstBonusListPtr CBonusProxy::get() const
 {
 	if(target->getTreeVersion() != cachedLast || !data)
 	{
@@ -381,8 +381,8 @@ void BonusList::stackBonuses()
 	while(next < bonuses.size())
 	{
 		bool remove;
-		const std::shared_ptr<Bonus> last = bonuses[next-1];
-		const std::shared_ptr<Bonus> current = bonuses[next];
+		std::shared_ptr<Bonus> last = bonuses[next-1];
+		std::shared_ptr<Bonus> current = bonuses[next];
 
 		if(current->stacking.empty())
 			remove = current == last;
@@ -494,7 +494,7 @@ std::shared_ptr<Bonus> BonusList::getFirst(const CSelector &select)
 	return nullptr;
 }
 
-const std::shared_ptr<Bonus> BonusList::getFirst(const CSelector &selector) const
+std::shared_ptr<const Bonus> BonusList::getFirst(const CSelector &selector) const
 {
 	for (auto & b : bonuses)
 	{
@@ -617,7 +617,7 @@ int IBonusBearer::valOfBonuses(Bonus::BonusType type, int subtype) const
 int IBonusBearer::valOfBonuses(const CSelector &selector, const std::string &cachingStr) const
 {
 	CSelector limit = nullptr;
-	TBonusListPtr hlp = getAllBonuses(selector, limit, nullptr, cachingStr);
+	TConstBonusListPtr hlp = getAllBonuses(selector, limit, nullptr, cachingStr);
 	return hlp->totalValue();
 }
 bool IBonusBearer::hasBonus(const CSelector &selector, const std::string &cachingStr) const
@@ -642,12 +642,12 @@ bool IBonusBearer::hasBonusOfType(Bonus::BonusType type, int subtype) const
 	return hasBonus(s, fmt.str());
 }
 
-const TBonusListPtr IBonusBearer::getBonuses(const CSelector &selector, const std::string &cachingStr) const
+TConstBonusListPtr IBonusBearer::getBonuses(const CSelector &selector, const std::string &cachingStr) const
 {
 	return getAllBonuses(selector, nullptr, nullptr, cachingStr);
 }
 
-const TBonusListPtr IBonusBearer::getBonuses(const CSelector &selector, const CSelector &limit, const std::string &cachingStr) const
+TConstBonusListPtr IBonusBearer::getBonuses(const CSelector &selector, const CSelector &limit, const std::string &cachingStr) const
 {
 	return getAllBonuses(selector, limit, nullptr, cachingStr);
 }
@@ -778,7 +778,7 @@ bool IBonusBearer::isLiving() const //TODO: theoreticaly there exists "LIVING" b
 	return !hasBonus(selector, cachingStr);
 }
 
-const std::shared_ptr<Bonus> IBonusBearer::getBonus(const CSelector &selector) const
+std::shared_ptr<const Bonus> IBonusBearer::getBonus(const CSelector &selector) const
 {
 	auto bonuses = getAllBonuses(selector, Selector::all);
 	return bonuses->getFirst(Selector::all);
@@ -800,7 +800,7 @@ std::shared_ptr<Bonus> CBonusSystemNode::getBonusLocalFirst(const CSelector &sel
 	return nullptr;
 }
 
-const std::shared_ptr<Bonus> CBonusSystemNode::getBonusLocalFirst( const CSelector &selector ) const
+std::shared_ptr<const Bonus> CBonusSystemNode::getBonusLocalFirst( const CSelector &selector ) const
 {
 	return (const_cast<CBonusSystemNode*>(this))->getBonusLocalFirst(selector);
 }
@@ -849,7 +849,7 @@ void CBonusSystemNode::getAllBonusesRec(BonusList &out) const
 		out.push_back(update(b));
 }
 
-const TBonusListPtr CBonusSystemNode::getAllBonuses(const CSelector &selector, const CSelector &limit, const CBonusSystemNode *root, const std::string &cachingStr) const
+TConstBonusListPtr CBonusSystemNode::getAllBonuses(const CSelector &selector, const CSelector &limit, const CBonusSystemNode *root, const std::string &cachingStr) const
 {
 	bool limitOnUs = (!root || root == this); //caching won't work when we want to limit bonuses against an external node
 	if (CBonusSystemNode::cachingEnabled && limitOnUs)
@@ -902,7 +902,7 @@ const TBonusListPtr CBonusSystemNode::getAllBonuses(const CSelector &selector, c
 	}
 }
 
-const TBonusListPtr CBonusSystemNode::getAllBonusesWithoutCaching(const CSelector &selector, const CSelector &limit, const CBonusSystemNode *root) const
+TConstBonusListPtr CBonusSystemNode::getAllBonusesWithoutCaching(const CSelector &selector, const CSelector &limit, const CBonusSystemNode *root) const
 {
 	auto ret = std::make_shared<BonusList>();
 
@@ -936,7 +936,7 @@ const TBonusListPtr CBonusSystemNode::getAllBonusesWithoutCaching(const CSelecto
 	return ret;
 }
 
-const std::shared_ptr<Bonus> CBonusSystemNode::update(const std::shared_ptr<Bonus> b) const
+std::shared_ptr<Bonus> CBonusSystemNode::update(const std::shared_ptr<Bonus> & b) const
 {
 	if(b->updater)
 		return b->updater->update(b, *this);
@@ -2126,7 +2126,7 @@ IUpdater::~IUpdater()
 {
 }
 
-const std::shared_ptr<Bonus> IUpdater::update(const std::shared_ptr<Bonus> b, const CBonusSystemNode & context) const
+std::shared_ptr<Bonus> IUpdater::update(const std::shared_ptr<Bonus> & b, const CBonusSystemNode & context) const
 {
 	return b;
 }
@@ -2149,7 +2149,7 @@ GrowsWithLevelUpdater::GrowsWithLevelUpdater(int valPer20, int stepSize) : valPe
 {
 }
 
-const std::shared_ptr<Bonus> GrowsWithLevelUpdater::update(const std::shared_ptr<Bonus> b, const CBonusSystemNode & context) const
+std::shared_ptr<Bonus> GrowsWithLevelUpdater::update(const std::shared_ptr<Bonus> & b, const CBonusSystemNode & context) const
 {
 	if(context.getNodeType() == CBonusSystemNode::HERO)
 	{
@@ -2186,7 +2186,7 @@ TimesHeroLevelUpdater::TimesHeroLevelUpdater()
 {
 }
 
-const std::shared_ptr<Bonus> TimesHeroLevelUpdater::update(const std::shared_ptr<Bonus> b, const CBonusSystemNode & context) const
+std::shared_ptr<Bonus> TimesHeroLevelUpdater::update(const std::shared_ptr<Bonus> & b, const CBonusSystemNode & context) const
 {
 	if(context.getNodeType() == CBonusSystemNode::HERO)
 	{
@@ -2212,7 +2212,7 @@ TimesStackLevelUpdater::TimesStackLevelUpdater()
 {
 }
 
-const std::shared_ptr<Bonus> TimesStackLevelUpdater::update(const std::shared_ptr<Bonus> b, const CBonusSystemNode & context) const
+std::shared_ptr<Bonus> TimesStackLevelUpdater::update(const std::shared_ptr<Bonus> & b, const CBonusSystemNode & context) const
 {
 	if(context.getNodeType() == CBonusSystemNode::STACK_INSTANCE)
 	{

--- a/lib/HeroBonus.h
+++ b/lib/HeroBonus.h
@@ -22,6 +22,7 @@ class IUpdater;
 class BonusList;
 
 typedef std::shared_ptr<BonusList> TBonusListPtr;
+typedef std::shared_ptr<const BonusList> TConstBonusListPtr;
 typedef std::shared_ptr<ILimiter> TLimiterPtr;
 typedef std::shared_ptr<IPropagator> TPropagatorPtr;
 typedef std::shared_ptr<IUpdater> TUpdaterPtr;
@@ -77,14 +78,14 @@ public:
 	CBonusProxy & operator=(CBonusProxy && other);
 	CBonusProxy & operator=(const CBonusProxy & other);
 
-	TBonusListPtr get() const;
+	TConstBonusListPtr get() const;
 
 	const BonusList * operator->() const;
 private:
 	mutable int64_t cachedLast;
 	const IBonusBearer * target;
 	CSelector selector;
-	mutable TBonusListPtr data;
+	mutable TConstBonusListPtr data;
 };
 
 class DLL_LINKAGE CTotalsProxy
@@ -568,7 +569,7 @@ public:
 
 	//special find functions
 	std::shared_ptr<Bonus> getFirst(const CSelector &select);
-	const std::shared_ptr<Bonus> getFirst(const CSelector &select) const;
+	std::shared_ptr<const Bonus> getFirst(const CSelector &select) const;
 	int valOfBonuses(const CSelector &select) const;
 
 	// conversion / output
@@ -662,7 +663,7 @@ public:
 
 struct BonusLimitationContext
 {
-	const std::shared_ptr<Bonus> b;
+	std::shared_ptr<const Bonus> b;
 	const CBonusSystemNode & node;
 	const BonusList & alreadyAccepted;
 	const BonusList & stillUndecided;
@@ -700,14 +701,14 @@ public:
 	// * root is node on which call was made (nullptr will be replaced with this)
 	//interface
 	IBonusBearer();
-	virtual const TBonusListPtr getAllBonuses(const CSelector &selector, const CSelector &limit, const CBonusSystemNode *root = nullptr, const std::string &cachingStr = "") const = 0;
+	virtual TConstBonusListPtr getAllBonuses(const CSelector &selector, const CSelector &limit, const CBonusSystemNode *root = nullptr, const std::string &cachingStr = "") const = 0;
 	int valOfBonuses(const CSelector &selector, const std::string &cachingStr = "") const;
 	bool hasBonus(const CSelector &selector, const std::string &cachingStr = "") const;
 	bool hasBonus(const CSelector &selector, const CSelector &limit, const std::string &cachingStr = "") const;
-	const TBonusListPtr getBonuses(const CSelector &selector, const CSelector &limit, const std::string &cachingStr = "") const;
-	const TBonusListPtr getBonuses(const CSelector &selector, const std::string &cachingStr = "") const;
+	TConstBonusListPtr getBonuses(const CSelector &selector, const CSelector &limit, const std::string &cachingStr = "") const;
+	TConstBonusListPtr getBonuses(const CSelector &selector, const std::string &cachingStr = "") const;
 
-	const std::shared_ptr<Bonus> getBonus(const CSelector &selector) const; //returns any bonus visible on node that matches (or nullptr if none matches)
+	std::shared_ptr<const Bonus> getBonus(const CSelector &selector) const; //returns any bonus visible on node that matches (or nullptr if none matches)
 
 	//legacy interface
 	int valOfBonuses(Bonus::BonusType type, const CSelector &selector) const;
@@ -766,8 +767,8 @@ private:
 
 	void getBonusesRec(BonusList &out, const CSelector &selector, const CSelector &limit) const;
 	void getAllBonusesRec(BonusList &out) const;
-	const TBonusListPtr getAllBonusesWithoutCaching(const CSelector &selector, const CSelector &limit, const CBonusSystemNode *root = nullptr) const;
-	const std::shared_ptr<Bonus> update(const std::shared_ptr<Bonus> b) const;
+	TConstBonusListPtr getAllBonusesWithoutCaching(const CSelector &selector, const CSelector &limit, const CBonusSystemNode *root = nullptr) const;
+	std::shared_ptr<Bonus> update(const std::shared_ptr<Bonus> & b) const;
 
 public:
 	explicit CBonusSystemNode();
@@ -777,9 +778,9 @@ public:
 
 	void limitBonuses(const BonusList &allBonuses, BonusList &out) const; //out will bo populed with bonuses that are not limited here
 	TBonusListPtr limitBonuses(const BonusList &allBonuses) const; //same as above, returns out by val for convienence
-	const TBonusListPtr getAllBonuses(const CSelector &selector, const CSelector &limit, const CBonusSystemNode *root = nullptr, const std::string &cachingStr = "") const override;
+	TConstBonusListPtr getAllBonuses(const CSelector &selector, const CSelector &limit, const CBonusSystemNode *root = nullptr, const std::string &cachingStr = "") const override;
 	void getParents(TCNodes &out) const;  //retrieves list of parent nodes (nodes to inherit bonuses from),
-	const std::shared_ptr<Bonus> getBonusLocalFirst(const CSelector &selector) const;
+	std::shared_ptr<const Bonus> getBonusLocalFirst(const CSelector &selector) const;
 
 	//non-const interface
 	void getParents(TNodes &out);  //retrieves list of parent nodes (nodes to inherit bonuses from)
@@ -1165,7 +1166,7 @@ class DLL_LINKAGE IUpdater
 public:
 	virtual ~IUpdater();
 
-	virtual const std::shared_ptr<Bonus> update(const std::shared_ptr<Bonus> b, const CBonusSystemNode & context) const;
+	virtual std::shared_ptr<Bonus> update(const std::shared_ptr<Bonus> & b, const CBonusSystemNode & context) const;
 	virtual std::string toString() const;
 	virtual JsonNode toJsonNode() const;
 
@@ -1190,7 +1191,7 @@ public:
 		h & stepSize;
 	}
 
-	const std::shared_ptr<Bonus> update(const std::shared_ptr<Bonus> b, const CBonusSystemNode & context) const override;
+	std::shared_ptr<Bonus> update(const std::shared_ptr<Bonus> & b, const CBonusSystemNode & context) const override;
 	virtual std::string toString() const override;
 	virtual JsonNode toJsonNode() const override;
 };
@@ -1205,7 +1206,7 @@ public:
 		h & static_cast<IUpdater &>(*this);
 	}
 
-	const std::shared_ptr<Bonus> update(const std::shared_ptr<Bonus> b, const CBonusSystemNode & context) const override;
+	std::shared_ptr<Bonus> update(const std::shared_ptr<Bonus> & b, const CBonusSystemNode & context) const override;
 	virtual std::string toString() const override;
 	virtual JsonNode toJsonNode() const override;
 };
@@ -1220,7 +1221,7 @@ public:
 		h & static_cast<IUpdater &>(*this);
 	}
 
-	const std::shared_ptr<Bonus> update(const std::shared_ptr<Bonus> b, const CBonusSystemNode & context) const override;
+	std::shared_ptr<Bonus> update(const std::shared_ptr<Bonus> & b, const CBonusSystemNode & context) const override;
 	virtual std::string toString() const override;
 	virtual JsonNode toJsonNode() const override;
 };

--- a/lib/battle/CBattleInfoCallback.cpp
+++ b/lib/battle/CBattleInfoCallback.cpp
@@ -680,7 +680,7 @@ bool CBattleInfoCallback::battleCanShoot(const battle::Unit * attacker) const
 		return false;
 
 	//forgetfulness
-	TBonusListPtr forgetfulList = attacker->getBonuses(Selector::type(Bonus::FORGETFULL));
+	TConstBonusListPtr forgetfulList = attacker->getBonuses(Selector::type(Bonus::FORGETFULL));
 	if (!forgetfulList->empty())
 	{
 		int forgetful = forgetfulList->valOfBonuses(Selector::type(Bonus::FORGETFULL));
@@ -749,7 +749,7 @@ TDmgRange CBattleInfoCallback::calculateDmgRange(const BattleAttackInfo & info) 
 	{ //minDmg and maxDmg are multiplied by hero attack + 1
 		auto retrieveHeroPrimSkill = [&](int skill) -> int
 		{
-			const std::shared_ptr<Bonus> b = attackerBonuses->getBonus(Selector::sourceTypeSel(Bonus::HERO_BASE_SKILL).And(Selector::typeSubtype(Bonus::PRIMARY_SKILL, skill)));
+			std::shared_ptr<const Bonus> b = attackerBonuses->getBonus(Selector::sourceTypeSel(Bonus::HERO_BASE_SKILL).And(Selector::typeSubtype(Bonus::PRIMARY_SKILL, skill)));
 			return b ? b->val : 0; //if there is no hero or no info on his primary skill, return 0
 		};
 
@@ -772,7 +772,7 @@ TDmgRange CBattleInfoCallback::calculateDmgRange(const BattleAttackInfo & info) 
 	//slayer handling //TODO: apply only ONLY_MELEE_FIGHT / DISTANCE_FIGHT?
 	auto slayerEffects = attackerBonuses->getBonuses(selectorSlayer, cachingStrSlayer);
 
-	if(const std::shared_ptr<Bonus> slayerEffect = slayerEffects->getFirst(Selector::all))
+	if(std::shared_ptr<const Bonus> slayerEffect = slayerEffects->getFirst(Selector::all))
 	{
 		std::vector<int32_t> affectedIds;
 		const auto spLevel = slayerEffect->val;
@@ -863,7 +863,7 @@ TDmgRange CBattleInfoCallback::calculateDmgRange(const BattleAttackInfo & info) 
 		//todo: set actual percentage in spell bonus configuration instead of just level; requires non trivial backward compatibility handling
 
 		//get list first, total value of 0 also counts
-		TBonusListPtr forgetfulList = attackerBonuses->getBonuses(Selector::type(Bonus::FORGETFULL),"type_FORGETFULL");
+		TConstBonusListPtr forgetfulList = attackerBonuses->getBonuses(Selector::type(Bonus::FORGETFULL),"type_FORGETFULL");
 
 		if(!forgetfulList->empty())
 		{
@@ -883,8 +883,8 @@ TDmgRange CBattleInfoCallback::calculateDmgRange(const BattleAttackInfo & info) 
 	const std::string cachingStrForcedMaxDamage = "type_ALWAYS_MAXIMUM_DAMAGE";
 	static const auto selectorForcedMaxDamage = Selector::type(Bonus::ALWAYS_MAXIMUM_DAMAGE);
 
-	TBonusListPtr curseEffects = attackerBonuses->getBonuses(selectorForcedMinDamage, cachingStrForcedMinDamage);
-	TBonusListPtr blessEffects = attackerBonuses->getBonuses(selectorForcedMaxDamage, cachingStrForcedMaxDamage);
+	TConstBonusListPtr curseEffects = attackerBonuses->getBonuses(selectorForcedMinDamage, cachingStrForcedMinDamage);
+	TConstBonusListPtr blessEffects = attackerBonuses->getBonuses(selectorForcedMaxDamage, cachingStrForcedMaxDamage);
 
 	int curseBlessAdditiveModifier = blessEffects->totalValue() - curseEffects->totalValue();
 	double curseMultiplicativePenalty = curseEffects->size() ? (*std::max_element(curseEffects->begin(), curseEffects->end(), &Bonus::compareByAdditionalInfo<std::shared_ptr<Bonus>>))->additionalInfo[0] : 0;
@@ -1860,7 +1860,7 @@ SpellID CBattleInfoCallback::getRandomCastedSpell(CRandomGenerator & rand,const 
 {
 	RETURN_IF_NOT_BATTLE(SpellID::NONE);
 
-	TBonusListPtr bl = caster->getBonuses(Selector::type(Bonus::SPELLCASTER));
+	TConstBonusListPtr bl = caster->getBonuses(Selector::type(Bonus::SPELLCASTER));
 	if (!bl->size())
 		return SpellID::NONE;
 	int totalWeight = 0;

--- a/lib/battle/CUnitState.cpp
+++ b/lib/battle/CUnitState.cpp
@@ -896,7 +896,7 @@ CUnitStateDetached::CUnitStateDetached(const IUnitInfo * unit_, const IBonusBear
 
 }
 
-const TBonusListPtr CUnitStateDetached::getAllBonuses(const CSelector & selector, const CSelector & limit, const CBonusSystemNode * root, const std::string & cachingStr) const
+TConstBonusListPtr CUnitStateDetached::getAllBonuses(const CSelector & selector, const CSelector & limit, const CBonusSystemNode * root, const std::string & cachingStr) const
 {
 	return bonus->getAllBonuses(selector, limit, root, cachingStr);
 }

--- a/lib/battle/CUnitState.h
+++ b/lib/battle/CUnitState.h
@@ -268,7 +268,7 @@ class DLL_LINKAGE CUnitStateDetached : public CUnitState
 public:
 	explicit CUnitStateDetached(const IUnitInfo * unit_, const IBonusBearer * bonus_);
 
-	const TBonusListPtr getAllBonuses(const CSelector & selector, const CSelector & limit,
+	TConstBonusListPtr getAllBonuses(const CSelector & selector, const CSelector & limit,
 		const CBonusSystemNode * root = nullptr, const std::string & cachingStr = "") const override;
 
 	int64_t getTreeVersion() const override;

--- a/lib/mapObjects/CGHeroInstance.cpp
+++ b/lib/mapObjects/CGHeroInstance.cpp
@@ -816,7 +816,7 @@ CStackBasicDescriptor CGHeroInstance::calculateNecromancy (const BattleResult &b
 		// figure out what to raise - pick strongest creature meeting requirements
 		CreatureID creatureTypeRaised = CreatureID::SKELETON;
 		int requiredCasualtyLevel = 1;
-		const TBonusListPtr improvedNecromancy = getBonuses(Selector::type(Bonus::IMPROVED_NECROMANCY));
+		TConstBonusListPtr improvedNecromancy = getBonuses(Selector::type(Bonus::IMPROVED_NECROMANCY));
 		if(!improvedNecromancy->empty())
 		{
 			auto getCreatureID = [necromancyLevel](std::shared_ptr<Bonus> bonus) -> CreatureID

--- a/lib/mapObjects/CGTownInstance.cpp
+++ b/lib/mapObjects/CGTownInstance.cpp
@@ -556,13 +556,13 @@ GrowthInfo CGTownInstance::getGrowthInfo(int level) const
 		ret.entries.push_back(GrowthInfo::Entry(VLC->generaltexth->allTexts[591], dwellingBonus));// \nExternal dwellings %+d
 
 	//other *-of-legion-like bonuses (%d to growth cumulative with grail)
-	TBonusListPtr bonuses = getBonuses(Selector::type(Bonus::CREATURE_GROWTH).And(Selector::subtype(level)));
-	for(const std::shared_ptr<Bonus> b : *bonuses)
+	TConstBonusListPtr bonuses = getBonuses(Selector::type(Bonus::CREATURE_GROWTH).And(Selector::subtype(level)));
+	for(const auto & b : *bonuses)
 		ret.entries.push_back(GrowthInfo::Entry(b->val, b->Description()));
 
 	//statue-of-legion-like bonus: % to base+castle
-	TBonusListPtr bonuses2 = getBonuses(Selector::type(Bonus::CREATURE_GROWTH_PERCENT));
-	for(const std::shared_ptr<Bonus> b : *bonuses2)
+	TConstBonusListPtr bonuses2 = getBonuses(Selector::type(Bonus::CREATURE_GROWTH_PERCENT));
+	for(const auto & b : *bonuses2)
 		ret.entries.push_back(GrowthInfo::Entry(b->val * (base + castleBonus) / 100, b->Description()));
 
 	if(hasBuilt(BuildingID::GRAIL)) //grail - +50% to ALL (so far added) growth

--- a/lib/spells/TargetCondition.cpp
+++ b/lib/spells/TargetCondition.cpp
@@ -115,7 +115,7 @@ protected:
 		std::stringstream cachingStr;
 		cachingStr << "type_" << Bonus::LEVEL_SPELL_IMMUNITY << "addInfo_1";
 
-		TBonusListPtr levelImmunities = target->getBonuses(Selector::type(Bonus::LEVEL_SPELL_IMMUNITY).And(Selector::info(1)), cachingStr.str());
+		TConstBonusListPtr levelImmunities = target->getBonuses(Selector::type(Bonus::LEVEL_SPELL_IMMUNITY).And(Selector::info(1)), cachingStr.str());
 		
 		return levelImmunities->size() == 0 ||
 		levelImmunities->totalValue() < m->getSpellLevel() ||
@@ -190,7 +190,7 @@ public:
 protected:
 	bool check(const Mechanics * m, const battle::Unit * target) const override
 	{
-		TBonusListPtr levelImmunities = target->getBonuses(Selector::type(Bonus::LEVEL_SPELL_IMMUNITY));
+		TConstBonusListPtr levelImmunities = target->getBonuses(Selector::type(Bonus::LEVEL_SPELL_IMMUNITY));
 		return levelImmunities->size() == 0 ||
 		levelImmunities->totalValue() < m->getSpellLevel() ||
 		m->getSpellLevel() <= 0;

--- a/lib/spells/effects/Dispel.cpp
+++ b/lib/spells/effects/Dispel.cpp
@@ -60,7 +60,7 @@ void Dispel::serializeJsonUnitEffect(JsonSerializeFormat & handler)
 	handler.serializeBool("dispelNeutral", neutral);
 }
 
-std::shared_ptr<BonusList> Dispel::getBonuses(const Mechanics * m, const battle::Unit * unit) const
+std::shared_ptr<const BonusList> Dispel::getBonuses(const Mechanics * m, const battle::Unit * unit) const
 {
 	auto addSelector = [=](const Bonus * bonus)
 	{

--- a/lib/spells/effects/Dispel.h
+++ b/lib/spells/effects/Dispel.h
@@ -39,7 +39,7 @@ private:
 	bool negative = false;
 	bool neutral = false;
 
-	std::shared_ptr<BonusList> getBonuses(const Mechanics * m, const battle::Unit * unit) const;
+	std::shared_ptr<const BonusList> getBonuses(const Mechanics * m, const battle::Unit * unit) const;
 
 	static bool mainSelector(const Bonus * bonus);
 	void prepareEffects(SetStackEffect & pack, RNG & rng, const Mechanics * m, const EffectTarget & target, bool describe) const;

--- a/lib/spells/effects/Timed.cpp
+++ b/lib/spells/effects/Timed.cpp
@@ -151,7 +151,7 @@ void Timed::prepareEffects(SetStackEffect & sse, const Mechanics * m, const Effe
 	std::vector<Bonus> converted;
     convertBonus(m, duration, converted);
 
-	std::shared_ptr<Bonus> bonus = nullptr;
+	std::shared_ptr<const Bonus> bonus = nullptr;
 	auto casterHero = dynamic_cast<const CGHeroInstance *>(m->caster);
 	if(casterHero)
 		bonus = casterHero->getBonusLocalFirst(Selector::typeSubtype(Bonus::SPECIAL_PECULIAR_ENCHANT, m->getSpellIndex()));

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -1015,7 +1015,7 @@ void CGameHandler::makeAttack(const CStack * attacker, const CStack * defender, 
 			applyBattleEffects(bat, attackerState, fireShield, stack, distance, true);
 	}
 
-	const std::shared_ptr<Bonus> bonus = attacker->getBonusLocalFirst(Selector::type(Bonus::SPELL_LIKE_ATTACK));
+	std::shared_ptr<const Bonus> bonus = attacker->getBonusLocalFirst(Selector::type(Bonus::SPELL_LIKE_ATTACK));
 	if(bonus && ranged) //TODO: make it work in melee?
 	{
 		//this is need for displaying hit animation
@@ -4492,8 +4492,8 @@ bool CGameHandler::makeBattleAction(BattleAction &ba)
 			const CStack * stack = gs->curB->battleGetStackByID(ba.stackNumber);
 			SpellID spellID = SpellID(ba.actionSubtype);
 
-			const std::shared_ptr<Bonus> randSpellcaster = stack->getBonusLocalFirst(Selector::type(Bonus::RANDOM_SPELLCASTER));
-			const std::shared_ptr<Bonus> spellcaster = stack->getBonusLocalFirst(Selector::typeSubtype(Bonus::SPELLCASTER, spellID));
+			std::shared_ptr<const Bonus> randSpellcaster = stack->getBonusLocalFirst(Selector::type(Bonus::RANDOM_SPELLCASTER));
+			std::shared_ptr<const Bonus> spellcaster = stack->getBonusLocalFirst(Selector::typeSubtype(Bonus::SPELLCASTER, spellID));
 
 			//TODO special bonus for genies ability
 			if (randSpellcaster && battleGetRandomStackSpell(getRandomGenerator(), stack, CBattleInfoCallback::RANDOM_AIMED) < 0)
@@ -4738,7 +4738,7 @@ void CGameHandler::stackTurnTrigger(const CStack *st)
 
 		if (st->hasBonusOfType(Bonus::POISON))
 		{
-			const std::shared_ptr<Bonus> b = st->getBonusLocalFirst(Selector::source(Bonus::SPELL_EFFECT, SpellID::POISON).And(Selector::type(Bonus::STACK_HEALTH)));
+			std::shared_ptr<const Bonus> b = st->getBonusLocalFirst(Selector::source(Bonus::SPELL_EFFECT, SpellID::POISON).And(Selector::type(Bonus::STACK_HEALTH)));
 			if (b) //TODO: what if not?...
 			{
 				bte.val = std::max (b->val - 10, -(st->valOfBonuses(Bonus::POISON)));
@@ -5412,8 +5412,8 @@ void CGameHandler::attackCasting(bool ranged, Bonus::BonusType attackMode, const
 	if(attacker->hasBonusOfType(attackMode))
 	{
 		std::set<SpellID> spellsToCast;
-		TBonusListPtr spells = attacker->getBonuses(Selector::type(attackMode));
-		for(const std::shared_ptr<Bonus> sf : *spells)
+		TConstBonusListPtr spells = attacker->getBonuses(Selector::type(attackMode));
+		for(const auto & sf : *spells)
 		{
 			spellsToCast.insert(SpellID(sf->subtype));
 		}
@@ -5426,8 +5426,8 @@ void CGameHandler::attackCasting(bool ranged, Bonus::BonusType attackMode, const
 				return;
 			}
 			int32_t spellLevel = 0;
-			TBonusListPtr spellsByType = attacker->getBonuses(Selector::typeSubtype(attackMode, spellID));
-			for(const std::shared_ptr<Bonus> sf : *spellsByType)
+			TConstBonusListPtr spellsByType = attacker->getBonuses(Selector::typeSubtype(attackMode, spellID));
+			for(const auto & sf : *spellsByType)
 			{
 				int meleeRanged;
 				if(sf->additionalInfo.size() < 2)
@@ -5522,8 +5522,8 @@ void CGameHandler::handleAfterAttackCasting(bool ranged, const CStack * attacker
 		return;
 
 	int64_t acidDamage = 0;
-	TBonusListPtr acidBreath = attacker->getBonuses(Selector::type(Bonus::ACID_BREATH));
-	for(const std::shared_ptr<Bonus> b : *acidBreath)
+	TConstBonusListPtr acidBreath = attacker->getBonuses(Selector::type(Bonus::ACID_BREATH));
+	for(const auto & b : *acidBreath)
 	{
 		if(b->additionalInfo[0] > getRandomGenerator().nextInt(99))
 			acidDamage += b->val;
@@ -5916,7 +5916,7 @@ void CGameHandler::runBattle()
 	{
 		if (stack->hasBonusOfType(Bonus::SUMMON_GUARDIANS))
 		{
-			const std::shared_ptr<Bonus> summonInfo = stack->getBonus(Selector::type(Bonus::SUMMON_GUARDIANS));
+			std::shared_ptr<const Bonus> summonInfo = stack->getBonus(Selector::type(Bonus::SUMMON_GUARDIANS));
 			auto accessibility = getAccesibility();
 			CreatureID creatureData = CreatureID(summonInfo->subtype);
 			std::vector<BattleHex> targetHexes;
@@ -5961,7 +5961,7 @@ void CGameHandler::runBattle()
 		auto h = gs->curB->battleGetFightingHero(i);
 		if (h)
 		{
-			TBonusListPtr bl = h->getBonuses(Selector::type(Bonus::OPENING_BATTLE_SPELL));
+			TConstBonusListPtr bl = h->getBonuses(Selector::type(Bonus::OPENING_BATTLE_SPELL));
 
 			for (auto b : *bl)
 			{

--- a/test/mock/mock_BonusBearer.cpp
+++ b/test/mock/mock_BonusBearer.cpp
@@ -25,7 +25,7 @@ void BonusBearerMock::addNewBonus(const std::shared_ptr<Bonus> & b)
 	treeVersion++;
 }
 
-const TBonusListPtr BonusBearerMock::getAllBonuses(const CSelector & selector, const CSelector & limit, const CBonusSystemNode * root, const std::string & cachingStr) const
+TConstBonusListPtr BonusBearerMock::getAllBonuses(const CSelector & selector, const CSelector & limit, const CBonusSystemNode * root, const std::string & cachingStr) const
 {
 	if(cachedLast != treeVersion)
 	{

--- a/test/mock/mock_BonusBearer.h
+++ b/test/mock/mock_BonusBearer.h
@@ -21,7 +21,7 @@ public:
 
 	void addNewBonus(const std::shared_ptr<Bonus> & b);
 
-	const TBonusListPtr getAllBonuses(const CSelector & selector, const CSelector & limit, const CBonusSystemNode * root = nullptr, const std::string & cachingStr = "") const override;
+	TConstBonusListPtr getAllBonuses(const CSelector & selector, const CSelector & limit, const CBonusSystemNode * root = nullptr, const std::string & cachingStr = "") const override;
 
 	int64_t getTreeVersion() const override;
 private:

--- a/test/mock/mock_battle_Unit.h
+++ b/test/mock/mock_battle_Unit.h
@@ -15,7 +15,7 @@
 class UnitMock : public battle::Unit
 {
 public:
-	MOCK_CONST_METHOD4(getAllBonuses, const TBonusListPtr(const CSelector &, const CSelector &, const CBonusSystemNode *, const std::string &));
+	MOCK_CONST_METHOD4(getAllBonuses, TConstBonusListPtr(const CSelector &, const CSelector &, const CBonusSystemNode *, const std::string &));
 	MOCK_CONST_METHOD0(getTreeVersion, int64_t());
 
 	MOCK_CONST_METHOD0(getCasterUnitId, int32_t());


### PR DESCRIPTION
Replaced const TBonusListPtr with TConstBonusListPtr where necessary
Replaced const std::shared_ptr<T> with std::shared_ptr<const T> where necessary.
Removed superfluous use of const.
Replaced const std::shared_ptr<T> with const std::shared_ptr<T> & in function parameters and ranged for-loops.