### PR TITLE
restore last used address in Multiplayer join dialog

### DIFF
--- a/client/CServerHandler.cpp
+++ b/client/CServerHandler.cpp
@@ -59,6 +59,8 @@
 
 template<typename T> class CApplyOnLobby;
 
+const std::string CServerHandler::localhostAddress{"127.0.0.1"};
+
 #ifdef VCMI_ANDROID
 extern std::atomic_bool androidTestServerReadyFlag;
 #endif
@@ -171,7 +173,7 @@ void CServerHandler::startLocalServerAndConnect()
 	auto errorMsg = CGI->generaltexth->localizedTexts["server"]["errors"]["existingProcess"].String();
 	try
 	{
-		CConnection testConnection(settings["server"]["server"].String(), getDefaultPort(), NAME, uuid);
+		CConnection testConnection(localhostAddress, getDefaultPort(), NAME, uuid);
 		logNetwork->error("Port is busy, check if another instance of vcmiserver is working");
 		CInfoWindow::showInfoDialog(errorMsg, {});
 		return;
@@ -243,7 +245,7 @@ void CServerHandler::startLocalServerAndConnect()
 #else
 	const ui16 port = 0;
 #endif
-	justConnectToServer(settings["server"]["server"].String(), port);
+	justConnectToServer(localhostAddress, port);
 
 	logNetwork->trace("\tConnecting to the server: %d ms", th->getDiff());
 }
@@ -269,9 +271,17 @@ void CServerHandler::justConnectToServer(const std::string & addr, const ui16 po
 	}
 
 	if(state == EClientState::CONNECTION_CANCELLED)
+	{
 		logNetwork->info("Connection aborted by player!");
-	else
-		c->handler = std::make_shared<boost::thread>(&CServerHandler::threadHandleConnection, this);
+		return;
+	}
+
+	c->handler = std::make_shared<boost::thread>(&CServerHandler::threadHandleConnection, this);
+
+	if(addr.empty() || addr == localhostAddress)
+		return;
+	Settings serverAddress = settings.write["server"]["server"];
+	serverAddress->String() = addr;
 }
 
 void CServerHandler::applyPacksOnLobbyScreen()
@@ -633,7 +643,7 @@ void CServerHandler::debugStartTest(std::string filename, bool save)
 		screenType = ESelectionScreen::newGame;
 	}
 	if(settings["session"]["donotstartserver"].Bool())
-		justConnectToServer("127.0.0.1", 3030);
+		justConnectToServer(localhostAddress, 3030);
 	else
 		startLocalServerAndConnect();
 

--- a/client/CServerHandler.h
+++ b/client/CServerHandler.h
@@ -106,6 +106,8 @@ public:
 
 	CondSh<bool> campaignServerRestartLock;
 
+	static const std::string localhostAddress;
+
 	CServerHandler();
 
 	void resetStateForLobby(const StartInfo::EMode mode, const std::vector<std::string> * names = nullptr);

--- a/client/mainmenu/CMainMenu.cpp
+++ b/client/mainmenu/CMainMenu.cpp
@@ -481,7 +481,7 @@ CSimpleJoinScreen::CSimpleJoinScreen(bool host)
 
 		inputAddress->giveFocus();
 	}
-	inputAddress->setText(settings["server"]["server"].String(), true);
+	inputAddress->setText(host ? CServerHandler::localhostAddress : settings["server"]["server"].String(), true);
 	inputPort->setText(CServerHandler::getDefaultPortStr(), true);
 
 	buttonCancel = std::make_shared<CButton>(Point(142, 142), "MUBCANC.DEF", CGI->generaltexth->zelp[561], std::bind(&CSimpleJoinScreen::leaveScreen, this), SDLK_ESCAPE);


### PR DESCRIPTION
- in all other cases (when machine is host) hardcoded localhost address is displayed
- the very first time also localhost address is shown because it's default setting

fixes #1004