### PR TITLE
Remove hero movement thread

### DIFF
--- a/AI/EmptyAI/CEmptyAI.cpp
+++ b/AI/EmptyAI/CEmptyAI.cpp
@@ -61,7 +61,7 @@ void CEmptyAI::showBlockingDialog(const std::string &text, const std::vector<Com
 	cb->selectionMade(0, askID);
 }
 
-void CEmptyAI::showTeleportDialog(TeleportChannelID channel, TTeleportExitsList exits, bool impassable, QueryID askID)
+void CEmptyAI::showTeleportDialog(const CGHeroInstance * hero, TeleportChannelID channel, TTeleportExitsList exits, bool impassable, QueryID askID)
 {
 	cb->selectionMade(0, askID);
 }

--- a/AI/EmptyAI/CEmptyAI.h
+++ b/AI/EmptyAI/CEmptyAI.h
@@ -29,7 +29,7 @@ public:
 	void heroGotLevel(const CGHeroInstance *hero, PrimarySkill pskill, std::vector<SecondarySkill> &skills, QueryID queryID) override;
 	void commanderGotLevel (const CCommanderInstance * commander, std::vector<ui32> skills, QueryID queryID) override;
 	void showBlockingDialog(const std::string &text, const std::vector<Component> &components, QueryID askID, const int soundID, bool selection, bool cancel) override;
-	void showTeleportDialog(TeleportChannelID channel, TTeleportExitsList exits, bool impassable, QueryID askID) override;
+	void showTeleportDialog(const CGHeroInstance * hero, TeleportChannelID channel, TTeleportExitsList exits, bool impassable, QueryID askID) override;
 	void showGarrisonDialog(const CArmedInstance *up, const CGHeroInstance *down, bool removableUnits, QueryID queryID) override;
 	void showMapObjectSelectDialog(QueryID askID, const Component & icon, const MetaString & title, const MetaString & description, const std::vector<ObjectInstanceID> & objects) override;
 	std::optional<BattleAction> makeSurrenderRetreatDecision(const BattleID & battleID, const BattleStateInfoForRetreat & battleState) override;

--- a/AI/Nullkiller/AIGateway.cpp
+++ b/AI/Nullkiller/AIGateway.cpp
@@ -654,7 +654,7 @@ void AIGateway::showBlockingDialog(const std::string & text, const std::vector<C
 	});
 }
 
-void AIGateway::showTeleportDialog(TeleportChannelID channel, TTeleportExitsList exits, bool impassable, QueryID askID)
+void AIGateway::showTeleportDialog(const CGHeroInstance * hero, TeleportChannelID channel, TTeleportExitsList exits, bool impassable, QueryID askID)
 {
 	NET_EVENT_HANDLER;
 	status.addQuery(askID, boost::str(boost::format("Teleport dialog query with %d exits") % exits.size()));

--- a/AI/Nullkiller/AIGateway.h
+++ b/AI/Nullkiller/AIGateway.h
@@ -117,7 +117,7 @@ public:
 	void commanderGotLevel(const CCommanderInstance * commander, std::vector<ui32> skills, QueryID queryID) override; //TODO
 	void showBlockingDialog(const std::string & text, const std::vector<Component> & components, QueryID askID, const int soundID, bool selection, bool cancel) override; //Show a dialog, player must take decision. If selection then he has to choose between one of given components, if cancel he is allowed to not choose. After making choice, CCallback::selectionMade should be called with number of selected component (1 - n) or 0 for cancel (if allowed) and askID.
 	void showGarrisonDialog(const CArmedInstance * up, const CGHeroInstance * down, bool removableUnits, QueryID queryID) override; //all stacks operations between these objects become allowed, interface has to call onEnd when done
-	void showTeleportDialog(TeleportChannelID channel, TTeleportExitsList exits, bool impassable, QueryID askID) override;
+	void showTeleportDialog(const CGHeroInstance * hero, TeleportChannelID channel, TTeleportExitsList exits, bool impassable, QueryID askID) override;
 	void showMapObjectSelectDialog(QueryID askID, const Component & icon, const MetaString & title, const MetaString & description, const std::vector<ObjectInstanceID> & objects) override;
 	void saveGame(BinarySerializer & h, const int version) override; //saving
 	void loadGame(BinaryDeserializer & h, const int version) override; //loading

--- a/AI/VCAI/VCAI.cpp
+++ b/AI/VCAI/VCAI.cpp
@@ -656,7 +656,7 @@ void VCAI::showBlockingDialog(const std::string & text, const std::vector<Compon
 	});
 }
 
-void VCAI::showTeleportDialog(TeleportChannelID channel, TTeleportExitsList exits, bool impassable, QueryID askID)
+void VCAI::showTeleportDialog(const CGHeroInstance * hero, TeleportChannelID channel, TTeleportExitsList exits, bool impassable, QueryID askID)
 {
 //	LOG_TRACE_PARAMS(logAi, "askID '%i', exits '%s'", askID % exits);
 	NET_EVENT_HANDLER;

--- a/AI/VCAI/VCAI.h
+++ b/AI/VCAI/VCAI.h
@@ -150,7 +150,7 @@ public:
 	void commanderGotLevel(const CCommanderInstance * commander, std::vector<ui32> skills, QueryID queryID) override; //TODO
 	void showBlockingDialog(const std::string & text, const std::vector<Component> & components, QueryID askID, const int soundID, bool selection, bool cancel) override; //Show a dialog, player must take decision. If selection then he has to choose between one of given components, if cancel he is allowed to not choose. After making choice, CCallback::selectionMade should be called with number of selected component (1 - n) or 0 for cancel (if allowed) and askID.
 	void showGarrisonDialog(const CArmedInstance * up, const CGHeroInstance * down, bool removableUnits, QueryID queryID) override; //all stacks operations between these objects become allowed, interface has to call onEnd when done
-	void showTeleportDialog(TeleportChannelID channel, TTeleportExitsList exits, bool impassable, QueryID askID) override;
+	void showTeleportDialog(const CGHeroInstance * hero, TeleportChannelID channel, TTeleportExitsList exits, bool impassable, QueryID askID) override;
 	void showMapObjectSelectDialog(QueryID askID, const Component & icon, const MetaString & title, const MetaString & description, const std::vector<ObjectInstanceID> & objects) override;
 	void saveGame(BinarySerializer & h, const int version) override; //saving
 	void loadGame(BinaryDeserializer & h, const int version) override; //loading

--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -142,6 +142,7 @@ set(client_SRCS
 	CVideoHandler.cpp
 	Client.cpp
 	ClientCommandManager.cpp
+	HeroMovementController.cpp
 	NetPacksClient.cpp
 	NetPacksLobbyClient.cpp
 )
@@ -304,6 +305,7 @@ set(client_HEADERS
 	Client.h
 	ClientCommandManager.h
 	ClientNetPackVisitors.h
+	HeroMovementController.h
 	LobbyClientNetPackVisitors.h
 	resource.h
 )

--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -347,7 +347,7 @@ void CPlayerInterface::heroMoved(const TryMoveHero & details, bool verbose)
 	if (!hero)
 		return;
 
-	movementController->heroMoved(hero, details);
+	movementController->onTryMoveHero(hero, details);
 }
 
 void CPlayerInterface::heroKilled(const CGHeroInstance* hero)
@@ -937,7 +937,7 @@ void CPlayerInterface::showInfoDialog(EInfoWindowMode type, const std::string &t
 		adventureInt->showInfoBoxMessage(components, text, timer);
 
 		// abort movement, if any. Strictly speaking unnecessary, but prevents some edge cases, like movement sound on visiting Magi Hut with "show messages in status window" on
-		movementController->movementAbortRequested();
+		movementController->requestMovementAbort();
 
 		if (makingTurn && GH.windows().count() > 0 && LOCPLINT == this)
 			CCS->soundh->playSound(static_cast<soundBase::soundID>(soundID));
@@ -984,7 +984,7 @@ void CPlayerInterface::showInfoDialog(const std::string &text, const std::vector
 	{
 		CCS->soundh->playSound(static_cast<soundBase::soundID>(soundID));
 		showingDialog->set(true);
-		movementController->movementAbortRequested(); // interrupt movement to show dialog
+		movementController->requestMovementAbort(); // interrupt movement to show dialog
 		GH.windows().pushWindow(temp);
 	}
 	else
@@ -1007,7 +1007,7 @@ void CPlayerInterface::showYesNoDialog(const std::string &text, CFunctionList<vo
 {
 	boost::unique_lock<boost::recursive_mutex> un(*pim);
 
-	movementController->movementAbortRequested();
+	movementController->requestMovementAbort();
 	LOCPLINT->showingDialog->setn(true);
 	CInfoWindow::showYesNoDialog(text, components, onYes, onNo, playerID);
 }
@@ -1017,7 +1017,7 @@ void CPlayerInterface::showBlockingDialog( const std::string &text, const std::v
 	EVENT_HANDLER_CALLED_BY_CLIENT;
 	waitWhileDialog();
 
-	movementController->movementAbortRequested();
+	movementController->requestMovementAbort();
 	CCS->soundh->playSound(static_cast<soundBase::soundID>(soundID));
 
 	if (!selection && cancel) //simple yes/no dialog
@@ -1182,7 +1182,7 @@ void CPlayerInterface::moveHero( const CGHeroInstance *h, const CGPath& path )
 	if (localState->isHeroSleeping(h))
 		localState->setHeroAwaken(h);
 
-	movementController->movementStartRequested(h, path);
+	movementController->requestMovementStart(h, path);
 }
 
 void CPlayerInterface::showGarrisonDialog( const CArmedInstance *up, const CGHeroInstance *down, bool removableUnits, QueryID queryID)

--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -1236,6 +1236,9 @@ void CPlayerInterface::requestRealized( PackageApplied *pa )
 {
 	if(pa->packType == typeList.getTypeID<MoveHero>())
 		movementController->onMoveHeroApplied();
+
+	if(pa->packType == typeList.getTypeID<QueryReply>())
+		movementController->onQueryReplyApplied();
 }
 
 void CPlayerInterface::showHeroExchange(ObjectInstanceID hero1, ObjectInstanceID hero2)

--- a/client/CPlayerInterface.h
+++ b/client/CPlayerInterface.h
@@ -194,7 +194,6 @@ public: // public interface for use by client via LOCPLINT access
 	void showInfoDialogAndWait(std::vector<Component> & components, const MetaString & text);
 	void showYesNoDialog(const std::string &text, CFunctionList<void()> onYes, CFunctionList<void()> onNo, const std::vector<std::shared_ptr<CComponent>> & components = std::vector<std::shared_ptr<CComponent>>());
 
-	void stopMovement();
 	void moveHero(const CGHeroInstance *h, const CGPath& path);
 
 	void tryDigging(const CGHeroInstance *h);

--- a/client/CPlayerInterface.h
+++ b/client/CPlayerInterface.h
@@ -47,6 +47,7 @@ class KeyInterested;
 class MotionInterested;
 class PlayerLocalState;
 class TimeInterested;
+class HeroMovementController;
 
 namespace boost
 {
@@ -57,7 +58,6 @@ namespace boost
 /// Central class for managing user interface logic
 class CPlayerInterface : public CGameInterface, public IUpdateable
 {
-	bool duringMovement;
 	bool ignoreEvents;
 	size_t numOfMovedArts;
 
@@ -67,9 +67,7 @@ class CPlayerInterface : public CGameInterface, public IUpdateable
 
 	std::list<std::shared_ptr<CInfoWindow>> dialogs; //queue of dialogs awaiting to be shown (not currently shown!)
 
-	ObjectInstanceID destinationTeleport; //contain -1 or object id if teleportation
-	int3 destinationTeleportPos;
-
+	std::unique_ptr<HeroMovementController> movementController;
 public: // TODO: make private
 	std::shared_ptr<Environment> env;
 
@@ -222,7 +220,6 @@ private:
 		{
 			owner.ignoreEvents = false;
 		};
-
 	};
 
 	void heroKilled(const CGHeroInstance* hero);
@@ -231,9 +228,6 @@ private:
 	void acceptTurn(QueryID queryID); //used during hot seat after your turn message is close
 	void initializeHeroTownList();
 	int getLastIndex(std::string namePrefix);
-	void doMoveHero(const CGHeroInstance *h, CGPath path);
-	void setMovementStatus(bool value);
-
 };
 
 /// Provides global access to instance of interface of currently active player

--- a/client/CPlayerInterface.h
+++ b/client/CPlayerInterface.h
@@ -120,7 +120,7 @@ protected: // Call-ins from server, should not be called directly, but only via 
 	void showInfoDialog(EInfoWindowMode type, const std::string & text, const std::vector<Component> & components, int soundID) override;
 	void showRecruitmentDialog(const CGDwelling *dwelling, const CArmedInstance *dst, int level) override;
 	void showBlockingDialog(const std::string &text, const std::vector<Component> &components, QueryID askID, const int soundID, bool selection, bool cancel) override; //Show a dialog, player must take decision. If selection then he has to choose between one of given components, if cancel he is allowed to not choose. After making choice, CCallback::selectionMade should be called with number of selected component (1 - n) or 0 for cancel (if allowed) and askID.
-	void showTeleportDialog(TeleportChannelID channel, TTeleportExitsList exits, bool impassable, QueryID askID) override;
+	void showTeleportDialog(const CGHeroInstance * hero, TeleportChannelID channel, TTeleportExitsList exits, bool impassable, QueryID askID) override;
 	void showGarrisonDialog(const CArmedInstance *up, const CGHeroInstance *down, bool removableUnits, QueryID queryID) override;
 	void showMapObjectSelectDialog(QueryID askID, const Component & icon, const MetaString & title, const MetaString & description, const std::vector<ObjectInstanceID> & objects) override;
 	void showMarketWindow(const IMarket *market, const CGHeroInstance *visitor) override;

--- a/client/HeroMovementController.cpp
+++ b/client/HeroMovementController.cpp
@@ -77,10 +77,7 @@ void HeroMovementController::onBattleStarted()
 	// when battle starts, game will send battleStart pack *before* movement confirmation
 	// and since network thread wait for battle intro to play, movement confirmation will only happen after intro
 	// leading to several bugs, such as blocked input during intro
-	// FIXME: should be on hero visit
-	assert(duringMovement == false);
-	assert(stoppingMovement == false);
-	duringMovement = false;
+	movementAbortRequested();
 }
 
 void HeroMovementController::showTeleportDialog(const CGHeroInstance * hero, TeleportChannelID channel, TTeleportExitsList exits, bool impassable, QueryID askID)
@@ -343,7 +340,7 @@ void HeroMovementController::moveHeroOnce(const CGHeroInstance * h, const CGPath
 
 		logGlobal->trace("Requesting hero movement to %s", nextNode.coord.toString());
 
-		bool useTransit = nextNode.layer == EPathfindingLayer::AIR;
+		bool useTransit = nextNode.layer == EPathfindingLayer::AIR || nextNode.layer == EPathfindingLayer::WATER;
 		LOCPLINT->cb->moveHero(h, nextCoord, useTransit);
 		return;
 	}

--- a/client/HeroMovementController.cpp
+++ b/client/HeroMovementController.cpp
@@ -1,0 +1,379 @@
+/*
+ * CPlayerInterface.cpp, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
+#include "StdInc.h"
+#include "HeroMovementController.h"
+
+#include "CGameInfo.h"
+#include "CMusicHandler.h"
+#include "CPlayerInterface.h"
+#include "PlayerLocalState.h"
+#include "adventureMap/AdventureMapInterface.h"
+#include "eventsSDL/InputHandler.h"
+#include "gui/CGuiHandler.h"
+#include "gui/CursorHandler.h"
+#include "mapView/mapHandler.h"
+
+#include "../CCallback.h"
+
+#include "../lib/pathfinder/CGPathNode.h"
+#include "../lib/mapObjects/CGHeroInstance.h"
+#include "../lib/mapObjects/MiscObjects.h"
+#include "../lib/RoadHandler.h"
+#include "../lib/TerrainHandler.h"
+#include "../lib/NetPacks.h"
+#include "../lib/CondSh.h"
+
+HeroMovementController::HeroMovementController()
+{
+	destinationTeleport = ObjectInstanceID();
+	destinationTeleportPos = int3(-1);
+	duringMovement = false;
+}
+
+void HeroMovementController::setMovementStatus(bool value)
+{
+	duringMovement = value;
+	if (value)
+	{
+		CCS->curh->hide();
+	}
+	else
+	{
+		CCS->curh->show();
+	}
+}
+
+bool HeroMovementController::isHeroMovingThroughGarrison(const CGHeroInstance * hero) const
+{
+	//to ignore calls on passing through garrisons
+	return (movementState == EMoveState::DURING_MOVE && LOCPLINT->localState->hasPath(hero) && LOCPLINT->localState->getPath(hero).nodes.size() > 1);
+}
+
+bool HeroMovementController::isHeroMoving() const
+{
+	return duringMovement;
+}
+
+void HeroMovementController::onMoveHeroApplied()
+{
+	assert(movementState == EMoveState::DURING_MOVE);
+
+	if(movementState == EMoveState::DURING_MOVE)
+	{
+		assert(destinationTeleport == ObjectInstanceID::NONE);
+		movementState = EMoveState::CONTINUE_MOVE;
+	}
+}
+
+void HeroMovementController::onQueryReplyApplied()
+{
+	assert(movementState == EMoveState::DURING_MOVE);
+
+	if(movementState == EMoveState::DURING_MOVE)
+	{
+		// After teleportation via CGTeleport object is finished
+		assert(destinationTeleport != ObjectInstanceID::NONE);
+		destinationTeleport = ObjectInstanceID();
+		destinationTeleportPos = int3(-1);
+		movementState = EMoveState::CONTINUE_MOVE;
+	}
+}
+
+void HeroMovementController::onPlayerTurnStarted()
+{
+	assert(movementState == EMoveState::STOP_MOVE);
+	movementState = EMoveState::STOP_MOVE;
+}
+
+void HeroMovementController::onBattleStarted()
+{
+	// when battle starts, game will send battleStart pack *before* movement confirmation
+	// and since network thread wait for battle intro to play, movement confirmation will only happen after intro
+	// leading to several bugs, such as blocked input during intro
+	movementState = EMoveState::STOP_MOVE;
+}
+
+void HeroMovementController::showTeleportDialog(TeleportChannelID channel, TTeleportExitsList exits, bool impassable, QueryID askID)
+{
+	int choosenExit = -1;
+	auto neededExit = std::make_pair(destinationTeleport, destinationTeleportPos);
+	if (destinationTeleport != ObjectInstanceID() && vstd::contains(exits, neededExit))
+		choosenExit = vstd::find_pos(exits, neededExit);
+
+	LOCPLINT->cb->selectionMade(choosenExit, askID);
+}
+
+void HeroMovementController::heroMoved(const CGHeroInstance * hero, const TryMoveHero & details)
+{
+	if (details.result == TryMoveHero::EMBARK || details.result == TryMoveHero::DISEMBARK)
+	{
+		if(hero->getRemovalSound() && hero->tempOwner == LOCPLINT->playerID)
+			CCS->soundh->playSound(hero->getRemovalSound().value());
+	}
+
+	std::unordered_set<int3> changedTiles {
+		hero->convertToVisitablePos(details.start),
+		hero->convertToVisitablePos(details.end)
+	};
+	adventureInt->onMapTilesChanged(changedTiles);
+	adventureInt->onHeroMovementStarted(hero);
+
+	bool directlyAttackingCreature = details.attackedFrom && LOCPLINT->localState->hasPath(hero) && LOCPLINT->localState->getPath(hero).endPos() == *details.attackedFrom;
+
+	if(LOCPLINT->makingTurn && hero->tempOwner == LOCPLINT->playerID) //we are moving our hero - we may need to update assigned path
+	{
+		if(details.result == TryMoveHero::TELEPORTATION)
+		{
+			if(LOCPLINT->localState->hasPath(hero))
+			{
+				assert(LOCPLINT->localState->getPath(hero).nodes.size() >= 2);
+				auto nodesIt = LOCPLINT->localState->getPath(hero).nodes.end() - 1;
+
+				if((nodesIt)->coord == hero->convertToVisitablePos(details.start)
+					&& (nodesIt - 1)->coord == hero->convertToVisitablePos(details.end))
+				{
+					//path was between entrance and exit of teleport -> OK, erase node as usual
+					LOCPLINT->localState->removeLastNode(hero);
+				}
+				else
+				{
+					//teleport was not along current path, it'll now be invalid (hero is somewhere else)
+					LOCPLINT->localState->erasePath(hero);
+
+				}
+			}
+		}
+
+		if(hero->pos != details.end //hero didn't change tile but visit succeeded
+			|| directlyAttackingCreature) // or creature was attacked from endangering tile.
+		{
+			LOCPLINT->localState->erasePath(hero);
+		}
+		else if(LOCPLINT->localState->hasPath(hero) && hero->pos == details.end) //&& hero is moving
+		{
+			if(details.start != details.end) //so we don't touch path when revisiting with spacebar
+				LOCPLINT->localState->removeLastNode(hero);
+		}
+	}
+
+	if(details.stopMovement()) //hero failed to move
+	{
+		movementState = EMoveState::STOP_MOVE;
+		adventureInt->onHeroChanged(hero);
+		return;
+	}
+
+	CGI->mh->waitForOngoingAnimations();
+
+	//move finished
+	adventureInt->onHeroChanged(hero);
+
+	//check if user cancelled movement
+	{
+		if (GH.input().ignoreEventsUntilInput())
+			movementState = EMoveState::STOP_MOVE;
+	}
+
+	if (movementState == EMoveState::WAITING_MOVE)
+		movementState = EMoveState::DURING_MOVE;
+
+	// Hero attacked creature directly, set direction to face it.
+	if (directlyAttackingCreature)
+	{
+		// Get direction to attacker.
+		int3 posOffset = *details.attackedFrom - details.end + int3(2, 1, 0);
+		static const ui8 dirLookup[3][3] =
+		{
+			{ 1, 2, 3 },
+			{ 8, 0, 4 },
+			{ 7, 6, 5 }
+		};
+		// FIXME: Avoid const_cast, make moveDir mutable in some other way?
+		const_cast<CGHeroInstance *>(hero)->moveDir = dirLookup[posOffset.y][posOffset.x];
+	}
+}
+
+void HeroMovementController::movementStopRequested()
+{
+	if (movementState == EMoveState::DURING_MOVE)//if we are in the middle of hero movement
+		movementState = EMoveState::STOP_MOVE;
+}
+
+void HeroMovementController::doMoveHero(const CGHeroInstance * h, const CGPath & path)
+{
+	setMovementStatus(true);
+
+	auto getObj = [&](int3 coord, bool ignoreHero)
+	{
+		return LOCPLINT->cb->getTile(h->convertToVisitablePos(coord))->topVisitableObj(ignoreHero);
+	};
+
+	auto isTeleportAction = [&](EPathNodeAction action) -> bool
+	{
+		if (action != EPathNodeAction::TELEPORT_NORMAL &&
+			action != EPathNodeAction::TELEPORT_BLOCKING_VISIT &&
+			action != EPathNodeAction::TELEPORT_BATTLE)
+		{
+			return false;
+		}
+
+		return true;
+	};
+
+	auto getDestTeleportObj = [&](const CGObjectInstance * currentObject, const CGObjectInstance * nextObjectTop, const CGObjectInstance * nextObject) -> const CGObjectInstance *
+	{
+		if (CGTeleport::isConnected(currentObject, nextObjectTop))
+			return nextObjectTop;
+
+		if (nextObjectTop && nextObjectTop->ID == Obj::HERO && CGTeleport::isConnected(currentObject, nextObject))
+		{
+			return nextObject;
+		}
+
+		return nullptr;
+	};
+
+	auto doMovement = [&](int3 dst, bool transit)
+	{
+		movementState = EMoveState::WAITING_MOVE;
+		LOCPLINT->cb->moveHero(h, dst, transit);
+		while(movementState != EMoveState::STOP_MOVE && movementState != EMoveState::CONTINUE_MOVE)
+			boost::this_thread::sleep_for(boost::chrono::milliseconds(1));
+	};
+
+	auto getMovementSoundFor = [&](const CGHeroInstance * hero, int3 posPrev, int3 posNext, EPathNodeAction moveType) -> AudioPath
+	{
+		if (moveType == EPathNodeAction::TELEPORT_BATTLE || moveType == EPathNodeAction::TELEPORT_BLOCKING_VISIT || moveType == EPathNodeAction::TELEPORT_NORMAL)
+			return {};
+
+		if (moveType == EPathNodeAction::EMBARK || moveType == EPathNodeAction::DISEMBARK)
+			return {};
+
+		if (moveType == EPathNodeAction::BLOCKING_VISIT)
+			return {};
+
+		// flying movement sound
+		if (hero->hasBonusOfType(BonusType::FLYING_MOVEMENT))
+			return AudioPath::builtin("HORSE10.wav");
+
+		auto prevTile = LOCPLINT->cb->getTile(h->convertToVisitablePos(posPrev));
+		auto nextTile = LOCPLINT->cb->getTile(h->convertToVisitablePos(posNext));
+
+		auto prevRoad = prevTile->roadType;
+		auto nextRoad = nextTile->roadType;
+		bool movingOnRoad = prevRoad->getId() != Road::NO_ROAD && nextRoad->getId() != Road::NO_ROAD;
+
+		if (movingOnRoad)
+			return nextTile->terType->horseSound;
+		else
+			return nextTile->terType->horseSoundPenalty;
+	};
+
+	auto canStop = [&](const CGPathNode * node) -> bool
+	{
+		if (node->layer != EPathfindingLayer::LAND && node->layer != EPathfindingLayer::SAIL)
+			return false;
+
+		if (node->accessible != EPathAccessibility::ACCESSIBLE)
+			return false;
+
+		return true;
+	};
+
+	int i = 1;
+	movementState = EMoveState::CONTINUE_MOVE;
+
+	int soundChannel = -1;
+	AudioPath soundName;
+
+	for (i=(int)path.nodes.size()-1; i>0 && (movementState == EMoveState::CONTINUE_MOVE || !canStop(&path.nodes[i])); i--)
+	{
+		int3 prevCoord = h->convertFromVisitablePos(path.nodes[i].coord);
+		int3 nextCoord = h->convertFromVisitablePos(path.nodes[i-1].coord);
+
+		auto prevObject = getObj(prevCoord, prevCoord == h->pos);
+		auto nextObjectTop = getObj(nextCoord, false);
+		auto nextObject = getObj(nextCoord, true);
+		auto destTeleportObj = getDestTeleportObj(prevObject, nextObjectTop, nextObject);
+		if (isTeleportAction(path.nodes[i-1].action) && destTeleportObj != nullptr)
+		{
+			CCS->soundh->stopSound(soundChannel);
+			destinationTeleport = destTeleportObj->id;
+			destinationTeleportPos = nextCoord;
+			doMovement(h->pos, false);
+			if (path.nodes[i-1].action == EPathNodeAction::TELEPORT_BLOCKING_VISIT
+				|| path.nodes[i-1].action == EPathNodeAction::TELEPORT_BATTLE)
+			{
+				destinationTeleport = ObjectInstanceID();
+				destinationTeleportPos = int3(-1);
+			}
+			if(i != path.nodes.size() - 1)
+			{
+				soundName = getMovementSoundFor(h, prevCoord, nextCoord, path.nodes[i-1].action);
+				if (!soundName.empty())
+					soundChannel = CCS->soundh->playSound(soundName, -1);
+				else
+					soundChannel = -1;
+			}
+			continue;
+		}
+
+		if (path.nodes[i-1].turns)
+		{ //stop sending move requests if the next node can't be reached at the current turn (hero exhausted his move points)
+			movementState = EMoveState::STOP_MOVE;
+			break;
+		}
+
+		{
+			// Start a new sound for the hero movement or let the existing one carry on.
+			AudioPath newSoundName = getMovementSoundFor(h, prevCoord, nextCoord, path.nodes[i-1].action);
+
+			if(newSoundName != soundName)
+			{
+				soundName = newSoundName;
+
+				CCS->soundh->stopSound(soundChannel);
+				if (!soundName.empty())
+					soundChannel = CCS->soundh->playSound(soundName, -1);
+				else
+					soundChannel = -1;
+			}
+		}
+
+		assert(h->pos.z == nextCoord.z); // Z should change only if it's movement via teleporter and in this case this code shouldn't be executed at all
+		int3 endpos(nextCoord.x, nextCoord.y, h->pos.z);
+		logGlobal->trace("Requesting hero movement to %s", endpos.toString());
+
+		bool useTransit = false;
+		if ((i-2 >= 0) // Check there is node after next one; otherwise transit is pointless
+			&& (CGTeleport::isConnected(nextObjectTop, getObj(h->convertFromVisitablePos(path.nodes[i-2].coord), false))
+				|| CGTeleport::isTeleport(nextObjectTop)))
+		{ // Hero should be able to go through object if it's allow transit
+			useTransit = true;
+		}
+		else if (path.nodes[i-1].layer == EPathfindingLayer::AIR)
+			useTransit = true;
+
+		doMovement(endpos, useTransit);
+
+		logGlobal->trace("Resuming %s", __FUNCTION__);
+		bool guarded = LOCPLINT->cb->isInTheMap(LOCPLINT->cb->getGuardingCreaturePosition(endpos - int3(1, 0, 0)));
+		if ((!useTransit && guarded) || LOCPLINT->showingDialog->get() == true) // Abort movement if a guard was fought or there is a dialog to display (Mantis #1136)
+			break;
+	}
+	CCS->soundh->stopSound(soundChannel);
+
+	//Update cursor so icon can change if needed when it reappears; doesn;'t apply if a dialog box pops up at the end of the movement
+	if (!LOCPLINT->showingDialog->get())
+		GH.fakeMouseMove();
+
+	CGI->mh->waitForOngoingAnimations();
+	setMovementStatus(false);
+}

--- a/client/HeroMovementController.h
+++ b/client/HeroMovementController.h
@@ -43,9 +43,9 @@ class HeroMovementController
 	void updatePath(const CGHeroInstance * hero, const TryMoveHero & details);
 
 	/// Moves hero 1 tile / path node
-	void moveHeroOnce(const CGHeroInstance * h, const CGPath & path);
+	void moveOnce(const CGHeroInstance * h, const CGPath & path);
 
-	void endHeroMove(const CGHeroInstance * h);
+	void endMove(const CGHeroInstance * h);
 
 	AudioPath getMovementSoundFor(const CGHeroInstance * hero, int3 posPrev, int3 posNext, EPathNodeAction moveType);
 	void updateMovementSound(const CGHeroInstance * hero, int3 posPrev, int3 posNext, EPathNodeAction moveType);
@@ -66,9 +66,9 @@ public:
 	void onPlayerTurnStarted();
 	void onBattleStarted();
 	void showTeleportDialog(const CGHeroInstance * hero, TeleportChannelID channel, TTeleportExitsList exits, bool impassable, QueryID askID);
-	void heroMoved(const CGHeroInstance * hero, const TryMoveHero & details);
+	void onTryMoveHero(const CGHeroInstance * hero, const TryMoveHero & details);
 
 	// UI handlers
-	void movementStartRequested(const CGHeroInstance * h, const CGPath & path);
-	void movementAbortRequested();
+	void requestMovementStart(const CGHeroInstance * h, const CGPath & path);
+	void requestMovementAbort();
 };

--- a/client/HeroMovementController.h
+++ b/client/HeroMovementController.h
@@ -1,5 +1,5 @@
 /*
- * CPlayerInterface.h, part of VCMI engine
+ * HeroMovementController.h, part of VCMI engine
  *
  * Authors: listed in file AUTHORS in main folder
  *
@@ -32,14 +32,11 @@ class HeroMovementController
 	/// movement was requested to be terminated, e.g. by player or due to inability to move
 	bool stoppingMovement = false;
 
+	bool waitingForQueryApplyReply = false;
+
 	const CGHeroInstance * currentlyMovingHero = nullptr;
 	AudioPath currentMovementSoundName;
 	int currentMovementSoundChannel = -1;
-
-	/// return final node in a path, if exists
-	std::optional<int3> getLastTile(const CGHeroInstance * h) const;
-	/// return first path in a path, if exists
-	std::optional<int3> getNextTile(const CGHeroInstance * h) const;
 
 	bool canHeroStopAtNode(const CGPathNode & node) const;
 
@@ -56,11 +53,16 @@ class HeroMovementController
 
 public:
 	// const queries
+
+	/// Returns true if hero should move through garrison without displaying garrison dialog
 	bool isHeroMovingThroughGarrison(const CGHeroInstance * hero, const CArmedInstance * garrison) const;
+
+	/// Returns true if there is an ongoing hero movement process
 	bool isHeroMoving() const;
 
 	// netpack handlers
 	void onMoveHeroApplied();
+	void onQueryReplyApplied();
 	void onPlayerTurnStarted();
 	void onBattleStarted();
 	void showTeleportDialog(const CGHeroInstance * hero, TeleportChannelID channel, TTeleportExitsList exits, bool impassable, QueryID askID);

--- a/client/HeroMovementController.h
+++ b/client/HeroMovementController.h
@@ -16,6 +16,7 @@ VCMI_LIB_NAMESPACE_BEGIN
 using TTeleportExitsList = std::vector<std::pair<ObjectInstanceID, int3>>;
 
 class CGHeroInstance;
+class CArmedInstance;
 
 struct CGPath;
 struct TryMoveHero;
@@ -38,21 +39,24 @@ class HeroMovementController
 	};
 
 	EMoveState movementState;
+
+	void setMovementStatus(bool value);
 public:
 	HeroMovementController();
 
-	bool isHeroMovingThroughGarrison(const CGHeroInstance * hero) const;
+	// const queries
+	bool isHeroMovingThroughGarrison(const CGHeroInstance * hero, const CArmedInstance * garrison) const;
 	bool isHeroMoving() const;
 
+	// netpack handlers
 	void onMoveHeroApplied();
 	void onQueryReplyApplied();
-
 	void onPlayerTurnStarted();
 	void onBattleStarted();
 	void showTeleportDialog(TeleportChannelID channel, TTeleportExitsList exits, bool impassable, QueryID askID);
 	void heroMoved(const CGHeroInstance * hero, const TryMoveHero & details);
 
+	// UI handlers
+	void movementStartRequested(const CGHeroInstance * h, const CGPath & path);
 	void movementStopRequested();
-	void doMoveHero(const CGHeroInstance * h, const CGPath & path);
-	void setMovementStatus(bool value);
 };

--- a/client/HeroMovementController.h
+++ b/client/HeroMovementController.h
@@ -32,6 +32,7 @@ class HeroMovementController
 	/// movement was requested to be terminated, e.g. by player or due to inability to move
 	bool stoppingMovement = false;
 
+	const CGHeroInstance * currentlyMovingHero = nullptr;
 	AudioPath currentMovementSoundName;
 	int currentMovementSoundChannel = -1;
 

--- a/client/HeroMovementController.h
+++ b/client/HeroMovementController.h
@@ -11,6 +11,7 @@
 
 #include "../lib/constants/EntityIdentifiers.h"
 #include "../lib/int3.h"
+#include "../lib/filesystem/ResourcePath.h"
 
 VCMI_LIB_NAMESPACE_BEGIN
 using TTeleportExitsList = std::vector<std::pair<ObjectInstanceID, int3>>;
@@ -20,6 +21,7 @@ class CArmedInstance;
 
 struct CGPath;
 struct TryMoveHero;
+enum class EPathNodeAction : ui8;
 VCMI_LIB_NAMESPACE_END
 
 class HeroMovementController
@@ -41,6 +43,12 @@ class HeroMovementController
 	EMoveState movementState;
 
 	void setMovementStatus(bool value);
+
+	void updatePath(const CGHeroInstance * hero, const TryMoveHero & details);
+
+	AudioPath getMovementSoundFor(const CGHeroInstance * hero, int3 posPrev, int3 posNext, EPathNodeAction moveType);
+	void updateMovementSound(const CGHeroInstance * hero, int3 posPrev, int3 posNext, EPathNodeAction moveType);
+	void stopMovementSound();
 public:
 	HeroMovementController();
 

--- a/client/HeroMovementController.h
+++ b/client/HeroMovementController.h
@@ -1,0 +1,58 @@
+/*
+ * CPlayerInterface.h, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
+#pragma once
+
+#include "../lib/constants/EntityIdentifiers.h"
+#include "../lib/int3.h"
+
+VCMI_LIB_NAMESPACE_BEGIN
+using TTeleportExitsList = std::vector<std::pair<ObjectInstanceID, int3>>;
+
+class CGHeroInstance;
+
+struct CGPath;
+struct TryMoveHero;
+VCMI_LIB_NAMESPACE_END
+
+class HeroMovementController
+{
+	ObjectInstanceID destinationTeleport; //contain -1 or object id if teleportation
+	int3 destinationTeleportPos;
+
+	bool duringMovement;
+
+
+	enum class EMoveState
+	{
+		STOP_MOVE,
+		WAITING_MOVE,
+		CONTINUE_MOVE,
+		DURING_MOVE
+	};
+
+	EMoveState movementState;
+public:
+	HeroMovementController();
+
+	bool isHeroMovingThroughGarrison(const CGHeroInstance * hero) const;
+	bool isHeroMoving() const;
+
+	void onMoveHeroApplied();
+	void onQueryReplyApplied();
+
+	void onPlayerTurnStarted();
+	void onBattleStarted();
+	void showTeleportDialog(TeleportChannelID channel, TTeleportExitsList exits, bool impassable, QueryID askID);
+	void heroMoved(const CGHeroInstance * hero, const TryMoveHero & details);
+
+	void movementStopRequested();
+	void doMoveHero(const CGHeroInstance * h, const CGPath & path);
+	void setMovementStatus(bool value);
+};

--- a/client/NetPacksClient.cpp
+++ b/client/NetPacksClient.cpp
@@ -703,7 +703,8 @@ void ApplyClientNetPackVisitor::visitExchangeDialog(ExchangeDialog & pack)
 
 void ApplyClientNetPackVisitor::visitTeleportDialog(TeleportDialog & pack)
 {
-	callOnlyThatInterface(cl, pack.player, &CGameInterface::showTeleportDialog, pack.channel, pack.exits, pack.impassable, pack.queryID);
+	const CGHeroInstance *h = cl.getHero(pack.hero);
+	callOnlyThatInterface(cl, h->getOwner(), &CGameInterface::showTeleportDialog, h, pack.channel, pack.exits, pack.impassable, pack.queryID);
 }
 
 void ApplyClientNetPackVisitor::visitMapObjectSelectDialog(MapObjectSelectDialog & pack)

--- a/client/PlayerLocalState.h
+++ b/client/PlayerLocalState.h
@@ -76,6 +76,11 @@ public:
 	void setPath(const CGHeroInstance * h, const CGPath & path);
 	bool setPath(const CGHeroInstance * h, const int3 & destination);
 
+	/// return final node in a path, if exists
+	std::optional<int3> getLastTile(const CGHeroInstance * h) const;
+	/// return first path in a path, if exists
+	std::optional<int3> getNextTile(const CGHeroInstance * h) const;
+
 	const CGPath & getPath(const CGHeroInstance * h) const;
 	bool hasPath(const CGHeroInstance * h) const;
 

--- a/client/PlayerLocalState.h
+++ b/client/PlayerLocalState.h
@@ -76,11 +76,6 @@ public:
 	void setPath(const CGHeroInstance * h, const CGPath & path);
 	bool setPath(const CGHeroInstance * h, const int3 & destination);
 
-	/// return final node in a path, if exists
-	std::optional<int3> getLastTile(const CGHeroInstance * h) const;
-	/// return first path in a path, if exists
-	std::optional<int3> getNextTile(const CGHeroInstance * h) const;
-
 	const CGPath & getPath(const CGHeroInstance * h) const;
 	bool hasPath(const CGHeroInstance * h) const;
 

--- a/client/adventureMap/AdventureMapInterface.cpp
+++ b/client/adventureMap/AdventureMapInterface.cpp
@@ -531,7 +531,8 @@ void AdventureMapInterface::onTileLeftClicked(const int3 &mapPos)
 			if(LOCPLINT->localState->hasPath(currentHero) &&
 			   LOCPLINT->localState->getPath(currentHero).endPos() == mapPos)//we'll be moving
 			{
-				if(!CGI->mh->hasOngoingAnimations())
+				assert(!CGI->mh->hasOngoingAnimations());
+				if(!CGI->mh->hasOngoingAnimations() && LOCPLINT->localState->getPath(currentHero).nextNode().turns == 0)
 					LOCPLINT->moveHero(currentHero, LOCPLINT->localState->getPath(currentHero));
 				return;
 			}

--- a/lib/CGameInterface.h
+++ b/lib/CGameInterface.h
@@ -103,7 +103,7 @@ public:
 
 	// all stacks operations between these objects become allowed, interface has to call onEnd when done
 	virtual void showGarrisonDialog(const CArmedInstance *up, const CGHeroInstance *down, bool removableUnits, QueryID queryID) = 0;
-	virtual void showTeleportDialog(TeleportChannelID channel, TTeleportExitsList exits, bool impassable, QueryID askID) = 0;
+	virtual void showTeleportDialog(const CGHeroInstance * hero, TeleportChannelID channel, TTeleportExitsList exits, bool impassable, QueryID askID) = 0;
 	virtual void showMapObjectSelectDialog(QueryID askID, const Component & icon, const MetaString & title, const MetaString & description, const std::vector<ObjectInstanceID> & objects) = 0;
 	virtual void finish(){}; //if for some reason we want to end
 

--- a/lib/NetPacks.h
+++ b/lib/NetPacks.h
@@ -1436,12 +1436,12 @@ struct DLL_LINKAGE TeleportDialog : public Query
 {
 	TeleportDialog() = default;
 
-	TeleportDialog(const PlayerColor & Player, const TeleportChannelID & Channel)
-		: player(Player)
+	TeleportDialog(const ObjectInstanceID & hero, const TeleportChannelID & Channel)
+		: hero(hero)
 		, channel(Channel)
 	{
 	}
-	PlayerColor player;
+	ObjectInstanceID hero;
 	TeleportChannelID channel;
 	TTeleportExitsList exits;
 	bool impassable = false;
@@ -1451,7 +1451,7 @@ struct DLL_LINKAGE TeleportDialog : public Query
 	template <typename Handler> void serialize(Handler & h, const int version)
 	{
 		h & queryID;
-		h & player;
+		h & hero;
 		h & channel;
 		h & exits;
 		h & impassable;

--- a/lib/mapObjects/CGObjectInstance.cpp
+++ b/lib/mapObjects/CGObjectInstance.cpp
@@ -64,15 +64,18 @@ void CGObjectInstance::setOwner(const PlayerColor & ow)
 {
 	tempOwner = ow;
 }
-int CGObjectInstance::getWidth() const//returns width of object graphic in tiles
+
+int CGObjectInstance::getWidth() const
 {
 	return appearance->getWidth();
 }
-int CGObjectInstance::getHeight() const //returns height of object graphic in tiles
+
+int CGObjectInstance::getHeight() const
 {
 	return appearance->getHeight();
 }
-bool CGObjectInstance::visitableAt(int x, int y) const //returns true if object is visitable at location (x, y) form left top tile of image (x, y in tiles)
+
+bool CGObjectInstance::visitableAt(int x, int y) const
 {
 	return appearance->isVisitableAt(pos.x - x, pos.y - y);
 }
@@ -84,6 +87,20 @@ bool CGObjectInstance::blockingAt(int x, int y) const
 bool CGObjectInstance::coveringAt(int x, int y) const
 {
 	return appearance->isVisibleAt(pos.x - x, pos.y - y);
+}
+
+bool CGObjectInstance::visitableAt(const int3 & testPos) const
+{
+	return pos.z == testPos.z && appearance->isVisitableAt(pos.x - testPos.x, pos.y - testPos.y);
+}
+bool CGObjectInstance::blockingAt(const int3 & testPos) const
+{
+	return pos.z == testPos.z && appearance->isBlockedAt(pos.x - testPos.x, pos.y - testPos.y);
+}
+
+bool CGObjectInstance::coveringAt(const int3 & testPos) const
+{
+	return pos.z == testPos.z && appearance->isVisibleAt(pos.x - testPos.x, pos.y - testPos.y);
 }
 
 std::set<int3> CGObjectInstance::getBlockedPos() const

--- a/lib/mapObjects/CGObjectInstance.h
+++ b/lib/mapObjects/CGObjectInstance.h
@@ -60,12 +60,17 @@ public:
 
 	int getWidth() const; //returns width of object graphic in tiles
 	int getHeight() const; //returns height of object graphic in tiles
-	bool visitableAt(int x, int y) const; //returns true if object is visitable at location (x, y) (h3m pos)
 	int3 visitablePos() const override;
 	int3 getPosition() const override;
 	int3 getTopVisiblePos() const;
+	bool visitableAt(int x, int y) const; //returns true if object is visitable at location (x, y) (h3m pos)
 	bool blockingAt(int x, int y) const; //returns true if object is blocking location (x, y) (h3m pos)
 	bool coveringAt(int x, int y) const; //returns true if object covers with picture location (x, y) (h3m pos)
+
+	bool visitableAt(const int3 & pos) const; //returns true if object is visitable at location (x, y) (h3m pos)
+	bool blockingAt (const int3 & pos) const; //returns true if object is blocking location (x, y) (h3m pos)
+	bool coveringAt (const int3 & pos) const; //returns true if object covers with picture location (x, y) (h3m pos)
+
 	std::set<int3> getBlockedPos() const; //returns set of positions blocked by this object
 	std::set<int3> getBlockedOffsets() const; //returns set of relative positions blocked by this object
 

--- a/lib/mapObjects/MiscObjects.cpp
+++ b/lib/mapObjects/MiscObjects.cpp
@@ -453,7 +453,7 @@ TeleportChannelID CGMonolith::findMeChannel(const std::vector<Obj> & IDs, int Su
 
 void CGMonolith::onHeroVisit( const CGHeroInstance * h ) const
 {
-	TeleportDialog td(h->tempOwner, channel);
+	TeleportDialog td(h->id, channel);
 	if(isEntrance())
 	{
 		if(cb->isTeleportChannelBidirectional(channel) && 1 < cb->getTeleportChannelExits(channel).size())
@@ -527,7 +527,7 @@ void CGMonolith::initObj(CRandomGenerator & rand)
 
 void CGSubterraneanGate::onHeroVisit( const CGHeroInstance * h ) const
 {
-	TeleportDialog td(h->tempOwner, channel);
+	TeleportDialog td(h->id, channel);
 	if(cb->isTeleportChannelImpassable(channel))
 	{
 		h->showInfoDialog(153);//Just inside the entrance you find a large pile of rubble blocking the tunnel. You leave discouraged.
@@ -611,7 +611,7 @@ void CGSubterraneanGate::postInit() //matches subterranean gates into pairs
 
 void CGWhirlpool::onHeroVisit( const CGHeroInstance * h ) const
 {
-	TeleportDialog td(h->tempOwner, channel);
+	TeleportDialog td(h->id, channel);
 	if(cb->isTeleportChannelImpassable(channel))
 	{
 		logGlobal->debug("Cannot find exit whirlpool for %d at %s", id.getNum(), pos.toString());

--- a/lib/pathfinder/CGPathNode.cpp
+++ b/lib/pathfinder/CGPathNode.cpp
@@ -24,6 +24,24 @@ static bool canSeeObj(const CGObjectInstance * obj)
 	return obj != nullptr && obj->ID != Obj::EVENT;
 }
 
+const CGPathNode & CGPath::currNode() const
+{
+	assert(nodes.size() > 1);
+	return nodes[nodes.size()-1];
+}
+
+const CGPathNode & CGPath::nextNode() const
+{
+	assert(nodes.size() > 1);
+	return nodes[nodes.size()-2];
+}
+
+const CGPathNode & CGPath::lastNode() const
+{
+	assert(nodes.size() > 1);
+	return nodes[0];
+}
+
 int3 CGPath::startPos() const
 {
 	return nodes[nodes.size()-1].coord;

--- a/lib/pathfinder/CGPathNode.h
+++ b/lib/pathfinder/CGPathNode.h
@@ -143,6 +143,18 @@ struct DLL_LINKAGE CGPathNode
 		return turns < 255;
 	}
 
+	bool isTeleportAction() const
+	{
+		if (action != EPathNodeAction::TELEPORT_NORMAL &&
+			action != EPathNodeAction::TELEPORT_BLOCKING_VISIT &&
+			action != EPathNodeAction::TELEPORT_BATTLE)
+		{
+			return false;
+		}
+
+		return true;
+	}
+
 	using TFibHeap = boost::heap::fibonacci_heap<CGPathNode *, boost::heap::compare<NodeComparer<CGPathNode>>>;
 
 	TFibHeap::handle_type pqHandle;
@@ -155,6 +167,13 @@ private:
 struct DLL_LINKAGE CGPath
 {
 	std::vector<CGPathNode> nodes; //just get node by node
+
+	/// Starting position of path, matches location of hero
+	const CGPathNode & currNode() const;
+	/// First node in path, this is where hero will move next
+	const CGPathNode & nextNode() const;
+	/// Last node in path, this is what hero wants to reach in the end
+	const CGPathNode & lastNode() const;
 
 	int3 startPos() const; // start point
 	int3 endPos() const; //destination point

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -1111,29 +1111,36 @@ bool CGameHandler::moveHero(ObjectInstanceID hid, int3 dst, ui8 teleporting, boo
 	const bool standAtObstacle = t.blocked && !t.visitable;
 	const bool standAtWater = !h->boat && t.terType->isWater() && (t.visitableObjects.empty() || !t.visitableObjects.back()->isCoastVisitable());
 	
-	//it's a rock or blocked and not visitable tile
-	//OR hero is on land and dest is water and (there is not present only one object - boat)
-	if (((!t.terType->isPassable() || (standAtObstacle && !canFly))
-			&& complain("Cannot move hero, destination tile is blocked!"))
-		|| ((standAtWater && !canFly && !canWalkOnSea)  //hero is not on boat/water walking and dst water tile doesn't contain boat/hero (objs visitable from land) -> we test back cause boat may be on top of another object (#276)
-			&& complain("Cannot move hero, destination tile is on water!"))
-		|| ((h->boat && h->boat->layer == EPathfindingLayer::SAIL && t.terType->isLand() && t.blocked)
-			&& complain("Cannot disembark hero, tile is blocked!"))
-		|| ((distance(h->pos, dst) >= 1.5 && !teleporting)
-			&& complain("Tiles are not neighboring!"))
-		|| ((h->inTownGarrison)
-			&& complain("Can not move garrisoned hero!"))
-		|| (((int)h->movementPointsRemaining() < cost  &&  dst != h->pos  &&  !teleporting)
-			&& complain("Hero doesn't have any movement points left!"))
-		|| ((transit && !canFly && !CGTeleport::isTeleport(t.topVisitableObj()))
-			&& complain("Hero cannot transit over this tile!"))
-		/*|| (states.checkFlag(h->tempOwner, &PlayerStatus::engagedIntoBattle)
-			&& complain("Cannot move hero during the battle"))*/)
-	{
+	auto const complainRet = [&](const std::string & message){
 		//send info about movement failure
+		complain(message);
 		sendAndApply(&tmh);
 		return false;
-	}
+	};
+
+	//it's a rock or blocked and not visitable tile
+	//OR hero is on land and dest is water and (there is not present only one object - boat)
+	if (!t.terType->isPassable() || (standAtObstacle && !canFly))
+		complainRet("Cannot move hero, destination tile is blocked!");
+
+	//hero is not on boat/water walking and dst water tile doesn't contain boat/hero (objs visitable from land) -> we test back cause boat may be on top of another object (#276)
+	if(standAtWater && !canFly && !canWalkOnSea)
+		complainRet("Cannot move hero, destination tile is on water!");
+
+	if(h->boat && h->boat->layer == EPathfindingLayer::SAIL && t.terType->isLand() && t.blocked)
+		complainRet("Cannot disembark hero, tile is blocked!");
+
+	if(distance(h->pos, dst) >= 1.5 && !teleporting)
+		complainRet("Tiles are not neighboring!");
+
+	if(h->inTownGarrison)
+		complainRet("Can not move garrisoned hero!");
+
+	if(h->movementPointsRemaining() < cost && dst != h->pos && !teleporting)
+		complainRet("Hero doesn't have any movement points left!");
+
+	if (transit && !canFly && !CGTeleport::isTeleport(t.topVisitableObj()))
+		complainRet("Hero cannot transit over this tile!");
 
 	//several generic blocks of code
 

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -1139,7 +1139,7 @@ bool CGameHandler::moveHero(ObjectInstanceID hid, int3 dst, ui8 teleporting, boo
 	if(h->movementPointsRemaining() < cost && dst != h->pos && !teleporting)
 		complainRet("Hero doesn't have any movement points left!");
 
-	if (transit && !canFly && !CGTeleport::isTeleport(t.topVisitableObj()))
+	if (transit && !canFly && !(canWalkOnSea && t.terType->isWater()))
 		complainRet("Hero cannot transit over this tile!");
 
 	//several generic blocks of code
@@ -1259,7 +1259,7 @@ bool CGameHandler::moveHero(ObjectInstanceID hid, int3 dst, ui8 teleporting, boo
 			if (CGTeleport::isTeleport(t.topVisitableObj()))
 				visitDest = DONT_VISIT_DEST;
 
-			if (canFly)
+			if (canFly || (canWalkOnSea && t.terType->isWater()))
 			{
 				lookForGuards = IGNORE_GUARDS;
 				visitDest = DONT_VISIT_DEST;

--- a/server/queries/MapQueries.cpp
+++ b/server/queries/MapQueries.cpp
@@ -171,7 +171,7 @@ CTeleportDialogQuery::CTeleportDialogQuery(CGameHandler * owner, const TeleportD
 	CDialogQuery(owner)
 {
 	this->td = td;
-	addPlayer(td.player);
+	addPlayer(gh->getHero(td.hero)->getOwner());
 }
 
 CHeroLevelUpDialogQuery::CHeroLevelUpDialogQuery(CGameHandler * owner, const HeroLevelUp & Hlu, const CGHeroInstance * Hero):


### PR DESCRIPTION
Hero movement processing is now done in GUI / network thread instead of dedicated thread, in line with other events.

Change made partially to simplify threading model and partially - to simplify eventual simultaneous movement of multiple heroes for simturns.

Changes:
- Moved hero movement code from PlayerInterface to a separate class
- All movement actions are done immediately on receiving event (input / netpack) instead of deferring action to a movement thread
- Hero movement sound now correctly stops on visiting Magi Hut
- Cleaned up and commented movement handling code