### PR TITLE
(1.4.0) Bugfixing

### DIFF
--- a/AI/Nullkiller/Analyzers/HeroManager.cpp
+++ b/AI/Nullkiller/Analyzers/HeroManager.cpp
@@ -187,7 +187,8 @@ bool HeroManager::heroCapReached() const
 	int heroCount = cb->getHeroCount(ai->playerID, includeGarnisoned);
 
 	return heroCount >= ALLOWED_ROAMING_HEROES
-		|| heroCount >= VLC->settings()->getInteger(EGameSettings::HEROES_PER_PLAYER_ON_MAP_CAP);
+		|| heroCount >= VLC->settings()->getInteger(EGameSettings::HEROES_PER_PLAYER_ON_MAP_CAP)
+		|| heroCount >= VLC->settings()->getInteger(EGameSettings::HEROES_PER_PLAYER_TOTAL_CAP);
 }
 
 float HeroManager::getMagicStrength(const CGHeroInstance * hero) const

--- a/client/battle/BattleActionsController.cpp
+++ b/client/battle/BattleActionsController.cpp
@@ -999,7 +999,7 @@ void BattleActionsController::onHexRightClicked(BattleHex clickedHex)
 		return action.spellcast();
 	};
 
-	bool isCurrentStackInSpellcastMode = std::all_of(possibleActions.begin(), possibleActions.end(), spellcastActionPredicate);
+	bool isCurrentStackInSpellcastMode = !possibleActions.empty() && std::all_of(possibleActions.begin(), possibleActions.end(), spellcastActionPredicate);
 
 	if (spellcastingModeActive() || isCurrentStackInSpellcastMode)
 	{

--- a/client/battle/BattleStacksController.cpp
+++ b/client/battle/BattleStacksController.cpp
@@ -534,7 +534,7 @@ void BattleStacksController::stackMoved(const CStack *stack, std::vector<BattleH
 		addNewAnim(new MovementStartAnimation(owner, stack));
 	});
 
-	if (!stack->hasBonus(Selector::typeSubtype(BonusType::FLYING, BonusCustomSubtype::movementFlying)))
+	if (!stack->hasBonus(Selector::typeSubtype(BonusType::FLYING, BonusCustomSubtype::movementTeleporting)))
 	{
 		owner.addToAnimationStage(EAnimationEvents::MOVEMENT, [&]()
 		{

--- a/client/widgets/TextControls.cpp
+++ b/client/widgets/TextControls.cpp
@@ -376,6 +376,7 @@ void CTextBox::setText(const std::string & text)
 	{
 		// decrease width again if slider still used
 		label->pos.w = pos.w - 32;
+		assert(label->pos.w > 0);
 		label->setText(text);
 		slider->setAmount(label->textSize.y);
 	}
@@ -383,6 +384,7 @@ void CTextBox::setText(const std::string & text)
 	{
 		// create slider and update widget
 		label->pos.w = pos.w - 32;
+		assert(label->pos.w > 0);
 		label->setText(text);
 
 		OBJECT_CONSTRUCTION_CUSTOM_CAPTURING(255 - DISPOSE);

--- a/client/windows/CMessage.cpp
+++ b/client/windows/CMessage.cpp
@@ -120,6 +120,10 @@ SDL_Surface * CMessage::drawDialogBox(int w, int h, PlayerColor playerColor)
 
 std::vector<std::string> CMessage::breakText( std::string text, size_t maxLineWidth, EFonts font )
 {
+	assert(maxLineWidth != 0);
+	if (maxLineWidth == 0)
+		return { text };
+
 	std::vector<std::string> ret;
 
 	boost::algorithm::trim_right_if(text,boost::algorithm::is_any_of(std::string(" ")));

--- a/client/windows/CSpellWindow.cpp
+++ b/client/windows/CSpellWindow.cpp
@@ -648,7 +648,14 @@ void CSpellWindow::SpellArea::setSpell(const CSpell * spell)
 
 		{
 			OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
-			schoolBorder = std::make_shared<CAnimImage>(owner->schoolBorders[owner->selectedTab >= 4 ? whichSchool.getNum() : owner->selectedTab], schoolLevel);
+			schoolBorder.reset();
+			if (owner->selectedTab >= 4)
+			{
+				if (whichSchool.getNum() != SpellSchool())
+					schoolBorder = std::make_shared<CAnimImage>(owner->schoolBorders.at(whichSchool.getNum()), schoolLevel);
+			}
+			else
+				schoolBorder = std::make_shared<CAnimImage>(owner->schoolBorders.at(owner->selectedTab), schoolLevel);
 		}
 
 		ColorRGBA firstLineColor, secondLineColor;

--- a/client/windows/CTradeWindow.cpp
+++ b/client/windows/CTradeWindow.cpp
@@ -137,7 +137,23 @@ std::vector<int> *CTradeWindow::getItemsIds(bool Left)
 {
 	std::vector<int> *ids = nullptr;
 
-	if(!Left)
+	if(Left)
+	{
+		switch(itemsType[1])
+		{
+		case CREATURE:
+			ids = new std::vector<int>;
+			for(int i = 0; i < 7; i++)
+			{
+				if(const CCreature *c = hero->getCreature(SlotID(i)))
+					ids->push_back(c->getId());
+				else
+					ids->push_back(-1);
+			}
+			break;
+		}
+	}
+	else
 	{
 		switch(itemsType[0])
 		{

--- a/client/windows/InfoWindows.cpp
+++ b/client/windows/InfoWindows.cpp
@@ -150,7 +150,9 @@ CInfoWindow::CInfoWindow(std::string Text, PlayerColor player, const TCompsInfo 
 	text = std::make_shared<CTextBox>(Text, Rect(0, 0, 250, 100), 0, FONT_MEDIUM, ETextAlignment::CENTER, Colors::WHITE);
 	if(!text->slider)
 	{
-		text->resize(text->label->textSize);
+		int finalWidth = std::min(250, text->label->textSize.x + 32);
+		int finalHeight = text->label->textSize.y;
+		text->resize(Point(finalWidth, finalHeight));
 	}
 
 	if(buttons.size() == 1)

--- a/lib/CArtHandler.cpp
+++ b/lib/CArtHandler.cpp
@@ -474,9 +474,6 @@ CArtifact * CArtHandler::loadFromJson(const std::string & scope, const JsonNode 
 			// Necessary for objects added via mods that don't have any templates in H3
 			VLC->objtypeh->getHandlerFor(Obj::ARTIFACT, art->getIndex())->addTemplate(templ);
 		}
-		// object does not have any templates - this is not usable object (e.g. pseudo-art like lock)
-		if(VLC->objtypeh->getHandlerFor(Obj::ARTIFACT, art->getIndex())->getTemplates().empty())
-			VLC->objtypeh->removeSubObject(Obj::ARTIFACT, art->getIndex());
 	});
 
 	return art;

--- a/lib/CPlayerState.cpp
+++ b/lib/CPlayerState.cpp
@@ -23,25 +23,7 @@ PlayerState::PlayerState()
 	setNodeType(PLAYER);
 }
 
-PlayerState::PlayerState(PlayerState && other) noexcept:
-	CBonusSystemNode(std::move(other)),
-	color(other.color),
-	human(other.human),
-	team(other.team),
-	resources(other.resources),
-	cheated(other.cheated),
-	enteredWinningCheatCode(other.enteredWinningCheatCode),
-	enteredLosingCheatCode(other.enteredLosingCheatCode),
-	status(other.status),
-	daysWithoutCastle(other.daysWithoutCastle)
-{
-	std::swap(visitedObjects, other.visitedObjects);
-	std::swap(heroes, other.heroes);
-	std::swap(towns, other.towns);
-	std::swap(dwellings, other.dwellings);
-	std::swap(quests, other.quests);
-	std::swap(battleBonuses, other.battleBonuses);
-}
+PlayerState::PlayerState(PlayerState && other) noexcept = default;
 
 PlayerState::~PlayerState() = default;
 

--- a/lib/MetaString.cpp
+++ b/lib/MetaString.cpp
@@ -51,8 +51,11 @@ void MetaString::appendRawString(const std::string & value)
 
 void MetaString::appendTextID(const std::string & value)
 {
-	message.push_back(EMessage::APPEND_TEXTID_STRING);
-	stringsTextID.push_back(value);
+	if (!value.empty())
+	{
+		message.push_back(EMessage::APPEND_TEXTID_STRING);
+		stringsTextID.push_back(value);
+	}
 }
 
 void MetaString::appendNumber(int64_t value)

--- a/lib/gameState/CGameState.cpp
+++ b/lib/gameState/CGameState.cpp
@@ -784,7 +784,7 @@ void CGameState::initTowns()
 		CGTownInstance * vti =(elem);
 		assert(vti->town);
 
-		if(vti->getNameTranslated().empty())
+		if(vti->getNameTextID().empty())
 		{
 			size_t nameID = getRandomGenerator().nextInt(vti->getTown()->getRandomNamesCount() - 1);
 			vti->setNameTextId(vti->getTown()->getRandomNameTextID(nameID));
@@ -1797,12 +1797,6 @@ void CGameState::buildBonusSystemTree()
 	{
 		t->deserializationFix();
 	}
-	// CStackInstance <-> CCreature, CStackInstance <-> CArmedInstance, CArtifactInstance <-> CArtifact
-	// are provided on initializing / deserializing
-
-	// NOTE: calling deserializationFix() might be more correct option, but might lead to side effects
-	for (auto hero : map->heroesOnMap)
-		hero->boatDeserializationFix();
 }
 
 void CGameState::deserializationFix()

--- a/lib/mapObjects/CGCreature.cpp
+++ b/lib/mapObjects/CGCreature.cpp
@@ -215,8 +215,12 @@ void CGCreature::pickRandomObject(CRandomGenerator & rand)
 			subID = VLC->creh->pickRandomMonster(rand, 7);
 			break;
 	}
-	ID = MapObjectID::MONSTER;
-	setType(ID, subID);
+
+	if (ID != MapObjectID::MONSTER)
+	{
+		ID = MapObjectID::MONSTER;
+		setType(ID, subID);
+	}
 }
 
 void CGCreature::initObj(CRandomGenerator & rand)

--- a/lib/mapObjects/CGHeroInstance.cpp
+++ b/lib/mapObjects/CGHeroInstance.cpp
@@ -1337,13 +1337,6 @@ std::vector<SecondarySkill> CGHeroInstance::getLevelUpProposedSecondarySkills(CR
 	if (canLearnSkill() && !none.empty() && skills.size() < 2)
 		chooseSkill(none);
 
-	if (skills.empty())
-		logGlobal->info("Selecting secondary skills: Nothing to select!");
-	if (skills.size() == 1)
-		logGlobal->info("Selecting secondary skills: %s (wisdom: %d, schools: %d)!", skills[0], skillsInfo.wisdomCounter, skillsInfo.magicSchoolCounter);
-	if (skills.size() == 2)
-		logGlobal->info("Selecting secondary skills: %s or %s (wisdom: %d, schools: %d)!", skills[0], skills[1], int(skillsInfo.wisdomCounter), int(skillsInfo.magicSchoolCounter));
-
 	return skills;
 }
 

--- a/lib/mapObjects/CGTownInstance.cpp
+++ b/lib/mapObjects/CGTownInstance.cpp
@@ -947,6 +947,11 @@ std::string CGTownInstance::getNameTranslated() const
 	return VLC->generaltexth->translate(nameTextId);
 }
 
+std::string CGTownInstance::getNameTextID() const
+{
+	return nameTextId;
+}
+
 void CGTownInstance::setNameTextId( const std::string & newName )
 {
 	nameTextId = newName;

--- a/lib/mapObjects/CGTownInstance.h
+++ b/lib/mapObjects/CGTownInstance.h
@@ -137,6 +137,7 @@ public:
 	const CArmedInstance *getUpperArmy() const; //garrisoned hero if present or the town itself
 
 	std::string getNameTranslated() const;
+	std::string getNameTextID() const;
 	void setNameTextId(const std::string & newName);
 
 	//////////////////////////////////////////////////////////////////////////

--- a/lib/mapObjects/CQuest.h
+++ b/lib/mapObjects/CQuest.h
@@ -45,7 +45,9 @@ public:
 	std::string heroName; //backup of hero name
 	HeroTypeID heroPortrait;
 
-	MetaString firstVisitText, nextVisitText, completedText;
+	MetaString firstVisitText;
+	MetaString nextVisitText;
+	MetaString completedText;
 	bool isCustomFirst;
 	bool isCustomNext;
 	bool isCustomComplete;

--- a/lib/mapObjects/MiscObjects.cpp
+++ b/lib/mapObjects/MiscObjects.cpp
@@ -739,10 +739,13 @@ void CGArtifact::pickRandomObject(CRandomGenerator & rand)
 			break;
 	}
 
-	if (ID != Obj::SPELL_SCROLL)
+	if (ID != MapObjectID::SPELL_SCROLL && ID != MapObjectID::ARTIFACT)
+	{
 		ID = MapObjectID::ARTIFACT;
-
-	setType(ID, subID);
+		setType(ID, subID);
+	}
+	else if (ID != MapObjectID::SPELL_SCROLL)
+		ID = MapObjectID::ARTIFACT;
 }
 
 void CGArtifact::initObj(CRandomGenerator & rand)

--- a/lib/mapping/MapFeaturesH3M.cpp
+++ b/lib/mapping/MapFeaturesH3M.cpp
@@ -97,7 +97,7 @@ MapFormatFeaturesH3M MapFormatFeaturesH3M::getFeaturesSOD()
 	MapFormatFeaturesH3M result = getFeaturesAB();
 	result.levelSOD = true;
 
-	result.artifactsCount = 141; // + Combined artifacts
+	result.artifactsCount = 144; // + Combined artifacts + 3 unfinished artifacts (required for some maps)
 	result.artifactsBytes = 18;
 
 	result.heroesPortraitsCount = 163; // +Finneas +young Gem +young Sandro +young Yog

--- a/lib/mapping/MapFormatH3M.cpp
+++ b/lib/mapping/MapFormatH3M.cpp
@@ -171,7 +171,7 @@ void CMapLoaderH3M::readHeader()
 		identifierMapper.loadMapping(VLC->settings()->getValue(EGameSettings::MAP_FORMAT_IN_THE_WAKE_OF_GODS));
 	if (features.levelHOTA0)
 		identifierMapper.loadMapping(VLC->settings()->getValue(EGameSettings::MAP_FORMAT_HORN_OF_THE_ABYSS));
-	
+
 	reader->setIdentifierRemapper(identifierMapper);
 
 	// include basic mod
@@ -898,7 +898,7 @@ void CMapLoaderH3M::loadArtifactsOfHero(CGHeroInstance * hero)
 
 	if(!hero->artifactsWorn.empty() || !hero->artifactsInBackpack.empty())
 	{
-		logGlobal->debug("Hero %s at %s has set artifacts twice (in map properties and on adventure map instance). Using the latter set...", hero->getNameTranslated(), hero->pos.toString());
+		logGlobal->debug("Hero %d at %s has set artifacts twice (in map properties and on adventure map instance). Using the latter set...", hero->getHeroType().getNum(), hero->pos.toString());
 
 		hero->artifactsInBackpack.clear();
 		while(!hero->artifactsWorn.empty())
@@ -1035,7 +1035,7 @@ void CMapLoaderH3M::readBoxContent(CGPandoraBox * object, const int3 & mapPositi
 	readMessageAndGuards(object->message, object, mapPosition);
 	Rewardable::VisitInfo vinfo;
 	auto & reward = vinfo.reward;
-	
+
 	reward.heroExperience = reader->readUInt32();
 	reward.manaDiff = reader->readInt32();
 	if(auto val = reader->readUInt8())
@@ -1052,7 +1052,7 @@ void CMapLoaderH3M::readBoxContent(CGPandoraBox * object, const int3 & mapPositi
 	{
 		auto rId = reader->readSkill();
 		auto rVal = reader->readUInt8();
-		
+
 		reward.secondary[rId] = rVal;
 	}
 	int gart = reader->readUInt8(); //number of gained artifacts
@@ -1068,13 +1068,13 @@ void CMapLoaderH3M::readBoxContent(CGPandoraBox * object, const int3 & mapPositi
 	{
 		auto rId = reader->readCreature();
 		auto rVal = reader->readUInt16();
-		
+
 		reward.creatures.emplace_back(rId, rVal);
 	}
-	
+
 	vinfo.visitType = Rewardable::EEventType::EVENT_FIRST_VISIT;
 	object->configuration.info.push_back(vinfo);
-	
+
 	reader->skipZero(8);
 }
 
@@ -1852,7 +1852,7 @@ CGObjectInstance * CMapLoaderH3M::readHero(const int3 & mapPosition, const Objec
 			auto ps = object->getAllBonuses(Selector::type()(BonusType::PRIMARY_SKILL).And(Selector::sourceType()(BonusSource::HERO_BASE_SKILL)), nullptr);
 			if(ps->size())
 			{
-				logGlobal->debug("Hero %s subID=%d has set primary skills twice (in map properties and on adventure map instance). Using the latter set...", object->getNameTranslated(), object->subID );
+				logGlobal->debug("Hero %s has set primary skills twice (in map properties and on adventure map instance). Using the latter set...", object->getHeroType().getNum() );
 				for(const auto & b : *ps)
 					object->removeBonus(b);
 			}
@@ -2008,7 +2008,7 @@ void CMapLoaderH3M::readSeerHutQuest(CGSeerHut * hut, const int3 & position, con
 			{
 				auto rId = reader->readUInt8();
 				auto rVal = reader->readUInt8();
-				
+
 				reward.primary.at(rId) = rVal;
 				break;
 			}
@@ -2016,7 +2016,7 @@ void CMapLoaderH3M::readSeerHutQuest(CGSeerHut * hut, const int3 & position, con
 			{
 				auto rId = reader->readSkill();
 				auto rVal = reader->readUInt8();
-				
+
 				reward.secondary[rId] = rVal;
 				break;
 			}
@@ -2034,7 +2034,7 @@ void CMapLoaderH3M::readSeerHutQuest(CGSeerHut * hut, const int3 & position, con
 			{
 				auto rId = reader->readCreature();
 				auto rVal = reader->readUInt16();
-				
+
 				reward.creatures.emplace_back(rId, rVal);
 				break;
 			}
@@ -2043,7 +2043,7 @@ void CMapLoaderH3M::readSeerHutQuest(CGSeerHut * hut, const int3 & position, con
 				assert(0);
 			}
 		}
-		
+
 		vinfo.visitType = Rewardable::EEventType::EVENT_FIRST_VISIT;
 		hut->configuration.info.push_back(vinfo);
 	}

--- a/lib/mapping/MapFormatH3M.cpp
+++ b/lib/mapping/MapFormatH3M.cpp
@@ -1162,18 +1162,24 @@ CGObjectInstance * CMapLoaderH3M::readWitchHut(const int3 & position, std::share
 					allowedAbilities.insert(SecondarySkill(skillID));
 		}
 
-		JsonVector anyOfList;
-
-		for (auto const & skill : allowedAbilities)
-		{
-			JsonNode entry;
-			entry.String() = VLC->skills()->getById(skill)->getJsonKey();
-			anyOfList.push_back(entry);
-		}
 		JsonNode variable;
-		variable["anyOf"].Vector() = anyOfList;
-		variable.setMeta(ModScope::scopeGame()); // list may include skills from all mods
+		if (allowedAbilities.size() == 1)
+		{
+			variable.String() = VLC->skills()->getById(*allowedAbilities.begin())->getJsonKey();
+		}
+		else
+		{
+			JsonVector anyOfList;
+			for (auto const & skill : allowedAbilities)
+			{
+				JsonNode entry;
+				entry.String() = VLC->skills()->getById(skill)->getJsonKey();
+				anyOfList.push_back(entry);
+			}
+			variable["anyOf"].Vector() = anyOfList;
+		}
 
+		variable.setMeta(ModScope::scopeGame()); // list may include skills from all mods
 		rewardable->configuration.presetVariable("secondarySkill", "gainedSkill", variable);
 	}
 	return object;

--- a/lib/mapping/MapFormatJson.cpp
+++ b/lib/mapping/MapFormatJson.cpp
@@ -158,20 +158,35 @@ namespace TriggeredEventsDetail
 			{
 				case EventCondition::HAVE_ARTIFACT:
 				case EventCondition::TRANSPORT:
-					event.objectType = ArtifactID(ArtifactID::decode(data["type"].String()));
+					if (data["type"].isNumber()) // compatibility
+						event.objectType = ArtifactID(data["type"].Integer());
+					else
+						event.objectType = ArtifactID(ArtifactID::decode(data["type"].String()));
 					break;
 				case EventCondition::HAVE_CREATURES:
-					event.objectType = CreatureID(CreatureID::decode(data["type"].String()));
+					if (data["type"].isNumber()) // compatibility
+						event.objectType = CreatureID(data["type"].Integer());
+					else
+						event.objectType = CreatureID(CreatureID::decode(data["type"].String()));
 					break;
 				case EventCondition::HAVE_RESOURCES:
-					event.objectType = GameResID(GameResID::decode(data["type"].String()));
+					if (data["type"].isNumber()) // compatibility
+						event.objectType = GameResID(data["type"].Integer());
+					else
+						event.objectType = GameResID(GameResID::decode(data["type"].String()));
 					break;
 				case EventCondition::HAVE_BUILDING:
-					event.objectType = BuildingID(BuildingID::decode(data["type"].String()));
+					if (data["type"].isNumber()) // compatibility
+						event.objectType = BuildingID(data["type"].Integer());
+					else
+						event.objectType = BuildingID(BuildingID::decode(data["type"].String()));
 					break;
 				case EventCondition::CONTROL:
 				case EventCondition::DESTROY:
-					event.objectType = MapObjectID(MapObjectID::decode(data["type"].String()));
+					if (data["type"].isNumber()) // compatibility
+						event.objectType = MapObjectID(data["type"].Integer());
+					else
+						event.objectType = MapObjectID(MapObjectID::decode(data["type"].String()));
 					break;
 			}
 

--- a/lib/serializer/Connection.cpp
+++ b/lib/serializer/Connection.cpp
@@ -222,7 +222,13 @@ int CConnection::read(void * data, unsigned size)
 CConnection::~CConnection()
 {
 	if(handler)
-		handler->join();
+	{
+		// ugly workaround to avoid self-join if last strong reference to shared_ptr that owns this class has been released in this very thread, e.g. on netpack processing
+		if (boost::this_thread::get_id() != handler->get_id())
+			handler->join();
+		else
+			handler->detach();
+	}
 
 	close();
 }

--- a/lib/spells/effects/Catapult.cpp
+++ b/lib/spells/effects/Catapult.cpp
@@ -72,6 +72,7 @@ void Catapult::applyMassive(ServerCallback * server, const Mechanics * m) const
 		return;
 
 	CatapultAttack ca;
+	ca.battleID = m->battle()->getBattle()->getBattleID();
 	ca.attacker = m->caster->getHeroCaster() ? -1 : m->caster->getCasterUnitId();
 
 	for(int i = 0; i < targetsToAttack; i++)


### PR DESCRIPTION
- Fixes #3234 
- Fixes #3233 
- Fixes #3228 
- Fixes #3226 
- Fixes #3225 
- Fixes #3220 
- Fixes #3219 
- Fixes "Spell Cancelled" message on right-clicking battlefield when there is no active unit
- Removes error messages on attempt to translate empty text identifier
- Removes some excessive logging (leftover from previous PR)