### PR TITLE
H3m parser fixes

### DIFF
--- a/config/mapOverrides.json
+++ b/config/mapOverrides.json
@@ -75,6 +75,46 @@
 		"victoryIconIndex" : 11,
 		"victoryString" : "core.vcdesc.0"
 	},
+	"data/evil2:0" : { // A Gryphon's Heart
+		"defeatIconIndex" : 2,
+		"defeatString" : "core.lcdesc.3",
+		"triggeredEvents" : {
+			"specialDefeat" : {
+				"condition" : [
+					"allOf",
+					[ "isHuman", { "value" : 1 } ],
+					[ "daysPassed", { "value" : 84 } ]
+				],
+				"effect" : {
+					"messageToSend" : "core.genrltxt.5",
+					"type" : "defeat"
+				},
+				"message" : "core.genrltxt.254"
+			},
+			"specialVictory" : {
+				"condition" : [
+					"allOf",
+					[ "isHuman", { "value" : 1 } ],
+					[ "transport", { "position" : [ 16, 23, 0 ], "type" : 84 } ]
+				],
+				"effect" : {
+					"messageToSend" : "core.genrltxt.293",
+					"type" : "victory"
+				},
+				"message" : "core.genrltxt.292"
+			},
+			"standardDefeat" : {
+				"condition" : [ "daysWithoutTown", { "value" : 7 } ],
+				"effect" : {
+					"messageToSend" : "core.genrltxt.8",
+					"type" : "defeat"
+				},
+				"message" : "core.genrltxt.7"
+			}
+		},
+		"victoryIconIndex" : 10,
+		"victoryString" : "core.vcdesc.11"
+	},
 	"data/secret1:0" : { // The Grail
 		"defeatIconIndex" : 2,
 		"defeatString" : "core.lcdesc.3",

--- a/lib/MetaString.cpp
+++ b/lib/MetaString.cpp
@@ -388,12 +388,11 @@ void MetaString::jsonDeserialize(const JsonNode & source)
 
 void MetaString::serializeJson(JsonSerializeFormat & handler)
 {
-	JsonNode attr;
 	if(handler.saving)
-		jsonSerialize(attr);
-	handler.serializeRaw("attributes", attr, std::nullopt);
+		jsonSerialize(const_cast<JsonNode&>(handler.getCurrent()));
+
 	if(!handler.saving)
-		jsonDeserialize(attr);
+		jsonDeserialize(handler.getCurrent());
 }
 
 VCMI_LIB_NAMESPACE_END

--- a/lib/mapping/MapFeaturesH3M.cpp
+++ b/lib/mapping/MapFeaturesH3M.cpp
@@ -49,7 +49,7 @@ MapFormatFeaturesH3M MapFormatFeaturesH3M::getFeaturesROE()
 
 	result.factionsCount = 8;
 	result.heroesCount = 128;
-	result.heroesPortraitsCount = 128;
+	result.heroesPortraitsCount = 130; // +General Kendal, +Catherine (portrait-only in RoE)
 	result.artifactsCount = 127;
 	result.resourcesCount = 7;
 	result.creaturesCount = 118;

--- a/lib/mapping/MapFormatJson.cpp
+++ b/lib/mapping/MapFormatJson.cpp
@@ -870,6 +870,11 @@ void CMapPatcher::readPatchData()
 {
 	JsonDeserializer handler(mapObjectResolver.get(), input);
 	readTriggeredEvents(handler);
+
+	handler.serializeInt("defeatIconIndex", mapHeader->defeatIconIndex);
+	handler.serializeInt("victoryIconIndex", mapHeader->victoryIconIndex);
+	handler.serializeStruct("victoryString", mapHeader->victoryMessage);
+	handler.serializeStruct("defeatString", mapHeader->defeatMessage);
 }
 
 ///CMapLoaderJson

--- a/lib/mapping/MapIdentifiersH3M.cpp
+++ b/lib/mapping/MapIdentifiersH3M.cpp
@@ -53,11 +53,11 @@ void MapIdentifiersH3M::loadMapping(const JsonNode & mapping)
 
 	for (auto entryTemplate : mapping["templates"].Struct())
 	{
-		std::string h3mName = boost::to_lower_copy(entryTemplate.second.String());
-		std::string vcmiName = boost::to_lower_copy(entryTemplate.first);
+		AnimationPath h3mName = AnimationPath::builtinTODO(entryTemplate.second.String());
+		AnimationPath vcmiName = AnimationPath::builtinTODO(entryTemplate.first);
 
-		if (!CResourceHandler::get()->existsResource(AnimationPath::builtinTODO("SPRITES/" + vcmiName)))
-			logMod->warn("Template animation file %s was not found!", vcmiName);
+		if (!CResourceHandler::get()->existsResource(vcmiName.addPrefix("SPRITES/")))
+			logMod->warn("Template animation file %s was not found!", vcmiName.getOriginalName());
 
 		mappingObjectTemplate[h3mName] = vcmiName;
 	}
@@ -108,10 +108,10 @@ void MapIdentifiersH3M::loadMapping(const JsonNode & mapping)
 
 void MapIdentifiersH3M::remapTemplate(ObjectTemplate & objectTemplate)
 {
-	std::string name = boost::to_lower_copy(objectTemplate.animationFile.getName());
+	auto name = objectTemplate.animationFile;
 
 	if (mappingObjectTemplate.count(name))
-		objectTemplate.animationFile = AnimationPath::builtinTODO(mappingObjectTemplate.at(name));
+		objectTemplate.animationFile = mappingObjectTemplate.at(name);
 
 	ObjectTypeIdentifier objectType{ objectTemplate.id, objectTemplate.subid};
 

--- a/lib/mapping/MapIdentifiersH3M.h
+++ b/lib/mapping/MapIdentifiersH3M.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "../GameConstants.h"
+#include "../filesystem/ResourcePath.h"
 
 VCMI_LIB_NAMESPACE_BEGIN
 
@@ -43,7 +44,7 @@ class MapIdentifiersH3M
 	std::map<ArtifactID, ArtifactID> mappingArtifact;
 	std::map<SecondarySkill, SecondarySkill> mappingSecondarySkill;
 
-	std::map<std::string, std::string> mappingObjectTemplate;
+	std::map<AnimationPath, AnimationPath> mappingObjectTemplate;
 	std::map<ObjectTypeIdentifier, ObjectTypeIdentifier> mappingObjectIndex;
 
 	template<typename IdentifierID>

--- a/lib/mapping/MapReaderH3M.cpp
+++ b/lib/mapping/MapReaderH3M.cpp
@@ -113,7 +113,12 @@ int32_t MapReaderH3M::readHeroPortrait()
 	if(result.getNum() == features.heroIdentifierInvalid)
 		return int32_t(-1);
 
-	assert(result.getNum() < features.heroesPortraitsCount);
+	if (result.getNum() >= features.heroesPortraitsCount)
+	{
+		logGlobal->warn("Map contains invalid hero portrait ID %d. Will be reset!", result.getNum() );
+		return int32_t(-1);
+	}
+
 	return remapper.remapPortrrait(result);
 }
 
@@ -199,7 +204,12 @@ PlayerColor MapReaderH3M::readPlayer()
 	if (value == 255)
 		return PlayerColor::NEUTRAL;
 
-	assert(value < PlayerColor::PLAYER_LIMIT_I);
+	if (value >= PlayerColor::PLAYER_LIMIT_I)
+	{
+		logGlobal->warn("Map contains invalid player ID %d. Will be reset!", value );
+		return PlayerColor::NEUTRAL;
+	}
+
 	return PlayerColor(value);
 }
 
@@ -210,7 +220,12 @@ PlayerColor MapReaderH3M::readPlayer32()
 	if (value == 255)
 		return PlayerColor::NEUTRAL;
 
-	assert(value < PlayerColor::PLAYER_LIMIT_I);
+	if (value >= PlayerColor::PLAYER_LIMIT_I)
+	{
+		logGlobal->warn("Map contains invalid player ID %d. Will be reset!", value );
+		return PlayerColor::NEUTRAL;
+	}
+
 	return PlayerColor(value);
 }
 


### PR DESCRIPTION
- Fixes #2883
- Fixes victory condition on 1st scenario of "Long Live the King" campaign - should be "Bring artifact" and not "Bring artifact / defeat all enemies"
- Fixed loading of defeat/victory icon & message for map overrides
- Fixed loading of some user-made h3m maps with weird (possibly hex-edited) properties