### PR TITLE
Linux CI: Don't install suggested packages, since they are not required

### DIFF
--- a/CI/android/before_install.sh
+++ b/CI/android/before_install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 sudo apt-get update
-sudo apt-get install ninja-build
+sudo apt-get install --no-install-suggests ninja-build
 
 mkdir ~/.conan ; cd ~/.conan
 curl -L "https://github.com/vcmi/vcmi-dependencies/releases/download/android-1.0/$DEPS_FILENAME.txz" \

--- a/CI/linux-qt6/before_install.sh
+++ b/CI/linux-qt6/before_install.sh
@@ -3,7 +3,7 @@
 sudo apt-get update
 
 # Dependencies
-sudo apt-get install libboost-dev libboost-filesystem-dev libboost-system-dev libboost-thread-dev libboost-program-options-dev libboost-locale-dev \
+sudo apt-get install --no-install-suggests libboost-dev libboost-filesystem-dev libboost-system-dev libboost-thread-dev libboost-program-options-dev libboost-locale-dev \
 libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev libsdl2-ttf-dev \
 qt6-base-dev qt6-base-dev-tools qt6-tools-dev qt6-tools-dev-tools qt6-l10n-tools \
 ninja-build zlib1g-dev libavformat-dev libswscale-dev libtbb-dev libluajit-5.1-dev \

--- a/CI/linux/before_install.sh
+++ b/CI/linux/before_install.sh
@@ -3,7 +3,7 @@
 sudo apt-get update
 
 # Dependencies
-sudo apt-get install libboost-dev libboost-filesystem-dev libboost-system-dev libboost-thread-dev libboost-program-options-dev libboost-locale-dev \
+sudo apt-get install --no-install-suggests libboost-dev libboost-filesystem-dev libboost-system-dev libboost-thread-dev libboost-program-options-dev libboost-locale-dev \
 libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev libsdl2-ttf-dev \
 qtbase5-dev \
 ninja-build zlib1g-dev libavformat-dev libswscale-dev libtbb-dev libluajit-5.1-dev \

--- a/CI/mingw-32/before_install.sh
+++ b/CI/mingw-32/before_install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 sudo apt-get update
-sudo apt-get install ninja-build mingw-w64 nsis
+sudo apt-get install --no-install-suggests ninja-build mingw-w64 nsis
 sudo update-alternatives --set i686-w64-mingw32-g++ /usr/bin/i686-w64-mingw32-g++-posix
 
 # Workaround for getting new MinGW headers on Ubuntu 22.04.

--- a/CI/mingw/before_install.sh
+++ b/CI/mingw/before_install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 sudo apt-get update
-sudo apt-get install ninja-build mingw-w64 nsis
+sudo apt-get install --no-install-suggests ninja-build mingw-w64 nsis
 sudo update-alternatives --set x86_64-w64-mingw32-g++ /usr/bin/x86_64-w64-mingw32-g++-posix
 
 # Workaround for getting new MinGW headers on Ubuntu 22.04.


### PR DESCRIPTION
This affects these two platforms of the CI matrix:

linux:
```
Suggested packages:
  avahi-autoipd gvfs i965-va-driver-shaders libasound2-doc libcuda1
  libnvcuvid1 libnvidia-encode1 libbluray-bdj libboost-doc graphviz
  libboost1.74-doc gccxml libboost-contract1.74-dev libmpfrc++-dev libntl-dev
  xsltproc doxygen docbook-xml docbook-xsl default-jdk fop
  libvisual-0.4-plugins libhwloc-contrib-plugins jackd2 libjs-jquery-ui-docs
  gnome-shell | notification-daemon avahi-autoipd | zeroconf openmpi-doc
  opus-tools pcscd pulseaudio qt5-image-formats-plugins qtwayland5
  qt5-qmltooling-plugins sndiod speex libtbb-doc libwayland-doc opencl-icd
  qt5-doc default-libmysqlclient-dev firebird-dev fluid-soundfont-gm
  libvdpau-va-gl1 wpagui libengine-pkcs11-openssl
```

linux-qt6:
```
Suggested packages:
  i965-va-driver-shaders libasound2-doc libcuda1 libnvcuvid1 libnvidia-encode1
  libbluray-bdj libboost-doc graphviz libboost1.74-doc gccxml
  libboost-contract1.74-dev libmpfrc++-dev libntl-dev xsltproc doxygen
  docbook-xml docbook-xsl default-jdk fop libhwloc-contrib-plugins jackd2
  libjs-jquery-ui-docs openmpi-doc opus-tools pulseaudio
  qt6-qmltooling-plugins sndiod speex libtbb-doc libwayland-doc opencl-icd
  fluid-soundfont-gm libvdpau-va-gl1
```

mingw:
```
Suggested packages:
  gcc-10-locales wine wine64 nsis-doc nsis-pluginapi
```

mingw-32:
```
Suggested packages:
  gcc-10-locales wine wine64 nsis-doc nsis-pluginapi
```