### PR TITLE
Fix hota offset + 2 possible crashes

### DIFF
--- a/lib/rmg/RmgObject.cpp
+++ b/lib/rmg/RmgObject.cpp
@@ -344,16 +344,6 @@ void Object::Instance::finalize(RmgMap & map)
 			setTemplate(terrainType->getId());
 		}
 	}
-	if (dObject.ID == Obj::MONSTER)
-	{
-		//Make up for extra offset in HotA creature templates
-		auto visitableOffset = dObject.getVisitableOffset();
-		auto fixedPos = getPosition(true) + visitableOffset;
-		vstd::abetween(fixedPos.x, visitableOffset.x, map.width() - 1);
-		vstd::abetween(fixedPos.y, visitableOffset.y, map.height() - 1);
-		int3 parentPos = getPosition(true) - getPosition(false);
-		setPosition(fixedPos - parentPos);
-	}
 
 	if (dObject.isVisitable() && !map.isOnMap(dObject.visitablePos()))
 		throw rmgException(boost::to_string(boost::format("Visitable tile %s of object %d at %s is outside the map") % dObject.visitablePos().toString() % dObject.id % dObject.pos.toString()));

--- a/lib/rmg/modificators/ObjectManager.cpp
+++ b/lib/rmg/modificators/ObjectManager.cpp
@@ -452,13 +452,19 @@ bool ObjectManager::createRequiredObjects()
 
 void ObjectManager::placeObject(rmg::Object & object, bool guarded, bool updateDistance, bool createRoad/* = false*/)
 {	
-	object.finalize(map);
+	//object.finalize(map);
 
 	if (object.instances().size() == 1 && object.instances().front()->object().ID == Obj::MONSTER)
 	{
 		//Fix for HoTA offset - lonely guards
-		object.getPosition();
+		
 		auto monster = object.instances().front();
+		if (!monster->object().appearance)
+		{
+			//Needed to determine visitable offset
+			monster->setAnyTemplate();
+		}
+		object.getPosition();
 		auto visitableOffset = monster->object().getVisitableOffset();
 		auto fixedPos = monster->getPosition(true) + visitableOffset;
 
@@ -468,6 +474,7 @@ void ObjectManager::placeObject(rmg::Object & object, bool guarded, bool updateD
 		int3 parentOffset = monster->getPosition(true) - monster->getPosition(false);
 		monster->setPosition(fixedPos - parentOffset);
 	}
+	object.finalize(map);
 
 	Zone::Lock lock(zone.areaMutex);
 	zone.areaPossible().subtract(object.getArea());


### PR DESCRIPTION
- Fix offset of HoTA monster templates. For good this time.
- Fix the risk of place objects outside the map if they don't start at their (0,0) tile
- Added more potential locations for quest artifacts in zone