### PR TITLE
Add welcome/setup page to Laucher

### DIFF
--- a/client/CMT.cpp
+++ b/client/CMT.cpp
@@ -258,7 +258,7 @@ int main(int argc, char * argv[])
 
 	// Init filesystem and settings
 	preinitDLL(::console);
-	settings.init();
+
 	Settings session = settings.write["session"];
 	auto setSettingBool = [](std::string key, std::string arg) {
 		Settings s = settings.write(vstd::split(key, "/"));

--- a/config/schemas/mod.json
+++ b/config/schemas/mod.json
@@ -91,7 +91,7 @@
 		"language" : {
 			"type":"string",
 			"description": "Base language of the mod, before applying localizations. By default vcmi assumes English",
-			"enum" : [ "chinese", "english", "german", "polish", "russian", "ukrainian" ],
+			"enum" : [ "chinese", "english", "korean", "german", "polish", "russian", "ukrainian" ],
 		},
 		"depends": {
 			"type":"array",
@@ -125,10 +125,16 @@
 			"type":"boolean",
 			"description": "If set to true, mod will not be enabled automatically on install"
 		},
+		"chinese" : {
+			"$ref" : "#/definitions/localizable"
+		},
 		"english" : {
 			"$ref" : "#/definitions/localizable"
 		},
 		"german" : {
+			"$ref" : "#/definitions/localizable"
+		},
+		"korean" : {
 			"$ref" : "#/definitions/localizable"
 		},
 		"polish" : {

--- a/config/schemas/settings.json
+++ b/config/schemas/settings.json
@@ -440,7 +440,7 @@
 			"type" : "object",
 			"default": {},
 			"additionalProperties" : false,
-			"required" : [ "repositoryURL", "enableInstalledMods", "extraResolutionsModPath", "autoCheckRepositories", "updateOnStartup", "updateConfigUrl", "lobbyUrl", "lobbyPort", "lobbyUsername", "connectionTimeout" ],
+			"required" : [ "setupCompleted", "repositoryURL", "enableInstalledMods", "extraResolutionsModPath", "autoCheckRepositories", "updateOnStartup", "updateConfigUrl", "lobbyUrl", "lobbyPort", "lobbyUsername", "connectionTimeout" ],
 			"properties" : {
 				"repositoryURL" : {
 					"type" : "array",
@@ -450,6 +450,10 @@
 					"items" : {
 						"type" : "string"
 					}
+				},
+				"setupCompleted" : {
+					"type" : "boolean",
+					"default" : false
 				},
 				"enableInstalledMods" : {
 					"type" : "boolean",

--- a/config/schemas/settings.json
+++ b/config/schemas/settings.json
@@ -22,6 +22,7 @@
 				"music",
 				"sound",
 				"language",
+				"gameDataLanguage",
 				"swipe",
 				"swipeDesktop",
 				"saveRandomMaps",
@@ -63,8 +64,13 @@
 				},
 				"language" : {
 					"type":"string",
-					"enum" : [ "chinese", "english", "german", "korean", "polish", "russian", "ukrainian", "other_cp1250", "other_cp1251", "other_cp1252" ],
+					"enum" : [ "chinese", "english", "german", "polish", "russian", "ukrainian" ],
 					"default" : "english"
+				},
+				"gameDataLanguage" : {
+					"type":"string",
+					"enum" : [ "auto", "chinese", "english", "german", "korean", "polish", "russian", "ukrainian", "other_cp1250", "other_cp1251", "other_cp1252" ],
+					"default" : "auto"
 				},
 				"lastSave" : {
 					"type":"string",

--- a/config/schemas/settings.json
+++ b/config/schemas/settings.json
@@ -63,7 +63,7 @@
 				},
 				"language" : {
 					"type":"string",
-					"enum" : [ "chinese", "english", "german", "polish", "russian", "ukrainian" ],
+					"enum" : [ "chinese", "english", "german", "korean", "polish", "russian", "ukrainian", "other_cp1250", "other_cp1251", "other_cp1252" ],
 					"default" : "english"
 				},
 				"lastSave" : {

--- a/launcher/CMakeLists.txt
+++ b/launcher/CMakeLists.txt
@@ -1,33 +1,13 @@
-set(launcher_modmanager_SRCS
+set(launcher_SRCS
+		StdInc.cpp
 		modManager/cdownloadmanager_moc.cpp
 		modManager/cmodlist.cpp
 		modManager/cmodlistmodel_moc.cpp
 		modManager/cmodlistview_moc.cpp
 		modManager/cmodmanager.cpp
 		modManager/imageviewer_moc.cpp
-)
-
-set(launcher_modmanager_HEADERS
-		modManager/cdownloadmanager_moc.h
-		modManager/cmodlist.h
-		modManager/cmodlistmodel_moc.h
-		modManager/cmodlistview_moc.h
-		modManager/cmodmanager.h
-		modManager/imageviewer_moc.h
-)
-
-set(launcher_settingsview_SRCS
 		settingsView/csettingsview_moc.cpp
-)
-
-set(launcher_settingsview_HEADERS
-		settingsView/csettingsview_moc.h
-)
-
-set(launcher_SRCS
-		StdInc.cpp
-		${launcher_modmanager_SRCS}
-		${launcher_settingsview_SRCS}
+		firstLaunch/firstlaunch_moc.cpp
 		main.cpp
 		mainwindow_moc.cpp
 		launcherdirs.cpp
@@ -40,8 +20,14 @@ set(launcher_SRCS
 
 set(launcher_HEADERS
 		StdInc.h
-		${launcher_modmanager_HEADERS}
-		${launcher_settingsview_HEADERS}
+		modManager/cdownloadmanager_moc.h
+		modManager/cmodlist.h
+		modManager/cmodlistmodel_moc.h
+		modManager/cmodlistview_moc.h
+		modManager/cmodmanager.h
+		modManager/imageviewer_moc.h
+		settingsView/csettingsview_moc.h
+		firstLaunch/firstlaunch_moc.h
 		mainwindow_moc.h
 		launcherdirs.h
 		jsonutils.h
@@ -56,6 +42,7 @@ set(launcher_FORMS
 		modManager/cmodlistview_moc.ui
 		modManager/imageviewer_moc.ui
 		settingsView/csettingsview_moc.ui
+		firstLaunch/firstlaunch_moc.ui
 		mainwindow_moc.ui
 		updatedialog_moc.ui
 		lobby/lobby_moc.ui

--- a/launcher/CMakeLists.txt
+++ b/launcher/CMakeLists.txt
@@ -10,6 +10,7 @@ set(launcher_SRCS
 		firstLaunch/firstlaunch_moc.cpp
 		main.cpp
 		mainwindow_moc.cpp
+		languages.cpp
 		launcherdirs.cpp
 		jsonutils.cpp
 		updatedialog_moc.cpp
@@ -29,6 +30,7 @@ set(launcher_HEADERS
 		settingsView/csettingsview_moc.h
 		firstLaunch/firstlaunch_moc.h
 		mainwindow_moc.h
+		languages.h
 		launcherdirs.h
 		jsonutils.h
 		updatedialog_moc.h

--- a/launcher/firstLaunch/firstlaunch_moc.cpp
+++ b/launcher/firstLaunch/firstlaunch_moc.cpp
@@ -11,10 +11,17 @@
 #include "firstlaunch_moc.h"
 #include "ui_firstlaunch_moc.h"
 
+#include "mainwindow_moc.h"
+
+#include "../languages.h"
+#include "../../lib/CConfigHandler.h"
+
 FirstLaunchView::FirstLaunchView(QWidget * parent)
 	: QWidget(parent), ui(new Ui::FirstLaunchView)
 {
 	ui->setupUi(this);
+
+	Languages::fillLanguages(ui->listWidgetLanguage);
 }
 
 FirstLaunchView::~FirstLaunchView()
@@ -27,21 +34,37 @@ void FirstLaunchView::on_buttonTabLanguage_clicked()
 	ui->installerTabs->setCurrentIndex(0);
 }
 
-
 void FirstLaunchView::on_buttonTabHeroesData_clicked()
 {
 	ui->installerTabs->setCurrentIndex(1);
 }
-
 
 void FirstLaunchView::on_buttonTabModPreset_clicked()
 {
 	ui->installerTabs->setCurrentIndex(2);
 }
 
-
 void FirstLaunchView::on_buttonTabFinish_clicked()
 {
 	ui->installerTabs->setCurrentIndex(3);
 }
 
+void FirstLaunchView::on_listWidgetLanguage_currentRowChanged(int currentRow)
+{
+	Settings node = settings.write["general"]["language"];
+	QString selectedLanguage = ui->listWidgetLanguage->item(currentRow)->data(Qt::UserRole).toString();
+	node->String() = selectedLanguage.toStdString();
+
+	if(auto * mainWindow = dynamic_cast<MainWindow *>(qApp->activeWindow()))
+		mainWindow->updateTranslation();
+}
+
+void FirstLaunchView::changeEvent(QEvent *event)
+{
+	if(event->type() == QEvent::LanguageChange)
+	{
+		ui->retranslateUi(this);
+		Languages::fillLanguages(ui->listWidgetLanguage);
+	}
+	QWidget::changeEvent(event);
+}

--- a/launcher/firstLaunch/firstlaunch_moc.cpp
+++ b/launcher/firstLaunch/firstlaunch_moc.cpp
@@ -1,0 +1,47 @@
+/*
+ * firstlaunch_moc.cpp, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
+#include "StdInc.h"
+#include "firstlaunch_moc.h"
+#include "ui_firstlaunch_moc.h"
+
+FirstLaunchView::FirstLaunchView(QWidget * parent)
+	: QWidget(parent), ui(new Ui::FirstLaunchView)
+{
+	ui->setupUi(this);
+}
+
+FirstLaunchView::~FirstLaunchView()
+{
+
+}
+
+void FirstLaunchView::on_buttonTabLanguage_clicked()
+{
+	ui->installerTabs->setCurrentIndex(0);
+}
+
+
+void FirstLaunchView::on_buttonTabHeroesData_clicked()
+{
+	ui->installerTabs->setCurrentIndex(1);
+}
+
+
+void FirstLaunchView::on_buttonTabModPreset_clicked()
+{
+	ui->installerTabs->setCurrentIndex(2);
+}
+
+
+void FirstLaunchView::on_buttonTabFinish_clicked()
+{
+	ui->installerTabs->setCurrentIndex(3);
+}
+

--- a/launcher/firstLaunch/firstlaunch_moc.cpp
+++ b/launcher/firstLaunch/firstlaunch_moc.cpp
@@ -49,11 +49,6 @@ void FirstLaunchView::on_buttonTabModPreset_clicked()
 	activateTabModPreset();
 }
 
-void FirstLaunchView::on_buttonTabFinish_clicked()
-{
-	activateTabFinish();
-}
-
 void FirstLaunchView::on_listWidgetLanguage_currentRowChanged(int currentRow)
 {
 	languageSelected(ui->listWidgetLanguage->item(currentRow)->data(Qt::UserRole).toString());
@@ -121,7 +116,6 @@ void FirstLaunchView::setSetupProgress(int progress)
 	ui->buttonTabLanguage->setDisabled(value < 1);
 	ui->buttonTabHeroesData->setDisabled(value < 2);
 	ui->buttonTabModPreset->setDisabled(value < 3);
-	ui->buttonTabFinish->setDisabled(value < 4);
 }
 
 void FirstLaunchView::activateTabLanguage()
@@ -131,7 +125,6 @@ void FirstLaunchView::activateTabLanguage()
 	ui->buttonTabLanguage->setChecked(true);
 	ui->buttonTabHeroesData->setChecked(false);
 	ui->buttonTabModPreset->setChecked(false);
-	ui->buttonTabFinish->setChecked(false);
 }
 
 void FirstLaunchView::activateTabHeroesData()
@@ -141,7 +134,6 @@ void FirstLaunchView::activateTabHeroesData()
 	ui->buttonTabLanguage->setChecked(false);
 	ui->buttonTabHeroesData->setChecked(true);
 	ui->buttonTabModPreset->setChecked(false);
-	ui->buttonTabFinish->setChecked(false);
 
 	if(!hasVCMIBuilderScript)
 	{
@@ -158,19 +150,8 @@ void FirstLaunchView::activateTabModPreset()
 	ui->buttonTabLanguage->setChecked(false);
 	ui->buttonTabHeroesData->setChecked(false);
 	ui->buttonTabModPreset->setChecked(true);
-	ui->buttonTabFinish->setChecked(false);
 
 	modPresetUpdate();
-}
-
-void FirstLaunchView::activateTabFinish()
-{
-	setSetupProgress(4);
-	ui->installerTabs->setCurrentIndex(3);
-	ui->buttonTabLanguage->setChecked(false);
-	ui->buttonTabModPreset->setChecked(false);
-	ui->buttonTabHeroesData->setChecked(false);
-	ui->buttonTabFinish->setChecked(true);
 }
 
 void FirstLaunchView::exitSetup()
@@ -443,6 +424,6 @@ void FirstLaunchView::on_pushButtonPresetBack_clicked()
 
 void FirstLaunchView::on_pushButtonPresetNext_clicked()
 {
-	activateTabFinish();
+	exitSetup();
 }
 

--- a/launcher/firstLaunch/firstlaunch_moc.cpp
+++ b/launcher/firstLaunch/firstlaunch_moc.cpp
@@ -59,7 +59,7 @@ void FirstLaunchView::changeEvent(QEvent * event)
 	if(event->type() == QEvent::LanguageChange)
 	{
 		ui->retranslateUi(this);
-		Languages::fillLanguages(ui->listWidgetLanguage);
+		Languages::fillLanguages(ui->listWidgetLanguage, false);
 	}
 	QWidget::changeEvent(event);
 }
@@ -102,9 +102,7 @@ void FirstLaunchView::on_comboBoxLanguage_currentIndexChanged(int index)
 
 void FirstLaunchView::enterSetup()
 {
-	// TODO: block all UI except FirstLaunchView
-	Languages::fillLanguages(ui->listWidgetLanguage);
-	Languages::fillLanguages(ui->comboBoxLanguage);
+	Languages::fillLanguages(ui->listWidgetLanguage, false);
 }
 
 void FirstLaunchView::setSetupProgress(int progress)
@@ -253,6 +251,8 @@ QString FirstLaunchView::heroesLanguageDetect()
 
 void FirstLaunchView::heroesLanguageUpdate()
 {
+	Languages::fillLanguages(ui->comboBoxLanguage, true);
+
 	QString language = heroesLanguageDetect();
 
 	bool success = !language.isEmpty();
@@ -266,6 +266,7 @@ void FirstLaunchView::heroesLanguageUpdate()
 		ui->comboBoxLanguage->insertItem(0, itemName, QString("auto"));
 		ui->comboBoxLanguage->setCurrentIndex(0);
 	}
+
 	ui->labelDataFailure->setVisible(!success);
 	ui->labelDataSuccess->setVisible(success);
 	ui->pushButtonDataNext->setEnabled(success);

--- a/launcher/firstLaunch/firstlaunch_moc.cpp
+++ b/launcher/firstLaunch/firstlaunch_moc.cpp
@@ -12,54 +12,54 @@
 #include "ui_firstlaunch_moc.h"
 
 #include "mainwindow_moc.h"
+#include "modManager/cmodlistview_moc.h"
 
-#include "../languages.h"
 #include "../../lib/CConfigHandler.h"
+#include "../../lib/CGeneralTextHandler.h"
+#include "../../lib/Languages.h"
+#include "../../lib/VCMIDirs.h"
+#include "../../lib/filesystem/Filesystem.h"
+#include "../languages.h"
 
 FirstLaunchView::FirstLaunchView(QWidget * parent)
-	: QWidget(parent), ui(new Ui::FirstLaunchView)
+	: QWidget(parent)
+	, ui(new Ui::FirstLaunchView)
 {
 	ui->setupUi(this);
 
-	Languages::fillLanguages(ui->listWidgetLanguage);
-}
+	enterSetup();
+	activateTabLanguage();
 
-FirstLaunchView::~FirstLaunchView()
-{
-
+	ui->lineEditDataSystem->setText(boost::filesystem::absolute(VCMIDirs::get().dataPaths().front()).c_str());
+	ui->lineEditDataUser->setText(boost::filesystem::absolute(VCMIDirs::get().userDataPath()).c_str());
 }
 
 void FirstLaunchView::on_buttonTabLanguage_clicked()
 {
-	ui->installerTabs->setCurrentIndex(0);
+	activateTabLanguage();
 }
 
 void FirstLaunchView::on_buttonTabHeroesData_clicked()
 {
-	ui->installerTabs->setCurrentIndex(1);
+	activateTabHeroesData();
 }
 
 void FirstLaunchView::on_buttonTabModPreset_clicked()
 {
-	ui->installerTabs->setCurrentIndex(2);
+	activateTabModPreset();
 }
 
 void FirstLaunchView::on_buttonTabFinish_clicked()
 {
-	ui->installerTabs->setCurrentIndex(3);
+	activateTabFinish();
 }
 
 void FirstLaunchView::on_listWidgetLanguage_currentRowChanged(int currentRow)
 {
-	Settings node = settings.write["general"]["language"];
-	QString selectedLanguage = ui->listWidgetLanguage->item(currentRow)->data(Qt::UserRole).toString();
-	node->String() = selectedLanguage.toStdString();
-
-	if(auto * mainWindow = dynamic_cast<MainWindow *>(qApp->activeWindow()))
-		mainWindow->updateTranslation();
+	languageSelected(ui->listWidgetLanguage->item(currentRow)->data(Qt::UserRole).toString());
 }
 
-void FirstLaunchView::changeEvent(QEvent *event)
+void FirstLaunchView::changeEvent(QEvent * event)
 {
 	if(event->type() == QEvent::LanguageChange)
 	{
@@ -68,3 +68,381 @@ void FirstLaunchView::changeEvent(QEvent *event)
 	}
 	QWidget::changeEvent(event);
 }
+
+void FirstLaunchView::on_pushButtonLanguageNext_clicked()
+{
+	activateTabHeroesData();
+}
+
+void FirstLaunchView::on_pushButtonDataNext_clicked()
+{
+	activateTabModPreset();
+}
+
+void FirstLaunchView::on_pushButtonDataBack_clicked()
+{
+	activateTabLanguage();
+}
+
+void FirstLaunchView::on_pushButtonDataSearch_clicked()
+{
+	heroesDataUpdate();
+}
+
+void FirstLaunchView::on_pushButtonDataCopy_clicked()
+{
+	copyHeroesData();
+}
+
+void FirstLaunchView::on_pushButtonDataHelp_clicked()
+{
+	static const QUrl vcmibuilderWiki("https://wiki.vcmi.eu/Installation_on_Linux#Installing_Heroes_III_data_files");
+	QDesktopServices::openUrl(vcmibuilderWiki);
+}
+
+void FirstLaunchView::on_comboBoxLanguage_currentIndexChanged(int index)
+{
+	forceHeroesLanguage(ui->comboBoxLanguage->itemData(index).toString());
+}
+
+void FirstLaunchView::enterSetup()
+{
+	// TODO: block all UI except FirstLaunchView
+	Languages::fillLanguages(ui->listWidgetLanguage);
+	Languages::fillLanguages(ui->comboBoxLanguage);
+}
+
+void FirstLaunchView::setSetupProgress(int progress)
+{
+	int value = std::max(progress, ui->setupProgressBar->value());
+
+	ui->setupProgressBar->setValue(value);
+
+	ui->buttonTabLanguage->setDisabled(value < 1);
+	ui->buttonTabHeroesData->setDisabled(value < 2);
+	ui->buttonTabModPreset->setDisabled(value < 3);
+	ui->buttonTabFinish->setDisabled(value < 4);
+}
+
+void FirstLaunchView::activateTabLanguage()
+{
+	setSetupProgress(1);
+	ui->installerTabs->setCurrentIndex(0);
+	ui->buttonTabLanguage->setChecked(true);
+	ui->buttonTabHeroesData->setChecked(false);
+	ui->buttonTabModPreset->setChecked(false);
+	ui->buttonTabFinish->setChecked(false);
+}
+
+void FirstLaunchView::activateTabHeroesData()
+{
+	setSetupProgress(2);
+	ui->installerTabs->setCurrentIndex(1);
+	ui->buttonTabLanguage->setChecked(false);
+	ui->buttonTabHeroesData->setChecked(true);
+	ui->buttonTabModPreset->setChecked(false);
+	ui->buttonTabFinish->setChecked(false);
+
+	if(!hasVCMIBuilderScript)
+	{
+		ui->pushButtonDataHelp->hide();
+		ui->labelDataHelp->hide();
+	}
+	heroesDataUpdate();
+}
+
+void FirstLaunchView::activateTabModPreset()
+{
+	setSetupProgress(3);
+	ui->installerTabs->setCurrentIndex(2);
+	ui->buttonTabLanguage->setChecked(false);
+	ui->buttonTabHeroesData->setChecked(false);
+	ui->buttonTabModPreset->setChecked(true);
+	ui->buttonTabFinish->setChecked(false);
+
+	modPresetUpdate();
+}
+
+void FirstLaunchView::activateTabFinish()
+{
+	setSetupProgress(4);
+	ui->installerTabs->setCurrentIndex(3);
+	ui->buttonTabLanguage->setChecked(false);
+	ui->buttonTabModPreset->setChecked(false);
+	ui->buttonTabHeroesData->setChecked(false);
+	ui->buttonTabFinish->setChecked(true);
+}
+
+void FirstLaunchView::exitSetup()
+{
+	//TODO: unlock UI, switch to another tab (mods?)
+}
+
+// Tab Language
+void FirstLaunchView::languageSelected(const QString & selectedLanguage)
+{
+	Settings node = settings.write["general"]["language"];
+	node->String() = selectedLanguage.toStdString();
+
+	if(auto * mainWindow = dynamic_cast<MainWindow *>(qApp->activeWindow()))
+		mainWindow->updateTranslation();
+}
+
+void FirstLaunchView::heroesDataUpdate()
+{
+	if(heroesDataDetect())
+		heroesDataDetected();
+	else
+		heroesDataMissing();
+}
+
+void FirstLaunchView::heroesDataMissing()
+{
+	QPalette newPalette = palette();
+	newPalette.setColor(QPalette::Base, QColor(200, 50, 50));
+	ui->lineEditDataSystem->setPalette(newPalette);
+	ui->lineEditDataUser->setPalette(newPalette);
+
+	ui->pushButtonDataSearch->setVisible(true);
+	ui->pushButtonDataCopy->setVisible(true);
+
+	ui->labelDataSearch->setVisible(true);
+	ui->labelDataCopy->setVisible(true);
+
+	ui->labelDataFound->setVisible(false);
+
+	if(hasVCMIBuilderScript)
+	{
+		ui->pushButtonDataHelp->setVisible(true);
+		ui->labelDataHelp->setVisible(true);
+	}
+}
+
+void FirstLaunchView::heroesDataDetected()
+{
+	QPalette newPalette = palette();
+	newPalette.setColor(QPalette::Base, QColor(50, 200, 50));
+	ui->lineEditDataSystem->setPalette(newPalette);
+	ui->lineEditDataUser->setPalette(newPalette);
+
+	ui->pushButtonDataSearch->setVisible(false);
+	ui->pushButtonDataCopy->setVisible(false);
+
+	ui->labelDataSearch->setVisible(false);
+	ui->labelDataCopy->setVisible(false);
+
+	if(hasVCMIBuilderScript)
+	{
+		ui->pushButtonDataHelp->setVisible(false);
+		ui->labelDataHelp->setVisible(false);
+	}
+
+	ui->labelDataFound->setVisible(true);
+
+	heroesLanguageUpdate();
+}
+
+// Tab Heroes III Data
+bool FirstLaunchView::heroesDataDetect()
+{
+	// user might have copied files to one of our data path.
+	// perform full reinitialization of virtual filesystem
+	CResourceHandler::destroy();
+	CResourceHandler::initialize();
+	CResourceHandler::load("config/filesystem.json");
+
+	// use file from lod archive to check presence of H3 data. Very rough estimate, but will work in majority of cases
+	bool heroesDataFound = CResourceHandler::get()->existsResource(ResourceID("DATA/GENRLTXT.TXT"));
+
+	return heroesDataFound;
+}
+
+QString FirstLaunchView::heroesLanguageDetect()
+{
+	CGeneralTextHandler::detectInstallParameters();
+
+	QString language = QString::fromStdString(settings["session"]["language"].String());
+	double deviation = settings["session"]["languageDeviation"].Float();
+
+	if(deviation > 0.05)
+		return QString();
+	return language;
+}
+
+void FirstLaunchView::heroesLanguageUpdate()
+{
+	QString language = heroesLanguageDetect();
+
+	bool success = !language.isEmpty();
+
+	if(!language.isEmpty())
+	{
+		std::string languageNameEnglish = Languages::getLanguageOptions(language.toStdString()).nameEnglish;
+		QString languageName = QApplication::translate( "Languages", languageNameEnglish.c_str());
+		QString itemName = tr("Auto (%1)").arg(languageName);
+
+		ui->comboBoxLanguage->insertItem(0, itemName, QString("auto"));
+		ui->comboBoxLanguage->setCurrentIndex(0);
+	}
+	ui->labelDataFailure->setVisible(!success);
+	ui->labelDataSuccess->setVisible(success);
+	ui->pushButtonDataNext->setEnabled(success);
+}
+
+void FirstLaunchView::forceHeroesLanguage(const QString & language)
+{
+	Settings node = settings.write["general"]["gameDataLanguage"];
+
+	node->String() = language.toStdString();
+}
+
+void FirstLaunchView::copyHeroesData()
+{
+	assert(0); // TODO: test
+
+	QDir dir = QFileDialog::getExistingDirectory(this, "", "", QFileDialog::ShowDirsOnly | QFileDialog::DontResolveSymlinks);
+
+	if(!dir.exists())
+		return;
+
+	QStringList dirData = dir.entryList({"data"}, QDir::Filter::Dirs);
+	QStringList dirMaps = dir.entryList({"maps"}, QDir::Filter::Dirs);
+	QStringList dirMp3 = dir.entryList({"mp3"}, QDir::Filter::Dirs);
+
+	if(dirData.empty() || dirMaps.empty() || dirMp3.empty())
+		return;
+
+	QStringList lodArchives = QDir(dirData.front()).entryList({"*.lod"}, QDir::Filter::Files);
+
+	if(lodArchives.empty())
+		return;
+
+	QStringList copyDirectories = {dirData.front(), dirMaps.front(), dirMp3.front()};
+
+	QDir targetRoot = QString(VCMIDirs::get().userDataPath().c_str());
+
+	for(QDir sourceDir : copyDirectories)
+	{
+		QString dirName = sourceDir.dirName();
+		QDir targetDir = targetRoot.filePath(dirName);
+
+		if(!targetRoot.exists(dirName))
+			targetRoot.mkdir(dirName);
+
+		for(QString filename : sourceDir.entryList(QDir::Filter::Files))
+		{
+			QFile sourceFile(sourceDir.filePath(filename));
+			sourceFile.copy(targetDir.filePath(filename));
+		}
+	}
+
+	heroesDataUpdate();
+}
+
+// Tab Mod Preset
+void FirstLaunchView::modPresetUpdate()
+{
+	bool translationExists = !findTranslationModName().isEmpty();
+
+	ui->labelPresetLanguage->setVisible(translationExists);
+	ui->toolButtonPresetLanguage->setVisible(translationExists);
+
+	ui->toolButtonPresetLanguage->setEnabled(checkCanInstallTranslation());
+	ui->toolButtonPresetExtras->setEnabled(checkCanInstallExtras());
+	ui->toolButtonPresetHota->setEnabled(checkCanInstallHota());
+	ui->toolButtonPresetWog->setEnabled(checkCanInstallWog());
+}
+
+QString FirstLaunchView::findTranslationModName()
+{
+	if (!getModView())
+		return QString();
+
+	QString preferredlanguage = QString::fromStdString(settings["general"]["language"].String());
+	QString installedlanguage = QString::fromStdString(settings["session"]["language"].String());
+
+	if (preferredlanguage == installedlanguage)
+		return QString();
+
+	return getModView()->getTranslationModName(preferredlanguage);
+}
+
+bool FirstLaunchView::checkCanInstallTranslation()
+{
+	QString modName = findTranslationModName();
+
+	if(modName.isEmpty())
+		return false;
+
+	return checkCanInstallMod(modName);
+}
+
+bool FirstLaunchView::checkCanInstallWog()
+{
+	return checkCanInstallMod("wake-of-gods");
+}
+
+bool FirstLaunchView::checkCanInstallHota()
+{
+	return checkCanInstallMod("hota");
+}
+
+bool FirstLaunchView::checkCanInstallExtras()
+{
+	return checkCanInstallMod("vcmi-extras");
+}
+
+CModListView * FirstLaunchView::getModView()
+{
+	auto * mainWindow = dynamic_cast<MainWindow *>(qApp->activeWindow());
+
+	assert(mainWindow);
+	if (!mainWindow)
+		return nullptr;
+
+	return mainWindow->getModView();
+}
+
+bool FirstLaunchView::checkCanInstallMod(const QString & modID)
+{
+	return getModView() && !getModView()->isModInstalled(modID);
+}
+
+void FirstLaunchView::installTranslation()
+{
+	installMod(findTranslationModName());
+}
+
+void FirstLaunchView::installWog()
+{
+	installMod("wake-of-gods");
+}
+
+void FirstLaunchView::installHota()
+{
+	installMod("hota");
+}
+
+void FirstLaunchView::instalExtras()
+{
+	installMod("vcmi-extras");
+}
+
+void FirstLaunchView::installMod(const QString & modID)
+{
+	assert(0); // TODO: test
+
+	return getModView()->doInstallMod(modID);
+}
+
+void FirstLaunchView::on_pushButtonPresetBack_clicked()
+{
+	activateTabHeroesData();
+}
+
+
+void FirstLaunchView::on_pushButtonPresetNext_clicked()
+{
+	activateTabFinish();
+}
+

--- a/launcher/firstLaunch/firstlaunch_moc.cpp
+++ b/launcher/firstLaunch/firstlaunch_moc.cpp
@@ -237,35 +237,12 @@ bool FirstLaunchView::heroesDataDetect()
 	return heroesDataFound;
 }
 
-QString FirstLaunchView::heroesLanguageDetect()
-{
-	CGeneralTextHandler::detectInstallParameters();
-
-	QString language = QString::fromStdString(settings["session"]["language"].String());
-	double deviation = settings["session"]["languageDeviation"].Float();
-
-	if(deviation > 0.05)
-		return QString();
-	return language;
-}
-
 void FirstLaunchView::heroesLanguageUpdate()
 {
 	Languages::fillLanguages(ui->comboBoxLanguage, true);
 
-	QString language = heroesLanguageDetect();
-
+	QString language = Languages::getHeroesDataLanguage();
 	bool success = !language.isEmpty();
-
-	if(!language.isEmpty())
-	{
-		std::string languageNameEnglish = Languages::getLanguageOptions(language.toStdString()).nameEnglish;
-		QString languageName = QApplication::translate( "Languages", languageNameEnglish.c_str());
-		QString itemName = tr("Auto (%1)").arg(languageName);
-
-		ui->comboBoxLanguage->insertItem(0, itemName, QString("auto"));
-		ui->comboBoxLanguage->setCurrentIndex(0);
-	}
 
 	ui->labelDataFailure->setVisible(!success);
 	ui->labelDataSuccess->setVisible(success);

--- a/launcher/firstLaunch/firstlaunch_moc.h
+++ b/launcher/firstLaunch/firstlaunch_moc.h
@@ -15,28 +15,90 @@ namespace Ui
 class FirstLaunchView;
 }
 
+class CModListView;
+
 class FirstLaunchView : public QWidget
 {
 	Q_OBJECT
 
+	// vcmibuilder script is not available on these platforms
+#if defined(VCMI_WINDOWS) || defined(VCMI_MOBILE) || defined(VCMI_APPLE)
+	static constexpr bool hasVCMIBuilderScript = false;
+#else
+	static constexpr bool hasVCMIBuilderScript = true;
+#endif
+
 	void changeEvent(QEvent *event);
+	CModListView * getModView();
+
+	void setSetupProgress(int progress);
+	void enterSetup();
+	void activateTabLanguage();
+	void activateTabHeroesData();
+	void activateTabModPreset();
+	void activateTabFinish();
+	void exitSetup();
+
+	// Tab Language
+	void languageSelected(const QString & languageCode);
+
+	// Tab Heroes III Data
+	void heroesDataUpdate();
+	bool heroesDataDetect();
+
+	void heroesDataMissing();
+	void heroesDataDetected();
+
+	QString heroesLanguageDetect();
+	void heroesLanguageUpdate();
+	void forceHeroesLanguage(const QString & language);
+
+	void copyHeroesData();
+
+	// Tab Mod Preset
+	void modPresetUpdate();
+
+	QString findTranslationModName();
+
+	bool checkCanInstallTranslation();
+	bool checkCanInstallWog();
+	bool checkCanInstallHota();
+	bool checkCanInstallExtras();
+	bool checkCanInstallMod(const QString & modID);
+
+	void installTranslation();
+	void installWog();
+	void installHota();
+	void instalExtras();
+	void installMod(const QString & modID);
+
 public:
 	explicit FirstLaunchView(QWidget * parent = 0);
-	~FirstLaunchView();
 
 public slots:
 
 private slots:
 
 	void on_buttonTabLanguage_clicked();
-
 	void on_buttonTabHeroesData_clicked();
-
 	void on_buttonTabModPreset_clicked();
-
 	void on_buttonTabFinish_clicked();
-
 	void on_listWidgetLanguage_currentRowChanged(int currentRow);
+	void on_pushButtonLanguageNext_clicked();
+	void on_pushButtonDataNext_clicked();
+	void on_pushButtonDataBack_clicked();
+
+	void on_pushButtonDataSearch_clicked();
+
+	void on_pushButtonDataCopy_clicked();
+
+	void on_pushButtonDataHelp_clicked();
+
+	void on_comboBoxLanguage_currentIndexChanged(int index);
+
+	void on_pushButtonPresetBack_clicked();
+
+	void on_pushButtonPresetNext_clicked();
 
 private:
 	Ui::FirstLaunchView * ui;

--- a/launcher/firstLaunch/firstlaunch_moc.h
+++ b/launcher/firstLaunch/firstlaunch_moc.h
@@ -48,7 +48,6 @@ class FirstLaunchView : public QWidget
 	void heroesDataMissing();
 	void heroesDataDetected();
 
-	QString heroesLanguageDetect();
 	void heroesLanguageUpdate();
 	void forceHeroesLanguage(const QString & language);
 

--- a/launcher/firstLaunch/firstlaunch_moc.h
+++ b/launcher/firstLaunch/firstlaunch_moc.h
@@ -1,0 +1,41 @@
+/*
+ * firstlaunch_moc.h, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
+#pragma once
+#include "../StdInc.h"
+
+namespace Ui
+{
+class FirstLaunchView;
+}
+
+class FirstLaunchView : public QWidget
+{
+	Q_OBJECT
+
+public:
+	explicit FirstLaunchView(QWidget * parent = 0);
+	~FirstLaunchView();
+
+public slots:
+
+private slots:
+
+	void on_buttonTabLanguage_clicked();
+
+	void on_buttonTabHeroesData_clicked();
+
+	void on_buttonTabModPreset_clicked();
+
+	void on_buttonTabFinish_clicked();
+
+private:
+	Ui::FirstLaunchView * ui;
+
+};

--- a/launcher/firstLaunch/firstlaunch_moc.h
+++ b/launcher/firstLaunch/firstlaunch_moc.h
@@ -36,7 +36,6 @@ class FirstLaunchView : public QWidget
 	void activateTabLanguage();
 	void activateTabHeroesData();
 	void activateTabModPreset();
-	void activateTabFinish();
 	void exitSetup();
 
 	// Tab Language
@@ -82,7 +81,6 @@ private slots:
 	void on_buttonTabLanguage_clicked();
 	void on_buttonTabHeroesData_clicked();
 	void on_buttonTabModPreset_clicked();
-	void on_buttonTabFinish_clicked();
 	void on_listWidgetLanguage_currentRowChanged(int currentRow);
 	void on_pushButtonLanguageNext_clicked();
 	void on_pushButtonDataNext_clicked();

--- a/launcher/firstLaunch/firstlaunch_moc.h
+++ b/launcher/firstLaunch/firstlaunch_moc.h
@@ -19,6 +19,7 @@ class FirstLaunchView : public QWidget
 {
 	Q_OBJECT
 
+	void changeEvent(QEvent *event);
 public:
 	explicit FirstLaunchView(QWidget * parent = 0);
 	~FirstLaunchView();
@@ -34,6 +35,8 @@ private slots:
 	void on_buttonTabModPreset_clicked();
 
 	void on_buttonTabFinish_clicked();
+
+	void on_listWidgetLanguage_currentRowChanged(int currentRow);
 
 private:
 	Ui::FirstLaunchView * ui;

--- a/launcher/firstLaunch/firstlaunch_moc.h
+++ b/launcher/firstLaunch/firstlaunch_moc.h
@@ -65,10 +65,6 @@ class FirstLaunchView : public QWidget
 	bool checkCanInstallExtras();
 	bool checkCanInstallMod(const QString & modID);
 
-	void installTranslation();
-	void installWog();
-	void installHota();
-	void instalExtras();
 	void installMod(const QString & modID);
 
 public:

--- a/launcher/firstLaunch/firstlaunch_moc.ui
+++ b/launcher/firstLaunch/firstlaunch_moc.ui
@@ -539,135 +539,7 @@
         </spacer>
        </item>
        <item>
-        <layout class="QGridLayout" name="gridLayout_4" rowstretch="1,0,0,0,0" columnstretch="3,1">
-         <item row="3" column="0">
-          <widget class="QLabel" name="labelPresetHota">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-             <horstretch>100</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>VCMI provides support for Horn of the Abyss: fan-made Heroes III expansion, ported by VCMI team</string>
-           </property>
-           <property name="wordWrap">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="0">
-          <widget class="QLabel" name="labelPresetExtras">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-             <horstretch>100</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>VCMI provides support for playing Heroes III in resolutions other than 800x600. If you wish, you can install this support</string>
-           </property>
-           <property name="wordWrap">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="1">
-          <widget class="QToolButton" name="toolButtonPresetExtras">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>Install HD support</string>
-           </property>
-           <property name="toolButtonStyle">
-            <enum>Qt::ToolButtonTextOnly</enum>
-           </property>
-          </widget>
-         </item>
-         <item row="4" column="1">
-          <widget class="QToolButton" name="toolButtonPresetWog">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>Install In the Wake of Gods</string>
-           </property>
-           <property name="toolButtonStyle">
-            <enum>Qt::ToolButtonTextOnly</enum>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="1">
-          <widget class="QToolButton" name="toolButtonPresetLanguage">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>Install localization</string>
-           </property>
-           <property name="toolButtonStyle">
-            <enum>Qt::ToolButtonTextOnly</enum>
-           </property>
-          </widget>
-         </item>
-         <item row="4" column="0">
-          <widget class="QLabel" name="labelPresetWog">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-             <horstretch>100</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>VCMI provides compatible version of the &quot;In The Wake of Gods&quot; fan-made addon</string>
-           </property>
-           <property name="wordWrap">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="0">
-          <widget class="QLabel" name="labelPresetLanguage">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-             <horstretch>100</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>VCMI provides translations of Heroes III into a different languages. If you wish, you can install translation to English</string>
-           </property>
-           <property name="wordWrap">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-         <item row="3" column="1">
-          <widget class="QToolButton" name="toolButtonPresetHota">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>Install Horn of the Abyss</string>
-           </property>
-           <property name="toolButtonStyle">
-            <enum>Qt::ToolButtonTextOnly</enum>
-           </property>
-          </widget>
-         </item>
+        <layout class="QFormLayout" name="formLayout">
          <item row="0" column="0" colspan="2">
           <widget class="QLabel" name="labelPresetDescription">
            <property name="sizePolicy">
@@ -677,7 +549,129 @@
             </sizepolicy>
            </property>
            <property name="text">
-            <string>Optionally, you can install additional mods either now or at any point later</string>
+            <string>Optionally, you can install additional mods either now or at any point later:</string>
+           </property>
+           <property name="wordWrap">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QCheckBox" name="checkBoxPresetLanguage">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+           <property name="checked">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="QLabel" name="labelPresetLanguage">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+             <horstretch>100</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Install English translation of Heroes III</string>
+           </property>
+           <property name="wordWrap">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="QCheckBox" name="checkBoxPresetExtras">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+           <property name="checked">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="QLabel" name="labelPresetExtras">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+             <horstretch>100</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Install support for playing Heroes III in resolutions other than 800x600.</string>
+           </property>
+           <property name="wordWrap">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="0">
+          <widget class="QCheckBox" name="checkBoxPresetHota">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="1">
+          <widget class="QLabel" name="labelPresetHota">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+             <horstretch>100</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Install compatible version of addon Horn of the Abyss: fan-made Heroes III expansion, ported by VCMI team</string>
+           </property>
+           <property name="wordWrap">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="0">
+          <widget class="QCheckBox" name="checkBoxPresetWog">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="1">
+          <widget class="QLabel" name="labelPresetWog">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+             <horstretch>100</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Install compatible version of addon &quot;In The Wake of Gods&quot;: fan-made Heroes III expansion</string>
            </property>
            <property name="wordWrap">
             <bool>true</bool>

--- a/launcher/firstLaunch/firstlaunch_moc.ui
+++ b/launcher/firstLaunch/firstlaunch_moc.ui
@@ -157,7 +157,7 @@
         <number>0</number>
        </property>
        <item row="0" column="0">
-        <widget class="QLabel" name="label">
+        <widget class="QLabel" name="labelLanguageTitle">
          <property name="font">
           <font>
            <weight>75</weight>
@@ -170,7 +170,7 @@
         </widget>
        </item>
        <item row="2" column="2">
-        <widget class="QPushButton" name="pushButton_3">
+        <widget class="QPushButton" name="pushButtonLanguageNext">
          <property name="text">
           <string>Next</string>
          </property>
@@ -203,35 +203,10 @@
         </spacer>
        </item>
        <item row="1" column="0" rowspan="2">
-        <widget class="QListWidget" name="listWidget">
+        <widget class="QListWidget" name="listWidgetLanguage">
          <property name="spacing">
           <number>5</number>
          </property>
-         <item>
-          <property name="text">
-           <string>English</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>German</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Polish</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Russian</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Ukrainian</string>
-          </property>
-         </item>
         </widget>
        </item>
       </layout>
@@ -254,7 +229,7 @@
         <number>0</number>
        </property>
        <item>
-        <widget class="QLabel" name="label_2">
+        <widget class="QLabel" name="labelDataTitle">
          <property name="font">
           <font>
            <weight>75</weight>
@@ -285,7 +260,7 @@
           <number>6</number>
          </property>
          <item row="4" column="3">
-          <widget class="QPushButton" name="pushButton_11">
+          <widget class="QPushButton" name="pushButtonDataHelp">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
              <horstretch>25</horstretch>
@@ -298,7 +273,7 @@
           </widget>
          </item>
          <item row="2" column="3">
-          <widget class="QPushButton" name="pushButton_8">
+          <widget class="QPushButton" name="pushButtonDataSearch">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
              <horstretch>25</horstretch>
@@ -311,7 +286,7 @@
           </widget>
          </item>
          <item row="1" column="1" colspan="3">
-          <widget class="QLineEdit" name="lineEdit">
+          <widget class="QLineEdit" name="lineEditData1">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
              <horstretch>50</horstretch>
@@ -321,7 +296,7 @@
           </widget>
          </item>
          <item row="0" column="1" colspan="3">
-          <widget class="QLineEdit" name="lineEdit_2">
+          <widget class="QLineEdit" name="lineEditData2">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
              <horstretch>50</horstretch>
@@ -331,7 +306,7 @@
           </widget>
          </item>
          <item row="4" column="0" colspan="3">
-          <widget class="QLabel" name="label_14">
+          <widget class="QLabel" name="labelDataHelp">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
              <horstretch>100</horstretch>
@@ -347,7 +322,7 @@
           </widget>
          </item>
          <item row="2" column="0" colspan="3">
-          <widget class="QLabel" name="label_8">
+          <widget class="QLabel" name="labelDataSearch">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
              <horstretch>100</horstretch>
@@ -363,7 +338,7 @@
           </widget>
          </item>
          <item row="0" column="0">
-          <widget class="QLabel" name="label_23">
+          <widget class="QLabel" name="labelDataFiles">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
              <horstretch>50</horstretch>
@@ -382,7 +357,7 @@
           </widget>
          </item>
          <item row="3" column="0" colspan="3">
-          <widget class="QLabel" name="label_13">
+          <widget class="QLabel" name="labelDataCopy">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
              <horstretch>100</horstretch>
@@ -398,7 +373,7 @@
           </widget>
          </item>
          <item row="3" column="3">
-          <widget class="QPushButton" name="pushButton_10">
+          <widget class="QPushButton" name="pushButtonDataCopy">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
              <horstretch>25</horstretch>
@@ -411,7 +386,7 @@
           </widget>
          </item>
          <item row="5" column="0" colspan="4">
-          <widget class="QLabel" name="label_15">
+          <widget class="QLabel" name="labelDataFound">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
              <horstretch>100</horstretch>
@@ -447,7 +422,7 @@
           <number>6</number>
          </property>
          <item row="1" column="0" colspan="2">
-          <widget class="QLabel" name="label_25">
+          <widget class="QLabel" name="labelDataSuccess">
            <property name="text">
             <string>You Heroes III language was succesfully detected automatically.</string>
            </property>
@@ -457,7 +432,7 @@
           </widget>
          </item>
          <item row="2" column="0" colspan="2">
-          <widget class="QLabel" name="label_24">
+          <widget class="QLabel" name="labelDataFailure">
            <property name="text">
             <string>Automatic detection of language failed. Please select language of your Heroes III copy</string>
            </property>
@@ -467,10 +442,10 @@
           </widget>
          </item>
          <item row="0" column="1">
-          <widget class="QComboBox" name="comboBox"/>
+          <widget class="QComboBox" name="comboBoxLanguage"/>
          </item>
          <item row="0" column="0">
-          <widget class="QLabel" name="label_5">
+          <widget class="QLabel" name="labelDataLanguage">
            <property name="font">
             <font>
              <weight>75</weight>
@@ -519,14 +494,14 @@
           </spacer>
          </item>
          <item>
-          <widget class="QPushButton" name="pushButton_2">
+          <widget class="QPushButton" name="pushButtonDataBack">
            <property name="text">
             <string>Back</string>
            </property>
           </widget>
          </item>
          <item>
-          <widget class="QPushButton" name="pushButton_4">
+          <widget class="QPushButton" name="pushButtonDataNext">
            <property name="text">
             <string>Next</string>
            </property>
@@ -551,7 +526,7 @@
         <number>0</number>
        </property>
        <item>
-        <widget class="QLabel" name="label_3">
+        <widget class="QLabel" name="labelPresetTitle">
          <property name="font">
           <font>
            <weight>75</weight>
@@ -579,7 +554,7 @@
        <item>
         <layout class="QGridLayout" name="gridLayout_4" rowstretch="1,0,0,0">
          <item row="2" column="0">
-          <widget class="QLabel" name="label_11">
+          <widget class="QLabel" name="labelPresetHota">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
              <horstretch>100</horstretch>
@@ -595,7 +570,7 @@
           </widget>
          </item>
          <item row="0" column="1">
-          <widget class="QToolButton" name="toolButton">
+          <widget class="QToolButton" name="toolButtonPresetLanguage">
            <property name="sizePolicy">
             <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
              <horstretch>0</horstretch>
@@ -603,7 +578,7 @@
             </sizepolicy>
            </property>
            <property name="text">
-            <string>Localization to (language)</string>
+            <string>Localization to English</string>
            </property>
            <property name="toolButtonStyle">
             <enum>Qt::ToolButtonTextOnly</enum>
@@ -611,7 +586,7 @@
           </widget>
          </item>
          <item row="3" column="0">
-          <widget class="QLabel" name="label_12">
+          <widget class="QLabel" name="labelPresetWog">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
              <horstretch>100</horstretch>
@@ -627,7 +602,7 @@
           </widget>
          </item>
          <item row="2" column="1">
-          <widget class="QToolButton" name="toolButton_3">
+          <widget class="QToolButton" name="toolButtonPresetHota">
            <property name="sizePolicy">
             <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
              <horstretch>0</horstretch>
@@ -643,7 +618,7 @@
           </widget>
          </item>
          <item row="3" column="1">
-          <widget class="QToolButton" name="toolButton_4">
+          <widget class="QToolButton" name="toolButtonPresetWog">
            <property name="sizePolicy">
             <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
              <horstretch>0</horstretch>
@@ -659,7 +634,7 @@
           </widget>
          </item>
          <item row="1" column="0">
-          <widget class="QLabel" name="label_10">
+          <widget class="QLabel" name="labelPresetExtras">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
              <horstretch>100</horstretch>
@@ -675,7 +650,7 @@
           </widget>
          </item>
          <item row="0" column="0">
-          <widget class="QLabel" name="label_9">
+          <widget class="QLabel" name="labelPresetLanguage">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
              <horstretch>100</horstretch>
@@ -683,7 +658,7 @@
             </sizepolicy>
            </property>
            <property name="text">
-            <string>VCMI provides translations of Heroes III into a different languages. If you wish, you can install translation to (your language)</string>
+            <string>VCMI provides translations of Heroes III into a different languages. If you wish, you can install translation to English</string>
            </property>
            <property name="wordWrap">
             <bool>true</bool>
@@ -691,7 +666,7 @@
           </widget>
          </item>
          <item row="1" column="1">
-          <widget class="QToolButton" name="toolButton_2">
+          <widget class="QToolButton" name="toolButtonPresetExtras">
            <property name="sizePolicy">
             <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
              <horstretch>0</horstretch>
@@ -737,14 +712,14 @@
           </spacer>
          </item>
          <item>
-          <widget class="QPushButton" name="pushButton_9">
+          <widget class="QPushButton" name="pushButtonPresetBack">
            <property name="text">
             <string>Back</string>
            </property>
           </widget>
          </item>
          <item>
-          <widget class="QPushButton" name="pushButton_13">
+          <widget class="QPushButton" name="pushButtonPresetNext">
            <property name="text">
             <string>Skip</string>
            </property>
@@ -810,14 +785,14 @@
           </spacer>
          </item>
          <item>
-          <widget class="QPushButton" name="pushButton_14">
+          <widget class="QPushButton" name="pushButtonFinishBack">
            <property name="text">
             <string>Back</string>
            </property>
           </widget>
          </item>
          <item>
-          <widget class="QPushButton" name="pushButton_15">
+          <widget class="QPushButton" name="pushButtonFinishExit">
            <property name="text">
             <string>Finish</string>
            </property>

--- a/launcher/firstLaunch/firstlaunch_moc.ui
+++ b/launcher/firstLaunch/firstlaunch_moc.ui
@@ -1,0 +1,836 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>FirstLaunchView</class>
+ <widget class="QWidget" name="FirstLaunchView">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>650</width>
+    <height>409</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string/>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QToolButton" name="buttonTabLanguage">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Language</string>
+       </property>
+       <property name="checkable">
+        <bool>true</bool>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
+       <property name="toolButtonStyle">
+        <enum>Qt::ToolButtonTextOnly</enum>
+       </property>
+       <property name="autoRaise">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QToolButton" name="buttonTabHeroesData">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Heroes III Data</string>
+       </property>
+       <property name="checkable">
+        <bool>true</bool>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
+       <property name="toolButtonStyle">
+        <enum>Qt::ToolButtonTextOnly</enum>
+       </property>
+       <property name="autoRaise">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QToolButton" name="buttonTabModPreset">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Mods Preset</string>
+       </property>
+       <property name="checkable">
+        <bool>true</bool>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
+       <property name="toolButtonStyle">
+        <enum>Qt::ToolButtonTextOnly</enum>
+       </property>
+       <property name="autoRaise">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QToolButton" name="buttonTabFinish">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Finish</string>
+       </property>
+       <property name="checkable">
+        <bool>true</bool>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
+       <property name="toolButtonStyle">
+        <enum>Qt::ToolButtonTextOnly</enum>
+       </property>
+       <property name="autoRaise">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QProgressBar" name="progressBar">
+     <property name="minimum">
+      <number>0</number>
+     </property>
+     <property name="maximum">
+      <number>4</number>
+     </property>
+     <property name="value">
+      <number>0</number>
+     </property>
+     <property name="textVisible">
+      <bool>true</bool>
+     </property>
+     <property name="format">
+      <string>Step %v out of %m</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QStackedWidget" name="installerTabs">
+     <property name="currentIndex">
+      <number>3</number>
+     </property>
+     <widget class="QWidget" name="pageLanguageSelect">
+      <layout class="QGridLayout" name="gridLayout_3">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+       <item row="0" column="0">
+        <widget class="QLabel" name="label">
+         <property name="font">
+          <font>
+           <weight>75</weight>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>Choose your language</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="2">
+        <widget class="QPushButton" name="pushButton_3">
+         <property name="text">
+          <string>Next</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="1">
+        <spacer name="horizontalSpacer">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="1" column="2">
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="1" column="0" rowspan="2">
+        <widget class="QListWidget" name="listWidget">
+         <property name="spacing">
+          <number>5</number>
+         </property>
+         <item>
+          <property name="text">
+           <string>English</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>German</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Polish</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Russian</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Ukrainian</string>
+          </property>
+         </item>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="pageDataFiles">
+      <layout class="QVBoxLayout" name="verticalLayout_4">
+       <property name="spacing">
+        <number>0</number>
+       </property>
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+       <item>
+        <widget class="QLabel" name="label_2">
+         <property name="font">
+          <font>
+           <weight>75</weight>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>Find Heroes III data files</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer_8">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>0</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <layout class="QGridLayout" name="gridLayout" columnstretch="1,1,1,1">
+         <property name="spacing">
+          <number>6</number>
+         </property>
+         <item row="4" column="3">
+          <widget class="QPushButton" name="pushButton_11">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+             <horstretch>25</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Open help in browser</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="3">
+          <widget class="QPushButton" name="pushButton_8">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+             <horstretch>25</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Search again</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1" colspan="3">
+          <widget class="QLineEdit" name="lineEdit">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+             <horstretch>50</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1" colspan="3">
+          <widget class="QLineEdit" name="lineEdit_2">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+             <horstretch>50</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="0" colspan="3">
+          <widget class="QLabel" name="label_14">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+             <horstretch>100</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>If you don't have installed Heroes III copy, it is possible to use our automatic installation tool 'vcmibuilder' to extract data from GoG.com installer. Visit our wiki for detailed instructions.</string>
+           </property>
+           <property name="wordWrap">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0" colspan="3">
+          <widget class="QLabel" name="label_8">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+             <horstretch>100</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>VCMI requires Heroes III data files in one of the locations listed above. Please copy Heroes III data in one of these directories.</string>
+           </property>
+           <property name="wordWrap">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="0">
+          <widget class="QLabel" name="label_23">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+             <horstretch>50</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="font">
+            <font>
+             <weight>75</weight>
+             <bold>true</bold>
+            </font>
+           </property>
+           <property name="text">
+            <string>Heroes III data files</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="0" colspan="3">
+          <widget class="QLabel" name="label_13">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+             <horstretch>100</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Alternatively, you can select directory with installed Heroes III data and VCMI will copy exisiting data automatically.</string>
+           </property>
+           <property name="wordWrap">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="3">
+          <widget class="QPushButton" name="pushButton_10">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+             <horstretch>25</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Copy existing data</string>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="0" colspan="4">
+          <widget class="QLabel" name="label_15">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+             <horstretch>100</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Your Heroes III data files have been succesfully found.</string>
+           </property>
+           <property name="wordWrap">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <spacer name="verticalSpacer_4">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>0</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <layout class="QGridLayout" name="gridLayout_2" columnstretch="2,1">
+         <property name="verticalSpacing">
+          <number>6</number>
+         </property>
+         <item row="1" column="0" colspan="2">
+          <widget class="QLabel" name="label_25">
+           <property name="text">
+            <string>You Heroes III language was succesfully detected automatically.</string>
+           </property>
+           <property name="wordWrap">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0" colspan="2">
+          <widget class="QLabel" name="label_24">
+           <property name="text">
+            <string>Automatic detection of language failed. Please select language of your Heroes III copy</string>
+           </property>
+           <property name="wordWrap">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="QComboBox" name="comboBox"/>
+         </item>
+         <item row="0" column="0">
+          <widget class="QLabel" name="label_5">
+           <property name="font">
+            <font>
+             <weight>75</weight>
+             <bold>true</bold>
+            </font>
+           </property>
+           <property name="text">
+            <string>Heroes III language</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <spacer name="verticalSpacer_3">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>0</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_4">
+         <property name="spacing">
+          <number>6</number>
+         </property>
+         <item>
+          <spacer name="horizontalSpacer_4">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeType">
+            <enum>QSizePolicy::MinimumExpanding</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>20</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <widget class="QPushButton" name="pushButton_2">
+           <property name="text">
+            <string>Back</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="pushButton_4">
+           <property name="text">
+            <string>Next</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="pageModPreset">
+      <layout class="QVBoxLayout" name="verticalLayout_3">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+       <item>
+        <widget class="QLabel" name="label_3">
+         <property name="font">
+          <font>
+           <weight>75</weight>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>Install VCMI Mod Preset</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer_5">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <layout class="QGridLayout" name="gridLayout_4" rowstretch="1,0,0,0">
+         <item row="2" column="0">
+          <widget class="QLabel" name="label_11">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+             <horstretch>100</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>VCMI provides its own version of Horn of the Abyss fan-made addon. If you wish you can install it right now. For more information about mod visit hota website</string>
+           </property>
+           <property name="wordWrap">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="QToolButton" name="toolButton">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Localization to (language)</string>
+           </property>
+           <property name="toolButtonStyle">
+            <enum>Qt::ToolButtonTextOnly</enum>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="0">
+          <widget class="QLabel" name="label_12">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+             <horstretch>100</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Install VCMI-compatible version of the &quot;In The Wake of Gods&quot; fan-made addon</string>
+           </property>
+           <property name="wordWrap">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="QToolButton" name="toolButton_3">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Heroes III + HotA</string>
+           </property>
+           <property name="toolButtonStyle">
+            <enum>Qt::ToolButtonTextOnly</enum>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="1">
+          <widget class="QToolButton" name="toolButton_4">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Heroes III + WoG</string>
+           </property>
+           <property name="toolButtonStyle">
+            <enum>Qt::ToolButtonTextOnly</enum>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="label_10">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+             <horstretch>100</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>VCMI provides support for playing Heroes III in resolutions other than 800x600. If you wish, you can install this support</string>
+           </property>
+           <property name="wordWrap">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="0">
+          <widget class="QLabel" name="label_9">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+             <horstretch>100</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>VCMI provides translations of Heroes III into a different languages. If you wish, you can install translation to (your language)</string>
+           </property>
+           <property name="wordWrap">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="QToolButton" name="toolButton_2">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>HD support</string>
+           </property>
+           <property name="toolButtonStyle">
+            <enum>Qt::ToolButtonTextOnly</enum>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <spacer name="verticalSpacer_6">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_3">
+         <item>
+          <spacer name="horizontalSpacer_3">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <widget class="QPushButton" name="pushButton_9">
+           <property name="text">
+            <string>Back</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="pushButton_13">
+           <property name="text">
+            <string>Skip</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="pageFinish">
+      <layout class="QVBoxLayout" name="verticalLayout_2">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+       <item>
+        <widget class="QLabel" name="label_7">
+         <property name="font">
+          <font>
+           <weight>75</weight>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>Join community / get help</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer_7">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_2">
+         <item>
+          <spacer name="horizontalSpacer_2">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <widget class="QPushButton" name="pushButton_14">
+           <property name="text">
+            <string>Back</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="pushButton_15">
+           <property name="text">
+            <string>Finish</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/launcher/firstLaunch/firstlaunch_moc.ui
+++ b/launcher/firstLaunch/firstlaunch_moc.ui
@@ -91,31 +91,6 @@
        </property>
       </widget>
      </item>
-     <item>
-      <widget class="QToolButton" name="buttonTabFinish">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="text">
-        <string>Finish</string>
-       </property>
-       <property name="checkable">
-        <bool>true</bool>
-       </property>
-       <property name="checked">
-        <bool>true</bool>
-       </property>
-       <property name="toolButtonStyle">
-        <enum>Qt::ToolButtonTextOnly</enum>
-       </property>
-       <property name="autoRaise">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
     </layout>
    </item>
    <item>
@@ -124,7 +99,7 @@
       <number>0</number>
      </property>
      <property name="maximum">
-      <number>4</number>
+      <number>3</number>
      </property>
      <property name="value">
       <number>0</number>
@@ -564,8 +539,8 @@
         </spacer>
        </item>
        <item>
-        <layout class="QGridLayout" name="gridLayout_4" rowstretch="1,0,0,0">
-         <item row="2" column="0">
+        <layout class="QGridLayout" name="gridLayout_4" rowstretch="1,0,0,0,0" columnstretch="3,1">
+         <item row="3" column="0">
           <widget class="QLabel" name="labelPresetHota">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
@@ -581,71 +556,7 @@
            </property>
           </widget>
          </item>
-         <item row="0" column="1">
-          <widget class="QToolButton" name="toolButtonPresetLanguage">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>Install localization</string>
-           </property>
-           <property name="toolButtonStyle">
-            <enum>Qt::ToolButtonTextOnly</enum>
-           </property>
-          </widget>
-         </item>
-         <item row="3" column="0">
-          <widget class="QLabel" name="labelPresetWog">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-             <horstretch>100</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>VCMI provides compatible version of the &quot;In The Wake of Gods&quot; fan-made addon</string>
-           </property>
-           <property name="wordWrap">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="1">
-          <widget class="QToolButton" name="toolButtonPresetHota">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>Install Horn of the Abyss</string>
-           </property>
-           <property name="toolButtonStyle">
-            <enum>Qt::ToolButtonTextOnly</enum>
-           </property>
-          </widget>
-         </item>
-         <item row="3" column="1">
-          <widget class="QToolButton" name="toolButtonPresetWog">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>Install In the Wake of Gods</string>
-           </property>
-           <property name="toolButtonStyle">
-            <enum>Qt::ToolButtonTextOnly</enum>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="0">
+         <item row="2" column="0">
           <widget class="QLabel" name="labelPresetExtras">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
@@ -661,7 +572,71 @@
            </property>
           </widget>
          </item>
-         <item row="0" column="0">
+         <item row="2" column="1">
+          <widget class="QToolButton" name="toolButtonPresetExtras">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Install HD support</string>
+           </property>
+           <property name="toolButtonStyle">
+            <enum>Qt::ToolButtonTextOnly</enum>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="1">
+          <widget class="QToolButton" name="toolButtonPresetWog">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Install In the Wake of Gods</string>
+           </property>
+           <property name="toolButtonStyle">
+            <enum>Qt::ToolButtonTextOnly</enum>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="QToolButton" name="toolButtonPresetLanguage">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Install localization</string>
+           </property>
+           <property name="toolButtonStyle">
+            <enum>Qt::ToolButtonTextOnly</enum>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="0">
+          <widget class="QLabel" name="labelPresetWog">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+             <horstretch>100</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>VCMI provides compatible version of the &quot;In The Wake of Gods&quot; fan-made addon</string>
+           </property>
+           <property name="wordWrap">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
           <widget class="QLabel" name="labelPresetLanguage">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
@@ -677,8 +652,8 @@
            </property>
           </widget>
          </item>
-         <item row="1" column="1">
-          <widget class="QToolButton" name="toolButtonPresetExtras">
+         <item row="3" column="1">
+          <widget class="QToolButton" name="toolButtonPresetHota">
            <property name="sizePolicy">
             <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
              <horstretch>0</horstretch>
@@ -686,10 +661,26 @@
             </sizepolicy>
            </property>
            <property name="text">
-            <string>Install HD support</string>
+            <string>Install Horn of the Abyss</string>
            </property>
            <property name="toolButtonStyle">
             <enum>Qt::ToolButtonTextOnly</enum>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="0" colspan="2">
+          <widget class="QLabel" name="labelPresetDescription">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+             <horstretch>100</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Optionally, you can install additional mods either now or at any point later</string>
+           </property>
+           <property name="wordWrap">
+            <bool>true</bool>
            </property>
           </widget>
          </item>
@@ -732,79 +723,6 @@
          </item>
          <item>
           <widget class="QPushButton" name="pushButtonPresetNext">
-           <property name="text">
-            <string>Skip</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-      </layout>
-     </widget>
-     <widget class="QWidget" name="pageFinish">
-      <layout class="QVBoxLayout" name="verticalLayout_2">
-       <property name="leftMargin">
-        <number>0</number>
-       </property>
-       <property name="topMargin">
-        <number>0</number>
-       </property>
-       <property name="rightMargin">
-        <number>0</number>
-       </property>
-       <property name="bottomMargin">
-        <number>0</number>
-       </property>
-       <item>
-        <widget class="QLabel" name="label_7">
-         <property name="font">
-          <font>
-           <weight>75</weight>
-           <bold>true</bold>
-          </font>
-         </property>
-         <property name="text">
-          <string>Join community / get help</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <spacer name="verticalSpacer_7">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_2">
-         <item>
-          <spacer name="horizontalSpacer_2">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>40</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-         <item>
-          <widget class="QPushButton" name="pushButtonFinishBack">
-           <property name="text">
-            <string>Back</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QPushButton" name="pushButtonFinishExit">
            <property name="text">
             <string>Finish</string>
            </property>

--- a/launcher/firstLaunch/firstlaunch_moc.ui
+++ b/launcher/firstLaunch/firstlaunch_moc.ui
@@ -115,7 +115,7 @@
    <item>
     <widget class="QStackedWidget" name="installerTabs">
      <property name="currentIndex">
-      <number>2</number>
+      <number>1</number>
      </property>
      <widget class="QWidget" name="pageLanguageSelect">
       <layout class="QGridLayout" name="gridLayout_3">
@@ -381,7 +381,7 @@
             </sizepolicy>
            </property>
            <property name="text">
-            <string>Your Heroes III data files have been succesfully found.</string>
+            <string>Your Heroes III data files have been successfully found.</string>
            </property>
            <property name="wordWrap">
             <bool>true</bool>
@@ -411,7 +411,7 @@
          <item row="1" column="0" colspan="2">
           <widget class="QLabel" name="labelDataSuccess">
            <property name="text">
-            <string>Your Heroes III language has been succesfully detected.</string>
+            <string>Your Heroes III language has been successfully detected.</string>
            </property>
            <property name="wordWrap">
             <bool>true</bool>
@@ -581,7 +581,7 @@
             </sizepolicy>
            </property>
            <property name="text">
-            <string>Install English translation of Heroes III</string>
+            <string>Install translation of Heroes III to your language</string>
            </property>
            <property name="wordWrap">
             <bool>true</bool>

--- a/launcher/firstLaunch/firstlaunch_moc.ui
+++ b/launcher/firstLaunch/firstlaunch_moc.ui
@@ -119,7 +119,7 @@
     </layout>
    </item>
    <item>
-    <widget class="QProgressBar" name="progressBar">
+    <widget class="QProgressBar" name="setupProgressBar">
      <property name="minimum">
       <number>0</number>
      </property>
@@ -140,7 +140,7 @@
    <item>
     <widget class="QStackedWidget" name="installerTabs">
      <property name="currentIndex">
-      <number>0</number>
+      <number>2</number>
      </property>
      <widget class="QWidget" name="pageLanguageSelect">
       <layout class="QGridLayout" name="gridLayout_3">
@@ -286,22 +286,34 @@
           </widget>
          </item>
          <item row="1" column="1" colspan="3">
-          <widget class="QLineEdit" name="lineEditData1">
+          <widget class="QLineEdit" name="lineEditDataSystem">
+           <property name="enabled">
+            <bool>true</bool>
+           </property>
            <property name="sizePolicy">
             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
              <horstretch>50</horstretch>
              <verstretch>0</verstretch>
             </sizepolicy>
            </property>
+           <property name="readOnly">
+            <bool>true</bool>
+           </property>
           </widget>
          </item>
          <item row="0" column="1" colspan="3">
-          <widget class="QLineEdit" name="lineEditData2">
+          <widget class="QLineEdit" name="lineEditDataUser">
+           <property name="enabled">
+            <bool>true</bool>
+           </property>
            <property name="sizePolicy">
             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
              <horstretch>50</horstretch>
              <verstretch>0</verstretch>
             </sizepolicy>
+           </property>
+           <property name="readOnly">
+            <bool>true</bool>
            </property>
           </widget>
          </item>
@@ -424,7 +436,7 @@
          <item row="1" column="0" colspan="2">
           <widget class="QLabel" name="labelDataSuccess">
            <property name="text">
-            <string>You Heroes III language was succesfully detected automatically.</string>
+            <string>Your Heroes III language has been succesfully detected.</string>
            </property>
            <property name="wordWrap">
             <bool>true</bool>
@@ -562,7 +574,7 @@
             </sizepolicy>
            </property>
            <property name="text">
-            <string>VCMI provides its own version of Horn of the Abyss fan-made addon. If you wish you can install it right now. For more information about mod visit hota website</string>
+            <string>VCMI provides support for Horn of the Abyss: fan-made Heroes III expansion, ported by VCMI team</string>
            </property>
            <property name="wordWrap">
             <bool>true</bool>
@@ -578,7 +590,7 @@
             </sizepolicy>
            </property>
            <property name="text">
-            <string>Localization to English</string>
+            <string>Install localization</string>
            </property>
            <property name="toolButtonStyle">
             <enum>Qt::ToolButtonTextOnly</enum>
@@ -594,7 +606,7 @@
             </sizepolicy>
            </property>
            <property name="text">
-            <string>Install VCMI-compatible version of the &quot;In The Wake of Gods&quot; fan-made addon</string>
+            <string>VCMI provides compatible version of the &quot;In The Wake of Gods&quot; fan-made addon</string>
            </property>
            <property name="wordWrap">
             <bool>true</bool>
@@ -610,7 +622,7 @@
             </sizepolicy>
            </property>
            <property name="text">
-            <string>Heroes III + HotA</string>
+            <string>Install Horn of the Abyss</string>
            </property>
            <property name="toolButtonStyle">
             <enum>Qt::ToolButtonTextOnly</enum>
@@ -626,7 +638,7 @@
             </sizepolicy>
            </property>
            <property name="text">
-            <string>Heroes III + WoG</string>
+            <string>Install In the Wake of Gods</string>
            </property>
            <property name="toolButtonStyle">
             <enum>Qt::ToolButtonTextOnly</enum>
@@ -674,7 +686,7 @@
             </sizepolicy>
            </property>
            <property name="text">
-            <string>HD support</string>
+            <string>Install HD support</string>
            </property>
            <property name="toolButtonStyle">
             <enum>Qt::ToolButtonTextOnly</enum>

--- a/launcher/firstLaunch/firstlaunch_moc.ui
+++ b/launcher/firstLaunch/firstlaunch_moc.ui
@@ -140,7 +140,7 @@
    <item>
     <widget class="QStackedWidget" name="installerTabs">
      <property name="currentIndex">
-      <number>3</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="pageLanguageSelect">
       <layout class="QGridLayout" name="gridLayout_3">

--- a/launcher/languages.cpp
+++ b/launcher/languages.cpp
@@ -42,11 +42,11 @@ QString Languages::generateLanguageName(const Languages::Options & language)
 	QString localizedName = QApplication::translate("Language", language.nameEnglish.c_str());
 	QString nativeName = language.nameNative.c_str();
 
-	if(activeLanguage == language.identifier)
-		return nativeName;
-
 	if(!language.hasTranslation)
 		return localizedName;
+
+	if(activeLanguage == language.identifier)
+		return nativeName;
 
 	QString displayName = QString("%1 (%2)").arg(localizedName, nativeName);
 

--- a/launcher/languages.cpp
+++ b/launcher/languages.cpp
@@ -17,7 +17,7 @@
 #include <QListWidget>
 
 // list of language names, for generation of translations. Do not use directly, use Languages namespace instead
-static const std::array<std::string, 11> languageTranslatedNamesGenerator = {
+static const std::array<std::string, 12> languageTranslatedNamesGenerator = {
 	{
 		QT_TRANSLATE_NOOP("Language", "Chinese"),
 		QT_TRANSLATE_NOOP("Language", "English"),
@@ -26,6 +26,7 @@ static const std::array<std::string, 11> languageTranslatedNamesGenerator = {
 		QT_TRANSLATE_NOOP("Language", "Korean"),
 		QT_TRANSLATE_NOOP("Language", "Polish"),
 		QT_TRANSLATE_NOOP("Language", "Russian"),
+		QT_TRANSLATE_NOOP("Language", "Spanish"),
 		QT_TRANSLATE_NOOP("Language", "Ukrainian"),
 		QT_TRANSLATE_NOOP("Language", "Other (East European)"),
 		QT_TRANSLATE_NOOP("Language", "Other (Cyrillic Script)"),
@@ -53,7 +54,7 @@ QString Languages::generateLanguageName(const Languages::Options & language)
 	return displayName;
 }
 
-void Languages::fillLanguages(QComboBox * widget)
+void Languages::fillLanguages(QComboBox * widget, bool includeAll)
 {
 	widget->blockSignals(true); // we do not want calls caused by initialization
 	widget->clear();
@@ -62,6 +63,9 @@ void Languages::fillLanguages(QComboBox * widget)
 
 	for(const auto & language : Languages::getLanguageList())
 	{
+		if (!language.hasTranslation && !includeAll)
+			continue;
+
 		QString displayName = generateLanguageName(language);
 		QVariant userData = QString::fromStdString(language.identifier);
 
@@ -73,7 +77,7 @@ void Languages::fillLanguages(QComboBox * widget)
 	widget->blockSignals(false);
 }
 
-void Languages::fillLanguages(QListWidget * widget)
+void Languages::fillLanguages(QListWidget * widget, bool includeAll)
 {
 	widget->blockSignals(true); // we do not want calls caused by initialization
 	widget->clear();
@@ -82,6 +86,9 @@ void Languages::fillLanguages(QListWidget * widget)
 
 	for(const auto & language : Languages::getLanguageList())
 	{
+		if (!language.hasTranslation && !includeAll)
+			continue;
+
 		QString displayName = generateLanguageName(language);
 		QVariant userData = QString::fromStdString(language.identifier);
 

--- a/launcher/languages.cpp
+++ b/launcher/languages.cpp
@@ -1,0 +1,94 @@
+/*
+ * languages.cpp, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
+#include "StdInc.h"
+#include "languages.h"
+
+#include "../lib/CConfigHandler.h"
+#include "../lib/Languages.h"
+
+#include <QComboBox>
+#include <QListWidget>
+
+// list of language names, for generation of translations. Do not use directly, use Languages namespace instead
+static const std::array<std::string, 11> languageTranslatedNamesGenerator = {
+	{
+		QT_TRANSLATE_NOOP("Language", "Chinese"),
+		QT_TRANSLATE_NOOP("Language", "English"),
+		QT_TRANSLATE_NOOP("Language", "French"),
+		QT_TRANSLATE_NOOP("Language", "German"),
+		QT_TRANSLATE_NOOP("Language", "Korean"),
+		QT_TRANSLATE_NOOP("Language", "Polish"),
+		QT_TRANSLATE_NOOP("Language", "Russian"),
+		QT_TRANSLATE_NOOP("Language", "Ukrainian"),
+		QT_TRANSLATE_NOOP("Language", "Other (East European)"),
+		QT_TRANSLATE_NOOP("Language", "Other (Cyrillic Script)"),
+		QT_TRANSLATE_NOOP("Language", "Other (West European)"),
+	 }
+};
+
+static_assert(languageTranslatedNamesGenerator.size() == static_cast<size_t>(Languages::ELanguages::COUNT), "Languages array is missing a value!");
+
+QString Languages::generateLanguageName(const Languages::Options & language)
+{
+	std::string activeLanguage = settings["general"]["language"].String();
+
+	QString localizedName = QApplication::translate("Language", language.nameEnglish.c_str());
+	QString nativeName = language.nameNative.c_str();
+
+	if(activeLanguage == language.identifier)
+		return nativeName;
+
+	if(!language.hasTranslation)
+		return localizedName;
+
+	QString displayName = QString("%1 (%2)").arg(localizedName, nativeName);
+
+	return displayName;
+}
+
+void Languages::fillLanguages(QComboBox * widget)
+{
+	widget->blockSignals(true); // we do not want calls caused by initialization
+	widget->clear();
+
+	std::string activeLanguage = settings["general"]["language"].String();
+
+	for(const auto & language : Languages::getLanguageList())
+	{
+		QString displayName = generateLanguageName(language);
+		QVariant userData = QString::fromStdString(language.identifier);
+
+		widget->addItem(displayName, userData);
+		if(activeLanguage == language.identifier)
+			widget->setCurrentIndex(widget->count() - 1);
+	}
+
+	widget->blockSignals(false);
+}
+
+void Languages::fillLanguages(QListWidget * widget)
+{
+	widget->blockSignals(true); // we do not want calls caused by initialization
+	widget->clear();
+
+	std::string activeLanguage = settings["general"]["language"].String();
+
+	for(const auto & language : Languages::getLanguageList())
+	{
+		QString displayName = generateLanguageName(language);
+		QVariant userData = QString::fromStdString(language.identifier);
+
+		widget->addItem(displayName);
+		widget->item(widget->count() - 1)->setData(Qt::UserRole, userData);
+		if(activeLanguage == language.identifier)
+			widget->setCurrentRow(widget->count() - 1);
+	}
+	widget->blockSignals(false);
+}

--- a/launcher/languages.h
+++ b/launcher/languages.h
@@ -1,0 +1,28 @@
+/*
+ * languages.h, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
+#pragma once
+
+class QString;
+class QComboBox;
+class QListWidget;
+
+VCMI_LIB_NAMESPACE_BEGIN
+
+namespace Languages
+{
+	struct Options;
+
+	QString generateLanguageName(const Languages::Options & identifier);
+
+	void fillLanguages(QComboBox * widget);
+	void fillLanguages(QListWidget * widget);
+}
+
+VCMI_LIB_NAMESPACE_END

--- a/launcher/languages.h
+++ b/launcher/languages.h
@@ -18,9 +18,10 @@ namespace Languages
 	struct Options;
 
 	QString generateLanguageName(const Languages::Options & identifier);
+	QString getHeroesDataLanguage();
 
 	/// if includeAll is set, all languages including encoding placeholders will be included into widget
 	void fillLanguages(QComboBox * widget, bool includeAll);
 	void fillLanguages(QListWidget * widget, bool includeAll);
-}
 
+}

--- a/launcher/languages.h
+++ b/launcher/languages.h
@@ -19,7 +19,8 @@ namespace Languages
 
 	QString generateLanguageName(const Languages::Options & identifier);
 
-	void fillLanguages(QComboBox * widget);
-	void fillLanguages(QListWidget * widget);
+	/// if includeAll is set, all languages including encoding placeholders will be included into widget
+	void fillLanguages(QComboBox * widget, bool includeAll);
+	void fillLanguages(QListWidget * widget, bool includeAll);
 }
 

--- a/launcher/languages.h
+++ b/launcher/languages.h
@@ -13,8 +13,6 @@ class QString;
 class QComboBox;
 class QListWidget;
 
-VCMI_LIB_NAMESPACE_BEGIN
-
 namespace Languages
 {
 	struct Options;
@@ -25,4 +23,3 @@ namespace Languages
 	void fillLanguages(QListWidget * widget);
 }
 
-VCMI_LIB_NAMESPACE_END

--- a/launcher/mainwindow_moc.cpp
+++ b/launcher/mainwindow_moc.cpp
@@ -197,3 +197,10 @@ void MainWindow::updateTranslation()
 
 #endif
 }
+
+void MainWindow::on_setupButton_clicked()
+{
+	ui->startGameButton->setEnabled(false);
+	ui->tabListWidget->setCurrentIndex(TabRows::SETUP);
+}
+

--- a/launcher/mainwindow_moc.cpp
+++ b/launcher/mainwindow_moc.cpp
@@ -106,18 +106,9 @@ MainWindow::MainWindow(QWidget * parent)
 	bool setupCompleted = settings["launcher"]["setupCompleted"].Bool();
 
 	if (h3DataFound && setupCompleted)
-	{
 		ui->tabListWidget->setCurrentIndex(TabRows::MODS);
-	}
 	else
-	{
-		ui->startGameButton->setEnabled(false);
-		ui->startEditorButton->setEnabled(false);
-		ui->lobbyButton->setEnabled(false);
-		ui->settingsButton->setEnabled(false);
-		ui->modslistButton->setEnabled(false);
-		ui->tabListWidget->setCurrentIndex(TabRows::SETUP);
-	}
+		enterSetup();
 
 	ui->settingsView->isExtraResolutionsModEnabled = ui->modlistView->isExtraResolutionsModEnabled();
 	ui->settingsView->setDisplayList();
@@ -126,6 +117,29 @@ MainWindow::MainWindow(QWidget * parent)
 	
 	if(settings["launcher"]["updateOnStartup"].Bool())
 		UpdateDialog::showUpdateDialog(false);
+}
+
+void MainWindow::enterSetup()
+{
+	ui->startGameButton->setEnabled(false);
+	ui->startEditorButton->setEnabled(false);
+	ui->lobbyButton->setEnabled(false);
+	ui->settingsButton->setEnabled(false);
+	ui->modslistButton->setEnabled(false);
+	ui->tabListWidget->setCurrentIndex(TabRows::SETUP);
+}
+
+void MainWindow::exitSetup()
+{
+	Settings writer = settings.write["launcher"]["setupCompleted"];
+	writer->Bool() = true;
+
+	ui->startGameButton->setEnabled(true);
+	ui->startEditorButton->setEnabled(true);
+	ui->lobbyButton->setEnabled(true);
+	ui->settingsButton->setEnabled(true);
+	ui->modslistButton->setEnabled(true);
+	ui->tabListWidget->setCurrentIndex(TabRows::MODS);
 }
 
 void MainWindow::changeEvent(QEvent *event)

--- a/launcher/mainwindow_moc.cpp
+++ b/launcher/mainwindow_moc.cpp
@@ -102,7 +102,22 @@ MainWindow::MainWindow(QWidget * parent)
 
 	computeSidePanelSizes();
 
-	ui->tabListWidget->setCurrentIndex(0);
+	bool h3DataFound = CResourceHandler::get()->existsResource(ResourceID("DATA/GENRLTXT.TXT"));
+	bool setupCompleted = settings["launcher"]["setupCompleted"].Bool();
+
+	if (h3DataFound && setupCompleted)
+	{
+		ui->tabListWidget->setCurrentIndex(TabRows::MODS);
+	}
+	else
+	{
+		ui->startGameButton->setEnabled(false);
+		ui->startEditorButton->setEnabled(false);
+		ui->lobbyButton->setEnabled(false);
+		ui->settingsButton->setEnabled(false);
+		ui->modslistButton->setEnabled(false);
+		ui->tabListWidget->setCurrentIndex(TabRows::SETUP);
+	}
 
 	ui->settingsView->isExtraResolutionsModEnabled = ui->modlistView->isExtraResolutionsModEnabled();
 	ui->settingsView->setDisplayList();
@@ -145,6 +160,11 @@ void MainWindow::on_startEditorButton_clicked()
 const CModList & MainWindow::getModList() const
 {
 	return ui->modlistView->getModList();
+}
+
+CModListView * MainWindow::getModView()
+{
+	return ui->modlistView;
 }
 
 void MainWindow::on_modslistButton_clicked()
@@ -197,10 +217,3 @@ void MainWindow::updateTranslation()
 
 #endif
 }
-
-void MainWindow::on_setupButton_clicked()
-{
-	ui->startGameButton->setEnabled(false);
-	ui->tabListWidget->setCurrentIndex(TabRows::SETUP);
-}
-

--- a/launcher/mainwindow_moc.cpp
+++ b/launcher/mainwindow_moc.cpp
@@ -142,6 +142,12 @@ void MainWindow::exitSetup()
 	ui->tabListWidget->setCurrentIndex(TabRows::MODS);
 }
 
+void MainWindow::switchToModsTab()
+{
+	ui->startGameButton->setEnabled(true);
+	ui->tabListWidget->setCurrentIndex(TabRows::MODS);
+}
+
 void MainWindow::changeEvent(QEvent *event)
 {
 	if(event->type() == QEvent::LanguageChange)
@@ -183,8 +189,7 @@ CModListView * MainWindow::getModView()
 
 void MainWindow::on_modslistButton_clicked()
 {
-	ui->startGameButton->setEnabled(true);
-	ui->tabListWidget->setCurrentIndex(TabRows::MODS);
+	switchToModsTab();
 }
 
 void MainWindow::on_settingsButton_clicked()

--- a/launcher/mainwindow_moc.h
+++ b/launcher/mainwindow_moc.h
@@ -21,7 +21,7 @@ const QString appName = "VCMI Launcher";
 
 class QTableWidgetItem;
 class CModList;
-
+class CModListView;
 
 class MainWindow : public QMainWindow
 {
@@ -48,6 +48,7 @@ public:
 	~MainWindow() override;
 
 	const CModList & getModList() const;
+	CModListView * getModView();
 
 	void updateTranslation();
 	void computeSidePanelSizes();
@@ -60,5 +61,4 @@ private slots:
 	void on_settingsButton_clicked();
 	void on_lobbyButton_clicked();
 	void on_startEditorButton_clicked();
-	void on_setupButton_clicked();
 };

--- a/launcher/mainwindow_moc.h
+++ b/launcher/mainwindow_moc.h
@@ -44,8 +44,8 @@ private:
 
 	void changeEvent(QEvent *event) override;
 public:
-	explicit MainWindow(QWidget * parent = 0);
-	~MainWindow();
+	explicit MainWindow(QWidget * parent = nullptr);
+	~MainWindow() override;
 
 	const CModList & getModList() const;
 

--- a/launcher/mainwindow_moc.h
+++ b/launcher/mainwindow_moc.h
@@ -55,6 +55,7 @@ public:
 	
 	void enterSetup();
 	void exitSetup();
+	void switchToModsTab();
 
 public slots:
 	void on_startGameButton_clicked();

--- a/launcher/mainwindow_moc.h
+++ b/launcher/mainwindow_moc.h
@@ -53,6 +53,9 @@ public:
 	void updateTranslation();
 	void computeSidePanelSizes();
 	
+	void enterSetup();
+	void exitSetup();
+
 public slots:
 	void on_startGameButton_clicked();
 	

--- a/launcher/mainwindow_moc.h
+++ b/launcher/mainwindow_moc.h
@@ -36,7 +36,10 @@ private:
 	
 	enum TabRows
 	{
-		MODS = 0, SETTINGS = 1, LOBBY = 2
+		MODS = 0,
+		SETTINGS = 1,
+		LOBBY = 2,
+		SETUP = 3
 	};
 
 	void changeEvent(QEvent *event) override;
@@ -57,4 +60,5 @@ private slots:
 	void on_settingsButton_clicked();
 	void on_lobbyButton_clicked();
 	void on_startEditorButton_clicked();
+	void on_setupButton_clicked();
 };

--- a/launcher/mainwindow_moc.ui
+++ b/launcher/mainwindow_moc.ui
@@ -184,52 +184,6 @@
        </widget>
       </item>
       <item>
-       <widget class="QToolButton" name="setupButton">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
-          <horstretch>1</horstretch>
-          <verstretch>1</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>0</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>16777215</width>
-          <height>16777215</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>Setup</string>
-        </property>
-        <property name="iconSize">
-         <size>
-          <width>60</width>
-          <height>60</height>
-         </size>
-        </property>
-        <property name="checkable">
-         <bool>true</bool>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-        <property name="autoExclusive">
-         <bool>true</bool>
-        </property>
-        <property name="toolButtonStyle">
-         <enum>Qt::ToolButtonTextOnly</enum>
-        </property>
-        <property name="autoRaise">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
        <spacer name="verticalSpacer">
         <property name="orientation">
          <enum>Qt::Vertical</enum>

--- a/launcher/mainwindow_moc.ui
+++ b/launcher/mainwindow_moc.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>800</width>
-    <height>410</height>
+    <height>490</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -184,6 +184,52 @@
        </widget>
       </item>
       <item>
+       <widget class="QToolButton" name="setupButton">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+          <horstretch>1</horstretch>
+          <verstretch>1</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>16777215</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>Setup</string>
+        </property>
+        <property name="iconSize">
+         <size>
+          <width>60</width>
+          <height>60</height>
+         </size>
+        </property>
+        <property name="checkable">
+         <bool>true</bool>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+        <property name="autoExclusive">
+         <bool>true</bool>
+        </property>
+        <property name="toolButtonStyle">
+         <enum>Qt::ToolButtonTextOnly</enum>
+        </property>
+        <property name="autoRaise">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
        <spacer name="verticalSpacer">
         <property name="orientation">
          <enum>Qt::Vertical</enum>
@@ -316,11 +362,12 @@
        </sizepolicy>
       </property>
       <property name="currentIndex">
-       <number>0</number>
+       <number>3</number>
       </property>
       <widget class="CModListView" name="modlistView"/>
       <widget class="CSettingsView" name="settingsView"/>
       <widget class="Lobby" name="lobbyView"/>
+      <widget class="FirstLaunchView" name="setupView"/>
      </widget>
     </item>
    </layout>
@@ -344,6 +391,12 @@
    <class>Lobby</class>
    <extends>QWidget</extends>
    <header>lobby/lobby_moc.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>FirstLaunchView</class>
+   <extends>QWidget</extends>
+   <header>firstLaunch/firstlaunch_moc.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/launcher/modManager/cmodlist.cpp
+++ b/launcher/modManager/cmodlist.cpp
@@ -159,6 +159,17 @@ QString CModEntry::getName() const
 
 QVariant CModEntry::getValue(QString value) const
 {
+	return getValueImpl(value, true);
+}
+
+QVariant CModEntry::getBaseValue(QString value) const
+{
+	return getValueImpl(value, false);
+}
+
+QVariant CModEntry::getValueImpl(QString value, bool localized) const
+
+{
 	QString langValue = QString::fromStdString(settings["general"]["language"].String());
 
 	// Priorities
@@ -178,7 +189,7 @@ QVariant CModEntry::getValue(QString value) const
 
 	auto & storage = useRepositoryData ? repository : localData;
 
-	if(storage.contains(langValue))
+	if(localized && storage.contains(langValue))
 	{
 		auto langStorage = storage[langValue].toMap();
 		if (langStorage.contains(value))

--- a/launcher/modManager/cmodlist.cpp
+++ b/launcher/modManager/cmodlist.cpp
@@ -139,6 +139,11 @@ bool CModEntry::isValid() const
 	return !localData.isEmpty() || !repository.isEmpty();
 }
 
+bool CModEntry::isTranslation() const
+{
+	return getBaseValue("modType").toString().toLower() == "translation";
+}
+
 int CModEntry::getModStatus() const
 {
 	int status = 0;

--- a/launcher/modManager/cmodlist.h
+++ b/launcher/modManager/cmodlist.h
@@ -42,6 +42,7 @@ class CModEntry
 
 	QString modname;
 
+	QVariant getValueImpl(QString value, bool localized) const;
 public:
 	CModEntry(QVariantMap repository, QVariantMap localData, QVariantMap modSettings, QString modname);
 
@@ -69,6 +70,7 @@ public:
 
 	// get value of some field in mod structure. Returns empty optional if value is not present
 	QVariant getValue(QString value) const;
+	QVariant getBaseValue(QString value) const;
 
 	// returns true if less < greater comparing versions section by section
 	static bool compareVersions(QString lesser, QString greater);

--- a/launcher/modManager/cmodlist.h
+++ b/launcher/modManager/cmodlist.h
@@ -62,6 +62,8 @@ public:
 	bool isCompatible() const;
 	// returns if has any data
 	bool isValid() const;
+	// installed and enabled
+	bool isTranslation() const;
 
 	// see ModStatus enum
 	int getModStatus() const;

--- a/launcher/modManager/cmodlistview_moc.cpp
+++ b/launcher/modManager/cmodlistview_moc.cpp
@@ -847,7 +847,7 @@ QString CModListView::getTranslationModName(const QString & language)
 	{
 		auto mod = modModel->getMod(modName);
 
-		if (mod.getBaseValue("modType").toString().toLower() != "translation")
+		if (!mod.isTranslation())
 			continue;
 
 		if (mod.getBaseValue("language").toString() != language)

--- a/launcher/modManager/cmodlistview_moc.cpp
+++ b/launcher/modManager/cmodlistview_moc.cpp
@@ -102,7 +102,7 @@ CModListView::CModListView(QWidget * parent)
 
 	ui->progressWidget->setVisible(false);
 	dlManager = nullptr;
-	disableModInfo();
+
 	if(settings["launcher"]["autoCheckRepositories"].Bool())
 	{
 		loadRepositories();
@@ -813,4 +813,40 @@ const CModList & CModListView::getModList() const
 {
 	assert(modModel);
 	return *modModel;
+}
+
+void CModListView::doInstallMod(const QString & modName)
+{
+	assert(findInvalidDependencies(modName).empty());
+
+	for(auto & name : modModel->getRequirements(modName))
+	{
+		auto mod = modModel->getMod(name);
+		if(!mod.isInstalled())
+			downloadFile(name + ".zip", mod.getValue("download").toString(), "mods");
+	}
+}
+
+bool CModListView::isModInstalled(const QString & modName)
+{
+	auto mod = modModel->getMod(modName);
+	return mod.isInstalled();
+}
+
+QString CModListView::getTranslationModName(const QString & language)
+{
+	for (auto const & modName : modModel->getModList())
+	{
+		auto mod = modModel->getMod(modName);
+
+		if (mod.getValue("type") != "localization")
+			continue;
+
+		if (mod.getValue("language") != language)
+			continue;
+
+		return modName;
+	}
+
+	return QString();
 }

--- a/launcher/modManager/cmodlistview_moc.cpp
+++ b/launcher/modManager/cmodlistview_moc.cpp
@@ -835,16 +835,22 @@ bool CModListView::isModInstalled(const QString & modName)
 	return mod.isInstalled();
 }
 
+bool CModListView::isModEnabled(const QString & modName)
+{
+	auto mod = modModel->getMod(modName);
+	return mod.isEnabled();
+}
+
 QString CModListView::getTranslationModName(const QString & language)
 {
 	for(const auto & modName : modModel->getModList())
 	{
 		auto mod = modModel->getMod(modName);
 
-		if (mod.getValue("type") != "localization")
+		if (mod.getBaseValue("modType").toString().toLower() != "translation")
 			continue;
 
-		if (mod.getValue("language") != language)
+		if (mod.getBaseValue("language").toString() != language)
 			continue;
 
 		return modName;

--- a/launcher/modManager/cmodlistview_moc.cpp
+++ b/launcher/modManager/cmodlistview_moc.cpp
@@ -90,11 +90,13 @@ void CModListView::setupModsView()
 }
 
 CModListView::CModListView(QWidget * parent)
-	: QWidget(parent), settingsListener(settings.listen["launcher"]["repositoryURL"]), ui(new Ui::CModListView)
+	: QWidget(parent)
+	, settingsListener(settings.listen["launcher"]["repositoryURL"])
+	, ui(new Ui::CModListView)
+	, repositoriesChanged(false)
 {
 	settingsListener([&](const JsonNode &){ repositoriesChanged = true; });
 	ui->setupUi(this);
-
 
 	setupModModel();
 	setupFilterModel();
@@ -835,7 +837,7 @@ bool CModListView::isModInstalled(const QString & modName)
 
 QString CModListView::getTranslationModName(const QString & language)
 {
-	for (auto const & modName : modModel->getModList())
+	for(const auto & modName : modModel->getModList())
 	{
 		auto mod = modModel->getMod(modName);
 

--- a/launcher/modManager/cmodlistview_moc.h
+++ b/launcher/modManager/cmodlistview_moc.h
@@ -74,7 +74,6 @@ public:
 
 	void loadScreenshots();
 
-	void enableModInfo();
 	void disableModInfo();
 
 	void selectMod(const QModelIndex & index);
@@ -82,6 +81,17 @@ public:
 
 	const CModList & getModList() const;
 	
+	// First Launch View interface
+
+	/// install mod by name
+	void doInstallMod(const QString & modName);
+
+	/// returns true if mod is currently installed
+	bool isModInstalled(const QString & modName);
+
+	/// finds translation mod for specified languages. Returns empty string on error
+	QString getTranslationModName(const QString & language);
+
 public slots:
 	void enableModByName(QString modName);
 	void disableModByName(QString modName);

--- a/launcher/modManager/cmodlistview_moc.h
+++ b/launcher/modManager/cmodlistview_moc.h
@@ -92,6 +92,9 @@ public:
 	/// finds translation mod for specified languages. Returns empty string on error
 	QString getTranslationModName(const QString & language);
 
+	/// returns true if mod is currently enabled
+	bool isModEnabled(const QString & modName);
+
 public slots:
 	void enableModByName(QString modName);
 	void disableModByName(QString modName);

--- a/launcher/settingsView/csettingsview_moc.cpp
+++ b/launcher/settingsView/csettingsview_moc.cpp
@@ -13,6 +13,7 @@
 
 #include "mainwindow_moc.h"
 
+#include "../modManager/cmodlistview_moc.h"
 #include "../jsonutils.h"
 #include "../languages.h"
 #include "../launcherdirs.h"
@@ -313,8 +314,15 @@ void CSettingsView::changeEvent(QEvent *event)
 	{
 		ui->retranslateUi(this);
 		Languages::fillLanguages(ui->comboBoxLanguage, false);
+		loadTranslation();
 	}
 	QWidget::changeEvent(event);
+}
+
+void CSettingsView::showEvent(QShowEvent * event)
+{
+	loadTranslation();
+	QWidget::showEvent(event);
 }
 
 void CSettingsView::on_comboBoxCursorType_currentIndexChanged(int index)
@@ -341,5 +349,84 @@ void CSettingsView::on_listWidgetSettings_currentRowChanged(int currentRow)
 	int maxPosition = ui->settingsScrollArea->verticalScrollBar()->maximum();
 	ui->settingsScrollArea->verticalScrollBar()->setValue(maxPosition);
 	ui->settingsScrollArea->ensureWidgetVisible(currentTarget, 5, 5);
+}
 
+void CSettingsView::loadTranslation()
+{
+	Languages::fillLanguages(ui->comboBoxLanguageBase, true);
+
+	QString baseLanguage = Languages::getHeroesDataLanguage();
+
+	auto * mainWindow = dynamic_cast<MainWindow *>(qApp->activeWindow());
+
+	if (!mainWindow)
+		return;
+
+	QString languageName = QString::fromStdString(settings["general"]["language"].String());
+	QString modName = mainWindow->getModView()->getTranslationModName(languageName);
+	bool translationExists = !modName.isEmpty();
+	bool translationNeeded = languageName != baseLanguage;
+	bool showTranslation = translationNeeded && translationExists;
+
+	ui->labelTranslation->setVisible(showTranslation);
+	ui->labelTranslationStatus->setVisible(showTranslation);
+	ui->pushButtonTranslation->setVisible(showTranslation);
+
+	if (!translationExists)
+		return;
+
+	bool translationInstalled = mainWindow->getModView()->isModInstalled(modName);
+	bool translationEnabled = mainWindow->getModView()->isModEnabled(modName);
+
+	ui->pushButtonTranslation->setVisible(!translationEnabled);
+
+	if (translationEnabled)
+	{
+		ui->labelTranslationStatus->setText(tr("Active"));
+	}
+
+	if (translationInstalled && !translationEnabled)
+	{
+		ui->labelTranslationStatus->setText(tr("Disabled"));
+		ui->pushButtonTranslation->setText(tr("Enable"));
+	}
+
+	if (!translationInstalled)
+	{
+		ui->labelTranslationStatus->setText(tr("Not Installed"));
+		ui->pushButtonTranslation->setText(tr("Install"));
+	}
+}
+
+void CSettingsView::on_pushButtonTranslation_clicked()
+{
+	auto * mainWindow = dynamic_cast<MainWindow *>(qApp->activeWindow());
+
+	assert(mainWindow);
+	if (!mainWindow)
+		return;
+
+	QString languageName = QString::fromStdString(settings["general"]["language"].String());
+	QString modName = mainWindow->getModView()->getTranslationModName(languageName);
+
+	assert(!modName.isEmpty());
+	if (modName.isEmpty())
+		return;
+
+	if (mainWindow->getModView()->isModInstalled(modName))
+	{
+		mainWindow->getModView()->enableModByName(modName);
+	}
+	else
+	{
+		mainWindow->switchToModsTab();
+		mainWindow->getModView()->doInstallMod(modName);
+	}
+}
+
+void CSettingsView::on_comboBoxLanguageBase_currentIndexChanged(int index)
+{
+	Settings node = settings.write["general"]["gameDataLanguage"];
+	QString selectedLanguage = ui->comboBoxLanguageBase->itemData(index).toString();
+	node->String() = selectedLanguage.toStdString();
 }

--- a/launcher/settingsView/csettingsview_moc.cpp
+++ b/launcher/settingsView/csettingsview_moc.cpp
@@ -97,7 +97,7 @@ void CSettingsView::loadSettings()
 
 	ui->comboBoxAutoSave->setCurrentIndex(settings["general"]["saveFrequency"].Integer() > 0 ? 1 : 0);
 
-	Languages::fillLanguages(ui->comboBoxLanguage);
+	Languages::fillLanguages(ui->comboBoxLanguage, false);
 
 	std::string cursorType = settings["video"]["cursor"].String();
 	size_t cursorTypeIndex = boost::range::find(cursorTypesList, cursorType) - cursorTypesList;
@@ -312,7 +312,7 @@ void CSettingsView::changeEvent(QEvent *event)
 	if(event->type() == QEvent::LanguageChange)
 	{
 		ui->retranslateUi(this);
-		Languages::fillLanguages(ui->comboBoxLanguage);
+		Languages::fillLanguages(ui->comboBoxLanguage, false);
 	}
 	QWidget::changeEvent(event);
 }

--- a/launcher/settingsView/csettingsview_moc.cpp
+++ b/launcher/settingsView/csettingsview_moc.cpp
@@ -83,12 +83,13 @@ void CSettingsView::loadSettings()
 	ui->spinBoxNetworkPort->setValue(settings["server"]["port"].Integer());
 
 	ui->comboBoxAutoCheck->setCurrentIndex(settings["launcher"]["autoCheckRepositories"].Bool());
-	// all calls to plainText will trigger textChanged() signal overwriting config. Create backup before editing widget
-	JsonNode urls = settings["launcher"]["repositoryURL"];
 
+	JsonNode urls = settings["launcher"]["repositoryURL"];
+	ui->plainTextEditRepos->blockSignals(true); // Do not report loading as change of data
 	ui->plainTextEditRepos->clear();
 	for(auto entry : urls.Vector())
 		ui->plainTextEditRepos->appendPlainText(QString::fromUtf8(entry.String().c_str()));
+	ui->plainTextEditRepos->blockSignals(false);
 
 	ui->lineEditUserDataDir->setText(pathToQString(VCMIDirs::get().userDataPath()));
 	ui->lineEditGameDir->setText(pathToQString(VCMIDirs::get().binaryPath()));

--- a/launcher/settingsView/csettingsview_moc.h
+++ b/launcher/settingsView/csettingsview_moc.h
@@ -24,8 +24,10 @@ public:
 	~CSettingsView();
 
 	void loadSettings();
+	void loadTranslation();
 	void setDisplayList();
 	void changeEvent(QEvent *event) override;
+	void showEvent(QShowEvent * event) override;
 
 	bool isExtraResolutionsModEnabled{};
 
@@ -34,44 +36,28 @@ public slots:
 
 private slots:
 	void on_comboBoxResolution_currentTextChanged(const QString & arg1);
-
 	void on_comboBoxFullScreen_currentIndexChanged(int index);
-
 	void on_comboBoxPlayerAI_currentIndexChanged(const QString & arg1);
-
 	void on_comboBoxFriendlyAI_currentIndexChanged(const QString & arg1);
-
 	void on_comboBoxNeutralAI_currentIndexChanged(const QString & arg1);
-
 	void on_comboBoxEnemyAI_currentIndexChanged(const QString & arg1);
-
 	void on_spinBoxNetworkPort_valueChanged(int arg1);
-
 	void on_plainTextEditRepos_textChanged();
-
 	void on_openTempDir_clicked();
-
 	void on_openUserDataDir_clicked();
-
 	void on_openGameDataDir_clicked();
-
 	void on_comboBoxShowIntro_currentIndexChanged(int index);
-
 	void on_changeGameDataDir_clicked();
-
 	void on_comboBoxAutoCheck_currentIndexChanged(int index);
-
 	void on_comboBoxDisplayIndex_currentIndexChanged(int index);
-
 	void on_comboBoxAutoSave_currentIndexChanged(int index);
-
 	void on_updatesButton_clicked();
-
 	void on_comboBoxLanguage_currentIndexChanged(int index);
-
 	void on_comboBoxCursorType_currentIndexChanged(int index);
-
 	void on_listWidgetSettings_currentRowChanged(int currentRow);
+	void on_pushButtonTranslation_clicked();
+
+	void on_comboBoxLanguageBase_currentIndexChanged(int index);
 
 private:
 	Ui::CSettingsView * ui;

--- a/launcher/settingsView/csettingsview_moc.ui
+++ b/launcher/settingsView/csettingsview_moc.ui
@@ -509,38 +509,7 @@
         </widget>
        </item>
        <item row="1" column="1" colspan="3">
-        <widget class="QComboBox" name="comboBoxLanguage">
-         <item>
-          <property name="text">
-           <string>English</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>简体中文 (Simplified Chinese)</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Deutsch (German)</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Polska (Polish)</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Русский (Russian)</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Українська (Ukrainian)</string>
-          </property>
-         </item>
-        </widget>
+        <widget class="QComboBox" name="comboBoxLanguage"/>
        </item>
        <item row="16" column="0">
         <widget class="QLabel" name="labelDataDirs">

--- a/launcher/settingsView/csettingsview_moc.ui
+++ b/launcher/settingsView/csettingsview_moc.ui
@@ -114,59 +114,119 @@
         <x>0</x>
         <y>0</y>
         <width>620</width>
-        <height>731</height>
+        <height>793</height>
        </rect>
       </property>
       <layout class="QGridLayout" name="gridLayout" columnstretch="3,0,0,0">
-       <item row="22" column="0" colspan="4">
-        <widget class="QPlainTextEdit" name="plainTextEditRepos">
-         <property name="lineWrapMode">
-          <enum>QPlainTextEdit::NoWrap</enum>
+       <item row="19" column="1" colspan="3">
+        <widget class="QComboBox" name="comboBoxEnemyAI">
+         <property name="editable">
+          <bool>false</bool>
          </property>
-         <property name="plainText">
-          <string notr="true">http://downloads.vcmi.eu/Mods/repository.json</string>
-         </property>
-        </widget>
-       </item>
-       <item row="12" column="1" colspan="3">
-        <widget class="QComboBox" name="comboBoxPlayerAI">
          <property name="currentText">
-          <string notr="true">VCAI</string>
+          <string notr="true">BattleAI</string>
          </property>
          <item>
           <property name="text">
-           <string notr="true">VCAI</string>
+           <string notr="true">BattleAI</string>
           </property>
          </item>
          <item>
           <property name="text">
-           <string notr="true">Nullkiller</string>
+           <string notr="true">StupidAI</string>
           </property>
          </item>
         </widget>
        </item>
-       <item row="15" column="0">
-        <widget class="QLabel" name="labelEnemyAI">
+       <item row="1" column="0">
+        <widget class="QLabel" name="labelLanguage">
          <property name="text">
-          <string>Enemy AI</string>
+          <string>VCMI Language</string>
          </property>
         </widget>
        </item>
-       <item row="21" column="2" colspan="2">
-        <widget class="QPushButton" name="updatesButton">
-         <property name="text">
-          <string>Update now</string>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="0">
+       <item row="6" column="0">
         <widget class="QLabel" name="labelNetworkPort">
          <property name="text">
           <string>Network port</string>
          </property>
         </widget>
        </item>
-       <item row="14" column="1" colspan="3">
+       <item row="11" column="0">
+        <widget class="QLabel" name="labelFullScreen">
+         <property name="text">
+          <string>Fullscreen</string>
+         </property>
+        </widget>
+       </item>
+       <item row="10" column="0">
+        <widget class="QLabel" name="labelResolution">
+         <property name="text">
+          <string>Resolution</string>
+         </property>
+        </widget>
+       </item>
+       <item row="17" column="0">
+        <widget class="QLabel" name="labelNeutralAI">
+         <property name="text">
+          <string>Neutral AI</string>
+         </property>
+        </widget>
+       </item>
+       <item row="7" column="0">
+        <widget class="QLabel" name="labelAutoSave">
+         <property name="text">
+          <string>Autosave</string>
+         </property>
+        </widget>
+       </item>
+       <item row="9" column="0">
+        <widget class="QLabel" name="labelVideo">
+         <property name="font">
+          <font>
+           <weight>75</weight>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>Video</string>
+         </property>
+        </widget>
+       </item>
+       <item row="23" column="1" colspan="2">
+        <widget class="QLineEdit" name="lineEditTempDir">
+         <property name="enabled">
+          <bool>false</bool>
+         </property>
+         <property name="text">
+          <string notr="true">/home/user/.vcmi</string>
+         </property>
+         <property name="readOnly">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="13" column="1" colspan="3">
+        <widget class="QComboBox" name="comboBoxDisplayIndex"/>
+       </item>
+       <item row="14" column="0">
+        <widget class="QLabel" name="labelCursorType">
+         <property name="text">
+          <string>Cursor</string>
+         </property>
+        </widget>
+       </item>
+       <item row="22" column="3">
+        <widget class="QPushButton" name="openUserDataDir">
+         <property name="text">
+          <string>Open</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1" colspan="3">
+        <widget class="QComboBox" name="comboBoxLanguage"/>
+       </item>
+       <item row="18" column="1" colspan="3">
         <widget class="QComboBox" name="comboBoxFriendlyAI">
          <property name="editable">
           <bool>false</bool>
@@ -186,65 +246,7 @@
          </item>
         </widget>
        </item>
-       <item row="13" column="1" colspan="3">
-        <widget class="QComboBox" name="comboBoxNeutralAI">
-         <property name="currentText">
-          <string notr="true">BattleAI</string>
-         </property>
-         <item>
-          <property name="text">
-           <string notr="true">BattleAI</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string notr="true">StupidAI</string>
-          </property>
-         </item>
-        </widget>
-       </item>
-       <item row="3" column="0">
-        <widget class="QLabel" name="labelAutoSave">
-         <property name="text">
-          <string>Autosave</string>
-         </property>
-        </widget>
-       </item>
-       <item row="17" column="1">
-        <widget class="QLineEdit" name="lineEditGameDir">
-         <property name="text">
-          <string notr="true">/usr/share/vcmi</string>
-         </property>
-        </widget>
-       </item>
-       <item row="19" column="3">
-        <widget class="QPushButton" name="openTempDir">
-         <property name="text">
-          <string>Open</string>
-         </property>
-        </widget>
-       </item>
-       <item row="8" column="0">
-        <widget class="QLabel" name="labelShowIntro">
-         <property name="text">
-          <string>Show intro</string>
-         </property>
-        </widget>
-       </item>
-       <item row="18" column="1" colspan="2">
-        <widget class="QLineEdit" name="lineEditUserDataDir">
-         <property name="enabled">
-          <bool>false</bool>
-         </property>
-         <property name="text">
-          <string notr="true">/home/user/.vcmi</string>
-         </property>
-         <property name="readOnly">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item row="7" column="1" colspan="3">
+       <item row="11" column="1" colspan="3">
         <widget class="QComboBox" name="comboBoxFullScreen">
          <property name="currentIndex">
           <number>0</number>
@@ -266,27 +268,27 @@
          </item>
         </widget>
        </item>
-       <item row="20" column="0">
-        <widget class="QLabel" name="labelRepositories">
-         <property name="font">
-          <font>
-           <weight>75</weight>
-           <bold>true</bold>
-          </font>
+       <item row="6" column="1" colspan="3">
+        <widget class="QSpinBox" name="spinBoxNetworkPort">
+         <property name="minimum">
+          <number>1024</number>
          </property>
-         <property name="text">
-          <string>Mod Repositories</string>
+         <property name="maximum">
+          <number>65535</number>
          </property>
-        </widget>
-       </item>
-       <item row="9" column="0">
-        <widget class="QLabel" name="labelDisplayIndex">
-         <property name="text">
-          <string>Display index</string>
+         <property name="value">
+          <number>3030</number>
          </property>
         </widget>
        </item>
-       <item row="3" column="1" colspan="3">
+       <item row="23" column="3">
+        <widget class="QPushButton" name="openTempDir">
+         <property name="text">
+          <string>Open</string>
+         </property>
+        </widget>
+       </item>
+       <item row="7" column="1" colspan="3">
         <widget class="QComboBox" name="comboBoxAutoSave">
          <property name="currentIndex">
           <number>1</number>
@@ -303,8 +305,8 @@
          </item>
         </widget>
        </item>
-       <item row="5" column="0">
-        <widget class="QLabel" name="labelVideo">
+       <item row="20" column="0">
+        <widget class="QLabel" name="labelDataDirs">
          <property name="font">
           <font>
            <weight>75</weight>
@@ -312,22 +314,77 @@
           </font>
          </property>
          <property name="text">
-          <string>Video</string>
+          <string>Data Directories</string>
          </property>
         </widget>
        </item>
-       <item row="19" column="0">
-        <widget class="QLabel" name="labelTempDir">
-         <property name="text">
-          <string>Log files directory</string>
-         </property>
-        </widget>
-       </item>
-       <item row="15" column="1" colspan="3">
-        <widget class="QComboBox" name="comboBoxEnemyAI">
-         <property name="editable">
+       <item row="21" column="2">
+        <widget class="QPushButton" name="changeGameDataDir">
+         <property name="enabled">
           <bool>false</bool>
          </property>
+         <property name="text">
+          <string>Change</string>
+         </property>
+        </widget>
+       </item>
+       <item row="22" column="0">
+        <widget class="QLabel" name="labelUserDataDir">
+         <property name="text">
+          <string>User data directory</string>
+         </property>
+        </widget>
+       </item>
+       <item row="8" column="0">
+        <widget class="QLabel" name="labelBuildVersionDesc">
+         <property name="text">
+          <string>Build version</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="0">
+        <widget class="QLabel" name="labelGeneral">
+         <property name="font">
+          <font>
+           <weight>75</weight>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>General</string>
+         </property>
+        </widget>
+       </item>
+       <item row="12" column="0">
+        <widget class="QLabel" name="labelShowIntro">
+         <property name="text">
+          <string>Show intro</string>
+         </property>
+        </widget>
+       </item>
+       <item row="25" column="2" colspan="2">
+        <widget class="QPushButton" name="updatesButton">
+         <property name="text">
+          <string>Update now</string>
+         </property>
+        </widget>
+       </item>
+       <item row="13" column="0">
+        <widget class="QLabel" name="labelDisplayIndex">
+         <property name="text">
+          <string>Display index</string>
+         </property>
+        </widget>
+       </item>
+       <item row="21" column="1">
+        <widget class="QLineEdit" name="lineEditGameDir">
+         <property name="text">
+          <string notr="true">/usr/share/vcmi</string>
+         </property>
+        </widget>
+       </item>
+       <item row="17" column="1" colspan="3">
+        <widget class="QComboBox" name="comboBoxNeutralAI">
          <property name="currentText">
           <string notr="true">BattleAI</string>
          </property>
@@ -343,31 +400,37 @@
          </item>
         </widget>
        </item>
-       <item row="4" column="0">
-        <widget class="QLabel" name="labelBuildVersionDesc">
+       <item row="10" column="1" colspan="3">
+        <widget class="QComboBox" name="comboBoxResolution"/>
+       </item>
+       <item row="24" column="0">
+        <widget class="QLabel" name="labelRepositories">
+         <property name="font">
+          <font>
+           <weight>75</weight>
+           <bold>true</bold>
+          </font>
+         </property>
          <property name="text">
-          <string>Build version</string>
+          <string>Mod Repositories</string>
          </property>
         </widget>
        </item>
-       <item row="17" column="3">
-        <widget class="QPushButton" name="openGameDataDir">
+       <item row="18" column="0">
+        <widget class="QLabel" name="labelFriendlyAI">
          <property name="text">
-          <string>Open</string>
+          <string>Friendly AI</string>
          </property>
         </widget>
        </item>
-       <item row="4" column="1" colspan="3">
-        <widget class="QLineEdit" name="lineEditBuildVersion">
+       <item row="25" column="0">
+        <widget class="QLabel" name="labelAutoCheck">
          <property name="text">
-          <string notr="true"/>
-         </property>
-         <property name="readOnly">
-          <bool>true</bool>
+          <string>Check on startup</string>
          </property>
         </widget>
        </item>
-       <item row="8" column="1" colspan="3">
+       <item row="12" column="1" colspan="3">
         <widget class="QComboBox" name="comboBoxShowIntro">
          <property name="currentIndex">
           <number>1</number>
@@ -384,41 +447,105 @@
          </item>
         </widget>
        </item>
-       <item row="11" column="0">
-        <widget class="QLabel" name="labelArtificialIntelligence">
-         <property name="font">
-          <font>
-           <weight>75</weight>
-           <bold>true</bold>
-          </font>
+       <item row="22" column="1" colspan="2">
+        <widget class="QLineEdit" name="lineEditUserDataDir">
+         <property name="enabled">
+          <bool>false</bool>
          </property>
          <property name="text">
-          <string>Artificial Intelligence</string>
+          <string notr="true">/home/user/.vcmi</string>
+         </property>
+         <property name="readOnly">
+          <bool>true</bool>
          </property>
         </widget>
        </item>
-       <item row="6" column="0">
-        <widget class="QLabel" name="labelResolution">
+       <item row="21" column="0">
+        <widget class="QLabel" name="labelGameDir">
          <property name="text">
-          <string>Resolution</string>
+          <string>Extra data directory</string>
          </property>
         </widget>
        </item>
-       <item row="10" column="0">
-        <widget class="QLabel" name="labelCursorType">
+       <item row="21" column="3">
+        <widget class="QPushButton" name="openGameDataDir">
          <property name="text">
-          <string>Cursor</string>
+          <string>Open</string>
          </property>
         </widget>
        </item>
-       <item row="13" column="0">
-        <widget class="QLabel" name="labelNeutralAI">
+       <item row="4" column="1" colspan="3">
+        <widget class="QComboBox" name="comboBoxLanguageBase"/>
+       </item>
+       <item row="25" column="1">
+        <widget class="QComboBox" name="comboBoxAutoCheck">
+         <property name="currentIndex">
+          <number>1</number>
+         </property>
+         <item>
+          <property name="text">
+           <string>Off</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>On</string>
+          </property>
+         </item>
+        </widget>
+       </item>
+       <item row="4" column="0">
+        <widget class="QLabel" name="labelLanguageBase">
          <property name="text">
-          <string>Neutral AI</string>
+          <string>Heroes III Data Language</string>
          </property>
         </widget>
        </item>
-       <item row="10" column="1" colspan="3">
+       <item row="16" column="1" colspan="3">
+        <widget class="QComboBox" name="comboBoxPlayerAI">
+         <property name="currentText">
+          <string notr="true">VCAI</string>
+         </property>
+         <item>
+          <property name="text">
+           <string notr="true">VCAI</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string notr="true">Nullkiller</string>
+          </property>
+         </item>
+        </widget>
+       </item>
+       <item row="8" column="1" colspan="3">
+        <widget class="QLineEdit" name="lineEditBuildVersion">
+         <property name="text">
+          <string notr="true"/>
+         </property>
+         <property name="readOnly">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="19" column="0">
+        <widget class="QLabel" name="labelEnemyAI">
+         <property name="text">
+          <string>Enemy AI</string>
+         </property>
+        </widget>
+       </item>
+       <item row="26" column="0" colspan="4">
+        <widget class="QPlainTextEdit" name="plainTextEditRepos">
+         <property name="lineWrapMode">
+          <enum>QPlainTextEdit::NoWrap</enum>
+         </property>
+         <property name="plainText">
+          <string notr="true">http://downloads.vcmi.eu/Mods/repository.json</string>
+         </property>
+        </widget>
+       </item>
+       <item row="14" column="1" colspan="3">
         <widget class="QComboBox" name="comboBoxCursorType">
          <item>
           <property name="text">
@@ -437,147 +564,51 @@
          </item>
         </widget>
        </item>
-       <item row="21" column="0">
-        <widget class="QLabel" name="labelAutoCheck">
-         <property name="text">
-          <string>Check on startup</string>
-         </property>
-        </widget>
-       </item>
-       <item row="18" column="3">
-        <widget class="QPushButton" name="openUserDataDir">
-         <property name="text">
-          <string>Open</string>
-         </property>
-        </widget>
-       </item>
-       <item row="7" column="0">
-        <widget class="QLabel" name="labelFullScreen">
-         <property name="text">
-          <string>Fullscreen</string>
-         </property>
-        </widget>
-       </item>
-       <item row="9" column="1" colspan="3">
-        <widget class="QComboBox" name="comboBoxDisplayIndex"/>
-       </item>
-       <item row="6" column="1" colspan="3">
-        <widget class="QComboBox" name="comboBoxResolution"/>
-       </item>
-       <item row="19" column="1" colspan="2">
-        <widget class="QLineEdit" name="lineEditTempDir">
-         <property name="enabled">
-          <bool>false</bool>
+       <item row="15" column="0">
+        <widget class="QLabel" name="labelArtificialIntelligence">
+         <property name="font">
+          <font>
+           <weight>75</weight>
+           <bold>true</bold>
+          </font>
          </property>
          <property name="text">
-          <string notr="true">/home/user/.vcmi</string>
-         </property>
-         <property name="readOnly">
-          <bool>true</bool>
+          <string>Artificial Intelligence</string>
          </property>
         </widget>
        </item>
-       <item row="1" column="0">
-        <widget class="QLabel" name="labelLanguage">
+       <item row="23" column="0">
+        <widget class="QLabel" name="labelTempDir">
          <property name="text">
-          <string>VCMI Language</string>
+          <string>Log files directory</string>
          </property>
         </widget>
        </item>
-       <item row="21" column="1">
-        <widget class="QComboBox" name="comboBoxAutoCheck">
-         <property name="currentIndex">
-          <number>1</number>
-         </property>
-         <item>
-          <property name="text">
-           <string>Off</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>On</string>
-          </property>
-         </item>
-        </widget>
-       </item>
-       <item row="12" column="0">
+       <item row="16" column="0">
         <widget class="QLabel" name="labelPlayerAI">
          <property name="text">
           <string>Adventure Map AI</string>
          </property>
         </widget>
        </item>
-       <item row="1" column="1" colspan="3">
-        <widget class="QComboBox" name="comboBoxLanguage"/>
-       </item>
-       <item row="16" column="0">
-        <widget class="QLabel" name="labelDataDirs">
-         <property name="font">
-          <font>
-           <weight>75</weight>
-           <bold>true</bold>
-          </font>
-         </property>
+       <item row="5" column="0">
+        <widget class="QLabel" name="labelTranslation">
          <property name="text">
-          <string>Data Directories</string>
+          <string>Heroes III Translation</string>
          </property>
         </widget>
        </item>
-       <item row="0" column="0">
-        <widget class="QLabel" name="labelGeneral">
-         <property name="font">
-          <font>
-           <weight>75</weight>
-           <bold>true</bold>
-          </font>
-         </property>
+       <item row="5" column="3">
+        <widget class="QPushButton" name="pushButtonTranslation">
          <property name="text">
-          <string>General</string>
+          <string/>
          </property>
         </widget>
        </item>
-       <item row="18" column="0">
-        <widget class="QLabel" name="labelUserDataDir">
+       <item row="5" column="1" colspan="2">
+        <widget class="QLabel" name="labelTranslationStatus">
          <property name="text">
-          <string>User data directory</string>
-         </property>
-        </widget>
-       </item>
-       <item row="17" column="0">
-        <widget class="QLabel" name="labelGameDir">
-         <property name="text">
-          <string>Extra data directory</string>
-         </property>
-        </widget>
-       </item>
-       <item row="14" column="0">
-        <widget class="QLabel" name="labelFriendlyAI">
-         <property name="text">
-          <string>Friendly AI</string>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="1" colspan="3">
-        <widget class="QSpinBox" name="spinBoxNetworkPort">
-         <property name="minimum">
-          <number>1024</number>
-         </property>
-         <property name="maximum">
-          <number>65535</number>
-         </property>
-         <property name="value">
-          <number>3030</number>
-         </property>
-        </widget>
-       </item>
-       <item row="17" column="2">
-        <widget class="QPushButton" name="changeGameDataDir">
-         <property name="enabled">
-          <bool>false</bool>
-         </property>
-         <property name="text">
-          <string>Change</string>
+          <string/>
          </property>
         </widget>
        </item>

--- a/launcher/translation/english.ts
+++ b/launcher/translation/english.ts
@@ -4,101 +4,86 @@
 <context>
     <name>CModListModel</name>
     <message>
-        <location filename="../modManager/cmodlistmodel_moc.cpp" line="150"/>
+        <location filename="../modManager/cmodlistmodel_moc.cpp" line="142"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistmodel_moc.cpp" line="153"/>
+        <location filename="../modManager/cmodlistmodel_moc.cpp" line="145"/>
         <source>Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistmodel_moc.cpp" line="154"/>
+        <location filename="../modManager/cmodlistmodel_moc.cpp" line="146"/>
         <source>Version</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modManager/cmodlistmodel_moc.cpp" line="155"/>
-        <source>Size</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modManager/cmodlistmodel_moc.cpp" line="156"/>
-        <source>Author</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>CModListView</name>
     <message>
-        <location filename="../modManager/cmodlistview_moc.ui" line="61"/>
+        <location filename="../modManager/cmodlistview_moc.ui" line="58"/>
         <source>Filter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.ui" line="84"/>
+        <location filename="../modManager/cmodlistview_moc.ui" line="81"/>
         <source>All mods</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.ui" line="89"/>
+        <location filename="../modManager/cmodlistview_moc.ui" line="86"/>
         <source>Downloadable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.ui" line="94"/>
+        <location filename="../modManager/cmodlistview_moc.ui" line="91"/>
         <source>Installed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.ui" line="99"/>
+        <location filename="../modManager/cmodlistview_moc.ui" line="96"/>
         <source>Updatable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.ui" line="104"/>
+        <location filename="../modManager/cmodlistview_moc.ui" line="101"/>
         <source>Active</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.ui" line="109"/>
+        <location filename="../modManager/cmodlistview_moc.ui" line="106"/>
         <source>Inactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.ui" line="123"/>
+        <location filename="../modManager/cmodlistview_moc.ui" line="120"/>
         <source>Download &amp;&amp; refresh repositories</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.ui" line="228"/>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="288"/>
+        <location filename="../modManager/cmodlistview_moc.ui" line="163"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="270"/>
         <source>Description</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.ui" line="273"/>
+        <location filename="../modManager/cmodlistview_moc.ui" line="208"/>
         <source>Changelog</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.ui" line="295"/>
+        <location filename="../modManager/cmodlistview_moc.ui" line="230"/>
         <source>Screenshots</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.ui" line="368"/>
-        <source>Show details</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modManager/cmodlistview_moc.ui" line="409"/>
+        <location filename="../modManager/cmodlistview_moc.ui" line="389"/>
         <source>Uninstall</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.ui" line="434"/>
+        <location filename="../modManager/cmodlistview_moc.ui" line="424"/>
         <source>Enable</source>
         <translation type="unfinished"></translation>
     </message>
@@ -108,134 +93,134 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.ui" line="484"/>
+        <location filename="../modManager/cmodlistview_moc.ui" line="494"/>
         <source>Update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.ui" line="509"/>
+        <location filename="../modManager/cmodlistview_moc.ui" line="529"/>
         <source>Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.ui" line="563"/>
+        <location filename="../modManager/cmodlistview_moc.ui" line="327"/>
         <source> %p% (%v KB out of %m KB)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.ui" line="576"/>
+        <location filename="../modManager/cmodlistview_moc.ui" line="340"/>
         <source>Abort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="246"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="228"/>
         <source>Mod name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="247"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="229"/>
         <source>Installed version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="248"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="230"/>
         <source>Latest version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="251"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="233"/>
         <source>Download size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="252"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="234"/>
         <source>Authors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="255"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="237"/>
         <source>License</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="258"/>
-        <source>Home</source>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="240"/>
+        <source>Contact</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="262"/>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="269"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="244"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="251"/>
         <source>Compatibility</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="271"/>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="279"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="253"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="261"/>
         <source>Required VCMI version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="277"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="259"/>
         <source>Supported VCMI version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="282"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="264"/>
         <source>Supported VCMI versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="286"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="268"/>
         <source>Required mods</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="287"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="269"/>
         <source>Conflicting mods</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="292"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="274"/>
         <source>This mod can not be installed or enabled because following dependencies are not present</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="293"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="275"/>
         <source>This mod can not be enabled because following mods are incompatible with this mod</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="294"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="276"/>
         <source>This mod can not be disabled because it is required to run following mods</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="295"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="277"/>
         <source>This mod can not be uninstalled or updated because it is required to run following mods</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="296"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="278"/>
         <source>This is submod and it can not be installed or uninstalled separately from parent mod</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="311"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="293"/>
         <source>Notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="828"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="795"/>
         <source>Screenshot %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="240"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="222"/>
         <source>Mod is compatible</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="241"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="223"/>
         <source>Mod is incompatible</source>
         <translation type="unfinished"></translation>
     </message>
@@ -243,216 +228,333 @@
 <context>
     <name>CSettingsView</name>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="80"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="580"/>
         <source>Change</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="104"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="205"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="396"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="223"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="356"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="450"/>
         <source>Open</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="445"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="507"/>
+        <source>Adventure Map AI</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsView/csettingsview_moc.ui" line="543"/>
         <source>User data directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="91"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="129"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="312"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="334"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="254"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="296"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="377"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="494"/>
         <source>Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="96"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="134"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="317"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="339"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="79"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="396"/>
+        <source>Artificial Intelligence</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsView/csettingsview_moc.ui" line="89"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="278"/>
+        <source>Mod Repositories</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsView/csettingsview_moc.ui" line="158"/>
+        <source>Update now</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsView/csettingsview_moc.ui" line="259"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="301"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="382"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="499"/>
         <source>On</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="118"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="410"/>
+        <source>Cursor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsView/csettingsview_moc.ui" line="425"/>
+        <source>Default</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsView/csettingsview_moc.ui" line="430"/>
+        <source>Hardware</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsView/csettingsview_moc.ui" line="435"/>
+        <source>Software</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsView/csettingsview_moc.ui" line="443"/>
+        <source>Check on startup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsView/csettingsview_moc.ui" line="457"/>
         <source>Fullscreen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="181"/>
-        <source>Repositories</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="188"/>
-        <source>Check for updates</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="549"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="417"/>
         <source>Neutral AI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="322"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="264"/>
         <source>Real</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="257"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="69"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="536"/>
         <source>General</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="212"/>
-        <source>Player AI</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="472"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="483"/>
         <source>VCMI Language</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="487"/>
-        <source>Central European (Windows 1250)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="492"/>
-        <source>Cyrillic script (Windows 1251)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="497"/>
-        <source>Western European (Windows 1252)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="502"/>
-        <source>Simplified Chinese (GBK)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="507"/>
-        <source>Simplified Chinese (GB2312)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="512"/>
-        <source>Korean (Windows 949)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="521"/>
-        <source>English</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="526"/>
-        <source>Deutsch (German)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="531"/>
-        <source>Polska (Polish)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="536"/>
-        <source>Русский (Russian)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="541"/>
-        <source>Українська (Ukrainian)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="579"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="557"/>
         <source>Friendly AI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="301"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="403"/>
         <source>Resolution</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="353"/>
-        <source>AI on the map</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="168"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="209"/>
         <source>Autosave</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="219"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="285"/>
         <source>Display index</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="198"/>
-        <source>Check repositories on startup</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="452"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="165"/>
         <source>Network port</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="422"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="84"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="523"/>
         <source>Data Directories</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="409"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="74"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="315"/>
         <source>Video</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="111"/>
-        <source>Heroes III character set</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="294"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="550"/>
         <source>Extra data directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="142"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="322"/>
         <source>Log files directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="264"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="230"/>
         <source>Show intro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="57"/>
-        <source>Launcher Settings</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="287"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="349"/>
         <source>Build version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="632"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="151"/>
         <source>Enemy AI</source>
         <translation type="unfinished"></translation>
     </message>
+</context>
+<context>
+    <name>FirstLaunchView</name>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="234"/>
-        <source>AI in the battlefield</source>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="28"/>
+        <source>Language</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="53"/>
+        <source>Heroes III Data</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="78"/>
+        <source>Mods Preset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="103"/>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="797"/>
+        <source>Finish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="136"/>
+        <source>Step %v out of %m</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="168"/>
+        <source>Choose your language</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="175"/>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="506"/>
+        <source>Next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="240"/>
+        <source>Find Heroes III data files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="271"/>
+        <source>Open help in browser</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="284"/>
+        <source>Search again</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="317"/>
+        <source>If you don&apos;t have installed Heroes III copy, it is possible to use our automatic installation tool &apos;vcmibuilder&apos; to extract data from GoG.com installer. Visit our wiki for detailed instructions.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="333"/>
+        <source>VCMI requires Heroes III data files in one of the locations listed above. Please copy Heroes III data in one of these directories.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="355"/>
+        <source>Heroes III data files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="368"/>
+        <source>Alternatively, you can select directory with installed Heroes III data and VCMI will copy exisiting data automatically.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="384"/>
+        <source>Copy existing data</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="397"/>
+        <source>Your Heroes III data files have been succesfully found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="427"/>
+        <source>You Heroes III language was succesfully detected automatically.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="437"/>
+        <source>Automatic detection of language failed. Please select language of your Heroes III copy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="456"/>
+        <source>Heroes III language</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="499"/>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="717"/>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="790"/>
+        <source>Back</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="537"/>
+        <source>Install VCMI Mod Preset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="565"/>
+        <source>VCMI provides its own version of Horn of the Abyss fan-made addon. If you wish you can install it right now. For more information about mod visit hota website</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="581"/>
+        <source>Localization to English</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="661"/>
+        <source>VCMI provides translations of Heroes III into a different languages. If you wish, you can install translation to English</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="597"/>
+        <source>Install VCMI-compatible version of the &quot;In The Wake of Gods&quot; fan-made addon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="613"/>
+        <source>Heroes III + HotA</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="629"/>
+        <source>Heroes III + WoG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="645"/>
+        <source>VCMI provides support for playing Heroes III in resolutions other than 800x600. If you wish, you can install this support</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="677"/>
+        <source>HD support</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="724"/>
+        <source>Skip</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="755"/>
+        <source>Join community / get help</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -465,65 +567,159 @@
     </message>
 </context>
 <context>
+    <name>Language</name>
+    <message>
+        <location filename="../languages.cpp" line="22"/>
+        <source>Chinese</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../languages.cpp" line="23"/>
+        <source>English</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../languages.cpp" line="24"/>
+        <source>French</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../languages.cpp" line="25"/>
+        <source>German</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../languages.cpp" line="26"/>
+        <source>Korean</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../languages.cpp" line="27"/>
+        <source>Polish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../languages.cpp" line="28"/>
+        <source>Russian</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../languages.cpp" line="29"/>
+        <source>Ukrainian</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../languages.cpp" line="30"/>
+        <source>Other (East European)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../languages.cpp" line="31"/>
+        <source>Other (Cyrillic Script)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../languages.cpp" line="32"/>
+        <source>Other (West European)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Lobby</name>
     <message>
-        <location filename="../lobby/lobby_moc.ui" line="26"/>
+        <location filename="../lobby/lobby_moc.ui" line="39"/>
+        <location filename="../lobby/lobby_moc.cpp" line="401"/>
         <source>Connect</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../lobby/lobby_moc.ui" line="45"/>
+        <location filename="../lobby/lobby_moc.ui" line="26"/>
         <source>Username</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../lobby/lobby_moc.ui" line="69"/>
+        <location filename="../lobby/lobby_moc.ui" line="56"/>
         <source>Server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../lobby/lobby_moc.ui" line="111"/>
+        <location filename="../lobby/lobby_moc.ui" line="76"/>
+        <source>People in lobby</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../lobby/lobby_moc.ui" line="114"/>
+        <source>Lobby chat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../lobby/lobby_moc.ui" line="194"/>
         <source>Session</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../lobby/lobby_moc.ui" line="116"/>
+        <location filename="../lobby/lobby_moc.ui" line="199"/>
         <source>Players</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../lobby/lobby_moc.ui" line="132"/>
+        <location filename="../lobby/lobby_moc.ui" line="274"/>
+        <source>Resolve</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../lobby/lobby_moc.ui" line="286"/>
+        <source>New game</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../lobby/lobby_moc.ui" line="293"/>
+        <source>Load game</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../lobby/lobby_moc.ui" line="149"/>
         <source>New room</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../lobby/lobby_moc.ui" line="142"/>
+        <location filename="../lobby/lobby_moc.ui" line="159"/>
         <source>Join room</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../lobby/lobby_moc.ui" line="153"/>
+        <location filename="../lobby/lobby_moc.ui" line="267"/>
         <source>Ready</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../lobby/lobby_moc.ui" line="160"/>
+        <location filename="../lobby/lobby_moc.ui" line="250"/>
         <source>Mods mismatch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../lobby/lobby_moc.ui" line="167"/>
+        <location filename="../lobby/lobby_moc.ui" line="243"/>
         <source>Leave</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../lobby/lobby_moc.ui" line="197"/>
+        <location filename="../lobby/lobby_moc.ui" line="216"/>
         <source>Kick player</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../lobby/lobby_moc.ui" line="204"/>
+        <location filename="../lobby/lobby_moc.ui" line="236"/>
         <source>Players in the room</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../lobby/lobby_moc.cpp" line="369"/>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../lobby/lobby_moc.cpp" line="461"/>
+        <source>No issues detected</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -558,27 +754,32 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow_moc.ui" line="95"/>
+        <location filename="../mainwindow_moc.ui" line="107"/>
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow_moc.ui" line="189"/>
+        <location filename="../mainwindow_moc.ui" line="207"/>
+        <source>Setup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow_moc.ui" line="272"/>
         <source>Map Editor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow_moc.ui" line="236"/>
+        <location filename="../mainwindow_moc.ui" line="325"/>
         <source>Start game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow_moc.ui" line="139"/>
+        <location filename="../mainwindow_moc.ui" line="157"/>
         <source>Lobby</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow_moc.ui" line="51"/>
+        <location filename="../mainwindow_moc.ui" line="57"/>
         <source>Mods</source>
         <translation type="unfinished"></translation>
     </message>

--- a/launcher/translation/english.ts
+++ b/launcher/translation/english.ts
@@ -63,7 +63,7 @@
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.ui" line="163"/>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="270"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="272"/>
         <source>Description</source>
         <translation type="unfinished"></translation>
     </message>
@@ -113,114 +113,114 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="228"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="230"/>
         <source>Mod name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="229"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="231"/>
         <source>Installed version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="230"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="232"/>
         <source>Latest version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="233"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="235"/>
         <source>Download size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="234"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="236"/>
         <source>Authors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="237"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="239"/>
         <source>License</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="240"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="242"/>
         <source>Contact</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="244"/>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="251"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="246"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="253"/>
         <source>Compatibility</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="253"/>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="261"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="255"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="263"/>
         <source>Required VCMI version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="259"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="261"/>
         <source>Supported VCMI version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="264"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="266"/>
         <source>Supported VCMI versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="268"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="270"/>
         <source>Required mods</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="269"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="271"/>
         <source>Conflicting mods</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="274"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="276"/>
         <source>This mod can not be installed or enabled because following dependencies are not present</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="275"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="277"/>
         <source>This mod can not be enabled because following mods are incompatible with this mod</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="276"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="278"/>
         <source>This mod can not be disabled because it is required to run following mods</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="277"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="279"/>
         <source>This mod can not be uninstalled or updated because it is required to run following mods</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="278"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="280"/>
         <source>This is submod and it can not be installed or uninstalled separately from parent mod</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="293"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="295"/>
         <source>Notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="795"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="797"/>
         <source>Screenshot %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="222"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="224"/>
         <source>Mod is compatible</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="223"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="225"/>
         <source>Mod is incompatible</source>
         <translation type="unfinished"></translation>
     </message>
@@ -414,147 +414,125 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="103"/>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="797"/>
-        <source>Finish</source>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="414"/>
+        <source>Your Heroes III language has been succesfully detected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="136"/>
-        <source>Step %v out of %m</source>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="552"/>
+        <source>Optionally, you can install additional mods either now or at any point later:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="168"/>
-        <source>Choose your language</source>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="584"/>
+        <source>Install English translation of Heroes III</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="175"/>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="506"/>
-        <source>Next</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="240"/>
-        <source>Find Heroes III data files</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="271"/>
-        <source>Open help in browser</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="284"/>
-        <source>Search again</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="317"/>
-        <source>If you don&apos;t have installed Heroes III copy, it is possible to use our automatic installation tool &apos;vcmibuilder&apos; to extract data from GoG.com installer. Visit our wiki for detailed instructions.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="333"/>
-        <source>VCMI requires Heroes III data files in one of the locations listed above. Please copy Heroes III data in one of these directories.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="355"/>
-        <source>Heroes III data files</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="368"/>
-        <source>Alternatively, you can select directory with installed Heroes III data and VCMI will copy exisiting data automatically.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="384"/>
-        <source>Copy existing data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="397"/>
-        <source>Your Heroes III data files have been succesfully found.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="427"/>
-        <source>You Heroes III language was succesfully detected automatically.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="437"/>
-        <source>Automatic detection of language failed. Please select language of your Heroes III copy</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="456"/>
-        <source>Heroes III language</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="499"/>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="717"/>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="790"/>
-        <source>Back</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="537"/>
-        <source>Install VCMI Mod Preset</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="565"/>
-        <source>VCMI provides its own version of Horn of the Abyss fan-made addon. If you wish you can install it right now. For more information about mod visit hota website</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="581"/>
-        <source>Localization to English</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="661"/>
-        <source>VCMI provides translations of Heroes III into a different languages. If you wish, you can install translation to English</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="597"/>
-        <source>Install VCMI-compatible version of the &quot;In The Wake of Gods&quot; fan-made addon</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="613"/>
-        <source>Heroes III + HotA</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="629"/>
-        <source>Heroes III + WoG</source>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="616"/>
+        <source>Install support for playing Heroes III in resolutions other than 800x600.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firstLaunch/firstlaunch_moc.ui" line="645"/>
-        <source>VCMI provides support for playing Heroes III in resolutions other than 800x600. If you wish, you can install this support</source>
+        <source>Install compatible version of addon Horn of the Abyss: fan-made Heroes III expansion, ported by VCMI team</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="677"/>
-        <source>HD support</source>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="674"/>
+        <source>Install compatible version of addon &quot;In The Wake of Gods&quot;: fan-made Heroes III expansion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="724"/>
-        <source>Skip</source>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="721"/>
+        <source>Finish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="755"/>
-        <source>Join community / get help</source>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="111"/>
+        <source>Step %v out of %m</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="143"/>
+        <source>Choose your language</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="150"/>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="493"/>
+        <source>Next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="215"/>
+        <source>Find Heroes III data files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="246"/>
+        <source>Open help in browser</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="259"/>
+        <source>Search again</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="304"/>
+        <source>If you don&apos;t have installed Heroes III copy, it is possible to use our automatic installation tool &apos;vcmibuilder&apos; to extract data from GoG.com installer. Visit our wiki for detailed instructions.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="320"/>
+        <source>VCMI requires Heroes III data files in one of the locations listed above. Please copy Heroes III data in one of these directories.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="342"/>
+        <source>Heroes III data files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="355"/>
+        <source>Alternatively, you can select directory with installed Heroes III data and VCMI will copy exisiting data automatically.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="371"/>
+        <source>Copy existing data</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="384"/>
+        <source>Your Heroes III data files have been succesfully found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="424"/>
+        <source>Automatic detection of language failed. Please select language of your Heroes III copy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="443"/>
+        <source>Heroes III language</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="486"/>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="714"/>
+        <source>Back</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="524"/>
+        <source>Install VCMI Mod Preset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.cpp" line="264"/>
+        <source>Auto (%1)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -605,21 +583,26 @@
     </message>
     <message>
         <location filename="../languages.cpp" line="29"/>
-        <source>Ukrainian</source>
+        <source>Spanish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../languages.cpp" line="30"/>
-        <source>Other (East European)</source>
+        <source>Ukrainian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../languages.cpp" line="31"/>
-        <source>Other (Cyrillic Script)</source>
+        <source>Other (East European)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../languages.cpp" line="32"/>
+        <source>Other (Cyrillic Script)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../languages.cpp" line="33"/>
         <source>Other (West European)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -759,17 +742,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow_moc.ui" line="207"/>
-        <source>Setup</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../mainwindow_moc.ui" line="272"/>
+        <location filename="../mainwindow_moc.ui" line="226"/>
         <source>Map Editor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow_moc.ui" line="325"/>
+        <location filename="../mainwindow_moc.ui" line="279"/>
         <source>Start game</source>
         <translation type="unfinished"></translation>
     </message>

--- a/launcher/translation/english.ts
+++ b/launcher/translation/english.ts
@@ -228,171 +228,206 @@
 <context>
     <name>CSettingsView</name>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="580"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="327"/>
         <source>Change</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="223"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="356"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="450"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="222"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="287"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="473"/>
         <source>Open</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="507"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="590"/>
         <source>Adventure Map AI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="543"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="334"/>
         <source>User data directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="254"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="296"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="377"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="494"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="256"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="298"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="440"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="487"/>
         <source>Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="79"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="396"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="576"/>
         <source>Artificial Intelligence</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="89"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="278"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="415"/>
         <source>Mod Repositories</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="158"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="368"/>
         <source>Update now</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="259"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="301"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="382"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="499"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="261"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="303"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="445"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="492"/>
         <source>On</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="410"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="215"/>
         <source>Cursor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="425"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="500"/>
+        <source>Heroes III Data Language</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsView/csettingsview_moc.ui" line="552"/>
         <source>Default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="430"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="557"/>
         <source>Hardware</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="435"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="562"/>
         <source>Software</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="443"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="597"/>
+        <source>Heroes III Translation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsView/csettingsview_moc.ui" line="429"/>
         <source>Check on startup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="457"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="158"/>
         <source>Fullscreen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="417"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="172"/>
         <source>Neutral AI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="264"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="266"/>
         <source>Real</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="69"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="536"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="354"/>
         <source>General</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="483"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="144"/>
         <source>VCMI Language</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="557"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="422"/>
         <source>Friendly AI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="403"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="165"/>
         <source>Resolution</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="209"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="179"/>
         <source>Autosave</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="285"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="375"/>
         <source>Display index</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="165"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="151"/>
         <source>Network port</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="84"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="523"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="317"/>
         <source>Data Directories</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="74"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="315"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="192"/>
         <source>Video</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="550"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="466"/>
         <source>Extra data directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="322"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="583"/>
         <source>Log files directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="230"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="361"/>
         <source>Show intro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="349"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="341"/>
         <source>Build version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="151"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="534"/>
         <source>Enemy AI</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsView/csettingsview_moc.cpp" line="385"/>
+        <source>Active</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsView/csettingsview_moc.cpp" line="390"/>
+        <source>Disabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsView/csettingsview_moc.cpp" line="391"/>
+        <source>Enable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsView/csettingsview_moc.cpp" line="396"/>
+        <source>Not Installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsView/csettingsview_moc.cpp" line="397"/>
+        <source>Install</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -414,18 +449,13 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="414"/>
-        <source>Your Heroes III language has been succesfully detected.</source>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="384"/>
+        <source>Your Heroes III data files have been successfully found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firstLaunch/firstlaunch_moc.ui" line="552"/>
         <source>Optionally, you can install additional mods either now or at any point later:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="584"/>
-        <source>Install English translation of Heroes III</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -505,8 +535,8 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="384"/>
-        <source>Your Heroes III data files have been succesfully found.</source>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="414"/>
+        <source>Your Heroes III language has been successfully detected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -531,8 +561,8 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firstLaunch/firstlaunch_moc.cpp" line="264"/>
-        <source>Auto (%1)</source>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="584"/>
+        <source>Install translation of Heroes III to your language</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -547,63 +577,68 @@
 <context>
     <name>Language</name>
     <message>
-        <location filename="../languages.cpp" line="22"/>
+        <location filename="../languages.cpp" line="23"/>
         <source>Chinese</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../languages.cpp" line="23"/>
+        <location filename="../languages.cpp" line="24"/>
         <source>English</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../languages.cpp" line="24"/>
+        <location filename="../languages.cpp" line="25"/>
         <source>French</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../languages.cpp" line="25"/>
+        <location filename="../languages.cpp" line="26"/>
         <source>German</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../languages.cpp" line="26"/>
+        <location filename="../languages.cpp" line="27"/>
         <source>Korean</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../languages.cpp" line="27"/>
+        <location filename="../languages.cpp" line="28"/>
         <source>Polish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../languages.cpp" line="28"/>
+        <location filename="../languages.cpp" line="29"/>
         <source>Russian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../languages.cpp" line="29"/>
+        <location filename="../languages.cpp" line="30"/>
         <source>Spanish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../languages.cpp" line="30"/>
+        <location filename="../languages.cpp" line="31"/>
         <source>Ukrainian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../languages.cpp" line="31"/>
+        <location filename="../languages.cpp" line="32"/>
         <source>Other (East European)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../languages.cpp" line="32"/>
+        <location filename="../languages.cpp" line="33"/>
         <source>Other (Cyrillic Script)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../languages.cpp" line="33"/>
+        <location filename="../languages.cpp" line="34"/>
         <source>Other (West European)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../languages.cpp" line="56"/>
+        <source>Auto (%1)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/launcher/translation/german.ts
+++ b/launcher/translation/german.ts
@@ -228,172 +228,207 @@
 <context>
     <name>CSettingsView</name>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="580"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="327"/>
         <source>Change</source>
         <translation>Ändern</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="223"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="356"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="450"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="222"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="287"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="473"/>
         <source>Open</source>
         <translation>Öffnen</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="507"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="590"/>
         <source>Adventure Map AI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="543"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="334"/>
         <source>User data directory</source>
         <translation>Verzeichnis der Benutzerdaten</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="254"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="296"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="377"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="494"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="256"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="298"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="440"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="487"/>
         <source>Off</source>
         <translation>Aus</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="79"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="396"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="576"/>
         <source>Artificial Intelligence</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="89"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="278"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="415"/>
         <source>Mod Repositories</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="158"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="368"/>
         <source>Update now</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="259"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="301"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="382"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="499"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="261"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="303"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="445"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="492"/>
         <source>On</source>
         <translation>An</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="410"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="215"/>
         <source>Cursor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="425"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="500"/>
+        <source>Heroes III Data Language</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsView/csettingsview_moc.ui" line="552"/>
         <source>Default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="430"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="557"/>
         <source>Hardware</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="435"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="562"/>
         <source>Software</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="443"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="597"/>
+        <source>Heroes III Translation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsView/csettingsview_moc.ui" line="429"/>
         <source>Check on startup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="457"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="158"/>
         <source>Fullscreen</source>
         <translation>Vollbild</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="417"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="172"/>
         <source>Neutral AI</source>
         <translation>Neutrale KI</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="264"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="266"/>
         <source>Real</source>
         <translation>Vollständig</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="69"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="536"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="354"/>
         <source>General</source>
         <translation>Allgemein</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="483"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="144"/>
         <source>VCMI Language</source>
         <translation>VCMI-Sprache</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="557"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="422"/>
         <source>Friendly AI</source>
         <translation>Freundliche KI</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="403"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="165"/>
         <source>Resolution</source>
         <translation>Auflösung</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="209"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="179"/>
         <source>Autosave</source>
         <translation>Autospeichern</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="285"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="375"/>
         <source>Display index</source>
         <translation>Anzeige-Index</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="165"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="151"/>
         <source>Network port</source>
         <translation>Netzwerk-Port</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="84"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="523"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="317"/>
         <source>Data Directories</source>
         <translation>Daten-Verzeichnisse</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="74"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="315"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="192"/>
         <source>Video</source>
         <translation>Video</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="550"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="466"/>
         <source>Extra data directory</source>
         <translation>Zusätzliches Daten-Verzeichnis</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="322"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="583"/>
         <source>Log files directory</source>
         <translation>Verzeichnis der Log-Dateien</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="230"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="361"/>
         <source>Show intro</source>
         <translation>Intro anzeigen</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="349"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="341"/>
         <source>Build version</source>
         <translation>Version des Builds</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="151"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="534"/>
         <source>Enemy AI</source>
         <translation>Feindliche KI</translation>
+    </message>
+    <message>
+        <location filename="../settingsView/csettingsview_moc.cpp" line="385"/>
+        <source>Active</source>
+        <translation type="unfinished">Aktiv</translation>
+    </message>
+    <message>
+        <location filename="../settingsView/csettingsview_moc.cpp" line="390"/>
+        <source>Disabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsView/csettingsview_moc.cpp" line="391"/>
+        <source>Enable</source>
+        <translation type="unfinished">Aktivieren</translation>
+    </message>
+    <message>
+        <location filename="../settingsView/csettingsview_moc.cpp" line="396"/>
+        <source>Not Installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsView/csettingsview_moc.cpp" line="397"/>
+        <source>Install</source>
+        <translation type="unfinished">Installieren</translation>
     </message>
 </context>
 <context>
@@ -414,18 +449,13 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="414"/>
-        <source>Your Heroes III language has been succesfully detected.</source>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="384"/>
+        <source>Your Heroes III data files have been successfully found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firstLaunch/firstlaunch_moc.ui" line="552"/>
         <source>Optionally, you can install additional mods either now or at any point later:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="584"/>
-        <source>Install English translation of Heroes III</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -505,8 +535,8 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="384"/>
-        <source>Your Heroes III data files have been succesfully found.</source>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="414"/>
+        <source>Your Heroes III language has been successfully detected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -531,8 +561,8 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firstLaunch/firstlaunch_moc.cpp" line="264"/>
-        <source>Auto (%1)</source>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="584"/>
+        <source>Install translation of Heroes III to your language</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -547,63 +577,68 @@
 <context>
     <name>Language</name>
     <message>
-        <location filename="../languages.cpp" line="22"/>
+        <location filename="../languages.cpp" line="23"/>
         <source>Chinese</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../languages.cpp" line="23"/>
+        <location filename="../languages.cpp" line="24"/>
         <source>English</source>
         <translation type="unfinished">English (Englisch)</translation>
     </message>
     <message>
-        <location filename="../languages.cpp" line="24"/>
+        <location filename="../languages.cpp" line="25"/>
         <source>French</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../languages.cpp" line="25"/>
+        <location filename="../languages.cpp" line="26"/>
         <source>German</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../languages.cpp" line="26"/>
+        <location filename="../languages.cpp" line="27"/>
         <source>Korean</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../languages.cpp" line="27"/>
+        <location filename="../languages.cpp" line="28"/>
         <source>Polish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../languages.cpp" line="28"/>
+        <location filename="../languages.cpp" line="29"/>
         <source>Russian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../languages.cpp" line="29"/>
+        <location filename="../languages.cpp" line="30"/>
         <source>Spanish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../languages.cpp" line="30"/>
+        <location filename="../languages.cpp" line="31"/>
         <source>Ukrainian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../languages.cpp" line="31"/>
+        <location filename="../languages.cpp" line="32"/>
         <source>Other (East European)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../languages.cpp" line="32"/>
+        <location filename="../languages.cpp" line="33"/>
         <source>Other (Cyrillic Script)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../languages.cpp" line="33"/>
+        <location filename="../languages.cpp" line="34"/>
         <source>Other (West European)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../languages.cpp" line="56"/>
+        <source>Auto (%1)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/launcher/translation/german.ts
+++ b/launcher/translation/german.ts
@@ -4,101 +4,86 @@
 <context>
     <name>CModListModel</name>
     <message>
-        <location filename="../modManager/cmodlistmodel_moc.cpp" line="150"/>
+        <location filename="../modManager/cmodlistmodel_moc.cpp" line="142"/>
         <source>Name</source>
         <translation>Name</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistmodel_moc.cpp" line="153"/>
+        <location filename="../modManager/cmodlistmodel_moc.cpp" line="145"/>
         <source>Type</source>
         <translation>Typ</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistmodel_moc.cpp" line="154"/>
+        <location filename="../modManager/cmodlistmodel_moc.cpp" line="146"/>
         <source>Version</source>
         <translation>Version</translation>
-    </message>
-    <message>
-        <location filename="../modManager/cmodlistmodel_moc.cpp" line="155"/>
-        <source>Size</source>
-        <translation>Größe</translation>
-    </message>
-    <message>
-        <location filename="../modManager/cmodlistmodel_moc.cpp" line="156"/>
-        <source>Author</source>
-        <translation>Autor</translation>
     </message>
 </context>
 <context>
     <name>CModListView</name>
     <message>
-        <location filename="../modManager/cmodlistview_moc.ui" line="61"/>
+        <location filename="../modManager/cmodlistview_moc.ui" line="58"/>
         <source>Filter</source>
         <translation>Filter</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.ui" line="84"/>
+        <location filename="../modManager/cmodlistview_moc.ui" line="81"/>
         <source>All mods</source>
         <translation>Alle Mods</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.ui" line="89"/>
+        <location filename="../modManager/cmodlistview_moc.ui" line="86"/>
         <source>Downloadable</source>
         <translation>Herunterladbar</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.ui" line="94"/>
+        <location filename="../modManager/cmodlistview_moc.ui" line="91"/>
         <source>Installed</source>
         <translation>Installiert</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.ui" line="99"/>
+        <location filename="../modManager/cmodlistview_moc.ui" line="96"/>
         <source>Updatable</source>
         <translation>Aktualisierbar</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.ui" line="104"/>
+        <location filename="../modManager/cmodlistview_moc.ui" line="101"/>
         <source>Active</source>
         <translation>Aktiv</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.ui" line="109"/>
+        <location filename="../modManager/cmodlistview_moc.ui" line="106"/>
         <source>Inactive</source>
         <translation>Inaktiv</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.ui" line="123"/>
+        <location filename="../modManager/cmodlistview_moc.ui" line="120"/>
         <source>Download &amp;&amp; refresh repositories</source>
         <translation>Repositories herunterladen &amp;&amp; aktualisieren</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.ui" line="228"/>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="288"/>
+        <location filename="../modManager/cmodlistview_moc.ui" line="163"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="270"/>
         <source>Description</source>
         <translation>Beschreibung</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.ui" line="273"/>
+        <location filename="../modManager/cmodlistview_moc.ui" line="208"/>
         <source>Changelog</source>
         <translation>Änderungslog</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.ui" line="295"/>
+        <location filename="../modManager/cmodlistview_moc.ui" line="230"/>
         <source>Screenshots</source>
         <translation>Screenshots</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.ui" line="368"/>
-        <source>Show details</source>
-        <translation>Details anzeigen</translation>
-    </message>
-    <message>
-        <location filename="../modManager/cmodlistview_moc.ui" line="409"/>
+        <location filename="../modManager/cmodlistview_moc.ui" line="389"/>
         <source>Uninstall</source>
         <translation>Deinstallieren</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.ui" line="434"/>
+        <location filename="../modManager/cmodlistview_moc.ui" line="424"/>
         <source>Enable</source>
         <translation>Aktivieren</translation>
     </message>
@@ -108,134 +93,134 @@
         <translation>Deaktivieren</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.ui" line="484"/>
+        <location filename="../modManager/cmodlistview_moc.ui" line="494"/>
         <source>Update</source>
         <translation>Aktualisieren</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.ui" line="509"/>
+        <location filename="../modManager/cmodlistview_moc.ui" line="529"/>
         <source>Install</source>
         <translation>Installieren</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.ui" line="563"/>
+        <location filename="../modManager/cmodlistview_moc.ui" line="327"/>
         <source> %p% (%v KB out of %m KB)</source>
         <translation> %p% (%v КB von %m КB)</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.ui" line="576"/>
+        <location filename="../modManager/cmodlistview_moc.ui" line="340"/>
         <source>Abort</source>
         <translation>Abbrechen</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="246"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="228"/>
         <source>Mod name</source>
         <translation>Mod-Name</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="247"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="229"/>
         <source>Installed version</source>
         <translation>Installierte Version</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="248"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="230"/>
         <source>Latest version</source>
         <translation>Letzte Version</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="251"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="233"/>
         <source>Download size</source>
         <translation>Downloadgröße</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="252"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="234"/>
         <source>Authors</source>
         <translation>Autoren</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="255"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="237"/>
         <source>License</source>
         <translation>Lizenz</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="258"/>
-        <source>Home</source>
-        <translation>Home</translation>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="240"/>
+        <source>Contact</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="262"/>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="269"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="244"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="251"/>
         <source>Compatibility</source>
         <translation>Kompatibilität</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="271"/>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="279"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="253"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="261"/>
         <source>Required VCMI version</source>
         <translation>Benötigte VCMI Version</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="277"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="259"/>
         <source>Supported VCMI version</source>
         <translation>Unterstützte VCMI Version</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="282"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="264"/>
         <source>Supported VCMI versions</source>
         <translation>Unterstützte VCMI Versionen</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="286"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="268"/>
         <source>Required mods</source>
         <translation>Benötigte Mods</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="287"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="269"/>
         <source>Conflicting mods</source>
         <translation>Mods mit Konflikt</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="292"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="274"/>
         <source>This mod can not be installed or enabled because following dependencies are not present</source>
         <translation>Diese Mod kann nicht installiert oder aktiviert werden, da die folgenden Abhängigkeiten nicht vorhanden sind</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="293"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="275"/>
         <source>This mod can not be enabled because following mods are incompatible with this mod</source>
         <translation>Diese Mod kann nicht aktiviert werden, da folgende Mods nicht mit dieser Mod kompatibel sind</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="294"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="276"/>
         <source>This mod can not be disabled because it is required to run following mods</source>
         <translation>Diese Mod kann nicht deaktiviert werden, da sie zum Ausführen der folgenden Mods erforderlich ist</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="295"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="277"/>
         <source>This mod can not be uninstalled or updated because it is required to run following mods</source>
         <translation>Diese Mod kann nicht deinstalliert oder aktualisiert werden, da sie für die folgenden Mods erforderlich ist</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="296"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="278"/>
         <source>This is submod and it can not be installed or uninstalled separately from parent mod</source>
         <translation>Dies ist eine Submod und kann nicht separat von der Hauptmod installiert oder deinstalliert werden</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="311"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="293"/>
         <source>Notes</source>
         <translation>Anmerkungen</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="828"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="795"/>
         <source>Screenshot %1</source>
         <translation>Screenshot %1</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="240"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="222"/>
         <source>Mod is compatible</source>
         <translation>Mod ist kompatibel</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="241"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="223"/>
         <source>Mod is incompatible</source>
         <translation>Mod ist inkompatibel</translation>
     </message>
@@ -243,217 +228,334 @@
 <context>
     <name>CSettingsView</name>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="80"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="580"/>
         <source>Change</source>
         <translation>Ändern</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="104"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="205"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="396"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="223"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="356"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="450"/>
         <source>Open</source>
         <translation>Öffnen</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="445"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="507"/>
+        <source>Adventure Map AI</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsView/csettingsview_moc.ui" line="543"/>
         <source>User data directory</source>
         <translation>Verzeichnis der Benutzerdaten</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="91"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="129"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="312"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="334"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="254"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="296"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="377"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="494"/>
         <source>Off</source>
         <translation>Aus</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="96"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="134"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="317"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="339"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="79"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="396"/>
+        <source>Artificial Intelligence</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsView/csettingsview_moc.ui" line="89"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="278"/>
+        <source>Mod Repositories</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsView/csettingsview_moc.ui" line="158"/>
+        <source>Update now</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsView/csettingsview_moc.ui" line="259"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="301"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="382"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="499"/>
         <source>On</source>
         <translation>An</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="118"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="410"/>
+        <source>Cursor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsView/csettingsview_moc.ui" line="425"/>
+        <source>Default</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsView/csettingsview_moc.ui" line="430"/>
+        <source>Hardware</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsView/csettingsview_moc.ui" line="435"/>
+        <source>Software</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsView/csettingsview_moc.ui" line="443"/>
+        <source>Check on startup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsView/csettingsview_moc.ui" line="457"/>
         <source>Fullscreen</source>
         <translation>Vollbild</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="234"/>
-        <source>AI in the battlefield</source>
-        <translation>KI auf dem Schlachtfeld</translation>
-    </message>
-    <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="181"/>
-        <source>Repositories</source>
-        <translation>Repositories</translation>
-    </message>
-    <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="188"/>
-        <source>Check for updates</source>
-        <translation>Nach Aktualisierungen suchen</translation>
-    </message>
-    <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="549"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="417"/>
         <source>Neutral AI</source>
         <translation>Neutrale KI</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="322"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="264"/>
         <source>Real</source>
         <translation>Vollständig</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="257"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="69"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="536"/>
         <source>General</source>
         <translation>Allgemein</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="212"/>
-        <source>Player AI</source>
-        <translation>Spieler-KI</translation>
-    </message>
-    <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="472"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="483"/>
         <source>VCMI Language</source>
         <translation>VCMI-Sprache</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="487"/>
-        <source>Central European (Windows 1250)</source>
-        <translation>Mitteleuropäisch (Windows 1250)</translation>
-    </message>
-    <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="492"/>
-        <source>Cyrillic script (Windows 1251)</source>
-        <translation>Kyrillische Schrift (Windows 1251)</translation>
-    </message>
-    <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="497"/>
-        <source>Western European (Windows 1252)</source>
-        <translation>Westeuropäisch (Windows 1252)</translation>
-    </message>
-    <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="502"/>
-        <source>Simplified Chinese (GBK)</source>
-        <translation>Vereinfachtes Chinesisch (GBK)</translation>
-    </message>
-    <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="507"/>
-        <source>Simplified Chinese (GB2312)</source>
-        <translation>Vereinfachtes Chinesisch (GB2312)</translation>
-    </message>
-    <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="512"/>
-        <source>Korean (Windows 949)</source>
-        <translation>Koreanisch (Windows 949)</translation>
-    </message>
-    <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="521"/>
-        <source>English</source>
-        <translation>English (Englisch)</translation>
-    </message>
-    <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="526"/>
-        <source>Deutsch (German)</source>
-        <translation>Deutsch</translation>
-    </message>
-    <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="531"/>
-        <source>Polska (Polish)</source>
-        <translation>Polska (Polnisch)</translation>
-    </message>
-    <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="536"/>
-        <source>Русский (Russian)</source>
-        <translation>Русский (Russisch)</translation>
-    </message>
-    <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="541"/>
-        <source>Українська (Ukrainian)</source>
-        <translation>Українська (Ukrainisch)</translation>
-    </message>
-    <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="579"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="557"/>
         <source>Friendly AI</source>
         <translation>Freundliche KI</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="301"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="403"/>
         <source>Resolution</source>
         <translation>Auflösung</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="353"/>
-        <source>AI on the map</source>
-        <translation>KI auf der Karte</translation>
-    </message>
-    <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="168"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="209"/>
         <source>Autosave</source>
         <translation>Autospeichern</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="219"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="285"/>
         <source>Display index</source>
         <translation>Anzeige-Index</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="198"/>
-        <source>Check repositories on startup</source>
-        <translation>Repositories beim Start prüfen</translation>
-    </message>
-    <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="452"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="165"/>
         <source>Network port</source>
         <translation>Netzwerk-Port</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="422"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="84"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="523"/>
         <source>Data Directories</source>
         <translation>Daten-Verzeichnisse</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="409"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="74"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="315"/>
         <source>Video</source>
         <translation>Video</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="111"/>
-        <source>Heroes III character set</source>
-        <translation>Heroes III Zeichensatz</translation>
-    </message>
-    <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="294"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="550"/>
         <source>Extra data directory</source>
         <translation>Zusätzliches Daten-Verzeichnis</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="142"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="322"/>
         <source>Log files directory</source>
         <translation>Verzeichnis der Log-Dateien</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="264"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="230"/>
         <source>Show intro</source>
         <translation>Intro anzeigen</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="57"/>
-        <source>Launcher Settings</source>
-        <translation>Launcher-Einstellungen</translation>
-    </message>
-    <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="287"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="349"/>
         <source>Build version</source>
         <translation>Version des Builds</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="632"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="151"/>
         <source>Enemy AI</source>
         <translation>Feindliche KI</translation>
+    </message>
+</context>
+<context>
+    <name>FirstLaunchView</name>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="28"/>
+        <source>Language</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="53"/>
+        <source>Heroes III Data</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="78"/>
+        <source>Mods Preset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="103"/>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="797"/>
+        <source>Finish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="136"/>
+        <source>Step %v out of %m</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="168"/>
+        <source>Choose your language</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="175"/>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="506"/>
+        <source>Next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="240"/>
+        <source>Find Heroes III data files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="271"/>
+        <source>Open help in browser</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="284"/>
+        <source>Search again</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="317"/>
+        <source>If you don&apos;t have installed Heroes III copy, it is possible to use our automatic installation tool &apos;vcmibuilder&apos; to extract data from GoG.com installer. Visit our wiki for detailed instructions.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="333"/>
+        <source>VCMI requires Heroes III data files in one of the locations listed above. Please copy Heroes III data in one of these directories.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="355"/>
+        <source>Heroes III data files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="368"/>
+        <source>Alternatively, you can select directory with installed Heroes III data and VCMI will copy exisiting data automatically.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="384"/>
+        <source>Copy existing data</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="397"/>
+        <source>Your Heroes III data files have been succesfully found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="427"/>
+        <source>You Heroes III language was succesfully detected automatically.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="437"/>
+        <source>Automatic detection of language failed. Please select language of your Heroes III copy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="456"/>
+        <source>Heroes III language</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="499"/>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="717"/>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="790"/>
+        <source>Back</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="537"/>
+        <source>Install VCMI Mod Preset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="565"/>
+        <source>VCMI provides its own version of Horn of the Abyss fan-made addon. If you wish you can install it right now. For more information about mod visit hota website</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="581"/>
+        <source>Localization to English</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="661"/>
+        <source>VCMI provides translations of Heroes III into a different languages. If you wish, you can install translation to English</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="597"/>
+        <source>Install VCMI-compatible version of the &quot;In The Wake of Gods&quot; fan-made addon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="613"/>
+        <source>Heroes III + HotA</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="629"/>
+        <source>Heroes III + WoG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="645"/>
+        <source>VCMI provides support for playing Heroes III in resolutions other than 800x600. If you wish, you can install this support</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="677"/>
+        <source>HD support</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="724"/>
+        <source>Skip</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="755"/>
+        <source>Join community / get help</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -465,66 +567,160 @@
     </message>
 </context>
 <context>
+    <name>Language</name>
+    <message>
+        <location filename="../languages.cpp" line="22"/>
+        <source>Chinese</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../languages.cpp" line="23"/>
+        <source>English</source>
+        <translation type="unfinished">English (Englisch)</translation>
+    </message>
+    <message>
+        <location filename="../languages.cpp" line="24"/>
+        <source>French</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../languages.cpp" line="25"/>
+        <source>German</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../languages.cpp" line="26"/>
+        <source>Korean</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../languages.cpp" line="27"/>
+        <source>Polish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../languages.cpp" line="28"/>
+        <source>Russian</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../languages.cpp" line="29"/>
+        <source>Ukrainian</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../languages.cpp" line="30"/>
+        <source>Other (East European)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../languages.cpp" line="31"/>
+        <source>Other (Cyrillic Script)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../languages.cpp" line="32"/>
+        <source>Other (West European)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Lobby</name>
     <message>
-        <location filename="../lobby/lobby_moc.ui" line="26"/>
+        <location filename="../lobby/lobby_moc.ui" line="39"/>
+        <location filename="../lobby/lobby_moc.cpp" line="401"/>
         <source>Connect</source>
         <translation>Verbinden</translation>
     </message>
     <message>
-        <location filename="../lobby/lobby_moc.ui" line="45"/>
+        <location filename="../lobby/lobby_moc.ui" line="26"/>
         <source>Username</source>
         <translation>Benutzername</translation>
     </message>
     <message>
-        <location filename="../lobby/lobby_moc.ui" line="69"/>
+        <location filename="../lobby/lobby_moc.ui" line="56"/>
         <source>Server</source>
         <translation>Server</translation>
     </message>
     <message>
-        <location filename="../lobby/lobby_moc.ui" line="111"/>
+        <location filename="../lobby/lobby_moc.ui" line="76"/>
+        <source>People in lobby</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../lobby/lobby_moc.ui" line="114"/>
+        <source>Lobby chat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../lobby/lobby_moc.ui" line="194"/>
         <source>Session</source>
         <translation>Sitzung</translation>
     </message>
     <message>
-        <location filename="../lobby/lobby_moc.ui" line="116"/>
+        <location filename="../lobby/lobby_moc.ui" line="199"/>
         <source>Players</source>
         <translation>Spieler</translation>
     </message>
     <message>
-        <location filename="../lobby/lobby_moc.ui" line="132"/>
+        <location filename="../lobby/lobby_moc.ui" line="274"/>
+        <source>Resolve</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../lobby/lobby_moc.ui" line="286"/>
+        <source>New game</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../lobby/lobby_moc.ui" line="293"/>
+        <source>Load game</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../lobby/lobby_moc.ui" line="149"/>
         <source>New room</source>
         <translation>Neuer Raum</translation>
     </message>
     <message>
-        <location filename="../lobby/lobby_moc.ui" line="142"/>
+        <location filename="../lobby/lobby_moc.ui" line="159"/>
         <source>Join room</source>
         <translation>Raum beitreten</translation>
     </message>
     <message>
-        <location filename="../lobby/lobby_moc.ui" line="153"/>
+        <location filename="../lobby/lobby_moc.ui" line="267"/>
         <source>Ready</source>
         <translation>Bereit</translation>
     </message>
     <message>
-        <location filename="../lobby/lobby_moc.ui" line="160"/>
+        <location filename="../lobby/lobby_moc.ui" line="250"/>
         <source>Mods mismatch</source>
         <translation>Mods stimmen nicht überein</translation>
     </message>
     <message>
-        <location filename="../lobby/lobby_moc.ui" line="167"/>
+        <location filename="../lobby/lobby_moc.ui" line="243"/>
         <source>Leave</source>
         <translation>Verlassen</translation>
     </message>
     <message>
-        <location filename="../lobby/lobby_moc.ui" line="197"/>
+        <location filename="../lobby/lobby_moc.ui" line="216"/>
         <source>Kick player</source>
         <translation>Spieler kicken</translation>
     </message>
     <message>
-        <location filename="../lobby/lobby_moc.ui" line="204"/>
+        <location filename="../lobby/lobby_moc.ui" line="236"/>
         <source>Players in the room</source>
         <translation>Spieler im Raum</translation>
+    </message>
+    <message>
+        <location filename="../lobby/lobby_moc.cpp" line="369"/>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../lobby/lobby_moc.cpp" line="461"/>
+        <source>No issues detected</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -558,31 +754,32 @@
         <translation>VCMI Launcher</translation>
     </message>
     <message>
-        <location filename="../mainwindow_moc.ui" line="51"/>
+        <location filename="../mainwindow_moc.ui" line="57"/>
         <source>Mods</source>
         <translation>Mods</translation>
     </message>
     <message>
-        <source>Editor</source>
-        <translation type="vanished">Editor</translation>
-    </message>
-    <message>
-        <location filename="../mainwindow_moc.ui" line="95"/>
+        <location filename="../mainwindow_moc.ui" line="107"/>
         <source>Settings</source>
         <translation>Einstellungen</translation>
     </message>
     <message>
-        <location filename="../mainwindow_moc.ui" line="139"/>
+        <location filename="../mainwindow_moc.ui" line="157"/>
         <source>Lobby</source>
         <translation>Lobby</translation>
     </message>
     <message>
-        <location filename="../mainwindow_moc.ui" line="189"/>
+        <location filename="../mainwindow_moc.ui" line="207"/>
+        <source>Setup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow_moc.ui" line="272"/>
         <source>Map Editor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow_moc.ui" line="236"/>
+        <location filename="../mainwindow_moc.ui" line="325"/>
         <source>Start game</source>
         <translation>Spiel starten</translation>
     </message>

--- a/launcher/translation/german.ts
+++ b/launcher/translation/german.ts
@@ -63,7 +63,7 @@
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.ui" line="163"/>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="270"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="272"/>
         <source>Description</source>
         <translation>Beschreibung</translation>
     </message>
@@ -113,114 +113,114 @@
         <translation>Abbrechen</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="228"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="230"/>
         <source>Mod name</source>
         <translation>Mod-Name</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="229"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="231"/>
         <source>Installed version</source>
         <translation>Installierte Version</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="230"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="232"/>
         <source>Latest version</source>
         <translation>Letzte Version</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="233"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="235"/>
         <source>Download size</source>
         <translation>Downloadgröße</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="234"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="236"/>
         <source>Authors</source>
         <translation>Autoren</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="237"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="239"/>
         <source>License</source>
         <translation>Lizenz</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="240"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="242"/>
         <source>Contact</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="244"/>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="251"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="246"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="253"/>
         <source>Compatibility</source>
         <translation>Kompatibilität</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="253"/>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="261"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="255"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="263"/>
         <source>Required VCMI version</source>
         <translation>Benötigte VCMI Version</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="259"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="261"/>
         <source>Supported VCMI version</source>
         <translation>Unterstützte VCMI Version</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="264"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="266"/>
         <source>Supported VCMI versions</source>
         <translation>Unterstützte VCMI Versionen</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="268"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="270"/>
         <source>Required mods</source>
         <translation>Benötigte Mods</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="269"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="271"/>
         <source>Conflicting mods</source>
         <translation>Mods mit Konflikt</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="274"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="276"/>
         <source>This mod can not be installed or enabled because following dependencies are not present</source>
         <translation>Diese Mod kann nicht installiert oder aktiviert werden, da die folgenden Abhängigkeiten nicht vorhanden sind</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="275"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="277"/>
         <source>This mod can not be enabled because following mods are incompatible with this mod</source>
         <translation>Diese Mod kann nicht aktiviert werden, da folgende Mods nicht mit dieser Mod kompatibel sind</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="276"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="278"/>
         <source>This mod can not be disabled because it is required to run following mods</source>
         <translation>Diese Mod kann nicht deaktiviert werden, da sie zum Ausführen der folgenden Mods erforderlich ist</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="277"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="279"/>
         <source>This mod can not be uninstalled or updated because it is required to run following mods</source>
         <translation>Diese Mod kann nicht deinstalliert oder aktualisiert werden, da sie für die folgenden Mods erforderlich ist</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="278"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="280"/>
         <source>This is submod and it can not be installed or uninstalled separately from parent mod</source>
         <translation>Dies ist eine Submod und kann nicht separat von der Hauptmod installiert oder deinstalliert werden</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="293"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="295"/>
         <source>Notes</source>
         <translation>Anmerkungen</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="795"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="797"/>
         <source>Screenshot %1</source>
         <translation>Screenshot %1</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="222"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="224"/>
         <source>Mod is compatible</source>
         <translation>Mod ist kompatibel</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="223"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="225"/>
         <source>Mod is incompatible</source>
         <translation>Mod ist inkompatibel</translation>
     </message>
@@ -414,147 +414,125 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="103"/>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="797"/>
-        <source>Finish</source>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="414"/>
+        <source>Your Heroes III language has been succesfully detected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="136"/>
-        <source>Step %v out of %m</source>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="552"/>
+        <source>Optionally, you can install additional mods either now or at any point later:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="168"/>
-        <source>Choose your language</source>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="584"/>
+        <source>Install English translation of Heroes III</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="175"/>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="506"/>
-        <source>Next</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="240"/>
-        <source>Find Heroes III data files</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="271"/>
-        <source>Open help in browser</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="284"/>
-        <source>Search again</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="317"/>
-        <source>If you don&apos;t have installed Heroes III copy, it is possible to use our automatic installation tool &apos;vcmibuilder&apos; to extract data from GoG.com installer. Visit our wiki for detailed instructions.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="333"/>
-        <source>VCMI requires Heroes III data files in one of the locations listed above. Please copy Heroes III data in one of these directories.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="355"/>
-        <source>Heroes III data files</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="368"/>
-        <source>Alternatively, you can select directory with installed Heroes III data and VCMI will copy exisiting data automatically.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="384"/>
-        <source>Copy existing data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="397"/>
-        <source>Your Heroes III data files have been succesfully found.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="427"/>
-        <source>You Heroes III language was succesfully detected automatically.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="437"/>
-        <source>Automatic detection of language failed. Please select language of your Heroes III copy</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="456"/>
-        <source>Heroes III language</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="499"/>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="717"/>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="790"/>
-        <source>Back</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="537"/>
-        <source>Install VCMI Mod Preset</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="565"/>
-        <source>VCMI provides its own version of Horn of the Abyss fan-made addon. If you wish you can install it right now. For more information about mod visit hota website</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="581"/>
-        <source>Localization to English</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="661"/>
-        <source>VCMI provides translations of Heroes III into a different languages. If you wish, you can install translation to English</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="597"/>
-        <source>Install VCMI-compatible version of the &quot;In The Wake of Gods&quot; fan-made addon</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="613"/>
-        <source>Heroes III + HotA</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="629"/>
-        <source>Heroes III + WoG</source>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="616"/>
+        <source>Install support for playing Heroes III in resolutions other than 800x600.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firstLaunch/firstlaunch_moc.ui" line="645"/>
-        <source>VCMI provides support for playing Heroes III in resolutions other than 800x600. If you wish, you can install this support</source>
+        <source>Install compatible version of addon Horn of the Abyss: fan-made Heroes III expansion, ported by VCMI team</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="677"/>
-        <source>HD support</source>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="674"/>
+        <source>Install compatible version of addon &quot;In The Wake of Gods&quot;: fan-made Heroes III expansion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="724"/>
-        <source>Skip</source>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="721"/>
+        <source>Finish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="755"/>
-        <source>Join community / get help</source>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="111"/>
+        <source>Step %v out of %m</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="143"/>
+        <source>Choose your language</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="150"/>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="493"/>
+        <source>Next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="215"/>
+        <source>Find Heroes III data files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="246"/>
+        <source>Open help in browser</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="259"/>
+        <source>Search again</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="304"/>
+        <source>If you don&apos;t have installed Heroes III copy, it is possible to use our automatic installation tool &apos;vcmibuilder&apos; to extract data from GoG.com installer. Visit our wiki for detailed instructions.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="320"/>
+        <source>VCMI requires Heroes III data files in one of the locations listed above. Please copy Heroes III data in one of these directories.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="342"/>
+        <source>Heroes III data files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="355"/>
+        <source>Alternatively, you can select directory with installed Heroes III data and VCMI will copy exisiting data automatically.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="371"/>
+        <source>Copy existing data</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="384"/>
+        <source>Your Heroes III data files have been succesfully found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="424"/>
+        <source>Automatic detection of language failed. Please select language of your Heroes III copy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="443"/>
+        <source>Heroes III language</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="486"/>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="714"/>
+        <source>Back</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="524"/>
+        <source>Install VCMI Mod Preset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.cpp" line="264"/>
+        <source>Auto (%1)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -605,21 +583,26 @@
     </message>
     <message>
         <location filename="../languages.cpp" line="29"/>
-        <source>Ukrainian</source>
+        <source>Spanish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../languages.cpp" line="30"/>
-        <source>Other (East European)</source>
+        <source>Ukrainian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../languages.cpp" line="31"/>
-        <source>Other (Cyrillic Script)</source>
+        <source>Other (East European)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../languages.cpp" line="32"/>
+        <source>Other (Cyrillic Script)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../languages.cpp" line="33"/>
         <source>Other (West European)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -769,17 +752,12 @@
         <translation>Lobby</translation>
     </message>
     <message>
-        <location filename="../mainwindow_moc.ui" line="207"/>
-        <source>Setup</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../mainwindow_moc.ui" line="272"/>
+        <location filename="../mainwindow_moc.ui" line="226"/>
         <source>Map Editor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow_moc.ui" line="325"/>
+        <location filename="../mainwindow_moc.ui" line="279"/>
         <source>Start game</source>
         <translation>Spiel starten</translation>
     </message>

--- a/launcher/translation/polish.ts
+++ b/launcher/translation/polish.ts
@@ -228,172 +228,207 @@
 <context>
     <name>CSettingsView</name>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="580"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="327"/>
         <source>Change</source>
         <translation>Zmień</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="223"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="356"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="450"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="222"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="287"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="473"/>
         <source>Open</source>
         <translation>Otwórz</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="507"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="590"/>
         <source>Adventure Map AI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="543"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="334"/>
         <source>User data directory</source>
         <translation>Katalog danych użytkownika</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="254"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="296"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="377"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="494"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="256"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="298"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="440"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="487"/>
         <source>Off</source>
         <translation>Wyłączony</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="79"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="396"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="576"/>
         <source>Artificial Intelligence</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="89"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="278"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="415"/>
         <source>Mod Repositories</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="158"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="368"/>
         <source>Update now</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="259"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="301"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="382"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="499"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="261"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="303"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="445"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="492"/>
         <source>On</source>
         <translation>Włączony</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="410"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="215"/>
         <source>Cursor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="425"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="500"/>
+        <source>Heroes III Data Language</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsView/csettingsview_moc.ui" line="552"/>
         <source>Default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="430"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="557"/>
         <source>Hardware</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="435"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="562"/>
         <source>Software</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="443"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="597"/>
+        <source>Heroes III Translation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsView/csettingsview_moc.ui" line="429"/>
         <source>Check on startup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="457"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="158"/>
         <source>Fullscreen</source>
         <translation>Pełny ekran</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="417"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="172"/>
         <source>Neutral AI</source>
         <translation>AI jednostek neutralnych</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="264"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="266"/>
         <source>Real</source>
         <translation>Prawdziwy</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="69"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="536"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="354"/>
         <source>General</source>
         <translation>Ogólne</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="483"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="144"/>
         <source>VCMI Language</source>
         <translation>Język VCMI</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="557"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="422"/>
         <source>Friendly AI</source>
         <translation>AI sojuszników</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="403"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="165"/>
         <source>Resolution</source>
         <translation>Rozdzielczość</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="209"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="179"/>
         <source>Autosave</source>
         <translation>Autozapis</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="285"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="375"/>
         <source>Display index</source>
         <translation>Numer wyświetlacza</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="165"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="151"/>
         <source>Network port</source>
         <translation>Port sieciowy</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="84"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="523"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="317"/>
         <source>Data Directories</source>
         <translation>Katalogi z danymi</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="74"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="315"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="192"/>
         <source>Video</source>
         <translation>Obraz</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="550"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="466"/>
         <source>Extra data directory</source>
         <translation>Katalog danych dodatkowych</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="322"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="583"/>
         <source>Log files directory</source>
         <translation>Katalog logów</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="230"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="361"/>
         <source>Show intro</source>
         <translation>Pokaż intro</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="349"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="341"/>
         <source>Build version</source>
         <translation>Wersja programu</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="151"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="534"/>
         <source>Enemy AI</source>
         <translation>AI wrogich graczy</translation>
+    </message>
+    <message>
+        <location filename="../settingsView/csettingsview_moc.cpp" line="385"/>
+        <source>Active</source>
+        <translation type="unfinished">Aktywny</translation>
+    </message>
+    <message>
+        <location filename="../settingsView/csettingsview_moc.cpp" line="390"/>
+        <source>Disabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsView/csettingsview_moc.cpp" line="391"/>
+        <source>Enable</source>
+        <translation type="unfinished">Włącz</translation>
+    </message>
+    <message>
+        <location filename="../settingsView/csettingsview_moc.cpp" line="396"/>
+        <source>Not Installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsView/csettingsview_moc.cpp" line="397"/>
+        <source>Install</source>
+        <translation type="unfinished">Zainstaluj</translation>
     </message>
 </context>
 <context>
@@ -414,18 +449,13 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="414"/>
-        <source>Your Heroes III language has been succesfully detected.</source>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="384"/>
+        <source>Your Heroes III data files have been successfully found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firstLaunch/firstlaunch_moc.ui" line="552"/>
         <source>Optionally, you can install additional mods either now or at any point later:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="584"/>
-        <source>Install English translation of Heroes III</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -505,8 +535,8 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="384"/>
-        <source>Your Heroes III data files have been succesfully found.</source>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="414"/>
+        <source>Your Heroes III language has been successfully detected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -531,8 +561,8 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firstLaunch/firstlaunch_moc.cpp" line="264"/>
-        <source>Auto (%1)</source>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="584"/>
+        <source>Install translation of Heroes III to your language</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -547,63 +577,68 @@
 <context>
     <name>Language</name>
     <message>
-        <location filename="../languages.cpp" line="22"/>
+        <location filename="../languages.cpp" line="23"/>
         <source>Chinese</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../languages.cpp" line="23"/>
+        <location filename="../languages.cpp" line="24"/>
         <source>English</source>
         <translation type="unfinished">English (Angielski)</translation>
     </message>
     <message>
-        <location filename="../languages.cpp" line="24"/>
+        <location filename="../languages.cpp" line="25"/>
         <source>French</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../languages.cpp" line="25"/>
+        <location filename="../languages.cpp" line="26"/>
         <source>German</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../languages.cpp" line="26"/>
+        <location filename="../languages.cpp" line="27"/>
         <source>Korean</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../languages.cpp" line="27"/>
+        <location filename="../languages.cpp" line="28"/>
         <source>Polish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../languages.cpp" line="28"/>
+        <location filename="../languages.cpp" line="29"/>
         <source>Russian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../languages.cpp" line="29"/>
+        <location filename="../languages.cpp" line="30"/>
         <source>Spanish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../languages.cpp" line="30"/>
+        <location filename="../languages.cpp" line="31"/>
         <source>Ukrainian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../languages.cpp" line="31"/>
+        <location filename="../languages.cpp" line="32"/>
         <source>Other (East European)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../languages.cpp" line="32"/>
+        <location filename="../languages.cpp" line="33"/>
         <source>Other (Cyrillic Script)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../languages.cpp" line="33"/>
+        <location filename="../languages.cpp" line="34"/>
         <source>Other (West European)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../languages.cpp" line="56"/>
+        <source>Auto (%1)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/launcher/translation/polish.ts
+++ b/launcher/translation/polish.ts
@@ -63,7 +63,7 @@
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.ui" line="163"/>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="270"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="272"/>
         <source>Description</source>
         <translation>Opis</translation>
     </message>
@@ -113,114 +113,114 @@
         <translation>Przerwij</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="228"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="230"/>
         <source>Mod name</source>
         <translation>Nazwa moda</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="229"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="231"/>
         <source>Installed version</source>
         <translation>Zainstalowana wersja</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="230"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="232"/>
         <source>Latest version</source>
         <translation>Najnowsza wersja</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="233"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="235"/>
         <source>Download size</source>
         <translation>Rozmiar pobierania</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="234"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="236"/>
         <source>Authors</source>
         <translation>Autorzy</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="237"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="239"/>
         <source>License</source>
         <translation>Licencja</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="240"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="242"/>
         <source>Contact</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="244"/>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="251"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="246"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="253"/>
         <source>Compatibility</source>
         <translation>Kompatybilność</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="253"/>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="261"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="255"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="263"/>
         <source>Required VCMI version</source>
         <translation>Wymagana wersja VCMI</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="259"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="261"/>
         <source>Supported VCMI version</source>
         <translation>Wspierana wersja VCMI</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="264"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="266"/>
         <source>Supported VCMI versions</source>
         <translation>Wspierane wersje VCMI</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="268"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="270"/>
         <source>Required mods</source>
         <translation>Wymagane mody</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="269"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="271"/>
         <source>Conflicting mods</source>
         <translation>Konfliktujące mody</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="274"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="276"/>
         <source>This mod can not be installed or enabled because following dependencies are not present</source>
         <translation>Ten mod nie może zostać zainstalowany lub włączony ponieważ następujące zależności nie zostały spełnione</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="275"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="277"/>
         <source>This mod can not be enabled because following mods are incompatible with this mod</source>
         <translation>Ten mod nie może zostać włączony ponieważ następujące mody są z nim niekompatybilne</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="276"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="278"/>
         <source>This mod can not be disabled because it is required to run following mods</source>
         <translation>Ten mod nie może zostać wyłączony ponieważ jest wymagany by do uruchomienia następujących modów</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="277"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="279"/>
         <source>This mod can not be uninstalled or updated because it is required to run following mods</source>
         <translation>Ten mod nie może zostać odinstalowany lub zaktualizowany ponieważ jest wymagany do uruchomienia następujących modów</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="278"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="280"/>
         <source>This is submod and it can not be installed or uninstalled separately from parent mod</source>
         <translation>To jest moduł składowy innego moda i nie może być zainstalowany lub odinstalowany oddzielnie od moda nadrzędnego</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="293"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="295"/>
         <source>Notes</source>
         <translation>Uwagi</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="795"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="797"/>
         <source>Screenshot %1</source>
         <translation>Zrzut ekranu %1</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="222"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="224"/>
         <source>Mod is compatible</source>
         <translation>Mod jest kompatybilny</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="223"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="225"/>
         <source>Mod is incompatible</source>
         <translation>Mod jest niekompatybilny</translation>
     </message>
@@ -414,147 +414,125 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="103"/>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="797"/>
-        <source>Finish</source>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="414"/>
+        <source>Your Heroes III language has been succesfully detected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="136"/>
-        <source>Step %v out of %m</source>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="552"/>
+        <source>Optionally, you can install additional mods either now or at any point later:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="168"/>
-        <source>Choose your language</source>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="584"/>
+        <source>Install English translation of Heroes III</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="175"/>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="506"/>
-        <source>Next</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="240"/>
-        <source>Find Heroes III data files</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="271"/>
-        <source>Open help in browser</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="284"/>
-        <source>Search again</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="317"/>
-        <source>If you don&apos;t have installed Heroes III copy, it is possible to use our automatic installation tool &apos;vcmibuilder&apos; to extract data from GoG.com installer. Visit our wiki for detailed instructions.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="333"/>
-        <source>VCMI requires Heroes III data files in one of the locations listed above. Please copy Heroes III data in one of these directories.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="355"/>
-        <source>Heroes III data files</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="368"/>
-        <source>Alternatively, you can select directory with installed Heroes III data and VCMI will copy exisiting data automatically.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="384"/>
-        <source>Copy existing data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="397"/>
-        <source>Your Heroes III data files have been succesfully found.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="427"/>
-        <source>You Heroes III language was succesfully detected automatically.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="437"/>
-        <source>Automatic detection of language failed. Please select language of your Heroes III copy</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="456"/>
-        <source>Heroes III language</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="499"/>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="717"/>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="790"/>
-        <source>Back</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="537"/>
-        <source>Install VCMI Mod Preset</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="565"/>
-        <source>VCMI provides its own version of Horn of the Abyss fan-made addon. If you wish you can install it right now. For more information about mod visit hota website</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="581"/>
-        <source>Localization to English</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="661"/>
-        <source>VCMI provides translations of Heroes III into a different languages. If you wish, you can install translation to English</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="597"/>
-        <source>Install VCMI-compatible version of the &quot;In The Wake of Gods&quot; fan-made addon</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="613"/>
-        <source>Heroes III + HotA</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="629"/>
-        <source>Heroes III + WoG</source>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="616"/>
+        <source>Install support for playing Heroes III in resolutions other than 800x600.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firstLaunch/firstlaunch_moc.ui" line="645"/>
-        <source>VCMI provides support for playing Heroes III in resolutions other than 800x600. If you wish, you can install this support</source>
+        <source>Install compatible version of addon Horn of the Abyss: fan-made Heroes III expansion, ported by VCMI team</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="677"/>
-        <source>HD support</source>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="674"/>
+        <source>Install compatible version of addon &quot;In The Wake of Gods&quot;: fan-made Heroes III expansion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="724"/>
-        <source>Skip</source>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="721"/>
+        <source>Finish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="755"/>
-        <source>Join community / get help</source>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="111"/>
+        <source>Step %v out of %m</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="143"/>
+        <source>Choose your language</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="150"/>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="493"/>
+        <source>Next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="215"/>
+        <source>Find Heroes III data files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="246"/>
+        <source>Open help in browser</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="259"/>
+        <source>Search again</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="304"/>
+        <source>If you don&apos;t have installed Heroes III copy, it is possible to use our automatic installation tool &apos;vcmibuilder&apos; to extract data from GoG.com installer. Visit our wiki for detailed instructions.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="320"/>
+        <source>VCMI requires Heroes III data files in one of the locations listed above. Please copy Heroes III data in one of these directories.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="342"/>
+        <source>Heroes III data files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="355"/>
+        <source>Alternatively, you can select directory with installed Heroes III data and VCMI will copy exisiting data automatically.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="371"/>
+        <source>Copy existing data</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="384"/>
+        <source>Your Heroes III data files have been succesfully found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="424"/>
+        <source>Automatic detection of language failed. Please select language of your Heroes III copy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="443"/>
+        <source>Heroes III language</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="486"/>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="714"/>
+        <source>Back</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="524"/>
+        <source>Install VCMI Mod Preset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.cpp" line="264"/>
+        <source>Auto (%1)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -605,21 +583,26 @@
     </message>
     <message>
         <location filename="../languages.cpp" line="29"/>
-        <source>Ukrainian</source>
+        <source>Spanish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../languages.cpp" line="30"/>
-        <source>Other (East European)</source>
+        <source>Ukrainian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../languages.cpp" line="31"/>
-        <source>Other (Cyrillic Script)</source>
+        <source>Other (East European)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../languages.cpp" line="32"/>
+        <source>Other (Cyrillic Script)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../languages.cpp" line="33"/>
         <source>Other (West European)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -759,17 +742,12 @@
         <translation>Ustawienia</translation>
     </message>
     <message>
-        <location filename="../mainwindow_moc.ui" line="207"/>
-        <source>Setup</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../mainwindow_moc.ui" line="272"/>
+        <location filename="../mainwindow_moc.ui" line="226"/>
         <source>Map Editor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow_moc.ui" line="325"/>
+        <location filename="../mainwindow_moc.ui" line="279"/>
         <source>Start game</source>
         <translation>Uruchom grę</translation>
     </message>

--- a/launcher/translation/polish.ts
+++ b/launcher/translation/polish.ts
@@ -4,101 +4,86 @@
 <context>
     <name>CModListModel</name>
     <message>
-        <location filename="../modManager/cmodlistmodel_moc.cpp" line="150"/>
+        <location filename="../modManager/cmodlistmodel_moc.cpp" line="142"/>
         <source>Name</source>
         <translation>Nazwa</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistmodel_moc.cpp" line="153"/>
+        <location filename="../modManager/cmodlistmodel_moc.cpp" line="145"/>
         <source>Type</source>
         <translation>Typ</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistmodel_moc.cpp" line="154"/>
+        <location filename="../modManager/cmodlistmodel_moc.cpp" line="146"/>
         <source>Version</source>
         <translation>Wersja</translation>
-    </message>
-    <message>
-        <location filename="../modManager/cmodlistmodel_moc.cpp" line="155"/>
-        <source>Size</source>
-        <translation>Rosmiar</translation>
-    </message>
-    <message>
-        <location filename="../modManager/cmodlistmodel_moc.cpp" line="156"/>
-        <source>Author</source>
-        <translation>Autor</translation>
     </message>
 </context>
 <context>
     <name>CModListView</name>
     <message>
-        <location filename="../modManager/cmodlistview_moc.ui" line="61"/>
+        <location filename="../modManager/cmodlistview_moc.ui" line="58"/>
         <source>Filter</source>
         <translation>Filtruj</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.ui" line="84"/>
+        <location filename="../modManager/cmodlistview_moc.ui" line="81"/>
         <source>All mods</source>
         <translation>Wszystkie mody</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.ui" line="89"/>
+        <location filename="../modManager/cmodlistview_moc.ui" line="86"/>
         <source>Downloadable</source>
         <translation>Dostępny do pobrania</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.ui" line="94"/>
+        <location filename="../modManager/cmodlistview_moc.ui" line="91"/>
         <source>Installed</source>
         <translation>Zainstalowany</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.ui" line="99"/>
+        <location filename="../modManager/cmodlistview_moc.ui" line="96"/>
         <source>Updatable</source>
         <translation>Można zaktualizować</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.ui" line="104"/>
+        <location filename="../modManager/cmodlistview_moc.ui" line="101"/>
         <source>Active</source>
         <translation>Aktywny</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.ui" line="109"/>
+        <location filename="../modManager/cmodlistview_moc.ui" line="106"/>
         <source>Inactive</source>
         <translation>Nieaktywny</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.ui" line="123"/>
+        <location filename="../modManager/cmodlistview_moc.ui" line="120"/>
         <source>Download &amp;&amp; refresh repositories</source>
         <translation>Pobierz i odśwież repozytoria</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.ui" line="228"/>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="288"/>
+        <location filename="../modManager/cmodlistview_moc.ui" line="163"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="270"/>
         <source>Description</source>
         <translation>Opis</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.ui" line="273"/>
+        <location filename="../modManager/cmodlistview_moc.ui" line="208"/>
         <source>Changelog</source>
         <translation>Lista zmian</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.ui" line="295"/>
+        <location filename="../modManager/cmodlistview_moc.ui" line="230"/>
         <source>Screenshots</source>
         <translation>Zrzuty ekranu</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.ui" line="368"/>
-        <source>Show details</source>
-        <translation>Pokaż szczegóły</translation>
-    </message>
-    <message>
-        <location filename="../modManager/cmodlistview_moc.ui" line="409"/>
+        <location filename="../modManager/cmodlistview_moc.ui" line="389"/>
         <source>Uninstall</source>
         <translation>Odinstaluj</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.ui" line="434"/>
+        <location filename="../modManager/cmodlistview_moc.ui" line="424"/>
         <source>Enable</source>
         <translation>Włącz</translation>
     </message>
@@ -108,134 +93,134 @@
         <translation>Wyłącz</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.ui" line="484"/>
+        <location filename="../modManager/cmodlistview_moc.ui" line="494"/>
         <source>Update</source>
         <translation>Zaktualizuj</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.ui" line="509"/>
+        <location filename="../modManager/cmodlistview_moc.ui" line="529"/>
         <source>Install</source>
         <translation>Zainstaluj</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.ui" line="563"/>
+        <location filename="../modManager/cmodlistview_moc.ui" line="327"/>
         <source> %p% (%v KB out of %m KB)</source>
         <translation> %p% (%v KB z %m KB)</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.ui" line="576"/>
+        <location filename="../modManager/cmodlistview_moc.ui" line="340"/>
         <source>Abort</source>
         <translation>Przerwij</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="246"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="228"/>
         <source>Mod name</source>
         <translation>Nazwa moda</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="247"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="229"/>
         <source>Installed version</source>
         <translation>Zainstalowana wersja</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="248"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="230"/>
         <source>Latest version</source>
         <translation>Najnowsza wersja</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="251"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="233"/>
         <source>Download size</source>
         <translation>Rozmiar pobierania</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="252"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="234"/>
         <source>Authors</source>
         <translation>Autorzy</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="255"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="237"/>
         <source>License</source>
         <translation>Licencja</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="258"/>
-        <source>Home</source>
-        <translation>Źródło</translation>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="240"/>
+        <source>Contact</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="262"/>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="269"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="244"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="251"/>
         <source>Compatibility</source>
         <translation>Kompatybilność</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="271"/>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="279"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="253"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="261"/>
         <source>Required VCMI version</source>
         <translation>Wymagana wersja VCMI</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="277"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="259"/>
         <source>Supported VCMI version</source>
         <translation>Wspierana wersja VCMI</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="282"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="264"/>
         <source>Supported VCMI versions</source>
         <translation>Wspierane wersje VCMI</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="286"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="268"/>
         <source>Required mods</source>
         <translation>Wymagane mody</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="287"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="269"/>
         <source>Conflicting mods</source>
         <translation>Konfliktujące mody</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="292"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="274"/>
         <source>This mod can not be installed or enabled because following dependencies are not present</source>
         <translation>Ten mod nie może zostać zainstalowany lub włączony ponieważ następujące zależności nie zostały spełnione</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="293"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="275"/>
         <source>This mod can not be enabled because following mods are incompatible with this mod</source>
         <translation>Ten mod nie może zostać włączony ponieważ następujące mody są z nim niekompatybilne</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="294"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="276"/>
         <source>This mod can not be disabled because it is required to run following mods</source>
         <translation>Ten mod nie może zostać wyłączony ponieważ jest wymagany by do uruchomienia następujących modów</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="295"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="277"/>
         <source>This mod can not be uninstalled or updated because it is required to run following mods</source>
         <translation>Ten mod nie może zostać odinstalowany lub zaktualizowany ponieważ jest wymagany do uruchomienia następujących modów</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="296"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="278"/>
         <source>This is submod and it can not be installed or uninstalled separately from parent mod</source>
         <translation>To jest moduł składowy innego moda i nie może być zainstalowany lub odinstalowany oddzielnie od moda nadrzędnego</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="311"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="293"/>
         <source>Notes</source>
         <translation>Uwagi</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="828"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="795"/>
         <source>Screenshot %1</source>
         <translation>Zrzut ekranu %1</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="240"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="222"/>
         <source>Mod is compatible</source>
         <translation>Mod jest kompatybilny</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="241"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="223"/>
         <source>Mod is incompatible</source>
         <translation>Mod jest niekompatybilny</translation>
     </message>
@@ -243,217 +228,334 @@
 <context>
     <name>CSettingsView</name>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="80"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="580"/>
         <source>Change</source>
         <translation>Zmień</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="104"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="205"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="396"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="223"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="356"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="450"/>
         <source>Open</source>
         <translation>Otwórz</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="445"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="507"/>
+        <source>Adventure Map AI</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsView/csettingsview_moc.ui" line="543"/>
         <source>User data directory</source>
         <translation>Katalog danych użytkownika</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="91"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="129"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="312"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="334"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="254"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="296"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="377"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="494"/>
         <source>Off</source>
         <translation>Wyłączony</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="96"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="134"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="317"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="339"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="79"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="396"/>
+        <source>Artificial Intelligence</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsView/csettingsview_moc.ui" line="89"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="278"/>
+        <source>Mod Repositories</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsView/csettingsview_moc.ui" line="158"/>
+        <source>Update now</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsView/csettingsview_moc.ui" line="259"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="301"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="382"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="499"/>
         <source>On</source>
         <translation>Włączony</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="118"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="410"/>
+        <source>Cursor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsView/csettingsview_moc.ui" line="425"/>
+        <source>Default</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsView/csettingsview_moc.ui" line="430"/>
+        <source>Hardware</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsView/csettingsview_moc.ui" line="435"/>
+        <source>Software</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsView/csettingsview_moc.ui" line="443"/>
+        <source>Check on startup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsView/csettingsview_moc.ui" line="457"/>
         <source>Fullscreen</source>
         <translation>Pełny ekran</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="181"/>
-        <source>Repositories</source>
-        <translation>Repozytoria</translation>
-    </message>
-    <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="188"/>
-        <source>Check for updates</source>
-        <translation>Sprawdź czy są aktualizacje</translation>
-    </message>
-    <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="549"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="417"/>
         <source>Neutral AI</source>
         <translation>AI jednostek neutralnych</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="322"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="264"/>
         <source>Real</source>
         <translation>Prawdziwy</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="257"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="69"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="536"/>
         <source>General</source>
         <translation>Ogólne</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="212"/>
-        <source>Player AI</source>
-        <translation>AI graczy</translation>
-    </message>
-    <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="472"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="483"/>
         <source>VCMI Language</source>
         <translation>Język VCMI</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="487"/>
-        <source>Central European (Windows 1250)</source>
-        <translation>Środkowoeuropejski (Windows 1250)</translation>
-    </message>
-    <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="492"/>
-        <source>Cyrillic script (Windows 1251)</source>
-        <translation>Cyrylica (Windows 1251)</translation>
-    </message>
-    <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="497"/>
-        <source>Western European (Windows 1252)</source>
-        <translation>Wschodnioeuropejski (Windows 1252)</translation>
-    </message>
-    <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="502"/>
-        <source>Simplified Chinese (GBK)</source>
-        <translation>Uproszczony chiński (GBK)</translation>
-    </message>
-    <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="507"/>
-        <source>Simplified Chinese (GB2312)</source>
-        <translation>Uproszczony chiński (GB2312)</translation>
-    </message>
-    <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="512"/>
-        <source>Korean (Windows 949)</source>
-        <translation>Koreański (Windows 949)</translation>
-    </message>
-    <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="521"/>
-        <source>English</source>
-        <translation>English (Angielski)</translation>
-    </message>
-    <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="526"/>
-        <source>Deutsch (German)</source>
-        <translation>Deutsch (Niemiecki)</translation>
-    </message>
-    <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="531"/>
-        <source>Polski (Polish)</source>
-        <translation>Polski</translation>
-    </message>
-    <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="536"/>
-        <source>Русский (Russian)</source>
-        <translation>Русский (Rosyjski)</translation>
-    </message>
-    <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="541"/>
-        <source>Українська (Ukrainian)</source>
-        <translation>Українська (Ukraiński)</translation>
-    </message>
-    <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="579"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="557"/>
         <source>Friendly AI</source>
         <translation>AI sojuszników</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="301"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="403"/>
         <source>Resolution</source>
         <translation>Rozdzielczość</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="353"/>
-        <source>AI on the map</source>
-        <translation>AI na mapie przygody</translation>
-    </message>
-    <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="168"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="209"/>
         <source>Autosave</source>
         <translation>Autozapis</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="219"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="285"/>
         <source>Display index</source>
         <translation>Numer wyświetlacza</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="198"/>
-        <source>Check repositories on startup</source>
-        <translation>Sprawdź repozytoria przy starcie</translation>
-    </message>
-    <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="452"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="165"/>
         <source>Network port</source>
         <translation>Port sieciowy</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="422"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="84"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="523"/>
         <source>Data Directories</source>
         <translation>Katalogi z danymi</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="409"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="74"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="315"/>
         <source>Video</source>
         <translation>Obraz</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="111"/>
-        <source>Heroes III character set</source>
-        <translation>Zestaw znaków w grze</translation>
-    </message>
-    <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="294"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="550"/>
         <source>Extra data directory</source>
         <translation>Katalog danych dodatkowych</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="142"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="322"/>
         <source>Log files directory</source>
         <translation>Katalog logów</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="264"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="230"/>
         <source>Show intro</source>
         <translation>Pokaż intro</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="57"/>
-        <source>Launcher Settings</source>
-        <translation>Ustawienia Launchera</translation>
-    </message>
-    <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="287"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="349"/>
         <source>Build version</source>
         <translation>Wersja programu</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="632"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="151"/>
         <source>Enemy AI</source>
         <translation>AI wrogich graczy</translation>
     </message>
+</context>
+<context>
+    <name>FirstLaunchView</name>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="234"/>
-        <source>AI in the battlefield</source>
-        <translation>AI na polu bitwy</translation>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="28"/>
+        <source>Language</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="53"/>
+        <source>Heroes III Data</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="78"/>
+        <source>Mods Preset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="103"/>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="797"/>
+        <source>Finish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="136"/>
+        <source>Step %v out of %m</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="168"/>
+        <source>Choose your language</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="175"/>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="506"/>
+        <source>Next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="240"/>
+        <source>Find Heroes III data files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="271"/>
+        <source>Open help in browser</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="284"/>
+        <source>Search again</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="317"/>
+        <source>If you don&apos;t have installed Heroes III copy, it is possible to use our automatic installation tool &apos;vcmibuilder&apos; to extract data from GoG.com installer. Visit our wiki for detailed instructions.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="333"/>
+        <source>VCMI requires Heroes III data files in one of the locations listed above. Please copy Heroes III data in one of these directories.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="355"/>
+        <source>Heroes III data files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="368"/>
+        <source>Alternatively, you can select directory with installed Heroes III data and VCMI will copy exisiting data automatically.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="384"/>
+        <source>Copy existing data</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="397"/>
+        <source>Your Heroes III data files have been succesfully found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="427"/>
+        <source>You Heroes III language was succesfully detected automatically.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="437"/>
+        <source>Automatic detection of language failed. Please select language of your Heroes III copy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="456"/>
+        <source>Heroes III language</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="499"/>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="717"/>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="790"/>
+        <source>Back</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="537"/>
+        <source>Install VCMI Mod Preset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="565"/>
+        <source>VCMI provides its own version of Horn of the Abyss fan-made addon. If you wish you can install it right now. For more information about mod visit hota website</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="581"/>
+        <source>Localization to English</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="661"/>
+        <source>VCMI provides translations of Heroes III into a different languages. If you wish, you can install translation to English</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="597"/>
+        <source>Install VCMI-compatible version of the &quot;In The Wake of Gods&quot; fan-made addon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="613"/>
+        <source>Heroes III + HotA</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="629"/>
+        <source>Heroes III + WoG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="645"/>
+        <source>VCMI provides support for playing Heroes III in resolutions other than 800x600. If you wish, you can install this support</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="677"/>
+        <source>HD support</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="724"/>
+        <source>Skip</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="755"/>
+        <source>Join community / get help</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -465,66 +567,160 @@
     </message>
 </context>
 <context>
+    <name>Language</name>
+    <message>
+        <location filename="../languages.cpp" line="22"/>
+        <source>Chinese</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../languages.cpp" line="23"/>
+        <source>English</source>
+        <translation type="unfinished">English (Angielski)</translation>
+    </message>
+    <message>
+        <location filename="../languages.cpp" line="24"/>
+        <source>French</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../languages.cpp" line="25"/>
+        <source>German</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../languages.cpp" line="26"/>
+        <source>Korean</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../languages.cpp" line="27"/>
+        <source>Polish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../languages.cpp" line="28"/>
+        <source>Russian</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../languages.cpp" line="29"/>
+        <source>Ukrainian</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../languages.cpp" line="30"/>
+        <source>Other (East European)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../languages.cpp" line="31"/>
+        <source>Other (Cyrillic Script)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../languages.cpp" line="32"/>
+        <source>Other (West European)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Lobby</name>
     <message>
-        <location filename="../lobby/lobby_moc.ui" line="26"/>
+        <location filename="../lobby/lobby_moc.ui" line="39"/>
+        <location filename="../lobby/lobby_moc.cpp" line="401"/>
         <source>Connect</source>
         <translation>Połącz</translation>
     </message>
     <message>
-        <location filename="../lobby/lobby_moc.ui" line="45"/>
+        <location filename="../lobby/lobby_moc.ui" line="26"/>
         <source>Username</source>
         <translation>Nazwa użytkownika</translation>
     </message>
     <message>
-        <location filename="../lobby/lobby_moc.ui" line="69"/>
+        <location filename="../lobby/lobby_moc.ui" line="56"/>
         <source>Server</source>
         <translation>Serwer</translation>
     </message>
     <message>
-        <location filename="../lobby/lobby_moc.ui" line="111"/>
+        <location filename="../lobby/lobby_moc.ui" line="76"/>
+        <source>People in lobby</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../lobby/lobby_moc.ui" line="114"/>
+        <source>Lobby chat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../lobby/lobby_moc.ui" line="194"/>
         <source>Session</source>
         <translation>Sesja</translation>
     </message>
     <message>
-        <location filename="../lobby/lobby_moc.ui" line="116"/>
+        <location filename="../lobby/lobby_moc.ui" line="199"/>
         <source>Players</source>
         <translation>Gracze</translation>
     </message>
     <message>
-        <location filename="../lobby/lobby_moc.ui" line="132"/>
+        <location filename="../lobby/lobby_moc.ui" line="274"/>
+        <source>Resolve</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../lobby/lobby_moc.ui" line="286"/>
+        <source>New game</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../lobby/lobby_moc.ui" line="293"/>
+        <source>Load game</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../lobby/lobby_moc.ui" line="149"/>
         <source>New room</source>
         <translation>Nowy pokój</translation>
     </message>
     <message>
-        <location filename="../lobby/lobby_moc.ui" line="142"/>
+        <location filename="../lobby/lobby_moc.ui" line="159"/>
         <source>Join room</source>
         <translation>Dołącz</translation>
     </message>
     <message>
-        <location filename="../lobby/lobby_moc.ui" line="153"/>
+        <location filename="../lobby/lobby_moc.ui" line="267"/>
         <source>Ready</source>
         <translation>Zgłoś gotowość</translation>
     </message>
     <message>
-        <location filename="../lobby/lobby_moc.ui" line="160"/>
+        <location filename="../lobby/lobby_moc.ui" line="250"/>
         <source>Mods mismatch</source>
         <translation>Niezgodność modów</translation>
     </message>
     <message>
-        <location filename="../lobby/lobby_moc.ui" line="167"/>
+        <location filename="../lobby/lobby_moc.ui" line="243"/>
         <source>Leave</source>
         <translation>Wyjdź</translation>
     </message>
     <message>
-        <location filename="../lobby/lobby_moc.ui" line="197"/>
+        <location filename="../lobby/lobby_moc.ui" line="216"/>
         <source>Kick player</source>
         <translation>Wyrzuć gracza</translation>
     </message>
     <message>
-        <location filename="../lobby/lobby_moc.ui" line="204"/>
+        <location filename="../lobby/lobby_moc.ui" line="236"/>
         <source>Players in the room</source>
         <translation>Gracze w pokoju</translation>
+    </message>
+    <message>
+        <location filename="../lobby/lobby_moc.cpp" line="369"/>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../lobby/lobby_moc.cpp" line="461"/>
+        <source>No issues detected</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -558,33 +754,34 @@
         <translation>VCMI Launcher (program startowy)</translation>
     </message>
     <message>
-        <location filename="../mainwindow_moc.ui" line="95"/>
+        <location filename="../mainwindow_moc.ui" line="107"/>
         <source>Settings</source>
         <translation>Ustawienia</translation>
     </message>
     <message>
-        <location filename="../mainwindow_moc.ui" line="189"/>
+        <location filename="../mainwindow_moc.ui" line="207"/>
+        <source>Setup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow_moc.ui" line="272"/>
         <source>Map Editor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow_moc.ui" line="236"/>
+        <location filename="../mainwindow_moc.ui" line="325"/>
         <source>Start game</source>
         <translation>Uruchom grę</translation>
     </message>
     <message>
-        <location filename="../mainwindow_moc.ui" line="139"/>
+        <location filename="../mainwindow_moc.ui" line="157"/>
         <source>Lobby</source>
         <translation>Lobby</translation>
     </message>
     <message>
-        <location filename="../mainwindow_moc.ui" line="51"/>
+        <location filename="../mainwindow_moc.ui" line="57"/>
         <source>Mods</source>
         <translation>Mody</translation>
-    </message>
-    <message>
-        <source>Editor</source>
-        <translation type="vanished">Edytor</translation>
     </message>
 </context>
 <context>

--- a/launcher/translation/russian.ts
+++ b/launcher/translation/russian.ts
@@ -228,172 +228,207 @@
 <context>
     <name>CSettingsView</name>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="580"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="327"/>
         <source>Change</source>
         <translation>Изменить</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="223"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="356"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="450"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="222"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="287"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="473"/>
         <source>Open</source>
         <translation>Открыть</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="507"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="590"/>
         <source>Adventure Map AI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="543"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="334"/>
         <source>User data directory</source>
         <translation>Данные пользователя</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="254"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="296"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="377"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="494"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="256"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="298"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="440"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="487"/>
         <source>Off</source>
         <translation>Отключено</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="259"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="301"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="382"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="499"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="261"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="303"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="445"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="492"/>
         <source>On</source>
         <translation>Включено</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="443"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="429"/>
         <source>Check on startup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="457"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="158"/>
         <source>Fullscreen</source>
         <translation>Полноэкранный режим</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="417"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="172"/>
         <source>Neutral AI</source>
         <translation>Нейтральный ИИ</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="264"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="266"/>
         <source>Real</source>
         <translation>Полный</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="69"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="536"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="354"/>
         <source>General</source>
         <translation>Общее</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="483"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="144"/>
         <source>VCMI Language</source>
         <translation>Язык VCMI</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="557"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="422"/>
         <source>Friendly AI</source>
         <translation>Дружественный ИИ</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="410"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="215"/>
         <source>Cursor</source>
         <translation>Курсор</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="79"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="396"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="576"/>
         <source>Artificial Intelligence</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="89"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="278"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="415"/>
         <source>Mod Repositories</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="158"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="368"/>
         <source>Update now</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="425"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="500"/>
+        <source>Heroes III Data Language</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsView/csettingsview_moc.ui" line="552"/>
         <source>Default</source>
         <translation>По умолчанию</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="430"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="557"/>
         <source>Hardware</source>
         <translation>Аппаратный</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="435"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="562"/>
         <source>Software</source>
         <translation>Программный</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="403"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="597"/>
+        <source>Heroes III Translation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsView/csettingsview_moc.ui" line="165"/>
         <source>Resolution</source>
         <translation>Разрешение экрана</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="209"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="179"/>
         <source>Autosave</source>
         <translation>Автосохранение</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="285"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="375"/>
         <source>Display index</source>
         <translation>Дисплей</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="165"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="151"/>
         <source>Network port</source>
         <translation>Сетевой порт</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="84"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="523"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="317"/>
         <source>Data Directories</source>
         <translation>Директории данных</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="74"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="315"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="192"/>
         <source>Video</source>
         <translation>Графика</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="550"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="466"/>
         <source>Extra data directory</source>
         <translation>Дополнительные данные</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="322"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="583"/>
         <source>Log files directory</source>
         <translation>Журналы</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="230"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="361"/>
         <source>Show intro</source>
         <translation>Вступление</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="349"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="341"/>
         <source>Build version</source>
         <translation>Версия сборки</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="151"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="534"/>
         <source>Enemy AI</source>
         <translation>Вражеский ИИ</translation>
+    </message>
+    <message>
+        <location filename="../settingsView/csettingsview_moc.cpp" line="385"/>
+        <source>Active</source>
+        <translation type="unfinished">Активны</translation>
+    </message>
+    <message>
+        <location filename="../settingsView/csettingsview_moc.cpp" line="390"/>
+        <source>Disabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsView/csettingsview_moc.cpp" line="391"/>
+        <source>Enable</source>
+        <translation type="unfinished">Включить</translation>
+    </message>
+    <message>
+        <location filename="../settingsView/csettingsview_moc.cpp" line="396"/>
+        <source>Not Installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsView/csettingsview_moc.cpp" line="397"/>
+        <source>Install</source>
+        <translation type="unfinished">Установить</translation>
     </message>
 </context>
 <context>
@@ -414,18 +449,13 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="414"/>
-        <source>Your Heroes III language has been succesfully detected.</source>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="384"/>
+        <source>Your Heroes III data files have been successfully found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firstLaunch/firstlaunch_moc.ui" line="552"/>
         <source>Optionally, you can install additional mods either now or at any point later:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="584"/>
-        <source>Install English translation of Heroes III</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -505,8 +535,8 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="384"/>
-        <source>Your Heroes III data files have been succesfully found.</source>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="414"/>
+        <source>Your Heroes III language has been successfully detected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -531,8 +561,8 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firstLaunch/firstlaunch_moc.cpp" line="264"/>
-        <source>Auto (%1)</source>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="584"/>
+        <source>Install translation of Heroes III to your language</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -547,63 +577,68 @@
 <context>
     <name>Language</name>
     <message>
-        <location filename="../languages.cpp" line="22"/>
+        <location filename="../languages.cpp" line="23"/>
         <source>Chinese</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../languages.cpp" line="23"/>
+        <location filename="../languages.cpp" line="24"/>
         <source>English</source>
         <translation type="unfinished">English (Английский)</translation>
     </message>
     <message>
-        <location filename="../languages.cpp" line="24"/>
+        <location filename="../languages.cpp" line="25"/>
         <source>French</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../languages.cpp" line="25"/>
+        <location filename="../languages.cpp" line="26"/>
         <source>German</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../languages.cpp" line="26"/>
+        <location filename="../languages.cpp" line="27"/>
         <source>Korean</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../languages.cpp" line="27"/>
+        <location filename="../languages.cpp" line="28"/>
         <source>Polish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../languages.cpp" line="28"/>
+        <location filename="../languages.cpp" line="29"/>
         <source>Russian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../languages.cpp" line="29"/>
+        <location filename="../languages.cpp" line="30"/>
         <source>Spanish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../languages.cpp" line="30"/>
+        <location filename="../languages.cpp" line="31"/>
         <source>Ukrainian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../languages.cpp" line="31"/>
+        <location filename="../languages.cpp" line="32"/>
         <source>Other (East European)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../languages.cpp" line="32"/>
+        <location filename="../languages.cpp" line="33"/>
         <source>Other (Cyrillic Script)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../languages.cpp" line="33"/>
+        <location filename="../languages.cpp" line="34"/>
         <source>Other (West European)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../languages.cpp" line="56"/>
+        <source>Auto (%1)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/launcher/translation/russian.ts
+++ b/launcher/translation/russian.ts
@@ -63,7 +63,7 @@
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.ui" line="163"/>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="270"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="272"/>
         <source>Description</source>
         <translation>Описание</translation>
     </message>
@@ -113,114 +113,114 @@
         <translation>Отмена</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="228"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="230"/>
         <source>Mod name</source>
         <translation>Название мода</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="229"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="231"/>
         <source>Installed version</source>
         <translation>Установленная версия</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="230"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="232"/>
         <source>Latest version</source>
         <translation>Последняя версия</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="233"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="235"/>
         <source>Download size</source>
         <translation>Размер загрузки</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="234"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="236"/>
         <source>Authors</source>
         <translation>Авторы</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="237"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="239"/>
         <source>License</source>
         <translation>Лицензия</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="240"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="242"/>
         <source>Contact</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="244"/>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="251"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="246"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="253"/>
         <source>Compatibility</source>
         <translation>Совместимость</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="253"/>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="261"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="255"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="263"/>
         <source>Required VCMI version</source>
         <translation>Требуемая версия VCMI</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="259"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="261"/>
         <source>Supported VCMI version</source>
         <translation>Поддерживаемая версия VCMI</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="264"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="266"/>
         <source>Supported VCMI versions</source>
         <translation>Поддерживаемые версии VCMI</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="268"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="270"/>
         <source>Required mods</source>
         <translation>Зависимости</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="269"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="271"/>
         <source>Conflicting mods</source>
         <translation>Конфликтующие моды</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="274"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="276"/>
         <source>This mod can not be installed or enabled because following dependencies are not present</source>
         <translation>Этот мод не может быть установлен или активирован, так как отсутствуют следующие зависимости</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="275"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="277"/>
         <source>This mod can not be enabled because following mods are incompatible with this mod</source>
         <translation>Этот мод не может быть установлен или активирован, так как следующие моды несовместимы с этим</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="276"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="278"/>
         <source>This mod can not be disabled because it is required to run following mods</source>
         <translation>Этот мод не может быть выключен, так как он является зависимостью для следующих</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="277"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="279"/>
         <source>This mod can not be uninstalled or updated because it is required to run following mods</source>
         <translation>Этот мод не может быть удален или обновлен, так как является зависимостью для следующих модов</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="278"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="280"/>
         <source>This is submod and it can not be installed or uninstalled separately from parent mod</source>
         <translation>Это вложенный мод, он не может быть установлен или удален отдельно от родительского</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="293"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="295"/>
         <source>Notes</source>
         <translation>Замечания</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="795"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="797"/>
         <source>Screenshot %1</source>
         <translation>Скриншот %1</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="222"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="224"/>
         <source>Mod is compatible</source>
         <translation>Мод совместим</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="223"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="225"/>
         <source>Mod is incompatible</source>
         <translation>Мод несовместим</translation>
     </message>
@@ -414,147 +414,125 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="103"/>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="797"/>
-        <source>Finish</source>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="414"/>
+        <source>Your Heroes III language has been succesfully detected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="136"/>
-        <source>Step %v out of %m</source>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="552"/>
+        <source>Optionally, you can install additional mods either now or at any point later:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="168"/>
-        <source>Choose your language</source>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="584"/>
+        <source>Install English translation of Heroes III</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="175"/>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="506"/>
-        <source>Next</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="240"/>
-        <source>Find Heroes III data files</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="271"/>
-        <source>Open help in browser</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="284"/>
-        <source>Search again</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="317"/>
-        <source>If you don&apos;t have installed Heroes III copy, it is possible to use our automatic installation tool &apos;vcmibuilder&apos; to extract data from GoG.com installer. Visit our wiki for detailed instructions.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="333"/>
-        <source>VCMI requires Heroes III data files in one of the locations listed above. Please copy Heroes III data in one of these directories.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="355"/>
-        <source>Heroes III data files</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="368"/>
-        <source>Alternatively, you can select directory with installed Heroes III data and VCMI will copy exisiting data automatically.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="384"/>
-        <source>Copy existing data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="397"/>
-        <source>Your Heroes III data files have been succesfully found.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="427"/>
-        <source>You Heroes III language was succesfully detected automatically.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="437"/>
-        <source>Automatic detection of language failed. Please select language of your Heroes III copy</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="456"/>
-        <source>Heroes III language</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="499"/>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="717"/>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="790"/>
-        <source>Back</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="537"/>
-        <source>Install VCMI Mod Preset</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="565"/>
-        <source>VCMI provides its own version of Horn of the Abyss fan-made addon. If you wish you can install it right now. For more information about mod visit hota website</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="581"/>
-        <source>Localization to English</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="661"/>
-        <source>VCMI provides translations of Heroes III into a different languages. If you wish, you can install translation to English</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="597"/>
-        <source>Install VCMI-compatible version of the &quot;In The Wake of Gods&quot; fan-made addon</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="613"/>
-        <source>Heroes III + HotA</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="629"/>
-        <source>Heroes III + WoG</source>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="616"/>
+        <source>Install support for playing Heroes III in resolutions other than 800x600.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firstLaunch/firstlaunch_moc.ui" line="645"/>
-        <source>VCMI provides support for playing Heroes III in resolutions other than 800x600. If you wish, you can install this support</source>
+        <source>Install compatible version of addon Horn of the Abyss: fan-made Heroes III expansion, ported by VCMI team</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="677"/>
-        <source>HD support</source>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="674"/>
+        <source>Install compatible version of addon &quot;In The Wake of Gods&quot;: fan-made Heroes III expansion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="724"/>
-        <source>Skip</source>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="721"/>
+        <source>Finish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="755"/>
-        <source>Join community / get help</source>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="111"/>
+        <source>Step %v out of %m</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="143"/>
+        <source>Choose your language</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="150"/>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="493"/>
+        <source>Next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="215"/>
+        <source>Find Heroes III data files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="246"/>
+        <source>Open help in browser</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="259"/>
+        <source>Search again</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="304"/>
+        <source>If you don&apos;t have installed Heroes III copy, it is possible to use our automatic installation tool &apos;vcmibuilder&apos; to extract data from GoG.com installer. Visit our wiki for detailed instructions.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="320"/>
+        <source>VCMI requires Heroes III data files in one of the locations listed above. Please copy Heroes III data in one of these directories.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="342"/>
+        <source>Heroes III data files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="355"/>
+        <source>Alternatively, you can select directory with installed Heroes III data and VCMI will copy exisiting data automatically.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="371"/>
+        <source>Copy existing data</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="384"/>
+        <source>Your Heroes III data files have been succesfully found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="424"/>
+        <source>Automatic detection of language failed. Please select language of your Heroes III copy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="443"/>
+        <source>Heroes III language</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="486"/>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="714"/>
+        <source>Back</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="524"/>
+        <source>Install VCMI Mod Preset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.cpp" line="264"/>
+        <source>Auto (%1)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -605,21 +583,26 @@
     </message>
     <message>
         <location filename="../languages.cpp" line="29"/>
-        <source>Ukrainian</source>
+        <source>Spanish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../languages.cpp" line="30"/>
-        <source>Other (East European)</source>
+        <source>Ukrainian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../languages.cpp" line="31"/>
-        <source>Other (Cyrillic Script)</source>
+        <source>Other (East European)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../languages.cpp" line="32"/>
+        <source>Other (Cyrillic Script)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../languages.cpp" line="33"/>
         <source>Other (West European)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -759,17 +742,12 @@
         <translation>Параметры</translation>
     </message>
     <message>
-        <location filename="../mainwindow_moc.ui" line="207"/>
-        <source>Setup</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../mainwindow_moc.ui" line="272"/>
+        <location filename="../mainwindow_moc.ui" line="226"/>
         <source>Map Editor</source>
         <translation>Редактор карт</translation>
     </message>
     <message>
-        <location filename="../mainwindow_moc.ui" line="325"/>
+        <location filename="../mainwindow_moc.ui" line="279"/>
         <source>Start game</source>
         <translation>Играть</translation>
     </message>

--- a/launcher/translation/russian.ts
+++ b/launcher/translation/russian.ts
@@ -4,257 +4,223 @@
 <context>
     <name>CModListModel</name>
     <message>
-        <location filename="../modManager/cmodlistmodel_moc.cpp" line="150"/>
+        <location filename="../modManager/cmodlistmodel_moc.cpp" line="142"/>
         <source>Name</source>
         <translation>Название</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistmodel_moc.cpp" line="153"/>
+        <location filename="../modManager/cmodlistmodel_moc.cpp" line="145"/>
         <source>Type</source>
         <translation>Тип</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistmodel_moc.cpp" line="154"/>
+        <location filename="../modManager/cmodlistmodel_moc.cpp" line="146"/>
         <source>Version</source>
         <translation>Версия</translation>
-    </message>
-    <message>
-        <location filename="../modManager/cmodlistmodel_moc.cpp" line="155"/>
-        <source>Size</source>
-        <translation>Размер</translation>
-    </message>
-    <message>
-        <location filename="../modManager/cmodlistmodel_moc.cpp" line="156"/>
-        <source>Author</source>
-        <translation>Автор</translation>
     </message>
 </context>
 <context>
     <name>CModListView</name>
     <message>
-        <location filename="../modManager/cmodlistview_moc.ui" line="61"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_cmodlistview_moc.h" line="333"/>
+        <location filename="../modManager/cmodlistview_moc.ui" line="58"/>
         <source>Filter</source>
         <translation>Фильтр</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.ui" line="84"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_cmodlistview_moc.h" line="334"/>
+        <location filename="../modManager/cmodlistview_moc.ui" line="81"/>
         <source>All mods</source>
         <translation>Все моды</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.ui" line="89"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_cmodlistview_moc.h" line="335"/>
+        <location filename="../modManager/cmodlistview_moc.ui" line="86"/>
         <source>Downloadable</source>
         <translation>Доступные</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.ui" line="94"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_cmodlistview_moc.h" line="336"/>
+        <location filename="../modManager/cmodlistview_moc.ui" line="91"/>
         <source>Installed</source>
         <translation>Установленные</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.ui" line="99"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_cmodlistview_moc.h" line="337"/>
+        <location filename="../modManager/cmodlistview_moc.ui" line="96"/>
         <source>Updatable</source>
         <translation>Обновления</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.ui" line="104"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_cmodlistview_moc.h" line="338"/>
+        <location filename="../modManager/cmodlistview_moc.ui" line="101"/>
         <source>Active</source>
         <translation>Активны</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.ui" line="109"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_cmodlistview_moc.h" line="339"/>
+        <location filename="../modManager/cmodlistview_moc.ui" line="106"/>
         <source>Inactive</source>
         <translation>Неактивны</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.ui" line="123"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_cmodlistview_moc.h" line="341"/>
+        <location filename="../modManager/cmodlistview_moc.ui" line="120"/>
         <source>Download &amp;&amp; refresh repositories</source>
         <translation>Обновить репозиторий</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.ui" line="228"/>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="288"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_cmodlistview_moc.h" line="343"/>
+        <location filename="../modManager/cmodlistview_moc.ui" line="163"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="270"/>
         <source>Description</source>
         <translation>Описание</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.ui" line="273"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_cmodlistview_moc.h" line="344"/>
+        <location filename="../modManager/cmodlistview_moc.ui" line="208"/>
         <source>Changelog</source>
         <translation>Изменения</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.ui" line="295"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_cmodlistview_moc.h" line="345"/>
+        <location filename="../modManager/cmodlistview_moc.ui" line="230"/>
         <source>Screenshots</source>
         <translation>Скриншоты</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.ui" line="368"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_cmodlistview_moc.h" line="346"/>
-        <source>Show details</source>
-        <translation>Подробности</translation>
-    </message>
-    <message>
-        <location filename="../modManager/cmodlistview_moc.ui" line="409"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_cmodlistview_moc.h" line="347"/>
+        <location filename="../modManager/cmodlistview_moc.ui" line="389"/>
         <source>Uninstall</source>
         <translation>Удалить</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.ui" line="434"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_cmodlistview_moc.h" line="348"/>
+        <location filename="../modManager/cmodlistview_moc.ui" line="424"/>
         <source>Enable</source>
         <translation>Включить</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.ui" line="459"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_cmodlistview_moc.h" line="349"/>
         <source>Disable</source>
         <translation>Отключить</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.ui" line="484"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_cmodlistview_moc.h" line="350"/>
+        <location filename="../modManager/cmodlistview_moc.ui" line="494"/>
         <source>Update</source>
         <translation>Обновить</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.ui" line="509"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_cmodlistview_moc.h" line="351"/>
+        <location filename="../modManager/cmodlistview_moc.ui" line="529"/>
         <source>Install</source>
         <translation>Установить</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.ui" line="563"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_cmodlistview_moc.h" line="352"/>
+        <location filename="../modManager/cmodlistview_moc.ui" line="327"/>
         <source> %p% (%v KB out of %m KB)</source>
         <translation> %p% (%v КБ з %m КБ)</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.ui" line="576"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_cmodlistview_moc.h" line="353"/>
+        <location filename="../modManager/cmodlistview_moc.ui" line="340"/>
         <source>Abort</source>
         <translation>Отмена</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="246"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="228"/>
         <source>Mod name</source>
         <translation>Название мода</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="247"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="229"/>
         <source>Installed version</source>
         <translation>Установленная версия</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="248"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="230"/>
         <source>Latest version</source>
         <translation>Последняя версия</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="251"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="233"/>
         <source>Download size</source>
         <translation>Размер загрузки</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="252"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="234"/>
         <source>Authors</source>
         <translation>Авторы</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="255"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="237"/>
         <source>License</source>
         <translation>Лицензия</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="258"/>
-        <source>Home</source>
-        <translation>Домашняя страница</translation>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="240"/>
+        <source>Contact</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="262"/>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="269"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="244"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="251"/>
         <source>Compatibility</source>
         <translation>Совместимость</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="271"/>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="279"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="253"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="261"/>
         <source>Required VCMI version</source>
         <translation>Требуемая версия VCMI</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="277"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="259"/>
         <source>Supported VCMI version</source>
         <translation>Поддерживаемая версия VCMI</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="282"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="264"/>
         <source>Supported VCMI versions</source>
         <translation>Поддерживаемые версии VCMI</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="286"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="268"/>
         <source>Required mods</source>
         <translation>Зависимости</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="287"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="269"/>
         <source>Conflicting mods</source>
         <translation>Конфликтующие моды</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="292"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="274"/>
         <source>This mod can not be installed or enabled because following dependencies are not present</source>
         <translation>Этот мод не может быть установлен или активирован, так как отсутствуют следующие зависимости</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="293"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="275"/>
         <source>This mod can not be enabled because following mods are incompatible with this mod</source>
         <translation>Этот мод не может быть установлен или активирован, так как следующие моды несовместимы с этим</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="294"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="276"/>
         <source>This mod can not be disabled because it is required to run following mods</source>
         <translation>Этот мод не может быть выключен, так как он является зависимостью для следующих</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="295"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="277"/>
         <source>This mod can not be uninstalled or updated because it is required to run following mods</source>
         <translation>Этот мод не может быть удален или обновлен, так как является зависимостью для следующих модов</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="296"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="278"/>
         <source>This is submod and it can not be installed or uninstalled separately from parent mod</source>
         <translation>Это вложенный мод, он не может быть установлен или удален отдельно от родительского</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="311"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="293"/>
         <source>Notes</source>
         <translation>Замечания</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="846"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="795"/>
         <source>Screenshot %1</source>
         <translation>Скриншот %1</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="240"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="222"/>
         <source>Mod is compatible</source>
         <translation>Мод совместим</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="241"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="223"/>
         <source>Mod is incompatible</source>
         <translation>Мод несовместим</translation>
     </message>
@@ -262,305 +228,400 @@
 <context>
     <name>CSettingsView</name>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="80"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="434"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="580"/>
         <source>Change</source>
         <translation>Изменить</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="104"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="205"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="396"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="438"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="449"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="467"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="223"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="356"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="450"/>
         <source>Open</source>
         <translation>Открыть</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="445"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="470"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="507"/>
+        <source>Adventure Map AI</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsView/csettingsview_moc.ui" line="543"/>
         <source>User data directory</source>
         <translation>Данные пользователя</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="91"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="129"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="312"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="334"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="435"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="441"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="458"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="462"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="254"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="296"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="377"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="494"/>
         <source>Off</source>
         <translation>Отключено</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="96"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="134"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="317"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="339"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="436"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="442"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="459"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="463"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="259"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="301"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="382"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="499"/>
         <source>On</source>
         <translation>Включено</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="118"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="440"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="443"/>
+        <source>Check on startup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsView/csettingsview_moc.ui" line="457"/>
         <source>Fullscreen</source>
         <translation>Полноэкранный режим</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="181"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="446"/>
-        <source>Repositories</source>
-        <translation>Репозитории</translation>
-    </message>
-    <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="188"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="447"/>
-        <source>Check for updates</source>
-        <translation>Проверить обновления</translation>
-    </message>
-    <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="554"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="487"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="417"/>
         <source>Neutral AI</source>
         <translation>Нейтральный ИИ</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="322"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="460"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="264"/>
         <source>Real</source>
         <translation>Полный</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="257"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="453"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="69"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="536"/>
         <source>General</source>
         <translation>Общее</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="212"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="450"/>
-        <source>Player AI</source>
-        <translation>ИИ игроков</translation>
-    </message>
-    <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="472"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="472"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="483"/>
         <source>VCMI Language</source>
         <translation>Язык VCMI</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="487"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="473"/>
-        <source>Automatic detection</source>
-        <translation>Автоматическое определение</translation>
-    </message>
-    <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="492"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="474"/>
-        <source>Central European (Windows 1250)</source>
-        <translation>Центральноевропейская (Windows-1250)</translation>
-    </message>
-    <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="497"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="475"/>
-        <source>Cyrillic script (Windows 1251)</source>
-        <translation>Кириллица (Windows 1251)</translation>
-    </message>
-    <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="502"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="476"/>
-        <source>Western European (Windows 1252)</source>
-        <translation>Западноевропейская (Windows 1252)</translation>
-    </message>
-    <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="507"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="477"/>
-        <source>Simplified Chinese (GBK)</source>
-        <translation>Упрощенная китайская (GBK)</translation>
-    </message>
-    <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="512"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="478"/>
-        <source>Simplified Chinese (GB2312)</source>
-        <translation>Упрощенная китайская (GB2312)</translation>
-    </message>
-    <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="517"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="479"/>
-        <source>Korean (Windows 949)</source>
-        <translation>Корейская (Windows 949)</translation>
-    </message>
-    <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="526"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="481"/>
-        <source>English</source>
-        <translation>English (Английский)</translation>
-    </message>
-    <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="531"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="482"/>
-        <source>Deutsch (German)</source>
-        <translation>Deutsch (Немецкий)</translation>
-    </message>
-    <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="536"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="483"/>
-        <source>Polska (Polish)</source>
-        <translation>Polska (Польский)</translation>
-    </message>
-    <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="541"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="484"/>
-        <source>Русский (Russian)</source>
-        <translation>Русский</translation>
-    </message>
-    <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="546"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="485"/>
-        <source>Українська (Ukrainian)</source>
-        <translation>Українська (Украинский)</translation>
-    </message>
-    <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="584"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="489"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="557"/>
         <source>Friendly AI</source>
         <translation>Дружественный ИИ</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="644"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="493"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="410"/>
         <source>Cursor</source>
         <translation>Курсор</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="652"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="494"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="79"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="396"/>
+        <source>Artificial Intelligence</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsView/csettingsview_moc.ui" line="89"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="278"/>
+        <source>Mod Repositories</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsView/csettingsview_moc.ui" line="158"/>
+        <source>Update now</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settingsView/csettingsview_moc.ui" line="425"/>
         <source>Default</source>
         <translation>По умолчанию</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="657"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="495"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="430"/>
         <source>Hardware</source>
         <translation>Аппаратный</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="662"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="496"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="435"/>
         <source>Software</source>
         <translation>Программный</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="301"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="457"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="403"/>
         <source>Resolution</source>
         <translation>Разрешение экрана</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="353"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="465"/>
-        <source>AI on the map</source>
-        <translation>ИИ на карте приключений</translation>
-    </message>
-    <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="168"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="445"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="209"/>
         <source>Autosave</source>
         <translation>Автосохранение</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="219"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="451"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="285"/>
         <source>Display index</source>
         <translation>Дисплей</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="198"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="448"/>
-        <source>Check repositories on startup</source>
-        <translation>Проверка репозиториев при запуске</translation>
-    </message>
-    <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="452"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="471"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="165"/>
         <source>Network port</source>
         <translation>Сетевой порт</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="422"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="469"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="84"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="523"/>
         <source>Data Directories</source>
         <translation>Директории данных</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="409"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="468"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="74"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="315"/>
         <source>Video</source>
         <translation>Графика</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="111"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="439"/>
-        <source>Heroes III character set</source>
-        <translation>Кодировка Героев III</translation>
-    </message>
-    <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="294"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="456"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="550"/>
         <source>Extra data directory</source>
         <translation>Дополнительные данные</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="142"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="444"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="322"/>
         <source>Log files directory</source>
         <translation>Журналы</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="264"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="454"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="230"/>
         <source>Show intro</source>
         <translation>Вступление</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="57"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="433"/>
-        <source>Launcher Settings</source>
-        <translation>Настройки загрузчика</translation>
-    </message>
-    <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="287"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="455"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="349"/>
         <source>Build version</source>
         <translation>Версия сборки</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="637"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="492"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="151"/>
         <source>Enemy AI</source>
         <translation>Вражеский ИИ</translation>
     </message>
+</context>
+<context>
+    <name>FirstLaunchView</name>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="234"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="452"/>
-        <source>AI in the battlefield</source>
-        <translation>ИИ на поле боя</translation>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="28"/>
+        <source>Language</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="53"/>
+        <source>Heroes III Data</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="78"/>
+        <source>Mods Preset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="103"/>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="797"/>
+        <source>Finish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="136"/>
+        <source>Step %v out of %m</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="168"/>
+        <source>Choose your language</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="175"/>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="506"/>
+        <source>Next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="240"/>
+        <source>Find Heroes III data files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="271"/>
+        <source>Open help in browser</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="284"/>
+        <source>Search again</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="317"/>
+        <source>If you don&apos;t have installed Heroes III copy, it is possible to use our automatic installation tool &apos;vcmibuilder&apos; to extract data from GoG.com installer. Visit our wiki for detailed instructions.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="333"/>
+        <source>VCMI requires Heroes III data files in one of the locations listed above. Please copy Heroes III data in one of these directories.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="355"/>
+        <source>Heroes III data files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="368"/>
+        <source>Alternatively, you can select directory with installed Heroes III data and VCMI will copy exisiting data automatically.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="384"/>
+        <source>Copy existing data</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="397"/>
+        <source>Your Heroes III data files have been succesfully found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="427"/>
+        <source>You Heroes III language was succesfully detected automatically.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="437"/>
+        <source>Automatic detection of language failed. Please select language of your Heroes III copy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="456"/>
+        <source>Heroes III language</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="499"/>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="717"/>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="790"/>
+        <source>Back</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="537"/>
+        <source>Install VCMI Mod Preset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="565"/>
+        <source>VCMI provides its own version of Horn of the Abyss fan-made addon. If you wish you can install it right now. For more information about mod visit hota website</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="581"/>
+        <source>Localization to English</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="661"/>
+        <source>VCMI provides translations of Heroes III into a different languages. If you wish, you can install translation to English</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="597"/>
+        <source>Install VCMI-compatible version of the &quot;In The Wake of Gods&quot; fan-made addon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="613"/>
+        <source>Heroes III + HotA</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="629"/>
+        <source>Heroes III + WoG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="645"/>
+        <source>VCMI provides support for playing Heroes III in resolutions other than 800x600. If you wish, you can install this support</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="677"/>
+        <source>HD support</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="724"/>
+        <source>Skip</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="755"/>
+        <source>Join community / get help</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ImageViewer</name>
     <message>
         <location filename="../modManager/imageviewer_moc.ui" line="20"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_imageviewer_moc.h" line="59"/>
         <source>Image Viewer</source>
         <translation>Просмотр изображений</translation>
+    </message>
+</context>
+<context>
+    <name>Language</name>
+    <message>
+        <location filename="../languages.cpp" line="22"/>
+        <source>Chinese</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../languages.cpp" line="23"/>
+        <source>English</source>
+        <translation type="unfinished">English (Английский)</translation>
+    </message>
+    <message>
+        <location filename="../languages.cpp" line="24"/>
+        <source>French</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../languages.cpp" line="25"/>
+        <source>German</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../languages.cpp" line="26"/>
+        <source>Korean</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../languages.cpp" line="27"/>
+        <source>Polish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../languages.cpp" line="28"/>
+        <source>Russian</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../languages.cpp" line="29"/>
+        <source>Ukrainian</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../languages.cpp" line="30"/>
+        <source>Other (East European)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../languages.cpp" line="31"/>
+        <source>Other (Cyrillic Script)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../languages.cpp" line="32"/>
+        <source>Other (West European)</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -568,103 +629,86 @@
     <message>
         <location filename="../lobby/lobby_moc.ui" line="39"/>
         <location filename="../lobby/lobby_moc.cpp" line="401"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_lobby_moc.h" line="284"/>
         <source>Connect</source>
         <translation>Подключиться</translation>
     </message>
     <message>
         <location filename="../lobby/lobby_moc.ui" line="26"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_lobby_moc.h" line="283"/>
         <source>Username</source>
         <translation>Имя пользователя</translation>
     </message>
     <message>
         <location filename="../lobby/lobby_moc.ui" line="56"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_lobby_moc.h" line="285"/>
         <source>Server</source>
         <translation>Сервер</translation>
     </message>
     <message>
         <location filename="../lobby/lobby_moc.ui" line="76"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_lobby_moc.h" line="286"/>
         <source>People in lobby</source>
         <translation>Люди в лобби</translation>
     </message>
     <message>
         <location filename="../lobby/lobby_moc.ui" line="114"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_lobby_moc.h" line="287"/>
         <source>Lobby chat</source>
         <translation>Чат лобби</translation>
     </message>
     <message>
         <location filename="../lobby/lobby_moc.ui" line="194"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_lobby_moc.h" line="291"/>
         <source>Session</source>
         <translation>Сессия</translation>
     </message>
     <message>
         <location filename="../lobby/lobby_moc.ui" line="199"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_lobby_moc.h" line="293"/>
         <source>Players</source>
         <translation>Игроки</translation>
     </message>
     <message>
         <location filename="../lobby/lobby_moc.ui" line="274"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_lobby_moc.h" line="299"/>
         <source>Resolve</source>
         <translation>Скорректировать</translation>
     </message>
     <message>
         <location filename="../lobby/lobby_moc.ui" line="286"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_lobby_moc.h" line="300"/>
         <source>New game</source>
         <translation>Новая игра</translation>
     </message>
     <message>
         <location filename="../lobby/lobby_moc.ui" line="293"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_lobby_moc.h" line="301"/>
         <source>Load game</source>
         <translation>Загрузить игру</translation>
     </message>
     <message>
         <location filename="../lobby/lobby_moc.ui" line="149"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_lobby_moc.h" line="288"/>
         <source>New room</source>
         <translation>Создать комнату</translation>
     </message>
     <message>
         <location filename="../lobby/lobby_moc.ui" line="159"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_lobby_moc.h" line="289"/>
         <source>Join room</source>
         <translation>Присоединиться к комнате</translation>
     </message>
     <message>
         <location filename="../lobby/lobby_moc.ui" line="267"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_lobby_moc.h" line="298"/>
         <source>Ready</source>
         <translation>Готово</translation>
     </message>
     <message>
         <location filename="../lobby/lobby_moc.ui" line="250"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_lobby_moc.h" line="297"/>
         <source>Mods mismatch</source>
         <translation>Моды не совпадают</translation>
     </message>
     <message>
         <location filename="../lobby/lobby_moc.ui" line="243"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_lobby_moc.h" line="296"/>
         <source>Leave</source>
         <translation>Выйти</translation>
     </message>
     <message>
         <location filename="../lobby/lobby_moc.ui" line="216"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_lobby_moc.h" line="294"/>
         <source>Kick player</source>
         <translation>Выгнать игрока</translation>
     </message>
     <message>
         <location filename="../lobby/lobby_moc.ui" line="236"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_lobby_moc.h" line="295"/>
         <source>Players in the room</source>
         <translation>Игроки в комнате</translation>
     </message>
@@ -683,25 +727,21 @@
     <name>LobbyRoomRequest</name>
     <message>
         <location filename="../lobby/lobbyroomrequest_moc.ui" line="17"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_lobbyroomrequest_moc.h" line="108"/>
         <source>Room settings</source>
         <translation>Настройки комнаты</translation>
     </message>
     <message>
         <location filename="../lobby/lobbyroomrequest_moc.ui" line="32"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_lobbyroomrequest_moc.h" line="109"/>
         <source>Room name</source>
         <translation>Название</translation>
     </message>
     <message>
         <location filename="../lobby/lobbyroomrequest_moc.ui" line="42"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_lobbyroomrequest_moc.h" line="110"/>
         <source>Maximum players</source>
         <translation>Максимум игроков</translation>
     </message>
     <message>
         <location filename="../lobby/lobbyroomrequest_moc.ui" line="97"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_lobbyroomrequest_moc.h" line="112"/>
         <source>Password (optional)</source>
         <translation>Пароль (не обязательно)</translation>
     </message>
@@ -710,37 +750,36 @@
     <name>MainWindow</name>
     <message>
         <location filename="../mainwindow_moc.ui" line="20"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_mainwindow_moc.h" line="203"/>
         <source>VCMI Launcher</source>
         <translation>Запуск VCMI</translation>
     </message>
     <message>
         <location filename="../mainwindow_moc.ui" line="107"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_mainwindow_moc.h" line="205"/>
         <source>Settings</source>
         <translation>Параметры</translation>
     </message>
     <message>
-        <location filename="../mainwindow_moc.ui" line="226"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_mainwindow_moc.h" line="207"/>
+        <location filename="../mainwindow_moc.ui" line="207"/>
+        <source>Setup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow_moc.ui" line="272"/>
         <source>Map Editor</source>
         <translation>Редактор карт</translation>
     </message>
     <message>
-        <location filename="../mainwindow_moc.ui" line="279"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_mainwindow_moc.h" line="208"/>
+        <location filename="../mainwindow_moc.ui" line="325"/>
         <source>Start game</source>
         <translation>Играть</translation>
     </message>
     <message>
         <location filename="../mainwindow_moc.ui" line="157"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_mainwindow_moc.h" line="206"/>
         <source>Lobby</source>
         <translation>Лобби</translation>
     </message>
     <message>
         <location filename="../mainwindow_moc.ui" line="57"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_mainwindow_moc.h" line="204"/>
         <source>Mods</source>
         <translation>Моды</translation>
     </message>
@@ -749,19 +788,16 @@
     <name>UpdateDialog</name>
     <message>
         <location filename="../updatedialog_moc.ui" line="71"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_updatedialog_moc.h" line="107"/>
         <source>You have latest version</source>
         <translation>У вас уже последняя версия</translation>
     </message>
     <message>
         <location filename="../updatedialog_moc.ui" line="94"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_updatedialog_moc.h" line="109"/>
         <source>Close</source>
         <translation>Закрыть</translation>
     </message>
     <message>
         <location filename="../updatedialog_moc.ui" line="101"/>
-        <location filename="../../out/build/linux-clang-release/launcher/ui_updatedialog_moc.h" line="110"/>
         <source>Check updates on startup</source>
         <translation>Проверять обновления при запуске</translation>
     </message>

--- a/launcher/translation/ukrainian.ts
+++ b/launcher/translation/ukrainian.ts
@@ -63,7 +63,7 @@
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.ui" line="163"/>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="270"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="272"/>
         <source>Description</source>
         <translation>Опис</translation>
     </message>
@@ -113,114 +113,114 @@
         <translation>Відмінити</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="228"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="230"/>
         <source>Mod name</source>
         <translation>Назва модифікації</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="229"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="231"/>
         <source>Installed version</source>
         <translation>Встановлена версія</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="230"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="232"/>
         <source>Latest version</source>
         <translation>Найновіша версія</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="233"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="235"/>
         <source>Download size</source>
         <translation>Розмір для завантаження</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="234"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="236"/>
         <source>Authors</source>
         <translation>Автори</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="237"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="239"/>
         <source>License</source>
         <translation>Ліцензія</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="240"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="242"/>
         <source>Contact</source>
         <translation>Контакти</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="244"/>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="251"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="246"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="253"/>
         <source>Compatibility</source>
         <translation>Сумісність</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="253"/>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="261"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="255"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="263"/>
         <source>Required VCMI version</source>
         <translation>Необхідна версія VCMI</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="259"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="261"/>
         <source>Supported VCMI version</source>
         <translation>Підтримувана версія VCMI</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="264"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="266"/>
         <source>Supported VCMI versions</source>
         <translation>Підтримувані версії VCMI</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="268"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="270"/>
         <source>Required mods</source>
         <translation>Необхідні модифікації</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="269"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="271"/>
         <source>Conflicting mods</source>
         <translation>Конфліктуючі модифікації</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="274"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="276"/>
         <source>This mod can not be installed or enabled because following dependencies are not present</source>
         <translation>Цю модифікацію не можна встановити чи активувати, оскільки відсутні наступні залежності</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="275"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="277"/>
         <source>This mod can not be enabled because following mods are incompatible with this mod</source>
         <translation>Цю модифікацію не можна ввімкнути, оскільки наступні модифікації несумісні з цією модифікацією</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="276"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="278"/>
         <source>This mod can not be disabled because it is required to run following mods</source>
         <translation>Цю модифікацію не можна відключити, оскільки вона необхідна для запуску наступних модифікацій</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="277"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="279"/>
         <source>This mod can not be uninstalled or updated because it is required to run following mods</source>
         <translation>Цю модифікацію не можна видалити або оновити, оскільки вона необхідна для запуску наступних модифікацій</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="278"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="280"/>
         <source>This is submod and it can not be installed or uninstalled separately from parent mod</source>
         <translation>Це вкладена модифікація, і її не можна встановити або видалити окремо від батьківської модифікації</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="293"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="295"/>
         <source>Notes</source>
         <translation>Примітки</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="795"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="797"/>
         <source>Screenshot %1</source>
         <translation>Знімок екрану %1</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="222"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="224"/>
         <source>Mod is compatible</source>
         <translation>Модифікація сумісна</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="223"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="225"/>
         <source>Mod is incompatible</source>
         <translation>Модифікація несумісна</translation>
     </message>
@@ -401,161 +401,139 @@
     <message>
         <location filename="../firstLaunch/firstlaunch_moc.ui" line="28"/>
         <source>Language</source>
-        <translation type="unfinished"></translation>
+        <translation>Мова</translation>
     </message>
     <message>
         <location filename="../firstLaunch/firstlaunch_moc.ui" line="53"/>
         <source>Heroes III Data</source>
-        <translation type="unfinished"></translation>
+        <translation>Дані Heroes III</translation>
     </message>
     <message>
         <location filename="../firstLaunch/firstlaunch_moc.ui" line="78"/>
         <source>Mods Preset</source>
+        <translation>Налаштування модифікацій</translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="414"/>
+        <source>Your Heroes III language has been succesfully detected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="103"/>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="797"/>
-        <source>Finish</source>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="552"/>
+        <source>Optionally, you can install additional mods either now or at any point later:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="136"/>
-        <source>Step %v out of %m</source>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="584"/>
+        <source>Install English translation of Heroes III</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="168"/>
-        <source>Choose your language</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="175"/>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="506"/>
-        <source>Next</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="240"/>
-        <source>Find Heroes III data files</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="271"/>
-        <source>Open help in browser</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="284"/>
-        <source>Search again</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="317"/>
-        <source>If you don&apos;t have installed Heroes III copy, it is possible to use our automatic installation tool &apos;vcmibuilder&apos; to extract data from GoG.com installer. Visit our wiki for detailed instructions.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="333"/>
-        <source>VCMI requires Heroes III data files in one of the locations listed above. Please copy Heroes III data in one of these directories.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="355"/>
-        <source>Heroes III data files</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="368"/>
-        <source>Alternatively, you can select directory with installed Heroes III data and VCMI will copy exisiting data automatically.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="384"/>
-        <source>Copy existing data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="397"/>
-        <source>Your Heroes III data files have been succesfully found.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="427"/>
-        <source>You Heroes III language was succesfully detected automatically.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="437"/>
-        <source>Automatic detection of language failed. Please select language of your Heroes III copy</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="456"/>
-        <source>Heroes III language</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="499"/>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="717"/>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="790"/>
-        <source>Back</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="537"/>
-        <source>Install VCMI Mod Preset</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="565"/>
-        <source>VCMI provides its own version of Horn of the Abyss fan-made addon. If you wish you can install it right now. For more information about mod visit hota website</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="581"/>
-        <source>Localization to English</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="661"/>
-        <source>VCMI provides translations of Heroes III into a different languages. If you wish, you can install translation to English</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="597"/>
-        <source>Install VCMI-compatible version of the &quot;In The Wake of Gods&quot; fan-made addon</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="613"/>
-        <source>Heroes III + HotA</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="629"/>
-        <source>Heroes III + WoG</source>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="616"/>
+        <source>Install support for playing Heroes III in resolutions other than 800x600.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firstLaunch/firstlaunch_moc.ui" line="645"/>
-        <source>VCMI provides support for playing Heroes III in resolutions other than 800x600. If you wish, you can install this support</source>
+        <source>Install compatible version of addon Horn of the Abyss: fan-made Heroes III expansion, ported by VCMI team</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="677"/>
-        <source>HD support</source>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="674"/>
+        <source>Install compatible version of addon &quot;In The Wake of Gods&quot;: fan-made Heroes III expansion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="724"/>
-        <source>Skip</source>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="721"/>
+        <source>Finish</source>
+        <translation>Завершити</translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="111"/>
+        <source>Step %v out of %m</source>
+        <translation>Крок %v з %m</translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="143"/>
+        <source>Choose your language</source>
+        <translation>Оберіть свою мову</translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="150"/>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="493"/>
+        <source>Next</source>
+        <translation>Далі</translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="215"/>
+        <source>Find Heroes III data files</source>
+        <translation>Пошук файлів даних Heroes III</translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="246"/>
+        <source>Open help in browser</source>
+        <translation>Відкрити довідку у браузері</translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="259"/>
+        <source>Search again</source>
+        <translation>Повторити пошук</translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="304"/>
+        <source>If you don&apos;t have installed Heroes III copy, it is possible to use our automatic installation tool &apos;vcmibuilder&apos; to extract data from GoG.com installer. Visit our wiki for detailed instructions.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="755"/>
-        <source>Join community / get help</source>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="320"/>
+        <source>VCMI requires Heroes III data files in one of the locations listed above. Please copy Heroes III data in one of these directories.</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="342"/>
+        <source>Heroes III data files</source>
+        <translation>Файли даних Heroes III</translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="355"/>
+        <source>Alternatively, you can select directory with installed Heroes III data and VCMI will copy exisiting data automatically.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="371"/>
+        <source>Copy existing data</source>
+        <translation>Копіювати наявні дані</translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="384"/>
+        <source>Your Heroes III data files have been succesfully found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="424"/>
+        <source>Automatic detection of language failed. Please select language of your Heroes III copy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="443"/>
+        <source>Heroes III language</source>
+        <translation>Мова Heroes III</translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="486"/>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="714"/>
+        <source>Back</source>
+        <translation>Назад</translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="524"/>
+        <source>Install VCMI Mod Preset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.cpp" line="264"/>
+        <source>Auto (%1)</source>
+        <translation>Авто (%1)</translation>
     </message>
 </context>
 <context>
@@ -605,21 +583,26 @@
     </message>
     <message>
         <location filename="../languages.cpp" line="29"/>
+        <source>Spanish</source>
+        <translation>Іспанська</translation>
+    </message>
+    <message>
+        <location filename="../languages.cpp" line="30"/>
         <source>Ukrainian</source>
         <translation>Українська</translation>
     </message>
     <message>
-        <location filename="../languages.cpp" line="30"/>
+        <location filename="../languages.cpp" line="31"/>
         <source>Other (East European)</source>
         <translation>Інша (східноєвропейська)</translation>
     </message>
     <message>
-        <location filename="../languages.cpp" line="31"/>
+        <location filename="../languages.cpp" line="32"/>
         <source>Other (Cyrillic Script)</source>
         <translation>Інша (кирилиця)</translation>
     </message>
     <message>
-        <location filename="../languages.cpp" line="32"/>
+        <location filename="../languages.cpp" line="33"/>
         <source>Other (West European)</source>
         <translation>Інша (західноєвропейська)</translation>
     </message>
@@ -769,17 +752,12 @@
         <translation>Лобі</translation>
     </message>
     <message>
-        <location filename="../mainwindow_moc.ui" line="207"/>
-        <source>Setup</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../mainwindow_moc.ui" line="272"/>
+        <location filename="../mainwindow_moc.ui" line="226"/>
         <source>Map Editor</source>
         <translation>Редактор мап</translation>
     </message>
     <message>
-        <location filename="../mainwindow_moc.ui" line="325"/>
+        <location filename="../mainwindow_moc.ui" line="279"/>
         <source>Start game</source>
         <translation>Грати</translation>
     </message>

--- a/launcher/translation/ukrainian.ts
+++ b/launcher/translation/ukrainian.ts
@@ -228,172 +228,207 @@
 <context>
     <name>CSettingsView</name>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="580"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="327"/>
         <source>Change</source>
         <translation>Змінити</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="223"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="356"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="450"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="222"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="287"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="473"/>
         <source>Open</source>
         <translation>Відкрити</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="507"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="590"/>
         <source>Adventure Map AI</source>
         <translation>ШІ Гравця</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="543"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="334"/>
         <source>User data directory</source>
         <translation>Тека даних користувача</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="254"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="296"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="377"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="494"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="256"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="298"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="440"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="487"/>
         <source>Off</source>
         <translation>Вимкнено</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="79"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="396"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="576"/>
         <source>Artificial Intelligence</source>
         <translation>Штучний інтелект</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="89"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="278"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="415"/>
         <source>Mod Repositories</source>
         <translation>Репозиторії модифікацій</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="158"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="368"/>
         <source>Update now</source>
         <translation>Оновити зараз</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="259"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="301"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="382"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="499"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="261"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="303"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="445"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="492"/>
         <source>On</source>
         <translation>Увімкнено</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="410"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="215"/>
         <source>Cursor</source>
         <translation>Курсор</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="425"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="500"/>
+        <source>Heroes III Data Language</source>
+        <translation>Мова Heroes III</translation>
+    </message>
+    <message>
+        <location filename="../settingsView/csettingsview_moc.ui" line="552"/>
         <source>Default</source>
         <translation>За замовчуванням</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="430"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="557"/>
         <source>Hardware</source>
         <translation>Апаратний</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="435"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="562"/>
         <source>Software</source>
         <translation>Програмний</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="443"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="597"/>
+        <source>Heroes III Translation</source>
+        <translation>Переклад Heroes III</translation>
+    </message>
+    <message>
+        <location filename="../settingsView/csettingsview_moc.ui" line="429"/>
         <source>Check on startup</source>
         <translation>Перевіряти на старті</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="457"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="158"/>
         <source>Fullscreen</source>
         <translation>Повноекранний режим</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="417"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="172"/>
         <source>Neutral AI</source>
         <translation>Нейтральний ШІ</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="264"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="266"/>
         <source>Real</source>
         <translation>Повний</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="69"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="536"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="354"/>
         <source>General</source>
         <translation>Загальні налаштування</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="483"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="144"/>
         <source>VCMI Language</source>
         <translation>Мова VCMI</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="557"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="422"/>
         <source>Friendly AI</source>
         <translation>Дружній ШІ</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="403"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="165"/>
         <source>Resolution</source>
         <translation>Роздільна здатність</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="209"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="179"/>
         <source>Autosave</source>
         <translation>Автозбереження</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="285"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="375"/>
         <source>Display index</source>
         <translation>Дісплей</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="165"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="151"/>
         <source>Network port</source>
         <translation>Мережевий порт</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="84"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="523"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="317"/>
         <source>Data Directories</source>
         <translation>Теки даних гри</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="74"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="315"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="192"/>
         <source>Video</source>
         <translation>Графіка</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="550"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="466"/>
         <source>Extra data directory</source>
         <translation>Додаткова тека даних</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="322"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="583"/>
         <source>Log files directory</source>
         <translation>Тека файлів журналу</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="230"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="361"/>
         <source>Show intro</source>
         <translation>Вступні відео</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="349"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="341"/>
         <source>Build version</source>
         <translation>Версія збірки</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="151"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="534"/>
         <source>Enemy AI</source>
         <translation>Ворожий ШІ</translation>
+    </message>
+    <message>
+        <location filename="../settingsView/csettingsview_moc.cpp" line="385"/>
+        <source>Active</source>
+        <translation>Активні</translation>
+    </message>
+    <message>
+        <location filename="../settingsView/csettingsview_moc.cpp" line="390"/>
+        <source>Disabled</source>
+        <translation>Деактивований</translation>
+    </message>
+    <message>
+        <location filename="../settingsView/csettingsview_moc.cpp" line="391"/>
+        <source>Enable</source>
+        <translation>Активувати</translation>
+    </message>
+    <message>
+        <location filename="../settingsView/csettingsview_moc.cpp" line="396"/>
+        <source>Not Installed</source>
+        <translation>Не встановлено</translation>
+    </message>
+    <message>
+        <location filename="../settingsView/csettingsview_moc.cpp" line="397"/>
+        <source>Install</source>
+        <translation>Встановити</translation>
     </message>
 </context>
 <context>
@@ -411,22 +446,17 @@
     <message>
         <location filename="../firstLaunch/firstlaunch_moc.ui" line="78"/>
         <source>Mods Preset</source>
-        <translation>Налаштування модифікацій</translation>
+        <translation>Початкові модифікації</translation>
     </message>
     <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="414"/>
-        <source>Your Heroes III language has been succesfully detected.</source>
-        <translation type="unfinished"></translation>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="384"/>
+        <source>Your Heroes III data files have been successfully found.</source>
+        <translation>Файли даних вашої гри Heroes III успішно знайдено.</translation>
     </message>
     <message>
         <location filename="../firstLaunch/firstlaunch_moc.ui" line="552"/>
         <source>Optionally, you can install additional mods either now or at any point later:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="584"/>
-        <source>Install English translation of Heroes III</source>
-        <translation type="unfinished"></translation>
+        <translation>За бажанням ви можете встановити додаткові модифікації зараз або пізніше:</translation>
     </message>
     <message>
         <location filename="../firstLaunch/firstlaunch_moc.ui" line="616"/>
@@ -505,14 +535,14 @@
         <translation>Копіювати наявні дані</translation>
     </message>
     <message>
-        <location filename="../firstLaunch/firstlaunch_moc.ui" line="384"/>
-        <source>Your Heroes III data files have been succesfully found.</source>
-        <translation type="unfinished"></translation>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="414"/>
+        <source>Your Heroes III language has been successfully detected.</source>
+        <translation>Мову вашої гри Heroes III успішно визначено.</translation>
     </message>
     <message>
         <location filename="../firstLaunch/firstlaunch_moc.ui" line="424"/>
         <source>Automatic detection of language failed. Please select language of your Heroes III copy</source>
-        <translation type="unfinished"></translation>
+        <translation>Не вдалося визначити мову гри. Будь ласка, виберіть мову вашої копії Heroes III</translation>
     </message>
     <message>
         <location filename="../firstLaunch/firstlaunch_moc.ui" line="443"/>
@@ -528,12 +558,12 @@
     <message>
         <location filename="../firstLaunch/firstlaunch_moc.ui" line="524"/>
         <source>Install VCMI Mod Preset</source>
-        <translation type="unfinished"></translation>
+        <translation>Встановлення початкових модифікацій VCMI</translation>
     </message>
     <message>
-        <location filename="../firstLaunch/firstlaunch_moc.cpp" line="264"/>
-        <source>Auto (%1)</source>
-        <translation>Авто (%1)</translation>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="584"/>
+        <source>Install translation of Heroes III to your language</source>
+        <translation>Встановити переклад Heroes III на вашу мову</translation>
     </message>
 </context>
 <context>
@@ -547,64 +577,69 @@
 <context>
     <name>Language</name>
     <message>
-        <location filename="../languages.cpp" line="22"/>
+        <location filename="../languages.cpp" line="23"/>
         <source>Chinese</source>
         <translation>Китайська</translation>
     </message>
     <message>
-        <location filename="../languages.cpp" line="23"/>
+        <location filename="../languages.cpp" line="24"/>
         <source>English</source>
         <translation>Англійська</translation>
     </message>
     <message>
-        <location filename="../languages.cpp" line="24"/>
+        <location filename="../languages.cpp" line="25"/>
         <source>French</source>
         <translation>Французька</translation>
     </message>
     <message>
-        <location filename="../languages.cpp" line="25"/>
+        <location filename="../languages.cpp" line="26"/>
         <source>German</source>
         <translation>Німецька</translation>
     </message>
     <message>
-        <location filename="../languages.cpp" line="26"/>
+        <location filename="../languages.cpp" line="27"/>
         <source>Korean</source>
         <translation>Корейська</translation>
     </message>
     <message>
-        <location filename="../languages.cpp" line="27"/>
+        <location filename="../languages.cpp" line="28"/>
         <source>Polish</source>
         <translation>Польська</translation>
     </message>
     <message>
-        <location filename="../languages.cpp" line="28"/>
+        <location filename="../languages.cpp" line="29"/>
         <source>Russian</source>
         <translation>Російська</translation>
     </message>
     <message>
-        <location filename="../languages.cpp" line="29"/>
+        <location filename="../languages.cpp" line="30"/>
         <source>Spanish</source>
         <translation>Іспанська</translation>
     </message>
     <message>
-        <location filename="../languages.cpp" line="30"/>
+        <location filename="../languages.cpp" line="31"/>
         <source>Ukrainian</source>
         <translation>Українська</translation>
     </message>
     <message>
-        <location filename="../languages.cpp" line="31"/>
+        <location filename="../languages.cpp" line="32"/>
         <source>Other (East European)</source>
         <translation>Інша (східноєвропейська)</translation>
     </message>
     <message>
-        <location filename="../languages.cpp" line="32"/>
+        <location filename="../languages.cpp" line="33"/>
         <source>Other (Cyrillic Script)</source>
         <translation>Інша (кирилиця)</translation>
     </message>
     <message>
-        <location filename="../languages.cpp" line="33"/>
+        <location filename="../languages.cpp" line="34"/>
         <source>Other (West European)</source>
         <translation>Інша (західноєвропейська)</translation>
+    </message>
+    <message>
+        <location filename="../languages.cpp" line="56"/>
+        <source>Auto (%1)</source>
+        <translation>Авто (%1)</translation>
     </message>
 </context>
 <context>

--- a/launcher/translation/ukrainian.ts
+++ b/launcher/translation/ukrainian.ts
@@ -4,101 +4,86 @@
 <context>
     <name>CModListModel</name>
     <message>
-        <location filename="../modManager/cmodlistmodel_moc.cpp" line="150"/>
+        <location filename="../modManager/cmodlistmodel_moc.cpp" line="142"/>
         <source>Name</source>
         <translation>Назва</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistmodel_moc.cpp" line="153"/>
+        <location filename="../modManager/cmodlistmodel_moc.cpp" line="145"/>
         <source>Type</source>
         <translation>Тип</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistmodel_moc.cpp" line="154"/>
+        <location filename="../modManager/cmodlistmodel_moc.cpp" line="146"/>
         <source>Version</source>
         <translation>Версія</translation>
-    </message>
-    <message>
-        <location filename="../modManager/cmodlistmodel_moc.cpp" line="155"/>
-        <source>Size</source>
-        <translation>Розмір</translation>
-    </message>
-    <message>
-        <location filename="../modManager/cmodlistmodel_moc.cpp" line="156"/>
-        <source>Author</source>
-        <translation>Автори</translation>
     </message>
 </context>
 <context>
     <name>CModListView</name>
     <message>
-        <location filename="../modManager/cmodlistview_moc.ui" line="61"/>
+        <location filename="../modManager/cmodlistview_moc.ui" line="58"/>
         <source>Filter</source>
         <translation>Фільтр</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.ui" line="84"/>
+        <location filename="../modManager/cmodlistview_moc.ui" line="81"/>
         <source>All mods</source>
         <translation>Усі модифікації</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.ui" line="89"/>
+        <location filename="../modManager/cmodlistview_moc.ui" line="86"/>
         <source>Downloadable</source>
         <translation>Усі доступні</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.ui" line="94"/>
+        <location filename="../modManager/cmodlistview_moc.ui" line="91"/>
         <source>Installed</source>
         <translation>Встановлені</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.ui" line="99"/>
+        <location filename="../modManager/cmodlistview_moc.ui" line="96"/>
         <source>Updatable</source>
         <translation>Доступні оновлення</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.ui" line="104"/>
+        <location filename="../modManager/cmodlistview_moc.ui" line="101"/>
         <source>Active</source>
         <translation>Активні</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.ui" line="109"/>
+        <location filename="../modManager/cmodlistview_moc.ui" line="106"/>
         <source>Inactive</source>
         <translation>Неактивні</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.ui" line="123"/>
+        <location filename="../modManager/cmodlistview_moc.ui" line="120"/>
         <source>Download &amp;&amp; refresh repositories</source>
         <translation>Оновити репозиторії</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.ui" line="228"/>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="288"/>
+        <location filename="../modManager/cmodlistview_moc.ui" line="163"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="270"/>
         <source>Description</source>
         <translation>Опис</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.ui" line="273"/>
+        <location filename="../modManager/cmodlistview_moc.ui" line="208"/>
         <source>Changelog</source>
         <translation>Зміни</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.ui" line="295"/>
+        <location filename="../modManager/cmodlistview_moc.ui" line="230"/>
         <source>Screenshots</source>
         <translation>Знімки</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.ui" line="368"/>
-        <source>Show details</source>
-        <translation>Показати подробиці</translation>
-    </message>
-    <message>
-        <location filename="../modManager/cmodlistview_moc.ui" line="409"/>
+        <location filename="../modManager/cmodlistview_moc.ui" line="389"/>
         <source>Uninstall</source>
         <translation>Видалити</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.ui" line="434"/>
+        <location filename="../modManager/cmodlistview_moc.ui" line="424"/>
         <source>Enable</source>
         <translation>Активувати</translation>
     </message>
@@ -108,134 +93,134 @@
         <translation>Деактивувати</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.ui" line="484"/>
+        <location filename="../modManager/cmodlistview_moc.ui" line="494"/>
         <source>Update</source>
         <translation>Оновити</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.ui" line="509"/>
+        <location filename="../modManager/cmodlistview_moc.ui" line="529"/>
         <source>Install</source>
         <translation>Встановити</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.ui" line="563"/>
+        <location filename="../modManager/cmodlistview_moc.ui" line="327"/>
         <source> %p% (%v KB out of %m KB)</source>
         <translation> %p% (%v КБ з %m КБ)</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.ui" line="576"/>
+        <location filename="../modManager/cmodlistview_moc.ui" line="340"/>
         <source>Abort</source>
         <translation>Відмінити</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="246"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="228"/>
         <source>Mod name</source>
         <translation>Назва модифікації</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="247"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="229"/>
         <source>Installed version</source>
         <translation>Встановлена версія</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="248"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="230"/>
         <source>Latest version</source>
         <translation>Найновіша версія</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="251"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="233"/>
         <source>Download size</source>
         <translation>Розмір для завантаження</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="252"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="234"/>
         <source>Authors</source>
         <translation>Автори</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="255"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="237"/>
         <source>License</source>
         <translation>Ліцензія</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="258"/>
-        <source>Home</source>
-        <translation>Домашня сторінка</translation>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="240"/>
+        <source>Contact</source>
+        <translation>Контакти</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="262"/>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="269"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="244"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="251"/>
         <source>Compatibility</source>
         <translation>Сумісність</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="271"/>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="279"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="253"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="261"/>
         <source>Required VCMI version</source>
         <translation>Необхідна версія VCMI</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="277"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="259"/>
         <source>Supported VCMI version</source>
         <translation>Підтримувана версія VCMI</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="282"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="264"/>
         <source>Supported VCMI versions</source>
         <translation>Підтримувані версії VCMI</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="286"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="268"/>
         <source>Required mods</source>
         <translation>Необхідні модифікації</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="287"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="269"/>
         <source>Conflicting mods</source>
         <translation>Конфліктуючі модифікації</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="292"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="274"/>
         <source>This mod can not be installed or enabled because following dependencies are not present</source>
         <translation>Цю модифікацію не можна встановити чи активувати, оскільки відсутні наступні залежності</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="293"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="275"/>
         <source>This mod can not be enabled because following mods are incompatible with this mod</source>
         <translation>Цю модифікацію не можна ввімкнути, оскільки наступні модифікації несумісні з цією модифікацією</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="294"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="276"/>
         <source>This mod can not be disabled because it is required to run following mods</source>
         <translation>Цю модифікацію не можна відключити, оскільки вона необхідна для запуску наступних модифікацій</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="295"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="277"/>
         <source>This mod can not be uninstalled or updated because it is required to run following mods</source>
         <translation>Цю модифікацію не можна видалити або оновити, оскільки вона необхідна для запуску наступних модифікацій</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="296"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="278"/>
         <source>This is submod and it can not be installed or uninstalled separately from parent mod</source>
         <translation>Це вкладена модифікація, і її не можна встановити або видалити окремо від батьківської модифікації</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="311"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="293"/>
         <source>Notes</source>
         <translation>Примітки</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="828"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="795"/>
         <source>Screenshot %1</source>
         <translation>Знімок екрану %1</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="240"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="222"/>
         <source>Mod is compatible</source>
         <translation>Модифікація сумісна</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="241"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="223"/>
         <source>Mod is incompatible</source>
         <translation>Модифікація несумісна</translation>
     </message>
@@ -243,217 +228,334 @@
 <context>
     <name>CSettingsView</name>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="80"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="580"/>
         <source>Change</source>
         <translation>Змінити</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="104"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="205"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="396"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="223"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="356"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="450"/>
         <source>Open</source>
         <translation>Відкрити</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="445"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="507"/>
+        <source>Adventure Map AI</source>
+        <translation>ШІ Гравця</translation>
+    </message>
+    <message>
+        <location filename="../settingsView/csettingsview_moc.ui" line="543"/>
         <source>User data directory</source>
         <translation>Тека даних користувача</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="91"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="129"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="312"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="334"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="254"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="296"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="377"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="494"/>
         <source>Off</source>
         <translation>Вимкнено</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="96"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="134"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="317"/>
-        <location filename="../settingsView/csettingsview_moc.ui" line="339"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="79"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="396"/>
+        <source>Artificial Intelligence</source>
+        <translation>Штучний інтелект</translation>
+    </message>
+    <message>
+        <location filename="../settingsView/csettingsview_moc.ui" line="89"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="278"/>
+        <source>Mod Repositories</source>
+        <translation>Репозиторії модифікацій</translation>
+    </message>
+    <message>
+        <location filename="../settingsView/csettingsview_moc.ui" line="158"/>
+        <source>Update now</source>
+        <translation>Оновити зараз</translation>
+    </message>
+    <message>
+        <location filename="../settingsView/csettingsview_moc.ui" line="259"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="301"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="382"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="499"/>
         <source>On</source>
         <translation>Увімкнено</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="118"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="410"/>
+        <source>Cursor</source>
+        <translation>Курсор</translation>
+    </message>
+    <message>
+        <location filename="../settingsView/csettingsview_moc.ui" line="425"/>
+        <source>Default</source>
+        <translation>За замовчуванням</translation>
+    </message>
+    <message>
+        <location filename="../settingsView/csettingsview_moc.ui" line="430"/>
+        <source>Hardware</source>
+        <translation>Апаратний</translation>
+    </message>
+    <message>
+        <location filename="../settingsView/csettingsview_moc.ui" line="435"/>
+        <source>Software</source>
+        <translation>Програмний</translation>
+    </message>
+    <message>
+        <location filename="../settingsView/csettingsview_moc.ui" line="443"/>
+        <source>Check on startup</source>
+        <translation>Перевіряти на старті</translation>
+    </message>
+    <message>
+        <location filename="../settingsView/csettingsview_moc.ui" line="457"/>
         <source>Fullscreen</source>
         <translation>Повноекранний режим</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="234"/>
-        <source>AI in the battlefield</source>
-        <translation>Штучний інтелект на полі бою</translation>
-    </message>
-    <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="181"/>
-        <source>Repositories</source>
-        <translation>Репозиторії</translation>
-    </message>
-    <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="188"/>
-        <source>Check for updates</source>
-        <translation>Оновити зараз</translation>
-    </message>
-    <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="549"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="417"/>
         <source>Neutral AI</source>
         <translation>Нейтральний ШІ</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="322"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="264"/>
         <source>Real</source>
         <translation>Повний</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="257"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="69"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="536"/>
         <source>General</source>
         <translation>Загальні налаштування</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="212"/>
-        <source>Player AI</source>
-        <translation>ШІ гравців</translation>
-    </message>
-    <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="472"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="483"/>
         <source>VCMI Language</source>
         <translation>Мова VCMI</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="487"/>
-        <source>Central European (Windows 1250)</source>
-        <translation>Центральноєвропейська (Windows 1250)</translation>
-    </message>
-    <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="492"/>
-        <source>Cyrillic script (Windows 1251)</source>
-        <translation>Кирилиця (Windows 1251)</translation>
-    </message>
-    <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="497"/>
-        <source>Western European (Windows 1252)</source>
-        <translation>Західноєвропейська (Windows 1252)</translation>
-    </message>
-    <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="502"/>
-        <source>Simplified Chinese (GBK)</source>
-        <translation>Спрощена китайська (GBK)</translation>
-    </message>
-    <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="507"/>
-        <source>Simplified Chinese (GB2312)</source>
-        <translation>Спрощена китайська (GB2312)</translation>
-    </message>
-    <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="512"/>
-        <source>Korean (Windows 949)</source>
-        <translation>Корейська (Windows 949)</translation>
-    </message>
-    <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="521"/>
-        <source>English</source>
-        <translation>English (Англійська)</translation>
-    </message>
-    <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="526"/>
-        <source>Deutsch (German)</source>
-        <translation>Deutsch (Німецька)</translation>
-    </message>
-    <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="531"/>
-        <source>Polska (Polish)</source>
-        <translation>Polska (Польська)</translation>
-    </message>
-    <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="536"/>
-        <source>Русский (Russian)</source>
-        <translation>Русский (Російська)</translation>
-    </message>
-    <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="541"/>
-        <source>Українська (Ukrainian)</source>
-        <translation>Українська</translation>
-    </message>
-    <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="579"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="557"/>
         <source>Friendly AI</source>
         <translation>Дружній ШІ</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="301"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="403"/>
         <source>Resolution</source>
         <translation>Роздільна здатність</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="353"/>
-        <source>AI on the map</source>
-        <translation>Штучний інтелект на карті пригод</translation>
-    </message>
-    <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="168"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="209"/>
         <source>Autosave</source>
         <translation>Автозбереження</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="219"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="285"/>
         <source>Display index</source>
         <translation>Дісплей</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="198"/>
-        <source>Check repositories on startup</source>
-        <translation>Перевірка репозиторіїв при запуску</translation>
-    </message>
-    <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="452"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="165"/>
         <source>Network port</source>
         <translation>Мережевий порт</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="422"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="84"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="523"/>
         <source>Data Directories</source>
         <translation>Теки даних гри</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="409"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="74"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="315"/>
         <source>Video</source>
         <translation>Графіка</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="111"/>
-        <source>Heroes III character set</source>
-        <translation>Кодування Heroes III</translation>
-    </message>
-    <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="294"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="550"/>
         <source>Extra data directory</source>
         <translation>Додаткова тека даних</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="142"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="322"/>
         <source>Log files directory</source>
         <translation>Тека файлів журналу</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="264"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="230"/>
         <source>Show intro</source>
         <translation>Вступні відео</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="57"/>
-        <source>Launcher Settings</source>
-        <translation>Налаштування лаунчера</translation>
-    </message>
-    <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="287"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="349"/>
         <source>Build version</source>
         <translation>Версія збірки</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="632"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="151"/>
         <source>Enemy AI</source>
         <translation>Ворожий ШІ</translation>
+    </message>
+</context>
+<context>
+    <name>FirstLaunchView</name>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="28"/>
+        <source>Language</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="53"/>
+        <source>Heroes III Data</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="78"/>
+        <source>Mods Preset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="103"/>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="797"/>
+        <source>Finish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="136"/>
+        <source>Step %v out of %m</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="168"/>
+        <source>Choose your language</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="175"/>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="506"/>
+        <source>Next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="240"/>
+        <source>Find Heroes III data files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="271"/>
+        <source>Open help in browser</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="284"/>
+        <source>Search again</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="317"/>
+        <source>If you don&apos;t have installed Heroes III copy, it is possible to use our automatic installation tool &apos;vcmibuilder&apos; to extract data from GoG.com installer. Visit our wiki for detailed instructions.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="333"/>
+        <source>VCMI requires Heroes III data files in one of the locations listed above. Please copy Heroes III data in one of these directories.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="355"/>
+        <source>Heroes III data files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="368"/>
+        <source>Alternatively, you can select directory with installed Heroes III data and VCMI will copy exisiting data automatically.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="384"/>
+        <source>Copy existing data</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="397"/>
+        <source>Your Heroes III data files have been succesfully found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="427"/>
+        <source>You Heroes III language was succesfully detected automatically.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="437"/>
+        <source>Automatic detection of language failed. Please select language of your Heroes III copy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="456"/>
+        <source>Heroes III language</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="499"/>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="717"/>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="790"/>
+        <source>Back</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="537"/>
+        <source>Install VCMI Mod Preset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="565"/>
+        <source>VCMI provides its own version of Horn of the Abyss fan-made addon. If you wish you can install it right now. For more information about mod visit hota website</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="581"/>
+        <source>Localization to English</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="661"/>
+        <source>VCMI provides translations of Heroes III into a different languages. If you wish, you can install translation to English</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="597"/>
+        <source>Install VCMI-compatible version of the &quot;In The Wake of Gods&quot; fan-made addon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="613"/>
+        <source>Heroes III + HotA</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="629"/>
+        <source>Heroes III + WoG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="645"/>
+        <source>VCMI provides support for playing Heroes III in resolutions other than 800x600. If you wish, you can install this support</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="677"/>
+        <source>HD support</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="724"/>
+        <source>Skip</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firstLaunch/firstlaunch_moc.ui" line="755"/>
+        <source>Join community / get help</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -465,66 +567,160 @@
     </message>
 </context>
 <context>
+    <name>Language</name>
+    <message>
+        <location filename="../languages.cpp" line="22"/>
+        <source>Chinese</source>
+        <translation>Китайська</translation>
+    </message>
+    <message>
+        <location filename="../languages.cpp" line="23"/>
+        <source>English</source>
+        <translation>Англійська</translation>
+    </message>
+    <message>
+        <location filename="../languages.cpp" line="24"/>
+        <source>French</source>
+        <translation>Французька</translation>
+    </message>
+    <message>
+        <location filename="../languages.cpp" line="25"/>
+        <source>German</source>
+        <translation>Німецька</translation>
+    </message>
+    <message>
+        <location filename="../languages.cpp" line="26"/>
+        <source>Korean</source>
+        <translation>Корейська</translation>
+    </message>
+    <message>
+        <location filename="../languages.cpp" line="27"/>
+        <source>Polish</source>
+        <translation>Польська</translation>
+    </message>
+    <message>
+        <location filename="../languages.cpp" line="28"/>
+        <source>Russian</source>
+        <translation>Російська</translation>
+    </message>
+    <message>
+        <location filename="../languages.cpp" line="29"/>
+        <source>Ukrainian</source>
+        <translation>Українська</translation>
+    </message>
+    <message>
+        <location filename="../languages.cpp" line="30"/>
+        <source>Other (East European)</source>
+        <translation>Інша (східноєвропейська)</translation>
+    </message>
+    <message>
+        <location filename="../languages.cpp" line="31"/>
+        <source>Other (Cyrillic Script)</source>
+        <translation>Інша (кирилиця)</translation>
+    </message>
+    <message>
+        <location filename="../languages.cpp" line="32"/>
+        <source>Other (West European)</source>
+        <translation>Інша (західноєвропейська)</translation>
+    </message>
+</context>
+<context>
     <name>Lobby</name>
     <message>
-        <location filename="../lobby/lobby_moc.ui" line="26"/>
+        <location filename="../lobby/lobby_moc.ui" line="39"/>
+        <location filename="../lobby/lobby_moc.cpp" line="401"/>
         <source>Connect</source>
         <translation>Підключитися</translation>
     </message>
     <message>
-        <location filename="../lobby/lobby_moc.ui" line="45"/>
+        <location filename="../lobby/lobby_moc.ui" line="26"/>
         <source>Username</source>
         <translation>Ім&apos;я користувача</translation>
     </message>
     <message>
-        <location filename="../lobby/lobby_moc.ui" line="69"/>
+        <location filename="../lobby/lobby_moc.ui" line="56"/>
         <source>Server</source>
         <translation>Сервер</translation>
     </message>
     <message>
-        <location filename="../lobby/lobby_moc.ui" line="111"/>
+        <location filename="../lobby/lobby_moc.ui" line="76"/>
+        <source>People in lobby</source>
+        <translation>Гравці у лобі</translation>
+    </message>
+    <message>
+        <location filename="../lobby/lobby_moc.ui" line="114"/>
+        <source>Lobby chat</source>
+        <translation>Лобі чат</translation>
+    </message>
+    <message>
+        <location filename="../lobby/lobby_moc.ui" line="194"/>
         <source>Session</source>
         <translation>Сесія</translation>
     </message>
     <message>
-        <location filename="../lobby/lobby_moc.ui" line="116"/>
+        <location filename="../lobby/lobby_moc.ui" line="199"/>
         <source>Players</source>
         <translation>Гравці</translation>
     </message>
     <message>
-        <location filename="../lobby/lobby_moc.ui" line="132"/>
+        <location filename="../lobby/lobby_moc.ui" line="274"/>
+        <source>Resolve</source>
+        <translation>Розв&apos;язати</translation>
+    </message>
+    <message>
+        <location filename="../lobby/lobby_moc.ui" line="286"/>
+        <source>New game</source>
+        <translation>Нова гра</translation>
+    </message>
+    <message>
+        <location filename="../lobby/lobby_moc.ui" line="293"/>
+        <source>Load game</source>
+        <translation>Завантажити гру</translation>
+    </message>
+    <message>
+        <location filename="../lobby/lobby_moc.ui" line="149"/>
         <source>New room</source>
         <translation>Створити кімнату</translation>
     </message>
     <message>
-        <location filename="../lobby/lobby_moc.ui" line="142"/>
+        <location filename="../lobby/lobby_moc.ui" line="159"/>
         <source>Join room</source>
         <translation>Приєднатися до кімнати</translation>
     </message>
     <message>
-        <location filename="../lobby/lobby_moc.ui" line="153"/>
+        <location filename="../lobby/lobby_moc.ui" line="267"/>
         <source>Ready</source>
         <translation>Готовність</translation>
     </message>
     <message>
-        <location filename="../lobby/lobby_moc.ui" line="160"/>
+        <location filename="../lobby/lobby_moc.ui" line="250"/>
         <source>Mods mismatch</source>
         <translation>Модифікації, що не збігаються</translation>
     </message>
     <message>
-        <location filename="../lobby/lobby_moc.ui" line="167"/>
+        <location filename="../lobby/lobby_moc.ui" line="243"/>
         <source>Leave</source>
         <translation>Вийти з кімнати</translation>
     </message>
     <message>
-        <location filename="../lobby/lobby_moc.ui" line="197"/>
+        <location filename="../lobby/lobby_moc.ui" line="216"/>
         <source>Kick player</source>
         <translation>Виключити гравця</translation>
     </message>
     <message>
-        <location filename="../lobby/lobby_moc.ui" line="204"/>
+        <location filename="../lobby/lobby_moc.ui" line="236"/>
         <source>Players in the room</source>
         <translation>Гравці у кімнаті</translation>
+    </message>
+    <message>
+        <location filename="../lobby/lobby_moc.cpp" line="369"/>
+        <source>Disconnect</source>
+        <translation>Від&apos;єднатися</translation>
+    </message>
+    <message>
+        <location filename="../lobby/lobby_moc.cpp" line="461"/>
+        <source>No issues detected</source>
+        <translation>Проблем не виявлено</translation>
     </message>
 </context>
 <context>
@@ -558,31 +754,32 @@
         <translation>VCMI Launcher</translation>
     </message>
     <message>
-        <location filename="../mainwindow_moc.ui" line="51"/>
+        <location filename="../mainwindow_moc.ui" line="57"/>
         <source>Mods</source>
         <translation>Модифікації</translation>
     </message>
     <message>
-        <source>Editor</source>
-        <translation type="vanished">Редактор</translation>
-    </message>
-    <message>
-        <location filename="../mainwindow_moc.ui" line="95"/>
+        <location filename="../mainwindow_moc.ui" line="107"/>
         <source>Settings</source>
         <translation>Налаштування</translation>
     </message>
     <message>
-        <location filename="../mainwindow_moc.ui" line="139"/>
+        <location filename="../mainwindow_moc.ui" line="157"/>
         <source>Lobby</source>
         <translation>Лобі</translation>
     </message>
     <message>
-        <location filename="../mainwindow_moc.ui" line="189"/>
-        <source>Map Editor</source>
+        <location filename="../mainwindow_moc.ui" line="207"/>
+        <source>Setup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow_moc.ui" line="236"/>
+        <location filename="../mainwindow_moc.ui" line="272"/>
+        <source>Map Editor</source>
+        <translation>Редактор мап</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow_moc.ui" line="325"/>
         <source>Start game</source>
         <translation>Грати</translation>
     </message>

--- a/lib/CGeneralTextHandler.cpp
+++ b/lib/CGeneralTextHandler.cpp
@@ -49,7 +49,7 @@ void CGeneralTextHandler::detectInstallParameters()
 
 	// load file that will be used for footprint generation
 	// this is one of the most text-heavy files in game and consists solely from translated texts
-	auto resource = CResourceHandler::get()->load(ResourceID("DATA/GENRLTXT.TXT", EResType::TEXT));
+	auto resource = CResourceHandler::get("core")->load(ResourceID("DATA/GENRLTXT.TXT", EResType::TEXT));
 
 	std::array<size_t, 256> charCount{};
 	std::array<double, 16> footprint{};
@@ -86,6 +86,9 @@ void CGeneralTextHandler::detectInstallParameters()
 
 	Settings language = settings.write["session"]["language"];
 	language->String() = knownLanguages[bestIndex];
+
+	Settings confidence = settings.write["session"]["languageDeviation"];
+	confidence->Float() = deviations[bestIndex];
 
 	Settings encoding = settings.write["session"]["encoding"];
 	encoding->String() =  Languages::getLanguageOptions(knownLanguages[bestIndex]).encoding;

--- a/lib/CGeneralTextHandler.cpp
+++ b/lib/CGeneralTextHandler.cpp
@@ -387,8 +387,6 @@ CGeneralTextHandler::CGeneralTextHandler():
 	znpc00           (*this, "vcmi.znpc00"  ), // technically - wog
 	qeModCommands    (*this, "vcmi.quickExchange" )
 {
-	detectInstallParameters();
-
 	readToVector("core.vcdesc",   "DATA/VCDESC.TXT"   );
 	readToVector("core.lcdesc",   "DATA/LCDESC.TXT"   );
 	readToVector("core.tcommand", "DATA/TCOMMAND.TXT" );
@@ -605,16 +603,19 @@ std::string CGeneralTextHandler::getModLanguage(const std::string & modContext)
 
 std::string CGeneralTextHandler::getPreferredLanguage()
 {
+	assert(!settings["general"]["language"].String().empty());
 	return settings["general"]["language"].String();
 }
 
 std::string CGeneralTextHandler::getInstalledLanguage()
 {
+	assert(!settings["session"]["language"].String().empty());
 	return settings["session"]["language"].String();
 }
 
 std::string CGeneralTextHandler::getInstalledEncoding()
 {
+	assert(!settings["session"]["encoding"].String().empty());
 	return settings["session"]["encoding"].String();
 }
 

--- a/lib/CModHandler.h
+++ b/lib/CModHandler.h
@@ -236,9 +236,6 @@ public:
 	/// CRC-32 checksum of the mod
 	ui32 checksum;
 
-	/// true if mod is enabled
-	bool enabled;
-
 	EValidationStatus validation;
 
 	JsonNode config;
@@ -249,10 +246,19 @@ public:
 	JsonNode saveLocalData() const;
 	void updateChecksum(ui32 newChecksum);
 
+	bool isEnabled() const;
+	void setEnabled(bool on);
+
 	static std::string getModDir(std::string name);
 	static std::string getModFile(std::string name);
 
 private:
+	/// true if mod is enabled by user, e.g. in Launcher UI
+	bool explicitlyEnabled;
+
+	/// true if mod can be loaded - compatible and has no missing deps
+	bool implicitlyEnabled;
+
 	void loadLocalData(const JsonNode & data);
 };
 
@@ -265,12 +271,6 @@ class DLL_LINKAGE CModHandler
 	void loadConfigFromFile(std::string name);
 
 	bool hasCircularDependency(TModID mod, std::set <TModID> currentList = std::set <TModID>()) const;
-
-	//returns false if mod list is incorrect and prints error to console. Possible errors are:
-	// - missing dependency mod
-	// - conflicting mod in load order
-	// - circular dependencies
-	bool checkDependencies(const std::vector <TModID> & input) const;
 
 	/**
 	* 1. Set apart mods with resolved dependencies from mods which have unresolved dependencies
@@ -449,7 +449,7 @@ public:
 				h & mver;
 				
 				if(allMods.count(m) && (allMods[m].version.isNull() || mver.isNull() || allMods[m].version.compatible(mver)))
-					allMods[m].enabled = true;
+					allMods[m].setEnabled(true);
 				else
 					missingMods.emplace_back(m, mver.toString());
 			}

--- a/lib/Languages.h
+++ b/lib/Languages.h
@@ -18,9 +18,10 @@ enum class ELanguages
 	ENGLISH,
 	FRENCH,
 	GERMAN,
-	KOREAN,
+	KOREAN, // currently has no translations or detection
 	POLISH,
 	RUSSIAN,
+	SPANISH,
 	UKRAINIAN,
 
 	// Pseudo-languages, that have no translations but can define H3 encoding to use
@@ -54,15 +55,16 @@ struct Options
 
 inline const auto & getLanguageList()
 {
-	static const std::array<Options, 11> languages
+	static const std::array<Options, 12> languages
 	{ {
-		{ "chinese",   "Chinese",   "简体中文",       "GBK",    true,  true },
+		{ "chinese",   "Chinese",   "简体中文",       "GBK",    true,  true }, // Note: actually Simplified Chinese
 		{ "english",   "English",   "English",    "CP1252", true,  true },
 		{ "french",    "French",    "Français",   "CP1252", true,  true },
 		{ "german",    "German",    "Deutsch",    "CP1252", true,  true },
-		{ "korean",    "Korean",    "한국어",        "CP949",  false, true },
+		{ "korean",    "Korean",    "한국어",        "CP949",  false, false },
 		{ "polish",    "Polish",    "Polski",     "CP1250", true,  true },
 		{ "russian",   "Russian",   "Русский",    "CP1251", true,  true },
+		{ "spanish",   "Spanish",   "Español",    "CP1252", false, true },
 		{ "ukrainian", "Ukrainian", "Українська", "CP1251", true,  true },
 
 		{ "other_cp1250", "Other (East European)",   "", "CP1251", false, false },

--- a/lib/Languages.h
+++ b/lib/Languages.h
@@ -67,7 +67,7 @@ inline const auto & getLanguageList()
 
 		{ "other_cp1250", "Other (East European)",   "", "CP1251", false, false },
 		{ "other_cp1251", "Other (Cyrillic Script)", "", "CP1250", false, false },
-		{ "other_cp1250", "Other (West European)",   "", "CP1252", false, false }
+		{ "other_cp1252", "Other (West European)",   "", "CP1252", false, false }
 	} };
 	static_assert(languages.size() == static_cast<size_t>(ELanguages::COUNT), "Languages array is missing a value!");
 

--- a/lib/Languages.h
+++ b/lib/Languages.h
@@ -18,9 +18,15 @@ enum class ELanguages
 	ENGLISH,
 	FRENCH,
 	GERMAN,
+	KOREAN,
 	POLISH,
 	RUSSIAN,
 	UKRAINIAN,
+
+	// Pseudo-languages, that have no translations but can define H3 encoding to use
+	OTHER_CP1250,
+	OTHER_CP1251,
+	OTHER_CP1252,
 
 	COUNT
 };
@@ -46,34 +52,38 @@ struct Options
 	bool hasTranslation = false;
 };
 
-inline auto const & getLanguageList( )
+inline const auto & getLanguageList()
 {
-	static const std::array<Options, 7> languages
+	static const std::array<Options, 11> languages
 	{ {
-		{ "chinese",   "Chinese",   "简体中文",       "GBK",    true, true },
+		{ "chinese",   "Chinese",   "简体中文",       "GBK",    true,  true },
 		{ "english",   "English",   "English",    "CP1252", true,  true },
 		{ "french",    "French",    "Français",   "CP1252", true,  true },
 		{ "german",    "German",    "Deutsch",    "CP1252", true,  true },
-			//TODO: korean - CP949 encoding
+		{ "korean",    "Korean",    "한국어",        "CP949",  false, true },
 		{ "polish",    "Polish",    "Polski",     "CP1250", true,  true },
 		{ "russian",   "Russian",   "Русский",    "CP1251", true,  true },
-		{ "ukrainian", "Ukrainian", "Українська", "CP1251", true,  true }
+		{ "ukrainian", "Ukrainian", "Українська", "CP1251", true,  true },
+
+		{ "other_cp1250", "Other (East European)",   "", "CP1251", false, false },
+		{ "other_cp1251", "Other (Cyrillic Script)", "", "CP1250", false, false },
+		{ "other_cp1250", "Other (West European)",   "", "CP1252", false, false }
 	} };
-	static_assert (languages.size() == static_cast<size_t>(ELanguages::COUNT), "Languages array is missing a value!" );
+	static_assert(languages.size() == static_cast<size_t>(ELanguages::COUNT), "Languages array is missing a value!");
 
 	return languages;
 }
 
-inline const Options & getLanguageOptions( ELanguages language )
+inline const Options & getLanguageOptions(ELanguages language)
 {
 	assert(language < ELanguages::COUNT);
 	return getLanguageList()[static_cast<size_t>(language)];
 }
 
-inline const Options & getLanguageOptions( std::string language )
+inline const Options & getLanguageOptions(const std::string & language)
 {
-	for (auto const & entry : getLanguageList())
-		if (entry.identifier == language)
+	for(const auto & entry : getLanguageList())
+		if(entry.identifier == language)
 			return entry;
 
 	static const Options emptyValue;

--- a/lib/VCMI_Lib.cpp
+++ b/lib/VCMI_Lib.cpp
@@ -18,6 +18,7 @@
 #include "CHeroHandler.h"
 #include "mapObjects/CObjectHandler.h"
 #include "CTownHandler.h"
+#include "CConfigHandler.h"
 #include "RoadHandler.h"
 #include "RiverHandler.h"
 #include "TerrainHandler.h"
@@ -48,7 +49,9 @@ DLL_LINKAGE void preinitDLL(CConsoleHandler * Console, bool onlyEssential, bool 
 	VLC = new LibClasses();
 	try
 	{
-		VLC->loadFilesystem(onlyEssential, extractArchives);
+		VLC->loadFilesystem(extractArchives);
+		settings.init();
+		VLC->loadModFilesystem(onlyEssential);
 	}
 	catch(...)
 	{
@@ -160,9 +163,8 @@ void LibClasses::updateEntity(Metatype metatype, int32_t index, const JsonNode &
 	}
 }
 
-void LibClasses::loadFilesystem(bool onlyEssential, bool extractArchives)
+void LibClasses::loadFilesystem(bool extractArchives)
 {
-	CStopWatch totalTime;
 	CStopWatch loadTime;
 
 	CResourceHandler::initialize();
@@ -170,15 +172,17 @@ void LibClasses::loadFilesystem(bool onlyEssential, bool extractArchives)
 
 	CResourceHandler::load("config/filesystem.json", extractArchives);
 	logGlobal->info("\tData loading: %d ms", loadTime.getDiff());
+}
 
+void LibClasses::loadModFilesystem(bool onlyEssential)
+{
+	CStopWatch loadTime;
 	modh = new CModHandler();
+	modh->loadMods(onlyEssential);
 	logGlobal->info("\tMod handler: %d ms", loadTime.getDiff());
 
-	modh->loadMods(onlyEssential);
 	modh->loadModFilesystems();
 	logGlobal->info("\tMod filesystems: %d ms", loadTime.getDiff());
-
-	logGlobal->info("Basic initialization: %d ms", totalTime.getDiff());
 }
 
 static void logHandlerLoaded(const std::string & name, CStopWatch & timer)

--- a/lib/VCMI_Lib.h
+++ b/lib/VCMI_Lib.h
@@ -107,7 +107,8 @@ public:
 	void clear(); //deletes all handlers and its data
 
 	// basic initialization. should be called before init(). Can also extract original H3 archives
-	void loadFilesystem(bool onlyEssential, bool extractArchives = false);
+	void loadFilesystem(bool extractArchives);
+	void loadModFilesystem(bool onlyEssential);
 
 #if SCRIPTING_ENABLED
 	void scriptsLoaded();

--- a/lib/filesystem/AdapterLoaders.cpp
+++ b/lib/filesystem/AdapterLoaders.cpp
@@ -58,12 +58,10 @@ std::unordered_set<ResourceID> CMappedFileLoader::getFilteredFiles(std::function
 
 CFilesystemList::CFilesystemList()
 {
-	//loaders = new std::vector<std::unique_ptr<ISimpleResourceLoader> >;
 }
 
 CFilesystemList::~CFilesystemList()
 {
-	//delete loaders;
 }
 
 std::unique_ptr<CInputStream> CFilesystemList::load(const ResourceID & resourceName) const

--- a/lib/filesystem/Filesystem.cpp
+++ b/lib/filesystem/Filesystem.cpp
@@ -192,6 +192,12 @@ void CResourceHandler::initialize()
 	addFilesystem("root", "local", localFS);
 }
 
+void CResourceHandler::destroy()
+{
+	knownLoaders.clear();
+	globalResourceHandler.rootLoader.reset();
+}
+
 ISimpleResourceLoader * CResourceHandler::get()
 {
 	return get("root");

--- a/lib/filesystem/Filesystem.h
+++ b/lib/filesystem/Filesystem.h
@@ -82,6 +82,12 @@ public:
 	static void initialize();
 
 	/**
+	 * Destroys all existing data in filesystem, bringing it into uninitialized state
+	 *
+	 */
+	static void destroy();
+
+	/**
 	 * Will load all filesystem data from Json data at this path (normally - config/filesystem.json)
 	 * @param fsConfigURI - URI from which data will be loaded
 	 */

--- a/mapeditor/mainwindow.cpp
+++ b/mapeditor/mainwindow.cpp
@@ -170,7 +170,6 @@ MainWindow::MainWindow(QWidget* parent) :
 
 	//init
 	preinitDLL(::console, false, extractionOptions.extractArchives);
-	settings.init();
 
 	// Initialize logging based on settings
 	logConfig->configure();

--- a/mapeditor/translation/ukrainian.ts
+++ b/mapeditor/translation/ukrainian.ts
@@ -62,17 +62,17 @@
     <message>
         <location filename="../mainwindow.ui" line="117"/>
         <source>Toolbar</source>
-        <translation type="unfinished"></translation>
+        <translation>Панель інструментів</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="163"/>
         <source>Minimap</source>
-        <translation type="unfinished"></translation>
+        <translation>Мінімапа</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="239"/>
         <source>Map Objects View</source>
-        <translation type="unfinished"></translation>
+        <translation>Перегляд об&apos;єктів мапи</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="283"/>
@@ -97,7 +97,7 @@
     <message>
         <location filename="../mainwindow.ui" line="432"/>
         <source>Terrains View</source>
-        <translation type="unfinished"></translation>
+        <translation>Перегляд поверхні</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="484"/>
@@ -339,53 +339,53 @@
     <message>
         <location filename="../mapsettings.ui" line="66"/>
         <source>Difficulty</source>
-        <translation type="unfinished"></translation>
+        <translation>Складність</translation>
     </message>
     <message>
         <location filename="../mapsettings.ui" line="111"/>
         <source>Events</source>
-        <translation type="unfinished"></translation>
+        <translation>Події</translation>
     </message>
     <message>
         <location filename="../mapsettings.ui" line="121"/>
         <source>Victory</source>
-        <translation type="unfinished"></translation>
+        <translation>Перемога</translation>
     </message>
     <message>
         <location filename="../mapsettings.ui" line="135"/>
         <source>Victory message</source>
-        <translation type="unfinished"></translation>
+        <translation>Повідомлення про перемогу</translation>
     </message>
     <message>
         <location filename="../mapsettings.ui" line="150"/>
         <source>Only for human players</source>
-        <translation type="unfinished"></translation>
+        <translation>Тільки для гравців-людей</translation>
     </message>
     <message>
         <location filename="../mapsettings.ui" line="157"/>
         <source>Allow standard victory</source>
-        <translation type="unfinished"></translation>
+        <translation>Дозволити типову перемогу</translation>
     </message>
     <message>
         <location filename="../mapsettings.ui" line="170"/>
         <location filename="../mapsettings.ui" line="218"/>
         <source>Parameters</source>
-        <translation type="unfinished"></translation>
+        <translation>Параметри</translation>
     </message>
     <message>
         <location filename="../mapsettings.ui" line="186"/>
         <source>Loss</source>
-        <translation type="unfinished"></translation>
+        <translation>Програш</translation>
     </message>
     <message>
         <location filename="../mapsettings.ui" line="195"/>
         <source>7 days without town</source>
-        <translation type="unfinished"></translation>
+        <translation>7 днів без міста</translation>
     </message>
     <message>
         <location filename="../mapsettings.ui" line="202"/>
         <source>Defeat message</source>
-        <translation type="unfinished"></translation>
+        <translation>Повідомлення про програш</translation>
     </message>
     <message>
         <location filename="../mapsettings.ui" line="235"/>
@@ -415,67 +415,67 @@
     <message>
         <location filename="../mapsettings.cpp" line="163"/>
         <source>No special victory</source>
-        <translation type="unfinished"></translation>
+        <translation>Немає особливої перемоги</translation>
     </message>
     <message>
         <location filename="../mapsettings.cpp" line="164"/>
         <source>Capture artifact</source>
-        <translation type="unfinished"></translation>
+        <translation>Отримати артефакт</translation>
     </message>
     <message>
         <location filename="../mapsettings.cpp" line="165"/>
         <source>Hire creatures</source>
-        <translation type="unfinished"></translation>
+        <translation>Найняти істот</translation>
     </message>
     <message>
         <location filename="../mapsettings.cpp" line="166"/>
         <source>Accumulate resources</source>
-        <translation type="unfinished"></translation>
+        <translation>Накопичити ресурси</translation>
     </message>
     <message>
         <location filename="../mapsettings.cpp" line="167"/>
         <source>Construct building</source>
-        <translation type="unfinished"></translation>
+        <translation>Побудувати будівлю</translation>
     </message>
     <message>
         <location filename="../mapsettings.cpp" line="168"/>
         <source>Capture town</source>
-        <translation type="unfinished"></translation>
+        <translation>Захопити місто</translation>
     </message>
     <message>
         <location filename="../mapsettings.cpp" line="169"/>
         <source>Defeat hero</source>
-        <translation type="unfinished"></translation>
+        <translation>Перемогти героя</translation>
     </message>
     <message>
         <location filename="../mapsettings.cpp" line="170"/>
         <source>Transport artifact</source>
-        <translation type="unfinished"></translation>
+        <translation>Доставити артефакт</translation>
     </message>
     <message>
         <location filename="../mapsettings.cpp" line="173"/>
         <source>No special loss</source>
-        <translation type="unfinished"></translation>
+        <translation>Немає особливої поразки</translation>
     </message>
     <message>
         <location filename="../mapsettings.cpp" line="174"/>
         <source>Lose castle</source>
-        <translation type="unfinished"></translation>
+        <translation>Втратити місто</translation>
     </message>
     <message>
         <location filename="../mapsettings.cpp" line="175"/>
         <source>Lose hero</source>
-        <translation type="unfinished"></translation>
+        <translation>Втратити героя</translation>
     </message>
     <message>
         <location filename="../mapsettings.cpp" line="176"/>
         <source>Time expired</source>
-        <translation type="unfinished"></translation>
+        <translation>Закінчився час</translation>
     </message>
     <message>
         <location filename="../mapsettings.cpp" line="177"/>
         <source>Days without town</source>
-        <translation type="unfinished"></translation>
+        <translation>Дні без міста</translation>
     </message>
 </context>
 <context>
@@ -751,7 +751,7 @@
     <message>
         <location filename="../mainwindow.cpp" line="98"/>
         <source>Filepath of the map to open.</source>
-        <translation>Файл мапи, який слід відкрити</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="101"/>

--- a/server/CVCMIServer.cpp
+++ b/server/CVCMIServer.cpp
@@ -1117,7 +1117,6 @@ int main(int argc, const char * argv[])
 	boost::program_options::variables_map opts;
 	handleCommandOptions(argc, argv, opts);
 	preinitDLL(console);
-	settings.init();
 	logConfig.configure();
 
 	loadDLLClasses();


### PR DESCRIPTION
As discussed before, mock-up of initial setup/welcome page for Launcher. 
Currently this is just UI mock-up, with 0 implemented functionality, mostly to gather feedback. Will probably wait for a week or so 


### Overall Design
- This tab will open automatically on first install or if H3 data is missing (e.g. deleted by user since last start)
- While in this tab, buttons from left panel will be most likely disabled until user finishes setup. We can't really play game if there is no H3 data.
- "Setup" button from left side will be likely removed, potentially - moved to settings.
- Top panel on mock-up has both progress bar and buttons to show progress. Currently planning to remove progress bar and only keep buttons. Another option is to keep only progress bar, but buttons are probably better option.

### Language Selector
- Left side will have language names using same format as language selector, e.g "Українська (Ukrainian)", shamelessly taken from Steam webpage design.
- For right side I'm planning to have some sort of introduction text, but not yet sure what to write there. Suggestions welcomed.

### Heroes III Data Selector
Should be mostly self-describing.
- text inputs near "Heroes II data files" should show one of data_dir paths (e.g. `.` on Windows or `/usr/share/vcmi` on Linux) and user data directory (e.g. `Documents/My Games/vcmi` for Windows, `~/.local/share/vcmi/` on Linux)
- some elements are conditional and won't always show up:
- - vcmibuilder tool only exists on Linux (and I think MacOS?), so no reason to show it on Windows/mobile platforms
- - "data successfully found" will only show up if H3 data detected (and disable/hide other texts)
- - for language, only one label will be shown, depending on language detection result.

### Mods Preset Selector
- Should probably add separate label with explanation about "optionally installable mods", to explain what's this about
- "Install localization" should be only visible if selected language differs from H3 language AND we have mod with localization to selected language.
- "HD support" means installation of vcmi-extras mod
- user can either skip this step completely and play vanilla game, or install more than one "preset"

### Finish tab
No screenshot because nothing to show. Currently considering dropping links to community (probably Discord & vcmi.eu forum) as well as link to Github for bug reports.

Probably some basic description of what can vcmi do would be good addition, but not sure what to add there. Suggestions?

Another option is to axe this tab and show community links someplace else, e.g. add "About" button or "Help" button somewhere with these links. Should be someplace easily accessible, e.g. on left panel, and not buried deep into settings.

### Screenshots
![launcher-welcome-language](https://user-images.githubusercontent.com/1576820/214892443-c300b7ea-46ba-44a0-a444-2d2652f2e157.png)
![launcher-welcome-h3data](https://user-images.githubusercontent.com/1576820/214892466-2f705cd9-2834-4ce1-8537-7d581e4aaa7e.png)
![launcher-welcome-modspreset](https://user-images.githubusercontent.com/1576820/214892482-430fd8e8-87ff-4b1a-81f6-1190e336f7dd.png)
