### PR TITLE
Fix broken intro and crash when resizing window

### DIFF
--- a/client/eventsSDL/InputHandler.cpp
+++ b/client/eventsSDL/InputHandler.cpp
@@ -145,7 +145,7 @@ void InputHandler::preprocessEvent(const SDL_Event & ev)
 			Settings full = settings.write["video"]["fullscreen"];
 			full->Bool() = !full->Bool();
 
-			GH.onScreenResize();
+			GH.onScreenResize(false);
 			return;
 		}
 	}
@@ -163,7 +163,7 @@ void InputHandler::preprocessEvent(const SDL_Event & ev)
 #ifndef VCMI_IOS
 			{
 				boost::mutex::scoped_lock interfaceLock(GH.interfaceMutex);
-				GH.onScreenResize();
+				GH.onScreenResize(false);
 			}
 #endif
 			break;

--- a/client/gui/CGuiHandler.cpp
+++ b/client/gui/CGuiHandler.cpp
@@ -251,8 +251,11 @@ void CGuiHandler::setStatusbar(std::shared_ptr<IStatusBar> newStatusBar)
 	currentStatusBar = newStatusBar;
 }
 
-void CGuiHandler::onScreenResize()
+void CGuiHandler::onScreenResize(bool resolutionChanged)
 {
-	screenHandler().onScreenResize();
+	if(resolutionChanged)
+	{
+		screenHandler().onScreenResize();
+	}
 	windows().onScreenResize();
 }

--- a/client/gui/CGuiHandler.h
+++ b/client/gui/CGuiHandler.h
@@ -92,8 +92,8 @@ public:
 	void init();
 	void renderFrame();
 
-	/// called whenever user selects different resolution, requiring to center/resize all windows
-	void onScreenResize();
+	/// called whenever SDL_WINDOWEVENT_RESTORED is reported or the user selects a different resolution, requiring to center/resize all windows
+	void onScreenResize(bool resolutionChanged);
 
 	void handleEvents(); //takes events from queue and calls interested objects
 	void fakeMouseMove();

--- a/client/renderSDL/ScreenHandler.cpp
+++ b/client/renderSDL/ScreenHandler.cpp
@@ -397,6 +397,7 @@ SDL_Window * ScreenHandler::createWindow()
 
 void ScreenHandler::onScreenResize()
 {
+	recreateWindowAndScreenBuffers();
 }
 
 void ScreenHandler::validateSettings()

--- a/client/renderSDL/ScreenHandler.cpp
+++ b/client/renderSDL/ScreenHandler.cpp
@@ -397,7 +397,6 @@ SDL_Window * ScreenHandler::createWindow()
 
 void ScreenHandler::onScreenResize()
 {
-	recreateWindowAndScreenBuffers();
 }
 
 void ScreenHandler::validateSettings()

--- a/client/windows/settings/GeneralOptionsTab.cpp
+++ b/client/windows/settings/GeneralOptionsTab.cpp
@@ -317,7 +317,7 @@ void GeneralOptionsTab::setGameResolution(int index)
 	widget<CLabel>("resolutionLabel")->setText(resolutionToLabelString(resolution.x, resolution.y));
 
 	GH.dispatchMainThread([](){
-		GH.onScreenResize();
+		GH.onScreenResize(true);
 	});
 }
 
@@ -341,7 +341,7 @@ void GeneralOptionsTab::setFullscreenMode(bool on, bool exclusive)
 	updateResolutionSelector();
 
 	GH.dispatchMainThread([](){
-		GH.onScreenResize();
+		GH.onScreenResize(true);
 	});
 }
 
@@ -400,7 +400,7 @@ void GeneralOptionsTab::setGameScaling(int index)
 	widget<CLabel>("scalingLabel")->setText(scalingToLabelString(scaling));
 
 	GH.dispatchMainThread([](){
-		GH.onScreenResize();
+		GH.onScreenResize(true);
 	});
 }
 


### PR DESCRIPTION
VCMI created a texture with the height of the original intro video, and the aspect ratio of the actual VCMI window. This resulted in a texture with a width greater than 16384 px.

Fixes #3200

Edit: This breaks interface scaling, I'll try and see how I can get both to work,