### PR TITLE
Remove trailing semicolons from macro definitions

### DIFF
--- a/AI/Nullkiller/AIGateway.cpp
+++ b/AI/Nullkiller/AIGateway.cpp
@@ -64,7 +64,7 @@ struct SetGlobalState
 };
 
 
-#define SET_GLOBAL_STATE(ai) SetGlobalState _hlpSetState(ai);
+#define SET_GLOBAL_STATE(ai) SetGlobalState _hlpSetState(ai)
 
 #define NET_EVENT_HANDLER SET_GLOBAL_STATE(this)
 #define MAKING_TURN SET_GLOBAL_STATE(this)

--- a/AI/VCAI/VCAI.cpp
+++ b/AI/VCAI/VCAI.cpp
@@ -66,7 +66,7 @@ struct SetGlobalState
 };
 
 
-#define SET_GLOBAL_STATE(ai) SetGlobalState _hlpSetState(ai);
+#define SET_GLOBAL_STATE(ai) SetGlobalState _hlpSetState(ai)
 
 #define NET_EVENT_HANDLER SET_GLOBAL_STATE(this)
 #define MAKING_TURN SET_GLOBAL_STATE(this)

--- a/include/vstd/CLoggerBase.h
+++ b/include/vstd/CLoggerBase.h
@@ -172,9 +172,10 @@ private:
 /// Macros for tracing the control flow of the application conveniently. If the LOG_TRACE macro is used it should be
 /// the first statement in the function. Logging traces via this macro have almost no impact when the trace is disabled.
 ///
-#define RAII_TRACE(logger, onEntry, onLeave)			\
-	if(logger->isTraceEnabled())						\
-		std::unique_ptr<vstd::CTraceLogger> ctl00 = std::make_unique<vstd::CTraceLogger>(logger, onEntry, onLeave)
+#define RAII_TRACE(logger, onEntry, onLeave)								\
+	std::unique_ptr<vstd::CTraceLogger> ctl00 = logger->isTraceEnabled() ?	\
+	std::make_unique<vstd::CTraceLogger>(logger, onEntry, onLeave) :		\
+    std::unique_ptr<vstd::CTraceLogger>()
 
 #define LOG_TRACE(logger) RAII_TRACE(logger,								\
 		boost::str(boost::format("Entering %s.") % BOOST_CURRENT_FUNCTION),	\

--- a/include/vstd/CLoggerBase.h
+++ b/include/vstd/CLoggerBase.h
@@ -173,9 +173,8 @@ private:
 /// the first statement in the function. Logging traces via this macro have almost no impact when the trace is disabled.
 ///
 #define RAII_TRACE(logger, onEntry, onLeave)			\
-	std::unique_ptr<vstd::CTraceLogger> ctl00;						\
 	if(logger->isTraceEnabled())						\
-		ctl00 = std::make_unique<vstd::CTraceLogger>(logger, onEntry, onLeave);
+		std::unique_ptr<vstd::CTraceLogger> ctl00 = std::make_unique<vstd::CTraceLogger>(logger, onEntry, onLeave)
 
 #define LOG_TRACE(logger) RAII_TRACE(logger,								\
 		boost::str(boost::format("Entering %s.") % BOOST_CURRENT_FUNCTION),	\


### PR DESCRIPTION
Fixes the following SonarCloud issue:

Modify the macro definition so that it needs to be followed by a semicolon, or remove this empty statement. Empty statements should be removed cpp:S1116
https://sonarcloud.io/organizations/vcmi/rules?open=cpp%3AS1116&rule_key=cpp%3AS1116