### PR TITLE
NKAI: cancel checking building which needs itself as prerequisite

### DIFF
--- a/AI/Nullkiller/Analyzers/BuildAnalyzer.cpp
+++ b/AI/Nullkiller/Analyzers/BuildAnalyzer.cpp
@@ -256,7 +256,7 @@ BuildingInfo BuildAnalyzer::getBuildingOrPrerequisite(
 			{
 				logAi->trace("cant build. Need other dwelling");
 			}
-			else
+			else if(missingBuildings[0] != toBuild)
 			{
 				logAi->trace("cant build. Need %d", missingBuildings[0].num);
 
@@ -273,6 +273,12 @@ BuildingInfo BuildAnalyzer::getBuildingOrPrerequisite(
 				prerequisite.dailyIncome = info.dailyIncome;
 
 				return prerequisite;
+			}
+			else
+			{
+				logAi->trace("Cant build. The building requires itself as prerequisite");
+
+				return info;
 			}
 		}
 	}


### PR DESCRIPTION
Sometimes modders need to block normal building creation but allow creating it via events. So the building is added as a prerequisite to itself. NKAI hangs in endless loop in this case