### PR TITLE
use SDL's standard input handling for in-game console

### DIFF
--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -148,14 +148,14 @@ set(client_HEADERS
 if(APPLE_IOS)
 	set(client_SRCS ${client_SRCS}
 		CFocusableHelper.cpp
-		ios/GameChatKeyboardHanlder.m
+		ios/GameChatKeyboardHandler.m
 		ios/main.m
 		ios/startSDL.mm
 		ios/utils.mm
 	)
 	set(client_HEADERS ${client_HEADERS}
 		CFocusableHelper.h
-		ios/GameChatKeyboardHanlder.h
+		ios/GameChatKeyboardHandler.h
 		ios/startSDL.h
 		ios/utils.h
 	)

--- a/client/ios/GameChatKeyboardHandler.h
+++ b/client/ios/GameChatKeyboardHandler.h
@@ -14,8 +14,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface GameChatKeyboardHandler : NSObject
 
-@property (nonatomic, weak) UITextField * textFieldSDL;
-
 - (void)triggerInput;
 
 @end

--- a/client/ios/GameChatKeyboardHandler.h
+++ b/client/ios/GameChatKeyboardHandler.h
@@ -1,5 +1,5 @@
 /*
- * GameChatKeyboardHanlder.h, part of VCMI engine
+ * GameChatKeyboardHandler.h, part of VCMI engine
  *
  * Authors: listed in file AUTHORS in main folder
  *
@@ -12,7 +12,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface GameChatKeyboardHanlder : NSObject
+@interface GameChatKeyboardHandler : NSObject
 
 @property (nonatomic, weak) UITextField * textFieldSDL;
 

--- a/client/ios/GameChatKeyboardHandler.m
+++ b/client/ios/GameChatKeyboardHandler.m
@@ -1,5 +1,5 @@
 /*
- * GameChatKeyboardHanlder.m, part of VCMI engine
+ * GameChatKeyboardHandler.m, part of VCMI engine
  *
  * Authors: listed in file AUTHORS in main folder
  *
@@ -8,7 +8,7 @@
  *
  */
 
-#import "GameChatKeyboardHanlder.h"
+#import "GameChatKeyboardHandler.h"
 
 #include <SDL_events.h>
 
@@ -32,11 +32,11 @@ static CGRect keyboardFrameBegin(NSNotification * n) { return keyboardFrame(n, U
 static CGRect keyboardFrameEnd  (NSNotification * n) { return keyboardFrame(n, UIKeyboardFrameEndUserInfoKey); }
 
 
-@interface GameChatKeyboardHanlder ()
+@interface GameChatKeyboardHandler ()
 @property (nonatomic) BOOL wasChatMessageSent;
 @end
 
-@implementation GameChatKeyboardHanlder
+@implementation GameChatKeyboardHandler
 
 - (void)triggerInput {
 	__auto_type notificationCenter = NSNotificationCenter.defaultCenter;
@@ -99,7 +99,7 @@ static int watchReturnKey(void * userdata, SDL_Event * event)
 {
 	if(event->type == SDL_KEYDOWN && event->key.keysym.scancode == SDL_SCANCODE_RETURN)
 	{
-		__auto_type self = (__bridge GameChatKeyboardHanlder *)userdata;
+		__auto_type self = (__bridge GameChatKeyboardHandler *)userdata;
 		self.wasChatMessageSent = YES;
 		SDL_DelEventWatch(watchReturnKey, userdata);
 	}

--- a/client/ios/startSDL.mm
+++ b/client/ios/startSDL.mm
@@ -33,26 +33,6 @@
 
     UIView * view = [object valueForKeyPath:keyPath];
 
-    UITextField * textField;
-    for (UIView * v in view.subviews) {
-        if ([v isKindOfClass:[UITextField class]]) {
-            textField = (UITextField *)v;
-            break;
-        }
-    }
-
-	auto r = textField.frame;
-	r.size.height = 40;
-	textField.frame = r;
-    self.gameChatHandler.textFieldSDL = textField;
-
-#if __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
-	if(@available(iOS 13.0, *))
-		textField.backgroundColor = UIColor.systemBackgroundColor;
-	else
-#endif
-		textField.backgroundColor = UIColor.whiteColor;
-
     auto longPress = [[UILongPressGestureRecognizer alloc] initWithTarget:self action:@selector(handleLongPress:)];
     longPress.minimumPressDuration = 0.2;
     [view addGestureRecognizer:longPress];

--- a/client/ios/startSDL.mm
+++ b/client/ios/startSDL.mm
@@ -8,7 +8,7 @@
  *
  */
 #import "startSDL.h"
-#import "GameChatKeyboardHanlder.h"
+#import "GameChatKeyboardHandler.h"
 
 #include "../Global.h"
 #include "CMT.h"
@@ -23,7 +23,7 @@
 #import <UIKit/UIKit.h>
 
 @interface SDLViewObserver : NSObject <UIGestureRecognizerDelegate>
-@property (nonatomic, strong) GameChatKeyboardHanlder * gameChatHandler;
+@property (nonatomic, strong) GameChatKeyboardHandler * gameChatHandler;
 @end
 
 @implementation SDLViewObserver
@@ -131,7 +131,7 @@ int startSDL(int argc, char * argv[], BOOL startManually)
 {
 	@autoreleasepool {
 		auto observer = [SDLViewObserver new];
-		observer.gameChatHandler = [GameChatKeyboardHanlder new];
+		observer.gameChatHandler = [GameChatKeyboardHandler new];
 
 		id __block sdlWindowCreationObserver = [NSNotificationCenter.defaultCenter addObserverForName:UIWindowDidBecomeKeyNotification object:nil queue:nil usingBlock:^(NSNotification * _Nonnull note) {
 			[NSNotificationCenter.defaultCenter removeObserver:sdlWindowCreationObserver];

--- a/client/widgets/AdventureMapClasses.cpp
+++ b/client/widgets/AdventureMapClasses.cpp
@@ -1129,7 +1129,7 @@ void CInGameConsole::textEdited(const SDL_TextEditingEvent & event)
 
 void CInGameConsole::startEnteringText()
 {
-	CSDL_Ext::startTextInput(&pos);
+	CSDL_Ext::startTextInput(&GH.statusbar->pos);
 
 	enteredText = "_";
 	if(GH.topInt() == adventureInt)


### PR DESCRIPTION
Now UI is moved to the top (default SDL behavior) to be able to see directly what's being typed into the console:

![Screen Shot 2022-09-29 at 14 07 48](https://user-images.githubusercontent.com/1557784/193016497-8f7f410b-29fe-4233-86bb-fbd7e0355a78.png)

fixes #986 