### PR TITLE
Bugfixing

### DIFF
--- a/client/lobby/CLobbyScreen.cpp
+++ b/client/lobby/CLobbyScreen.cpp
@@ -76,7 +76,7 @@ CLobbyScreen::CLobbyScreen(ESelectionScreen screenType)
 
 		card->iconDifficulty->addCallback(std::bind(&IServerAPI::setDifficulty, CSH, _1));
 
-		buttonStart = std::make_shared<CButton>(Point(411, 535), AnimationPath::builtin("SCNRBEG.DEF"), CGI->generaltexth->zelp[103], std::bind(&CLobbyScreen::startScenario, this, true), EShortcut::LOBBY_BEGIN_GAME);
+		buttonStart = std::make_shared<CButton>(Point(411, 535), AnimationPath::builtin("SCNRBEG.DEF"), CGI->generaltexth->zelp[103], std::bind(&CLobbyScreen::startScenario, this, false), EShortcut::LOBBY_BEGIN_GAME);
 		initLobby();
 		break;
 	}
@@ -84,7 +84,7 @@ CLobbyScreen::CLobbyScreen(ESelectionScreen screenType)
 	{
 		tabOpt = std::make_shared<OptionsTab>();
 		tabTurnOptions = std::make_shared<TurnOptionsTab>();
-		buttonStart = std::make_shared<CButton>(Point(411, 535), AnimationPath::builtin("SCNRLOD.DEF"), CGI->generaltexth->zelp[103], std::bind(&CLobbyScreen::startScenario, this, true), EShortcut::LOBBY_LOAD_GAME);
+		buttonStart = std::make_shared<CButton>(Point(411, 535), AnimationPath::builtin("SCNRLOD.DEF"), CGI->generaltexth->zelp[103], std::bind(&CLobbyScreen::startScenario, this, false), EShortcut::LOBBY_LOAD_GAME);
 		initLobby();
 		break;
 	}

--- a/client/lobby/OptionsTab.cpp
+++ b/client/lobby/OptionsTab.cpp
@@ -959,7 +959,7 @@ void OptionsTab::PlayerOptionsEntry::updateName() {
 
 void OptionsTab::onSetPlayerClicked(const PlayerSettings & ps) const
 {
-	if(ps.isControlledByAI() || humanPlayers > 0)
+	if(ps.isControlledByAI() || humanPlayers > 1)
 		CSH->setPlayer(ps.color);
 }
 

--- a/config/schemas/settings.json
+++ b/config/schemas/settings.json
@@ -255,7 +255,7 @@
 				},
 				"quickCombat" : {
 					"type" : "boolean",
-					"default" : true
+					"default" : false
 				},
 				"objectAnimation" : {
 					"type" : "boolean",

--- a/lib/constants/EntityIdentifiers.cpp
+++ b/lib/constants/EntityIdentifiers.cpp
@@ -371,7 +371,7 @@ si32 BattleField::decode(const std::string & identifier)
 
 std::string BattleField::encode(const si32 index)
 {
-	return VLC->spells()->getByIndex(index)->getJsonKey();
+	return VLC->battlefields()->getByIndex(index)->getJsonKey();
 }
 
 std::string SpellID::entityType()

--- a/lib/constants/NumericConstants.h
+++ b/lib/constants/NumericConstants.h
@@ -50,6 +50,7 @@ namespace GameConstants
 	constexpr int CREATURES_COUNT = 197;
 
 	constexpr ui32 BASE_MOVEMENT_COST = 100; //default cost for non-diagonal movement
+	constexpr int64_t PLAYER_RESOURCES_CAP = 1000 * 1000 * 1000;
 }
 
 VCMI_LIB_NAMESPACE_END

--- a/lib/mapObjects/CGHeroInstance.cpp
+++ b/lib/mapObjects/CGHeroInstance.cpp
@@ -329,7 +329,6 @@ void CGHeroInstance::initHero(CRandomGenerator & rand)
 		if(!getArt(ArtifactPosition::SPELLBOOK) && type->haveSpellBook)
 		{
 			auto artifact = ArtifactUtils::createNewArtifactInstance(ArtifactID::SPELLBOOK);
-			cb->gameState()->map->addNewArtifactInstance(artifact);
 			putArtifact(ArtifactPosition::SPELLBOOK, artifact);
 		}
 	}
@@ -339,7 +338,6 @@ void CGHeroInstance::initHero(CRandomGenerator & rand)
 	if(!getArt(ArtifactPosition::MACH4))
 	{
 		auto artifact = ArtifactUtils::createNewArtifactInstance(ArtifactID::CATAPULT);
-		cb->gameState()->map->addNewArtifactInstance(artifact);
 		putArtifact(ArtifactPosition::MACH4, artifact); //everyone has a catapult
 	}
 
@@ -458,7 +456,6 @@ void CGHeroInstance::initArmy(CRandomGenerator & rand, IArmyDescriptor * dst)
 				if(!getArt(slot))
 				{
 					auto artifact = ArtifactUtils::createNewArtifactInstance(aid);
-					cb->gameState()->map->addNewArtifactInstance(artifact);
 					putArtifact(slot, artifact);
 				}
 				else

--- a/lib/networkPacks/NetPacksLib.cpp
+++ b/lib/networkPacks/NetPacksLib.cpp
@@ -797,6 +797,7 @@ void SetResources::applyGs(CGameState * gs) const
 		gs->getPlayerState(player)->resources = res;
 	else
 		gs->getPlayerState(player)->resources += res;
+	gs->getPlayerState(player)->resources.amin(GameConstants::PLAYER_RESOURCES_CAP);
 
 	//just ensure that player resources are not negative
 	//server is responsible to check if player can afford deal
@@ -2022,6 +2023,7 @@ void NewTurn::applyGs(CGameState *gs)
 	{
 		assert(re.first.isValidPlayer());
 		gs->getPlayerState(re.first)->resources = re.second;
+		gs->getPlayerState(re.first)->resources.amin(GameConstants::PLAYER_RESOURCES_CAP);
 	}
 
 	for(const auto & creatureSet : cres) //set available creatures in towns


### PR DESCRIPTION
- Limit resources to 1 000 000 000 to prevent overflow. Fixes #2963
- Fix crash on battlefield deserialization
- Fix crash on artifact movement
- Disable quick combat by default to avoid confusing players
- Disable spectator mode in single player. Likely fixes #3205