### PR TITLE
Added pressing and deleting with the [DELETE] key

### DIFF
--- a/mapeditor/mainwindow.cpp
+++ b/mapeditor/mainwindow.cpp
@@ -1181,3 +1181,13 @@ void MainWindow::on_actionPaste_triggered()
 	}
 }
 
+void MainWindow::keyPressEvent(QKeyEvent* event)
+{
+	switch (event->key()) 
+	{
+	case Qt::Key_Delete: 
+			on_actionErase_triggered();
+			break;
+	}
+}
+

--- a/mapeditor/mainwindow.cpp
+++ b/mapeditor/mainwindow.cpp
@@ -1186,8 +1186,8 @@ void MainWindow::keyPressEvent(QKeyEvent* event)
 	switch (event->key()) 
 	{
 	case Qt::Key_Delete: 
-			on_actionErase_triggered();
-			break;
+		on_actionErase_triggered();
+		break;
 	}
 }
 

--- a/mapeditor/mainwindow.cpp
+++ b/mapeditor/mainwindow.cpp
@@ -233,6 +233,10 @@ MainWindow::MainWindow(QWidget* parent) :
 	//Load map from command line
 	if(!mapFilePath.isEmpty())
 		openMap(mapFilePath);
+
+	keyBackspace = new QShortcut(this);
+	keyBackspace->setKey(Qt::Key_Backspace);
+	connect(keyBackspace, &QShortcut::activated, this, &MainWindow::backSpaceAction);
 }
 
 MainWindow::~MainWindow()
@@ -1179,6 +1183,11 @@ void MainWindow::on_actionPaste_triggered()
 	{
 		controller.pasteFromClipboard(mapLevel);
 	}
+}
+
+void MainWindow::backSpaceAction()
+{
+	on_actionErase_triggered();
 }
 
 void MainWindow::keyPressEvent(QKeyEvent * event)

--- a/mapeditor/mainwindow.cpp
+++ b/mapeditor/mainwindow.cpp
@@ -1181,7 +1181,7 @@ void MainWindow::on_actionPaste_triggered()
 	}
 }
 
-void MainWindow::keyPressEvent(QKeyEvent* event)
+void MainWindow::keyPressEvent(QKeyEvent * event)
 {
 	switch (event->key()) 
 	{

--- a/mapeditor/mainwindow.h
+++ b/mapeditor/mainwindow.h
@@ -161,6 +161,7 @@ private:
 
 	// command line options
 	QString mapFilePath;			// FilePath to the H3 or VCMI map to open
+
 protected:
-	virtual void keyPressEvent(QKeyEvent* event);
+	virtual void keyPressEvent(QKeyEvent * event) override;
 };

--- a/mapeditor/mainwindow.h
+++ b/mapeditor/mainwindow.h
@@ -161,4 +161,6 @@ private:
 
 	// command line options
 	QString mapFilePath;			// FilePath to the H3 or VCMI map to open
+protected:
+	virtual void keyPressEvent(QKeyEvent* event);
 };

--- a/mapeditor/mainwindow.h
+++ b/mapeditor/mainwindow.h
@@ -114,6 +114,8 @@ private slots:
 
 	void on_actionPaste_triggered();
 
+	void backSpaceAction();
+
 public slots:
 
 	void treeViewSelected(const QModelIndex &selected, const QModelIndex &deselected);
@@ -161,6 +163,8 @@ private:
 
 	// command line options
 	QString mapFilePath;			// FilePath to the H3 or VCMI map to open
+
+	QShortcut * keyBackspace;
 
 protected:
 	virtual void keyPressEvent(QKeyEvent * event) override;


### PR DESCRIPTION
added pressing and deleting with the [DELETE] key (issue #1356 [DELETE] key doesn't work in map editor)