### PR TITLE
Attempt to fix & improve error reporting

### DIFF
--- a/Global.h
+++ b/Global.h
@@ -253,26 +253,6 @@ using TLockGuardRec = std::lock_guard<std::recursive_mutex>;
 
 VCMI_LIB_NAMESPACE_BEGIN
 
-void inline handleException()
-{
-	try
-	{
-		throw;
-	}
-	catch(const std::exception & ex)
-	{
-		logGlobal->error(ex.what());
-	}
-	catch(const std::string & ex)
-	{
-		logGlobal->error(ex);
-	}
-	catch(...)
-	{
-		logGlobal->error("Sorry, caught unknown exception type. No more info available.");
-	}
-}
-
 namespace vstd
 {
 	// combine hashes. Present in boost but not in std

--- a/client/CServerHandler.cpp
+++ b/client/CServerHandler.cpp
@@ -865,8 +865,11 @@ void CServerHandler::threadHandleConnection()
 		}
 		else
 		{
-			logNetwork->error("Lost connection to server, ending listening thread!");
-			logNetwork->error(e.what());
+			if (e.code() == boost::asio::error::eof)
+				logNetwork->error("Lost connection to server, ending listening thread! Connection has been closed");
+			else
+				logNetwork->error("Lost connection to server, ending listening thread! Reason: %s", e.what());
+
 			if(client)
 			{
 				state = EClientState::DISCONNECTING;

--- a/lib/VCMI_Lib.cpp
+++ b/lib/VCMI_Lib.cpp
@@ -48,17 +48,10 @@ DLL_LINKAGE void preinitDLL(CConsoleHandler * Console, bool onlyEssential, bool 
 {
 	console = Console;
 	VLC = new LibClasses();
-	try
-	{
-		VLC->loadFilesystem(extractArchives);
-		settings.init();
-		VLC->loadModFilesystem(onlyEssential);
-	}
-	catch(...)
-	{
-		handleException();
-		throw;
-	}
+	VLC->loadFilesystem(extractArchives);
+	settings.init();
+	VLC->loadModFilesystem(onlyEssential);
+
 }
 
 DLL_LINKAGE void loadDLLClasses(bool onlyEssential)

--- a/lib/gameState/CGameState.cpp
+++ b/lib/gameState/CGameState.cpp
@@ -569,7 +569,6 @@ void CGameState::initNewGame(const IMapService * mapService, bool allowSavingRan
 			catch(...)
 			{
 				logGlobal->error("Saving random map failed with exception");
-				handleException();
 			}
 		}
 

--- a/lib/logging/CLogger.h
+++ b/lib/logging/CLogger.h
@@ -220,7 +220,7 @@ public:
 	void write(const LogRecord & record) override;
 
 private:
-	FileStream file;
+	boost::filesystem::fstream file;
 	CLogFormatter formatter;
 	mutable std::mutex mx;
 };

--- a/lib/mapObjectConstructors/AObjectTypeHandler.cpp
+++ b/lib/mapObjectConstructors/AObjectTypeHandler.cpp
@@ -77,15 +77,8 @@ void AObjectTypeHandler::init(const JsonNode & input)
 		tmpl->id = Obj(type);
 		tmpl->subid = subtype;
 		tmpl->stringID = entry.first; // FIXME: create "fullID" - type.object.template?
-		try
-		{
-			tmpl->readJson(entry.second);
-			templates.push_back(std::shared_ptr<const ObjectTemplate>(tmpl));
-		}
-		catch (const std::exception & e)
-		{
-			logGlobal->warn("Failed to load terrains for object %s: %s", entry.first, e.what());
-		}
+		tmpl->readJson(entry.second);
+		templates.push_back(std::shared_ptr<const ObjectTemplate>(tmpl));
 	}
 
 	for(const JsonNode & node : input["sounds"]["ambient"].Vector())

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -109,10 +109,6 @@ public:
             (void)e;
 			return false;
 		}
-		catch(...)
-		{
-			throw;
-		}
 	}
 };
 

--- a/server/PlayerMessageProcessor.cpp
+++ b/server/PlayerMessageProcessor.cpp
@@ -175,7 +175,7 @@ void PlayerMessageProcessor::cheatGiveArmy(PlayerColor player, const CGHeroInsta
 	{
 		amountPerSlot = std::stol(words.at(1));
 	}
-	catch(std::exception&)
+	catch(std::logic_error&)
 	{
 	}
 
@@ -233,7 +233,7 @@ void PlayerMessageProcessor::cheatLevelup(PlayerColor player, const CGHeroInstan
 	{
 		levelsToGain = std::stol(words.at(0));
 	}
-	catch(std::exception&)
+	catch(std::logic_error&)
 	{
 		levelsToGain = 1;
 	}
@@ -252,7 +252,7 @@ void PlayerMessageProcessor::cheatExperience(PlayerColor player, const CGHeroIns
 	{
 		expAmountProcessed = std::stol(words.at(0));
 	}
-	catch(std::exception&)
+	catch(std::logic_error&)
 	{
 		expAmountProcessed = 10000;
 	}
@@ -271,7 +271,7 @@ void PlayerMessageProcessor::cheatMovement(PlayerColor player, const CGHeroInsta
 	{
 		smp.val = std::stol(words.at(0));;
 	}
-	catch(std::exception&)
+	catch(std::logic_error&)
 	{
 		smp.val = 1000000;
 	}
@@ -293,7 +293,7 @@ void PlayerMessageProcessor::cheatResources(PlayerColor player, std::vector<std:
 	{
 		baseResourceAmount = std::stol(words.at(0));;
 	}
-	catch(std::exception&)
+	catch(std::logic_error&)
 	{
 		baseResourceAmount = 100;
 	}


### PR DESCRIPTION
Currently figuring out reason for crash on user-side is quite painful - logs are corrupted, thrown exceptions are "handled" by writing irrelevant error message & discarding call stack.

These changes should alleviate this situation somewhat.

- use std::fstream instead of boost::iostreams for properly working flush
- removed some catch-all blocks
- reduce catch scope of some try/catch blocks to clearly indicate intent