### PR TITLE
[844] - fix pathfinding for fly towards guarded tile

### DIFF
--- a/lib/CPathfinder.cpp
+++ b/lib/CPathfinder.cpp
@@ -620,10 +620,11 @@ void LayerTransitionRule::process(
 				destination.blocked = true;
 			}
 		}
-		else if(source.node->accessible != CGPathNode::ACCESSIBLE &&	destination.node->accessible != CGPathNode::ACCESSIBLE)
+		else if(destination.node->accessible != CGPathNode::ACCESSIBLE)
 		{
 			/// Hero that fly can only land on accessible tiles
-			destination.blocked = true;
+			if(!destination.isGuardianTile && destination.nodeObject)
+				destination.blocked = true;
 		}
 
 		break;


### PR DESCRIPTION
I am not sure about the crash origin but observed bad behavior related to fly and angel wings. It is possible to pick removable objects (artifacts) standing on water tile. After this hero becomes unmovable and can escape only using adv spells. This behavior is fixed now according to HOMM3. It is possible to attack guards directly from air.