### PR TITLE
#1186 - disable status bar with other advmap controls

### DIFF
--- a/client/windows/CAdvmapInterface.cpp
+++ b/client/windows/CAdvmapInterface.cpp
@@ -978,6 +978,7 @@ void CAdvMapInt::deactivate()
 		}
 		minimap.deactivate();
 		terrain.deactivate();
+		statusbar->deactivate();
 	}
 }
 


### PR DESCRIPTION
Fixes #1186 also fixes crashes on AdvMap destruction.