### PR TITLE
Enable ccache for CI

### DIFF
--- a/.github/workflows/github.yml
+++ b/.github/workflows/github.yml
@@ -158,6 +158,15 @@ jobs:
       env:
         VCMI_BUILD_PLATFORM: x64
 
+    - name: ccache
+      if: startsWith(matrix.preset, 'ios') != true
+      uses: hendrikmuhs/ccache-action@v1.2
+      with:
+          key: ${{ matrix.preset }}
+          # actual cache takes up less space, at most ~1 GB
+          max-size: "5G"
+          verbose: 2
+
     - uses: actions/setup-python@v4
       if: "${{ matrix.conan_profile != '' }}"
       with:
@@ -193,7 +202,13 @@ jobs:
       env:
         PULL_REQUEST: ${{ github.event.pull_request.number }}
 
-    - name: CMake Preset
+    - name: CMake Preset with ccache
+      if: startsWith(matrix.preset, 'ios') != true
+      run: |
+        cmake -DCMAKE_CXX_COMPILER_LAUNCHER=ccache --preset ${{ matrix.preset }}
+
+    - name: CMake Preset without ccache
+      if: startsWith(matrix.preset, 'ios')
       run: |
         cmake --preset ${{ matrix.preset }}
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -25,7 +25,8 @@
                 "CMAKE_BUILD_TYPE": "RelWithDebInfo",
                 "ENABLE_TEST": "OFF",
                 "ENABLE_STRICT_COMPILATION": "ON",
-                "ENABLE_GITVERSION": "$env{VCMI_PACKAGE_GITVERSION}"
+                "ENABLE_GITVERSION": "$env{VCMI_PACKAGE_GITVERSION}",
+                "ENABLE_PCH" : "OFF"
             }
         },
         {
@@ -217,7 +218,10 @@
             "inherits": [
                 "base-ios-release",
                 "ios-device-conan"
-            ]
+            ],
+            "cacheVariables": {
+                "ENABLE_PCH" : "ON"
+            }
         },
         {
             "name": "ios-release-legacy",


### PR DESCRIPTION
This had been removed in the past:
https://github.com/vcmi/vcmi/commit/6e5ad22efc8ea74684980a745236518680b1dafd