### PR TITLE
Fix for hero info window mana points not getting spent on spellcast - option 1

### DIFF
--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -476,6 +476,9 @@ void CPlayerInterface::heroManaPointsChanged(const CGHeroInstance * hero)
 	adventureInt->onHeroChanged(hero);
 	if (makingTurn && hero->tempOwner == playerID)
 		adventureInt->onHeroChanged(hero);
+
+	for (auto window : GH.windows().findWindows<BattleWindow>())
+		window->heroManaPointsChanged(hero);
 }
 void CPlayerInterface::heroMovePointsChanged(const CGHeroInstance * hero)
 {

--- a/client/battle/BattleInterface.cpp
+++ b/client/battle/BattleInterface.cpp
@@ -584,7 +584,15 @@ void BattleInterface::endAction(const BattleAction* action)
 
 	//we have activated next stack after sending request that has been just realized -> blockmap due to movement has changed
 	if(action->actionType == EActionType::HERO_SPELL)
+	{
 		fieldController->redrawBackgroundWithHexes();
+
+		//update casting hero info window
+		auto hero = action->side == 0 ? attackingHero : defendingHero;
+		InfoAboutHero heroInfo = InfoAboutHero();
+		heroInfo.initFromHero(hero->instance(), InfoAboutHero::INBATTLE);
+		windowObject->updateHeroInfoWindow(action->side, heroInfo);
+	}
 }
 
 void BattleInterface::appendBattleLog(const std::string & newEntry)

--- a/client/battle/BattleInterface.cpp
+++ b/client/battle/BattleInterface.cpp
@@ -584,15 +584,7 @@ void BattleInterface::endAction(const BattleAction* action)
 
 	//we have activated next stack after sending request that has been just realized -> blockmap due to movement has changed
 	if(action->actionType == EActionType::HERO_SPELL)
-	{
 		fieldController->redrawBackgroundWithHexes();
-
-		//update casting hero info window
-		auto hero = action->side == 0 ? attackingHero : defendingHero;
-		InfoAboutHero heroInfo = InfoAboutHero();
-		heroInfo.initFromHero(hero->instance(), InfoAboutHero::INBATTLE);
-		windowObject->updateHeroInfoWindow(action->side, heroInfo);
-	}
 }
 
 void BattleInterface::appendBattleLog(const std::string & newEntry)

--- a/client/battle/BattleInterfaceClasses.cpp
+++ b/client/battle/BattleInterfaceClasses.cpp
@@ -389,6 +389,12 @@ HeroInfoBasicPanel::HeroInfoBasicPanel(const InfoAboutHero & hero, Point * posit
 		background->colorize(hero.owner);
 	}
 
+	initializeData(hero);
+}
+
+void HeroInfoBasicPanel::initializeData(const InfoAboutHero & hero)
+{
+	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
 	auto attack = hero.details->primskills[0];
 	auto defense = hero.details->primskills[1];
 	auto power = hero.details->primskills[2];
@@ -421,6 +427,14 @@ HeroInfoBasicPanel::HeroInfoBasicPanel(const InfoAboutHero & hero, Point * posit
 	//spell points
 	labels.push_back(std::make_shared<CLabel>(39, 174, EFonts::FONT_TINY, ETextAlignment::CENTER, Colors::WHITE, CGI->generaltexth->allTexts[387]));
 	labels.push_back(std::make_shared<CLabel>(39, 186, EFonts::FONT_TINY, ETextAlignment::CENTER, Colors::WHITE, std::to_string(currentSpellPoints) + "/" + std::to_string(maxSpellPoints)));
+}
+
+void HeroInfoBasicPanel::update(const InfoAboutHero & updatedInfo)
+{
+	icons.clear();
+	labels.clear();
+
+	initializeData(updatedInfo);
 }
 
 void HeroInfoBasicPanel::show(Canvas & to)

--- a/client/battle/BattleInterfaceClasses.h
+++ b/client/battle/BattleInterfaceClasses.h
@@ -137,6 +137,9 @@ public:
 	HeroInfoBasicPanel(const InfoAboutHero & hero, Point * position, bool initializeBackground = true);
 
 	void show(Canvas & to) override;
+
+	void initializeData(const InfoAboutHero & hero);
+	void update(const InfoAboutHero & updatedInfo);
 };
 
 class HeroInfoWindow : public CWindowObject

--- a/client/battle/BattleWindow.cpp
+++ b/client/battle/BattleWindow.cpp
@@ -256,6 +256,21 @@ void BattleWindow::updateHeroInfoWindow(uint8_t side, const InfoAboutHero & hero
 	panelToUpdate->update(hero);
 }
 
+void BattleWindow::heroManaPointsChanged(const CGHeroInstance * hero)
+{
+	if(hero == owner.attackingHeroInstance || hero == owner.defendingHeroInstance)
+	{
+		InfoAboutHero heroInfo = InfoAboutHero();
+		heroInfo.initFromHero(hero, InfoAboutHero::INBATTLE);
+
+		updateHeroInfoWindow(hero == owner.attackingHeroInstance ? 0 : 1, heroInfo);
+	}
+	else
+	{
+		logGlobal->error("BattleWindow::heroManaPointsChanged: 'Mana points changed' called for hero not belonging to current battle window");
+	}
+}
+
 void BattleWindow::activate()
 {
 	GH.setStatusbar(console);

--- a/client/battle/BattleWindow.cpp
+++ b/client/battle/BattleWindow.cpp
@@ -237,8 +237,8 @@ void BattleWindow::showStickyHeroWindows()
 	if(settings["battle"]["stickyHeroInfoWindows"].Bool() == true)
 		return;
 
-	Settings showStickyHeroInfoWIndows = settings.write["battle"]["stickyHeroInfoWindows"];
-	showStickyHeroInfoWIndows->Bool() = true;
+	Settings showStickyHeroInfoWindows = settings.write["battle"]["stickyHeroInfoWindows"];
+	showStickyHeroInfoWindows->Bool() = true;
 
 
 	createStickyHeroInfoWindows();
@@ -248,6 +248,12 @@ void BattleWindow::showStickyHeroWindows()
 void BattleWindow::updateQueue()
 {
 	queue->update();
+}
+
+void BattleWindow::updateHeroInfoWindow(uint8_t side, const InfoAboutHero & hero)
+{
+	std::shared_ptr<HeroInfoBasicPanel> panelToUpdate = side == 0 ? attackerHeroWindow : defenderHeroWindow;
+	panelToUpdate->update(hero);
 }
 
 void BattleWindow::activate()

--- a/client/battle/BattleWindow.h
+++ b/client/battle/BattleWindow.h
@@ -88,6 +88,9 @@ public:
 	/// Refresh queue after turn order changes
 	void updateQueue();
 
+	/// Refresh sticky variant of hero info window after spellcast, side same as in BattleSpellCast::side
+	void updateHeroInfoWindow(uint8_t side, const InfoAboutHero & hero);
+
 	/// Get mouse-hovered battle queue unit ID if any found
 	std::optional<uint32_t> getQueueHoveredUnitId();
 

--- a/client/battle/BattleWindow.h
+++ b/client/battle/BattleWindow.h
@@ -79,8 +79,12 @@ public:
 	void hideQueue();
 	void showQueue();
 
+	/// Toggle permanent hero info windows visibility (HD mod feature)
 	void hideStickyHeroWindows();
 	void showStickyHeroWindows();
+
+	/// Event handler for netpack changing hero mana points
+	void heroManaPointsChanged(const CGHeroInstance * hero);
 
 	/// block all UI elements when player is not allowed to act, e.g. during enemy turn
 	void blockUI(bool on);


### PR DESCRIPTION
First proposition to approach mana not refreshing in hero info window - poke window on mana used. Does not handle imp mana steam and spells cheat yet, but these are niche anyway. Somewhat resembles approach that would be used in observer pattern, except that battle interface deals with window refresh in its own code

Pick or close this PR, depending on which option is better, compared with #2391 