### PR TITLE
Fix: Get rid of 'Terrain tile is not visible' error message

### DIFF
--- a/AI/Nullkiller/AIGateway.cpp
+++ b/AI/Nullkiller/AIGateway.cpp
@@ -79,7 +79,7 @@ void AIGateway::availableCreaturesChanged(const CGDwelling * town)
 	NET_EVENT_HANDLER;
 }
 
-void AIGateway::heroMoved(const TryMoveHero & details)
+void AIGateway::heroMoved(const TryMoveHero & details, bool verbose)
 {
 	LOG_TRACE(logAi);
 	NET_EVENT_HANDLER;
@@ -89,8 +89,8 @@ void AIGateway::heroMoved(const TryMoveHero & details)
 
 	const int3 from = CGHeroInstance::convertPosition(details.start, false);
 	const int3 to = CGHeroInstance::convertPosition(details.end, false);
-	const CGObjectInstance * o1 = vstd::frontOrNull(cb->getVisitableObjs(from));
-	const CGObjectInstance * o2 = vstd::frontOrNull(cb->getVisitableObjs(to));
+	const CGObjectInstance * o1 = vstd::frontOrNull(cb->getVisitableObjs(from, verbose));
+	const CGObjectInstance * o2 = vstd::frontOrNull(cb->getVisitableObjs(to, verbose));
 
 	if(details.result == TryMoveHero::TELEPORTATION)
 	{

--- a/AI/Nullkiller/AIGateway.h
+++ b/AI/Nullkiller/AIGateway.h
@@ -123,7 +123,7 @@ public:
 	void finish() override;
 
 	void availableCreaturesChanged(const CGDwelling * town) override;
-	void heroMoved(const TryMoveHero & details) override;
+	void heroMoved(const TryMoveHero & details, bool verbose = true) override;
 	void heroInGarrisonChange(const CGTownInstance * town) override;
 	void centerView(int3 pos, int focusTime) override;
 	void tileHidden(const std::unordered_set<int3, ShashInt3> & pos) override;

--- a/AI/VCAI/VCAI.cpp
+++ b/AI/VCAI/VCAI.cpp
@@ -89,7 +89,7 @@ void VCAI::availableCreaturesChanged(const CGDwelling * town)
 	NET_EVENT_HANDLER;
 }
 
-void VCAI::heroMoved(const TryMoveHero & details)
+void VCAI::heroMoved(const TryMoveHero & details, bool verbose)
 {
 	LOG_TRACE(logAi);
 	NET_EVENT_HANDLER;
@@ -99,8 +99,8 @@ void VCAI::heroMoved(const TryMoveHero & details)
 
 	const int3 from = CGHeroInstance::convertPosition(details.start, false);
 	const int3 to = CGHeroInstance::convertPosition(details.end, false);
-	const CGObjectInstance * o1 = vstd::frontOrNull(cb->getVisitableObjs(from));
-	const CGObjectInstance * o2 = vstd::frontOrNull(cb->getVisitableObjs(to));
+	const CGObjectInstance * o1 = vstd::frontOrNull(cb->getVisitableObjs(from, verbose));
+	const CGObjectInstance * o2 = vstd::frontOrNull(cb->getVisitableObjs(to, verbose));
 
 	if(details.result == TryMoveHero::TELEPORTATION)
 	{

--- a/AI/VCAI/VCAI.h
+++ b/AI/VCAI/VCAI.h
@@ -153,7 +153,7 @@ public:
 	void finish() override;
 
 	void availableCreaturesChanged(const CGDwelling * town) override;
-	void heroMoved(const TryMoveHero & details) override;
+	void heroMoved(const TryMoveHero & details, bool verbose = true) override;
 	void heroInGarrisonChange(const CGTownInstance * town) override;
 	void centerView(int3 pos, int focusTime) override;
 	void tileHidden(const std::unordered_set<int3, ShashInt3> & pos) override;

--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -234,7 +234,7 @@ STRONG_INLINE void delObjRect(const int & x, const int & y, const int & z, const
 			return;
 		}
 }
-void CPlayerInterface::heroMoved(const TryMoveHero & details)
+void CPlayerInterface::heroMoved(const TryMoveHero & details, bool verbose)
 {
 	EVENT_HANDLER_CALLED_BY_CLIENT;
 	waitWhileDialog();

--- a/client/CPlayerInterface.h
+++ b/client/CPlayerInterface.h
@@ -135,7 +135,7 @@ public:
 	void heroGotLevel(const CGHeroInstance *hero, PrimarySkill::PrimarySkill pskill, std::vector<SecondarySkill> &skills, QueryID queryID) override;
 	void commanderGotLevel (const CCommanderInstance * commander, std::vector<ui32> skills, QueryID queryID) override;
 	void heroInGarrisonChange(const CGTownInstance *town) override;
-	void heroMoved(const TryMoveHero & details) override;
+	void heroMoved(const TryMoveHero & details, bool verbose = true) override;
 	void heroPrimarySkillChanged(const CGHeroInstance * hero, int which, si64 val) override;
 	void heroSecondarySkillChanged(const CGHeroInstance * hero, int which, int val) override;
 	void heroManaPointsChanged(const CGHeroInstance * hero) override;

--- a/client/NetPacksClient.cpp
+++ b/client/NetPacksClient.cpp
@@ -433,12 +433,19 @@ void TryMoveHero::applyCl(CClient *cl)
 			i.second->tileRevealed(fowRevealed);
 
 	//notify interfaces about move
+	auto gs = cl->gameState();
+
 	for(auto i=cl->playerint.begin(); i!=cl->playerint.end(); i++)
 	{
+		if(i->first != PlayerColor::SPECTATOR && gs->checkForStandardLoss(i->first)) // Do not notify vanquished player's interface
+			continue;
+
 		if(GS(cl)->isVisible(start - int3(1, 0, 0), i->first)
 			|| GS(cl)->isVisible(end - int3(1, 0, 0), i->first))
 		{
-			i->second->heroMoved(*this);
+			// src and dst of enemy hero move may be not visible => 'verbose' should be false
+			const bool verbose = cl->getPlayerRelations(i->first, player) != PlayerRelations::ENEMIES;
+			i->second->heroMoved(*this, verbose);
 		}
 	}
 

--- a/lib/CGameInfoCallback.cpp
+++ b/lib/CGameInfoCallback.cpp
@@ -493,10 +493,12 @@ std::vector<const CGHeroInstance *> CGameInfoCallback::getAvailableHeroes(const 
 
 const TerrainTile * CGameInfoCallback::getTile( int3 tile, bool verbose) const
 {
-	ERROR_VERBOSE_OR_NOT_RET_VAL_IF(!isVisible(tile), verbose, tile.toString() + " is not visible!", nullptr);
+	if(isVisible(tile))
+		return &gs->map->getTile(tile);
 
-	//boost::shared_lock<boost::shared_mutex> lock(*gs->mx);
-	return &gs->map->getTile(tile);
+	if(verbose)
+		logGlobal->error("\r\n%s: %s\r\n", BOOST_CURRENT_FUNCTION, tile.toString() + " is not visible!");
+	return nullptr;
 }
 
 //TODO: typedef?

--- a/lib/CGameState.cpp
+++ b/lib/CGameState.cpp
@@ -2457,8 +2457,8 @@ PlayerColor CGameState::checkForStandardWin() const
 bool CGameState::checkForStandardLoss( PlayerColor player ) const
 {
 	//std loss condition is: player lost all towns and heroes
-	const PlayerState &p = *CGameInfoCallback::getPlayerState(player);
-	return !p.heroes.size() && !p.towns.size();
+	const PlayerState & pState = *CGameInfoCallback::getPlayerState(player);
+	return pState.checkVanquished();
 }
 
 struct statsHLP

--- a/lib/CPlayerState.h
+++ b/lib/CPlayerState.h
@@ -49,6 +49,11 @@ public:
 	const IBonusBearer * accessBonuses() const override;
 	int getResourceAmount(int type) const override;
 
+	bool checkVanquished() const
+	{
+		return heroes.empty() && towns.empty();
+	}
+
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
 		h & color;

--- a/lib/IGameEventsReceiver.h
+++ b/lib/IGameEventsReceiver.h
@@ -93,7 +93,7 @@ public:
 	virtual void heroVisit(const CGHeroInstance *visitor, const CGObjectInstance *visitedObj, bool start){};
 	virtual void heroCreated(const CGHeroInstance*){};
 	virtual void heroInGarrisonChange(const CGTownInstance *town){};
-	virtual void heroMoved(const TryMoveHero & details){};
+	virtual void heroMoved(const TryMoveHero & details, bool verbose = true){};
 	virtual void heroPrimarySkillChanged(const CGHeroInstance * hero, int which, si64 val){};
 	virtual void heroSecondarySkillChanged(const CGHeroInstance * hero, int which, int val){};
 	virtual void heroManaPointsChanged(const CGHeroInstance * hero){} //not called at the beginning of turn and after spell casts


### PR DESCRIPTION
Get rid of annoying error message 'Terrain tile is not visible'.

Solution:
1) Do not notify vanquished players interfaces
2) Turn off 'verbose' parameter for enemy heroes because enemy src and/or dst may be not visible for the current player.

