### PR TITLE
Mod compatibility fixes

### DIFF
--- a/lib/mapObjectConstructors/CObjectClassesHandler.cpp
+++ b/lib/mapObjectConstructors/CObjectClassesHandler.cpp
@@ -194,9 +194,9 @@ TObjectTypeHandler CObjectClassesHandler::loadSubObjectFromJson(const std::strin
 	assert(!scope.empty());
 
 	std::string handler = obj->handlerName;
-	if(!handlerConstructors.count(obj->handlerName))
+	if(!handlerConstructors.count(handler))
 	{
-		logMod->error("Handler with name %s was not found!", obj->handlerName);
+		logMod->error("Handler with name %s was not found!", handler);
 		// workaround for potential crash - if handler does not exists, continue with generic handler that is used for objects without any custom logc
 		handler = "generic";
 		assert(handlerConstructors.count(handler) != 0);

--- a/lib/mapObjectConstructors/CObjectClassesHandler.cpp
+++ b/lib/mapObjectConstructors/CObjectClassesHandler.cpp
@@ -193,13 +193,16 @@ TObjectTypeHandler CObjectClassesHandler::loadSubObjectFromJson(const std::strin
 	assert(identifier.find(':') == std::string::npos);
 	assert(!scope.empty());
 
+	std::string handler = obj->handlerName;
 	if(!handlerConstructors.count(obj->handlerName))
 	{
-		logGlobal->error("Handler with name %s was not found!", obj->handlerName);
-		return nullptr;
+		logMod->error("Handler with name %s was not found!", obj->handlerName);
+		// workaround for potential crash - if handler does not exists, continue with generic handler that is used for objects without any custom logc
+		handler = "generic";
+		assert(handlerConstructors.count(handler) != 0);
 	}
 
-	auto createdObject = handlerConstructors.at(obj->handlerName)();
+	auto createdObject = handlerConstructors.at(handler)();
 
 	createdObject->modScope = scope;
 	createdObject->typeName = obj->identifier;;


### PR DESCRIPTION
Minor fixes to avoid potential crashes if player has outdated mods:
- Do not crash if handler for map objects was not found, instead fall back onto generic (empty) handler. Discovered since I removed separate "shrine" handler (merged into "configurable"), but hota mod uses "shrine" handler in 1.3.
- Block loading of objects into another mod namespace. Side effect of "torosar " fix - mods that still edit "torosar " now attempt to create new object with mostly invalid/unset properties. With this change such attempts will be ignored.