### PR TITLE
Disable warnings about boost including deprecated headers internally

### DIFF
--- a/Global.h
+++ b/Global.h
@@ -149,6 +149,9 @@ static_assert(sizeof(bool) == 1, "Bool needs to be 1 byte in size.");
 #if BOOST_VERSION > 105000
 #  define BOOST_THREAD_VERSION 3
 #endif
+#if BOOST_VERSION == 107400
+#  define BOOST_ALLOW_DEPRECATED_HEADERS
+#endif
 #define BOOST_THREAD_DONT_PROVIDE_THREAD_DESTRUCTOR_CALLS_TERMINATE_IF_JOINABLE 1
 //need to link boost thread dynamically to avoid https://stackoverflow.com/questions/35978572/boost-thread-interupt-does-not-work-when-crossing-a-dll-boundary
 #define BOOST_THREAD_USE_DLL //for example VCAI::finish() may freeze on thread join after interrupt when linking this statically


### PR DESCRIPTION
https://stackoverflow.com/a/75056937/2278742

Example:

 [275/736] Building CXX object lib/CMakeFiles/vcmi.dir/rmg/CZonePlacer.cpp.o
In file included from /usr/include/boost/smart_ptr/detail/sp_thread_sleep.hpp:22,
                 from /usr/include/boost/smart_ptr/detail/yield_k.hpp:23,
                 from /usr/include/boost/smart_ptr/detail/spinlock_gcc_atomic.hpp:14,
                 from /usr/include/boost/smart_ptr/detail/spinlock.hpp:42,
                 from /usr/include/boost/smart_ptr/detail/spinlock_pool.hpp:25,
                 from /usr/include/boost/smart_ptr/shared_ptr.hpp:29,
                 from /usr/include/boost/shared_ptr.hpp:17,
                 from /usr/include/boost/exception/detail/shared_ptr.hpp:13,
                 from /usr/include/boost/exception/info.hpp:13,
                 from /usr/include/boost/algorithm/hex.hpp:30,
                 from /home/runner/work/vcmi/vcmi/lib/../Global.h:161,
                 from /home/runner/work/vcmi/vcmi/lib/StdInc.h:12,
                 from /home/runner/work/vcmi/vcmi/lib/rmg/CZonePlacer.cpp:11:
/usr/include/boost/detail/no_exceptions_support.hpp:17:1: note: ‘#pragma message: This header is deprecated. Use <boost/core/no_exceptions_support.hpp> instead.’
   17 | BOOST_HEADER_DEPRECATED("<boost/core/no_exceptions_support.hpp>")
      | ^~~~~~~~~~~~~~~~~~~~~~~
      
https://github.com/vcmi/vcmi/actions/runs/8560076496/job/23458231102?pr=3713#step:13:288