### PR TITLE
combined art move

### DIFF
--- a/client/widgets/CArtifactHolder.h
+++ b/client/widgets/CArtifactHolder.h
@@ -90,7 +90,6 @@ public:
 	void clickLeft(tribool down, bool previousState) override;
 	void clickRight(tribool down, bool previousState) override;
 	void select();
-	void deselect();
 	void showAll(SDL_Surface * to) override;
 	bool fitsHere (const CArtifactInstance * art) const; //returns true if given artifact can be placed here
 

--- a/lib/CArtHandler.cpp
+++ b/lib/CArtHandler.cpp
@@ -1365,8 +1365,10 @@ const ArtSlotInfo * CArtifactSet::getSlot(ArtifactPosition pos) const
 	if(pos == ArtifactPosition::TRANSITION_POS)
 	{
 		// Always add to the end. Always take from the beginning.
-		assert(!artifactsTransitionPos.empty());
-		return &(*artifactsTransitionPos.begin());
+		if(artifactsTransitionPos.empty())
+			return nullptr;
+		else
+			return &(*artifactsTransitionPos.begin());
 	}
 	if(vstd::contains(artifactsWorn, pos))
 		return &artifactsWorn.at(pos);


### PR DESCRIPTION
Allows to move combined to slots locked by the same artifact.
![move](https://user-images.githubusercontent.com/87084363/218326689-53460d8e-ea05-43cd-b985-63c0e0bd556d.png)

This PR makes a change in the mechanics of client-server art transfers.
Now, as soon as the user selects a slot with an artifact, "moveArtifact" is immediately sent to the server. Artifact moves to transit location. This frees up the slot. This approach simplifies the code.

Another approach is when we send "move Artifact" when the user puts the Artifact to slot (as it was before). Code becomes too unwieldy.

Third approach: These changes are not significant. We leave code as is.

I prefer the first one (this PR). I think that +1 transver is not a problem.