### PR TITLE
Optimization and cleanup CArtifactHolder

### DIFF
--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -143,6 +143,7 @@ CPlayerInterface::CPlayerInterface(PlayerColor Player)
 
 	duringMovement = false;
 	ignoreEvents = false;
+	numOfMovedArts = 0;
 }
 
 CPlayerInterface::~CPlayerInterface()
@@ -2145,21 +2146,28 @@ void CPlayerInterface::artifactMoved(const ArtifactLocation &src, const Artifact
 {
 	EVENT_HANDLER_CALLED_BY_CLIENT;
 	adventureInt->infoBar->showSelection();
+
+	bool redraw = true;
+	// If a bulk transfer has arrived, then redrawing only the last art movement.
+	if(numOfMovedArts != 0)
+	{
+		numOfMovedArts--;
+		if(numOfMovedArts != 0)
+			redraw = false;
+	}
+
 	for(auto isa : GH.listInt)
 	{
 		auto artWin = dynamic_cast<CArtifactHolder*>(isa.get());
 		if (artWin)
-			artWin->artifactMoved(src, dst);
+			artWin->artifactMoved(src, dst, redraw);
 	}
-	if(!GH.objsToBlit.empty())
-		GH.objsToBlit.back()->redraw();
-
 	waitWhileDialog();
 }
 
-void CPlayerInterface::artifactPossibleAssembling(const ArtifactLocation & dst)
+void CPlayerInterface::bulkArtMovementStart(size_t numOfArts)
 {
-	askToAssembleArtifact(dst);
+	numOfMovedArts = numOfArts;
 }
 
 void CPlayerInterface::artifactAssembled(const ArtifactLocation &al)

--- a/client/CPlayerInterface.h
+++ b/client/CPlayerInterface.h
@@ -131,8 +131,9 @@ public:
 	void artifactPut(const ArtifactLocation &al) override;
 	void artifactRemoved(const ArtifactLocation &al) override;
 	void artifactMoved(const ArtifactLocation &src, const ArtifactLocation &dst) override;
+	void bulkArtMovementStart(size_t numOfArts) override;
 	void artifactAssembled(const ArtifactLocation &al) override;
-	void artifactPossibleAssembling(const ArtifactLocation & dst) override;
+	void askToAssembleArtifact(const ArtifactLocation & dst) override;
 	void artifactDisassembled(const ArtifactLocation &al) override;
 
 	void heroVisit(const CGHeroInstance * visitor, const CGObjectInstance * visitedObj, bool start) override;
@@ -276,10 +277,10 @@ private:
 
 	bool duringMovement;
 	bool ignoreEvents;
+	size_t numOfMovedArts;
 
 	void doMoveHero(const CGHeroInstance *h, CGPath path);
 	void setMovementStatus(bool value);
-	void askToAssembleArtifact(const ArtifactLocation &al);
 };
 
 extern CPlayerInterface * LOCPLINT;

--- a/client/widgets/CArtifactHolder.h
+++ b/client/widgets/CArtifactHolder.h
@@ -27,7 +27,7 @@ public:
 	CArtifactHolder();
 
 	virtual void artifactRemoved(const ArtifactLocation &artLoc)=0;
-	virtual void artifactMoved(const ArtifactLocation &artLoc, const ArtifactLocation &destLoc)=0;
+	virtual void artifactMoved(const ArtifactLocation &artLoc, const ArtifactLocation &destLoc, bool withRedraw)=0;
 	virtual void artifactDisassembled(const ArtifactLocation &artLoc)=0;
 	virtual void artifactAssembled(const ArtifactLocation &artLoc)=0;
 };
@@ -114,7 +114,6 @@ public:
 			const CArtifactsOfHero *AOH;
 			const CArtifactInstance *art;
 
-			Artpos();
 			void clear();
 			void setTo(const CHeroArtPlace *place, bool dontTakeBackpack);
 			bool valid();
@@ -127,8 +126,6 @@ public:
 	};
 	std::shared_ptr<SCommonPart> commonInfo; //when we have more than one CArtifactsOfHero in one window with exchange possibility, we use this (eg. in exchange window); to be provided externally
 
-	bool updateState; // Whether the commonInfo should be updated on setHero or not.
-
 	std::shared_ptr<CButton> leftArtRoll;
 	std::shared_ptr<CButton> rightArtRoll;
 	bool allowedAssembling;
@@ -137,7 +134,7 @@ public:
 	std::function<void(CHeroArtPlace*)> highlightModeCallback; //if set, clicking on art place doesn't pick artifact but highlights the slot and calls this function
 
 	void realizeCurrentTransaction(); //calls callback with parameters stored in commonInfo
-	void artifactMoved(const ArtifactLocation &src, const ArtifactLocation &dst);
+	void artifactMoved(const ArtifactLocation &src, const ArtifactLocation &dst, bool withUIUpdate);
 	void artifactRemoved(const ArtifactLocation &al);
 	void artifactUpdateSlots(const ArtifactLocation &al);
 	ArtPlacePtr getArtPlace(ArtifactPosition slot);//may return null
@@ -151,11 +148,11 @@ public:
 	void deactivate() override;
 
 	void safeRedraw();
-	void markPossibleSlots(const CArtifactInstance* art);
-	void unmarkSlots(bool withRedraw = true); //unmarks slots in all visible AOHs
-	void unmarkLocalSlots(bool withRedraw = true); //unmarks slots in that particular AOH
-	void updateWornSlots(bool redrawParent = true);
-	void updateBackpackSlots(bool redrawParent = true);
+	void markPossibleSlots(const CArtifactInstance * art, bool withRedraw = false);
+	void unmarkSlots(bool withRedraw = false); //unmarks slots in all visible AOHs
+	void unmarkLocalSlots(bool withRedraw = false); //unmarks slots in that particular AOH
+	void updateWornSlots(bool redrawParent = false);
+	void updateBackpackSlots(bool redrawParent = false);
 
 	void updateSlot(ArtifactPosition i);
 
@@ -189,7 +186,7 @@ public:
 	std::shared_ptr<CArtifactsOfHero::SCommonPart> getCommonPart();
 
 	void artifactRemoved(const ArtifactLocation &artLoc) override;
-	void artifactMoved(const ArtifactLocation &artLoc, const ArtifactLocation &destLoc) override;
+	void artifactMoved(const ArtifactLocation &artLoc, const ArtifactLocation &destLoc, bool withRedraw) override;
 	void artifactDisassembled(const ArtifactLocation &artLoc) override;
 	void artifactAssembled(const ArtifactLocation &artLoc) override;
 };

--- a/client/windows/CKingdomInterface.cpp
+++ b/client/windows/CKingdomInterface.cpp
@@ -668,10 +668,10 @@ void CKingdomInterface::artifactDisassembled(const ArtifactLocation& artLoc)
 		arts->artifactDisassembled(artLoc);
 }
 
-void CKingdomInterface::artifactMoved(const ArtifactLocation& artLoc, const ArtifactLocation& destLoc)
+void CKingdomInterface::artifactMoved(const ArtifactLocation& artLoc, const ArtifactLocation& destLoc, bool withRedraw)
 {
 	if(auto arts = std::dynamic_pointer_cast<CArtifactHolder>(tabArea->getItem()))
-		arts->artifactMoved(artLoc, destLoc);
+		arts->artifactMoved(artLoc, destLoc, withRedraw);
 }
 
 void CKingdomInterface::artifactRemoved(const ArtifactLocation& artLoc)

--- a/client/windows/CKingdomInterface.h
+++ b/client/windows/CKingdomInterface.h
@@ -251,7 +251,7 @@ public:
 	void townChanged(const CGTownInstance *town);
 	void updateGarrisons() override;
 	void artifactRemoved(const ArtifactLocation &artLoc) override;
-	void artifactMoved(const ArtifactLocation &artLoc, const ArtifactLocation &destLoc) override;
+	void artifactMoved(const ArtifactLocation &artLoc, const ArtifactLocation &destLoc, bool withRedraw) override;
 	void artifactDisassembled(const ArtifactLocation &artLoc) override;
 	void artifactAssembled(const ArtifactLocation &artLoc) override;
 };

--- a/lib/IGameEventsReceiver.h
+++ b/lib/IGameEventsReceiver.h
@@ -90,7 +90,8 @@ public:
 	virtual void artifactAssembled(const ArtifactLocation &al){};
 	virtual void artifactDisassembled(const ArtifactLocation &al){};
 	virtual void artifactMoved(const ArtifactLocation &src, const ArtifactLocation &dst){};
-	virtual void artifactPossibleAssembling(const ArtifactLocation & dst) {};
+	virtual void bulkArtMovementStart(size_t numOfArts) {};
+	virtual void askToAssembleArtifact(const ArtifactLocation & dst) {};
 
 	virtual void heroVisit(const CGHeroInstance *visitor, const CGObjectInstance *visitedObj, bool start){};
 	virtual void heroCreated(const CGHeroInstance*){};


### PR DESCRIPTION
Removed extra screen redraw operations. This is especially useful for bulk movements of arts. Also some code cleanup.