### PR TITLE
Fix corpse

### DIFF
--- a/config/objects/generic.json
+++ b/config/objects/generic.json
@@ -10,7 +10,11 @@
 			}
 		},
 		"types" : {
-			"prison" : { "index" : 0, "aiValue" : 5000 }
+			"prison" : {
+				"index" : 0,
+				"aiValue" : 5000,
+				"removable": true
+			}
 		}
 	},
 
@@ -136,6 +140,7 @@
 			"object" : {
 				"index" : 0,
 				"aiValue" : 10000,
+				"removable": true,
 				"templates" : {
 					"normal" : { "animation" : "ava0128.def", "visitableFrom" : [ "+++", "+-+", "+++" ], "mask" : [ "VV", "VA"] }
 				},
@@ -150,6 +155,7 @@
 		"types" : {
 			"object" : {
 				"index" : 0,
+				"removable": true,
 				"rmg" : {
 				}
 			}
@@ -313,6 +319,7 @@
 			"object" : {
 				"index" : 0,
 				"aiValue" : 0,
+				"removable": true,
 				"rmg" : {
 				}
 			}
@@ -444,6 +451,7 @@
 			"object" : {
 				"index" : 0,
 				"aiValue" : 10000,
+				"removable": true,
 				"rmg" : {
 				}
 			}
@@ -495,6 +503,7 @@
 		"types" : {
 			"object" : {
 				"index" : 0,
+				"removable": true,
 				"rmg" : {
 					"value"		: 2000,
 					"rarity"	: 150
@@ -511,6 +520,7 @@
 		"types" : {
 			"object" : {
 				"index" : 0,
+				"removable": true,
 				"rmg" : {
 					"value"		: 5000,
 					"rarity"	: 150
@@ -527,6 +537,7 @@
 		"types" : {
 			"object" : {
 				"index" : 0,
+				"removable": true,
 				"rmg" : {
 					"value"		: 10000,
 					"rarity"	: 150
@@ -543,6 +554,7 @@
 		"types" : {
 			"object" : {
 				"index" : 0,
+				"removable": true,
 				"rmg" : {
 					"value"		: 20000,
 					"rarity"	: 150
@@ -572,6 +584,7 @@
 		"types" : {
 			"object" : {
 				"index" : 0,
+				"removable": true,
 				"templates" : {
 					"normal" : { "animation" : "AVWmon1", "visitableFrom" : [ "+++", "+-+", "+++" ], "mask" : [ "VV", "VA"] }
 				}
@@ -584,6 +597,7 @@
 		"types" : {
 			"object" : {
 				"index" : 0,
+				"removable": true,
 				"templates" : {
 					"normal" : { "animation" : "AVWmon2", "visitableFrom" : [ "+++", "+-+", "+++" ], "mask" : [ "VV", "VA"] }
 				}
@@ -596,6 +610,7 @@
 		"types" : {
 			"object" : {
 				"index" : 0,
+				"removable": true,
 				"templates" : {
 					"normal" : { "animation" : "AVWmon3", "visitableFrom" : [ "+++", "+-+", "+++" ], "mask" : [ "VV", "VA"] }
 				}
@@ -608,6 +623,7 @@
 		"types" : {
 			"object" : {
 				"index" : 0,
+				"removable": true,
 				"templates" : {
 					"normal" : { "animation" : "AVWmon4", "visitableFrom" : [ "+++", "+-+", "+++" ], "mask" : [ "VV", "VA"] }
 				}
@@ -632,6 +648,7 @@
 		"types" : {
 			"object" : {
 				"index" : 0,
+				"removable": true,
 				"templates" : {
 					"normal" : { "animation" : "AVWmon6", "visitableFrom" : [ "+++", "+-+", "+++" ], "mask" : [ "VV", "VA"] }
 				}
@@ -644,6 +661,7 @@
 		"types" : {
 			"object" : {
 				"index" : 0,
+				"removable": true,
 				"templates" : {
 					"normal" : { "animation" : "AVWmon7", "visitableFrom" : [ "+++", "+-+", "+++" ], "mask" : [ "VV", "VA"] }
 				}
@@ -687,6 +705,7 @@
 			"object" : {
 				"index" : 0,
 				"aiValue" : 0,
+				"removable": true,
 				"rmg" : {
 				}
 			}
@@ -723,6 +742,7 @@
 		"index" :95,
 		"handler": "generic",
 		"base" : {
+			"blockVisit": true,
 			"sounds" : {
 				"ambient" : ["LOOPTAV"],
 				"visit" : ["STORE"]

--- a/config/objects/moddables.json
+++ b/config/objects/moddables.json
@@ -8,6 +8,7 @@
 		"index" :5, 
 		"handler": "artifact",
 		"base" : {
+			"removable": true,
 			"base" : {
 				"visitableFrom" : [ "+++", "+-+", "+++" ],
 				"mask" : [ "VV", "VA"]
@@ -25,6 +26,7 @@
 		"handler": "hero",
 		"base" : {
 			"aiValue" : 7500,
+			"removable": true,
 			"base" : {
 				"visitableFrom" : [ "+++", "+-+", "+++" ],
 				"mask" : [ "VVV", "VAV"]
@@ -40,6 +42,7 @@
 		"index" :54,
 		"handler": "monster",
 		"base" : {
+			"removable": true,
 			"base" : {
 				"visitableFrom" : [ "+++", "+-+", "+++" ],
 				"mask" : [ "VV", "VA"]
@@ -55,6 +58,7 @@
 		"index" :76,
 		"handler": "randomResource",
 		"base" : {
+			"removable": true,
 			"base" : {
 				"visitableFrom" : [ "+++", "+-+", "+++" ],
 				"mask" : [ "VA" ]
@@ -85,6 +89,7 @@
 		"handler": "resource",
 		"lastReservedIndex" : 6,
 		"base" : {
+			"removable": true,
 			"base" : {
 				"visitableFrom" : [ "+++", "+-+", "+++" ],
 				"mask" : [ "VA" ]
@@ -138,6 +143,7 @@
 		"lastReservedIndex" : 2,
 		"base" : {
 			"aiValue" : 0,
+			"removable": true,
 			"layer" : "sail",
 			"onboardAssaultAllowed" : true,
 			"onboardVisitAllowed" : true,
@@ -175,6 +181,7 @@
 		"lastReservedIndex" : 7,
 		"base" : {
 			"aiValue" : 0,
+			"removable": true,
 			"sounds" : {
 				"visit" : ["CAVEHEAD"],
 				"removal" : [ "PICKUP01", "PICKUP02", "PICKUP03", "PICKUP04", "PICKUP05", "PICKUP06", "PICKUP07" ]

--- a/config/objects/rewardableOnceVisitable.json
+++ b/config/objects/rewardableOnceVisitable.json
@@ -41,6 +41,7 @@
 		"index" : 22,
 		"handler": "configurable",
 		"base" : {
+			"blockedVisitable" : true,
 			"sounds" : {
 				"visit" : ["MYSTERY"]
 			}
@@ -54,9 +55,7 @@
 					"rarity"	: 100
 				},
 				"compatibilityIdentifiers" : [ "object" ],
-
 				"onVisitedMessage" : 38,
-				"blockedVisitable" : true,
 				"visitMode" : "once",
 				"selectMode" : "selectFirst",
 				"rewards" : [

--- a/config/objects/rewardablePickable.json
+++ b/config/objects/rewardablePickable.json
@@ -19,6 +19,7 @@
 					"value"		: 2000,
 					"rarity"	: 500
 				},
+				"removable": true,
 				"compatibilityIdentifiers" : [ "object" ],
 
 				"blockedVisitable" : true,
@@ -61,6 +62,7 @@
 					"value"		: 2000,
 					"rarity"	: 100
 				},
+				"removable": true,
 				"compatibilityIdentifiers" : [ "object" ],
 
 				"blockedVisitable" : true,
@@ -119,6 +121,7 @@
 					"value"		: 1500,
 					"rarity"	: 500
 				},
+				"removable": true,
 				"compatibilityIdentifiers" : [ "object" ],
 
 				"blockedVisitable" : true,
@@ -170,6 +173,7 @@
 					"value"		: 1500,
 					"rarity"	: 50
 				},
+				"removable": true,
 				"compatibilityIdentifiers" : [ "object" ],
 
 				"blockedVisitable" : true,
@@ -221,6 +225,7 @@
 					"value"		: 1500,
 					"rarity"	: 1000
 				},
+				"removable": true,
 				"compatibilityIdentifiers" : [ "object" ],
 
 				"blockedVisitable" : true,

--- a/config/objects/rewardablePickable.json
+++ b/config/objects/rewardablePickable.json
@@ -5,6 +5,8 @@
 		"index" : 12,
 		"handler": "configurable",
 		"base" : {
+			"blockedVisitable" : true,
+			"removable": true,
 			"sounds" : {
 				"ambient" : ["LOOPCAMP"],
 				"visit" : ["EXPERNCE"],
@@ -19,10 +21,7 @@
 					"value"		: 2000,
 					"rarity"	: 500
 				},
-				"removable": true,
 				"compatibilityIdentifiers" : [ "object" ],
-
-				"blockedVisitable" : true,
 				"visitMode" : "unlimited",
 				"selectMode" : "selectFirst",
 				"rewards" : [
@@ -49,6 +48,8 @@
 		"index" : 29,
 		"handler": "configurable",
 		"base" : {
+			"blockedVisitable" : true,
+			"removable": true,
 			"sounds" : {
 				"visit" : ["GENIE"],
 				"removal" : [ "PICKUP01", "PICKUP02", "PICKUP03", "PICKUP04", "PICKUP05", "PICKUP06", "PICKUP07" ]
@@ -62,17 +63,14 @@
 					"value"		: 2000,
 					"rarity"	: 100
 				},
-				"removable": true,
 				"compatibilityIdentifiers" : [ "object" ],
-
-				"blockedVisitable" : true,
 				"visitMode" : "unlimited",
 				"selectMode" : "selectFirst",
 				"rewards" : [
 					{
 						"message" : 51,
 						"appearChance" : { "max" : 25 },
-						"removeObject" : true,
+						"removeObject" : true
 					},
 					{
 						"message" : 52,
@@ -108,6 +106,8 @@
 		"index" : 82,
 		"handler": "configurable",
 		"base" : {
+			"blockedVisitable" : true,
+			"removable": true,
 			"sounds" : {
 				"visit" : ["CHEST"],
 				"removal" : [ "PICKUP01", "PICKUP02", "PICKUP03", "PICKUP04", "PICKUP05", "PICKUP06", "PICKUP07" ]
@@ -121,10 +121,7 @@
 					"value"		: 1500,
 					"rarity"	: 500
 				},
-				"removable": true,
 				"compatibilityIdentifiers" : [ "object" ],
-
-				"blockedVisitable" : true,
 				"visitMode" : "unlimited",
 				"selectMode" : "selectFirst",
 				"rewards" : [
@@ -160,6 +157,8 @@
 		"index" : 86,
 		"handler": "configurable",
 		"base" : {
+			"blockedVisitable" : true,
+			"removable": true,
 			"sounds" : {
 				"visit" : ["TREASURE"],
 				"removal" : [ "PICKUP01", "PICKUP02", "PICKUP03", "PICKUP04", "PICKUP05", "PICKUP06", "PICKUP07" ]
@@ -173,10 +172,7 @@
 					"value"		: 1500,
 					"rarity"	: 50
 				},
-				"removable": true,
 				"compatibilityIdentifiers" : [ "object" ],
-
-				"blockedVisitable" : true,
 				"visitMode" : "unlimited",
 				"selectMode" : "selectFirst",
 				"rewards" : [
@@ -212,6 +208,7 @@
 		"index" : 101,
 		"handler": "configurable",
 		"base" : {
+			"removable": true,
 			"sounds" : {
 				"visit" : ["CHEST"],
 				"removal" : [ "PICKUP01", "PICKUP02", "PICKUP03", "PICKUP04", "PICKUP05", "PICKUP06", "PICKUP07" ]
@@ -225,7 +222,6 @@
 					"value"		: 1500,
 					"rarity"	: 1000
 				},
-				"removable": true,
 				"compatibilityIdentifiers" : [ "object" ],
 
 				"blockedVisitable" : true,

--- a/lib/mapObjectConstructors/AObjectTypeHandler.cpp
+++ b/lib/mapObjectConstructors/AObjectTypeHandler.cpp
@@ -97,16 +97,8 @@ void AObjectTypeHandler::init(const JsonNode & input)
 		aiValue = static_cast<std::optional<si32>>(input["aiValue"].Integer());
 
 	// TODO: Define properties, move them to actual object instance
-	if(input["blockVisit"].isNull())
-		blockVisit = false;
-	else
-		blockVisit = input["blockVisit"].Bool();
-
-	if(input["removable"].isNull())
-		removable = false;
-	else
-		removable = input["removable"].Bool();
-
+	blockVisit = input["blockVisit"].Bool();
+	removable = input["removable"].Bool();
 
 	battlefield = BattleField::NONE;
 

--- a/lib/mapObjectConstructors/AObjectTypeHandler.cpp
+++ b/lib/mapObjectConstructors/AObjectTypeHandler.cpp
@@ -96,6 +96,18 @@ void AObjectTypeHandler::init(const JsonNode & input)
 	else
 		aiValue = static_cast<std::optional<si32>>(input["aiValue"].Integer());
 
+	// TODO: Define properties, move them to actual object instance
+	if(input["blockVisit"].isNull())
+		blockVisit = false;
+	else
+		blockVisit = input["blockVisit"].Bool();
+
+	if(input["removable"].isNull())
+		removable = false;
+	else
+		removable = input["removable"].Bool();
+
+
 	battlefield = BattleField::NONE;
 
 	if(!input["battleground"].isNull())
@@ -120,6 +132,8 @@ void AObjectTypeHandler::preInitObject(CGObjectInstance * obj) const
 	obj->subID = subtype;
 	obj->typeName = typeName;
 	obj->subTypeName = subTypeName;
+	obj->blockVisit = blockVisit;
+	obj->removable = removable;
 }
 
 void AObjectTypeHandler::initTypeData(const JsonNode & input)

--- a/lib/mapObjectConstructors/AObjectTypeHandler.h
+++ b/lib/mapObjectConstructors/AObjectTypeHandler.h
@@ -43,6 +43,9 @@ class DLL_LINKAGE AObjectTypeHandler : public boost::noncopyable
 	si32 type;
 	si32 subtype;
 
+	bool blockVisit;
+	bool removable;
+
 protected:
 	void preInitObject(CGObjectInstance * obj) const;
 	virtual bool objectFilter(const CGObjectInstance * obj, std::shared_ptr<const ObjectTemplate> tmpl) const;

--- a/lib/mapObjects/CGObjectInstance.cpp
+++ b/lib/mapObjects/CGObjectInstance.cpp
@@ -33,7 +33,8 @@ CGObjectInstance::CGObjectInstance():
 	ID(Obj::NO_OBJ),
 	subID(-1),
 	tempOwner(PlayerColor::UNFLAGGABLE),
-	blockVisit(false)
+	blockVisit(false),
+	removable(false)
 {
 }
 
@@ -173,12 +174,7 @@ void CGObjectInstance::pickRandomObject(CRandomGenerator & rand)
 
 void CGObjectInstance::initObj(CRandomGenerator & rand)
 {
-	switch(ID.toEnum())
-	{
-	case Obj::TAVERN:
-		blockVisit = true;
-		break;
-	}
+	// no-op
 }
 
 void CGObjectInstance::setProperty( ObjProperty what, ObjPropertyID identifier )
@@ -191,6 +187,7 @@ void CGObjectInstance::setProperty( ObjProperty what, ObjPropertyID identifier )
 		tempOwner = identifier.as<PlayerColor>();
 		break;
 	case ObjProperty::BLOCKVIS:
+		// Never actually used in code, but possible in ERM
 		blockVisit = identifier.getNum();
 		break;
 	case ObjProperty::ID:
@@ -327,7 +324,14 @@ bool CGObjectInstance::isVisitable() const
 
 bool CGObjectInstance::isBlockedVisitable() const
 {
+	// TODO: Read from json
 	return blockVisit;
+}
+
+bool CGObjectInstance::isRemovable() const
+{
+	// TODO: Read from json
+	return removable;
 }
 
 bool CGObjectInstance::isCoastVisitable() const

--- a/lib/mapObjects/CGObjectInstance.h
+++ b/lib/mapObjects/CGObjectInstance.h
@@ -54,6 +54,7 @@ public:
 	int3 getSightCenter() const;
 	/// If true hero can visit this object only from neighbouring tiles and can't stand on this object
 	bool blockVisit;
+	bool removable;
 
 	PlayerColor getOwner() const override
 	{
@@ -84,6 +85,9 @@ public:
 
 	/// If true hero can visit this object only from neighbouring tiles and can't stand on this object
 	virtual bool isBlockedVisitable() const;
+
+	// If true, can be possibly removed from the map
+	virtual bool isRemovable() const;
 
 	/// If true this object can be visited by hero standing on the coast
 	virtual bool isCoastVisitable() const;
@@ -144,6 +148,7 @@ public:
 		h & id;
 		h & tempOwner;
 		h & blockVisit;
+		h & removable;
 		h & appearance;
 		//definfo is handled by map serializer
 	}

--- a/lib/rmg/RmgObject.cpp
+++ b/lib/rmg/RmgObject.cpp
@@ -275,7 +275,7 @@ const rmg::Area & Object::getBlockVisitableArea() const
 	if(dInstances.empty())
 		return dBlockVisitableCache;
 
-	for(const auto i : dInstances)
+	for(const auto & i : dInstances)
 	{
 		// FIXME: Account for blockvis objects with multiple visitable tiles
 		if (i.isBlockedVisitable())
@@ -290,7 +290,7 @@ const rmg::Area & Object::getRemovableArea() const
 	if(dInstances.empty())
 		return dRemovableAreaCache;
 
-	for(const auto i : dInstances)
+	for(const auto & i : dInstances)
 	{
 		if (i.isRemovable())
 			dRemovableAreaCache.unite(i.getBlockedArea());

--- a/lib/rmg/RmgObject.h
+++ b/lib/rmg/RmgObject.h
@@ -35,6 +35,7 @@ public:
 		
 		int3 getVisitablePosition() const;
 		bool isVisitableFrom(const int3 & tile) const;
+		bool isBlockedVisitable() const;
 		const Area & getAccessibleArea() const;
 		void setTemplate(TerrainId terrain, CRandomGenerator &); //cache invalidation
 		void setAnyTemplate(CRandomGenerator &); //cache invalidation
@@ -71,6 +72,7 @@ public:
 	
 	int3 getVisitablePosition() const;
 	const Area & getAccessibleArea(bool exceptLast = false) const;
+	const Area & getBlockVisitableArea() const;
 	
 	const int3 & getPosition() const;
 	void setPosition(const int3 & position);
@@ -83,12 +85,14 @@ public:
 	void setGuardedIfMonster(const Instance & object);
 	
 	void finalize(RmgMap & map, CRandomGenerator &);
+	void clearCachedArea() const;
 	void clear();
 	
 private:
 	std::list<Instance> dInstances;
 	mutable Area dFullAreaCache;
 	mutable Area dAccessibleAreaCache, dAccessibleAreaFullCache;
+	mutable Area dBlockVisitableCache;
 	int3 dPosition;
 	ui32 dStrength;
 	bool guarded;

--- a/lib/rmg/RmgObject.h
+++ b/lib/rmg/RmgObject.h
@@ -36,6 +36,7 @@ public:
 		int3 getVisitablePosition() const;
 		bool isVisitableFrom(const int3 & tile) const;
 		bool isBlockedVisitable() const;
+		bool isRemovable() const;
 		const Area & getAccessibleArea() const;
 		void setTemplate(TerrainId terrain, CRandomGenerator &); //cache invalidation
 		void setAnyTemplate(CRandomGenerator &); //cache invalidation
@@ -73,6 +74,8 @@ public:
 	int3 getVisitablePosition() const;
 	const Area & getAccessibleArea(bool exceptLast = false) const;
 	const Area & getBlockVisitableArea() const;
+	const Area & getRemovableArea() const;
+	const Area getEntrableArea() const;
 	
 	const int3 & getPosition() const;
 	void setPosition(const int3 & position);
@@ -93,6 +96,7 @@ private:
 	mutable Area dFullAreaCache;
 	mutable Area dAccessibleAreaCache, dAccessibleAreaFullCache;
 	mutable Area dBlockVisitableCache;
+	mutable Area dRemovableAreaCache;
 	int3 dPosition;
 	ui32 dStrength;
 	bool guarded;

--- a/lib/rmg/modificators/ObjectDistributor.cpp
+++ b/lib/rmg/modificators/ObjectDistributor.cpp
@@ -42,8 +42,6 @@ void ObjectDistributor::init()
 
 void ObjectDistributor::distributeLimitedObjects()
 {
-	//FIXME: Must be called after TerrainPainter::process()
-
 	ObjectInfo oi;
 	auto zones = map.getZones();
 
@@ -77,6 +75,8 @@ void ObjectDistributor::distributeLimitedObjects()
 
 					auto rmgInfo = handler->getRMGInfo();
 
+					// FIXME: Random order of distribution
+					RandomGeneratorUtil::randomShuffle(matchingZones, zone.getRand());
 					for (auto& zone : matchingZones)
 					{
 						oi.generateObject = [primaryID, secondaryID]() -> CGObjectInstance *

--- a/lib/rmg/modificators/ObjectManager.cpp
+++ b/lib/rmg/modificators/ObjectManager.cpp
@@ -666,14 +666,14 @@ bool ObjectManager::addGuard(rmg::Object & object, si32 strength, bool zoneGuard
 	
 	// Prefer non-blocking tiles, if any
 	auto entrableTiles = object.getEntrableArea().getTiles();
-	int3 entrableTile;
+	int3 entrableTile(-1, -1, -1);
 	if (entrableTiles.empty())
 	{
 		entrableTile = object.getVisitablePosition();
 	}
 	else
 	{
-		*RandomGeneratorUtil::nextItem(entrableTiles, zone.getRand());
+		entrableTile = *RandomGeneratorUtil::nextItem(entrableTiles, zone.getRand());
 	}
 
 	rmg::Area visitablePos({entrableTile});

--- a/lib/rmg/modificators/ObjectManager.cpp
+++ b/lib/rmg/modificators/ObjectManager.cpp
@@ -664,7 +664,19 @@ bool ObjectManager::addGuard(rmg::Object & object, si32 strength, bool zoneGuard
 	if(!guard)
 		return false;
 	
-	rmg::Area visitablePos({object.getVisitablePosition()});
+	// Prefer non-blocking tiles, if any
+	auto entrableTiles = object.getEntrableArea().getTiles();
+	int3 entrableTile;
+	if (entrableTiles.empty())
+	{
+		entrableTile = object.getVisitablePosition();
+	}
+	else
+	{
+		*RandomGeneratorUtil::nextItem(entrableTiles, zone.getRand());
+	}
+
+	rmg::Area visitablePos({entrableTile});
 	visitablePos.unite(visitablePos.getBorderOutside());
 	
 	auto accessibleArea = object.getAccessibleArea();

--- a/lib/rmg/modificators/ObjectManager.cpp
+++ b/lib/rmg/modificators/ObjectManager.cpp
@@ -546,8 +546,12 @@ void ObjectManager::placeObject(rmg::Object & object, bool guarded, bool updateD
 		objects.push_back(&instance->object());
 		if(auto * m = zone.getModificator<RoadPlacer>())
 		{
-			//FIXME: Objects that can be removed, can be trespassed. Does not include Corpse
-			if(instance->object().appearance->isVisitableFromTop())
+			if (instance->object().blockVisit && !instance->object().removable)
+			{
+				//Cannot be trespassed (Corpse)
+				continue;
+			}
+			else if(instance->object().appearance->isVisitableFromTop())
 				m->areaForRoads().add(instance->getVisitablePosition());
 			else
 			{

--- a/lib/rmg/modificators/RoadPlacer.cpp
+++ b/lib/rmg/modificators/RoadPlacer.cpp
@@ -85,7 +85,7 @@ bool RoadPlacer::createRoad(const int3 & dst)
 			{
 				if(areaIsolated().contains(dst) || areaIsolated().contains(src))
 				{
-					return 1e30;
+					return 1e12;
 				}
 			}
 			else

--- a/lib/rmg/modificators/TreasurePlacer.cpp
+++ b/lib/rmg/modificators/TreasurePlacer.cpp
@@ -676,7 +676,8 @@ rmg::Object TreasurePlacer::constructTreasurePile(const std::vector<ObjectInfo*>
 			auto instanceAccessibleArea = instance.getAccessibleArea();
 			if(instance.getBlockedArea().getTilesVector().size() == 1)
 			{
-				if(instance.object().appearance->isVisitableFromTop() && instance.object().ID != Obj::CORPSE)
+				//TOOD: Move hardcoded option to template
+				if(instance.object().appearance->isVisitableFromTop() && !instance.object().isBlockedVisitable())
 					instanceAccessibleArea.add(instance.getVisitablePosition());
 			}
 			
@@ -684,6 +685,9 @@ rmg::Object TreasurePlacer::constructTreasurePile(const std::vector<ObjectInfo*>
 			if(rmgObject.instances().size() == 1)
 				break;
 			
+			// TODO: Do not place blockvis objects so that they block access to existing accessible area
+			// Either object must be removable, or both must be accessible independently
+
 			//condition for good position
 			if(!blockedArea.overlap(instance.getBlockedArea()) && accessibleArea.overlap(instanceAccessibleArea))
 				break;

--- a/lib/rmg/modificators/TreasurePlacer.cpp
+++ b/lib/rmg/modificators/TreasurePlacer.cpp
@@ -836,13 +836,18 @@ void TreasurePlacer::createTreasures(ObjectManager& manager)
 
 			int value = std::accumulate(treasurePileInfos.begin(), treasurePileInfos.end(), 0, [](int v, const ObjectInfo* oi) {return v + oi->value; });
 
-			for (ui32 attempt = 0; attempt <= 2; attempt++)
+			const ui32 maxPileGenerationAttemps = 2;
+			for (ui32 attempt = 0; attempt <= maxPileGenerationAttemps; attempt++)
 			{
 				auto rmgObject = constructTreasurePile(treasurePileInfos, attempt == maxAttempts);
 
-				if (rmgObject.instances().empty()) //handle incorrect placement
+				if (rmgObject.instances().empty())
 				{
-					restoreZoneLimits(treasurePileInfos);
+					// Restore once if all attemps failed
+					if (attempt == (maxPileGenerationAttemps - 1))
+					{
+						restoreZoneLimits(treasurePileInfos);
+					}
 					continue;
 				}
 


### PR DESCRIPTION
- Moved blockVisit to object properties
- Added "removable" to object properties
- Updated object config accordingly

Actual fix for Corpse (blockVis and not removable):
- Do not place guard next to blockVis tile, if possible (so that some non-blocking object is accessible)
- Do not place two blockVis objects next to each other

Bonus fixes:

- Fixed randomly banning / exceeding cap of objects in zones. This could have severe side effects, too.
- Objects with limited per-map count will now be distributed among zones randomly

TODO:

- [x] Do not route road through Corpse
- [ ] Allow to change blockedVisitable per template (HoTA water object variants)