### PR TITLE
Save RNG state and load it on battle replay

### DIFF
--- a/server/battles/BattleProcessor.cpp
+++ b/server/battles/BattleProcessor.cpp
@@ -79,6 +79,7 @@ void BattleProcessor::restartBattlePrimary(const BattleID & battleID, const CArm
 			}
 		}
 
+		lastBattleQuery->rngSerializer.iser & gameHandler->getRandomGenerator();
 		lastBattleQuery->result = std::nullopt;
 
 		assert(lastBattleQuery->belligerents[0] == battle->sides[0].armyObject);
@@ -109,6 +110,7 @@ void BattleProcessor::startBattlePrimary(const CArmedInstance *army1, const CArm
 	heroes[0] = hero1;
 	heroes[1] = hero2;
 
+	auto savedRng = CMemorySerializer::deepCopy(gameHandler->getRandomGenerator());
 	auto battleID = setupBattle(tile, armies, heroes, creatureBank, town); //initializes stacks, places creatures on battlefield, blocks and informs player interfaces
 
 	const auto * battle = gameHandler->gameState()->getBattle(battleID);
@@ -129,6 +131,7 @@ void BattleProcessor::startBattlePrimary(const CArmedInstance *army1, const CArm
 			if(heroes[i])
 				newBattleQuery->initialHeroMana[i] = heroes[i]->mana;
 
+		newBattleQuery->rngSerializer.oser & *savedRng.release();
 		gameHandler->queries->addQuery(newBattleQuery);
 	}
 

--- a/server/queries/BattleQueries.h
+++ b/server/queries/BattleQueries.h
@@ -12,6 +12,7 @@
 #include "CQuery.h"
 
 #include "../../lib/NetPacks.h"
+#include "../../lib/serializer/CMemorySerializer.h"
 
 VCMI_LIB_NAMESPACE_BEGIN
 class IBattleInfo;
@@ -25,6 +26,7 @@ public:
 
 	BattleID battleID;
 	std::optional<BattleResult> result;
+	CMemorySerializer rngSerializer;
 
 	CBattleQuery(CGameHandler * owner);
 	CBattleQuery(CGameHandler * owner, const IBattleInfo * Bi); //TODO


### PR DESCRIPTION
So a battle replay has same morale, damage, etc as a quick battle, otherwise sometimes you don't even have a chance to perform better than a quick combat. (HD mod replays work the same way).