### PR TITLE
Fix tests + scripting compilation

### DIFF
--- a/lib/ScriptHandler.cpp
+++ b/lib/ScriptHandler.cpp
@@ -17,6 +17,7 @@
 
 #include "CGameInterface.h"
 #include "CScriptingModule.h"
+#include "CModHandler.h"
 
 #include "VCMIDirs.h"
 #include "serializer/JsonDeserializer.h"

--- a/scripting/lua/LuaScriptingContext.cpp
+++ b/scripting/lua/LuaScriptingContext.cpp
@@ -24,6 +24,7 @@
 #include "../../lib/filesystem/Filesystem.h"
 #include "../../lib/battle/IBattleInfoCallback.h"
 #include "../../lib/CGameInfoCallback.h"
+#include "../../lib/CModHandler.h"
 
 
 VCMI_LIB_NAMESPACE_BEGIN

--- a/test/entity/CArtifactTest.cpp
+++ b/test/entity/CArtifactTest.cpp
@@ -19,7 +19,7 @@ using namespace ::testing;
 class CArtifactTest : public Test
 {
 public:
-	MOCK_METHOD3(registarCb, void(int32_t, const std::string &, const std::string &));
+	MOCK_METHOD4(registarCb, void(int32_t, int32_t, const std::string &, const std::string &));
 
 protected:
 	std::shared_ptr<CArtifact> subject;
@@ -36,10 +36,10 @@ TEST_F(CArtifactTest, RegistersIcons)
 	subject->image = "Test1";
 	subject->large = "Test2";
 
-	auto cb = std::bind(&CArtifactTest::registarCb, this, _1, _2, _3);
+	auto cb = std::bind(&CArtifactTest::registarCb, this, _1, _2, _3, _4);
 
-	EXPECT_CALL(*this, registarCb(Eq(4242), "ARTIFACT", "Test1"));
-	EXPECT_CALL(*this, registarCb(Eq(4242), "ARTIFACTLARGE", "Test2"));
+	EXPECT_CALL(*this, registarCb(Eq(4242), Eq(0), "ARTIFACT", "Test1"));
+	EXPECT_CALL(*this, registarCb(Eq(4242), Eq(0), "ARTIFACTLARGE", "Test2"));
 
 	subject->registerIcons(cb);
 }

--- a/test/entity/CCreatureTest.cpp
+++ b/test/entity/CCreatureTest.cpp
@@ -19,7 +19,7 @@ using namespace ::testing;
 class CCreatureTest : public Test
 {
 public:
-	MOCK_METHOD3(registarCb, void(int32_t, const std::string &, const std::string &));
+	MOCK_METHOD4(registarCb, void(int32_t, int32_t, const std::string &, const std::string &));
 protected:
 	std::shared_ptr<CCreature> subject;
 
@@ -35,10 +35,10 @@ TEST_F(CCreatureTest, RegistersIcons)
 	subject->smallIconName = "Test1";
 	subject->largeIconName = "Test2";
 
-	auto cb = std::bind(&CCreatureTest::registarCb, this, _1, _2, _3);
+	auto cb = std::bind(&CCreatureTest::registarCb, this, _1, _2, _3, _4);
 
-	EXPECT_CALL(*this, registarCb(Eq(4242), "CPRSMALL", "Test1"));
-	EXPECT_CALL(*this, registarCb(Eq(4242), "TWCRPORT", "Test2"));
+	EXPECT_CALL(*this, registarCb(Eq(4242), Eq(0), "CPRSMALL", "Test1"));
+	EXPECT_CALL(*this, registarCb(Eq(4242), Eq(0), "TWCRPORT", "Test2"));
 
 	subject->registerIcons(cb);
 }

--- a/test/entity/CFactionTest.cpp
+++ b/test/entity/CFactionTest.cpp
@@ -19,7 +19,7 @@ using namespace ::testing;
 class CFactionTest : public Test
 {
 public:
-	MOCK_METHOD3(registarCb, void(int32_t, const std::string &, const std::string &));
+	MOCK_METHOD4(registarCb, void(int32_t, int32_t, const std::string &, const std::string &));
 
 protected:
 	std::shared_ptr<CFaction> subject;
@@ -41,13 +41,13 @@ TEST_F(CFactionTest, HasTown)
 
 TEST_F(CFactionTest, RegistersNoIconsIfNoTown)
 {
-	auto cb = std::bind(&CFactionTest::registarCb, this, _1, _2, _3);
+	auto cb = std::bind(&CFactionTest::registarCb, this, _1, _2, _3, _4);
 	subject->registerIcons(cb);
 }
 
 TEST_F(CFactionTest, RegistersIcons)
 {
-	auto cb = std::bind(&CFactionTest::registarCb, this, _1, _2, _3);
+	auto cb = std::bind(&CFactionTest::registarCb, this, _1, _2, _3, _4);
 
 	subject->town = new CTown();
 
@@ -69,15 +69,15 @@ TEST_F(CFactionTest, RegistersIcons)
 	info.iconSmall[1][1] = "Test40";
 
 
-	EXPECT_CALL(*this, registarCb(Eq(10), "ITPT", "Test1"));
-	EXPECT_CALL(*this, registarCb(Eq(11), "ITPT", "Test2"));
-	EXPECT_CALL(*this, registarCb(Eq(12), "ITPT", "Test3"));
-	EXPECT_CALL(*this, registarCb(Eq(13), "ITPT", "Test4"));
+	EXPECT_CALL(*this, registarCb(Eq(10), Eq(0), "ITPT", "Test1"));
+	EXPECT_CALL(*this, registarCb(Eq(11), Eq(0), "ITPT", "Test2"));
+	EXPECT_CALL(*this, registarCb(Eq(12), Eq(0), "ITPT", "Test3"));
+	EXPECT_CALL(*this, registarCb(Eq(13), Eq(0), "ITPT", "Test4"));
 
-	EXPECT_CALL(*this, registarCb(Eq(12), "ITPA", "Test10"));
-	EXPECT_CALL(*this, registarCb(Eq(13), "ITPA", "Test20"));
-	EXPECT_CALL(*this, registarCb(Eq(14), "ITPA", "Test30"));
-	EXPECT_CALL(*this, registarCb(Eq(15), "ITPA", "Test40"));
+	EXPECT_CALL(*this, registarCb(Eq(12), Eq(0), "ITPA", "Test10"));
+	EXPECT_CALL(*this, registarCb(Eq(13), Eq(0), "ITPA", "Test20"));
+	EXPECT_CALL(*this, registarCb(Eq(14), Eq(0), "ITPA", "Test30"));
+	EXPECT_CALL(*this, registarCb(Eq(15), Eq(0), "ITPA", "Test40"));
 
 	subject->registerIcons(cb);
 }

--- a/test/entity/CHeroClassTest.cpp
+++ b/test/entity/CHeroClassTest.cpp
@@ -19,7 +19,7 @@ using namespace ::testing;
 class CHeroClassTest : public Test
 {
 public:
-	MOCK_METHOD3(registarCb, void(int32_t, const std::string &, const std::string &));
+	MOCK_METHOD4(registarCb, void(int32_t, int32_t, const std::string &, const std::string &));
 
 protected:
 	std::shared_ptr<CHeroClass> subject;
@@ -32,7 +32,7 @@ protected:
 
 TEST_F(CHeroClassTest, RegistersIconsDoesNothing)
 {
-	auto cb = std::bind(&CHeroClassTest::registarCb, this, _1, _2, _3);
+	auto cb = std::bind(&CHeroClassTest::registarCb, this, _1, _2, _3, _4);
 	subject->registerIcons(cb);
 }
 

--- a/test/entity/CHeroTest.cpp
+++ b/test/entity/CHeroTest.cpp
@@ -19,7 +19,7 @@ using namespace ::testing;
 class CHeroTest : public Test
 {
 public:
-	MOCK_METHOD3(registarCb, void(int32_t, const std::string &, const std::string &));
+	MOCK_METHOD4(registarCb, void(int32_t, int32_t, const std::string &, const std::string &));
 
 protected:
 	std::shared_ptr<CHero> subject;
@@ -39,12 +39,12 @@ TEST_F(CHeroTest, RegistersIcons)
 	subject->portraitSmall = "Test3";
 	subject->portraitLarge = "Test4";
 
-	auto cb = std::bind(&CHeroTest::registarCb, this, _1, _2, _3);
+	auto cb = std::bind(&CHeroTest::registarCb, this, _1, _2, _3, _4);
 
-	EXPECT_CALL(*this, registarCb(Eq(4242), "UN32", "Test1"));
-	EXPECT_CALL(*this, registarCb(Eq(4242), "UN44", "Test2"));
-	EXPECT_CALL(*this, registarCb(Eq(4242), "PORTRAITSSMALL", "Test3"));
-	EXPECT_CALL(*this, registarCb(Eq(4242), "PORTRAITSLARGE", "Test4"));
+	EXPECT_CALL(*this, registarCb(Eq(4242), Eq(0), "UN32", "Test1"));
+	EXPECT_CALL(*this, registarCb(Eq(4242), Eq(0), "UN44", "Test2"));
+	EXPECT_CALL(*this, registarCb(Eq(4242), Eq(0), "PORTRAITSSMALL", "Test3"));
+	EXPECT_CALL(*this, registarCb(Eq(4242), Eq(0), "PORTRAITSLARGE", "Test4"));
 
 	subject->registerIcons(cb);
 }

--- a/test/entity/CSkillTest.cpp
+++ b/test/entity/CSkillTest.cpp
@@ -19,7 +19,7 @@ using namespace ::testing;
 class CSkillTest : public Test
 {
 public:
-	MOCK_METHOD3(registarCb, void(int32_t, const std::string &, const std::string &));
+	MOCK_METHOD4(registarCb, void(int32_t, int32_t, const std::string &, const std::string &));
 
 protected:
 	std::shared_ptr<CSkill> subject;
@@ -41,15 +41,15 @@ TEST_F(CSkillTest, RegistersIcons)
 		skillAtLevel.iconLarge = "TestL"+std::to_string(level);
 	}
 
-	auto cb = std::bind(&CSkillTest::registarCb, this, _1, _2, _3);
+	auto cb = std::bind(&CSkillTest::registarCb, this, _1, _2, _3, _4);
 
 	for(int level = 1; level <= 3; level++)
 	{
 		int frame = 2 + level + 3 * 42;
 
-		EXPECT_CALL(*this, registarCb(Eq(frame), "SECSK32", "TestS"+std::to_string(level)));
-		EXPECT_CALL(*this, registarCb(Eq(frame), "SECSKILL", "TestM"+std::to_string(level)));
-		EXPECT_CALL(*this, registarCb(Eq(frame), "SECSK82", "TestL"+std::to_string(level)));
+		EXPECT_CALL(*this, registarCb(Eq(frame), Eq(0), "SECSK32", "TestS"+std::to_string(level)));
+		EXPECT_CALL(*this, registarCb(Eq(frame), Eq(0), "SECSKILL", "TestM"+std::to_string(level)));
+		EXPECT_CALL(*this, registarCb(Eq(frame), Eq(0), "SECSK82", "TestL"+std::to_string(level)));
 	}
 
 	subject->registerIcons(cb);

--- a/test/erm/ERM_BU.cpp
+++ b/test/erm/ERM_BU.cpp
@@ -245,7 +245,6 @@ TEST_F(ERM_BU_S, Summon)
 
 	auto checkApply = [&](BattleUnitsChanged * pack)
 	{
-		EXPECT_TRUE(pack->customEffects.empty());
 		EXPECT_EQ(pack->changedStacks.size(), 1);
 
 		if(!pack->changedStacks.empty())

--- a/test/events/EventBusTest.cpp
+++ b/test/events/EventBusTest.cpp
@@ -28,7 +28,7 @@ public:
 public:
 	static SubscriptionRegistry<EventExample> * getRegistry()
 	{
-		static std::unique_ptr<SubscriptionRegistry<EventExample>> Instance = make_unique<SubscriptionRegistry<EventExample>>();
+		static std::unique_ptr<SubscriptionRegistry<EventExample>> Instance = std::make_unique<SubscriptionRegistry<EventExample>>();
 		return Instance.get();
 	}
 

--- a/test/map/CMapEditManagerTest.cpp
+++ b/test/map/CMapEditManagerTest.cpp
@@ -24,7 +24,7 @@ TEST(MapManager, DrawTerrain_Type)
 {
 	try
 	{
-		auto map = make_unique<CMap>();
+		auto map = std::make_unique<CMap>();
 		map->width = 52;
 		map->height = 52;
 		map->initTerrain();

--- a/test/mock/mock_battle_Unit.h
+++ b/test/mock/mock_battle_Unit.h
@@ -49,6 +49,7 @@ public:
 	MOCK_CONST_METHOD0(ableToRetaliate, bool());
 	MOCK_CONST_METHOD0(alive, bool());
 	MOCK_CONST_METHOD0(isGhost, bool());
+	MOCK_CONST_METHOD0(isFrozen, bool());
 	MOCK_CONST_METHOD1(isValidTarget, bool(bool));
 
 	MOCK_CONST_METHOD0(isClone, bool());

--- a/test/scripting/ScriptFixture.cpp
+++ b/test/scripting/ScriptFixture.cpp
@@ -8,6 +8,7 @@
  *
  */
 #include "StdInc.h"
+#include "lib/CModHandler.h"
 
 #include "ScriptFixture.h"
 

--- a/test/spells/CSpellTest.cpp
+++ b/test/spells/CSpellTest.cpp
@@ -19,7 +19,7 @@ using namespace ::testing;
 class CSpellTest : public Test
 {
 public:
-	MOCK_METHOD3(registarCb, void(int32_t, const std::string &, const std::string &));
+	MOCK_METHOD4(registarCb, void(int32_t, int32_t, const std::string &, const std::string &));
 	std::shared_ptr<CSpell> subject;
 protected:
 	void SetUp() override
@@ -36,12 +36,12 @@ TEST_F(CSpellTest, RegistersIcons)
 {
 	subject->id = SpellID(42);
 
-	auto cb = std::bind(&CSpellTest::registarCb, this, _1, _2, _3);
+	auto cb = std::bind(&CSpellTest::registarCb, this, _1, _2, _3, _4);
 
-	EXPECT_CALL(*this, registarCb(Eq(42), "SPELLS", "Test1"));
-	EXPECT_CALL(*this, registarCb(Eq(43), "SPELLINT", "Test2"));
-	EXPECT_CALL(*this, registarCb(Eq(42), "SPELLBON", "Test3"));
-	EXPECT_CALL(*this, registarCb(Eq(42), "SPELLSCR", "Test4"));
+	EXPECT_CALL(*this, registarCb(Eq(42), Eq(0), "SPELLS", "Test1"));
+	EXPECT_CALL(*this, registarCb(Eq(43), Eq(0), "SPELLINT", "Test2"));
+	EXPECT_CALL(*this, registarCb(Eq(42), Eq(0), "SPELLBON", "Test3"));
+	EXPECT_CALL(*this, registarCb(Eq(42), Eq(0), "SPELLSCR", "Test4"));
 
 	subject->registerIcons(cb);
 }

--- a/test/spells/effects/TimedTest.cpp
+++ b/test/spells/effects/TimedTest.cpp
@@ -12,6 +12,7 @@
 #include "EffectFixture.h"
 
 #include <vstd/RNG.h>
+#include "lib/CModHandler.h"
 
 namespace test
 {


### PR DESCRIPTION
As in title.

RegisterIcons tests got their parameters fixed to include change in amount of parameters
Removed CustomEffect check in summon test - support for CustomEffect was removed in #1229
Forward declarations for CModHandler are not enough in some places for some reason now
Added std:: in some places
Minor fixes were needed in mock classes to reflect method changes in their mock targets