### PR TITLE
fix buggy multiplayer selection

### DIFF
--- a/client/lobby/OptionsTab.cpp
+++ b/client/lobby/OptionsTab.cpp
@@ -400,12 +400,11 @@ void OptionsTab::CPlayerOptionTooltipBox::genBonusWindow()
 	textBonusDescription = std::make_shared<CTextBox>(getDescription(), Rect(10, 100, pos.w - 20, 70), 0, FONT_SMALL, ETextAlignment::CENTER, Colors::WHITE);
 }
 
-OptionsTab::SelectionWindow::SelectionWindow(CPlayerSettingsHelper & helper, SelType _type)
-	: CWindowObject(BORDERED), CPlayerSettingsHelper(helper)
+OptionsTab::SelectionWindow::SelectionWindow(const PlayerColor & color, SelType _type)
+	: CWindowObject(BORDERED), color(color)
 {
 	addUsedEvents(LCLICK | SHOW_POPUP);
 
-	color = helper.playerSettings.color;
 	type = _type;
 
 	initialFaction = SEL->getStartInfo()->playerInfos.find(color)->second.castle;
@@ -481,9 +480,10 @@ void OptionsTab::SelectionWindow::setSelection()
 
 void OptionsTab::SelectionWindow::reopen()
 {
-	std::shared_ptr<SelectionWindow> window = std::shared_ptr<SelectionWindow>(new SelectionWindow(*this, type));
+	std::shared_ptr<SelectionWindow> window = std::shared_ptr<SelectionWindow>(new SelectionWindow(color, type));
 	close();
-	GH.windows().pushWindow(window);
+	if(CSH->isMyColor(color) || CSH->isHost())
+		GH.windows().pushWindow(window);
 }
 
 void OptionsTab::SelectionWindow::recreate()
@@ -632,7 +632,7 @@ void OptionsTab::SelectionWindow::genContentHeroes()
 
 void OptionsTab::SelectionWindow::genContentBonus()
 {
-	PlayerSettings set = PlayerSettings(playerSettings);
+	PlayerSettings set = SEL->getStartInfo()->playerInfos.find(color)->second;
 
 	int i = 0;
 	for(auto elem : allowedBonus)
@@ -819,7 +819,7 @@ void OptionsTab::SelectedBox::clickReleased(const Point & cursorPosition)
 		return;
 
 	GH.input().hapticFeedback();
-	GH.windows().createAndPushWindow<SelectionWindow>(*this, selectionType);
+	GH.windows().createAndPushWindow<SelectionWindow>(playerSettings.color, selectionType);
 }
 
 void OptionsTab::SelectedBox::scrollBy(int distance)

--- a/client/lobby/OptionsTab.h
+++ b/client/lobby/OptionsTab.h
@@ -96,7 +96,7 @@ private:
 		CPlayerOptionTooltipBox(CPlayerSettingsHelper & helper);
 	};
 
-	class SelectionWindow : public CWindowObject, public CPlayerSettingsHelper
+	class SelectionWindow : public CWindowObject
 	{
 		//const int ICON_SMALL_WIDTH = 48;
 		const int ICON_SMALL_HEIGHT = 32;
@@ -148,7 +148,7 @@ private:
 	public:
 		void reopen();
 
-		SelectionWindow(CPlayerSettingsHelper & helper, SelType _type);
+		SelectionWindow(const PlayerColor & color, SelType _type);
 	};
 
 	/// Image with current town/hero/bonus


### PR DESCRIPTION
Fix crash in multiplayer selection if selection changed from host while selection-window opened when
- Selection is changed
- Slot is changed