### PR TITLE
Fix crash caused by duplicated delete

### DIFF
--- a/lib/rmg/modificators/ObjectManager.cpp
+++ b/lib/rmg/modificators/ObjectManager.cpp
@@ -447,7 +447,6 @@ bool ObjectManager::createRequiredObjects()
 					instance->object().getObjectName(), instance->getPosition(true).toString());
 				mapProxy->removeObject(&instance->object());
 			}
-			rmgNearObject.clear();
 		}
 	}
 	


### PR DESCRIPTION
clear() does delete for obj, but pointer is saved in undo stack of MapEditManager

Probably fixes #1377 and #2645