### PR TITLE
remove copy-pasted ioapi.c functions from FileStream.cpp

### DIFF
--- a/lib/filesystem/FileStream.cpp
+++ b/lib/filesystem/FileStream.cpp
@@ -20,6 +20,8 @@
 
 #include <cstdio>
 
+#define GETFILE static_cast<std::FILE*>(filePtr)
+
 #ifdef VCMI_WINDOWS
 	#ifndef _CRT_SECURE_NO_WARNINGS
 		#define _CRT_SECURE_NO_WARNINGS
@@ -43,12 +45,10 @@ inline FILE* do_open(const CharType* name, const CharType* mode)
 	#endif
 }
 
-#define GETFILE static_cast<std::FILE*>(filePtr)
-
 voidpf ZCALLBACK MinizipOpenFunc(voidpf opaque, const void* filename, int mode)
 {
-    const CharType* mode_fopen = [mode]() -> const CharType*
-    {
+	const CharType* mode_fopen = [mode]() -> const CharType*
+	{
 		if ((mode & ZLIB_FILEFUNC_MODE_READWRITEFILTER) == ZLIB_FILEFUNC_MODE_READ)
 			return CHAR_LITERAL("rb");
 		else if (mode & ZLIB_FILEFUNC_MODE_EXISTING)
@@ -56,10 +56,10 @@ voidpf ZCALLBACK MinizipOpenFunc(voidpf opaque, const void* filename, int mode)
 		else if (mode & ZLIB_FILEFUNC_MODE_CREATE)
 			return CHAR_LITERAL("wb");
 		return nullptr;
-    }();
+	}();
 
-    if (filename != nullptr && mode_fopen != nullptr)
-        return do_open(static_cast<const CharType*>(filename), mode_fopen);
+	if (filename != nullptr && mode_fopen != nullptr)
+		return do_open(static_cast<const CharType*>(filename), mode_fopen);
 	else
 		return nullptr;
 }

--- a/lib/filesystem/FileStream.cpp
+++ b/lib/filesystem/FileStream.cpp
@@ -12,155 +12,13 @@
 
 #ifdef USE_SYSTEM_MINIZIP
 #include <minizip/unzip.h>
+#include <minizip/ioapi.h>
 #else
 #include "../minizip/unzip.h"
+#include "../minizip/ioapi.h"
 #endif
 
 #include <cstdio>
-
-///copied from ioapi.c due to linker issues on MSVS
-
-#include "../minizip/ioapi.h"
-
-#if defined(__APPLE__) || defined(IOAPI_NO_64)
-// In darwin and perhaps other BSD variants off_t is a 64 bit value, hence no need for specific 64 bit functions
-#define FOPEN_FUNC(filename, mode) fopen(filename, mode)
-#define FTELLO_FUNC(stream) ftello(stream)
-#define FSEEKO_FUNC(stream, offset, origin) fseeko(stream, offset, origin)
-#else
-#define FOPEN_FUNC(filename, mode) fopen64(filename, mode)
-#define FTELLO_FUNC(stream) ftello64(stream)
-#define FSEEKO_FUNC(stream, offset, origin) fseeko64(stream, offset, origin)
-#endif
-
-voidpf call_zopen64 (const zlib_filefunc64_32_def* pfilefunc,const void*filename,int mode)
-{
-	if (pfilefunc->zfile_func64.zopen64_file != NULL)
-		return (*(pfilefunc->zfile_func64.zopen64_file)) (pfilefunc->zfile_func64.opaque,filename,mode);
-	else
-	{
-		return (*(pfilefunc->zopen32_file))(pfilefunc->zfile_func64.opaque,(const char*)filename,mode);
-	}
-}
-
-long call_zseek64(const zlib_filefunc64_32_def* pfilefunc, voidpf filestream, ZPOS64_T offset, int origin)
-{
-	if (pfilefunc->zfile_func64.zseek64_file != NULL)
-		return (*(pfilefunc->zfile_func64.zseek64_file)) (pfilefunc->zfile_func64.opaque, filestream, offset, origin);
-	else
-	{
-		uLong offsetTruncated = (uLong)offset;
-		if (offsetTruncated != offset)
-			return -1;
-		else
-			return (*(pfilefunc->zseek32_file))(pfilefunc->zfile_func64.opaque, filestream, offsetTruncated, origin);
-	}
-}
-
-ZPOS64_T call_ztell64(const zlib_filefunc64_32_def* pfilefunc, voidpf filestream)
-{
-	if (pfilefunc->zfile_func64.zseek64_file != NULL)
-		return (*(pfilefunc->zfile_func64.ztell64_file)) (pfilefunc->zfile_func64.opaque, filestream);
-	else
-	{
-		uLong tell_uLong = (*(pfilefunc->ztell32_file))(pfilefunc->zfile_func64.opaque, filestream);
-		if ((tell_uLong) == MAXU32)
-			return (ZPOS64_T)-1;
-		else
-			return tell_uLong;
-	}
-}
-
-static uLong   ZCALLBACK fread_file_func OF((voidpf opaque, voidpf stream, void* buf, uLong size));
-static uLong   ZCALLBACK fwrite_file_func OF((voidpf opaque, voidpf stream, const void* buf,uLong size));
-static ZPOS64_T ZCALLBACK ftell64_file_func OF((voidpf opaque, voidpf stream));
-static long    ZCALLBACK fseek64_file_func OF((voidpf opaque, voidpf stream, ZPOS64_T offset, int origin));
-static int     ZCALLBACK fclose_file_func OF((voidpf opaque, voidpf stream));
-static int     ZCALLBACK ferror_file_func OF((voidpf opaque, voidpf stream));
-
-static voidpf ZCALLBACK fopen64_file_func(voidpf opaque, const void* filename, int mode)
-{
-	FILE* file = NULL;
-	const char* mode_fopen = NULL;
-	if ((mode & ZLIB_FILEFUNC_MODE_READWRITEFILTER) == ZLIB_FILEFUNC_MODE_READ)
-		mode_fopen = "rb";
-	else
-		if (mode & ZLIB_FILEFUNC_MODE_EXISTING)
-			mode_fopen = "r+b";
-		else
-			if (mode & ZLIB_FILEFUNC_MODE_CREATE)
-				mode_fopen = "wb";
-
-	if ((filename != NULL) && (mode_fopen != NULL))
-		file = FOPEN_FUNC((const char*)filename, mode_fopen);
-	return file;
-}
-
-
-static uLong ZCALLBACK fread_file_func(voidpf opaque, voidpf stream, void* buf, uLong size)
-{
-	uLong ret;
-	ret = (uLong)fread(buf, 1, (size_t)size, (FILE *)stream);
-	return ret;
-}
-
-static uLong ZCALLBACK fwrite_file_func(voidpf opaque, voidpf stream, const void* buf, uLong size)
-{
-	uLong ret;
-	ret = (uLong)fwrite(buf, 1, (size_t)size, (FILE *)stream);
-	return ret;
-}
-
-static ZPOS64_T ZCALLBACK ftell64_file_func(voidpf opaque, voidpf stream)
-{
-	ZPOS64_T ret;
-	ret = FTELLO_FUNC((FILE *)stream);
-	return ret;
-}
-
-static long ZCALLBACK fseek64_file_func(voidpf  opaque, voidpf stream, ZPOS64_T offset, int origin)
-{
-	int fseek_origin = 0;
-	long ret;
-	switch (origin)
-	{
-	case ZLIB_FILEFUNC_SEEK_CUR:
-		fseek_origin = SEEK_CUR;
-		break;
-	case ZLIB_FILEFUNC_SEEK_END:
-		fseek_origin = SEEK_END;
-		break;
-	case ZLIB_FILEFUNC_SEEK_SET:
-		fseek_origin = SEEK_SET;
-		break;
-	default: return -1;
-	}
-	ret = 0;
-
-	if (FSEEKO_FUNC((FILE *)stream, offset, fseek_origin) != 0)
-		ret = -1;
-
-	return ret;
-}
-
-
-static int ZCALLBACK fclose_file_func(voidpf opaque, voidpf stream)
-{
-	int ret;
-	ret = fclose((FILE *)stream);
-	return ret;
-}
-
-static int ZCALLBACK ferror_file_func(voidpf opaque, voidpf stream)
-{
-	int ret;
-	ret = ferror((FILE *)stream);
-	return ret;
-}
-
-///end of ioapi.c
-
-//extern MINIZIP_EXPORT void fill_fopen64_filefunc(zlib_filefunc64_def*  pzlib_filefunc_def);
 
 #ifdef VCMI_WINDOWS
 	#ifndef _CRT_SECURE_NO_WARNINGS
@@ -203,20 +61,6 @@ voidpf ZCALLBACK MinizipOpenFunc(voidpf opaque, const void* filename, int mode)
 	else
 		return nullptr;
 }
-
-
-void fill_fopen64_filefunc(zlib_filefunc64_def*  pzlib_filefunc_def)
-{
-	pzlib_filefunc_def->zopen64_file = fopen64_file_func;
-	pzlib_filefunc_def->zread_file = fread_file_func;
-	pzlib_filefunc_def->zwrite_file = fwrite_file_func;
-	pzlib_filefunc_def->ztell64_file = ftell64_file_func;
-	pzlib_filefunc_def->zseek64_file = fseek64_file_func;
-	pzlib_filefunc_def->zclose_file = fclose_file_func;
-	pzlib_filefunc_def->zerror_file = ferror_file_func;
-	pzlib_filefunc_def->opaque = NULL;
-}
-
 
 template struct boost::iostreams::stream<VCMI_LIB_WRAP_NAMESPACE(FileBuf)>;
 

--- a/lib/filesystem/FileStream.cpp
+++ b/lib/filesystem/FileStream.cpp
@@ -32,6 +32,8 @@
 	using CharType = char;
 #endif
 
+namespace
+{
 inline FILE* do_open(const CharType* name, const CharType* mode)
 {
 	#ifdef VCMI_WINDOWS
@@ -61,6 +63,7 @@ voidpf ZCALLBACK MinizipOpenFunc(voidpf opaque, const void* filename, int mode)
 	else
 		return nullptr;
 }
+} // namespace
 
 template struct boost::iostreams::stream<VCMI_LIB_WRAP_NAMESPACE(FileBuf)>;
 

--- a/lib/minizip/ioapi.h
+++ b/lib/minizip/ioapi.h
@@ -201,7 +201,7 @@ typedef struct zlib_filefunc64_def_s
     voidpf              opaque;
 } zlib_filefunc64_def;
 
-void fill_fopen64_filefunc OF((zlib_filefunc64_def* pzlib_filefunc_def));
+void MINIZIP_EXPORT fill_fopen64_filefunc OF((zlib_filefunc64_def* pzlib_filefunc_def));
 void fill_fopen_filefunc OF((zlib_filefunc_def* pzlib_filefunc_def));
 
 /* now internal definition, only for zip.c and unzip.h */


### PR DESCRIPTION
> copied from ioapi.c due to linker issues on MSVS

seems like an issue in the library header (function not exported) which I adjusted. In upstream declaration is still the same, but no bug reports about it...

anonymous namespace, besides sensible improvement, fixes single-process build on android.

Probably whole FileStream class can be moved to a separate library:
- it has no dependencies on VCMI lib
- in single process build both copies of VCMI lib will contain exactly the same thing => can be made a shared lib ("normal" build can have it static)