### PR TITLE
Change client's polling rate for server startup

### DIFF
--- a/client/CMT.cpp
+++ b/client/CMT.cpp
@@ -414,7 +414,7 @@ int main(int argc, char * argv[])
 	else
 	{
 		while(true)
-			boost::this_thread::sleep_for(boost::chrono::milliseconds(1000));
+			boost::this_thread::sleep_for(boost::chrono::milliseconds(200));
 	}
 
 	return 0;


### PR DESCRIPTION
Saw failed attempts in the past... instead of overfocusing this thing I am just changing to 200 ms. Should not explode anything while being somewhat more responsive when server loads up in 1.3 or 2.1 sec