### PR TITLE
Fix network crash

### DIFF
--- a/lib/CConsoleHandler.cpp
+++ b/lib/CConsoleHandler.cpp
@@ -143,13 +143,6 @@ LONG WINAPI onUnhandledException(EXCEPTION_POINTERS* exception)
 	HANDLE dfile = CreateFileA(mname, GENERIC_READ|GENERIC_WRITE, FILE_SHARE_WRITE|FILE_SHARE_READ, 0, CREATE_ALWAYS, 0, 0);
 	logGlobal->error("Crash info will be put in %s", mname);
 	
-	// flush loggers
-	std::string padding(1000, '@');
-
-	logGlobal->error(padding);
-	logAi->error(padding);
-	logNetwork->error(padding);
-
 	auto dumpType = MiniDumpWithDataSegs;
 	
 	if(settings["general"]["extraDump"].Bool())

--- a/lib/network/NetworkConnection.cpp
+++ b/lib/network/NetworkConnection.cpp
@@ -49,6 +49,12 @@ void NetworkConnection::onHeaderReceived(const boost::system::error_code & ecHea
 		return;
 	}
 
+	if (messageSize == 0)
+	{
+		listener.onDisconnected(shared_from_this(), "Zero-sized packet!");
+		return;
+	}
+
 	boost::asio::async_read(*socket,
 							readBuffer,
 							boost::asio::transfer_exactly(messageSize),

--- a/lib/network/NetworkConnection.cpp
+++ b/lib/network/NetworkConnection.cpp
@@ -88,6 +88,7 @@ void NetworkConnection::sendPacket(const std::vector<std::byte> & message)
 	// create array with single element - boost::asio::buffer can be constructed from containers, but not from plain integer
 	std::array<uint32_t, 1> messageSize{static_cast<uint32_t>(message.size())};
 
+	boost::mutex::scoped_lock lock(writeMutex);
 	boost::asio::write(*socket, boost::asio::buffer(messageSize), ec );
 	boost::asio::write(*socket, boost::asio::buffer(message), ec );
 

--- a/lib/network/NetworkConnection.h
+++ b/lib/network/NetworkConnection.h
@@ -19,6 +19,7 @@ class NetworkConnection : public INetworkConnection, public std::enable_shared_f
 	static const int messageMaxSize = 64 * 1024 * 1024; // arbitrary size to prevent potential massive allocation if we receive garbage input
 
 	std::shared_ptr<NetworkSocket> socket;
+	boost::mutex writeMutex;
 
 	NetworkBuffer readBuffer;
 	INetworkConnectionListener & listener;


### PR DESCRIPTION
Looks like multiple thread could call asio::write at the same time, leading to garbled data for receiver.
Also removed stream of '@@@' when vcmi crashes - since file flushing was fixed long ago.

Will check fix using CI artifacts. Was not reproducible for me for some reason.