### PR TITLE
Better error-reporting for modding system errors

### DIFF
--- a/lib/modding/ContentTypeHandler.cpp
+++ b/lib/modding/ContentTypeHandler.cpp
@@ -111,7 +111,7 @@ bool ContentTypeHandler::loadMod(const std::string & modName, bool validate)
 			// - another mod attempts to add object into this mod (technically can be supported, but might lead to weird edge cases)
 			// - another mod attempts to edit object from this mod that no longer exist - DANGER since such patch likely has very incomplete data
 			// so emit warning and skip such case
-			logMod->warn("Mod %s attempts to edit object %s from mod %s but no such object exist!", data.meta, name, modName);
+			logMod->warn("Mod '%s' attempts to edit object '%s' of type '%s' from mod '%s' but no such object exist!", data.meta, name, objectName, modName);
 			continue;
 		}
 
@@ -157,6 +157,33 @@ void ContentTypeHandler::loadCustom()
 
 void ContentTypeHandler::afterLoadFinalization()
 {
+	for (auto const & data : modData)
+	{
+		if (data.second.modData.isNull())
+		{
+			for (auto node : data.second.patches.Struct())
+				logMod->warn("Mod '%s' have added patch for object '%s' from mod '%s', but this mod was not loaded or has no new objects.", node.second.meta, node.first, data.first);
+		}
+
+		for(auto & otherMod : modData)
+		{
+			if (otherMod.first == data.first)
+				continue;
+
+			if (otherMod.second.modData.isNull())
+				continue;
+
+			for(auto & otherObject : otherMod.second.modData.Struct())
+			{
+				if (data.second.modData.Struct().count(otherObject.first))
+				{
+					logMod->warn("Mod '%s' have added object with name '%s' that is also available in mod '%s'", data.first, otherObject.first, otherMod.first);
+					logMod->warn("Two objects with same name were loaded. Please use form '%s:%s' if mod '%s' needs to modify this object instead", otherMod.first, otherObject.first, data.first);
+				}
+			}
+		}
+	}
+
 	handler->afterLoadFinalization();
 }
 

--- a/lib/modding/IdentifierStorage.h
+++ b/lib/modding/IdentifierStorage.h
@@ -69,6 +69,8 @@ class DLL_LINKAGE CIdentifierStorage
 	bool resolveIdentifier(const ObjectCallback & callback) const;
 	std::vector<ObjectData> getPossibleIdentifiers(const ObjectCallback & callback) const;
 
+	void showIdentifierResolutionErrorDetails(const ObjectCallback & callback) const;
+	std::optional<si32> getIdentifierImpl(const ObjectCallback & callback, bool silent) const;
 public:
 	CIdentifierStorage();
 	virtual ~CIdentifierStorage() = default;

--- a/lib/modding/IdentifierStorage.h
+++ b/lib/modding/IdentifierStorage.h
@@ -32,6 +32,7 @@ class DLL_LINKAGE CIdentifierStorage
 		std::string name;        /// string ID
 		std::function<void(si32)> callback;
 		bool optional;
+		bool dynamicType;
 
 		/// Builds callback from identifier in form "targetMod:type.name"
 		static ObjectCallback fromNameWithType(const std::string & scope, const std::string & fullName, const std::function<void(si32)> & callback, bool optional);


### PR DESCRIPTION
Added better explanation of how vcmi modding system works, based on common issues reported by modders on Discord and forums. No actual changes in modding functionality other than better logging.

(note: all examples were made by breaking hota/wog mod and don't exist in current version)

Changes:
- if game fails to resolve identifier because mod with desired identifier is not a dependency vcmi will show which mod has this object and propose to add a dependency: 
```
Failed to resolve identifier 'santaGremlin' of type 'creature' from mod 'hota.interference'
Identifier 'santaGremlin' exists in mod wake-of-gods.creatures
Please add mod 'wake-of-gods.creatures' as dependency of mod 'hota.interference' to access this identifier
```
- if mod attempts to reference identifier as 'modID:objectID', but object ID actually exists in different (sub)mod, e.g. after changes in targeted mod, vcmi will suggest to use simple 'objectID' form or fixes 'actualModID:objectID' form
```
Failed to resolve identifier 'santaGremlin' of type 'creature' from mod 'hota.interference'
Identifier 'santaGremlin' exists in mod 'wake-of-gods.creatures' but identifier was explicitly requested from mod 'wake-of-gods'
Please use form 'santaGremlin' or 'wake-of-gods.creatures:santaGremlin' to access this identifier
```
- if two mods add object with same name, vcmi will warn about it - since in most cases one of these mods is actually trying to modify/patch another mod. (warning can be ignored if these mods are unrelated and add unrelated objects)
```
Mod 'wake-of-gods.creatures' have added object with name 'sorceress' that is also available in mod 'hota.cove'
Two objects with same name were loaded. Please use form 'hota.cove:sorceress' if mod 'wake-of-gods.creatures' needs to modify this object instead
```
- if mod attempts to patch another mod, but target mod was not found (e.g. typo/incorrect mod name) vcmi will warn that patch was not used (warning can be ignored if this was intentional, optional compatibility patch)
```
Mod 'hota.gameBalance' have added patch for object 'pikeman' from mod 'corez', but this mod was not loaded or has no new objects
```