### PR TITLE
fix bug: may load mod before dependencies

### DIFF
--- a/lib/CModHandler.h
+++ b/lib/CModHandler.h
@@ -242,9 +242,15 @@ class DLL_LINKAGE CModHandler
 	// - circular dependencies
 	bool checkDependencies(const std::vector <TModID> & input) const;
 
-	// returns load order in which all dependencies are resolved, e.g. loaded after required mods
-	// function assumes that input list is valid (checkDependencies returned true)
-	std::vector <TModID> resolveDependencies(std::vector<TModID> input) const;
+	/**
+	* 1. Set apart mods with resolved dependencies from mods which have unresolved dependencies
+	* 2. Sort resolved mods using topological algorithm
+	* 3. Log all problem mods and their unresolved dependencies
+	*
+	* @param modsToResolve list of valid mod IDs (checkDependencies returned true - TODO: Clarify it.)
+	* @return a vector of the topologically sorted resolved mods: child nodes (dependent mods) have greater index than parents
+	*/
+	std::vector <TModID> validateAndSortDependencies(std::vector <TModID> modsToResolve) const;
 
 	std::vector<std::string> getModList(std::string path);
 	void loadMods(std::string path, std::string parent, const JsonNode & modSettings, bool enableMods);


### PR DESCRIPTION
Commit [db1f9a1 ](https://github.com/vcmi/vcmi/commit/db1f9a15b0f67c59aacd7e0af41ef460f6455baf) disable topological sort，in some case a mod will lead mod loads before dependencies. If the mod replaces some object with the same in dependencies. Things go wrong. 

I just keep topological sort, put all mod after dependencies. If no more new mods to be be added  in a  topological sort, the sort should be ended. All left mod are broken and need to be logged.