### PR TITLE
Implement movement points info on ALT hold + tile mouse hover

### DIFF
--- a/client/windows/CAdvmapInterface.cpp
+++ b/client/windows/CAdvmapInterface.cpp
@@ -1708,7 +1708,7 @@ void CAdvMapInt::tileHovered(const int3 &mapPos)
 		else
 			CCS->curh->set(Cursor::Map::POINTER);
 	}
-	else if(const CGHeroInstance * h = curHero())
+	else if(const CGHeroInstance * hero = curHero())
 	{
 		std::array<Cursor::Map, 4> cursorMove      = { Cursor::Map::T1_MOVE,       Cursor::Map::T2_MOVE,       Cursor::Map::T3_MOVE,       Cursor::Map::T4_MOVE,       };
 		std::array<Cursor::Map, 4> cursorAttack    = { Cursor::Map::T1_ATTACK,     Cursor::Map::T2_ATTACK,     Cursor::Map::T3_ATTACK,     Cursor::Map::T4_ATTACK,     };
@@ -1718,28 +1718,21 @@ void CAdvMapInt::tileHovered(const int3 &mapPos)
 		std::array<Cursor::Map, 4> cursorVisit     = { Cursor::Map::T1_VISIT,      Cursor::Map::T2_VISIT,      Cursor::Map::T3_VISIT,      Cursor::Map::T4_VISIT,      };
 		std::array<Cursor::Map, 4> cursorSailVisit = { Cursor::Map::T1_SAIL_VISIT, Cursor::Map::T2_SAIL_VISIT, Cursor::Map::T3_SAIL_VISIT, Cursor::Map::T4_SAIL_VISIT, };
 
-		const CGPathNode * pnode = LOCPLINT->cb->getPathsInfo(h)->getPathInfo(mapPos);
-		assert(pnode);
+		const CGPathNode * pathNode = LOCPLINT->cb->getPathsInfo(hero)->getPathInfo(mapPos);
+		assert(pathNode);
 
-		if(LOCPLINT->altPressed() && pnode->reachable()) //overwrite status bar text with movement info
+		if(LOCPLINT->altPressed() && pathNode->reachable()) //overwrite status bar text with movement info
 		{
-			const int maxMovementPointsForDestinationLastTurn = pnode->turns > 0 ? h->maxMovePoints(pnode->layer == EPathfindingLayer::LAND) : h->movement;
-			const int movementPointsLastTurnCost = maxMovementPointsForDestinationLastTurn - pnode->moveRemains;
-			const int remainingPointsAfterMove = pnode->turns == 0 ? pnode->moveRemains : 0;
-
-			const std::string costWord = VLC->generaltexth->allTexts[346];
-			const std::string leftWord = VLC->generaltexth->allTexts[200];
-			const std::string turnsCount = pnode->turns > 0 ? std::to_string(pnode->turns) + "T + " : "";
-			statusbar->write(costWord + ": " + turnsCount + std::to_string(movementPointsLastTurnCost) + ", " + leftWord + ": " + std::to_string(remainingPointsAfterMove));
+			ShowMoveDetailsInStatusbar(*hero, *pathNode);
 		}
 
-		int turns = pnode->turns;
+		int turns = pathNode->turns;
 		vstd::amin(turns, 3);
-		switch(pnode->action)
+		switch(pathNode->action)
 		{
 		case CGPathNode::NORMAL:
 		case CGPathNode::TELEPORT_NORMAL:
-			if(pnode->layer == EPathfindingLayer::LAND)
+			if(pathNode->layer == EPathfindingLayer::LAND)
 				CCS->curh->set(cursorMove[turns]);
 			else
 				CCS->curh->set(cursorSailVisit[turns]);
@@ -1755,7 +1748,7 @@ void CAdvMapInt::tileHovered(const int3 &mapPos)
 				else
 					CCS->curh->set(cursorExchange[turns]);
 			}
-			else if(pnode->layer == EPathfindingLayer::LAND)
+			else if(pathNode->layer == EPathfindingLayer::LAND)
 				CCS->curh->set(cursorVisit[turns]);
 			else
 				CCS->curh->set(cursorSailVisit[turns]);
@@ -1794,6 +1787,21 @@ void CAdvMapInt::tileHovered(const int3 &mapPos)
 	{
 		CCS->curh->set(Cursor::Map::T1_SAIL);
 	}
+}
+
+void CAdvMapInt::ShowMoveDetailsInStatusbar(const CGHeroInstance & hero, const CGPathNode & pathNode)
+{
+	const int maxMovementPointsAtStartOfLastTurn = pathNode.turns > 0 ? hero.maxMovePoints(pathNode.layer == EPathfindingLayer::LAND) : hero.movement;
+	const int movementPointsLastTurnCost = maxMovementPointsAtStartOfLastTurn - pathNode.moveRemains;
+	const int remainingPointsAfterMove = pathNode.turns == 0 ? pathNode.moveRemains : 0;
+
+	std::string result = VLC->generaltexth->translate("vcmi.adventureMap", pathNode.turns > 0 ? "moveCostDetails" : "moveCostDetailsNoTurns");
+
+	boost::replace_first(result, "%TURNS", std::to_string(pathNode.turns));
+	boost::replace_first(result, "%POINTS", std::to_string(movementPointsLastTurnCost));
+	boost::replace_first(result, "%REMAINING", std::to_string(remainingPointsAfterMove));
+
+	statusbar->write(result);
 }
 
 void CAdvMapInt::tileRClicked(const int3 &mapPos)

--- a/client/windows/CAdvmapInterface.cpp
+++ b/client/windows/CAdvmapInterface.cpp
@@ -1721,6 +1721,18 @@ void CAdvMapInt::tileHovered(const int3 &mapPos)
 		const CGPathNode * pnode = LOCPLINT->cb->getPathsInfo(h)->getPathInfo(mapPos);
 		assert(pnode);
 
+		if(LOCPLINT->altPressed() && pnode->reachable()) //overwrite status bar text with movement info
+		{
+			const int maxMovementPointsForDestinationLastTurn = pnode->turns > 0 ? h->maxMovePoints(pnode->layer == EPathfindingLayer::LAND) : h->movement;
+			const int movementPointsLastTurnCost = maxMovementPointsForDestinationLastTurn - pnode->moveRemains;
+			const int remainingPointsAfterMove = pnode->turns == 0 ? pnode->moveRemains : 0;
+
+			const std::string costWord = VLC->generaltexth->allTexts[346];
+			const std::string leftWord = VLC->generaltexth->allTexts[200];
+			const std::string turnsCount = pnode->turns > 0 ? std::to_string(pnode->turns) + "T + " : "";
+			statusbar->write(costWord + ": " + turnsCount + std::to_string(movementPointsLastTurnCost) + ", " + leftWord + ": " + std::to_string(remainingPointsAfterMove));
+		}
+
 		int turns = pnode->turns;
 		vstd::amin(turns, 3);
 		switch(pnode->action)

--- a/client/windows/CAdvmapInterface.h
+++ b/client/windows/CAdvmapInterface.h
@@ -20,6 +20,7 @@
 VCMI_LIB_NAMESPACE_BEGIN
 
 struct CGPath;
+struct CGPathNode;
 class CGHeroInstance;
 class CGTownInstance;
 class CSpell;
@@ -269,6 +270,8 @@ public:
 	void handleMapScrollingUpdate();
 	void handleSwipeUpdate();
 
+private:
+	void ShowMoveDetailsInStatusbar(const CGHeroInstance & hero, const CGPathNode & pathNode);
 };
 
 extern std::shared_ptr<CAdvMapInt> adventureInt;

--- a/config/translate.json
+++ b/config/translate.json
@@ -13,11 +13,13 @@
 	"vcmi.adventureMap.monsterThreat.levels.10" : "Deadly",
 	"vcmi.adventureMap.monsterThreat.levels.11" : "Impossible",
 
-	"vcmi.adventureMap.confirmRestartGame"  : "Are you sure you want to restart game?",
-	"vcmi.adventureMap.noTownWithMarket"    : "No available marketplace!",
-	"vcmi.adventureMap.noTownWithTavern"    : "No available town with tavern!",
-	"vcmi.adventureMap.spellUnknownProblem" : "Unknown problem with this spell, no more information available.",
-	"vcmi.adventureMap.playerAttacked"      : "Player has been attacked: %s",
+	"vcmi.adventureMap.confirmRestartGame"     : "Are you sure you want to restart game?",
+	"vcmi.adventureMap.noTownWithMarket"       : "No available marketplace!",
+	"vcmi.adventureMap.noTownWithTavern"       : "No available town with tavern!",
+	"vcmi.adventureMap.spellUnknownProblem"    : "Unknown problem with this spell, no more information available.",
+	"vcmi.adventureMap.playerAttacked"         : "Player has been attacked: %s",
+	"vcmi.adventureMap.moveCostDetails"        : "Movement points - Cost: %TURNS turns + %POINTS points, Remaining points: %REMAINING",
+	"vcmi.adventureMap.moveCostDetailsNoTurns" : "Movement points - Cost: %POINTS points, Remaining points: %REMAINING",
 
 	"vcmi.server.errors.existingProcess"     : "Another vcmiserver process is running, please terminate it first",
 	"vcmi.server.errors.modsIncompatibility" : "Required mods to load game:",


### PR DESCRIPTION
Show movement points cost for moves when holding alt key and hovering mouse over visitable tile. Not thoroughly tested but looks OK for basic use cases. Reuses H3 strings. Feature present in HD mod or HotA (not sure which), wanted for multiplayer.