### PR TITLE
Do not activate new items when parent widget is inactive

### DIFF
--- a/client/widgets/ObjectLists.cpp
+++ b/client/widgets/ObjectLists.cpp
@@ -35,7 +35,8 @@ std::shared_ptr<CIntObject> CObjectList::createItem(size_t index)
 
 	item->recActions = defActions;
 	addChild(item.get());
-	item->activate();
+	if (active)
+		item->activate();
 	return item;
 }
 


### PR DESCRIPTION
- Fixes #1464 
- and its duplicate, #1761