### PR TITLE
Creature bonus for modders: limited shooting range

### DIFF
--- a/lib/HeroBonus.h
+++ b/lib/HeroBonus.h
@@ -330,7 +330,8 @@ public:
 	BONUS_NAME(GARGOYLE) /* gargoyle is special than NON_LIVING, cannot be rised or healed */ \
 	BONUS_NAME(SPECIAL_ADD_VALUE_ENCHANT) /*specialty spell like Aenin has, increased effect of spell, additionalInfo = value to add*/\
 	BONUS_NAME(SPECIAL_FIXED_VALUE_ENCHANT) /*specialty spell like Melody has, constant spell effect (i.e. 3 luck), additionalInfo = value to fix.*/\
-	BONUS_NAME(TOWN_MAGIC_WELL) /*one-time pseudo-bonus to implement Magic Well in the town*/ \
+	BONUS_NAME(TOWN_MAGIC_WELL) /*one-time pseudo-bonus to implement Magic Well in the town*/\
+    BONUS_NAME(LIMITED_SHOOTING_RANGE) /*limits range of shooting creatures, doesn't adjust any other mechanics (half vs full damage etc). val - range in hexes*/\
 	/* end of list */
 
 

--- a/lib/HeroBonus.h
+++ b/lib/HeroBonus.h
@@ -331,7 +331,7 @@ public:
 	BONUS_NAME(SPECIAL_ADD_VALUE_ENCHANT) /*specialty spell like Aenin has, increased effect of spell, additionalInfo = value to add*/\
 	BONUS_NAME(SPECIAL_FIXED_VALUE_ENCHANT) /*specialty spell like Melody has, constant spell effect (i.e. 3 luck), additionalInfo = value to fix.*/\
 	BONUS_NAME(TOWN_MAGIC_WELL) /*one-time pseudo-bonus to implement Magic Well in the town*/\
-    BONUS_NAME(LIMITED_SHOOTING_RANGE) /*limits range of shooting creatures, doesn't adjust any other mechanics (half vs full damage etc). val - range in hexes*/\
+	BONUS_NAME(LIMITED_SHOOTING_RANGE) /*limits range of shooting creatures, doesn't adjust any other mechanics (half vs full damage etc). val - range in hexes, additional info - optional new range for broken arrow mechanic */\
 	/* end of list */
 
 

--- a/lib/battle/CBattleInfoCallback.cpp
+++ b/lib/battle/CBattleInfoCallback.cpp
@@ -1609,7 +1609,13 @@ bool CBattleInfoCallback::battleHasDistancePenalty(const IBonusBearer * shooter,
 	if(auto target = battleGetUnitByPos(destHex, true))
 	{
 		//If any hex of target creature is within range, there is no penalty
-		if(isEnemyUnitWithinSpecifiedRange(shooterPosition, target, GameConstants::BATTLE_PENALTY_DISTANCE))
+		int range = GameConstants::BATTLE_PENALTY_DISTANCE;
+
+		auto bonus = shooter->getBonus(Selector::type()(Bonus::LIMITED_SHOOTING_RANGE));
+		if(bonus != nullptr && bonus->additionalInfo != CAddInfo::NONE)
+			range = bonus->additionalInfo[0];
+
+		if(isEnemyUnitWithinSpecifiedRange(shooterPosition, target, range))
 			return false;
 	}
 	else

--- a/lib/battle/CBattleInfoCallback.cpp
+++ b/lib/battle/CBattleInfoCallback.cpp
@@ -702,13 +702,13 @@ bool CBattleInfoCallback::battleCanShoot(const battle::Unit * attacker, BattleHe
 	{
 		if(battleCanShoot(attacker))
 		{
-			auto shooterBonus = attacker->getBonus(Selector::type()(Bonus::SHOOTER));
-			if(shooterBonus->additionalInfo == CAddInfo::NONE)
+			auto limitedRangeBonus = attacker->getBonus(Selector::type()(Bonus::LIMITED_SHOOTING_RANGE));
+			if(limitedRangeBonus == nullptr)
 			{
 				return true;
 			}
 
-			int shootingRange = shooterBonus->additionalInfo[0];
+			int shootingRange = limitedRangeBonus->val;
 			int distanceBetweenHexes = BattleHex::getDistance(attacker->getPosition(), dest);
 
 			if(distanceBetweenHexes <= shootingRange)

--- a/lib/battle/CBattleInfoCallback.cpp
+++ b/lib/battle/CBattleInfoCallback.cpp
@@ -699,7 +699,28 @@ bool CBattleInfoCallback::battleCanShoot(const battle::Unit * attacker, BattleHe
 		return false;
 
 	if(battleMatchOwner(attacker, defender) && defender->alive())
-		return battleCanShoot(attacker);
+	{
+		if(battleCanShoot(attacker))
+		{
+			auto shooterBonus = attacker->getBonus(Selector::type()(Bonus::SHOOTER));
+			if(shooterBonus->additionalInfo == CAddInfo::NONE)
+			{
+				return true;
+			}
+
+			int shootingRange = shooterBonus->additionalInfo[0];
+			int distanceBetweenHexes = BattleHex::getDistance(attacker->getPosition(), dest);
+
+			if(distanceBetweenHexes <= shootingRange)
+			{
+				return true;
+			}
+			else
+			{
+				return false;
+			}
+		}
+	}
 
 	return false;
 }

--- a/lib/battle/CBattleInfoCallback.cpp
+++ b/lib/battle/CBattleInfoCallback.cpp
@@ -709,16 +709,7 @@ bool CBattleInfoCallback::battleCanShoot(const battle::Unit * attacker, BattleHe
 			}
 
 			int shootingRange = limitedRangeBonus->val;
-			int distanceBetweenHexes = BattleHex::getDistance(attacker->getPosition(), dest);
-
-			if(distanceBetweenHexes <= shootingRange)
-			{
-				return true;
-			}
-			else
-			{
-				return false;
-			}
+			return isEnemyUnitWithinSpecifiedRange(attacker->getPosition(), defender, shootingRange);
 		}
 	}
 
@@ -1618,10 +1609,8 @@ bool CBattleInfoCallback::battleHasDistancePenalty(const IBonusBearer * shooter,
 	if(auto target = battleGetUnitByPos(destHex, true))
 	{
 		//If any hex of target creature is within range, there is no penalty
-		for(auto hex : target->getHexes())
-			if(BattleHex::getDistance(shooterPosition, hex) <= GameConstants::BATTLE_PENALTY_DISTANCE)
-				return false;
-		//TODO what about two-hex shooters?
+		if(isEnemyUnitWithinSpecifiedRange(shooterPosition, target, GameConstants::BATTLE_PENALTY_DISTANCE))
+			return false;
 	}
 	else
 	{
@@ -1630,6 +1619,16 @@ bool CBattleInfoCallback::battleHasDistancePenalty(const IBonusBearer * shooter,
 	}
 
 	return true;
+}
+
+bool CBattleInfoCallback::isEnemyUnitWithinSpecifiedRange(BattleHex attackerPosition, const battle::Unit * defenderUnit, unsigned int range) const
+{
+	for(auto hex : defenderUnit->getHexes())
+		if(BattleHex::getDistance(attackerPosition, hex) <= range)
+			return true;
+
+	//TODO what about shooting distance calculation for two-hex shooters? Is it correct?
+	return false;
 }
 
 BattleHex CBattleInfoCallback::wallPartToBattleHex(EWallPart::EWallPart part) const

--- a/lib/battle/CBattleInfoCallback.cpp
+++ b/lib/battle/CBattleInfoCallback.cpp
@@ -1632,8 +1632,7 @@ bool CBattleInfoCallback::isEnemyUnitWithinSpecifiedRange(BattleHex attackerPosi
 	for(auto hex : defenderUnit->getHexes())
 		if(BattleHex::getDistance(attackerPosition, hex) <= range)
 			return true;
-
-	//TODO what about shooting distance calculation for two-hex shooters? Is it correct?
+	
 	return false;
 }
 

--- a/lib/battle/CBattleInfoCallback.h
+++ b/lib/battle/CBattleInfoCallback.h
@@ -94,6 +94,7 @@ public:
 	int battleGetSurrenderCost(PlayerColor Player) const; //returns cost of surrendering battle, -1 if surrendering is not possible
 	ReachabilityInfo::TDistances battleGetDistances(const battle::Unit * unit, BattleHex assumedPosition) const;
 	std::set<BattleHex> battleGetAttackedHexes(const CStack* attacker, BattleHex destinationTile, BattleHex attackerPos = BattleHex::INVALID) const;
+	bool isEnemyUnitWithinSpecifiedRange(BattleHex attackerPosition, const battle::Unit * defenderUnit, unsigned int range) const;
 
 	bool battleCanAttack(const CStack * stack, const CStack * target, BattleHex dest) const; //determines if stack with given ID can attack target at the selected destination
 	bool battleCanShoot(const battle::Unit * attacker, BattleHex dest) const; //determines if stack with given ID shoot at the selected destination


### PR DESCRIPTION
Introduce LIMITED_SHOOTING_RANGE bonus, with "val" being required and  interpreted as max distance in hexes (calculated via same distance algorithm as "half damage" shooting), and addInfo is optional new range for half damage mechanics.

Sample usage:

```
"abilities" :
{
	"canShoot":
	{
		"type": "SHOOTER"
	}

	"limitedRange" :
	{
		"type" : "LIMITED_SHOOTING_RANGE",
		"val": 9
	}
}
```

results in creature being unable to shoot targets that are further than 9 hexes

```
"abilities" :
{
	"canShoot":
	{
		"type": "SHOOTER"
	}

	"limitedRange" :
	{
		"type" : "LIMITED_SHOOTING_RANGE",
		"val": 8,
		"addInfo": 4
	}
}
```

results in creature being unable to shoot targets that are further than 8 hexes, and does full damage only within 4 hexes range. Setting val as 99 or other high value is kind of workaround way to create bonus that manipulates half damage range mechanic and nothing else.