### PR TITLE
Workaround for a potential deadlock in MusicHandler

### DIFF
--- a/client/CMusicHandler.cpp
+++ b/client/CMusicHandler.cpp
@@ -495,15 +495,15 @@ void CMusicHandler::musicFinishedCallback()
 	// 1) SDL thread to call this method on end of playback
 	// 2) VCMI code to call queueNext() method to queue new file
 	// this leads to:
-	// 1) SDL thread waiting to aquire music lock in this method (while keeping internal SDL mutex locked)
-	// 2) VCMI thread waiting to aquire internal SDL mutex (while keeping music mutex locked)
+	// 1) SDL thread waiting to acquire music lock in this method (while keeping internal SDL mutex locked)
+	// 2) VCMI thread waiting to acquire internal SDL mutex (while keeping music mutex locked)
 	// Because of that (and lack of clear way to fix that)
 	// We will try to acquire lock here and if failed - do nothing
 	// This may break music playback till next song is enqued but won't deadlock the game
 
 	if (!mutex.try_lock())
 	{
-		logGlobal->error("Failed to aquire mutex! Unable to restart music!");
+		logGlobal->error("Failed to acquire mutex! Unable to restart music!");
 		return;
 	}
 

--- a/client/CMusicHandler.cpp
+++ b/client/CMusicHandler.cpp
@@ -409,6 +409,8 @@ void CMusicHandler::release()
 
 void CMusicHandler::playMusic(const std::string & musicURI, bool loop, bool fromStart)
 {
+	boost::mutex::scoped_lock guard(mutex);
+
 	if (current && current->isPlaying() && current->isTrack(musicURI))
 		return;
 
@@ -422,6 +424,8 @@ void CMusicHandler::playMusicFromSet(const std::string & musicSet, const std::st
 
 void CMusicHandler::playMusicFromSet(const std::string & whichSet, bool loop, bool fromStart)
 {
+	boost::mutex::scoped_lock guard(mutex);
+
 	auto selectedSet = musicsSet.find(whichSet);
 	if (selectedSet == musicsSet.end())
 	{
@@ -440,8 +444,6 @@ void CMusicHandler::queueNext(std::unique_ptr<MusicEntry> queued)
 {
 	if (!initialized)
 		return;
-
-	boost::mutex::scoped_lock guard(mutex);
 
 	next = std::move(queued);
 
@@ -487,13 +489,32 @@ void CMusicHandler::setVolume(ui32 percent)
 
 void CMusicHandler::musicFinishedCallback()
 {
-	boost::mutex::scoped_lock guard(mutex);
+	// boost::mutex::scoped_lock guard(mutex);
+	// FIXME: WORKAROUND FOR A POTENTIAL DEADLOCK
+	// It is possible for:
+	// 1) SDL thread to call this method on end of playback
+	// 2) VCMI code to call queueNext() method to queue new file
+	// this leads to:
+	// 1) SDL thread waiting to aquire music lock in this method (while keeping internal SDL mutex locked)
+	// 2) VCMI thread waiting to aquire internal SDL mutex (while keeping music mutex locked)
+	// Because of that (and lack of clear way to fix that)
+	// We will try to acquire lock here and if failed - do nothing
+	// This may break music playback till next song is enqued but won't deadlock the game
+
+	if (!mutex.try_lock())
+	{
+		logGlobal->error("Failed to aquire mutex! Unable to restart music!");
+		return;
+	}
 
 	if (current.get() != nullptr)
 	{
 		// if music is looped, play it again
 		if (current->play())
+		{
+			mutex.unlock();
 			return;
+		}
 		else
 			current.reset();
 	}
@@ -503,6 +524,7 @@ void CMusicHandler::musicFinishedCallback()
 		current.reset(next.release());
 		current->play();
 	}
+	mutex.unlock();
 }
 
 MusicEntry::MusicEntry(CMusicHandler *owner, std::string setName, std::string musicURI, bool looped, bool fromStart):
@@ -597,7 +619,7 @@ bool MusicEntry::play()
 
 bool MusicEntry::stop(int fade_ms)
 {
-	if (Mix_PlayingMusic())
+	if (playing)
 	{
 		playing = false;
 		loop = 0;


### PR DESCRIPTION
Fixes #1310 
See large comment in source code for description.

Unfortunately I was unable to find any nice solution without making major changes.
If somebody can find one - feel free to tell me.

Still, potentially not looping music is better than full deadlock of the game so submitting it as a workaround.