### PR TITLE
Miscellaneous bugfixing

### DIFF
--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -166,8 +166,9 @@ void CPlayerInterface::initGameInterface(std::shared_ptr<Environment> ENV, std::
 	env = ENV;
 
 	CCS->musich->loadTerrainMusicThemes();
-
 	initializeHeroTownList();
+
+	adventureInt.reset(new AdventureMapInterface());
 }
 
 void CPlayerInterface::playerEndsTurn(PlayerColor player)
@@ -207,9 +208,6 @@ void CPlayerInterface::playerStartsTurn(PlayerColor player)
 	if(GH.windows().findWindows<AdventureMapInterface>().empty())
 	{
 		// after map load - remove all active windows and replace them with adventure map
-		// always recreate advmap interface to avoid possible memory-corruption bugs
-		adventureInt.reset(new AdventureMapInterface());
-
 		GH.windows().clear();
 		GH.windows().pushWindow(adventureInt);
 	}

--- a/lib/mapObjects/CGHeroInstance.cpp
+++ b/lib/mapObjects/CGHeroInstance.cpp
@@ -487,7 +487,7 @@ void CGHeroInstance::onHeroVisit(const CGHeroInstance * h) const
 				if (!boat)
 				{
 					//Create a new boat for hero
-					cb->createObject(boatPos, Obj::BOAT, getBoatType().getNum());
+					cb->createObject(boatPos, h->getOwner(), Obj::BOAT, getBoatType().getNum());
 					boatId = cb->getTopObj(boatPos)->id;
 				}
 			}

--- a/lib/mapObjects/CQuest.cpp
+++ b/lib/mapObjects/CQuest.cpp
@@ -557,6 +557,10 @@ void CGSeerHut::setObjToKill()
 		quest->heroName = getHeroToKill(false)->getNameTranslated();
 		quest->heroPortrait = getHeroToKill(false)->portrait;
 	}
+
+	quest->getCompletionText(configuration.onSelect);
+	for(auto & i : configuration.info)
+		quest->getCompletionText(i.message);
 }
 
 void CGSeerHut::init(CRandomGenerator & rand)
@@ -596,10 +600,6 @@ void CGSeerHut::initObj(CRandomGenerator & rand)
 		quest->progress = CQuest::COMPLETE;
 		quest->firstVisitText = VLC->generaltexth->seerEmpty[quest->completedOption];
 	}
-	
-	quest->getCompletionText(configuration.onSelect);
-	for(auto & i : configuration.info)
-		quest->getCompletionText(i.message);
 }
 
 void CGSeerHut::getRolloverText(MetaString &text, bool onHover) const

--- a/lib/mapping/MapFormatH3M.cpp
+++ b/lib/mapping/MapFormatH3M.cpp
@@ -425,7 +425,7 @@ void CMapLoaderH3M::readVictoryLossConditions()
 			case EVictoryConditionType::BEATHERO:
 			{
 				if (!allowNormalVictory)
-					logGlobal->warn("Map %s: Has 'beat hero' as victory condition, but 'allow normal victory' not set. Ignoring", mapName);
+					logGlobal->debug("Map %s: Has 'beat hero' as victory condition, but 'allow normal victory' not set. Ignoring", mapName);
 				allowNormalVictory = true; // H3 behavior
 				assert(appliesToAI == false); // not selectable in editor
 				EventCondition cond(EventCondition::DESTROY);


### PR DESCRIPTION
- Fix boat creation for heroes recruited on water. Fixes #2923
- Fixed boat boarding
- Removed excessive warning. Fixes #2928
- Fix crash on loading Seer Hut with kill monster mission (reported in #2923)
- Fix crash on starting map as non-red player