### PR TITLE
activate battle hexes after heroes

### DIFF
--- a/client/battle/CBattleInterface.cpp
+++ b/client/battle/CBattleInterface.cpp
@@ -502,13 +502,14 @@ void CBattleInterface::activate()
 	bWait->activate();
 	bDefence->activate();
 
-	for (auto hex : bfield)
-		hex->activate();
-
 	if (attackingHero)
 		attackingHero->activate();
 	if (defendingHero)
 		defendingHero->activate();
+
+	for (auto hex : bfield)
+		hex->activate();
+
 	if (settings["battle"]["showQueue"].Bool())
 		queue->activate();
 


### PR DESCRIPTION
gives hexes higher priority when performing "hit test" for mouse click as `CGuiHandler::handleElementActivate()` uses `push_front` to a list. this fixes RMB click on the topmost corner stacks: now it shows stack info instead of hero.

fixes #792