### PR TITLE
Support Homebrew on M1 in `mac/before_install.sh`

### DIFF
--- a/CI/mac/before_install.sh
+++ b/CI/mac/before_install.sh
@@ -5,4 +5,4 @@ brew update
 brew install smpeg2 libpng freetype qt5 ffmpeg ninja boost tbb luajit
 brew install sdl2 sdl2_ttf sdl2_image sdl2_mixer
 
-echo CMAKE_PREFIX_PATH="/usr/local/opt/ffmpeg@4:/usr/local/opt/qt5:$CMAKE_PREFIX_PATH" >> $GITHUB_ENV
+echo CMAKE_PREFIX_PATH="$(brew --prefix)/opt/ffmpeg@4:$(brew --prefix)/opt/qt5:$CMAKE_PREFIX_PATH" >> $GITHUB_ENV

--- a/CI/mac/before_install.sh
+++ b/CI/mac/before_install.sh
@@ -5,4 +5,4 @@ brew update
 brew install smpeg2 libpng freetype qt5 ffmpeg ninja boost tbb luajit
 brew install sdl2 sdl2_ttf sdl2_image sdl2_mixer
 
-echo CMAKE_PREFIX_PATH="$(brew --prefix)/opt/ffmpeg@4:$(brew --prefix)/opt/qt5:$CMAKE_PREFIX_PATH" >> $GITHUB_ENV
+echo CMAKE_PREFIX_PATH="$(brew --prefix)/opt/qt5:$CMAKE_PREFIX_PATH" >> $GITHUB_ENV


### PR DESCRIPTION
Homebrew uses prefix path on M1 (`/opt/homebrew`) different from x86_64 Homebrew path (`/usr/local`). It can be queried with `brew --prefix` command, which allows supporting both platforms in `mac/before_install.sh`.