### PR TITLE
Improve ccache hit rate for PRs

### DIFF
--- a/.github/workflows/github.yml
+++ b/.github/workflows/github.yml
@@ -166,18 +166,36 @@ jobs:
       env:
         VCMI_BUILD_PLATFORM: x64
 
-    - name: ccache
+    # ensure the ccache for each PR is separate so they don't interfere with each other
+    # fall back to ccache of the vcmi/vcmi repo if no PR-specific ccache is found
+    - name: Ccache for PRs
       uses: hendrikmuhs/ccache-action@v1.2
+      if: ${{ github.event.number != '' }}
       with:
-          key: ${{ matrix.preset }}
-          # actual cache takes up less space, at most ~1 GB
-          max-size: "5G"
-          verbose: 2
+        key: ${{ matrix.preset }}-PR-${{ github.event.number }}
+        restore-keys: |
+          ${{ matrix.preset }}-PR-${{ github.event.number }}
+          ${{ matrix.preset }}-no-PR
+        # actual cache takes up less space, at most ~1 GB
+        max-size: "5G"
+        verbose: 2
+
+    - name: Ccache for everything but PRs
+      uses: hendrikmuhs/ccache-action@v1.2
+      if: ${{ github.event.number == '' }}
+      with:
+        key: ${{ matrix.preset }}-no-PR
+        restore-keys: |
+          ${{ matrix.preset }}-no-PR
+        # actual cache takes up less space, at most ~1 GB
+        max-size: "5G"
+        verbose: 2
 
     - uses: actions/setup-python@v4
       if: "${{ matrix.conan_profile != '' }}"
       with:
         python-version: '3.10'
+
     - name: Conan setup
       if: "${{ matrix.conan_profile != '' }}"
       run: |


### PR DESCRIPTION
Ensure the ccache for each PR is separate by appending the PR ID to the key, so they don't interfere with each other.
Fall back to ccache of the vcmi/vcmi repo if no PR-specific ccache is found.

CI for a PR:
![image](https://github.com/vcmi/vcmi/assets/3226457/ee0417ca-b686-4d51-92b1-51c103c0f3b8)
![image](https://github.com/vcmi/vcmi/assets/3226457/86d03438-c1da-4be1-b949-3cd7ded98875)

CI for a commit outside a PR (e.g. https://github.com/Alexander-Wilms/vcmi/actions/runs/6680396279/job/18153474337):
![image](https://github.com/vcmi/vcmi/assets/3226457/37f9ec55-c9af-4188-a361-cc2aa8bedcf0)
![image](https://github.com/vcmi/vcmi/assets/3226457/5948b5ba-3cc0-4e62-84c4-468651374c94)
