### PR TITLE
Strict weak ordering on the data

### DIFF
--- a/launcher/modManager/cmodlistview_moc.cpp
+++ b/launcher/modManager/cmodlistview_moc.cpp
@@ -200,8 +200,9 @@ QString CModListView::genChangelogText(CModEntry & mod)
 
 	std::sort(versions.begin(), versions.end(), [](QString lesser, QString greater)
 	{
-		return !CModEntry::compareVersions(lesser, greater);
+		return CModEntry::compareVersions(lesser, greater);
 	});
+	std::reverse(versions.begin(), versions.end());
 
 	for(auto & version : versions)
 	{


### PR DESCRIPTION
Fixes https://github.com/vcmi/vcmi/issues/2187

Explanation from chatgpt:

```
There might be an issue with the use of this function in the context of std::sort. Here's why:

Your original lambda function for std::sort negates the result of compareVersions, which might be causing issues with the sort. 
The compareVersions function returns true if versionLesser is smaller than versionGreater, but in the lambda function, you negate this result.
This means that the sort function will interpret true as "lesser is greater than greater", which is incorrect and might cause unexpected results.

The sorting algorithm expects a comparison function that provides a strict weak ordering.
If it doesn't, the algorithm's behavior is undefined, and it might cause an infinite loop, crash, or other unwanted behavior.
```