### PR TITLE
Fix for hero info window mana points not getting spent on spellcast - option 2

### DIFF
--- a/client/battle/BattleInterfaceClasses.cpp
+++ b/client/battle/BattleInterfaceClasses.cpp
@@ -311,12 +311,10 @@ void BattleHero::heroRightClicked()
 		windowPosition.y = owner.fieldController->pos.y;
 	}
 
-	InfoAboutHero targetHero;
 	if(owner.makingTurn() || settings["session"]["spectate"].Bool())
 	{
 		auto h = defender ? owner.defendingHeroInstance : owner.attackingHeroInstance;
-		targetHero.initFromHero(h, InfoAboutHero::EInfoLevel::INBATTLE);
-		GH.windows().createAndPushWindow<HeroInfoWindow>(targetHero, &windowPosition);
+		GH.windows().createAndPushWindow<HeroInfoWindow>(*h, &windowPosition);
 	}
 }
 
@@ -375,70 +373,94 @@ BattleHero::BattleHero(const BattleInterface & owner, const CGHeroInstance * her
 	addUsedEvents(TIME);
 }
 
-HeroInfoBasicPanel::HeroInfoBasicPanel(const InfoAboutHero & hero, Point * position, bool initializeBackground)
+HeroInfoBasicPanel::HeroInfoBasicPanel(const CGHeroInstance * hero, Point * position, bool initializeBackground)
 	: CIntObject(0)
 {
 	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
 	if (position != nullptr)
 		moveTo(*position);
 
+	relatedHero = hero;
+
 	if(initializeBackground)
 	{
 		background = std::make_shared<CPicture>("CHRPOP");
 		background->getSurface()->setBlitMode(EImageBlitMode::OPAQUE);
-		background->colorize(hero.owner);
+		background->colorize(hero->getOwner());
 	}
 
-	auto attack = hero.details->primskills[0];
-	auto defense = hero.details->primskills[1];
-	auto power = hero.details->primskills[2];
-	auto knowledge = hero.details->primskills[3];
-	auto morale = hero.details->morale;
-	auto luck = hero.details->luck;
-	auto currentSpellPoints = hero.details->mana;
-	auto maxSpellPoints = hero.details->manaLimit;
+	InitializePanel();
+}
 
-	icons.push_back(std::make_shared<CAnimImage>("PortraitsLarge", hero.portrait, 0, 10, 6));
+void HeroInfoBasicPanel::InitializePanel()
+{
+	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
+
+	InfoAboutHero heroInfo;
+	heroInfo.initFromHero(relatedHero, InfoAboutHero::EInfoLevel::INBATTLE);
+
+	auto attack = heroInfo.details->primskills[0];
+	auto defense = heroInfo.details->primskills[1];
+	auto power = heroInfo.details->primskills[2];
+	auto knowledge = heroInfo.details->primskills[3];
+	auto morale = heroInfo.details->morale;
+	auto luck = heroInfo.details->luck;
+	auto currentSpellPoints = heroInfo.details->mana;
+	auto maxSpellPoints = heroInfo.details->manaLimit;
+
+	lastSpellPointsValue = currentSpellPoints;
+
+	icons.push_back(std::make_shared<CAnimImage>("PortraitsLarge", heroInfo.portrait, 0, 10, 6));
 
 	//primary stats
-	labels.push_back(std::make_shared<CLabel>(9, 75, EFonts::FONT_TINY, ETextAlignment::TOPLEFT, Colors::WHITE, CGI->generaltexth->allTexts[380] + ":"));
-	labels.push_back(std::make_shared<CLabel>(9, 87, EFonts::FONT_TINY, ETextAlignment::TOPLEFT, Colors::WHITE, CGI->generaltexth->allTexts[381] + ":"));
-	labels.push_back(std::make_shared<CLabel>(9, 99, EFonts::FONT_TINY, ETextAlignment::TOPLEFT, Colors::WHITE, CGI->generaltexth->allTexts[382] + ":"));
-	labels.push_back(std::make_shared<CLabel>(9, 111, EFonts::FONT_TINY, ETextAlignment::TOPLEFT, Colors::WHITE, CGI->generaltexth->allTexts[383] + ":"));
+	labels.push_back(std::make_shared<CLabel>(9, 75, FONT_TINY, ETextAlignment::TOPLEFT, Colors::WHITE, CGI->generaltexth->allTexts[380] + ":"));
+	labels.push_back(std::make_shared<CLabel>(9, 87, FONT_TINY, ETextAlignment::TOPLEFT, Colors::WHITE, CGI->generaltexth->allTexts[381] + ":"));
+	labels.push_back(std::make_shared<CLabel>(9, 99, FONT_TINY, ETextAlignment::TOPLEFT, Colors::WHITE, CGI->generaltexth->allTexts[382] + ":"));
+	labels.push_back(std::make_shared<CLabel>(9, 111, FONT_TINY, ETextAlignment::TOPLEFT, Colors::WHITE, CGI->generaltexth->allTexts[383] + ":"));
 
-	labels.push_back(std::make_shared<CLabel>(69, 87, EFonts::FONT_TINY, ETextAlignment::BOTTOMRIGHT, Colors::WHITE, std::to_string(attack)));
-	labels.push_back(std::make_shared<CLabel>(69, 99, EFonts::FONT_TINY, ETextAlignment::BOTTOMRIGHT, Colors::WHITE, std::to_string(defense)));
-	labels.push_back(std::make_shared<CLabel>(69, 111, EFonts::FONT_TINY, ETextAlignment::BOTTOMRIGHT, Colors::WHITE, std::to_string(power)));
-	labels.push_back(std::make_shared<CLabel>(69, 123, EFonts::FONT_TINY, ETextAlignment::BOTTOMRIGHT, Colors::WHITE, std::to_string(knowledge)));
+	labels.push_back(std::make_shared<CLabel>(69, 87, FONT_TINY, ETextAlignment::BOTTOMRIGHT, Colors::WHITE, std::to_string(attack)));
+	labels.push_back(std::make_shared<CLabel>(69, 99, FONT_TINY, ETextAlignment::BOTTOMRIGHT, Colors::WHITE, std::to_string(defense)));
+	labels.push_back(std::make_shared<CLabel>(69, 111, FONT_TINY, ETextAlignment::BOTTOMRIGHT, Colors::WHITE, std::to_string(power)));
+	labels.push_back(std::make_shared<CLabel>(69, 123, FONT_TINY, ETextAlignment::BOTTOMRIGHT, Colors::WHITE, std::to_string(knowledge)));
 
 	//morale+luck
-	labels.push_back(std::make_shared<CLabel>(9, 131, EFonts::FONT_TINY, ETextAlignment::TOPLEFT, Colors::WHITE, CGI->generaltexth->allTexts[384] + ":"));
-	labels.push_back(std::make_shared<CLabel>(9, 143, EFonts::FONT_TINY, ETextAlignment::TOPLEFT, Colors::WHITE, CGI->generaltexth->allTexts[385] + ":"));
+	labels.push_back(std::make_shared<CLabel>(9, 131, FONT_TINY, ETextAlignment::TOPLEFT, Colors::WHITE, CGI->generaltexth->allTexts[384] + ":"));
+	labels.push_back(std::make_shared<CLabel>(9, 143, FONT_TINY, ETextAlignment::TOPLEFT, Colors::WHITE, CGI->generaltexth->allTexts[385] + ":"));
 
 	icons.push_back(std::make_shared<CAnimImage>("IMRL22", morale + 3, 0, 47, 131));
 	icons.push_back(std::make_shared<CAnimImage>("ILCK22", luck + 3, 0, 47, 143));
 
 	//spell points
-	labels.push_back(std::make_shared<CLabel>(39, 174, EFonts::FONT_TINY, ETextAlignment::CENTER, Colors::WHITE, CGI->generaltexth->allTexts[387]));
-	labels.push_back(std::make_shared<CLabel>(39, 186, EFonts::FONT_TINY, ETextAlignment::CENTER, Colors::WHITE, std::to_string(currentSpellPoints) + "/" + std::to_string(maxSpellPoints)));
+	labels.push_back(std::make_shared<CLabel>(39, 174, FONT_TINY, ETextAlignment::CENTER, Colors::WHITE, CGI->generaltexth->allTexts[387]));
+	labels.push_back(std::make_shared<CLabel>(39, 186, FONT_TINY, ETextAlignment::CENTER, Colors::WHITE, std::to_string(currentSpellPoints) + "/" + std::to_string(maxSpellPoints)));
+}
+
+void HeroInfoBasicPanel::update()
+{
+	icons.clear();
+	labels.clear();
+	InitializePanel();
 }
 
 void HeroInfoBasicPanel::show(Canvas & to)
 {
+	if(relatedHero->mana != lastSpellPointsValue)
+		update();
+
 	showAll(to);
 	CIntObject::show(to);
 }
 
-HeroInfoWindow::HeroInfoWindow(const InfoAboutHero & hero, Point * position)
+HeroInfoWindow::HeroInfoWindow(const CGHeroInstance & hero, Point * position)
 	: CWindowObject(RCLICK_POPUP | SHADOW_DISABLED, "CHRPOP")
 {
 	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
 	if (position != nullptr)
 		moveTo(*position);
 
-	background->colorize(hero.owner); //maybe add this functionality to base class?
+	background->colorize(hero.getOwner()); //maybe add this functionality to base class?
 
-	content = std::make_shared<HeroInfoBasicPanel>(hero, nullptr, false);
+	content = std::make_shared<HeroInfoBasicPanel>(&hero, nullptr, false);
 }
 
 BattleResultWindow::BattleResultWindow(const BattleResult & br, CPlayerInterface & _owner, bool allowReplay)

--- a/client/battle/BattleInterfaceClasses.h
+++ b/client/battle/BattleInterfaceClasses.h
@@ -133,10 +133,16 @@ private:
 	std::shared_ptr<CPicture> background;
 	std::vector<std::shared_ptr<CLabel>> labels;
 	std::vector<std::shared_ptr<CAnimImage>> icons;
+
+	const CGHeroInstance * relatedHero;
+	int lastSpellPointsValue;
 public:
-	HeroInfoBasicPanel(const InfoAboutHero & hero, Point * position, bool initializeBackground = true);
+	HeroInfoBasicPanel(const CGHeroInstance * hero, Point * position, bool initializeBackground = true);
 
 	void show(Canvas & to) override;
+	void update();
+
+	void InitializePanel();
 };
 
 class HeroInfoWindow : public CWindowObject
@@ -144,7 +150,7 @@ class HeroInfoWindow : public CWindowObject
 private:
 	std::shared_ptr<HeroInfoBasicPanel> content;
 public:
-	HeroInfoWindow(const InfoAboutHero & hero, Point * position);
+	HeroInfoWindow(const CGHeroInstance & hero, Point * position);
 };
 
 /// Class which is responsible for showing the battle result window

--- a/client/battle/BattleWindow.cpp
+++ b/client/battle/BattleWindow.cpp
@@ -124,21 +124,17 @@ void BattleWindow::createStickyHeroInfoWindows()
 
 	if(owner.defendingHeroInstance)
 	{
-		InfoAboutHero info;
-		info.initFromHero(owner.defendingHeroInstance, InfoAboutHero::EInfoLevel::INBATTLE);
 		Point position = (GH.screenDimensions().x >= 1000)
 				? Point(pos.x + pos.w + 15, pos.y)
 				: Point(pos.x + pos.w -79, pos.y + 135);
-		defenderHeroWindow = std::make_shared<HeroInfoBasicPanel>(info, &position);
+		defenderHeroWindow = std::make_shared<HeroInfoBasicPanel>(owner.defendingHeroInstance, &position);
 	}
 	if(owner.attackingHeroInstance)
 	{
-		InfoAboutHero info;
-		info.initFromHero(owner.attackingHeroInstance, InfoAboutHero::EInfoLevel::INBATTLE);
 		Point position = (GH.screenDimensions().x >= 1000)
 				? Point(pos.x - 93, pos.y)
 				: Point(pos.x + 1, pos.y + 135);
-		attackerHeroWindow = std::make_shared<HeroInfoBasicPanel>(info, &position);
+		attackerHeroWindow = std::make_shared<HeroInfoBasicPanel>(owner.attackingHeroInstance, &position);
 	}
 
 	bool showInfoWindows = settings["battle"]["stickyHeroInfoWindows"].Bool();


### PR DESCRIPTION
Alternative to #2390 - store hero reference in info window and poll for changes - handles all mana usages + optimization that skips labels remake if mana points did not change