### PR TITLE
Remove allowed artifacts list from arthandler

### DIFF
--- a/lib/CArtHandler.cpp
+++ b/lib/CArtHandler.cpp
@@ -625,7 +625,7 @@ void CArtHandler::makeItCommanderArt(CArtifact * a, bool onlyCommander)
 		a->possibleSlots[ArtBearer::COMMANDER].push_back(ArtifactPosition(slot));
 }
 
-bool CArtHandler::legalArtifact(const ArtifactID & id)
+bool CArtHandler::legalArtifact(const ArtifactID & id) const
 {
 	auto art = id.toArtifact();
 	//assert ( (!art->constituents) || art->constituents->size() ); //artifacts is not combined or has some components
@@ -646,18 +646,6 @@ bool CArtHandler::legalArtifact(const ArtifactID & id)
 		return true;
 
 	return false;
-}
-
-void CArtHandler::initAllowedArtifactsList(const std::set<ArtifactID> & allowed)
-{
-	allowedArtifacts.clear();
-
-	for (ArtifactID i : allowed)
-	{
-		if (legalArtifact(ArtifactID(i)))
-			allowedArtifacts.push_back(i.toArtifact());
-			//keep im mind that artifact can be worn by more than one type of bearer
-	}
 }
 
 std::set<ArtifactID> CArtHandler::getDefaultAllowed() const

--- a/lib/CArtHandler.h
+++ b/lib/CArtHandler.h
@@ -141,15 +141,11 @@ public:
 class DLL_LINKAGE CArtHandler : public CHandlerBase<ArtifactID, Artifact, CArtifact, ArtifactService>
 {
 public:
-	/// List of artifacts allowed on the map
-	std::vector<const CArtifact *> allowedArtifacts;
-
 	void addBonuses(CArtifact *art, const JsonNode &bonusList);
 
 	static CArtifact::EartClass stringToClass(const std::string & className); //TODO: rework EartClass to make this a constructor
 
-	bool legalArtifact(const ArtifactID & id);
-	void initAllowedArtifactsList(const std::set<ArtifactID> & allowed);
+	bool legalArtifact(const ArtifactID & id) const;
 	static void makeItCreatureArt(CArtifact * a, bool onlyCreature = true);
 	static void makeItCommanderArt(CArtifact * a, bool onlyCommander = true);
 

--- a/lib/JsonRandom.cpp
+++ b/lib/JsonRandom.cpp
@@ -384,8 +384,9 @@ namespace JsonRandom
 	ArtifactID loadArtifact(const JsonNode & value, CRandomGenerator & rng, const Variables & variables)
 	{
 		std::set<ArtifactID> allowedArts;
-		for (auto const * artifact : VLC->arth->allowedArtifacts)
-			allowedArts.insert(artifact->getId());
+		for(const auto & artifact : VLC->arth->objects)
+			if (IObjectInterface::cb->isAllowed(artifact->getId()) && VLC->arth->legalArtifact(artifact->getId()))
+				allowedArts.insert(artifact->getId());
 
 		std::set<ArtifactID> potentialPicks = filterKeys(value, allowedArts, variables);
 

--- a/lib/gameState/CGameState.cpp
+++ b/lib/gameState/CGameState.cpp
@@ -195,7 +195,6 @@ void CGameState::init(const IMapService * mapService, StartInfo * si, Load::Prog
 		logGlobal->error("Wrong mode: %d", static_cast<int>(scenarioOps->mode));
 		return;
 	}
-	VLC->arth->initAllowedArtifactsList(map->allowedArtifact);
 	logGlobal->info("Map loaded!");
 
 	checkMapChecksum();
@@ -1947,8 +1946,13 @@ ArtifactID CGameState::pickRandomArtifact(CRandomGenerator & rand, int flags, st
 	std::set<ArtifactID> potentialPicks;
 
 	// Select artifacts that satisfy provided criterias
-	for (auto const * artifact : VLC->arth->allowedArtifacts)
+	for (auto const & artifactID : map->allowedArtifact)
 	{
+		if (!VLC->arth->legalArtifact(artifactID))
+			continue;
+
+		auto const * artifact = artifactID.toArtifact();
+
 		assert(artifact->aClass != CArtifact::ART_SPECIAL); // should be filtered out when allowedArtifacts is initialized
 
 		if ((flags & CArtifact::ART_TREASURE) == 0 && artifact->aClass == CArtifact::ART_TREASURE)


### PR DESCRIPTION
1. Handlers should not contain non-const game state data
2. This field was duplicating same field in CMap
3. Due to removal of VLC serialization, this field is not updated on map load leading to issues with artifact randomization

- Fixes #3293
- Fixes update of artifacts in Artifact Merchant in loaded saves