### PR TITLE
vcmi: no open-code NO_APPROPRIATE_TARGET

### DIFF
--- a/lib/spells/effects/Sacrifice.cpp
+++ b/lib/spells/effects/Sacrifice.cpp
@@ -76,12 +76,7 @@ bool Sacrifice::applicable(Problem & problem, const Mechanics * m) const
 	}
 
 	if(!(targetExists && targetToSacrificeExists))
-	{
-		MetaString text;
-		text.addTxt(MetaString::GENERAL_TXT, 185);
-		problem.add(std::move(text), Problem::NORMAL);
-		return false;
-	}
+		return m->adaptProblem(ESpellCastProblem::NO_APPROPRIATE_TARGET, problem);
 
 	return true;
 }

--- a/lib/spells/effects/UnitEffect.cpp
+++ b/lib/spells/effects/UnitEffect.cpp
@@ -46,13 +46,7 @@ bool UnitEffect::applicable(Problem & problem, const Mechanics * m) const
 	auto targets = m->battle()->battleGetUnitsIf(mainFilter);
 	vstd::erase_if(targets, predicate);
 	if(targets.empty())
-	{
-		MetaString text;
-		text.addTxt(MetaString::GENERAL_TXT, 185);
-		problem.add(std::move(text), Problem::NORMAL);
-		return false;
-	}
-
+		return m->adaptProblem(ESpellCastProblem::NO_APPROPRIATE_TARGET, problem);
 
 	return true;
 }


### PR DESCRIPTION
Open-coding a funciton leads to code duplication.

Replace open-coded string access to m->adaptProblem, which internally does the same.