### PR TITLE
Mod system improvement: Special buildings should work in modders towns. Part II.

### DIFF
--- a/config/factions/castle.json
+++ b/config/factions/castle.json
@@ -170,7 +170,7 @@
 				"resourceSilo":   { "id" : 15, "requires" : [ "marketplace" ], "produce": { "ore": 1, "wood": 1 } },
 				"blacksmith":     { "id" : 16 },
 
-				"special1":       { "requires" : [ "shipyard" ] },
+				"special1":       { "type" : "lighthouse", "requires" : [ "shipyard" ] },
 				"horde1":         { "id" : 18, "upgrades" : "dwellingLvl3" },
 				"horde1Upgr":     { "id" : 19, "upgrades" : "dwellingUpLvl3", "requires" : [ "horde1" ], "mode" : "auto" },
 				"ship":           { "id" : 20, "upgrades" : "shipyard" },

--- a/config/factions/dungeon.json
+++ b/config/factions/dungeon.json
@@ -174,7 +174,7 @@
 				"horde1Upgr":     { "id" : 19, "upgrades" : "dwellingUpLvl1", "requires" : [ "horde1" ], "mode" : "auto" },
 				"special2":       { "type" : "manaVortex", "requires" : [ "mageGuild1" ] },
 				"special3":       { "type" : "portalOfSummoning" },
-				"special4":       { },
+				"special4":       { "type" : "experienceVisitingBonus" },
 				"grail":          { "id" : 26, "mode" : "grail", "produce": { "gold": 5000 }},
 
 				"dwellingLvl1":   { "id" : 30, "requires" : [ "fort" ] },

--- a/config/factions/fortress.json
+++ b/config/factions/fortress.json
@@ -169,7 +169,7 @@
 				"resourceSilo":   { "id" : 15, "requires" : [ "marketplace" ], "produce": { "wood": 1, "ore": 1 } },
 				"blacksmith":     { "id" : 16 },
 
-				"special1":       { "requires" : [ "allOf", [ "townHall" ], [ "special2" ] ] },
+				"special1":       { "type" : "defenceVisitingBonus", "requires" : [ "allOf", [ "townHall" ], [ "special2" ] ] },
 				"horde1":         { "id" : 18, "upgrades" : "dwellingLvl1" },
 				"horde1Upgr":     { "id" : 19, "upgrades" : "dwellingUpLvl1", "requires" : [ "horde1" ], "mode" : "auto" },
 				"ship":           { "id" : 20, "upgrades" : "shipyard" },

--- a/config/factions/inferno.json
+++ b/config/factions/inferno.json
@@ -174,7 +174,7 @@
 				"horde1Upgr":     { "id" : 19, "upgrades" : "dwellingUpLvl1", "requires" : [ "horde1" ], "mode" : "auto" },
 				"special2":       { "type" : "spellPowerGarrisonBonus", "requires" : [ "fort" ] },
 				"special3":       { "type" : "castleGate", "requires" : [ "citadel" ] },
-				"special4":       { "requires" : [ "mageGuild1" ] },
+				"special4":       { "type" : "spellPowerVisitingBonus", "requires" : [ "mageGuild1" ] },
 				"horde2":         { "id" : 24, "upgrades" : "dwellingLvl3" },
 				"horde2Upgr":     { "id" : 25, "upgrades" : "dwellingUpLvl3", "requires" : [ "horde2" ], "mode" : "auto" },
 				"grail":          { "id" : 26, "mode" : "grail", "produce": { "gold": 5000 }},

--- a/config/factions/rampart.json
+++ b/config/factions/rampart.json
@@ -178,7 +178,7 @@
 				"horde1":         { "id" : 18, "upgrades" : "dwellingLvl2" },
 				"horde1Upgr":     { "id" : 19, "upgrades" : "dwellingUpLvl2", "requires" : [ "horde1" ], "mode" : "auto" },
 				"special2":       { "type" : "fountainOfFortune", "upgrades" : "special1" },
-				"special3":       { "requires" : [ "horde1" ] },
+				"special3":       { "type" : "treasury", "requires" : [ "horde1" ] },
 				"horde2":         { "id" : 24, "upgrades" : "dwellingLvl5" },
 				"horde2Upgr":     { "id" : 25, "upgrades" : "dwellingUpLvl5", "requires" : [ "horde2" ], "mode" : "auto" },
 				"grail":          { "id" : 26, "mode" : "grail", "produce": { "gold": 5000 }},

--- a/config/factions/stronghold.json
+++ b/config/factions/stronghold.json
@@ -171,7 +171,7 @@
 				"horde1Upgr":     { "id" : 19, "upgrades" : "dwellingUpLvl1", "requires" : [ "horde1" ], "mode" : "auto" },
 				"special2":       { "type" : "freelancersGuild", "requires" : [ "marketplace" ] },
 				"special3":       { "type" : "ballistaYard", "requires" : [ "blacksmith" ] },
-				"special4":       { "requires" : [ "fort" ] },
+				"special4":       { "type" : "attackVisitingBonus", "requires" : [ "fort" ] },
 				"grail":          { "id" : 26, "mode" : "grail", "produce": { "gold": 5000 }},
 
 				"dwellingLvl1":   { "id" : 30, "requires" : [ "fort" ] },

--- a/config/factions/tower.json
+++ b/config/factions/tower.json
@@ -174,7 +174,7 @@
 				"horde1Upgr":     { "id" : 19, "upgrades" : "dwellingUpLvl2", "requires" : [ "horde1" ], "mode" : "auto" },
 				"special2":       { "type" : "lookoutTower", "height" : "high", "requires" : [ "fort" ] },
 				"special3":       { "type" : "library", "requires" : [ "mageGuild1" ] },
-				"special4":       { "requires" : [ "mageGuild1" ] },
+				"special4":       { "type" : "knowledgeVisitingBonus", "requires" : [ "mageGuild1" ] },
 				"grail":          { "height" : "skyship",  "produce" : { "gold": 5000 } },
 
 				"dwellingLvl1":   { "id" : 30, "requires" : [ "fort" ] },

--- a/lib/CHeroHandler.h
+++ b/lib/CHeroHandler.h
@@ -195,6 +195,13 @@ public:
 		h & imageBattleFemale;
 		h & imageMapMale;
 		h & imageMapFemale;
+
+		if(!h.saving)
+		{
+			for(auto i = 0; i < secSkillProbability.size(); i++)
+				if(secSkillProbability[i] < 0)
+					secSkillProbability[i] = 0;
+		}
 	}
 	EAlignment::EAlignment getAlignment() const;
 };

--- a/lib/CSkillHandler.cpp
+++ b/lib/CSkillHandler.cpp
@@ -34,6 +34,7 @@ CSkill::LevelInfo::~LevelInfo()
 CSkill::CSkill(SecondarySkill id, std::string identifier)
 	: id(id), identifier(identifier)
 {
+	gainChance[0] = gainChance[1] = 0; //affects CHeroClassHandler::afterLoadFinalization()
 	levels.resize(NSecondarySkill::levels.size() - 1);
 }
 

--- a/lib/CTownHandler.h
+++ b/lib/CTownHandler.h
@@ -85,6 +85,22 @@ public:
 		return bid == BuildingID::MARKETPLACE || subId == BuildingSubID::ARTIFACT_MERCHANT || subId == BuildingSubID::FREELANCERS_GUILD;
 	}
 
+	STRONG_INLINE
+	bool IsWeekBonus() const
+	{
+		return subId == BuildingSubID::STABLES || subId == BuildingSubID::MANA_VORTEX;
+	}
+
+	STRONG_INLINE
+	bool IsVisitingBonus() const
+	{
+		return subId == BuildingSubID::ATTACK_VISITING_BONUS ||
+			subId == BuildingSubID::DEFENSE_VISITING_BONUS || 
+			subId == BuildingSubID::SPELL_POWER_VISITING_BONUS ||
+			subId == BuildingSubID::KNOWLEDGE_VISITING_BONUS ||
+			subId == BuildingSubID::EXPERIENCE_VISITING_BONUS;
+	}
+
 	/// input: faction, bid; output: subId, height;
 	void update792(const BuildingID & bid, BuildingSubID::EBuildingSubID & subId, ETowerHeight & height);
 

--- a/lib/GameConstants.h
+++ b/lib/GameConstants.h
@@ -442,11 +442,17 @@ namespace BuildingSubID
 		ESCAPE_TUNNEL,
 		FREELANCERS_GUILD,
 		BALLISTA_YARD,
-		HALL_OF_VALHALLA,
+		ATTACK_VISITING_BONUS,
 		MAGIC_UNIVERSITY,
 		SPELL_POWER_GARRISON_BONUS,
 		ATTACK_GARRISON_BONUS,
-		DEFENSE_GARRISON_BONUS
+		DEFENSE_GARRISON_BONUS,
+		DEFENSE_VISITING_BONUS,
+		SPELL_POWER_VISITING_BONUS,
+		KNOWLEDGE_VISITING_BONUS,
+		EXPERIENCE_VISITING_BONUS,
+		LIGHTHOUSE,
+		TREASURY
 	};
 }
 
@@ -490,7 +496,14 @@ namespace MappedKeys
 		{ "spellPowerGarrisonBonus", BuildingSubID::SPELL_POWER_GARRISON_BONUS },//such as 'stormclouds', but this name is not ok for good towns
 		{ "attackGarrisonBonus", BuildingSubID::ATTACK_GARRISON_BONUS },
 		{ "defenseGarrisonBonus", BuildingSubID::DEFENSE_GARRISON_BONUS },
-		{ "escapeTunnel", BuildingSubID::ESCAPE_TUNNEL }
+		{ "escapeTunnel", BuildingSubID::ESCAPE_TUNNEL },
+		{ "attackVisitingBonus", BuildingSubID::ATTACK_VISITING_BONUS },
+		{ "defenceVisitingBonus", BuildingSubID::DEFENSE_VISITING_BONUS },
+		{ "spellPowerVisitingBonus", BuildingSubID::SPELL_POWER_VISITING_BONUS },
+		{ "knowledgeVisitingBonus", BuildingSubID::KNOWLEDGE_VISITING_BONUS },
+		{ "experienceVisitingBonus", BuildingSubID::EXPERIENCE_VISITING_BONUS },
+		{ "lighthouse", BuildingSubID::LIGHTHOUSE },
+		{ "treasury", BuildingSubID::TREASURY }
 	};
 }
 

--- a/lib/mapObjects/CGTownInstance.h
+++ b/lib/mapObjects/CGTownInstance.h
@@ -158,7 +158,7 @@ public:
 	void setProperty(ui8 what, ui32 val) override;
 	void onHeroVisit (const CGHeroInstance * h) const override;
 
-	CTownBonus (BuildingID index, CGTownInstance *TOWN);
+	CTownBonus (BuildingID index, BuildingSubID::EBuildingSubID subId, CGTownInstance *TOWN);
 	CTownBonus () {};
 
 	template <typename Handler> void serialize(Handler &h, const int version)
@@ -262,6 +262,7 @@ public:
 	void deserializationFix();
 	void recreateBuildingsBonuses();
 	///bid: param to bind a building with a bonus, subId: param to check if already built
+	bool addBonusIfBuilt(BuildingSubID::EBuildingSubID subId, Bonus::BonusType type, int val, TPropagatorPtr & prop, int subtype = -1);
 	bool addBonusIfBuilt(BuildingSubID::EBuildingSubID subId, Bonus::BonusType type, int val, int subtype = -1);
 	bool addBonusIfBuilt(BuildingID building, Bonus::BonusType type, int val, TPropagatorPtr &prop, int subtype = -1); //returns true if building is built and bonus has been added
 	bool addBonusIfBuilt(BuildingID building, Bonus::BonusType type, int val, int subtype = -1); //convienence version of above
@@ -342,5 +343,7 @@ private:
 	bool hasBuiltInOldWay(ETownType::ETownType type, BuildingID bid) const;
 	bool addBonusImpl(BuildingID building, Bonus::BonusType type, int val, TPropagatorPtr & prop, const std::string & description, int subtype = -1);
 	bool townEnvisagesBuilding(BuildingSubID::EBuildingSubID bid) const;
-	bool tryAddOnePerWeekBonus(BuildingSubID::EBuildingSubID subID);
+	void tryAddOnePerWeekBonus(BuildingSubID::EBuildingSubID subID);
+	void tryAddVisitingBonus(BuildingSubID::EBuildingSubID subID);
+	void addTownBonuses();
 };

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -1812,7 +1812,7 @@ void CGameHandler::newTurn()
 				setPortalDwelling(t, true, (n.specialWeek == NewTurn::PLAGUE ? true : false)); //set creatures for Portal of Summoning
 
 			if (!firstTurn)
-				if (t->hasBuilt(BuildingID::TREASURY, ETownType::RAMPART) && player < PlayerColor::PLAYER_LIMIT)
+				if (t->hasBuilt(BuildingSubID::TREASURY) && player < PlayerColor::PLAYER_LIMIT)
 						n.res[player][Res::GOLD] += hadGold.at(player)/10; //give 10% of starting gold
 
 			if (!vstd::contains(n.cres, t->id))
@@ -3848,8 +3848,18 @@ bool CGameHandler::queryReply(QueryID qid, const JsonNode & answer, PlayerColor 
 	logGlobal->trace(answer.toJson());
 
 	auto topQuery = queries.topQuery(player);
+
 	COMPLAIN_RET_FALSE_IF(!topQuery, "This player doesn't have any queries!");
-	COMPLAIN_RET_FALSE_IF(topQuery->queryID != qid, "This player top query has different ID!");
+
+	if(topQuery->queryID != qid)
+	{
+		auto currentQuery = queries.getQuery(qid);
+
+		if(currentQuery != nullptr && currentQuery->endsByPlayerAnswer())
+			currentQuery->setReply(answer);
+
+		COMPLAIN_RET("This player top query has different ID!"); //topQuery->queryID != qid
+	}
 	COMPLAIN_RET_FALSE_IF(!topQuery->endsByPlayerAnswer(), "This query cannot be ended by player's answer!");
 
 	topQuery->setReply(answer);

--- a/server/CQuery.cpp
+++ b/server/CQuery.cpp
@@ -248,15 +248,24 @@ std::vector<std::shared_ptr<const CQuery>> Queries::allQueries() const
 	return ret;
 }
 
-std::vector<std::shared_ptr<CQuery>> Queries::allQueries()
+std::vector<QueryPtr> Queries::allQueries()
 {
 	//TODO code duplication with const function :(
-	std::vector<std::shared_ptr<CQuery>> ret;
+	std::vector<QueryPtr> ret;
 	for(auto & playerQueries : queries)
 		for(auto & query : playerQueries.second)
 			ret.push_back(query);
 
 	return ret;
+}
+
+QueryPtr Queries::getQuery(QueryID queryID)
+{
+	for(auto & playerQueries : queries)
+		for(auto & query : playerQueries.second)
+			if(query->queryID == queryID)
+				return query;
+	return nullptr;
 }
 
 void CBattleQuery::notifyObjectAboutRemoval(const CObjectVisitQuery & objectVisit) const

--- a/server/CQuery.h
+++ b/server/CQuery.h
@@ -219,7 +219,7 @@ public:
 	QueryPtr topQuery(PlayerColor player);
 
 	std::vector<std::shared_ptr<const CQuery>> allQueries() const;
-	std::vector<std::shared_ptr<CQuery>> allQueries();
+	std::vector<QueryPtr> allQueries();
+	QueryPtr getQuery(QueryID queryID);
 	//void removeQuery
-
 };


### PR DESCRIPTION
Following special buildings becomes available in the fan towns:

- "attackVisitingBonus"
- "defenceVisitingBonus"
- "spellPowerVisitingBonus"
- "knowledgeVisitingBonus"
 -"experienceVisitingBonus"
- "lighthouse"
- "treasury"

Fixed couple of bugs:

- Simultaneous level up for visiting and garrison heroes caused  crashing
- Level up for heroes which class has not probability for selected skill caused crashing or UB
