### PR TITLE
Fixes & improvements to tavern/hero pool handling

### DIFF
--- a/CCallback.cpp
+++ b/CCallback.cpp
@@ -270,17 +270,10 @@ void CCallback::recruitHero(const CGObjectInstance *townOrTavern, const CGHeroIn
 {
 	assert(townOrTavern);
 	assert(hero);
-	ui8 i=0;
-	for(; i<gs->players[*player].availableHeroes.size(); i++)
-	{
-		if(gs->players[*player].availableHeroes[i] == hero)
-		{
-			HireHero pack(i, townOrTavern->id);
-			pack.player = *player;
-			sendRequest(&pack);
-			return;
-		}
-	}
+
+	HireHero pack(HeroTypeID(hero->subID), townOrTavern->id);
+	pack.player = *player;
+	sendRequest(&pack);
 }
 
 void CCallback::save( const std::string &fname )

--- a/cmake_modules/VCMI_lib.cmake
+++ b/cmake_modules/VCMI_lib.cmake
@@ -68,6 +68,7 @@ macro(add_main_lib TARGET_NAME LIBRARY_TYPE)
 		${MAIN_LIB_DIR}/gameState/CGameState.cpp
 		${MAIN_LIB_DIR}/gameState/CGameStateCampaign.cpp
 		${MAIN_LIB_DIR}/gameState/InfoAboutArmy.cpp
+		${MAIN_LIB_DIR}/gameState/TavernHeroesPool.cpp
 
 		${MAIN_LIB_DIR}/logging/CBasicLogConfigurator.cpp
 		${MAIN_LIB_DIR}/logging/CLogger.cpp
@@ -394,6 +395,7 @@ macro(add_main_lib TARGET_NAME LIBRARY_TYPE)
 		${MAIN_LIB_DIR}/gameState/EVictoryLossCheckResult.h
 		${MAIN_LIB_DIR}/gameState/InfoAboutArmy.h
 		${MAIN_LIB_DIR}/gameState/SThievesGuildInfo.h
+		${MAIN_LIB_DIR}/gameState/TavernHeroesPool.h
 		${MAIN_LIB_DIR}/gameState/QuestInfo.h
 
 		${MAIN_LIB_DIR}/logging/CBasicLogConfigurator.h

--- a/cmake_modules/VCMI_lib.cmake
+++ b/cmake_modules/VCMI_lib.cmake
@@ -396,6 +396,7 @@ macro(add_main_lib TARGET_NAME LIBRARY_TYPE)
 		${MAIN_LIB_DIR}/gameState/InfoAboutArmy.h
 		${MAIN_LIB_DIR}/gameState/SThievesGuildInfo.h
 		${MAIN_LIB_DIR}/gameState/TavernHeroesPool.h
+		${MAIN_LIB_DIR}/gameState/TavernSlot.h
 		${MAIN_LIB_DIR}/gameState/QuestInfo.h
 
 		${MAIN_LIB_DIR}/logging/CBasicLogConfigurator.h

--- a/lib/CGameInfoCallback.cpp
+++ b/lib/CGameInfoCallback.cpp
@@ -13,6 +13,7 @@
 #include "gameState/CGameState.h"
 #include "gameState/InfoAboutArmy.h"
 #include "gameState/SThievesGuildInfo.h"
+#include "gameState/TavernHeroesPool.h"
 #include "CGeneralTextHandler.h"
 #include "StartInfo.h" // for StartInfo
 #include "battle/BattleInfo.h" // for BattleInfo
@@ -97,13 +98,6 @@ const PlayerState * CGameInfoCallback::getPlayerState(PlayerColor color, bool ve
 			logGlobal->error("Cannot find player %d info!", color);
 		return nullptr;
 	}
-}
-
-const CTown * CGameInfoCallback::getNativeTown(PlayerColor color) const
-{
-	const PlayerSettings *ps = getPlayerSettings(color);
-	ERROR_RET_VAL_IF(!ps, "There is no such player!", nullptr);
-	return (*VLC->townh)[ps->castle]->town;
 }
 
 const CGObjectInstance * CGameInfoCallback::getObjByQuestIdentifier(int identifier) const
@@ -486,13 +480,10 @@ std::vector<const CGHeroInstance *> CGameInfoCallback::getAvailableHeroes(const 
 	//ERROR_RET_VAL_IF(!isOwnedOrVisited(townOrTavern), "Town or tavern must be owned or visited!", ret);
 	//TODO: town needs to be owned, advmap tavern needs to be visited; to be reimplemented when visit tracking is done
 	const CGTownInstance * town = getTown(townOrTavern->id);
+
 	if(townOrTavern->ID == Obj::TAVERN || (town && town->hasBuilt(BuildingID::TAVERN)))
-	{
-		range::copy(gs->players[*player].availableHeroes, std::back_inserter(ret));
-		vstd::erase_if(ret, [](const CGHeroInstance * h) {
-			return h == nullptr;
-		});
-	}
+		return gs->hpool->getHeroesFor(*player);
+
 	return ret;
 }
 

--- a/lib/CGameInfoCallback.cpp
+++ b/lib/CGameInfoCallback.cpp
@@ -482,7 +482,7 @@ std::vector<const CGHeroInstance *> CGameInfoCallback::getAvailableHeroes(const 
 	const CGTownInstance * town = getTown(townOrTavern->id);
 
 	if(townOrTavern->ID == Obj::TAVERN || (town && town->hasBuilt(BuildingID::TAVERN)))
-		return gs->hpool->getHeroesFor(*player);
+		return gs->heroesPool->getHeroesFor(*player);
 
 	return ret;
 }

--- a/lib/CGameInfoCallback.h
+++ b/lib/CGameInfoCallback.h
@@ -108,7 +108,6 @@ public:
 //	std::string getTavernRumor(const CGObjectInstance * townOrTavern) const;
 //	EBuildingState::EBuildingState canBuildStructure(const CGTownInstance *t, BuildingID ID);//// 0 - no more than one capitol, 1 - lack of water, 2 - forbidden, 3 - Add another level to Mage Guild, 4 - already built, 5 - cannot build, 6 - cannot afford, 7 - build, 8 - lack of requirements
 //	virtual bool getTownInfo(const CGObjectInstance * town, InfoAboutTown & dest, const CGObjectInstance * selectedObject = nullptr) const;
-//	const CTown *getNativeTown(PlayerColor color) const;
 
 	//from gs
 //	const TeamState *getTeam(TeamID teamID) const;
@@ -206,7 +205,6 @@ public:
 	virtual std::string getTavernRumor(const CGObjectInstance * townOrTavern) const;
 	virtual EBuildingState::EBuildingState canBuildStructure(const CGTownInstance *t, BuildingID ID);//// 0 - no more than one capitol, 1 - lack of water, 2 - forbidden, 3 - Add another level to Mage Guild, 4 - already built, 5 - cannot build, 6 - cannot afford, 7 - build, 8 - lack of requirements
 	virtual bool getTownInfo(const CGObjectInstance * town, InfoAboutTown & dest, const CGObjectInstance * selectedObject = nullptr) const;
-	virtual const CTown *getNativeTown(PlayerColor color) const;
 
 	//from gs
 	virtual const TeamState *getTeam(TeamID teamID) const;

--- a/lib/CPlayerState.cpp
+++ b/lib/CPlayerState.cpp
@@ -35,7 +35,6 @@ PlayerState::PlayerState(PlayerState && other) noexcept:
 	std::swap(visitedObjects, other.visitedObjects);
 	std::swap(heroes, other.heroes);
 	std::swap(towns, other.towns);
-	std::swap(availableHeroes, other.availableHeroes);
 	std::swap(dwellings, other.dwellings);
 	std::swap(quests, other.quests);
 }

--- a/lib/CPlayerState.h
+++ b/lib/CPlayerState.h
@@ -33,7 +33,6 @@ public:
 	std::set<ObjectInstanceID> visitedObjects; // as a std::set, since most accesses here will be from visited status checks
 	std::vector<ConstTransitivePtr<CGHeroInstance> > heroes;
 	std::vector<ConstTransitivePtr<CGTownInstance> > towns;
-	std::vector<ConstTransitivePtr<CGHeroInstance> > availableHeroes; //heroes available in taverns
 	std::vector<ConstTransitivePtr<CGDwelling> > dwellings; //used for town growth
 	std::vector<QuestInfo> quests; //store info about all received quests
 
@@ -74,7 +73,6 @@ public:
 		h & status;
 		h & heroes;
 		h & towns;
-		h & availableHeroes;
 		h & dwellings;
 		h & quests;
 		h & visitedObjects;

--- a/lib/CRandomGenerator.cpp
+++ b/lib/CRandomGenerator.cpp
@@ -20,6 +20,11 @@ CRandomGenerator::CRandomGenerator()
 	resetSeed();
 }
 
+CRandomGenerator::CRandomGenerator(int seed)
+{
+	setSeed(seed);
+}
+
 void CRandomGenerator::setSeed(int seed)
 {
 	rand.seed(seed);

--- a/lib/CRandomGenerator.h
+++ b/lib/CRandomGenerator.h
@@ -30,6 +30,9 @@ public:
 	/// current thread ID.
 	CRandomGenerator();
 
+	/// Seeds the generator with provided initial seed
+	explicit CRandomGenerator(int seed);
+
 	void setSeed(int seed);
 
 	/// Resets the seed to the product of the current time in milliseconds and the

--- a/lib/GameConstants.h
+++ b/lib/GameConstants.h
@@ -357,8 +357,11 @@ class PlayerColor : public BaseForID<PlayerColor, ui8>
 
 	enum EPlayerColor
 	{
-		PLAYER_LIMIT_I = 8
+		PLAYER_LIMIT_I = 8,
+		ALL_PLAYERS_MASK = 0xff
 	};
+
+	using Mask = uint8_t;
 
 	DLL_LINKAGE static const PlayerColor SPECTATOR; //252
 	DLL_LINKAGE static const PlayerColor CANNOT_DETERMINE; //253

--- a/lib/GameConstants.h
+++ b/lib/GameConstants.h
@@ -358,7 +358,6 @@ class PlayerColor : public BaseForID<PlayerColor, ui8>
 	enum EPlayerColor
 	{
 		PLAYER_LIMIT_I = 8,
-		ALL_PLAYERS_MASK = 0xff
 	};
 
 	using Mask = uint8_t;

--- a/lib/IGameCallback.cpp
+++ b/lib/IGameCallback.cpp
@@ -36,6 +36,7 @@
 #include "StartInfo.h"
 #include "gameState/CGameState.h"
 #include "gameState/CGameStateCampaign.h"
+#include "gameState/TavernHeroesPool.h"
 #include "mapping/CMap.h"
 #include "CPlayerState.h"
 #include "GameSettings.h"

--- a/lib/NetPackVisitor.h
+++ b/lib/NetPackVisitor.h
@@ -36,7 +36,7 @@ public:
 	virtual void visitSetMana(SetMana & pack) {}
 	virtual void visitSetMovePoints(SetMovePoints & pack) {}
 	virtual void visitFoWChange(FoWChange & pack) {}
-	virtual void visitSetAvailableHeroes(SetAvailableHeroes & pack) {}
+	virtual void visitSetAvailableHeroes(SetAvailableHero & pack) {}
 	virtual void visitGiveBonus(GiveBonus & pack) {}
 	virtual void visitChangeObjPos(ChangeObjPos & pack) {}
 	virtual void visitPlayerEndsGame(PlayerEndsGame & pack) {}

--- a/lib/NetPacks.h
+++ b/lib/NetPacks.h
@@ -19,6 +19,7 @@
 #include "battle/BattleAction.h"
 #include "battle/CObstacleInstance.h"
 #include "gameState/EVictoryLossCheckResult.h"
+#include "gameState/TavernSlot.h"
 #include "gameState/QuestInfo.h"
 #include "mapObjects/CGHeroInstance.h"
 #include "mapping/CMapDefines.h"
@@ -338,7 +339,8 @@ struct DLL_LINKAGE SetAvailableHero : public CPackForClient
 	}
 	void applyGs(CGameState * gs);
 
-	uint8_t slotID;
+	TavernHeroSlot slotID;
+	TavernSlotRole roleID;
 	PlayerColor player;
 	HeroTypeID hid; //-1 if no hero
 	CSimpleArmy army;
@@ -348,6 +350,7 @@ struct DLL_LINKAGE SetAvailableHero : public CPackForClient
 	template <typename Handler> void serialize(Handler & h, const int version)
 	{
 		h & slotID;
+		h & roleID;
 		h & player;
 		h & hid;
 		h & army;

--- a/lib/NetPacks.h
+++ b/lib/NetPacks.h
@@ -330,23 +330,24 @@ struct DLL_LINKAGE FoWChange : public CPackForClient
 	}
 };
 
-struct DLL_LINKAGE SetAvailableHeroes : public CPackForClient
+struct DLL_LINKAGE SetAvailableHero : public CPackForClient
 {
-	SetAvailableHeroes()
+	SetAvailableHero()
 	{
-		for(auto & i : army)
-			i.clear();
+		army.clear();
 	}
 	void applyGs(CGameState * gs);
 
+	uint8_t slotID;
 	PlayerColor player;
-	si32 hid[GameConstants::AVAILABLE_HEROES_PER_PLAYER]; //-1 if no hero
-	CSimpleArmy army[GameConstants::AVAILABLE_HEROES_PER_PLAYER];
+	HeroTypeID hid; //-1 if no hero
+	CSimpleArmy army;
 
 	virtual void visitTyped(ICPackVisitor & visitor) override;
 
 	template <typename Handler> void serialize(Handler & h, const int version)
 	{
+		h & slotID;
 		h & player;
 		h & hid;
 		h & army;
@@ -692,7 +693,7 @@ struct DLL_LINKAGE HeroRecruited : public CPackForClient
 {
 	void applyGs(CGameState * gs) const;
 
-	si32 hid = -1; //subID of hero
+	HeroTypeID hid; //subID of hero
 	ObjectInstanceID tid;
 	ObjectInstanceID boatId;
 	int3 tile;
@@ -2437,12 +2438,12 @@ struct DLL_LINKAGE SetFormation : public CPackForServer
 struct DLL_LINKAGE HireHero : public CPackForServer
 {
 	HireHero() = default;
-	HireHero(si32 HID, const ObjectInstanceID & TID)
+	HireHero(HeroTypeID HID, const ObjectInstanceID & TID)
 		: hid(HID)
 		, tid(TID)
 	{
 	}
-	si32 hid = 0; //available hero serial
+	HeroTypeID hid; //available hero serial
 	ObjectInstanceID tid; //town (tavern) id
 	PlayerColor player;
 

--- a/lib/NetPacks.h
+++ b/lib/NetPacks.h
@@ -342,7 +342,7 @@ struct DLL_LINKAGE SetAvailableHero : public CPackForClient
 	TavernHeroSlot slotID;
 	TavernSlotRole roleID;
 	PlayerColor player;
-	HeroTypeID hid; //-1 if no hero
+	HeroTypeID hid; //HeroTypeID::NONE if no hero
 	CSimpleArmy army;
 
 	virtual void visitTyped(ICPackVisitor & visitor) override;

--- a/lib/NetPacksLib.cpp
+++ b/lib/NetPacksLib.cpp
@@ -942,7 +942,7 @@ void FoWChange::applyGs(CGameState *gs)
 
 void SetAvailableHero::applyGs(CGameState *gs)
 {
-	gs->hpool->setHeroForPlayer(player, TavernHeroSlot(slotID), hid, army);
+	gs->hpool->setHeroForPlayer(player, slotID, hid, army, roleID);
 }
 
 void GiveBonus::applyGs(CGameState *gs)

--- a/lib/NetPacksLib.cpp
+++ b/lib/NetPacksLib.cpp
@@ -942,7 +942,7 @@ void FoWChange::applyGs(CGameState *gs)
 
 void SetAvailableHero::applyGs(CGameState *gs)
 {
-	gs->hpool->setHeroForPlayer(player, slotID, hid, army, roleID);
+	gs->heroesPool->setHeroForPlayer(player, slotID, hid, army, roleID);
 }
 
 void GiveBonus::applyGs(CGameState *gs)
@@ -1143,7 +1143,7 @@ void RemoveObject::applyGs(CGameState *gs)
 		}
 		//return hero to the pool, so he may reappear in tavern
 
-		gs->hpool->addHeroToPool(beatenHero);
+		gs->heroesPool->addHeroToPool(beatenHero);
 		gs->map->objects[id.getNum()] = nullptr;
 
 		//If hero on Boat is removed, the Boat disappears
@@ -1368,7 +1368,7 @@ void SetHeroesInTown::applyGs(CGameState * gs) const
 
 void HeroRecruited::applyGs(CGameState * gs) const
 {
-	CGHeroInstance *h = gs->hpool->takeHero(hid);
+	CGHeroInstance *h = gs->heroesPool->takeHeroFromPool(hid);
 	CGTownInstance *t = gs->getTown(tid);
 	PlayerState *p = gs->getPlayerState(player);
 
@@ -2017,7 +2017,7 @@ void NewTurn::applyGs(CGameState *gs)
 		hero->mana = h.mana;
 	}
 
-	gs->hpool->onNewDay();
+	gs->heroesPool->onNewDay();
 
 	for(const auto & re : res)
 	{

--- a/lib/NetPacksLib.cpp
+++ b/lib/NetPacksLib.cpp
@@ -2012,6 +2012,9 @@ void NewTurn::applyGs(CGameState *gs)
 			logGlobal->error("Hero %d not found in NewTurn::applyGs", h.id.getNum());
 			continue;
 		}
+
+		hero->setMovementPoints(h.move);
+		hero->mana = h.mana;
 	}
 
 	gs->hpool->onNewDay();

--- a/lib/NetPacksLib.cpp
+++ b/lib/NetPacksLib.cpp
@@ -20,6 +20,7 @@
 #include "spells/CSpellHandler.h"
 #include "CCreatureHandler.h"
 #include "gameState/CGameState.h"
+#include "gameState/TavernHeroesPool.h"
 #include "CStack.h"
 #include "battle/BattleInfo.h"
 #include "CTownHandler.h"
@@ -151,7 +152,7 @@ void FoWChange::visitTyped(ICPackVisitor & visitor)
 	visitor.visitFoWChange(*this);
 }
 
-void SetAvailableHeroes::visitTyped(ICPackVisitor & visitor)
+void SetAvailableHero::visitTyped(ICPackVisitor & visitor)
 {
 	visitor.visitSetAvailableHeroes(*this);
 }
@@ -939,18 +940,9 @@ void FoWChange::applyGs(CGameState *gs)
 	}
 }
 
-void SetAvailableHeroes::applyGs(CGameState *gs)
+void SetAvailableHero::applyGs(CGameState *gs)
 {
-	PlayerState *p = gs->getPlayerState(player);
-	p->availableHeroes.clear();
-
-	for (int i = 0; i < GameConstants::AVAILABLE_HEROES_PER_PLAYER; i++)
-	{
-		CGHeroInstance *h = (hid[i]>=0 ?  gs->hpool.heroesPool[hid[i]].get() : nullptr);
-		if(h && army[i])
-			h->setToArmy(army[i]);
-		p->availableHeroes.emplace_back(h);
-	}
+	gs->hpool->setHeroForPlayer(player, TavernHeroSlot(slotID), hid, army);
 }
 
 void GiveBonus::applyGs(CGameState *gs)
@@ -1150,11 +1142,8 @@ void RemoveObject::applyGs(CGameState *gs)
 			beatenHero->inTownGarrison = false;
 		}
 		//return hero to the pool, so he may reappear in tavern
-		gs->hpool.heroesPool[beatenHero->subID] = beatenHero;
 
-		if(!vstd::contains(gs->hpool.pavailable, beatenHero->subID))
-			gs->hpool.pavailable[beatenHero->subID] = 0xff;
-
+		gs->hpool->addHeroToPool(beatenHero);
 		gs->map->objects[id.getNum()] = nullptr;
 
 		//If hero on Boat is removed, the Boat disappears
@@ -1379,8 +1368,7 @@ void SetHeroesInTown::applyGs(CGameState * gs) const
 
 void HeroRecruited::applyGs(CGameState * gs) const
 {
-	assert(vstd::contains(gs->hpool.heroesPool, hid));
-	CGHeroInstance *h = gs->hpool.heroesPool[hid];
+	CGHeroInstance *h = gs->hpool->takeHero(hid);
 	CGTownInstance *t = gs->getTown(tid);
 	PlayerState *p = gs->getPlayerState(player);
 
@@ -1411,7 +1399,6 @@ void HeroRecruited::applyGs(CGameState * gs) const
 		}
 	}
 
-	gs->hpool.heroesPool.erase(hid);
 	if(h->id == ObjectInstanceID())
 	{
 		h->id = ObjectInstanceID(static_cast<si32>(gs->map->objects.size()));
@@ -2022,24 +2009,12 @@ void NewTurn::applyGs(CGameState *gs)
 		CGHeroInstance *hero = gs->getHero(h.id);
 		if(!hero)
 		{
-			// retreated or surrendered hero who has not been reset yet
-			for(auto& hp : gs->hpool.heroesPool)
-			{
-				if(hp.second->id == h.id)
-				{
-					hero = hp.second;
-					break;
-				}
-			}
-		}
-		if(!hero)
-		{
 			logGlobal->error("Hero %d not found in NewTurn::applyGs", h.id.getNum());
 			continue;
 		}
-		hero->setMovementPoints(h.move);
-		hero->mana = h.mana;
 	}
+
+	gs->hpool->onNewDay();
 
 	for(const auto & re : res)
 	{

--- a/lib/StartInfo.h
+++ b/lib/StartInfo.h
@@ -35,9 +35,9 @@ struct DLL_LINKAGE PlayerSettings
 	};
 
 	Ebonus bonus;
-	si16 castle;
-	si32 hero,
-		 heroPortrait; //-1 if default, else ID
+	FactionID castle;
+	HeroTypeID hero;
+	HeroTypeID heroPortrait; //-1 if default, else ID
 
 	std::string heroName;
 	PlayerColor color; //from 0 -

--- a/lib/gameState/CGameState.cpp
+++ b/lib/gameState/CGameState.cpp
@@ -12,6 +12,7 @@
 
 #include "EVictoryLossCheckResult.h"
 #include "InfoAboutArmy.h"
+#include "TavernHeroesPool.h"
 #include "CGameStateCampaign.h"
 #include "SThievesGuildInfo.h"
 
@@ -100,81 +101,6 @@ static CGObjectInstance * createObject(const Obj & id, int subid, const int3 & p
 		nobj->appearance = VLC->objtypeh->getHandlerFor(id, subid)->getTemplates().front();
 
 	return nobj;
-}
-
-CGHeroInstance * CGameState::HeroesPool::pickHeroFor(bool native,
-													 const PlayerColor & player,
-													 const CTown * town,
-													 std::map<ui32, ConstTransitivePtr<CGHeroInstance>> & available,
-													 CRandomGenerator & rand,
-													 const CHeroClass * bannedClass) const
-{
-	CGHeroInstance *ret = nullptr;
-
-	if(player>=PlayerColor::PLAYER_LIMIT)
-	{
-		logGlobal->error("Cannot pick hero for faction %s. Wrong owner!", town->faction->getJsonKey());
-		return nullptr;
-	}
-
-	std::vector<CGHeroInstance *> pool;
-
-	if(native)
-	{
-		for(auto & elem : available)
-		{
-			if(pavailable.find(elem.first)->second & 1<<player.getNum()
-				&& elem.second->type->heroClass->faction == town->faction->getIndex())
-			{
-				pool.push_back(elem.second); //get all available heroes
-			}
-		}
-		if(pool.empty())
-		{
-			logGlobal->error("Cannot pick native hero for %s. Picking any...", player.getStr());
-			return pickHeroFor(false, player, town, available, rand);
-		}
-		else
-		{
-			ret = *RandomGeneratorUtil::nextItem(pool, rand);
-		}
-	}
-	else
-	{
-		int sum = 0;
-		int r;
-
-		for(auto & elem : available)
-		{
-			if (pavailable.find(elem.first)->second & (1<<player.getNum()) &&    // hero is available
-			    ( !bannedClass || elem.second->type->heroClass != bannedClass) ) // and his class is not same as other hero
-			{
-				pool.push_back(elem.second);
-				sum += elem.second->type->heroClass->selectionProbability[town->faction->getId()]; //total weight
-			}
-		}
-		if(pool.empty() || sum == 0)
-		{
-			logGlobal->error("There are no heroes available for player %s!", player.getStr());
-			return nullptr;
-		}
-
-		r = rand.nextInt(sum - 1);
-		for (auto & elem : pool)
-		{
-			r -= elem->type->heroClass->selectionProbability[town->faction->getId()];
-			if(r < 0)
-			{
-				ret = elem;
-				break;
-			}
-		}
-		if(!ret)
-			ret = pool.back();
-	}
-
-	available.erase(ret->subID);
-	return ret;
 }
 
 HeroTypeID CGameState::pickNextHeroType(const PlayerColor & owner)
@@ -459,6 +385,7 @@ int CGameState::getDate(Date::EDateType mode) const
 CGameState::CGameState()
 {
 	gs = this;
+	hpool = std::make_unique<TavernHeroesPool>(this);
 	applier = std::make_shared<CApplier<CBaseForGSApply>>();
 	registerTypesClientPacks1(*applier);
 	registerTypesClientPacks2(*applier);
@@ -469,9 +396,6 @@ CGameState::~CGameState()
 {
 	map.dellNull();
 	curB.dellNull();
-
-	for(auto ptr : hpool.heroesPool) // clean hero pool
-		ptr.second.dellNull();
 }
 
 void CGameState::preInit(Services * services)
@@ -951,8 +875,7 @@ void CGameState::initHeroes()
 		if(!vstd::contains(heroesToCreate, HeroTypeID(ph->subID)))
 			continue;
 		ph->initHero(getRandomGenerator());
-		hpool.heroesPool[ph->subID] = ph;
-		hpool.pavailable[ph->subID] = 0xff;
+		hpool->addHeroToPool(ph);
 		heroesToCreate.erase(ph->type->getId());
 
 		map->allHeroes[ph->subID] = ph;
@@ -965,14 +888,11 @@ void CGameState::initHeroes()
 
 		int typeID = htype.getNum();
 		map->allHeroes[typeID] = vhi;
-		hpool.heroesPool[typeID] = vhi;
-		hpool.pavailable[typeID] = 0xff;
+		hpool->addHeroToPool(vhi);
 	}
 
 	for(auto & elem : map->disposedHeroes)
-	{
-		hpool.pavailable[elem.heroId] = elem.players;
-	}
+		hpool->setAvailability(elem.heroId, elem.players);
 
 	if (campaign)
 		campaign->initHeroes();
@@ -2065,17 +1985,6 @@ void CGameState::obtainPlayersStats(SThievesGuildInfo & tgi, int level)
 	}
 
 #undef FILL_FIELD
-}
-
-std::map<ui32, ConstTransitivePtr<CGHeroInstance> > CGameState::unusedHeroesFromPool()
-{
-	std::map<ui32, ConstTransitivePtr<CGHeroInstance> > pool = hpool.heroesPool;
-	for(const auto & player : players)
-		for(auto availableHero : player.second.availableHeroes)
-			if(availableHero)
-				pool.erase((*availableHero).subID);
-
-	return pool;
 }
 
 void CGameState::buildBonusSystemTree()

--- a/lib/gameState/CGameState.cpp
+++ b/lib/gameState/CGameState.cpp
@@ -385,7 +385,7 @@ int CGameState::getDate(Date::EDateType mode) const
 CGameState::CGameState()
 {
 	gs = this;
-	hpool = std::make_unique<TavernHeroesPool>(this);
+	hpool = std::make_unique<TavernHeroesPool>();
 	applier = std::make_shared<CApplier<CBaseForGSApply>>();
 	registerTypesClientPacks1(*applier);
 	registerTypesClientPacks2(*applier);

--- a/lib/gameState/CGameState.cpp
+++ b/lib/gameState/CGameState.cpp
@@ -385,7 +385,7 @@ int CGameState::getDate(Date::EDateType mode) const
 CGameState::CGameState()
 {
 	gs = this;
-	hpool = std::make_unique<TavernHeroesPool>();
+	heroesPool = std::make_unique<TavernHeroesPool>();
 	applier = std::make_shared<CApplier<CBaseForGSApply>>();
 	registerTypesClientPacks1(*applier);
 	registerTypesClientPacks2(*applier);
@@ -875,7 +875,7 @@ void CGameState::initHeroes()
 		if(!vstd::contains(heroesToCreate, HeroTypeID(ph->subID)))
 			continue;
 		ph->initHero(getRandomGenerator());
-		hpool->addHeroToPool(ph);
+		heroesPool->addHeroToPool(ph);
 		heroesToCreate.erase(ph->type->getId());
 
 		map->allHeroes[ph->subID] = ph;
@@ -888,11 +888,11 @@ void CGameState::initHeroes()
 
 		int typeID = htype.getNum();
 		map->allHeroes[typeID] = vhi;
-		hpool->addHeroToPool(vhi);
+		heroesPool->addHeroToPool(vhi);
 	}
 
 	for(auto & elem : map->disposedHeroes)
-		hpool->setAvailability(elem.heroId, elem.players);
+		heroesPool->setAvailability(elem.heroId, elem.players);
 
 	if (campaign)
 		campaign->initHeroes();

--- a/lib/gameState/CGameState.h
+++ b/lib/gameState/CGameState.h
@@ -82,7 +82,7 @@ class DLL_LINKAGE CGameState : public CNonConstInfoCallback
 
 public:
 	//we have here all heroes available on this map that are not hired
-	std::unique_ptr<TavernHeroesPool> hpool;
+	std::unique_ptr<TavernHeroesPool> heroesPool;
 
 	CGameState();
 	virtual ~CGameState();
@@ -154,7 +154,7 @@ public:
 		h & map;
 		h & players;
 		h & teams;
-		h & hpool;
+		h & heroesPool;
 		h & globalEffects;
 		h & rand;
 		h & rumor;

--- a/lib/gameState/CGameState.h
+++ b/lib/gameState/CGameState.h
@@ -29,6 +29,7 @@ struct EventCondition;
 struct CampaignTravel;
 class CStackInstance;
 class CGameStateCampaign;
+class TavernHeroesPool;
 struct SThievesGuildInfo;
 
 template<typename T> class CApplier;
@@ -78,25 +79,10 @@ DLL_LINKAGE std::ostream & operator<<(std::ostream & os, const EVictoryLossCheck
 class DLL_LINKAGE CGameState : public CNonConstInfoCallback
 {
 	friend class CGameStateCampaign;
+
 public:
-	struct DLL_LINKAGE HeroesPool
-	{
-		std::map<ui32, ConstTransitivePtr<CGHeroInstance> > heroesPool; //[subID] - heroes available to buy; nullptr if not available
-		std::map<ui32,ui8> pavailable; // [subid] -> which players can recruit hero (binary flags)
-
-		CGHeroInstance * pickHeroFor(bool native,
-									 const PlayerColor & player,
-									 const CTown * town,
-									 std::map<ui32, ConstTransitivePtr<CGHeroInstance>> & available,
-									 CRandomGenerator & rand,
-									 const CHeroClass * bannedClass = nullptr) const;
-
-		template <typename Handler> void serialize(Handler &h, const int version)
-		{
-			h & heroesPool;
-			h & pavailable;
-		}
-	} hpool; //we have here all heroes available on this map that are not hired
+	//we have here all heroes available on this map that are not hired
+	std::unique_ptr<TavernHeroesPool> hpool;
 
 	CGameState();
 	virtual ~CGameState();
@@ -142,7 +128,6 @@ public:
 	bool checkForStandardLoss(const PlayerColor & player) const; //checks if given player lost the game
 
 	void obtainPlayersStats(SThievesGuildInfo & tgi, int level); //fills tgi with info about other players that is available at given level of thieves' guild
-	std::map<ui32, ConstTransitivePtr<CGHeroInstance> > unusedHeroesFromPool(); //heroes pool without heroes that are available in taverns
 
 	bool isVisible(int3 pos, const std::optional<PlayerColor> & player) const override;
 	bool isVisible(const CGObjectInstance * obj, const std::optional<PlayerColor> & player) const override;

--- a/lib/gameState/TavernHeroesPool.cpp
+++ b/lib/gameState/TavernHeroesPool.cpp
@@ -1,0 +1,176 @@
+/*
+ * TavernHeroesPool.cpp, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
+#include "StdInc.h"
+#include "TavernHeroesPool.h"
+
+#include "CGameState.h"
+#include "CPlayerState.h"
+
+#include "../mapObjects/CGHeroInstance.h"
+#include "../CHeroHandler.h"
+
+TavernHeroesPool::TavernHeroesPool() = default;
+
+TavernHeroesPool::TavernHeroesPool(CGameState * gameState)
+	: gameState(gameState)
+{
+}
+
+TavernHeroesPool::~TavernHeroesPool()
+{
+	for(auto ptr : heroesPool) // clean hero pool
+		delete ptr.second;
+}
+
+std::map<HeroTypeID, CGHeroInstance*> TavernHeroesPool::unusedHeroesFromPool()
+{
+	std::map<HeroTypeID, CGHeroInstance*> pool = heroesPool;
+	for(const auto & player : currentTavern)
+		for(auto availableHero : player.second)
+			if(availableHero.second)
+				pool.erase(HeroTypeID(availableHero.second->subID));
+
+	return pool;
+}
+
+void TavernHeroesPool::setHeroForPlayer(PlayerColor player, TavernHeroSlot slot, HeroTypeID hero, CSimpleArmy & army)
+{
+	currentTavern[player].erase(slot);
+
+	if (hero == HeroTypeID::NONE)
+		return;
+
+	CGHeroInstance * h = heroesPool[hero];
+
+	if (h && army)
+		h->setToArmy(army);
+
+	currentTavern[player][slot] = h;
+}
+
+bool TavernHeroesPool::isHeroAvailableFor(HeroTypeID hero, PlayerColor color) const
+{
+	if (pavailable.count(hero))
+		return pavailable.at(hero) & (1 << color.getNum());
+
+	return true;
+}
+
+CGHeroInstance * TavernHeroesPool::pickHeroFor(TavernHeroSlot slot,
+													 const PlayerColor & player,
+													 const FactionID & factionID,
+													 CRandomGenerator & rand,
+													 const CHeroClass * bannedClass) const
+{
+	if(player>=PlayerColor::PLAYER_LIMIT)
+	{
+		logGlobal->error("Cannot pick hero for player %d. Wrong owner!", player.getStr());
+		return nullptr;
+	}
+
+	if(slot == TavernHeroSlot::NATIVE)
+	{
+		std::vector<CGHeroInstance *> pool;
+
+		for(auto & elem : heroesPool)
+		{
+			//get all available heroes
+			bool heroAvailable = isHeroAvailableFor(elem.first, player);
+			bool heroClassNative = elem.second->type->heroClass->faction == factionID;
+
+			if(heroAvailable && heroClassNative)
+				pool.push_back(elem.second);
+		}
+
+		if(!pool.empty())
+			return *RandomGeneratorUtil::nextItem(pool, rand);
+
+		logGlobal->error("Cannot pick native hero for %s. Picking any...", player.getStr());
+	}
+
+	std::vector<CGHeroInstance *> pool;
+	int totalWeight = 0;
+
+	for(auto & elem : heroesPool)
+	{
+		bool heroAvailable = isHeroAvailableFor(elem.first, player);
+		bool heroClassBanned = bannedClass && elem.second->type->heroClass == bannedClass;
+
+		if ( heroAvailable && !heroClassBanned)
+		{
+			pool.push_back(elem.second);
+			totalWeight += elem.second->type->heroClass->selectionProbability[factionID]; //total weight
+		}
+	}
+	if(pool.empty() || totalWeight == 0)
+	{
+		logGlobal->error("There are no heroes available for player %s!", player.getStr());
+		return nullptr;
+	}
+
+	int roll = rand.nextInt(totalWeight - 1);
+	for (auto & elem : pool)
+	{
+		roll -= elem->type->heroClass->selectionProbability[factionID];
+		if(roll < 0)
+		{
+			return elem;
+		}
+	}
+
+	return pool.back();
+}
+
+std::vector<const CGHeroInstance *> TavernHeroesPool::getHeroesFor(PlayerColor color) const
+{
+	std::vector<const CGHeroInstance *> result;
+
+	if(!currentTavern.count(color))
+		return result;
+
+	for(const auto & hero : currentTavern.at(color))
+		result.push_back(hero.second);
+
+	return result;
+}
+
+CGHeroInstance * TavernHeroesPool::takeHero(HeroTypeID hero)
+{
+	assert(heroesPool.count(hero));
+
+	CGHeroInstance * result = heroesPool[hero];
+	heroesPool.erase(hero);
+
+	assert(result);
+	return result;
+}
+
+void TavernHeroesPool::onNewDay()
+{
+	for(auto & hero : heroesPool)
+	{
+		assert(hero.second);
+		if(!hero.second)
+			continue;
+
+		hero.second->setMovementPoints(hero.second->movementPointsLimit(true));
+		hero.second->mana = hero.second->manaLimit();
+	}
+}
+
+void TavernHeroesPool::addHeroToPool(CGHeroInstance * hero)
+{
+	heroesPool[HeroTypeID(hero->subID)] = hero;
+}
+
+void TavernHeroesPool::setAvailability(HeroTypeID hero, PlayerColor::Mask mask)
+{
+	pavailable[hero] = mask;
+}

--- a/lib/gameState/TavernHeroesPool.cpp
+++ b/lib/gameState/TavernHeroesPool.cpp
@@ -16,7 +16,7 @@ VCMI_LIB_NAMESPACE_BEGIN
 
 TavernHeroesPool::~TavernHeroesPool()
 {
-	for(auto ptr : heroesPool) // clean hero pool
+	for(const auto & ptr : heroesPool) // clean hero pool
 		delete ptr.second;
 }
 

--- a/lib/gameState/TavernHeroesPool.cpp
+++ b/lib/gameState/TavernHeroesPool.cpp
@@ -113,6 +113,15 @@ void TavernHeroesPool::onNewDay()
 		hero.second->setMovementPoints(hero.second->movementPointsLimit(true));
 		hero.second->mana = hero.second->manaLimit();
 	}
+
+	for (auto & slot : currentTavern)
+	{
+		if (slot.role == TavernSlotRole::RETREATED_TODAY)
+			slot.role = TavernSlotRole::RETREATED;
+
+		if (slot.role == TavernSlotRole::SURRENDERED_TODAY)
+			slot.role = TavernSlotRole::SURRENDERED;
+	}
 }
 
 void TavernHeroesPool::addHeroToPool(CGHeroInstance * hero)

--- a/lib/gameState/TavernHeroesPool.h
+++ b/lib/gameState/TavernHeroesPool.h
@@ -44,7 +44,7 @@ class DLL_LINKAGE TavernHeroesPool
 
 	/// list of which players are able to purchase specific hero
 	/// if hero is not present in list, he is available for everyone
-	std::map<HeroTypeID, PlayerColor::Mask> pavailable;
+	std::map<HeroTypeID, PlayerColor::Mask> perPlayerAvailability;
 
 	/// list of heroes currently available in taverns
 	std::vector<TavernSlot> currentTavern;
@@ -63,19 +63,23 @@ public:
 
 	TavernSlotRole getSlotRole(HeroTypeID hero) const;
 
-	CGHeroInstance * takeHero(HeroTypeID hero);
+	CGHeroInstance * takeHeroFromPool(HeroTypeID hero);
 
 	/// reset mana and movement points for all heroes in pool
 	void onNewDay();
 
 	void addHeroToPool(CGHeroInstance * hero);
+
+	/// Marks hero as available to only specific set of players
 	void setAvailability(HeroTypeID hero, PlayerColor::Mask mask);
+
+	/// Makes hero available in tavern of specified player
 	void setHeroForPlayer(PlayerColor player, TavernHeroSlot slot, HeroTypeID hero, CSimpleArmy & army, TavernSlotRole role);
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
 		h & heroesPool;
-		h & pavailable;
+		h & perPlayerAvailability;
 		h & currentTavern;
 	}
 };

--- a/lib/gameState/TavernHeroesPool.h
+++ b/lib/gameState/TavernHeroesPool.h
@@ -23,37 +23,33 @@ class CSimpleArmy;
 
 enum class TavernHeroSlot
 {
-	NATIVE,
-	RANDOM
+	NATIVE, // 1st / left slot in tavern, contains hero native to player's faction on new week
+	RANDOM  // 2nd / right slot in tavern, contains hero of random class
 };
 
 class DLL_LINKAGE TavernHeroesPool
 {
-	CGameState * gameState;
-
-	//[subID] - heroes available to buy; nullptr if not available
+	/// list of all heroes in pool, including those currently present in taverns
 	std::map<HeroTypeID, CGHeroInstance* > heroesPool;
 
-	// [subid] -> which players can recruit hero (binary flags)
+	/// list of which players are able to purchase specific hero
+	/// if hero is not present in list, he is available for everyone
 	std::map<HeroTypeID, PlayerColor::Mask> pavailable;
 
-	std::map<HeroTypeID, CGHeroInstance* > unusedHeroesFromPool(); //heroes pool without heroes that are available in taverns
-
+	/// list of heroes currently available in a tavern of a specific player
 	std::map<PlayerColor, std::map<TavernHeroSlot, CGHeroInstance*> > currentTavern;
 
-	bool isHeroAvailableFor(HeroTypeID hero, PlayerColor color) const;
 public:
-	TavernHeroesPool();
-	TavernHeroesPool(CGameState * gameState);
 	~TavernHeroesPool();
 
-	CGHeroInstance * pickHeroFor(TavernHeroSlot slot,
-								 const PlayerColor & player,
-								 const FactionID & faction,
-								 CRandomGenerator & rand,
-								 const CHeroClass * bannedClass = nullptr) const;
-
+	/// Returns heroes currently availabe in tavern of a specific player
 	std::vector<const CGHeroInstance *> getHeroesFor(PlayerColor color) const;
+
+	/// returns heroes in pool without heroes that are available in taverns
+	std::map<HeroTypeID, CGHeroInstance* > unusedHeroesFromPool() const;
+
+	/// Returns true if hero is available to a specific player
+	bool isHeroAvailableFor(HeroTypeID hero, PlayerColor color) const;
 
 	CGHeroInstance * takeHero(HeroTypeID hero);
 
@@ -66,7 +62,6 @@ public:
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & gameState;
 		h & heroesPool;
 		h & pavailable;
 	}

--- a/lib/gameState/TavernHeroesPool.h
+++ b/lib/gameState/TavernHeroesPool.h
@@ -9,8 +9,8 @@
  */
 #pragma once
 
-#include "../ConstTransitivePtr.h"
 #include "../GameConstants.h"
+#include "TavernSlot.h"
 
 VCMI_LIB_NAMESPACE_BEGIN
 
@@ -21,14 +21,24 @@ class CHeroClass;
 class CGameState;
 class CSimpleArmy;
 
-enum class TavernHeroSlot
-{
-	NATIVE, // 1st / left slot in tavern, contains hero native to player's faction on new week
-	RANDOM  // 2nd / right slot in tavern, contains hero of random class
-};
-
 class DLL_LINKAGE TavernHeroesPool
 {
+	struct TavernSlot
+	{
+		CGHeroInstance * hero;
+		TavernHeroSlot slot;
+		TavernSlotRole role;
+		PlayerColor player;
+
+		template <typename Handler> void serialize(Handler &h, const int version)
+		{
+			h & hero;
+			h & slot;
+			h & role;
+			h & player;
+		}
+	};
+
 	/// list of all heroes in pool, including those currently present in taverns
 	std::map<HeroTypeID, CGHeroInstance* > heroesPool;
 
@@ -36,8 +46,8 @@ class DLL_LINKAGE TavernHeroesPool
 	/// if hero is not present in list, he is available for everyone
 	std::map<HeroTypeID, PlayerColor::Mask> pavailable;
 
-	/// list of heroes currently available in a tavern of a specific player
-	std::map<PlayerColor, std::map<TavernHeroSlot, CGHeroInstance*> > currentTavern;
+	/// list of heroes currently available in taverns
+	std::vector<TavernSlot> currentTavern;
 
 public:
 	~TavernHeroesPool();
@@ -51,6 +61,8 @@ public:
 	/// Returns true if hero is available to a specific player
 	bool isHeroAvailableFor(HeroTypeID hero, PlayerColor color) const;
 
+	TavernSlotRole getSlotRole(HeroTypeID hero) const;
+
 	CGHeroInstance * takeHero(HeroTypeID hero);
 
 	/// reset mana and movement points for all heroes in pool
@@ -58,7 +70,7 @@ public:
 
 	void addHeroToPool(CGHeroInstance * hero);
 	void setAvailability(HeroTypeID hero, PlayerColor::Mask mask);
-	void setHeroForPlayer(PlayerColor player, TavernHeroSlot slot, HeroTypeID hero, CSimpleArmy & army);
+	void setHeroForPlayer(PlayerColor player, TavernHeroSlot slot, HeroTypeID hero, CSimpleArmy & army, TavernSlotRole role);
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{

--- a/lib/gameState/TavernHeroesPool.h
+++ b/lib/gameState/TavernHeroesPool.h
@@ -64,6 +64,7 @@ public:
 	{
 		h & heroesPool;
 		h & pavailable;
+		h & currentTavern;
 	}
 };
 

--- a/lib/gameState/TavernHeroesPool.h
+++ b/lib/gameState/TavernHeroesPool.h
@@ -1,0 +1,75 @@
+/*
+ * TavernHeroesPool.h, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
+#pragma once
+
+#include "../ConstTransitivePtr.h"
+#include "../GameConstants.h"
+
+VCMI_LIB_NAMESPACE_BEGIN
+
+class CGHeroInstance;
+class CTown;
+class CRandomGenerator;
+class CHeroClass;
+class CGameState;
+class CSimpleArmy;
+
+enum class TavernHeroSlot
+{
+	NATIVE,
+	RANDOM
+};
+
+class DLL_LINKAGE TavernHeroesPool
+{
+	CGameState * gameState;
+
+	//[subID] - heroes available to buy; nullptr if not available
+	std::map<HeroTypeID, CGHeroInstance* > heroesPool;
+
+	// [subid] -> which players can recruit hero (binary flags)
+	std::map<HeroTypeID, PlayerColor::Mask> pavailable;
+
+	std::map<HeroTypeID, CGHeroInstance* > unusedHeroesFromPool(); //heroes pool without heroes that are available in taverns
+
+	std::map<PlayerColor, std::map<TavernHeroSlot, CGHeroInstance*> > currentTavern;
+
+	bool isHeroAvailableFor(HeroTypeID hero, PlayerColor color) const;
+public:
+	TavernHeroesPool();
+	TavernHeroesPool(CGameState * gameState);
+	~TavernHeroesPool();
+
+	CGHeroInstance * pickHeroFor(TavernHeroSlot slot,
+								 const PlayerColor & player,
+								 const FactionID & faction,
+								 CRandomGenerator & rand,
+								 const CHeroClass * bannedClass = nullptr) const;
+
+	std::vector<const CGHeroInstance *> getHeroesFor(PlayerColor color) const;
+
+	CGHeroInstance * takeHero(HeroTypeID hero);
+
+	/// reset mana and movement points for all heroes in pool
+	void onNewDay();
+
+	void addHeroToPool(CGHeroInstance * hero);
+	void setAvailability(HeroTypeID hero, PlayerColor::Mask mask);
+	void setHeroForPlayer(PlayerColor player, TavernHeroSlot slot, HeroTypeID hero, CSimpleArmy & army);
+
+	template <typename Handler> void serialize(Handler &h, const int version)
+	{
+		h & gameState;
+		h & heroesPool;
+		h & pavailable;
+	}
+};
+
+VCMI_LIB_NAMESPACE_END

--- a/lib/gameState/TavernSlot.h
+++ b/lib/gameState/TavernSlot.h
@@ -1,0 +1,35 @@
+/*
+ * TavernSlot.h, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
+#pragma once
+
+VCMI_LIB_NAMESPACE_BEGIN
+
+enum class TavernHeroSlot : int8_t
+{
+	NONE = -1,
+	NATIVE, // 1st / left slot in tavern, contains hero native to player's faction on new week
+	RANDOM  // 2nd / right slot in tavern, contains hero of random class
+};
+
+enum class TavernSlotRole : int8_t
+{
+	NONE = -1,
+
+	SINGLE_UNIT, // hero was added after buying hero from this slot, and only has 1 creature in army
+	FULL_ARMY, // hero was added to tavern on new week and still has full army
+
+	RETREATED, // hero was owned by player before, but have retreated from battle and only has 1 creature in army
+	SURRENDERED, // hero was owned by player before, but have surrendered in battle and kept some troops
+
+//	SURRENDERED_DAY7, // helper value for heroes that surrendered after 7th day during enemy turn
+//	RETREATED_DAY7,
+};
+
+VCMI_LIB_NAMESPACE_END

--- a/lib/gameState/TavernSlot.h
+++ b/lib/gameState/TavernSlot.h
@@ -26,10 +26,10 @@ enum class TavernSlotRole : int8_t
 	FULL_ARMY, // hero was added to tavern on new week and still has full army
 
 	RETREATED, // hero was owned by player before, but have retreated from battle and only has 1 creature in army
-	SURRENDERED, // hero was owned by player before, but have surrendered in battle and kept some troops
+	RETREATED_TODAY,
 
-//	SURRENDERED_DAY7, // helper value for heroes that surrendered after 7th day during enemy turn
-//	RETREATED_DAY7,
+	SURRENDERED, // hero was owned by player before, but have surrendered in battle and kept some troops
+	SURRENDERED_TODAY,
 };
 
 VCMI_LIB_NAMESPACE_END

--- a/lib/mapping/CMap.h
+++ b/lib/mapping/CMap.h
@@ -56,10 +56,10 @@ struct DLL_LINKAGE DisposedHero
 {
 	DisposedHero();
 
-	ui32 heroId;
+	HeroTypeID heroId;
 	ui32 portrait; /// The portrait id of the hero, -1 is default.
 	std::string name;
-	ui8 players; /// Who can hire this hero (bitfield).
+	PlayerColor::Mask players; /// Who can hire this hero (bitfield).
 
 	template <typename Handler>
 	void serialize(Handler & h, const int version)

--- a/lib/mapping/CMap.h
+++ b/lib/mapping/CMap.h
@@ -57,7 +57,7 @@ struct DLL_LINKAGE DisposedHero
 	DisposedHero();
 
 	HeroTypeID heroId;
-	ui32 portrait; /// The portrait id of the hero, -1 is default.
+	HeroTypeID portrait; /// The portrait id of the hero, -1 is default.
 	std::string name;
 	PlayerColor::Mask players; /// Who can hire this hero (bitfield).
 

--- a/lib/registerTypes/RegisterTypes.h
+++ b/lib/registerTypes/RegisterTypes.h
@@ -239,7 +239,7 @@ void registerTypesClientPacks1(Serializer &s)
 	s.template registerType<CPackForClient, SetMana>();
 	s.template registerType<CPackForClient, SetMovePoints>();
 	s.template registerType<CPackForClient, FoWChange>();
-	s.template registerType<CPackForClient, SetAvailableHeroes>();
+	s.template registerType<CPackForClient, SetAvailableHero>();
 	s.template registerType<CPackForClient, GiveBonus>();
 	s.template registerType<CPackForClient, ChangeObjPos>();
 	s.template registerType<CPackForClient, PlayerEndsGame>();

--- a/lib/registerTypes/TypesLobbyPacks.cpp
+++ b/lib/registerTypes/TypesLobbyPacks.cpp
@@ -14,6 +14,7 @@
 #include "../StartInfo.h"
 #include "../gameState/CGameState.h"
 #include "../gameState/CGameStateCampaign.h"
+#include "../gameState/TavernHeroesPool.h"
 #include "../mapping/CMap.h"
 #include "../CModHandler.h"
 #include "../mapObjects/CObjectHandler.h"

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -7242,3 +7242,10 @@ void CGameHandler::createObject(const int3 & visitablePosition, Obj type, int32_
 	no.targetPos = visitablePosition;
 	sendAndApply(&no);
 }
+
+void CGameHandler::deserializationFix()
+{
+	//FIXME: pointer to GameHandler itself can't be deserialized at the moment since GameHandler is top-level entity in serialization
+	// restore any places that requires such pointer manually
+	heroPool->gameHandler = this;
+}

--- a/server/CGameHandler.h
+++ b/server/CGameHandler.h
@@ -99,6 +99,8 @@ class CGameHandler : public IGameCallback, public CBattleInfoCallback, public En
 	std::shared_ptr<CApplier<CBaseForGHApply>> applier;
 	std::unique_ptr<boost::thread> battleThread;
 
+	void deserializationFix();
+
 public:
 	std::unique_ptr<HeroPoolProcessor> heroPool;
 
@@ -289,6 +291,9 @@ public:
 		h & finishingBattle;
 		h & heroPool;
 		h & getRandomGenerator();
+
+		if (!h.saving)
+			deserializationFix();
 
 #if SCRIPTING_ENABLED
 		JsonNode scriptsState;

--- a/server/CGameHandler.h
+++ b/server/CGameHandler.h
@@ -99,8 +99,6 @@ class CGameHandler : public IGameCallback, public CBattleInfoCallback, public En
 	std::shared_ptr<CApplier<CBaseForGHApply>> applier;
 	std::unique_ptr<boost::thread> battleThread;
 
-	void deserializationFix();
-
 public:
 	std::unique_ptr<HeroPoolProcessor> heroPool;
 
@@ -365,6 +363,8 @@ public:
 	scripting::Pool * getContextPool() const override;
 #endif
 
+	std::list<PlayerColor> generatePlayerTurnOrder() const;
+
 	friend class CVCMIServer;
 private:
 	std::unique_ptr<events::EventBus> serverEventBus;
@@ -373,8 +373,9 @@ private:
 #endif
 
 	void reinitScripting();
+	void deserializationFix();
 
-	std::list<PlayerColor> generatePlayerTurnOrder() const;
+
 	void makeStackDoNothing(const CStack * next);
 	void getVictoryLossMessage(PlayerColor player, const EVictoryLossCheckResult & victoryLossCheckResult, InfoWindow & out) const;
 

--- a/server/CGameHandler.h
+++ b/server/CGameHandler.h
@@ -46,6 +46,7 @@ template<typename T> class CApplier;
 
 VCMI_LIB_NAMESPACE_END
 
+class HeroPoolProcessor;
 class CGameHandler;
 class CVCMIServer;
 class CBaseForGHApply;
@@ -97,7 +98,10 @@ class CGameHandler : public IGameCallback, public CBattleInfoCallback, public En
 	CVCMIServer * lobby;
 	std::shared_ptr<CApplier<CBaseForGHApply>> applier;
 	std::unique_ptr<boost::thread> battleThread;
+
 public:
+	std::unique_ptr<HeroPoolProcessor> heroPool;
+
 	using FireShieldInfo = std::vector<std::pair<const CStack *, int64_t>>;
 	//use enums as parameters, because doMove(sth, true, false, true) is not readable
 	enum EGuardLook {CHECK_FOR_GUARDS, IGNORE_GUARDS};
@@ -145,6 +149,7 @@ public:
 	void setupBattle(int3 tile, const CArmedInstance *armies[2], const CGHeroInstance *heroes[2], bool creatureBank, const CGTownInstance *town);
 	void setBattleResult(BattleResult::EResult resultType, int victoriusSide);
 
+	CGameHandler() = default;
 	CGameHandler(CVCMIServer * lobby);
 	~CGameHandler();
 
@@ -240,7 +245,6 @@ public:
 
 	void removeObstacle(const CObstacleInstance &obstacle);
 	bool queryReply( QueryID qid, const JsonNode & answer, PlayerColor player );
-	bool hireHero( const CGObjectInstance *obj, ui8 hid, PlayerColor player );
 	bool buildBoat( ObjectInstanceID objid, PlayerColor player );
 	bool setFormation( ObjectInstanceID hid, ui8 formation );
 	bool tradeResources(const IMarket *market, ui32 val, PlayerColor player, ui32 id1, ui32 id2);
@@ -283,6 +287,7 @@ public:
 		h & QID;
 		h & states;
 		h & finishingBattle;
+		h & heroPool;
 		h & getRandomGenerator();
 
 #if SCRIPTING_ENABLED

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -2,6 +2,7 @@ set(server_SRCS
 		StdInc.cpp
 
 		CGameHandler.cpp
+		HeroPoolProcessor.cpp
 		ServerSpellCastEnvironment.cpp
 		CQuery.cpp
 		CVCMIServer.cpp
@@ -13,6 +14,7 @@ set(server_HEADERS
 		StdInc.h
 
 		CGameHandler.h
+		HeroPoolProcessor.h
 		ServerSpellCastEnvironment.h
 		CQuery.h
 		CVCMIServer.h

--- a/server/CVCMIServer.cpp
+++ b/server/CVCMIServer.cpp
@@ -822,7 +822,7 @@ void CVCMIServer::setPlayer(PlayerColor clickedColor)
 void CVCMIServer::optionNextCastle(PlayerColor player, int dir)
 {
 	PlayerSettings & s = si->playerInfos[player];
-	si16 & cur = s.castle;
+	FactionID & cur = s.castle;
 	auto & allowed = getPlayerInfo(player.getNum()).allowedFactions;
 	const bool allowRandomTown = getPlayerInfo(player.getNum()).isFactionRandom;
 
@@ -856,7 +856,7 @@ void CVCMIServer::optionNextCastle(PlayerColor player, int dir)
 		else
 		{
 			assert(dir >= -1 && dir <= 1); //othervice std::advance may go out of range
-			auto iter = allowed.find(FactionID(cur));
+			auto iter = allowed.find(cur);
 			std::advance(iter, dir);
 			cur = *iter;
 		}

--- a/server/HeroPoolProcessor.cpp
+++ b/server/HeroPoolProcessor.cpp
@@ -1,0 +1,162 @@
+/*
+ * HeroPoolProcessor.cpp, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
+#include "StdInc.h"
+#include "HeroPoolProcessor.h"
+
+#include "CGameHandler.h"
+
+#include "../lib/CHeroHandler.h"
+#include "../lib/CPlayerState.h"
+#include "../lib/GameSettings.h"
+#include "../lib/NetPacks.h"
+#include "../lib/StartInfo.h"
+#include "../lib/mapObjects/CGTownInstance.h"
+#include "../lib/gameState/CGameState.h"
+#include "../lib/gameState/TavernHeroesPool.h"
+
+HeroPoolProcessor::HeroPoolProcessor() = default;
+
+HeroPoolProcessor::HeroPoolProcessor(CGameHandler * gameHandler):
+	gameHandler(gameHandler)
+{
+}
+
+void HeroPoolProcessor::onHeroSurrendered(const PlayerColor & color, const CGHeroInstance * hero)
+{
+	SetAvailableHero sah;
+	sah.slotID = 0;
+	sah.player = color;
+	sah.hid = hero->subID;
+	sah.army.clear();
+	sah.army.setCreature(SlotID(0), hero->type->initialArmy.at(0).creature, 1);
+	gameHandler->sendAndApply(&sah);
+}
+
+void HeroPoolProcessor::onHeroEscaped(const PlayerColor & color, const CGHeroInstance * hero)
+{
+	SetAvailableHero sah;
+	sah.slotID = 0;
+	sah.player = color;
+	sah.hid = hero->subID;
+
+	gameHandler->sendAndApply(&sah);
+}
+
+void HeroPoolProcessor::clearHeroFromSlot(const PlayerColor & color, TavernHeroSlot slot)
+{
+	SetAvailableHero sah;
+	sah.player = color;
+	sah.slotID = static_cast<int>(slot);
+	sah.hid = HeroTypeID::NONE;
+	gameHandler->sendAndApply(&sah);
+}
+
+void HeroPoolProcessor::selectNewHeroForSlot(const PlayerColor & color, TavernHeroSlot slot)
+{
+	SetAvailableHero sah;
+	sah.player = color;
+	sah.slotID = static_cast<int>(slot);
+
+	//first hero - native if possible, second hero -> any other class
+	CGHeroInstance *h = gameHandler->gameState()->hpool->pickHeroFor(slot, color, gameHandler->getPlayerSettings(color)->castle, gameHandler->getRandomGenerator());
+
+	if (h)
+	{
+		sah.hid = h->subID;
+		h->initArmy(gameHandler->getRandomGenerator(), &sah.army);
+	}
+	else
+	{
+		sah.hid = -1;
+	}
+	gameHandler->sendAndApply(&sah);
+}
+
+void HeroPoolProcessor::onNewWeek(const PlayerColor & color)
+{
+	clearHeroFromSlot(color, TavernHeroSlot::NATIVE);
+	clearHeroFromSlot(color, TavernHeroSlot::RANDOM);
+	selectNewHeroForSlot(color, TavernHeroSlot::NATIVE);
+	selectNewHeroForSlot(color, TavernHeroSlot::RANDOM);
+}
+
+bool HeroPoolProcessor::hireHero(const CGObjectInstance *obj, const HeroTypeID & heroToRecruit, const PlayerColor & player)
+{
+	const PlayerState * playerState = gameHandler->getPlayerState(player);
+	const CGTownInstance * town = gameHandler->getTown(obj->id);
+
+	if (playerState->resources[EGameResID::GOLD] < GameConstants::HERO_GOLD_COST && gameHandler->complain("Not enough gold for buying hero!"))
+		return false;
+
+	if (gameHandler->getHeroCount(player, false) >= VLC->settings()->getInteger(EGameSettings::HEROES_PER_PLAYER_ON_MAP_CAP) && gameHandler->complain("Cannot hire hero, too many wandering heroes already!"))
+		return false;
+
+	if (gameHandler->getHeroCount(player, true) >= VLC->settings()->getInteger(EGameSettings::HEROES_PER_PLAYER_TOTAL_CAP) && gameHandler->complain("Cannot hire hero, too many heroes garrizoned and wandering already!"))
+		return false;
+
+	if (town) //tavern in town
+	{
+		if (!town->hasBuilt(BuildingID::TAVERN) && gameHandler->complain("No tavern!"))
+			return false;
+
+		if (town->visitingHero  && gameHandler->complain("There is visiting hero - no place!"))
+			return false;
+	}
+
+	if (obj->ID == Obj::TAVERN)
+	{
+		if (gameHandler->getTile(obj->visitablePos())->visitableObjects.back() != obj && gameHandler->complain("Tavern entry must be unoccupied!"))
+			return false;
+	}
+
+	auto recruitableHeroes = gameHandler->gameState()->hpool->getHeroesFor(player);
+
+	const CGHeroInstance *recruitedHero = nullptr;;
+
+	for(const auto & hero : recruitableHeroes)
+	{
+		if (hero->subID == heroToRecruit)
+			recruitedHero = hero;
+	}
+
+	if (!recruitedHero)
+	{
+		gameHandler->complain ("Hero is not available for hiring!");
+		return false;
+	}
+
+	HeroRecruited hr;
+	hr.tid = obj->id;
+	hr.hid = recruitedHero->subID;
+	hr.player = player;
+	hr.tile = recruitedHero->convertFromVisitablePos(obj->visitablePos());
+	if (gameHandler->getTile(hr.tile)->isWater())
+	{
+		//Create a new boat for hero
+		gameHandler->createObject(obj->visitablePos(), Obj::BOAT, recruitedHero->getBoatType().getNum());
+
+		hr.boatId = gameHandler->getTopObj(hr.tile)->id;
+	}
+	gameHandler->sendAndApply(&hr);
+
+	if (recruitableHeroes[0] == recruitedHero)
+		selectNewHeroForSlot(player, TavernHeroSlot::NATIVE);
+	else
+		selectNewHeroForSlot(player, TavernHeroSlot::RANDOM);
+
+	gameHandler->giveResource(player, EGameResID::GOLD, -GameConstants::HERO_GOLD_COST);
+
+	if(town)
+	{
+		gameHandler->visitCastleObjects(town, recruitedHero);
+		gameHandler->giveSpells(town, recruitedHero);
+	}
+	return true;
+}

--- a/server/HeroPoolProcessor.h
+++ b/server/HeroPoolProcessor.h
@@ -1,0 +1,45 @@
+/*
+ * HeroPoolProcessor.h, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
+#pragma once
+
+VCMI_LIB_NAMESPACE_BEGIN
+
+enum class TavernHeroSlot;
+class PlayerColor;
+class CGHeroInstance;
+class HeroTypeID;
+class CGObjectInstance;
+
+VCMI_LIB_NAMESPACE_END
+
+class CGameHandler;
+
+class HeroPoolProcessor : boost::noncopyable
+{
+	CGameHandler * gameHandler;
+
+	void clearHeroFromSlot(const PlayerColor & color, TavernHeroSlot slot);
+	void selectNewHeroForSlot(const PlayerColor & color, TavernHeroSlot slot);
+public:
+	HeroPoolProcessor();
+	HeroPoolProcessor(CGameHandler * gameHandler);
+
+	void onHeroSurrendered(const PlayerColor & color, const CGHeroInstance * hero);
+	void onHeroEscaped(const PlayerColor & color, const CGHeroInstance * hero);
+
+	void onNewWeek(const PlayerColor & color);
+
+	bool hireHero(const CGObjectInstance *obj, const HeroTypeID & hid, const PlayerColor & player);
+
+	template <typename Handler> void serialize(Handler &h, const int version)
+	{
+		h & gameHandler;
+	}
+};

--- a/server/HeroPoolProcessor.h
+++ b/server/HeroPoolProcessor.h
@@ -26,23 +26,24 @@ class CGameHandler;
 
 class HeroPoolProcessor : boost::noncopyable
 {
-	CGameHandler * gameHandler;
-
 	/// per-player random generators
-	std::map<PlayerColor, CRandomGenerator> playerSeed;
+	std::map<PlayerColor, std::unique_ptr<CRandomGenerator>> playerSeed;
 
 	void clearHeroFromSlot(const PlayerColor & color, TavernHeroSlot slot);
 	void selectNewHeroForSlot(const PlayerColor & color, TavernHeroSlot slot, bool needNativeHero, bool giveStartingArmy);
 
-	std::set<const CHeroClass *> findAvailableClassesFor(const PlayerColor & player) const;
-	std::set<CGHeroInstance *> findAvailableHeroesFor(const PlayerColor & player, const CHeroClass * heroClass) const;
+	std::vector<const CHeroClass *> findAvailableClassesFor(const PlayerColor & player) const;
+	std::vector<CGHeroInstance *> findAvailableHeroesFor(const PlayerColor & player, const CHeroClass * heroClass) const;
 
 	const CHeroClass * pickClassFor(bool isNative, const PlayerColor & player);
 
 	CGHeroInstance * pickHeroFor(bool isNative, const PlayerColor & player);
 
 	CRandomGenerator & getRandomGenerator(const PlayerColor & player);
+
 public:
+	CGameHandler * gameHandler;
+
 	HeroPoolProcessor();
 	HeroPoolProcessor(CGameHandler * gameHandler);
 
@@ -55,7 +56,6 @@ public:
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
-		h & gameHandler;
 		h & playerSeed;
 	}
 };

--- a/server/HeroPoolProcessor.h
+++ b/server/HeroPoolProcessor.h
@@ -11,7 +11,8 @@
 
 VCMI_LIB_NAMESPACE_BEGIN
 
-enum class TavernHeroSlot;
+enum class TavernHeroSlot : int8_t;
+enum class TavernSlotRole : int8_t;
 class PlayerColor;
 class CGHeroInstance;
 class HeroTypeID;
@@ -41,6 +42,7 @@ class HeroPoolProcessor : boost::noncopyable
 
 	CRandomGenerator & getRandomGenerator(const PlayerColor & player);
 
+	TavernHeroSlot selectSlotForRole(const PlayerColor & player, TavernSlotRole roleID);
 public:
 	CGameHandler * gameHandler;
 

--- a/server/HeroPoolProcessor.h
+++ b/server/HeroPoolProcessor.h
@@ -16,7 +16,7 @@ enum class TavernSlotRole : int8_t;
 class PlayerColor;
 class CGHeroInstance;
 class HeroTypeID;
-class CGObjectInstance;
+class ObjectInstanceID;
 class CRandomGenerator;
 class CHeroClass;
 
@@ -55,10 +55,12 @@ public:
 
 	void onNewWeek(const PlayerColor & color);
 
-	bool hireHero(const CGObjectInstance *obj, const HeroTypeID & hid, const PlayerColor & player);
+	/// Incoming net pack handling
+	bool hireHero(const ObjectInstanceID & objectID, const HeroTypeID & hid, const PlayerColor & player);
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
+		// h & gameHandler; // FIXME: make this work instead of using deserializationFix in gameHandler
 		h & playerSeed;
 	}
 };

--- a/server/HeroPoolProcessor.h
+++ b/server/HeroPoolProcessor.h
@@ -17,7 +17,6 @@ class PlayerColor;
 class CGHeroInstance;
 class HeroTypeID;
 class CGObjectInstance;
-class FactionID;
 class CRandomGenerator;
 class CHeroClass;
 
@@ -43,6 +42,8 @@ class HeroPoolProcessor : boost::noncopyable
 	CRandomGenerator & getRandomGenerator(const PlayerColor & player);
 
 	TavernHeroSlot selectSlotForRole(const PlayerColor & player, TavernSlotRole roleID);
+
+	bool playerEndedTurn(const PlayerColor & player);
 public:
 	CGameHandler * gameHandler;
 

--- a/server/HeroPoolProcessor.h
+++ b/server/HeroPoolProcessor.h
@@ -31,6 +31,11 @@ class HeroPoolProcessor : boost::noncopyable
 	void clearHeroFromSlot(const PlayerColor & color, TavernHeroSlot slot);
 	void selectNewHeroForSlot(const PlayerColor & color, TavernHeroSlot slot, bool needNativeHero, bool giveStartingArmy);
 
+	std::set<const CHeroClass *> findAvailableClassesFor(const PlayerColor & player) const;
+	std::set<CGHeroInstance *> findAvailableHeroesFor(const PlayerColor & player, const CHeroClass * heroClass) const;
+
+	const CHeroClass * pickClassFor(bool isNative, const PlayerColor & player, const FactionID & faction, CRandomGenerator & rand) const;
+
 	CGHeroInstance * pickHeroFor(bool isNative, const PlayerColor & player, const FactionID & faction, CRandomGenerator & rand, const CHeroClass * bannedClass) const;
 public:
 	HeroPoolProcessor();

--- a/server/HeroPoolProcessor.h
+++ b/server/HeroPoolProcessor.h
@@ -16,6 +16,9 @@ class PlayerColor;
 class CGHeroInstance;
 class HeroTypeID;
 class CGObjectInstance;
+class FactionID;
+class CRandomGenerator;
+class CHeroClass;
 
 VCMI_LIB_NAMESPACE_END
 
@@ -26,7 +29,9 @@ class HeroPoolProcessor : boost::noncopyable
 	CGameHandler * gameHandler;
 
 	void clearHeroFromSlot(const PlayerColor & color, TavernHeroSlot slot);
-	void selectNewHeroForSlot(const PlayerColor & color, TavernHeroSlot slot);
+	void selectNewHeroForSlot(const PlayerColor & color, TavernHeroSlot slot, bool needNativeHero, bool giveStartingArmy);
+
+	CGHeroInstance * pickHeroFor(bool isNative, const PlayerColor & player, const FactionID & faction, CRandomGenerator & rand, const CHeroClass * bannedClass) const;
 public:
 	HeroPoolProcessor();
 	HeroPoolProcessor(CGameHandler * gameHandler);

--- a/server/HeroPoolProcessor.h
+++ b/server/HeroPoolProcessor.h
@@ -28,15 +28,20 @@ class HeroPoolProcessor : boost::noncopyable
 {
 	CGameHandler * gameHandler;
 
+	/// per-player random generators
+	std::map<PlayerColor, CRandomGenerator> playerSeed;
+
 	void clearHeroFromSlot(const PlayerColor & color, TavernHeroSlot slot);
 	void selectNewHeroForSlot(const PlayerColor & color, TavernHeroSlot slot, bool needNativeHero, bool giveStartingArmy);
 
 	std::set<const CHeroClass *> findAvailableClassesFor(const PlayerColor & player) const;
 	std::set<CGHeroInstance *> findAvailableHeroesFor(const PlayerColor & player, const CHeroClass * heroClass) const;
 
-	const CHeroClass * pickClassFor(bool isNative, const PlayerColor & player, const FactionID & faction, CRandomGenerator & rand) const;
+	const CHeroClass * pickClassFor(bool isNative, const PlayerColor & player);
 
-	CGHeroInstance * pickHeroFor(bool isNative, const PlayerColor & player, const FactionID & faction, CRandomGenerator & rand, const CHeroClass * bannedClass) const;
+	CGHeroInstance * pickHeroFor(bool isNative, const PlayerColor & player);
+
+	CRandomGenerator & getRandomGenerator(const PlayerColor & player);
 public:
 	HeroPoolProcessor();
 	HeroPoolProcessor(CGameHandler * gameHandler);
@@ -51,5 +56,6 @@ public:
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{
 		h & gameHandler;
+		h & playerSeed;
 	}
 };

--- a/server/NetPacksServer.cpp
+++ b/server/NetPacksServer.cpp
@@ -248,12 +248,10 @@ void ApplyGhNetPackVisitor::visitSetFormation(SetFormation & pack)
 
 void ApplyGhNetPackVisitor::visitHireHero(HireHero & pack)
 {
-	const CGObjectInstance * obj = gh.getObj(pack.tid);
-	const CGTownInstance * town = dynamic_ptr_cast<CGTownInstance>(obj);
-	if(town && PlayerRelations::ENEMIES == gh.getPlayerRelations(obj->tempOwner, gh.getPlayerAt(pack.c)))
-		gh.throwAndComplain(&pack, "Can't buy hero in enemy town!");
+	if (!gh.hasPlayerAt(pack.player, pack.c))
+		gh.throwAndComplain(&pack, "No such pack.player!");
 
-	result = gh.heroPool->hireHero(obj, pack.hid, pack.player);
+	result = gh.heroPool->hireHero(pack.tid, pack.hid, pack.player);
 }
 
 void ApplyGhNetPackVisitor::visitBuildBoat(BuildBoat & pack)

--- a/server/NetPacksServer.cpp
+++ b/server/NetPacksServer.cpp
@@ -11,6 +11,8 @@
 #include "ServerNetPackVisitors.h"
 
 #include "CGameHandler.h"
+#include "HeroPoolProcessor.h"
+
 #include "../lib/IGameCallback.h"
 #include "../lib/mapObjects/CGTownInstance.h"
 #include "../lib/gameState/CGameState.h"
@@ -251,7 +253,7 @@ void ApplyGhNetPackVisitor::visitHireHero(HireHero & pack)
 	if(town && PlayerRelations::ENEMIES == gh.getPlayerRelations(obj->tempOwner, gh.getPlayerAt(pack.c)))
 		gh.throwAndComplain(&pack, "Can't buy hero in enemy town!");
 
-	result = gh.hireHero(obj, pack.hid, pack.player);
+	result = gh.heroPool->hireHero(obj, pack.hid, pack.player);
 }
 
 void ApplyGhNetPackVisitor::visitBuildBoat(BuildBoat & pack)


### PR DESCRIPTION
Changes:
- [x] extract hero pool related code from massive classes CGameState / CGameHandler
- [x] Make hero selection logic same as in H3 - first select class, then select hero
- [x] Implement persistent random seed for taverns, as suggested on Discord
- [x] Fix retreating on 7th day during AI turn (https://bugs.vcmi.eu/view.php?id=2603)
- [x] Fix selection of slot to place retreated heroes (should be random AFAIK)
- [x] Fix retreating of multiple heroes (https://bugs.vcmi.eu/view.php?id=1416)