### PR TITLE
Replaced deprecated(removed from qt6) signals

### DIFF
--- a/launcher/settingsView/csettingsview_moc.cpp
+++ b/launcher/settingsView/csettingsview_moc.cpp
@@ -225,25 +225,25 @@ void CSettingsView::on_comboBoxDisplayIndex_currentIndexChanged(int index)
 	fillValidResolutionsForScreen(index);
 }
 
-void CSettingsView::on_comboBoxPlayerAI_currentIndexChanged(const QString & arg1)
+void CSettingsView::on_comboBoxPlayerAI_currentTextChanged(const QString & arg1)
 {
 	Settings node = settings.write["server"]["playerAI"];
 	node->String() = arg1.toUtf8().data();
 }
 
-void CSettingsView::on_comboBoxFriendlyAI_currentIndexChanged(const QString & arg1)
+void CSettingsView::on_comboBoxFriendlyAI_currentTextChanged(const QString & arg1)
 {
 	Settings node = settings.write["server"]["friendlyAI"];
 	node->String() = arg1.toUtf8().data();
 }
 
-void CSettingsView::on_comboBoxNeutralAI_currentIndexChanged(const QString & arg1)
+void CSettingsView::on_comboBoxNeutralAI_currentTextChanged(const QString & arg1)
 {
 	Settings node = settings.write["server"]["neutralAI"];
 	node->String() = arg1.toUtf8().data();
 }
 
-void CSettingsView::on_comboBoxEnemyAI_currentIndexChanged(const QString & arg1)
+void CSettingsView::on_comboBoxEnemyAI_currentTextChanged(const QString & arg1)
 {
 	Settings node = settings.write["server"]["enemyAI"];
 	node->String() = arg1.toUtf8().data();

--- a/launcher/settingsView/csettingsview_moc.h
+++ b/launcher/settingsView/csettingsview_moc.h
@@ -35,10 +35,10 @@ public slots:
 private slots:
 	void on_comboBoxResolution_currentTextChanged(const QString & arg1);
 	void on_comboBoxFullScreen_currentIndexChanged(int index);
-	void on_comboBoxPlayerAI_currentIndexChanged(const QString & arg1);
-	void on_comboBoxFriendlyAI_currentIndexChanged(const QString & arg1);
-	void on_comboBoxNeutralAI_currentIndexChanged(const QString & arg1);
-	void on_comboBoxEnemyAI_currentIndexChanged(const QString & arg1);
+	void on_comboBoxPlayerAI_currentTextChanged(const QString & arg1);
+	void on_comboBoxFriendlyAI_currentTextChanged(const QString & arg1);
+	void on_comboBoxNeutralAI_currentTextChanged(const QString & arg1);
+	void on_comboBoxEnemyAI_currentTextChanged(const QString & arg1);
 	void on_spinBoxNetworkPort_valueChanged(int arg1);
 	void on_plainTextEditRepos_textChanged();
 	void on_openTempDir_clicked();


### PR DESCRIPTION
QComboBox currentIndexChanged(const QString&) got removed in Qt6: https://code.qt.io/cgit/qt/qtbase.git/commit/?h=6.3&id=3703a28511bed9daea2af57409db150cb3ed1a23. Replaced it with currentTextChanged(const QString&).