### PR TITLE
Fix victory condition draw

### DIFF
--- a/client/battle/CBattleInterfaceClasses.cpp
+++ b/client/battle/CBattleInterfaceClasses.cpp
@@ -406,15 +406,22 @@ CBattleResultWindow::CBattleResultWindow(const BattleResult & br, CPlayerInterfa
 	exit = std::make_shared<CButton>(Point(384, 505), "iok6432.def", std::make_pair("", ""), [&](){ bExitf();}, SDLK_RETURN);
 	exit->setBorderColor(Colors::METALLIC_GOLD);
 
-	if(br.winner==0) //attacker won
+	if(br.winner == 0) //attacker won
 	{
 		labels.push_back(std::make_shared<CLabel>(59, 124, FONT_SMALL, CENTER, Colors::WHITE, CGI->generaltexth->allTexts[410]));
-		labels.push_back(std::make_shared<CLabel>(408, 124, FONT_SMALL, CENTER, Colors::WHITE, CGI->generaltexth->allTexts[411]));
 	}
-	else //if(br.winner==1)
+	else
 	{
 		labels.push_back(std::make_shared<CLabel>(59, 124, FONT_SMALL, CENTER, Colors::WHITE, CGI->generaltexth->allTexts[411]));
+	}
+
+	if(br.winner == 1)
+	{
 		labels.push_back(std::make_shared<CLabel>(412, 124, FONT_SMALL, CENTER, Colors::WHITE, CGI->generaltexth->allTexts[410]));
+	}
+	else
+	{
+		labels.push_back(std::make_shared<CLabel>(408, 124, FONT_SMALL, CENTER, Colors::WHITE, CGI->generaltexth->allTexts[411]));
 	}
 
 	labels.push_back(std::make_shared<CLabel>(232, 302, FONT_BIG, CENTER, Colors::YELLOW,  CGI->generaltexth->allTexts[407]));

--- a/client/widgets/CGarrisonInt.cpp
+++ b/client/widgets/CGarrisonInt.cpp
@@ -328,7 +328,7 @@ void CGarrisonSlot::clickLeft(tribool down, bool previousState)
 			bool lastHeroStackSelected = false;
 			if(selectedObj->stacksCount() == 1
 				&& owner->getSelection()->upg != upg
-				&& dynamic_cast<const CGHeroInstance*>(selectedObj))
+				&& selectedObj->needsLastStack())
 			{
 				lastHeroStackSelected = true;
 			}

--- a/lib/battle/CBattleInfoCallback.cpp
+++ b/lib/battle/CBattleInfoCallback.cpp
@@ -1968,7 +1968,7 @@ boost::optional<int> CBattleInfoCallback::battleIsFinished() const
 {
 	auto units = battleGetUnitsIf([=](const battle::Unit * unit)
 	{
-		return unit->alive() && !unit->isTurret() && unit->alive();
+		return unit->alive() && !unit->isTurret() && !unit->hasBonusOfType(Bonus::SIEGE_WEAPON);
 	});
 
 	std::array<bool, 2> hasUnit = {false, false}; //index is BattleSide
@@ -1976,20 +1976,26 @@ boost::optional<int> CBattleInfoCallback::battleIsFinished() const
 	for(auto & unit : units)
 	{
 		//todo: move SIEGE_WEAPON check to Unit state
-		if(!unit->hasBonusOfType(Bonus::SIEGE_WEAPON))
+		hasUnit.at(unit->unitSide()) = true;
+
+		if(hasUnit[0] && hasUnit[1])
+			return boost::none;
+	}
+	
+	hasUnit = {false, false};
+
+	for(auto & unit : units)
+	{
+		if(!unit->isClone() && !unit->acquireState()->summoned && !dynamic_cast <const CCommanderInstance *>(unit))
 		{
 			hasUnit.at(unit->unitSide()) = true;
 		}
-
-		if(hasUnit[0] && hasUnit[1])
-			break;
 	}
 
 	if(!hasUnit[0] && !hasUnit[1])
 		return 2;
 	if(!hasUnit[1])
 		return 0;
-	if(!hasUnit[0])
+	else
 		return 1;
-	return boost::none;
 }

--- a/lib/mapObjects/CGHeroInstance.cpp
+++ b/lib/mapObjects/CGHeroInstance.cpp
@@ -51,16 +51,22 @@ static void showInfoDialog(const CGHeroInstance* h, const ui32 txtID, const ui16
 
 static int lowestSpeed(const CGHeroInstance * chi)
 {
+	static const CSelector selectorSTACKS_SPEED = Selector::type()(Bonus::STACKS_SPEED);
+	static const std::string keySTACKS_SPEED = "type_" + std::to_string((si32)Bonus::STACKS_SPEED);
+
 	if(!chi->stacksCount())
 	{
+		if(chi->commander && chi->commander->alive)
+		{
+			return chi->commander->valOfBonuses(selectorSTACKS_SPEED, keySTACKS_SPEED);
+		}
+
 		logGlobal->error("Hero %d (%s) has no army!", chi->id.getNum(), chi->name);
 		return 20;
 	}
+
 	auto i = chi->Slots().begin();
 	//TODO? should speed modifiers (eg from artifacts) affect hero movement?
-
-	static const CSelector selectorSTACKS_SPEED = Selector::type()(Bonus::STACKS_SPEED);
-	static const std::string keySTACKS_SPEED = "type_"+std::to_string((si32)Bonus::STACKS_SPEED);
 
 	int ret = (i++)->second->valOfBonuses(selectorSTACKS_SPEED, keySTACKS_SPEED);
 	for(; i != chi->Slots().end(); i++)

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -974,7 +974,8 @@ void CGameHandler::battleAfterLevelUp(const BattleResult &result)
 
 		sendAndApply(&sah);
 	}
-	if (result.winner != 2 && finishingBattle->winnerHero && finishingBattle->winnerHero->stacks.empty())
+	if (result.winner != 2 && finishingBattle->winnerHero && finishingBattle->winnerHero->stacks.empty()
+		&& (!finishingBattle->winnerHero->commander || !finishingBattle->winnerHero->commander->alive))
 	{
 		RemoveObject ro(finishingBattle->winnerHero->id);
 		sendAndApply(&ro);


### PR DESCRIPTION
- fix crash when ending battle only with summoned creatures (Battle result is changed to draw: both defeated)
- fix wog crash when ending battle with only commander alive (Winner hero stays alive without army. Expected behavior TBD)