### PR TITLE
Fix: Skyship Grail should work immediately after capturing without battle

### DIFF
--- a/lib/mapObjects/CGTownInstance.cpp
+++ b/lib/mapObjects/CGTownInstance.cpp
@@ -683,7 +683,8 @@ void CGTownInstance::onHeroVisit(const CGHeroInstance * h) const
 		else
 		{
 			auto heroColor = h->getOwner();
-			setOwner(heroColor);
+			onTownCaptured(heroColor);
+
 			if(cb->gameState()->getPlayerStatus(heroColor) == EPlayerStatus::WINNER)
 			{
 				return; //we just won game, we do not need to perform any extra actions
@@ -1362,7 +1363,7 @@ void CGTownInstance::setGarrisonedHero(CGHeroInstance *h)
 
 bool CGTownInstance::armedGarrison() const
 {
-	return stacksCount() || garrisonHero;
+	return !stacks.empty() || garrisonHero;
 }
 
 const CTown * CGTownInstance::getTown() const
@@ -1526,16 +1527,19 @@ void CGTownInstance::battleFinished(const CGHeroInstance * hero, const BattleRes
 {
 	if(result.winner == BattleSide::ATTACKER)
 	{
-		auto heroColor = hero->getOwner(); //get tempOwner
-
 		clearArmy();
-		setOwner(heroColor); //give control after checkout is done
-		FoWChange fw;
-		fw.player = heroColor;
-		fw.mode = 1;
-		cb->getTilesInRange(fw.tiles, getSightCenter(), getSightRadius(), tempOwner, 1);
-		cb->sendAndApply(&fw);
+		onTownCaptured(hero->getOwner());
 	}
+}
+
+void CGTownInstance::onTownCaptured(const PlayerColor winner) const
+{
+	setOwner(winner);
+	FoWChange fw;
+	fw.player = winner;
+	fw.mode = 1;
+	cb->getTilesInRange(fw.tiles, getSightCenter(), getSightRadius(), winner, 1);
+	cb->sendAndApply(& fw);
 }
 
 void CGTownInstance::afterAddToMap(CMap * map)

--- a/lib/mapObjects/CGTownInstance.h
+++ b/lib/mapObjects/CGTownInstance.h
@@ -349,7 +349,7 @@ public:
 	void onHeroVisit(const CGHeroInstance * h) const override;
 	void onHeroLeave(const CGHeroInstance * h) const override;
 	void initObj(CRandomGenerator & rand) override;
-	void battleFinished(const CGHeroInstance *hero, const BattleResult &result) const override;
+	void battleFinished(const CGHeroInstance * hero, const BattleResult & result) const override;
 	std::string getObjectName() const override;
 
 	void afterAddToMap(CMap * map) override;
@@ -365,6 +365,7 @@ protected:
 
 private:
 	void setOwner(const PlayerColor owner) const;
+	void onTownCaptured(const PlayerColor winner) const;
 	int getDwellingBonus(const std::vector<CreatureID>& creatureIds, const std::vector<ConstTransitivePtr<CGDwelling> >& dwellings) const;
 	void updateBonusingBuildings();
 	bool hasBuiltInOldWay(ETownType::ETownType type, BuildingID bid) const;

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -1982,7 +1982,8 @@ void CGameHandler::newTurn()
 		{
 			n.res[player] = n.res[player] + t->dailyIncome();
 		}
-		if (t->hasBuilt(BuildingID::GRAIL, ETownType::TOWER))
+		if(t->hasBuilt(BuildingID::GRAIL)
+			&& t->town->buildings.at(BuildingID::GRAIL)->height == CBuilding::HEIGHT_SKYSHIP)
 		{
 			// Skyship, probably easier to handle same as Veil of darkness
 			//do it every new day after veils apply


### PR DESCRIPTION
Fixed: Skyship Grail does not work immediately after capturing town without battle  because corresponding update is implemented only for  battle result handling and on the new turn.