### PR TITLE
Fixed selection update in saving screen

### DIFF
--- a/client/lobby/CSavingScreen.cpp
+++ b/client/lobby/CSavingScreen.cpp
@@ -36,10 +36,10 @@ CSavingScreen::CSavingScreen()
 	localMi->mapHeader = std::unique_ptr<CMapHeader>(new CMapHeader(*LOCPLINT->cb->getMapHeader()));
 
 	tabSel = std::make_shared<SelectionTab>(screenType);
-	curTab = tabSel;
-	tabSel->toggleMode();
-
 	tabSel->callOnSelect = std::bind(&CSavingScreen::changeSelection, this, _1);
+	tabSel->toggleMode();
+	curTab = tabSel;
+		
 	buttonStart = std::make_shared<CButton>(Point(411, 535), "SCNRSAV.DEF", CGI->generaltexth->zelp[103], std::bind(&CSavingScreen::saveGame, this), EShortcut::LOBBY_SAVE_GAME);
 }
 

--- a/client/lobby/CSavingScreen.cpp
+++ b/client/lobby/CSavingScreen.cpp
@@ -62,6 +62,7 @@ void CSavingScreen::changeSelection(std::shared_ptr<CMapInfo> to)
 
 	localMi = to;
 	card->changeSelection();
+	card->redraw();
 }
 
 void CSavingScreen::saveGame()

--- a/client/lobby/SelectionTab.cpp
+++ b/client/lobby/SelectionTab.cpp
@@ -415,7 +415,7 @@ void SelectionTab::select(int position)
 	rememberCurrentSelection();
 
 	if(inputName && inputName->isActive())
-	{	
+	{
 		auto filename = *CResourceHandler::get("local")->getResourceName(ResourceID(curItems[py]->fileURI, EResType::CLIENT_SAVEGAME));
 		inputName->setText(filename.stem().string());
 	}
@@ -444,9 +444,6 @@ void SelectionTab::updateListItems()
 	// elemIdx is the index of the maps or saved game to display on line 0
 	// slider->capacity contains the number of available screen lines
 	// slider->positionsAmnt is the number of elements after filtering
-
-	logGlobal->trace("updateListItems called, selectionPos: %d", selectionPos);
-
 	int elemIdx = slider->getValue();
 	for(auto item : listItems)
 	{

--- a/client/lobby/SelectionTab.cpp
+++ b/client/lobby/SelectionTab.cpp
@@ -442,6 +442,9 @@ void SelectionTab::updateListItems()
 	// elemIdx is the index of the maps or saved game to display on line 0
 	// slider->capacity contains the number of available screen lines
 	// slider->positionsAmnt is the number of elements after filtering
+
+	logGlobal->trace("updateListItems called, selectionPos: %d", selectionPos);
+
 	int elemIdx = slider->getValue();
 	for(auto item : listItems)
 	{

--- a/client/lobby/SelectionTab.cpp
+++ b/client/lobby/SelectionTab.cpp
@@ -415,11 +415,13 @@ void SelectionTab::select(int position)
 	rememberCurrentSelection();
 
 	if(inputName && inputName->isActive())
-	{
+	{	
 		auto filename = *CResourceHandler::get("local")->getResourceName(ResourceID(curItems[py]->fileURI, EResType::CLIENT_SAVEGAME));
 		inputName->setText(filename.stem().string());
 	}
+
 	updateListItems();
+	redraw();
 	if(callOnSelect)
 		callOnSelect(curItems[py]);
 }


### PR DESCRIPTION
The cause of the delayed update is that we didn't redraw immediately. 
Also noticed that we tried to load scenario on the right side before setting up the select call back. So nothing was displayed initially. 

This should fix #1371, #2082 and #2137 

The save file name input on the bottom is still not redrawn right after initial loading. But it doesn't seem to be a big issue. Once another file is selected, it will be redrawn. 
