### PR TITLE
Small fixes for AI and launcher

### DIFF
--- a/AI/Nullkiller/AIGateway.cpp
+++ b/AI/Nullkiller/AIGateway.cpp
@@ -1022,6 +1022,8 @@ bool AIGateway::canRecruitAnyHero(const CGTownInstance * t) const
 		return false;
 	if(cb->getHeroesInfo().size() >= ALLOWED_ROAMING_HEROES)
 		return false;
+	if(cb->getHeroesInfo().size() >= VLC->modh->settings.MAX_HEROES_ON_MAP_PER_PLAYER)
+		return false;
 	if(!cb->getAvailableHeroes(t).size())
 		return false;
 

--- a/AI/VCAI/VCAI.cpp
+++ b/AI/VCAI/VCAI.cpp
@@ -1317,6 +1317,8 @@ bool VCAI::canRecruitAnyHero(const CGTownInstance * t) const
 		return false;
 	if(cb->getHeroesInfo().size() >= ALLOWED_ROAMING_HEROES)
 		return false;
+	if(cb->getHeroesInfo().size() >= VLC->modh->settings.MAX_HEROES_ON_MAP_PER_PLAYER)
+        	return false;
 	if(!cb->getAvailableHeroes(t).size())
 		return false;
 

--- a/launcher/settingsView/csettingsview_moc.ui
+++ b/launcher/settingsView/csettingsview_moc.ui
@@ -449,6 +449,16 @@
        <string>1024x768</string>
       </property>
      </item>
+      <item>
+      <property name="text">
+       <string>1181x664</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>1280x720</string>
+      </property>
+     </item>
      <item>
       <property name="text">
        <string>1280x800</string>

--- a/launcher/settingsView/csettingsview_moc.ui
+++ b/launcher/settingsView/csettingsview_moc.ui
@@ -461,6 +461,11 @@
      </item>
      <item>
       <property name="text">
+       <string>1280x768</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
        <string>1280x800</string>
       </property>
      </item>


### PR DESCRIPTION
Fix for AI bug in VCAI and Nullkiller AI . 
Bug report : https://bugs.vcmi.eu/view.php?id=3208

Many years ago I have made resolutions for vcmi 1280x720,  1280x768, 1181x664.
https://forum.vcmi.eu/t/resolution-support-1280x720-1280x768-and-1181x664/1001/10
It seems someone pushed them into vcmi-essentials, but with no support from launcher one can set them only in client and when set they make the launcher crash, so when using them we cannot use launcher at all only client. 

 I've added support for them in launcher code. 
