### PR TITLE
Docs: remove `Manual.md` link from `Readme.md`

### DIFF
--- a/docs/Readme.md
+++ b/docs/Readme.md
@@ -45,7 +45,6 @@ Please see corresponding installation guide articles for details for your platfo
 
 ## Documentation and guidelines for players
 
-- [General information about VCMI Project](players/Manual.md)
 - [Frequently asked questions](https://vcmi.eu/faq/) (external link)
 - [Game mechanics](players/Game_Mechanics.md)
 - [Bug reporting guidelines](players/Bug_Reporting_Guidelines.md)


### PR DESCRIPTION
Link is not valid anymore: https://github.com/vcmi/vcmi/blob/develop/docs/players/Manual.md

Related PR:
https://github.com/vcmi/vcmi/pull/3165