### PR TITLE
Better hero exchange in town

### DIFF
--- a/client/windows/CCastleInterface.cpp
+++ b/client/windows/CCastleInterface.cpp
@@ -427,7 +427,11 @@ void CHeroGSlot::clickPressed(const Point & cursorPosition)
 	if(hero && isSelected())
 	{
 		setHighlight(false);
-		LOCPLINT->openHeroWindow(hero);
+
+		if(other->hero)
+			LOCPLINT->showHeroExchange(hero->id, other->hero->id);
+		else
+			LOCPLINT->openHeroWindow(hero);
 	}
 	else if(other->hero && other->isSelected())
 	{
@@ -513,14 +517,6 @@ void HeroSlots::update()
 {
 	garrisonedHero->set(town->garrisonHero);
 	visitingHero->set(town->visitingHero);
-}
-
-void HeroSlots::splitClicked()
-{
-	if(!!town->visitingHero && town->garrisonHero && (visitingHero->isSelected() || garrisonedHero->isSelected()))
-	{
-		LOCPLINT->showHeroExchange(town->visitingHero->id, town->garrisonHero->id);
-	}
 }
 
 void HeroSlots::swapArmies()
@@ -1217,11 +1213,7 @@ CCastleInterface::CCastleInterface(const CGTownInstance * Town, const CGTownInst
 	exit = std::make_shared<CButton>(Point(744, 544), AnimationPath::builtin("TSBTNS"), CButton::tooltip(CGI->generaltexth->tcommands[8]), [&](){close();}, EShortcut::GLOBAL_RETURN);
 	exit->setImageOrder(4, 5, 6, 7);
 
-	auto split = std::make_shared<CButton>(Point(744, 382), AnimationPath::builtin("TSBTNS"), CButton::tooltip(CGI->generaltexth->tcommands[3]), [&]()
-	{
-		garr->splitClick();
-		heroes->splitClicked();
-	});
+	auto split = std::make_shared<CButton>(Point(744, 382), AnimationPath::builtin("TSBTNS"), CButton::tooltip(CGI->generaltexth->tcommands[3]), [this]() { garr->splitClick(); });
 	garr->addSplitBtn(split);
 
 	Rect barRect(9, 182, 732, 18);

--- a/client/windows/CCastleInterface.h
+++ b/client/windows/CCastleInterface.h
@@ -226,7 +226,6 @@ class CCastleInterface : public CStatusbarWindow, public IGarrisonHolder
 	std::shared_ptr<CTownInfo> fort;
 
 	std::shared_ptr<CButton> exit;
-	std::shared_ptr<CButton> split;
 	std::shared_ptr<CButton> fastTownHall;
 	std::shared_ptr<CButton> fastArmyPurchase;
 	std::shared_ptr<LRClickableArea> fastMarket;

--- a/client/windows/CCastleInterface.h
+++ b/client/windows/CCastleInterface.h
@@ -133,7 +133,6 @@ public:
 	HeroSlots(const CGTownInstance * town, Point garrPos, Point visitPos, std::shared_ptr<CGarrisonInt> Garrison, bool ShowEmpty);
 	~HeroSlots();
 
-	void splitClicked(); //for hero meeting only (splitting stacks is handled by garrison int)
 	void update();
 	void swapArmies(); //exchange garrisoned and visiting heroes or move hero to\from garrison
 };


### PR DESCRIPTION
Up to discussion. Now double-clicking hero portrait in town will open exchange screen if there are two heroes in town. 

Unlike current behavior (clicking on troop split button) this logic is easy to find for players and usable on mobiles. And if player need to open hero screen - he can click on hero portrait inside hero exchange screen.

Does not requires any new graphical assets and (AFAIK) this is behavior in Heroes 5, so should be familiar to some players.

- Supersedes #1424