### PR TITLE
Add missing include headers when building with -DENABLE_PCH=OFF

### DIFF
--- a/lib/spells/ObstacleCasterProxy.cpp
+++ b/lib/spells/ObstacleCasterProxy.cpp
@@ -8,6 +8,7 @@
  *
  */
 
+#include "StdInc.h"
 #include "ObstacleCasterProxy.h"
 
 VCMI_LIB_NAMESPACE_BEGIN


### PR DESCRIPTION
Example build failure is missing `VCMI_LIB_NAMESPACE_BEGIN` declaration:

    [  0%] Building CXX object lib/CMakeFiles/vcmi.dir/spells/ObstacleCasterProxy.cpp.o
    In file included from lib/spells/ProxyCaster.h:13,
                     from lib/spells/ObstacleCasterProxy.h:11,
                     from lib/spells/ObstacleCasterProxy.cpp:11:
    lib/../include/vcmi/spells/Caster.h:13:1: error: 'VCMI_LIB_NAMESPACE_BEGIN' does not name a type
       13 | VCMI_LIB_NAMESPACE_BEGIN
          | ^~~~~~~~~~~~~~~~~~~~~~~~