### PR TITLE
Canvas-based rendering

### DIFF
--- a/client/ClientCommandManager.cpp
+++ b/client/ClientCommandManager.cpp
@@ -40,8 +40,6 @@
 #include "../lib/ScriptHandler.h"
 #endif
 
-#include <SDL_surface.h>
-
 void ClientCommandManager::handleQuitCommand()
 {
 		exit(EXIT_SUCCESS);
@@ -172,21 +170,6 @@ void ClientCommandManager::handleSetBattleAICommand(std::istringstream& singleWo
 void ClientCommandManager::handleRedrawCommand()
 {
 	GH.windows().totalRedraw();
-}
-
-void ClientCommandManager::handleScreenCommand()
-{
-	printCommandMessage("Screenbuf points to ");
-
-	if(screenBuf == screen)
-		printCommandMessage("screen", ELogLevel::ERROR);
-	else if(screenBuf == screen2)
-		printCommandMessage("screen2", ELogLevel::ERROR);
-	else
-		printCommandMessage("?!?", ELogLevel::ERROR);
-
-	SDL_SaveBMP(screen, "Screen_c.bmp");
-	SDL_SaveBMP(screen2, "Screen2_c.bmp");
 }
 
 void ClientCommandManager::handleNotDialogCommand()
@@ -526,9 +509,6 @@ void ClientCommandManager::processCommand(const std::string & message, bool call
 
 	else if(commandName == "redraw")
 		handleRedrawCommand();
-
-	else if(commandName == "screen")
-		handleScreenCommand();
 
 	else if(commandName == "not dialog")
 		handleNotDialogCommand();

--- a/client/ClientCommandManager.h
+++ b/client/ClientCommandManager.h
@@ -45,9 +45,6 @@ class ClientCommandManager //take mantis #2292 issue about account if thinking a
 	// Redraw the current screen
 	void handleRedrawCommand();
 
-	// Prints information about current screen, and saves both screens as .bmp in root folder
-	void handleScreenCommand();
-
 	// Set the state indicating if dialog box is active to "no"
 	void handleNotDialogCommand();
 

--- a/client/adventureMap/AdventureMapInterface.cpp
+++ b/client/adventureMap/AdventureMapInterface.cpp
@@ -28,6 +28,7 @@
 #include "../gui/CGuiHandler.h"
 #include "../gui/Shortcut.h"
 #include "../gui/WindowHandler.h"
+#include "../render/Canvas.h"
 #include "../CMT.h"
 #include "../PlayerLocalState.h"
 #include "../CPlayerInterface.h"
@@ -133,13 +134,13 @@ void AdventureMapInterface::deactivate()
 	CCS->curh->set(Cursor::Map::POINTER);
 }
 
-void AdventureMapInterface::showAll(SDL_Surface * to)
+void AdventureMapInterface::showAll(Canvas & to)
 {
 	CIntObject::showAll(to);
 	LOCPLINT->cingconsole->show(to);
 }
 
-void AdventureMapInterface::show(SDL_Surface * to)
+void AdventureMapInterface::show(Canvas & to)
 {
 	CIntObject::show(to);
 	LOCPLINT->cingconsole->show(to);
@@ -396,7 +397,8 @@ void AdventureMapInterface::onPlayerTurnStarted(PlayerColor playerID)
 	widget->getInfoBar()->showDate();
 
 	onHeroChanged(nullptr);
-	showAll(screen);
+	Canvas canvas = Canvas::createFromSurface(screen);
+	showAll(canvas);
 	mapAudio->onPlayerTurnStarted();
 
 	if(settings["session"]["autoSkip"].Bool() && !GH.isKeyboardShiftDown())

--- a/client/adventureMap/AdventureMapInterface.h
+++ b/client/adventureMap/AdventureMapInterface.h
@@ -94,8 +94,8 @@ protected:
 	void deactivate() override;
 
 	void tick(uint32_t msPassed) override;
-	void show(SDL_Surface * to) override;
-	void showAll(SDL_Surface * to) override;
+	void show(Canvas & to) override;
+	void showAll(Canvas & to) override;
 
 	void keyPressed(EShortcut key) override;
 

--- a/client/adventureMap/AdventureMapWidget.cpp
+++ b/client/adventureMap/AdventureMapWidget.cpp
@@ -410,7 +410,7 @@ void CAdventureMapIcon::setPlayer(const PlayerColor & player)
 	image->setFrame(index + player.getNum() * iconsPerPlayer);
 }
 
-void CAdventureMapOverlayWidget::show(SDL_Surface * to)
+void CAdventureMapOverlayWidget::show(Canvas & to)
 {
 	CIntObject::showAll(to);
 }

--- a/client/adventureMap/AdventureMapWidget.h
+++ b/client/adventureMap/AdventureMapWidget.h
@@ -92,7 +92,7 @@ class CAdventureMapContainerWidget : public CIntObject
 class CAdventureMapOverlayWidget : public CAdventureMapContainerWidget
 {
 public:
-	void show(SDL_Surface * to) override;
+	void show(Canvas & to) override;
 };
 
 /// Small helper class that provides player-colorable icon using animation file

--- a/client/adventureMap/CInGameConsole.cpp
+++ b/client/adventureMap/CInGameConsole.cpp
@@ -19,7 +19,9 @@
 #include "../gui/CGuiHandler.h"
 #include "../gui/WindowHandler.h"
 #include "../gui/Shortcut.h"
+#include "../gui/TextAlignment.h"
 #include "../render/Colors.h"
+#include "../render/Canvas.h"
 #include "../adventureMap/AdventureMapInterface.h"
 #include "../windows/CMessage.h"
 
@@ -35,12 +37,12 @@ CInGameConsole::CInGameConsole()
 	type |= REDRAW_PARENT;
 }
 
-void CInGameConsole::showAll(SDL_Surface * to)
+void CInGameConsole::showAll(Canvas & to)
 {
 	show(to);
 }
 
-void CInGameConsole::show(SDL_Surface * to)
+void CInGameConsole::show(Canvas & to)
 {
 	if (LOCPLINT->cingconsole != this)
 		return;
@@ -53,8 +55,7 @@ void CInGameConsole::show(SDL_Surface * to)
 		Point leftBottomCorner(0, pos.h);
 		Point textPosition(leftBottomCorner.x + 50, leftBottomCorner.y - texts.size() * 20 - 80 + number * 20);
 
-		graphics->fonts[FONT_MEDIUM]->renderTextLeft(to, text.text, Colors::GREEN, pos.topLeft() + textPosition );
-
+		to.drawText(pos.topLeft() + textPosition, FONT_MEDIUM, Colors::GREEN, ETextAlignment::TOPLEFT, text.text);
 		number++;
 	}
 }

--- a/client/adventureMap/CInGameConsole.h
+++ b/client/adventureMap/CInGameConsole.h
@@ -45,8 +45,8 @@ public:
 	void print(const std::string & txt);
 
 	void tick(uint32_t msPassed) override;
-	void show(SDL_Surface * to) override;
-	void showAll(SDL_Surface * to) override;
+	void show(Canvas & to) override;
+	void showAll(Canvas & to) override;
 	void keyPressed(EShortcut key) override;
 	void textInputed(const std::string & enteredText) override;
 	void textEdited(const std::string & enteredText) override;

--- a/client/adventureMap/CInfoBar.cpp
+++ b/client/adventureMap/CInfoBar.cpp
@@ -36,7 +36,7 @@ CInfoBar::CVisibleInfo::CVisibleInfo()
 {
 }
 
-void CInfoBar::CVisibleInfo::show(SDL_Surface * to)
+void CInfoBar::CVisibleInfo::show(Canvas & to)
 {
 	CIntObject::show(to);
 	for(auto object : forceRefresh)

--- a/client/adventureMap/CInfoBar.h
+++ b/client/adventureMap/CInfoBar.h
@@ -46,7 +46,7 @@ private:
 		static constexpr int offset_x = 8;
 		static constexpr int offset_y = 12;
 
-		void show(SDL_Surface * to) override;
+		void show(Canvas & to) override;
 
 	protected:
 		std::shared_ptr<CPicture> background;

--- a/client/adventureMap/CList.cpp
+++ b/client/adventureMap/CList.cpp
@@ -21,7 +21,7 @@
 #include "../CPlayerInterface.h"
 #include "../PlayerLocalState.h"
 #include "../gui/CGuiHandler.h"
-#include "../renderSDL/SDL_Extensions.h"
+#include "../render/Canvas.h"
 
 #include "../../lib/CGeneralTextHandler.h"
 #include "../../lib/CHeroHandler.h"
@@ -92,9 +92,9 @@ CList::CList(int Size, Rect widgetDimensions)
 	pos.h = widgetDimensions.h;
 }
 
-void CList::showAll(SDL_Surface * to)
+void CList::showAll(Canvas & to)
 {
-	CSDL_Ext::fillRect(to, pos, Colors::BLACK);
+	to.drawColor(pos, Colors::BLACK);
 	CIntObject::showAll(to);
 }
 

--- a/client/adventureMap/CList.h
+++ b/client/adventureMap/CList.h
@@ -91,7 +91,7 @@ public:
 	void selectNext();
 	void selectPrev();
 
-	void showAll(SDL_Surface * to) override;
+	void showAll(Canvas & to) override;
 };
 
 /// List of heroes which is shown at the right of the adventure map screen

--- a/client/adventureMap/CMinimap.cpp
+++ b/client/adventureMap/CMinimap.cpp
@@ -82,10 +82,9 @@ CMinimapInstance::CMinimapInstance(CMinimap *Parent, int Level):
 	redrawMinimap();
 }
 
-void CMinimapInstance::showAll(SDL_Surface * to)
+void CMinimapInstance::showAll(Canvas & to)
 {
-	Canvas target(to);
-	target.drawScaled(*minimap, pos.topLeft(), pos.dimensions());
+	to.drawScaled(*minimap, pos.topLeft(), pos.dimensions());
 }
 
 CMinimap::CMinimap(const Rect & position)
@@ -164,15 +163,13 @@ void CMinimap::mouseMoved(const Point & cursorPosition)
 		moveAdvMapSelection();
 }
 
-void CMinimap::showAll(SDL_Surface * to)
+void CMinimap::showAll(Canvas & to)
 {
-	CSDL_Ext::CClipRectGuard guard(to, pos);
+	CSDL_Ext::CClipRectGuard guard(to.getInternalSurface(), pos);
 	CIntObject::showAll(to);
 
 	if(minimap)
 	{
-		Canvas target(to);
-
 		int3 mapSizes = LOCPLINT->cb->getMapSize();
 
 		//draw radar
@@ -184,7 +181,7 @@ void CMinimap::showAll(SDL_Surface * to)
 			screenArea.h * pos.h / mapSizes.y - 1
 		};
 
-		Canvas clippedTarget(target, pos);
+		Canvas clippedTarget(to, pos);
 		clippedTarget.drawBorderDashed(radar, CSDL_Ext::fromSDL(Colors::PURPLE));
 	}
 }

--- a/client/adventureMap/CMinimap.h
+++ b/client/adventureMap/CMinimap.h
@@ -31,7 +31,7 @@ class CMinimapInstance : public CIntObject
 public:
 	CMinimapInstance(CMinimap * parent, int level);
 
-	void showAll(SDL_Surface * to) override;
+	void showAll(Canvas & to) override;
 	void refreshTile(const int3 & pos);
 };
 
@@ -65,7 +65,7 @@ public:
 	void update();
 	void setAIRadar(bool on);
 
-	void showAll(SDL_Surface * to) override;
+	void showAll(Canvas & to) override;
 
 	void updateTiles(std::unordered_set<int3> positions);
 };

--- a/client/adventureMap/CResDataBar.cpp
+++ b/client/adventureMap/CResDataBar.cpp
@@ -12,8 +12,10 @@
 
 #include "../CGameInfo.h"
 #include "../CPlayerInterface.h"
+#include "../render/Canvas.h"
 #include "../render/Colors.h"
 #include "../gui/CGuiHandler.h"
+#include "../gui/TextAlignment.h"
 #include "../widgets/Images.h"
 
 #include "../../CCallback.h"
@@ -67,24 +69,20 @@ std::string CResDataBar::buildDateString()
 	return boost::str(formatted);
 }
 
-void CResDataBar::draw(SDL_Surface * to)
+void CResDataBar::showAll(Canvas & to)
 {
+	CIntObject::showAll(to);
+
 	//TODO: all this should be labels, but they require proper text update on change
 	for (auto & entry : resourcePositions)
 	{
 		std::string text = std::to_string(LOCPLINT->cb->getResourceAmount(entry.first));
 
-		graphics->fonts[FONT_SMALL]->renderTextLeft(to, text, Colors::WHITE, pos.topLeft() + entry.second);
+		to.drawText(pos.topLeft() + entry.second, FONT_SMALL, Colors::WHITE, ETextAlignment::TOPLEFT, text);
 	}
 
 	if (datePosition)
-		graphics->fonts[FONT_SMALL]->renderTextLeft(to, buildDateString(), Colors::WHITE, pos.topLeft() + *datePosition);
-}
-
-void CResDataBar::showAll(SDL_Surface * to)
-{
-	CIntObject::showAll(to);
-	draw(to);
+		to.drawText(pos.topLeft() + *datePosition, FONT_SMALL, Colors::WHITE, ETextAlignment::TOPLEFT, buildDateString());
 }
 
 void CResDataBar::colorize(PlayerColor player)

--- a/client/adventureMap/CResDataBar.h
+++ b/client/adventureMap/CResDataBar.h
@@ -27,7 +27,6 @@ class CResDataBar : public CIntObject
 	std::map<GameResID, Point> resourcePositions;
 	std::optional<Point> datePosition;
 
-	void draw(SDL_Surface * to);
 public:
 
 	/// For dynamically-sized UI windows, e.g. adventure map interface
@@ -40,6 +39,6 @@ public:
 	void setResourcePosition(const GameResID & resource, const Point & position);
 
 	void colorize(PlayerColor player);
-	void showAll(SDL_Surface * to) override;
+	void showAll(Canvas & to) override;
 };
 

--- a/client/battle/BattleFieldController.cpp
+++ b/client/battle/BattleFieldController.cpp
@@ -606,7 +606,7 @@ bool BattleFieldController::stackCountOutsideHex(const BattleHex & number) const
 	return stackCountOutsideHexes[number];
 }
 
-void BattleFieldController::showAll(SDL_Surface * to)
+void BattleFieldController::showAll(Canvas & to)
 {
 	show(to);
 }
@@ -619,10 +619,9 @@ void BattleFieldController::tick(uint32_t msPassed)
 	owner.projectilesController->tick(msPassed);
 }
 
-void BattleFieldController::show(SDL_Surface * to)
+void BattleFieldController::show(Canvas & to)
 {
-	Canvas canvas(to);
-	CSDL_Ext::CClipRectGuard guard(to, pos);
+	CSDL_Ext::CClipRectGuard guard(to.getInternalSurface(), pos);
 
-	renderBattlefield(canvas);
+	renderBattlefield(to);
 }

--- a/client/battle/BattleFieldController.h
+++ b/client/battle/BattleFieldController.h
@@ -68,8 +68,8 @@ class BattleFieldController : public CIntObject
 	void clickRight(tribool down, bool previousState) override;
 	void activate() override;
 
-	void showAll(SDL_Surface * to) override;
-	void show(SDL_Surface * to) override;
+	void showAll(Canvas & to) override;
+	void show(Canvas & to) override;
 	void tick(uint32_t msPassed) override;
 public:
 	BattleFieldController(BattleInterface & owner);

--- a/client/battle/BattleInterface.h
+++ b/client/battle/BattleInterface.h
@@ -163,7 +163,7 @@ public:
 
 	const CGHeroInstance *getActiveHero(); //returns hero that can currently cast a spell
 
-	void showInterface(SDL_Surface * to);
+	void showInterface(Canvas & to);
 
 	void setHeroAnimation(ui8 side, EHeroAnimType phase);
 

--- a/client/battle/BattleInterfaceClasses.cpp
+++ b/client/battle/BattleInterfaceClasses.cpp
@@ -36,7 +36,6 @@
 #include "../windows/CSpellWindow.h"
 #include "../render/CAnimation.h"
 #include "../adventureMap/CInGameConsole.h"
-#include "../renderSDL/SDL_Extensions.h"
 
 #include "../../CCallback.h"
 #include "../../lib/CStack.h"
@@ -52,7 +51,7 @@
 #include "../../lib/mapObjects/CGTownInstance.h"
 #include "../../lib/TextOperations.h"
 
-void BattleConsole::showAll(SDL_Surface * to)
+void BattleConsole::showAll(Canvas & to)
 {
 	CIntObject::showAll(to);
 
@@ -62,10 +61,10 @@ void BattleConsole::showAll(SDL_Surface * to)
 	auto visibleText = getVisibleText();
 
 	if(visibleText.size() > 0)
-		graphics->fonts[FONT_SMALL]->renderTextCenter(to, visibleText[0], Colors::WHITE, line1);
+		to.drawText(line1, FONT_SMALL, Colors::WHITE, ETextAlignment::CENTER, visibleText[0]);
 
 	if(visibleText.size() > 1)
-		graphics->fonts[FONT_SMALL]->renderTextCenter(to, visibleText[1], Colors::WHITE, line2);
+		to.drawText(line2, FONT_SMALL, Colors::WHITE, ETextAlignment::CENTER, visibleText[1]);
 }
 
 std::vector<std::string> BattleConsole::getVisibleText()
@@ -580,10 +579,10 @@ void BattleResultWindow::activate()
 	CIntObject::activate();
 }
 
-void BattleResultWindow::show(SDL_Surface * to)
+void BattleResultWindow::show(Canvas & to)
 {
 	CIntObject::show(to);
-	CCS->videoh->update(pos.x + 107, pos.y + 70, to, true, false);
+	CCS->videoh->update(pos.x + 107, pos.y + 70, to.getInternalSurface(), true, false);
 }
 
 void BattleResultWindow::buttonPressed(int button)
@@ -651,7 +650,7 @@ StackQueue::StackQueue(bool Embedded, BattleInterface & owner)
 	}
 }
 
-void StackQueue::show(SDL_Surface * to)
+void StackQueue::show(Canvas & to)
 {
 	auto unitIdsToHighlight = owner.stacksController->getHoveredStacksUnitIds();
 
@@ -789,10 +788,10 @@ void StackQueue::StackBox::toggleHighlight(bool value)
 	highlighted = value;
 }
 
-void StackQueue::StackBox::show(SDL_Surface *to)
+void StackQueue::StackBox::show(Canvas & to)
 {
 	if(highlighted)
-		CSDL_Ext::drawBorder(to, background->pos.x, background->pos.y, background->pos.w, background->pos.h,  { 0, 255, 255, 255 }, 2);
+		to.drawBorder(background->pos, Colors::CYAN, 2);
 
 	CIntObject::show(to);
 }

--- a/client/battle/BattleInterfaceClasses.h
+++ b/client/battle/BattleInterfaceClasses.h
@@ -29,7 +29,6 @@ class Unit;
 VCMI_LIB_NAMESPACE_END
 
 class Canvas;
-struct SDL_Surface;
 class BattleInterface;
 class CPicture;
 class CFilledTexture;
@@ -70,7 +69,7 @@ private:
 public:
 	BattleConsole(std::shared_ptr<CPicture> backgroundSource, const Point & objectPos, const Point & imagePos, const Point &size);
 
-	void showAll(SDL_Surface * to) override;
+	void showAll(Canvas & to) override;
 	void deactivate() override;
 
 	bool addText(const std::string &text); //adds text at the last position; returns false if failed (e.g. text longer than 70 characters)
@@ -158,7 +157,7 @@ public:
 	std::function<void(int result)> resultCallback; //callback receiving which button was pressed
 
 	void activate() override;
-	void show(SDL_Surface * to = 0) override;
+	void show(Canvas & to) override;
 };
 
 /// Shows the stack queue
@@ -181,7 +180,7 @@ class StackQueue : public CIntObject
 		void toggleHighlight(bool value);
 		std::optional<uint32_t> getBoundUnitID() const;
 
-		void show(SDL_Surface * to) override;
+		void show(Canvas & to) override;
 	};
 
 	static const int QUEUE_SIZE = 10;
@@ -200,5 +199,5 @@ public:
 	void update();
 	std::optional<uint32_t> getHoveredUnitIdIfAny() const;
 
-	void show(SDL_Surface * to) override;
+	void show(Canvas & to) override;
 };

--- a/client/battle/BattleStacksController.cpp
+++ b/client/battle/BattleStacksController.cpp
@@ -28,7 +28,6 @@
 #include "../gui/CGuiHandler.h"
 #include "../render/Colors.h"
 #include "../render/Canvas.h"
-#include "../renderSDL/SDL_Extensions.h"
 
 #include "../../CCallback.h"
 #include "../../lib/spells/ISpellMechanics.h"

--- a/client/battle/BattleWindow.cpp
+++ b/client/battle/BattleWindow.cpp
@@ -555,15 +555,15 @@ std::optional<uint32_t> BattleWindow::getQueueHoveredUnitId()
 	return queue->getHoveredUnitIdIfAny();
 }
 
-void BattleWindow::showAll(SDL_Surface *to)
+void BattleWindow::showAll(Canvas & to)
 {
 	CIntObject::showAll(to);
 
 	if (GH.screenDimensions().x != 800 || GH.screenDimensions().y !=600)
-		CMessage::drawBorder(owner.curInt->playerID, to, pos.w+28, pos.h+29, pos.x-14, pos.y-15);
+		CMessage::drawBorder(owner.curInt->playerID, to.getInternalSurface(), pos.w+28, pos.h+29, pos.x-14, pos.y-15);
 }
 
-void BattleWindow::show(SDL_Surface *to)
+void BattleWindow::show(Canvas & to)
 {
 	CIntObject::show(to);
 	LOCPLINT->cingconsole->show(to);

--- a/client/battle/BattleWindow.h
+++ b/client/battle/BattleWindow.h
@@ -87,8 +87,8 @@ public:
 	void keyPressed(EShortcut key) override;
 	bool captureThisKey(EShortcut key) override;
 	void clickRight(tribool down, bool previousState) override;
-	void show(SDL_Surface *to) override;
-	void showAll(SDL_Surface *to) override;
+	void show(Canvas & to) override;
+	void showAll(Canvas & to) override;
 
 	/// Toggle UI to displaying tactics phase
 	void tacticPhaseStarted();

--- a/client/gui/CGuiHandler.cpp
+++ b/client/gui/CGuiHandler.cpp
@@ -21,7 +21,6 @@
 
 #include "../CGameInfo.h"
 #include "../render/Colors.h"
-#include "../renderSDL/SDL_Extensions.h"
 #include "../renderSDL/ScreenHandler.h"
 #include "../CMT.h"
 #include "../CPlayerInterface.h"

--- a/client/gui/CIntObject.cpp
+++ b/client/gui/CIntObject.cpp
@@ -13,7 +13,7 @@
 #include "CGuiHandler.h"
 #include "WindowHandler.h"
 #include "Shortcut.h"
-#include "../renderSDL/SDL_Extensions.h"
+#include "../render/Canvas.h"
 #include "../windows/CMessage.h"
 #include "../CMT.h"
 
@@ -53,7 +53,7 @@ CIntObject::~CIntObject()
 		parent_m->removeChild(this);
 }
 
-void CIntObject::show(SDL_Surface * to)
+void CIntObject::show(Canvas & to)
 {
 	if(defActions & UPDATE)
 		for(auto & elem : children)
@@ -61,7 +61,7 @@ void CIntObject::show(SDL_Surface * to)
 				elem->show(to);
 }
 
-void CIntObject::showAll(SDL_Surface * to)
+void CIntObject::showAll(Canvas & to)
 {
 	if(defActions & SHOWALL)
 	{
@@ -98,16 +98,6 @@ void CIntObject::deactivate()
 		for(auto & elem : children)
 			if(elem->recActions & DEACTIVATE)
 				elem->deactivate();
-}
-
-void CIntObject::printAtMiddleLoc(const std::string & text, const Point &p, EFonts font, const SDL_Color & kolor, SDL_Surface * dst)
-{
-	graphics->fonts[font]->renderTextCenter(dst, text, kolor, pos.topLeft() + p);
-}
-
-void CIntObject::printAtMiddleWBLoc( const std::string & text, const Point &p, EFonts font, int charpr, const SDL_Color & kolor, SDL_Surface * dst)
-{
-	graphics->fonts[font]->renderTextLinesCenter(dst, CMessage::breakText(text, charpr, font), kolor, pos.topLeft() + p);
 }
 
 void CIntObject::addUsedEvents(ui16 newActions)
@@ -226,9 +216,15 @@ void CIntObject::redraw()
 		}
 		else
 		{
-			showAll(screenBuf);
+			Canvas buffer = Canvas::createFromSurface(screenBuf);
+
+			showAll(buffer);
 			if(screenBuf != screen)
-				showAll(screen);
+			{
+				Canvas screenBuffer = Canvas::createFromSurface(screen);
+
+				showAll(screenBuffer);
+			}
 		}
 	}
 }

--- a/client/gui/CIntObject.h
+++ b/client/gui/CIntObject.h
@@ -13,9 +13,9 @@
 #include "../../lib/Rect.h"
 #include "EventsReceiver.h"
 
-struct SDL_Surface;
 class CGuiHandler;
 class CPicture;
+class Canvas;
 
 class IUpdateable
 {
@@ -31,8 +31,8 @@ public:
 	virtual void deactivate()=0;
 
 	virtual void redraw()=0;
-	virtual void show(SDL_Surface * to) = 0;
-	virtual void showAll(SDL_Surface * to) = 0;
+	virtual void show(Canvas & to) = 0;
+	virtual void showAll(Canvas & to) = 0;
 
 	virtual void onScreenResize() = 0;
 	virtual ~IShowActivatable() = default;
@@ -90,9 +90,9 @@ public:
 	void deactivate() override;
 
 	//called each frame to update screen
-	void show(SDL_Surface * to) override;
+	void show(Canvas & to) override;
 	//called on complete redraw only
-	void showAll(SDL_Surface * to) override;
+	void showAll(Canvas & to) override;
 	//request complete redraw of this object
 	void redraw() override;
 
@@ -112,10 +112,6 @@ public:
 	void addChild(CIntObject *child, bool adjustPosition = false);
 	void removeChild(CIntObject *child, bool adjustPosition = false);
 
-	/// functions for printing text.
-	/// Deprecated. Use CLabel where possible instead
-	void printAtMiddleLoc(const std::string & text, const Point &p, EFonts font, const SDL_Color & color, SDL_Surface * dst);
-	void printAtMiddleWBLoc(const std::string & text, const Point &p, EFonts font, int charsPerLine, const SDL_Color & color, SDL_Surface * dst);
 };
 
 /// Class for binding keys to left mouse button clicks

--- a/client/gui/CursorHandler.cpp
+++ b/client/gui/CursorHandler.cpp
@@ -17,7 +17,6 @@
 #include "../renderSDL/CursorHardware.h"
 #include "../render/CAnimation.h"
 #include "../render/IImage.h"
-#include "../renderSDL/SDL_Extensions.h"
 
 #include "../../lib/CConfigHandler.h"
 

--- a/client/gui/WindowHandler.cpp
+++ b/client/gui/WindowHandler.cpp
@@ -16,6 +16,7 @@
 
 #include "../CMT.h"
 #include "../CGameInfo.h"
+#include "../render/Canvas.h"
 #include "../render/Colors.h"
 #include "../renderSDL/SDL_Extensions.h"
 
@@ -92,8 +93,10 @@ void WindowHandler::totalRedraw()
 {
 	CSDL_Ext::fillSurface(screen2, Colors::BLACK);
 
+	Canvas target = Canvas::createFromSurface(screen2);
+
 	for(auto & elem : windowsStack)
-		elem->showAll(screen2);
+		elem->showAll(target);
 	CSDL_Ext::blitAt(screen2, 0, 0, screen);
 }
 
@@ -102,8 +105,11 @@ void WindowHandler::simpleRedraw()
 	//update only top interface and draw background
 	if(windowsStack.size() > 1)
 		CSDL_Ext::blitAt(screen2, 0, 0, screen); //blit background
+
+	Canvas target = Canvas::createFromSurface(screen);
+
 	if(!windowsStack.empty())
-		windowsStack.back()->show(screen); //blit active interface/window
+		windowsStack.back()->show(target); //blit active interface/window
 }
 
 void WindowHandler::onScreenResize()

--- a/client/lobby/CBonusSelection.h
+++ b/client/lobby/CBonusSelection.h
@@ -18,7 +18,6 @@ struct CampaignRegions;
 
 VCMI_LIB_NAMESPACE_END
 
-struct SDL_Surface;
 class CButton;
 class CTextBox;
 class CToggleGroup;

--- a/client/mainmenu/CCampaignScreen.cpp
+++ b/client/mainmenu/CCampaignScreen.cpp
@@ -20,6 +20,7 @@
 #include "../CServerHandler.h"
 #include "../gui/CGuiHandler.h"
 #include "../gui/Shortcut.h"
+#include "../render/Canvas.h"
 #include "../widgets/CComponent.h"
 #include "../widgets/Buttons.h"
 #include "../widgets/MiscWidgets.h"
@@ -111,7 +112,7 @@ CCampaignScreen::CCampaignButton::CCampaignButton(const JsonNode & config)
 		graphicsCompleted = std::make_shared<CPicture>("CAMPCHK");
 }
 
-void CCampaignScreen::CCampaignButton::show(SDL_Surface * to)
+void CCampaignScreen::CCampaignButton::show(Canvas & to)
 {
 	if(status == CCampaignScreen::DISABLED)
 		return;
@@ -124,7 +125,7 @@ void CCampaignScreen::CCampaignButton::show(SDL_Surface * to)
 		if(CCS->videoh->fname != video)
 			CCS->videoh->open(video);
 
-		CCS->videoh->update(pos.x, pos.y, to, true, false); // plays sequentially frame by frame, starts at the beginning when the video is over
+		CCS->videoh->update(pos.x, pos.y, to.getInternalSurface(), true, false); // plays sequentially frame by frame, starts at the beginning when the video is over
 	}
 	else if(CCS->videoh->fname == video) // When you got out of the bounds of the button then close the video
 	{

--- a/client/mainmenu/CCampaignScreen.h
+++ b/client/mainmenu/CCampaignScreen.h
@@ -20,7 +20,6 @@ VCMI_LIB_NAMESPACE_END
 class CLabel;
 class CPicture;
 class CButton;
-struct SDL_Surface;
 
 class CCampaignScreen : public CWindowObject
 {
@@ -46,7 +45,7 @@ private:
 
 	public:
 		CCampaignButton(const JsonNode & config);
-		void show(SDL_Surface * to) override;
+		void show(Canvas & to) override;
 	};
 
 	std::vector<std::shared_ptr<CCampaignButton>> campButtons;

--- a/client/mainmenu/CMainMenu.cpp
+++ b/client/mainmenu/CMainMenu.cpp
@@ -22,6 +22,7 @@
 #include "../gui/ShortcutHandler.h"
 #include "../gui/Shortcut.h"
 #include "../gui/WindowHandler.h"
+#include "../render/Canvas.h"
 #include "../widgets/CComponent.h"
 #include "../widgets/Buttons.h"
 #include "../widgets/MiscWidgets.h"
@@ -102,10 +103,10 @@ std::shared_ptr<CIntObject> CMenuScreen::createTab(size_t index)
 		return std::make_shared<CMenuEntry>(this, config["items"].Vector()[index]);
 }
 
-void CMenuScreen::show(SDL_Surface * to)
+void CMenuScreen::show(Canvas & to)
 {
 	if(!config["video"].isNull())
-		CCS->videoh->update((int)config["video"]["x"].Float() + pos.x, (int)config["video"]["y"].Float() + pos.y, to, true, false);
+		CCS->videoh->update((int)config["video"]["x"].Float() + pos.x, (int)config["video"]["y"].Float() + pos.y, to.getInternalSurface(), true, false);
 	CIntObject::show(to);
 }
 
@@ -334,10 +335,12 @@ void CMainMenu::update()
 	// Handles mouse and key input
 	GH.handleEvents();
 
+	Canvas canvas = Canvas::createFromSurface(screen);
+
 	// check for null othervice crash on finishing a campaign
 	// /FIXME: find out why GH.windows().listInt is empty to begin with
 	if(GH.windows().topWindow<CIntObject>())
-		GH.windows().topWindow<CIntObject>()->show(screen);
+		GH.windows().topWindow<CIntObject>()->show(canvas);
 }
 
 void CMainMenu::openLobby(ESelectionScreen screenType, bool host, const std::vector<std::string> * names, ELoadMode loadMode)
@@ -576,7 +579,7 @@ CLoadingScreen::~CLoadingScreen()
 	loadingThread.join();
 }
 
-void CLoadingScreen::showAll(SDL_Surface * to)
+void CLoadingScreen::showAll(Canvas & to)
 {
 	//FIXME: filling screen with transparency? BLACK intended?
 	//Rect rect(0, 0, to->w, to->h);

--- a/client/mainmenu/CMainMenu.h
+++ b/client/mainmenu/CMainMenu.h
@@ -54,7 +54,7 @@ public:
 
 	CMenuScreen(const JsonNode & configNode);
 
-	void show(SDL_Surface * to) override;
+	void show(Canvas & to) override;
 	void activate() override;
 	void deactivate() override;
 
@@ -187,7 +187,7 @@ public:
 	CLoadingScreen(std::function<void()> loader);
 	~CLoadingScreen();
 
-	void showAll(SDL_Surface * to) override;
+	void showAll(Canvas & to) override;
 };
 
 extern std::shared_ptr<CMainMenu> CMM;

--- a/client/mainmenu/CPrologEpilogVideo.cpp
+++ b/client/mainmenu/CPrologEpilogVideo.cpp
@@ -16,7 +16,7 @@
 #include "../CVideoHandler.h"
 #include "../gui/CGuiHandler.h"
 #include "../widgets/TextControls.h"
-#include "../renderSDL/SDL_Extensions.h"
+#include "../render/Canvas.h"
 
 #include "../../lib/mapping/CCampaignHandler.h"
 
@@ -38,13 +38,13 @@ CPrologEpilogVideo::CPrologEpilogVideo(CCampaignScenario::SScenarioPrologEpilog 
 	text->scrollTextTo(-100);
 }
 
-void CPrologEpilogVideo::show(SDL_Surface * to)
+void CPrologEpilogVideo::show(Canvas & to)
 {
-	CSDL_Ext::fillRect(to, pos, Colors::BLACK);
+	to.drawColor(pos, Colors::BLACK);
 	//BUG: some videos are 800x600 in size while some are 800x400
 	//VCMI should center them in the middle of the screen. Possible but needs modification
 	//of video player API which I'd like to avoid until we'll get rid of Windows-specific player
-	CCS->videoh->update(pos.x, pos.y, to, true, false);
+	CCS->videoh->update(pos.x, pos.y, to.getInternalSurface(), true, false);
 
 	//move text every 5 calls/frames; seems to be good enough
 	++positionCounter;

--- a/client/mainmenu/CPrologEpilogVideo.h
+++ b/client/mainmenu/CPrologEpilogVideo.h
@@ -12,7 +12,6 @@
 #include "../../lib/mapping/CCampaignHandler.h"
 
 class CMultiLineLabel;
-struct SDL_Surface;
 
 class CPrologEpilogVideo : public CWindowObject
 {
@@ -27,5 +26,5 @@ public:
 	CPrologEpilogVideo(CCampaignScenario::SScenarioPrologEpilog _spe, std::function<void()> callback);
 
 	void clickLeft(tribool down, bool previousState) override;
-	void show(SDL_Surface * to) override;
+	void show(Canvas & to) override;
 };

--- a/client/mainmenu/CreditsScreen.cpp
+++ b/client/mainmenu/CreditsScreen.cpp
@@ -34,7 +34,7 @@ CreditsScreen::CreditsScreen(Rect rect)
 	credits->scrollTextTo(-600); // move all text below the screen
 }
 
-void CreditsScreen::show(SDL_Surface * to)
+void CreditsScreen::show(Canvas & to)
 {
 	CIntObject::show(to);
 	positionCounter++;

--- a/client/mainmenu/CreditsScreen.h
+++ b/client/mainmenu/CreditsScreen.h
@@ -12,7 +12,6 @@
 #include "../windows/CWindowObject.h"
 
 class CMultiLineLabel;
-struct SDL_Surface;
 
 class CreditsScreen : public CIntObject
 {
@@ -21,7 +20,7 @@ class CreditsScreen : public CIntObject
 
 public:
 	CreditsScreen(Rect rect);
-	void show(SDL_Surface * to) override;
+	void show(Canvas & to) override;
 	void clickLeft(tribool down, bool previousState) override;
 	void clickRight(tribool down, bool previousState) override;
 };

--- a/client/mapView/MapView.cpp
+++ b/client/mapView/MapView.cpp
@@ -68,23 +68,21 @@ void BasicMapView::tick(uint32_t msPassed)
 	controller->tick(msPassed);
 }
 
-void BasicMapView::show(SDL_Surface * to)
+void BasicMapView::show(Canvas & to)
 {
-	Canvas target(to);
-	CSDL_Ext::CClipRectGuard guard(to, pos);
-	render(target, false);
+	CSDL_Ext::CClipRectGuard guard(to.getInternalSurface(), pos);
+	render(to, false);
 
 	controller->afterRender();
 }
 
-void BasicMapView::showAll(SDL_Surface * to)
+void BasicMapView::showAll(Canvas & to)
 {
-	Canvas target(to);
-	CSDL_Ext::CClipRectGuard guard(to, pos);
-	render(target, true);
+	CSDL_Ext::CClipRectGuard guard(to.getInternalSurface(), pos);
+	render(to, true);
 }
 
-void MapView::show(SDL_Surface * to)
+void MapView::show(Canvas & to)
 {
 	actions->setContext(controller->getContext());
 	BasicMapView::show(to);

--- a/client/mapView/MapView.h
+++ b/client/mapView/MapView.h
@@ -38,8 +38,8 @@ public:
 	~BasicMapView() override;
 
 	void tick(uint32_t msPassed) override;
-	void show(SDL_Surface * to) override;
-	void showAll(SDL_Surface * to) override;
+	void show(Canvas & to) override;
+	void showAll(Canvas & to) override;
 };
 
 /// Main class that represents visible section of adventure map
@@ -51,7 +51,7 @@ class MapView : public BasicMapView
 	bool isSwiping;
 
 public:
-	void show(SDL_Surface * to) override;
+	void show(Canvas & to) override;
 
 	MapView(const Point & offset, const Point & dimensions);
 

--- a/client/render/Canvas.cpp
+++ b/client/render/Canvas.cpp
@@ -31,6 +31,13 @@ Canvas::Canvas(const Canvas & other):
 	surface->refcount++;
 }
 
+Canvas::Canvas(Canvas && other):
+	surface(other.surface),
+	renderArea(other.renderArea)
+{
+	surface->refcount++;
+}
+
 Canvas::Canvas(const Canvas & other, const Rect & newClipRect):
 	Canvas(other)
 {
@@ -43,6 +50,11 @@ Canvas::Canvas(const Point & size):
 {
 	CSDL_Ext::fillSurface(surface, Colors::TRANSPARENCY );
 	SDL_SetSurfaceBlendMode(surface, SDL_BLENDMODE_NONE);
+}
+
+Canvas Canvas::createFromSurface(SDL_Surface * surface)
+{
+	return Canvas(surface);
 }
 
 void Canvas::applyTransparency(bool on)
@@ -115,6 +127,13 @@ void Canvas::drawLineDashed(const Point & from, const Point & dest, const ColorR
 	CSDL_Ext::drawLineDashed(surface, renderArea.topLeft() + from, renderArea.topLeft() + dest, CSDL_Ext::toSDL(color));
 }
 
+void Canvas::drawBorder(const Rect & target, const SDL_Color & color, uint width)
+{
+	Rect realTarget = target + renderArea.topLeft();
+
+	CSDL_Ext::drawBorder(surface, realTarget.x, realTarget.y, realTarget.w, realTarget.h, color, width);
+}
+
 void Canvas::drawBorderDashed(const Rect & target, const ColorRGBA & color)
 {
 	Rect realTarget = target + renderArea.topLeft();
@@ -145,3 +164,14 @@ void Canvas::drawText(const Point & position, const EFonts & font, const SDL_Col
 	}
 }
 
+void Canvas::drawColor(const Rect & target, const SDL_Color & color)
+{
+	Rect realTarget = target + renderArea.topLeft();
+
+	CSDL_Ext::fillRect(surface, realTarget, color);
+}
+
+SDL_Surface * Canvas::getInternalSurface()
+{
+	return surface;
+}

--- a/client/render/Canvas.h
+++ b/client/render/Canvas.h
@@ -27,20 +27,28 @@ class Canvas
 	/// Current rendering area, all rendering operations will be moved into selected area
 	Rect renderArea;
 
-public:
-	Canvas & operator = (const Canvas & other) = delete;
-
 	/// constructs canvas using existing surface. Caller maintains ownership on the surface
 	explicit Canvas(SDL_Surface * surface);
 
 	/// copy contructor
 	Canvas(const Canvas & other);
 
+public:
+	Canvas & operator = (const Canvas & other) = delete;
+	Canvas & operator = (Canvas && other) = delete;
+
+	/// move contructor
+	Canvas(Canvas && other);
+
 	/// creates canvas that only covers specified subsection of a surface
 	Canvas(const Canvas & other, const Rect & clipRect);
 
 	/// constructs canvas of specified size
 	explicit Canvas(const Point & size);
+
+	/// constructs canvas using existing surface. Caller maintains ownership on the surface
+	/// Compatibility method. AVOID USAGE. To be removed once SDL abstraction layer is finished.
+	static Canvas createFromSurface(SDL_Surface * surface);
 
 	~Canvas();
 
@@ -74,6 +82,9 @@ public:
 	/// renders dashed, 1-pixel wide line with specified color
 	void drawLineDashed(const Point & from, const Point & dest, const ColorRGBA & color);
 
+	/// renders rectangular, solid-color border in specified location
+	void drawBorder(const Rect & target, const SDL_Color & color, uint width = 1);
+
 	/// renders rectangular, dashed border in specified location
 	void drawBorderDashed(const Rect & target, const ColorRGBA & color);
 
@@ -82,4 +93,10 @@ public:
 
 	/// renders multiple lines of text with specified parameters
 	void drawText(const Point & position, const EFonts & font, const SDL_Color & colorDest, ETextAlignment alignment, const std::vector<std::string> & text );
+
+	/// fills selected area with solid color, ignoring any transparency
+	void drawColor(const Rect & target, const SDL_Color & color);
+
+	/// Compatibility method. AVOID USAGE. To be removed once SDL abstraction layer is finished.
+	SDL_Surface * getInternalSurface();
 };

--- a/client/render/Colors.cpp
+++ b/client/render/Colors.cpp
@@ -17,6 +17,7 @@ const SDL_Color Colors::YELLOW = { 229, 215, 123, SDL_ALPHA_OPAQUE };
 const SDL_Color Colors::WHITE = { 255, 243, 222, SDL_ALPHA_OPAQUE };
 const SDL_Color Colors::METALLIC_GOLD = { 173, 142, 66, SDL_ALPHA_OPAQUE };
 const SDL_Color Colors::GREEN = { 0, 255, 0, SDL_ALPHA_OPAQUE };
+const SDL_Color Colors::CYAN = { 0, 255, 255, SDL_ALPHA_OPAQUE };
 const SDL_Color Colors::ORANGE = { 232, 184, 32, SDL_ALPHA_OPAQUE };
 const SDL_Color Colors::BRIGHT_YELLOW = { 242, 226, 110, SDL_ALPHA_OPAQUE };
 const SDL_Color Colors::DEFAULT_KEY_COLOR = {0, 255, 255, SDL_ALPHA_OPAQUE};

--- a/client/render/Colors.h
+++ b/client/render/Colors.h
@@ -44,6 +44,8 @@ public:
 	/// Minimap border
 	static const SDL_Color PURPLE;
 
+	static const SDL_Color CYAN;
+
 	static const SDL_Color BLACK;
 
 	static const SDL_Color TRANSPARENCY;

--- a/client/renderSDL/SDL_Extensions.cpp
+++ b/client/renderSDL/SDL_Extensions.cpp
@@ -110,8 +110,6 @@ SDL_Surface * CSDL_Ext::createSurfaceWithBpp(int width, int height)
 
 void CSDL_Ext::blitAt(SDL_Surface * src, int x, int y, SDL_Surface * dst)
 {
-	if(!dst)
-		dst = screen;
 	CSDL_Ext::blitSurface(src, dst, Point(x, y));
 }
 

--- a/client/widgets/Buttons.cpp
+++ b/client/widgets/Buttons.cpp
@@ -23,7 +23,7 @@
 #include "../gui/Shortcut.h"
 #include "../windows/InfoWindows.h"
 #include "../render/CAnimation.h"
-#include "../renderSDL/SDL_Extensions.h"
+#include "../render/Canvas.h"
 
 #include "../../lib/CConfigHandler.h"
 #include "../../lib/CGeneralTextHandler.h"
@@ -285,13 +285,13 @@ void CButton::setPlayerColor(PlayerColor player)
 		image->playerColored(player);
 }
 
-void CButton::showAll(SDL_Surface * to)
+void CButton::showAll(Canvas & to)
 {
 	CIntObject::showAll(to);
 
 	auto borderColor = stateToBorderColor[getState()];
 	if (borderColor)
-		CSDL_Ext::drawBorder(to, pos.x-1, pos.y-1, pos.w+2, pos.h+2, *borderColor);
+		to.drawBorder(Rect::createAround(pos, 1), *borderColor);
 }
 
 std::pair<std::string, std::string> CButton::tooltip()
@@ -783,9 +783,9 @@ void CSlider::setAmount( int to )
 	vstd::amax(positions, 0);
 }
 
-void CSlider::showAll(SDL_Surface * to)
+void CSlider::showAll(Canvas & to)
 {
-	CSDL_Ext::fillRect(to, pos, Colors::BLACK);
+	to.drawColor(pos, Colors::BLACK);
 	CIntObject::showAll(to);
 }
 

--- a/client/widgets/Buttons.h
+++ b/client/widgets/Buttons.h
@@ -19,7 +19,6 @@ VCMI_LIB_NAMESPACE_BEGIN
 class Rect;
 VCMI_LIB_NAMESPACE_END
 
-struct SDL_Surface;
 class CAnimImage;
 class CLabel;
 class CAnimation;
@@ -106,7 +105,7 @@ public:
 	void clickRight(tribool down, bool previousState) override;
 	void clickLeft(tribool down, bool previousState) override;
 	void hover (bool on) override;
-	void showAll(SDL_Surface * to) override;
+	void showAll(Canvas & to) override;
 
 	/// generates tooltip that can be passed into constructor
 	static std::pair<std::string, std::string> tooltip();
@@ -274,7 +273,7 @@ public:
 	void wheelScrolled(bool down, bool in) override;
 	void clickLeft(tribool down, bool previousState) override;
 	void mouseMoved (const Point & cursorPosition) override;
-	void showAll(SDL_Surface * to) override;
+	void showAll(Canvas & to) override;
 
 	 /// @param position coordinates of slider
 	 /// @param length length of slider ribbon, including left/right buttons

--- a/client/widgets/CArtifactHolder.cpp
+++ b/client/widgets/CArtifactHolder.cpp
@@ -16,14 +16,13 @@
 #include "CComponent.h"
 
 #include "../windows/GUIClasses.h"
-#include "../renderSDL/SDL_Extensions.h"
+#include "../render/Canvas.h"
+#include "../render/Colors.h"
 #include "../CPlayerInterface.h"
 #include "../CGameInfo.h"
 
 #include "../../CCallback.h"
-
 #include "../../lib/CGeneralTextHandler.h"
-
 #include "../../lib/mapObjects/CGHeroInstance.h"
 
 void CArtPlace::setInternals(const CArtifactInstance * artInst)
@@ -206,7 +205,7 @@ void CHeroArtPlace::clickRight(tribool down, bool previousState)
 	}
 }
 
-void CHeroArtPlace::showAll(SDL_Surface* to)
+void CHeroArtPlace::showAll(Canvas & to)
 {
 	if(ourArt)
 	{
@@ -214,21 +213,7 @@ void CHeroArtPlace::showAll(SDL_Surface* to)
 	}
 
 	if(marked && isActive())
-	{
-		// Draw vertical bars.
-		for(int i = 0; i < pos.h; ++i)
-		{
-			CSDL_Ext::putPixelWithoutRefresh(to, pos.x, pos.y + i, 240, 220, 120);
-			CSDL_Ext::putPixelWithoutRefresh(to, pos.x + pos.w - 1, pos.y + i, 240, 220, 120);
-		}
-
-		// Draw horizontal bars.
-		for(int i = 0; i < pos.w; ++i)
-		{
-			CSDL_Ext::putPixelWithoutRefresh(to, pos.x + i, pos.y, 240, 220, 120);
-			CSDL_Ext::putPixelWithoutRefresh(to, pos.x + i, pos.y + pos.h - 1, 240, 220, 120);
-		}
-	}
+		to.drawBorder(pos, Colors::BRIGHT_YELLOW);
 }
 
 void CHeroArtPlace::setArtifact(const CArtifactInstance * art)

--- a/client/widgets/CArtifactHolder.h
+++ b/client/widgets/CArtifactHolder.h
@@ -80,7 +80,7 @@ public:
 	bool isMarked() const;
 	void clickLeft(tribool down, bool previousState) override;
 	void clickRight(tribool down, bool previousState) override;
-	void showAll(SDL_Surface * to) override;
+	void showAll(Canvas & to) override;
 	void setArtifact(const CArtifactInstance * art) override;
 	void addCombinedArtInfo(std::map<const CArtifact*, int> & arts);
 

--- a/client/widgets/CArtifactsOfHeroBase.cpp
+++ b/client/widgets/CArtifactsOfHeroBase.cpp
@@ -16,7 +16,6 @@
 
 #include "Buttons.h"
 
-#include "../renderSDL/SDL_Extensions.h"
 #include "../CPlayerInterface.h"
 #include "../CGameInfo.h"
 

--- a/client/widgets/CComponent.cpp
+++ b/client/widgets/CComponent.cpp
@@ -20,7 +20,7 @@
 #include "../gui/CursorHandler.h"
 #include "../gui/TextAlignment.h"
 #include "../gui/Shortcut.h"
-#include "../renderSDL/SDL_Extensions.h"
+#include "../render/Canvas.h"
 #include "../windows/CMessage.h"
 #include "../windows/InfoWindows.h"
 #include "../widgets/TextControls.h"
@@ -302,12 +302,12 @@ void CSelectableComponent::select(bool on)
 	}
 }
 
-void CSelectableComponent::showAll(SDL_Surface * to)
+void CSelectableComponent::showAll(Canvas & to)
 {
 	CComponent::showAll(to);
 	if(selected)
 	{
-		CSDL_Ext::drawBorder(to, Rect::createAround(image->pos, 1), Colors::BRIGHT_YELLOW);
+		to.drawBorder(Rect::createAround(image->pos, 1), Colors::BRIGHT_YELLOW);
 	}
 }
 

--- a/client/widgets/CComponent.h
+++ b/client/widgets/CComponent.h
@@ -76,7 +76,7 @@ public:
 	bool selected; //if true, this component is selected
 	std::function<void()> onSelect; //function called on selection change
 
-	void showAll(SDL_Surface * to) override;
+	void showAll(Canvas & to) override;
 	void select(bool on);
 
 	void clickLeft(tribool down, bool previousState) override; //call-in

--- a/client/widgets/CGarrisonInt.cpp
+++ b/client/widgets/CGarrisonInt.cpp
@@ -15,7 +15,6 @@
 
 #include "../gui/CGuiHandler.h"
 #include "../gui/WindowHandler.h"
-#include "../renderSDL/SDL_Extensions.h"
 #include "../windows/CCreatureWindow.h"
 #include "../windows/GUIClasses.h"
 #include "../CGameInfo.h"

--- a/client/widgets/Images.h
+++ b/client/widgets/Images.h
@@ -16,7 +16,6 @@ VCMI_LIB_NAMESPACE_BEGIN
 class Rect;
 VCMI_LIB_NAMESPACE_END
 
-struct SDL_Surface;
 struct SDL_Color;
 class CAnimImage;
 class CLabel;
@@ -61,8 +60,8 @@ public:
 	void scaleTo(Point size);
 	void colorize(PlayerColor player);
 
-	void show(SDL_Surface * to) override;
-	void showAll(SDL_Surface * to) override;
+	void show(Canvas & to) override;
+	void showAll(Canvas & to) override;
 };
 
 /// area filled with specific texture
@@ -76,7 +75,7 @@ public:
 	CFilledTexture(std::string imageName, Rect position);
 	CFilledTexture(std::shared_ptr<IImage> image, Rect position, Rect imageArea);
 
-	void showAll(SDL_Surface *to) override;
+	void showAll(Canvas & to) override;
 };
 
 class FilledTexturePlayerColored : public CFilledTexture
@@ -124,7 +123,7 @@ public:
 	/// returns true if image has player-colored effect applied
 	bool isPlayerColored() const;
 
-	void showAll(SDL_Surface * to) override;
+	void showAll(Canvas & to) override;
 };
 
 /// Base class for displaying animation, used as superclass for different animations
@@ -154,7 +153,7 @@ protected:
 	ui8 flags;//Flags from EFlags enum
 
 	//blit image with optional rotation, fitting into rect, etc
-	void blitImage(size_t frame, size_t group, SDL_Surface *to);
+	void blitImage(size_t frame, size_t group, Canvas & to);
 
 	//For clipping in rect, offsets of picture coordinates
 	int xOffset, yOffset;
@@ -188,8 +187,8 @@ public:
 	void setDuration(int durationMs);
 
 	//show current frame and increase counter
-	void show(SDL_Surface * to) override;
-	void showAll(SDL_Surface * to) override;
+	void show(Canvas & to) override;
+	void showAll(Canvas & to) override;
 	void tick(uint32_t msPassed) override;
 };
 

--- a/client/widgets/MiscWidgets.cpp
+++ b/client/widgets/MiscWidgets.cpp
@@ -20,7 +20,7 @@
 #include "../widgets/TextControls.h"
 #include "../windows/CCastleInterface.h"
 #include "../windows/InfoWindows.h"
-#include "../renderSDL/SDL_Extensions.h"
+#include "../render/Canvas.h"
 
 #include "../../CCallback.h"
 
@@ -180,7 +180,7 @@ LRClickableAreaOpenTown::LRClickableAreaOpenTown(const Rect & Pos, const CGTownI
 {
 }
 
-void CMinorResDataBar::show(SDL_Surface * to)
+void CMinorResDataBar::show(Canvas & to)
 {
 }
 
@@ -196,7 +196,7 @@ std::string CMinorResDataBar::buildDateString()
 	return boost::str(formatted);
 }
 
-void CMinorResDataBar::showAll(SDL_Surface * to)
+void CMinorResDataBar::showAll(Canvas & to)
 {
 	CIntObject::showAll(to);
 
@@ -204,9 +204,14 @@ void CMinorResDataBar::showAll(SDL_Surface * to)
 	{
 		std::string text = std::to_string(LOCPLINT->cb->getResourceAmount(i));
 
-		graphics->fonts[FONT_SMALL]->renderTextCenter(to, text, Colors::WHITE, Point(pos.x + 50 + 76 * GameResID(i), pos.y + pos.h/2));
+		Point target(pos.x + 50 + 76 * GameResID(i), pos.y + pos.h/2);
+
+		to.drawText(target, FONT_SMALL, Colors::WHITE, ETextAlignment::CENTER, text);
 	}
-	graphics->fonts[FONT_SMALL]->renderTextCenter(to, buildDateString(), Colors::WHITE, Point(pos.x+545+(pos.w-545)/2,pos.y+pos.h/2));
+
+	Point target(pos.x+545+(pos.w-545)/2,pos.y+pos.h/2);
+
+	to.drawText(target, FONT_SMALL, Colors::WHITE, ETextAlignment::CENTER, buildDateString());
 }
 
 CMinorResDataBar::CMinorResDataBar()
@@ -466,7 +471,7 @@ CCreaturePic::CCreaturePic(int x, int y, const CCreature * cre, bool Big, bool A
 	pos.h = bg->pos.h;
 }
 
-void CCreaturePic::show(SDL_Surface * to)
+void CCreaturePic::show(Canvas & to)
 {
 	// redraw everything in a proper order
 	bg->showAll(to);

--- a/client/widgets/MiscWidgets.h
+++ b/client/widgets/MiscWidgets.h
@@ -107,7 +107,7 @@ private:
 	std::shared_ptr<CCreatureAnim> anim; //displayed animation
 	std::shared_ptr<CLabel> amount;
 
-	void show(SDL_Surface * to) override;
+	void show(Canvas & to) override;
 public:
 	CCreaturePic(int x, int y, const CCreature * cre, bool Big=true, bool Animated=true);
 	void setAmount(int newAmount);
@@ -120,8 +120,8 @@ class CMinorResDataBar : public CIntObject
 
 	std::string buildDateString();
 public:
-	void show(SDL_Surface * to) override;
-	void showAll(SDL_Surface * to) override;
+	void show(Canvas & to) override;
+	void showAll(Canvas & to) override;
 	CMinorResDataBar();
 	~CMinorResDataBar();
 };

--- a/client/widgets/ObjectLists.h
+++ b/client/widgets/ObjectLists.h
@@ -15,7 +15,6 @@ VCMI_LIB_NAMESPACE_BEGIN
 class Rect;
 VCMI_LIB_NAMESPACE_END
 
-struct SDL_Surface;
 class CAnimImage;
 class CSlider;
 class CLabel;

--- a/client/widgets/TextControls.cpp
+++ b/client/widgets/TextControls.cpp
@@ -19,6 +19,7 @@
 #include "../windows/CMessage.h"
 #include "../adventureMap/CInGameConsole.h"
 #include "../renderSDL/SDL_Extensions.h"
+#include "../render/Canvas.h"
 
 #include "../../lib/TextOperations.h"
 
@@ -34,7 +35,7 @@ std::string CLabel::visibleText()
 	return text;
 }
 
-void CLabel::showAll(SDL_Surface * to)
+void CLabel::showAll(Canvas & to)
 {
 	CIntObject::showAll(to);
 
@@ -137,7 +138,7 @@ void CMultiLineLabel::setText(const std::string & Txt)
 	CLabel::setText(Txt);
 }
 
-void CTextContainer::blitLine(SDL_Surface * to, Rect destRect, std::string what)
+void CTextContainer::blitLine(Canvas & to, Rect destRect, std::string what)
 {
 	const auto f = graphics->fonts[font];
 	Point where = destRect.topLeft();
@@ -180,9 +181,10 @@ void CTextContainer::blitLine(SDL_Surface * to, Rect destRect, std::string what)
 			std::string toPrint = what.substr(begin, end - begin);
 
 			if(currDelimeter % 2) // Enclosed in {} text - set to yellow
-				f->renderTextLeft(to, toPrint, Colors::YELLOW, where);
+				to.drawText(where, font, Colors::YELLOW, ETextAlignment::TOPLEFT, toPrint);
 			else // Non-enclosed text, use default color
-				f->renderTextLeft(to, toPrint, color, where);
+				to.drawText(where, font, color, ETextAlignment::TOPLEFT, toPrint);
+
 			begin = end;
 
 			where.x += (int)f->getStringWidth(toPrint);
@@ -198,7 +200,7 @@ CTextContainer::CTextContainer(ETextAlignment alignment, EFonts font, SDL_Color 
 {
 }
 
-void CMultiLineLabel::showAll(SDL_Surface * to)
+void CMultiLineLabel::showAll(Canvas & to)
 {
 	CIntObject::showAll(to);
 
@@ -224,7 +226,7 @@ void CMultiLineLabel::showAll(SDL_Surface * to)
 	Point lineStart = getTextLocation().topLeft() - visibleSize + Point(0, beginLine * (int)f->getLineHeight());
 	Point lineSize = Point(getTextLocation().w, (int)f->getLineHeight());
 
-	CSDL_Ext::CClipRectGuard guard(to, getTextLocation()); // to properly trim text that is too big to fit
+	CSDL_Ext::CClipRectGuard guard(to.getInternalSurface(), getTextLocation()); // to properly trim text that is too big to fit
 
 	for(int i = beginLine; i < std::min(totalLines, endLine); i++)
 	{
@@ -437,7 +439,7 @@ CGStatusBar::~CGStatusBar()
 	assert(GH.statusbar().get() != this);
 }
 
-void CGStatusBar::show(SDL_Surface * to)
+void CGStatusBar::show(Canvas & to)
 {
 	showAll(to);
 }

--- a/client/widgets/TextControls.h
+++ b/client/widgets/TextControls.h
@@ -28,7 +28,7 @@ protected:
 	/// returns size of border, for left- or right-aligned text
 	virtual Point getBorderSize() = 0;
 	/// do actual blitting of line. Text "what" will be placed at "where" and aligned according to alignment
-	void blitLine(SDL_Surface * to, Rect where, std::string what);
+	void blitLine(Canvas & to, Rect where, std::string what);
 
 	CTextContainer(ETextAlignment alignment, EFonts font, SDL_Color color);
 
@@ -59,7 +59,7 @@ public:
 
 	CLabel(int x = 0, int y = 0, EFonts Font = FONT_SMALL, ETextAlignment Align = ETextAlignment::TOPLEFT,
 		const SDL_Color & Color = Colors::WHITE, const std::string & Text = "");
-	void showAll(SDL_Surface * to) override; //shows statusbar (with current text)
+	void showAll(Canvas & to) override; //shows statusbar (with current text)
 };
 
 /// Small helper class to manage group of similar labels
@@ -94,7 +94,7 @@ public:
 	CMultiLineLabel(Rect position, EFonts Font = FONT_SMALL, ETextAlignment Align = ETextAlignment::TOPLEFT, const SDL_Color & Color = Colors::WHITE, const std::string & Text = "");
 
 	void setText(const std::string & Txt) override;
-	void showAll(SDL_Surface * to) override;
+	void showAll(Canvas & to) override;
 
 	void setVisibleSize(Rect visibleSize, bool redrawElement = true);
 	// scrolls text visible in widget. Positive value will move text up
@@ -150,7 +150,7 @@ public:
 		return ret;
 	}
 
-	void show(SDL_Surface * to) override;
+	void show(Canvas & to) override;
 	void activate() override;
 	void deactivate() override;
 

--- a/client/windows/CCastleInterface.cpp
+++ b/client/windows/CCastleInterface.cpp
@@ -27,7 +27,7 @@
 #include "../widgets/CComponent.h"
 #include "../widgets/Buttons.h"
 #include "../widgets/TextControls.h"
-#include "../renderSDL/SDL_Extensions.h"
+#include "../render/Canvas.h"
 #include "../render/IImage.h"
 #include "../render/ColorFilter.h"
 #include "../adventureMap/AdventureMapInterface.h"
@@ -162,7 +162,7 @@ void CBuildingRect::clickRight(tribool down, bool previousState)
 	}
 }
 
-void CBuildingRect::show(SDL_Surface * to)
+void CBuildingRect::show(Canvas & to)
 {
 	uint32_t stageDelay = BUILDING_APPEAR_TIMEPOINT;
 
@@ -182,7 +182,7 @@ void CBuildingRect::show(SDL_Surface * to)
 		if(stateTimeCounter >= BUILD_ANIMATION_FINISHED_TIMEPOINT)
 		{
 			if(parent->selectedBuilding == this)
-				border->draw(to, pos.x, pos.y);
+				to.draw(border, pos.topLeft());
 			return;
 		}
 
@@ -200,7 +200,7 @@ void CBuildingRect::show(SDL_Surface * to)
 		else
 			border->adjustPalette(baseBorder, 0);
 
-		border->draw(to, pos.x, pos.y);
+		to.draw(border, pos.topLeft());
 	}
 }
 
@@ -210,14 +210,14 @@ void CBuildingRect::tick(uint32_t msPassed)
 	stateTimeCounter += msPassed;
 }
 
-void CBuildingRect::showAll(SDL_Surface * to)
+void CBuildingRect::showAll(Canvas & to)
 {
 	if (stateTimeCounter == 0)
 		return;
 
 	CShowableAnim::showAll(to);
 	if(!isActive() && parent->selectedBuilding == this && border)
-		border->draw(to, pos.x, pos.y);
+		to.draw(border, pos.topLeft());
 }
 
 std::string CBuildingRect::getSubtitle()//hover text for building

--- a/client/windows/CCastleInterface.h
+++ b/client/windows/CCastleInterface.h
@@ -70,8 +70,8 @@ public:
 	void clickRight(tribool down, bool previousState) override;
 	void mouseMoved (const Point & cursorPosition) override;
 	void tick(uint32_t msPassed) override;
-	void show(SDL_Surface * to) override;
-	void showAll(SDL_Surface * to) override;
+	void show(Canvas & to) override;
+	void showAll(Canvas & to) override;
 };
 
 /// Dwelling info box - right-click screen for dwellings

--- a/client/windows/CCreatureWindow.cpp
+++ b/client/windows/CCreatureWindow.cpp
@@ -23,7 +23,6 @@
 #include "../widgets/ObjectLists.h"
 #include "../gui/CGuiHandler.h"
 #include "../gui/Shortcut.h"
-#include "../renderSDL/SDL_Extensions.h"
 
 #include "../../CCallback.h"
 #include "../../lib/CStack.h"

--- a/client/windows/CHeroWindow.cpp
+++ b/client/windows/CHeroWindow.cpp
@@ -25,7 +25,6 @@
 #include "../widgets/CComponent.h"
 #include "../widgets/TextControls.h"
 #include "../widgets/Buttons.h"
-#include "../renderSDL/SDL_Extensions.h"
 #include "../render/CAnimation.h"
 
 #include "../../CCallback.h"

--- a/client/windows/CHeroWindow.h
+++ b/client/windows/CHeroWindow.h
@@ -23,7 +23,6 @@ class CGHeroInstance;
 VCMI_LIB_NAMESPACE_END
 
 class CButton;
-struct SDL_Surface;
 class CHeroWindow;
 class LClickableAreaHero;
 class LRClickableAreaWText;

--- a/client/windows/CKingdomInterface.cpp
+++ b/client/windows/CKingdomInterface.cpp
@@ -23,7 +23,6 @@
 #include "../widgets/MiscWidgets.h"
 #include "../widgets/Buttons.h"
 #include "../widgets/ObjectLists.h"
-#include "../renderSDL/SDL_Extensions.h"
 
 #include "../../CCallback.h"
 

--- a/client/windows/CMessage.cpp
+++ b/client/windows/CMessage.cpp
@@ -22,6 +22,7 @@
 #include "../gui/CGuiHandler.h"
 #include "../render/CAnimation.h"
 #include "../render/IImage.h"
+#include "../render/Canvas.h"
 #include "../renderSDL/SDL_Extensions.h"
 
 #include <SDL_surface.h>
@@ -46,7 +47,7 @@ public:
 	std::shared_ptr<CComponent> comp;
 
 	//blit component with image centered at this position
-	void showAll(SDL_Surface * to) override;
+	void showAll(Canvas & to) override;
 
 	//ComponentResolved();
 	ComponentResolved(std::shared_ptr<CComponent> Comp);
@@ -420,7 +421,7 @@ ComponentResolved::~ComponentResolved()
 	}
 }
 
-void ComponentResolved::showAll(SDL_Surface *to)
+void ComponentResolved::showAll(Canvas & to)
 {
 	CIntObject::showAll(to);
 	comp->showAll(to);
@@ -500,7 +501,9 @@ void ComponentsToBlit::blitCompsOnSur( bool blitOr, int inter, int &curh, SDL_Su
 			cur->moveTo(Point(curw, curh));
 
 			//blit component
-			cur->showAll(ret);
+			Canvas canvas = Canvas::createFromSurface(ret);
+
+			cur->showAll(canvas);
 			curw += cur->pos.w;
 
 			//if there is subsequent component blit "or"

--- a/client/windows/CPuzzleWindow.cpp
+++ b/client/windows/CPuzzleWindow.cpp
@@ -69,12 +69,12 @@ CPuzzleWindow::CPuzzleWindow(const int3 & GrailPos, double discoveredRatio)
 	}
 }
 
-void CPuzzleWindow::showAll(SDL_Surface * to)
+void CPuzzleWindow::showAll(Canvas & to)
 {
 	CWindowObject::showAll(to);
 }
 
-void CPuzzleWindow::show(SDL_Surface * to)
+void CPuzzleWindow::show(Canvas & to)
 {
 	static int animSpeed = 2;
 

--- a/client/windows/CPuzzleWindow.h
+++ b/client/windows/CPuzzleWindow.h
@@ -33,8 +33,8 @@ private:
 	ui8 currentAlpha;
 
 public:
-	void showAll(SDL_Surface * to) override;
-	void show(SDL_Surface * to) override;
+	void showAll(Canvas & to) override;
+	void show(Canvas & to) override;
 
 	CPuzzleWindow(const int3 & grailPos, double discoveredRatio);
 };

--- a/client/windows/CQuestLog.cpp
+++ b/client/windows/CQuestLog.cpp
@@ -19,6 +19,7 @@
 #include "../adventureMap/AdventureMapInterface.h"
 #include "../widgets/Buttons.h"
 #include "../adventureMap/CMinimap.h"
+#include "../render/Canvas.h"
 #include "../renderSDL/SDL_Extensions.h"
 
 #include "../../CCallback.h"
@@ -43,7 +44,7 @@ void CQuestLabel::clickLeft(tribool down, bool previousState)
 		callback();
 }
 
-void CQuestLabel::showAll(SDL_Surface * to)
+void CQuestLabel::showAll(Canvas & to)
 {
 	CMultiLineLabel::showAll (to);
 }
@@ -60,9 +61,9 @@ void CQuestIcon::clickLeft(tribool down, bool previousState)
 		callback();
 }
 
-void CQuestIcon::showAll(SDL_Surface * to)
+void CQuestIcon::showAll(Canvas & to)
 {
-	CSDL_Ext::CClipRectGuard guard(to, parent->pos);
+	CSDL_Ext::CClipRectGuard guard(to.getInternalSurface(), parent->pos);
 	CAnimImage::showAll(to);
 }
 
@@ -109,7 +110,7 @@ void CQuestMinimap::iconClicked()
 	//moveAdvMapSelection();
 }
 
-void CQuestMinimap::showAll(SDL_Surface * to)
+void CQuestMinimap::showAll(Canvas & to)
 {
 	CIntObject::showAll(to); // blitting IntObject directly to hide radar
 //	for (auto pic : icons)
@@ -201,7 +202,7 @@ void CQuestLog::recreateLabelList()
 	}
 }
 
-void CQuestLog::showAll(SDL_Surface * to)
+void CQuestLog::showAll(Canvas & to)
 {
 	CWindowObject::showAll(to);
 	if(questIndex >= 0 && questIndex < labels.size())
@@ -210,7 +211,7 @@ void CQuestLog::showAll(SDL_Surface * to)
 		Rect rect = Rect::createAround(labels[questIndex]->pos, 1);
 		rect.x -= 2; // Adjustment needed as we want selection box on top of border in graphics
 		rect.w += 2;
-		CSDL_Ext::drawBorder(to, rect, Colors::METALLIC_GOLD);
+		to.drawBorder(rect, Colors::METALLIC_GOLD);
 	}
 }
 

--- a/client/windows/CQuestLog.h
+++ b/client/windows/CQuestLog.h
@@ -46,7 +46,7 @@ public:
 	CQuestLabel(Rect position, EFonts Font = FONT_SMALL, ETextAlignment Align = ETextAlignment::TOPLEFT, const SDL_Color &Color = Colors::WHITE, const std::string &Text =  "")
 		: CMultiLineLabel (position, FONT_SMALL, ETextAlignment::TOPLEFT, Colors::WHITE, Text){};
 	void clickLeft(tribool down, bool previousState) override;
-	void showAll(SDL_Surface * to) override;
+	void showAll(Canvas & to) override;
 };
 
 class CQuestIcon : public CAnimImage
@@ -57,7 +57,7 @@ public:
 	CQuestIcon(const std::string &defname, int index, int x=0, int y=0);
 
 	void clickLeft(tribool down, bool previousState) override;
-	void showAll(SDL_Surface * to) override;
+	void showAll(Canvas & to) override;
 };
 
 class CQuestMinimap : public CMinimap
@@ -76,7 +76,7 @@ public:
 	void update();
 	void addQuestMarks (const QuestInfo * q);
 
-	void showAll(SDL_Surface * to) override;
+	void showAll(Canvas & to) override;
 };
 
 class CQuestLog : public CWindowObject
@@ -107,5 +107,5 @@ public:
 	void recreateLabelList();
 	void recreateQuestList (int pos);
 	void toggleComplete(bool on);
-	void showAll (SDL_Surface * to) override;
+	void showAll (Canvas & to) override;
 };

--- a/client/windows/CSpellWindow.cpp
+++ b/client/windows/CSpellWindow.cpp
@@ -30,7 +30,6 @@
 #include "../widgets/TextControls.h"
 #include "../adventureMap/AdventureMapInterface.h"
 #include "../render/CAnimation.h"
-#include "../renderSDL/SDL_Extensions.h"
 
 #include "../../CCallback.h"
 
@@ -307,7 +306,7 @@ void CSpellWindow::fRcornerb()
 	computeSpellsPerArea();
 }
 
-void CSpellWindow::show(SDL_Surface * to)
+void CSpellWindow::show(Canvas & to)
 {
 	statusBar->show(to);
 }

--- a/client/windows/CSpellWindow.h
+++ b/client/windows/CSpellWindow.h
@@ -18,7 +18,6 @@ class CSpell;
 
 VCMI_LIB_NAMESPACE_END
 
-struct SDL_Surface;
 class IImage;
 class CAnimImage;
 class CPicture;
@@ -114,5 +113,5 @@ public:
 
 	void keyPressed(EShortcut key) override;
 
-	void show(SDL_Surface * to) override;
+	void show(Canvas & to) override;
 };

--- a/client/windows/CTradeWindow.cpp
+++ b/client/windows/CTradeWindow.cpp
@@ -13,7 +13,7 @@
 #include "../gui/CGuiHandler.h"
 #include "../gui/CursorHandler.h"
 #include "../widgets/Images.h"
-#include "../renderSDL/SDL_Extensions.h"
+#include "../render/Canvas.h"
 #include "../gui/TextAlignment.h"
 #include "../gui/Shortcut.h"
 #include "../gui/WindowHandler.h"
@@ -127,7 +127,7 @@ int CTradeWindow::CTradeableItem::getIndex()
 	}
 }
 
-void CTradeWindow::CTradeableItem::showAll(SDL_Surface * to)
+void CTradeWindow::CTradeableItem::showAll(Canvas & to)
 {
 	CTradeWindow *mw = dynamic_cast<CTradeWindow *>(parent);
 	assert(mw);
@@ -168,7 +168,7 @@ void CTradeWindow::CTradeableItem::showAll(SDL_Surface * to)
 		CIntObject::showAll(to);
 	}
 
-	printAtMiddleLoc(subtitle, posToSubCenter, FONT_SMALL, Colors::WHITE, to);
+	to.drawText(pos.topLeft() + posToSubCenter, FONT_SMALL, Colors::WHITE, ETextAlignment::CENTER, subtitle);
 }
 
 void CTradeWindow::CTradeableItem::clickLeft(tribool down, bool previousState)
@@ -224,7 +224,7 @@ void CTradeWindow::CTradeableItem::clickLeft(tribool down, bool previousState)
 	}
 }
 
-void CTradeWindow::CTradeableItem::showAllAt(const Point &dstPos, const std::string &customSub, SDL_Surface * to)
+void CTradeWindow::CTradeableItem::showAllAt(const Point &dstPos, const std::string &customSub, Canvas & to)
 {
 	Rect oldPos = pos;
 	std::string oldSub = subtitle;
@@ -576,14 +576,14 @@ void CTradeWindow::initSubs(bool Left)
 	}
 }
 
-void CTradeWindow::showAll(SDL_Surface * to)
+void CTradeWindow::showAll(Canvas & to)
 {
 	CWindowObject::showAll(to);
 
 	if(hRight)
-		CSDL_Ext::drawBorder(to, hRight->pos.x-1, hRight->pos.y-1, hRight->pos.w+2, hRight->pos.h+2, Colors::BRIGHT_YELLOW);
+		to.drawBorder(Rect::createAround(hRight->pos, 1), Colors::BRIGHT_YELLOW, 2);
 	if(hLeft && hLeft->type != ARTIFACT_INSTANCE)
-		CSDL_Ext::drawBorder(to, hLeft->pos.x-1, hLeft->pos.y-1, hLeft->pos.w+2, hLeft->pos.h+2, Colors::BRIGHT_YELLOW);
+		to.drawBorder(Rect::createAround(hLeft->pos, 1), Colors::BRIGHT_YELLOW, 2);
 
 	if(readyToTrade)
 	{
@@ -1466,7 +1466,7 @@ void CAltarWindow::artifactPicked()
 	redraw();
 }
 
-void CAltarWindow::showAll(SDL_Surface * to)
+void CAltarWindow::showAll(Canvas & to)
 {
 	CTradeWindow::showAll(to);
 	if(mode == EMarketMode::ARTIFACT_EXP && arts)
@@ -1479,7 +1479,8 @@ void CAltarWindow::showAll(SDL_Surface * to)
 			int dmp, val;
 			market->getOffer(pickedArt->getTypeId(), 0, dmp, val, EMarketMode::ARTIFACT_EXP);
 			val = static_cast<int>(hero->calculateXp(val));
-			printAtMiddleLoc(std::to_string(val), Point(304, 498), FONT_SMALL, Colors::WHITE, to);
+
+			to.drawText(Point(304, 498), FONT_SMALL, Colors::WHITE, ETextAlignment::CENTER, std::to_string(val));
 		}
 	}
 }

--- a/client/windows/CTradeWindow.h
+++ b/client/windows/CTradeWindow.h
@@ -54,11 +54,11 @@ public:
 		CFunctionList<void()> callback;
 		bool downSelection;
 
-		void showAllAt(const Point & dstPos, const std::string & customSub, SDL_Surface * to);
+		void showAllAt(const Point & dstPos, const std::string & customSub, Canvas & to);
 
 		void clickRight(tribool down, bool previousState) override;
 		void hover(bool on) override;
-		void showAll(SDL_Surface * to) override;
+		void showAll(Canvas & to) override;
 		void clickLeft(tribool down, bool previousState) override;
 		std::string getName(int number = -1) const;
 		CTradeableItem(Point pos, EType Type, int ID, bool Left, int Serial);
@@ -86,7 +86,7 @@ public:
 
 	CTradeWindow(std::string bgName, const IMarket * Market, const CGHeroInstance * Hero, EMarketMode::EMarketMode Mode); //c
 
-	void showAll(SDL_Surface * to) override;
+	void showAll(Canvas & to) override;
 
 	void initSubs(bool Left);
 	void initTypes();
@@ -169,7 +169,7 @@ public:
 	void putOnAltar(int backpackIndex);
 	bool putOnAltar(std::shared_ptr<CTradeableItem> altarSlot, const CArtifactInstance * art);
 	void makeDeal();
-	void showAll(SDL_Surface * to) override;
+	void showAll(Canvas & to) override;
 
 	void blockTrade();
 	void sliderMoved(int to);

--- a/client/windows/CWindowObject.cpp
+++ b/client/windows/CWindowObject.cpp
@@ -18,9 +18,9 @@
 #include "../battle/BattleInterface.h"
 #include "../battle/BattleInterfaceClasses.h"
 #include "../windows/CMessage.h"
-#include "../renderSDL/SDL_Extensions.h"
 #include "../renderSDL/SDL_PixelAccess.h"
 #include "../render/IImage.h"
+#include "../render/Canvas.h"
 
 #include "../CGameInfo.h"
 #include "../CPlayerInterface.h"
@@ -224,15 +224,15 @@ void CWindowObject::setShadow(bool on)
 	}
 }
 
-void CWindowObject::showAll(SDL_Surface *to)
+void CWindowObject::showAll(Canvas & to)
 {
 	auto color = LOCPLINT ? LOCPLINT->playerID : PlayerColor(1);
 	if(settings["session"]["spectate"].Bool())
 		color = PlayerColor(1); // TODO: Spectator shouldn't need special code for UI colors
 
 	CIntObject::showAll(to);
-	if ((options & BORDERED) && (pos.h != to->h || pos.w != to->w))
-		CMessage::drawBorder(color, to, pos.w+28, pos.h+29, pos.x-14, pos.y-15);
+	if ((options & BORDERED) && (pos.dimensions() != GH.screenDimensions()))
+		CMessage::drawBorder(color, to.getInternalSurface(), pos.w+28, pos.h+29, pos.x-14, pos.y-15);
 }
 
 void CWindowObject::clickRight(tribool down, bool previousState)

--- a/client/windows/CWindowObject.h
+++ b/client/windows/CWindowObject.h
@@ -50,7 +50,7 @@ public:
 	CWindowObject(int options, std::string imageName = "");
 	~CWindowObject();
 
-	void showAll(SDL_Surface * to) override;
+	void showAll(Canvas & to) override;
 };
 
 class CStatusbarWindow : public CWindowObject

--- a/client/windows/GUIClasses.h
+++ b/client/windows/GUIClasses.h
@@ -62,7 +62,7 @@ class CRecruitmentWindow : public CStatusbarWindow
 
 		void clickLeft(tribool down, bool previousState) override;
 		void clickRight(tribool down, bool previousState) override;
-		void showAll(SDL_Surface * to) override;
+		void showAll(Canvas & to) override;
 	};
 
 	std::function<void(CreatureID,int)> onRecruit; //void (int ID, int amount) <-- call to recruit creatures
@@ -89,7 +89,7 @@ class CRecruitmentWindow : public CStatusbarWindow
 	void buy();
 	void sliderMoved(int to);
 
-	void showAll(SDL_Surface * to) override;
+	void showAll(Canvas & to) override;
 public:
 	const CGDwelling * const dwelling;
 	CRecruitmentWindow(const CGDwelling * Dwelling, int Level, const CArmedInstance * Dst, const std::function<void(CreatureID,int)> & Recruit, int y_offset = 0);
@@ -233,6 +233,9 @@ public:
 
 	std::shared_ptr<CLabel> title;
 	std::shared_ptr<CLabel> cost;
+	std::shared_ptr<CLabel> heroesForHire;
+	std::shared_ptr<CTextBox> heroDescription;
+
 	std::shared_ptr<CTextBox> rumor;
 
 	CTavernWindow(const CGObjectInstance * TavernObj);
@@ -240,7 +243,7 @@ public:
 
 	void recruitb();
 	void thievesguildb();
-	void show(SDL_Surface * to) override;
+	void show(Canvas & to) override;
 };
 
 class CCallback;
@@ -414,7 +417,7 @@ class CUniversityWindow : public CStatusbarWindow
 		int ID;//id of selected skill
 		CUniversityWindow * parent;
 
-		void showAll(SDL_Surface * to) override;
+		void showAll(Canvas & to) override;
 		void clickLeft(tribool down, bool previousState) override;
 		void clickRight(tribool down, bool previousState) override;
 		void hover(bool on) override;

--- a/client/windows/InfoWindows.cpp
+++ b/client/windows/InfoWindows.cpp
@@ -25,6 +25,7 @@
 #include "../battle/BattleInterfaceClasses.h"
 #include "../adventureMap/AdventureMapInterface.h"
 #include "../windows/CMessage.h"
+#include "../render/Canvas.h"
 #include "../renderSDL/SDL_Extensions.h"
 #include "../gui/CursorHandler.h"
 #include "../gui/Shortcut.h"
@@ -41,10 +42,10 @@
 
 #include <SDL_surface.h>
 
-void CSimpleWindow::show(SDL_Surface * to)
+void CSimpleWindow::show(Canvas & to)
 {
 	if(bitmap)
-		CSDL_Ext::blitAt(bitmap,pos.x,pos.y,to);
+		CSDL_Ext::blitAt(bitmap, pos.x, pos.y, to.getInternalSurface());
 }
 CSimpleWindow::~CSimpleWindow()
 {
@@ -168,14 +169,14 @@ void CInfoWindow::close()
 		LOCPLINT->showingDialog->setn(false);
 }
 
-void CInfoWindow::show(SDL_Surface * to)
+void CInfoWindow::show(Canvas & to)
 {
 	CIntObject::show(to);
 }
 
 CInfoWindow::~CInfoWindow() = default;
 
-void CInfoWindow::showAll(SDL_Surface * to)
+void CInfoWindow::showAll(Canvas & to)
 {
 	CSimpleWindow::show(to);
 	CIntObject::showAll(to);
@@ -261,9 +262,9 @@ void CInfoPopup::close()
 	WindowBase::close();
 }
 
-void CInfoPopup::show(SDL_Surface * to)
+void CInfoPopup::show(Canvas & to)
 {
-	CSDL_Ext::blitAt(bitmap,pos.x,pos.y,to);
+	CSDL_Ext::blitAt(bitmap,pos.x,pos.y,to.getInternalSurface());
 }
 
 CInfoPopup::~CInfoPopup()

--- a/client/windows/InfoWindows.h
+++ b/client/windows/InfoWindows.h
@@ -36,7 +36,7 @@ class CSimpleWindow : public WindowBase
 {
 public:
 	SDL_Surface * bitmap; //background
-	void show(SDL_Surface * to) override;
+	void show(Canvas & to) override;
 	CSimpleWindow():bitmap(nullptr){};
 	virtual ~CSimpleWindow();
 };
@@ -54,8 +54,8 @@ public:
 
 	virtual void close();
 
-	void show(SDL_Surface * to) override;
-	void showAll(SDL_Surface * to) override;
+	void show(Canvas & to) override;
+	void showAll(Canvas & to) override;
 	void sliderMoved(int to);
 
 	CInfoWindow(std::string Text, PlayerColor player, const TCompsInfo & comps = TCompsInfo(), const TButtonsInfo & Buttons = TButtonsInfo());
@@ -102,7 +102,7 @@ public:
 	bool free; //TODO: comment me
 	SDL_Surface * bitmap; //popup background
 	void close() override;
-	void show(SDL_Surface * to) override;
+	void show(Canvas & to) override;
 	CInfoPopup(SDL_Surface * Bitmap, int x, int y, bool Free=false);
 	CInfoPopup(SDL_Surface * Bitmap, const Point &p, ETextAlignment alignment, bool Free=false);
 	CInfoPopup(SDL_Surface * Bitmap = nullptr, bool Free = false);

--- a/client/windows/settings/SettingsMainWindow.cpp
+++ b/client/windows/settings/SettingsMainWindow.cpp
@@ -23,6 +23,7 @@
 #include "filesystem/ResourceID.h"
 #include "gui/CGuiHandler.h"
 #include "gui/WindowHandler.h"
+#include "render/Canvas.h"
 #include "lobby/CSavingScreen.h"
 #include "widgets/Buttons.h"
 #include "widgets/Images.h"
@@ -147,14 +148,14 @@ void SettingsMainWindow::closeAndPushEvent(EUserEvent code)
 	GH.pushUserEvent(code);
 }
 
-void SettingsMainWindow::showAll(SDL_Surface *to)
+void SettingsMainWindow::showAll(Canvas & to)
 {
 	auto color = LOCPLINT ? LOCPLINT->playerID : PlayerColor(1);
 	if(settings["session"]["spectate"].Bool())
 		color = PlayerColor(1); // TODO: Spectator shouldn't need special code for UI colors
 
 	CIntObject::showAll(to);
-	CMessage::drawBorder(color, to, pos.w+28, pos.h+29, pos.x-14, pos.y-15);
+	CMessage::drawBorder(color, to.getInternalSurface(), pos.w+28, pos.h+29, pos.x-14, pos.y-15);
 }
 
 void SettingsMainWindow::onScreenResize()

--- a/client/windows/settings/SettingsMainWindow.h
+++ b/client/windows/settings/SettingsMainWindow.h
@@ -41,7 +41,7 @@ private:
 public:
 	SettingsMainWindow(BattleInterface * parentBattleInterface = nullptr);
 
-	void showAll(SDL_Surface * to) override;
+	void showAll(Canvas & to) override;
 	void onScreenResize() override;
 };
 

--- a/mapeditor/BitmapHandler.cpp
+++ b/mapeditor/BitmapHandler.cpp
@@ -42,8 +42,6 @@ namespace BitmapHandler
 
 	QImage loadH3PCX(ui8 * pcx, size_t size)
 	{
-		//SDL_Surface * ret;
-		
 		Epcxformat format;
 		int it = 0;
 		


### PR DESCRIPTION
Another step towards SDL abstraction. Now show/showAll methods use Canvas class instead of direct access to SDL_Surface.
To minimize changes, Canvas now provides compatibility methods to ease transition.

List of changes:
- added compatibility method to Canvas to allow SDL_Surface access
- added drawBorder method to Canvas to replace CSDL_Ext method
- added drawColor method to Canvas to replace CSDL_Ext method
- minor changes to Tavern and Trade windows to adapt to new API