### PR TITLE
Fix memleak related to battleResult

### DIFF
--- a/lib/CondSh.h
+++ b/lib/CondSh.h
@@ -22,6 +22,13 @@ template <typename T> struct CondSh
 
 	CondSh(T t) : data(t) {}
 
+	void unset()
+	{
+	  boost::unique_lock<boost::mutex> lock(mx);
+	  delete data;
+	  data = nullptr;
+	}
+
 	// set data
 	void set(T t)
 	{

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -2119,7 +2119,7 @@ std::list<PlayerColor> CGameHandler::generatePlayerTurnOrder() const
 
 void CGameHandler::setupBattle(int3 tile, const CArmedInstance *armies[2], const CGHeroInstance *heroes[2], bool creatureBank, const CGTownInstance *town)
 {
-	battleResult.set(nullptr);
+	battleResult.unset();
 
 	const auto & t = *getTile(tile);
 	TerrainId terrain = t.terType->getId();


### PR DESCRIPTION
Addresses an issue mentioned in my comment here: https://github.com/vcmi/vcmi/issues/953#issuecomment-1787151606

A `BattleResult` object created in `CGameHandler::setBattleResult`:

```cpp
auto br = new BattleResult();
// ...
battleResult.data = br;
```

leaks in `CGameHandler::setupBattle`:

```cpp
battleResult.set(nullptr);
// effectively battleResult.data = nullptr
```
