### PR TITLE
#1912 trap, exception on adding duplicating hero

### DIFF
--- a/lib/mapObjects/CGHeroInstance.cpp
+++ b/lib/mapObjects/CGHeroInstance.cpp
@@ -37,6 +37,7 @@
 #include "../modding/ModScope.h"
 #include "../constants/StringConstants.h"
 #include "../battle/Unit.h"
+#include "CConfigHandler.h"
 
 VCMI_LIB_NAMESPACE_BEGIN
 
@@ -1504,8 +1505,29 @@ std::string CGHeroInstance::getHeroTypeName() const
 
 void CGHeroInstance::afterAddToMap(CMap * map)
 {
+	auto existingHero = std::find_if(map->objects.begin(), map->objects.end(), [&](const CGObjectInstance * o) ->bool
+		{
+			return (o->ID == Obj::HERO || o->ID == Obj::PRISON) && o->subID == subID && o != this;
+		});
+
+	if(existingHero != map->objects.end())
+	{
+		if(settings["session"]["editor"].Bool())
+		{
+			logGlobal->warn("Hero is already on the map at %s", (*existingHero)->visitablePos().toString());
+		}
+		else
+		{
+			logGlobal->error("Hero is already on the map at %s", (*existingHero)->visitablePos().toString());
+
+			throw std::runtime_error("Hero is already on the map");
+		}
+	}
+
 	if(ID == Obj::HERO)
+	{		
 		map->heroesOnMap.emplace_back(this);
+	}
 }
 void CGHeroInstance::afterRemoveFromMap(CMap* map)
 {

--- a/mapeditor/mainwindow.cpp
+++ b/mapeditor/mainwindow.cpp
@@ -68,6 +68,10 @@ QPixmap pixmapFromJson(const QJsonValue &val)
 void init()
 {
 	loadDLLClasses();
+
+	Settings config = settings.write["session"]["editor"];
+	config->Bool() = true;
+
 	logGlobal->info("Initializing VCMI_Lib");
 }
 


### PR DESCRIPTION
A trap for #1912. We expect it is duplicating heroes issue so I added a trap for it to trigger earlier and reveal who wants to add duplicating hero. The map with duplicating Orrins attached to #1912 crashes on start now as expected