### PR TITLE
fix negative tile cost from pathfinding skill

### DIFF
--- a/lib/CPathfinder.cpp
+++ b/lib/CPathfinder.cpp
@@ -1227,7 +1227,7 @@ int CPathfinderHelper::getMovementCost(
 	/// TODO: by the original game rules hero shouldn't be affected by terrain penalty while flying.
 	/// Also flying movement only has penalty when player moving over blocked tiles.
 	/// So if you only have base flying with 40% penalty you can still ignore terrain penalty while having zero flying penalty.
-	int ret = hero->getTileCost(*dt, *ct, ti);
+	ui32 ret = hero->getTileCost(*dt, *ct, ti);
 	/// Unfortunately this can't be implemented yet as server don't know when player flying and when he's not.
 	/// Difference in cost calculation on client and server is much worse than incorrect cost.
 	/// So this one is waiting till server going to use pathfinder rules for path validation.

--- a/lib/mapObjects/CGHeroInstance.cpp
+++ b/lib/mapObjects/CGHeroInstance.cpp
@@ -70,7 +70,7 @@ static int lowestSpeed(const CGHeroInstance * chi)
 
 ui32 CGHeroInstance::getTileCost(const TerrainTile & dest, const TerrainTile & from, const TurnInfo * ti) const
 {
-	unsigned ret = GameConstants::BASE_MOVEMENT_COST;
+	int64_t ret = GameConstants::BASE_MOVEMENT_COST;
 
 	//if there is road both on dest and src tiles - use road movement cost
 	if(dest.roadType != ERoadType::NO_ROAD && from.roadType != ERoadType::NO_ROAD)
@@ -105,7 +105,7 @@ ui32 CGHeroInstance::getTileCost(const TerrainTile & dest, const TerrainTile & f
 		if(ret < GameConstants::BASE_MOVEMENT_COST)
 			ret = GameConstants::BASE_MOVEMENT_COST;
 	}
-	return ret;
+	return (ui32)ret;
 }
 
 ETerrainType::EETerrainType CGHeroInstance::getNativeTerrain() const


### PR DESCRIPTION
In some mods pathfinding can be boosted with artifacts to negative tile cost. unsigned overflow causes it to bypass some checks and later it is casted back to signed and become negative.