### PR TITLE
Fix: Crash on startup when mod dependency is not found

### DIFF
--- a/lib/CModHandler.h
+++ b/lib/CModHandler.h
@@ -266,7 +266,7 @@ public:
 	void loadMods(bool onlyEssential = false);
 	void loadModFilesystems();
 
-	CModInfo & getModData(TModID modId);
+	std::set<TModID> getModDependencies(TModID modId, bool & isModFound);
 
 	/// returns list of all (active) mods
 	std::vector<std::string> getAllMods();

--- a/lib/JsonDetail.cpp
+++ b/lib/JsonDetail.cpp
@@ -997,10 +997,15 @@ namespace
 		bool testFilePresence(std::string scope, ResourceID resource)
 		{
 			std::set<std::string> allowedScopes;
-			if (scope != "core" && scope != "") // all real mods may have dependencies
+			if(scope != "core" && !scope.empty()) // all real mods may have dependencies
 			{
 				//NOTE: recursive dependencies are not allowed at the moment - update code if this changes
-				allowedScopes = VLC->modh->getModData(scope).dependencies;
+				bool found = true;
+				allowedScopes = VLC->modh->getModDependencies(scope, found);
+
+				if(!found)
+					return false;
+
 				allowedScopes.insert("core"); // all mods can use H3 files
 			}
 			allowedScopes.insert(scope); // mods can use their own files


### PR DESCRIPTION
Issue description: Some mods such as 'Tartarus' have implicit dependencies in the 'targetCondition' and other sections. If the dependency is not found, the crash is occurred. 

Fixed: Invalid dependencies should be ignored.