### PR TITLE
Mod versioning in launcher [part 4]

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,22 @@
-0.99 -> 1.0
+1.0.0 -> 1.1.0
+
+GENERAL:
+* Mods and their versions and serialized into save files. Game checks mod compatibility before loading
+* Logs are stored in system default logs directory
+* LUA/ERM libs are not compiled by default
+* FFMpeg dependency is optional now
+
+MODS:
+* Supported rewardable objects customization
+* Battleground obstacles are extendable now with VLC mechanism
+* Introduced "compatibility" section into mods settings
+
+LAUNCHER:
+* Fixed problem with duplicated mods in the list
+* Launcher shows compatible mods only
+* Uninstall button was moved to the left of layout
+
+0.99 -> 1.0.0
 
 GENERAL:
 * Spectator mode was implemented through command-line options

--- a/launcher/modManager/cmodlist.cpp
+++ b/launcher/modManager/cmodlist.cpp
@@ -284,6 +284,15 @@ CModEntry CModList::getMod(QString modname) const
 		}
 	}
 
+	if(settings.value("active").toBool())
+	{
+		auto compatibility = local.value("compatibility").toMap();
+		if(compatibility["min"].isValid() || compatibility["max"].isValid())
+			if(!isCompatible(compatibility["min"].toString(), compatibility["max"].toString()))
+				settings["active"] = false;
+	}
+
+
 	for(auto entry : repositories)
 	{
 		QVariant repoVal = getValue(entry, path);

--- a/lib/GameConstants.cpp
+++ b/lib/GameConstants.cpp
@@ -52,7 +52,7 @@ const TeamID TeamID::NO_TEAM = TeamID(255);
 namespace GameConstants
 {
 	const int VCMI_VERSION_MAJOR = 1;
-	const int VCMI_VERSION_MINOR = 0;
+	const int VCMI_VERSION_MINOR = 1;
 	const int VCMI_VERSION_PATCH = 0;
 
 	const std::string VCMI_VERSION_STRING = std::to_string(VCMI_VERSION_MAJOR) + "." +


### PR DESCRIPTION
Scenarios:
 - launcher shows the last _compatible_ version available to download
 - launcher prevents incompatible mods from enabling

```
"compatibility":
{
  "min" : "1.0.0",
  "max" : "1.1.0"
}
```