### PR TITLE
Fix crash due to incorrect logic on transferring last creature

### DIFF
--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -1973,7 +1973,9 @@ bool CGameHandler::bulkMoveArmy(ObjectInstanceID srcArmy, ObjectInstanceID destA
 		{
 			const bool needsLastStack = armySrc->needsLastStack();
 			const auto quantity = setSrc.getStackCount(srcSlot) - (needsLastStack ? 1 : 0);
-			moves.insert(std::make_pair(srcSlot, std::make_pair(slotToMove, quantity)));
+
+			if(quantity > 0) //0 may happen when we need last creature and we have exactly 1 amount of that creature - amount of "rest we can transfer" becomes 0
+				moves.insert(std::make_pair(srcSlot, std::make_pair(slotToMove, quantity)));
 		}
 	}
 	BulkRebalanceStacks bulkRS;


### PR DESCRIPTION
With WoG mod active there is crash caused by trying to assign experience to unit with quantity 0 after "moving" it to another hero. It happens when source hero has exactly 1 weakest unit and is trying to split it with another hero.