### PR TITLE
[Launcher] mod manager drag'n'drop

### DIFF
--- a/launcher/launcherdirs.cpp
+++ b/launcher/launcherdirs.cpp
@@ -34,3 +34,8 @@ QString CLauncherDirs::modsPath()
 {
 	return pathToQString(VCMIDirs::get().userDataPath() / "Mods");
 }
+
+QString CLauncherDirs::mapsPath()
+{
+	return pathToQString(VCMIDirs::get().userDataPath() / "Maps");
+}

--- a/launcher/launcherdirs.h
+++ b/launcher/launcherdirs.h
@@ -19,4 +19,5 @@ public:
 
 	QString downloadsPath();
 	QString modsPath();
+	QString mapsPath();
 };

--- a/launcher/modManager/cmodlistview_moc.cpp
+++ b/launcher/modManager/cmodlistview_moc.cpp
@@ -718,9 +718,9 @@ void CModListView::installFiles(QStringList files)
 	{
 		if(filename.endsWith(".zip"))
 			mods.push_back(filename);
-		if(filename.endsWith(".h3m") || filename.endsWith(".h3c") || filename.endsWith(".vmap") || filename.endsWith(".vcmp"))
+		else if(filename.endsWith(".h3m") || filename.endsWith(".h3c") || filename.endsWith(".vmap") || filename.endsWith(".vcmp"))
 			maps.push_back(filename);
-		if(filename.endsWith(".json"))
+		else if(filename.endsWith(".json"))
 		{
 			//download and merge additional files
 			auto repoData = JsonUtils::JsonFromFile(filename).toMap();
@@ -744,7 +744,7 @@ void CModListView::installFiles(QStringList files)
 			}
 			repositories.push_back(repoData);
 		}
-		if(filename.endsWith(".png"))
+		else if(filename.endsWith(".png"))
 			images.push_back(filename);
 	}
 

--- a/launcher/modManager/cmodlistview_moc.cpp
+++ b/launcher/modManager/cmodlistview_moc.cpp
@@ -50,7 +50,14 @@ void CModListView::changeEvent(QEvent *event)
 
 void CModListView::dragEnterEvent(QDragEnterEvent* event)
 {
-	event->acceptProposedAction();
+	if(event->mimeData()->hasUrls())
+		for(const auto & url : event->mimeData()->urls())
+			for(const auto & ending : QStringList({".zip", ".h3m", ".h3c", ".vmap", ".vcmp"}))
+				if(url.fileName().endsWith(ending, Qt::CaseInsensitive))
+				{
+					event->acceptProposedAction();
+					return;
+				}
 }
 
 void CModListView::dropEvent(QDropEvent* event)
@@ -61,7 +68,7 @@ void CModListView::dropEvent(QDropEvent* event)
 	{
 		const QList<QUrl> urlList = mimeData->urls();
 
-		for (auto & url : urlList)
+		for (const auto & url : urlList)
 		{
 			QString urlStr = url.toString();
 			QString fileName = url.fileName();
@@ -716,11 +723,11 @@ void CModListView::installFiles(QStringList files)
 	// TODO: some better way to separate zip's with mods and downloaded repository files
 	for(QString filename : files)
 	{
-		if(filename.endsWith(".zip"))
+		if(filename.endsWith(".zip", Qt::CaseInsensitive))
 			mods.push_back(filename);
-		else if(filename.endsWith(".h3m") || filename.endsWith(".h3c") || filename.endsWith(".vmap") || filename.endsWith(".vcmp"))
+		else if(filename.endsWith(".h3m", Qt::CaseInsensitive) || filename.endsWith(".h3c", Qt::CaseInsensitive) || filename.endsWith(".vmap", Qt::CaseInsensitive) || filename.endsWith(".vcmp", Qt::CaseInsensitive))
 			maps.push_back(filename);
-		else if(filename.endsWith(".json"))
+		else if(filename.endsWith(".json", Qt::CaseInsensitive))
 		{
 			//download and merge additional files
 			auto repoData = JsonUtils::JsonFromFile(filename).toMap();
@@ -744,7 +751,7 @@ void CModListView::installFiles(QStringList files)
 			}
 			repositories.push_back(repoData);
 		}
-		else if(filename.endsWith(".png"))
+		else if(filename.endsWith(".png", Qt::CaseInsensitive))
 			images.push_back(filename);
 	}
 
@@ -832,13 +839,13 @@ void CModListView::installMods(QStringList archives)
 		QFile::remove(archive);
 }
 
-void CModListView::installMaps(QStringList archives)
+void CModListView::installMaps(QStringList maps)
 {
 	QString destDir = CLauncherDirs::get().mapsPath() + "/";
 
-	for(QString archive : archives)
+	for(QString map : maps)
 	{
-		QFile(archive).rename(destDir + archive.section('/', -1, -1));
+		QFile(map).rename(destDir + map.section('/', -1, -1));
 	}
 }
 

--- a/launcher/modManager/cmodlistview_moc.cpp
+++ b/launcher/modManager/cmodlistview_moc.cpp
@@ -52,16 +52,6 @@ void CModListView::dragEnterEvent(QDragEnterEvent* event)
 {
 	event->acceptProposedAction();
 }
- 
-void CModListView::dragMoveEvent(QDragMoveEvent* event)
-{
-	event->acceptProposedAction();
-}
- 
-void CModListView::dragLeaveEvent(QDragLeaveEvent* event)
-{
-	event->accept();
-}
 
 void CModListView::dropEvent(QDropEvent* event)
 {
@@ -69,21 +59,21 @@ void CModListView::dropEvent(QDropEvent* event)
 
 	if(mimeData->hasUrls())
 	{
-		QStringList pathList;
-		QList<QUrl> urlList = mimeData->urls();
+		const QList<QUrl> urlList = mimeData->urls();
 
-		for (int i = 0; i < urlList.size(); i++)
+		for (auto & url : urlList)
 		{
-			QString url = urlList.at(i).toString();
-			if(url.endsWith(".zip", Qt::CaseInsensitive))
-				downloadFile(url.split("/").last().toLower()
+			QString urlStr = url.toString();
+			QString fileName = url.fileName();
+			if(urlStr.endsWith(".zip", Qt::CaseInsensitive))
+				downloadFile(fileName.toLower()
 					// mod name currently comes from zip file -> remove suffixes from github zip download
 					.replace(QRegularExpression("-[0-9a-f]{40}"), "")
-					.replace(QRegularExpression("-vcmi-.*\\.zip"), ".zip")
-					.replace(QRegularExpression("-main.zip"), ".zip")
-					, url, "mods", 0);
+					.replace(QRegularExpression("-vcmi-.+\\.zip"), ".zip")
+					.replace("-main.zip", ".zip")
+					, urlStr, "mods", 0);
 			else
-				downloadFile(url.split("/").last(), url, "mods", 0);
+				downloadFile(fileName, urlStr, "mods", 0);
 		}
 	}
 }
@@ -1021,4 +1011,3 @@ void CModListView::on_allModsView_doubleClicked(const QModelIndex &index)
 		return;
 	}
 }
-

--- a/launcher/modManager/cmodlistview_moc.h
+++ b/launcher/modManager/cmodlistview_moc.h
@@ -62,8 +62,6 @@ class CModListView : public QWidget
 
 	void changeEvent(QEvent *event) override;
 	void dragEnterEvent(QDragEnterEvent* event) override;
-	void dragMoveEvent(QDragMoveEvent* event) override;
-	void dragLeaveEvent(QDragLeaveEvent* event) override;
 	void dropEvent(QDropEvent *event) override;
 signals:
 	void modsChanged();

--- a/launcher/modManager/cmodlistview_moc.h
+++ b/launcher/modManager/cmodlistview_moc.h
@@ -54,12 +54,17 @@ class CModListView : public QWidget
 	void downloadFile(QString file, QString url, QString description, qint64 size = 0);
 
 	void installMods(QStringList archives);
+	void installMaps(QStringList archives);
 	void installFiles(QStringList mods);
 
 	QString genChangelogText(CModEntry & mod);
 	QString genModInfoText(CModEntry & mod);
 
 	void changeEvent(QEvent *event) override;
+	void dragEnterEvent(QDragEnterEvent* event) override;
+	void dragMoveEvent(QDragMoveEvent* event) override;
+	void dragLeaveEvent(QDragLeaveEvent* event) override;
+	void dropEvent(QDropEvent *event) override;
 signals:
 	void modsChanged();
 

--- a/launcher/modManager/cmodlistview_moc.h
+++ b/launcher/modManager/cmodlistview_moc.h
@@ -54,7 +54,7 @@ class CModListView : public QWidget
 	void downloadFile(QString file, QString url, QString description, qint64 size = 0);
 
 	void installMods(QStringList archives);
-	void installMaps(QStringList archives);
+	void installMaps(QStringList maps);
 	void installFiles(QStringList mods);
 
 	QString genChangelogText(CModEntry & mod);

--- a/launcher/modManager/cmodmanager.cpp
+++ b/launcher/modManager/cmodmanager.cpp
@@ -161,9 +161,6 @@ bool CModManager::canInstallMod(QString modname)
 
 	if(mod.isInstalled())
 		return addError(modname, "Mod is already installed");
-
-	if(!mod.isAvailable())
-		return addError(modname, "Mod is not available");
 	return true;
 }
 


### PR DESCRIPTION
fixes #853

allows to drag zip files (e.g. manual downloads from github) to mod list and install the zip file.

also allows to install maps and campaigns with drag'n'drop.