### PR TITLE
Fix: Captured town should not be duplicated on the UI

### DIFF
--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -1505,6 +1505,7 @@ void CPlayerInterface::objectPropertyChanged(const SetObjectProperty * sop)
 				towns -= obj;
 
 			adventureInt->townList.update();
+			adventureInt->minimap.update();
 		}
 		assert(cb->getTownsInfo().size() == towns.size());
 	}

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -887,12 +887,8 @@ void CGameHandler::endBattle(int3 tile, const CGHeroInstance * heroAttacker, con
 
 	if(battleResult.data->winner != BattleSide::DEFENDER && heroDefender) //remove beaten Defender
 	{
-		auto town = heroDefender->visitedTown;
 		RemoveObject ro(heroDefender->id);
 		sendAndApply(&ro);
-
-		if(town && !town->garrisonHero) // TODO: that must be called from CGHeroInstance or CGTownInstance
-			town->battleFinished(heroAttacker, *battleResult.get());
 	}
 
 	if(battleResult.data->winner == BattleSide::DEFENDER 
@@ -5340,7 +5336,22 @@ void CGameHandler::objectVisited(const CGObjectInstance * obj, const CGHeroInsta
 
 	auto startVisit = [&](ObjectVisitStarted & event)
 	{
-		visitQuery = std::make_shared<CObjectVisitQuery>(this, obj, h, obj->visitablePos());
+		auto visitedObject = obj;
+
+		if(obj->ID == Obj::HERO)
+		{
+			auto visitedHero = static_cast<const CGHeroInstance *>(obj);
+			const auto visitedTown = visitedHero->visitedTown;
+
+			if(visitedTown)
+			{
+				const bool isEnemy = visitedHero->getOwner() != h->getOwner();
+
+				if(isEnemy && !visitedTown->isBattleOutsideTown(visitedHero))
+					visitedObject = visitedTown;
+			}
+		}
+		visitQuery = std::make_shared<CObjectVisitQuery>(this, visitedObject, h, visitedObject->visitablePos());
 		queries.addQuery(visitQuery); //TODO real visit pos
 
 		HeroVisit hv;


### PR DESCRIPTION
RCA: When a hero attacks an enemy town visiting by an enemy hero, visiting object should be the town, not  the enemy hero.