### PR TITLE
Fix starting army

### DIFF
--- a/AI/Nullkiller/Analyzers/ArmyManager.cpp
+++ b/AI/Nullkiller/Analyzers/ArmyManager.cpp
@@ -170,7 +170,7 @@ std::vector<SlotInfo> ArmyManager::getBestArmy(const IBonusBearer * armyCarrier,
 
 		std::vector<SlotInfo> newArmy;
 		uint64_t newValue = 0;
-		newArmyInstance.clear();
+		newArmyInstance.clearSlots();
 
 		for(auto & slot : sortedSlots)
 		{

--- a/lib/CCreatureSet.cpp
+++ b/lib/CCreatureSet.cpp
@@ -445,7 +445,7 @@ void CCreatureSet::setStackExp(const SlotID & slot, TExpType exp)
 	stacks[slot]->experience = exp;
 }
 
-void CCreatureSet::clear()
+void CCreatureSet::clearSlots()
 {
 	while(!stacks.empty())
 	{
@@ -533,12 +533,12 @@ void CCreatureSet::changeStackCount(const SlotID & slot, TQuantity toAdd)
 
 CCreatureSet::~CCreatureSet()
 {
-	clear();
+	clearSlots();
 }
 
 void CCreatureSet::setToArmy(CSimpleArmy &src)
 {
-	clear();
+	clearSlots();
 	while(src)
 	{
 		auto i = src.army.begin();
@@ -1050,7 +1050,7 @@ void CStackBasicDescriptor::serializeJson(JsonSerializeFormat & handler)
 	}
 }
 
-void CSimpleArmy::clear()
+void CSimpleArmy::clearSlots()
 {
 	army.clear();
 }

--- a/lib/CCreatureSet.h
+++ b/lib/CCreatureSet.h
@@ -181,7 +181,7 @@ using TCreatureQueue = std::priority_queue<TPairCreatureSlot, std::vector<TPairC
 class IArmyDescriptor
 {
 public:
-	virtual void clear() = 0;
+	virtual void clearSlots() = 0;
 	virtual bool setCreature(SlotID slot, CreatureID cre, TQuantity count) = 0;
 };
 
@@ -190,7 +190,7 @@ class DLL_LINKAGE CSimpleArmy : public IArmyDescriptor
 {
 public:
 	TSimpleSlots army;
-	void clear() override;
+	void clearSlots() override;
 	bool setCreature(SlotID slot, CreatureID cre, TQuantity count) override;
 	operator bool() const;
 
@@ -226,7 +226,7 @@ public:
 
 	void addToSlot(const SlotID & slot, const CreatureID & cre, TQuantity count, bool allowMerging = true); //Adds stack to slot. Slot must be empty or with same type creature
 	void addToSlot(const SlotID & slot, CStackInstance * stack, bool allowMerging = true); //Adds stack to slot. Slot must be empty or with same type creature
-	void clear() override;
+	void clearSlots() override;
 	void setFormation(bool tight);
 	CArmedInstance *castToArmyObj();
 

--- a/lib/NetPacks.h
+++ b/lib/NetPacks.h
@@ -335,7 +335,7 @@ struct DLL_LINKAGE SetAvailableHero : public CPackForClient
 {
 	SetAvailableHero()
 	{
-		army.clear();
+		army.clearSlots();
 	}
 	void applyGs(CGameState * gs);
 

--- a/lib/mapObjects/CBank.cpp
+++ b/lib/mapObjects/CBank.cpp
@@ -58,7 +58,7 @@ std::string CBank::getHoverText(PlayerColor player) const
 void CBank::setConfig(const BankConfig & config)
 {
 	bc = std::make_unique<BankConfig>(config);
-	clear(); // remove all stacks, if any
+	clearSlots(); // remove all stacks, if any
 
 	for(const auto & stack : config.guards)
 		setCreature (SlotID(stacksCount()), stack.type->getId(), stack.count);

--- a/lib/mapping/MapFormatH3M.cpp
+++ b/lib/mapping/MapFormatH3M.cpp
@@ -1736,7 +1736,7 @@ CGObjectInstance * CMapLoaderH3M::readHero(const int3 & mapPosition, const Objec
 		{
 			if(!object->spells.empty())
 			{
-				object->clear();
+				object->spells.clear();
 				logGlobal->debug("Hero %s subID=%d has spells set twice (in map properties and on adventure map instance). Using the latter set...", object->getNameTextID(), object->subID);
 			}
 

--- a/mapeditor/inspector/rewardswidget.cpp
+++ b/mapeditor/inspector/rewardswidget.cpp
@@ -222,7 +222,7 @@ bool RewardsWidget::commitChanges()
 		pandora->resources = ResourceSet();
 		pandora->artifacts.clear();
 		pandora->spells.clear();
-		pandora->creatures.clear();
+		pandora->creatures.clearSlots();
 		
 		for(int row = 0; row < rewards; ++row)
 		{

--- a/server/HeroPoolProcessor.cpp
+++ b/server/HeroPoolProcessor.cpp
@@ -112,7 +112,7 @@ void HeroPoolProcessor::onHeroEscaped(const PlayerColor & color, const CGHeroIns
 	sah.slotID = selectSlotForRole(color, sah.roleID);
 	sah.player = color;
 	sah.hid = hero->subID;
-	sah.army.clear();
+	sah.army.clearSlots();
 	sah.army.setCreature(SlotID(0), hero->type->initialArmy.at(0).creature, 1);
 
 	gameHandler->sendAndApply(&sah);
@@ -148,7 +148,7 @@ void HeroPoolProcessor::selectNewHeroForSlot(const PlayerColor & color, TavernHe
 		else
 		{
 			sah.roleID = TavernSlotRole::SINGLE_UNIT;
-			sah.army.clear();
+			sah.army.clearSlots();
 			sah.army.setCreature(SlotID(0), newHero->type->initialArmy[0].creature, 1);
 		}
 	}


### PR DESCRIPTION
- Rename ambiguous 'CCreatureSet::clear' to 'clearSlots'
- Fixes #2479 