### PR TITLE
Add second workaround for CPack issue on macOS

### DIFF
--- a/.github/workflows/github.yml
+++ b/.github/workflows/github.yml
@@ -268,6 +268,13 @@ jobs:
       run: |
         ctest --preset ${{matrix.preset}}
 
+    - name: Kill XProtect to work around CPack issue on macOS 
+      if: runner.os == 'macOS'
+      run: |
+        # Cf. https://github.com/actions/runner-images/issues/7522#issuecomment-1556766641
+        echo Killing...; sudo pkill -9 XProtect >/dev/null || true;
+        echo Waiting...; while pgrep XProtect; do sleep 3; done;
+
     - name: Pack
       id: cpack
       if: ${{ matrix.pack == 1 }}
@@ -279,7 +286,7 @@ jobs:
           && '${{github.workspace}}/CI/${{matrix.platform}}/post_pack.sh' '${{github.workspace}}' "$(ls '${{ env.VCMI_PACKAGE_FILE_NAME }}'.*)"
         rm -rf _CPack_Packages
 
-    - name: Create android package
+    - name: Create Android package
       if: ${{ startsWith(matrix.platform, 'android') }}
       run: |
         cd android
@@ -414,7 +421,7 @@ jobs:
         name: Android JNI android-64
         path: ${{ github.workspace }}/android/vcmi-app/src/main/jniLibs/
  
-    - name: Create android package
+    - name: Create Android package
       run: |
         cd android
         ./gradlew bundleRelease --info

--- a/.github/workflows/github.yml
+++ b/.github/workflows/github.yml
@@ -282,7 +282,7 @@ jobs:
       run: |
         cd '${{github.workspace}}/out/build/${{matrix.preset}}'
         CPACK_PATH=`which -a cpack | grep -m1 -v -i chocolatey`
-        "$CPACK_PATH" -C ${{matrix.pack_type}} ${{ matrix.cpack_args }}
+        counter=0; until "$CPACK_PATH" -C ${{matrix.pack_type}} ${{ matrix.cpack_args }} || ((counter > 20)); do sleep 3; ((counter++)); done
         test -f '${{github.workspace}}/CI/${{matrix.platform}}/post_pack.sh' \
           && '${{github.workspace}}/CI/${{matrix.platform}}/post_pack.sh' '${{github.workspace}}' "$(ls '${{ env.VCMI_PACKAGE_FILE_NAME }}'.*)"
         rm -rf _CPack_Packages

--- a/.github/workflows/github.yml
+++ b/.github/workflows/github.yml
@@ -269,11 +269,12 @@ jobs:
         ctest --preset ${{matrix.preset}}
 
     - name: Kill XProtect to work around CPack issue on macOS 
-      if: runner.os == 'macOS'
+      if: ${{ startsWith(matrix.platform, 'mac') }}
       run: |
         # Cf. https://github.com/actions/runner-images/issues/7522#issuecomment-1556766641
         echo Killing...; sudo pkill -9 XProtect >/dev/null || true;
-        echo Waiting...; while pgrep XProtect; do sleep 3; done;
+        echo "Waiting..."; counter=0; while pgrep XProtect && ((counter < 20)); do sleep 3; ((counter++)); done
+        pgrep XProtect || true
 
     - name: Pack
       id: cpack


### PR DESCRIPTION
The `hdiutil: create failed - Resource busy` issue needs a different workaround than the `No child processes` issue.