### PR TITLE
Artifacts swap optimization

### DIFF
--- a/client/Client.h
+++ b/client/Client.h
@@ -188,8 +188,7 @@ public:
 	void removeAfterVisit(const CGObjectInstance * object) override {};
 	bool swapGarrisonOnSiege(ObjectInstanceID tid) override {return false;};
 	bool giveHeroNewArtifact(const CGHeroInstance * h, const CArtifact * artType, ArtifactPosition pos) override {return false;}
-	bool giveHeroArtifact(const CGHeroInstance * h, const CArtifactInstance * a, ArtifactPosition pos) override {return false;}
-	void putArtifact(const ArtifactLocation & al, const CArtifactInstance * a) override {};
+	bool putArtifact(const ArtifactLocation & al, const CArtifactInstance * art, std::optional<bool> askAssemble) override {return false;};
 	void removeArtifact(const ArtifactLocation & al) override {};
 	bool moveArtifact(const ArtifactLocation & al1, const ArtifactLocation & al2) override {return false;};
 

--- a/client/NetPacksClient.cpp
+++ b/client/NetPacksClient.cpp
@@ -301,7 +301,7 @@ void ApplyClientNetPackVisitor::visitBulkMoveArtifacts(BulkMoveArtifacts & pack)
 		{
 			auto srcLoc = ArtifactLocation(pack.srcArtHolder, slotToMove.srcPos);
 			auto dstLoc = ArtifactLocation(pack.dstArtHolder, slotToMove.dstPos);
-			MoveArtifact ma(&srcLoc, &dstLoc, false);
+			MoveArtifact ma(&srcLoc, &dstLoc, pack.askAssemble);
 			visitMoveArtifact(ma);
 		}
 	};

--- a/lib/ArtifactUtils.cpp
+++ b/lib/ArtifactUtils.cpp
@@ -33,10 +33,11 @@ DLL_LINKAGE ArtifactPosition ArtifactUtils::getArtAnyPosition(const CArtifactSet
 DLL_LINKAGE ArtifactPosition ArtifactUtils::getArtBackpackPosition(const CArtifactSet * target, const ArtifactID & aid)
 {
 	const auto * art = aid.toArtifact();
-	if(art->canBePutAt(target, ArtifactPosition::BACKPACK_START))
-	{
-		return ArtifactPosition::BACKPACK_START;
-	}
+	if(target->bearerType() == ArtBearer::HERO)
+		if(art->canBePutAt(target, ArtifactPosition::BACKPACK_START))
+		{
+			return ArtifactPosition::BACKPACK_START;
+		}
 	return ArtifactPosition::PRE_FIRST;
 }
 

--- a/lib/IGameCallback.h
+++ b/lib/IGameCallback.h
@@ -107,8 +107,7 @@ public:
 	virtual void removeAfterVisit(const CGObjectInstance *object) = 0; //object will be destroyed when interaction is over. Do not call when interaction is not ongoing!
 
 	virtual bool giveHeroNewArtifact(const CGHeroInstance * h, const CArtifact * artType, ArtifactPosition pos) = 0;
-	virtual bool giveHeroArtifact(const CGHeroInstance * h, const CArtifactInstance * a, ArtifactPosition pos) = 0;
-	virtual void putArtifact(const ArtifactLocation &al, const CArtifactInstance *a) = 0;
+	virtual bool putArtifact(const ArtifactLocation & al, const CArtifactInstance * art, std::optional<bool> askAssemble = std::nullopt) = 0;
 	virtual void removeArtifact(const ArtifactLocation &al) = 0;
 	virtual bool moveArtifact(const ArtifactLocation &al1, const ArtifactLocation &al2) = 0;
 

--- a/lib/mapObjects/MiscObjects.cpp
+++ b/lib/mapObjects/MiscObjects.cpp
@@ -881,7 +881,7 @@ void CGArtifact::onHeroVisit(const CGHeroInstance * h) const
 
 void CGArtifact::pick(const CGHeroInstance * h) const
 {
-	if(cb->giveHeroArtifact(h, storedArtifact, ArtifactPosition::FIRST_AVAILABLE))
+	if(cb->putArtifact(ArtifactLocation(h->id, ArtifactPosition::FIRST_AVAILABLE), storedArtifact))
 		cb->removeObject(this, h->getOwner());
 }
 

--- a/lib/networkPacks/ArtifactLocation.h
+++ b/lib/networkPacks/ArtifactLocation.h
@@ -31,6 +31,12 @@ struct ArtifactLocation
 		, creature(std::nullopt)
 	{
 	}
+	ArtifactLocation(const ObjectInstanceID id, const std::optional<SlotID> creatureSlot)
+		: artHolder(id)
+		, slot(ArtifactPosition::PRE_FIRST)
+		, creature(creatureSlot)
+	{
+	}
 
 	template <typename Handler> void serialize(Handler & h, const int version)
 	{

--- a/lib/networkPacks/NetPacksLib.cpp
+++ b/lib/networkPacks/NetPacksLib.cpp
@@ -1837,13 +1837,13 @@ void BulkMoveArtifacts::applyGs(CGameState * gs)
 			switch(operation)
 			{
 			case EBulkArtsOp::BULK_MOVE:
-				art->move(artSet, srcPos, *gs->getHero(dstArtHolder), slot.dstPos);
+				art->move(artSet, srcPos, *gs->getArtSet(ArtifactLocation(dstArtHolder, dstCreature)), slot.dstPos);
 				break;
 			case EBulkArtsOp::BULK_REMOVE:
 				art->removeFrom(artSet, srcPos);
 				break;
 			case EBulkArtsOp::BULK_PUT:
-				art->putAt(*gs->getHero(srcArtHolder), slot.dstPos);
+				art->putAt(*gs->getArtSet(ArtifactLocation(srcArtHolder, srcCreature)), slot.dstPos);
 				break;
 			default:
 				break;
@@ -1856,11 +1856,11 @@ void BulkMoveArtifacts::applyGs(CGameState * gs)
 		}
 	};
 	
-	auto * leftSet = gs->getArtSet(ArtifactLocation(srcArtHolder));
+	auto * leftSet = gs->getArtSet(ArtifactLocation(srcArtHolder, srcCreature));
 	if(swap)
 	{
 		// Swap
-		auto * rightSet = gs->getArtSet(ArtifactLocation(dstArtHolder));
+		auto * rightSet = gs->getArtSet(ArtifactLocation(dstArtHolder, dstCreature));
 		CArtifactFittingSet artFittingSet(leftSet->bearerType());
 
 		artFittingSet.artifactsWorn = rightSet->artifactsWorn;

--- a/lib/networkPacks/PacksForClient.h
+++ b/lib/networkPacks/PacksForClient.h
@@ -975,13 +975,13 @@ struct DLL_LINKAGE CArtifactOperationPack : CPackForClient
 struct DLL_LINKAGE PutArtifact : CArtifactOperationPack
 {
 	PutArtifact() = default;
-	explicit PutArtifact(ArtifactLocation * dst, bool askAssemble = true)
-		: al(*dst), askAssemble(askAssemble)
+	explicit PutArtifact(ArtifactLocation & dst, bool askAssemble = true)
+		: al(dst), askAssemble(askAssemble)
 	{
 	}
 
 	ArtifactLocation al;
-	bool askAssemble = false;
+	bool askAssemble;
 	ConstTransitivePtr<CArtifactInstance> art;
 
 	void applyGs(CGameState * gs);

--- a/lib/networkPacks/PacksForClient.h
+++ b/lib/networkPacks/PacksForClient.h
@@ -1064,17 +1064,25 @@ struct DLL_LINKAGE BulkMoveArtifacts : CArtifactOperationPack
 
 	ObjectInstanceID srcArtHolder;
 	ObjectInstanceID dstArtHolder;
+	std::optional<SlotID> srcCreature;
+	std::optional<SlotID> dstCreature;
 
 	BulkMoveArtifacts()
 		: srcArtHolder(ObjectInstanceID::NONE)
 		, dstArtHolder(ObjectInstanceID::NONE)
 		, swap(false)
+		, askAssemble(false)
+		, srcCreature(std::nullopt)
+		, dstCreature(std::nullopt)
 	{
 	}
 	BulkMoveArtifacts(const ObjectInstanceID srcArtHolder, const ObjectInstanceID dstArtHolder, bool swap)
 		: srcArtHolder(std::move(srcArtHolder))
 		, dstArtHolder(std::move(dstArtHolder))
 		, swap(swap)
+		, askAssemble(false)
+		, srcCreature(std::nullopt)
+		, dstCreature(std::nullopt)
 	{
 	}
 
@@ -1083,6 +1091,7 @@ struct DLL_LINKAGE BulkMoveArtifacts : CArtifactOperationPack
 	std::vector<LinkedSlots> artsPack0;
 	std::vector<LinkedSlots> artsPack1;
 	bool swap;
+	bool askAssemble;
 
 	void visitTyped(ICPackVisitor & visitor) override;
 
@@ -1092,7 +1101,10 @@ struct DLL_LINKAGE BulkMoveArtifacts : CArtifactOperationPack
 		h & artsPack1;
 		h & srcArtHolder;
 		h & dstArtHolder;
+		h & srcCreature;
+		h & dstCreature;
 		h & swap;
+		h & askAssemble;
 	}
 };
 

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -2720,16 +2720,9 @@ bool CGameHandler::moveArtifact(const ArtifactLocation & src, const ArtifactLoca
 		ma.swap = true;
 	}
 
-	try
-	{
-		auto hero = getHero(dst.artHolder);
-		if(ArtifactUtils::checkSpellbookIsNeeded(hero, srcArtifact->artType->getId(), dstSlot))
-			giveHeroNewArtifact(hero, VLC->arth->objects[ArtifactID::SPELLBOOK], ArtifactPosition::SPELLBOOK);
-	}
-	catch(const std::bad_variant_access &)
-	{
-		// object other than hero received an art - ignore
-	}
+	auto hero = getHero(dst.artHolder);
+	if(ArtifactUtils::checkSpellbookIsNeeded(hero, srcArtifact->artType->getId(), dstSlot))
+		giveHeroNewArtifact(hero, VLC->arth->objects[ArtifactID::SPELLBOOK], ArtifactPosition::SPELLBOOK);
 
 	ma.artsPack0.push_back(BulkMoveArtifacts::LinkedSlots(src.slot, dstSlot));
 	if(src.artHolder != dst.artHolder)

--- a/server/CGameHandler.h
+++ b/server/CGameHandler.h
@@ -127,8 +127,7 @@ public:
 	void removeAfterVisit(const CGObjectInstance *object) override;
 
 	bool giveHeroNewArtifact(const CGHeroInstance * h, const CArtifact * artType, ArtifactPosition pos = ArtifactPosition::FIRST_AVAILABLE) override;
-	bool giveHeroArtifact(const CGHeroInstance * h, const CArtifactInstance * a, ArtifactPosition pos) override;
-	void putArtifact(const ArtifactLocation &al, const CArtifactInstance *a) override;
+	bool putArtifact(const ArtifactLocation & al, const CArtifactInstance * art, std::optional<bool> askAssemble) override;
 	void removeArtifact(const ArtifactLocation &al) override;
 	bool moveArtifact(const ArtifactLocation & src, const ArtifactLocation & dst) override;
 	bool bulkMoveArtifacts(ObjectInstanceID srcHero, ObjectInstanceID dstHero, bool swap, bool equipped, bool backpack);

--- a/test/mock/mock_IGameCallback.h
+++ b/test/mock/mock_IGameCallback.h
@@ -67,8 +67,7 @@ public:
 	void removeAfterVisit(const CGObjectInstance *object) override {} //object will be destroyed when interaction is over. Do not call when interaction is not ongoing!
 
 	bool giveHeroNewArtifact(const CGHeroInstance * h, const CArtifact * artType, ArtifactPosition pos) override {return false;}
-	bool giveHeroArtifact(const CGHeroInstance * h, const CArtifactInstance * a, ArtifactPosition pos) override {return false;}
-	void putArtifact(const ArtifactLocation &al, const CArtifactInstance *a) override {}
+	bool putArtifact(const ArtifactLocation & al, const CArtifactInstance * art, std::optional<bool> askAssemble) override {return false;}
 	void removeArtifact(const ArtifactLocation &al) override {}
 	bool moveArtifact(const ArtifactLocation &al1, const ArtifactLocation &al2) override {return false;}
 


### PR DESCRIPTION
The artifact swap operation has been optimized. Now, instead of two net packages, one is used. This will be useful for the quick backpack window. For now the only case where a one artifact movement is used is the end of battle (planned to rework).

Fixed an old regression where the window with a question about assembling an artifact did not appear if the artifact was picked from the map.

giveHeroArtifact and putArtifact in CGameHandler have been merged. There was no reason to have two separate methods.