### PR TITLE
client/lobby/CBonusSelection.cpp: fix difficulty overflow in bonus UI

### DIFF
--- a/client/lobby/CBonusSelection.cpp
+++ b/client/lobby/CBonusSelection.cpp
@@ -460,7 +460,9 @@ void CBonusSelection::increaseDifficulty()
 
 void CBonusSelection::decreaseDifficulty()
 {
-	CSH->setDifficulty(CSH->si->difficulty - 1);
+	// avoid negative overflow (0 - 1 = 255)
+	if (CSH->si->difficulty > 0)
+		CSH->setDifficulty(CSH->si->difficulty - 1);
 }
 
 CBonusSelection::CRegion::CRegion(int id, bool accessible, bool selectable, const SCampPositions & campDsc)


### PR DESCRIPTION
Before the change campaign bonus selection screen had inconsistent
overflow behaviour for difficulty selection:

```
    0 1 2 3 4 | available buttons: '-' to decrease
      ^       |                    '+' to increase
```

Before the change:

1. If we click '+' 5 times we will end up on difficulty=4 (ok, saturated).
2. If we click '-' 5 times we will end up on difficulty=1 (unexpected, wrap around).

After the change:

1. If we click '+' 5 times we will end up on difficulty=4 (saturated).
2. If we click '-' 5 times we will end up on difficulty=0 (saturated).

The inconsistency happens because `difficulty` variable has `ui8` type
and server uses `difficulty = vstd::abetween(difficulty, 0, 4)` to
implement the saturation.

For large positive values saturation works as expected:
    vstd::abetween(difficulty=5, 0, 4) -> 4
For small values it does not:
    vstd::abetween(difficulty=-1, 0, 4) -> 4

The change makes client to avoid using negative values.