### PR TITLE
Fix some warnings, Add headers to the solution, Fix MSVS build

### DIFF
--- a/scripting/erm/CMakeLists.txt
+++ b/scripting/erm/CMakeLists.txt
@@ -7,7 +7,14 @@ set(lib_SRCS
 		ERMScriptModule.cpp
 )
 
-add_library(vcmiERM SHARED ${lib_SRCS})
+set(lib_HDRS
+		StdInc.h
+		ERMParser.h
+		ERMInterpreter.h
+		ERMScriptModule.h
+)
+
+add_library(vcmiERM SHARED ${lib_SRCS} ${lib_HDRS})
 target_link_libraries(vcmiERM ${Boost_LIBRARIES} vcmi)
 
 vcmi_set_output_dir(vcmiERM "scripting")

--- a/scripting/erm/ERMInterpreter.cpp
+++ b/scripting/erm/ERMInterpreter.cpp
@@ -1282,7 +1282,7 @@ namespace ERMConverter
 
 			ERM::Tidentifier tid = trig.identifier.get();
 
-			if(tid.size() == 0)
+			if(tid.empty())
 				throw EInterpreterError("Function must have identifier");
 
 			Variable v = boost::apply_visitor(LVL1IexpToVar(), tid[0]);
@@ -1432,7 +1432,7 @@ bool ERMInterpreter::isATrigger( const ERM::TLine & line )
 	case 0: //v-exp
 		{
 			TVExp vexp = boost::get<TVExp>(line);
-			if(vexp.children.size() == 0)
+			if(vexp.children.empty())
 				return false;
 
 			switch (getExpType(vexp.children[0]))
@@ -1614,7 +1614,7 @@ namespace VERMInterpreter
 			if(asSymbol)
 			{
 				children.resize(children.size()+1);
-				for(int i=children.size()-1; i >0; i--)
+				for(auto i=children.size()-1; i >0; i--)
 				{
 					children[i] = children[i-1];
 				}
@@ -1718,7 +1718,7 @@ namespace VERMInterpreter
 	}
 	VOption OptionConverterVisitor::operator()( ERM::TSymbol const& cmd ) const
 	{
-		if(cmd.symModifier.size() == 0)
+		if(cmd.symModifier.empty())
 			return VSymbol(cmd.sym);
 		else
 			return VNode(cmd);

--- a/scripting/erm/ERMParser.cpp
+++ b/scripting/erm/ERMParser.cpp
@@ -187,7 +187,8 @@ std::vector<LineInfo> ERMParser::parseFile(CERMPreprocessor & preproc)
 	}
 	catch (ParseErrorException & e)
 	{
-		logGlobal->error("Stopped parsing file.");
+		logGlobal->error("ERM Parser Error. File: '%s' Line: %d Exception: '%s'"
+			, preproc.getCurFileName(), preproc.getCurLineNo(), e.what());
 		throw;
 	}
 	return ret;

--- a/scripting/erm/ERMParser.h
+++ b/scripting/erm/ERMParser.h
@@ -37,6 +37,11 @@ public:
 	{
 		return lineNo;
 	}
+
+	const std::string& getCurFileName() const
+	{
+		return fname;
+	}
 };
 
 //various classes that represent ERM/VERM AST

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -40,9 +40,11 @@ set(test_SRCS
 		erm/ERM_MF.cpp
 		erm/ERM_TM_T.cpp
 		erm/ERM_VR.cpp
+		erm/ERM_UN.cpp
 		erm/ERMPersistenceTest.cpp
 		erm/ExamplesTest.cpp
 		erm/interpretter/ERM_VR.cpp
+		erm/interpretter/ERM_UN.cpp
 		erm/interpretter/ErmRunner.cpp
 
 		events/ApplyDamageTest.cpp

--- a/test/erm/interpretter/ERM_UN.cpp
+++ b/test/erm/interpretter/ERM_UN.cpp
@@ -1,0 +1,28 @@
+/*
+ * ERM_UN.cpp, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
+#include "StdInc.h"
+#include "ErmRunner.h"
+
+namespace test
+{
+	namespace scripting
+	{
+		using namespace ::testing;
+
+		TEST(ERM_UN_B, AnyInteger_ShouldGenerateIntToStringConversionAndSetStatement)
+		{
+			LuaStrings lua = ErmRunner::convertErmToLua({ "!#UN:B;" });
+			ASSERT_EQ(lua.lines.size(), 9) << lua.text;
+			EXPECT_EQ(lua.lines[ErmRunner::REGULAR_INSTRUCTION_FIRST_LINE], "ERM.UN():B(x)");
+		}
+	}
+}
+
+


### PR DESCRIPTION
- Fixed some minor warnings.
- There's an attempt to solve lua51.dll issue - it should be copied into build\{BUILD_OPTION} folder where BUILD_OPTION is Release, Debug or RelWithDebInfo. It's not working when  lua51.dll is in the 'bin' folder.

- Fixed some weird build issues. Without it I available to build solution only commenting some problem lines.
Following lines of code:

trigger %= cmdName >> -identifier >> -condition > qi::lit(";");
normalBodyOption = qi::char_("A-Z") > -(exactBodyOptionList);
instruction %= cmdName >> -identifier >> -condition >> body;
receiver %= cmdName >> -identifier >> -condition >> body;
postTrigger %= cmdName >> -identifier >> -condition > qi::lit(";");

cause following errors on build:

` ERMParser.cpp
\VCMI\vcpkg\installed\x64-windows\include\boost/spirit/home/qi/detail/attributes.hpp(87): error C2593: 'operator =' is ambiguous

\VCMI\vcpkg\installed\x64-windows\include\boost/optional/optional.hpp(994): 

'boost::optional<ERM::Tidentifier> & boost::optional<ERM::Tidentifier>::operator =(boost::none_t) noexcept'
'boost::optional<ERM::Tidentifier> & boost::optional<ERM::Tidentifier>::operator =(boost::optional<ERM::Tidentifier> &&) noexcept'
'boost::optional<ERM::Tidentifier> & boost::optional<ERM::Tidentifier>::operator =(const boost::optional<ERM::Tidentifier> &)'
'boost::optional<ERM::Tidentifier> & boost::optional<ERM::Tidentifier>::operator =<std::vector<ERM::TIexp,std::allocator<_Ty>>>(T_ &&)'
`
The only idea I've found to fix them it's get rid of some optionals (So, I suggest to make identifier, body and optionList non optional).