### PR TITLE
Minor tweaks for most noticeable issues with new lobby

### DIFF
--- a/CI/linux-qt6/before_install.sh
+++ b/CI/linux-qt6/before_install.sh
@@ -3,7 +3,7 @@
 sudo apt-get update
 
 # Dependencies
-sudo apt-get install libboost-all-dev \
+sudo apt-get install libboost-dev libboost-filesystem-dev libboost-system-dev libboost-thread-dev libboost-program-options-dev libboost-locale-dev \
 libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev libsdl2-ttf-dev \
 qt6-base-dev qt6-base-dev-tools qt6-tools-dev qt6-tools-dev-tools qt6-l10n-tools \
 ninja-build zlib1g-dev libavformat-dev libswscale-dev libtbb-dev libluajit-5.1-dev \

--- a/CI/linux/before_install.sh
+++ b/CI/linux/before_install.sh
@@ -3,7 +3,7 @@
 sudo apt-get update
 
 # Dependencies
-sudo apt-get install libboost-all-dev \
+sudo apt-get install libboost-dev libboost-filesystem-dev libboost-system-dev libboost-thread-dev libboost-program-options-dev libboost-locale-dev \
 libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev libsdl2-ttf-dev \
 qtbase5-dev \
 ninja-build zlib1g-dev libavformat-dev libswscale-dev libtbb-dev libluajit-5.1-dev \

--- a/Mods/vcmi/config/vcmi/english.json
+++ b/Mods/vcmi/config/vcmi/english.json
@@ -79,6 +79,7 @@
 	"vcmi.lobby.login.error" : "Connection error: %s",
 	"vcmi.lobby.login.create" : "New Account",
 	"vcmi.lobby.login.login" : "Login",
+	"vcmi.lobby.login.as" : "Login as %s",
 	"vcmi.lobby.header.rooms" : "Game Rooms - %d",
 	"vcmi.lobby.header.channels" : "Chat Channels",
 	"vcmi.lobby.header.chat.global" : "Global Game Chat - %s", // %s -> language name

--- a/Mods/vcmi/config/vcmi/ukrainian.json
+++ b/Mods/vcmi/config/vcmi/ukrainian.json
@@ -78,6 +78,7 @@
 	"vcmi.lobby.login.error" : "Помилка з'єднання: %s",
 	"vcmi.lobby.login.create" : "Створити акаунт",
 	"vcmi.lobby.login.login" : "Увійти",
+	"vcmi.lobby.login.as" : "Увійти як %s",
 	"vcmi.lobby.header.rooms" : "Активні кімнати - %d",
 	"vcmi.lobby.header.channels" : "Канали чату",
 	"vcmi.lobby.header.chat.global" : "Глобальний ігровий чат - %s", // %s -> language name

--- a/client/globalLobby/GlobalLobbyClient.cpp
+++ b/client/globalLobby/GlobalLobbyClient.cpp
@@ -85,14 +85,9 @@ void GlobalLobbyClient::receiveAccountCreated(const JsonNode & json)
 		throw std::runtime_error("lobby connection finished without active login window!");
 
 	{
-		Settings configID = settings.write["lobby"]["accountID"];
-		configID->String() = json["accountID"].String();
-
-		Settings configName = settings.write["lobby"]["displayName"];
-		configName->String() = json["displayName"].String();
-
-		Settings configCookie = settings.write["lobby"]["accountCookie"];
-		configCookie->String() = json["accountCookie"].String();
+		setAccountID(json["accountID"].String());
+		setAccountDisplayName(json["displayName"].String());
+		setAccountCookie(json["accountCookie"].String());
 	}
 
 	sendClientLogin();
@@ -105,17 +100,15 @@ void GlobalLobbyClient::receiveOperationFailed(const JsonNode & json)
 	if(loginWindowPtr)
 		loginWindowPtr->onConnectionFailed(json["reason"].String());
 
+	logGlobal->warn("Operation failed! Reason: %s", json["reason"].String());
 	// TODO: handle errors in lobby menu
 }
 
 void GlobalLobbyClient::receiveClientLoginSuccess(const JsonNode & json)
 {
 	{
-		Settings configCookie = settings.write["lobby"]["accountCookie"];
-		configCookie->String() = json["accountCookie"].String();
-
-		Settings configName = settings.write["lobby"]["displayName"];
-		configName->String() = json["displayName"].String();
+		setAccountDisplayName(json["displayName"].String());
+		setAccountCookie(json["accountCookie"].String());
 	}
 
 	auto loginWindowPtr = loginWindow.lock();
@@ -288,8 +281,8 @@ void GlobalLobbyClient::receiveJoinRoomSuccess(const JsonNode & json)
 		CSH->resetStateForLobby(EStartMode::NEW_GAME, ESelectionScreen::newGame, EServerMode::LOBBY_GUEST, {});
 		CSH->loadMode = ELoadMode::MULTI;
 
-		std::string hostname = settings["lobby"]["hostname"].String();
-		uint16_t port = settings["lobby"]["port"].Integer();
+		std::string hostname = getServerHost();
+		uint16_t port = getServerPort();
 		CSH->connectToServer(hostname, port);
 	}
 
@@ -324,8 +317,8 @@ void GlobalLobbyClient::sendClientLogin()
 {
 	JsonNode toSend;
 	toSend["type"].String() = "clientLogin";
-	toSend["accountID"] = settings["lobby"]["accountID"];
-	toSend["accountCookie"] = settings["lobby"]["accountCookie"];
+	toSend["accountID"].String() = getAccountID();
+	toSend["accountCookie"].String() = getAccountCookie();
 	toSend["language"].String() = CGI->generaltexth->getPreferredLanguage();
 	toSend["version"].String() = VCMI_VERSION_STRING;
 	sendMessage(toSend);
@@ -370,7 +363,7 @@ void GlobalLobbyClient::sendOpenRoom(const std::string & mode, int playerLimit)
 {
 	JsonNode toSend;
 	toSend["type"].String() = "activateGameRoom";
-	toSend["hostAccountID"] = settings["lobby"]["accountID"];
+	toSend["hostAccountID"].String() = getAccountID();
 	toSend["roomType"].String() = mode;
 	toSend["playerLimit"].Integer() = playerLimit;
 	sendMessage(toSend);
@@ -378,8 +371,8 @@ void GlobalLobbyClient::sendOpenRoom(const std::string & mode, int playerLimit)
 
 void GlobalLobbyClient::connect()
 {
-	std::string hostname = settings["lobby"]["hostname"].String();
-	uint16_t port = settings["lobby"]["port"].Integer();
+	std::string hostname = getServerHost();
+	uint16_t port = getServerPort();
 	CSH->getNetworkHandler().connectToRemote(*this, hostname, port);
 }
 
@@ -479,12 +472,55 @@ void GlobalLobbyClient::activateRoomInviteInterface()
 	GH.windows().createAndPushWindow<GlobalLobbyInviteWindow>();
 }
 
+void GlobalLobbyClient::setAccountID(const std::string & accountID)
+{
+	Settings configID = persistentStorage.write["lobby"][getServerHost()]["accountID"];
+	configID->String() = accountID;
+}
+
+void GlobalLobbyClient::setAccountCookie(const std::string & accountCookie)
+{
+	Settings configCookie = persistentStorage.write["lobby"][getServerHost()]["accountCookie"];
+	configCookie->String() = accountCookie;
+}
+
+void GlobalLobbyClient::setAccountDisplayName(const std::string & accountDisplayName)
+{
+	Settings configName = persistentStorage.write["lobby"][getServerHost()]["displayName"];
+	configName->String() = accountDisplayName;
+}
+
+const std::string & GlobalLobbyClient::getAccountID() const
+{
+	return persistentStorage["lobby"][getServerHost()]["accountID"].String();
+}
+
+const std::string & GlobalLobbyClient::getAccountCookie() const
+{
+	return persistentStorage["lobby"][getServerHost()]["accountCookie"].String();
+}
+
+const std::string & GlobalLobbyClient::getAccountDisplayName() const
+{
+	return persistentStorage["lobby"][getServerHost()]["displayName"].String();
+}
+
+const std::string & GlobalLobbyClient::getServerHost() const
+{
+	return settings["lobby"]["hostname"].String();
+}
+
+uint16_t GlobalLobbyClient::getServerPort() const
+{
+	return settings["lobby"]["port"].Integer();
+}
+
 void GlobalLobbyClient::sendProxyConnectionLogin(const NetworkConnectionPtr & netConnection)
 {
 	JsonNode toSend;
 	toSend["type"].String() = "clientProxyLogin";
-	toSend["accountID"] = settings["lobby"]["accountID"];
-	toSend["accountCookie"] = settings["lobby"]["accountCookie"];
+	toSend["accountID"].String() = getAccountID();
+	toSend["accountCookie"].String() = getAccountCookie();
 	toSend["gameRoomID"].String() = currentGameRoomUUID;
 
 	assert(JsonUtils::validate(toSend, "vcmi:lobbyProtocol/" + toSend["type"].String(), toSend["type"].String() + " pack"));
@@ -509,6 +545,8 @@ void GlobalLobbyClient::sendMatchChatMessage(const std::string & messageText)
 	toSend["channelType"].String() = "match";
 	toSend["channelName"].String() = currentGameRoomUUID;
 	toSend["messageText"].String() = messageText;
+
+	assert(TextOperations::isValidUnicodeString(messageText));
 
 	CSH->getGlobalLobby().sendMessage(toSend);
 }

--- a/client/globalLobby/GlobalLobbyClient.h
+++ b/client/globalLobby/GlobalLobbyClient.h
@@ -58,6 +58,10 @@ class GlobalLobbyClient final : public INetworkClientListener, boost::noncopyabl
 	std::shared_ptr<GlobalLobbyLoginWindow> createLoginWindow();
 	std::shared_ptr<GlobalLobbyWindow> createLobbyWindow();
 
+	void setAccountID(const std::string & accountID);
+	void setAccountCookie(const std::string & accountCookie);
+	void setAccountDisplayName(const std::string & accountDisplayName);
+
 public:
 	explicit GlobalLobbyClient();
 	~GlobalLobbyClient();
@@ -67,6 +71,12 @@ public:
 	const std::vector<std::string> & getActiveChannels() const;
 	const std::vector<GlobalLobbyRoom> & getMatchesHistory() const;
 	const std::vector<GlobalLobbyChannelMessage> & getChannelHistory(const std::string & channelType, const std::string & channelName) const;
+
+	const std::string & getAccountID() const;
+	const std::string & getAccountCookie() const;
+	const std::string & getAccountDisplayName() const;
+	const std::string & getServerHost() const;
+	uint16_t getServerPort() const;
 
 	/// Activate interface and pushes lobby UI as top window
 	void activateInterface();

--- a/client/globalLobby/GlobalLobbyLoginWindow.cpp
+++ b/client/globalLobby/GlobalLobbyLoginWindow.cpp
@@ -36,9 +36,14 @@ GlobalLobbyLoginWindow::GlobalLobbyLoginWindow()
 	pos.w = 284;
 	pos.h = 220;
 
+	MetaString loginAs;
+	loginAs.appendTextID("vcmi.lobby.login.as");
+	loginAs.replaceTextID(CSH->getGlobalLobby().getAccountDisplayName());
+
 	filledBackground = std::make_shared<FilledTexturePlayerColored>(ImagePath::builtin("DiBoxBck"), Rect(0, 0, pos.w, pos.h));
 	labelTitle = std::make_shared<CLabel>( pos.w / 2, 20, FONT_BIG, ETextAlignment::CENTER, Colors::YELLOW, CGI->generaltexth->translate("vcmi.lobby.login.title"));
-	labelUsername = std::make_shared<CLabel>( 10, 65, FONT_MEDIUM, ETextAlignment::TOPLEFT, Colors::WHITE, CGI->generaltexth->translate("vcmi.lobby.login.username"));
+	labelUsernameTitle = std::make_shared<CLabel>( 10, 65, FONT_MEDIUM, ETextAlignment::TOPLEFT, Colors::WHITE, CGI->generaltexth->translate("vcmi.lobby.login.username"));
+	labelUsername = std::make_shared<CLabel>( 10, 65, FONT_MEDIUM, ETextAlignment::TOPLEFT, Colors::WHITE, loginAs.toString());
 	backgroundUsername = std::make_shared<TransparentFilledRectangle>(Rect(10, 90, 264, 20), ColorRGBA(0,0,0,128), ColorRGBA(64,64,64,64));
 	inputUsername = std::make_shared<CTextInput>(Rect(15, 93, 260, 16), FONT_SMALL, nullptr, ETextAlignment::TOPLEFT, true);
 	buttonLogin = std::make_shared<CButton>(Point(10, 180), AnimationPath::builtin("MuBchck"), CButton::tooltip(), [this](){ onLogin(); });
@@ -56,7 +61,7 @@ GlobalLobbyLoginWindow::GlobalLobbyLoginWindow()
 	toggleMode->setSelected(settings["lobby"]["roomType"].Integer());
 	toggleMode->addCallback([this](int index){onLoginModeChanged(index);});
 
-	if (settings["lobby"]["accountID"].String().empty())
+	if (CSH->getGlobalLobby().getAccountID().empty())
 	{
 		buttonLogin->block(true);
 		toggleMode->setSelected(0);
@@ -77,12 +82,19 @@ void GlobalLobbyLoginWindow::onLoginModeChanged(int value)
 {
 	if (value == 0)
 	{
-		inputUsername->setText("");
+		inputUsername->enable();
+		backgroundUsername->enable();
+		labelUsernameTitle->enable();
+		labelUsername->disable();
 	}
 	else
 	{
-		inputUsername->setText(settings["lobby"]["displayName"].String());
+		inputUsername->disable();
+		backgroundUsername->disable();
+		labelUsernameTitle->disable();
+		labelUsername->enable();
 	}
+	redraw();
 }
 
 void GlobalLobbyLoginWindow::onClose()
@@ -104,7 +116,7 @@ void GlobalLobbyLoginWindow::onLogin()
 
 void GlobalLobbyLoginWindow::onConnectionSuccess()
 {
-	std::string accountID = settings["lobby"]["accountID"].String();
+	std::string accountID = CSH->getGlobalLobby().getAccountID();
 
 	if(toggleMode->getSelected() == 0)
 		CSH->getGlobalLobby().sendClientRegister(inputUsername->getText());

--- a/client/globalLobby/GlobalLobbyLoginWindow.h
+++ b/client/globalLobby/GlobalLobbyLoginWindow.h
@@ -23,6 +23,7 @@ class GlobalLobbyLoginWindow : public CWindowObject
 {
 	std::shared_ptr<FilledTexturePlayerColored> filledBackground;
 	std::shared_ptr<CLabel> labelTitle;
+	std::shared_ptr<CLabel> labelUsernameTitle;
 	std::shared_ptr<CLabel> labelUsername;
 	std::shared_ptr<CTextBox> labelStatus;
 	std::shared_ptr<TransparentFilledRectangle> backgroundUsername;

--- a/client/globalLobby/GlobalLobbyWidget.cpp
+++ b/client/globalLobby/GlobalLobbyWidget.cpp
@@ -272,7 +272,7 @@ GlobalLobbyMatchCard::GlobalLobbyMatchCard(GlobalLobbyWindow * window, const Glo
 
 	if (matchDescription.participants.size() == 2)
 	{
-		std::string ourAccountID = settings["lobby"]["accountID"].String();
+		std::string ourAccountID = CSH->getGlobalLobby().getAccountID();
 
 		opponentDescription.appendTextID("vcmi.lobby.match.duel");
 		// Find display name of our one and only opponent in this game

--- a/client/globalLobby/GlobalLobbyWindow.cpp
+++ b/client/globalLobby/GlobalLobbyWindow.cpp
@@ -24,6 +24,7 @@
 #include "../../lib/CConfigHandler.h"
 #include "../../lib/Languages.h"
 #include "../../lib/MetaString.h"
+#include "../../lib/TextOperations.h"
 
 GlobalLobbyWindow::GlobalLobbyWindow()
 	: CWindowObject(BORDERED)
@@ -33,7 +34,7 @@ GlobalLobbyWindow::GlobalLobbyWindow()
 	pos = widget->pos;
 	center();
 
-	widget->getAccountNameLabel()->setText(settings["lobby"]["displayName"].String());
+	widget->getAccountNameLabel()->setText(CSH->getGlobalLobby().getAccountDisplayName());
 	doOpenChannel("global", "english", Languages::getLanguageOptions("english").nameNative);
 
 	widget->getChannelListHeader()->setText(MetaString::createFromTextID("vcmi.lobby.header.channels").toString());
@@ -54,7 +55,7 @@ void GlobalLobbyWindow::doOpenChannel(const std::string & channelType, const std
 
 	auto history = CSH->getGlobalLobby().getChannelHistory(channelType, channelName);
 
-	for (auto const & entry : history)
+	for(const auto & entry : history)
 		onGameChatMessage(entry.displayName, entry.messageText, entry.timeFormatted, channelType, channelName);
 
 	MetaString text;
@@ -79,6 +80,8 @@ void GlobalLobbyWindow::doSendChatMessage()
 	toSend["channelType"].String() = currentChannelType;
 	toSend["channelName"].String() = currentChannelName;
 	toSend["messageText"].String() = messageText;
+
+	assert(TextOperations::isValidUnicodeString(messageText));
 
 	CSH->getGlobalLobby().sendMessage(toSend);
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -18,7 +18,6 @@ set(lib_SRCS
 
 	json/JsonNode.cpp
 	json/JsonParser.cpp
-	json/JsonRandom.cpp
 	json/JsonUtils.cpp
 	json/JsonValidator.cpp
 	json/JsonWriter.cpp
@@ -89,6 +88,7 @@ set(lib_MAIN_SRCS
 	events/TurnStarted.cpp
 
 	json/JsonBonus.cpp
+	json/JsonRandom.cpp
 
 	gameState/CGameState.cpp
 	gameState/CGameStateCampaign.cpp
@@ -315,11 +315,9 @@ set(lib_HEADERS
 	filesystem/MinizipExtensions.h
 	filesystem/ResourcePath.h
 
-	json/JsonBonus.h
 	json/JsonFormatException.h
 	json/JsonNode.h
 	json/JsonParser.h
-	json/JsonRandom.h
 	json/JsonUtils.h
 	json/JsonValidator.h
 	json/JsonWriter.h
@@ -440,6 +438,9 @@ set(lib_MAIN_HEADERS
 	events/ObjectVisitStarted.h
 	events/PlayerGotTurn.h
 	events/TurnStarted.h
+
+	json/JsonBonus.h
+	json/JsonRandom.h
 
 	gameState/CGameState.h
 	gameState/CGameStateCampaign.h

--- a/lobby/LobbyServer.cpp
+++ b/lobby/LobbyServer.cpp
@@ -595,6 +595,7 @@ void LobbyServer::receiveClientLogin(const NetworkConnectionPtr & connection, co
 
 	activeAccounts[connection] = accountID;
 
+	logGlobal->info("%s: Logged in as %s", accountID, displayName);
 	sendClientLoginSuccess(connection, accountCookie, displayName);
 	sendRecentChatHistory(connection, "global", "english");
 	if (language != "english")

--- a/lobby/LobbyServer.cpp
+++ b/lobby/LobbyServer.cpp
@@ -489,7 +489,7 @@ void LobbyServer::receiveSendChatMessage(const NetworkConnectionPtr & connection
 	std::string channelName = json["channelName"].String();
 	std::string displayName = database->getAccountDisplayName(senderAccountID);
 
-	if(TextOperations::isValidUnicodeString(messageText))
+	if(!TextOperations::isValidUnicodeString(messageText))
 		return sendOperationFailed(connection, "String contains invalid characters!");
 
 	std::string messageTextClean = sanitizeChatMessage(messageText);

--- a/server/GlobalLobbyProcessor.cpp
+++ b/server/GlobalLobbyProcessor.cpp
@@ -122,8 +122,8 @@ void GlobalLobbyProcessor::onConnectionEstablished(const std::shared_ptr<INetwor
 		JsonNode toSend;
 		toSend["type"].String() = "serverLogin";
 		toSend["gameRoomID"].String() = owner.uuid;
-		toSend["accountID"] = settings["lobby"]["accountID"];
-		toSend["accountCookie"] = settings["lobby"]["accountCookie"];
+		toSend["accountID"].String() = getHostAccountID();
+		toSend["accountCookie"].String() = getHostAccountCookie();
 		toSend["version"].String() = VCMI_VERSION_STRING;
 
 		sendMessage(connection, toSend);
@@ -140,7 +140,7 @@ void GlobalLobbyProcessor::onConnectionEstablished(const std::shared_ptr<INetwor
 		toSend["type"].String() = "serverProxyLogin";
 		toSend["gameRoomID"].String() = owner.uuid;
 		toSend["guestAccountID"].String() = guestAccountID;
-		toSend["accountCookie"] = settings["lobby"]["accountCookie"];
+		toSend["accountCookie"].String() = getHostAccountCookie();
 
 		sendMessage(connection, toSend);
 
@@ -169,4 +169,25 @@ void GlobalLobbyProcessor::sendMessage(const NetworkConnectionPtr & targetConnec
 {
 	assert(JsonUtils::validate(toSend, "vcmi:lobbyProtocol/" + toSend["type"].String(), toSend["type"].String() + " pack"));
 	targetConnection->sendPacket(toSend.toBytes());
+}
+
+//FIXME: consider whether these methods should be replaced with some other way to define our account ID / account cookie
+static const std::string & getServerHost()
+{
+	return settings["lobby"]["hostname"].String();
+}
+
+const std::string & GlobalLobbyProcessor::getHostAccountID() const
+{
+	return persistentStorage["lobby"][getServerHost()]["accountID"].String();
+}
+
+const std::string & GlobalLobbyProcessor::getHostAccountCookie() const
+{
+	return persistentStorage["lobby"][getServerHost()]["accountCookie"].String();
+}
+
+const std::string & GlobalLobbyProcessor::getHostAccountDisplayName() const
+{
+	return persistentStorage["lobby"][getServerHost()]["displayName"].String();
 }

--- a/server/GlobalLobbyProcessor.h
+++ b/server/GlobalLobbyProcessor.h
@@ -35,6 +35,10 @@ class GlobalLobbyProcessor : public INetworkClientListener
 
 	void establishNewConnection();
 	void sendMessage(const NetworkConnectionPtr & targetConnection, const JsonNode & payload);
+
+	const std::string & getHostAccountID() const;
+	const std::string & getHostAccountCookie() const;
+	const std::string & getHostAccountDisplayName() const;
 public:
 	void sendChangeRoomDescription(const std::string & description);
 	void sendGameStarted();


### PR DESCRIPTION
- Do not install entire libboost on Linux CI, but only parts used by vcmi
- Moved some files that are not needed for lobby from "minimal" vcmi lib to main library part
- Fixed error on attempt to send message to lobby chat
- Added logging of successful lobby logins for convenience
- Moved account login details from settings to persistent storage
- Account login details are now stored per server. Unlikely to be used by players, but useful to test with local lobby server
- Do not show text input in login window, but only on account creation window (at least until we have password-protected accounts)