### PR TITLE
Fixed UI of objects that provide one reward that can be refused

### DIFF
--- a/lib/mapObjects/CRewardableObject.cpp
+++ b/lib/mapObjects/CRewardableObject.cpp
@@ -152,8 +152,14 @@ void CRewardableObject::onHeroVisit(const CGHeroInstance *h) const
 		BlockingDialog sd(canRefuse, rewards.size() > 1);
 		sd.player = h->tempOwner;
 		sd.text = dialog;
-		for (auto index : rewards)
-			sd.components.push_back(info[index].reward.getDisplayedComponent(h));
+
+		if (rewards.size() > 1)
+			for (auto index : rewards)
+				sd.components.push_back(info[index].reward.getDisplayedComponent(h));
+
+		if (rewards.size() == 1)
+			info[rewards[0]].reward.loadComponents(sd.components, h);
+
 		cb->showBlockingDialog(&sd);
 	};
 


### PR DESCRIPTION
Effectively fixes #1894 
What it changes is that now VCMI will display full list of components of objects that provide one reward that player can refuse.
H3 (AFAIK) has no such objects, so only mods may be affected. Specifically:
- objects that provide rewards with no visual components but can be refused will no longer crash. Example: Watering Place in HotA provides no visual rewards - only movement points which are hidden in UI.
- objects that provide multiple visual components will now show all such components. Example: Ancient Lamp in HotA will now show not just Genie icon but also total cost of Genies.
- objects that provide multiple reward to select from, e.g. School of Magic in H3 are not affected by change.