### PR TITLE
No alt-tab console

### DIFF
--- a/client/adventureMap/CInGameConsole.cpp
+++ b/client/adventureMap/CInGameConsole.cpp
@@ -151,6 +151,9 @@ void CInGameConsole::keyPressed (EShortcut key)
 		break;
 
 	case EShortcut::GAME_ACTIVATE_CONSOLE:
+		if(GH.isKeyboardAltDown())
+			return; //QoL for alt-tab operating system shortcut
+
 		if(!enteredText.empty())
 			endEnteringText(false);
 		else


### PR DESCRIPTION
Do not trigger console when pressing alt and then tab to switch focus from VCMI another program. QoL improvement IMO