### PR TITLE
Fix crash on video playback (and who knows how many more)

### DIFF
--- a/client/CServerHandler.cpp
+++ b/client/CServerHandler.cpp
@@ -88,6 +88,8 @@ template<typename T> class CApplyOnLobby : public CBaseForLobbyApply
 public:
 	bool applyOnLobbyHandler(CServerHandler * handler, void * pack) const override
 	{
+		boost::unique_lock<boost::recursive_mutex> un(*CPlayerInterface::pim);
+
 		T * ptr = static_cast<T *>(pack);
 		ApplyOnLobbyHandlerNetPackVisitor visitor(*handler);
 


### PR DESCRIPTION
Yet another crash caused by poor multithreading logic.
In lobby, server handler thread could access GUI state without acquiring PlayerInterface::pim first, leading to potential data races, commonly resulting in crash inside ffmpeg.

- Fixes #2553 

Thanks to Laserlicht for catching this crash in debugger.