### PR TITLE
Artifacts counter impovements

### DIFF
--- a/client/widgets/CArtifactHolder.cpp
+++ b/client/widgets/CArtifactHolder.cpp
@@ -264,7 +264,7 @@ bool ArtifactUtilsClient::askToAssemble(const CGHeroInstance * hero, const Artif
 	if(hero->tempOwner != LOCPLINT->playerID)
 		return false;
 
-	auto assemblyPossibilities = ArtifactUtils::assemblyPossibilities(hero, art->getTypeId(), ArtifactUtils::isSlotEquipment(slot));
+	auto assemblyPossibilities = ArtifactUtils::assemblyPossibilities(hero, art->getTypeId());
 	if(!assemblyPossibilities.empty())
 	{
 		auto askThread = new boost::thread([hero, art, slot, assemblyPossibilities]() -> void

--- a/client/widgets/CArtifactsOfHeroBase.cpp
+++ b/client/widgets/CArtifactsOfHeroBase.cpp
@@ -261,8 +261,10 @@ void CArtifactsOfHeroBase::setSlotData(ArtPlacePtr artPlace, const ArtifactPosit
 			{
 				arts.insert(std::pair(combinedArt, 0));
 				for(const auto part : combinedArt->getConstituents())
-					if(artSet.hasArt(part->getId(), true))
+				{
+					if(artSet.hasArt(part->getId(), false))
 						arts.at(combinedArt)++;
+				}
 			}
 			artPlace->addCombinedArtInfo(arts);
 		}

--- a/client/widgets/CWindowWithArtifacts.cpp
+++ b/client/widgets/CWindowWithArtifacts.cpp
@@ -244,7 +244,7 @@ void CWindowWithArtifacts::rightClickArtPlaceHero(CArtifactsOfHeroBase & artsIns
 
 void CWindowWithArtifacts::artifactRemoved(const ArtifactLocation & artLoc)
 {
-	updateSlots(artLoc.slot);
+	updateSlots();
 }
 
 void CWindowWithArtifacts::artifactMoved(const ArtifactLocation & srcLoc, const ArtifactLocation & destLoc, bool withRedraw)
@@ -310,26 +310,23 @@ void CWindowWithArtifacts::artifactMoved(const ArtifactLocation & srcLoc, const 
 
 void CWindowWithArtifacts::artifactDisassembled(const ArtifactLocation & artLoc)
 {
-	updateSlots(artLoc.slot);
+	updateSlots();
 }
 
 void CWindowWithArtifacts::artifactAssembled(const ArtifactLocation & artLoc)
 {
 	markPossibleSlots();
-	updateSlots(artLoc.slot);
+	updateSlots();
 }
 
-void CWindowWithArtifacts::updateSlots(const ArtifactPosition & slot)
+void CWindowWithArtifacts::updateSlots()
 {
-	auto updateSlotBody = [slot](auto artSetWeak) -> void
+	auto updateSlotBody = [](auto artSetWeak) -> void
 	{
 		if(const auto artSetPtr = artSetWeak.lock())
 		{
-			if(ArtifactUtils::isSlotEquipment(slot))
-				artSetPtr->updateWornSlots();
-			else if(ArtifactUtils::isSlotBackpack(slot))
-				artSetPtr->updateBackpackSlots();
-
+			artSetPtr->updateWornSlots();
+			artSetPtr->updateBackpackSlots();
 			artSetPtr->redraw();
 		}
 	};

--- a/client/widgets/CWindowWithArtifacts.h
+++ b/client/widgets/CWindowWithArtifacts.h
@@ -43,7 +43,7 @@ private:
 	std::vector<CArtifactsOfHeroPtr> artSets;
 	CloseCallback closeCallback;
 
-	void updateSlots(const ArtifactPosition & slot);
+	void updateSlots();
 	std::optional<std::tuple<const CGHeroInstance*, const CArtifactInstance*>> getState();
 	std::optional<CArtifactsOfHeroPtr> findAOHbyRef(CArtifactsOfHeroBase & artsInst);
 	void markPossibleSlots();

--- a/lib/ArtifactUtils.cpp
+++ b/lib/ArtifactUtils.cpp
@@ -116,7 +116,7 @@ DLL_LINKAGE bool ArtifactUtils::isBackpackFreeSlots(const CArtifactSet * target,
 }
 
 DLL_LINKAGE std::vector<const CArtifact*> ArtifactUtils::assemblyPossibilities(
-	const CArtifactSet * artSet, const ArtifactID & aid, bool equipped)
+	const CArtifactSet * artSet, const ArtifactID & aid)
 {
 	std::vector<const CArtifact*> arts;
 	const auto * art = aid.toArtifact();
@@ -130,23 +130,10 @@ DLL_LINKAGE std::vector<const CArtifact*> ArtifactUtils::assemblyPossibilities(
 
 		for(const auto constituent : artifact->getConstituents()) //check if all constituents are available
 		{
-			if(equipped)
+			if(!artSet->hasArt(constituent->getId(), false, false, false))
 			{
-				// Search for equipped arts
-				if(!artSet->hasArt(constituent->getId(), true, false, false))
-				{
-					possible = false;
-					break;
-				}
-			}
-			else
-			{
-				// Search in backpack
-				if(!artSet->hasArtBackpack(constituent->getId()))
-				{
-					possible = false;
-					break;
-				}
+				possible = false;
+				break;
 			}
 		}
 		if(possible)

--- a/lib/ArtifactUtils.h
+++ b/lib/ArtifactUtils.h
@@ -36,7 +36,7 @@ namespace ArtifactUtils
 	DLL_LINKAGE bool isSlotBackpack(const ArtifactPosition & slot);
 	DLL_LINKAGE bool isSlotEquipment(const ArtifactPosition & slot);
 	DLL_LINKAGE bool isBackpackFreeSlots(const CArtifactSet * target, const size_t reqSlots = 1);
-	DLL_LINKAGE std::vector<const CArtifact*> assemblyPossibilities(const CArtifactSet * artSet, const ArtifactID & aid, bool equipped);
+	DLL_LINKAGE std::vector<const CArtifact*> assemblyPossibilities(const CArtifactSet * artSet, const ArtifactID & aid);
 	DLL_LINKAGE CArtifactInstance * createScroll(const SpellID & sid);
 	DLL_LINKAGE CArtifactInstance * createNewArtifactInstance(CArtifact * art);
 	DLL_LINKAGE CArtifactInstance * createNewArtifactInstance(const ArtifactID & aid);

--- a/lib/CArtHandler.cpp
+++ b/lib/CArtHandler.cpp
@@ -820,12 +820,6 @@ ArtifactPosition CArtifactSet::getArtPos(const ArtifactID & aid, bool onlyWorn, 
 	return result.empty() ? ArtifactPosition{ArtifactPosition::PRE_FIRST} : result[0];
 }
 
-ArtifactPosition CArtifactSet::getArtBackpackPos(const ArtifactID & aid) const
-{
-	const auto result = getBackpackArtPositions(aid);
-	return result.empty() ? ArtifactPosition{ArtifactPosition::PRE_FIRST} : result[0];
-}
-
 std::vector<ArtifactPosition> CArtifactSet::getAllArtPositions(const ArtifactID & aid, bool onlyWorn, bool allowLocked, bool getAll) const
 {
 	std::vector<ArtifactPosition> result;

--- a/lib/CArtHandler.h
+++ b/lib/CArtHandler.h
@@ -260,7 +260,6 @@ public:
 	/// (if more than one such artifact lower ID is returned)
 	ArtifactPosition getArtPos(const ArtifactID & aid, bool onlyWorn = true, bool allowLocked = true) const;
 	ArtifactPosition getArtPos(const CArtifactInstance *art) const;
-	ArtifactPosition getArtBackpackPos(const ArtifactID & aid) const;
 	std::vector<ArtifactPosition> getAllArtPositions(const ArtifactID & aid, bool onlyWorn, bool allowLocked, bool getAll) const;
 	std::vector<ArtifactPosition> getBackpackArtPositions(const ArtifactID & aid) const;
 	const CArtifactInstance * getArtByInstanceId(const ArtifactInstanceID & artInstId) const;

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -2683,7 +2683,7 @@ bool CGameHandler::moveArtifact(const ArtifactLocation &al1, const ArtifactLocat
 		}
 
 		MoveArtifact ma(&src, &dst);
-		if(dst.slot == ArtifactPosition::TRANSITION_POS)
+		if(src.artHolder == dst.artHolder)
 			ma.askAssemble = false;
 		sendAndApply(&ma);
 	}


### PR DESCRIPTION
Trying to fix https://github.com/vcmi/vcmi/issues/2581.
Now the counter in the pop-up window will also counts artifacts that are in the backpack.
A combined artifact can now be assembled even if some of its parts are in the backpack.
In this case, the assembled artifact will be placed at the beginning of the backpack. Or if the assembly is initiated from the backpack, then will be placed in the slot of the artifact that the player clicked on.

It was also noted that the number of annoying assembling requests has increased, because all artifacts are taken into account.
I have reduced the number of such requests. And now the request will be asked only if the artifact is transferred from hero to hero. This is experimental change. (The player can still assemble/disassemble artifacts by clicking the right button.)