### PR TITLE
Fix for fullscreen game always starting in native resolution

### DIFF
--- a/client/renderSDL/ScreenHandler.cpp
+++ b/client/renderSDL/ScreenHandler.cpp
@@ -476,7 +476,7 @@ void ScreenHandler::clearScreen()
 
 std::vector<Point> ScreenHandler::getSupportedResolutions() const
 {
-	int displayID = SDL_GetWindowDisplayIndex(mainWindow);
+	int displayID = getPreferredDisplayIndex();
 	return getSupportedResolutions(displayID);
 }
 


### PR DESCRIPTION
In traditional fullscreen mode game always launches in native resolution (overrides launcher settings) - attempt to get display index for nullptr mainWindow for building list of allowed resolutions, resulting in empty list and overriding setting value