### PR TITLE
Nkai disallow allied shipyard

### DIFF
--- a/AI/Nullkiller/Pathfinding/Rules/AILayerTransitionRule.cpp
+++ b/AI/Nullkiller/Pathfinding/Rules/AILayerTransitionRule.cpp
@@ -53,13 +53,15 @@ namespace AIPathfinding
 
 		for(const CGTownInstance * t : cb->getTownsInfo())
 		{
-			if(t->hasBuilt(BuildingID::SHIPYARD))
+			// do not allow ally shipyards because of bug
+			if(t->hasBuilt(BuildingID::SHIPYARD) && t->getOwner() == ai->playerID)
 				shipyards.push_back(t);
 		}
 
 		for(const CGObjectInstance * obj : ai->memory->visitableObjs)
 		{
-			if(obj->ID != Obj::TOWN) //towns were handled in the previous loop
+			// do not allow ally shipyards because of bug
+			if(obj->ID != Obj::TOWN && obj->getOwner() == ai->playerID) //towns were handled in the previous loop
 			{
 				if(const IShipyard * shipyard = IShipyard::castFrom(obj))
 					shipyards.push_back(shipyard);


### PR DESCRIPTION
While there is a bug that when building a boat in ally shipyard the resources will be taken from ally we disallow using ally shipyards for NKAI