### PR TITLE
Fix crash on teleport cast

### DIFF
--- a/lib/spells/effects/Teleport.cpp
+++ b/lib/spells/effects/Teleport.cpp
@@ -12,6 +12,7 @@
 #include "Teleport.h"
 #include "Registry.h"
 #include "../ISpellMechanics.h"
+#include "../../battle/IBattleState.h"
 #include "../../battle/CBattleInfoCallback.h"
 #include "../../battle/Unit.h"
 #include "../../networkPacks/PacksForClientBattle.h"
@@ -76,6 +77,7 @@ void Teleport::apply(ServerCallback * server, const Mechanics * m, const EffectT
 	const auto destination = target[1].hexValue;
 
 	BattleStackMoved pack;
+	pack.battleID = m->battle()->getBattle()->getBattleID();
 	pack.distance = 0;
 	pack.stack = targetUnit->unitId();
 	std::vector<BattleHex> tiles;


### PR DESCRIPTION
Correctly initialize battleID for teleport action.
- Fixes #3133