### PR TITLE
Fix(minizip/minizip.c): fix possibly uninitialized variable usage

### DIFF
--- a/lib/minizip/minizip.c
+++ b/lib/minizip/minizip.c
@@ -395,7 +395,7 @@ int main(argc,argv)
                    ((argv[i][1]>='0') || (argv[i][1]<='9'))) &&
                   (strlen(argv[i]) == 2)))
             {
-                FILE * fin;
+                FILE * fin = NULL;
                 int size_read;
                 const char* filenameinzip = argv[i];
                 const char *savefilenameinzip;


### PR DESCRIPTION
Situation before this patch:

`fin` variable is first assigned here:
https://github.com/vcmi/vcmi/blob/b419c70f1823b7c1ca8f4e39c8d3364d4acac5ef/lib/minizip/minizip.c#L463

However, this assignment happens only within `else` branch here:
https://github.com/vcmi/vcmi/blob/b419c70f1823b7c1ca8f4e39c8d3364d4acac5ef/lib/minizip/minizip.c#L459-L469

If the `else` branch was not called, we check against possibly uninitialized `fin` later:
https://github.com/vcmi/vcmi/blob/b419c70f1823b7c1ca8f4e39c8d3364d4acac5ef/lib/minizip/minizip.c#L495