### PR TITLE
make FFmpeg dependency optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -226,7 +226,7 @@ if(TARGET zlib::zlib)
 	add_library(ZLIB::ZLIB ALIAS zlib::zlib)
 endif()
 
-find_package(ffmpeg REQUIRED COMPONENTS avutil swscale avformat avcodec)
+find_package(ffmpeg COMPONENTS avutil swscale avformat avcodec)
 option(FORCE_BUNDLED_MINIZIP "Force bundled Minizip library" OFF)
 if(NOT FORCE_BUNDLED_MINIZIP)
 	find_package(minizip)

--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -177,8 +177,15 @@ endif()
 
 target_link_libraries(vcmiclient PRIVATE
 		vcmi SDL2::SDL2 SDL2::Image SDL2::Mixer SDL2::TTF
-		ffmpeg::swscale ffmpeg::avutil ffmpeg::avcodec ffmpeg::avformat
 )
+
+if(ffmpeg_LIBRARIES)
+	target_link_libraries(vcmiclient PRIVATE
+		ffmpeg::swscale ffmpeg::avutil ffmpeg::avcodec ffmpeg::avformat
+	)
+else()
+	target_compile_definitions(vcmiclient PRIVATE DISABLE_VIDEO)
+endif()
 
 target_include_directories(vcmiclient
 	PUBLIC	${CMAKE_CURRENT_SOURCE_DIR})


### PR DESCRIPTION
Without FFmpeg video player code is disabled.

closes #876.