### PR TITLE
Map editor - fix submod list and mine resources

### DIFF
--- a/mapeditor/inspector/inspector.cpp
+++ b/mapeditor/inspector/inspector.cpp
@@ -370,7 +370,7 @@ void Inspector::updateProperties(CGMine * o)
 	
 	addProperty("Owner", o->tempOwner, false);
 	addProperty("Resource", o->producedResource);
-	addProperty("Productivity", o->producedQuantity, false);
+	addProperty("Productivity", o->producedQuantity);
 }
 
 void Inspector::updateProperties(CGResource * o)

--- a/mapeditor/mapcontroller.cpp
+++ b/mapeditor/mapcontroller.cpp
@@ -204,6 +204,15 @@ void MapController::repairMap(CMap * map) const
 				art->storedArtifact = a;
 			}
 		}
+		//fix mines 
+		if(auto * mine = dynamic_cast<CGMine*>(obj.get()))
+		{
+			if(!mine->isAbandoned())
+			{
+				mine->producedResource = GameResID(mine->subID);
+				mine->producedQuantity = mine->defaultResProduction();
+			}
+		}
 	}
 }
 

--- a/mapeditor/mapsettings/modsettings.cpp
+++ b/mapeditor/mapsettings/modsettings.cpp
@@ -78,9 +78,8 @@ void ModSettings::initialize(MapController & c)
 		auto pieces = qmodName.split(".");
 		assert(pieces.size() > 1);
 
-		QString qs;
-		for(int i = 0; i < pieces.size() - 1; ++i)
-			qs += pieces[i];
+		pieces.pop_back();
+		auto qs = pieces.join(".");
 
 		if(addedMods.count(qs))
 		{


### PR DESCRIPTION
Fixed two issues:
1. Mod list in settings didn't show more then one level of submods, visible with  In `The Wake of Gods->WoG Graphics Fix->Patched map objects`, until now last level was not visible
2. After loading map resource type and quantity was not initialized for mines and was showing garbage like player color instead of resource type . Also made quantity non editable same as type