### PR TITLE
Few more tweaks for new lobby

### DIFF
--- a/client/globalLobby/GlobalLobbyClient.cpp
+++ b/client/globalLobby/GlobalLobbyClient.cpp
@@ -141,7 +141,7 @@ void GlobalLobbyClient::receiveChatHistory(const JsonNode & json)
 
 		chatHistory[channelKey].push_back(message);
 
-		if(lobbyWindowPtr)
+		if(lobbyWindowPtr && lobbyWindowPtr->isChannelOpen(channelType, channelName))
 			lobbyWindowPtr->onGameChatMessage(message.displayName, message.messageText, message.timeFormatted, channelType, channelName);
 	}
 }

--- a/client/globalLobby/GlobalLobbyLoginWindow.cpp
+++ b/client/globalLobby/GlobalLobbyLoginWindow.cpp
@@ -38,7 +38,7 @@ GlobalLobbyLoginWindow::GlobalLobbyLoginWindow()
 
 	MetaString loginAs;
 	loginAs.appendTextID("vcmi.lobby.login.as");
-	loginAs.replaceTextID(CSH->getGlobalLobby().getAccountDisplayName());
+	loginAs.replaceRawString(CSH->getGlobalLobby().getAccountDisplayName());
 
 	filledBackground = std::make_shared<FilledTexturePlayerColored>(ImagePath::builtin("DiBoxBck"), Rect(0, 0, pos.w, pos.h));
 	labelTitle = std::make_shared<CLabel>( pos.w / 2, 20, FONT_BIG, ETextAlignment::CENTER, Colors::YELLOW, CGI->generaltexth->translate("vcmi.lobby.login.title"));

--- a/client/globalLobby/GlobalLobbyLoginWindow.cpp
+++ b/client/globalLobby/GlobalLobbyLoginWindow.cpp
@@ -65,6 +65,7 @@ GlobalLobbyLoginWindow::GlobalLobbyLoginWindow()
 	{
 		buttonLogin->block(true);
 		toggleMode->setSelected(0);
+		onLoginModeChanged(0); // call it manually to disable widgets - toggleMode will not emit this call if this is currenly selected option
 	}
 	else
 		toggleMode->setSelected(1);

--- a/client/globalLobby/GlobalLobbyWindow.cpp
+++ b/client/globalLobby/GlobalLobbyWindow.cpp
@@ -64,6 +64,7 @@ void GlobalLobbyWindow::doOpenChannel(const std::string & channelType, const std
 	widget->getGameChatHeader()->setText(text.toString());
 
 	// Update currently selected item in UI
+	// WARNING: this invalidates function parameters since some of them are members of objects that will be destroyed by reset
 	widget->getAccountList()->reset();
 	widget->getChannelList()->reset();
 	widget->getMatchList()->reset();

--- a/lobby/LobbyDatabase.cpp
+++ b/lobby/LobbyDatabase.cpp
@@ -288,7 +288,7 @@ void LobbyDatabase::prepareStatements()
 	isAccountNameExistsStatement = database->prepare(R"(
 		SELECT COUNT(displayName)
 		FROM accounts
-		WHERE displayName = ?
+		WHERE displayName = ? COLLATE NOCASE
 	)");
 }
 


### PR DESCRIPTION
- Do not mark channel as unread when receiving chat history, for example when logging in.
- Do not attempt to translate usernames
- Fixed overlapping UI elements on login screen when player has no stored account details (e.g. first launch)
- Blocked creation of accounts with same name but different case (already deployed on server)