### PR TITLE
Commander abilities UI fix

### DIFF
--- a/client/windows/CCreatureWindow.cpp
+++ b/client/windows/CCreatureWindow.cpp
@@ -128,6 +128,11 @@ void CCommanderSkillIcon::deselect()
 	isSelected = false;
 }
 
+bool CCommanderSkillIcon::getIsGrandmasterAbility()
+{
+	return isGrandmasterAbility;
+}
+
 void CCommanderSkillIcon::show(Canvas &to)
 {
 	CIntObject::show(to);
@@ -915,7 +920,10 @@ void CStackWindow::setSelection(si32 newSkill, std::shared_ptr<CCommanderSkillIc
 
 	if(selectedIcon)
 	{
-		selectedIcon->text = getSkillDescription(oldSelection, false); //update previously selected icon's message to existing skill level
+		if(!selectedIcon->getIsGrandmasterAbility()) //unlike WoG, in VCMI grandmaster skill descriptions are taken from bonus descriptions
+		{
+			selectedIcon->text = getSkillDescription(oldSelection, false); //update previously selected icon's message to existing skill level
+		}
 		selectedIcon->deselect();
 	}
 
@@ -923,7 +931,10 @@ void CStackWindow::setSelection(si32 newSkill, std::shared_ptr<CCommanderSkillIc
 	if(newSkill < 100)
 	{
 		newIcon->setObject(std::make_shared<CPicture>(getSkillImage(newSkill)));
-		newIcon->text = getSkillDescription(newSkill, true); //update currently selected icon's message to show upgrade description
+		if(!newIcon->getIsGrandmasterAbility())
+		{
+			newIcon->text = getSkillDescription(newSkill, true); //update currently selected icon's message to show upgrade description
+		}
 	}
 }
 

--- a/client/windows/CCreatureWindow.cpp
+++ b/client/windows/CCreatureWindow.cpp
@@ -469,6 +469,7 @@ CStackWindow::CommanderMainSection::CommanderMainSection(CStackWindow * owner, i
 		};
 
 		abilities = std::make_shared<CListBox>(onCreate, Point(38, 3+pos.h), Point(63, 0), 6, abilitiesCount);
+		abilities->setRedrawParent(true);
 
 		leftBtn = std::make_shared<CButton>(Point(10,  pos.h + 6), "hsbtns3.def", CButton::tooltip(), [=](){ abilities->moveToPrev(); }, EShortcut::MOVE_LEFT);
 		rightBtn = std::make_shared<CButton>(Point(411, pos.h + 6), "hsbtns5.def", CButton::tooltip(), [=](){ abilities->moveToNext(); }, EShortcut::MOVE_RIGHT);

--- a/client/windows/CCreatureWindow.cpp
+++ b/client/windows/CCreatureWindow.cpp
@@ -15,6 +15,7 @@
 
 #include "../CGameInfo.h"
 #include "../CPlayerInterface.h"
+#include "../render/Canvas.h"
 #include "../widgets/Buttons.h"
 #include "../widgets/CArtifactHolder.h"
 #include "../widgets/CComponent.h"
@@ -84,7 +85,6 @@ public:
 	{
 	}
 
-
 	std::string getName() const
 	{
 		if(commander)
@@ -96,11 +96,14 @@ private:
 
 };
 
-CCommanderSkillIcon::CCommanderSkillIcon(std::shared_ptr<CIntObject> object_, std::function<void()> callback)
+CCommanderSkillIcon::CCommanderSkillIcon(std::shared_ptr<CIntObject> object_, bool isGrandmasterAbility_, std::function<void()> callback)
 	: object(),
+	isGrandmasterAbility(isGrandmasterAbility_),
+	isSelected(false),
 	callback(callback)
 {
 	pos = object_->pos;
+	this->isGrandmasterAbility = isGrandmasterAbility_;
 	setObject(object_);
 }
 
@@ -117,6 +120,20 @@ void CCommanderSkillIcon::setObject(std::shared_ptr<CIntObject> newObject)
 void CCommanderSkillIcon::clickPressed(const Point & cursorPosition)
 {
 	callback();
+	isSelected = true;
+}
+
+void CCommanderSkillIcon::deselect()
+{
+	isSelected = false;
+}
+
+void CCommanderSkillIcon::show(Canvas &to)
+{
+	CIntObject::show(to);
+
+	if(isGrandmasterAbility && isSelected)
+		to.drawBorder(pos, Colors::YELLOW, 2);
 }
 
 static std::string skillToFile(int skill, int level, bool selected)
@@ -376,7 +393,7 @@ CStackWindow::CommanderMainSection::CommanderMainSection(CStackWindow * owner, i
 	{
 		Point skillPos = getSkillPos(index);
 
-		auto icon = std::make_shared<CCommanderSkillIcon>(std::make_shared<CPicture>(getSkillImage(index), skillPos.x, skillPos.y), [=]()
+		auto icon = std::make_shared<CCommanderSkillIcon>(std::make_shared<CPicture>(getSkillImage(index), skillPos.x, skillPos.y), false, [=]()
 		{
 			LOCPLINT->showInfoDialog(getSkillDescription(index));
 		});
@@ -430,7 +447,7 @@ CStackWindow::CommanderMainSection::CommanderMainSection(CStackWindow * owner, i
 				{
 					const auto bonus = CGI->creh->skillRequirements[skillID-100].first;
 					const CStackInstance * stack = parent->info->commander;
-					auto icon = std::make_shared<CCommanderSkillIcon>(std::make_shared<CPicture>(stack->bonusToGraphics(bonus)), [](){});
+					auto icon = std::make_shared<CCommanderSkillIcon>(std::make_shared<CPicture>(stack->bonusToGraphics(bonus)), true,  [](){});
 					icon->callback = [=]()
 					{
 						parent->setSelection(skillID, icon);
@@ -897,7 +914,10 @@ void CStackWindow::setSelection(si32 newSkill, std::shared_ptr<CCommanderSkillIc
 		selectedIcon->setObject(std::make_shared<CPicture>(getSkillImage(oldSelection)));
 
 	if(selectedIcon)
+	{
 		selectedIcon->text = getSkillDescription(oldSelection, false); //update previously selected icon's message to existing skill level
+		selectedIcon->deselect();
+	}
 
 	selectedIcon = newIcon; // update new selection
 	if(newSkill < 100)

--- a/client/windows/CCreatureWindow.h
+++ b/client/windows/CCreatureWindow.h
@@ -43,6 +43,7 @@ public:
 
 	void setObject(std::shared_ptr<CIntObject> object);
 	void deselect(); //TODO: consider using observer pattern instead?
+	bool getIsGrandmasterAbility();
 
 	void show(Canvas &to) override;
 };

--- a/client/windows/CCreatureWindow.h
+++ b/client/windows/CCreatureWindow.h
@@ -32,14 +32,19 @@ class CCommanderArtPlace;
 class CCommanderSkillIcon : public LRClickableAreaWText //TODO: maybe bring commander skill button initialization logic inside?
 {
 	std::shared_ptr<CIntObject> object; // passive object that will be used to determine clickable area
+	bool isGrandmasterAbility; // refers to WoG abilities obtainable via combining grandmaster skills (for example attack + speed unlocks shoot)
+	bool isSelected; // used only for programatically created border around selected "grandmaster abilities"
 public:
-	CCommanderSkillIcon(std::shared_ptr<CIntObject> object_, std::function<void()> callback);
+	CCommanderSkillIcon(std::shared_ptr<CIntObject> object_, bool isGrandmasterAbility, std::function<void()> callback);
 
 	std::function<void()> callback;
 
 	void clickPressed(const Point & cursorPosition) override;
 
 	void setObject(std::shared_ptr<CIntObject> object);
+	void deselect(); //TODO: consider using observer pattern instead?
+
+	void show(Canvas &to) override;
 };
 
 class CStackWindow : public CWindowObject


### PR DESCRIPTION
- Add yellow border to selected commander grandmaster ability
- Remove attempt to use wog-specific translation which is not provided for right-click popup for these abilities, assuming bonus description is preferred for now
- Fix bugged UI for scrolling when there is a lot of grandmaster abilities