### PR TITLE
Patch III for Mod system improvement : Negative bonuses: new feature, fixes, town building: Magic Well 

### DIFF
--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -1491,24 +1491,23 @@ void CPlayerInterface::objectPropertyChanged(const SetObjectProperty * sop)
 	{
 		const CGObjectInstance * obj = cb->getObj(sop->id);
 		std::set<int3> pos = obj->getBlockedPos();
-		for (auto & po : pos)
+
+		for(auto & po : pos)
 		{
-			if (cb->isVisible(po))
+			if(cb->isVisible(po))
 				adventureInt->minimap.showTile(po);
 		}
-
-		if (obj->ID == Obj::TOWN)
+		if(obj->ID == Obj::TOWN)
 		{
-			if (obj->tempOwner == playerID)
+			if(obj->tempOwner == playerID)
 				towns.push_back(static_cast<const CGTownInstance *>(obj));
 			else
 				towns -= obj;
+
 			adventureInt->townList.update();
 		}
-
 		assert(cb->getTownsInfo().size() == towns.size());
 	}
-
 }
 
 void CPlayerInterface::initializeHeroTownList()

--- a/client/Client.cpp
+++ b/client/Client.cpp
@@ -558,7 +558,6 @@ int CClient::sendRequest(const CPackForServer * request, PlayerColor player)
 
 void CClient::battleStarted(const BattleInfo * info)
 {
-	BattleInfo::adjustOppositeBonuses(const_cast<BattleInfo *>(info));
 	setBattle(info);
 
 	for(auto & battleCb : battleCallbacks)

--- a/client/Client.cpp
+++ b/client/Client.cpp
@@ -558,7 +558,9 @@ int CClient::sendRequest(const CPackForServer * request, PlayerColor player)
 
 void CClient::battleStarted(const BattleInfo * info)
 {
+	BattleInfo::adjustOppositeBonuses(const_cast<BattleInfo *>(info));
 	setBattle(info);
+
 	for(auto & battleCb : battleCallbacks)
 	{
 		if(vstd::contains_if(info->sides, [&](const SideInBattle& side) {return side.color == battleCb.first; })

--- a/client/Client.h
+++ b/client/Client.h
@@ -202,7 +202,7 @@ public:
 	bool moveStack(const StackLocation & src, const StackLocation & dst, TQuantity count = -1) override {return false;}
 
 	void removeAfterVisit(const CGObjectInstance * object) override {};
-	bool garrisonSwapOnSiege(ObjectInstanceID tid) override {return false;};
+	bool swapGarrisonOnSiege(ObjectInstanceID tid) override {return false;};
 	void giveHeroNewArtifact(const CGHeroInstance * h, const CArtifact * artType, ArtifactPosition pos) override {};
 	void giveHeroArtifact(const CGHeroInstance * h, const CArtifactInstance * a, ArtifactPosition pos) override {};
 	void putArtifact(const ArtifactLocation & al, const CArtifactInstance * a) override {};

--- a/client/Client.h
+++ b/client/Client.h
@@ -202,7 +202,7 @@ public:
 	bool moveStack(const StackLocation & src, const StackLocation & dst, TQuantity count = -1) override {return false;}
 
 	void removeAfterVisit(const CGObjectInstance * object) override {};
-
+	bool garrisonSwapOnSiege(ObjectInstanceID tid) override {return false;};
 	void giveHeroNewArtifact(const CGHeroInstance * h, const CArtifact * artType, ArtifactPosition pos) override {};
 	void giveHeroArtifact(const CGHeroInstance * h, const CArtifactInstance * a, ArtifactPosition pos) override {};
 	void putArtifact(const ArtifactLocation & al, const CArtifactInstance * a) override {};

--- a/client/NetPacksClient.cpp
+++ b/client/NetPacksClient.cpp
@@ -526,7 +526,7 @@ void InfoWindow::applyCl(CClient *cl)
 		logNetwork->warn("We received InfoWindow for not our player...");
 }
 
-void SetObjectProperty::applyCl(CClient *cl)
+void SetObjectProperty::applyCl(CClient * cl)
 {
 	//inform all players that see this object
 	for(auto it = cl->playerint.cbegin(); it != cl->playerint.cend(); ++it)

--- a/client/widgets/MiscWidgets.cpp
+++ b/client/widgets/MiscWidgets.cpp
@@ -404,18 +404,22 @@ void MoraleLuckBox::set(const IBonusBearer * node)
 		text += "\n" + noLuck->Description();
 		bonusValue = 0;
 	}
-	else if(modifierList->empty())
-		text += CGI->generaltexth->arraytxt[noneTxtId];//no modifiers
 	else
 	{
-		for(auto& elem : *modifierList)
-		{
-			if(elem->val != 0)
-				//no bonuses with value 0
-				text += "\n" + elem->Description();
-		}
-	}
+		bool isListActual = false;
+		std::string addInfo = "";
 
+		for(auto & bonus : * modifierList)
+		{
+			if(bonus->val && bonus->effectRange != Bonus::ONLY_ENEMY_ARMY)
+			{
+				addInfo += "\n" + bonus->Description();
+				isListActual = true;
+			}
+		}
+		text = isListActual ? text + addInfo
+			: text + CGI->generaltexth->arraytxt[noneTxtId];//no modifiers
+	}
 	std::string imageName;
 	if (small)
 		imageName = morale ? "IMRL30": "ILCK30";

--- a/client/widgets/MiscWidgets.cpp
+++ b/client/widgets/MiscWidgets.cpp
@@ -411,7 +411,7 @@ void MoraleLuckBox::set(const IBonusBearer * node)
 
 		for(auto & bonus : * modifierList)
 		{
-			if(bonus->val && bonus->effectRange != Bonus::ONLY_ENEMY_ARMY)
+			if(bonus->val)
 			{
 				addInfo += "\n" + bonus->Description();
 				isListActual = true;

--- a/client/widgets/MiscWidgets.cpp
+++ b/client/widgets/MiscWidgets.cpp
@@ -406,19 +406,15 @@ void MoraleLuckBox::set(const IBonusBearer * node)
 	}
 	else
 	{
-		bool isListActual = false;
 		std::string addInfo = "";
-
 		for(auto & bonus : * modifierList)
 		{
 			if(bonus->val)
-			{
 				addInfo += "\n" + bonus->Description();
-				isListActual = true;
-			}
 		}
-		text = isListActual ? text + addInfo
-			: text + CGI->generaltexth->arraytxt[noneTxtId];//no modifiers
+		text = addInfo.empty() 
+			? text + CGI->generaltexth->arraytxt[noneTxtId] 
+			: text + addInfo;
 	}
 	std::string imageName;
 	if (small)

--- a/config/creatures/necropolis.json
+++ b/config/creatures/necropolis.json
@@ -339,10 +339,13 @@
 			{
 				"type" : "DRAGON_NATURE"
 			},
-			"const_lowers_morale" :
+			"descreaseMorale" :
 			{
+				"type" : "MORALE",
+				"effectRange": "ONLY_ENEMY_ARMY",
+				"val" : -1,
 				"stacking" : "Undead Dragons"
-			}
+			},
 		},
 		"upgrades": ["ghostDragon"],
 		"graphics" :
@@ -369,8 +372,11 @@
 			{
 				"type" : "DRAGON_NATURE"
 			},
-			"const_lowers_morale" :
+			"descreaseMorale" :
 			{
+				"type" : "MORALE",
+				"effectRange": "ONLY_ENEMY_ARMY",
+				"val" : -1,
 				"stacking" : "Undead Dragons"
 			},
 			"age" :

--- a/config/creatures/necropolis.json
+++ b/config/creatures/necropolis.json
@@ -339,7 +339,7 @@
 			{
 				"type" : "DRAGON_NATURE"
 			},
-			"descreaseMorale" :
+			"decreaseMorale" :
 			{
 				"type" : "MORALE",
 				"effectRange": "ONLY_ENEMY_ARMY",
@@ -372,7 +372,7 @@
 			{
 				"type" : "DRAGON_NATURE"
 			},
-			"descreaseMorale" :
+			"decreaseMorale" :
 			{
 				"type" : "MORALE",
 				"effectRange": "ONLY_ENEMY_ARMY",

--- a/config/translate.json
+++ b/config/translate.json
@@ -53,7 +53,8 @@
 		"hasNotProduced" : "The %s has not produced anything yet.",
 		"hasProduced" : "The %s produced %d %s this week.",
 		"greetingCustomBonus" : "%s gives you +%d %s%s",
-		"greetingCustomUntil" : " until next battle."
+		"greetingCustomUntil" : " until next battle.",
+		"greetingInTownMagicWell" : "%s has restored your spell points to maximum."
 	},
 	"logicalExpressions" :
 	{

--- a/lib/CCreatureHandler.cpp
+++ b/lib/CCreatureHandler.cpp
@@ -392,6 +392,20 @@ void CCreature::fillWarMachine()
 	warMachine = ArtifactID::NONE; //this creature is not artifact
 }
 
+void CCreature::updateOppositeBonuses()
+{
+	auto & bonusList = getExportedBonusList();
+	for(auto & bonus : bonusList)
+	{
+		if(bonus->effectRange == Bonus::ONLY_ENEMY_ARMY //Opposite Side bonuses should not be exported from CREATURE node.
+			|| (bonus->propagator && bonus->propagator->getPropagatorType() == CBonusSystemNode::BATTLE))
+		{
+			bonus->effectRange == Bonus::ONLY_ENEMY_ARMY;
+			bonus->propagator.reset();
+		}
+	}
+}
+
 CCreatureHandler::CCreatureHandler()
 	: expAfterUpgrade(0)
 {

--- a/lib/CCreatureHandler.cpp
+++ b/lib/CCreatureHandler.cpp
@@ -497,13 +497,6 @@ void CCreatureHandler::loadBonuses(JsonNode & creature, std::string bonuses)
 		node["propagator"].String() = "HERO";
 		creature["abilities"]["const_raises_morale"] = node;
 	}
-	if(hasAbility("const_lowers_morale"))
-	{
-		JsonNode node = makeBonusNode("MORALE");
-		node["val"].Float() = -1;
-		node["effectRange"].String() = "ONLY_ENEMY_ARMY";
-		creature["abilities"]["const_lowers_morale"] = node;
-	}
 }
 
 std::vector<JsonNode> CCreatureHandler::loadLegacyData(size_t dataSize)
@@ -870,6 +863,10 @@ void CCreatureHandler::loadCreatureJson(CCreature * creature, const JsonNode & c
 			if (!ability.second.isNull())
 			{
 				auto b = JsonUtils::parseBonus(ability.second);
+
+				if(b->effectRange == Bonus::ONLY_ENEMY_ARMY) //Opposite Side bonuses should not be exported from CREATURE node.
+					b->propagator.reset();
+
 				b->source = Bonus::CREATURE_ABILITY;
 				b->sid = creature->getIndex();
 				b->duration = Bonus::PERMANENT;

--- a/lib/CCreatureHandler.cpp
+++ b/lib/CCreatureHandler.cpp
@@ -1322,14 +1322,20 @@ CreatureID CCreatureHandler::pickRandomMonster(CRandomGenerator & rand, int tier
 	return CreatureID(r);
 }
 
-void CCreatureHandler::addBonusForTier(int tier, std::shared_ptr<Bonus> b)
+void CCreatureHandler::addBonusForTier(int tier, const std::shared_ptr<Bonus> & b)
 {
 	assert(vstd::iswithin(tier, 1, 7));
 	creaturesOfLevel[tier].addNewBonus(b);
 }
 
-void CCreatureHandler::addBonusForAllCreatures(std::shared_ptr<Bonus> b)
+void CCreatureHandler::addBonusForAllCreatures(const std::shared_ptr<Bonus> & b)
 {
+	const auto & exportedBonuses = allCreatures.getExportedBonusList();
+	for(const auto & bonus : exportedBonuses)
+	{
+		if(bonus->type == b->type && bonus->subtype == b->subtype)
+			return;
+	}
 	allCreatures.addNewBonus(b);
 }
 

--- a/lib/CCreatureHandler.cpp
+++ b/lib/CCreatureHandler.cpp
@@ -392,20 +392,6 @@ void CCreature::fillWarMachine()
 	warMachine = ArtifactID::NONE; //this creature is not artifact
 }
 
-void CCreature::updateOppositeBonuses()
-{
-	auto & bonusList = getExportedBonusList();
-	for(auto & bonus : bonusList)
-	{
-		if(bonus->effectRange == Bonus::ONLY_ENEMY_ARMY //Opposite Side bonuses should not be exported from CREATURE node.
-			|| (bonus->propagator && bonus->propagator->getPropagatorType() == CBonusSystemNode::BATTLE))
-		{
-			bonus->effectRange == Bonus::ONLY_ENEMY_ARMY;
-			bonus->propagator.reset();
-		}
-	}
-}
-
 CCreatureHandler::CCreatureHandler()
 	: expAfterUpgrade(0)
 {
@@ -877,10 +863,6 @@ void CCreatureHandler::loadCreatureJson(CCreature * creature, const JsonNode & c
 			if (!ability.second.isNull())
 			{
 				auto b = JsonUtils::parseBonus(ability.second);
-
-				if(b->effectRange == Bonus::ONLY_ENEMY_ARMY) //Opposite Side bonuses should not be exported from CREATURE node.
-					b->propagator.reset();
-
 				b->source = Bonus::CREATURE_ABILITY;
 				b->sid = creature->getIndex();
 				b->duration = Bonus::PERMANENT;

--- a/lib/CCreatureHandler.h
+++ b/lib/CCreatureHandler.h
@@ -223,17 +223,12 @@ public:
 		{
 			fillWarMachine();
 		}
-		if(version < 801 && !h.saving) // Opposite bonuses are introduced
-		{
-			updateOppositeBonuses();
-		}
 	}
 
 	CCreature();
 
 private:
 	void fillWarMachine();
-	void updateOppositeBonuses();
 };
 
 class DLL_LINKAGE CCreatureHandler : public CHandlerBase<CreatureID, Creature, CCreature, CreatureService>

--- a/lib/CCreatureHandler.h
+++ b/lib/CCreatureHandler.h
@@ -278,8 +278,8 @@ public:
 
 	void deserializationFix();
 	CreatureID pickRandomMonster(CRandomGenerator & rand, int tier = -1) const; //tier <1 - CREATURES_PER_TOWN> or -1 for any
-	void addBonusForTier(int tier, std::shared_ptr<Bonus> b); //tier must be <1-7>
-	void addBonusForAllCreatures(std::shared_ptr<Bonus> b);
+	void addBonusForTier(int tier, const std::shared_ptr<Bonus> & b); //tier must be <1-7>
+	void addBonusForAllCreatures(const std::shared_ptr<Bonus> & b); //due to CBonusSystem::addNewBonus(const std::shared_ptr<Bonus>& b);
 	void removeBonusesFromAllCreatures();
 	void restoreAllCreaturesNodeType794(); //restore ALL_CREATURES node type for old saves
 

--- a/lib/CCreatureHandler.h
+++ b/lib/CCreatureHandler.h
@@ -223,12 +223,17 @@ public:
 		{
 			fillWarMachine();
 		}
+		if(version < 801 && !h.saving) // Opposite bonuses are introduced
+		{
+			updateOppositeBonuses();
+		}
 	}
 
 	CCreature();
 
 private:
 	void fillWarMachine();
+	void updateOppositeBonuses();
 };
 
 class DLL_LINKAGE CCreatureHandler : public CHandlerBase<CreatureID, Creature, CCreature, CreatureService>

--- a/lib/CCreatureSet.cpp
+++ b/lib/CCreatureSet.cpp
@@ -630,10 +630,38 @@ void CStackInstance::setType(CreatureID creID)
 		setType((const CCreature*)nullptr);
 }
 
+
+void CStackInstance::copyOppositeBonusesFromCreature(const CCreature * creature)
+{
+	auto owner = _armyObj ? _armyObj->getOwner() : PlayerColor::NEUTRAL;
+
+	if(owner == PlayerColor::UNFLAGGABLE)
+		owner = PlayerColor::NEUTRAL;
+
+	auto & creatureBonuses = const_cast<CCreature *>(type)->getExportedBonusList();
+
+	for(auto & creatureBonus : creatureBonuses)
+	{
+		if(creatureBonus->effectRange == Bonus::ONLY_ENEMY_ARMY) //it has better prformance than dynamic_cast
+		{
+			auto bCopy = std::make_shared<Bonus>(*creatureBonus);
+			bCopy->propagator.reset(new CPropagatorNodeType(CBonusSystemNode::BATTLE));
+			bCopy->limiter.reset(new OppositeSideLimiter(owner));
+			this->addNewBonus(bCopy);
+		}
+	}
+}
+
+void CStackInstance::removeOppositeBonuses()
+{
+	removeBonuses(Selector::effectRange()(Bonus::ONLY_ENEMY_ARMY));
+}
+
 void CStackInstance::setType(const CCreature *c)
 {
 	if(type)
 	{
+		removeOppositeBonuses();
 		detachFrom(const_cast<CCreature*>(type));
 		if (type->isMyUpgrade(c) && VLC->modh->modules.STACK_EXP)
 			experience = static_cast<TExpType>(experience * VLC->creh->expAfterUpgrade / 100.0);
@@ -642,7 +670,11 @@ void CStackInstance::setType(const CCreature *c)
 	CStackBasicDescriptor::setType(c);
 
 	if(type)
-		attachTo(const_cast<CCreature*>(type));
+	{
+		auto creature = const_cast<CCreature*>(type);
+		copyOppositeBonusesFromCreature(creature);
+		attachTo(creature);
+	}
 }
 std::string CStackInstance::bonusToString(const std::shared_ptr<Bonus>& bonus, bool description) const
 {
@@ -662,7 +694,7 @@ std::string CStackInstance::bonusToGraphics(const std::shared_ptr<Bonus>& bonus)
 	return VLC->getBth()->bonusToGraphics(bonus);
 }
 
-void CStackInstance::setArmyObj(const CArmedInstance *ArmyObj)
+void CStackInstance::setArmyObj(const CArmedInstance * ArmyObj)
 {
 	if(_armyObj)
 		detachFrom(const_cast<CArmedInstance*>(_armyObj));
@@ -670,6 +702,24 @@ void CStackInstance::setArmyObj(const CArmedInstance *ArmyObj)
 	_armyObj = ArmyObj;
 	if(ArmyObj)
 	{
+		auto owner = _armyObj->getOwner();
+
+		if(owner == PlayerColor::UNFLAGGABLE)
+			owner = PlayerColor::NEUTRAL;
+
+		auto & bonusList = getExportedBonusList();
+
+		for(auto & bonus : bonusList)
+		{
+			if(bonus->effectRange != Bonus::ONLY_ENEMY_ARMY)
+				continue;
+
+			auto limPtr = bonus->limiter.get();
+			if(limPtr)
+				static_cast<OppositeSideLimiter *>(limPtr)->owner = owner;
+			else
+				logGlobal->error("setArmyObj. Limiter has been lost. Creature is %s", type ? type->nodeShortInfo() : std::string("No creature"));
+		}
 		attachTo(const_cast<CArmedInstance*>(_armyObj));
 	}
 }

--- a/lib/CCreatureSet.h
+++ b/lib/CCreatureSet.h
@@ -99,10 +99,7 @@ public:
 	ArtBearer::ArtBearer bearerType() const override; //from CArtifactSet
 	virtual std::string nodeName() const override; //from CBonusSystemnode
 	void deserializationFix();
-
-private:
-	void copyOppositeBonusesFromCreature(const CCreature * creature);
-	inline void removeOppositeBonuses();
+	PlayerColor getOwner() const override;
 };
 
 class DLL_LINKAGE CCommanderInstance : public CStackInstance

--- a/lib/CCreatureSet.h
+++ b/lib/CCreatureSet.h
@@ -102,7 +102,7 @@ public:
 
 private:
 	void copyOppositeBonusesFromCreature(const CCreature * creature);
-	STRONG_INLINE void removeOppositeBonuses();
+	inline void removeOppositeBonuses();
 };
 
 class DLL_LINKAGE CCommanderInstance : public CStackInstance

--- a/lib/CCreatureSet.h
+++ b/lib/CCreatureSet.h
@@ -99,6 +99,10 @@ public:
 	ArtBearer::ArtBearer bearerType() const override; //from CArtifactSet
 	virtual std::string nodeName() const override; //from CBonusSystemnode
 	void deserializationFix();
+
+private:
+	void copyOppositeBonusesFromCreature(const CCreature * creature);
+	STRONG_INLINE void removeOppositeBonuses();
 };
 
 class DLL_LINKAGE CCommanderInstance : public CStackInstance

--- a/lib/CStack.h
+++ b/lib/CStack.h
@@ -20,6 +20,7 @@
 struct BattleStackAttacked;
 class BattleInfo;
 
+//Represents STACK_BATTLE nodes
 class DLL_LINKAGE CStack : public CBonusSystemNode, public battle::CUnitState, public battle::IUnitEnvironment
 {
 public:
@@ -78,6 +79,11 @@ public:
 	PlayerColor unitEffectiveOwner(const battle::Unit * unit) const override;
 
 	void spendMana(ServerCallback * server, const int spellCost) const override;
+
+	PlayerColor getOwner() const override
+	{
+		return this->owner;
+	}
 
 	template <typename Handler> void serialize(Handler & h, const int version)
 	{

--- a/lib/CTownHandler.cpp
+++ b/lib/CTownHandler.cpp
@@ -377,7 +377,11 @@ JsonNode readBuilding(CLegacyConfigParser & parser)
 	return ret;
 }
 
-TPropagatorPtr CTownHandler::emptyPropagator = std::make_shared<CPropagatorNodeType>();
+TPropagatorPtr & CTownHandler::emptyPropagator()
+{
+	static TPropagatorPtr emptyProp(nullptr);
+	return emptyProp;
+}
 
 std::vector<JsonNode> CTownHandler::loadLegacyData(size_t dataSize)
 {
@@ -618,7 +622,7 @@ void CTownHandler::addBonusesForVanilaBuilding(CBuilding * building)
 
 std::shared_ptr<Bonus> CTownHandler::createBonus(CBuilding * build, Bonus::BonusType type, int val, int subtype)
 {
-	return createBonus(build, type, val, emptyPropagator, subtype);
+	return createBonus(build, type, val, emptyPropagator(), subtype);
 }
 
 std::shared_ptr<Bonus> CTownHandler::createBonus(CBuilding * build, Bonus::BonusType type, int val, TPropagatorPtr & prop, int subtype)
@@ -657,7 +661,7 @@ void CTownHandler::loadSpecialBuildingBonuses(const JsonNode & source, BonusList
 		//JsonUtils::parseBuildingBonus produces UNKNOWN type propagator instead of empty.
 		if(bonus->propagator != nullptr
 			&& bonus->propagator->getPropagatorType() == CBonusSystemNode::ENodeTypes::UNKNOWN)
-				bonus->addPropagator(emptyPropagator);
+				bonus->addPropagator(emptyPropagator());
 		building->addNewBonus(bonus, bonusList);
 	}
 }

--- a/lib/CTownHandler.h
+++ b/lib/CTownHandler.h
@@ -388,7 +388,7 @@ class DLL_LINKAGE CTownHandler : public CHandlerBase<FactionID, Faction, CFactio
 	const static ETerrainType::EETerrainType defaultEvilTerrain = ETerrainType::EETerrainType::LAVA;
 	const static ETerrainType::EETerrainType defaultNeutralTerrain = ETerrainType::EETerrainType::ROUGH;
 
-	static TPropagatorPtr emptyPropagator;
+	static TPropagatorPtr & emptyPropagator();
 
 	void initializeRequirements();
 	void initializeOverridden();

--- a/lib/HeroBonus.cpp
+++ b/lib/HeroBonus.cpp
@@ -26,7 +26,6 @@
 #include "battle/BattleInfo.h"
 
 #define FOREACH_PARENT(pname) 	TNodes lparents; getParents(lparents); for(CBonusSystemNode *pname : lparents)
-#define FOREACH_CPARENT(pname) 	TCNodes lparents; getParents(lparents); for(const CBonusSystemNode *pname : lparents)
 #define FOREACH_RED_CHILD(pname) 	TNodes lchildren; getRedChildren(lchildren); for(CBonusSystemNode *pname : lchildren)
 #define FOREACH_RED_PARENT(pname) 	TNodes lparents; getRedParents(lparents); for(CBonusSystemNode *pname : lparents)
 
@@ -873,26 +872,25 @@ void CBonusSystemNode::getParents(TNodes &out)
 	}
 }
 
-void CBonusSystemNode::getBonusesRec(BonusList &out, const CSelector &selector, const CSelector &limit) const
+void CBonusSystemNode::getAllParents(TCNodes & out) const /*retrieves list of parent nodes (nodes to inherit bonuses from) */
 {
-	BonusList beforeUpdate;
-	FOREACH_CPARENT(p)
+	for(auto & cparent : parents)
 	{
-		p->getBonusesRec(beforeUpdate, selector, limit);
+		const CBonusSystemNode * parent = cparent;
+		out.insert(parent);
+		parent->getAllParents(out);
 	}
-	bonuses.getBonuses(beforeUpdate, selector, limit);
-
-	for(auto b : beforeUpdate)
-		out.push_back(update(b));
 }
 
 void CBonusSystemNode::getAllBonusesRec(BonusList &out) const
 {
 	BonusList beforeUpdate;
-	FOREACH_CPARENT(p)
-	{
-		p->getAllBonusesRec(beforeUpdate);
-	}
+	TCNodes lparents;
+	getAllParents(lparents);
+
+	for(auto parent : lparents)
+		parent->bonuses.getAllBonuses(beforeUpdate);
+
 	bonuses.getAllBonuses(beforeUpdate);
 
 	for(auto b : beforeUpdate)

--- a/lib/HeroBonus.cpp
+++ b/lib/HeroBonus.cpp
@@ -428,6 +428,9 @@ int BonusList::totalValue() const
 
 	for(std::shared_ptr<Bonus> b : bonuses)
 	{
+		if(b->effectRange == Bonus::ONLY_ENEMY_ARMY)
+			continue;
+
 		switch(b->valType)
 		{
 		case Bonus::BASE_NUMBER:
@@ -452,7 +455,6 @@ int BonusList::totalValue() const
 			{
 				vstd::amax(indepMax, b->val);
 			}
-
 			break;
 		case Bonus::INDEPENDENT_MIN:
 			if (!hasIndepMin)
@@ -464,7 +466,6 @@ int BonusList::totalValue() const
 			{
 				vstd::amin(indepMin, b->val);
 			}
-
 			break;
 		}
 	}
@@ -595,11 +596,14 @@ void BonusList::insert(BonusList::TInternalContainer::iterator position, BonusLi
 	changed();
 }
 
-CSelector IBonusBearer::anaffectedByMoraleSelector
-	= Selector::type()(Bonus::NON_LIVING)
-		.Or(Selector::type()(Bonus::UNDEAD))
-		.Or(Selector::type()(Bonus::NO_MORALE))
-		.Or(Selector::type()(Bonus::SIEGE_WEAPON));
+CSelector IBonusBearer::anaffectedByMoraleSelector =
+Selector::type()(Bonus::NON_LIVING)
+.Or(Selector::type()(Bonus::UNDEAD))
+.Or(Selector::type()(Bonus::SIEGE_WEAPON))
+.Or(Selector::effectRange()(Bonus::ONLY_ENEMY_ARMY).Not()
+	.And(Selector::type()(Bonus::NO_MORALE)
+		.Or(Selector::type()(Bonus::BLOCK_MORALE))
+	));
 
 CSelector IBonusBearer::moraleSelector = Selector::type()(Bonus::MORALE);
 CSelector IBonusBearer::luckSelector = Selector::type()(Bonus::LUCK);

--- a/lib/HeroBonus.h
+++ b/lib/HeroBonus.h
@@ -56,6 +56,11 @@ public:
 		auto thisCopy = *this;
 		return [thisCopy, rhs](const Bonus *b) mutable { return thisCopy(b) || rhs(b); };
 	}
+	CSelector Not() const
+	{
+		auto thisCopy = *this;
+		return [thisCopy](const Bonus *b) mutable { return !thisCopy(b); };
+	}
 
 	bool operator()(const Bonus *b) const
 	{

--- a/lib/HeroBonus.h
+++ b/lib/HeroBonus.h
@@ -323,7 +323,7 @@ public:
 	BONUS_NAME(GARGOYLE) /* gargoyle is special than NON_LIVING, cannot be rised or healed */ \
 	BONUS_NAME(SPECIAL_ADD_VALUE_ENCHANT) /*specialty spell like Aenin has, increased effect of spell, additionalInfo = value to add*/\
 	BONUS_NAME(SPECIAL_FIXED_VALUE_ENCHANT) /*specialty spell like Melody has, constant spell effect (i.e. 3 luck), additionalInfo = value to fix.*/\
-
+	BONUS_NAME(TOWN_MAGIC_WELL) /*one-time pseudo-bonus to implement Magic Well in the town*/ \
 	/* end of list */
 
 

--- a/lib/HeroBonus.h
+++ b/lib/HeroBonus.h
@@ -769,7 +769,6 @@ private:
 	mutable std::map<std::string, TBonusListPtr > cachedRequests;
 	mutable boost::mutex sync;
 
-	void getBonusesRec(BonusList &out, const CSelector &selector, const CSelector &limit) const;
 	void getAllBonusesRec(BonusList &out) const;
 	TConstBonusListPtr getAllBonusesWithoutCaching(const CSelector &selector, const CSelector &limit, const CBonusSystemNode *root = nullptr) const;
 	std::shared_ptr<Bonus> update(const std::shared_ptr<Bonus> & b) const;
@@ -793,6 +792,7 @@ public:
 	void getRedAncestors(TNodes &out);
 	void getRedChildren(TNodes &out);
 	void getRedDescendants(TNodes &out);
+	void getAllParents(TCNodes & out) const;
 	std::shared_ptr<Bonus> getBonusLocalFirst(const CSelector &selector);
 
 	void attachTo(CBonusSystemNode *parent);

--- a/lib/HeroBonus.h
+++ b/lib/HeroBonus.h
@@ -455,6 +455,10 @@ struct DLL_LINKAGE Bonus : public std::enable_shared_from_this<Bonus>
 		{
 			h & updater;
 		}
+		if(version < 801 && !h.saving) //Opposite Side bonuses are introduced
+		{
+			updateOppositeBonuses();
+		}
 	}
 
 	template <typename Ptr>
@@ -522,6 +526,10 @@ struct DLL_LINKAGE Bonus : public std::enable_shared_from_this<Bonus>
 	std::shared_ptr<Bonus> addLimiter(TLimiterPtr Limiter); //returns this for convenient chain-calls
 	std::shared_ptr<Bonus> addPropagator(TPropagatorPtr Propagator); //returns this for convenient chain-calls
 	std::shared_ptr<Bonus> addUpdater(TUpdaterPtr Updater); //returns this for convenient chain-calls
+
+	inline void createOppositeLimiter();
+	inline void createBattlePropagator();
+	void updateOppositeBonuses();
 };
 
 DLL_LINKAGE std::ostream & operator<<(std::ostream &out, const Bonus &bonus);

--- a/lib/IGameCallback.h
+++ b/lib/IGameCallback.h
@@ -98,7 +98,7 @@ public:
 	virtual void startBattleI(const CArmedInstance *army1, const CArmedInstance *army2, int3 tile, bool creatureBank = false)=0; //if any of armies is hero, hero will be used
 	virtual void startBattleI(const CArmedInstance *army1, const CArmedInstance *army2, bool creatureBank = false)=0; //if any of armies is hero, hero will be used, visitable tile of second obj is place of battle
 	virtual bool moveHero(ObjectInstanceID hid, int3 dst, ui8 teleporting, bool transit = false, PlayerColor asker = PlayerColor::NEUTRAL)=0;
-	virtual bool garrisonSwapOnSiege(ObjectInstanceID tid)=0;
+	virtual bool swapGarrisonOnSiege(ObjectInstanceID tid)=0;
 	virtual void giveHeroBonus(GiveBonus * bonus)=0;
 	virtual void setMovePoints(SetMovePoints * smp)=0;
 	virtual void setManaPoints(ObjectInstanceID hid, int val)=0;

--- a/lib/IGameCallback.h
+++ b/lib/IGameCallback.h
@@ -98,6 +98,7 @@ public:
 	virtual void startBattleI(const CArmedInstance *army1, const CArmedInstance *army2, int3 tile, bool creatureBank = false)=0; //if any of armies is hero, hero will be used
 	virtual void startBattleI(const CArmedInstance *army1, const CArmedInstance *army2, bool creatureBank = false)=0; //if any of armies is hero, hero will be used, visitable tile of second obj is place of battle
 	virtual bool moveHero(ObjectInstanceID hid, int3 dst, ui8 teleporting, bool transit = false, PlayerColor asker = PlayerColor::NEUTRAL)=0;
+	virtual bool garrisonSwapOnSiege(ObjectInstanceID tid)=0;
 	virtual void giveHeroBonus(GiveBonus * bonus)=0;
 	virtual void setMovePoints(SetMovePoints * smp)=0;
 	virtual void setManaPoints(ObjectInstanceID hid, int val)=0;

--- a/lib/JsonNode.cpp
+++ b/lib/JsonNode.cpp
@@ -751,38 +751,6 @@ std::shared_ptr<Bonus> JsonUtils::parseBuildingBonus(const JsonNode &ability, Bu
 	return b;
 }
 
-inline void createOppositeLimiter(Bonus * b)
-{
-	if(b->limiter)
-	{
-		if(!dynamic_cast<OppositeSideLimiter *>(b->limiter.get()))
-		{
-			logMod->error("Wrong Limiter will be ignored: The 'ONLY_ENEMY_ARMY' effectRange is only compatible with the 'OPPOSITE_SIDE' limiter.");
-			b->limiter.reset(new OppositeSideLimiter());
-		}
-	}
-	else
-	{
-		b->limiter = std::make_shared<OppositeSideLimiter>();
-	}
-}
-
-inline void createBattlePropagator(Bonus * b)
-{
-	if(b->propagator)
-	{
-		if(b->propagator->getPropagatorType() != CBonusSystemNode::BATTLE)
-		{
-			logMod->error("Wrong Propagator will be ignored: The 'ONLY_ENEMY_ARMY' effectRange is only compatible with the 'BATTLE_WIDE' propagator.");
-			b->propagator.reset(new CPropagatorNodeType(CBonusSystemNode::BATTLE));
-		}
-	}
-	else
-	{
-		b->propagator = std::make_shared<CPropagatorNodeType>(CBonusSystemNode::BATTLE);
-	}
-}
-
 bool JsonUtils::parseBonus(const JsonNode &ability, Bonus *b)
 {
 	const JsonNode *value;
@@ -878,16 +846,7 @@ bool JsonUtils::parseBonus(const JsonNode &ability, Bonus *b)
 			break;
 		}
 	}
-	if(b->effectRange == Bonus::ONLY_ENEMY_ARMY)
-	{
-		createBattlePropagator(b);
-		createOppositeLimiter(b);
-	}
-	else if(b->limiter && dynamic_cast<OppositeSideLimiter *>(b->limiter.get()))
-	{
-		createBattlePropagator(b);
-		b->effectRange = Bonus::ONLY_ENEMY_ARMY;
-	}
+	b->updateOppositeBonuses();
 	return true;
 }
 

--- a/lib/NetPacksLib.cpp
+++ b/lib/NetPacksLib.cpp
@@ -392,43 +392,44 @@ DLL_LINKAGE void RemoveObject::applyGs(CGameState *gs)
 	//unblock tiles
 	gs->map->removeBlockVisTiles(obj);
 
-	if(obj->ID==Obj::HERO)
+	if(obj->ID == Obj::HERO) //remove beaten hero
 	{
-		CGHeroInstance *h = static_cast<CGHeroInstance*>(obj);
-		PlayerState *p = gs->getPlayerState(h->tempOwner);
-		gs->map->heroesOnMap -= h;
-		p->heroes -= h;
-		h->detachFrom(h->whereShouldBeAttached(gs));
-		h->tempOwner = PlayerColor::NEUTRAL; //no one owns beaten hero
-		vstd::erase_if(h->artifactsInBackpack, [](const ArtSlotInfo& asi)
+		CGHeroInstance * beatenHero = static_cast<CGHeroInstance*>(obj);
+		PlayerState * p = gs->getPlayerState(beatenHero->tempOwner);
+		gs->map->heroesOnMap -= beatenHero;
+		p->heroes -= beatenHero;
+		beatenHero->detachFrom(beatenHero->whereShouldBeAttachedOnSiege(gs));
+		beatenHero->tempOwner = PlayerColor::NEUTRAL; //no one owns beaten hero
+		vstd::erase_if(beatenHero->artifactsInBackpack, [](const ArtSlotInfo& asi)
 		{
 			return asi.artifact->artType->id == ArtifactID::GRAIL;
 		});
 
-		if(h->visitedTown)
+		if(beatenHero->visitedTown)
 		{
-			if(h->inTownGarrison)
-				h->visitedTown->garrisonHero = nullptr;
+			if(beatenHero->visitedTown->garrisonHero == beatenHero)
+				beatenHero->visitedTown->garrisonHero = nullptr;
 			else
-				h->visitedTown->visitingHero = nullptr;
-			h->visitedTown = nullptr;
-		}
+				beatenHero->visitedTown->visitingHero = nullptr;
 
+			beatenHero->visitedTown = nullptr;
+			beatenHero->inTownGarrison = false;
+		}
 		//return hero to the pool, so he may reappear in tavern
-		gs->hpool.heroesPool[h->subID] = h;
-		if(!vstd::contains(gs->hpool.pavailable, h->subID))
-			gs->hpool.pavailable[h->subID] = 0xff;
+		gs->hpool.heroesPool[beatenHero->subID] = beatenHero;
+
+		if(!vstd::contains(gs->hpool.pavailable, beatenHero->subID))
+			gs->hpool.pavailable[beatenHero->subID] = 0xff;
 
 		gs->map->objects[id.getNum()] = nullptr;
 
 		//If hero on Boat is removed, the Boat disappears
-		if(h->boat)
+		if(beatenHero->boat)
 		{
-			gs->map->instanceNames.erase(h->boat->instanceName);
-			gs->map->objects[h->boat->id.getNum()].dellNull();
-			h->boat = nullptr;
+			gs->map->instanceNames.erase(beatenHero->boat->instanceName);
+			gs->map->objects[beatenHero->boat->id.getNum()].dellNull();
+			beatenHero->boat = nullptr;
 		}
-
 		return;
 	}
 

--- a/lib/battle/BattleInfo.cpp
+++ b/lib/battle/BattleInfo.cpp
@@ -186,48 +186,6 @@ struct RangeGenerator
 	std::function<int()> myRand;
 };
 
-void BattleInfo::adjustOppositeBonuses(CBonusSystemNode * node, PlayerColor ownerColor)
-{
-	auto & bonusList = node->getExportedBonusList();
-	if(bonusList.empty())
-		return;
-
-	for(const auto & bonus : bonusList)
-	{
-		if(bonus->effectRange != Bonus::ONLY_ENEMY_ARMY)
-			continue;
-
-		auto limPtr = bonus->limiter.get();
-		if(limPtr)
-			static_cast<OppositeSideLimiter *>(limPtr)->owner = ownerColor;
-		else
-			logGlobal->error("adjustOppositeBonuses. Limiter has been lost. Node is %s", node->nodeShortInfo());
-	}
-}
-
-void BattleInfo::adjustOppositeBonuses(BattleInfo * curB)
-{
-	for(int i = 0; i < 2; i++)
-	{
-		TNodes nodes;
-		auto * army = curB->battleGetArmyObject(i);
-		auto ownerColor = curB->sides[i].color;
-
-		if(army->getNodeType() == CBonusSystemNode::HERO)
-			adjustOppositeBonuses(army, ownerColor);
-			
-		army->getRedAncestors(nodes);
-
-		for(auto node : nodes)
-		{
-			auto currentNodeType = node->getNodeType();
-
-			if(currentNodeType == CBonusSystemNode::ARTIFACT || currentNodeType == CBonusSystemNode::TOWN)
-				adjustOppositeBonuses(node, ownerColor);
-		}
-	}
-}
-
 BattleInfo * BattleInfo::setupBattle(int3 tile, ETerrainType terrain, BFieldType battlefieldType, const CArmedInstance * armies[2], const CGHeroInstance * heroes[2], bool creatureBank, const CGTownInstance * town)
 {
 	CMP_stack cmpst;
@@ -597,7 +555,6 @@ BattleInfo * BattleInfo::setupBattle(int3 tile, ETerrainType terrain, BFieldType
 	else
 		curB->tacticDistance = 0;
 
-	adjustOppositeBonuses(curB);
 	return curB;
 }
 

--- a/lib/battle/BattleInfo.h
+++ b/lib/battle/BattleInfo.h
@@ -137,10 +137,7 @@ public:
 	const CGHeroInstance * getHero(PlayerColor player) const; //returns fighting hero that belongs to given player
 
 	void localInit();
-
-	static void setupBonusesFromTownToEnemy(const CGTownInstance * town, BattleInfo * curB); //besieged city may contain buildings with negative bonuses for enemy army
-	static void setupBonusesFromTownToBothSides(const CGTownInstance * town, BattleInfo * curB); //if visiting hero is town defender during siege, he/she should receive bonuses
-	static void setupBonusesFromUnitsToEnemy(BattleInfo * curB);
+	static void adjustOppositeBonuses(BattleInfo * curB);
 	static BattleInfo * setupBattle(int3 tile, ETerrainType terrain, BFieldType battlefieldType, const CArmedInstance * armies[2], const CGHeroInstance * heroes[2], bool creatureBank, const CGTownInstance * town);
 
 	ui8 whatSide(PlayerColor player) const;
@@ -151,8 +148,7 @@ protected:
 	scripting::Pool * getContextPool() const override;
 
 private:
-	static void addOnlyEnemyArmyBonuses(const BonusList & bonusList, BattleInfo * curB, BattleInfo::BattleSide enemySide);
-	STRONG_INLINE static std::shared_ptr<Bonus> makeBonusForEnemy(const std::shared_ptr<Bonus> & b, PlayerColor & enemyColor);
+	inline static void adjustOppositeBonuses(CBonusSystemNode * node, PlayerColor ownerColor);
 };
 
 

--- a/lib/battle/BattleInfo.h
+++ b/lib/battle/BattleInfo.h
@@ -137,7 +137,6 @@ public:
 	const CGHeroInstance * getHero(PlayerColor player) const; //returns fighting hero that belongs to given player
 
 	void localInit();
-	static void adjustOppositeBonuses(BattleInfo * curB);
 	static BattleInfo * setupBattle(int3 tile, ETerrainType terrain, BFieldType battlefieldType, const CArmedInstance * armies[2], const CGHeroInstance * heroes[2], bool creatureBank, const CGTownInstance * town);
 
 	ui8 whatSide(PlayerColor player) const;
@@ -146,9 +145,6 @@ public:
 
 protected:
 	scripting::Pool * getContextPool() const override;
-
-private:
-	inline static void adjustOppositeBonuses(CBonusSystemNode * node, PlayerColor ownerColor);
 };
 
 

--- a/lib/battle/BattleInfo.h
+++ b/lib/battle/BattleInfo.h
@@ -22,6 +22,11 @@ class CStackBasicDescriptor;
 class DLL_LINKAGE BattleInfo : public CBonusSystemNode, public CBattleInfoCallback, public IBattleState
 {
 public:
+	enum BattleSide
+	{
+		ATTACKER = 0,
+		DEFENDER
+	};
 	std::array<SideInBattle, 2> sides; //sides[0] - attacker, sides[1] - defender
 	si32 round, activeStack;
 	const CGTownInstance * town; //used during town siege, nullptr if this is not a siege (note that fortless town IS also a siege)
@@ -133,6 +138,8 @@ public:
 
 	void localInit();
 
+	static void setupBonusesFromTown(const CGTownInstance * town, BattleInfo * curB); //besieged city may contain buildings with negative bonuses for enemy army.
+	static void setupBonusesFromUnits(BattleInfo * curB); //besieged city may contain buildings with negative bonuses for enemy army.
 	static BattleInfo * setupBattle(int3 tile, ETerrainType terrain, BFieldType battlefieldType, const CArmedInstance * armies[2], const CGHeroInstance * heroes[2], bool creatureBank, const CGTownInstance * town);
 
 	ui8 whatSide(PlayerColor player) const;
@@ -141,6 +148,9 @@ public:
 
 protected:
 	scripting::Pool * getContextPool() const override;
+
+private:
+	static void addOnlyEnemyArmyBonuses(const BonusList & bonusList, BattleInfo * curB, BattleInfo::BattleSide side);
 };
 
 

--- a/lib/battle/BattleInfo.h
+++ b/lib/battle/BattleInfo.h
@@ -138,8 +138,9 @@ public:
 
 	void localInit();
 
-	static void setupBonusesFromTown(const CGTownInstance * town, BattleInfo * curB); //besieged city may contain buildings with negative bonuses for enemy army.
-	static void setupBonusesFromUnits(BattleInfo * curB); //besieged city may contain buildings with negative bonuses for enemy army.
+	static void setupBonusesFromTownToEnemy(const CGTownInstance * town, BattleInfo * curB); //besieged city may contain buildings with negative bonuses for enemy army
+	static void setupBonusesFromTownToBothSides(const CGTownInstance * town, BattleInfo * curB); //if visiting hero is town defender during siege, he/she should receive bonuses
+	static void setupBonusesFromUnitsToEnemy(BattleInfo * curB);
 	static BattleInfo * setupBattle(int3 tile, ETerrainType terrain, BFieldType battlefieldType, const CArmedInstance * armies[2], const CGHeroInstance * heroes[2], bool creatureBank, const CGTownInstance * town);
 
 	ui8 whatSide(PlayerColor player) const;
@@ -150,7 +151,8 @@ protected:
 	scripting::Pool * getContextPool() const override;
 
 private:
-	static void addOnlyEnemyArmyBonuses(const BonusList & bonusList, BattleInfo * curB, BattleInfo::BattleSide side);
+	static void addOnlyEnemyArmyBonuses(const BonusList & bonusList, BattleInfo * curB, BattleInfo::BattleSide enemySide);
+	STRONG_INLINE static std::shared_ptr<Bonus> makeBonusForEnemy(const std::shared_ptr<Bonus> & b, PlayerColor & enemyColor);
 };
 
 

--- a/lib/mapObjects/CArmedInstance.h
+++ b/lib/mapObjects/CArmedInstance.h
@@ -38,6 +38,11 @@ public:
 	CArmedInstance();
 	CArmedInstance(bool isHypotetic);
 
+	PlayerColor getOwner() const override
+	{
+		return this->tempOwner;
+	}
+
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
 		h & static_cast<CGObjectInstance&>(*this);

--- a/lib/mapObjects/CGHeroInstance.cpp
+++ b/lib/mapObjects/CGHeroInstance.cpp
@@ -1069,11 +1069,29 @@ void CGHeroInstance::deserializationFix()
 	artDeserializationFix(this);
 }
 
-CBonusSystemNode * CGHeroInstance::whereShouldBeAttached(CGameState *gs)
+CBonusSystemNode * CGHeroInstance::whereShouldBeAttachedOnSiege(const bool isBattleOutsideTown) const
+{
+	if(!visitedTown)
+		return nullptr;
+
+	return isBattleOutsideTown ? (CBonusSystemNode *)(& visitedTown->townAndVis)
+		: (CBonusSystemNode *)(visitedTown.get());
+
+}
+
+CBonusSystemNode * CGHeroInstance::whereShouldBeAttachedOnSiege(CGameState * gs)
 {
 	if(visitedTown)
+		return whereShouldBeAttachedOnSiege(visitedTown->isBattleOutsideTown(this));
+
+	return CArmedInstance::whereShouldBeAttached(gs);
+}
+
+CBonusSystemNode * CGHeroInstance::whereShouldBeAttached(CGameState * gs)
+{
+	if (visitedTown)
 	{
-		if(inTownGarrison)
+		if (inTownGarrison)
 			return visitedTown;
 		else
 			return &visitedTown->townAndVis;

--- a/lib/mapObjects/CGHeroInstance.cpp
+++ b/lib/mapObjects/CGHeroInstance.cpp
@@ -1089,9 +1089,9 @@ CBonusSystemNode * CGHeroInstance::whereShouldBeAttachedOnSiege(CGameState * gs)
 
 CBonusSystemNode * CGHeroInstance::whereShouldBeAttached(CGameState * gs)
 {
-	if (visitedTown)
+	if(visitedTown)
 	{
-		if (inTownGarrison)
+		if(inTownGarrison)
 			return visitedTown;
 		else
 			return &visitedTown->townAndVis;

--- a/lib/mapObjects/CGHeroInstance.h
+++ b/lib/mapObjects/CGHeroInstance.h
@@ -246,8 +246,11 @@ public:
 	ArtBearer::ArtBearer bearerType() const override;
 
 	///IBonusBearer
-	CBonusSystemNode *whereShouldBeAttached(CGameState *gs) override;
+	CBonusSystemNode * whereShouldBeAttached(CGameState *gs) override;
 	std::string nodeName() const override;
+
+	CBonusSystemNode * whereShouldBeAttachedOnSiege(const bool isBattleOutsideTown) const;
+	CBonusSystemNode * whereShouldBeAttachedOnSiege(CGameState * gs);
 
 	///spells::Caster
 	int32_t getCasterUnitId() const override;

--- a/lib/mapObjects/CGTownInstance.cpp
+++ b/lib/mapObjects/CGTownInstance.cpp
@@ -1265,6 +1265,8 @@ void CGTownInstance::recreateBuildingsBonuses()
 
 		for(auto bonus : building->buildingBonuses)
 		{
+			if(bonus->effectRange == Bonus::ONLY_ENEMY_ARMY) //will be added in the 'setupBattle' to Battle node.
+				continue;
 			if(bonus->propagator != nullptr && bonus->propagator->getPropagatorType() == ALL_CREATURES)
 				VLC->creh->addBonusForAllCreatures(bonus);
 			else

--- a/lib/mapObjects/CGTownInstance.cpp
+++ b/lib/mapObjects/CGTownInstance.cpp
@@ -592,7 +592,6 @@ int CGTownInstance::getDwellingBonus(const std::vector<CreatureID>& creatureIds,
 TResources CGTownInstance::dailyIncome() const
 {
 	TResources ret;
-
 	for (auto & p : town->buildings)
 	{
 		BuildingID buildingUpgrade;
@@ -604,28 +603,28 @@ TResources CGTownInstance::dailyIncome() const
 				buildingUpgrade = p2.first;
 			}
 		}
-
 		if (!hasBuilt(buildingUpgrade)&&(hasBuilt(p.first)))
 		{
 			ret += p.second->produce;
 		}
-
 	}
-
 	return ret;
 }
+
 bool CGTownInstance::hasFort() const
 {
 	return hasBuilt(BuildingID::FORT);
 }
+
 bool CGTownInstance::hasCapitol() const
 {
 	return hasBuilt(BuildingID::CAPITOL);
 }
+
 CGTownInstance::CGTownInstance()
 	:CGDwelling(), IShipyard(this), IMarket(this), town(nullptr), builded(0), destroyed(0), identifier(0), alignment(0xff)
 {
-
+	this->setNodeType(CBonusSystemNode::TOWN);
 }
 
 CGTownInstance::~CGTownInstance()
@@ -653,43 +652,43 @@ bool CGTownInstance::needsLastStack() const
 	else return false;
 }
 
+void CGTownInstance::setOwner(const PlayerColor player) const
+{
+	removeCapitols(player);
+	cb->setOwner(this, player);
+}
+
 void CGTownInstance::onHeroVisit(const CGHeroInstance * h) const
 {
-	if( !cb->gameState()->getPlayerRelations( getOwner(), h->getOwner() ))//if this is enemy
+	if(!cb->gameState()->getPlayerRelations( getOwner(), h->getOwner() ))//if this is enemy
 	{
 		if(armedGarrison() || visitingHero)
 		{
-			const CGHeroInstance *defendingHero = nullptr;
-			const CArmedInstance *defendingArmy = this;
+			const CGHeroInstance * defendingHero = visitingHero ? visitingHero : garrisonHero;
+			const CArmedInstance * defendingArmy = defendingHero ? (CArmedInstance *)defendingHero : (CArmedInstance *)this;
+			const bool isBattleOutside = isBattleOutsideTown(defendingHero); //defendingHero && garrisonHero && defendingHero != garrisonHero;
 
-			if(visitingHero)
-				defendingHero = visitingHero;
-			else if(garrisonHero)
-				defendingHero = garrisonHero;
-
-			if(defendingHero)
-				defendingArmy = defendingHero;
-
-			bool outsideTown = (defendingHero == visitingHero && garrisonHero);
-
-			//"borrowing" army from garrison to visiting hero
-			if(!outsideTown && armedGarrison() &&
-				visitingHero && defendingHero == visitingHero)
+			if(!isBattleOutside && visitingHero && defendingHero == visitingHero)
 			{
-				mergeGarrisonOnSiege();
-			}
+				//we have two approaches to merge armies: mergeGarrisonOnSiege() and used in the CGameHandler::garrisonSwap(ObjectInstanceID tid)
+				auto nodeSiege = defendingHero->whereShouldBeAttachedOnSiege(isBattleOutside);
 
-			cb->startBattlePrimary(h, defendingArmy, getSightCenter(), h, defendingHero, false, (outsideTown ? nullptr : this));
+				if(nodeSiege == (CBonusSystemNode *)this)
+					cb->garrisonSwapOnSiege(this->id);
+
+				const_cast<CGHeroInstance *>(defendingHero)->inTownGarrison = false; //hack to return visitor from garrison after battle
+			}
+			cb->startBattlePrimary(h, defendingArmy, getSightCenter(), h, defendingHero, false, (isBattleOutside ? nullptr : this));
 		}
 		else
 		{
-			cb->setOwner(this, h->tempOwner);
-			if(cb->gameState()->getPlayerStatus(h->getOwner()) == EPlayerStatus::WINNER)
+			auto heroColor = h->getOwner();
+			setOwner(heroColor);
+			if(cb->gameState()->getPlayerStatus(heroColor) == EPlayerStatus::WINNER)
 			{
 				return; //we just won game, we do not need to perform any extra actions
 				//TODO: check how does H3 behave, visiting town on victory can affect campaigns (spells learned, +1 stat building visited)
 			}
-			removeCapitols(h->getOwner());
 			cb->heroVisitCastle(this, h);
 		}
 	}
@@ -1253,7 +1252,8 @@ void CGTownInstance::recreateBuildingsBonuses()
 	for(auto b : bl)
 		removeBonus(b);
 
-	for(auto bid : builtBuildings)
+	auto owner = this->getOwner();
+	for(const auto bid : builtBuildings)
 	{
 		if(vstd::contains(overriddenBuildings, bid)) //tricky! -> checks tavern only if no bratherhood of sword
 			continue;
@@ -1263,10 +1263,15 @@ void CGTownInstance::recreateBuildingsBonuses()
 		if(building->buildingBonuses.empty())
 			continue;
 
-		for(auto bonus : building->buildingBonuses)
+		for(auto & bonus : building->buildingBonuses)
 		{
-			if(bonus->effectRange == Bonus::ONLY_ENEMY_ARMY) //will be added in the 'setupBattle' to Battle node.
+			if(bonus->limiter && bonus->effectRange == Bonus::ONLY_ENEMY_ARMY) //ONLY_ENEMY_ARMY is only mark for OppositeSide limiter to avoid extra dynamic_cast.
+			{
+				auto bCopy = std::make_shared<Bonus>(*bonus); //just a copy of the shared_ptr has been changed and reassigned.
+				bCopy->limiter = std::make_shared<OppositeSideLimiter>(this->getOwner());
+				addNewBonus(bCopy);
 				continue;
+			}
 			if(bonus->propagator != nullptr && bonus->propagator->getPropagatorType() == ALL_CREATURES)
 				VLC->creh->addBonusForAllCreatures(bonus);
 			else
@@ -1277,14 +1282,7 @@ void CGTownInstance::recreateBuildingsBonuses()
 
 void CGTownInstance::setVisitingHero(CGHeroInstance *h)
 {
-	//if (!(!!visitingHero == !h))
-	//{
-	//	logGlobal->warn("Hero visiting town %s is %s ", name, (visitingHero.get() ? visitingHero->name : "NULL"));
-	//	logGlobal->warn("New hero will be %s ", (h ? h->name : "NULL"));
-	//
-	//}
 	assert(!!visitingHero == !h);
-
 	if(h)
 	{
 		PlayerState *p = cb->gameState()->getPlayerState(h->tempOwner);
@@ -1388,7 +1386,7 @@ const CGTownBuilding * CGTownInstance::getBonusingBuilding(BuildingSubID::EBuild
 
 bool CGTownInstance::hasBuiltSomeTradeBuilding() const
 {
-	for (const auto & bid : builtBuildings)
+	for(const auto & bid : builtBuildings)
 	{
 		if(town->buildings.at(bid)->IsTradeBuilding())
 			return true;
@@ -1492,18 +1490,19 @@ void CGTownInstance::addHeroToStructureVisitors(const CGHeroInstance *h, si64 st
 	}
 }
 
-void CGTownInstance::battleFinished(const CGHeroInstance *hero, const BattleResult &result) const
+void CGTownInstance::battleFinished(const CGHeroInstance * hero, const BattleResult & result) const
 {
-	if(result.winner == 0)
+	if(result.winner == BattleSide::ATTACKER)
 	{
+		auto heroColor = hero->getOwner(); //get tempOwner
+
 		clearArmy();
-		removeCapitols(hero->getOwner());
-		cb->setOwner (this, hero->tempOwner); //give control after checkout is done
+		setOwner(heroColor); //give control after checkout is done
 		FoWChange fw;
-		fw.player = hero->tempOwner;
+		fw.player = heroColor;
 		fw.mode = 1;
 		cb->getTilesInRange(fw.tiles, getSightCenter(), getSightRadius(), tempOwner, 1);
-		cb->sendAndApply (&fw);
+		cb->sendAndApply(&fw);
 	}
 }
 

--- a/lib/mapObjects/CGTownInstance.cpp
+++ b/lib/mapObjects/CGTownInstance.cpp
@@ -1812,6 +1812,13 @@ void CTownBonus::applyBonuses(CGHeroInstance * h, const BonusList & bonuses) con
 		GiveBonus gb;
 		InfoWindow iw;
 
+		if(bonus->type == Bonus::TOWN_MAGIC_WELL)
+		{
+			if(h->mana >= h->manaLimit())
+				return;
+			cb->setManaPoints(h->id, h->manaLimit());
+			bonus->duration = Bonus::ONE_DAY;
+		}
 		gb.bonus = * bonus;
 		gb.id = h->id.getNum();
 		cb->giveHeroBonus(&gb);
@@ -1895,8 +1902,15 @@ const std::string CGTownBuilding::getVisitingBonusGreeting() const
 	return bonusGreeting;
 }
 
-const std::string CGTownBuilding::getCustomBonusGreeting(const Bonus & bonus)
+const std::string CGTownBuilding::getCustomBonusGreeting(const Bonus & bonus) const
 {
+	if(bonus.type == Bonus::TOWN_MAGIC_WELL)
+	{
+		auto bonusGreeting = std::string(VLC->generaltexth->localizedTexts["townHall"]["greetingInTownMagicWell"].String());
+		auto buildingName = town->town->getSpecialBuilding(bType)->Name();
+		boost::algorithm::replace_first(bonusGreeting, "%s", buildingName);
+		return bonusGreeting;
+	}
 	auto bonusGreeting = std::string(VLC->generaltexth->localizedTexts["townHall"]["greetingCustomBonus"].String()); //"%s gives you +%d %s%s"
 	std::string param = "";
 	std::string until = "";

--- a/lib/mapObjects/CGTownInstance.h
+++ b/lib/mapObjects/CGTownInstance.h
@@ -352,7 +352,7 @@ public:
 	void afterAddToMap(CMap * map) override;
 	static void reset();
 
-	STRONG_INLINE bool isBattleOutsideTown(const CGHeroInstance * defendingHero) const
+	inline bool isBattleOutsideTown(const CGHeroInstance * defendingHero) const
 	{
 		return defendingHero && garrisonHero && defendingHero != garrisonHero;
 	}

--- a/lib/mapObjects/CGTownInstance.h
+++ b/lib/mapObjects/CGTownInstance.h
@@ -140,7 +140,7 @@ protected:
 	BuildingSubID::EBuildingSubID bType;
 
 	const std::string getVisitingBonusGreeting() const;
-	static const std::string getCustomBonusGreeting(const Bonus & bonus);
+	const std::string getCustomBonusGreeting(const Bonus & bonus) const;
 };
 
 class DLL_LINKAGE COPWBonus : public CGTownBuilding

--- a/lib/mapObjects/CGTownInstance.h
+++ b/lib/mapObjects/CGTownInstance.h
@@ -275,6 +275,9 @@ public:
 		else if(!h.saving)
 			updateTown794();
 
+		if(!h.saving && (version >= 794 && version < 801))
+			fixBonusingDuplicates();
+
 		if(!h.saving)
 			this->setNodeType(CBonusSystemNode::TOWN);
 	}
@@ -366,9 +369,11 @@ private:
 	void updateBonusingBuildings();
 	bool hasBuiltInOldWay(ETownType::ETownType type, BuildingID bid) const;
 	bool townEnvisagesBuilding(BuildingSubID::EBuildingSubID bid) const;
+	bool isBonusingBuildingAdded(BuildingID::EBuildingID bid) const;
 	void tryAddOnePerWeekBonus(BuildingSubID::EBuildingSubID subID);
 	void tryAddVisitingBonus(BuildingSubID::EBuildingSubID subID);
 	void initOverriddenBids();
 	void addTownBonuses();
 	void updateTown794(); //populate overriddenBuildings and vanila bonuses for old saves 
+	void fixBonusingDuplicates(); //For versions 794-800.
 };

--- a/lib/mapObjects/CGTownInstance.h
+++ b/lib/mapObjects/CGTownInstance.h
@@ -274,6 +274,9 @@ public:
 			h & overriddenBuildings;
 		else if(!h.saving)
 			updateTown794();
+
+		if(!h.saving)
+			this->setNodeType(CBonusSystemNode::TOWN);
 	}
 	//////////////////////////////////////////////////////////////////////////
 
@@ -349,11 +352,16 @@ public:
 	void afterAddToMap(CMap * map) override;
 	static void reset();
 
+	STRONG_INLINE bool isBattleOutsideTown(const CGHeroInstance * defendingHero) const
+	{
+		return defendingHero && garrisonHero && defendingHero != garrisonHero;
+	}
 protected:
 	void setPropertyDer(ui8 what, ui32 val) override;
 	void serializeJsonOptions(JsonSerializeFormat & handler) override;
 
 private:
+	void setOwner(const PlayerColor owner) const;
 	int getDwellingBonus(const std::vector<CreatureID>& creatureIds, const std::vector<ConstTransitivePtr<CGDwelling> >& dwellings) const;
 	void updateBonusingBuildings();
 	bool hasBuiltInOldWay(ETownType::ETownType type, BuildingID bid) const;

--- a/lib/mapObjects/CObjectHandler.cpp
+++ b/lib/mapObjects/CObjectHandler.cpp
@@ -119,14 +119,6 @@ CObjectHandler::CObjectHandler()
 	logGlobal->trace("\t\tDone loading resource prices!");
 }
 
-PlayerColor CGObjectInstance::getOwner() const
-{
-	//if (state)
-	//	return state->owner;
-	//else
-		return tempOwner; //won't have owner
-}
-
 CGObjectInstance::CGObjectInstance():
 	pos(-1,-1,-1),
 	ID(Obj::NO_OBJ),

--- a/lib/mapObjects/CObjectHandler.h
+++ b/lib/mapObjects/CObjectHandler.h
@@ -118,12 +118,12 @@ public:
 	Obj ID;
 	/// Subtype of object, depends on type
 	si32 subID;
+	/// Current owner of an object (when below PLAYER_LIMIT)
+	PlayerColor tempOwner;
 	/// Index of object in map's list of objects
 	ObjectInstanceID id;
 	/// Defines appearance of object on map (animation, blocked tiles, blit order, etc)
 	ObjectTemplate appearance;
-	/// Current owner of an object (when below PLAYER_LIMIT)
-	PlayerColor tempOwner;
 	/// If true hero can visit this object only from neighbouring tiles and can't stand on this object
 	bool blockVisit;
 
@@ -140,7 +140,10 @@ public:
 	/// "center" tile from which the sight distance is calculated
 	int3 getSightCenter() const;
 
-	PlayerColor getOwner() const override;
+	PlayerColor getOwner() const override 
+	{
+		return this->tempOwner;
+	}
 	void setOwner(PlayerColor ow);
 
 	/** APPEARANCE ACCESSORS **/
@@ -213,8 +216,8 @@ public:
 
 	///Entry point of Json (de-)serialization
 	void serializeJson(JsonSerializeFormat & handler);
-
 	virtual void updateFrom(const JsonNode & data);
+
 protected:
 	/// virtual method that allows synchronously update object state on server and all clients
 	virtual void setPropertyDer(ui8 what, ui32 val);

--- a/lib/registerTypes/RegisterTypes.h
+++ b/lib/registerTypes/RegisterTypes.h
@@ -143,6 +143,7 @@ void registerTypesMapObjectTypes(Serializer &s)
 
 	s.template registerType<ILimiter, AnyOfLimiter>();
 	s.template registerType<ILimiter, NoneOfLimiter>();
+	s.template registerType<ILimiter, OppositeSideLimiter>();
 	//new types (other than netpacks) must register here
 	//order of type registration is critical for loading old savegames
 }

--- a/lib/registerTypes/RegisterTypes.h
+++ b/lib/registerTypes/RegisterTypes.h
@@ -144,6 +144,7 @@ void registerTypesMapObjectTypes(Serializer &s)
 	s.template registerType<ILimiter, AnyOfLimiter>();
 	s.template registerType<ILimiter, NoneOfLimiter>();
 	s.template registerType<ILimiter, OppositeSideLimiter>();
+	s.template registerType<IUpdater, OwnerUpdater>();
 	//new types (other than netpacks) must register here
 	//order of type registration is critical for loading old savegames
 }

--- a/lib/serializer/CSerializer.h
+++ b/lib/serializer/CSerializer.h
@@ -12,7 +12,7 @@
 #include "../ConstTransitivePtr.h"
 #include "../GameConstants.h"
 
-const ui32 SERIALIZATION_VERSION = 800;
+const ui32 SERIALIZATION_VERSION = 801;
 const ui32 MINIMAL_SERIALIZATION_VERSION = 753;
 const std::string SAVEGAME_MAGIC = "VCMISVG";
 

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -901,7 +901,7 @@ void CGameHandler::endBattle(int3 tile, const CGHeroInstance * heroAttacker, con
 		&& !heroDefender->inTownGarrison
 		&& heroDefender->visitedTown->garrisonHero == heroDefender)
 	{
-		garrisonSwapOnSiege(heroDefender->visitedTown->id); //return defending visitor from garrison to its rightful place
+		swapGarrisonOnSiege(heroDefender->visitedTown->id); //return defending visitor from garrison to its rightful place
 	}
 	//give exp
 	if(battleResult.data->exp[0] && heroAttacker && battleResult.get()->winner == BattleSide::ATTACKER)
@@ -3492,7 +3492,7 @@ void CGameHandler::moveArmy(const CArmedInstance *src, const CArmedInstance *dst
 	}
 }
 
-bool CGameHandler::garrisonSwapOnSiege(ObjectInstanceID tid)
+bool CGameHandler::swapGarrisonOnSiege(ObjectInstanceID tid)
 {
 	const CGTownInstance * town = getTown(tid);
 

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -904,9 +904,9 @@ void CGameHandler::endBattle(int3 tile, const CGHeroInstance * heroAttacker, con
 		garrisonSwapOnSiege(heroDefender->visitedTown->id); //return defending visitor from garrison to its rightful place
 	}
 	//give exp
-	if (battleResult.data->exp[0] && heroAttacker && battleResult.get()->winner == BattleSide::ATTACKER)
+	if(battleResult.data->exp[0] && heroAttacker && battleResult.get()->winner == BattleSide::ATTACKER)
 		changePrimSkill(heroAttacker, PrimarySkill::EXPERIENCE, battleResult.data->exp[0]);
-	else if (battleResult.data->exp[1] && heroDefender && battleResult.get()->winner == BattleSide::DEFENDER)
+	else if(battleResult.data->exp[1] && heroDefender && battleResult.get()->winner == BattleSide::DEFENDER)
 		changePrimSkill(heroDefender, PrimarySkill::EXPERIENCE, battleResult.data->exp[1]);
 
 	queries.popIfTop(battleQuery);

--- a/server/CGameHandler.h
+++ b/server/CGameHandler.h
@@ -242,6 +242,7 @@ public:
 	//void lootArtifacts (TArtHolder source, TArtHolder dest, std::vector<ui32> &arts); //after battle - move al arts to winer
 	bool buySecSkill( const IMarket *m, const CGHeroInstance *h, SecondarySkill skill);
 	bool garrisonSwap(ObjectInstanceID tid);
+	bool garrisonSwapOnSiege(ObjectInstanceID tid);
 	bool upgradeCreature( ObjectInstanceID objid, SlotID pos, CreatureID upgID );
 	bool recruitCreatures(ObjectInstanceID objid, ObjectInstanceID dst, CreatureID crid, ui32 cram, si32 level);
 	bool buildStructure(ObjectInstanceID tid, BuildingID bid, bool force=false);//force - for events: no cost, no checkings

--- a/server/CGameHandler.h
+++ b/server/CGameHandler.h
@@ -242,7 +242,7 @@ public:
 	//void lootArtifacts (TArtHolder source, TArtHolder dest, std::vector<ui32> &arts); //after battle - move al arts to winer
 	bool buySecSkill( const IMarket *m, const CGHeroInstance *h, SecondarySkill skill);
 	bool garrisonSwap(ObjectInstanceID tid);
-	bool garrisonSwapOnSiege(ObjectInstanceID tid);
+	bool swapGarrisonOnSiege(ObjectInstanceID tid);
 	bool upgradeCreature( ObjectInstanceID objid, SlotID pos, CreatureID upgID );
 	bool recruitCreatures(ObjectInstanceID objid, ObjectInstanceID dst, CreatureID crid, ui32 cram, si32 level);
 	bool buildStructure(ObjectInstanceID tid, BuildingID bid, bool force=false);//force - for events: no cost, no checkings

--- a/test/mock/mock_IGameCallback.h
+++ b/test/mock/mock_IGameCallback.h
@@ -78,7 +78,7 @@ public:
 	void startBattleI(const CArmedInstance *army1, const CArmedInstance *army2, int3 tile, bool creatureBank = false) override {}; //if any of armies is hero, hero will be used
 	void startBattleI(const CArmedInstance *army1, const CArmedInstance *army2, bool creatureBank = false) override {}; //if any of armies is hero, hero will be used, visitable tile of second obj is place of battle
 	bool moveHero(ObjectInstanceID hid, int3 dst, ui8 teleporting, bool transit = false, PlayerColor asker = PlayerColor::NEUTRAL) override {return false;};
-	bool garrisonSwapOnSiege(ObjectInstanceID tid) override {};
+	bool swapGarrisonOnSiege(ObjectInstanceID tid) override {};
 	void giveHeroBonus(GiveBonus * bonus) override {};
 	void setMovePoints(SetMovePoints * smp) override {};
 	void setManaPoints(ObjectInstanceID hid, int val) override {};

--- a/test/mock/mock_IGameCallback.h
+++ b/test/mock/mock_IGameCallback.h
@@ -78,6 +78,7 @@ public:
 	void startBattleI(const CArmedInstance *army1, const CArmedInstance *army2, int3 tile, bool creatureBank = false) override {}; //if any of armies is hero, hero will be used
 	void startBattleI(const CArmedInstance *army1, const CArmedInstance *army2, bool creatureBank = false) override {}; //if any of armies is hero, hero will be used, visitable tile of second obj is place of battle
 	bool moveHero(ObjectInstanceID hid, int3 dst, ui8 teleporting, bool transit = false, PlayerColor asker = PlayerColor::NEUTRAL) override {return false;};
+	bool garrisonSwapOnSiege(ObjectInstanceID tid) override {};
 	void giveHeroBonus(GiveBonus * bonus) override {};
 	void setMovePoints(SetMovePoints * smp) override {};
 	void setManaPoints(ObjectInstanceID hid, int val) override {};


### PR DESCRIPTION
- [x] New feature: Negative town bonuses for enemy army implementation
- [x] Fix: Negative bonus bearers should not be affected by own negative bonuses. So, devils, archdevils, negative artifacts (shaman's thing and some dead head), negative hero's abilities (such as Amanda from  Cathedral) should work now.
- [x] Fix: Visiting hero should receive town bonuses during town siege when he defends a town as garrison hero. Bonus tree mounting is fixed to provide town bonuses.

- [x] New feature: 'Magic Well' should work in fan towns.
- [x] New feature: Introduced new limiter. The advantage of this solution is the bonus propagation is implemented using a standard propagation mechanic, it needs just owner adjustment instead of whole bonus copying to the node on battle setup

**Samples:**

Magic Well: `"onVisitBonuses" : [ { "type": "TOWN_MAGIC_WELL" } ],`
Magic Absorber: `"bonuses" : [ { "type": "SPELL_DAMAGE_REDUCTION", "val": 50, "subtype": -1 } ]`
-2 morale to enemy army: `"bonuses" : [ { "type": "MORALE", "val": -2, "effectRange":"ONLY_ENEMY_ARMY" } ]`

**Guide to feature applying:**

No limiters or propagators  should be used with  ` "effectRange": "ONLY_ENEMY_ARMY" `

**Testing:**

Precondition: Devils are in the hero's army.

- Attack neutrals with devils outside a town.  
- Make sure, negatives are propagated from hero's army to the neutrals units.
- Make sure, own negatives are not propagated to the negative bonus owner.
- Attack neutral devils.  
- Make sure, negatives are propagated from neutrals units to the hero's army.
- Attack neutral devils with devils. 
- Make sure, enemy negatives are propagated to all units
- Attack neutral town (no devils in the hero's army) with devils in the town garrison. 
- Make sure, enemy negatives are propagated  from garrison to hero's army
- Attack neutral town (devils are the hero's army) with devils in the town garrison. 
- Make sure, enemy negatives are propagated to all units
- Attack town with built negative bonus building
- Make sure, negatives are propagated from town building to the hero's army
- Capture this town and remain weak  visitor (not garrison) hero as defender. Enemy should attack.
- Make sure, defending visitor obtains positive bonuses from town. 
- Make sure, enemy attacker obtains negative bonuses from town
- Win this battle. Move hero to garrison and wait for next attack.
- Make sure, defending garrison hero obtains positive bonuses from town. 
- Lose this battle and wait until enemy remains this town without guardians.
- Capture this town again, wait for enemy attack 
- Make sure, that negative bonuses from town work properly against enemy attacker only
- Get negative artifacts (shaman's thing, dead head and horseshoe), attack enemy neutral
- Make sure, that negative bonuses from artifacts work against neutrals only. Win battle
- Attack enemy hero. Make sure, that negative bonuses from artifacts work against enemy army only. 
- Choose hero with negative ability, attack enemy with this hero.
- Make sure, negative hero ability work properly against neutrals, enemy armies, town garrisons.
- Make sure, opposite bonuses without value (such as NO_MORALE) work properly against enemy in / outside town battles
- Make sure, that negative primary skills artifacts don't cause primary skill value to be less than valid minimum (0 and 1 for SP and Knowledge)
- Make sure Magic Well works properly (one time in day per hero)
- Make sure, negative artifacts work properly in the old saves
- Make sure, creatures with negative bonuses work properly in the old saves
- Make sure, negative hero's abilities work properly in the old saves
- Make sure, town buildings with  negative bonuses work properly in the old saves
