### PR TITLE
Fixed potential race condition

### DIFF
--- a/client/battle/CBattleInterface.cpp
+++ b/client/battle/CBattleInterface.cpp
@@ -49,10 +49,10 @@ CondSh<BattleAction *> CBattleInterface::givenCommand(nullptr);
 
 static void onAnimationFinished(const CStack *stack, std::weak_ptr<CCreatureAnimation> anim)
 {
-	if(anim.expired())
+	std::shared_ptr<CCreatureAnimation> animation = anim.lock();
+	if(!animation)
 		return;
 
-	std::shared_ptr<CCreatureAnimation> animation = anim.lock();
 	if (animation->isIdle())
 	{
 		const CCreature *creature = stack->getCreature();


### PR DESCRIPTION
There is a potential race condition at lines 52 - 55 in client\battle\CBattleInterface.cpp.

```
    if(anim.expired())
        return;

    std::shared_ptr<CCreatureAnimation> animation = anim.lock();
    if (animation->isIdle())
```

Using a shared pointer obtained by locking a weak pointer without checking the result of the lock could result in a crash if the shared pointer has expired before lock() is called.

When expired() is called before lock() in a multi-threaded environment, it is possible for the shared pointer to expire between expired() and lock(). The safe method is to check the result of lock().