### PR TITLE
[beta] Changed Sirens behavior to match H3 logic

### DIFF
--- a/lib/mapObjects/MiscObjects.cpp
+++ b/lib/mapObjects/MiscObjects.cpp
@@ -1956,7 +1956,13 @@ void CGSirens::onHeroVisit( const CGHeroInstance * h ) const
 
 		for (auto i = h->Slots().begin(); i != h->Slots().end(); i++)
 		{
-			TQuantity drown = static_cast<TQuantity>(i->second->count * 0.3);
+			// 1-sized stacks are not affected by sirens
+			if (i->second->count == 1)
+				continue;
+
+			// tested H3 behavior: 30% (rounded up) of stack drowns
+			TQuantity drown = std::ceil(i->second->count * 0.3);
+
 			if(drown)
 			{
 				cb->changeStackCount(StackLocation(h, i->first), -drown);


### PR DESCRIPTION
After testing H3 I can confirm - vcmi formula is wrong.
Actual behavior:
70% (rounded down) of stack survives
or, in other words
30% (rounded up) of stack dies

exception - if stack consists of a single creature it will always survive