### PR TITLE
fix unaligned memory access when building with clang

### DIFF
--- a/client/gui/CAnimation.cpp
+++ b/client/gui/CAnimation.cpp
@@ -33,6 +33,7 @@ class CDefFile
 {
 private:
 
+	PACKED_STRUCT_BEGIN
 	struct SSpriteDef
 	{
 		ui32 size;
@@ -43,7 +44,7 @@ private:
 		ui32 height;
 		si32 leftMargin;
 		si32 topMargin;
-	} PACKED_STRUCT;
+	} PACKED_STRUCT_END;
 	//offset[group][frame] - offset of frame data in file
 	std::map<size_t, std::vector <size_t> > offset;
 

--- a/lib/vcmi_endian.h
+++ b/lib/vcmi_endian.h
@@ -9,7 +9,7 @@
  */
 #pragma once
 
-//FIXME:library file depends on SDL - make cause troubles
+//FIXME:library file depends on SDL - may cause troubles
 #include <SDL_endian.h>
 
 VCMI_LIB_NAMESPACE_BEGIN


### PR DESCRIPTION
Happens on client launch, found it with UBSAN. Sample report:

```
/Users/kambala/dev/vcmi/vcmi/client/gui/CAnimation.cpp:329:24: runtime error: load of misaligned address 0x62d0004b094f for type 'const ui32' (aka 'const unsigned int'), which requires 4 byte alignment
0x62d0004b094f: note: pointer points here
 70 63 78 00 fb  05 00 00 83 11 00 00 4f  14 00 00 80 7b 00 00 8e  16 00 00 c2 30 00 00 72  39 00 00
             ^ 
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /Users/kambala/dev/vcmi/vcmi/client/gui/CAnimation.cpp:329:24 in 

/Users/kambala/dev/vcmi/vcmi/client/gui/CAnimation.cpp:398:32: runtime error: load of misaligned address 0x62d0004b0a1b for type 'const ui32' (aka 'const unsigned int'), which requires 4 byte alignment
0x62d0004b0a1b: note: pointer points here
 00  00 00 00 48 00 00 00 4e  00 00 00 55 00 00 00 5d  00 00 00 66 00 00 00 70  00 00 00 7b 00 00 00
              ^ 
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /Users/kambala/dev/vcmi/vcmi/client/gui/CAnimation.cpp:398:32 in 

/Users/kambala/dev/vcmi/vcmi/client/gui/CAnimation.cpp:424:33: runtime error: load of misaligned address 0x62b00012da3b for type 'const ui16' (aka 'const unsigned short'), which requires 2 byte alignment
0x62b00012da3b: note: pointer points here
 04  00 00 00 2a 00 33 00 40  00 50 00 64 00 79 00 8e  00 a2 00 b6 00 c7 00 d5  00 e5 00 f8 00 0c 01
              ^ 
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /Users/kambala/dev/vcmi/vcmi/client/gui/CAnimation.cpp:424:33 in 

/Users/kambala/dev/vcmi/vcmi/client/gui/CAnimation.cpp:318:20: runtime error: load of misaligned address 0x6310011a8b31 for type 'const ui32' (aka 'const unsigned int'), which requires 4 byte alignment
0x6310011a8b31: note: pointer points here
 e5 1d 00  00 01 00 00 00 01 00 00  00 a0 07 7e 00 10 30 7e  00 61 68 30 30 5f 30 34  2e 70 63 78 00
              ^ 
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /Users/kambala/dev/vcmi/vcmi/client/gui/CAnimation.cpp:318:20 in 

/Users/kambala/dev/vcmi/vcmi/client/gui/CAnimation.cpp:320:25: runtime error: load of misaligned address 0x6310011a8b35 for type 'const ui32' (aka 'const unsigned int'), which requires 4 byte alignment
0x6310011a8b35: note: pointer points here
 01 00 00 00 01 00 00  00 a0 07 7e 00 10 30 7e  00 61 68 30 30 5f 30 34  2e 70 63 78 00 00 86 17  00
             ^ 
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /Users/kambala/dev/vcmi/vcmi/client/gui/CAnimation.cpp:320:25 in 

/Users/kambala/dev/vcmi/vcmi/client/gui/CAnimation.cpp:455:34: runtime error: load of misaligned address 0x6310011aa605 for type 'const ui16' (aka 'const unsigned short'), which requires 2 byte alignment
0x6310011aa605: note: pointer points here
 06 00 00 00 74 00 79  00 7e 00 83 00 88 00 8d  00 92 00 97 00 9c 00 a1  00 a6 00 ab 00 b0 00 b5  00
             ^ 
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /Users/kambala/dev/vcmi/vcmi/client/gui/CAnimation.cpp:455:34 in
```

My OS is macOS 12.6.2 (Intel). Could someone check if same issue applies to Linux-clang (and maybe macOS-ARM) as well or if I should restrict the condition to Apple-clang?