### PR TITLE
Remove "currentPlayer" from gamestate

### DIFF
--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -1469,7 +1469,7 @@ void CPlayerInterface::centerView (int3 pos, int focusTime)
 void CPlayerInterface::objectRemoved(const CGObjectInstance * obj)
 {
 	EVENT_HANDLER_CALLED_BY_CLIENT;
-	if(LOCPLINT->cb->getCurrentPlayer() == playerID && obj->getRemovalSound())
+	if(LOCPLINT->cb->isPlayerMakingTurn(playerID) && obj->getRemovalSound())
 	{
 		waitWhileDialog();
 		CCS->soundh->playSound(obj->getRemovalSound().value());

--- a/client/Client.cpp
+++ b/client/Client.cpp
@@ -693,13 +693,6 @@ std::shared_ptr<const CPathsInfo> CClient::getPathsInfo(const CGHeroInstance * h
 	}
 }
 
-PlayerColor CClient::getLocalPlayer() const
-{
-	if(LOCPLINT)
-		return LOCPLINT->playerID;
-	return getCurrentPlayer();
-}
-
 #if SCRIPTING_ENABLED
 scripting::Pool * CClient::getGlobalContextPool() const
 {

--- a/client/Client.h
+++ b/client/Client.h
@@ -156,7 +156,6 @@ public:
 
 	void invalidatePaths();
 	std::shared_ptr<const CPathsInfo> getPathsInfo(const CGHeroInstance * h);
-	virtual PlayerColor getLocalPlayer() const override;
 
 	friend class CCallback; //handling players actions
 	friend class CBattleCallback; //handling players actions

--- a/client/adventureMap/AdventureMapInterface.cpp
+++ b/client/adventureMap/AdventureMapInterface.cpp
@@ -327,7 +327,7 @@ void AdventureMapInterface::onEnemyTurnStarted(PlayerColor playerID, bool isHuma
 
 	mapAudio->onEnemyTurnStarted();
 	widget->getMinimap()->setAIRadar(!isHuman);
-	widget->getInfoBar()->startEnemyTurn(LOCPLINT->cb->getCurrentPlayer());
+	widget->getInfoBar()->startEnemyTurn(playerID);
 	setState(isHuman ? EAdventureState::OTHER_HUMAN_PLAYER_TURN : EAdventureState::AI_PLAYER_TURN);
 }
 
@@ -363,8 +363,7 @@ void AdventureMapInterface::onPlayerTurnStarted(PlayerColor playerID)
 	onCurrentPlayerChanged(playerID);
 
 	setState(EAdventureState::MAKING_TURN);
-	if(LOCPLINT->cb->getCurrentPlayer() == LOCPLINT->playerID
-		|| settings["session"]["spectate"].Bool())
+	if(playerID == LOCPLINT->playerID || settings["session"]["spectate"].Bool())
 	{
 		widget->getMinimap()->setAIRadar(false);
 		widget->getInfoBar()->showSelection();

--- a/client/adventureMap/TurnTimerWidget.h
+++ b/client/adventureMap/TurnTimerWidget.h
@@ -39,13 +39,13 @@ private:
 	std::set<int> notifications;
 	
 	std::shared_ptr<DrawRect> buildDrawRect(const JsonNode & config) const;
-	
+
 public:
 
 	void show(Canvas & to) override;
 	void tick(uint32_t msPassed) override;
 	
-	void setTime(int time);
+	void setTime(PlayerColor player, int time);
 
 	TurnTimerWidget();
 };

--- a/lib/CGameInfoCallback.cpp
+++ b/lib/CGameInfoCallback.cpp
@@ -320,8 +320,7 @@ bool CGameInfoCallback::getHeroInfo(const CGObjectInstance * hero, InfoAboutHero
 	dest.initFromHero(h, infoLevel);
 
 	//DISGUISED bonus implementation
-
-	if(getPlayerRelations(getLocalPlayer(), hero->tempOwner) == PlayerRelations::ENEMIES)
+	if(getPlayerRelations(*player, hero->tempOwner) == PlayerRelations::ENEMIES)
 	{
 		//todo: bonus cashing
 		int disguiseLevel = h->valOfBonuses(Selector::typeSubtype(BonusType::DISGUISED, 0));
@@ -705,9 +704,9 @@ bool CGameInfoCallback::isOwnedOrVisited(const CGObjectInstance *obj) const
 	return visitor->ID == Obj::HERO && canGetFullInfo(visitor); //owned or allied hero is a visitor
 }
 
-PlayerColor CGameInfoCallback::getCurrentPlayer() const
+bool CGameInfoCallback::isPlayerMakingTurn(PlayerColor player) const
 {
-	return gs->currentPlayer;
+	return gs->actingPlayers.count(player);
 }
 
 CGameInfoCallback::CGameInfoCallback(CGameState * GS, std::optional<PlayerColor> Player):
@@ -932,11 +931,6 @@ const CGHeroInstance * CGameInfoCallback::getHeroWithSubid( int subid ) const
 	return gs->map->allHeroes.at(subid).get();
 }
 
-PlayerColor CGameInfoCallback::getLocalPlayer() const
-{
-	return getCurrentPlayer();
-}
-
 bool CGameInfoCallback::isInTheMap(const int3 &pos) const
 {
 	return gs->map->isInTheMap(pos);
@@ -944,7 +938,7 @@ bool CGameInfoCallback::isInTheMap(const int3 &pos) const
 
 void CGameInfoCallback::getVisibleTilesInRange(std::unordered_set<int3> &tiles, int3 pos, int radious, int3::EDistanceFormula distanceFormula) const
 {
-	gs->getTilesInRange(tiles, pos, radious, getLocalPlayer(), -1, distanceFormula);
+	gs->getTilesInRange(tiles, pos, radious, *player, -1, distanceFormula);
 }
 
 void CGameInfoCallback::calculatePaths(const std::shared_ptr<PathfinderConfig> & config)

--- a/lib/CGameInfoCallback.h
+++ b/lib/CGameInfoCallback.h
@@ -63,8 +63,6 @@ public:
 //	PlayerRelations getPlayerRelations(PlayerColor color1, PlayerColor color2) const;
 //	void getThievesGuildInfo(SThievesGuildInfo & thi, const CGObjectInstance * obj); //get thieves' guild info obtainable while visiting given object
 //	EPlayerStatus getPlayerStatus(PlayerColor player, bool verbose = true) const; //-1 if no such player
-//	PlayerColor getCurrentPlayer() const; //player that currently makes move // TODO synchronous turns
-	virtual PlayerColor getLocalPlayer() const = 0; //player that is currently owning given client (if not a client, then returns current player)
 //	const PlayerSettings * getPlayerSettings(PlayerColor color) const;
 
 
@@ -99,7 +97,6 @@ public:
 //	const TerrainTile * getTile(int3 tile, bool verbose = true) const;
 //	std::shared_ptr<boost::multi_array<TerrainTile*, 3>> getAllVisibleTiles() const;
 //	bool isInTheMap(const int3 &pos) const;
-//	void getVisibleTilesInRange(std::unordered_set<int3> &tiles, int3 pos, int radious, int3::EDistanceFormula distanceFormula = int3::DIST_2D) const;
 
 	//town
 //	const CGTownInstance* getTown(ObjectInstanceID objid) const;
@@ -151,8 +148,7 @@ public:
 	virtual PlayerRelations getPlayerRelations(PlayerColor color1, PlayerColor color2) const;
 	virtual void getThievesGuildInfo(SThievesGuildInfo & thi, const CGObjectInstance * obj); //get thieves' guild info obtainable while visiting given object
 	virtual EPlayerStatus getPlayerStatus(PlayerColor player, bool verbose = true) const; //-1 if no such player
-	virtual PlayerColor getCurrentPlayer() const; //player that currently makes move // TODO synchronous turns
-	PlayerColor getLocalPlayer() const override; //player that is currently owning given client (if not a client, then returns current player)
+	virtual bool isPlayerMakingTurn(PlayerColor player) const; //player that currently makes move // TODO synchronous turns
 	virtual const PlayerSettings * getPlayerSettings(PlayerColor color) const;
 	virtual TurnTimerInfo getPlayerTurnTime(PlayerColor color) const;
 

--- a/lib/NetPacksLib.cpp
+++ b/lib/NetPacksLib.cpp
@@ -2501,7 +2501,8 @@ void PlayerCheated::applyGs(CGameState * gs) const
 
 void YourTurn::applyGs(CGameState * gs) const
 {
-	gs->currentPlayer = player;
+	gs->actingPlayers.clear();
+	gs->actingPlayers.insert(player);
 }
 
 void DaysWithoutTown::applyGs(CGameState * gs) const

--- a/lib/gameState/CGameState.h
+++ b/lib/gameState/CGameState.h
@@ -86,6 +86,9 @@ public:
 	//we have here all heroes available on this map that are not hired
 	std::unique_ptr<TavernHeroesPool> heroesPool;
 
+	/// list of players currently making turn. Usually - just one, except for simturns
+	std::set<PlayerColor> actingPlayers;
+
 	CGameState();
 	virtual ~CGameState();
 
@@ -95,7 +98,6 @@ public:
 	void updateOnLoad(StartInfo * si);
 
 	ConstTransitivePtr<StartInfo> scenarioOps, initialOpts; //second one is a copy of settings received from pregame (not randomized)
-	PlayerColor currentPlayer; //ID of player currently having turn
 	ConstTransitivePtr<BattleInfo> curB; //current battle
 	ui32 day; //total number of days in game
 	ConstTransitivePtr<CMap> map;
@@ -151,7 +153,7 @@ public:
 	{
 		h & scenarioOps;
 		h & initialOpts;
-		h & currentPlayer;
+		h & actingPlayers;
 		h & day;
 		h & map;
 		h & players;

--- a/scripting/lua/api/GameCb.cpp
+++ b/scripting/lua/api/GameCb.cpp
@@ -30,7 +30,6 @@ const std::vector<GameCbProxy::CustomRegType> GameCbProxy::REGISTER_CUSTOM =
 {
 	{"getDate", LuaMethodWrapper<GameCb, decltype(&GameCb::getDate), &GameCb::getDate>::invoke, false},
 	{"isAllowed", LuaMethodWrapper<GameCb, decltype(&GameCb::isAllowed), &GameCb::isAllowed>::invoke, false},
-	{"getCurrentPlayer", LuaMethodWrapper<GameCb, decltype(&GameCb::getLocalPlayer), &GameCb::getLocalPlayer>::invoke, false},
 	{"getPlayer", LuaMethodWrapper<GameCb, decltype(&GameCb::getPlayer), &GameCb::getPlayer>::invoke, false},
 
 	{"getHero", LuaMethodWrapper<GameCb, decltype(&GameCb::getHero), &GameCb::getHero>::invoke, false},

--- a/server/CGameHandler.h
+++ b/server/CGameHandler.h
@@ -178,7 +178,6 @@ public:
 	void init(StartInfo *si, Load::ProgressAccumulator & progressTracking);
 	void handleClientDisconnection(std::shared_ptr<CConnection> c);
 	void handleReceivedPack(CPackForServer * pack);
-	PlayerColor getPlayerAt(std::shared_ptr<CConnection> c) const;
 	bool hasPlayerAt(PlayerColor player, std::shared_ptr<CConnection> c) const;
 
 	bool queryReply( QueryID qid, const JsonNode & answer, PlayerColor player );
@@ -243,16 +242,22 @@ public:
 
 	void sendToAllClients(CPackForClient * pack);
 	void sendAndApply(CPackForClient * pack) override;
-	void applyAndSend(CPackForClient * pack);
 	void sendAndApply(CGarrisonOperationPack * pack);
 	void sendAndApply(SetResources * pack);
 	void sendAndApply(NewStructures * pack);
 
 	void wrongPlayerMessage(CPackForServer * pack, PlayerColor expectedplayer);
+	/// Unconditionally throws with "Action not allowed" message
 	void throwNotAllowedAction(CPackForServer * pack);
-	void throwOnWrongOwner(CPackForServer * pack, ObjectInstanceID id);
-	void throwOnWrongPlayer(CPackForServer * pack, PlayerColor player);
+	/// Throws if player stated in pack is not making turn right now
+	void throwIfPlayerNotActive(CPackForServer * pack);
+	/// Throws if object is not owned by pack sender
+	void throwIfWrongOwner(CPackForServer * pack, ObjectInstanceID id);
+	/// Throws if player is not present on connection of this pack
+	void throwIfWrongPlayer(CPackForServer * pack, PlayerColor player);
+	void throwIfWrongPlayer(CPackForServer * pack);
 	void throwAndComplain(CPackForServer * pack, std::string txt);
+
 	bool isPlayerOwns(CPackForServer * pack, ObjectInstanceID id);
 
 	void run(bool resume);

--- a/server/processors/TurnOrderProcessor.cpp
+++ b/server/processors/TurnOrderProcessor.cpp
@@ -103,7 +103,7 @@ void TurnOrderProcessor::doStartPlayerTurn(PlayerColor which)
 	gameHandler->sendAndApply(&yt);
 
 	assert(actingPlayers.size() == 1); // No simturns yet :(
-	assert(gameHandler->getCurrentPlayer() == *actingPlayers.begin());
+	assert(gameHandler->isPlayerMakingTurn(*actingPlayers.begin()));
 }
 
 void TurnOrderProcessor::doEndPlayerTurn(PlayerColor which)
@@ -122,7 +122,7 @@ void TurnOrderProcessor::doEndPlayerTurn(PlayerColor which)
 
 	assert(!actingPlayers.empty());
 	assert(actingPlayers.size() == 1); // No simturns yet :(
-	assert(gameHandler->getCurrentPlayer() == *actingPlayers.begin());
+	assert(gameHandler->isPlayerMakingTurn(*actingPlayers.begin()));
 }
 
 void TurnOrderProcessor::addPlayer(PlayerColor which)
@@ -144,7 +144,7 @@ void TurnOrderProcessor::onPlayerEndsGame(PlayerColor which)
 
 	assert(!actingPlayers.empty());
 	assert(actingPlayers.size() == 1); // No simturns yet :(
-	assert(gameHandler->getCurrentPlayer() == *actingPlayers.begin());
+	assert(gameHandler->isPlayerMakingTurn(*actingPlayers.begin()));
 }
 
 bool TurnOrderProcessor::onPlayerEndsTurn(PlayerColor which)


### PR DESCRIPTION
Another simturns step, replace checking for currently active player with checking whether player is active

- Now gamestate provides isPlayerMakingTurn check instead of one that directly returns active player
- Cleared up validation of netpacks by server, e.g. always check that packet was send by correct player and that player owns affected object