### PR TITLE
Arts swap regression fixed

### DIFF
--- a/client/widgets/CArtifactHolder.cpp
+++ b/client/widgets/CArtifactHolder.cpp
@@ -633,7 +633,7 @@ CArtifactsOfHero::~CArtifactsOfHero()
 	if(!curHero->artifactsTransitionPos.empty())
 	{
 		auto artPlace = getArtPlace(
-			ArtifactUtils::getArtifactDstPosition(curHero->artifactsTransitionPos.begin()->artifact, curHero, curHero->bearerType()));
+			ArtifactUtils::getArtifactDstPosition(curHero->artifactsTransitionPos.begin()->artifact, curHero));
 		assert(artPlace);
 		assert(artPlace->ourOwner);
 		artPlace->setMeAsDest();
@@ -748,10 +748,7 @@ void CArtifactsOfHero::artifactMoved(const ArtifactLocation & src, const Artifac
 	if(withUIUpdate)
 	{
 		updateParentWindow();
-		// If backpack is changed, update it
-		if((isCurHeroSrc && ArtifactUtils::isSlotBackpack(src.slot))
-			|| (isCurHeroDst && ArtifactUtils::isSlotBackpack(dst.slot)))
-			scrollBackpack(0);
+		scrollBackpack(0);
 	}
 }
 

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -841,7 +841,7 @@ void CExchangeController::moveArtifact(
 {
 	auto srcLocation = ArtifactLocation(source, srcPosition);
 	auto dstLocation = ArtifactLocation(target,
-		ArtifactUtils::getArtifactDstPosition(source->getArt(srcPosition), target, target->bearerType()));
+		ArtifactUtils::getArtifactDstPosition(source->getArt(srcPosition), target));
 
 	cb->swapArtifacts(srcLocation, dstLocation);
 }

--- a/lib/CArtHandler.cpp
+++ b/lib/CArtHandler.cpp
@@ -410,7 +410,7 @@ void CArtHandler::addSlot(CArtifact * art, const std::string & slotID)
 
 	static const std::vector<ArtifactPosition> ringSlots =
 	{
-		ArtifactPosition::LEFT_RING, ArtifactPosition::RIGHT_RING
+		ArtifactPosition::RIGHT_RING, ArtifactPosition::LEFT_RING
 	};
 
 	if (slotID == "MISC")
@@ -425,7 +425,7 @@ void CArtHandler::addSlot(CArtifact * art, const std::string & slotID)
 	{
 		auto slot = ArtifactPosition(slotID);
 		if (slot != ArtifactPosition::PRE_FIRST)
-			art->possibleSlots[ArtBearer::HERO].push_back (slot);
+			art->possibleSlots[ArtBearer::HERO].push_back(slot);
 	}
 }
 
@@ -440,6 +440,7 @@ void CArtHandler::loadSlots(CArtifact * art, const JsonNode & node)
 			for (const JsonNode & slot : node["slot"].Vector())
 				addSlot(art, slot.String());
 		}
+		std::sort(art->possibleSlots.at(ArtBearer::HERO).begin(), art->possibleSlots.at(ArtBearer::HERO).end());
 	}
 }
 
@@ -1565,17 +1566,14 @@ ArtBearer::ArtBearer CArtifactFittingSet::bearerType() const
 	return this->Bearer;
 }
 
-DLL_LINKAGE ArtifactPosition ArtifactUtils::getArtifactDstPosition(	const CArtifactInstance * artifact,
-									const CArtifactSet * target, 
-									ArtBearer::ArtBearer bearer)
+DLL_LINKAGE ArtifactPosition ArtifactUtils::getArtifactDstPosition(const CArtifactInstance * artifact,
+	const CArtifactSet * target)
 {
-	for(auto slot : artifact->artType->possibleSlots.at(bearer))
+	for(auto slot : artifact->artType->possibleSlots.at(target->bearerType()))
 	{
-		auto existingArtifact = target->getArt(slot);
 		auto existingArtInfo = target->getSlot(slot);
 
-		if(!existingArtifact
-			&& (!existingArtInfo || !existingArtInfo->locked)
+		if((!existingArtInfo || !existingArtInfo->locked)
 			&& artifact->canBePutAt(target, slot))
 		{
 			return slot;

--- a/lib/CArtHandler.h
+++ b/lib/CArtHandler.h
@@ -384,9 +384,8 @@ protected:
 namespace ArtifactUtils
 {
 	// Calculates where an artifact gets placed when it gets transferred from one hero to another.
-	DLL_LINKAGE ArtifactPosition getArtifactDstPosition(	const CArtifactInstance * artifact, 
-								const CArtifactSet * target,
-								ArtBearer::ArtBearer bearer);
+	DLL_LINKAGE ArtifactPosition getArtifactDstPosition(const CArtifactInstance * artifact, 
+		const CArtifactSet * target);
 	// TODO: Make this constexpr when the toolset is upgraded
 	DLL_LINKAGE const std::vector<ArtifactPosition::EArtifactPosition> & unmovableSlots();
 	DLL_LINKAGE const std::vector<ArtifactPosition::EArtifactPosition> & constituentWornSlots();


### PR DESCRIPTION
Regression caused by https://github.com/vcmi/vcmi/pull/1112 fixed.
Place artifacts as in the pic. And click swap.
![step1](https://user-images.githubusercontent.com/87084363/223408129-3ba2f78a-3486-4011-81fe-b3dc44d8899b.png)
 Observe wrong placement
![step2](https://user-images.githubusercontent.com/87084363/223408289-a5952dfd-2df8-460b-80bd-577a6048548c.png)