### PR TITLE
config: CATAPULT_EXTRA_SHOTS should be hidden

### DIFF
--- a/Mods/vcmi/config/vcmi/chinese.json
+++ b/Mods/vcmi/config/vcmi/chinese.json
@@ -144,8 +144,6 @@
 	"core.bonus.BLOCKS_RANGED_RETALIATION.description": "敌人无法对射击进行反击",
 	"core.bonus.CATAPULT.name": "攻城",
 	"core.bonus.CATAPULT.description": "可以攻击城墙",
-	"core.bonus.CATAPULT_EXTRA_SHOTS.name": "额外攻击城墙",
-	"core.bonus.CATAPULT_EXTRA_SHOTS.description": "可以额外攻击城墙 ${val} 次",
 	"core.bonus.CHANGES_SPELL_COST_FOR_ALLY.name": "施法消耗 - (${val})",
 	"core.bonus.CHANGES_SPELL_COST_FOR_ALLY.description": "减少英雄的施法消耗",
 	"core.bonus.CHANGES_SPELL_COST_FOR_ENEMY.name": "对方施法消耗 + (${val})",

--- a/Mods/vcmi/config/vcmi/english.json
+++ b/Mods/vcmi/config/vcmi/english.json
@@ -169,8 +169,6 @@
 	"core.bonus.BLOCKS_RANGED_RETALIATION.description": "Enemy cannot Retaliate by shooting",
 	"core.bonus.CATAPULT.name": "Catapult",
 	"core.bonus.CATAPULT.description": "Attacks siege walls",
-	"core.bonus.CATAPULT_EXTRA_SHOTS.name": "Additional siege attacks",
-	"core.bonus.CATAPULT_EXTRA_SHOTS.description": "Can hit siege walls ${val} extra times per attack",
 	"core.bonus.CHANGES_SPELL_COST_FOR_ALLY.name": "Reduce Casting Cost (${val})",
 	"core.bonus.CHANGES_SPELL_COST_FOR_ALLY.description": "Reduces spell cost for hero",
 	"core.bonus.CHANGES_SPELL_COST_FOR_ENEMY.name": "Magic Damper (${val})",

--- a/Mods/vcmi/config/vcmi/german.json
+++ b/Mods/vcmi/config/vcmi/german.json
@@ -154,8 +154,6 @@
 	"core.bonus.BLOCKS_RANGED_RETALIATION.description": "Feind kann nicht durch Schießen vergelten",
 	"core.bonus.CATAPULT.name": "Katapult",
 	"core.bonus.CATAPULT.description": "Greift Belagerungsmauern an",
-	"core.bonus.CATAPULT_EXTRA_SHOTS.name": "Zusätzliche Belagerungsangriffe",
-	"core.bonus.CATAPULT_EXTRA_SHOTS.description": "Kann Belagerungsmauern ${val} zusätzliche Male pro Angriff treffen",
 	"core.bonus.CHANGES_SPELL_COST_FOR_ALLY.name": "Reduziere Zauberkosten (${val})",
 	"core.bonus.CHANGES_SPELL_COST_FOR_ALLY.description": "Reduziert die Zauberkosten für den Helden",
 	"core.bonus.CHANGES_SPELL_COST_FOR_ENEMY.name": "Zauberdämpfer (${val})",

--- a/Mods/vcmi/config/vcmi/polish.json
+++ b/Mods/vcmi/config/vcmi/polish.json
@@ -155,8 +155,6 @@
 	"core.bonus.BLOCKS_RANGED_RETALIATION.description": "Wróg nie może kontratakować poprzez strzelanie",
 	"core.bonus.CATAPULT.name": "Katapulta",
 	"core.bonus.CATAPULT.description": "Atakuje mury obronne",
-	"core.bonus.CATAPULT_EXTRA_SHOTS.name": "Dodatkowe ataki oblężnicze",
-	"core.bonus.CATAPULT_EXTRA_SHOTS.description": "Może uderzyć mury obronne ${val} dodatkowych razy na atak",
 	"core.bonus.CHANGES_SPELL_COST_FOR_ALLY.name": "Zmniejsz koszt czarów (${val})",
 	"core.bonus.CHANGES_SPELL_COST_FOR_ALLY.description": "Zmniejsza koszt czaru bohatera",
 	"core.bonus.CHANGES_SPELL_COST_FOR_ENEMY.name": "Tłumienie magii (${val})",

--- a/Mods/vcmi/config/vcmi/russian.json
+++ b/Mods/vcmi/config/vcmi/russian.json
@@ -171,8 +171,6 @@
 	"core.bonus.BLOCKS_RANGED_RETALIATION.description": "Враг не отвечает в дальнем бою",
 	"core.bonus.CATAPULT.name": "Стенобитное орудие",
 	"core.bonus.CATAPULT.description": "Может атаковать стены",
-	"core.bonus.CATAPULT_EXTRA_SHOTS.name": "Дополнительные атаки стен",
-	"core.bonus.CATAPULT_EXTRA_SHOTS.description": "Может дополнительно бить в стены ${val} раз за атаку",
 	"core.bonus.CHANGES_SPELL_COST_FOR_ALLY.name": "Снижение стоимости заклинаний (${val})",
 	"core.bonus.CHANGES_SPELL_COST_FOR_ALLY.description": "Снижаемость стоимость заклинаний для героя",
 	"core.bonus.CHANGES_SPELL_COST_FOR_ENEMY.name": "Подавитель магии (${val})",

--- a/Mods/vcmi/config/vcmi/spanish.json
+++ b/Mods/vcmi/config/vcmi/spanish.json
@@ -157,8 +157,6 @@
     "core.bonus.BLOCKS_RANGED_RETALIATION.description": "El enemigo no puede contraatacar disparando",
     "core.bonus.CATAPULT.name": "Catapulta",
     "core.bonus.CATAPULT.description": "Ataca a las paredes de asedio",
-    "core.bonus.CATAPULT_EXTRA_SHOTS.name": "Ataques adicionales de asedio",
-    "core.bonus.CATAPULT_EXTRA_SHOTS.description": "Puede golpear las paredes de asedio ${val} veces adicionales por ataque",
     "core.bonus.CHANGES_SPELL_COST_FOR_ALLY.name": "Reducir coste del conjuro (${val})",
     "core.bonus.CHANGES_SPELL_COST_FOR_ALLY.description": "Reduce el coste del conjuro para el héroe",
     "core.bonus.CHANGES_SPELL_COST_FOR_ENEMY.name": "Disminuir efecto mágico (${val})",

--- a/Mods/vcmi/config/vcmi/ukrainian.json
+++ b/Mods/vcmi/config/vcmi/ukrainian.json
@@ -157,8 +157,6 @@
 	"core.bonus.BLOCKS_RANGED_RETALIATION.description" : "Ворог не може відповісти пострілом",
 	"core.bonus.CATAPULT.name" : "Катапульта",
 	"core.bonus.CATAPULT.description" : "Атакує стіни фортеці",
-	"core.bonus.CATAPULT_EXTRA_SHOTS.name" : "Додаткові атаки стін",
-	"core.bonus.CATAPULT_EXTRA_SHOTS.description" : "Може вражати стіни фортеці ${val} додаткових разів за атаку",
 	"core.bonus.CHANGES_SPELL_COST_FOR_ALLY.name" : "Зменшує вартість закляття (${val})",
 	"core.bonus.CHANGES_SPELL_COST_FOR_ALLY.description" : "Зменшує вартість закляття для героя",
 	"core.bonus.CHANGES_SPELL_COST_FOR_ENEMY.name" : "Демпфер магії (${val})",

--- a/config/bonuses.json
+++ b/config/bonuses.json
@@ -53,10 +53,7 @@
 	
 	"CATAPULT_EXTRA_SHOTS":
 	{
-		"graphics":
-		{
-			"icon":  "zvs/Lib1.res/Catapult"
-		}
+		"hidden": true
 	},
 
 	"CHANGES_SPELL_COST_FOR_ALLY":


### PR DESCRIPTION
If it will be shown, it leads to annoying extra bonus for all stacks of heroes with Ballistics.