### PR TITLE
Enable ccache option for linux

### DIFF
--- a/.github/workflows/github.yml
+++ b/.github/workflows/github.yml
@@ -244,7 +244,7 @@ jobs:
 
     - name: CMake Preset with ccache
       run: |
-        cmake -DCMAKE_CXX_COMPILER_LAUNCHER=ccache --preset ${{ matrix.preset }}
+        cmake -DENABLE_CCACHE:BOOL=ON --preset ${{ matrix.preset }}
 
     - name: Build Preset
       run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,10 +81,7 @@ endif()
 
 option(ENABLE_CCACHE "Speed up recompilation by caching previous compilations" OFF)
 if(ENABLE_CCACHE)
-	find_program(CCACHE ccache)
-	if(CCACHE-NOTFOUND)
-		message(FATAL_ERROR "'ccache' could not be found; install it or set ENABLE_CCACHE=OFF.")
-	endif()
+	find_program(CCACHE ccache REQUIRED)
 endif()
 
 # On Linux, use ccache via CMAKE_CXX_COMPILER_LAUNCHER.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,21 +95,18 @@ if(ENABLE_CCACHE AND LINUX)
 endif()
 
 if(ENABLE_CCACHE AND (CMAKE_GENERATOR STREQUAL "Xcode"))
-	find_program(CCACHE ccache REQUIRED)
-	if(CCACHE)
-		# https://stackoverflow.com/a/36515503/2278742
-		# Set up wrapper scripts
-		configure_file(xcode/launch-c.in   xcode/launch-c)
-		configure_file(xcode/launch-cxx.in xcode/launch-cxx)
-		execute_process(COMMAND chmod a+rx
-												"${CMAKE_BINARY_DIR}/xcode/launch-c"
-												"${CMAKE_BINARY_DIR}/xcode/launch-cxx")
-		# Set Xcode project attributes to route compilation through our scripts
-		set(CMAKE_XCODE_ATTRIBUTE_CC         	"${CMAKE_BINARY_DIR}/xcode/launch-c")
-		set(CMAKE_XCODE_ATTRIBUTE_CXX        	"${CMAKE_BINARY_DIR}/xcode/launch-cxx")
-		set(CMAKE_XCODE_ATTRIBUTE_LD         	"${CMAKE_BINARY_DIR}/xcode/launch-c")
-		set(CMAKE_XCODE_ATTRIBUTE_LDPLUSPLUS 	"${CMAKE_BINARY_DIR}/xcode/launch-cxx")
-	endif()
+	# https://stackoverflow.com/a/36515503/2278742
+	# Set up wrapper scripts
+	configure_file(xcode/launch-c.in   xcode/launch-c)
+	configure_file(xcode/launch-cxx.in xcode/launch-cxx)
+	execute_process(COMMAND chmod a+rx
+											"${CMAKE_BINARY_DIR}/xcode/launch-c"
+											"${CMAKE_BINARY_DIR}/xcode/launch-cxx")
+	# Set Xcode project attributes to route compilation through our scripts
+	set(CMAKE_XCODE_ATTRIBUTE_CC         	"${CMAKE_BINARY_DIR}/xcode/launch-c")
+	set(CMAKE_XCODE_ATTRIBUTE_CXX        	"${CMAKE_BINARY_DIR}/xcode/launch-cxx")
+	set(CMAKE_XCODE_ATTRIBUTE_LD         	"${CMAKE_BINARY_DIR}/xcode/launch-c")
+	set(CMAKE_XCODE_ATTRIBUTE_LDPLUSPLUS 	"${CMAKE_BINARY_DIR}/xcode/launch-cxx")
 endif()
 
 # Allow to pass package name from Travis CI
@@ -275,19 +272,16 @@ if(MINGW OR MSVC)
 	if(MSVC)
 		if(ENABLE_CCACHE)
 			# https://github.com/ccache/ccache/discussions/1154#discussioncomment-3611387
-			find_program(CCACHE ccache REQUIRED)
-			if (CCACHE)
-				file(COPY_FILE
-					${CCACHE} ${CMAKE_BINARY_DIR}/cl.exe
-					ONLY_IF_DIFFERENT)
+			file(COPY_FILE
+				${CCACHE} ${CMAKE_BINARY_DIR}/cl.exe
+				ONLY_IF_DIFFERENT)
 
-				set(CMAKE_VS_GLOBALS
-					"CLToolExe=cl.exe"
-					"CLToolPath=${CMAKE_BINARY_DIR}"
-					"TrackFileAccess=false"
-					"UseMultiToolTask=true"
-				)
-			endif()
+			set(CMAKE_VS_GLOBALS
+				"CLToolExe=cl.exe"
+				"CLToolPath=${CMAKE_BINARY_DIR}"
+				"TrackFileAccess=false"
+				"UseMultiToolTask=true"
+			)
 		endif()
 
 		add_definitions(-DBOOST_ALL_NO_LIB)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,10 +79,19 @@ if(NOT APPLE_IOS AND NOT ANDROID)
 	option(ENABLE_MONOLITHIC_INSTALL "Install everything in single directory on Linux and Mac" OFF)
 endif()
 
-# On Linux, use -DCMAKE_CXX_COMPILER_LAUNCHER=ccache instead.
-# The XCode and MSVC builds each require some more configuration, which is enabled by the following option:
-if(MSVC OR (CMAKE_GENERATOR STREQUAL "Xcode"))
-  option(ENABLE_CCACHE "Speed up recompilation by caching previous compilations" OFF)
+option(ENABLE_CCACHE "Speed up recompilation by caching previous compilations" OFF)
+if(ENABLE_CCACHE)
+	find_program(CCACHE ccache)
+	if(CCACHE-NOTFOUND)
+		message(FATAL_ERROR "'ccache' could not be found; install it or set ENABLE_CCACHE=OFF.")
+	endif()
+endif()
+
+# On Linux, use ccache via CMAKE_CXX_COMPILER_LAUNCHER.
+# The XCode and MSVC builds each require some more configuration further down.
+if(ENABLE_CCACHE AND LINUX)
+	set(CMAKE_C_COMPILER_LAUNCHER "ccache")
+	set(CMAKE_CXX_COMPILER_LAUNCHER "ccache")
 endif()
 
 if(ENABLE_CCACHE AND (CMAKE_GENERATOR STREQUAL "Xcode"))

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -66,6 +66,15 @@
             }
         },
         {
+            "name": "linux-clang-release-ccache",
+            "displayName": "Clang x86_64-pc-linux-gnu with ccache",
+            "description": "VCMI Linux Clang with ccache",
+            "inherits": "linux-release",
+            "cacheVariables": {
+                "ENABLE_CCACHE": "ON"
+            }
+        },
+        {
             "name": "linux-gcc-release",
             "displayName": "GCC x86_64-pc-linux-gnu",
             "description": "VCMI Linux GCC",
@@ -74,6 +83,15 @@
                 "ENABLE_LUA" : "ON",
                 "CMAKE_C_COMPILER": "/usr/bin/gcc",
                 "CMAKE_CXX_COMPILER": "/usr/bin/g++"
+            }
+        },
+        {
+            "name": "linux-gcc-release-ccache",
+            "displayName": "GCC x86_64-pc-linux-gnu with ccache",
+            "description": "VCMI Linux GCC with ccache",
+            "inherits": "linux-release",
+            "cacheVariables": {
+                "ENABLE_CCACHE": "ON"
             }
         },
         {
@@ -285,6 +303,11 @@
             "inherits": "default-release"
         },
         {
+            "name": "linux-clang-release-ccache",
+            "configurePreset": "linux-clang-release-ccache",
+            "inherits": "linux-clang-release"
+        },
+        {
             "name": "linux-clang-test",
             "configurePreset": "linux-clang-test",
             "inherits": "default-release"
@@ -298,6 +321,11 @@
             "name": "linux-gcc-release",
             "configurePreset": "linux-gcc-release",
             "inherits": "default-release"
+        },
+        {
+            "name": "linux-gcc-release-ccache",
+            "configurePreset": "linux-gcc-release-ccache",
+            "inherits": "linux-gcc-release"
         },
         {
             "name": "linux-gcc-debug",

--- a/docs/developers/Building_Android.md
+++ b/docs/developers/Building_Android.md
@@ -62,7 +62,7 @@ Building for Android is a 2-step process. First, native C++ code is compiled to 
 This is a traditional CMake project, you can build it from command line or some IDE. You're not required to pass any custom options (except Conan toolchain file), defaults are already good. If you wish to use your own CMake presets, inherit them from our `build-with-conan` preset. Example:
 
 ```
-cmake -S . -B ../build -G Ninja -D CMAKE_BUILD_TYPE=Debug -D CMAKE_CXX_COMPILER_LAUNCHER=ccache -D CMAKE_C_COMPILER_LAUNCHER=ccache --toolchain ...
+cmake -S . -B ../build -G Ninja -D CMAKE_BUILD_TYPE=Debug -D ENABLE_CCACHE:BOOL=ON --toolchain ...
 cmake --build ../build
 ```
 

--- a/docs/developers/Building_Linux.md
+++ b/docs/developers/Building_Linux.md
@@ -76,7 +76,7 @@ cmake ../vcmi
 **Notice**: The ../vcmi/ is not a typo, it will place makefile scripts into the build dir as the build dir is your working dir when calling CMake.
 
 ## To use ccache:
-`cmake ../vcmi -D CMAKE_CXX_COMPILER_LAUNCHER=ccache -D CMAKE_C_COMPILER_LAUNCHER=ccache`
+`cmake ../vcmi -D ENABLE_CCACHE:BOOL=ON`
 
 ## Trigger build
 


### PR DESCRIPTION
# Enable ccache option for linux
## Rationale
Previously, developers had to know that for linux they have to pass `ccache` manually to `CMAKE_C(XX)_COMPILER_LAUNCHER` but for Windows and XCode it was sufficient to pass `ENABLE_CCACHE`. Now a dev just needs to care about passing `ENABLE_CCACHE` regardless of project generator / platform; which I think is a nice simplification

`ENABLE_CCACHE` is no longer generator / platform dependant option - the option always exists.

## Testing
Tested locally on linux, seems to behave as intended - when option is enabled `ccache` is used and otherwise it is not (verified by zeroing stats via `ccache --zero-stats` and `ccache --show-stats`).

## Documentation
Updated by searching for `ccache` and updating docs where needed