### PR TITLE
[launcher] select first language

### DIFF
--- a/launcher/mainwindow_moc.cpp
+++ b/launcher/mainwindow_moc.cpp
@@ -136,14 +136,14 @@ void MainWindow::detectPreferredLanguage()
 		for (auto const & vcmiLang : Languages::getLanguageList())
 			if (vcmiLang.tagIETF == userLang.toStdString())
 				selectedLanguage = vcmiLang.identifier;
-	}
 
-	logGlobal->info("Selected language: %s", selectedLanguage);
-
-	if (!selectedLanguage.empty())
-	{
-		Settings node = settings.write["general"]["language"];
-		node->String() = selectedLanguage;
+		if (!selectedLanguage.empty())
+		{
+			logGlobal->info("Selected language: %s", selectedLanguage);
+			Settings node = settings.write["general"]["language"];
+			node->String() = selectedLanguage;
+			return;
+		}
 	}
 }
 


### PR DESCRIPTION
fix language selection if multiple languages available.

Current problem:
```
INFO global [2a84] - Preferred language: de-DE
INFO global [2a84] - Preferred language: de
INFO global [2a84] - Preferred language: de-Latn-DE
INFO global [2a84] - Preferred language: en-US
INFO global [2a84] - Preferred language: en
INFO global [2a84] - Preferred language: en-Latn-US
INFO global [2a84] - Selected language: english
INFO global [2a84] - Loading translation 'english.qm'
```

https://doc.qt.io/qt-5/qlocale.html#uiLanguages
`The first item in the list is the most preferred one.`