### PR TITLE
(1.3.2) Android SDK version bump

### DIFF
--- a/android/vcmi-app/build.gradle
+++ b/android/vcmi-app/build.gradle
@@ -3,13 +3,13 @@ plugins {
 }
 
 android {
-	compileSdk 31
+	compileSdk 33
 	ndkVersion '25.2.9519653'
 
 	defaultConfig {
 		applicationId "is.xyz.vcmi"
 		minSdk 19
-		targetSdk 31
+		targetSdk 33
 		versionCode 1306
 		versionName "1.3.0"
 		setProperty("archivesBaseName", "vcmi")


### PR DESCRIPTION
Google Play requires targeting SDK version 33 (Android 13) for any new updates after August, 31.

According to migration guide, we don't use anything that might be affected, so transition should be smooth. However not sure if our build pipeline needs any other changes.