### PR TITLE
Fix regressions from adventure map PR

### DIFF
--- a/client/gui/InterfaceObjectConfigurable.cpp
+++ b/client/gui/InterfaceObjectConfigurable.cpp
@@ -300,7 +300,7 @@ std::shared_ptr<CToggleButton> InterfaceObjectConfigurable::buildToggleButton(co
 		assert(imgOrder.size() >= 4);
 		button->setImageOrder(imgOrder[0].Integer(), imgOrder[1].Integer(), imgOrder[2].Integer(), imgOrder[3].Integer());
 	}
-	loadButtonCallback(button, config["callback"]);
+	loadToggleButtonCallback(button, config["callback"]);
 	return button;
 }
 
@@ -338,6 +338,19 @@ void InterfaceObjectConfigurable::loadButtonBorderColor(std::shared_ptr<CButton>
 
 	auto color = readColor(config);
 	button->setBorderColor(color);
+}
+
+void InterfaceObjectConfigurable::loadToggleButtonCallback(std::shared_ptr<CToggleButton> button, const JsonNode & config) const
+{
+	if(config.isNull())
+		return;
+
+	std::string callbackName = config.String();
+
+	if (callbacks.count(callbackName) > 0)
+		button->addCallback(callbacks.at(callbackName));
+	else
+		logGlobal->error("Invalid callback '%s' in widget", callbackName );
 }
 
 void InterfaceObjectConfigurable::loadButtonCallback(std::shared_ptr<CButton> button, const JsonNode & config) const

--- a/client/gui/InterfaceObjectConfigurable.h
+++ b/client/gui/InterfaceObjectConfigurable.h
@@ -75,6 +75,7 @@ protected:
 	std::pair<std::string, std::string> readHintText(const JsonNode &) const;
 	EShortcut readHotkey(const JsonNode &) const;
 	
+	void loadToggleButtonCallback(std::shared_ptr<CToggleButton> button, const JsonNode & config) const;
 	void loadButtonCallback(std::shared_ptr<CButton> button, const JsonNode & config) const;
 	void loadButtonHotkey(std::shared_ptr<CButton> button, const JsonNode & config) const;
 	void loadButtonBorderColor(std::shared_ptr<CButton> button, const JsonNode & config) const;

--- a/config/widgets/settings/generalOptionsTab.json
+++ b/config/widgets/settings/generalOptionsTab.json
@@ -68,7 +68,7 @@
 			"text": "vcmi.systemOptions.scalingButton.hover"
 		},
 		{
-			"name": "resolutionButton",
+			"name": "scalingButton",
 			"type": "button",
 			"position": {"x": 10, "y": 113},
 			"image": "settingsWindow/button32",


### PR DESCRIPTION
Fixes so far:
- Fix broken toggle button callbacks in settings window
- Fix "Duplicate widget name" error on opening settings window