### PR TITLE
Replace redundant types with `auto`

### DIFF
--- a/AI/Nullkiller/Pathfinding/Actors.cpp
+++ b/AI/Nullkiller/Pathfinding/Actors.cpp
@@ -327,7 +327,7 @@ ExchangeResult HeroExchangeMap::tryExchangeNoLock(const ChainActor * other)
 			return result;
 		}
 
-		HeroActor * exchanged = new HeroActor(actor, other, newArmy, ai);
+		auto * exchanged = new HeroActor(actor, other, newArmy, ai);
 
 		exchanged->armyCost += newArmy->armyCost;
 		result.actor = exchanged;
@@ -342,7 +342,7 @@ HeroExchangeArmy * HeroExchangeMap::tryUpgrade(
 	const CGObjectInstance * upgrader,
 	TResources resources) const
 {
-	HeroExchangeArmy * target = new HeroExchangeArmy();
+	auto * target = new HeroExchangeArmy();
 	auto upgradeInfo = ai->armyManager->calculateCreaturesUpgrade(army, upgrader, resources);
 
 	if(upgradeInfo.upgradeValue)
@@ -393,7 +393,7 @@ HeroExchangeArmy * HeroExchangeMap::tryUpgrade(
 
 HeroExchangeArmy * HeroExchangeMap::pickBestCreatures(const CCreatureSet * army1, const CCreatureSet * army2) const
 {
-	HeroExchangeArmy * target = new HeroExchangeArmy();
+	auto * target = new HeroExchangeArmy();
 	auto bestArmy = ai->armyManager->getBestArmy(actor->hero, army1, army2);
 
 	for(auto & slotInfo : bestArmy)
@@ -445,7 +445,7 @@ std::string DwellingActor::toString() const
 
 CCreatureSet * DwellingActor::getDwellingCreatures(const CGDwelling * dwelling, bool waitForGrowth)
 {
-	CCreatureSet * dwellingCreatures = new CCreatureSet();
+	auto * dwellingCreatures = new CCreatureSet();
 
 	for(auto & creatureInfo : dwelling->creatures)
 	{

--- a/client/renderSDL/SDLImage.cpp
+++ b/client/renderSDL/SDLImage.cpp
@@ -184,7 +184,7 @@ std::shared_ptr<IImage> SDLImage::scaleFast(const Point & size) const
 	else
 		CSDL_Ext::setDefaultColorKey(scaled);//just in case
 
-	SDLImage * ret = new SDLImage(scaled, EImageBlitMode::ALPHA);
+	auto * ret = new SDLImage(scaled, EImageBlitMode::ALPHA);
 
 	ret->fullSize.x = (int) round((float)fullSize.x * scaleX);
 	ret->fullSize.y = (int) round((float)fullSize.y * scaleY);

--- a/launcher/lobby/lobby_moc.cpp
+++ b/launcher/lobby/lobby_moc.cpp
@@ -139,10 +139,10 @@ void Lobby::serverCommand(const ServerCommand & command) try
 
 			int playersJoined = args[tagPoint++].toInt();
 			int playersTotal = args[tagPoint++].toInt();
-			QTableWidgetItem * sessionPlayerItem = new QTableWidgetItem(QString("%1/%2").arg(playersJoined).arg(playersTotal));
+			auto * sessionPlayerItem = new QTableWidgetItem(QString("%1/%2").arg(playersJoined).arg(playersTotal));
 			ui->sessionsTable->setItem(i, 1, sessionPlayerItem);
 
-			QTableWidgetItem * sessionProtectedItem = new QTableWidgetItem();
+			auto * sessionProtectedItem = new QTableWidgetItem();
 			bool isPrivate = (args[tagPoint++] == "True");
 			sessionProtectedItem->setData(Qt::UserRole, isPrivate);
 			if(isPrivate)

--- a/launcher/modManager/cmodlistview_moc.cpp
+++ b/launcher/modManager/cmodlistview_moc.cpp
@@ -852,7 +852,7 @@ void CModListView::loadScreenshots()
 			{
 				// managed to load cached image
 				QIcon icon(pixmap);
-				QListWidgetItem * item = new QListWidgetItem(icon, QString(tr("Screenshot %1")).arg(ui->screenshotsList->count() + 1));
+				auto * item = new QListWidgetItem(icon, QString(tr("Screenshot %1")).arg(ui->screenshotsList->count() + 1));
 				ui->screenshotsList->addItem(item);
 			}
 		}

--- a/launcher/modManager/imageviewer_moc.cpp
+++ b/launcher/modManager/imageviewer_moc.cpp
@@ -43,7 +43,7 @@ void ImageViewer::showPixmap(QPixmap & pixmap, QWidget * parent)
 {
 	assert(!pixmap.isNull());
 
-	ImageViewer * iw = new ImageViewer(parent);
+	auto * iw = new ImageViewer(parent);
 
 	QSize size = pixmap.size();
 	size.scale(iw->calculateWindowSize(), Qt::KeepAspectRatio);

--- a/launcher/updatedialog_moc.cpp
+++ b/launcher/updatedialog_moc.cpp
@@ -79,7 +79,7 @@ UpdateDialog::~UpdateDialog()
 
 void UpdateDialog::showUpdateDialog(bool isManually)
 {
-	UpdateDialog * dialog = new UpdateDialog(isManually);
+	auto * dialog = new UpdateDialog(isManually);
 	
 	dialog->setAttribute(Qt::WA_DeleteOnClose);
 }

--- a/lib/mapObjects/CQuest.h
+++ b/lib/mapObjects/CQuest.h
@@ -98,7 +98,7 @@ public:
 class DLL_LINKAGE IQuestObject
 {
 public:
-	CQuest * quest = new CQuest();
+	auto * quest = new CQuest();
 
 	///Information about quest should remain accessible even if IQuestObject removed from map
 	///All CQuest objects are freed in CMap destructor

--- a/lib/mapObjects/CQuest.h
+++ b/lib/mapObjects/CQuest.h
@@ -98,7 +98,7 @@ public:
 class DLL_LINKAGE IQuestObject
 {
 public:
-	auto * quest = new CQuest();
+	CQuest * quest = new CQuest();
 
 	///Information about quest should remain accessible even if IQuestObject removed from map
 	///All CQuest objects are freed in CMap destructor

--- a/mapeditor/mainwindow.cpp
+++ b/mapeditor/mainwindow.cpp
@@ -586,7 +586,7 @@ void MainWindow::loadObjectsTree()
 	//adding terrains
 	for(auto & terrain : VLC->terrainTypeHandler->objects)
 	{
-		QPushButton *b = new QPushButton(QString::fromStdString(terrain->getNameTranslated()));
+		auto *b = new QPushButton(QString::fromStdString(terrain->getNameTranslated()));
 		ui->terrainLayout->addWidget(b);
 		connect(b, &QPushButton::clicked, this, [this, terrain]{ terrainButtonClicked(terrain->getId()); });
 
@@ -601,7 +601,7 @@ void MainWindow::loadObjectsTree()
 	//adding roads
 	for(auto & road : VLC->roadTypeHandler->objects)
 	{
-		QPushButton *b = new QPushButton(QString::fromStdString(road->getNameTranslated()));
+		auto *b = new QPushButton(QString::fromStdString(road->getNameTranslated()));
 		ui->roadLayout->addWidget(b);
 		connect(b, &QPushButton::clicked, this, [this, road]{ roadOrRiverButtonClicked(road->getIndex(), true); });
 	}
@@ -610,7 +610,7 @@ void MainWindow::loadObjectsTree()
 	//adding rivers
 	for(auto & river : VLC->riverTypeHandler->objects)
 	{
-		QPushButton *b = new QPushButton(QString::fromStdString(river->getNameTranslated()));
+		auto *b = new QPushButton(QString::fromStdString(river->getNameTranslated()));
 		ui->riverLayout->addWidget(b);
 		connect(b, &QPushButton::clicked, this, [this, river]{ roadOrRiverButtonClicked(river->getIndex(), false); });
 	}

--- a/mapeditor/objectbrowser.cpp
+++ b/mapeditor/objectbrowser.cpp
@@ -128,7 +128,7 @@ void ObjectBrowser::startDrag(Qt::DropActions supportedActions)
 	if(!mimeData)
 		return;
 		
-	QDrag *drag = new QDrag(this);
+	auto *drag = new QDrag(this);
 	drag->setMimeData(mimeData);
 	drag->exec(supportedActions);
 }

--- a/test/battle/CBattleInfoCallbackTest.cpp
+++ b/test/battle/CBattleInfoCallbackTest.cpp
@@ -85,7 +85,7 @@ public:
 
 	UnitFake & add(ui8 side)
 	{
-		UnitFake * unit = new UnitFake();
+		auto * unit = new UnitFake();
 		EXPECT_CALL(*unit, unitSide()).WillRepeatedly(Return(side));
 		unit->setDefaultExpectations();
 

--- a/test/mock/BattleFake.cpp
+++ b/test/mock/BattleFake.cpp
@@ -46,7 +46,7 @@ void UnitFake::expectAnyBonusSystemCall()
 
 UnitFake & UnitsFake::add(ui8 side)
 {
-	UnitFake * unit = new UnitFake();
+	auto * unit = new UnitFake();
 	ON_CALL(*unit, unitSide()).WillByDefault(Return(side));
 	unit->redirectBonusesToFake();
 


### PR DESCRIPTION
Fixes some instances of https://sonarcloud.io/organizations/vcmi/rules?open=cpp%3AS5827&rule_key=cpp%3AS5827

First, find lines with redundant types:

```bash
grep -r --include \*.h --include \*.cpp " = " * | grep -v auto | grep "cast<" | grep -v for | grep -v if | grep -Po ".*cast<.*?>" | grep -v googletest | grep -Po ".+ .+ = .+" | tr -d "\t" | grep -v "fuzzylite" > redudant_types.txt
```

Then replace the first one with auto:

```python
import re

with open("redundant_types.txt") as f:
    for line in f:
        print()
        line = line.strip()
        path = line.split(":", 1)[0]
        original_code = line.split(":")[1]
        code = original_code.replace("*", " * ").replace("  ", " ").replace("* >", "*>")
        print(path)
        print(code)
        statement_without_redundant_type_matches = re.findall(r"[a-zA-Z0-9_]+ =.*", code)
        if statement_without_redundant_type_matches:
            statement_without_redundant_type = statement_without_redundant_type_matches[0]
            new_code = f"auto {statement_without_redundant_type}"
            print(new_code)

            with open(path, "r") as f:
                filedata = f.read()

            filedata = filedata.replace(code, new_code)

            with open(path, "w") as f:
                f.write(filedata)
```