### PR TITLE
Sleep for 10 ms instead of 1000 ms while waiting for server connection

### DIFF
--- a/client/CServerHandler.cpp
+++ b/client/CServerHandler.cpp
@@ -263,7 +263,7 @@ void CServerHandler::justConnectToServer(const std::string & addr, const ui16 po
 	if(hostAddress == "127.0.0.1" || hostAddress == "localhost")
 	{
 		sleepDuration = boost::chrono::milliseconds(10);
-		maxConnectionAttempts = 100;
+		maxConnectionAttempts = 1000;
 	}
 	else
 	{

--- a/client/CServerHandler.cpp
+++ b/client/CServerHandler.cpp
@@ -183,7 +183,7 @@ void CServerHandler::startLocalServerAndConnect()
 	
 #if defined(SINGLE_PROCESS_APP)
 	boost::condition_variable cond;
-	std::vector<std::string> args{"--uuid=" + uuid, "--port=" + std::to_string(getHostPort())};
+	std::vector<std::string> args{"--uuid=" + uuid, "--port=" + std::to_string(getHostPortFromSettings())};
 	if(settings["session"]["lobby"].Bool() && settings["session"]["host"].Bool())
 	{
 		args.push_back("--lobby=" + settings["session"]["address"].String());

--- a/client/CServerHandler.cpp
+++ b/client/CServerHandler.cpp
@@ -260,7 +260,7 @@ void CServerHandler::justConnectToServer(const std::string & addr, const ui16 po
 	boost::chrono::duration<long, boost::ratio<1, 1000>> sleepDuration{};
 	int maxConnectionAttempts;
 	
-	if(hostAddress == "127.0.0.1")
+	if(hostAddress == "127.0.0.1" || hostAddress == "localhost")
 	{
 		sleepDuration = boost::chrono::milliseconds(10);
 		maxConnectionAttempts = 100;
@@ -281,7 +281,7 @@ void CServerHandler::justConnectToServer(const std::string & addr, const ui16 po
 		if(connectionAttemptCount > maxConnectionAttempts)
 		{
 			logNetwork->error("\nExceeded maximum of %d connection attempts", maxConnectionAttempts);
-			break;
+			return;
 		}
 
 		try

--- a/client/CServerHandler.cpp
+++ b/client/CServerHandler.cpp
@@ -263,8 +263,8 @@ void CServerHandler::justConnectToServer(const std::string & addr, const ui16 po
 		}
 		catch(std::runtime_error & error)
 		{
-			logNetwork->warn("\nCannot establish connection. %s Retrying in 1 second", error.what());
-			boost::this_thread::sleep_for(boost::chrono::milliseconds(1000));
+			logNetwork->warn("\nCannot establish connection. %s Retrying in 10 ms", error.what());
+			boost::this_thread::sleep_for(boost::chrono::milliseconds(10));
 		}
 	}
 

--- a/client/CServerHandler.cpp
+++ b/client/CServerHandler.cpp
@@ -252,27 +252,33 @@ void CServerHandler::justConnectToServer(const std::string & addr, const ui16 po
 {
 	state = EClientState::CONNECTING;
 	
-	logNetwork->info("Establishing connection...");
+	logNetwork->info("justConnectToServer(%s, %d)", addr, port);
+
+	std::string hostAddressFromSettings = getHostAddressFromSettings();
+	ui16 hostPortFromSettings = getHostPortFromSettings();
+
+	logNetwork->info("Host settings %s:%d", hostAddressFromSettings, hostPortFromSettings);
 	
-	std::string hostAddress = getHostAddress();
-	ui16 hostPort = getHostPort();
+	std::string connectionAddress = addr.size() ? addr : hostAddressFromSettings;
+	ui16 connectionPort = port ? port : hostPortFromSettings;
 
 	boost::chrono::duration<long, boost::ratio<1, 1000>> sleepDuration{};
 	int maxConnectionAttempts;
 	
-	if(hostAddress == "127.0.0.1" || hostAddress == "localhost")
+	if(connectionAddress == "127.0.0.1" || connectionAddress == "localhost")
 	{
+		logNetwork->info("Local server");
 		sleepDuration = boost::chrono::milliseconds(10);
 		maxConnectionAttempts = 1000;
 	}
 	else
 	{
-		// remote server
+		logNetwork->info("Remote server");
 		sleepDuration = boost::chrono::seconds(2);
 		maxConnectionAttempts = 10;
 	}
 
-	logNetwork->info("\nWaiting for %d ms between each of the %d attempts to connect", sleepDuration.count(), maxConnectionAttempts);
+	logNetwork->info("Waiting for %d ms between each of the %d attempts to connect", sleepDuration.count(), maxConnectionAttempts);
 	
 	ui16 connectionAttemptCount = 0;
 	while(!c && state != EClientState::CONNECTION_CANCELLED)
@@ -287,8 +293,8 @@ void CServerHandler::justConnectToServer(const std::string & addr, const ui16 po
 		try
 		{
 			c = std::make_shared<CConnection>(
-					addr.size() ? addr : hostAddress,
-					port ? port : hostPort,
+					connectionAddress,
+					connectionPort,
 					NAME, uuid);
 		}
 		catch(std::runtime_error & error)
@@ -305,12 +311,12 @@ void CServerHandler::justConnectToServer(const std::string & addr, const ui16 po
 
 	c->handler = std::make_shared<boost::thread>(&CServerHandler::threadHandleConnection, this);
 
-	if(!addr.empty() && addr != getHostAddress())
+	if(!addr.empty() && addr != getHostAddressFromSettings())
 	{
 		Settings serverAddress = settings.write["server"]["server"];
 		serverAddress->String() = addr;
 	}
-	if(port && port != getHostPort())
+	if(port && port != getHostPortFromSettings())
 	{
 		Settings serverPort = settings.write["server"]["port"];
 		serverPort->Integer() = port;
@@ -394,7 +400,7 @@ std::string CServerHandler::getDefaultPortStr()
 	return std::to_string(getDefaultPort());
 }
 
-std::string CServerHandler::getHostAddress() const
+std::string CServerHandler::getHostAddressFromSettings() const
 {
 	if(settings["session"]["lobby"].isNull() || !settings["session"]["lobby"].Bool())
 		return settings["server"]["server"].String();
@@ -405,7 +411,7 @@ std::string CServerHandler::getHostAddress() const
 	return settings["session"]["address"].String();
 }
 
-ui16 CServerHandler::getHostPort() const
+ui16 CServerHandler::getHostPortFromSettings() const
 {
 	if(settings["session"]["lobby"].isNull() || !settings["session"]["lobby"].Bool())
 		return getDefaultPort();
@@ -995,7 +1001,7 @@ void CServerHandler::threadRunServer()
 	setThreadName("runServer");
 	const std::string logName = (VCMIDirs::get().userLogsPath() / "server_log.txt").string();
 	std::string comm = VCMIDirs::get().serverPath().string()
-		+ " --port=" + std::to_string(getHostPort())
+		+ " --port=" + std::to_string(getHostPortFromSettings())
 		+ " --run-by-client"
 		+ " --uuid=" + uuid;
 	if(settings["session"]["lobby"].Bool() && settings["session"]["host"].Bool())

--- a/client/CServerHandler.cpp
+++ b/client/CServerHandler.cpp
@@ -251,14 +251,16 @@ void CServerHandler::startLocalServerAndConnect()
 void CServerHandler::justConnectToServer(const std::string & addr, const ui16 port)
 {
 	state = EClientState::CONNECTING;
+	std::string hostAddress = getHostAddress();
+	ui16 hostPort = getHostPort();
+	logNetwork->info("Establishing connection...");
 	while(!c && state != EClientState::CONNECTION_CANCELLED)
 	{
 		try
 		{
-			logNetwork->info("Establishing connection...");
 			c = std::make_shared<CConnection>(
-					addr.size() ? addr : getHostAddress(),
-					port ? port : getHostPort(),
+					addr.size() ? addr : hostAddress,
+					port ? port : hostPort,
 					NAME, uuid);
 		}
 		catch(std::runtime_error & error)

--- a/client/CServerHandler.cpp
+++ b/client/CServerHandler.cpp
@@ -274,7 +274,7 @@ void CServerHandler::justConnectToServer(const std::string & addr, const ui16 po
 
 	logNetwork->info("\nWaiting for %d ms between each of the %d attempts to connect", sleepDuration.count(), maxConnectionAttempts);
 	
-	uint connectionAttemptCount = 0;
+	ui16 connectionAttemptCount = 0;
 	while(!c && state != EClientState::CONNECTION_CANCELLED)
 	{
 		connectionAttemptCount++;

--- a/client/CServerHandler.h
+++ b/client/CServerHandler.h
@@ -121,8 +121,8 @@ public:
 
 	CServerHandler();
 	
-	std::string getHostAddress() const;
-	ui16 getHostPort() const;
+	std::string getHostAddressFromSettings() const;
+	ui16 getHostPortFromSettings() const;
 
 	void resetStateForLobby(const StartInfo::EMode mode, const std::vector<std::string> * names = nullptr);
 	void startLocalServerAndConnect();

--- a/client/mainmenu/CMainMenu.cpp
+++ b/client/mainmenu/CMainMenu.cpp
@@ -534,8 +534,8 @@ CSimpleJoinScreen::CSimpleJoinScreen(bool host)
 
 		inputAddress->giveFocus();
 	}
-	inputAddress->setText(host ? CServerHandler::localhostAddress : CSH->getHostAddress(), true);
-	inputPort->setText(std::to_string(CSH->getHostPort()), true);
+	inputAddress->setText(host ? CServerHandler::localhostAddress : CSH->getHostAddressFromSettings(), true);
+	inputPort->setText(std::to_string(CSH->getHostPortFromSettings()), true);
 
 	buttonCancel = std::make_shared<CButton>(Point(142, 142), AnimationPath::builtin("MUBCANC.DEF"), CGI->generaltexth->zelp[561], std::bind(&CSimpleJoinScreen::leaveScreen, this), EShortcut::GLOBAL_CANCEL);
 	statusBar = CGStatusBar::create(std::make_shared<CPicture>(background->getSurface(), Rect(7, 186, 218, 18), 7, 186));


### PR DESCRIPTION
With my i7 7700K the connection takes ~228 ms.

Would 1 ms be alright or would that be too much busy waiting for lower-end systems?