### PR TITLE
Fix RMG to place special dwellings like elemental conflux

### DIFF
--- a/CI/mac/before_install.sh
+++ b/CI/mac/before_install.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 brew update
-brew pin python@3.9
+#brew pin python@3.9
 brew install smpeg2 libpng freetype qt5 ffmpeg@4 ninja boost tbb luajit
 brew install sdl2 sdl2_ttf sdl2_image sdl2_mixer
 


### PR DESCRIPTION
RMG was enable to place special dwellings like Golem Factory and Elemental Conflux.
It was because they are mapped to CREATURE_GENERATOR4