### PR TITLE
Cleaned up and fixed ownership checks for market netpack

### DIFF
--- a/client/windows/CCastleInterface.cpp
+++ b/client/windows/CCastleInterface.cpp
@@ -698,7 +698,11 @@ void CCastleBuildings::buildingClicked(BuildingID building, BuildingSubID::EBuil
 				break;
 
 		case BuildingID::MARKETPLACE:
-				GH.windows().createAndPushWindow<CMarketplaceWindow>(town, town->visitingHero);
+				// can't use allied marketplace
+				if (town->getOwner() == LOCPLINT->playerID)
+					GH.windows().createAndPushWindow<CMarketplaceWindow>(town, town->visitingHero);
+				else
+					enterBuilding(building);
 				break;
 
 		case BuildingID::BLACKSMITH:

--- a/client/windows/CTradeWindow.cpp
+++ b/client/windows/CTradeWindow.cpp
@@ -872,7 +872,25 @@ void CMarketplaceWindow::selectionChanged(bool side)
 
 bool CMarketplaceWindow::printButtonFor(EMarketMode M) const
 {
-	return market->allowsTrade(M) && M != mode && (hero || ( M != EMarketMode::CREATURE_RESOURCE && M != EMarketMode::RESOURCE_ARTIFACT && M != EMarketMode::ARTIFACT_RESOURCE ));
+	if (!market->allowsTrade(M))
+		return false;
+
+	if (M == mode)
+		return false;
+
+	if ( M == EMarketMode::RESOURCE_RESOURCE || M == EMarketMode::RESOURCE_PLAYER)
+	{
+		auto * town = dynamic_cast<const CGTownInstance *>(market);
+
+		if (town)
+			return town->getOwner() == LOCPLINT->playerID;
+		else
+			return true;
+	}
+	else
+	{
+		return hero != nullptr;
+	}
 }
 
 void CMarketplaceWindow::garrisonChanged()


### PR DESCRIPTION
- Fixes #2863 
- Player can no longer use market in his ally town (and use exchange costs of his ally)
- Player can now use Skeleton Transformer and Artifact Merchants in allied town (but only with own troops)