### PR TITLE
Fix start game button for rmg without templates

### DIFF
--- a/client/lobby/CLobbyScreen.cpp
+++ b/client/lobby/CLobbyScreen.cpp
@@ -131,25 +131,19 @@ void CLobbyScreen::startScenario(bool allowOnlyAI)
 		CSH->sendStartGame(allowOnlyAI);
 		buttonStart->block(true);
 	}
-	catch(ExceptionMapMissing & e)
+	catch(std::exception & e)
 	{
-		(void)e;	// unused
-	}
-	catch(ExceptionNoHuman & e)
-	{
-		(void)e;	// unused
-		// You must position yourself prior to starting the game.
-		CInfoWindow::showInfoDialog(std::ref(CGI->generaltexth->allTexts[530]), CInfoWindow::TCompsInfo(), PlayerColor(1));
-	}
-	catch(ExceptionNoTemplate & e)
-	{
-		(void)e; // unused
-		// Could not create a random map that fits current choices.
-		CInfoWindow::showInfoDialog(std::ref(CGI->generaltexth->allTexts[751]), CInfoWindow::TCompsInfo(), PlayerColor(1));
+		logGlobal->error("Exception during startScenario: %s", e.what());
+		
+		if(std::string(e.what()) == "ExceptionNoHuman")
+			CInfoWindow::showInfoDialog(std::ref(CGI->generaltexth->allTexts[530]), CInfoWindow::TCompsInfo(), PlayerColor(1));
+		
+		if(std::string(e.what()) == "ExceptionNoTemplate")
+			CInfoWindow::showInfoDialog(std::ref(CGI->generaltexth->allTexts[751]), CInfoWindow::TCompsInfo(), PlayerColor(1));
 	}
 	catch(...)
 	{
-
+		logGlobal->error("Unknown exception");
 	}
 }
 

--- a/lib/CGeneralTextHandler.cpp
+++ b/lib/CGeneralTextHandler.cpp
@@ -493,6 +493,28 @@ CGeneralTextHandler::CGeneralTextHandler()
 			logGlobal->warn("WoG file ZNPC00.TXT containing commander texts was not found");
 		}
 	}
+	
+	//sanity check: in most places we get strings using operator[] so it may lead to crash if data is not valid
+	//use highest hardcoded index to check
+	if(allTexts.size() < 741 ||
+	   arraytxt.size() < 232 ||
+	   primarySkillNames.size() < 4 ||
+	   jktexts.size() < 44 ||
+	   heroscrn.size() < 33 ||
+	   overview.size() < 16 ||
+	   colors.size() < 8 ||
+	   capColors.size() < 8 ||
+	   tcommands.size() < 33 ||
+	   hcommands.size() < 9 ||
+	   fcommands.size() < 7 ||
+	   tavernInfo.size() < 8 ||
+	   zelp.size() < 614 ||
+	   advobtxt.size() < 91 ||
+	   restypes.size() < 7 ||
+	   mines.size() < 7)
+	{
+		logGlobal->error("YOUR ORIGINAL HOMM3 DATA IS CORRUPTED, GAME MAY CRASH");
+	}
 }
 
 int32_t CGeneralTextHandler::pluralText(const int32_t textIndex, const int32_t count) const

--- a/lib/CGeneralTextHandler.cpp
+++ b/lib/CGeneralTextHandler.cpp
@@ -513,7 +513,7 @@ CGeneralTextHandler::CGeneralTextHandler()
 	   restypes.size() < 7 ||
 	   mines.size() < 7)
 	{
-		logGlobal->error("YOUR ORIGINAL HOMM3 DATA IS CORRUPTED, GAME MAY CRASH");
+		logGlobal->error("GeneralTextHandler: GAME DATA IS CORRUPTED, GAME MAY CRASH!");
 	}
 }
 

--- a/lib/CGeneralTextHandler.cpp
+++ b/lib/CGeneralTextHandler.cpp
@@ -513,7 +513,7 @@ CGeneralTextHandler::CGeneralTextHandler()
 	   restypes.size() < 7 ||
 	   mines.size() < 7)
 	{
-		logGlobal->error("GeneralTextHandler: GAME DATA IS CORRUPTED, GAME MAY CRASH!");
+		logGlobal->error("YOUR ORIGINAL HOMM3 DATA IS CORRUPTED, GAME MAY CRASH");
 	}
 }
 

--- a/lib/CGeneralTextHandler.cpp
+++ b/lib/CGeneralTextHandler.cpp
@@ -493,28 +493,6 @@ CGeneralTextHandler::CGeneralTextHandler()
 			logGlobal->warn("WoG file ZNPC00.TXT containing commander texts was not found");
 		}
 	}
-	
-	//sanity check: in most places we get strings using operator[] so it may lead to crash if data is not valid
-	//use highest hardcoded index to check
-	if(allTexts.size() < 741 ||
-	   arraytxt.size() < 232 ||
-	   primarySkillNames.size() < 4 ||
-	   jktexts.size() < 44 ||
-	   heroscrn.size() < 33 ||
-	   overview.size() < 16 ||
-	   colors.size() < 8 ||
-	   capColors.size() < 8 ||
-	   tcommands.size() < 33 ||
-	   hcommands.size() < 9 ||
-	   fcommands.size() < 7 ||
-	   tavernInfo.size() < 8 ||
-	   zelp.size() < 614 ||
-	   advobtxt.size() < 91 ||
-	   restypes.size() < 7 ||
-	   mines.size() < 7)
-	{
-		logGlobal->error("YOUR ORIGINAL HOMM3 DATA IS CORRUPTED, GAME MAY CRASH");
-	}
 }
 
 int32_t CGeneralTextHandler::pluralText(const int32_t textIndex, const int32_t count) const

--- a/lib/StartInfo.cpp
+++ b/lib/StartInfo.cpp
@@ -64,7 +64,7 @@ std::string StartInfo::getCampaignName() const
 void LobbyInfo::verifyStateBeforeStart(bool ignoreNoHuman) const
 {
 	if(!mi)
-		throw ExceptionMapMissing();
+		throw std::domain_error("ExceptionMapMissing");
 
 	//there must be at least one human player before game can be started
 	std::map<PlayerColor, PlayerSettings>::const_iterator i;
@@ -73,12 +73,12 @@ void LobbyInfo::verifyStateBeforeStart(bool ignoreNoHuman) const
 			break;
 
 	if(i == si->playerInfos.cend() && !ignoreNoHuman)
-		throw ExceptionNoHuman();
+		throw std::domain_error("ExceptionNoHuman");
 
 	if(si->mapGenOptions && si->mode == StartInfo::NEW_GAME)
 	{
 		if(!si->mapGenOptions->checkOptions())
-			throw ExceptionNoTemplate();
+			throw std::domain_error("ExceptionNoTemplate");
 	}
 }
 

--- a/lib/StartInfo.h
+++ b/lib/StartInfo.h
@@ -187,6 +187,3 @@ struct DLL_LINKAGE LobbyInfo : public LobbyState
 	TeamID getPlayerTeamId(PlayerColor color);
 };
 
-class ExceptionMapMissing : public std::exception {};
-class ExceptionNoHuman : public std::exception {};
-class ExceptionNoTemplate : public std::exception {};


### PR DESCRIPTION
1. The story: I tried to install vcmi on the new machine but It was crashed at random moments (but at most cases right after connecting to the server). Investigating that I understood that the problem is in data resources or in its parsing (despite the fact that original game works fine at the same computer).
So I've decided to make small just to have small hint in the log. It creates purely negative impression for the new people who just want to try vcmi and observing crash without any reason.

We can discuss stricter rule - such as throwing an exception or something, but record in the log helps a lot.

2. I fixed exception catching mechanism. Steps to reproduce a problem:
   a. Disable all rmg template mods from launcher
   b. Run client and try to generate any random map
Expected result: uses sees window with error about missing templates
Actual result: nothing happens