### PR TITLE
NK: fix AI speed

### DIFF
--- a/AI/Nullkiller/AIGateway.cpp
+++ b/AI/Nullkiller/AIGateway.cpp
@@ -766,10 +766,10 @@ void AIGateway::makeTurn()
 		logAi->debug("Making turn thread has been interrupted. We'll end without calling endTurn.");
 		return;
 	}
-	/*catch (std::exception & e)
+	catch (std::exception & e)
 	{
 		logAi->debug("Making turn thread has caught an exception: %s", e.what());
-	}*/
+	}
 
 	endTurn();
 }

--- a/AI/Nullkiller/Analyzers/ObjectClusterizer.cpp
+++ b/AI/Nullkiller/Analyzers/ObjectClusterizer.cpp
@@ -120,18 +120,23 @@ const CGObjectInstance * ObjectClusterizer::getBlocker(const AIPath & path) cons
 
 		auto blocker = blockers.front();
 
+		if(isObjectPassable(ai, blocker))
+			continue;
+
 		if(blocker->ID == Obj::GARRISON
-			|| blocker->ID == Obj::MONSTER
-			|| blocker->ID == Obj::GARRISON2
-			|| blocker->ID == Obj::BORDERGUARD
-			|| blocker->ID == Obj::BORDER_GATE
-			|| blocker->ID == Obj::SHIPYARD)
+			|| blocker->ID == Obj::GARRISON2)
 		{
-			if(!isObjectPassable(ai, blocker))
+			if(dynamic_cast<const CArmedInstance *>(blocker)->getArmyStrength() == 0)
+				continue;
+			else
 				return blocker;
 		}
 
-		if(blocker->ID == Obj::QUEST_GUARD && node->actionIsBlocked)
+		if(blocker->ID == Obj::MONSTER
+			|| blocker->ID == Obj::BORDERGUARD
+			|| blocker->ID == Obj::BORDER_GATE
+			|| blocker->ID == Obj::SHIPYARD
+			|| (blocker->ID == Obj::QUEST_GUARD && node->actionIsBlocked))
 		{
 			return blocker;
 		}

--- a/AI/Nullkiller/Engine/Nullkiller.cpp
+++ b/AI/Nullkiller/Engine/Nullkiller.cpp
@@ -116,9 +116,10 @@ void Nullkiller::resetAiState()
 	playerID = ai->playerID;
 	lockedHeroes.clear();
 	dangerHitMap->reset();
+	useHeroChain = true;
 }
 
-void Nullkiller::updateAiState(int pass)
+void Nullkiller::updateAiState(int pass, bool fast)
 {
 	boost::this_thread::interruption_point();
 
@@ -126,39 +127,42 @@ void Nullkiller::updateAiState(int pass)
 
 	activeHero = nullptr;
 
-	memory->removeInvisibleObjects(cb.get());
-
-	dangerHitMap->updateHitMap();
-
-	boost::this_thread::interruption_point();
-
-	heroManager->update();
-	logAi->trace("Updating paths");
-
-	std::map<const CGHeroInstance *, HeroRole> activeHeroes;
-
-	for(auto hero : cb->getHeroesInfo())
+	if(!fast)
 	{
-		if(getHeroLockedReason(hero) == HeroLockedReason::DEFENCE)
-			continue;
+		memory->removeInvisibleObjects(cb.get());
 
-		activeHeroes[hero] = heroManager->getHeroRole(hero);
+		dangerHitMap->updateHitMap();
+
+		boost::this_thread::interruption_point();
+
+		heroManager->update();
+		logAi->trace("Updating paths");
+
+		std::map<const CGHeroInstance *, HeroRole> activeHeroes;
+
+		for(auto hero : cb->getHeroesInfo())
+		{
+			if(getHeroLockedReason(hero) == HeroLockedReason::DEFENCE)
+				continue;
+
+			activeHeroes[hero] = heroManager->getHeroRole(hero);
+		}
+
+		PathfinderSettings cfg;
+		cfg.useHeroChain = useHeroChain;
+		cfg.scoutTurnDistanceLimit = SCOUT_TURN_DISTANCE_LIMIT;
+
+		if(scanDepth != ScanDepth::FULL)
+		{
+			cfg.mainTurnDistanceLimit = MAIN_TURN_DISTANCE_LIMIT * ((int)scanDepth + 1);
+		}
+
+		pathfinder->updatePaths(activeHeroes, cfg);
+
+		objectClusterizer->clusterize();
 	}
-
-	PathfinderSettings cfg;
-	cfg.useHeroChain = true;
-	cfg.scoutTurnDistanceLimit = SCOUT_TURN_DISTANCE_LIMIT;
-
-	if(scanDepth != ScanDepth::FULL)
-	{
-		cfg.mainTurnDistanceLimit = MAIN_TURN_DISTANCE_LIMIT * ((int)scanDepth + 1);
-	}
-
-	pathfinder->updatePaths(activeHeroes, cfg);
 
 	armyManager->update();
-
-	objectClusterizer->clusterize();
 	buildAnalyzer->update();
 	decomposer->reset();
 
@@ -213,13 +217,30 @@ void Nullkiller::makeTurn()
 	{
 		updateAiState(i);
 
+		Goals::TTask bestTask = taskptr(Goals::Invalid());
+		
+		do
+		{
+			Goals::TTaskVec fastTasks = {
+				choseBestTask(sptr(BuyArmyBehavior()), 1),
+				choseBestTask(sptr(RecruitHeroBehavior()), 1),
+				choseBestTask(sptr(BuildingBehavior()), 1)
+			};
+
+			bestTask = choseBestTask(fastTasks);
+
+			if(bestTask->priority >= 1)
+			{
+				executeTask(bestTask);
+				updateAiState(i, true);
+			}
+		} while(bestTask->priority >= 1);
+
 		Goals::TTaskVec bestTasks = {
-			choseBestTask(sptr(BuyArmyBehavior()), 1),
+			bestTask,
 			choseBestTask(sptr(CaptureObjectsBehavior()), 1),
 			choseBestTask(sptr(ClusterBehavior()), MAX_DEPTH),
-			choseBestTask(sptr(RecruitHeroBehavior()), 1),
 			choseBestTask(sptr(DefenceBehavior()), MAX_DEPTH),
-			choseBestTask(sptr(BuildingBehavior()), 1),
 			choseBestTask(sptr(GatherArmyBehavior()), MAX_DEPTH)
 		};
 
@@ -228,19 +249,25 @@ void Nullkiller::makeTurn()
 			bestTasks.push_back(choseBestTask(sptr(StartupBehavior()), 1));
 		}
 
-		Goals::TTask bestTask = choseBestTask(bestTasks);
+		bestTask = choseBestTask(bestTasks);
+
 		HeroPtr hero = bestTask->getHero();
+
+		HeroRole heroRole = HeroRole::MAIN;
+
+		if(hero.validAndSet())
+			heroRole = heroManager->getHeroRole(hero);
+
+		if(heroRole != HeroRole::MAIN || bestTask->getHeroExchangeCount() <= 1)
+			useHeroChain = false;
 
 		if(bestTask->priority < NEXT_SCAN_MIN_PRIORITY
 			&& scanDepth != ScanDepth::FULL)
 		{
-			HeroRole heroRole = HeroRole::MAIN;
-
-			if(hero.validAndSet())
-				heroRole = heroManager->getHeroRole(hero);
-
 			if(heroRole == HeroRole::MAIN || bestTask->priority < MIN_PRIORITY)
 			{
+				useHeroChain = false;
+
 				logAi->trace(
 					"Goal %s has too low priority %f so increasing scan depth",
 					bestTask->toString(),
@@ -258,26 +285,31 @@ void Nullkiller::makeTurn()
 			return;
 		}
 
-		std::string taskDescr = bestTask->toString();
+		executeTask(bestTask);
+	}
+}
 
-		boost::this_thread::interruption_point();
-		logAi->debug("Trying to realize %s (value %2.3f)", taskDescr, bestTask->priority);
+void Nullkiller::executeTask(Goals::TTask task)
+{
+	std::string taskDescr = task->toString();
 
-		try
-		{
-			bestTask->accept(ai.get());
-		}
-		catch(goalFulfilledException &)
-		{
-			logAi->trace("Task %s completed", bestTask->toString());
-		}
-		catch(std::exception & e)
-		{
-			logAi->debug("Failed to realize subgoal of type %s, I will stop.", taskDescr);
-			logAi->debug("The error message was: %s", e.what());
+	boost::this_thread::interruption_point();
+	logAi->debug("Trying to realize %s (value %2.3f)", taskDescr, task->priority);
 
-			return;
-		}
+	try
+	{
+		task->accept(ai.get());
+	}
+	catch(goalFulfilledException &)
+	{
+		logAi->trace("Task %s completed", task->toString());
+	}
+	catch(std::exception & e)
+	{
+		logAi->debug("Failed to realize subgoal of type %s, I will stop.", taskDescr);
+		logAi->debug("The error message was: %s", e.what());
+
+		throw;
 	}
 }
 

--- a/AI/Nullkiller/Engine/Nullkiller.h
+++ b/AI/Nullkiller/Engine/Nullkiller.h
@@ -51,6 +51,7 @@ private:
 	std::map<const CGHeroInstance *, HeroLockedReason> lockedHeroes;
 	ScanDepth scanDepth;
 	TResources lockedResources;
+	bool useHeroChain;
 
 public:
 	std::unique_ptr<DangerHitMapAnalyzer> dangerHitMap;
@@ -86,7 +87,8 @@ public:
 
 private:
 	void resetAiState();
-	void updateAiState(int pass);
+	void updateAiState(int pass, bool fast = false);
 	Goals::TTask choseBestTask(Goals::TSubgoal behavior, int decompositionMaxDepth) const;
 	Goals::TTask choseBestTask(Goals::TTaskVec & tasks) const;
+	void executeTask(Goals::TTask task);
 };

--- a/AI/Nullkiller/Goals/AbstractGoal.h
+++ b/AI/Nullkiller/Goals/AbstractGoal.h
@@ -162,6 +162,7 @@ namespace Goals
 		virtual std::string toString() const = 0;
 		virtual HeroPtr getHero() const = 0;
 		virtual ~ITask() {}
+		virtual int getHeroExchangeCount() const = 0;
 	};
 }
 

--- a/AI/Nullkiller/Goals/CGoal.h
+++ b/AI/Nullkiller/Goals/CGoal.h
@@ -90,6 +90,8 @@ namespace Goals
 		virtual bool isElementar() const override { return true; }
 
 		virtual HeroPtr getHero() const override { return AbstractGoal::hero; }
+
+		virtual int getHeroExchangeCount() const override { return 0; }
 	};
 
 	class DLL_EXPORT Invalid : public ElementarGoal<Invalid>

--- a/AI/Nullkiller/Goals/Composition.cpp
+++ b/AI/Nullkiller/Goals/Composition.cpp
@@ -73,3 +73,8 @@ bool Composition::isElementar() const
 {
 	return subtasks.back()->isElementar();
 }
+
+int Composition::getHeroExchangeCount() const
+{
+	return isElementar() ? taskptr(*subtasks.back())->getHeroExchangeCount() : 0;
+}

--- a/AI/Nullkiller/Goals/Composition.h
+++ b/AI/Nullkiller/Goals/Composition.h
@@ -36,5 +36,6 @@ namespace Goals
 		Composition & addNext(TSubgoal goal);
 		virtual TGoalVec decompose() const override;
 		virtual bool isElementar() const override;
+		virtual int getHeroExchangeCount() const override;
 	};
 }

--- a/AI/Nullkiller/Goals/ExecuteHeroChain.h
+++ b/AI/Nullkiller/Goals/ExecuteHeroChain.h
@@ -31,6 +31,8 @@ namespace Goals
 		virtual bool operator==(const ExecuteHeroChain & other) const override;
 		const AIPath & getPath() const { return chainPath; }
 
+		virtual int getHeroExchangeCount() const override { return chainPath.exchangeCount; }
+
 	private:
 		bool moveHeroToTile(const CGHeroInstance * hero, const int3 & tile);
 	};

--- a/AI/Nullkiller/Pathfinding/AINodeStorage.h
+++ b/AI/Nullkiller/Pathfinding/AINodeStorage.h
@@ -25,10 +25,16 @@
 
 namespace AIPathfinding
 {
-	const int BUCKET_COUNT = 11;
-	const int BUCKET_SIZE = GameConstants::MAX_HEROES_PER_PLAYER;
+#ifdef ENVIRONMENT64
+	const int BUCKET_COUNT = 7;
+#else
+	const int BUCKET_COUNT = 5;
+#endif // ENVIRONMENT64
+
+	const int BUCKET_SIZE = 5;
 	const int NUM_CHAINS = BUCKET_COUNT * BUCKET_SIZE;
 	const int THREAD_COUNT = 8;
+	const int CHAIN_MAX_DEPTH = 4;
 }
 
 struct AIPathNode : public CGPathNode
@@ -239,7 +245,14 @@ public:
 		return ((uintptr_t)actor * 395) % AIPathfinding::BUCKET_COUNT;
 	}
 
-
 	void calculateTownPortalTeleportations(std::vector<CGPathNode *> & neighbours);
 	void fillChainInfo(const AIPathNode * node, AIPath & path, int parentIndex) const;
+
+private:
+	template<class TVector>
+	void calculateTownPortal(
+		const ChainActor * actor,
+		const std::map<const CGHeroInstance *, int> & maskMap,
+		const std::vector<CGPathNode *> & initialNodes,
+		TVector & output);
 };

--- a/AI/Nullkiller/Pathfinding/Actors.cpp
+++ b/AI/Nullkiller/Pathfinding/Actors.cpp
@@ -275,6 +275,9 @@ ExchangeResult HeroExchangeMap::tryExchangeNoLock(const ChainActor * other)
 
 		if(!differentMasks) return result;
 
+		if(actor->allowSpellCast || other->allowSpellCast)
+			return result;
+
 		TResources resources = ai->cb->getResourceAmount();
 
 		if(!resources.canAfford(actor->armyCost + other->armyCost))


### PR DESCRIPTION
This branch has goal to reduce AI turn time by reducing hero chain usage. It is kind of experimental.
- fast tasks which does not affect (at least significantly) chain because they do not move heroes
- twice reduce storage size
- turn of hero chain at later stages of turn when scouts move mostly