### PR TITLE
Fix inspector randomly using wrong editor(delegate) for some fields

### DIFF
--- a/mapeditor/inspector/inspector.h
+++ b/mapeditor/inspector/inspector.h
@@ -128,7 +128,6 @@ protected:
 		{
 			itemKey = keyItems[key];
 			table->setItem(table->row(itemKey), 1, itemValue);
-			if(delegate)
 				table->setItemDelegateForRow(table->row(itemKey), delegate);
 		}
 		else
@@ -139,7 +138,6 @@ protected:
 			table->setRowCount(row + 1);
 			table->setItem(row, 0, itemKey);
 			table->setItem(row, 1, itemValue);
-			if(delegate)
 				table->setItemDelegateForRow(row, delegate);
 			++row;
 		}


### PR DESCRIPTION
Reported on discord as 
> sometimes text fields in the inspector can shift into a rewards window and hero skills window

> it is impossible to set hero experience pts because it just pops up army settings

Happened because previous delegates were not cleared, looks like `setRowCount(0)` is not enough.
`setItemDelegateForRow` with `nullptr` should remove reference to old delegate