### PR TITLE
Get next visible bound portal feature

### DIFF
--- a/client/adventureMap/AdventureMapInterface.cpp
+++ b/client/adventureMap/AdventureMapInterface.cpp
@@ -45,7 +45,6 @@
 #include "../../lib/mapping/CMapDefines.h"
 #include "../../lib/pathfinder/CGPathNode.h"
 
-
 std::shared_ptr<AdventureMapInterface> adventureInt;
 
 AdventureMapInterface::AdventureMapInterface():
@@ -465,7 +464,6 @@ const CGObjectInstance* AdventureMapInterface::getActiveObject(const int3 &mapPo
 
 void AdventureMapInterface::onTileLeftClicked(const int3 &mapPos)
 {
-
 	if(!shortcuts->optionMapViewActive())
 		return;
 
@@ -726,8 +724,6 @@ void AdventureMapInterface::showMoveDetailsInStatusbar(const CGHeroInstance & he
 
 void AdventureMapInterface::onTileRightClicked(const int3 &mapPos)
 {
-	const CGObjectInstance * obj = getActiveObject(mapPos);
-
 	if(!shortcuts->optionMapViewActive())
 		return;
 
@@ -743,6 +739,7 @@ void AdventureMapInterface::onTileRightClicked(const int3 &mapPos)
 		return;
 	}
 
+	const CGObjectInstance * obj = getActiveObject(mapPos);
 	if(!obj)
 	{
 		// Bare or undiscovered terrain
@@ -760,8 +757,6 @@ void AdventureMapInterface::onTileRightClicked(const int3 &mapPos)
 			std::optional<const CGObjectInstance*> closestExit = portal->getNextVisibleExit(LOCPLINT->playerID);
 			if (closestExit.has_value()) {
 					widget->getMapView()->onCenteredObject(closestExit.value());
-					// Remove to ensure easy hero selection after screen moving (rather than opening hero window)
-					// LOCPLINT->localState->setSelection(nullptr);
 				}
 	}
 

--- a/client/adventureMap/AdventureMapInterface.cpp
+++ b/client/adventureMap/AdventureMapInterface.cpp
@@ -41,8 +41,10 @@
 #include "../../lib/spells/CSpellHandler.h"
 #include "../../lib/mapObjects/CGHeroInstance.h"
 #include "../../lib/mapObjects/CGTownInstance.h"
+#include "../../lib/mapObjects/MiscObjects.h"
 #include "../../lib/mapping/CMapDefines.h"
 #include "../../lib/pathfinder/CGPathNode.h"
+
 
 std::shared_ptr<AdventureMapInterface> adventureInt;
 
@@ -463,6 +465,7 @@ const CGObjectInstance* AdventureMapInterface::getActiveObject(const int3 &mapPo
 
 void AdventureMapInterface::onTileLeftClicked(const int3 &mapPos)
 {
+
 	if(!shortcuts->optionMapViewActive())
 		return;
 
@@ -723,6 +726,8 @@ void AdventureMapInterface::showMoveDetailsInStatusbar(const CGHeroInstance & he
 
 void AdventureMapInterface::onTileRightClicked(const int3 &mapPos)
 {
+	const CGObjectInstance * obj = getActiveObject(mapPos);
+
 	if(!shortcuts->optionMapViewActive())
 		return;
 
@@ -738,7 +743,6 @@ void AdventureMapInterface::onTileRightClicked(const int3 &mapPos)
 		return;
 	}
 
-	const CGObjectInstance * obj = getActiveObject(mapPos);
 	if(!obj)
 	{
 		// Bare or undiscovered terrain
@@ -749,6 +753,16 @@ void AdventureMapInterface::onTileRightClicked(const int3 &mapPos)
 			CRClickPopup::createAndPush(hlp);
 		}
 		return;
+	}
+
+	const CGTeleport * portal = dynamic_cast<const CGTeleport*>(obj);
+	if(portal) {
+			std::optional<const CGObjectInstance*> closestExit = portal->getNextVisibleExit(LOCPLINT->playerID);
+			if (closestExit.has_value()) {
+					widget->getMapView()->onCenteredObject(closestExit.value());
+					// Remove to ensure easy hero selection after screen moving (rather than opening hero window)
+					// LOCPLINT->localState->setSelection(nullptr);
+				}
 	}
 
 	CRClickPopup::createAndPush(obj, GH.getCursorPosition(), ETextAlignment::CENTER);

--- a/client/windows/InfoWindows.cpp
+++ b/client/windows/InfoWindows.cpp
@@ -421,6 +421,17 @@ std::shared_ptr<WindowBase> CRClickPopup::createInfoWin(Point position, const CG
 	case Obj::GARRISON:
 	case Obj::GARRISON2:
 		return std::make_shared<CInfoBoxPopup>(position, dynamic_cast<const CGGarrison *>(specific));
+	case Obj::MONOLITH_ONE_WAY_ENTRANCE:
+	case Obj::MONOLITH_ONE_WAY_EXIT:
+	case Obj::MONOLITH_TWO_WAY:
+	     // CRClickPopupInt  Больше подходит по смыслу и реализации
+	     //return std::make_shared<CRClickPopupInt>(, position);
+	     // CInfoBoxPopup имеет метод point toScreen, но он скорее для героя, гарнизона или замка (отображает войска), а его родитель - CWindowObject
+	     // Не годится, т.к. конструктору нужен герой, гарнизон или замок
+	     //return std::make_shared<CInfoBoxPopup>(/* опции, имя картинки */, position);
+	     // CWindowObject родитель для CInfoBoxPopup
+	     return std::make_shared<CWindowObject>(8, "BoCsMag3.pcx", position);
+	     //return std::make_shared<CWindowObject>(/* опции, имя картинки */, position);
 	default:
 		return std::shared_ptr<WindowBase>();
 	}

--- a/client/windows/InfoWindows.cpp
+++ b/client/windows/InfoWindows.cpp
@@ -421,17 +421,6 @@ std::shared_ptr<WindowBase> CRClickPopup::createInfoWin(Point position, const CG
 	case Obj::GARRISON:
 	case Obj::GARRISON2:
 		return std::make_shared<CInfoBoxPopup>(position, dynamic_cast<const CGGarrison *>(specific));
-	case Obj::MONOLITH_ONE_WAY_ENTRANCE:
-	case Obj::MONOLITH_ONE_WAY_EXIT:
-	case Obj::MONOLITH_TWO_WAY:
-	     // CRClickPopupInt  Больше подходит по смыслу и реализации
-	     //return std::make_shared<CRClickPopupInt>(, position);
-	     // CInfoBoxPopup имеет метод point toScreen, но он скорее для героя, гарнизона или замка (отображает войска), а его родитель - CWindowObject
-	     // Не годится, т.к. конструктору нужен герой, гарнизон или замок
-	     //return std::make_shared<CInfoBoxPopup>(/* опции, имя картинки */, position);
-	     // CWindowObject родитель для CInfoBoxPopup
-	     return std::make_shared<CWindowObject>(8, "BoCsMag3.pcx", position);
-	     //return std::make_shared<CWindowObject>(/* опции, имя картинки */, position);
 	default:
 		return std::shared_ptr<WindowBase>();
 	}

--- a/lib/mapObjects/MiscObjects.cpp
+++ b/lib/mapObjects/MiscObjects.cpp
@@ -361,7 +361,7 @@ std::vector<ObjectInstanceID> CGTeleport::getAllExits(bool excludeCurrent) const
 
 /**
  * \brief Finds the next visible exit for a teleporter.
- * 
+ *
  * This method tries to find the next visible exit for a teleporter based on the player color.
  * If an exit is found, it returns the object instance. Otherwise, it returns a nullopt.
  */
@@ -406,7 +406,6 @@ std::optional<const CGObjectInstance*> CGTeleport::getNextVisibleExit(PlayerColo
 	}
 
 }
-
 
 ObjectInstanceID CGTeleport::getRandomExit(const CGHeroInstance * h) const
 {

--- a/lib/mapObjects/MiscObjects.h
+++ b/lib/mapObjects/MiscObjects.h
@@ -16,6 +16,7 @@ VCMI_LIB_NAMESPACE_BEGIN
 
 class CMap;
 
+
 // This one teleport-specific, but has to be available everywhere in callbacks and netpacks
 // For now it's will be there till teleports code refactored and moved into own file
 using TTeleportExitsList = std::vector<std::pair<ObjectInstanceID, int3>>;
@@ -257,6 +258,7 @@ protected:
 public:
 	TeleportChannelID channel;
 
+
 	bool isEntrance() const;
 	bool isExit() const;
 
@@ -268,6 +270,7 @@ public:
 	static void addToChannel(std::map<TeleportChannelID, std::shared_ptr<TeleportChannel> > &channelsList, const CGTeleport * obj);
 	static std::vector<ObjectInstanceID> getPassableExits(CGameState * gs, const CGHeroInstance * h, std::vector<ObjectInstanceID> exits);
 	static bool isExitPassable(CGameState * gs, const CGHeroInstance * h, const CGObjectInstance * obj);
+	std::optional<const CGObjectInstance*> getNextVisibleExit(PlayerColor playerColor) const;
 
 	template <typename Handler> void serialize(Handler &h, const int version)
 	{

--- a/lib/mapObjects/MiscObjects.h
+++ b/lib/mapObjects/MiscObjects.h
@@ -16,7 +16,6 @@ VCMI_LIB_NAMESPACE_BEGIN
 
 class CMap;
 
-
 // This one teleport-specific, but has to be available everywhere in callbacks and netpacks
 // For now it's will be there till teleports code refactored and moved into own file
 using TTeleportExitsList = std::vector<std::pair<ObjectInstanceID, int3>>;
@@ -257,7 +256,6 @@ protected:
 
 public:
 	TeleportChannelID channel;
-
 
 	bool isEntrance() const;
 	bool isExit() const;

--- a/lib/mapping/MapReaderH3M.cpp
+++ b/lib/mapping/MapReaderH3M.cpp
@@ -106,8 +106,6 @@ int32_t MapReaderH3M::readHeroPortrait()
 
 	if(result.getNum() == features.heroIdentifierInvalid)
 		return int32_t(-1);
-
-	assert(result.getNum() < features.heroesPortraitsCount);
 	return remapper.remapPortrrait(result);
 }
 


### PR DESCRIPTION
**Summary**
This PR introduces the GetNextVisibleBoundPortalFeature, which enhances the user's navigation experience in the adventure map. Now, right-clicking on any portal will sequentially move the screen to the next exit/entrance, providing a more intuitive way to understand portal connections.

**Future Work**
1. Implement long/short click to distinguish between original behavior (show caption on long press) and show next portal (on short click).
2. Remove focus/selection from hero after viewing next portal exit. This will help to easily return scsreen to the hero (rather than opening hero window).

Multiple exits may necessitate splitting the info window into additional windows.
The info window doesn't display the location on the map and the minimap.
Implementing this feature via the info window may require more time.