### PR TITLE
Fix BonusLimitEffect

### DIFF
--- a/lib/bonuses/Bonus.h
+++ b/lib/bonuses/Bonus.h
@@ -70,7 +70,7 @@ struct DLL_LINKAGE Bonus : public std::enable_shared_from_this<Bonus>
 	std::string stacking; // bonuses with the same stacking value don't stack (e.g. Angel/Archangel morale bonus)
 
 	CAddInfo additionalInfo;
-	BonusLimitEffect effectRange = BonusLimitEffect::NO_LIMIT; //if not NO_LIMIT, bonus will be omitted by default
+	BonusLimitEffect effectRange = BonusLimitEffect::NO_LIMIT;
 
 	TLimiterPtr limiter;
 	TPropagatorPtr propagator;

--- a/lib/bonuses/BonusList.cpp
+++ b/lib/bonuses/BonusList.cpp
@@ -190,9 +190,7 @@ void BonusList::getBonuses(BonusList & out, const CSelector &selector, const CSe
 	out.reserve(bonuses.size());
 	for(const auto & b : bonuses)
 	{
-		//add matching bonuses that matches limit predicate or have NO_LIMIT if no given predicate
-		auto noFightLimit = b->effectRange == BonusLimitEffect::NO_LIMIT;
-		if(selector(b.get()) && ((!limit && noFightLimit) || ((bool)limit && limit(b.get()))))
+		if(selector(b.get()) && (!limit || ((bool)limit && limit(b.get()))))
 			out.push_back(b);
 	}
 }


### PR DESCRIPTION
Change BonusList::getBonus() to return bonuses with any BonusLimitEffect by default (returned only bonuses with BonusLimitEffect::NO_LIMIT previously)

Fixes #3070.
Also fixes the problem that dispel magic didn't work on bloodlust and precision.

Alternatively, appropriate BonusLimitEffect parameters could be added in a few function calls to fix this issue (if BonusList::getBonuses() should work as before)