### PR TITLE
vcmi: make "noneOf" selector more restrictive

### DIFF
--- a/CI/mingw-ubuntu/before_install.sh
+++ b/CI/mingw-ubuntu/before_install.sh
@@ -6,10 +6,10 @@ sudo update-alternatives --set x86_64-w64-mingw32-g++ /usr/bin/x86_64-w64-mingw3
 
 # Workaround for getting new MinGW headers on Ubuntu 22.04.
 # Remove it once MinGW headers version in repository will be 10.0 at least
-curl -O -L http://mirrors.kernel.org/ubuntu/pool/universe/m/mingw-w64/mingw-w64-common_10.0.0-2_all.deb \
-  && sudo dpkg -i mingw-w64-common_10.0.0-2_all.deb;
-curl -O -L http://mirrors.kernel.org/ubuntu/pool/universe/m/mingw-w64/mingw-w64-x86-64-dev_10.0.0-2_all.deb \
-  && sudo dpkg -i mingw-w64-x86-64-dev_10.0.0-2_all.deb;
+curl -O -L http://mirrors.kernel.org/ubuntu/pool/universe/m/mingw-w64/mingw-w64-common_10.0.0-3_all.deb \
+  && sudo dpkg -i mingw-w64-common_10.0.0-3_all.deb;
+curl -O -L http://mirrors.kernel.org/ubuntu/pool/universe/m/mingw-w64/mingw-w64-x86-64-dev_10.0.0-3_all.deb \
+  && sudo dpkg -i mingw-w64-x86-64-dev_10.0.0-3_all.deb;
 
 mkdir ~/.conan ; cd ~/.conan
 curl -L "https://github.com/vcmi/vcmi-deps-windows-conan/releases/download/1.0/vcmi-deps-windows-conan-w64.tgz" \

--- a/lib/JsonNode.cpp
+++ b/lib/JsonNode.cpp
@@ -1058,9 +1058,9 @@ CSelector JsonUtils::parseSelector(const JsonNode & ability)
 	value = &ability["noneOf"];
 	if(value->isVector())
 	{
-		CSelector base = Selector::all;
+		CSelector base = Selector::none;
 		for(const auto & andN : value->Vector())
-			base.And(parseSelector(andN));
+			base.Or(parseSelector(andN));
 		
 		ret = ret.And(base.Not());
 	}


### PR DESCRIPTION
It should do "or-not" instead of "and-not", because if we write 

```js
"noneOf" : [
     { "type" : "UNDEAD"},
     {"type" : "NON_LIVING"}
]
```

it should not affect both undead and non-living enemies, but not require enemy to be both undead and non-living same time.

Need to be merged after #2821, includes it.