### PR TITLE
Artifact assembly fix

### DIFF
--- a/client/gui/CCursorHandler.cpp
+++ b/client/gui/CCursorHandler.cpp
@@ -67,6 +67,8 @@ void CCursorHandler::initCursor()
 
 void CCursorHandler::changeGraphic(ECursor::ECursorTypes type, int index)
 {
+	assert(dndObject == nullptr);
+
 	if(type != this->type)
 	{
 		this->type = type;

--- a/client/widgets/CArtifactHolder.cpp
+++ b/client/widgets/CArtifactHolder.cpp
@@ -691,10 +691,8 @@ void CArtifactsOfHero::updateParentWindow()
 
 		if(!updateState)
 		{
-			cew->deactivate();
 			cew->updateWidgets();
 			cew->redraw();
-			cew->activate();
 		}
 	}
 }

--- a/client/widgets/CArtifactHolder.cpp
+++ b/client/widgets/CArtifactHolder.cpp
@@ -254,6 +254,22 @@ void CHeroArtPlace::clickRight(tribool down, bool previousState)
 	}
 }
 
+void CArtifactsOfHero::activate()
+{
+	if (commonInfo->src.AOH == this && commonInfo->src.art)
+		CCS->curh->dragAndDropCursor(make_unique<CAnimImage>("artifact", commonInfo->src.art->artType->getIconIndex()));
+
+	CIntObject::activate();
+}
+
+void CArtifactsOfHero::deactivate()
+{
+	if (commonInfo->src.AOH == this && commonInfo->src.art)
+		CCS->curh->dragAndDropCursor(nullptr);
+
+	CIntObject::deactivate();
+}
+
 /**
  * Selects artifact slot so that the containing artifact looks like it's picked up.
  */

--- a/client/widgets/CArtifactHolder.h
+++ b/client/widgets/CArtifactHolder.h
@@ -148,6 +148,9 @@ public:
 	void dispose(); //free resources not needed after closing windows and reset state
 	void scrollBackpack(int dir); //dir==-1 => to left; dir==1 => to right
 
+	void activate() override;
+	void deactivate() override;
+
 	void safeRedraw();
 	void markPossibleSlots(const CArtifactInstance* art);
 	void unmarkSlots(bool withRedraw = true); //unmarks slots in all visible AOHs

--- a/lib/CArtHandler.cpp
+++ b/lib/CArtHandler.cpp
@@ -861,8 +861,6 @@ void CArtifactInstance::removeFrom(ArtifactLocation al)
 	al.getHolderArtSet()->eraseArtSlot(al.slot);
 	if(!ArtifactUtils::isSlotBackpack(al.slot))
 		al.getHolderNode()->detachFrom(*this);
-
-	//TODO delete me?
 }
 
 bool CArtifactInstance::canBeDisassembled() const
@@ -1062,7 +1060,9 @@ void CCombinedArtifactInstance::createConstituents()
 
 void CCombinedArtifactInstance::addAsConstituent(CArtifactInstance *art, ArtifactPosition slot)
 {
-	assert(vstd::contains(*artType->constituents, art->artType.get()));
+	assert(vstd::contains_if(*artType->constituents, [=](const CArtifact * constituent){
+		return constituent->id == art->artType->id;
+	}));
 	assert(art->getParentNodes().size() == 1  &&  art->getParentNodes().front() == art->artType);
 	constituentsInfo.push_back(ConstituentInfo(art, slot));
 	attachTo(*art);
@@ -1354,11 +1354,16 @@ bool CArtifactSet::isPositionFree(ArtifactPosition pos, bool onlyLockCheck) cons
 ArtSlotInfo & CArtifactSet::retrieveNewArtSlot(ArtifactPosition slot)
 {
 	assert(!vstd::contains(artifactsWorn, slot));
-	ArtSlotInfo &ret = !ArtifactUtils::isSlotBackpack(slot)
-		? artifactsWorn[slot]
-		: *artifactsInBackpack.insert(artifactsInBackpack.begin() + (slot - GameConstants::BACKPACK_START), ArtSlotInfo());
 
-	return ret;
+	if (!ArtifactUtils::isSlotBackpack(slot))
+		return artifactsWorn[slot];
+
+	ArtSlotInfo newSlot;
+	size_t index  = slot - GameConstants::BACKPACK_START;
+	auto position = artifactsInBackpack.begin() + index;
+	auto inserted = artifactsInBackpack.insert(position, newSlot);
+
+	return *inserted;
 }
 
 void CArtifactSet::setNewArtSlot(ArtifactPosition slot, CArtifactInstance *art, bool locked)
@@ -1372,9 +1377,10 @@ void CArtifactSet::eraseArtSlot(ArtifactPosition slot)
 {
 	if(ArtifactUtils::isSlotBackpack(slot))
 	{
-		assert(artifactsInBackpack.begin() + slot < artifactsInBackpack.end());
-		slot = ArtifactPosition(slot - GameConstants::BACKPACK_START);
-		artifactsInBackpack.erase(artifactsInBackpack.begin() + slot);
+		auto backpackSlot = ArtifactPosition(slot - GameConstants::BACKPACK_START);
+
+		assert(artifactsInBackpack.begin() + backpackSlot < artifactsInBackpack.end());
+		artifactsInBackpack.erase(artifactsInBackpack.begin() + backpackSlot);
 	}
 	else
 	{


### PR DESCRIPTION
Fixes #840 - Correctly update drag-and-drop cursor if window with artifacts gets deactivated due to pop-up dialog
Fixes artefact-related assertion failures
Fixes Exchange Window not getting updated on assembly/deassembly of an artifact