### PR TITLE
Erase outdated path that was previously available

### DIFF
--- a/client/PlayerLocalState.cpp
+++ b/client/PlayerLocalState.cpp
@@ -68,7 +68,10 @@ bool PlayerLocalState::setPath(const CGHeroInstance * h, const int3 & destinatio
 {
 	CGPath path;
 	if(!owner.cb->getPathsInfo(h)->getPath(path, destination))
+	{
+		paths.erase(h); //invalidate previously possible path if selected (before other hero blocked only path / fly spell expired)
 		return false;
+	}
 
 	setPath(h, path);
 	return true;


### PR DESCRIPTION
When 2nd hero blocks path or fly spell expires, it is possible to see invalid path still drawn on adventure map. This PR fixes these cases. In H3 there is no path restoration when fly spell is re-cast or the way is unblocked again, so forgetting the path should be OK.