### PR TITLE
Better export command for translations

### DIFF
--- a/client/ClientCommandManager.h
+++ b/client/ClientCommandManager.h
@@ -48,8 +48,11 @@ class ClientCommandManager //take mantis #2292 issue about account if thinking a
 	// Set the state indicating if dialog box is active to "no"
 	void handleNotDialogCommand();
 
-	// Dumps all game text, maps text and campaign maps text into Client log between BEGIN TEXT EXPORT and END TEXT EXPORT
-	void handleConvertTextCommand();
+	// Extracts all translateable game texts into Translation directory, separating files on per-mod basis
+	void handleTranslateGameCommand();
+
+	// Extracts all translateable texts from maps and campaigns into Translation directory, separating files on per-mod basis
+	void handleTranslateMapsCommand();
 
 	// Saves current game configuration into extracted/configuration folder
 	void handleGetConfigCommand();

--- a/docs/modders/Translations.md
+++ b/docs/modders/Translations.md
@@ -38,10 +38,12 @@ VCMI allows translating game data into languages other than English. In order to
 If you have already existing Heroes III translation you can:
 
 - Install VCMI and select your localized Heroes III data files for VCMI data files
-- Launch VCMI_Client.exe directly from game install directory
-- In console window, type `convert txt`
+- Launch VCMI and start any map to get in game
+- Press Tab to activate chat and enter '/translate'
 
-This will export all strings from game into `Documents/My Games/VCMI/VCMI_Client_log.txt` which you can then use to update json files in your translation
+This will export all strings from game into `Documents/My Games/VCMI/extracted/translation/` directory which you can then use to update json files in your translation.
+
+To export maps and campaigns, use '/translate maps' command instead.
 
 ## Translating VCMI data
 
@@ -111,7 +113,15 @@ If everything is OK, your changes will be accepted and will be part of next rele
 
 ### Exporting translation
 
-TODO
+If you want to start new translation for a mod or to update existing one you may need to export it first. To do that:
+
+- Enable mod(s) that you want to export and set game language in Launcher to one that you want to target
+- Launch VCMI and start any map to get in game
+- Press Tab to activate chat and enter '/translate'
+
+After that, start Launcher, switch to Help tab and open "log files directory". You can find exported json's in 'extracted/translation' directory.
+
+If your mod also contains maps or campaigns that you want to translate, then use '/translate maps' command instead.
 
 ### Translating mod information
 In order to display information in Launcher in language selected by user add following block into your mod.json:
@@ -126,6 +136,12 @@ In order to display information in Launcher in language selected by user add fol
 	},
 ```
 However, normally you don't need to use block for English. Instead, English text should remain in root section of your mod.json file, to be used when game can not find translated version.
+
+### Tranlating in-game strings
+
+After you have exported translation and added mod information for your language, copy exported file to `<mod directory>/Content/config/<mod name>/<language>.json`.
+
+Use any text editor (Notepad++ is recommended for Windows) and translate all strings from this file to your language
 
 # Developers documentation
 

--- a/docs/players/Cheat_Codes.md
+++ b/docs/players/Cheat_Codes.md
@@ -114,7 +114,8 @@ Below a list of supported commands, with their arguments wrapped in `<>`
 `bonuses` - shows bonuses of currently selected adventure map object
 
 #### Extract commands
-`convert txt` - save game texts into json files  
+`translate` - save game texts into json files  
+`translate maps` - save map and campaign texts into json files  
 `get config` - save game objects data into json files  
 `get scripts` - dumps lua script stuff into files (currently inactive due to scripting disabled for default builds)    
 `get txt` - save game texts into .txt files matching original heroes 3 files  

--- a/lib/CBonusTypeHandler.cpp
+++ b/lib/CBonusTypeHandler.cpp
@@ -239,8 +239,8 @@ void CBonusTypeHandler::loadItem(const JsonNode & source, CBonusType & dest, con
 
 	if (!dest.hidden)
 	{
-		VLC->generaltexth->registerString( "core", dest.getNameTextID(), source["name"].String());
-		VLC->generaltexth->registerString( "core", dest.getDescriptionTextID(), source["description"].String());
+		VLC->generaltexth->registerString( "vcmi", dest.getNameTextID(), source["name"].String());
+		VLC->generaltexth->registerString( "vcmi", dest.getDescriptionTextID(), source["description"].String());
 	}
 
 	const JsonNode & graphics = source["graphics"];

--- a/lib/CGeneralTextHandler.cpp
+++ b/lib/CGeneralTextHandler.cpp
@@ -500,6 +500,7 @@ CGeneralTextHandler::CGeneralTextHandler():
 	readToVector("core.overview", "DATA/OVERVIEW.TXT" );
 	readToVector("core.arraytxt", "DATA/ARRAYTXT.TXT" );
 	readToVector("core.priskill", "DATA/PRISKILL.TXT" );
+	readToVector("core.plcolors", "DATA/PLCOLORS.TXT" );
 	readToVector("core.jktext",   "DATA/JKTEXT.TXT"   );
 	readToVector("core.tvrninfo", "DATA/TVRNINFO.TXT" );
 	readToVector("core.turndur",  "DATA/TURNDUR.TXT"  );
@@ -550,20 +551,6 @@ CGeneralTextHandler::CGeneralTextHandler():
 			std::string second = parser.readString();
 			registerString("core", "core.help." + std::to_string(index) + ".hover", first);
 			registerString("core", "core.help." + std::to_string(index) + ".help",  second);
-			index += 1;
-		}
-		while (parser.endLine());
-	}
-	{
-		CLegacyConfigParser parser(TextPath::builtin("DATA/PLCOLORS.TXT"));
-		size_t index = 0;
-		do
-		{
-			std::string color = parser.readString();
-
-			registerString("core", {"core.plcolors", index}, color);
-			color[0] = toupper(color[0]);
-			registerString("core", {"vcmi.capitalColors", index}, color);
 			index += 1;
 		}
 		while (parser.endLine());

--- a/lib/CGeneralTextHandler.cpp
+++ b/lib/CGeneralTextHandler.cpp
@@ -10,15 +10,16 @@
 #include "StdInc.h"
 #include "CGeneralTextHandler.h"
 
-#include "filesystem/Filesystem.h"
-#include "serializer/JsonSerializeFormat.h"
 #include "CConfigHandler.h"
 #include "GameSettings.h"
-#include "mapObjects/CQuest.h"
-#include "modding/CModHandler.h"
-#include "VCMI_Lib.h"
 #include "Languages.h"
 #include "TextOperations.h"
+#include "VCMIDirs.h"
+#include "VCMI_Lib.h"
+#include "filesystem/Filesystem.h"
+#include "mapObjects/CQuest.h"
+#include "modding/CModHandler.h"
+#include "serializer/JsonSerializeFormat.h"
 
 VCMI_LIB_NAMESPACE_BEGIN
 
@@ -386,18 +387,26 @@ bool TextLocalizationContainer::identifierExists(const TextIdentifier & UID) con
 	return stringsLocalizations.count(UID.get());
 }
 
-void TextLocalizationContainer::dumpAllTexts()
+void TextLocalizationContainer::exportAllTexts(std::map<std::string, std::map<std::string, std::string>> & storage) const
 {
-	logGlobal->info("BEGIN TEXT EXPORT");
-	for(const auto & entry : stringsLocalizations)
-	{
-		if (!entry.second.overrideValue.empty())
-			logGlobal->info(R"("%s" : "%s",)", entry.first, TextOperations::escapeString(entry.second.overrideValue));
-		else
-			logGlobal->info(R"("%s" : "%s",)", entry.first, TextOperations::escapeString(entry.second.baseValue));
-	}
+	for (auto const & subContainer : subContainers)
+		subContainer->exportAllTexts(storage);
 
-	logGlobal->info("END TEXT EXPORT");
+	for (auto const & entry : stringsLocalizations)
+	{
+		std::string textToWrite;
+		std::string modName = entry.second.modContext;
+
+		if (modName.find('.') != std::string::npos)
+			modName = modName.substr(0, modName.find('.'));
+
+		if (!entry.second.overrideValue.empty())
+			textToWrite = entry.second.overrideValue;
+		else
+			textToWrite = entry.second.baseValue;
+
+		storage[modName][entry.first] = textToWrite;
+	}
 }
 
 std::string TextLocalizationContainer::getModLanguage(const std::string & modContext)

--- a/lib/CGeneralTextHandler.h
+++ b/lib/CGeneralTextHandler.h
@@ -181,8 +181,9 @@ public:
 	/// converts identifier into user-readable string
 	const std::string & deserialize(const TextIdentifier & identifier) const;
 	
-	/// Debug method, dumps all currently known texts into console using Json-like format
-	void dumpAllTexts();
+	/// Debug method, returns all currently stored texts
+	/// Format: [mod ID][string ID] -> human-readable text
+	void exportAllTexts(std::map<std::string, std::map<std::string, std::string>> & storage) const;
 	
 	/// Add or override subcontainer which can store identifiers
 	void addSubContainer(const TextLocalizationContainer & container);

--- a/lib/mapObjects/CQuest.cpp
+++ b/lib/mapObjects/CQuest.cpp
@@ -684,6 +684,9 @@ void CGSeerHut::serializeJsonOptions(JsonSerializeFormat & handler)
 		//backward compatibility for VCMI maps that use old SeerHut format
 		auto s = handler.enterStruct("reward");
 		const JsonNode & rewardsJson = handler.getCurrent();
+
+		if (rewardsJson.Struct().empty())
+			return;
 		
 		std::string fullIdentifier;
 		std::string metaTypeName;


### PR DESCRIPTION
This PR replaces existing (but inconvenient) `convert txt` command that dumps all strings into log file with more convenient options:
- `/translate` will now export all in-game strings to `<cache directory>/extracted/translation/` directory, with files split on per-mod basis.
- `/translate maps` will do the same, but will only export maps & campaigns. This command separate from "main" command since it needs to load every map, making it rather slow, compared to almost-instant `/translate`.

All files will be exported as valid json that can be used for translations as it, without manual formatting manipulations. If mod has submods, game will put all strings from submods into translation for main mod since this form is one that is generally used for translations