### PR TITLE
Create extra Monoliths for RMG

### DIFF
--- a/lib/mapObjects/CObjectClassesHandler.cpp
+++ b/lib/mapObjects/CObjectClassesHandler.cpp
@@ -393,12 +393,43 @@ void CObjectClassesHandler::afterLoadFinalization()
 		}
 	}
 
+	generateExtraMonolithsForRMG();
+}
+
+void CObjectClassesHandler::generateExtraMonolithsForRMG()
+{
 	//duplicate existing two-way portals to make reserve for RMG
 	auto& portalVec = objects[Obj::MONOLITH_TWO_WAY]->objects;
-	size_t portalCount = portalVec.size();
+	//FIXME: Monoliths  in this vector can be already not useful for every terrain
+	const size_t portalCount = portalVec.size();
 
-	for (size_t i = portalCount; i < 100; ++i)
-		portalVec.push_back(portalVec[static_cast<si32>(i % portalCount)]);
+	//Invalid portals will be skipped and portalVec size stays unchanged
+	for (size_t i = portalCount; portalVec.size() < 100; ++i)
+	{
+		auto index = static_cast<si32>(i % portalCount);
+		auto portal = portalVec[index];
+		auto templates = portal->getTemplates();
+		if (templates.empty() || !templates[0]->canBePlacedAtAnyTerrain())
+		{
+			continue; //Do not clone HoTA water-only portals or any others we can't use
+		}
+
+		//deep copy of noncopyable object :?
+		auto newPortal = std::make_shared<CDefaultObjectTypeHandler<CGMonolith>>();
+		newPortal->rmgInfo = portal->getRMGInfo();
+		newPortal->base = portal->base; //not needed?
+		newPortal->templates = portal->getTemplates();
+		newPortal->sounds = portal->getSounds();
+		newPortal->aiValue = portal->getAiValue();
+		newPortal->battlefield = portal->battlefield; //getter is not initialized at this point
+		newPortal->modScope = portal->modScope; //private
+		newPortal->typeName = portal->getTypeName(); 
+		newPortal->subTypeName = std::string("monolith") + std::to_string(portalVec.size());
+		newPortal->type = portal->getIndex();
+
+		newPortal->subtype = portalVec.size(); //indexes must be unique, they are returned as a set
+		portalVec.push_back(newPortal);
+	}
 }
 
 std::string CObjectClassesHandler::getObjectName(si32 type, si32 subtype) const

--- a/lib/mapObjects/CObjectClassesHandler.h
+++ b/lib/mapObjects/CObjectClassesHandler.h
@@ -291,6 +291,8 @@ class DLL_LINKAGE CObjectClassesHandler : public IHandlerBase
 
 	ObjectClass * loadFromJson(const std::string & scope, const JsonNode & json, const std::string & name, size_t index);
 
+	void generateExtraMonolithsForRMG();
+
 public:
 	CObjectClassesHandler();
 	~CObjectClassesHandler();

--- a/lib/mapObjects/ObjectTemplate.h
+++ b/lib/mapObjects/ObjectTemplate.h
@@ -102,6 +102,11 @@ public:
 		return visitDir & 2;
 	};
 
+	inline bool canBePlacedAtAnyTerrain() const
+	{
+		return anyTerrain;
+	}; 
+
 	// Checks if object can be placed on specific terrain
 	bool canBePlacedAt(TerrainId terrain) const;
 

--- a/lib/rmg/CMapGenerator.cpp
+++ b/lib/rmg/CMapGenerator.cpp
@@ -367,10 +367,24 @@ void CMapGenerator::addHeaderInfo()
 
 int CMapGenerator::getNextMonlithIndex()
 {
-	if (monolithIndex >= VLC->objtypeh->knownSubObjects(Obj::MONOLITH_TWO_WAY).size())
-		throw rmgException(boost::to_string(boost::format("There is no Monolith Two Way with index %d available!") % monolithIndex));
-	else
-		return monolithIndex++;
+	while (true)
+	{
+		if (monolithIndex >= VLC->objtypeh->knownSubObjects(Obj::MONOLITH_TWO_WAY).size())
+			throw rmgException(boost::to_string(boost::format("There is no Monolith Two Way with index %d available!") % monolithIndex));
+		else
+		{
+			//Skip modded Monoliths which can't beplaced on every terrain
+			auto templates = VLC->objtypeh->getHandlerFor(Obj::MONOLITH_TWO_WAY, monolithIndex)->getTemplates();
+			if (templates.empty() || !templates[0]->canBePlacedAtAnyTerrain())
+			{
+				monolithIndex++;
+			}
+			else
+			{
+				return monolithIndex++;
+			}
+		}
+	}
 }
 
 int CMapGenerator::getPrisonsRemaning() const


### PR DESCRIPTION
Reuse existing set of Monolith graphics to create 100 pairs with different IDs, so that each pair can create an independent connection.

- Fixes https://github.com/vcmi/vcmi/issues/1687
- Additionally, RMG won't use Monoliths which can't be placed at any land. Some Monoliths from mods do not meet this condition. Missing template could lead to RMG error (couldn't find template for object 45) and missing connection.

![image](https://user-images.githubusercontent.com/2566990/225528458-8aab3164-bae2-4882-aac8-7a52ced36ae5.png)![image](https://user-images.githubusercontent.com/2566990/225528548-186425cd-6283-4da6-8f4a-173d69b81e27.png)
