### PR TITLE
Adventure map fixes for 1.3

### DIFF
--- a/AI/Nullkiller/AIGateway.cpp
+++ b/AI/Nullkiller/AIGateway.cpp
@@ -448,6 +448,12 @@ void AIGateway::battleResultsApplied()
 	status.setBattle(NO_BATTLE);
 }
 
+void AIGateway::beforeObjectPropertyChanged(const SetObjectProperty * sop)
+{
+
+}
+
+
 void AIGateway::objectPropertyChanged(const SetObjectProperty * sop)
 {
 	LOG_TRACE(logAi);

--- a/AI/Nullkiller/AIGateway.h
+++ b/AI/Nullkiller/AIGateway.h
@@ -161,6 +161,7 @@ public:
 	void heroManaPointsChanged(const CGHeroInstance * hero) override;
 	void heroSecondarySkillChanged(const CGHeroInstance * hero, int which, int val) override;
 	void battleResultsApplied() override;
+	void beforeObjectPropertyChanged(const SetObjectProperty * sop) override;
 	void objectPropertyChanged(const SetObjectProperty * sop) override;
 	void buildChanged(const CGTownInstance * town, BuildingID buildingID, int what) override;
 	void heroBonusChanged(const CGHeroInstance * hero, const Bonus & bonus, bool gain) override;

--- a/AI/VCAI/VCAI.cpp
+++ b/AI/VCAI/VCAI.cpp
@@ -538,6 +538,11 @@ void VCAI::battleResultsApplied()
 	status.setBattle(NO_BATTLE);
 }
 
+void VCAI::beforeObjectPropertyChanged(const SetObjectProperty * sop)
+{
+
+}
+
 void VCAI::objectPropertyChanged(const SetObjectProperty * sop)
 {
 	LOG_TRACE(logAi);

--- a/AI/VCAI/VCAI.h
+++ b/AI/VCAI/VCAI.h
@@ -194,6 +194,7 @@ public:
 	void heroManaPointsChanged(const CGHeroInstance * hero) override;
 	void heroSecondarySkillChanged(const CGHeroInstance * hero, int which, int val) override;
 	void battleResultsApplied() override;
+	void beforeObjectPropertyChanged(const SetObjectProperty * sop) override;
 	void objectPropertyChanged(const SetObjectProperty * sop) override;
 	void buildChanged(const CGTownInstance * town, BuildingID buildingID, int what) override;
 	void heroBonusChanged(const CGHeroInstance * hero, const Bonus & bonus, bool gain) override;

--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -1317,11 +1317,8 @@ void CPlayerInterface::heroExchangeStarted(ObjectInstanceID hero1, ObjectInstanc
 	GH.windows().createAndPushWindow<CExchangeWindow>(hero1, hero2, query);
 }
 
-void CPlayerInterface::objectPropertyChanged(const SetObjectProperty * sop)
+void CPlayerInterface::beforeObjectPropertyChanged(const SetObjectProperty * sop)
 {
-	EVENT_HANDLER_CALLED_BY_CLIENT;
-
-	//redraw minimap if owner changed
 	if (sop->what == ObjProperty::OWNER)
 	{
 		const CGObjectInstance * obj = cb->getObj(sop->id);
@@ -1331,13 +1328,34 @@ void CPlayerInterface::objectPropertyChanged(const SetObjectProperty * sop)
 			auto town = static_cast<const CGTownInstance *>(obj);
 
 			if(obj->tempOwner == playerID)
-				localState->addOwnedTown(town);
-			else
+			{
 				localState->removeOwnedTown(town);
+				adventureInt->onTownChanged(town);
+			}
+		}
+	}
+}
 
-			adventureInt->onTownChanged(town);
+void CPlayerInterface::objectPropertyChanged(const SetObjectProperty * sop)
+{
+	EVENT_HANDLER_CALLED_BY_CLIENT;
+
+	if (sop->what == ObjProperty::OWNER)
+	{
+		const CGObjectInstance * obj = cb->getObj(sop->id);
+
+		if(obj->ID == Obj::TOWN)
+		{
+			auto town = static_cast<const CGTownInstance *>(obj);
+
+			if(obj->tempOwner == playerID)
+			{
+				localState->addOwnedTown(town);
+				adventureInt->onTownChanged(town);
+			}
 		}
 
+		//redraw minimap if owner changed
 		std::set<int3> pos = obj->getBlockedPos();
 		std::unordered_set<int3> upos(pos.begin(), pos.end());
 		adventureInt->onMapTilesChanged(upos);

--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -183,7 +183,10 @@ void CPlayerInterface::playerStartsTurn(PlayerColor player)
 	if (player != playerID && LOCPLINT == this)
 	{
 		waitWhileDialog();
-		adventureInt->onEnemyTurnStarted(player);
+
+		bool isHuman = cb->getStartInfo()->playerInfos.count(player) && cb->getStartInfo()->playerInfos.at(player).isControlledByHuman();
+
+		adventureInt->onEnemyTurnStarted(player, isHuman);
 	}
 }
 

--- a/client/CPlayerInterface.h
+++ b/client/CPlayerInterface.h
@@ -144,6 +144,7 @@ protected: // Call-ins from server, should not be called directly, but only via 
 	void requestRealized(PackageApplied *pa) override;
 	void heroExchangeStarted(ObjectInstanceID hero1, ObjectInstanceID hero2, QueryID query) override;
 	void centerView (int3 pos, int focusTime) override;
+	void beforeObjectPropertyChanged(const SetObjectProperty * sop) override;
 	void objectPropertyChanged(const SetObjectProperty * sop) override;
 	void objectRemoved(const CGObjectInstance *obj) override;
 	void objectRemovedAfter() override;

--- a/client/ClientNetPackVisitors.h
+++ b/client/ClientNetPackVisitors.h
@@ -128,4 +128,5 @@ public:
 	virtual void visitBattleStackMoved(BattleStackMoved & pack) override;
 	virtual void visitBattleAttack(BattleAttack & pack) override;
 	virtual void visitStartAction(StartAction & pack) override;
+	virtual void visitSetObjectProperty(SetObjectProperty & pack) override;
 };

--- a/client/NetPacksClient.cpp
+++ b/client/NetPacksClient.cpp
@@ -611,6 +611,20 @@ void ApplyClientNetPackVisitor::visitInfoWindow(InfoWindow & pack)
 		logNetwork->warn("We received InfoWindow for not our player...");
 }
 
+void ApplyFirstClientNetPackVisitor::visitSetObjectProperty(SetObjectProperty & pack)
+{
+	//inform all players that see this object
+	for(auto it = cl.playerint.cbegin(); it != cl.playerint.cend(); ++it)
+	{
+		if(gs.isVisible(gs.getObjInstance(pack.id), it->first))
+			callInterfaceIfPresent(cl, it->first, &IGameEventsReceiver::beforeObjectPropertyChanged, &pack);
+	}
+
+	// invalidate section of map view with our object and force an update with new flag color
+	if (pack.what == ObjProperty::OWNER)
+		CGI->mh->onObjectInstantRemove(gs.getObjInstance(pack.id));
+}
+
 void ApplyClientNetPackVisitor::visitSetObjectProperty(SetObjectProperty & pack)
 {
 	//inform all players that see this object
@@ -620,12 +634,9 @@ void ApplyClientNetPackVisitor::visitSetObjectProperty(SetObjectProperty & pack)
 			callInterfaceIfPresent(cl, it->first, &IGameEventsReceiver::objectPropertyChanged, &pack);
 	}
 
+	// invalidate section of map view with our object and force an update with new flag color
 	if (pack.what == ObjProperty::OWNER)
-	{
-		// invalidate section of map view with our object and force an update with new flag color
-		CGI->mh->onObjectInstantRemove(gs.getObjInstance(pack.id));
 		CGI->mh->onObjectInstantAdd(gs.getObjInstance(pack.id));
-	}
 }
 
 void ApplyClientNetPackVisitor::visitHeroLevelUp(HeroLevelUp & pack)

--- a/client/adventureMap/AdventureMapInterface.cpp
+++ b/client/adventureMap/AdventureMapInterface.cpp
@@ -318,7 +318,6 @@ void AdventureMapInterface::onEnemyTurnStarted(PlayerColor playerID)
 	widget->getMinimap()->setAIRadar(true);
 	widget->getInfoBar()->startEnemyTurn(LOCPLINT->cb->getCurrentPlayer());
 	setState(EAdventureState::ENEMY_TURN);
-
 }
 
 void AdventureMapInterface::setState(EAdventureState state)
@@ -333,17 +332,8 @@ void AdventureMapInterface::adjustActiveness()
 	bool widgetMustBeActive = isActive() && shortcuts->optionSidePanelActive();
 	bool mapViewMustBeActive = isActive() && (shortcuts->optionMapViewActive());
 
-	if (widgetMustBeActive && !widget->isActive())
-		widget->activate();
-
-	if (!widgetMustBeActive && widget->isActive())
-		widget->deactivate();
-
-	if (mapViewMustBeActive && !widget->getMapView()->isActive())
-		widget->getMapView()->activate();
-
-	if (!mapViewMustBeActive && widget->getMapView()->isActive())
-		widget->getMapView()->deactivate();
+	widget->setInputEnabled(widgetMustBeActive);
+	widget->getMapView()->setInputEnabled(mapViewMustBeActive);
 }
 
 void AdventureMapInterface::onCurrentPlayerChanged(PlayerColor playerID)

--- a/client/adventureMap/AdventureMapInterface.cpp
+++ b/client/adventureMap/AdventureMapInterface.cpp
@@ -137,6 +137,9 @@ void AdventureMapInterface::deactivate()
 {
 	CIntObject::deactivate();
 	CCS->curh->set(Cursor::Map::POINTER);
+
+	if(LOCPLINT)
+		LOCPLINT->cingconsole->deactivate();
 }
 
 void AdventureMapInterface::showAll(Canvas & to)

--- a/client/adventureMap/AdventureMapInterface.cpp
+++ b/client/adventureMap/AdventureMapInterface.cpp
@@ -83,8 +83,11 @@ void AdventureMapInterface::onAudioPaused()
 
 void AdventureMapInterface::onHeroMovementStarted(const CGHeroInstance * hero)
 {
-	widget->getInfoBar()->popAll();
-	widget->getInfoBar()->showSelection();
+	if (shortcuts->optionMapViewActive())
+	{
+		widget->getInfoBar()->popAll();
+		widget->getInfoBar()->showSelection();
+	}
 }
 
 void AdventureMapInterface::onHeroChanged(const CGHeroInstance *h)

--- a/client/adventureMap/AdventureMapInterface.cpp
+++ b/client/adventureMap/AdventureMapInterface.cpp
@@ -309,13 +309,13 @@ void AdventureMapInterface::onHotseatWaitStarted(PlayerColor playerID)
 	setState(EAdventureState::HOTSEAT_WAIT);
 }
 
-void AdventureMapInterface::onEnemyTurnStarted(PlayerColor playerID)
+void AdventureMapInterface::onEnemyTurnStarted(PlayerColor playerID, bool isHuman)
 {
 	if(settings["session"]["spectate"].Bool())
 		return;
 
 	mapAudio->onEnemyTurnStarted();
-	widget->getMinimap()->setAIRadar(true);
+	widget->getMinimap()->setAIRadar(!isHuman);
 	widget->getInfoBar()->startEnemyTurn(LOCPLINT->cb->getCurrentPlayer());
 	setState(EAdventureState::ENEMY_TURN);
 }

--- a/client/adventureMap/AdventureMapInterface.h
+++ b/client/adventureMap/AdventureMapInterface.h
@@ -115,7 +115,7 @@ public:
 	void onHotseatWaitStarted(PlayerColor playerID);
 
 	/// Called by PlayerInterface when AI or remote human player starts his turn
-	void onEnemyTurnStarted(PlayerColor playerID);
+	void onEnemyTurnStarted(PlayerColor playerID, bool isHuman);
 
 	/// Called by PlayerInterface when local human player starts his turn
 	void onPlayerTurnStarted(PlayerColor playerID);

--- a/client/adventureMap/AdventureMapShortcuts.cpp
+++ b/client/adventureMap/AdventureMapShortcuts.cpp
@@ -402,7 +402,7 @@ bool AdventureMapShortcuts::optionCanViewQuests()
 
 bool AdventureMapShortcuts::optionCanToggleLevel()
 {
-	return optionInMapView() && LOCPLINT->cb->getMapSize().z > 0;
+	return optionInMapView() && LOCPLINT->cb->getMapSize().z > 1;
 }
 
 bool AdventureMapShortcuts::optionMapLevelSurface()

--- a/client/adventureMap/CInGameConsole.cpp
+++ b/client/adventureMap/CInGameConsole.cpp
@@ -34,7 +34,7 @@ CInGameConsole::CInGameConsole()
 	: CIntObject(KEYBOARD | TIME | TEXTINPUT)
 	, prevEntDisp(-1)
 {
-	type |= REDRAW_PARENT;
+	setRedrawParent(true);
 }
 
 void CInGameConsole::showAll(Canvas & to)

--- a/client/adventureMap/CInGameConsole.cpp
+++ b/client/adventureMap/CInGameConsole.cpp
@@ -104,6 +104,7 @@ void CInGameConsole::print(const std::string & txt)
 	}
 
 	GH.windows().totalRedraw(); // FIXME: ingame console has no parent widget set
+	CCS->soundh->playSound("CHAT");
 }
 
 void CInGameConsole::keyPressed (EShortcut key)
@@ -134,11 +135,6 @@ void CInGameConsole::keyPressed (EShortcut key)
 			{
 				bool anyTextExceptCaret = enteredText.size() > 1;
 				endEnteringText(anyTextExceptCaret);
-
-				if(anyTextExceptCaret)
-				{
-					CCS->soundh->playSound("CHAT");
-				}
 			}
 			break;
 		}

--- a/client/adventureMap/CInGameConsole.h
+++ b/client/adventureMap/CInGameConsole.h
@@ -50,6 +50,7 @@ public:
 	void keyPressed(EShortcut key) override;
 	void textInputed(const std::string & enteredText) override;
 	void textEdited(const std::string & enteredText) override;
+	bool captureThisKey(EShortcut key) override;
 
 	void startEnteringText();
 	void endEnteringText(bool processEnteredText);

--- a/client/adventureMap/CMinimap.cpp
+++ b/client/adventureMap/CMinimap.cpp
@@ -231,7 +231,7 @@ void CMinimap::setAIRadar(bool on)
 	redraw();
 }
 
-void CMinimap::updateTiles(std::unordered_set<int3> positions)
+void CMinimap::updateTiles(const std::unordered_set<int3> & positions)
 {
 	if(minimap)
 	{

--- a/client/adventureMap/CMinimap.h
+++ b/client/adventureMap/CMinimap.h
@@ -68,6 +68,6 @@ public:
 
 	void showAll(Canvas & to) override;
 
-	void updateTiles(std::unordered_set<int3> positions);
+	void updateTiles(const std::unordered_set<int3> & positions);
 };
 

--- a/client/eventsSDL/InputSourceKeyboard.cpp
+++ b/client/eventsSDL/InputSourceKeyboard.cpp
@@ -33,6 +33,12 @@ void InputSourceKeyboard::handleEventKeyDown(const SDL_KeyboardEvent & key)
 	if(key.repeat != 0)
 		return; // ignore periodic event resends
 
+	if (SDL_IsTextInputActive() == SDL_TRUE)
+	{
+		if (key.keysym.sym >= ' ' && key.keysym.sym < 0x80)
+			return; // printable character - will be handled as text input
+	}
+
 	assert(key.state == SDL_PRESSED);
 
 	if(key.keysym.sym >= SDLK_F1 && key.keysym.sym <= SDLK_F15 && settings["session"]["spectate"].Bool())
@@ -76,6 +82,12 @@ void InputSourceKeyboard::handleEventKeyUp(const SDL_KeyboardEvent & key)
 {
 	if(key.repeat != 0)
 		return; // ignore periodic event resends
+
+	if (SDL_IsTextInputActive() == SDL_TRUE)
+	{
+		if (key.keysym.sym >= ' ' && key.keysym.sym < 0x80)
+			return; // printable character - will be handled as text input
+	}
 
 	assert(key.state == SDL_RELEASED);
 

--- a/client/eventsSDL/InputSourceMouse.cpp
+++ b/client/eventsSDL/InputSourceMouse.cpp
@@ -18,6 +18,12 @@
 #include "../gui/MouseButton.h"
 
 #include <SDL_events.h>
+#include <SDL_hints.h>
+
+InputSourceMouse::InputSourceMouse()
+{
+	SDL_SetHint(SDL_HINT_MOUSE_FOCUS_CLICKTHROUGH, "1");
+}
 
 void InputSourceMouse::handleEventMouseMotion(const SDL_MouseMotionEvent & motion)
 {

--- a/client/eventsSDL/InputSourceMouse.h
+++ b/client/eventsSDL/InputSourceMouse.h
@@ -24,6 +24,8 @@ class InputSourceMouse
 	Point middleClickPosition;
 	int mouseButtonsMask = 0;
 public:
+	InputSourceMouse();
+
 	void handleEventMouseMotion(const SDL_MouseMotionEvent & current);
 	void handleEventMouseButtonDown(const SDL_MouseButtonEvent & current);
 	void handleEventMouseWheel(const SDL_MouseWheelEvent & current);

--- a/client/gui/CIntObject.cpp
+++ b/client/gui/CIntObject.cpp
@@ -37,8 +37,6 @@ CIntObject::~CIntObject()
 	if(isActive())
 		deactivate();
 
-	GH.events().assertElementInactive(this);
-
 	while(!children.empty())
 	{
 		if((defActions & DISPOSE) && (children.front()->recActions & DISPOSE))
@@ -104,7 +102,7 @@ void CIntObject::deactivate()
 
 void CIntObject::addUsedEvents(ui16 newActions)
 {
-	if (isActive())
+	if (isActive() && inputEnabled)
 		activateEvents(~used & newActions);
 	used |= newActions;
 }

--- a/client/gui/CIntObject.h
+++ b/client/gui/CIntObject.h
@@ -47,11 +47,10 @@ class CIntObject : public IShowActivatable, public AEventsReceiver //interface o
 	//non-const versions of fields to allow changing them in CIntObject
 	CIntObject *parent_m; //parent object
 
-public:
-	//redraw parent flag - this int may be semi-transparent and require redraw of parent window
-	enum {REDRAW_PARENT=8};
-	int type; //bin flags using etype
+	bool inputEnabled;
+	bool redrawParent;
 
+public:
 	std::vector<CIntObject *> children;
 
 	/// read-only parent access. May not be a "clean" solution but allows some compatibility
@@ -81,6 +80,13 @@ public:
 	void enable();
 	/// deactivates or activates UI element based on flag
 	void setEnabled(bool on);
+
+	/// Block (or allow) all user input, e.g. mouse/keyboard/touch without hiding element
+	void setInputEnabled(bool on);
+
+	/// Mark this input as one that requires parent redraw on update,
+	/// for example if current control might have semi-transparent elements and requires redrawing of background
+	void setRedrawParent(bool on);
 
 	// activate or deactivate object. Inactive object won't receive any input events (keyboard\mouse)
 	// usually used automatically by parent

--- a/client/gui/CIntObject.h
+++ b/client/gui/CIntObject.h
@@ -62,10 +62,8 @@ public:
 	CIntObject(int used=0, Point offset=Point());
 	virtual ~CIntObject();
 
-	//keyboard handling
-	bool captureAllKeys; //if true, only this object should get info about pressed keys
-
-	bool captureThisKey(EShortcut key) override; //allows refining captureAllKeys against specific events (eg. don't capture ENTER)
+	/// allows capturing key input so it will be delivered only to this element
+	bool captureThisKey(EShortcut key) override;
 
 	void addUsedEvents(ui16 newActions);
 	void removeUsedEvents(ui16 newActions);

--- a/client/gui/EventDispatcher.cpp
+++ b/client/gui/EventDispatcher.cpp
@@ -63,7 +63,9 @@ void EventDispatcher::dispatchTimer(uint32_t msPassed)
 	EventReceiversList hlp = timeinterested;
 	for (auto & elem : hlp)
 	{
-		if(!vstd::contains(timeinterested,elem)) continue;
+		if(!vstd::contains(timeinterested,elem))
+			continue;
+
 		elem->tick(msPassed);
 	}
 }

--- a/client/gui/InterfaceObjectConfigurable.cpp
+++ b/client/gui/InterfaceObjectConfigurable.cpp
@@ -493,7 +493,7 @@ public:
 InterfaceLayoutWidget::InterfaceLayoutWidget()
 	:CIntObject() 
 {
-	type |= REDRAW_PARENT;
+	setRedrawParent(true);
 }
 
 std::shared_ptr<CIntObject> InterfaceObjectConfigurable::buildLayout(const JsonNode & config)

--- a/client/ios/startSDL.mm
+++ b/client/ios/startSDL.mm
@@ -28,84 +28,7 @@
 
 @implementation SDLViewObserver
 
-- (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary<NSKeyValueChangeKey,id> *)change context:(void *)context {
-	[object removeObserver:self forKeyPath:keyPath];
-
-    UIView * view = [object valueForKeyPath:keyPath];
-
-    auto longPress = [[UILongPressGestureRecognizer alloc] initWithTarget:self action:@selector(handleLongPress:)];
-    longPress.minimumPressDuration = 0.2;
-    [view addGestureRecognizer:longPress];
-
-    auto pinch = [[UIPinchGestureRecognizer alloc] initWithTarget:self action:@selector(handlePinch:)];
-    [view addGestureRecognizer:pinch];
-}
-
-#pragma mark - Gestures
-
-- (void)handleLongPress:(UIGestureRecognizer *)gesture {
-    // send RMB click
-    SDL_EventType mouseButtonType;
-    switch (gesture.state)
-    {
-        case UIGestureRecognizerStateBegan:
-            mouseButtonType = SDL_MOUSEBUTTONDOWN;
-            break;
-        case UIGestureRecognizerStateEnded:
-            mouseButtonType = SDL_MOUSEBUTTONUP;
-            break;
-        default:
-            return;
-    }
-
-    auto renderer = SDL_GetRenderer(mainWindow);
-    float scaleX, scaleY;
-    SDL_Rect viewport;
-    SDL_RenderGetScale(renderer, &scaleX, &scaleY);
-    SDL_RenderGetViewport(renderer, &viewport);
-
-    auto touchedPoint = [gesture locationInView:gesture.view];
-    auto screenScale = UIScreen.mainScreen.nativeScale;
-    Sint32 x = (int)touchedPoint.x * screenScale / scaleX - viewport.x;
-    Sint32 y = (int)touchedPoint.y * screenScale / scaleY - viewport.y;
-
-    SDL_Event rmbEvent;
-    rmbEvent.button = (SDL_MouseButtonEvent){
-        .type = mouseButtonType,
-        .button = SDL_BUTTON_RIGHT,
-        .clicks = 1,
-        .x = x,
-        .y = y,
-    };
-    SDL_PushEvent(&rmbEvent);
-
-    // small hack to prevent cursor jumping
-    if (mouseButtonType == SDL_MOUSEBUTTONUP)
-        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.025 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-            SDL_Event motionEvent;
-            motionEvent.motion = (SDL_MouseMotionEvent){
-                .type = SDL_MOUSEMOTION,
-                .x = x,
-                .y = y,
-            };
-            SDL_PushEvent(&motionEvent);
-        });
-}
-
-- (void)handlePinch:(UIGestureRecognizer *)gesture {
-    if(gesture.state != UIGestureRecognizerStateBegan || CSH->state != EClientState::GAMEPLAY)
-        return;
-	[GameChatKeyboardHandler sendKeyEventWithKeyCode:SDLK_SPACE];
-}
-
-#pragma mark - UIGestureRecognizerDelegate
-
-- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldBeRequiredToFailByGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer {
-    return [gestureRecognizer isKindOfClass:[UIPinchGestureRecognizer class]];
-}
-
 @end
-
 
 int startSDL(int argc, char * argv[], BOOL startManually)
 {
@@ -113,13 +36,6 @@ int startSDL(int argc, char * argv[], BOOL startManually)
 		auto observer = [SDLViewObserver new];
 		observer.gameChatHandler = [GameChatKeyboardHandler new];
 
-		id __block sdlWindowCreationObserver = [NSNotificationCenter.defaultCenter addObserverForName:UIWindowDidBecomeKeyNotification object:nil queue:nil usingBlock:^(NSNotification * _Nonnull note) {
-			[NSNotificationCenter.defaultCenter removeObserver:sdlWindowCreationObserver];
-			sdlWindowCreationObserver = nil;
-
-			UIWindow * sdlWindow = note.object;
-			[sdlWindow.rootViewController addObserver:observer forKeyPath:NSStringFromSelector(@selector(view)) options:NSKeyValueObservingOptionNew context:NULL];
-		}];
 		id textFieldObserver = [NSNotificationCenter.defaultCenter addObserverForName:UITextFieldTextDidEndEditingNotification object:nil queue:nil usingBlock:^(NSNotification * _Nonnull note) {
 			removeFocusFromActiveInput();
 		}];

--- a/client/lobby/CSelectionBase.cpp
+++ b/client/lobby/CSelectionBase.cpp
@@ -310,7 +310,6 @@ CChatBox::CChatBox(const Rect & rect)
 {
 	OBJ_CONSTRUCTION;
 	pos += rect.topLeft();
-	captureAllKeys = true;
 	setRedrawParent(true);
 
 	const int height = static_cast<int>(graphics->fonts[FONT_SMALL]->getLineHeight());

--- a/client/lobby/CSelectionBase.cpp
+++ b/client/lobby/CSelectionBase.cpp
@@ -115,7 +115,7 @@ InfoCard::InfoCard()
 	: showChat(true)
 {
 	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
-	CIntObject::type |= REDRAW_PARENT;
+	setRedrawParent(true);
 	pos.x += 393;
 	pos.y += 6;
 
@@ -311,7 +311,7 @@ CChatBox::CChatBox(const Rect & rect)
 	OBJ_CONSTRUCTION;
 	pos += rect.topLeft();
 	captureAllKeys = true;
-	type |= REDRAW_PARENT;
+	setRedrawParent(true);
 
 	const int height = static_cast<int>(graphics->fonts[FONT_SMALL]->getLineHeight());
 	inputBox = std::make_shared<CTextInput>(Rect(0, rect.h - height, rect.w, height), EFonts::FONT_SMALL, 0);

--- a/client/lobby/RandomMapTab.cpp
+++ b/client/lobby/RandomMapTab.cpp
@@ -371,7 +371,7 @@ TemplatesDropBox::ListItem::ListItem(const JsonNode & config, TemplatesDropBox &
 		pos.w = w->pos.w;
 		pos.h = w->pos.h;
 	}
-	type |= REDRAW_PARENT;
+	setRedrawParent(true);
 }
 
 void TemplatesDropBox::ListItem::updateItem(int idx, const CRmgTemplate * _item)

--- a/client/lobby/SelectionTab.cpp
+++ b/client/lobby/SelectionTab.cpp
@@ -179,7 +179,7 @@ SelectionTab::SelectionTab(ESelectionScreen Type)
 		break;
 	case ESelectionScreen::campaignList:
 		tabTitle = CGI->generaltexth->allTexts[726];
-		type |= REDRAW_PARENT; // we use parent background so we need to make sure it's will be redrawn too
+		setRedrawParent(true); // we use parent background so we need to make sure it's will be redrawn too
 		pos.w = parent->pos.w;
 		pos.h = parent->pos.h;
 		pos.x += 3;

--- a/client/lobby/SelectionTab.cpp
+++ b/client/lobby/SelectionTab.cpp
@@ -460,7 +460,7 @@ void SelectionTab::updateListItems()
 bool SelectionTab::receiveEvent(const Point & position, int eventType) const
 {
 	// FIXME: widget should instead have well-defined pos so events will be filtered using standard routine
-	return getLine(position) != -1;
+	return getLine(position - pos.topLeft()) != -1;
 }
 
 int SelectionTab::getLine() const

--- a/client/lobby/SelectionTab.cpp
+++ b/client/lobby/SelectionTab.cpp
@@ -457,10 +457,21 @@ void SelectionTab::updateListItems()
 	}
 }
 
-int SelectionTab::getLine()
+bool SelectionTab::receiveEvent(const Point & position, int eventType) const
+{
+	// FIXME: widget should instead have well-defined pos so events will be filtered using standard routine
+	return getLine(position) != -1;
+}
+
+int SelectionTab::getLine() const
+{
+	Point clickPos = GH.getCursorPosition() - pos.topLeft();
+	return getLine(clickPos);
+}
+
+int SelectionTab::getLine(const Point & clickPos) const
 {
 	int line = -1;
-	Point clickPos = GH.getCursorPosition() - pos.topLeft();
 
 	// Ignore clicks on save name area
 	int maxPosY;

--- a/client/lobby/SelectionTab.h
+++ b/client/lobby/SelectionTab.h
@@ -67,8 +67,8 @@ public:
 
 	void clickLeft(tribool down, bool previousState) override;
 	void keyPressed(EShortcut key) override;
-
 	void clickDouble() override;
+	bool receiveEvent(const Point & position, int eventType) const override;
 
 	void filter(int size, bool selectFirst = false); //0 - all
 	void sortBy(int criteria);
@@ -77,7 +77,8 @@ public:
 	void selectAbs(int position); //position: absolute position in curItems vector
 	void sliderMove(int slidPos);
 	void updateListItems();
-	int getLine();
+	int getLine() const;
+	int getLine(const Point & position) const;
 	void selectFileName(std::string fname);
 	std::shared_ptr<CMapInfo> getSelectedMapInfo() const;
 	void rememberCurrentSelection();

--- a/client/mainmenu/CMainMenu.cpp
+++ b/client/mainmenu/CMainMenu.cpp
@@ -95,7 +95,7 @@ CMenuScreen::CMenuScreen(const JsonNode & configNode)
 	menuNameToEntry.push_back("credits");
 
 	tabs = std::make_shared<CTabbedInt>(std::bind(&CMenuScreen::createTab, this, _1));
-	tabs->type |= REDRAW_PARENT;
+	tabs->setRedrawParent(true);
 }
 
 std::shared_ptr<CIntObject> CMenuScreen::createTab(size_t index)
@@ -248,7 +248,7 @@ std::shared_ptr<CButton> CMenuEntry::createButton(CMenuScreen * parent, const Js
 CMenuEntry::CMenuEntry(CMenuScreen * parent, const JsonNode & config)
 {
 	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
-	type |= REDRAW_PARENT;
+	setRedrawParent(true);
 	pos = parent->pos;
 
 	for(const JsonNode & node : config["images"].Vector())
@@ -258,7 +258,7 @@ CMenuEntry::CMenuEntry(CMenuScreen * parent, const JsonNode & config)
 	{
 		buttons.push_back(createButton(parent, node));
 		buttons.back()->hoverable = true;
-		buttons.back()->type |= REDRAW_PARENT;
+		buttons.back()->setRedrawParent(true);
 	}
 }
 

--- a/client/mainmenu/CreditsScreen.cpp
+++ b/client/mainmenu/CreditsScreen.cpp
@@ -24,7 +24,7 @@ CreditsScreen::CreditsScreen(Rect rect)
 {
 	pos.w = rect.w;
 	pos.h = rect.h;
-	type |= REDRAW_PARENT;
+	setRedrawParent(true);
 	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
 	auto textFile = CResourceHandler::get()->load(ResourceID("DATA/CREDITS.TXT"))->readAll();
 	std::string text((char *)textFile.first.get(), textFile.second);

--- a/client/mapView/MapView.cpp
+++ b/client/mapView/MapView.cpp
@@ -90,7 +90,6 @@ void MapView::show(Canvas & to)
 
 MapView::MapView(const Point & offset, const Point & dimensions)
 	: BasicMapView(offset, dimensions)
-	, isSwiping(false)
 {
 	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
 	actions = std::make_shared<MapViewActions>(*this, model);
@@ -110,19 +109,13 @@ void MapView::onMapLevelSwitched()
 
 void MapView::onMapScrolled(const Point & distance)
 {
-	if(!isSwiping)
+	if(!isGesturing())
 		controller->setViewCenter(model->getMapViewCenter() + distance, model->getLevel());
 }
 
 void MapView::onMapSwiped(const Point & viewPosition)
 {
-	isSwiping = true;
 	controller->setViewCenter(model->getMapViewCenter() + viewPosition, model->getLevel());
-}
-
-void MapView::onMapSwipeEnded()
-{
-	isSwiping = false;
 }
 
 void MapView::onCenteredTile(const int3 & tile)

--- a/client/mapView/MapView.h
+++ b/client/mapView/MapView.h
@@ -48,8 +48,6 @@ class MapView : public BasicMapView
 {
 	std::shared_ptr<MapViewActions> actions;
 
-	bool isSwiping;
-
 public:
 	void show(Canvas & to) override;
 
@@ -63,9 +61,6 @@ public:
 
 	/// Moves current view to specified position, in pixels
 	void onMapSwiped(const Point & viewPosition);
-
-	/// Ends swiping mode and allows normal map scrolling once again
-	void onMapSwipeEnded();
 
 	/// Moves current view to specified tile
 	void onCenteredTile(const int3 & tile);

--- a/client/mapView/MapViewController.cpp
+++ b/client/mapView/MapViewController.cpp
@@ -185,9 +185,16 @@ void MapViewController::tick(uint32_t timeDelta)
 		fadingInContext->progress = std::min( 1.0, fadingInContext->progress);
 	}
 
+	if (adventureContext)
+		adventureContext->animationTime += timeDelta;
+
+	updateState();
+}
+
+void MapViewController::updateState()
+{
 	if(adventureContext)
 	{
-		adventureContext->animationTime += timeDelta;
 		adventureContext->settingsSessionSpectate = settings["session"]["spectate"].Bool();
 		adventureContext->settingsAdventureObjectAnimation = settings["adventure"]["objectAnimation"].Bool();
 		adventureContext->settingsAdventureTerrainAnimation = settings["adventure"]["terrainAnimation"].Bool();
@@ -511,6 +518,7 @@ void MapViewController::activateAdventureContext(uint32_t animationTime)
 	adventureContext = std::make_shared<MapRendererAdventureContext>(*state);
 	adventureContext->animationTime = animationTime;
 	context = adventureContext;
+	updateState();
 }
 
 void MapViewController::activateAdventureContext()

--- a/client/mapView/MapViewController.h
+++ b/client/mapView/MapViewController.h
@@ -74,6 +74,7 @@ private:
 	void onAfterHeroDisembark(const CGHeroInstance * obj, const int3 & from, const int3 & dest) override;
 
 	void resetContext();
+	void updateState();
 
 public:
 	MapViewController(std::shared_ptr<MapViewModel> model, std::shared_ptr<MapViewCache> view);

--- a/client/widgets/CComponent.cpp
+++ b/client/widgets/CComponent.cpp
@@ -281,7 +281,7 @@ void CSelectableComponent::init()
 CSelectableComponent::CSelectableComponent(const Component &c, std::function<void()> OnSelect):
 	CComponent(c),onSelect(OnSelect)
 {
-	type |= REDRAW_PARENT;
+	setRedrawParent(true);
 	addUsedEvents(LCLICK | KEYBOARD);
 	init();
 }
@@ -289,7 +289,7 @@ CSelectableComponent::CSelectableComponent(const Component &c, std::function<voi
 CSelectableComponent::CSelectableComponent(Etype Type, int Sub, int Val, ESize imageSize, std::function<void()> OnSelect):
 	CComponent(Type,Sub,Val, imageSize),onSelect(OnSelect)
 {
-	type |= REDRAW_PARENT;
+	setRedrawParent(true);
 	addUsedEvents(LCLICK | KEYBOARD);
 	init();
 }
@@ -466,7 +466,7 @@ CComponentBox::CComponentBox(std::vector<std::shared_ptr<CComponent>> _component
 	betweenRows(betweenRows),
 	componentsInRow(componentsInRow)
 {
-	type |= REDRAW_PARENT;
+	setRedrawParent(true);
 	pos = position + pos.topLeft();
 	placeComponents(false);
 }
@@ -484,7 +484,7 @@ CComponentBox::CComponentBox(std::vector<std::shared_ptr<CSelectableComponent>> 
 	betweenRows(betweenRows),
 	componentsInRow(componentsInRow)
 {
-	type |= REDRAW_PARENT;
+	setRedrawParent(true);
 	pos = position + pos.topLeft();
 	placeComponents(true);
 

--- a/client/widgets/CreatureCostBox.cpp
+++ b/client/widgets/CreatureCostBox.cpp
@@ -17,7 +17,7 @@ CreatureCostBox::CreatureCostBox(Rect position, std::string titleText)
 {
 	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
 
-	type |= REDRAW_PARENT;
+	setRedrawParent(true);
 	pos = position + pos.topLeft();
 
 	title = std::make_shared<CLabel>(pos.w/2, 10, FONT_SMALL, ETextAlignment::CENTER, Colors::WHITE, titleText);

--- a/client/widgets/MiscWidgets.h
+++ b/client/widgets/MiscWidgets.h
@@ -143,6 +143,7 @@ public:
 class LRClickableAreaWTextComp: public LRClickableAreaWText
 {
 public:
+	int type;
 	int baseType;
 	int bonusValue;
 	virtual void clickLeft(tribool down, bool previousState) override;

--- a/client/widgets/ObjectLists.cpp
+++ b/client/widgets/ObjectLists.cpp
@@ -138,6 +138,9 @@ void CListBox::reset()
 
 void CListBox::resize(size_t newSize)
 {
+	if (totalSize == newSize)
+		return;
+
 	totalSize = newSize;
 	if (slider)
 		slider->setAmount((int)totalSize);

--- a/client/widgets/Slider.cpp
+++ b/client/widgets/Slider.cpp
@@ -138,6 +138,10 @@ void CSlider::clickLeft(tribool down, bool previousState)
 			rw = pw / (pos.h-48);
 		}
 
+		// click on area covered by buttons -> ignore, will be handled by left/right buttons
+		if (!vstd::iswithin(rw, 0, 1))
+			return;
+
 		slider->clickLeft(true, slider->isMouseLeftButtonPressed());
 		scrollTo((int)(rw * positions  +  0.5));
 		return;

--- a/client/widgets/Slider.cpp
+++ b/client/widgets/Slider.cpp
@@ -214,6 +214,10 @@ CSlider::CSlider(Point position, int totalw, std::function<void(int)> Moved, int
 		pos.h = totalw;
 	}
 
+	// for horizontal sliders that act as values selection - add keyboard event to receive left/right click
+	if (getOrientation() == Orientation::HORIZONTAL)
+		addUsedEvents(KEYBOARD);
+
 	updateSliderPos();
 }
 

--- a/client/widgets/TextControls.cpp
+++ b/client/widgets/TextControls.cpp
@@ -495,7 +495,6 @@ CTextInput::CTextInput(const Rect & Pos, EFonts font, const CFunctionList<void(c
 	setRedrawParent(true);
 	pos.h = Pos.h;
 	pos.w = Pos.w;
-	captureAllKeys = true;
 	background.reset();
 	addUsedEvents(LCLICK | KEYBOARD | TEXTINPUT);
 
@@ -511,7 +510,6 @@ CTextInput::CTextInput(const Rect & Pos, const Point & bgOffset, const std::stri
 	pos.h = Pos.h;
 	pos.w = Pos.w;
 
-	captureAllKeys = true;
 	OBJ_CONSTRUCTION;
 	background = std::make_shared<CPicture>(bgName, bgOffset.x, bgOffset.y);
 	addUsedEvents(LCLICK | KEYBOARD | TEXTINPUT);
@@ -525,7 +523,6 @@ CTextInput::CTextInput(const Rect & Pos, std::shared_ptr<IImage> srf)
 	:CFocusable(std::make_shared<CKeyboardFocusListener>(this))
 {
 	pos += Pos.topLeft();
-	captureAllKeys = true;
 	OBJ_CONSTRUCTION;
 	background = std::make_shared<CPicture>(srf, Pos);
 	pos.w = background->pos.w;
@@ -618,17 +615,6 @@ void CTextInput::setText(const std::string & nText, bool callCb)
 	CLabel::setText(nText);
 	if(callCb)
 		cb(text);
-}
-
-bool CTextInput::captureThisKey(EShortcut key)
-{
-	if(key == EShortcut::GLOBAL_RETURN)
-		return false;
-
-	if (!focus)
-		return false;
-
-	return true;
 }
 
 void CTextInput::textInputed(const std::string & enteredText)

--- a/client/widgets/TextControls.cpp
+++ b/client/widgets/TextControls.cpp
@@ -47,7 +47,7 @@ void CLabel::showAll(Canvas & to)
 CLabel::CLabel(int x, int y, EFonts Font, ETextAlignment Align, const SDL_Color & Color, const std::string & Text)
 	: CTextContainer(Align, Font, Color), text(Text)
 {
-	type |= REDRAW_PARENT;
+	setRedrawParent(true);
 	autoRedraw = true;
 	pos.x += x;
 	pos.y += y;
@@ -299,7 +299,7 @@ CTextBox::CTextBox(std::string Text, const Rect & rect, int SliderStyle, EFonts 
 	OBJECT_CONSTRUCTION_CAPTURING(255 - DISPOSE);
 	label = std::make_shared<CMultiLineLabel>(rect, Font, Align, Color);
 
-	type |= REDRAW_PARENT;
+	setRedrawParent(true);
 	pos.x += rect.x;
 	pos.y += rect.y;
 	pos.h = rect.h;
@@ -492,7 +492,7 @@ CTextInput::CTextInput(const Rect & Pos, EFonts font, const CFunctionList<void(c
 	cb(CB),
 	CFocusable(std::make_shared<CKeyboardFocusListener>(this))
 {
-	type |= REDRAW_PARENT;
+	setRedrawParent(true);
 	pos.h = Pos.h;
 	pos.w = Pos.w;
 	captureAllKeys = true;

--- a/client/widgets/TextControls.h
+++ b/client/widgets/TextControls.h
@@ -227,7 +227,7 @@ public:
 	void clickLeft(tribool down, bool previousState) override;
 	void keyPressed(EShortcut key) override;
 
-	bool captureThisKey(EShortcut key) override;
+	//bool captureThisKey(EShortcut key) override;
 
 	void textInputed(const std::string & enteredText) override;
 	void textEdited(const std::string & enteredText) override;

--- a/client/windows/CCastleInterface.cpp
+++ b/client/windows/CCastleInterface.cpp
@@ -1160,7 +1160,7 @@ CCastleInterface::CCastleInterface(const CGTownInstance * Town, const CGTownInst
 	updateShadow();
 
 	garr = std::make_shared<CGarrisonInt>(305, 387, 4, Point(0,96), town->getUpperArmy(), town->visitingHero);
-	garr->type |= REDRAW_PARENT;
+	garr->setRedrawParent(true);
 
 	heroes = std::make_shared<HeroSlots>(town, Point(241, 387), Point(241, 483), garr, true);
 	title = std::make_shared<CLabel>(85, 387, FONT_MEDIUM, ETextAlignment::TOPLEFT, Colors::WHITE, town->getNameTranslated());

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -1776,7 +1776,7 @@ CObjectListWindow::CItem::CItem(CObjectListWindow * _parent, size_t _id, std::st
 	border = std::make_shared<CPicture>("TPGATES");
 	pos = border->pos;
 
-	type |= REDRAW_PARENT;
+	setRedrawParent(true);
 
 	text = std::make_shared<CLabel>(pos.w/2, pos.h/2, FONT_SMALL, ETextAlignment::CENTER, Colors::WHITE, _text);
 	select(index == parent->selected);
@@ -1850,7 +1850,7 @@ void CObjectListWindow::init(std::shared_ptr<CIntObject> titleWidget_, std::stri
 	}
 	list = std::make_shared<CListBox>(std::bind(&CObjectListWindow::genItem, this, _1),
 		Point(14, 151), Point(0, 25), 9, items.size(), 0, 1, Rect(262, -32, 256, 256) );
-	list->type |= REDRAW_PARENT;
+	list->setRedrawParent(true);
 
 	ok = std::make_shared<CButton>(Point(15, 402), "IOKAY.DEF", CButton::tooltip(), std::bind(&CObjectListWindow::elementSelected, this), EShortcut::GLOBAL_ACCEPT);
 	ok->block(!list->size());

--- a/client/windows/settings/AdventureOptionsTab.cpp
+++ b/client/windows/settings/AdventureOptionsTab.cpp
@@ -34,7 +34,7 @@ AdventureOptionsTab::AdventureOptionsTab()
 		: InterfaceObjectConfigurable()
 {
 	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
-	type |= REDRAW_PARENT;
+	setRedrawParent(true);
 
 	const JsonNode config(ResourceID("config/widgets/settings/adventureOptionsTab.json"));
 	addCallback("playerHeroSpeedChanged", [this](int value)

--- a/client/windows/settings/BattleOptionsTab.cpp
+++ b/client/windows/settings/BattleOptionsTab.cpp
@@ -21,7 +21,7 @@
 BattleOptionsTab::BattleOptionsTab(BattleInterface * owner)
 {
 	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
-	type |= REDRAW_PARENT;
+	setRedrawParent(true);
 
 	const JsonNode config(ResourceID("config/widgets/settings/battleOptionsTab.json"));
 	addCallback("viewGridChanged", [this, owner](bool value)

--- a/client/windows/settings/GeneralOptionsTab.cpp
+++ b/client/windows/settings/GeneralOptionsTab.cpp
@@ -94,7 +94,7 @@ GeneralOptionsTab::GeneralOptionsTab()
 		  onFullscreenChanged(settings.listen["video"]["fullscreen"])
 {
 	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
-	type |= REDRAW_PARENT;
+	setRedrawParent(true);
 
 	addConditional("touchscreen", GH.input().hasTouchInputDevice());
 #ifdef VCMI_MOBILE

--- a/client/windows/settings/SettingsMainWindow.cpp
+++ b/client/windows/settings/SettingsMainWindow.cpp
@@ -71,7 +71,7 @@ SettingsMainWindow::SettingsMainWindow(BattleInterface * parentBattleUi) : Inter
 
 	parentBattleInterface = parentBattleUi;
 	tabContentArea = std::make_shared<CTabbedInt>(std::bind(&SettingsMainWindow::createTab, this, _1), Point(0, 0), defaultTabIndex);
-	tabContentArea->type |= REDRAW_PARENT;
+	tabContentArea->setRedrawParent(true);
 
 	std::shared_ptr<CToggleGroup> mainTabs = widget<CToggleGroup>("settingsTabs");
 	mainTabs->setSelected(defaultTabIndex);

--- a/lib/IGameEventsReceiver.h
+++ b/lib/IGameEventsReceiver.h
@@ -127,6 +127,7 @@ public:
 	virtual void playerBonusChanged(const Bonus &bonus, bool gain){};//if gain hero received bonus, else he lost it
 	virtual void requestSent(const CPackForServer *pack, int requestID){};
 	virtual void requestRealized(PackageApplied *pa){};
+	virtual void beforeObjectPropertyChanged(const SetObjectProperty * sop){}; //eg. mine has been flagged
 	virtual void objectPropertyChanged(const SetObjectProperty * sop){}; //eg. mine has been flagged
 	virtual void objectRemoved(const CGObjectInstance *obj){}; //eg. collected resource, picked artifact, beaten hero
 	virtual void objectRemovedAfter(){}; //eg. collected resource, picked artifact, beaten hero

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -4980,12 +4980,6 @@ void CGameHandler::playerMessage(PlayerColor player, const std::string &message,
 {
 	bool cheated = false;
 	
-	if(!getPlayerSettings(player)->isControlledByAI())
-	{
-		PlayerMessageClient temp_message(player, message);
-		sendAndApply(&temp_message);
-	}
-
 	std::vector<std::string> words;
 	boost::split(words, message, boost::is_any_of(" "));
 	
@@ -5105,6 +5099,14 @@ void CGameHandler::playerMessage(PlayerColor player, const std::string &message,
 
 		if(!player.isSpectator())
 			checkVictoryLossConditionsForPlayer(player);//Player enter win code or got required art\creature
+	}
+	else
+	{
+		if(!getPlayerSettings(player)->isControlledByAI())
+		{
+			PlayerMessageClient temp_message(player, message);
+			sendAndApply(&temp_message);
+		}
 	}
 }
 


### PR DESCRIPTION
List of changes:
- Fixes #2059 
- Fixes #2213 
- Fixes #2225
- Fixes #2231 
- Fixes #2190 
- Fixes #2191
- Fixes #2165 
- Fixes #2294 
- (presumably) Fixes #2194
- entering cheat will not display cheat text, but only "Cheater!" message (to avoid double sound on cheat input & to match H3)
- After map scrolling via mouse wheel - further scrolling via bringing mouse to screen border does not work
- Fixed not working (for how long?) left/right hotkeys on windows with sliders, e.g. split window, recruit window, etc.
- Fixed broken input handling on clicking map sort button multiple times

Issues to fix separately:
- #2224
- #2215 
- #2193 