### PR TITLE
CI config cleanup

### DIFF
--- a/.github/workflows/github.yml
+++ b/.github/workflows/github.yml
@@ -337,14 +337,6 @@ jobs:
       env:
         DEPLOY_RSA: ${{ secrets.DEPLOY_RSA }}
         PACKAGE_EXTENSION: ${{ matrix.extension }}
-
-    - uses: act10ns/slack@v2
-      with:
-        status: ${{ job.status }}
-        channel: '#notifications'
-      env:
-        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-      if: always()
   
   # copy-pasted mostly
   bundle_release:
@@ -437,11 +429,3 @@ jobs:
         name: ${{ env.VCMI_PACKAGE_FILE_NAME }}
         path: |
           ${{ env.ANDROID_APK_PATH }}
-
-    - uses: act10ns/slack@v2
-      with:
-        status: ${{ job.status }}
-        channel: '#notifications'
-      env:
-        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-      if: always()

--- a/.github/workflows/github.yml
+++ b/.github/workflows/github.yml
@@ -28,6 +28,7 @@ jobs:
       - name: Get repo name
         id: get_repo_name
         run: echo "::set-output name=value::${GITHUB_REPOSITORY#*/}"
+
       - name: Get last successful build for ${{ github.sha }}
         uses: octokit/request-action@v2.1.9
         id: get_last_scheduled_run
@@ -40,6 +41,7 @@ jobs:
           head_sha: ${{ github.sha }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Check if successful build of the current commit exists
         id: check_if_built
         run: |
@@ -48,6 +50,7 @@ jobs:
           else
             echo '::set-output name=skip_build::0'
           fi
+
       - name: Cancel current run
         if: steps.check_if_built.outputs.skip_build == 1
         uses: octokit/request-action@v2.1.9
@@ -58,6 +61,7 @@ jobs:
           run_id: ${{ github.run_id }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Wait for the run to be cancelled
         if: steps.check_if_built.outputs.skip_build == 1
         run: sleep 60
@@ -206,7 +210,7 @@ jobs:
         max-size: "5G"
         verbose: 2
 
-    - name: Clone Heroes 3 data
+    - name: Prepare Heroes 3 data
       env:
         HEROES_3_DATA_PASSWORD: ${{ secrets.HEROES_3_DATA_PASSWORD }}
       if: ${{ env.HEROES_3_DATA_PASSWORD != '' && matrix.test == 1 }}
@@ -376,6 +380,7 @@ jobs:
       if: "${{ matrix.conan_profile != '' }}"
       with:
         python-version: '3.10'
+
     - name: Conan setup
       if: "${{ matrix.conan_profile != '' }}"
       run: |

--- a/.github/workflows/github.yml
+++ b/.github/workflows/github.yml
@@ -236,10 +236,6 @@ jobs:
       env:
         GENERATE_ONLY_BUILT_CONFIG: 1
 
-    - name: Git branch name
-      id: git-branch-name
-      uses: EthanSK/git-branch-name-action@v1
-
     - name: Build Number
       run: |
         source '${{github.workspace}}/CI/get_package_name.sh'
@@ -394,10 +390,6 @@ jobs:
           ${{ matrix.conan_options }}
       env:
         GENERATE_ONLY_BUILT_CONFIG: 1
-
-    - name: Git branch name
-      id: git-branch-name
-      uses: EthanSK/git-branch-name-action@v1
 
     - name: Build Number
       run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -815,6 +815,10 @@ elseif(APPLE_MACOS AND NOT ENABLE_MONOLITHIC_INSTALL)
 	set(CPACK_MONOLITHIC_INSTALL 1)
 	set(CPACK_GENERATOR "DragNDrop")
 	set(CPACK_DMG_BACKGROUND_IMAGE "${CMAKE_SOURCE_DIR}/osx/dmg_background.png")
+	# Workaround for this issue:
+	# CPack Error: Error executing: /usr/bin/hdiutil detach "/Volumes/VCMI"
+	# https://github.com/actions/runner-images/issues/7522#issuecomment-1564467252
+	set(CPACK_COMMAND_HDIUTIL "/usr/bin/sudo /usr/bin/hdiutil")
 	# CMake code for CPACK_DMG_DS_STORE executed before DS_STORE_SETUP_SCRIPT
 	# So we can keep both enabled and this shouldn't hurt
 	# set(CPACK_DMG_DS_STORE "${CMAKE_SOURCE_DIR}/osx/dmg_DS_Store")

--- a/docs/Readme.md
+++ b/docs/Readme.md
@@ -1,4 +1,4 @@
-[![VCMI](https://github.com/vcmi/vcmi/actions/workflows/github.yml/badge.svg?event=schedule)](https://github.com/vcmi/vcmi/actions/workflows/github.yml)
+[![VCMI](https://github.com/vcmi/vcmi/actions/workflows/github.yml/badge.svg?event=schedule)](https://github.com/vcmi/vcmi/actions/workflows/github.yml?query=event%3Aschedule)
 [![Github Downloads](https://img.shields.io/github/downloads/vcmi/vcmi/1.4.0/total)](https://github.com/vcmi/vcmi/releases/tag/1.4.0)
 [![Github Downloads](https://img.shields.io/github/downloads/vcmi/vcmi/1.4.1/total)](https://github.com/vcmi/vcmi/releases/tag/1.4.1)
 [![Github Downloads](https://img.shields.io/github/downloads/vcmi/vcmi/1.4.2/total)](https://github.com/vcmi/vcmi/releases/tag/1.4.2)


### PR DESCRIPTION
Its output is unused and it causes this warning:

> The following actions uses node12 which is deprecated and will be forced to run on node16: EthanSK/git-branch-name-action@v1

https://github.com/vcmi/vcmi/actions/runs/7523451879