### PR TITLE
vcmi: deprecate MAXED_SPELL

### DIFF
--- a/config/heroes/tower.json
+++ b/config/heroes/tower.json
@@ -213,8 +213,9 @@
 		"specialty" : {
 			"bonuses" : {
 				"fortune" : {
+					"addInfo" : 3,
 					"subtype" : "spell.fortune",
-					"type" : "MAXED_SPELL"
+					"type" : "SPECIAL_FIXED_VALUE_ENCHANT"
 				}
 			}
 		}

--- a/lib/CHeroHandler.cpp
+++ b/lib/CHeroHandler.cpp
@@ -611,8 +611,9 @@ std::vector<std::shared_ptr<Bonus>> SpecialtyInfoToBonuses(const SSpecialtyInfo 
 		result.push_back(bonus);
 		break;
 	case 7: //maxed mastery for spell
-		bonus->type = Bonus::MAXED_SPELL;
+		bonus->type = Bonus::SPECIAL_FIXED_VALUE_ENCHANT;
 		bonus->subtype = spec.subtype; //spell id
+		bonus->val = 3; //to match MAXED_BONUS
 		result.push_back(bonus);
 		break;
 	case 8: //peculiar spells - enchantments

--- a/lib/HeroBonus.h
+++ b/lib/HeroBonus.h
@@ -285,7 +285,7 @@ public:
 	BONUS_NAME(SPELL_DAMAGE) /*val = value*/\
 	BONUS_NAME(SPECIFIC_SPELL_DAMAGE) /*subtype = id of spell, val = value*/\
 	BONUS_NAME(SPECIAL_BLESS_DAMAGE) /*val = spell (bless), additionalInfo = value per level in percent*/\
-	BONUS_NAME(MAXED_SPELL) /*val = id*/\
+	BONUS_NAME(MAXED_SPELL) /*val = id. deprecated in favour of SPECIAL_FIXED_VALUE_ENCHANT*/\
 	BONUS_NAME(SPECIAL_PECULIAR_ENCHANT) /*blesses and curses with id = val dependent on unit's level, subtype = 0 or 1 for Coronius*/\
 	BONUS_NAME(SPECIAL_UPGRADE) /*subtype = base, additionalInfo = target */\
 	BONUS_NAME(DRAGON_NATURE) \

--- a/lib/mapObjects/CGHeroInstance.cpp
+++ b/lib/mapObjects/CGHeroInstance.cpp
@@ -647,10 +647,7 @@ int64_t CGHeroInstance::getSpecificSpellBonus(const spells::Spell * spell, int64
 
 int32_t CGHeroInstance::getEffectLevel(const spells::Spell * spell) const
 {
-	if(hasBonusOfType(Bonus::MAXED_SPELL, spell->getIndex()))
-		return 3;//todo: recheck specialty from where this bonus is. possible bug
-	else
-		return getSpellSchoolLevel(spell);
+	return getSpellSchoolLevel(spell);
 }
 
 int32_t CGHeroInstance::getEffectPower(const spells::Spell * spell) const


### PR DESCRIPTION
It is almost identical to SPECIAL_FIXED_VALUE_ENCHANT.

Replace its usage in JSON and inside deprecated converter to SPECIAL_FIXED_VALUE_ENCHANT. Remove buggy string inside getEffectLevel.

This is a variant of #1519 without removing savegame compatibility.