### PR TITLE
Fix Launcher issues discovered in 1.2

### DIFF
--- a/launcher/firstLaunch/firstlaunch_moc.cpp
+++ b/launcher/firstLaunch/firstlaunch_moc.cpp
@@ -264,6 +264,18 @@ void FirstLaunchView::copyHeroesData()
 	if(!sourceRoot.exists())
 		return;
 
+	if (sourceRoot.dirName().compare("data", Qt::CaseInsensitive) == 0)
+	{
+		// We got Data folder. Possibly user selected "Data" folder of Heroes III install. Check whether valid data might exist 1 level above
+
+		QStringList dirData = sourceRoot.entryList({"data"}, QDir::Filter::Dirs);
+		if (dirData.empty())
+		{
+			// This is "Data" folder without any "Data" folders inside. Try to check for data 1 level above
+			sourceRoot.cdUp();
+		}
+	}
+
 	QStringList dirData = sourceRoot.entryList({"data"}, QDir::Filter::Dirs);
 	QStringList dirMaps = sourceRoot.entryList({"maps"}, QDir::Filter::Dirs);
 	QStringList dirMp3 = sourceRoot.entryList({"mp3"}, QDir::Filter::Dirs);

--- a/launcher/firstLaunch/firstlaunch_moc.cpp
+++ b/launcher/firstLaunch/firstlaunch_moc.cpp
@@ -190,6 +190,7 @@ void FirstLaunchView::heroesDataMissing()
 	ui->labelDataCopy->setVisible(true);
 
 	ui->labelDataFound->setVisible(false);
+	ui->pushButtonDataNext->setEnabled(true);
 
 	if(hasVCMIBuilderScript)
 	{
@@ -218,6 +219,7 @@ void FirstLaunchView::heroesDataDetected()
 	}
 
 	ui->labelDataFound->setVisible(true);
+	ui->pushButtonDataNext->setEnabled(true);
 
 	heroesLanguageUpdate();
 }
@@ -247,7 +249,6 @@ void FirstLaunchView::heroesLanguageUpdate()
 
 	ui->labelDataFailure->setVisible(!success);
 	ui->labelDataSuccess->setVisible(success);
-	ui->pushButtonDataNext->setEnabled(success);
 }
 
 void FirstLaunchView::forceHeroesLanguage(const QString & language)

--- a/launcher/languages.cpp
+++ b/launcher/languages.cpp
@@ -44,7 +44,7 @@ QString Languages::getHeroesDataLanguage()
 	QString language = QString::fromStdString(settings["session"]["language"].String());
 	double deviation = settings["session"]["languageDeviation"].Float();
 
-	if(deviation > 0.05)
+	if(deviation > 0.1)
 		return QString();
 	return language;
 }


### PR DESCRIPTION
- Fix case when player actually selects "Data" directory on request to select H3 data
- Fix inability to proceed in setup because vcmi failed to detect language automatically
- Be less strict in detecting language, since this might lead to inability to detect different install of the same language