### PR TITLE
scalingMode to config

### DIFF
--- a/client/renderSDL/ScreenHandler.cpp
+++ b/client/renderSDL/ScreenHandler.cpp
@@ -294,7 +294,7 @@ void ScreenHandler::initializeWindow()
 
 	SDL_RendererInfo info;
 	SDL_GetRendererInfo(mainRenderer, &info);
-	SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, "best");
+	SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, settings["video"]["scalingMode"].String().c_str());
 	logGlobal->info("Created renderer %s", info.name);
 }
 

--- a/config/schemas/settings.json
+++ b/config/schemas/settings.json
@@ -160,7 +160,8 @@
 				"displayIndex",
 				"showfps",
 				"targetfps",
-				"vsync"
+				"vsync",
+				"scalingMode"
 			],
 			"properties" : {
 				"resolution" : {
@@ -223,6 +224,11 @@
 				"vsync" : {
 					"type" : "boolean",
 					"default" : true
+				},
+				"scalingMode" : {
+					"type" : "string",
+					"enum" : [ "nearest", "linear", "best" ],
+					"default" : "best"
 				}
 			}
 		},


### PR DESCRIPTION
add option to change SDL scaling mode over config file.

fixes #3712

@Gagert Try it with following change (scalingMode) in settings.json
```
	"video" : {
		"resolution" : {
			"height" : 1200,
			"scaling" : 200,
			"width" : 1920
		},
		"scalingMode" : "nearest"
	}
```

Nearest at 200% (see full, unscaled image):
![image](https://github.com/vcmi/vcmi/assets/13953785/b8b59030-8e7d-4043-a4b6-58df6c24b2db)
