### PR TITLE
Fix invalid logic which made AI not attack guards

### DIFF
--- a/lib/pathfinder/PathfindingRules.cpp
+++ b/lib/pathfinder/PathfindingRules.cpp
@@ -271,9 +271,9 @@ PathfinderBlockingRule::BlockingReason MovementAfterDestinationRule::getBlocking
 		if(destination.guarded)
 		{
 			if (pathfinderHelper->options.ignoreGuards)
-				return BlockingReason::DESTINATION_GUARDED;
-			else
 				return BlockingReason::NONE;
+			else
+				return BlockingReason::DESTINATION_GUARDED;
 		}
 
 		break;


### PR DESCRIPTION
Default value is set to false, but logic is reversed and thus adventure AI ignores guards and everything behind them.