### PR TITLE
Bugfixing

### DIFF
--- a/config/objects/creatureBanks.json
+++ b/config/objects/creatureBanks.json
@@ -1055,9 +1055,8 @@
 					{
 						"chance": 100,
 						"guards": [
-							{ "amount": 20, "type": "goldGolem" },
+							{ "amount": 40, "type": "goldGolem" },
 							{ "amount": 10, "type": "diamondGolem" },
-							{ "amount": 20, "type": "goldGolem" },
 							{ "amount": 10, "type": "diamondGolem" }
 						],
 						"combat_value": 786,

--- a/lib/JsonRandom.cpp
+++ b/lib/JsonRandom.cpp
@@ -406,7 +406,7 @@ namespace JsonRandom
 	{
 		std::set<SpellID> defaultSpells;
 		for(const auto & spell : VLC->spellh->objects)
-			if (IObjectInterface::cb->isAllowed(spell->getId()))
+			if (IObjectInterface::cb->isAllowed(spell->getId()) && !spell->isSpecial())
 				defaultSpells.insert(spell->getId());
 
 		std::set<SpellID> potentialPicks = filterKeys(value, defaultSpells, variables);

--- a/lib/battle/CBattleInfoEssentials.cpp
+++ b/lib/battle/CBattleInfoEssentials.cpp
@@ -282,7 +282,7 @@ bool CBattleInfoEssentials::battleCanFlee(const PlayerColor & player) const
 		return false;
 
 	//we are besieged defender
-	if(side == BattleSide::DEFENDER && battleGetSiegeLevel())
+	if(side == BattleSide::DEFENDER && getBattle()->getDefendedTown() != nullptr)
 	{
 		const auto * town = battleGetDefendedTown();
 		if(!town->hasBuilt(BuildingSubID::ESCAPE_TUNNEL))
@@ -357,7 +357,7 @@ bool CBattleInfoEssentials::battleCanSurrender(const PlayerColor & player) const
 	const auto side = playerToSide(player);
 	if(!side)
 		return false;
-	bool iAmSiegeDefender = (side.value() == BattleSide::DEFENDER && battleGetSiegeLevel());
+	bool iAmSiegeDefender = (side.value() == BattleSide::DEFENDER && getBattle()->getDefendedTown() != nullptr);
 	//conditions like for fleeing (except escape tunnel presence) + enemy must have a hero
 	return battleCanFlee(player) && !iAmSiegeDefender && battleHasHero(otherSide(side.value()));
 }

--- a/lib/mapObjectConstructors/CObjectClassesHandler.cpp
+++ b/lib/mapObjectConstructors/CObjectClassesHandler.cpp
@@ -36,6 +36,7 @@
 #include "../mapObjects/CGTownInstance.h"
 #include "../modding/IdentifierStorage.h"
 #include "../modding/CModHandler.h"
+#include "../modding/ModScope.h"
 
 VCMI_LIB_NAMESPACE_BEGIN
 
@@ -267,6 +268,10 @@ ObjectClass * CObjectClassesHandler::loadFromJson(const std::string & scope, con
 		else
 			loadSubObject(subData.second.meta, subData.first, subData.second, obj);
 	}
+
+	if (obj->id == MapObjectID::MONOLITH_TWO_WAY)
+		generateExtraMonolithsForRMG(obj);
+
 	return obj;
 }
 
@@ -413,14 +418,12 @@ void CObjectClassesHandler::afterLoadFinalization()
 				logGlobal->warn("No templates found for %s:%s", entry->getJsonKey(), obj->getJsonKey());
 		}
 	}
-
-	generateExtraMonolithsForRMG();
 }
 
-void CObjectClassesHandler::generateExtraMonolithsForRMG()
+void CObjectClassesHandler::generateExtraMonolithsForRMG(ObjectClass * container)
 {
 	//duplicate existing two-way portals to make reserve for RMG
-	auto& portalVec = objects[Obj::MONOLITH_TWO_WAY]->objects;
+	auto& portalVec = container->objects;
 	//FIXME: Monoliths  in this vector can be already not useful for every terrain
 	const size_t portalCount = portalVec.size();
 
@@ -449,7 +452,10 @@ void CObjectClassesHandler::generateExtraMonolithsForRMG()
 		newPortal->type = portal->getIndex();
 
 		newPortal->subtype = portalVec.size(); //indexes must be unique, they are returned as a set
+
 		portalVec.push_back(newPortal);
+
+		registerObject(ModScope::scopeGame(), container->getJsonKey(), newPortal->subTypeName, newPortal->subtype);
 	}
 }
 

--- a/lib/mapObjectConstructors/CObjectClassesHandler.h
+++ b/lib/mapObjectConstructors/CObjectClassesHandler.h
@@ -84,7 +84,7 @@ class DLL_LINKAGE CObjectClassesHandler : public IHandlerBase
 
 	ObjectClass * loadFromJson(const std::string & scope, const JsonNode & json, const std::string & name, size_t index);
 
-	void generateExtraMonolithsForRMG();
+	void generateExtraMonolithsForRMG(ObjectClass * container);
 
 public:
 	CObjectClassesHandler();

--- a/lib/mapObjects/CQuest.cpp
+++ b/lib/mapObjects/CQuest.cpp
@@ -778,7 +778,7 @@ void CGQuestGuard::serializeJsonOptions(JsonSerializeFormat & handler)
 
 bool CGKeys::wasMyColorVisited(const PlayerColor & player) const
 {
-	return cb->getPlayerState(player)->visitedObjectsGlobal.count({ID, subID}) != 0;
+	return cb->getPlayerState(player)->visitedObjectsGlobal.count({Obj::KEYMASTER, subID}) != 0;
 }
 
 std::string CGKeys::getHoverText(PlayerColor player) const

--- a/lib/mapping/MapFormatH3M.cpp
+++ b/lib/mapping/MapFormatH3M.cpp
@@ -678,8 +678,6 @@ void CMapLoaderH3M::readTeamInfo()
 
 void CMapLoaderH3M::readAllowedHeroes()
 {
-	mapHeader->allowedHeroes = VLC->heroh->getDefaultAllowed();
-
 	if(features.levelHOTA0)
 		reader->readBitmaskHeroesSized(mapHeader->allowedHeroes, false);
 	else
@@ -749,8 +747,6 @@ void CMapLoaderH3M::readMapOptions()
 
 void CMapLoaderH3M::readAllowedArtifacts()
 {
-	map->allowedArtifact = VLC->arth->getDefaultAllowed();
-
 	if(features.levelAB)
 	{
 		if(features.levelHOTA0)
@@ -1827,9 +1823,8 @@ CGObjectInstance * CMapLoaderH3M::readHero(const int3 & mapPosition, const Objec
 				logGlobal->debug("Hero %s subID=%d has spells set twice (in map properties and on adventure map instance). Using the latter set...", object->getNameTextID(), object->subID);
 			}
 
-			object->spells.insert(SpellID::PRESET); //placeholder "preset spells"
-
 			reader->readBitmaskSpells(object->spells, false);
+			object->spells.insert(SpellID::PRESET); //placeholder "preset spells"
 		}
 	}
 	else if(features.levelAB)

--- a/lib/mapping/MapReaderH3M.cpp
+++ b/lib/mapping/MapReaderH3M.cpp
@@ -325,6 +325,8 @@ void MapReaderH3M::readBitmaskSkills(std::set<SecondarySkill> & dest, bool inver
 template<class Identifier>
 void MapReaderH3M::readBitmask(std::set<Identifier> & dest, int bytesToRead, int objectsToRead, bool invert)
 {
+	dest.clear();
+
 	for(int byte = 0; byte < bytesToRead; ++byte)
 	{
 		const ui8 mask = reader->readUInt8();

--- a/lib/serializer/JsonSerializer.cpp
+++ b/lib/serializer/JsonSerializer.cpp
@@ -97,7 +97,6 @@ void JsonSerializer::serializeInternal(int64_t & value)
 
 void JsonSerializer::serializeLIC(const std::string & fieldName, const TDecoder & decoder, const TEncoder & encoder, const std::set<int32_t> & standard, std::set<int32_t> & value)
 {
-	assert(standard.size() == value.size());
 	if(standard == value)
 		return;
 


### PR DESCRIPTION
- Fixes generation of additional monolith types for RMG
- Fixes loading of allowed heroes from h3m maps
- Fixes #3213 
- Fix guards composition of Pyramids (positioning of stacks is still wrong)
- Do not allow special spells such as Titan Bolt as a reward
- Do not allow fleeing from cities without fort. Fixes #3058 