### PR TITLE
Change default SDL driver name from opengl to empty (autoselection)

### DIFF
--- a/config/schemas/settings.json
+++ b/config/schemas/settings.json
@@ -199,6 +199,7 @@
 				},
 				"driver" : {
 					"type" : "string",
+					"defaultWindows" : "",
 					"default" : "opengl",
 					"description" : "preferred graphics backend driver name for SDL2"
 				},

--- a/launcher/settingsView/csettingsview_moc.cpp
+++ b/launcher/settingsView/csettingsview_moc.cpp
@@ -169,6 +169,8 @@ static QStringList getAvailableRenderingDrivers()
 	SDL_Init(SDL_INIT_VIDEO);
 	QStringList result;
 
+	result += QString(); // empty value for autoselection
+
 	int driversCount = SDL_GetNumRenderDrivers();
 
 	for(int it = 0; it < driversCount; it++)

--- a/lib/JsonNode.cpp
+++ b/lib/JsonNode.cpp
@@ -1289,7 +1289,12 @@ static JsonNode getDefaultValue(const JsonNode & schema, std::string fieldName)
 #elif defined(VCMI_ANDROID)
 	if (!fieldProps["defaultAndroid"].isNull())
 		return fieldProps["defaultAndroid"];
-#elif !defined(VCMI_MOBILE)
+#elif defined(VCMI_WINDOWS)
+	if (!fieldProps["defaultWindows"].isNull())
+		return fieldProps["defaultWindows"];
+#endif
+
+#if !defined(VCMI_MOBILE)
 	if (!fieldProps["defaultDesktop"].isNull())
 		return fieldProps["defaultDesktop"];
 #endif


### PR DESCRIPTION
We have too many cases where VCMI fails to start on Windows because SDL can't create opengl video driver.

This PR changes video driver on Windows to empty string which our code will interpret as using default / auto-selection.