### PR TITLE
Use minstd_rand instead of mt19937 to avoid save game bloat

### DIFF
--- a/lib/CRandomGenerator.h
+++ b/lib/CRandomGenerator.h
@@ -14,7 +14,7 @@
 
 VCMI_LIB_NAMESPACE_BEGIN
 
-using TGenerator = std::mt19937;
+using TGenerator = std::minstd_rand;
 using TIntDist = std::uniform_int_distribution<int>;
 using TInt64Dist = std::uniform_int_distribution<int64_t>;
 using TRealDist = std::uniform_real_distribution<double>;

--- a/lib/CRandomGenerator.h
+++ b/lib/CRandomGenerator.h
@@ -14,6 +14,10 @@
 
 VCMI_LIB_NAMESPACE_BEGIN
 
+/// Generator to use for all randomization in game
+/// minstd_rand is selected due to following reasons:
+/// 1. Its randomization quality is below mt_19937 however this is unlikely to be noticeable in game
+/// 2. It has very low state size, leading to low overhead in size of saved games (due to large number of random generator instances in game)
 using TGenerator = std::minstd_rand;
 using TIntDist = std::uniform_int_distribution<int>;
 using TInt64Dist = std::uniform_int_distribution<int64_t>;


### PR DESCRIPTION
As in title.

Switches RMG that we use in game from mt19937 to minstd_rand.

This might reduce quality of randomization a bit, but:
1) Difference is unlikely to be noticeable
2) Should slightly improve save game loading / game startup times
3) This *greatly* reduces save game size. Size of save game on "All For One" on day 1 went down from 2 194 Kb to 1 213 Kb (This test was done while also including #3147 )