### PR TITLE
Proper mod compatibility check logic

### DIFF
--- a/Mods/vcmi/config/vcmi/chinese.json
+++ b/Mods/vcmi/config/vcmi/chinese.json
@@ -30,9 +30,9 @@
 	"vcmi.capitalColors.6" : "褐色",
 	"vcmi.capitalColors.7" : "粉色",
 
-	"vcmi.server.errors.existingProcess"     : "一个VCMI进程已经在运行，启动新进程前请结束它。",
-	"vcmi.server.errors.modsIncompatibility" : "需要加载的MOD列表:",
-	"vcmi.server.confirmReconnect"           : "您想要重连上一个会话么？",
+	"vcmi.server.errors.existingProcess" : "一个VCMI进程已经在运行，启动新进程前请结束它。",
+	"vcmi.server.errors.modsToEnable"    : "{需要加载的MOD列表}",
+	"vcmi.server.confirmReconnect"       : "您想要重连上一个会话么？",
 
 	"vcmi.settingsMainWindow.generalTab.hover"   : "常规",
 	"vcmi.settingsMainWindow.generalTab.help"    : "切换到“常规”选项卡 - 设置游戏客户端呈现",

--- a/Mods/vcmi/config/vcmi/czech.json
+++ b/Mods/vcmi/config/vcmi/czech.json
@@ -48,9 +48,9 @@
 	"vcmi.lobby.filename" : "Název souboru",
 	"vcmi.lobby.creationDate" : "Datum vytvoření",
 
-	"vcmi.server.errors.existingProcess"     : "Již běží jiný server VCMI. Prosím, ukončete ho před startem nové hry.",
-	"vcmi.server.errors.modsIncompatibility" : "Následující modifikace jsou nutné pro načtení hry:",
-	"vcmi.server.confirmReconnect"           : "Chcete se připojit k poslední relaci?",
+	"vcmi.server.errors.existingProcess" : "Již běží jiný server VCMI. Prosím, ukončete ho před startem nové hry.",
+	"vcmi.server.errors.modsToEnable"    : "{Následující modifikace jsou nutné pro načtení hry}",
+	"vcmi.server.confirmReconnect"       : "Chcete se připojit k poslední relaci?",
 
 	"vcmi.settingsMainWindow.generalTab.hover" : "Obecné",
 	"vcmi.settingsMainWindow.generalTab.help"     : "Přepne na kartu obecných nastavení, která obsahuje nastavení související s obecným chováním klienta hry",

--- a/Mods/vcmi/config/vcmi/english.json
+++ b/Mods/vcmi/config/vcmi/english.json
@@ -53,9 +53,10 @@
 	"vcmi.lobby.filename" : "Filename",
 	"vcmi.lobby.creationDate" : "Creation date",
 
-	"vcmi.server.errors.existingProcess"     : "Another VCMI server process is running. Please terminate it before starting a new game.",
-	"vcmi.server.errors.modsIncompatibility" : "The following mods are required to load the game:",
-	"vcmi.server.confirmReconnect"           : "Do you want to reconnect to the last session?",
+	"vcmi.server.errors.existingProcess" : "Another VCMI server process is running. Please terminate it before starting a new game.",
+	"vcmi.server.errors.modsToEnable"    : "{Following mods are required}",
+	"vcmi.server.errors.modsToDisable"   : "{Following mods must be disabled}",
+	"vcmi.server.confirmReconnect"       : "Do you want to reconnect to the last session?",
 
 	"vcmi.settingsMainWindow.generalTab.hover" : "General",
 	"vcmi.settingsMainWindow.generalTab.help"     : "Switches to General Options tab, which contains settings related to general game client behavior.",

--- a/Mods/vcmi/config/vcmi/french.json
+++ b/Mods/vcmi/config/vcmi/french.json
@@ -38,9 +38,9 @@
 	"vcmi.mainMenu.joinTCP" : "Rejoindre TCP/IP jeu",
 	"vcmi.mainMenu.playerName" : "Joueur",
 
-	"vcmi.server.errors.existingProcess"     : "Un autre processus de serveur VCMI est en cours d'exécution. Veuillez l'arrêter' avant de démarrer un nouveau jeu.",
-	"vcmi.server.errors.modsIncompatibility" : "Les mods suivants sont nécessaires pour charger le jeu :",
-	"vcmi.server.confirmReconnect"           : "Voulez-vous vous reconnecter à la dernière session ?",
+	"vcmi.server.errors.existingProcess" : "Un autre processus de serveur VCMI est en cours d'exécution. Veuillez l'arrêter' avant de démarrer un nouveau jeu.",
+	"vcmi.server.errors.modsToEnable"    : "{Les mods suivants sont nécessaires pour charger le jeu}",
+	"vcmi.server.confirmReconnect"       : "Voulez-vous vous reconnecter à la dernière session ?",
 
 	"vcmi.settingsMainWindow.generalTab.hover" : "Général",
 	"vcmi.settingsMainWindow.generalTab.help"     : "Passe à l'onglet Options générales, qui contient des paramètres liés au comportement général du client de jeu",

--- a/Mods/vcmi/config/vcmi/german.json
+++ b/Mods/vcmi/config/vcmi/german.json
@@ -52,9 +52,9 @@
 	"vcmi.lobby.filename" : "Dateiname",
 	"vcmi.lobby.creationDate" : "Erstellungsdatum",
 
-	"vcmi.server.errors.existingProcess"     : "Es läuft ein weiterer vcmiserver-Prozess, bitte beendet diesen zuerst",
-	"vcmi.server.errors.modsIncompatibility" : "Erforderliche Mods um das Spiel zu laden:",
-	"vcmi.server.confirmReconnect"           : "Mit der letzten Sitzung verbinden?",
+	"vcmi.server.errors.existingProcess" : "Es läuft ein weiterer vcmiserver-Prozess, bitte beendet diesen zuerst",
+	"vcmi.server.errors.modsToEnable"    : "{Erforderliche Mods um das Spiel zu laden}",
+	"vcmi.server.confirmReconnect"       : "Mit der letzten Sitzung verbinden?",
 
 	"vcmi.settingsMainWindow.generalTab.hover" : "Allgemein",
 	"vcmi.settingsMainWindow.generalTab.help"     : "Wechselt zur Registerkarte Allgemeine Optionen, die Einstellungen zum allgemeinen Verhalten des Spielclients enthält.",

--- a/Mods/vcmi/config/vcmi/polish.json
+++ b/Mods/vcmi/config/vcmi/polish.json
@@ -47,9 +47,9 @@
 	"vcmi.lobby.filename" : "Nazwa pliku",
 	"vcmi.lobby.creationDate" : "Data utworzenia",
 
-	"vcmi.server.errors.existingProcess"     : "Inny proces 'vcmiserver' został już uruchomiony, zakończ go nim przejdziesz dalej",
-	"vcmi.server.errors.modsIncompatibility" : "Następujące mody są wymagane do wczytania gry:",
-	"vcmi.server.confirmReconnect"           : "Połączyć ponownie z ostatnią sesją?",
+	"vcmi.server.errors.existingProcess" : "Inny proces 'vcmiserver' został już uruchomiony, zakończ go nim przejdziesz dalej",
+	"vcmi.server.errors.modsToEnable"    : "{Następujące mody są wymagane do wczytania gry}",
+	"vcmi.server.confirmReconnect"       : "Połączyć ponownie z ostatnią sesją?",
 
 	"vcmi.settingsMainWindow.generalTab.hover"   : "Ogólne",
 	"vcmi.settingsMainWindow.generalTab.help"    : "Przełącza do zakładki opcji ogólnych, która zawiera ustawienia związane z ogólnym działaniem gry",

--- a/Mods/vcmi/config/vcmi/russian.json
+++ b/Mods/vcmi/config/vcmi/russian.json
@@ -21,9 +21,9 @@
 	"vcmi.adventureMap.moveCostDetails"        : "Очки движения - Стоимость: %TURNS ходов + %POINTS очков, Останется: %REMAINING очков",
 	"vcmi.adventureMap.moveCostDetailsNoTurns" : "Очки движения - Стоимость: %POINTS очков, Останется: %REMAINING очков",
 
-	"vcmi.server.errors.existingProcess"     : "Запущен другой процесс vcmiserver, сначала завершите его.",
-	"vcmi.server.errors.modsIncompatibility" : "Требуемые моды для загрузки игры:",
-	"vcmi.server.confirmReconnect"          : "Подключиться к предыдущей сессии?",
+	"vcmi.server.errors.existingProcess" : "Запущен другой процесс vcmiserver, сначала завершите его.",
+	"vcmi.server.errors.modsToEnable"    : "{Требуемые моды для загрузки игры}",
+	"vcmi.server.confirmReconnect"       : "Подключиться к предыдущей сессии?",
 
 	"vcmi.settingsMainWindow.generalTab.hover" : "Общее",
 	"vcmi.settingsMainWindow.generalTab.help"     : "Переключиться на вкладку \"Общее\", содержащее общие настройки клиента игры",

--- a/Mods/vcmi/config/vcmi/spanish.json
+++ b/Mods/vcmi/config/vcmi/spanish.json
@@ -30,9 +30,9 @@
 	"vcmi.capitalColors.6" : "Turquesa",
 	"vcmi.capitalColors.7" : "Rosa",
 
-	"vcmi.server.errors.existingProcess"     : "Otro proceso de vcmiserver está en ejecución, por favor termínalo primero",
-	"vcmi.server.errors.modsIncompatibility" : "Mods necesarios para cargar el juego:",
-	"vcmi.server.confirmReconnect"           : "¿Conectar a la última sesión?",
+	"vcmi.server.errors.existingProcess" : "Otro proceso de vcmiserver está en ejecución, por favor termínalo primero",
+	"vcmi.server.errors.modsToEnable"    : "{Mods necesarios para cargar el juego}",
+	"vcmi.server.confirmReconnect"       : "¿Conectar a la última sesión?",
 
 	"vcmi.settingsMainWindow.generalTab.hover" : "General",
 	"vcmi.settingsMainWindow.generalTab.help"     : "Cambiar a la pestaña de opciones generales, que contiene ajustes relacionados con el comportamiento general del juego",

--- a/Mods/vcmi/config/vcmi/ukrainian.json
+++ b/Mods/vcmi/config/vcmi/ukrainian.json
@@ -48,9 +48,9 @@
 	"vcmi.lobby.filename" : "Назва файлу",
 	"vcmi.lobby.creationDate" : "Дата створення",
 
-	"vcmi.server.errors.existingProcess"     : "Працює інший процес vcmiserver, будь ласка, спочатку завершіть його",
-	"vcmi.server.errors.modsIncompatibility" : "Потрібні модифікації для завантаження гри:",
-	"vcmi.server.confirmReconnect"           : "Підключитися до минулої сесії?",
+	"vcmi.server.errors.existingProcess" : "Працює інший процес vcmiserver, будь ласка, спочатку завершіть його",
+	"vcmi.server.errors.modsToEnable"    : "{Потрібні модифікації для завантаження гри}",
+	"vcmi.server.confirmReconnect"       : "Підключитися до минулої сесії?",
 
 	"vcmi.settingsMainWindow.generalTab.hover" : "Загальні",
 	"vcmi.settingsMainWindow.generalTab.help"     : "Перемикає на вкладку загальних параметрів, яка містить налаштування, пов'язані із загальною поведінкою ігрового клієнта",

--- a/client/CServerHandler.cpp
+++ b/client/CServerHandler.cpp
@@ -704,6 +704,9 @@ void CServerHandler::startCampaignScenario(std::shared_ptr<CampaignState> cs)
 
 void CServerHandler::showServerError(const std::string & txt) const
 {
+	if(auto w = GH.windows().topWindow<CLoadingScreen>())
+		GH.windows().popWindow(w);
+	
 	CInfoWindow::showInfoDialog(txt, {});
 }
 

--- a/client/CServerHandler.cpp
+++ b/client/CServerHandler.cpp
@@ -537,6 +537,8 @@ void CServerHandler::sendGuiAction(ui8 action) const
 
 void CServerHandler::sendRestartGame() const
 {
+	GH.windows().createAndPushWindow<CLoadingScreen>();
+	
 	LobbyEndGame endGame;
 	endGame.closeConnection = false;
 	endGame.restart = true;

--- a/client/CServerHandler.cpp
+++ b/client/CServerHandler.cpp
@@ -572,7 +572,8 @@ bool CServerHandler::validateGameStart(bool allowOnlyAI) const
 void CServerHandler::sendStartGame(bool allowOnlyAI) const
 {
 	verifyStateBeforeStart(allowOnlyAI ? true : settings["session"]["onlyai"].Bool());
-
+	GH.windows().createAndPushWindow<CLoadingScreen>();
+	
 	LobbyStartGame lsg;
 	if(client)
 	{

--- a/client/CServerHandler.cpp
+++ b/client/CServerHandler.cpp
@@ -552,10 +552,17 @@ bool CServerHandler::validateGameStart(bool allowOnlyAI) const
 	catch(ModIncompatibility & e)
 	{
 		logGlobal->warn("Incompatibility exception during start scenario: %s", e.what());
-
-		auto errorMsg = CGI->generaltexth->translate("vcmi.server.errors.modsIncompatibility") + '\n';
-		errorMsg += e.what();
-
+		std::string errorMsg;
+		if(!e.whatMissing().empty())
+		{
+			errorMsg += VLC->generaltexth->translate("vcmi.server.errors.modsToEnable") + '\n';
+			errorMsg += e.whatMissing();
+		}
+		if(!e.whatExcessive().empty())
+		{
+			errorMsg += VLC->generaltexth->translate("vcmi.server.errors.modsToDisable") + '\n';
+			errorMsg += e.whatExcessive();
+		}
 		showServerError(errorMsg);
 		return false;
 	}

--- a/client/NetPacksLobbyClient.cpp
+++ b/client/NetPacksLobbyClient.cpp
@@ -149,8 +149,6 @@ void ApplyOnLobbyScreenNetPackVisitor::visitLobbyLoadProgress(LobbyLoadProgress 
 		w->tick(0);
 		w->redraw();
 	}
-	else
-		GH.windows().createAndPushWindow<CLoadingScreen>();
 }
 
 void ApplyOnLobbyHandlerNetPackVisitor::visitLobbyUpdateState(LobbyUpdateState & pack)

--- a/client/lobby/CLobbyScreen.cpp
+++ b/client/lobby/CLobbyScreen.cpp
@@ -29,7 +29,6 @@
 #include "../../lib/CGeneralTextHandler.h"
 #include "../../lib/campaign/CampaignHandler.h"
 #include "../../lib/mapping/CMapInfo.h"
-#include "../../lib/modding/ModIncompatibility.h"
 #include "../../lib/rmg/CMapGenOptions.h"
 
 CLobbyScreen::CLobbyScreen(ESelectionScreen screenType)

--- a/lib/StartInfo.cpp
+++ b/lib/StartInfo.cpp
@@ -74,12 +74,12 @@ void LobbyInfo::verifyStateBeforeStart(bool ignoreNoHuman) const
 		throw std::domain_error(VLC->generaltexth->translate("core.genrltxt.529"));
 	
 	auto missingMods = CMapService::verifyMapHeaderMods(*mi->mapHeader);
-	ModIncompatibility::ModList modList;
+	ModIncompatibility::ModListWithVersion modList;
 	for(const auto & m : missingMods)
 		modList.push_back({m.second.name, m.second.version.toString()});
 	
 	if(!modList.empty())
-		throw ModIncompatibility(std::move(modList));
+		throw ModIncompatibility(modList);
 
 	//there must be at least one human player before game can be started
 	std::map<PlayerColor, PlayerSettings>::const_iterator i;

--- a/lib/StartInfo.cpp
+++ b/lib/StartInfo.cpp
@@ -76,7 +76,7 @@ void LobbyInfo::verifyStateBeforeStart(bool ignoreNoHuman) const
 	auto missingMods = CMapService::verifyMapHeaderMods(*mi->mapHeader);
 	ModIncompatibility::ModList modList;
 	for(const auto & m : missingMods)
-		modList.push_back({m.first, m.second.toString()});
+		modList.push_back({m.second.name, m.second.version.toString()});
 	
 	if(!modList.empty())
 		throw ModIncompatibility(std::move(modList));

--- a/lib/mapping/CMapHeader.h
+++ b/lib/mapping/CMapHeader.h
@@ -10,7 +10,7 @@
 
 #pragma once
 
-#include "../modding/CModVersion.h"
+#include "../modding/CModInfo.h"
 #include "../LogicalExpression.h"
 #include "../int3.h"
 #include "../MetaString.h"
@@ -19,7 +19,7 @@ VCMI_LIB_NAMESPACE_BEGIN
 
 class CGObjectInstance;
 enum class EMapFormat : uint8_t;
-using ModCompatibilityInfo = std::map<std::string, CModVersion>;
+using ModCompatibilityInfo = std::map<std::string, CModInfo::VerificationInfo>;
 
 /// The hero name struct consists of the hero id and the hero name.
 struct DLL_LINKAGE SHeroName
@@ -249,8 +249,7 @@ public:
 	void serialize(Handler & h, const int Version)
 	{
 		h & version;
-		if(Version >= 821)
-			h & mods;
+		h & mods;
 		h & name;
 		h & description;
 		h & width;

--- a/lib/mapping/CMapService.cpp
+++ b/lib/mapping/CMapService.cpp
@@ -92,14 +92,15 @@ void CMapService::saveMap(const std::unique_ptr<CMap> & map, boost::filesystem::
 
 ModCompatibilityInfo CMapService::verifyMapHeaderMods(const CMapHeader & map)
 {
-	ModCompatibilityInfo modCompatibilityInfo;
 	const auto & activeMods = VLC->modh->getActiveMods();
+	
+	ModCompatibilityInfo modCompatibilityInfo;
 	for(const auto & mapMod : map.mods)
 	{
 		if(vstd::contains(activeMods, mapMod.first))
 		{
 			const auto & modInfo = VLC->modh->getModInfo(mapMod.first);
-			if(modInfo.version.compatible(mapMod.second))
+			if(modInfo.getVerificationInfo().version.compatible(mapMod.second.version))
 				continue;
 		}
 		

--- a/lib/mapping/CMapService.h
+++ b/lib/mapping/CMapService.h
@@ -10,6 +10,8 @@
 
 #pragma once
 
+#include "../modding/CModInfo.h"
+
 VCMI_LIB_NAMESPACE_BEGIN
 
 class ResourcePath;
@@ -17,12 +19,11 @@ class ResourcePath;
 class CMap;
 class CMapHeader;
 class CInputStream;
-struct CModVersion;
 
 class IMapLoader;
 class IMapPatcher;
 
-using ModCompatibilityInfo = std::map<std::string, CModVersion>;
+using ModCompatibilityInfo = std::map<std::string, CModInfo::VerificationInfo>;
 
 /**
  * The map service provides loading of VCMI/H3 map files. It can

--- a/lib/mapping/MapFormatJson.cpp
+++ b/lib/mapping/MapFormatJson.cpp
@@ -958,6 +958,7 @@ void CMapLoaderJson::readHeader(const bool complete)
 			info.version = CModVersion::fromString(mod["version"].String());
 			info.checksum = mod["checksum"].Integer();
 			info.name = mod["name"].String();
+			info.parent = mod["parent"].String();
 			info.impactsGameplay = true;
 			
 			if(!mod["modId"].isNull())
@@ -1307,6 +1308,7 @@ void CMapSaverJson::writeHeader()
 		JsonNode modWriter;
 		modWriter["modId"].String() = mod.first;
 		modWriter["name"].String() = mod.second.name;
+		modWriter["parent"].String() = mod.second.parent;
 		modWriter["version"].String() = mod.second.version.toString();
 		modWriter["checksum"].Integer() = mod.second.checksum;
 		mods.Vector().push_back(modWriter);

--- a/lib/modding/CModHandler.cpp
+++ b/lib/modding/CModHandler.cpp
@@ -481,7 +481,7 @@ void CModHandler::trySetActiveMods(const std::vector<std::pair<TModID, CModInfo:
 		return nullptr;
 	};
 	
-	std::vector<TModID> newActiveMods, missingMods, excessiveMods;
+	std::vector<TModID> missingMods, excessiveMods;
 	ModIncompatibility::ModListWithVersion missingModsResult;
 	ModIncompatibility::ModList excessiveModsResult;
 	
@@ -492,10 +492,7 @@ void CModHandler::trySetActiveMods(const std::vector<std::pair<TModID, CModInfo:
 
 		//TODO: support actual disabling of these mods
 		if(getModInfo(m).checkModGameplayAffecting())
-		{
 			excessiveMods.push_back(m);
-			allMods[m].setEnabled(false);
-		}
 	}
 	
 	for(const auto & infoPair : modList)
@@ -523,10 +520,7 @@ void CModHandler::trySetActiveMods(const std::vector<std::pair<TModID, CModInfo:
 		bool modLocalyEnabled = vstd::contains(activeMods, remoteModId);
 		
 		if(modVersionCompatible && modAffectsGameplay && modLocalyEnabled)
-		{
-			newActiveMods.push_back(remoteModId);
 			continue;
-		}
 		
 		if(modAffectsGameplay)
 			missingMods.push_back(remoteModId); //incompatible mod impacts gameplay
@@ -555,11 +549,7 @@ void CModHandler::trySetActiveMods(const std::vector<std::pair<TModID, CModInfo:
 	if(!missingModsResult.empty() || !excessiveModsResult.empty())
 		throw ModIncompatibility(missingModsResult, excessiveModsResult);
 	
-	//TODO: support actual enabling of these mods
-	for(auto & m : newActiveMods)
-		allMods[m].setEnabled(true);
-
-	std::swap(activeMods, newActiveMods);
+	//TODO: support actual enabling of required mods
 }
 
 VCMI_LIB_NAMESPACE_END

--- a/lib/modding/CModInfo.cpp
+++ b/lib/modding/CModInfo.cpp
@@ -42,6 +42,9 @@ CModInfo::CModInfo(const std::string & identifier, const JsonNode & local, const
 {
 	verificationInfo.name = config["name"].String();
 	verificationInfo.version = CModVersion::fromString(config["version"].String());
+	verificationInfo.parent = identifier.substr(0, identifier.find_last_of('.'));
+	if(verificationInfo.parent == identifier)
+		verificationInfo.parent.clear();
 	
 	if(!config["compatibility"].isNull())
 	{

--- a/lib/modding/CModInfo.h
+++ b/lib/modding/CModInfo.h
@@ -41,6 +41,9 @@ public:
 		/// CRC-32 checksum of the mod
 		ui32 checksum = 0;
 		
+		/// parent mod ID, empty if root-level mod
+		TModID parent;
+		
 		/// for serialization purposes
 		bool impactsGameplay = true;
 		
@@ -50,6 +53,7 @@ public:
 			h & name;
 			h & version;
 			h & checksum;
+			h & parent;
 			h & impactsGameplay;
 		}
 	};

--- a/lib/modding/CModInfo.h
+++ b/lib/modding/CModInfo.h
@@ -29,16 +29,36 @@ public:
 		FAILED,
 		PASSED
 	};
+	
+	struct VerificationInfo
+	{
+		/// human-readable mod name
+		std::string name;
+		
+		/// version of the mod
+		CModVersion version;
+		
+		/// CRC-32 checksum of the mod
+		ui32 checksum = 0;
+		
+		/// for serialization purposes
+		bool impactsGameplay = true;
+		
+		template <typename Handler>
+		void serialize(Handler & h, const int v)
+		{
+			h & name;
+			h & version;
+			h & checksum;
+			h & impactsGameplay;
+		}
+	};
 
 	/// identifier, identical to name of folder with mod
 	std::string identifier;
 
-	/// human-readable strings
-	std::string name;
+	/// detailed mod description
 	std::string description;
-
-	/// version of the mod
-	CModVersion version;
 
 	/// Base language of mod, all mod strings are assumed to be in this language
 	std::string baseLanguage;
@@ -51,9 +71,6 @@ public:
 
 	/// list of mods that can't be used in the same time as this one
 	std::set <TModID> conflicts;
-
-	/// CRC-32 checksum of the mod
-	ui32 checksum;
 
 	EValidationStatus validation;
 
@@ -73,6 +90,8 @@ public:
 
 	/// return true if this mod can affect gameplay, e.g. adds or modifies any game objects
 	bool checkModGameplayAffecting() const;
+	
+	const VerificationInfo & getVerificationInfo() const;
 
 private:
 	/// true if mod is enabled by user, e.g. in Launcher UI
@@ -80,6 +99,8 @@ private:
 
 	/// true if mod can be loaded - compatible and has no missing deps
 	bool implicitlyEnabled;
+	
+	VerificationInfo verificationInfo;
 
 	void loadLocalData(const JsonNode & data);
 };

--- a/lib/modding/ContentTypeHandler.cpp
+++ b/lib/modding/ContentTypeHandler.cpp
@@ -212,7 +212,8 @@ void CContentHandler::preloadData(CModInfo & mod)
 	bool validate = (mod.validation != CModInfo::PASSED);
 
 	// print message in format [<8-symbols checksum>] <modname>
-	logMod->info("\t\t[%08x]%s", mod.checksum, mod.name);
+	auto & info = mod.getVerificationInfo();
+	logMod->info("\t\t[%08x]%s", info.checksum, info.name);
 
 	if (validate && mod.identifier != ModScope::scopeBuiltin())
 	{
@@ -233,12 +234,12 @@ void CContentHandler::load(CModInfo & mod)
 	if (validate)
 	{
 		if (mod.validation != CModInfo::FAILED)
-			logMod->info("\t\t[DONE] %s", mod.name);
+			logMod->info("\t\t[DONE] %s", mod.getVerificationInfo().name);
 		else
-			logMod->error("\t\t[FAIL] %s", mod.name);
+			logMod->error("\t\t[FAIL] %s", mod.getVerificationInfo().name);
 	}
 	else
-		logMod->info("\t\t[SKIP] %s", mod.name);
+		logMod->info("\t\t[SKIP] %s", mod.getVerificationInfo().name);
 }
 
 const ContentTypeHandler & CContentHandler::operator[](const std::string & name) const

--- a/lib/modding/ModIncompatibility.h
+++ b/lib/modding/ModIncompatibility.h
@@ -14,29 +14,44 @@ VCMI_LIB_NAMESPACE_BEGIN
 class DLL_LINKAGE ModIncompatibility: public std::exception
 {
 public:
-	using StringPair = std::pair<const std::string, const std::string>;
-	using ModList = std::list<StringPair>;
+	using ModListWithVersion = std::vector<std::pair<const std::string, const std::string>>;
+	using ModList = std::vector<const std::string>;
 
-	ModIncompatibility(ModList && _missingMods):
-		missingMods(std::move(_missingMods))
+	ModIncompatibility(const ModListWithVersion & _missingMods)
 	{
 		std::ostringstream _ss;
-		for(const auto & m : missingMods)
+		for(const auto & m : _missingMods)
 			_ss << m.first << ' ' << m.second << std::endl;
-		message = _ss.str();
+		messageMissingMods = _ss.str();
 	}
-
+	
+	ModIncompatibility(const ModListWithVersion & _missingMods, ModList & _excessiveMods)
+		: ModIncompatibility(_missingMods)
+	{
+		std::ostringstream _ss;
+		for(const auto & m : _excessiveMods)
+			_ss << m << std::endl;
+		messageExcessiveMods = _ss.str();
+	}
+	
 	const char * what() const noexcept override
 	{
-		return message.c_str();
+		static const std::string w("Mod incompatibility exception");
+		return w.c_str();
+	}
+	
+	const std::string & whatMissing() const noexcept
+	{
+		return messageMissingMods;
+	}
+	
+	const std::string & whatExcessive() const noexcept
+	{
+		return messageExcessiveMods;
 	}
 
 private:
-	//list of mods required to load the game
-	// first: mod name
-	// second: mod version
-	const ModList missingMods;
-	std::string message;
+	std::string messageMissingMods, messageExcessiveMods;
 };
 
 VCMI_LIB_NAMESPACE_END

--- a/lib/modding/ModIncompatibility.h
+++ b/lib/modding/ModIncompatibility.h
@@ -15,7 +15,7 @@ class DLL_LINKAGE ModIncompatibility: public std::exception
 {
 public:
 	using ModListWithVersion = std::vector<std::pair<const std::string, const std::string>>;
-	using ModList = std::vector<const std::string>;
+	using ModList = std::vector<std::string>;
 
 	ModIncompatibility(const ModListWithVersion & _missingMods)
 	{

--- a/mapeditor/mainwindow.cpp
+++ b/mapeditor/mainwindow.cpp
@@ -336,19 +336,20 @@ bool MainWindow::openMap(const QString & filenameSelect)
 		if(auto header = mapService.loadMapHeader(resId))
 		{
 			auto missingMods = CMapService::verifyMapHeaderMods(*header);
-			ModIncompatibility::ModList modList;
+			ModIncompatibility::ModListWithVersion modList;
 			for(const auto & m : missingMods)
 				modList.push_back({m.second.name, m.second.version.toString()});
 			
 			if(!modList.empty())
-				throw ModIncompatibility(std::move(modList));
+				throw ModIncompatibility(modList);
 			
 			controller.setMap(mapService.loadMap(resId));
 		}
 	}
 	catch(const ModIncompatibility & e)
 	{
-		QMessageBox::warning(this, "Mods requiered", e.what());
+		assert(e.whatExcessive().empty());
+		QMessageBox::warning(this, "Mods are requiered", QString::fromStdString(e.whatMissing()));
 		return false;
 	}
 	catch(const std::exception & e)

--- a/mapeditor/mainwindow.cpp
+++ b/mapeditor/mainwindow.cpp
@@ -338,7 +338,7 @@ bool MainWindow::openMap(const QString & filenameSelect)
 			auto missingMods = CMapService::verifyMapHeaderMods(*header);
 			ModIncompatibility::ModList modList;
 			for(const auto & m : missingMods)
-				modList.push_back({m.first, m.second.toString()});
+				modList.push_back({m.second.name, m.second.version.toString()});
 			
 			if(!modList.empty())
 				throw ModIncompatibility(std::move(modList));

--- a/mapeditor/mapcontroller.cpp
+++ b/mapeditor/mapcontroller.cpp
@@ -588,7 +588,7 @@ ModCompatibilityInfo MapController::modAssessmentAll()
 			auto handler = VLC->objtypeh->getHandlerFor(primaryID, secondaryID);
 			auto modName = QString::fromStdString(handler->getJsonKey()).split(":").at(0).toStdString();
 			if(modName != "core")
-				result[modName] = VLC->modh->getModInfo(modName).version;
+				result[modName] = VLC->modh->getModInfo(modName).getVerificationInfo();
 		}
 	}
 	return result;
@@ -605,7 +605,7 @@ ModCompatibilityInfo MapController::modAssessmentMap(const CMap & map)
 		auto handler = VLC->objtypeh->getHandlerFor(obj->ID, obj->subID);
 		auto modName = QString::fromStdString(handler->getJsonKey()).split(":").at(0).toStdString();
 		if(modName != "core")
-			result[modName] = VLC->modh->getModInfo(modName).version;
+			result[modName] = VLC->modh->getModInfo(modName).getVerificationInfo();
 	}
 	//TODO: terrains?
 	return result;

--- a/mapeditor/mapcontroller.h
+++ b/mapeditor/mapcontroller.h
@@ -13,10 +13,10 @@
 #include "maphandler.h"
 #include "mapview.h"
 
-#include "../lib/modding/CModVersion.h"
+#include "../lib/modding/CModInfo.h"
 
 VCMI_LIB_NAMESPACE_BEGIN
-using ModCompatibilityInfo = std::map<std::string, CModVersion>;
+using ModCompatibilityInfo = std::map<std::string, CModInfo::VerificationInfo>;
 class EditorObstaclePlacer;
 VCMI_LIB_NAMESPACE_END
 

--- a/mapeditor/mapsettings/modsettings.cpp
+++ b/mapeditor/mapsettings/modsettings.cpp
@@ -47,7 +47,7 @@ void ModSettings::initialize(MapController & c)
 
 	auto createModTreeWidgetItem = [&](QTreeWidgetItem * parent, const CModInfo & modInfo)
 	{
-		auto item = new QTreeWidgetItem(parent, {QString::fromStdString(modInfo.name), QString::fromStdString(modInfo.version.toString())});
+		auto item = new QTreeWidgetItem(parent, {QString::fromStdString(modInfo.getVerificationInfo().name), QString::fromStdString(modInfo.getVerificationInfo().version.toString())});
 		item->setData(0, Qt::UserRole, QVariant(QString::fromStdString(modInfo.identifier)));
 		item->setFlags(item->flags() | Qt::ItemIsUserCheckable);
 		item->setCheckState(0, controller->map()->mods.count(modInfo.identifier) ? Qt::Checked : Qt::Unchecked);
@@ -104,7 +104,7 @@ void ModSettings::update()
 		if(item->checkState(0) == Qt::Checked)
 		{
 			auto modName = item->data(0, Qt::UserRole).toString().toStdString();
-			controller->map()->mods[modName] = VLC->modh->getModInfo(modName).version;
+			controller->map()->mods[modName] = VLC->modh->getModInfo(modName).getVerificationInfo();
 		}
 	};
 

--- a/mapeditor/validator.cpp
+++ b/mapeditor/validator.cpp
@@ -174,7 +174,7 @@ std::list<Validator::Issue> Validator::validate(const CMap * map)
 		{
 			if(!map->mods.count(mod.first))
 			{
-				issues.emplace_back(QString(tr("Map contains object from mod \"%1\", but doesn't require it")).arg(QString::fromStdString(VLC->modh->getModInfo(mod.first).name)), true);
+				issues.emplace_back(QString(tr("Map contains object from mod \"%1\", but doesn't require it")).arg(QString::fromStdString(VLC->modh->getModInfo(mod.first).getVerificationInfo().name)), true);
 			}
 		}
 	}

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -1765,8 +1765,17 @@ bool CGameHandler::load(const std::string & filename)
 	catch(const ModIncompatibility & e)
 	{
 		logGlobal->error("Failed to load game: %s", e.what());
-		auto errorMsg = VLC->generaltexth->translate("vcmi.server.errors.modsIncompatibility") + '\n';
-		errorMsg += e.what();
+		std::string errorMsg;
+		if(!e.whatMissing().empty())
+		{
+			errorMsg += VLC->generaltexth->translate("vcmi.server.errors.modsToEnable") + '\n';
+			errorMsg += e.whatMissing();
+		}
+		if(!e.whatExcessive().empty())
+		{
+			errorMsg += VLC->generaltexth->translate("vcmi.server.errors.modsToDisable") + '\n';
+			errorMsg += e.whatExcessive();
+		}
 		lobby->announceMessage(errorMsg);
 		return false;
 	}


### PR DESCRIPTION
Shows missing mods in human-readable format
Change logic of showing missing mods and auto-resolving process
Works for both saves and maps