### PR TITLE
alt mode to select instead of changing path

### DIFF
--- a/client/adventureMap/AdventureMapInterface.cpp
+++ b/client/adventureMap/AdventureMapInterface.cpp
@@ -537,8 +537,11 @@ void AdventureMapInterface::onTileLeftClicked(const int3 &mapPos)
 			}
 			else //remove old path and find a new one if we clicked on accessible tile
 			{
-				if(canSelect && GH.isKeyboardCtrlDown())
-					LOCPLINT->localState->setSelection(static_cast<const CArmedInstance*>(topBlocking));
+				if(GH.isKeyboardCtrlDown())
+				{
+					if(canSelect)
+						LOCPLINT->localState->setSelection(static_cast<const CArmedInstance*>(topBlocking));
+				}
 				else
 				{
 					LOCPLINT->localState->setPath(currentHero, mapPos);
@@ -616,7 +619,7 @@ void AdventureMapInterface::onTileHovered(const int3 &mapPos)
 		}
 	}
 
-	if(LOCPLINT->localState->getCurrentArmy()->ID == Obj::TOWN)
+	if(LOCPLINT->localState->getCurrentArmy()->ID == Obj::TOWN || GH.isKeyboardCtrlDown())
 	{
 		if(objAtTile)
 		{
@@ -668,12 +671,7 @@ void AdventureMapInterface::onTileHovered(const int3 &mapPos)
 				if(LOCPLINT->localState->getCurrentArmy()  == objAtTile)
 					CCS->curh->set(Cursor::Map::HERO);
 				else
-				{
-					if(GH.isKeyboardCtrlDown())
-						CCS->curh->set(Cursor::Map::HERO);
-					else
-						CCS->curh->set(cursorExchange[turns]);
-				}
+					CCS->curh->set(cursorExchange[turns]);
 			}
 			else if(pathNode->layer == EPathfindingLayer::LAND)
 				CCS->curh->set(cursorVisit[turns]);

--- a/client/adventureMap/AdventureMapInterface.cpp
+++ b/client/adventureMap/AdventureMapInterface.cpp
@@ -537,8 +537,13 @@ void AdventureMapInterface::onTileLeftClicked(const int3 &mapPos)
 			}
 			else //remove old path and find a new one if we clicked on accessible tile
 			{
-				LOCPLINT->localState->setPath(currentHero, mapPos);
-				onHeroChanged(currentHero);
+				if(canSelect && GH.isKeyboardCtrlDown())
+					LOCPLINT->localState->setSelection(static_cast<const CArmedInstance*>(topBlocking));
+				else
+				{
+					LOCPLINT->localState->setPath(currentHero, mapPos);
+					onHeroChanged(currentHero);
+				}
 			}
 		}
 	} //end of hero is selected "case"
@@ -663,7 +668,12 @@ void AdventureMapInterface::onTileHovered(const int3 &mapPos)
 				if(LOCPLINT->localState->getCurrentArmy()  == objAtTile)
 					CCS->curh->set(Cursor::Map::HERO);
 				else
-					CCS->curh->set(cursorExchange[turns]);
+				{
+					if(GH.isKeyboardCtrlDown())
+						CCS->curh->set(Cursor::Map::HERO);
+					else
+						CCS->curh->set(cursorExchange[turns]);
+				}
 			}
 			else if(pathNode->layer == EPathfindingLayer::LAND)
 				CCS->curh->set(cursorVisit[turns]);

--- a/client/adventureMap/AdventureMapInterface.cpp
+++ b/client/adventureMap/AdventureMapInterface.cpp
@@ -535,14 +535,14 @@ void AdventureMapInterface::onTileLeftClicked(const int3 &mapPos)
 					LOCPLINT->moveHero(currentHero, LOCPLINT->localState->getPath(currentHero));
 				return;
 			}
-			else //remove old path and find a new one if we clicked on accessible tile
+			else
 			{
-				if(GH.isKeyboardCtrlDown())
+				if(GH.isKeyboardCtrlDown()) //normal click behaviour (as no hero selected)
 				{
 					if(canSelect)
 						LOCPLINT->localState->setSelection(static_cast<const CArmedInstance*>(topBlocking));
 				}
-				else
+				else //remove old path and find a new one if we clicked on accessible tile
 				{
 					LOCPLINT->localState->setPath(currentHero, mapPos);
 					onHeroChanged(currentHero);

--- a/docs/players/Game_Mechanics.md
+++ b/docs/players/Game_Mechanics.md
@@ -29,6 +29,9 @@ Some of H3 mechanics can't be straight considered as bug, but default VCMI behav
 
 # List of extended game functionality
 
+## Adventure map
+- [LCtrl] + LClick – perform a normal click (same as no hero is selected). This make it possible to select other hero instead of changing path of current hero.
+
 ## Quick Army Management
 
 - [LShift] + LClick – splits a half units from the selected stack into an empty slot.


### PR DESCRIPTION
Ctrl-click on hero will select him instead of changing path of current hero.

@IvanSavenko Where do we document this feature?