### PR TITLE
(1.3.1) Fix assertion failure on screen resize

### DIFF
--- a/client/adventureMap/AdventureMapInterface.cpp
+++ b/client/adventureMap/AdventureMapInterface.cpp
@@ -822,6 +822,15 @@ void AdventureMapInterface::hotkeyZoom(int delta)
 void AdventureMapInterface::onScreenResize()
 {
 	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
+
+	// remember our activation state and reactive after reconstruction
+	// since othervice activate() calls for created elements will bypass virtual dispatch
+	// and will call directly CIntObject::activate() instead of dispatching virtual function call
+	bool widgetActive = isActive();
+
+	if (widgetActive)
+		deactivate();
+
 	widget.reset();
 	pos.x = pos.y = 0;
 	pos.w = GH.screenDimensions().x;
@@ -838,4 +847,7 @@ void AdventureMapInterface::onScreenResize()
 		widget->getMapView()->onCenteredObject(LOCPLINT->localState->getCurrentArmy());
 
 	adjustActiveness();
+
+	if (widgetActive)
+		activate();
 }


### PR DESCRIPTION
Fixes possible assertion failure (and broken status bar) when:
- start the game in windowed mode
- start a map
- press 2xF4 to maximize the game and get back to the windowed mode
- press E to end turn (or just click the button)

Targeting 1.3.1 to be safe, in case if I missed something