### PR TITLE
Use separate json for vcmi-1.3

### DIFF
--- a/config/schemas/settings.json
+++ b/config/schemas/settings.json
@@ -463,7 +463,7 @@
 				"repositoryURL" : {
 					"type" : "array",
 					"default" : [
-						"https://raw.githubusercontent.com/vcmi/vcmi-mods-repository/develop/vcmi-1.2.json"
+						"https://raw.githubusercontent.com/vcmi/vcmi-mods-repository/develop/vcmi-1.3.json"
 					],
 					"items" : {
 						"type" : "string"


### PR DESCRIPTION
Updated vcmi-extras to use shortcuts, now battlefield actions submod from extras needs update that is not compatible with 1.2