### PR TITLE
Deactivate activeStack when auto combat starts

### DIFF
--- a/client/battle/BattleInterface.cpp
+++ b/client/battle/BattleInterface.cpp
@@ -693,6 +693,8 @@ void BattleInterface::requestAutofightingAIToTakeAction()
 				auto ba = std::make_unique<BattleAction>(curInt->autofightingAI->activeStack(activeStack));
 				givenCommand.setn(ba.release());
 			}
+
+			stacksController->setActiveStack(nullptr);
 		}
 	});
 


### PR DESCRIPTION
Seems to fix https://github.com/vcmi/vcmi/issues/1529

The issue also suggests a review of autocombat code. Honestly, I don't fully understand how multithreading works at the `BattleInterface::requestAutofightingAIToTakeAction()` function, so there could be some multithreading-related bugs that are tricky to discover.