### PR TITLE
#3691 - boat attached to hero should not block tiles on its own

### DIFF
--- a/lib/gameState/CGameState.cpp
+++ b/lib/gameState/CGameState.cpp
@@ -642,7 +642,6 @@ void CGameState::initHeroes()
 			boat->id = ObjectInstanceID(static_cast<si32>(gs->map->objects.size()));
 
 			map->objects.emplace_back(boat);
-			map->addBlockVisTiles(boat);
 
 			hero->attachToBoat(boat);
 		}


### PR DESCRIPTION
Fix for #3691 
Hero standing on water gains boat but it was blocking tiles at that place making it impossible to attack such hero until it moves. Even after move the initial tile was not visitable any longer like it was blocked. Destroying such a boat causes AI crash