### PR TITLE
Fix: include guards, licenses, StdInc

### DIFF
--- a/AI/EmptyAI/StdInc.cpp
+++ b/AI/EmptyAI/StdInc.cpp
@@ -1,2 +1,11 @@
+/*
+ * StdInc.cpp, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
 // Creates the precompiled header
 #include "StdInc.h"

--- a/AI/EmptyAI/StdInc.h
+++ b/AI/EmptyAI/StdInc.h
@@ -1,3 +1,12 @@
+/*
+ * StdInc.h, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
 #pragma once
 
 #include "../../Global.h"

--- a/AI/Nullkiller/Goals/Build.cpp
+++ b/AI/Nullkiller/Goals/Build.cpp
@@ -1,6 +1,3 @@
-namespace Nullkiller
-{
-
 /*
 * Build.cpp, part of VCMI engine
 *
@@ -23,6 +20,8 @@ namespace Nullkiller
 #include "../../../lib/CPathfinder.h"
 #include "../../../lib/StringConstants.h"
 
+namespace Nullkiller
+{
 
 extern boost::thread_specific_ptr<CCallback> cb;
 extern boost::thread_specific_ptr<AIGateway> ai;

--- a/AI/Nullkiller/Goals/Build.h
+++ b/AI/Nullkiller/Goals/Build.h
@@ -1,6 +1,3 @@
-namespace Nullkiller
-{
-
 /*
 * Build.h, part of VCMI engine
 *
@@ -13,6 +10,9 @@ namespace Nullkiller
 #pragma once
 
 #include "CGoal.h"
+
+namespace Nullkiller
+{
 
 struct HeroPtr;
 class AIGateway;

--- a/AI/Nullkiller/Goals/GatherArmy.cpp
+++ b/AI/Nullkiller/Goals/GatherArmy.cpp
@@ -1,6 +1,3 @@
-namespace Nullkiller
-{
-
 /*
 * GatherArmy.cpp, part of VCMI engine
 *
@@ -22,6 +19,8 @@ namespace Nullkiller
 #include "../../../lib/CPathfinder.h"
 #include "../../../lib/StringConstants.h"
 
+namespace Nullkiller
+{
 
 extern boost::thread_specific_ptr<CCallback> cb;
 extern boost::thread_specific_ptr<AIGateway> ai;

--- a/AI/Nullkiller/Goals/GatherArmy.h
+++ b/AI/Nullkiller/Goals/GatherArmy.h
@@ -1,6 +1,3 @@
-namespace Nullkiller
-{
-
 /*
 * GatherArmy.h, part of VCMI engine
 *
@@ -13,6 +10,9 @@ namespace Nullkiller
 #pragma once
 
 #include "CGoal.h"
+
+namespace Nullkiller
+{
 
 struct HeroPtr;
 class AIGateway;

--- a/AI/Nullkiller/StdInc.cpp
+++ b/AI/Nullkiller/StdInc.cpp
@@ -1,1 +1,10 @@
+/*
+ * StdInc.cpp, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
 #include "StdInc.h"

--- a/AI/Nullkiller/StdInc.h
+++ b/AI/Nullkiller/StdInc.h
@@ -1,3 +1,12 @@
+/*
+ * StdInc.h, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
 #pragma  once
 #include "../../Global.h"
 VCMI_LIB_USING_NAMESPACE

--- a/AI/StupidAI/StdInc.cpp
+++ b/AI/StupidAI/StdInc.cpp
@@ -1,2 +1,11 @@
+/*
+ * StdInc.cpp, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
 // Creates the precompiled header
 #include "StdInc.h"

--- a/AI/StupidAI/StdInc.h
+++ b/AI/StupidAI/StdInc.h
@@ -1,3 +1,12 @@
+/*
+ * StdInc.h, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
 #pragma once
 
 #include "../../Global.h"

--- a/AI/VCAI/AIhelper.cpp
+++ b/AI/VCAI/AIhelper.cpp
@@ -1,5 +1,5 @@
 /*
-* AIhelper.h, part of VCMI engine
+* AIhelper.cpp, part of VCMI engine
 *
 * Authors: listed in file AUTHORS in main folder
 *

--- a/AI/VCAI/MapObjectsEvaluator.cpp
+++ b/AI/VCAI/MapObjectsEvaluator.cpp
@@ -1,3 +1,12 @@
+/*
+ * MapObjectsEvaluator.cpp, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
 #include "StdInc.h"
 #include "MapObjectsEvaluator.h"
 #include "../../lib/GameConstants.h"

--- a/AI/VCAI/StdInc.cpp
+++ b/AI/VCAI/StdInc.cpp
@@ -1,1 +1,10 @@
+/*
+ * StdInc.cpp, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
 #include "StdInc.h"

--- a/AI/VCAI/StdInc.h
+++ b/AI/VCAI/StdInc.h
@@ -1,3 +1,12 @@
+/*
+ * StdInc.h, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
 #pragma  once
 #include "../../Global.h"
 

--- a/client/CFocusableHelper.cpp
+++ b/client/CFocusableHelper.cpp
@@ -7,9 +7,9 @@
  * Full text of license available in license.txt file, in main folder
  *
  */
+#include "StdInc.h"
 #include "CFocusableHelper.h"
 #include "../Global.h"
-#include "StdInc.h"
 #include "widgets/TextControls.h"
 
 void removeFocusFromActiveInput()

--- a/client/CFocusableHelper.h
+++ b/client/CFocusableHelper.h
@@ -7,5 +7,6 @@
  * Full text of license available in license.txt file, in main folder
  *
  */
+#pragma once
 
 void removeFocusFromActiveInput();

--- a/client/Client.cpp
+++ b/client/Client.cpp
@@ -7,8 +7,8 @@
  * Full text of license available in license.txt file, in main folder
  *
  */
-#include "Global.h"
 #include "StdInc.h"
+#include "Global.h"
 #include "Client.h"
 
 #include "CGameInfo.h"

--- a/client/StdInc.cpp
+++ b/client/StdInc.cpp
@@ -1,2 +1,11 @@
+/*
+ * StdInc.cpp, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
 // Creates the precompiled header
 #include "StdInc.h"

--- a/client/StdInc.h
+++ b/client/StdInc.h
@@ -1,3 +1,12 @@
+/*
+ * StdInc.h, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
 #pragma once
 
 #include "../Global.h"

--- a/client/gui/FramerateManager.cpp
+++ b/client/gui/FramerateManager.cpp
@@ -1,5 +1,5 @@
 /*
- * FramerateManager.h, part of VCMI engine
+ * FramerateManager.cpp, part of VCMI engine
  *
  * Authors: listed in file AUTHORS in main folder
  *

--- a/client/ios/GameChatKeyboardHandler.h
+++ b/client/ios/GameChatKeyboardHandler.h
@@ -7,6 +7,7 @@
  * Full text of license available in license.txt file, in main folder
  *
  */
+#pragma once
 
 #import <UIKit/UIKit.h>
 

--- a/client/ios/startSDL.mm
+++ b/client/ios/startSDL.mm
@@ -7,8 +7,8 @@
  * Full text of license available in license.txt file, in main folder
  *
  */
-#import "startSDL.h"
 #include "StdInc.h"
+#import "startSDL.h"
 #import "GameChatKeyboardHandler.h"
 
 #include "../Global.h"

--- a/client/render/Colors.h
+++ b/client/render/Colors.h
@@ -1,5 +1,5 @@
 /*
- * ICursor.h, part of VCMI engine
+ * Colors.h, part of VCMI engine
  *
  * Authors: listed in file AUTHORS in main folder
  *

--- a/client/widgets/CExchangeController.h
+++ b/client/widgets/CExchangeController.h
@@ -7,10 +7,10 @@
  * Full text of license available in license.txt file, in main folder
  *
  */
- #pragma once
+#pragma once
  
- #include "../windows/CWindowObject.h"
- #include "CWindowWithArtifacts.h"
+#include "../windows/CWindowObject.h"
+#include "CWindowWithArtifacts.h"
  
 class CCallback;
 

--- a/launcher/StdInc.cpp
+++ b/launcher/StdInc.cpp
@@ -1,1 +1,10 @@
+/*
+ * StdInc.cpp, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
 #include "StdInc.h"

--- a/launcher/StdInc.h
+++ b/launcher/StdInc.h
@@ -1,3 +1,12 @@
+/*
+ * StdInc.h, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
 #pragma once
 
 #include "../Global.h"

--- a/launcher/modManager/cmodlist.h
+++ b/launcher/modManager/cmodlist.h
@@ -9,17 +9,9 @@
  */
 #pragma once
 
-#include "StdInc.h"
-
 #include <QVariantMap>
 #include <QVariant>
 #include <QVector>
-
-VCMI_LIB_NAMESPACE_BEGIN
-
-class JsonNode;
-
-VCMI_LIB_NAMESPACE_END
 
 namespace ModStatus
 {

--- a/launcher/modManager/imageviewer_moc.h
+++ b/launcher/modManager/imageviewer_moc.h
@@ -7,8 +7,7 @@
  * Full text of license available in license.txt file, in main folder
  *
  */
-#ifndef IMAGEVIEWER_H
-#define IMAGEVIEWER_H
+#pragma once
 
 #include <QDialog>
 
@@ -38,5 +37,3 @@ protected:
 private:
 	Ui::ImageViewer * ui;
 };
-
-#endif // IMAGEVIEWER_H

--- a/lib/LoadProgress.h
+++ b/lib/LoadProgress.h
@@ -10,7 +10,6 @@
 
 #pragma once
 
-#include "StdInc.h"
 #include <atomic>
 
 namespace Load

--- a/lib/LoadProgress.h
+++ b/lib/LoadProgress.h
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include "StdInc.h"
 #include <atomic>
 
 namespace Load

--- a/lib/StdInc.cpp
+++ b/lib/StdInc.cpp
@@ -1,2 +1,11 @@
+/*
+ * StdInc.cpp, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
 // Creates the precompiled header
 #include "StdInc.h"

--- a/lib/StdInc.h
+++ b/lib/StdInc.h
@@ -1,3 +1,12 @@
+/*
+ * StdInc.h, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
 #pragma once
 
 #include "../Global.h"

--- a/lib/battle/PossiblePlayerBattleAction.h
+++ b/lib/battle/PossiblePlayerBattleAction.h
@@ -7,7 +7,7 @@
  * Full text of license available in license.txt file, in main folder
  *
  */
- #pragma once
+#pragma once
 
 #include "../GameConstants.h"
 

--- a/lib/battle/PossiblePlayerBattleAction.h
+++ b/lib/battle/PossiblePlayerBattleAction.h
@@ -1,5 +1,5 @@
 /*
- * CBattleInfoCallback.h, part of VCMI engine
+ * PossiblePlayerBattleAction.h, part of VCMI engine
  *
  * Authors: listed in file AUTHORS in main folder
  *
@@ -7,6 +7,7 @@
  * Full text of license available in license.txt file, in main folder
  *
  */
+ #pragma once
 
 #include "../GameConstants.h"
 

--- a/lib/bonuses/IBonusBearer.h
+++ b/lib/bonuses/IBonusBearer.h
@@ -1,4 +1,3 @@
-
 /*
  * IBonusBearer.h, part of VCMI engine
  *

--- a/lib/modding/CModVersion.cpp
+++ b/lib/modding/CModVersion.cpp
@@ -1,5 +1,5 @@
 /*
- * CModVersion.h, part of VCMI engine
+ * CModVersion.cpp, part of VCMI engine
  *
  * Authors: listed in file AUTHORS in main folder
  *

--- a/lib/spells/ObstacleCasterProxy.h
+++ b/lib/spells/ObstacleCasterProxy.h
@@ -7,6 +7,7 @@
  * Full text of license available in license.txt file, in main folder
  *
  */
+#pragma once
 
 #include "ProxyCaster.h"
 #include "../battle/BattleHex.h"

--- a/lib/spells/ViewSpellInt.h
+++ b/lib/spells/ViewSpellInt.h
@@ -8,10 +8,10 @@
  *
  */
 
- #pragma once
+#pragma once
 
- #include "../int3.h"
- #include "../GameConstants.h"
+#include "../int3.h"
+#include "../GameConstants.h"
 
 VCMI_LIB_NAMESPACE_BEGIN
 

--- a/lib/vstd/DateUtils.cpp
+++ b/lib/vstd/DateUtils.cpp
@@ -1,3 +1,12 @@
+/*
+ * DateUtils.cpp, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
 #include "StdInc.h"
 #include <vstd/DateUtils.h>
 

--- a/lib/vstd/StringUtils.cpp
+++ b/lib/vstd/StringUtils.cpp
@@ -1,3 +1,12 @@
+/*
+ * StringUtils.cpp, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
 #include "StdInc.h"
 #include <vstd/StringUtils.h>
 

--- a/lobby/StdInc.cpp
+++ b/lobby/StdInc.cpp
@@ -1,2 +1,11 @@
+/*
+ * StdInc.cpp, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
 // Creates the precompiled header
 #include "StdInc.h"

--- a/mapeditor/StdInc.cpp
+++ b/mapeditor/StdInc.cpp
@@ -1,1 +1,10 @@
+/*
+ * StdInc.cpp, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
 #include "StdInc.h"

--- a/mapeditor/StdInc.h
+++ b/mapeditor/StdInc.h
@@ -1,3 +1,12 @@
+/*
+ * StdInc.h, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
 #pragma once
 
 #include "../Global.h"

--- a/mapeditor/main.cpp
+++ b/mapeditor/main.cpp
@@ -7,8 +7,8 @@
  * Full text of license available in license.txt file, in main folder
  *
  */
-#include <QApplication>
 #include "StdInc.h"
+#include <QApplication>
 #include "mainwindow.h"
 
 int main(int argc, char * argv[])

--- a/mapeditor/mapsettings/victoryconditions.cpp
+++ b/mapeditor/mapsettings/victoryconditions.cpp
@@ -1,5 +1,5 @@
 /*
- * victoryconditions.h, part of VCMI engine
+ * victoryconditions.cpp, part of VCMI engine
  *
  * Authors: listed in file AUTHORS in main folder
  *

--- a/scripting/erm/StdInc.cpp
+++ b/scripting/erm/StdInc.cpp
@@ -1,2 +1,11 @@
+/*
+ * StdInc.cpp, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
 // Creates the precompiled header
 #include "StdInc.h"

--- a/scripting/erm/StdInc.h
+++ b/scripting/erm/StdInc.h
@@ -1,3 +1,12 @@
+/*
+ * StdInc.h, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
 #pragma once
 
 #include "../../Global.h"

--- a/scripting/lua/StdInc.cpp
+++ b/scripting/lua/StdInc.cpp
@@ -1,2 +1,11 @@
+/*
+ * StdInc.cpp, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
 // Creates the precompiled header
 #include "StdInc.h"

--- a/scripting/lua/StdInc.h
+++ b/scripting/lua/StdInc.h
@@ -1,3 +1,12 @@
+/*
+ * StdInc.h, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
 #pragma once
 
 #include "../../Global.h"

--- a/server/ServerSpellCastEnvironment.h
+++ b/server/ServerSpellCastEnvironment.h
@@ -7,6 +7,7 @@
  * Full text of license available in license.txt file, in main folder
  *
  */
+#pragma once
 
 #include "../lib/spells/ISpellMechanics.h"
 

--- a/server/StdInc.cpp
+++ b/server/StdInc.cpp
@@ -1,2 +1,11 @@
+/*
+ * StdInc.cpp, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
 // Creates the precompiled header
 #include "StdInc.h"

--- a/serverapp/StdInc.cpp
+++ b/serverapp/StdInc.cpp
@@ -1,2 +1,11 @@
+/*
+ * StdInc.cpp, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
 // Creates the precompiled header
 #include "StdInc.h"

--- a/test/mock/ZoneOptionsFake.h
+++ b/test/mock/ZoneOptionsFake.h
@@ -7,11 +7,11 @@
  * Full text of license available in license.txt file, in main folder
  *
  */
+#pragma once
+
 #include "../../../lib/mapping/CMap.h"
 #include "../../../lib/rmg/CMapGenOptions.h"
 #include "../../../lib/rmg/CMapGenerator.h"
-
-#pragma once
 
 class ZoneOptionsFake : public rmg::ZoneOptions
 {

--- a/test/spells/targetConditions/SpellEffectConditionTest.cpp
+++ b/test/spells/targetConditions/SpellEffectConditionTest.cpp
@@ -9,8 +9,6 @@
  */
 #include "StdInc.h"
 
-#include "StdInc.h"
-
 #include "TargetConditionItemFixture.h"
 
 namespace test

--- a/test/vcai/mock_ResourceManager.cpp
+++ b/test/vcai/mock_ResourceManager.cpp
@@ -1,3 +1,12 @@
+/*
+ * mock_ResourceManager.cpp, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
 #include "StdInc.h"
 
 #include "mock_ResourceManager.h"

--- a/test/vcai/mock_ResourceManager.h
+++ b/test/vcai/mock_ResourceManager.h
@@ -1,3 +1,12 @@
+/*
+ * mock_ResourceManager.h, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
 #pragma once
 
 #include "gtest/gtest.h"


### PR DESCRIPTION
- Add missing licenses
- Fix file names in licenses
- Move namespace according to code style
- Add missing `#pragma once` in headers
- Make `#include "StdInc.h"` the top level include according to code style
- Removed empty unused `server/battles/ServerBattleCallback.h|.cpp`
- Smaller fixes