### PR TITLE
fix crash due assertion failure

### DIFF
--- a/lib/battle/CBattleInfoCallback.cpp
+++ b/lib/battle/CBattleInfoCallback.cpp
@@ -1504,7 +1504,7 @@ std::vector<const battle::Unit*> CBattleInfoCallback::getAttackedBattleUnits(con
 			if (vstd::contains(at.hostileCreaturePositions, hex))
 				return true;
 			if (vstd::contains(at.friendlyCreaturePositions, hex))
-				return true;
+				return false;
 		}
 		return false;
 	});


### PR DESCRIPTION
In some cases (seems to happen more often with black dragons), vcmiclient crashes with:

```
/AI/BattleAI/AttackPossibility.cpp:121: static AttackPossibility AttackPossibility::evaluate(const BattleAttackInfo&, BattleHex, const HypotheticBattle*): Assertion `u->unitId() != attacker->unitId()' failed.
```

I think the cause is pretty obvious from the change