### PR TITLE
a few erm interpretter unit tests and fixes

### DIFF
--- a/scripting/erm/ERMParser.cpp
+++ b/scripting/erm/ERMParser.cpp
@@ -81,11 +81,12 @@ std::string CERMPreprocessor::retrieveCommandLine()
 
 		if(openedString)
 		{
-			wholeCommand += "\\n";
+			wholeCommand += "\n";
 			if(dash != std::string::npos)
 			{
-				wholeCommand += line.substr(0, dash);
-				line.erase(0,dash);
+				wholeCommand += line.substr(0, dash + 1);
+				line.erase(0,dash + 1);
+				openedString = false;
 			}
 			else //no closing marker -> the whole line is further part of string
 			{

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -42,6 +42,8 @@ set(test_SRCS
 		erm/ERM_VR.cpp
 		erm/ERMPersistenceTest.cpp
 		erm/ExamplesTest.cpp
+		erm/interpretter/ERM_VR.cpp
+		erm/interpretter/ErmRunner.cpp
 
 		events/ApplyDamageTest.cpp
 		events/EventBusTest.cpp
@@ -107,6 +109,7 @@ set(test_HEADERS
 		JsonComparer.h
 
 		scripting/ScriptFixture.h
+		erm/interpretter/ErmRunner.h
 
  		map/MapComparer.h
 

--- a/test/erm/interpretter/ERM_VR.cpp
+++ b/test/erm/interpretter/ERM_VR.cpp
@@ -1,0 +1,74 @@
+/*
+ * ERM_VR.cpp, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
+#include "StdInc.h"
+#include "ErmRunner.h"
+
+
+namespace test
+{
+namespace scripting
+{
+
+using namespace ::testing;
+
+TEST(ERM_VR_S, SetInteger_ShouldGenerateSetStatement)
+{
+	LuaStrings lua = ErmRunner::convertErmToLua({"!#VRv2:S110;"});
+
+	ASSERT_EQ(lua.lines.size(), 9) << lua.text;
+	EXPECT_EQ(lua.lines[ErmRunner::REGULAR_INSTRUCTION_FIRST_LINE], "v['2'] = 110");
+}
+
+TEST(ERM_VR_S, SetString_ShouldGenerateSetStatement)
+{
+	LuaStrings lua = ErmRunner::convertErmToLua({"!#VRz100:S^Some str^;"});
+
+	ASSERT_EQ(lua.lines.size(), 9) << lua.text;
+	EXPECT_EQ(lua.lines[ErmRunner::REGULAR_INSTRUCTION_FIRST_LINE], "z['100'] = [===[Some str]===]");
+}
+
+TEST(ERM_VR_S, SetStringMultiline_ShouldGenerateMultilineSetStatement)
+{
+	LuaStrings lua = ErmRunner::convertErmToLua({
+		"!#VRz100:S^Some",
+		"multiline",
+		"string^;"
+		});
+
+	ASSERT_EQ(lua.lines.size(), 11) << lua.text;
+	EXPECT_EQ(lua.lines[ErmRunner::REGULAR_INSTRUCTION_FIRST_LINE], "z['100'] = [===[Some");
+	EXPECT_EQ(lua.lines[ErmRunner::REGULAR_INSTRUCTION_FIRST_LINE + 1], "multiline");
+	EXPECT_EQ(lua.lines[ErmRunner::REGULAR_INSTRUCTION_FIRST_LINE + 2], "string]===]");
+}
+
+TEST(ERM_VR_C, SetIntegers_ShouldGenerateSetStatements)
+{
+	LuaStrings lua = ErmRunner::convertErmToLua({"!#VRv100:C10/20/40;"});
+
+	ASSERT_EQ(lua.lines.size(), 11) << lua.text;
+	EXPECT_EQ(lua.lines[ErmRunner::REGULAR_INSTRUCTION_FIRST_LINE], "v['100'] = 10");
+	EXPECT_EQ(lua.lines[ErmRunner::REGULAR_INSTRUCTION_FIRST_LINE + 1], "v['101'] = 20");
+	EXPECT_EQ(lua.lines[ErmRunner::REGULAR_INSTRUCTION_FIRST_LINE + 2], "v['102'] = 40");
+}
+
+TEST(ERM_VR_C, GetInteger_ShouldGenerateSetStatement)
+{
+	LuaStrings lua = ErmRunner::convertErmToLua({
+		"!#VRv100:C10/20/40;",
+		"!#VRv100:C?v1;"});
+
+	ASSERT_EQ(lua.lines.size(), 12) << lua.text;
+	EXPECT_EQ(lua.lines[8], "v['1'] = v['100']");
+}
+
+}
+}
+
+

--- a/test/erm/interpretter/ErmRunner.cpp
+++ b/test/erm/interpretter/ErmRunner.cpp
@@ -1,0 +1,40 @@
+/*
+ * ErmRunner.cpp, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
+#include "StdInc.h"
+
+#include "../../scripting/ScriptFixture.h"
+#include "ErmRunner.h"
+
+namespace test
+{
+	namespace scripting
+	{
+		const size_t ErmRunner::REGULAR_INSTRUCTION_FIRST_LINE = 5;
+
+		LuaStrings::LuaStrings(std::string lua)
+			:text(lua), lines()
+		{
+			boost::split(lines, lua, boost::is_any_of("\r\n"));
+		}
+
+		LuaStrings ErmRunner::convertErmToLua(std::initializer_list<std::string> list)
+		{
+			std::stringstream source;
+
+			source << "ZVSE" << std::endl;
+			for(auto ermLine : list)
+				source << ermLine << std::endl;
+
+			auto lua = VLC->scriptHandler->erm->compile("", source.str(), logGlobal);
+
+			return LuaStrings(lua);
+		}
+	}
+}

--- a/test/erm/interpretter/ErmRunner.h
+++ b/test/erm/interpretter/ErmRunner.h
@@ -1,0 +1,34 @@
+/*
+ * ErmRunner.h, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
+
+#pragma once
+
+#include "../../../scripting/erm/ERMScriptModule.h"
+
+namespace test
+{
+	namespace scripting
+	{
+		struct LuaStrings
+		{
+			std::string text;
+			std::vector<std::string> lines;
+
+			LuaStrings(std::string lua);
+		};
+
+		static class ErmRunner
+		{
+		public:
+			static const size_t REGULAR_INSTRUCTION_FIRST_LINE;
+			static LuaStrings convertErmToLua(std::initializer_list<std::string> list);
+		};
+	}
+}


### PR DESCRIPTION
I plan to write more tests but this one can be merged because it fixes multiline string handling. Lua [===[ do not interpret \n so we need real newlines instead