### PR TITLE
Fix the case of invalid native town type

### DIFF
--- a/lib/GameConstants.h
+++ b/lib/GameConstants.h
@@ -250,8 +250,8 @@ public:
 	}
 
 	bool operator == (const Identifier & b) const { return num == b.num; }
-	bool operator <= (const Identifier & b) const { return num >= b.num; }
-	bool operator >= (const Identifier & b) const { return num <= b.num; }
+	bool operator <= (const Identifier & b) const { return num <= b.num; }
+	bool operator >= (const Identifier & b) const { return num >= b.num; }
 	bool operator != (const Identifier & b) const { return num != b.num; }
 	bool operator <  (const Identifier & b) const { return num <  b.num; }
 	bool operator >  (const Identifier & b) const { return num > b.num; }

--- a/lib/rmg/Functions.cpp
+++ b/lib/rmg/Functions.cpp
@@ -134,7 +134,7 @@ void initTerrainType(Zone & zone, CMapGenerator & gen)
 
 			if (terrainType <= ETerrainId::NONE)
 			{
-				logGlobal->warn("Town %s has invalid terrain type: %s", zone.getTownType(), terrainType);
+				logGlobal->warn("Town %s has invalid terrain type: %d", zone.getTownType(), terrainType);
 				zone.setTerrainType(ETerrainId::DIRT);
 			}
 			else

--- a/lib/rmg/Functions.cpp
+++ b/lib/rmg/Functions.cpp
@@ -130,7 +130,17 @@ void initTerrainType(Zone & zone, CMapGenerator & gen)
 	{
 		if(zone.isMatchTerrainToTown() && zone.getTownType() != ETownType::NEUTRAL)
 		{
-			zone.setTerrainType((*VLC->townh)[zone.getTownType()]->nativeTerrain);
+			auto terrainType = (*VLC->townh)[zone.getTownType()]->nativeTerrain;
+
+			if (terrainType <= ETerrainId::NONE)
+			{
+				logGlobal->warn("Town %s has invalid terrain type: %s", zone.getTownType(), terrainType);
+				zone.setTerrainType(ETerrainId::DIRT);
+			}
+			else
+			{
+				zone.setTerrainType(terrainType);
+			}
 		}
 		else
 		{


### PR DESCRIPTION
Found another case when RMG can fail.

Still not sure if it shouldn't be just an assert. However, Map Editor freezes in infinite wait if the lib crashes (threw `runtime_error` before).