### PR TITLE
Multiplayer

### DIFF
--- a/client/CMT.cpp
+++ b/client/CMT.cpp
@@ -1359,7 +1359,7 @@ static void handleEvent(SDL_Event & ev)
 			break;
 		case EUserEvent::RESTART_GAME:
 			{
-				CSH->sendStartGame();
+				CSH->sendRestartGame();
 			}
 			break;
 		case EUserEvent::CAMPAIGN_START_SCENARIO:

--- a/client/CServerHandler.cpp
+++ b/client/CServerHandler.cpp
@@ -514,6 +514,8 @@ void CServerHandler::sendStartGame(bool allowOnlyAI) const
 		* si = * lsg.initializedStartInfo;
 	}
 	sendLobbyPack(lsg);
+	c->enterLobbyConnectionMode();
+	c->disableStackSendingByID();
 }
 
 void CServerHandler::startGameplay(CGameState * gameState)

--- a/client/CServerHandler.cpp
+++ b/client/CServerHandler.cpp
@@ -541,7 +541,7 @@ void CServerHandler::startGameplay(CGameState * gameState)
 		client->newGame(gameState);
 		break;
 	case StartInfo::LOAD_GAME:
-		client->loadGame();
+		client->loadGame(gameState);
 		break;
 	default:
 		throw std::runtime_error("Invalid mode");

--- a/client/CServerHandler.cpp
+++ b/client/CServerHandler.cpp
@@ -577,8 +577,8 @@ void CServerHandler::endGameplay(bool closeConnection, bool restart)
 		}
 	}
 	
-	serverConnection->enterLobbyConnectionMode();
-	serverConnection->disableStackSendingByID();
+	c->enterLobbyConnectionMode();
+	c->disableStackSendingByID();
 }
 
 void CServerHandler::startCampaignScenario(std::shared_ptr<CCampaignState> cs)

--- a/client/CServerHandler.cpp
+++ b/client/CServerHandler.cpp
@@ -516,7 +516,7 @@ void CServerHandler::sendStartGame(bool allowOnlyAI) const
 	sendLobbyPack(lsg);
 }
 
-void CServerHandler::startGameplay()
+void CServerHandler::startGameplay(CGameState * gameState)
 {
 	if(CMM)
 		CMM->disable();
@@ -525,10 +525,10 @@ void CServerHandler::startGameplay()
 	switch(si->mode)
 	{
 	case StartInfo::NEW_GAME:
-		client->newGame();
+		client->newGame(gameState);
 		break;
 	case StartInfo::CAMPAIGN:
-		client->newGame();
+		client->newGame(gameState);
 		break;
 	case StartInfo::LOAD_GAME:
 		client->loadGame();

--- a/client/CServerHandler.cpp
+++ b/client/CServerHandler.cpp
@@ -502,6 +502,14 @@ void CServerHandler::sendGuiAction(ui8 action) const
 	sendLobbyPack(lga);
 }
 
+void CServerHandler::sendRestartGame() const
+{
+	LobbyEndGame endGame;
+	endGame.closeConnection = false;
+	endGame.restart = true;
+	sendLobbyPack(endGame);
+}
+
 void CServerHandler::sendStartGame(bool allowOnlyAI) const
 {
 	verifyStateBeforeStart(allowOnlyAI ? true : settings["session"]["onlyai"].Bool());
@@ -568,6 +576,9 @@ void CServerHandler::endGameplay(bool closeConnection, bool restart)
 			GH.curInt = CMainMenu::create().get();
 		}
 	}
+	
+	serverConnection->enterLobbyConnectionMode();
+	serverConnection->disableStackSendingByID();
 }
 
 void CServerHandler::startCampaignScenario(std::shared_ptr<CCampaignState> cs)

--- a/client/CServerHandler.h
+++ b/client/CServerHandler.h
@@ -21,6 +21,7 @@ class PlayerColor;
 struct StartInfo;
 
 class CMapInfo;
+class CGameState;
 struct ClientPlayer;
 struct CPack;
 struct CPackForLobby;
@@ -142,7 +143,7 @@ public:
 	void sendGuiAction(ui8 action) const override;
 	void sendStartGame(bool allowOnlyAI = false) const override;
 
-	void startGameplay();
+	void startGameplay(CGameState * gameState = nullptr);
 	void endGameplay(bool closeConnection = true, bool restart = false);
 	void startCampaignScenario(std::shared_ptr<CCampaignState> cs = {});
 	void showServerError(std::string txt);

--- a/client/CServerHandler.h
+++ b/client/CServerHandler.h
@@ -70,6 +70,7 @@ public:
 	virtual void sendMessage(const std::string & txt) const = 0;
 	virtual void sendGuiAction(ui8 action) const = 0; // TODO: possibly get rid of it?
 	virtual void sendStartGame(bool allowOnlyAI = false) const = 0;
+	virtual void sendRestartGame() const = 0;
 };
 
 /// structure to handle running server and connecting to it
@@ -141,6 +142,7 @@ public:
 	void setTurnLength(int npos) const override;
 	void sendMessage(const std::string & txt) const override;
 	void sendGuiAction(ui8 action) const override;
+	void sendRestartGame() const override;
 	void sendStartGame(bool allowOnlyAI = false) const override;
 
 	void startGameplay(CGameState * gameState = nullptr);

--- a/client/Client.cpp
+++ b/client/Client.cpp
@@ -200,6 +200,8 @@ void CClient::newGame(CGameState * initializedGameState)
 void CClient::loadGame(CGameState * initializedGameState)
 {
 	logNetwork->info("Loading procedure started!");
+	
+	std::unique_ptr<CLoadFile> loader;
 
 	if(initializedGameState)
 	{
@@ -208,7 +210,6 @@ void CClient::loadGame(CGameState * initializedGameState)
 	}
 	else
 	{
-		std::unique_ptr<CLoadFile> loader;
 		try
 		{
 			boost::filesystem::path clientSaveName = *CResourceHandler::get("local")->getResourceName(ResourceID(CSH->si->mapname, EResType::CLIENT_SAVEGAME));
@@ -234,8 +235,6 @@ void CClient::loadGame(CGameState * initializedGameState)
 				loadCommonState(checkingLoader);
 				loader = checkingLoader.decay();
 			}
-			
-			serialize(loader->serializer, loader->serializer.fileVersion);
 		}
 		catch(std::exception & e)
 		{
@@ -253,6 +252,9 @@ void CClient::loadGame(CGameState * initializedGameState)
 	reinitScripting();
 
 	initPlayerEnvironments();
+	
+	if(loader)
+		serialize(loader->serializer, loader->serializer.fileVersion);
 
 	initPlayerInterfaces();
 }

--- a/client/Client.cpp
+++ b/client/Client.cpp
@@ -180,14 +180,15 @@ events::EventBus * CClient::eventBus() const
 	return clientEventBus.get();
 }
 
-void CClient::newGame()
+void CClient::newGame(CGameState * gameState)
 {
 	CSH->th->update();
 	CMapService mapService;
-	gs = new CGameState();
+	gs = gameState ? gameState : new CGameState();
 	gs->preInit(VLC);
 	logNetwork->trace("\tCreating gamestate: %i", CSH->th->getDiff());
-	gs->init(&mapService, CSH->si.get(), settings["general"]["saveRandomMaps"].Bool());
+	if(!gameState)
+		gs->init(&mapService, CSH->si.get(), settings["general"]["saveRandomMaps"].Bool());
 	logNetwork->trace("Initializing GameState (together): %d ms", CSH->th->getDiff());
 
 	initMapHandler();

--- a/client/Client.cpp
+++ b/client/Client.cpp
@@ -180,14 +180,14 @@ events::EventBus * CClient::eventBus() const
 	return clientEventBus.get();
 }
 
-void CClient::newGame(CGameState * gameState)
+void CClient::newGame(CGameState * initializedGameState)
 {
 	CSH->th->update();
 	CMapService mapService;
-	gs = gameState ? gameState : new CGameState();
+	gs = initializedGameState ? initializedGameState : new CGameState();
 	gs->preInit(VLC);
 	logNetwork->trace("\tCreating gamestate: %i", CSH->th->getDiff());
-	if(!gameState)
+	if(!initializedGameState)
 		gs->init(&mapService, CSH->si.get(), settings["general"]["saveRandomMaps"].Bool());
 	logNetwork->trace("Initializing GameState (together): %d ms", CSH->th->getDiff());
 
@@ -197,14 +197,14 @@ void CClient::newGame(CGameState * gameState)
 	initPlayerInterfaces();
 }
 
-void CClient::loadGame(CGameState * gameState)
+void CClient::loadGame(CGameState * initializedGameState)
 {
 	logNetwork->info("Loading procedure started!");
 
-	if(gameState)
+	if(initializedGameState)
 	{
 		logNetwork->info("Game state was transferred over network, loading.");
-		gs = gameState;
+		gs = initializedGameState;
 	}
 	else
 	{

--- a/client/Client.h
+++ b/client/Client.h
@@ -150,7 +150,7 @@ public:
 	vstd::CLoggerBase * logger() const override;
 	events::EventBus * eventBus() const override;
 
-	void newGame();
+	void newGame(CGameState * gameState);
 	void loadGame();
 	void serialize(BinarySerializer & h, const int version);
 	void serialize(BinaryDeserializer & h, const int version);

--- a/client/Client.h
+++ b/client/Client.h
@@ -151,7 +151,7 @@ public:
 	events::EventBus * eventBus() const override;
 
 	void newGame(CGameState * gameState);
-	void loadGame();
+	void loadGame(CGameState * gameState);
 	void serialize(BinarySerializer & h, const int version);
 	void serialize(BinaryDeserializer & h, const int version);
 

--- a/client/NetPacksLobbyClient.cpp
+++ b/client/NetPacksLobbyClient.cpp
@@ -57,7 +57,8 @@ bool LobbyClientDisconnected::applyOnLobbyHandler(CServerHandler * handler)
 
 void LobbyClientDisconnected::applyOnLobbyScreen(CLobbyScreen * lobby, CServerHandler * handler)
 {
-	GH.popInts(1);
+	if(GH.listInt.size())
+		GH.popInts(1);
 }
 
 void LobbyChatMessage::applyOnLobbyScreen(CLobbyScreen * lobby, CServerHandler * handler)

--- a/client/NetPacksLobbyClient.cpp
+++ b/client/NetPacksLobbyClient.cpp
@@ -93,12 +93,21 @@ void LobbyGuiAction::applyOnLobbyScreen(CLobbyScreen * lobby, CServerHandler * h
 	}
 }
 
-bool LobbyStartGame::applyOnLobbyHandler(CServerHandler * handler)
+bool LobbyEndGame::applyOnLobbyHandler(CServerHandler * handler)
 {
 	if(handler->state == EClientState::GAMEPLAY)
 	{
-		handler->endGameplay(false, true);
+		handler->endGameplay(closeConnection, restart);
 	}
+	
+	if(restart)
+		handler->sendStartGame();
+	
+	return true;
+}
+
+bool LobbyStartGame::applyOnLobbyHandler(CServerHandler * handler)
+{
 	handler->state = EClientState::STARTING;
 	if(handler->si->mode != StartInfo::LOAD_GAME)
 	{

--- a/client/NetPacksLobbyClient.cpp
+++ b/client/NetPacksLobbyClient.cpp
@@ -111,7 +111,7 @@ bool LobbyStartGame::applyOnLobbyHandler(CServerHandler * handler)
 
 void LobbyStartGame::applyOnLobbyScreen(CLobbyScreen * lobby, CServerHandler * handler)
 {
-	GH.pushIntT<CLoadingScreen>(std::bind(&CServerHandler::startGameplay, handler));
+	GH.pushIntT<CLoadingScreen>(std::bind(&CServerHandler::startGameplay, handler, nullptr));
 }
 
 bool LobbyUpdateState::applyOnLobbyHandler(CServerHandler * handler)

--- a/client/NetPacksLobbyClient.cpp
+++ b/client/NetPacksLobbyClient.cpp
@@ -105,13 +105,13 @@ bool LobbyStartGame::applyOnLobbyHandler(CServerHandler * handler)
 		handler->si = initializedStartInfo;
 	}
 	if(settings["session"]["headless"].Bool())
-		handler->startGameplay();
+		handler->startGameplay(initializedGameState);
 	return true;
 }
 
 void LobbyStartGame::applyOnLobbyScreen(CLobbyScreen * lobby, CServerHandler * handler)
 {
-	GH.pushIntT<CLoadingScreen>(std::bind(&CServerHandler::startGameplay, handler, nullptr));
+	GH.pushIntT<CLoadingScreen>(std::bind(&CServerHandler::startGameplay, handler, initializedGameState));
 }
 
 bool LobbyUpdateState::applyOnLobbyHandler(CServerHandler * handler)

--- a/lib/CCreatureSet.cpp
+++ b/lib/CCreatureSet.cpp
@@ -859,9 +859,6 @@ PlayerColor CStackInstance::getOwner() const
 
 void CStackInstance::deserializationFix()
 {
-	const CCreature *backup = type;
-	type = nullptr;
-		setType(backup);
 	const CArmedInstance *armyBackup = _armyObj;
 	_armyObj = nullptr;
 	setArmyObj(armyBackup);

--- a/lib/CCreatureSet.h
+++ b/lib/CCreatureSet.h
@@ -12,6 +12,7 @@
 #include "HeroBonus.h"
 #include "GameConstants.h"
 #include "CArtHandler.h"
+#include "CCreatureHandler.h"
 
 VCMI_LIB_NAMESPACE_BEGIN
 
@@ -40,7 +41,20 @@ public:
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & type;
+		if(h.saving)
+		{
+			CreatureID idNumber = type ? type->idNumber : CreatureID(CreatureID::NONE);
+			h & idNumber;
+		}
+		else
+		{
+			CreatureID idNumber;
+			h & idNumber;
+			if(idNumber != CreatureID::NONE)
+				setType(VLC->creh->objects[idNumber]);
+			else
+				type = nullptr;
+		}
 		h & count;
 	}
 

--- a/lib/NetPacksLobby.h
+++ b/lib/NetPacksLobby.h
@@ -142,8 +142,9 @@ struct LobbyStartGame : public CLobbyPackToPropagate
 {
 	// Set by server
 	std::shared_ptr<StartInfo> initializedStartInfo;
+	CGameState * initializedGameState;
 
-	LobbyStartGame() : initializedStartInfo(nullptr) {}
+	LobbyStartGame() : initializedStartInfo(nullptr), initializedGameState(nullptr) {}
 	bool checkClientPermissions(CVCMIServer * srv) const;
 	bool applyOnServer(CVCMIServer * srv);
 	void applyOnServerAfterAnnounce(CVCMIServer * srv);
@@ -153,6 +154,10 @@ struct LobbyStartGame : public CLobbyPackToPropagate
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
 		h & initializedStartInfo;
+		bool sps = h.smartPointerSerialization;
+		h.smartPointerSerialization = true;
+		h & initializedGameState;
+		h.smartPointerSerialization = sps;
 	}
 };
 

--- a/lib/NetPacksLobby.h
+++ b/lib/NetPacksLobby.h
@@ -138,6 +138,22 @@ struct LobbyGuiAction : public CLobbyPackToPropagate
 	}
 };
 
+struct LobbyEndGame : public CLobbyPackToPropagate
+{
+	bool closeConnection = false, restart = false;
+	
+	bool checkClientPermissions(CVCMIServer * srv) const;
+	bool applyOnServer(CVCMIServer * srv);
+	void applyOnServerAfterAnnounce(CVCMIServer * srv);
+	bool applyOnLobbyHandler(CServerHandler * handler);
+	
+	template <typename Handler> void serialize(Handler &h, const int version)
+	{
+		h & closeConnection;
+		h & restart;
+	}
+};
+
 struct LobbyStartGame : public CLobbyPackToPropagate
 {
 	// Set by server

--- a/lib/mapping/CMap.h
+++ b/lib/mapping/CMap.h
@@ -330,7 +330,7 @@ public:
 		h & players;
 		h & howManyTeams;
 		h & allowedHeroes;
-		h & triggeredEvents;
+		//Do not serialize triggeredEvents in header as they can contain information about heroes and armies
 		h & victoryMessage;
 		h & victoryIconIndex;
 		h & defeatMessage;
@@ -424,6 +424,7 @@ public:
 	void serialize(Handler &h, const int formatVersion)
 	{
 		h & static_cast<CMapHeader&>(*this);
+		h & triggeredEvents; //from CMapHeader
 		h & rumors;
 		h & allowedSpell;
 		h & allowedAbilities;

--- a/lib/registerTypes/RegisterTypes.h
+++ b/lib/registerTypes/RegisterTypes.h
@@ -372,6 +372,7 @@ void registerTypesLobbyPacks(Serializer &s)
 	s.template registerType<CLobbyPackToPropagate, LobbyChatMessage>();
 	// Only host client send
 	s.template registerType<CLobbyPackToPropagate, LobbyGuiAction>();
+	s.template registerType<CLobbyPackToPropagate, LobbyEndGame>();
 	s.template registerType<CLobbyPackToPropagate, LobbyStartGame>();
 	s.template registerType<CLobbyPackToPropagate, LobbyChangeHost>();
 	// Only server send

--- a/server/CVCMIServer.cpp
+++ b/server/CVCMIServer.cpp
@@ -238,7 +238,6 @@ bool CVCMIServer::prepareToStartGame()
 		c->disableStackSendingByID();
 	}
 
-	//if(!gh)
 	gh = std::make_shared<CGameHandler>(this);
 	switch(si->mode)
 	{

--- a/server/CVCMIServer.cpp
+++ b/server/CVCMIServer.cpp
@@ -220,7 +220,7 @@ void CVCMIServer::threadAnnounceLobby()
 	}
 }
 
-bool CVCMIServer::prepareToStartGame()
+void CVCMIServer::prepareToRestart()
 {
 	if(state == EServerState::GAMEPLAY)
 	{
@@ -237,7 +237,12 @@ bool CVCMIServer::prepareToStartGame()
 		c->enterLobbyConnectionMode();
 		c->disableStackSendingByID();
 	}
+	boost::unique_lock<boost::recursive_mutex> queueLock(mx);
+	gh = nullptr;
+}
 
+bool CVCMIServer::prepareToStartGame()
+{
 	gh = std::make_shared<CGameHandler>(this);
 	switch(si->mode)
 	{

--- a/server/CVCMIServer.cpp
+++ b/server/CVCMIServer.cpp
@@ -230,10 +230,16 @@ bool CVCMIServer::prepareToStartGame()
 		state = EServerState::LOBBY;
 		// FIXME: dirry hack to make sure old CGameHandler::run is finished
 		boost::this_thread::sleep(boost::posix_time::milliseconds(1000));
+		
+		for(auto c : connections)
+		{
+			c->enterLobbyConnectionMode();
+			c->disableStackSendingByID();
+		}
 	}
 
-	if(!gh)
-		gh = std::make_shared<CGameHandler>(this);
+	//if(!gh)
+	gh = std::make_shared<CGameHandler>(this);
 	switch(si->mode)
 	{
 	case StartInfo::CAMPAIGN:

--- a/server/CVCMIServer.cpp
+++ b/server/CVCMIServer.cpp
@@ -230,12 +230,12 @@ bool CVCMIServer::prepareToStartGame()
 		state = EServerState::LOBBY;
 		// FIXME: dirry hack to make sure old CGameHandler::run is finished
 		boost::this_thread::sleep(boost::posix_time::milliseconds(1000));
-		
-		for(auto c : connections)
-		{
-			c->enterLobbyConnectionMode();
-			c->disableStackSendingByID();
-		}
+	}
+	
+	for(auto c : connections)
+	{
+		c->enterLobbyConnectionMode();
+		c->disableStackSendingByID();
 	}
 
 	//if(!gh)

--- a/server/CVCMIServer.h
+++ b/server/CVCMIServer.h
@@ -69,6 +69,7 @@ public:
 	~CVCMIServer();
 	void run();
 	bool prepareToStartGame();
+	void prepareToRestart();
 	void startGameImmidiately();
 
 	void startAsyncAccept();

--- a/server/NetPacksLobbyServer.cpp
+++ b/server/NetPacksLobbyServer.cpp
@@ -181,6 +181,8 @@ bool LobbyStartGame::applyOnServer(CVCMIServer * srv)
 		return false;
 	
 	initializedStartInfo = std::make_shared<StartInfo>(*srv->gh->getStartInfo(true));
+	initializedGameState = srv->gh->gameState();
+
 	return true;
 }
 

--- a/server/NetPacksLobbyServer.cpp
+++ b/server/NetPacksLobbyServer.cpp
@@ -161,6 +161,27 @@ bool LobbyGuiAction::checkClientPermissions(CVCMIServer * srv) const
 	return srv->isClientHost(c->connectionID);
 }
 
+bool LobbyEndGame::checkClientPermissions(CVCMIServer * srv) const
+{
+	return srv->isClientHost(c->connectionID);
+}
+
+bool LobbyEndGame::applyOnServer(CVCMIServer * srv)
+{
+	srv->prepareToRestart();
+	return true;
+}
+
+void LobbyEndGame::applyOnServerAfterAnnounce(CVCMIServer * srv)
+{
+	boost::unique_lock<boost::mutex> stateLock(srv->stateMutex);
+	for(auto & c : srv->connections)
+	{
+		c->enterLobbyConnectionMode();
+		c->disableStackSendingByID();
+	}
+}
+
 bool LobbyStartGame::checkClientPermissions(CVCMIServer * srv) const
 {
 	return srv->isClientHost(c->connectionID);


### PR DESCRIPTION
Ok, then here is code which actually allows multiplayer among different platforms and architectures.
As side effect we have boost on RMG performance because now map is generated only once on server side and transferred it over network.

Tested scenarios:
 - start scenario (predefined map) (SP/MP)
 - start random map (SP/MP)
 - save, load, restart scenario (SP/MP)
 - campaign (but still cannot test next missions due to another bug)

No confidence:
 - save random map flag (should work for SP, but not sure about MP)
 - headless
 - AI-only

Known MP-related bugs (not related to the change)
 - cannot swap host/client for saved games
 - crash if someone exits from the game

I tried different approaches to manage this, but looks like that's the best. The main problem is that a lot of objects are connected between each other via raw pointers. That's probably a reason why it wasn't done from the beginning. For instance, artifacts have fields constituents and constituentOf, which creates infinite loop during serialisation. Similar story was for heroes and army. This PR is kind of combination of workarounds to pass all of that.
Note, that bugs, related to MP only, should be fixed separately as they are no regression