### PR TITLE
Disable loading of client save game

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -54,7 +54,6 @@
 * Hero movement speed now matches H3
 * Improved performance of adventure map rendering
 * Fixed embarking and disembarking sounds
-* Fixed loading of sleeping status and movement path of heroes
 * Fixed selection of "new week" animation for status window
 * Object render order now mostly matches H3
 

--- a/client/Client.cpp
+++ b/client/Client.cpp
@@ -202,6 +202,15 @@ void CClient::loadGame(CGameState * initializedGameState)
 
 	initPlayerEnvironments();
 	
+	// Loading of client state - disabled for now
+	// Since client no longer writes or loads its own state and instead receives it from server
+	// client state serializer will serialize its own copies of all pointers, e.g. heroes/towns/objects
+	// and on deserialize will create its own copies (instead of using copies from state received from server)
+	// Potential solutions:
+	// 1) Use server gamestate to deserialize pointers, so any pointer to same object will point to server instance and not our copy
+	// 2) Remove all serialization of pointers with instance ID's and restore them on load (including AI deserializer code)
+	// 3) Completely remove client savegame and send all information, like hero paths and sleeping status to server (either in form of hero properties or as some generic "client options" message
+#ifdef BROKEN_CLIENT_STATE_SERIALIZATION_HAS_BEEN_FIXED
 	// try to deserialize client data including sleepingHeroes
 	try
 	{
@@ -219,6 +228,7 @@ void CClient::loadGame(CGameState * initializedGameState)
 	{
 		logGlobal->info("Cannot load client data for game %s. Error: %s", CSH->si->mapname, e.what());
 	}
+#endif
 
 	initPlayerInterfaces();
 }


### PR DESCRIPTION
Unfortunately have to revert #1663
Currently, due to way our serializer works, client ends up with two copies of every owned object, e.g. heroes/towns and everything linked to them via pointers.

Don't see any clear way to fix it in reasonable time, so for now will disable this code.

To reproduce most noticeable bug on current develop:
- start new game
- move hero outside of town
- save game
- load game
- move hero few tiles away from his position
- try to move hero second time
Expected result: game builds path from hero's visible position to clicked tile
Actual result: game builds path from hero position on game load (because client's copy of hero was not moved when applying hero movement pack)