### PR TITLE
Fix SharedMemory declaration

### DIFF
--- a/client/CServerHandler.h
+++ b/client/CServerHandler.h
@@ -25,7 +25,6 @@ class CGameState;
 struct ClientPlayer;
 struct CPack;
 struct CPackForLobby;
-struct SharedMemory;
 
 template<typename T> class CApplier;
 

--- a/client/CServerHandler.h
+++ b/client/CServerHandler.h
@@ -25,12 +25,11 @@ class CGameState;
 struct ClientPlayer;
 struct CPack;
 struct CPackForLobby;
+struct SharedMemory;
 
 template<typename T> class CApplier;
 
 VCMI_LIB_NAMESPACE_END
-
-struct SharedMemory;
 
 class CClient;
 


### PR DESCRIPTION
Should be under VCMI_LIB_NAMESPACE_BEGIN as its definition. But this forward declaration is not used, so I removed it. Also my GCC 11 for MIPS fails to compile the project without this change.
Required for #1227. The error was introduced after latest changes in master.