### PR TITLE
vcmibuilder script fixes

### DIFF
--- a/vcmibuilder
+++ b/vcmibuilder
@@ -168,13 +168,19 @@ mkdir -p "$temp_dir"
 
 if [[ -n "$gog_file" ]]
 then
-	data_dir="$temp_dir"/app
+	data_dir="$temp_dir"/gog
 	mkdir -p "$data_dir"
 
 	# innoextract always reports error (iconv 84 error). Just test file for presence
 	test -f "$gog_file" || fail "Error: gog.com executable was not found!"
 	gog_file="$(cd "$(dirname "$gog_file")"; pwd)/$(basename "$gog_file")"
 	cd "$data_dir" && innoextract "$gog_file"
+	
+	# some versions of gog.com installer (or innoextract tool?) place game files inside /app directory
+	if [[ -d "$data_dir"/app ]]
+	then
+		data_dir="$data_dir"/app
+	fi
 fi
 
 if [[ -n "$cd1_dir" ]]

--- a/vcmibuilder
+++ b/vcmibuilder
@@ -254,10 +254,10 @@ fi
 
 if [[ -n "$validate" ]]
 then
-	test -f "$dest_dir"/Data/H3bitmap.lod || fail "Error: Heroes 3 data files are missing!"
-	test -f "$dest_dir"/Data/H3sprite.lod || fail "Error: Heroes 3 data files are missing!"
-	test -f "$dest_dir"/Data/VIDEO.VID    || fail "Error: Heroes 3 data files (CD2) are missing!"
-	test -d "$dest_dir"/Mods/vcmi/Data    || fail "Error: VCMI data files are missing!"
+	test -f "$dest_dir"/[Dd][Aa][Tt][Aa]/H3bitmap.lod || fail "Error: Heroes 3 data files are missing!"
+	test -f "$dest_dir"/[Dd][Aa][Tt][Aa]/H3sprite.lod || fail "Error: Heroes 3 data files are missing!"
+	test -f "$dest_dir"/[Dd][Aa][Tt][Aa]/VIDEO.VID    || fail "Error: Heroes 3 data files (CD2) are missing!"
+	#test -d "$dest_dir"/Mods/vcmi/Data                || fail "Error: VCMI data files are missing!"
 fi
 
 rm -rf "$temp_dir"


### PR DESCRIPTION
Fix #982 - handle scenario with different name of Data folder, remove old check for vcmi mod
Fix #884 - handle potentially different filesystem layout of gog.com installer / innoextract tool