### PR TITLE
Battle stacks informations

### DIFF
--- a/Mods/vcmi/config/vcmi/english.json
+++ b/Mods/vcmi/config/vcmi/english.json
@@ -181,6 +181,7 @@
 	"vcmi.battleWindow.damageEstimation.damage.1" : "%d damage",
 	"vcmi.battleWindow.damageEstimation.kills" : "%d will perish",
 	"vcmi.battleWindow.damageEstimation.kills.1" : "%d will perish",
+	"vcmi.battleWindow.killed" : "Killed",
 
 	"vcmi.battleResultsWindow.applyResultsLabel" : "Apply battle result",
 

--- a/Mods/vcmi/config/vcmi/german.json
+++ b/Mods/vcmi/config/vcmi/german.json
@@ -180,6 +180,7 @@
 	"vcmi.battleWindow.damageEstimation.damage.1" : "%d Schaden",
 	"vcmi.battleWindow.damageEstimation.kills" : "%d werden verenden",
 	"vcmi.battleWindow.damageEstimation.kills.1" : "%d werden verenden",
+	"vcmi.battleWindow.killed" : "Getötet",
 
 	"vcmi.battleResultsWindow.applyResultsLabel" : "Kampfergebnis übernehmen",
 

--- a/client/battle/BattleActionsController.cpp
+++ b/client/battle/BattleActionsController.cpp
@@ -864,8 +864,6 @@ void BattleActionsController::onHoverEnded()
 
 void BattleActionsController::onHexLeftClicked(BattleHex clickedHex)
 {
-	owner.stacksController->updateHoveredStacks(true);
-
 	if (owner.stacksController->getActiveStack() == nullptr)
 		return;
 
@@ -996,8 +994,6 @@ void BattleActionsController::activateStack()
 
 void BattleActionsController::onHexRightClicked(BattleHex clickedHex)
 {
-	owner.stacksController->updateHoveredStacks(true);
-
 	auto spellcastActionPredicate = [](PossiblePlayerBattleAction & action)
 	{
 		return action.spellcast();

--- a/client/battle/BattleActionsController.cpp
+++ b/client/battle/BattleActionsController.cpp
@@ -864,6 +864,8 @@ void BattleActionsController::onHoverEnded()
 
 void BattleActionsController::onHexLeftClicked(BattleHex clickedHex)
 {
+	owner.stacksController->updateHoveredStacks(true);
+
 	if (owner.stacksController->getActiveStack() == nullptr)
 		return;
 
@@ -994,6 +996,8 @@ void BattleActionsController::activateStack()
 
 void BattleActionsController::onHexRightClicked(BattleHex clickedHex)
 {
+	owner.stacksController->updateHoveredStacks(true);
+
 	auto spellcastActionPredicate = [](PossiblePlayerBattleAction & action)
 	{
 		return action.spellcast();

--- a/client/battle/BattleInterfaceClasses.cpp
+++ b/client/battle/BattleInterfaceClasses.cpp
@@ -504,7 +504,7 @@ void StackInfoBasicPanel::initializeData(const CStack * stack)
 	icons.push_back(std::make_shared<CAnimImage>(AnimationPath::builtin("ILCK22"), luck + 3, 0, 47, 143));
 
 	//extra information
-	labels.push_back(std::make_shared<CLabel>(9, 168, EFonts::FONT_TINY, ETextAlignment::TOPLEFT, Colors::WHITE, std::string("Killed") + ":"));
+	labels.push_back(std::make_shared<CLabel>(9, 168, EFonts::FONT_TINY, ETextAlignment::TOPLEFT, Colors::WHITE, VLC->generaltexth->translate("vcmi.battleWindow.killed") + ":"));
 	labels.push_back(std::make_shared<CLabel>(9, 180, EFonts::FONT_TINY, ETextAlignment::TOPLEFT, Colors::WHITE, CGI->generaltexth->allTexts[389] + ":"));
 
 	labels.push_back(std::make_shared<CLabel>(69, 180, EFonts::FONT_TINY, ETextAlignment::BOTTOMRIGHT, Colors::WHITE, std::to_string(killed)));
@@ -531,7 +531,8 @@ void StackInfoBasicPanel::initializeData(const CStack * stack)
 			int duration = stack->getBonusLocalFirst(Selector::source(BonusSource::SPELL_EFFECT, BonusSourceID(effect)))->turnsRemain;
 
 			icons.push_back(std::make_shared<CAnimImage>(AnimationPath::builtin("SpellInt"), effect + 1, 0, firstPos.x + offset.x * printed, firstPos.y + offset.y * printed));
-			labels.push_back(std::make_shared<CLabel>(firstPos.x + offset.x * printed + 46, firstPos.y + offset.y * printed + 36, EFonts::FONT_TINY, ETextAlignment::BOTTOMRIGHT, Colors::WHITE, std::to_string(duration)));
+			if(settings["general"]["enableUiEnhancements"].Bool())
+				labels.push_back(std::make_shared<CLabel>(firstPos.x + offset.x * printed + 46, firstPos.y + offset.y * printed + 36, EFonts::FONT_TINY, ETextAlignment::BOTTOMRIGHT, Colors::WHITE, std::to_string(duration)));
 			if(++printed >= 3 || (printed == 2 && spells.size() > 3)) // interface limit reached
 				break;
 		}
@@ -540,7 +541,7 @@ void StackInfoBasicPanel::initializeData(const CStack * stack)
 	if(spells.size() == 0)
 		labelsMultiline.push_back(std::make_shared<CMultiLineLabel>(Rect(firstPos.x, firstPos.y, 48, 36), EFonts::FONT_TINY, ETextAlignment::CENTER, Colors::WHITE, CGI->generaltexth->allTexts[674]));
 	if(spells.size() > 3)
-		labelsMultiline.push_back(std::make_shared<CMultiLineLabel>(Rect(firstPos.x + offset.x * 2, firstPos.y + offset.y * 2 - 5, 48, 36), EFonts::FONT_MEDIUM, ETextAlignment::CENTER, Colors::WHITE, "..."));
+		labelsMultiline.push_back(std::make_shared<CMultiLineLabel>(Rect(firstPos.x + offset.x * 2, firstPos.y + offset.y * 2 - 4, 48, 36), EFonts::FONT_MEDIUM, ETextAlignment::CENTER, Colors::WHITE, "..."));
 }
 
 void StackInfoBasicPanel::update(const CStack * updatedInfo)

--- a/client/battle/BattleInterfaceClasses.cpp
+++ b/client/battle/BattleInterfaceClasses.cpp
@@ -447,7 +447,7 @@ void HeroInfoBasicPanel::show(Canvas & to)
 }
 
 
-ArmyInfoBasicPanel::ArmyInfoBasicPanel(const InfoAboutArmy & army, Point * position, bool initializeBackground)
+StackInfoBasicPanel::StackInfoBasicPanel(const CStack * stack, Point * position, bool initializeBackground)
 	: CIntObject(0)
 {
 	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
@@ -458,18 +458,50 @@ ArmyInfoBasicPanel::ArmyInfoBasicPanel(const InfoAboutArmy & army, Point * posit
 	{
 		background = std::make_shared<CPicture>(ImagePath::builtin("CHRPOP"));
 		background->getSurface()->setBlitMode(EImageBlitMode::OPAQUE);
-		background->colorize(army.owner);
+		background->colorize(stack->getOwner());
 	}
 
-	initializeData(army);
+	initializeData(stack);
 }
 
-void ArmyInfoBasicPanel::initializeData(const InfoAboutArmy & army)
+void StackInfoBasicPanel::initializeData(const CStack * stack)
 {
 	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
+	/*auto attack = hero.details->primskills[0];
+	auto defense = hero.details->primskills[1];
+	auto power = hero.details->primskills[2];
+	auto knowledge = hero.details->primskills[3];
+	auto morale = hero.details->morale;
+	auto luck = hero.details->luck;
+	auto currentSpellPoints = hero.details->mana;
+	auto maxSpellPoints = hero.details->manaLimit;
+
+	icons.push_back(std::make_shared<CAnimImage>(AnimationPath::builtin("PortraitsLarge"), hero.getIconIndex(), 0, 10, 6));
+
+	//primary stats
+	labels.push_back(std::make_shared<CLabel>(9, 75, EFonts::FONT_TINY, ETextAlignment::TOPLEFT, Colors::WHITE, CGI->generaltexth->allTexts[380] + ":"));
+	labels.push_back(std::make_shared<CLabel>(9, 87, EFonts::FONT_TINY, ETextAlignment::TOPLEFT, Colors::WHITE, CGI->generaltexth->allTexts[381] + ":"));
+	labels.push_back(std::make_shared<CLabel>(9, 99, EFonts::FONT_TINY, ETextAlignment::TOPLEFT, Colors::WHITE, CGI->generaltexth->allTexts[382] + ":"));
+	labels.push_back(std::make_shared<CLabel>(9, 111, EFonts::FONT_TINY, ETextAlignment::TOPLEFT, Colors::WHITE, CGI->generaltexth->allTexts[383] + ":"));
+
+	labels.push_back(std::make_shared<CLabel>(69, 87, EFonts::FONT_TINY, ETextAlignment::BOTTOMRIGHT, Colors::WHITE, std::to_string(attack)));
+	labels.push_back(std::make_shared<CLabel>(69, 99, EFonts::FONT_TINY, ETextAlignment::BOTTOMRIGHT, Colors::WHITE, std::to_string(defense)));
+	labels.push_back(std::make_shared<CLabel>(69, 111, EFonts::FONT_TINY, ETextAlignment::BOTTOMRIGHT, Colors::WHITE, std::to_string(power)));
+	labels.push_back(std::make_shared<CLabel>(69, 123, EFonts::FONT_TINY, ETextAlignment::BOTTOMRIGHT, Colors::WHITE, std::to_string(knowledge)));
+
+	//morale+luck
+	labels.push_back(std::make_shared<CLabel>(9, 131, EFonts::FONT_TINY, ETextAlignment::TOPLEFT, Colors::WHITE, CGI->generaltexth->allTexts[384] + ":"));
+	labels.push_back(std::make_shared<CLabel>(9, 143, EFonts::FONT_TINY, ETextAlignment::TOPLEFT, Colors::WHITE, CGI->generaltexth->allTexts[385] + ":"));
+
+	icons.push_back(std::make_shared<CAnimImage>(AnimationPath::builtin("IMRL22"), morale + 3, 0, 47, 131));
+	icons.push_back(std::make_shared<CAnimImage>(AnimationPath::builtin("ILCK22"), luck + 3, 0, 47, 143));
+
+	//spell points
+	labels.push_back(std::make_shared<CLabel>(39, 174, EFonts::FONT_TINY, ETextAlignment::CENTER, Colors::WHITE, CGI->generaltexth->allTexts[387]));
+	labels.push_back(std::make_shared<CLabel>(39, 186, EFonts::FONT_TINY, ETextAlignment::CENTER, Colors::WHITE, std::to_string(currentSpellPoints) + "/" + std::to_string(maxSpellPoints)));*/
 }
 
-void ArmyInfoBasicPanel::update(const InfoAboutArmy & updatedInfo)
+void StackInfoBasicPanel::update(const CStack * updatedInfo)
 {
 	icons.clear();
 	labels.clear();
@@ -477,7 +509,7 @@ void ArmyInfoBasicPanel::update(const InfoAboutArmy & updatedInfo)
 	initializeData(updatedInfo);
 }
 
-void ArmyInfoBasicPanel::show(Canvas & to)
+void StackInfoBasicPanel::show(Canvas & to)
 {
 	showAll(to);
 	CIntObject::show(to);

--- a/client/battle/BattleInterfaceClasses.cpp
+++ b/client/battle/BattleInterfaceClasses.cpp
@@ -478,12 +478,12 @@ void StackInfoBasicPanel::initializeData(const CStack * stack)
 	auto attack = std::to_string(CGI->creatures()->getByIndex(stack->creatureIndex())->getAttack(stack->isShooter())) + "(" + std::to_string(stack->getAttack(stack->isShooter())) + ")";
 	auto defense = std::to_string(CGI->creatures()->getByIndex(stack->creatureIndex())->getDefense(stack->isShooter())) + "(" + std::to_string(stack->getDefense(stack->isShooter())) + ")";
 	auto damage = std::to_string(CGI->creatures()->getByIndex(stack->creatureIndex())->getMinDamage(stack->isShooter())) + "-" + std::to_string(stack->getMaxDamage(stack->isShooter()));
-	auto health = std::to_string(CGI->creatures()->getByIndex(stack->creatureIndex())->getMaxHealth());
+	auto health = CGI->creatures()->getByIndex(stack->creatureIndex())->getMaxHealth();
 	auto morale = stack->moraleVal();
 	auto luck = stack->luckVal();
 
 	auto killed = stack->getKilled();
-	auto healthRemaining = TextOperations::formatMetric(stack->getAvailableHealth(), 4);
+	auto healthRemaining = TextOperations::formatMetric(stack->getAvailableHealth() - (stack->getCount() - 1) * health, 4);
 
 	//primary stats*/
 	labels.push_back(std::make_shared<CLabel>(9, 75, EFonts::FONT_TINY, ETextAlignment::TOPLEFT, Colors::WHITE, CGI->generaltexth->allTexts[380] + ":"));
@@ -494,7 +494,7 @@ void StackInfoBasicPanel::initializeData(const CStack * stack)
 	labels.push_back(std::make_shared<CLabel>(69, 87, EFonts::FONT_TINY, ETextAlignment::BOTTOMRIGHT, Colors::WHITE, attack));
 	labels.push_back(std::make_shared<CLabel>(69, 99, EFonts::FONT_TINY, ETextAlignment::BOTTOMRIGHT, Colors::WHITE, defense));
 	labels.push_back(std::make_shared<CLabel>(69, 111, EFonts::FONT_TINY, ETextAlignment::BOTTOMRIGHT, Colors::WHITE, damage));
-	labels.push_back(std::make_shared<CLabel>(69, 123, EFonts::FONT_TINY, ETextAlignment::BOTTOMRIGHT, Colors::WHITE, health));
+	labels.push_back(std::make_shared<CLabel>(69, 123, EFonts::FONT_TINY, ETextAlignment::BOTTOMRIGHT, Colors::WHITE, std::to_string(health)));
 
 	//morale+luck
 	labels.push_back(std::make_shared<CLabel>(9, 131, EFonts::FONT_TINY, ETextAlignment::TOPLEFT, Colors::WHITE, CGI->generaltexth->allTexts[384] + ":"));
@@ -505,16 +505,49 @@ void StackInfoBasicPanel::initializeData(const CStack * stack)
 
 	//extra information
 	labels.push_back(std::make_shared<CLabel>(9, 168, EFonts::FONT_TINY, ETextAlignment::TOPLEFT, Colors::WHITE, std::string("Killed") + ":"));
-	labels.push_back(std::make_shared<CLabel>(9, 180, EFonts::FONT_TINY, ETextAlignment::TOPLEFT, Colors::WHITE, std::string("Rem He") + ":"));
+	labels.push_back(std::make_shared<CLabel>(9, 180, EFonts::FONT_TINY, ETextAlignment::TOPLEFT, Colors::WHITE, CGI->generaltexth->allTexts[389] + ":"));
 
 	labels.push_back(std::make_shared<CLabel>(69, 180, EFonts::FONT_TINY, ETextAlignment::BOTTOMRIGHT, Colors::WHITE, std::to_string(killed)));
 	labels.push_back(std::make_shared<CLabel>(69, 192, EFonts::FONT_TINY, ETextAlignment::BOTTOMRIGHT, Colors::WHITE, healthRemaining));
+
+	//spells
+	static const Point firstPos(15, 206); // position of 1st spell box
+	static const Point offset(0, 38);  // offset of each spell box from previous
+
+	for(int i = 0; i < 3; i++)
+		icons.push_back(std::make_shared<CAnimImage>(AnimationPath::builtin("SpellInt"), 78, 0, firstPos.x + offset.x * i, firstPos.y + offset.y * i));
+
+	int printed=0; //how many effect pics have been printed
+	std::vector<SpellID> spells = stack->activeSpells();
+	for(SpellID effect : spells)
+	{
+		//not all effects have graphics (for eg. Acid Breath)
+		//for modded spells iconEffect is added to SpellInt.def
+		const bool hasGraphics = (effect < SpellID::THUNDERBOLT) || (effect >= SpellID::AFTER_LAST);
+
+		if (hasGraphics)
+		{
+			//FIXME: support permanent duration
+			int duration = stack->getBonusLocalFirst(Selector::source(BonusSource::SPELL_EFFECT, BonusSourceID(effect)))->turnsRemain;
+
+			icons.push_back(std::make_shared<CAnimImage>(AnimationPath::builtin("SpellInt"), effect + 1, 0, firstPos.x + offset.x * printed, firstPos.y + offset.y * printed));
+			labels.push_back(std::make_shared<CLabel>(firstPos.x + offset.x * printed + 46, firstPos.y + offset.y * printed + 36, EFonts::FONT_TINY, ETextAlignment::BOTTOMRIGHT, Colors::WHITE, std::to_string(duration)));
+			if(++printed >= 3 || (printed == 2 && spells.size() > 3)) // interface limit reached
+				break;
+		}
+	}
+
+	if(spells.size() == 0)
+		labelsMultiline.push_back(std::make_shared<CMultiLineLabel>(Rect(firstPos.x, firstPos.y, 48, 36), EFonts::FONT_TINY, ETextAlignment::CENTER, Colors::WHITE, CGI->generaltexth->allTexts[674]));
+	if(spells.size() > 3)
+		labelsMultiline.push_back(std::make_shared<CMultiLineLabel>(Rect(firstPos.x + offset.x * 2, firstPos.y + offset.y * 2 - 5, 48, 36), EFonts::FONT_MEDIUM, ETextAlignment::CENTER, Colors::WHITE, "..."));
 }
 
 void StackInfoBasicPanel::update(const CStack * updatedInfo)
 {
 	icons.clear();
 	labels.clear();
+	labelsMultiline.clear();
 
 	initializeData(updatedInfo);
 }

--- a/client/battle/BattleInterfaceClasses.cpp
+++ b/client/battle/BattleInterfaceClasses.cpp
@@ -456,9 +456,13 @@ StackInfoBasicPanel::StackInfoBasicPanel(const CStack * stack, Point * position,
 
 	if(initializeBackground)
 	{
-		background = std::make_shared<CPicture>(ImagePath::builtin("CHRPOP"));
+		background = std::make_shared<CPicture>(ImagePath::builtin("CCRPOP"));
+		background->pos.y += 37;
 		background->getSurface()->setBlitMode(EImageBlitMode::OPAQUE);
 		background->colorize(stack->getOwner());
+		background2 = std::make_shared<CPicture>(ImagePath::builtin("CHRPOP"));
+		background2->getSurface()->setBlitMode(EImageBlitMode::OPAQUE);
+		background2->colorize(stack->getOwner());
 	}
 
 	initializeData(stack);

--- a/client/battle/BattleInterfaceClasses.cpp
+++ b/client/battle/BattleInterfaceClasses.cpp
@@ -483,7 +483,7 @@ void StackInfoBasicPanel::initializeData(const CStack * stack)
 	auto luck = stack->luckVal();
 
 	auto killed = stack->getKilled();
-	auto healthRemaining = TextOperations::formatMetric(stack->getAvailableHealth() - (stack->getCount() - 1) * health, 4);
+	auto healthRemaining = TextOperations::formatMetric(std::max(stack->getAvailableHealth() - (stack->getCount() - 1) * health, (si64)0), 4);
 
 	//primary stats*/
 	labels.push_back(std::make_shared<CLabel>(9, 75, EFonts::FONT_TINY, ETextAlignment::TOPLEFT, Colors::WHITE, CGI->generaltexth->allTexts[380] + ":"));

--- a/client/battle/BattleInterfaceClasses.cpp
+++ b/client/battle/BattleInterfaceClasses.cpp
@@ -467,27 +467,30 @@ StackInfoBasicPanel::StackInfoBasicPanel(const CStack * stack, Point * position,
 void StackInfoBasicPanel::initializeData(const CStack * stack)
 {
 	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
-	/*auto attack = hero.details->primskills[0];
-	auto defense = hero.details->primskills[1];
-	auto power = hero.details->primskills[2];
-	auto knowledge = hero.details->primskills[3];
-	auto morale = hero.details->morale;
-	auto luck = hero.details->luck;
-	auto currentSpellPoints = hero.details->mana;
-	auto maxSpellPoints = hero.details->manaLimit;
 
-	icons.push_back(std::make_shared<CAnimImage>(AnimationPath::builtin("PortraitsLarge"), hero.getIconIndex(), 0, 10, 6));
+	icons.push_back(std::make_shared<CAnimImage>(AnimationPath::builtin("TWCRPORT"), stack->creatureId() + 2, 0, 10, 6));
+	labels.push_back(std::make_shared<CLabel>(10 + 58, 6 + 64, FONT_MEDIUM, ETextAlignment::BOTTOMRIGHT, Colors::WHITE, TextOperations::formatMetric(stack->getCount(), 4)));
 
-	//primary stats
+	auto attack = std::to_string(CGI->creatures()->getByIndex(stack->creatureIndex())->getAttack(stack->isShooter())) + "(" + std::to_string(stack->getAttack(stack->isShooter())) + ")";
+	auto defense = std::to_string(CGI->creatures()->getByIndex(stack->creatureIndex())->getDefense(stack->isShooter())) + "(" + std::to_string(stack->getDefense(stack->isShooter())) + ")";
+	auto damage = std::to_string(CGI->creatures()->getByIndex(stack->creatureIndex())->getMinDamage(stack->isShooter())) + "-" + std::to_string(stack->getMaxDamage(stack->isShooter()));
+	auto health = std::to_string(CGI->creatures()->getByIndex(stack->creatureIndex())->getMaxHealth());
+	auto morale = stack->moraleVal();
+	auto luck = stack->luckVal();
+
+	auto killed = stack->getKilled();
+	auto healthRemaining = TextOperations::formatMetric(stack->getAvailableHealth(), 4);
+
+	//primary stats*/
 	labels.push_back(std::make_shared<CLabel>(9, 75, EFonts::FONT_TINY, ETextAlignment::TOPLEFT, Colors::WHITE, CGI->generaltexth->allTexts[380] + ":"));
 	labels.push_back(std::make_shared<CLabel>(9, 87, EFonts::FONT_TINY, ETextAlignment::TOPLEFT, Colors::WHITE, CGI->generaltexth->allTexts[381] + ":"));
-	labels.push_back(std::make_shared<CLabel>(9, 99, EFonts::FONT_TINY, ETextAlignment::TOPLEFT, Colors::WHITE, CGI->generaltexth->allTexts[382] + ":"));
-	labels.push_back(std::make_shared<CLabel>(9, 111, EFonts::FONT_TINY, ETextAlignment::TOPLEFT, Colors::WHITE, CGI->generaltexth->allTexts[383] + ":"));
+	labels.push_back(std::make_shared<CLabel>(9, 99, EFonts::FONT_TINY, ETextAlignment::TOPLEFT, Colors::WHITE, CGI->generaltexth->allTexts[386] + ":"));
+	labels.push_back(std::make_shared<CLabel>(9, 111, EFonts::FONT_TINY, ETextAlignment::TOPLEFT, Colors::WHITE, CGI->generaltexth->allTexts[389] + ":"));
 
-	labels.push_back(std::make_shared<CLabel>(69, 87, EFonts::FONT_TINY, ETextAlignment::BOTTOMRIGHT, Colors::WHITE, std::to_string(attack)));
-	labels.push_back(std::make_shared<CLabel>(69, 99, EFonts::FONT_TINY, ETextAlignment::BOTTOMRIGHT, Colors::WHITE, std::to_string(defense)));
-	labels.push_back(std::make_shared<CLabel>(69, 111, EFonts::FONT_TINY, ETextAlignment::BOTTOMRIGHT, Colors::WHITE, std::to_string(power)));
-	labels.push_back(std::make_shared<CLabel>(69, 123, EFonts::FONT_TINY, ETextAlignment::BOTTOMRIGHT, Colors::WHITE, std::to_string(knowledge)));
+	labels.push_back(std::make_shared<CLabel>(69, 87, EFonts::FONT_TINY, ETextAlignment::BOTTOMRIGHT, Colors::WHITE, attack));
+	labels.push_back(std::make_shared<CLabel>(69, 99, EFonts::FONT_TINY, ETextAlignment::BOTTOMRIGHT, Colors::WHITE, defense));
+	labels.push_back(std::make_shared<CLabel>(69, 111, EFonts::FONT_TINY, ETextAlignment::BOTTOMRIGHT, Colors::WHITE, damage));
+	labels.push_back(std::make_shared<CLabel>(69, 123, EFonts::FONT_TINY, ETextAlignment::BOTTOMRIGHT, Colors::WHITE, health));
 
 	//morale+luck
 	labels.push_back(std::make_shared<CLabel>(9, 131, EFonts::FONT_TINY, ETextAlignment::TOPLEFT, Colors::WHITE, CGI->generaltexth->allTexts[384] + ":"));
@@ -496,9 +499,12 @@ void StackInfoBasicPanel::initializeData(const CStack * stack)
 	icons.push_back(std::make_shared<CAnimImage>(AnimationPath::builtin("IMRL22"), morale + 3, 0, 47, 131));
 	icons.push_back(std::make_shared<CAnimImage>(AnimationPath::builtin("ILCK22"), luck + 3, 0, 47, 143));
 
-	//spell points
-	labels.push_back(std::make_shared<CLabel>(39, 174, EFonts::FONT_TINY, ETextAlignment::CENTER, Colors::WHITE, CGI->generaltexth->allTexts[387]));
-	labels.push_back(std::make_shared<CLabel>(39, 186, EFonts::FONT_TINY, ETextAlignment::CENTER, Colors::WHITE, std::to_string(currentSpellPoints) + "/" + std::to_string(maxSpellPoints)));*/
+	//extra information
+	labels.push_back(std::make_shared<CLabel>(9, 168, EFonts::FONT_TINY, ETextAlignment::TOPLEFT, Colors::WHITE, std::string("Killed") + ":"));
+	labels.push_back(std::make_shared<CLabel>(9, 180, EFonts::FONT_TINY, ETextAlignment::TOPLEFT, Colors::WHITE, std::string("Rem He") + ":"));
+
+	labels.push_back(std::make_shared<CLabel>(69, 180, EFonts::FONT_TINY, ETextAlignment::BOTTOMRIGHT, Colors::WHITE, std::to_string(killed)));
+	labels.push_back(std::make_shared<CLabel>(69, 192, EFonts::FONT_TINY, ETextAlignment::BOTTOMRIGHT, Colors::WHITE, healthRemaining));
 }
 
 void StackInfoBasicPanel::update(const CStack * updatedInfo)

--- a/client/battle/BattleInterfaceClasses.cpp
+++ b/client/battle/BattleInterfaceClasses.cpp
@@ -446,6 +446,43 @@ void HeroInfoBasicPanel::show(Canvas & to)
 	CIntObject::show(to);
 }
 
+
+ArmyInfoBasicPanel::ArmyInfoBasicPanel(const InfoAboutArmy & army, Point * position, bool initializeBackground)
+	: CIntObject(0)
+{
+	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	if (position != nullptr)
+		moveTo(*position);
+
+	if(initializeBackground)
+	{
+		background = std::make_shared<CPicture>(ImagePath::builtin("CHRPOP"));
+		background->getSurface()->setBlitMode(EImageBlitMode::OPAQUE);
+		background->colorize(army.owner);
+	}
+
+	initializeData(army);
+}
+
+void ArmyInfoBasicPanel::initializeData(const InfoAboutArmy & army)
+{
+	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
+}
+
+void ArmyInfoBasicPanel::update(const InfoAboutArmy & updatedInfo)
+{
+	icons.clear();
+	labels.clear();
+
+	initializeData(updatedInfo);
+}
+
+void ArmyInfoBasicPanel::show(Canvas & to)
+{
+	showAll(to);
+	CIntObject::show(to);
+}
+
 HeroInfoWindow::HeroInfoWindow(const InfoAboutHero & hero, Point * position)
 	: CWindowObject(RCLICK_POPUP | SHADOW_DISABLED, ImagePath::builtin("CHRPOP"))
 {

--- a/client/battle/BattleInterfaceClasses.h
+++ b/client/battle/BattleInterfaceClasses.h
@@ -20,6 +20,7 @@ VCMI_LIB_NAMESPACE_BEGIN
 class CGHeroInstance;
 struct BattleResult;
 struct InfoAboutHero;
+struct InfoAboutArmy;
 class CStack;
 
 namespace battle
@@ -142,6 +143,21 @@ public:
 
 	void initializeData(const InfoAboutHero & hero);
 	void update(const InfoAboutHero & updatedInfo);
+};
+
+class ArmyInfoBasicPanel : public CIntObject
+{
+private:
+	std::shared_ptr<CPicture> background;
+	std::vector<std::shared_ptr<CLabel>> labels;
+	std::vector<std::shared_ptr<CAnimImage>> icons;
+public:
+	ArmyInfoBasicPanel(const InfoAboutArmy & army, Point * position, bool initializeBackground = true);
+
+	void show(Canvas & to) override;
+
+	void initializeData(const InfoAboutArmy & army);
+	void update(const InfoAboutArmy & updatedInfo);
 };
 
 class HeroInfoWindow : public CWindowObject

--- a/client/battle/BattleInterfaceClasses.h
+++ b/client/battle/BattleInterfaceClasses.h
@@ -148,6 +148,7 @@ class StackInfoBasicPanel : public CIntObject
 {
 private:
 	std::shared_ptr<CPicture> background;
+	std::shared_ptr<CPicture> background2;
 	std::vector<std::shared_ptr<CLabel>> labels;
 	std::vector<std::shared_ptr<CAnimImage>> icons;
 public:

--- a/client/battle/BattleInterfaceClasses.h
+++ b/client/battle/BattleInterfaceClasses.h
@@ -20,7 +20,6 @@ VCMI_LIB_NAMESPACE_BEGIN
 class CGHeroInstance;
 struct BattleResult;
 struct InfoAboutHero;
-struct InfoAboutArmy;
 class CStack;
 
 namespace battle
@@ -145,19 +144,19 @@ public:
 	void update(const InfoAboutHero & updatedInfo);
 };
 
-class ArmyInfoBasicPanel : public CIntObject
+class StackInfoBasicPanel : public CIntObject
 {
 private:
 	std::shared_ptr<CPicture> background;
 	std::vector<std::shared_ptr<CLabel>> labels;
 	std::vector<std::shared_ptr<CAnimImage>> icons;
 public:
-	ArmyInfoBasicPanel(const InfoAboutArmy & army, Point * position, bool initializeBackground = true);
+	StackInfoBasicPanel(const CStack * stack, Point * position, bool initializeBackground = true);
 
 	void show(Canvas & to) override;
 
-	void initializeData(const InfoAboutArmy & army);
-	void update(const InfoAboutArmy & updatedInfo);
+	void initializeData(const CStack * stack);
+	void update(const CStack * updatedInfo);
 };
 
 class HeroInfoWindow : public CWindowObject

--- a/client/battle/BattleInterfaceClasses.h
+++ b/client/battle/BattleInterfaceClasses.h
@@ -37,6 +37,7 @@ class CFilledTexture;
 class CButton;
 class CToggleButton;
 class CLabel;
+class CMultiLineLabel;
 class CTextBox;
 class CAnimImage;
 class CPlayerInterface;
@@ -150,6 +151,7 @@ private:
 	std::shared_ptr<CPicture> background;
 	std::shared_ptr<CPicture> background2;
 	std::vector<std::shared_ptr<CLabel>> labels;
+	std::vector<std::shared_ptr<CMultiLineLabel>> labelsMultiline;
 	std::vector<std::shared_ptr<CAnimImage>> icons;
 public:
 	StackInfoBasicPanel(const CStack * stack, Point * position, bool initializeBackground = true);

--- a/client/battle/BattleStacksController.cpp
+++ b/client/battle/BattleStacksController.cpp
@@ -816,7 +816,10 @@ void BattleStacksController::updateHoveredStacks()
 			continue;
 
 		if (stack == activeStack)
+		{
+			owner.windowObject->updateStackInfoWindow(stack);
 			stackAnimation[stack->unitId()]->setBorderColor(AnimationControls::getGoldBorder());
+		}
 		else
 			stackAnimation[stack->unitId()]->setBorderColor(AnimationControls::getNoBorder());
 	}

--- a/client/battle/BattleStacksController.cpp
+++ b/client/battle/BattleStacksController.cpp
@@ -26,6 +26,7 @@
 #include "../CMusicHandler.h"
 #include "../CGameInfo.h"
 #include "../gui/CGuiHandler.h"
+#include "../gui/WindowHandler.h"
 #include "../render/Colors.h"
 #include "../render/Canvas.h"
 #include "../render/IRenderHandler.h"
@@ -346,7 +347,7 @@ void BattleStacksController::showStack(Canvas & canvas, const CStack * stack)
 
 void BattleStacksController::tick(uint32_t msPassed)
 {
-	updateHoveredStacks(false);
+	updateHoveredStacks();
 	updateBattleAnimations(msPassed);
 }
 
@@ -806,11 +807,11 @@ void BattleStacksController::removeExpiredColorFilters()
 	});
 }
 
-void BattleStacksController::updateHoveredStacks(bool clear)
+void BattleStacksController::updateHoveredStacks()
 {
 	auto newStacks = selectHoveredStacks();
 
-	if(clear)
+	if(newStacks.size() == 0)
 		owner.windowObject->updateStackInfoWindow(nullptr);
 
 	for(const auto * stack : mouseHoveredStacks)
@@ -818,7 +819,6 @@ void BattleStacksController::updateHoveredStacks(bool clear)
 		if (vstd::contains(newStacks, stack))
 			continue;
 
-		owner.windowObject->updateStackInfoWindow(nullptr);
 		if (stack == activeStack)
 			stackAnimation[stack->unitId()]->setBorderColor(AnimationControls::getGoldBorder());
 		else
@@ -835,6 +835,9 @@ void BattleStacksController::updateHoveredStacks(bool clear)
 		if (stackAnimation[stack->unitId()]->framesInGroup(ECreatureAnimType::MOUSEON) > 0 && stack->alive() && !stack->isFrozen())
 			stackAnimation[stack->unitId()]->playOnce(ECreatureAnimType::MOUSEON);
 	}
+
+	if(mouseHoveredStacks != newStacks)
+		GH.windows().totalRedraw(); //fix for frozen stack info window and blue border in action bar
 
 	mouseHoveredStacks = newStacks;
 }

--- a/client/battle/BattleStacksController.cpp
+++ b/client/battle/BattleStacksController.cpp
@@ -346,7 +346,7 @@ void BattleStacksController::showStack(Canvas & canvas, const CStack * stack)
 
 void BattleStacksController::tick(uint32_t msPassed)
 {
-	updateHoveredStacks();
+	updateHoveredStacks(false);
 	updateBattleAnimations(msPassed);
 }
 
@@ -806,20 +806,21 @@ void BattleStacksController::removeExpiredColorFilters()
 	});
 }
 
-void BattleStacksController::updateHoveredStacks()
+void BattleStacksController::updateHoveredStacks(bool clear)
 {
 	auto newStacks = selectHoveredStacks();
+
+	if(clear)
+		owner.windowObject->updateStackInfoWindow(nullptr);
 
 	for(const auto * stack : mouseHoveredStacks)
 	{
 		if (vstd::contains(newStacks, stack))
 			continue;
 
+		owner.windowObject->updateStackInfoWindow(nullptr);
 		if (stack == activeStack)
-		{
-			owner.windowObject->updateStackInfoWindow(stack);
 			stackAnimation[stack->unitId()]->setBorderColor(AnimationControls::getGoldBorder());
-		}
 		else
 			stackAnimation[stack->unitId()]->setBorderColor(AnimationControls::getNoBorder());
 	}
@@ -829,6 +830,7 @@ void BattleStacksController::updateHoveredStacks()
 		if (vstd::contains(mouseHoveredStacks, stack))
 			continue;
 
+		owner.windowObject->updateStackInfoWindow(newStacks.size() == 1 && vstd::find_pos(newStacks, stack) == 0 ? stack : nullptr);
 		stackAnimation[stack->unitId()]->setBorderColor(AnimationControls::getBlueBorder());
 		if (stackAnimation[stack->unitId()]->framesInGroup(ECreatureAnimType::MOUSEON) > 0 && stack->alive() && !stack->isFrozen())
 			stackAnimation[stack->unitId()]->playOnce(ECreatureAnimType::MOUSEON);

--- a/client/battle/BattleStacksController.h
+++ b/client/battle/BattleStacksController.h
@@ -125,8 +125,8 @@ public:
 
 	void showAliveStack(Canvas & canvas, const CStack * stack);
 	void showStack(Canvas & canvas, const CStack * stack);
-	
-	void updateHoveredStacks(bool clear);
+
+	void updateHoveredStacks();
 
 	void collectRenderableObjects(BattleRenderer & renderer);
 

--- a/client/battle/BattleStacksController.h
+++ b/client/battle/BattleStacksController.h
@@ -94,7 +94,6 @@ class BattleStacksController
 	void tickFrameBattleAnimations(uint32_t msPassed);
 
 	void updateBattleAnimations(uint32_t msPassed);
-	void updateHoveredStacks();
 
 	std::vector<const CStack *> selectHoveredStacks();
 
@@ -126,6 +125,8 @@ public:
 
 	void showAliveStack(Canvas & canvas, const CStack * stack);
 	void showStack(Canvas & canvas, const CStack * stack);
+	
+	void updateHoveredStacks(bool clear);
 
 	void collectRenderableObjects(BattleRenderer & renderer);
 

--- a/client/battle/BattleWindow.cpp
+++ b/client/battle/BattleWindow.cpp
@@ -154,41 +154,6 @@ void BattleWindow::createStickyHeroInfoWindows()
 	}
 }
 
-void BattleWindow::createStickyArmyInfoWindows(std::optional<uint32_t> unitId)
-{
-	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
-
-	if(owner.defendingHeroInstance)
-	{
-		InfoAboutHero info;
-		info.initFromHero(owner.defendingHeroInstance, InfoAboutHero::EInfoLevel::INBATTLE);
-		Point position = (GH.screenDimensions().x >= 1000)
-				? Point(pos.x + pos.w + 15, pos.y + 250)
-				: Point(pos.x + pos.w -79, pos.y + 135);
-		defenderArmyWindow = std::make_shared<ArmyInfoBasicPanel>(info, &position);
-	}
-	if(owner.attackingHeroInstance)
-	{
-		InfoAboutHero info;
-		info.initFromHero(owner.attackingHeroInstance, InfoAboutHero::EInfoLevel::INBATTLE);
-		Point position = (GH.screenDimensions().x >= 1000)
-				? Point(pos.x - 93, pos.y + 250)
-				: Point(pos.x + 1, pos.y + 135);
-		attackerArmyWindow = std::make_shared<ArmyInfoBasicPanel>(info, &position);
-	}
-
-	bool showInfoWindows = settings["battle"]["stickyHeroInfoWindows"].Bool();
-
-	if(!showInfoWindows)
-	{
-		if(attackerArmyWindow)
-			attackerArmyWindow->disable();
-
-		if(defenderArmyWindow)
-			defenderArmyWindow->disable();
-	}
-}
-
 BattleWindow::~BattleWindow()
 {
 	CPlayerInterface::battleInt = nullptr;
@@ -290,6 +255,28 @@ void BattleWindow::updateHeroInfoWindow(uint8_t side, const InfoAboutHero & hero
 {
 	std::shared_ptr<HeroInfoBasicPanel> panelToUpdate = side == 0 ? attackerHeroWindow : defenderHeroWindow;
 	panelToUpdate->update(hero);
+}
+
+void BattleWindow::updateStackInfoWindow(const CStack * stack)
+{
+	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
+
+	Point position = (GH.screenDimensions().x >= 1000)
+			? Point(pos.x + pos.w + 15, pos.y + 250)
+			: Point(pos.x + pos.w -79, pos.y + 135);
+	defenderStackWindow = std::make_shared<StackInfoBasicPanel>(stack, &position);
+	
+	position = (GH.screenDimensions().x >= 1000)
+			? Point(pos.x - 93, pos.y + 250)
+			: Point(pos.x + 1, pos.y + 135);
+	attackerStackWindow = std::make_shared<StackInfoBasicPanel>(stack, &position);
+
+	//const CStack * stack = owner.getBattle()->battleGetStackByID(unitId.value(), true);
+
+	bool showInfoWindows = settings["battle"]["stickyHeroInfoWindows"].Bool();
+
+	attackerStackWindow->setEnabled(showInfoWindows && stack && stack->unitSide() == BattleSide::ATTACKER);
+	defenderStackWindow->setEnabled(showInfoWindows && stack && stack->unitSide() == BattleSide::DEFENDER);
 }
 
 void BattleWindow::heroManaPointsChanged(const CGHeroInstance * hero)
@@ -706,9 +693,7 @@ void BattleWindow::blockUI(bool on)
 
 std::optional<uint32_t> BattleWindow::getQueueHoveredUnitId()
 {
-	std::optional<uint32_t> unitId = queue->getHoveredUnitIdIfAny();
-	createStickyArmyInfoWindows(unitId);
-	return unitId;
+	return queue->getHoveredUnitIdIfAny();
 }
 
 void BattleWindow::showAll(Canvas & to)

--- a/client/battle/BattleWindow.cpp
+++ b/client/battle/BattleWindow.cpp
@@ -266,8 +266,8 @@ void BattleWindow::updateStackInfoWindow(const CStack * stack)
 	if(stack && stack->unitSide() == BattleSide::DEFENDER)
 	{
 		Point position = (GH.screenDimensions().x >= 1000)
-				? Point(pos.x + pos.w + 15, pos.y + 250)
-				: Point(pos.x + pos.w -79, pos.y + 135);
+				? Point(pos.x + pos.w + 15, defenderHeroWindow ? defenderHeroWindow->pos.y + 210 : pos.y)
+				: Point(pos.x + pos.w -79, defenderHeroWindow ? defenderHeroWindow->pos.y : pos.y + 135);
 		defenderStackWindow = std::make_shared<StackInfoBasicPanel>(stack, &position);
 		defenderStackWindow->setEnabled(showInfoWindows);
 	}
@@ -277,8 +277,8 @@ void BattleWindow::updateStackInfoWindow(const CStack * stack)
 	if(stack && stack->unitSide() == BattleSide::ATTACKER)
 	{
 		Point position = (GH.screenDimensions().x >= 1000)
-				? Point(pos.x - 93, pos.y + 250)
-				: Point(pos.x + 1, pos.y + 135);
+				? Point(pos.x - 93, attackerHeroWindow ? attackerHeroWindow->pos.y + 210 : pos.y)
+				: Point(pos.x + 1, attackerHeroWindow ? attackerHeroWindow->pos.y : pos.y + 135);
 		attackerStackWindow = std::make_shared<StackInfoBasicPanel>(stack, &position);
 		attackerStackWindow->setEnabled(showInfoWindows);
 	}

--- a/client/battle/BattleWindow.cpp
+++ b/client/battle/BattleWindow.cpp
@@ -154,6 +154,41 @@ void BattleWindow::createStickyHeroInfoWindows()
 	}
 }
 
+void BattleWindow::createStickyArmyInfoWindows(std::optional<uint32_t> unitId)
+{
+	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
+
+	if(owner.defendingHeroInstance)
+	{
+		InfoAboutHero info;
+		info.initFromHero(owner.defendingHeroInstance, InfoAboutHero::EInfoLevel::INBATTLE);
+		Point position = (GH.screenDimensions().x >= 1000)
+				? Point(pos.x + pos.w + 15, pos.y + 250)
+				: Point(pos.x + pos.w -79, pos.y + 135);
+		defenderArmyWindow = std::make_shared<ArmyInfoBasicPanel>(info, &position);
+	}
+	if(owner.attackingHeroInstance)
+	{
+		InfoAboutHero info;
+		info.initFromHero(owner.attackingHeroInstance, InfoAboutHero::EInfoLevel::INBATTLE);
+		Point position = (GH.screenDimensions().x >= 1000)
+				? Point(pos.x - 93, pos.y + 250)
+				: Point(pos.x + 1, pos.y + 135);
+		attackerArmyWindow = std::make_shared<ArmyInfoBasicPanel>(info, &position);
+	}
+
+	bool showInfoWindows = settings["battle"]["stickyHeroInfoWindows"].Bool();
+
+	if(!showInfoWindows)
+	{
+		if(attackerArmyWindow)
+			attackerArmyWindow->disable();
+
+		if(defenderArmyWindow)
+			defenderArmyWindow->disable();
+	}
+}
+
 BattleWindow::~BattleWindow()
 {
 	CPlayerInterface::battleInt = nullptr;
@@ -671,7 +706,9 @@ void BattleWindow::blockUI(bool on)
 
 std::optional<uint32_t> BattleWindow::getQueueHoveredUnitId()
 {
-	return queue->getHoveredUnitIdIfAny();
+	std::optional<uint32_t> unitId = queue->getHoveredUnitIdIfAny();
+	createStickyArmyInfoWindows(unitId);
+	return unitId;
 }
 
 void BattleWindow::showAll(Canvas & to)

--- a/client/battle/BattleWindow.cpp
+++ b/client/battle/BattleWindow.cpp
@@ -261,22 +261,29 @@ void BattleWindow::updateStackInfoWindow(const CStack * stack)
 {
 	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
 
-	Point position = (GH.screenDimensions().x >= 1000)
-			? Point(pos.x + pos.w + 15, pos.y + 250)
-			: Point(pos.x + pos.w -79, pos.y + 135);
-	defenderStackWindow = std::make_shared<StackInfoBasicPanel>(stack, &position);
-	
-	position = (GH.screenDimensions().x >= 1000)
-			? Point(pos.x - 93, pos.y + 250)
-			: Point(pos.x + 1, pos.y + 135);
-	attackerStackWindow = std::make_shared<StackInfoBasicPanel>(stack, &position);
-
-	//const CStack * stack = owner.getBattle()->battleGetStackByID(unitId.value(), true);
-
 	bool showInfoWindows = settings["battle"]["stickyHeroInfoWindows"].Bool();
 
-	attackerStackWindow->setEnabled(showInfoWindows && stack && stack->unitSide() == BattleSide::ATTACKER);
-	defenderStackWindow->setEnabled(showInfoWindows && stack && stack->unitSide() == BattleSide::DEFENDER);
+	if(stack && stack->unitSide() == BattleSide::DEFENDER)
+	{
+		Point position = (GH.screenDimensions().x >= 1000)
+				? Point(pos.x + pos.w + 15, pos.y + 250)
+				: Point(pos.x + pos.w -79, pos.y + 135);
+		defenderStackWindow = std::make_shared<StackInfoBasicPanel>(stack, &position);
+		defenderStackWindow->setEnabled(showInfoWindows);
+	}
+	else
+		defenderStackWindow = nullptr;
+	
+	if(stack && stack->unitSide() == BattleSide::ATTACKER)
+	{
+		Point position = (GH.screenDimensions().x >= 1000)
+				? Point(pos.x - 93, pos.y + 250)
+				: Point(pos.x + 1, pos.y + 135);
+		attackerStackWindow = std::make_shared<StackInfoBasicPanel>(stack, &position);
+		attackerStackWindow->setEnabled(showInfoWindows);
+	}
+	else
+		attackerStackWindow = nullptr;
 }
 
 void BattleWindow::heroManaPointsChanged(const CGHeroInstance * hero)

--- a/client/battle/BattleWindow.h
+++ b/client/battle/BattleWindow.h
@@ -25,6 +25,7 @@ class BattleConsole;
 class BattleRenderer;
 class StackQueue;
 class HeroInfoBasicPanel;
+class ArmyInfoBasicPanel;
 
 /// GUI object that handles functionality of panel at the bottom of combat screen
 class BattleWindow : public InterfaceObjectConfigurable
@@ -35,6 +36,8 @@ class BattleWindow : public InterfaceObjectConfigurable
 	std::shared_ptr<BattleConsole> console;
 	std::shared_ptr<HeroInfoBasicPanel> attackerHeroWindow;
 	std::shared_ptr<HeroInfoBasicPanel> defenderHeroWindow;
+	std::shared_ptr<ArmyInfoBasicPanel> attackerArmyWindow;
+	std::shared_ptr<ArmyInfoBasicPanel> defenderArmyWindow;
 
 	/// button press handling functions
 	void bOptionsf();
@@ -65,6 +68,7 @@ class BattleWindow : public InterfaceObjectConfigurable
 
 	void toggleStickyHeroWindowsVisibility();
 	void createStickyHeroInfoWindows();
+	void createStickyArmyInfoWindows(std::optional<uint32_t> unitId);
 
 	std::shared_ptr<BattleConsole> buildBattleConsole(const JsonNode &) const;
 

--- a/client/battle/BattleWindow.h
+++ b/client/battle/BattleWindow.h
@@ -25,7 +25,7 @@ class BattleConsole;
 class BattleRenderer;
 class StackQueue;
 class HeroInfoBasicPanel;
-class ArmyInfoBasicPanel;
+class StackInfoBasicPanel;
 
 /// GUI object that handles functionality of panel at the bottom of combat screen
 class BattleWindow : public InterfaceObjectConfigurable
@@ -36,8 +36,8 @@ class BattleWindow : public InterfaceObjectConfigurable
 	std::shared_ptr<BattleConsole> console;
 	std::shared_ptr<HeroInfoBasicPanel> attackerHeroWindow;
 	std::shared_ptr<HeroInfoBasicPanel> defenderHeroWindow;
-	std::shared_ptr<ArmyInfoBasicPanel> attackerArmyWindow;
-	std::shared_ptr<ArmyInfoBasicPanel> defenderArmyWindow;
+	std::shared_ptr<StackInfoBasicPanel> attackerStackWindow;
+	std::shared_ptr<StackInfoBasicPanel> defenderStackWindow;
 
 	/// button press handling functions
 	void bOptionsf();
@@ -68,7 +68,6 @@ class BattleWindow : public InterfaceObjectConfigurable
 
 	void toggleStickyHeroWindowsVisibility();
 	void createStickyHeroInfoWindows();
-	void createStickyArmyInfoWindows(std::optional<uint32_t> unitId);
 
 	std::shared_ptr<BattleConsole> buildBattleConsole(const JsonNode &) const;
 
@@ -98,6 +97,9 @@ public:
 
 	/// Refresh sticky variant of hero info window after spellcast, side same as in BattleSpellCast::side
 	void updateHeroInfoWindow(uint8_t side, const InfoAboutHero & hero);
+
+	/// Refresh sticky variant of hero info window after spellcast, side same as in BattleSpellCast::side
+	void updateStackInfoWindow(const CStack * stack);
 
 	/// Get mouse-hovered battle queue unit ID if any found
 	std::optional<uint32_t> getQueueHoveredUnitId();

--- a/client/widgets/MiscWidgets.cpp
+++ b/client/widgets/MiscWidgets.cpp
@@ -611,6 +611,8 @@ void MoraleLuckBox::set(const AFactionMember * node)
 
 	image = std::make_shared<CAnimImage>(AnimationPath::builtin(imageName), *component.value + 3);
 	image->moveBy(Point(pos.w/2 - image->pos.w/2, pos.h/2 - image->pos.h/2));//center icon
+	if(settings["general"]["enableUiEnhancements"].Bool())
+		label = std::make_shared<CLabel>(small ? 30 : 42, small ? 20 : 38, EFonts::FONT_TINY, ETextAlignment::BOTTOMRIGHT, Colors::WHITE, std::to_string(modifierList->totalValue()));
 }
 
 MoraleLuckBox::MoraleLuckBox(bool Morale, const Rect &r, bool Small)

--- a/client/widgets/MiscWidgets.h
+++ b/client/widgets/MiscWidgets.h
@@ -238,6 +238,7 @@ public:
 class MoraleLuckBox : public LRClickableAreaWTextComp
 {
 	std::shared_ptr<CAnimImage> image;
+	std::shared_ptr<CLabel> label;
 public:
 	bool morale; //true if morale, false if luck
 	bool small;

--- a/client/windows/CCreatureWindow.cpp
+++ b/client/windows/CCreatureWindow.cpp
@@ -229,6 +229,7 @@ CStackWindow::ActiveSpellsSection::ActiveSpellsSection(CStackWindow * owner, int
 			boost::replace_first(spellText, "%d", std::to_string(duration));
 
 			spellIcons.push_back(std::make_shared<CAnimImage>(AnimationPath::builtin("SpellInt"), effect + 1, 0, firstPos.x + offset.x * printed, firstPos.y + offset.y * printed));
+			labels.push_back(std::make_shared<CLabel>(firstPos.x + offset.x * printed + 46, firstPos.y + offset.y * printed + 36, EFonts::FONT_TINY, ETextAlignment::BOTTOMRIGHT, Colors::WHITE, std::to_string(duration)));
 			clickableAreas.push_back(std::make_shared<LRClickableAreaWText>(Rect(firstPos + offset * printed, Point(50, 38)), spellText, spellText));
 			if(++printed >= 8) // interface limit reached
 				break;

--- a/client/windows/CCreatureWindow.h
+++ b/client/windows/CCreatureWindow.h
@@ -72,6 +72,7 @@ class CStackWindow : public CWindowObject
 	{
 		std::vector<std::shared_ptr<CAnimImage>> spellIcons;
 		std::vector<std::shared_ptr<LRClickableAreaWText>> clickableAreas;
+		std::vector<std::shared_ptr<CLabel>> labels;
 	public:
 		ActiveSpellsSection(CStackWindow * owner, int yOffset);
 	};


### PR DESCRIPTION
fixes #3253 
fixes #1490
fixes #2961

Features:
- Show Battle Stacks Info (with showing lost units + remaining health)
- if more than 3 spells active then in the third slot "..." is shown (then you have to right click stack)
- Fix Bug with frozen blue border in order bar
- Show spell duration (if ui enhancement enabled)
- Show luck morale value (if ui enhancement enabled)

Todo:
- [x] add translatable strings
- [x] show active spells
- [x] show spell duration
- [x] find solution for ATB bug (after right clicking unit it keeps highlighted)
- [x] position on mobile

Current state:
![grafik](https://github.com/vcmi/vcmi/assets/13953785/2fb7ec67-a7bc-49e5-aa44-82f8d16f0d59)
