### PR TITLE
Remove(reduce durations) of bonuses for tavern heroes

### DIFF
--- a/lib/gameState/TavernHeroesPool.cpp
+++ b/lib/gameState/TavernHeroesPool.cpp
@@ -117,6 +117,10 @@ void TavernHeroesPool::onNewDay()
 		if(!hero.second)
 			continue;
 
+		hero.second->removeBonusesRecursive(Bonus::OneDay);
+		hero.second->reduceBonusDurations(Bonus::NDays);
+		hero.second->reduceBonusDurations(Bonus::OneWeek);
+
 		// do not access heroes who are not present in tavern of any players
 		if (vstd::contains(unusedHeroes, hero.first))
 			continue;


### PR DESCRIPTION
Tried to fix this situation:
1. A hero with the stables bonus dismissed, retreated or surrendered
2. Unlike OH3 the bonus of stables keeps its duration until he's hired again
3. The bonus will reset in the middle of the week instead.

Another case is:
1. A hero cast fly, ends turn on day 7
2. Got attacked, then retreated or surrendered
3. Hired again and have the fly effect on a new turn.