### PR TITLE
Fix saving map settings (allowed abilities, spells, arts and heroes)

### DIFF
--- a/mapeditor/mapsettings/mapsettings.cpp
+++ b/mapeditor/mapsettings/mapsettings.cpp
@@ -81,7 +81,7 @@ void MapSettings::on_pushButton_clicked()
 	auto updateMapArray = [](const QListWidget * widget, auto & arr)
 	{
 		arr.clear();
-		for(int i = 0; i < arr.size(); ++i)
+		for(int i = 0; i < widget->count(); ++i)
 		{
 			auto * item = widget->item(i);
 			if (item->checkState() == Qt::Checked)


### PR DESCRIPTION
Looks like regression from refactoring (https://github.com/vcmi/vcmi/pull/3188/files#diff-b7dbe17f713c1167a1491a36dc64e31c139840c126396e13141778fe9a245682R83),
Fixes #3300 
About linked issues:
#3383 - could not reproduce at all
#3297 - this PR doesn't fix that