### PR TITLE
Fix landmines staying on battlefield after trigger

### DIFF
--- a/lib/NetPacksBase.h
+++ b/lib/NetPacksBase.h
@@ -308,8 +308,6 @@ public:
 		RESET_STATE,
 		UPDATE,
 		REMOVE,
-		ACTIVATE_AND_UPDATE,
-		ACTIVATE_AND_REMOVE
 	};
 
 	JsonNode data;

--- a/lib/NetPacksLib.cpp
+++ b/lib/NetPacksLib.cpp
@@ -2398,7 +2398,6 @@ void BattleObstaclesChanged::applyBattle(IBattleState * battleState)
 		case BattleChanges::EOperation::ADD:
 			battleState->addObstacle(change);
 			break;
-		case BattleChanges::EOperation::ACTIVATE_AND_UPDATE:
 		case BattleChanges::EOperation::UPDATE:
 			battleState->updateObstacle(change);
 			break;

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -5323,9 +5323,9 @@ bool CGameHandler::handleDamageFromObstacle(const CStack * curStack, bool stackI
 					ObstacleChanges changeInfo;
 					changeInfo.id = spellObstacle->uniqueID;
 					if (oneTimeObstacle)
-						changeInfo.operation = ObstacleChanges::EOperation::ACTIVATE_AND_REMOVE;
+						changeInfo.operation = ObstacleChanges::EOperation::REMOVE;
 					else
-						changeInfo.operation = ObstacleChanges::EOperation::ACTIVATE_AND_UPDATE;
+						changeInfo.operation = ObstacleChanges::EOperation::UPDATE;
 
 					SpellCreatedObstacle changedObstacle;
 					changedObstacle.uniqueID = spellObstacle->uniqueID;


### PR DESCRIPTION
NetPacksLib: remove obstacle ACTIVATE* actions
Actually these actions was not working anyway.