### PR TITLE
Fix bug: When object template contains zIndex field, it will fail in json valid check.

### DIFF
--- a/config/schemas/objectTemplate.json
+++ b/config/schemas/objectTemplate.json
@@ -38,6 +38,10 @@
 			"type":"array",
 			"items": { "type": "string" },
 			"description": "Object mask that describes on which tiles object is visible/blocked/activatable"
+		},
+		"zIndex" :  {
+			"type":"number",
+			"description": "Defines order in which objects on same tile will be blit."
 		}
 	}
 }


### PR DESCRIPTION
The ObjectTemplate schema file is lack of zIndex field. I fix it.