### PR TITLE
HoMM3 bug workaround: fixes missing slot on artifact merchant background image

### DIFF
--- a/client/windows/CTradeWindow.cpp
+++ b/client/windows/CTradeWindow.cpp
@@ -676,6 +676,10 @@ CMarketplaceWindow::CMarketplaceWindow(const IMarket * Market, const CGHeroInsta
 			break;
 		case EMarketMode::ARTIFACT_RESOURCE:
 			title = (*CGI->townh)[market->o->subID]->town->buildings[BuildingID::ARTIFACT_MERCHANT]->Name();
+
+			// create image that copies part of background containing slot MISC_1 into position of slot MISC_5
+			// this is workaround for bug in H3 files where this slot for ragdoll on this screen is missing
+			images.push_back(std::make_shared<CPicture>(background->bg, Rect(20, 187, 47, 47), 18, 339 ));
 			sliderNeeded = false;
 			break;
 		default:

--- a/client/windows/CTradeWindow.h
+++ b/client/windows/CTradeWindow.h
@@ -21,6 +21,7 @@ VCMI_LIB_NAMESPACE_END
 
 class CSlider;
 class CTextBox;
+class CPicture;
 class CGStatusBar;
 
 class CTradeWindow : public CWindowObject, public CWindowWithArtifacts //base for markets and altar of sacrifice
@@ -108,6 +109,7 @@ public:
 protected:
 	std::shared_ptr<CGStatusBar> statusBar;
 	std::vector<std::shared_ptr<CLabel>> labels;
+	std::vector<std::shared_ptr<CPicture>> images;
 	std::vector<std::shared_ptr<CButton>> buttons;
 	std::vector<std::shared_ptr<CTextBox>> texts;
 };


### PR DESCRIPTION
Fixes #827 
From what I see in HD Mod screenshot their fix was edited image where slot MISC_1 is copied into place that should be occupied by slot MISC_5.
To avoid copying H3 assets, we can do the same but in code, ending up with the same result.

Opening PR against beta branch since bug has 1.1 set as milestone. Can switch to develop branch if preferable.