### PR TITLE
[1.1] Fix compatibility check

### DIFF
--- a/launcher/modManager/cmodlist.cpp
+++ b/launcher/modManager/cmodlist.cpp
@@ -31,7 +31,7 @@ bool isCompatible(const QString & verMin, const QString & verMax)
 		if(ver.segmentCount() < maxSections)
 		{
 			auto segments = ver.segments();
-			for(int i = segments.size() - 1; i < maxSections; ++i)
+			for(int i = segments.size(); i < maxSections; ++i)
 				segments.append(0);
 			ver = QVersionNumber(segments);
 		}


### PR DESCRIPTION
QVersionNumber compares 1.1.0.0 versus 1.1.0 and concludes them incompatible