### PR TITLE
option for disabling cheats

### DIFF
--- a/Mods/vcmi/config/vcmi/english.json
+++ b/Mods/vcmi/config/vcmi/english.json
@@ -264,9 +264,11 @@
 	"vcmi.optionsTab.simturnsMin.hover" : "At least for",
 	"vcmi.optionsTab.simturnsMax.hover" : "At most for",
 	"vcmi.optionsTab.simturnsAI.hover" : "(Experimental) Simultaneous AI Turns",
+	"vcmi.optionsTab.cheatAllowed.hover" : "Allow cheats",
 	"vcmi.optionsTab.simturnsMin.help" : "Play simultaneously for specified number of days. Contacts between players during this period are blocked",
 	"vcmi.optionsTab.simturnsMax.help" : "Play simultaneously for specified number of days or until contact with another player",
 	"vcmi.optionsTab.simturnsAI.help" : "{Simultaneous AI Turns}\nExperimental option. Allows AI players to act at the same time as human player when simultaneous turns are enabled.",
+	"vcmi.optionsTab.cheatAllowed.help" : "{Allow cheats}\nAllows the inputs of cheats during the game.",
 
 	"vcmi.optionsTab.turnTime.select"     : "Select turn timer preset",
 	"vcmi.optionsTab.turnTime.unlimited"  : "Unlimited turn time",

--- a/Mods/vcmi/config/vcmi/german.json
+++ b/Mods/vcmi/config/vcmi/german.json
@@ -283,9 +283,11 @@
 	"vcmi.optionsTab.simturnsMin.hover" : "Zumindest für",
 	"vcmi.optionsTab.simturnsMax.hover" : "Höchstens für",
 	"vcmi.optionsTab.simturnsAI.hover" : "(Experimentell) Simultane KI Züge",
+	"vcmi.optionsTab.cheatAllowed.hover" : "Cheats erlauben",
 	"vcmi.optionsTab.simturnsMin.help" : "Spielt gleichzeitig für eine bestimmte Anzahl von Tagen. Die Kontakte zwischen den Spielern sind während dieser Zeit blockiert",
 	"vcmi.optionsTab.simturnsMax.help" : "Spielt gleichzeitig für eine bestimmte Anzahl von Tagen oder bis zum Kontakt mit einem anderen Spieler",
 	"vcmi.optionsTab.simturnsAI.help" : "{Simultane KI Züge}\nExperimentelle Option. Ermöglicht es den KI-Spielern, gleichzeitig mit dem menschlichen Spieler zu agieren, wenn simultane Spielzüge aktiviert sind.",
+	"vcmi.optionsTab.cheatAllowed.help" : "{Cheats erlauben}\nErlaubt die Eingabe von Cheats während des Spiels.",
 	
 	// Translation note: translate strings below using form that is correct for "0 days", "1 day" and "2 days" in your language
 	// Using this information, VCMI will automatically select correct plural form for every possible amount

--- a/client/CServerHandler.cpp
+++ b/client/CServerHandler.cpp
@@ -507,6 +507,13 @@ void CServerHandler::setTurnTimerInfo(const TurnTimerInfo & info) const
 	sendLobbyPack(lstt);
 }
 
+void CServerHandler::setCheatAllowedInfo(bool allowed) const
+{
+	LobbySetCheatAllowed lsca;
+	lsca.allowed = allowed;
+	sendLobbyPack(lsca);
+}
+
 void CServerHandler::sendMessage(const std::string & txt) const
 {
 	std::istringstream readed;

--- a/client/CServerHandler.h
+++ b/client/CServerHandler.h
@@ -72,6 +72,7 @@ public:
 	virtual void setDifficulty(int to) const = 0;
 	virtual void setTurnTimerInfo(const TurnTimerInfo &) const = 0;
 	virtual void setSimturnsInfo(const SimturnsInfo &) const = 0;
+	virtual void setCheatAllowedInfo(bool allowed) const = 0;
 	virtual void sendMessage(const std::string & txt) const = 0;
 	virtual void sendGuiAction(ui8 action) const = 0; // TODO: possibly get rid of it?
 	virtual void sendStartGame(bool allowOnlyAI = false) const = 0;
@@ -158,6 +159,7 @@ public:
 	void setDifficulty(int to) const override;
 	void setTurnTimerInfo(const TurnTimerInfo &) const override;
 	void setSimturnsInfo(const SimturnsInfo &) const override;
+	void setCheatAllowedInfo(bool allowed) const override;
 	void sendMessage(const std::string & txt) const override;
 	void sendGuiAction(ui8 action) const override;
 	void sendRestartGame() const override;

--- a/client/lobby/OptionsTabBase.cpp
+++ b/client/lobby/OptionsTabBase.cpp
@@ -90,6 +90,10 @@ OptionsTabBase::OptionsTabBase(const JsonPath & configPath)
 		CSH->setSimturnsInfo(info);
 	});
 
+	addCallback("setCheatAllowed", [&](int index){
+		CSH->setCheatAllowedInfo(index);
+	});
+
 	addCallback("setTurnTimerAccumulate", [&](int index){
 		TurnTimerInfo info = SEL->getStartInfo()->turnTimerInfo;
 		info.accumulatingTurnTimer = index;

--- a/config/widgets/turnOptionsTab.json
+++ b/config/widgets/turnOptionsTab.json
@@ -316,7 +316,7 @@
 		},
 		{
 			"name": "buttonSimturnsAI",
-			"position": {"x": 70, "y": 535},
+			"position": {"x": 70, "y": 530},
 			"type": "toggleButton",
 			"image": "lobby/checkbox",
 			"callback" : "setSimturnAI"
@@ -328,7 +328,24 @@
 			"alignment": "left",
 			"color": "yellow",
 			"text": "vcmi.optionsTab.simturnsAI.hover",
-			"position": {"x": 110, "y": 540}
+			"position": {"x": 110, "y": 533}
+		},
+		{
+			"name": "buttonCheatAllowed",
+			"position": {"x": 70, "y": 555},
+			"type": "toggleButton",
+			"image": "lobby/checkbox",
+			"callback" : "setCheatAllowed",
+			"selected" : true
+		},
+		{
+			"name": "labelCheatAllowed",
+			"type": "label",
+			"font": "small",
+			"alignment": "left",
+			"color": "yellow",
+			"text": "vcmi.optionsTab.cheatAllowed.hover",
+			"position": {"x": 110, "y": 558}
 		}
 	],
 	

--- a/lib/StartInfo.h
+++ b/lib/StartInfo.h
@@ -105,6 +105,8 @@ struct DLL_LINKAGE StartInfo
 	EMode mode;
 	ui8 difficulty; //0=easy; 4=impossible
 
+	bool cheatAllowed;
+
 	using TPlayerInfos = std::map<PlayerColor, PlayerSettings>;
 	TPlayerInfos playerInfos; //color indexed
 
@@ -141,13 +143,14 @@ struct DLL_LINKAGE StartInfo
 		h & fileURI;
 		h & simturnsInfo;
 		h & turnTimerInfo;
+		h & cheatAllowed;
 		h & mapname;
 		h & mapGenOptions;
 		h & campState;
 	}
 
 	StartInfo() : mode(INVALID), difficulty(1), seedToBeUsed(0), seedPostInit(0),
-		mapfileChecksum(0), startTimeIso8601(vstd::getDateTimeISO8601Basic(std::time(nullptr))), fileURI("")
+		mapfileChecksum(0), startTimeIso8601(vstd::getDateTimeISO8601Basic(std::time(nullptr))), fileURI(""), cheatAllowed(true)
 	{
 
 	}

--- a/lib/networkPacks/NetPackVisitor.h
+++ b/lib/networkPacks/NetPackVisitor.h
@@ -164,6 +164,7 @@ public:
 	virtual void visitLobbySetPlayerName(LobbySetPlayerName & pack) {}
 	virtual void visitLobbySetSimturns(LobbySetSimturns & pack) {}
 	virtual void visitLobbySetTurnTime(LobbySetTurnTime & pack) {}
+	virtual void visitLobbySetCheatAllowed(LobbySetCheatAllowed & pack) {}
 	virtual void visitLobbySetDifficulty(LobbySetDifficulty & pack) {}
 	virtual void visitLobbyForceSetPlayer(LobbyForceSetPlayer & pack) {}
 	virtual void visitLobbyShowMessage(LobbyShowMessage & pack) {}

--- a/lib/networkPacks/NetPacksLib.cpp
+++ b/lib/networkPacks/NetPacksLib.cpp
@@ -770,6 +770,11 @@ void LobbySetTurnTime::visitTyped(ICPackVisitor & visitor)
 	visitor.visitLobbySetTurnTime(*this);
 }
 
+void LobbySetCheatAllowed::visitTyped(ICPackVisitor & visitor)
+{
+	visitor.visitLobbySetCheatAllowed(*this);
+}
+
 void LobbySetDifficulty::visitTyped(ICPackVisitor & visitor)
 {
 	visitor.visitLobbySetDifficulty(*this);

--- a/lib/networkPacks/PacksForLobby.h
+++ b/lib/networkPacks/PacksForLobby.h
@@ -287,6 +287,18 @@ struct DLL_LINKAGE LobbySetTurnTime : public CLobbyPackToServer
 	}
 };
 
+struct DLL_LINKAGE LobbySetCheatAllowed : public CLobbyPackToServer
+{
+	bool allowed;
+
+	void visitTyped(ICPackVisitor & visitor) override;
+
+	template <typename Handler> void serialize(Handler &h, const int version)
+	{
+		h & allowed;
+	}
+};
+
 struct DLL_LINKAGE LobbySetDifficulty : public CLobbyPackToServer
 {
 	ui8 difficulty = 0;

--- a/lib/registerTypes/RegisterTypesLobbyPacks.h
+++ b/lib/registerTypes/RegisterTypesLobbyPacks.h
@@ -54,6 +54,7 @@ void registerTypesLobbyPacks(Serializer &s)
 	s.template registerType<CLobbyPackToServer, LobbySetPlayer>();
 	s.template registerType<CLobbyPackToServer, LobbySetPlayerName>();
 	s.template registerType<CLobbyPackToServer, LobbySetTurnTime>();
+	s.template registerType<CLobbyPackToServer, LobbySetCheatAllowed>();
 	s.template registerType<CLobbyPackToServer, LobbySetSimturns>();
 	s.template registerType<CLobbyPackToServer, LobbySetDifficulty>();
 	s.template registerType<CLobbyPackToServer, LobbyForceSetPlayer>();

--- a/server/LobbyNetPackVisitors.h
+++ b/server/LobbyNetPackVisitors.h
@@ -88,6 +88,7 @@ public:
 	virtual void visitLobbySetPlayer(LobbySetPlayer & pack) override;
 	virtual void visitLobbySetPlayerName(LobbySetPlayerName & pack) override;
 	virtual void visitLobbySetTurnTime(LobbySetTurnTime & pack) override;
+	virtual void visitLobbySetCheatAllowed(LobbySetCheatAllowed & pack) override;
 	virtual void visitLobbySetSimturns(LobbySetSimturns & pack) override;
 	virtual void visitLobbySetDifficulty(LobbySetDifficulty & pack) override;
 	virtual void visitLobbyForceSetPlayer(LobbyForceSetPlayer & pack) override;

--- a/server/NetPacksLobbyServer.cpp
+++ b/server/NetPacksLobbyServer.cpp
@@ -414,6 +414,12 @@ void ApplyOnServerNetPackVisitor::visitLobbySetTurnTime(LobbySetTurnTime & pack)
 	result = true;
 }
 
+void ApplyOnServerNetPackVisitor::visitLobbySetCheatAllowed(LobbySetCheatAllowed & pack)
+{
+	srv.si->cheatAllowed = pack.allowed;
+	result = true;
+}
+
 void ApplyOnServerNetPackVisitor::visitLobbySetDifficulty(LobbySetDifficulty & pack)
 {
 	srv.si->difficulty = std::clamp<uint8_t>(pack.difficulty, 0, 4);

--- a/server/processors/PlayerMessageProcessor.cpp
+++ b/server/processors/PlayerMessageProcessor.cpp
@@ -440,7 +440,7 @@ bool PlayerMessageProcessor::handleCheatCode(const std::string & cheat, PlayerCo
 	std::vector<std::string> words;
 	boost::split(words, cheat, boost::is_any_of("\t\r\n "));
 
-	if (words.empty())
+	if (words.empty() || !gameHandler->getStartInfo()->cheatAllowed)
 		return false;
 
 	//Make cheat name case-insensitive, but keep words/parameters (e.g. creature name) as it


### PR DESCRIPTION
Until we have a better place, it's in turn options:
![grafik](https://github.com/vcmi/vcmi/assets/13953785/de610640-e5ef-47f3-a25a-35a3d5639719)

@IvanSavenko We should add this to develop and not beta because it breaks savegame, right?