### PR TITLE
Fix: Terrain description should be shown correctly

### DIFF
--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -2386,16 +2386,16 @@ void CPlayerInterface::acceptTurn()
 	}
 }
 
-void CPlayerInterface::tryDiggging(const CGHeroInstance *h)
+void CPlayerInterface::tryDiggging(const CGHeroInstance * h)
 {
-	std::string hlp;
-	CGI->mh->getTerrainDescr(h->getPosition(false), hlp, false);
-	auto isDiggingPossible = h->diggingStatus();
-	if (hlp.length())
-		isDiggingPossible = EDiggingStatus::TILE_OCCUPIED; //TODO integrate with canDig
-
 	int msgToShow = -1;
-	switch(isDiggingPossible)
+	const bool isBlocked = CGI->mh->hasObjectHole(h->getPosition(false)); // Don't dig in the pit.
+
+	const auto diggingStatus = isBlocked
+		? EDiggingStatus::TILE_OCCUPIED
+		: h->diggingStatus().num;
+
+	switch(diggingStatus)
 	{
 	case EDiggingStatus::CAN_DIG:
 		break;
@@ -2412,7 +2412,7 @@ void CPlayerInterface::tryDiggging(const CGHeroInstance *h)
 		assert(0);
 	}
 
-	if (msgToShow < 0)
+	if(msgToShow < 0)
 		cb->dig(h);
 	else
 		showInfoDialog(CGI->generaltexth->allTexts[msgToShow]);

--- a/client/mapHandler.h
+++ b/client/mapHandler.h
@@ -382,9 +382,10 @@ public:
 	CMapHandler();
 	~CMapHandler();
 
-	void getTerrainDescr(const int3 &pos, std::string & out, bool terName); //if tername == false => empty string when tile is clear
+	void getTerrainDescr(const int3 & pos, std::string & out, bool isRMB) const; // isRMB = whether Right Mouse Button is clicked
 	bool printObject(const CGObjectInstance * obj, bool fadein = false); //puts appropriate things to tiles, so obj will be visible on map
 	bool hideObject(const CGObjectInstance * obj, bool fadeout = false); //removes appropriate things from ttiles, so obj will be no longer visible on map (but still will exist)
+	bool hasObjectHole(const int3 & pos) const; // Checks if TerrainTile2 tile has a pit remained after digging.
 	void init();
 
 	EMapAnimRedrawStatus drawTerrainRectNew(SDL_Surface * targetSurface, const MapDrawingInfo * info, bool redrawOnlyAnim = false);

--- a/lib/mapObjects/CObjectHandler.h
+++ b/lib/mapObjects/CObjectHandler.h
@@ -159,6 +159,22 @@ public:
 	std::set<int3> getBlockedOffsets() const; //returns set of relative positions blocked by this object
 	bool isVisitable() const; //returns true if object is visitable
 
+	bool isTile2Terrain() const
+	{
+		return ID.num == Obj::CLOVER_FIELD
+			|| ID.num == Obj::CURSED_GROUND1
+			|| ID.num == Obj::CURSED_GROUND2
+			|| ID.num == Obj::EVIL_FOG
+			|| ID.num == Obj::FAVORABLE_WINDS
+			|| ID.num == Obj::FIERY_FIELDS
+			|| ID.num == Obj::HOLY_GROUNDS
+			|| ID.num == Obj::LUCID_POOLS
+			|| ID.num == Obj::MAGIC_CLOUDS
+			|| ID.num == Obj::MAGIC_PLAINS1
+			|| ID.num == Obj::MAGIC_PLAINS2
+			|| ID.num == Obj::ROCKLANDS;
+	}
+
 	boost::optional<std::string> getAmbientSound() const;
 	boost::optional<std::string> getVisitSound() const;
 	boost::optional<std::string> getRemovalSound() const;


### PR DESCRIPTION
Fixed: Specific terrains description is not shown correctly 
Fixed: Hero should be able to dig in any clean terrain
Fixed: Hero should not be able to dig in the pit

![fixed](https://user-images.githubusercontent.com/58867270/140579128-6a9a92c4-2696-422e-bfa0-b342c9c617cd.jpg)

`bool isTile2Terrain() const` has been introduced to avoid strange buggy behavior: on the clear terrain near trees and some other objects object's name overrides the terrain one, thus,  we obtain something like 'Trees (digging ok)' in such cases.
