### PR TITLE
attempt to show shipyard dialog only when a hero is selected

### DIFF
--- a/client/windows/CAdvmapInterface.cpp
+++ b/client/windows/CAdvmapInterface.cpp
@@ -1587,6 +1587,7 @@ void CAdvMapInt::tileLClicked(const int3 &mapPos)
 	bool canSelect = topBlocking && topBlocking->ID == Obj::HERO && topBlocking->tempOwner == LOCPLINT->playerID;
 	canSelect |= topBlocking && topBlocking->ID == Obj::TOWN && LOCPLINT->cb->getPlayerRelations(LOCPLINT->playerID, topBlocking->tempOwner);
 
+	bool isHero = false;
 	if(selection->ID != Obj::HERO) //hero is not selected (presumably town)
 	{
 		assert(!terrain.currentPath); //path can be active only when hero is selected
@@ -1597,6 +1598,8 @@ void CAdvMapInt::tileLClicked(const int3 &mapPos)
 	}
 	else if(const CGHeroInstance * currentHero = curHero()) //hero is selected
 	{
+		isHero = true;
+
 		const CGPathNode *pn = LOCPLINT->cb->getPathsInfo(currentHero)->getPathInfo(mapPos);
 		if(currentHero == topBlocking) //clicked selected hero
 		{
@@ -1638,7 +1641,8 @@ void CAdvMapInt::tileLClicked(const int3 &mapPos)
 		throw std::runtime_error("Nothing is selected...");
 	}
 
-	if(const IShipyard *shipyard = ourInaccessibleShipyard(topBlocking))
+	const auto shipyard = ourInaccessibleShipyard(topBlocking);
+	if(isHero && shipyard != nullptr)
 	{
 		LOCPLINT->showShipyardDialogOrProblemPopup(shipyard);
 	}


### PR DESCRIPTION
> double-clicking town without Shipyard opens "This an abandoned shipyard" dialog.

fixes regression coming from #1484