### PR TITLE
Map full name and locale date

### DIFF
--- a/client/lobby/SelectionTab.cpp
+++ b/client/lobby/SelectionTab.cpp
@@ -328,7 +328,7 @@ void SelectionTab::showPopupWindow(const Point & cursorPosition)
 	if(py >= curItems.size())
 		return;
 
-	std::string text = boost::str(boost::format("{%1%}\r\n\r\n%2%:\r\n%3%") % curItems[py]->getName() % CGI->generaltexth->translate("vcmi.lobby.filename") % curItems[py]->fileURI);
+	std::string text = boost::str(boost::format("{%1%}\r\n\r\n%2%:\r\n%3%") % curItems[py]->getName() % CGI->generaltexth->translate("vcmi.lobby.filename") % curItems[py]->fullFileURI);
 	if(curItems[py]->date != "")
 	    text += boost::str(boost::format("\r\n\r\n%1%:\r\n%2%") % CGI->generaltexth->translate("vcmi.lobby.creationDate") % curItems[py]->date);
 

--- a/lib/mapping/CMapInfo.cpp
+++ b/lib/mapping/CMapInfo.cpp
@@ -61,11 +61,11 @@ void CMapInfo::saveInit(const ResourceID & file)
 	countPlayers();
 	std::time_t time = boost::filesystem::last_write_time(*CResourceHandler::get()->getResourceName(file));
 
-    std::tm tm = *std::localtime(&time);
+	std::tm tm = *std::localtime(&time);
 	std::stringstream s;
 	s.imbue(std::locale(""));
-    s << std::put_time(&tm, "%x %X");
-    date = s.str();
+	s << std::put_time(&tm, "%x %X");
+	date = s.str();
 
 	// We absolutely not need this data for lobby and server will read it from save
 	// FIXME: actually we don't want them in CMapHeader!

--- a/lib/mapping/CMapInfo.h
+++ b/lib/mapping/CMapInfo.h
@@ -62,7 +62,6 @@ public:
 		h & campaign;
 		h & scenarioOptionsOfSave;
 		h & fileURI;
-		h & fullFileURI;
 		h & date;
 		h & amountOfPlayersOnMap;
 		h & amountOfHumanControllablePlayers;

--- a/lib/mapping/CMapInfo.h
+++ b/lib/mapping/CMapInfo.h
@@ -28,6 +28,7 @@ public:
 	std::unique_ptr<Campaign> campaign; //may be nullptr if scenario
 	StartInfo * scenarioOptionsOfSave; // Options with which scenario has been started (used only with saved games)
 	std::string fileURI;
+	std::string fullFileURI;
 	std::string date;
 	int amountOfPlayersOnMap;
 	int amountOfHumanControllablePlayers;
@@ -61,6 +62,7 @@ public:
 		h & campaign;
 		h & scenarioOptionsOfSave;
 		h & fileURI;
+		h & fullFileURI;
 		h & date;
 		h & amountOfPlayersOnMap;
 		h & amountOfHumanControllablePlayers;


### PR DESCRIPTION
Shows the full path to the map with file extension.

Also uses system date&time output format now. Fixes #2365