### PR TITLE
Change infoBarCreatureManagement setting: true by default

### DIFF
--- a/config/schemas/settings.json
+++ b/config/schemas/settings.json
@@ -615,7 +615,7 @@
 				},
 				"infoBarCreatureManagement": {
 					"type" : "boolean",
-					"default" : false
+					"default" : true
 				},
 				"enableLargeSpellbook" : {
 					"type": "boolean",


### PR DESCRIPTION
Since this does not block original function anymore when clicking something else than unit slot, i think it makes sense to turn this setting on by default