### PR TITLE
Fix installation of multiple mods at once, e.g. during setup

### DIFF
--- a/launcher/modManager/cdownloadmanager_moc.cpp
+++ b/launcher/modManager/cdownloadmanager_moc.cpp
@@ -20,12 +20,12 @@ CDownloadManager::CDownloadManager()
 
 void CDownloadManager::downloadFile(const QUrl & url, const QString & file)
 {
-	filename = file;
 	QNetworkRequest request(url);
 	FileEntry entry;
 	entry.file.reset(new QFile(CLauncherDirs::get().downloadsPath() + '/' + file));
 	entry.bytesReceived = 0;
 	entry.totalSize = 0;
+	entry.filename = file;
 
 	if(entry.file->open(QIODevice::WriteOnly | QIODevice::Truncate))
 	{
@@ -68,10 +68,13 @@ void CDownloadManager::downloadFinished(QNetworkReply * reply)
 	
 	if(possibleRedirectUrl.isValid())
 	{
+		QString filename;
+
 		for(int i = 0; i< currentDownloads.size(); ++i)
 		{
 			if(currentDownloads[i].file == file.file)
 			{
+				filename = currentDownloads[i].filename;
 				currentDownloads.removeAt(i);
 				break;
 			}

--- a/launcher/modManager/cdownloadmanager_moc.h
+++ b/launcher/modManager/cdownloadmanager_moc.h
@@ -29,14 +29,13 @@ class CDownloadManager : public QObject
 
 		QNetworkReply * reply;
 		QSharedPointer<QFile> file;
+		QString filename;
 		Status status;
 		qint64 bytesReceived;
 		qint64 totalSize;
 	};
 
 	QStringList encounteredErrors;
-	
-	QString filename;
 
 	QNetworkAccessManager manager;
 


### PR DESCRIPTION
Fixes bug when launcher fails to install mods if multiple mods were selected during initial setup (e.g. extras + localization)