### PR TITLE
Revert "fix unaligned memory access when building with clang"

### DIFF
--- a/client/gui/CAnimation.cpp
+++ b/client/gui/CAnimation.cpp
@@ -34,7 +34,6 @@ class CDefFile
 {
 private:
 
-	PACKED_STRUCT_BEGIN
 	struct SSpriteDef
 	{
 		ui32 size;
@@ -45,7 +44,7 @@ private:
 		ui32 height;
 		si32 leftMargin;
 		si32 topMargin;
-	} PACKED_STRUCT_END;
+	} PACKED_STRUCT;
 	//offset[group][frame] - offset of frame data in file
 	std::map<size_t, std::vector <size_t> > offset;
 

--- a/lib/vcmi_endian.h
+++ b/lib/vcmi_endian.h
@@ -9,7 +9,7 @@
  */
 #pragma once
 
-//FIXME:library file depends on SDL - may cause troubles
+//FIXME:library file depends on SDL - make cause troubles
 #include <SDL_endian.h>
 
 VCMI_LIB_NAMESPACE_BEGIN

--- a/lib/vcmi_endian.h
+++ b/lib/vcmi_endian.h
@@ -20,18 +20,11 @@ VCMI_LIB_NAMESPACE_BEGIN
  *    memory. On big endian machines, the value will be byteswapped.
  */
 
-#if defined(__clang__) || defined(__GNUC__) || defined(_MSC_VER)
-
-#if defined(_MSC_VER)
-#define PACKED_STRUCT_BEGIN __pragma( pack(push, 1) )
-#define PACKED_STRUCT_END   __pragma( pack(pop) )
-#else
-#define PACKED_STRUCT_BEGIN
-#define PACKED_STRUCT_END __attribute__(( packed ))
-#endif
-
-PACKED_STRUCT_BEGIN struct unaligned_Uint16 { ui16 val; } PACKED_STRUCT_END;
-PACKED_STRUCT_BEGIN struct unaligned_Uint32 { ui32 val; } PACKED_STRUCT_END;
+#if (defined(linux) || defined(__linux) || defined(__linux__)) && (defined(sparc) || defined(__arm__))
+/* SPARC does not support unaligned memory access. Let gcc know when
+ * to emit the right code. */
+struct unaligned_Uint16 { ui16 val __attribute__(( packed )); };
+struct unaligned_Uint32 { ui32 val __attribute__(( packed )); };
 
 static inline ui16 read_unaligned_u16(const void *p)
 {
@@ -48,15 +41,14 @@ static inline ui32 read_unaligned_u32(const void *p)
 #define read_le_u16(p) (SDL_SwapLE16(read_unaligned_u16(p)))
 #define read_le_u32(p) (SDL_SwapLE32(read_unaligned_u32(p)))
 
-#else
+#define PACKED_STRUCT __attribute__(( packed ))
 
-#warning UB: unaligned memory access
+#else
 
 #define read_le_u16(p) (SDL_SwapLE16(* reinterpret_cast<const ui16 *>(p)))
 #define read_le_u32(p) (SDL_SwapLE32(* reinterpret_cast<const ui32 *>(p)))
 
-#define PACKED_STRUCT_BEGIN
-#define PACKED_STRUCT_END
+#define PACKED_STRUCT
 
 #endif
 


### PR DESCRIPTION
I love MXE

I think due to this PR FPS on Windows got multiplied by zero.
Creating PR to trigger test build