### PR TITLE
CI badge: Only report status of vcmi/vcmi, ignore statuses of PRs

### DIFF
--- a/docs/Readme.md
+++ b/docs/Readme.md
@@ -1,4 +1,4 @@
-[![GitHub](https://github.com/vcmi/vcmi/actions/workflows/github.yml/badge.svg)](https://github.com/vcmi/vcmi/actions/workflows/github.yml)
+[![VCMI](https://github.com/vcmi/vcmi/actions/workflows/github.yml/badge.svg?event=schedule)](https://github.com/vcmi/vcmi/actions/workflows/github.yml)
 [![Github Downloads](https://img.shields.io/github/downloads/vcmi/vcmi/1.4.0/total)](https://github.com/vcmi/vcmi/releases/tag/1.4.0)
 [![Github Downloads](https://img.shields.io/github/downloads/vcmi/vcmi/1.4.1/total)](https://github.com/vcmi/vcmi/releases/tag/1.4.1)
 [![Github Downloads](https://img.shields.io/github/downloads/vcmi/vcmi/1.4.2/total)](https://github.com/vcmi/vcmi/releases/tag/1.4.2)


### PR DESCRIPTION
Show status of latest scheduled CI run on the develop branch. Until now, the status of the latest CI run was shown, even if that was triggered by a PR