### PR TITLE
Add 'windows-mingw-release' CMake preset

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,9 +84,9 @@ if(ENABLE_CCACHE)
 	find_program(CCACHE ccache REQUIRED)
 endif()
 
-# On Linux, use ccache via CMAKE_CXX_COMPILER_LAUNCHER.
+# On Linux and MinGW, use ccache via CMAKE_CXX_COMPILER_LAUNCHER.
 # The XCode and MSVC builds each require some more configuration further down.
-if(ENABLE_CCACHE AND LINUX)
+if(ENABLE_CCACHE AND (LINUX OR MINGW))
 	set(CMAKE_C_COMPILER_LAUNCHER "ccache")
 	set(CMAKE_CXX_COMPILER_LAUNCHER "ccache")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,9 +84,8 @@ if(ENABLE_CCACHE)
 	find_program(CCACHE ccache REQUIRED)
 endif()
 
-# On Linux and MinGW, use ccache via CMAKE_CXX_COMPILER_LAUNCHER.
 # The XCode and MSVC builds each require some more configuration further down.
-if(ENABLE_CCACHE AND (LINUX OR MINGW))
+if(ENABLE_CCACHE)
 	set(CMAKE_C_COMPILER_LAUNCHER "ccache")
 	set(CMAKE_CXX_COMPILER_LAUNCHER "ccache")
 endif()

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -110,6 +110,15 @@
             }
         },
         {
+            "name": "windows-mingw-release",
+            "displayName": "Windows x64 MinGW Release",
+            "description": "VCMI Windows Ninja using MinGW",
+            "inherits": "default-release",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Release"
+            }
+        },
+        {
             "name": "windows-msvc-release",
             "displayName": "Windows x64 RelWithDebInfo",
             "description": "VCMI RelWithDebInfo build",
@@ -325,6 +334,11 @@
             "inherits": "default-release"
         },
         {
+            "name": "windows-mingw-release",
+            "configurePreset": "windows-mingw-release",
+            "inherits": "default-release"
+        },
+        {
             "name": "windows-msvc-release",
             "configurePreset": "windows-msvc-release",
             "inherits": "default-release"
@@ -408,6 +422,11 @@
         {
             "name": "macos-ninja-release",
             "configurePreset": "macos-ninja-release",
+            "inherits": "default-release"
+        },
+        {
+            "name": "windows-mingw-release",
+            "configurePreset": "windows-mingw-release",
             "inherits": "default-release"
         },
         {

--- a/client/render/Colors.cpp
+++ b/client/render/Colors.cpp
@@ -29,11 +29,11 @@ std::optional<ColorRGBA> Colors::parseColor(std::string text)
 {
 	std::smatch match;
 	std::regex expr("^#([0-9a-fA-F]{6})$");
-	ui8 rgb[3] = {0, 0, 0};
+	std::vector<ui8> rgb;
+	rgb.reserve(3);
 	if(std::regex_search(text, match, expr))
 	{
-		std::string tmp = boost::algorithm::unhex(match[1].str()); 
-		std::copy(tmp.begin(), tmp.end(), rgb);
+		boost::algorithm::unhex(match[1].str(), std::back_inserter(rgb)); 
 		return ColorRGBA(rgb[0], rgb[1], rgb[2]);
 	}
 
@@ -42,8 +42,7 @@ std::optional<ColorRGBA> Colors::parseColor(std::string text)
 	for(auto & color : colors) {
 		if(boost::algorithm::to_lower_copy(color.first) == boost::algorithm::to_lower_copy(text))
 		{
-			std::string tmp = boost::algorithm::unhex(color.second.String()); 
-			std::copy(tmp.begin(), tmp.end(), rgb);
+			boost::algorithm::unhex(color.second.String(), std::back_inserter(rgb)); 
 			return ColorRGBA(rgb[0], rgb[1], rgb[2]);
 		}
 	}

--- a/docs/developers/Building_Windows.md
+++ b/docs/developers/Building_Windows.md
@@ -114,8 +114,10 @@ Extract `ccache` to a folder of your choosing, add the folder to the `PATH` envi
 ## Compile VCMI with MinGW via MSYS2
 - Install MSYS2 from https://www.msys2.org/
 - Start the `MSYS MinGW x64`-shell
-- Install dependencies: `pacman -S mingw-w64-x86_64-SDL2 mingw-w64-x86_64-SDL2_image mingw-w64-x86_64-SDL2_mixer mingw-w64-x86_64-SDL2_ttf mingw-w64-x86_64-boost mingw-w64-x86_64-gcc mingw-w64-x86_64-ninja mingw-w64-x86_64-qt5-base mingw-w64-x86_64-qt5-tools`
+- Install dependencies: `pacman -S mingw-w64-x86_64-SDL2 mingw-w64-x86_64-SDL2_image mingw-w64-x86_64-SDL2_mixer mingw-w64-x86_64-SDL2_ttf mingw-w64-x86_64-boost mingw-w64-x86_64-gcc mingw-w64-x86_64-ninja mingw-w64-x86_64-qt5-static`
 - Generate and build solution from VCMI-root dir: `cmake --preset windows-mingw-release && cmake --build --preset windows-mingw-release`
+
+**NOTE:** This will link Qt5 statically to `VCMI_launcher.exe` and `VCMI_Mapeditor.exe`. See [PR #3421](https://github.com/vcmi/vcmi/pull/3421) for some background.
 
 # Create VCMI installer (This step is not required for just building & development)
 

--- a/docs/developers/Building_Windows.md
+++ b/docs/developers/Building_Windows.md
@@ -111,6 +111,12 @@ Extract `ccache` to a folder of your choosing, add the folder to the `PATH` envi
 - Right click on `BUILD_ALL` project. This `BUILD_ALL` project should be in `CMakePredefinedTargets` tree in Solution Explorer.
 - VCMI will be built in `%VCMI_DIR%/build/bin` folder!
 
+## Compile VCMI with MinGW via MSYS2
+- Install MSYS2 from https://www.msys2.org/
+- Start the `MSYS MinGW x64`-shell
+- Install dependencies: `pacman -S mingw-w64-x86_64-SDL2 mingw-w64-x86_64-SDL2_image mingw-w64-x86_64-SDL2_mixer mingw-w64-x86_64-SDL2_ttf mingw-w64-x86_64-boost mingw-w64-x86_64-gcc mingw-w64-x86_64-ninja mingw-w64-x86_64-qt5-base mingw-w64-x86_64-qt5-tools`
+- Generate and build solution from VCMI-root dir: `cmake --preset windows-mingw-release && cmake --build --preset windows-mingw-release`
+
 # Create VCMI installer (This step is not required for just building & development)
 
 Make sure NSIS is installed to default directory or have registry entry so CMake can find it.

--- a/lib/ResourceSet.cpp
+++ b/lib/ResourceSet.cpp
@@ -19,6 +19,8 @@
 
 VCMI_LIB_NAMESPACE_BEGIN
 
+ResourceSet::ResourceSet() = default;
+
 ResourceSet::ResourceSet(const JsonNode & node)
 {
 	for(auto i = 0; i < GameConstants::RESOURCE_QUANTITY; i++)

--- a/lib/ResourceSet.h
+++ b/lib/ResourceSet.h
@@ -30,7 +30,7 @@ private:
 public:
 	// read resources set from json. Format example: { "gold": 500, "wood":5 }
 	DLL_LINKAGE ResourceSet(const JsonNode & node);
-	DLL_LINKAGE ResourceSet() = default;
+	DLL_LINKAGE ResourceSet();
 
 
 #define scalarOperator(OPSIGN)									\


### PR DESCRIPTION
Adds a 'windows-mingw-release'-preset (configure, build and test).

Two commits [8846fba](https://github.com/vcmi/vcmi/pull/3421/commits/8846fba1fcec461c33c8649c1aef3f4e215d9513) and [100664e](https://github.com/vcmi/vcmi/pull/3421/commits/100664e019c37c85401df6744e85ee64aa35c611) fixes compilation errors using said preset.

Full disclosure: [100664e](https://github.com/vcmi/vcmi/pull/3421/commits/100664e019c37c85401df6744e85ee64aa35c611) is _not_ tested locally. I haven't gotten around to actually running locally built binaries yet. Let me know if you want me to test this locally, or if you were able to test it yourself.