### PR TITLE
#3550 - fix case when unit is in reachability map but only next turn

### DIFF
--- a/AI/BattleAI/BattleExchangeVariant.cpp
+++ b/AI/BattleAI/BattleExchangeVariant.cpp
@@ -843,7 +843,7 @@ bool BattleExchangeEvaluator::checkPositionBlocksOurStacks(HypotheticBattle & hb
 					}
 				}
 
-				if(!reachable && vstd::contains(reachabilityMap[hex], unit))
+				if(!reachable && std::count(reachabilityMap[hex].begin(), reachabilityMap[hex].end(), unit) > 1)
 				{
 					blockingScore += ratio * (enemyUnit ? BLOCKING_OWN_ATTACK_PENALTY : BLOCKING_OWN_MOVE_PENALTY);
 				}


### PR DESCRIPTION
Fix logic of battle ai when some units can reach enemy in 2 turns only