### PR TITLE
Resource Extractor produces files with only zeroes.

### DIFF
--- a/lib/filesystem/CArchiveLoader.cpp
+++ b/lib/filesystem/CArchiveLoader.cpp
@@ -231,7 +231,15 @@ void CArchiveLoader::extractToFolder(const std::string & outputSubFolder, const 
 {
 	std::unique_ptr<CInputStream> inputStream = load(ResourceID(mountPoint + entry.name));
 
-	extractToFolder(outputSubFolder, *inputStream, entry);
+	std::vector<ui8> data(entry.fullSize);
+	inputStream->read(data.data(), entry.fullSize);
+
+	bfs::path extractedFilePath = createExtractedFilePath(outputSubFolder, entry.name);
+
+	// writeToOutputFile
+	std::ofstream out(extractedFilePath.string(), std::ofstream::binary);
+	out.exceptions(std::ifstream::failbit | std::ifstream::badbit);
+	out.write((char*)data.data(), entry.fullSize);
 }
 
 bfs::path createExtractedFilePath(const std::string & outputSubFolder, const std::string & entryName)

--- a/lib/filesystem/CArchiveLoader.cpp
+++ b/lib/filesystem/CArchiveLoader.cpp
@@ -231,15 +231,8 @@ void CArchiveLoader::extractToFolder(const std::string & outputSubFolder, const 
 {
 	std::unique_ptr<CInputStream> inputStream = load(ResourceID(mountPoint + entry.name));
 
-	std::vector<ui8> data(entry.fullSize);
-	inputStream->read(data.data(), entry.fullSize);
-
-	bfs::path extractedFilePath = createExtractedFilePath(outputSubFolder, entry.name);
-
-	// writeToOutputFile
-	std::ofstream out(extractedFilePath.string(), std::ofstream::binary);
-	out.exceptions(std::ifstream::failbit | std::ifstream::badbit);
-	out.write((char*)data.data(), entry.fullSize);
+	entry.offset = 0;
+	extractToFolder(outputSubFolder, *inputStream, entry);
 }
 
 bfs::path createExtractedFilePath(const std::string & outputSubFolder, const std::string & entryName)


### PR DESCRIPTION
This bug was introduces with the modification of:
`void CArchiveLoader::extractToFolder(const std::string& outputSubFolder, const std::string& mountPoint, ArchiveEntry entry)`
to internally make use of:
`void CArchiveLoader::extractToFolder(const std::string & outputSubFolder, CInputStream & fileStream, ArchiveEntry entry)`
