### PR TITLE
Fix crashes from 1.2.1 statistics on Google Play

### DIFF
--- a/AI/BattleAI/BattleAI.cpp
+++ b/AI/BattleAI/BattleAI.cpp
@@ -93,6 +93,162 @@ void CBattleAI::initBattleInterface(std::shared_ptr<Environment> ENV, std::share
 	movesSkippedByDefense = 0;
 }
 
+BattleAction CBattleAI::useHealingTent(const CStack *stack)
+{
+	auto healingTargets = cb->battleGetStacks(CBattleInfoEssentials::ONLY_MINE);
+	std::map<int, const CStack*> woundHpToStack;
+	for(const auto * stack : healingTargets)
+	{
+		if(auto woundHp = stack->getMaxHealth() - stack->getFirstHPleft())
+			woundHpToStack[woundHp] = stack;
+	}
+
+	if(woundHpToStack.empty())
+		return BattleAction::makeDefend(stack);
+	else
+		return BattleAction::makeHeal(stack, woundHpToStack.rbegin()->second); //last element of the woundHpToStack is the most wounded stack
+}
+
+std::optional<PossibleSpellcast> CBattleAI::findBestCreatureSpell(const CStack *stack)
+{
+	//TODO: faerie dragon type spell should be selected by server
+	SpellID creatureSpellToCast = cb->battleGetRandomStackSpell(CRandomGenerator::getDefault(), stack, CBattleInfoCallback::RANDOM_AIMED);
+	if(stack->hasBonusOfType(BonusType::SPELLCASTER) && stack->canCast() && creatureSpellToCast != SpellID::NONE)
+	{
+		const CSpell * spell = creatureSpellToCast.toSpell();
+
+		if(spell->canBeCast(getCbc().get(), spells::Mode::CREATURE_ACTIVE, stack))
+		{
+			std::vector<PossibleSpellcast> possibleCasts;
+			spells::BattleCast temp(getCbc().get(), stack, spells::Mode::CREATURE_ACTIVE, spell);
+			for(auto & target : temp.findPotentialTargets())
+			{
+				PossibleSpellcast ps;
+				ps.dest = target;
+				ps.spell = spell;
+				evaluateCreatureSpellcast(stack, ps);
+				possibleCasts.push_back(ps);
+			}
+
+			std::sort(possibleCasts.begin(), possibleCasts.end(), [&](const PossibleSpellcast & lhs, const PossibleSpellcast & rhs) { return lhs.value > rhs.value; });
+			if(!possibleCasts.empty() && possibleCasts.front().value > 0)
+			{
+				return possibleCasts.front();
+			}
+		}
+	}
+	return std::nullopt;
+}
+
+BattleAction CBattleAI::selectStackAction(const CStack * stack)
+{
+	//evaluate casting spell for spellcasting stack
+	std::optional<PossibleSpellcast> bestSpellcast = findBestCreatureSpell(stack);
+
+	HypotheticBattle hb(env.get(), cb);
+
+	PotentialTargets targets(stack, hb);
+	BattleExchangeEvaluator scoreEvaluator(cb, env);
+	auto moveTarget = scoreEvaluator.findMoveTowardsUnreachable(stack, targets, hb);
+
+	int64_t score = EvaluationResult::INEFFECTIVE_SCORE;
+
+
+	if(targets.possibleAttacks.empty() && bestSpellcast.has_value())
+	{
+		movesSkippedByDefense = 0;
+		return BattleAction::makeCreatureSpellcast(stack, bestSpellcast->dest, bestSpellcast->spell->id);
+	}
+
+	if(!targets.possibleAttacks.empty())
+	{
+#if BATTLE_TRACE_LEVEL>=1
+		logAi->trace("Evaluating attack for %s", stack->getDescription());
+#endif
+
+		auto evaluationResult = scoreEvaluator.findBestTarget(stack, targets, hb);
+		auto & bestAttack = evaluationResult.bestAttack;
+
+		//TODO: consider more complex spellcast evaluation, f.e. because "re-retaliation" during enemy move in same turn for melee attack etc.
+		if(bestSpellcast.has_value() && bestSpellcast->value > bestAttack.damageDiff())
+		{
+			// return because spellcast value is damage dealt and score is dps reduce
+			movesSkippedByDefense = 0;
+			return BattleAction::makeCreatureSpellcast(stack, bestSpellcast->dest, bestSpellcast->spell->id);
+		}
+
+		if(evaluationResult.score > score)
+		{
+			score = evaluationResult.score;
+
+			logAi->debug("BattleAI: %s -> %s x %d, from %d curpos %d dist %d speed %d: +%lld -%lld = %lld",
+				bestAttack.attackerState->unitType()->getJsonKey(),
+				bestAttack.affectedUnits[0]->unitType()->getJsonKey(),
+				(int)bestAttack.affectedUnits[0]->getCount(),
+				(int)bestAttack.from,
+				(int)bestAttack.attack.attacker->getPosition().hex,
+				bestAttack.attack.chargeDistance,
+				bestAttack.attack.attacker->speed(0, true),
+				bestAttack.defenderDamageReduce,
+				bestAttack.attackerDamageReduce, bestAttack.attackValue()
+			);
+
+			if (moveTarget.score <= score)
+			{
+				if(evaluationResult.wait)
+				{
+					return BattleAction::makeWait(stack);
+				}
+				else if(bestAttack.attack.shooting)
+				{
+					movesSkippedByDefense = 0;
+					return BattleAction::makeShotAttack(stack, bestAttack.attack.defender);
+				}
+				else
+				{
+					movesSkippedByDefense = 0;
+					return BattleAction::makeMeleeAttack(stack, bestAttack.attack.defender->getPosition(), bestAttack.from);
+				}
+			}
+		}
+	}
+
+	//ThreatMap threatsToUs(stack); // These lines may be usefull but they are't used in the code.
+	if(moveTarget.score > score)
+	{
+		score = moveTarget.score;
+
+		if(stack->waited())
+		{
+			return goTowardsNearest(stack, moveTarget.positions);
+		}
+		else
+		{
+			return BattleAction::makeWait(stack);
+		}
+	}
+
+	if(score <= EvaluationResult::INEFFECTIVE_SCORE
+		&& !stack->hasBonusOfType(BonusType::FLYING)
+		&& stack->unitSide() == BattleSide::ATTACKER
+		&& cb->battleGetSiegeLevel() >= CGTownInstance::CITADEL)
+	{
+		auto brokenWallMoat = getBrokenWallMoatHexes();
+
+		if(brokenWallMoat.size())
+		{
+			movesSkippedByDefense = 0;
+
+			if(stack->doubleWide() && vstd::contains(brokenWallMoat, stack->getPosition()))
+				return BattleAction::makeMove(stack, stack->getPosition().cloneInDirection(BattleHex::RIGHT));
+			else
+				return goTowardsNearest(stack, brokenWallMoat);
+		}
+	}
+
+	return BattleAction::makeDefend(stack);
+}
+
 BattleAction CBattleAI::activeStack( const CStack * stack )
 {
 	LOG_TRACE_PARAMS(logAi, "stack: %s", stack->nodeName());
@@ -105,17 +261,7 @@ BattleAction CBattleAI::activeStack( const CStack * stack )
 		if(stack->creatureId() == CreatureID::CATAPULT)
 			return useCatapult(stack);
 		if(stack->hasBonusOfType(BonusType::SIEGE_WEAPON) && stack->hasBonusOfType(BonusType::HEALER))
-		{
-			auto healingTargets = cb->battleGetStacks(CBattleInfoEssentials::ONLY_MINE);
-			std::map<int, const CStack*> woundHpToStack;
-			for(auto stack : healingTargets)
-				if(auto woundHp = stack->getMaxHealth() - stack->getFirstHPleft())
-					woundHpToStack[woundHp] = stack;
-			if(woundHpToStack.empty())
-				return BattleAction::makeDefend(stack);
-			else
-				return BattleAction::makeHeal(stack, woundHpToStack.rbegin()->second); //last element of the woundHpToStack is the most wounded stack
-		}
+			return useHealingTent(stack);
 
 		attemptCastingSpell();
 
@@ -130,133 +276,8 @@ BattleAction CBattleAI::activeStack( const CStack * stack )
 
 		if(auto action = considerFleeingOrSurrendering())
 			return *action;
-		//best action is from effective owner point if view, we are effective owner as we received "activeStack"
 
-
-		//evaluate casting spell for spellcasting stack
-		std::optional<PossibleSpellcast> bestSpellcast(std::nullopt);
-		//TODO: faerie dragon type spell should be selected by server
-		SpellID creatureSpellToCast = cb->battleGetRandomStackSpell(CRandomGenerator::getDefault(), stack, CBattleInfoCallback::RANDOM_AIMED);
-		if(stack->hasBonusOfType(BonusType::SPELLCASTER) && stack->canCast() && creatureSpellToCast != SpellID::NONE)
-		{
-			const CSpell * spell = creatureSpellToCast.toSpell();
-
-			if(spell->canBeCast(getCbc().get(), spells::Mode::CREATURE_ACTIVE, stack))
-			{
-				std::vector<PossibleSpellcast> possibleCasts;
-				spells::BattleCast temp(getCbc().get(), stack, spells::Mode::CREATURE_ACTIVE, spell);
-				for(auto & target : temp.findPotentialTargets())
-				{
-					PossibleSpellcast ps;
-					ps.dest = target;
-					ps.spell = spell;
-					evaluateCreatureSpellcast(stack, ps);
-					possibleCasts.push_back(ps);
-				}
-
-				std::sort(possibleCasts.begin(), possibleCasts.end(), [&](const PossibleSpellcast & lhs, const PossibleSpellcast & rhs) { return lhs.value > rhs.value; });
-				if(!possibleCasts.empty() && possibleCasts.front().value > 0)
-				{
-					bestSpellcast = std::optional<PossibleSpellcast>(possibleCasts.front());
-				}
-			}
-		}
-
-		HypotheticBattle hb(env.get(), cb);
-		
-		PotentialTargets targets(stack, hb);
-		BattleExchangeEvaluator scoreEvaluator(cb, env);
-		auto moveTarget = scoreEvaluator.findMoveTowardsUnreachable(stack, targets, hb);
-
-		int64_t score = EvaluationResult::INEFFECTIVE_SCORE;
-
-		if(!targets.possibleAttacks.empty())
-		{
-#if BATTLE_TRACE_LEVEL>=1
-			logAi->trace("Evaluating attack for %s", stack->getDescription());
-#endif
-
-			auto evaluationResult = scoreEvaluator.findBestTarget(stack, targets, hb);
-			auto & bestAttack = evaluationResult.bestAttack;
-
-			//TODO: consider more complex spellcast evaluation, f.e. because "re-retaliation" during enemy move in same turn for melee attack etc.
-			if(bestSpellcast.has_value() && bestSpellcast->value > bestAttack.damageDiff())
-			{
-				// return because spellcast value is damage dealt and score is dps reduce
-				movesSkippedByDefense = 0;
-				return BattleAction::makeCreatureSpellcast(stack, bestSpellcast->dest, bestSpellcast->spell->id);
-			}
-
-			if(evaluationResult.score > score)
-			{
-				score = evaluationResult.score;
-				std::string action;
-
-				if(evaluationResult.wait)
-				{
-					result = BattleAction::makeWait(stack);
-					action = "wait";
-				}
-				else if(bestAttack.attack.shooting)
-				{
-					result = BattleAction::makeShotAttack(stack, bestAttack.attack.defender);
-					action = "shot";
-					movesSkippedByDefense = 0;
-				}
-				else
-				{
-					result = BattleAction::makeMeleeAttack(stack, bestAttack.attack.defender->getPosition(), bestAttack.from);
-					action = "melee";
-					movesSkippedByDefense = 0;
-				}
-
-				logAi->debug("BattleAI: %s -> %s x %d, %s, from %d curpos %d dist %d speed %d: +%lld -%lld = %lld",
-					bestAttack.attackerState->unitType()->getJsonKey(),
-					bestAttack.affectedUnits[0]->unitType()->getJsonKey(),
-					(int)bestAttack.affectedUnits[0]->getCount(), action, (int)bestAttack.from, (int)bestAttack.attack.attacker->getPosition().hex,
-					bestAttack.attack.chargeDistance, bestAttack.attack.attacker->speed(0, true),
-					bestAttack.defenderDamageReduce, bestAttack.attackerDamageReduce, bestAttack.attackValue()
-				);
-			}
-		}
-		else if(bestSpellcast.has_value())
-		{
-			movesSkippedByDefense = 0;
-			return BattleAction::makeCreatureSpellcast(stack, bestSpellcast->dest, bestSpellcast->spell->id);
-		}
-
-			//ThreatMap threatsToUs(stack); // These lines may be usefull but they are't used in the code.
-		if(moveTarget.score > score)
-		{
-			score = moveTarget.score;
-
-			if(stack->waited())
-			{
-				result = goTowardsNearest(stack, moveTarget.positions);
-			}
-			else
-			{
-				result = BattleAction::makeWait(stack);
-			}
-		}
-
-		if(score <= EvaluationResult::INEFFECTIVE_SCORE
-			&& !stack->hasBonusOfType(BonusType::FLYING)
-			&& stack->unitSide() == BattleSide::ATTACKER
-			&& cb->battleGetSiegeLevel() >= CGTownInstance::CITADEL)
-		{
-			auto brokenWallMoat = getBrokenWallMoatHexes();
-
-			if(brokenWallMoat.size())
-			{
-				movesSkippedByDefense = 0;
-
-				if(stack->doubleWide() && vstd::contains(brokenWallMoat, stack->getPosition()))
-					result = BattleAction::makeMove(stack, stack->getPosition().cloneInDirection(BattleHex::RIGHT));
-				else
-					result = goTowardsNearest(stack, brokenWallMoat);
-			}
-		}
+		result = selectStackAction(stack);
 	}
 	catch(boost::thread_interrupted &)
 	{

--- a/AI/BattleAI/BattleAI.h
+++ b/AI/BattleAI/BattleAI.h
@@ -77,6 +77,10 @@ public:
 
 	void print(const std::string &text) const;
 	BattleAction useCatapult(const CStack *stack);
+	BattleAction useHealingTent(const CStack *stack);
+	BattleAction selectStackAction(const CStack * stack);
+	std::optional<PossibleSpellcast> findBestCreatureSpell(const CStack *stack);
+
 	void battleStart(const CCreatureSet * army1, const CCreatureSet * army2, int3 tile, const CGHeroInstance * hero1, const CGHeroInstance * hero2, bool Side) override;
 	//void actionFinished(const BattleAction &action) override;//occurs AFTER every action taken by any stack or by the hero
 	//void actionStarted(const BattleAction &action) override;//occurs BEFORE every action taken by any stack or by the hero

--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -774,6 +774,14 @@ BattleAction CPlayerInterface::activeStack(const CStack * stack) //called when i
 	logGlobal->trace("Awaiting command for %s", stack->nodeName());
 	auto stackId = stack->unitId();
 	auto stackName = stack->nodeName();
+
+	assert(!cb->battleIsFinished());
+	if (cb->battleIsFinished())
+	{
+		logGlobal->error("Received CPlayerInterface::activeStack after battle is finished!");
+		return BattleAction::makeDefend(stack);
+	}
+
 	if (autofightingAI)
 	{
 		if (isAutoFightOn)

--- a/client/CServerHandler.cpp
+++ b/client/CServerHandler.cpp
@@ -887,11 +887,6 @@ void CServerHandler::threadHandleConnection()
 			}
 		}
 	}
-	catch(...)
-	{
-		handleException();
-		throw;
-	}
 }
 
 void CServerHandler::visitForLobby(CPackForLobby & lobbyPack)

--- a/client/Client.cpp
+++ b/client/Client.cpp
@@ -683,7 +683,6 @@ void CClient::stopPlayerBattleAction(PlayerColor color)
 		}
 		playerActionThreads.erase(color);
 	}
-
 }
 
 void CClient::stopAllBattleActions()

--- a/client/Client.h
+++ b/client/Client.h
@@ -60,9 +60,8 @@ namespace boost { class thread; }
 template<typename T>
 class ThreadSafeVector
 {
-	using TVector = std::vector<T>;
 	using TLock = boost::unique_lock<boost::mutex>;
-	TVector items;
+	std::vector<T> items;
 	boost::mutex mx;
 	boost::condition_variable cond;
 
@@ -81,28 +80,16 @@ public:
 		cond.notify_all();
 	}
 
-// 	//to access list, caller must present a lock used to lock mx
-// 	TVector &getList(TLock &lockedLock)
-// 	{
-// 		assert(lockedLock.owns_lock() && lockedLock.mutex() == &mx);
-// 		return items;
-// 	}
-
-	TLock getLock()
-	{
-		return TLock(mx);
-	}
-
 	void waitWhileContains(const T & item)
 	{
-		auto lock = getLock();
+		TLock lock(mx);
 		while(vstd::contains(items, item))
 			cond.wait(lock);
 	}
 
 	bool tryRemovingElement(const T & item) //returns false if element was not present
 	{
-		auto lock = getLock();
+		TLock lock(mx);
 		auto itr = vstd::find(items, item);
 		if(itr == items.end()) //not in container
 		{

--- a/client/battle/BattleInterface.cpp
+++ b/client/battle/BattleInterface.cpp
@@ -163,6 +163,7 @@ BattleInterface::~BattleInterface()
 	if (adventureInt)
 		adventureInt->onAudioResumed();
 
+	awaitingEvents.clear();
 	onAnimationsFinished();
 }
 
@@ -781,8 +782,19 @@ void BattleInterface::onAnimationsFinished()
 
 void BattleInterface::waitForAnimations()
 {
-	auto unlockPim = vstd::makeUnlockGuard(*CPlayerInterface::pim);
-	ongoingAnimationsState.waitUntil(false);
+	{
+		auto unlockPim = vstd::makeUnlockGuard(*CPlayerInterface::pim);
+		ongoingAnimationsState.waitUntil(false);
+	}
+
+	assert(!hasAnimations());
+	assert(awaitingEvents.empty());
+
+	if (!awaitingEvents.empty())
+	{
+		logGlobal->error("Wait for animations finished but we still have awaiting events!");
+		awaitingEvents.clear();
+	}
 }
 
 bool BattleInterface::hasAnimations()

--- a/client/battle/BattleStacksController.cpp
+++ b/client/battle/BattleStacksController.cpp
@@ -375,13 +375,11 @@ void BattleStacksController::updateBattleAnimations(uint32_t msPassed)
 	tickFrameBattleAnimations(msPassed);
 	vstd::erase(currentAnimations, nullptr);
 
-	if (hadAnimations && currentAnimations.empty())
-	{
-		//stackAmountBoxHidden.clear();
+	if (currentAnimations.empty())
 		owner.executeStagedAnimations();
-		if (currentAnimations.empty())
-			owner.onAnimationsFinished();
-	}
+
+	if (hadAnimations && currentAnimations.empty())
+		owner.onAnimationsFinished();
 
 	initializeBattleAnimations();
 }

--- a/client/gui/WindowHandler.cpp
+++ b/client/gui/WindowHandler.cpp
@@ -99,6 +99,12 @@ bool WindowHandler::isTopWindow(IShowActivatable * window) const
 
 void WindowHandler::totalRedraw()
 {
+	totalRedrawRequested = true;
+}
+
+void WindowHandler::totalRedrawImpl()
+{
+	logGlobal->debug("totalRedraw requested!");
 	CSDL_Ext::fillSurface(screen2, Colors::BLACK);
 
 	Canvas target = Canvas::createFromSurface(screen2);
@@ -109,6 +115,16 @@ void WindowHandler::totalRedraw()
 }
 
 void WindowHandler::simpleRedraw()
+{
+	if (totalRedrawRequested)
+		totalRedrawImpl();
+	else
+		simpleRedrawImpl();
+
+	totalRedrawRequested = false;
+}
+
+void WindowHandler::simpleRedrawImpl()
 {
 	//update only top interface and draw background
 	if(windowsStack.size() > 1)

--- a/client/gui/WindowHandler.h
+++ b/client/gui/WindowHandler.h
@@ -20,8 +20,16 @@ class WindowHandler
 	/// Temporary list of recently popped windows
 	std::vector<std::shared_ptr<IShowActivatable>> disposed;
 
+	bool totalRedrawRequested = false;
+
 	/// returns top windows
 	std::shared_ptr<IShowActivatable> topWindowImpl() const;
+
+	/// forces total redraw (using showAll), sets a flag, method gets called at the end of the rendering
+	void totalRedrawImpl();
+
+	/// update only top windows and draw background from buffer, sets a flag, method gets called at the end of the rendering
+	void simpleRedrawImpl();
 
 public:
 	/// forces total redraw (using showAll), sets a flag, method gets called at the end of the rendering

--- a/client/mainmenu/CMainMenu.cpp
+++ b/client/mainmenu/CMainMenu.cpp
@@ -337,13 +337,7 @@ void CMainMenu::update()
 
 	// Handles mouse and key input
 	GH.handleEvents();
-
-	Canvas canvas = Canvas::createFromSurface(screen);
-
-	// check for null othervice crash on finishing a campaign
-	// /FIXME: find out why GH.windows().listInt is empty to begin with
-	if(GH.windows().topWindow<CIntObject>())
-		GH.windows().topWindow<CIntObject>()->show(canvas);
+	GH.windows().simpleRedraw();
 }
 
 void CMainMenu::openLobby(ESelectionScreen screenType, bool host, const std::vector<std::string> * names, ELoadMode loadMode)

--- a/client/mapView/MapRenderer.cpp
+++ b/client/mapView/MapRenderer.cpp
@@ -145,6 +145,13 @@ void MapRendererTerrain::renderTile(IMapRendererContext & context, Canvas & targ
 
 	const auto & image = storage.find(terrainIndex, rotationIndex, imageIndex);
 
+	assert(image);
+	if (!image)
+	{
+		logGlobal->error("Failed to find image %d for terrain %s on tile %s", imageIndex, mapTile.terType->getNameTranslated(), coordinates.toString());
+		return;
+	}
+
 	for( auto const & element : mapTile.terType->paletteAnimation)
 		image->shiftPalette(element.start, element.length, context.terrainImageIndex(element.length));
 

--- a/config/gameConfig.json
+++ b/config/gameConfig.json
@@ -310,7 +310,7 @@
 			// if enabled, neutral dwellings will accumulate creatures 
 			"accumulateWhenNeutral" : false,
 			// if enabled, dwellings owned by players will accumulate creatures 
-			"accumulateWhenOwned" : false
+			"accumulateWhenOwned" : false,
 			// if enabled, game will attempt to merge slots in army on recruit if all slots in hero army are in use
 			"mergeOnRecruit" : true
 		},

--- a/lib/NetPacksLib.cpp
+++ b/lib/NetPacksLib.cpp
@@ -1479,6 +1479,7 @@ void NewObject::applyGs(CGameState *gs)
 	terrainType = t.terType->getId();
 
 	auto handler = VLC->objtypeh->getHandlerFor(ID, subID);
+
 	CGObjectInstance * o = handler->create();
 	handler->configureObject(o, gs->getRandomGenerator());
 	
@@ -1496,6 +1497,11 @@ void NewObject::applyGs(CGameState *gs)
 	}
 
 	assert(!handler->getTemplates(terrainType).empty());
+	if (handler->getTemplates().empty())
+	{
+		logGlobal->error("Attempt to create object (%d %d) with no templates!", ID, subID);
+		return;
+	}
 
 	if (!handler->getTemplates(terrainType).empty())
 		o->appearance = handler->getTemplates(terrainType).front();


### PR DESCRIPTION
Attempt to resolve or at least - add some better error checking for several crashes found in Android statistics.

Largest source of crashes seems to be:
- *extremely* common crash on BattleAI taking action, as well as on activation of quick combat.
- NewObject::applyGs (likely already fixed in boat refactoring)
- few more unknown crashes with unavailable stack trace due to throwing exception from catch block on server

Progress so far:
- remove "catch-all" block from server that does not provides any useful info, but successfully clears any stacktrace in case of exception
- attempt to fix crash on NewObject::applyGs
- refactored BattleAI::activeStack() method into smaller ones, to localize crash (Google Play only shows stacktrace, without locals or line numbers)
- removed async execution from ExchangeWindow, to simplify our threading model
- implemented lazy total redraws to prevent multiple totalRedraws on one frame
- fixes (possibly - only partially) #1323 

TODO: 
- fix (newly discovered bug) that makes it impossible to cancel autocombat
- try to simplify threading model of client/netpack handling to fix extremely common crash on AI action (autocombat likely)