### PR TITLE
Ignore corrupted .def files

### DIFF
--- a/client/render/CAnimation.cpp
+++ b/client/render/CAnimation.cpp
@@ -204,11 +204,19 @@ void CAnimation::printError(size_t frame, size_t group, std::string type) const
 
 CAnimation::CAnimation(const AnimationPath & Name):
 	name(boost::starts_with(Name.getName(), "SPRITES") ? Name : Name.addPrefix("SPRITES/")),
-	preloaded(false),
-	defFile()
+	preloaded(false)
 {
 	if(CResourceHandler::get()->existsResource(name))
-		defFile = std::make_shared<CDefFile>(name);
+	{
+		try
+		{
+			defFile = std::make_shared<CDefFile>(name);
+		}
+		catch ( const std::runtime_error & e)
+		{
+			logAnim->error("Def file %s failed to load! Reason: %s", Name.getOriginalName(), e.what());
+		}
+	}
 
 	init();
 


### PR DESCRIPTION
Slightly better handling of corrupted .def file.
Right now VCMI will silently crash when this happens, without meaningful error message in any form.

With this change vcmi will ignore such files and report all such cases in log file.

Note that it is still possible for vcmi to crash later, e.g. if vcmi expects some images to be present in def file, but at the very least this will be properly logged and not a silent crash.