### PR TITLE
MP handle disconnection

### DIFF
--- a/client/CMT.cpp
+++ b/client/CMT.cpp
@@ -395,6 +395,7 @@ int main(int argc, char * argv[])
 	CCS = new CClientState();
 	CGI = new CGameInfo(); //contains all global informations about game (texts, lodHandlers, map handler etc.)
 	CSH = new CServerHandler();
+	
 	// Initialize video
 #ifdef DISABLE_VIDEO
 	CCS->videoh = new CEmptyVideoPlayer();
@@ -494,6 +495,12 @@ int main(int argc, char * argv[])
 	else
 	{
 		GH.curInt = CMainMenu::create().get();
+	}
+	
+	// Restore remote session - start game immediately
+	if(settings["server"]["reconnect"].Bool())
+	{
+		CSH->restoreLastSession();
 	}
 
 	if(!settings["session"]["headless"].Bool())

--- a/client/CServerHandler.cpp
+++ b/client/CServerHandler.cpp
@@ -563,6 +563,7 @@ void CServerHandler::startGameplay(CGameState * gameState)
 		Settings saveUuid = settings.write["server"]["uuid"];
 		saveUuid->String() = uuid;
 		Settings saveNames = settings.write["server"]["names"];
+		saveNames->Vector().clear();
 		for(auto & name : myNames)
 		{
 			JsonNode jsonName;

--- a/client/CServerHandler.h
+++ b/client/CServerHandler.h
@@ -155,6 +155,7 @@ public:
 	ui8 getLoadMode();
 
 	void debugStartTest(std::string filename, bool save = false);
+	void restoreLastSession();
 };
 
 extern CServerHandler * CSH;

--- a/client/NetPacksClient.cpp
+++ b/client/NetPacksClient.cpp
@@ -347,11 +347,21 @@ void PlayerEndsGame::applyCl(CClient *cl)
 
 void PlayerReinitInterface::applyCl(CClient * cl)
 {
-	CSH->si->getIthPlayersSettings(player).connectedPlayerIDs.clear();
-	cl->initPlayerEnvironments();
-	cl->initPlayerInterfaces();
-	if(cl->gameState()->currentPlayer == player)
+	auto & plSettings = CSH->si->getIthPlayersSettings(player);
+	if(!playerConnectionId)
+	{
+		plSettings.connectedPlayerIDs.clear();
+		cl->initPlayerEnvironments();
+		cl->initPlayerInterfaces();
+		if(cl->gameState()->currentPlayer == player)
+			callOnlyThatInterface(cl, player, &CGameInterface::yourTurn);
+	}
+	else
+	{
+		plSettings.connectedPlayerIDs.insert(playerConnectionId);
+		callAllInterfaces(cl, &IGameEventsReceiver::playerStartsTurn, player);
 		callOnlyThatInterface(cl, player, &CGameInterface::yourTurn);
+	}
 }
 
 void RemoveBonus::applyCl(CClient *cl)

--- a/client/NetPacksClient.cpp
+++ b/client/NetPacksClient.cpp
@@ -359,7 +359,9 @@ void PlayerReinitInterface::applyCl(CClient * cl)
 	else
 	{
 		plSettings.connectedPlayerIDs.insert(playerConnectionId);
+		cl->initPlayerInterfaces();
 		callAllInterfaces(cl, &IGameEventsReceiver::playerStartsTurn, player);
+		//if(cl->gameState()->currentPlayer == player)
 		callOnlyThatInterface(cl, player, &CGameInterface::yourTurn);
 	}
 }

--- a/client/NetPacksClient.cpp
+++ b/client/NetPacksClient.cpp
@@ -356,13 +356,14 @@ void PlayerReinitInterface::applyCl(CClient * cl)
 		if(cl->gameState()->currentPlayer == player)
 			callOnlyThatInterface(cl, player, &CGameInterface::yourTurn);
 	}
-	else
+	else if(playerConnectionId == CSH->c->connectionID)
 	{
 		plSettings.connectedPlayerIDs.insert(playerConnectionId);
+		cl->playerint.clear();
 		cl->initPlayerInterfaces();
-		callAllInterfaces(cl, &IGameEventsReceiver::playerStartsTurn, player);
-		//if(cl->gameState()->currentPlayer == player)
-		callOnlyThatInterface(cl, player, &CGameInterface::yourTurn);
+		auto currentPlayer = cl->gameState()->currentPlayer;
+		callAllInterfaces(cl, &IGameEventsReceiver::playerStartsTurn, currentPlayer);
+		callOnlyThatInterface(cl, currentPlayer, &CGameInterface::yourTurn);
 	}
 }
 

--- a/client/NetPacksClient.cpp
+++ b/client/NetPacksClient.cpp
@@ -345,6 +345,15 @@ void PlayerEndsGame::applyCl(CClient *cl)
 		handleQuit(settings["session"]["spectate"].Bool()); // if spectator is active ask to close client or not
 }
 
+void PlayerReinitInterface::applyCl(CClient * cl)
+{
+	CSH->si->getIthPlayersSettings(player).connectedPlayerIDs.clear();
+	cl->initPlayerEnvironments();
+	cl->initPlayerInterfaces();
+	if(cl->gameState()->currentPlayer == player)
+		callOnlyThatInterface(cl, player, &CGameInterface::yourTurn);
+}
+
 void RemoveBonus::applyCl(CClient *cl)
 {
 	cl->invalidatePaths();

--- a/client/NetPacksClient.cpp
+++ b/client/NetPacksClient.cpp
@@ -353,8 +353,9 @@ void PlayerReinitInterface::applyCl(CClient * cl)
 		plSettings.connectedPlayerIDs.clear();
 		cl->initPlayerEnvironments();
 		cl->initPlayerInterfaces();
-		if(cl->gameState()->currentPlayer == player)
-			callOnlyThatInterface(cl, player, &CGameInterface::yourTurn);
+		auto currentPlayer = cl->gameState()->currentPlayer;
+		callAllInterfaces(cl, &IGameEventsReceiver::playerStartsTurn, currentPlayer);
+		callOnlyThatInterface(cl, currentPlayer, &CGameInterface::yourTurn);
 	}
 	else if(playerConnectionId == CSH->c->connectionID)
 	{

--- a/client/NetPacksLobbyClient.cpp
+++ b/client/NetPacksLobbyClient.cpp
@@ -74,7 +74,7 @@ void LobbyChatMessage::applyOnLobbyScreen(CLobbyScreen * lobby, CServerHandler *
 
 void LobbyGuiAction::applyOnLobbyScreen(CLobbyScreen * lobby, CServerHandler * handler)
 {
-	if(!handler->isGuest())
+	if(!lobby || !handler->isGuest())
 		return;
 
 	switch(action)
@@ -133,6 +133,9 @@ bool LobbyUpdateState::applyOnLobbyHandler(CServerHandler * handler)
 
 void LobbyUpdateState::applyOnLobbyScreen(CLobbyScreen * lobby, CServerHandler * handler)
 {
+	if(!lobby) //stub: ignore message for game mode
+		return;
+		
 	if(!lobby->bonusSel && handler->si->campState && handler->state == EClientState::LOBBY_CAMPAIGN)
 	{
 		lobby->bonusSel = std::make_shared<CBonusSelection>();
@@ -150,6 +153,9 @@ void LobbyUpdateState::applyOnLobbyScreen(CLobbyScreen * lobby, CServerHandler *
 
 void LobbyShowMessage::applyOnLobbyScreen(CLobbyScreen * lobby, CServerHandler * handler)
 {
+	if(!lobby) //stub: ignore message for game mode
+		return;
+	
 	lobby->buttonStart->block(false);
 	handler->showServerError(message);
 }

--- a/client/NetPacksLobbyClient.cpp
+++ b/client/NetPacksLobbyClient.cpp
@@ -113,9 +113,11 @@ bool LobbyStartGame::applyOnLobbyHandler(CServerHandler * handler)
 		return false;
 	
 	handler->state = EClientState::STARTING;
-	if(handler->si->mode != StartInfo::LOAD_GAME)
+	if(handler->si->mode != StartInfo::LOAD_GAME || clientId == handler->c->connectionID)
 	{
+		auto modeBackup = handler->si->mode;
 		handler->si = initializedStartInfo;
+		handler->si->mode = modeBackup;
 	}
 	if(settings["session"]["headless"].Bool())
 		handler->startGameplay(initializedGameState);

--- a/client/NetPacksLobbyClient.cpp
+++ b/client/NetPacksLobbyClient.cpp
@@ -109,6 +109,9 @@ bool LobbyEndGame::applyOnLobbyHandler(CServerHandler * handler)
 
 bool LobbyStartGame::applyOnLobbyHandler(CServerHandler * handler)
 {
+	if(clientId != -1 && clientId != handler->c->connectionID)
+		return false;
+	
 	handler->state = EClientState::STARTING;
 	if(handler->si->mode != StartInfo::LOAD_GAME)
 	{
@@ -121,6 +124,9 @@ bool LobbyStartGame::applyOnLobbyHandler(CServerHandler * handler)
 
 void LobbyStartGame::applyOnLobbyScreen(CLobbyScreen * lobby, CServerHandler * handler)
 {
+	if(clientId != -1 && clientId != handler->c->connectionID)
+		return;
+	
 	GH.pushIntT<CLoadingScreen>(std::bind(&CServerHandler::startGameplay, handler, initializedGameState));
 }
 

--- a/config/schemas/settings.json
+++ b/config/schemas/settings.json
@@ -253,7 +253,7 @@
 			"type" : "object",
 			"additionalProperties" : false,
 			"default": {},
-			"required" : [ "server", "port", "localInformation", "playerAI", "friendlyAI","neutralAI", "enemyAI", "reconnect", "uuid" ],
+			"required" : [ "server", "port", "localInformation", "playerAI", "friendlyAI","neutralAI", "enemyAI", "reconnect", "uuid", "names" ],
 			"properties" : {
 				"server" : {
 					"type":"string",
@@ -290,6 +290,15 @@
 				"uuid" : {
 					"type" : "string",
 					"default" : ""
+				},
+				"names" : {
+					"type" : "array",
+					"default" : {},
+					"items":
+					{
+						"type" : "string",
+						"default" : ""
+					}
 				}
 			}
 		},

--- a/config/schemas/settings.json
+++ b/config/schemas/settings.json
@@ -253,7 +253,7 @@
 			"type" : "object",
 			"additionalProperties" : false,
 			"default": {},
-			"required" : [ "server", "port", "localInformation", "playerAI", "friendlyAI","neutralAI", "enemyAI" ],
+			"required" : [ "server", "port", "localInformation", "playerAI", "friendlyAI","neutralAI", "enemyAI", "reconnect", "uuid" ],
 			"properties" : {
 				"server" : {
 					"type":"string",
@@ -282,6 +282,14 @@
 				"enemyAI" : {
 					"type" : "string",
 					"default" : "BattleAI"
+				},
+				"reconnect" : {
+					"type" : "boolean",
+					"default" : false
+				},
+				"uuid" : {
+					"type" : "string",
+					"default" : ""
 				}
 			}
 		},

--- a/lib/NetPacks.h
+++ b/lib/NetPacks.h
@@ -421,6 +421,21 @@ struct PlayerEndsGame : public CPackForClient
 	}
 };
 
+struct PlayerReinitInterface : public CPackForClient
+{
+	void applyCl(CClient * cl);
+	DLL_LINKAGE void applyGs(CGameState *gs);
+	
+	PlayerColor player;
+	ui8 playerConnectionId; //PLAYER_AI fro AI player
+	
+	template <typename Handler> void serialize(Handler &h, const int version)
+	{
+		h & player;
+		h & playerConnectionId;
+	}
+};
+
 struct RemoveBonus :  public CPackForClient
 {
 	RemoveBonus(ui8 Who = 0)

--- a/lib/NetPacksLib.cpp
+++ b/lib/NetPacksLib.cpp
@@ -370,6 +370,11 @@ DLL_LINKAGE void PlayerReinitInterface::applyGs(CGameState *gs)
 	if(!gs || !gs->scenarioOps)
 		return;
 	
+	gs->currentPlayer = player;
+	
+	//auto & playerState = gs->players[player];
+	//playerState.daysWithoutCastle = daysWithoutCastle;
+	
 	//TODO: what does mean if more that one player connected?
 	//gs->scenarioOps->getIthPlayersSettings(player).connectedPlayerIDs.clear();
 }

--- a/lib/NetPacksLib.cpp
+++ b/lib/NetPacksLib.cpp
@@ -365,6 +365,15 @@ DLL_LINKAGE void PlayerEndsGame::applyGs(CGameState *gs)
 	}
 }
 
+DLL_LINKAGE void PlayerReinitInterface::applyGs(CGameState *gs)
+{
+	if(!gs || !gs->scenarioOps)
+		return;
+	
+	//TODO: what does mean if more that one player connected?
+	gs->scenarioOps->getIthPlayersSettings(player).connectedPlayerIDs.clear();
+}
+
 DLL_LINKAGE void RemoveBonus::applyGs(CGameState *gs)
 {
 	CBonusSystemNode *node;

--- a/lib/NetPacksLib.cpp
+++ b/lib/NetPacksLib.cpp
@@ -369,9 +369,6 @@ DLL_LINKAGE void PlayerReinitInterface::applyGs(CGameState *gs)
 {
 	if(!gs || !gs->scenarioOps)
 		return;
-	
-	gs->currentPlayer = player;
-	
 	//auto & playerState = gs->players[player];
 	//playerState.daysWithoutCastle = daysWithoutCastle;
 	

--- a/lib/NetPacksLib.cpp
+++ b/lib/NetPacksLib.cpp
@@ -371,7 +371,7 @@ DLL_LINKAGE void PlayerReinitInterface::applyGs(CGameState *gs)
 		return;
 	
 	//TODO: what does mean if more that one player connected?
-	gs->scenarioOps->getIthPlayersSettings(player).connectedPlayerIDs.clear();
+	//gs->scenarioOps->getIthPlayersSettings(player).connectedPlayerIDs.clear();
 }
 
 DLL_LINKAGE void RemoveBonus::applyGs(CGameState *gs)

--- a/lib/NetPacksLobby.h
+++ b/lib/NetPacksLobby.h
@@ -159,8 +159,9 @@ struct LobbyStartGame : public CLobbyPackToPropagate
 	// Set by server
 	std::shared_ptr<StartInfo> initializedStartInfo;
 	CGameState * initializedGameState;
+	int clientId; //-1 means to all clients
 
-	LobbyStartGame() : initializedStartInfo(nullptr), initializedGameState(nullptr) {}
+	LobbyStartGame() : initializedStartInfo(nullptr), initializedGameState(nullptr), clientId(-1) {}
 	bool checkClientPermissions(CVCMIServer * srv) const;
 	bool applyOnServer(CVCMIServer * srv);
 	void applyOnServerAfterAnnounce(CVCMIServer * srv);
@@ -169,6 +170,7 @@ struct LobbyStartGame : public CLobbyPackToPropagate
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
+		h & clientId;
 		h & initializedStartInfo;
 		bool sps = h.smartPointerSerialization;
 		h.smartPointerSerialization = true;

--- a/lib/mapObjects/CGTownInstance.h
+++ b/lib/mapObjects/CGTownInstance.h
@@ -349,7 +349,7 @@ public:
 
 	inline bool isBattleOutsideTown(const CGHeroInstance * defendingHero) const
 	{
-		return defendingHero && garrisonHero && defendingHero != garrisonHero;
+		return defendingHero && defendingHero != garrisonHero;
 	}
 protected:
 	void setPropertyDer(ui8 what, ui32 val) override;

--- a/lib/registerTypes/RegisterTypes.h
+++ b/lib/registerTypes/RegisterTypes.h
@@ -240,6 +240,7 @@ void registerTypesClientPacks1(Serializer &s)
 	s.template registerType<CPackForClient, GiveBonus>();
 	s.template registerType<CPackForClient, ChangeObjPos>();
 	s.template registerType<CPackForClient, PlayerEndsGame>();
+	s.template registerType<CPackForClient, PlayerReinitInterface>();
 	s.template registerType<CPackForClient, RemoveBonus>();
 	s.template registerType<CPackForClient, UpdateArtHandlerLists>();
 	s.template registerType<CPackForClient, UpdateMapEvents>();

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -1324,7 +1324,7 @@ void CGameHandler::addGenericKilledLog(BattleLogMessage & blm, const CStack * de
 
 void CGameHandler::handleClientDisconnection(std::shared_ptr<CConnection> c)
 {
-	for(auto playerConns : connections)
+	/*for(auto playerConns : connections)
 	{
 		for(auto i = playerConns.second.begin(); i != playerConns.second.end(); )
 		{
@@ -1342,7 +1342,7 @@ void CGameHandler::handleClientDisconnection(std::shared_ptr<CConnection> c)
 			else
 				++i;
 		}
-	}
+	}*/
 }
 
 void CGameHandler::handleReceivedPack(CPackForServer * pack)
@@ -5003,7 +5003,7 @@ bool CGameHandler::makeBattleAction(BattleAction &ba)
 
 void CGameHandler::playerMessage(PlayerColor player, const std::string &message, ObjectInstanceID currObj)
 {
-	bool cheated = true;
+	bool cheated = false;
 	PlayerMessageClient temp_message(player, message);
 	sendAndApply(&temp_message);
 
@@ -6924,6 +6924,7 @@ void CGameHandler::handleCheatCode(std::string & cheat, PlayerColor player, cons
 {
 	if (cheat == "vcmiistari")
 	{
+		cheated = true;
 		if (!hero) return;
 		///Give hero spellbook
 		if (!hero->hasSpellbook())
@@ -6949,6 +6950,7 @@ void CGameHandler::handleCheatCode(std::string & cheat, PlayerColor player, cons
 	}
 	else if (cheat == "vcmiarmenelos")
 	{
+		cheated = true;
 		if (!town) return;
 		///Build all buildings in selected town
 		for (auto & build : town->town->buildings)
@@ -6963,6 +6965,7 @@ void CGameHandler::handleCheatCode(std::string & cheat, PlayerColor player, cons
 	}
 	else if (cheat == "vcmiainur" || cheat == "vcmiangband" || cheat == "vcmiglaurung")
 	{
+		cheated = true;
 		if (!hero) return;
 		///Gives N creatures into each slot
 		std::map<std::string, std::pair<int, int>> creatures;
@@ -6977,6 +6980,7 @@ void CGameHandler::handleCheatCode(std::string & cheat, PlayerColor player, cons
 	}
 	else if (cheat == "vcminoldor")
 	{
+		cheated = true;
 		if (!hero) return;
 		///Give all war machines to hero
 		if (!hero->getArt(ArtifactPosition::MACH1))
@@ -6988,6 +6992,7 @@ void CGameHandler::handleCheatCode(std::string & cheat, PlayerColor player, cons
 	}
 	else if (cheat == "vcmiforgeofnoldorking")
 	{
+		cheated = true;
 		if (!hero) return;
 		///Give hero all artifacts except war machines, spell scrolls and spell book
 		for (int g = 7; g < VLC->arth->objects.size(); ++g) //including artifacts from mods
@@ -6995,12 +7000,14 @@ void CGameHandler::handleCheatCode(std::string & cheat, PlayerColor player, cons
 	}
 	else if (cheat == "vcmiglorfindel")
 	{
+		cheated = true;
 		if (!hero) return;
 		///selected hero gains a new level
 		changePrimSkill(hero, PrimarySkill::EXPERIENCE, VLC->heroh->reqExp(hero->level + 1) - VLC->heroh->reqExp(hero->level));
 	}
 	else if (cheat == "vcminahar")
 	{
+		cheated = true;
 		if (!hero) return;
 		///Give 1000000 movement points to hero
 		SetMovePoints smp;
@@ -7017,6 +7024,7 @@ void CGameHandler::handleCheatCode(std::string & cheat, PlayerColor player, cons
 	}
 	else if (cheat == "vcmiformenos")
 	{
+		cheated = true;
 		///Give resources to player
 		TResources resources;
 		resources[Res::GOLD] = 100000;
@@ -7027,6 +7035,7 @@ void CGameHandler::handleCheatCode(std::string & cheat, PlayerColor player, cons
 	}
 	else if (cheat == "vcmisilmaril")
 	{
+		cheated = true;
 		///Player wins
 		PlayerCheated pc;
 		pc.player = player;
@@ -7035,6 +7044,7 @@ void CGameHandler::handleCheatCode(std::string & cheat, PlayerColor player, cons
 	}
 	else if (cheat == "vcmimelkor")
 	{
+		cheated = true;
 		///Player looses
 		PlayerCheated pc;
 		pc.player = player;
@@ -7043,6 +7053,7 @@ void CGameHandler::handleCheatCode(std::string & cheat, PlayerColor player, cons
 	}
 	else if (cheat == "vcmieagles" || cheat == "vcmiungoliant")
 	{
+		cheated = true;
 		///Reveal or conceal FoW
 		FoWChange fc;
 		fc.mode = (cheat == "vcmieagles" ? 1 : 0);
@@ -7061,8 +7072,6 @@ void CGameHandler::handleCheatCode(std::string & cheat, PlayerColor player, cons
 		delete [] hlp_tab;
 		sendAndApply(&fc);
 	}
-	else
-		cheated = false;
 }
 
 void CGameHandler::removeObstacle(const CObstacleInstance & obstacle)

--- a/server/CVCMIServer.cpp
+++ b/server/CVCMIServer.cpp
@@ -466,7 +466,8 @@ bool CVCMIServer::passHost(int toConnectionId)
 
 void CVCMIServer::clientConnected(std::shared_ptr<CConnection> c, std::vector<std::string> & names, std::string uuid, StartInfo::EMode mode)
 {
-	c->connectionID = currentClientId++;
+	if(state == EServerState::LOBBY)
+		c->connectionID = currentClientId++;
 
 	if(!hostClient)
 	{
@@ -476,6 +477,8 @@ void CVCMIServer::clientConnected(std::shared_ptr<CConnection> c, std::vector<st
 	}
 
 	logNetwork->info("Connection with client %d established. UUID: %s", c->connectionID, c->uuid);
+	
+	if(state == EServerState::LOBBY)
 	for(auto & name : names)
 	{
 		logNetwork->info("Client %d player: %s", c->connectionID, name);

--- a/server/CVCMIServer.cpp
+++ b/server/CVCMIServer.cpp
@@ -327,10 +327,23 @@ void CVCMIServer::connectionAccepted(const boost::system::error_code & ec)
 			connections.insert(c);
 			c->handler = std::make_shared<boost::thread>(&CVCMIServer::threadHandleClient, this, c);
 			
-			if(!hangingConnections.empty())
+			if(!hangingConnections.empty() && gh)
 			{
+				//TODO: check client uuid
 				logNetwork->info("Reconnection player");
 				c->connectionID = (*hangingConnections.begin())->connectionID;
+				for(auto & playerConnection : gh->connections)
+				{
+					for(auto & existingConnection : playerConnection.second)
+					{
+						if(existingConnection == *hangingConnections.begin())
+						{
+							playerConnection.second.erase(existingConnection);
+							playerConnection.second.insert(c);
+							break;
+						}
+					}
+				}
 				//hangingConnections.clear();
 			}
 		}

--- a/server/CVCMIServer.h
+++ b/server/CVCMIServer.h
@@ -61,6 +61,8 @@ public:
 
 	boost::program_options::variables_map cmdLineOptions;
 	std::set<std::shared_ptr<CConnection>> connections;
+	std::set<std::shared_ptr<CConnection>> hangingConnections; //keep connections of players disconnected during the game
+	
 	std::atomic<int> currentClientId;
 	std::atomic<ui8> currentPlayerId;
 	std::shared_ptr<CConnection> hostClient;
@@ -90,6 +92,7 @@ public:
 
 	void clientConnected(std::shared_ptr<CConnection> c, std::vector<std::string> & names, std::string uuid, StartInfo::EMode mode);
 	void clientDisconnected(std::shared_ptr<CConnection> c);
+	void reconnectPlayer(int connId);
 
 	void updateAndPropagateLobbyState();
 

--- a/server/NetPacksLobbyServer.cpp
+++ b/server/NetPacksLobbyServer.cpp
@@ -52,18 +52,16 @@ void LobbyClientConnected::applyOnServerAfterAnnounce(CVCMIServer * srv)
 	// FIXME: we need to avoid senting something to client that not yet get answer for LobbyClientConnected
 	// Until UUID set we only pass LobbyClientConnected to this client
 	c->uuid = uuid;
+	srv->updateAndPropagateLobbyState();
 	if(srv->state == EServerState::GAMEPLAY)
 	{
+		
 		//immediately start game
 		std::unique_ptr<LobbyStartGame> startGameForReconnectedPlayer(new LobbyStartGame);
 		startGameForReconnectedPlayer->initializedStartInfo = srv->si;
 		startGameForReconnectedPlayer->initializedGameState = srv->gh->gameState();
 		startGameForReconnectedPlayer->clientId = c->connectionID;
 		srv->addToAnnounceQueue(std::move(startGameForReconnectedPlayer));
-	}
-	else
-	{
-		srv->updateAndPropagateLobbyState();
 	}
 }
 


### PR DESCRIPTION
Desired behavior:
- client intentionally disconnected - AI takes control over the player(s)
- client accidentally disconnected - continue game if turn not under client control. If player turn, suggest host to kick the client from the session

ToDo:
- [ ] verify client by uuid
- [ ] move pop up messages to translate.json
- [ ] get session ip and port from stored settings
- [ ] fix transferring ownership to AI
- [ ] make server notifications about client connected/disconnected
- [ ] check and support multiple players on single client
- [ ] implement kick player suggestion
- [ ] allow game save & exit if client was disconnected on its turn
- [ ] implement notification about refusing to restore session
- [ ] implement timeout or another solution if server isn't available while session recovery
- [ ] implement host transferring (out of scope?)