### PR TITLE
vcmi: fix week animation

### DIFF
--- a/client/adventureMap/CInfoBar.cpp
+++ b/client/adventureMap/CInfoBar.cpp
@@ -64,6 +64,7 @@ CInfoBar::VisibleDateInfo::VisibleDateInfo()
 	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
 
 	animation = std::make_shared<CShowableAnim>(1, 0, getNewDayName(), CShowableAnim::PLAY_ONCE, 180);// H3 uses around 175-180 ms per frame
+	animation->setDuration(1500);
 
 	std::string labelText;
 	if(LOCPLINT->cb->getDate(Date::DAY_OF_WEEK) == 1 && LOCPLINT->cb->getDate(Date::DAY) != 1) // monday of any week but first - show new week info
@@ -81,7 +82,7 @@ std::string CInfoBar::VisibleDateInfo::getNewDayName()
 	if(LOCPLINT->cb->getDate(Date::DAY) == 1)
 		return "NEWDAY";
 
-	if(LOCPLINT->cb->getDate(Date::DAY) != 1)
+	if(LOCPLINT->cb->getDate(Date::DAY_OF_WEEK) != 1)
 		return "NEWDAY";
 
 	switch(LOCPLINT->cb->getDate(Date::WEEK))

--- a/client/widgets/Images.cpp
+++ b/client/widgets/Images.cpp
@@ -392,6 +392,11 @@ void CShowableAnim::rotate(bool on, bool vertical)
 		flags &= ~flag;
 }
 
+void CShowableAnim::setDuration(int durationMs)
+{
+	frameTimeTotal = durationMs/(last - first);
+}
+
 CCreatureAnim::CCreatureAnim(int x, int y, std::string name, ui8 flags, ECreatureAnimType type):
 	CShowableAnim(x, y, name, flags, 100, size_t(type)) // H3 uses 100 ms per frame, irregardless of battle speed settings
 {

--- a/client/widgets/Images.h
+++ b/client/widgets/Images.h
@@ -169,6 +169,9 @@ public:
 	//set frame to first, call callback
 	virtual void reset();
 
+	//set animation duration
+	void setDuration(int durationMs);
+
 	//show current frame and increase counter
 	void show(SDL_Surface * to) override;
 	void showAll(SDL_Surface * to) override;


### PR DESCRIPTION
There was always day animation running on new weeks. Run week animation properly now.
Timer for week animation is estimation, maybe not accurately match H3.