### PR TITLE
various interface shortcuts

### DIFF
--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -593,7 +593,7 @@ void CPlayerInterface::buildChanged(const CGTownInstance *town, BuildingID build
 	}
 
 	for (auto cgh : GH.windows().findWindows<ITownHolder>())
-		cgh->buildChanged(town);
+		cgh->buildChanged();
 }
 
 void CPlayerInterface::battleStartBefore(const BattleID & battleID, const CCreatureSet *army1, const CCreatureSet *army2, int3 tile, const CGHeroInstance *hero1, const CGHeroInstance *hero2)

--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -591,6 +591,9 @@ void CPlayerInterface::buildChanged(const CGTownInstance *town, BuildingID build
 		// Perform totalRedraw in order to force redraw of updated town list icon from adventure map
 		GH.windows().totalRedraw();
 	}
+
+	for (auto cgh : GH.windows().findWindows<ITownHolder>())
+		cgh->buildChanged(town);
 }
 
 void CPlayerInterface::battleStartBefore(const BattleID & battleID, const CCreatureSet *army1, const CCreatureSet *army2, int3 tile, const CGHeroInstance *hero1, const CGHeroInstance *hero2)

--- a/client/gui/CIntObject.h
+++ b/client/gui/CIntObject.h
@@ -153,6 +153,12 @@ public:
 	virtual void updateGarrisons() = 0;
 };
 
+class ITownHolder
+{
+public:
+	virtual void buildChanged() = 0;
+};
+
 class IStatusBar
 {
 public:

--- a/client/widgets/MiscWidgets.cpp
+++ b/client/widgets/MiscWidgets.cpp
@@ -447,7 +447,7 @@ void CInteractableTownTooltip::init(const CGTownInstance * town)
 				std::make_shared<CCastleBuildings>(town)->enterToTheQuickRecruitmentWindow();
 		}
 	});
-	fastMarket = std::make_shared<LRClickableArea>(Rect(143, 31, 30, 34), [townId]()
+	fastMarket = std::make_shared<LRClickableArea>(Rect(143, 31, 30, 34), []()
 	{
 		std::vector<const CGTownInstance*> towns = LOCPLINT->cb->getTownsInfo(true);
 		for(auto & town : towns)

--- a/client/widgets/MiscWidgets.cpp
+++ b/client/widgets/MiscWidgets.cpp
@@ -19,6 +19,7 @@
 #include "../CGameInfo.h"
 #include "../PlayerLocalState.h"
 #include "../gui/WindowHandler.h"
+#include "../eventsSDL/InputHandler.h"
 #include "../windows/CTradeWindow.h"
 #include "../widgets/TextControls.h"
 #include "../widgets/CGarrisonInt.h"
@@ -180,7 +181,10 @@ LRClickableAreaOpenTown::LRClickableAreaOpenTown(const Rect & Pos, const CGTownI
 void LRClickableArea::clickPressed(const Point & cursorPosition)
 {
 	if(onClick)
+	{
 		onClick();
+		GH.input().hapticFeedback();
+	}
 }
 
 void LRClickableArea::showPopupWindow(const Point & cursorPosition)
@@ -445,6 +449,15 @@ void CInteractableTownTooltip::init(const CGTownInstance * town)
 		{
 			if(town->id == townId)
 				std::make_shared<CCastleBuildings>(town)->enterToTheQuickRecruitmentWindow();
+		}
+	});
+	fastTavern = std::make_shared<LRClickableArea>(Rect(3, 2, 58, 64), [townId]()
+	{
+		std::vector<const CGTownInstance*> towns = LOCPLINT->cb->getTownsInfo(true);
+		for(auto & town : towns)
+		{
+			if(town->id == townId && town->builtBuildings.count(BuildingID::TAVERN))
+				LOCPLINT->showTavernWindow(town, nullptr, QueryID::NONE);
 		}
 	});
 	fastMarket = std::make_shared<LRClickableArea>(Rect(143, 31, 30, 34), []()

--- a/client/widgets/MiscWidgets.h
+++ b/client/widgets/MiscWidgets.h
@@ -135,6 +135,7 @@ class CInteractableTownTooltip : public CIntObject
 	std::shared_ptr<CAnimImage> res2;
 	std::shared_ptr<CGarrisonInt> garrison;
 	
+	std::shared_ptr<LRClickableArea> fastTavern;
 	std::shared_ptr<LRClickableArea> fastMarket;
 	std::shared_ptr<LRClickableArea> fastTownHall;
 	std::shared_ptr<LRClickableArea> fastArmyPurchase;

--- a/client/widgets/MiscWidgets.h
+++ b/client/widgets/MiscWidgets.h
@@ -31,6 +31,7 @@ class CGarrisonInt;
 class CCreatureAnim;
 class CComponent;
 class CAnimImage;
+class LRClickableArea;
 
 /// Shows a text by moving the mouse cursor over the object
 class CHoverableArea: public virtual CIntObject
@@ -133,8 +134,12 @@ class CInteractableTownTooltip : public CIntObject
 	std::shared_ptr<CAnimImage> res1;
 	std::shared_ptr<CAnimImage> res2;
 	std::shared_ptr<CGarrisonInt> garrison;
+	
+	std::shared_ptr<LRClickableArea> fastMarket;
+	std::shared_ptr<LRClickableArea> fastTownHall;
+	std::shared_ptr<LRClickableArea> fastArmyPurchase;
 
-	void init(const InfoAboutTown & town);
+	void init(const CGTownInstance * town);
 public:
 	CInteractableTownTooltip(Point pos, const CGTownInstance * town);
 };
@@ -213,6 +218,17 @@ public:
 	const CGTownInstance * town;
 	void clickPressed(const Point & cursorPosition) override;
 	LRClickableAreaOpenTown(const Rect & Pos, const CGTownInstance * Town);
+};
+
+/// Can do action on click
+class LRClickableArea: public CIntObject
+{
+	std::function<void()> onClick;
+	std::function<void()> onPopup;
+public:
+	void clickPressed(const Point & cursorPosition) override;
+	void showPopupWindow(const Point & cursorPosition) override;
+	LRClickableArea(const Rect & Pos, std::function<void()> onClick = nullptr, std::function<void()> onPopup = nullptr);
 };
 
 class MoraleLuckBox : public LRClickableAreaWTextComp

--- a/client/windows/CCastleInterface.cpp
+++ b/client/windows/CCastleInterface.cpp
@@ -1294,6 +1294,21 @@ void CCastleInterface::recreateIcons()
 	fastArmyPurchase->setImageOrder(town->fortLevel() - 1, town->fortLevel() - 1, town->fortLevel() - 1, town->fortLevel() - 1);
 	fastArmyPurchase->setAnimateLonelyFrame(true);
 
+	fastMarket = std::make_shared<LRClickableArea>(Rect(163, 410, 64, 42), [&]()
+	{
+		if(town->builtBuildings.count(BuildingID::MARKETPLACE))
+		{
+			if (town->getOwner() == LOCPLINT->playerID)
+				GH.windows().createAndPushWindow<CMarketplaceWindow>(town, town->visitingHero, nullptr, EMarketMode::RESOURCE_RESOURCE);
+		}
+	});
+	
+	fastTavern = std::make_shared<LRClickableArea>(Rect(15, 387, 58, 64), [&]()
+	{
+		if(town->builtBuildings.count(BuildingID::TAVERN))
+			LOCPLINT->showTavernWindow(town, nullptr, QueryID::NONE);
+	});
+
 	creainfo.clear();
 
 	bool compactCreatureInfo = useCompactCreatureBox();

--- a/client/windows/CCastleInterface.h
+++ b/client/windows/CCastleInterface.h
@@ -36,6 +36,7 @@ class CTownList;
 class CGarrisonInt;
 class CComponent;
 class CComponentBox;
+class LRClickableArea;
 
 /// Building "button"
 class CBuildingRect : public CShowableAnim
@@ -154,7 +155,7 @@ class CCastleBuildings : public CIntObject
 	void enterCastleGate();
 	void enterFountain(const BuildingID & building, BuildingSubID::EBuildingSubID subID, BuildingID upgrades);//Rampart's fountains
 	void enterMagesGuild();
-
+	
 	void openMagesGuild();
 	void openTownHall();
 
@@ -228,6 +229,8 @@ class CCastleInterface : public CStatusbarWindow, public IGarrisonHolder
 	std::shared_ptr<CButton> split;
 	std::shared_ptr<CButton> fastTownHall;
 	std::shared_ptr<CButton> fastArmyPurchase;
+	std::shared_ptr<LRClickableArea> fastMarket;
+	std::shared_ptr<LRClickableArea> fastTavern;
 
 	std::vector<std::shared_ptr<CCreaInfo>> creainfo;//small icons of creatures (bottom-left corner);
 

--- a/client/windows/CKingdomInterface.cpp
+++ b/client/windows/CKingdomInterface.cpp
@@ -822,6 +822,10 @@ CTownItem::CTownItem(const CGTownInstance * Town)
 		}
 		LOCPLINT->showInfoDialog(CGI->generaltexth->translate("vcmi.adventureMap.noTownWithMarket"));
 	});
+	fastTown = std::make_shared<LRClickableArea>(Rect(67, 6, 165, 20), [&]()
+	{
+		GH.windows().createAndPushWindow<CCastleInterface>(town);
+	});
 }
 
 void CTownItem::updateGarrisons()

--- a/client/windows/CKingdomInterface.cpp
+++ b/client/windows/CKingdomInterface.cpp
@@ -599,20 +599,6 @@ void CKingdomInterface::generateMinesList(const std::vector<const CGObjectInstan
 	incomeArea->pos = Rect(pos.x+580, pos.y+31+footerPos, 136, 68);
 	incomeArea->hoverText = CGI->generaltexth->allTexts[255];
 	incomeAmount = std::make_shared<CLabel>(628, footerPos + 70, FONT_SMALL, ETextAlignment::TOPLEFT, Colors::WHITE, std::to_string(totalIncome));
-
-	fastMarket = std::make_shared<LRClickableArea>(Rect(20, 31 + footerPos, 716, 68), []()
-	{
-		std::vector<const CGTownInstance*> towns = LOCPLINT->cb->getTownsInfo(true);
-		for(auto & town : towns)
-		{
-			if(town->builtBuildings.count(BuildingID::MARKETPLACE))
-			{
-				GH.windows().createAndPushWindow<CMarketplaceWindow>(town, nullptr, nullptr, EMarketMode::RESOURCE_RESOURCE);
-				return;
-			}
-		}
-		LOCPLINT->showInfoDialog(CGI->generaltexth->translate("vcmi.adventureMap.noTownWithMarket"));
-	});
 }
 
 void CKingdomInterface::generateButtons()
@@ -793,13 +779,6 @@ CTownItem::CTownItem(const CGTownInstance * Town)
 	hall = std::make_shared<CTownInfo>( 69, 31, town, true);
 	fort = std::make_shared<CTownInfo>(111, 31, town, false);
 
-	fastTownHall = std::make_shared<CButton>(Point(69, 31), AnimationPath::builtin("ITMTL.def"), CButton::tooltip(), [&]() { std::make_shared<CCastleBuildings>(town)->enterTownHall(); });
-	fastTownHall->setImageOrder(town->hallLevel() - 1, town->hallLevel() - 1, town->hallLevel() - 1, town->hallLevel() - 1);
-	fastTownHall->setAnimateLonelyFrame(true);
-	fastArmyPurchase = std::make_shared<CButton>(Point(111, 31), AnimationPath::builtin("itmcl.def"), CButton::tooltip(), [&]() { std::make_shared<CCastleBuildings>(town)->enterToTheQuickRecruitmentWindow(); });
-	fastArmyPurchase->setImageOrder(town->fortLevel() - 1, town->fortLevel() - 1, town->fortLevel() - 1, town->fortLevel() - 1);
-	fastArmyPurchase->setAnimateLonelyFrame(true);
-
 	garr = std::make_shared<CGarrisonInt>(Point(313, 3), 4, Point(232,0), town->getUpperArmy(), town->visitingHero, true, true, CGarrisonInt::ESlotsLayout::TWO_ROWS);
 	heroes = std::make_shared<HeroSlots>(town, Point(244,6), Point(475,6), garr, false);
 
@@ -813,6 +792,31 @@ CTownItem::CTownItem(const CGTownInstance * Town)
 		growth.push_back(std::make_shared<CCreaInfo>(Point(401+37*(int)i, 78), town, (int)i, true, true));
 		available.push_back(std::make_shared<CCreaInfo>(Point(48+37*(int)i, 78), town, (int)i, true, false));
 	}
+
+	fastTownHall = std::make_shared<CButton>(Point(69, 31), AnimationPath::builtin("ITMTL.def"), CButton::tooltip(), [&]() { std::make_shared<CCastleBuildings>(town)->enterTownHall(); });
+	fastTownHall->setImageOrder(town->hallLevel() - 1, town->hallLevel() - 1, town->hallLevel() - 1, town->hallLevel() - 1);
+	fastTownHall->setAnimateLonelyFrame(true);
+	fastArmyPurchase = std::make_shared<CButton>(Point(111, 31), AnimationPath::builtin("itmcl.def"), CButton::tooltip(), [&]() { std::make_shared<CCastleBuildings>(town)->enterToTheQuickRecruitmentWindow(); });
+	fastArmyPurchase->setImageOrder(town->fortLevel() - 1, town->fortLevel() - 1, town->fortLevel() - 1, town->fortLevel() - 1);
+	fastArmyPurchase->setAnimateLonelyFrame(true);
+	fastTavern = std::make_shared<LRClickableArea>(Rect(5, 6, 58, 64), [&]()
+	{
+		if(town->builtBuildings.count(BuildingID::TAVERN))
+			LOCPLINT->showTavernWindow(town, nullptr, QueryID::NONE);
+	});
+	fastMarket = std::make_shared<LRClickableArea>(Rect(153, 6, 65, 64), []()
+	{
+		std::vector<const CGTownInstance*> towns = LOCPLINT->cb->getTownsInfo(true);
+		for(auto & town : towns)
+		{
+			if(town->builtBuildings.count(BuildingID::MARKETPLACE))
+			{
+				GH.windows().createAndPushWindow<CMarketplaceWindow>(town, nullptr, nullptr, EMarketMode::RESOURCE_RESOURCE);
+				return;
+			}
+		}
+		LOCPLINT->showInfoDialog(CGI->generaltexth->translate("vcmi.adventureMap.noTownWithMarket"));
+	});
 }
 
 void CTownItem::updateGarrisons()

--- a/client/windows/CKingdomInterface.cpp
+++ b/client/windows/CKingdomInterface.cpp
@@ -640,6 +640,11 @@ void CKingdomInterface::activateTab(size_t which)
 	tabArea->setActive(which);
 }
 
+void CKingdomInterface::buildChanged()
+{
+	tabArea->reset();
+}
+
 void CKingdomInterface::townChanged(const CGTownInstance *town)
 {
 	if(auto townList = std::dynamic_pointer_cast<CKingdTownList>(tabArea->getItem()))

--- a/client/windows/CKingdomInterface.h
+++ b/client/windows/CKingdomInterface.h
@@ -200,7 +200,7 @@ public:
 };
 
 /// Class which holds all parts of kingdom overview window
-class CKingdomInterface : public CWindowObject, public IGarrisonHolder, public CArtifactHolder
+class CKingdomInterface : public CWindowObject, public IGarrisonHolder, public CArtifactHolder, public ITownHolder
 {
 private:
 	struct OwnedObjectInfo
@@ -257,6 +257,7 @@ public:
 	void artifactMoved(const ArtifactLocation &artLoc, const ArtifactLocation &destLoc, bool withRedraw) override;
 	void artifactDisassembled(const ArtifactLocation &artLoc) override;
 	void artifactAssembled(const ArtifactLocation &artLoc) override;
+	void buildChanged() override;
 };
 
 /// List item with town

--- a/client/windows/CKingdomInterface.h
+++ b/client/windows/CKingdomInterface.h
@@ -233,6 +233,7 @@ private:
 
 	std::shared_ptr<CHoverableArea> incomeArea;
 	std::shared_ptr<CLabel> incomeAmount;
+	std::shared_ptr<LRClickableArea> fastMarket;
 
 	std::shared_ptr<CGStatusBar> statusbar;
 	std::shared_ptr<CResDataBar> resdatabar;
@@ -276,6 +277,9 @@ class CTownItem : public CIntObject, public IGarrisonHolder
 	std::vector<std::shared_ptr<CCreaInfo>> growth;
 
 	std::shared_ptr<LRClickableAreaOpenTown> openTown;
+
+	std::shared_ptr<CButton> fastTownHall;
+	std::shared_ptr<CButton> fastArmyPurchase;
 
 public:
 	const CGTownInstance * town;

--- a/client/windows/CKingdomInterface.h
+++ b/client/windows/CKingdomInterface.h
@@ -282,6 +282,7 @@ class CTownItem : public CIntObject, public IGarrisonHolder
 	std::shared_ptr<CButton> fastArmyPurchase;
 	std::shared_ptr<LRClickableArea> fastMarket;
 	std::shared_ptr<LRClickableArea> fastTavern;
+	std::shared_ptr<LRClickableArea> fastTown;
 
 public:
 	const CGTownInstance * town;

--- a/client/windows/CKingdomInterface.h
+++ b/client/windows/CKingdomInterface.h
@@ -233,7 +233,6 @@ private:
 
 	std::shared_ptr<CHoverableArea> incomeArea;
 	std::shared_ptr<CLabel> incomeAmount;
-	std::shared_ptr<LRClickableArea> fastMarket;
 
 	std::shared_ptr<CGStatusBar> statusbar;
 	std::shared_ptr<CResDataBar> resdatabar;
@@ -280,6 +279,8 @@ class CTownItem : public CIntObject, public IGarrisonHolder
 
 	std::shared_ptr<CButton> fastTownHall;
 	std::shared_ptr<CButton> fastArmyPurchase;
+	std::shared_ptr<LRClickableArea> fastMarket;
+	std::shared_ptr<LRClickableArea> fastTavern;
 
 public:
 	const CGTownInstance * town;

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -489,7 +489,7 @@ CTavernWindow::CTavernWindow(const CGObjectInstance * TavernObj, const std::func
 		recruit->addHoverText(CButton::NORMAL, boost::str(boost::format(CGI->generaltexth->tavernInfo[1]) % LOCPLINT->cb->howManyHeroes(false)));
 		recruit->block(true);
 	}
-	else if(LOCPLINT->castleInt && LOCPLINT->castleInt->town->visitingHero)
+	else if((LOCPLINT->castleInt && LOCPLINT->castleInt->town->visitingHero) || (dynamic_cast<const CGTownInstance *>(TavernObj) && dynamic_cast<const CGTownInstance *>(TavernObj)->visitingHero))
 	{
 		recruit->addHoverText(CButton::NORMAL, CGI->generaltexth->tavernInfo[2]); //Cannot recruit. You already have a Hero in this town.
 		recruit->block(true);
@@ -501,6 +501,8 @@ CTavernWindow::CTavernWindow(const CGObjectInstance * TavernObj, const std::func
 	}
 	if(LOCPLINT->castleInt)
 		CCS->videoh->open(LOCPLINT->castleInt->town->town->clientInfo.tavernVideo);
+	else if(dynamic_cast<const CGTownInstance *>(TavernObj))
+		CCS->videoh->open(dynamic_cast<const CGTownInstance *>(TavernObj)->town->clientInfo.tavernVideo);
 	else
 		CCS->videoh->open(VideoPath::builtin("TAVERN.BIK"));
 }

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -501,8 +501,8 @@ CTavernWindow::CTavernWindow(const CGObjectInstance * TavernObj, const std::func
 	}
 	if(LOCPLINT->castleInt)
 		CCS->videoh->open(LOCPLINT->castleInt->town->town->clientInfo.tavernVideo);
-	else if(dynamic_cast<const CGTownInstance *>(TavernObj))
-		CCS->videoh->open(dynamic_cast<const CGTownInstance *>(TavernObj)->town->clientInfo.tavernVideo);
+	else if(const auto * townObj = dynamic_cast<const CGTownInstance *>(TavernObj))
+		CCS->videoh->open(townObj->town->clientInfo.tavernVideo);
 	else
 		CCS->videoh->open(VideoPath::builtin("TAVERN.BIK"));
 }

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -489,7 +489,7 @@ CTavernWindow::CTavernWindow(const CGObjectInstance * TavernObj, const std::func
 		recruit->addHoverText(CButton::NORMAL, boost::str(boost::format(CGI->generaltexth->tavernInfo[1]) % LOCPLINT->cb->howManyHeroes(false)));
 		recruit->block(true);
 	}
-	else if(dynamic_cast<const CGTownInstance *>(TavernObj) && dynamic_cast<const CGTownInstance *>(TavernObj)->visitingHero))
+	else if(dynamic_cast<const CGTownInstance *>(TavernObj) && dynamic_cast<const CGTownInstance *>(TavernObj)->visitingHero)
 	{
 		recruit->addHoverText(CButton::NORMAL, CGI->generaltexth->tavernInfo[2]); //Cannot recruit. You already have a Hero in this town.
 		recruit->block(true);

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -489,7 +489,7 @@ CTavernWindow::CTavernWindow(const CGObjectInstance * TavernObj, const std::func
 		recruit->addHoverText(CButton::NORMAL, boost::str(boost::format(CGI->generaltexth->tavernInfo[1]) % LOCPLINT->cb->howManyHeroes(false)));
 		recruit->block(true);
 	}
-	else if((LOCPLINT->castleInt && LOCPLINT->castleInt->town->visitingHero) || (dynamic_cast<const CGTownInstance *>(TavernObj) && dynamic_cast<const CGTownInstance *>(TavernObj)->visitingHero))
+	else if(dynamic_cast<const CGTownInstance *>(TavernObj) && dynamic_cast<const CGTownInstance *>(TavernObj)->visitingHero))
 	{
 		recruit->addHoverText(CButton::NORMAL, CGI->generaltexth->tavernInfo[2]); //Cannot recruit. You already have a Hero in this town.
 		recruit->block(true);

--- a/docs/players/Game_Mechanics.md
+++ b/docs/players/Game_Mechanics.md
@@ -41,6 +41,14 @@ Some of H3 mechanics can't be straight considered as bug, but default VCMI behav
 - [Alt] + [LCtrl] + LClick - move all units of selected stack to the city's garrison or to the met hero 
 - [Alt] + [LShift] + LClick - dismiss selected stack`
 
+## Interface Shourtcuts
+
+It's now possible to open Tavern (click on town icon), Townhall, Quick Recruitment and Marketplace (click on gold) from various places:
+
+- Town screen (left bottom)
+- Kingdom overview for each town
+- Infobox (only if info box army management is enabled)
+
 ## Quick Recruitment
 
 Mouse click on castle icon in the town screen open quick recruitment window, where we can purhase in fast way units.


### PR DESCRIPTION
On touch devices it's not possible to use hotkeys.

Because of that. And for people (like me) who search the correct building. Some improvements:

![grafik](https://github.com/vcmi/vcmi/assets/13953785/dc8bed1e-4901-4519-9527-7771d3f1b968)
(additional to existing)
- town icon opens tavern
- gold opens marketplace

![grafik](https://github.com/vcmi/vcmi/assets/13953785/d5838f9d-78ba-45c3-ada9-772ec0737f18)
- top -> same as town screen
- bottom -> last setting is now saved (for next menu open; same as HD mod)

![grafik](https://github.com/vcmi/vcmi/assets/13953785/d894764f-9494-4cf3-944a-a45de37f8f5a)
(only if quick army setting active)
- same as town screen
- except: no tavern (we need some space to switch between the different info windows
