### PR TITLE
Fix: ID-collisions on large mods collections loading

### DIFF
--- a/lib/JsonNode.h
+++ b/lib/JsonNode.h
@@ -87,6 +87,9 @@ public:
 	/// removes all data from node and sets type to null
 	void clear();
 
+	/// returns bool or bool equivalent of string value if 'success' is true, or false otherwise
+	bool TryBoolFromString(bool & success) const;
+
 	/// non-const accessors, node will change type on type mismatch
 	bool & Bool();
 	double & Float();

--- a/lib/mapObjects/CObjectClassesHandler.h
+++ b/lib/mapObjects/CObjectClassesHandler.h
@@ -283,8 +283,9 @@ class DLL_LINKAGE CObjectClassesHandler : public IHandlerBase
 	/// format: customNames[primaryID][secondaryID] -> name
 	std::map<si32, std::vector<std::string>> customNames;
 
-	void loadObjectEntry(const std::string & identifier, const JsonNode & entry, ObjectContainter * obj);
+	void loadObjectEntry(const std::string & identifier, const JsonNode & entry, ObjectContainter * obj, bool isSubobject = false);
 	ObjectContainter * loadFromJson(const JsonNode & json, const std::string & name);
+
 public:
 	CObjectClassesHandler();
 	~CObjectClassesHandler();

--- a/lib/mapObjects/CommonConstructors.cpp
+++ b/lib/mapObjects/CommonConstructors.cpp
@@ -144,21 +144,24 @@ CDwellingInstanceConstructor::CDwellingInstanceConstructor()
 void CDwellingInstanceConstructor::initTypeData(const JsonNode & input)
 {
 	const JsonVector & levels = input["creatures"].Vector();
-	availableCreatures.resize(levels.size());
-	for (size_t i=0; i<levels.size(); i++)
+	const auto totalLevels = levels.size();
+
+	availableCreatures.resize(totalLevels);
+	for(auto currentLevel = 0; currentLevel < totalLevels; currentLevel++)
 	{
-		const JsonVector & creatures = levels[i].Vector();
-		availableCreatures[i].resize(creatures.size());
-		for (size_t j=0; j<creatures.size(); j++)
+		const JsonVector & creaturesOnLevel = levels[currentLevel].Vector();
+		const auto creaturesNumber = creaturesOnLevel.size();
+		availableCreatures[currentLevel].resize(creaturesNumber);
+
+		for(auto currentCreature = 0; currentCreature < creaturesNumber; currentCreature++)
 		{
-			VLC->modh->identifiers.requestIdentifier("creature", creatures[j], [=] (si32 index)
+			VLC->modh->identifiers.requestIdentifier("creature", creaturesOnLevel[currentCreature], [=] (si32 index)
 			{
-				availableCreatures[i][j] = VLC->creh->creatures[index];
+				availableCreatures[currentLevel][currentCreature] = VLC->creh->creatures[index];
 			});
 		}
-		assert(!availableCreatures[i].empty());
+		assert(!availableCreatures[currentLevel].empty());
 	}
-
 	guards = input["guards"];
 }
 


### PR DESCRIPTION
Fixed:  
- ID-collisions on large mods collections processing
- one annoying assertion while parsing mods is fixed
- some refactoring of old code for better experience

RCA:

Map index for sub-objects, which have fixed obj->id greater than some fixed bound is calculated per algorithm which is intended for objects without fixed id. But the further code supposes, that calculated sub-object map index is  obj->id  of corresponding sub-object.