### PR TITLE
Fixed morale and luck chance lookup.

### DIFF
--- a/server/battles/BattleActionProcessor.cpp
+++ b/server/battles/BattleActionProcessor.cpp
@@ -884,7 +884,7 @@ void BattleActionProcessor::makeAttack(const CBattleInfoCallback & battle, const
 	if(attackerLuck > 0)
 	{
 		auto diceSize = VLC->settings()->getVector(EGameSettings::COMBAT_GOOD_LUCK_DICE);
-		size_t diceIndex = std::min<size_t>(diceSize.size() - 1, attackerLuck);
+		size_t diceIndex = std::min<size_t>(diceSize.size(), attackerLuck) - 1; // array index, so 0-indexed
 
 		if(diceSize.size() > 0 && gameHandler->getRandomGenerator().nextInt(1, diceSize[diceIndex]) == 1)
 			bat.flags |= BattleAttack::LUCKY;
@@ -893,7 +893,7 @@ void BattleActionProcessor::makeAttack(const CBattleInfoCallback & battle, const
 	if(attackerLuck < 0)
 	{
 		auto diceSize = VLC->settings()->getVector(EGameSettings::COMBAT_BAD_LUCK_DICE);
-		size_t diceIndex = std::min<size_t>(diceSize.size() - 1, -attackerLuck);
+		size_t diceIndex = std::min<size_t>(diceSize.size(), -attackerLuck) - 1; // array index, so 0-indexed
 
 		if(diceSize.size() > 0 && gameHandler->getRandomGenerator().nextInt(1, diceSize[diceIndex]) == 1)
 			bat.flags |= BattleAttack::UNLUCKY;

--- a/server/battles/BattleFlowProcessor.cpp
+++ b/server/battles/BattleFlowProcessor.cpp
@@ -340,7 +340,7 @@ bool BattleFlowProcessor::tryMakeAutomaticAction(const CBattleInfoCallback & bat
 	if(!next->hadMorale && !next->waited() && nextStackMorale < 0)
 	{
 		auto diceSize = VLC->settings()->getVector(EGameSettings::COMBAT_BAD_MORALE_DICE);
-		size_t diceIndex = std::min<size_t>(diceSize.size()-1, -nextStackMorale);
+		size_t diceIndex = std::min<size_t>(diceSize.size(), -nextStackMorale) - 1; // array index, so 0-indexed
 
 		if(diceSize.size() > 0 && gameHandler->getRandomGenerator().nextInt(1, diceSize[diceIndex]) == 1)
 		{
@@ -492,7 +492,7 @@ bool BattleFlowProcessor::rollGoodMorale(const CBattleInfoCallback & battle, con
 		&& nextStackMorale > 0)
 	{
 		auto diceSize = VLC->settings()->getVector(EGameSettings::COMBAT_GOOD_MORALE_DICE);
-		size_t diceIndex = std::min<size_t>(diceSize.size()-1, nextStackMorale);
+		size_t diceIndex = std::min<size_t>(diceSize.size(), nextStackMorale) - 1; // array index, so 0-indexed
 
 		if(diceSize.size() > 0 && gameHandler->getRandomGenerator().nextInt(1, diceSize[diceIndex]) == 1)
 		{


### PR DESCRIPTION
Good and bad Morale and Luck skipped the first value from the settings. It was an off-by-1 error when changing good/bad Luck/Morale counts (starting from +-1) into array indexes (starting from 0).