### PR TITLE
[3167] Crash when click single scenario in new game

### DIFF
--- a/client/widgets/TextControls.cpp
+++ b/client/widgets/TextControls.cpp
@@ -656,19 +656,20 @@ CFocusable::~CFocusable()
 
 	focusables -= this;
 }
+
 void CFocusable::giveFocus()
 {
+	focus = true;
+	focusGot();
+	redraw();
+
 	if(inputWithFocus)
 	{
 		inputWithFocus->focus = false;
-		inputWithFocus->focusLost();
 		inputWithFocus->redraw();
 	}
 
-	focus = true;
 	inputWithFocus = this;
-	focusGot();
-	redraw();
 }
 
 void CFocusable::moveFocus()


### PR DESCRIPTION
Remove extra SDL_StopTextInput calls. We don't need to stop text input when we are switching to another text input.