### PR TITLE
Fix: 'Load' and 'Main Menu' in-game buttons should work properly

### DIFF
--- a/client/CMT.cpp
+++ b/client/CMT.cpp
@@ -1291,6 +1291,7 @@ static void handleEvent(SDL_Event & ev)
 			{
 				CSH->endGameplay();
 				GH.defActionsDef = 63;
+				CMM->menu->switchToTab("main");
 			}
 			break;
 		case EUserEvent::RESTART_GAME:

--- a/client/mainmenu/CMainMenu.cpp
+++ b/client/mainmenu/CMainMenu.cpp
@@ -139,6 +139,11 @@ void CMenuScreen::switchToTab(std::string name)
 	switchToTab(vstd::find_pos(menuNameToEntry, name));
 }
 
+size_t CMenuScreen::getActiveTab() const
+{
+	return tabs->getActive();
+}
+
 //funciton for std::string -> std::function conversion for main menu
 static std::function<void()> genCommand(CMenuScreen * menu, std::vector<std::string> menuType, const std::string & string)
 {
@@ -301,7 +306,7 @@ void CMainMenu::update()
 	{
 		GH.pushInt(CMM);
 		GH.pushInt(menu);
-		menu->switchToTab(0);
+		menu->switchToTab(menu->getActiveTab());
 	}
 
 	// Handles mouse and key input

--- a/client/mainmenu/CMainMenu.h
+++ b/client/mainmenu/CMainMenu.h
@@ -55,6 +55,7 @@ public:
 
 	void switchToTab(size_t index);
 	void switchToTab(std::string name);
+	size_t getActiveTab() const;
 };
 
 class CMenuEntry : public CIntObject

--- a/client/widgets/ObjectLists.cpp
+++ b/client/widgets/ObjectLists.cpp
@@ -58,6 +58,11 @@ void CTabbedInt::setActive(size_t which)
 	}
 }
 
+size_t CTabbedInt::getActive() const
+{
+	return activeID;
+}
+
 void CTabbedInt::reset()
 {
 	deleteItem(activeTab);

--- a/client/widgets/ObjectLists.h
+++ b/client/widgets/ObjectLists.h
@@ -49,6 +49,7 @@ public:
 	CTabbedInt(CreateFunc create, Point position=Point(), size_t ActiveID=0);
 
 	void setActive(size_t which);
+	size_t getActive() const;
 	//recreate active tab
 	void reset();
 


### PR DESCRIPTION
Fixed issue: 'Load' button leads to the Main menu and 'Main Menu' button leads to the New game tab.
