### PR TITLE
Fix battle ai trying to act with killed stack

### DIFF
--- a/AI/BattleAI/BattleAI.cpp
+++ b/AI/BattleAI/BattleAI.cpp
@@ -117,9 +117,9 @@ BattleAction CBattleAI::activeStack( const CStack * stack )
 
 		attemptCastingSpell();
 
-		if(auto ret = cb->battleIsFinished())
+		if(cb->battleIsFinished() || !stack->alive())
 		{
-			//spellcast may finish battle
+			//spellcast may finish battle or kill active stack
 			//send special preudo-action
 			BattleAction cancel;
 			cancel.actionType = EActionType::CANCEL;


### PR DESCRIPTION
There is a crash dump showing that somehow AI managed to kill own stack with spellcast. Theoretically it is prohibited to injure own stacks so this should not happen but it did somehow. So kind of blind fix.