### PR TITLE
Bulk swap artifacts

### DIFF
--- a/CCallback.cpp
+++ b/CCallback.cpp
@@ -183,7 +183,7 @@ bool CCallback::assembleArtifacts (const CGHeroInstance * hero, ArtifactPosition
 
 bool CCallback::bulkMoveArtifacts(ObjectInstanceID srcHero, ObjectInstanceID dstHero)
 {
-	BulkMoveArtifacts bma(srcHero, dstHero);
+	BulkExchangeArtifacts bma(srcHero, dstHero);
 	sendRequest(&bma);
 	return true;
 }

--- a/CCallback.cpp
+++ b/CCallback.cpp
@@ -181,6 +181,13 @@ bool CCallback::assembleArtifacts (const CGHeroInstance * hero, ArtifactPosition
 	return true;
 }
 
+bool CCallback::bulkMoveArtifacts(ObjectInstanceID srcHero, ObjectInstanceID dstHero)
+{
+	BulkMoveArtifacts bma(srcHero, dstHero);
+	sendRequest(&bma);
+	return true;
+}
+
 bool CCallback::buildBuilding(const CGTownInstance *town, BuildingID buildingID)
 {
 	if(town->tempOwner!=player)

--- a/CCallback.h
+++ b/CCallback.h
@@ -84,6 +84,9 @@ public:
 	virtual int bulkSplitStack(ObjectInstanceID armyId, SlotID srcSlot, int howMany = 1) = 0;
 	virtual int bulkSmartSplitStack(ObjectInstanceID armyId, SlotID srcSlot) = 0;
 	virtual int bulkMergeStacks(ObjectInstanceID armyId, SlotID srcSlot) = 0;
+
+	// Moves all artifacts from one hero to another
+	virtual bool bulkMoveArtifacts(ObjectInstanceID srcHero, ObjectInstanceID dstHero) = 0;
 };
 
 struct CPackForServer;
@@ -140,6 +143,7 @@ public:
 	bool dismissHero(const CGHeroInstance * hero) override;
 	bool swapArtifacts(const ArtifactLocation &l1, const ArtifactLocation &l2) override;
 	bool assembleArtifacts(const CGHeroInstance * hero, ArtifactPosition artifactSlot, bool assemble, ArtifactID assembleTo) override;
+	bool bulkMoveArtifacts(ObjectInstanceID srcHero, ObjectInstanceID dstHero) override;
 	bool buildBuilding(const CGTownInstance *town, BuildingID buildingID) override;
 	void recruitCreatures(const CGDwelling * obj, const CArmedInstance * dst, CreatureID ID, ui32 amount, si32 level=-1) override;
 	bool dismissCreature(const CArmedInstance *obj, SlotID stackPos) override;

--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -2582,6 +2582,9 @@ void CPlayerInterface::artifactMoved(const ArtifactLocation &src, const Artifact
 		if (artWin)
 			artWin->artifactMoved(src, dst);
 	}
+
+	GH.totalRedraw();
+
 	askToAssembleArtifact(dst);
 }
 

--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -2583,6 +2583,8 @@ void CPlayerInterface::artifactMoved(const ArtifactLocation &src, const Artifact
 			artWin->artifactMoved(src, dst);
 	}
 
+	// This needs to be called otherwise the artifacts don't get displayed until
+	// the window is closed and reopened
 	GH.totalRedraw();
 
 	askToAssembleArtifact(dst);

--- a/client/NetPacksClient.cpp
+++ b/client/NetPacksClient.cpp
@@ -279,6 +279,19 @@ void MoveArtifact::applyCl(CClient *cl)
 		callInterfaceIfPresent(cl, dst.owningPlayer(), &IGameEventsReceiver::artifactMoved, src, dst);
 }
 
+void BulkMoveArtifact::applyCl(CClient * cl)
+{
+	if (!artifacts.empty())
+	{
+		auto src = artifacts[0].src;
+		auto dst = artifacts[0].dst;
+		callInterfaceIfPresent(cl, src.owningPlayer(), &IGameEventsReceiver::artifactMoved, src, dst);
+
+		if (src.owningPlayer() != dst.owningPlayer())
+			callInterfaceIfPresent(cl, dst.owningPlayer(), &IGameEventsReceiver::artifactMoved, src, dst);
+	}
+}
+
 void AssembledArtifact::applyCl(CClient *cl)
 {
 	callInterfaceIfPresent(cl, al.owningPlayer(), &IGameEventsReceiver::artifactAssembled, al);

--- a/client/NetPacksClient.cpp
+++ b/client/NetPacksClient.cpp
@@ -281,10 +281,10 @@ void MoveArtifact::applyCl(CClient *cl)
 
 void BulkMoveArtifact::applyCl(CClient * cl)
 {
-	if (!artifacts.empty())
+	for (unsigned i = 0; i < artifacts.size(); ++i)
 	{
-		auto src = artifacts[0].src;
-		auto dst = artifacts[0].dst;
+		auto src = artifacts[i].src;
+		auto dst = artifacts[i].dst;
 		callInterfaceIfPresent(cl, src.owningPlayer(), &IGameEventsReceiver::artifactMoved, src, dst);
 
 		if (src.owningPlayer() != dst.owningPlayer())

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -902,15 +902,6 @@ std::vector<CArtifactInstance *> getBackpackArts(const CGHeroInstance * hero)
 	return result;
 }
 
-const std::vector<ArtifactPosition> unmovablePositions = {ArtifactPosition::SPELLBOOK, ArtifactPosition::MACH4};
-
-bool isArtRemovable(const std::pair<ArtifactPosition, ArtSlotInfo> & slot)
-{
-	return slot.second.artifact
-		&& !slot.second.locked
-		&& !vstd::contains(unmovablePositions, slot.first);
-}
-
 // Puts all composite arts to backpack and returns their previous location
 std::vector<HeroArtifact> CExchangeController::moveCompositeArtsToBackpack()
 {
@@ -942,7 +933,7 @@ void CExchangeController::swapArtifacts()
 {
 	for(int i = ArtifactPosition::HEAD; i < ArtifactPosition::AFTER_LAST; i++)
 	{
-		if(vstd::contains(unmovablePositions, i))
+		if(vstd::contains(CArtHandler::UNMOVABLE_POSITIONS, i))
 			continue;
 
 		swapArtifacts(ArtifactPosition(i));
@@ -1144,9 +1135,9 @@ void CExchangeController::moveArtifacts(bool leftToRight)
 
 	GsThread::run([=]
 	{	
-		while(vstd::contains_if(source->artifactsWorn, isArtRemovable))
+		while(vstd::contains_if(source->artifactsWorn, CArtHandler::isArtRemovable))
 		{
-			auto art = std::find_if(source->artifactsWorn.begin(), source->artifactsWorn.end(), isArtRemovable);
+			auto art = std::find_if(source->artifactsWorn.begin(), source->artifactsWorn.end(), CArtHandler::isArtRemovable);
 
 			moveArtifact(source, target, art->first);
 		}

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -933,7 +933,7 @@ void CExchangeController::swapArtifacts()
 {
 	for(int i = ArtifactPosition::HEAD; i < ArtifactPosition::AFTER_LAST; i++)
 	{
-		if(vstd::contains(CArtHandler::UNMOVABLE_POSITIONS, i))
+		if(vstd::contains(ArtifactUtils::unmovablePositions(), i))
 			continue;
 
 		swapArtifacts(ArtifactPosition(i));
@@ -1135,9 +1135,9 @@ void CExchangeController::moveArtifacts(bool leftToRight)
 
 	GsThread::run([=]
 	{	
-		while(vstd::contains_if(source->artifactsWorn, CArtHandler::isArtRemovable))
+		while(vstd::contains_if(source->artifactsWorn, ArtifactUtils::isArtRemovable))
 		{
-			auto art = std::find_if(source->artifactsWorn.begin(), source->artifactsWorn.end(), CArtHandler::isArtRemovable);
+			auto art = std::find_if(source->artifactsWorn.begin(), source->artifactsWorn.end(), ArtifactUtils::isArtRemovable);
 
 			moveArtifact(source, target, art->first);
 		}

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -1158,24 +1158,9 @@ void CExchangeController::moveArtifact(
 {
 	auto artifact = source->getArt(srcPosition);
 	auto srcLocation = ArtifactLocation(source, srcPosition);
+	auto dstLocation = ArtifactUtils::getArtifactDstLocation(source, target, srcPosition);
 
-	for(auto slot : artifact->artType->possibleSlots.at(target->bearerType()))
-	{
-		auto existingArtifact = target->getArt(slot);
-		auto existingArtInfo = target->getSlot(slot);
-		ArtifactLocation destLocation(target, slot);
-
-		if(!existingArtifact
-			&& (!existingArtInfo || !existingArtInfo->locked)
-			&& artifact->canBePutAt(destLocation))
-		{
-			cb->swapArtifacts(srcLocation, ArtifactLocation(target, slot));
-			
-			return;
-		}
-	}
-
-	cb->swapArtifacts(srcLocation, ArtifactLocation(target, ArtifactPosition(GameConstants::BACKPACK_START)));
+	cb->swapArtifacts(srcLocation, dstLocation);
 }
 
 CExchangeWindow::CExchangeWindow(ObjectInstanceID hero1, ObjectInstanceID hero2, QueryID queryID)

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -1143,7 +1143,7 @@ void CExchangeController::moveArtifact(
 {
 	auto artifact = source->getArt(srcPosition);
 	auto srcLocation = ArtifactLocation(source, srcPosition);
-	auto dstLocation = ArtifactUtils::getArtifactDstLocation(source, target, srcPosition);
+	auto dstLocation = ArtifactUtils::getArtifactDstLocation(source, target, srcPosition, {});
 
 	cb->swapArtifacts(srcLocation, dstLocation);
 }

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -1133,22 +1133,7 @@ void CExchangeController::moveArtifacts(bool leftToRight)
 		return;
 	}
 
-	GsThread::run([=]
-	{	
-		while(vstd::contains_if(source->artifactsWorn, ArtifactUtils::isArtRemovable))
-		{
-			auto art = std::find_if(source->artifactsWorn.begin(), source->artifactsWorn.end(), ArtifactUtils::isArtRemovable);
-
-			moveArtifact(source, target, art->first);
-		}
-
-		while(!source->artifactsInBackpack.empty())
-		{
-			moveArtifact(source, target, source->getArtPos(source->artifactsInBackpack.begin()->artifact));
-		}
-
-		view->redraw();
-	});
+	cb->bulkMoveArtifacts(source->id, target->id);
 }
 
 void CExchangeController::moveArtifact(

--- a/lib/CArtHandler.cpp
+++ b/lib/CArtHandler.cpp
@@ -1429,7 +1429,7 @@ void CArtifactSet::serializeJsonSlot(JsonSerializeFormat & handler, const Artifa
 	}
 }
 
-ArtifactLocation ArtifactUtils::getArtifactDstLocation(const CGHeroInstance * source, const CGHeroInstance * target, ArtifactPosition srcPosition, std::set<ArtifactPosition::EArtifactPosition> dstOccupiedSlots)
+ArtifactLocation ArtifactUtils::getArtifactDstLocation(const CGHeroInstance * source, const CGHeroInstance * target, ArtifactPosition srcPosition, const std::set<ArtifactPosition::EArtifactPosition> & dstOccupiedSlots)
 {
 	auto artifact = source->getArt(srcPosition);
 	auto srcLocation = ArtifactLocation(source, srcPosition);

--- a/lib/CArtHandler.cpp
+++ b/lib/CArtHandler.cpp
@@ -48,6 +48,8 @@
 	ART_POS(SHOULDERS)  \
 	ART_POS(HEAD)
 
+const std::vector<ArtifactPosition>CArtHandler::UNMOVABLE_POSITIONS = { ArtifactPosition::SPELLBOOK, ArtifactPosition::MACH4 };
+
 int32_t CArtifact::getIndex() const
 {
 	return id.toEnum();
@@ -711,6 +713,13 @@ void CArtHandler::afterLoadFinalization()
 		}
 	}
 	CBonusSystemNode::treeHasChanged();
+}
+
+bool CArtHandler::isArtRemovable(const std::pair<ArtifactPosition, ArtSlotInfo>& slot)
+{
+	return slot.second.artifact
+		&& !slot.second.locked
+		&& !vstd::contains(UNMOVABLE_POSITIONS, slot.first);
 }
 
 CArtifactInstance::CArtifactInstance()

--- a/lib/CArtHandler.cpp
+++ b/lib/CArtHandler.cpp
@@ -48,8 +48,6 @@
 	ART_POS(SHOULDERS)  \
 	ART_POS(HEAD)
 
-const std::vector<ArtifactPosition>CArtHandler::UNMOVABLE_POSITIONS = { ArtifactPosition::SPELLBOOK, ArtifactPosition::MACH4 };
-
 int32_t CArtifact::getIndex() const
 {
 	return id.toEnum();
@@ -713,13 +711,6 @@ void CArtHandler::afterLoadFinalization()
 		}
 	}
 	CBonusSystemNode::treeHasChanged();
-}
-
-bool CArtHandler::isArtRemovable(const std::pair<ArtifactPosition, ArtSlotInfo>& slot)
-{
-	return slot.second.artifact
-		&& !slot.second.locked
-		&& !vstd::contains(UNMOVABLE_POSITIONS, slot.first);
 }
 
 CArtifactInstance::CArtifactInstance()
@@ -1458,4 +1449,16 @@ ArtifactLocation ArtifactUtils::getArtifactDstLocation(const CGHeroInstance * so
 	}
 
 	return ArtifactLocation(target, ArtifactPosition(GameConstants::BACKPACK_START));
+}
+
+DLL_LINKAGE std::vector<ArtifactPosition> ArtifactUtils::unmovablePositions()
+{
+	return { ArtifactPosition::SPELLBOOK, ArtifactPosition::MACH4 };
+}
+
+DLL_LINKAGE bool ArtifactUtils::isArtRemovable(const std::pair<ArtifactPosition, ArtSlotInfo> & slot)
+{
+	return slot.second.artifact
+		&& !slot.second.locked
+		&& !vstd::contains(unmovablePositions(), slot.first);
 }

--- a/lib/CArtHandler.cpp
+++ b/lib/CArtHandler.cpp
@@ -1437,3 +1437,25 @@ void CArtifactSet::serializeJsonSlot(JsonSerializeFormat & handler, const Artifa
 		}
 	}
 }
+
+ArtifactLocation ArtifactUtils::getArtifactDstLocation(const CGHeroInstance * source, const CGHeroInstance * target, ArtifactPosition srcPosition)
+{
+	auto artifact = source->getArt(srcPosition);
+	auto srcLocation = ArtifactLocation(source, srcPosition);
+
+	for (auto slot : artifact->artType->possibleSlots.at(target->bearerType()))
+	{
+		auto existingArtifact = target->getArt(slot);
+		auto existingArtInfo = target->getSlot(slot);
+		ArtifactLocation destLocation(target, slot);
+
+		if (!existingArtifact
+			&& (!existingArtInfo || !existingArtInfo->locked)
+			&& artifact->canBePutAt(destLocation))
+		{
+			return ArtifactLocation(target, slot);
+		}
+	}
+
+	return ArtifactLocation(target, ArtifactPosition(GameConstants::BACKPACK_START));
+}

--- a/lib/CArtHandler.h
+++ b/lib/CArtHandler.h
@@ -362,7 +362,7 @@ private:
 namespace ArtifactUtils
 {
 	// Calculates where an artifact gets placed when it gets transferred from one hero to another.
-	DLL_LINKAGE ArtifactLocation getArtifactDstLocation(const CGHeroInstance * source, const CGHeroInstance * target, ArtifactPosition srcPosition);
+	DLL_LINKAGE ArtifactLocation getArtifactDstLocation(const CGHeroInstance * source, const CGHeroInstance * target, ArtifactPosition srcPosition, std::set<ArtifactPosition::EArtifactPosition> dstOccupiedSlots);
 	DLL_LINKAGE std::vector<ArtifactPosition> unmovablePositions();
 	DLL_LINKAGE bool isArtRemovable(const std::pair<ArtifactPosition, ArtSlotInfo> & slot);
 }

--- a/lib/CArtHandler.h
+++ b/lib/CArtHandler.h
@@ -252,8 +252,6 @@ public:
 	std::vector<CArtifact *> allowedArtifacts;
 	std::set<ArtifactID> growingArtifacts;
 
-	static const std::vector<ArtifactPosition> UNMOVABLE_POSITIONS;
-
 	void addBonuses(CArtifact *art, const JsonNode &bonusList);
 
 	void fillList(std::vector<CArtifact*> &listToBeFilled, CArtifact::EartClass artifactClass); //fills given empty list with allowed artifacts of given class. No side effects
@@ -283,8 +281,6 @@ public:
 	void afterLoadFinalization() override;
 
 	std::vector<bool> getDefaultAllowed() const override;
-
-	static bool isArtRemovable(const std::pair<ArtifactPosition, ArtSlotInfo>& slot);
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
@@ -367,4 +363,6 @@ namespace ArtifactUtils
 {
 	// Calculates where an artifact gets placed when it gets transferred from one hero to another.
 	DLL_LINKAGE ArtifactLocation getArtifactDstLocation(const CGHeroInstance * source, const CGHeroInstance * target, ArtifactPosition srcPosition);
+	DLL_LINKAGE std::vector<ArtifactPosition> unmovablePositions();
+	DLL_LINKAGE bool isArtRemovable(const std::pair<ArtifactPosition, ArtSlotInfo> & slot);
 }

--- a/lib/CArtHandler.h
+++ b/lib/CArtHandler.h
@@ -362,7 +362,7 @@ private:
 namespace ArtifactUtils
 {
 	// Calculates where an artifact gets placed when it gets transferred from one hero to another.
-	DLL_LINKAGE ArtifactLocation getArtifactDstLocation(const CGHeroInstance * source, const CGHeroInstance * target, ArtifactPosition srcPosition, std::set<ArtifactPosition::EArtifactPosition> dstOccupiedSlots);
+	DLL_LINKAGE ArtifactLocation getArtifactDstLocation(const CGHeroInstance * source, const CGHeroInstance * target, ArtifactPosition srcPosition, const std::set<ArtifactPosition::EArtifactPosition> & dstOccupiedSlots);
 	DLL_LINKAGE std::vector<ArtifactPosition> unmovablePositions(); // TODO: Make this constexpr when the toolset is upgraded
 	DLL_LINKAGE bool isArtRemovable(const std::pair<ArtifactPosition, ArtSlotInfo> & slot);
 }

--- a/lib/CArtHandler.h
+++ b/lib/CArtHandler.h
@@ -363,6 +363,6 @@ namespace ArtifactUtils
 {
 	// Calculates where an artifact gets placed when it gets transferred from one hero to another.
 	DLL_LINKAGE ArtifactLocation getArtifactDstLocation(const CGHeroInstance * source, const CGHeroInstance * target, ArtifactPosition srcPosition, std::set<ArtifactPosition::EArtifactPosition> dstOccupiedSlots);
-	DLL_LINKAGE std::vector<ArtifactPosition> unmovablePositions();
+	DLL_LINKAGE std::vector<ArtifactPosition> unmovablePositions(); // TODO: Make this constexpr when the toolset is upgraded
 	DLL_LINKAGE bool isArtRemovable(const std::pair<ArtifactPosition, ArtSlotInfo> & slot);
 }

--- a/lib/CArtHandler.h
+++ b/lib/CArtHandler.h
@@ -366,5 +366,5 @@ private:
 namespace ArtifactUtils
 {
 	// Calculates where an artifact gets placed when it gets transferred from one hero to another.
-	ArtifactLocation getArtifactDstLocation(const CGHeroInstance * source, const CGHeroInstance * target, ArtifactPosition srcPosition);
+	DLL_LINKAGE ArtifactLocation getArtifactDstLocation(const CGHeroInstance * source, const CGHeroInstance * target, ArtifactPosition srcPosition);
 }

--- a/lib/CArtHandler.h
+++ b/lib/CArtHandler.h
@@ -230,6 +230,20 @@ public:
 	}
 };
 
+struct DLL_LINKAGE ArtSlotInfo
+{
+	ConstTransitivePtr<CArtifactInstance> artifact;
+	ui8 locked; //if locked, then artifact points to the combined artifact
+
+	ArtSlotInfo() : locked(false) {}
+
+	template <typename Handler> void serialize(Handler& h, const int version)
+	{
+		h& artifact;
+		h& locked;
+	}
+};
+
 class DLL_LINKAGE CArtHandler : public CHandlerBase<ArtifactID, Artifact, CArtifact, ArtifactService>
 {
 public:
@@ -237,6 +251,8 @@ public:
 
 	std::vector<CArtifact *> allowedArtifacts;
 	std::set<ArtifactID> growingArtifacts;
+
+	static const std::vector<ArtifactPosition> UNMOVABLE_POSITIONS;
 
 	void addBonuses(CArtifact *art, const JsonNode &bonusList);
 
@@ -268,6 +284,8 @@ public:
 
 	std::vector<bool> getDefaultAllowed() const override;
 
+	static bool isArtRemovable(const std::pair<ArtifactPosition, ArtSlotInfo>& slot);
+
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
 		h & objects;
@@ -293,20 +311,6 @@ private:
 	void loadGrowingArt(CGrowingArtifact * art, const JsonNode & node);
 
 	void erasePickedArt(ArtifactID id);
-};
-
-struct DLL_LINKAGE ArtSlotInfo
-{
-	ConstTransitivePtr<CArtifactInstance> artifact;
-	ui8 locked; //if locked, then artifact points to the combined artifact
-
-	ArtSlotInfo() : locked(false) {}
-
-	template <typename Handler> void serialize(Handler &h, const int version)
-	{
-		h & artifact;
-		h & locked;
-	}
 };
 
 class DLL_LINKAGE CArtifactSet

--- a/lib/CArtHandler.h
+++ b/lib/CArtHandler.h
@@ -230,20 +230,6 @@ public:
 	}
 };
 
-struct DLL_LINKAGE ArtSlotInfo
-{
-	ConstTransitivePtr<CArtifactInstance> artifact;
-	ui8 locked; //if locked, then artifact points to the combined artifact
-
-	ArtSlotInfo() : locked(false) {}
-
-	template <typename Handler> void serialize(Handler& h, const int version)
-	{
-		h& artifact;
-		h& locked;
-	}
-};
-
 class DLL_LINKAGE CArtHandler : public CHandlerBase<ArtifactID, Artifact, CArtifact, ArtifactService>
 {
 public:
@@ -307,6 +293,20 @@ private:
 	void loadGrowingArt(CGrowingArtifact * art, const JsonNode & node);
 
 	void erasePickedArt(ArtifactID id);
+};
+
+struct DLL_LINKAGE ArtSlotInfo
+{
+	ConstTransitivePtr<CArtifactInstance> artifact;
+	ui8 locked; //if locked, then artifact points to the combined artifact
+
+	ArtSlotInfo() : locked(false) {}
+
+	template <typename Handler> void serialize(Handler & h, const int version)
+	{
+		h & artifact;
+		h & locked;
+	}
 };
 
 class DLL_LINKAGE CArtifactSet

--- a/lib/CArtHandler.h
+++ b/lib/CArtHandler.h
@@ -362,3 +362,9 @@ private:
 
 	void serializeJsonSlot(JsonSerializeFormat & handler, const ArtifactPosition & slot, CMap * map);//normal slots
 };
+
+namespace ArtifactUtils
+{
+	// Calculates where an artifact gets placed when it gets transferred from one hero to another.
+	ArtifactLocation getArtifactDstLocation(const CGHeroInstance * source, const CGHeroInstance * target, ArtifactPosition srcPosition);
+}

--- a/lib/IGameEventsReceiver.h
+++ b/lib/IGameEventsReceiver.h
@@ -89,6 +89,7 @@ public:
 	virtual void artifactAssembled(const ArtifactLocation &al){};
 	virtual void artifactDisassembled(const ArtifactLocation &al){};
 	virtual void artifactMoved(const ArtifactLocation &src, const ArtifactLocation &dst){};
+	virtual void bulkMoveArtifact(ObjectInstanceID srcHero, ObjectInstanceID dstHero){};
 
 	virtual void heroVisit(const CGHeroInstance *visitor, const CGObjectInstance *visitedObj, bool start){};
 	virtual void heroCreated(const CGHeroInstance*){};

--- a/lib/NetPacks.h
+++ b/lib/NetPacks.h
@@ -2179,6 +2179,25 @@ struct ExchangeArtifacts : public CPackForServer
 	}
 };
 
+struct BulkMoveArtifacts : public CPackForServer
+{
+	ObjectInstanceID srcHero;
+	ObjectInstanceID dstHero;
+
+	BulkMoveArtifacts() = default;
+
+	BulkMoveArtifacts(ObjectInstanceID srcHero, ObjectInstanceID dstHero) : srcHero(srcHero), dstHero(dstHero)
+	{}
+
+	bool applyGh(CGameHandler* gh);
+	template <typename Handler> void serialize(Handler& h, const int version)
+	{
+		h & static_cast<CPackForServer&>(*this);
+		h & srcHero;
+		h & dstHero;
+	}
+};
+
 struct AssembleArtifacts : public CPackForServer
 {
 	AssembleArtifacts():assemble(false){};

--- a/lib/NetPacks.h
+++ b/lib/NetPacks.h
@@ -988,6 +988,19 @@ struct MoveArtifact : CArtifactOperationPack
 	}
 };
 
+struct BulkMoveArtifact : CArtifactOperationPack
+{
+	std::vector<MoveArtifact> artifacts;
+
+	void applyCl(CClient * cl);
+	DLL_LINKAGE void applyGs(CGameState * gs);
+
+	template <typename Handler> void serialize(Handler & h, const int version)
+	{
+		h & artifacts;
+	}
+};
+
 struct AssembledArtifact : CArtifactOperationPack
 {
 	ArtifactLocation al; //where assembly will be put
@@ -2179,14 +2192,14 @@ struct ExchangeArtifacts : public CPackForServer
 	}
 };
 
-struct BulkMoveArtifacts : public CPackForServer
+struct BulkExchangeArtifacts : public CPackForServer
 {
 	ObjectInstanceID srcHero;
 	ObjectInstanceID dstHero;
 
-	BulkMoveArtifacts() = default;
+	BulkExchangeArtifacts() = default;
 
-	BulkMoveArtifacts(ObjectInstanceID srcHero, ObjectInstanceID dstHero) : srcHero(srcHero), dstHero(dstHero)
+	BulkExchangeArtifacts(ObjectInstanceID srcHero, ObjectInstanceID dstHero) : srcHero(srcHero), dstHero(dstHero)
 	{}
 
 	bool applyGh(CGameHandler* gh);

--- a/lib/NetPacksLib.cpp
+++ b/lib/NetPacksLib.cpp
@@ -1101,8 +1101,24 @@ DLL_LINKAGE void MoveArtifact::applyGs(CGameState *gs)
 
 DLL_LINKAGE void BulkMoveArtifact::applyGs(CGameState * gs)
 {
+	int numBackpackArtifactsMoved = 0;
 	for (auto & artifact : artifacts)
+	{
+		// When an object gets removed from the backpack, the backpack shrinks
+		// so all the following indices will be affected. Thus, we need to update
+		// the subsequent artifact slots to account for that
+		if (artifact.src.slot >= GameConstants::BACKPACK_START)
+		{
+			artifact.src.slot = ArtifactPosition(artifact.src.slot.num - numBackpackArtifactsMoved);
+		}
+
 		artifact.applyGs(gs);
+
+		if (artifact.src.slot >= GameConstants::BACKPACK_START)
+		{
+			numBackpackArtifactsMoved++;
+		}
+	}
 }
 
 DLL_LINKAGE void AssembledArtifact::applyGs(CGameState *gs)

--- a/lib/NetPacksLib.cpp
+++ b/lib/NetPacksLib.cpp
@@ -1099,6 +1099,12 @@ DLL_LINKAGE void MoveArtifact::applyGs(CGameState *gs)
 	}
 }
 
+DLL_LINKAGE void BulkMoveArtifact::applyGs(CGameState * gs)
+{
+	for (auto & artifact : artifacts)
+		artifact.applyGs(gs);
+}
+
 DLL_LINKAGE void AssembledArtifact::applyGs(CGameState *gs)
 {
 	CArtifactSet *artSet = al.getHolderArtSet();

--- a/lib/registerTypes/RegisterTypes.h
+++ b/lib/registerTypes/RegisterTypes.h
@@ -355,7 +355,7 @@ void registerTypesServerPacks(Serializer &s)
 	s.template registerType<CPackForServer, BulkMergeStacks>();
 	s.template registerType<CPackForServer, BulkSmartSplitStack>();
 	s.template registerType<CPackForServer, BulkMoveArmy>();
-	s.template registerType<CPackForServer, BulkMoveArtifacts>();
+	s.template registerType<CPackForServer, BulkExchangeArtifacts>();
 }
 
 template<typename Serializer>

--- a/lib/registerTypes/RegisterTypes.h
+++ b/lib/registerTypes/RegisterTypes.h
@@ -316,6 +316,7 @@ void registerTypesClientPacks2(Serializer &s)
 	s.template registerType<CArtifactOperationPack, MoveArtifact>();
 	s.template registerType<CArtifactOperationPack, AssembledArtifact>();
 	s.template registerType<CArtifactOperationPack, DisassembledArtifact>();
+	s.template registerType<CArtifactOperationPack, BulkMoveArtifact>();
 
 	s.template registerType<CPackForClient, SaveGameClient>();
 	s.template registerType<CPackForClient, PlayerMessageClient>();

--- a/lib/registerTypes/RegisterTypes.h
+++ b/lib/registerTypes/RegisterTypes.h
@@ -355,6 +355,7 @@ void registerTypesServerPacks(Serializer &s)
 	s.template registerType<CPackForServer, BulkMergeStacks>();
 	s.template registerType<CPackForServer, BulkSmartSplitStack>();
 	s.template registerType<CPackForServer, BulkMoveArmy>();
+	s.template registerType<CPackForServer, BulkMoveArtifacts>();
 }
 
 template<typename Serializer>

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -63,7 +63,7 @@
 #define COMPLAIN_RET_FALSE_IF(cond, txt) do {if (cond){complain(txt); return false;}} while(0)
 #define COMPLAIN_RET(txt) {complain(txt); return false;}
 #define COMPLAIN_RETF(txt, FORMAT) {complain(boost::str(boost::format(txt) % FORMAT)); return false;}
-#define COMPLAIN_RET_OPT_NONE(txt) { complain(txt); return {}; }
+#define COMPLAIN_RET_OPT_NONE(txt) { complain(txt); return boost::none; }
 
 class ServerSpellCastEnvironment : public SpellCastEnvironment
 {
@@ -3881,7 +3881,7 @@ boost::optional<MoveArtifact> CGameHandler::calcArtifactDst(const ArtifactLocati
 
 // With the amount of changes done to the function, it's more like transferArtifacts.
 // Function moves artifact from src to dst. If dst is not a backpack and is already occupied, old dst art goes to backpack and is replaced.
-bool CGameHandler::moveArtifactImpl(const ArtifactLocation & al1, const ArtifactLocation & al2, std::vector<MoveArtifact> * artifactsToMove)
+bool CGameHandler::moveArtifactInternal(const ArtifactLocation & al1, const ArtifactLocation & al2, std::vector<MoveArtifact> * artifactsToMove)
 {
 	auto ma = calcArtifactDst(al1, al2);
 
@@ -3915,7 +3915,7 @@ bool CGameHandler::moveArtifact(const ArtifactLocation &al1, const ArtifactLocat
 	ArtifactLocation src = al1, dst = al2;
 
 	std::vector<MoveArtifact> artifacts;
-	if (!moveArtifactImpl(src, dst, &artifacts))
+	if (!moveArtifactInternal(src, dst, &artifacts))
 		COMPLAIN_RET("Unable to move artifact");
 
 	BulkMoveArtifact bma;
@@ -3951,7 +3951,7 @@ bool CGameHandler::bulkMoveArtifacts(ObjectInstanceID srcHero, ObjectInstanceID 
 			std::tie(srcLocation, dstLocation) = getArtSrcDst(psrcHero, pdstHero, it->first);
 			dstOccupiedSlots.insert(dstLocation.slot.num);
 
-			moveArtifactImpl(srcLocation, dstLocation, &artifacts);
+			moveArtifactInternal(srcLocation, dstLocation, &artifacts);
 		}
 	}
 
@@ -3962,7 +3962,7 @@ bool CGameHandler::bulkMoveArtifacts(ObjectInstanceID srcHero, ObjectInstanceID 
 		std::tie(srcLocation, dstLocation) = getArtSrcDst(psrcHero, pdstHero, psrcHero->getArtPos(it->artifact));
 		dstOccupiedSlots.insert(dstLocation.slot.num);
 
-		moveArtifactImpl(srcLocation, dstLocation, &artifacts);
+		moveArtifactInternal(srcLocation, dstLocation, &artifacts);
 	}
 
 	BulkMoveArtifact bma;

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -3885,6 +3885,11 @@ bool CGameHandler::moveArtifact(const ArtifactLocation &al1, const ArtifactLocat
 	return true;
 }
 
+bool CGameHandler::bulkMoveArtifacts(ObjectInstanceID srcHero, ObjectInstanceID dstHero)
+{
+	return true;
+}
+
 /**
  * Assembles or disassembles a combination artifact.
  * @param heroID ID of hero holding the artifact(s).

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -3904,7 +3904,9 @@ bool CGameHandler::moveArtifactImpl(const ArtifactLocation & al1, const Artifact
 	}
 
 	artifactsToMove->push_back(*ma);
-	artifactsToMove->push_back(*ma2);
+
+	if(ma2)
+		artifactsToMove->push_back(*ma2);
 
 	return true;
 }
@@ -3979,6 +3981,7 @@ bool CGameHandler::bulkMoveArtifacts(ObjectInstanceID srcHero, ObjectInstanceID 
 		return std::make_pair(srcLocation, dstLocation);
 	};
 
+	// Move over artifacts that are worn
 	for (auto it = psrcHero->artifactsWorn.begin(); it != psrcHero->artifactsWorn.end(); it++)
 	{
 		if (ArtifactUtils::isArtRemovable(*it))
@@ -3991,6 +3994,7 @@ bool CGameHandler::bulkMoveArtifacts(ObjectInstanceID srcHero, ObjectInstanceID 
 		}
 	}
 
+	// Move over artifacts that are in backpack
 	for (auto it = psrcHero->artifactsInBackpack.begin(); it != psrcHero->artifactsInBackpack.end(); it++)
 	{
 		// TODO-C++17: replace with structured bindings

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -3930,13 +3930,14 @@ bool CGameHandler::bulkMoveArtifacts(ObjectInstanceID srcHero, ObjectInstanceID 
 	const CGHeroInstance * pdstHero = getHero(dstHero);
 
 	std::vector<MoveArtifact> artifacts;
+
+	// keep track of slots that are filled, otherwise we get repeats
 	std::set<ArtifactPosition::EArtifactPosition> dstOccupiedSlots;
 
 	// Gets the source location and dest location of an artifact
-	auto getArtSrcDst = [&dstOccupiedSlots](const CGHeroInstance * psrcHero, const CGHeroInstance * pdstHero, ArtifactPosition artSrcPos) -> auto{
+	auto getArtSrcDst = [&dstOccupiedSlots](const CGHeroInstance * psrcHero, const CGHeroInstance * pdstHero, ArtifactPosition artSrcPos) -> auto {
 		auto artifact = psrcHero->getArt(artSrcPos);
 		auto srcLocation = ArtifactLocation(psrcHero, artSrcPos);
-		// TODO: add map of slots that are filled, otherwise we get repeats
 		auto dstLocation = ArtifactUtils::getArtifactDstLocation(psrcHero, pdstHero, artSrcPos, dstOccupiedSlots);
 
 		return std::make_pair(srcLocation, dstLocation);
@@ -3947,7 +3948,6 @@ bool CGameHandler::bulkMoveArtifacts(ObjectInstanceID srcHero, ObjectInstanceID 
 	{
 		if (ArtifactUtils::isArtRemovable(*it))
 		{
-			// TODO-C++17: replace with structured bindings
 			ArtifactLocation srcLocation, dstLocation;
 			std::tie(srcLocation, dstLocation) = getArtSrcDst(psrcHero, pdstHero, it->first);
 			dstOccupiedSlots.insert(dstLocation.slot.num);
@@ -3959,9 +3959,9 @@ bool CGameHandler::bulkMoveArtifacts(ObjectInstanceID srcHero, ObjectInstanceID 
 	// Move over artifacts that are in backpack
 	for (auto it = psrcHero->artifactsInBackpack.begin(); it != psrcHero->artifactsInBackpack.end(); it++)
 	{
-		// TODO-C++17: replace with structured bindings
 		ArtifactLocation srcLocation, dstLocation;
 		std::tie(srcLocation, dstLocation) = getArtSrcDst(psrcHero, pdstHero, psrcHero->getArtPos(it->artifact));
+		dstOccupiedSlots.insert(dstLocation.slot.num);
 
 		moveArtifactImpl(srcLocation, dstLocation, &artifacts);
 	}

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -3930,12 +3930,14 @@ bool CGameHandler::bulkMoveArtifacts(ObjectInstanceID srcHero, ObjectInstanceID 
 	const CGHeroInstance * pdstHero = getHero(dstHero);
 
 	std::vector<MoveArtifact> artifacts;
+	std::set<ArtifactPosition::EArtifactPosition> dstOccupiedSlots;
 
 	// Gets the source location and dest location of an artifact
-	auto getArtSrcDst = [](const CGHeroInstance * psrcHero, const CGHeroInstance * pdstHero, ArtifactPosition artSrcPos) -> auto{
+	auto getArtSrcDst = [&dstOccupiedSlots](const CGHeroInstance * psrcHero, const CGHeroInstance * pdstHero, ArtifactPosition artSrcPos) -> auto{
 		auto artifact = psrcHero->getArt(artSrcPos);
 		auto srcLocation = ArtifactLocation(psrcHero, artSrcPos);
-		auto dstLocation = ArtifactUtils::getArtifactDstLocation(psrcHero, pdstHero, artSrcPos);
+		// TODO: add map of slots that are filled, otherwise we get repeats
+		auto dstLocation = ArtifactUtils::getArtifactDstLocation(psrcHero, pdstHero, artSrcPos, dstOccupiedSlots);
 
 		return std::make_pair(srcLocation, dstLocation);
 	};
@@ -3948,6 +3950,7 @@ bool CGameHandler::bulkMoveArtifacts(ObjectInstanceID srcHero, ObjectInstanceID 
 			// TODO-C++17: replace with structured bindings
 			ArtifactLocation srcLocation, dstLocation;
 			std::tie(srcLocation, dstLocation) = getArtSrcDst(psrcHero, pdstHero, it->first);
+			dstOccupiedSlots.insert(dstLocation.slot.num);
 
 			moveArtifactImpl(srcLocation, dstLocation, &artifacts);
 		}

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -3876,7 +3876,7 @@ boost::optional<MoveArtifact> CGameHandler::calcArtifactDst(const ArtifactLocati
 	ma.src = src;
 	ma.dst = dst;
 
-	return { ma };
+	return boost::make_optional(ma);
 }
 
 // With the amount of changes done to the function, it's more like transferArtifacts.
@@ -3936,7 +3936,6 @@ bool CGameHandler::bulkMoveArtifacts(ObjectInstanceID srcHero, ObjectInstanceID 
 
 	// Gets the source location and dest location of an artifact
 	auto getArtSrcDst = [&dstOccupiedSlots](const CGHeroInstance * psrcHero, const CGHeroInstance * pdstHero, ArtifactPosition artSrcPos) -> auto {
-		auto artifact = psrcHero->getArt(artSrcPos);
 		auto srcLocation = ArtifactLocation(psrcHero, artSrcPos);
 		auto dstLocation = ArtifactUtils::getArtifactDstLocation(psrcHero, pdstHero, artSrcPos, dstOccupiedSlots);
 

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -3830,6 +3830,12 @@ bool CGameHandler::garrisonSwap(ObjectInstanceID tid)
 
 // With the amount of changes done to the function, it's more like transferArtifacts.
 // Function moves artifact from src to dst. If dst is not a backpack and is already occupied, old dst art goes to backpack and is replaced.
+bool CGameHandler::moveArtifactImpl(const ArtifactLocation & al1, const ArtifactLocation & al2)
+{
+
+	return true;
+}
+
 bool CGameHandler::moveArtifact(const ArtifactLocation &al1, const ArtifactLocation &al2)
 {
 	ArtifactLocation src = al1, dst = al2;
@@ -3887,6 +3893,22 @@ bool CGameHandler::moveArtifact(const ArtifactLocation &al1, const ArtifactLocat
 
 bool CGameHandler::bulkMoveArtifacts(ObjectInstanceID srcHero, ObjectInstanceID dstHero)
 {
+	const CGHeroInstance * psrcHero = getHero(srcHero);
+	const CGHeroInstance * pdstHero = getHero(dstHero);
+
+	while (vstd::contains_if(psrcHero->artifactsWorn, CArtHandler::isArtRemovable))
+	{
+		auto art = std::find_if(psrcHero->artifactsWorn.begin(), psrcHero->artifactsWorn.end(), CArtHandler::isArtRemovable);
+		auto artSrcPos = art->first;
+
+		auto artifact = psrcHero->getArt(artSrcPos);
+		auto srcLocation = ArtifactLocation(psrcHero, artSrcPos);
+		auto dstLocation = ArtifactUtils::getArtifactDstLocation(psrcHero, pdstHero, artSrcPos);
+
+
+
+	}
+
 	return true;
 }
 

--- a/server/CGameHandler.h
+++ b/server/CGameHandler.h
@@ -173,6 +173,7 @@ public:
 	void putArtifact(const ArtifactLocation &al, const CArtifactInstance *a) override;
 	void removeArtifact(const ArtifactLocation &al) override;
 	bool moveArtifact(const ArtifactLocation &al1, const ArtifactLocation &al2) override;
+	bool bulkMoveArtifacts(ObjectInstanceID srcHero, ObjectInstanceID dstHero);
 	void synchronizeArtifactHandlerLists();
 
 	void showCompInfo(ShowInInfobox * comp) override;

--- a/server/CGameHandler.h
+++ b/server/CGameHandler.h
@@ -346,7 +346,7 @@ private:
 	void checkVictoryLossConditions(const std::set<PlayerColor> & playerColors);
 	void checkVictoryLossConditionsForAll();
 
-	bool moveArtifactImpl(const ArtifactLocation & al1, const ArtifactLocation & al2);
+	boost::optional<MoveArtifact> moveArtifactImpl(const ArtifactLocation & al1, const ArtifactLocation & al2);
 
 	const std::string complainNoCreatures;
 	const std::string complainNotEnoughCreatures;

--- a/server/CGameHandler.h
+++ b/server/CGameHandler.h
@@ -346,7 +346,7 @@ private:
 	void checkVictoryLossConditions(const std::set<PlayerColor> & playerColors);
 	void checkVictoryLossConditionsForAll();
 
-	bool moveArtifactImpl(const ArtifactLocation & al1, const ArtifactLocation & al2, std::vector<MoveArtifact> * artifactsToMove);
+	bool moveArtifactInternal(const ArtifactLocation & al1, const ArtifactLocation & al2, std::vector<MoveArtifact> * artifactsToMove);
 	boost::optional<MoveArtifact> calcArtifactDst(const ArtifactLocation & al1, const ArtifactLocation & al2);
 
 	const std::string complainNoCreatures;

--- a/server/CGameHandler.h
+++ b/server/CGameHandler.h
@@ -346,6 +346,8 @@ private:
 	void checkVictoryLossConditions(const std::set<PlayerColor> & playerColors);
 	void checkVictoryLossConditionsForAll();
 
+	bool moveArtifactImpl(const ArtifactLocation & al1, const ArtifactLocation & al2);
+
 	const std::string complainNoCreatures;
 	const std::string complainNotEnoughCreatures;
 	const std::string complainInvalidSlot;

--- a/server/CGameHandler.h
+++ b/server/CGameHandler.h
@@ -346,7 +346,8 @@ private:
 	void checkVictoryLossConditions(const std::set<PlayerColor> & playerColors);
 	void checkVictoryLossConditionsForAll();
 
-	boost::optional<MoveArtifact> moveArtifactImpl(const ArtifactLocation & al1, const ArtifactLocation & al2);
+	bool moveArtifactImpl(const ArtifactLocation & al1, const ArtifactLocation & al2, std::vector<MoveArtifact> * artifactsToMove);
+	boost::optional<MoveArtifact> calcArtifactDst(const ArtifactLocation & al1, const ArtifactLocation & al2);
 
 	const std::string complainNoCreatures;
 	const std::string complainNotEnoughCreatures;

--- a/server/CQuery.cpp
+++ b/server/CQuery.cpp
@@ -368,6 +368,10 @@ bool CGarrisonDialogQuery::blocksPack(const CPack * pack) const
 				return true;
 		return false;
 	}
+
+	if (auto arts = dynamic_ptr_cast<BulkExchangeArtifacts>(pack))
+		return !vstd::contains(ourIds, arts->srcHero) || !vstd::contains(ourIds, arts->dstHero);
+
 	if(auto dismiss = dynamic_ptr_cast<DisbandCreature>(pack))
 		return !vstd::contains(ourIds, dismiss->id);
 

--- a/server/NetPacksServer.cpp
+++ b/server/NetPacksServer.cpp
@@ -180,6 +180,13 @@ bool ExchangeArtifacts::applyGh(CGameHandler * gh)
 	return gh->moveArtifact(src, dst);
 }
 
+bool BulkMoveArtifacts::applyGh(CGameHandler* gh)
+{
+	const CGHeroInstance* pHeroSrc = gh->getHero(srcHero);
+	throwOnWrongPlayer(gh, pHeroSrc->getOwner());
+	return gh->bulkMoveArtifacts(srcHero, dstHero);
+}
+
 bool AssembleArtifacts::applyGh(CGameHandler * gh)
 {
 	throwOnWrongOwner(gh, heroID);

--- a/server/NetPacksServer.cpp
+++ b/server/NetPacksServer.cpp
@@ -180,10 +180,10 @@ bool ExchangeArtifacts::applyGh(CGameHandler * gh)
 	return gh->moveArtifact(src, dst);
 }
 
-bool BulkMoveArtifacts::applyGh(CGameHandler* gh)
+bool BulkExchangeArtifacts::applyGh(CGameHandler* gh)
 {
-	const CGHeroInstance* pHeroSrc = gh->getHero(srcHero);
-	throwOnWrongPlayer(gh, pHeroSrc->getOwner());
+	const CGHeroInstance* pSrcHero = gh->getHero(srcHero);
+	throwOnWrongPlayer(gh, pSrcHero->getOwner());
 	return gh->bulkMoveArtifacts(srcHero, dstHero);
 }
 


### PR DESCRIPTION
Implements bulk swapping artifacts in a single packet to optimize this operation, like `BulkMoveArmy` does for transferring stacks. Most of the implementation was based on that, and the existing `MoveArtifact` stuff. This tries to reuse as much of the existing `MoveArtifact` stuff as possible, and some refactoring was done to achieve that.

The biggest difference is that a set of the destination of the transferred needs to be kept while building up the list of destinations. This needs to be done because the changes don't register until the clients have been notified of the changes.