### PR TITLE
Allow configuring all objects

### DIFF
--- a/lib/mapObjectConstructors/CRewardableConstructor.cpp
+++ b/lib/mapObjectConstructors/CRewardableConstructor.cpp
@@ -44,7 +44,9 @@ void CRewardableConstructor::configureObject(CGObjectInstance * object, CRandomG
 {
 	if(auto * rewardableObject = dynamic_cast<CRewardableObject*>(object))
 	{
-		objectInfo.configureObject(rewardableObject->configuration, rng);
+		if(rewardableObject->configuration.info.empty())
+			objectInfo.configureObject(rewardableObject->configuration, rng);
+		
 		for(auto & rewardInfo : rewardableObject->configuration.info)
 		{
 			for (auto & bonus : rewardInfo.reward.bonuses)

--- a/mapeditor/mainwindow.cpp
+++ b/mapeditor/mainwindow.cpp
@@ -88,7 +88,7 @@ void MainWindow::loadUserSettings()
 	}
 	lastSavingDir = s.value(lastDirectorySetting).toString();
 	if(lastSavingDir.isEmpty())
-		lastSavingDir = QString::fromStdString(VCMIDirs::get().userCachePath().make_preferred().string());
+		lastSavingDir = QString::fromStdString(VCMIDirs::get().userDataPath().make_preferred().string());
 }
 
 void MainWindow::saveUserSettings()
@@ -382,7 +382,7 @@ void MainWindow::on_actionOpen_triggered()
 		return;
 	
 	auto filenameSelect = QFileDialog::getOpenFileName(this, tr("Open map"),
-		QString::fromStdString(VCMIDirs::get().userCachePath().make_preferred().string()),
+		QString::fromStdString(VCMIDirs::get().userDataPath().make_preferred().string()),
 		tr("All supported maps (*.vmap *.h3m);;VCMI maps(*.vmap);;HoMM3 maps(*.h3m)"));
 	if(filenameSelect.isEmpty())
 		return;
@@ -1172,7 +1172,7 @@ void MainWindow::on_actionTranslations_triggered()
 void MainWindow::on_actionh3m_converter_triggered()
 {
 	auto mapFiles = QFileDialog::getOpenFileNames(this, tr("Select maps to convert"),
-		QString::fromStdString(VCMIDirs::get().userCachePath().make_preferred().string()),
+		QString::fromStdString(VCMIDirs::get().userDataPath().make_preferred().string()),
 		tr("HoMM3 maps(*.h3m)"));
 	if(mapFiles.empty())
 		return;

--- a/mapeditor/mainwindow.h
+++ b/mapeditor/mainwindow.h
@@ -27,6 +27,7 @@ class MainWindow : public QMainWindow
 
 	const QString mainWindowSizeSetting = "MainWindow/Size";
 	const QString mainWindowPositionSetting = "MainWindow/Position";
+	const QString lastDirectorySetting = "MainWindow/Directory";
 
 #ifdef ENABLE_QT_TRANSLATIONS
 	QTranslator translator;
@@ -180,7 +181,6 @@ private:
 	QStandardItemModel objectsModel;
 
 	int mapLevel = 0;
-	QRectF initialScale;
 
 	std::set<int> catalog;
 


### PR DESCRIPTION
All rewardable objects are possible to customise in map editor.

Also, fixes #3087 