### PR TITLE
prevent crash when a mod from save file doesn't exist

### DIFF
--- a/lib/CHeroHandler.cpp
+++ b/lib/CHeroHandler.cpp
@@ -842,10 +842,22 @@ void CHeroHandler::loadObstacles()
 	allConfigs.insert(allConfigs.begin(), "core");
 	for(auto & mod : allConfigs)
 	{
-		if(!CResourceHandler::get(mod)->existsResource(ResourceID("config/obstacles.json")))
+		ISimpleResourceLoader * modResourceLoader;
+		try
+		{
+			modResourceLoader = CResourceHandler::get(mod);
+		}
+		catch(const std::out_of_range &)
+		{
+			logMod->warn("Mod '%1%' doesn't exist! Its obstacles won't be loaded!", mod);
+			continue;
+		}
+
+		const ResourceID obstaclesResource{"config/obstacles.json"};
+		if(!modResourceLoader->existsResource(obstaclesResource))
 			continue;
 		
-		const JsonNode config(mod, ResourceID("config/obstacles.json"));
+		const JsonNode config(mod, obstaclesResource);
 		loadObstacles(config["obstacles"], false, obstacles);
 		loadObstacles(config["absoluteObstacles"], true, absoluteObstacles);
 	}


### PR DESCRIPTION
fixes #866

This is just a workaround, proper fix should come in #786.

I could reproduce the following way: have the old top-level mod _VCMI Quick Exchange_, start game with it, then reinstall all mods to the latest versions and you have the QE mod under _VCMI Extras_ now. Second attempt to load old save game crashes because it can't find QE at the old path.

If save game requires some mod to function, then crash happens in another place. Tested by disabling Forge/Asphalt mod and loading respective save:

```
Cannot get object with id 4092. Object was removed
Something wrong, that object already has been removed or hasn't existed!

* thread #17, stop reason = breakpoint 1.1
    frame #0: 0x00007ff818e3bc58 libc++abi.dylib`__cxa_throw
  * frame #1: 0x000000010d06bfa2 libvcmi.dylib`CTypeList::castSequence(this=0x000000010d473750, from=std::__1::shared_ptr<CTypeList::TypeDescriptor>::element_type @ 0x000000010a93b428 weak=21, to=std::__1::shared_ptr<CTypeList::TypeDescriptor>::element_type @ 0x000000010a945e98 weak=58) const at CTypeList.cpp:112:3
    frame #2: 0x000000010d06c62e libvcmi.dylib`CTypeList::castSequence(this=0x000000010d473750, from=0x000000010d40aba8, to=0x0000000100c9fba0) const at CTypeList.cpp:124:9
    frame #3: 0x000000010014d4e8 vcmiclient`boost::any CTypeList::castHelper<&(IPointerCaster::castRawPtr(boost::any const&) const)>(this=0x000000010d473750, inputPtr=(content = 0x000000010b8aa270), fromArg=0x000000010d40aba8, toArg=0x0000000100c9fba0) const at CTypeList.h:93:24
    frame #4: 0x000000010016c401 vcmiclient`CTypeList::castRaw(this=0x000000010d473750, inputPtr=0x000000010b871300, from=0x000000010d40aba8, to=0x0000000100c9fba0) const at CTypeList.h:183:33
    frame #5: 0x00000001001effb9 vcmiclient`CPackForLobby* dynamic_ptr_cast<CPackForLobby, CPack>(ptr=0x000000010b871300) at Cast.h:54:12
    frame #6: 0x00000001001ec054 vcmiclient`CServerHandler::threadHandleConnection(this=0x000000011456fa90) at CServerHandler.cpp:635:29
    frame #7: 0x000000010023d636 vcmiclient`boost::_mfi::mf0<void, CServerHandler>::operator(this=0x0000000123a770e0, p=0x000000011456fa90)(CServerHandler*) const at mem_fn_template.hpp:49:29
    frame #8: 0x000000010023d5a9 vcmiclient`void boost::_bi::list1<boost::_bi::value<CServerHandler*> >::operator(this=0x0000000123a770f0, (null)=type<void> @ 0x0000700006b42ee8, f=0x0000000123a770e0, a=0x0000700006b42f10, (null)=0)<boost::_mfi::mf0<void, CServerHandler>, boost::_bi::list0>(boost::_bi::type<void>, boost::_mfi::mf0<void, CServerHandler>&, boost::_bi::list0&, int) at bind.hpp:238:9
    frame #9: 0x000000010023d553 vcmiclient`boost::_bi::bind_t<void, boost::_mfi::mf0<void, CServerHandler>, boost::_bi::list1<boost::_bi::value<CServerHandler*> > >::operator(this=0x0000000123a770e0)() at bind.hpp:1273:16
    frame #10: 0x000000010023cf2c vcmiclient`boost::detail::thread_data<boost::_bi::bind_t<void, boost::_mfi::mf0<void, CServerHandler>, boost::_bi::list1<boost::_bi::value<CServerHandler*> > > >::run(this=0x0000000123a76f90) at thread.hpp:120:17
    frame #11: 0x0000000104884c12 libboost_thread-mt.dylib`boost::(anonymous namespace)::thread_proxy(void*) + 146
    frame #12: 0x00000001043b2c0d libsystem_pthread.dylib`_pthread_start + 125
    frame #13: 0x00000001043baccf libsystem_pthread.dylib`thread_start + 15
```