### PR TITLE
Default large spellbook

### DIFF
--- a/client/windows/settings/GeneralOptionsTab.cpp
+++ b/client/windows/settings/GeneralOptionsTab.cpp
@@ -162,9 +162,15 @@ GeneralOptionsTab::GeneralOptionsTab()
 		setBoolSetting("general", "enableUiEnhancements", value);
 	});
 
-	addCallback("enableLargeSpellbookChanged", [](bool value)
+	addCallback("enableLargeSpellbookChanged", [this](bool value)
 	{
 		setBoolSetting("gameTweaks", "enableLargeSpellbook", value);
+		std::shared_ptr<CToggleButton> spellbookAnimationCheckbox = widget<CToggleButton>("spellbookAnimationCheckbox");
+		if(value)
+			spellbookAnimationCheckbox->disable();
+		else
+			spellbookAnimationCheckbox->enable();
+		redraw();
 	});
 
 	addCallback("audioMuteFocusChanged", [](bool value)
@@ -196,6 +202,10 @@ GeneralOptionsTab::GeneralOptionsTab()
 
 	std::shared_ptr<CToggleButton> spellbookAnimationCheckbox = widget<CToggleButton>("spellbookAnimationCheckbox");
 	spellbookAnimationCheckbox->setSelected(settings["video"]["spellbookAnimation"].Bool());
+	if(settings["gameTweaks"]["enableLargeSpellbook"].Bool())
+		spellbookAnimationCheckbox->disable();
+	else
+		spellbookAnimationCheckbox->enable();
 
 	std::shared_ptr<CToggleButton> fullscreenBorderlessCheckbox = widget<CToggleButton>("fullscreenBorderlessCheckbox");
 	if (fullscreenBorderlessCheckbox)

--- a/config/schemas/settings.json
+++ b/config/schemas/settings.json
@@ -619,7 +619,7 @@
 				},
 				"enableLargeSpellbook" : {
 					"type": "boolean",
-					"default": false
+					"default": true
 				}
 			}
 		}

--- a/config/widgets/settings/generalOptionsTab.json
+++ b/config/widgets/settings/generalOptionsTab.json
@@ -72,6 +72,35 @@
 		},
 		{
 			"type" : "verticalLayout",
+			"customType" : "checkboxFake",
+			"position" : {"x": 10, "y": 83},
+			"items" : [
+				{
+					"created" : "desktop"
+				},
+				{},
+				{
+					"created" : "desktop"
+				},
+				{
+					"created" : "desktop"
+				},
+				{},
+				{},
+				{
+					"name": "spellbookAnimationCheckboxPlaceholder"
+				},
+				{
+					"created" : "touchscreen"
+				},
+				{
+					"created" : "mobile"
+				},
+				{}
+			]
+		},
+		{
+			"type" : "verticalLayout",
 			"customType" : "checkbox",
 			"position" : {"x": 10, "y": 83},
 			"items" : [


### PR DESCRIPTION
To be decided whether to merge or not

Reasoning why it makes sense to be merged:
- we have "enable UI enhancements" by default so large spellbook enhancement would be consistent with this change
- people are used to large spellbook as most of them play with HD mod, because otherwise H3 does not work well on modern windows and it has forced large spellbook with no animation in there
- few upvotes on discord and 0 downvotes while asking if this change should be made

One confusion it may bring:
- some people not reading right-click description and wondering why spellbook animation doesn't work while toggled on (can be eventually mitigated by some sort of graying-out spellbook animation setting when large spellbook is active)