### PR TITLE
Fixes for recently reported crashes

### DIFF
--- a/AI/VCAI/VCAI.cpp
+++ b/AI/VCAI/VCAI.cpp
@@ -2031,6 +2031,9 @@ void VCAI::tryRealize(Goals::Explore & g)
 
 void VCAI::tryRealize(Goals::RecruitHero & g)
 {
+	if(cb->getResourceAmount(EGameResID::GOLD) < GameConstants::HERO_GOLD_COST)
+		throw cannotFulfillGoalException("Not enough gold to recruit hero!");
+
 	if(const CGTownInstance * t = findTownWithTavern())
 	{
 		recruitHero(t, true);

--- a/client/lobby/CBonusSelection.cpp
+++ b/client/lobby/CBonusSelection.cpp
@@ -119,7 +119,7 @@ CBonusSelection::CBonusSelection()
 	if (!getCampaign()->getMusic().empty())
 		CCS->musich->playMusic( getCampaign()->getMusic(), true, false);
 
-	if(settings["general"]["enableUiEnhancements"].Bool())
+	if(CSH->getState() != EClientState::GAMEPLAY && settings["general"]["enableUiEnhancements"].Bool())
 	{
 		tabExtraOptions = std::make_shared<ExtraOptionsTab>();
 		tabExtraOptions->recActions = UPDATE | SHOWALL | LCLICK | RCLICK_POPUP;

--- a/config/heroes/conflux.json
+++ b/config/heroes/conflux.json
@@ -176,7 +176,7 @@
 			"bonuses" : {
 				"damage" : {
 					"type" : "CREATURE_DAMAGE",
-					"subtype" : "creatureDamageMin",
+					"subtype" : "creatureDamageBoth",
 					"val" : 5
 				},
 				"attack" : {

--- a/lib/battle/CBattleInfoCallback.cpp
+++ b/lib/battle/CBattleInfoCallback.cpp
@@ -742,7 +742,7 @@ DamageEstimation CBattleInfoCallback::battleEstimateDamage(const battle::Unit * 
 {
 	RETURN_IF_NOT_BATTLE({});
 	auto reachability = battleGetDistances(attacker, attacker->getPosition());
-	int getMovementRange = reachability[attackerPosition];
+	int getMovementRange = attackerPosition.isValid() ? reachability[attackerPosition] : 0;
 	return battleEstimateDamage(attacker, defender, getMovementRange, retaliationDmg);
 }
 

--- a/lib/campaign/CampaignState.cpp
+++ b/lib/campaign/CampaignState.cpp
@@ -369,7 +369,7 @@ JsonNode CampaignState::crossoverSerialize(CGHeroInstance * hero) const
 CGHeroInstance * CampaignState::crossoverDeserialize(const JsonNode & node, CMap * map) const
 {
 	JsonDeserializer handler(nullptr, const_cast<JsonNode&>(node));
-	auto * hero = new CGHeroInstance(map->cb);
+	auto * hero = new CGHeroInstance(map ? map->cb : nullptr);
 	hero->ID = Obj::HERO;
 	hero->serializeJsonOptions(handler);
 	if (map)


### PR DESCRIPTION
Fixes for several recently reported crashes:
- Fixes #3622
- Fixes #3661 
- Fixes #3694 
- Fixes #3717 
- Also, fixed possible error message from server when VCAI attempts to buy hero without having resources to do so.