### PR TITLE
improve generating Version.cpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,6 +90,7 @@ define_property(
 # Generate Version.cpp
 if(ENABLE_GITVERSION)
 	add_custom_target(update_version ALL
+		BYPRODUCTS "Version.cpp"
 		COMMAND ${CMAKE_COMMAND} -DGIT_SHA1="${GIT_SHA1}" -P "${PROJECT_SOURCE_DIR}/cmake_modules/Version.cmake"
 	)
 else()


### PR DESCRIPTION
Currently Xcode's "new build system" complains that Version.cpp doesn't exist and building freezes, Xcode process must be killed after this.