### PR TITLE
Towers should block ranged retalitation

### DIFF
--- a/config/creatures/special.json
+++ b/config/creatures/special.json
@@ -118,6 +118,7 @@
 			"ignoreDefence" : { "type" : "ENEMY_DEFENCE_REDUCTION", "val" : 100 },
 			"noWallPenalty" : { "type" : "NO_WALL_PENALTY" },
 			"noDistancePenalty" : { "type" : "NO_DISTANCE_PENALTY" },
+			"noRetalitation" : { "type" : "BLOCKS_RANGED_RETALIATION" },
 			"noLuck" : { "type" : "NO_LUCK" }
 		},
 		"graphics" :


### PR DESCRIPTION
Towers attack a stack with RANGED_RETALITATION. The stack answers and kill tower. To avoid this BLOCKS_RANGED_RETALITATION is added