### PR TITLE
CVideoHandler.cpp: Clear screen before rendering each frame of the intro

### DIFF
--- a/client/CVideoHandler.cpp
+++ b/client/CVideoHandler.cpp
@@ -631,6 +631,7 @@ bool CVideoPlayer::playVideo(int x, int y, bool stopOnKey)
 
 		SDL_Rect rect = CSDL_Ext::toSDL(pos);
 
+		SDL_RenderClear(mainRenderer);
 		SDL_RenderCopy(mainRenderer, texture, nullptr, &rect);
 		SDL_RenderPresent(mainRenderer);
 


### PR DESCRIPTION
This way, the background is black instead of showing glitchy artifacts when one resizes the window

Before:
![image](https://github.com/vcmi/vcmi/assets/3226457/20c8a950-137e-47cf-8281-cb97a42b45ea)

After:
![image](https://github.com/vcmi/vcmi/assets/3226457/b621dfff-6412-4a6f-ac92-ec02371acd53)

This change was also part of https://github.com/vcmi/vcmi/pull/3041, but I've decided to split it up to get the working changes merged already.