### PR TITLE
Monoliths and Subterranean Gates placement tweaks

### DIFF
--- a/lib/rmg/ConnectionsPlacer.cpp
+++ b/lib/rmg/ConnectionsPlacer.cpp
@@ -243,7 +243,7 @@ void ConnectionsPlacer::selfSideIndirectConnection(const rmg::ZoneConnection & c
 				
 				path2 = managerOther.placeAndConnectObject(toPlace, rmgGate2, minDist, guarded2, true, ObjectManager::OptimizeType::NONE);
 				
-				return path2.valid() ? (dist + otherDist) : -1.f;
+				return path2.valid() ? (dist * otherDist) : -1.f;
 			}, guarded1, true, ObjectManager::OptimizeType::DISTANCE);
 			
 			if(path1.valid() && path2.valid())

--- a/lib/rmg/MinePlacer.cpp
+++ b/lib/rmg/MinePlacer.cpp
@@ -7,6 +7,7 @@
 #include "StdInc.h"
 #include "MinePlacer.h"
 #include "TownPlacer.h"
+#include "ConnectionsPlacer.h"
 #include "CMapGenerator.h"
 #include "RmgMap.h"
 #include "../mapping/CMap.h"
@@ -38,6 +39,7 @@ void MinePlacer::process()
 void MinePlacer::init()
 {
 	DEPENDENCY(TownPlacer);
+	DEPENDENCY(ConnectionsPlacer);
 	POSTFUNCTION(ObjectManager);
 	POSTFUNCTION(RoadPlacer);
 }


### PR DESCRIPTION
Little tweaks:

- Make sure Mines are placed after Monoliths and all the connections.
- Use product instead of distance sum for Subterranean Gate placement. Yields a little bit more natural results.