### PR TITLE
Better default stack action handling + "F shortcut" mode fixes

### DIFF
--- a/client/battle/BattleActionsController.h
+++ b/client/battle/BattleActionsController.h
@@ -53,7 +53,7 @@ class BattleActionsController
 	bool isCastingPossibleHere (const CSpell * spell, const CStack *shere, BattleHex myNumber);
 	bool canStackMoveHere (const CStack *sactive, BattleHex MyNumber) const; //TODO: move to BattleState / callback
 	std::vector<PossiblePlayerBattleAction> getPossibleActionsForStack (const CStack *stack) const; //called when stack gets its turn
-	void reorderPossibleActionsPriority(const CStack * stack, MouseHoveredHexContext context);
+	void reorderPossibleActionsPriority(const CStack * stack, const CStack * targetStack);
 
 	bool actionIsLegal(PossiblePlayerBattleAction action, BattleHex hoveredHex);
 

--- a/client/battle/BattleWindow.cpp
+++ b/client/battle/BattleWindow.cpp
@@ -450,6 +450,10 @@ void BattleWindow::showAlternativeActionIcon(PossiblePlayerBattleAction action)
 		case PossiblePlayerBattleAction::AIMED_SPELL_CREATURE:
 			iconName = variables["actionIconSpell"].String();
 			break;
+
+		case PossiblePlayerBattleAction::ANY_LOCATION:
+			iconName = variables["actionIconSpell"].String();
+			break;
 			
 		//TODO: figure out purpose of this icon
 		//case PossiblePlayerBattleAction::???:

--- a/client/gui/ShortcutHandler.cpp
+++ b/client/gui/ShortcutHandler.cpp
@@ -120,7 +120,7 @@ std::vector<EShortcut> ShortcutHandler::translateKeycode(SDL_Keycode key) const
 		{SDLK_KP_MINUS,  EShortcut::ADVENTURE_ZOOM_OUT        },
 		{SDLK_BACKSPACE, EShortcut::ADVENTURE_ZOOM_RESET      },
 		{SDLK_q,         EShortcut::BATTLE_TOGGLE_QUEUE       },
-		{SDLK_c,         EShortcut::BATTLE_USE_CREATURE_SPELL },
+		{SDLK_f,         EShortcut::BATTLE_USE_CREATURE_SPELL },
 		{SDLK_s,         EShortcut::BATTLE_SURRENDER          },
 		{SDLK_r,         EShortcut::BATTLE_RETREAT            },
 		{SDLK_a,         EShortcut::BATTLE_AUTOCOMBAT         },


### PR DESCRIPTION
Fixes for multiple creature spellcast issues:
1. Wrong creature spellcast shortcut
2. Impossible to perform melee attack by creatures with spells, especially area spells
3. right click not ending creature spellcast mode