### PR TITLE
Do not allow selecting resolutions not supported by display

### DIFF
--- a/Mods/vcmi/config/vcmi/english.json
+++ b/Mods/vcmi/config/vcmi/english.json
@@ -31,6 +31,7 @@
 	"vcmi.systemOptions.resolutionButton.help"  : "{Select resolution}\n\n Change in-game screen resolution. Game restart required to apply new resolution.",
 	"vcmi.systemOptions.resolutionMenu.hover"   : "Select resolution",
 	"vcmi.systemOptions.resolutionMenu.help"    : "Change in-game screen resolution.",
+	"vcmi.systemOptions.fullscreenFailed"       : "{Fullscreen}\n\n Failed to switch to fullscreen mode! Current resolution is not supported by display!",
 
 	"vcmi.townHall.missingBase"             : "Base building %s must be built first",
 	"vcmi.townHall.noCreaturesToRecruit"    : "There are no creatures to recruit!",

--- a/client/renderSDL/SDL_Extensions.cpp
+++ b/client/renderSDL/SDL_Extensions.cpp
@@ -66,14 +66,6 @@ SDL_Color CSDL_Ext::toSDL(const ColorRGBA & color)
 	return result;
 }
 
-Rect CSDL_Ext::getDisplayBounds()
-{
-	SDL_Rect displayBounds;
-	SDL_GetDisplayBounds(std::max(0, SDL_GetWindowDisplayIndex(mainWindow)), &displayBounds);
-
-	return fromSDL(displayBounds);
-}
-
 void CSDL_Ext::setColors(SDL_Surface *surface, SDL_Color *colors, int firstcolor, int ncolors)
 {
 	SDL_SetPaletteColors(surface->format->palette,colors,firstcolor,ncolors);

--- a/client/renderSDL/SDL_Extensions.cpp
+++ b/client/renderSDL/SDL_Extensions.cpp
@@ -891,7 +891,42 @@ void CSDL_Ext::getClipRect(SDL_Surface * src, Rect & other)
 	other = CSDL_Ext::fromSDL(rect);
 }
 
+bool CSDL_Ext::isResolutionSupported(const std::vector<Point> & resolutions, const Point toTest )
+{
+#if defined(VCMI_ANDROID) || defined(VCMI_IOS)
+	// ios can use any resolution
+	// presumably, same goes for Android
+	return true;
+#else
+	// in fullscreen only resolutions supported by monitor can be used
+	return vstd::contains(resolutions, toTest);
+#endif
+}
 
+std::vector<Point> CSDL_Ext::getSupportedResolutions()
+{
+	int displayID = SDL_GetWindowDisplayIndex(mainWindow);
+	return getSupportedResolutions(displayID);
+}
+
+std::vector<Point> CSDL_Ext::getSupportedResolutions( int displayIndex)
+{
+	std::vector<Point> result;
+
+	int modesCount = SDL_GetNumDisplayModes(displayIndex);
+
+	for (int i =0; i < modesCount; ++i)
+	{
+		SDL_DisplayMode mode;
+		if (SDL_GetDisplayMode(displayIndex, i, &mode) != 0)
+			continue;
+
+		Point resolution(mode.w, mode.h);
+
+		result.push_back(resolution);
+	}
+	return result;
+}
 
 template SDL_Surface * CSDL_Ext::createSurfaceWithBpp<2>(int, int);
 template SDL_Surface * CSDL_Ext::createSurfaceWithBpp<3>(int, int);

--- a/client/renderSDL/SDL_Extensions.h
+++ b/client/renderSDL/SDL_Extensions.h
@@ -108,9 +108,6 @@ typedef void (*TColorPutterAlpha)(uint8_t *&ptr, const uint8_t & R, const uint8_
 	uint32_t colorTouint32_t(const SDL_Color * color); //little endian only
 	SDL_Color makeColor(ui8 r, ui8 g, ui8 b, ui8 a);
 
-	/// returns dimensions of display on which VCMI window is located
-	Rect getDisplayBounds();
-
 	void drawLine(SDL_Surface * sur, int x1, int y1, int x2, int y2, const SDL_Color & color1, const SDL_Color & color2);
 	void drawBorder(SDL_Surface * sur, int x, int y, int w, int h, const SDL_Color &color, int depth = 1);
 	void drawBorder(SDL_Surface * sur, const Rect &r, const SDL_Color &color, int depth = 1);

--- a/client/renderSDL/SDL_Extensions.h
+++ b/client/renderSDL/SDL_Extensions.h
@@ -130,6 +130,11 @@ typedef void (*TColorPutterAlpha)(uint8_t *&ptr, const uint8_t & R, const uint8_
 	void applyEffectBpp( SDL_Surface * surf, const Rect & rect, int mode );
 	void applyEffect(SDL_Surface * surf, const Rect & rect, int mode); //mode: 0 - sepia, 1 - grayscale
 
+	bool isResolutionSupported(const std::vector<Point> & resolutions, const Point toTest );
+
+	std::vector<Point> getSupportedResolutions();
+	std::vector<Point> getSupportedResolutions( int displayIndex);
+
 	void setColorKey(SDL_Surface * surface, SDL_Color color);
 
 	///set key-color to 0,255,255

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -63,6 +63,8 @@
 #include "../lib/NetPacksBase.h"
 #include "../lib/StartInfo.h"
 
+#include <SDL_surface.h>
+
 CRecruitmentWindow::CCreatureCard::CCreatureCard(CRecruitmentWindow * window, const CCreature * crea, int totalAmount)
 	: CIntObject(LCLICK | RCLICK),
 	parent(window),
@@ -582,30 +584,8 @@ void CSystemOptionsWindow::setFullscreenMode( bool on)
 	}
 }
 
-void CSystemOptionsWindow::fillSupportedResolutions()
-{
-	supportedResolutions.clear();
-
-	// in game we can only change resolution, display is fixed
-	int displayID = SDL_GetWindowDisplayIndex(mainWindow);
-
-	int modesCount = SDL_GetNumDisplayModes(displayID);
-
-	for (int i =0; i < modesCount; ++i)
-	{
-		SDL_DisplayMode mode;
-		if (SDL_GetDisplayMode(displayID, i, &mode) != 0)
-			continue;
-
-		Point resolution(mode.w, mode.h);
-
-		supportedResolutions.push_back(resolution);
-	}
-}
-
 void CSystemOptionsWindow::fillSelectableResolutions()
 {
-	fillSupportedResolutions();
 	selectableResolutions.clear();
 
 	for(const auto & it : conf.guiOptions)
@@ -629,18 +609,12 @@ bool CSystemOptionsWindow::isResolutionSupported(const Point & resolution)
 
 bool CSystemOptionsWindow::isResolutionSupported(const Point & resolution, bool fullscreen)
 {
-#ifdef VCMI_IOS
-	// ios can use any resolution
-	bool canUseAllResolutions = true;
-#else
-	// in fullscreen only resolutions supported by monitor can be used
-	bool canUseAllResolutions = (fullscreen == false);
-#endif
-
-	if (canUseAllResolutions)
+	if (!fullscreen)
 		return true;
 
-	return vstd::contains(supportedResolutions, resolution);
+	auto supportedList = CSDL_Ext::getSupportedResolutions();
+
+	return CSDL_Ext::isResolutionSupported(supportedList, resolution);
 }
 
 void CSystemOptionsWindow::selectGameRes()

--- a/client/windows/GUIClasses.h
+++ b/client/windows/GUIClasses.h
@@ -226,6 +226,9 @@ private:
 
 	SettingsListener onFullscreenChanged;
 
+	std::vector<Point> supportedResolutions;
+	std::vector<Point> selectableResolutions;
+
 	//functions bound to buttons
 	void bloadf(); //load game
 	void bsavef(); //save game
@@ -233,6 +236,12 @@ private:
 	void breturnf(); //return to game
 	void brestartf(); //restart game
 	void bmainmenuf(); //return to main menu
+
+	void setFullscreenMode( bool on);
+	void fillSupportedResolutions();
+	void fillSelectableResolutions();
+	bool isResolutionSupported(const Point & resolution);
+	bool isResolutionSupported(const Point & resolution, bool fullscreen);
 
 	void selectGameRes();
 	void setGameRes(int index);

--- a/client/windows/GUIClasses.h
+++ b/client/windows/GUIClasses.h
@@ -238,7 +238,6 @@ private:
 	void bmainmenuf(); //return to main menu
 
 	void setFullscreenMode( bool on);
-	void fillSupportedResolutions();
 	void fillSelectableResolutions();
 	bool isResolutionSupported(const Point & resolution);
 	bool isResolutionSupported(const Point & resolution, bool fullscreen);


### PR DESCRIPTION
Client only right now. Should prevent buggy mouse positioning after selecting weird resolutions

But don't see any easy way to do such filter in Launcher.
SDL provides way to query all available resolutions, so in-game filter is done.
Qt doesn't have such method. So I have no way to query which resolutions are supported while in Launcher.

One option would be to load SDL in Launcher, get the info and exit SDL. (SDL_InitSubsystem & SDL_Exit)
But this change is rather significant and not something I am willing to do for a hotfix.

NOTE: PR targets beta, but I no longer think that change is safe enough for beta