### PR TITLE
[CI] switch develop to nightly builds

### DIFF
--- a/.github/workflows/github.yml
+++ b/.github/workflows/github.yml
@@ -1,11 +1,11 @@
 name: VCMI
 
 on:
-    push:
-      branches:
-        - features/*
-        - develop
-    pull_request:
+  push:
+    branches:
+      - features/*
+      - develop
+  pull_request:
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   BUILD_TYPE: Release

--- a/.github/workflows/github.yml
+++ b/.github/workflows/github.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
   schedule:
     - cron: '0 2 * * *'
+  workflow_dispatch:
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)

--- a/.github/workflows/github.yml
+++ b/.github/workflows/github.yml
@@ -4,14 +4,64 @@ on:
   push:
     branches:
       - features/*
-      - develop
   pull_request:
+  schedule:
+    - cron: '0 2 * * *'
+
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   BUILD_TYPE: Release
 
 jobs:
+  check_last_build:
+    if: github.event.schedule != ''
+    runs-on: ubuntu-latest
+    outputs:
+      skip_build: ${{ steps.check_if_built.outputs.skip_build }}
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Get repo name
+        id: get_repo_name
+        run: echo "::set-output name=value::${GITHUB_REPOSITORY#*/}"
+      - name: Get last successful build for ${{ github.sha }}
+        uses: octokit/request-action@v2.1.0
+        id: get_last_scheduled_run
+        with:
+          route: GET /repos/{owner}/{repo}/actions/runs
+          owner: ${{ github.repository_owner }}
+          repo: ${{ steps.get_repo_name.outputs.value }}
+          status: success
+          per_page: 1
+          head_sha: ${{ github.sha }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Check if successful build of the current commit exists
+        id: check_if_built
+        run: |
+          if [ ${{ fromJson(steps.get_last_scheduled_run.outputs.data).total_count }} -gt 0 ]; then
+            echo '::set-output name=skip_build::1'
+          else
+            echo '::set-output name=skip_build::0'
+          fi
+      - name: Cancel current run
+        if: steps.check_if_built.outputs.skip_build == 1
+        uses: octokit/request-action@v2.1.0
+        with:
+          route: POST /repos/{owner}/{repo}/actions/runs/{run_id}/cancel
+          owner: ${{ github.repository_owner }}
+          repo: ${{ steps.get_repo_name.outputs.value }}
+          run_id: ${{ github.run_id }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Wait for the run to be cancelled
+        if: steps.check_if_built.outputs.skip_build == 1
+        run: sleep 60
+
   build:
+    needs: check_last_build
+    if: always() && needs.check_last_build.skip_build != 1
     strategy:
       matrix:
         include:


### PR DESCRIPTION
- from now on we'll have a single nightly build (at 2 AM UTC) from the latest develop instead of building it on each push
- also possible to trigger build manually now
- if a successful build already exists (e.g. already built manually or ran in the past), current run is cancelled, by default an email will be sent about this

Tested the approach in a dummy workflow: https://github.com/kambala-decapitator/workflow-test/actions/workflows/time-based.yml