### PR TITLE
font height fix

### DIFF
--- a/client/renderSDL/CTrueTypeFont.cpp
+++ b/client/renderSDL/CTrueTypeFont.cpp
@@ -72,7 +72,7 @@ CTrueTypeFont::~CTrueTypeFont() = default;
 size_t CTrueTypeFont::getLineHeight() const
 {
 	if (fallbackFont)
-		fallbackFont->getLineHeight();
+		return fallbackFont->getLineHeight();
 
 	return TTF_FontHeight(font.get());
 }


### PR DESCRIPTION
Missing return. Fixes problem with multiline and active ttf font.

Bug:
![image](https://github.com/vcmi/vcmi/assets/13953785/e8474f18-a54e-4b7e-9c62-e26a6b54d3d0)

@psyhlo