### PR TITLE
switch to flat libs directory structure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -402,8 +402,14 @@ else()
 	add_definitions(-DM_LIB_DIR="${CMAKE_INSTALL_PREFIX}/${LIB_DIR}")
 endif()
 
-set(AI_LIB_DIR "${LIB_DIR}/AI")
-set(SCRIPTING_LIB_DIR "${LIB_DIR}/scripting")
+# iOS has flat libs directory structure
+if(APPLE_IOS)
+	set(AI_LIB_DIR "${LIB_DIR}")
+	set(SCRIPTING_LIB_DIR "${LIB_DIR}")
+else()
+	set(AI_LIB_DIR "${LIB_DIR}/AI")
+	set(SCRIPTING_LIB_DIR "${LIB_DIR}/scripting")
+endif()
 
 #######################################
 #        Add subdirectories           #

--- a/launcher/mainwindow_moc.cpp
+++ b/launcher/mainwindow_moc.cpp
@@ -92,7 +92,8 @@ MainWindow::MainWindow(QWidget * parent)
 
 	connect(ui->tabSelectList, &QListWidget::currentRowChanged, [this](int i) {
 #ifdef Q_OS_IOS
-		qApp->focusWidget()->clearFocus();
+		if(auto widget = qApp->focusWidget())
+			widget->clearFocus();
 #endif
 		ui->tabListWidget->setCurrentIndex(i);
 	});

--- a/lib/VCMIDirs.cpp
+++ b/lib/VCMIDirs.cpp
@@ -391,6 +391,7 @@ public:
 	std::vector<bfs::path> dataPaths() const override;
 
 	bfs::path libraryPath() const override;
+	bfs::path fullLibraryPath(const std::string & desiredFolder, const std::string & baseLibName) const override;
 	bfs::path binaryPath() const override;
 };
 
@@ -409,6 +410,12 @@ std::vector<bfs::path> VCMIDirsIOS::dataPaths() const
 	paths.emplace_back(iOS_utils::documentsPath());
 	paths.emplace_back(binaryPath());
 	return paths;
+}
+
+bfs::path VCMIDirsIOS::fullLibraryPath(const std::string & desiredFolder, const std::string & baseLibName) const
+{
+	// iOS has flat libs directory structure
+	return libraryPath() / libraryName(baseLibName);
 }
 
 bfs::path VCMIDirsIOS::libraryPath() const { return {iOS_utils::frameworksPath()}; }


### PR DESCRIPTION
3rd party signing tools like AltStore and Sideloadly seem to sign app bundle incorrectly when `Frameworks` directory contains subdirectories.

also fixed iOS-only regression introduced in #1012 

fixes #996
fixes #1026 
fixes #1031