### PR TITLE
[1.1] Mod validation fix

### DIFF
--- a/Mods/vcmi/config/vcmi/towerCreature.json
+++ b/Mods/vcmi/config/vcmi/towerCreature.json
@@ -1,0 +1,10 @@
+{
+	"core:arrowTower" :
+	{
+		"graphics" :
+		{
+			"iconSmall" : "vcmi/creatureIcons/towerSmall",
+			"iconLarge" : "vcmi/creatureIcons/towerLarge",
+		}
+	}
+}

--- a/Mods/vcmi/config/vcmi/towerFactions.json
+++ b/Mods/vcmi/config/vcmi/towerFactions.json
@@ -1,0 +1,101 @@
+{
+	"core:castle" :
+	{
+		"town" :
+		{
+			"siege" :
+			{
+				"towerIconSmall" : "vcmi/creatureIcons/towerSmall",
+				"towerIconLarge" : "vcmi/creatureIcons/towerLarge",
+			}
+		}
+	},
+	"core:rampart" :
+	{
+		"town" :
+		{
+			"siege" :
+			{
+				"towerIconSmall" : "vcmi/creatureIcons/towerSmall",
+				"towerIconLarge" : "vcmi/creatureIcons/towerLarge",
+			}
+		}
+	},
+	"core:tower" :
+	{
+		"town" :
+		{
+			"siege" :
+			{
+				"towerIconSmall" : "vcmi/creatureIcons/towerSmall",
+				"towerIconLarge" : "vcmi/creatureIcons/towerLarge",
+			}
+		}
+	},
+	"core:inferno" :
+	{
+		"town" :
+		{
+			"siege" :
+			{
+				"towerIconSmall" : "vcmi/creatureIcons/towerSmall",
+				"towerIconLarge" : "vcmi/creatureIcons/towerLarge",
+			}
+		}
+	},
+	"core:necropolis" :
+	{
+		"town" :
+		{
+			"siege" :
+			{
+				"towerIconSmall" : "vcmi/creatureIcons/towerSmall",
+				"towerIconLarge" : "vcmi/creatureIcons/towerLarge",
+			}
+		}
+	},
+	"core:dungeon" :
+	{
+		"town" :
+		{
+			"siege" :
+			{
+				"towerIconSmall" : "vcmi/creatureIcons/towerSmall",
+				"towerIconLarge" : "vcmi/creatureIcons/towerLarge",
+			}
+		}
+	},
+	"core:stronghold" :
+	{
+		"town" :
+		{
+			"siege" :
+			{
+				"towerIconSmall" : "vcmi/creatureIcons/towerSmall",
+				"towerIconLarge" : "vcmi/creatureIcons/towerLarge",
+			}
+		}
+	},
+	"core:fortress" :
+	{
+		"town" :
+		{
+			"siege" :
+			{
+				"towerIconSmall" : "vcmi/creatureIcons/towerSmall",
+				"towerIconLarge" : "vcmi/creatureIcons/towerLarge",
+			}
+		}
+	},
+	"core:conflux" :
+	{
+		"town" :
+		{
+			"siege" :
+			{
+				"towerIconSmall" : "vcmi/creatureIcons/towerSmall",
+				"towerIconLarge" : "vcmi/creatureIcons/towerLarge",
+			}
+		}
+	}
+}

--- a/Mods/vcmi/mod.json
+++ b/Mods/vcmi/mod.json
@@ -2,13 +2,20 @@
 	"name" : "VCMI essential files",
 	"description" : "Essential files required for VCMI to run correctly",
 
-	"version" : "1.0",
+	"version" : "1.1",
 	"author" : "VCMI Team",
 	"contact" : "http://forum.vcmi.eu/index.php",
 	"modType" : "Graphical",
+	
+	"factions" : [ "config/vcmi/towerFactions" ],
+	"creatures" : [ "config/vcmi/towerCreature" ],
 
 	"filesystem":
 	{
+		"CONFIG/" :
+		[
+			{"type" : "dir",  "path" : "/Config"}
+		],
 		"DATA/" :
 		[
 			{"type" : "dir",  "path" : "/Data"}

--- a/config/creatures/special.json
+++ b/config/creatures/special.json
@@ -123,8 +123,6 @@
 		},
 		"graphics" :
 		{
-			"iconSmall" : "vcmi/creatureIcons/towerSmall",
-			"iconLarge" : "vcmi/creatureIcons/towerLarge",
 			"animation": "CLCBOW.DEF" // needed to pass validation, never used
 		},
 		"sound": {}

--- a/config/factions/castle.json
+++ b/config/factions/castle.json
@@ -203,8 +203,6 @@
 			"siege" :
 			{
 				"shooter" : "archer",
-				"towerIconSmall" : "vcmi/creatureIcons/towerSmall",
-				"towerIconLarge" : "vcmi/creatureIcons/towerLarge",
 				"imagePrefix" : "SGCS",
 				"gate" :
 				{

--- a/config/factions/conflux.json
+++ b/config/factions/conflux.json
@@ -210,8 +210,6 @@
 			"siege" :
 			{
 				"shooter" : "stormElemental",
-				"towerIconSmall" : "vcmi/creatureIcons/towerSmall",
-				"towerIconLarge" : "vcmi/creatureIcons/towerLarge",
 				"imagePrefix" : "SGEL",
 				"gate" :
 				{

--- a/config/factions/dungeon.json
+++ b/config/factions/dungeon.json
@@ -204,8 +204,6 @@
 			"siege" :
 			{
 				"shooter" : "medusa",
-				"towerIconSmall" : "vcmi/creatureIcons/towerSmall",
-				"towerIconLarge" : "vcmi/creatureIcons/towerLarge",
 				"imagePrefix" : "SGDN",
 				"gate" :
 				{

--- a/config/factions/fortress.json
+++ b/config/factions/fortress.json
@@ -209,8 +209,6 @@
 			"siege" :
 			{
 				"shooter" : "lizardman",
-				"towerIconSmall" : "vcmi/creatureIcons/towerSmall",
-				"towerIconLarge" : "vcmi/creatureIcons/towerLarge",
 				"imagePrefix" : "SGFR",
 				"gate" :
 				{

--- a/config/factions/inferno.json
+++ b/config/factions/inferno.json
@@ -204,8 +204,6 @@
 			"siege" :
 			{
 				"shooter" : "gog",
-				"towerIconSmall" : "vcmi/creatureIcons/towerSmall",
-				"towerIconLarge" : "vcmi/creatureIcons/towerLarge",
 				"imagePrefix" : "SGIN",
 				"gate" :
 				{

--- a/config/factions/necropolis.json
+++ b/config/factions/necropolis.json
@@ -214,8 +214,6 @@
 			"siege" :
 			{
 				"shooter" : "lich",
-				"towerIconSmall" : "vcmi/creatureIcons/towerSmall",
-				"towerIconLarge" : "vcmi/creatureIcons/towerLarge",
 				"imagePrefix" : "SGNC",
 				"gate" :
 				{

--- a/config/factions/neutral.json
+++ b/config/factions/neutral.json
@@ -2,7 +2,6 @@
 	"neutral" :
 	{
 		"name" : "Neutral",
-		"index" : 9,
 		"alignment" : "neutral",
 		"creatureBackground" :
 		{

--- a/config/factions/neutral.json
+++ b/config/factions/neutral.json
@@ -2,6 +2,7 @@
 	"neutral" :
 	{
 		"name" : "Neutral",
+		"index" : 9,
 		"alignment" : "neutral",
 		"creatureBackground" :
 		{

--- a/config/factions/rampart.json
+++ b/config/factions/rampart.json
@@ -211,8 +211,6 @@
 			"siege" :
 			{
 				"shooter" : "woodElf",
-				"towerIconSmall" : "vcmi/creatureIcons/towerSmall",
-				"towerIconLarge" : "vcmi/creatureIcons/towerLarge",
 				"imagePrefix" : "SGRM",
 				"gate" :
 				{

--- a/config/factions/stronghold.json
+++ b/config/factions/stronghold.json
@@ -203,8 +203,6 @@
 			{
 				"shooter" : "orc",
 				"imagePrefix" : "SGST",
-				"towerIconSmall" : "vcmi/creatureIcons/towerSmall",
-				"towerIconLarge" : "vcmi/creatureIcons/towerLarge",
 				"gate" :
 				{
 					"arch" : { "x" : 478, "y" : 235 },

--- a/config/factions/tower.json
+++ b/config/factions/tower.json
@@ -202,8 +202,6 @@
 			"siege" :
 			{
 				"shooter" : "mage",
-				"towerIconSmall" : "vcmi/creatureIcons/towerSmall",
-				"towerIconLarge" : "vcmi/creatureIcons/towerLarge",
 				"imagePrefix" : "SGTW",
 				"gate" :
 				{

--- a/config/schemas/mod.json
+++ b/config/schemas/mod.json
@@ -56,6 +56,13 @@
 			"description": "List of mods that can't be enabled in the same time as this one",
 			"items": { "type":"string" }
 		},
+		"compatibility" : {
+			"type":"object",
+			"description": "List of supported version of vcmi engine",
+			"additionalProperties" : {
+				"type" : "string"
+			}
+		},
 
 		"keepDisabled" : {
 			"type":"boolean",
@@ -116,6 +123,12 @@
 		"battlefields":{
 			"type":"array",
 			"description": "List of configuration files for battlefields",
+			"items": { "type":"string", "format" : "textFile" }
+
+		},
+		"obstacles":{
+			"type":"array",
+			"description": "List of configuration files for obstacles",
 			"items": { "type":"string", "format" : "textFile" }
 
 		},

--- a/config/schemas/mod.json
+++ b/config/schemas/mod.json
@@ -58,9 +58,19 @@
 		},
 		"compatibility" : {
 			"type":"object",
-			"description": "List of supported version of vcmi engine",
-			"additionalProperties" : {
-				"type" : "string"
+			"description": "Supported versions of vcmi engine",
+			"additionalProperties" : false,
+			"properties" : {
+				"min" : {
+					"type" : "string",
+					"description" : "minimal compatible vcmi engine version in a format major.minor.patch. When specified, earlier versions won't be supported"
+					//"pattern" : "^\\d+\\.\\d+\\.\\d+$" // Not implemented in schema support
+				},
+				"max" : {
+					"type" : "string",
+					"description" : "maximum compatible vcmi engine version in a format major.minor.patch. When specified, later versions won't be supported"
+					//"pattern" : "^\\d+\\.\\d+\\.\\d+$" // Not implemented in schema support
+				}
 			}
 		},
 

--- a/lib/CModHandler.cpp
+++ b/lib/CModHandler.cpp
@@ -404,6 +404,9 @@ bool ContentTypeHandler::loadMod(std::string modName, bool validate)
 
 		if (vstd::contains(data.Struct(), "index") && !data["index"].isNull())
 		{
+			if (modName != "core")
+				logMod->warn("Mod %s is attempting to load original data! This should be reserved for built-in mod.", modName);
+
 			// try to add H3 object data
 			size_t index = static_cast<size_t>(data["index"].Float());
 
@@ -416,7 +419,7 @@ bool ContentTypeHandler::loadMod(std::string modName, bool validate)
 			}
 			else
 			{
-				logMod->warn("no original data in loadMod(%s) at index %d", name, index);
+				logMod->trace("no original data in loadMod(%s) at index %d", name, index);
 			}
 			performValidate(data, name);
 			handler->loadObject(modName, name, data, index);

--- a/lib/mapObjects/ObjectTemplate.cpp
+++ b/lib/mapObjects/ObjectTemplate.cpp
@@ -293,7 +293,7 @@ void ObjectTemplate::readJson(const JsonNode &node, const bool withTerrain)
 			}
 			catch (const std::out_of_range & )
 			{
-				logGlobal->warn("Failed to find terrain %s for object %s", entry.String(), animationFile);
+				logGlobal->warn("Failed to find terrain '%s' for object '%s'", entry.String(), animationFile);
 			}
 		}
 	}

--- a/lib/mapObjects/ObjectTemplate.cpp
+++ b/lib/mapObjects/ObjectTemplate.cpp
@@ -287,7 +287,15 @@ void ObjectTemplate::readJson(const JsonNode &node, const bool withTerrain)
 	if(withTerrain && !node["allowedTerrains"].isNull())
 	{
 		for(auto& entry : node["allowedTerrains"].Vector())
-			allowedTerrains.insert(VLC->terrainTypeHandler->getInfoByName(entry.String())->id);
+		{
+			try {
+				allowedTerrains.insert(VLC->terrainTypeHandler->getInfoByName(entry.String())->id);
+			}
+			catch (const std::out_of_range & )
+			{
+				logGlobal->warn("Failed to find terrain %s for object %s", entry.String(), animationFile);
+			}
+		}
 	}
 	else
 	{
@@ -300,7 +308,7 @@ void ObjectTemplate::readJson(const JsonNode &node, const bool withTerrain)
 	}
 
 	if(withTerrain && allowedTerrains.empty())
-		logGlobal->warn("Loaded template without allowed terrains!");
+		logGlobal->warn("Loaded template %s without allowed terrains!", animationFile);
 
 	auto charToTile = [&](const char & ch) -> ui8
 	{


### PR DESCRIPTION
Fixes for validation errors on startup:

- Added "obstacles" section in mod.json schema
- Added "compatibility" section in mod.json schema
- Added human-readable error reporting for access to invalid terrain in mods
- Moved tower shooter definitions to "vcmi" mods - required for file presence validation checks to pass since tower shooter
icons reside in vcmi mod