### PR TITLE
Log format change

### DIFF
--- a/config/schemas/settings.json
+++ b/config/schemas/settings.json
@@ -356,7 +356,7 @@
 					"properties" : {
 						"format" : {
 							"type" : "string",
-							"default" : "%l %n [%t] - %m"
+							"default" : "[%c] %l %n - %m"
 						}
 					}
 				},

--- a/lib/logging/CLogger.cpp
+++ b/lib/logging/CLogger.cpp
@@ -295,6 +295,7 @@ std::string CLogFormatter::format(const LogRecord & record) const
 	boost::algorithm::replace_first(message, "%n", record.domain.getName());
 	boost::algorithm::replace_first(message, "%t", record.threadId);
 	boost::algorithm::replace_first(message, "%m", record.message);
+	boost::algorithm::replace_first(message, "%c", boost::posix_time::to_simple_string(record.timeStamp));
 
 	//return boost::to_string (boost::format("%d %d %d[%d] - %d") % dateStream.str() % level % record.domain.getName() % record.threadId % record.message);
 

--- a/lib/logging/CLogger.cpp
+++ b/lib/logging/CLogger.cpp
@@ -146,7 +146,7 @@ void CLogger::log(ELogLevel::ELogLevel level, const boost::format & fmt) const
 	}
 	catch(...)
 	{
-        log(ELogLevel::ERROR, "Invalid log format!");
+		log(ELogLevel::ERROR, "Invalid log format!");
 	}
 }
 
@@ -349,9 +349,9 @@ EConsoleTextColor::EConsoleTextColor CColorMapping::getColorFor(const CLoggerDom
 
 CLogConsoleTarget::CLogConsoleTarget(CConsoleHandler * console) :
 #ifndef VCMI_IOS
-    console(console),
+	console(console),
 #endif
-    threshold(ELogLevel::INFO), coloredOutputEnabled(true)
+	threshold(ELogLevel::INFO), coloredOutputEnabled(true)
 {
 	formatter.setPattern("%m");
 }
@@ -364,7 +364,7 @@ void CLogConsoleTarget::write(const LogRecord & record)
 	std::string message = formatter.format(record);
 
 #ifdef VCMI_ANDROID
-    __android_log_write(ELogLevel::toAndroid(record.level), ("VCMI-" + record.domain.getName()).c_str(), message.c_str());
+	__android_log_write(ELogLevel::toAndroid(record.level), ("VCMI-" + record.domain.getName()).c_str(), message.c_str());
 #elif defined(VCMI_IOS)
 	os_log_type_t type;
 	switch (record.level)


### PR DESCRIPTION
Proposition to change log file format.
Current one shows thread ID which is usually not exactly helpful information.
In the same time, log shows zero information on time of event.

Timing information is often extremely important, so proposing to change format to one that includes timing. Built-in boost date formatting has microsecond resolution which is more than enough.
`[2023-Jan-08 18:31:12.924408] INFO global - Loading settings: 228 ms`