### PR TITLE
Fixes for RMG water

### DIFF
--- a/config/randomMap.json
+++ b/config/randomMap.json
@@ -3,8 +3,9 @@
   {
     "treasure" :
     [
-        { "min" : 2000, "max" : 6000, "density" : 1 },
-        { "min" : 100, "max" : 1000, "density" : 5 }
+        { "min" : 4000, "max" : 12000, "density" : 1 },
+        { "min" : 1000, "max" : 4000, "density" : 3 },
+        { "min" : 100, "max" : 1000, "density" : 6 }
     ],
     "shipyard" :
     {

--- a/lib/rmg/CZonePlacer.cpp
+++ b/lib/rmg/CZonePlacer.cpp
@@ -908,7 +908,7 @@ void CZonePlacer::assignZones(CRandomGenerator * rand)
 		vertexMapping[closestZone].insert(int3(vertex.x() * width, vertex.y() * height, closestZone->getPos().z)); //Closest vertex belongs to zone
 	}
 
-	//Assign actual tiles to each zone using nonlinear norm for fine edges
+	//Assign actual tiles to each zone
 	for (pos.z = 0; pos.z < levels; pos.z++)
 	{
 		for (pos.x = 0; pos.x < width; pos.x++)
@@ -918,7 +918,6 @@ void CZonePlacer::assignZones(CRandomGenerator * rand)
 				distances.clear();
 				for(const auto & zoneVertex : vertexMapping)
 				{
-					// FIXME: Find closest vertex, not closest zone
 					auto zone = zoneVertex.first;
 					for (const auto & vertex : zoneVertex.second)
 					{
@@ -929,7 +928,8 @@ void CZonePlacer::assignZones(CRandomGenerator * rand)
 					}
 				}
 
-				auto closestZone = boost::min_element(distances, simpleCompareByDistance)->first; //closest tile belongs to zone
+				//Tile closes to vertex belongs to zone
+				auto closestZone = boost::min_element(distances, simpleCompareByDistance)->first;
 				closestZone->area().add(pos);
 				map.setZoneID(pos, closestZone->getId());
 			}

--- a/lib/rmg/modificators/ObjectManager.cpp
+++ b/lib/rmg/modificators/ObjectManager.cpp
@@ -579,11 +579,15 @@ void ObjectManager::placeObject(rmg::Object & object, bool guarded, bool updateD
 
 		for (auto id : adjacentZones)
 		{
-			auto manager = map.getZones().at(id)->getModificator<ObjectManager>();
-			if (manager)
+			auto otherZone = map.getZones().at(id);
+			if ((otherZone->getType() == ETemplateZoneType::WATER) == (zone.getType()	== ETemplateZoneType::WATER))
 			{
-				// TODO: Update distances for perimeter of guarded object, not just treasures
-				manager->updateDistances(object);
+				// Do not update other zone if only one is water
+				auto manager = otherZone->getModificator<ObjectManager>();
+				if (manager)
+				{
+					manager->updateDistances(object);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
- Fix too many obstacles added to water zone
- Fix race condition which could occur if treasures wee placed at the shore before water zone was ready
- Set water treasure values to HoTA values. Original values were quite nonsensical, as there were not enough vanilla objects to even spawn in this range.