### PR TITLE
Fix for random dwellings

### DIFF
--- a/lib/gameState/CGameState.cpp
+++ b/lib/gameState/CGameState.cpp
@@ -286,7 +286,7 @@ std::pair<Obj,int> CGameState::pickObject (CGObjectInstance *obj)
 			//if level set to range
 			if(auto * info = dynamic_cast<CCreGenLeveledInfo *>(dwl->info))
 			{
-				level = getRandomGenerator().nextInt(info->minLevel, info->maxLevel);
+				level = getRandomGenerator().nextInt(info->minLevel, info->maxLevel) - 1;
 			}
 			else // fixed level
 			{
@@ -297,7 +297,20 @@ std::pair<Obj,int> CGameState::pickObject (CGObjectInstance *obj)
 			dwl->info = nullptr;
 
 			std::pair<Obj, int> result(Obj::NO_OBJ, -1);
-			CreatureID cid = (*VLC->townh)[faction]->town->creatures[level][0];
+			CreatureID cid;
+			if((*VLC->townh)[faction]->town)
+				cid = (*VLC->townh)[faction]->town->creatures[level][0];
+			else
+			{
+				//neutral faction
+				std::vector<CCreature*> possibleCreatures;
+				std::copy_if(VLC->creh->objects.begin(), VLC->creh->objects.end(), std::back_inserter(possibleCreatures), [faction](const CCreature * c)
+				{
+					return c->getFaction() == faction;
+				});
+				assert(!possibleCreatures.empty());
+				cid = (*RandomGeneratorUtil::nextItem(possibleCreatures, getRandomGenerator()))->getId();
+			}
 
 			//NOTE: this will pick last dwelling with this creature (Mantis #900)
 			//check for block map equality is better but more complex solution

--- a/lib/mapObjects/CGDwelling.h
+++ b/lib/mapObjects/CGDwelling.h
@@ -42,7 +42,7 @@ public:
 class DLL_LINKAGE CCreGenLeveledInfo : public virtual CSpecObjInfo
 {
 public:
-	ui8 minLevel = 0;
+	ui8 minLevel = 1;
 	ui8 maxLevel = 7; //minimal and maximal level of creature in dwelling: <1, 7>
 
 	void serializeJson(JsonSerializeFormat & handler) override;

--- a/lib/mapping/MapFormatH3M.cpp
+++ b/lib/mapping/MapFormatH3M.cpp
@@ -1273,8 +1273,8 @@ CGObjectInstance * CMapLoaderH3M::readDwellingRandom(const int3 & mapPosition, s
 	//216 and 218
 	if(auto * lvlSpec = dynamic_cast<CCreGenLeveledInfo *>(spec))
 	{
-		lvlSpec->minLevel = std::max(reader->readUInt8(), static_cast<ui8>(1));
-		lvlSpec->maxLevel = std::min(reader->readUInt8(), static_cast<ui8>(7));
+		lvlSpec->minLevel = std::max(reader->readUInt8(), static_cast<ui8>(0)) + 1;
+		lvlSpec->maxLevel = std::min(reader->readUInt8(), static_cast<ui8>(6)) + 1;
 	}
 	object->info = spec;
 	return object;


### PR DESCRIPTION
1. Fixes https://github.com/vcmi/vcmi/issues/2790
2. Fixes problem with h3m random dwellings which are never become a 1lvl 

Fix preserves full backward compatibility with any vmap created earlier