### PR TITLE
Nkai priority rework

### DIFF
--- a/AI/BattleAI/BattleAI.cpp
+++ b/AI/BattleAI/BattleAI.cpp
@@ -863,7 +863,7 @@ std::optional<BattleAction> CBattleAI::considerFleeingOrSurrendering()
 
 	bs.turnsSkippedByDefense = movesSkippedByDefense / bs.ourStacks.size();
 
-	if(!bs.canFlee || !bs.canSurrender)
+	if(!bs.canFlee && !bs.canSurrender)
 	{
 		return std::nullopt;
 	}

--- a/AI/Nullkiller/AIGateway.cpp
+++ b/AI/Nullkiller/AIGateway.cpp
@@ -779,24 +779,20 @@ void AIGateway::makeTurn()
 	boost::shared_lock<boost::shared_mutex> gsLock(CGameState::mutex);
 	setThreadName("AIGateway::makeTurn");
 
+	cb->sendMessage("vcmieagles");
+
+	retrieveVisitableObjs();
+
 	if(cb->getDate(Date::DAY_OF_WEEK) == 1)
 	{
-		std::vector<const CGObjectInstance *> objs;
-		retrieveVisitableObjs(objs, true);
-
-		for(const CGObjectInstance * obj : objs)
+		for(const CGObjectInstance * obj : nullkiller->memory->visitableObjs)
 		{
 			if(isWeeklyRevisitable(obj))
 			{
-				addVisitableObj(obj);
 				nullkiller->memory->markObjectUnvisited(obj);
 			}
 		}
 	}
-
-	cb->sendMessage("vcmieagles");
-
-	retrieveVisitableObjs();
 
 #if NKAI_TRACE_LEVEL == 0
 	try
@@ -1106,26 +1102,13 @@ void AIGateway::waitTillFree()
 	status.waitTillFree();
 }
 
-void AIGateway::retrieveVisitableObjs(std::vector<const CGObjectInstance *> & out, bool includeOwned) const
-{
-	foreach_tile_pos([&](const int3 & pos)
-	{
-		for(const CGObjectInstance * obj : myCb->getVisitableObjs(pos, false))
-		{
-			if(includeOwned || obj->tempOwner != playerID)
-				out.push_back(obj);
-		}
-	});
-}
-
 void AIGateway::retrieveVisitableObjs()
 {
 	foreach_tile_pos([&](const int3 & pos)
 	{
 		for(const CGObjectInstance * obj : myCb->getVisitableObjs(pos, false))
 		{
-			if(obj->tempOwner != playerID)
-				addVisitableObj(obj);
+			addVisitableObj(obj);
 		}
 	});
 }

--- a/AI/Nullkiller/AIGateway.cpp
+++ b/AI/Nullkiller/AIGateway.cpp
@@ -867,6 +867,19 @@ void AIGateway::pickBestCreatures(const CArmedInstance * destinationArmy, const 
 
 	auto bestArmy = nullkiller->armyManager->getBestArmy(destinationArmy, destinationArmy, source);
 
+	for(auto army : armies)
+	{
+		// move first stack at first slot if empty to avoid can not take away last creature
+		if(!army->hasStackAtSlot(SlotID(0)) && army->stacksCount() > 0)
+		{
+			cb->mergeOrSwapStacks(
+				army,
+				army,
+				SlotID(0),
+				army->Slots().begin()->first);
+		}
+	}
+
 	//foreach best type -> iterate over slots in both armies and if it's the appropriate type, send it to the slot where it belongs
 	for(SlotID i = SlotID(0); i.validSlot(); i.advance(1)) //i-th strongest creature type will go to i-th slot
 	{

--- a/AI/Nullkiller/AIGateway.cpp
+++ b/AI/Nullkiller/AIGateway.cpp
@@ -1058,6 +1058,11 @@ void AIGateway::recruitCreatures(const CGDwelling * d, const CArmedInstance * re
 		int count = d->creatures[i].first;
 		CreatureID creID = d->creatures[i].second.back();
 
+		if(!recruiter->getSlotFor(creID).validSlot())
+		{
+			continue;
+		}
+
 		vstd::amin(count, cb->getResourceAmount() / creID.toCreature()->getFullRecruitCost());
 		if(count > 0)
 			cb->recruitCreatures(d, recruiter, creID, count, i);

--- a/AI/Nullkiller/AIGateway.cpp
+++ b/AI/Nullkiller/AIGateway.cpp
@@ -29,7 +29,7 @@ namespace NKAI
 {
 
 // our to enemy strength ratio constants
-const float SAFE_ATTACK_CONSTANT = 1.2f;
+const float SAFE_ATTACK_CONSTANT = 1.1f;
 const float RETREAT_THRESHOLD = 0.3f;
 const double RETREAT_ABSOLUTE_THRESHOLD = 10000.;
 
@@ -90,8 +90,10 @@ void AIGateway::heroMoved(const TryMoveHero & details, bool verbose)
 	LOG_TRACE(logAi);
 	NET_EVENT_HANDLER;
 
-	validateObject(details.id); //enemy hero may have left visible area
 	auto hero = cb->getHero(details.id);
+
+	if(!hero)
+		validateObject(details.id); //enemy hero may have left visible area
 
 	const int3 from = hero ? hero->convertToVisitablePos(details.start) : (details.start - int3(0,1,0));;
 	const int3 to   = hero ? hero->convertToVisitablePos(details.end)   : (details.end   - int3(0,1,0));
@@ -794,10 +796,7 @@ void AIGateway::makeTurn()
 
 	cb->sendMessage("vcmieagles");
 
-	if(cb->getDate(Date::DAY) == 1)
-	{
-		retrieveVisitableObjs();
-	}
+	retrieveVisitableObjs();
 
 #if NKAI_TRACE_LEVEL == 0
 	try

--- a/AI/Nullkiller/AIGateway.h
+++ b/AI/Nullkiller/AIGateway.h
@@ -195,7 +195,6 @@ public:
 
 	void validateObject(const CGObjectInstance * obj); //checks if object is still visible and if not, removes references to it
 	void validateObject(ObjectIdRef obj); //checks if object is still visible and if not, removes references to it
-	void retrieveVisitableObjs(std::vector<const CGObjectInstance *> & out, bool includeOwned = false) const;
 	void retrieveVisitableObjs();
 	virtual std::vector<const CGObjectInstance *> getFlaggedObjects() const;
 

--- a/AI/Nullkiller/AIUtility.cpp
+++ b/AI/Nullkiller/AIUtility.cpp
@@ -323,13 +323,9 @@ bool isWeeklyRevisitable(const CGObjectInstance * obj)
 
 	if(dynamic_cast<const CGDwelling *>(obj))
 		return true;
-	if(dynamic_cast<const CBank *>(obj)) //banks tend to respawn often in mods
-		return true;
 
 	switch(obj->ID)
 	{
-	case Obj::STABLES:
-	case Obj::MAGIC_WELL:
 	case Obj::HILL_FORT:
 		return true;
 	case Obj::BORDER_GATE:

--- a/AI/Nullkiller/Analyzers/ArmyManager.cpp
+++ b/AI/Nullkiller/Analyzers/ArmyManager.cpp
@@ -13,6 +13,7 @@
 #include "../Engine/Nullkiller.h"
 #include "../../../CCallback.h"
 #include "../../../lib/mapObjects/MapObjects.h"
+#include "../../../lib/GameConstants.h"
 
 namespace NKAI
 {
@@ -306,7 +307,7 @@ std::vector<creInfo> ArmyManager::getArmyAvailableToBuy(
 	int freeHeroSlots = GameConstants::ARMY_SIZE - hero->stacksCount();
 	bool countGrowth = (cb->getDate(Date::DAY_OF_WEEK) + turn) > 7;
 
-	const CGTownInstance * town = dwelling->ID == CGTownInstance::TOWN
+	const CGTownInstance * town = dwelling->ID == Obj::TOWN
 		? dynamic_cast<const CGTownInstance *>(dwelling)
 		: nullptr;
 

--- a/AI/Nullkiller/Analyzers/ArmyManager.cpp
+++ b/AI/Nullkiller/Analyzers/ArmyManager.cpp
@@ -33,6 +33,45 @@ public:
 	}
 };
 
+void ArmyUpgradeInfo::addArmyToBuy(std::vector<SlotInfo> army)
+{
+	for(auto slot : army)
+	{
+		resultingArmy.push_back(slot);
+
+		upgradeValue += slot.power;
+		upgradeCost += slot.creature->getFullRecruitCost() * slot.count;
+	}
+}
+
+void ArmyUpgradeInfo::addArmyToGet(std::vector<SlotInfo> army)
+{
+	for(auto slot : army)
+	{
+		resultingArmy.push_back(slot);
+
+		upgradeValue += slot.power;
+	}
+}
+
+std::vector<SlotInfo> ArmyManager::toSlotInfo(std::vector<creInfo> army) const
+{
+	std::vector<SlotInfo> result;
+
+	for(auto i : army)
+	{
+		SlotInfo slot;
+
+		slot.creature = VLC->creh->objects[i.cre->getId()];
+		slot.count = i.count;
+		slot.power = evaluateStackPower(i.cre, i.count);
+
+		result.push_back(slot);
+	}
+
+	return result;
+}
+
 uint64_t ArmyManager::howManyReinforcementsCanGet(const CGHeroInstance * hero, const CCreatureSet * source) const
 {
 	return howManyReinforcementsCanGet(hero, hero, source);
@@ -136,7 +175,7 @@ std::vector<SlotInfo> ArmyManager::getBestArmy(const IBonusBearer * armyCarrier,
 		{
 			if(vstd::contains(allowedFactions, slot.creature->getFaction()))
 			{
-				auto slotID = newArmyInstance.getSlotFor(slot.creature);
+				auto slotID = newArmyInstance.getSlotFor(slot.creature->getId());
 
 				if(slotID.validSlot())
 				{
@@ -319,7 +358,7 @@ ui64 ArmyManager::howManyReinforcementsCanGet(const IBonusBearer * armyCarrier, 
 	return newArmy > oldArmy ? newArmy - oldArmy : 0;
 }
 
-uint64_t ArmyManager::evaluateStackPower(const CCreature * creature, int count) const
+uint64_t ArmyManager::evaluateStackPower(const Creature * creature, int count) const
 {
 	return creature->getAIValue() * count;
 }

--- a/AI/Nullkiller/Analyzers/ArmyManager.h
+++ b/AI/Nullkiller/Analyzers/ArmyManager.h
@@ -34,6 +34,9 @@ struct ArmyUpgradeInfo
 	std::vector<SlotInfo> resultingArmy;
 	uint64_t upgradeValue = 0;
 	TResources upgradeCost;
+
+	void addArmyToBuy(std::vector<SlotInfo> army);
+	void addArmyToGet(std::vector<SlotInfo> army);
 };
 
 class DLL_EXPORT IArmyManager //: public: IAbstractManager
@@ -57,6 +60,7 @@ public:
 	virtual std::vector<SlotInfo> getBestArmy(const IBonusBearer * armyCarrier, const CCreatureSet * target, const CCreatureSet * source) const = 0;
 	virtual std::vector<SlotInfo>::iterator getWeakestCreature(std::vector<SlotInfo> & army) const = 0;
 	virtual std::vector<SlotInfo> getSortedSlots(const CCreatureSet * target, const CCreatureSet * source) const = 0;
+	virtual std::vector<SlotInfo> toSlotInfo(std::vector<creInfo> creatures) const = 0;
 
 	virtual std::vector<creInfo> getArmyAvailableToBuy(const CCreatureSet * hero, const CGDwelling * dwelling) const = 0;
 	virtual std::vector<creInfo> getArmyAvailableToBuy(
@@ -65,7 +69,7 @@ public:
 		TResources availableRes,
 		uint8_t turn = 0) const = 0;
 
-	virtual uint64_t evaluateStackPower(const CCreature * creature, int count) const = 0;
+	virtual uint64_t evaluateStackPower(const Creature * creature, int count) const = 0;
 	virtual SlotInfo getTotalCreaturesAvailable(CreatureID creatureID) const = 0;
 	virtual ArmyUpgradeInfo calculateCreaturesUpgrade(
 		const CCreatureSet * army,
@@ -99,6 +103,7 @@ public:
 	std::vector<SlotInfo> getBestArmy(const IBonusBearer * armyCarrier, const CCreatureSet * target, const CCreatureSet * source) const override;
 	std::vector<SlotInfo>::iterator getWeakestCreature(std::vector<SlotInfo> & army) const override;
 	std::vector<SlotInfo> getSortedSlots(const CCreatureSet * target, const CCreatureSet * source) const override;
+	std::vector<SlotInfo> toSlotInfo(std::vector<creInfo> creatures) const override;
 
 	std::vector<creInfo> getArmyAvailableToBuy(const CCreatureSet * hero, const CGDwelling * dwelling) const override;
 	std::vector<creInfo> getArmyAvailableToBuy(
@@ -108,7 +113,7 @@ public:
 		uint8_t turn = 0) const override;
 
 	std::shared_ptr<CCreatureSet> getArmyAvailableToBuyAsCCreatureSet(const CGDwelling * dwelling, TResources availableRes) const override;
-	uint64_t evaluateStackPower(const CCreature * creature, int count) const override;
+	uint64_t evaluateStackPower(const Creature * creature, int count) const override;
 	SlotInfo getTotalCreaturesAvailable(CreatureID creatureID) const override;
 	ArmyUpgradeInfo calculateCreaturesUpgrade(
 		const CCreatureSet * army, 

--- a/AI/Nullkiller/Analyzers/ArmyManager.h
+++ b/AI/Nullkiller/Analyzers/ArmyManager.h
@@ -45,20 +45,32 @@ public:
 	virtual	ui64 howManyReinforcementsCanBuy(
 		const CCreatureSet * targetArmy,
 		const CGDwelling * dwelling,
-		const TResources & availableResources) const = 0;
+		const TResources & availableResources,
+		uint8_t turn = 0) const = 0;
+
 	virtual ui64 howManyReinforcementsCanGet(const CGHeroInstance * hero, const CCreatureSet * source) const = 0;
-	virtual ui64 howManyReinforcementsCanGet(const IBonusBearer * armyCarrier, const CCreatureSet * target, const CCreatureSet * source) const = 0;
+	virtual ui64 howManyReinforcementsCanGet(
+		const IBonusBearer * armyCarrier,
+		const CCreatureSet * target,
+		const CCreatureSet * source) const = 0;
+
 	virtual std::vector<SlotInfo> getBestArmy(const IBonusBearer * armyCarrier, const CCreatureSet * target, const CCreatureSet * source) const = 0;
 	virtual std::vector<SlotInfo>::iterator getWeakestCreature(std::vector<SlotInfo> & army) const = 0;
 	virtual std::vector<SlotInfo> getSortedSlots(const CCreatureSet * target, const CCreatureSet * source) const = 0;
-	virtual std::vector<creInfo> getArmyAvailableToBuy(const CCreatureSet * hero, const CGDwelling * dwelling, TResources availableRes) const = 0;
+
+	virtual std::vector<creInfo> getArmyAvailableToBuy(const CCreatureSet * hero, const CGDwelling * dwelling) const = 0;
+	virtual std::vector<creInfo> getArmyAvailableToBuy(
+		const CCreatureSet * hero,
+		const CGDwelling * dwelling,
+		TResources availableRes,
+		uint8_t turn = 0) const = 0;
+
 	virtual uint64_t evaluateStackPower(const CCreature * creature, int count) const = 0;
 	virtual SlotInfo getTotalCreaturesAvailable(CreatureID creatureID) const = 0;
 	virtual ArmyUpgradeInfo calculateCreaturesUpgrade(
 		const CCreatureSet * army,
 		const CGObjectInstance * upgrader,
 		const TResources & availableResources) const = 0;
-	virtual std::vector<creInfo> getArmyAvailableToBuy(const CCreatureSet * hero, const CGDwelling * dwelling) const = 0;
 	virtual std::shared_ptr<CCreatureSet> getArmyAvailableToBuyAsCCreatureSet(const CGDwelling * dwelling, TResources availableRes) const = 0;
 };
 
@@ -74,18 +86,27 @@ private:
 public:
 	ArmyManager(CPlayerSpecificInfoCallback * CB, const Nullkiller * ai): cb(CB), ai(ai) {}
 	void update() override;
+
 	ui64 howManyReinforcementsCanBuy(const CCreatureSet * target, const CGDwelling * source) const override;
 	ui64 howManyReinforcementsCanBuy(
 		const CCreatureSet * targetArmy,
 		const CGDwelling * dwelling,
-		const TResources & availableResources) const override;
+		const TResources & availableResources,
+		uint8_t turn = 0) const override;
+
 	ui64 howManyReinforcementsCanGet(const CGHeroInstance * hero, const CCreatureSet * source) const override;
 	ui64 howManyReinforcementsCanGet(const IBonusBearer * armyCarrier, const CCreatureSet * target, const CCreatureSet * source) const override;
 	std::vector<SlotInfo> getBestArmy(const IBonusBearer * armyCarrier, const CCreatureSet * target, const CCreatureSet * source) const override;
 	std::vector<SlotInfo>::iterator getWeakestCreature(std::vector<SlotInfo> & army) const override;
 	std::vector<SlotInfo> getSortedSlots(const CCreatureSet * target, const CCreatureSet * source) const override;
-	std::vector<creInfo> getArmyAvailableToBuy(const CCreatureSet * hero, const CGDwelling * dwelling, TResources availableRes) const override;
+
 	std::vector<creInfo> getArmyAvailableToBuy(const CCreatureSet * hero, const CGDwelling * dwelling) const override;
+	std::vector<creInfo> getArmyAvailableToBuy(
+		const CCreatureSet * hero,
+		const CGDwelling * dwelling,
+		TResources availableRes,
+		uint8_t turn = 0) const override;
+
 	std::shared_ptr<CCreatureSet> getArmyAvailableToBuyAsCCreatureSet(const CGDwelling * dwelling, TResources availableRes) const override;
 	uint64_t evaluateStackPower(const CCreature * creature, int count) const override;
 	SlotInfo getTotalCreaturesAvailable(CreatureID creatureID) const override;

--- a/AI/Nullkiller/Analyzers/BuildAnalyzer.cpp
+++ b/AI/Nullkiller/Analyzers/BuildAnalyzer.cpp
@@ -166,7 +166,7 @@ void BuildAnalyzer::update()
 	}
 	else
 	{
-		goldPreasure = ai->getLockedResources()[EGameResID::GOLD] / 10000.0f
+		goldPreasure = ai->getLockedResources()[EGameResID::GOLD] / 5000.0f
 			+ (float)armyCost[EGameResID::GOLD] / (1 + ai->getFreeGold() + (float)dailyIncome[EGameResID::GOLD] * 7.0f);
 	}
 

--- a/AI/Nullkiller/Analyzers/BuildAnalyzer.cpp
+++ b/AI/Nullkiller/Analyzers/BuildAnalyzer.cpp
@@ -167,7 +167,7 @@ void BuildAnalyzer::update()
 	else
 	{
 		goldPreasure = ai->getLockedResources()[EGameResID::GOLD] / 5000.0f
-			+ (float)armyCost[EGameResID::GOLD] / (1 + ai->getFreeGold() + (float)dailyIncome[EGameResID::GOLD] * 7.0f);
+			+ (float)armyCost[EGameResID::GOLD] / (1 + 2 * ai->getFreeGold() + (float)dailyIncome[EGameResID::GOLD] * 7.0f);
 	}
 
 	logAi->trace("Gold preasure: %f", goldPreasure);

--- a/AI/Nullkiller/Analyzers/DangerHitMapAnalyzer.cpp
+++ b/AI/Nullkiller/Analyzers/DangerHitMapAnalyzer.cpp
@@ -156,11 +156,10 @@ void DangerHitMapAnalyzer::calculateTileOwners()
 			CRandomGenerator rng;
 			auto visitablePos = town->visitablePos();
 			
-			townHero->pos = visitablePos;
 			townHero->setOwner(ai->playerID); // lets avoid having multiple colors
 			townHero->initHero(rng, static_cast<HeroTypeID>(0));
-			townHero->initObj(rng);
 			townHero->pos = townHero->convertFromVisitablePos(visitablePos);
+			townHero->initObj(rng);
 			
 			heroTownMap[townHero] = town;
 			townHeroes[townHero] = HeroRole::MAIN;

--- a/AI/Nullkiller/Analyzers/DangerHitMapAnalyzer.cpp
+++ b/AI/Nullkiller/Analyzers/DangerHitMapAnalyzer.cpp
@@ -148,17 +148,19 @@ void DangerHitMapAnalyzer::calculateTileOwners()
 	std::map<const CGHeroInstance *, const CGTownInstance *> heroTownMap;
 	PathfinderSettings pathfinderSettings;
 
-	pathfinderSettings.mainTurnDistanceLimit = 3;
+	pathfinderSettings.mainTurnDistanceLimit = 5;
 
 	auto addTownHero = [&](const CGTownInstance * town)
 	{
 			auto townHero = new CGHeroInstance();
 			CRandomGenerator rng;
+			auto visitablePos = town->visitablePos();
 			
-			townHero->pos = town->pos;
+			townHero->pos = visitablePos;
 			townHero->setOwner(ai->playerID); // lets avoid having multiple colors
 			townHero->initHero(rng, static_cast<HeroTypeID>(0));
 			townHero->initObj(rng);
+			townHero->pos = townHero->convertFromVisitablePos(visitablePos);
 			
 			heroTownMap[townHero] = town;
 			townHeroes[townHero] = HeroRole::MAIN;

--- a/AI/Nullkiller/Analyzers/DangerHitMapAnalyzer.h
+++ b/AI/Nullkiller/Analyzers/DangerHitMapAnalyzer.h
@@ -55,19 +55,23 @@ class DangerHitMapAnalyzer
 {
 private:
 	boost::multi_array<HitMapNode, 3> hitMap;
+	boost::multi_array<PlayerColor, 3> tileOwners;
 	std::map<const CGHeroInstance *, std::set<const CGObjectInstance *>> enemyHeroAccessibleObjects;
-	bool upToDate;
+	bool hitMapUpToDate = false;
+	bool tileOwnersUpToDate = false;
 	const Nullkiller * ai;
 
 public:
 	DangerHitMapAnalyzer(const Nullkiller * ai) :ai(ai) {}
 
 	void updateHitMap();
+	void calculateTileOwners();
 	uint64_t enemyCanKillOurHeroesAlongThePath(const AIPath & path) const;
 	const HitMapNode & getObjectTreat(const CGObjectInstance * obj) const;
 	const HitMapNode & getTileTreat(const int3 & tile) const;
 	const std::set<const CGObjectInstance *> & getOneTurnAccessibleObjects(const CGHeroInstance * enemy) const;
 	void reset();
+	void resetTileOwners() { tileOwnersUpToDate = false; }
 };
 
 }

--- a/AI/Nullkiller/Analyzers/DangerHitMapAnalyzer.h
+++ b/AI/Nullkiller/Analyzers/DangerHitMapAnalyzer.h
@@ -55,10 +55,6 @@ struct HitMapNode
 	}
 };
 
-struct TileOwner
-{
-};
-
 class DangerHitMapAnalyzer
 {
 private:

--- a/AI/Nullkiller/Analyzers/DangerHitMapAnalyzer.h
+++ b/AI/Nullkiller/Analyzers/DangerHitMapAnalyzer.h
@@ -35,12 +35,16 @@ struct HitMapInfo
 		turn = 255;
 		hero = HeroPtr();
 	}
+
+	double value() const;
 };
 
 struct HitMapNode
 {
 	HitMapInfo maximumDanger;
 	HitMapInfo fastestDanger;
+
+	const CGTownInstance * closestTown = nullptr;
 
 	HitMapNode() = default;
 
@@ -51,15 +55,19 @@ struct HitMapNode
 	}
 };
 
+struct TileOwner
+{
+};
+
 class DangerHitMapAnalyzer
 {
 private:
 	boost::multi_array<HitMapNode, 3> hitMap;
-	boost::multi_array<PlayerColor, 3> tileOwners;
 	std::map<const CGHeroInstance *, std::set<const CGObjectInstance *>> enemyHeroAccessibleObjects;
 	bool hitMapUpToDate = false;
 	bool tileOwnersUpToDate = false;
 	const Nullkiller * ai;
+	std::map<ObjectInstanceID, std::vector<HitMapInfo>> townTreats;
 
 public:
 	DangerHitMapAnalyzer(const Nullkiller * ai) :ai(ai) {}
@@ -72,6 +80,9 @@ public:
 	const std::set<const CGObjectInstance *> & getOneTurnAccessibleObjects(const CGHeroInstance * enemy) const;
 	void reset();
 	void resetTileOwners() { tileOwnersUpToDate = false; }
+	PlayerColor getTileOwner(const int3 & tile) const;
+	const CGTownInstance * getClosestTown(const int3 & tile) const;
+	const std::vector<HitMapInfo> & getTownTreats(const CGTownInstance * town) const;
 };
 
 }

--- a/AI/Nullkiller/Analyzers/HeroManager.cpp
+++ b/AI/Nullkiller/Analyzers/HeroManager.cpp
@@ -125,6 +125,7 @@ void HeroManager::update()
 	}
 
 	std::sort(myHeroes.begin(), myHeroes.end(), scoreSort);
+	heroRoles.clear();
 
 	for(auto hero : myHeroes)
 	{

--- a/AI/Nullkiller/Analyzers/HeroManager.cpp
+++ b/AI/Nullkiller/Analyzers/HeroManager.cpp
@@ -229,6 +229,31 @@ const CGHeroInstance * HeroManager::findHeroWithGrail() const
 	return nullptr;
 }
 
+const CGHeroInstance * HeroManager::findWeakHeroToDismiss(uint64_t armyLimit) const
+{
+	const CGHeroInstance * weakestHero = nullptr;
+	auto myHeroes = ai->cb->getHeroesInfo();
+
+	for(auto existingHero : myHeroes)
+	{
+		if(ai->isHeroLocked(existingHero)
+			|| existingHero->getArmyStrength() >armyLimit
+			|| getHeroRole(existingHero) == HeroRole::MAIN
+			|| existingHero->movementPointsRemaining()
+			|| existingHero->artifactsWorn.size() > (existingHero->hasSpellbook() ? 2 : 1))
+		{
+			continue;
+		}
+
+		if(!weakestHero || weakestHero->getFightingStrength() > existingHero->getFightingStrength())
+		{
+			weakestHero = existingHero;
+		}
+	}
+
+	return weakestHero;
+}
+
 SecondarySkillScoreMap::SecondarySkillScoreMap(std::map<SecondarySkill, float> scoreMap)
 	:scoreMap(scoreMap)
 {

--- a/AI/Nullkiller/Analyzers/HeroManager.cpp
+++ b/AI/Nullkiller/Analyzers/HeroManager.cpp
@@ -236,7 +236,7 @@ const CGHeroInstance * HeroManager::findWeakHeroToDismiss(uint64_t armyLimit) co
 
 	for(auto existingHero : myHeroes)
 	{
-		if(ai->isHeroLocked(existingHero) && ai->getHeroLockedReason(existingHero) == HeroLockedReason::DEFENCE
+		if(ai->getHeroLockedReason(existingHero) == HeroLockedReason::DEFENCE
 			|| existingHero->getArmyStrength() >armyLimit
 			|| getHeroRole(existingHero) == HeroRole::MAIN
 			|| existingHero->movementPointsRemaining()

--- a/AI/Nullkiller/Analyzers/HeroManager.cpp
+++ b/AI/Nullkiller/Analyzers/HeroManager.cpp
@@ -180,6 +180,15 @@ float HeroManager::evaluateHero(const CGHeroInstance * hero) const
 	return evaluateFightingStrength(hero);
 }
 
+bool HeroManager::heroCapReached() const
+{
+	const bool includeGarnisoned = true;
+	int heroCount = cb->getHeroCount(ai->playerID, includeGarnisoned);
+
+	return heroCount >= ALLOWED_ROAMING_HEROES
+		|| heroCount >= VLC->settings()->getInteger(EGameSettings::HEROES_PER_PLAYER_ON_MAP_CAP);
+}
+
 bool HeroManager::canRecruitHero(const CGTownInstance * town) const
 {
 	if(!town)
@@ -191,13 +200,7 @@ bool HeroManager::canRecruitHero(const CGTownInstance * town) const
 	if(cb->getResourceAmount(EGameResID::GOLD) < GameConstants::HERO_GOLD_COST)
 		return false;
 
-	const bool includeGarnisoned = true;
-	int heroCount = cb->getHeroCount(ai->playerID, includeGarnisoned);
-
-	if(heroCount >= ALLOWED_ROAMING_HEROES)
-		return false;
-
-	if(heroCount >= VLC->settings()->getInteger(EGameSettings::HEROES_PER_PLAYER_ON_MAP_CAP))
+	if(heroCapReached())
 		return false;
 
 	if(!cb->getAvailableHeroes(town).size())

--- a/AI/Nullkiller/Analyzers/HeroManager.cpp
+++ b/AI/Nullkiller/Analyzers/HeroManager.cpp
@@ -236,7 +236,7 @@ const CGHeroInstance * HeroManager::findWeakHeroToDismiss(uint64_t armyLimit) co
 
 	for(auto existingHero : myHeroes)
 	{
-		if(ai->isHeroLocked(existingHero)
+		if(ai->isHeroLocked(existingHero) && ai->getHeroLockedReason(existingHero) == HeroLockedReason::DEFENCE
 			|| existingHero->getArmyStrength() >armyLimit
 			|| getHeroRole(existingHero) == HeroRole::MAIN
 			|| existingHero->movementPointsRemaining()

--- a/AI/Nullkiller/Analyzers/HeroManager.h
+++ b/AI/Nullkiller/Analyzers/HeroManager.h
@@ -33,6 +33,7 @@ public:
 	virtual bool canRecruitHero(const CGTownInstance * t = nullptr) const = 0;
 	virtual bool heroCapReached() const = 0;
 	virtual const CGHeroInstance * findHeroWithGrail() const = 0;
+	virtual const CGHeroInstance * findWeakHeroToDismiss(uint64_t armyLimit) const = 0;
 };
 
 class DLL_EXPORT ISecondarySkillRule
@@ -74,6 +75,7 @@ public:
 	bool canRecruitHero(const CGTownInstance * t = nullptr) const override;
 	bool heroCapReached() const override;
 	const CGHeroInstance * findHeroWithGrail() const override;
+	const CGHeroInstance * findWeakHeroToDismiss(uint64_t armyLimit) const override;
 
 private:
 	float evaluateFightingStrength(const CGHeroInstance * hero) const;

--- a/AI/Nullkiller/Analyzers/HeroManager.h
+++ b/AI/Nullkiller/Analyzers/HeroManager.h
@@ -31,6 +31,7 @@ public:
 	virtual float evaluateSecSkill(SecondarySkill skill, const CGHeroInstance * hero) const = 0;
 	virtual float evaluateHero(const CGHeroInstance * hero) const = 0;
 	virtual bool canRecruitHero(const CGTownInstance * t = nullptr) const = 0;
+	virtual bool heroCapReached() const = 0;
 	virtual const CGHeroInstance * findHeroWithGrail() const = 0;
 };
 
@@ -71,6 +72,7 @@ public:
 	float evaluateSecSkill(SecondarySkill skill, const CGHeroInstance * hero) const override;
 	float evaluateHero(const CGHeroInstance * hero) const override;
 	bool canRecruitHero(const CGTownInstance * t = nullptr) const override;
+	bool heroCapReached() const override;
 	const CGHeroInstance * findHeroWithGrail() const override;
 
 private:

--- a/AI/Nullkiller/Analyzers/ObjectClusterizer.cpp
+++ b/AI/Nullkiller/Analyzers/ObjectClusterizer.cpp
@@ -227,7 +227,12 @@ void ObjectClusterizer::clusterize()
 			auto obj = objs[i];
 
 			if(!shouldVisitObject(obj))
-				return;
+			{
+#if NKAI_TRACE_LEVEL >= 2
+				logAi->trace("Skip object %s%s.", obj->getObjectName(), obj->visitablePos().toString());
+#endif
+				continue;
+			}
 
 #if NKAI_TRACE_LEVEL >= 2
 			logAi->trace("Check object %s%s.", obj->getObjectName(), obj->visitablePos().toString());

--- a/AI/Nullkiller/Behaviors/CaptureObjectsBehavior.cpp
+++ b/AI/Nullkiller/Behaviors/CaptureObjectsBehavior.cpp
@@ -213,7 +213,7 @@ Goals::TGoalVec CaptureObjectsBehavior::decompose() const
 	{
 		captureObjects(ai->nullkiller->objectClusterizer->getNearbyObjects());
 
-		if(tasks.empty() || ai->nullkiller->getScanDepth() == ScanDepth::FULL)
+		if(tasks.empty() || ai->nullkiller->getScanDepth() != ScanDepth::SMALL)
 			captureObjects(ai->nullkiller->objectClusterizer->getFarObjects());
 	}
 

--- a/AI/Nullkiller/Behaviors/CaptureObjectsBehavior.cpp
+++ b/AI/Nullkiller/Behaviors/CaptureObjectsBehavior.cpp
@@ -56,7 +56,7 @@ Goals::TGoalVec CaptureObjectsBehavior::getVisitGoals(const std::vector<AIPath> 
 
 	tasks.reserve(paths.size());
 
-	const AIPath * closestWay = nullptr;
+	std::unordered_map<HeroRole, const AIPath *> closestWaysByRole;
 	std::vector<ExecuteHeroChain *> waysToVisitObj;
 
 	for(auto & path : paths)
@@ -128,8 +128,9 @@ Goals::TGoalVec CaptureObjectsBehavior::getVisitGoals(const std::vector<AIPath> 
 
 			auto heroRole = ai->nullkiller->heroManager->getHeroRole(path.targetHero);
 
-			if(heroRole == HeroRole::SCOUT
-				&& (!closestWay || closestWay->movementCost() > path.movementCost()))
+			auto & closestWay = closestWaysByRole[heroRole];
+
+			if(!closestWay || closestWay->movementCost() > path.movementCost())
 			{
 				closestWay = &path;
 			}
@@ -142,9 +143,12 @@ Goals::TGoalVec CaptureObjectsBehavior::getVisitGoals(const std::vector<AIPath> 
 		}
 	}
 
-	if(closestWay)
+	for(auto way : waysToVisitObj)
 	{
-		for(auto way : waysToVisitObj)
+		auto heroRole = ai->nullkiller->heroManager->getHeroRole(way->getPath().targetHero);
+		auto closestWay = closestWaysByRole[heroRole];
+
+		if(closestWay)
 		{
 			way->closestWayRatio
 				= closestWay->movementCost() / way->getPath().movementCost();

--- a/AI/Nullkiller/Behaviors/DefenceBehavior.h
+++ b/AI/Nullkiller/Behaviors/DefenceBehavior.h
@@ -15,8 +15,12 @@
 
 namespace NKAI
 {
+
+struct HitMapInfo;
+
 namespace Goals
 {
+
 	class DefenceBehavior : public CGoal<DefenceBehavior>
 	{
 	public:
@@ -35,6 +39,7 @@ namespace Goals
 
 	private:
 		void evaluateDefence(Goals::TGoalVec & tasks, const CGTownInstance * town) const;
+		void evaluateRecruitingHero(Goals::TGoalVec & tasks, const HitMapInfo & treat, const CGTownInstance * town) const;
 	};
 }
 

--- a/AI/Nullkiller/Behaviors/GatherArmyBehavior.cpp
+++ b/AI/Nullkiller/Behaviors/GatherArmyBehavior.cpp
@@ -321,8 +321,6 @@ Goals::TGoalVec GatherArmyBehavior::upgradeArmy(const CGTownInstance * upgrader)
 			upgrade.upgradeCost += armyToGetOrBuy.upgradeCost;
 			vstd::concatenate(upgrade.resultingArmy, armyToGetOrBuy.resultingArmy);
 
-			auto getOrBuyArmyValue = (float)armyToGetOrBuy.upgradeValue / path.getHeroStrength();
-
 			if(!upgrade.upgradeValue
 				&& armyToGetOrBuy.upgradeValue > 20000
 				&& ai->nullkiller->heroManager->canRecruitHero(town)

--- a/AI/Nullkiller/Behaviors/GatherArmyBehavior.cpp
+++ b/AI/Nullkiller/Behaviors/GatherArmyBehavior.cpp
@@ -360,7 +360,7 @@ Goals::TGoalVec GatherArmyBehavior::upgradeArmy(const CGTownInstance * upgrader)
 
 		auto armyValue = (float)upgrade.upgradeValue / path.getHeroStrength();
 
-		if((armyValue < 0.1f && upgrade.upgradeValue < 20000) || upgrade.upgradeValue < 300) // avoid small upgrades
+		if((armyValue < 0.25f && upgrade.upgradeValue < 40000) || upgrade.upgradeValue < 2000) // avoid small upgrades
 		{
 #if NKAI_TRACE_LEVEL >= 2
 			logAi->trace("Ignore path. Army value is too small (%f)", armyValue);

--- a/AI/Nullkiller/Behaviors/GatherArmyBehavior.cpp
+++ b/AI/Nullkiller/Behaviors/GatherArmyBehavior.cpp
@@ -307,6 +307,8 @@ Goals::TGoalVec GatherArmyBehavior::upgradeArmy(const CGTownInstance * upgrader)
 					path.heroArmy,
 					upgrader->getUpperArmy()));
 
+			armyToGetOrBuy.upgradeValue -= path.heroArmy->getArmyStrength();
+
 			armyToGetOrBuy.addArmyToBuy(
 				ai->nullkiller->armyManager->toSlotInfo(
 					ai->nullkiller->armyManager->getArmyAvailableToBuy(

--- a/AI/Nullkiller/Behaviors/GatherArmyBehavior.cpp
+++ b/AI/Nullkiller/Behaviors/GatherArmyBehavior.cpp
@@ -119,10 +119,11 @@ Goals::TGoalVec GatherArmyBehavior::deliverArmyToHero(const CGHeroInstance * her
 
 		HeroExchange heroExchange(hero, path);
 
-		float armyValue = (float)heroExchange.getReinforcementArmyStrength() / hero->getArmyStrength();
+		uint64_t armyValue = heroExchange.getReinforcementArmyStrength();
+		float armyRatio = (float)armyValue / hero->getArmyStrength();
 
 		// avoid transferring very small amount of army
-		if(armyValue < 0.1f && armyValue < 20000)
+		if((armyRatio < 0.1f && armyValue < 20000) || armyValue < 500)
 		{
 #if NKAI_TRACE_LEVEL >= 2
 			logAi->trace("Army value is too small.");

--- a/AI/Nullkiller/Behaviors/RecruitHeroBehavior.cpp
+++ b/AI/Nullkiller/Behaviors/RecruitHeroBehavior.cpp
@@ -70,10 +70,10 @@ Goals::TGoalVec RecruitHeroBehavior::decompose() const
 
 			for(auto obj : ai->nullkiller->objectClusterizer->getNearbyObjects())
 			{
-				if((obj->ID == Obj::RESOURCE && obj->subID == GameResID(EGameResID::GOLD))
+				if((obj->ID == Obj::RESOURCE)
 					|| obj->ID == Obj::TREASURE_CHEST
 					|| obj->ID == Obj::CAMPFIRE
-					|| obj->ID == Obj::WATER_WHEEL
+					|| isWeeklyRevisitable(obj)
 					|| obj->ID ==Obj::ARTIFACT)
 				{
 					auto tile = obj->visitablePos();
@@ -84,7 +84,7 @@ Goals::TGoalVec RecruitHeroBehavior::decompose() const
 				}
 			}
 
-			if(treasureSourcesCount < 10)
+			if(treasureSourcesCount < 5)
 				continue;
 
 			if(cb->getHeroesInfo().size() < cb->getTownsInfo().size() + 1

--- a/AI/Nullkiller/Behaviors/RecruitHeroBehavior.cpp
+++ b/AI/Nullkiller/Behaviors/RecruitHeroBehavior.cpp
@@ -66,6 +66,27 @@ Goals::TGoalVec RecruitHeroBehavior::decompose() const
 				}
 			}
 
+			int treasureSourcesCount = 0;
+
+			for(auto obj : ai->nullkiller->objectClusterizer->getNearbyObjects())
+			{
+				if((obj->ID == Obj::RESOURCE && obj->subID == GameResID(EGameResID::GOLD))
+					|| obj->ID == Obj::TREASURE_CHEST
+					|| obj->ID == Obj::CAMPFIRE
+					|| obj->ID == Obj::WATER_WHEEL
+					|| obj->ID ==Obj::ARTIFACT)
+				{
+					auto tile = obj->visitablePos();
+					auto closestTown = ai->nullkiller->dangerHitMap->getClosestTown(tile);
+
+					if(town == closestTown)
+						treasureSourcesCount++;
+				}
+			}
+
+			if(treasureSourcesCount < 10)
+				continue;
+
 			if(cb->getHeroesInfo().size() < cb->getTownsInfo().size() + 1
 				|| (ai->nullkiller->getFreeResources()[EGameResID::GOLD] > 10000
 					&& ai->nullkiller->buildAnalyzer->getGoldPreasure() < MAX_GOLD_PEASURE))

--- a/AI/Nullkiller/CMakeLists.txt
+++ b/AI/Nullkiller/CMakeLists.txt
@@ -52,6 +52,7 @@ set(Nullkiller_SRCS
 		Behaviors/BuildingBehavior.cpp
 		Behaviors/GatherArmyBehavior.cpp
 		Behaviors/ClusterBehavior.cpp
+		Helpers/ArmyFormation.cpp
 		AIGateway.cpp
 )
 
@@ -114,6 +115,7 @@ set(Nullkiller_HEADERS
 		Behaviors/BuildingBehavior.h
 		Behaviors/GatherArmyBehavior.h
 		Behaviors/ClusterBehavior.h
+		Helpers/ArmyFormation.h
 		AIGateway.h
 )
 

--- a/AI/Nullkiller/Engine/FuzzyHelper.cpp
+++ b/AI/Nullkiller/Engine/FuzzyHelper.cpp
@@ -150,17 +150,15 @@ ui64 FuzzyHelper::evaluateDanger(const CGObjectInstance * obj)
 	case Obj::MINE:
 	case Obj::ABANDONED_MINE:
 	case Obj::PANDORAS_BOX:
-	{
-		const CArmedInstance * a = dynamic_cast<const CArmedInstance *>(obj);
-		return a->getArmyStrength();
-	}
 	case Obj::CRYPT: //crypt
 	case Obj::CREATURE_BANK: //crebank
 	case Obj::DRAGON_UTOPIA:
 	case Obj::SHIPWRECK: //shipwreck
 	case Obj::DERELICT_SHIP: //derelict ship
-							 //	case Obj::PYRAMID:
-		return estimateBankDanger(dynamic_cast<const CBank *>(obj));
+	{
+		const CArmedInstance * a = dynamic_cast<const CArmedInstance *>(obj);
+		return a->getArmyStrength();
+	}
 	case Obj::PYRAMID:
 	{
 		if(obj->subID == 0)

--- a/AI/Nullkiller/Engine/Nullkiller.cpp
+++ b/AI/Nullkiller/Engine/Nullkiller.cpp
@@ -61,6 +61,7 @@ void Nullkiller::init(std::shared_ptr<CCallback> cb, PlayerColor playerID)
 	armyManager.reset(new ArmyManager(cb.get(), this));
 	heroManager.reset(new HeroManager(cb.get(), this));
 	decomposer.reset(new DeepDecomposer());
+	armyFormation.reset(new ArmyFormation(cb, this));
 }
 
 Goals::TTask Nullkiller::choseBestTask(Goals::TTaskVec & tasks) const
@@ -137,6 +138,7 @@ void Nullkiller::updateAiState(int pass, bool fast)
 	{
 		memory->removeInvisibleObjects(cb.get());
 
+		dangerHitMap->calculateTileOwners();
 		dangerHitMap->updateHitMap();
 
 		boost::this_thread::interruption_point();
@@ -222,7 +224,7 @@ void Nullkiller::makeTurn()
 	boost::lock_guard<boost::mutex> sharedStorageLock(AISharedStorage::locker);
 
 	const int MAX_DEPTH = 10;
-	const float FAST_TASK_MINIMAL_PRIORITY = 0.7;
+	const float FAST_TASK_MINIMAL_PRIORITY = 0.7f;
 
 	resetAiState();
 

--- a/AI/Nullkiller/Engine/Nullkiller.cpp
+++ b/AI/Nullkiller/Engine/Nullkiller.cpp
@@ -118,7 +118,7 @@ Goals::TTask Nullkiller::choseBestTask(Goals::TSubgoal behavior, int decompositi
 void Nullkiller::resetAiState()
 {
 	lockedResources = TResources();
-	scanDepth = ScanDepth::FULL;
+	scanDepth = ScanDepth::MAIN_FULL;
 	playerID = ai->playerID;
 	lockedHeroes.clear();
 	dangerHitMap->reset();
@@ -158,11 +158,15 @@ void Nullkiller::updateAiState(int pass, bool fast)
 
 		PathfinderSettings cfg;
 		cfg.useHeroChain = useHeroChain;
-		cfg.scoutTurnDistanceLimit = SCOUT_TURN_DISTANCE_LIMIT;
 
-		if(scanDepth != ScanDepth::FULL)
+		if(scanDepth == ScanDepth::SMALL)
 		{
-			cfg.mainTurnDistanceLimit = MAIN_TURN_DISTANCE_LIMIT * ((int)scanDepth + 1);
+			cfg.mainTurnDistanceLimit = MAIN_TURN_DISTANCE_LIMIT;
+		}
+
+		if(scanDepth != ScanDepth::ALL_FULL)
+		{
+			cfg.scoutTurnDistanceLimit = SCOUT_TURN_DISTANCE_LIMIT;
 		}
 
 		boost::this_thread::interruption_point();
@@ -233,8 +237,8 @@ void Nullkiller::makeTurn()
 		updateAiState(i);
 
 		Goals::TTask bestTask = taskptr(Goals::Invalid());
-		
-		do
+
+		for(;i <= MAXPASS; i++)
 		{
 			Goals::TTaskVec fastTasks = {
 				choseBestTask(sptr(BuyArmyBehavior()), 1),
@@ -248,7 +252,11 @@ void Nullkiller::makeTurn()
 				executeTask(bestTask);
 				updateAiState(i, true);
 			}
-		} while(bestTask->priority >= FAST_TASK_MINIMAL_PRIORITY);
+			else
+			{
+				break;
+			}
+		}
 
 		Goals::TTaskVec bestTasks = {
 			bestTask,
@@ -267,7 +275,6 @@ void Nullkiller::makeTurn()
 		bestTask = choseBestTask(bestTasks);
 
 		HeroPtr hero = bestTask->getHero();
-
 		HeroRole heroRole = HeroRole::MAIN;
 
 		if(hero.validAndSet())
@@ -276,20 +283,39 @@ void Nullkiller::makeTurn()
 		if(heroRole != HeroRole::MAIN || bestTask->getHeroExchangeCount() <= 1)
 			useHeroChain = false;
 
+		// TODO: better to check turn distance here instead of priority
 		if((heroRole != HeroRole::MAIN || bestTask->priority < SMALL_SCAN_MIN_PRIORITY)
-			&& scanDepth == ScanDepth::FULL)
+			&& scanDepth == ScanDepth::MAIN_FULL)
 		{
 			useHeroChain = false;
 			scanDepth = ScanDepth::SMALL;
 
 			logAi->trace(
-				"Goal %s has too low priority %f so increasing scan depth",
+				"Goal %s has low priority %f so decreasing  scan depth to gain performance.",
 				bestTask->toString(),
 				bestTask->priority);
 		}
 
 		if(bestTask->priority < MIN_PRIORITY)
 		{
+			auto heroes = cb->getHeroesInfo();
+			auto hasMp = vstd::contains_if(heroes, [](const CGHeroInstance * h) -> bool
+				{
+					return h->movementPointsRemaining() > 100;
+				});
+
+			if(hasMp && scanDepth != ScanDepth::ALL_FULL)
+			{
+				logAi->trace(
+					"Goal %s has too low priority %f so increasing scan depth to full.",
+					bestTask->toString(),
+					bestTask->priority);
+
+				scanDepth = ScanDepth::ALL_FULL;
+				useHeroChain = false;
+				continue;
+			}
+
 			logAi->trace("Goal %s has too low priority. It is not worth doing it. Ending turn.", bestTask->toString());
 
 			return;

--- a/AI/Nullkiller/Engine/Nullkiller.cpp
+++ b/AI/Nullkiller/Engine/Nullkiller.cpp
@@ -134,6 +134,9 @@ void Nullkiller::updateAiState(int pass, bool fast)
 	activeHero = nullptr;
 	setTargetObject(-1);
 
+	decomposer->reset();
+	buildAnalyzer->update();
+
 	if(!fast)
 	{
 		memory->removeInvisibleObjects(cb.get());
@@ -179,8 +182,6 @@ void Nullkiller::updateAiState(int pass, bool fast)
 	}
 
 	armyManager->update();
-	buildAnalyzer->update();
-	decomposer->reset();
 
 	logAi->debug("AI state updated in %ld", timeElapsed(start));
 }

--- a/AI/Nullkiller/Engine/Nullkiller.h
+++ b/AI/Nullkiller/Engine/Nullkiller.h
@@ -40,9 +40,11 @@ enum class HeroLockedReason
 
 enum class ScanDepth
 {
-	FULL = 0,
+	MAIN_FULL = 0,
 
-	SMALL = 1
+	SMALL = 1,
+
+	ALL_FULL = 2
 };
 
 class Nullkiller

--- a/AI/Nullkiller/Engine/Nullkiller.h
+++ b/AI/Nullkiller/Engine/Nullkiller.h
@@ -23,7 +23,7 @@
 namespace NKAI
 {
 
-const float MAX_GOLD_PEASURE = 0.3f;
+const float MAX_GOLD_PEASURE = 0.6f;
 const float MIN_PRIORITY = 0.01f;
 const float SMALL_SCAN_MIN_PRIORITY = 0.4f;
 

--- a/AI/Nullkiller/Engine/Nullkiller.h
+++ b/AI/Nullkiller/Engine/Nullkiller.h
@@ -23,7 +23,7 @@
 namespace NKAI
 {
 
-const float MAX_GOLD_PEASURE = 0.6f;
+const float MAX_GOLD_PEASURE = 0.3f;
 const float MIN_PRIORITY = 0.01f;
 const float SMALL_SCAN_MIN_PRIORITY = 0.4f;
 

--- a/AI/Nullkiller/Engine/Nullkiller.h
+++ b/AI/Nullkiller/Engine/Nullkiller.h
@@ -18,6 +18,7 @@
 #include "../Analyzers/ArmyManager.h"
 #include "../Analyzers/HeroManager.h"
 #include "../Analyzers/ObjectClusterizer.h"
+#include "../Helpers/ArmyFormation.h"
 
 namespace NKAI
 {
@@ -67,6 +68,7 @@ public:
 	std::unique_ptr<AIMemory> memory;
 	std::unique_ptr<FuzzyHelper> dangerEvaluator;
 	std::unique_ptr<DeepDecomposer> decomposer;
+	std::unique_ptr<ArmyFormation> armyFormation;
 	PlayerColor playerID;
 	std::shared_ptr<CCallback> cb;
 

--- a/AI/Nullkiller/Engine/PriorityEvaluator.cpp
+++ b/AI/Nullkiller/Engine/PriorityEvaluator.cpp
@@ -108,7 +108,8 @@ int32_t estimateTownIncome(CCallback * cb, const CGObjectInstance * target, cons
 	auto town = cb->getTown(target->id);
 	auto fortLevel = town->fortLevel();
 
-	if(town->hasCapitol()) return booster * 2000;
+	if(town->hasCapitol())
+		return booster * 2000;
 
 	// probably well developed town will have city hall
 	if(fortLevel == CGTownInstance::CASTLE) return booster * 750;
@@ -497,14 +498,15 @@ float RewardEvaluator::getStrategicalValue(const CGObjectInstance * target) cons
 		}
 
 		auto fortLevel = town->fortLevel();
-		auto booster = isAnotherAi(town, *ai->cb) ? 0.3f : 0.7f;
+		auto booster = isAnotherAi(town, *ai->cb) ? 0.4f : 1.0f;
 
-		if(town->hasCapitol()) return booster;
+		if(town->hasCapitol())
+			return booster * 1.5;
 
 		if(fortLevel < CGTownInstance::CITADEL)
-			return booster * (town->hasFort() ? 0.6 : 0.4);
+			return booster * (town->hasFort() ? 1.0 : 0.8);
 		else
-			return booster * (fortLevel == CGTownInstance::CASTLE ? 0.9 : 0.8);
+			return booster * (fortLevel == CGTownInstance::CASTLE ? 1.4 : 1.2);
 	}
 
 	case Obj::HERO:
@@ -731,7 +733,7 @@ public:
 
 		multiplier /= 1.0f + treat.turn / 5.0f;
 
-		if(defendTown.getTurn() > 0 && defendTown.isContrAttack())
+		if(defendTown.getTurn() > 0 && defendTown.isCounterAttack())
 		{
 			auto ourSpeed = defendTown.hero->movementPointsLimit(true);
 			auto enemySpeed = treat.hero->movementPointsLimit(true);

--- a/AI/Nullkiller/Engine/PriorityEvaluator.cpp
+++ b/AI/Nullkiller/Engine/PriorityEvaluator.cpp
@@ -1014,6 +1014,8 @@ float PriorityEvaluator::evaluate(Goals::TSubgoal task)
 		+ (evaluationContext.armyReward > 0 ? 1 : 0)
 		+ (evaluationContext.skillReward > 0 ? 1 : 0)
 		+ (evaluationContext.strategicalValue > 0 ? 1 : 0);
+
+	auto goldRewardPerTurn = evaluationContext.goldReward / std::log2f(evaluationContext.movementCost * 10);
 	
 	double result = 0;
 
@@ -1023,7 +1025,7 @@ float PriorityEvaluator::evaluate(Goals::TSubgoal task)
 		heroRoleVariable->setValue(evaluationContext.heroRole);
 		mainTurnDistanceVariable->setValue(evaluationContext.movementCostByRole[HeroRole::MAIN]);
 		scoutTurnDistanceVariable->setValue(evaluationContext.movementCostByRole[HeroRole::SCOUT]);
-		goldRewardVariable->setValue(evaluationContext.goldReward);
+		goldRewardVariable->setValue(goldRewardPerTurn);
 		armyRewardVariable->setValue(evaluationContext.armyReward);
 		armyGrowthVariable->setValue(evaluationContext.armyGrowth);
 		skillRewardVariable->setValue(evaluationContext.skillReward);

--- a/AI/Nullkiller/Engine/PriorityEvaluator.cpp
+++ b/AI/Nullkiller/Engine/PriorityEvaluator.cpp
@@ -727,8 +727,8 @@ public:
 
 		if(defendTown.getTurn() > 0 && defendTown.isContrAttack())
 		{
-			auto ourSpeed = defendTown.hero->maxMovePoints(true);
-			auto enemySpeed = treat.hero->maxMovePoints(true);
+			auto ourSpeed = defendTown.hero->movementPointsLimit(true);
+			auto enemySpeed = treat.hero->movementPointsLimit(true);
 
 			if(enemySpeed > ourSpeed) multiplier *= 0.7f;
 		}
@@ -894,7 +894,7 @@ public:
 		const CGHeroInstance * dismissedHero = dismissCommand.getHero().get();
 
 		auto role = ai->heroManager->getHeroRole(dismissedHero);
-		auto mpLeft = dismissedHero->movement;
+		auto mpLeft = dismissedHero->movementPointsRemaining();
 			
 		evaluationContext.movementCost += mpLeft;
 		evaluationContext.movementCostByRole[role] += mpLeft;

--- a/AI/Nullkiller/Engine/PriorityEvaluator.cpp
+++ b/AI/Nullkiller/Engine/PriorityEvaluator.cpp
@@ -316,8 +316,6 @@ uint64_t RewardEvaluator::getArmyGrowth(
 	const CGHeroInstance * hero,
 	const CCreatureSet * army) const
 {
-	const float enemyArmyEliminationRewardRatio = 0.5f;
-
 	if(!target)
 		return 0;
 

--- a/AI/Nullkiller/Engine/PriorityEvaluator.cpp
+++ b/AI/Nullkiller/Engine/PriorityEvaluator.cpp
@@ -592,7 +592,6 @@ int32_t getArmyCost(const CArmedInstance * army)
 	return value;
 }
 
-/// Gets aproximated reward in gold. Daily income is multiplied by 5
 int32_t RewardEvaluator::getGoldReward(const CGObjectInstance * target, const CGHeroInstance * hero) const
 {
 	if(!target)
@@ -713,9 +712,6 @@ public:
 
 		auto strategicalValue = evaluationContext.evaluator.getStrategicalValue(town);
 
-		if(evaluationContext.evaluator.ai->buildAnalyzer->getDevelopmentInfo().size() == 1)
-			vstd::amax(evaluationContext.strategicalValue, 10.0);
-
 		float multiplier = 1;
 
 		if(treat.turn < defendTown.getTurn())
@@ -736,7 +732,12 @@ public:
 
 		evaluationContext.armyGrowth += armyGrowth * multiplier;
 		evaluationContext.goldReward += dailyIncome * 5 * multiplier;
-		evaluationContext.addNonCriticalStrategicalValue(1.7f * multiplier * strategicalValue);
+
+		if(evaluationContext.evaluator.ai->buildAnalyzer->getDevelopmentInfo().size() == 1)
+			vstd::amax(evaluationContext.strategicalValue, 2.5f * multiplier * strategicalValue);
+		else
+			evaluationContext.addNonCriticalStrategicalValue(1.7f * multiplier * strategicalValue);
+
 		vstd::amax(evaluationContext.danger, defendTown.getTreat().danger);
 		addTileDanger(evaluationContext, town->visitablePos(), defendTown.getTurn(), defendTown.getDefenceStrength());
 	}

--- a/AI/Nullkiller/Engine/PriorityEvaluator.cpp
+++ b/AI/Nullkiller/Engine/PriorityEvaluator.cpp
@@ -915,6 +915,7 @@ public:
 		evaluationContext.heroRole = HeroRole::MAIN;
 		evaluationContext.movementCostByRole[evaluationContext.heroRole] += bi.prerequisitesCount;
 		evaluationContext.goldCost += bi.buildCostWithPrerequisits[EGameResID::GOLD];
+		evaluationContext.closestWayRatio = 1;
 
 		if(bi.creatureID != CreatureID::NONE)
 		{
@@ -938,7 +939,12 @@ public:
 			evaluationContext.addNonCriticalStrategicalValue(buildThis.town->creatures.size() * 0.2f);
 			evaluationContext.armyReward += buildThis.townInfo.armyStrength / 2;
 		}
-		else
+		else if(bi.id >= BuildingID::MAGES_GUILD_1 && bi.id <= BuildingID::MAGES_GUILD_5)
+		{
+			evaluationContext.skillReward += 2 * (bi.id - BuildingID::MAGES_GUILD_1);
+		}
+		
+		if(evaluationContext.goldReward)
 		{
 			auto goldPreasure = evaluationContext.evaluator.ai->buildAnalyzer->getGoldPreasure();
 

--- a/AI/Nullkiller/Engine/PriorityEvaluator.cpp
+++ b/AI/Nullkiller/Engine/PriorityEvaluator.cpp
@@ -420,10 +420,10 @@ float RewardEvaluator::getTotalResourceRequirementStrength(int resType) const
 		return 0;
 
 	float ratio = dailyIncome[resType] == 0
-		? (float)requiredResources[resType] / 50.0f
-		: (float)requiredResources[resType] / dailyIncome[resType] / 50.0f;
+		? (float)requiredResources[resType] / 10.0f
+		: (float)requiredResources[resType] / dailyIncome[resType] / 20.0f;
 
-	return std::min(ratio, 1.0f);
+	return std::min(ratio, 2.0f);
 }
 
 uint64_t RewardEvaluator::townArmyGrowth(const CGTownInstance * town) const
@@ -954,7 +954,9 @@ public:
 
 		if(bi.notEnoughRes && bi.prerequisitesCount == 1)
 		{
-			evaluationContext.strategicalValue /= 2;
+			evaluationContext.strategicalValue /= 3;
+			evaluationContext.movementCostByRole[evaluationContext.heroRole] += 5;
+			evaluationContext.turn += 5;
 		}
 	}
 };

--- a/AI/Nullkiller/Engine/PriorityEvaluator.h
+++ b/AI/Nullkiller/Engine/PriorityEvaluator.h
@@ -44,6 +44,7 @@ public:
 	int32_t getGoldReward(const CGObjectInstance * target, const CGHeroInstance * hero) const;
 	uint64_t getUpgradeArmyReward(const CGTownInstance * town, const BuildingInfo & bi) const;
 	const HitMapInfo & getEnemyHeroDanger(const int3 & tile, uint8_t turn) const;
+	uint64_t townArmyGrowth(const CGTownInstance * town) const;
 };
 
 struct DLL_EXPORT EvaluationContext

--- a/AI/Nullkiller/Engine/PriorityEvaluator.h
+++ b/AI/Nullkiller/Engine/PriorityEvaluator.h
@@ -33,6 +33,7 @@ public:
 	RewardEvaluator(const Nullkiller * ai) : ai(ai) {}
 
 	uint64_t getArmyReward(const CGObjectInstance * target, const CGHeroInstance * hero, const CCreatureSet * army, bool checkGold) const;
+	uint64_t getArmyGrowth(const CGObjectInstance * target, const CGHeroInstance * hero, const CCreatureSet * army) const;
 	int getGoldCost(const CGObjectInstance * target, const CGHeroInstance * hero, const CCreatureSet * army) const;
 	float getEnemyHeroStrategicalValue(const CGHeroInstance * enemy) const;
 	float getResourceRequirementStrength(int resType) const;
@@ -54,6 +55,7 @@ struct DLL_EXPORT EvaluationContext
 	float closestWayRatio;
 	float armyLossPersentage;
 	float armyReward;
+	uint64_t armyGrowth;
 	int32_t goldReward;
 	int32_t goldCost;
 	float skillReward;
@@ -95,6 +97,7 @@ private:
 	fl::InputVariable * turnVariable;
 	fl::InputVariable * goldRewardVariable;
 	fl::InputVariable * armyRewardVariable;
+	fl::InputVariable * armyGrowthVariable;
 	fl::InputVariable * dangerVariable;
 	fl::InputVariable * skillRewardVariable;
 	fl::InputVariable * strategicalValueVariable;

--- a/AI/Nullkiller/Engine/PriorityEvaluator.h
+++ b/AI/Nullkiller/Engine/PriorityEvaluator.h
@@ -66,6 +66,8 @@ struct DLL_EXPORT EvaluationContext
 	float enemyHeroDangerRatio;
 
 	EvaluationContext(const Nullkiller * ai);
+
+	void addNonCriticalStrategicalValue(float value);
 };
 
 class IEvaluationContextBuilder

--- a/AI/Nullkiller/Goals/BuyArmy.cpp
+++ b/AI/Nullkiller/Goals/BuyArmy.cpp
@@ -71,7 +71,7 @@ void BuyArmy::accept(AIGateway * ai)
 		throw cannotFulfillGoalException("No creatures to buy.");
 	}
 
-	if(town->visitingHero)
+	if(town->visitingHero && !town->garrisonHero)
 	{
 		ai->moveHeroToTile(town->visitablePos(), town->visitingHero.get());
 	}

--- a/AI/Nullkiller/Goals/Composition.cpp
+++ b/AI/Nullkiller/Goals/Composition.cpp
@@ -31,9 +31,17 @@ std::string Composition::toString() const
 {
 	std::string result = "Composition";
 
-	for(auto goal : subtasks)
+	for(auto step : subtasks)
 	{
-		result += " " + goal->toString();
+		result += "[";
+		for(auto goal : step)
+		{
+			if(goal->isElementar())
+				result +=  goal->toString() + " => ";
+			else
+				result += goal->toString() + ", ";
+		}
+		result += "] ";
 	}
 
 	return result;
@@ -41,17 +49,34 @@ std::string Composition::toString() const
 
 void Composition::accept(AIGateway * ai)
 {
-	taskptr(*subtasks.back())->accept(ai);
+	for(auto task : subtasks.back())
+	{
+		if(task->isElementar())
+		{
+			taskptr(*task)->accept(ai);
+		}
+		else
+		{
+			break;
+		}
+	}
 }
 
 TGoalVec Composition::decompose() const
 {
-	return subtasks;
+	TGoalVec result;
+
+	for(const TGoalVec & step : subtasks)
+		vstd::concatenate(result, step);
+
+	return result;
 }
 
-Composition & Composition::addNext(const AbstractGoal & goal)
+Composition & Composition::addNextSequence(const TGoalVec & taskSequence)
 {
-	return addNext(sptr(goal));
+	subtasks.push_back(taskSequence);
+
+	return *this;
 }
 
 Composition & Composition::addNext(TSubgoal goal)
@@ -64,20 +89,35 @@ Composition & Composition::addNext(TSubgoal goal)
 	}
 	else
 	{
-		subtasks.push_back(goal);
+		subtasks.push_back({goal});
 	}
 
 	return *this;
 }
 
+Composition & Composition::addNext(const AbstractGoal & goal)
+{
+	return addNext(sptr(goal));
+}
+
 bool Composition::isElementar() const
 {
-	return subtasks.back()->isElementar();
+	return subtasks.back().front()->isElementar();
 }
 
 int Composition::getHeroExchangeCount() const
 {
-	return isElementar() ? taskptr(*subtasks.back())->getHeroExchangeCount() : 0;
+	auto result = 0;
+
+	for(auto task : subtasks.back())
+	{
+		if(task->isElementar())
+		{
+			result += taskptr(*task)->getHeroExchangeCount();
+		}
+	}
+	
+	return result;
 }
 
 }

--- a/AI/Nullkiller/Goals/Composition.h
+++ b/AI/Nullkiller/Goals/Composition.h
@@ -18,16 +18,11 @@ namespace Goals
 	class DLL_EXPORT Composition : public ElementarGoal<Composition>
 	{
 	private:
-		TGoalVec subtasks;
+		std::vector<TGoalVec> subtasks; // things we want to do now
 
 	public:
 		Composition()
 			: ElementarGoal(Goals::COMPOSITION), subtasks()
-		{
-		}
-
-		Composition(TGoalVec subtasks)
-			: ElementarGoal(Goals::COMPOSITION), subtasks(subtasks)
 		{
 		}
 
@@ -36,6 +31,7 @@ namespace Goals
 		void accept(AIGateway * ai) override;
 		Composition & addNext(const AbstractGoal & goal);
 		Composition & addNext(TSubgoal goal);
+		Composition & addNextSequence(const TGoalVec & taskSequence);
 		virtual TGoalVec decompose() const override;
 		virtual bool isElementar() const override;
 		virtual int getHeroExchangeCount() const override;

--- a/AI/Nullkiller/Goals/ExecuteHeroChain.cpp
+++ b/AI/Nullkiller/Goals/ExecuteHeroChain.cpp
@@ -52,6 +52,20 @@ void ExecuteHeroChain::accept(AIGateway * ai)
 	ai->nullkiller->setActive(chainPath.targetHero, tile);
 	ai->nullkiller->setTargetObject(objid);
 
+	auto targetObject = ai->myCb->getObj(static_cast<ObjectInstanceID>(objid), false);
+
+	if(chainPath.turn() == 0 && targetObject && targetObject->ID == Obj::TOWN)
+	{
+		auto relations = ai->myCb->getPlayerRelations(ai->playerID, targetObject->getOwner());
+
+		if(relations == PlayerRelations::ENEMIES)
+		{
+			ai->nullkiller->armyFormation->rearrangeArmyForSiege(
+				dynamic_cast<const CGTownInstance *>(targetObject),
+				chainPath.targetHero);
+		}
+	}
+
 	std::set<int> blockedIndexes;
 
 	for(int i = chainPath.nodes.size() - 1; i >= 0; i--)

--- a/AI/Nullkiller/Goals/RecruitHero.cpp
+++ b/AI/Nullkiller/Goals/RecruitHero.cpp
@@ -24,7 +24,10 @@ using namespace Goals;
 
 std::string RecruitHero::toString() const
 {
-	return "Recruit hero at " + town->getNameTranslated();
+	if(heroToBuy)
+		return "Recruit " + heroToBuy->getNameTranslated() + " at " + town->getNameTranslated();
+	else
+		return "Recruit hero at " + town->getNameTranslated();
 }
 
 void RecruitHero::accept(AIGateway * ai)
@@ -45,19 +48,19 @@ void RecruitHero::accept(AIGateway * ai)
 		throw cannotFulfillGoalException("No available heroes in tavern in " + t->nodeName());
 	}
 
-	auto heroToHire = heroes[0];
+	auto heroToHire = heroToBuy;
 
-	for(auto hero : heroes)
+	if(!heroToHire)
 	{
-		if(objid == hero->id.getNum())
+		for(auto hero : heroes)
 		{
-			heroToHire = hero;
-			break;
+			if(!heroToHire || hero->getTotalStrength() > heroToHire->getTotalStrength())
+				heroToHire = hero;
 		}
-
-		if(hero->getTotalStrength() > heroToHire->getTotalStrength())
-			heroToHire = hero;
 	}
+
+	if(!heroToHire)
+		throw cannotFulfillGoalException("No hero to hire!");
 
 	if(t->visitingHero)
 	{

--- a/AI/Nullkiller/Goals/RecruitHero.h
+++ b/AI/Nullkiller/Goals/RecruitHero.h
@@ -22,18 +22,20 @@ namespace Goals
 {
 	class DLL_EXPORT RecruitHero : public ElementarGoal<RecruitHero>
 	{
+	private:
+		const CGHeroInstance * heroToBuy;
+
 	public:
 		RecruitHero(const CGTownInstance * townWithTavern, const CGHeroInstance * heroToBuy)
-			: RecruitHero(townWithTavern)
+			: ElementarGoal(Goals::RECRUIT_HERO), heroToBuy(heroToBuy)
 		{
-			objid = heroToBuy->id.getNum();
+			town = townWithTavern;
+			priority = 1;
 		}
 
 		RecruitHero(const CGTownInstance * townWithTavern)
-			: ElementarGoal(Goals::RECRUIT_HERO)
+			: RecruitHero(townWithTavern, nullptr)
 		{
-			priority = 1;
-			town = townWithTavern;
 		}
 
 		virtual bool operator==(const RecruitHero & other) const override

--- a/AI/Nullkiller/Helpers/ArmyFormation.cpp
+++ b/AI/Nullkiller/Helpers/ArmyFormation.cpp
@@ -1,0 +1,68 @@
+/*
+* ArmyFormation.cpp, part of VCMI engine
+*
+* Authors: listed in file AUTHORS in main folder
+*
+* License: GNU General Public License v2.0 or later
+* Full text of license available in license.txt file, in main folder
+*
+*/
+#include "StdInc.h"
+#include "ArmyFormation.h"
+#include "../../../lib/mapObjects/CGTownInstance.h"
+
+namespace NKAI
+{
+
+void ArmyFormation::rearrangeArmyForSiege(const CGTownInstance * town, const CGHeroInstance * attacker)
+{
+	auto freeSlots = attacker->getFreeSlotsQueue();
+
+	while(!freeSlots.empty())
+	{
+		auto weakestCreature = vstd::minElementByFun(attacker->Slots(), [](const std::pair<SlotID, CStackInstance *> & slot) -> int
+			{
+				return slot.second->getCount() == 1
+					? std::numeric_limits<int>::max()
+					: slot.second->getCreatureID().toCreature()->getAIValue();
+			});
+
+		if(weakestCreature == attacker->Slots().end() || weakestCreature->second->getCount() == 1)
+		{
+			break;
+		}
+
+		cb->splitStack(attacker, attacker, weakestCreature->first, freeSlots.front(), 1);
+		freeSlots.pop();
+	}
+
+	if(town->fortLevel() > CGTownInstance::FORT)
+	{
+		std::vector<CStackInstance *> stacks;
+
+		for(auto slot : attacker->Slots())
+			stacks.push_back(slot.second);
+
+		boost::sort(
+			stacks,
+			[](CStackInstance * slot1, CStackInstance * slot2) -> bool
+			{
+				auto cre1 = slot1->getCreatureID().toCreature();
+				auto cre2 = slot2->getCreatureID().toCreature();
+				auto flying = cre1->hasBonusOfType(BonusType::FLYING) - cre2->hasBonusOfType(BonusType::FLYING);
+			
+				if(flying != 0) return flying < 0;
+				else return cre1->getAIValue() < cre2->getAIValue();
+			});
+
+		for(int i = 0; i < stacks.size(); i++)
+		{
+			auto pos = vstd::findKey(attacker->Slots(), stacks[i]);
+
+			if(pos.getNum() != i)
+				cb->swapCreatures(attacker, attacker, static_cast<SlotID>(i), pos);
+		}
+	}
+}
+
+}

--- a/AI/Nullkiller/Helpers/ArmyFormation.h
+++ b/AI/Nullkiller/Helpers/ArmyFormation.h
@@ -1,0 +1,39 @@
+/*
+* ArmyFormation.h, part of VCMI engine
+*
+* Authors: listed in file AUTHORS in main folder
+*
+* License: GNU General Public License v2.0 or later
+* Full text of license available in license.txt file, in main folder
+*
+*/
+#pragma once
+
+#include "../AIUtility.h"
+
+#include "../../../lib/GameConstants.h"
+#include "../../../lib/VCMI_Lib.h"
+#include "../../../lib/CTownHandler.h"
+#include "../../../lib/CBuildingHandler.h"
+
+namespace NKAI
+{
+
+struct HeroPtr;
+class AIGateway;
+class FuzzyHelper;
+class Nullkiller;
+
+class DLL_EXPORT ArmyFormation
+{
+private:
+	std::shared_ptr<CCallback> cb; //this is enough, but we downcast from CCallback
+	const Nullkiller * ai;
+
+public:
+	ArmyFormation(std::shared_ptr<CCallback> CB, const Nullkiller * ai): cb(CB), ai(ai) {}
+
+	void rearrangeArmyForSiege(const CGTownInstance * town, const CGHeroInstance * attacker);
+};
+
+}

--- a/AI/Nullkiller/Helpers/ArmyFormation.h
+++ b/AI/Nullkiller/Helpers/ArmyFormation.h
@@ -30,7 +30,7 @@ private:
 	std::shared_ptr<CCallback> cb; //this is enough, but we downcast from CCallback
 
 public:
-	ArmyFormation(std::shared_ptr<CCallback> CB, const Nullkiller * ai): cb(CB), ai(ai) {}
+	ArmyFormation(std::shared_ptr<CCallback> CB, const Nullkiller * ai): cb(CB) {}
 
 	void rearrangeArmyForSiege(const CGTownInstance * town, const CGHeroInstance * attacker);
 };

--- a/AI/Nullkiller/Helpers/ArmyFormation.h
+++ b/AI/Nullkiller/Helpers/ArmyFormation.h
@@ -28,7 +28,6 @@ class DLL_EXPORT ArmyFormation
 {
 private:
 	std::shared_ptr<CCallback> cb; //this is enough, but we downcast from CCallback
-	const Nullkiller * ai;
 
 public:
 	ArmyFormation(std::shared_ptr<CCallback> CB, const Nullkiller * ai): cb(CB), ai(ai) {}

--- a/AI/Nullkiller/Markers/ArmyUpgrade.cpp
+++ b/AI/Nullkiller/Markers/ArmyUpgrade.cpp
@@ -28,6 +28,13 @@ ArmyUpgrade::ArmyUpgrade(const AIPath & upgradePath, const CGObjectInstance * up
 	sethero(upgradePath.targetHero);
 }
 
+ArmyUpgrade::ArmyUpgrade(const CGHeroInstance * targetMain, const CGObjectInstance * upgrader, const ArmyUpgradeInfo & upgrade)
+	: CGoal(Goals::ARMY_UPGRADE), upgrader(upgrader), upgradeValue(upgrade.upgradeValue),
+	initialValue(targetMain->getArmyStrength()), goldCost(upgrade.upgradeCost[EGameResID::GOLD])
+{
+	sethero(targetMain);
+}
+
 bool ArmyUpgrade::operator==(const ArmyUpgrade & other) const
 {
 	return false;

--- a/AI/Nullkiller/Markers/ArmyUpgrade.h
+++ b/AI/Nullkiller/Markers/ArmyUpgrade.h
@@ -27,6 +27,7 @@ namespace Goals
 
 	public:
 		ArmyUpgrade(const AIPath & upgradePath, const CGObjectInstance * upgrader, const ArmyUpgradeInfo & upgrade);
+		ArmyUpgrade(const CGHeroInstance * targetMain, const CGObjectInstance * upgrader, const ArmyUpgradeInfo & upgrade);
 
 		virtual bool operator==(const ArmyUpgrade & other) const override;
 		virtual std::string toString() const override;

--- a/AI/Nullkiller/Markers/DefendTown.cpp
+++ b/AI/Nullkiller/Markers/DefendTown.cpp
@@ -18,8 +18,8 @@ namespace NKAI
 
 using namespace Goals;
 
-DefendTown::DefendTown(const CGTownInstance * town, const HitMapInfo & treat, const AIPath & defencePath)
-	: CGoal(Goals::DEFEND_TOWN), treat(treat), defenceArmyStrength(defencePath.getHeroStrength()), turn(defencePath.turn())
+DefendTown::DefendTown(const CGTownInstance * town, const HitMapInfo & treat, const AIPath & defencePath, bool isContrattack)
+	: CGoal(Goals::DEFEND_TOWN), treat(treat), defenceArmyStrength(defencePath.getHeroStrength()), turn(defencePath.turn()), contrattack(isContrattack)
 {
 	settown(town);
 	sethero(defencePath.targetHero);

--- a/AI/Nullkiller/Markers/DefendTown.cpp
+++ b/AI/Nullkiller/Markers/DefendTown.cpp
@@ -18,8 +18,8 @@ namespace NKAI
 
 using namespace Goals;
 
-DefendTown::DefendTown(const CGTownInstance * town, const HitMapInfo & treat, const AIPath & defencePath, bool isContrattack)
-	: CGoal(Goals::DEFEND_TOWN), treat(treat), defenceArmyStrength(defencePath.getHeroStrength()), turn(defencePath.turn()), contrattack(isContrattack)
+DefendTown::DefendTown(const CGTownInstance * town, const HitMapInfo & treat, const AIPath & defencePath, bool isCounterAttack)
+	: CGoal(Goals::DEFEND_TOWN), treat(treat), defenceArmyStrength(defencePath.getHeroStrength()), turn(defencePath.turn()), counterattack(isCounterAttack)
 {
 	settown(town);
 	sethero(defencePath.targetHero);

--- a/AI/Nullkiller/Markers/DefendTown.h
+++ b/AI/Nullkiller/Markers/DefendTown.h
@@ -24,9 +24,10 @@ namespace Goals
 		uint64_t defenceArmyStrength;
 		HitMapInfo treat;
 		uint8_t turn;
+		bool contrattack;
 
 	public:
-		DefendTown(const CGTownInstance * town, const HitMapInfo & treat, const AIPath & defencePath);
+		DefendTown(const CGTownInstance * town, const HitMapInfo & treat, const AIPath & defencePath, bool isContrattack = false);
 		DefendTown(const CGTownInstance * town, const HitMapInfo & treat, const CGHeroInstance * defender);
 
 		virtual bool operator==(const DefendTown & other) const override;
@@ -37,6 +38,8 @@ namespace Goals
 		uint64_t getDefenceStrength() const { return defenceArmyStrength; }
 
 		uint8_t getTurn() const { return turn; }
+
+		bool isContrAttack() { return contrattack; }
 	};
 }
 

--- a/AI/Nullkiller/Markers/DefendTown.h
+++ b/AI/Nullkiller/Markers/DefendTown.h
@@ -24,10 +24,10 @@ namespace Goals
 		uint64_t defenceArmyStrength;
 		HitMapInfo treat;
 		uint8_t turn;
-		bool contrattack;
+		bool counterattack;
 
 	public:
-		DefendTown(const CGTownInstance * town, const HitMapInfo & treat, const AIPath & defencePath, bool isContrattack = false);
+		DefendTown(const CGTownInstance * town, const HitMapInfo & treat, const AIPath & defencePath, bool isCounterAttack = false);
 		DefendTown(const CGTownInstance * town, const HitMapInfo & treat, const CGHeroInstance * defender);
 
 		virtual bool operator==(const DefendTown & other) const override;
@@ -39,7 +39,7 @@ namespace Goals
 
 		uint8_t getTurn() const { return turn; }
 
-		bool isContrAttack() { return contrattack; }
+		bool isCounterAttack() { return counterattack; }
 	};
 }
 

--- a/AI/Nullkiller/Markers/HeroExchange.cpp
+++ b/AI/Nullkiller/Markers/HeroExchange.cpp
@@ -29,7 +29,7 @@ bool HeroExchange::operator==(const HeroExchange & other) const
 
 std::string HeroExchange::toString() const
 {
-	return "Hero exchange " + exchangePath.toString();
+	return "Hero exchange for " +hero.get()->getObjectName() + " by " + exchangePath.toString();
 }
 
 uint64_t HeroExchange::getReinforcementArmyStrength() const

--- a/AI/Nullkiller/Pathfinding/AINodeStorage.cpp
+++ b/AI/Nullkiller/Pathfinding/AINodeStorage.cpp
@@ -879,8 +879,12 @@ void AINodeStorage::setHeroes(std::map<const CGHeroInstance *, HeroRole> heroes)
 	for(auto & hero : heroes)
 	{
 		// do not allow our own heroes in garrison to act on map
-		if(hero.first->getOwner() == ai->playerID && hero.first->inTownGarrison && ai->isHeroLocked(hero.first))
+		if(hero.first->getOwner() == ai->playerID
+			&& hero.first->inTownGarrison
+			&& (ai->isHeroLocked(hero.first) || ai->heroManager->heroCapReached()))
+		{
 			continue;
+		}
 
 		uint64_t mask = FirstActorMask << actors.size();
 		auto actor = std::make_shared<HeroActor>(hero.first, hero.second, mask, ai);

--- a/AI/Nullkiller/Pathfinding/AINodeStorage.cpp
+++ b/AI/Nullkiller/Pathfinding/AINodeStorage.cpp
@@ -879,7 +879,7 @@ void AINodeStorage::setHeroes(std::map<const CGHeroInstance *, HeroRole> heroes)
 	for(auto & hero : heroes)
 	{
 		// do not allow our own heroes in garrison to act on map
-		if(hero.first->getOwner() == ai->playerID && hero.first->inTownGarrison)
+		if(hero.first->getOwner() == ai->playerID && hero.first->inTownGarrison && ai->isHeroLocked(hero.first))
 			continue;
 
 		uint64_t mask = FirstActorMask << actors.size();

--- a/AI/Nullkiller/Pathfinding/AINodeStorage.cpp
+++ b/AI/Nullkiller/Pathfinding/AINodeStorage.cpp
@@ -879,7 +879,7 @@ void AINodeStorage::setHeroes(std::map<const CGHeroInstance *, HeroRole> heroes)
 	for(auto & hero : heroes)
 	{
 		// do not allow our own heroes in garrison to act on map
-		if(hero.first->getOwner() == ai->playerID && hero.first->inTownGarrison && ai->isHeroLocked(hero.first))
+		if(hero.first->getOwner() == ai->playerID && hero.first->inTownGarrison)
 			continue;
 
 		uint64_t mask = FirstActorMask << actors.size();

--- a/AI/Nullkiller/Pathfinding/AINodeStorage.h
+++ b/AI/Nullkiller/Pathfinding/AINodeStorage.h
@@ -11,7 +11,7 @@
 #pragma once
 
 #define NKAI_PATHFINDER_TRACE_LEVEL 0
-#define NKAI_TRACE_LEVEL 2
+#define NKAI_TRACE_LEVEL 0
 
 #include "../../../lib/pathfinder/CGPathNode.h"
 #include "../../../lib/pathfinder/INodeStorage.h"
@@ -258,7 +258,7 @@ public:
 	{
 		double ratio = (double)danger / (armyValue * hero->getFightingStrength());
 
-		return (uint64_t)(armyValue * ratio * ratio * ratio);
+		return (uint64_t)(armyValue * ratio * ratio);
 	}
 
 	STRONG_INLINE

--- a/AI/Nullkiller/Pathfinding/AINodeStorage.h
+++ b/AI/Nullkiller/Pathfinding/AINodeStorage.h
@@ -11,7 +11,7 @@
 #pragma once
 
 #define NKAI_PATHFINDER_TRACE_LEVEL 0
-#define NKAI_TRACE_LEVEL 0
+#define NKAI_TRACE_LEVEL 2
 
 #include "../../../lib/pathfinder/CGPathNode.h"
 #include "../../../lib/pathfinder/INodeStorage.h"
@@ -24,8 +24,8 @@
 
 namespace NKAI
 {
-	const int SCOUT_TURN_DISTANCE_LIMIT = 3;
-	const int MAIN_TURN_DISTANCE_LIMIT = 5;
+	const int SCOUT_TURN_DISTANCE_LIMIT = 5;
+	const int MAIN_TURN_DISTANCE_LIMIT = 10;
 
 namespace AIPathfinding
 {

--- a/AI/Nullkiller/Pathfinding/AIPathfinder.cpp
+++ b/AI/Nullkiller/Pathfinding/AIPathfinder.cpp
@@ -61,6 +61,11 @@ void AIPathfinder::updatePaths(std::map<const CGHeroInstance *, HeroRole> heroes
 	storage->setScoutTurnDistanceLimit(pathfinderSettings.scoutTurnDistanceLimit);
 	storage->setMainTurnDistanceLimit(pathfinderSettings.mainTurnDistanceLimit);
 
+	logAi->trace(
+		"Scout turn distance: %s, main %s",
+		std::to_string(pathfinderSettings.scoutTurnDistanceLimit),
+		std::to_string(pathfinderSettings.mainTurnDistanceLimit));
+
 	if(pathfinderSettings.useHeroChain)
 	{
 		storage->setTownsAndDwellings(cb->getTownsInfo(), ai->memory->visitableObjs);

--- a/AI/Nullkiller/Pathfinding/Actors.cpp
+++ b/AI/Nullkiller/Pathfinding/Actors.cpp
@@ -134,6 +134,7 @@ void ChainActor::setBaseActor(HeroActor * base)
 	armyCost = base->armyCost;
 	actorAction = base->actorAction;
 	tiCache = base->tiCache;
+	actorExchangeCount = base->actorExchangeCount;
 }
 
 void HeroActor::setupSpecialActors()

--- a/config/ai/object-priorities.txt
+++ b/config/ai/object-priorities.txt
@@ -6,9 +6,9 @@ InputVariable: mainTurnDistance
   range: 0.000 10.000
   lock-range: true
   term: LOWEST Ramp 0.250 0.000
-  term: LOW Discrete 0.000 1.000 0.500 0.800 1.000 0.000
-  term: MEDIUM Discrete 0.000 0.000 0.500 0.200 1.000 1.000 3.000 0.000
-  term: LONG Discrete 1.000 0.000 1.500 0.200 3.000 0.800 10.000 1.000
+  term: LOW Discrete 0.000 1.000 0.500 0.800 0.800 0.300 2.000 0.000
+  term: MEDIUM Discrete 0.000 0.000 0.500 0.200 0.800 0.700 2.000 1.000 6.000 0.000
+  term: LONG Discrete 2.000 0.000 6.000 1.000 10.000 0.800
 InputVariable: scoutTurnDistance
   description: distance to tile in turns
   enabled: true
@@ -43,6 +43,7 @@ InputVariable: armyLoss
   term: LOW Ramp 0.200 0.000
   term: MEDIUM Triangle 0.000 0.200 0.500
   term: HIGH Ramp 0.200 0.500
+  term: ALL Ramp 0.700 1.000
 InputVariable: heroRole
   enabled: true
   range: -0.100 1.100
@@ -82,13 +83,14 @@ InputVariable: closestHeroRatio
 InputVariable: strategicalValue
   description: Some abstract long term benefit non gold or army or skill
   enabled: true
-  range: 0.000 1.000
+  range: 0.000 3.000
   lock-range: false
   term: NONE Ramp 0.200 0.000
   term: LOWEST Triangle 0.000 0.010 0.250
-  term: LOW Triangle 0.000 0.250 0.700
-  term: MEDIUM Triangle 0.250 0.700 1.000
-  term: HIGH Ramp 0.700 1.000
+  term: LOW Triangle 0.000 0.250 1.000
+  term: MEDIUM Triangle 0.250 1.000 2.000
+  term: HIGH Triangle 1.000 2.000 3.000
+  term: CRITICAL Ramp 2.000 3.000
 InputVariable: goldPreasure
   description: Ratio between weekly army cost and gold income
   enabled: true
@@ -132,21 +134,22 @@ InputVariable: armyGrowth
   term: HUGE Ramp 8000.000 20000.000
 OutputVariable: Value
   enabled: true
-  range: -1.500 2.000
+  range: -1.500 2.500
   lock-range: false
   aggregation: AlgebraicSum
   defuzzifier: Centroid 100
   default: 0.500
   lock-previous: false
-  term: WORST Binary -1.000 -inf 0.500
+  term: WORST Binary -1.000 -inf 0.700
   term: BAD Rectangle -1.000 -0.700 0.500
-  term: BASE Rectangle -0.200 0.200 0.400
-  term: LOW Rectangle 1.110 1.190 0.320
-  term: HIGHEST Discrete 0.300 0.000 0.300 1.000 0.600 1.000 0.600 0.000 1.700 0.000 1.700 1.000 2.000 1.000 2.000 0.000 0.500
-  term: HIGH Discrete 0.600 0.000 0.600 1.000 0.850 1.000 0.850 0.000 1.450 0.000 1.450 1.000 1.700 1.000 1.700 0.000 0.400
-  term: BITHIGH Discrete 0.850 0.000 0.850 1.000 1.000 1.000 1.000 0.000 1.300 0.000 1.300 1.000 1.450 1.000 1.450 0.000 0.350
-  term: MEDIUM Discrete 1.000 0.000 1.000 1.000 1.100 1.000 1.100 0.000 1.200 0.000 1.200 1.000 1.300 1.000 1.300 0.000 0.330
-RuleBlock: gold reward
+  term: BASE Rectangle -0.200 0.200 0.350
+  term: MEDIUM Rectangle 0.910 1.090 0.500
+  term: SMALL Rectangle 0.960 1.040 0.600
+  term: BITHIGH Rectangle 0.850 1.150 0.400
+  term: HIGH Rectangle 0.750 1.250 0.400
+  term: HIGHEST Rectangle 0.500 1.500 0.350
+  term: CRITICAL Ramp 0.500 2.000 0.500
+RuleBlock: basic
   enabled: true
   conjunction: AlgebraicProduct
   disjunction: AlgebraicSum
@@ -154,6 +157,61 @@ RuleBlock: gold reward
   activation: General
   rule: if heroRole is MAIN then Value is BASE
   rule: if heroRole is SCOUT then Value is BASE
-  rule: if heroRole is MAIN and armyGrowth is HUGE then Value is HIGH
-  rule: if heroRole is MAIN and armyGrowth is BIG then Value is BITHIGH
-  rule: if heroRole is MAIN and strategicalValue is HIGH then Value is HIGHEST
+  rule: if heroRole is MAIN and armyGrowth is HUGE and fear is not HIGH then Value is HIGH
+  rule: if heroRole is MAIN and armyGrowth is BIG and mainTurnDistance is LOW then Value is HIGH
+  rule: if heroRole is MAIN and armyGrowth is BIG and mainTurnDistance is MEDIUM and fear is not HIGH then Value is BITHIGH
+  rule: if heroRole is MAIN and armyGrowth is BIG and mainTurnDistance is LONG and fear is not HIGH then Value is MEDIUM
+  rule: if armyLoss is ALL then Value is WORST
+  rule: if turn is not NOW then Value is BAD with 0.1
+  rule: if closestHeroRatio is LOWEST and heroRole is SCOUT then Value is WORST
+  rule: if closestHeroRatio is LOW and heroRole is SCOUT then Value is BAD
+  rule: if closestHeroRatio is LOWEST and heroRole is MAIN then Value is BAD
+RuleBlock: strategicalValue
+  enabled: true
+  conjunction: AlgebraicProduct
+  disjunction: NormalizedSum
+  implication: AlgebraicProduct
+  activation: General
+  rule: if heroRole is MAIN and strategicalValue is HIGH and turn is NOW then Value is HIGHEST
+  rule: if heroRole is MAIN and strategicalValue is HIGH and turn is not NOW and mainTurnDistance is LOW and fear is not HIGH then Value is HIGHEST
+  rule: if heroRole is MAIN and strategicalValue is HIGH and mainTurnDistance is MEDIUM and fear is not HIGH then Value is HIGHEST with 0.5
+  rule: if heroRole is MAIN and strategicalValue is HIGH and mainTurnDistance is LONG and fear is not HIGH then Value is HIGH
+  rule: if heroRole is MAIN and strategicalValue is MEDIUM and mainTurnDistance is LOW then Value is HIGH
+  rule: if heroRole is MAIN and strategicalValue is MEDIUM and mainTurnDistance is MEDIUM and fear is not HIGH then Value is BITHIGH
+  rule: if heroRole is MAIN and strategicalValue is MEDIUM and mainTurnDistance is LONG and fear is not HIGH then Value is MEDIUM
+  rule: if heroRole is MAIN and strategicalValue is LOW and mainTurnDistance is LOW and fear is not HIGH then Value is MEDIUM
+  rule: if heroRole is MAIN and strategicalValue is LOW and mainTurnDistance is MEDIUM and fear is not HIGH then Value is SMALL
+  rule: if heroRole is SCOUT and strategicalValue is HIGH and danger is not NONE and turn is NOW then Value is HIGH
+  rule: if heroRole is SCOUT and strategicalValue is HIGH and danger is not NONE and turn is not NOW and scoutTurnDistance is LOW and fear is not HIGH then Value is HIGH
+  rule: if heroRole is SCOUT and strategicalValue is HIGH and danger is not NONE and scoutTurnDistance is MEDIUM and fear is not HIGH then Value is HIGH with 0.5
+  rule: if heroRole is SCOUT and strategicalValue is HIGH and danger is not NONE and scoutTurnDistance is LONG and fear is not HIGH then Value is BITHIGH
+  rule: if heroRole is SCOUT and strategicalValue is MEDIUM and danger is not NONE and scoutTurnDistance is LOW then Value is BITHIGH
+  rule: if heroRole is SCOUT and strategicalValue is MEDIUM and danger is not NONE and scoutTurnDistance is MEDIUM and fear is not HIGH then Value is MEDIUM
+  rule: if heroRole is SCOUT and strategicalValue is MEDIUM and danger is not NONE and scoutTurnDistance is LONG and fear is not HIGH then Value is SMALL
+  rule: if heroRole is SCOUT and strategicalValue is LOW and danger is not NONE and scoutTurnDistance is LOW and fear is not HIGH then Value is SMALL
+  rule: if heroRole is SCOUT and strategicalValue is HIGH and danger is NONE and turn is NOW then Value is HIGHEST
+  rule: if heroRole is SCOUT and strategicalValue is HIGH and danger is NONE and turn is not NOW and scoutTurnDistance is LOW and fear is not HIGH then Value is HIGHEST
+  rule: if heroRole is SCOUT and strategicalValue is HIGH and danger is NONE and scoutTurnDistance is MEDIUM and fear is not HIGH then Value is HIGHEST with 0.5
+  rule: if heroRole is SCOUT and strategicalValue is HIGH and danger is NONE and scoutTurnDistance is LONG and fear is not HIGH then Value is HIGH
+  rule: if heroRole is SCOUT and strategicalValue is MEDIUM and danger is NONE and scoutTurnDistance is LOW then Value is HIGH
+  rule: if heroRole is SCOUT and strategicalValue is MEDIUM and danger is NONE and scoutTurnDistance is MEDIUM and fear is not HIGH then Value is BITHIGH
+  rule: if heroRole is SCOUT and strategicalValue is MEDIUM and danger is NONE and scoutTurnDistance is LONG and fear is not HIGH then Value is MEDIUM
+  rule: if heroRole is SCOUT and strategicalValue is LOW and danger is NONE and scoutTurnDistance is LOW and fear is not HIGH then Value is MEDIUM
+  rule: if heroRole is SCOUT and strategicalValue is LOW and danger is NONE and scoutTurnDistance is MEDIUM and fear is not HIGH then Value is SMALL
+  rule: if armyLoss is HIGH and strategicalValue is LOW then Value is BAD
+  rule: if armyLoss is HIGH and strategicalValue is MEDIUM then Value is BAD with 0.7
+  rule: if strategicalValue is CRITICAL then Value is CRITICAL
+RuleBlock: armyReward
+  enabled: true
+  conjunction: AlgebraicProduct
+  disjunction: AlgebraicSum
+  implication: AlgebraicProduct
+  activation: General
+  rule: if heroRole is MAIN and armyReward is HIGH and mainTurnDistance is LOW and fear is not HIGH then Value is HIGHEST
+  rule: if heroRole is MAIN and armyReward is HIGH and mainTurnDistance is MEDIUM and fear is not HIGH then Value is HIGH
+  rule: if heroRole is MAIN and armyReward is HIGH and mainTurnDistance is LONG and fear is not HIGH then Value is BITHIGH
+  rule: if heroRole is MAIN and armyReward is MEDIUM and mainTurnDistance is LOW then Value is HIGH
+  rule: if heroRole is MAIN and armyReward is MEDIUM and mainTurnDistance is MEDIUM and fear is not HIGH then Value is BITHIGH
+  rule: if heroRole is MAIN and armyReward is MEDIUM and mainTurnDistance is LONG and fear is not HIGH then Value is MEDIUM
+  rule: if heroRole is MAIN and armyReward is LOW and mainTurnDistance is LOW and fear is not HIGH then Value is MEDIUM
+  rule: if heroRole is MAIN and armyReward is LOW and mainTurnDistance is MEDIUM and fear is not HIGH then Value is SMALL

--- a/config/ai/object-priorities.txt
+++ b/config/ai/object-priorities.txt
@@ -5,7 +5,7 @@ InputVariable: mainTurnDistance
   enabled: true
   range: 0.000 10.000
   lock-range: true
-  term: LOWEST Ramp 0.250 0.000
+  term: LOWEST Ramp 0.400 0.000
   term: LOW Discrete 0.000 1.000 0.500 0.800 0.800 0.300 2.000 0.000
   term: MEDIUM Discrete 0.000 0.000 0.500 0.200 0.800 0.700 2.000 1.000 6.000 0.000
   term: LONG Discrete 2.000 0.000 6.000 1.000 10.000 0.800
@@ -239,3 +239,21 @@ RuleBlock: gold
   rule: if goldReward is MEDIUM and goldPreasure is HIGH and heroRole is MAIN and danger is not NONE and armyLoss is LOW then Value is BITHIGH
   rule: if goldReward is SMALL and goldPreasure is HIGH and heroRole is SCOUT and danger is NONE then Value is MEDIUM
   rule: if goldReward is SMALL and goldPreasure is HIGH and heroRole is MAIN and danger is not NONE and armyLoss is LOW then Value is SMALL
+RuleBlock: skill reward
+  enabled: true
+  conjunction: AlgebraicProduct
+  disjunction: AlgebraicSum
+  implication: AlgebraicProduct
+  activation: General
+  rule: if heroRole is MAIN and skillReward is LOW and mainTurnDistance is LOWEST and fear is not HIGH then Value is HIGH
+  rule: if heroRole is MAIN and skillReward is MEDIUM and mainTurnDistance is LOWEST and fear is not HIGH then Value is HIGHEST
+  rule: if heroRole is MAIN and skillReward is HIGH and mainTurnDistance is LOWEST and fear is not HIGH then Value is HIGHEST
+  rule: if heroRole is MAIN and skillReward is LOW and mainTurnDistance is LOW and fear is not HIGH then Value is BITHIGH
+  rule: if heroRole is MAIN and skillReward is MEDIUM and mainTurnDistance is LOW and fear is not HIGH then Value is HIGH
+  rule: if heroRole is MAIN and skillReward is HIGH and mainTurnDistance is LOW and fear is not HIGH then Value is HIGHEST
+  rule: if heroRole is MAIN and skillReward is LOW and mainTurnDistance is MEDIUM and fear is not HIGH then Value is MEDIUM
+  rule: if heroRole is MAIN and skillReward is MEDIUM and mainTurnDistance is MEDIUM and fear is not HIGH then Value is BITHIGH
+  rule: if heroRole is MAIN and skillReward is HIGH and mainTurnDistance is MEDIUM and fear is not HIGH then Value is HIGH
+  rule: if heroRole is MAIN and skillReward is LOW and mainTurnDistance is LONG and fear is not HIGH then Value is SMALL
+  rule: if heroRole is MAIN and skillReward is MEDIUM and mainTurnDistance is LONG and fear is not HIGH then Value is MEDIUM
+  rule: if heroRole is MAIN and skillReward is HIGH and mainTurnDistance is LONG and fear is not HIGH then Value is BITHIGH

--- a/config/ai/object-priorities.txt
+++ b/config/ai/object-priorities.txt
@@ -23,11 +23,11 @@ InputVariable: goldReward
   enabled: true
   range: 0.000 5000.000
   lock-range: true
-  term: LOW Triangle 10.000 500.000 2000.000
-  term: MEDIUM Triangle 500.000 2000.000 5000.000
-  term: HIGH Ramp 2000.000 5000.000
-  term: NONE Ramp 100.000 0.000
-  term: LOWEST Triangle 0.000 100.000 500.000
+  term: LOWEST Triangle 0.000 100.000 200.000
+  term: SMALL Triangle 100.000 200.000 400.000
+  term: MEDIUM Triangle 200.000 400.000 1000.000
+  term: BIG Triangle 400.000 1000.000 5000.000
+  term: HUGE Ramp 1000.000 5000.000
 InputVariable: armyReward
   enabled: true
   range: 0.000 10000.000
@@ -97,7 +97,7 @@ InputVariable: goldPreasure
   range: 0.000 1.000
   lock-range: false
   term: LOW Ramp 0.300 0.000
-  term: HIGH Discrete 0.100 0.000 0.250 0.100 0.300 0.200 0.400 0.700 1.000 1.000
+  term: HIGH Discrete 0.100 0.000 0.250 0.200 0.300 0.300 0.400 0.700 1.000 1.000
 InputVariable: goldCost
   description: Action cost in gold
   enabled: true
@@ -215,3 +215,22 @@ RuleBlock: armyReward
   rule: if heroRole is MAIN and armyReward is MEDIUM and mainTurnDistance is LONG and fear is not HIGH then Value is MEDIUM
   rule: if heroRole is MAIN and armyReward is LOW and mainTurnDistance is LOW and fear is not HIGH then Value is MEDIUM
   rule: if heroRole is MAIN and armyReward is LOW and mainTurnDistance is MEDIUM and fear is not HIGH then Value is SMALL
+RuleBlock: gold
+  enabled: true
+  conjunction: AlgebraicProduct
+  disjunction: AlgebraicSum
+  implication: AlgebraicProduct
+  activation: General
+  rule: if goldReward is HUGE and goldPreasure is HIGH and heroRole is SCOUT and danger is NONE then Value is HIGHEST
+  rule: if goldReward is HUGE and goldPreasure is HIGH and heroRole is SCOUT and danger is not NONE and armyLoss is LOW then Value is BITHIGH
+  rule: if goldReward is HUGE and heroRole is MAIN and danger is not NONE and armyLoss is LOW then Value is HIGHEST
+  rule: if goldReward is HUGE and goldPreasure is HIGH and heroRole is MAIN and danger is NONE then Value is HIGH
+  rule: if goldReward is BIG and goldPreasure is HIGH and heroRole is SCOUT and danger is NONE then Value is HIGH
+  rule: if goldReward is BIG and goldPreasure is HIGH and heroRole is SCOUT and danger is not NONE then Value is MEDIUM
+  rule: if goldReward is BIG and goldPreasure is HIGH and heroRole is MAIN and danger is not NONE and armyLoss is LOW then Value is HIGH
+  rule: if goldReward is BIG and goldPreasure is HIGH and heroRole is MAIN and danger is NONE then Value is MEDIUM
+  rule: if goldReward is MEDIUM and goldPreasure is HIGH and heroRole is SCOUT and danger is NONE then Value is BITHIGH
+  rule: if goldReward is MEDIUM and goldPreasure is HIGH and heroRole is SCOUT and danger is not NONE then Value is SMALL
+  rule: if goldReward is MEDIUM and goldPreasure is HIGH and heroRole is MAIN and danger is not NONE and armyLoss is LOW then Value is BITHIGH
+  rule: if goldReward is SMALL and goldPreasure is HIGH and heroRole is SCOUT and danger is NONE then Value is MEDIUM
+  rule: if goldReward is SMALL and goldPreasure is HIGH and heroRole is MAIN and danger is not NONE and armyLoss is LOW then Value is SMALL

--- a/config/ai/object-priorities.txt
+++ b/config/ai/object-priorities.txt
@@ -121,106 +121,39 @@ InputVariable: fear
   term: LOW Triangle 0.000 0.500 1.000
   term: MEDIUM Triangle 0.500 1.000 1.500
   term: HIGH Ramp 1.000 1.800
+InputVariable: armyGrowth
+  enabled: true
+  range: 0.000 20000.000
+  lock-range: false
+  term: NONE Ramp 100.000 0.000
+  term: SMALL Triangle 0.000 1000.000 3000.000
+  term: MEDIUM Triangle 1000.000 3000.000 8000.000
+  term: BIG Triangle 3000.000 8000.000 20000.000
+  term: HUGE Ramp 8000.000 20000.000
 OutputVariable: Value
   enabled: true
-  range: -0.500 1.500
+  range: -1.500 2.000
   lock-range: false
   aggregation: AlgebraicSum
   defuzzifier: Centroid 100
   default: 0.500
   lock-previous: false
-  term: LOWEST Discrete -0.500 0.000 -0.500 1.000 -0.200 1.000 -0.200 0.000 0.200 0.000 0.200 1.000 0.500 1.000 0.500 0.000 0.500
-  term: BITLOW Rectangle -0.010 0.010 0.500
-  term: LOW Discrete -0.150 0.000 -0.150 1.000 -0.050 1.000 -0.050 0.000 0.050 0.000 0.050 1.000 0.150 1.000 0.150 0.000 0.500
-  term: MEDIUM Triangle 0.450 0.500 0.550 0.050
-  term: HIGH Discrete 0.850 0.000 0.850 1.000 0.950 1.000 0.950 0.000 1.050 0.000 1.050 1.000 1.150 1.000 1.150 0.000 0.500
-  term: HIGHEST Discrete 0.500 0.000 0.500 1.000 0.800 1.000 0.800 0.000 1.200 0.000 1.200 1.000 1.500 1.000 1.500 0.000 0.500
-  term: BITHIGH Rectangle 0.990 1.010 0.500
+  term: WORST Binary -1.000 -inf 0.500
+  term: BAD Rectangle -1.000 -0.700 0.500
+  term: BASE Rectangle -0.200 0.200 0.400
+  term: LOW Rectangle 1.110 1.190 0.320
+  term: HIGHEST Discrete 0.300 0.000 0.300 1.000 0.600 1.000 0.600 0.000 1.700 0.000 1.700 1.000 2.000 1.000 2.000 0.000 0.500
+  term: HIGH Discrete 0.600 0.000 0.600 1.000 0.850 1.000 0.850 0.000 1.450 0.000 1.450 1.000 1.700 1.000 1.700 0.000 0.400
+  term: BITHIGH Discrete 0.850 0.000 0.850 1.000 1.000 1.000 1.000 0.000 1.300 0.000 1.300 1.000 1.450 1.000 1.450 0.000 0.350
+  term: MEDIUM Discrete 1.000 0.000 1.000 1.000 1.100 1.000 1.100 0.000 1.200 0.000 1.200 1.000 1.300 1.000 1.300 0.000 0.330
 RuleBlock: gold reward
   enabled: true
   conjunction: AlgebraicProduct
   disjunction: AlgebraicSum
   implication: AlgebraicProduct
   activation: General
-  rule: if turn is NOW and mainTurnDistance is very LONG and heroRole is SCOUT then Value is LOW with 0.5
-  rule: if turn is NOW and mainTurnDistance is LONG and heroRole is SCOUT then Value is LOW with 0.3
-  rule: if turn is NOW and scoutTurnDistance is LONG and heroRole is SCOUT then Value is LOW with 0.3
-  rule: if turn is NOW and mainTurnDistance is LONG and heroRole is MAIN then Value is LOW with 0.3
-  rule: if turn is NEXT and mainTurnDistance is very LONG and heroRole is SCOUT then Value is LOW with 0.8
-  rule: if turn is NEXT and scoutTurnDistance is LONG and heroRole is SCOUT then Value is BITLOW
-  rule: if turn is NEXT and mainTurnDistance is LONG and heroRole is MAIN then Value is LOW with 0.3
-  rule: if turn is NEXT and mainTurnDistance is LONG and heroRole is SCOUT then Value is BITLOW with 0.3
-  rule: if turn is FUTURE and scoutTurnDistance is very LONG and heroRole is SCOUT then Value is LOWEST with 0.3
-  rule: if turn is FUTURE and mainTurnDistance is very LONG and heroRole is SCOUT then Value is LOWEST with 0.5
-  rule: if turn is FUTURE and mainTurnDistance is very LONG and heroRole is MAIN and strategicalValue is NONE then Value is LOWEST with 0.5
-  rule: if turn is FUTURE and mainTurnDistance is very LONG and heroRole is MAIN and strategicalValue is LOW then Value is LOWEST with 0.3
-  rule: if turn is FUTURE and mainTurnDistance is very LONG and heroRole is MAIN and strategicalValue is MEDIUM then Value is LOW with 0.5
-  rule: if turn is FUTURE and mainTurnDistance is very LONG and heroRole is MAIN and strategicalValue is HIGH then Value is BITLOW
-  rule: if turn is FUTURE and scoutTurnDistance is LONG and heroRole is SCOUT then Value is LOW
-  rule: if turn is FUTURE and mainTurnDistance is LONG and heroRole is MAIN then Value is LOW
-  rule: if turn is FUTURE and mainTurnDistance is LONG and heroRole is SCOUT then Value is LOW
-  rule: if scoutTurnDistance is MEDIUM and heroRole is SCOUT then Value is BITLOW
-  rule: if mainTurnDistance is MEDIUM then Value is BITLOW
-  rule: if scoutTurnDistance is LOW and heroRole is SCOUT then Value is MEDIUM
-  rule: if mainTurnDistance is LOW then Value is MEDIUM
-  rule: if goldReward is HIGH and goldPreasure is HIGH and heroRole is SCOUT and danger is not NONE and armyLoss is LOW then Value is BITHIGH
-  rule: if goldReward is HIGH and goldPreasure is HIGH and heroRole is SCOUT and danger is NONE then Value is HIGH with 0.7
-  rule: if goldReward is HIGH and goldPreasure is HIGH and heroRole is MAIN and danger is not NONE and armyLoss is LOW and fear is not HIGH then Value is HIGHEST
-  rule: if goldReward is HIGH and goldPreasure is HIGH and heroRole is MAIN and danger is NONE then Value is BITHIGH
-  rule: if goldReward is MEDIUM and goldPreasure is HIGH and heroRole is SCOUT and danger is NONE then Value is HIGH
-  rule: if goldReward is MEDIUM and goldPreasure is HIGH and armyLoss is LOW and heroRole is SCOUT and danger is not NONE then Value is MEDIUM
-  rule: if goldReward is MEDIUM and heroRole is MAIN and danger is NONE and rewardType is SINGLE then Value is BITLOW
-  rule: if goldReward is MEDIUM and goldPreasure is HIGH and armyLoss is LOW and heroRole is MAIN and danger is not NONE then Value is BITHIGH
-  rule: if goldReward is LOW and goldPreasure is HIGH and heroRole is SCOUT and armyLoss is LOW then Value is BITHIGH
-  rule: if goldReward is LOW and heroRole is MAIN and danger is not NONE and rewardType is SINGLE and armyLoss is LOW then Value is BITLOW
-  rule: if goldReward is LOW and heroRole is MAIN and danger is NONE and rewardType is SINGLE then Value is LOW
-  rule: if goldReward is LOWEST and heroRole is MAIN and danger is NONE and rewardType is SINGLE then Value is LOWEST
-  rule: if armyReward is HIGH and heroRole is SCOUT and danger is not NONE and armyLoss is LOW then Value is HIGH with 0.5
-  rule: if armyReward is HIGH and heroRole is SCOUT and danger is NONE then Value is HIGHEST
-  rule: if armyReward is HIGH and heroRole is MAIN and rewardType is MIXED and armyLoss is LOW and fear is not HIGH then Value is HIGHEST
-  rule: if armyReward is HIGH and heroRole is MAIN and rewardType is SINGLE and mainTurnDistance is LOWEST then Value is HIGHEST
-  rule: if armyReward is HIGH and heroRole is MAIN and rewardType is SINGLE and danger is NONE and fear is not HIGH then Value is HIGH
-  rule: if armyReward is HIGH and heroRole is MAIN and rewardType is SINGLE and danger is not NONE and armyLoss is LOW and fear is not HIGH then Value is HIGHEST
-  rule: if armyReward is MEDIUM and heroRole is MAIN and danger is not NONE and armyLoss is LOW and fear is not HIGH then Value is HIGHEST with 0.5
-  rule: if armyReward is MEDIUM and heroRole is MAIN and danger is NONE then Value is BITHIGH
-  rule: if armyReward is MEDIUM and heroRole is MAIN and danger is NONE and mainTurnDistance is LOWEST then Value is HIGH with 0.2
-  rule: if armyReward is MEDIUM and heroRole is SCOUT and danger is NONE then Value is HIGHEST with 0.5
-  rule: if armyReward is LOW and heroRole is SCOUT and danger is NONE then Value is HIGH
-  rule: if armyReward is LOW and heroRole is MAIN and danger is not NONE and armyLoss is LOW then Value is HIGH
-  rule: if armyReward is LOW and heroRole is MAIN and danger is NONE then Value is BITLOW with 0.5
-  rule: if armyReward is LOW and heroRole is MAIN and danger is NONE and mainTurnDistance is LOWEST then Value is HIGH
-  rule: if skillReward is LOW and heroRole is MAIN and armyLoss is LOW then Value is BITHIGH
-  rule: if skillReward is MEDIUM and heroRole is MAIN and armyLoss is LOW and fear is not HIGH then Value is BITHIGH
-  rule: if skillReward is MEDIUM and heroRole is MAIN and rewardType is MIXED and armyLoss is LOW and fear is not HIGH then Value is HIGH with 0.5
-  rule: if skillReward is HIGH and heroRole is MAIN and armyLoss is LOW and fear is not HIGH then Value is HIGH
-  rule: if skillReward is MEDIUM and heroRole is SCOUT then Value is LOWEST
-  rule: if skillReward is HIGH and heroRole is SCOUT then Value is LOWEST
-  rule: if strategicalValue is LOW and heroRole is MAIN and armyLoss is LOW then Value is BITHIGH
-  rule: if strategicalValue is LOWEST and heroRole is MAIN and armyLoss is LOW then Value is LOW
-  rule: if strategicalValue is LOW and heroRole is SCOUT and armyLoss is LOW and fear is not HIGH then Value is HIGH with 0.5
-  rule: if strategicalValue is MEDIUM and heroRole is SCOUT and danger is NONE and fear is not HIGH then Value is HIGH
-  rule: if strategicalValue is HIGH and heroRole is SCOUT and danger is NONE and fear is not HIGH then Value is HIGHEST with 0.5
-  rule: if strategicalValue is HIGH and heroRole is MAIN and armyLoss is LOW and fear is not HIGH then Value is HIGHEST
-  rule: if strategicalValue is HIGH and heroRole is MAIN and armyLoss is MEDIUM and fear is not HIGH then Value is HIGH
-  rule: if strategicalValue is MEDIUM and heroRole is MAIN and armyLoss is LOW and fear is not HIGH then Value is HIGH
-  rule: if rewardType is NONE then Value is LOWEST
-  rule: if armyLoss is HIGH and strategicalValue is not HIGH and heroRole is MAIN then Value is LOWEST
-  rule: if armyLoss is HIGH and strategicalValue is HIGH and heroRole is MAIN then Value is LOW
-  rule: if armyLoss is HIGH and heroRole is SCOUT then Value is LOWEST
-  rule: if heroRole is SCOUT and closestHeroRatio is LOW then Value is LOW
-  rule: if heroRole is SCOUT and closestHeroRatio is LOWEST then Value is LOWEST
-  rule: if heroRole is MAIN and danger is NONE and skillReward is NONE and rewardType is SINGLE and closestHeroRatio is LOW then Value is LOW
-  rule: if heroRole is MAIN and danger is NONE and skillReward is NONE and rewardType is SINGLE and closestHeroRatio is LOWEST then Value is LOWEST
-  rule: if heroRole is MAIN and danger is not NONE and armyLoss is LOW then Value is BITHIGH with 0.2
-  rule: if heroRole is SCOUT then Value is BITLOW
-  rule: if goldCost is not NONE and goldReward is NONE and goldPreasure is HIGH then Value is LOWEST
-  rule: if turn is NOW then Value is LOW with 0.3
-  rule: if turn is not NOW then Value is LOW with 0.4
-  rule: if goldPreasure is HIGH and goldReward is HIGH and heroRole is MAIN and danger is not NONE and armyLoss is LOW and fear is not HIGH then Value is HIGHEST
-  rule: if goldPreasure is HIGH and goldReward is MEDIUM and heroRole is MAIN and danger is not NONE and armyLoss is LOW and fear is not HIGH then Value is HIGH
-  rule: if goldPreasure is HIGH and goldReward is HIGH and heroRole is SCOUT and danger is NONE and armyLoss is LOW and fear is not HIGH then Value is HIGHEST
-  rule: if goldPreasure is HIGH and goldReward is MEDIUM and heroRole is SCOUT and danger is NONE and armyLoss is LOW and fear is not HIGH then Value is HIGH
-  rule: if goldPreasure is HIGH and goldReward is LOW and heroRole is SCOUT and armyLoss is LOW then Value is BITHIGH
-  rule: if goldPreasure is HIGH and goldReward is LOW and heroRole is SCOUT and scoutTurnDistance is LOW and armyLoss is LOW then Value is HIGH with 0.5
-  rule: if fear is MEDIUM then Value is LOW
-  rule: if fear is HIGH then Value is LOWEST
+  rule: if heroRole is MAIN then Value is BASE
+  rule: if heroRole is SCOUT then Value is BASE
+  rule: if heroRole is MAIN and armyGrowth is HUGE then Value is HIGH
+  rule: if heroRole is MAIN and armyGrowth is BIG then Value is BITHIGH
+  rule: if heroRole is MAIN and strategicalValue is HIGH then Value is HIGHEST

--- a/config/ai/object-priorities.txt
+++ b/config/ai/object-priorities.txt
@@ -170,7 +170,6 @@ RuleBlock: basic
   rule: if heroRole is SCOUT and turn is NOW and mainTurnDistance is MEDIUM then Value is BAD
   rule: if heroRole is SCOUT and turn is NEXT and mainTurnDistance is LONG then Value is BAD
   rule: if heroRole is SCOUT and turn is NOW and scoutTurnDistance is LONG then Value is BAD
-  rule: if heroRole is SCOUT and turn is NOW and scoutTurnDistance is MEDIUM then Value is BAD with 0.3
   rule: if heroRole is SCOUT and fear is HIGH then Value is BAD with 0.8
   rule: if heroRole is SCOUT and fear is MEDIUM then Value is BAD with 0.5
   rule: if heroRole is MAIN and fear is HIGH then Value is BAD with 0.5
@@ -252,6 +251,11 @@ RuleBlock: gold
   rule: if goldReward is MEDIUM and goldPreasure is HIGH and heroRole is MAIN and danger is not NONE and armyLoss is LOW then Value is BITHIGH
   rule: if goldReward is SMALL and goldPreasure is HIGH and heroRole is SCOUT and danger is NONE then Value is MEDIUM
   rule: if goldReward is SMALL and goldPreasure is HIGH and heroRole is MAIN and danger is not NONE and armyLoss is LOW then Value is SMALL
+  rule: if goldReward is LOWEST then Value is SMALL with 0.1
+  rule: if goldReward is SMALL then Value is SMALL with 0.2
+  rule: if goldReward is MEDIUM then Value is SMALL with 0.5
+  rule: if goldReward is BIG then Value is SMALL
+  rule: if goldReward is HUGE then Value is BITHIGH
 RuleBlock: skill reward
   enabled: true
   conjunction: AlgebraicProduct

--- a/config/ai/object-priorities.txt
+++ b/config/ai/object-priorities.txt
@@ -166,6 +166,11 @@ RuleBlock: basic
   rule: if closestHeroRatio is LOWEST and heroRole is SCOUT then Value is WORST
   rule: if closestHeroRatio is LOW and heroRole is SCOUT then Value is BAD
   rule: if closestHeroRatio is LOWEST and heroRole is MAIN then Value is BAD
+  rule: if heroRole is SCOUT and turn is NOW and mainTurnDistance is LONG then Value is WORST
+  rule: if heroRole is SCOUT and turn is NOW and mainTurnDistance is MEDIUM then Value is BAD
+  rule: if heroRole is SCOUT and turn is NEXT and mainTurnDistance is LONG then Value is BAD
+  rule: if heroRole is SCOUT and turn is NOW and scoutTurnDistance is LONG then Value is BAD
+  rule: if heroRole is SCOUT and turn is NOW and scoutTurnDistance is MEDIUM then Value is BAD with 0.3
 RuleBlock: strategicalValue
   enabled: true
   conjunction: AlgebraicProduct

--- a/config/ai/object-priorities.txt
+++ b/config/ai/object-priorities.txt
@@ -171,6 +171,10 @@ RuleBlock: basic
   rule: if heroRole is SCOUT and turn is NEXT and mainTurnDistance is LONG then Value is BAD
   rule: if heroRole is SCOUT and turn is NOW and scoutTurnDistance is LONG then Value is BAD
   rule: if heroRole is SCOUT and turn is NOW and scoutTurnDistance is MEDIUM then Value is BAD with 0.3
+  rule: if heroRole is SCOUT and fear is HIGH then Value is BAD with 0.8
+  rule: if heroRole is SCOUT and fear is MEDIUM then Value is BAD with 0.5
+  rule: if heroRole is MAIN and fear is HIGH then Value is BAD with 0.5
+  rule: if heroRole is MAIN and fear is MEDIUM then Value is BAD with 0.2
 RuleBlock: strategicalValue
   enabled: true
   conjunction: AlgebraicProduct
@@ -205,7 +209,8 @@ RuleBlock: strategicalValue
   rule: if heroRole is SCOUT and strategicalValue is LOW and danger is NONE and scoutTurnDistance is MEDIUM and fear is not HIGH then Value is SMALL
   rule: if armyLoss is HIGH and strategicalValue is LOW then Value is BAD
   rule: if armyLoss is HIGH and strategicalValue is MEDIUM then Value is BAD with 0.7
-  rule: if strategicalValue is CRITICAL then Value is CRITICAL
+  rule: if strategicalValue is CRITICAL and heroRole is MAIN then Value is CRITICAL
+  rule: if strategicalValue is CRITICAL and heroRole is SCOUT then Value is CRITICAL with 0.7
 RuleBlock: armyReward
   enabled: true
   conjunction: AlgebraicProduct
@@ -220,6 +225,14 @@ RuleBlock: armyReward
   rule: if heroRole is MAIN and armyReward is MEDIUM and mainTurnDistance is LONG and fear is not HIGH then Value is MEDIUM
   rule: if heroRole is MAIN and armyReward is LOW and mainTurnDistance is LOW and fear is not HIGH then Value is MEDIUM
   rule: if heroRole is MAIN and armyReward is LOW and mainTurnDistance is MEDIUM and fear is not HIGH then Value is SMALL
+  rule: if heroRole is SCOUT and armyReward is HIGH and danger is NONE and scoutTurnDistance is LOW and fear is not HIGH then Value is HIGH
+  rule: if heroRole is SCOUT and armyReward is HIGH and danger is NONE and scoutTurnDistance is MEDIUM and fear is not HIGH then Value is HIGH with 0.7
+  rule: if heroRole is SCOUT and armyReward is HIGH and danger is NONE and scoutTurnDistance is LONG and fear is not HIGH then Value is BITHIGH
+  rule: if heroRole is SCOUT and armyReward is MEDIUM and danger is NONE and scoutTurnDistance is LOW then Value is HIGH with 0.7
+  rule: if heroRole is SCOUT and armyReward is MEDIUM and danger is NONE and scoutTurnDistance is MEDIUM and fear is not HIGH then Value is BITHIGH
+  rule: if heroRole is SCOUT and armyReward is MEDIUM and danger is NONE and scoutTurnDistance is LONG and fear is not HIGH then Value is MEDIUM
+  rule: if heroRole is SCOUT and armyReward is LOW and danger is NONE and scoutTurnDistance is LOW and fear is not HIGH then Value is MEDIUM
+  rule: if heroRole is SCOUT and armyReward is LOW and danger is NONE and scoutTurnDistance is MEDIUM and fear is not HIGH then Value is SMALL
 RuleBlock: gold
   enabled: true
   conjunction: AlgebraicProduct


### PR DESCRIPTION
The goal of this PR is to improve defense. AI will attack enemy heroes around their towns more aggressively.
Also reworked priority engine a bit. Movement spending is not considered now as a bad effect but instead it modulates value of other gains. Added army growth as a separate fuzzy variable to not clash with one-time army value.