### PR TITLE
#913 fix artifact assembling check

### DIFF
--- a/lib/CArtHandler.cpp
+++ b/lib/CArtHandler.cpp
@@ -881,7 +881,10 @@ std::vector<const CArtifact *> CArtifactInstance::assemblyPossibilities(const CA
 
 		for(const CArtifact * constituent : *artifact->constituents) //check if all constituents are available
 		{
-			if(!h->hasArt(constituent->id, true)) //constituent must be equipped
+			const bool noBackpack = false;
+			const bool notAlreadyAssembled = false;
+
+			if(!h->hasArt(constituent->id, true, noBackpack, notAlreadyAssembled)) //constituent must be equipped
 			{
 				possible = false;
 				break;
@@ -1184,10 +1187,10 @@ CArtifactInstance* CArtifactSet::getArt(ArtifactPosition pos, bool excludeLocked
 	return const_cast<CArtifactInstance*>((const_cast<const CArtifactSet*>(this))->getArt(pos, excludeLocked));
 }
 
-ArtifactPosition CArtifactSet::getArtPos(int aid, bool onlyWorn) const
+ArtifactPosition CArtifactSet::getArtPos(int aid, bool onlyWorn, bool allowLocked) const
 {
 	for(auto i = artifactsWorn.cbegin(); i != artifactsWorn.cend(); i++)
-		if(i->second.artifact->artType->id == aid)
+		if(i->second.artifact->artType->id == aid && (allowLocked || !i->second.locked))
 			return i->first;
 
 	if(onlyWorn)
@@ -1226,10 +1229,13 @@ const CArtifactInstance * CArtifactSet::getArtByInstanceId( ArtifactInstanceID a
 	return nullptr;
 }
 
-bool CArtifactSet::hasArt(ui32 aid, bool onlyWorn,
-                          bool searchBackpackAssemblies) const
+bool CArtifactSet::hasArt(
+	ui32 aid,
+	bool onlyWorn,
+    bool searchBackpackAssemblies,
+	bool allowLocked) const
 {
-	return getArtPos(aid, onlyWorn) != ArtifactPosition::PRE_FIRST ||
+	return getArtPos(aid, onlyWorn, allowLocked) != ArtifactPosition::PRE_FIRST ||
 	       (searchBackpackAssemblies && getHiddenArt(aid));
 }
 

--- a/lib/CArtHandler.h
+++ b/lib/CArtHandler.h
@@ -324,14 +324,14 @@ public:
 	CArtifactInstance* getArt(ArtifactPosition pos, bool excludeLocked = true); //nullptr - no artifact
 	/// Looks for equipped artifact with given ID and returns its slot ID or -1 if none
 	/// (if more than one such artifact lower ID is returned)
-	ArtifactPosition getArtPos(int aid, bool onlyWorn = true) const;
+	ArtifactPosition getArtPos(int aid, bool onlyWorn = true, bool allowLocked = true) const;
 	ArtifactPosition getArtPos(const CArtifactInstance *art) const;
 	const CArtifactInstance *getArtByInstanceId(ArtifactInstanceID artInstId) const;
 	/// Search for constituents of assemblies in backpack which do not have an ArtifactPosition
 	const CArtifactInstance *getHiddenArt(int aid) const;
 	const CCombinedArtifactInstance *getAssemblyByConstituent(int aid) const;
 	/// Checks if hero possess artifact of given id (either in backack or worn)
-	bool hasArt(ui32 aid, bool onlyWorn = false, bool searchBackpackAssemblies = false) const;
+	bool hasArt(ui32 aid, bool onlyWorn = false, bool searchBackpackAssemblies = false, bool allowLocked = true) const;
 	bool isPositionFree(ArtifactPosition pos, bool onlyLockCheck = false) const;
 
 	virtual ArtBearer::ArtBearer bearerType() const = 0;


### PR DESCRIPTION
Artefact assembly check only checks that hero wears required artifacts but not if they are already a part of another assembly, e.g. locked