### PR TITLE
Allow defining default values of settings per platform

### DIFF
--- a/client/gui/CursorHandler.cpp
+++ b/client/gui/CursorHandler.cpp
@@ -22,17 +22,10 @@
 
 std::unique_ptr<ICursor> CursorHandler::createCursor()
 {
-	if (settings["video"]["cursor"].String() == "auto")
-	{
 #if defined(VCMI_MOBILE)
-		if (settings["general"]["userRelativePointer"].Bool())
-			return std::make_unique<CursorSoftware>();
-		else
-			return std::make_unique<CursorHardware>();
-#else
-		return std::make_unique<CursorHardware>();
+	if (settings["general"]["userRelativePointer"].Bool())
+		return std::make_unique<CursorSoftware>();
 #endif
-	}
 
 	if (settings["video"]["cursor"].String() == "hardware")
 		return std::make_unique<CursorHardware>();

--- a/config/schemas/settings.json
+++ b/config/schemas/settings.json
@@ -123,6 +123,8 @@
 						"height" : { "type" : "number" },
 						"scaling" : { "type" : "number" }
 					},
+					"defaultIOS" : {"width" : 800, "height" : 600, "scaling" : 200 },
+					"defaultAndroid" : {"width" : 800, "height" : 600, "scaling" : 200 },
 					"default" : {"width" : 800, "height" : 600, "scaling" : 100 }
 				},
 				"bitsPerPixel" : {
@@ -139,8 +141,8 @@
 				},
 				"cursor" :  {
 					"type" : "string",
-					"enum" : [ "auto", "hardware", "software" ],
-					"default" : "auto"
+					"enum" : [ "hardware", "software" ],
+					"default" : "hardware"
 				},
 				"showIntro" : {
 					"type" : "boolean",
@@ -210,6 +212,8 @@
 				"borderScroll" : 
 				{
 					"type" : "boolean",
+					"defaultIOS" : false,
+					"defaultAndroid" : false,
 					"default" : true
 				},
 			}
@@ -458,7 +462,7 @@
 			"type" : "object",
 			"default" : {},
 			"additionalProperties" : false,
-			"required" : [ "setupCompleted", "repositoryURL", "enableInstalledMods", "extraResolutionsModPath", "autoCheckRepositories", "updateOnStartup", "updateConfigUrl", "lobbyUrl", "lobbyPort", "lobbyUsername", "connectionTimeout" ],
+			"required" : [ "setupCompleted", "repositoryURL", "enableInstalledMods", "autoCheckRepositories", "updateOnStartup", "updateConfigUrl", "lobbyUrl", "lobbyPort", "lobbyUsername", "connectionTimeout" ],
 			"properties" : {
 				"repositoryURL" : {
 					"type" : "array",
@@ -476,10 +480,6 @@
 				"enableInstalledMods" : {
 					"type" : "boolean",
 					"default" : true
-				},
-				"extraResolutionsModPath" : {
-					"type" : "string",
-					"default" : "/vcmi-extras/Mods/extraResolutions/Content/config/resolutions.json"
 				},
 				"autoCheckRepositories" : {
 					"type" : "boolean",

--- a/launcher/settingsView/csettingsview_moc.cpp
+++ b/launcher/settingsView/csettingsview_moc.cpp
@@ -38,7 +38,6 @@ QString resolutionToString(const QSize & resolution)
 
 static const std::string cursorTypesList[] =
 {
-	"auto",
 	"hardware",
 	"software"
 };

--- a/launcher/settingsView/csettingsview_moc.ui
+++ b/launcher/settingsView/csettingsview_moc.ui
@@ -112,7 +112,7 @@
       <property name="geometry">
        <rect>
         <x>0</x>
-        <y>-107</y>
+        <y>0</y>
         <width>620</width>
         <height>745</height>
        </rect>
@@ -547,11 +547,6 @@
        </item>
        <item row="14" column="1" colspan="3">
         <widget class="QComboBox" name="comboBoxCursorType">
-         <item>
-          <property name="text">
-           <string>Default</string>
-          </property>
-         </item>
          <item>
           <property name="text">
            <string>Hardware</string>


### PR DESCRIPTION
Allows settings with different default values per platform (e.g. Android / iOS).

This should allow having (for example) UI scaling at value higher than 100% on mobile, high-dpi screens as default without custom handling of every such option.

Currently this feature is largely unused and is mostly added for future use.