### PR TITLE
Russian translation and Qt6 translation update

### DIFF
--- a/launcher/CMakeLists.txt
+++ b/launcher/CMakeLists.txt
@@ -90,11 +90,6 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 if(TARGET Qt6::Core)
 	qt_wrap_ui(launcher_UI_HEADERS ${launcher_FORMS})
-	if(ENABLE_TRANSLATIONS)
-		set_source_files_properties(${launcher_TS} PROPERTIES OUTPUT_LOCATION ${CMAKE_CURRENT_BINARY_DIR}/translation)
-		# TODO: consider using qt_add_translations: https://doc.qt.io/qt-6/qtlinguist-cmake-qt-add-translations.html
-		qt_add_translation( launcher_QM ${launcher_TS} )
-	endif()
 else()
 	qt5_wrap_ui(launcher_UI_HEADERS ${launcher_FORMS})
 	if(ENABLE_TRANSLATIONS)
@@ -112,6 +107,17 @@ if(ENABLE_SINGLE_APP_BUILD)
 	add_library(vcmilauncher STATIC ${launcher_QM} ${launcher_SRCS} ${launcher_HEADERS} ${launcher_UI_HEADERS})
 else()
 	add_executable(vcmilauncher WIN32 ${launcher_QM} ${launcher_SRCS} ${launcher_HEADERS} ${launcher_UI_HEADERS} ${launcher_ICON})
+endif()
+
+if(TARGET Qt6::Core)
+	if(ENABLE_TRANSLATIONS)
+		set_source_files_properties(${launcher_TS} PROPERTIES OUTPUT_LOCATION ${CMAKE_CURRENT_BINARY_DIR}/translation)
+		qt_add_translations(vcmilauncher
+			TS_FILES ${launcher_TS}
+			QM_FILES_OUTPUT_VARIABLE launcher_QM
+			INCLUDE_DIRECTORIES
+				${CMAKE_CURRENT_BINARY_DIR})
+	endif()
 endif()
 
 if(WIN32)

--- a/launcher/translation/russian.ts
+++ b/launcher/translation/russian.ts
@@ -6,599 +6,764 @@
     <message>
         <location filename="../modManager/cmodlistmodel_moc.cpp" line="150"/>
         <source>Name</source>
-        <translation type="unfinished"></translation>
+        <translation>Название</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistmodel_moc.cpp" line="153"/>
         <source>Type</source>
-        <translation type="unfinished"></translation>
+        <translation>Тип</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistmodel_moc.cpp" line="154"/>
         <source>Version</source>
-        <translation type="unfinished"></translation>
+        <translation>Версия</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistmodel_moc.cpp" line="155"/>
         <source>Size</source>
-        <translation type="unfinished"></translation>
+        <translation>Размер</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistmodel_moc.cpp" line="156"/>
         <source>Author</source>
-        <translation type="unfinished"></translation>
+        <translation>Автор</translation>
     </message>
 </context>
 <context>
     <name>CModListView</name>
     <message>
         <location filename="../modManager/cmodlistview_moc.ui" line="61"/>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_cmodlistview_moc.h" line="333"/>
         <source>Filter</source>
-        <translation type="unfinished"></translation>
+        <translation>Фильтр</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.ui" line="84"/>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_cmodlistview_moc.h" line="334"/>
         <source>All mods</source>
-        <translation type="unfinished"></translation>
+        <translation>Все моды</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.ui" line="89"/>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_cmodlistview_moc.h" line="335"/>
         <source>Downloadable</source>
-        <translation type="unfinished"></translation>
+        <translation>Доступные</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.ui" line="94"/>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_cmodlistview_moc.h" line="336"/>
         <source>Installed</source>
-        <translation type="unfinished"></translation>
+        <translation>Установленные</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.ui" line="99"/>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_cmodlistview_moc.h" line="337"/>
         <source>Updatable</source>
-        <translation type="unfinished"></translation>
+        <translation>Обновления</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.ui" line="104"/>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_cmodlistview_moc.h" line="338"/>
         <source>Active</source>
-        <translation type="unfinished"></translation>
+        <translation>Активны</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.ui" line="109"/>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_cmodlistview_moc.h" line="339"/>
         <source>Inactive</source>
-        <translation type="unfinished"></translation>
+        <translation>Неактивны</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.ui" line="123"/>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_cmodlistview_moc.h" line="341"/>
         <source>Download &amp;&amp; refresh repositories</source>
-        <translation type="unfinished"></translation>
+        <translation>Обновить репозиторий</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.ui" line="228"/>
         <location filename="../modManager/cmodlistview_moc.cpp" line="288"/>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_cmodlistview_moc.h" line="343"/>
         <source>Description</source>
-        <translation type="unfinished"></translation>
+        <translation>Описание</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.ui" line="273"/>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_cmodlistview_moc.h" line="344"/>
         <source>Changelog</source>
-        <translation type="unfinished"></translation>
+        <translation>Изменения</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.ui" line="295"/>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_cmodlistview_moc.h" line="345"/>
         <source>Screenshots</source>
-        <translation type="unfinished"></translation>
+        <translation>Скриншоты</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.ui" line="368"/>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_cmodlistview_moc.h" line="346"/>
         <source>Show details</source>
-        <translation type="unfinished"></translation>
+        <translation>Подробности</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.ui" line="409"/>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_cmodlistview_moc.h" line="347"/>
         <source>Uninstall</source>
-        <translation type="unfinished"></translation>
+        <translation>Удалить</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.ui" line="434"/>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_cmodlistview_moc.h" line="348"/>
         <source>Enable</source>
-        <translation type="unfinished"></translation>
+        <translation>Включить</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.ui" line="459"/>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_cmodlistview_moc.h" line="349"/>
         <source>Disable</source>
-        <translation type="unfinished"></translation>
+        <translation>Отключить</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.ui" line="484"/>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_cmodlistview_moc.h" line="350"/>
         <source>Update</source>
-        <translation type="unfinished"></translation>
+        <translation>Обновить</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.ui" line="509"/>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_cmodlistview_moc.h" line="351"/>
         <source>Install</source>
-        <translation type="unfinished"></translation>
+        <translation>Установить</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.ui" line="563"/>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_cmodlistview_moc.h" line="352"/>
         <source> %p% (%v KB out of %m KB)</source>
-        <translation type="unfinished"></translation>
+        <translation> %p% (%v КБ з %m КБ)</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.ui" line="576"/>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_cmodlistview_moc.h" line="353"/>
         <source>Abort</source>
-        <translation type="unfinished"></translation>
+        <translation>Отмена</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.cpp" line="246"/>
         <source>Mod name</source>
-        <translation type="unfinished"></translation>
+        <translation>Название мода</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.cpp" line="247"/>
         <source>Installed version</source>
-        <translation type="unfinished"></translation>
+        <translation>Установленная версия</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.cpp" line="248"/>
         <source>Latest version</source>
-        <translation type="unfinished"></translation>
+        <translation>Последняя версия</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.cpp" line="251"/>
         <source>Download size</source>
-        <translation type="unfinished"></translation>
+        <translation>Размер загрузки</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.cpp" line="252"/>
         <source>Authors</source>
-        <translation type="unfinished"></translation>
+        <translation>Авторы</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.cpp" line="255"/>
         <source>License</source>
-        <translation type="unfinished"></translation>
+        <translation>Лицензия</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.cpp" line="258"/>
         <source>Home</source>
-        <translation type="unfinished"></translation>
+        <translation>Домашняя страница</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.cpp" line="262"/>
         <location filename="../modManager/cmodlistview_moc.cpp" line="269"/>
         <source>Compatibility</source>
-        <translation type="unfinished"></translation>
+        <translation>Совместимость</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.cpp" line="271"/>
         <location filename="../modManager/cmodlistview_moc.cpp" line="279"/>
         <source>Required VCMI version</source>
-        <translation type="unfinished"></translation>
+        <translation>Требуемая версия VCMI</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.cpp" line="277"/>
         <source>Supported VCMI version</source>
-        <translation type="unfinished"></translation>
+        <translation>Поддерживаемая версия VCMI</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.cpp" line="282"/>
         <source>Supported VCMI versions</source>
-        <translation type="unfinished"></translation>
+        <translation>Поддерживаемые версии VCMI</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.cpp" line="286"/>
         <source>Required mods</source>
-        <translation type="unfinished"></translation>
+        <translation>Зависимости</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.cpp" line="287"/>
         <source>Conflicting mods</source>
-        <translation type="unfinished"></translation>
+        <translation>Конфликтующие моды</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.cpp" line="292"/>
         <source>This mod can not be installed or enabled because following dependencies are not present</source>
-        <translation type="unfinished"></translation>
+        <translation>Этот мод не может быть установлен или активирован, так как отсутствуют следующие зависимости</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.cpp" line="293"/>
         <source>This mod can not be enabled because following mods are incompatible with this mod</source>
-        <translation type="unfinished"></translation>
+        <translation>Этот мод не может быть установлен или активирован, так как следующие моды несовместимы с этим</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.cpp" line="294"/>
         <source>This mod can not be disabled because it is required to run following mods</source>
-        <translation type="unfinished"></translation>
+        <translation>Этот мод не может быть выключен, так как он является зависимостью для следующих</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.cpp" line="295"/>
         <source>This mod can not be uninstalled or updated because it is required to run following mods</source>
-        <translation type="unfinished"></translation>
+        <translation>Этот мод не может быть удален или обновлен, так как является зависимостью для следующих модов</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.cpp" line="296"/>
         <source>This is submod and it can not be installed or uninstalled separately from parent mod</source>
-        <translation type="unfinished"></translation>
+        <translation>Это вложенный мод, он не может быть установлен или удален отдельно от родительского</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.cpp" line="311"/>
         <source>Notes</source>
-        <translation type="unfinished"></translation>
+        <translation>Замечания</translation>
     </message>
     <message>
-        <location filename="../modManager/cmodlistview_moc.cpp" line="828"/>
+        <location filename="../modManager/cmodlistview_moc.cpp" line="846"/>
         <source>Screenshot %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Скриншот %1</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.cpp" line="240"/>
         <source>Mod is compatible</source>
-        <translation type="unfinished"></translation>
+        <translation>Мод совместим</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.cpp" line="241"/>
         <source>Mod is incompatible</source>
-        <translation type="unfinished"></translation>
+        <translation>Мод несовместим</translation>
     </message>
 </context>
 <context>
     <name>CSettingsView</name>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="80"/>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="434"/>
         <source>Change</source>
-        <translation type="unfinished"></translation>
+        <translation>Изменить</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="104"/>
         <location filename="../settingsView/csettingsview_moc.ui" line="205"/>
         <location filename="../settingsView/csettingsview_moc.ui" line="396"/>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="438"/>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="449"/>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="467"/>
         <source>Open</source>
-        <translation type="unfinished"></translation>
+        <translation>Открыть</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="445"/>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="470"/>
         <source>User data directory</source>
-        <translation type="unfinished"></translation>
+        <translation>Данные пользователя</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="91"/>
         <location filename="../settingsView/csettingsview_moc.ui" line="129"/>
         <location filename="../settingsView/csettingsview_moc.ui" line="312"/>
         <location filename="../settingsView/csettingsview_moc.ui" line="334"/>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="435"/>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="441"/>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="458"/>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="462"/>
         <source>Off</source>
-        <translation type="unfinished"></translation>
+        <translation>Отключено</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="96"/>
         <location filename="../settingsView/csettingsview_moc.ui" line="134"/>
         <location filename="../settingsView/csettingsview_moc.ui" line="317"/>
         <location filename="../settingsView/csettingsview_moc.ui" line="339"/>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="436"/>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="442"/>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="459"/>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="463"/>
         <source>On</source>
-        <translation type="unfinished"></translation>
+        <translation>Включено</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="118"/>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="440"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Полноэкранный режим</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="181"/>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="446"/>
         <source>Repositories</source>
-        <translation type="unfinished"></translation>
+        <translation>Репозитории</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="188"/>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="447"/>
         <source>Check for updates</source>
-        <translation type="unfinished"></translation>
+        <translation>Проверить обновления</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="549"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="554"/>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="487"/>
         <source>Neutral AI</source>
-        <translation type="unfinished"></translation>
+        <translation>Нейтральный ИИ</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="322"/>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="460"/>
         <source>Real</source>
-        <translation type="unfinished"></translation>
+        <translation>Полный</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="257"/>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="453"/>
         <source>General</source>
-        <translation type="unfinished"></translation>
+        <translation>Общее</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="212"/>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="450"/>
         <source>Player AI</source>
-        <translation type="unfinished"></translation>
+        <translation>ИИ игроков</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="472"/>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="472"/>
         <source>VCMI Language</source>
-        <translation type="unfinished"></translation>
+        <translation>Язык VCMI</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="487"/>
-        <source>Central European (Windows 1250)</source>
-        <translation type="unfinished"></translation>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="473"/>
+        <source>Automatic detection</source>
+        <translation>Автоматическое определение</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="492"/>
-        <source>Cyrillic script (Windows 1251)</source>
-        <translation type="unfinished"></translation>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="474"/>
+        <source>Central European (Windows 1250)</source>
+        <translation>Центральноевропейская (Windows-1250)</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="497"/>
-        <source>Western European (Windows 1252)</source>
-        <translation type="unfinished"></translation>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="475"/>
+        <source>Cyrillic script (Windows 1251)</source>
+        <translation>Кириллица (Windows 1251)</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="502"/>
-        <source>Simplified Chinese (GBK)</source>
-        <translation type="unfinished"></translation>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="476"/>
+        <source>Western European (Windows 1252)</source>
+        <translation>Западноевропейская (Windows 1252)</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="507"/>
-        <source>Simplified Chinese (GB2312)</source>
-        <translation type="unfinished"></translation>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="477"/>
+        <source>Simplified Chinese (GBK)</source>
+        <translation>Упрощенная китайская (GBK)</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="512"/>
-        <source>Korean (Windows 949)</source>
-        <translation type="unfinished"></translation>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="478"/>
+        <source>Simplified Chinese (GB2312)</source>
+        <translation>Упрощенная китайская (GB2312)</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="521"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="517"/>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="479"/>
+        <source>Korean (Windows 949)</source>
+        <translation>Корейская (Windows 949)</translation>
+    </message>
+    <message>
+        <location filename="../settingsView/csettingsview_moc.ui" line="526"/>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="481"/>
         <source>English</source>
         <translation>English (Английский)</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="526"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="531"/>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="482"/>
         <source>Deutsch (German)</source>
-        <translation type="unfinished">Deutsch (Немецкий)</translation>
+        <translation>Deutsch (Немецкий)</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="531"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="536"/>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="483"/>
         <source>Polska (Polish)</source>
         <translation>Polska (Польский)</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="536"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="541"/>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="484"/>
         <source>Русский (Russian)</source>
         <translation>Русский</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="541"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="546"/>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="485"/>
         <source>Українська (Ukrainian)</source>
         <translation>Українська (Украинский)</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="579"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="584"/>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="489"/>
         <source>Friendly AI</source>
-        <translation type="unfinished"></translation>
+        <translation>Дружественный ИИ</translation>
+    </message>
+    <message>
+        <location filename="../settingsView/csettingsview_moc.ui" line="644"/>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="493"/>
+        <source>Cursor</source>
+        <translation>Курсор</translation>
+    </message>
+    <message>
+        <location filename="../settingsView/csettingsview_moc.ui" line="652"/>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="494"/>
+        <source>Default</source>
+        <translation>По умолчанию</translation>
+    </message>
+    <message>
+        <location filename="../settingsView/csettingsview_moc.ui" line="657"/>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="495"/>
+        <source>Hardware</source>
+        <translation>Аппаратный</translation>
+    </message>
+    <message>
+        <location filename="../settingsView/csettingsview_moc.ui" line="662"/>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="496"/>
+        <source>Software</source>
+        <translation>Программный</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="301"/>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="457"/>
         <source>Resolution</source>
-        <translation type="unfinished"></translation>
+        <translation>Разрешение экрана</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="353"/>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="465"/>
         <source>AI on the map</source>
-        <translation type="unfinished"></translation>
+        <translation>ИИ на карте приключений</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="168"/>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="445"/>
         <source>Autosave</source>
-        <translation type="unfinished"></translation>
+        <translation>Автосохранение</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="219"/>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="451"/>
         <source>Display index</source>
-        <translation type="unfinished"></translation>
+        <translation>Дисплей</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="198"/>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="448"/>
         <source>Check repositories on startup</source>
-        <translation type="unfinished"></translation>
+        <translation>Проверка репозиториев при запуске</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="452"/>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="471"/>
         <source>Network port</source>
-        <translation type="unfinished"></translation>
+        <translation>Сетевой порт</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="422"/>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="469"/>
         <source>Data Directories</source>
-        <translation type="unfinished"></translation>
+        <translation>Директории данных</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="409"/>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="468"/>
         <source>Video</source>
-        <translation type="unfinished"></translation>
+        <translation>Графика</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="111"/>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="439"/>
         <source>Heroes III character set</source>
-        <translation type="unfinished"></translation>
+        <translation>Кодировка Героев III</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="294"/>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="456"/>
         <source>Extra data directory</source>
-        <translation type="unfinished"></translation>
+        <translation>Дополнительные данные</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="142"/>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="444"/>
         <source>Log files directory</source>
-        <translation type="unfinished"></translation>
+        <translation>Журналы</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="264"/>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="454"/>
         <source>Show intro</source>
-        <translation type="unfinished"></translation>
+        <translation>Вступление</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="57"/>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="433"/>
         <source>Launcher Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>Настройки загрузчика</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="287"/>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="455"/>
         <source>Build version</source>
-        <translation type="unfinished"></translation>
+        <translation>Версия сборки</translation>
     </message>
     <message>
-        <location filename="../settingsView/csettingsview_moc.ui" line="632"/>
+        <location filename="../settingsView/csettingsview_moc.ui" line="637"/>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="492"/>
         <source>Enemy AI</source>
-        <translation type="unfinished"></translation>
+        <translation>Вражеский ИИ</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="234"/>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_csettingsview_moc.h" line="452"/>
         <source>AI in the battlefield</source>
-        <translation type="unfinished"></translation>
+        <translation>ИИ на поле боя</translation>
     </message>
 </context>
 <context>
     <name>ImageViewer</name>
     <message>
         <location filename="../modManager/imageviewer_moc.ui" line="20"/>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_imageviewer_moc.h" line="59"/>
         <source>Image Viewer</source>
-        <translation type="unfinished"></translation>
+        <translation>Просмотр изображений</translation>
     </message>
 </context>
 <context>
     <name>Lobby</name>
     <message>
-        <location filename="../lobby/lobby_moc.ui" line="26"/>
+        <location filename="../lobby/lobby_moc.ui" line="39"/>
+        <location filename="../lobby/lobby_moc.cpp" line="401"/>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_lobby_moc.h" line="284"/>
         <source>Connect</source>
-        <translation type="unfinished"></translation>
+        <translation>Подключиться</translation>
     </message>
     <message>
-        <location filename="../lobby/lobby_moc.ui" line="45"/>
+        <location filename="../lobby/lobby_moc.ui" line="26"/>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_lobby_moc.h" line="283"/>
         <source>Username</source>
-        <translation type="unfinished"></translation>
+        <translation>Имя пользователя</translation>
     </message>
     <message>
-        <location filename="../lobby/lobby_moc.ui" line="69"/>
+        <location filename="../lobby/lobby_moc.ui" line="56"/>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_lobby_moc.h" line="285"/>
         <source>Server</source>
-        <translation type="unfinished"></translation>
+        <translation>Сервер</translation>
     </message>
     <message>
-        <location filename="../lobby/lobby_moc.ui" line="111"/>
+        <location filename="../lobby/lobby_moc.ui" line="76"/>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_lobby_moc.h" line="286"/>
+        <source>People in lobby</source>
+        <translation>Люди в лобби</translation>
+    </message>
+    <message>
+        <location filename="../lobby/lobby_moc.ui" line="114"/>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_lobby_moc.h" line="287"/>
+        <source>Lobby chat</source>
+        <translation>Чат лобби</translation>
+    </message>
+    <message>
+        <location filename="../lobby/lobby_moc.ui" line="194"/>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_lobby_moc.h" line="291"/>
         <source>Session</source>
-        <translation type="unfinished"></translation>
+        <translation>Сессия</translation>
     </message>
     <message>
-        <location filename="../lobby/lobby_moc.ui" line="116"/>
+        <location filename="../lobby/lobby_moc.ui" line="199"/>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_lobby_moc.h" line="293"/>
         <source>Players</source>
-        <translation type="unfinished"></translation>
+        <translation>Игроки</translation>
     </message>
     <message>
-        <location filename="../lobby/lobby_moc.ui" line="132"/>
+        <location filename="../lobby/lobby_moc.ui" line="274"/>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_lobby_moc.h" line="299"/>
+        <source>Resolve</source>
+        <translation>Скорректировать</translation>
+    </message>
+    <message>
+        <location filename="../lobby/lobby_moc.ui" line="286"/>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_lobby_moc.h" line="300"/>
+        <source>New game</source>
+        <translation>Новая игра</translation>
+    </message>
+    <message>
+        <location filename="../lobby/lobby_moc.ui" line="293"/>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_lobby_moc.h" line="301"/>
+        <source>Load game</source>
+        <translation>Загрузить игру</translation>
+    </message>
+    <message>
+        <location filename="../lobby/lobby_moc.ui" line="149"/>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_lobby_moc.h" line="288"/>
         <source>New room</source>
-        <translation type="unfinished"></translation>
+        <translation>Создать комнату</translation>
     </message>
     <message>
-        <location filename="../lobby/lobby_moc.ui" line="142"/>
+        <location filename="../lobby/lobby_moc.ui" line="159"/>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_lobby_moc.h" line="289"/>
         <source>Join room</source>
-        <translation type="unfinished"></translation>
+        <translation>Присоединиться к комнате</translation>
     </message>
     <message>
-        <location filename="../lobby/lobby_moc.ui" line="153"/>
+        <location filename="../lobby/lobby_moc.ui" line="267"/>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_lobby_moc.h" line="298"/>
         <source>Ready</source>
-        <translation type="unfinished"></translation>
+        <translation>Готово</translation>
     </message>
     <message>
-        <location filename="../lobby/lobby_moc.ui" line="160"/>
+        <location filename="../lobby/lobby_moc.ui" line="250"/>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_lobby_moc.h" line="297"/>
         <source>Mods mismatch</source>
-        <translation type="unfinished"></translation>
+        <translation>Моды не совпадают</translation>
     </message>
     <message>
-        <location filename="../lobby/lobby_moc.ui" line="167"/>
+        <location filename="../lobby/lobby_moc.ui" line="243"/>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_lobby_moc.h" line="296"/>
         <source>Leave</source>
-        <translation type="unfinished"></translation>
+        <translation>Выйти</translation>
     </message>
     <message>
-        <location filename="../lobby/lobby_moc.ui" line="197"/>
+        <location filename="../lobby/lobby_moc.ui" line="216"/>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_lobby_moc.h" line="294"/>
         <source>Kick player</source>
-        <translation type="unfinished"></translation>
+        <translation>Выгнать игрока</translation>
     </message>
     <message>
-        <location filename="../lobby/lobby_moc.ui" line="204"/>
+        <location filename="../lobby/lobby_moc.ui" line="236"/>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_lobby_moc.h" line="295"/>
         <source>Players in the room</source>
-        <translation type="unfinished"></translation>
+        <translation>Игроки в комнате</translation>
+    </message>
+    <message>
+        <location filename="../lobby/lobby_moc.cpp" line="369"/>
+        <source>Disconnect</source>
+        <translation>Отключиться</translation>
+    </message>
+    <message>
+        <location filename="../lobby/lobby_moc.cpp" line="461"/>
+        <source>No issues detected</source>
+        <translation>Проблем не обнаружено</translation>
     </message>
 </context>
 <context>
     <name>LobbyRoomRequest</name>
     <message>
         <location filename="../lobby/lobbyroomrequest_moc.ui" line="17"/>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_lobbyroomrequest_moc.h" line="108"/>
         <source>Room settings</source>
-        <translation type="unfinished"></translation>
+        <translation>Настройки комнаты</translation>
     </message>
     <message>
         <location filename="../lobby/lobbyroomrequest_moc.ui" line="32"/>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_lobbyroomrequest_moc.h" line="109"/>
         <source>Room name</source>
-        <translation type="unfinished"></translation>
+        <translation>Название</translation>
     </message>
     <message>
         <location filename="../lobby/lobbyroomrequest_moc.ui" line="42"/>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_lobbyroomrequest_moc.h" line="110"/>
         <source>Maximum players</source>
-        <translation type="unfinished"></translation>
+        <translation>Максимум игроков</translation>
     </message>
     <message>
         <location filename="../lobby/lobbyroomrequest_moc.ui" line="97"/>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_lobbyroomrequest_moc.h" line="112"/>
         <source>Password (optional)</source>
-        <translation type="unfinished"></translation>
+        <translation>Пароль (не обязательно)</translation>
     </message>
 </context>
 <context>
     <name>MainWindow</name>
     <message>
         <location filename="../mainwindow_moc.ui" line="20"/>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_mainwindow_moc.h" line="203"/>
         <source>VCMI Launcher</source>
-        <translation type="unfinished"></translation>
+        <translation>Запуск VCMI</translation>
     </message>
     <message>
-        <location filename="../mainwindow_moc.ui" line="95"/>
+        <location filename="../mainwindow_moc.ui" line="107"/>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_mainwindow_moc.h" line="205"/>
         <source>Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>Параметры</translation>
     </message>
     <message>
-        <location filename="../mainwindow_moc.ui" line="189"/>
+        <location filename="../mainwindow_moc.ui" line="226"/>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_mainwindow_moc.h" line="207"/>
         <source>Map Editor</source>
-        <translation type="unfinished"></translation>
+        <translation>Редактор карт</translation>
     </message>
     <message>
-        <location filename="../mainwindow_moc.ui" line="236"/>
+        <location filename="../mainwindow_moc.ui" line="279"/>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_mainwindow_moc.h" line="208"/>
         <source>Start game</source>
-        <translation type="unfinished"></translation>
+        <translation>Играть</translation>
     </message>
     <message>
-        <location filename="../mainwindow_moc.ui" line="139"/>
+        <location filename="../mainwindow_moc.ui" line="157"/>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_mainwindow_moc.h" line="206"/>
         <source>Lobby</source>
-        <translation type="unfinished"></translation>
+        <translation>Лобби</translation>
     </message>
     <message>
-        <location filename="../mainwindow_moc.ui" line="51"/>
+        <location filename="../mainwindow_moc.ui" line="57"/>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_mainwindow_moc.h" line="204"/>
         <source>Mods</source>
-        <translation type="unfinished"></translation>
+        <translation>Моды</translation>
     </message>
 </context>
 <context>
     <name>UpdateDialog</name>
     <message>
         <location filename="../updatedialog_moc.ui" line="71"/>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_updatedialog_moc.h" line="107"/>
         <source>You have latest version</source>
-        <translation type="unfinished"></translation>
+        <translation>У вас уже последняя версия</translation>
     </message>
     <message>
         <location filename="../updatedialog_moc.ui" line="94"/>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_updatedialog_moc.h" line="109"/>
         <source>Close</source>
-        <translation type="unfinished"></translation>
+        <translation>Закрыть</translation>
     </message>
     <message>
         <location filename="../updatedialog_moc.ui" line="101"/>
+        <location filename="../../out/build/linux-clang-release/launcher/ui_updatedialog_moc.h" line="110"/>
         <source>Check updates on startup</source>
-        <translation type="unfinished"></translation>
+        <translation>Проверять обновления при запуске</translation>
     </message>
 </context>
 </TS>

--- a/mapeditor/CMakeLists.txt
+++ b/mapeditor/CMakeLists.txt
@@ -92,11 +92,6 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 if(TARGET Qt6::Core)
 	qt_wrap_ui(editor_UI_HEADERS ${editor_FORMS})
-	if(ENABLE_TRANSLATIONS)
-		set_source_files_properties(${editor_TS} PROPERTIES OUTPUT_LOCATION ${CMAKE_CURRENT_BINARY_DIR}/translation)
-		# TODO: consider using qt_add_translations: https://doc.qt.io/qt-6/qtlinguist-cmake-qt-add-translations.html
-		qt_add_translation( editor_QM ${editor_TS} )
-	endif()
 else()
 	qt5_wrap_ui(editor_UI_HEADERS ${editor_FORMS})
 	if(ENABLE_TRANSLATIONS)
@@ -110,6 +105,17 @@ if(WIN32)
 endif()
 
 add_executable(vcmieditor WIN32 ${editor_QM} ${editor_SRCS} ${editor_HEADERS} ${editor_UI_HEADERS} ${editor_ICON})
+
+if(TARGET Qt6::Core)
+	if(ENABLE_TRANSLATIONS)
+		set_source_files_properties(${editor_TS} PROPERTIES OUTPUT_LOCATION ${CMAKE_CURRENT_BINARY_DIR}/translation)
+		qt_add_translations(vcmieditor
+			TS_FILES ${editor_TS}
+			QM_FILES_OUTPUT_VARIABLE editor_QM
+			INCLUDE_DIRECTORIES
+				${CMAKE_CURRENT_BINARY_DIR})
+	endif()
+endif()
 
 if(WIN32)
 	set_target_properties(vcmieditor

--- a/mapeditor/translation/russian.ts
+++ b/mapeditor/translation/russian.ts
@@ -6,17 +6,17 @@
     <message>
         <location filename="../inspector/armywidget.ui" line="20"/>
         <source>Army settings</source>
-        <translation type="unfinished"></translation>
+        <translation>Настройки армии</translation>
     </message>
     <message>
         <location filename="../inspector/armywidget.ui" line="162"/>
         <source>Wide formation</source>
-        <translation type="unfinished"></translation>
+        <translation>Расширенная формация</translation>
     </message>
     <message>
         <location filename="../inspector/armywidget.ui" line="290"/>
         <source>Tight formation</source>
-        <translation type="unfinished"></translation>
+        <translation>Суженная формация</translation>
     </message>
 </context>
 <context>
@@ -24,7 +24,7 @@
     <message>
         <location filename="../generatorprogress.ui" line="29"/>
         <source>Generating map</source>
-        <translation type="unfinished"></translation>
+        <translation>Создание карты</translation>
     </message>
 </context>
 <context>
@@ -32,266 +32,266 @@
     <message>
         <location filename="../mainwindow.ui" line="14"/>
         <source>VCMI Map Editor</source>
-        <translation type="unfinished"></translation>
+        <translation>Редактор карт VCMI</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="59"/>
         <source>File</source>
-        <translation type="unfinished"></translation>
+        <translation>Файл</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="68"/>
         <source>Map</source>
-        <translation type="unfinished"></translation>
+        <translation>Карта</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="78"/>
         <source>Edit</source>
-        <translation type="unfinished"></translation>
+        <translation>Правка</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="86"/>
         <source>View</source>
-        <translation type="unfinished"></translation>
+        <translation>Вид</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="94"/>
         <source>Player</source>
-        <translation type="unfinished"></translation>
+        <translation>Игрок</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="274"/>
         <source>Browser</source>
-        <translation type="unfinished"></translation>
+        <translation>Навигатор</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="352"/>
         <source>Inspector</source>
-        <translation type="unfinished"></translation>
+        <translation>Инспектор</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="391"/>
         <source>Property</source>
-        <translation type="unfinished"></translation>
+        <translation>Свойство</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="396"/>
         <source>Value</source>
-        <translation type="unfinished"></translation>
+        <translation>Значение</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="472"/>
         <source>Brush</source>
-        <translation type="unfinished"></translation>
+        <translation>Кисть</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="747"/>
         <source>Terrains</source>
-        <translation type="unfinished"></translation>
+        <translation>Земли</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="790"/>
         <source>Roads</source>
-        <translation type="unfinished"></translation>
+        <translation>Дороги</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="826"/>
         <source>Rivers</source>
-        <translation type="unfinished"></translation>
+        <translation>Реки</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="873"/>
         <source>Open</source>
-        <translation type="unfinished"></translation>
+        <translation>Открыть</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="885"/>
         <source>Save</source>
-        <translation type="unfinished"></translation>
+        <translation>Сохранить</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="897"/>
         <source>New</source>
-        <translation type="unfinished"></translation>
+        <translation>Создать</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="905"/>
         <source>Save as</source>
-        <translation type="unfinished"></translation>
+        <translation>Сохранить как</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="908"/>
         <source>Ctrl+Shift+S</source>
-        <translation type="unfinished"></translation>
+        <translation>Ctrl+Shift+S</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="917"/>
         <source>U/G</source>
-        <translation type="unfinished"></translation>
+        <translation>П/Н</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="920"/>
         <location filename="../mainwindow.cpp" line="731"/>
         <source>View underground</source>
-        <translation type="unfinished"></translation>
+        <translation>Вид на подземелье</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="935"/>
         <source>Pass</source>
-        <translation type="unfinished"></translation>
+        <translation>Проходимость</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="947"/>
         <source>Cut</source>
-        <translation type="unfinished"></translation>
+        <translation>Вырезать</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="959"/>
         <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <translation>Копировать</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="971"/>
         <source>Paste</source>
-        <translation type="unfinished"></translation>
+        <translation>Вставить</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="983"/>
         <source>Fill</source>
-        <translation type="unfinished"></translation>
+        <translation>Заливка</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="986"/>
         <source>Fills the selection with obstacles</source>
-        <translation type="unfinished"></translation>
+        <translation>Заливает выбранное препятствиями</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="1001"/>
         <source>Grid</source>
-        <translation type="unfinished"></translation>
+        <translation>Сетка</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="1012"/>
         <source>General</source>
-        <translation type="unfinished"></translation>
+        <translation>Общее</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="1015"/>
         <source>Map title and description</source>
-        <translation type="unfinished"></translation>
+        <translation>Название и описание карты</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="1026"/>
         <source>Players settings</source>
-        <translation type="unfinished"></translation>
+        <translation>Настройки игроков</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="1041"/>
         <location filename="../mainwindow.ui" line="1044"/>
         <source>Undo</source>
-        <translation type="unfinished"></translation>
+        <translation>Отменить</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="1062"/>
         <source>Redo</source>
-        <translation type="unfinished"></translation>
+        <translation>Повторить</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="1080"/>
         <source>Erase</source>
-        <translation type="unfinished"></translation>
+        <translation>Удалить</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="1091"/>
         <source>Neutral</source>
-        <translation type="unfinished"></translation>
+        <translation>Нейтральный</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="1099"/>
         <source>Validate</source>
-        <translation type="unfinished"></translation>
+        <translation>Проверить</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="1110"/>
         <source>Update appearance</source>
-        <translation type="unfinished"></translation>
+        <translation>Обновить вид</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="1121"/>
         <source>Recreate obstacles</source>
-        <translation type="unfinished"></translation>
+        <translation>Обновить препятствия</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="1132"/>
         <source>Player 1</source>
-        <translation type="unfinished"></translation>
+        <translation>Игрок 1</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="1143"/>
         <source>Player 2</source>
-        <translation type="unfinished"></translation>
+        <translation>Игрок 2</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="1154"/>
         <source>Player 3</source>
-        <translation type="unfinished"></translation>
+        <translation>Игрок 3</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="1165"/>
         <source>Player 4</source>
-        <translation type="unfinished"></translation>
+        <translation>Игрок 4</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="1176"/>
         <source>Player 5</source>
-        <translation type="unfinished"></translation>
+        <translation>Игрок 5</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="1187"/>
         <source>Player 6</source>
-        <translation type="unfinished"></translation>
+        <translation>Игрок 6</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="1198"/>
         <source>Player 7</source>
-        <translation type="unfinished"></translation>
+        <translation>Игрок 7</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="1209"/>
         <source>Player 8</source>
-        <translation type="unfinished"></translation>
+        <translation>Игрок 8</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="331"/>
         <source>Open map</source>
-        <translation type="unfinished"></translation>
+        <translation>Открыть карту</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="333"/>
         <source>All supported maps (*.vmap *.h3m);;VCMI maps(*.vmap);;HoMM3 maps(*.h3m)</source>
-        <translation type="unfinished"></translation>
+        <translation>Все поддерживаемые карты  (*.vmap *.h3m);;Карты VCMI (*.vmap);;Карты Героев III (*.h3m)</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="382"/>
         <location filename="../mainwindow.cpp" line="409"/>
         <source>Save map</source>
-        <translation type="unfinished"></translation>
+        <translation>Сохранить карту</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="382"/>
         <location filename="../mainwindow.cpp" line="409"/>
         <source>VCMI maps (*.vmap)</source>
-        <translation type="unfinished"></translation>
+        <translation>Карты VCMI (*.vmap)</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="567"/>
         <source>Type</source>
-        <translation type="unfinished"></translation>
+        <translation>Тип</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="735"/>
         <source>View surface</source>
-        <translation type="unfinished"></translation>
+        <translation>Вид на поверхность</translation>
     </message>
 </context>
 <context>
@@ -299,47 +299,47 @@
     <message>
         <location filename="../mapsettings.ui" line="23"/>
         <source>Map settings</source>
-        <translation type="unfinished"></translation>
+        <translation>Настройки карты</translation>
     </message>
     <message>
         <location filename="../mapsettings.ui" line="33"/>
         <source>General</source>
-        <translation type="unfinished"></translation>
+        <translation>Общее</translation>
     </message>
     <message>
         <location filename="../mapsettings.ui" line="39"/>
         <source>Map name</source>
-        <translation type="unfinished"></translation>
+        <translation>Название карты</translation>
     </message>
     <message>
         <location filename="../mapsettings.ui" line="49"/>
         <source>Map description</source>
-        <translation type="unfinished"></translation>
+        <translation>Описание карты</translation>
     </message>
     <message>
         <location filename="../mapsettings.ui" line="60"/>
         <source>Abilities</source>
-        <translation type="unfinished"></translation>
+        <translation>Способности</translation>
     </message>
     <message>
         <location filename="../mapsettings.ui" line="86"/>
         <source>Spells</source>
-        <translation type="unfinished"></translation>
+        <translation>Заклинания</translation>
     </message>
     <message>
         <location filename="../mapsettings.ui" line="112"/>
         <source>Artifacts</source>
-        <translation type="unfinished"></translation>
+        <translation>Артефакты</translation>
     </message>
     <message>
         <location filename="../mapsettings.ui" line="138"/>
         <source>Heroes</source>
-        <translation type="unfinished"></translation>
+        <translation>Герои</translation>
     </message>
     <message>
         <location filename="../mapsettings.ui" line="167"/>
         <source>Ok</source>
-        <translation type="unfinished"></translation>
+        <translation>ОК</translation>
     </message>
 </context>
 <context>
@@ -347,7 +347,7 @@
     <message>
         <location filename="../inspector/messagewidget.ui" line="20"/>
         <source>Message</source>
-        <translation type="unfinished"></translation>
+        <translation>Сообщение</translation>
     </message>
 </context>
 <context>
@@ -355,47 +355,47 @@
     <message>
         <location filename="../playerparams.ui" line="57"/>
         <source>No team</source>
-        <translation type="unfinished"></translation>
+        <translation>Без команды</translation>
     </message>
     <message>
         <location filename="../playerparams.ui" line="65"/>
         <source>Human/CPU</source>
-        <translation type="unfinished"></translation>
+        <translation>Человек/ИИ</translation>
     </message>
     <message>
         <location filename="../playerparams.ui" line="72"/>
         <source>CPU only</source>
-        <translation type="unfinished"></translation>
+        <translation>Только ИИ</translation>
     </message>
     <message>
         <location filename="../playerparams.ui" line="79"/>
         <source>Team</source>
-        <translation type="unfinished"></translation>
+        <translation>Команда</translation>
     </message>
     <message>
         <location filename="../playerparams.ui" line="86"/>
         <source>Main town</source>
-        <translation type="unfinished"></translation>
+        <translation>Главный город</translation>
     </message>
     <message>
         <location filename="../playerparams.ui" line="93"/>
         <source>Random faction</source>
-        <translation type="unfinished"></translation>
+        <translation>Случайная фракция</translation>
     </message>
     <message>
         <location filename="../playerparams.ui" line="100"/>
         <source>Generate hero at main</source>
-        <translation type="unfinished"></translation>
+        <translation>Создать героя</translation>
     </message>
     <message>
         <location filename="../playerparams.ui" line="108"/>
         <source>(default)</source>
-        <translation type="unfinished"></translation>
+        <translation>(по умолчанию)</translation>
     </message>
     <message>
         <location filename="../playerparams.cpp" line="86"/>
         <source>Player ID: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Игрок: %1</translation>
     </message>
 </context>
 <context>
@@ -403,17 +403,17 @@
     <message>
         <location filename="../playersettings.ui" line="20"/>
         <source>Player settings</source>
-        <translation type="unfinished"></translation>
+        <translation>Настройки игрока</translation>
     </message>
     <message>
         <location filename="../playersettings.ui" line="63"/>
         <source>Players</source>
-        <translation type="unfinished"></translation>
+        <translation>Игрок</translation>
     </message>
     <message>
         <location filename="../playersettings.ui" line="112"/>
         <source>Ok</source>
-        <translation type="unfinished"></translation>
+        <translation>ОК</translation>
     </message>
 </context>
 <context>
@@ -421,7 +421,7 @@
     <message>
         <location filename="../inspector/questwidget.ui" line="14"/>
         <source>Mission goal</source>
-        <translation type="unfinished"></translation>
+        <translation>Цель миссии</translation>
     </message>
 </context>
 <context>
@@ -429,22 +429,22 @@
     <message>
         <location filename="../inspector/rewardswidget.ui" line="14"/>
         <source>Rewards</source>
-        <translation type="unfinished"></translation>
+        <translation>Награды</translation>
     </message>
     <message>
         <location filename="../inspector/rewardswidget.ui" line="20"/>
         <source>Remove selected</source>
-        <translation type="unfinished"></translation>
+        <translation>Удалить выбранное</translation>
     </message>
     <message>
         <location filename="../inspector/rewardswidget.ui" line="40"/>
         <source>Delete all</source>
-        <translation type="unfinished"></translation>
+        <translation>Удалить все</translation>
     </message>
     <message>
         <location filename="../inspector/rewardswidget.ui" line="47"/>
         <source>Add or change</source>
-        <translation type="unfinished"></translation>
+        <translation>Добавить/Изменить</translation>
     </message>
 </context>
 <context>
@@ -452,7 +452,7 @@
     <message>
         <location filename="../inspector/townbulidingswidget.ui" line="26"/>
         <source>Buildings</source>
-        <translation type="unfinished"></translation>
+        <translation>Постройки</translation>
     </message>
 </context>
 <context>
@@ -460,12 +460,12 @@
     <message>
         <location filename="../validator.ui" line="17"/>
         <source>Map validation results</source>
-        <translation type="unfinished"></translation>
+        <translation>Результаты проверки карты</translation>
     </message>
     <message>
         <location filename="../validator.cpp" line="101"/>
         <source>Town %1 has undefined owner %2</source>
-        <translation type="unfinished"></translation>
+        <translation>У города %1 неопределенный владелец %2</translation>
     </message>
 </context>
 <context>
@@ -473,67 +473,67 @@
     <message>
         <location filename="../windownewmap.ui" line="32"/>
         <source>Create new map</source>
-        <translation type="unfinished"></translation>
+        <translation>Создание новой карты</translation>
     </message>
     <message>
         <location filename="../windownewmap.ui" line="47"/>
         <source>Map size</source>
-        <translation type="unfinished"></translation>
+        <translation>Размер</translation>
     </message>
     <message>
         <location filename="../windownewmap.ui" line="62"/>
         <source>Two level map</source>
-        <translation type="unfinished"></translation>
+        <translation>Двухуровневая</translation>
     </message>
     <message>
         <location filename="../windownewmap.ui" line="82"/>
         <source>Height</source>
-        <translation type="unfinished"></translation>
+        <translation>Высота</translation>
     </message>
     <message>
         <location filename="../windownewmap.ui" line="114"/>
         <source>Width</source>
-        <translation type="unfinished"></translation>
+        <translation>Ширина</translation>
     </message>
     <message>
         <location filename="../windownewmap.ui" line="152"/>
         <source>S (36x36)</source>
-        <translation type="unfinished"></translation>
+        <translation>Мал. (36x36)</translation>
     </message>
     <message>
         <location filename="../windownewmap.ui" line="157"/>
         <source>M (72x72)</source>
-        <translation type="unfinished"></translation>
+        <translation>Ср. (72x72)</translation>
     </message>
     <message>
         <location filename="../windownewmap.ui" line="162"/>
         <source>L (108x108)</source>
-        <translation type="unfinished"></translation>
+        <translation>Бол. (108x108)</translation>
     </message>
     <message>
         <location filename="../windownewmap.ui" line="167"/>
         <source>XL (144x144)</source>
-        <translation type="unfinished"></translation>
+        <translation>Гиг. (144x144)</translation>
     </message>
     <message>
         <location filename="../windownewmap.ui" line="193"/>
         <source>Random map</source>
-        <translation type="unfinished"></translation>
+        <translation>Случайная карта</translation>
     </message>
     <message>
         <location filename="../windownewmap.ui" line="205"/>
         <source>Players</source>
-        <translation type="unfinished"></translation>
+        <translation>Игроки</translation>
     </message>
     <message>
         <location filename="../windownewmap.ui" line="736"/>
         <source>0</source>
-        <translation type="unfinished"></translation>
+        <translation>0</translation>
     </message>
     <message>
         <location filename="../windownewmap.ui" line="268"/>
         <source>Human/Computer</source>
-        <translation type="unfinished"></translation>
+        <translation>Человек/ИИ</translation>
     </message>
     <message>
         <location filename="../windownewmap.ui" line="288"/>
@@ -541,73 +541,73 @@
         <location filename="../windownewmap.ui" line="455"/>
         <location filename="../windownewmap.ui" line="596"/>
         <source>Random</source>
-        <translation type="unfinished"></translation>
+        <translation>Случайно</translation>
     </message>
     <message>
         <location filename="../windownewmap.ui" line="336"/>
         <source>Computer only</source>
-        <translation type="unfinished"></translation>
+        <translation>Только ИИ</translation>
     </message>
     <message>
         <location filename="../windownewmap.ui" line="428"/>
         <source>Monster strength</source>
-        <translation type="unfinished"></translation>
+        <translation>Сила монстров</translation>
     </message>
     <message>
         <location filename="../windownewmap.ui" line="477"/>
         <source>Weak</source>
-        <translation type="unfinished"></translation>
+        <translation>Слабо</translation>
     </message>
     <message>
         <location filename="../windownewmap.ui" line="496"/>
         <location filename="../windownewmap.ui" line="637"/>
         <source>Normal</source>
-        <translation type="unfinished"></translation>
+        <translation>Нормально</translation>
     </message>
     <message>
         <location filename="../windownewmap.ui" line="515"/>
         <source>Strong</source>
-        <translation type="unfinished"></translation>
+        <translation>Сильно</translation>
     </message>
     <message>
         <location filename="../windownewmap.ui" line="569"/>
         <source>Water content</source>
-        <translation type="unfinished"></translation>
+        <translation>Вода</translation>
     </message>
     <message>
         <location filename="../windownewmap.ui" line="618"/>
         <source>None</source>
-        <translation type="unfinished"></translation>
+        <translation>Нет</translation>
     </message>
     <message>
         <location filename="../windownewmap.ui" line="656"/>
         <source>Islands</source>
-        <translation type="unfinished"></translation>
+        <translation>Острова</translation>
     </message>
     <message>
         <location filename="../windownewmap.ui" line="701"/>
         <source>Template</source>
-        <translation type="unfinished"></translation>
+        <translation>Шаблон</translation>
     </message>
     <message>
         <location filename="../windownewmap.ui" line="749"/>
         <source>Custom seed</source>
-        <translation type="unfinished"></translation>
+        <translation>Пользовательское зерно</translation>
     </message>
     <message>
         <location filename="../windownewmap.ui" line="763"/>
         <source>Generate random map</source>
-        <translation type="unfinished"></translation>
+        <translation>Сгенерировать случайную карту</translation>
     </message>
     <message>
         <location filename="../windownewmap.ui" line="797"/>
         <source>Ok</source>
-        <translation type="unfinished"></translation>
+        <translation>ОК</translation>
     </message>
     <message>
         <location filename="../windownewmap.ui" line="816"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Отмена</translation>
     </message>
 </context>
 <context>
@@ -615,27 +615,27 @@
     <message>
         <location filename="../mainwindow.cpp" line="95"/>
         <source>Filepath of the map to open.</source>
-        <translation type="unfinished"></translation>
+        <translation>Путь к файлу карты для открытия.</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="98"/>
         <source>Extract original H3 archives into a separate folder.</source>
-        <translation type="unfinished"></translation>
+        <translation>Распаковать архивы оригинальных Героев III в отдельную папку.</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="99"/>
         <source>From an extracted archive, it Splits TwCrPort, CPRSMALL, FlagPort, ITPA, ITPt, Un32 and Un44 into individual PNG&apos;s.</source>
-        <translation type="unfinished"></translation>
+        <translation>Разделение в распакованном архиве TwCrPort, CPRSMALL, FlagPort, ITPA, ITPt, Un32 и Un44 на отдельные PNG.</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="100"/>
         <source>From an extracted archive, Converts single Images (found in Images folder) from .pcx to png.</source>
-        <translation type="unfinished"></translation>
+        <translation>Преобразование в расспакованном архиве изображений .pcx в .png.</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="101"/>
         <source>Delete original files, for the ones splitted / converted.</source>
-        <translation type="unfinished"></translation>
+        <translation>Удалить оригиналы для преобразованных файлов.</translation>
     </message>
 </context>
 </TS>


### PR DESCRIPTION
Russian translation for launcher and mapeditor.
Small changes to CMakeLists.txt to make generating of translations easier on Qt 6.