### PR TITLE
Ban Armageddon's Blade and Vial of Dragon Blood

### DIFF
--- a/config/artifacts.json
+++ b/config/artifacts.json
@@ -1873,6 +1873,7 @@
 			}
 		],
 		"index" : 127,
+		"class" : "SPECIAL",
 		"type" : ["HERO"]
 	},
 	"armageddonsBlade":
@@ -1917,6 +1918,7 @@
 			}
 		],
 		"index" : 128,
+		"class" : "SPECIAL",
 		"type" : ["HERO"]
 	},
 	"angelicAlliance":


### PR DESCRIPTION
Now they need to be explicitely set to `"class" : "SPECIAL"`.