### PR TITLE
vcmi: change gcc variant to build lua and no pch

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -61,6 +61,8 @@
             "description": "VCMI Linux GCC",
             "inherits": "linux-release",
             "cacheVariables": {
+                "ENABLE_LUA" : "ON",
+                "ENABLE_PCH" : "OFF",
                 "CMAKE_C_COMPILER": "/usr/bin/gcc",
                 "CMAKE_CXX_COMPILER": "/usr/bin/g++"
             }


### PR DESCRIPTION
For avoiding a bugs like #1893.

Please, merge after that PR, because CI will fail before.