### PR TITLE
[macOS] text input handling must be done on main thread

### DIFF
--- a/client/gui/SDL_Extensions.cpp
+++ b/client/gui/SDL_Extensions.cpp
@@ -16,6 +16,10 @@
 #include "../Graphics.h"
 #include "../CMT.h"
 
+#ifdef VCMI_APPLE
+#include <dispatch/dispatch.h>
+#endif
+
 const SDL_Color Colors::YELLOW = { 229, 215, 123, 0 };
 const SDL_Color Colors::WHITE = { 255, 243, 222, 0 };
 const SDL_Color Colors::METALLIC_GOLD = { 173, 142, 66, 0 };
@@ -786,19 +790,35 @@ SDL_Color CSDL_Ext::makeColor(ui8 r, ui8 g, ui8 b, ui8 a)
 
 void CSDL_Ext::startTextInput(SDL_Rect * where)
 {
+#ifdef VCMI_APPLE
+	dispatch_async(dispatch_get_main_queue(), ^{
+#endif
+
 	if (SDL_IsTextInputActive() == SDL_FALSE)
 	{
 		SDL_StartTextInput();
 	}
 	SDL_SetTextInputRect(where);
+
+#ifdef VCMI_APPLE
+	});
+#endif
 }
 
 void CSDL_Ext::stopTextInput()
 {
+#ifdef VCMI_APPLE
+	dispatch_async(dispatch_get_main_queue(), ^{
+#endif
+
 	if (SDL_IsTextInputActive() == SDL_TRUE)
 	{
 		SDL_StopTextInput();
 	}
+
+#ifdef VCMI_APPLE
+	});
+#endif
 }
 
 STRONG_INLINE static uint32_t mapColor(SDL_Surface * surface, SDL_Color color)


### PR DESCRIPTION
Xcode's Main Thread Checker warns about that.

`VCMI_APPLE` macro Is used because iOS also needs this.