### PR TITLE
Award 500 experience for towns conquered during a battle.

### DIFF
--- a/server/battles/BattleResultProcessor.cpp
+++ b/server/battles/BattleResultProcessor.cpp
@@ -241,12 +241,12 @@ void BattleResultProcessor::endBattle(const CBattleInfoCallback & battle)
 			battleResult->exp[1] += 500;
 		if(heroDefender)
 			battleResult->exp[0] += 500;
-
-		// Give 500 exp to winner if a town was conquered during the battle
-		const auto * defendedTown = battle.battleGetDefendedTown();
-		if (defendedTown && battleResult->winner == BattleSide::ATTACKER)
-			battleResult->exp[BattleSide::ATTACKER] += 500;
 	}
+
+	// Give 500 exp to winner if a town was conquered during the battle
+	const auto * defendedTown = battle.battleGetDefendedTown();
+	if (defendedTown && battleResult->winner == BattleSide::ATTACKER)
+		battleResult->exp[BattleSide::ATTACKER] += 500;
 
 	if(heroAttacker)
 		battleResult->exp[0] = heroAttacker->calculateXp(battleResult->exp[0]);//scholar skill

--- a/server/battles/BattleResultProcessor.cpp
+++ b/server/battles/BattleResultProcessor.cpp
@@ -241,6 +241,11 @@ void BattleResultProcessor::endBattle(const CBattleInfoCallback & battle)
 			battleResult->exp[1] += 500;
 		if(heroDefender)
 			battleResult->exp[0] += 500;
+
+		// Give 500 exp to winner if a town was conquered during the battle
+		const auto * defendedTown = battle.battleGetDefendedTown();
+		if (defendedTown && battleResult->winner == BattleSide::ATTACKER)
+			battleResult->exp[BattleSide::ATTACKER] += 500;
 	}
 
 	if(heroAttacker)


### PR DESCRIPTION
**Summary**
This PR fixes a bug/missing feature where if a town was conquered during a battle 500 extra experience points should be awarded to the attacker.

 - Fixes #2784

Before patch:
![without_patch](https://github.com/vcmi/vcmi/assets/1322979/16a8ba30-52f3-4d9d-862d-90ef8994960d)

After patch:
![with_patch](https://github.com/vcmi/vcmi/assets/1322979/8cd3a40a-4e43-4c1b-8c7c-14f6ff4ddf3b)

