### PR TITLE
Treasure generation tweaks

### DIFF
--- a/Mods/vcmi/config/vcmi/rmg/hdmod/longRun.JSON
+++ b/Mods/vcmi/config/vcmi/rmg/hdmod/longRun.JSON
@@ -18,8 +18,7 @@
 				"treasure" :
 				[
 					{ "min" : 300, "max" : 3000, "density" : 12 },
-					{ "min" : 5000, "max" : 9000, "density" : 6 },
-					{ "min" : 0, "max" : 0, "density" : 1 }
+					{ "min" : 5000, "max" : 9000, "density" : 6 }
 				]
 			},
 			"2" :
@@ -34,8 +33,8 @@
 				"mines" : { "wood" : 1, "mercury" : 1, "ore" : 1, "sulfur" : 1, "crystal" : 1, "gems" : 1, "gold" : 1 },
 				"treasure" :
 				[
-					{ "min" : 5000, "max" : 7000, "density" : 30 },
 					{ "min" : 10000, "max" : 15000, "density" : 1 },
+					{ "min" : 5000, "max" : 7000, "density" : 30 },
 					{ "min" : 300, "max" : 3000, "density" : 5 }
 				]
 			},
@@ -51,8 +50,8 @@
 				"mines" : { "wood" : 1, "mercury" : 1, "ore" : 1, "sulfur" : 1, "crystal" : 1, "gems" : 1, "gold" : 0 },
 				"treasure" :
 				[
-					{ "min" : 12000, "max" : 16000, "density" : 5 },
 					{ "min" : 20000, "max" : 21000, "density" : 6 },
+					{ "min" : 12000, "max" : 16000, "density" : 5 },
 					{ "min" : 300, "max" : 3000, "density" : 5 }
 				]
 			},
@@ -69,8 +68,7 @@
 				"treasure" :
 				[
 					{ "min" : 25000, "max" : 30000, "density" : 10 },
-					{ "min" : 300, "max" : 3000, "density" : 10 },
-					{ "min" : 0, "max" : 0, "density" : 1 }
+					{ "min" : 300, "max" : 3000, "density" : 10 }
 				]
 			},
 			"5" :
@@ -85,9 +83,7 @@
 				"mines" : { "wood" : 0, "mercury" : 0, "ore" : 0, "sulfur" : 0, "crystal" : 0, "gems" : 0, "gold" : 4 },
 				"treasure" :
 				[
-					{ "min" : 30000, "max" : 90000, "density" : 25 },
-					{ "min" : 0, "max" : 0, "density" : 1 },
-					{ "min" : 0, "max" : 0, "density" : 1 }
+					{ "min" : 30000, "max" : 90000, "density" : 25 }
 				]
 			},
 			"6" :
@@ -167,8 +163,7 @@
 				"treasure" :
 				[
 					{ "min" : 300, "max" : 3000, "density" : 12 },
-					{ "min" : 5000, "max" : 9000, "density" : 6 },
-					{ "min" : 0, "max" : 0, "density" : 1 }
+					{ "min" : 5000, "max" : 9000, "density" : 6 }
 				]
 			},
 			"2" :
@@ -183,8 +178,8 @@
 				"mines" : { "wood" : 1, "mercury" : 1, "ore" : 1, "sulfur" : 1, "crystal" : 1, "gems" : 1, "gold" : 1 },
 				"treasure" :
 				[
-					{ "min" : 5000, "max" : 7000, "density" : 10 },
 					{ "min" : 10000, "max" : 15000, "density" : 1 },
+					{ "min" : 5000, "max" : 7000, "density" : 10 },
 					{ "min" : 300, "max" : 3000, "density" : 5 }
 				]
 			},
@@ -200,8 +195,8 @@
 				"mines" : { "wood" : 1, "mercury" : 1, "ore" : 1, "sulfur" : 1, "crystal" : 1, "gems" : 1, "gold" : 0 },
 				"treasure" :
 				[
-					{ "min" : 12000, "max" : 16000, "density" : 5 },
 					{ "min" : 20000, "max" : 21000, "density" : 6 },
+					{ "min" : 12000, "max" : 16000, "density" : 5 },
 					{ "min" : 300, "max" : 3000, "density" : 5 }
 				]
 			},
@@ -218,8 +213,7 @@
 				"treasure" :
 				[
 					{ "min" : 25000, "max" : 30000, "density" : 10 },
-					{ "min" : 300, "max" : 3000, "density" : 10 },
-					{ "min" : 0, "max" : 0, "density" : 1 }
+					{ "min" : 300, "max" : 3000, "density" : 10 }
 				]
 			},
 			"5" :

--- a/Mods/vcmi/config/vcmi/rmg/hdmod/longRun.JSON
+++ b/Mods/vcmi/config/vcmi/rmg/hdmod/longRun.JSON
@@ -233,9 +233,7 @@
 				"mines" : { "wood" : 0, "mercury" : 0, "ore" : 0, "sulfur" : 0, "crystal" : 0, "gems" : 0, "gold" : 10 },
 				"treasure" :
 				[
-					{ "min" : 30000, "max" : 90000, "density" : 25 },
-					{ "min" : 0, "max" : 0, "density" : 1 },
-					{ "min" : 0, "max" : 0, "density" : 1 }
+					{ "min" : 30000, "max" : 90000, "density" : 25 }
 				]
 			},
 			"6" :

--- a/config/objects/generic.json
+++ b/config/objects/generic.json
@@ -511,6 +511,7 @@
 				"index" : 0,
 				"aiValue" : 100,
 				"rmg" : {
+					"zoneLimit"	: 1,
 					"mapLimit"	: 32,
 					"value"		: 100,
 					"rarity"	: 20

--- a/config/objects/moddables.json
+++ b/config/objects/moddables.json
@@ -50,6 +50,34 @@
 		}
 	},
 
+	"randomResource":
+	{
+		"index" :76,
+		"handler": "resource",
+		"base" : {
+			"base" : {
+				"visitableFrom" : [ "+++", "+-+", "+++" ],
+				"mask" : [ "VA" ]
+			}
+		},
+		"types" : {
+			"randomResource" : {
+				"index" : 0,
+				"rmg" : {
+					"value"		: 1500,
+					"rarity"	: 2000
+				},
+				"templates" :
+				{
+					"res" :
+					{
+						"animation" : "AVTrndm0.def"
+					}
+				}
+			}
+		}
+	},
+
 	// subtype: resource ID
 	"resource" : {
 		"index" :79,

--- a/config/objects/rewardableBonusing.json
+++ b/config/objects/rewardableBonusing.json
@@ -15,6 +15,7 @@
 				"index" : 0,
 				"aiValue" : 100,
 				"rmg" : {
+					"zoneLimit"	: 1,
 					"value"		: 100,
 					"rarity"	: 100
 				},
@@ -253,6 +254,7 @@
 				"index" : 0,
 				"aiValue" : 100,
 				"rmg" : {
+					"zoneLimit"	: 1,
 					"value"		: 100,
 					"rarity"	: 20
 				},

--- a/lib/rmg/RmgArea.cpp
+++ b/lib/rmg/RmgArea.cpp
@@ -64,21 +64,35 @@ void Area::invalidate()
 	dBorderOutsideCache.clear();
 }
 
-bool Area::connected() const
+bool Area::connected(bool noDiagonals) const
 {
 	std::list<int3> queue({*dTiles.begin()});
 	Tileset connected = dTiles; //use invalidated cache - ok
+
 	while(!queue.empty())
 	{
 		auto t = queue.front();
 		connected.erase(t);
 		queue.pop_front();
 		
-		for(auto & i : int3::getDirs())
+		if (noDiagonals)
 		{
-			if(connected.count(t + i))
+			for (auto& i : dirs4)
 			{
-				queue.push_back(t + i);
+				if (connected.count(t + i))
+				{
+					queue.push_back(t + i);
+				}
+			}
+		}
+		else
+		{
+			for (auto& i : int3::getDirs())
+			{
+				if (connected.count(t + i))
+				{
+					queue.push_back(t + i);
+				}
 			}
 		}
 	}

--- a/lib/rmg/RmgArea.h
+++ b/lib/rmg/RmgArea.h
@@ -44,7 +44,7 @@ namespace rmg
 
 		Area getSubarea(const std::function<bool(const int3 &)> & filter) const;
 
-		bool connected() const; //is connected
+		bool connected(bool noDiagonals = false) const; //is connected
 		bool empty() const;
 		bool contains(const int3 & tile) const;
 		bool contains(const std::vector<int3> & tiles) const;

--- a/lib/rmg/RmgObject.h
+++ b/lib/rmg/RmgObject.h
@@ -77,6 +77,9 @@ public:
 	
 	const Area & getArea() const;  //lazy cache invalidation
 	const int3 getVisibleTop() const;
+
+	bool isGuarded() const;
+	void setGuardedIfMonster(const Instance & object);
 	
 	void finalize(RmgMap & map);
 	void clear();
@@ -87,6 +90,7 @@ private:
 	mutable Area dAccessibleAreaCache, dAccessibleAreaFullCache;
 	int3 dPosition;
 	ui32 dStrength;
+	bool guarded;
 };
 }
 

--- a/lib/rmg/Zone.cpp
+++ b/lib/rmg/Zone.cpp
@@ -215,10 +215,10 @@ void Zone::fractalize()
 		treasureDensity += t.density;
 	}
 
-	if (treasureValue > 100)
+	if (treasureValue > 200)
 	{
 		//Less obstacles - max span is 1 (no obstacles)
-		spanFactor = 1.0f - ((std::max(0, (1000 - treasureValue)) / 1000.f) * (1 - spanFactor));
+		spanFactor = 1.0f - ((std::max(0, (1000 - treasureValue)) / (1000.f - 200)) * (1 - spanFactor));
 	}
 	else if (treasureValue < 100)
 	{

--- a/lib/rmg/Zone.cpp
+++ b/lib/rmg/Zone.cpp
@@ -203,8 +203,34 @@ void Zone::fractalize()
 	rmg::Area possibleTiles(dAreaPossible);
 	rmg::Area tilesToIgnore; //will be erased in this iteration
 
-	const float minDistance = 10 * 10; //squared
-	float blockDistance = minDistance * 0.25f;
+	//Squared
+	float minDistance = 10 * 10;
+	float spanFactor = (pos.z ? 0.25 : 0.5f); //Narrower passages in the Underground
+
+	int treasureValue = 0;
+	int treasureDensity = 0;
+	for (auto t : treasureInfo)
+	{
+		treasureValue += ((t.min + t.max) / 2) * t.density / 1000.f; //Thousands
+		treasureDensity += t.density;
+	}
+
+	if (treasureValue > 100)
+	{
+		//Less obstacles - max span is 1 (no obstacles)
+		spanFactor = 1.0f - ((std::max(0, (1000 - treasureValue)) / 1000.f) * (1 - spanFactor));
+	}
+	else if (treasureValue < 100)
+	{
+		//Dense obstacles
+		spanFactor *= (treasureValue / 100.f);
+		vstd::amax(spanFactor, 0.2f);
+	}
+	if (treasureDensity <= 10)
+	{
+		vstd::amin(spanFactor, 0.25f); //Add extra obstacles to fill up space
+	}
+	float blockDistance = minDistance * spanFactor; //More obstacles in the Underground
 	
 	if(type != ETemplateZoneType::JUNCTION)
 	{

--- a/lib/rmg/modificators/ObjectManager.cpp
+++ b/lib/rmg/modificators/ObjectManager.cpp
@@ -183,8 +183,15 @@ int3 ObjectManager::findPlaceForObject(const rmg::Area & searchArea, rmg::Object
 
 		for(const auto & t : obj.getArea().getTilesVector())
 		{
-			if(map.getTileInfo(t).getNearestObjectDistance() < min_dist)
+			auto localDist = map.getTileInfo(t).getNearestObjectDistance();
+			if (localDist < min_dist)
+			{
 				return -1.f;
+			}
+			else
+			{
+				vstd::amin(dist, localDist); //Evaluate object tile which will be closest to another object
+			}
 		}
 		
 		return dist;

--- a/lib/rmg/modificators/ObjectManager.cpp
+++ b/lib/rmg/modificators/ObjectManager.cpp
@@ -166,7 +166,6 @@ int3 ObjectManager::findPlaceForObject(const rmg::Area & searchArea, rmg::Object
 		}
 	}
 	
-	//FIXME: Race condition for tiles? For Area?
 	if(result.valid())
 		obj.setPosition(result);
 	return result;
@@ -213,6 +212,55 @@ rmg::Path ObjectManager::placeAndConnectObject(const rmg::Area & searchArea, rmg
 				return -1.f;
 		}
 		
+		rmg::Area perimeter;
+		rmg::Area areaToBlock;
+		if (obj.isGuarded())
+		{
+			auto guardedArea = obj.instances().back()->getAccessibleArea();
+			guardedArea.add(obj.instances().back()->getVisitablePosition());
+			areaToBlock = obj.getAccessibleArea(true);
+			areaToBlock.subtract(guardedArea);
+		
+			if (!areaToBlock.empty())
+			{
+				perimeter = areaToBlock;
+				perimeter.unite(areaToBlock.getBorderOutside());
+				//We could have added border around guard
+				perimeter.subtract(guardedArea);
+			}
+		}
+		else
+		{
+			perimeter = obj.getArea();
+			perimeter.subtract(obj.getAccessibleArea());
+			if (!perimeter.empty())
+			{
+				perimeter.unite(perimeter.getBorderOutside());
+				perimeter.subtract(obj.getAccessibleArea());
+			}
+		}
+		//Check if perimeter of the object intersects with more than one blocked areas
+
+		auto tiles = perimeter.getTiles();
+		vstd::erase_if(tiles, [this](const int3& tile) -> bool
+		{
+			//Out-of-map area also is an obstacle
+			if (!map.isOnMap(tile))
+				return false;
+			return !(map.isBlocked(tile) || map.isUsed(tile));
+		});
+
+		if (!tiles.empty())
+		{
+			rmg::Area border(tiles);
+			border.subtract(areaToBlock);
+			if (!border.connected())
+			{
+				//We don't want to connect two blocked areas to create impassable obstacle
+				return -1.f;
+			}
+		}
+		
 		return dist;
 	}, isGuarded, onlyStraight, optimizer);
 }
@@ -237,7 +285,7 @@ rmg::Path ObjectManager::placeAndConnectObject(const rmg::Area & searchArea, rmg
 			accessibleArea.intersect(guardedArea);
 			accessibleArea.add(obj.instances().back()->getPosition(true));
 		}
-		
+
 		auto path = zone.searchPath(accessibleArea, onlyStraight, [&obj, isGuarded](const int3 & t)
 		{
 			if(isGuarded)

--- a/lib/rmg/modificators/ObstaclePlacer.cpp
+++ b/lib/rmg/modificators/ObstaclePlacer.cpp
@@ -12,7 +12,7 @@
 #include "ObstaclePlacer.h"
 #include "ObjectManager.h"
 #include "TreasurePlacer.h"
-#include "RockPlacer.h"
+#include "RockFiller.h"
 #include "WaterRoutes.h"
 #include "WaterProxy.h"
 #include "RoadPlacer.h"
@@ -94,10 +94,16 @@ void ObstaclePlacer::init()
 {
 	DEPENDENCY(ObjectManager);
 	DEPENDENCY(TreasurePlacer);
-	DEPENDENCY(WaterRoutes);
-	DEPENDENCY(WaterProxy);
 	DEPENDENCY(RoadPlacer);
-	DEPENDENCY_ALL(RockPlacer);
+	if (zone.isUnderground())
+	{
+		DEPENDENCY(RockFiller);
+	}
+	else
+	{
+		DEPENDENCY(WaterRoutes);
+		DEPENDENCY(WaterProxy);
+	}
 }
 
 bool ObstaclePlacer::isInTheMap(const int3& tile)

--- a/lib/rmg/modificators/RiverPlacer.cpp
+++ b/lib/rmg/modificators/RiverPlacer.cpp
@@ -82,7 +82,10 @@ void RiverPlacer::process()
 
 void RiverPlacer::init()
 {
-	DEPENDENCY_ALL(WaterProxy);
+	if (!zone.isUnderground())
+	{
+		DEPENDENCY_ALL(WaterProxy);
+	}
 	DEPENDENCY(ObjectManager);
 	DEPENDENCY(ObstaclePlacer);
 }

--- a/lib/rmg/modificators/RoadPlacer.cpp
+++ b/lib/rmg/modificators/RoadPlacer.cpp
@@ -12,6 +12,7 @@
 #include "RoadPlacer.h"
 #include "ObjectManager.h"
 #include "ObstaclePlacer.h"
+#include "RockFiller.h"
 #include "../Functions.h"
 #include "../CMapGenerator.h"
 #include "../threadpool/MapProxy.h"
@@ -26,6 +27,14 @@ void RoadPlacer::process()
 		return; //do not generate roads at all
 	
 	connectRoads();
+}
+
+void RoadPlacer::init()
+{
+	if (zone.isUnderground())
+	{
+		DEPENDENCY_ALL(RockFiller);
+	}
 }
 
 rmg::Area & RoadPlacer::areaForRoads()

--- a/lib/rmg/modificators/RoadPlacer.h
+++ b/lib/rmg/modificators/RoadPlacer.h
@@ -19,6 +19,7 @@ public:
 	MODIFICATOR(RoadPlacer);
 	
 	void process() override;
+	void init();
 	char dump(const int3 &) override;
 	
 	void addRoadNode(const int3 & node);

--- a/lib/rmg/modificators/RoadPlacer.h
+++ b/lib/rmg/modificators/RoadPlacer.h
@@ -19,7 +19,7 @@ public:
 	MODIFICATOR(RoadPlacer);
 	
 	void process() override;
-	void init();
+	void init() override;
 	char dump(const int3 &) override;
 	
 	void addRoadNode(const int3 & node);

--- a/lib/rmg/modificators/RockFiller.cpp
+++ b/lib/rmg/modificators/RockFiller.cpp
@@ -13,7 +13,6 @@
 #include "RockPlacer.h"
 #include "TreasurePlacer.h"
 #include "ObjectManager.h"
-#include "RoadPlacer.h"
 #include "RiverPlacer.h"
 #include "../RmgMap.h"
 #include "../CMapGenerator.h"
@@ -63,7 +62,6 @@ void RockFiller::processMap()
 void RockFiller::init()
 {
 	DEPENDENCY_ALL(RockPlacer);
-	POSTFUNCTION_ALL(RoadPlacer);
 }
 
 char RockFiller::dump(const int3 & t)

--- a/lib/rmg/modificators/RockPlacer.cpp
+++ b/lib/rmg/modificators/RockPlacer.cpp
@@ -67,7 +67,17 @@ void RockPlacer::postProcess()
 
 void RockPlacer::init()
 {
-	DEPENDENCY_ALL(TreasurePlacer);
+	for (const auto& zone : map.getZones())
+	{
+		if (zone.second->isUnderground())
+		{
+			auto * tp = zone.second->getModificator<TreasurePlacer>();
+			if (tp)
+			{
+				dependency(tp);
+			}
+		}
+	}
 }
 
 char RockPlacer::dump(const int3 & t)

--- a/lib/rmg/modificators/TownPlacer.cpp
+++ b/lib/rmg/modificators/TownPlacer.cpp
@@ -163,11 +163,14 @@ void TownPlacer::cleanupBoundaries(const rmg::Object & rmgObject)
 	Zone::Lock lock(zone.areaMutex);
 	for(const auto & t : rmgObject.getArea().getBorderOutside())
 	{
-		if(map.isOnMap(t))
+		if (t.y > rmgObject.getVisitablePosition().y) //Line below the town
 		{
-			map.setOccupied(t, ETileType::FREE);
-			zone.areaPossible().erase(t);
-			zone.freePaths().add(t);
+			if (map.isOnMap(t))
+			{
+				map.setOccupied(t, ETileType::FREE);
+				zone.areaPossible().erase(t);
+				zone.freePaths().add(t);
+			}
 		}
 	}
 }

--- a/lib/rmg/modificators/TreasurePlacer.cpp
+++ b/lib/rmg/modificators/TreasurePlacer.cpp
@@ -763,16 +763,12 @@ void TreasurePlacer::createTreasures(ObjectManager& manager)
 		//this is squared distance for optimization purposes
 		const float minDistance = std::max<float>((125.f / totalDensity), 1.0f);
 
-		for (size_t i = 0; i < count;)
+		for (size_t i = 0; i < count; i++)
 		{
 			auto treasurePileInfos = prepareTreasurePile(t);
 			if (treasurePileInfos.empty())
 			{
 				continue;
-			}
-			else
-			{
-				i++;
 			}
 
 			int value = std::accumulate(treasurePileInfos.begin(), treasurePileInfos.end(), 0, [](int v, const ObjectInfo* oi) {return v + oi->value; });

--- a/lib/rmg/modificators/TreasurePlacer.cpp
+++ b/lib/rmg/modificators/TreasurePlacer.cpp
@@ -736,7 +736,7 @@ void TreasurePlacer::createTreasures(ObjectManager& manager)
 	size_t size = 0;
 	{
 		Zone::Lock lock(zone.areaMutex);
-		size = zone.areaPossible().getTiles().size();
+		size = zone.getArea().getTiles().size();
 	}
 
 	int totalDensity = 0;
@@ -753,10 +753,12 @@ void TreasurePlacer::createTreasures(ObjectManager& manager)
 
 		totalDensity += t.density;
 
-		const size_t count = size * t.density / 300;
-
-		//treasure density is inversely proportional to zone size but must be scaled back to map size
-		//also, normalize it to zone count - higher count means relatively smaller zones
+		size_t count = size * t.density / 500;
+		const int averageValue = (t.min + t.max) / 2;
+		if (averageValue > 10000) //Will surely be guarded => larger
+		{
+			vstd::amin(count, size * (10.f/500) / (std::sqrt((float)averageValue / 10000)));
+		}
 		
 		//this is squared distance for optimization purposes
 		const float minDistance = std::max<float>((125.f / totalDensity), 1.0f);

--- a/lib/rmg/modificators/TreasurePlacer.cpp
+++ b/lib/rmg/modificators/TreasurePlacer.cpp
@@ -704,7 +704,6 @@ ObjectInfo * TreasurePlacer::getRandomObject(ui32 desiredValue, ui32 currentValu
 void TreasurePlacer::createTreasures(ObjectManager& manager)
 {
 	const int maxAttempts = 2;
-	const int minDistance = 2;
 
 	int mapMonsterStrength = map.getMapGenOptions().getMonsterStrength();
 	int monsterStrength = (zone.monsterStrength == EMonsterStrength::ZONE_NONE ? 0 : zone.monsterStrength + mapMonsterStrength - 1); //array index from 0 to 4; pick any correct value for ZONE_NONE, minGuardedValue won't be used in this case anyway

--- a/lib/rmg/modificators/TreasurePlacer.cpp
+++ b/lib/rmg/modificators/TreasurePlacer.cpp
@@ -562,7 +562,7 @@ std::vector<ObjectInfo*> TreasurePlacer::prepareTreasurePile(const CTreasureInfo
 	bool hasLargeObject = false;
 	while(currentValue <= static_cast<int>(desiredValue) - 100) //no objects with value below 100 are available
 	{
-		auto * oi = getRandomObject(desiredValue, currentValue, maxValue, !hasLargeObject);
+		auto * oi = getRandomObject(desiredValue, currentValue, !hasLargeObject);
 		if(!oi) //fail
 			break;
 		
@@ -659,13 +659,13 @@ rmg::Object TreasurePlacer::constructTreasurePile(const std::vector<ObjectInfo*>
 	return rmgObject;
 }
 
-ObjectInfo * TreasurePlacer::getRandomObject(ui32 desiredValue, ui32 currentValue, ui32 maxValue, bool allowLargeObjects)
+ObjectInfo * TreasurePlacer::getRandomObject(ui32 desiredValue, ui32 currentValue, bool allowLargeObjects)
 {
 	std::vector<std::pair<ui32, ObjectInfo*>> thresholds; //handle complex object via pointer
 	ui32 total = 0;
 	
 	//calculate actual treasure value range based on remaining value
-	ui32 maxVal = maxValue - currentValue;
+	ui32 maxVal = desiredValue - currentValue;
 	ui32 minValue = static_cast<ui32>(0.25f * (desiredValue - currentValue));
 	
 	for(ObjectInfo & oi : possibleObjects) //copy constructor turned out to be costly

--- a/lib/rmg/modificators/TreasurePlacer.h
+++ b/lib/rmg/modificators/TreasurePlacer.h
@@ -54,7 +54,7 @@ public:
 protected:
 	bool isGuardNeededForTreasure(int value);
 	
-	ObjectInfo * getRandomObject(ui32 desiredValue, ui32 currentValue, ui32 maxValue, bool allowLargeObjects);
+	ObjectInfo * getRandomObject(ui32 desiredValue, ui32 currentValue, bool allowLargeObjects);
 	std::vector<ObjectInfo*> prepareTreasurePile(const CTreasureInfo & treasureInfo);
 	rmg::Object constructTreasurePile(const std::vector<ObjectInfo*> & treasureInfos, bool densePlacement = false);
 

--- a/lib/rmg/modificators/WaterProxy.cpp
+++ b/lib/rmg/modificators/WaterProxy.cpp
@@ -83,8 +83,11 @@ void WaterProxy::init()
 {
 	for(auto & z : map.getZones())
 	{
-		dependency(z.second->getModificator<TownPlacer>());
-		dependency(z.second->getModificator<WaterAdopter>());
+		if (!zone.isUnderground())
+		{
+			dependency(z.second->getModificator<TownPlacer>());
+			dependency(z.second->getModificator<WaterAdopter>());
+		}
 		postfunction(z.second->getModificator<ConnectionsPlacer>());
 		postfunction(z.second->getModificator<ObjectManager>());
 	}


### PR DESCRIPTION
Many tweaks based on p4v opinions, hours of parameter tweaking and sudden enlightenment.

- Generate certain number of treasures of given value before placing them. Do not interrupt until all treasures were checked.
- Obstacle density will depend on treasure density.
- Do not round up treasure value, should match OH3 now. Previous value was too high, which made maps too difficult.
- Treasure piles will check all covered tiles for minimum distance optimization
- Added some magic hand-crafted formulas to ensure nice balance on a variety of templates.

- Following Gus Smedstad's presentation, make sure that treasure pile perimeters will not join two separate blocks. Also, fill all irrelevant tiles and remove all possible tiles taht could block passage.

- Added "Random Resource" object which has significant impact on balance
- Some bonusing / morale objects will be limited to one per zone (effectively one per map with current implementation). No more 100 sign bottles per map.

- Surface and underground zones no longer depend on each other, which helps parallel processing.
