### PR TITLE
Added explicit "PlayerEndsTurn" netpack

### DIFF
--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -172,11 +172,17 @@ void CPlayerInterface::initGameInterface(std::shared_ptr<Environment> ENV, std::
 	adventureInt.reset(new AdventureMapInterface());
 }
 
+void CPlayerInterface::playerEndsTurn(PlayerColor player)
+{
+	EVENT_HANDLER_CALLED_BY_CLIENT;
+	if (player == playerID)
+		makingTurn = false;
+}
+
 void CPlayerInterface::playerStartsTurn(PlayerColor player)
 {
 	EVENT_HANDLER_CALLED_BY_CLIENT;
 
-	makingTurn = false;
 	movementController->onPlayerTurnStarted();
 
 	if(GH.windows().findWindows<AdventureMapInterface>().empty())

--- a/client/CPlayerInterface.h
+++ b/client/CPlayerInterface.h
@@ -145,6 +145,7 @@ protected: // Call-ins from server, should not be called directly, but only via 
 	void playerBlocked(int reason, bool start) override;
 	void gameOver(PlayerColor player, const EVictoryLossCheckResult & victoryLossCheckResult) override;
 	void playerStartsTurn(PlayerColor player) override; //called before yourTurn on active itnerface
+	void playerEndsTurn(PlayerColor player) override;
 	void saveGame(BinarySerializer & h, const int version) override; //saving
 	void loadGame(BinaryDeserializer & h, const int version) override; //loading
 	void showWorldViewEx(const std::vector<ObjectPosInfo> & objectPositions, bool showTerrain) override;

--- a/client/ClientCommandManager.cpp
+++ b/client/ClientCommandManager.cpp
@@ -470,7 +470,7 @@ void ClientCommandManager::printCommandMessage(const std::string &commandMessage
 
 void ClientCommandManager::giveTurn(const PlayerColor &colorIdentifier)
 {
-	YourTurn yt;
+	PlayerStartsTurn yt;
 	yt.player = colorIdentifier;
 	yt.queryID = -1;
 

--- a/client/ClientNetPackVisitors.h
+++ b/client/ClientNetPackVisitors.h
@@ -56,6 +56,7 @@ public:
 	void visitNewTurn(NewTurn & pack) override;
 	void visitGiveBonus(GiveBonus & pack) override;
 	void visitChangeObjPos(ChangeObjPos & pack) override;
+	void visitPlayerEndsTurn(PlayerEndsTurn & pack) override;
 	void visitPlayerEndsGame(PlayerEndsGame & pack) override;
 	void visitPlayerReinitInterface(PlayerReinitInterface & pack) override;
 	void visitRemoveBonus(RemoveBonus & pack) override;
@@ -93,7 +94,7 @@ public:
 	void visitPackageApplied(PackageApplied & pack) override;
 	void visitSystemMessage(SystemMessage & pack) override;
 	void visitPlayerBlocked(PlayerBlocked & pack) override;
-	void visitYourTurn(YourTurn & pack) override;
+	void visitPlayerStartsTurn(PlayerStartsTurn & pack) override;
 	void visitTurnTimeUpdate(TurnTimeUpdate & pack) override;
 	void visitPlayerMessageClient(PlayerMessageClient & pack) override;
 	void visitAdvmapSpellCast(AdvmapSpellCast & pack) override;

--- a/client/NetPacksClient.cpp
+++ b/client/NetPacksClient.cpp
@@ -873,12 +873,19 @@ void ApplyClientNetPackVisitor::visitPlayerBlocked(PlayerBlocked & pack)
 	callInterfaceIfPresent(cl, pack.player, &IGameEventsReceiver::playerBlocked, pack.reason, pack.startOrEnd == PlayerBlocked::BLOCKADE_STARTED);
 }
 
-void ApplyClientNetPackVisitor::visitYourTurn(YourTurn & pack)
+void ApplyClientNetPackVisitor::visitPlayerStartsTurn(PlayerStartsTurn & pack)
 {
 	logNetwork->debug("Server gives turn to %s", pack.player.toString());
 
 	callAllInterfaces(cl, &IGameEventsReceiver::playerStartsTurn, pack.player);
 	callOnlyThatInterface(cl, pack.player, &CGameInterface::yourTurn, pack.queryID);
+}
+
+void ApplyClientNetPackVisitor::visitPlayerEndsTurn(PlayerEndsTurn & pack)
+{
+	logNetwork->debug("Server ends turn of %s", pack.player.toString());
+
+	callAllInterfaces(cl, &IGameEventsReceiver::playerEndsTurn, pack.player);
 }
 
 void ApplyClientNetPackVisitor::visitTurnTimeUpdate(TurnTimeUpdate & pack)

--- a/lib/IGameEventsReceiver.h
+++ b/lib/IGameEventsReceiver.h
@@ -134,6 +134,7 @@ public:
 	virtual void playerBlocked(int reason, bool start){}; //reason: 0 - upcoming battle
 	virtual void gameOver(PlayerColor player, const EVictoryLossCheckResult & victoryLossCheckResult) {}; //player lost or won the game
 	virtual void playerStartsTurn(PlayerColor player){};
+	virtual void playerEndsTurn(PlayerColor player){};
 
 	//TODO shouldn't be moved down the tree?
 	virtual void heroExchangeStarted(ObjectInstanceID hero1, ObjectInstanceID hero2, QueryID queryID){};

--- a/lib/NetPackVisitor.h
+++ b/lib/NetPackVisitor.h
@@ -26,7 +26,7 @@ public:
 	virtual void visitSystemMessage(SystemMessage & pack) {}
 	virtual void visitPlayerBlocked(PlayerBlocked & pack) {}
 	virtual void visitPlayerCheated(PlayerCheated & pack) {}
-	virtual void visitYourTurn(YourTurn & pack) {}
+	virtual void visitPlayerStartsTurn(PlayerStartsTurn & pack) {}
 	virtual void visitDaysWithoutTown(DaysWithoutTown & pack) {}
 	virtual void visitTurnTimeUpdate(TurnTimeUpdate & pack) {}
 	virtual void visitEntitiesChanged(EntitiesChanged & pack) {}
@@ -41,6 +41,7 @@ public:
 	virtual void visitSetAvailableHeroes(SetAvailableHero & pack) {}
 	virtual void visitGiveBonus(GiveBonus & pack) {}
 	virtual void visitChangeObjPos(ChangeObjPos & pack) {}
+	virtual void visitPlayerEndsTurn(PlayerEndsTurn & pack) {};
 	virtual void visitPlayerEndsGame(PlayerEndsGame & pack) {}
 	virtual void visitPlayerReinitInterface(PlayerReinitInterface & pack) {}
 	virtual void visitRemoveBonus(RemoveBonus & pack) {}

--- a/lib/NetPacks.h
+++ b/lib/NetPacks.h
@@ -163,7 +163,7 @@ struct DLL_LINKAGE TurnTimeUpdate : public CPackForClient
 	}
 };
 
-struct DLL_LINKAGE YourTurn : public Query
+struct DLL_LINKAGE PlayerStartsTurn : public Query
 {
 	void applyGs(CGameState * gs) const;
 
@@ -431,6 +431,20 @@ struct DLL_LINKAGE ChangeObjPos : public CPackForClient
 	{
 		h & objid;
 		h & nPos;
+	}
+};
+
+struct DLL_LINKAGE PlayerEndsTurn : public CPackForClient
+{
+	void applyGs(CGameState * gs) const;
+
+	PlayerColor player;
+
+	virtual void visitTyped(ICPackVisitor & visitor) override;
+
+	template <typename Handler> void serialize(Handler & h, const int version)
+	{
+		h & player;
 	}
 };
 

--- a/lib/NetPacksLib.cpp
+++ b/lib/NetPacksLib.cpp
@@ -100,9 +100,9 @@ void PlayerCheated::visitTyped(ICPackVisitor & visitor)
 	visitor.visitPlayerCheated(*this);
 }
 
-void YourTurn::visitTyped(ICPackVisitor & visitor)
+void PlayerStartsTurn::visitTyped(ICPackVisitor & visitor)
 {
-	visitor.visitYourTurn(*this);
+	visitor.visitPlayerStartsTurn(*this);
 }
 
 void DaysWithoutTown::visitTyped(ICPackVisitor & visitor)
@@ -168,6 +168,11 @@ void GiveBonus::visitTyped(ICPackVisitor & visitor)
 void ChangeObjPos::visitTyped(ICPackVisitor & visitor)
 {
 	visitor.visitChangeObjPos(*this);
+}
+
+void PlayerEndsTurn::visitTyped(ICPackVisitor & visitor)
+{
+	visitor.visitPlayerEndsTurn(*this);
 }
 
 void PlayerEndsGame::visitTyped(ICPackVisitor & visitor)
@@ -1071,6 +1076,9 @@ void PlayerEndsGame::applyGs(CGameState * gs) const
 	{
 		p->status = EPlayerStatus::LOSER;
 	}
+
+	// defeated player may be making turn right now
+	gs->actingPlayers.erase(player);
 }
 
 void PlayerReinitInterface::applyGs(CGameState *gs)
@@ -2503,10 +2511,16 @@ void PlayerCheated::applyGs(CGameState * gs) const
 	gs->getPlayerState(player)->enteredWinningCheatCode = winningCheatCode;
 }
 
-void YourTurn::applyGs(CGameState * gs) const
+void PlayerStartsTurn::applyGs(CGameState * gs) const
 {
-	gs->actingPlayers.clear();
+	assert(gs->actingPlayers.count(player) == 0);
 	gs->actingPlayers.insert(player);
+}
+
+void PlayerEndsTurn::applyGs(CGameState * gs) const
+{
+	assert(gs->actingPlayers.count(player) == 1);
+	gs->actingPlayers.erase(player);
 }
 
 void DaysWithoutTown::applyGs(CGameState * gs) const

--- a/lib/registerTypes/RegisterTypes.h
+++ b/lib/registerTypes/RegisterTypes.h
@@ -231,7 +231,7 @@ void registerTypesClientPacks1(Serializer &s)
 	s.template registerType<CPackForClient, SystemMessage>();
 	s.template registerType<CPackForClient, PlayerBlocked>();
 	s.template registerType<CPackForClient, PlayerCheated>();
-	s.template registerType<CPackForClient, YourTurn>();
+	s.template registerType<CPackForClient, PlayerStartsTurn>();
 	s.template registerType<CPackForClient, DaysWithoutTown>();
 	s.template registerType<CPackForClient, TurnTimeUpdate>();
 	s.template registerType<CPackForClient, SetResources>();
@@ -245,6 +245,7 @@ void registerTypesClientPacks1(Serializer &s)
 	s.template registerType<CPackForClient, SetAvailableHero>();
 	s.template registerType<CPackForClient, GiveBonus>();
 	s.template registerType<CPackForClient, ChangeObjPos>();
+	s.template registerType<CPackForClient, PlayerEndsTurn>();
 	s.template registerType<CPackForClient, PlayerEndsGame>();
 	s.template registerType<CPackForClient, PlayerReinitInterface>();
 	s.template registerType<CPackForClient, RemoveBonus>();

--- a/server/processors/TurnOrderProcessor.cpp
+++ b/server/processors/TurnOrderProcessor.cpp
@@ -102,10 +102,10 @@ void TurnOrderProcessor::doStartPlayerTurn(PlayerColor which)
 	auto turnQuery = std::make_shared<PlayerStartsTurnQuery>(gameHandler, which);
 	gameHandler->queries->addQuery(turnQuery);
 
-	YourTurn yt;
-	yt.player = which;
-	yt.queryID = turnQuery->queryID;
-	gameHandler->sendAndApply(&yt);
+	PlayerStartsTurn pst;
+	pst.player = which;
+	pst.queryID = turnQuery->queryID;
+	gameHandler->sendAndApply(&pst);
 
 	assert(actingPlayers.size() == 1); // No simturns yet :(
 	assert(gameHandler->isPlayerMakingTurn(*actingPlayers.begin()));
@@ -118,6 +118,10 @@ void TurnOrderProcessor::doEndPlayerTurn(PlayerColor which)
 
 	actingPlayers.erase(which);
 	actedPlayers.insert(which);
+
+	PlayerEndsTurn pet;
+	pet.player = which;
+	gameHandler->sendAndApply(&pet);
 
 	if (!awaitingPlayers.empty())
 		tryStartTurnsForPlayers();

--- a/server/processors/TurnOrderProcessor.h
+++ b/server/processors/TurnOrderProcessor.h
@@ -53,7 +53,7 @@ public:
 	/// Ends player turn and removes this player from turn order
 	void onPlayerEndsGame(PlayerColor which);
 
-	/// Start game (or resume from save) and send YourTurn pack to player(s)
+	/// Start game (or resume from save) and send PlayerStartsTurn pack to player(s)
 	void onGameStarted();
 
 	template<typename Handler>


### PR DESCRIPTION
Another small piece towards simturns

- PlayerEndsTurn pack is now sent when player ends turn
- YourTurn pack has been renamed to PlayerStartsTurn for consistency
- PlayerStartsTurn will no longer replace list of acting players, but only appends to list
- PlayerEndsGame and PlayerEndsTurn will remove player from acting players list