### PR TITLE
Do not show destroyed towers in battle results window

### DIFF
--- a/client/battle/CBattleInterfaceClasses.cpp
+++ b/client/battle/CBattleInterfaceClasses.cpp
@@ -478,7 +478,11 @@ CBattleResultWindow::CBattleResultWindow(const BattleResult & br, CPlayerInterfa
 			int yPos = 344 + step * 97;
 			for(auto & elem : br.casualties[step])
 			{
-				icons.push_back(std::make_shared<CAnimImage>("CPRSMALL", CGI->creatures()->getByIndex(elem.first)->getIconIndex(), 0, xPos, yPos));
+				auto creature = CGI->creatures()->getByIndex(elem.first);
+				if (creature->getId() == CreatureID::ARROW_TOWERS )
+					continue; // do not show destroyed towers in battle results
+
+				icons.push_back(std::make_shared<CAnimImage>("CPRSMALL", creature->getIconIndex(), 0, xPos, yPos));
 				std::ostringstream amount;
 				amount<<elem.second;
 				labels.push_back(std::make_shared<CLabel>(xPos + 16, yPos + 42, FONT_SMALL, CENTER, Colors::WHITE, amount.str()));


### PR DESCRIPTION
Fixes bug mentioned in #1199 (and probably closes #1199 since this is only remaining part to do)

There is no need to show towers in battle result - H3 does not show them and towers will respawn in next battle anyway