### PR TITLE
Adjust positions of heroes in towns earlier

### DIFF
--- a/lib/CGameState.h
+++ b/lib/CGameState.h
@@ -269,6 +269,7 @@ private:
 	void placeStartingHero(PlayerColor playerColor, HeroTypeID heroTypeId, int3 townPos);
 	void initStartingResources();
 	void initHeroes();
+	void placeHeroesInTowns();
 	void giveCampaignBonusToHero(CGHeroInstance * hero);
 	void initFogOfWar();
 	void initStartingBonus();


### PR DESCRIPTION
fixes crash due to accessing tile that is outside of map bonds.
Fixes Dragons Nest map mentioned in #1192 

Rechecked all test cases from previous PR, everything seems to be OK.