### PR TITLE
Fix most project warnings

### DIFF
--- a/AI/Nullkiller/Analyzers/ArmyManager.cpp
+++ b/AI/Nullkiller/Analyzers/ArmyManager.cpp
@@ -204,7 +204,6 @@ std::shared_ptr<CCreatureSet> ArmyManager::getArmyAvailableToBuyAsCCreatureSet(
 	TResources availableRes) const
 {
 	std::vector<creInfo> creaturesInDwellings;
-	int freeHeroSlots = GameConstants::ARMY_SIZE;
 	auto army = std::make_shared<TemporaryArmy>();
 
 	for(int i = dwelling->creatures.size() - 1; i >= 0; i--)

--- a/AI/Nullkiller/Analyzers/ArmyManager.h
+++ b/AI/Nullkiller/Analyzers/ArmyManager.h
@@ -41,6 +41,7 @@ struct ArmyUpgradeInfo
 class DLL_EXPORT IArmyManager //: public: IAbstractManager
 {
 public:
+	virtual ~IArmyManager() = default;
 	virtual void update() = 0;
 	virtual ui64 howManyReinforcementsCanBuy(const CCreatureSet * target, const CGDwelling * source) const = 0;
 	virtual	ui64 howManyReinforcementsCanBuy(

--- a/AI/Nullkiller/Analyzers/BuildAnalyzer.cpp
+++ b/AI/Nullkiller/Analyzers/BuildAnalyzer.cpp
@@ -129,8 +129,6 @@ void BuildAnalyzer::update()
 	{
 		logAi->trace("Checking town %s", town->name);
 
-		auto townInfo = town->town;
-
 		developmentInfos.push_back(TownDevelopmentInfo(town));
 		TownDevelopmentInfo & developmentInfo = developmentInfos.back();
 

--- a/AI/Nullkiller/Analyzers/DangerHitMapAnalyzer.cpp
+++ b/AI/Nullkiller/Analyzers/DangerHitMapAnalyzer.cpp
@@ -63,7 +63,7 @@ void DangerHitMapAnalyzer::updateHitMap()
 				auto & node = hitMap[pos.x][pos.y][pos.z];
 
 				if(tileDanger > node.maximumDanger.danger
-					|| tileDanger == node.maximumDanger.danger && node.maximumDanger.turn > turn)
+					|| (tileDanger == node.maximumDanger.danger && node.maximumDanger.turn > turn))
 				{
 					node.maximumDanger.danger = tileDanger;
 					node.maximumDanger.turn = turn;
@@ -71,7 +71,7 @@ void DangerHitMapAnalyzer::updateHitMap()
 				}
 
 				if(turn < node.fastestDanger.turn
-					|| turn == node.fastestDanger.turn && node.fastestDanger.danger < tileDanger)
+					|| (turn == node.fastestDanger.turn && node.fastestDanger.danger < tileDanger))
 				{
 					node.fastestDanger.danger = tileDanger;
 					node.fastestDanger.turn = turn;
@@ -101,8 +101,8 @@ uint64_t DangerHitMapAnalyzer::enemyCanKillOurHeroesAlongThePath(const AIPath & 
 	int turn = path.turn();
 	const HitMapNode & info = hitMap[tile.x][tile.y][tile.z];
 
-	return info.fastestDanger.turn <= turn && !isSafeToVisit(path.targetHero, path.heroArmy, info.fastestDanger.danger)
-		|| info.maximumDanger.turn <= turn && !isSafeToVisit(path.targetHero, path.heroArmy, info.maximumDanger.danger);
+	return (info.fastestDanger.turn <= turn && !isSafeToVisit(path.targetHero, path.heroArmy, info.fastestDanger.danger))
+		|| (info.maximumDanger.turn <= turn && !isSafeToVisit(path.targetHero, path.heroArmy, info.maximumDanger.danger));
 }
 
 const HitMapNode & DangerHitMapAnalyzer::getObjectTreat(const CGObjectInstance * obj) const

--- a/AI/Nullkiller/Analyzers/HeroManager.h
+++ b/AI/Nullkiller/Analyzers/HeroManager.h
@@ -54,11 +54,10 @@ private:
 	static SecondarySkillEvaluator scountSkillsScores;
 
 	CCallback * cb; //this is enough, but we downcast from CCallback
-	const Nullkiller * ai;
 	std::map<HeroPtr, HeroRole> heroRoles;
 
 public:
-	HeroManager(CCallback * CB, const Nullkiller * ai) : cb(CB), ai(ai) {}
+	HeroManager(CCallback * CB, const Nullkiller * ai) : cb(CB) {}
 	const std::map<HeroPtr, HeroRole> & getHeroRoles() const override;
 	HeroRole getHeroRole(const HeroPtr & hero) const override;
 	int selectBestSkill(const HeroPtr & hero, const std::vector<SecondarySkill> & skills) const override;

--- a/AI/Nullkiller/Analyzers/HeroManager.h
+++ b/AI/Nullkiller/Analyzers/HeroManager.h
@@ -20,6 +20,7 @@
 class DLL_EXPORT IHeroManager //: public: IAbstractManager
 {
 public:
+	virtual ~IHeroManager() = default;
 	virtual const std::map<HeroPtr, HeroRole> & getHeroRoles() const = 0;
 	virtual int selectBestSkill(const HeroPtr & hero, const std::vector<SecondarySkill> & skills) const = 0;
 	virtual HeroRole getHeroRole(const HeroPtr & hero) const = 0;
@@ -31,6 +32,7 @@ public:
 class DLL_EXPORT ISecondarySkillRule
 {
 public:
+	virtual ~ISecondarySkillRule() = default;
 	virtual void evaluateScore(const CGHeroInstance * hero, SecondarySkill skill, float & score) const = 0;
 };
 

--- a/AI/Nullkiller/Analyzers/ObjectClusterizer.cpp
+++ b/AI/Nullkiller/Analyzers/ObjectClusterizer.cpp
@@ -149,7 +149,7 @@ bool ObjectClusterizer::shouldVisitObject(const CGObjectInstance * obj) const
 
 	const int3 pos = obj->visitablePos();
 
-	if(obj->ID != Obj::CREATURE_GENERATOR1 && vstd::contains(ai->memory->alreadyVisited, obj)
+	if((obj->ID != Obj::CREATURE_GENERATOR1 && vstd::contains(ai->memory->alreadyVisited, obj))
 		|| obj->wasVisited(ai->playerID))
 	{
 		return false;

--- a/AI/Nullkiller/Behaviors/BuildingBehavior.cpp
+++ b/AI/Nullkiller/Behaviors/BuildingBehavior.cpp
@@ -53,8 +53,6 @@ Goals::TGoalVec BuildingBehavior::decompose() const
 
 	for(auto & developmentInfo : developmentInfos)
 	{
-		auto town = developmentInfo.town;
-
 		for(auto & buildingInfo : developmentInfo.toBuild)
 		{
 			if(goldPreasure < MAX_GOLD_PEASURE || buildingInfo.dailyIncome[Res::GOLD] > 0)

--- a/AI/Nullkiller/Behaviors/DefenceBehavior.cpp
+++ b/AI/Nullkiller/Behaviors/DefenceBehavior.cpp
@@ -106,10 +106,10 @@ void DefenceBehavior::evaluateDefence(Goals::TGoalVec & tasks, const CGTownInsta
 		{
 			if(path.getHeroStrength() > treat.danger)
 			{
-				if(path.turn() <= treat.turn && dayOfWeek + treat.turn < 6 && isSafeToVisit(path.targetHero, path.heroArmy, treat.danger)
-					|| path.exchangeCount == 1 && path.turn() < treat.turn
+				if((path.turn() <= treat.turn && dayOfWeek + treat.turn < 6 && isSafeToVisit(path.targetHero, path.heroArmy, treat.danger))
+					|| (path.exchangeCount == 1 && path.turn() < treat.turn)
 					|| path.turn() < treat.turn - 1
-					|| path.turn() < treat.turn && treat.turn >= 2)
+					|| (path.turn() < treat.turn && treat.turn >= 2))
 				{
 					logAi->debug(
 						"Hero %s can eliminate danger for town %s using path %s.",
@@ -217,7 +217,7 @@ void DefenceBehavior::evaluateDefence(Goals::TGoalVec & tasks, const CGTownInsta
 				// dismiss creatures we are not able to pick to be able to hide in garrison
 				if(town->garrisonHero
 					|| town->getUpperArmy()->stacksCount() == 0
-					|| town->getUpperArmy()->getArmyStrength() < 500 && town->fortLevel() >= CGTownInstance::CITADEL)
+					|| (town->getUpperArmy()->getArmyStrength() < 500 && town->fortLevel() >= CGTownInstance::CITADEL))
 				{
 					tasks.push_back(
 						Goals::sptr(Composition()
@@ -228,7 +228,7 @@ void DefenceBehavior::evaluateDefence(Goals::TGoalVec & tasks, const CGTownInsta
 				continue;
 			}
 				
-			if(treat.turn == 0 || path.turn() <= treat.turn && path.getHeroStrength() * SAFE_ATTACK_CONSTANT >= treat.danger)
+			if(treat.turn == 0 || (path.turn() <= treat.turn && path.getHeroStrength() * SAFE_ATTACK_CONSTANT >= treat.danger))
 			{
 				if(ai->nullkiller->arePathHeroesLocked(path))
 				{

--- a/AI/Nullkiller/Behaviors/StartupBehavior.cpp
+++ b/AI/Nullkiller/Behaviors/StartupBehavior.cpp
@@ -82,7 +82,7 @@ bool needToRecruitHero(const CGTownInstance * startupTown)
 			|| obj->ID == Obj::WATER_WHEEL)
 		{
 			auto path = paths->getPathInfo(obj->visitablePos());
-			if((path->accessible == CGPathNode::BLOCKVIS || path->accessible == CGPathNode::VISIT) 
+			if((path->accessible == CGPathNode::BLOCKVIS || path->accessible == CGPathNode::VISITABLE) 
 				&& path->reachable())
 			{
 				treasureSourcesCount++;

--- a/AI/Nullkiller/Behaviors/StartupBehavior.cpp
+++ b/AI/Nullkiller/Behaviors/StartupBehavior.cpp
@@ -55,7 +55,7 @@ const CGHeroInstance * getNearestHero(const CGTownInstance * town)
 	if(shortestPath.nodes.size() > 1
 		|| shortestPath.turn() != 0
 		|| shortestPath.targetHero->visitablePos().dist2dSQ(town->visitablePos()) > 4
-		|| town->garrisonHero && shortestPath.targetHero == town->garrisonHero.get())
+		|| (town->garrisonHero && shortestPath.targetHero == town->garrisonHero.get()))
 		return nullptr;
 
 	return shortestPath.targetHero;
@@ -76,7 +76,7 @@ bool needToRecruitHero(const CGTownInstance * startupTown)
 
 	for(auto obj : ai->nullkiller->objectClusterizer->getNearbyObjects())
 	{
-		if(obj->ID == Obj::RESOURCE && obj->subID == Res::GOLD
+		if((obj->ID == Obj::RESOURCE && obj->subID == Res::GOLD)
 			|| obj->ID == Obj::TREASURE_CHEST
 			|| obj->ID == Obj::CAMPFIRE
 			|| obj->ID == Obj::WATER_WHEEL)
@@ -162,7 +162,7 @@ Goals::TGoalVec StartupBehavior::decompose() const
 				auto garrisonHeroScore = ai->nullkiller->heroManager->evaluateHero(garrisonHero);
 
 				if(visitingHeroScore > garrisonHeroScore
-					|| ai->nullkiller->heroManager->getHeroRole(garrisonHero) == HeroRole::SCOUT && ai->nullkiller->heroManager->getHeroRole(visitingHero) == HeroRole::MAIN)
+					|| (ai->nullkiller->heroManager->getHeroRole(garrisonHero) == HeroRole::SCOUT && ai->nullkiller->heroManager->getHeroRole(visitingHero) == HeroRole::MAIN))
 				{
 					if(canRecruitHero || ai->nullkiller->armyManager->howManyReinforcementsCanGet(visitingHero, garrisonHero) > 200)
 					{

--- a/AI/Nullkiller/Engine/PriorityEvaluator.cpp
+++ b/AI/Nullkiller/Engine/PriorityEvaluator.cpp
@@ -122,7 +122,7 @@ uint64_t getCreatureBankArmyReward(const CGObjectInstance * target, const CGHero
 	{
 		//No free slot, we might discard our weakest stack
 		weakestStackPower = std::numeric_limits<ui64>().max();
-		for (const auto stack : slots)
+		for (const auto & stack : slots)
 		{
 			vstd::amin(weakestStackPower, stack.second->getPower());
 		}

--- a/AI/Nullkiller/Engine/PriorityEvaluator.cpp
+++ b/AI/Nullkiller/Engine/PriorityEvaluator.cpp
@@ -645,7 +645,6 @@ public:
 		}
 
 		auto heroPtr = task->hero;
-		auto day = ai->cb->getDate(Date::DAY);
 		auto hero = heroPtr.get(ai->cb.get());
 		bool checkGold = evaluationContext.danger == 0;
 		auto army = path.heroArmy;
@@ -670,11 +669,8 @@ public:
 
 class ClusterEvaluationContextBuilder : public IEvaluationContextBuilder
 {
-private:
-	const Nullkiller * ai;
-
 public:
-	ClusterEvaluationContextBuilder(const Nullkiller * ai) : ai(ai) {}
+	ClusterEvaluationContextBuilder(const Nullkiller * ai) {}
 
 	virtual void buildEvaluationContext(EvaluationContext & evaluationContext, Goals::TSubgoal task) const override
 	{
@@ -699,7 +695,6 @@ public:
 		for(auto objInfo : objects)
 		{
 			auto target = objInfo.first;
-			auto day = ai->cb->getDate(Date::DAY);
 			bool checkGold = objInfo.second.danger == 0;
 			auto army = hero;
 
@@ -718,9 +713,6 @@ public:
 			if(boost > 8)
 				break;
 		}
-
-		const AIPath & pathToCenter = clusterGoal.getPathToCenter();
-
 	}
 };
 

--- a/AI/Nullkiller/Engine/PriorityEvaluator.h
+++ b/AI/Nullkiller/Engine/PriorityEvaluator.h
@@ -61,6 +61,7 @@ struct DLL_EXPORT EvaluationContext
 class IEvaluationContextBuilder
 {
 public:
+	virtual ~IEvaluationContextBuilder() = default;
 	virtual void buildEvaluationContext(EvaluationContext & evaluationContext, Goals::TSubgoal goal) const = 0;
 };
 

--- a/AI/Nullkiller/Pathfinding/AINodeStorage.cpp
+++ b/AI/Nullkiller/Pathfinding/AINodeStorage.cpp
@@ -558,7 +558,7 @@ bool AINodeStorage::selectNextActor()
 	for(auto actor = actors.begin(); actor != actors.end(); actor++)
 	{
 		if(actor->get()->armyValue > currentActor->get()->armyValue
-			|| actor->get()->armyValue == currentActor->get()->armyValue && actor <= currentActor)
+			|| (actor->get()->armyValue == currentActor->get()->armyValue && actor <= currentActor))
 		{
 			continue;
 		}

--- a/AI/Nullkiller/Pathfinding/Actions/BoatActions.h
+++ b/AI/Nullkiller/Pathfinding/Actions/BoatActions.h
@@ -24,9 +24,6 @@ namespace AIPathfinding
 	
 	class SummonBoatAction : public VirtualBoatAction
 	{
-	private:
-		const CGHeroInstance * hero;
-
 	public:
 		virtual void execute(const CGHeroInstance * hero) const override;
 

--- a/AI/Nullkiller/Pathfinding/Actions/SpecialAction.h
+++ b/AI/Nullkiller/Pathfinding/Actions/SpecialAction.h
@@ -18,6 +18,8 @@ struct AIPathNode;
 class SpecialAction
 {
 public:
+	virtual ~SpecialAction() = default;
+
 	virtual bool canAct(const AIPathNode * source) const
 	{
 		return true;

--- a/AI/Nullkiller/Pathfinding/Actors.cpp
+++ b/AI/Nullkiller/Pathfinding/Actors.cpp
@@ -269,8 +269,6 @@ ExchangeResult HeroExchangeMap::tryExchangeNoLock(const ChainActor * other)
 			return result; // already inserted
 		}
 
-		auto position = inserted.first;
-
 		auto differentMasks = (actor->chainMask & other->chainMask) == 0;
 
 		if(!differentMasks) return result;
@@ -461,15 +459,6 @@ CCreatureSet * DwellingActor::getDwellingCreatures(const CGDwelling * dwelling, 
 			continue;
 
 		auto creature = creatureInfo.second.back().toCreature();
-		auto count = creatureInfo.first;
-
-		if(waitForGrowth)
-		{
-			const CGTownInstance * town = dynamic_cast<const CGTownInstance *>(dwelling);
-
-			count += town ? town->creatureGrowth(creature->level) : creature->growth;
-		}
-
 		dwellingCreatures->addToSlot(
 			dwellingCreatures->getSlotFor(creature),
 			creature->idNumber,

--- a/AI/Nullkiller/Pathfinding/Actors.h
+++ b/AI/Nullkiller/Pathfinding/Actors.h
@@ -75,7 +75,8 @@ public:
 	TResources armyCost;
 	std::shared_ptr<TurnInfo> tiCache;
 
-	ChainActor(){}
+	ChainActor() = default;
+	virtual ~ChainActor() = default;
 
 	virtual std::string toString() const;
 	ExchangeResult tryExchangeNoLock(const ChainActor * other) const { return tryExchangeNoLock(this, other); }

--- a/AI/Nullkiller/Pathfinding/Rules/AIMovementAfterDestinationRule.cpp
+++ b/AI/Nullkiller/Pathfinding/Rules/AIMovementAfterDestinationRule.cpp
@@ -126,7 +126,6 @@ namespace AIPathfinding
 		const AIPathNode * destinationNode = nodeStorage->getAINode(destination.node);
 		auto questObj = dynamic_cast<const IQuestObject *>(destination.nodeObject);
 		auto questInfo = QuestInfo(questObj->quest, destination.nodeObject, destination.coord);
-		auto nodeHero = pathfinderHelper->hero;
 		QuestAction questAction(questInfo);
 
 		if(destination.nodeObject->ID == Obj::QUEST_GUARD && questObj->quest->missionType == CQuest::MISSION_NONE)
@@ -157,8 +156,6 @@ namespace AIPathfinding
 
 			nodeStorage->updateAINode(destination.node, [&](AIPathNode * node)
 			{
-				auto questInfo = QuestInfo(questObj->quest, destination.nodeObject, destination.coord);
-
 				node->specialAction.reset(new QuestAction(questAction));
 			});
 		}

--- a/AI/VCAI/AIhelper.cpp
+++ b/AI/VCAI/AIhelper.cpp
@@ -19,10 +19,6 @@ AIhelper::AIhelper()
 	armyManager.reset(new ArmyManager());
 }
 
-AIhelper::~AIhelper()
-{
-}
-
 bool AIhelper::notifyGoalCompleted(Goals::TSubgoal goal)
 {
 	return resourceManager->notifyGoalCompleted(goal);

--- a/AI/VCAI/AIhelper.h
+++ b/AI/VCAI/AIhelper.h
@@ -36,7 +36,6 @@ class DLL_EXPORT AIhelper : public IResourceManager, public IBuildingManager, pu
 	//TODO: vector<IAbstractManager>
 public:
 	AIhelper();
-	~AIhelper();
 
 	bool canAfford(const TResources & cost) const;
 	TResources reservedResources() const override;

--- a/AI/VCAI/ArmyManager.h
+++ b/AI/VCAI/ArmyManager.h
@@ -28,6 +28,7 @@ struct SlotInfo
 class DLL_EXPORT IArmyManager //: public: IAbstractManager
 {
 public:
+	virtual ~IArmyManager() = default;
 	virtual void init(CPlayerSpecificInfoCallback * CB) = 0;
 	virtual void setAI(VCAI * AI) = 0;
 	virtual bool canGetArmy(const CArmedInstance * target, const CArmedInstance * source) const = 0;

--- a/AI/VCAI/ResourceManager.cpp
+++ b/AI/VCAI/ResourceManager.cpp
@@ -121,7 +121,7 @@ Goals::TSubgoal ResourceManager::collectResourcesForOurGoal(ResourceObjective &o
 	}
 
 	float goalPriority = 10; //arbitrary, will be divided
-	for (const resPair & p : missingResources)
+	for (const resPair p : missingResources)
 	{
 		if (!income[p.first]) //prioritize resources with 0 income
 		{

--- a/AI/VCAI/ResourceManager.cpp
+++ b/AI/VCAI/ResourceManager.cpp
@@ -120,14 +120,12 @@ Goals::TSubgoal ResourceManager::collectResourcesForOurGoal(ResourceObjective &o
 		return o.goal;
 	}
 
-	float goalPriority = 10; //arbitrary, will be divided
 	for (const resPair p : missingResources)
 	{
 		if (!income[p.first]) //prioritize resources with 0 income
 		{
 			resourceType = p.first;
 			amountToCollect = p.second;
-			goalPriority /= amountToCollect; //need more resources -> lower priority
 			break;
 		}
 	}
@@ -138,7 +136,7 @@ Goals::TSubgoal ResourceManager::collectResourcesForOurGoal(ResourceObjective &o
 		std::map<Res::ERes, float> daysToEarn;
 		for (auto it : missingResources)
 			daysToEarn[it.first] = (float)missingResources[it.first] / income[it.first];
-		auto incomeComparer = [&income](const timePair & lhs, const timePair & rhs) -> bool
+		auto incomeComparer = [](const timePair & lhs, const timePair & rhs) -> bool
 		{
 			//theoretically income can be negative, but that falls into this comparison
 			return lhs.second < rhs.second;
@@ -146,12 +144,9 @@ Goals::TSubgoal ResourceManager::collectResourcesForOurGoal(ResourceObjective &o
 
 		resourceType = boost::max_element(daysToEarn, incomeComparer)->first;
 		amountToCollect = missingResources[resourceType];
-		goalPriority /= daysToEarn[resourceType]; //more days - lower priority
 	}
-	if (resourceType == Res::GOLD)
-		goalPriority *= 1000;
 
-	//this is abstract goal and might take soem time to complete
+	//this is abstract goal and might take some time to complete
 	return Goals::sptr(Goals::CollectRes(resourceType, amountToCollect).setisAbstract(true));
 }
 

--- a/CCallback.h
+++ b/CCallback.h
@@ -35,6 +35,8 @@ struct ArtifactLocation;
 class IBattleCallback
 {
 public:
+	virtual ~IBattleCallback() = default;
+
 	bool waitTillRealize; //if true, request functions will return after they are realized by server
 	bool unlockGsWhenWaiting;//if true after sending each request, gs mutex will be unlocked so the changes can be applied; NOTICE caller must have gs mx locked prior to any call to actiob callback!
 	//battle

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -192,6 +192,7 @@ if(CMAKE_COMPILER_IS_GNUCXX OR NOT WIN32) #so far all *nix compilers support suc
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-strict-aliasing -Wno-switch -Wno-sign-compare -Wno-unused-local-typedefs")
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-parameter -Wno-overloaded-virtual -Wno-type-limits -Wno-unknown-pragmas")
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-reorder")
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-varargs") # fuzzylite - Operation.h
 
 	if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
 		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-mismatched-tags -Wno-unknown-warning-option -Wno-missing-braces")

--- a/client/battle/CBattleInterface.cpp
+++ b/client/battle/CBattleInterface.cpp
@@ -1083,11 +1083,10 @@ void CBattleInterface::stacksAreAttacked(std::vector<StackAttackedInfo> attacked
 
 	std::array<int, 2> killedBySide = {0, 0};
 
-	int targets = 0, damage = 0;
+	int targets = 0;
 	for(const StackAttackedInfo & attackedInfo : attackedInfos)
 	{
 		++targets;
-		damage += (int)attackedInfo.dmg;
 
 		ui8 side = attackedInfo.defender->side;
 		killedBySide.at(side) += attackedInfo.amountKilled;

--- a/client/gui/SDL_Extensions.h
+++ b/client/gui/SDL_Extensions.h
@@ -155,6 +155,7 @@ typedef void (*BlitterWithRotationVal)(SDL_Surface *src,SDL_Rect srcRect, SDL_Su
 class ColorShifter
 {
 public:
+	virtual ~ColorShifter() = default;
 	virtual SDL_Color shiftColor(SDL_Color clr) const = 0;
 };
 

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -1286,7 +1286,7 @@ CExchangeWindow::CExchangeWindow(ObjectInstanceID hero1, ObjectInstanceID hero2,
 			int skill = hero->secSkills[g].first,
 				level = hero->secSkills[g].second; // <1, 3>
 			secSkillAreas[b].push_back(std::make_shared<LRClickableAreaWTextComp>());
-			secSkillAreas[b][g]->pos = genRect(32, 32, pos.x + 32 + g*36 + b*454 , pos.y + qeLayout ? 83 : 88);
+			secSkillAreas[b][g]->pos = genRect(32, 32, pos.x + 32 + g*36 + b*454 , pos.y + (qeLayout ? 83 : 88));
 			secSkillAreas[b][g]->baseType = 1;
 
 			secSkillAreas[b][g]->type = skill;
@@ -1301,12 +1301,12 @@ CExchangeWindow::CExchangeWindow(ObjectInstanceID hero1, ObjectInstanceID hero2,
 		heroAreas[b] = std::make_shared<CHeroArea>(257 + 228*b, 13, hero);
 
 		specialtyAreas[b] = std::make_shared<LRClickableAreaWText>();
-		specialtyAreas[b]->pos = genRect(32, 32, pos.x + 69 + 490*b, pos.y + qeLayout ? 41 : 45);
+		specialtyAreas[b]->pos = genRect(32, 32, pos.x + 69 + 490*b, pos.y + (qeLayout ? 41 : 45));
 		specialtyAreas[b]->hoverText = CGI->generaltexth->heroscrn[27];
 		specialtyAreas[b]->text = hero->type->specDescr;
 
 		experienceAreas[b] = std::make_shared<LRClickableAreaWText>();
-		experienceAreas[b]->pos = genRect(32, 32, pos.x + 105 + 490*b, pos.y + qeLayout ? 41 : 45);
+		experienceAreas[b]->pos = genRect(32, 32, pos.x + 105 + 490*b, pos.y + (qeLayout ? 41 : 45));
 		experienceAreas[b]->hoverText = CGI->generaltexth->heroscrn[9];
 		experienceAreas[b]->text = CGI->generaltexth->allTexts[2];
 		boost::algorithm::replace_first(experienceAreas[b]->text, "%d", boost::lexical_cast<std::string>(hero->level));
@@ -1314,7 +1314,7 @@ CExchangeWindow::CExchangeWindow(ObjectInstanceID hero1, ObjectInstanceID hero2,
 		boost::algorithm::replace_first(experienceAreas[b]->text, "%d", boost::lexical_cast<std::string>(hero->exp));
 
 		spellPointsAreas[b] = std::make_shared<LRClickableAreaWText>();
-		spellPointsAreas[b]->pos = genRect(32, 32, pos.x + 141 + 490*b, pos.y + qeLayout ? 41 : 45);
+		spellPointsAreas[b]->pos = genRect(32, 32, pos.x + 141 + 490*b, pos.y + (qeLayout ? 41 : 45));
 		spellPointsAreas[b]->hoverText = CGI->generaltexth->heroscrn[22];
 		spellPointsAreas[b]->text = CGI->generaltexth->allTexts[205];
 		boost::algorithm::replace_first(spellPointsAreas[b]->text, "%s", hero->name);

--- a/include/vcmi/ServerCallback.h
+++ b/include/vcmi/ServerCallback.h
@@ -27,6 +27,8 @@ struct CatapultAttack;
 class DLL_LINKAGE ServerCallback
 {
 public:
+	virtual ~ServerCallback() = default;
+
 	virtual void complain(const std::string & problem) = 0;
 	virtual bool describeChanges() const = 0;
 

--- a/lib/CPathfinder.h
+++ b/lib/CPathfinder.h
@@ -386,6 +386,9 @@ class DLL_LINKAGE INodeStorage
 {
 public:
 	using ELayer = EPathfindingLayer;
+
+	virtual ~INodeStorage() = default;
+
 	virtual std::vector<CGPathNode *> getInitialNodes() = 0;
 
 	virtual std::vector<CGPathNode *> calculateNeighbours(
@@ -448,6 +451,7 @@ public:
 	PathfinderConfig(
 		std::shared_ptr<INodeStorage> nodeStorage,
 		std::vector<std::shared_ptr<IPathfindingRule>> rules);
+	virtual ~PathfinderConfig() = default;
 
 	virtual CPathfinderHelper * getOrCreatePathfinderHelper(const PathNodeInfo & source, CGameState * gs) = 0;
 };

--- a/lib/Terrain.cpp
+++ b/lib/Terrain.cpp
@@ -201,12 +201,6 @@ Terrain::operator std::string() const
 Terrain::Terrain(const std::string & _name) : name(_name)
 {}
 	
-Terrain& Terrain::operator=(const Terrain & _name)
-{
-	name = _name.name;
-	return *this;
-}
-	
 Terrain& Terrain::operator=(const std::string & _name)
 {
 	name = _name;

--- a/lib/Terrain.h
+++ b/lib/Terrain.h
@@ -74,7 +74,6 @@ public:
 	
 	int id() const; //TODO: has to be completely removed
 	
-	Terrain& operator=(const Terrain & _type);
 	Terrain& operator=(const std::string & _type);
 	
 	DLL_LINKAGE friend bool operator==(const Terrain & l, const Terrain & r);

--- a/lib/events/ApplyDamage.cpp
+++ b/lib/events/ApplyDamage.cpp
@@ -25,10 +25,8 @@ SubscriptionRegistry<ApplyDamage> * ApplyDamage::getRegistry()
 }
 
 CApplyDamage::CApplyDamage(const Environment * env_, BattleStackAttacked * pack_, std::shared_ptr<battle::Unit> target_)
-	: env(env_),
-	pack(pack_),
+	: pack(pack_),
 	target(target_)
-
 {
 	initalDamage = pack->damageAmount;
 }

--- a/lib/events/ApplyDamage.h
+++ b/lib/events/ApplyDamage.h
@@ -28,12 +28,8 @@ public:
 private:
 	int64_t initalDamage;
 
-	const Environment * env;
 	BattleStackAttacked * pack;
 	std::shared_ptr<battle::Unit> target;
 };
 
 }
-
-
-

--- a/lib/rmg/Zone.cpp
+++ b/lib/rmg/Zone.cpp
@@ -193,11 +193,7 @@ void Zone::fractalize()
 	rmg::Area clearedTiles(dAreaFree);
 	rmg::Area possibleTiles(dAreaPossible);
 	rmg::Area tilesToIgnore; //will be erased in this iteration
-	
-	//the more treasure density, the greater distance between paths. Scaling is experimental.
-	int totalDensity = 0;
-	for(auto ti : treasureInfo)
-		totalDensity += ti.density;
+
 	const float minDistance = 10 * 10; //squared
 	
 	if(type != ETemplateZoneType::JUNCTION)

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -5585,7 +5585,7 @@ bool CGameHandler::isAllowedExchange(ObjectInstanceID id1, ObjectInstanceID id2)
 			auto topArmy = dialog->exchangingArmies.at(0);
 			auto bottomArmy = dialog->exchangingArmies.at(1);
 
-			if (topArmy == o1 && bottomArmy == o2 || bottomArmy == o1 && topArmy == o2)
+			if ((topArmy == o1 && bottomArmy == o2) || (bottomArmy == o1 && topArmy == o2))
 				return true;
 		}
 	}


### PR DESCRIPTION
Warnings as reported by Apple clang 13.

Some notes:

- I decided not to touch the deprecation warning of `std::random_shuffle` in `AI/Nullkiller/Pathfinding/AINodeStorage.cpp` as I'm not quite sure of the correct replacement (might have side effects, needs testing). The fix itself is to use variant 3 from https://en.cppreference.com/w/cpp/algorithm/random_shuffle e.g. like in the example in the bottom of the page.
- the FL's varargs warning is ok to silence as there's no UB there, see https://github.com/fuzzylite/fuzzylite/issues/77
- after the "fix operator precedence" change I expected to see some difference in the UI, but strangely nothing has changed... See screenshots: first is "before", second is "after".

![Screenshot 2022-09-22 at 10 38 12](https://user-images.githubusercontent.com/1557784/191710463-e66daa34-0436-437e-9188-6005a21a335b.png) ![Screenshot 2022-09-22 at 10 42 59](https://user-images.githubusercontent.com/1557784/191710476-b2412169-a52d-4189-aa61-19fa93314dab.png)

![Screenshot 2022-09-22 at 10 39 08](https://user-images.githubusercontent.com/1557784/191710512-1b254a57-3dac-427a-864d-b3bb4c837111.png) ![Screenshot 2022-09-22 at 10 41 04](https://user-images.githubusercontent.com/1557784/191710538-e24c5e96-dab6-44a2-9b1e-f6c099e75a8f.png)
