### PR TITLE
Fix: Some map objects sometimes do not increment some primary skills of some heroes

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -75,3 +75,6 @@ Andrzej Żak aka godric3
    
 Andrii Danylchenko
    * VCAI improvements
+
+Dmitry Orlov, <shubus.corporation@gmail.com>
+   * special buildings support in fan towns, new features and bug fixes

--- a/lib/CHeroHandler.h
+++ b/lib/CHeroHandler.h
@@ -236,6 +236,7 @@ struct DLL_LINKAGE CObstacleInfo
 
 class DLL_LINKAGE CHeroClassHandler : public IHandlerBase
 {
+	void fillPrimarySkillData(const JsonNode & node, CHeroClass * heroClass, PrimarySkill::PrimarySkill pSkill);
 	CHeroClass *loadFromJson(const JsonNode & node, const std::string & identifier);
 public:
 	std::vector< ConstTransitivePtr<CHeroClass> > heroClasses;

--- a/lib/HeroBonus.cpp
+++ b/lib/HeroBonus.cpp
@@ -786,13 +786,9 @@ int IBonusBearer::getPrimSkillLevel(PrimarySkill::PrimarySkill id) const
 {
 	static const CSelector selectorAllSkills = Selector::type()(Bonus::PRIMARY_SKILL);
 	static const std::string keyAllSkills = "type_PRIMARY_SKILL";
-
 	auto allSkills = getBonuses(selectorAllSkills, keyAllSkills);
-
-	int ret = allSkills->valOfBonuses(Selector::subtype()(id));
-
-	vstd::amax(ret, id/2); //minimal value is 0 for attack and defense and 1 for spell power and knowledge
-	return ret;
+	auto ret = allSkills->valOfBonuses(Selector::subtype()(id));
+	return ret; //sp=0 works in old saves
 }
 
 si32 IBonusBearer::magicResistance() const

--- a/lib/rmg/CMapGenerator.cpp
+++ b/lib/rmg/CMapGenerator.cpp
@@ -167,10 +167,14 @@ std::string CMapGenerator::getMapDescription() const
 	const std::string monsterStrengthStr[3] = { "weak", "normal", "strong" };
 
 	int monsterStrengthIndex = mapGenOptions->getMonsterStrength() - EMonsterStrength::GLOBAL_WEAK; //does not start from 0
+	const auto * mapTemplate = mapGenOptions->getMapTemplate();
+
+	if(!mapTemplate)
+		throw rmgException("Map template for Random Map Generator is not found. Could not start the game.");
 
     std::stringstream ss;
     ss << boost::str(boost::format(std::string("Map created by the Random Map Generator.\nTemplate was %s, Random seed was %d, size %dx%d") +
-        ", levels %s, players %d, computers %d, water %s, monster %s, VCMI map") % mapGenOptions->getMapTemplate()->getName() %
+        ", levels %s, players %d, computers %d, water %s, monster %s, VCMI map") % mapTemplate->getName() %
 		randomSeed % map->width % map->height % (map->twoLevel ? "2" : "1") % static_cast<int>(mapGenOptions->getPlayerCount()) %
 		static_cast<int>(mapGenOptions->getCompOnlyPlayerCount()) % waterContentStr[mapGenOptions->getWaterContent()] %
 		monsterStrengthStr[monsterStrengthIndex]);


### PR DESCRIPTION
*Abbreviations: Kn = Knowledge, SP = Spell Power

Known Requirements:  
- installed 'Cathedral' mod
- Map with 'Magic Ring' or 'Knowledge Stone ' (for +1 SP or +1 Kn)

Reproduction steps:
- Start new game from 'Cathedral' with 'Archon'-class hero
- You have following PS-s: 2,3,1,1
- Go to the +1 SP / Kn object
- Bonus popup showing, press Ok
- Look at the primary skills of your hero

Actual result : PS-s: 2,3,1,1
Expected result: PS-s: 2,3,2,1 or PS-s: 2,3,1,2

Root cause analysis:
The corresponding mod sets initial values for archons as 2,3,0,0 but legal minimum for SP and Kn is 1. Then UI uses `getPrimSkillLevel` to provide info about PS-s, that method artificially increases the zero result to the legal minimum, which is misleading.  Then PS-increasing routine uses real PS value, calculated from bonuses. Thus, it brings the impression that nothing is changed.

Solution: Set correct values instead of zeros for SP and Kn on hero class deserialization. Incorrect zero values will be shown correctly in the old saves, and it does not cause problems.