### PR TITLE
[beta] Added checks to music player to detect potential freezes

### DIFF
--- a/client/CMusicHandler.cpp
+++ b/client/CMusicHandler.cpp
@@ -89,7 +89,7 @@ CSoundHandler::CSoundHandler():
 		soundBase::battle02, soundBase::battle03, soundBase::battle04,
 		soundBase::battle05, soundBase::battle06, soundBase::battle07
 	};
-	
+
 	//predefine terrain set
 	//TODO: support custom sounds for new terrains and load from json
 	horseSounds =
@@ -542,6 +542,20 @@ MusicEntry::MusicEntry(CMusicHandler *owner, std::string setName, std::string mu
 }
 MusicEntry::~MusicEntry()
 {
+	if (playing)
+	{
+		assert(0);
+		logGlobal->error("Attempt to delete music while playing!");
+		Mix_HaltMusic();
+	}
+
+	if (loop == 0 && Mix_FadingMusic() != MIX_NO_FADING)
+	{
+		assert(0);
+		logGlobal->error("Attempt to delete music while fading out!");
+		Mix_HaltMusic();
+	}
+
 	logGlobal->trace("Del-ing music file %s", currentName);
 	if (music)
 		Mix_FreeMusic(music);
@@ -619,7 +633,7 @@ bool MusicEntry::play()
 
 bool MusicEntry::stop(int fade_ms)
 {
-	if (playing)
+	if (Mix_PlayingMusic())
 	{
 		playing = false;
 		loop = 0;


### PR DESCRIPTION
According to SDL docs, deleting music that is in process of fade-out will lock this thread for a duration of a fade-out.
This is definitely not desirable for us so:

- Added checks for such scenarios and instantly halt fading-out music if this ever happens
- Fixed one case of such scenario that I have found (regression from my music freeze fix)