### PR TITLE
Fix crash in scenario information window if campaign has no difficulty settings

### DIFF
--- a/client/lobby/CBonusSelection.cpp
+++ b/client/lobby/CBonusSelection.cpp
@@ -360,8 +360,10 @@ void CBonusSelection::updateAfterStateChange()
 		buttonStart->disable();
 		buttonRestart->enable();
 		buttonBack->block(false);
-		buttonDifficultyLeft->disable();
-		buttonDifficultyRight->disable();
+		if(buttonDifficultyLeft)
+			buttonDifficultyLeft->disable();
+		if(buttonDifficultyRight)
+			buttonDifficultyRight->disable();
 	}
 	if(CSH->campaignBonus == -1)
 	{


### PR DESCRIPTION
VCMI-branch-develop-b8b3306.exe
1. Start any campaign scenario with fixed difficulty
2. Open "Adventure settings" and "Scenario information", application crashed