### PR TITLE
Reorganize player turn order handling on server

### DIFF
--- a/AI/Nullkiller/Analyzers/ArmyManager.cpp
+++ b/AI/Nullkiller/Analyzers/ArmyManager.cpp
@@ -225,7 +225,8 @@ std::vector<SlotInfo> ArmyManager::getBestArmy(const IBonusBearer * armyCarrier,
 
 		if(weakest->count == 1) 
 		{
-			assert(resultingArmy.size() > 1);
+			if (resultingArmy.size() == 1)
+				logAi->warn("Unexpected resulting army size!");
 
 			resultingArmy.erase(weakest);
 		}

--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -1625,15 +1625,6 @@ void CPlayerInterface::gameOver(PlayerColor player, const EVictoryLossCheckResul
 		if (GH.curInt == this)
 			GH.curInt = nullptr;
 	}
-	else
-	{
-		if (victoryLossCheckResult.loss() && cb->getPlayerStatus(playerID) == EPlayerStatus::INGAME) //enemy has lost
-		{
-			MetaString message = victoryLossCheckResult.messageToSelf;
-			message.appendLocalString(EMetaText::COLOR, player.getNum());
-			showInfoDialog(message.toString(), std::vector<std::shared_ptr<CComponent>>(1, std::make_shared<CComponent>(CComponent::flag, player.getNum(), 0)));
-		}
-	}
 }
 
 void CPlayerInterface::playerBonusChanged( const Bonus &bonus, bool gain )

--- a/client/ClientCommandManager.cpp
+++ b/client/ClientCommandManager.cpp
@@ -471,7 +471,6 @@ void ClientCommandManager::giveTurn(const PlayerColor &colorIdentifier)
 {
 	YourTurn yt;
 	yt.player = colorIdentifier;
-	yt.daysWithoutCastle = CSH->client->getPlayerState(colorIdentifier)->daysWithoutCastle;
 
 	ApplyClientNetPackVisitor visitor(*CSH->client, *CSH->client->gameState());
 	yt.visit(visitor);

--- a/client/adventureMap/AdventureMapShortcuts.cpp
+++ b/client/adventureMap/AdventureMapShortcuts.cpp
@@ -397,7 +397,7 @@ void AdventureMapShortcuts::moveHeroDirectional(const Point & direction)
 
 bool AdventureMapShortcuts::optionCanViewQuests()
 {
-	return optionInMapView() && CGI->mh->getMap()->quests.empty();
+	return optionInMapView() && !CGI->mh->getMap()->quests.empty();
 }
 
 bool AdventureMapShortcuts::optionCanToggleLevel()

--- a/client/adventureMap/AdventureMapWidget.cpp
+++ b/client/adventureMap/AdventureMapWidget.cpp
@@ -372,10 +372,14 @@ void AdventureMapWidget::setPlayerChildren(CIntObject * widget, const PlayerColo
 		auto container = dynamic_cast<CAdventureMapContainerWidget *>(entry);
 		auto icon = dynamic_cast<CAdventureMapIcon *>(entry);
 		auto button = dynamic_cast<CButton *>(entry);
+		auto resDataBar = dynamic_cast<CResDataBar *>(entry);
 		auto texture = dynamic_cast<FilledTexturePlayerColored *>(entry);
 
 		if(button)
 			button->setPlayerColor(player);
+
+		if(resDataBar)
+			resDataBar->colorize(player);
 
 		if(icon)
 			icon->setPlayer(player);

--- a/client/battle/BattleInterface.cpp
+++ b/client/battle/BattleInterface.cpp
@@ -265,7 +265,7 @@ void BattleInterface::sendCommand(BattleAction command, const CStack * actor)
 	{
 		logGlobal->trace("Setting command for %s", (actor ? actor->nodeName() : "hero"));
 		stacksController->setActiveStack(nullptr);
-		LOCPLINT->cb->battleMakeUnitAction(command);
+		curInt->cb->battleMakeUnitAction(command);
 	}
 	else
 	{

--- a/include/vcmi/events/PlayerGotTurn.h
+++ b/include/vcmi/events/PlayerGotTurn.h
@@ -29,7 +29,7 @@ public:
 	using ExecHandler = Sub::ExecHandler;
 
 	static Sub * getRegistry();
-	static void defaultExecute(const EventBus * bus, const ExecHandler & execHandler, PlayerColor & player);
+	static void defaultExecute(const EventBus * bus, PlayerColor & player);
 
 	virtual PlayerColor getPlayer() const = 0;
 	virtual void setPlayer(const PlayerColor & value) = 0;

--- a/include/vcmi/events/PlayerGotTurn.h
+++ b/include/vcmi/events/PlayerGotTurn.h
@@ -29,7 +29,7 @@ public:
 	using ExecHandler = Sub::ExecHandler;
 
 	static Sub * getRegistry();
-	static void defaultExecute(const EventBus * bus, PlayerColor & player);
+	static void defaultExecute(const EventBus * bus, const PlayerColor & player);
 
 	virtual PlayerColor getPlayer() const = 0;
 	virtual void setPlayer(const PlayerColor & value) = 0;

--- a/lib/NetPackVisitor.h
+++ b/lib/NetPackVisitor.h
@@ -27,7 +27,7 @@ public:
 	virtual void visitPlayerBlocked(PlayerBlocked & pack) {}
 	virtual void visitPlayerCheated(PlayerCheated & pack) {}
 	virtual void visitYourTurn(YourTurn & pack) {}
-	virtual void visitYourTurn(DaysWithoutTown & pack) {}
+	virtual void visitDaysWithoutTown(DaysWithoutTown & pack) {}
 	virtual void visitTurnTimeUpdate(TurnTimeUpdate & pack) {}
 	virtual void visitEntitiesChanged(EntitiesChanged & pack) {}
 	virtual void visitSetResources(SetResources & pack) {}

--- a/lib/NetPackVisitor.h
+++ b/lib/NetPackVisitor.h
@@ -27,6 +27,7 @@ public:
 	virtual void visitPlayerBlocked(PlayerBlocked & pack) {}
 	virtual void visitPlayerCheated(PlayerCheated & pack) {}
 	virtual void visitYourTurn(YourTurn & pack) {}
+	virtual void visitYourTurn(DaysWithoutTown & pack) {}
 	virtual void visitTurnTimeUpdate(TurnTimeUpdate & pack) {}
 	virtual void visitEntitiesChanged(EntitiesChanged & pack) {}
 	virtual void visitSetResources(SetResources & pack) {}

--- a/lib/NetPacks.h
+++ b/lib/NetPacks.h
@@ -167,7 +167,21 @@ struct DLL_LINKAGE YourTurn : public CPackForClient
 	void applyGs(CGameState * gs) const;
 
 	PlayerColor player;
-	std::optional<ui8> daysWithoutCastle;
+
+	virtual void visitTyped(ICPackVisitor & visitor) override;
+
+	template <typename Handler> void serialize(Handler & h, const int version)
+	{
+		h & player;
+	}
+};
+
+struct DLL_LINKAGE DaysWithoutTown : public CPackForClient
+{
+	void applyGs(CGameState * gs) const;
+
+	PlayerColor player;
+	std::optional<int32_t> daysWithoutCastle;
 
 	virtual void visitTyped(ICPackVisitor & visitor) override;
 

--- a/lib/NetPacksLib.cpp
+++ b/lib/NetPacksLib.cpp
@@ -110,7 +110,7 @@ void YourTurn::visitTyped(ICPackVisitor & visitor)
 
 void DaysWithoutTown::visitTyped(ICPackVisitor & visitor)
 {
-	visitor.visitYourTurn(*this);
+	visitor.visitDaysWithoutTown(*this);
 }
 
 void EntitiesChanged::visitTyped(ICPackVisitor & visitor)

--- a/lib/events/PlayerGotTurn.cpp
+++ b/lib/events/PlayerGotTurn.cpp
@@ -24,12 +24,11 @@ SubscriptionRegistry<PlayerGotTurn> * PlayerGotTurn::getRegistry()
 	return Instance.get();
 }
 
-void PlayerGotTurn::defaultExecute(const EventBus * bus, PlayerColor & player)
+void PlayerGotTurn::defaultExecute(const EventBus * bus, const PlayerColor & player)
 {
 	CPlayerGotTurn event;
 	event.setPlayer(player);
 	bus->executeEvent(event);
-	player = event.getPlayer();
 }
 
 CPlayerGotTurn::CPlayerGotTurn() = default;

--- a/lib/events/PlayerGotTurn.cpp
+++ b/lib/events/PlayerGotTurn.cpp
@@ -24,11 +24,11 @@ SubscriptionRegistry<PlayerGotTurn> * PlayerGotTurn::getRegistry()
 	return Instance.get();
 }
 
-void PlayerGotTurn::defaultExecute(const EventBus * bus, const ExecHandler & execHandler, PlayerColor & player)
+void PlayerGotTurn::defaultExecute(const EventBus * bus, PlayerColor & player)
 {
 	CPlayerGotTurn event;
 	event.setPlayer(player);
-	bus->executeEvent(event, execHandler);
+	bus->executeEvent(event);
 	player = event.getPlayer();
 }
 

--- a/lib/gameState/TavernHeroesPool.cpp
+++ b/lib/gameState/TavernHeroesPool.cpp
@@ -124,15 +124,6 @@ void TavernHeroesPool::onNewDay()
 		hero.second->setMovementPoints(hero.second->movementPointsLimit(true));
 		hero.second->mana = hero.second->manaLimit();
 	}
-
-	for (auto & slot : currentTavern)
-	{
-		if (slot.role == TavernSlotRole::RETREATED_TODAY)
-			slot.role = TavernSlotRole::RETREATED;
-
-		if (slot.role == TavernSlotRole::SURRENDERED_TODAY)
-			slot.role = TavernSlotRole::SURRENDERED;
-	}
 }
 
 void TavernHeroesPool::addHeroToPool(CGHeroInstance * hero)

--- a/lib/gameState/TavernSlot.h
+++ b/lib/gameState/TavernSlot.h
@@ -24,12 +24,8 @@ enum class TavernSlotRole : int8_t
 
 	SINGLE_UNIT, // hero was added after buying hero from this slot, and only has 1 creature in army
 	FULL_ARMY, // hero was added to tavern on new week and still has full army
-
 	RETREATED, // hero was owned by player before, but have retreated from battle and only has 1 creature in army
-	RETREATED_TODAY,
-
-	SURRENDERED, // hero was owned by player before, but have surrendered in battle and kept some troops
-	SURRENDERED_TODAY,
+	SURRENDERED // hero was owned by player before, but have surrendered in battle and kept some troops
 };
 
 VCMI_LIB_NAMESPACE_END

--- a/lib/registerTypes/RegisterTypes.h
+++ b/lib/registerTypes/RegisterTypes.h
@@ -232,6 +232,7 @@ void registerTypesClientPacks1(Serializer &s)
 	s.template registerType<CPackForClient, PlayerBlocked>();
 	s.template registerType<CPackForClient, PlayerCheated>();
 	s.template registerType<CPackForClient, YourTurn>();
+	s.template registerType<CPackForClient, DaysWithoutTown>();
 	s.template registerType<CPackForClient, TurnTimeUpdate>();
 	s.template registerType<CPackForClient, SetResources>();
 	s.template registerType<CPackForClient, SetPrimSkill>();

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -609,7 +609,8 @@ void CGameHandler::onPlayerTurnStarted(PlayerColor which)
 
 void CGameHandler::onPlayerTurnEnded(PlayerColor which)
 {
-
+	// 7 days without castle
+	checkVictoryLossConditionsForPlayer(which);
 }
 
 void CGameHandler::onNewTurn()
@@ -3550,7 +3551,7 @@ void CGameHandler::checkVictoryLossConditionsForPlayer(PlayerColor player)
 		// If we are called before the actual game start, there might be no current player
 		// If player making turn has lost his turn must be over as well
 		if (playerInfo && playerInfo->status != EPlayerStatus::INGAME)
-			turnOrder->onPlayerEndsTurn(gs->currentPlayer);
+			turnOrder->onPlayerEndsTurn(gs->currentPlayer, PlayerTurnEndReason::GAME_END);
 	}
 }
 

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -609,7 +609,28 @@ void CGameHandler::onPlayerTurnStarted(PlayerColor which)
 
 void CGameHandler::onPlayerTurnEnded(PlayerColor which)
 {
-	// 7 days without castle
+	const auto * playerState = gs->getPlayerState(which);
+	assert(playerState->status == EPlayerStatus::INGAME);
+
+	if (playerState->towns.empty())
+	{
+		DaysWithoutTown pack;
+		pack.player = which;
+		pack.daysWithoutCastle = playerState->daysWithoutCastle.value_or(0) + 1;
+		sendAndApply(&pack);
+	}
+	else
+	{
+		if (playerState->daysWithoutCastle.has_value())
+		{
+			DaysWithoutTown pack;
+			pack.player = which;
+			pack.daysWithoutCastle = std::nullopt;
+			sendAndApply(&pack);
+		}
+	}
+
+	// check for 7 days without castle
 	checkVictoryLossConditionsForPlayer(which);
 
 	bool newWeek = getDate(Date::DAY_OF_WEEK) == 7; // end of 7th day

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -3480,6 +3480,8 @@ void CGameHandler::checkVictoryLossConditionsForPlayer(PlayerColor player)
 		peg.victoryLossCheckResult = victoryLossCheckResult;
 		sendAndApply(&peg);
 
+		turnOrder->onPlayerEndsGame(player);
+
 		if (victoryLossCheckResult.victory())
 		{
 			//one player won -> all enemies lost
@@ -3545,13 +3547,6 @@ void CGameHandler::checkVictoryLossConditionsForPlayer(PlayerColor player)
 			}
 			checkVictoryLossConditions(playerColors);
 		}
-
-		auto playerInfo = getPlayerState(gs->currentPlayer, false);
-
-		// If we are called before the actual game start, there might be no current player
-		// If player making turn has lost his turn must be over as well
-		if (playerInfo && playerInfo->status != EPlayerStatus::INGAME)
-			turnOrder->onPlayerEndsTurn(gs->currentPlayer, PlayerTurnEndReason::GAME_END);
 	}
 }
 

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -947,6 +947,9 @@ void CGameHandler::onNewTurn()
 		}
 	}
 
+	if (!firstTurn)
+		checkVictoryLossConditionsForAll(); // check for map turn limit
+
 	logGlobal->trace("Info about turn %d has been sent!", n.day);
 	handleTimeEvents();
 	//call objects

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -611,6 +611,11 @@ void CGameHandler::onPlayerTurnEnded(PlayerColor which)
 {
 	// 7 days without castle
 	checkVictoryLossConditionsForPlayer(which);
+
+	bool newWeek = getDate(Date::DAY_OF_WEEK) == 7; // end of 7th day
+
+	if (newWeek) //new heroes in tavern
+		heroPool->onNewWeek(which);
 }
 
 void CGameHandler::onNewTurn()
@@ -702,13 +707,13 @@ void CGameHandler::onNewTurn()
 	{
 		if (elem.first == PlayerColor::NEUTRAL)
 			continue;
-		else if (elem.first >= PlayerColor::PLAYER_LIMIT)
-			assert(0); //illegal player number!
+
+		assert(elem.first.isValidPlayer());//illegal player number!
 
 		std::pair<PlayerColor, si32> playerGold(elem.first, elem.second.resources[EGameResID::GOLD]);
 		hadGold.insert(playerGold);
 
-		if (newWeek) //new heroes in tavern
+		if (firstTurn)
 			heroPool->onNewWeek(elem.first);
 
 		n.res[elem.first] = elem.second.resources;

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -13,6 +13,7 @@ set(server_SRCS
 
 		processors/HeroPoolProcessor.cpp
 		processors/PlayerMessageProcessor.cpp
+		processors/TurnOrderProcessor.cpp
 
 		CGameHandler.cpp
 		ServerSpellCastEnvironment.cpp
@@ -37,6 +38,7 @@ set(server_HEADERS
 
 		processors/HeroPoolProcessor.h
 		processors/PlayerMessageProcessor.h
+		processors/TurnOrderProcessor.h
 
 		CGameHandler.h
 		ServerSpellCastEnvironment.h

--- a/server/CVCMIServer.cpp
+++ b/server/CVCMIServer.cpp
@@ -158,6 +158,16 @@ CVCMIServer::~CVCMIServer()
 		announceLobbyThread->join();
 }
 
+void CVCMIServer::setState(EServerState value)
+{
+	state.store(value);
+}
+
+EServerState CVCMIServer::getState() const
+{
+	return state.load();
+}
+
 void CVCMIServer::run()
 {
 	if(!restartGameplay)
@@ -1159,7 +1169,7 @@ int main(int argc, const char * argv[])
 
 		try
 		{
-			while(server.state != EServerState::SHUTDOWN)
+			while(server.getState() != EServerState::SHUTDOWN)
 			{
 				server.run();
 			}
@@ -1168,7 +1178,7 @@ int main(int argc, const char * argv[])
 		catch(boost::system::system_error & e) //for boost errors just log, not crash - probably client shut down connection
 		{
 			logNetwork->error(e.what());
-			server.state = EServerState::SHUTDOWN;
+			server.setState(EServerState::SHUTDOWN);
 		}
 	}
 	catch(boost::system::system_error & e)

--- a/server/CVCMIServer.h
+++ b/server/CVCMIServer.h
@@ -56,10 +56,10 @@ class CVCMIServer : public LobbyInfo
 	boost::recursive_mutex mx;
 	std::shared_ptr<CApplier<CBaseForServerApply>> applier;
 	std::unique_ptr<boost::thread> announceLobbyThread, remoteConnectionsThread;
+	std::atomic<EServerState> state;
 
 public:
 	std::shared_ptr<CGameHandler> gh;
-	std::atomic<EServerState> state;
 	ui16 port;
 
 	boost::program_options::variables_map cmdLineOptions;
@@ -100,6 +100,9 @@ public:
 	void reconnectPlayer(int connId);
 
 	void updateAndPropagateLobbyState();
+
+	void setState(EServerState value);
+	EServerState getState() const;
 
 	// Work with LobbyInfo
 	void setPlayer(PlayerColor clickedColor);

--- a/server/NetPacksLobbyServer.cpp
+++ b/server/NetPacksLobbyServer.cpp
@@ -53,11 +53,11 @@ void ClientPermissionsCheckerNetPackVisitor::visitLobbyClientConnected(LobbyClie
 		}
 	}
 	
-	if(srv.state == EServerState::LOBBY)
-		{
+	if(srv.getState() == EServerState::LOBBY)
+	{
 		result = true;
 		return;
-		}
+	}
 	
 	//disconnect immediately and ignore this client
 	srv.connections.erase(pack.c);
@@ -115,7 +115,7 @@ void ApplyOnServerAfterAnnounceNetPackVisitor::visitLobbyClientConnected(LobbyCl
 	// Until UUID set we only pass LobbyClientConnected to this client
 	pack.c->uuid = pack.uuid;
 	srv.updateAndPropagateLobbyState();
-	if(srv.state == EServerState::GAMEPLAY)
+	if(srv.getState() == EServerState::GAMEPLAY)
 	{
 		//immediately start game
 		std::unique_ptr<LobbyStartGame> startGameForReconnectedPlayer(new LobbyStartGame);
@@ -173,13 +173,13 @@ void ApplyOnServerAfterAnnounceNetPackVisitor::visitLobbyClientDisconnected(Lobb
 	if(pack.shutdownServer)
 	{
 		logNetwork->info("Client requested shutdown, server will close itself...");
-		srv.state = EServerState::SHUTDOWN;
+		srv.setState(EServerState::SHUTDOWN);
 		return;
 	}
 	else if(srv.connections.empty())
 	{
 		logNetwork->error("Last connection lost, server will close itself...");
-		srv.state = EServerState::SHUTDOWN;
+		srv.setState(EServerState::SHUTDOWN);
 	}
 	else if(pack.c == srv.hostClient)
 	{
@@ -198,7 +198,7 @@ void ClientPermissionsCheckerNetPackVisitor::visitLobbyChatMessage(LobbyChatMess
 
 void ApplyOnServerNetPackVisitor::visitLobbySetMap(LobbySetMap & pack)
 {
-	if(srv.state != EServerState::LOBBY)
+	if(srv.getState() != EServerState::LOBBY)
 	{
 		result = false;
 		return;
@@ -300,7 +300,7 @@ void ApplyOnServerNetPackVisitor::visitLobbyStartGame(LobbyStartGame & pack)
 	pack.initializedStartInfo = std::make_shared<StartInfo>(*srv.gh->getStartInfo(true));
 	pack.initializedGameState = srv.gh->gameState();
 
-	srv.state = EServerState::GAMEPLAY_STARTING;
+	srv.setState(EServerState::GAMEPLAY_STARTING);
 	result = true;
 }
 

--- a/server/NetPacksServer.cpp
+++ b/server/NetPacksServer.cpp
@@ -40,7 +40,7 @@ void ApplyGhNetPackVisitor::visitEndTurn(EndTurn & pack)
 	if (!gh.hasPlayerAt(pack.player, pack.c))
 		gh.throwAndComplain(&pack, "No such pack.player!");
 
-	result = gh.turnOrder->onPlayerEndsTurn(pack.player);
+	result = gh.turnOrder->onPlayerEndsTurn(pack.player, PlayerTurnEndReason::CLIENT_REQUEST);
 }
 
 void ApplyGhNetPackVisitor::visitDismissHero(DismissHero & pack)

--- a/server/NetPacksServer.cpp
+++ b/server/NetPacksServer.cpp
@@ -40,7 +40,7 @@ void ApplyGhNetPackVisitor::visitEndTurn(EndTurn & pack)
 	if (!gh.hasPlayerAt(pack.player, pack.c))
 		gh.throwAndComplain(&pack, "No such pack.player!");
 
-	result = gh.turnOrder->onPlayerEndsTurn(pack.player, PlayerTurnEndReason::CLIENT_REQUEST);
+	result = gh.turnOrder->onPlayerEndsTurn(pack.player);
 }
 
 void ApplyGhNetPackVisitor::visitDismissHero(DismissHero & pack)

--- a/server/ServerNetPackVisitors.h
+++ b/server/ServerNetPackVisitors.h
@@ -16,11 +16,10 @@ class ApplyGhNetPackVisitor : public VCMI_LIB_WRAP_NAMESPACE(ICPackVisitor)
 private:
 	bool result;
 	CGameHandler & gh;
-	CGameState & gs;
 
 public:
-	ApplyGhNetPackVisitor(CGameHandler & gh, CGameState & gs)
-		:gh(gh), gs(gs), result(false)
+	ApplyGhNetPackVisitor(CGameHandler & gh)
+		:gh(gh), result(false)
 	{
 	}
 

--- a/server/TurnTimerHandler.cpp
+++ b/server/TurnTimerHandler.cpp
@@ -84,7 +84,7 @@ void TurnTimerHandler::onPlayerMakingTurn(PlayerState & state, int waitTime)
 			state.turnTimer.baseTimer = 0;
 			onPlayerMakingTurn(state, waitTime);
 		}
-		else if(!gameHandler.queries->topQuery(state.color))
+		else if(!gameHandler.queries->topQuery(state.color)) //wait for replies to avoid pending queries
 			gameHandler.turnOrder->onPlayerEndsTurn(state.color);
 	}
 }

--- a/server/TurnTimerHandler.cpp
+++ b/server/TurnTimerHandler.cpp
@@ -85,7 +85,7 @@ void TurnTimerHandler::onPlayerMakingTurn(PlayerState & state, int waitTime)
 			onPlayerMakingTurn(state, waitTime);
 		}
 		else if(!gameHandler.queries->topQuery(state.color))
-			gameHandler.turnOrder->onPlayerEndsTurn(state.color);
+			gameHandler.turnOrder->onPlayerEndsTurn(state.color, PlayerTurnEndReason::TURN_TIMEOUT);
 	}
 }
 

--- a/server/TurnTimerHandler.cpp
+++ b/server/TurnTimerHandler.cpp
@@ -12,6 +12,7 @@
 #include "CGameHandler.h"
 #include "battles/BattleProcessor.h"
 #include "queries/QueriesProcessor.h"
+#include "processors/TurnOrderProcessor.h"
 #include "../lib/battle/BattleInfo.h"
 #include "../lib/gameState/CGameState.h"
 #include "../lib/CPlayerState.h"
@@ -83,8 +84,8 @@ void TurnTimerHandler::onPlayerMakingTurn(PlayerState & state, int waitTime)
 			state.turnTimer.baseTimer = 0;
 			onPlayerMakingTurn(state, waitTime);
 		}
-		else if(!gameHandler.queries->topQuery(state.color)) //wait for replies to avoid pending queries
-			gameHandler.states.players.at(state.color).makingTurn = false; //force end turn
+		else if(!gameHandler.queries->topQuery(state.color))
+			gameHandler.turnOrder->onPlayerEndsTurn(state.color);
 	}
 }
 

--- a/server/TurnTimerHandler.cpp
+++ b/server/TurnTimerHandler.cpp
@@ -85,7 +85,7 @@ void TurnTimerHandler::onPlayerMakingTurn(PlayerState & state, int waitTime)
 			onPlayerMakingTurn(state, waitTime);
 		}
 		else if(!gameHandler.queries->topQuery(state.color))
-			gameHandler.turnOrder->onPlayerEndsTurn(state.color, PlayerTurnEndReason::TURN_TIMEOUT);
+			gameHandler.turnOrder->onPlayerEndsTurn(state.color);
 	}
 }
 

--- a/server/battles/BattleActionProcessor.cpp
+++ b/server/battles/BattleActionProcessor.cpp
@@ -499,6 +499,7 @@ bool BattleActionProcessor::dispatchBattleAction(const BattleAction & ba)
 {
 	switch(ba.actionType)
 	{
+		case EActionType::BAD_MORALE:
 		case EActionType::NO_ACTION:
 			return doEmptyAction(ba);
 		case EActionType::END_TACTIC_PHASE:

--- a/server/battles/BattleFlowProcessor.cpp
+++ b/server/battles/BattleFlowProcessor.cpp
@@ -286,7 +286,6 @@ const CStack * BattleFlowProcessor::getNextStack()
 
 void BattleFlowProcessor::activateNextStack()
 {
-	//TODO: activate next round if next == nullptr
 	const auto & curB = *gameHandler->gameState()->curB;
 
 	// Find next stack that requires manual control

--- a/server/battles/BattleProcessor.cpp
+++ b/server/battles/BattleProcessor.cpp
@@ -219,7 +219,7 @@ void BattleProcessor::updateGateState()
 bool BattleProcessor::makePlayerBattleAction(PlayerColor player, const BattleAction &ba)
 {
 	bool result = actionsProcessor->makePlayerBattleAction(player, ba);
-	if (!resultProcessor->battleIsEnding())
+	if (!resultProcessor->battleIsEnding() && gameHandler->gameState()->curB != nullptr)
 		flowProcessor->onActionMade(ba);
 	return result;
 }

--- a/server/battles/BattleProcessor.cpp
+++ b/server/battles/BattleProcessor.cpp
@@ -219,7 +219,8 @@ void BattleProcessor::updateGateState()
 bool BattleProcessor::makePlayerBattleAction(PlayerColor player, const BattleAction &ba)
 {
 	bool result = actionsProcessor->makePlayerBattleAction(player, ba);
-	flowProcessor->onActionMade(ba);
+	if (!resultProcessor->battleIsEnding())
+		flowProcessor->onActionMade(ba);
 	return result;
 }
 

--- a/server/processors/HeroPoolProcessor.cpp
+++ b/server/processors/HeroPoolProcessor.cpp
@@ -10,6 +10,7 @@
 #include "StdInc.h"
 #include "HeroPoolProcessor.h"
 
+#include "TurnOrderProcessor.h"
 #include "../CGameHandler.h"
 
 #include "../../lib/CHeroHandler.h"
@@ -30,29 +31,6 @@ HeroPoolProcessor::HeroPoolProcessor()
 HeroPoolProcessor::HeroPoolProcessor(CGameHandler * gameHandler)
 	: gameHandler(gameHandler)
 {
-}
-
-bool HeroPoolProcessor::playerEndedTurn(const PlayerColor & player)
-{
-	// our player is acting right now and have not ended turn
-	if (player == gameHandler->gameState()->currentPlayer)
-		return false;
-
-	auto turnOrder = gameHandler->generatePlayerTurnOrder();
-
-	for (auto const & entry : turnOrder)
-	{
-		// our player is yet to start turn
-		if (entry == gameHandler->gameState()->currentPlayer)
-			return false;
-
-		// our player have finished turn
-		if (entry == player)
-			return true;
-	}
-
-	assert(false);
-	return false;
 }
 
 TavernHeroSlot HeroPoolProcessor::selectSlotForRole(const PlayerColor & player, TavernSlotRole roleID)
@@ -90,7 +68,7 @@ TavernHeroSlot HeroPoolProcessor::selectSlotForRole(const PlayerColor & player, 
 void HeroPoolProcessor::onHeroSurrendered(const PlayerColor & color, const CGHeroInstance * hero)
 {
 	SetAvailableHero sah;
-	if (playerEndedTurn(color))
+	if (gameHandler->turnOrder->playerAwaitsNewDay(color))
 		sah.roleID = TavernSlotRole::SURRENDERED_TODAY;
 	else
 		sah.roleID = TavernSlotRole::SURRENDERED;
@@ -104,7 +82,7 @@ void HeroPoolProcessor::onHeroSurrendered(const PlayerColor & color, const CGHer
 void HeroPoolProcessor::onHeroEscaped(const PlayerColor & color, const CGHeroInstance * hero)
 {
 	SetAvailableHero sah;
-	if (playerEndedTurn(color))
+	if (gameHandler->turnOrder->playerAwaitsNewDay(color))
 		sah.roleID = TavernSlotRole::RETREATED_TODAY;
 	else
 		sah.roleID = TavernSlotRole::RETREATED;

--- a/server/processors/HeroPoolProcessor.cpp
+++ b/server/processors/HeroPoolProcessor.cpp
@@ -68,10 +68,7 @@ TavernHeroSlot HeroPoolProcessor::selectSlotForRole(const PlayerColor & player, 
 void HeroPoolProcessor::onHeroSurrendered(const PlayerColor & color, const CGHeroInstance * hero)
 {
 	SetAvailableHero sah;
-	if (gameHandler->turnOrder->playerAwaitsNewDay(color))
-		sah.roleID = TavernSlotRole::SURRENDERED_TODAY;
-	else
-		sah.roleID = TavernSlotRole::SURRENDERED;
+	sah.roleID = TavernSlotRole::SURRENDERED;
 
 	sah.slotID = selectSlotForRole(color, sah.roleID);
 	sah.player = color;
@@ -82,10 +79,7 @@ void HeroPoolProcessor::onHeroSurrendered(const PlayerColor & color, const CGHer
 void HeroPoolProcessor::onHeroEscaped(const PlayerColor & color, const CGHeroInstance * hero)
 {
 	SetAvailableHero sah;
-	if (gameHandler->turnOrder->playerAwaitsNewDay(color))
-		sah.roleID = TavernSlotRole::RETREATED_TODAY;
-	else
-		sah.roleID = TavernSlotRole::RETREATED;
+	sah.roleID = TavernSlotRole::RETREATED;
 
 	sah.slotID = selectSlotForRole(color, sah.roleID);
 	sah.player = color;
@@ -139,26 +133,10 @@ void HeroPoolProcessor::selectNewHeroForSlot(const PlayerColor & color, TavernHe
 
 void HeroPoolProcessor::onNewWeek(const PlayerColor & color)
 {
-	const auto & heroesPool = gameHandler->gameState()->heroesPool;
-	const auto & heroes = heroesPool->getHeroesFor(color);
-
-	const auto nativeSlotRole = heroes.size() < 1 ? TavernSlotRole::NONE : heroesPool->getSlotRole(heroes[0]->type->getId());
-	const auto randomSlotRole = heroes.size() < 2 ? TavernSlotRole::NONE : heroesPool->getSlotRole(heroes[1]->type->getId());
-
-	bool resetNativeSlot = nativeSlotRole != TavernSlotRole::RETREATED_TODAY && nativeSlotRole != TavernSlotRole::SURRENDERED_TODAY;
-	bool resetRandomSlot = randomSlotRole != TavernSlotRole::RETREATED_TODAY && randomSlotRole != TavernSlotRole::SURRENDERED_TODAY;
-
-	if (resetNativeSlot)
-		clearHeroFromSlot(color, TavernHeroSlot::NATIVE);
-
-	if (resetRandomSlot)
-		clearHeroFromSlot(color, TavernHeroSlot::RANDOM);
-
-	if (resetNativeSlot)
-		selectNewHeroForSlot(color, TavernHeroSlot::NATIVE, true, true);
-
-	if (resetRandomSlot)
-		selectNewHeroForSlot(color, TavernHeroSlot::RANDOM, false, true);
+	clearHeroFromSlot(color, TavernHeroSlot::NATIVE);
+	clearHeroFromSlot(color, TavernHeroSlot::RANDOM);
+	selectNewHeroForSlot(color, TavernHeroSlot::NATIVE, true, true);
+	selectNewHeroForSlot(color, TavernHeroSlot::RANDOM, false, true);
 }
 
 bool HeroPoolProcessor::hireHero(const ObjectInstanceID & objectID, const HeroTypeID & heroToRecruit, const PlayerColor & player)

--- a/server/processors/HeroPoolProcessor.h
+++ b/server/processors/HeroPoolProcessor.h
@@ -43,7 +43,6 @@ class HeroPoolProcessor : boost::noncopyable
 
 	TavernHeroSlot selectSlotForRole(const PlayerColor & player, TavernSlotRole roleID);
 
-	bool playerEndedTurn(const PlayerColor & player);
 public:
 	CGameHandler * gameHandler;
 

--- a/server/processors/PlayerMessageProcessor.cpp
+++ b/server/processors/PlayerMessageProcessor.cpp
@@ -71,7 +71,7 @@ bool PlayerMessageProcessor::handleHostCommand(PlayerColor player, const std::st
 	if(words[1] == "exit" || words[1] == "quit" || words[1] == "end")
 	{
 		broadcastSystemMessage("game was terminated");
-		gameHandler->gameLobby()->state = EServerState::SHUTDOWN;
+		gameHandler->gameLobby()->setState(EServerState::SHUTDOWN);
 
 		return true;
 	}

--- a/server/processors/TurnOrderProcessor.cpp
+++ b/server/processors/TurnOrderProcessor.cpp
@@ -100,8 +100,6 @@ void TurnOrderProcessor::doStartPlayerTurn(PlayerColor which)
 
 	YourTurn yt;
 	yt.player = which;
-	//Change local daysWithoutCastle counter for local interface message //TODO: needed?
-	yt.daysWithoutCastle = gameHandler->getPlayerState(which)->daysWithoutCastle;
 	gameHandler->sendAndApply(&yt);
 
 	assert(actingPlayers.size() == 1); // No simturns yet :(
@@ -111,6 +109,7 @@ void TurnOrderProcessor::doStartPlayerTurn(PlayerColor which)
 void TurnOrderProcessor::doEndPlayerTurn(PlayerColor which)
 {
 	assert(playerMakingTurn(which));
+	assert(gameHandler->getPlayerStatus(which) == EPlayerStatus::INGAME);
 
 	actingPlayers.erase(which);
 	actedPlayers.insert(which);
@@ -170,7 +169,10 @@ bool TurnOrderProcessor::onPlayerEndsTurn(PlayerColor which)
 
 	gameHandler->onPlayerTurnEnded(which);
 
-	doEndPlayerTurn(which);
+	// it is possible that player have lost - e.g. spent 7 days without town
+	// in this case - don't call doEndPlayerTurn - turn transfer was already handled by onPlayerEndsGame
+	if(gameHandler->getPlayerStatus(which) == EPlayerStatus::INGAME)
+		doEndPlayerTurn(which);
 
 	return true;
 }

--- a/server/processors/TurnOrderProcessor.cpp
+++ b/server/processors/TurnOrderProcessor.cpp
@@ -108,7 +108,7 @@ void TurnOrderProcessor::doStartPlayerTurn(PlayerColor which)
 
 void TurnOrderProcessor::doEndPlayerTurn(PlayerColor which)
 {
-	assert(playerMakingTurn(which));
+	assert(isPlayerMakingTurn(which));
 	assert(gameHandler->getPlayerStatus(which) == EPlayerStatus::INGAME);
 
 	actingPlayers.erase(which);
@@ -149,7 +149,7 @@ void TurnOrderProcessor::onPlayerEndsGame(PlayerColor which)
 
 bool TurnOrderProcessor::onPlayerEndsTurn(PlayerColor which)
 {
-	if (!playerMakingTurn(which))
+	if (!isPlayerMakingTurn(which))
 	{
 		gameHandler->complain("Can not end turn for player that is not acting!");
 		return false;
@@ -197,17 +197,17 @@ void TurnOrderProcessor::tryStartTurnsForPlayers()
 	}
 }
 
-bool TurnOrderProcessor::playerAwaitsTurn(PlayerColor which) const
+bool TurnOrderProcessor::isPlayerAwaitsTurn(PlayerColor which) const
 {
 	return vstd::contains(awaitingPlayers, which);
 }
 
-bool TurnOrderProcessor::playerMakingTurn(PlayerColor which) const
+bool TurnOrderProcessor::isPlayerMakingTurn(PlayerColor which) const
 {
 	return vstd::contains(actingPlayers, which);
 }
 
-bool TurnOrderProcessor::playerAwaitsNewDay(PlayerColor which) const
+bool TurnOrderProcessor::isPlayerAwaitsNewDay(PlayerColor which) const
 {
 	return vstd::contains(actedPlayers, which);
 }

--- a/server/processors/TurnOrderProcessor.cpp
+++ b/server/processors/TurnOrderProcessor.cpp
@@ -1,0 +1,183 @@
+/*
+ * TurnOrderProcessor.cpp, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
+#include "StdInc.h"
+#include "TurnOrderProcessor.h"
+
+#include "../queries/QueriesProcessor.h"
+#include "../CGameHandler.h"
+#include "../CVCMIServer.h"
+
+#include "../../lib/CPlayerState.h"
+#include "../../lib/NetPacks.h"
+
+TurnOrderProcessor::TurnOrderProcessor(CGameHandler * owner):
+	gameHandler(owner)
+{
+
+}
+
+bool TurnOrderProcessor::canActSimultaneously(PlayerColor active, PlayerColor waiting) const
+{
+	return false;
+}
+
+bool TurnOrderProcessor::mustActBefore(PlayerColor left, PlayerColor right) const
+{
+	const auto * leftInfo = gameHandler->getPlayerState(left, false);
+	const auto * rightInfo = gameHandler->getPlayerState(right, false);
+
+	assert(left != right);
+	assert(leftInfo && rightInfo);
+
+	if (!leftInfo)
+		return false;
+	if (!rightInfo)
+		return true;
+
+	if (leftInfo->isHuman() && !rightInfo->isHuman())
+		return true;
+
+	if (!leftInfo->isHuman() && rightInfo->isHuman())
+		return false;
+
+	return left < right;
+}
+
+bool TurnOrderProcessor::canStartTurn(PlayerColor which) const
+{
+	for (auto player : awaitingPlayers)
+	{
+		if (mustActBefore(player, which))
+			return false;
+	}
+
+	for (auto player : actingPlayers)
+	{
+		if (!canActSimultaneously(player, which))
+			return false;
+	}
+
+	return true;
+}
+
+void TurnOrderProcessor::doStartNewDay()
+{
+	assert(awaitingPlayers.empty());
+	assert(actingPlayers.empty());
+
+	bool activePlayer = false;
+	for (auto player : actedPlayers)
+	{
+		if (gameHandler->getPlayerState(player)->status == EPlayerStatus::INGAME)
+			activePlayer = true;
+	}
+
+	if(!activePlayer)
+		gameHandler->gameLobby()->setState(EServerState::GAMEPLAY_ENDED);
+
+	std::swap(actedPlayers, awaitingPlayers);
+}
+
+void TurnOrderProcessor::doStartPlayerTurn(PlayerColor which)
+{
+	//if player runs out of time, he shouldn't get the turn (especially AI)
+	//pre-trigger may change anything, should check before each player
+	//TODO: is it enough to check only one player?
+	gameHandler->checkVictoryLossConditionsForAll();
+
+	assert(gameHandler->getPlayerState(which));
+	assert(gameHandler->getPlayerState(which)->status == EPlayerStatus::INGAME);
+
+	gameHandler->onPlayerTurnStarted(which);
+
+	YourTurn yt;
+	yt.player = which;
+	//Change local daysWithoutCastle counter for local interface message //TODO: needed?
+	yt.daysWithoutCastle = gameHandler->getPlayerState(which)->daysWithoutCastle;
+	gameHandler->sendAndApply(&yt);
+}
+
+void TurnOrderProcessor::doEndPlayerTurn(PlayerColor which)
+{
+	assert(playerMakingTurn(which));
+
+	actingPlayers.erase(which);
+	actedPlayers.insert(which);
+
+	if (!awaitingPlayers.empty())
+		tryStartTurnsForPlayers();
+
+	if (actingPlayers.empty())
+		doStartNewDay();
+}
+
+void TurnOrderProcessor::addPlayer(PlayerColor which)
+{
+	awaitingPlayers.insert(which);
+}
+
+bool TurnOrderProcessor::onPlayerEndsTurn(PlayerColor which)
+{
+	if (!playerMakingTurn(which))
+	{
+		gameHandler->complain("Can not end turn for player that is not acting!");
+		return false;
+	}
+
+	if(gameHandler->getPlayerStatus(which) != EPlayerStatus::INGAME)
+	{
+		gameHandler->complain("Can not end turn for player that is not in game!");
+		return false;
+	}
+
+	if(gameHandler->queries->topQuery(which) != nullptr)
+	{
+		gameHandler->complain("Cannot end turn before resolving queries!");
+		return false;
+	}
+
+	doEndPlayerTurn(which);
+	return true;
+}
+
+void TurnOrderProcessor::onGameStarted()
+{
+	tryStartTurnsForPlayers();
+
+	// this may be game load - send notification to players that they can act
+	auto actingPlayersCopy = actingPlayers;
+	for (auto player : actingPlayersCopy)
+		doStartPlayerTurn(player);
+}
+
+void TurnOrderProcessor::tryStartTurnsForPlayers()
+{
+	auto awaitingPlayersCopy = awaitingPlayers;
+	for (auto player : awaitingPlayersCopy)
+	{
+		if (canStartTurn(player))
+			doStartPlayerTurn(player);
+	}
+}
+
+bool TurnOrderProcessor::playerAwaitsTurn(PlayerColor which) const
+{
+	return vstd::contains(awaitingPlayers, which);
+}
+
+bool TurnOrderProcessor::playerMakingTurn(PlayerColor which) const
+{
+	return vstd::contains(actingPlayers, which);
+}
+
+bool TurnOrderProcessor::playerAwaitsNewDay(PlayerColor which) const
+{
+	return vstd::contains(actedPlayers, which);
+}

--- a/server/processors/TurnOrderProcessor.h
+++ b/server/processors/TurnOrderProcessor.h
@@ -13,13 +13,6 @@
 
 class CGameHandler;
 
-enum class PlayerTurnEndReason
-{
-	CLIENT_REQUEST, // client requested end of turn (e.g. press End Turn button)
-	TURN_TIMEOUT, // Player's turn timer has run out
-	GAME_END // Player have won or lost the game
-};
-
 class TurnOrderProcessor : boost::noncopyable
 {
 	CGameHandler * gameHandler;
@@ -42,7 +35,7 @@ class TurnOrderProcessor : boost::noncopyable
 
 	void doStartNewDay();
 	void doStartPlayerTurn(PlayerColor which);
-	void doEndPlayerTurn(PlayerColor which, PlayerTurnEndReason reason);
+	void doEndPlayerTurn(PlayerColor which);
 
 public:
 	TurnOrderProcessor(CGameHandler * owner);
@@ -51,7 +44,9 @@ public:
 	void addPlayer(PlayerColor which);
 
 	/// NetPack call-in
-	bool onPlayerEndsTurn(PlayerColor which, PlayerTurnEndReason reason);
+	bool onPlayerEndsTurn(PlayerColor which);
+
+	void onPlayerEndsGame(PlayerColor which);
 
 	/// Start game (or resume from save) and send YourTurn pack to player(s)
 	void onGameStarted();

--- a/server/processors/TurnOrderProcessor.h
+++ b/server/processors/TurnOrderProcessor.h
@@ -1,0 +1,67 @@
+/*
+ * TurnOrderProcessor.h, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
+#pragma once
+
+#include "../../lib/GameConstants.h"
+
+class CGameHandler;
+
+class TurnOrderProcessor : boost::noncopyable
+{
+	CGameHandler * gameHandler;
+
+	std::set<PlayerColor> awaitingPlayers;
+	std::set<PlayerColor> actingPlayers;
+	std::set<PlayerColor> actedPlayers;
+
+	/// Returns true if waiting player can act alongside with currently acting player
+	bool canActSimultaneously(PlayerColor active, PlayerColor waiting) const;
+
+	/// Returns true if left player must act before right player
+	bool mustActBefore(PlayerColor left, PlayerColor right) const;
+
+	/// Returns true if player is ready to start turn
+	bool canStartTurn(PlayerColor which) const;
+
+	/// Starts turn for all players that can start turn
+	void tryStartTurnsForPlayers();
+
+	void doStartNewDay();
+	void doStartPlayerTurn(PlayerColor which);
+	void doEndPlayerTurn(PlayerColor which);
+
+public:
+	TurnOrderProcessor(CGameHandler * owner);
+
+	/// Add new player to handle (e.g. on game start)
+	void addPlayer(PlayerColor which);
+
+	/// NetPack call-in
+	bool onPlayerEndsTurn(PlayerColor which);
+
+	/// Start game (or resume from save) and send YourTurn pack to player(s)
+	void onGameStarted();
+
+	/// Returns true if player turn has not started today
+	bool playerAwaitsTurn(PlayerColor which) const;
+
+	/// Returns true if player is currently making his turn
+	bool playerMakingTurn(PlayerColor which) const;
+
+	/// Returns true if player has finished his turn and is waiting for new day
+	bool playerAwaitsNewDay(PlayerColor which) const;
+
+	template <typename Handler> void serialize(Handler &h, const int version)
+	{
+		h & awaitingPlayers;
+		h & actingPlayers;
+		h & actedPlayers;
+	}
+};

--- a/server/processors/TurnOrderProcessor.h
+++ b/server/processors/TurnOrderProcessor.h
@@ -37,9 +37,9 @@ class TurnOrderProcessor : boost::noncopyable
 	void doStartPlayerTurn(PlayerColor which);
 	void doEndPlayerTurn(PlayerColor which);
 
-	bool playerAwaitsTurn(PlayerColor which) const;
-	bool playerMakingTurn(PlayerColor which) const;
-	bool playerAwaitsNewDay(PlayerColor which) const;
+	bool isPlayerAwaitsTurn(PlayerColor which) const;
+	bool isPlayerMakingTurn(PlayerColor which) const;
+	bool isPlayerAwaitsNewDay(PlayerColor which) const;
 
 public:
 	TurnOrderProcessor(CGameHandler * owner);

--- a/server/processors/TurnOrderProcessor.h
+++ b/server/processors/TurnOrderProcessor.h
@@ -37,6 +37,10 @@ class TurnOrderProcessor : boost::noncopyable
 	void doStartPlayerTurn(PlayerColor which);
 	void doEndPlayerTurn(PlayerColor which);
 
+	bool playerAwaitsTurn(PlayerColor which) const;
+	bool playerMakingTurn(PlayerColor which) const;
+	bool playerAwaitsNewDay(PlayerColor which) const;
+
 public:
 	TurnOrderProcessor(CGameHandler * owner);
 
@@ -46,21 +50,14 @@ public:
 	/// NetPack call-in
 	bool onPlayerEndsTurn(PlayerColor which);
 
+	/// Ends player turn and removes this player from turn order
 	void onPlayerEndsGame(PlayerColor which);
 
 	/// Start game (or resume from save) and send YourTurn pack to player(s)
 	void onGameStarted();
 
-	/// Returns true if player turn has not started today
-	bool playerAwaitsTurn(PlayerColor which) const;
-
-	/// Returns true if player is currently making his turn
-	bool playerMakingTurn(PlayerColor which) const;
-
-	/// Returns true if player has finished his turn and is waiting for new day
-	bool playerAwaitsNewDay(PlayerColor which) const;
-
-	template <typename Handler> void serialize(Handler &h, const int version)
+	template<typename Handler>
+	void serialize(Handler & h, const int version)
 	{
 		h & awaitingPlayers;
 		h & actingPlayers;

--- a/server/processors/TurnOrderProcessor.h
+++ b/server/processors/TurnOrderProcessor.h
@@ -13,6 +13,13 @@
 
 class CGameHandler;
 
+enum class PlayerTurnEndReason
+{
+	CLIENT_REQUEST, // client requested end of turn (e.g. press End Turn button)
+	TURN_TIMEOUT, // Player's turn timer has run out
+	GAME_END // Player have won or lost the game
+};
+
 class TurnOrderProcessor : boost::noncopyable
 {
 	CGameHandler * gameHandler;
@@ -35,7 +42,7 @@ class TurnOrderProcessor : boost::noncopyable
 
 	void doStartNewDay();
 	void doStartPlayerTurn(PlayerColor which);
-	void doEndPlayerTurn(PlayerColor which);
+	void doEndPlayerTurn(PlayerColor which, PlayerTurnEndReason reason);
 
 public:
 	TurnOrderProcessor(CGameHandler * owner);
@@ -44,7 +51,7 @@ public:
 	void addPlayer(PlayerColor which);
 
 	/// NetPack call-in
-	bool onPlayerEndsTurn(PlayerColor which);
+	bool onPlayerEndsTurn(PlayerColor which, PlayerTurnEndReason reason);
 
 	/// Start game (or resume from save) and send YourTurn pack to player(s)
 	void onGameStarted();


### PR DESCRIPTION
First step for simturns support out of many:
- Moved logic related to player turn order out of GameHandler into a new class.
- Reorganized server-side logic to allow potential support for multiple acting players
- Tavern will now be updated immediately when player ends turn on 7th day (to simplify logic for 7th day retreat)
- Fixes #2662 
- Fixes #2609
- Fixes #2564
- Fixes #2539
- Fixes incorrect infobox message (%s placeholder not replaced) on defeating player

TODO:
- [x] Test turn order (single-player)
- [x] Test turn order (hot-seat)
- [x] Check human player defeating (single-player)
- [x] Check human player defeating (hotseat)
- [x] Check AI player defeating
- [x] Check "7 days without castle" loss condition
- [x] Check maps with turn limit
- [x] Refresh tavern when player ends turn (and remove 7th day workaround)