### PR TITLE
Fix movement freeze after battle in teleport

### DIFF
--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -2771,7 +2771,8 @@ void CPlayerInterface::doMoveHero(const CGHeroInstance * h, CGPath path)
 				destinationTeleport = destTeleportObj->id;
 				destinationTeleportPos = nextCoord;
 				doMovement(h->pos, false);
-				if (path.nodes[i-1].action == CGPathNode::TELEPORT_BLOCKING_VISIT)
+				if (path.nodes[i-1].action == CGPathNode::TELEPORT_BLOCKING_VISIT
+					|| path.nodes[i-1].action == CGPathNode::TELEPORT_BATTLE)
 				{
 					destinationTeleport = ObjectInstanceID();
 					destinationTeleportPos = int3(-1);

--- a/lib/serializer/CTypeList.cpp
+++ b/lib/serializer/CTypeList.cpp
@@ -45,6 +45,21 @@ ui16 CTypeList::getTypeID(const std::type_info *type, bool throws) const
 	return descriptor->typeID;
 }
 
+CTypeList::TypeInfoPtr CTypeList::getTypeDescriptor(ui16 typeID) const
+{
+	auto found = std::find_if(typeInfos.begin(), typeInfos.end(), [typeID](const std::pair<const std::type_info *, TypeInfoPtr> & p) -> bool
+		{
+			return p.second->typeID == typeID;
+		});
+
+	if(found != typeInfos.end())
+	{
+		return found->second;
+	}
+
+	return TypeInfoPtr();
+}
+
 std::vector<CTypeList::TypeInfoPtr> CTypeList::castSequence(TypeInfoPtr from, TypeInfoPtr to) const
 {
 	if(!strcmp(from->name, to->name))

--- a/lib/serializer/CTypeList.h
+++ b/lib/serializer/CTypeList.h
@@ -148,6 +148,8 @@ public:
 		return getTypeID(getTypeInfo(t), throws);
 	}
 
+	TypeInfoPtr getTypeDescriptor(ui16 typeID) const;
+
 	template<typename TInput>
 	void * castToMostDerived(const TInput * inputPtr) const
 	{


### PR DESCRIPTION
Not 100% correct but working fix. If battle happens in teleport the movement considered as failed but destinationTeleport and destinationTeleportPos variables are left uncleared causing further hang during next move.
Now it will be possible to continue movement but teleportation is considered as canceled and you have to reenter teleport again. In original HoMM3 however teleportation succeeds.