### PR TITLE
Fix crash in VCAI

### DIFF
--- a/AI/VCAI/Goals/CollectRes.cpp
+++ b/AI/VCAI/Goals/CollectRes.cpp
@@ -133,7 +133,7 @@ TSubgoal CollectRes::whatToDoToTrade()
 	ai->retrieveVisitableObjs(visObjs, true);
 	for(const CGObjectInstance * obj : visObjs)
 	{
-		if(const IMarket * m = IMarket::castFrom(obj, false); m->allowsTrade(EMarketMode::RESOURCE_RESOURCE))
+		if(const IMarket * m = IMarket::castFrom(obj, false); m && m->allowsTrade(EMarketMode::RESOURCE_RESOURCE))
 		{
 			if(obj->ID == Obj::TOWN)
 			{


### PR DESCRIPTION
Start any map with VCAI as a map AI and skip some turns, it will often crash in the first 2-3 turns.