### PR TITLE
Allow empty army as result of quests creature removal

### DIFF
--- a/client/Client.h
+++ b/client/Client.h
@@ -178,7 +178,7 @@ public:
 	void giveCreatures(const CArmedInstance * objid, const CGHeroInstance * h, const CCreatureSet & creatures, bool remove) override {};
 	void takeCreatures(ObjectInstanceID objid, const std::vector<CStackBasicDescriptor> & creatures) override {};
 	bool changeStackType(const StackLocation & sl, const CCreature * c) override {return false;};
-	bool changeStackCount(const StackLocation & sl, TQuantity count, bool absoluteValue = false) override {return false;};
+	bool changeStackCount(const StackLocation & sl, TQuantity count, bool absoluteValue = false, bool allowZeroStacksArmyResult = false) override {return false;};
 	bool insertNewStack(const StackLocation & sl, const CCreature * c, TQuantity count) override {return false;};
 	bool eraseStack(const StackLocation & sl, bool forceRemoval = false) override {return false;};
 	bool swapStacks(const StackLocation & sl1, const StackLocation & sl2) override {return false;}

--- a/lib/IGameCallback.h
+++ b/lib/IGameCallback.h
@@ -103,7 +103,7 @@ public:
 
 	virtual void giveCreatures(const CArmedInstance *objid, const CGHeroInstance * h, const CCreatureSet &creatures, bool remove) =0;
 	virtual void takeCreatures(ObjectInstanceID objid, const std::vector<CStackBasicDescriptor> &creatures) =0;
-	virtual bool changeStackCount(const StackLocation &sl, TQuantity count, bool absoluteValue = false) =0;
+	virtual bool changeStackCount(const StackLocation &sl, TQuantity count, bool absoluteValue = false, bool allowZeroStacksArmyResult = false) = 0;
 	virtual bool changeStackType(const StackLocation &sl, const CCreature *c) =0;
 	virtual bool insertNewStack(const StackLocation &sl, const CCreature *c, TQuantity count = -1) =0; //count -1 => moves whole stack
 	virtual bool eraseStack(const StackLocation &sl, bool forceRemoval = false) =0;

--- a/lib/mapObjects/CQuest.cpp
+++ b/lib/mapObjects/CQuest.cpp
@@ -116,6 +116,12 @@ bool CQuest::checkMissionArmy(const CQuest * q, const CCreatureSet * army)
 		hasExtraCreatures |= static_cast<TQuantity>(count) > cre->count;
 	}
 
+	bool allowEmptyArmyAfterQuest = true;
+
+	if(allowEmptyArmyAfterQuest)
+		return true;
+
+	//do NOT remove below line without making sure there will not be VCMI mode with strict empty army prevention
 	return hasExtraCreatures || slotsCount < army->Slots().size();
 }
 

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -2539,7 +2539,7 @@ void CGameHandler::takeCreatures(ObjectInstanceID objid, const std::vector<CStac
 				if (i->second->type == sbd.type)
 				{
 					TQuantity take = std::min(sbd.count - collected, i->second->count); //collect as much cres as we can
-					changeStackCount(StackLocation(obj, i->first), -take, false);
+					changeStackCount(StackLocation(obj, i->first), -take, false, true);
 					collected += take;
 					foundSth = true;
 					break;
@@ -5909,7 +5909,7 @@ bool CGameHandler::eraseStack(const StackLocation &sl, bool forceRemoval)
 	return true;
 }
 
-bool CGameHandler::changeStackCount(const StackLocation &sl, TQuantity count, bool absoluteValue)
+bool CGameHandler::changeStackCount(const StackLocation &sl, TQuantity count, bool absoluteValue, bool allowZeroStacksArmyResult)
 {
 	TQuantity currentCount = sl.army->getStackCount(sl.slot);
 	if ((absoluteValue && count < 0)
@@ -5921,7 +5921,7 @@ bool CGameHandler::changeStackCount(const StackLocation &sl, TQuantity count, bo
 	if ((currentCount == -count  &&  !absoluteValue)
 	   || (!count && absoluteValue))
 	{
-		eraseStack(sl);
+		eraseStack(sl, allowZeroStacksArmyResult);
 	}
 	else
 	{

--- a/server/CGameHandler.h
+++ b/server/CGameHandler.h
@@ -180,7 +180,7 @@ public:
 	void giveCreatures(const CArmedInstance *objid, const CGHeroInstance * h, const CCreatureSet &creatures, bool remove) override;
 	void takeCreatures(ObjectInstanceID objid, const std::vector<CStackBasicDescriptor> &creatures) override;
 	bool changeStackType(const StackLocation &sl, const CCreature *c) override;
-	bool changeStackCount(const StackLocation &sl, TQuantity count, bool absoluteValue = false) override;
+	bool changeStackCount(const StackLocation &sl, TQuantity count, bool absoluteValue = false, bool allowZeroStacksArmyResult = false) override;
 	bool insertNewStack(const StackLocation &sl, const CCreature *c, TQuantity count) override;
 	bool eraseStack(const StackLocation &sl, bool forceRemoval = false) override;
 	bool swapStacks(const StackLocation &sl1, const StackLocation &sl2) override;

--- a/test/mock/mock_IGameCallback.h
+++ b/test/mock/mock_IGameCallback.h
@@ -54,7 +54,7 @@ public:
 
 	void giveCreatures(const CArmedInstance *objid, const CGHeroInstance * h, const CCreatureSet &creatures, bool remove) override {}
 	void takeCreatures(ObjectInstanceID objid, const std::vector<CStackBasicDescriptor> &creatures) override {}
-	bool changeStackCount(const StackLocation &sl, TQuantity count, bool absoluteValue = false) override {return false;}
+	bool changeStackCount(const StackLocation &sl, TQuantity count, bool absoluteValue = false, bool allowZeroStacksArmyResult = true) override {return false;}
 	bool changeStackType(const StackLocation &sl, const CCreature *c) override {return false;}
 	bool insertNewStack(const StackLocation &sl, const CCreature *c, TQuantity count = -1) override {return false;} //count -1 => moves whole stack
 	bool eraseStack(const StackLocation &sl, bool forceRemoval = false) override {return false;}


### PR DESCRIPTION
Fixes #2527 

Needs design of empty army handling - for example currently there is error on every move "hero has empty army". Would be a waste to remove strict ghost army prevention for typical matches.
I suggest new gamesettings entry.