### PR TITLE
limit displayed units number to 4 digits

### DIFF
--- a/client/battle/BattleInterfaceClasses.cpp
+++ b/client/battle/BattleInterfaceClasses.cpp
@@ -850,7 +850,7 @@ void StackQueue::StackBox::setUnit(const battle::Unit * unit, size_t turn)
 		if (unit->unitType()->idNumber == CreatureID::ARROW_TOWERS)
 			icon->setFrame(owner->getSiegeShooterIconID(), 1);
 
-		amount->setText(CSDL_Ext::makeNumberShort(unit->getCount()));
+		amount->setText(CSDL_Ext::makeNumberShort(unit->getCount(), 4));
 
 		if(stateIcon)
 		{

--- a/client/battle/BattleStacksController.cpp
+++ b/client/battle/BattleStacksController.cpp
@@ -318,7 +318,7 @@ void BattleStacksController::showStackAmountBox(Canvas & canvas, const CStack * 
 	//blitting amount
 	Point textPos = stackAnimation[stack->ID]->pos.topLeft() + amountBG->dimensions()/2 + Point(xAdd, yAdd);
 
-	canvas.drawText(textPos, EFonts::FONT_TINY, Colors::WHITE, ETextAlignment::CENTER, CSDL_Ext::makeNumberShort(stack->getCount()));
+	canvas.drawText(textPos, EFonts::FONT_TINY, Colors::WHITE, ETextAlignment::CENTER, CSDL_Ext::makeNumberShort(stack->getCount(), 4));
 }
 
 void BattleStacksController::showStack(Canvas & canvas, const CStack * stack)

--- a/client/widgets/CGarrisonInt.cpp
+++ b/client/widgets/CGarrisonInt.cpp
@@ -378,7 +378,7 @@ void CGarrisonSlot::update()
 		creatureImage->setFrame(creature->getIconIndex());
 
 		stackCount->enable();
-		stackCount->setText(boost::lexical_cast<std::string>(myStack->count));
+		stackCount->setText(CSDL_Ext::makeNumberShort(myStack->count, 4));
 	}
 	else
 	{

--- a/client/widgets/MiscWidgets.cpp
+++ b/client/widgets/MiscWidgets.cpp
@@ -247,7 +247,7 @@ void CArmyTooltip::init(const InfoAboutArmy &army)
 		std::string subtitle;
 		if(army.army.isDetailed)
 		{
-			subtitle = boost::lexical_cast<std::string>(slot.second.count);
+			subtitle = CSDL_Ext::makeNumberShort(slot.second.count, 4);
 		}
 		else
 		{


### PR DESCRIPTION
counts < 10000 are displayed as is

fixes #1448

test map: [unit-numbers.vmap.zip](https://github.com/vcmi/vcmi/files/10468748/unit-numbers.vmap.zip) (called "vcmi units number")

![Screenshot 2023-01-20 at 20 36 58](https://user-images.githubusercontent.com/1557784/213767996-7b6393cf-1d45-4a8d-99fd-9ef0296de7e6.png)

![Screenshot 2023-01-20 at 20 33 07](https://user-images.githubusercontent.com/1557784/213768094-c89adc24-929e-41d0-9260-fb63c21e04f6.png)
