### PR TITLE
Use full debug information in release build on Android

### DIFF
--- a/android/vcmi-app/build.gradle
+++ b/android/vcmi-app/build.gradle
@@ -42,7 +42,7 @@ android {
 				applicationLabel: '@string/app_name',
 			]
 			ndk {
-				debugSymbolLevel 'symbol_table'
+				debugSymbolLevel 'full'
 			}
 		}
 		daily {


### PR DESCRIPTION
Currently on Google Play only function-level information is available for crashes in native code. This is sometimes... less than helpful thanks to some of our massive methods.

This change according to documentation should give access to actual crash locations. However not 100% whether this will work or whether this will bloat our package too much.