### PR TITLE
CI: Always use latest XCode

### DIFF
--- a/CI/mac/before_install.sh
+++ b/CI/mac/before_install.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
-echo DEVELOPER_DIR=/Applications/Xcode_14.2.app >> $GITHUB_ENV
+LATEST_XCODE=$(ls /Applications | grep Xcode | tail -n 1)
+echo DEVELOPER_DIR=/Applications/$LATEST_XCODE >> $GITHUB_ENV
 
 brew install ninja
 


### PR DESCRIPTION
macOS 14 is now available on the GitHub Actions runners, which doesn't ship with XCode 14.2:

https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/

However, in order to get the CI build to work on macOS 14 more changes are required.

Currently, it gets stuck here:

```
 -- Conan: Target declared 'qt::qt'
CMake Error at conan-generated/cmakedeps_macros.cmake:39 (message):
  Library 'Qt5Designer' not found in package.  If 'Qt5Designer' is a system
  library, declare it with 'cpp_info.system_libs' property
Call Stack (most recent call first):
  conan-generated/Qt5-Target-release.cmake:24 (conan_package_library_targets)
  conan-generated/Qt5Targets.cmake:26 (include)
  conan-generated/Qt5Config.cmake:16 (include)
  CMakeLists.txt:480 (find_package)


-- Configuring incomplete, errors occurred!
Error: Process completed with exit code 1.
```

https://github.com/Alexander-Wilms/vcmi/actions/runs/7716509043/job/21033468843#step:12:155