### PR TITLE
Fix quest check that requires identical artifacts

### DIFF
--- a/lib/CArtHandler.h
+++ b/lib/CArtHandler.h
@@ -328,6 +328,7 @@ public:
 	/// (if more than one such artifact lower ID is returned)
 	ArtifactPosition getArtPos(int aid, bool onlyWorn = true, bool allowLocked = true) const;
 	ArtifactPosition getArtPos(const CArtifactInstance *art) const;
+	std::vector<ArtifactPosition> getAllArtPositions(int aid, bool onlyWorn, bool allowLocked, bool getAll) const;
 	const CArtifactInstance *getArtByInstanceId(ArtifactInstanceID artInstId) const;
 	/// Search for constituents of assemblies in backpack which do not have an ArtifactPosition
 	const CArtifactInstance *getHiddenArt(int aid) const;
@@ -335,6 +336,7 @@ public:
 	/// Checks if hero possess artifact of given id (either in backack or worn)
 	bool hasArt(ui32 aid, bool onlyWorn = false, bool searchBackpackAssemblies = false, bool allowLocked = true) const;
 	bool isPositionFree(ArtifactPosition pos, bool onlyLockCheck = false) const;
+	unsigned getArtPosCount(int aid, bool onlyWorn = true, bool searchBackpackAssemblies = true, bool allowLocked = true) const;
 
 	virtual ArtBearer::ArtBearer bearerType() const = 0;
 	virtual void putArtifact(ArtifactPosition pos, CArtifactInstance * art) = 0;

--- a/lib/mapObjects/CQuest.cpp
+++ b/lib/mapObjects/CQuest.cpp
@@ -112,11 +112,16 @@ bool CQuest::checkQuest(const CGHeroInstance * h) const
 				return true;
 			return false;
 		case MISSION_ART:
-			for(auto & elem : m5arts)
+			// if the object was deserialized
+			if(artifactsRequirements.empty())
+				for(auto id : m5arts)
+					++artifactsRequirements[id];
+
+			for(const auto & elem : artifactsRequirements)
 			{
-				if(h->hasArt(elem, false, true))
-					continue;
-				return false; //if the artifact was not found
+				// check required amount of artifacts
+				if(h->getArtPosCount(elem.first, false, true, true) < elem.second)
+					return false;
 			}
 			return true;
 		case MISSION_ARMY:
@@ -415,6 +420,12 @@ void CQuest::getCompletionText(MetaString &iwText, std::vector<Component> &compo
 				iwText.addReplacement(VLC->generaltexth->colors[m13489val]);
 			break;
 	}
+}
+
+void CQuest::addArtifactID(ui16 id)
+{
+	m5arts.push_back(id);
+	++artifactsRequirements[id];
 }
 
 void CQuest::serializeJson(JsonSerializeFormat & handler, const std::string & fieldName)

--- a/lib/mapObjects/CQuest.h
+++ b/lib/mapObjects/CQuest.h
@@ -19,7 +19,7 @@ VCMI_LIB_NAMESPACE_BEGIN
 
 class CGCreature;
 
-class DLL_LINKAGE CQuest
+class DLL_LINKAGE CQuest final
 {
 public:
 	enum Emission {MISSION_NONE = 0, MISSION_LEVEL = 1, MISSION_PRIMARY_STAT = 2, MISSION_KILL_HERO = 3, MISSION_KILL_CREATURE = 4,
@@ -52,7 +52,6 @@ public:
 	bool isCustomFirst, isCustomNext, isCustomComplete;
 
 	CQuest();
-	virtual ~CQuest(){};
 
 	static bool checkMissionArmy(const CQuest * q, const CCreatureSet * army);
 	virtual bool checkQuest (const CGHeroInstance * h) const; //determines whether the quest is complete or not
@@ -161,7 +160,7 @@ protected:
 class DLL_LINKAGE CGQuestGuard : public CGSeerHut
 {
 public:
-	CGQuestGuard() : CGSeerHut(){};
+	CGQuestGuard() = default;
 	void init(CRandomGenerator & rand) override;
 	void completeQuest (const CGHeroInstance * h) const override;
 
@@ -209,7 +208,7 @@ public:
 class DLL_LINKAGE CGBorderGuard : public CGKeys, public IQuestObject
 {
 public:
-	CGBorderGuard() : IQuestObject(){};
+	CGBorderGuard() = default;
 	void initObj(CRandomGenerator & rand) override;
 	void onHeroVisit(const CGHeroInstance * h) const override;
 	void blockingDialogAnswered(const CGHeroInstance *hero, ui32 answer) const override;
@@ -231,7 +230,7 @@ public:
 class DLL_LINKAGE CGBorderGate : public CGBorderGuard
 {
 public:
-	CGBorderGate() : CGBorderGuard(){};
+	CGBorderGate() = default;
 	void onHeroVisit(const CGHeroInstance * h) const override;
 
 	bool passableFor(PlayerColor color) const override;

--- a/lib/mapObjects/CQuest.h
+++ b/lib/mapObjects/CQuest.h
@@ -21,6 +21,8 @@ class CGCreature;
 
 class DLL_LINKAGE CQuest final
 {
+	mutable std::unordered_map<ui16, unsigned> artifactsRequirements; // artifact ID -> required count
+
 public:
 	enum Emission {MISSION_NONE = 0, MISSION_LEVEL = 1, MISSION_PRIMARY_STAT = 2, MISSION_KILL_HERO = 3, MISSION_KILL_CREATURE = 4,
 		MISSION_ART = 5, MISSION_ARMY = 6, MISSION_RESOURCES = 7, MISSION_HERO = 8, MISSION_PLAYER = 9, MISSION_KEYMASTER = 10};
@@ -34,7 +36,7 @@ public:
 
 	ui32 m13489val;
 	std::vector<ui32> m2stats;
-	std::vector<ui16> m5arts; //artifacts id
+	std::vector<ui16> m5arts; // artifact IDs. Add IDs through addArtifactID(), not directly to the field.
 	std::vector<CStackBasicDescriptor> m6creatures; //pair[cre id, cre count], CreatureSet info irrelevant
 	std::vector<ui32> m7resources; //TODO: use resourceset?
 
@@ -60,6 +62,7 @@ public:
 	virtual void getRolloverText (MetaString &text, bool onHover) const; //hover or quest log entry
 	virtual void completeQuest (const CGHeroInstance * h) const {};
 	virtual void addReplacements(MetaString &out, const std::string &base) const;
+	void addArtifactID(ui16 id);
 
 	bool operator== (const CQuest & quest) const
 	{

--- a/lib/mapping/MapFormatH3M.cpp
+++ b/lib/mapping/MapFormatH3M.cpp
@@ -1758,7 +1758,7 @@ CGSeerHut * CMapLoaderH3M::readSeerHut()
 		if (artID != 255)
 		{
 			//not none quest
-			hut->quest->m5arts.push_back (artID);
+			hut->quest->addArtifactID(artID);
 			hut->quest->missionType = CQuest::MISSION_ART;
 		}
 		else
@@ -1887,7 +1887,7 @@ void CMapLoaderH3M::readQuest(IQuestObject * guard)
 			for(int yy = 0; yy < artNumber; ++yy)
 			{
 				int artid = reader.readUInt16();
-				guard->quest->m5arts.push_back(artid);
+				guard->quest->addArtifactID(artid);
 				map->allowedArtifact[artid] = false; //these are unavailable for random generation
 			}
 			break;

--- a/lib/rmg/TreasurePlacer.cpp
+++ b/lib/rmg/TreasurePlacer.cpp
@@ -430,7 +430,7 @@ void TreasurePlacer::addAllPossibleObjects()
 				
 				obj->quest->missionType = CQuest::MISSION_ART;
 				ArtifactID artid = *RandomGeneratorUtil::nextItem(generator.getQuestArtsRemaning(), generator.rand);
-				obj->quest->m5arts.push_back(artid);
+				obj->quest->addArtifactID(artid);
 				obj->quest->lastDay = -1;
 				obj->quest->isCustomFirst = obj->quest->isCustomNext = obj->quest->isCustomComplete = false;
 				
@@ -467,7 +467,7 @@ void TreasurePlacer::addAllPossibleObjects()
 				
 				obj->quest->missionType = CQuest::MISSION_ART;
 				ArtifactID artid = *RandomGeneratorUtil::nextItem(generator.getQuestArtsRemaning(), generator.rand);
-				obj->quest->m5arts.push_back(artid);
+				obj->quest->addArtifactID(artid);
 				obj->quest->lastDay = -1;
 				obj->quest->isCustomFirst = obj->quest->isCustomNext = obj->quest->isCustomComplete = false;
 				
@@ -490,7 +490,7 @@ void TreasurePlacer::addAllPossibleObjects()
 				
 				obj->quest->missionType = CQuest::MISSION_ART;
 				ArtifactID artid = *RandomGeneratorUtil::nextItem(generator.getQuestArtsRemaning(), generator.rand);
-				obj->quest->m5arts.push_back(artid);
+				obj->quest->addArtifactID(artid);
 				obj->quest->lastDay = -1;
 				obj->quest->isCustomFirst = obj->quest->isCustomNext = obj->quest->isCustomComplete = false;
 				


### PR DESCRIPTION
Now the check fetches amount of a given artifact from hero and compares that to the quest requirement.

fixes #945, you can find test map there.