### PR TITLE
Enable & fix glibc assertions

### DIFF
--- a/Global.h
+++ b/Global.h
@@ -100,6 +100,12 @@ static_assert(sizeof(bool) == 1, "Bool needs to be 1 byte in size.");
 
 #define _USE_MATH_DEFINES
 
+#ifndef NDEBUG
+// Enable additional debug checks from glibc / libstdc++ when building with enabled assertions
+// Since these defines must be declared BEFORE including glibc header we can not check for __GLIBCXX__ macro to detect that glibc is in use
+#  define _GLIBCXX_ASSERTIONS
+#endif
+
 #include <algorithm>
 #include <any>
 #include <array>

--- a/client/windows/CCreatureWindow.cpp
+++ b/client/windows/CCreatureWindow.cpp
@@ -666,6 +666,7 @@ CStackWindow::CStackWindow(const CStack * stack, bool popup)
 {
 	info->stack = stack;
 	info->stackNode = stack->base;
+	info->commander = dynamic_cast<const CCommanderInstance*>(stack->base);
 	info->creature = stack->unitType();
 	info->creatureCount = stack->getCount();
 	info->popupWindow = popup;

--- a/lib/CHeroHandler.cpp
+++ b/lib/CHeroHandler.cpp
@@ -257,7 +257,15 @@ CHeroClass * CHeroClassHandler::loadFromJson(const std::string & scope, const Js
 
 	VLC->generaltexth->registerString(scope, heroClass->getNameTextID(), node["name"].String());
 
-	heroClass->affinity = vstd::find_pos(affinityStr, node["affinity"].String());
+	if (vstd::contains(affinityStr, node["affinity"].String()))
+	{
+		heroClass->affinity = vstd::find_pos(affinityStr, node["affinity"].String());
+	}
+	else
+	{
+		logGlobal->error("Mod '%s', hero class '%s': invalid affinity '%s'! Expected 'might' or 'magic'!", scope, identifier, node["affinity"].String());
+		heroClass->affinity = CHeroClass::MIGHT;
+	}
 
 	fillPrimarySkillData(node, heroClass, PrimarySkill::ATTACK);
 	fillPrimarySkillData(node, heroClass, PrimarySkill::DEFENSE);


### PR DESCRIPTION
Apparently glibc provides optional assertions on illegal access to std containers, like out-of-bounds check in operator[]. Since this option is already in use on some distros (Arch, Fedora) we can even enable it in release builds for wider testing, but for beta I'd rather minimize potentially disruptive changes, so for now these assertions are only enabled when building in debug mode.

- Enabled assertions built-in into glibc/libstdc++ when building in debug mode
- Fixes #3446
- Side effect: it is now possible to inspect commander skills / artifacts during battles (broken pre-existing feature)
- Fixes #3429 