### PR TITLE
Terrain performance

### DIFF
--- a/lib/Terrain.cpp
+++ b/lib/Terrain.cpp
@@ -154,6 +154,11 @@ Terrain::Manager::Manager()
 			}
 			
 			terrainInfo[terr.first] = info;
+			if(!terrainId.count(terr.first))
+			{
+				terrainId[terr.first] = terrainVault.size();
+				terrainVault.push_back(terr.first);
+			}
 		}
 	}
 }
@@ -164,12 +169,18 @@ Terrain::Manager & Terrain::Manager::get()
 	return manager;
 }
 
-std::vector<Terrain> Terrain::Manager::terrains()
+const std::vector<Terrain> & Terrain::Manager::terrains()
 {
-	std::set<Terrain> _terrains; //have to use std::set to have ordered container. Othervise de-sync is possible
-	for(const auto & info : Terrain::Manager::get().terrainInfo)
-		_terrains.insert(info.first);
-	return std::vector<Terrain>(_terrains.begin(), _terrains.end());
+	return Terrain::Manager::get().terrainVault;
+}
+
+int Terrain::Manager::id(const Terrain & terrain)
+{
+	if(terrain.name == "ANY") return -3;
+	if(terrain.name == "WRONG") return -2;
+	if(terrain.name == "BORDER") return -1;
+	
+	return Terrain::Manager::get().terrainId.at(terrain);
 }
 
 const Terrain::Info & Terrain::Manager::getInfo(const Terrain & terrain)
@@ -219,13 +230,7 @@ bool operator<(const Terrain & l, const Terrain & r)
 	
 int Terrain::id() const
 {
-	if(name == "ANY") return -3;
-	if(name == "WRONG") return -2;
-	if(name == "BORDER") return -1;
-	
-	auto _terrains = Terrain::Manager::terrains();
-	auto iter = std::find(_terrains.begin(), _terrains.end(), *this);
-	return iter - _terrains.begin();
+	return Terrain::Manager::id(*this);
 }
 	
 bool Terrain::isLand() const

--- a/lib/Terrain.h
+++ b/lib/Terrain.h
@@ -48,14 +48,17 @@ public:
 	class DLL_LINKAGE Manager
 	{
 	public:
-		static std::vector<Terrain> terrains();
+		static const std::vector<Terrain> & terrains();
 		static const Info & getInfo(const Terrain &);
+		static int id(const Terrain &);
 		
 	private:
 		static Manager & get();
 		Manager();
 		
 		std::unordered_map<std::string, Info> terrainInfo;
+		std::vector<Terrain> terrainVault;
+		std::map<Terrain, int> terrainId;
 	};
 	
 	/*enum EETerrainType


### PR DESCRIPTION
Complexity of id() before (for 10 terrains, string comparisons, worst case):
1. Create std::set - 10 * ln(10)
2. Create std::vector - 10 * ln(10)
3. Search element in vector - 10

Complexity of id after ln(10)

Summary: speedup ~20 times