### PR TITLE
Slider input event fix

### DIFF
--- a/client/adventureMap/CMinimap.cpp
+++ b/client/adventureMap/CMinimap.cpp
@@ -88,7 +88,7 @@ void CMinimapInstance::showAll(Canvas & to)
 }
 
 CMinimap::CMinimap(const Rect & position)
-	: CIntObject(LCLICK | SHOW_POPUP | HOVER | MOVE | GESTURE, position.topLeft()),
+	: CIntObject(LCLICK | SHOW_POPUP | DRAG | MOVE | GESTURE, position.topLeft()),
 	level(0)
 {
 	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
@@ -162,10 +162,9 @@ void CMinimap::hover(bool on)
 		GH.statusbar()->clear();
 }
 
-void CMinimap::mouseMoved(const Point & cursorPosition)
+void CMinimap::mouseDragged(const Point & cursorPosition, const Point & lastUpdateDistance)
 {
-	if(isMouseLeftButtonPressed())
-		moveAdvMapSelection(cursorPosition);
+	moveAdvMapSelection(cursorPosition);
 }
 
 void CMinimap::showAll(Canvas & to)

--- a/client/adventureMap/CMinimap.h
+++ b/client/adventureMap/CMinimap.h
@@ -46,8 +46,8 @@ class CMinimap : public CIntObject
 	void gesturePanning(const Point & initialPosition, const Point & currentPosition, const Point & lastUpdateDistance) override;
 	void clickLeft(tribool down, bool previousState) override;
 	void showPopupWindow() override;
-	void hover (bool on) override;
-	void mouseMoved (const Point & cursorPosition) override;
+	void hover(bool on) override;
+	void mouseDragged(const Point & cursorPosition, const Point & lastUpdateDistance) override;
 
 	/// relocates center of adventure map screen to currently hovered tile
 	void moveAdvMapSelection(const Point & positionGlobal);

--- a/client/battle/BattleFieldController.cpp
+++ b/client/battle/BattleFieldController.cpp
@@ -197,7 +197,7 @@ void BattleFieldController::gesturePanning(const Point & initialPosition, const 
 		owner.actionsController->onHexHovered(getHoveredHex());
 }
 
-void BattleFieldController::mouseMoved(const Point & cursorPosition)
+void BattleFieldController::mouseMoved(const Point & cursorPosition, const Point & lastUpdateDistance)
 {
 	hoveredHex = getHexAtPosition(cursorPosition);
 	currentAttackOriginPoint = cursorPosition;

--- a/client/battle/BattleFieldController.h
+++ b/client/battle/BattleFieldController.h
@@ -90,7 +90,7 @@ class BattleFieldController : public CIntObject
 
 	void gesture(bool on, const Point & initialPosition, const Point & finalPosition) override;
 	void gesturePanning(const Point & initialPosition, const Point & currentPosition, const Point & lastUpdateDistance) override;
-	void mouseMoved(const Point & cursorPosition) override;
+	void mouseMoved(const Point & cursorPosition, const Point & lastUpdateDistance) override;
 	void clickLeft(tribool down, bool previousState) override;
 	void showPopupWindow() override;
 	void activate() override;

--- a/client/eventsSDL/InputHandler.cpp
+++ b/client/eventsSDL/InputHandler.cpp
@@ -244,11 +244,6 @@ bool InputHandler::hasTouchInputDevice() const
 	return fingerHandler->hasTouchInputDevice();
 }
 
-bool InputHandler::isMouseButtonPressed(MouseButton button) const
-{
-	return mouseHandler->isMouseButtonPressed(button) || fingerHandler->isMouseButtonPressed(button);
-}
-
 void InputHandler::pushUserEvent(EUserEvent usercode, void * userdata)
 {
 	SDL_Event event;

--- a/client/eventsSDL/InputHandler.cpp
+++ b/client/eventsSDL/InputHandler.cpp
@@ -75,7 +75,7 @@ void InputHandler::handleCurrentEvent(const SDL_Event & current)
 void InputHandler::processEvents()
 {
 	boost::unique_lock<boost::mutex> lock(eventsMutex);
-	for (auto const & currentEvent : eventsQueue)
+	for(const auto & currentEvent : eventsQueue)
 		handleCurrentEvent(currentEvent);
 
 	eventsQueue.clear();
@@ -87,7 +87,7 @@ bool InputHandler::ignoreEventsUntilInput()
 	bool inputFound = false;
 
 	boost::unique_lock<boost::mutex> lock(eventsMutex);
-	for (auto const & event : eventsQueue)
+	for(const auto & event : eventsQueue)
 	{
 		switch(event.type)
 		{
@@ -226,7 +226,7 @@ void InputHandler::moveCursorPosition(const Point & distance)
 void InputHandler::setCursorPosition(const Point & position)
 {
 	cursorPosition = position;
-	GH.events().dispatchMouseMoved(position);
+	GH.events().dispatchMouseMoved(Point(0, 0), position);
 }
 
 void InputHandler::startTextInput(const Rect & where)

--- a/client/eventsSDL/InputHandler.h
+++ b/client/eventsSDL/InputHandler.h
@@ -66,9 +66,6 @@ public:
 	/// returns true if system has active touchscreen
 	bool hasTouchInputDevice() const;
 
-	/// Returns true if selected mouse button is pressed at the moment
-	bool isMouseButtonPressed(MouseButton button) const;
-
 	/// Generates new user event that will be processed on next frame
 	void pushUserEvent(EUserEvent usercode, void * userdata);
 

--- a/client/eventsSDL/InputSourceMouse.cpp
+++ b/client/eventsSDL/InputSourceMouse.cpp
@@ -26,6 +26,8 @@ void InputSourceMouse::handleEventMouseMotion(const SDL_MouseMotionEvent & motio
 
 	if (mouseButtonsMask & SDL_BUTTON(SDL_BUTTON_MIDDLE))
 		GH.events().dispatchGesturePanning(middleClickPosition, newPosition, distance);
+	else if (mouseButtonsMask & SDL_BUTTON(SDL_BUTTON_LEFT))
+		GH.events().dispatchMouseDragged(newPosition, distance);
 	else
 		GH.input().setCursorPosition(newPosition);
 

--- a/client/eventsSDL/InputSourceMouse.cpp
+++ b/client/eventsSDL/InputSourceMouse.cpp
@@ -78,15 +78,3 @@ void InputSourceMouse::handleEventMouseButtonUp(const SDL_MouseButtonEvent & but
 			break;
 	}
 }
-
-bool InputSourceMouse::isMouseButtonPressed(MouseButton button) const
-{
-	static_assert(static_cast<uint32_t>(MouseButton::LEFT)   == SDL_BUTTON_LEFT,   "mismatch between VCMI and SDL enum!");
-	static_assert(static_cast<uint32_t>(MouseButton::MIDDLE) == SDL_BUTTON_MIDDLE, "mismatch between VCMI and SDL enum!");
-	static_assert(static_cast<uint32_t>(MouseButton::RIGHT)  == SDL_BUTTON_RIGHT,  "mismatch between VCMI and SDL enum!");
-	static_assert(static_cast<uint32_t>(MouseButton::EXTRA1) == SDL_BUTTON_X1,     "mismatch between VCMI and SDL enum!");
-	static_assert(static_cast<uint32_t>(MouseButton::EXTRA2) == SDL_BUTTON_X2,     "mismatch between VCMI and SDL enum!");
-
-	uint32_t index = static_cast<uint32_t>(button);
-	return mouseButtonsMask & SDL_BUTTON(index);
-}

--- a/client/eventsSDL/InputSourceMouse.h
+++ b/client/eventsSDL/InputSourceMouse.h
@@ -28,6 +28,4 @@ public:
 	void handleEventMouseButtonDown(const SDL_MouseButtonEvent & current);
 	void handleEventMouseWheel(const SDL_MouseWheelEvent & current);
 	void handleEventMouseButtonUp(const SDL_MouseButtonEvent & current);
-
-	bool isMouseButtonPressed(MouseButton button) const;
 };

--- a/client/eventsSDL/InputSourceTouch.cpp
+++ b/client/eventsSDL/InputSourceTouch.cpp
@@ -237,17 +237,6 @@ bool InputSourceTouch::hasTouchInputDevice() const
 	return SDL_GetNumTouchDevices() > 0;
 }
 
-bool InputSourceTouch::isMouseButtonPressed(MouseButton button) const
-{
-	if (state == TouchState::TAP_DOWN_LONG)
-	{
-		if (button == MouseButton::RIGHT)
-			return true;
-	}
-
-	return false;
-}
-
 void InputSourceTouch::emitPanningEvent(const SDL_TouchFingerEvent & tfinger)
 {
 	Point distance = convertTouchToMouse(-tfinger.dx, -tfinger.dy);

--- a/client/eventsSDL/InputSourceTouch.h
+++ b/client/eventsSDL/InputSourceTouch.h
@@ -105,5 +105,4 @@ public:
 	void handleUpdate();
 
 	bool hasTouchInputDevice() const;
-	bool isMouseButtonPressed(MouseButton button) const;
 };

--- a/client/eventsSDL/UserEventHandler.cpp
+++ b/client/eventsSDL/UserEventHandler.cpp
@@ -82,7 +82,7 @@ void UserEventHandler::handleUserEvent(const SDL_UserEvent & user)
 			break;
 		}
 		case EUserEvent::FAKE_MOUSE_MOVE:
-			GH.events().dispatchMouseMoved(GH.getCursorPosition());
+			GH.events().dispatchMouseMoved(Point(0, 0), GH.getCursorPosition());
 			break;
 		default:
 			logGlobal->error("Unknown user event. Code %d", user.code);

--- a/client/gui/CGuiHandler.cpp
+++ b/client/gui/CGuiHandler.cpp
@@ -189,11 +189,6 @@ Point CGuiHandler::screenDimensions() const
 	return Point(screen->w, screen->h);
 }
 
-bool CGuiHandler::isMouseButtonPressed(MouseButton button) const
-{
-	return inputHandlerInstance->isMouseButtonPressed(button);
-}
-
 void CGuiHandler::drawFPSCounter()
 {
 	static SDL_Rect overlay = { 0, 0, 64, 32};

--- a/client/gui/CGuiHandler.h
+++ b/client/gui/CGuiHandler.h
@@ -70,9 +70,6 @@ public:
 	/// May not match size of window if user has UI scaling different from 100%
 	Point screenDimensions() const;
 
-	/// returns true if specified mouse button is pressed
-	bool isMouseButtonPressed(MouseButton button) const;
-
 	/// returns true if chosen keyboard key is currently pressed down
 	bool isKeyboardAltDown() const;
 	bool isKeyboardCtrlDown() const;

--- a/client/gui/EventDispatcher.cpp
+++ b/client/gui/EventDispatcher.cpp
@@ -31,6 +31,7 @@ void EventDispatcher::processLists(ui16 activityFlag, const Functor & cb)
 	processList(AEventsReceiver::SHOW_POPUP, rclickable);
 	processList(AEventsReceiver::HOVER, hoverable);
 	processList(AEventsReceiver::MOVE, motioninterested);
+	processList(AEventsReceiver::DRAG, draginterested);
 	processList(AEventsReceiver::KEYBOARD, keyinterested);
 	processList(AEventsReceiver::TIME, timeinterested);
 	processList(AEventsReceiver::WHEEL, wheelInterested);
@@ -63,7 +64,7 @@ void EventDispatcher::dispatchTimer(uint32_t msPassed)
 	for (auto & elem : hlp)
 	{
 		if(!vstd::contains(timeinterested,elem)) continue;
-		(elem)->tick(msPassed);
+		elem->tick(msPassed);
 	}
 }
 
@@ -270,7 +271,7 @@ void EventDispatcher::dispatchGesturePinch(const Point & initialPosition, double
 	}
 }
 
-void EventDispatcher::dispatchMouseMoved(const Point & position)
+void EventDispatcher::dispatchMouseMoved(const Point & distance, const Point & position)
 {
 	EventReceiversList newlyHovered;
 
@@ -288,8 +289,8 @@ void EventDispatcher::dispatchMouseMoved(const Point & position)
 		{
 			if (elem->isHovered())
 			{
-				(elem)->hover(false);
-				(elem)->hoveredState = false;
+				elem->hover(false);
+				elem->hoveredState = false;
 			}
 		}
 	}
@@ -305,8 +306,16 @@ void EventDispatcher::dispatchMouseMoved(const Point & position)
 	for(auto & elem : miCopy)
 	{
 		if(elem->receiveEvent(position, AEventsReceiver::HOVER))
-		{
-			(elem)->mouseMoved(position);
-		}
+			elem->mouseMoved(position, distance);
+	}
+}
+
+void EventDispatcher::dispatchMouseDragged(const Point & currentPosition, const Point & lastUpdateDistance)
+{
+	EventReceiversList diCopy = draginterested;
+	for(auto & elem : diCopy)
+	{
+		if (elem->mouseClickedState)
+			elem->mouseDragged(currentPosition, lastUpdateDistance);
 	}
 }

--- a/client/gui/EventDispatcher.h
+++ b/client/gui/EventDispatcher.h
@@ -28,6 +28,7 @@ class EventDispatcher
 	EventReceiversList hoverable;
 	EventReceiversList keyinterested;
 	EventReceiversList motioninterested;
+	EventReceiversList draginterested;
 	EventReceiversList timeinterested;
 	EventReceiversList wheelInterested;
 	EventReceiversList doubleClickInterested;
@@ -59,7 +60,9 @@ public:
 	void dispatchMouseLeftButtonReleased(const Point & position);
 	void dispatchMouseScrolled(const Point & distance, const Point & position);
 	void dispatchMouseDoubleClick(const Point & position);
-	void dispatchMouseMoved(const Point & distance);
+	void dispatchMouseMoved(const Point & distance, const Point & position);
+
+	void dispatchMouseDragged(const Point & currentPosition, const Point & lastUpdateDistance);
 
 	void dispatchShowPopup(const Point & position);
 	void dispatchClosePopup(const Point & position);

--- a/client/gui/EventsReceiver.h
+++ b/client/gui/EventsReceiver.h
@@ -45,7 +45,8 @@ protected:
 	virtual void gesturePinch(const Point & centerPosition, double lastUpdateFactor) {}
 
 	virtual void wheelScrolled(int distance) {}
-	virtual void mouseMoved(const Point & cursorPosition) {}
+	virtual void mouseMoved(const Point & cursorPosition, const Point & lastUpdateDistance) {}
+	virtual void mouseDragged(const Point & cursorPosition, const Point & lastUpdateDistance) {}
 
 	/// Called when UI element hover status changes
 	virtual void hover(bool on) {}
@@ -84,6 +85,7 @@ public:
 		DOUBLECLICK = 256,
 		TEXTINPUT = 512,
 		GESTURE = 1024,
+		DRAG = 2048,
 	};
 
 	/// Returns true if element is currently hovered by mouse

--- a/client/gui/InterfaceObjectConfigurable.cpp
+++ b/client/gui/InterfaceObjectConfigurable.cpp
@@ -453,7 +453,7 @@ std::shared_ptr<CSlider> InterfaceObjectConfigurable::buildSlider(const JsonNode
 	auto value = config["selected"].Integer();
 	bool horizontal = config["orientation"].String() == "horizontal";
 	const auto & result =
-		std::make_shared<CSlider>(position, length, callbacks.at(config["callback"].String()), itemsVisible, itemsTotal, value, horizontal, style);
+		std::make_shared<CSlider>(position, length, callbacks.at(config["callback"].String()), itemsVisible, itemsTotal, value, horizontal ? Orientation::HORIZONTAL : Orientation::VERTICAL, style);
 
 	if (!config["scrollBounds"].isNull())
 	{

--- a/client/lobby/OptionsTab.cpp
+++ b/client/lobby/OptionsTab.cpp
@@ -48,7 +48,7 @@ OptionsTab::OptionsTab() : humanPlayers(0)
 	labelStartingBonus = std::make_shared<CMultiLineLabel>(Rect(315, 86, 70, (int)graphics->fonts[EFonts::FONT_SMALL]->getLineHeight()*2), EFonts::FONT_SMALL, ETextAlignment::CENTER, Colors::YELLOW, CGI->generaltexth->allTexts[520]);
 	if(SEL->screenType == ESelectionScreen::newGame || SEL->screenType == ESelectionScreen::loadGame || SEL->screenType == ESelectionScreen::scenarioInfo)
 	{
-		sliderTurnDuration = std::make_shared<CSlider>(Point(55, 551), 194, std::bind(&IServerAPI::setTurnLength, CSH, _1), 1, (int)GameConstants::POSSIBLE_TURNTIME.size(), (int)GameConstants::POSSIBLE_TURNTIME.size(), true, CSlider::BLUE);
+		sliderTurnDuration = std::make_shared<CSlider>(Point(55, 551), 194, std::bind(&IServerAPI::setTurnLength, CSH, _1), 1, (int)GameConstants::POSSIBLE_TURNTIME.size(), (int)GameConstants::POSSIBLE_TURNTIME.size(), Orientation::HORIZONTAL, CSlider::BLUE);
 		sliderTurnDuration->setScrollBounds(Rect(-3, -25, 337, 43));
 		sliderTurnDuration->setPanningStep(20);
 		labelPlayerTurnDuration = std::make_shared<CLabel>(222, 538, FONT_SMALL, ETextAlignment::CENTER, Colors::YELLOW, CGI->generaltexth->allTexts[521]);

--- a/client/lobby/RandomMapTab.cpp
+++ b/client/lobby/RandomMapTab.cpp
@@ -447,6 +447,11 @@ TemplatesDropBox::TemplatesDropBox(RandomMapTab & randomMapTab, int3 size):
 	{
 		w->setAmount(curItems.size());
 	}
+
+	//FIXME: this should be done by InterfaceObjectConfigurable, but might have side-effects
+	pos = children.front()->pos;
+	for (auto const & child : children)
+		pos = pos.include(child->pos);
 	
 	updateListItems();
 }
@@ -469,16 +474,10 @@ void TemplatesDropBox::sliderMove(int slidPos)
 
 void TemplatesDropBox::clickLeft(tribool down, bool previousState)
 {
-	if(down && !isActive())
+	if (!pos.isInside(GH.getCursorPosition()))
 	{
-		auto w = widget<CSlider>("slider");
-
-		// pop the interface only if the mouse is not clicking on the slider
-		if (!w || !w->isMouseLeftButtonPressed())
-		{
-			assert(GH.windows().isTopWindow(this));
-			GH.windows().popWindows(1);
-		}
+		assert(GH.windows().isTopWindow(this));
+		GH.windows().popWindows(1);
 	}
 }
 

--- a/client/lobby/SelectionTab.cpp
+++ b/client/lobby/SelectionTab.cpp
@@ -205,8 +205,12 @@ SelectionTab::SelectionTab(ESelectionScreen Type)
 		listItems.push_back(std::make_shared<ListItem>(Point(30, 129 + i * 25), iconsMapFormats, iconsVictoryCondition, iconsLossCondition));
 
 	labelTabTitle = std::make_shared<CLabel>(205, 28, FONT_MEDIUM, ETextAlignment::CENTER, Colors::YELLOW, tabTitle);
-	slider = std::make_shared<CSlider>(Point(372, 86), tabType != ESelectionScreen::saveGame ? 480 : 430, std::bind(&SelectionTab::sliderMove, this, _1), positionsToShow, (int)curItems.size(), 0, false, CSlider::BLUE);
+	slider = std::make_shared<CSlider>(Point(372, 86), tabType != ESelectionScreen::saveGame ? 480 : 430, std::bind(&SelectionTab::sliderMove, this, _1), positionsToShow, (int)curItems.size(), 0, Orientation::VERTICAL, CSlider::BLUE);
 	slider->setPanningStep(24);
+
+	// create scroll bounds that encompass all area in this UI element to the left of slider (including area of slider itself)
+	// entire screen can't be used in here since map description might also have slider
+	slider->setScrollBounds(Rect(pos.x - slider->pos.x, 0, slider->pos.x + slider->pos.w - pos.x, slider->pos.h ));
 	filter(0);
 }
 

--- a/client/mapView/MapViewActions.cpp
+++ b/client/mapView/MapViewActions.cpp
@@ -63,7 +63,7 @@ void MapViewActions::showPopupWindow()
 		adventureInt->onTileRightClicked(tile);
 }
 
-void MapViewActions::mouseMoved(const Point & cursorPosition)
+void MapViewActions::mouseMoved(const Point & cursorPosition, const Point & lastUpdateDistance)
 {
 	handleHover(cursorPosition);
 }

--- a/client/mapView/MapViewActions.h
+++ b/client/mapView/MapViewActions.h
@@ -37,6 +37,6 @@ public:
 	void gesturePinch(const Point & centerPosition, double lastUpdateFactor) override;
 	void hover(bool on) override;
 	void gesture(bool on, const Point & initialPosition, const Point & finalPosition) override;
-	void mouseMoved(const Point & cursorPosition) override;
+	void mouseMoved(const Point & cursorPosition, const Point & lastUpdateDistance) override;
 	void wheelScrolled(int distance) override;
 };

--- a/client/widgets/ObjectLists.cpp
+++ b/client/widgets/ObjectLists.cpp
@@ -92,8 +92,16 @@ CListBox::CListBox(CreateFunc create, Point Pos, Point ItemOffset, size_t Visibl
 	if(Slider & 1)
 	{
 		OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
-		slider = std::make_shared<CSlider>(SliderPos.topLeft(), SliderPos.w, std::bind(&CListBox::moveToPos, this, _1),
-			(int)VisibleSize, (int)TotalSize, (int)InitialPos, Slider & 2, Slider & 4 ? CSlider::BLUE : CSlider::BROWN);
+		slider = std::make_shared<CSlider>(
+			SliderPos.topLeft(),
+			SliderPos.w,
+			std::bind(&CListBox::moveToPos, this, _1),
+			(int)VisibleSize,
+			(int)TotalSize,
+			(int)InitialPos,
+			Slider & 2 ? Orientation::HORIZONTAL : Orientation::VERTICAL,
+			Slider & 4 ? CSlider::BLUE : CSlider::BROWN
+		);
 
 		slider->setPanningStep(itemOffset.x + itemOffset.y);
 	}

--- a/client/widgets/Slider.cpp
+++ b/client/widgets/Slider.cpp
@@ -18,26 +18,17 @@
 #include "../gui/CGuiHandler.h"
 #include "../render/Canvas.h"
 
-void CSlider::sliderClicked()
-{
-	addUsedEvents(MOVE);
-}
-
-void CSlider::mouseMoved (const Point & cursorPosition)
+void CSlider::mouseDragged(const Point & cursorPosition, const Point & lastUpdateDistance)
 {
 	double v = 0;
 	if(getOrientation() == Orientation::HORIZONTAL)
 	{
-		if(	std::abs(cursorPosition.y-(pos.y+pos.h/2)) > pos.h/2+40  ||  std::abs(cursorPosition.x-(pos.x+pos.w/2)) > pos.w/2  )
-			return;
 		v = cursorPosition.x - pos.x - 24;
 		v *= positions;
 		v /= (pos.w - 48);
 	}
 	else
 	{
-		if(std::abs(cursorPosition.x-(pos.x+pos.w/2)) > pos.w/2+40  ||  std::abs(cursorPosition.y-(pos.y+pos.h/2)) > pos.h/2  )
-			return;
 		v = cursorPosition.y - pos.y - 24;
 		v *= positions;
 		v /= (pos.h - 48);
@@ -138,20 +129,16 @@ void CSlider::clickLeft(tribool down, bool previousState)
 			pw = GH.getCursorPosition().y-pos.y-24;
 			rw = pw / (pos.h-48);
 		}
-		if(pw < -8  ||  pw > (getOrientation() == Orientation::HORIZONTAL ? pos.w : pos.h) - 40)
-			return;
-		// 		if (rw>1) return;
-		// 		if (rw<0) return;
+
 		slider->clickLeft(true, slider->isMouseLeftButtonPressed());
 		scrollTo((int)(rw * positions  +  0.5));
 		return;
 	}
-	removeUsedEvents(MOVE);
 }
 
 bool CSlider::receiveEvent(const Point &position, int eventType) const
 {
-	if (eventType != WHEEL && eventType != GESTURE)
+	if(eventType != WHEEL && eventType != GESTURE)
 	{
 		return CIntObject::receiveEvent(position, eventType);
 	}
@@ -165,7 +152,7 @@ bool CSlider::receiveEvent(const Point &position, int eventType) const
 }
 
 CSlider::CSlider(Point position, int totalw, std::function<void(int)> Moved, int Capacity, int Amount, int Value, bool Horizontal, CSlider::EStyle style)
-	: Scrollable(LCLICK, position, Horizontal ? Orientation::HORIZONTAL : Orientation::VERTICAL ),
+	: Scrollable(LCLICK | DRAG, position, Horizontal ? Orientation::HORIZONTAL : Orientation::VERTICAL ),
 	capacity(Capacity),
 	amount(Amount),
 	value(Value),
@@ -207,7 +194,6 @@ CSlider::CSlider(Point position, int totalw, std::function<void(int)> Moved, int
 
 	left->addCallback(std::bind(&CSlider::scrollPrev,this));
 	right->addCallback(std::bind(&CSlider::scrollNext,this));
-	slider->addCallback(std::bind(&CSlider::sliderClicked,this));
 
 	if(getOrientation() == Orientation::HORIZONTAL)
 	{

--- a/client/widgets/Slider.cpp
+++ b/client/widgets/Slider.cpp
@@ -40,6 +40,14 @@ void CSlider::mouseDragged(const Point & cursorPosition, const Point & lastUpdat
 	}
 }
 
+void CSlider::gesturePanning(const Point & initialPosition, const Point & currentPosition, const Point & lastUpdateDistance)
+{
+	if (getOrientation() == Orientation::VERTICAL)
+		Scrollable::gesturePanning(initialPosition, currentPosition, lastUpdateDistance);
+	else
+		mouseDragged(currentPosition, lastUpdateDistance);
+}
+
 void CSlider::setScrollBounds(const Rect & bounds )
 {
 	scrollBounds = bounds;
@@ -151,8 +159,8 @@ bool CSlider::receiveEvent(const Point &position, int eventType) const
 	return testTarget.isInside(position);
 }
 
-CSlider::CSlider(Point position, int totalw, std::function<void(int)> Moved, int Capacity, int Amount, int Value, bool Horizontal, CSlider::EStyle style)
-	: Scrollable(LCLICK | DRAG, position, Horizontal ? Orientation::HORIZONTAL : Orientation::VERTICAL ),
+CSlider::CSlider(Point position, int totalw, std::function<void(int)> Moved, int Capacity, int Amount, int Value, Orientation orientation, CSlider::EStyle style)
+	: Scrollable(LCLICK | DRAG, position, orientation ),
 	capacity(Capacity),
 	amount(Amount),
 	value(Value),

--- a/client/widgets/Slider.h
+++ b/client/widgets/Slider.h
@@ -71,6 +71,7 @@ public:
 	void keyPressed(EShortcut key) override;
 	void clickLeft(tribool down, bool previousState) override;
 	void mouseDragged(const Point & cursorPosition, const Point & lastUpdateDistance) override;
+	void gesturePanning(const Point & initialPosition, const Point & currentPosition, const Point & lastUpdateDistance) override;
 	void showAll(Canvas & to) override;
 
 	 /// @param position coordinates of slider
@@ -80,6 +81,6 @@ public:
 	 /// @param Amount total amount of elements, including not visible
 	 /// @param Value starting position
 	CSlider(Point position, int length, std::function<void(int)> Moved, int Capacity, int Amount,
-		int Value=0, bool Horizontal=true, EStyle style = BROWN);
+		int Value, Orientation orientation, EStyle style = BROWN);
 	~CSlider();
 };

--- a/client/widgets/Slider.h
+++ b/client/widgets/Slider.h
@@ -37,7 +37,6 @@ class CSlider : public Scrollable
 	CFunctionList<void(int)> moved;
 
 	void updateSliderPos();
-	void sliderClicked();
 
 public:
 	enum EStyle
@@ -71,7 +70,7 @@ public:
 	bool receiveEvent(const Point & position, int eventType) const override;
 	void keyPressed(EShortcut key) override;
 	void clickLeft(tribool down, bool previousState) override;
-	void mouseMoved (const Point & cursorPosition) override;
+	void mouseDragged(const Point & cursorPosition, const Point & lastUpdateDistance) override;
 	void showAll(Canvas & to) override;
 
 	 /// @param position coordinates of slider

--- a/client/widgets/TextControls.cpp
+++ b/client/widgets/TextControls.cpp
@@ -349,8 +349,10 @@ void CTextBox::setText(const std::string & text)
 
 		OBJECT_CONSTRUCTION_CUSTOM_CAPTURING(255 - DISPOSE);
 		slider = std::make_shared<CSlider>(Point(pos.w - 32, 0), pos.h, std::bind(&CTextBox::sliderMoved, this, _1),
-			label->pos.h, label->textSize.y, 0, false, CSlider::EStyle(sliderStyle));
+			label->pos.h, label->textSize.y, 0, Orientation::VERTICAL, CSlider::EStyle(sliderStyle));
 		slider->setScrollStep((int)graphics->fonts[label->font]->getLineHeight());
+		slider->setPanningStep(1);
+		slider->setScrollBounds(pos - slider->pos.topLeft());
 	}
 }
 

--- a/client/windows/CCastleInterface.h
+++ b/client/windows/CCastleInterface.h
@@ -68,7 +68,8 @@ public:
 	void hover(bool on) override;
 	void clickLeft(tribool down, bool previousState) override;
 	void showPopupWindow() override;
-	void mouseMoved (const Point & cursorPosition) override;
+	void mouseMoved (const Point & cursorPosition, const Point & lastUpdateDistance) override;
+	bool receiveEvent(const Point & position, int eventType) const override;
 	void tick(uint32_t msPassed) override;
 	void show(Canvas & to) override;
 	void showAll(Canvas & to) override;

--- a/client/windows/CQuestLog.cpp
+++ b/client/windows/CQuestLog.cpp
@@ -134,7 +134,8 @@ CQuestLog::CQuestLog (const std::vector<QuestInfo> & Quests)
 	// Both button and lable are shifted to -2px by x and y to not make them actually look like they're on same line with quests list and ok button
 	hideCompleteButton = std::make_shared<CToggleButton>(Point(10, 396), "sysopchk.def", CButton::tooltipLocalized("vcmi.questLog.hideComplete"), std::bind(&CQuestLog::toggleComplete, this, _1));
 	hideCompleteLabel = std::make_shared<CLabel>(46, 398, FONT_MEDIUM, ETextAlignment::TOPLEFT, Colors::WHITE, CGI->generaltexth->translate("vcmi.questLog.hideComplete.hover"));
-	slider = std::make_shared<CSlider>(Point(166, 195), 191, std::bind(&CQuestLog::sliderMoved, this, _1), QUEST_COUNT, 0, false, CSlider::BROWN);
+	slider = std::make_shared<CSlider>(Point(166, 195), 191, std::bind(&CQuestLog::sliderMoved, this, _1), QUEST_COUNT, 0, 0, Orientation::VERTICAL, CSlider::BROWN);
+	slider->setPanningStep(32);
 
 	recreateLabelList();
 	recreateQuestList(0);

--- a/client/windows/CQuestLog.h
+++ b/client/windows/CQuestLog.h
@@ -66,7 +66,7 @@ class CQuestMinimap : public CMinimap
 
 	void clickLeft(tribool down, bool previousState) override{}; //minimap ignores clicking on its surface
 	void iconClicked();
-	void mouseMoved (const Point & cursorPosition) override{};
+	void mouseDragged(const Point & cursorPosition, const Point & lastUpdateDistance) override{};
 
 public:
 	const QuestInfo * currentQuest;

--- a/client/windows/CTradeWindow.cpp
+++ b/client/windows/CTradeWindow.cpp
@@ -716,7 +716,7 @@ CMarketplaceWindow::CMarketplaceWindow(const IMarket * Market, const CGHeroInsta
 
 	if(sliderNeeded)
 	{
-		slider = std::make_shared<CSlider>(Point(231, 490),137, std::bind(&CMarketplaceWindow::sliderMoved,this,_1),0,0);
+		slider = std::make_shared<CSlider>(Point(231, 490), 137, std::bind(&CMarketplaceWindow::sliderMoved, this, _1), 0, 0, 0, Orientation::HORIZONTAL);
 		max = std::make_shared<CButton>(Point(229, 520), "IRCBTNS.DEF", CGI->generaltexth->zelp[596], [&](){ setMax(); });
 		max->block(true);
 	}
@@ -1117,7 +1117,7 @@ CAltarWindow::CAltarWindow(const IMarket * Market, const CGHeroInstance * Hero, 
 		 //To sacrifice creatures, move them from your army on to the Altar and click Sacrifice
 		new CTextBox(CGI->generaltexth->allTexts[480], Rect(320, 56, 256, 40), 0, FONT_SMALL, ETextAlignment::CENTER, Colors::YELLOW);
 
-		slider = std::make_shared<CSlider>(Point(231,481),137,std::bind(&CAltarWindow::sliderMoved,this,_1),0,0);
+		slider = std::make_shared<CSlider>(Point(231, 481), 137, std::bind(&CAltarWindow::sliderMoved, this, _1), 0, 0, 0, Orientation::HORIZONTAL);
 		max = std::make_shared<CButton>(Point(147, 520), "IRCBTNS.DEF", CGI->generaltexth->zelp[578], std::bind(&CSlider::scrollToMax, slider));
 
 		sacrificedUnits.resize(GameConstants::ARMY_SIZE, 0);

--- a/client/windows/CreaturePurchaseCard.cpp
+++ b/client/windows/CreaturePurchaseCard.cpp
@@ -75,7 +75,7 @@ void CreaturePurchaseCard::updateAmountInfo(int value)
 
 void CreaturePurchaseCard::initSlider()
 {
-	slider = std::make_shared<CSlider>(Point(pos.x, pos.y + 158), 102, std::bind(&CreaturePurchaseCard::sliderMoved, this , _1), 0, maxAmount, 0);
+	slider = std::make_shared<CSlider>(Point(pos.x, pos.y + 158), 102, std::bind(&CreaturePurchaseCard::sliderMoved, this, _1), 0, maxAmount, 0, Orientation::HORIZONTAL);
 }
 
 void CreaturePurchaseCard::initCostBox()

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -215,7 +215,7 @@ CRecruitmentWindow::CRecruitmentWindow(const CGDwelling * Dwelling, int Level, c
 
 	statusbar = CGStatusBar::create(std::make_shared<CPicture>(background->getSurface(), Rect(8, pos.h - 26, pos.w - 16, 19), 8, pos.h - 26));
 
-	slider = std::make_shared<CSlider>(Point(176,279),135,std::bind(&CRecruitmentWindow::sliderMoved,this, _1),0,0,0,true);
+	slider = std::make_shared<CSlider>(Point(176, 279), 135, std::bind(&CRecruitmentWindow::sliderMoved, this, _1), 0, 0, 0, Orientation::HORIZONTAL);
 
 	maxButton = std::make_shared<CButton>(Point(134, 313), "IRCBTNS.DEF", CGI->generaltexth->zelp[553], std::bind(&CSlider::scrollToMax, slider), EShortcut::RECRUITMENT_MAX);
 	buyButton = std::make_shared<CButton>(Point(212, 313), "IBY6432.DEF", CGI->generaltexth->zelp[554], std::bind(&CRecruitmentWindow::buy, this), EShortcut::GLOBAL_ACCEPT);
@@ -338,7 +338,7 @@ CSplitWindow::CSplitWindow(const CCreature * creature, std::function<void(int, i
 	animLeft = std::make_shared<CCreaturePic>(20, 54, creature, true, false);
 	animRight = std::make_shared<CCreaturePic>(177, 54,creature, true, false);
 
-	slider = std::make_shared<CSlider>(Point(21, 194), 257, std::bind(&CSplitWindow::sliderMoved, this, _1), 0, sliderPosition, rightAmount - rightMin, true);
+	slider = std::make_shared<CSlider>(Point(21, 194), 257, std::bind(&CSplitWindow::sliderMoved, this, _1), 0, sliderPosition, rightAmount - rightMin, Orientation::HORIZONTAL);
 
 	std::string titleStr = CGI->generaltexth->allTexts[256];
 	boost::algorithm::replace_first(titleStr,"%s", creature->getNamePluralTranslated());

--- a/lib/Rect.h
+++ b/lib/Rect.h
@@ -109,6 +109,11 @@ public:
 		return Rect(x+p.x,y+p.y,w,h);
 	}
 
+	Rect operator-(const Point &p) const
+	{
+		return Rect(x-p.x,y-p.y,w,h);
+	}
+
 	Rect& operator=(const Rect &p)
 	{
 		x = p.x;


### PR DESCRIPTION
Fixes #2212

Changes:
- Added "drag" UI event that is triggered by moving mouse while left button is pressed
- Fixed slider dragging if cursor goes outside dragging area
- For all horizontal sliders, swiping will act like dragging - slider position will be moved to cursor/touch position
- For all vertical sliders, swiping works as before - as list scrolling