### PR TITLE
Fixes #825 - do not wait for new week dialog in single-player

### DIFF
--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -2338,10 +2338,13 @@ void CPlayerInterface::acceptTurn()
 		while(CInfoWindow *iw = dynamic_cast<CInfoWindow *>(GH.topInt().get()))
 			iw->close();
 	}
-	waitWhileDialog();
 
 	if(CSH->howManyPlayerInterfaces() > 1)
+	{
+		waitWhileDialog(); // wait for player to accept turn in hot-seat mode
+
 		adventureInt->startTurn();
+	}
 
 	adventureInt->heroList.update();
 	adventureInt->townList.update();


### PR DESCRIPTION
Fixes #825
New week sound is actually played by infobox from bottom-right corner. 
But on new week/month game will pause at waitWhileDialog() which should have been used only in hotseat mode (for "Player X starts his turn" message) incorrectly waiting for new week dialog instead.