### PR TITLE
mapeditor/mainwindow.cpp: use '%s' (not '%b') for string formatter

### DIFF
--- a/mapeditor/mainwindow.cpp
+++ b/mapeditor/mainwindow.cpp
@@ -1011,7 +1011,7 @@ void MainWindow::onSelectionMade(int level, bool anythingSelected)
 {
 	if (level == mapLevel)
 	{
-		auto info = QString::asprintf("Selection on layer %d: %b", level, anythingSelected ? "true" : "false");
+		auto info = QString::asprintf("Selection on layer %d: %s", level, anythingSelected ? "true" : "false");
 		setStatusMessage(info);
 
 		ui->actionErase->setEnabled(anythingSelected);


### PR DESCRIPTION
    mapeditor/mainwindow.cpp: In member function
      'void MainWindow::onSelectionMade(int, bool)':
    mapeditor/mainwindow.cpp:1014:47:
      warning: format '%b' expects argument of type 'unsigned int',
      but argument 3 has type 'const char*' [-Wformat=]
     1014 |                 auto info = QString::asprintf(
         "Selection on layer %d: %b", level, anythingSelected ? "true" : "false");
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         |                                                    |
         |                                                    const char*