### PR TITLE
Allow to reconnect to proxy server

### DIFF
--- a/client/CServerHandler.cpp
+++ b/client/CServerHandler.cpp
@@ -417,6 +417,9 @@ void CServerHandler::sendClientDisconnecting()
 		logNetwork->info("Sent leaving signal to the server");
 	}
 	sendLobbyPack(lcd);
+	
+	c->close();
+	c.reset();
 }
 
 void CServerHandler::setCampaignState(std::shared_ptr<CampaignState> newCampaign)

--- a/server/CVCMIServer.cpp
+++ b/server/CVCMIServer.cpp
@@ -211,21 +211,20 @@ void CVCMIServer::establishRemoteConnections()
 	
 	uuid = cmdLineOptions["lobby-uuid"].as<std::string>();
     int numOfConnections = cmdLineOptions["connections"].as<ui16>();
-	auto address = cmdLineOptions["lobby"].as<std::string>();
-	int port = cmdLineOptions["lobby-port"].as<ui16>();
-	logGlobal->info("Server is connecting to remote at %s:%d with uuid %s %d times", address, port, uuid, numOfConnections);
-	
 	for(int i = 0; i < numOfConnections; ++i)
-		connectToRemote(address, port);
+		connectToRemote();
 }
 
-void CVCMIServer::connectToRemote(const std::string & addr, int port)
+void CVCMIServer::connectToRemote()
 {
 	std::shared_ptr<CConnection> c;
 	try
 	{
-		logNetwork->info("Establishing connection...");
-		c = std::make_shared<CConnection>(addr, port, SERVER_NAME, uuid);
+		auto address = cmdLineOptions["lobby"].as<std::string>();
+		int port = cmdLineOptions["lobby-port"].as<ui16>();
+		
+		logNetwork->info("Establishing connection to remote at %s:%d with uuid %s", address, port, uuid);
+		c = std::make_shared<CConnection>(address, port, SERVER_NAME, uuid);
 	}
 	catch(...)
 	{
@@ -235,6 +234,7 @@ void CVCMIServer::connectToRemote(const std::string & addr, int port)
 	if(c)
 	{
 		connections.insert(c);
+		remoteConnections.insert(c);
 		c->handler = std::make_shared<boost::thread>(&CVCMIServer::threadHandleClient, this, c);
 	}
 }

--- a/server/CVCMIServer.h
+++ b/server/CVCMIServer.h
@@ -64,6 +64,7 @@ public:
 
 	boost::program_options::variables_map cmdLineOptions;
 	std::set<std::shared_ptr<CConnection>> connections;
+	std::set<std::shared_ptr<CConnection>> remoteConnections;
 	std::set<std::shared_ptr<CConnection>> hangingConnections; //keep connections of players disconnected during the game
 	
 	std::atomic<int> currentClientId;
@@ -78,7 +79,7 @@ public:
 	void startGameImmidiately();
 
 	void establishRemoteConnections();
-	void connectToRemote(const std::string & addr, int port);
+	void connectToRemote();
 	void startAsyncAccept();
 	void connectionAccepted(const boost::system::error_code & ec);
 	void threadHandleClient(std::shared_ptr<CConnection> c);

--- a/server/NetPacksLobbyServer.cpp
+++ b/server/NetPacksLobbyServer.cpp
@@ -189,6 +189,12 @@ void ApplyOnServerAfterAnnounceNetPackVisitor::visitLobbyClientDisconnected(Lobb
 		srv.addToAnnounceQueue(std::move(ph));
 	}
 	srv.updateAndPropagateLobbyState();
+	
+	if(srv.getState() != EServerState::SHUTDOWN && srv.remoteConnections.count(pack.c))
+	{
+		srv.remoteConnections -= pack.c;
+		srv.connectToRemote();
+	}
 }
 
 void ClientPermissionsCheckerNetPackVisitor::visitLobbyChatMessage(LobbyChatMessage & pack)


### PR DESCRIPTION
If client player will return to main menu, they cannot join back to proxy-server and hang in the connection window. Now player can reconnect in combination with proxy server 0.6.1, which keeps session enabled for 5 min