### PR TITLE
fix error C2338 when building Client on Windows

### DIFF
--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -175,6 +175,7 @@ if(WIN32)
 	if(NOT ENABLE_DEBUG_CONSOLE)
 		target_link_libraries(vcmiclient SDL2::SDL2main)
 	endif()
+	target_compile_definitions(vcmiclient PRIVATE WINDOWS_IGNORE_PACKING_MISMATCH)
 endif()
 
 target_link_libraries(vcmiclient PRIVATE


### PR DESCRIPTION
Error message comes from winnt.h and is:

> Windows headers require the default packing option. Changing this can lead to memory corruption. This diagnostic can be disabled by building with WINDOWS_IGNORE_PACKING_MISMATCH defined.

I was building on Windows 8.1 32-bit with MSVC 2019 x86 and Windows SDK 10.0.19041.0.