### PR TITLE
Small optimizations

### DIFF
--- a/Global.h
+++ b/Global.h
@@ -746,6 +746,12 @@ namespace vstd
 		}
 		return std::to_string(number) + *iter;
 	}
+	
+	///compile-time version of std::abs for ints for int3, in clang++15 std::abs is constexpr
+	static constexpr int abs(int i) {
+		if(i < 0) return -i;
+		return i;
+	}
 }
 using vstd::operator-=;
 

--- a/client/adventureMap/mapHandler.cpp
+++ b/client/adventureMap/mapHandler.cpp
@@ -23,6 +23,7 @@
 #include "../../lib/mapObjects/CGHeroInstance.h"
 #include "../../lib/mapObjects/CObjectClassesHandler.h"
 #include "../../lib/mapping/CMap.h"
+#include "../../lib/Color.h"
 #include "../../lib/CConfigHandler.h"
 #include "../../lib/CGeneralTextHandler.h"
 #include "../../lib/CStopWatch.h"
@@ -925,21 +926,21 @@ void CMapHandler::CMapBlitter::blit(SDL_Surface * targetSurf, const MapDrawingIn
 		{
 			for (realPos.y = initPos.y, pos.y = topTile.y; pos.y < topTile.y + tileCount.y; pos.y++, realPos.y += tileSize)
 			{
-				const int3 color(0x555555, 0x555555, 0x555555);
+				constexpr ColorRGBA color(0x55, 0x55, 0x55);
 
 				if (realPos.y >= info->drawBounds.y &&
 					realPos.y < info->drawBounds.y + info->drawBounds.h)
 					for(int i = 0; i < tileSize; i++)
 						if (realPos.x + i >= info->drawBounds.x &&
 							realPos.x + i < info->drawBounds.x + info->drawBounds.w)
-							CSDL_Ext::putPixelWithoutRefresh(targetSurf, realPos.x + i, realPos.y, color.x, color.y, color.z);
+							CSDL_Ext::putPixelWithoutRefresh(targetSurf, realPos.x + i, realPos.y, color.r, color.g, color.b);
 
 				if (realPos.x >= info->drawBounds.x &&
 					realPos.x < info->drawBounds.x + info->drawBounds.w)
 					for(int i = 0; i < tileSize; i++)
 						if (realPos.y + i >= info->drawBounds.y &&
 							realPos.y + i < info->drawBounds.y + info->drawBounds.h)
-							CSDL_Ext::putPixelWithoutRefresh(targetSurf, realPos.x, realPos.y + i, color.x, color.y, color.z);
+							CSDL_Ext::putPixelWithoutRefresh(targetSurf, realPos.x, realPos.y + i, color.r, color.g, color.b);
 			}
 		}
 	}

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -40,6 +40,7 @@
 #include "../lobby/CSavingScreen.h"
 #include "../renderSDL/SDL_Extensions.h"
 #include "../render/CAnimation.h"
+#include "../CMT.h"
 
 #include "../../CCallback.h"
 

--- a/lib/Color.h
+++ b/lib/Color.h
@@ -27,7 +27,7 @@ public:
 	uint8_t a;
 
 	//constructors
-	ColorRGBA()
+	constexpr ColorRGBA()
 		:r(0)
 		,g(0)
 		,b(0)
@@ -35,14 +35,14 @@ public:
 	{
 	}
 
-	ColorRGBA(uint8_t r, uint8_t g, uint8_t b, uint8_t a)
+	constexpr ColorRGBA(uint8_t r, uint8_t g, uint8_t b, uint8_t a)
 		: r(r)
 		, g(g)
 		, b(b)
 		, a(a)
 	{}
 
-	ColorRGBA(uint8_t r, uint8_t g, uint8_t b)
+	constexpr ColorRGBA(uint8_t r, uint8_t g, uint8_t b)
 		: r(r)
 		, g(g)
 		, b(b)

--- a/lib/ConstTransitivePtr.h
+++ b/lib/ConstTransitivePtr.h
@@ -16,7 +16,7 @@ VCMI_LIB_NAMESPACE_BEGIN
 template <typename T>
 class ConstTransitivePtr
 {
-	T *ptr;
+	T *ptr = nullptr;
 	ConstTransitivePtr(const T *Ptr)
 		: ptr(const_cast<T*>(Ptr)) 
 	{}
@@ -25,10 +25,7 @@ public:
 		: ptr(Ptr) 
 	{}
 	ConstTransitivePtr(std::nullptr_t)
-		: ptr(nullptr) 
 	{}
-
-
 	const T& operator*() const
 	{
 		return *ptr;

--- a/lib/int3.h
+++ b/lib/int3.h
@@ -18,48 +18,41 @@ public:
 	si32 x, y, z;
 
 	//c-tor: x, y, z initialized to 0
-	int3() : x(0), y(0), z(0) {} // I think that x, y, z should be left uninitialized.
+	constexpr int3() : x(0), y(0), z(0) {} // I think that x, y, z should be left uninitialized.
 	//c-tor: x, y, z initialized to i
-	explicit int3(const si32 i) : x(i), y(i), z(i) {}
+	explicit constexpr int3(const si32 i) : x(i), y(i), z(i) {}
 	//c-tor: x, y, z initialized to X, Y, Z
-	int3(const si32 X, const si32 Y, const si32 Z) : x(X), y(Y), z(Z) {}
-	int3(const int3 & c) : x(c.x), y(c.y), z(c.z) {} // Should be set to default (C++11)?
+	constexpr int3(const si32 X, const si32 Y, const si32 Z) : x(X), y(Y), z(Z) {}
+	constexpr int3(const int3 & c) = default;
 
-	int3 & operator=(const int3 & c) // Should be set to default (C++11)?
-	{
-		x = c.x;
-		y = c.y;
-		z = c.z;
+	constexpr int3 & operator=(const int3 & c) = default;
+	constexpr int3 operator-() const { return int3(-x, -y, -z); }
 
-		return *this;
-	}
-	int3 operator-() const { return int3(-x, -y, -z); }
-
-	int3 operator+(const int3 & i) const { return int3(x + i.x, y + i.y, z + i.z); }
-	int3 operator-(const int3 & i) const { return int3(x - i.x, y - i.y, z - i.z); }
+	constexpr int3 operator+(const int3 & i) const { return int3(x + i.x, y + i.y, z + i.z); }
+	constexpr int3 operator-(const int3 & i) const { return int3(x - i.x, y - i.y, z - i.z); }
 	//returns int3 with coordinates increased by given number
-	int3 operator+(const si32 i) const { return int3(x + i, y + i, z + i); }
+	constexpr int3 operator+(const si32 i) const { return int3(x + i, y + i, z + i); }
 	//returns int3 with coordinates decreased by given number
-	int3 operator-(const si32 i) const { return int3(x - i, y - i, z - i); }
+	constexpr int3 operator-(const si32 i) const { return int3(x - i, y - i, z - i); }
 
 	//returns int3 with coordinates multiplied by given number
-	int3 operator*(const double i) const { return int3((int)(x * i), (int)(y * i), (int)(z * i)); }
+	constexpr int3 operator*(const double i) const { return int3((int)(x * i), (int)(y * i), (int)(z * i)); }
 	//returns int3 with coordinates divided by given number
-	int3 operator/(const double i) const { return int3((int)(x / i), (int)(y / i), (int)(z / i)); }
+	constexpr int3 operator/(const double i) const { return int3((int)(x / i), (int)(y / i), (int)(z / i)); }
 
 	//returns int3 with coordinates multiplied by given number
-	int3 operator*(const si32 i) const { return int3(x * i, y * i, z * i); }
+	constexpr int3 operator*(const si32 i) const { return int3(x * i, y * i, z * i); }
 	//returns int3 with coordinates divided by given number
-	int3 operator/(const si32 i) const { return int3(x / i, y / i, z / i); }
+	constexpr int3 operator/(const si32 i) const { return int3(x / i, y / i, z / i); }
 
-	int3 & operator+=(const int3 & i)
+	constexpr int3 & operator+=(const int3 & i)
 	{
 		x += i.x;
 		y += i.y;
 		z += i.z;
 		return *this;
 	}
-	int3 & operator-=(const int3 & i)
+	constexpr int3 & operator-=(const int3 & i)
 	{
 		x -= i.x;
 		y -= i.y;
@@ -68,7 +61,7 @@ public:
 	}
 
 	//increases all coordinates by given number
-	int3 & operator+=(const si32 i)
+	constexpr int3 & operator+=(const si32 i)
 	{
 		x += i;
 		y += i;
@@ -76,7 +69,7 @@ public:
 		return *this;
 	}
 	//decreases all coordinates by given number
-	int3 & operator-=(const si32 i)
+	constexpr int3 & operator-=(const si32 i)
 	{
 		x -= i;
 		y -= i;
@@ -84,10 +77,10 @@ public:
 		return *this;
 	}
 
-	bool operator==(const int3 & i) const { return (x == i.x && y == i.y && z == i.z); }
-	bool operator!=(const int3 & i) const { return (x != i.x || y != i.y || z != i.z); }
+	constexpr bool operator==(const int3 & i) const { return (x == i.x && y == i.y && z == i.z); }
+	constexpr bool operator!=(const int3 & i) const { return (x != i.x || y != i.y || z != i.z); }
 
-	bool operator<(const int3 & i) const
+	constexpr bool operator<(const int3 & i) const
 	{
 		if (z < i.z)
 			return true;
@@ -130,7 +123,7 @@ public:
 	}
 
 	//returns squared distance on Oxy plane (z coord is not used)
-	ui32 dist2dSQ(const int3 & o) const
+	constexpr ui32 dist2dSQ(const int3 & o) const
 	{
 		const si32 dx = (x - o.x);
 		const si32 dy = (y - o.y);
@@ -142,17 +135,17 @@ public:
 		return std::sqrt((double)dist2dSQ(o));
 	}
 	//manhattan distance used for patrol radius (z coord is not used)
-	double mandist2d(const int3 & o) const
+	constexpr double mandist2d(const int3 & o) const
 	{
-		return abs(o.x - x) + abs(o.y - y);
+		return vstd::abs(o.x - x) + vstd::abs(o.y - y);
 	}
 	//chebyshev distance used for ambient sounds (z coord is not used)
-	double chebdist2d(const int3 & o) const
+	constexpr double chebdist2d(const int3 & o) const
 	{
-		return std::max(std::abs(o.x - x), std::abs(o.y - y));
+		return std::max(vstd::abs(o.x - x), vstd::abs(o.y - y));
 	}
 
-	bool areNeighbours(const int3 & o) const
+	constexpr bool areNeighbours(const int3 & o) const
 	{
 		return (dist2dSQ(o) < 4) && (z == o.z);
 	}
@@ -169,7 +162,7 @@ public:
 		return result;
 	}
 
-	bool valid() const //Should be named "isValid"?
+	constexpr bool valid() const //Should be named "isValid"?
 	{
 		return z >= 0; //minimal condition that needs to be fulfilled for tiles in the map
 	}
@@ -182,7 +175,7 @@ public:
 		h & z;
 	}
 
-	static std::array<int3, 8> getDirs()
+	constexpr static std::array<int3, 8> getDirs()
 	{
 		return { { int3(0,1,0),int3(0,-1,0),int3(-1,0,0),int3(+1,0,0),
 			int3(1,1,0),int3(-1,1,0),int3(1,-1,0),int3(-1,-1,0) } };

--- a/lib/rmg/ObjectManager.cpp
+++ b/lib/rmg/ObjectManager.cpp
@@ -241,7 +241,6 @@ bool ObjectManager::createRequiredObjects()
 	for(const auto & object : requiredObjects)
 	{
 		auto * obj = object.first;
-		int3 pos;
 		rmg::Object rmgObject(*obj);
 		rmgObject.setTemplate(zone.getTerrainType());
 		bool guarded = addGuard(rmgObject, object.second, (obj->ID == Obj::MONOLITH_TWO_WAY));
@@ -278,7 +277,6 @@ bool ObjectManager::createRequiredObjects()
 	for(const auto & object : closeObjects)
 	{
 		auto * obj = object.first;
-		int3 pos;
 		auto possibleArea = zone.areaPossible();
 		rmg::Object rmgObject(*obj);
 		rmgObject.setTemplate(zone.getTerrainType());

--- a/lib/rmg/TreasurePlacer.cpp
+++ b/lib/rmg/TreasurePlacer.cpp
@@ -736,7 +736,6 @@ void TreasurePlacer::createTreasures(ObjectManager & manager)
 			if(guarded)
 				guarded = manager.addGuard(rmgObject, value);
 			
-			int3 pos;
 			auto possibleArea = zone.areaPossible();
 			
 			auto path = rmg::Path::invalid();


### PR DESCRIPTION
This is a set of small optimizations for VCMI:

1. make ConstTransitivePtr always init self as nullptr
2. make int3 as constexpr, which allows us to calculate map distances between fixed points at compile time
3. Remove some unused variables
4. Remove int3 overflow from client, which can be noticed only if constexpr.
5. Add missing include to GUIClasses.cpp, which fixes build with clang++ 15 on ArchLinux.