### PR TITLE
Android launcher fixes

### DIFF
--- a/android/vcmi-app/src/main/java/eu/vcmi/vcmi/ActivityMods.java
+++ b/android/vcmi-app/src/main/java/eu/vcmi/vcmi/ActivityMods.java
@@ -267,6 +267,14 @@ public class ActivityMods extends ActivityWithToolbar
         @Override
         public void onDownloadPressed(final ModsAdapter.ModItem mod, final RecyclerView.ViewHolder vh)
         {
+			if (mod.mMod.mInstalled)
+			{
+				// Update - erase old mod first
+				File installationFolder = mod.mMod.installationFolder;
+				FileUtil.clearDirectory(installationFolder);
+				installationFolder.delete();
+			}
+			
             Log.i(this, "Mod download pressed: " + mod);
             mModsAdapter.downloadProgress(mod, "0%");
             installModAsync(mod);

--- a/android/vcmi-app/src/main/java/eu/vcmi/vcmi/content/ModsAdapter.java
+++ b/android/vcmi-app/src/main/java/eu/vcmi/vcmi/content/ModsAdapter.java
@@ -164,8 +164,11 @@ public class ModsAdapter extends RecyclerView.Adapter<ModBaseViewHolder>
 
         for (VCMIMod mod : mods)
         {
-            ModItem modItem = new ModItem(mod);
-            list.add(modItem);
+            if (mod.mVisible)
+            {
+                ModItem modItem = new ModItem(mod);
+                list.add(modItem);
+            }
         }
 
         mDataset.addAll(list);

--- a/android/vcmi-app/src/main/java/eu/vcmi/vcmi/content/ModsAdapter.java
+++ b/android/vcmi-app/src/main/java/eu/vcmi/vcmi/content/ModsAdapter.java
@@ -83,14 +83,14 @@ public class ModsAdapter extends RecyclerView.Adapter<ModBaseViewHolder>
                     }
                     else
 					{
-						if (!item.mMod.mInstalled)
-						{
+						//if (!item.mMod.mInstalled)
+						//{
 							modHolder.mDownloadBtn.setVisibility(View.VISIBLE);
-						}
-						if (item.mMod.mRepoVersion != null && item.mMod.mLocalVersion != null && !item.mMod.mRepoVersion.equals(item.mMod.mLocalVersion))
-						{
-							modHolder.mDownloadBtn.setVisibility(View.VISIBLE);
-						}
+						//}
+						//if (item.mMod.mRepoVersion != null && item.mMod.mLocalVersion != null && !item.mMod.mRepoVersion.equals(item.mMod.mLocalVersion))
+						//{
+						//	modHolder.mDownloadBtn.setVisibility(View.VISIBLE);
+						//}
 						
 						if (item.mMod.installationFolder != null)
 						{
@@ -172,11 +172,8 @@ public class ModsAdapter extends RecyclerView.Adapter<ModBaseViewHolder>
 
         for (VCMIMod mod : mods)
         {
-            if (mod.mVisible)
-            {
-                ModItem modItem = new ModItem(mod);
-                list.add(modItem);
-            }
+            ModItem modItem = new ModItem(mod);
+            list.add(modItem);
         }
 
         mDataset.addAll(list);

--- a/android/vcmi-app/src/main/java/eu/vcmi/vcmi/content/ModsAdapter.java
+++ b/android/vcmi-app/src/main/java/eu/vcmi/vcmi/content/ModsAdapter.java
@@ -81,14 +81,22 @@ public class ModsAdapter extends RecyclerView.Adapter<ModBaseViewHolder>
                         modHolder.mDownloadProgress.setText(item.mDownloadProgress);
                         modHolder.mDownloadProgress.setVisibility(View.VISIBLE);
                     }
-                    else if (!item.mMod.mInstalled)
-                    {
-                        modHolder.mDownloadBtn.setVisibility(View.VISIBLE);
-                    }
-                    else if (item.mMod.installationFolder != null)
-                    {
-                        modHolder.mUninstall.setVisibility(View.VISIBLE);
-                    }
+                    else
+					{
+						if (!item.mMod.mInstalled)
+						{
+							modHolder.mDownloadBtn.setVisibility(View.VISIBLE);
+						}
+						if (item.mMod.mRepoVersion != null && item.mMod.mLocalVersion != null && !item.mMod.mRepoVersion.equals(item.mMod.mLocalVersion))
+						{
+							modHolder.mDownloadBtn.setVisibility(View.VISIBLE);
+						}
+						
+						if (item.mMod.installationFolder != null)
+						{
+							modHolder.mUninstall.setVisibility(View.VISIBLE);
+						}
+					}
 
                     modHolder.itemView.setOnClickListener(v -> mItemListener.onItemPressed(item, holder));
                     modHolder.mStatusIcon.setOnClickListener(v -> mItemListener.onTogglePressed(item, holder));

--- a/android/vcmi-app/src/main/java/eu/vcmi/vcmi/mods/VCMIMod.java
+++ b/android/vcmi-app/src/main/java/eu/vcmi/vcmi/mods/VCMIMod.java
@@ -46,6 +46,7 @@ public class VCMIMod
     // internal
     public boolean mLoadedCorrectly;
     public boolean mSystem;
+    public boolean mVisible;
 
     protected VCMIMod()
     {
@@ -67,6 +68,7 @@ public class VCMIMod
         mod.mArchiveUrl = modDownloadData.optString("download");
         mod.mSize = obj.optLong("size");
         mod.mLoadedCorrectly = true;
+		mod.mVisible = mModType.equals("Compatibility");
         return mod;
     }
 
@@ -87,6 +89,7 @@ public class VCMIMod
         }
         mod.mLoadedCorrectly = true;
         mod.mActive = true; // active by default
+		mod.mVisible = true;
         mod.mInstalled = true;
         mod.installationFolder = modPath;
 
@@ -171,6 +174,7 @@ public class VCMIMod
             mAuthor = modInfoContent.optString("author");
             mContact = modInfoContent.optString("contact");
             mModType = modInfoContent.optString("modType");
+			mVisible = mModType.equals("Compatibility");
             mSystem = mId.equals("vcmi");
 
             final File submodsDir = new File(modPath, "Mods");

--- a/android/vcmi-app/src/main/java/eu/vcmi/vcmi/mods/VCMIMod.java
+++ b/android/vcmi-app/src/main/java/eu/vcmi/vcmi/mods/VCMIMod.java
@@ -71,7 +71,7 @@ public class VCMIMod
         mod.mArchiveUrl = modDownloadData.optString("download");
         mod.mSize = obj.optLong("size");
         mod.mLoadedCorrectly = true;
-		mod.mVisible = mModType.equals("Compatibility");
+		mod.mVisible = mod.mModType.equals("Compatibility");
         return mod;
     }
 

--- a/android/vcmi-app/src/main/java/eu/vcmi/vcmi/mods/VCMIMod.java
+++ b/android/vcmi-app/src/main/java/eu/vcmi/vcmi/mods/VCMIMod.java
@@ -30,6 +30,8 @@ public class VCMIMod
     public String mName;
     public String mDesc;
     public String mVersion;
+	public String mRepoVersion;
+	public String mLocalVersion;
     public String mAuthor;
     public String mContact;
     public String mModType;
@@ -62,6 +64,7 @@ public class VCMIMod
         mod.mName = obj.optString("name");
         mod.mDesc = obj.optString("description");
         mod.mVersion = obj.optString("version");
+		mod.mRepoVersion = obj.optString("version");
         mod.mAuthor = obj.optString("author");
         mod.mContact = obj.optString("contact");
         mod.mModType = obj.optString("modType");
@@ -171,6 +174,7 @@ public class VCMIMod
             mName = modInfoContent.optString("name");
             mDesc = modInfoContent.optString("description");
             mVersion = modInfoContent.optString("version");
+			mLocalVersion = modInfoContent.optString("version");
             mAuthor = modInfoContent.optString("author");
             mContact = modInfoContent.optString("contact");
             mModType = modInfoContent.optString("modType");
@@ -258,5 +262,6 @@ public class VCMIMod
         this.mAuthor = other.mAuthor;
         this.mDesc = other.mDesc;
         this.mArchiveUrl = other.mArchiveUrl;
+		this.mRepoVersion = other.mRepoVersion;
     }
 }


### PR DESCRIPTION
No idea whether this will work or not, but:
- allow updating already installed mods without reinstall
- hide "compatibility" mods, same as on desktop launcher

Will test using CI artifacts