### PR TITLE
Fix Clang Analyzer warnings

### DIFF
--- a/AI/Nullkiller/AIUtility.cpp
+++ b/AI/Nullkiller/AIUtility.cpp
@@ -307,6 +307,9 @@ bool compareArtifacts(const CArtifactInstance * a1, const CArtifactInstance * a2
 
 bool isWeeklyRevisitable(const CGObjectInstance * obj)
 {
+	if(!obj)
+		return false;
+
 	//TODO: allow polling of remaining creatures in dwelling
 	if(dynamic_cast<const CGVisitableOPW *>(obj)) // ensures future compatibility, unlike IDs
 		return true;

--- a/AI/Nullkiller/Analyzers/BuildAnalyzer.cpp
+++ b/AI/Nullkiller/Analyzers/BuildAnalyzer.cpp
@@ -205,8 +205,6 @@ BuildingInfo BuildAnalyzer::getBuildingOrPrerequisite(
 	logAi->trace("checking %s", info.name);
 	logAi->trace("buildInfo %s", info.toString());
 
-	buildPtr = nullptr;
-
 	if(!town->hasBuilt(building))
 	{
 		auto canBuild = ai->cb->canBuildStructure(town, building);
@@ -239,8 +237,6 @@ BuildingInfo BuildAnalyzer::getBuildingOrPrerequisite(
 			}
 			else
 			{
-				buildPtr = townInfo->buildings.at(building);
-
 				logAi->trace("cant build. Need %d", missingBuildings[0].num);
 
 				BuildingInfo prerequisite = getBuildingOrPrerequisite(town, missingBuildings[0], excludeDwellingDependencies);

--- a/AI/Nullkiller/Behaviors/CaptureObjectsBehavior.cpp
+++ b/AI/Nullkiller/Behaviors/CaptureObjectsBehavior.cpp
@@ -133,6 +133,7 @@ Goals::TGoalVec CaptureObjectsBehavior::getVisitGoals(const std::vector<AIPath> 
 		}
 	}
 
+	assert(closestWay || waysToVisitObj.empty());
 	for(auto way : waysToVisitObj)
 	{
 		way->closestWayRatio

--- a/AI/Nullkiller/Pathfinding/Rules/AIMovementAfterDestinationRule.cpp
+++ b/AI/Nullkiller/Pathfinding/Rules/AIMovementAfterDestinationRule.cpp
@@ -147,7 +147,6 @@ namespace AIPathfinding
 					return false;
 				}
 
-				destinationNode = questNode.get();
 				destination.node = questNode.get();
 
 				nodeStorage->commit(destination, source);

--- a/client/CMessage.cpp
+++ b/client/CMessage.cpp
@@ -208,6 +208,7 @@ void CMessage::drawIWindow(CInfoWindow * ret, std::string text, PlayerColor play
 
 	const int sizes[][2] = {{400, 125}, {500, 150}, {600, 200}, {480, 400}};
 
+	assert(ret && ret->text);
 	for(int i = 0;
 		i < ARRAY_COUNT(sizes)
 			&& sizes[i][0] < screen->w - 150

--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -1327,7 +1327,7 @@ void CPlayerInterface::availableCreaturesChanged( const CGDwelling *town )
 				ki->townChanged(townObj);
 		}
 	}
-	else if (GH.listInt.size() && (town->ID == Obj::CREATURE_GENERATOR1
+	else if(town && GH.listInt.size() && (town->ID == Obj::CREATURE_GENERATOR1
 		||  town->ID == Obj::CREATURE_GENERATOR4  ||  town->ID == Obj::WAR_MACHINE_FACTORY))
 	{
 		CRecruitmentWindow *crw = dynamic_cast<CRecruitmentWindow*>(GH.topInt().get());

--- a/client/battle/CBattleAnimations.cpp
+++ b/client/battle/CBattleAnimations.cpp
@@ -196,7 +196,7 @@ bool CDefenceAnimation::init()
 	}
 	//unit reversed
 
-	if(rangedAttack) //delay hit animation
+	if(rangedAttack && attacker != nullptr) //delay hit animation
 	{
 		for(std::list<ProjectileInfo>::const_iterator it = owner->projectiles.begin(); it != owner->projectiles.end(); ++it)
 		{

--- a/client/windows/CKingdomInterface.cpp
+++ b/client/windows/CKingdomInterface.cpp
@@ -315,6 +315,9 @@ int InfoBoxHeroData::getSubID()
 
 si64 InfoBoxHeroData::getValue()
 {
+	if(!hero)
+		return 0;
+
 	switch(type)
 	{
 	case HERO_PRIMARY_SKILL:

--- a/lib/CCreatureHandler.cpp
+++ b/lib/CCreatureHandler.cpp
@@ -1230,7 +1230,7 @@ void CCreatureHandler::loadStackExp(Bonus & b, BonusList & bl, CLegacyConfigPars
 	{
 		if (b.type != Bonus::REBIRTH)
 			b.val = 0; //on-off ability, no value specified
-		curVal = static_cast<si32>(parser.readNumber());// 0 level is never active
+		parser.readNumber(); // 0 level is never active
 		for (int i = 1; i < 11; ++i)
 		{
 			curVal = static_cast<si32>(parser.readNumber());

--- a/lib/CPathfinder.cpp
+++ b/lib/CPathfinder.cpp
@@ -463,7 +463,7 @@ std::vector<int3> CPathfinderHelper::getAllowedTeleportChannelExits(TeleportChan
 					allowedExits.push_back(p);
 			}
 		}
-		else if(CGTeleport::isExitPassable(gs, hero, obj))
+		else if(obj && CGTeleport::isExitPassable(gs, hero, obj))
 			allowedExits.push_back(obj->visitablePos());
 	}
 

--- a/lib/CStack.cpp
+++ b/lib/CStack.cpp
@@ -304,6 +304,7 @@ std::vector<BattleHex> CStack::meleeAttackHexes(const battle::Unit * attacker, c
 			res.push_back(otherDefenderPos);
 		}
 	}
+	UNUSED(mask);
 
 	return res;
 }

--- a/lib/NetPacksLib.cpp
+++ b/lib/NetPacksLib.cpp
@@ -916,10 +916,8 @@ DLL_LINKAGE void SwapStacks::applyGs(CGameState * gs)
 
 DLL_LINKAGE void InsertNewStack::applyGs(CGameState *gs)
 {
-	auto s = new CStackInstance(type, count);
-	auto obj = gs->getArmyInstance(army);
-	if(obj)
-		obj->putStack(slot, s);
+	if(auto obj = gs->getArmyInstance(army))
+		obj->putStack(slot, new CStackInstance(type, count));
 	else
 		logNetwork->error("[CRITICAL] InsertNewStack: invalid army object %d, possible game state corruption.", army.getNum());
 }

--- a/lib/spells/ISpellMechanics.cpp
+++ b/lib/spells/ISpellMechanics.cpp
@@ -490,6 +490,7 @@ bool BaseMechanics::adaptGenericProblem(Problem & target) const
 	MetaString text;
 	// %s recites the incantations but they seem to have no effect.
 	text.addTxt(MetaString::GENERAL_TXT, 541);
+	assert(caster);
 	caster->getCasterName(text);
 
 	target.add(std::move(text), spells::Problem::NORMAL);


### PR DESCRIPTION
The following warnings were not fixed:

1. should never be the case, as when `waysToVisitObj` is not empty, this guarantees that `closestWay` will be set to a valid pointer.

```
AI/Nullkiller/Behaviors/CaptureObjectsBehavior.cpp:140:6: warning: Called C++ object pointer is null [core.CallAndMessage]
                        = closestWay->movementCost() / way->getPath().movementCost();
                          ^~~~~~~~~~~~~~~~~~~~~~~~~~
```

2. @nullkiller says it's ok to have it uninitialized. There're more uninitialized fields: `manaCost`, `chainOther`. Points to `HeroChainCalculationTask::calculateExchange()` in NK AI.

```
In file included from AI/Nullkiller/Pathfinding/AINodeStorage.cpp:11:
AI/Nullkiller/Pathfinding/../Engine/../Goals/../Analyzers/../Pathfinding/AINodeStorage.h:34:8: warning: Value assigned to field 'danger' in implicit constructor is garbage or undefined [core.uninitialized.Assign]
struct AIPathNode : public CGPathNode
       ^~~~~~~~~~
```

3. this one I simply didn't understand, buried quite deep. Points to `CGameHandler::load()` - `lf >> *this`.

```
In file included from server/CGameHandler.cpp:42:
In file included from server/CVCMIServer.h:12:
In file included from server/../lib/serializer/Connection.h:12:
server/../lib/serializer/BinaryDeserializer.h:206:3: warning: Method called on moved-from object 'value' [cplusplus.Move]
                hlp.serialize(*this,fileVersion);
                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```