### PR TITLE
don't add Necromancy to Witch Hut on random maps

### DIFF
--- a/lib/mapObjects/CObjectClassesHandler.cpp
+++ b/lib/mapObjects/CObjectClassesHandler.cpp
@@ -58,7 +58,6 @@ CObjectClassesHandler::CObjectClassesHandler()
 	SET_HANDLER("randomDwelling", CGDwelling);
 
 	SET_HANDLER("generic", CGObjectInstance);
-	SET_HANDLER("market", CGMarket);
 	SET_HANDLER("cartographer", CCartographer);
 	SET_HANDLER("artifact", CGArtifact);
 	SET_HANDLER("blackMarket", CGBlackMarket);

--- a/lib/mapObjects/MiscObjects.cpp
+++ b/lib/mapObjects/MiscObjects.cpp
@@ -1452,8 +1452,10 @@ void CGWitchHut::initObj(CRandomGenerator & rand)
 {
 	if (allowedAbilities.empty()) //this can happen for RMG. regular maps load abilities from map file
 	{
+		// Necromancy can't be learned on random maps
 		for(int i = 0; i < VLC->skillh->size(); i++)
-			allowedAbilities.push_back(i);
+			if(VLC->skillh->getByIndex(i)->getId() != SecondarySkill::NECROMANCY)
+				allowedAbilities.push_back(i);
 	}
 	ability = *RandomGeneratorUtil::nextItem(allowedAbilities, rand);
 }


### PR DESCRIPTION
The fix seems to work: tested by starting/loading existing scenarios to ensure that this code path isn't called, also created random map and visited witch hut with inverted condition to ensure that I receive Necromancy. But I saw there's another possibility although seems more complicated: create witch hut "specialisation" by inheriting from `CDefaultObjectTypeHandler` similarly to e.g. `CTownInstanceConstructor`.

fixes #934