### PR TITLE
change BonusList:totalValue to return float (not int as before)

### DIFF
--- a/lib/BasicTypes.cpp
+++ b/lib/BasicTypes.cpp
@@ -118,7 +118,7 @@ int AFactionMember::moraleValAndBonusList(TConstBonusListPtr & bonusList) const
 	static const std::string cachingStrMor = "type_MORALE";
 	bonusList = getBonusBearer()->getBonuses(moraleSelector, cachingStrMor);
 
-	return std::clamp(bonusList->totalValue(), maxBadMorale, maxGoodMorale);
+	return std::clamp((int)bonusList->totalValue(), maxBadMorale, maxGoodMorale);
 }
 
 int AFactionMember::luckValAndBonusList(TConstBonusListPtr & bonusList) const
@@ -144,7 +144,7 @@ int AFactionMember::luckValAndBonusList(TConstBonusListPtr & bonusList) const
 	static const std::string cachingStrLuck = "type_LUCK";
 	bonusList = getBonusBearer()->getBonuses(luckSelector, cachingStrLuck);
 
-	return std::clamp(bonusList->totalValue(), maxBadLuck, maxGoodLuck);
+	return std::clamp((int)bonusList->totalValue(), maxBadLuck, maxGoodLuck);
 }
 
 int AFactionMember::moraleVal() const
@@ -163,7 +163,7 @@ ui32 ACreature::getMaxHealth() const
 {
 	const std::string cachingStr = "type_STACK_HEALTH";
 	static const auto selector = Selector::type()(BonusType::STACK_HEALTH);
-	auto value = getBonusBearer()->valOfBonuses(selector, cachingStr);
+	auto value = (int)getBonusBearer()->valOfBonuses(selector, cachingStr);
 	return std::max(1, value); //never 0
 }
 

--- a/lib/CArtifactInstance.cpp
+++ b/lib/CArtifactInstance.cpp
@@ -84,7 +84,7 @@ void CGrowingArtifactInstance::growingUp()
 		for(const auto & bonus : artInst->artType->getBonusesPerLevel())
 		{
 			// Every n levels
-			if(artInst->valOfBonuses(BonusType::LEVEL_COUNTER) % bonus.first == 0)
+			if((int)artInst->valOfBonuses(BonusType::LEVEL_COUNTER) % bonus.first == 0)
 			{
 				artInst->accumulateBonus(std::make_shared<Bonus>(bonus.second));
 			}

--- a/lib/bonuses/BonusList.cpp
+++ b/lib/bonuses/BonusList.cpp
@@ -83,21 +83,21 @@ void BonusList::stackBonuses()
 	}
 }
 
-int BonusList::totalValue() const
+float BonusList::totalValue() const
 {
 	struct BonusCollection
 	{
-		int base = 0;
-		int percentToBase = 0;
-		int percentToAll = 0;
-		int additive = 0;
-		int percentToSource = 0;
-		int indepMin = std::numeric_limits<int>::max();
-		int indepMax = std::numeric_limits<int>::min();
+		float base = 0;
+		float percentToBase = 0;
+		float percentToAll = 0;
+		float additive = 0;
+		float percentToSource = 0;
+		float indepMin = std::numeric_limits<float>::max();
+		float indepMax = std::numeric_limits<float>::min();
 	};
 
-	auto percent = [](int64_t base, int64_t percent) -> int {
-		return static_cast<int>(std::clamp<int64_t>((base * (100 + percent)) / 100, std::numeric_limits<int>::min(), std::numeric_limits<int>::max()));
+	auto percent = [](float base, float percent) -> float {
+		return static_cast<float>(std::clamp<float>((base * (100 + percent)) / 100, std::numeric_limits<float>::min(), std::numeric_limits<float>::max()));
 	};
 	std::array <BonusCollection, vstd::to_underlying(BonusSource::NUM_BONUS_SOURCE)> sources = {};
 	BonusCollection any;

--- a/lib/bonuses/BonusList.h
+++ b/lib/bonuses/BonusList.h
@@ -59,7 +59,7 @@ public:
 
 	// BonusList functions
 	void stackBonuses();
-	int totalValue() const;
+	float totalValue() const;
 	void getBonuses(BonusList &out, const CSelector &selector, const CSelector &limit = nullptr) const;
 	void getAllBonuses(BonusList &out) const;
 

--- a/lib/bonuses/IBonusBearer.cpp
+++ b/lib/bonuses/IBonusBearer.cpp
@@ -15,7 +15,7 @@
 
 VCMI_LIB_NAMESPACE_BEGIN
 
-int IBonusBearer::valOfBonuses(const CSelector &selector, const std::string &cachingStr) const
+float IBonusBearer::valOfBonuses(const CSelector &selector, const std::string &cachingStr) const
 {
 	TConstBonusListPtr hlp = getAllBonuses(selector, nullptr, nullptr, cachingStr);
 	return hlp->totalValue();
@@ -42,7 +42,7 @@ TConstBonusListPtr IBonusBearer::getBonuses(const CSelector &selector, const CSe
 	return getAllBonuses(selector, limit, nullptr, cachingStr);
 }
 
-int IBonusBearer::valOfBonuses(BonusType type) const
+float IBonusBearer::valOfBonuses(BonusType type) const
 {
 	//This part is performance-critical
 	std::string cachingStr = "type_" + std::to_string(static_cast<int>(type));
@@ -62,7 +62,7 @@ bool IBonusBearer::hasBonusOfType(BonusType type) const
 	return hasBonus(s, cachingStr);
 }
 
-int IBonusBearer::valOfBonuses(BonusType type, BonusSubtypeID subtype) const
+float IBonusBearer::valOfBonuses(BonusType type, BonusSubtypeID subtype) const
 {
 	//This part is performance-critical
 	std::string cachingStr = "type_" + std::to_string(static_cast<int>(type)) + "_" + subtype.toString();

--- a/lib/bonuses/IBonusBearer.h
+++ b/lib/bonuses/IBonusBearer.h
@@ -24,7 +24,7 @@ public:
 	IBonusBearer() = default;
 	virtual ~IBonusBearer() = default;
 	virtual TConstBonusListPtr getAllBonuses(const CSelector &selector, const CSelector &limit, const CBonusSystemNode *root = nullptr, const std::string &cachingStr = "") const = 0;
-	int valOfBonuses(const CSelector &selector, const std::string &cachingStr = "") const;
+	float valOfBonuses(const CSelector &selector, const std::string &cachingStr = "") const;
 	bool hasBonus(const CSelector &selector, const std::string &cachingStr = "") const;
 	bool hasBonus(const CSelector &selector, const CSelector &limit, const std::string &cachingStr = "") const;
 	TConstBonusListPtr getBonuses(const CSelector &selector, const CSelector &limit, const std::string &cachingStr = "") const;
@@ -33,9 +33,9 @@ public:
 	std::shared_ptr<const Bonus> getBonus(const CSelector &selector) const; //returns any bonus visible on node that matches (or nullptr if none matches)
 
 	//Optimized interface (with auto-caching)
-	int valOfBonuses(BonusType type) const; //subtype -> subtype of bonus;
+	float valOfBonuses(BonusType type) const; //subtype -> subtype of bonus;
 	bool hasBonusOfType(BonusType type) const;//determines if hero has a bonus of given type (and optionally subtype)
-	int valOfBonuses(BonusType type, BonusSubtypeID subtype) const; //subtype -> subtype of bonus;
+	float valOfBonuses(BonusType type, BonusSubtypeID subtype) const; //subtype -> subtype of bonus;
 	bool hasBonusOfType(BonusType type, BonusSubtypeID subtype) const;//determines if hero has a bonus of given type (and optionally subtype)
 	bool hasBonusFrom(BonusSource source, BonusSourceID sourceID) const;
 

--- a/lib/mapObjects/CGHeroInstance.cpp
+++ b/lib/mapObjects/CGHeroInstance.cpp
@@ -89,7 +89,7 @@ static int lowestSpeed(const CGHeroInstance * chi)
 
 	int ret = (i++)->second->valOfBonuses(selectorSTACKS_SPEED, keySTACKS_SPEED);
 	for(; i != chi->Slots().end(); i++)
-		ret = std::min(ret, i->second->valOfBonuses(selectorSTACKS_SPEED, keySTACKS_SPEED));
+		ret = std::min(ret, (int)i->second->valOfBonuses(selectorSTACKS_SPEED, keySTACKS_SPEED));
 	return ret;
 }
 
@@ -1198,7 +1198,7 @@ const std::set<SpellID> & CGHeroInstance::getSpellsInSpellbook() const
 
 int CGHeroInstance::maxSpellLevel() const
 {
-	return std::min(GameConstants::SPELL_LEVELS, valOfBonuses(Selector::type()(BonusType::MAX_LEARNABLE_SPELL_LEVEL)));
+	return std::min(GameConstants::SPELL_LEVELS, (int)valOfBonuses(Selector::type()(BonusType::MAX_LEARNABLE_SPELL_LEVEL)));
 }
 
 void CGHeroInstance::attachToBoat(CGBoat* newBoat)

--- a/lib/pathfinder/TurnInfo.cpp
+++ b/lib/pathfinder/TurnInfo.cpp
@@ -112,7 +112,7 @@ int TurnInfo::valOfBonuses(BonusType type, BonusSubtypeID subtype) const
 		return bonusCache->pathfindingVal;
 	}
 
-	return bonuses->valOfBonuses(Selector::type()(type).And(Selector::subtype()(subtype)));
+	return (int)bonuses->valOfBonuses(Selector::type()(type).And(Selector::subtype()(subtype)));
 }
 
 int TurnInfo::getMaxMovePoints(const EPathfindingLayer & layer) const

--- a/server/battles/BattleFlowProcessor.cpp
+++ b/server/battles/BattleFlowProcessor.cpp
@@ -279,7 +279,7 @@ const CStack * BattleFlowProcessor::getNextStack(const CBattleInfoCallback & bat
 
 		const int32_t lostHealth = stack->getMaxHealth() - stack->getFirstHPleft();
 		if(stack->hasBonusOfType(BonusType::HP_REGENERATION))
-			bte.val = std::min(lostHealth, stack->valOfBonuses(BonusType::HP_REGENERATION));
+			bte.val = std::min(lostHealth, (int)stack->valOfBonuses(BonusType::HP_REGENERATION));
 
 		if(bte.val) // anything to heal
 			gameHandler->sendAndApply(&bte);
@@ -384,7 +384,7 @@ bool BattleFlowProcessor::tryMakeAutomaticAction(const CBattleInfoCallback & bat
 	const CreatureID stackCreatureId = next->unitType()->getId();
 
 	if ((stackCreatureId == CreatureID::ARROW_TOWERS || stackCreatureId == CreatureID::BALLISTA)
-		&& (!curOwner || gameHandler->getRandomGenerator().nextInt(99) >= curOwner->valOfBonuses(BonusType::MANUAL_CONTROL, BonusSubtypeID(stackCreatureId))))
+		&& (!curOwner || gameHandler->getRandomGenerator().nextInt(99) >= (int)curOwner->valOfBonuses(BonusType::MANUAL_CONTROL, BonusSubtypeID(stackCreatureId))))
 	{
 		BattleAction attack;
 		attack.actionType = EActionType::SHOOT;
@@ -429,7 +429,7 @@ bool BattleFlowProcessor::tryMakeAutomaticAction(const CBattleInfoCallback & bat
 			return true;
 		}
 
-		if (!curOwner || gameHandler->getRandomGenerator().nextInt(99) >= curOwner->valOfBonuses(BonusType::MANUAL_CONTROL, BonusSubtypeID(CreatureID(CreatureID::CATAPULT))))
+		if (!curOwner || gameHandler->getRandomGenerator().nextInt(99) >= (int)curOwner->valOfBonuses(BonusType::MANUAL_CONTROL, BonusSubtypeID(CreatureID(CreatureID::CATAPULT))))
 		{
 			BattleAction attack;
 			attack.actionType = EActionType::CATAPULT;
@@ -454,7 +454,7 @@ bool BattleFlowProcessor::tryMakeAutomaticAction(const CBattleInfoCallback & bat
 			return true;
 		}
 
-		if (!curOwner || gameHandler->getRandomGenerator().nextInt(99) >= curOwner->valOfBonuses(BonusType::MANUAL_CONTROL, BonusSubtypeID(CreatureID(CreatureID::FIRST_AID_TENT))))
+		if (!curOwner || gameHandler->getRandomGenerator().nextInt(99) >= (int)curOwner->valOfBonuses(BonusType::MANUAL_CONTROL, BonusSubtypeID(CreatureID(CreatureID::FIRST_AID_TENT))))
 		{
 			RandomGeneratorUtil::randomShuffle(possibleStacks, gameHandler->getRandomGenerator());
 			const CStack * toBeHealed = possibleStacks.front();
@@ -588,7 +588,7 @@ void BattleFlowProcessor::stackEnchantedTrigger(const CBattleInfoCallback & batt
 			continue;
 
 		const CSpell * sp = b->subtype.as<SpellID>().toSpell();
-		const int32_t val = bl.valOfBonuses(Selector::typeSubtype(b->type, b->subtype));
+		const int32_t val = (int)bl.valOfBonuses(Selector::typeSubtype(b->type, b->subtype));
 		const int32_t level = ((val > 3) ? (val - 3) : val);
 
 		spells::BattleCast battleCast(&battle, st, spells::Mode::PASSIVE, sp);
@@ -667,7 +667,7 @@ void BattleFlowProcessor::stackTurnTrigger(const CBattleInfoCallback & battle, c
 			std::shared_ptr<const Bonus> b = st->getFirstBonus(Selector::source(BonusSource::SPELL_EFFECT, BonusSourceID(SpellID(SpellID::POISON))).And(Selector::type()(BonusType::STACK_HEALTH)));
 			if (b) //TODO: what if not?...
 			{
-				bte.val = std::max (b->val - 10, -(st->valOfBonuses(BonusType::POISON)));
+				bte.val = std::max (b->val - 10, -((int)st->valOfBonuses(BonusType::POISON)));
 				if (bte.val < b->val) //(negative) poison effect increases - update it
 				{
 					bte.effect = vstd::to_underlying(BonusType::POISON);
@@ -680,7 +680,7 @@ void BattleFlowProcessor::stackTurnTrigger(const CBattleInfoCallback & battle, c
 			const CGHeroInstance * opponentHero = battle.battleGetFightingHero(battle.otherSide(st->unitSide()));
 			if(opponentHero)
 			{
-				ui32 manaDrained = st->valOfBonuses(BonusType::MANA_DRAIN);
+				ui32 manaDrained = (int)st->valOfBonuses(BonusType::MANA_DRAIN);
 				vstd::amin(manaDrained, opponentHero->mana);
 				if(manaDrained)
 				{


### PR DESCRIPTION
Change BonusList:totalValue and BonusList::valOfBonuses to return float (instead of int).

These changes fix #3670. I'm not sure it doesn't break anything.

Probably would be better to separate bonuses which should be calculated using floating point numbers from bonuses like: "MAX_LEARNABLE_SPELL_LEVEL" or make separate functions for different types of bonuses.

I made some type castings from float to int but it probably could be done better (separate function for different cases?).