### PR TITLE
Fix crash

### DIFF
--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -443,14 +443,15 @@ void CPlayerInterface::heroKilled(const CGHeroInstance* hero)
 	}
 
 	wanderingHeroes -= hero;
-	if (vstd::contains(paths, hero))
-		paths.erase(hero);
 
 	adventureInt->heroList.update(hero);
 	if (makingTurn && newSelection)
 		adventureInt->select(newSelection, true);
 	else if (adventureInt->selection == hero)
 		adventureInt->selection = nullptr;
+	
+	if (vstd::contains(paths, hero))
+		paths.erase(hero);
 }
 
 void CPlayerInterface::heroVisit(const CGHeroInstance * visitor, const CGObjectInstance * visitedObj, bool start)


### PR DESCRIPTION
Crash was rare:
 - fight with some monster, pointing exactly on tile with monster
 - escape from battle at first move
 - observe crash

Root cause: line adventureInt->heroList.update(hero) calls currentPath->size(), but currentPath is invalid because paths.erase already happened.