### PR TITLE
replace boost::chrono with std::chrono

### DIFF
--- a/AI/Nullkiller/AIUtility.cpp
+++ b/AI/Nullkiller/AIUtility.cpp
@@ -378,11 +378,11 @@ bool isWeeklyRevisitable(const CGObjectInstance * obj)
 	return false;
 }
 
-uint64_t timeElapsed(boost::chrono::time_point<boost::chrono::steady_clock> start)
+uint64_t timeElapsed(std::chrono::time_point<std::chrono::steady_clock> start)
 {
-	auto end = boost::chrono::high_resolution_clock::now();
+	auto end = std::chrono::high_resolution_clock::now();
 
-	return boost::chrono::duration_cast<boost::chrono::milliseconds>(end - start).count();
+	return std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count();
 }
 
 // todo: move to obj manager

--- a/AI/Nullkiller/AIUtility.cpp
+++ b/AI/Nullkiller/AIUtility.cpp
@@ -378,7 +378,7 @@ bool isWeeklyRevisitable(const CGObjectInstance * obj)
 	return false;
 }
 
-uint64_t timeElapsed(std::chrono::time_point<std::chrono::steady_clock> start)
+uint64_t timeElapsed(std::chrono::time_point<std::chrono::high_resolution_clock> start)
 {
 	auto end = std::chrono::high_resolution_clock::now();
 

--- a/AI/Nullkiller/AIUtility.h
+++ b/AI/Nullkiller/AIUtility.h
@@ -218,7 +218,7 @@ bool compareHeroStrength(HeroPtr h1, HeroPtr h2);
 bool compareArmyStrength(const CArmedInstance * a1, const CArmedInstance * a2);
 bool compareArtifacts(const CArtifactInstance * a1, const CArtifactInstance * a2);
 
-uint64_t timeElapsed(std::chrono::time_point<std::chrono::steady_clock> start);
+uint64_t timeElapsed(std::chrono::time_point<std::chrono::high_resolution_clock> start);
 
 // todo: move to obj manager
 bool shouldVisit(const Nullkiller * ai, const CGHeroInstance * h, const CGObjectInstance * obj);

--- a/AI/Nullkiller/AIUtility.h
+++ b/AI/Nullkiller/AIUtility.h
@@ -49,6 +49,8 @@
 #include "../../lib/mapObjects/CGHeroInstance.h"
 #include "../../lib/CPathfinder.h"
 
+#include <chrono>
+
 using namespace tbb;
 
 class CCallback;
@@ -216,7 +218,7 @@ bool compareHeroStrength(HeroPtr h1, HeroPtr h2);
 bool compareArmyStrength(const CArmedInstance * a1, const CArmedInstance * a2);
 bool compareArtifacts(const CArtifactInstance * a1, const CArtifactInstance * a2);
 
-uint64_t timeElapsed(boost::chrono::time_point<boost::chrono::steady_clock> start);
+uint64_t timeElapsed(std::chrono::time_point<std::chrono::steady_clock> start);
 
 // todo: move to obj manager
 bool shouldVisit(const Nullkiller * ai, const CGHeroInstance * h, const CGObjectInstance * obj);

--- a/AI/Nullkiller/Analyzers/DangerHitMapAnalyzer.cpp
+++ b/AI/Nullkiller/Analyzers/DangerHitMapAnalyzer.cpp
@@ -19,7 +19,7 @@ void DangerHitMapAnalyzer::updateHitMap()
 	logAi->trace("Update danger hitmap");
 
 	upToDate = true;
-	auto start = boost::chrono::high_resolution_clock::now();
+	auto start = std::chrono::high_resolution_clock::now();
 
 	auto cb = ai->cb.get();
 	auto mapSize = ai->cb->getMapSize();

--- a/AI/Nullkiller/Analyzers/ObjectClusterizer.cpp
+++ b/AI/Nullkiller/Analyzers/ObjectClusterizer.cpp
@@ -178,7 +178,7 @@ bool ObjectClusterizer::shouldVisitObject(const CGObjectInstance * obj) const
 
 void ObjectClusterizer::clusterize()
 {
-	auto start = boost::chrono::high_resolution_clock::now();
+	auto start = std::chrono::high_resolution_clock::now();
 
 	nearObjects.reset();
 	farObjects.reset();

--- a/AI/Nullkiller/Engine/Nullkiller.cpp
+++ b/AI/Nullkiller/Engine/Nullkiller.cpp
@@ -73,7 +73,7 @@ Goals::TTask Nullkiller::choseBestTask(Goals::TSubgoal behavior, int decompositi
 {
 	logAi->debug("Checking behavior %s", behavior->toString());
 
-	auto start = boost::chrono::high_resolution_clock::now();
+	auto start = std::chrono::high_resolution_clock::now();
 	
 	Goals::TGoalVec elementarGoals = decomposer->decompose(behavior, decompositionMaxDepth);
 	Goals::TTaskVec tasks;
@@ -122,7 +122,7 @@ void Nullkiller::updateAiState(int pass)
 {
 	boost::this_thread::interruption_point();
 
-	auto start = boost::chrono::high_resolution_clock::now();
+	auto start = std::chrono::high_resolution_clock::now();
 
 	activeHero = nullptr;
 

--- a/AI/Nullkiller/Pathfinding/AIPathfinder.cpp
+++ b/AI/Nullkiller/Pathfinding/AIPathfinder.cpp
@@ -49,7 +49,7 @@ void AIPathfinder::updatePaths(std::map<const CGHeroInstance *, HeroRole> heroes
 		storage.reset(new AINodeStorage(ai, cb->getMapSize()));
 	}
 
-	auto start = boost::chrono::high_resolution_clock::now();
+	auto start = std::chrono::high_resolution_clock::now();
 	logAi->debug("Recalculate all paths");
 	int pass = 0;
 


### PR DESCRIPTION
1. std::chrono is available since C++11, no need to use Boost for that
2. Existing code (FuzzyLite) already uses it
3. boost::chrono isn't listed as required dependency in https://github.com/vcmi/vcmi/blob/develop/CMakeLists.txt#L215 hence may not build (faced this in iOS build)