### PR TITLE
Fix mana drain not refreshing battle hero window mana

### DIFF
--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -898,6 +898,12 @@ void CPlayerInterface::battleTriggerEffect (const BattleTriggerEffect & bte)
 
 	RETURN_IF_QUICK_COMBAT;
 	battleInt->effectsController->battleTriggerEffect(bte);
+
+	if(bte.effect == vstd::to_underlying(BonusType::MANA_DRAIN))
+	{
+		const CGHeroInstance * manaDrainedHero = LOCPLINT->cb->getHero(ObjectInstanceID(bte.additionalInfo));
+		battleInt->windowObject->heroManaPointsChanged(manaDrainedHero);
+	}
 }
 void CPlayerInterface::battleStacksAttacked(const std::vector<BattleStackAttacked> & bsa, bool ranged)
 {


### PR DESCRIPTION
Battle hero window did not have refreshed mana when MANA_DRAIN creature ability was triggering, as it uses another netpack (BattleTriggerEffect) than usual SetMana