### PR TITLE
Fix crash on casting clone on modded creature

### DIFF
--- a/client/CMT.cpp
+++ b/client/CMT.cpp
@@ -721,7 +721,7 @@ void processCommand(const std::string &message)
 				{
 					const JsonNode & object = nameAndObject.second;
 
-					std::string name = CModHandler::normalizeIdentifier(object.meta, "core", nameAndObject.first);
+					std::string name = CModHandler::normalizeIdentifier(object.meta, CModHandler::scopeBuiltin(), nameAndObject.first);
 
 					boost::algorithm::replace_all(name,":","_");
 

--- a/client/Graphics.cpp
+++ b/client/Graphics.cpp
@@ -101,7 +101,7 @@ void Graphics::loadPaletteAndColors()
 void Graphics::initializeBattleGraphics()
 {
 	auto allConfigs = VLC->modh->getActiveMods();
-	allConfigs.insert(allConfigs.begin(), "core");
+	allConfigs.insert(allConfigs.begin(), CModHandler::scopeBuiltin());
 	for(auto & mod : allConfigs)
 	{
 		if(!CResourceHandler::get(mod)->existsResource(ResourceID("config/battles_graphics.json")))

--- a/lib/CArtHandler.cpp
+++ b/lib/CArtHandler.cpp
@@ -280,7 +280,7 @@ std::vector<JsonNode> CArtHandler::loadLegacyData(size_t dataSize)
 
 void CArtHandler::loadObject(std::string scope, std::string name, const JsonNode & data)
 {
-	auto object = loadFromJson(scope, data, normalizeIdentifier(scope, "core", name), objects.size());
+	auto object = loadFromJson(scope, data, normalizeIdentifier(scope, CModHandler::scopeBuiltin(), name), objects.size());
 
 	object->iconIndex = object->getIndex() + 5;
 
@@ -291,7 +291,7 @@ void CArtHandler::loadObject(std::string scope, std::string name, const JsonNode
 
 void CArtHandler::loadObject(std::string scope, std::string name, const JsonNode & data, size_t index)
 {
-	auto object = loadFromJson(scope, data, normalizeIdentifier(scope, "core", name), index);
+	auto object = loadFromJson(scope, data, normalizeIdentifier(scope, CModHandler::scopeBuiltin(), name), index);
 
 	object->iconIndex = object->getIndex();
 

--- a/lib/CCreatureHandler.cpp
+++ b/lib/CCreatureHandler.cpp
@@ -425,7 +425,7 @@ const CCreature * CCreatureHandler::getCreature(const std::string & scope, const
 void CCreatureHandler::loadCommanders()
 {
 	JsonNode data(ResourceID("config/commanders.json"));
-	data.setMeta("core"); // assume that commanders are in core mod (for proper bonuses resolution)
+	data.setMeta(CModHandler::scopeBuiltin()); // assume that commanders are in core mod (for proper bonuses resolution)
 
 	const JsonNode & config = data; // switch to const data accessors
 

--- a/lib/CCreatureSet.cpp
+++ b/lib/CCreatureSet.cpp
@@ -1053,7 +1053,7 @@ void CStackBasicDescriptor::serializeJson(JsonSerializeFormat & handler)
 		std::string typeName("");
 		handler.serializeString("type", typeName);
 		if(!typeName.empty())
-			setType(VLC->creh->getCreature("core", typeName));
+			setType(VLC->creh->getCreature(CModHandler::scopeBuiltin(), typeName));
 	}
 }
 

--- a/lib/CHeroHandler.cpp
+++ b/lib/CHeroHandler.cpp
@@ -348,7 +348,7 @@ CHeroHandler::CHeroHandler()
 	loadTerrains();
 	for(const auto & terrain : VLC->terrainTypeHandler->terrains())
 	{
-		VLC->modh->identifiers.registerObject("core", "terrain", terrain.name, terrain.id);
+		VLC->modh->identifiers.registerObject(CModHandler::scopeBuiltin(), "terrain", terrain.name, terrain.id);
 	}
 	loadBallistics();
 	loadExperience();
@@ -868,7 +868,7 @@ std::vector<JsonNode> CHeroHandler::loadLegacyData(size_t dataSize)
 void CHeroHandler::loadObject(std::string scope, std::string name, const JsonNode & data)
 {
 	size_t index = objects.size();
-	auto object = loadFromJson(scope, data, normalizeIdentifier(scope, "core", name), index);
+	auto object = loadFromJson(scope, data, normalizeIdentifier(scope, CModHandler::scopeBuiltin(), name), index);
 	object->imageIndex = (si32)index + GameConstants::HERO_PORTRAIT_SHIFT; // 2 special frames + some extra portraits
 
 	objects.push_back(object);
@@ -878,7 +878,7 @@ void CHeroHandler::loadObject(std::string scope, std::string name, const JsonNod
 
 void CHeroHandler::loadObject(std::string scope, std::string name, const JsonNode & data, size_t index)
 {
-	auto object = loadFromJson(scope, data, normalizeIdentifier(scope, "core", name), index);
+	auto object = loadFromJson(scope, data, normalizeIdentifier(scope, CModHandler::scopeBuiltin(), name), index);
 	object->imageIndex = static_cast<si32>(index);
 
 	assert(objects[index] == nullptr); // ensure that this id was not loaded before

--- a/lib/CModHandler.cpp
+++ b/lib/CModHandler.cpp
@@ -209,8 +209,7 @@ std::vector<CIdentifierStorage::ObjectData> CIdentifierStorage::getPossibleIdent
 	// called have not specified destination mod explicitly
 	if (request.remoteScope.empty())
 	{
-		// FIXME: temporary, for queries from map loader allow access to any identifer
-		// should be changed to list of mods that are marked as required by current map
+		// "map" is special scope that should have access to all in-game objects
 		if (request.localScope == "map")
 		{
 			for (auto const & modName : VLC->modh->getActiveMods())
@@ -234,10 +233,14 @@ std::vector<CIdentifierStorage::ObjectData> CIdentifierStorage::getPossibleIdent
 	else
 	{
 		//if destination mod was specified explicitly, restrict lookup to this mod
-
 		if(request.remoteScope == "core" )
 		{
 			//"core" mod is an implicit dependency for all mods, allow access into it
+			allowedScopes.insert(request.remoteScope);
+		}
+		else if ( request.localScope == "map" )
+		{
+			// allow access, "map" is special scope that should have access to all in-game objects
 			allowedScopes.insert(request.remoteScope);
 		}
 		else if(request.remoteScope == request.localScope )

--- a/lib/CModHandler.cpp
+++ b/lib/CModHandler.cpp
@@ -209,15 +209,15 @@ std::vector<CIdentifierStorage::ObjectData> CIdentifierStorage::getPossibleIdent
 	// called have not specified destination mod explicitly
 	if (request.remoteScope.empty())
 	{
-		// "map" is special scope that should have access to all in-game objects
-		if (request.localScope == "map")
+		// special scope that should have access to all in-game objects
+		if (request.localScope == CModHandler::scopeGame())
 		{
 			for (auto const & modName : VLC->modh->getActiveMods())
 				allowedScopes.insert(modName);
 		}
 
-		// normally ID's from all required mods, own mod and virtual "core" mod are allowed
-		else if(request.localScope != "core" && !request.localScope.empty())
+		// normally ID's from all required mods, own mod and virtual built-in mod are allowed
+		else if(request.localScope != CModHandler::scopeBuiltin() && !request.localScope.empty())
 		{
 			allowedScopes = VLC->modh->getModDependencies(request.localScope, isValidScope);
 
@@ -228,19 +228,19 @@ std::vector<CIdentifierStorage::ObjectData> CIdentifierStorage::getPossibleIdent
 		}
 
 		// all mods can access built-in mod
-		allowedScopes.insert("core");
+		allowedScopes.insert(CModHandler::scopeBuiltin());
 	}
 	else
 	{
 		//if destination mod was specified explicitly, restrict lookup to this mod
-		if(request.remoteScope == "core" )
+		if(request.remoteScope == CModHandler::scopeBuiltin() )
 		{
-			//"core" mod is an implicit dependency for all mods, allow access into it
+			//built-in mod is an implicit dependency for all mods, allow access into it
 			allowedScopes.insert(request.remoteScope);
 		}
-		else if ( request.localScope == "map" )
+		else if ( request.localScope == CModHandler::scopeGame() )
 		{
-			// allow access, "map" is special scope that should have access to all in-game objects
+			// allow access, this is special scope that should have access to all in-game objects
 			allowedScopes.insert(request.remoteScope);
 		}
 		else if(request.remoteScope == request.localScope )
@@ -343,7 +343,7 @@ ContentTypeHandler::ContentTypeHandler(IHandlerBase * handler, std::string objec
 {
 	for(auto & node : originalData)
 	{
-		node.setMeta("core");
+		node.setMeta(CModHandler::scopeBuiltin());
 	}
 }
 
@@ -509,7 +509,7 @@ void CContentHandler::preloadData(CModInfo & mod)
 	// print message in format [<8-symbols checksum>] <modname>
 	logMod->info("\t\t[%08x]%s", mod.checksum, mod.name);
 
-	if (validate && mod.identifier != "core")
+	if (validate && mod.identifier != CModHandler::scopeBuiltin())
 	{
 		if (!JsonUtils::validate(mod.config, "vcmi:mod", mod.identifier))
 			mod.validation = CModInfo::FAILED;
@@ -701,13 +701,13 @@ CModHandler::CModHandler() : content(std::make_shared<CContentHandler>())
     modules.MITHRIL = false;
 	for (int i = 0; i < GameConstants::RESOURCE_QUANTITY; ++i)
 	{
-		identifiers.registerObject("core", "resource", GameConstants::RESOURCE_NAMES[i], i);
+		identifiers.registerObject(CModHandler::scopeBuiltin(), "resource", GameConstants::RESOURCE_NAMES[i], i);
 	}
 
 	for(int i=0; i<GameConstants::PRIMARY_SKILLS; ++i)
 	{
-		identifiers.registerObject("core", "primSkill", PrimarySkill::names[i], i);
-		identifiers.registerObject("core", "primarySkill", PrimarySkill::names[i], i);
+		identifiers.registerObject(CModHandler::scopeBuiltin(), "primSkill", PrimarySkill::names[i], i);
+		identifiers.registerObject(CModHandler::scopeBuiltin(), "primarySkill", PrimarySkill::names[i], i);
 	}
 }
 
@@ -908,6 +908,35 @@ std::vector<std::string> CModHandler::getModList(std::string path)
 	return foundMods;
 }
 
+bool CModHandler::isScopeReserved(const TModID & scope)
+{
+	static const std::array<TModID, 3> reservedScopes = {
+		"core", "map", "game"
+	};
+
+	return std::find(reservedScopes.begin(), reservedScopes.end(), scope) != reservedScopes.end();
+}
+
+const TModID & CModHandler::scopeBuiltin()
+{
+	static const TModID scope = "core";
+	return scope;
+}
+
+const TModID & CModHandler::scopeGame()
+{
+	static const TModID scope = "game";
+	return scope;
+}
+
+const TModID & CModHandler::scopeMap()
+{
+	//TODO: implement accessing map dependencies for both H3 and VCMI maps
+	// for now, allow access to any identifiers
+	static const TModID scope = "game";
+	return scope;
+}
+
 void CModHandler::loadMods(std::string path, std::string parent, const JsonNode & modSettings, bool enableMods)
 {
 	for(std::string modName : getModList(path))
@@ -918,6 +947,12 @@ void CModHandler::loadOneMod(std::string modName, std::string parent, const Json
 {
 	boost::to_lower(modName);
 	std::string modFullName = parent.empty() ? modName : parent + '.' + modName;
+
+	if ( isScopeReserved(modFullName))
+	{
+		logMod->error("Can not load mod %s - this name is reserved for internal use!", modFullName);
+		return;
+	}
 
 	if(CResourceHandler::get("initial")->existsResource(ResourceID(CModInfo::getModFile(modFullName))))
 	{
@@ -947,7 +982,7 @@ void CModHandler::loadMods(bool onlyEssential)
 		loadMods("", "", modConfig["activeMods"], true);
 	}
 
-	coreMod = CModInfo("core", modConfig["core"], JsonNode(ResourceID("config/gameConfig.json")));
+	coreMod = CModInfo(CModHandler::scopeBuiltin(), modConfig[CModHandler::scopeBuiltin()], JsonNode(ResourceID("config/gameConfig.json")));
 	coreMod.name = "Original game files";
 }
 
@@ -994,7 +1029,7 @@ static ui32 calculateModChecksum(const std::string modName, ISimpleResourceLoade
 
 	// second - add mod.json into checksum because filesystem does not contains this file
 	// FIXME: remove workaround for core mod
-	if (modName != "core")
+	if (modName != CModHandler::scopeBuiltin())
 	{
 		ResourceID modConfFile(CModInfo::getModFile(modName), EResType::TEXT);
 		ui32 configChecksum = CResourceHandler::get("initial")->load(modConfFile)->calculateCRC32();
@@ -1020,7 +1055,7 @@ void CModHandler::loadModFilesystems()
 {
 	activeMods = validateAndSortDependencies(activeMods);
 
-	coreMod.updateChecksum(calculateModChecksum("core", CResourceHandler::get("core")));
+	coreMod.updateChecksum(calculateModChecksum(CModHandler::scopeBuiltin(), CResourceHandler::get(CModHandler::scopeBuiltin())));
 
 	for(std::string & modName : activeMods)
 	{
@@ -1060,7 +1095,7 @@ void CModHandler::load()
 		allMods[modName].updateChecksum(calculateModChecksum(modName, CResourceHandler::get(modName)));
 	}
 
-	// first - load virtual "core" mod that contains all data
+	// first - load virtual builtin mod that contains all data
 	// TODO? move all data into real mods? RoE, AB, SoD, WoG
 	content->preloadData(coreMod);
 	for(const TModID & modName : activeMods)
@@ -1099,7 +1134,7 @@ void CModHandler::afterLoad(bool onlyEssential)
 
 		modSettings["activeMods"].resolvePointer(pointer) = modEntry.second.saveLocalData();
 	}
-	modSettings["core"] = coreMod.saveLocalData();
+	modSettings[CModHandler::scopeBuiltin()] = coreMod.saveLocalData();
 
 	if(!onlyEssential)
 	{

--- a/lib/CModHandler.h
+++ b/lib/CModHandler.h
@@ -277,7 +277,19 @@ class DLL_LINKAGE CModHandler
 	void loadMods(std::string path, std::string parent, const JsonNode & modSettings, bool enableMods);
 	void loadOneMod(std::string modName, std::string parent, const JsonNode & modSettings, bool enableMods);
 public:
-	
+
+	/// returns true if scope is reserved for internal use and can not be used by mods
+	static bool isScopeReserved(const TModID & scope);
+
+	/// reserved scope name for referencing built-in (e.g. H3) objects
+	static const TModID & scopeBuiltin();
+
+	/// reserved scope name for accessing objects from any loaded mod
+	static const TModID & scopeGame();
+
+	/// reserved scope name for accessing object for map loading
+	static const TModID & scopeMap();
+
 	class DLL_LINKAGE Incompatibility: public std::exception
 	{
 	public:

--- a/lib/CSkillHandler.cpp
+++ b/lib/CSkillHandler.cpp
@@ -267,7 +267,7 @@ std::vector<bool> CSkillHandler::getDefaultAllowed() const
 
 si32 CSkillHandler::decodeSkill(const std::string & identifier)
 {
-	auto rawId = VLC->modh->identifiers.getIdentifier("core", "skill", identifier);
+	auto rawId = VLC->modh->identifiers.getIdentifier(CModHandler::scopeBuiltin(), "skill", identifier);
 	if(rawId)
 		return rawId.get();
 	else

--- a/lib/CTownHandler.cpp
+++ b/lib/CTownHandler.cpp
@@ -1010,7 +1010,7 @@ CFaction * CTownHandler::loadFromJson(const std::string & scope, const JsonNode 
 
 void CTownHandler::loadObject(std::string scope, std::string name, const JsonNode & data)
 {
-	auto object = loadFromJson(scope, data, normalizeIdentifier(scope, "core", name), objects.size());
+	auto object = loadFromJson(scope, data, normalizeIdentifier(scope, CModHandler::scopeBuiltin(), name), objects.size());
 
 	objects.push_back(object);
 
@@ -1049,7 +1049,7 @@ void CTownHandler::loadObject(std::string scope, std::string name, const JsonNod
 
 void CTownHandler::loadObject(std::string scope, std::string name, const JsonNode & data, size_t index)
 {
-	auto object = loadFromJson(scope, data, normalizeIdentifier(scope, "core", name), index);
+	auto object = loadFromJson(scope, data, normalizeIdentifier(scope, CModHandler::scopeBuiltin(), name), index);
 
 	if (objects.size() > index)
 		assert(objects[index] == nullptr); // ensure that this id was not loaded before
@@ -1083,7 +1083,7 @@ void CTownHandler::loadRandomFaction()
 	static const ResourceID randomFactionPath("config/factions/random.json");
 
 	JsonNode randomFactionJson(randomFactionPath);
-	randomFactionJson.setMeta("core", true);
+	randomFactionJson.setMeta(CModHandler::scopeBuiltin(), true);
 	loadBuildings(randomTown, randomFactionJson["random"]["town"]["buildings"]);
 }
 

--- a/lib/GameConstants.cpp
+++ b/lib/GameConstants.cpp
@@ -86,7 +86,7 @@ const Artifact * ArtifactID::toArtifact(const ArtifactService * service) const
 
 si32 ArtifactID::decode(const std::string & identifier)
 {
-	auto rawId = VLC->modh->identifiers.getIdentifier("core", "artifact", identifier);
+	auto rawId = VLC->modh->identifiers.getIdentifier("map", "artifact", identifier);
 	if(rawId)
 		return rawId.get();
 	else
@@ -110,7 +110,7 @@ const Creature * CreatureID::toCreature(const CreatureService * creatures) const
 
 si32 CreatureID::decode(const std::string & identifier)
 {
-	auto rawId = VLC->modh->identifiers.getIdentifier("core", "creature", identifier);
+	auto rawId = VLC->modh->identifiers.getIdentifier("map", "creature", identifier);
 	if(rawId)
 		return rawId.get();
 	else
@@ -139,7 +139,7 @@ const spells::Spell * SpellID::toSpell(const spells::Service * service) const
 
 si32 SpellID::decode(const std::string & identifier)
 {
-	auto rawId = VLC->modh->identifiers.getIdentifier("core", "spell", identifier);
+	auto rawId = VLC->modh->identifiers.getIdentifier("map", "spell", identifier);
 	if(rawId)
 		return rawId.get();
 	else
@@ -201,7 +201,7 @@ const FactionID FactionID::NEUTRAL = FactionID(9);
 
 si32 FactionID::decode(const std::string & identifier)
 {
-	auto rawId = VLC->modh->identifiers.getIdentifier("core", "faction", identifier);
+	auto rawId = VLC->modh->identifiers.getIdentifier("map", "faction", identifier);
 	if(rawId)
 		return rawId.get();
 	else

--- a/lib/GameConstants.cpp
+++ b/lib/GameConstants.cpp
@@ -62,7 +62,7 @@ namespace GameConstants
 
 si32 HeroTypeID::decode(const std::string & identifier)
 {
-	auto rawId = VLC->modh->identifiers.getIdentifier("core", "hero", identifier);
+	auto rawId = VLC->modh->identifiers.getIdentifier(CModHandler::scopeBuiltin(), "hero", identifier);
 	if(rawId)
 		return rawId.get();
 	else
@@ -86,7 +86,7 @@ const Artifact * ArtifactID::toArtifact(const ArtifactService * service) const
 
 si32 ArtifactID::decode(const std::string & identifier)
 {
-	auto rawId = VLC->modh->identifiers.getIdentifier("map", "artifact", identifier);
+	auto rawId = VLC->modh->identifiers.getIdentifier(CModHandler::scopeGame(), "artifact", identifier);
 	if(rawId)
 		return rawId.get();
 	else
@@ -110,7 +110,7 @@ const Creature * CreatureID::toCreature(const CreatureService * creatures) const
 
 si32 CreatureID::decode(const std::string & identifier)
 {
-	auto rawId = VLC->modh->identifiers.getIdentifier("map", "creature", identifier);
+	auto rawId = VLC->modh->identifiers.getIdentifier(CModHandler::scopeGame(), "creature", identifier);
 	if(rawId)
 		return rawId.get();
 	else
@@ -139,7 +139,7 @@ const spells::Spell * SpellID::toSpell(const spells::Service * service) const
 
 si32 SpellID::decode(const std::string & identifier)
 {
-	auto rawId = VLC->modh->identifiers.getIdentifier("map", "spell", identifier);
+	auto rawId = VLC->modh->identifiers.getIdentifier(CModHandler::scopeGame(), "spell", identifier);
 	if(rawId)
 		return rawId.get();
 	else
@@ -201,7 +201,7 @@ const FactionID FactionID::NEUTRAL = FactionID(9);
 
 si32 FactionID::decode(const std::string & identifier)
 {
-	auto rawId = VLC->modh->identifiers.getIdentifier("map", "faction", identifier);
+	auto rawId = VLC->modh->identifiers.getIdentifier(CModHandler::scopeGame(), "faction", identifier);
 	if(rawId)
 		return rawId.get();
 	else
@@ -289,7 +289,7 @@ const BattleFieldInfo * BattleField::getInfo() const
 
 BattleField BattleField::fromString(std::string identifier)
 {
-	auto rawId = VLC->modh->identifiers.getIdentifier("core", "battlefield", identifier);
+	auto rawId = VLC->modh->identifiers.getIdentifier(CModHandler::scopeBuiltin(), "battlefield", identifier);
 
 	if(rawId)
 		return BattleField(rawId.get());
@@ -309,7 +309,7 @@ Obstacle::operator std::string() const
 
 Obstacle Obstacle::fromString(std::string identifier)
 {
-	auto rawId = VLC->modh->identifiers.getIdentifier("core", "obstacle", identifier);
+	auto rawId = VLC->modh->identifiers.getIdentifier(CModHandler::scopeBuiltin(), "obstacle", identifier);
 
 	if(rawId)
 		return Obstacle(rawId.get());

--- a/lib/IHandlerBase.cpp
+++ b/lib/IHandlerBase.cpp
@@ -14,6 +14,10 @@
 
 VCMI_LIB_NAMESPACE_BEGIN
 
+std::string IHandlerBase::getScopeBuiltin() const
+{
+	return CModHandler::scopeBuiltin();
+}
 
 void IHandlerBase::registerObject(std::string scope, std::string type_name, std::string name, si32 index)
 {

--- a/lib/IHandlerBase.h
+++ b/lib/IHandlerBase.h
@@ -21,6 +21,8 @@ class Entity;
 class DLL_LINKAGE IHandlerBase
 {
 protected:
+	std::string getScopeBuiltin() const;
+
 	/// Calls modhandler. Mostly needed to avoid large number of includes in headers
 	void registerObject(std::string scope, std::string type_name, std::string name, si32 index);
 	std::string normalizeIdentifier(const std::string & scope, const std::string & remoteScope, const std::string & identifier) const;
@@ -92,7 +94,7 @@ public:
 
 	void loadObject(std::string scope, std::string name, const JsonNode & data) override
 	{
-		auto object = loadFromJson(scope, data, normalizeIdentifier(scope, "core", name), objects.size());
+		auto object = loadFromJson(scope, data, normalizeIdentifier(scope, getScopeBuiltin(), name), objects.size());
 
 		objects.push_back(object);
 
@@ -102,7 +104,7 @@ public:
 
 	void loadObject(std::string scope, std::string name, const JsonNode & data, size_t index) override
 	{
-		auto object = loadFromJson(scope, data, normalizeIdentifier(scope, "core", name), index);
+		auto object = loadFromJson(scope, data, normalizeIdentifier(scope, getScopeBuiltin(), name), index);
 
 		assert(objects[index] == nullptr); // ensure that this id was not loaded before
 		objects[index] = object;

--- a/lib/JsonDetail.cpp
+++ b/lib/JsonDetail.cpp
@@ -999,7 +999,7 @@ namespace
 		bool testFilePresence(std::string scope, ResourceID resource)
 		{
 			std::set<std::string> allowedScopes;
-			if(scope != "core" && !scope.empty()) // all real mods may have dependencies
+			if(scope != CModHandler::scopeBuiltin() && !scope.empty()) // all real mods may have dependencies
 			{
 				//NOTE: recursive dependencies are not allowed at the moment - update code if this changes
 				bool found = true;
@@ -1008,7 +1008,7 @@ namespace
 				if(!found)
 					return false;
 
-				allowedScopes.insert("core"); // all mods can use H3 files
+				allowedScopes.insert(CModHandler::scopeBuiltin()); // all mods can use H3 files
 			}
 			allowedScopes.insert(scope); // mods can use their own files
 

--- a/lib/ScriptHandler.cpp
+++ b/lib/ScriptHandler.cpp
@@ -242,7 +242,7 @@ ScriptPtr ScriptHandler::loadFromJson(vstd::CLoggerBase * logger, const std::str
 
 void ScriptHandler::loadObject(std::string scope, std::string name, const JsonNode & data)
 {
-	auto object = loadFromJson(logMod, scope, data, normalizeIdentifier(scope, "core", name));
+	auto object = loadFromJson(logMod, scope, data, normalizeIdentifier(scope, CModHandler::scopeBuiltin(), name));
 	objects[object->identifier] = object;
 }
 

--- a/lib/Terrain.cpp
+++ b/lib/Terrain.cpp
@@ -22,7 +22,7 @@ VCMI_LIB_NAMESPACE_BEGIN
 TerrainTypeHandler::TerrainTypeHandler()
 {
 	auto allConfigs = VLC->modh->getActiveMods();
-	allConfigs.insert(allConfigs.begin(), "core");
+	allConfigs.insert(allConfigs.begin(), CModHandler::scopeBuiltin());
 
 	initRivers(allConfigs);
 	recreateRiverMaps();

--- a/lib/filesystem/Filesystem.cpp
+++ b/lib/filesystem/Filesystem.cpp
@@ -20,6 +20,7 @@
 #include "../GameConstants.h"
 #include "../VCMIDirs.h"
 #include "../CStopWatch.h"
+#include "../CModHandler.h"
 
 VCMI_LIB_NAMESPACE_BEGIN
 
@@ -207,7 +208,7 @@ void CResourceHandler::load(const std::string &fsConfigURI, bool extractArchives
 
 	const JsonNode fsConfig((char*)fsConfigData.first.get(), fsConfigData.second);
 
-	addFilesystem("data", "core", createFileSystem("", fsConfig["filesystem"], extractArchives));
+	addFilesystem("data", CModHandler::scopeBuiltin(), createFileSystem("", fsConfig["filesystem"], extractArchives));
 }
 
 void CResourceHandler::addFilesystem(const std::string & parent, const std::string & identifier, ISimpleResourceLoader * loader)

--- a/lib/mapObjects/CGHeroInstance.cpp
+++ b/lib/mapObjects/CGHeroInstance.cpp
@@ -1413,7 +1413,7 @@ void CGHeroInstance::setHeroTypeName(const std::string & identifier)
 {
 	if(ID == Obj::HERO || ID == Obj::PRISON)
 	{
-		auto rawId = VLC->modh->identifiers.getIdentifier("core", "hero", identifier);
+		auto rawId = VLC->modh->identifiers.getIdentifier(CModHandler::scopeBuiltin(), "hero", identifier);
 
 		if(rawId)
 			subID = rawId.get();

--- a/lib/mapObjects/CGTownInstance.cpp
+++ b/lib/mapObjects/CGTownInstance.cpp
@@ -1466,7 +1466,7 @@ void CGTownInstance::serializeJsonOptions(JsonSerializeFormat & handler)
 	{
 		auto decodeBuilding = [this](const std::string & identifier) -> si32
 		{
-			auto rawId = VLC->modh->identifiers.getIdentifier("core", getTown()->getBuildingScope(), identifier);
+			auto rawId = VLC->modh->identifiers.getIdentifier(CModHandler::scopeBuiltin(), getTown()->getBuildingScope(), identifier);
 
 			if(rawId)
 				return rawId.get();

--- a/lib/mapObjects/CObjectClassesHandler.cpp
+++ b/lib/mapObjects/CObjectClassesHandler.cpp
@@ -170,7 +170,7 @@ void CObjectClassesHandler::loadObjectEntry(const std::string & identifier, cons
 		logGlobal->error("Handler with name %s was not found!", obj->handlerName);
 		return;
 	}
-	const auto convertedId = VLC->modh->normalizeIdentifier(entry.meta, "core", identifier);
+	const auto convertedId = VLC->modh->normalizeIdentifier(entry.meta, CModHandler::scopeBuiltin(), identifier);
 	const auto & entryIndex = entry["index"];
 	bool useSelectNextID = !isSubobject || entryIndex.isNull();
 
@@ -259,14 +259,14 @@ CObjectClassesHandler::ObjectContainter * CObjectClassesHandler::loadFromJson(co
 
 void CObjectClassesHandler::loadObject(std::string scope, std::string name, const JsonNode & data)
 {
-	auto object = loadFromJson(scope, data, normalizeIdentifier(scope, "core", name));
+	auto object = loadFromJson(scope, data, normalizeIdentifier(scope, CModHandler::scopeBuiltin(), name));
 	objects[object->id] = object;
 	VLC->modh->identifiers.registerObject(scope, "object", name, object->id);
 }
 
 void CObjectClassesHandler::loadObject(std::string scope, std::string name, const JsonNode & data, size_t index)
 {
-	auto object = loadFromJson(scope, data, normalizeIdentifier(scope, "core", name));
+	auto object = loadFromJson(scope, data, normalizeIdentifier(scope, CModHandler::scopeBuiltin(), name));
 	assert(objects[(si32)index] == nullptr); // ensure that this id was not loaded before
 	objects[(si32)index] = object;
 	VLC->modh->identifiers.registerObject(scope, "object", name, object->id);

--- a/lib/mapObjects/CQuest.cpp
+++ b/lib/mapObjects/CQuest.cpp
@@ -1028,7 +1028,7 @@ void CGSeerHut::serializeJsonOptions(JsonSerializeFormat & handler)
 
 		if(doRequest)
 		{
-			auto rawId = VLC->modh->identifiers.getIdentifier("core", fullIdentifier, false);
+			auto rawId = VLC->modh->identifiers.getIdentifier(CModHandler::scopeBuiltin(), fullIdentifier, false);
 
 			if(rawId)
 			{

--- a/lib/mapObjects/MiscObjects.cpp
+++ b/lib/mapObjects/MiscObjects.cpp
@@ -1804,7 +1804,7 @@ void CGScholar::serializeJsonOptions(JsonSerializeFormat & handler)
 		bonusType = RANDOM;
 		if(!json["rewardPrimSkill"].String().empty())
 		{
-			auto raw = VLC->modh->identifiers.getIdentifier("core", "primSkill", json["rewardPrimSkill"].String());
+			auto raw = VLC->modh->identifiers.getIdentifier(CModHandler::scopeBuiltin(), "primSkill", json["rewardPrimSkill"].String());
 			if(raw)
 			{
 				bonusType = PRIM_SKILL;
@@ -1813,7 +1813,7 @@ void CGScholar::serializeJsonOptions(JsonSerializeFormat & handler)
 		}
 		else if(!json["rewardSkill"].String().empty())
 		{
-			auto raw = VLC->modh->identifiers.getIdentifier("core", "skill", json["rewardSkill"].String());
+			auto raw = VLC->modh->identifiers.getIdentifier(CModHandler::scopeBuiltin(), "skill", json["rewardSkill"].String());
 			if(raw)
 			{
 				bonusType = SECONDARY_SKILL;
@@ -1822,7 +1822,7 @@ void CGScholar::serializeJsonOptions(JsonSerializeFormat & handler)
 		}
 		else if(!json["rewardSpell"].String().empty())
 		{
-			auto raw = VLC->modh->identifiers.getIdentifier("core", "spell", json["rewardSpell"].String());
+			auto raw = VLC->modh->identifiers.getIdentifier(CModHandler::scopeBuiltin(), "spell", json["rewardSpell"].String());
 			if(raw)
 			{
 				bonusType = SPELL;

--- a/lib/mapping/MapFormatJson.cpp
+++ b/lib/mapping/MapFormatJson.cpp
@@ -215,7 +215,7 @@ namespace TriggeredEventsDetail
 
 					event.metaType = decodeMetaclass(metaTypeName);
 
-					auto type = VLC->modh->identifiers.getIdentifier("core", fullIdentifier, false);
+					auto type = VLC->modh->identifiers.getIdentifier(CModHandler::scopeBuiltin(), fullIdentifier, false);
 
 					if(type)
 						event.objectType = type.get();
@@ -1121,7 +1121,7 @@ void CMapLoaderJson::MapObjectLoader::construct()
 		return;
 	}
 
-	auto handler = VLC->objtypeh->getHandlerFor( "map", typeName, subtypeName);
+	auto handler = VLC->objtypeh->getHandlerFor( CModHandler::scopeMap(), typeName, subtypeName);
 
 	auto appearance = new ObjectTemplate;
 
@@ -1158,7 +1158,7 @@ void CMapLoaderJson::MapObjectLoader::configure()
 		if(art->ID == Obj::SPELL_SCROLL)
 		{
 			auto spellIdentifier = configuration["options"]["spell"].String();
-			auto rawId = VLC->modh->identifiers.getIdentifier("core", "spell", spellIdentifier);
+			auto rawId = VLC->modh->identifiers.getIdentifier(CModHandler::scopeBuiltin(), "spell", spellIdentifier);
 			if(rawId)
 				spellID = rawId.get();
 			else

--- a/lib/rmg/CRmgTemplateStorage.cpp
+++ b/lib/rmg/CRmgTemplateStorage.cpp
@@ -14,6 +14,7 @@
 #include "CRmgTemplate.h"
 
 #include "../serializer/JsonDeserializer.h"
+#include "../CModHandler.h"
 
 VCMI_LIB_NAMESPACE_BEGIN
 
@@ -30,7 +31,7 @@ void CRmgTemplateStorage::loadObject(std::string scope, std::string name, const 
 	try
 	{
 		JsonDeserializer handler(nullptr, data);
-		auto fullKey = normalizeIdentifier(scope, "core", name); //actually it's not used
+		auto fullKey = normalizeIdentifier(scope, CModHandler::scopeBuiltin(), name); //actually it's not used
 		templates[fullKey].setId(name);
 		templates[fullKey].serializeJson(handler);
 		templates[fullKey].validate();

--- a/scripting/lua/LuaScriptingContext.cpp
+++ b/scripting/lua/LuaScriptingContext.cpp
@@ -511,14 +511,14 @@ int LuaContext::loadModule()
 
 		registar->pushMetatable(L);
 	}
-	else if(scope == "core")
+	else if(scope == CModHandler::scopeBuiltin())
 	{
 
 	//	boost::algorithm::replace_all(modulePath, boost::is_any_of("\\/ "), "");
 
 		boost::algorithm::replace_all(modulePath, ".", "/");
 
-		auto loader = CResourceHandler::get("core");
+		auto loader = CResourceHandler::get(CModHandler::scopeBuiltin());
 
 		modulePath = "scripts/lib/" + modulePath;
 

--- a/test/scripting/ScriptFixture.cpp
+++ b/test/scripting/ScriptFixture.cpp
@@ -29,7 +29,7 @@ void ScriptFixture::loadScriptFromFile(const std::string & path)
 
 void ScriptFixture::loadScript(const JsonNode & scriptConfig)
 {
-	subject = VLC->scriptHandler->loadFromJson(&loggerMock, "core", scriptConfig, "test");
+	subject = VLC->scriptHandler->loadFromJson(&loggerMock, CModHandler::scopeBuiltin(), scriptConfig, "test");
 
 	GTEST_ASSERT_NE(subject, nullptr);
 

--- a/test/spells/effects/TimedTest.cpp
+++ b/test/spells/effects/TimedTest.cpp
@@ -79,7 +79,7 @@ TEST_P(TimedApplyTest, ChangesBonuses)
 	options["cumulative"].Bool() = cumulative;
 	options["bonus"]["test1"] = testBonus1.toJsonNode();
 	options["bonus"]["test2"] = testBonus2.toJsonNode();
-	options.setMeta("core");
+	options.setMeta(CModHandler::scopeBuiltin());
 	setupEffect(options);
 
 	const uint32_t unitId = 42;


### PR DESCRIPTION
Fixes #1211 - json deserializer would incorrectly resolve identifiers using "core" mod that should only have access to H3 data, not mods