### PR TITLE
AI/Nullkiller/Goals/ExecuteHeroChain.cpp: catch polymorphic exception…

### DIFF
--- a/AI/Nullkiller/Goals/ExecuteHeroChain.cpp
+++ b/AI/Nullkiller/Goals/ExecuteHeroChain.cpp
@@ -127,7 +127,7 @@ void ExecuteHeroChain::accept(AIGateway * ai)
 							continue;
 						}
 					}
-					catch(cannotFulfillGoalException)
+					catch(cannotFulfillGoalException &)
 					{
 						if(!heroPtr.validAndSet())
 						{
@@ -173,7 +173,7 @@ void ExecuteHeroChain::accept(AIGateway * ai)
 			ai->nullkiller->lockHero(hero, HeroLockedReason::HERO_CHAIN);
 			blockedIndexes.insert(node.parentIndex);
 		}
-		catch(goalFulfilledException)
+		catch(goalFulfilledException &)
 		{
 			if(!heroPtr.validAndSet())
 			{


### PR DESCRIPTION
…s by reference

The suspicious code was detected by `gcc-13` as:

    AI/Nullkiller/Goals/ExecuteHeroChain.cpp: In member function 'virtual void NKAI::Goals::ExecuteHeroChain::accept(NKAI::AIGateway*)':
    AI/Nullkiller/Goals/ExecuteHeroChain.cpp:130:47: warning: catching polymorphic type 'class NKAI::cannotFulfillGoalException' by value [-Wcatch-value=]
      130 |                                         catch(cannotFulfillGoalException)
          |                                               ^~~~~~~~~~~~~~~~~~~~~~~~~~
    AI/Nullkiller/Goals/ExecuteHeroChain.cpp:176:23: warning: catching polymorphic type 'class NKAI::goalFulfilledException' by value [-Wcatch-value=]
      176 |                 catch(goalFulfilledException)
          |                       ^~~~~~~~~~~~~~~~~~~~~~

Similar to object passing by value and reference passing polymorphic exceptions by reference likely destroys them when copy-constructed to a base class. Let's catch them by reference.