### PR TITLE
Fix: Siege crashes when creature on the archer's tower is not a shooter

### DIFF
--- a/client/battle/CBattleAnimations.cpp
+++ b/client/battle/CBattleAnimations.cpp
@@ -758,11 +758,19 @@ bool CShootingAnimation::init()
 	// If the creature id is 149 then it's a arrow tower which has no additional info so get the
 	// actual arrow tower shooter instead.
 	const CCreature *shooterInfo = shooter->getCreature();
-	if (shooterInfo->idNumber == CreatureID::ARROW_TOWERS)
+
+	if(shooterInfo->idNumber == CreatureID::ARROW_TOWERS)
 	{
 		int creID = owner->siegeH->town->town->clientInfo.siegeShooter;
 		shooterInfo = CGI->creh->creatures[creID];
 	}
+	if(!shooterInfo->animation.missleFrameAngles.size())
+		logAnim->error("Mod error: Creature '%s' on the Archer's tower is not a shooter. Mod should be fixed. Trying to use archer's data instead..."
+			, shooterInfo->nameSing);
+	
+	auto & angles = shooterInfo->animation.missleFrameAngles.size() 
+		? shooterInfo->animation.missleFrameAngles
+		: CGI->creh->creatures[CreatureID::ARCHER]->animation.missleFrameAngles;
 
 	ProjectileInfo spi;
 	spi.shotDone = false;
@@ -844,8 +852,6 @@ bool CShootingAnimation::init()
 
 		owner->addNewAnim( new CEffectAnimation(owner, catapultDamage ? "SGEXPL.DEF" : "CSGRCK.DEF", animPos.x, animPos.y));
 	}
-
-	auto & angles = shooterInfo->animation.missleFrameAngles;
 	double pi = boost::math::constants::pi<double>();
 
 	if (owner->idToProjectile.count(spi.creID) == 0) //in some cases (known one: hero grants shooter bonus to unit) the shooter stack's projectile may not be properly initialized

--- a/lib/CTownHandler.cpp
+++ b/lib/CTownHandler.cpp
@@ -815,7 +815,13 @@ void CTownHandler::loadSiegeScreen(CTown &town, const JsonNode & source)
 	town.clientInfo.siegePrefix = source["imagePrefix"].String();
 	VLC->modh->identifiers.requestIdentifier("creature", source["shooter"], [&town](si32 creature)
 	{
-		town.clientInfo.siegeShooter = CreatureID(creature);
+		auto crId = CreatureID(creature);
+		if(!VLC->creh->creatures[crId]->animation.missleFrameAngles.size())
+			logMod->error("Mod '%s' error: Creature '%s' on the Archer's tower is not a shooter. Mod should be fixed. Siege will not work properly!"
+				, town.faction->name
+				, VLC->creh->creatures[crId]->nameSing);
+
+		town.clientInfo.siegeShooter = crId;
 	});
 
 	auto & pos = town.clientInfo.siegePositions;

--- a/lib/GameConstants.h
+++ b/lib/GameConstants.h
@@ -1046,6 +1046,7 @@ public:
 	enum ECreatureID
 	{
 		NONE = -1,
+		ARCHER = 2,
 		CAVALIER = 10,
 		CHAMPION = 11,
 		STONE_GOLEM = 32,


### PR DESCRIPTION
Fix: Siege crashes when creature on the archer's tower is not a shooter
Solution: Rise up error messages and trying use archer's data instead.