### PR TITLE
CCreatureHandler: fix native terrain for any

### DIFF
--- a/lib/CCreatureHandler.cpp
+++ b/lib/CCreatureHandler.cpp
@@ -327,12 +327,12 @@ bool CCreature::isItNativeTerrain(TerrainId terrain) const
 
 TerrainId CCreature::getNativeTerrain() const
 {
-	const std::string cachingStringNoTerrainPenalty = "type_NO_TERRAIN_PENALTY";
-	static const auto selectorNoTerrainPenalty = Selector::type()(Bonus::NO_TERRAIN_PENALTY);
+	const std::string cachingStringNoTerrainPenalty = "type_NO_TERRAIN_PENALTY_sANY";
+	static const auto selectorNoTerrainPenalty = Selector::typeSubtype(Bonus::NO_TERRAIN_PENALTY, static_cast<int>(ETerrainId::ANY_TERRAIN));
 
 	//this code is used in the CreatureTerrainLimiter::limit to setup battle bonuses
 	//and in the CGHeroInstance::getNativeTerrain() to setup movement bonuses or/and penalties.
-	return hasBonus(selectorNoTerrainPenalty, selectorNoTerrainPenalty)
+	return hasBonus(selectorNoTerrainPenalty, cachingStringNoTerrainPenalty)
 		? TerrainId(ETerrainId::ANY_TERRAIN)
 		: (*VLC->townh)[faction]->nativeTerrain;
 }


### PR DESCRIPTION
This was a bug inside native terrain handling in VCMI (we will take creatures with any NO_TERRAIN_PENALTY bonus as native). Fixing it.