### PR TITLE
Shut down the thread for tactic phase properly

### DIFF
--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -1032,6 +1032,12 @@ void CPlayerInterface::yourTacticPhase(int distance)
 		boost::this_thread::sleep(boost::posix_time::millisec(1));
 }
 
+void CPlayerInterface::forceEndTacticPhase()
+{
+	if (battleInt)
+		battleInt->tacticsMode = false;
+}
+
 void CPlayerInterface::showInfoDialog(EInfoWindowMode type, const std::string &text, const std::vector<Component> & components, int soundID)
 {
 	EVENT_HANDLER_CALLED_BY_CLIENT;

--- a/client/CPlayerInterface.h
+++ b/client/CPlayerInterface.h
@@ -226,6 +226,7 @@ public:
 	void battleCatapultAttacked(const CatapultAttack & ca) override; //called when catapult makes an attack
 	void battleGateStateChanged(const EGateState state) override;
 	void yourTacticPhase(int distance) override;
+	void forceEndTacticPhase() override;
 
 	//-------------//
 	void showArtifactAssemblyDialog(const Artifact * artifact, const Artifact * assembledArtifact, CFunctionList<bool()> onYes);

--- a/client/Client.h
+++ b/client/Client.h
@@ -9,6 +9,7 @@
  */
 #pragma once
 
+#include <memory>
 #include <vcmi/Environment.h>
 
 #include "../lib/IGameCallback.h"
@@ -241,6 +242,8 @@ public:
 	void showInfoDialog(const std::string & msg, PlayerColor player) override {};
 	void removeGUI();
 
+	void cleanThreads();
+
 #if SCRIPTING_ENABLED
 	scripting::Pool * getGlobalContextPool() const override;
 	scripting::Pool * getContextPool() const override;
@@ -261,6 +264,8 @@ private:
 	std::map<const CGHeroInstance *, std::shared_ptr<CPathsInfo>> pathCache;
 
 	std::map<PlayerColor, std::shared_ptr<boost::thread>> playerActionThreads;
+
+	std::map<PlayerColor, std::unique_ptr<boost::thread>> playerTacticThreads;
 
 	void waitForMoveAndSend(PlayerColor color);
 	void reinitScripting();

--- a/lib/CGameInterface.h
+++ b/lib/CGameInterface.h
@@ -82,6 +82,7 @@ public:
 	//battle call-ins
 	virtual BattleAction activeStack(const CStack * stack)=0; //called when it's turn of that stack
 	virtual void yourTacticPhase(int distance){}; //called when interface has opportunity to use Tactics skill -> use cb->battleMakeTacticAction from this function
+	virtual void forceEndTacticPhase(){}; //force the tatic phase to end to clean up the tactic phase thread
 };
 
 /// Central class for managing human player / AI interface logic


### PR DESCRIPTION
## Issue

1. Use a hero with the tactic skill to enter a battle
2. Load game during the tactic phase
3. Crash

## Fix
The thread for tactic phase keeps running even if the game is ended. This PR shut that down properly.

This might not be the most elegant solution since I need to create a `forceEndTacticPhase()` function. However, I couldn't figure out a good solution given how the thread is implemented. 

Btw, I have a feeling that it is very easy to make mistake with threads in VCMI, I suggest that people who review PR (including mine :smile:) with threading-related code should pay extra attention to ensure that they work properly.