### PR TITLE
Map editor fix owner selection

### DIFF
--- a/mapeditor/inspector/inspector.cpp
+++ b/mapeditor/inspector/inspector.cpp
@@ -298,7 +298,8 @@ void Inspector::updateProperties(CGHeroInstance * o)
 {
 	if(!o) return;
 	
-	addProperty("Owner", o->tempOwner, new OwnerDelegate(controller), o->ID == Obj::PRISON); //field is not editable for prison
+	auto isPrison = o->ID == Obj::PRISON;
+	addProperty("Owner", o->tempOwner, new OwnerDelegate(controller, isPrison), isPrison); //field is not editable for prison
 	addProperty<int>("Experience", o->exp, false);
 	addProperty("Hero class", o->type ? o->type->heroClass->getNameTranslated() : "", true);
 	
@@ -923,9 +924,10 @@ void InspectorDelegate::setModelData(QWidget *editor, QAbstractItemModel *model,
 	}
 }
 
-OwnerDelegate::OwnerDelegate(MapController & controller)
+OwnerDelegate::OwnerDelegate(MapController & controller, bool addNeutral)
 {
-	options.push_back({QObject::tr("neutral"), QVariant::fromValue(PlayerColor::NEUTRAL.getNum()) });
+	if(addNeutral)
+		options.push_back({QObject::tr("neutral"), QVariant::fromValue(PlayerColor::NEUTRAL.getNum()) });
 	for(int p = 0; p < controller.map()->players.size(); ++p)
 		if(controller.map()->players[p].canAnyonePlay())
 			options.push_back({QString::fromStdString(GameConstants::PLAYER_COLOR_NAMES[p]), QVariant::fromValue(PlayerColor(p).getNum()) });

--- a/mapeditor/inspector/inspector.cpp
+++ b/mapeditor/inspector/inspector.cpp
@@ -233,7 +233,7 @@ void Inspector::updateProperties(CGDwelling * o)
 {
 	if(!o) return;
 	
-	addProperty("Owner", o->tempOwner, false);
+	addProperty("Owner", o->tempOwner, new OwnerDelegate(controller), false);
 	
 	if (o->ID == Obj::RANDOM_DWELLING || o->ID == Obj::RANDOM_DWELLING_LVL)
 	{
@@ -245,15 +245,15 @@ void Inspector::updateProperties(CGDwelling * o)
 void Inspector::updateProperties(CGLighthouse * o)
 {
 	if(!o) return;
-	
-	addProperty("Owner", o->tempOwner, false);
+
+	addProperty("Owner", o->tempOwner, new OwnerDelegate(controller), false);
 }
 
 void Inspector::updateProperties(CGGarrison * o)
 {
 	if(!o) return;
 	
-	addProperty("Owner", o->tempOwner, false);
+	addProperty("Owner", o->tempOwner, new OwnerDelegate(controller), false);
 	addProperty("Removable units", o->removableUnits, false);
 }
 
@@ -261,14 +261,14 @@ void Inspector::updateProperties(CGShipyard * o)
 {
 	if(!o) return;
 	
-	addProperty("Owner", o->tempOwner, false);
+	addProperty("Owner", o->tempOwner, new OwnerDelegate(controller), false);
 }
 
 void Inspector::updateProperties(CGHeroPlaceholder * o)
 {
 	if(!o) return;
 	
-	addProperty("Owner", o->tempOwner, false);
+	addProperty("Owner", o->tempOwner, new OwnerDelegate(controller), false);
 	
 	bool type = false;
 	if(o->heroType.has_value())
@@ -298,7 +298,7 @@ void Inspector::updateProperties(CGHeroInstance * o)
 {
 	if(!o) return;
 	
-	addProperty("Owner", o->tempOwner, o->ID == Obj::PRISON); //field is not editable for prison
+	addProperty("Owner", o->tempOwner, new OwnerDelegate(controller), o->ID == Obj::PRISON); //field is not editable for prison
 	addProperty<int>("Experience", o->exp, false);
 	addProperty("Hero class", o->type ? o->type->heroClass->getNameTranslated() : "", true);
 	
@@ -368,7 +368,7 @@ void Inspector::updateProperties(CGMine * o)
 {
 	if(!o) return;
 	
-	addProperty("Owner", o->tempOwner, false);
+	addProperty("Owner", o->tempOwner, new OwnerDelegate(controller), false);
 	addProperty("Resource", o->producedResource);
 	addProperty("Productivity", o->producedQuantity);
 }
@@ -474,12 +474,7 @@ void Inspector::updateProperties()
 		addProperty("IsStatic", factory->isStaticObject());
 	}
 	
-	auto * delegate = new InspectorDelegate();
-	delegate->options.push_back({QObject::tr("neutral"), QVariant::fromValue(PlayerColor::NEUTRAL.getNum())});
-	for(int p = 0; p < controller.map()->players.size(); ++p)
-		if(controller.map()->players[p].canAnyonePlay())
-			delegate->options.push_back({QString::fromStdString(GameConstants::PLAYER_COLOR_NAMES[p]), QVariant::fromValue(PlayerColor(p).getNum())});
-	addProperty("Owner", obj->tempOwner, delegate, true);
+	addProperty("Owner", obj->tempOwner, new OwnerDelegate(controller), true);
 	
 	UPDATE_OBJ_PROPERTIES(CArmedInstance);
 	UPDATE_OBJ_PROPERTIES(CGResource);
@@ -926,4 +921,12 @@ void InspectorDelegate::setModelData(QWidget *editor, QAbstractItemModel *model,
 	{
 		QStyledItemDelegate::setModelData(editor, model, index);
 	}
+}
+
+OwnerDelegate::OwnerDelegate(MapController & controller)
+{
+	options.push_back({QObject::tr("neutral"), QVariant::fromValue(PlayerColor::NEUTRAL.getNum()) });
+	for(int p = 0; p < controller.map()->players.size(); ++p)
+		if(controller.map()->players[p].canAnyonePlay())
+			options.push_back({QString::fromStdString(GameConstants::PLAYER_COLOR_NAMES[p]), QVariant::fromValue(PlayerColor(p).getNum()) });
 }

--- a/mapeditor/inspector/inspector.h
+++ b/mapeditor/inspector/inspector.h
@@ -177,5 +177,5 @@ class OwnerDelegate : public InspectorDelegate
 {
 	Q_OBJECT
 public:
-	OwnerDelegate(MapController &);
+	OwnerDelegate(MapController & controller, bool addNeutral = true);
 };

--- a/mapeditor/inspector/inspector.h
+++ b/mapeditor/inspector/inspector.h
@@ -128,7 +128,7 @@ protected:
 		{
 			itemKey = keyItems[key];
 			table->setItem(table->row(itemKey), 1, itemValue);
-				table->setItemDelegateForRow(table->row(itemKey), delegate);
+			table->setItemDelegateForRow(table->row(itemKey), delegate);
 		}
 		else
 		{
@@ -138,7 +138,7 @@ protected:
 			table->setRowCount(row + 1);
 			table->setItem(row, 0, itemKey);
 			table->setItem(row, 1, itemValue);
-				table->setItemDelegateForRow(row, delegate);
+			table->setItemDelegateForRow(row, delegate);
 			++row;
 		}
 		itemKey->setFlags(restricted ? Qt::NoItemFlags : Qt::ItemIsEnabled);
@@ -170,4 +170,12 @@ public:
 	void setModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const override;
 	
 	QList<std::pair<QString, QVariant>> options;
+};
+
+
+class OwnerDelegate : public InspectorDelegate
+{
+	Q_OBJECT
+public:
+	OwnerDelegate(MapController &);
 };


### PR DESCRIPTION
Fixes #3635 

Before my changes from #3541 original InspectorDelegate was reused even after re-adding owner property later. After my change re-adding owner resulted in clearing delegate, so we need to set it up every time we add owner property.
