### PR TITLE
fix boost.locale crash on macOS-arm64

### DIFF
--- a/Global.h
+++ b/Global.h
@@ -191,7 +191,7 @@ static_assert(sizeof(bool) == 1, "Bool needs to be 1 byte in size.");
 #include <boost/format.hpp>
 #include <boost/functional/hash.hpp>
 #include <boost/lexical_cast.hpp>
-#ifndef VCMI_ANDROID
+#ifdef VCMI_WINDOWS
 #include <boost/locale/generator.hpp>
 #endif
 #include <boost/logic/tribool.hpp>

--- a/lib/VCMIDirs.cpp
+++ b/lib/VCMIDirs.cpp
@@ -654,7 +654,7 @@ namespace VCMIDirs
 		static bool initialized = false;
 		if (!initialized)
 		{
-			#ifndef VCMI_ANDROID
+			#ifdef VCMI_WINDOWS
 			std::locale::global(boost::locale::generator().generate("en_US.UTF-8"));
 			#endif
 			boost::filesystem::path::imbue(std::locale());


### PR DESCRIPTION
The fix is taken from https://github.com/SuperTux/supertux/pull/1663