### PR TITLE
vcmi: allow loads bonuses info from mods

### DIFF
--- a/config/schemas/mod.json
+++ b/config/schemas/mod.json
@@ -141,6 +141,12 @@
 			"description": "List of configuration files for artifacts",
 			"items": { "type":"string", "format" : "textFile" }
 		},
+		"bonuses":{
+			"type":"array",
+			"description": "List of configuration files for bonuses",
+			"items": { "type":"string", "format" : "textFile" }
+
+		},
 		"creatures": {
 			"type":"array",
 			"description": "List of configuration files for creatures",


### PR DESCRIPTION
It is useful for making custom bonus graphics into mods, now mods just replace game config, which is not good.

Please, backport into stable if possible.

@IvanSavenko 