### PR TITLE
Fix crash on game load

### DIFF
--- a/lib/CConfigHandler.cpp
+++ b/lib/CConfigHandler.cpp
@@ -61,7 +61,7 @@ void SettingsStorage::init(const std::string & dataFilename, const std::string &
 
 	JsonPath confName = JsonPath::builtin(dataFilename);
 
-	JsonUtils::assembleFromFiles(confName.getOriginalName()).swap(config);
+	config = JsonUtils::assembleFromFiles(confName.getOriginalName());
 
 	// Probably new install. Create config file to save settings to
 	if (!CResourceHandler::get("local")->existsResource(confName))

--- a/lib/JsonNode.h
+++ b/lib/JsonNode.h
@@ -37,17 +37,8 @@ public:
 	};
 
 private:
-	union JsonData
-	{
-		bool Bool;
-		double Float;
-		std::string* String;
-		JsonVector* Vector;
-		JsonMap* Struct;
-		si64 Integer;
-	};
+	using JsonData = std::variant<std::monostate, bool, double, std::string, JsonVector, JsonMap, si64>;
 
-	JsonType type;
 	JsonData data;
 
 public:
@@ -64,13 +55,6 @@ public:
 	explicit JsonNode(const JsonPath & fileURI);
 	explicit JsonNode(const std::string & modName, const JsonPath & fileURI);
 	explicit JsonNode(const JsonPath & fileURI, bool & isValidSyntax);
-	//Copy c-tor
-	JsonNode(const JsonNode &copy);
-
-	~JsonNode();
-
-	void swap(JsonNode &b);
-	JsonNode& operator =(JsonNode node);
 
 	bool operator == (const JsonNode &other) const;
 	bool operator != (const JsonNode &other) const;
@@ -137,30 +121,7 @@ public:
 	{
 		h & meta;
 		h & flags;
-		h & type;
-		switch(type)
-		{
-		case JsonType::DATA_NULL:
-			break;
-		case JsonType::DATA_BOOL:
-			h & data.Bool;
-			break;
-		case JsonType::DATA_FLOAT:
-			h & data.Float;
-			break;
-		case JsonType::DATA_STRING:
-			h & data.String;
-			break;
-		case JsonType::DATA_VECTOR:
-			h & data.Vector;
-			break;
-		case JsonType::DATA_STRUCT:
-			h & data.Struct;
-			break;
-		case JsonType::DATA_INTEGER:
-			h & data.Integer;
-			break;
-		}
+		h & data;
 	}
 };
 

--- a/lib/modding/ContentTypeHandler.cpp
+++ b/lib/modding/ContentTypeHandler.cpp
@@ -63,7 +63,7 @@ bool ContentTypeHandler::preloadModData(const std::string & modName, const std::
 		if (colon == std::string::npos)
 		{
 			// normal object, local to this mod
-			modInfo.modData[entry.first].swap(entry.second);
+			std::swap(modInfo.modData[entry.first], entry.second);
 		}
 		else
 		{

--- a/lib/serializer/BinaryDeserializer.h
+++ b/lib/serializer/BinaryDeserializer.h
@@ -404,6 +404,11 @@ public:
 			data.reset();
 	}
 
+	void load(std::monostate & data)
+	{
+		// no-op
+	}
+
 	template <typename T>
 	void load(std::shared_ptr<const T> & data)
 	{

--- a/lib/serializer/BinarySerializer.h
+++ b/lib/serializer/BinarySerializer.h
@@ -238,6 +238,11 @@ public:
 		const_cast<T&>(data).serialize(*this, SERIALIZATION_VERSION);
 	}
 
+	void save(const std::monostate & data)
+	{
+		// no-op
+	}
+
 	template <typename T>
 	void save(const std::shared_ptr<T> &data)
 	{


### PR DESCRIPTION
Looks that due to recent changes game now crashes on save loading.

Cause seems to be JsonNode deserialization. Probably - issue with union usage alongside with copy and/or move constructors.

After looking into it I haven't noticed any obvious bugs, so decided to drop union usage instead and use std::variant instead which is definitely more well-tested than our class.