### PR TITLE
Fix obstacles generation

### DIFF
--- a/lib/battle/BattleInfo.cpp
+++ b/lib/battle/BattleInfo.cpp
@@ -261,13 +261,12 @@ BattleInfo * BattleInfo::setupBattle(const int3 & tile, TerrainId terrain, const
 			auto * info = Obstacle(id).getInfo();
 			return info && !info->isAbsoluteObstacle && info->isAppropriate(curB->terrainType, battlefieldType);
 		};
-
-		RangeGenerator obidgen(0, VLC->obstacleHandler->objects.size() - 1, ourRand);
 		
 		if(r.rand(1,100) <= 40) //put cliff-like obstacle
 		{
 			try
 			{
+				RangeGenerator obidgen(0, VLC->obstacleHandler->objects.size() - 1, ourRand);
 				auto obstPtr = std::make_shared<CObstacleInstance>();
 				obstPtr->obstacleType = CObstacleInstance::ABSOLUTE_OBSTACLE;
 				obstPtr->ID = obidgen.getSuchNumber(appropriateAbsoluteObstacle);
@@ -282,6 +281,8 @@ BattleInfo * BattleInfo::setupBattle(const int3 & tile, TerrainId terrain, const
 			{
 				//silently ignore, if we can't place absolute obstacle, we'll go with the usual ones
 				logGlobal->debug("RangeGenerator::ExhaustedPossibilities exception occured - cannot place absolute obstacle");
+				
+				//
 			}
 		}
 
@@ -289,6 +290,7 @@ BattleInfo * BattleInfo::setupBattle(const int3 & tile, TerrainId terrain, const
 		{
 			while(tilesToBlock > 0)
 			{
+				RangeGenerator obidgen(0, VLC->obstacleHandler->objects.size() - 1, ourRand);
 				auto tileAccessibility = curB->getAccesibility();
 				const int obid = obidgen.getSuchNumber(appropriateUsualObstacle);
 				const ObstacleInfo &obi = *Obstacle(obid).getInfo();

--- a/lib/battle/BattleInfo.cpp
+++ b/lib/battle/BattleInfo.cpp
@@ -281,8 +281,6 @@ BattleInfo * BattleInfo::setupBattle(const int3 & tile, TerrainId terrain, const
 			{
 				//silently ignore, if we can't place absolute obstacle, we'll go with the usual ones
 				logGlobal->debug("RangeGenerator::ExhaustedPossibilities exception occured - cannot place absolute obstacle");
-				
-				//
 			}
 		}
 


### PR DESCRIPTION
Problem statement: RNG used to generate obstacles is the same for absolute obstacles and usual obstacles. If possibilities are exhausted while generating absolute obstacles, battlefield will not place obstacles at all. So the comment in catch block is "//silently ignore, if we can't place absolute obstacle, we'll go with the usual ones" but in fact usual obstacle placement will be immediately failed with same exception.
It's very easy to reproduce if remove all absolute obstacles for some battlefield: in 40% battles there will be no obstacles at all