### PR TITLE
Fix SonarCloud issue: non-portable path to file '<Windows.h>'

### DIFF
--- a/client/eventsSDL/NotificationHandler.cpp
+++ b/client/eventsSDL/NotificationHandler.cpp
@@ -18,7 +18,7 @@
 
 #define WIN32_LEAN_AND_MEAN		// Exclude rarely-used stuff from Windows headers
 // Windows Header Files:
-#include <windows.h>
+#include <Windows.h>
 #include <shellapi.h>
 // C RunTime Header Files
 

--- a/lib/CConsoleHandler.cpp
+++ b/lib/CConsoleHandler.cpp
@@ -31,8 +31,8 @@ VCMI_LIB_NAMESPACE_END
 	#define CONSOLE_GRAY "\x1b[1;30m"
 	#define CONSOLE_TEAL "\x1b[1;36m"
 #else
-	#include <windows.h>
-	#include <dbghelp.h>
+	#include <Windows.h>
+	#include <DbgHelp.h>
 #ifndef __MINGW32__
 	#pragma comment(lib, "dbghelp.lib")
 #endif

--- a/lib/CThreadHelper.cpp
+++ b/lib/CThreadHelper.cpp
@@ -11,7 +11,7 @@
 #include "CThreadHelper.h"
 
 #ifdef VCMI_WINDOWS
-	#include <windows.h>
+	#include <Windows.h>
 #elif defined(VCMI_HAIKU)
 	#include <OS.h>
 #elif !defined(VCMI_APPLE) && !defined(VCMI_FREEBSD) && \

--- a/lib/VCMIDirs.cpp
+++ b/lib/VCMIDirs.cpp
@@ -72,8 +72,8 @@ void IVCMIDirs::init()
 	#endif
 #endif // __MINGW32__
 
-#include <windows.h>
-#include <shlobj.h>
+#include <Windows.h>
+#include <ShlObj.h>
 #include <shellapi.h>
 
 // Generates script file named _temp.bat in 'to' directory and runs it


### PR DESCRIPTION
non-portable path to file '<Windows.h>'; specified path differs in case from file name on disk "#include" paths should be portable cpp:S3806

Cf. https://sonarcloud.io/project/issues?resolved=false&rules=cpp%3AS3806&types=CODE_SMELL&id=vcmi_vcmi&open=AYzk1AQFdKxbEY19qsF2
