### PR TITLE
vcmi: fix first aid regression

### DIFF
--- a/config/creatures/special.json
+++ b/config/creatures/special.json
@@ -86,12 +86,6 @@
 			"heals" : {
 				"type" : "HEALER" ,
 				"subtype" : "spell.firstAid"
-			},
-			"power" : {
-				"type" : "SPECIFIC_SPELL_POWER",
-				"subtype" : "spell.firstAid",
-				"val" : 10,
-				"valueType" : "BASE_NUMBER"
 			}
 		},
 		"graphics" :

--- a/config/skills.json
+++ b/config/skills.json
@@ -805,17 +805,17 @@
 		},
 		"basic" : {
 			"effects" : {
-				"main" : { "val" : 40 }
+				"main" : { "val" : 50 }
 			}
 		},
 		"advanced" : {
 			"effects" : {
-				"main" : { "val" : 65 }
+				"main" : { "val" : 75 }
 			}
 		},
 		"expert" : {
 			"effects" : {
-				"main" : { "val" : 90 }
+				"main" : { "val" : 100 }
 			}
 		}
 	}

--- a/lib/JsonNode.cpp
+++ b/lib/JsonNode.cpp
@@ -818,8 +818,6 @@ static BonusParams convertDeprecatedBonus(const JsonNode &ability)
 			if(!params.valRelevant) {
 				params.val = static_cast<si32>(ability["val"].Float());
 				params.valRelevant = true;
-				if(params.type == Bonus::SPECIFIC_SPELL_POWER) //First Aid value should be substracted by 10
-					params.val -= 10; //Base First Aid value
 			}
 			Bonus::ValueType valueType = Bonus::ADDITIVE_VALUE;
 			if(!ability["valueType"].isNull())


### PR DESCRIPTION
First aid specialists was count a percentage not from full value, but from value - 10.
Fix it by removal of bonus from First Aid Tent and adding 10 pt to each skill level.

Checked with specialist and non-specialist, all is working according to description.