### PR TITLE
Fix market of time, crashes game

### DIFF
--- a/config/objects/generic.json
+++ b/config/objects/generic.json
@@ -870,7 +870,15 @@
 	},
 	"marketOfTime" : { // Unused/not implemented H3 object present on some RoE maps
 		"index" :50,
-		"handler": "generic"
+		"handler": "generic",
+		"types" : {
+			"object" : {
+				"index" : 0,
+				"aiValue" : 0,
+				"rmg" : {
+				}
+			}
+		}
 	},
 	"tavern" : {
 		"index" :95,


### PR DESCRIPTION
Sample map. Visiting market of time was crashing game.
[SoD_Dzien_wistaka.zip](https://github.com/vcmi/vcmi/files/12445430/SoD_Dzien_wistaka.zip)

![image](https://github.com/vcmi/vcmi/assets/5644734/13fd0ed8-b78e-4484-a4a7-5c1c37222839)
