### PR TITLE
Fix HoTA guard offset in RMG

### DIFF
--- a/lib/rmg/modificators/ObjectManager.cpp
+++ b/lib/rmg/modificators/ObjectManager.cpp
@@ -606,6 +606,8 @@ bool ObjectManager::addGuard(rmg::Object & object, si32 strength, bool zoneGuard
 	auto & instance = object.addInstance(*guard);
 	instance.setPosition(guardPos - object.getPosition());
 	instance.setAnyTemplate(); //terrain is irrelevant for monsters, but monsters need some template now
+	//Make up for extra offset in HotA creature templates
+	instance.setPosition(instance.getPosition() + instance.object().getVisitableOffset());
 		
 	return true;
 }


### PR DESCRIPTION
Shift monster so its visitablePos ends up in target position.