### PR TITLE
Fix #1088 - Refactoring of hero movement animation code

### DIFF
--- a/config/objects/moddables.json
+++ b/config/objects/moddables.json
@@ -27,7 +27,7 @@
 		"base" : {
 			"base" : {
 				"visitableFrom" : [ "+++", "+-+", "+++" ],
-				"mask" : [ "VV", "AV"]
+				"mask" : [ "VVV", "VAV"]
 			},
 			"sounds" : {
 				"removal" : ["KILLFADE"]


### PR DESCRIPTION
Replaced ancient and obscure code that had separate routines for each possible movement direction with generic version.
Fixes #1088 which apparently was due to bug in one of these routines - old code would incorrectly reassign tiles on which game should render hero sprite.