### PR TITLE
Do not show visitable for current hero

### DIFF
--- a/client/mapView/IMapRendererContext.h
+++ b/client/mapView/IMapRendererContext.h
@@ -52,6 +52,9 @@ public:
 	/// returns true if specified tile is visible in current context
 	virtual bool isVisible(const int3 & coordinates) const = 0;
 
+	/// returns true if specified object is the currently active hero
+	virtual bool isActiveHero(const CGObjectInstance* obj) const = 0;
+
 	virtual size_t objectGroupIndex(ObjectInstanceID objectID) const = 0;
 	virtual Point objectImageOffset(ObjectInstanceID objectID, const int3 & coordinates) const = 0;
 

--- a/client/mapView/MapRenderer.cpp
+++ b/client/mapView/MapRenderer.cpp
@@ -601,7 +601,7 @@ void MapRendererDebug::renderTile(IMapRendererContext & context, Canvas & target
 		{
 			const auto * object = context.getObject(objectID);
 
-			if (context.objectTransparency(objectID, coordinates) > 0)
+			if(context.objectTransparency(objectID, coordinates) > 0 && !context.isActiveHero(object))
 			{
 				visitable |= object->visitableAt(coordinates.x, coordinates.y);
 				blocking |= object->blockingAt(coordinates.x, coordinates.y);

--- a/client/mapView/MapRendererContext.cpp
+++ b/client/mapView/MapRendererContext.cpp
@@ -68,6 +68,21 @@ bool MapRendererBaseContext::isVisible(const int3 & coordinates) const
 		return LOCPLINT->cb->isVisible(coordinates);
 }
 
+bool MapRendererBaseContext::isActiveHero(const CGObjectInstance * obj) const
+{
+	if(obj->ID == Obj::HERO)
+	{
+		assert(dynamic_cast<const CGHeroInstance *>(obj) != nullptr);
+		if(adventureInt->curHero() != nullptr)
+		{
+			if(obj->id == adventureInt->curHero()->id)
+				return true;
+		}
+	}
+
+	return false;
+}
+
 bool MapRendererBaseContext::tileAnimated(const int3 & coordinates) const
 {
 	return false;

--- a/client/mapView/MapRendererContext.h
+++ b/client/mapView/MapRendererContext.h
@@ -35,6 +35,8 @@ public:
 	bool isVisible(const int3 & coordinates) const override;
 	bool tileAnimated(const int3 & coordinates) const override;
 
+	bool isActiveHero(const CGObjectInstance* obj) const override;
+
 	const TerrainTile & getMapTile(const int3 & coordinates) const override;
 	const MapObjectsList & getObjects(const int3 & coordinates) const override;
 	const CGObjectInstance * getObject(ObjectInstanceID objectID) const override;


### PR DESCRIPTION
The visitable square overlay for selected hero was jerky when hero was moving. This is fixed by removing the `showVisitable `from current hero.