### PR TITLE
TBB: use 1.7 vcpkg prebuild libs for msvc

### DIFF
--- a/CI/msvc/before_install.sh
+++ b/CI/msvc/before_install.sh
@@ -1,5 +1,5 @@
 curl -LfsS -o "vcpkg-export-${VCMI_BUILD_PLATFORM}-windows-v143.7z" \
-	"https://github.com/vcmi/vcmi-deps-windows/releases/download/v1.6/vcpkg-export-${VCMI_BUILD_PLATFORM}-windows-v143.7z"
+	"https://github.com/vcmi/vcmi-deps-windows/releases/download/v1.7/vcpkg-export-${VCMI_BUILD_PLATFORM}-windows-v143.7z"
 7z x "vcpkg-export-${VCMI_BUILD_PLATFORM}-windows-v143.7z"
 
 #rm -r -f vcpkg/installed/${VCMI_BUILD_PLATFORM}-windows/debug


### PR DESCRIPTION
Removed TBBTargets-debug.cmake to avoid cpack using debug libs of it