### PR TITLE
Fixes patrol position initialization on H3M load

### DIFF
--- a/lib/mapObjects/CGHeroInstance.cpp
+++ b/lib/mapObjects/CGHeroInstance.cpp
@@ -319,6 +319,9 @@ void CGHeroInstance::initHero(CRandomGenerator & rand)
 	}
 	assert(validTypes());
 
+	if (patrol.patrolling)
+		patrol.initialPos = visitablePos();
+
 	if(exp == 0xffffffff)
 	{
 		initExp(rand);

--- a/lib/mapping/MapFormatH3M.cpp
+++ b/lib/mapping/MapFormatH3M.cpp
@@ -1657,15 +1657,7 @@ CGObjectInstance * CMapLoaderH3M::readHero(ObjectInstanceID idToBeGiven, const i
 	nhi->formation = reader.readUInt8();
 	loadArtifactsOfHero(nhi);
 	nhi->patrol.patrolRadius = reader.readUInt8();
-	if(nhi->patrol.patrolRadius == 0xff)
-	{
-		nhi->patrol.patrolling = false;
-	}
-	else
-	{
-		nhi->patrol.patrolling = true;
-		nhi->patrol.initialPos = nhi->convertToVisitablePos(initialPos);
-	}
+	nhi->patrol.patrolling = (nhi->patrol.patrolRadius != 0xff);
 
 	if(map->version > EMapFormat::ROE)
 	{


### PR DESCRIPTION
Fixes crash on loading Wayfarer map (and any other maps that have patrolling heroes)

Missed this case when removing convertPosition method from heroes