### PR TITLE
Prefer symlink word

### DIFF
--- a/docs/players/Installation_Android.md
+++ b/docs/players/Installation_Android.md
@@ -23,7 +23,7 @@ Installation is a two step process, at first you need to install game, then you 
 
 ### I imported game data files, but music in game is missing
 
-**Solution:** Try to run data import again or copy Mp3 folder from Heroes III manually to Android/data/is.xyz.vcmi/files/vcmi-data/Mp3
+**Solution:** Try to run data import again or place Mp3 folder from Heroes III manually to Android/data/is.xyz.vcmi/files/vcmi-data/Mp3
 
 ### I installed google play version, but have a problem while installing daily builds
 

--- a/docs/players/Installation_Linux.md
+++ b/docs/players/Installation_Linux.md
@@ -101,7 +101,7 @@ innoextract --output-dir=~/Downloads/HoMM3 "setup_heroes_of_might_and_magic_3_co
 ```
 (note that installer file name might be different)
 
-Once innoextract completes, start VCMI Launcher and choose to copy existing files. Select the ~/Downloads/HoMM3 directory. Once copy is complete, you can delete both offline installer files as well as ~/Downloads/HoMM3.
+Once innoextract completes, start VCMI Launcher and choose to place existing files. Select the ~/Downloads/HoMM3 directory. Once placing is complete, you can delete both offline installer files as well as ~/Downloads/HoMM3.
 
 ## Install manually using existing Heroes III data
 

--- a/docs/players/Installation_Windows.md
+++ b/docs/players/Installation_Windows.md
@@ -17,7 +17,7 @@ Install one of following into new folder, same as when installing new game:
 **Since VCMI 1.2 you can skip this step, just run VCMI launcher and it will help you with importing H3 data. For older releases you can follow this step.**
 
 -   Install Heroes III from disk or using GOG installer.
--   Copy "Data", "Maps" and "Mp3" from Heroes III to: `Documents\My Games\vcmi\`
+-   Place "Data", "Maps" and "Mp3" from Heroes III to: `Documents\My Games\vcmi\`
 
 Create this folder if it doesnt exist yet
 

--- a/docs/players/Installation_iOS.md
+++ b/docs/players/Installation_iOS.md
@@ -28,7 +28,7 @@ To play the game, you need to upload HoMM3 data files - **Data**, **Maps** and *
 
 If you have data somewhere on device or in shared folder or you have downloaded it, you can copy it directly on your iPhone/iPad using Files application.
 
-Move or copy **Data**, **Maps** and **Mp3** folders into vcmi application - it will be visible in Files along with other applications' folders.
+Place **Data**, **Maps** and **Mp3** folders into vcmi application - it will be visible in Files along with other applications' folders.
 
 ### Step 2.c: Installing data files with Xcode on macOS
 

--- a/docs/players/Installation_macOS.md
+++ b/docs/players/Installation_macOS.md
@@ -16,4 +16,4 @@ Please report about gameplay problem on forums: [Help & Bugs](https://forum.vcmi
 # Step 2: Installing Heroes III data files
 
 1.  Find a way to unpack Windows Heroes III or GOG installer. For example, use `vcmibuilder` script inside app bundle or install the game with [CrossOver](https://www.codeweavers.com/crossover) or [Wineskin](https://github.com/Gcenx/WineskinServer).
-2.  Copy (or symlink) **Data**, **Maps** and **Mp3** directories from Heroes III to:`~/Library/Application\ Support/vcmi/`
+2.  Symlink **Data**, **Maps** and **Mp3** directories from Heroes III to:`~/Library/Application\ Support/vcmi/`

--- a/docs/players/Installation_macOS.md
+++ b/docs/players/Installation_macOS.md
@@ -16,4 +16,4 @@ Please report about gameplay problem on forums: [Help & Bugs](https://forum.vcmi
 # Step 2: Installing Heroes III data files
 
 1.  Find a way to unpack Windows Heroes III or GOG installer. For example, use `vcmibuilder` script inside app bundle or install the game with [CrossOver](https://www.codeweavers.com/crossover) or [Wineskin](https://github.com/Gcenx/WineskinServer).
-2.  Symlink **Data**, **Maps** and **Mp3** directories from Heroes III to:`~/Library/Application\ Support/vcmi/`
+2.  Place or symlink **Data**, **Maps** and **Mp3** directories from Heroes III to:`~/Library/Application\ Support/vcmi/`


### PR DESCRIPTION
For reasons, it is probably preferable that our documentation only says "symlink" here