### PR TITLE
NKAI: avoid writing to commited tiles when calculating hero chain

### DIFF
--- a/AI/Nullkiller/Pathfinding/AINodeStorage.h
+++ b/AI/Nullkiller/Pathfinding/AINodeStorage.h
@@ -200,7 +200,8 @@ public:
 		EPathNodeAction action,
 		int turn,
 		int movementLeft,
-		float cost) const;
+		float cost,
+		bool saveToCommited = true) const;
 
 	inline const AIPathNode * getAINode(const CGPathNode * node) const
 	{


### PR DESCRIPTION
Attempt to fix async access to a collection