### PR TITLE
Fix spellbook page flip animation

### DIFF
--- a/client/CVideoHandler.cpp
+++ b/client/CVideoHandler.cpp
@@ -637,7 +637,7 @@ bool CVideoPlayer::playVideo(int x, int y, bool stopOnKey)
 
 		SDL_Rect rect = CSDL_Ext::toSDL(pos);
 
-		SDL_RenderClear(mainRenderer);
+		SDL_RenderFillRect(mainRenderer, &rect);
 		SDL_RenderCopy(mainRenderer, texture, nullptr, &rect);
 		SDL_RenderPresent(mainRenderer);
 


### PR DESCRIPTION
Clear only part of screen covered by video, instead of entire screen turning black