### PR TITLE
Fixed #2022": Storing event in map editor

### DIFF
--- a/mapeditor/inspector/inspector.cpp
+++ b/mapeditor/inspector/inspector.cpp
@@ -472,6 +472,9 @@ void Inspector::setProperty(CGLighthouse * o, const QString & key, const QVarian
 void Inspector::setProperty(CGPandoraBox * o, const QString & key, const QVariant & value)
 {
 	if(!o) return;
+	
+	if(key == "Message")
+		o->message = value.toString().toStdString();
 }
 
 void Inspector::setProperty(CGEvent * o, const QString & key, const QVariant & value)


### PR DESCRIPTION
Fixing issue "Event message isn't stored #2022" by adding message in Pandora setProperty ( cause CGEvent inherits CGPandoraBox)