### PR TITLE
Add additional constructor to JsonNode from const char *

### DIFF
--- a/lib/json/JsonNode.cpp
+++ b/lib/json/JsonNode.cpp
@@ -76,6 +76,11 @@ JsonNode::JsonNode(double number)
 {
 }
 
+JsonNode::JsonNode(const char * string)
+	: data(std::string(string))
+{
+}
+
 JsonNode::JsonNode(const std::string & string)
 	: data(string)
 {

--- a/lib/json/JsonNode.h
+++ b/lib/json/JsonNode.h
@@ -68,6 +68,7 @@ public:
 	explicit JsonNode(uint32_t number);
 	explicit JsonNode(int64_t number);
 	explicit JsonNode(double number);
+	explicit JsonNode(const char * string);
 	explicit JsonNode(const std::string & string);
 
 	/// Create tree from Json-formatted input


### PR DESCRIPTION
Fixes an issue where due to implicit conversion JsonNode(bool) will be called instead of expected JsonNode(std::string)

- Fixes #3643