### PR TITLE
Fix town portal query when it calls level up query

### DIFF
--- a/server/CQuery.cpp
+++ b/server/CQuery.cpp
@@ -536,5 +536,10 @@ void CGenericQuery::onExposure(QueryPtr topQuery)
 
 void CGenericQuery::setReply(const JsonNode & reply)
 {
+	this->reply = reply;
+}
+
+void CGenericQuery::onRemoval(PlayerColor color)
+{
 	callback(reply);
 }

--- a/server/CQuery.h
+++ b/server/CQuery.h
@@ -11,6 +11,7 @@
 #include "../lib/GameConstants.h"
 #include "../lib/int3.h"
 #include "../lib/NetPacks.h"
+#include "JsonNode.h"
 
 VCMI_LIB_NAMESPACE_BEGIN
 
@@ -198,8 +199,10 @@ public:
 	bool endsByPlayerAnswer() const override;
 	void onExposure(QueryPtr topQuery) override;
 	void setReply(const JsonNode & reply) override;
+	void onRemoval(PlayerColor color) override;
 private:
 	std::function<void(const JsonNode &)> callback;
+	JsonNode reply;
 };
 
 class Queries


### PR DESCRIPTION
Fixes https://github.com/vcmi/vcmi/issues/1367

@IvanSavenko You mean something like this? Now every `CGenericQuery` callback is called in `onRemoval`. I did consider to make this behavior optional, but I think the class is safer in this form.