### PR TITLE
#1065 - fix random hero initial position

### DIFF
--- a/lib/mapObjects/CObjectHandler.cpp
+++ b/lib/mapObjects/CObjectHandler.cpp
@@ -197,9 +197,6 @@ void CGObjectInstance::setType(si32 ID, si32 subID)
 {
 	const TerrainTile &tile = cb->gameState()->map->getTile(visitablePos());
 
-	this->ID = Obj(ID);
-	this->subID = subID;
-
 	//recalculate blockvis tiles - new appearance might have different blockmap than before
 	cb->gameState()->map->removeBlockVisTiles(this, true);
 	auto handler = VLC->objtypeh->getHandlerFor(ID, subID);
@@ -212,11 +209,16 @@ void CGObjectInstance::setType(si32 ID, si32 subID)
 		appearance = handler->getTemplates(tile.terType->id)[0];
 	else
 		appearance = handler->getTemplates()[0]; // get at least some appearance since alternative is crash
-	if (ID == Obj::HERO)
+
+	if(this->ID == Obj::PRISON && ID == Obj::HERO)
 	{
 		//adjust for the prison offset
 		pos = visitablePos();
 	}
+
+	this->ID = Obj(ID);
+	this->subID = subID;
+
 	cb->gameState()->map->addBlockVisTiles(this);
 }
 


### PR DESCRIPTION
I expect the hack for HOTA prison broke it. https://bugs.vcmi.eu/view.php?id=3227