### PR TITLE
Allow factions to be special

### DIFF
--- a/config/schemas/faction.json
+++ b/config/schemas/faction.json
@@ -58,6 +58,10 @@
 			"type" : "boolean",
 			"description" : "Random map generator places player/cpu-owned towns underground if true is specified and on the ground otherwise. Parameter is unused for maps without underground."
 		},
+		"special" : {
+			"type" : "boolean",
+			"description" : "If true, faction is disabled from starting pick and in random map generation"
+		},
 		"creatureBackground" : {
 			"type" : "object",
 			"additionalProperties" : false,

--- a/docs/modders/Entities_Format/Faction_Format.md
+++ b/docs/modders/Entities_Format/Faction_Format.md
@@ -75,6 +75,9 @@ Each town requires a set of buildings (Around 30-45 buildings)
 	
 	// Random map generator places player/cpu-owned towns underground if true is specified and on the ground otherwise. Parameter is unused for maps without underground.
 	"preferUndergroundPlacement" : false
+	
+	// Optional, if set to true then faction cannot be selected on game start and will not be used for "random town" object
+	"special" : false
 
 	// Town puzzle map
 	"puzzleMap" :

--- a/lib/CTownHandler.cpp
+++ b/lib/CTownHandler.cpp
@@ -1068,8 +1068,7 @@ CFaction * CTownHandler::loadFromJson(const std::string & scope, const JsonNode 
 	
 	auto preferUndergound = source["preferUndergroundPlacement"];
 	faction->preferUndergroundPlacement = preferUndergound.isNull() ? false : preferUndergound.Bool();
-	auto isSpecial = source["special"];
-	faction->special = isSpecial.isNull() ? false : isSpecial.Bool();
+	faction->special = source["special"].Bool();
 
 	// NOTE: semi-workaround - normally, towns are supposed to have native terrains.
 	// Towns without one are exceptions. So, vcmi requires nativeTerrain to be defined

--- a/lib/CTownHandler.cpp
+++ b/lib/CTownHandler.cpp
@@ -1068,6 +1068,8 @@ CFaction * CTownHandler::loadFromJson(const std::string & scope, const JsonNode 
 	
 	auto preferUndergound = source["preferUndergroundPlacement"];
 	faction->preferUndergroundPlacement = preferUndergound.isNull() ? false : preferUndergound.Bool();
+	auto isSpecial = source["special"];
+	faction->special = isSpecial.isNull() ? false : isSpecial.Bool();
 
 	// NOTE: semi-workaround - normally, towns are supposed to have native terrains.
 	// Towns without one are exceptions. So, vcmi requires nativeTerrain to be defined
@@ -1259,7 +1261,7 @@ std::set<FactionID> CTownHandler::getDefaultAllowed() const
 	std::set<FactionID> allowedFactions;
 
 	for(auto town : objects)
-		if (town->town != nullptr)
+		if (town->town != nullptr && !town->special)
 			allowedFactions.insert(town->getId());
 
 	return allowedFactions;

--- a/lib/CTownHandler.h
+++ b/lib/CTownHandler.h
@@ -168,6 +168,7 @@ public:
 	TerrainId nativeTerrain;
 	EAlignment alignment = EAlignment::NEUTRAL;
 	bool preferUndergroundPlacement = false;
+	bool special = false;
 
 	/// Boat that will be used by town shipyard (if any)
 	/// and for placing heroes directly on boat (in map editor, water prisons & taverns)


### PR DESCRIPTION
Feature caused by needs of modders - make faction unavailable on standard maps, allows making pseudo-factions mostly for custom maps that are not proper town equivalent for standard gameplay etc. Presence of heroes from this faction in tavern and creatures map presence etc. can be changed independently via their own "special" parameter.