### PR TITLE
Mantis-2934: fix conditions to upgrade town in h3m format parser

### DIFF
--- a/lib/mapping/MapFormatH3M.cpp
+++ b/lib/mapping/MapFormatH3M.cpp
@@ -400,7 +400,7 @@ void CMapLoaderH3M::readVictoryLossConditions()
 				EventExpression::OperatorAll oper;
 				EventCondition cond(EventCondition::HAVE_BUILDING);
 				cond.position = readInt3();
-				cond.objectType = BuildingID::VILLAGE_HALL + reader.readUInt8();
+				cond.objectType = BuildingID::TOWN_HALL + reader.readUInt8();
 				oper.expressions.push_back(cond);
 				cond.objectType = BuildingID::FORT + reader.readUInt8();
 				oper.expressions.push_back(cond);


### PR DESCRIPTION
It is not possible to build Village hall because it is what we start with. So the condition was shifted.

https://bugs.vcmi.eu/view.php?id=2934