### PR TITLE
Fix warnings/errors on MSVC

### DIFF
--- a/AI/Nullkiller/Analyzers/ArmyManager.h
+++ b/AI/Nullkiller/Analyzers/ArmyManager.h
@@ -63,7 +63,7 @@ public:
 	virtual std::shared_ptr<CCreatureSet> getArmyAvailableToBuyAsCCreatureSet(const CGDwelling * dwelling, TResources availableRes) const = 0;
 };
 
-struct StackUpgradeInfo;
+class StackUpgradeInfo;
 
 class DLL_EXPORT ArmyManager : public IArmyManager
 {

--- a/AI/StupidAI/StupidAI.cpp
+++ b/AI/StupidAI/StupidAI.cpp
@@ -45,8 +45,9 @@ void CStupidAI::actionStarted(const BattleAction &action)
 	print("actionStarted called");
 }
 
-struct EnemyInfo
+class EnemyInfo
 {
+public:
 	const CStack * s;
 	int adi, adr;
 	std::vector<BattleHex> attackFrom; //for melee fight

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,7 +158,9 @@ if(MINGW OR MSVC)
 		add_definitions(-D_CRT_SECURE_NO_WARNINGS)
 		add_definitions(-D_SCL_SECURE_NO_WARNINGS)
 		# 4250: 'class1' : inherits 'class2::member' via dominance
-		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /bigobj  /wd4250")
+		# 4251: class 'xxx' needs to have dll-interface to be used by clients of class 'yyy'
+		# 4275: non dll-interface class 'xxx' used as base for dll-interface class
+		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /bigobj /wd4250 /wd4251 /wd4275")
 
 		if(ENABLE_MULTI_PROCESS_BUILDS)
 			set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP")

--- a/lib/CPlayerState.h
+++ b/lib/CPlayerState.h
@@ -18,7 +18,7 @@
 class CGHeroInstance;
 class CGTownInstance;
 class CGDwelling;
-class QuestInfo;
+struct QuestInfo;
 
 struct DLL_LINKAGE PlayerState : public CBonusSystemNode, public Player
 {

--- a/scripting/erm/ERMParser.h
+++ b/scripting/erm/ERMParser.h
@@ -256,7 +256,7 @@ namespace ERM
 	//script line
 	typedef boost::variant<TVExp, TERMline> TLine;
 
-	template <typename T> class ERM_grammar;
+	template <typename T> struct ERM_grammar;
 }
 
 struct LineInfo

--- a/scripting/lua/api/BonusSystem.h
+++ b/scripting/lua/api/BonusSystem.h
@@ -12,7 +12,7 @@
 
 #include "../LuaWrapper.h"
 
-class Bonus;
+struct Bonus;
 class BonusList;
 class IBonusBearer;
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -147,6 +147,9 @@ set(mock_HEADERS
 		mock/mock_CPSICallback.h
 )
 
+if(MSVC)
+	set(gtest_force_shared_crt ON CACHE BOOL "Use shared (DLL) run-time lib even when Google Test is built as static lib." FORCE)
+endif()
 add_subdirectory_with_folder("3rdparty" googletest EXCLUDE_FROM_ALL)
 
 add_executable(vcmitest ${test_SRCS} ${test_HEADERS} ${mock_HEADERS})

--- a/test/mock/mock_IGameCallback.h
+++ b/test/mock/mock_IGameCallback.h
@@ -35,58 +35,58 @@ public:
 
 	//TODO: fail all stub calls
 
-	void setObjProperty(ObjectInstanceID objid, int prop, si64 val) override {};
-	void showInfoDialog(InfoWindow * iw) override {};
-	void showInfoDialog(const std::string & msg, PlayerColor player) override {};
+	void setObjProperty(ObjectInstanceID objid, int prop, si64 val) override {}
+	void showInfoDialog(InfoWindow * iw) override {}
+	void showInfoDialog(const std::string & msg, PlayerColor player) override {}
 
-	void changeSpells(const CGHeroInstance * hero, bool give, const std::set<SpellID> &spells) override {};
-	bool removeObject(const CGObjectInstance * obj) override {return false;};
-	void setOwner(const CGObjectInstance * objid, PlayerColor owner) override {};
-	void changePrimSkill(const CGHeroInstance * hero, PrimarySkill::PrimarySkill which, si64 val, bool abs=false) override {};
-	void changeSecSkill(const CGHeroInstance * hero, SecondarySkill which, int val, bool abs=false) override {};
-	void showBlockingDialog(BlockingDialog *iw) override {};
-	void showGarrisonDialog(ObjectInstanceID upobj, ObjectInstanceID hid, bool removableUnits) override {}; //cb will be called when player closes garrison window
-	void showTeleportDialog(TeleportDialog *iw) override {};
-	void showThievesGuildWindow(PlayerColor player, ObjectInstanceID requestingObjId) override {};
-	void giveResource(PlayerColor player, Res::ERes which, int val) override {};
-	void giveResources(PlayerColor player, TResources resources) override {};
+	void changeSpells(const CGHeroInstance * hero, bool give, const std::set<SpellID> &spells) override {}
+	bool removeObject(const CGObjectInstance * obj) override {return false;}
+	void setOwner(const CGObjectInstance * objid, PlayerColor owner) override {}
+	void changePrimSkill(const CGHeroInstance * hero, PrimarySkill::PrimarySkill which, si64 val, bool abs=false) override {}
+	void changeSecSkill(const CGHeroInstance * hero, SecondarySkill which, int val, bool abs=false) override {}
+	void showBlockingDialog(BlockingDialog *iw) override {}
+	void showGarrisonDialog(ObjectInstanceID upobj, ObjectInstanceID hid, bool removableUnits) override {} //cb will be called when player closes garrison window
+	void showTeleportDialog(TeleportDialog *iw) override {}
+	void showThievesGuildWindow(PlayerColor player, ObjectInstanceID requestingObjId) override {}
+	void giveResource(PlayerColor player, Res::ERes which, int val) override {}
+	void giveResources(PlayerColor player, TResources resources) override {}
 
-	void giveCreatures(const CArmedInstance *objid, const CGHeroInstance * h, const CCreatureSet &creatures, bool remove) override {};
-	void takeCreatures(ObjectInstanceID objid, const std::vector<CStackBasicDescriptor> &creatures) override {};
-	bool changeStackCount(const StackLocation &sl, TQuantity count, bool absoluteValue = false) override {return false;};
-	bool changeStackType(const StackLocation &sl, const CCreature *c) override {return false;};
-	bool insertNewStack(const StackLocation &sl, const CCreature *c, TQuantity count = -1) override {return false;}; //count -1 => moves whole stack
-	bool eraseStack(const StackLocation &sl, bool forceRemoval = false) override {return false;};
-	bool swapStacks(const StackLocation &sl1, const StackLocation &sl2) override {return false;};
-	bool addToSlot(const StackLocation &sl, const CCreature *c, TQuantity count) override {return false;}; //makes new stack or increases count of already existing
-	void tryJoiningArmy(const CArmedInstance *src, const CArmedInstance *dst, bool removeObjWhenFinished, bool allowMerging) override {}; //merges army from src do dst or opens a garrison window
-	bool moveStack(const StackLocation &src, const StackLocation &dst, TQuantity count) override {return false;};
+	void giveCreatures(const CArmedInstance *objid, const CGHeroInstance * h, const CCreatureSet &creatures, bool remove) override {}
+	void takeCreatures(ObjectInstanceID objid, const std::vector<CStackBasicDescriptor> &creatures) override {}
+	bool changeStackCount(const StackLocation &sl, TQuantity count, bool absoluteValue = false) override {return false;}
+	bool changeStackType(const StackLocation &sl, const CCreature *c) override {return false;}
+	bool insertNewStack(const StackLocation &sl, const CCreature *c, TQuantity count = -1) override {return false;} //count -1 => moves whole stack
+	bool eraseStack(const StackLocation &sl, bool forceRemoval = false) override {return false;}
+	bool swapStacks(const StackLocation &sl1, const StackLocation &sl2) override {return false;}
+	bool addToSlot(const StackLocation &sl, const CCreature *c, TQuantity count) override {return false;} //makes new stack or increases count of already existing
+	void tryJoiningArmy(const CArmedInstance *src, const CArmedInstance *dst, bool removeObjWhenFinished, bool allowMerging) override {} //merges army from src do dst or opens a garrison window
+	bool moveStack(const StackLocation &src, const StackLocation &dst, TQuantity count) override {return false;}
 
-	void removeAfterVisit(const CGObjectInstance *object) override {}; //object will be destroyed when interaction is over. Do not call when interaction is not ongoing!
+	void removeAfterVisit(const CGObjectInstance *object) override {} //object will be destroyed when interaction is over. Do not call when interaction is not ongoing!
 
-	void giveHeroNewArtifact(const CGHeroInstance *h, const CArtifact *artType, ArtifactPosition pos) override {};
-	void giveHeroArtifact(const CGHeroInstance *h, const CArtifactInstance *a, ArtifactPosition pos) override {}; //pos==-1 - first free slot in backpack=0; pos==-2 - default if available or backpack
-	void putArtifact(const ArtifactLocation &al, const CArtifactInstance *a) override {};
-	void removeArtifact(const ArtifactLocation &al) override {};
-	bool moveArtifact(const ArtifactLocation &al1, const ArtifactLocation &al2) override {return false;};
+	void giveHeroNewArtifact(const CGHeroInstance *h, const CArtifact *artType, ArtifactPosition pos) override {}
+	void giveHeroArtifact(const CGHeroInstance *h, const CArtifactInstance *a, ArtifactPosition pos) override {} //pos==-1 - first free slot in backpack=0; pos==-2 - default if available or backpack
+	void putArtifact(const ArtifactLocation &al, const CArtifactInstance *a) override {}
+	void removeArtifact(const ArtifactLocation &al) override {}
+	bool moveArtifact(const ArtifactLocation &al1, const ArtifactLocation &al2) override {return false;}
 
-	void showCompInfo(ShowInInfobox * comp) override {};
-	void heroVisitCastle(const CGTownInstance * obj, const CGHeroInstance * hero) override {};
-	void stopHeroVisitCastle(const CGTownInstance * obj, const CGHeroInstance * hero) override {};
-	void visitCastleObjects(const CGTownInstance * obj, const CGHeroInstance * hero) override {};
-	void startBattlePrimary(const CArmedInstance *army1, const CArmedInstance *army2, int3 tile, const CGHeroInstance *hero1, const CGHeroInstance *hero2, bool creatureBank = false, const CGTownInstance *town = nullptr) override {}; //use hero=nullptr for no hero
-	void startBattleI(const CArmedInstance *army1, const CArmedInstance *army2, int3 tile, bool creatureBank = false) override {}; //if any of armies is hero, hero will be used
-	void startBattleI(const CArmedInstance *army1, const CArmedInstance *army2, bool creatureBank = false) override {}; //if any of armies is hero, hero will be used, visitable tile of second obj is place of battle
-	bool moveHero(ObjectInstanceID hid, int3 dst, ui8 teleporting, bool transit = false, PlayerColor asker = PlayerColor::NEUTRAL) override {return false;};
-	bool swapGarrisonOnSiege(ObjectInstanceID tid) override {};
-	void giveHeroBonus(GiveBonus * bonus) override {};
-	void setMovePoints(SetMovePoints * smp) override {};
-	void setManaPoints(ObjectInstanceID hid, int val) override {};
-	void giveHero(ObjectInstanceID id, PlayerColor player) override {};
-	void changeObjPos(ObjectInstanceID objid, int3 newPos, ui8 flags) override {};
-	void heroExchange(ObjectInstanceID hero1, ObjectInstanceID hero2) override {}; //when two heroes meet on adventure map
-	void changeFogOfWar(int3 center, ui32 radius, PlayerColor player, bool hide) override {};
-	void changeFogOfWar(std::unordered_set<int3, ShashInt3> &tiles, PlayerColor player, bool hide) override {};
+	void showCompInfo(ShowInInfobox * comp) override {}
+	void heroVisitCastle(const CGTownInstance * obj, const CGHeroInstance * hero) override {}
+	void stopHeroVisitCastle(const CGTownInstance * obj, const CGHeroInstance * hero) override {}
+	void visitCastleObjects(const CGTownInstance * obj, const CGHeroInstance * hero) override {}
+	void startBattlePrimary(const CArmedInstance *army1, const CArmedInstance *army2, int3 tile, const CGHeroInstance *hero1, const CGHeroInstance *hero2, bool creatureBank = false, const CGTownInstance *town = nullptr) override {} //use hero=nullptr for no hero
+	void startBattleI(const CArmedInstance *army1, const CArmedInstance *army2, int3 tile, bool creatureBank = false) override {} //if any of armies is hero, hero will be used
+	void startBattleI(const CArmedInstance *army1, const CArmedInstance *army2, bool creatureBank = false) override {} //if any of armies is hero, hero will be used, visitable tile of second obj is place of battle
+	bool moveHero(ObjectInstanceID hid, int3 dst, ui8 teleporting, bool transit = false, PlayerColor asker = PlayerColor::NEUTRAL) override {return false;}
+	bool swapGarrisonOnSiege(ObjectInstanceID tid) override {return false;}
+	void giveHeroBonus(GiveBonus * bonus) override {}
+	void setMovePoints(SetMovePoints * smp) override {}
+	void setManaPoints(ObjectInstanceID hid, int val) override {}
+	void giveHero(ObjectInstanceID id, PlayerColor player) override {}
+	void changeObjPos(ObjectInstanceID objid, int3 newPos, ui8 flags) override {}
+	void heroExchange(ObjectInstanceID hero1, ObjectInstanceID hero2) override {} //when two heroes meet on adventure map
+	void changeFogOfWar(int3 center, ui32 radius, PlayerColor player, bool hide) override {}
+	void changeFogOfWar(std::unordered_set<int3, ShashInt3> &tiles, PlayerColor player, bool hide) override {}
 
 	///useful callback methods
 	void sendAndApply(CPackForClient * pack) override;


### PR DESCRIPTION
1. update googletest to tag release-1.11.0 to make googletest and googlemock compile on MSVC2022.
2. set gtest_force_shared_crt to ON in test cmake project to make tests compile on MSVC.
3. add /wd4251 and /wd4275 to MSVC compile flags to ignore DLL related warnings for class exports.
4. fix some other warnings and errors while compiling on MSVC2022.