### PR TITLE
Add 'ENABLE_EXPORT_COMPILE_COMMANDS'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ VCMI_VS11.sdf
 VCMI_VS11.opensdf
 .DS_Store
 CMakeUserPresets.json
+compile_commands.json
 
 # Visual Studio
 *.suo

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,6 +106,18 @@ if(ENABLE_CCACHE AND (CMAKE_GENERATOR STREQUAL "Xcode"))
 	set(CMAKE_XCODE_ATTRIBUTE_LDPLUSPLUS 	"${CMAKE_BINARY_DIR}/xcode/launch-cxx")
 endif()
 
+option(ENABLE_EXPORT_COMPILE_COMMANDS "Enable export of 'compile_commands.json', used by C++ tooling such as clangd or cppcheck" ON)
+if(ENABLE_EXPORT_COMPILE_COMMANDS)
+	# NOTE: compile_commands.json is generated during configuration-time
+	#       in the build directory (same directory as CMakeCache.txt)
+	#       Many tools look recursively upwards to find compile_commands.json,
+	#       so put a symlink at CMAKE_BINARY_DIR to help tooling.
+	set(CMAKE_EXPORT_COMPILE_COMMANDS on)
+	execute_process(
+		COMMAND cmake -E create_symlink "${CMAKE_BINARY_DIR}/compile_commands.json" "${CMAKE_CURRENT_SOURCE_DIR}/compile_commands.json"
+	)
+endif()
+
 # Allow to pass package name from Travis CI
 set(PACKAGE_NAME_SUFFIX "" CACHE STRING "Suffix for CPack package name")
 set(PACKAGE_FILE_NAME "" CACHE STRING "Override for CPack package filename")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,18 +106,6 @@ if(ENABLE_CCACHE AND (CMAKE_GENERATOR STREQUAL "Xcode"))
 	set(CMAKE_XCODE_ATTRIBUTE_LDPLUSPLUS 	"${CMAKE_BINARY_DIR}/xcode/launch-cxx")
 endif()
 
-option(ENABLE_EXPORT_COMPILE_COMMANDS "Enable export of 'compile_commands.json', used by C++ tooling such as clangd or cppcheck" ON)
-if(ENABLE_EXPORT_COMPILE_COMMANDS)
-	# NOTE: compile_commands.json is generated during configuration-time
-	#       in the build directory (same directory as CMakeCache.txt)
-	#       Many tools look recursively upwards to find compile_commands.json,
-	#       so put a symlink at CMAKE_BINARY_DIR to help tooling.
-	set(CMAKE_EXPORT_COMPILE_COMMANDS on)
-	execute_process(
-		COMMAND cmake -E create_symlink "${CMAKE_BINARY_DIR}/compile_commands.json" "${CMAKE_CURRENT_SOURCE_DIR}/compile_commands.json"
-	)
-endif()
-
 # Allow to pass package name from Travis CI
 set(PACKAGE_NAME_SUFFIX "" CACHE STRING "Suffix for CPack package name")
 set(PACKAGE_FILE_NAME "" CACHE STRING "Override for CPack package filename")


### PR DESCRIPTION
Add CMake option `ENABLE_EXPORT_COMPILE_COMMANDS`. The generated `compile_commands.json` is also symlinked to `CMAKE_BINARY_DIR`. Symlinking helps tooling, e.g `clangd` (which works out-of-the-box with VSCode as of this PR using `llvm-vs-code-extensions.vscode-clangd`), to find `compile_commands.json`.