### PR TITLE
Fix initialization of spell effects registry

### DIFF
--- a/client/LobbyClientNetPackVisitors.h
+++ b/client/LobbyClientNetPackVisitors.h
@@ -12,7 +12,9 @@
 #include "../lib/NetPackVisitor.h"
 
 class CClient;
+VCMI_LIB_NAMESPACE_BEGIN
 class CGameState;
+VCMI_LIB_NAMESPACE_END
 
 class ApplyOnLobbyHandlerNetPackVisitor : public VCMI_LIB_WRAP_NAMESPACE(ICPackVisitor)
 {

--- a/lib/spells/effects/Catapult.cpp
+++ b/lib/spells/effects/Catapult.cpp
@@ -23,14 +23,10 @@
 
 VCMI_LIB_NAMESPACE_BEGIN
 
-static const std::string EFFECT_NAME = "core:catapult";
-
 namespace spells
 {
 namespace effects
 {
-
-VCMI_REGISTER_SPELL_EFFECT(Catapult, EFFECT_NAME);
 
 bool Catapult::applicable(Problem & problem, const Mechanics * m) const
 {

--- a/lib/spells/effects/Clone.cpp
+++ b/lib/spells/effects/Clone.cpp
@@ -19,14 +19,10 @@
 
 VCMI_LIB_NAMESPACE_BEGIN
 
-static const std::string EFFECT_NAME = "core:clone";
-
 namespace spells
 {
 namespace effects
 {
-
-VCMI_REGISTER_SPELL_EFFECT(Clone, EFFECT_NAME);
 
 void Clone::apply(ServerCallback * server, const Mechanics * m, const EffectTarget & target) const
 {

--- a/lib/spells/effects/Damage.cpp
+++ b/lib/spells/effects/Damage.cpp
@@ -22,14 +22,10 @@
 
 VCMI_LIB_NAMESPACE_BEGIN
 
-static const std::string EFFECT_NAME = "core:damage";
-
 namespace spells
 {
 namespace effects
 {
-
-VCMI_REGISTER_SPELL_EFFECT(Damage, EFFECT_NAME);
 
 void Damage::apply(ServerCallback * server, const Mechanics * m, const EffectTarget & target) const
 {

--- a/lib/spells/effects/DemonSummon.cpp
+++ b/lib/spells/effects/DemonSummon.cpp
@@ -19,14 +19,10 @@
 
 VCMI_LIB_NAMESPACE_BEGIN
 
-static const std::string EFFECT_NAME = "core:demonSummon";
-
 namespace spells
 {
 namespace effects
 {
-
-VCMI_REGISTER_SPELL_EFFECT(DemonSummon, EFFECT_NAME);
 
 void DemonSummon::apply(ServerCallback * server, const Mechanics * m, const EffectTarget & target) const
 {

--- a/lib/spells/effects/Dispel.cpp
+++ b/lib/spells/effects/Dispel.cpp
@@ -23,14 +23,10 @@
 
 VCMI_LIB_NAMESPACE_BEGIN
 
-static const std::string EFFECT_NAME = "core:dispel";
-
 namespace spells
 {
 namespace effects
 {
-
-VCMI_REGISTER_SPELL_EFFECT(Dispel, EFFECT_NAME);
 
 void Dispel::apply(ServerCallback * server, const Mechanics * m, const EffectTarget & target) const
 {

--- a/lib/spells/effects/Effect.h
+++ b/lib/spells/effects/Effect.h
@@ -35,9 +35,6 @@ class Effects;
 class Effect;
 class Registry;
 
-template<typename F>
-class RegisterEffect;
-
 using TargetType = spells::AimType;
 
 class DLL_LINKAGE Effect

--- a/lib/spells/effects/Heal.cpp
+++ b/lib/spells/effects/Heal.cpp
@@ -22,15 +22,10 @@
 
 VCMI_LIB_NAMESPACE_BEGIN
 
-
-static const std::string EFFECT_NAME = "core:heal";
-
 namespace spells
 {
 namespace effects
 {
-
-VCMI_REGISTER_SPELL_EFFECT(Heal, EFFECT_NAME);
 
 void Heal::apply(ServerCallback * server, const Mechanics * m, const EffectTarget & target) const
 {

--- a/lib/spells/effects/Obstacle.cpp
+++ b/lib/spells/effects/Obstacle.cpp
@@ -21,14 +21,10 @@
 
 VCMI_LIB_NAMESPACE_BEGIN
 
-static const std::string EFFECT_NAME = "core:obstacle";
-
 namespace spells
 {
 namespace effects
 {
-
-VCMI_REGISTER_SPELL_EFFECT(Obstacle, EFFECT_NAME);
 
 using RelativeShape = std::vector<std::vector<BattleHex::EDir>>;
 

--- a/lib/spells/effects/Registry.cpp
+++ b/lib/spells/effects/Registry.cpp
@@ -11,6 +11,23 @@
 
 #include "Registry.h"
 
+#include "Catapult.h"
+#include "Clone.h"
+#include "Damage.h"
+#include "DemonSummon.h"
+#include "Dispel.h"
+#include "Effect.h"
+#include "Effects.h"
+#include "Heal.h"
+#include "LocationEffect.h"
+#include "Obstacle.h"
+#include "RemoveObstacle.h"
+#include "Sacrifice.h"
+#include "Summon.h"
+#include "Teleport.h"
+#include "Timed.h"
+#include "UnitEffect.h"
+
 VCMI_LIB_NAMESPACE_BEGIN
 
 namespace spells
@@ -23,6 +40,22 @@ namespace detail
 class RegistryImpl : public Registry
 {
 public:
+	RegistryImpl()
+	{
+		add("core:catapult", std::make_shared<EffectFactory<Catapult>>());
+		add("core:clone", std::make_shared<EffectFactory<Clone>>());
+		add("core:damage", std::make_shared<EffectFactory<Damage>>());
+		add("core:demonSummon", std::make_shared<EffectFactory<DemonSummon>>());
+		add("core:dispel", std::make_shared<EffectFactory<Dispel>>());
+		add("core:heal", std::make_shared<EffectFactory<Heal>>());
+		add("core:obstacle", std::make_shared<EffectFactory<Obstacle>>());
+		add("core:removeObstacle", std::make_shared<EffectFactory<RemoveObstacle>>());
+		add("core:sacrifice", std::make_shared<EffectFactory<Sacrifice>>());
+		add("core:summon", std::make_shared<EffectFactory<Summon>>());
+		add("core:teleport", std::make_shared<EffectFactory<Teleport>>());
+		add("core:timed", std::make_shared<EffectFactory<Timed>>());
+	}
+
 	const IEffectFactory * find(const std::string & name) const override
 	{
 		auto iter = data.find(name);

--- a/lib/spells/effects/Registry.h
+++ b/lib/spells/effects/Registry.h
@@ -12,13 +12,6 @@
 
 #include "Effect.h"
 
-#define VCMI_REGISTER_SPELL_EFFECT(Type, Name) \
-namespace\
-{\
-RegisterEffect<Type> register ## Type(Name);\
-}\
-\
-
 VCMI_LIB_NAMESPACE_BEGIN
 
 namespace spells
@@ -57,17 +50,6 @@ public:
 	Effect * create() const override
 	{
 		return new E();
-	}
-};
-
-template<typename E>
-class RegisterEffect
-{
-public:
-	RegisterEffect(const std::string & name)
-	{
-		auto f = std::make_shared<EffectFactory<E>>();
-		GlobalRegistry::get()->add(name, f);
 	}
 };
 

--- a/lib/spells/effects/RemoveObstacle.cpp
+++ b/lib/spells/effects/RemoveObstacle.cpp
@@ -22,14 +22,10 @@
 
 VCMI_LIB_NAMESPACE_BEGIN
 
-static const std::string EFFECT_NAME = "core:removeObstacle";
-
 namespace spells
 {
 namespace effects
 {
-
-VCMI_REGISTER_SPELL_EFFECT(RemoveObstacle, EFFECT_NAME);
 
 bool RemoveObstacle::applicable(Problem & problem, const Mechanics * m) const
 {

--- a/lib/spells/effects/Sacrifice.cpp
+++ b/lib/spells/effects/Sacrifice.cpp
@@ -21,15 +21,10 @@
 
 VCMI_LIB_NAMESPACE_BEGIN
 
-
-static const std::string EFFECT_NAME = "core:sacrifice";
-
 namespace spells
 {
 namespace effects
 {
-
-VCMI_REGISTER_SPELL_EFFECT(Sacrifice, EFFECT_NAME);
 
 void Sacrifice::adjustTargetTypes(std::vector<TargetType> & types) const
 {

--- a/lib/spells/effects/Summon.cpp
+++ b/lib/spells/effects/Summon.cpp
@@ -24,15 +24,10 @@
 
 VCMI_LIB_NAMESPACE_BEGIN
 
-
-static const std::string EFFECT_NAME = "core:summon";
-
 namespace spells
 {
 namespace effects
 {
-
-VCMI_REGISTER_SPELL_EFFECT(Summon, EFFECT_NAME);
 
 void Summon::adjustAffectedHexes(std::set<BattleHex> & hexes, const Mechanics * m, const Target & spellTarget) const
 {

--- a/lib/spells/effects/Teleport.cpp
+++ b/lib/spells/effects/Teleport.cpp
@@ -18,16 +18,10 @@
 
 VCMI_LIB_NAMESPACE_BEGIN
 
-//TODO: Teleport effect
-
-static const std::string EFFECT_NAME = "core:teleport";
-
 namespace spells
 {
 namespace effects
 {
-VCMI_REGISTER_SPELL_EFFECT(Teleport, EFFECT_NAME);
-
 
 void Teleport::adjustTargetTypes(std::vector<TargetType> & types) const
 {

--- a/lib/spells/effects/Timed.cpp
+++ b/lib/spells/effects/Timed.cpp
@@ -20,14 +20,10 @@
 
 VCMI_LIB_NAMESPACE_BEGIN
 
-static const std::string EFFECT_NAME = "core:timed";
-
 namespace spells
 {
 namespace effects
 {
-
-VCMI_REGISTER_SPELL_EFFECT(Timed, EFFECT_NAME);
 
 static void describeEffect(std::vector<MetaString> & log, const Mechanics * m, const std::vector<Bonus> & bonuses, const battle::Unit * target) 
 {


### PR DESCRIPTION
Fixes #1869 

And this is why boys and girls you should not try to do too smart stuff that is not guaranteed by the standard:

> It is implementation-defined whether or not the dynamic initialization (dcl.init, class.static, class.ctor, class.expl.init) of an object of namespace scope is done before the first statement of main. If the initialization is deferred to some point in time after the first statement of main, _it shall occur before the first use of any function or object defined in the same translation unit_ as the object to be initialized.

For reference, damage and timed effects worked because those effects are directly instantiated by server. Meanwhile compiler dropped all other effects because they were not referenced anywhere in the code.

Removed static-initialization idiocity and moved registration of effects to registry construtor.
Fixed bug for me on single-app build, presumably should also fix it on Android