### PR TITLE
(develop) Remove access to SDL_Color from UI code

### DIFF
--- a/client/CMT.cpp
+++ b/client/CMT.cpp
@@ -25,6 +25,7 @@
 #include "ClientCommandManager.h"
 #include "windows/CMessage.h"
 #include "render/IScreenHandler.h"
+#include "render/Graphics.h"
 
 #include "../lib/filesystem/Filesystem.h"
 #include "../lib/CGeneralTextHandler.h"

--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -226,6 +226,7 @@ set(client_HEADERS
 	render/Canvas.h
 	render/ColorFilter.h
 	render/Colors.h
+	render/EFont.h
 	render/Graphics.h
 	render/ICursor.h
 	render/IFont.h

--- a/client/NetPacksLobbyClient.cpp
+++ b/client/NetPacksLobbyClient.cpp
@@ -68,7 +68,7 @@ void ApplyOnLobbyScreenNetPackVisitor::visitLobbyChatMessage(LobbyChatMessage & 
 		lobby->card->chat->addNewMessage(pack.playerName + ": " + pack.message);
 		lobby->card->setChat(true);
 		if(lobby->buttonChat)
-			lobby->buttonChat->addTextOverlay(CGI->generaltexth->allTexts[531], FONT_SMALL);
+			lobby->buttonChat->addTextOverlay(CGI->generaltexth->allTexts[531], FONT_SMALL, Colors::WHITE);
 	}
 }
 

--- a/client/adventureMap/AdventureMapWidget.h
+++ b/client/adventureMap/AdventureMapWidget.h
@@ -11,6 +11,7 @@
 
 #include "../gui/InterfaceObjectConfigurable.h"
 
+class CAnimation;
 class CHeroList;
 class CTownList;
 class CMinimap;

--- a/client/adventureMap/CList.cpp
+++ b/client/adventureMap/CList.cpp
@@ -22,6 +22,7 @@
 #include "../PlayerLocalState.h"
 #include "../gui/CGuiHandler.h"
 #include "../render/Canvas.h"
+#include "../render/Colors.h"
 
 #include "../../lib/CGeneralTextHandler.h"
 #include "../../lib/CHeroHandler.h"

--- a/client/adventureMap/CMinimap.cpp
+++ b/client/adventureMap/CMinimap.cpp
@@ -20,8 +20,9 @@
 #include "../gui/MouseButton.h"
 #include "../gui/WindowHandler.h"
 #include "../render/Colors.h"
-#include "../renderSDL/SDL_Extensions.h"
 #include "../render/Canvas.h"
+#include "../render/Graphics.h"
+#include "../renderSDL/SDL_Extensions.h"
 #include "../windows/InfoWindows.h"
 
 #include "../../CCallback.h"
@@ -30,25 +31,23 @@
 #include "../../lib/mapObjects/CGHeroInstance.h"
 #include "../../lib/mapping/CMapDefines.h"
 
-#include <SDL_pixels.h>
-
 ColorRGBA CMinimapInstance::getTileColor(const int3 & pos) const
 {
 	const TerrainTile * tile = LOCPLINT->cb->getTile(pos, false);
 
 	// if tile is not visible it will be black on minimap
 	if(!tile)
-		return CSDL_Ext::fromSDL(Colors::BLACK);
+		return Colors::BLACK;
 
 	// if object at tile is owned - it will be colored as its owner
 	for (const CGObjectInstance *obj : tile->blockingObjects)
 	{
 		PlayerColor player = obj->getOwner();
 		if(player == PlayerColor::NEUTRAL)
-			return CSDL_Ext::fromSDL(*graphics->neutralColor);
+			return graphics->neutralColor;
 
 		if (player < PlayerColor::PLAYER_LIMIT)
-			return CSDL_Ext::fromSDL(graphics->playerColors[player.getNum()]);
+			return graphics->playerColors[player.getNum()];
 	}
 
 	if (tile->blocked && (!tile->visitable))
@@ -185,7 +184,7 @@ void CMinimap::showAll(Canvas & to)
 		};
 
 		Canvas clippedTarget(to, pos);
-		clippedTarget.drawBorderDashed(radar, CSDL_Ext::fromSDL(Colors::PURPLE));
+		clippedTarget.drawBorderDashed(radar, Colors::PURPLE);
 	}
 }
 

--- a/client/adventureMap/CResDataBar.cpp
+++ b/client/adventureMap/CResDataBar.cpp
@@ -14,6 +14,7 @@
 #include "../CPlayerInterface.h"
 #include "../render/Canvas.h"
 #include "../render/Colors.h"
+#include "../render/EFont.h"
 #include "../gui/CGuiHandler.h"
 #include "../gui/TextAlignment.h"
 #include "../widgets/Images.h"

--- a/client/battle/BattleAnimationClasses.cpp
+++ b/client/battle/BattleAnimationClasses.cpp
@@ -384,8 +384,8 @@ void MovementAnimation::tick(uint32_t msPassed)
 	progress += float(msPassed) / 1000 * progressPerSecond;
 
 	//moving instructions
-	myAnim->pos.x = static_cast<Sint16>(begX + distanceX * progress );
-	myAnim->pos.y = static_cast<Sint16>(begY + distanceY * progress );
+	myAnim->pos.x = begX + distanceX * progress;
+	myAnim->pos.y = begY + distanceY * progress;
 
 	BattleAnimation::tick(msPassed);
 

--- a/client/battle/BattleAnimationClasses.h
+++ b/client/battle/BattleAnimationClasses.h
@@ -21,7 +21,6 @@ class Point;
 
 VCMI_LIB_NAMESPACE_END
 
-struct SDL_Color;
 class ColorFilter;
 class BattleHero;
 class CAnimation;

--- a/client/battle/BattleEffectsController.cpp
+++ b/client/battle/BattleEffectsController.cpp
@@ -23,6 +23,7 @@
 #include "../CPlayerInterface.h"
 #include "../render/Canvas.h"
 #include "../render/CAnimation.h"
+#include "../render/Graphics.h"
 
 #include "../../CCallback.h"
 #include "../../lib/battle/BattleAction.h"

--- a/client/battle/BattleFieldController.h
+++ b/client/battle/BattleFieldController.h
@@ -19,6 +19,7 @@ class Rect;
 VCMI_LIB_NAMESPACE_END
 
 class BattleHero;
+class CAnimation;
 class Canvas;
 class IImage;
 class BattleInterface;

--- a/client/battle/BattleInterfaceClasses.cpp
+++ b/client/battle/BattleInterfaceClasses.cpp
@@ -29,6 +29,8 @@
 #include "../gui/WindowHandler.h"
 #include "../render/Canvas.h"
 #include "../render/IImage.h"
+#include "../render/IFont.h"
+#include "../render/Graphics.h"
 #include "../widgets/Buttons.h"
 #include "../widgets/Images.h"
 #include "../widgets/TextControls.h"

--- a/client/battle/BattleInterfaceClasses.h
+++ b/client/battle/BattleInterfaceClasses.h
@@ -19,6 +19,7 @@ VCMI_LIB_NAMESPACE_BEGIN
 
 class CGHeroInstance;
 struct BattleResult;
+struct InfoAboutHero;
 class CStack;
 
 namespace battle
@@ -28,6 +29,7 @@ class Unit;
 
 VCMI_LIB_NAMESPACE_END
 
+class CAnimation;
 class Canvas;
 class BattleInterface;
 class CPicture;

--- a/client/battle/CreatureAnimation.cpp
+++ b/client/battle/CreatureAnimation.cpp
@@ -15,28 +15,27 @@
 
 #include "../render/Canvas.h"
 #include "../render/ColorFilter.h"
-#include "../renderSDL/SDL_Extensions.h"
 
-static const SDL_Color creatureBlueBorder = { 0, 255, 255, 255 };
-static const SDL_Color creatureGoldBorder = { 255, 255, 0, 255 };
-static const SDL_Color creatureNoBorder  =  { 0, 0, 0, 0 };
+static const ColorRGBA creatureBlueBorder = { 0, 255, 255, 255 };
+static const ColorRGBA creatureGoldBorder = { 255, 255, 0, 255 };
+static const ColorRGBA creatureNoBorder  =  { 0, 0, 0, 0 };
 
-static SDL_Color genShadow(ui8 alpha)
+static ColorRGBA genShadow(ui8 alpha)
 {
-	return CSDL_Ext::makeColor(0, 0, 0, alpha);
+	return ColorRGBA(0, 0, 0, alpha);
 }
 
-SDL_Color AnimationControls::getBlueBorder()
+ColorRGBA AnimationControls::getBlueBorder()
 {
 	return creatureBlueBorder;
 }
 
-SDL_Color AnimationControls::getGoldBorder()
+ColorRGBA AnimationControls::getGoldBorder()
 {
 	return creatureGoldBorder;
 }
 
-SDL_Color AnimationControls::getNoBorder()
+ColorRGBA AnimationControls::getNoBorder()
 {
 	return creatureNoBorder;
 }
@@ -194,7 +193,6 @@ CreatureAnimation::CreatureAnimation(const std::string & name_, TSpeedController
 	  animationEnd(-1),
 	  elapsedTime(0),
 	  type(ECreatureAnimType::HOLDING),
-	  border(CSDL_Ext::makeColor(0, 0, 0, 0)),
 	  speedController(controller),
 	  once(false)
 {
@@ -288,7 +286,7 @@ bool CreatureAnimation::incrementFrame(float timePassed)
 	return false;
 }
 
-void CreatureAnimation::setBorderColor(SDL_Color palette)
+void CreatureAnimation::setBorderColor(ColorRGBA palette)
 {
 	border = palette;
 }
@@ -321,9 +319,9 @@ inline int getBorderStrength(float time)
 	return static_cast<int>(borderStrength * 155 + 100); // scale to 0-255
 }
 
-static SDL_Color genBorderColor(ui8 alpha, const SDL_Color & base)
+static ColorRGBA genBorderColor(ui8 alpha, const ColorRGBA & base)
 {
-	return CSDL_Ext::makeColor(base.r, base.g, base.b, ui8(base.a * alpha / 256));
+	return ColorRGBA(base.r, base.g, base.b, ui8(base.a * alpha / 256));
 }
 
 static ui8 mixChannels(ui8 c1, ui8 c2, ui8 a1, ui8 a2)
@@ -331,9 +329,9 @@ static ui8 mixChannels(ui8 c1, ui8 c2, ui8 a1, ui8 a2)
 	return c1*a1 / 256 + c2*a2*(255 - a1) / 256 / 256;
 }
 
-static SDL_Color addColors(const SDL_Color & base, const SDL_Color & over)
+static ColorRGBA addColors(const ColorRGBA & base, const ColorRGBA & over)
 {
-	return CSDL_Ext::makeColor(
+	return ColorRGBA(
 			mixChannels(over.r, base.r, over.a, base.a),
 			mixChannels(over.g, base.g, over.a, base.a),
 			mixChannels(over.b, base.b, over.a, base.a),
@@ -355,7 +353,7 @@ void CreatureAnimation::genSpecialPalette(IImage::SpecialPalette & target)
 
 void CreatureAnimation::nextFrame(Canvas & canvas, const ColorFilter & shifter, bool facingRight)
 {
-	SDL_Color shadowTest = shifter.shiftColor(genShadow(128));
+	ColorRGBA shadowTest = shifter.shiftColor(genShadow(128));
 	shadowAlpha = shadowTest.a;
 
 	size_t frame = static_cast<size_t>(floor(currentFrame));

--- a/client/battle/CreatureAnimation.h
+++ b/client/battle/CreatureAnimation.h
@@ -10,11 +10,10 @@
 #pragma once
 
 #include "../../lib/FunctionList.h"
+#include "../../lib/Color.h"
 #include "../widgets/Images.h"
 #include "../render/CAnimation.h"
 #include "../render/IImage.h"
-
-#include <SDL_pixels.h>
 
 class CIntObject;
 class CreatureAnimation;
@@ -23,10 +22,10 @@ class Canvas;
 /// Namespace for some common controls of animations
 namespace AnimationControls
 {
-	/// get SDL_Color for creature selection borders
-	SDL_Color getBlueBorder();
-	SDL_Color getGoldBorder();
-	SDL_Color getNoBorder();
+	/// get color for creature selection borders
+	ColorRGBA getBlueBorder();
+	ColorRGBA getGoldBorder();
+	ColorRGBA getNoBorder();
 
 	/// returns animation speed factor according to game settings,
 	/// slow speed is considered to be "base speed" and will return 1.0
@@ -100,7 +99,7 @@ private:
 	uint8_t shadowAlpha;
 
 	/// border color, disabled if alpha = 0
-	SDL_Color border;
+	ColorRGBA border;
 
 	TSpeedController speedController;
 
@@ -136,7 +135,7 @@ public:
 	/// should be called every frame, return true when animation was reset to beginning
 	bool incrementFrame(float timePassed);
 
-	void setBorderColor(SDL_Color palette);
+	void setBorderColor(ColorRGBA palette);
 
 	/// Gets the current frame ID within current group.
 	float getCurrentFrame() const;

--- a/client/gui/CGuiHandler.cpp
+++ b/client/gui/CGuiHandler.cpp
@@ -21,6 +21,9 @@
 
 #include "../CGameInfo.h"
 #include "../render/Colors.h"
+#include "../render/Graphics.h"
+#include "../render/IFont.h"
+#include "../render/EFont.h"
 #include "../renderSDL/ScreenHandler.h"
 #include "../CMT.h"
 #include "../CPlayerInterface.h"

--- a/client/gui/CIntObject.h
+++ b/client/gui/CIntObject.h
@@ -9,9 +9,11 @@
  */
 #pragma once
 
-#include "../render/Graphics.h"
-#include "../../lib/Rect.h"
 #include "EventsReceiver.h"
+
+#include "../../lib/Rect.h"
+#include "../../lib/Color.h"
+#include "../../lib/GameConstants.h"
 
 class CGuiHandler;
 class CPicture;

--- a/client/gui/InterfaceObjectConfigurable.cpp
+++ b/client/gui/InterfaceObjectConfigurable.cpp
@@ -185,7 +185,7 @@ ETextAlignment InterfaceObjectConfigurable::readTextAlignment(const JsonNode & c
 	return ETextAlignment::CENTER;
 }
 
-SDL_Color InterfaceObjectConfigurable::readColor(const JsonNode & config) const
+ColorRGBA InterfaceObjectConfigurable::readColor(const JsonNode & config) const
 {
 	logGlobal->debug("Reading color");
 	if(!config.isNull())

--- a/client/gui/InterfaceObjectConfigurable.h
+++ b/client/gui/InterfaceObjectConfigurable.h
@@ -12,6 +12,7 @@
 
 #include "CIntObject.h"
 #include "TextAlignment.h"
+#include "../render/EFont.h"
 
 #include "../../lib/JsonNode.h"
 
@@ -73,7 +74,7 @@ protected:
 	Point readPosition(const JsonNode &) const;
 	Rect readRect(const JsonNode &) const;
 	ETextAlignment readTextAlignment(const JsonNode &) const;
-	SDL_Color readColor(const JsonNode &) const;
+	ColorRGBA readColor(const JsonNode &) const;
 	EFonts readFont(const JsonNode &) const;
 	std::string readText(const JsonNode &) const;
 	std::pair<std::string, std::string> readHintText(const JsonNode &) const;

--- a/client/gui/WindowHandler.cpp
+++ b/client/gui/WindowHandler.cpp
@@ -105,7 +105,6 @@ void WindowHandler::totalRedraw()
 void WindowHandler::totalRedrawImpl()
 {
 	logGlobal->debug("totalRedraw requested!");
-	CSDL_Ext::fillSurface(screen2, Colors::BLACK);
 
 	Canvas target = Canvas::createFromSurface(screen2);
 

--- a/client/lobby/CBonusSelection.cpp
+++ b/client/lobby/CBonusSelection.cpp
@@ -32,6 +32,7 @@
 #include "../windows/InfoWindows.h"
 #include "../render/IImage.h"
 #include "../render/CAnimation.h"
+#include "../render/Graphics.h"
 #include "../gui/CGuiHandler.h"
 #include "../gui/Shortcut.h"
 #include "../gui/WindowHandler.h"

--- a/client/lobby/CLobbyScreen.cpp
+++ b/client/lobby/CLobbyScreen.cpp
@@ -20,6 +20,7 @@
 #include "../gui/Shortcut.h"
 #include "../widgets/Buttons.h"
 #include "../windows/InfoWindows.h"
+#include "../render/Colors.h"
 
 #include "../../CCallback.h"
 
@@ -53,7 +54,7 @@ CLobbyScreen::CLobbyScreen(ESelectionScreen screenType)
 	};
 
 	buttonChat = std::make_shared<CButton>(Point(619, 80), "GSPBUT2.DEF", CGI->generaltexth->zelp[48], std::bind(&CLobbyScreen::toggleChat, this), EShortcut::LOBBY_HIDE_CHAT);
-	buttonChat->addTextOverlay(CGI->generaltexth->allTexts[532], FONT_SMALL);
+	buttonChat->addTextOverlay(CGI->generaltexth->allTexts[532], FONT_SMALL, Colors::WHITE);
 
 	switch(screenType)
 	{
@@ -182,9 +183,9 @@ void CLobbyScreen::toggleChat()
 {
 	card->toggleChat();
 	if(card->showChat)
-		buttonChat->addTextOverlay(CGI->generaltexth->allTexts[531], FONT_SMALL);
+		buttonChat->addTextOverlay(CGI->generaltexth->allTexts[531], FONT_SMALL, Colors::WHITE);
 	else
-		buttonChat->addTextOverlay(CGI->generaltexth->allTexts[532], FONT_SMALL);
+		buttonChat->addTextOverlay(CGI->generaltexth->allTexts[532], FONT_SMALL, Colors::WHITE);
 }
 
 void CLobbyScreen::updateAfterStateChange()

--- a/client/lobby/CSelectionBase.cpp
+++ b/client/lobby/CSelectionBase.cpp
@@ -37,6 +37,8 @@
 #include "../windows/GUIClasses.h"
 #include "../windows/InfoWindows.h"
 #include "../render/CAnimation.h"
+#include "../render/Graphics.h"
+#include "../render/IFont.h"
 
 #include "../../lib/NetPacksLobby.h"
 #include "../../lib/CGeneralTextHandler.h"

--- a/client/lobby/OptionsTab.cpp
+++ b/client/lobby/OptionsTab.cpp
@@ -16,6 +16,8 @@
 #include "../CServerHandler.h"
 #include "../gui/CGuiHandler.h"
 #include "../gui/WindowHandler.h"
+#include "../render/Graphics.h"
+#include "../render/IFont.h"
 #include "../widgets/CComponent.h"
 #include "../widgets/Buttons.h"
 #include "../widgets/MiscWidgets.h"

--- a/client/lobby/RandomMapTab.cpp
+++ b/client/lobby/RandomMapTab.cpp
@@ -304,9 +304,9 @@ void RandomMapTab::setMapGenOptions(std::shared_ptr<CMapGenOptions> opts)
 	if(auto w = widget<CButton>("templateButton"))
 	{
 		if(tmpl)
-			w->addTextOverlay(tmpl->getName(), EFonts::FONT_SMALL);
+			w->addTextOverlay(tmpl->getName(), EFonts::FONT_SMALL, Colors::WHITE);
 		else
-			w->addTextOverlay(readText(variables["randomTemplate"]), EFonts::FONT_SMALL);
+			w->addTextOverlay(readText(variables["randomTemplate"]), EFonts::FONT_SMALL, Colors::WHITE);
 	}
 	for(auto r : VLC->roadTypeHandler->objects)
 	{
@@ -324,9 +324,9 @@ void RandomMapTab::setTemplate(const CRmgTemplate * tmpl)
 	if(auto w = widget<CButton>("templateButton"))
 	{
 		if(tmpl)
-			w->addTextOverlay(tmpl->getName(), EFonts::FONT_SMALL);
+			w->addTextOverlay(tmpl->getName(), EFonts::FONT_SMALL, Colors::WHITE);
 		else
-			w->addTextOverlay(readText(variables["randomTemplate"]), EFonts::FONT_SMALL);
+			w->addTextOverlay(readText(variables["randomTemplate"]), EFonts::FONT_SMALL, Colors::WHITE);
 	}
 	updateMapInfoByHost();
 }

--- a/client/mapView/MapView.h
+++ b/client/mapView/MapView.h
@@ -13,6 +13,7 @@
 
 VCMI_LIB_NAMESPACE_BEGIN
 struct ObjectPosInfo;
+class CGObjectInstance;
 VCMI_LIB_NAMESPACE_END
 
 class Canvas;

--- a/client/render/Canvas.cpp
+++ b/client/render/Canvas.cpp
@@ -14,8 +14,10 @@
 #include "Colors.h"
 #include "IImage.h"
 #include "Graphics.h"
+#include "IFont.h"
 
 #include <SDL_surface.h>
+#include <SDL_pixels.h>
 
 Canvas::Canvas(SDL_Surface * surface):
 	surface(surface),
@@ -48,7 +50,7 @@ Canvas::Canvas(const Point & size):
 	renderArea(Point(0,0), size),
 	surface(CSDL_Ext::newSurface(size.x, size.y))
 {
-	CSDL_Ext::fillSurface(surface, Colors::TRANSPARENCY );
+	CSDL_Ext::fillSurface(surface, CSDL_Ext::toSDL(Colors::TRANSPARENCY) );
 	SDL_SetSurfaceBlendMode(surface, SDL_BLENDMODE_NONE);
 }
 
@@ -127,11 +129,11 @@ void Canvas::drawLineDashed(const Point & from, const Point & dest, const ColorR
 	CSDL_Ext::drawLineDashed(surface, renderArea.topLeft() + from, renderArea.topLeft() + dest, CSDL_Ext::toSDL(color));
 }
 
-void Canvas::drawBorder(const Rect & target, const SDL_Color & color, int width)
+void Canvas::drawBorder(const Rect & target, const ColorRGBA & color, int width)
 {
 	Rect realTarget = target + renderArea.topLeft();
 
-	CSDL_Ext::drawBorder(surface, realTarget.x, realTarget.y, realTarget.w, realTarget.h, color, width);
+	CSDL_Ext::drawBorder(surface, realTarget.x, realTarget.y, realTarget.w, realTarget.h, CSDL_Ext::toSDL(color), width);
 }
 
 void Canvas::drawBorderDashed(const Rect & target, const ColorRGBA & color)
@@ -144,7 +146,7 @@ void Canvas::drawBorderDashed(const Rect & target, const ColorRGBA & color)
 	CSDL_Ext::drawLineDashed(surface, realTarget.topRight(),   realTarget.bottomRight(), CSDL_Ext::toSDL(color));
 }
 
-void Canvas::drawText(const Point & position, const EFonts & font, const SDL_Color & colorDest, ETextAlignment alignment, const std::string & text )
+void Canvas::drawText(const Point & position, const EFonts & font, const ColorRGBA & colorDest, ETextAlignment alignment, const std::string & text )
 {
 	switch (alignment)
 	{
@@ -154,7 +156,7 @@ void Canvas::drawText(const Point & position, const EFonts & font, const SDL_Col
 	}
 }
 
-void Canvas::drawText(const Point & position, const EFonts & font, const SDL_Color & colorDest, ETextAlignment alignment, const std::vector<std::string> & text )
+void Canvas::drawText(const Point & position, const EFonts & font, const ColorRGBA & colorDest, ETextAlignment alignment, const std::vector<std::string> & text )
 {
 	switch (alignment)
 	{
@@ -164,11 +166,11 @@ void Canvas::drawText(const Point & position, const EFonts & font, const SDL_Col
 	}
 }
 
-void Canvas::drawColor(const Rect & target, const SDL_Color & color)
+void Canvas::drawColor(const Rect & target, const ColorRGBA & color)
 {
 	Rect realTarget = target + renderArea.topLeft();
 
-	CSDL_Ext::fillRect(surface, realTarget, color);
+	CSDL_Ext::fillRect(surface, realTarget, CSDL_Ext::toSDL(color));
 }
 
 SDL_Surface * Canvas::getInternalSurface()

--- a/client/render/Canvas.h
+++ b/client/render/Canvas.h
@@ -13,7 +13,6 @@
 #include "../../lib/Rect.h"
 #include "../../lib/Color.h"
 
-struct SDL_Color;
 struct SDL_Surface;
 class IImage;
 enum EFonts : int;
@@ -83,19 +82,19 @@ public:
 	void drawLineDashed(const Point & from, const Point & dest, const ColorRGBA & color);
 
 	/// renders rectangular, solid-color border in specified location
-	void drawBorder(const Rect & target, const SDL_Color & color, int width = 1);
+	void drawBorder(const Rect & target, const ColorRGBA & color, int width = 1);
 
 	/// renders rectangular, dashed border in specified location
 	void drawBorderDashed(const Rect & target, const ColorRGBA & color);
 
 	/// renders single line of text with specified parameters
-	void drawText(const Point & position, const EFonts & font, const SDL_Color & colorDest, ETextAlignment alignment, const std::string & text );
+	void drawText(const Point & position, const EFonts & font, const ColorRGBA & colorDest, ETextAlignment alignment, const std::string & text );
 
 	/// renders multiple lines of text with specified parameters
-	void drawText(const Point & position, const EFonts & font, const SDL_Color & colorDest, ETextAlignment alignment, const std::vector<std::string> & text );
+	void drawText(const Point & position, const EFonts & font, const ColorRGBA & colorDest, ETextAlignment alignment, const std::vector<std::string> & text );
 
 	/// fills selected area with solid color, ignoring any transparency
-	void drawColor(const Rect & target, const SDL_Color & color);
+	void drawColor(const Rect & target, const ColorRGBA & color);
 
 	/// Compatibility method. AVOID USAGE. To be removed once SDL abstraction layer is finished.
 	SDL_Surface * getInternalSurface();

--- a/client/render/ColorFilter.cpp
+++ b/client/render/ColorFilter.cpp
@@ -10,11 +10,10 @@
 #include "StdInc.h"
 #include "ColorFilter.h"
 
-#include <SDL_pixels.h>
-
 #include "../../lib/JsonNode.h"
+#include "../../lib/Color.h"
 
-SDL_Color ColorFilter::shiftColor(const SDL_Color & in) const
+ColorRGBA ColorFilter::shiftColor(const ColorRGBA & in) const
 {
 	int r_out = in.r * r.r + in.g * r.g + in.b * r.b + 255 * r.a;
 	int g_out = in.r * g.r + in.g * g.g + in.b * g.b + 255 * g.a;

--- a/client/render/ColorFilter.h
+++ b/client/render/ColorFilter.h
@@ -10,10 +10,9 @@
 
 #pragma once
 
-struct SDL_Color;
-
 VCMI_LIB_NAMESPACE_BEGIN
 class JsonNode;
+class ColorRGBA;
 VCMI_LIB_NAMESPACE_END
 
 /// Base class for applying palette transformation on images
@@ -32,7 +31,7 @@ class ColorFilter
 		r(r), g(g), b(b), a(a)
 	{}
 public:
-	SDL_Color shiftColor(const SDL_Color & in) const;
+	ColorRGBA shiftColor(const ColorRGBA & in) const;
 
 	bool operator == (const ColorFilter & other) const;
 	bool operator != (const ColorFilter & other) const;

--- a/client/render/Colors.cpp
+++ b/client/render/Colors.cpp
@@ -11,17 +11,15 @@
 #include "StdInc.h"
 #include "Colors.h"
 
-#include <SDL_pixels.h>
-
-const SDL_Color Colors::YELLOW = { 229, 215, 123, SDL_ALPHA_OPAQUE };
-const SDL_Color Colors::WHITE = { 255, 243, 222, SDL_ALPHA_OPAQUE };
-const SDL_Color Colors::METALLIC_GOLD = { 173, 142, 66, SDL_ALPHA_OPAQUE };
-const SDL_Color Colors::GREEN = { 0, 255, 0, SDL_ALPHA_OPAQUE };
-const SDL_Color Colors::CYAN = { 0, 255, 255, SDL_ALPHA_OPAQUE };
-const SDL_Color Colors::ORANGE = { 232, 184, 32, SDL_ALPHA_OPAQUE };
-const SDL_Color Colors::BRIGHT_YELLOW = { 242, 226, 110, SDL_ALPHA_OPAQUE };
-const SDL_Color Colors::DEFAULT_KEY_COLOR = {0, 255, 255, SDL_ALPHA_OPAQUE};
-const SDL_Color Colors::RED = {255, 0, 0, SDL_ALPHA_OPAQUE};
-const SDL_Color Colors::PURPLE = {255, 75, 125, SDL_ALPHA_OPAQUE};
-const SDL_Color Colors::BLACK = {0, 0, 0, SDL_ALPHA_OPAQUE};
-const SDL_Color Colors::TRANSPARENCY = {0, 0, 0, SDL_ALPHA_TRANSPARENT};
+const ColorRGBA Colors::YELLOW = { 229, 215, 123, ColorRGBA::ALPHA_OPAQUE };
+const ColorRGBA Colors::WHITE = { 255, 243, 222, ColorRGBA::ALPHA_OPAQUE };
+const ColorRGBA Colors::METALLIC_GOLD = { 173, 142, 66, ColorRGBA::ALPHA_OPAQUE };
+const ColorRGBA Colors::GREEN = { 0, 255, 0, ColorRGBA::ALPHA_OPAQUE };
+const ColorRGBA Colors::CYAN = { 0, 255, 255, ColorRGBA::ALPHA_OPAQUE };
+const ColorRGBA Colors::ORANGE = { 232, 184, 32, ColorRGBA::ALPHA_OPAQUE };
+const ColorRGBA Colors::BRIGHT_YELLOW = { 242, 226, 110, ColorRGBA::ALPHA_OPAQUE };
+const ColorRGBA Colors::DEFAULT_KEY_COLOR = {0, 255, 255, ColorRGBA::ALPHA_OPAQUE};
+const ColorRGBA Colors::RED = {255, 0, 0, ColorRGBA::ALPHA_OPAQUE};
+const ColorRGBA Colors::PURPLE = {255, 75, 125, ColorRGBA::ALPHA_OPAQUE};
+const ColorRGBA Colors::BLACK = {0, 0, 0, ColorRGBA::ALPHA_OPAQUE};
+const ColorRGBA Colors::TRANSPARENCY = {0, 0, 0, ColorRGBA::ALPHA_TRANSPARENT};

--- a/client/render/Colors.h
+++ b/client/render/Colors.h
@@ -9,44 +9,44 @@
  */
 #pragma once
 
-struct SDL_Color;
+#include "../../lib/Color.h"
 
 /**
- * The colors class defines color constants of type SDL_Color.
+ * The colors class defines color constants of type ColorRGBA.
  */
 class Colors
 {
 public:
 	/** the h3 yellow color, typically used for headlines */
-	static const SDL_Color YELLOW;
+	static const ColorRGBA YELLOW;
 
 	/** the standard h3 white color */
-	static const SDL_Color WHITE;
+	static const ColorRGBA WHITE;
 
 	/** the metallic gold color used mostly as a border around buttons */
-	static const SDL_Color METALLIC_GOLD;
+	static const ColorRGBA METALLIC_GOLD;
 
 	/** green color used for in-game console */
-	static const SDL_Color GREEN;
+	static const ColorRGBA GREEN;
 
 	/** the h3 orange color, used for blocked buttons */
-	static const SDL_Color ORANGE;
+	static const ColorRGBA ORANGE;
 
 	/** the h3 bright yellow color, used for selection border */
-	static const SDL_Color BRIGHT_YELLOW;
+	static const ColorRGBA BRIGHT_YELLOW;
 
 	/** default key color for all 8 & 24 bit graphics */
-	static const SDL_Color DEFAULT_KEY_COLOR;
+	static const ColorRGBA DEFAULT_KEY_COLOR;
 
 	/// Selected creature card
-	static const SDL_Color RED;
+	static const ColorRGBA RED;
 
 	/// Minimap border
-	static const SDL_Color PURPLE;
+	static const ColorRGBA PURPLE;
 
-	static const SDL_Color CYAN;
+	static const ColorRGBA CYAN;
 
-	static const SDL_Color BLACK;
+	static const ColorRGBA BLACK;
 
-	static const SDL_Color TRANSPARENCY;
+	static const ColorRGBA TRANSPARENCY;
 };

--- a/client/render/EFont.h
+++ b/client/render/EFont.h
@@ -1,0 +1,15 @@
+/*
+ * EFonts.h, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
+#pragma once
+
+enum EFonts : int
+{
+	FONT_BIG, FONT_CALLI, FONT_CREDITS, FONT_HIGH_SCORE, FONT_MEDIUM, FONT_SMALL, FONT_TIMES, FONT_TINY, FONT_VERD
+};

--- a/client/render/Graphics.cpp
+++ b/client/render/Graphics.cpp
@@ -46,22 +46,20 @@ void Graphics::loadPaletteAndColors()
 	auto textFile = CResourceHandler::get()->load(ResourceID("DATA/PLAYERS.PAL"))->readAll();
 	std::string pals((char*)textFile.first.get(), textFile.second);
 
-	playerColorPalette = new SDL_Color[256];
-	neutralColor = new SDL_Color;
-	playerColors = new SDL_Color[PlayerColor::PLAYER_LIMIT_I];
 	int startPoint = 24; //beginning byte; used to read
-	for(int i=0; i<256; ++i)
+	for(int i=0; i<8; ++i)
 	{
-		SDL_Color col;
-		col.r = pals[startPoint++];
-		col.g = pals[startPoint++];
-		col.b = pals[startPoint++];
-		col.a = SDL_ALPHA_OPAQUE;
-		startPoint++;
-		playerColorPalette[i] = col;
+		for(int j=0; j<32; ++j)
+		{
+			ColorRGBA col;
+			col.r = pals[startPoint++];
+			col.g = pals[startPoint++];
+			col.b = pals[startPoint++];
+			col.a = SDL_ALPHA_OPAQUE;
+			startPoint++;
+			playerColorPalette[i][j] = col;
+		}
 	}
-
-	neutralColorPalette = new SDL_Color[32];
 
 	auto stream = CResourceHandler::get()->load(ResourceID("config/NEUTRAL.PAL"));
 	CBinaryReader reader(stream.get());
@@ -75,7 +73,7 @@ void Graphics::loadPaletteAndColors()
 		neutralColorPalette[i].a = SDL_ALPHA_OPAQUE;
 	}
 	//colors initialization
-	SDL_Color colors[]  = {
+	ColorRGBA colors[]  = {
 		{0xff,0,  0,    SDL_ALPHA_OPAQUE},
 		{0x31,0x52,0xff,SDL_ALPHA_OPAQUE},
 		{0x9c,0x73,0x52,SDL_ALPHA_OPAQUE},
@@ -91,10 +89,10 @@ void Graphics::loadPaletteAndColors()
 		playerColors[i] = colors[i];
 	}
 	//gray
-	neutralColor->r = 0x84;
-	neutralColor->g = 0x84;
-	neutralColor->b = 0x84;
-	neutralColor->a = SDL_ALPHA_OPAQUE;
+	neutralColor.r = 0x84;
+	neutralColor.g = 0x84;
+	neutralColor.b = 0x84;
+	neutralColor.a = SDL_ALPHA_OPAQUE;
 }
 
 void Graphics::initializeBattleGraphics()
@@ -148,26 +146,20 @@ Graphics::Graphics()
 	//(!) do not load any CAnimation here
 }
 
-Graphics::~Graphics()
-{
-	delete[] playerColors;
-	delete neutralColor;
-	delete[] playerColorPalette;
-	delete[] neutralColorPalette;
-}
-
 void Graphics::blueToPlayersAdv(SDL_Surface * sur, PlayerColor player)
 {
 	if(sur->format->palette)
 	{
-		SDL_Color * palette = nullptr;
+		SDL_Color palette[32];
 		if(player < PlayerColor::PLAYER_LIMIT)
 		{
-			palette = playerColorPalette + 32*player.getNum();
+			for(int i=0; i<32; ++i)
+				palette[i] = CSDL_Ext::toSDL(playerColorPalette[player][i]);
 		}
 		else if(player == PlayerColor::NEUTRAL)
 		{
-			palette = neutralColorPalette;
+			for(int i=0; i<32; ++i)
+				palette[i] = CSDL_Ext::toSDL(neutralColorPalette[i]);
 		}
 		else
 		{
@@ -176,7 +168,6 @@ void Graphics::blueToPlayersAdv(SDL_Surface * sur, PlayerColor player)
 		}
 //FIXME: not all player colored images have player palette at last 32 indexes
 //NOTE: following code is much more correct but still not perfect (bugged with status bar)
-
 		CSDL_Ext::setColors(sur, palette, 224, 32);
 
 

--- a/client/render/Graphics.h
+++ b/client/render/Graphics.h
@@ -9,8 +9,8 @@
  */
 #pragma once
 
-#include "IFont.h"
 #include "../lib/GameConstants.h"
+#include "../lib/Color.h"
 
 VCMI_LIB_NAMESPACE_BEGIN
 
@@ -27,13 +27,8 @@ class JsonNode;
 VCMI_LIB_NAMESPACE_END
 
 struct SDL_Surface;
-struct SDL_Color;
 class CAnimation;
-
-enum EFonts : int
-{
-	FONT_BIG, FONT_CALLI, FONT_CREDITS, FONT_HIGH_SCORE, FONT_MEDIUM, FONT_SMALL, FONT_TIMES, FONT_TINY, FONT_VERD
-};
+class IFont;
 
 /// Handles fonts, hero images, town images, various graphics
 class Graphics
@@ -52,11 +47,14 @@ public:
 	static const int FONTS_NUMBER = 9;
 	std::array< std::shared_ptr<IFont>, FONTS_NUMBER> fonts;
 
+	using PlayerPalette = std::array<ColorRGBA, 32>;
+
 	//various graphics
-	SDL_Color * playerColors; //array [8]
-	SDL_Color * neutralColor;
-	SDL_Color * playerColorPalette; //palette to make interface colors good - array of size [256]
-	SDL_Color * neutralColorPalette;
+	std::array<ColorRGBA, 8> playerColors;
+	std::array<PlayerPalette, 8> playerColorPalette; //palette to make interface colors good - array of size [256]
+
+	PlayerPalette neutralColorPalette;
+	ColorRGBA neutralColor;
 
 	std::map<std::string, JsonNode> imageLists;
 
@@ -67,7 +65,6 @@ public:
 
 	//functions
 	Graphics();
-	~Graphics();
 
 	void blueToPlayersAdv(SDL_Surface * sur, PlayerColor player); //replaces blue interface colour with a color of player
 };

--- a/client/render/IFont.cpp
+++ b/client/render/IFont.cpp
@@ -25,24 +25,24 @@ size_t IFont::getStringWidth(const std::string & data) const
 	return width;
 }
 
-void IFont::renderTextLeft(SDL_Surface * surface, const std::string & data, const SDL_Color & color, const Point & pos) const
+void IFont::renderTextLeft(SDL_Surface * surface, const std::string & data, const ColorRGBA & color, const Point & pos) const
 {
 	renderText(surface, data, color, pos);
 }
 
-void IFont::renderTextRight(SDL_Surface * surface, const std::string & data, const SDL_Color & color, const Point & pos) const
+void IFont::renderTextRight(SDL_Surface * surface, const std::string & data, const ColorRGBA & color, const Point & pos) const
 {
 	Point size((int)getStringWidth(data), (int)getLineHeight());
 	renderText(surface, data, color, pos - size);
 }
 
-void IFont::renderTextCenter(SDL_Surface * surface, const std::string & data, const SDL_Color & color, const Point & pos) const
+void IFont::renderTextCenter(SDL_Surface * surface, const std::string & data, const ColorRGBA & color, const Point & pos) const
 {
 	Point size((int)getStringWidth(data), (int)getLineHeight());
 	renderText(surface, data, color, pos - size / 2);
 }
 
-void IFont::renderTextLinesLeft(SDL_Surface * surface, const std::vector<std::string> & data, const SDL_Color & color, const Point & pos) const
+void IFont::renderTextLinesLeft(SDL_Surface * surface, const std::vector<std::string> & data, const ColorRGBA & color, const Point & pos) const
 {
 	Point currPos = pos;
 
@@ -53,7 +53,7 @@ void IFont::renderTextLinesLeft(SDL_Surface * surface, const std::vector<std::st
 	}
 }
 
-void IFont::renderTextLinesRight(SDL_Surface * surface, const std::vector<std::string> & data, const SDL_Color & color, const Point & pos) const
+void IFont::renderTextLinesRight(SDL_Surface * surface, const std::vector<std::string> & data, const ColorRGBA & color, const Point & pos) const
 {
 	Point currPos = pos;
 	currPos.y -= (int)data.size() * (int)getLineHeight();
@@ -65,7 +65,7 @@ void IFont::renderTextLinesRight(SDL_Surface * surface, const std::vector<std::s
 	}
 }
 
-void IFont::renderTextLinesCenter(SDL_Surface * surface, const std::vector<std::string> & data, const SDL_Color & color, const Point & pos) const
+void IFont::renderTextLinesCenter(SDL_Surface * surface, const std::vector<std::string> & data, const ColorRGBA & color, const Point & pos) const
 {
 	Point currPos = pos;
 	currPos.y -= (int)data.size() * (int)getLineHeight() / 2;

--- a/client/render/IFont.h
+++ b/client/render/IFont.h
@@ -11,16 +11,16 @@
 
 VCMI_LIB_NAMESPACE_BEGIN
 class Point;
+class ColorRGBA;
 VCMI_LIB_NAMESPACE_END
 
 struct SDL_Surface;
-struct SDL_Color;
 
 class IFont
 {
 protected:
 	/// Internal function to render font, see renderTextLeft
-	virtual void renderText(SDL_Surface * surface, const std::string & data, const SDL_Color & color, const Point & pos) const = 0;
+	virtual void renderText(SDL_Surface * surface, const std::string & data, const ColorRGBA & color, const Point & pos) const = 0;
 
 public:
 	virtual ~IFont()
@@ -40,17 +40,17 @@ public:
 	 * @param pos - position of rendered font
 	 */
 	/// pos = topleft corner of the text
-	void renderTextLeft(SDL_Surface * surface, const std::string & data, const SDL_Color & color, const Point & pos) const;
+	void renderTextLeft(SDL_Surface * surface, const std::string & data, const ColorRGBA & color, const Point & pos) const;
 	/// pos = center of the text
-	void renderTextRight(SDL_Surface * surface, const std::string & data, const SDL_Color & color, const Point & pos) const;
+	void renderTextRight(SDL_Surface * surface, const std::string & data, const ColorRGBA & color, const Point & pos) const;
 	/// pos = bottomright corner of the text
-	void renderTextCenter(SDL_Surface * surface, const std::string & data, const SDL_Color & color, const Point & pos) const;
+	void renderTextCenter(SDL_Surface * surface, const std::string & data, const ColorRGBA & color, const Point & pos) const;
 
 	/// pos = topleft corner of the text
-	void renderTextLinesLeft(SDL_Surface * surface, const std::vector<std::string> & data, const SDL_Color & color, const Point & pos) const;
+	void renderTextLinesLeft(SDL_Surface * surface, const std::vector<std::string> & data, const ColorRGBA & color, const Point & pos) const;
 	/// pos = center of the text
-	void renderTextLinesRight(SDL_Surface * surface, const std::vector<std::string> & data, const SDL_Color & color, const Point & pos) const;
+	void renderTextLinesRight(SDL_Surface * surface, const std::vector<std::string> & data, const ColorRGBA & color, const Point & pos) const;
 	/// pos = bottomright corner of the text
-	void renderTextLinesCenter(SDL_Surface * surface, const std::vector<std::string> & data, const SDL_Color & color, const Point & pos) const;
+	void renderTextLinesCenter(SDL_Surface * surface, const std::vector<std::string> & data, const ColorRGBA & color, const Point & pos) const;
 };
 

--- a/client/render/IImage.h
+++ b/client/render/IImage.h
@@ -14,11 +14,11 @@ VCMI_LIB_NAMESPACE_BEGIN
 class PlayerColor;
 class Rect;
 class Point;
+class ColorRGBA;
 
 VCMI_LIB_NAMESPACE_END
 
 struct SDL_Surface;
-struct SDL_Color;
 class ColorFilter;
 
 /// Defines which blit method will be selected when image is used for rendering
@@ -40,7 +40,7 @@ enum class EImageBlitMode : uint8_t
 class IImage
 {
 public:
-	using SpecialPalette = std::vector<SDL_Color>;
+	using SpecialPalette = std::vector<ColorRGBA>;
 	static constexpr int32_t SPECIAL_PALETTE_MASK_CREATURES = 0b11110011;
 
 	//draws image on surface "where" at position

--- a/client/renderSDL/CBitmapFont.cpp
+++ b/client/renderSDL/CBitmapFont.cpp
@@ -112,7 +112,7 @@ bool CBitmapFont::canRepresentString(const std::string & data) const
 	return true;
 }
 
-void CBitmapFont::renderCharacter(SDL_Surface * surface, const BitmapChar & character, const SDL_Color & color, int &posX, int &posY) const
+void CBitmapFont::renderCharacter(SDL_Surface * surface, const BitmapChar & character, const ColorRGBA & color, int &posX, int &posY) const
 {
 	Rect clipRect;
 	CSDL_Ext::getClipRect(surface, clipRect);
@@ -162,7 +162,7 @@ void CBitmapFont::renderCharacter(SDL_Surface * surface, const BitmapChar & char
 	posX += character.rightOffset;
 }
 
-void CBitmapFont::renderText(SDL_Surface * surface, const std::string & data, const SDL_Color & color, const Point & pos) const
+void CBitmapFont::renderText(SDL_Surface * surface, const std::string & data, const ColorRGBA & color, const Point & pos) const
 {
 	if (data.empty())
 		return;

--- a/client/renderSDL/CBitmapFont.h
+++ b/client/renderSDL/CBitmapFont.h
@@ -33,8 +33,8 @@ class CBitmapFont : public IFont
 
 	void loadModFont(const std::string & modName, const ResourceID & resource);
 
-	void renderCharacter(SDL_Surface * surface, const BitmapChar & character, const SDL_Color & color, int &posX, int &posY) const;
-	void renderText(SDL_Surface * surface, const std::string & data, const SDL_Color & color, const Point & pos) const override;
+	void renderCharacter(SDL_Surface * surface, const BitmapChar & character, const ColorRGBA & color, int &posX, int &posY) const;
+	void renderText(SDL_Surface * surface, const std::string & data, const ColorRGBA & color, const Point & pos) const override;
 public:
 	explicit CBitmapFont(const std::string & filename);
 

--- a/client/renderSDL/CBitmapHanFont.cpp
+++ b/client/renderSDL/CBitmapHanFont.cpp
@@ -35,7 +35,7 @@ size_t CBitmapHanFont::getCharacterIndex(ui8 first, ui8 second) const
 	return (first - 0x81) * (12*16 - 2) + (second - 0x40);
 }
 
-void CBitmapHanFont::renderCharacter(SDL_Surface * surface, int characterIndex, const SDL_Color & color, int &posX, int &posY) const
+void CBitmapHanFont::renderCharacter(SDL_Surface * surface, int characterIndex, const ColorRGBA & color, int &posX, int &posY) const
 {
 	//TODO: somewhat duplicated with CBitmapFont::renderCharacter();
 	Rect clipRect;
@@ -76,7 +76,7 @@ void CBitmapHanFont::renderCharacter(SDL_Surface * surface, int characterIndex, 
 	posX += (int)size + 1;
 }
 
-void CBitmapHanFont::renderText(SDL_Surface * surface, const std::string & data, const SDL_Color & color, const Point & pos) const
+void CBitmapHanFont::renderText(SDL_Surface * surface, const std::string & data, const ColorRGBA & color, const Point & pos) const
 {
 	int posX = pos.x;
 	int posY = pos.y;

--- a/client/renderSDL/CBitmapHanFont.h
+++ b/client/renderSDL/CBitmapHanFont.h
@@ -30,8 +30,8 @@ class CBitmapHanFont : public IFont
 	size_t getCharacterDataOffset(size_t index) const;
 	size_t getCharacterIndex(ui8 first, ui8 second) const;
 
-	void renderCharacter(SDL_Surface * surface, int characterIndex, const SDL_Color & color, int &posX, int &posY) const;
-	void renderText(SDL_Surface * surface, const std::string & data, const SDL_Color & color, const Point & pos) const override;
+	void renderCharacter(SDL_Surface * surface, int characterIndex, const ColorRGBA & color, int &posX, int &posY) const;
+	void renderText(SDL_Surface * surface, const std::string & data, const ColorRGBA & color, const Point & pos) const override;
 public:
 	CBitmapHanFont(const JsonNode & config);
 

--- a/client/renderSDL/CTrueTypeFont.cpp
+++ b/client/renderSDL/CTrueTypeFont.cpp
@@ -98,7 +98,7 @@ size_t CTrueTypeFont::getStringWidth(const std::string & data) const
 	return width;
 }
 
-void CTrueTypeFont::renderText(SDL_Surface * surface, const std::string & data, const SDL_Color & color, const Point & pos) const
+void CTrueTypeFont::renderText(SDL_Surface * surface, const std::string & data, const ColorRGBA & color, const Point & pos) const
 {
 	if (fallbackFont && fallbackFont->canRepresentString(data))
 	{
@@ -113,9 +113,9 @@ void CTrueTypeFont::renderText(SDL_Surface * surface, const std::string & data, 
 	{
 		SDL_Surface * rendered;
 		if (blended)
-			rendered = TTF_RenderUTF8_Blended(font.get(), data.c_str(), color);
+			rendered = TTF_RenderUTF8_Blended(font.get(), data.c_str(), CSDL_Ext::toSDL(color));
 		else
-			rendered = TTF_RenderUTF8_Solid(font.get(), data.c_str(), color);
+			rendered = TTF_RenderUTF8_Solid(font.get(), data.c_str(), CSDL_Ext::toSDL(color));
 
 		assert(rendered);
 

--- a/client/renderSDL/CTrueTypeFont.h
+++ b/client/renderSDL/CTrueTypeFont.h
@@ -32,7 +32,7 @@ class CTrueTypeFont : public IFont
 	TTF_Font * loadFont(const JsonNode & config);
 	int getFontStyle(const JsonNode & config);
 
-	void renderText(SDL_Surface * surface, const std::string & data, const SDL_Color & color, const Point & pos) const override;
+	void renderText(SDL_Surface * surface, const std::string & data, const ColorRGBA & color, const Point & pos) const override;
 public:
 	CTrueTypeFont(const JsonNode & fontConfig);
 	~CTrueTypeFont();

--- a/client/renderSDL/CursorHardware.cpp
+++ b/client/renderSDL/CursorHardware.cpp
@@ -52,7 +52,7 @@ void CursorHardware::setImage(std::shared_ptr<IImage> image, const Point & pivot
 {
 	auto cursorSurface = CSDL_Ext::newSurface(image->dimensions().x, image->dimensions().y);
 
-	CSDL_Ext::fillSurface(cursorSurface, Colors::TRANSPARENCY);
+	CSDL_Ext::fillSurface(cursorSurface, CSDL_Ext::toSDL(Colors::TRANSPARENCY));
 
 	image->draw(cursorSurface);
 

--- a/client/renderSDL/CursorSoftware.cpp
+++ b/client/renderSDL/CursorSoftware.cpp
@@ -56,7 +56,7 @@ void CursorSoftware::updateTexture()
 	if (!cursorSurface ||  Point(cursorSurface->w, cursorSurface->h) != cursorImage->dimensions())
 		createTexture(cursorImage->dimensions());
 
-	CSDL_Ext::fillSurface(cursorSurface, Colors::TRANSPARENCY);
+	CSDL_Ext::fillSurface(cursorSurface, CSDL_Ext::toSDL(Colors::TRANSPARENCY));
 
 	cursorImage->draw(cursorSurface);
 	SDL_UpdateTexture(cursorTexture, NULL, cursorSurface->pixels, cursorSurface->pitch);

--- a/client/renderSDL/SDLImage.cpp
+++ b/client/renderSDL/SDLImage.cpp
@@ -327,7 +327,7 @@ void SDLImage::adjustPalette(const ColorFilter & shifter, uint32_t colorsToSkipM
 		if(i < std::numeric_limits<uint32_t>::digits && ((colorsToSkipMask >> i) & 1) == 1)
 			continue;
 
-		palette->colors[i] = shifter.shiftColor(originalPalette->colors[i]);
+		palette->colors[i] = CSDL_Ext::toSDL(shifter.shiftColor(CSDL_Ext::fromSDL(originalPalette->colors[i])));
 	}
 }
 
@@ -358,7 +358,7 @@ void SDLImage::setSpecialPallete(const IImage::SpecialPalette & specialPalette, 
 		for (size_t i = 0; i < last; ++i)
 		{
 			if(i < std::numeric_limits<uint32_t>::digits && ((colorsToSkipMask >> i) & 1) == 1)
-				surf->format->palette->colors[i] = specialPalette[i];
+				surf->format->palette->colors[i] = CSDL_Ext::toSDL(specialPalette[i]);
 		}
 	}
 }

--- a/client/renderSDL/SDL_Extensions.h
+++ b/client/renderSDL/SDL_Extensions.h
@@ -9,7 +9,6 @@
  */
 
 #pragma once
-#include "../../lib/GameConstants.h"
 #include "../../lib/Rect.h"
 #include "../../lib/Color.h"
 
@@ -22,6 +21,7 @@ struct SDL_Color;
 
 VCMI_LIB_NAMESPACE_BEGIN
 
+class PlayerColor;
 class Rect;
 class Point;
 
@@ -79,21 +79,19 @@ using TColorPutterAlpha = void (*)(uint8_t *&, const uint8_t &, const uint8_t &,
 	int blit8bppAlphaTo24bppT(const SDL_Surface * src, const Rect & srcRect, SDL_Surface * dst, const Point & dstPoint); //blits 8 bpp surface with alpha channel to 24 bpp surface
 	int blit8bppAlphaTo24bpp(const SDL_Surface * src, const Rect & srcRect, SDL_Surface * dst, const Point & dstPoint); //blits 8 bpp surface with alpha channel to 24 bpp surface
 	uint32_t colorTouint32_t(const SDL_Color * color); //little endian only
-	SDL_Color makeColor(ui8 r, ui8 g, ui8 b, ui8 a);
 
 	void drawLine(SDL_Surface * sur, const Point & from, const Point & dest, const SDL_Color & color1, const SDL_Color & color2);
 	void drawLineDashed(SDL_Surface * sur, const Point & from, const Point & dest, const SDL_Color & color);
 
 	void drawBorder(SDL_Surface * sur, int x, int y, int w, int h, const SDL_Color & color, int depth = 1);
 	void drawBorder(SDL_Surface * sur, const Rect & r, const SDL_Color & color, int depth = 1);
-	void setPlayerColor(SDL_Surface * sur, PlayerColor player); //sets correct color of flags; -1 for neutral
+	void setPlayerColor(SDL_Surface * sur, const PlayerColor & player); //sets correct color of flags; -1 for neutral
 
 	SDL_Surface * newSurface(int w, int h, SDL_Surface * mod); //creates new surface, with flags/format same as in surface given
 	SDL_Surface * newSurface(int w, int h); //creates new surface, with flags/format same as in screen surface
 	SDL_Surface * copySurface(SDL_Surface * mod); //returns copy of given surface
 	template<int bpp>
 	SDL_Surface * createSurfaceWithBpp(int width, int height); //create surface with give bits per pixels value
-	void VflipSurf(SDL_Surface * surf); //fluipis given surface by vertical axis
 
 	//scale surface to required size.
 	//nearest neighbour algorithm

--- a/client/widgets/Buttons.cpp
+++ b/client/widgets/Buttons.cpp
@@ -59,21 +59,9 @@ void CButton::update()
 		redraw();
 }
 
-void CButton::setBorderColor(std::optional<SDL_Color> borderColor)
+void CButton::setBorderColor(std::optional<ColorRGBA> newBorderColor)
 {
-	setBorderColor(borderColor, borderColor, borderColor, borderColor);
-}
-
-void CButton::setBorderColor(std::optional<SDL_Color> normalBorderColor,
-							 std::optional<SDL_Color> pressedBorderColor,
-							 std::optional<SDL_Color> blockedBorderColor,
-							 std::optional<SDL_Color> highlightedBorderColor)
-{
-	stateToBorderColor[NORMAL] = normalBorderColor;
-	stateToBorderColor[PRESSED] = pressedBorderColor;
-	stateToBorderColor[BLOCKED] = blockedBorderColor;
-	stateToBorderColor[HIGHLIGHTED] = highlightedBorderColor;
-	update();
+	borderColor = newBorderColor;
 }
 
 void CButton::addCallback(std::function<void()> callback)
@@ -81,7 +69,7 @@ void CButton::addCallback(std::function<void()> callback)
 	this->callback += callback;
 }
 
-void CButton::addTextOverlay(const std::string & Text, EFonts font, SDL_Color color)
+void CButton::addTextOverlay(const std::string & Text, EFonts font, ColorRGBA color)
 {
 	OBJECT_CONSTRUCTION_CUSTOM_CAPTURING(255-DISPOSE);
 	addOverlay(std::make_shared<CLabel>(pos.w/2, pos.h/2, font, ETextAlignment::CENTER, color, Text));
@@ -298,7 +286,6 @@ void CButton::showAll(Canvas & to)
 {
 	CIntObject::showAll(to);
 
-	auto borderColor = stateToBorderColor[getState()];
 	if (borderColor)
 		to.drawBorder(Rect::createAround(pos, 1), *borderColor);
 }

--- a/client/widgets/Buttons.h
+++ b/client/widgets/Buttons.h
@@ -10,10 +10,8 @@
 #pragma once
 
 #include "../gui/CIntObject.h"
-#include "../render/Colors.h"
+#include "../render/EFont.h"
 #include "../../lib/FunctionList.h"
-
-#include <SDL_pixels.h>
 
 VCMI_LIB_NAMESPACE_BEGIN
 class Rect;
@@ -45,7 +43,7 @@ private:
 
 	std::array<int, 4> stateToIndex; // mapping of button state to index of frame in animation
 	std::array<std::string, 4> hoverTexts; //texts for statusbar, if empty - first entry will be used
-	std::array<std::optional<SDL_Color>, 4> stateToBorderColor; // mapping of button state to border color
+	std::optional<ColorRGBA> borderColor; // mapping of button state to border color
 	std::string helpBox; //for right-click help
 
 	std::shared_ptr<CAnimImage> image; //image for this button
@@ -64,22 +62,15 @@ public:
 		hoverable,//if true, button will be highlighted when hovered (e.g. main menu)
 		soundDisabled;
 
-	// sets border color for each button state;
-	// if it's set, the button will have 1-px border around it with this color
-	void setBorderColor(std::optional<SDL_Color> normalBorderColor,
-						std::optional<SDL_Color> pressedBorderColor,
-						std::optional<SDL_Color> blockedBorderColor,
-						std::optional<SDL_Color> highlightedBorderColor);
-
 	// sets the same border color for all button states.
-	void setBorderColor(std::optional<SDL_Color> borderColor);
+	void setBorderColor(std::optional<ColorRGBA> borderColor);
 
 	/// adds one more callback to on-click actions
 	void addCallback(std::function<void()> callback);
 
 	/// adds overlay on top of button image. Only one overlay can be active at once
 	void addOverlay(std::shared_ptr<CIntObject> newOverlay);
-	void addTextOverlay(const std::string & Text, EFonts font, SDL_Color color = Colors::WHITE);
+	void addTextOverlay(const std::string & Text, EFonts font, ColorRGBA color);
 
 	void addImage(std::string filename);
 	void addHoverText(ButtonState state, std::string text);

--- a/client/widgets/CComponent.cpp
+++ b/client/widgets/CComponent.cpp
@@ -21,6 +21,8 @@
 #include "../gui/TextAlignment.h"
 #include "../gui/Shortcut.h"
 #include "../render/Canvas.h"
+#include "../render/IFont.h"
+#include "../render/Graphics.h"
 #include "../windows/CMessage.h"
 #include "../windows/InfoWindows.h"
 #include "../widgets/TextControls.h"

--- a/client/widgets/CComponent.h
+++ b/client/widgets/CComponent.h
@@ -10,6 +10,8 @@
 #pragma once
 
 #include "../gui/CIntObject.h"
+#include "../render/EFont.h"
+
 
 VCMI_LIB_NAMESPACE_BEGIN
 

--- a/client/widgets/Images.h
+++ b/client/widgets/Images.h
@@ -16,7 +16,6 @@ VCMI_LIB_NAMESPACE_BEGIN
 class Rect;
 VCMI_LIB_NAMESPACE_END
 
-struct SDL_Color;
 class CAnimImage;
 class CLabel;
 class CAnimation;

--- a/client/widgets/MiscWidgets.h
+++ b/client/widgets/MiscWidgets.h
@@ -16,7 +16,11 @@ VCMI_LIB_NAMESPACE_BEGIN
 
 class CGGarrison;
 struct InfoAboutArmy;
+struct InfoAboutHero;
+struct InfoAboutTown;
 class CArmedInstance;
+class CGTownInstance;
+class CGHeroInstance;
 class AFactionMember;
 
 VCMI_LIB_NAMESPACE_END

--- a/client/widgets/Slider.cpp
+++ b/client/widgets/Slider.cpp
@@ -17,6 +17,7 @@
 #include "../gui/Shortcut.h"
 #include "../gui/CGuiHandler.h"
 #include "../render/Canvas.h"
+#include "../render/Colors.h"
 
 void CSlider::mouseDragged(const Point & cursorPosition, const Point & lastUpdateDistance)
 {

--- a/client/widgets/TextControls.cpp
+++ b/client/widgets/TextControls.cpp
@@ -20,6 +20,8 @@
 #include "../adventureMap/CInGameConsole.h"
 #include "../renderSDL/SDL_Extensions.h"
 #include "../render/Canvas.h"
+#include "../render/Graphics.h"
+#include "../render/IFont.h"
 
 #include "../../lib/TextOperations.h"
 
@@ -44,7 +46,7 @@ void CLabel::showAll(Canvas & to)
 
 }
 
-CLabel::CLabel(int x, int y, EFonts Font, ETextAlignment Align, const SDL_Color & Color, const std::string & Text)
+CLabel::CLabel(int x, int y, EFonts Font, ETextAlignment Align, const ColorRGBA & Color, const std::string & Text)
 	: CTextContainer(Align, Font, Color), text(Text)
 {
 	setRedrawParent(true);
@@ -87,7 +89,7 @@ void CLabel::setText(const std::string & Txt)
 	}
 }
 
-void CLabel::setColor(const SDL_Color & Color)
+void CLabel::setColor(const ColorRGBA & Color)
 {
 	color = Color;
 	if(autoRedraw)
@@ -104,7 +106,7 @@ size_t CLabel::getWidth()
 	return graphics->fonts[font]->getStringWidth(visibleText());;
 }
 
-CMultiLineLabel::CMultiLineLabel(Rect position, EFonts Font, ETextAlignment Align, const SDL_Color & Color, const std::string & Text) :
+CMultiLineLabel::CMultiLineLabel(Rect position, EFonts Font, ETextAlignment Align, const ColorRGBA & Color, const std::string & Text) :
 	CLabel(position.x, position.y, Font, Align, Color, Text),
 	visibleSize(0, 0, position.w, position.h)
 {
@@ -193,7 +195,7 @@ void CTextContainer::blitLine(Canvas & to, Rect destRect, std::string what)
 	} while(begin++ != std::string::npos);
 }
 
-CTextContainer::CTextContainer(ETextAlignment alignment, EFonts font, SDL_Color color) :
+CTextContainer::CTextContainer(ETextAlignment alignment, EFonts font, ColorRGBA color) :
 	alignment(alignment),
 	font(font),
 	color(color)
@@ -275,7 +277,7 @@ Rect CMultiLineLabel::getTextLocation()
 	return Rect();
 }
 
-CLabelGroup::CLabelGroup(EFonts Font, ETextAlignment Align, const SDL_Color & Color)
+CLabelGroup::CLabelGroup(EFonts Font, ETextAlignment Align, const ColorRGBA & Color)
 	: font(Font), align(Align), color(Color)
 {
 	defActions = 255 - DISPOSE;
@@ -292,7 +294,7 @@ size_t CLabelGroup::currentSize() const
 	return labels.size();
 }
 
-CTextBox::CTextBox(std::string Text, const Rect & rect, int SliderStyle, EFonts Font, ETextAlignment Align, const SDL_Color & Color) :
+CTextBox::CTextBox(std::string Text, const Rect & rect, int SliderStyle, EFonts Font, ETextAlignment Align, const ColorRGBA & Color) :
 	sliderStyle(SliderStyle),
 	slider(nullptr)
 {
@@ -403,7 +405,7 @@ void CGStatusBar::clear()
 	write({});
 }
 
-CGStatusBar::CGStatusBar(std::shared_ptr<CIntObject> background_, EFonts Font, ETextAlignment Align, const SDL_Color & Color)
+CGStatusBar::CGStatusBar(std::shared_ptr<CIntObject> background_, EFonts Font, ETextAlignment Align, const ColorRGBA & Color)
 	: CLabel(background_->pos.x, background_->pos.y, Font, Align, Color, "")
 	, enteringText(false)
 {

--- a/client/widgets/TextControls.h
+++ b/client/widgets/TextControls.h
@@ -12,10 +12,8 @@
 #include "../gui/CIntObject.h"
 #include "../gui/TextAlignment.h"
 #include "../render/Colors.h"
-#include "../render/Graphics.h"
+#include "../render/EFont.h"
 #include "../../lib/FunctionList.h"
-
-#include <SDL_pixels.h>
 
 class IImage;
 class CSlider;
@@ -30,12 +28,12 @@ protected:
 	/// do actual blitting of line. Text "what" will be placed at "where" and aligned according to alignment
 	void blitLine(Canvas & to, Rect where, std::string what);
 
-	CTextContainer(ETextAlignment alignment, EFonts font, SDL_Color color);
+	CTextContainer(ETextAlignment alignment, EFonts font, ColorRGBA color);
 
 public:
 	ETextAlignment alignment;
 	EFonts font;
-	SDL_Color color; // default font color. Can be overridden by placing "{}" into the string
+	ColorRGBA color; // default font color. Can be overridden by placing "{}" into the string
 };
 
 /// Label which shows text
@@ -54,11 +52,11 @@ public:
 	std::string getText();
 	virtual void setAutoRedraw(bool option);
 	virtual void setText(const std::string & Txt);
-	virtual void setColor(const SDL_Color & Color);
+	virtual void setColor(const ColorRGBA & Color);
 	size_t getWidth();
 
 	CLabel(int x = 0, int y = 0, EFonts Font = FONT_SMALL, ETextAlignment Align = ETextAlignment::TOPLEFT,
-		const SDL_Color & Color = Colors::WHITE, const std::string & Text = "");
+		const ColorRGBA & Color = Colors::WHITE, const std::string & Text = "");
 	void showAll(Canvas & to) override; //shows statusbar (with current text)
 };
 
@@ -68,9 +66,9 @@ class CLabelGroup : public CIntObject
 	std::vector<std::shared_ptr<CLabel>> labels;
 	EFonts font;
 	ETextAlignment align;
-	SDL_Color color;
+	ColorRGBA color;
 public:
-	CLabelGroup(EFonts Font = FONT_SMALL, ETextAlignment Align = ETextAlignment::TOPLEFT, const SDL_Color & Color = Colors::WHITE);
+	CLabelGroup(EFonts Font = FONT_SMALL, ETextAlignment Align = ETextAlignment::TOPLEFT, const ColorRGBA & Color = Colors::WHITE);
 	void add(int x = 0, int y = 0, const std::string & text = "");
 	size_t currentSize() const;
 };
@@ -91,7 +89,7 @@ public:
 	// total size of text, x = longest line of text, y = total height of lines
 	Point textSize;
 
-	CMultiLineLabel(Rect position, EFonts Font = FONT_SMALL, ETextAlignment Align = ETextAlignment::TOPLEFT, const SDL_Color & Color = Colors::WHITE, const std::string & Text = "");
+	CMultiLineLabel(Rect position, EFonts Font = FONT_SMALL, ETextAlignment Align = ETextAlignment::TOPLEFT, const ColorRGBA & Color = Colors::WHITE, const std::string & Text = "");
 
 	void setText(const std::string & Txt) override;
 	void showAll(Canvas & to) override;
@@ -111,7 +109,7 @@ public:
 	std::shared_ptr<CMultiLineLabel> label;
 	std::shared_ptr<CSlider> slider;
 
-	CTextBox(std::string Text, const Rect & rect, int SliderStyle, EFonts Font = FONT_SMALL, ETextAlignment Align = ETextAlignment::TOPLEFT, const SDL_Color & Color = Colors::WHITE);
+	CTextBox(std::string Text, const Rect & rect, int SliderStyle, EFonts Font = FONT_SMALL, ETextAlignment Align = ETextAlignment::TOPLEFT, const ColorRGBA & Color = Colors::WHITE);
 
 	void resize(Point newSize);
 	void setText(const std::string & Txt);
@@ -125,7 +123,7 @@ class CGStatusBar : public CLabel, public std::enable_shared_from_this<CGStatusB
 	std::string consoleText;
 	bool enteringText;
 
-	CGStatusBar(std::shared_ptr<CIntObject> background_, EFonts Font = FONT_SMALL, ETextAlignment Align = ETextAlignment::CENTER, const SDL_Color & Color = Colors::WHITE);
+	CGStatusBar(std::shared_ptr<CIntObject> background_, EFonts Font = FONT_SMALL, ETextAlignment Align = ETextAlignment::CENTER, const ColorRGBA & Color = Colors::WHITE);
 	CGStatusBar(int x, int y, std::string name, int maxw = -1);
 
 	//make CLabel API private

--- a/client/windows/CKingdomInterface.h
+++ b/client/windows/CKingdomInterface.h
@@ -12,6 +12,10 @@
 #include "../widgets/CWindowWithArtifacts.h"
 #include "CWindowObject.h"
 
+VCMI_LIB_NAMESPACE_BEGIN
+class CGObjectInstance;
+VCMI_LIB_NAMESPACE_END
+
 class CButton;
 class CAnimImage;
 class CToggleGroup;

--- a/client/windows/CMessage.cpp
+++ b/client/windows/CMessage.cpp
@@ -24,6 +24,8 @@
 #include "../render/CAnimation.h"
 #include "../render/IImage.h"
 #include "../render/Canvas.h"
+#include "../render/Graphics.h"
+#include "../render/IFont.h"
 #include "../renderSDL/SDL_Extensions.h"
 
 #include <SDL_surface.h>

--- a/client/windows/CMessage.h
+++ b/client/windows/CMessage.h
@@ -9,7 +9,7 @@
  */
 #pragma once
 
-#include "../render/Graphics.h"
+#include "../render/EFont.h"
 #include "../../lib/GameConstants.h"
 
 struct SDL_Surface;

--- a/client/windows/CPuzzleWindow.cpp
+++ b/client/windows/CPuzzleWindow.cpp
@@ -30,7 +30,7 @@
 CPuzzleWindow::CPuzzleWindow(const int3 & GrailPos, double discoveredRatio)
 	: CWindowObject(PLAYER_COLORED | BORDERED, "PUZZLE"),
 	grailPos(GrailPos),
-	currentAlpha(SDL_ALPHA_OPAQUE)
+	currentAlpha(ColorRGBA::ALPHA_OPAQUE)
 {
 	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
 

--- a/client/windows/CQuestLog.h
+++ b/client/windows/CQuestLog.h
@@ -43,7 +43,7 @@ class CQuestLabel : public LRClickableAreaWText, public CMultiLineLabel
 public:
 	std::function<void()> callback;
 
-	CQuestLabel(Rect position, EFonts Font = FONT_SMALL, ETextAlignment Align = ETextAlignment::TOPLEFT, const SDL_Color &Color = Colors::WHITE, const std::string &Text =  "")
+	CQuestLabel(Rect position, EFonts Font = FONT_SMALL, ETextAlignment Align = ETextAlignment::TOPLEFT, const ColorRGBA &Color = Colors::WHITE, const std::string &Text =  "")
 		: CMultiLineLabel (position, FONT_SMALL, ETextAlignment::TOPLEFT, Colors::WHITE, Text){};
 	void clickPressed(const Point & cursorPosition) override;
 	void showAll(Canvas & to) override;

--- a/client/windows/CSpellWindow.cpp
+++ b/client/windows/CSpellWindow.cpp
@@ -590,7 +590,7 @@ void CSpellWindow::SpellArea::setSpell(const CSpell * spell)
 			schoolBorder = std::make_shared<CAnimImage>(owner->schoolBorders[owner->selectedTab >= 4 ? whichSchool : owner->selectedTab], schoolLevel);
 		}
 
-		SDL_Color firstLineColor, secondLineColor;
+		ColorRGBA firstLineColor, secondLineColor;
 		if(spellCost > owner->myHero->mana) //hero cannot cast this spell
 		{
 			firstLineColor = Colors::WHITE;

--- a/client/windows/CSpellWindow.h
+++ b/client/windows/CSpellWindow.h
@@ -19,6 +19,7 @@ class CSpell;
 VCMI_LIB_NAMESPACE_END
 
 class IImage;
+class CAnimation;
 class CAnimImage;
 class CPicture;
 class CLabel;

--- a/client/windows/GUIClasses.h
+++ b/client/windows/GUIClasses.h
@@ -18,6 +18,7 @@
 
 VCMI_LIB_NAMESPACE_BEGIN
 
+class CGObjectInstance;
 class CGDwelling;
 class IMarket;
 

--- a/client/windows/InfoWindows.h
+++ b/client/windows/InfoWindows.h
@@ -15,6 +15,9 @@
 
 VCMI_LIB_NAMESPACE_BEGIN
 
+class CGObjectInstance;
+class CGTownInstance;
+class CGHeroInstance;
 class CGGarrison;
 class Rect;
 

--- a/client/windows/QuickRecruitmentWindow.h
+++ b/client/windows/QuickRecruitmentWindow.h
@@ -11,6 +11,10 @@
 
 #include "../windows/CWindowObject.h"
 
+VCMI_LIB_NAMESPACE_BEGIN
+class CGTownInstance;
+VCMI_LIB_NAMESPACE_END
+
 class CButton;
 class CreatureCostBox;
 class CreaturePurchaseCard;


### PR DESCRIPTION
Another piece of SDL abstraction:
- removed all references to SDL_Color from UI code in favor of ColorRGBA
- removed several includes in headers
- removed no longer used code from SDL_Extensions

With this the only remaining pieces of direct access to SDL from UI are:
- shadow for windows
- ancient code of infobox popup generation