### PR TITLE
#973 - use ship battleground for favorable winds

### DIFF
--- a/config/battlefields.json
+++ b/config/battlefields.json
@@ -124,10 +124,6 @@
 			}
 		]
 	},
-	"favorable_winds": {
-		"graphics": "CMBKFW.BMP",
-		"isSpecial" : true
-	},
 	"cursed_ground": {
 		"graphics": "CMBKCUR.BMP",
 		"isSpecial" : true,

--- a/config/objects/generic.json
+++ b/config/objects/generic.json
@@ -970,7 +970,7 @@
 	"favorableWinds" : {
 		"index" :225,
 		"handler": "terrain",
-		"types" : { "object" : { "index" : 0, "battleground": "favorable_winds" } }
+		"types" : { "object" : { "index" : 0, "battleground": "ship" } }
 	},
 	"fieryFields": {
 		"index" :226,


### PR DESCRIPTION
Looks like favorable winds resource was not finished and regular water was used instead in original homm3.