### PR TITLE
Nullkiller ai tweaks

### DIFF
--- a/AI/Nullkiller/Engine/PriorityEvaluator.cpp
+++ b/AI/Nullkiller/Engine/PriorityEvaluator.cpp
@@ -255,6 +255,8 @@ uint64_t RewardEvaluator::getArmyReward(
 		return ai->cb->getPlayerRelations(target->tempOwner, ai->playerID) == PlayerRelations::ENEMIES
 			? enemyArmyEliminationRewardRatio * dynamic_cast<const CGHeroInstance *>(target)->getArmyStrength()
 			: 0;
+	case Obj::PANDORAS_BOX:
+		return 5000;
 	default:
 		return 0;
 	}
@@ -421,6 +423,9 @@ float RewardEvaluator::getSkillReward(const CGObjectInstance * target, const CGH
 		return 8;
 	case Obj::WITCH_HUT:
 		return evaluateWitchHutSkillScore(dynamic_cast<const CGWitchHut *>(target), hero, role);
+	case Obj::PANDORAS_BOX:
+		//Can contains experience, spells, or skills (only on custom maps)
+		return 2.5f;
 	case Obj::HERO:
 		return ai->cb->getPlayerRelations(target->tempOwner, ai->playerID) == PlayerRelations::ENEMIES
 			? enemyHeroEliminationSkillRewardRatio * dynamic_cast<const CGHeroInstance *>(target)->level
@@ -500,6 +505,8 @@ int32_t RewardEvaluator::getGoldReward(const CGObjectInstance * target, const CG
 		return 10000;
 	case Obj::SEA_CHEST:
 		return 1500;
+	case Obj::PANDORAS_BOX:
+		return 5000;
 	case Obj::HERO:
 		return ai->cb->getPlayerRelations(target->tempOwner, ai->playerID) == PlayerRelations::ENEMIES
 			? heroEliminationBonus + enemyArmyEliminationGoldRewardRatio * getArmyCost(dynamic_cast<const CGHeroInstance *>(target))

--- a/AI/Nullkiller/Engine/PriorityEvaluator.cpp
+++ b/AI/Nullkiller/Engine/PriorityEvaluator.cpp
@@ -196,7 +196,6 @@ uint64_t evaluateArtifactArmyValue(CArtifactInstance * art)
 		+ 700 * art->getDefense(false)
 		+ 700 * art->valOfBonuses(Bonus::PRIMARY_SKILL, PrimarySkill::KNOWLEDGE)
 		+ 700 * art->valOfBonuses(Bonus::PRIMARY_SKILL, PrimarySkill::SPELL_POWER)
-		+ 700 * art->getDefense(false)
 		+ 500 * art->valOfBonuses(Bonus::LUCK);
 
 	auto classValue = 0;

--- a/AI/Nullkiller/Engine/PriorityEvaluator.cpp
+++ b/AI/Nullkiller/Engine/PriorityEvaluator.cpp
@@ -190,7 +190,8 @@ uint64_t evaluateArtifactArmyValue(CArtifactInstance * art)
 		return 1500;
 
 	auto statsValue =
-		4 * art->valOfBonuses(Bonus::LAND_MOVEMENT)
+		10 * art->valOfBonuses(Bonus::LAND_MOVEMENT)
+		+ 1200 * art->valOfBonuses(Bonus::STACKS_SPEED)
 		+ 700 * art->valOfBonuses(Bonus::MORALE)
 		+ 700 * art->getAttack(false)
 		+ 700 * art->getDefense(false)

--- a/AI/Nullkiller/Engine/PriorityEvaluator.cpp
+++ b/AI/Nullkiller/Engine/PriorityEvaluator.cpp
@@ -507,6 +507,9 @@ int32_t RewardEvaluator::getGoldReward(const CGObjectInstance * target, const CG
 		return 1500;
 	case Obj::PANDORAS_BOX:
 		return 5000;
+	case Obj::PRISON:
+		//Objectively saves us 2500 to hire hero
+		return GameConstants::HERO_GOLD_COST;
 	case Obj::HERO:
 		return ai->cb->getPlayerRelations(target->tempOwner, ai->playerID) == PlayerRelations::ENEMIES
 			? heroEliminationBonus + enemyArmyEliminationGoldRewardRatio * getArmyCost(dynamic_cast<const CGHeroInstance *>(target))

--- a/AI/Nullkiller/Engine/PriorityEvaluator.cpp
+++ b/AI/Nullkiller/Engine/PriorityEvaluator.cpp
@@ -297,7 +297,8 @@ float RewardEvaluator::getEnemyHeroStrategicalValue(const CGHeroInstance * enemy
 		vstd::amax(objectValue, getStrategicalValue(obj));
 	}
 
-	return objectValue / 2.0f + enemy->level / 15.0f;
+	//AI should absolutely prioritize killing enemy heroes, even scouts
+	return std::min(1.0f, objectValue * 0.9f + (1.0f - (1.0f / (1 + enemy->level))));
 }
 
 float RewardEvaluator::getResourceRequirementStrength(int resType) const

--- a/AI/Nullkiller/Engine/PriorityEvaluator.cpp
+++ b/AI/Nullkiller/Engine/PriorityEvaluator.cpp
@@ -299,7 +299,13 @@ float RewardEvaluator::getEnemyHeroStrategicalValue(const CGHeroInstance * enemy
 		vstd::amax(objectValue, getStrategicalValue(obj));
 	}
 
-	//AI should absolutely prioritize killing enemy heroes, even scouts
+	/*
+	  1. If an enemy hero can attack nearby object, it's not useful to capture the object on our own.
+	  Killing the hero is almost as important (0.9) as capturing the object itself.
+
+	  2. The formula quickly approaches 1.0 as hero level increases,
+	  but higher level always means higher value and the minimal value for level 1 hero is 0.5
+	*/
 	return std::min(1.0f, objectValue * 0.9f + (1.0f - (1.0f / (1 + enemy->level))));
 }
 

--- a/AI/Nullkiller/Engine/PriorityEvaluator.cpp
+++ b/AI/Nullkiller/Engine/PriorityEvaluator.cpp
@@ -368,7 +368,7 @@ float RewardEvaluator::getStrategicalValue(const CGObjectInstance * target) cons
 
 		return dynamic_cast<const CGTownInstance *>(target)->hasFort()
 			? (target->tempOwner == PlayerColor::NEUTRAL ? 0.8f : 1.0f)
-			: 0.5f;
+			: 0.7f;
 
 	case Obj::HERO:
 		return ai->cb->getPlayerRelations(target->tempOwner, ai->playerID) == PlayerRelations::ENEMIES

--- a/AI/Nullkiller/Engine/PriorityEvaluator.cpp
+++ b/AI/Nullkiller/Engine/PriorityEvaluator.cpp
@@ -92,6 +92,8 @@ int32_t estimateTownIncome(CCallback * cb, const CGObjectInstance * target, cons
 
 TResources getCreatureBankResources(const CGObjectInstance * target, const CGHeroInstance * hero)
 {
+	//Fixme: unused variable hero
+
 	auto objectInfo = VLC->objtypeh->getHandlerFor(target->ID, target->subID)->getObjectInfo(target->appearance);
 	CBankInfo * bankInfo = dynamic_cast<CBankInfo *>(objectInfo.get());
 	auto resources = bankInfo->getPossibleResourcesReward();

--- a/lib/mapObjects/CGHeroInstance.cpp
+++ b/lib/mapObjects/CGHeroInstance.cpp
@@ -450,9 +450,8 @@ void CGHeroInstance::onHeroVisit(const CGHeroInstance * h) const
 	{
 		int txt_id;
 
-		if (cb->getHeroCount(h->tempOwner, false) < VLC->modh->settings.MAX_HEROES_ON_MAP_PER_PLAYER)//GameConstants::MAX_HEROES_PER_PLAYER) //free hero slot
+		if (cb->getHeroCount(h->tempOwner, false) < VLC->modh->settings.MAX_HEROES_ON_MAP_PER_PLAYER)//free hero slot
 		{
-			cb->changeObjPos(id,pos+int3(1,0,0),0);
 			//update hero parameters
 			SetMovePoints smp;
 			smp.hid = id;

--- a/lib/mapObjects/CGHeroInstance.cpp
+++ b/lib/mapObjects/CGHeroInstance.cpp
@@ -1412,7 +1412,9 @@ void CGHeroInstance::setHeroTypeName(const std::string & identifier)
 		if(rawId)
 			subID = rawId.get();
 		else
-			subID = 0; //fallback to Orrin, throw error instead?
+		{
+			throw std::runtime_error("Couldn't resolve hero identifier " + identifier);
+		}
 	}
 }
 

--- a/lib/mapObjects/CObjectHandler.cpp
+++ b/lib/mapObjects/CObjectHandler.cpp
@@ -210,6 +210,11 @@ void CGObjectInstance::setType(si32 ID, si32 subID)
 		appearance = handler->getTemplates(tile.terType)[0];
 	else
 		appearance = handler->getTemplates()[0]; // get at least some appearance since alternative is crash
+	if (ID == Obj::HERO)
+	{
+		//adjust for the prison offset
+		pos = visitablePos();
+	}
 	cb->gameState()->map->addBlockVisTiles(this);
 }
 

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -5583,10 +5583,7 @@ bool CGameHandler::isAllowedExchange(ObjectInstanceID id1, ObjectInstanceID id2)
 			auto topArmy = dialog->exchangingArmies.at(0);
 			auto bottomArmy = dialog->exchangingArmies.at(1);
 
-			if (topArmy == o1 && bottomArmy == o2)
-				return true;
-
-			if (bottomArmy == o1 && topArmy == o2)
+			if (topArmy == o1 && bottomArmy == o2 || bottomArmy == o1 && topArmy == o2)
 				return true;
 		}
 	}

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -5572,13 +5572,21 @@ bool CGameHandler::isAllowedExchange(ObjectInstanceID id1, ObjectInstanceID id2)
 				return true;
 		}
 
-		//Ongoing garrison exchange
-		if (auto dialog = std::dynamic_pointer_cast<CGarrisonDialogQuery>(queries.topQuery(o1->tempOwner)))
+		//Ongoing garrison exchange - usually picking from top garison (from o1 to o2), but who knows
+		auto dialog = std::dynamic_pointer_cast<CGarrisonDialogQuery>(queries.topQuery(o1->tempOwner));
+		if (!dialog)
 		{
-			if (dialog->exchangingArmies.at(0) == o1 && dialog->exchangingArmies.at(1) == o2)
+			dialog = std::dynamic_pointer_cast<CGarrisonDialogQuery>(queries.topQuery(o2->tempOwner));
+		}
+		if (dialog)
+		{
+			auto topArmy = dialog->exchangingArmies.at(0);
+			auto bottomArmy = dialog->exchangingArmies.at(1);
+
+			if (topArmy == o1 && bottomArmy == o2)
 				return true;
 
-			if (dialog->exchangingArmies.at(1) == o1 && dialog->exchangingArmies.at(0) == o2)
+			if (bottomArmy == o1 && topArmy == o2)
 				return true;
 		}
 	}


### PR DESCRIPTION
Many AI tweaks:

- AI will now pick Pandoras as they are valuable objects
- AI will pick Prisons. At the same time I fixed #3227 https://bugs.vcmi.eu/view.php?id=3227
- Fixed exchange dialogs which in particular stopped AI from joining armies from Banks, Pandoras and Diplomacy when it already had 7 stacks in army.
- AI will attack anemy heroes agressively. This in fact makes it able to win in finite time.
- Various value tweak here and there