### PR TITLE
Remove trailing semicolons from more macros

### DIFF
--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -111,11 +111,7 @@
 // They all assume that interface mutex is locked.
 #define EVENT_HANDLER_CALLED_BY_CLIENT
 
-#define BATTLE_EVENT_POSSIBLE_RETURN	\
-	if (LOCPLINT != this)				\
-		return;							\
-	if (isAutoFightOn && !battleInt)	\
-		return;
+#define BATTLE_EVENT_POSSIBLE_RETURN	if (LOCPLINT != this) return; if (isAutoFightOn && !battleInt) return
 
 CPlayerInterface * LOCPLINT;
 

--- a/lib/battle/CPlayerBattleCallback.cpp
+++ b/lib/battle/CPlayerBattleCallback.cpp
@@ -64,7 +64,7 @@ TStacks CPlayerBattleCallback::battleGetStacks(EStackOwnership whose, bool onlyA
 
 int CPlayerBattleCallback::battleGetSurrenderCost() const
 {
-	RETURN_IF_NOT_BATTLE(-3)
+	RETURN_IF_NOT_BATTLE(-3);
 			ASSERT_IF_CALLED_WITH_PLAYER
 			return CBattleInfoCallback::battleGetSurrenderCost(*getPlayerID());
 }

--- a/lib/battle/IBattleInfoCallback.h
+++ b/lib/battle/IBattleInfoCallback.h
@@ -15,7 +15,7 @@
 
 #include <vcmi/Entity.h>
 
-#define RETURN_IF_NOT_BATTLE(...) if(!duringBattle()) {logGlobal->error("%s called when no battle!", __FUNCTION__); return __VA_ARGS__; }
+#define RETURN_IF_NOT_BATTLE(...) do { if(!duringBattle()) {logGlobal->error("%s called when no battle!", __FUNCTION__); return __VA_ARGS__; } } while (false)
 
 VCMI_LIB_NAMESPACE_BEGIN
 

--- a/lib/mapObjectConstructors/CObjectClassesHandler.cpp
+++ b/lib/mapObjectConstructors/CObjectClassesHandler.cpp
@@ -42,7 +42,7 @@ VCMI_LIB_NAMESPACE_BEGIN
 
 CObjectClassesHandler::CObjectClassesHandler()
 {
-#define SET_HANDLER_CLASS(STRING, CLASSNAME) handlerConstructors[STRING] = std::make_shared<CLASSNAME>;
+#define SET_HANDLER_CLASS(STRING, CLASSNAME) handlerConstructors[STRING] = std::make_shared<CLASSNAME>
 #define SET_HANDLER(STRING, TYPENAME) handlerConstructors[STRING] = std::make_shared<CDefaultObjectTypeHandler<TYPENAME>>
 
 	// list of all known handlers, hardcoded for now since the only way to add new objects is via C++ code

--- a/lib/rmg/modificators/Modificator.h
+++ b/lib/rmg/modificators/Modificator.h
@@ -21,8 +21,8 @@ class Zone;
 class MapProxy;
 
 #define MODIFICATOR(x) x(Zone & z, RmgMap & m, CMapGenerator & g): Modificator(z, m, g) {setName(#x);}
-#define DEPENDENCY(x) 		dependency(zone.getModificator<x>());
-#define POSTFUNCTION(x)		postfunction(zone.getModificator<x>());
+#define DEPENDENCY(x) 		dependency(zone.getModificator<x>())
+#define POSTFUNCTION(x)		postfunction(zone.getModificator<x>())
 #define DEPENDENCY_ALL(x) 	for(auto & z : map.getZones()) \
 							{ \
 								dependency(z.second->getModificator<x>()); \


### PR DESCRIPTION
The analysis also lists this as an error, but I don't know how one could make the trailing semicolon after the macro usage mandatory.

```
RETURN_IF_NOT_BATTLE(battle::Units());
```
https://sonarcloud.io/code?id=vcmi_vcmi&selected=vcmi_vcmi%3Alib%2Fbattle%2FCBattleInfoEssentials.cpp&line=120

The macro is defined as such:

```
#define RETURN_IF_NOT_BATTLE(...) if(!duringBattle()) {logGlobal->error("%s called when no battle!", __FUNCTION__); return __VA_ARGS__; }
```
https://github.com/vcmi/vcmi/blob/develop/lib/battle/IBattleInfoCallback.h#L18
