### PR TITLE
lib/CArtHandler.cpp: avoid return of already destroyed objects

### DIFF
--- a/lib/CArtHandler.cpp
+++ b/lib/CArtHandler.cpp
@@ -1547,17 +1547,16 @@ DLL_LINKAGE ArtifactPosition ArtifactUtils::getArtifactDstPosition(	const CArtif
 
 DLL_LINKAGE const std::vector<ArtifactPosition::EArtifactPosition> & ArtifactUtils::unmovableSlots()
 {
-	return
-	{
+	static const std::vector<ArtifactPosition::EArtifactPosition> slots = {
 		ArtifactPosition::SPELLBOOK,
 		ArtifactPosition::MACH4
 	};
+	return slots;
 }
 
 DLL_LINKAGE const std::vector<ArtifactPosition::EArtifactPosition> & ArtifactUtils::constituentWornSlots()
 {
-	return
-	{
+	static const std::vector<ArtifactPosition::EArtifactPosition> slots = {
 		ArtifactPosition::HEAD,
 		ArtifactPosition::SHOULDERS,
 		ArtifactPosition::NECK,
@@ -1573,6 +1572,7 @@ DLL_LINKAGE const std::vector<ArtifactPosition::EArtifactPosition> & ArtifactUti
 		ArtifactPosition::MISC4,
 		ArtifactPosition::MISC5,
 	};
+	return slots;
 }
 
 DLL_LINKAGE bool ArtifactUtils::isArtRemovable(const std::pair<ArtifactPosition, ArtSlotInfo> & slot)


### PR DESCRIPTION
`gcc-13` detects return of dangling objects as:

    lib/CArtHandler.cpp: In function 'const std::vector<ArtifactPosition::EArtifactPosition>& ArtifactUtils::unmovableSlots()':
    lib/CArtHandler.cpp:1554:9: warning: returning reference to temporary [-Wreturn-local-addr]
     1554 |         };
          |         ^
    lib/CArtHandler.cpp: In function 'const std::vector<ArtifactPosition::EArtifactPosition>& ArtifactUtils::constituentWornSlots()':
    lib/CArtHandler.cpp:1575:9: warning: returning reference to temporary [-Wreturn-local-addr]
     1575 |         };
          |         ^

The change converts local objects to constants and returns references to them to guarantee that they outlive local functions.