### PR TITLE
Bump SDK version for Android build release

### DIFF
--- a/android/vcmi-app/build.gradle
+++ b/android/vcmi-app/build.gradle
@@ -3,14 +3,14 @@ plugins {
 }
 
 android {
-	compileSdk 31
+	compileSdk 33
 	ndkVersion '25.2.9519653'
 
 	defaultConfig {
 		applicationId "is.xyz.vcmi"
 		minSdk 19
-		targetSdk 31
-		versionCode 1310
+		targetSdk 33
+		versionCode 1311
 		versionName "1.3.1"
 		setProperty("archivesBaseName", "vcmi")
 	}


### PR DESCRIPTION
Pushing SDK version bump to master - Google Play requires new build with this change by end of August