### PR TITLE
Fix: VCAI should not attempt to move Spell Book

### DIFF
--- a/AI/VCAI/VCAI.cpp
+++ b/AI/VCAI/VCAI.cpp
@@ -1165,11 +1165,11 @@ void VCAI::pickBestArtifacts(const CGHeroInstance * h, const CGHeroInstance * ot
 
 			for(auto location : allArtifacts)
 			{
+				if(location.slot == ArtifactPosition::MACH4 || location.slot == ArtifactPosition::SPELLBOOK)
+					continue; // don't attempt to move catapult and spellbook
+
 				if(location.relatedObj() == target && location.slot < ArtifactPosition::AFTER_LAST)
 					continue; //don't reequip artifact we already wear
-
-				if(location.slot == ArtifactPosition::MACH4) // don't attempt to move catapult
-					continue;
 
 				auto s = location.getSlot();
 				if(!s || s->locked) //we can't move locks


### PR DESCRIPTION
Minor fix:
![vcai_art_err](https://user-images.githubusercontent.com/58867270/116472754-feda5800-a87e-11eb-8174-75a73ef60182.jpg)
