### PR TITLE
Fix a few crashes

### DIFF
--- a/AI/Nullkiller/Pathfinding/AINodeStorage.cpp
+++ b/AI/Nullkiller/Pathfinding/AINodeStorage.cpp
@@ -1148,7 +1148,7 @@ bool AINodeStorage::hasBetterChain(
 	{
 		auto sameNode = node.actor == candidateNode->actor;
 
-		if(sameNode	|| node.action == CGPathNode::ENodeAction::UNKNOWN || !node.actor->hero)
+		if(sameNode	|| node.action == CGPathNode::ENodeAction::UNKNOWN || !node.actor || !node.actor->hero)
 		{
 			continue;
 		}

--- a/client/battle/CBattleInterface.cpp
+++ b/client/battle/CBattleInterface.cpp
@@ -2799,6 +2799,11 @@ void CBattleInterface::requestAutofightingAIToTakeAction()
 	{
 		auto ba = make_unique<BattleAction>(curInt->autofightingAI->activeStack(activeStack));
 
+		if(curInt->cb->battleIsFinished())
+		{
+			return; // battle finished with spellcast
+		}
+
 		if (curInt->isAutoFightOn)
 		{
 			if (tacticsMode)

--- a/lib/HeroBonus.h
+++ b/lib/HeroBonus.h
@@ -84,7 +84,10 @@ protected:
 	CSelector selector;
 	const IBonusBearer * target;
 	mutable int64_t bonusListCachedLast;
-	mutable TConstBonusListPtr bonusList;
+	mutable TConstBonusListPtr bonusList[2];
+	mutable int currentBonusListIndex;
+	mutable boost::mutex swapGuard;
+	void swapBonusList(TConstBonusListPtr other) const;
 };
 
 class DLL_LINKAGE CTotalsProxy : public CBonusProxy


### PR DESCRIPTION
- Workaround crash when reading and modifiing the same instance of std::shared_ptr simultaneously. Want to avoid heavy locking.
- Fix when the battle ends with a spellcast during autofight
