### PR TITLE
Add right click to Quick Recruit Window

### DIFF
--- a/client/gui/CIntObject.h
+++ b/client/gui/CIntObject.h
@@ -140,6 +140,7 @@ public:
 	//double click
 	virtual void onDoubleClick(){}
 
+	// These are the arguments that can be used to determine what kind of input the CIntObject will receive
 	enum {LCLICK=1, RCLICK=2, HOVER=4, MOVE=8, KEYBOARD=16, TIME=32, GENERAL=64, WHEEL=128, DOUBLECLICK=256, TEXTINPUT=512, MCLICK=1024, ALL=0xffff};
 	const ui16 & active;
 	void addUsedEvents(ui16 newActions);

--- a/client/windows/CreaturePurchaseCard.cpp
+++ b/client/windows/CreaturePurchaseCard.cpp
@@ -17,6 +17,7 @@
 #include "QuickRecruitmentWindow.h"
 #include "../gui/CGuiHandler.h"
 #include "../../lib/CCreatureHandler.h"
+#include "CCreatureWindow.h"
 
 void CreaturePurchaseCard::initButtons()
 {
@@ -82,14 +83,26 @@ void CreaturePurchaseCard::sliderMoved(int to)
 	parent->updateAllSliders();
 }
 
+void CreaturePurchaseCard::clickRight(tribool down, bool previousState)
+{
+	if (down)
+		GH.pushIntT<CStackWindow>(creatureOnTheCard, true);
+}
+
 CreaturePurchaseCard::CreaturePurchaseCard(const std::vector<CreatureID> & creaturesID, Point position, int creaturesMaxAmount, QuickRecruitmentWindow * parents)
-	: upgradesID(creaturesID),
+	: CIntObject(RCLICK),
+	upgradesID(creaturesID),
 	parent(parents),
 	maxAmount(creaturesMaxAmount)
 {
 	creatureOnTheCard = upgradesID.back().toCreature();
 	moveTo(Point(position.x, position.y));
 	initView();
+
+	// Card's position needs to be set to the animation's width/height
+	// otherwise the clicks won't register
+	pos.w = picture->pos.w;
+	pos.h = picture->pos.h;
 }
 
 void CreaturePurchaseCard::initView()

--- a/client/windows/CreaturePurchaseCard.cpp
+++ b/client/windows/CreaturePurchaseCard.cpp
@@ -47,6 +47,7 @@ void CreaturePurchaseCard::switchCreatureLevel()
 	auto index = vstd::find_pos(upgradesID, creatureOnTheCard->idNumber);
 	auto nextCreatureId = vstd::circularAt(upgradesID, ++index);
 	creatureOnTheCard = nextCreatureId.toCreature();
+	creatureClickArea = std::make_shared<CCreatureClickArea>(Point(pos.x + CCreatureClickArea::CREATURE_X_POS, pos.y + CCreatureClickArea::CREATURE_Y_POS), picture, creatureOnTheCard);
 	picture = std::make_shared<CCreaturePic>(parent->pos.x, parent->pos.y, creatureOnTheCard);
 	parent->updateAllSliders();
 	cost->set(creatureOnTheCard->cost * slider->getValue());
@@ -83,34 +84,41 @@ void CreaturePurchaseCard::sliderMoved(int to)
 	parent->updateAllSliders();
 }
 
-void CreaturePurchaseCard::clickRight(tribool down, bool previousState)
-{
-	if (down)
-		GH.pushIntT<CStackWindow>(creatureOnTheCard, true);
-}
-
 CreaturePurchaseCard::CreaturePurchaseCard(const std::vector<CreatureID> & creaturesID, Point position, int creaturesMaxAmount, QuickRecruitmentWindow * parents)
-	: CIntObject(RCLICK),
-	upgradesID(creaturesID),
+	: upgradesID(creaturesID),
 	parent(parents),
 	maxAmount(creaturesMaxAmount)
 {
 	creatureOnTheCard = upgradesID.back().toCreature();
 	moveTo(Point(position.x, position.y));
 	initView();
-
-	// Card's position needs to be set to the animation's width/height
-	// otherwise the clicks won't register
-	pos.w = picture->pos.w;
-	pos.h = picture->pos.h;
 }
 
 void CreaturePurchaseCard::initView()
 {
 	picture = std::make_shared<CCreaturePic>(pos.x, pos.y, creatureOnTheCard);
 	background = std::make_shared<CPicture>("QuickRecruitmentWindow/CreaturePurchaseCard.png", pos.x-4, pos.y-50);
+	initButtons();
+
+	creatureClickArea = std::make_shared<CCreatureClickArea>(Point(pos.x + CCreatureClickArea::CREATURE_X_POS, pos.y + CCreatureClickArea::CREATURE_Y_POS), picture, creatureOnTheCard);
+
 	initAmountInfo();
 	initSlider();
-	initButtons();
 	initCostBox();
+}
+
+CreaturePurchaseCard::CCreatureClickArea::CCreatureClickArea(const Point & position, const std::shared_ptr<CCreaturePic> creaturePic, const CCreature * creatureOnTheCard)
+	: CIntObject(RCLICK),
+	creatureOnTheCard(creatureOnTheCard)
+{
+	pos.x = position.x;
+	pos.y = position.y;
+	pos.w = CREATURE_WIDTH;
+	pos.h = CREATURE_HEIGHT;
+}
+
+void CreaturePurchaseCard::CCreatureClickArea::clickRight(tribool down, bool previousState)
+{
+	if (down)
+		GH.pushIntT<CStackWindow>(creatureOnTheCard, true);
 }

--- a/client/windows/CreaturePurchaseCard.h
+++ b/client/windows/CreaturePurchaseCard.h
@@ -25,6 +25,8 @@ public:
 	QuickRecruitmentWindow * parent;
 	int maxAmount;
 	void sliderMoved(int to);
+	void clickRight(tribool down, bool previousState) override;
+
 	CreaturePurchaseCard(const std::vector<CreatureID> & creaturesID, Point position, int creaturesMaxAmount, QuickRecruitmentWindow * parents);
 private:
 	void initView();

--- a/client/windows/CreaturePurchaseCard.h
+++ b/client/windows/CreaturePurchaseCard.h
@@ -25,7 +25,6 @@ public:
 	QuickRecruitmentWindow * parent;
 	int maxAmount;
 	void sliderMoved(int to);
-	void clickRight(tribool down, bool previousState) override;
 
 	CreaturePurchaseCard(const std::vector<CreatureID> & creaturesID, Point position, int creaturesMaxAmount, QuickRecruitmentWindow * parents);
 private:
@@ -44,10 +43,28 @@ private:
 
 	void initCostBox();
 
+	// This just wraps a clickeable area. There's a weird layout scheme in the file and
+	// it's easier to just add a separate invisble box on top
+	class CCreatureClickArea : public CIntObject
+	{
+	public:
+		CCreatureClickArea(const Point & pos, const std::shared_ptr<CCreaturePic> creaturePic, const CCreature * creatureOnTheCard);
+		void clickRight(tribool down, bool previousState) override;
+		const CCreature * creatureOnTheCard;
+
+		// These are obtained by guessing and checking. I'm not sure how the other numbers
+		// used to set positions were obtained; commit messages don't document it
+		static constexpr int CREATURE_WIDTH = 110;
+		static constexpr int CREATURE_HEIGHT = 132;
+		static constexpr int CREATURE_X_POS = 15;
+		static constexpr int CREATURE_Y_POS = 44;
+	};
+
 	std::shared_ptr<CButton> maxButton, minButton, creatureSwitcher;
 	std::shared_ptr<CLabel> availableAmount,  purhaseAmount;
 	std::shared_ptr<CCreaturePic> picture;
 	std::shared_ptr<CreatureCostBox> cost;
 	std::vector<CreatureID> upgradesID;
 	std::shared_ptr<CPicture> background;
+	std::shared_ptr<CCreatureClickArea> creatureClickArea;
 };


### PR DESCRIPTION
Adds clickable area on top of creature picture. The clickable area is just a class that wraps an instance of `CIntObject` and creates an area that users can right click to view information about the creature they're buying. The constants were based off the existing ones in the code and were refined by guessing and checking where clicking falls inside/outside the border of the rectangle.

Fixes #937 