### PR TITLE
Fix game hang/crash on locking mutex

### DIFF
--- a/AI/BattleAI/BattleAI.h
+++ b/AI/BattleAI/BattleAI.h
@@ -59,7 +59,8 @@ class CBattleAI : public CBattleGameInterface
 	std::shared_ptr<Environment> env;
 
 	//Previous setting of cb
-	bool wasWaitingForRealize, wasUnlockingGs;
+	bool wasWaitingForRealize;
+	bool wasUnlockingGs;
 	int movesSkippedByDefense;
 
 public:

--- a/AI/StupidAI/StupidAI.cpp
+++ b/AI/StupidAI/StupidAI.cpp
@@ -18,14 +18,21 @@ static std::shared_ptr<CBattleCallback> cbc;
 
 CStupidAI::CStupidAI()
 	: side(-1)
+	, wasWaitingForRealize(false)
+	, wasUnlockingGs(false)
 {
 	print("created");
 }
 
-
 CStupidAI::~CStupidAI()
 {
 	print("destroyed");
+	if(cb)
+	{
+		//Restore previous state of CB - it may be shared with the main AI (like VCAI)
+		cb->waitTillRealize = wasWaitingForRealize;
+		cb->unlockGsWhenWaiting = wasUnlockingGs;
+	}
 }
 
 void CStupidAI::initBattleInterface(std::shared_ptr<Environment> ENV, std::shared_ptr<CBattleCallback> CB)
@@ -33,6 +40,11 @@ void CStupidAI::initBattleInterface(std::shared_ptr<Environment> ENV, std::share
 	print("init called, saving ptr to IBattleCallback");
 	env = ENV;
 	cbc = cb = CB;
+
+	wasWaitingForRealize = CB->waitTillRealize;
+	wasUnlockingGs = CB->unlockGsWhenWaiting;
+	CB->waitTillRealize = false;
+	CB->unlockGsWhenWaiting = false;
 }
 
 void CStupidAI::actionFinished(const BattleAction &action)

--- a/AI/StupidAI/StupidAI.h
+++ b/AI/StupidAI/StupidAI.h
@@ -20,6 +20,9 @@ class CStupidAI : public CBattleGameInterface
 	std::shared_ptr<CBattleCallback> cb;
 	std::shared_ptr<Environment> env;
 
+	bool wasWaitingForRealize;
+	bool wasUnlockingGs;
+
 	void print(const std::string &text) const;
 public:
 	CStupidAI();

--- a/client/eventsSDL/InputHandler.cpp
+++ b/client/eventsSDL/InputHandler.cpp
@@ -70,13 +70,22 @@ void InputHandler::handleCurrentEvent(const SDL_Event & current)
 	}
 }
 
-void InputHandler::processEvents()
+std::vector<SDL_Event> InputHandler::acquireEvents()
 {
 	boost::unique_lock<boost::mutex> lock(eventsMutex);
-	for(const auto & currentEvent : eventsQueue)
+
+	std::vector<SDL_Event> result;
+	std::swap(result, eventsQueue);
+	return result;
+}
+
+void InputHandler::processEvents()
+{
+	std::vector<SDL_Event> eventsToProcess = acquireEvents();
+
+	for(const auto & currentEvent : eventsToProcess)
 		handleCurrentEvent(currentEvent);
 
-	eventsQueue.clear();
 	fingerHandler->handleUpdate();
 }
 

--- a/client/eventsSDL/InputHandler.h
+++ b/client/eventsSDL/InputHandler.h
@@ -29,6 +29,8 @@ class InputHandler
 
 	Point cursorPosition;
 
+	std::vector<SDL_Event> acquireEvents();
+
 	void preprocessEvent(const SDL_Event & event);
 	void handleCurrentEvent(const SDL_Event & current);
 	void handleUserEvent(const SDL_UserEvent & current);


### PR DESCRIPTION
- Fixes handling of gamestate locks by StupidAI - AI will no longer try to unlock mutex & wait for callback reply
- Fixes game shutdown - InputHandler would keep mutex locked during event processing (so almost always), resulting in assertion failure on exit