### PR TITLE
Fix counting wood mines starting from 8 in kingdom overview

### DIFF
--- a/client/windows/CKingdomInterface.cpp
+++ b/client/windows/CKingdomInterface.cpp
@@ -555,7 +555,7 @@ std::shared_ptr<CIntObject> CKingdomInterface::createMainTab(size_t index)
 void CKingdomInterface::generateMinesList(const std::vector<const CGObjectInstance *> & ownedObjects)
 {
 	ui32 footerPos = OVERVIEW_SIZE * 116;
-	TResources minesCount(GameConstants::RESOURCE_QUANTITY, 0);
+	ResourceSet minesCount = ResourceSet();
 	int totalIncome=0;
 
 	for(const CGObjectInstance * object : ownedObjects)


### PR DESCRIPTION
Fix wood mines being counted starting from 8 in kingdom overview - wrong constructor usage, probably regression from some rework. Fixes #2575 