### PR TITLE
enable cotire for EmptyAI

### DIFF
--- a/AI/EmptyAI/CMakeLists.txt
+++ b/AI/EmptyAI/CMakeLists.txt
@@ -20,5 +20,6 @@ target_link_libraries(EmptyAI PRIVATE vcmi)
 vcmi_set_output_dir(EmptyAI "AI")
 
 set_target_properties(EmptyAI PROPERTIES ${PCH_PROPERTIES})
+cotire(EmptyAI)
 
 install(TARGETS EmptyAI RUNTIME DESTINATION ${AI_LIB_DIR} LIBRARY DESTINATION ${AI_LIB_DIR})


### PR DESCRIPTION
If one doesn't build all available targets but only e.g. client, then without this `cmake --install` fails because EmptyAI lib doesn't exist.