### PR TITLE
Fix crash when clicking scenario info during campaign gameplay.

### DIFF
--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -49,6 +49,7 @@ set(client_SRCS
 		lobby/CLobbyScreen.cpp
 		lobby/CSavingScreen.cpp
 		lobby/CScenarioInfoScreen.cpp
+		lobby/CCampaignInfoScreen.cpp
 		lobby/OptionsTab.cpp
 		lobby/RandomMapTab.cpp
 		lobby/SelectionTab.cpp
@@ -121,6 +122,7 @@ set(client_HEADERS
 		lobby/CLobbyScreen.h
 		lobby/CSavingScreen.h
 		lobby/CScenarioInfoScreen.h
+		lobby/CCampaignInfoScreen.h
 		lobby/OptionsTab.h
 		lobby/RandomMapTab.h
 		lobby/SelectionTab.h

--- a/client/lobby/CBonusSelection.cpp
+++ b/client/lobby/CBonusSelection.cpp
@@ -360,6 +360,8 @@ void CBonusSelection::updateAfterStateChange()
 		buttonStart->disable();
 		buttonRestart->enable();
 		buttonBack->block(false);
+		buttonDifficultyLeft->disable();
+		buttonDifficultyRight->disable();
 	}
 	if(CSH->campaignBonus == -1)
 	{
@@ -449,7 +451,7 @@ void CBonusSelection::restartMap()
 	close();
 	LOCPLINT->showYesNoDialog(CGI->generaltexth->allTexts[67], [=]()
 	{
-		CSH->startCampaignScenario();
+		LOCPLINT->sendCustomEvent(EUserEvent::RESTART_GAME);
 	}, 0);
 }
 

--- a/client/lobby/CBonusSelection.h
+++ b/client/lobby/CBonusSelection.h
@@ -18,6 +18,7 @@ class CToggleGroup;
 class CAnimImage;
 class CLabel;
 class CFlagBox;
+class ISelectionScreenInfo;
 
 /// Campaign screen where you can choose one out of three starting bonuses
 class CBonusSelection : public CWindowObject

--- a/client/lobby/CCampaignInfoScreen.cpp
+++ b/client/lobby/CCampaignInfoScreen.cpp
@@ -1,0 +1,49 @@
+/*
+ * CCampaignInfoScreen.cpp, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
+#include "StdInc.h"
+
+#include "CCampaignInfoScreen.h"
+
+#include "../../CCallback.h"
+#include "../../lib/CGeneralTextHandler.h"
+#include "../../lib/StartInfo.h"
+#include "../../lib/mapping/CMapInfo.h"
+#include "../gui/CAnimation.h"
+#include "../gui/CGuiHandler.h"
+#include "../CGameInfo.h"
+#include "../CMessage.h"
+#include "../CPlayerInterface.h"
+
+CCampaignInfoScreen::CCampaignInfoScreen()
+{
+	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
+	localSi = new StartInfo(*LOCPLINT->cb->getStartInfo());
+	localMi = new CMapInfo();
+	localMi->mapHeader = std::unique_ptr<CMapHeader>(new CMapHeader(*LOCPLINT->cb->getMapHeader()));
+
+	screenType = ESelectionScreen::scenarioInfo;
+
+	updateAfterStateChange();
+}
+
+CCampaignInfoScreen::~CCampaignInfoScreen()
+{
+	vstd::clear_pointer(localSi);
+	vstd::clear_pointer(localMi);
+}
+
+const CMapInfo * CCampaignInfoScreen::getMapInfo()
+{
+	return localMi;
+}
+const StartInfo * CCampaignInfoScreen::getStartInfo()
+{
+	return localSi;
+}

--- a/client/lobby/CCampaignInfoScreen.h
+++ b/client/lobby/CCampaignInfoScreen.h
@@ -1,0 +1,26 @@
+/*
+ * CCampaignInfoScreen.h, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
+#pragma once
+
+#include "CSelectionBase.h"
+#include "CBonusSelection.h"
+
+class CCampaignInfoScreen : public CBonusSelection, ISelectionScreenInfo
+{
+	const StartInfo * localSi;
+	CMapInfo * localMi;
+
+public:
+	CCampaignInfoScreen();
+	~CCampaignInfoScreen();
+
+	const CMapInfo * getMapInfo() override;
+	const StartInfo * getStartInfo() override;
+};

--- a/client/windows/CAdvmapInterface.cpp
+++ b/client/windows/CAdvmapInterface.cpp
@@ -23,7 +23,8 @@
 #include "../CMusicHandler.h"
 #include "../CPlayerInterface.h"
 #include "../mainmenu/CMainMenu.h"
-#include "../lobby/CBonusSelection.h"
+#include "../lobby/CSelectionBase.h"
+#include "../lobby/CCampaignInfoScreen.h"
 #include "../lobby/CSavingScreen.h"
 #include "../lobby/CScenarioInfoScreen.h"
 #include "../Graphics.h"
@@ -51,6 +52,7 @@
 #include "../../lib/UnlockGuard.h"
 #include "../../lib/VCMI_Lib.h"
 #include "../../lib/StartInfo.h"
+#include "../../lib/mapping/CMapInfo.h"
 
 #ifdef _MSC_VER
 #pragma warning (disable : 4355)
@@ -1964,7 +1966,7 @@ void CAdventureOptions::showScenarioInfo()
 {
 	if(LOCPLINT->cb->getStartInfo()->campState)
 	{
-		GH.pushIntT<CBonusSelection>();
+		GH.pushIntT<CCampaignInfoScreen>();
 	}
 	else
 	{


### PR DESCRIPTION
CBonusSelection needs active IScenarionInfoScreen instance because it initializes static SEL variable.