### PR TITLE
Backpack window fix

### DIFF
--- a/client/widgets/CWindowWithArtifacts.cpp
+++ b/client/widgets/CWindowWithArtifacts.cpp
@@ -165,7 +165,7 @@ void CWindowWithArtifacts::leftClickArtPlaceHero(CArtifactsOfHeroBase & artsInst
 
 				if constexpr(std::is_same_v<decltype(artSetWeak), std::weak_ptr<CArtifactsOfHeroBackpack>>)
 				{
-					if(!isTransferAllowed)
+					if(!isTransferAllowed && artPlace.getArt())
 					{
 						if(closeCallback)
 							closeCallback();


### PR DESCRIPTION
Now the backpack window will not close when clicking on an empty slot.