### PR TITLE
Crash fix. Cosmetic fixes.

### DIFF
--- a/lib/ArtifactUtils.cpp
+++ b/lib/ArtifactUtils.cpp
@@ -204,7 +204,7 @@ DLL_LINKAGE CArtifactInstance * ArtifactUtils::createArtifact(CMap * map, const 
 			art = ArtifactUtils::createScroll(SpellID(spellID));
 		}
 	}
-	else //TODO: create combined artifact instance for random artifacts, just in case
+	else
 	{
 		art = new CArtifactInstance(); // random, empty
 	}

--- a/lib/CArtHandler.cpp
+++ b/lib/CArtHandler.cpp
@@ -849,12 +849,12 @@ bool CArtifactInstance::canBePutAt(const ArtifactLocation & al, bool assumeDestR
 	return artType->canBePutAt(al.getHolderArtSet(), al.slot, assumeDestRemoved);
 }
 
-void CArtifactInstance::putAt(ArtifactLocation al)
+void CArtifactInstance::putAt(const ArtifactLocation & al)
 {
 	al.getHolderArtSet()->putArtifact(al.slot, this);
 }
 
-void CArtifactInstance::removeFrom(ArtifactLocation al)
+void CArtifactInstance::removeFrom(const ArtifactLocation & al)
 {
 	al.getHolderArtSet()->removeArtifact(al.slot);
 }
@@ -917,7 +917,7 @@ void CCombinedArtifactInstance::addAsConstituent(CArtifactInstance * art, const 
 	attachTo(*art);
 }
 
-void CCombinedArtifactInstance::removeFrom(ArtifactLocation al)
+void CCombinedArtifactInstance::removeFrom(const ArtifactLocation & al)
 {
 	CArtifactInstance::removeFrom(al);
 	for(auto & part : constituentsInfo)

--- a/lib/CArtHandler.cpp
+++ b/lib/CArtHandler.cpp
@@ -1110,7 +1110,7 @@ void CArtifactSet::putArtifact(ArtifactPosition slot, CArtifactInstance * art)
 					part.slot = ArtifactUtils::getArtAnyPosition(this, part.art->getTypeId());
 
 				assert(ArtifactUtils::isSlotEquipment(part.slot));
-				setNewArtSlot(part.slot, art, true);
+				setNewArtSlot(part.slot, part.art, true);
 			}
 		}
 	}

--- a/lib/CArtHandler.cpp
+++ b/lib/CArtHandler.cpp
@@ -819,9 +819,6 @@ void CArtifactInstance::init()
 std::string CArtifactInstance::getDescription() const
 {
 	std::string text = artType->getDescriptionTranslated();
-	if (!vstd::contains(text, '{'))
-		text = '{' + artType->getNameTranslated() + "}\n\n" + text; //workaround for new artifacts with single name, turns it to H3-style
-
 	if(artType->getId() == ArtifactID::SPELL_SCROLL)
 	{
 		// we expect scroll description to be like this: This scroll contains the [spell name] spell which is added into your spell book for as long as you carry the scroll.

--- a/lib/CArtHandler.h
+++ b/lib/CArtHandler.h
@@ -162,8 +162,8 @@ public:
 	/// of itself, additionally truth is returned for constituents of combined arts
 	virtual bool isPart(const CArtifactInstance *supposedPart) const;
 
-	virtual void putAt(ArtifactLocation al);
-	virtual void removeFrom(ArtifactLocation al);
+	virtual void putAt(const ArtifactLocation & al);
+	virtual void removeFrom(const ArtifactLocation & al);
 	virtual void move(const ArtifactLocation & src, const ArtifactLocation & dst);
 
 	template <typename Handler> void serialize(Handler &h, const int version)
@@ -198,7 +198,7 @@ public:
 	bool isPart(const CArtifactInstance *supposedPart) const override;
 	void createConstituents();
 	void addAsConstituent(CArtifactInstance * art, const ArtifactPosition & slot);
-	void removeFrom(ArtifactLocation al) override;
+	void removeFrom(const ArtifactLocation & al) override;
 
 	CCombinedArtifactInstance() = default;
 

--- a/lib/CCreatureSet.cpp
+++ b/lib/CCreatureSet.cpp
@@ -882,9 +882,8 @@ void CStackInstance::removeArtifact(ArtifactPosition pos)
 {
 	assert(getArt(pos));
 
+	detachFrom(*getArt(pos));
 	CArtifactSet::removeArtifact(pos);
-	if(ArtifactUtils::isSlotEquipment(pos))
-		detachFrom(*getArt(pos));
 }
 
 void CStackInstance::serializeJson(JsonSerializeFormat & handler)

--- a/lib/NetPacks.h
+++ b/lib/NetPacks.h
@@ -782,20 +782,6 @@ struct DLL_LINKAGE SetAvailableArtifacts : public CPackForClient
 	}
 };
 
-struct DLL_LINKAGE NewArtifact : public CPackForClient
-{
-	void applyGs(CGameState * gs);
-
-	ConstTransitivePtr<CArtifactInstance> art;
-
-	virtual void visitTyped(ICPackVisitor & visitor) override;
-
-	template <typename Handler> void serialize(Handler & h, const int version)
-	{
-		h & art;
-	}
-};
-
 struct DLL_LINKAGE CGarrisonOperationPack : CPackForClient
 {
 };
@@ -981,6 +967,19 @@ struct DLL_LINKAGE PutArtifact : CArtifactOperationPack
 	{
 		h & al;
 		h & askAssemble;
+		h & art;
+	}
+};
+
+struct DLL_LINKAGE NewArtifact : public CArtifactOperationPack
+{
+	ConstTransitivePtr<CArtifactInstance> art;
+
+	void applyGs(CGameState * gs);
+	virtual void visitTyped(ICPackVisitor & visitor) override;
+
+	template <typename Handler> void serialize(Handler & h, const int version)
+	{
 		h & art;
 	}
 };

--- a/lib/NetPacksBase.h
+++ b/lib/NetPacksBase.h
@@ -192,7 +192,7 @@ struct ArtifactLocation
 	DLL_LINKAGE PlayerColor owningPlayer() const;
 	DLL_LINKAGE CArtifactSet *getHolderArtSet();
 	DLL_LINKAGE CBonusSystemNode *getHolderNode();
-	DLL_LINKAGE const CArtifactSet *getHolderArtSet() const;
+	DLL_LINKAGE CArtifactSet *getHolderArtSet() const;
 	DLL_LINKAGE const CBonusSystemNode *getHolderNode() const;
 
 	DLL_LINKAGE const CArtifactInstance *getArt() const;

--- a/lib/NetPacksLib.cpp
+++ b/lib/NetPacksLib.cpp
@@ -1620,7 +1620,7 @@ const CArtifactInstance *ArtifactLocation::getArt() const
 		return nullptr;
 }
 
-const CArtifactSet * ArtifactLocation::getHolderArtSet() const
+CArtifactSet * ArtifactLocation::getHolderArtSet() const
 {
 	auto * t = const_cast<ArtifactLocation *>(this);
 	return t->getHolderArtSet();


### PR DESCRIPTION
Fixed crash when unequip commander artifacts (regression).

I also noticed that CGrowingArtifact is used only for commander artifacts. Perhaps it makes sense add the same "growing" property to the hero's artifacts?