### PR TITLE
Ignore compile_commands.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ VCMI_VS11.sdf
 VCMI_VS11.opensdf
 .DS_Store
 CMakeUserPresets.json
+compile_commands.json
 
 # Visual Studio
 *.suo


### PR DESCRIPTION
Ignore `compile_commands.json` in root directory. This is useful for workflows where users manually symlink `compile_commands.json` out of build directories, to get tools such as clangd, cppcheck, clang-tidy etc working locally.