### PR TITLE
Fix SDL2MAIN_LIBRARY CMake warning

### DIFF
--- a/cmake_modules/FindSDL2.cmake
+++ b/cmake_modules/FindSDL2.cmake
@@ -314,13 +314,6 @@ FIND_PACKAGE_HANDLE_STANDARD_ARGS(SDL2
                                   REQUIRED_VARS SDL2_LIBRARY SDL2_INCLUDE_DIR
                                   VERSION_VAR SDL2_VERSION_STRING)
 
-if(SDL2MAIN_LIBRARY)
-  FIND_PACKAGE_HANDLE_STANDARD_ARGS(SDL2main
-                                    REQUIRED_VARS SDL2MAIN_LIBRARY SDL2_INCLUDE_DIR
-                                    VERSION_VAR SDL2_VERSION_STRING)
-endif()
-
-
 mark_as_advanced(SDL2_PATH
                  SDL2_NO_DEFAULT_PATH
                  SDL2_LIBRARY


### PR DESCRIPTION
```
 -- Found SDL2: /usr/lib/x86_64-linux-gnu/libSDL2.so (found version "2.0.20")
CMake Warning (dev) at /usr/local/share/cmake-3.28/Modules/FindPackageHandleStandardArgs.cmake:438 (message):
  The package name passed to `find_package_handle_standard_args` (SDL2main)
  does not match the name of the calling package (SDL2).  This can lead to
  problems in calling code that expects `find_package` result variables
  (e.g., `_FOUND`) to follow a certain pattern.
Call Stack (most recent call first):
  cmake_modules/FindSDL2.cmake:318 (FIND_PACKAGE_HANDLE_STANDARD_ARGS)
  CMakeLists.txt:473 (find_package)
This warning is for project developers.  Use -Wno-dev to suppress it.
```


This change gets rid of the warning, but I don't know if other references to `SDL2MAIN_LIBRARY` can be removed as well.