### PR TITLE
Fixes some tickets for Campaigns: 3095 cloned heroes, 3164 too high stats

### DIFF
--- a/lib/CGameState.cpp
+++ b/lib/CGameState.cpp
@@ -381,8 +381,22 @@ void CGameState::CrossoverHeroesList::addHeroToBothLists(CGHeroInstance * hero)
 
 void CGameState::CrossoverHeroesList::removeHeroFromBothLists(CGHeroInstance * hero)
 {
-	heroesFromPreviousScenario -= hero;
-	heroesFromAnyPreviousScenarios -= hero;
+	for (auto obj : heroesFromPreviousScenario)
+	{
+		if (obj->name == hero->name)
+		{
+			heroesFromPreviousScenario -= obj;
+			break;
+		}
+	}
+	for (auto obj : heroesFromAnyPreviousScenarios)
+	{
+		if (obj->name == hero->name) 
+		{
+			heroesFromAnyPreviousScenarios -= obj;
+			break;
+		}
+	}
 }
 
 CGameState::CampaignHeroReplacement::CampaignHeroReplacement(CGHeroInstance * hero, ObjectInstanceID heroPlaceholderId) : hero(hero), heroPlaceholderId(heroPlaceholderId)

--- a/lib/mapObjects/CGHeroInstance.cpp
+++ b/lib/mapObjects/CGHeroInstance.cpp
@@ -1399,6 +1399,14 @@ void CGHeroInstance::serializeCommonOptions(JsonSerializeFormat & handler)
 {
 	handler.serializeString("biography", biography);
 	handler.serializeInt("experience", exp, 0);
+	if(!handler.saving)
+	{
+		while(gainsLevel())
+		{
+			++level;
+		}
+	}
+
 	handler.serializeString("name", name);
 	handler.serializeBool<ui8>("female", sex, 1, 0, 0xFF);
 


### PR DESCRIPTION
Fixes some mantis tickets for Campaign game: 
3095 multiple heroes when switching to a new mission,
3164 Bug with primary skills when moving from mission to mission.

details:
CGameState: method removeHeroFromBothLists didnt work as there were different Hero objects and no exact match. Because this method didnt work, we had duplicated heroes on the map. It was replaced with deleting hero by its name instead.
CGHeroInstance: we didnt initialize level on loading hero from crossover, so the game did full levelups later, and bumped stats.
Changes were tested to work on transfer between 1st and 2nd scenario of Gelu SoD campaign.
Please note that this commit doesnt fix existing issues about transfering artifacts. Transfering artifacts is a more complex thing as if I recall correctly, we shouldnt just transfer every artifact, but only quest ones.