### PR TITLE
Fix #985 - resume town & terrain themes

### DIFF
--- a/client/CMusicHandler.cpp
+++ b/client/CMusicHandler.cpp
@@ -416,7 +416,7 @@ void CMusicHandler::playMusic(const std::string & musicURI, bool loop, bool from
 	if (current && current->isTrack(musicURI))
 		return;
 
-    queueNext(this, "", musicURI, loop, fromStart);
+	queueNext(this, "", musicURI, loop, fromStart);
 }
 
 void CMusicHandler::playMusicFromSet(const std::string & whichSet, bool loop, bool fromStart)
@@ -432,7 +432,7 @@ void CMusicHandler::playMusicFromSet(const std::string & whichSet, bool loop, bo
 		return;
 
 	// in this mode - play random track from set
-    queueNext(this, whichSet, "", loop, fromStart);
+	queueNext(this, whichSet, "", loop, fromStart);
 }
 
 void CMusicHandler::playMusicFromSet(const std::string & whichSet, const std::string & entryID, bool loop,  bool fromStart)
@@ -455,7 +455,7 @@ void CMusicHandler::playMusicFromSet(const std::string & whichSet, const std::st
 		return;
 
 	// in this mode - play specific track from set
-    queueNext(this, "", selectedEntry->second, loop, fromStart);
+	queueNext(this, "", selectedEntry->second, loop, fromStart);
 }
 
 void CMusicHandler::queueNext(std::unique_ptr<MusicEntry> queued)
@@ -478,7 +478,7 @@ void CMusicHandler::queueNext(CMusicHandler *owner, const std::string & setName,
 {
 	try
 	{
-        queueNext(make_unique<MusicEntry>(owner, setName, musicURI, looped, fromStart));
+		queueNext(make_unique<MusicEntry>(owner, setName, musicURI, looped, fromStart));
 	}
 	catch(std::exception &e)
 	{
@@ -530,10 +530,10 @@ void CMusicHandler::musicFinishedCallback()
 MusicEntry::MusicEntry(CMusicHandler *owner, std::string setName, std::string musicURI, bool looped, bool fromStart):
 	owner(owner),
 	music(nullptr),
-    startTime(uint64_t(-1)),
-    startPosition(0),
+	startTime(uint64_t(-1)),
+	startPosition(0),
 	loop(looped ? -1 : 1),
-    fromStart(fromStart),
+	fromStart(fromStart),
 	setName(std::move(setName))
 {
 	if (!musicURI.empty())
@@ -583,25 +583,25 @@ bool MusicEntry::play()
 
 	logGlobal->trace("Playing music file %s", currentName);
 
-    if ( !fromStart && owner->trackPositions.count(currentName) > 0 && owner->trackPositions[currentName] > 0)
-    {
-        float timeToStart = owner->trackPositions[currentName];
-        startPosition = std::round(timeToStart * 1000);
+	if ( !fromStart && owner->trackPositions.count(currentName) > 0 && owner->trackPositions[currentName] > 0)
+	{
+		float timeToStart = owner->trackPositions[currentName];
+		startPosition = std::round(timeToStart * 1000);
 
-        if (Mix_FadeInMusicPos(music, 1, 1000, timeToStart) == -1)
-        {
-            logGlobal->error("Unable to play music (%s)", Mix_GetError());
-            return false;
-        }
-    }
-    else if(Mix_PlayMusic(music, 1) == -1)
-    {
-        logGlobal->error("Unable to play music (%s)", Mix_GetError());
-        return false;
-    }
+		if (Mix_FadeInMusicPos(music, 1, 1000, timeToStart) == -1)
+		{
+			logGlobal->error("Unable to play music (%s)", Mix_GetError());
+			return false;
+		}
+	}
+	else if(Mix_PlayMusic(music, 1) == -1)
+	{
+		logGlobal->error("Unable to play music (%s)", Mix_GetError());
+		return false;
+	}
 
-    startTime = SDL_GetTicks64();
-    return true;
+	startTime = SDL_GetTicks64();
+	return true;
 }
 
 bool MusicEntry::stop(int fade_ms)
@@ -609,11 +609,11 @@ bool MusicEntry::stop(int fade_ms)
 	if (Mix_PlayingMusic())
 	{
 		loop = 0;
-        uint64_t endTime = SDL_GetTicks64();
-        assert(startTime != uint64_t(-1));
-        float playDuration = (endTime - startTime + startPosition) / 1000.f;
-        owner->trackPositions[currentName] = playDuration;
-        logGlobal->info("Stopping music file %s at %f", currentName, playDuration);
+		uint64_t endTime = SDL_GetTicks64();
+		assert(startTime != uint64_t(-1));
+		float playDuration = (endTime - startTime + startPosition) / 1000.f;
+		owner->trackPositions[currentName] = playDuration;
+		logGlobal->info("Stopping music file %s at %f", currentName, playDuration);
 
 		Mix_FadeOutMusic(fade_ms);
 		return true;

--- a/client/CMusicHandler.cpp
+++ b/client/CMusicHandler.cpp
@@ -9,6 +9,7 @@
  */
 #include "StdInc.h"
 #include <SDL_mixer.h>
+#include <SDL.h>
 
 #include "CMusicHandler.h"
 #include "CGameInfo.h"
@@ -410,15 +411,15 @@ void CMusicHandler::release()
 	CAudioBase::release();
 }
 
-void CMusicHandler::playMusic(const std::string & musicURI, bool loop)
+void CMusicHandler::playMusic(const std::string & musicURI, bool loop, bool fromStart)
 {
 	if (current && current->isTrack(musicURI))
 		return;
 
-	queueNext(this, "", musicURI, loop);
+    queueNext(this, "", musicURI, loop, fromStart);
 }
 
-void CMusicHandler::playMusicFromSet(const std::string & whichSet, bool loop)
+void CMusicHandler::playMusicFromSet(const std::string & whichSet, bool loop, bool fromStart)
 {
 	auto selectedSet = musicsSet.find(whichSet);
 	if (selectedSet == musicsSet.end())
@@ -431,10 +432,10 @@ void CMusicHandler::playMusicFromSet(const std::string & whichSet, bool loop)
 		return;
 
 	// in this mode - play random track from set
-	queueNext(this, whichSet, "", loop);
+    queueNext(this, whichSet, "", loop, fromStart);
 }
 
-void CMusicHandler::playMusicFromSet(const std::string & whichSet, const std::string & entryID, bool loop)
+void CMusicHandler::playMusicFromSet(const std::string & whichSet, const std::string & entryID, bool loop,  bool fromStart)
 {
 	auto selectedSet = musicsSet.find(whichSet);
 	if (selectedSet == musicsSet.end())
@@ -454,7 +455,7 @@ void CMusicHandler::playMusicFromSet(const std::string & whichSet, const std::st
 		return;
 
 	// in this mode - play specific track from set
-	queueNext(this, "", selectedEntry->second, loop);
+    queueNext(this, "", selectedEntry->second, loop, fromStart);
 }
 
 void CMusicHandler::queueNext(std::unique_ptr<MusicEntry> queued)
@@ -473,11 +474,11 @@ void CMusicHandler::queueNext(std::unique_ptr<MusicEntry> queued)
 	}
 }
 
-void CMusicHandler::queueNext(CMusicHandler *owner, const std::string & setName, const std::string & musicURI, bool looped)
+void CMusicHandler::queueNext(CMusicHandler *owner, const std::string & setName, const std::string & musicURI, bool looped, bool fromStart)
 {
 	try
 	{
-		queueNext(make_unique<MusicEntry>(owner, setName, musicURI, looped));
+        queueNext(make_unique<MusicEntry>(owner, setName, musicURI, looped, fromStart));
 	}
 	catch(std::exception &e)
 	{
@@ -526,10 +527,13 @@ void CMusicHandler::musicFinishedCallback()
 	}
 }
 
-MusicEntry::MusicEntry(CMusicHandler *owner, std::string setName, std::string musicURI, bool looped):
+MusicEntry::MusicEntry(CMusicHandler *owner, std::string setName, std::string musicURI, bool looped, bool fromStart):
 	owner(owner),
 	music(nullptr),
+    startTime(uint64_t(-1)),
+    startPosition(0),
 	loop(looped ? -1 : 1),
+    fromStart(fromStart),
 	setName(std::move(setName))
 {
 	if (!musicURI.empty())
@@ -578,20 +582,39 @@ bool MusicEntry::play()
 	}
 
 	logGlobal->trace("Playing music file %s", currentName);
-	if(Mix_PlayMusic(music, 1) == -1)
-	{
-		logGlobal->error("Unable to play music (%s)", Mix_GetError());
-		return false;
-	}
-	return true;
+
+    if ( !fromStart && owner->trackPositions.count(currentName) > 0 && owner->trackPositions[currentName] > 0)
+    {
+        float timeToStart = owner->trackPositions[currentName];
+        startPosition = std::round(timeToStart * 1000);
+
+        if (Mix_FadeInMusicPos(music, 1, 1000, timeToStart) == -1)
+        {
+            logGlobal->error("Unable to play music (%s)", Mix_GetError());
+            return false;
+        }
+    }
+    else if(Mix_PlayMusic(music, 1) == -1)
+    {
+        logGlobal->error("Unable to play music (%s)", Mix_GetError());
+        return false;
+    }
+
+    startTime = SDL_GetTicks64();
+    return true;
 }
 
 bool MusicEntry::stop(int fade_ms)
 {
 	if (Mix_PlayingMusic())
 	{
-		logGlobal->trace("Stopping music file %s", currentName);
 		loop = 0;
+        uint64_t endTime = SDL_GetTicks64();
+        assert(startTime != uint64_t(-1));
+        float playDuration = (endTime - startTime + startPosition) / 1000.f;
+        owner->trackPositions[currentName] = playDuration;
+        logGlobal->info("Stopping music file %s at %f", currentName, playDuration);
+
 		Mix_FadeOutMusic(fade_ms);
 		return true;
 	}

--- a/client/CMusicHandler.cpp
+++ b/client/CMusicHandler.cpp
@@ -530,7 +530,7 @@ void CMusicHandler::musicFinishedCallback()
 MusicEntry::MusicEntry(CMusicHandler *owner, std::string setName, std::string musicURI, bool looped, bool fromStart):
 	owner(owner),
 	music(nullptr),
-	startTime(uint64_t(-1)),
+	startTime(uint32_t(-1)),
 	startPosition(0),
 	loop(looped ? -1 : 1),
 	fromStart(fromStart),
@@ -600,7 +600,7 @@ bool MusicEntry::play()
 		return false;
 	}
 
-	startTime = SDL_GetTicks64();
+	startTime = SDL_GetTicks();
 	return true;
 }
 
@@ -609,8 +609,8 @@ bool MusicEntry::stop(int fade_ms)
 	if (Mix_PlayingMusic())
 	{
 		loop = 0;
-		uint64_t endTime = SDL_GetTicks64();
-		assert(startTime != uint64_t(-1));
+		uint32_t endTime = SDL_GetTicks();
+		assert(startTime != uint32_t(-1));
 		float playDuration = (endTime - startTime + startPosition) / 1000.f;
 		owner->trackPositions[currentName] = playDuration;
 		logGlobal->info("Stopping music file %s at %f", currentName, playDuration);

--- a/client/CMusicHandler.h
+++ b/client/CMusicHandler.h
@@ -99,7 +99,10 @@ class MusicEntry
 	Mix_Music *music;
 
 	int loop; // -1 = indefinite
-	//if not null - set from which music will be randomly selected
+    bool fromStart;
+    uint64_t startTime;
+    uint64_t startPosition;
+    //if not null - set from which music will be randomly selected
 	std::string setName;
 	std::string currentName;
 
@@ -110,7 +113,7 @@ public:
 	bool isSet(std::string setName);
 	bool isTrack(std::string trackName);
 
-	MusicEntry(CMusicHandler *owner, std::string setName, std::string musicURI, bool looped);
+    MusicEntry(CMusicHandler *owner, std::string setName, std::string musicURI, bool looped, bool fromStart);
 	~MusicEntry();
 
 	bool play();
@@ -128,10 +131,11 @@ private:
 	std::unique_ptr<MusicEntry> current;
 	std::unique_ptr<MusicEntry> next;
 
-	void queueNext(CMusicHandler *owner, const std::string & setName, const std::string & musicURI, bool looped);
+    void queueNext(CMusicHandler *owner, const std::string & setName, const std::string & musicURI, bool looped, bool fromStart);
 	void queueNext(std::unique_ptr<MusicEntry> queued);
 
 	std::map<std::string, std::map<std::string, std::string>> musicsSet;
+    std::map<std::string, float> trackPositions;
 public:
 	
 	CMusicHandler();
@@ -145,11 +149,11 @@ public:
 	void setVolume(ui32 percent) override;
 
 	/// play track by URI, if loop = true music will be looped
-	void playMusic(const std::string & musicURI, bool loop);
+    void playMusic(const std::string & musicURI, bool loop, bool fromStart);
 	/// play random track from this set
-	void playMusicFromSet(const std::string & musicSet, bool loop);
+    void playMusicFromSet(const std::string & musicSet, bool loop, bool fromStart);
 	/// play specific track from set
-	void playMusicFromSet(const std::string & musicSet, const std::string & entryID, bool loop);
+    void playMusicFromSet(const std::string & musicSet, const std::string & entryID, bool loop, bool fromStart);
 	void stopMusic(int fade_ms=1000);
 	void musicFinishedCallback();
 

--- a/client/CMusicHandler.h
+++ b/client/CMusicHandler.h
@@ -99,10 +99,10 @@ class MusicEntry
 	Mix_Music *music;
 
 	int loop; // -1 = indefinite
-    bool fromStart;
-    uint64_t startTime;
-    uint64_t startPosition;
-    //if not null - set from which music will be randomly selected
+	bool fromStart;
+	uint64_t startTime;
+	uint64_t startPosition;
+	//if not null - set from which music will be randomly selected
 	std::string setName;
 	std::string currentName;
 
@@ -113,7 +113,7 @@ public:
 	bool isSet(std::string setName);
 	bool isTrack(std::string trackName);
 
-    MusicEntry(CMusicHandler *owner, std::string setName, std::string musicURI, bool looped, bool fromStart);
+	MusicEntry(CMusicHandler *owner, std::string setName, std::string musicURI, bool looped, bool fromStart);
 	~MusicEntry();
 
 	bool play();
@@ -131,11 +131,11 @@ private:
 	std::unique_ptr<MusicEntry> current;
 	std::unique_ptr<MusicEntry> next;
 
-    void queueNext(CMusicHandler *owner, const std::string & setName, const std::string & musicURI, bool looped, bool fromStart);
+	void queueNext(CMusicHandler *owner, const std::string & setName, const std::string & musicURI, bool looped, bool fromStart);
 	void queueNext(std::unique_ptr<MusicEntry> queued);
 
 	std::map<std::string, std::map<std::string, std::string>> musicsSet;
-    std::map<std::string, float> trackPositions;
+	std::map<std::string, float> trackPositions;
 public:
 	
 	CMusicHandler();
@@ -149,11 +149,11 @@ public:
 	void setVolume(ui32 percent) override;
 
 	/// play track by URI, if loop = true music will be looped
-    void playMusic(const std::string & musicURI, bool loop, bool fromStart);
+	void playMusic(const std::string & musicURI, bool loop, bool fromStart);
 	/// play random track from this set
-    void playMusicFromSet(const std::string & musicSet, bool loop, bool fromStart);
+	void playMusicFromSet(const std::string & musicSet, bool loop, bool fromStart);
 	/// play specific track from set
-    void playMusicFromSet(const std::string & musicSet, const std::string & entryID, bool loop, bool fromStart);
+	void playMusicFromSet(const std::string & musicSet, const std::string & entryID, bool loop, bool fromStart);
 	void stopMusic(int fade_ms=1000);
 	void musicFinishedCallback();
 

--- a/client/CMusicHandler.h
+++ b/client/CMusicHandler.h
@@ -100,8 +100,8 @@ class MusicEntry
 
 	int loop; // -1 = indefinite
 	bool fromStart;
-	uint64_t startTime;
-	uint64_t startPosition;
+	uint32_t startTime;
+	uint32_t startPosition;
 	//if not null - set from which music will be randomly selected
 	std::string setName;
 	std::string currentName;

--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -276,7 +276,7 @@ void CPlayerInterface::heroMoved(const TryMoveHero & details, bool verbose)
 	{
 		updateAmbientSounds();
 		//We may need to change music - select new track, music handler will change it if needed
-		CCS->musich->playMusicFromSet("terrain", LOCPLINT->cb->getTile(hero->visitablePos())->terType->name, true);
+        CCS->musich->playMusicFromSet("terrain", LOCPLINT->cb->getTile(hero->visitablePos())->terType->name, true, false);
 
 		if(details.result == TryMoveHero::TELEPORTATION)
 		{

--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -276,7 +276,7 @@ void CPlayerInterface::heroMoved(const TryMoveHero & details, bool verbose)
 	{
 		updateAmbientSounds();
 		//We may need to change music - select new track, music handler will change it if needed
-        CCS->musich->playMusicFromSet("terrain", LOCPLINT->cb->getTile(hero->visitablePos())->terType->name, true, false);
+		CCS->musich->playMusicFromSet("terrain", LOCPLINT->cb->getTile(hero->visitablePos())->terType->name, true, false);
 
 		if(details.result == TryMoveHero::TELEPORTATION)
 		{

--- a/client/battle/CBattleInterface.cpp
+++ b/client/battle/CBattleInterface.cpp
@@ -411,7 +411,7 @@ CBattleInterface::CBattleInterface(const CCreatureSet *army1, const CCreatureSet
 	{
 		if(LOCPLINT->battleInt)
 		{
-            CCS->musich->playMusicFromSet("battle", true, true);
+			CCS->musich->playMusicFromSet("battle", true, true);
 			battleActionsStarted = true;
 			blockUI(settings["session"]["spectate"].Bool());
 			battleIntroSoundChannel = -1;
@@ -457,7 +457,7 @@ CBattleInterface::~CBattleInterface()
 	if (adventureInt && adventureInt->selection)
 	{
 		const auto & terrain = *(LOCPLINT->cb->getTile(adventureInt->selection->visitablePos())->terType);
-        CCS->musich->playMusicFromSet("terrain", terrain.name, true, false);
+		CCS->musich->playMusicFromSet("terrain", terrain.name, true, false);
 	}
 	animsAreDisplayed.setn(false);
 }

--- a/client/battle/CBattleInterface.cpp
+++ b/client/battle/CBattleInterface.cpp
@@ -411,7 +411,7 @@ CBattleInterface::CBattleInterface(const CCreatureSet *army1, const CCreatureSet
 	{
 		if(LOCPLINT->battleInt)
 		{
-			CCS->musich->playMusicFromSet("battle", true);
+            CCS->musich->playMusicFromSet("battle", true, true);
 			battleActionsStarted = true;
 			blockUI(settings["session"]["spectate"].Bool());
 			battleIntroSoundChannel = -1;
@@ -457,7 +457,7 @@ CBattleInterface::~CBattleInterface()
 	if (adventureInt && adventureInt->selection)
 	{
 		const auto & terrain = *(LOCPLINT->cb->getTile(adventureInt->selection->visitablePos())->terType);
-		CCS->musich->playMusicFromSet("terrain", terrain.name, true);
+        CCS->musich->playMusicFromSet("terrain", terrain.name, true, false);
 	}
 	animsAreDisplayed.setn(false);
 }

--- a/client/battle/CBattleInterfaceClasses.cpp
+++ b/client/battle/CBattleInterfaceClasses.cpp
@@ -506,7 +506,7 @@ CBattleResultWindow::CBattleResultWindow(const BattleResult & br, CPlayerInterfa
 			break;
 		}
 
-		CCS->musich->playMusic("Music/Win Battle", false);
+        CCS->musich->playMusic("Music/Win Battle", false, true);
 		CCS->videoh->open("WIN3.BIK");
 		std::string str = CGI->generaltexth->allTexts[text];
 
@@ -543,7 +543,7 @@ CBattleResultWindow::CBattleResultWindow(const BattleResult & br, CPlayerInterfa
 			logGlobal->error("Invalid battle result code %d. Assumed normal.", static_cast<int>(br.result));
 			break;
 		}
-		CCS->musich->playMusic(musicName, false);
+        CCS->musich->playMusic(musicName, false, true);
 		CCS->videoh->open(videoName);
 
 		labels.push_back(std::make_shared<CLabel>(235, 235, FONT_SMALL, CENTER, Colors::WHITE, CGI->generaltexth->allTexts[text]));

--- a/client/battle/CBattleInterfaceClasses.cpp
+++ b/client/battle/CBattleInterfaceClasses.cpp
@@ -506,7 +506,7 @@ CBattleResultWindow::CBattleResultWindow(const BattleResult & br, CPlayerInterfa
 			break;
 		}
 
-        CCS->musich->playMusic("Music/Win Battle", false, true);
+		CCS->musich->playMusic("Music/Win Battle", false, true);
 		CCS->videoh->open("WIN3.BIK");
 		std::string str = CGI->generaltexth->allTexts[text];
 
@@ -543,7 +543,7 @@ CBattleResultWindow::CBattleResultWindow(const BattleResult & br, CPlayerInterfa
 			logGlobal->error("Invalid battle result code %d. Assumed normal.", static_cast<int>(br.result));
 			break;
 		}
-        CCS->musich->playMusic(musicName, false, true);
+		CCS->musich->playMusic(musicName, false, true);
 		CCS->videoh->open(videoName);
 
 		labels.push_back(std::make_shared<CLabel>(235, 235, FONT_SMALL, CENTER, Colors::WHITE, CGI->generaltexth->allTexts[text]));

--- a/client/mainmenu/CMainMenu.cpp
+++ b/client/mainmenu/CMainMenu.cpp
@@ -115,7 +115,7 @@ void CMenuScreen::show(SDL_Surface * to)
 
 void CMenuScreen::activate()
 {
-	CCS->musich->playMusic("Music/MainMenu", true);
+    CCS->musich->playMusic("Music/MainMenu", true, true);
 	if(!config["video"].isNull())
 		CCS->videoh->open(config["video"]["name"].String());
 	CIntObject::activate();

--- a/client/mainmenu/CMainMenu.cpp
+++ b/client/mainmenu/CMainMenu.cpp
@@ -115,7 +115,7 @@ void CMenuScreen::show(SDL_Surface * to)
 
 void CMenuScreen::activate()
 {
-    CCS->musich->playMusic("Music/MainMenu", true, true);
+	CCS->musich->playMusic("Music/MainMenu", true, true);
 	if(!config["video"].isNull())
 		CCS->videoh->open(config["video"]["name"].String());
 	CIntObject::activate();

--- a/client/mainmenu/CPrologEpilogVideo.cpp
+++ b/client/mainmenu/CPrologEpilogVideo.cpp
@@ -29,7 +29,7 @@ CPrologEpilogVideo::CPrologEpilogVideo(CCampaignScenario::SScenarioPrologEpilog 
 	updateShadow();
 
 	CCS->videoh->open(CCampaignHandler::prologVideoName(spe.prologVideo));
-    CCS->musich->playMusic("Music/" + CCampaignHandler::prologMusicName(spe.prologMusic), true, true);
+	CCS->musich->playMusic("Music/" + CCampaignHandler::prologMusicName(spe.prologMusic), true, true);
 	// MPTODO: Custom campaign crashing on this?
 //	voiceSoundHandle = CCS->soundh->playSound(CCampaignHandler::prologVoiceName(spe.prologVideo));
 

--- a/client/mainmenu/CPrologEpilogVideo.cpp
+++ b/client/mainmenu/CPrologEpilogVideo.cpp
@@ -29,7 +29,7 @@ CPrologEpilogVideo::CPrologEpilogVideo(CCampaignScenario::SScenarioPrologEpilog 
 	updateShadow();
 
 	CCS->videoh->open(CCampaignHandler::prologVideoName(spe.prologVideo));
-	CCS->musich->playMusic("Music/" + CCampaignHandler::prologMusicName(spe.prologMusic), true);
+    CCS->musich->playMusic("Music/" + CCampaignHandler::prologMusicName(spe.prologMusic), true, true);
 	// MPTODO: Custom campaign crashing on this?
 //	voiceSoundHandle = CCS->soundh->playSound(CCampaignHandler::prologVoiceName(spe.prologVideo));
 

--- a/client/windows/CAdvmapInterface.cpp
+++ b/client/windows/CAdvmapInterface.cpp
@@ -1413,7 +1413,7 @@ void CAdvMapInt::select(const CArmedInstance *sel, bool centerView)
 		auto pos = sel->visitablePos();
 		auto tile = LOCPLINT->cb->getTile(pos);
 		if(tile)
-            CCS->musich->playMusicFromSet("terrain", tile->terType->name, true, false);
+			CCS->musich->playMusicFromSet("terrain", tile->terType->name, true, false);
 	}
 	if(centerView)
 		centerOn(sel);
@@ -1863,7 +1863,7 @@ void CAdvMapInt::aiTurnStarted()
 		return;
 
 	adjustActiveness(true);
-    CCS->musich->playMusicFromSet("enemy-turn", true, false);
+	CCS->musich->playMusicFromSet("enemy-turn", true, false);
 	adventureInt->minimap.setAIRadar(true);
 	adventureInt->infoBar.startEnemyTurn(LOCPLINT->cb->getCurrentPlayer());
 	adventureInt->infoBar.showAll(screen);//force refresh on inactive object

--- a/client/windows/CAdvmapInterface.cpp
+++ b/client/windows/CAdvmapInterface.cpp
@@ -1413,7 +1413,7 @@ void CAdvMapInt::select(const CArmedInstance *sel, bool centerView)
 		auto pos = sel->visitablePos();
 		auto tile = LOCPLINT->cb->getTile(pos);
 		if(tile)
-			CCS->musich->playMusicFromSet("terrain", tile->terType->name, true);
+            CCS->musich->playMusicFromSet("terrain", tile->terType->name, true, false);
 	}
 	if(centerView)
 		centerOn(sel);
@@ -1863,7 +1863,7 @@ void CAdvMapInt::aiTurnStarted()
 		return;
 
 	adjustActiveness(true);
-	CCS->musich->playMusicFromSet("enemy-turn", true);
+    CCS->musich->playMusicFromSet("enemy-turn", true, false);
 	adventureInt->minimap.setAIRadar(true);
 	adventureInt->infoBar.startEnemyTurn(LOCPLINT->cb->getCurrentPlayer());
 	adventureInt->infoBar.showAll(screen);//force refresh on inactive object

--- a/client/windows/CCastleInterface.cpp
+++ b/client/windows/CCastleInterface.cpp
@@ -1171,7 +1171,7 @@ CCastleInterface::CCastleInterface(const CGTownInstance * Town, const CGTownInst
 	townlist->onSelect = std::bind(&CCastleInterface::townChange, this);
 
 	recreateIcons();
-	CCS->musich->playMusic(town->town->clientInfo.musicTheme, true);
+    CCS->musich->playMusic(town->town->clientInfo.musicTheme, true, false);
 }
 
 CCastleInterface::~CCastleInterface()

--- a/client/windows/CCastleInterface.cpp
+++ b/client/windows/CCastleInterface.cpp
@@ -1171,7 +1171,7 @@ CCastleInterface::CCastleInterface(const CGTownInstance * Town, const CGTownInst
 	townlist->onSelect = std::bind(&CCastleInterface::townChange, this);
 
 	recreateIcons();
-    CCS->musich->playMusic(town->town->clientInfo.musicTheme, true, false);
+	CCS->musich->playMusic(town->town->clientInfo.musicTheme, true, false);
 }
 
 CCastleInterface::~CCastleInterface()


### PR DESCRIPTION
Town & terrain themes will now resume from previously stopped position instead of playing from start, as it was in original game.
Thankfully, SDL2_Mixer has support for resuming, unlike SDL1
Fixes #985 