### PR TITLE
Backpack statusbar

### DIFF
--- a/client/widgets/CWindowWithArtifacts.cpp
+++ b/client/widgets/CWindowWithArtifacts.cpp
@@ -279,6 +279,9 @@ void CWindowWithArtifacts::gestureArtPlaceHero(CArtifactsOfHeroBase & artsInst, 
 				std::is_same_v<decltype(artSetWeak), std::weak_ptr<CArtifactsOfHeroMain>> ||
 				std::is_same_v<decltype(artSetWeak), std::weak_ptr<CArtifactsOfHeroKingdom>>)
 			{
+				if(!settings["general"]["enableUiEnhancements"].Bool())
+					return;
+
 				GH.windows().createAndPushWindow<CHeroQuickBackpackWindow>(artSetPtr->getHero(), artPlace.slot);
 				auto backpackWindow = GH.windows().topWindow<CHeroQuickBackpackWindow>();
 				backpackWindow->moveTo(cursorPosition - Point(1, 1));

--- a/client/windows/CHeroBackpackWindow.cpp
+++ b/client/windows/CHeroBackpackWindow.cpp
@@ -15,12 +15,13 @@
 
 #include "../widgets/Buttons.h"
 #include "../widgets/Images.h"
+#include "../widgets/TextControls.h"
 #include "CMessage.h"
 #include "render/Canvas.h"
 #include "CPlayerInterface.h"
 
 CHeroBackpackWindow::CHeroBackpackWindow(const CGHeroInstance * hero)
-	: CWindowObject((EOptions)0)
+	: CStatusbarWindow((EOptions)0)
 {
 	OBJECT_CONSTRUCTION_CAPTURING(255 - DISPOSE);
 
@@ -30,10 +31,14 @@ CHeroBackpackWindow::CHeroBackpackWindow(const CGHeroInstance * hero)
 	addSetAndCallbacks(arts);
 	arts->setHero(hero);
 	addCloseCallback(std::bind(&CHeroBackpackWindow::close, this));
-	quitButton = std::make_shared<CButton>(Point(), AnimationPath::builtin("IOKAY32.def"), CButton::tooltip(""), [this]() { close(); }, EShortcut::GLOBAL_RETURN);
+	quitButton = std::make_shared<CButton>(Point(), AnimationPath::builtin("IOKAY32.def"), CButton::tooltip(""),
+		[this]() { WindowBase::close(); }, EShortcut::GLOBAL_RETURN);
 	pos.w = stretchedBackground->pos.w = arts->pos.w + 2 * windowMargin;
 	pos.h = stretchedBackground->pos.h = arts->pos.h + quitButton->pos.h + 3 * windowMargin;
 	quitButton->moveTo(Point(pos.x + pos.w / 2 - quitButton->pos.w / 2, pos.y + arts->pos.h + 2 * windowMargin));
+	statusbar = CGStatusBar::create(0, pos.h, ImagePath::builtin("ADROLLVR.bmp"), pos.w);
+	pos.h += statusbar->pos.h;
+
 	center();
 }
 

--- a/client/windows/CHeroBackpackWindow.h
+++ b/client/windows/CHeroBackpackWindow.h
@@ -14,7 +14,7 @@
 
 class CFilledTexture;
 
-class CHeroBackpackWindow : public CWindowObject, public CWindowWithArtifacts
+class CHeroBackpackWindow : public CStatusbarWindow, public CWindowWithArtifacts
 {
 public:
 	CHeroBackpackWindow(const CGHeroInstance * hero);

--- a/lib/CArtHandler.cpp
+++ b/lib/CArtHandler.cpp
@@ -183,7 +183,7 @@ bool CArtifact::canBePutAt(const CArtifactSet * artSet, ArtifactPosition slot, b
 	{
 		if(ArtifactUtils::isSlotBackpack(slot))
 		{
-			if(isBig() || !ArtifactUtils::isBackpackFreeSlots(artSet))
+			if(isBig() || (!assumeDestRemoved && !ArtifactUtils::isBackpackFreeSlots(artSet)))
 				return false;
 			return true;
 		}

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -2870,8 +2870,8 @@ bool CGameHandler::assembleArtifacts(ObjectInstanceID heroID, ArtifactPosition a
 		{
 			COMPLAIN_RET("assembleArtifacts: It's impossible to assemble requested artifact!");
 		}
-		if(!destArtifact->canBePutAt(hero, artifactSlot)
-			&& !destArtifact->canBePutAt(hero, ArtifactPosition::BACKPACK_START))
+		if(!destArtifact->canBePutAt(hero, artifactSlot, true)
+			&& !destArtifact->canBePutAt(hero, ArtifactPosition::BACKPACK_START, true))
 		{
 			COMPLAIN_RET("assembleArtifacts: It's impossible to give the artholder requested artifact!");
 		}


### PR DESCRIPTION
- Fixed the assembly of the artifact in the backpack when the backpack limit is enabled and the backpack is full.
- Added a status bar to the backpack window. (The exit button is not displayed in the status bar. I don’t know how to add a translation correctly)
- Quick backpack window is now only available when enabled Interface enhancements