### PR TITLE
BattleAI: stacks should not measure damage against turret

### DIFF
--- a/AI/BattleAI/AttackPossibility.cpp
+++ b/AI/BattleAI/AttackPossibility.cpp
@@ -50,7 +50,22 @@ int64_t AttackPossibility::calculateDamageReduce(
 	vstd::amin(damageDealt, defender->getAvailableHealth());
 
 	// FIXME: provide distance info for Jousting bonus
-	auto enemyDamageBeforeAttack = cb.battleEstimateDamage(defender, attacker, 0);
+	auto attackerUnitForMeasurement = attacker;
+
+	if(attackerUnitForMeasurement->isTurret())
+	{
+		auto ourUnits = cb.battleGetUnitsIf([&](const battle::Unit * u) -> bool
+			{
+				return u->unitSide() == attacker->unitSide() && !u->isTurret();
+			});
+
+		if(ourUnits.empty())
+			attackerUnitForMeasurement = defender;
+		else
+			attackerUnitForMeasurement = ourUnits.front();
+	}
+
+	auto enemyDamageBeforeAttack = cb.battleEstimateDamage(defender, attackerUnitForMeasurement, 0);
 	auto enemiesKilled = damageDealt / defender->getMaxHealth() + (damageDealt % defender->getMaxHealth() >= defender->getFirstHPleft() ? 1 : 0);
 	auto enemyDamage = averageDmg(enemyDamageBeforeAttack.damage);
 	auto damagePerEnemy = enemyDamage / (double)defender->getCount();

--- a/AI/BattleAI/BattleExchangeVariant.cpp
+++ b/AI/BattleAI/BattleExchangeVariant.cpp
@@ -386,8 +386,12 @@ int64_t BattleExchangeEvaluator::calculateExchange(
 
 	for(auto unit : exchangeUnits)
 	{
+		if(unit->isTurret())
+			continue;
+
 		bool isOur = cb->battleMatchOwner(ap.attack.attacker, unit, true);
 		auto & attackerQueue = isOur ? ourStacks : enemyStacks;
+
 
 		if(!vstd::contains(attackerQueue, unit))
 		{
@@ -593,6 +597,9 @@ void BattleExchangeEvaluator::updateReachabilityMap(HypotheticBattle & hb)
 
 		for(const battle::Unit * unit : turnQueue)
 		{
+			if(unit->isTurret())
+				continue;
+
 			if(turnBattle.battleCanShoot(unit))
 			{
 				for(BattleHex hex = BattleHex::TOP_LEFT; hex.isValid(); hex = hex + 1)


### PR DESCRIPTION
When turret under Artillery skill considers whom to attack, it measures how many damage the enemy stacks deal before and after attack and selects the one with highest difference. Because enemies can not attack turret, measurement fails in endless loop.