### PR TITLE
Reworked and fixed selection of secondary skills on levelup

### DIFF
--- a/lib/CHeroHandler.cpp
+++ b/lib/CHeroHandler.cpp
@@ -123,26 +123,30 @@ void CHero::serializeJson(JsonSerializeFormat & handler)
 
 SecondarySkill CHeroClass::chooseSecSkill(const std::set<SecondarySkill> & possibles, CRandomGenerator & rand) const //picks secondary skill out from given possibilities
 {
+	assert(!possibles.empty());
+
+	if (possibles.size() == 1)
+		return *possibles.begin();
+
 	int totalProb = 0;
 	for(const auto & possible : possibles)
 		if (secSkillProbability.count(possible) != 0)
 			totalProb += secSkillProbability.at(possible);
 
-	if (totalProb != 0) // may trigger if set contains only banned skills (0 probability)
-	{
-		auto ran = rand.nextInt(totalProb - 1);
-		for(const auto & possible : possibles)
-		{
-			if (secSkillProbability.count(possible) != 0)
-				ran -= secSkillProbability.at(possible);
+	if (totalProb == 0) // may trigger if set contains only banned skills (0 probability)
+		return *RandomGeneratorUtil::nextItem(possibles, rand);
 
-			if(ran < 0)
-			{
-				return possible;
-			}
-		}
+	auto ran = rand.nextInt(totalProb - 1);
+	for(const auto & possible : possibles)
+	{
+		if (secSkillProbability.count(possible) != 0)
+			ran -= secSkillProbability.at(possible);
+
+		if(ran < 0)
+			return possible;
 	}
-	// FIXME: select randomly? How H3 handles such rare situation?
+
+	assert(0); // should not be possible
 	return *possibles.begin();
 }
 

--- a/lib/mapObjects/CGHeroInstance.h
+++ b/lib/mapObjects/CGHeroInstance.h
@@ -111,9 +111,6 @@ public:
 
 	struct DLL_LINKAGE SecondarySkillsInfo
 	{
-		//skills are determined, initialized at map start
-		//FIXME remove mutable
-		mutable CRandomGenerator rand;
 		ui8 magicSchoolCounter;
 		ui8 wisdomCounter;
 
@@ -126,7 +123,6 @@ public:
 		{
 			h & magicSchoolCounter;
 			h & wisdomCounter;
-			h & rand;
 		}
 	} skillsInfo;
 
@@ -194,7 +190,7 @@ public:
 	std::optional<SecondarySkill> nextSecondarySkill(CRandomGenerator & rand) const;
 
 	/// Gets 0, 1 or 2 secondary skills which are proposed on hero level up.
-	std::vector<SecondarySkill> getLevelUpProposedSecondarySkills() const;
+	std::vector<SecondarySkill> getLevelUpProposedSecondarySkills(CRandomGenerator & rand) const;
 
 	ui8 getSecSkillLevel(const SecondarySkill & skill) const; //0 - no skill
 

--- a/lib/networkPacks/NetPackVisitor.h
+++ b/lib/networkPacks/NetPackVisitor.h
@@ -87,7 +87,6 @@ public:
 	virtual void visitInfoWindow(InfoWindow & pack) {}
 	virtual void visitSetObjectProperty(SetObjectProperty & pack) {}
 	virtual void visitChangeObjectVisitors(ChangeObjectVisitors & pack) {}
-	virtual void visitPrepareHeroLevelUp(PrepareHeroLevelUp & pack) {}
 	virtual void visitHeroLevelUp(HeroLevelUp & pack) {}
 	virtual void visitCommanderLevelUp(CommanderLevelUp & pack) {}
 	virtual void visitBlockingDialog(BlockingDialog & pack) {}

--- a/lib/networkPacks/NetPacksLib.cpp
+++ b/lib/networkPacks/NetPacksLib.cpp
@@ -380,11 +380,6 @@ void ChangeObjectVisitors::visitTyped(ICPackVisitor & visitor)
 	visitor.visitChangeObjectVisitors(*this);
 }
 
-void PrepareHeroLevelUp::visitTyped(ICPackVisitor & visitor)
-{
-	visitor.visitPrepareHeroLevelUp(*this);
-}
-
 void HeroLevelUp::visitTyped(ICPackVisitor & visitor)
 {
 	visitor.visitHeroLevelUp(*this);
@@ -2079,23 +2074,6 @@ void SetObjectProperty::applyGs(CGameState * gs) const
 	else //not an armed instance
 	{
 		obj->setProperty(what, identifier);
-	}
-}
-
-void PrepareHeroLevelUp::applyGs(CGameState * gs)
-{
-	auto * hero = gs->getHero(heroId);
-	assert(hero);
-
-	auto proposedSkills = hero->getLevelUpProposedSecondarySkills();
-
-	if(skills.size() == 1 || hero->tempOwner == PlayerColor::NEUTRAL) //choose skill automatically
-	{
-		skills.push_back(*RandomGeneratorUtil::nextItem(proposedSkills, hero->skillsInfo.rand));
-	}
-	else
-	{
-		skills = proposedSkills;
 	}
 }
 

--- a/lib/networkPacks/PacksForClient.h
+++ b/lib/networkPacks/PacksForClient.h
@@ -1276,23 +1276,6 @@ struct DLL_LINKAGE ChangeObjectVisitors : public CPackForClient
 	}
 };
 
-struct DLL_LINKAGE PrepareHeroLevelUp : public CPackForClient
-{
-	ObjectInstanceID heroId;
-
-	/// Do not serialize, used by server only
-	std::vector<SecondarySkill> skills;
-
-	void applyGs(CGameState * gs);
-
-	void visitTyped(ICPackVisitor & visitor) override;
-
-	template <typename Handler> void serialize(Handler & h, const int version)
-	{
-		h & heroId;
-	}
-};
-
 struct DLL_LINKAGE HeroLevelUp : public Query
 {
 	PlayerColor player;

--- a/lib/registerTypes/RegisterTypesClientPacks.h
+++ b/lib/registerTypes/RegisterTypesClientPacks.h
@@ -68,7 +68,6 @@ void registerTypesClientPacks(Serializer &s)
 	s.template registerType<CPackForClient, SetCommanderProperty>();
 	s.template registerType<CPackForClient, ChangeObjectVisitors>();
 	s.template registerType<CPackForClient, ShowWorldViewEx>();
-	s.template registerType<CPackForClient, PrepareHeroLevelUp>();
 	s.template registerType<CPackForClient, EntitiesChanged>();
 	s.template registerType<CPackForClient, BattleStart>();
 	s.template registerType<CPackForClient, BattleNextRound>();

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -187,25 +187,21 @@ void CGameHandler::levelUpHero(const CGHeroInstance * hero)
 	sps.val = 1;
 	sendAndApply(&sps);
 
-	PrepareHeroLevelUp pre;
-	pre.heroId = hero->id;
-	sendAndApply(&pre);
-
 	HeroLevelUp hlu;
 	hlu.player = hero->tempOwner;
 	hlu.heroId = hero->id;
 	hlu.primskill = primarySkill;
-	hlu.skills = pre.skills;
+	hlu.skills = hero->getLevelUpProposedSecondarySkills(heroPool->getHeroSkillsRandomGenerator(hero->getHeroType()));
 
 	if (hlu.skills.size() == 0)
 	{
 		sendAndApply(&hlu);
 		levelUpHero(hero);
 	}
-	else if (hlu.skills.size() == 1)
+	else if (hlu.skills.size() == 1 || !hero->getOwner().isValidPlayer())
 	{
 		sendAndApply(&hlu);
-		levelUpHero(hero, pre.skills.front());
+		levelUpHero(hero, hlu.skills.front());
 	}
 	else if (hlu.skills.size() > 1)
 	{
@@ -550,6 +546,9 @@ void CGameHandler::init(StartInfo *si, Load::ProgressAccumulator & progressTrack
 
 	for (auto & elem : gs->players)
 		turnOrder->addPlayer(elem.first);
+
+	for (auto & elem : gs->map->allHeroes)
+		heroPool->getHeroSkillsRandomGenerator(elem->getHeroType()); // init RMG seed
 
 	reinitScripting();
 }

--- a/server/processors/HeroPoolProcessor.cpp
+++ b/server/processors/HeroPoolProcessor.cpp
@@ -351,6 +351,17 @@ CGHeroInstance * HeroPoolProcessor::pickHeroFor(bool isNative, const PlayerColor
 	return *RandomGeneratorUtil::nextItem(possibleHeroes, getRandomGenerator(player));
 }
 
+CRandomGenerator & HeroPoolProcessor::getHeroSkillsRandomGenerator(const HeroTypeID & hero)
+{
+	if (heroSeed.count(hero) == 0)
+	{
+		int seed = gameHandler->getRandomGenerator().nextInt();
+		heroSeed.emplace(hero, std::make_unique<CRandomGenerator>(seed));
+	}
+
+	return *heroSeed.at(hero);
+}
+
 CRandomGenerator & HeroPoolProcessor::getRandomGenerator(const PlayerColor & player)
 {
 	if (playerSeed.count(player) == 0)

--- a/server/processors/HeroPoolProcessor.h
+++ b/server/processors/HeroPoolProcessor.h
@@ -29,6 +29,9 @@ class HeroPoolProcessor : boost::noncopyable
 	/// per-player random generators
 	std::map<PlayerColor, std::unique_ptr<CRandomGenerator>> playerSeed;
 
+	/// per-hero random generators used to randomize skills
+	std::map<HeroTypeID, std::unique_ptr<CRandomGenerator>> heroSeed;
+
 	void clearHeroFromSlot(const PlayerColor & color, TavernHeroSlot slot);
 	void selectNewHeroForSlot(const PlayerColor & color, TavernHeroSlot slot, bool needNativeHero, bool giveStartingArmy);
 
@@ -54,6 +57,8 @@ public:
 
 	void onNewWeek(const PlayerColor & color);
 
+	CRandomGenerator & getHeroSkillsRandomGenerator(const HeroTypeID & hero);
+
 	/// Incoming net pack handling
 	bool hireHero(const ObjectInstanceID & objectID, const HeroTypeID & hid, const PlayerColor & player);
 
@@ -61,5 +66,6 @@ public:
 	{
 		// h & gameHandler; // FIXME: make this work instead of using deserializationFix in gameHandler
 		h & playerSeed;
+		h & heroSeed;
 	}
 };


### PR DESCRIPTION
Off-by-one error in skill selection was reported on Discord, but after looking into code I have discovered multiple other issues with logic of secondary skills selection.

- Fixed off-by-one error when checking for obligatory skills
- If both wisdom and magic school must be offered in the same slot, magic school will be correctly offered on next levelup
- Obligatory skill can now be proposed for upgrade
- Obligatory skills are now offered using hero class weight instead of simple random
- If hero has multiple skills not available to his class game will select random skill instead of first one
- Moved storage of random seed to server instead of mutable member