### PR TITLE
adjustable queue size for embedded queue

### DIFF
--- a/client/battle/BattleInterfaceClasses.cpp
+++ b/client/battle/BattleInterfaceClasses.cpp
@@ -852,9 +852,14 @@ StackQueue::StackQueue(bool Embedded, BattleInterface & owner)
 	owner(owner)
 {
 	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+
+	uint32_t queueSize = QUEUE_SIZE_BIG;
+
 	if(embedded)
 	{
-		pos.w = QUEUE_SIZE * 41;
+		queueSize = std::clamp(static_cast<int>(settings["battle"]["queueSizeEmbeddedSlots"].Float()), 1, 19);
+
+		pos.w = queueSize * 41;
 		pos.h = 49;
 		pos.x += parent->pos.w/2 - pos.w/2;
 		pos.y += 10;
@@ -878,7 +883,7 @@ StackQueue::StackQueue(bool Embedded, BattleInterface & owner)
 	}
 	stateIcons->preload();
 
-	stackBoxes.resize(QUEUE_SIZE);
+	stackBoxes.resize(queueSize);
 	for (int i = 0; i < stackBoxes.size(); i++)
 	{
 		stackBoxes[i] = std::make_shared<StackBox>(this);

--- a/client/battle/BattleInterfaceClasses.h
+++ b/client/battle/BattleInterfaceClasses.h
@@ -239,7 +239,7 @@ class StackQueue : public CIntObject
 		std::optional<uint32_t> getBoundUnitID() const;
 	};
 
-	static const int QUEUE_SIZE = 10;
+	static const int QUEUE_SIZE_BIG = 10;
 	std::shared_ptr<CFilledTexture> background;
 	std::vector<std::shared_ptr<StackBox>> stackBoxes;
 	BattleInterface & owner;

--- a/config/schemas/settings.json
+++ b/config/schemas/settings.json
@@ -304,7 +304,7 @@
 			"type" : "object",
 			"additionalProperties" : false,
 			"default" : {},
-			"required" : [ "speedFactor", "mouseShadow", "cellBorders", "stackRange", "movementHighlightOnHover", "rangeLimitHighlightOnHover", "showQueue", "swipeAttackDistance", "queueSize", "stickyHeroInfoWindows", "enableAutocombatSpells", "endWithAutocombat" ],
+			"required" : [ "speedFactor", "mouseShadow", "cellBorders", "stackRange", "movementHighlightOnHover", "rangeLimitHighlightOnHover", "showQueue", "swipeAttackDistance", "queueSize", "stickyHeroInfoWindows", "enableAutocombatSpells", "endWithAutocombat", "queueSizeEmbeddedSlots" ],
 			"properties" : {
 				"speedFactor" : {
 					"type" : "number",
@@ -354,6 +354,10 @@
 				"endWithAutocombat" : {
 					"type": "boolean",
 					"default": false
+				},
+				"queueSizeEmbeddedSlots" : {
+					"type": "number",
+					"default": 10
 				}
 			}
 		},


### PR DESCRIPTION
![grafik](https://github.com/vcmi/vcmi/assets/13953785/7b04305d-067e-4e8a-951d-b639d3cbc007)

Possible to adjust from 1 to 19 slots. Only for embedded queue.

Only possible to change in `settings.json` yet:
```
	"battle" : {
		"queueSize" : "small",
		"queueSizeEmbeddedSlots" : 19
	},
```

Settings have currently no space for slider. Can be added later.