### PR TITLE
Translations support - base functionality for main game texts

### DIFF
--- a/AI/Nullkiller/Engine/FuzzyEngines.cpp
+++ b/AI/Nullkiller/Engine/FuzzyEngines.cpp
@@ -31,7 +31,7 @@ engineBase::engineBase()
 void engineBase::configure()
 {
 	engine.configure("Minimum", "Maximum", "Minimum", "AlgebraicSum", "Centroid", "Proportional");
-	logAi->info(engine.toString());
+	logAi->trace(engine.toString());
 }
 
 void engineBase::addRule(const std::string & txt)

--- a/AI/VCAI/FuzzyEngines.cpp
+++ b/AI/VCAI/FuzzyEngines.cpp
@@ -30,7 +30,7 @@ engineBase::engineBase()
 void engineBase::configure()
 {
 	engine.configure("Minimum", "Maximum", "Minimum", "AlgebraicSum", "Centroid", "Proportional");
-	logAi->info(engine.toString());
+	logAi->trace(engine.toString());
 }
 
 void engineBase::addRule(const std::string & txt)

--- a/client/CMT.cpp
+++ b/client/CMT.cpp
@@ -664,36 +664,7 @@ void processCommand(const std::string &message)
 //	}
 	else if(message=="convert txt")
 	{
-		std::cout << "Command accepted.\t";
-
-		const bfs::path outPath =
-			VCMIDirs::get().userExtractedPath();
-
-		bfs::create_directories(outPath);
-
-		auto extractVector = [=](const std::vector<std::string> & source, const std::string & name)
-		{
-			JsonNode data(JsonNode::JsonType::DATA_VECTOR);
-			size_t index = 0;
-			for(auto & line : source)
-			{
-				JsonNode lineNode(JsonNode::JsonType::DATA_STRUCT);
-				lineNode["text"].String() = line;
-				lineNode["index"].Integer() = index++;
-				data.Vector().push_back(lineNode);
-			}
-
-			const bfs::path filePath = outPath / (name + ".json");
-			bfs::ofstream file(filePath);
-			file << data.toJson();
-		};
-
-		//extractVector(VLC->generaltexth->allTexts, "generalTexts");
-		//extractVector(VLC->generaltexth->jktexts, "jkTexts");
-		//extractVector(VLC->generaltexth->arraytxt, "arrayTexts");
-
-		std::cout << "\rExtracting done :)\n";
-		std::cout << " Extracted files can be found in " << outPath << " directory\n";
+		VLC->generaltexth->dumpAllTexts();
 	}
 	else if(message=="get config")
 	{

--- a/client/CMT.cpp
+++ b/client/CMT.cpp
@@ -688,9 +688,9 @@ void processCommand(const std::string &message)
 			file << data.toJson();
 		};
 
-		extractVector(VLC->generaltexth->allTexts, "generalTexts");
-		extractVector(VLC->generaltexth->jktexts, "jkTexts");
-		extractVector(VLC->generaltexth->arraytxt, "arrayTexts");
+		//extractVector(VLC->generaltexth->allTexts, "generalTexts");
+		//extractVector(VLC->generaltexth->jktexts, "jkTexts");
+		//extractVector(VLC->generaltexth->arraytxt, "arrayTexts");
 
 		std::cout << "\rExtracting done :)\n";
 		std::cout << " Extracted files can be found in " << outPath << " directory\n";

--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -1603,7 +1603,7 @@ void CPlayerInterface::playerBlocked(int reason, bool start)
 			GH.curInt = this;
 			adventureInt->selection = nullptr;
 			adventureInt->setPlayer(playerID);
-			std::string msg = CGI->generaltexth->localizedTexts["adventureMap"]["playerAttacked"].String();
+			std::string msg = CGI->generaltexth->translate("vcmi.adventureMap.playerAttacked");
 			boost::replace_first(msg, "%s", cb->getStartInfo()->playerInfos.find(playerID)->second.name);
 			std::vector<std::shared_ptr<CComponent>> cmp;
 			cmp.push_back(std::make_shared<CComponent>(CComponent::flag, playerID.getNum(), 0));

--- a/client/CServerHandler.cpp
+++ b/client/CServerHandler.cpp
@@ -176,7 +176,7 @@ void CServerHandler::startLocalServerAndConnect()
 
 	th->update();
 	
-	auto errorMsg = CGI->generaltexth->localizedTexts["server"]["errors"]["existingProcess"].String();
+	auto errorMsg = CGI->generaltexth->translate("vcmi.server.errors.existingProcess");
 	try
 	{
 		CConnection testConnection(localhostAddress, getDefaultPort(), NAME, uuid);
@@ -718,7 +718,7 @@ void CServerHandler::restoreLastSession()
 		saveSession->Bool() = false;
 	};
 	
-	CInfoWindow::showYesNoDialog(VLC->generaltexth->localizedTexts["server"]["confirmReconnect"].String(), {}, loadSession, cleanUpSession);
+	CInfoWindow::showYesNoDialog(VLC->generaltexth->translate("vcmi.server.confirmReconnect"), {}, loadSession, cleanUpSession);
 }
 
 void CServerHandler::debugStartTest(std::string filename, bool save)

--- a/client/gui/InterfaceObjectConfigurable.cpp
+++ b/client/gui/InterfaceObjectConfigurable.cpp
@@ -92,19 +92,10 @@ std::string InterfaceObjectConfigurable::readText(const JsonNode & config) const
 	
 	const std::string delimiter = "/";
 	std::string s = config.String();
+	boost::replace_all(s, "/", "." );
+
 	logGlobal->debug("Reading text from translations by key: %s", s);
-	JsonNode translated = CGI->generaltexth->localizedTexts;
-	for(size_t p = s.find(delimiter); p != std::string::npos; p = s.find(delimiter))
-	{
-		translated = translated[s.substr(0, p)];
-		s.erase(0, p + delimiter.length());
-	}
-	if(s == config.String())
-	{
-		logGlobal->warn("Reading non-translated text: %s", s);
-		return s;
-	}
-	return translated[s].String();
+	return CGI->generaltexth->translate(s);
 }
 
 Point InterfaceObjectConfigurable::readPosition(const JsonNode & config) const

--- a/client/gui/InterfaceObjectConfigurable.cpp
+++ b/client/gui/InterfaceObjectConfigurable.cpp
@@ -84,16 +84,7 @@ std::string InterfaceObjectConfigurable::readText(const JsonNode & config) const
 	if(config.isNull())
 		return "";
 	
-	if(config.isNumber())
-	{
-		logGlobal->debug("Reading text from generaltext handler id:%d", config.Integer());
-		return CGI->generaltexth->allTexts[config.Integer()];
-	}
-	
-	const std::string delimiter = "/";
 	std::string s = config.String();
-	boost::replace_all(s, "/", "." );
-
 	logGlobal->debug("Reading text from translations by key: %s", s);
 	return CGI->generaltexth->translate(s);
 }
@@ -180,12 +171,6 @@ std::pair<std::string, std::string> InterfaceObjectConfigurable::readHintText(co
 	std::pair<std::string, std::string> result;
 	if(!config.isNull())
 	{
-		if(config.isNumber())
-		{
-			logGlobal->debug("Reading hint text (zelp) from generaltext handler id:%d", config.Integer());
-			return CGI->generaltexth->zelp[config.Integer()];
-		}
-		
 		if(config.getType() == JsonNode::JsonType::DATA_STRUCT)
 		{
 			result.first = readText(config["hover"]);
@@ -194,8 +179,9 @@ std::pair<std::string, std::string> InterfaceObjectConfigurable::readHintText(co
 		}
 		if(config.getType() == JsonNode::JsonType::DATA_STRING)
 		{
-			logGlobal->debug("Reading non-translated hint: %s", config.String());
-			result.first = result.second = config.String();
+			logGlobal->debug("Reading hint text (help) from generaltext handler:%sd", config.String());
+			result.first  = CGI->generaltexth->translate( config.String() + ".hover");
+			result.second = CGI->generaltexth->translate( config.String() + ".help");
 		}
 	}
 	return result;
@@ -251,8 +237,8 @@ std::shared_ptr<CToggleButton> InterfaceObjectConfigurable::buildToggleButton(co
 	logGlobal->debug("Building widget CToggleButton");
 	auto position = readPosition(config["position"]);
 	auto image = config["image"].String();
-	auto zelp = readHintText(config["zelp"]);
-	auto button = std::make_shared<CToggleButton>(position, image, zelp);
+	auto help = readHintText(config["help"]);
+	auto button = std::make_shared<CToggleButton>(position, image, help);
 	if(!config["selected"].isNull())
 		button->setSelected(config["selected"].Bool());
 	if(!config["imageOrder"].isNull())
@@ -271,8 +257,8 @@ std::shared_ptr<CButton> InterfaceObjectConfigurable::buildButton(const JsonNode
 	logGlobal->debug("Building widget CButton");
 	auto position = readPosition(config["position"]);
 	auto image = config["image"].String();
-	auto zelp = readHintText(config["zelp"]);
-	auto button = std::make_shared<CButton>(position, image, zelp);
+	auto help = readHintText(config["help"]);
+	auto button = std::make_shared<CButton>(position, image, help);
 	if(!config["items"].isNull())
 	{
 		for(const auto & item : config["items"].Vector())

--- a/client/gui/InterfaceObjectConfigurable.cpp
+++ b/client/gui/InterfaceObjectConfigurable.cpp
@@ -180,8 +180,8 @@ std::pair<std::string, std::string> InterfaceObjectConfigurable::readHintText(co
 		if(config.getType() == JsonNode::JsonType::DATA_STRING)
 		{
 			logGlobal->debug("Reading hint text (help) from generaltext handler:%sd", config.String());
-			result.first  = CGI->generaltexth->translate( config.String() + ".hover");
-			result.second = CGI->generaltexth->translate( config.String() + ".help");
+			result.first  = CGI->generaltexth->translate( config.String(), "hover");
+			result.second = CGI->generaltexth->translate( config.String(), "help");
 		}
 	}
 	return result;

--- a/client/lobby/CBonusSelection.cpp
+++ b/client/lobby/CBonusSelection.cpp
@@ -141,8 +141,6 @@ void CBonusSelection::loadPositionsOfGraphics()
 
 		idx++;
 	}
-
-	assert(idx == CGI->generaltexth->campaignMapNames.size());
 }
 
 void CBonusSelection::createBonusesIcons()

--- a/client/lobby/CBonusSelection.cpp
+++ b/client/lobby/CBonusSelection.cpp
@@ -92,7 +92,8 @@ CBonusSelection::CBonusSelection()
 	flagbox = std::make_shared<CFlagBox>(Rect(486, 407, 335, 23));
 
 	std::vector<std::string> difficulty;
-	boost::split(difficulty, CGI->generaltexth->allTexts[492], boost::is_any_of(" "));
+	std::string difficultyString = CGI->generaltexth->allTexts[492];
+	boost::split(difficulty, difficultyString, boost::is_any_of(" "));
 	labelDifficulty = std::make_shared<CLabel>(689, 432, FONT_MEDIUM, ETextAlignment::TOPLEFT, Colors::WHITE, difficulty.back());
 
 	for(size_t b = 0; b < difficultyIcons.size(); ++b)

--- a/client/lobby/CLobbyScreen.cpp
+++ b/client/lobby/CLobbyScreen.cpp
@@ -136,10 +136,10 @@ void CLobbyScreen::startScenario(bool allowOnlyAI)
 		logGlobal->error("Exception during startScenario: %s", e.what());
 		
 		if(std::string(e.what()) == "ExceptionNoHuman")
-			CInfoWindow::showInfoDialog(std::ref(CGI->generaltexth->allTexts[530]), CInfoWindow::TCompsInfo(), PlayerColor(1));
+			CInfoWindow::showInfoDialog(CGI->generaltexth->allTexts[530], CInfoWindow::TCompsInfo(), PlayerColor(1));
 		
 		if(std::string(e.what()) == "ExceptionNoTemplate")
-			CInfoWindow::showInfoDialog(std::ref(CGI->generaltexth->allTexts[751]), CInfoWindow::TCompsInfo(), PlayerColor(1));
+			CInfoWindow::showInfoDialog(CGI->generaltexth->allTexts[751], CInfoWindow::TCompsInfo(), PlayerColor(1));
 	}
 	catch(...)
 	{

--- a/client/lobby/SelectionTab.cpp
+++ b/client/lobby/SelectionTab.cpp
@@ -99,8 +99,8 @@ bool mapSorter::operator()(const std::shared_ptr<CMapInfo> aaa, const std::share
 		switch(sortBy)
 		{
 		case _numOfMaps: //by number of maps in campaign
-			return CGI->generaltexth->campaignRegionNames[aaa->campaignHeader->mapVersion].size() <
-				   CGI->generaltexth->campaignRegionNames[bbb->campaignHeader->mapVersion].size();
+			return CGI->generaltexth->getCampaignLength(aaa->campaignHeader->mapVersion) <
+				   CGI->generaltexth->getCampaignLength(bbb->campaignHeader->mapVersion);
 			break;
 		case _name: //by name
 			return boost::ilexicographical_compare(aaa->campaignHeader->name, bbb->campaignHeader->name);
@@ -660,7 +660,7 @@ void SelectionTab::ListItem::updateItem(std::shared_ptr<CMapInfo> info, bool sel
 		iconLossCondition->disable();
 		labelNumberOfCampaignMaps->enable();
 		std::ostringstream ostr(std::ostringstream::out);
-		ostr << CGI->generaltexth->campaignRegionNames[info->campaignHeader->mapVersion].size();
+		ostr << CGI->generaltexth->getCampaignLength(info->campaignHeader->mapVersion);
 		labelNumberOfCampaignMaps->setText(ostr.str());
 		labelNumberOfCampaignMaps->setColor(color);
 	}

--- a/client/mainmenu/CMainMenu.cpp
+++ b/client/mainmenu/CMainMenu.cpp
@@ -205,7 +205,7 @@ static std::function<void()> genCommand(CMenuScreen * menu, std::vector<std::str
 			break;
 			case 4: //exit
 			{
-				return std::bind(CInfoWindow::showYesNoDialog, std::ref(CGI->generaltexth->allTexts[69]), std::vector<std::shared_ptr<CComponent>>(), do_quit, 0, PlayerColor(1));
+				return std::bind(CInfoWindow::showYesNoDialog, CGI->generaltexth->allTexts[69], std::vector<std::shared_ptr<CComponent>>(), do_quit, 0, PlayerColor(1));
 			}
 			break;
 			case 5: //highscores

--- a/client/widgets/Buttons.cpp
+++ b/client/widgets/Buttons.cpp
@@ -289,8 +289,8 @@ std::pair<std::string, std::string> CButton::tooltip()
 std::pair<std::string, std::string> CButton::tooltipLocalized(const std::string & key)
 {
 	return std::make_pair(
-		CGI->generaltexth->translate(key + ".hover"),
-		CGI->generaltexth->translate(key + ".help")
+		CGI->generaltexth->translate(key, "hover"),
+		CGI->generaltexth->translate(key, "help")
 	);
 }
 
@@ -523,7 +523,7 @@ void CVolumeSlider::clickRight(tribool down, bool previousState)
 		int index = static_cast<int>(px / static_cast<double>(pos.w) * animImage->size());
 
 		size_t helpIndex = index + (mode == MUSIC ? 326 : 336);
-		std::string helpBox = CGI->generaltexth->translate("core.help." + std::to_string(helpIndex) + ".help" );
+		std::string helpBox = CGI->generaltexth->translate("core.help", helpIndex, "help" );
 
 		if(!helpBox.empty())
 			CRClickPopup::createAndPush(helpBox);

--- a/client/widgets/Buttons.cpp
+++ b/client/widgets/Buttons.cpp
@@ -22,6 +22,7 @@
 #include "../gui/CGuiHandler.h"
 #include "../windows/InfoWindows.h"
 #include "../../lib/CConfigHandler.h"
+#include "../../lib/CGeneralTextHandler.h"
 
 void CButton::update()
 {
@@ -285,9 +286,12 @@ std::pair<std::string, std::string> CButton::tooltip()
 	return std::pair<std::string, std::string>();
 }
 
-std::pair<std::string, std::string> CButton::tooltip(const JsonNode & localizedTexts)
+std::pair<std::string, std::string> CButton::tooltipLocalized(const std::string & key)
 {
-	return std::make_pair(localizedTexts["label"].String(), localizedTexts["help"].String());
+	return std::make_pair(
+		CGI->generaltexth->translate(key + ".label"),
+		CGI->generaltexth->translate(key + ".help")
+	);
 }
 
 std::pair<std::string, std::string> CButton::tooltip(const std::string & hover, const std::string & help)
@@ -457,10 +461,10 @@ int CToggleGroup::getSelected() const
 	return selectedID;
 }
 
-CVolumeSlider::CVolumeSlider(const Point & position, const std::string & defName, const int value, const std::pair<std::string, std::string> * const help)
+CVolumeSlider::CVolumeSlider(const Point & position, const std::string & defName, const int value, ETooltipMode mode)
 	: CIntObject(LCLICK | RCLICK | WHEEL),
 	value(value),
-	helpHandlers(help)
+	mode(mode)
 {
 	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
 	animImage = std::make_shared<CAnimImage>(std::make_shared<CAnimation>(defName), 0, 0, position.x, position.y),
@@ -517,8 +521,10 @@ void CVolumeSlider::clickRight(tribool down, bool previousState)
 	{
 		double px = GH.current->motion.x - pos.x;
 		int index = static_cast<int>(px / static_cast<double>(pos.w) * animImage->size());
-		std::string hoverText = helpHandlers[index].first;
-		std::string helpBox = helpHandlers[index].second;
+
+		size_t helpIndex = index + (mode == MUSIC ? 326 : 336);
+		std::string helpBox = CGI->generaltexth->translate("core.help." + std::to_string(helpIndex) + ".help" );
+
 		if(!helpBox.empty())
 			CRClickPopup::createAndPush(helpBox);
 		if(GH.statusbar)

--- a/client/widgets/Buttons.cpp
+++ b/client/widgets/Buttons.cpp
@@ -289,7 +289,7 @@ std::pair<std::string, std::string> CButton::tooltip()
 std::pair<std::string, std::string> CButton::tooltipLocalized(const std::string & key)
 {
 	return std::make_pair(
-		CGI->generaltexth->translate(key + ".label"),
+		CGI->generaltexth->translate(key + ".hover"),
 		CGI->generaltexth->translate(key + ".help")
 	);
 }

--- a/client/widgets/Buttons.h
+++ b/client/widgets/Buttons.h
@@ -115,7 +115,7 @@ public:
 
 	/// generates tooltip that can be passed into constructor
 	static std::pair<std::string, std::string> tooltip();
-	static std::pair<std::string, std::string> tooltip(const JsonNode & localizedTexts);
+	static std::pair<std::string, std::string> tooltipLocalized(const std::string & key);
 	static std::pair<std::string, std::string> tooltip(const std::string & hover, const std::string & help = "");
 };
 
@@ -191,19 +191,25 @@ public:
 /// A typical slider for volume with an animated indicator
 class CVolumeSlider : public CIntObject
 {
+public:
+	enum ETooltipMode
+	{
+		MUSIC,
+		SOUND
+	};
+
+private:
 	int value;
 	CFunctionList<void(int)> onChange;
 	std::shared_ptr<CAnimImage> animImage;
-	const std::pair<std::string, std::string> * const helpHandlers;
+	ETooltipMode mode;
 	void setVolume(const int v);
 public:
-
 	/// @param position coordinates of slider
 	/// @param defName name of def animation for slider
 	/// @param value initial value for volume
-	/// @param help pointer to first helptext of slider
-	CVolumeSlider(const Point & position, const std::string & defName, const int value,
-	              const std::pair<std::string, std::string> * const help);
+	/// @param mode that determines tooltip texts
+	CVolumeSlider(const Point & position, const std::string & defName, const int value, ETooltipMode mode);
 
 	void moveTo(int id);
 	void addCallback(std::function<void(int)> callback);

--- a/client/widgets/CArtifactHolder.cpp
+++ b/client/widgets/CArtifactHolder.cpp
@@ -1008,7 +1008,7 @@ CCommanderArtPlace::CCommanderArtPlace(Point position, const CGHeroInstance * co
 void CCommanderArtPlace::clickLeft(tribool down, bool previousState)
 {
 	if (ourArt && text.size() && down)
-		LOCPLINT->showYesNoDialog(CGI->generaltexth->localizedTexts["commanderWindow"]["artifactMessage"].String(), [this](){ returnArtToHeroCallback(); }, [](){});
+		LOCPLINT->showYesNoDialog(CGI->generaltexth->translate("vcmi.commanderWindow.artifactMessage"), [this](){ returnArtToHeroCallback(); }, [](){});
 }
 
 void CCommanderArtPlace::clickRight(tribool down, bool previousState)

--- a/client/windows/CAdvmapInterface.cpp
+++ b/client/windows/CAdvmapInterface.cpp
@@ -1215,7 +1215,7 @@ void CAdvMapInt::keyPressed(const SDL_KeyboardEvent & key)
 			if(itr != LOCPLINT->towns.end())
 				LOCPLINT->showThievesGuildWindow(*itr);
 			else
-				LOCPLINT->showInfoDialog(CGI->generaltexth->localizedTexts["adventureMap"]["noTownWithTavern"].String());
+				LOCPLINT->showInfoDialog(CGI->generaltexth->translate("vcmi.adventureMap.noTownWithTavern"));
 		}
 		return;
 	case SDLK_i:
@@ -1247,7 +1247,7 @@ void CAdvMapInt::keyPressed(const SDL_KeyboardEvent & key)
 	case SDLK_r:
 		if(isActive() && LOCPLINT->ctrlPressed())
 		{
-			LOCPLINT->showYesNoDialog(CGI->generaltexth->localizedTexts["adventureMap"]["confirmRestartGame"].String(),
+			LOCPLINT->showYesNoDialog(CGI->generaltexth->translate("vcmi.adventureMap.confirmRestartGame"),
 				[](){ LOCPLINT->sendCustomEvent(EUserEvent::RESTART_GAME); }, nullptr);
 		}
 		return;
@@ -1306,7 +1306,7 @@ void CAdvMapInt::keyPressed(const SDL_KeyboardEvent & key)
 				if(townWithMarket) //if any town has marketplace, open window
 					GH.pushIntT<CMarketplaceWindow>(townWithMarket);
 				else //if not - complain
-					LOCPLINT->showInfoDialog(CGI->generaltexth->localizedTexts["adventureMap"]["noTownWithMarket"].String());
+					LOCPLINT->showInfoDialog(CGI->generaltexth->translate("vcmi.adventureMap.noTownWithMarket"));
 			}
 			else if(isActive()) //no ctrl, advmapint is on the top => switch to town
 			{

--- a/client/windows/CCastleInterface.cpp
+++ b/client/windows/CCastleInterface.cpp
@@ -851,7 +851,7 @@ void CCastleBuildings::enterToTheQuickRecruitmentWindow()
 	if(hasSomeoneToRecruit)
 		GH.pushIntT<QuickRecruitmentWindow>(town, pos);
 	else
-		CInfoWindow::showInfoDialog(CGI->generaltexth->localizedTexts["townHall"]["noCreaturesToRecruit"].String(), {});
+		CInfoWindow::showInfoDialog(CGI->generaltexth->translate("vcmi.townHall.noCreaturesToRecruit"), {});
 }
 
 void CCastleBuildings::enterFountain(const BuildingID & building, BuildingSubID::EBuildingSubID subID, BuildingID::EBuildingID upgrades)
@@ -870,8 +870,8 @@ void CCastleBuildings::enterFountain(const BuildingID & building, BuildingSubID:
 	{
 		auto buildingName = town->town->getSpecialBuilding(subID)->Name();
 
-		hasNotProduced = std::string(CGI->generaltexth->localizedTexts["townHall"]["hasNotProduced"].String());
-		hasProduced = std::string(CGI->generaltexth->localizedTexts["townHall"]["hasProduced"].String());
+		hasNotProduced = std::string(CGI->generaltexth->translate("vcmi.townHall.hasNotProduced"));
+		hasProduced = std::string(CGI->generaltexth->translate("vcmi.townHall.hasProduced"));
 		boost::algorithm::replace_first(hasNotProduced, "%s", buildingName);
 		boost::algorithm::replace_first(hasProduced, "%s", buildingName);
 	}
@@ -1468,7 +1468,7 @@ std::string CBuildWindow::getTextForState(int state)
 		}
 	case EBuildingState::MISSING_BASE:
 		{
-			std::string msg = CGI->generaltexth->localizedTexts["townHall"]["missingBase"].String();
+			std::string msg = CGI->generaltexth->translate("vcmi.townHall.missingBase");
 			ret = boost::str(boost::format(msg) % town->town->buildings.at(building->upgrade)->Name());
 			break;
 		}

--- a/client/windows/CCreatureWindow.cpp
+++ b/client/windows/CCreatureWindow.cpp
@@ -377,10 +377,7 @@ CStackWindow::CommanderMainSection::CommanderMainSection(CStackWindow * owner, i
 
 	auto getSkillDescription = [this](int skillIndex) -> std::string
 	{
-		if(CGI->generaltexth->znpc00.size() == 0)
-			return "";
-
-		return CGI->generaltexth->znpc00[151 + (12 * skillIndex) + (parent->info->commander->secondarySkills[skillIndex] * 2)];
+		return CGI->generaltexth->znpc00[152 + (12 * skillIndex) + (parent->info->commander->secondarySkills[skillIndex] * 2)];
 	};
 
 	for(int index = ECommander::ATTACK; index <= ECommander::SPELL_POWER; ++index)
@@ -868,9 +865,9 @@ std::string CStackWindow::generateStackExpDescription()
 	if (!vstd::iswithin(tier, 1, 7))
 		tier = 0;
 	int number;
-	std::string expText = CGI->generaltexth->zcrexp[325];
+	std::string expText = CGI->generaltexth->translate("vcmi.stackExperience.description");
 	boost::replace_first(expText, "%s", creature->namePl);
-	boost::replace_first(expText, "%s", CGI->generaltexth->zcrexp[rank]);
+	boost::replace_first(expText, "%s", CGI->generaltexth->translate("vcmi.stackExperience.rank", rank));
 	boost::replace_first(expText, "%i", boost::lexical_cast<std::string>(rank));
 	boost::replace_first(expText, "%i", boost::lexical_cast<std::string>(stack->experience));
 	number = static_cast<int>(CGI->creh->expRanks[tier][rank] - stack->experience);
@@ -905,13 +902,10 @@ void CStackWindow::setSelection(si32 newSkill, std::shared_ptr<CCommanderSkillIc
 {
 	auto getSkillDescription = [this](int skillIndex, bool selected) -> std::string
 	{
-		if(CGI->generaltexth->znpc00.size() == 0)
-			return "";
-
 		if(selected)
-			return CGI->generaltexth->znpc00[151 + (12 * skillIndex) + ((info->commander->secondarySkills[skillIndex] + 1) * 2)]; //upgrade description
+			return CGI->generaltexth->znpc00[152 + (12 * skillIndex) + ((info->commander->secondarySkills[skillIndex] + 1) * 2)]; //upgrade description
 		else
-			return CGI->generaltexth->znpc00[151 + (12 * skillIndex) + (info->commander->secondarySkills[skillIndex] * 2)];
+			return CGI->generaltexth->znpc00[152 + (12 * skillIndex) + (info->commander->secondarySkills[skillIndex] * 2)];
 	};
 
 	auto getSkillImage = [this](int skillIndex) -> std::string

--- a/client/windows/CCreatureWindow.cpp
+++ b/client/windows/CCreatureWindow.cpp
@@ -348,8 +348,8 @@ CStackWindow::ButtonsSection::ButtonsSection(CStackWindow * owner, int yOffset)
 				parent->redraw(); // FIXME: enable/disable don't redraw screen themselves
 			};
 
-			const JsonNode & text = VLC->generaltexth->localizedTexts["creatureWindow"][btnIDs[buttonIndex]];
-			parent->switchButtons[buttonIndex] = std::make_shared<CButton>(Point(302 + (int)buttonIndex*40, 5), "stackWindow/upgradeButton", CButton::tooltip(text), onSwitch);
+			std::string tooltipText = "vcmi.creatureWindow." + btnIDs[buttonIndex];
+			parent->switchButtons[buttonIndex] = std::make_shared<CButton>(Point(302 + (int)buttonIndex*40, 5), "stackWindow/upgradeButton", CButton::tooltipLocalized(tooltipText), onSwitch);
 			parent->switchButtons[buttonIndex]->addOverlay(std::make_shared<CAnimImage>("stackWindow/switchModeIcons", buttonIndex));
 		}
 		parent->switchButtons[parent->activeTab]->disable();
@@ -601,13 +601,12 @@ CStackWindow::MainSection::MainSection(CStackWindow * owner, int yOffset, bool s
 			parent->stackArtifactIcon = std::make_shared<CAnimImage>("ARTIFACT", art->artType->iconIndex, 0, pos.x, pos.y);
 			parent->stackArtifactHelp = std::make_shared<LRClickableAreaWTextComp>(Rect(pos, Point(44, 44)), CComponent::artifact);
 			parent->stackArtifactHelp->type = art->artType->id;
-			const JsonNode & text =	VLC->generaltexth->localizedTexts["creatureWindow"]["returnArtifact"];
 
 			if(parent->info->owner)
 			{
 				parent->stackArtifactButton = std::make_shared<CButton>(
 						Point(pos.x - 2 , pos.y + 46), "stackWindow/cancelButton",
-						CButton::tooltip(text),	[=]()
+						CButton::tooltipLocalized("vcmi.creatureWindow.returnArtifact"),	[=]()
 				{
 					parent->removeStackArtifact(ArtifactPosition::CREATURE_SLOT);
 				});

--- a/client/windows/CHeroWindow.cpp
+++ b/client/windows/CHeroWindow.cpp
@@ -128,8 +128,7 @@ CHeroWindow::CHeroWindow(const CGHeroInstance * hero)
 
 	if(hero->commander)
 	{
-		auto texts = CGI->generaltexth->localizedTexts["heroWindow"]["openCommander"];
-		commanderButton = std::make_shared<CButton>(Point(317, 18), "buttons/commander", CButton::tooltip(texts), [&](){ commanderWindow(); }, SDLK_c);
+		commanderButton = std::make_shared<CButton>(Point(317, 18), "buttons/commander", CButton::tooltipLocalized("vcmi.heroWindow.openCommander"), [&](){ commanderWindow(); }, SDLK_c);
 	}
 
 	//right list of heroes

--- a/client/windows/CKingdomInterface.cpp
+++ b/client/windows/CKingdomInterface.cpp
@@ -594,7 +594,7 @@ void CKingdomInterface::generateMinesList(const std::vector<const CGObjectInstan
 	for(int i=0; i<7; i++)
 	{
 		std::string value = boost::lexical_cast<std::string>(minesCount[i]);
-		auto data = std::make_shared<InfoBoxCustom>(value, "", "OVMINES", i, CGI->generaltexth->mines[i].first);
+		auto data = std::make_shared<InfoBoxCustom>(value, "", "OVMINES", i, CGI->generaltexth->translate("core.minename", i));
 		minesBox[i] = std::make_shared<InfoBox>(Point(20+i*80, 31+footerPos), InfoBox::POS_INSIDE, InfoBox::SIZE_SMALL, data);
 		minesBox[i]->removeUsedEvents(LCLICK|RCLICK); //fixes #890 - mines boxes ignore clicks
 	}

--- a/client/windows/CQuestLog.cpp
+++ b/client/windows/CQuestLog.cpp
@@ -132,7 +132,7 @@ CQuestLog::CQuestLog (const std::vector<QuestInfo> & Quests)
 	ok = std::make_shared<CButton>(Point(539, 398), "IOKAY.DEF", CGI->generaltexth->zelp[445], std::bind(&CQuestLog::close, this), SDLK_RETURN);
 	// Both button and lable are shifted to -2px by x and y to not make them actually look like they're on same line with quests list and ok button
 	hideCompleteButton = std::make_shared<CToggleButton>(Point(10, 396), "sysopchk.def", CButton::tooltipLocalized("vcmi.questLog.hideComplete"), std::bind(&CQuestLog::toggleComplete, this, _1));
-	hideCompleteLabel = std::make_shared<CLabel>(46, 398, FONT_MEDIUM, ETextAlignment::TOPLEFT, Colors::WHITE, CGI->generaltexth->translate("vcmi.questLog.hideComplete.label"));
+	hideCompleteLabel = std::make_shared<CLabel>(46, 398, FONT_MEDIUM, ETextAlignment::TOPLEFT, Colors::WHITE, CGI->generaltexth->translate("vcmi.questLog.hideComplete.hover"));
 	slider = std::make_shared<CSlider>(Point(166, 195), 191, std::bind(&CQuestLog::sliderMoved, this, _1), QUEST_COUNT, 0, false, CSlider::BROWN);
 
 	recreateLabelList();

--- a/client/windows/CQuestLog.cpp
+++ b/client/windows/CQuestLog.cpp
@@ -126,15 +126,13 @@ CQuestLog::CQuestLog (const std::vector<QuestInfo> & Quests)
 {
 	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
 
-	const JsonNode & texts = CGI->generaltexth->localizedTexts["questLog"];
-
 	minimap = std::make_shared<CQuestMinimap>(Rect(12, 12, 169, 169));
 	// TextBox have it's own 4 pixel padding from top at least for English. To achieve 10px from both left and top only add 6px margin
 	description = std::make_shared<CTextBox>("", Rect(205, 18, 385, DESCRIPTION_HEIGHT_MAX), CSlider::BROWN, FONT_MEDIUM, ETextAlignment::TOPLEFT, Colors::WHITE);
 	ok = std::make_shared<CButton>(Point(539, 398), "IOKAY.DEF", CGI->generaltexth->zelp[445], std::bind(&CQuestLog::close, this), SDLK_RETURN);
 	// Both button and lable are shifted to -2px by x and y to not make them actually look like they're on same line with quests list and ok button
-	hideCompleteButton = std::make_shared<CToggleButton>(Point(10, 396), "sysopchk.def", CButton::tooltip(texts["hideComplete"]), std::bind(&CQuestLog::toggleComplete, this, _1));
-	hideCompleteLabel = std::make_shared<CLabel>(46, 398, FONT_MEDIUM, ETextAlignment::TOPLEFT, Colors::WHITE, texts["hideComplete"]["label"].String());
+	hideCompleteButton = std::make_shared<CToggleButton>(Point(10, 396), "sysopchk.def", CButton::tooltipLocalized("vcmi.questLog.hideComplete"), std::bind(&CQuestLog::toggleComplete, this, _1));
+	hideCompleteLabel = std::make_shared<CLabel>(46, 398, FONT_MEDIUM, ETextAlignment::TOPLEFT, Colors::WHITE, CGI->generaltexth->translate("vcmi.questLog.hideComplete.label"));
 	slider = std::make_shared<CSlider>(Point(166, 195), 191, std::bind(&CQuestLog::sliderMoved, this, _1), QUEST_COUNT, 0, false, CSlider::BROWN);
 
 	recreateLabelList();

--- a/client/windows/CSpellWindow.cpp
+++ b/client/windows/CSpellWindow.cpp
@@ -562,7 +562,7 @@ void CSpellWindow::SpellArea::clickLeft(tribool down, bool previousState)
 				if(!texts.empty())
 					owner->myInt->showInfoDialog(texts.front());
 				else
-					owner->myInt->showInfoDialog(CGI->generaltexth->localizedTexts["adventureMap"]["spellUnknownProblem"].String());
+					owner->myInt->showInfoDialog(CGI->generaltexth->translate("vcmi.adventureMap.spellUnknownProblem"));
 			}
 		}
 		else //adventure spell
@@ -658,7 +658,7 @@ void CSpellWindow::SpellArea::setSpell(const CSpell * spell)
 		{
 			boost::format fmt("%s/%s");
 			fmt % CGI->generaltexth->allTexts[171 + mySpell->level];
-			fmt % CGI->generaltexth->levels.at(3+(schoolLevel-1));//lines 4-6
+			fmt % CGI->generaltexth->levels[3+(schoolLevel-1)];//lines 4-6
 			level->setText(fmt.str());
 		}
 		else

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -449,14 +449,12 @@ CSystemOptionsWindow::CSystemOptionsWindow()
 	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
 	title = std::make_shared<CLabel>(242, 32, FONT_BIG, ETextAlignment::CENTER, Colors::YELLOW, CGI->generaltexth->allTexts[568]);
 
-	const JsonNode & texts = CGI->generaltexth->localizedTexts["systemOptions"];
-
 	//left window section
 	leftGroup = std::make_shared<CLabelGroup>(FONT_MEDIUM, ETextAlignment::CENTER, Colors::YELLOW);
 	leftGroup->add(122,  64, CGI->generaltexth->allTexts[569]);
 	leftGroup->add(122, 130, CGI->generaltexth->allTexts[570]);
 	leftGroup->add(122, 196, CGI->generaltexth->allTexts[571]);
-	leftGroup->add(122, 262, texts["resolutionButton"]["label"].String());
+	leftGroup->add(122, 262, CGI->generaltexth->translate("vcmi.systemOptions.resolutionButton.label"));
 	leftGroup->add(122, 347, CGI->generaltexth->allTexts[394]);
 	leftGroup->add(122, 412, CGI->generaltexth->allTexts[395]);
 
@@ -466,8 +464,8 @@ CSystemOptionsWindow::CSystemOptionsWindow()
 	rightGroup->add(282, 89,  CGI->generaltexth->allTexts[573]);
 	rightGroup->add(282, 121, CGI->generaltexth->allTexts[574]);
 	rightGroup->add(282, 153, CGI->generaltexth->allTexts[577]);
-	rightGroup->add(282, 185, texts["creatureWindowButton"]["label"].String());
-	rightGroup->add(282, 217, texts["fullscreenButton"]["label"].String());
+	//rightGroup->add(282, 185, CGI->generaltexth->translate("vcmi.systemOptions.creatureWindowButton.label"));
+	rightGroup->add(282, 217, CGI->generaltexth->translate("vcmi.systemOptions.fullscreenButton.label"));
 
 	//setting up buttons
 	load = std::make_shared<CButton>(Point(246,  298), "SOLOAD.DEF", CGI->generaltexth->zelp[321], [&](){ bloadf(); }, SDLK_l);
@@ -520,10 +518,10 @@ CSystemOptionsWindow::CSystemOptionsWindow()
 	mapScrollSpeed->setSelected((int)settings["adventure"]["scrollSpeed"].Float());
 	mapScrollSpeed->addCallback(std::bind(&setIntSetting, "adventure", "scrollSpeed", _1));
 
-	musicVolume = std::make_shared<CVolumeSlider>(Point(29, 359), "syslb.def", CCS->musich->getVolume(), &CGI->generaltexth->zelp[326]);
+	musicVolume = std::make_shared<CVolumeSlider>(Point(29, 359), "syslb.def", CCS->musich->getVolume(), CVolumeSlider::MUSIC);
 	musicVolume->addCallback(std::bind(&setIntSetting, "general", "music", _1));
 
-	effectsVolume = std::make_shared<CVolumeSlider>(Point(29, 425), "syslb.def", CCS->soundh->getVolume(), &CGI->generaltexth->zelp[336]);
+	effectsVolume = std::make_shared<CVolumeSlider>(Point(29, 425), "syslb.def", CCS->soundh->getVolume(), CVolumeSlider::SOUND);
 	effectsVolume->addCallback(std::bind(&setIntSetting, "general", "sound", _1));
 
 	showReminder = std::make_shared<CToggleButton>(Point(246, 87), "sysopchk.def", CGI->generaltexth->zelp[361], [&](bool value)
@@ -544,7 +542,7 @@ CSystemOptionsWindow::CSystemOptionsWindow()
 	});
 	spellbookAnim->setSelected(settings["video"]["spellbookAnimation"].Bool());
 
-	fullscreen = std::make_shared<CToggleButton>(Point(246, 215), "sysopchk.def", CButton::tooltip(texts["fullscreenButton"]), [&](bool value)
+	fullscreen = std::make_shared<CToggleButton>(Point(246, 215), "sysopchk.def", CButton::tooltipLocalized("vcmi.systemOptions.fullscreenButton"), [&](bool value)
 	{
 		setBoolSetting("video", "fullscreen", value);
 	});
@@ -552,7 +550,7 @@ CSystemOptionsWindow::CSystemOptionsWindow()
 
 	onFullscreenChanged([&](const JsonNode &newState){ fullscreen->setSelected(newState.Bool());});
 
-	gameResButton = std::make_shared<CButton>(Point(28, 275),"buttons/resolution", CButton::tooltip(texts["resolutionButton"]), std::bind(&CSystemOptionsWindow::selectGameRes, this), SDLK_g);
+	gameResButton = std::make_shared<CButton>(Point(28, 275),"buttons/resolution", CButton::tooltipLocalized("vcmi.systemOptions.resolutionButton"), std::bind(&CSystemOptionsWindow::selectGameRes, this), SDLK_g);
 
 	const auto & screenRes = settings["video"]["screenRes"];
 	gameResLabel = std::make_shared<CLabel>(170, 292, FONT_MEDIUM, ETextAlignment::CENTER, Colors::YELLOW, resolutionToString(screenRes["width"].Integer(), screenRes["height"].Integer()));
@@ -561,7 +559,6 @@ CSystemOptionsWindow::CSystemOptionsWindow()
 void CSystemOptionsWindow::selectGameRes()
 {
 	std::vector<std::string> items;
-	const JsonNode & texts = CGI->generaltexth->localizedTexts["systemOptions"]["resolutionMenu"];
 
 #ifndef VCMI_IOS
 	SDL_Rect displayBounds;
@@ -585,7 +582,11 @@ void CSystemOptionsWindow::selectGameRes()
 		++i;
 	}
 
-	GH.pushIntT<CObjectListWindow>(items, nullptr, texts["label"].String(), texts["help"].String(), std::bind(&CSystemOptionsWindow::setGameRes, this, _1), currentResolutionIndex);
+	GH.pushIntT<CObjectListWindow>(items, nullptr,
+								   CGI->generaltexth->translate("vcmi.systemOptions.resolutionMenu.label"),
+								   CGI->generaltexth->translate("vcmi.systemOptions.resolutionMenu.help"),
+								   std::bind(&CSystemOptionsWindow::setGameRes, this, _1),
+								   currentResolutionIndex);
 }
 
 void CSystemOptionsWindow::setGameRes(int index)
@@ -1217,7 +1218,7 @@ CExchangeWindow::CExchangeWindow(ObjectInstanceID hero1, ObjectInstanceID hero2,
 	garr->addSplitBtn(std::make_shared<CButton>( Point( 10, qeLayout ? 122 : 132), "TSBTNS.DEF", CButton::tooltip(CGI->generaltexth->tcommands[3]), splitButtonCallback));
 	garr->addSplitBtn(std::make_shared<CButton>( Point(744, qeLayout ? 122 : 132), "TSBTNS.DEF", CButton::tooltip(CGI->generaltexth->tcommands[3]), splitButtonCallback));
 
-	if (qeLayout && (CGI->generaltexth->qeModCommands.size() >= 5))
+	if (qeLayout )
 	{
 		moveAllGarrButtonLeft    = std::make_shared<CButton>(Point(325, 118), QUICK_EXCHANGE_MOD_PREFIX + "/armRight.DEF", CButton::tooltip(CGI->generaltexth->qeModCommands[1]), controller.onMoveArmyToRight());
 		echangeGarrButton        = std::make_shared<CButton>(Point(377, 118), QUICK_EXCHANGE_MOD_PREFIX + "/swapAll.DEF", CButton::tooltip(CGI->generaltexth->qeModCommands[2]), controller.onSwapArmy());

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -464,7 +464,6 @@ CSystemOptionsWindow::CSystemOptionsWindow()
 	rightGroup->add(282, 89,  CGI->generaltexth->allTexts[573]);
 	rightGroup->add(282, 121, CGI->generaltexth->allTexts[574]);
 	rightGroup->add(282, 153, CGI->generaltexth->allTexts[577]);
-	//rightGroup->add(282, 185, CGI->generaltexth->translate("vcmi.systemOptions.creatureWindowButton.hover"));
 	rightGroup->add(282, 217, CGI->generaltexth->translate("vcmi.systemOptions.fullscreenButton.hover"));
 
 	//setting up buttons
@@ -1218,7 +1217,7 @@ CExchangeWindow::CExchangeWindow(ObjectInstanceID hero1, ObjectInstanceID hero2,
 	garr->addSplitBtn(std::make_shared<CButton>( Point( 10, qeLayout ? 122 : 132), "TSBTNS.DEF", CButton::tooltip(CGI->generaltexth->tcommands[3]), splitButtonCallback));
 	garr->addSplitBtn(std::make_shared<CButton>( Point(744, qeLayout ? 122 : 132), "TSBTNS.DEF", CButton::tooltip(CGI->generaltexth->tcommands[3]), splitButtonCallback));
 
-	if (qeLayout )
+	if(qeLayout)
 	{
 		moveAllGarrButtonLeft    = std::make_shared<CButton>(Point(325, 118), QUICK_EXCHANGE_MOD_PREFIX + "/armRight.DEF", CButton::tooltip(CGI->generaltexth->qeModCommands[1]), controller.onMoveArmyToRight());
 		echangeGarrButton        = std::make_shared<CButton>(Point(377, 118), QUICK_EXCHANGE_MOD_PREFIX + "/swapAll.DEF", CButton::tooltip(CGI->generaltexth->qeModCommands[2]), controller.onSwapArmy());

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -454,7 +454,7 @@ CSystemOptionsWindow::CSystemOptionsWindow()
 	leftGroup->add(122,  64, CGI->generaltexth->allTexts[569]);
 	leftGroup->add(122, 130, CGI->generaltexth->allTexts[570]);
 	leftGroup->add(122, 196, CGI->generaltexth->allTexts[571]);
-	leftGroup->add(122, 262, CGI->generaltexth->translate("vcmi.systemOptions.resolutionButton.label"));
+	leftGroup->add(122, 262, CGI->generaltexth->translate("vcmi.systemOptions.resolutionButton.hover"));
 	leftGroup->add(122, 347, CGI->generaltexth->allTexts[394]);
 	leftGroup->add(122, 412, CGI->generaltexth->allTexts[395]);
 
@@ -464,8 +464,8 @@ CSystemOptionsWindow::CSystemOptionsWindow()
 	rightGroup->add(282, 89,  CGI->generaltexth->allTexts[573]);
 	rightGroup->add(282, 121, CGI->generaltexth->allTexts[574]);
 	rightGroup->add(282, 153, CGI->generaltexth->allTexts[577]);
-	//rightGroup->add(282, 185, CGI->generaltexth->translate("vcmi.systemOptions.creatureWindowButton.label"));
-	rightGroup->add(282, 217, CGI->generaltexth->translate("vcmi.systemOptions.fullscreenButton.label"));
+	//rightGroup->add(282, 185, CGI->generaltexth->translate("vcmi.systemOptions.creatureWindowButton.hover"));
+	rightGroup->add(282, 217, CGI->generaltexth->translate("vcmi.systemOptions.fullscreenButton.hover"));
 
 	//setting up buttons
 	load = std::make_shared<CButton>(Point(246,  298), "SOLOAD.DEF", CGI->generaltexth->zelp[321], [&](){ bloadf(); }, SDLK_l);
@@ -583,7 +583,7 @@ void CSystemOptionsWindow::selectGameRes()
 	}
 
 	GH.pushIntT<CObjectListWindow>(items, nullptr,
-								   CGI->generaltexth->translate("vcmi.systemOptions.resolutionMenu.label"),
+								   CGI->generaltexth->translate("vcmi.systemOptions.resolutionMenu.hover"),
 								   CGI->generaltexth->translate("vcmi.systemOptions.resolutionMenu.help"),
 								   std::bind(&CSystemOptionsWindow::setGameRes, this, _1),
 								   currentResolutionIndex);

--- a/config/translate.json
+++ b/config/translate.json
@@ -23,11 +23,11 @@
 	"vcmi.server.errors.modsIncompatibility" : "Required mods to load game:",
 	"vcmi.server.confirmReconnect"          : "Connect to the last session?",
 
-	"vcmi.systemOptions.fullscreenButton.label" : "Fullscreen",
+	"vcmi.systemOptions.fullscreenButton.hover" : "Fullscreen",
 	"vcmi.systemOptions.fullscreenButton.help"  : "{Fullscreen}\n\n If selected, VCMI will run in fullscreen mode, othervice VCMI will run in window",
-	"vcmi.systemOptions.resolutionButton.label" : "Resolution",
+	"vcmi.systemOptions.resolutionButton.hover" : "Resolution",
 	"vcmi.systemOptions.resolutionButton.help"  : "{Select resolution}\n\n Change in-game screen resolution. Game restart required to apply new resolution.",
-	"vcmi.systemOptions.resolutionMenu.label"   : "Select resolution",
+	"vcmi.systemOptions.resolutionMenu.hover"   : "Select resolution",
 	"vcmi.systemOptions.resolutionMenu.help"    : "Change in-game screen resolution.",
 
 	"vcmi.townHall.missingBase"             : "Base building %s must be built first",
@@ -48,19 +48,19 @@
 	"vcmi.logicalExpressions.allOf"  : "All of the following:",
 	"vcmi.logicalExpressions.noneOf" : "None of the following:",
 
-	"vcmi.heroWindow.openCommander.label" : "Open commander window",
+	"vcmi.heroWindow.openCommander.hover" : "Open commander window",
 	"vcmi.heroWindow.openCommander.help"  : "Displays information about commander of this hero",
 
 	"vcmi.commanderWindow.artifactMessage" : "Do you want to give this artifact back to hero?",
 
-	"vcmi.creatureWindow.showBonuses.label"    : "Switch to bonuses view",
+	"vcmi.creatureWindow.showBonuses.hover"    : "Switch to bonuses view",
 	"vcmi.creatureWindow.showBonuses.help"     : "Displays all active bonuses of the commander",
-	"vcmi.creatureWindow.showSkills.label"     : "Switch to skills view",
+	"vcmi.creatureWindow.showSkills.hover"     : "Switch to skills view",
 	"vcmi.creatureWindow.showSkills.help"      : "Displays all learned skills of the commander",
-	"vcmi.creatureWindow.returnArtifact.label" : "Give back artifact",
+	"vcmi.creatureWindow.returnArtifact.hover" : "Give back artifact",
 	"vcmi.creatureWindow.returnArtifact.help"  : "Use this button to return stack artifact back into hero backpack",
 
-	"vcmi.questLog.hideComplete.label" : "Hide complete quests",
+	"vcmi.questLog.hideComplete.hover" : "Hide complete quests",
 	"vcmi.questLog.hideComplete.help"  : "Hide all quests that already completed",
 
 	"vcmi.randomMapTab.widgets.defaultTemplate"      : "default",

--- a/config/translate.json
+++ b/config/translate.json
@@ -1,127 +1,70 @@
-// This file contains all translateable strings added in VCMI
 {
-	"adventureMap":
-	{
-		"monsterThreat" :
-		{
-			"title" : "\n\n Threat: ",
-			"levels" :
-			[
-				"Effortless",
-				"Very Weak",
-				"Weak",
-				"A bit weaker",
-				"Equal",
-				"A bit stronger",
-				"Strong",
-				"Very Strong",
-				"Challenging",
-				"Overpowering",
-				"Deadly",
-				"Impossible"
-			]
-		},
-		"confirmRestartGame" : "Are you sure you want to restart game?",
-		"noTownWithMarket": "No available marketplace!",
-		"noTownWithTavern": "No available town with tavern!",
-		"spellUnknownProblem": "Unknown problem with this spell, no more information available.",
-		"playerAttacked" : "Player has been attacked: %s"
-	},
-	"server" :
-	{
-		"errors" :
-		{
-			"existingProcess" : "Another vcmiserver process is running, please terminate it first",
-			"modsIncompatibility" : "Required mods to load game:"
-		},
-		"confirmReconnect" : "Connect to the last session?"
-	},
-	"systemOptions" :
-	{
-		"fullscreenButton" :
-		{
-			"label" : "Fullscreen",
-			"help"  : "{Fullscreen}\n\n If selected, VCMI will run in fullscreen mode, othervice VCMI will run in window"
-		},
-		"resolutionButton" :
-		{
-			"label" : "Resolution",
-			"help"  : "{Select resolution}\n\n Change in-game screen resolution. Game restart required to apply new resolution."
-		},
-		"resolutionMenu" :
-		{
-			"label" : "Select resolution",
-			"help" : "Change in-game screen resolution."
-		}
-	},
-	"townHall" :
-	{
-		"missingBase" : "Base building %s must be built first",
-		"noCreaturesToRecruit" : "There are no creatures to recruit!",
-		"greetingManaVortex" : "As you near the %s your body is filled with new energy. You have doubled your normal spell points.",
-		"greetingKnowledge" : "You study the glyphs on the %s and gain insight into the workings of various magics (+1 Knowledge).",
-		"greetingSpellPower" : "The %s teaches you new ways to focus your magical powers (+1 Power).",
-		"greetingExperience" : "A visit to the %s teaches you many new skills (+1000 Experience).",
-		"greetingAttack" : "Some time spent at the %s allows you to learn more effective combat skills (+1 Attack Skill).",
-		"greetingDefence" : "Spending time in the %s, the experienced warriors therein teach you additional defensive skills (+1 Defense).",
-		"hasNotProduced" : "The %s has not produced anything yet.",
-		"hasProduced" : "The %s produced %d %s this week.",
-		"greetingCustomBonus" : "%s gives you +%d %s%s",
-		"greetingCustomUntil" : " until next battle.",
-		"greetingInTownMagicWell" : "%s has restored your spell points to maximum."
-	},
-	"logicalExpressions" :
-	{
-		"anyOf"  :  "Any of the following:",
-		"allOf"  :  "All of the following:",
-		"noneOf" : "None of the following:"
-	},
-	"heroWindow" :
-	{
-		"openCommander" :
-		{
-			"label" : "Open commander window",
-			"help" : "Displays information about commander of this hero"
-		}
-	},
-	"commanderWindow":
-	{
-		"artifactMessage": "Do you want to give this artifact back to hero?"
-	},
-	"creatureWindow" :
-	{
-		"showBonuses" :
-		{
-			"label" : "Switch to bonuses view",
-			"help" : "Displays all active bonuses of the commander"
-		},
-		"showSkills" :
-		{
-			"label" : "Switch to skills view",
-			"help" : "Displays all learned skills of the commander"
-		},
-		"returnArtifact" :
-		{
-			"label" : "Give back artifact",
-			"help" : "Use this button to return stack artifact back into hero backpack"
-		}
-	},
-	"questLog" :
-	{
-		"hideComplete" :
-		{
-			"label" : "Hide complete quests",
-			"help" : "Hide all quests that already completed"
-		}
-	},
-	"randomMapTab":
-	{
-		"widgets":
-		{
-			"defaultTemplate": "default",
-			"templateLabel": "Template",
-			"teamAlignmentsButton": "Setup...",
-			"teamAlignmentsLabel": "Team alignments"
-		}
-	}
+	"vcmi.adventureMap.monsterThreat.title"     : "\n\n Threat: ",
+	"vcmi.adventureMap.monsterThreat.levels.0"  : "Effortless",
+	"vcmi.adventureMap.monsterThreat.levels.1"  : "Very Weak",
+	"vcmi.adventureMap.monsterThreat.levels.2"  : "Weak",
+	"vcmi.adventureMap.monsterThreat.levels.3"  : "A bit weaker",
+	"vcmi.adventureMap.monsterThreat.levels.4"  : "Equal",
+	"vcmi.adventureMap.monsterThreat.levels.5"  : "A bit stronger",
+	"vcmi.adventureMap.monsterThreat.levels.6"  : "Strong",
+	"vcmi.adventureMap.monsterThreat.levels.7"  : "Very Strong",
+	"vcmi.adventureMap.monsterThreat.levels.8"  : "Challenging",
+	"vcmi.adventureMap.monsterThreat.levels.9"  : "Overpowering",
+	"vcmi.adventureMap.monsterThreat.levels.10" : "Deadly",
+	"vcmi.adventureMap.monsterThreat.levels.11" : "Impossible",
+
+	"vcmi.adventureMap.confirmRestartGame"  : "Are you sure you want to restart game?",
+	"vcmi.adventureMap.noTownWithMarket"    : "No available marketplace!",
+	"vcmi.adventureMap.noTownWithTavern"    : "No available town with tavern!",
+	"vcmi.adventureMap.spellUnknownProblem" : "Unknown problem with this spell, no more information available.",
+	"vcmi.adventureMap.playerAttacked"      : "Player has been attacked: %s",
+
+	"vcmi.server.errors.existingProcess"     : "Another vcmiserver process is running, please terminate it first",
+	"vcmi.server.errors.modsIncompatibility" : "Required mods to load game:",
+	"vcmi.server.confirmReconnect"          : "Connect to the last session?",
+
+	"vcmi.systemOptions.fullscreenButton.label" : "Fullscreen",
+	"vcmi.systemOptions.fullscreenButton.help"  : "{Fullscreen}\n\n If selected, VCMI will run in fullscreen mode, othervice VCMI will run in window",
+	"vcmi.systemOptions.resolutionButton.label" : "Resolution",
+	"vcmi.systemOptions.resolutionButton.help"  : "{Select resolution}\n\n Change in-game screen resolution. Game restart required to apply new resolution.",
+	"vcmi.systemOptions.resolutionMenu.label"   : "Select resolution",
+	"vcmi.systemOptions.resolutionMenu.help"    : "Change in-game screen resolution.",
+
+	"vcmi.townHall.missingBase"             : "Base building %s must be built first",
+	"vcmi.townHall.noCreaturesToRecruit"    : "There are no creatures to recruit!",
+	"vcmi.townHall.greetingManaVortex"      : "As you near the %s your body is filled with new energy. You have doubled your normal spell points.",
+	"vcmi.townHall.greetingKnowledge"       : "You study the glyphs on the %s and gain insight into the workings of various magics (+1 Knowledge).",
+	"vcmi.townHall.greetingSpellPower"      : "The %s teaches you new ways to focus your magical powers (+1 Power).",
+	"vcmi.townHall.greetingExperience"      : "A visit to the %s teaches you many new skills (+1000 Experience).",
+	"vcmi.townHall.greetingAttack"          : "Some time spent at the %s allows you to learn more effective combat skills (+1 Attack Skill).",
+	"vcmi.townHall.greetingDefence"         : "Spending time in the %s, the experienced warriors therein teach you additional defensive skills (+1 Defense).",
+	"vcmi.townHall.hasNotProduced"          : "The %s has not produced anything yet.",
+	"vcmi.townHall.hasProduced"             : "The %s produced %d %s this week.",
+	"vcmi.townHall.greetingCustomBonus"     : "%s gives you +%d %s%s",
+	"vcmi.townHall.greetingCustomUntil"     : " until next battle.",
+	"vcmi.townHall.greetingInTownMagicWell" : "%s has restored your spell points to maximum.",
+
+	"vcmi.logicalExpressions.anyOf"  : "Any of the following:",
+	"vcmi.logicalExpressions.allOf"  : "All of the following:",
+	"vcmi.logicalExpressions.noneOf" : "None of the following:",
+
+	"vcmi.heroWindow.openCommander.label" : "Open commander window",
+	"vcmi.heroWindow.openCommander.help"  : "Displays information about commander of this hero",
+
+	"vcmi.commanderWindow.artifactMessage" : "Do you want to give this artifact back to hero?",
+
+	"vcmi.creatureWindow.showBonuses.label"    : "Switch to bonuses view",
+	"vcmi.creatureWindow.showBonuses.help"     : "Displays all active bonuses of the commander",
+	"vcmi.creatureWindow.showSkills.label"     : "Switch to skills view",
+	"vcmi.creatureWindow.showSkills.help"      : "Displays all learned skills of the commander",
+	"vcmi.creatureWindow.returnArtifact.label" : "Give back artifact",
+	"vcmi.creatureWindow.returnArtifact.help"  : "Use this button to return stack artifact back into hero backpack",
+
+	"vcmi.questLog.hideComplete.label" : "Hide complete quests",
+	"vcmi.questLog.hideComplete.help"  : "Hide all quests that already completed",
+
+	"vcmi.randomMapTab.widgets.defaultTemplate"      : "default",
+	"vcmi.randomMapTab.widgets.templateLabel"        : "Template",
+	"vcmi.randomMapTab.widgets.teamAlignmentsButton" : "Setup...",
+	"vcmi.randomMapTab.widgets.teamAlignmentsLabel"  : "Team alignments"
 }

--- a/config/translate.json
+++ b/config/translate.json
@@ -66,5 +66,19 @@
 	"vcmi.randomMapTab.widgets.defaultTemplate"      : "default",
 	"vcmi.randomMapTab.widgets.templateLabel"        : "Template",
 	"vcmi.randomMapTab.widgets.teamAlignmentsButton" : "Setup...",
-	"vcmi.randomMapTab.widgets.teamAlignmentsLabel"  : "Team alignments"
+	"vcmi.randomMapTab.widgets.teamAlignmentsLabel"  : "Team alignments",
+	
+	// few strings from WoG used by vcmi
+	"vcmi.stackExperience.description" : "» S t a c k   E x p e r i e n c e   D e t a i l s «\n\nCreature Type ................... : %s\nExperience Rank ................. : %s (%i)\nExperience Points ............... : %i\nExperience Points to Next Rank .. : %i\nMaximum Experience per Battle ... : %i%% (%i)\nNumber of Creatures in stack .... : %i\nMaximum New Recruits\n without losing current Rank .... : %i\nExperience Multiplier ........... : %.2f\nUpgrade Multiplier .............. : %.2f\nExperience after Rank 10 ........ : %i\nMaximum New Recruits to remain at\n Rank 10 if at Maximum Experience : %i",
+	"vcmi.stackExperience.rank.1" : "Basic",
+	"vcmi.stackExperience.rank.2" : "Novice",
+	"vcmi.stackExperience.rank.3" : "Trained",
+	"vcmi.stackExperience.rank.4" : "Skilled",
+	"vcmi.stackExperience.rank.5" : "Proven",
+	"vcmi.stackExperience.rank.6" : "Veteran",
+	"vcmi.stackExperience.rank.7" : "Adept",
+	"vcmi.stackExperience.rank.8" : "Expert",
+	"vcmi.stackExperience.rank.9" : "Elite",
+	"vcmi.stackExperience.rank.10" : "Master",
+	"vcmi.stackExperience.rank.11" : "Ace"
 }

--- a/config/widgets/randomMapTab.json
+++ b/config/widgets/randomMapTab.json
@@ -14,7 +14,7 @@
 			"font": "big",
 			"alignment": "center",
 			"color": "yellow",
-			"text": 738,
+			"text": "core.genrltxt.738",
 			"position": {"x": 222, "y": 36}
 		},
 
@@ -24,7 +24,7 @@
 			"font": "small",
 			"alignment": "center",
 			"color": "white",
-			"text": 739,
+			"text": "core.genrltxt.739",
 			"position": {"x": 222, "y": 56}
 		},
 
@@ -34,7 +34,7 @@
 			"font": "small",
 			"alignment": "center",
 			"color": "white",
-			"text": 752,
+			"text": "core.genrltxt.752",
 			"position": {"x": 104, "y": 97}
 		},
 
@@ -48,7 +48,7 @@
 					"index": 0,
 					"type": "toggleButton",
 					"image": "RANSIZS",
-					"zelp": 198,
+					"help": "core.help.198",
 					"imageOrder": [0, 1, 1, 3],
 					"position": {"x": 0, "y": 0},
 				},
@@ -56,7 +56,7 @@
 				{
 					"type": "toggleButton",
 					"image": "RANSIZM",
-					"zelp": 199,
+					"help": "core.help.199",
 					"imageOrder": [0, 1, 1, 3],
 					"position": {"x": 47, "y": 0},
 				},
@@ -64,7 +64,7 @@
 				{
 					"type": "toggleButton",
 					"image": "RANSIZL",
-					"zelp": 200,
+					"help": "core.help.200",
 					"imageOrder": [0, 1, 1, 3],
 					"position": {"x": 94, "y": 0},
 				},
@@ -72,7 +72,7 @@
 				{
 					"type": "toggleButton",
 					"image": "RANSIZX",
-					"zelp": 201,
+					"help": "core.help.201",
 					"imageOrder": [0, 1, 1, 3],
 					"position": {"x": 141, "y": 0}
 				}
@@ -100,56 +100,56 @@
 					"index": 1,
 					"type": "toggleButton",
 					"image": "RANNUM1",
-					"zelp": 204,
+					"help": "core.help.204",
 					"imageOrder": [0, 1, 1, 3],
 					"position": {"x": 0, "y": 0}
 				},
 				{
 					"type": "toggleButton",
 					"image": "RANNUM2",
-					"zelp": 205,
+					"help": "core.help.205",
 					"imageOrder": [0, 1, 1, 3],
 					"position": {"x": 32, "y": 0}
 				},
 				{
 					"type": "toggleButton",
 					"image": "RANNUM3",
-					"zelp": 206,
+					"help": "core.help.206",
 					"imageOrder": [0, 1, 1, 3],
 					"position": {"x": 64, "y": 0}
 				},
 				{
 					"type": "toggleButton",
 					"image": "RANNUM4",
-					"zelp": 207,
+					"help": "core.help.207",
 					"imageOrder": [0, 1, 1, 3],
 					"position": {"x": 96, "y": 0}
 				},
 				{
 					"type": "toggleButton",
 					"image": "RANNUM5",
-					"zelp": 208,
+					"help": "core.help.208",
 					"imageOrder": [0, 1, 1, 3],
 					"position": {"x": 128, "y": 0}
 				},
 				{
 					"type": "toggleButton",
 					"image": "RANNUM6",
-					"zelp": 209,
+					"help": "core.help.209",
 					"imageOrder": [0, 1, 1, 3],
 					"position": {"x": 160, "y": 0}
 				},
 				{
 					"type": "toggleButton",
 					"image": "RANNUM7",
-					"zelp": 210,
+					"help": "core.help.210",
 					"imageOrder": [0, 1, 1, 3],
 					"position": {"x": 192, "y": 0}
 				},
 				{
 					"type": "toggleButton",
 					"image": "RANNUM8",
-					"zelp": 211,
+					"help": "core.help.211",
 					"imageOrder": [0, 1, 1, 3],
 					"position": {"x": 224, "y": 0}
 				},
@@ -157,7 +157,7 @@
 					"index": -1,
 					"type": "toggleButton",
 					"image": "RANRAND",
-					"zelp": 212,
+					"help": "core.help.212",
 					"position": {"x": 256, "y": 0},
 				}
 			],
@@ -175,56 +175,56 @@
 					"index": 0,
 					"type": "toggleButton",
 					"image": "RANNUM0",
-					"zelp": 214,
+					"help": "core.help.214",
 					"imageOrder": [0, 1, 1, 3],
 					"position": {"x": 0, "y": 0}
 				},
 				{
 					"type": "toggleButton",
 					"image": "RANNUM1",
-					"zelp": 215,
+					"help": "core.help.215",
 					"imageOrder": [0, 1, 1, 3],
 					"position": {"x": 32, "y": 0}
 				},
 				{
 					"type": "toggleButton",
 					"image": "RANNUM2",
-					"zelp": 216,
+					"help": "core.help.216",
 					"imageOrder": [0, 1, 1, 3],
 					"position": {"x": 64, "y": 0}
 				},
 				{
 					"type": "toggleButton",
 					"image": "RANNUM3",
-					"zelp": 217,
+					"help": "core.help.217",
 					"imageOrder": [0, 1, 1, 3],
 					"position": {"x": 96, "y": 0}
 				},
 				{
 					"type": "toggleButton",
 					"image": "RANNUM4",
-					"zelp": 218,
+					"help": "core.help.218",
 					"imageOrder": [0, 1, 1, 3],
 					"position": {"x": 128, "y": 0}
 				},
 				{
 					"type": "toggleButton",
 					"image": "RANNUM5",
-					"zelp": 219,
+					"help": "core.help.219",
 					"imageOrder": [0, 1, 1, 3],
 					"position": {"x": 160, "y": 0}
 				},
 				{
 					"type": "toggleButton",
 					"image": "RANNUM6",
-					"zelp": 220,
+					"help": "core.help.220",
 					"imageOrder": [0, 1, 1, 3],
 					"position": {"x": 192, "y": 0}
 				},
 				{
 					"type": "toggleButton",
 					"image": "RANNUM7",
-					"zelp": 221,
+					"help": "core.help.221",
 					"imageOrder": [0, 1, 1, 3],
 					"position": {"x": 224, "y": 0}
 				},
@@ -232,7 +232,7 @@
 					"index": -1,
 					"type": "toggleButton",
 					"image": "RANRAND",
-					"zelp": 222,
+					"help": "core.help.222",
 					"position": {"x": 256, "y": 0},
 				}
 			],
@@ -250,56 +250,56 @@
 					"index": 0,
 					"type": "toggleButton",
 					"image": "RANNUM0",
-					"zelp": 224,
+					"help": "core.help.224",
 					"imageOrder": [0, 1, 1, 3],
 					"position": {"x": 0, "y": 0}
 				},
 				{
 					"type": "toggleButton",
 					"image": "RANNUM1",
-					"zelp": 225,
+					"help": "core.help.225",
 					"imageOrder": [0, 1, 1, 3],
 					"position": {"x": 32, "y": 0}
 				},
 				{
 					"type": "toggleButton",
 					"image": "RANNUM2",
-					"zelp": 226,
+					"help": "core.help.226",
 					"imageOrder": [0, 1, 1, 3],
 					"position": {"x": 64, "y": 0}
 				},
 				{
 					"type": "toggleButton",
 					"image": "RANNUM3",
-					"zelp": 227,
+					"help": "core.help.227",
 					"imageOrder": [0, 1, 1, 3],
 					"position": {"x": 96, "y": 0}
 				},
 				{
 					"type": "toggleButton",
 					"image": "RANNUM4",
-					"zelp": 228,
+					"help": "core.help.228",
 					"imageOrder": [0, 1, 1, 3],
 					"position": {"x": 128, "y": 0}
 				},
 				{
 					"type": "toggleButton",
 					"image": "RANNUM5",
-					"zelp": 229,
+					"help": "core.help.229",
 					"imageOrder": [0, 1, 1, 3],
 					"position": {"x": 160, "y": 0}
 				},
 				{
 					"type": "toggleButton",
 					"image": "RANNUM6",
-					"zelp": 230,
+					"help": "core.help.230",
 					"imageOrder": [0, 1, 1, 3],
 					"position": {"x": 192, "y": 0}
 				},
 				{
 					"type": "toggleButton",
 					"image": "RANNUM7",
-					"zelp": 231,
+					"help": "core.help.231",
 					"imageOrder": [0, 1, 1, 3],
 					"position": {"x": 224, "y": 0}
 				},
@@ -307,7 +307,7 @@
 					"index": -1,
 					"type": "toggleButton",
 					"image": "RANRAND",
-					"zelp": 232,
+					"help": "core.help.232",
 					"position": {"x": 256, "y": 0},
 				}
 			],
@@ -325,49 +325,49 @@
 					"index": 0,
 					"type": "toggleButton",
 					"image": "RANNUM0",
-					"zelp": 234,
+					"help": 234,
 					"imageOrder": [0, 1, 1, 3],
 					"position": {"x": 0, "y": 0}
 				},
 				{
 					"type": "toggleButton",
 					"image": "RANNUM1",
-					"zelp": 235,
+					"help": "core.help.235",
 					"imageOrder": [0, 1, 1, 3],
 					"position": {"x": 32, "y": 0}
 				},
 				{
 					"type": "toggleButton",
 					"image": "RANNUM2",
-					"zelp": 236,
+					"help": "core.help.236",
 					"imageOrder": [0, 1, 1, 3],
 					"position": {"x": 64, "y": 0}
 				},
 				{
 					"type": "toggleButton",
 					"image": "RANNUM3",
-					"zelp": 237,
+					"help": "core.help.237",
 					"imageOrder": [0, 1, 1, 3],
 					"position": {"x": 96, "y": 0}
 				},
 				{
 					"type": "toggleButton",
 					"image": "RANNUM4",
-					"zelp": 238,
+					"help": "core.help.238",
 					"imageOrder": [0, 1, 1, 3],
 					"position": {"x": 128, "y": 0}
 				},
 				{
 					"type": "toggleButton",
 					"image": "RANNUM5",
-					"zelp": 239,
+					"help": "core.help.239",
 					"imageOrder": [0, 1, 1, 3],
 					"position": {"x": 160, "y": 0}
 				},
 				{
 					"type": "toggleButton",
 					"image": "RANNUM6",
-					"zelp": 240,
+					"help": "core.help.240",
 					"imageOrder": [0, 1, 1, 3],
 					"position": {"x": 192, "y": 0}
 				},
@@ -375,7 +375,7 @@
 					"index": -1,
 					"type": "toggleButton",
 					"image": "RANRAND",
-					"zelp": 241,
+					"help": "core.help.241",
 					"position": {"x": 256, "y": 0},
 				}
 			],
@@ -393,21 +393,21 @@
 					"index": 0,
 					"type": "toggleButton",
 					"image": "RANNONE",
-					"zelp": 243,
+					"help": "core.help.243",
 					"imageOrder": [0, 1, 1, 3],
 					"position": {"x": 0, "y": 0}
 				},
 				{
 					"type": "toggleButton",
 					"image": "RANNORM",
-					"zelp": 244,
+					"help": "core.help.244",
 					"imageOrder": [0, 1, 1, 3],
 					"position": {"x": 85, "y": 0}
 				},
 				{
 					"type": "toggleButton",
 					"image": "RANISLD",
-					"zelp": 245,
+					"help": "core.help.245",
 					"imageOrder": [0, 1, 1, 3],
 					"position": {"x": 170, "y": 0}
 				},
@@ -415,7 +415,7 @@
 					"index": -1,
 					"type": "toggleButton",
 					"image": "RANRAND",
-					"zelp": 246,
+					"help": "core.help.246",
 					"position": {"x": 256, "y": 0},
 				}
 			],
@@ -433,7 +433,7 @@
 					"index": 2,
 					"type": "toggleButton",
 					"image": "RANWEAK",
-					"zelp": 248,
+					"help": "core.help.248",
 					"imageOrder": [0, 1, 1, 3],
 					"position": {"x": 0, "y": 0}
 				},
@@ -441,7 +441,7 @@
 					"index": 3,
 					"type": "toggleButton",
 					"image": "RANNORM",
-					"zelp": 249,
+					"help": "core.help.249",
 					"imageOrder": [0, 1, 1, 3],
 					"position": {"x": 85, "y": 0}
 				},
@@ -449,7 +449,7 @@
 					"index": 4,
 					"type": "toggleButton",
 					"image": "RANSTRG",
-					"zelp": 250,
+					"help": "core.help.250",
 					"imageOrder": [0, 1, 1, 3],
 					"position": {"x": 170, "y": 0}
 				},
@@ -457,7 +457,7 @@
 					"index": -2,
 					"type": "toggleButton",
 					"image": "RANRAND",
-					"zelp": 251,
+					"help": "core.help.251",
 					"position": {"x": 256, "y": 0},
 				}
 			],
@@ -470,7 +470,7 @@
 			"type": "button",
 			"position": {"x": 54, "y": 535},
 			"image": "RANSHOW",
-			"zelp": 252
+			"help": "core.help.252"
 		},
 
 		{
@@ -482,27 +482,27 @@
 			[
 				{
 					"position": {"x": 68, "y": 133},
-					"text": 753
+					"text": "core.genrltxt.753"
 				},
 				{
 					"position": {"x": 68, "y": 199},
-					"text": 754
+					"text": "core.genrltxt.754"
 				},
 				{
 					"position": {"x": 68, "y": 265},
-					"text": 755
+					"text": "core.genrltxt.755"
 				},
 				{
 					"position": {"x": 68, "y": 331},
-					"text": 756
+					"text": "core.genrltxt.756"
 				},
 				{
 					"position": {"x": 68, "y": 398},
-					"text": 757
+					"text": "core.genrltxt.757"
 				},
 				{
 					"position": {"x": 68, "y": 465},
-					"text": 758
+					"text": "core.genrltxt.758"
 				}
 			]
 		}

--- a/lib/CGameState.cpp
+++ b/lib/CGameState.cpp
@@ -139,7 +139,7 @@ void MetaString::getLocalString(const std::pair<ui8,ui32> &txt, std::string &dst
 		switch(type)
 		{
 		case GENERAL_TXT:
-			dst = VLC->generaltexth->translate("core.allTexts", ser);
+			dst = VLC->generaltexth->translate("core.genrltxt", ser);
 			break;
 		case XTRAINFO_TXT:
 			dst = VLC->generaltexth->translate("core.xtrainfo", ser);

--- a/lib/CGameState.cpp
+++ b/lib/CGameState.cpp
@@ -112,11 +112,11 @@ void MetaString::getLocalString(const std::pair<ui8,ui32> &txt, std::string &dst
 	}
 	else if(type == MINE_NAMES)
 	{
-		dst = VLC->generaltexth->mines[ser].first;
+		dst = VLC->generaltexth->translate("core.minename", ser);
 	}
 	else if(type == MINE_EVNTS)
 	{
-		dst = VLC->generaltexth->mines[ser].second;
+		dst = VLC->generaltexth->translate("core.mineevnt", ser);
 	}
 	else if(type == SPELL_NAME)
 	{
@@ -136,48 +136,40 @@ void MetaString::getLocalString(const std::pair<ui8,ui32> &txt, std::string &dst
 	}
 	else
 	{
-		std::vector<std::string> *vec;
 		switch(type)
 		{
 		case GENERAL_TXT:
-			vec = &VLC->generaltexth->allTexts;
+			dst = VLC->generaltexth->translate("core.allTexts", ser);
 			break;
 		case XTRAINFO_TXT:
-			vec = &VLC->generaltexth->xtrainfo;
+			dst = VLC->generaltexth->translate("core.xtrainfo", ser);
 			break;
 		case RES_NAMES:
-			vec = &VLC->generaltexth->restypes;
+			dst = VLC->generaltexth->translate("core.restypes", ser);
 			break;
 		case ARRAY_TXT:
-			vec = &VLC->generaltexth->arraytxt;
+			dst = VLC->generaltexth->translate("core.arraytxt", ser);
 			break;
 		case CREGENS:
-			vec = &VLC->generaltexth->creGens;
+			dst = VLC->generaltexth->translate("core.crgen1", ser);
 			break;
 		case CREGENS4:
-			vec = &VLC->generaltexth->creGens4;
+			dst = VLC->generaltexth->translate("core.crgen4", ser);
 			break;
 		case ADVOB_TXT:
-			vec = &VLC->generaltexth->advobtxt;
+			dst = VLC->generaltexth->translate("core.advevent", ser);
 			break;
 		case COLOR:
-			vec = &VLC->generaltexth->capColors;
+			dst = VLC->generaltexth->translate("vcmi.capitalColors", ser);
 			break;
 		case JK_TXT:
-			vec = &VLC->generaltexth->jktexts;
+			dst = VLC->generaltexth->translate("core.jktext", ser);
 			break;
 		default:
 			logGlobal->error("Failed string substitution because type is %d", type);
 			dst = "#@#";
 			return;
 		}
-		if(vec->size() <= ser)
-		{
-			logGlobal->error("Failed string substitution with type %d because index %d is out of bounds!", type, ser);
-			dst = "#!#";
-		}
-		else
-			dst = (*vec)[ser];
 	}
 }
 
@@ -2182,11 +2174,10 @@ void CGameState::updateRumor()
 			FALLTHROUGH
 
 		case RumorState::TYPE_RAND:
+			auto vector = VLC->generaltexth->findStringsWithPrefix("core.randtvrn");
 			do
-			{
-				rumorId = rand.nextInt((int)VLC->generaltexth->tavernRumors.size() - 1);
-			}
-			while(!VLC->generaltexth->tavernRumors[rumorId].length());
+				rumorId = rand.nextInt((int)vector.size() - 1);
+			while(vector[rumorId].empty());
 
 			break;
 		}

--- a/lib/CGameState.cpp
+++ b/lib/CGameState.cpp
@@ -2175,9 +2175,7 @@ void CGameState::updateRumor()
 
 		case RumorState::TYPE_RAND:
 			auto vector = VLC->generaltexth->findStringsWithPrefix("core.randtvrn");
-			do
-				rumorId = rand.nextInt((int)vector.size() - 1);
-			while(vector[rumorId].empty());
+			rumorId = rand.nextInt((int)vector.size() - 1);
 
 			break;
 		}

--- a/lib/CGeneralTextHandler.cpp
+++ b/lib/CGeneralTextHandler.cpp
@@ -345,8 +345,6 @@ CGeneralTextHandler::CGeneralTextHandler():
 	restypes         (*this, "core.restypes" ),
 	terrainNames     (*this, "core.terrname" ),
 	randsign         (*this, "core.randsign" ),
-	creGens          (*this, "core.crgen1"   ),
-	creGens4         (*this, "core.crgen4"   ),
 	overview         (*this, "core.overview" ),
 	arraytxt         (*this, "core.arraytxt" ),
 	primarySkillNames(*this, "core.priskill" ),
@@ -376,8 +374,6 @@ CGeneralTextHandler::CGeneralTextHandler():
 	readToVector("core.restypes", "DATA/RESTYPES.TXT" );
 	readToVector("core.terrname", "DATA/TERRNAME.TXT" );
 	readToVector("core.randsign", "DATA/RANDSIGN.TXT" );
-	readToVector("core.crgen1",   "DATA/CRGEN1.TXT"   );
-	readToVector("core.crgen4",   "DATA/CRGEN4.TXT"   );
 	readToVector("core.overview", "DATA/OVERVIEW.TXT" );
 	readToVector("core.arraytxt", "DATA/ARRAYTXT.TXT" );
 	readToVector("core.priskill", "DATA/PRISKILL.TXT" );

--- a/lib/CGeneralTextHandler.cpp
+++ b/lib/CGeneralTextHandler.cpp
@@ -546,8 +546,6 @@ CGeneralTextHandler::CGeneralTextHandler():
 		if (CResourceHandler::get()->existsResource(ResourceID("DATA/ZNPC00.TXT", EResType::TEXT)))
 			readToVector("vcmi.znpc00", "DATA/ZNPC00.TXT" );
 	}
-
-	dumpAllTexts();
 }
 
 int32_t CGeneralTextHandler::pluralText(const int32_t textIndex, const int32_t count) const
@@ -564,7 +562,7 @@ int32_t CGeneralTextHandler::pluralText(const int32_t textIndex, const int32_t c
 
 void CGeneralTextHandler::dumpAllTexts()
 {
-	logGlobal->trace("BEGIN TEXT EXPORT");
+	logGlobal->info("BEGIN TEXT EXPORT");
 	for ( auto const & entry : stringsLocalizations)
 	{
 		auto cleanString = entry.second;
@@ -574,9 +572,9 @@ void CGeneralTextHandler::dumpAllTexts()
 		boost::replace_all(cleanString, "\t", "\\t");
 		boost::replace_all(cleanString, "\"", "\\\"");
 
-		logGlobal->trace("\"%s\" : \"%s\",", entry.first, cleanString);
+		logGlobal->info("\"%s\" : \"%s\",", entry.first, cleanString);
 	}
-	logGlobal->trace("END TEXT EXPORT");
+	logGlobal->info("END TEXT EXPORT");
 }
 
 size_t CGeneralTextHandler::getCampaignLength(size_t campaignID) const

--- a/lib/CGeneralTextHandler.cpp
+++ b/lib/CGeneralTextHandler.cpp
@@ -398,7 +398,6 @@ CGeneralTextHandler::CGeneralTextHandler():
 	readToVector("core.priskill", "DATA/PRISKILL.TXT" );
 	readToVector("core.jktext",   "DATA/JKTEXT.TXT"   );
 	readToVector("core.tvrninfo", "DATA/TVRNINFO.TXT" );
-	readToVector("core.randtvrn", "DATA/RANDTVRN.TXT" );
 	readToVector("core.turndur",  "DATA/TURNDUR.TXT"  );
 	readToVector("core.heroscrn", "DATA/HEROSCRN.TXT" );
 	readToVector("core.tentcolr", "DATA/TENTCOLR.TXT" );
@@ -416,6 +415,21 @@ CGeneralTextHandler::CGeneralTextHandler():
 	for ( auto const & node : vcmiTexts.Struct())
 		registerString(node.first, node.second.String());
 
+	{
+		CLegacyConfigParser parser("DATA/RANDTVRN.TXT");
+		parser.endLine();
+		size_t index = 0;
+		do
+		{
+			std::string line = parser.readString();
+			if (!line.empty())
+			{
+				registerH3String("core.randtvrn", index, line);
+				index += 1;
+			}
+		}
+		while (parser.endLine());
+	}
 	{
 		CLegacyConfigParser parser("DATA/GENRLTXT.TXT");
 		parser.endLine();

--- a/lib/CGeneralTextHandler.cpp
+++ b/lib/CGeneralTextHandler.cpp
@@ -321,7 +321,7 @@ const std::string & CGeneralTextHandler::serialize(const std::string & identifie
 
 const std::string & CGeneralTextHandler::deserialize(const TextIdentifier & identifier) const
 {
-	if (stringsLocalizations.count(identifier.get()))
+	if(stringsLocalizations.count(identifier.get()))
 		return stringsLocalizations.at(identifier.get());
 	logGlobal->error("Unable to find localization for string '%s'", identifier.get());
 	return identifier.get();
@@ -403,7 +403,7 @@ CGeneralTextHandler::CGeneralTextHandler():
 		do
 		{
 			std::string line = parser.readString();
-			if (!line.empty())
+			if(!line.empty())
 			{
 				registerString({"core.randtvrn", index}, line);
 				index += 1;
@@ -538,7 +538,7 @@ CGeneralTextHandler::CGeneralTextHandler():
 	}
 	if (VLC->modh->modules.COMMANDERS)
 	{
-		if (CResourceHandler::get()->existsResource(ResourceID("DATA/ZNPC00.TXT", EResType::TEXT)))
+		if(CResourceHandler::get()->existsResource(ResourceID("DATA/ZNPC00.TXT", EResType::TEXT)))
 			readToVector("vcmi.znpc00", "DATA/ZNPC00.TXT" );
 	}
 }
@@ -576,7 +576,7 @@ size_t CGeneralTextHandler::getCampaignLength(size_t campaignID) const
 {
 	assert(campaignID < scenariosCountPerCampaign.size());
 
-	if ( campaignID < scenariosCountPerCampaign.size())
+	if(campaignID < scenariosCountPerCampaign.size())
 		return scenariosCountPerCampaign[campaignID];
 	return 0;
 }
@@ -587,7 +587,7 @@ std::vector<std::string> CGeneralTextHandler::findStringsWithPrefix(std::string 
 
 	for (auto const & entry : stringsLocalizations)
 	{
-		if (boost::algorithm::starts_with(entry.first, prefix))
+		if(boost::algorithm::starts_with(entry.first, prefix))
 			result.push_back(entry.first);
 	}
 

--- a/lib/CGeneralTextHandler.cpp
+++ b/lib/CGeneralTextHandler.cpp
@@ -448,7 +448,7 @@ CGeneralTextHandler::CGeneralTextHandler():
 		{
 			std::string first = parser.readString();
 			std::string second = parser.readString();
-			registerString("core.help." + std::to_string(index) + ".label", first);
+			registerString("core.help." + std::to_string(index) + ".hover", first);
 			registerString("core.help." + std::to_string(index) + ".help",  second);
 			index += 1;
 		}
@@ -631,7 +631,7 @@ LegacyHelpContainer::LegacyHelpContainer(CGeneralTextHandler & owner, std::strin
 std::pair<std::string, std::string> LegacyHelpContainer::operator[](size_t index) const
 {
 	return {
-		owner.translate(basePath + "." + std::to_string(index) + ".label"),
+		owner.translate(basePath + "." + std::to_string(index) + ".hover"),
 		owner.translate(basePath + "." + std::to_string(index) + ".help")
 	};
 }

--- a/lib/CGeneralTextHandler.cpp
+++ b/lib/CGeneralTextHandler.cpp
@@ -331,12 +331,10 @@ const std::string & CGeneralTextHandler::serialize(const std::string & identifie
 
 const std::string & CGeneralTextHandler::deserialize(const std::string & identifier) const
 {
-	static const std::string emptyString;
-
 	if (stringsLocalizations.count(identifier))
 		return stringsLocalizations.at(identifier);
 	logGlobal->error("Unable to find localization for string '%s'", identifier);
-	return emptyString;
+	return identifier;
 }
 
 void CGeneralTextHandler::registerH3String(const std::string & file, size_t index, const std::string & localized)
@@ -519,7 +517,7 @@ CGeneralTextHandler::CGeneralTextHandler():
 		}
 		while (parser.endLine() && !text.empty());
 
-		for (size_t i=0; i<campaignsCount; i++)
+		for (size_t campaign=0; campaign<campaignsCount; campaign++)
 		{
 			size_t region = 0;
 
@@ -534,7 +532,7 @@ CGeneralTextHandler::CGeneralTextHandler():
 				text = parser.readString();
 				if (!text.empty())
 				{
-					registerH3String("core.camptext.regions." + std::to_string(campaignsCount), region, text);
+					registerH3String("core.camptext.regions." + std::to_string(campaign), region, text);
 					region += 1;
 				}
 			}
@@ -566,7 +564,7 @@ int32_t CGeneralTextHandler::pluralText(const int32_t textIndex, const int32_t c
 
 void CGeneralTextHandler::dumpAllTexts()
 {
-	logGlobal->info("BEGIN TEXT EXPORT");
+	logGlobal->trace("BEGIN TEXT EXPORT");
 	for ( auto const & entry : stringsLocalizations)
 	{
 		auto cleanString = entry.second;
@@ -576,9 +574,9 @@ void CGeneralTextHandler::dumpAllTexts()
 		boost::replace_all(cleanString, "\t", "\\t");
 		boost::replace_all(cleanString, "\"", "\\\"");
 
-		logGlobal->info("\"%s\" : \"%s\",", entry.first, cleanString);
+		logGlobal->trace("\"%s\" : \"%s\",", entry.first, cleanString);
 	}
-	logGlobal->info("END TEXT EXPORT");
+	logGlobal->trace("END TEXT EXPORT");
 }
 
 size_t CGeneralTextHandler::getCampaignLength(size_t campaignID) const

--- a/lib/CGeneralTextHandler.cpp
+++ b/lib/CGeneralTextHandler.cpp
@@ -300,58 +300,118 @@ bool CLegacyConfigParser::endLine()
 	return curr < end;
 }
 
-void CGeneralTextHandler::readToVector(std::string sourceName, std::vector<std::string> &dest)
+void CGeneralTextHandler::readToVector(std::string sourceID, std::string sourceName)
 {
 	CLegacyConfigParser parser(sourceName);
+	size_t index = 0;
 	do
 	{
-		dest.push_back(parser.readString());
+		registerH3String(sourceID, index, parser.readString());
+		index += 1;
 	}
 	while (parser.endLine());
 }
 
-CGeneralTextHandler::CGeneralTextHandler()
+const std::string & CGeneralTextHandler::translate(const std::string & identifier, size_t index) const
 {
-	std::vector<std::string> h3mTerrainNames;
-	readToVector("DATA/VCDESC.TXT",   victoryConditions);
-	readToVector("DATA/LCDESC.TXT",   lossCondtions);
-	readToVector("DATA/TCOMMAND.TXT", tcommands);
-	readToVector("DATA/HALLINFO.TXT", hcommands);
-	readToVector("DATA/CASTINFO.TXT", fcommands);
-	readToVector("DATA/ADVEVENT.TXT", advobtxt);
-	readToVector("DATA/XTRAINFO.TXT", xtrainfo);
-	readToVector("DATA/RESTYPES.TXT", restypes);
-	readToVector("DATA/TERRNAME.TXT", h3mTerrainNames);
-	readToVector("DATA/RANDSIGN.TXT", randsign);
-	readToVector("DATA/CRGEN1.TXT",   creGens);
-	readToVector("DATA/CRGEN4.TXT",   creGens4);
-	readToVector("DATA/OVERVIEW.TXT", overview);
-	readToVector("DATA/ARRAYTXT.TXT", arraytxt);
-	readToVector("DATA/PRISKILL.TXT", primarySkillNames);
-	readToVector("DATA/JKTEXT.TXT",   jktexts);
-	readToVector("DATA/TVRNINFO.TXT", tavernInfo);
-	readToVector("DATA/RANDTVRN.TXT", tavernRumors);
-	readToVector("DATA/TURNDUR.TXT",  turnDurations);
-	readToVector("DATA/HEROSCRN.TXT", heroscrn);
-	readToVector("DATA/TENTCOLR.TXT", tentColors);
-	readToVector("DATA/SKILLLEV.TXT", levels);
-	
-	for(int i = 0; i < h3mTerrainNames.size(); ++i)
-	{
-		terrainNames[i] = h3mTerrainNames[i];
-	}
-	for(const auto & terrain : VLC->terrainTypeHandler->terrains())
-	{
-		if(!terrain.terrainText.empty())
-			terrainNames[terrain.id] = terrain.terrainText;
-	}
-	
+	return translate(identifier + std::to_string(index));
+}
+
+const std::string & CGeneralTextHandler::translate(const std::string & identifier) const
+{
+	return deserialize(identifier);
+}
+
+const std::string & CGeneralTextHandler::serialize(const std::string & identifier) const
+{
+	assert(stringsIdentifiers.count(identifier));
+	return stringsIdentifiers.at(identifier);
+}
+
+const std::string & CGeneralTextHandler::deserialize(const std::string & identifier) const
+{
+	static const std::string emptyString;
+
+	if (stringsLocalizations.count(identifier))
+		return stringsLocalizations.at(identifier);
+	logGlobal->error("Unable to find localization for string '%s'", identifier);
+	return emptyString;
+}
+
+void CGeneralTextHandler::registerH3String(const std::string & file, size_t index, const std::string & localized)
+{
+	registerString(file + '.' + std::to_string(index), localized);
+}
+
+void CGeneralTextHandler::registerString(const std::string & UID, const std::string & localized)
+{
+	stringsIdentifiers[localized] = UID;
+	stringsLocalizations[UID] = localized;
+}
+
+CGeneralTextHandler::CGeneralTextHandler():
+	victoryConditions(*this, "core.vcdesc"   ),
+	lossCondtions    (*this, "core.lcdesc"   ),
+	colors           (*this, "core.plcolors" ),
+	tcommands        (*this, "core.tcommand" ),
+	hcommands        (*this, "core.hallinfo" ),
+	fcommands        (*this, "core.castinfo" ),
+	advobtxt         (*this, "core.advevent" ),
+	xtrainfo         (*this, "core.xtrainfo" ),
+	restypes         (*this, "core.restypes" ),
+	terrainNames     (*this, "core.terrname" ),
+	randsign         (*this, "core.randsign" ),
+	creGens          (*this, "core.crgen1"   ),
+	creGens4         (*this, "core.crgen4"   ),
+	overview         (*this, "core.overview" ),
+	arraytxt         (*this, "core.arraytxt" ),
+	primarySkillNames(*this, "core.priskill" ),
+	jktexts          (*this, "core.jktext"   ),
+	tavernInfo       (*this, "core.tvrninfo" ),
+	tavernRumors     (*this, "core.randtvrn" ),
+	turnDurations    (*this, "core.turndur"  ),
+	heroscrn         (*this, "core.heroscrn" ),
+	tentColors       (*this, "core.tentcolr" ),
+	levels           (*this, "core.skilllev" ),
+	zelp             (*this, "core.help"     ),
+	// pseudo-array, that don't have H3 file with same name
+	capColors        (*this, "vcmi.capitalColors"  ),
+	qeModCommands    (*this, "vcmi.quickExchange" )
+{
+	readToVector("core.vcdesc",   "DATA/VCDESC.TXT"   );
+	readToVector("core.lcdesc",   "DATA/LCDESC.TXT"   );
+	readToVector("core.tcommand", "DATA/TCOMMAND.TXT" );
+	readToVector("core.hallinfo", "DATA/HALLINFO.TXT" );
+	readToVector("core.castinfo", "DATA/CASTINFO.TXT" );
+	readToVector("core.advevent", "DATA/ADVEVENT.TXT" );
+	readToVector("core.xtrainfo", "DATA/XTRAINFO.TXT" );
+	readToVector("core.restypes", "DATA/RESTYPES.TXT" );
+	readToVector("core.terrname", "DATA/TERRNAME.TXT" );
+	readToVector("core.randsign", "DATA/RANDSIGN.TXT" );
+	readToVector("core.crgen1",   "DATA/CRGEN1.TXT"   );
+	readToVector("core.crgen4",   "DATA/CRGEN4.TXT"   );
+	readToVector("core.overview", "DATA/OVERVIEW.TXT" );
+	readToVector("core.arraytxt", "DATA/ARRAYTXT.TXT" );
+	readToVector("core.priskill", "DATA/PRISKILL.TXT" );
+	readToVector("core.jktext",   "DATA/JKTEXT.TXT"   );
+	readToVector("core.tvrninfo", "DATA/TVRNINFO.TXT" );
+	readToVector("core.randtvrn", "DATA/RANDTVRN.TXT" );
+	readToVector("core.turndur",  "DATA/TURNDUR.TXT"  );
+	readToVector("core.heroscrn", "DATA/HEROSCRN.TXT" );
+	readToVector("core.tentcolr", "DATA/TENTCOLR.TXT" );
+	readToVector("core.skilllev", "DATA/SKILLLEV.TXT" );
+	readToVector("core.cmpmusic", "DATA/CMPMUSIC.TXT" );
+	readToVector("core.minename", "DATA/MINENAME.TXT" );
+	readToVector("core.mineevnt", "DATA/MINEEVNT.TXT" );
 
 	static const char * QE_MOD_COMMANDS = "DATA/QECOMMANDS.TXT";
 	if (CResourceHandler::get()->existsResource(ResourceID(QE_MOD_COMMANDS, EResType::TEXT)))
-		readToVector(QE_MOD_COMMANDS, qeModCommands);
+		readToVector("vcmi.quickExchange", QE_MOD_COMMANDS);
 
-	localizedTexts = JsonNode(ResourceID("config/translate.json", EResType::TEXT));
+	auto vcmiTexts = JsonNode(ResourceID("config/translate.json", EResType::TEXT));
+
+	for ( auto const & node : vcmiTexts.Struct())
+		registerString(node.first, node.second.String());
 
 	{
 		CLegacyConfigParser parser("DATA/GENRLTXT.TXT");
@@ -359,40 +419,34 @@ CGeneralTextHandler::CGeneralTextHandler()
 		do
 		{
 			allTexts.push_back(parser.readString());
+			registerH3String("core.genrltxt", allTexts.size(), allTexts.back());
 		}
 		while (parser.endLine());
 	}
 	{
 		CLegacyConfigParser parser("DATA/HELP.TXT");
+		size_t index = 0;
 		do
 		{
 			std::string first = parser.readString();
 			std::string second = parser.readString();
-			zelp.push_back(std::make_pair(first, second));
+			registerString("core.help." + std::to_string(index) + ".label", first);
+			registerString("core.help." + std::to_string(index) + ".help",  second);
+			index += 1;
 		}
 		while (parser.endLine());
 	}
 	{
-		CLegacyConfigParser nameParser("DATA/MINENAME.TXT");
-		CLegacyConfigParser eventParser("DATA/MINEEVNT.TXT");
-
-		do
-		{
-			std::string name  = nameParser.readString();
-			std::string event = eventParser.readString();
-			mines.push_back(std::make_pair(name, event));
-		}
-		while (nameParser.endLine() && eventParser.endLine());
-	}
-	{
 		CLegacyConfigParser parser("DATA/PLCOLORS.TXT");
+		size_t index = 0;
 		do
 		{
 			std::string color = parser.readString();
-			colors.push_back(color);
 
+			registerH3String("core.plcolors", index, color);
 			color[0] = toupper(color[0]);
-			capColors.push_back(color);
+			registerH3String("vcmi.capitalColors", index, color);
+			index += 1;
 		}
 		while (parser.endLine());
 	}
@@ -403,7 +457,10 @@ CGeneralTextHandler::CGeneralTextHandler()
 		parser.endLine();
 
 		for (int i = 0; i < 6; ++i)
+		{
 			seerEmpty.push_back(parser.readString());
+			registerH3String("core.seerhut.empty", seerEmpty.size(), seerEmpty.back());
+		}
 		parser.endLine();
 
 		quests.resize(10);
@@ -414,7 +471,11 @@ CGeneralTextHandler::CGeneralTextHandler()
 			{
 				parser.readString(); //front description
 				for (int k = 0; k < 6; ++k)
+				{
 					quests[i][j].push_back(parser.readString());
+
+					registerH3String("core.seerhut.quest." + std::to_string(i) + "." + std::to_string(j), k, quests[i][j].back());
+				}
 
 				parser.endLine();
 			}
@@ -521,5 +582,42 @@ int32_t CGeneralTextHandler::pluralText(const int32_t textIndex, const int32_t c
 	else
 		return textIndex + 1;
 }
+
+std::vector<std::string> CGeneralTextHandler::findStringsWithPrefix(std::string const & prefix)
+{
+	std::vector<std::string> result;
+
+	for (auto const & entry : stringsLocalizations)
+	{
+		if (boost::algorithm::starts_with(entry.first, prefix))
+			result.push_back(entry.first);
+	}
+
+	return result;
+}
+
+LegacyTextContainer::LegacyTextContainer(CGeneralTextHandler & owner, std::string const & basePath):
+	owner(owner),
+	basePath(basePath)
+{}
+
+const std::string & LegacyTextContainer::operator[](size_t index) const
+{
+	return owner.translate(basePath + "." + std::to_string(index));
+}
+
+LegacyHelpContainer::LegacyHelpContainer(CGeneralTextHandler & owner, std::string const & basePath):
+	owner(owner),
+	basePath(basePath)
+{}
+
+std::pair<std::string, std::string> LegacyHelpContainer::operator[](size_t index) const
+{
+	return {
+		owner.translate(basePath + "." + std::to_string(index) + ".label"),
+		owner.translate(basePath + "." + std::to_string(index) + ".help")
+	};
+}
+
 
 VCMI_LIB_NAMESPACE_END

--- a/lib/CGeneralTextHandler.cpp
+++ b/lib/CGeneralTextHandler.cpp
@@ -603,7 +603,7 @@ LegacyTextContainer::LegacyTextContainer(CGeneralTextHandler & owner, std::strin
 	basePath(basePath)
 {}
 
-const std::string & LegacyTextContainer::operator[](size_t index) const
+std::string LegacyTextContainer::operator[](size_t index) const
 {
 	return owner.translate(basePath, index);
 }

--- a/lib/CGeneralTextHandler.h
+++ b/lib/CGeneralTextHandler.h
@@ -91,50 +91,94 @@ public:
 	CLegacyConfigParser(const std::unique_ptr<CInputStream> & input);
 };
 
-class DLL_LINKAGE CGeneralTextHandler //Handles general texts
+class CGeneralTextHandler;
+
+class DLL_LINKAGE LegacyTextContainer
 {
+	CGeneralTextHandler & owner;
+	std::string basePath;
+
 public:
-	JsonNode localizedTexts;
+	LegacyTextContainer(CGeneralTextHandler & owner, std::string const & basePath);
+	const std::string & operator[](size_t index) const;
+};
+
+class DLL_LINKAGE LegacyHelpContainer
+{
+	CGeneralTextHandler & owner;
+	std::string basePath;
+
+public:
+	LegacyHelpContainer(CGeneralTextHandler & owner, std::string const & basePath);
+	std::pair<std::string, std::string> operator[](size_t index) const;
+};
+
+/// Handles all text-related data in game
+class DLL_LINKAGE CGeneralTextHandler
+{
+	/// map identifier -> localization
+	std::unordered_map<std::string, std::string> stringsLocalizations;
+
+	/// map localization -> identifier
+	std::unordered_map<std::string, std::string> stringsIdentifiers;
+
+	/// add selected string to internal storage
+	void registerString(const std::string & UID, const std::string & localized);
+	void registerH3String(const std::string & file, size_t index, const std::string & localized);
+
+	void readToVector(std::string sourceID, std::string sourceName);
+
+public:
+	/// returns translated version of a string that can be displayed to user
+	const std::string & translate(const std::string & identifier) const;
+
+	/// returns translated version of a string that can be displayed to user, H3-array compatibility version
+	const std::string & translate(const std::string & identifier, size_t index) const;
+
+	/// converts translated string into locale-independent text that can be sent to another client
+	const std::string & serialize(const std::string & identifier) const;
+
+	/// converts identifier into user-readable string, may be identical to 'translate' but reserved for serialization calls
+	const std::string & deserialize(const std::string & identifier) const;
 
 	std::vector<std::string> allTexts;
 
-	std::vector<std::string> arraytxt;
-	std::vector<std::string> primarySkillNames;
-	std::vector<std::string> jktexts;
-	std::vector<std::string> heroscrn;
-	std::vector<std::string> overview;//text for Kingdom Overview window
-	std::vector<std::string> colors; //names of player colors ("red",...)
-	std::vector<std::string> capColors; //names of player colors with first letter capitalized ("Red",...)
-	std::vector<std::string> turnDurations; //turn durations for pregame (1 Minute ... Unlimited)
+	LegacyTextContainer arraytxt;
+	LegacyTextContainer primarySkillNames;
+	LegacyTextContainer jktexts;
+	LegacyTextContainer heroscrn;
+	LegacyTextContainer overview;//text for Kingdom Overview window
+	LegacyTextContainer colors; //names of player colors ("red",...)
+	LegacyTextContainer capColors; //names of player colors with first letter capitalized ("Red",...)
+	LegacyTextContainer turnDurations; //turn durations for pregame (1 Minute ... Unlimited)
 
 	//towns
-	std::vector<std::string> tcommands, hcommands, fcommands; //texts for town screen, town hall screen and fort screen
-	std::vector<std::string> tavernInfo;
-	std::vector<std::string> tavernRumors;
+	LegacyTextContainer tcommands, hcommands, fcommands; //texts for town screen, town hall screen and fort screen
+	LegacyTextContainer tavernInfo;
+	LegacyTextContainer tavernRumors;
 
-	std::vector<std::string> qeModCommands;
+	LegacyTextContainer qeModCommands;
 
-	std::vector<std::pair<std::string,std::string>> zelp;
-	std::vector<std::string> lossCondtions;
-	std::vector<std::string> victoryConditions;
+	LegacyHelpContainer zelp;
+	LegacyTextContainer lossCondtions;
+	LegacyTextContainer victoryConditions;
 
 	//objects
-	std::vector<std::string> creGens; //names of creatures' generators
-	std::vector<std::string> creGens4; //names of multiple creatures' generators
-	std::vector<std::string> advobtxt;
-	std::vector<std::string> xtrainfo;
-	std::vector<std::string> restypes; //names of resources
-	std::map<TerrainId, std::string> terrainNames;
-	std::vector<std::string> randsign;
-	std::vector<std::pair<std::string,std::string>> mines; //first - name; second - event description
+	LegacyTextContainer creGens; //names of creatures' generators
+	LegacyTextContainer creGens4; //names of multiple creatures' generators
+	LegacyTextContainer advobtxt;
+	LegacyTextContainer xtrainfo;
+	LegacyTextContainer restypes; //names of resources
+	LegacyTextContainer terrainNames;
+	LegacyTextContainer randsign;
 	std::vector<std::string> seerEmpty;
 	std::vector<std::vector<std::vector<std::string>>>  quests; //[quest][type][index]
 	//type: quest, progress, complete, rollover, log OR time limit //index: 0-2 seer hut, 3-5 border guard
 	std::vector<std::string> seerNames;
-	std::vector<std::string> tentColors;
+	LegacyTextContainer tentColors;
 
 	//sec skills
-	std::vector<std::string> levels;
+	LegacyTextContainer levels;
 	std::vector<std::string> zcrexp; //more or less useful content of that file
 	//commanders
 	std::vector<std::string> znpc00; //more or less useful content of that file
@@ -143,7 +187,7 @@ public:
 	std::vector<std::string> campaignMapNames;
 	std::vector<std::vector<std::string>> campaignRegionNames;
 
-	static void readToVector(std::string sourceName, std::vector<std::string> &dest);
+	std::vector<std::string> findStringsWithPrefix(std::string const & prefix);
 
 	int32_t pluralText(const int32_t textIndex, const int32_t count) const;
 

--- a/lib/CGeneralTextHandler.h
+++ b/lib/CGeneralTextHandler.h
@@ -204,8 +204,6 @@ public:
 	LegacyTextContainer victoryConditions;
 
 	//objects
-	LegacyTextContainer creGens; //names of creatures' generators
-	LegacyTextContainer creGens4; //names of multiple creatures' generators
 	LegacyTextContainer advobtxt;
 	LegacyTextContainer xtrainfo;
 	LegacyTextContainer restypes; //names of resources

--- a/lib/CGeneralTextHandler.h
+++ b/lib/CGeneralTextHandler.h
@@ -93,6 +93,7 @@ public:
 
 class CGeneralTextHandler;
 
+/// Small wrapper that provides text access API compatible with old code
 class DLL_LINKAGE LegacyTextContainer
 {
 	CGeneralTextHandler & owner;
@@ -103,6 +104,7 @@ public:
 	const std::string & operator[](size_t index) const;
 };
 
+/// Small wrapper that provides help text access API compatible with old code
 class DLL_LINKAGE LegacyHelpContainer
 {
 	CGeneralTextHandler & owner;
@@ -141,7 +143,10 @@ public:
 	/// converts identifier into user-readable string, may be identical to 'translate' but reserved for serialization calls
 	const std::string & deserialize(const std::string & identifier) const;
 
-	std::vector<std::string> allTexts;
+	/// Debug methods, dumps all currently known texts into console using Json-like format
+	void dumpAllTexts();
+
+	LegacyTextContainer allTexts;
 
 	LegacyTextContainer arraytxt;
 	LegacyTextContainer primarySkillNames;
@@ -171,10 +176,8 @@ public:
 	LegacyTextContainer restypes; //names of resources
 	LegacyTextContainer terrainNames;
 	LegacyTextContainer randsign;
-	std::vector<std::string> seerEmpty;
-	std::vector<std::vector<std::vector<std::string>>>  quests; //[quest][type][index]
-	//type: quest, progress, complete, rollover, log OR time limit //index: 0-2 seer hut, 3-5 border guard
-	std::vector<std::string> seerNames;
+	LegacyTextContainer seerEmpty;
+	LegacyTextContainer seerNames;
 	LegacyTextContainer tentColors;
 
 	//sec skills

--- a/lib/CGeneralTextHandler.h
+++ b/lib/CGeneralTextHandler.h
@@ -115,6 +115,34 @@ public:
 	std::pair<std::string, std::string> operator[](size_t index) const;
 };
 
+class TextIdentifier
+{
+	std::string identifier;
+public:
+	std::string const & get() const
+	{
+		return identifier;
+	}
+
+	TextIdentifier(const char * id):
+		identifier(id)
+	{}
+
+	TextIdentifier(std::string const & id):
+		identifier(id)
+	{}
+
+	template<typename ... T>
+	TextIdentifier(std::string const & id, size_t index, T ... rest):
+		TextIdentifier(id + '.' + std::to_string(index), rest ... )
+	{}
+
+	template<typename ... T>
+	TextIdentifier(std::string const & id, std::string const & id2, T ... rest):
+		TextIdentifier(id + '.' + id2, rest ... )
+	{}
+};
+
 /// Handles all text-related data in game
 class DLL_LINKAGE CGeneralTextHandler
 {
@@ -124,30 +152,31 @@ class DLL_LINKAGE CGeneralTextHandler
 	/// map localization -> identifier
 	std::unordered_map<std::string, std::string> stringsIdentifiers;
 
-	/// add selected string to internal storage
-	void registerString(const std::string & UID, const std::string & localized);
-	void registerH3String(const std::string & file, size_t index, const std::string & localized);
-
-	void readToVector(std::string sourceID, std::string sourceName);
+	void readToVector(const std::string & sourceID, const std::string & sourceName);
 
 	/// number of scenarios in specific campaign. TODO: move to a better location
 	std::vector<size_t> scenariosCountPerCampaign;
 public:
+	/// add selected string to internal storage
+	void registerString(const TextIdentifier & UID, const std::string & localized);
+
 	// returns true if identifier with such name was registered, even if not translated to current language
 	// not required right now, can be added if necessary
 	// bool identifierExists( const std::string identifier) const;
 
 	/// returns translated version of a string that can be displayed to user
-	const std::string & translate(const std::string & identifier) const;
-
-	/// returns translated version of a string that can be displayed to user, H3-array compatibility version
-	const std::string & translate(const std::string & identifier, size_t index) const;
+	template<typename  ... Args>
+	const std::string & translate(std::string arg1, Args ... args) const
+	{
+		TextIdentifier id(arg1, args ...);
+		return deserialize(id);
+	}
 
 	/// converts translated string into locale-independent text that can be sent to another client
 	const std::string & serialize(const std::string & identifier) const;
 
-	/// converts identifier into user-readable string, may be identical to 'translate' but reserved for serialization calls
-	const std::string & deserialize(const std::string & identifier) const;
+	/// converts identifier into user-readable string
+	const std::string & deserialize(const TextIdentifier & identifier) const;
 
 	/// Debug method, dumps all currently known texts into console using Json-like format
 	void dumpAllTexts();

--- a/lib/CGeneralTextHandler.h
+++ b/lib/CGeneralTextHandler.h
@@ -101,7 +101,7 @@ class DLL_LINKAGE LegacyTextContainer
 
 public:
 	LegacyTextContainer(CGeneralTextHandler & owner, std::string const & basePath);
-	const std::string & operator[](size_t index) const;
+	std::string operator [](size_t index) const;
 };
 
 /// Small wrapper that provides help text access API compatible with old code
@@ -166,7 +166,7 @@ public:
 
 	/// returns translated version of a string that can be displayed to user
 	template<typename  ... Args>
-	const std::string & translate(std::string arg1, Args ... args) const
+	std::string translate(std::string arg1, Args ... args) const
 	{
 		TextIdentifier id(arg1, args ...);
 		return deserialize(id);

--- a/lib/CGeneralTextHandler.h
+++ b/lib/CGeneralTextHandler.h
@@ -130,7 +130,13 @@ class DLL_LINKAGE CGeneralTextHandler
 
 	void readToVector(std::string sourceID, std::string sourceName);
 
+	/// number of scenarios in specific campaign. TODO: move to a better location
+	std::vector<size_t> scenariosCountPerCampaign;
 public:
+	// returns true if identifier with such name was registered, even if not translated to current language
+	// not required right now, can be added if necessary
+	// bool identifierExists( const std::string identifier) const;
+
 	/// returns translated version of a string that can be displayed to user
 	const std::string & translate(const std::string & identifier) const;
 
@@ -143,7 +149,7 @@ public:
 	/// converts identifier into user-readable string, may be identical to 'translate' but reserved for serialization calls
 	const std::string & deserialize(const std::string & identifier) const;
 
-	/// Debug methods, dumps all currently known texts into console using Json-like format
+	/// Debug method, dumps all currently known texts into console using Json-like format
 	void dumpAllTexts();
 
 	LegacyTextContainer allTexts;
@@ -182,17 +188,14 @@ public:
 
 	//sec skills
 	LegacyTextContainer levels;
-	std::vector<std::string> zcrexp; //more or less useful content of that file
 	//commanders
-	std::vector<std::string> znpc00; //more or less useful content of that file
-
-	//campaigns
-	std::vector<std::string> campaignMapNames;
-	std::vector<std::vector<std::string>> campaignRegionNames;
+	LegacyTextContainer znpc00; //more or less useful content of that file
 
 	std::vector<std::string> findStringsWithPrefix(std::string const & prefix);
 
 	int32_t pluralText(const int32_t textIndex, const int32_t count) const;
+
+	size_t getCampaignLength(size_t campaignID) const;
 
 	CGeneralTextHandler();
 	CGeneralTextHandler(const CGeneralTextHandler&) = delete;

--- a/lib/LogicalExpression.cpp
+++ b/lib/LogicalExpression.cpp
@@ -19,7 +19,7 @@ VCMI_LIB_NAMESPACE_BEGIN
 std::string LogicalExpressionDetail::getTextForOperator(std::string operation)
 {
 	//placed in cpp mostly to avoid unnecessary includes in header
-	return VLC->generaltexth->localizedTexts["logicalExpressions"][operation].String();
+	return VLC->generaltexth->translate("vcmi.logicalExpressions." + operation);
 }
 
 VCMI_LIB_NAMESPACE_END

--- a/lib/mapObjects/CBank.cpp
+++ b/lib/mapObjects/CBank.cpp
@@ -24,7 +24,7 @@
 VCMI_LIB_NAMESPACE_BEGIN
 
 ///helpers
-static std::string & visitedTxt(const bool visited)
+static const std::string & visitedTxt(const bool visited)
 {
 	int id = visited ? 352 : 353;
 	return VLC->generaltexth->allTexts[id];

--- a/lib/mapObjects/CBank.cpp
+++ b/lib/mapObjects/CBank.cpp
@@ -24,7 +24,7 @@
 VCMI_LIB_NAMESPACE_BEGIN
 
 ///helpers
-static const std::string & visitedTxt(const bool visited)
+static std::string visitedTxt(const bool visited)
 {
 	int id = visited ? 352 : 353;
 	return VLC->generaltexth->allTexts[id];

--- a/lib/mapObjects/CGTownInstance.cpp
+++ b/lib/mapObjects/CGTownInstance.cpp
@@ -1815,22 +1815,22 @@ const std::string CGTownBuilding::getVisitingBonusGreeting() const
 	switch(bType)
 	{
 	case BuildingSubID::MANA_VORTEX:
-		bonusGreeting = std::string(VLC->generaltexth->localizedTexts["townHall"]["greetingManaVortex"].String());
+		bonusGreeting = std::string(VLC->generaltexth->translate("vcmi.townHall.greetingManaVortex"));
 		break;
 	case BuildingSubID::KNOWLEDGE_VISITING_BONUS:
-		bonusGreeting = std::string(VLC->generaltexth->localizedTexts["townHall"]["greetingKnowledge"].String());
+		bonusGreeting = std::string(VLC->generaltexth->translate("vcmi.townHall.greetingKnowledge"));
 		break;
 	case BuildingSubID::SPELL_POWER_VISITING_BONUS:
-		bonusGreeting = std::string(VLC->generaltexth->localizedTexts["townHall"]["greetingSpellPower"].String());
+		bonusGreeting = std::string(VLC->generaltexth->translate("vcmi.townHall.greetingSpellPower"));
 		break;
 	case BuildingSubID::ATTACK_VISITING_BONUS:
-		bonusGreeting = std::string(VLC->generaltexth->localizedTexts["townHall"]["greetingAttack"].String());
+		bonusGreeting = std::string(VLC->generaltexth->translate("vcmi.townHall.greetingAttack"));
 		break;
 	case BuildingSubID::EXPERIENCE_VISITING_BONUS:
-		bonusGreeting = std::string(VLC->generaltexth->localizedTexts["townHall"]["greetingExperience"].String());
+		bonusGreeting = std::string(VLC->generaltexth->translate("vcmi.townHall.greetingExperience"));
 		break;
 	case BuildingSubID::DEFENSE_VISITING_BONUS:
-		bonusGreeting = std::string(VLC->generaltexth->localizedTexts["townHall"]["greetingDefence"].String());
+		bonusGreeting = std::string(VLC->generaltexth->translate("vcmi.townHall.greetingDefence"));
 		break;
 	}
 	auto buildingName = town->town->getSpecialBuilding(bType)->Name();
@@ -1849,12 +1849,12 @@ const std::string CGTownBuilding::getCustomBonusGreeting(const Bonus & bonus) co
 {
 	if(bonus.type == Bonus::TOWN_MAGIC_WELL)
 	{
-		auto bonusGreeting = std::string(VLC->generaltexth->localizedTexts["townHall"]["greetingInTownMagicWell"].String());
+		auto bonusGreeting = std::string(VLC->generaltexth->translate("vcmi.townHall.greetingInTownMagicWell"));
 		auto buildingName = town->town->getSpecialBuilding(bType)->Name();
 		boost::algorithm::replace_first(bonusGreeting, "%s", buildingName);
 		return bonusGreeting;
 	}
-	auto bonusGreeting = std::string(VLC->generaltexth->localizedTexts["townHall"]["greetingCustomBonus"].String()); //"%s gives you +%d %s%s"
+	auto bonusGreeting = std::string(VLC->generaltexth->translate("vcmi.townHall.greetingCustomBonus")); //"%s gives you +%d %s%s"
 	std::string param = "";
 	std::string until = "";
 
@@ -1864,7 +1864,7 @@ const std::string CGTownBuilding::getCustomBonusGreeting(const Bonus & bonus) co
 		param = VLC->generaltexth->allTexts[385];
 
 	until = bonus.duration == (ui16)Bonus::ONE_BATTLE
-		? VLC->generaltexth->localizedTexts["townHall"]["greetingCustomUntil"].String() : ".";
+		? VLC->generaltexth->translate("vcmi.townHall.greetingCustomUntil") : ".";
 
 	boost::format fmt = boost::format(bonusGreeting) % bonus.description % bonus.val % param % until;
 	std::string greeting = fmt.str();

--- a/lib/mapObjects/CQuest.cpp
+++ b/lib/mapObjects/CQuest.cpp
@@ -56,7 +56,7 @@ static void showInfoDialog(const CGHeroInstance* h, const ui32 txtID, const ui16
 	showInfoDialog(playerID,txtID,soundID);
 }
 
-static const std::string & visitedTxt(const bool visited)
+static std::string visitedTxt(const bool visited)
 {
 	int id = visited ? 352 : 353;
 	return VLC->generaltexth->allTexts[id];

--- a/lib/mapObjects/CQuest.cpp
+++ b/lib/mapObjects/CQuest.cpp
@@ -78,7 +78,7 @@ const std::string & CQuest::missionName(CQuest::Emission mission)
 		"keymaster"
 	};
 
-	if (static_cast<size_t>(mission) < names.size())
+	if(static_cast<size_t>(mission) < names.size())
 		return names[static_cast<size_t>(mission)];
 	return names[0];
 }
@@ -93,7 +93,7 @@ const std::string & CQuest::missionState(int state)
 		"description",
 	};
 
-	if (state < states.size())
+	if(state < states.size())
 		return states[state];
 	return states[0];
 }

--- a/lib/mapObjects/CQuest.cpp
+++ b/lib/mapObjects/CQuest.cpp
@@ -56,10 +56,46 @@ static void showInfoDialog(const CGHeroInstance* h, const ui32 txtID, const ui16
 	showInfoDialog(playerID,txtID,soundID);
 }
 
-static std::string & visitedTxt(const bool visited)
+static const std::string & visitedTxt(const bool visited)
 {
 	int id = visited ? 352 : 353;
 	return VLC->generaltexth->allTexts[id];
+}
+
+const std::string & CQuest::missionName(CQuest::Emission mission)
+{
+	static const std::array<std::string, 11> names = {
+		"empty",
+		"heroLevel",
+		"primarySkill",
+		"killHero",
+		"killCreature",
+		"bringArt",
+		"bringCreature",
+		"bringResources",
+		"bringHero",
+		"bringPlayer",
+		"keymaster,"
+	};
+
+	if (static_cast<size_t>(mission) < names.size())
+		return names[static_cast<size_t>(mission)];
+	return names[0];
+}
+
+const std::string & CQuest::missionState(int state)
+{
+	static const std::array<std::string, 5> states = {
+		"receive",
+		"visit",
+		"complete",
+		"hover",
+		"description",
+	};
+
+	if (state < states.size())
+		return states[state];
+	return states[0];
 }
 
 bool CQuest::checkMissionArmy(const CQuest * q, const CCreatureSet * army)
@@ -264,7 +300,10 @@ void CQuest::getRolloverText(MetaString &ms, bool onHover) const
 	if(onHover)
 		ms << "\n\n";
 
-	ms << VLC->generaltexth->quests[missionType-1][onHover ? 3 : 4][textOption];
+	std::string questName  = missionName(Emission(missionType-1));
+	std::string questState = missionState(onHover ? 3 : 4);
+
+	ms << VLC->generaltexth->translate("core.seerhut.quest." + questName + "." + questState,textOption);
 
 	switch(missionType)
 	{
@@ -535,7 +574,9 @@ void CGSeerHut::setObjToKill()
 
 void CGSeerHut::init(CRandomGenerator & rand)
 {
-	seerName = *RandomGeneratorUtil::nextItem(VLC->generaltexth->seerNames, rand);
+	auto names = VLC->generaltexth->findStringsWithPrefix("core.seerhut.names");
+
+	seerName = *RandomGeneratorUtil::nextItem(names, rand);
 	quest->textOption = rand.nextInt(2);
 	quest->completedOption = rand.nextInt(1, 3);
 }
@@ -547,12 +588,14 @@ void CGSeerHut::initObj(CRandomGenerator & rand)
 	quest->progress = CQuest::NOT_ACTIVE;
 	if(quest->missionType)
 	{
+		std::string questName  = quest->missionName(CQuest::Emission(quest->missionType-1));
+
 		if(!quest->isCustomFirst)
-			quest->firstVisitText = VLC->generaltexth->quests[quest->missionType-1][0][quest->textOption];
+			quest->firstVisitText = VLC->generaltexth->translate("core.seerhut.quest." + questName + "." + quest->missionState(0), quest->textOption);
 		if(!quest->isCustomNext)
-			quest->nextVisitText = VLC->generaltexth->quests[quest->missionType-1][1][quest->textOption];
+			quest->nextVisitText = VLC->generaltexth->translate("core.seerhut.quest." + questName + "." + quest->missionState(1), quest->textOption);
 		if(!quest->isCustomComplete)
-			quest->completedText = VLC->generaltexth->quests[quest->missionType-1][2][quest->textOption];
+			quest->completedText = VLC->generaltexth->translate("core.seerhut.quest." + questName + "." + quest->missionState(2), quest->textOption);
 	}
 	else
 	{

--- a/lib/mapObjects/CQuest.cpp
+++ b/lib/mapObjects/CQuest.cpp
@@ -75,7 +75,7 @@ const std::string & CQuest::missionName(CQuest::Emission mission)
 		"bringResources",
 		"bringHero",
 		"bringPlayer",
-		"keymaster,"
+		"keymaster"
 	};
 
 	if (static_cast<size_t>(mission) < names.size())

--- a/lib/mapObjects/CQuest.cpp
+++ b/lib/mapObjects/CQuest.cpp
@@ -303,7 +303,7 @@ void CQuest::getRolloverText(MetaString &ms, bool onHover) const
 	std::string questName  = missionName(Emission(missionType-1));
 	std::string questState = missionState(onHover ? 3 : 4);
 
-	ms << VLC->generaltexth->translate("core.seerhut.quest." + questName + "." + questState,textOption);
+	ms << VLC->generaltexth->translate("core.seerhut.quest", questName, questState,textOption);
 
 	switch(missionType)
 	{

--- a/lib/mapObjects/CQuest.h
+++ b/lib/mapObjects/CQuest.h
@@ -24,9 +24,28 @@ class DLL_LINKAGE CQuest final
 	mutable std::unordered_map<ArtifactID, unsigned, ArtifactID::hash> artifactsRequirements; // artifact ID -> required count
 
 public:
-	enum Emission {MISSION_NONE = 0, MISSION_LEVEL = 1, MISSION_PRIMARY_STAT = 2, MISSION_KILL_HERO = 3, MISSION_KILL_CREATURE = 4,
-		MISSION_ART = 5, MISSION_ARMY = 6, MISSION_RESOURCES = 7, MISSION_HERO = 8, MISSION_PLAYER = 9, MISSION_KEYMASTER = 10};
-	enum Eprogress {NOT_ACTIVE, IN_PROGRESS, COMPLETE};
+	enum Emission {
+		MISSION_NONE = 0,
+		MISSION_LEVEL = 1,
+		MISSION_PRIMARY_STAT = 2,
+		MISSION_KILL_HERO = 3,
+		MISSION_KILL_CREATURE = 4,
+		MISSION_ART = 5,
+		MISSION_ARMY = 6,
+		MISSION_RESOURCES = 7,
+		MISSION_HERO = 8,
+		MISSION_PLAYER = 9,
+		MISSION_KEYMASTER = 10
+	};
+
+	enum Eprogress {
+		NOT_ACTIVE,
+		IN_PROGRESS,
+		COMPLETE
+	};
+
+	static const std::string  & missionName(Emission mission);
+	static const std::string  & missionState(int index);
 
 	si32 qid; //unique quest id for serialization / identification
 

--- a/lib/mapObjects/CRewardableObject.cpp
+++ b/lib/mapObjects/CRewardableObject.cpp
@@ -402,7 +402,7 @@ Component CRewardInfo::getDisplayedComponent(const CGHeroInstance * h) const
 }
 
 // FIXME: copy-pasted from CObjectHandler
-static std::string & visitedTxt(const bool visited)
+static const std::string & visitedTxt(const bool visited)
 {
 	int id = visited ? 352 : 353;
 	return VLC->generaltexth->allTexts[id];

--- a/lib/mapObjects/CRewardableObject.cpp
+++ b/lib/mapObjects/CRewardableObject.cpp
@@ -402,7 +402,7 @@ Component CRewardInfo::getDisplayedComponent(const CGHeroInstance * h) const
 }
 
 // FIXME: copy-pasted from CObjectHandler
-static const std::string & visitedTxt(const bool visited)
+static std::string visitedTxt(const bool visited)
 {
 	int id = visited ? 352 : 353;
 	return VLC->generaltexth->allTexts[id];

--- a/lib/mapObjects/MiscObjects.cpp
+++ b/lib/mapObjects/MiscObjects.cpp
@@ -58,7 +58,7 @@ static void showInfoDialog(const CGHeroInstance* h, const ui32 txtID, const ui16
 	showInfoDialog(playerID,txtID,soundID);
 }
 
-static std::string & visitedTxt(const bool visited)
+static const std::string & visitedTxt(const bool visited)
 {
 	int id = visited ? 352 : 353;
 	return VLC->generaltexth->allTexts[id];

--- a/lib/mapObjects/MiscObjects.cpp
+++ b/lib/mapObjects/MiscObjects.cpp
@@ -1687,7 +1687,8 @@ void CGSignBottle::initObj(CRandomGenerator & rand)
 	if(message.empty())
 	{
 		auto vector = VLC->generaltexth->findStringsWithPrefix("core.randsign");
-		message = *RandomGeneratorUtil::nextItem(vector, rand);
+		std::string messageIdentifier = *RandomGeneratorUtil::nextItem(vector, rand);
+		message = VLC->generaltexth->translate(messageIdentifier);
 	}
 
 	if(ID == Obj::OCEAN_BOTTLE)

--- a/lib/mapObjects/MiscObjects.cpp
+++ b/lib/mapObjects/MiscObjects.cpp
@@ -58,7 +58,7 @@ static void showInfoDialog(const CGHeroInstance* h, const ui32 txtID, const ui16
 	showInfoDialog(playerID,txtID,soundID);
 }
 
-static const std::string & visitedTxt(const bool visited)
+static std::string visitedTxt(const bool visited)
 {
 	int id = visited ? 352 : 353;
 	return VLC->generaltexth->allTexts[id];

--- a/lib/mapObjects/MiscObjects.cpp
+++ b/lib/mapObjects/MiscObjects.cpp
@@ -147,9 +147,8 @@ std::string CGCreature::getHoverText(const CGHeroInstance * hero) const
 		hoverName = getHoverText(hero->tempOwner);
 	}
 
-	const JsonNode & texts = VLC->generaltexth->localizedTexts["adventureMap"]["monsterThreat"];
+	hoverName += VLC->generaltexth->translate("vcmi.adventureMap.monsterThreat.title");
 
-	hoverName += texts["title"].String();
 	int choice;
 	double ratio = ((double)getArmyStrength() / hero->getTotalStrength());
 		 if (ratio < 0.1)  choice = 0;
@@ -164,7 +163,8 @@ std::string CGCreature::getHoverText(const CGHeroInstance * hero) const
 	else if (ratio < 8)    choice = 9;
 	else if (ratio < 20)   choice = 10;
 	else                   choice = 11;
-	hoverName += texts["levels"].Vector()[choice].String();
+
+	hoverName += VLC->generaltexth->translate("vcmi.adventureMap.monsterThreat.levels." + std::to_string(choice));
 	return hoverName;
 }
 
@@ -710,7 +710,7 @@ bool CGMine::isAbandoned() const
 
 std::string CGMine::getObjectName() const
 {
-	return VLC->generaltexth->mines.at(subID).first;
+	return VLC->generaltexth->translate("core.minename", subID);
 }
 
 std::string CGMine::getHoverText(PlayerColor player) const
@@ -1686,7 +1686,8 @@ void CGSignBottle::initObj(CRandomGenerator & rand)
 	//if no text is set than we pick random from the predefined ones
 	if(message.empty())
 	{
-		message = *RandomGeneratorUtil::nextItem(VLC->generaltexth->randsign, rand);
+		auto vector = VLC->generaltexth->findStringsWithPrefix("core.randsign");
+		message = *RandomGeneratorUtil::nextItem(vector, rand);
 	}
 
 	if(ID == Obj::OCEAN_BOTTLE)

--- a/lib/mapping/CCampaignHandler.cpp
+++ b/lib/mapping/CCampaignHandler.cpp
@@ -546,11 +546,7 @@ std::string CCampaignHandler::prologVideoName(ui8 index)
 std::string CCampaignHandler::prologMusicName(ui8 index)
 {
 	std::vector<std::string> music;
-
-	VLC->generaltexth->readToVector("Data/CmpMusic.txt", music);
-	if(index < music.size())
-		return music[index];
-	return "";
+	return VLC->generaltexth->translate("core.cmpmusic." + std::to_string(int(index)));
 }
 
 std::string CCampaignHandler::prologVoiceName(ui8 index)

--- a/lib/mapping/CCampaignHandler.cpp
+++ b/lib/mapping/CCampaignHandler.cpp
@@ -79,7 +79,7 @@ std::unique_ptr<CCampaign> CCampaignHandler::getCampaign( const std::string & na
 	ret->header = readHeaderFromMemory(reader);
 	ret->header.filename = name;
 
-	int howManyScenarios = static_cast<int>(VLC->generaltexth->campaignRegionNames[ret->header.mapVersion].size());
+	int howManyScenarios = static_cast<int>(VLC->generaltexth->getCampaignLength(ret->header.mapVersion));
 	for(int g=0; g<howManyScenarios; ++g)
 	{
 		CCampaignScenario sc = readScenarioFromMemory(reader, ret->header.version, ret->header.mapVersion);

--- a/lib/mapping/CCampaignHandler.h
+++ b/lib/mapping/CCampaignHandler.h
@@ -229,6 +229,8 @@ public:
 
 class DLL_LINKAGE CCampaignHandler
 {
+	std::vector<size_t> scenariosCountPerCampaign;
+
 	static CCampaignHeader readHeaderFromMemory(CBinaryReader & reader);
 	static CCampaignScenario readScenarioFromMemory(CBinaryReader & reader, int version, int mapVersion );
 	static CScenarioTravel readScenarioTravelFromMemory(CBinaryReader & reader, int version);

--- a/lib/spells/effects/Damage.cpp
+++ b/lib/spells/effects/Damage.cpp
@@ -179,7 +179,7 @@ void Damage::describeEffect(std::vector<MetaString> & log, const Mechanics * m, 
 		{
 			MetaString line;
 			//todo: handle newlines in metastring
-			std::string text = VLC->generaltexth->allTexts.at(343); //Does %d points of damage.
+			std::string text = VLC->generaltexth->allTexts[343]; //Does %d points of damage.
 			boost::algorithm::trim(text);
 			line << text;
 			line.addReplacement((int)damage); //no more text afterwards

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -2987,7 +2987,7 @@ bool CGameHandler::load(const std::string & filename)
 	catch(const CModHandler::Incompatibility & e)
 	{
 		logGlobal->error("Failed to load game: %s", e.what());
-		auto errorMsg = VLC->generaltexth->localizedTexts["server"]["errors"]["modsIncompatibility"].String() + '\n';
+		auto errorMsg = VLC->generaltexth->translate("vcmi.server.errors.modsIncompatibility") + '\n';
 		errorMsg += e.what();
 		lobby->announceMessage(errorMsg);
 		return false;

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -1300,7 +1300,7 @@ void CGameHandler::addGenericKilledLog(BattleLogMessage & blm, const CStack * de
 	if(killed > 0)
 	{
 		const int32_t txtIndex = (killed > 1) ? 379 : 378;
-		std::string formatString = VLC->generaltexth->allTexts.at(txtIndex);
+		std::string formatString = VLC->generaltexth->allTexts[txtIndex];
 
 		// these default h3 texts have unnecessary new lines, so get rid of them before displaying (and trim just in case, trimming newlines does not works for some reason)
 		formatString.erase(std::remove(formatString.begin(), formatString.end(), '\n'), formatString.end());
@@ -5209,7 +5209,7 @@ void CGameHandler::playerMessage(PlayerColor player, const std::string &message,
 
 	if (cheated)
 	{
-		SystemMessage temp_message(VLC->generaltexth->allTexts.at(260));
+		SystemMessage temp_message(VLC->generaltexth->allTexts[260]);
 		sendAndApply(&temp_message);
 
 		if(!player.isSpectator())


### PR DESCRIPTION
Yet another subtask of #1300 

Functionality:
- [x] Provide mechanism to translate data from H3 files via mods that is better than direct editing of H3 files
- [x] Integrate existing translate.json into H3 translation support

List of changes:
- all "simple" interface text files from H3 are now using unified identifiers access in form of `"core.{filename}.{string number}"`
- all "complex" interface text files also use unified identifiers, however exact string format depends on file content, e.g. help.txt uses `"core.help.{number}.{'help' or 'hover'}"`
- all vcmi texts from translate.json are now available in form `"vcmi.string_id_from_translate_json"`
- translate.json now uses simple key-value format without nested fields
- to avoid massive edits through all codebase, CGeneralTextHandler provides public members that emulate file-based access from before.