### PR TITLE
SDL relative pointer for android

### DIFF
--- a/client/CMT.cpp
+++ b/client/CMT.cpp
@@ -374,7 +374,8 @@ int main(int argc, char * argv[])
 		SDL_GL_SetAttribute(SDL_GL_DEPTH_SIZE, 0);
 		#endif // VCMI_ANDROID
 
-		GH.mainFPSmng->init(); //(!)init here AFTER SDL_Init() while using SDL for FPS management
+		//(!)init here AFTER SDL_Init() while using SDL for FPS management
+		GH.init();
 
 		SDL_LogSetOutputFunction(&SDLLogCallback, nullptr);
 
@@ -430,10 +431,17 @@ int main(int argc, char * argv[])
 		CCS->musich->setVolume((ui32)settings["general"]["music"].Float());
 		logGlobal->info("Initializing screen and sound handling: %d ms", pomtime.getDiff());
 	}
+
 #ifdef VCMI_MAC
 	// Ctrl+click should be treated as a right click on Mac OS X
 	SDL_SetHint(SDL_HINT_MAC_CTRL_CLICK_EMULATE_RIGHT_CLICK, "1");
 #endif
+
+	if(GH.isPointerRelativeMode)
+	{
+		SDL_SetHint(SDL_HINT_MOUSE_TOUCH_EVENTS, "0");
+		SDL_SetHint(SDL_HINT_TOUCH_MOUSE_EVENTS, "0");
+	}
 
 #ifndef VCMI_NO_THREADED_LOAD
 	//we can properly play intro only in the main thread, so we have to move loading to the separate thread

--- a/client/CMT.cpp
+++ b/client/CMT.cpp
@@ -437,11 +437,13 @@ int main(int argc, char * argv[])
 	SDL_SetHint(SDL_HINT_MAC_CTRL_CLICK_EMULATE_RIGHT_CLICK, "1");
 #endif
 
+#ifdef SDL_HINT_MOUSE_TOUCH_EVENTS
 	if(GH.isPointerRelativeMode)
 	{
 		SDL_SetHint(SDL_HINT_MOUSE_TOUCH_EVENTS, "0");
 		SDL_SetHint(SDL_HINT_TOUCH_MOUSE_EVENTS, "0");
 	}
+#endif
 
 #ifndef VCMI_NO_THREADED_LOAD
 	//we can properly play intro only in the main thread, so we have to move loading to the separate thread

--- a/client/gui/CGuiHandler.cpp
+++ b/client/gui/CGuiHandler.cpp
@@ -268,12 +268,17 @@ void CGuiHandler::fakeMouseButtonEventRelativeMode(bool down, bool right)
 	sme.x = CCS->curh->xpos;
 	sme.y = CCS->curh->ypos;
 
-	int windowX, windowY;
+	float xScale, yScale;
+	int w, h, rLogicalWidth, rLogicalHeight;
 
-	SDL_RenderLogicalToWindow(mainRenderer, sme.x, sme.y, &windowX, &windowY);
+	SDL_GetWindowSize(mainWindow, &w, &h);
+	SDL_RenderGetLogicalSize(mainRenderer, &rLogicalWidth, &rLogicalHeight);
+	SDL_RenderGetScale(mainRenderer, &xScale, &yScale);
 
 	SDL_EventState(SDL_MOUSEMOTION, SDL_IGNORE);
-	SDL_WarpMouse(windowX, windowY);
+	SDL_WarpMouse(
+		(int)(sme.x * xScale) + (w - rLogicalWidth * xScale) / 2,
+		(int)(sme.y * yScale + (h - rLogicalHeight * yScale) / 2));
 	SDL_EventState(SDL_MOUSEMOTION, SDL_ENABLE);
 
 	event.button = sme;
@@ -430,7 +435,6 @@ void CGuiHandler::handleCurrentEvent()
 			}
 		}
 	}
-#ifndef VCMI_IOS
 	else if(current->type == SDL_FINGERMOTION)
 	{
 		if(isPointerRelativeMode)
@@ -453,12 +457,14 @@ void CGuiHandler::handleCurrentEvent()
 				fakeMouseButtonEventRelativeMode(true, isRightClick);
 			}
 		}
+#ifndef VCMI_IOS
 		else if(fingerCount == 2)
 		{
 			convertTouchToMouse(current);
 			handleMouseMotion();
 			handleMouseButtonClick(rclickable, EIntObjMouseBtnType::RIGHT, true);
 		}
+#endif //VCMI_IOS
 	}
 	else if(current->type == SDL_FINGERUP)
 	{
@@ -473,6 +479,7 @@ void CGuiHandler::handleCurrentEvent()
 				fakeMouseButtonEventRelativeMode(false, isRightClick);
 			}
 		}
+#ifndef VCMI_IOS
 		else if(multifinger)
 		{
 			convertTouchToMouse(current);
@@ -480,8 +487,8 @@ void CGuiHandler::handleCurrentEvent()
 			handleMouseButtonClick(rclickable, EIntObjMouseBtnType::RIGHT, false);
 			multifinger = fingerCount != 0;
 		}
-	}
 #endif //VCMI_IOS
+	}
 
 	current = nullptr;
 } //event end

--- a/client/gui/CGuiHandler.h
+++ b/client/gui/CGuiHandler.h
@@ -88,6 +88,10 @@ private:
 
 	void handleMouseButtonClick(CIntObjectList & interestedObjs, EIntObjMouseBtnType btn, bool isPressed);
 	void processLists(const ui16 activityFlag, std::function<void (std::list<CIntObject*> *)> cb);
+	void convertTouchToMouse(SDL_Event * current);
+	void fakeMoveCursor(float dx, float dy);
+	void fakeMouseButtonEventRelativeMode(bool down, bool right);
+
 public:
 	void handleElementActivate(CIntObject * elem, ui16 activityFlag);
 	void handleElementDeActivate(CIntObject * elem, ui16 activityFlag);
@@ -102,6 +106,8 @@ public:
 	Point lastClick;
 	unsigned lastClickTime;
 	bool multifinger;
+	bool isPointerRelativeMode;
+	float pointerSpeedMultiplier;
 
 	ui8 defActionsDef; //default auto actions
 	bool captureChildren; //all newly created objects will get their parents from stack and will be added to parents children list
@@ -110,6 +116,7 @@ public:
 	CGuiHandler();
 	~CGuiHandler();
 
+	void init();
 	void renderFrame();
 
 	void totalRedraw(); //forces total redraw (using showAll), sets a flag, method gets called at the end of the rendering

--- a/config/schemas/settings.json
+++ b/config/schemas/settings.json
@@ -17,7 +17,20 @@
 			"type" : "object",
 			"default": {},
 			"additionalProperties" : false,
-			"required" : [ "playerName", "showfps", "music", "sound", "encoding", "swipe", "saveRandomMaps", "saveFrequency", "notifications", "extraDump" ],
+			"required" : [
+				"playerName",
+				"showfps",
+				"music",
+				"sound",
+				"encoding",
+				"swipe",
+				"saveRandomMaps",
+				"saveFrequency",
+				"notifications",
+				"extraDump",
+				"userRelativePointer",
+				"relativePointerSpeedMultiplier"
+			],
 			"properties" : {
 				"playerName" : {
 					"type":"string",
@@ -70,6 +83,14 @@
 				"extraDump" : {
 					"type" : "boolean",
 					"default" : false
+				},
+				"userRelativePointer" : {
+					"type" : "boolean",
+					"default" : false
+				},
+				"relativePointerSpeedMultiplier" : {
+					"type" : "number",
+					"default" : 1
 				}
 			}
 		},


### PR DESCRIPTION
Implement relative mode when you can drag pointer with finger. Kind of on-screen controls but invisible. This feature existed before in Android and was broken after SDL update so reimplemented it using SDL itself.