### PR TITLE
Battle ai movement fix

### DIFF
--- a/AI/BattleAI/AttackPossibility.cpp
+++ b/AI/BattleAI/AttackPossibility.cpp
@@ -157,13 +157,9 @@ float AttackPossibility::calculateDamageReduce(
 	auto enemyDamageBeforeAttack = damageCache.getOriginalDamage(defender, attackerUnitForMeasurement, state);
 	auto enemiesKilled = damageDealt / maxHealth + (damageDealt % maxHealth >= defender->getFirstHPleft() ? 1 : 0);
 	auto damagePerEnemy = enemyDamageBeforeAttack / (double)defender->getCount();
-	
-	// lets use cached maxHealth here instead of getAvailableHealth
-	auto firstUnitHpLeft = (availableHealth - damageDealt) % maxHealth;
-	auto firstUnitHealthRatio = firstUnitHpLeft == 0 ? 1 : static_cast<float>(firstUnitHpLeft) / maxHealth;
-	auto firstUnitKillValue = (1 - firstUnitHealthRatio) * (1 - firstUnitHealthRatio);
+	auto lastUnitKillValue = (damageDealt % maxHealth) / (double)maxHealth;;
 
-	return damagePerEnemy * (enemiesKilled + firstUnitKillValue * HEALTH_BOUNTY);
+	return damagePerEnemy * (enemiesKilled + lastUnitKillValue * HEALTH_BOUNTY);
 }
 
 int64_t AttackPossibility::evaluateBlockedShootersDmg(

--- a/AI/BattleAI/AttackPossibility.cpp
+++ b/AI/BattleAI/AttackPossibility.cpp
@@ -114,6 +114,23 @@ float AttackPossibility::attackValue() const
 	return damageDiff();
 }
 
+float hpFunction(uint64_t unitHealthStart, uint64_t unitHealthEnd, uint64_t maxHealth)
+{
+	float ratioStart = static_cast<float>(unitHealthStart) / maxHealth;
+	float ratioEnd = static_cast<float>(unitHealthEnd) / maxHealth;
+	float base = 0.666666f;
+
+	// reduce from max to 0 must be 1. 
+	// 10 hp from end costs bit more than 10 hp from start because our goal is to kill unit, not just hurt it
+	// ********** 2 * base - ratioStart *********
+	// *                                                              *
+	// *        height = ratioStart - ratioEnd         *
+	// *                                                                  *
+	// ******************** 2 * base - ratioEnd ******
+	// S = (a + b) * h / 2
+	return (base * (4 - ratioStart - ratioEnd)) * (ratioStart - ratioEnd) / 2 ;
+}
+
 /// <summary>
 /// How enemy damage will be reduced by this attack
 /// Half bounty for kill, half for making damage equal to enemy health
@@ -127,6 +144,7 @@ float AttackPossibility::calculateDamageReduce(
 	std::shared_ptr<CBattleInfoCallback> state)
 {
 	const float HEALTH_BOUNTY = 0.5;
+	const float KILL_BOUNTY = 0.5;
 
 	// FIXME: provide distance info for Jousting bonus
 	auto attackerUnitForMeasurement = attacker;
@@ -157,9 +175,20 @@ float AttackPossibility::calculateDamageReduce(
 	auto enemyDamageBeforeAttack = damageCache.getOriginalDamage(defender, attackerUnitForMeasurement, state);
 	auto enemiesKilled = damageDealt / maxHealth + (damageDealt % maxHealth >= defender->getFirstHPleft() ? 1 : 0);
 	auto damagePerEnemy = enemyDamageBeforeAttack / (double)defender->getCount();
-	auto lastUnitKillValue = (damageDealt % maxHealth) / (double)maxHealth;;
+	auto exceedingDamage = (damageDealt % maxHealth);
+	float hpValue = (damageDealt / maxHealth);
+	
+	if(defender->getFirstHPleft() >= exceedingDamage)
+	{
+		hpValue += hpFunction(defender->getFirstHPleft(), defender->getFirstHPleft() - exceedingDamage, maxHealth);
+	}
+	else
+	{
+		hpValue += hpFunction(defender->getFirstHPleft(), 0, maxHealth);
+		hpValue += hpFunction(maxHealth, maxHealth + defender->getFirstHPleft() - exceedingDamage, maxHealth);
+	}
 
-	return damagePerEnemy * (enemiesKilled + lastUnitKillValue * HEALTH_BOUNTY);
+	return damagePerEnemy * (enemiesKilled * KILL_BOUNTY + hpValue * HEALTH_BOUNTY);
 }
 
 int64_t AttackPossibility::evaluateBlockedShootersDmg(

--- a/AI/BattleAI/BattleEvaluator.cpp
+++ b/AI/BattleAI/BattleEvaluator.cpp
@@ -190,6 +190,14 @@ BattleAction BattleEvaluator::selectStackAction(const CStack * stack)
 
 		if(stack->waited())
 		{
+			logAi->debug(
+				"Moving %s towards hex %s[%d], score: %2f/%2f",
+				stack->getDescription(),
+				moveTarget.cachedAttack->attack.defender->getDescription(),
+				moveTarget.cachedAttack->attack.defender->getPosition().hex,
+				moveTarget.score,
+				moveTarget.scorePerTurn);
+
 			return goTowardsNearest(stack, moveTarget.positions);
 		}
 		else
@@ -572,7 +580,7 @@ bool BattleEvaluator::attemptCastingSpell(const CStack * activeStack)
 				}
 				else
 				{
-					ps.value = scoreEvaluator.calculateExchange(*cachedAttack, *targets, innerCache, state);
+					ps.value = scoreEvaluator.evaluateExchange(*cachedAttack, *targets, innerCache, state);
 				}
 
 				for(auto unit : allUnits)

--- a/AI/BattleAI/BattleEvaluator.cpp
+++ b/AI/BattleAI/BattleEvaluator.cpp
@@ -149,7 +149,7 @@ BattleAction BattleEvaluator::selectStackAction(const CStack * stack)
 				bestAttack.attack.attacker->speed(0, true),
 				bestAttack.defenderDamageReduce,
 				bestAttack.attackerDamageReduce,
-				bestAttack.attackValue()
+				score
 			);
 
 			if (moveTarget.scorePerTurn <= score)
@@ -580,7 +580,7 @@ bool BattleEvaluator::attemptCastingSpell(const CStack * activeStack)
 				}
 				else
 				{
-					ps.value = scoreEvaluator.evaluateExchange(*cachedAttack, *targets, innerCache, state);
+					ps.value = scoreEvaluator.evaluateExchange(*cachedAttack, 0, *targets, innerCache, state);
 				}
 
 				for(auto unit : allUnits)

--- a/AI/BattleAI/BattleExchangeVariant.h
+++ b/AI/BattleAI/BattleExchangeVariant.h
@@ -132,6 +132,7 @@ class BattleExchangeEvaluator
 private:
 	std::shared_ptr<CBattleInfoCallback> cb;
 	std::shared_ptr<Environment> env;
+	std::map<uint32_t, ReachabilityInfo> reachabilityCache;
 	std::map<BattleHex, std::vector<const battle::Unit *>> reachabilityMap;
 	std::vector<battle::Units> turnOrder;
 	float negativeEffectMultiplier;
@@ -140,6 +141,7 @@ private:
 
 	BattleScore calculateExchange(
 		const AttackPossibility & ap,
+		uint8_t turn,
 		PotentialTargets & targets,
 		DamageCache & damageCache,
 		std::shared_ptr<HypotheticBattle> hb);
@@ -151,7 +153,7 @@ public:
 		std::shared_ptr<CBattleInfoCallback> cb,
 		std::shared_ptr<Environment> env,
 		float strengthRatio): cb(cb), env(env) {
-		negativeEffectMultiplier = std::sqrt(strengthRatio);
+		negativeEffectMultiplier = strengthRatio >= 1 ? 1 : strengthRatio;
 	}
 
 	EvaluationResult findBestTarget(
@@ -162,10 +164,12 @@ public:
 
 	float evaluateExchange(
 		const AttackPossibility & ap,
+		uint8_t turn,
 		PotentialTargets & targets,
 		DamageCache & damageCache,
 		std::shared_ptr<HypotheticBattle> hb);
 
+	std::vector<const battle::Unit *> getOneTurnReachableUnits(uint8_t turn, BattleHex hex);
 	void updateReachabilityMap(std::shared_ptr<HypotheticBattle> hb);
 
 	ReachabilityData getExchangeUnits(

--- a/AI/BattleAI/BattleExchangeVariant.h
+++ b/AI/BattleAI/BattleExchangeVariant.h
@@ -14,6 +14,34 @@
 #include "PotentialTargets.h"
 #include "StackWithBonuses.h"
 
+struct BattleScore
+{
+	float ourDamageReduce;
+	float enemyDamageReduce;
+
+	BattleScore(float enemyDamageReduce, float ourDamageReduce)
+		:enemyDamageReduce(enemyDamageReduce), ourDamageReduce(ourDamageReduce)
+	{
+	}
+
+	BattleScore() : BattleScore(0, 0) {}
+
+	float value()
+	{
+		return enemyDamageReduce - ourDamageReduce;
+	}
+
+	BattleScore  operator+(BattleScore & other)
+	{
+		BattleScore result = *this;
+
+		result.ourDamageReduce += other.ourDamageReduce;
+		result.enemyDamageReduce += other.enemyDamageReduce;
+
+		return result;
+	}
+};
+
 struct AttackerValue
 {
 	float value;
@@ -59,8 +87,8 @@ struct EvaluationResult
 class BattleExchangeVariant
 {
 public:
-	BattleExchangeVariant(float positiveEffectMultiplier, float negativeEffectMultiplier)
-		: dpsScore(0), positiveEffectMultiplier(positiveEffectMultiplier), negativeEffectMultiplier(negativeEffectMultiplier) {}
+	BattleExchangeVariant()
+		: dpsScore() {}
 
 	float trackAttack(
 		const AttackPossibility & ap,
@@ -76,7 +104,7 @@ public:
 		std::shared_ptr<HypotheticBattle> hb,
 		bool evaluateOnly = false);
 
-	float getScore() const { return dpsScore; }
+	const BattleScore & getScore() const { return dpsScore; }
 
 	void adjustPositions(
 		std::vector<const battle::Unit *> attackers,
@@ -84,10 +112,19 @@ public:
 		std::map<BattleHex, battle::Units> & reachabilityMap);
 
 private:
-	float positiveEffectMultiplier;
-	float negativeEffectMultiplier;
-	float dpsScore;
+	BattleScore dpsScore;
 	std::map<uint32_t, AttackerValue> attackerValue;
+};
+
+struct ReachabilityData
+{
+	std::vector<const battle::Unit *> units;
+
+	// shooters which are within mellee attack and mellee units
+	std::vector<const battle::Unit *> melleeAccessible;
+
+	// far shooters
+	std::vector<const battle::Unit *> shooters;
 };
 
 class BattleExchangeEvaluator
@@ -99,12 +136,22 @@ private:
 	std::vector<battle::Units> turnOrder;
 	float negativeEffectMultiplier;
 
+	float scoreValue(const BattleScore & score) const;
+
+	BattleScore calculateExchange(
+		const AttackPossibility & ap,
+		PotentialTargets & targets,
+		DamageCache & damageCache,
+		std::shared_ptr<HypotheticBattle> hb);
+
+	bool canBeHitThisTurn(const AttackPossibility & ap);
+
 public:
 	BattleExchangeEvaluator(
 		std::shared_ptr<CBattleInfoCallback> cb,
 		std::shared_ptr<Environment> env,
 		float strengthRatio): cb(cb), env(env) {
-		negativeEffectMultiplier = strengthRatio;
+		negativeEffectMultiplier = std::sqrt(strengthRatio);
 	}
 
 	EvaluationResult findBestTarget(
@@ -113,14 +160,20 @@ public:
 		DamageCache & damageCache,
 		std::shared_ptr<HypotheticBattle> hb);
 
-	float calculateExchange(
+	float evaluateExchange(
 		const AttackPossibility & ap,
 		PotentialTargets & targets,
 		DamageCache & damageCache,
 		std::shared_ptr<HypotheticBattle> hb);
 
 	void updateReachabilityMap(std::shared_ptr<HypotheticBattle> hb);
-	std::vector<const battle::Unit *> getExchangeUnits(const AttackPossibility & ap, PotentialTargets & targets, std::shared_ptr<HypotheticBattle> hb);
+
+	ReachabilityData getExchangeUnits(
+		const AttackPossibility & ap,
+		uint8_t turn,
+		PotentialTargets & targets,
+		std::shared_ptr<HypotheticBattle> hb);
+
 	bool checkPositionBlocksOurStacks(HypotheticBattle & hb, const battle::Unit * unit, BattleHex position);
 
 	MoveTarget findMoveTowardsUnreachable(
@@ -131,6 +184,6 @@ public:
 
 	std::vector<const battle::Unit *> getAdjacentUnits(const battle::Unit * unit);
 
-	float getPositiveEffectMultiplier() { return 1; }
-	float getNegativeEffectMultiplier() { return negativeEffectMultiplier; }
+	float getPositiveEffectMultiplier() const { return 1; }
+	float getNegativeEffectMultiplier() const { return negativeEffectMultiplier; }
 };

--- a/AI/Nullkiller/Engine/Nullkiller.cpp
+++ b/AI/Nullkiller/Engine/Nullkiller.cpp
@@ -274,6 +274,7 @@ void Nullkiller::makeTurn()
 
 		bestTask = choseBestTask(bestTasks);
 
+		std::string taskDescription = bestTask->toString();
 		HeroPtr hero = bestTask->getHero();
 		HeroRole heroRole = HeroRole::MAIN;
 
@@ -292,7 +293,7 @@ void Nullkiller::makeTurn()
 
 			logAi->trace(
 				"Goal %s has low priority %f so decreasing  scan depth to gain performance.",
-				bestTask->toString(),
+				taskDescription,
 				bestTask->priority);
 		}
 
@@ -308,7 +309,7 @@ void Nullkiller::makeTurn()
 			{
 				logAi->trace(
 					"Goal %s has too low priority %f so increasing scan depth to full.",
-					bestTask->toString(),
+					taskDescription,
 					bestTask->priority);
 
 				scanDepth = ScanDepth::ALL_FULL;
@@ -316,7 +317,7 @@ void Nullkiller::makeTurn()
 				continue;
 			}
 
-			logAi->trace("Goal %s has too low priority. It is not worth doing it. Ending turn.", bestTask->toString());
+			logAi->trace("Goal %s has too low priority. It is not worth doing it. Ending turn.", taskDescription);
 
 			return;
 		}
@@ -325,7 +326,7 @@ void Nullkiller::makeTurn()
 
 		if(i == MAXPASS)
 		{
-			logAi->error("Goal %s exceeded maxpass. Terminating AI turn.", bestTask->toString());
+			logAi->error("Goal %s exceeded maxpass. Terminating AI turn.", taskDescription);
 		}
 	}
 }


### PR DESCRIPTION
A lot of debugging showed some bugs and flaws in initial design. Should be a bit better now.
AI should see strong stacks (archers) even if guarded by weak stacks (1-units).
AI prefers more slower targets comparing to own stack speed even if they are not reachable this turn. Still it is not hardcoded behavior.