### PR TITLE
Few more fixes for recently discovered lobby issues

### DIFF
--- a/client/globalLobby/GlobalLobbyClient.h
+++ b/client/globalLobby/GlobalLobbyClient.h
@@ -34,6 +34,7 @@ class GlobalLobbyClient final : public INetworkClientListener, boost::noncopyabl
 
 	std::shared_ptr<INetworkConnection> networkConnection;
 	std::string currentGameRoomUUID;
+	bool accountLoggedIn = false;
 
 	std::weak_ptr<GlobalLobbyLoginWindow> loginWindow;
 	std::weak_ptr<GlobalLobbyWindow> lobbyWindow;
@@ -93,5 +94,6 @@ public:
 
 	void connect();
 	bool isConnected() const;
+	bool isLoggedIn() const;
 	bool isInvitedToRoom(const std::string & gameRoomID);
 };

--- a/config/schemas/settings.json
+++ b/config/schemas/settings.json
@@ -546,23 +546,11 @@
 			"type" : "object",
 			"additionalProperties" : false,
 			"default" : {},
-			"required" : [ "mapPreview", "accountID", "accountCookie", "displayName", "hostname", "port", "roomPlayerLimit", "roomType", "roomMode" ],
+			"required" : [ "mapPreview", "hostname", "port", "roomPlayerLimit", "roomType", "roomMode" ],
 			"properties" : {
 				"mapPreview" : {
 					"type" : "boolean",
 					"default" : true
-				},
-				"accountID" : {
-					"type" : "string",
-					"default" : ""
-				},
-				"accountCookie" : {
-					"type" : "string",
-					"default" : ""
-				},
-				"displayName" : {
-					"type" : "string",
-					"default" : ""
 				},
 				"hostname" : {
 					"type" : "string",

--- a/lib/VCMIDirs.cpp
+++ b/lib/VCMIDirs.cpp
@@ -367,8 +367,9 @@ class IVCMIDirsUNIX : public IVCMIDirs
 bool IVCMIDirsUNIX::developmentMode() const
 {
 	// We want to be able to run VCMI from single directory. E.g to run from build output directory
-	const bool result = bfs::exists("AI") && bfs::exists("config") && bfs::exists("Mods") && bfs::exists("vcmiclient");
-	return result;
+	const bool hasConfigs = bfs::exists("config") && bfs::exists("Mods");
+	const bool hasBinaries = bfs::exists("vcmiclient") || bfs::exists("vcmiserver") || bfs::exists("vcmilobby");
+	return hasConfigs && hasBinaries;
 }
 
 bfs::path IVCMIDirsUNIX::clientPath() const { return binaryPath() / "vcmiclient"; }

--- a/lobby/LobbyServer.cpp
+++ b/lobby/LobbyServer.cpp
@@ -293,6 +293,7 @@ void LobbyServer::onDisconnected(const NetworkConnectionPtr & connection, const 
 {
 	if(activeAccounts.count(connection))
 	{
+		logGlobal->info("Account %s disconnecting. Accounts online: %d", activeAccounts.at(connection), activeAccounts.size() - 1);
 		database->setAccountOnline(activeAccounts.at(connection), false);
 		activeAccounts.erase(connection);
 	}
@@ -300,6 +301,7 @@ void LobbyServer::onDisconnected(const NetworkConnectionPtr & connection, const 
 	if(activeGameRooms.count(connection))
 	{
 		std::string gameRoomID = activeGameRooms.at(connection);
+		logGlobal->info("Game room %s disconnecting. Rooms online: %d", gameRoomID, activeGameRooms.size() - 1);
 
 		if (database->getGameRoomStatus(gameRoomID) == LobbyRoomState::BUSY)
 		{


### PR DESCRIPTION
- Fixed handling of login failure - don't open lobby window if player presses Ctrl+Tab after failing to login.
- This fixes #3702 
- Fixed handling of 'development mode' when only lobby is built and AI or vcmiclient don't exists
- Remove no longer used fields from config
- Add more convenience logging

Will merge once CI passes and update lobby running on server.