### PR TITLE
#3006 - fix starting move from teleport

### DIFF
--- a/client/HeroMovementController.cpp
+++ b/client/HeroMovementController.cpp
@@ -359,7 +359,7 @@ void HeroMovementController::moveOnce(const CGHeroInstance * h, const CGPath & p
 	{
 		stopMovementSound();
 		logGlobal->trace("Requesting hero teleportation to %s", nextNode.coord.toString());
-		LOCPLINT->cb->moveHero(h, nextCoord, false);
+		LOCPLINT->cb->moveHero(h, h->pos, false);
 		return;
 	}
 	else


### PR DESCRIPTION
Looks a bit glitchy but working. When we bypass teleporter we visit it and only when it asks what exit to use you answer according to what is the next cord. So we can not visit the other side right away but need to visit the one directly under us. This fix only affects starting movement from teleporter or subterra gate