### PR TITLE
[MSVC] place AI dependencies into the right location at build time

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,6 @@ project(VCMI)
 #
 # Vckpg:
 # - Improve install code once there is better way to deploy DLLs and Qt plugins
-# - Move Vcpkg install BundleUtilities code from osx/CMakeLists.txt
 #
 # Other:
 # - Cleanup remove_directory copy_directory if performance will be a problem.
@@ -564,7 +563,6 @@ if(WIN32)
 	set(CPACK_NSIS_EXECUTABLES_DIRECTORY ".")
 	# Use BundleUtilities to fix build when Vcpkg is used and disable it for MXE
 	if(NOT (${CMAKE_CROSSCOMPILING}))
-		add_subdirectory(osx)
 		add_subdirectory(win)
 	endif()
 elseif(APPLE_MACOS AND NOT ENABLE_MONOLITHIC_INSTALL)

--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -198,6 +198,15 @@ if(WIN32)
 		target_link_libraries(vcmiclient SDL2::SDL2main)
 	endif()
 	target_compile_definitions(vcmiclient PRIVATE WINDOWS_IGNORE_PACKING_MISMATCH)
+
+	# TODO: very hacky, find proper solution to copy AI dlls into bin dir
+	if(MSVC)
+		add_custom_command(TARGET vcmiclient POST_BUILD
+			WORKING_DIRECTORY "$<TARGET_FILE_DIR:vcmiclient>"
+			COMMAND ${CMAKE_COMMAND} -E rename AI/fuzzylite.dll fuzzylite.dll
+			COMMAND ${CMAKE_COMMAND} -E rename AI/tbb.dll tbb.dll
+		)
+	endif()
 elseif(APPLE_IOS)
 	target_link_libraries(vcmiclient PRIVATE
 		iOS_utils


### PR DESCRIPTION
Currently when you build project with MSVC, fuzzylite.dll and tbb.dll end up in the `AI` subdirectory which prevents loading adventure AI dll on game start and client crashes, and you have to move those dlls to the `bin` directory manually. This workaround fixes that.