### PR TITLE
Fix: prevent possible int16_t overflow

### DIFF
--- a/client/globalLobby/GlobalLobbyClient.cpp
+++ b/client/globalLobby/GlobalLobbyClient.cpp
@@ -289,7 +289,7 @@ void GlobalLobbyClient::receiveJoinRoomSuccess(const JsonNode & json)
 		CSH->loadMode = ELoadMode::MULTI;
 
 		std::string hostname = settings["lobby"]["hostname"].String();
-		int16_t port = settings["lobby"]["port"].Integer();
+		uint16_t port = settings["lobby"]["port"].Integer();
 		CSH->connectToServer(hostname, port);
 	}
 
@@ -379,7 +379,7 @@ void GlobalLobbyClient::sendOpenRoom(const std::string & mode, int playerLimit)
 void GlobalLobbyClient::connect()
 {
 	std::string hostname = settings["lobby"]["hostname"].String();
-	int16_t port = settings["lobby"]["port"].Integer();
+	uint16_t port = settings["lobby"]["port"].Integer();
 	CSH->getNetworkHandler().connectToRemote(*this, hostname, port);
 }
 

--- a/server/GlobalLobbyProcessor.cpp
+++ b/server/GlobalLobbyProcessor.cpp
@@ -24,7 +24,7 @@ GlobalLobbyProcessor::GlobalLobbyProcessor(CVCMIServer & owner)
 void GlobalLobbyProcessor::establishNewConnection()
 {
 	std::string hostname = settings["lobby"]["hostname"].String();
-	int16_t port = settings["lobby"]["port"].Integer();
+	uint16_t port = settings["lobby"]["port"].Integer();
 	owner.getNetworkHandler().connectToRemote(*this, hostname, port);
 }
 


### PR DESCRIPTION
Ex. `port` == 40000 -> int16_t assignment overflow