### PR TITLE
Fix regressions

### DIFF
--- a/client/CMusicHandler.cpp
+++ b/client/CMusicHandler.cpp
@@ -188,7 +188,12 @@ uint32_t CSoundHandler::getSoundDurationMilliseconds(const AudioPath & sound)
 	if (!initialized || sound.empty())
 		return 0;
 
-	auto data = CResourceHandler::get()->load(sound.addPrefix("SOUNDS/"))->readAll();
+	auto resourcePath = sound.addPrefix("SOUNDS/");
+
+	if (!CResourceHandler::get()->existsResource(resourcePath))
+		return 0;
+
+	auto data = CResourceHandler::get()->load(resourcePath)->readAll();
 
 	SDL_AudioSpec spec;
 	uint32_t audioLen;

--- a/lib/MetaString.cpp
+++ b/lib/MetaString.cpp
@@ -325,6 +325,11 @@ void MetaString::serializeJson(JsonSerializeFormat & handler)
 		jsonDeserialize(handler.getCurrent());
 }
 
+void MetaString::appendName(const ArtifactID & id)
+{
+	appendTextID(id.toEntity(VLC)->getNameTextID());
+}
+
 void MetaString::appendName(const SpellID & id)
 {
 	appendTextID(id.toEntity(VLC)->getNameTextID());

--- a/lib/MetaString.h
+++ b/lib/MetaString.h
@@ -75,6 +75,7 @@ public:
 	/// Appends specified number to resulting string
 	void appendNumber(int64_t value);
 
+	void appendName(const ArtifactID& id);
 	void appendName(const SpellID& id);
 	void appendName(const PlayerColor& id);
 	void appendName(const CreatureID & id, TQuantity count);

--- a/lib/mapObjects/CGHeroInstance.cpp
+++ b/lib/mapObjects/CGHeroInstance.cpp
@@ -1276,7 +1276,7 @@ EDiggingStatus CGHeroInstance::diggingStatus() const
 {
 	if(static_cast<int>(movement) < movementPointsLimit(true))
 		return EDiggingStatus::LACK_OF_MOVEMENT;
-	if(ArtifactID(ArtifactID::GRAIL).toArtifact()->canBePutAt(this))
+	if(!ArtifactID(ArtifactID::GRAIL).toArtifact()->canBePutAt(this))
 		return EDiggingStatus::BACKPACK_IS_FULL;
 	return cb->getTileDigStatus(visitablePos());
 }

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -3699,8 +3699,8 @@ bool CGameHandler::dig(const CGHeroInstance *h)
 	{
 		ArtifactID grail = ArtifactID::GRAIL;
 
-		iw.text.appendLocalString(EMetaText::GENERAL_TXT, 58); //"Congratulations! After spending many hours digging here, your hero has uncovered the "
-		iw.text.replaceName(grail);
+		iw.text.appendLocalString(EMetaText::GENERAL_TXT, 58); //"Congratulations! After spending many hours digging here, your hero has uncovered the " ...
+		iw.text.appendName(grail); // ... " The Grail"
 		iw.soundID = soundBase::ULTIMATEARTIFACT;
 		giveHeroNewArtifact(h, grail.toArtifact(), ArtifactPosition::FIRST_AVAILABLE); //give grail
 		sendAndApply(&iw);


### PR DESCRIPTION
Discovered today on Discord:
- check for prolog/epilog audio existence before attempting to load it
- fixed inverted check for backpack space availability when digging for Grail
- fixed incorrect message on successful digging for Grail