### PR TITLE
Fix 3184

### DIFF
--- a/lib/mapObjects/CGHeroInstance.cpp
+++ b/lib/mapObjects/CGHeroInstance.cpp
@@ -1431,6 +1431,15 @@ void CGHeroInstance::serializeCommonOptions(JsonSerializeFormat & handler)
 {
 	handler.serializeString("biography", biography);
 	handler.serializeInt("experience", exp, 0);
+
+	if (!handler.saving)
+	{
+		while (gainsLevel())
+		{
+			++level;
+		}
+	}
+
 	handler.serializeString("name", name);
 	handler.serializeBool<ui8>("female", sex, 1, 0, 0xFF);
 


### PR DESCRIPTION
Taken from #684. This fixes a bug with primary skills that results in
heroes not being able to interact with objects, or skills being
incorrect when moving from mission to mission.