### PR TITLE
Fixed overlapped text display in adventure map settings

### DIFF
--- a/client/gui/InterfaceObjectConfigurable.cpp
+++ b/client/gui/InterfaceObjectConfigurable.cpp
@@ -487,7 +487,14 @@ class InterfaceLayoutWidget : public CIntObject
 {
 public:
 	std::vector<std::shared_ptr<CIntObject>> ownedChildren;
+	InterfaceLayoutWidget();
 };
+
+InterfaceLayoutWidget::InterfaceLayoutWidget()
+	:CIntObject() 
+{
+	type |= REDRAW_PARENT;
+}
 
 std::shared_ptr<CIntObject> InterfaceObjectConfigurable::buildLayout(const JsonNode & config)
 {

--- a/config/widgets/settings/adventureOptionsTab.json
+++ b/config/widgets/settings/adventureOptionsTab.json
@@ -53,13 +53,13 @@
 			"items":
 			[
 				{
-					"name": "heroSpeedValueLabel",
+					"name": "heroSpeedValueLabel"
 				},
 				{
-					"name": "enemySpeedValueLabel",
+					"name": "enemySpeedValueLabel"
 				},
 				{
-					"name": "mapScrollingValueLabel",
+					"name": "mapScrollingValueLabel"
 				}
 			]
 		},


### PR DESCRIPTION
This PR is to fix issue #2189 