### PR TITLE
Bugfixing iteration

### DIFF
--- a/AI/BattleAI/BattleAI.cpp
+++ b/AI/BattleAI/BattleAI.cpp
@@ -251,7 +251,7 @@ BattleAction CBattleAI::selectStackAction(const CStack * stack)
 
 void CBattleAI::yourTacticPhase(int distance)
 {
-	cb->battleMakeUnitAction(BattleAction::makeEndOFTacticPhase(cb->battleGetTacticsSide()));
+	cb->battleMakeTacticAction(BattleAction::makeEndOFTacticPhase(cb->battleGetTacticsSide()));
 }
 
 void CBattleAI::activeStack( const CStack * stack )

--- a/AI/EmptyAI/CEmptyAI.cpp
+++ b/AI/EmptyAI/CEmptyAI.cpp
@@ -41,7 +41,7 @@ void CEmptyAI::activeStack(const CStack * stack)
 
 void CEmptyAI::yourTacticPhase(int distance)
 {
-	cb->battleMakeUnitAction(BattleAction::makeEndOFTacticPhase(cb->battleGetTacticsSide()));
+	cb->battleMakeTacticAction(BattleAction::makeEndOFTacticPhase(cb->battleGetTacticsSide()));
 }
 
 void CEmptyAI::heroGotLevel(const CGHeroInstance *hero, PrimarySkill::PrimarySkill pskill, std::vector<SecondarySkill> &skills, QueryID queryID)

--- a/AI/StupidAI/StupidAI.cpp
+++ b/AI/StupidAI/StupidAI.cpp
@@ -90,7 +90,7 @@ static bool willSecondHexBlockMoreEnemyShooters(const BattleHex &h1, const Battl
 
 void CStupidAI::yourTacticPhase(int distance)
 {
-	cb->battleMakeUnitAction(BattleAction::makeEndOFTacticPhase(cb->battleGetTacticsSide()));
+	cb->battleMakeTacticAction(BattleAction::makeEndOFTacticPhase(cb->battleGetTacticsSide()));
 }
 
 void CStupidAI::activeStack( const CStack * stack )

--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -1904,8 +1904,9 @@ bool CPlayerInterface::capturedAllEvents()
 	}
 
 	bool needToLockAdventureMap = adventureInt && adventureInt->isActive() && CGI->mh->hasOngoingAnimations();
+	bool quickCombatOngoing = isAutoFightOn && !battleInt;
 
-	if (ignoreEvents || needToLockAdventureMap || isAutoFightOn)
+	if (ignoreEvents || needToLockAdventureMap || quickCombatOngoing )
 	{
 		GH.input().ignoreEventsUntilInput();
 		return true;

--- a/client/Client.cpp
+++ b/client/Client.cpp
@@ -26,6 +26,7 @@
 #include "../lib/gameState/CGameState.h"
 #include "../lib/CThreadHelper.h"
 #include "../lib/VCMIDirs.h"
+#include "../lib/UnlockGuard.h"
 #include "../lib/battle/BattleInfo.h"
 #include "../lib/serializer/BinaryDeserializer.h"
 #include "../lib/mapping/CMapService.h"
@@ -624,6 +625,14 @@ void CClient::battleStarted(const BattleInfo * info)
 			CPlayerInterface::battleInt = std::make_shared<BattleInterface>(leftSide.armyObject, rightSide.armyObject, leftSide.hero, rightSide.hero, att, def, spectratorInt);
 		}
 	}
+
+	if(info->tacticDistance)
+	{
+		auto tacticianColor = info->sides[info->tacticsSide].color;
+
+		if (vstd::contains(battleints, tacticianColor))
+			battleints[tacticianColor]->yourTacticPhase(info->tacticDistance);
+	}
 }
 
 void CClient::battleFinished()
@@ -645,6 +654,9 @@ void CClient::startPlayerBattleAction(PlayerColor color)
 
 	if(vstd::contains(battleints, color))
 	{
+		// we want to avoid locking gamestate and causing UI to freeze while AI is making turn
+		auto unlock = vstd::makeUnlockGuardIf(*CPlayerInterface::pim, !battleints[color]->human);
+
 		assert(vstd::contains(battleints, color));
 		battleints[color]->activeStack(gs->curB->battleGetStackByID(gs->curB->activeStack, false));
 	}

--- a/client/battle/BattleSiegeController.cpp
+++ b/client/battle/BattleSiegeController.cpp
@@ -330,8 +330,6 @@ bool BattleSiegeController::isAttackableByCatapult(BattleHex hex) const
 
 void BattleSiegeController::stackIsCatapulting(const CatapultAttack & ca)
 {
-	owner.checkForAnimations();
-
 	if (ca.attacker != -1)
 	{
 		const CStack *stack = owner.curInt->cb->battleGetStackByID(ca.attacker);

--- a/client/battle/BattleStacksController.cpp
+++ b/client/battle/BattleStacksController.cpp
@@ -235,6 +235,9 @@ void BattleStacksController::setActiveStack(const CStack *stack)
 		stackAnimation[activeStack->unitId()]->setBorderColor(AnimationControls::getGoldBorder());
 
 	owner.windowObject->blockUI(activeStack == nullptr);
+
+	if (activeStack)
+		stackAmountBoxHidden.clear();
 }
 
 bool BattleStacksController::stackNeedsAmountBox(const CStack * stack) const

--- a/client/battle/BattleStacksController.cpp
+++ b/client/battle/BattleStacksController.cpp
@@ -154,11 +154,6 @@ void BattleStacksController::collectRenderableObjects(BattleRenderer & renderer)
 
 void BattleStacksController::stackReset(const CStack * stack)
 {
-	owner.checkForAnimations();
-
-	//reset orientation?
-	//stackFacingRight[stack->unitId()] = stack->unitSide() == BattleSide::ATTACKER;
-
 	auto iter = stackAnimation.find(stack->unitId());
 
 	if(iter == stackAnimation.end())

--- a/client/eventsSDL/InputSourceTouch.cpp
+++ b/client/eventsSDL/InputSourceTouch.cpp
@@ -81,7 +81,10 @@ void InputSourceTouch::handleEventFingerMotion(const SDL_TouchFingerEvent & tfin
 		{
 			Point distance = convertTouchToMouse(tfinger) - lastTapPosition;
 			if ( std::abs(distance.x) > params.panningSensitivityThreshold || std::abs(distance.y) > params.panningSensitivityThreshold)
+			{
 				state = TouchState::TAP_DOWN_PANNING;
+				GH.events().dispatchGesturePanningStarted(lastTapPosition);
+			}
 			break;
 		}
 		case TouchState::TAP_DOWN_PANNING:
@@ -128,7 +131,6 @@ void InputSourceTouch::handleEventFingerDown(const SDL_TouchFingerEvent & tfinge
 		{
 			lastTapPosition = convertTouchToMouse(tfinger);
 			GH.input().setCursorPosition(lastTapPosition);
-			GH.events().dispatchGesturePanningStarted(lastTapPosition);
 			state = TouchState::TAP_DOWN_SHORT;
 			break;
 		}

--- a/client/eventsSDL/InputSourceTouch.cpp
+++ b/client/eventsSDL/InputSourceTouch.cpp
@@ -135,6 +135,12 @@ void InputSourceTouch::handleEventFingerDown(const SDL_TouchFingerEvent & tfinge
 			break;
 		}
 		case TouchState::TAP_DOWN_SHORT:
+		{
+			GH.input().setCursorPosition(convertTouchToMouse(tfinger));
+			GH.events().dispatchGesturePanningStarted(lastTapPosition);
+			state = TouchState::TAP_DOWN_DOUBLE;
+			break;
+		}
 		case TouchState::TAP_DOWN_PANNING:
 		{
 			GH.input().setCursorPosition(convertTouchToMouse(tfinger));

--- a/client/windows/InfoWindows.cpp
+++ b/client/windows/InfoWindows.cpp
@@ -90,6 +90,15 @@ CSelWindow::CSelWindow(const std::string &Text, PlayerColor player, int charperl
 		//buttons.back()->addCallback(std::bind(&CCallback::selectionMade, LOCPLINT->cb.get(), 0, askID));
 	}
 
+	if(buttons.size() == 1)
+		buttons.front()->assignedKey = EShortcut::GLOBAL_RETURN;
+
+	if(buttons.size() == 2)
+	{
+		buttons.front()->assignedKey = EShortcut::GLOBAL_ACCEPT;
+		buttons.back()->assignedKey = EShortcut::GLOBAL_CANCEL;
+	}
+
 	for(int i=0;i<comps.size();i++)
 	{
 		comps[i]->recActions = 255-DISPOSE;

--- a/launcher/modManager/cmodlist.cpp
+++ b/launcher/modManager/cmodlist.cpp
@@ -280,7 +280,7 @@ CModEntry CModList::getMod(QString modname) const
 
 	if(conf.isNull())
 	{
-		settings["active"] = true; // default
+		settings["active"] = !local.value("keepDisabled").toBool();
 	}
 	else
 	{
@@ -288,7 +288,7 @@ CModEntry CModList::getMod(QString modname) const
 		{
 			settings = conf.toMap();
 			if(settings.value("active").isNull())
-				settings["active"] = true; // default
+				settings["active"] = !local.value("keepDisabled").toBool();
 		}
 		else
 			settings.insert("active", conf);

--- a/lib/NetPacksLib.cpp
+++ b/lib/NetPacksLib.cpp
@@ -1390,18 +1390,7 @@ void HeroRecruited::applyGs(CGameState * gs) const
 
 	h->setOwner(player);
 	h->pos = tile;
-	bool fresh = !h->isInitialized();
-	if(fresh)
-	{ // this is a fresh hero who hasn't appeared yet
-		if (boatId >= 0) //Hero spawns on water
-		{
-			h->setMovementPoints(h->movementPointsLimit(false));
-		}
-		else
-		{
-			h->setMovementPoints(h->movementPointsLimit(true));
-		}
-	}
+	h->initObj(gs->getRandomGenerator());
 
 	if(h->id == ObjectInstanceID())
 	{
@@ -1414,16 +1403,10 @@ void HeroRecruited::applyGs(CGameState * gs) const
 	gs->map->heroesOnMap.emplace_back(h);
 	p->heroes.emplace_back(h);
 	h->attachTo(*p);
-	if(fresh)
-	{
-		h->initObj(gs->getRandomGenerator());
-	}
 	gs->map->addBlockVisTiles(h);
 
 	if(t)
-	{
 		t->setVisitingHero(h);
-	}
 }
 
 void GiveHero::applyGs(CGameState * gs) const

--- a/lib/NetPacksLib.cpp
+++ b/lib/NetPacksLib.cpp
@@ -2208,19 +2208,25 @@ void BattleResultAccepted::applyGs(CGameState * gs) const
 			res.hero->removeBonusesRecursive(Bonus::OneBattle);
 	}
 
-	// Grow up growing artifacts
-	if(const auto hero = heroResult[winnerSide].hero)
+	if(winnerSide != 2)
 	{
-		if(hero->commander && hero->commander->alive)
+		// Grow up growing artifacts
+		const auto hero = heroResult[winnerSide].hero;
+
+		if (hero)
 		{
-			for(auto & art : hero->commander->artifactsWorn)
+			if(hero->commander && hero->commander->alive)
+			{
+				for(auto & art : hero->commander->artifactsWorn)
+					art.second.artifact->growingUp();
+			}
+			for(auto & art : hero->artifactsWorn)
+			{
 				art.second.artifact->growingUp();
-		}
-		for(auto & art : hero->artifactsWorn)
-		{
-			art.second.artifact->growingUp();
+			}
 		}
 	}
+
 	if(VLC->settings()->getBoolean(EGameSettings::MODULE_STACK_EXPERIENCE))
 	{
 		if(heroResult[0].army)


### PR DESCRIPTION
Issues to investigate:
- [x] battle hangs on start if enemy AI has tactics phase
- [x] Autocombat can be deactivated (missing commit from previous PR)
- [x] Fixed activation of radial wheel when using touchscreen input
- [x] Game crash on ending battle in a draw
- [x] Option "keepDisabled" does not correctly shows up in Launcher
- [x] sometimes enemy hero tile is visited with overlapping (sharing same tile) so both attacker and defender are seen on same tile
- [x] enchanters lose their creature count label when it's their turn, probably related to casting spell before attack

To be done later:
- [ ] creatures walking animation looks choppy when decreasing FPS to 30 -  can be seen by looking at nomad legs during animation in H3 and VCMI
- [ ] clicking between real and borderless fullscreen in options (one, then another etc.) leads to both being turned off at some point 
- [ ] Switching to world view and back breaks adventure map - no date display.
- [ ] Visiting Magi Hut - hero movement sound plays while terrain is being revealed
- [ ] water under ship covering land tile
- [ ] Error on accepting quick combat results or fighting against AI - non-existing query
