### PR TITLE
Fixed access violation in artifacts code and potentially non-finisheable battles

### DIFF
--- a/lib/CArtHandler.cpp
+++ b/lib/CArtHandler.cpp
@@ -1547,16 +1547,18 @@ DLL_LINKAGE ArtifactPosition ArtifactUtils::getArtifactDstPosition(	const CArtif
 
 DLL_LINKAGE const std::vector<ArtifactPosition::EArtifactPosition> & ArtifactUtils::unmovableSlots()
 {
-	return
+	static const std::vector<ArtifactPosition::EArtifactPosition> positions =
 	{
 		ArtifactPosition::SPELLBOOK,
 		ArtifactPosition::MACH4
 	};
+
+	return positions;
 }
 
 DLL_LINKAGE const std::vector<ArtifactPosition::EArtifactPosition> & ArtifactUtils::constituentWornSlots()
 {
-	return
+	static const std::vector<ArtifactPosition::EArtifactPosition> positions =
 	{
 		ArtifactPosition::HEAD,
 		ArtifactPosition::SHOULDERS,
@@ -1573,6 +1575,8 @@ DLL_LINKAGE const std::vector<ArtifactPosition::EArtifactPosition> & ArtifactUti
 		ArtifactPosition::MISC4,
 		ArtifactPosition::MISC5,
 	};
+
+	return positions;
 }
 
 DLL_LINKAGE bool ArtifactUtils::isArtRemovable(const std::pair<ArtifactPosition, ArtSlotInfo> & slot)

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -6642,6 +6642,8 @@ void CGameHandler::runBattle()
 			}
 		}
 	}
+	// it is possible that due to opening spells one side was eliminated -> check for end of battle
+	checkBattleStateChanges();
 
 	bool firstRound = true;//FIXME: why first round is -1?
 


### PR DESCRIPTION
Fixes #1063 - added check for end-of-battle after opening spells are cast (not possible in H3, possible with mods)
During testing, discovered new crash introduced in #1175 - it is illegal to return address of a temporary, fixed.