### PR TITLE
Battle ai improvements

### DIFF
--- a/AI/BattleAI/AttackPossibility.h
+++ b/AI/BattleAI/AttackPossibility.h
@@ -13,6 +13,8 @@
 #include "common.h"
 #include "StackWithBonuses.h"
 
+#define BATTLE_TRACE_LEVEL 0
+
 class AttackPossibility
 {
 public:
@@ -35,6 +37,12 @@ public:
 	int64_t attackValue() const;
 
 	static AttackPossibility evaluate(const BattleAttackInfo & attackInfo, BattleHex hex, const HypotheticBattle * state);
+
+	static int64_t calculateDpsReduce(
+		const battle::Unit * attacker,
+		const battle::Unit * defender,
+		uint64_t damageDealt,
+		std::shared_ptr<CBattleInfoCallback> cb);
 
 private:
 	static int64_t evaluateBlockedShootersDmg(const BattleAttackInfo & attackInfo, BattleHex hex, const HypotheticBattle * state);

--- a/AI/BattleAI/AttackPossibility.h
+++ b/AI/BattleAI/AttackPossibility.h
@@ -15,6 +15,10 @@
 
 #define BATTLE_TRACE_LEVEL 0
 
+/// <summary>
+/// Evaluate attack value of one particular attack taking into account various effects like
+/// retaliation, 2-hex breath, collateral damage, shooters blocked damage
+/// </summary>
 class AttackPossibility
 {
 public:
@@ -26,9 +30,9 @@ public:
 
 	std::vector<std::shared_ptr<battle::CUnitState>> affectedUnits;
 
-	int64_t damageDealt = 0;
-	int64_t damageReceived = 0; //usually by counter-attack
-	int64_t collateralDamage = 0; // friendly fire (usually by two-hex attacks)
+	int64_t defenderDamageReduce = 0;
+	int64_t attackerDamageReduce = 0; //usually by counter-attack
+	int64_t collateralDamageReduce = 0; // friendly fire (usually by two-hex attacks)
 	int64_t shootersBlockedDmg = 0;
 
 	AttackPossibility(BattleHex from, BattleHex dest, const BattleAttackInfo & attack_);
@@ -36,14 +40,14 @@ public:
 	int64_t damageDiff() const;
 	int64_t attackValue() const;
 
-	static AttackPossibility evaluate(const BattleAttackInfo & attackInfo, BattleHex hex, const HypotheticBattle * state);
+	static AttackPossibility evaluate(const BattleAttackInfo & attackInfo, BattleHex hex, const HypotheticBattle & state);
 
-	static int64_t calculateDpsReduce(
+	static int64_t calculateDamageReduce(
 		const battle::Unit * attacker,
 		const battle::Unit * defender,
 		uint64_t damageDealt,
-		std::shared_ptr<CBattleInfoCallback> cb);
+		const CBattleInfoCallback & cb);
 
 private:
-	static int64_t evaluateBlockedShootersDmg(const BattleAttackInfo & attackInfo, BattleHex hex, const HypotheticBattle * state);
+	static int64_t evaluateBlockedShootersDmg(const BattleAttackInfo & attackInfo, BattleHex hex, const HypotheticBattle & state);
 };

--- a/AI/BattleAI/BattleExchangeVariant.cpp
+++ b/AI/BattleAI/BattleExchangeVariant.cpp
@@ -1,0 +1,504 @@
+/*
+ * BattleAI.cpp, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
+#include "StdInc.h"
+#include "BattleExchangeVariant.h"
+#include "../../lib/CStack.h"
+
+int64_t BattleExchangeVariant::trackAttack(const AttackPossibility & ap, HypotheticBattle * state)
+{
+	auto affectedUnits = ap.affectedUnits;
+
+	affectedUnits.push_back(ap.attackerState);
+
+	for(auto affectedUnit : affectedUnits)
+	{
+		auto unitToUpdate = state->getForUpdate(affectedUnit->unitId());
+
+		unitToUpdate->health = affectedUnit->health;
+		unitToUpdate->shots = affectedUnit->shots;
+		unitToUpdate->counterAttacks = affectedUnit->counterAttacks;
+		unitToUpdate->movedThisRound = affectedUnit->movedThisRound;
+	}
+
+	auto attackValue = ap.attackValue();
+
+	dpsScore += attackValue;
+
+	logAi->trace(
+		"%s -> %s, ap attack, %s, dps: %d, score: %d",
+		ap.attack.attacker->getDescription(),
+		ap.attack.defender->getDescription(),
+		ap.attack.shooting ? "shot" : "mellee",
+		ap.damageDealt,
+		attackValue);
+
+	return attackValue;
+}
+
+int64_t BattleExchangeVariant::trackAttack(
+	std::shared_ptr<StackWithBonuses> attacker,
+	std::shared_ptr<StackWithBonuses> defender,
+	bool shooting,
+	bool isOurAttack,
+	std::shared_ptr<CBattleInfoCallback> cb,
+	bool evaluateOnly)
+{
+	const std::string cachingStringBlocksRetaliation = "type_BLOCKS_RETALIATION";
+	static const auto selectorBlocksRetaliation = Selector::type()(Bonus::BLOCKS_RETALIATION);
+	const bool counterAttacksBlocked = attacker->hasBonus(selectorBlocksRetaliation, cachingStringBlocksRetaliation);
+
+	TDmgRange retalitation;
+	BattleAttackInfo bai(attacker.get(), defender.get(), shooting);
+	auto attack = cb->battleEstimateDamage(bai, &retalitation);
+	int64_t attackDamage = (attack.first + attack.second) / 2;
+	int64_t defenderDpsReduce = calculateDpsReduce(attacker.get(), defender.get(), attackDamage, cb);
+	int64_t attackerDpsReduce = 0;
+
+	if(!evaluateOnly)
+	{
+		logAi->trace(
+			"%s -> %s, normal attack, %s, dps: %d, %d",
+			attacker->getDescription(),
+			defender->getDescription(),
+			shooting ? "shot" : "mellee",
+			attackDamage,
+			defenderDpsReduce);
+
+		if(isOurAttack)
+		{
+			dpsScore += defenderDpsReduce;
+			attackerValue[attacker->unitId()].value += defenderDpsReduce;
+		}
+		else
+			dpsScore -= defenderDpsReduce;
+
+		defender->damage(attackDamage);
+		attacker->afterAttack(shooting, false);
+	}
+
+	if(defender->alive() && defender->ableToRetaliate() && !counterAttacksBlocked && !shooting)
+	{
+		if(retalitation.second != 0)
+		{
+			auto retalitationDamage = (retalitation.first + retalitation.second) / 2;
+			attackerDpsReduce = calculateDpsReduce(defender.get(), attacker.get(), retalitationDamage, cb);
+
+			if(!evaluateOnly)
+			{
+				logAi->trace(
+					"%s -> %s, retalitation, dps: %d, %d",
+					defender->getDescription(),
+					attacker->getDescription(),
+					retalitationDamage,
+					attackerDpsReduce);
+
+				if(isOurAttack)
+				{
+					dpsScore -= attackerDpsReduce;
+					attackerValue[attacker->unitId()].isRetalitated = true;
+				}
+				else
+				{
+					dpsScore += attackerDpsReduce;
+					attackerValue[defender->unitId()].value += attackerDpsReduce;
+				}
+
+				attacker->damage(retalitationDamage);
+				defender->afterAttack(false, true);
+			}
+		}
+	}
+
+	auto score = defenderDpsReduce - attackerDpsReduce;
+
+	if(!score)
+	{
+		logAi->trace("Zero %d %d", defenderDpsReduce, attackerDpsReduce);
+	}
+
+	return score;
+}
+
+int64_t BattleExchangeVariant::calculateDpsReduce(
+	const battle::Unit * attacker,
+	const battle::Unit * defender,
+	uint64_t damageDealt,
+	std::shared_ptr<CBattleInfoCallback> cb) const
+{
+	vstd::amin(damageDealt, defender->getAvailableHealth());
+
+	auto enemyDamageBeforeAttack = cb->battleEstimateDamage(BattleAttackInfo(defender, attacker, defender->canShoot()));
+	auto enemiesKilled = damageDealt / defender->MaxHealth() + (damageDealt % defender->MaxHealth() >= defender->getFirstHPleft() ? 1 : 0);
+	auto enemyDps = (enemyDamageBeforeAttack.first + enemyDamageBeforeAttack.second) / 2;
+
+	return (int64_t)(enemyDps * enemiesKilled / (double)defender->getCount()
+		+ enemyDps / (double)defender->getCount() * ((damageDealt - defender->getFirstHPleft()) % defender->MaxHealth()) / defender->MaxHealth());
+};
+
+EvaluationResult BattleExchangeEvaluator::findBestTarget(const battle::Unit * activeStack, PotentialTargets & targets, HypotheticBattle & hb)
+{
+	EvaluationResult result(targets.bestAction());
+
+	updateReachabilityMap(hb);
+
+	for(auto & ap : targets.possibleAttacks)
+	{
+		int64_t score = calculateExchange(ap);
+
+		if(score > result.score)
+		{
+			result.score = score;
+			result.bestAttack = ap;
+		}
+	}
+
+	if(!activeStack->waited())
+	{
+		logAi->trace("Evaluating waited attack for %s", activeStack->getDescription());
+
+		hb.getForUpdate(activeStack->unitId())->waiting = true;
+		hb.getForUpdate(activeStack->unitId())->waitedThisTurn = true;
+
+		updateReachabilityMap(hb);
+
+		for(auto & ap : targets.possibleAttacks)
+		{
+			int64_t score = calculateExchange(ap);
+
+			if(score > result.score)
+			{
+				result.score = score;
+				result.bestAttack = ap;
+				result.wait = true;
+			}
+		}
+	}
+
+	return result;
+}
+
+std::vector<const battle::Unit *> BattleExchangeEvaluator::getExchangeUnits(
+	const AttackPossibility & ap)
+{
+	auto hexes = ap.attack.defender->getHexes();
+
+	if(!ap.attack.shooting) hexes.push_back(ap.from);
+
+	std::vector<const battle::Unit *> exchangeUnits;
+	std::vector<const battle::Unit *> allReachableUnits;
+
+	for(auto hex : hexes)
+	{
+		vstd::concatenate(allReachableUnits, reachabilityMap[hex]);
+	}
+
+	vstd::removeDuplicates(allReachableUnits);
+
+	if(allReachableUnits.size() < 2)
+	{
+		logAi->trace("Reachability map contains only %d stacks", allReachableUnits.size());
+
+		return exchangeUnits;
+	}
+
+	for(int turn = 0; turn < turnOrder.size(); turn++)
+	{
+		for(auto unit : turnOrder[turn])
+		{
+			if(vstd::contains(allReachableUnits, unit))
+				exchangeUnits.push_back(unit);
+		}
+	}
+
+	return exchangeUnits;
+}
+
+int64_t BattleExchangeEvaluator::calculateExchange(const AttackPossibility & ap)
+{
+	logAi->trace("Battle exchange at %d", ap.attack.shooting ? ap.dest : ap.from);
+
+	std::vector<const battle::Unit *> ourStacks;
+	std::vector<const battle::Unit *> enemyStacks;
+
+	enemyStacks.push_back(ap.attack.defender);
+
+	std::vector<const battle::Unit *> exchangeUnits = getExchangeUnits(ap);
+
+	if(exchangeUnits.empty())
+	{
+		return 0;
+	}
+
+	HypotheticBattle exchangeBattle(env.get(), cb);
+	BattleExchangeVariant v;
+	auto melleeAttackers = ourStacks;
+
+	vstd::removeDuplicates(melleeAttackers);
+	vstd::erase_if(melleeAttackers, [&](const battle::Unit * u) -> bool
+		{
+			return !cb->battleCanShoot(u);
+		});
+
+	for(auto unit : exchangeUnits)
+	{
+		bool isOur = cb->battleMatchOwner(ap.attack.attacker, unit, true);
+		auto & attackerQueue = isOur ? ourStacks : enemyStacks;
+		auto & oppositeQueue = isOur ? enemyStacks : ourStacks;
+
+		if(!vstd::contains(attackerQueue, unit))
+		{
+			attackerQueue.push_back(unit);
+		}
+	}
+
+	bool canUseAp = true;
+
+	for(auto activeUnit : exchangeUnits)
+	{
+		bool isOur = cb->battleMatchOwner(ap.attack.attacker, activeUnit, true);
+		battle::Units & attackerQueue = isOur ? ourStacks : enemyStacks;
+		battle::Units & oppositeQueue = isOur ? enemyStacks : ourStacks;
+
+		auto attacker = exchangeBattle.getForUpdate(activeUnit->unitId());
+
+		if(!attacker->alive() || oppositeQueue.empty())
+		{
+			logAi->trace(
+				"Attacker [%s] dead(%d) or opposite queue empty(%d)",
+				attacker->getDescription(),
+				attacker->alive() ? 0 : 1,
+				oppositeQueue.size());
+
+			continue;
+		}
+
+		auto targetUnit = ap.attack.defender;
+
+		if(!isOur || !exchangeBattle.getForUpdate(targetUnit->unitId())->alive())
+		{
+			targetUnit = *vstd::maxElementByFun(oppositeQueue, [&](const battle::Unit * u) -> int64_t
+				{
+					auto stackWithBonuses = exchangeBattle.getForUpdate(u->unitId());
+					auto score = v.trackAttack(
+						attacker,
+						stackWithBonuses,
+						exchangeBattle.battleCanShoot(stackWithBonuses.get()),
+						isOur,
+						cb,
+						true);
+
+					logAi->trace("Best target selector %s->%s score = %d", attacker->getDescription(), u->getDescription(), score);
+
+					return score;
+				});
+		}
+
+		auto defender = exchangeBattle.getForUpdate(targetUnit->unitId());
+		auto shooting = cb->battleCanShoot(attacker.get());
+		const int totalAttacks = attacker->getTotalAttacks(shooting);
+
+		if(canUseAp && activeUnit == ap.attack.attacker && targetUnit == ap.attack.defender)
+		{
+			v.trackAttack(ap, &exchangeBattle);
+		}
+		else
+		{
+			for(int i = 0; i < totalAttacks; i++)
+			{
+				v.trackAttack(attacker, defender, shooting, isOur, cb);
+
+				if(!attacker->alive() || !defender->alive())
+					break;
+			}
+		}
+
+		canUseAp = false;
+
+		vstd::erase_if(attackerQueue, [&](const battle::Unit * u) -> bool
+			{
+				return !exchangeBattle.getForUpdate(u->unitId())->alive();
+			});
+
+		vstd::erase_if(oppositeQueue, [&](const battle::Unit * u) -> bool
+			{
+				return !exchangeBattle.getForUpdate(u->unitId())->alive();
+			});
+	}
+
+	v.adjustPositions(melleeAttackers, ap, reachabilityMap);
+
+	logAi->trace("Exchange score: %ld", v.getScore());
+
+	return v.getScore();
+}
+
+void BattleExchangeVariant::adjustPositions(
+	std::vector<const battle::Unit*> attackers,
+	const AttackPossibility & ap,
+	std::map<BattleHex, battle::Units> & reachabilityMap)
+{
+	auto hexes = ap.attack.defender->getSurroundingHexes();
+
+	boost::sort(attackers, [&](const battle::Unit * u1, const battle::Unit * u2) -> bool
+		{
+			if(attackerValue[u1->unitId()].isRetalitated && !attackerValue[u2->unitId()].isRetalitated)
+				return true;
+
+			if(attackerValue[u2->unitId()].isRetalitated && !attackerValue[u1->unitId()].isRetalitated)
+				return false;
+
+			return attackerValue[u1->unitId()].value > attackerValue[u2->unitId()].value;
+		});
+
+	if(!ap.attack.shooting)
+	{
+		vstd::erase_if_present(hexes, ap.from);
+		vstd::erase_if_present(hexes, ap.attack.attacker->occupiedHex(ap.attack.attackerPos));
+	}
+
+	int64_t notRealizedDps = 0;
+
+	for(auto unit : attackers)
+	{
+		if(unit->unitId() == ap.attack.attacker->unitId())
+			continue;
+
+		if(!vstd::contains_if(hexes, [&](BattleHex h) -> bool
+			{
+				return vstd::contains(reachabilityMap[h], unit);
+			}))
+		{
+			notRealizedDps += attackerValue[unit->unitId()].value;
+			continue;
+		}
+
+		auto desiredPosition = vstd::minElementByFun(hexes, [&](BattleHex h) -> int64_t
+			{
+				auto score = vstd::contains(reachabilityMap[h], unit)
+					? reachabilityMap[h].size()
+					: 1000;
+
+				if(unit->doubleWide())
+				{
+					auto backHex = unit->occupiedHex(h);
+
+					if(vstd::contains(hexes, backHex))
+						score += reachabilityMap[backHex].size();
+				}
+
+				return score;
+			});
+
+		hexes.erase(desiredPosition);
+	}
+
+	if(notRealizedDps > ap.attackValue() && notRealizedDps > attackerValue[ap.attack.attacker->unitId()].value)
+	{
+		dpsScore = EvaluationResult::INEFFECTIVE_SCORE;
+	}
+}
+
+void BattleExchangeEvaluator::updateReachabilityMap(HypotheticBattle & hb)
+{
+	turnOrder.clear();
+
+	hb.battleGetTurnOrder(turnOrder, 1000, 2);
+	reachabilityMap.clear();
+
+	for(int turn = 0; turn < turnOrder.size(); turn++)
+	{
+		auto & turnQueue = turnOrder[turn];
+		HypotheticBattle turnBattle(env.get(), cb);
+
+		for(const battle::Unit * unit : turnQueue)
+		{
+			auto unitReachability = turnBattle.getReachability(unit);
+
+			for(BattleHex hex = BattleHex::TOP_LEFT; hex.isValid(); hex = hex + 1)
+			{
+				bool reachable = unitReachability.distances[hex] <= unit->Speed(turn);
+
+				if(!reachable && unitReachability.accessibility[hex] == EAccessibility::ALIVE_STACK)
+				{
+					const battle::Unit * hexStack = cb->battleGetUnitByPos(hex);
+
+					if(hexStack && cb->battleMatchOwner(unit, hexStack, false))
+					{
+						for(BattleHex neighbor : hex.neighbouringTiles())
+						{
+							reachable = unitReachability.distances[neighbor] <= unit->Speed(turn);
+
+							if(reachable) break;
+						}
+					}
+				}
+
+				if(reachable)
+				{
+					reachabilityMap[hex].push_back(unit);
+				}
+			}
+		}
+	}
+}
+
+bool BattleExchangeEvaluator::checkPositionBlocksOurStacks(HypotheticBattle & hb, const battle::Unit * activeUnit, BattleHex position)
+{
+	int blockingScore = 0;
+
+	for(int turn = 0; turn < turnOrder.size(); turn++)
+	{
+		auto & turnQueue = turnOrder[turn];
+		HypotheticBattle turnBattle(env.get(), cb);
+
+		auto unitToUpdate = turnBattle.getForUpdate(activeUnit->unitId());
+		unitToUpdate->setPosition(position);
+
+		for(const battle::Unit * unit : turnQueue)
+		{
+			if(unit->unitId() == unitToUpdate->unitId() || cb->battleMatchOwner(unit, activeUnit, false))
+				continue;
+
+			auto unitReachability = turnBattle.getReachability(unit);
+
+			for(BattleHex hex = BattleHex::TOP_LEFT; hex.isValid(); hex = hex + 1)
+			{
+				bool enemyUnit = false;
+				bool reachable = unitReachability.distances[hex] <= unit->Speed(turn);
+
+				if(!reachable && unitReachability.accessibility[hex] == EAccessibility::ALIVE_STACK)
+				{
+					const battle::Unit * hexStack = turnBattle.battleGetUnitByPos(hex);
+
+					if(hexStack && cb->battleMatchOwner(unit, hexStack, false))
+					{
+						enemyUnit = true;
+
+						for(BattleHex neighbor : hex.neighbouringTiles())
+						{
+							reachable = unitReachability.distances[neighbor] <= unit->Speed(turn);
+
+							if(reachable) break;
+						}
+					}
+				}
+
+				if(!reachable && vstd::contains(reachabilityMap[hex], unit))
+				{
+					blockingScore += enemyUnit ? 100 : 1;
+				}
+			}
+		}
+	}
+
+	logAi->trace("Position %d, blocking score %d", position.hex, blockingScore);
+
+	return blockingScore > 50;
+}

--- a/AI/BattleAI/BattleExchangeVariant.h
+++ b/AI/BattleAI/BattleExchangeVariant.h
@@ -20,10 +20,30 @@ struct AttackerValue
 	bool isRetalitated;
 	BattleHex position;
 
-	AttackerValue()
+	AttackerValue();
+};
+
+struct MoveTarget
+{
+	int64_t score;
+	std::vector<BattleHex> positions;
+
+	MoveTarget();
+};
+
+struct EvaluationResult
+{
+	static const int64_t INEFFECTIVE_SCORE = -1000000;
+
+	AttackPossibility bestAttack;
+	MoveTarget bestMove;
+	bool wait;
+	int64_t score;
+	bool defend;
+
+	EvaluationResult(const AttackPossibility & ap)
+		:wait(false), score(0), bestAttack(ap), defend(false)
 	{
-		value = 0;
-		isRetalitated = false;
 	}
 };
 
@@ -55,27 +75,6 @@ public:
 private:
 	int64_t dpsScore;
 	std::map<uint32_t, AttackerValue> attackerValue;
-
-	int64_t calculateDpsReduce(
-		const battle::Unit * attacker,
-		const battle::Unit * defender,
-		uint64_t damageDealt,
-		std::shared_ptr<CBattleInfoCallback> cb) const;
-};
-
-struct EvaluationResult
-{
-	static const int64_t INEFFECTIVE_SCORE = -1000000;
-
-	AttackPossibility bestAttack;
-	bool wait;
-	int64_t score;
-	bool defend;
-
-	EvaluationResult(AttackPossibility & ap)
-		:wait(false), score(0), bestAttack(ap), defend(false)
-	{
-	}
 };
 
 class BattleExchangeEvaluator
@@ -93,8 +92,10 @@ public:
 	}
 
 	EvaluationResult findBestTarget(const battle::Unit * activeStack, PotentialTargets & targets, HypotheticBattle & hb);
-	int64_t calculateExchange(const AttackPossibility & ap);
+	int64_t calculateExchange(const AttackPossibility & ap, PotentialTargets & targets, HypotheticBattle & hb);
 	void updateReachabilityMap(HypotheticBattle & hb);
-	std::vector<const battle::Unit *> getExchangeUnits(const AttackPossibility & ap);
+	std::vector<const battle::Unit *> getExchangeUnits(const AttackPossibility & ap, PotentialTargets & targets, HypotheticBattle & hb);
 	bool checkPositionBlocksOurStacks(HypotheticBattle & hb, const battle::Unit * unit, BattleHex position);
+	MoveTarget findMoveTowardsUnreachable(const battle::Unit * activeStack, PotentialTargets & targets, HypotheticBattle & hb);
+	std::vector<const battle::Unit *> getAdjacentUnits(const battle::Unit * unit);
 };

--- a/AI/BattleAI/BattleExchangeVariant.h
+++ b/AI/BattleAI/BattleExchangeVariant.h
@@ -47,6 +47,12 @@ struct EvaluationResult
 	}
 };
 
+/// <summary>
+/// The class represents evaluation of attack value
+/// of exchanges between all stacks which can access particular hex
+/// starting from initial attack represented by AttackPossibility and further according turn order.
+/// Negative score value means we get more demage than deal
+/// </summary>
 class BattleExchangeVariant
 {
 public:
@@ -55,14 +61,14 @@ public:
 	{
 	}
 
-	int64_t trackAttack(const AttackPossibility & ap, HypotheticBattle * state);
+	int64_t trackAttack(const AttackPossibility & ap, HypotheticBattle & state);
 
 	int64_t trackAttack(
 		std::shared_ptr<StackWithBonuses> attacker,
 		std::shared_ptr<StackWithBonuses> defender,
 		bool shooting,
 		bool isOurAttack,
-		std::shared_ptr<CBattleInfoCallback> cb,
+		const CBattleInfoCallback & cb,
 		bool evaluateOnly = false);
 
 	int64_t getScore() const { return dpsScore; }

--- a/AI/BattleAI/CMakeLists.txt
+++ b/AI/BattleAI/CMakeLists.txt
@@ -10,6 +10,7 @@ set(battleAI_SRCS
 		PotentialTargets.cpp
 		StackWithBonuses.cpp
 		ThreatMap.cpp
+		BattleExchangeVariant.cpp
 )
 
 set(battleAI_HEADERS
@@ -23,6 +24,7 @@ set(battleAI_HEADERS
 		PossibleSpellcast.h
 		StackWithBonuses.h
 		ThreatMap.h
+		BattleExchangeVariant.h
 )
 
 assign_source_group(${battleAI_SRCS} ${battleAI_HEADERS})

--- a/AI/BattleAI/PotentialTargets.cpp
+++ b/AI/BattleAI/PotentialTargets.cpp
@@ -13,9 +13,7 @@
 
 PotentialTargets::PotentialTargets(const battle::Unit * attacker, const HypotheticBattle * state)
 {
-	auto attIter = state->stackStates.find(attacker->unitId());
-	const battle::Unit * attackerInfo = (attIter == state->stackStates.end()) ? attacker : attIter->second.get();
-
+	auto attackerInfo = state->battleGetUnitByID(attacker->unitId());
 	auto reachability = state->getReachability(attackerInfo);
 	auto avHexes = state->battleGetAvailableHexes(reachability, attackerInfo);
 
@@ -95,7 +93,7 @@ PotentialTargets::PotentialTargets(const battle::Unit * attacker, const Hypothet
 
 	if (!possibleAttacks.empty())
 	{
-		auto &bestAp = possibleAttacks[0];
+		auto & bestAp = possibleAttacks[0];
 
 		logGlobal->info("Battle AI best: %s -> %s at %d from %d, affects %d units: %lld %lld %lld %lld",
 			bestAp.attack.attacker->unitType()->identifier,
@@ -112,10 +110,10 @@ int64_t PotentialTargets::bestActionValue() const
 	return bestAction().attackValue();
 }
 
-AttackPossibility PotentialTargets::bestAction() const
+const AttackPossibility & PotentialTargets::bestAction() const
 {
 	if(possibleAttacks.empty())
 		throw std::runtime_error("No best action, since we don't have any actions");
-	return possibleAttacks[0];
+	return possibleAttacks.at(0);
 	//return *vstd::maxElementByFun(possibleAttacks, [](const AttackPossibility &ap) { return ap.attackValue(); } );
 }

--- a/AI/BattleAI/PotentialTargets.h
+++ b/AI/BattleAI/PotentialTargets.h
@@ -17,7 +17,7 @@ public:
 	std::vector<const battle::Unit *> unreachableEnemies;
 
 	PotentialTargets(){};
-	PotentialTargets(const battle::Unit * attacker, const HypotheticBattle * state);
+	PotentialTargets(const battle::Unit * attacker, const HypotheticBattle & state);
 
 	const AttackPossibility & bestAction() const;
 	int64_t bestActionValue() const;

--- a/AI/BattleAI/PotentialTargets.h
+++ b/AI/BattleAI/PotentialTargets.h
@@ -19,6 +19,6 @@ public:
 	PotentialTargets(){};
 	PotentialTargets(const battle::Unit * attacker, const HypotheticBattle * state);
 
-	AttackPossibility bestAction() const;
+	const AttackPossibility & bestAction() const;
 	int64_t bestActionValue() const;
 };

--- a/AI/BattleAI/StackWithBonuses.cpp
+++ b/AI/BattleAI/StackWithBonuses.cpp
@@ -199,6 +199,21 @@ void StackWithBonuses::removeUnitBonus(const CSelector & selector)
 	vstd::erase_if(bonusesToUpdate, [&](const Bonus & b){return selector(&b);});
 }
 
+std::string StackWithBonuses::getDescription() const
+{
+	std::ostringstream oss;
+	oss << unitOwner().getStr();
+	oss << " battle stack [" << unitId() << "]: " << getCount() << " of ";
+	if(type)
+		oss << type->namePl;
+	else
+		oss << "[UNDEFINED TYPE]";
+
+	oss << " from slot " << slot;
+
+	return oss.str();
+}
+
 void StackWithBonuses::spendMana(ServerCallback * server, const int spellCost) const
 {
 	//TODO: evaluate cast use
@@ -284,7 +299,6 @@ int32_t HypotheticBattle::getActiveStackID() const
 void HypotheticBattle::nextRound(int32_t roundNr)
 {
 	//TODO:HypotheticBattle::nextRound
-
 	for(auto unit : battleAliveUnits())
 	{
 		auto forUpdate = getForUpdate(unit->unitId());

--- a/AI/BattleAI/StackWithBonuses.h
+++ b/AI/BattleAI/StackWithBonuses.h
@@ -85,6 +85,7 @@ public:
 	void removeUnitBonus(const CSelector & selector);
 
 	void spendMana(ServerCallback * server, const int spellCost) const override;
+	std::string getDescription() const override;
 
 private:
 	const IBonusBearer * origBearer;

--- a/AI/Nullkiller/AIGateway.cpp
+++ b/AI/Nullkiller/AIGateway.cpp
@@ -27,7 +27,9 @@
 namespace NKAI
 {
 
+// our to enemy strength ratio constants
 const float SAFE_ATTACK_CONSTANT = 1.2;
+const float RETREAT_THRESHOLD = 0.3;
 
 //one thread may be turn of AI and another will be handling a side effect for AI2
 boost::thread_specific_ptr<CCallback> cb;
@@ -201,6 +203,9 @@ void AIGateway::gameOver(PlayerColor player, const EVictoryLossCheckResult & vic
 		{
 			logAi->debug("AIGateway: Player %d (%s) lost. It's me. What a disappointment! :(", player, player.getStr());
 		}
+
+		// some whitespace to flush stream
+		logAi->debug(std::string(200, ' '));
 
 		finish();
 	}
@@ -498,7 +503,7 @@ boost::optional<BattleAction> AIGateway::makeSurrenderRetreatDecision(
 	double fightRatio = battleState.getOurStrength() / (double)battleState.getEnemyStrength();
 
 	// if we have no towns - things are already bad, so retreat is not an option.
-	if(cb->getTownsInfo().size() && fightRatio < 0.3 && battleState.canFlee)
+	if(cb->getTownsInfo().size() && fightRatio < RETREAT_THRESHOLD && battleState.canFlee)
 	{
 		return BattleAction::makeRetreat(battleState.ourSide);
 	}

--- a/AI/Nullkiller/Pathfinding/AINodeStorage.cpp
+++ b/AI/Nullkiller/Pathfinding/AINodeStorage.cpp
@@ -180,12 +180,13 @@ std::vector<CGPathNode *> AINodeStorage::getInitialNodes()
 	for(auto actorPtr : actors)
 	{
 		ChainActor * actor = actorPtr.get();
-		AIPathNode * initialNode =
-			getOrCreateNode(actor->initialPosition, actor->layer, actor)
-			.get();
 
-		if(!initialNode)
+		auto allocated = getOrCreateNode(actor->initialPosition, actor->layer, actor);
+
+		if(!allocated)
 			continue;
+
+		AIPathNode * initialNode = allocated.get();
 
 		initialNode->inPQ = false;
 		initialNode->pq = nullptr;

--- a/lib/battle/ReachabilityInfo.cpp
+++ b/lib/battle/ReachabilityInfo.cpp
@@ -70,7 +70,12 @@ int ReachabilityInfo::distToNearestNeighbour(
 	const battle::Unit * defender,
 	BattleHex * chosenHex) const
 {
-	auto attackableHexes = defender->getAttackableHexes(attacker);
+	auto attackableHexes = defender->getHexes();
+
+	if(attacker->doubleWide())
+	{
+		vstd::concatenate(attackableHexes, battle::Unit::getHexes(defender->occupiedHex(), true, attacker->unitSide()));
+	}
 
 	return distToNearestNeighbour(attackableHexes, chosenHex);
 }


### PR DESCRIPTION
AI likes to attack ballista and other war machines because they can not retaliate. This tactics is not always good. This logic uses a bit different attack evaluation - damage diff - how our attack changed enemy damage. Obviously that attacking ballista has usually no effect on enemy damage except cases with a lot of walkers can not get into a fort while a lot of defending archers attack them. These cases are rare and should be handled by a separate logic branch.
Also AI now can wait in order to attack more effectively using single creature stacks.

Performance might get affected a bit so.