### PR TITLE
fix infinite recursion when using SDL_mixer v2.6

### DIFF
--- a/client/CMusicHandler.cpp
+++ b/client/CMusicHandler.cpp
@@ -257,13 +257,14 @@ void CSoundHandler::soundFinishedCallback(int channel)
 {
 	std::map<int, std::function<void()> >::iterator iter;
 	iter = callbacks.find(channel);
+	if (iter == callbacks.end())
+		return;
 
-	assert(iter != callbacks.end());
-
-	if (iter->second)
-		iter->second();
-
+	auto callback = std::move(iter->second);
 	callbacks.erase(iter);
+
+	if (callback)
+		callback();
 }
 
 int CSoundHandler::ambientGetRange() const


### PR DESCRIPTION
Can be reproduced e.g. by double-clicking town. Using this change with lib version 2.0.4 also works correctly.

Backtraces:

macOS:
```
Thread 0 Crashed::  Dispatch queue: com.apple.main-thread
0   libSDL2_mixer-2.0.0.dylib     	       0x1089f12f3 _Mix_channel_done_playing + 35 (mixer.c:285)
1   libSDL2_mixer-2.0.0.dylib     	       0x1089f0d74 Mix_HaltChannel_locked + 36 (mixer.c:921)
2   libSDL2_mixer-2.0.0.dylib     	       0x1089f0d07 Mix_FreeChunk + 103 (mixer.c:943)
3   vcmiclient                    	       0x107f81941 CSoundHandler::soundFinishedCallback(int) + 81
4   libSDL2_mixer-2.0.0.dylib     	       0x1089f12f5 _Mix_channel_done_playing + 37 (mixer.c:285)
5   libSDL2_mixer-2.0.0.dylib     	       0x1089f0d74 Mix_HaltChannel_locked + 36 (mixer.c:921)
6   libSDL2_mixer-2.0.0.dylib     	       0x1089f0d07 Mix_FreeChunk + 103 (mixer.c:943)
7   vcmiclient                    	       0x107f81941 CSoundHandler::soundFinishedCallback(int) + 81
```

iOS:
![image](https://user-images.githubusercontent.com/1557784/179999669-3684c673-3d16-4bad-b737-e24329c6817f.png)

Original Slack post: https://h3vcmi.slack.com/archives/C02CWRN6WH2/p1658244388297839