### PR TITLE
SDL usage cleanup

### DIFF
--- a/Global.h
+++ b/Global.h
@@ -726,17 +726,18 @@ namespace vstd
 	}
 
 	/// converts number into string using metric system prefixes, e.g. 'k' or 'M' to keep resulting strings within specified size
-	template<typename IntType>
-	std::string formatMetric(IntType number, int maxLength)
+	/// Note that resulting string may have more symbols than digits: minus sign and prefix symbol
+	template<typename Arithmetic>
+	std::string formatMetric(Arithmetic number, int maxDigits)
 	{
-		IntType max = pow(10, maxLength);
+		Arithmetic max = std::pow(10, maxDigits);
 		if (std::abs(number) < max)
-			return boost::lexical_cast<std::string>(number);
+			return std::to_string(number);
 
 		std::string symbols = " kMGTPE";
 		auto iter = symbols.begin();
 
-		while (number >= max)
+		while (std::abs(number) >= max)
 		{
 			number /= 1000;
 			iter++;
@@ -745,8 +746,6 @@ namespace vstd
 		}
 		return std::to_string(number) + *iter;
 	}
-
-	using boost::math::round;
 }
 using vstd::operator-=;
 

--- a/Global.h
+++ b/Global.h
@@ -725,6 +725,27 @@ namespace vstd
 		return a + (b - a) * f;
 	}
 
+	/// converts number into string using metric system prefixes, e.g. 'k' or 'M' to keep resulting strings within specified size
+	template<typename IntType>
+	std::string formatMetric(IntType number, int maxLength)
+	{
+		IntType max = pow(10, maxLength);
+		if (std::abs(number) < max)
+			return boost::lexical_cast<std::string>(number);
+
+		std::string symbols = " kMGTPE";
+		auto iter = symbols.begin();
+
+		while (number >= max)
+		{
+			number /= 1000;
+			iter++;
+
+			assert(iter != symbols.end());//should be enough even for int64
+		}
+		return std::to_string(number) + *iter;
+	}
+
 	using boost::math::round;
 }
 using vstd::operator-=;

--- a/client/CVideoHandler.cpp
+++ b/client/CVideoHandler.cpp
@@ -10,6 +10,7 @@
 #include "StdInc.h"
 #include "CVideoHandler.h"
 
+#include "CMT.h"
 #include "gui/CGuiHandler.h"
 #include "renderSDL/SDL_Extensions.h"
 #include "CPlayerInterface.h"

--- a/client/adventureMap/CAdvMapInt.cpp
+++ b/client/adventureMap/CAdvMapInt.cpp
@@ -43,8 +43,6 @@
 #include "../../lib/UnlockGuard.h"
 #include "../../lib/TerrainHandler.h"
 
-#include <SDL_surface.h>
-
 #define ADVOPT (conf.go()->ac)
 
 std::shared_ptr<CAdvMapInt> adventureInt;
@@ -90,8 +88,8 @@ CAdvMapInt::CAdvMapInt():
 	swipeTargetPosition(int3(-1, -1, -1))
 {
 	pos.x = pos.y = 0;
-	pos.w = screen->w;
-	pos.h = screen->h;
+	pos.w = GH.screenDimensions().x;
+	pos.h = GH.screenDimensions().y;
 	strongInterest = true; // handle all mouse move events to prevent dead mouse move space in fullscreen mode
 	townList.onSelect = std::bind(&CAdvMapInt::selectionChanged,this);
 	bg = IImage::createFromFile(ADVOPT.mainGraphic);
@@ -137,7 +135,7 @@ CAdvMapInt::CAdvMapInt():
 	nextHero     = makeButton(301, std::bind(&CAdvMapInt::fnextHero,this),         ADVOPT.nextHero,     SDLK_h);
 	endTurn      = makeButton(302, std::bind(&CAdvMapInt::fendTurn,this),          ADVOPT.endTurn,      SDLK_e);
 
-	int panelSpaceBottom = screen->h - resdatabar.pos.h - 4;
+	int panelSpaceBottom = GH.screenDimensions().y - resdatabar.pos.h - 4;
 
 	panelMain = std::make_shared<CAdvMapPanel>(nullptr, Point(0, 0));
 	// TODO correct drawing position
@@ -158,7 +156,7 @@ CAdvMapInt::CAdvMapInt():
 	// TODO move configs to resolutions.json, similarly to previous buttons
 	config::ButtonInfo worldViewBackConfig = config::ButtonInfo();
 	worldViewBackConfig.defName = "IOK6432.DEF";
-	worldViewBackConfig.x = screen->w - 73;
+	worldViewBackConfig.x = GH.screenDimensions().x - 73;
 	worldViewBackConfig.y = 343 + 195;
 	worldViewBackConfig.playerColoured = false;
 	panelWorldView->addChildToPanel(
@@ -166,7 +164,7 @@ CAdvMapInt::CAdvMapInt():
 
 	config::ButtonInfo worldViewPuzzleConfig = config::ButtonInfo();
 	worldViewPuzzleConfig.defName = "VWPUZ.DEF";
-	worldViewPuzzleConfig.x = screen->w - 188;
+	worldViewPuzzleConfig.x = GH.screenDimensions().x - 188;
 	worldViewPuzzleConfig.y = 343 + 195;
 	worldViewPuzzleConfig.playerColoured = false;
 	panelWorldView->addChildToPanel( // no help text for this one
@@ -175,7 +173,7 @@ CAdvMapInt::CAdvMapInt():
 
 	config::ButtonInfo worldViewScale1xConfig = config::ButtonInfo();
 	worldViewScale1xConfig.defName = "VWMAG1.DEF";
-	worldViewScale1xConfig.x = screen->w - 191;
+	worldViewScale1xConfig.x = GH.screenDimensions().x - 191;
 	worldViewScale1xConfig.y = 23 + 195;
 	worldViewScale1xConfig.playerColoured = false;
 	panelWorldView->addChildToPanel( // help text is wrong for this button
@@ -183,7 +181,7 @@ CAdvMapInt::CAdvMapInt():
 
 	config::ButtonInfo worldViewScale2xConfig = config::ButtonInfo();
 	worldViewScale2xConfig.defName = "VWMAG2.DEF";
-	worldViewScale2xConfig.x = screen->w - 191 + 63;
+	worldViewScale2xConfig.x = GH.screenDimensions().x- 191 + 63;
 	worldViewScale2xConfig.y = 23 + 195;
 	worldViewScale2xConfig.playerColoured = false;
 	panelWorldView->addChildToPanel( // help text is wrong for this button
@@ -191,7 +189,7 @@ CAdvMapInt::CAdvMapInt():
 
 	config::ButtonInfo worldViewScale4xConfig = config::ButtonInfo();
 	worldViewScale4xConfig.defName = "VWMAG4.DEF";
-	worldViewScale4xConfig.x = screen->w - 191 + 126;
+	worldViewScale4xConfig.x = GH.screenDimensions().x- 191 + 126;
 	worldViewScale4xConfig.y = 23 + 195;
 	worldViewScale4xConfig.playerColoured = false;
 	panelWorldView->addChildToPanel( // help text is wrong for this button
@@ -200,7 +198,7 @@ CAdvMapInt::CAdvMapInt():
 	config::ButtonInfo worldViewUndergroundConfig = config::ButtonInfo();
 	worldViewUndergroundConfig.defName = "IAM010.DEF";
 	worldViewUndergroundConfig.additionalDefs.push_back("IAM003.DEF");
-	worldViewUndergroundConfig.x = screen->w - 115;
+	worldViewUndergroundConfig.x = GH.screenDimensions().x - 115;
 	worldViewUndergroundConfig.y = 343 + 195;
 	worldViewUndergroundConfig.playerColoured = true;
 	worldViewUnderground = makeButton(294, std::bind(&CAdvMapInt::fswitchLevel,this), worldViewUndergroundConfig, SDLK_u);
@@ -1019,7 +1017,7 @@ void CAdvMapInt::mouseMoved( const Point & cursorPosition )
 		{
 			scrollingDir &= ~LEFT;
 		}
-		if(cursorPosition.x>screen->w-15)
+		if(cursorPosition.x > GH.screenDimensions().x - 15)
 		{
 			scrollingDir |= RIGHT;
 		}
@@ -1035,7 +1033,7 @@ void CAdvMapInt::mouseMoved( const Point & cursorPosition )
 		{
 			scrollingDir &= ~UP;
 		}
-		if(cursorPosition.y>screen->h-15)
+		if(cursorPosition.y > GH.screenDimensions().y - 15)
 		{
 			scrollingDir |= DOWN;
 		}

--- a/client/adventureMap/CResDataBar.cpp
+++ b/client/adventureMap/CResDataBar.cpp
@@ -45,8 +45,6 @@ CResDataBar::CResDataBar(const std::string & defname, int x, int y, int offx, in
 		txtpos[i].second = pos.y + offy;
 	}
 	txtpos[7].first = txtpos[6].first + datedist;
-	datetext =  CGI->generaltexth->allTexts[62]+": %s, " + CGI->generaltexth->allTexts[63]
-	+ ": %s, " + CGI->generaltexth->allTexts[64] + ": %s";
 	addUsedEvents(RCLICK);
 }
 
@@ -69,11 +67,22 @@ CResDataBar::CResDataBar()
 		txtpos[i].second = pos.y + ADVOPT.resOffsetY;
 	}
 	txtpos[7].first = txtpos[6].first + ADVOPT.resDateDist;
-	datetext =  CGI->generaltexth->allTexts[62]+": %s, " + CGI->generaltexth->allTexts[63]
-				+ ": %s, " + CGI->generaltexth->allTexts[64] + ": %s";
+
 }
 
 CResDataBar::~CResDataBar() = default;
+
+std::string CResDataBar::buildDateString()
+{
+	std::string pattern = "%s: %d, %s: %d, %s: %d";
+
+	auto formatted = boost::format(pattern)
+		% CGI->generaltexth->allTexts[62] % LOCPLINT->cb->getDate(Date::MONTH)
+		% CGI->generaltexth->allTexts[63] % LOCPLINT->cb->getDate(Date::WEEK)
+		% CGI->generaltexth->allTexts[64] % LOCPLINT->cb->getDate(Date::DAY_OF_WEEK);
+
+	return boost::str(formatted);
+}
 
 void CResDataBar::draw(SDL_Surface * to)
 {
@@ -84,13 +93,7 @@ void CResDataBar::draw(SDL_Surface * to)
 
 		graphics->fonts[FONT_SMALL]->renderTextLeft(to, text, Colors::WHITE, Point(txtpos[i].first,txtpos[i].second));
 	}
-	std::vector<std::string> temp;
-
-	temp.push_back(boost::lexical_cast<std::string>(LOCPLINT->cb->getDate(Date::MONTH)));
-	temp.push_back(boost::lexical_cast<std::string>(LOCPLINT->cb->getDate(Date::WEEK)));
-	temp.push_back(boost::lexical_cast<std::string>(LOCPLINT->cb->getDate(Date::DAY_OF_WEEK)));
-
-	graphics->fonts[FONT_SMALL]->renderTextLeft(to, CSDL_Ext::processStr(datetext,temp), Colors::WHITE, Point(txtpos[7].first,txtpos[7].second));
+	graphics->fonts[FONT_SMALL]->renderTextLeft(to, buildDateString(), Colors::WHITE, Point(txtpos[7].first,txtpos[7].second));
 }
 
 void CResDataBar::show(SDL_Surface * to)

--- a/client/adventureMap/CResDataBar.cpp
+++ b/client/adventureMap/CResDataBar.cpp
@@ -77,9 +77,9 @@ std::string CResDataBar::buildDateString()
 	std::string pattern = "%s: %d, %s: %d, %s: %d";
 
 	auto formatted = boost::format(pattern)
-		% CGI->generaltexth->allTexts[62] % LOCPLINT->cb->getDate(Date::MONTH)
-		% CGI->generaltexth->allTexts[63] % LOCPLINT->cb->getDate(Date::WEEK)
-		% CGI->generaltexth->allTexts[64] % LOCPLINT->cb->getDate(Date::DAY_OF_WEEK);
+		% CGI->generaltexth->translate("core.genrltxt.62") % LOCPLINT->cb->getDate(Date::MONTH)
+		% CGI->generaltexth->translate("core.genrltxt.63") % LOCPLINT->cb->getDate(Date::WEEK)
+		% CGI->generaltexth->translate("core.genrltxt.64") % LOCPLINT->cb->getDate(Date::DAY_OF_WEEK);
 
 	return boost::str(formatted);
 }
@@ -91,9 +91,9 @@ void CResDataBar::draw(SDL_Surface * to)
 	{
 		std::string text = boost::lexical_cast<std::string>(LOCPLINT->cb->getResourceAmount(i));
 
-		graphics->fonts[FONT_SMALL]->renderTextLeft(to, text, Colors::WHITE, Point(txtpos[i].first,txtpos[i].second));
+		graphics->fonts[FONT_SMALL]->renderTextLeft(to, text, Colors::WHITE, Point(txtpos[i].first, txtpos[i].second));
 	}
-	graphics->fonts[FONT_SMALL]->renderTextLeft(to, buildDateString(), Colors::WHITE, Point(txtpos[7].first,txtpos[7].second));
+	graphics->fonts[FONT_SMALL]->renderTextLeft(to, buildDateString(), Colors::WHITE, Point(txtpos[7].first, txtpos[7].second));
 }
 
 void CResDataBar::show(SDL_Surface * to)

--- a/client/adventureMap/CResDataBar.h
+++ b/client/adventureMap/CResDataBar.h
@@ -15,11 +15,12 @@
 /// Current date is displayed too
 class CResDataBar : public CIntObject
 {
+	std::string buildDateString();
+
 public:
 	std::shared_ptr<CPicture> background;
 
 	std::vector<std::pair<int,int> > txtpos;
-	std::string datetext;
 
 	void clickRight(tribool down, bool previousState) override;
 	CResDataBar();

--- a/client/adventureMap/CTerrainRect.cpp
+++ b/client/adventureMap/CTerrainRect.cpp
@@ -22,6 +22,7 @@
 #include "../render/IImage.h"
 #include "../renderSDL/SDL_Extensions.h"
 #include "../widgets/TextControls.h"
+#include "../CMT.h"
 
 #include "../../CCallback.h"
 #include "../../lib/CConfigHandler.h"

--- a/client/adventureMap/CTerrainRect.cpp
+++ b/client/adventureMap/CTerrainRect.cpp
@@ -277,17 +277,17 @@ void CTerrainRect::showPath(const Rect & extRect, SDL_Surface * to)
 				}
 				else if(hvx<0)
 				{
-					Rect srcRect = CSDL_Ext::genRect(arrow->height() - hvy, arrow->width(), 0, 0);
+					Rect srcRect (Point(0, 0), Point(arrow->height() - hvy, arrow->width()));
 					arrow->draw(to, x + moveX, y + moveY, &srcRect);
 				}
 				else if (hvy<0)
 				{
-					Rect srcRect = CSDL_Ext::genRect(arrow->height(), arrow->width() - hvx, 0, 0);
+					Rect srcRect (Point(0, 0), Point(arrow->height(), arrow->width() - hvx));
 					arrow->draw(to, x + moveX, y + moveY, &srcRect);
 				}
 				else
 				{
-					Rect srcRect = CSDL_Ext::genRect(arrow->height() - hvy, arrow->width() - hvx, 0, 0);
+					Rect srcRect (Point(0, 0), Point(arrow->height() - hvy, arrow->width() - hvx));
 					arrow->draw(to, x + moveX, y + moveY, &srcRect);
 				}
 			}
@@ -299,17 +299,17 @@ void CTerrainRect::showPath(const Rect & extRect, SDL_Surface * to)
 				}
 				else if(hvx<0)
 				{
-					Rect srcRect = CSDL_Ext::genRect(arrow->height() - hvy, arrow->width(), 0, 0);
+					Rect srcRect (Point(0, 0), Point(arrow->height() - hvy, arrow->width()));
 					arrow->draw(to, x, y, &srcRect);
 				}
 				else if (hvy<0)
 				{
-					Rect srcRect = CSDL_Ext::genRect(arrow->height(), arrow->width() - hvx, 0, 0);
+					Rect srcRect (Point(0, 0), Point(arrow->height(), arrow->width() - hvx));
 					arrow->draw(to, x, y, &srcRect);
 				}
 				else
 				{
-					Rect srcRect = CSDL_Ext::genRect(arrow->height() - hvy, arrow->width() - hvx, 0, 0);
+					Rect srcRect (Point(0, 0), Point(arrow->height() - hvy, arrow->width() - hvx));
 					arrow->draw(to, x, y, &srcRect);
 				}
 			}

--- a/client/battle/BattleInterface.cpp
+++ b/client/battle/BattleInterface.cpp
@@ -525,9 +525,9 @@ void BattleInterface::setAnimSpeed(int set)
 int BattleInterface::getAnimSpeed() const
 {
 	if(settings["session"]["spectate"].Bool() && !settings["session"]["spectate-battle-speed"].isNull())
-		return static_cast<int>(vstd::round(settings["session"]["spectate-battle-speed"].Float()));
+		return static_cast<int>(std::round(settings["session"]["spectate-battle-speed"].Float()));
 
-	return static_cast<int>(vstd::round(settings["battle"]["speedFactor"].Float()));
+	return static_cast<int>(std::round(settings["battle"]["speedFactor"].Float()));
 }
 
 CPlayerInterface *BattleInterface::getCurrentPlayerInterface() const

--- a/client/battle/BattleInterfaceClasses.cpp
+++ b/client/battle/BattleInterfaceClasses.cpp
@@ -48,8 +48,6 @@
 #include "../../lib/CondSh.h"
 #include "../../lib/mapObjects/CGTownInstance.h"
 
-#include <SDL_surface.h>
-
 void BattleConsole::showAll(SDL_Surface * to)
 {
 	CIntObject::showAll(to);
@@ -475,9 +473,9 @@ BattleResultWindow::BattleResultWindow(const BattleResult & br, CPlayerInterface
 {
 	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
 
-	pos = CSDL_Ext::genRect(561, 470, (screen->w - 800)/2 + 165, (screen->h - 600)/2 + 19);
 	background = std::make_shared<CPicture>("CPRESULT");
 	background->colorize(owner.playerID);
+	pos = center(background->pos);
 
 	exit = std::make_shared<CButton>(Point(384, 505), "iok6432.def", std::make_pair("", ""), [&](){ bExitf();}, SDLK_RETURN);
 	exit->setBorderColor(Colors::METALLIC_GOLD);
@@ -639,7 +637,7 @@ void BattleResultWindow::activate()
 void BattleResultWindow::show(SDL_Surface * to)
 {
 	CIntObject::show(to);
-	CCS->videoh->update(pos.x + 107, pos.y + 70, screen, true, false);
+	CCS->videoh->update(pos.x + 107, pos.y + 70, to, true, false);
 }
 
 void BattleResultWindow::bExitf()

--- a/client/battle/BattleInterfaceClasses.cpp
+++ b/client/battle/BattleInterfaceClasses.cpp
@@ -789,7 +789,7 @@ void StackQueue::StackBox::setUnit(const battle::Unit * unit, size_t turn)
 		if (unit->unitType()->idNumber == CreatureID::ARROW_TOWERS)
 			icon->setFrame(owner->getSiegeShooterIconID(), 1);
 
-		amount->setText(CSDL_Ext::makeNumberShort(unit->getCount(), 4));
+		amount->setText(vstd::formatMetric(unit->getCount(), 4));
 
 		if(stateIcon)
 		{

--- a/client/battle/BattleStacksController.cpp
+++ b/client/battle/BattleStacksController.cpp
@@ -316,7 +316,7 @@ void BattleStacksController::showStackAmountBox(Canvas & canvas, const CStack * 
 	//blitting amount
 	Point textPos = stackAnimation[stack->ID]->pos.topLeft() + amountBG->dimensions()/2 + Point(xAdd, yAdd);
 
-	canvas.drawText(textPos, EFonts::FONT_TINY, Colors::WHITE, ETextAlignment::CENTER, CSDL_Ext::makeNumberShort(stack->getCount(), 4));
+	canvas.drawText(textPos, EFonts::FONT_TINY, Colors::WHITE, ETextAlignment::CENTER, vstd::formatMetric(stack->getCount(), 4));
 }
 
 void BattleStacksController::showStack(Canvas & canvas, const CStack * stack)

--- a/client/battle/BattleWindow.cpp
+++ b/client/battle/BattleWindow.cpp
@@ -28,7 +28,6 @@
 #include "../render/CAnimation.h"
 #include "../render/Canvas.h"
 #include "../adventureMap/CInGameConsole.h"
-#include "../CMT.h"
 
 #include "../../CCallback.h"
 #include "../../lib/CGeneralTextHandler.h"
@@ -36,8 +35,6 @@
 #include "../../lib/CStack.h"
 #include "../../lib/CConfigHandler.h"
 #include "../../lib/filesystem/ResourceID.h"
-
-#include <SDL_surface.h>
 
 BattleWindow::BattleWindow(BattleInterface & owner):
 	owner(owner)
@@ -79,9 +76,9 @@ BattleWindow::BattleWindow(BattleInterface & owner):
 	std::string queueSize = settings["battle"]["queueSize"].String();
 
 	if(queueSize == "auto")
-		embedQueue = screen->h < 700;
+		embedQueue = GH.screenDimensions().y < 700;
 	else
-		embedQueue = screen->h < 700 || queueSize == "small";
+		embedQueue = GH.screenDimensions().y < 700 || queueSize == "small";
 
 	queue = std::make_shared<StackQueue>(embedQueue, owner);
 	if(!embedQueue && settings["battle"]["showQueue"].Bool())
@@ -562,7 +559,7 @@ void BattleWindow::showAll(SDL_Surface *to)
 {
 	CIntObject::showAll(to);
 
-	if (screen->w != 800 || screen->h !=600)
+	if (GH.screenDimensions().x != 800 || GH.screenDimensions().y !=600)
 		CMessage::drawBorder(owner.curInt->playerID, to, pos.w+28, pos.h+29, pos.x-14, pos.y-15);
 }
 

--- a/client/battle/CreatureAnimation.cpp
+++ b/client/battle/CreatureAnimation.cpp
@@ -312,7 +312,7 @@ void CreatureAnimation::playOnce( ECreatureAnimType type )
 
 inline int getBorderStrength(float time)
 {
-	float borderStrength = fabs(vstd::round(time) - time) * 2; // generate value in range 0-1
+	float borderStrength = fabs(std::round(time) - time) * 2; // generate value in range 0-1
 
 	return static_cast<int>(borderStrength * 155 + 100); // scale to 0-255
 }

--- a/client/gui/CGuiHandler.cpp
+++ b/client/gui/CGuiHandler.cpp
@@ -740,6 +740,11 @@ const Point & CGuiHandler::getCursorPosition() const
 	return cursorPosition;
 }
 
+Point CGuiHandler::screenDimensions() const
+{
+	return return Point(screen->w, screen->h);
+}
+
 bool CGuiHandler::isMouseButtonPressed() const
 {
 	return mouseButtonsMask > 0;

--- a/client/gui/CGuiHandler.cpp
+++ b/client/gui/CGuiHandler.cpp
@@ -742,7 +742,7 @@ const Point & CGuiHandler::getCursorPosition() const
 
 Point CGuiHandler::screenDimensions() const
 {
-	return return Point(screen->w, screen->h);
+	return Point(screen->w, screen->h);
 }
 
 bool CGuiHandler::isMouseButtonPressed() const

--- a/client/gui/CGuiHandler.h
+++ b/client/gui/CGuiHandler.h
@@ -113,6 +113,8 @@ public:
 	/// returns current position of mouse cursor, relative to vcmi window
 	const Point & getCursorPosition() const;
 
+	Point screenDimensions() const;
+
 	/// returns true if at least one mouse button is pressed
 	bool isMouseButtonPressed() const;
 

--- a/client/gui/CIntObject.cpp
+++ b/client/gui/CIntObject.cpp
@@ -13,9 +13,9 @@
 #include "CGuiHandler.h"
 #include "../renderSDL/SDL_Extensions.h"
 #include "../windows/CMessage.h"
+#include "../CMT.h"
 
 #include <SDL_pixels.h>
-#include <SDL_surface.h>
 
 IShowActivatable::IShowActivatable()
 {
@@ -227,8 +227,8 @@ void CIntObject::fitToScreen(int borderWidth, bool propagate)
 	Point newPos = pos.topLeft();
 	vstd::amax(newPos.x, borderWidth);
 	vstd::amax(newPos.y, borderWidth);
-	vstd::amin(newPos.x, screen->w - borderWidth - pos.w);
-	vstd::amin(newPos.y, screen->h - borderWidth - pos.h);
+	vstd::amin(newPos.x, GH.screenDimensions().x - borderWidth - pos.w);
+	vstd::amin(newPos.y, GH.screenDimensions().y - borderWidth - pos.h);
 	if (newPos != pos.topLeft())
 		moveTo(newPos, propagate);
 }
@@ -308,7 +308,7 @@ const Rect & CIntObject::center( const Rect &r, bool propagate )
 {
 	pos.w = r.w;
 	pos.h = r.h;
-	return center(Point(screen->w/2, screen->h/2), propagate);
+	return center(Point(GH.screenDimensions().x/2, GH.screenDimensions().y/2), propagate);
 }
 
 const Rect & CIntObject::center( bool propagate )

--- a/client/gui/CursorHandler.cpp
+++ b/client/gui/CursorHandler.cpp
@@ -17,7 +17,6 @@
 #include "../render/CAnimation.h"
 #include "../render/IImage.h"
 #include "../renderSDL/SDL_Extensions.h"
-#include "../CMT.h"
 
 #include "../../lib/CConfigHandler.h"
 

--- a/client/mainmenu/CMainMenu.cpp
+++ b/client/mainmenu/CMainMenu.cpp
@@ -17,7 +17,6 @@
 #include "../lobby/CSelectionBase.h"
 #include "../lobby/CLobbyScreen.h"
 #include "../gui/CursorHandler.h"
-#include "../CMT.h"
 #include "../windows/GUIClasses.h"
 #include "../gui/CGuiHandler.h"
 #include "../widgets/CComponent.h"
@@ -33,6 +32,7 @@
 #include "../CVideoHandler.h"
 #include "../CPlayerInterface.h"
 #include "../Client.h"
+#include "../CMT.h"
 
 #include "../../CCallback.h"
 
@@ -53,7 +53,6 @@
 #include "../../lib/CondSh.h"
 #include "../../lib/mapping/CCampaignHandler.h"
 
-#include <SDL_surface.h>
 
 namespace fs = boost::filesystem;
 
@@ -72,7 +71,7 @@ CMenuScreen::CMenuScreen(const JsonNode & configNode)
 
 	background = std::make_shared<CPicture>(config["background"].String());
 	if(config["scalable"].Bool())
-		background->scaleTo(Point(screen->w, screen->h));
+		background->scaleTo(GH.screenDimensions());
 
 	pos = background->center();
 
@@ -275,8 +274,8 @@ const JsonNode & CMainMenuConfig::getCampaigns() const
 
 CMainMenu::CMainMenu()
 {
-	pos.w = screen->w;
-	pos.h = screen->h;
+	pos.w = GH.screenDimensions().x;
+	pos.h = GH.screenDimensions().y;
 
 	GH.defActionsDef = 63;
 	menu = std::make_shared<CMenuScreen>(CMainMenuConfig::get().getConfig()["window"]);

--- a/client/renderSDL/CursorSoftware.cpp
+++ b/client/renderSDL/CursorSoftware.cpp
@@ -13,6 +13,7 @@
 
 #include "../render/Colors.h"
 #include "../render/IImage.h"
+#include "../CMT.h"
 #include "SDL_Extensions.h"
 
 #include <SDL_render.h>

--- a/client/renderSDL/SDL_Extensions.cpp
+++ b/client/renderSDL/SDL_Extensions.cpp
@@ -558,15 +558,6 @@ uint8_t * CSDL_Ext::getPxPtr(const SDL_Surface * const &srf, const int x, const 
 	return (uint8_t *)srf->pixels + y * srf->pitch + x * srf->format->BytesPerPixel;
 }
 
-std::string CSDL_Ext::processStr(std::string str, std::vector<std::string> & tor)
-{
-	for (size_t i=0; (i<tor.size())&&(boost::find_first(str,"%s")); ++i)
-	{
-		boost::replace_first(str,"%s",tor[i]);
-	}
-	return str;
-}
-
 bool CSDL_Ext::isTransparent( SDL_Surface * srf, const Point & position )
 {
 	return isTransparent(srf, position.x, position.y);

--- a/client/renderSDL/SDL_Extensions.cpp
+++ b/client/renderSDL/SDL_Extensions.cpp
@@ -18,24 +18,6 @@
 
 #include <SDL_render.h>
 
-#ifdef VCMI_APPLE
-#include <dispatch/dispatch.h>
-#endif
-
-#ifdef VCMI_IOS
-#include "ios/utils.h"
-#endif
-
-Rect CSDL_Ext::genRect(const int & hh, const int & ww, const int & xx, const int & yy)
-{
-	Rect ret;
-	ret.h=hh;
-	ret.w=ww;
-	ret.x=xx;
-	ret.y=yy;
-	return ret;
-}
-
 Rect CSDL_Ext::fromSDL(const SDL_Rect & rect)
 {
 	return Rect(Point(rect.x, rect.y), Point(rect.w, rect.h));

--- a/client/renderSDL/SDL_Extensions.cpp
+++ b/client/renderSDL/SDL_Extensions.cpp
@@ -14,6 +14,7 @@
 
 #include "../render/Graphics.h"
 #include "../render/Colors.h"
+#include "../CMT.h"
 
 #include <SDL_render.h>
 
@@ -95,6 +96,11 @@ void CSDL_Ext::updateRect(SDL_Surface *surface, const Rect & rect )
 		logGlobal->error("%sSDL_RenderCopy %s", __FUNCTION__, SDL_GetError());
 	SDL_RenderPresent(mainRenderer);
 
+}
+
+SDL_Surface * CSDL_Ext::newSurface(int w, int h)
+{
+	return newSurface(w, h, screen);
 }
 
 SDL_Surface * CSDL_Ext::newSurface(int w, int h, SDL_Surface * mod) //creates new surface, with flags/format same as in surface given

--- a/client/renderSDL/SDL_Extensions.h
+++ b/client/renderSDL/SDL_Extensions.h
@@ -20,11 +20,6 @@ struct SDL_Texture;
 struct SDL_Surface;
 struct SDL_Color;
 
-extern SDL_Window * mainWindow;
-extern SDL_Renderer * mainRenderer;
-extern SDL_Texture * screenTexture;
-extern SDL_Surface * screen, *screen2, *screenBuf;
-
 VCMI_LIB_NAMESPACE_BEGIN
 
 class Rect;
@@ -75,8 +70,8 @@ Rect genRect(const int & hh, const int & ww, const int & xx, const int & yy);
 typedef void (*TColorPutter)(uint8_t *&ptr, const uint8_t & R, const uint8_t & G, const uint8_t & B);
 typedef void (*TColorPutterAlpha)(uint8_t *&ptr, const uint8_t & R, const uint8_t & G, const uint8_t & B, const uint8_t & A);
 
-	void blitAt(SDL_Surface * src, int x, int y, SDL_Surface * dst=screen);
-	void blitAt(SDL_Surface * src, const Rect & pos, SDL_Surface * dst=screen);
+	void blitAt(SDL_Surface * src, int x, int y, SDL_Surface * dst);
+	void blitAt(SDL_Surface * src, const Rect & pos, SDL_Surface * dst);
 
 	void setClipRect(SDL_Surface * src, const Rect & other);
 	void getClipRect(SDL_Surface * src, Rect & other);
@@ -117,7 +112,8 @@ typedef void (*TColorPutterAlpha)(uint8_t *&ptr, const uint8_t & R, const uint8_
 	void drawDashedBorder(SDL_Surface * sur, const Rect &r, const SDL_Color &color);
 	void setPlayerColor(SDL_Surface * sur, PlayerColor player); //sets correct color of flags; -1 for neutral
 	std::string processStr(std::string str, std::vector<std::string> & tor); //replaces %s in string
-	SDL_Surface * newSurface(int w, int h, SDL_Surface * mod=screen); //creates new surface, with flags/format same as in surface given
+	SDL_Surface * newSurface(int w, int h, SDL_Surface * mod); //creates new surface, with flags/format same as in surface given
+	SDL_Surface * newSurface(int w, int h); //creates new surface, with flags/format same as in screen surface
 	SDL_Surface * copySurface(SDL_Surface * mod); //returns copy of given surface
 	template<int bpp>
 	SDL_Surface * createSurfaceWithBpp(int width, int height); //create surface with give bits per pixels value

--- a/client/renderSDL/SDL_Extensions.h
+++ b/client/renderSDL/SDL_Extensions.h
@@ -45,8 +45,6 @@ SDL_Color toSDL(const ColorRGBA & color);
 void setColors(SDL_Surface *surface, SDL_Color *colors, int firstcolor, int ncolors);
 void setAlpha(SDL_Surface * bg, int value);
 
-Rect genRect(const int & hh, const int & ww, const int & xx, const int & yy);
-
 typedef void (*TColorPutter)(uint8_t *&ptr, const uint8_t & R, const uint8_t & G, const uint8_t & B);
 typedef void (*TColorPutterAlpha)(uint8_t *&ptr, const uint8_t & R, const uint8_t & G, const uint8_t & B, const uint8_t & A);
 

--- a/client/renderSDL/SDL_Extensions.h
+++ b/client/renderSDL/SDL_Extensions.h
@@ -45,26 +45,6 @@ SDL_Color toSDL(const ColorRGBA & color);
 void setColors(SDL_Surface *surface, SDL_Color *colors, int firstcolor, int ncolors);
 void setAlpha(SDL_Surface * bg, int value);
 
-template<typename IntType>
-std::string makeNumberShort(IntType number, IntType maxLength = 3) //the output is a string containing at most 5 characters [4 if positive] (eg. intead 10000 it gives 10k)
-{
-	IntType max = pow(10, maxLength);
-	if (std::abs(number) < max)
-		return boost::lexical_cast<std::string>(number);
-
-	std::string symbols = " kMGTPE";
-	auto iter = symbols.begin();
-
-	while (number >= max)
-	{
-		number /= 1000;
-		iter++;
-
-		assert(iter != symbols.end());//should be enough even for int64
-	}
-	return boost::lexical_cast<std::string>(number) + *iter;
-}
-
 Rect genRect(const int & hh, const int & ww, const int & xx, const int & yy);
 
 typedef void (*TColorPutter)(uint8_t *&ptr, const uint8_t & R, const uint8_t & G, const uint8_t & B);
@@ -111,7 +91,7 @@ typedef void (*TColorPutterAlpha)(uint8_t *&ptr, const uint8_t & R, const uint8_
 	void drawBorder(SDL_Surface * sur, const Rect &r, const SDL_Color &color, int depth = 1);
 	void drawDashedBorder(SDL_Surface * sur, const Rect &r, const SDL_Color &color);
 	void setPlayerColor(SDL_Surface * sur, PlayerColor player); //sets correct color of flags; -1 for neutral
-	std::string processStr(std::string str, std::vector<std::string> & tor); //replaces %s in string
+
 	SDL_Surface * newSurface(int w, int h, SDL_Surface * mod); //creates new surface, with flags/format same as in surface given
 	SDL_Surface * newSurface(int w, int h); //creates new surface, with flags/format same as in screen surface
 	SDL_Surface * copySurface(SDL_Surface * mod); //returns copy of given surface

--- a/client/widgets/CGarrisonInt.cpp
+++ b/client/widgets/CGarrisonInt.cpp
@@ -374,7 +374,7 @@ void CGarrisonSlot::update()
 		creatureImage->setFrame(creature->getIconIndex());
 
 		stackCount->enable();
-		stackCount->setText(CSDL_Ext::makeNumberShort(myStack->count, 4));
+		stackCount->setText(vstd::formatMetric(myStack->count, 4));
 	}
 	else
 	{

--- a/client/widgets/MiscWidgets.cpp
+++ b/client/widgets/MiscWidgets.cpp
@@ -187,9 +187,9 @@ std::string CMinorResDataBar::buildDateString()
 	std::string pattern = "%s: %d, %s: %d, %s: %d";
 
 	auto formatted = boost::format(pattern)
-		% CGI->generaltexth->allTexts[62] % LOCPLINT->cb->getDate(Date::MONTH)
-		% CGI->generaltexth->allTexts[63] % LOCPLINT->cb->getDate(Date::WEEK)
-		% CGI->generaltexth->allTexts[64] % LOCPLINT->cb->getDate(Date::DAY_OF_WEEK);
+		% CGI->generaltexth->translate("core.genrltxt.62") % LOCPLINT->cb->getDate(Date::MONTH)
+		% CGI->generaltexth->translate("core.genrltxt.63") % LOCPLINT->cb->getDate(Date::WEEK)
+		% CGI->generaltexth->translate("core.genrltxt.64") % LOCPLINT->cb->getDate(Date::DAY_OF_WEEK);
 
 	return boost::str(formatted);
 }

--- a/client/widgets/MiscWidgets.cpp
+++ b/client/widgets/MiscWidgets.cpp
@@ -182,6 +182,18 @@ void CMinorResDataBar::show(SDL_Surface * to)
 {
 }
 
+std::string CMinorResDataBar::buildDateString()
+{
+	std::string pattern = "%s: %d, %s: %d, %s: %d";
+
+	auto formatted = boost::format(pattern)
+		% CGI->generaltexth->allTexts[62] % LOCPLINT->cb->getDate(Date::MONTH)
+		% CGI->generaltexth->allTexts[63] % LOCPLINT->cb->getDate(Date::WEEK)
+		% CGI->generaltexth->allTexts[64] % LOCPLINT->cb->getDate(Date::DAY_OF_WEEK);
+
+	return boost::str(formatted);
+}
+
 void CMinorResDataBar::showAll(SDL_Surface * to)
 {
 	CIntObject::showAll(to);
@@ -192,16 +204,7 @@ void CMinorResDataBar::showAll(SDL_Surface * to)
 
 		graphics->fonts[FONT_SMALL]->renderTextCenter(to, text, Colors::WHITE, Point(pos.x + 50 + 76 * i, pos.y + pos.h/2));
 	}
-	std::vector<std::string> temp;
-
-	temp.push_back(boost::lexical_cast<std::string>(LOCPLINT->cb->getDate(Date::MONTH)));
-	temp.push_back(boost::lexical_cast<std::string>(LOCPLINT->cb->getDate(Date::WEEK)));
-	temp.push_back(boost::lexical_cast<std::string>(LOCPLINT->cb->getDate(Date::DAY_OF_WEEK)));
-
-	std::string datetext =  CGI->generaltexth->allTexts[62]+": %s, " + CGI->generaltexth->allTexts[63]
-							+ ": %s, " + CGI->generaltexth->allTexts[64] + ": %s";
-
-	graphics->fonts[FONT_SMALL]->renderTextCenter(to, CSDL_Ext::processStr(datetext,temp), Colors::WHITE, Point(pos.x+545+(pos.w-545)/2,pos.y+pos.h/2));
+	graphics->fonts[FONT_SMALL]->renderTextCenter(to, buildDateString(), Colors::WHITE, Point(pos.x+545+(pos.w-545)/2,pos.y+pos.h/2));
 }
 
 CMinorResDataBar::CMinorResDataBar()
@@ -248,7 +251,7 @@ void CArmyTooltip::init(const InfoAboutArmy &army)
 		std::string subtitle;
 		if(army.army.isDetailed)
 		{
-			subtitle = CSDL_Ext::makeNumberShort(slot.second.count, 4);
+			subtitle = vstd::formatMetric(slot.second.count, 4);
 		}
 		else
 		{

--- a/client/widgets/MiscWidgets.h
+++ b/client/widgets/MiscWidgets.h
@@ -117,6 +117,8 @@ public:
 class CMinorResDataBar : public CIntObject
 {
 	std::shared_ptr<CPicture> background;
+
+	std::string buildDateString();
 public:
 	void show(SDL_Surface * to) override;
 	void showAll(SDL_Surface * to) override;

--- a/client/windows/CCastleInterface.cpp
+++ b/client/windows/CCastleInterface.cpp
@@ -43,7 +43,6 @@
 #include "../../lib/mapObjects/CGHeroInstance.h"
 #include "../../lib/mapObjects/CGTownInstance.h"
 
-#include <SDL_surface.h>
 
 CBuildingRect::CBuildingRect(CCastleBuildings * Par, const CGTownInstance * Town, const CStructure * Str)
 	: CShowableAnim(0, 0, Str->defName, CShowableAnim::BASE, BUILDING_FRAME_TIME),
@@ -1066,7 +1065,7 @@ void CCreaInfo::clickRight(tribool down, bool previousState)
 	if(down)
 	{
 		if (showAvailable)
-			GH.pushIntT<CDwellingInfoBox>(screen->w/2, screen->h/2, town, level);
+			GH.pushIntT<CDwellingInfoBox>(GH.screenDimensions().x/2, GH.screenDimensions().y/2, town, level);
 		else
 			CRClickPopup::createAndPush(genGrowthText(), std::make_shared<CComponent>(CComponent::creature, creature->idNumber));
 	}

--- a/client/windows/CCastleInterface.cpp
+++ b/client/windows/CCastleInterface.cpp
@@ -145,7 +145,7 @@ void CBuildingRect::clickRight(tribool down, bool previousState)
 		else
 		{
 			int level = ( bid - BuildingID::DWELL_FIRST ) % GameConstants::CREATURES_PER_TOWN;
-			GH.pushIntT<CDwellingInfoBox>(parent->pos.x+parent->pos.w/2, parent->pos.y+parent->pos.h/2, town, level);
+			GH.pushIntT<CDwellingInfoBox>(parent->pos.x+parent->pos.w / 2, parent->pos.y+parent->pos.h  /2, town, level);
 		}
 	}
 }
@@ -1065,7 +1065,7 @@ void CCreaInfo::clickRight(tribool down, bool previousState)
 	if(down)
 	{
 		if (showAvailable)
-			GH.pushIntT<CDwellingInfoBox>(GH.screenDimensions().x/2, GH.screenDimensions().y/2, town, level);
+			GH.pushIntT<CDwellingInfoBox>(GH.screenDimensions().x / 2, GH.screenDimensions().y / 2, town, level);
 		else
 			CRClickPopup::createAndPush(genGrowthText(), std::make_shared<CComponent>(CComponent::creature, creature->idNumber));
 	}

--- a/client/windows/CCreatureWindow.cpp
+++ b/client/windows/CCreatureWindow.cpp
@@ -517,8 +517,8 @@ CStackWindow::MainSection::MainSection(CStackWindow * owner, int yOffset, bool s
 
 	const CStack * battleStack = parent->info->stack;
 
-	morale = std::make_shared<MoraleLuckBox>(true, CSDL_Ext::genRect(42, 42, 321, 110));
-	luck = std::make_shared<MoraleLuckBox>(false, CSDL_Ext::genRect(42, 42, 375, 110));
+	morale = std::make_shared<MoraleLuckBox>(true, Rect(Point(321, 110), Point(42, 42) ));
+	luck = std::make_shared<MoraleLuckBox>(false,  Rect(Point(375, 110), Point(42, 42) ));
 
 	if(battleStack != nullptr) // in battle
 	{

--- a/client/windows/CCreatureWindow.cpp
+++ b/client/windows/CCreatureWindow.cpp
@@ -582,7 +582,7 @@ CStackWindow::MainSection::MainSection(CStackWindow * owner, int yOffset, bool s
 		}
 		expLabel = std::make_shared<CLabel>(
 				pos.x + 21, pos.y + 52, FONT_SMALL, ETextAlignment::CENTER, Colors::WHITE,
-				CSDL_Ext::makeNumberShort<TExpType>(stack->experience, 6));
+				vstd::formatMetric(stack->experience, 6));
 	}
 
 	if(showArt)

--- a/client/windows/CHeroWindow.cpp
+++ b/client/windows/CHeroWindow.cpp
@@ -15,7 +15,6 @@
 #include "GUIClasses.h"
 
 #include "../CGameInfo.h"
-#include "../CMT.h"
 #include "../CPlayerInterface.h"
 
 #include "../gui/CGuiHandler.h"

--- a/client/windows/CKingdomInterface.cpp
+++ b/client/windows/CKingdomInterface.cpp
@@ -14,7 +14,6 @@
 #include "InfoWindows.h"
 
 #include "../CGameInfo.h"
-#include "../CMT.h"
 #include "../CPlayerInterface.h"
 #include "../gui/CGuiHandler.h"
 #include "../widgets/CComponent.h"

--- a/client/windows/CMessage.cpp
+++ b/client/windows/CMessage.cpp
@@ -211,8 +211,8 @@ void CMessage::drawIWindow(CInfoWindow * ret, std::string text, PlayerColor play
 	assert(ret && ret->text);
 	for(int i = 0;
 		i < ARRAY_COUNT(sizes)
-			&& sizes[i][0] < screen->w - 150
-			&& sizes[i][1] < screen->h - 150
+			&& sizes[i][0] < GH.screenDimensions().x - 150
+			&& sizes[i][1] < GH.screenDimensions().y - 150
 			&& ret->text->slider;
 		i++)
 	{
@@ -254,7 +254,7 @@ void CMessage::drawIWindow(CInfoWindow * ret, std::string text, PlayerColor play
 	vstd::amax(winSize.first, comps.w);
 	vstd::amax(winSize.first, bw);
 
-	vstd::amin(winSize.first, screen->w - 150);
+	vstd::amin(winSize.first, GH.screenDimensions().x - 150);
 
 	ret->bitmap = drawDialogBox (winSize.first + 2*SIDE_MARGIN, winSize.second + 2*SIDE_MARGIN, player);
 	ret->pos.h=ret->bitmap->h;

--- a/client/windows/CMessage.cpp
+++ b/client/windows/CMessage.cpp
@@ -18,6 +18,7 @@
 #include "../widgets/Buttons.h"
 #include "../widgets/CComponent.h"
 #include "../widgets/TextControls.h"
+#include "../gui/CGuiHandler.h"
 #include "../render/CAnimation.h"
 #include "../render/IImage.h"
 #include "../renderSDL/SDL_Extensions.h"

--- a/client/windows/CSpellWindow.cpp
+++ b/client/windows/CSpellWindow.cpp
@@ -183,38 +183,25 @@ CSpellWindow::CSpellWindow(const CGHeroInstance * _myHero, CPlayerInterface * _m
 	mana = std::make_shared<CLabel>(435, 426, FONT_SMALL, ETextAlignment::CENTER, Colors::YELLOW, boost::lexical_cast<std::string>(myHero->mana));
 	statusBar = CGStatusBar::create(7, 569, "Spelroll.bmp");
 
-	Rect temp_rect = CSDL_Ext::genRect(45, 35, 479 + pos.x, 405 + pos.y);
-	interactiveAreas.push_back(std::make_shared<InteractiveArea>(temp_rect, std::bind(&CSpellWindow::fexitb, this), 460, this));
-	temp_rect = CSDL_Ext::genRect(45, 35, 221 + pos.x, 405 + pos.y);
-	interactiveAreas.push_back(std::make_shared<InteractiveArea>(temp_rect, std::bind(&CSpellWindow::fbattleSpellsb, this), 453, this));
-	temp_rect = CSDL_Ext::genRect(45, 35, 355 + pos.x, 405 + pos.y);
-	interactiveAreas.push_back(std::make_shared<InteractiveArea>(temp_rect, std::bind(&CSpellWindow::fadvSpellsb, this), 452, this));
-	temp_rect = CSDL_Ext::genRect(45, 35, 418 + pos.x, 405 + pos.y);
-	interactiveAreas.push_back(std::make_shared<InteractiveArea>(temp_rect, std::bind(&CSpellWindow::fmanaPtsb, this), 459, this));
+	interactiveAreas.push_back(std::make_shared<InteractiveArea>( Rect( 479 + pos.x, 405 + pos.y, 36, 56), std::bind(&CSpellWindow::fexitb,         this),    460, this));
+	interactiveAreas.push_back(std::make_shared<InteractiveArea>( Rect( 221 + pos.x, 405 + pos.y, 36, 56), std::bind(&CSpellWindow::fbattleSpellsb, this),    453, this));
+	interactiveAreas.push_back(std::make_shared<InteractiveArea>( Rect( 355 + pos.x, 405 + pos.y, 36, 56), std::bind(&CSpellWindow::fadvSpellsb,    this),    452, this));
+	interactiveAreas.push_back(std::make_shared<InteractiveArea>( Rect( 418 + pos.x, 405 + pos.y, 36, 56), std::bind(&CSpellWindow::fmanaPtsb,      this),    459, this));
+	interactiveAreas.push_back(std::make_shared<InteractiveArea>( Rect( 549 + pos.x,  94 + pos.y, 36, 56), std::bind(&CSpellWindow::selectSchool,   this, 0), 454, this));
+	interactiveAreas.push_back(std::make_shared<InteractiveArea>( Rect( 549 + pos.x, 151 + pos.y, 45, 35), std::bind(&CSpellWindow::selectSchool,   this, 3), 457, this));
+	interactiveAreas.push_back(std::make_shared<InteractiveArea>( Rect( 549 + pos.x, 210 + pos.y, 45, 35), std::bind(&CSpellWindow::selectSchool,   this, 1), 455, this));
+	interactiveAreas.push_back(std::make_shared<InteractiveArea>( Rect( 549 + pos.x, 270 + pos.y, 45, 35), std::bind(&CSpellWindow::selectSchool,   this, 2), 456, this));
+	interactiveAreas.push_back(std::make_shared<InteractiveArea>( Rect( 549 + pos.x, 330 + pos.y, 45, 35), std::bind(&CSpellWindow::selectSchool,   this, 4), 458, this));
 
-	temp_rect = CSDL_Ext::genRect(36, 56, 549 + pos.x, 94 + pos.y);
-	interactiveAreas.push_back(std::make_shared<InteractiveArea>(temp_rect, std::bind(&CSpellWindow::selectSchool, this, 0), 454, this));
-	temp_rect = CSDL_Ext::genRect(36, 56, 549 + pos.x, 151 + pos.y);
-	interactiveAreas.push_back(std::make_shared<InteractiveArea>(temp_rect, std::bind(&CSpellWindow::selectSchool, this, 3), 457, this));
-	temp_rect = CSDL_Ext::genRect(36, 56, 549 + pos.x, 210 + pos.y);
-	interactiveAreas.push_back(std::make_shared<InteractiveArea>(temp_rect, std::bind(&CSpellWindow::selectSchool, this, 1), 455, this));
-	temp_rect = CSDL_Ext::genRect(36, 56, 549 + pos.x, 270 + pos.y);
-	interactiveAreas.push_back(std::make_shared<InteractiveArea>(temp_rect, std::bind(&CSpellWindow::selectSchool, this, 2), 456, this));
-	temp_rect = CSDL_Ext::genRect(36, 56, 549 + pos.x, 330 + pos.y);
-	interactiveAreas.push_back(std::make_shared<InteractiveArea>(temp_rect, std::bind(&CSpellWindow::selectSchool, this, 4), 458, this));
-
-	temp_rect = CSDL_Ext::genRect(leftCorner->pos.h, leftCorner->pos.w, 97 + pos.x, 77 + pos.y);
-	interactiveAreas.push_back(std::make_shared<InteractiveArea>(temp_rect, std::bind(&CSpellWindow::fLcornerb, this), 450, this));
-	temp_rect = CSDL_Ext::genRect(rightCorner->pos.h, rightCorner->pos.w, 487 + pos.x, 72 + pos.y);
-	interactiveAreas.push_back(std::make_shared<InteractiveArea>(temp_rect, std::bind(&CSpellWindow::fRcornerb, this), 451, this));
+	interactiveAreas.push_back(std::make_shared<InteractiveArea>( Rect(  97 + pos.x, 77 + pos.y, leftCorner->pos.h,  leftCorner->pos.w  ), std::bind(&CSpellWindow::fLcornerb, this), 450, this));
+	interactiveAreas.push_back(std::make_shared<InteractiveArea>( Rect( 487 + pos.x, 72 + pos.y, rightCorner->pos.h, rightCorner->pos.w ), std::bind(&CSpellWindow::fRcornerb, this), 451, this));
 
 	//areas for spells
 	int xpos = 117 + pos.x, ypos = 90 + pos.y;
 
 	for(int v=0; v<12; ++v)
 	{
-		temp_rect = CSDL_Ext::genRect(65, 78, xpos, ypos);
-		spellAreas[v] = std::make_shared<SpellArea>(temp_rect, this);
+		spellAreas[v] = std::make_shared<SpellArea>( Rect(xpos, ypos, 65, 78), this);
 
 		if(v == 5) //to right page
 		{

--- a/client/windows/CSpellWindow.cpp
+++ b/client/windows/CSpellWindow.cpp
@@ -17,7 +17,6 @@
 #include "CCastleInterface.h"
 
 #include "../CGameInfo.h"
-#include "../CMT.h"
 #include "../CPlayerInterface.h"
 #include "../CVideoHandler.h"
 

--- a/client/windows/CTradeWindow.cpp
+++ b/client/windows/CTradeWindow.cpp
@@ -504,13 +504,13 @@ void CTradeWindow::getPositionsFor(std::vector<Rect> &poss, bool Left, EType typ
 
 		const std::vector<Rect> tmp =
 		{
-			Rect(Point(x + 0*dx, y + 0*dx), Point(h, w) ),
-			Rect(Point(x + 1*dx, y + 0*dx), Point(h, w) ),
-			Rect(Point(x + 2*dx, y + 0*dx), Point(h, w) ),
-			Rect(Point(x + 0*dx, y + 1*dy), Point(h, w) ),
-			Rect(Point(x + 1*dx, y + 1*dy), Point(h, w) ),
-			Rect(Point(x + 2*dx, y + 1*dy), Point(h, w) ),
-			Rect(Point(x + 1*dx, y + 2*dy), Point(h, w) )
+			Rect(Point(x + 0 * dx, y + 0 * dx), Point(h, w) ),
+			Rect(Point(x + 1 * dx, y + 0 * dx), Point(h, w) ),
+			Rect(Point(x + 2 * dx, y + 0 * dx), Point(h, w) ),
+			Rect(Point(x + 0 * dx, y + 1 * dy), Point(h, w) ),
+			Rect(Point(x + 1 * dx, y + 1 * dy), Point(h, w) ),
+			Rect(Point(x + 2 * dx, y + 1 * dy), Point(h, w) ),
+			Rect(Point(x + 1 * dx, y + 2 * dy), Point(h, w) )
 		};
 
 		vstd::concatenate(poss, tmp);

--- a/client/windows/CTradeWindow.cpp
+++ b/client/windows/CTradeWindow.cpp
@@ -504,9 +504,13 @@ void CTradeWindow::getPositionsFor(std::vector<Rect> &poss, bool Left, EType typ
 
 		const std::vector<Rect> tmp =
 		{
-			CSDL_Ext::genRect(h, w, x, y), CSDL_Ext::genRect(h, w, x + dx, y), CSDL_Ext::genRect(h, w, x + 2*dx, y),
-			CSDL_Ext::genRect(h, w, x, y + dy), CSDL_Ext::genRect(h, w, x + dx, y + dy), CSDL_Ext::genRect(h, w, x + 2*dx, y + dy),
-			CSDL_Ext::genRect(h, w, x + dx, y + 2*dy)
+			Rect(Point(x + 0*dx, y + 0*dx), Point(h, w) ),
+			Rect(Point(x + 1*dx, y + 0*dx), Point(h, w) ),
+			Rect(Point(x + 2*dx, y + 0*dx), Point(h, w) ),
+			Rect(Point(x + 0*dx, y + 1*dy), Point(h, w) ),
+			Rect(Point(x + 1*dx, y + 1*dy), Point(h, w) ),
+			Rect(Point(x + 2*dx, y + 1*dy), Point(h, w) ),
+			Rect(Point(x + 1*dx, y + 2*dy), Point(h, w) )
 		};
 
 		vstd::concatenate(poss, tmp);

--- a/client/windows/CWindowObject.cpp
+++ b/client/windows/CWindowObject.cpp
@@ -69,7 +69,7 @@ CWindowObject::CWindowObject(int options_, std::string imageName):
 	if(background)
 		pos = background->center();
 	else
-		center(Point(screen->w/2, screen->h/2));
+		center(GH.screenDimensions() / 2);
 
 	if(!(options & SHADOW_DISABLED))
 		setShadow(true);

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -1157,7 +1157,7 @@ CExchangeWindow::CExchangeWindow(ObjectInstanceID hero1, ObjectInstanceID hero2,
 			int skill = hero->secSkills[g].first,
 				level = hero->secSkills[g].second; // <1, 3>
 			secSkillAreas[b].push_back(std::make_shared<LRClickableAreaWTextComp>());
-			secSkillAreas[b][g]->pos = Rect(Point(pos.x + 32 + g*36 + b*454 , pos.y + (qeLayout ? 83 : 88)), Point(32, 32) );
+			secSkillAreas[b][g]->pos = Rect(Point(pos.x + 32 + g * 36 + b * 454 , pos.y + (qeLayout ? 83 : 88)), Point(32, 32) );
 			secSkillAreas[b][g]->baseType = 1;
 
 			secSkillAreas[b][g]->type = skill;
@@ -1172,12 +1172,12 @@ CExchangeWindow::CExchangeWindow(ObjectInstanceID hero1, ObjectInstanceID hero2,
 		heroAreas[b] = std::make_shared<CHeroArea>(257 + 228*b, 13, hero);
 
 		specialtyAreas[b] = std::make_shared<LRClickableAreaWText>();
-		specialtyAreas[b]->pos = Rect(Point(pos.x + 69 + 490*b, pos.y + (qeLayout ? 41 : 45)), Point(32, 32));
+		specialtyAreas[b]->pos = Rect(Point(pos.x + 69 + 490 * b, pos.y + (qeLayout ? 41 : 45)), Point(32, 32));
 		specialtyAreas[b]->hoverText = CGI->generaltexth->heroscrn[27];
 		specialtyAreas[b]->text = hero->type->getSpecialtyDescriptionTranslated();
 
 		experienceAreas[b] = std::make_shared<LRClickableAreaWText>();
-		experienceAreas[b]->pos = Rect(Point(pos.x + 105 + 490*b, pos.y + (qeLayout ? 41 : 45)), Point(32, 32));
+		experienceAreas[b]->pos = Rect(Point(pos.x + 105 + 490 * b, pos.y + (qeLayout ? 41 : 45)), Point(32, 32));
 		experienceAreas[b]->hoverText = CGI->generaltexth->heroscrn[9];
 		experienceAreas[b]->text = CGI->generaltexth->allTexts[2];
 		boost::algorithm::replace_first(experienceAreas[b]->text, "%d", boost::lexical_cast<std::string>(hero->level));
@@ -1185,7 +1185,7 @@ CExchangeWindow::CExchangeWindow(ObjectInstanceID hero1, ObjectInstanceID hero2,
 		boost::algorithm::replace_first(experienceAreas[b]->text, "%d", boost::lexical_cast<std::string>(hero->exp));
 
 		spellPointsAreas[b] = std::make_shared<LRClickableAreaWText>();
-		spellPointsAreas[b]->pos = Rect(Point(pos.x + 141 + 490*b, pos.y + (qeLayout ? 41 : 45)), Point(32, 32));
+		spellPointsAreas[b]->pos = Rect(Point(pos.x + 141 + 490 * b, pos.y + (qeLayout ? 41 : 45)), Point(32, 32));
 		spellPointsAreas[b]->hoverText = CGI->generaltexth->heroscrn[22];
 		spellPointsAreas[b]->text = CGI->generaltexth->allTexts[205];
 		boost::algorithm::replace_first(spellPointsAreas[b]->text, "%s", hero->getNameTranslated());

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -1281,8 +1281,8 @@ void CExchangeWindow::updateWidgets()
 			secSkillIcons[leftRight][m]->setFrame(2 + id * 3 + level);
 		}
 
-		expValues[leftRight]->setText(CSDL_Ext::makeNumberShort(hero->exp));
-		manaValues[leftRight]->setText(CSDL_Ext::makeNumberShort(hero->mana));
+		expValues[leftRight]->setText(vstd::formatMetric(hero->exp, 3));
+		manaValues[leftRight]->setText(vstd::formatMetric(hero->mana, 3));
 
 		morale[leftRight]->set(hero);
 		luck[leftRight]->set(hero);

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -1135,9 +1135,9 @@ CExchangeWindow::CExchangeWindow(ObjectInstanceID hero1, ObjectInstanceID hero2,
 	{
 		primSkillAreas.push_back(std::make_shared<LRClickableAreaWTextComp>());
 		if (qeLayout)
-			primSkillAreas[g]->pos = CSDL_Ext::genRect(22, 152, pos.x + 324, pos.y + 12 + 26 * g);
+			primSkillAreas[g]->pos = Rect(Point(pos.x + 324, pos.y + 12 + 26 * g), Point(22, 152));
 		else
-			primSkillAreas[g]->pos = CSDL_Ext::genRect(32, 140, pos.x + 329, pos.y + 19 + 36 * g);
+			primSkillAreas[g]->pos = Rect(Point(pos.x + 329, pos.y + 19 + 36 * g), Point(32, 140));
 		primSkillAreas[g]->text = CGI->generaltexth->arraytxt[2+g];
 		primSkillAreas[g]->type = g;
 		primSkillAreas[g]->bonusValue = -1;
@@ -1157,7 +1157,7 @@ CExchangeWindow::CExchangeWindow(ObjectInstanceID hero1, ObjectInstanceID hero2,
 			int skill = hero->secSkills[g].first,
 				level = hero->secSkills[g].second; // <1, 3>
 			secSkillAreas[b].push_back(std::make_shared<LRClickableAreaWTextComp>());
-			secSkillAreas[b][g]->pos = CSDL_Ext::genRect(32, 32, pos.x + 32 + g*36 + b*454 , pos.y + (qeLayout ? 83 : 88));
+			secSkillAreas[b][g]->pos = Rect(Point(pos.x + 32 + g*36 + b*454 , pos.y + (qeLayout ? 83 : 88)), Point(32, 32) );
 			secSkillAreas[b][g]->baseType = 1;
 
 			secSkillAreas[b][g]->type = skill;
@@ -1172,12 +1172,12 @@ CExchangeWindow::CExchangeWindow(ObjectInstanceID hero1, ObjectInstanceID hero2,
 		heroAreas[b] = std::make_shared<CHeroArea>(257 + 228*b, 13, hero);
 
 		specialtyAreas[b] = std::make_shared<LRClickableAreaWText>();
-		specialtyAreas[b]->pos = CSDL_Ext::genRect(32, 32, pos.x + 69 + 490*b, pos.y + (qeLayout ? 41 : 45));
+		specialtyAreas[b]->pos = Rect(Point(pos.x + 69 + 490*b, pos.y + (qeLayout ? 41 : 45)), Point(32, 32));
 		specialtyAreas[b]->hoverText = CGI->generaltexth->heroscrn[27];
 		specialtyAreas[b]->text = hero->type->getSpecialtyDescriptionTranslated();
 
 		experienceAreas[b] = std::make_shared<LRClickableAreaWText>();
-		experienceAreas[b]->pos = CSDL_Ext::genRect(32, 32, pos.x + 105 + 490*b, pos.y + (qeLayout ? 41 : 45));
+		experienceAreas[b]->pos = Rect(Point(pos.x + 105 + 490*b, pos.y + (qeLayout ? 41 : 45)), Point(32, 32));
 		experienceAreas[b]->hoverText = CGI->generaltexth->heroscrn[9];
 		experienceAreas[b]->text = CGI->generaltexth->allTexts[2];
 		boost::algorithm::replace_first(experienceAreas[b]->text, "%d", boost::lexical_cast<std::string>(hero->level));
@@ -1185,15 +1185,15 @@ CExchangeWindow::CExchangeWindow(ObjectInstanceID hero1, ObjectInstanceID hero2,
 		boost::algorithm::replace_first(experienceAreas[b]->text, "%d", boost::lexical_cast<std::string>(hero->exp));
 
 		spellPointsAreas[b] = std::make_shared<LRClickableAreaWText>();
-		spellPointsAreas[b]->pos = CSDL_Ext::genRect(32, 32, pos.x + 141 + 490*b, pos.y + (qeLayout ? 41 : 45));
+		spellPointsAreas[b]->pos = Rect(Point(pos.x + 141 + 490*b, pos.y + (qeLayout ? 41 : 45)), Point(32, 32));
 		spellPointsAreas[b]->hoverText = CGI->generaltexth->heroscrn[22];
 		spellPointsAreas[b]->text = CGI->generaltexth->allTexts[205];
 		boost::algorithm::replace_first(spellPointsAreas[b]->text, "%s", hero->getNameTranslated());
 		boost::algorithm::replace_first(spellPointsAreas[b]->text, "%d", boost::lexical_cast<std::string>(hero->mana));
 		boost::algorithm::replace_first(spellPointsAreas[b]->text, "%d", boost::lexical_cast<std::string>(hero->manaLimit()));
 
-		morale[b] = std::make_shared<MoraleLuckBox>(true, CSDL_Ext::genRect(32, 32, 176 + 490 * b, 39), true);
-		luck[b] = std::make_shared<MoraleLuckBox>(false, CSDL_Ext::genRect(32, 32, 212 + 490 * b, 39), true);
+		morale[b] = std::make_shared<MoraleLuckBox>(true, Rect(Point(176 + 490 * b, 39), Point(32, 32)), true);
+		luck[b] = std::make_shared<MoraleLuckBox>(false,  Rect(Point(212 + 490 * b, 39), Point(32, 32)), true);
 	}
 
 	quit = std::make_shared<CButton>(Point(732, 567), "IOKAY.DEF", CGI->generaltexth->zelp[600], std::bind(&CExchangeWindow::close, this), SDLK_RETURN);
@@ -1375,7 +1375,7 @@ CPuzzleWindow::CPuzzleWindow(const int3 & GrailPos, double discoveredRatio)
 void CPuzzleWindow::showAll(SDL_Surface * to)
 {
 	int3 moveInt = int3(8, 9, 0);
-	Rect mapRect = CSDL_Ext::genRect(544, 591, pos.x + 8, pos.y + 7);
+	Rect mapRect = Rect(Point(pos.x + 8, pos.y + 7), Point(544, 591));
 	int3 topTile = grailPos - moveInt;
 
 	MapDrawingInfo info(topTile, LOCPLINT->cb->getVisibilityMap(), mapRect);

--- a/client/windows/InfoWindows.cpp
+++ b/client/windows/InfoWindows.cpp
@@ -245,8 +245,8 @@ CInfoPopup::CInfoPopup(SDL_Surface *Bitmap, bool Free)
 
 	if(bitmap)
 	{
-		pos.x = screen->w/2 - bitmap->w/2;
-		pos.y = screen->h/2 - bitmap->h/2;
+		pos.x = GH.screenDimensions().x/2 - bitmap->w/2;
+		pos.y = GH.screenDimensions().y/2 - bitmap->h/2;
 		pos.h = bitmap->h;
 		pos.w = bitmap->w;
 	}
@@ -281,8 +281,8 @@ void CInfoPopup::init(int x, int y)
 	// Put the window back on screen if necessary
 	vstd::amax(pos.x, 0);
 	vstd::amax(pos.y, 0);
-	vstd::amin(pos.x, screen->w - bitmap->w);
-	vstd::amin(pos.y, screen->h - bitmap->h);
+	vstd::amin(pos.x, GH.screenDimensions().x - bitmap->w);
+	vstd::amin(pos.y, GH.screenDimensions().y - bitmap->h);
 }
 
 

--- a/client/windows/InfoWindows.cpp
+++ b/client/windows/InfoWindows.cpp
@@ -245,8 +245,8 @@ CInfoPopup::CInfoPopup(SDL_Surface *Bitmap, bool Free)
 
 	if(bitmap)
 	{
-		pos.x = GH.screenDimensions().x/2 - bitmap->w/2;
-		pos.y = GH.screenDimensions().y/2 - bitmap->h/2;
+		pos.x = GH.screenDimensions().x / 2 - bitmap->w / 2;
+		pos.y = GH.screenDimensions().y / 2 - bitmap->h / 2;
 		pos.h = bitmap->h;
 		pos.w = bitmap->w;
 	}


### PR DESCRIPTION
Small set of changes to reduce SDL usage. Probably last change for now, need to decide on suitable architecture for future changes.
- Removed some instances of access to screen surface
- Removed text utilities from SDL_Extensions
- Replaced genRect with Rect constructor call