### PR TITLE
(1.3.2) Implemented tolerance for touch events

### DIFF
--- a/client/eventsSDL/InputSourceMouse.cpp
+++ b/client/eventsSDL/InputSourceMouse.cpp
@@ -50,10 +50,10 @@ void InputSourceMouse::handleEventMouseButtonDown(const SDL_MouseButtonEvent & b
 			if(button.clicks > 1)
 				GH.events().dispatchMouseDoubleClick(position);
 			else
-				GH.events().dispatchMouseLeftButtonPressed(position);
+				GH.events().dispatchMouseLeftButtonPressed(position, 0);
 			break;
 		case SDL_BUTTON_RIGHT:
-			GH.events().dispatchShowPopup(position);
+			GH.events().dispatchShowPopup(position, 0);
 			break;
 		case SDL_BUTTON_MIDDLE:
 			middleClickPosition = position;
@@ -74,7 +74,7 @@ void InputSourceMouse::handleEventMouseButtonUp(const SDL_MouseButtonEvent & but
 	switch(button.button)
 	{
 		case SDL_BUTTON_LEFT:
-			GH.events().dispatchMouseLeftButtonReleased(position);
+			GH.events().dispatchMouseLeftButtonReleased(position, 0);
 			break;
 		case SDL_BUTTON_RIGHT:
 			GH.events().dispatchClosePopup(position);

--- a/client/eventsSDL/InputSourceTouch.cpp
+++ b/client/eventsSDL/InputSourceTouch.cpp
@@ -121,9 +121,9 @@ void InputSourceTouch::handleEventFingerDown(const SDL_TouchFingerEvent & tfinge
 			if(tfinger.x > 0.5)
 			{
 				if (tfinger.y < 0.5)
-					GH.events().dispatchShowPopup(GH.getCursorPosition());
+					GH.events().dispatchShowPopup(GH.getCursorPosition(), params.touchToleranceDistance);
 				else
-					GH.events().dispatchMouseLeftButtonPressed(GH.getCursorPosition());
+					GH.events().dispatchMouseLeftButtonPressed(GH.getCursorPosition(), params.touchToleranceDistance);
 			}
 			break;
 		}
@@ -168,7 +168,7 @@ void InputSourceTouch::handleEventFingerUp(const SDL_TouchFingerEvent & tfinger)
 				if (tfinger.y < 0.5)
 					GH.events().dispatchClosePopup(GH.getCursorPosition());
 				else
-					GH.events().dispatchMouseLeftButtonReleased(GH.getCursorPosition());
+					GH.events().dispatchMouseLeftButtonReleased(GH.getCursorPosition(), params.touchToleranceDistance);
 			}
 			break;
 		}
@@ -180,8 +180,8 @@ void InputSourceTouch::handleEventFingerUp(const SDL_TouchFingerEvent & tfinger)
 		case TouchState::TAP_DOWN_SHORT:
 		{
 			GH.input().setCursorPosition(convertTouchToMouse(tfinger));
-			GH.events().dispatchMouseLeftButtonPressed(convertTouchToMouse(tfinger));
-			GH.events().dispatchMouseLeftButtonReleased(convertTouchToMouse(tfinger));
+			GH.events().dispatchMouseLeftButtonPressed(convertTouchToMouse(tfinger), params.touchToleranceDistance);
+			GH.events().dispatchMouseLeftButtonReleased(convertTouchToMouse(tfinger), params.touchToleranceDistance);
 			state = TouchState::IDLE;
 			break;
 		}
@@ -230,7 +230,7 @@ void InputSourceTouch::handleUpdate()
 		uint32_t currentTime = SDL_GetTicks();
 		if (currentTime > lastTapTimeTicks + params.longTouchTimeMilliseconds)
 		{
-			GH.events().dispatchShowPopup(GH.getCursorPosition());
+			GH.events().dispatchShowPopup(GH.getCursorPosition(), params.touchToleranceDistance);
 
 			if (GH.windows().isTopWindowPopup())
 			{

--- a/client/eventsSDL/InputSourceTouch.cpp
+++ b/client/eventsSDL/InputSourceTouch.cpp
@@ -39,6 +39,7 @@ InputSourceTouch::InputSourceTouch()
 	params.relativeModeSpeedFactor = settings["general"]["relativePointerSpeedMultiplier"].Float();
 	params.longTouchTimeMilliseconds = settings["general"]["longTouchTimeMilliseconds"].Float();
 	params.hapticFeedbackEnabled = settings["general"]["hapticFeedback"].Bool();
+	params.touchToleranceDistance = settings["input"]["touchToleranceDistance"].Bool();
 
 	if (params.useRelativeMode)
 		state = TouchState::RELATIVE_MODE;

--- a/client/eventsSDL/InputSourceTouch.h
+++ b/client/eventsSDL/InputSourceTouch.h
@@ -78,6 +78,9 @@ struct TouchInputParameters
 	/// gesture will be qualified as pinch if distance between fingers is at least specified here
 	uint32_t pinchSensitivityThreshold = 10;
 
+	/// touch event will trigger clicking of elements up to X pixels away from actual touch position
+	uint32_t touchToleranceDistance = 20;
+
 	bool useRelativeMode = false;
 
 	bool hapticFeedbackEnabled = false;

--- a/client/gui/CIntObject.cpp
+++ b/client/gui/CIntObject.cpp
@@ -263,6 +263,11 @@ bool CIntObject::receiveEvent(const Point & position, int eventType) const
 	return pos.isInside(position);
 }
 
+const Rect & CIntObject::getPosition() const
+{
+	return pos;
+}
+
 void CIntObject::onScreenResize()
 {
 	center(pos, true);

--- a/client/gui/CIntObject.h
+++ b/client/gui/CIntObject.h
@@ -109,6 +109,8 @@ public:
 	/// by default, usedEvents inside UI elements are always handled
 	bool receiveEvent(const Point & position, int eventType) const override;
 
+	const Rect & getPosition() const override;
+
 	const Rect & center(const Rect &r, bool propagate = true); //sets pos so that r will be in the center of screen, assigns sizes of r to pos, returns new position
 	const Rect & center(const Point &p, bool propagate = true);  //moves object so that point p will be in its center
 	const Rect & center(bool propagate = true); //centers when pos.w and pos.h are set, returns new position

--- a/client/gui/EventDispatcher.h
+++ b/client/gui/EventDispatcher.h
@@ -35,8 +35,8 @@ class EventDispatcher
 	EventReceiversList textInterested;
 	EventReceiversList panningInterested;
 
-	void handleLeftButtonClick(const Point & position, bool isPressed);
-
+	void handleLeftButtonClick(const Point & position, int tolerance, bool isPressed);
+	AEventsReceiver * findElementInToleranceRange(const EventReceiversList & list, const Point & position, int eventToTest, int tolerance);
 
 	template<typename Functor>
 	void processLists(ui16 activityFlag, const Functor & cb);
@@ -56,15 +56,15 @@ public:
 	void dispatchShortcutReleased(const std::vector<EShortcut> & shortcuts);
 
 	/// Mouse events
-	void dispatchMouseLeftButtonPressed(const Point & position);
-	void dispatchMouseLeftButtonReleased(const Point & position);
+	void dispatchMouseLeftButtonPressed(const Point & position, int tolerance);
+	void dispatchMouseLeftButtonReleased(const Point & position, int tolerance);
 	void dispatchMouseScrolled(const Point & distance, const Point & position);
 	void dispatchMouseDoubleClick(const Point & position);
 	void dispatchMouseMoved(const Point & distance, const Point & position);
 
 	void dispatchMouseDragged(const Point & currentPosition, const Point & lastUpdateDistance);
 
-	void dispatchShowPopup(const Point & position);
+	void dispatchShowPopup(const Point & position, int tolerance);
 	void dispatchClosePopup(const Point & position);
 
 	void dispatchGesturePanningStarted(const Point & initialPosition);

--- a/client/gui/EventsReceiver.h
+++ b/client/gui/EventsReceiver.h
@@ -11,6 +11,7 @@
 
 VCMI_LIB_NAMESPACE_BEGIN
 class Point;
+class Rect;
 VCMI_LIB_NAMESPACE_END
 
 class EventDispatcher;
@@ -38,6 +39,8 @@ protected:
 
 	/// If true, event of selected type in selected position will be processed by this element
 	virtual bool receiveEvent(const Point & position, int eventType) const= 0;
+
+	virtual const Rect & getPosition() const= 0;
 
 public:
 	virtual void clickPressed(const Point & cursorPosition) {}

--- a/client/widgets/Buttons.cpp
+++ b/client/widgets/Buttons.cpp
@@ -128,6 +128,13 @@ void CButton::setState(ButtonState newState)
 {
 	if (state == newState)
 		return;
+
+	if (newState == BLOCKED)
+		removeUsedEvents(LCLICK | SHOW_POPUP | HOVER | KEYBOARD);
+	else
+		addUsedEvents(LCLICK | SHOW_POPUP | HOVER | KEYBOARD);
+
+
 	state = newState;
 	update();
 }

--- a/config/schemas/settings.json
+++ b/config/schemas/settings.json
@@ -214,11 +214,15 @@
 			"type" : "object",
 			"additionalProperties" : false,
 			"default" : {},
-			"required" : [ "radialWheelGarrisonSwipe" ],
+			"required" : [ "radialWheelGarrisonSwipe", "touchToleranceDistance" ],
 			"properties" : {
 				"radialWheelGarrisonSwipe" : {
 					"type" : "boolean",
 					"default" : true
+				},
+				"touchToleranceDistance" : {
+					"type" : "number",
+					"default" : 20
 				}
 			}
 		},

--- a/lib/Rect.cpp
+++ b/lib/Rect.cpp
@@ -136,4 +136,12 @@ Rect Rect::intersect(const Rect & other) const
 	}
 }
 
+int Rect::distanceTo(const Point & target) const
+{
+	int distanceX = std::max({left() - target.x, 0, target.x - right()});
+	int distanceY = std::max({top() - target.y, 0, target.y - bottom()});
+
+	return Point(distanceX, distanceY).length();
+}
+
 VCMI_LIB_NAMESPACE_END

--- a/lib/Rect.h
+++ b/lib/Rect.h
@@ -142,6 +142,9 @@ public:
 		return x == other.x && y == other.y && w == other.w && h == other.h;
 	}
 
+	/// returns distance from this rect to point, or 0 if inside
+	DLL_LINKAGE int distanceTo(const Point & target) const;
+
 	/// returns true if this rect intersects with another rect
 	DLL_LINKAGE bool intersectionTest(const Rect & other) const;
 


### PR DESCRIPTION
When using touch input, events that happen within certain (20px) distance will now trigger nearby control input.

- Only active when touch input is used, for mouse tolerance is set to 0px
- Only clicking and popup display events are affected
- Fixes #2439 