### PR TITLE
Lodestar Grail should work.

### DIFF
--- a/lib/CCreatureHandler.h
+++ b/lib/CCreatureHandler.h
@@ -114,7 +114,14 @@ public:
 
 	ArtifactID warMachine;
 
-	bool isItNativeTerrain(int terrain) const;
+	bool isItNativeTerrain(ETerrainType::EETerrainType terrain) const;
+	/**
+	Returns creature native terrain considering some terrain bonuses.
+	@param considerBonus is used to avoid Dead Lock when this method is called inside getAllBonuses
+	considerBonus = true is called from Pathfinder and fills actual nativeTerrain considering bonus(es).
+	considerBonus = false is called on Battle init and returns already prepared nativeTerrain without Bonus system calling.
+	*/
+	ETerrainType::EETerrainType getNativeTerrain() const;
 	bool isDoubleWide() const; //returns true if unit is double wide on battlefield
 	bool isFlying() const; //returns true if it is a flying unit
 	bool isShooting() const; //returns true if unit can shoot
@@ -241,6 +248,7 @@ public:
 	CreatureID pickRandomMonster(CRandomGenerator & rand, int tier = -1) const; //tier <1 - CREATURES_PER_TOWN> or -1 for any
 	void addBonusForTier(int tier, std::shared_ptr<Bonus> b); //tier must be <1-7>
 	void addBonusForAllCreatures(std::shared_ptr<Bonus> b);
+	void removeBonusesFromAllCreatures();
 
 	CCreatureHandler();
 	~CCreatureHandler();

--- a/lib/CGameState.cpp
+++ b/lib/CGameState.cpp
@@ -1746,6 +1746,8 @@ void CGameState::initTowns()
 void CGameState::initMapObjects()
 {
 	logGlobal->debug("\tObject initialization");
+	VLC->creh->removeBonusesFromAllCreatures();
+
 //	objCaller->preInit();
 	for(CGObjectInstance *obj : map->objects)
 	{

--- a/lib/CPathfinder.h
+++ b/lib/CPathfinder.h
@@ -515,7 +515,7 @@ struct DLL_LINKAGE TurnInfo
 	TConstBonusListPtr bonuses;
 	mutable int maxMovePointsLand;
 	mutable int maxMovePointsWater;
-	int nativeTerrain;
+	ETerrainType::EETerrainType nativeTerrain;
 
 	TurnInfo(const CGHeroInstance * Hero, const int Turn = 0);
 	bool isLayerAvailable(const EPathfindingLayer layer) const;

--- a/lib/CStack.h
+++ b/lib/CStack.h
@@ -27,6 +27,7 @@ public:
 
 	ui32 ID; //unique ID of stack
 	const CCreature * type;
+	ETerrainType::EETerrainType nativeTerrain; //tmp variable to save native terrain value on battle init
 	ui32 baseAmount;
 
 	PlayerColor owner; //owner - player color (255 for neutrals)

--- a/lib/CTownHandler.cpp
+++ b/lib/CTownHandler.cpp
@@ -172,7 +172,7 @@ std::vector<BattleHex> CTown::defaultMoatHexes()
 	return moatHexes;
 }
 
-std::string CTown::getFactionName() const
+std::string CTown::getLocalizedFactionName() const
 {
 	if(faction == nullptr)
 		return "Random";
@@ -510,7 +510,7 @@ void CTownHandler::loadBuilding(CTown * town, const std::string & stringID, cons
 		if(stringID == source["upgrades"].String())
 		{
 			throw std::runtime_error(boost::str(boost::format("Building with ID '%s' of town '%s' can't be an upgrade of the same building.") %
-												stringID % ret->town->getFactionName()));
+												stringID % ret->town->getLocalizedFactionName()));
 		}
 
 		VLC->modh->identifiers.requestIdentifier(ret->town->getBuildingScope(), source["upgrades"], [=](si32 identifier)

--- a/lib/CTownHandler.h
+++ b/lib/CTownHandler.h
@@ -224,7 +224,7 @@ public:
 	// TODO: remove once save and mod compatability not needed
 	static std::vector<BattleHex> defaultMoatHexes();
 
-	std::string getFactionName() const;
+	std::string getLocalizedFactionName() const;
 	std::string getBuildingScope() const;
 	std::set<si32> getAllBuildings() const;
 	const CBuilding * getSpecialBuilding(BuildingSubID::EBuildingSubID subID) const;

--- a/lib/GameConstants.h
+++ b/lib/GameConstants.h
@@ -860,8 +860,9 @@ class DLL_LINKAGE ETerrainType
 public:
 	enum EETerrainType
 	{
+		ANY_TERRAIN = -3,
 		WRONG = -2, BORDER = -1, DIRT, SAND, GRASS, SNOW, SWAMP,
-		ROUGH, SUBTERRANEAN, LAVA, WATER, ROCK
+		ROUGH, SUBTERRANEAN, LAVA, WATER, ROCK // ROCK is also intended to be max value.
 	};
 
 	ETerrainType(EETerrainType _num = WRONG) : num(_num)

--- a/lib/HeroBonus.cpp
+++ b/lib/HeroBonus.cpp
@@ -1980,13 +1980,13 @@ JsonNode CreatureTerrainLimiter::toJsonNode() const
 	return root;
 }
 
-CreatureFactionLimiter::CreatureFactionLimiter(int Faction)
-	: faction(Faction)
+CreatureFactionLimiter::CreatureFactionLimiter(TFaction creatureFaction)
+	: faction(creatureFaction)
 {
 }
 
 CreatureFactionLimiter::CreatureFactionLimiter()
-	: faction(-1)
+	: faction((TFaction)-1)
 {
 }
 

--- a/lib/HeroBonus.h
+++ b/lib/HeroBonus.h
@@ -520,7 +520,6 @@ struct DLL_LINKAGE Bonus : public std::enable_shared_from_this<Bonus>
 
 DLL_LINKAGE std::ostream & operator<<(std::ostream &out, const Bonus &bonus);
 
-
 class DLL_LINKAGE BonusList
 {
 public:
@@ -758,7 +757,7 @@ public:
 	enum ENodeTypes
 	{
 		UNKNOWN, STACK_INSTANCE, STACK_BATTLE, SPECIALTY, ARTIFACT, CREATURE, ARTIFACT_INSTANCE, HERO, PLAYER, TEAM,
-		TOWN_AND_VISITOR, BATTLE, COMMANDER, GLOBAL_EFFECTS
+		TOWN_AND_VISITOR, BATTLE, COMMANDER, GLOBAL_EFFECTS, ALL_CREATURES
 	};
 private:
 	BonusList bonuses; //wielded bonuses (local or up-propagated here)
@@ -1062,9 +1061,9 @@ public:
 class DLL_LINKAGE CreatureFactionLimiter : public ILimiter //applies only to creatures of given faction
 {
 public:
-	si8 faction;
+	TFaction faction;
 	CreatureFactionLimiter();
-	CreatureFactionLimiter(int TerrainType);
+	CreatureFactionLimiter(TFaction faction);
 
 	int limit(const BonusLimitationContext &context) const override;
 	virtual std::string toString() const override;

--- a/lib/mapObjects/CGHeroInstance.h
+++ b/lib/mapObjects/CGHeroInstance.h
@@ -162,7 +162,7 @@ public:
 	bool needsLastStack()const override;
 	TFaction getFaction() const;
 	ui32 getTileCost(const TerrainTile &dest, const TerrainTile &from, const TurnInfo * ti) const; //move cost - applying pathfinding skill, road and terrain modifiers. NOT includes diagonal move penalty, last move levelling
-	int getNativeTerrain() const;
+	ETerrainType::EETerrainType getNativeTerrain() const;
 	ui32 getLowestCreatureSpeed() const;
 	int3 getPosition(bool h3m = false) const; //h3m=true - returns position of hero object; h3m=false - returns position of hero 'manifestation'
 	si32 manaRegain() const; //how many points of mana can hero regain "naturally" in one day

--- a/lib/mapObjects/CGTownInstance.cpp
+++ b/lib/mapObjects/CGTownInstance.cpp
@@ -1232,6 +1232,16 @@ void CGTownInstance::recreateBuildingsBonuses()
 		addBonusIfBuilt(BuildingID::GRAIL, Bonus::PRIMARY_SKILL, +10, PrimarySkill::ATTACK); //grail
 		addBonusIfBuilt(BuildingID::GRAIL, Bonus::PRIMARY_SKILL, +10, PrimarySkill::DEFENSE); //grail
 	}
+	else if(boost::algorithm::ends_with(this->town->faction->identifier, ":cove") && hasBuilt(BuildingID::GRAIL))
+	{
+		static TPropagatorPtr lsProp(new CPropagatorNodeType(ALL_CREATURES));
+		static auto factionLimiter = std::make_shared<CreatureFactionLimiter>(this->town->faction->index);
+		auto b = std::make_shared<Bonus>(Bonus::PERMANENT, Bonus::NO_TERRAIN_PENALTY, Bonus::TOWN_STRUCTURE, 0, BuildingID::GRAIL, "", -1);
+
+		b->addLimiter(factionLimiter);
+		b->addPropagator(lsProp);
+		VLC->creh->addBonusForAllCreatures(b);
+	}
 }
 
 bool CGTownInstance::addBonusIfBuilt(BuildingSubID::EBuildingSubID subId, Bonus::BonusType type, int val, TPropagatorPtr & prop, int subtype)
@@ -1275,6 +1285,7 @@ bool CGTownInstance::addBonusIfBuilt(BuildingID building, Bonus::BonusType type,
 bool CGTownInstance::addBonusImpl(BuildingID building, Bonus::BonusType type, int val, TPropagatorPtr & prop, const std::string & description, int subtype)
 {
 	auto b = std::make_shared<Bonus>(Bonus::PERMANENT, type, Bonus::TOWN_STRUCTURE, val, building, description, subtype);
+
 	if(prop)
 		b->addPropagator(prop);
 	addNewBonus(b);


### PR DESCRIPTION
When Lodestar Grail is built:

- Any terrain is native for all creatures of 'Cove' faction. Thus, any hero with only 'Cove' creatures has not terrain movement penalty.
- Any creature of 'Cove' faction receives +1 attack, +1 defence, +1 speed bonuses in the battle.

When Nomad creature is in the hero army: No terrain penalty when hero is on the sand (according to the FizMiG)
