### PR TITLE
Fix data import on Android

### DIFF
--- a/android/vcmi-app/src/main/java/eu/vcmi/vcmi/Storage.java
+++ b/android/vcmi-app/src/main/java/eu/vcmi/vcmi/Storage.java
@@ -22,7 +22,9 @@ public class Storage
     public static boolean testH3DataFolder(final File baseDir)
     {
         final File testH3Data = new File(baseDir, "Data");
-        return testH3Data.exists();
+        final File testH3data = new File(baseDir, "data");
+        final File testH3DATA = new File(baseDir, "DATA");
+        return testH3Data.exists() || testH3data.exists() || testH3DATA.exists();
     }
 
     public static String getH3DataFolder(Context context){

--- a/android/vcmi-app/src/main/java/eu/vcmi/vcmi/settings/CopyDataController.java
+++ b/android/vcmi-app/src/main/java/eu/vcmi/vcmi/settings/CopyDataController.java
@@ -140,7 +140,7 @@ public class CopyDataController extends LauncherSettingController<Void, Void>
                         }
                     }
                     
-                    if (fileAllowed)
+                    if (!fileAllowed)
                         continue;
                 }
 

--- a/android/vcmi-app/src/main/java/eu/vcmi/vcmi/settings/CopyDataController.java
+++ b/android/vcmi-app/src/main/java/eu/vcmi/vcmi/settings/CopyDataController.java
@@ -127,9 +127,21 @@ public class CopyDataController extends LauncherSettingController<Void, Void>
 
             for (DocumentFile child : sourceDir.listFiles())
             {
-                if (allowed != null && !allowed.contains(child.getName()))
+                if (allowed != null)
                 {
-                    continue;
+                    boolean fileAllowed = false;
+                    
+                    for (String str : allowed)
+                    {
+                        if (str.equalsIgnoreCase(child.getName()))
+                        {
+                            fileAllowed = true;
+                            break;
+                        }
+                    }
+                    
+                    if (fileAllowed)
+                        continue;
                 }
 
                 File exported = new File(targetDir, child.getName());


### PR DESCRIPTION
Ignore case when checking whether path is white-listed. Fixes data import with H3 data that has different case in directory names.

We had reports where player has "data" or "mp3" directories in imported h3 files, but our Android launcher only copies "Data" or "Mp3".

Blind fix since I don't have java knowledge or Android build set up, will test using build artifacts.