### PR TITLE
Support rewardable objects

### DIFF
--- a/lib/mapObjects/CRewardableConstructor.cpp
+++ b/lib/mapObjects/CRewardableConstructor.cpp
@@ -111,16 +111,35 @@ void CRandomRewardObjectInfo::configureObject(CRewardableObject * object, CRando
 
 		info.message = loadMessage(reward["message"]);
 		info.selectChance = JsonRandom::loadValue(reward["selectChance"], rng);
+		
+		object->info.push_back(info);
 	}
 
 	object->onSelect  = loadMessage(parameters["onSelectMessage"]);
 	object->onVisited = loadMessage(parameters["onVisitedMessage"]);
 	object->onEmpty   = loadMessage(parameters["onEmptyMessage"]);
-
-	//TODO: visitMode and selectMode
-
 	object->resetDuration = static_cast<ui16>(parameters["resetDuration"].Float());
 	object->canRefuse = parameters["canRefuse"].Bool();
+	
+	auto visitMode = parameters["visitMode"].String();
+	for(int i = 0; Rewardable::VisitModeString.size(); ++i)
+	{
+		if(Rewardable::VisitModeString[i] == visitMode)
+		{
+			object->visitMode = i;
+			break;
+		}
+	}
+	
+	auto selectMode = parameters["selectMode"].String();
+	for(int i = 0; Rewardable::SelectModeString.size(); ++i)
+	{
+		if(Rewardable::SelectModeString[i] == selectMode)
+		{
+			object->selectMode = i;
+			break;
+		}
+	}	
 }
 
 bool CRandomRewardObjectInfo::givesResources() const
@@ -179,7 +198,6 @@ CRewardableConstructor::CRewardableConstructor()
 
 void CRewardableConstructor::initTypeData(const JsonNode & config)
 {
-	AObjectTypeHandler::init(config);
 	objectInfo.init(config);
 }
 

--- a/lib/mapObjects/CRewardableObject.cpp
+++ b/lib/mapObjects/CRewardableObject.cpp
@@ -446,6 +446,11 @@ void CRewardableObject::newTurn(CRandomGenerator & rand) const
 		triggerRewardReset();
 }
 
+void CRewardableObject::initObj(CRandomGenerator & rand)
+{
+	VLC->objtypeh->getHandlerFor(ID, subID)->configureObject(this, rand);
+}
+
 CRewardableObject::CRewardableObject():
 	selectMode(0),
 	visitMode(0),

--- a/lib/mapObjects/CRewardableObject.h
+++ b/lib/mapObjects/CRewardableObject.h
@@ -175,6 +175,12 @@ public:
 	}
 };
 
+namespace Rewardable
+{
+	const std::array<std::string, 3> SelectModeString{"selectFirst", "selectPlayer", "selectRandom"};
+	const std::array<std::string, 5> VisitModeString{"unlimited", "once", "hero", "bonus", "player"};
+}
+
 /// Base class that can handle granting rewards to visiting heroes.
 /// Inherits from CArmedInstance for proper trasfer of armies
 class DLL_LINKAGE CRewardableObject : public CArmedInstance
@@ -256,6 +262,8 @@ public:
 
 	/// function that will be called once reward is fully granted to hero
 	virtual void onRewardGiven(const CGHeroInstance * hero) const;
+	
+	void initObj(CRandomGenerator & rand) override;
 
 	CRewardableObject();
 


### PR DESCRIPTION
I realised that we have many objects from hota, which are not supported (warehouses, magic coliseum, etc.)

I found that we already have class and handler to support it, but unfortunately it didn't work from the box.
So here are small changes to make it possible.

How to test: extract files to "HotA decorations" submod and play map attached
[HotA decorations.zip](https://github.com/vcmi/vcmi/files/9569095/HotA.decorations.zip)
[test3.vmap.txt](https://github.com/vcmi/vcmi/files/9569102/test3.vmap.txt)
