### PR TITLE
Fix crash on using heal in SPELL_AFTER_ATTACK bonus

### DIFF
--- a/lib/spells/effects/Heal.cpp
+++ b/lib/spells/effects/Heal.cpp
@@ -132,7 +132,8 @@ void Heal::prepareHealEffect(int64_t value, BattleUnitsChanged & pack, BattleLog
 			else if (unitHPgained > 0 && m->caster->getHeroCaster() == nullptr) //Show text about healed HP if healed by unit
 			{
 				MetaString healText;
-				auto casterUnit = dynamic_cast<const battle::Unit*>(m->caster);
+				auto casterUnitID = m->caster->getCasterUnitId();
+				auto casterUnit = m->battle()->battleGetUnitByID(casterUnitID);
 				healText.appendLocalString(EMetaText::GENERAL_TXT, 414);
 				casterUnit->addNameReplacement(healText, false);
 				state->addNameReplacement(healText, false);


### PR DESCRIPTION
Reported by povelitel via crash dump. Not 100% sure what are exact conditions, but seems to be caused by using spell with Heal effect in SPELL_BEFORE_ATTACK / SPELL_AFTER_ATTACK bonuses. Caused due to AbilityCaster containing Unit and not inheriting from it.