### PR TITLE
Disable tests to fix building deb packages

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -9,7 +9,8 @@ override_dh_auto_configure:
 		-DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON \
 		-DCMAKE_INSTALL_RPATH=/usr/lib/$(DEB_HOST_MULTIARCH)/vcmi \
 		-DBIN_DIR=games \
-		-DFORCE_BUNDLED_FL=OFF
+		-DFORCE_BUNDLED_FL=OFF \
+		-DENABLE_TEST=0
 
 override_dh_strip:
 	dh_strip --dbg-package=vcmi-dbg


### PR DESCRIPTION
Deb packages in PPA doesn't build since Oct 3 (commit ff471af3de3d8d39de0c3a29aaff38df6ae546ea), please return disabling tests - see commit 84fc8770e9a2374d301e7329fc268ba7f5dd99b8 and https://launchpadlibrarian.net/506617159/buildlog_ubuntu-hirsute-amd64.vcmi_0.99+git202011120020~ubuntu21.04.1_BUILDING.txt.gz