### PR TITLE
Fix vcmi map loading

### DIFF
--- a/config/objects/rewardableBonusing.json
+++ b/config/objects/rewardableBonusing.json
@@ -18,7 +18,8 @@
 					"value"		: 100,
 					"rarity"	: 100
 				},
-				
+				"compatibilityIdentifiers" : [ "object" ],
+
 				"blockedVisitable" : true,
 				"onVisitedMessage" : 22,
 				"visitMode" : "bonus",
@@ -49,7 +50,8 @@
 					"value"		: 100,
 					"rarity"	: 100
 				},
-				
+				"compatibilityIdentifiers" : [ "object" ],
+
 				"onVisitedMessage" : 30,
 				"visitMode" : "bonus",
 				"selectMode" : "selectFirst",
@@ -81,7 +83,8 @@
 					"value"		: 100,
 					"rarity"	: 100
 				},
-				
+				"compatibilityIdentifiers" : [ "object" ],
+
 				"onVisitedMessage" : 50,
 				"visitMode" : "bonus",
 				"selectMode" : "selectFirst",
@@ -112,7 +115,8 @@
 					"value"		: 100,
 					"rarity"	: 100
 				},
-				
+				"compatibilityIdentifiers" : [ "object" ],
+
 				"onVisitedMessage" : 56,
 				"visitMode" : "bonus",
 				"selectMode" : "selectFirst",
@@ -164,7 +168,8 @@
 					"value"		: 100,
 					"rarity"	: 50
 				},
-				
+				"compatibilityIdentifiers" : [ "object" ],
+
 				"onVisitedMessage" : 58,
 				"visitMode" : "bonus",
 				"selectMode" : "selectFirst",
@@ -195,7 +200,8 @@
 					"value"		: 100,
 					"rarity"	: 100
 				},
-				
+				"compatibilityIdentifiers" : [ "object" ],
+
 				"onVisitedMessage" : 63,
 				"visitMode" : "bonus",
 				"selectMode" : "selectFirst",
@@ -250,7 +256,8 @@
 					"value"		: 100,
 					"rarity"	: 20
 				},
-				
+				"compatibilityIdentifiers" : [ "object" ],
+
 				"onVisitedMessage" : 82,
 				"visitMode" : "bonus",
 				"selectMode" : "selectFirst",
@@ -280,7 +287,8 @@
 					"value"		: 100,
 					"rarity"	: 50
 				},
-				
+				"compatibilityIdentifiers" : [ "object" ],
+
 				"onVisitedMessage" : 95,
 				"visitMode" : "bonus",
 				"selectMode" : "selectFirst",
@@ -312,10 +320,10 @@
 					"value"		: 200,
 					"rarity"	: 40
 				},
-				
+				"compatibilityIdentifiers" : [ "object" ],
+
 				"visitMode" : "bonus",
 				"selectMode" : "selectFirst",
-
 				"onVisited" : [
 					{
 						"message" : 139,
@@ -370,7 +378,8 @@
 					"value"		: 100,
 					"rarity"	: 100
 				},
-				
+				"compatibilityIdentifiers" : [ "object" ],
+
 				"onVisitedMessage" : 141,
 				"visitMode" : "bonus",
 				"selectMode" : "selectFirst",
@@ -406,7 +415,8 @@
 					"value"		: 100,
 					"rarity"	: 100
 				},
-				
+				"compatibilityIdentifiers" : [ "object" ],
+
 				"onVisitedMessage" : 111,
 				"visitMode" : "bonus",
 				"selectMode" : "selectFirst",
@@ -440,7 +450,8 @@
 					"value"		: 500,
 					"rarity"	: 50
 				},
-				
+				"compatibilityIdentifiers" : [ "object" ],
+
 				"onVisitedMessage" : 167,
 				"visitMode" : "bonus",
 				"selectMode" : "selectFirst",

--- a/config/objects/rewardableOncePerHero.json
+++ b/config/objects/rewardableOncePerHero.json
@@ -18,7 +18,8 @@
 					"value"		: 3000,
 					"rarity"	: 50
 				},
-				
+				"compatibilityIdentifiers" : [ "object" ],
+
 				"onSelectMessage" : 0,
 				"onVisitedMessage" : 1,
 				"visitMode" : "hero",
@@ -51,6 +52,7 @@
 					"value"		: 1500,
 					"rarity"	: 100
 				},
+				"compatibilityIdentifiers" : [ "object" ],
 
 				"onVisitedMessage" : 40,
 				"visitMode" : "hero",
@@ -81,7 +83,8 @@
 					"value"		: 1500,
 					"rarity"	: 100
 				},
-				
+				"compatibilityIdentifiers" : [ "object" ],
+
 				"onVisitedMessage" : 60,
 				"visitMode" : "hero",
 				"selectMode" : "selectFirst",
@@ -110,7 +113,8 @@
 					"value"		: 12000,
 					"rarity"	: 20
 				},
-				
+				"compatibilityIdentifiers" : [ "object" ],
+
 				"onVisitedMessage" : 67,
 				"onEmptyMessage" : 68,
 				"visitMode" : "hero",
@@ -154,7 +158,8 @@
 					"value"		: 1500,
 					"rarity"	: 100
 				},
-			
+				"compatibilityIdentifiers" : [ "object" ],
+
 				"onVisitedMessage" : 81,
 				"visitMode" : "hero",
 				"selectMode" : "selectFirst",
@@ -184,7 +189,8 @@
 					"value"		: 1500,
 					"rarity"	: 100
 				},
-				
+				"compatibilityIdentifiers" : [ "object" ],
+
 				"onVisitedMessage" : 101,
 				"visitMode" : "hero",
 				"selectMode" : "selectFirst",
@@ -214,6 +220,7 @@
 					"value"		: 2500,
 					"rarity"	: 50
 				},
+				"compatibilityIdentifiers" : [ "object" ],
 
 				"onEmpty" : [
 					{
@@ -270,7 +277,8 @@
 					"value"		: 1000,
 					"rarity"	: 50
 				},
-				
+				"compatibilityIdentifiers" : [ "object" ],
+
 				"onSelectMessage" : 71,
 				"onVisitedMessage" : 72,
 				"onEmptyMessage" : 73,
@@ -309,6 +317,7 @@
 					"value"		: 1000,
 					"rarity"	: 50
 				},
+				"compatibilityIdentifiers" : [ "object" ],
 
 				"onSelectMessage" : 158,
 				"onVisitedMessage" : 159,
@@ -348,6 +357,7 @@
 					"value"		: 1500,
 					"rarity"	: 200
 				},
+				"compatibilityIdentifiers" : [ "object" ],
 
 				"onVisitedMessage" : 144,
 				"visitMode" : "hero",

--- a/config/objects/rewardableOncePerWeek.json
+++ b/config/objects/rewardableOncePerWeek.json
@@ -17,7 +17,8 @@
 					"value"		: 250,
 					"rarity"	: 100
 				},
-				
+				"compatibilityIdentifiers" : [ "object" ],
+
 				"onEmptyMessage" : 79,
 				"onVisitedMessage" : 78,
 				"visitMode" : "bonus",
@@ -54,7 +55,8 @@
 				//	"value"		: 500,
 				//	"rarity"	: 50
 				//},
-				
+				"compatibilityIdentifiers" : [ "object" ],
+
 				"onEmptyMessage" : 76,
 				"onVisitedMessage" : 75,
 				"resetParameters" : {
@@ -92,7 +94,8 @@
 					"value"		: 500,
 					"rarity"	: 50
 				},
-				
+				"compatibilityIdentifiers" : [ "object" ],
+
 				"onVisitedMessage" : 93,
 				"resetParameters" : {
 					"period" : 7,
@@ -133,7 +136,8 @@
 					"value"		: 1500,
 					"rarity"	: 80
 				},
-				
+				"compatibilityIdentifiers" : [ "object" ],
+
 				"onVisitedMessage" : 169,
 				"resetParameters" : {
 					"period" : 7,
@@ -174,7 +178,8 @@
 					"value"		: 750,
 					"rarity"	: 50
 				},
-				
+				"compatibilityIdentifiers" : [ "object" ],
+
 				"onVisitedMessage" : 165,
 				"resetParameters" : {
 					"period" : 7,

--- a/config/objects/rewardableOnceVisitable.json
+++ b/config/objects/rewardableOnceVisitable.json
@@ -17,7 +17,8 @@
 					"value"		: 500,
 					"rarity"	: 100
 				},
-				
+				"compatibilityIdentifiers" : [ "object" ],
+
 				"onVisitedMessage" : 65,
 				"visitMode" : "once",
 				"selectMode" : "selectFirst",
@@ -32,7 +33,7 @@
 							}
 						]
 					}
-				]				
+				]
 			}
 		}
 	},
@@ -52,7 +53,8 @@
 					"value"		: 500,
 					"rarity"	: 100
 				},
-				
+				"compatibilityIdentifiers" : [ "object" ],
+
 				"onVisitedMessage" : 38,
 				"blockedVisitable" : true,
 				"visitMode" : "once",
@@ -92,7 +94,8 @@
 					"value"		: 500,
 					"rarity"	: 50
 				},
-				
+				"compatibilityIdentifiers" : [ "object" ],
+
 				"onVisitedMessage" : 156,
 				"visitMode" : "once",
 				"selectMode" : "selectFirst",
@@ -142,7 +145,8 @@
 					"value"		: 6000,
 					"rarity"	: 20
 				},
-				
+				"compatibilityIdentifiers" : [ "object" ],
+
 				"onSelectMessage" : 161,
 				"visitMode" : "once",
 				"selectMode" : "selectFirst",

--- a/config/objects/rewardablePickable.json
+++ b/config/objects/rewardablePickable.json
@@ -19,7 +19,8 @@
 					"value"		: 2000,
 					"rarity"	: 500
 				},
-				
+				"compatibilityIdentifiers" : [ "object" ],
+
 				"blockedVisitable" : true,
 				"visitMode" : "unlimited",
 				"selectMode" : "selectFirst",
@@ -60,7 +61,8 @@
 					"value"		: 2000,
 					"rarity"	: 100
 				},
-				
+				"compatibilityIdentifiers" : [ "object" ],
+
 				"blockedVisitable" : true,
 				"visitMode" : "unlimited",
 				"selectMode" : "selectFirst",
@@ -117,7 +119,8 @@
 					"value"		: 1500,
 					"rarity"	: 500
 				},
-				
+				"compatibilityIdentifiers" : [ "object" ],
+
 				"blockedVisitable" : true,
 				"visitMode" : "unlimited",
 				"selectMode" : "selectFirst",
@@ -167,6 +170,7 @@
 					"value"		: 1500,
 					"rarity"	: 50
 				},
+				"compatibilityIdentifiers" : [ "object" ],
 
 				"blockedVisitable" : true,
 				"visitMode" : "unlimited",
@@ -217,7 +221,8 @@
 					"value"		: 1500,
 					"rarity"	: 1000
 				},
-				
+				"compatibilityIdentifiers" : [ "object" ],
+
 				"blockedVisitable" : true,
 				"onSelectMessage" : 146,
 				"visitMode" : "unlimited",

--- a/lib/mapObjects/CObjectClassesHandler.cpp
+++ b/lib/mapObjects/CObjectClassesHandler.cpp
@@ -165,6 +165,8 @@ void CObjectClassesHandler::loadSubObject(const std::string & scope, const std::
 	obj->objects.push_back(object);
 
 	registerObject(scope, obj->getJsonKey(), object->getSubTypeName(), object->subtype);
+	for (auto const & compatID : entry["compatibilityIdentifiers"].Vector())
+		registerObject(scope, obj->getJsonKey(), compatID.String(), object->subtype);
 }
 
 void CObjectClassesHandler::loadSubObject(const std::string & scope, const std::string & identifier, const JsonNode & entry, ObjectClass * obj, size_t index)
@@ -176,6 +178,8 @@ void CObjectClassesHandler::loadSubObject(const std::string & scope, const std::
 	obj->objects[index] = object;
 
 	registerObject(scope, obj->getJsonKey(), object->getSubTypeName(), object->subtype);
+	for (auto const & compatID : entry["compatibilityIdentifiers"].Vector())
+		registerObject(scope, obj->getJsonKey(), compatID.String(), object->subtype);
 }
 
 TObjectTypeHandler CObjectClassesHandler::loadSubObjectFromJson(const std::string & scope, const std::string & identifier, const JsonNode & entry, ObjectClass * obj, size_t index)


### PR DESCRIPTION
Fixes #1917 

... however we need to decide how to handle map compatibility in long-term. 

Perhaps make sure that 1.X editor can always load 1.X-1 maps & ask map authors to update maps by re-saving them after major release?