### PR TITLE
[macOS] perform ad-hoc codesigning

### DIFF
--- a/osx/CMakeLists.txt
+++ b/osx/CMakeLists.txt
@@ -44,6 +44,20 @@ if(APPLE)
 		)
 		file(REMOVE \"${bundleContentsDir}/conan_imports_manifest.txt\")
 	")
+
+	# perform ad-hoc codesigning
+	set(codesignCommand "codesign --verbose=4 --force --options=runtime --timestamp=none --sign -")
+	set(codesignCommandWithEntitlements "${codesignCommand} --entitlements \"${CMAKE_SOURCE_DIR}/osx/entitlements.plist\"")
+	install(CODE "
+		execute_process(COMMAND
+			${codesignCommand} \"${bundleContentsDir}/MacOS/vcmibuilder\"
+		)
+		foreach(executable vcmiclient vcmiserver vcmilauncher)
+			execute_process(COMMAND
+				${codesignCommandWithEntitlements} \"${bundleContentsDir}/MacOS/\${executable}\"
+			)
+		endforeach()
+	")
 endif(APPLE)
 
 # This will likely only work for Vcpkg

--- a/osx/entitlements.plist
+++ b/osx/entitlements.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.cs.disable-library-validation</key>
+	<true/>
+	<key>com.apple.security.get-task-allow</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
It seems that macOS ARM builds require signature to prevent run error "VCMI is damaged and must be moved to Trash". Although it's not quite clear if any ARM build requires this or only cross-compiled ones.

Some details can be found in https://github.com/golang/go/issues/42684

Full explanation: https://developer.apple.com/documentation/macos-release-notes/macos-big-sur-11_0_1-universal-apps-release-notes

> New in macOS 11 on Macs with Apple silicon, and starting in macOS Big Sur 11 beta 6, the operating system enforces that any executable must be signed before it’s allowed to run.
> This new policy doesn’t apply to translated x86 binaries running under Rosetta 2, nor does it apply to macOS 11 running on Intel-based platforms.