### PR TITLE
display owner of ownable objects in tooltip

### DIFF
--- a/lib/mapObjects/CObjectHandler.cpp
+++ b/lib/mapObjects/CObjectHandler.cpp
@@ -328,7 +328,10 @@ boost::optional<std::string> CGObjectInstance::getRemovalSound() const
 
 std::string CGObjectInstance::getHoverText(PlayerColor player) const
 {
-	return getObjectName();
+	auto text = getObjectName();
+	if (tempOwner.isValidPlayer())
+		text += "\n" + VLC->generaltexth->arraytxt[23 + tempOwner.getNum()];
+	return text;
 }
 
 std::string CGObjectInstance::getHoverText(const CGHeroInstance * hero) const

--- a/lib/mapObjects/MiscObjects.cpp
+++ b/lib/mapObjects/MiscObjects.cpp
@@ -715,14 +715,10 @@ std::string CGMine::getObjectName() const
 
 std::string CGMine::getHoverText(PlayerColor player) const
 {
-	std::string hoverName = getObjectName(); // Sawmill
+	std::string hoverName = CArmedInstance::getHoverText(player);
 
 	if (tempOwner != PlayerColor::NEUTRAL)
-	{
-		hoverName += "\n";
-		hoverName += VLC->generaltexth->arraytxt[23 + tempOwner.getNum()]; // owned by Red Player
 		hoverName += "\n(" + VLC->generaltexth->restypes[producedResource] + ")";
-	}
 
 	if(stacksCount())
 	{
@@ -2198,12 +2194,6 @@ void CGLighthouse::initObj(CRandomGenerator & rand)
 		// FIXME: This is dirty hack
 		giveBonusTo(tempOwner, true);
 	}
-}
-
-std::string CGLighthouse::getHoverText(PlayerColor player) const
-{
-	//TODO: owned by %s player
-	return getObjectName();
 }
 
 void CGLighthouse::giveBonusTo(PlayerColor player, bool onInit) const

--- a/lib/mapObjects/MiscObjects.h
+++ b/lib/mapObjects/MiscObjects.h
@@ -523,7 +523,6 @@ class DLL_LINKAGE CGLighthouse : public CGObjectInstance
 public:
 	void onHeroVisit(const CGHeroInstance * h) const override;
 	void initObj(CRandomGenerator & rand) override;
-	std::string getHoverText(PlayerColor player) const override;
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{


### PR DESCRIPTION
also displays owner of towns (deviation from oh3)

fixes #1437

test map: [owners.h3m.zip](https://github.com/vcmi/vcmi/files/10472046/owners.h3m.zip)

![Screenshot 2023-01-21 at 14 08 15](https://user-images.githubusercontent.com/1557784/213864900-c901f46c-14e3-4176-947c-b7efdb2c8fe8.png) ![Screenshot 2023-01-21 at 14 21 50](https://user-images.githubusercontent.com/1557784/213864906-35af290f-6af6-4345-987c-488c26375b6e.png) ![Screenshot 2023-01-21 at 14 08 21](https://user-images.githubusercontent.com/1557784/213864903-884e4967-6189-417a-9a16-af62e5d3b4f5.png)
