### PR TITLE
Feature: Army management key shortcuts should work as in HD+ Mod

### DIFF
--- a/CCallback.cpp
+++ b/CCallback.cpp
@@ -109,9 +109,38 @@ int CCallback::mergeStacks(const CArmedInstance *s1, const CArmedInstance *s2, S
 	sendRequest(&pack);
 	return 0;
 }
+
 int CCallback::splitStack(const CArmedInstance *s1, const CArmedInstance *s2, SlotID p1, SlotID p2, int val)
 {
 	ArrangeStacks pack(3,p1,p2,s1->id,s2->id,val);
+	sendRequest(&pack);
+	return 0;
+}
+
+int CCallback::bulkMoveArmy(ObjectInstanceID srcArmy, ObjectInstanceID destArmy, SlotID srcSlot)
+{
+	BulkMoveArmy pack(srcArmy, destArmy, srcSlot);
+	sendRequest(&pack);
+	return 0;
+}
+
+int CCallback::bulkSplitStack(ObjectInstanceID armyId, SlotID srcSlot, int howMany)
+{
+	BulkSplitStack pack(armyId, srcSlot, howMany);
+	sendRequest(&pack);
+	return 0;
+}
+
+int CCallback::bulkSmartSplitStack(ObjectInstanceID armyId, SlotID srcSlot)
+{
+	BulkSmartSplitStack pack(armyId, srcSlot);
+	sendRequest(&pack);
+	return 0;
+}
+
+int CCallback::bulkMergeStacks(ObjectInstanceID armyId, SlotID srcSlot)
+{
+	BulkMergeStacks pack(armyId, srcSlot);
 	sendRequest(&pack);
 	return 0;
 }

--- a/CCallback.h
+++ b/CCallback.h
@@ -78,6 +78,12 @@ public:
 	virtual void save(const std::string &fname) = 0;
 	virtual void sendMessage(const std::string &mess, const CGObjectInstance * currentObject = nullptr) = 0;
 	virtual void buildBoat(const IShipyard *obj) = 0;
+
+	// To implement high-level army management bulk actions
+	virtual int bulkMoveArmy(ObjectInstanceID srcArmy, ObjectInstanceID destArmy, SlotID srcSlot) = 0;
+	virtual int bulkSplitStack(ObjectInstanceID armyId, SlotID srcSlot, int howMany = 1) = 0;
+	virtual int bulkSmartSplitStack(ObjectInstanceID armyId, SlotID srcSlot) = 0;
+	virtual int bulkMergeStacks(ObjectInstanceID armyId, SlotID srcSlot) = 0;
 };
 
 struct CPackForServer;
@@ -99,7 +105,9 @@ public:
 	friend class CClient;
 };
 
-class CCallback : public CPlayerSpecificInfoCallback, public IGameActionCallback, public CBattleCallback
+class CCallback : public CPlayerSpecificInfoCallback,
+	public IGameActionCallback,
+	public CBattleCallback
 {
 public:
 	CCallback(CGameState * GS, boost::optional<PlayerColor> Player, CClient *C);
@@ -125,6 +133,10 @@ public:
 	int mergeOrSwapStacks(const CArmedInstance *s1, const CArmedInstance *s2, SlotID p1, SlotID p2) override; //first goes to the second
 	int mergeStacks(const CArmedInstance *s1, const CArmedInstance *s2, SlotID p1, SlotID p2) override; //first goes to the second
 	int splitStack(const CArmedInstance *s1, const CArmedInstance *s2, SlotID p1, SlotID p2, int val) override;
+	int bulkMoveArmy(ObjectInstanceID srcArmy, ObjectInstanceID destArmy, SlotID srcSlot) override;
+	int bulkSplitStack(ObjectInstanceID armyId, SlotID srcSlot, int howMany = 1) override;
+	int bulkSmartSplitStack(ObjectInstanceID armyId, SlotID srcSlot) override;
+	int bulkMergeStacks(ObjectInstanceID armyId, SlotID srcSlot) override;
 	bool dismissHero(const CGHeroInstance * hero) override;
 	bool swapArtifacts(const ArtifactLocation &l1, const ArtifactLocation &l2) override;
 	bool assembleArtifacts(const CGHeroInstance * hero, ArtifactPosition artifactSlot, bool assemble, ArtifactID assembleTo) override;

--- a/README.md
+++ b/README.md
@@ -35,4 +35,4 @@ Platform support is constantly tested by continuous integration and CMake config
 VCMI Project source code is licensed under GPL version 2 or later.
 VCMI Project assets are licensed under CC-BY-SA 4.0. Assets sources and information about contributors are available under following link: [https://github.com/vcmi/vcmi-assets]
 
-Copyright (C) 2007-2020  VCMI Team (check AUTHORS file for the contributors list)
+Copyright (C) 2007-2022  VCMI Team (check AUTHORS file for the contributors list)

--- a/client/NetPacksClient.cpp
+++ b/client/NetPacksClient.cpp
@@ -238,6 +238,30 @@ void RebalanceStacks::applyCl(CClient * cl)
 	dispatchGarrisonChange(cl, srcArmy, dstArmy);
 }
 
+void BulkRebalanceStacks::applyCl(CClient * cl)
+{
+	if(!moves.empty())
+	{
+		auto destArmy = moves[0].srcArmy == moves[0].dstArmy
+			? ObjectInstanceID()
+			: moves[0].dstArmy;
+		dispatchGarrisonChange(cl, moves[0].srcArmy, destArmy);
+	}
+}
+
+void BulkSmartRebalanceStacks::applyCl(CClient * cl)
+{
+	if(!moves.empty())
+	{
+		assert(moves[0].srcArmy == moves[0].dstArmy);
+		dispatchGarrisonChange(cl, moves[0].srcArmy, ObjectInstanceID());
+	}
+	else if(!changes.empty())
+	{
+		dispatchGarrisonChange(cl, changes[0].army, ObjectInstanceID());
+	}
+}
+
 void PutArtifact::applyCl(CClient *cl)
 {
 	callInterfaceIfPresent(cl, al.owningPlayer(), &IGameEventsReceiver::artifactPut, al);

--- a/client/widgets/CGarrisonInt.cpp
+++ b/client/widgets/CGarrisonInt.cpp
@@ -74,17 +74,22 @@ void CGarrisonSlot::hover (bool on)
 			}
 			else
 			{
-				if(upg == EGarrisonType::UP)
+				const bool isHeroOnMap = owner->armedObjs[0] // Hero is not a visitor and not a garrison defender
+					&& owner->armedObjs[0]->ID == Obj::HERO
+					&& (!owner->armedObjs[1] || owner->armedObjs[1]->ID == Obj::HERO) // one hero or we are in the Heroes exchange window
+					&& !(static_cast<const CGHeroInstance*>(owner->armedObjs[0]))->inTownGarrison;
+
+				if(isHeroOnMap)
+				{
+					temp = CGI->generaltexth->allTexts[481]; //Select %s
+				}
+				else if(upg == EGarrisonType::UP)
 				{
 					temp = CGI->generaltexth->tcommands[12]; //Select %s (in garrison)
 				}
-				else if(owner->armedObjs[0] && (owner->armedObjs[0]->ID == Obj::TOWN || owner->armedObjs[0]->ID == Obj::HERO))
+				else // Hero is visiting some object (town, mine, etc)
 				{
 					temp = CGI->generaltexth->tcommands[32]; //Select %s (visiting)
-				}
-				else
-				{
-					temp = CGI->generaltexth->allTexts[481]; //Select %s
 				}
 				boost::algorithm::replace_first(temp,"%s",creature->nameSing);
 			}
@@ -140,6 +145,18 @@ bool CGarrisonSlot::ally() const
 	return PlayerRelations::ALLIES == LOCPLINT->cb->getPlayerRelations(LOCPLINT->playerID, getObj()->tempOwner);
 }
 
+std::function<void()> CGarrisonSlot::getDismiss() const
+{
+	const bool canDismiss = getObj()->tempOwner == LOCPLINT->playerID
+		&& (getObj()->stacksCount() > 1 ||
+			!getObj()->needsLastStack());
+
+	return canDismiss ? [=]()
+	{
+		LOCPLINT->cb->dismissCreature(getObj(), ID);
+	} : (std::function<void()>)nullptr;
+}
+
 /// The creature slot has been clicked twice, therefore the creature info should be shown
 /// @return Whether the view should be refreshed
 bool CGarrisonSlot::viewInfo()
@@ -148,11 +165,9 @@ bool CGarrisonSlot::viewInfo()
 	LOCPLINT->cb->getUpgradeInfo(getObj(), ID, pom);
 
 	bool canUpgrade = getObj()->tempOwner == LOCPLINT->playerID && pom.oldID>=0; //upgrade is possible
-	bool canDismiss = getObj()->tempOwner == LOCPLINT->playerID && (getObj()->stacksCount()>1  || !getObj()->needsLastStack());
 	std::function<void(CreatureID)> upgr = nullptr;
-	std::function<void()> dism = nullptr;
+	auto dism = getDismiss();
 	if(canUpgrade) upgr = [=] (CreatureID newID) { LOCPLINT->cb->upgradeCreature(getObj(), ID, newID); };
-	if(canDismiss) dism = [=](){ LOCPLINT->cb->dismissCreature(getObj(), ID); };
 
 	owner->selectSlot(nullptr);
 	owner->setSplittingMode(false);
@@ -288,13 +303,17 @@ void CGarrisonSlot::clickLeft(tribool down, bool previousState)
 	{
 		bool refr = false;
 		const CGarrisonSlot * selection = owner->getSelection();
+
 		if(!selection)
 		{
-			refr = highlightOrDropArtifact();
+			refr = highlightOrDropArtifact(); // Affects selection
 			handleSplittingShortcuts();
 		}
 		else if(selection == this)
-			refr = viewInfo();
+		{
+			if(!handleSplittingShortcuts())
+				refr = viewInfo(); // Affects selection
+		}
 		// Re-highlight if troops aren't removable or not ours.
 		else if (mustForceReselection())
 		{
@@ -403,34 +422,67 @@ CGarrisonSlot::CGarrisonSlot(CGarrisonInt * Owner, int x, int y, SlotID IID, CGa
 	update();
 }
 
-void CGarrisonSlot::splitIntoParts(CGarrisonSlot::EGarrisonType type, int amount, int maxOfSplittedSlots)
+void CGarrisonSlot::splitIntoParts(CGarrisonSlot::EGarrisonType type, int amount)
 {
+	auto empty = owner->getEmptySlot(type);
+
+	if(empty == SlotID())
+		return;
+
 	owner->pb = type;
-	for(CGarrisonSlot * slot : owner->getEmptySlots(type))
-	{
-		owner->p2 = slot->ID;
-		owner->splitStacks(1, amount);
-		maxOfSplittedSlots--;
-		if(!maxOfSplittedSlots || owner->getSelection()->myStack->count <= 1)
-			break;
-	}
+	owner->p2 = empty;
+	owner->splitStacks(1, amount);
 }
 
-void CGarrisonSlot::handleSplittingShortcuts()
+bool CGarrisonSlot::handleSplittingShortcuts()
 {
 	const Uint8 * state = SDL_GetKeyboardState(NULL);
-	if(owner->getSelection() && owner->getEmptySlots(owner->getSelection()->upg).size() && owner->getSelection()->myStack->count > 1)
+	const bool isAlt = !!state[SDL_SCANCODE_LALT];
+	const bool isLShift = !!state[SDL_SCANCODE_LSHIFT];
+	const bool isLCtrl = !!state[SDL_SCANCODE_LCTRL];
+
+	if(!isAlt && !isLShift && !isLCtrl)
+		return false; // This is only case when return false
+
+	auto selected = owner->getSelection();
+	if(!selected)
+		return true; // Some Shortcusts are pressed but there are no appropriate actions
+
+	auto units = selected->myStack->count;
+	if(units < 1)
+		return true;
+
+	if (isLShift && isLCtrl && isAlt)
 	{
-		if(state[SDL_SCANCODE_LCTRL] && state[SDL_SCANCODE_LSHIFT])
-			splitIntoParts(owner->getSelection()->upg, 1, 7);
-		else if(state[SDL_SCANCODE_LCTRL])
-			splitIntoParts(owner->getSelection()->upg, 1, 1);
-		else if(state[SDL_SCANCODE_LSHIFT])
-			splitIntoParts(owner->getSelection()->upg, owner->getSelection()->myStack->count/2 , 1);
-		else
-			return;
-		owner->selectSlot(nullptr);
+		owner->bulkMoveArmy(selected);
 	}
+	else if(isLCtrl && isAlt)
+	{
+		owner->moveStackToAnotherArmy(selected);
+	}
+	else if(isLShift && isAlt)
+	{
+		auto dismiss = getDismiss();
+		if(dismiss)
+			LOCPLINT->showYesNoDialog(CGI->generaltexth->allTexts[12], dismiss, nullptr);
+	}
+	else if(isAlt)
+	{
+		owner->bulkMergeStacks(selected);
+	}
+	else
+	{
+		if(units <= 1)
+			return true;
+
+		if(isLCtrl && isLShift)
+			owner->bulkSplitStack(selected);
+		else if(isLShift)
+			owner->bulkSmartSplitStack(selected);
+		else
+			splitIntoParts(selected->upg, 1); // LCtrl
+	}
+	return true;
 }
 
 void CGarrisonInt::addSplitBtn(std::shared_ptr<CButton> button)
@@ -492,6 +544,115 @@ void CGarrisonInt::splitStacks(int, int amountRight)
 	LOCPLINT->cb->splitStack(armedObjs[getSelection()->upg], armedObjs[pb], getSelection()->ID, p2, amountRight);
 }
 
+bool CGarrisonInt::checkSelected(const CGarrisonSlot * selected, TQuantity min) const
+{
+	return selected && selected->myStack && selected->myStack->count > min && selected->creature;
+}
+
+void CGarrisonInt::moveStackToAnotherArmy(const CGarrisonSlot * selected)
+{
+	if(!checkSelected(selected))
+		return;
+
+	const auto srcArmyType = selected->upg;
+	const auto destArmyType = srcArmyType == CGarrisonSlot::UP
+		? CGarrisonSlot::DOWN
+		: CGarrisonSlot::UP;
+
+	auto srcArmy = armedObjs[srcArmyType];
+	auto destArmy = armedObjs[destArmyType];
+
+	if(!destArmy)
+		return;
+
+	auto destSlot = destArmy->getSlotFor(selected->creature);
+
+	if(destSlot == SlotID())
+		return;
+
+	const auto srcSlot = selected->ID;
+	const bool isDestSlotEmpty = !destArmy->getStackCount(destSlot);
+
+	if(isDestSlotEmpty && !destArmy->getStackCount(srcSlot))
+		destSlot = srcSlot; // Same place is more preferable
+
+	const bool isLastStack = srcArmy->stacksCount() == 1 && srcArmy->needsLastStack();
+	auto srcAmount = selected->myStack->count - (isLastStack ? 1 : 0);
+
+	if(!srcAmount)
+		return;
+
+	if(!isDestSlotEmpty || isLastStack)
+	{
+		srcAmount += destArmy->getStackCount(destSlot); // Due to 'split' implementation in the 'CGameHandler::arrangeStacks'
+		LOCPLINT->cb->splitStack(srcArmy, destArmy, srcSlot, destSlot, srcAmount);
+	}
+	else
+	{
+		LOCPLINT->cb->swapCreatures(srcArmy, destArmy, srcSlot, destSlot);
+	}
+}
+
+void CGarrisonInt::bulkMoveArmy(const CGarrisonSlot * selected)
+{
+	if(!checkSelected(selected))
+		return;
+
+	const auto srcArmyType = selected->upg;
+	const auto destArmyType = (srcArmyType == CGarrisonSlot::UP)
+		? CGarrisonSlot::DOWN
+		: CGarrisonSlot::UP;
+
+	auto srcArmy = armedObjs[srcArmyType];
+	auto destArmy = armedObjs[destArmyType];
+
+	if(!destArmy)
+		return;
+
+	const auto srcSlot = selected->ID;
+	LOCPLINT->cb->bulkMoveArmy(srcArmy->id, destArmy->id, srcSlot);
+}
+
+void CGarrisonInt::bulkMergeStacks(const CGarrisonSlot * selected)
+{
+	if(!checkSelected(selected))
+		return;
+
+	const auto type = selected->upg;
+
+	if(!armedObjs[type]->hasCreatureSlots(selected->creature, selected->ID))
+		return;
+
+	LOCPLINT->cb->bulkMergeStacks(armedObjs[type]->id, selected->ID);
+}
+
+void CGarrisonInt::bulkSplitStack(const CGarrisonSlot * selected)
+{
+	if(!checkSelected(selected, 1)) // check if > 1
+		return;
+
+	const auto type = selected->upg;
+
+	if(!hasEmptySlot(type))
+		return;
+
+	LOCPLINT->cb->bulkSplitStack(armedObjs[type]->id, selected->ID);
+}
+
+void CGarrisonInt::bulkSmartSplitStack(const CGarrisonSlot * selected)
+{
+	if(!checkSelected(selected, 1))
+		return;
+
+	const auto type = selected->upg;
+
+	// Do not disturb the server if the creature is already balanced
+	if(!hasEmptySlot(type) && armedObjs[type]->isCreatureBalanced(selected->creature))
+		return;
+
+	LOCPLINT->cb->bulkSmartSplitStack(armedObjs[type]->id, selected->ID);
+}
+
 CGarrisonInt::CGarrisonInt(int x, int y, int inx, const Point & garsOffset,
 		const CArmedInstance * s1, const CArmedInstance * s2,
 		bool _removableUnits, bool smallImgs, bool _twoRows)
@@ -513,7 +674,7 @@ CGarrisonInt::CGarrisonInt(int x, int y, int inx, const Point & garsOffset,
 	createSlots();
 }
 
-const CGarrisonSlot * CGarrisonInt::getSelection()
+const CGarrisonSlot * CGarrisonInt::getSelection() const
 {
 	return highlighted;
 }
@@ -554,15 +715,15 @@ bool CGarrisonInt::getSplittingMode()
 	return inSplittingMode;
 }
 
-std::vector<CGarrisonSlot *> CGarrisonInt::getEmptySlots(CGarrisonSlot::EGarrisonType type)
+SlotID CGarrisonInt::getEmptySlot(CGarrisonSlot::EGarrisonType type) const
 {
-	std::vector<CGarrisonSlot *> emptySlots;
-	for(auto slot : availableSlots)
-	{
-		if(type == slot->upg && ((slot->our() || slot->ally()) && slot->creature == nullptr))
-			emptySlots.push_back(slot.get());
-	}
-	return emptySlots;
+	assert(armedObjs[type]);
+	return armedObjs[type] ? armedObjs[type]->getFreeSlot() : SlotID();
+}
+
+bool CGarrisonInt::hasEmptySlot(CGarrisonSlot::EGarrisonType type) const
+{
+	return getEmptySlot(type) != SlotID();
 }
 
 void CGarrisonInt::setArmy(const CArmedInstance * army, bool bottomGarrison)

--- a/client/widgets/CGarrisonInt.h
+++ b/client/widgets/CGarrisonInt.h
@@ -45,6 +45,8 @@ class CGarrisonSlot : public CIntObject
 	bool mustForceReselection() const;
 
 	void setHighlight(bool on);
+	std::function<void()> getDismiss() const;
+
 public:
 	virtual void hover (bool on) override; //call-in
 	const CArmedInstance * getObj() const;
@@ -55,8 +57,8 @@ public:
 	void update();
 	CGarrisonSlot(CGarrisonInt *Owner, int x, int y, SlotID IID, EGarrisonType Upg=EGarrisonType::UP, const CStackInstance * creature_ = nullptr);
 
-	void splitIntoParts(EGarrisonType type, int amount, int maxOfSplittedSlots);
-	void handleSplittingShortcuts();
+	void splitIntoParts(EGarrisonType type, int amount);
+	bool handleSplittingShortcuts(); /// Returns true when some shortcut is pressed, false otherwise
 
 	friend class CGarrisonInt;
 };
@@ -70,6 +72,8 @@ class CGarrisonInt :public CIntObject
 	std::vector<std::shared_ptr<CGarrisonSlot>> availableSlots;  ///< Slots of upper and lower garrison
 
 	void createSlots();
+	bool checkSelected(const CGarrisonSlot * selected, TQuantity min = 0) const;
+
 public:
 	int interx;  ///< Space between slots
 	Point garOffset;  ///< Offset between garrisons (not used if only one hero)
@@ -83,12 +87,13 @@ public:
 		 owned[2];        ///< player Owns up or down army ([0] upper, [1] lower)
 
 	void selectSlot(CGarrisonSlot * slot); ///< @param slot null = deselect
-	const CGarrisonSlot * getSelection();
+	const CGarrisonSlot * getSelection() const;
 
 	void setSplittingMode(bool on);
 	bool getSplittingMode();
 
-	std::vector<CGarrisonSlot *> getEmptySlots(CGarrisonSlot::EGarrisonType type);
+	bool hasEmptySlot(CGarrisonSlot::EGarrisonType type) const;
+	SlotID getEmptySlot(CGarrisonSlot::EGarrisonType type) const;
 
 	const CArmedInstance * armedObjs[2];  ///< [0] is upper, [1] is down
 
@@ -99,6 +104,11 @@ public:
 
 	void splitClick();  ///< handles click on split button
 	void splitStacks(int amountLeft, int amountRight);  ///< TODO: comment me
+	void moveStackToAnotherArmy(const CGarrisonSlot * selected);
+	void bulkMoveArmy(const CGarrisonSlot * selected);
+	void bulkMergeStacks(const CGarrisonSlot * selected); // Gather all creatures of selected type to the selected slot from other hero/garrison slots
+	void bulkSplitStack(const CGarrisonSlot * selected); // Used to separate one-creature troops from main stack
+	void bulkSmartSplitStack(const CGarrisonSlot * selected);
 
 	/// Constructor
 	/// @param x, y Position

--- a/lib/CCreatureSet.h
+++ b/lib/CCreatureSet.h
@@ -142,6 +142,20 @@ public:
 typedef std::map<SlotID, CStackInstance*> TSlots;
 typedef std::map<SlotID, std::pair<CreatureID, TQuantity>> TSimpleSlots;
 
+typedef std::pair<const CCreature*, SlotID> TPairCreatureSlot;
+typedef std::map<const CCreature*, SlotID> TMapCreatureSlot;
+
+struct DLL_LINKAGE CreatureSlotComparer
+{
+	bool operator()(const TPairCreatureSlot & lhs, const TPairCreatureSlot & rhs);
+};
+
+typedef std::priority_queue<
+	TPairCreatureSlot,
+	std::vector<TPairCreatureSlot>,
+	CreatureSlotComparer
+> TCreatureQueue;
+
 class IArmyDescriptor
 {
 public:
@@ -209,7 +223,17 @@ public:
 	SlotID findStack(const CStackInstance *stack) const; //-1 if none
 	SlotID getSlotFor(CreatureID creature, ui32 slotsAmount = GameConstants::ARMY_SIZE) const; //returns -1 if no slot available
 	SlotID getSlotFor(const CCreature *c, ui32 slotsAmount = GameConstants::ARMY_SIZE) const; //returns -1 if no slot available
-	SlotID getFreeSlot(ui32 slotsAmount = GameConstants::ARMY_SIZE) const;
+	bool hasCreatureSlots(const CCreature * c, SlotID exclude) const;
+	std::vector<SlotID> getCreatureSlots(const CCreature * c, SlotID exclude, TQuantity ignoreAmount = -1) const;
+	bool isCreatureBalanced(const CCreature* c, TQuantity ignoreAmount = 1) const; // Check if the creature is evenly distributed across slots
+
+	SlotID getFreeSlot(ui32 slotsAmount = GameConstants::ARMY_SIZE) const; //returns first free slot
+	std::vector<SlotID> getFreeSlots(ui32 slotsAmount = GameConstants::ARMY_SIZE) const;
+	std::queue<SlotID> getFreeSlotsQueue(ui32 slotsAmount = GameConstants::ARMY_SIZE) const;
+
+	TMapCreatureSlot getCreatureMap() const;
+	TCreatureQueue getCreatureQueue(SlotID exclude) const;
+
 	bool mergableStacks(std::pair<SlotID, SlotID> &out, SlotID preferable = SlotID()) const; //looks for two same stacks, returns slot positions;
 	bool validTypes(bool allowUnrandomized = false) const; //checks if all types of creatures are set properly
 	bool slotEmpty(SlotID slot) const;

--- a/lib/NetPacks.h
+++ b/lib/NetPacks.h
@@ -886,7 +886,7 @@ struct RebalanceStacks : CGarrisonOperationPack
 	TQuantity count;
 
 	void applyCl(CClient *cl);
-	DLL_LINKAGE void applyGs(CGameState *gs);
+	DLL_LINKAGE void applyGs(CGameState * gs);
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
@@ -895,6 +895,36 @@ struct RebalanceStacks : CGarrisonOperationPack
 		h & srcSlot;
 		h & dstSlot;
 		h & count;
+	}
+};
+
+struct BulkRebalanceStacks : CGarrisonOperationPack
+{
+	std::vector<RebalanceStacks> moves;
+
+	void applyCl(CClient * cl);
+	DLL_LINKAGE void applyGs(CGameState * gs);
+
+	template <typename Handler> 
+	void serialize(Handler & h, const int version)
+	{
+		h & moves;
+	}
+};
+
+struct BulkSmartRebalanceStacks : CGarrisonOperationPack
+{
+	std::vector<RebalanceStacks> moves;
+	std::vector<ChangeStackCount> changes;
+
+	void applyCl(CClient * cl);
+	DLL_LINKAGE void applyGs(CGameState * gs);
+
+	template <typename Handler> 
+	void serialize(Handler & h, const int version)
+	{
+		h & moves;
+		h & changes;
 	}
 };
 
@@ -1943,6 +1973,102 @@ struct ArrangeStacks : public CPackForServer
 		h & id1;
 		h & id2;
 		h & val;
+	}
+};
+
+struct BulkMoveArmy : public CPackForServer
+{
+	SlotID srcSlot;
+	ObjectInstanceID srcArmy;
+	ObjectInstanceID destArmy;
+
+	BulkMoveArmy()
+	{};
+
+	BulkMoveArmy(ObjectInstanceID srcArmy, ObjectInstanceID destArmy, SlotID srcSlot)
+		: srcArmy(srcArmy), destArmy(destArmy), srcSlot(srcSlot)
+	{};
+
+	bool applyGh(CGameHandler * gh);
+
+	template <typename Handler>
+	void serialize(Handler & h, const int version)
+	{
+		h & static_cast<CPackForServer&>(*this);
+		h & srcSlot;
+		h & srcArmy;
+		h & destArmy;
+	}
+};
+
+struct BulkSplitStack : public CPackForServer
+{
+	SlotID src;
+	ObjectInstanceID srcOwner;
+	si32 amount;
+
+	BulkSplitStack() : amount(0)
+	{};
+
+	BulkSplitStack(ObjectInstanceID srcOwner, SlotID src, si32 howMany)
+		: src(src), srcOwner(srcOwner), amount(howMany) 
+	{};
+
+	bool applyGh(CGameHandler * gh);
+
+	template <typename Handler> 
+	void serialize(Handler & h, const int version)
+	{
+		h & static_cast<CPackForServer&>(*this);
+		h & src;
+		h & srcOwner;
+		h & amount;
+	}
+};
+
+struct BulkMergeStacks : public CPackForServer
+{
+	SlotID src;
+	ObjectInstanceID srcOwner;
+
+	BulkMergeStacks()
+	{};
+
+	BulkMergeStacks(ObjectInstanceID srcOwner, SlotID src)
+		: src(src), srcOwner(srcOwner)
+	{};
+
+	bool applyGh(CGameHandler * gh);
+
+	template <typename Handler>
+	void serialize(Handler & h, const int version)
+	{
+		h & static_cast<CPackForServer&>(*this);
+		h & src;
+		h & srcOwner;
+	}
+};
+
+struct BulkSmartSplitStack : public CPackForServer
+{
+	SlotID src;
+	ObjectInstanceID srcOwner;
+
+	BulkSmartSplitStack()
+	{};
+
+	BulkSmartSplitStack(ObjectInstanceID srcOwner, SlotID src)
+		: src(src), srcOwner(srcOwner)
+	{};
+
+	bool applyGh(CGameHandler * gh);
+
+	template <typename Handler>
+	void serialize(Handler & h, const int version)
+	{
+		h & static_cast<CPackForServer&>(*this);
+		h & src;
+		h & srcOwner;
 	}
 };
 

--- a/lib/NetPacksLib.cpp
+++ b/lib/NetPacksLib.cpp
@@ -1020,6 +1020,21 @@ DLL_LINKAGE void RebalanceStacks::applyGs(CGameState * gs)
 	CBonusSystemNode::treeHasChanged();
 }
 
+DLL_LINKAGE void BulkRebalanceStacks::applyGs(CGameState * gs)
+{
+	for(auto & move : moves)
+		move.applyGs(gs);
+}
+
+DLL_LINKAGE void BulkSmartRebalanceStacks::applyGs(CGameState * gs)
+{
+	for(auto & move : moves)
+		move.applyGs(gs);
+
+	for(auto & change : changes)
+		change.applyGs(gs);
+}
+
 DLL_LINKAGE void PutArtifact::applyGs(CGameState *gs)
 {
 	assert(art->canBePutAt(al));

--- a/lib/registerTypes/RegisterTypes.h
+++ b/lib/registerTypes/RegisterTypes.h
@@ -317,6 +317,8 @@ void registerTypesClientPacks2(Serializer &s)
 
 	s.template registerType<CPackForClient, SaveGameClient>();
 	s.template registerType<CPackForClient, PlayerMessageClient>();
+	s.template registerType<CGarrisonOperationPack, BulkRebalanceStacks>();
+	s.template registerType<CGarrisonOperationPack, BulkSmartRebalanceStacks>();
 }
 
 template<typename Serializer>
@@ -347,6 +349,10 @@ void registerTypesServerPacks(Serializer &s)
 	s.template registerType<CPackForServer, CastleTeleportHero>();
 	s.template registerType<CPackForServer, SaveGame>();
 	s.template registerType<CPackForServer, PlayerMessage>();
+	s.template registerType<CPackForServer, BulkSplitStack>();
+	s.template registerType<CPackForServer, BulkMergeStacks>();
+	s.template registerType<CPackForServer, BulkSmartSplitStack>();
+	s.template registerType<CPackForServer, BulkMoveArmy>();
 }
 
 template<typename Serializer>

--- a/server/CGameHandler.h
+++ b/server/CGameHandler.h
@@ -249,6 +249,10 @@ public:
 	bool razeStructure(ObjectInstanceID tid, BuildingID bid);
 	bool disbandCreature( ObjectInstanceID id, SlotID pos );
 	bool arrangeStacks( ObjectInstanceID id1, ObjectInstanceID id2, ui8 what, SlotID p1, SlotID p2, si32 val, PlayerColor player);
+	bool bulkMoveArmy(ObjectInstanceID srcArmy, ObjectInstanceID destArmy, SlotID srcSlot);
+	bool bulkSplitStack(SlotID src, ObjectInstanceID srcOwner, si32 howMany);
+	bool bulkMergeStacks(SlotID slotSrc, ObjectInstanceID srcOwner);
+	bool bulkSmartSplitStack(SlotID slotSrc, ObjectInstanceID srcOwner);
 	void save(const std::string &fname);
 	void load(const std::string &fname);
 
@@ -353,7 +357,9 @@ private:
 	void checkVictoryLossConditions(const std::set<PlayerColor> & playerColors);
 	void checkVictoryLossConditionsForAll();
 
-
+	const std::string complainNoCreatures;
+	const std::string complainNotEnoughCreatures;
+	const std::string complainInvalidSlot;
 };
 
 class ExceptionNotAllowedAction : public std::exception

--- a/server/CQuery.cpp
+++ b/server/CQuery.cpp
@@ -69,7 +69,25 @@ void CQuery::addPlayer(PlayerColor color)
 
 std::string CQuery::toString() const
 {
-	std::string ret = boost::str(boost::format("A query of type %s and qid=%d affecting players %s") % typeid(*this).name() % queryID % formatContainer(players));
+	const auto size = players.size();
+	const std::string plural = size > 1 ? "s" : "";
+	std::string names;
+
+	for(size_t i = 0; i < size; i++)
+	{
+		names += boost::to_upper_copy<std::string>(players[i].getStr());
+
+		if(i < size - 2)
+			names += ", ";
+		else if(size > 1 && i == size - 2)
+			names += " and ";
+	}
+	std::string ret = boost::str(boost::format("A query of type '%s' and qid = %d affecting player%s %s")
+		% typeid(*this).name()
+		% queryID 
+		% plural
+		% names
+	);
 	return ret;
 }
 
@@ -326,6 +344,18 @@ bool CGarrisonDialogQuery::blocksPack(const CPack * pack) const
 
 	if(auto stacks = dynamic_ptr_cast<ArrangeStacks>(pack))
 		return !vstd::contains(ourIds, stacks->id1) || !vstd::contains(ourIds, stacks->id2);
+
+	if(auto stacks = dynamic_ptr_cast<BulkSplitStack>(pack))
+		return !vstd::contains(ourIds, stacks->srcOwner);
+
+	if(auto stacks = dynamic_ptr_cast<BulkMergeStacks>(pack))
+		return !vstd::contains(ourIds, stacks->srcOwner);
+
+	if(auto stacks = dynamic_ptr_cast<BulkSmartSplitStack>(pack))
+		return !vstd::contains(ourIds, stacks->srcOwner);
+
+	if(auto stacks = dynamic_ptr_cast<BulkMoveArmy>(pack))
+		return !vstd::contains(ourIds, stacks->srcArmy) || !vstd::contains(ourIds, stacks->destArmy);
 
 	if(auto arts = dynamic_ptr_cast<ExchangeArtifacts>(pack))
 	{

--- a/server/NetPacksServer.cpp
+++ b/server/NetPacksServer.cpp
@@ -123,6 +123,26 @@ bool ArrangeStacks::applyGh(CGameHandler * gh)
 	return gh->arrangeStacks(id1, id2, what, p1, p2, val, gh->getPlayerAt(c));
 }
 
+bool BulkMoveArmy::applyGh(CGameHandler * gh)
+{
+	return gh->bulkMoveArmy(srcArmy, destArmy, srcSlot);
+}
+
+bool BulkSplitStack::applyGh(CGameHandler * gh)
+{
+	return gh->bulkSplitStack(src, srcOwner, amount);
+}
+
+bool BulkMergeStacks::applyGh(CGameHandler* gh)
+{
+	return gh->bulkMergeStacks(src, srcOwner);
+}
+
+bool BulkSmartSplitStack::applyGh(CGameHandler * gh)
+{
+	return gh->bulkSmartSplitStack(src, srcOwner);
+}
+
 bool DisbandCreature::applyGh(CGameHandler * gh)
 {
 	throwOnWrongOwner(gh, id);


### PR DESCRIPTION
New features are implemented:

[SHIFT] + Click - “smart” stepwise proportional division. Ignores units with a single creature,  if necessary, evens out the number and divides the stacks proportionally. With this operation, you can quickly align by the number of stacks of the same type, divide the stack in half in 1 click, divide by 3 in 2 clicks. 

[ALT] + Click - collects troops of the same type from hero / garrison slots into a slot

[ALT] + [SHIFT] + Click - disbands the squad (the last squad of the hero cannot be fired).

[CTRL] + [ALT] + Click - in the hero meeting window and in the city window, transfers the stack to another hero. You cannot leave a hero without an army, so at least 1 creature remains. This combination also works in the garrison.

[CTRL] + [ALT] + [SHIFT] + Click - transfers the entire army. If an army is transferred from the hero, then at least one creature remains from the clicked squad.

Reworked:

[CTRL] + [SHIFT] + Click - separates one creature from the squad to all empty hero / garrison slots.
(Now works as a bulk operation)

Minor refactoring is implemented for the following feature:

[CTRL] + Click - separates one creature from the squad into a free slot.

___________________________________________________________________________________________________________________________

I've taken measures to minimize the network packets quantity. The set of bulk operations is implemented due to this purpose.  In addition, the key shortcuts are more responsive now. C++, Algebra and a little inspiration came in handy for deriving a smart balancing formula, implementing armies merging algorithm and other things..

Minor status bar text issue has been fixed for heroes exchange window:
![garrison](https://user-images.githubusercontent.com/58867270/143659501-8829fd7c-4f3c-4e40-b59c-81a9f7d03376.jpg)

The copyright has been updated to 2022.