### PR TITLE
Fix regression with replacing quest artifact

### DIFF
--- a/lib/rmg/modificators/QuestArtifactPlacer.cpp
+++ b/lib/rmg/modificators/QuestArtifactPlacer.cpp
@@ -89,14 +89,15 @@ void QuestArtifactPlacer::placeQuestArtifacts(CRandomGenerator & rand)
 				artifactToReplace->getObjectName(),
 				artifactToReplace->getPosition().toString(),
 				VLC->artifacts()->getById(artifactToPlace)->getNameTranslated());
-			artifactToReplace->ID = Obj::ARTIFACT;
-			artifactToReplace->subID = artifactToPlace;
 
 			//Update appearance. Terrain is irrelevant.
 			auto handler = VLC->objtypeh->getHandlerFor(Obj::ARTIFACT, artifactToPlace);
+			auto newObj = handler->create();
 			auto templates = handler->getTemplates();
-			artifactToReplace->appearance = templates.front();
-			//FIXME: Instance name is still "randomArtifact"
+			//artifactToReplace->appearance = templates.front();
+			newObj->appearance  = templates.front();
+			newObj->pos = artifactToReplace->pos;
+			mapProxy->insertObject(newObj);
 
 			for (auto z : map.getZones())
 			{
@@ -107,6 +108,7 @@ void QuestArtifactPlacer::placeQuestArtifacts(CRandomGenerator & rand)
 					localQap->dropReplacedArtifact(artifactToReplace);
 				}
 			}
+			mapProxy->removeObject(artifactToReplace);
 			break;
 		}
 	}

--- a/lib/rmg/threadpool/MapProxy.cpp
+++ b/lib/rmg/threadpool/MapProxy.cpp
@@ -30,6 +30,12 @@ void MapProxy::insertObjects(std::set<CGObjectInstance*>& objects)
     map.getEditManager()->insertObjects(objects);
 }
 
+void MapProxy::removeObject(CGObjectInstance * obj)
+{
+    Lock lock(mx);
+    map.getEditManager()->removeObject(obj);
+}
+
 void MapProxy::drawTerrain(CRandomGenerator & generator, std::vector<int3> & tiles, TerrainId terrain)
 {
     Lock lock(mx);

--- a/lib/rmg/threadpool/MapProxy.h
+++ b/lib/rmg/threadpool/MapProxy.h
@@ -26,6 +26,7 @@ public:
 
     void insertObject(CGObjectInstance * obj);
     void insertObjects(std::set<CGObjectInstance*>& objects);
+    void removeObject(CGObjectInstance* obj);
 
     void drawTerrain(CRandomGenerator & generator, std::vector<int3> & tiles, TerrainId terrain);
     void drawRivers(CRandomGenerator & generator, std::vector<int3> & tiles, TerrainId terrain);


### PR DESCRIPTION
Recently I decided to allow replacing random resources with quest artifacts. However, this crashes when AI tries to upcast it to wrong type.

Now objects will be properly and fully replaced.