### PR TITLE
Add Dependabot configuration to update GitHub Actions

### DIFF
--- a/.github/.dependabot.yml
+++ b/.github/.dependabot.yml
@@ -1,0 +1,11 @@
+# https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot#example-dependabotyml-file-for-github-actions
+# Set update schedule for GitHub Actions
+
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every day
+      interval: "daily"


### PR DESCRIPTION
Dependabot automatically creates PRs to update GitHub Actions used in `.github/workflows/github.yml`

You just need to click `Enable Dependabot` here: https://github.com/vcmi/vcmi/network/updates

See https://github.com/Alexander-Wilms/vcmi/pulls for examples:

![image](https://github.com/vcmi/vcmi/assets/3226457/a654ed47-cec8-4afe-b40f-e4c0c6de898c)

The build failure seen above is just the usual macOS CI error.

`schedule.interval` can be `daily`, `weekly` or `monthly`: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#scheduleinterval


