### PR TITLE
Final crashfixes for 1.3.1

### DIFF
--- a/android/vcmi-app/build.gradle
+++ b/android/vcmi-app/build.gradle
@@ -10,7 +10,7 @@ android {
 		applicationId "is.xyz.vcmi"
 		minSdk 19
 		targetSdk 31
-		versionCode 1305
+		versionCode 1306
 		versionName "1.3.0"
 		setProperty("archivesBaseName", "vcmi")
 	}

--- a/client/CServerHandler.cpp
+++ b/client/CServerHandler.cpp
@@ -88,6 +88,8 @@ template<typename T> class CApplyOnLobby : public CBaseForLobbyApply
 public:
 	bool applyOnLobbyHandler(CServerHandler * handler, void * pack) const override
 	{
+		boost::unique_lock<boost::recursive_mutex> un(*CPlayerInterface::pim);
+
 		T * ptr = static_cast<T *>(pack);
 		ApplyOnLobbyHandlerNetPackVisitor visitor(*handler);
 

--- a/lib/CModHandler.cpp
+++ b/lib/CModHandler.cpp
@@ -649,6 +649,48 @@ void CModInfo::updateChecksum(ui32 newChecksum)
 	}
 }
 
+bool CModInfo::checkModGameplayAffecting() const
+{
+	if (modGameplayAffecting.has_value())
+		return *modGameplayAffecting;
+
+	static const std::vector<std::string> keysToTest = {
+		"heroClasses",
+		"artifacts",
+		"creatures",
+		"factions",
+		"objects",
+		"heroes",
+		"spells",
+		"skills",
+		"templates",
+		"scripts",
+		"battlefields",
+		"terrains",
+		"rivers",
+		"roads",
+		"obstacles"
+	};
+
+	ResourceID modFileResource(CModInfo::getModFile(identifier));
+
+	if(CResourceHandler::get("initial")->existsResource(modFileResource))
+	{
+		const JsonNode modConfig(modFileResource);
+
+		for (auto const & key : keysToTest)
+		{
+			if (!modConfig[key].isNull())
+			{
+				modGameplayAffecting = true;
+				return *modGameplayAffecting;
+			}
+		}
+	}
+	modGameplayAffecting = false;
+	return *modGameplayAffecting;
+}
+
 void CModInfo::loadLocalData(const JsonNode & data)
 {
 	bool validated = false;

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -77,7 +77,6 @@
 #define COMPLAIN_RETF(txt, FORMAT) {complain(boost::str(boost::format(txt) % FORMAT)); return false;}
 
 CondSh<bool> battleMadeAction(false);
-boost::recursive_mutex battleActionMutex;
 CondSh<BattleResult *> battleResult(nullptr);
 template <typename T> class CApplyOnGH;
 

--- a/server/CGameHandler.h
+++ b/server/CGameHandler.h
@@ -102,6 +102,8 @@ class CGameHandler : public IGameCallback, public CBattleInfoCallback, public En
 	std::unique_ptr<boost::thread> battleThread;
 
 public:
+	boost::recursive_mutex battleActionMutex;
+
 	std::unique_ptr<HeroPoolProcessor> heroPool;
 
 	using FireShieldInfo = std::vector<std::pair<const CStack *, int64_t>>;

--- a/server/NetPacksServer.cpp
+++ b/server/NetPacksServer.cpp
@@ -25,8 +25,6 @@
 #include "../lib/spells/ISpellMechanics.h"
 #include "../lib/serializer/Cast.h"
 
-extern boost::recursive_mutex battleActionMutex;
-
 void ApplyGhNetPackVisitor::visitSaveGame(SaveGame & pack)
 {
 	gh.save(pack.fname);
@@ -282,7 +280,7 @@ void ApplyGhNetPackVisitor::visitQueryReply(QueryReply & pack)
 
 void ApplyGhNetPackVisitor::visitMakeAction(MakeAction & pack)
 {
-	boost::unique_lock lock(battleActionMutex);
+	boost::unique_lock lock(gh.battleActionMutex);
 
 	const BattleInfo * b = gs.curB;
 	if(!b)
@@ -311,7 +309,7 @@ void ApplyGhNetPackVisitor::visitMakeAction(MakeAction & pack)
 
 void ApplyGhNetPackVisitor::visitMakeCustomAction(MakeCustomAction & pack)
 {
-	boost::unique_lock lock(battleActionMutex);
+	boost::unique_lock lock(gh.battleActionMutex);
 
 	const BattleInfo * b = gs.curB;
 	if(!b)


### PR DESCRIPTION
Fixes for remaining common issues according to Google Play. Not yet sure whether will be released in 1.3.1 or in another hotfix.

1) Fixed mod dependencies check on save loading to prevent crashes:
- mods that don't affect game objects can be ignored when loading save
- gameplay-affecting mods that were present in save must be active
- gameplay-affecting mods that were not in save must not be active

2) Attempt to fix crash on quitApplication (probably destruction of newly added mutex in GameHandler)

3) Backport video player fix