### PR TITLE
Fix mod identifiers registration & incorrect mod validation

### DIFF
--- a/lib/CArtHandler.cpp
+++ b/lib/CArtHandler.cpp
@@ -373,8 +373,8 @@ CArtifact * CArtHandler::loadFromJson(const std::string & scope, const JsonNode 
 		if(!art->advMapDef.empty())
 		{
 			JsonNode templ;
-			templ.setMeta(scope);
 			templ["animation"].String() = art->advMapDef;
+			templ.setMeta(scope);
 
 			// add new template.
 			// Necessary for objects added via mods that don't have any templates in H3

--- a/lib/CCreatureHandler.cpp
+++ b/lib/CCreatureHandler.cpp
@@ -633,6 +633,7 @@ CCreature * CCreatureHandler::loadFromJson(const std::string & scope, const Json
 		{
 			JsonNode templ;
 			templ["animation"].String() = cre->advMapDef;
+			templ.setMeta(scope);
 			VLC->objtypeh->getHandlerFor(Obj::MONSTER, cre->idNumber.num)->addTemplate(templ);
 		}
 

--- a/lib/CModHandler.cpp
+++ b/lib/CModHandler.cpp
@@ -311,10 +311,14 @@ void CIdentifierStorage::finalize()
 	state = FINALIZING;
 	bool errorsFound = false;
 
-	//Note: we may receive new requests during resolution phase -> end may change -> range for can't be used
-	for(auto it = scheduledRequests.begin(); it != scheduledRequests.end(); it++)
+	while ( !scheduledRequests.empty() )
 	{
-		errorsFound |= !resolveIdentifier(*it);
+		// Use local copy since new requests may appear during resolving, invalidating any iterators
+		auto request = scheduledRequests.back();
+		scheduledRequests.pop_back();
+
+		if (!resolveIdentifier(request))
+			errorsFound = true;
 	}
 
 	if (errorsFound)

--- a/lib/CModHandler.cpp
+++ b/lib/CModHandler.cpp
@@ -206,8 +206,11 @@ std::vector<CIdentifierStorage::ObjectData> CIdentifierStorage::getPossibleIdent
 	std::set<std::string> allowedScopes;
 	bool isValidScope = true;
 
+	// called have not specified destination mod explicitly
 	if (request.remoteScope.empty())
 	{
+		// FIXME: temporary, for queries from map loader allow access to any identifer
+		// should be changed to list of mods that are marked as required by current map
 		if (request.localScope == "map")
 		{
 			for (auto const & modName : VLC->modh->getActiveMods())
@@ -221,13 +224,16 @@ std::vector<CIdentifierStorage::ObjectData> CIdentifierStorage::getPossibleIdent
 
 			if(!isValidScope)
 				return std::vector<ObjectData>();
+
+			allowedScopes.insert(request.localScope);
 		}
-		allowedScopes.insert(request.localScope);
+
+		// all mods can access built-in mod
 		allowedScopes.insert("core");
 	}
 	else
 	{
-		//...unless destination mod was specified explicitly
+		//if destination mod was specified explicitly, restrict lookup to this mod
 
 		if(request.remoteScope == "core" )
 		{

--- a/lib/JsonNode.h
+++ b/lib/JsonNode.h
@@ -184,7 +184,7 @@ namespace JsonUtils
 	 * null   : if value in source is present but set to null it will delete entry in dest
 	 * @note this function will destroy data in source
 	 */
-	DLL_LINKAGE void merge(JsonNode & dest, JsonNode & source, bool noOverride = false);
+	DLL_LINKAGE void merge(JsonNode & dest, JsonNode & source, bool ignoreOverride = false, bool copyMeta = false);
 
 	/**
 	 * @brief recursively merges source into dest, replacing identical fields
@@ -194,7 +194,7 @@ namespace JsonUtils
 	 * null   : if value in source is present but set to null it will delete entry in dest
 	 * @note this function will preserve data stored in source by creating copy
 	 */
-	DLL_LINKAGE void mergeCopy(JsonNode & dest, JsonNode source, bool noOverride = false);
+	DLL_LINKAGE void mergeCopy(JsonNode & dest, JsonNode source, bool ignoreOverride = false, bool copyMeta = false);
 
     /** @brief recursively merges descendant into copy of base node
      * Result emulates inheritance semantic

--- a/lib/mapObjects/CObjectClassesHandler.cpp
+++ b/lib/mapObjects/CObjectClassesHandler.cpp
@@ -319,9 +319,9 @@ TObjectTypeHandler CObjectClassesHandler::getHandlerFor(si32 type, si32 subtype)
 	throw std::runtime_error("Object type handler not found");
 }
 
-TObjectTypeHandler CObjectClassesHandler::getHandlerFor(std::string type, std::string subtype) const
+TObjectTypeHandler CObjectClassesHandler::getHandlerFor(std::string scope, std::string type, std::string subtype) const
 {
-	boost::optional<si32> id = VLC->modh->identifiers.getIdentifier("core", "object", type, false);
+	boost::optional<si32> id = VLC->modh->identifiers.getIdentifier(scope, "object", type, false);
 	if(id)
 	{
 		auto object = objects.at(id.get());

--- a/lib/mapObjects/CObjectClassesHandler.cpp
+++ b/lib/mapObjects/CObjectClassesHandler.cpp
@@ -360,17 +360,9 @@ void CObjectClassesHandler::beforeValidate(JsonNode & object)
 {
 	for (auto & entry : object["types"].Struct())
 	{
-		JsonNode base = object["base"];
-		base.setMeta(entry.second.meta);
-
-		JsonUtils::inherit(entry.second, base);
+		JsonUtils::inherit(entry.second, object["base"]);
 		for (auto & templ : entry.second["templates"].Struct())
-		{
-			JsonNode subBase = entry.second["base"];
-			subBase.setMeta(entry.second.meta);
-
-			JsonUtils::inherit(templ.second, subBase);
-		}
+			JsonUtils::inherit(templ.second, entry.second["base"]);
 	}
 }
 

--- a/lib/mapObjects/CObjectClassesHandler.h
+++ b/lib/mapObjects/CObjectClassesHandler.h
@@ -303,7 +303,7 @@ public:
 
 	/// returns handler for specified object (ID-based). ObjectHandler keeps ownership
 	TObjectTypeHandler getHandlerFor(si32 type, si32 subtype) const;
-	TObjectTypeHandler getHandlerFor(std::string type, std::string subtype) const;
+	TObjectTypeHandler getHandlerFor(std::string scope, std::string type, std::string subtype) const;
 	TObjectTypeHandler getHandlerFor(CompoundMapObjectID compoundIdentifier) const;
 
 	std::string getObjectName(si32 type) const;

--- a/lib/mapObjects/CommonConstructors.cpp
+++ b/lib/mapObjects/CommonConstructors.cpp
@@ -44,6 +44,9 @@ void CTownInstanceConstructor::initTypeData(const JsonNode & input)
 	});
 
 	filtersJson = input["filters"];
+
+	// change scope of "filters" to scope of object that is being loaded
+	// since this filters require to resolve building ID's
 	filtersJson.setMeta(input["faction"].meta);
 }
 

--- a/lib/mapObjects/CommonConstructors.cpp
+++ b/lib/mapObjects/CommonConstructors.cpp
@@ -44,6 +44,7 @@ void CTownInstanceConstructor::initTypeData(const JsonNode & input)
 	});
 
 	filtersJson = input["filters"];
+	filtersJson.setMeta(input["faction"].meta);
 }
 
 void CTownInstanceConstructor::afterLoadFinalization()

--- a/lib/mapping/MapFormatJson.cpp
+++ b/lib/mapping/MapFormatJson.cpp
@@ -1121,7 +1121,7 @@ void CMapLoaderJson::MapObjectLoader::construct()
 		return;
 	}
 
-	auto handler = VLC->objtypeh->getHandlerFor(typeName, subtypeName);
+	auto handler = VLC->objtypeh->getHandlerFor( "map", typeName, subtypeName);
 
 	auto appearance = new ObjectTemplate;
 


### PR DESCRIPTION
Resolves #1174 

Fixes several cases where manipulations with json would lead to situations where some fields or even entire object will end up with incorrect meta field, resulting in validation failure in mods (#1174) or objects ending up registered under tag of another mod

Cleaned up map loader code responsible for object resolving phase, which was working poorly due to incorrectly registered objects