### PR TITLE
Fix discovered undefined behavior cases

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -393,8 +393,10 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR NOT WIN32)
 		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error=array-bounds") # false positives in boost::multiarray during release build, keep as warning-only
 	endif()
 
-	# For gcc 14+ we can use -fhardened instead
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_FORTIFY_SOURCE=2 -D_GLIBCXX_ASSERTIONS -fstack-protector-strong -fstack-clash-protection -fcf-protection=full")
+	if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND NOT WIN32)
+		# For gcc 14+ we can use -fhardened instead
+		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_FORTIFY_SOURCE=2 -D_GLIBCXX_ASSERTIONS -fstack-protector-strong -fstack-clash-protection -fcf-protection=full")
+	endif()
 
 	# Fix string inspection with lldb
 	# https://stackoverflow.com/questions/58578615/cannot-inspect-a-stdstring-variable-in-lldb

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -393,6 +393,9 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR NOT WIN32)
 		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error=array-bounds") # false positives in boost::multiarray during release build, keep as warning-only
 	endif()
 
+	# For gcc 14+ we can use -fhardened instead
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_FORTIFY_SOURCE=2 -D_GLIBCXX_ASSERTIONS -fstack-protector-strong -fstack-clash-protection -fcf-protection=full")
+
 	# Fix string inspection with lldb
 	# https://stackoverflow.com/questions/58578615/cannot-inspect-a-stdstring-variable-in-lldb
 	if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")

--- a/Global.h
+++ b/Global.h
@@ -104,12 +104,6 @@ static_assert(sizeof(bool) == 1, "Bool needs to be 1 byte in size.");
 
 #define _USE_MATH_DEFINES
 
-#ifndef NDEBUG
-// Enable additional debug checks from glibc / libstdc++ when building with enabled assertions
-// Since these defines must be declared BEFORE including glibc header we can not check for __GLIBCXX__ macro to detect that glibc is in use
-#  define _GLIBCXX_ASSERTIONS
-#endif
-
 #include <algorithm>
 #include <any>
 #include <array>

--- a/client/CMusicHandler.cpp
+++ b/client/CMusicHandler.cpp
@@ -322,6 +322,13 @@ void CSoundHandler::setCallback(int channel, std::function<void()> function)
 		iter->second.push_back(function);
 }
 
+void CSoundHandler::resetCallback(int channel)
+{
+	boost::mutex::scoped_lock lockGuard(mutexCallbacks);
+
+	callbacks.erase(channel);
+}
+
 void CSoundHandler::soundFinishedCallback(int channel)
 {
 	boost::mutex::scoped_lock lockGuard(mutexCallbacks);

--- a/client/CMusicHandler.h
+++ b/client/CMusicHandler.h
@@ -85,6 +85,7 @@ public:
 	void stopSound(int handler);
 
 	void setCallback(int channel, std::function<void()> function);
+	void resetCallback(int channel);
 	void soundFinishedCallback(int channel);
 
 	int ambientGetRange() const;

--- a/client/gui/EventDispatcher.cpp
+++ b/client/gui/EventDispatcher.cpp
@@ -213,12 +213,21 @@ void EventDispatcher::handleLeftButtonClick(const Point & position, int toleranc
 		if( i->receiveEvent(position, AEventsReceiver::LCLICK) || i == nearestElement)
 		{
 			if(isPressed)
+			{
+				i->mouseClickedState = isPressed;
 				i->clickPressed(position, lastActivated);
+			}
+			else
+			{
+				if (i->mouseClickedState)
+				{
+					i->mouseClickedState = isPressed;
+					i->clickReleased(position, lastActivated);
+				}
+				else
+					i->mouseClickedState = isPressed;
+			}
 
-			if (i->mouseClickedState && !isPressed)
-				i->clickReleased(position, lastActivated);
-
-			i->mouseClickedState = isPressed;
 			lastActivated = false;
 		}
 		else

--- a/client/lobby/SelectionTab.cpp
+++ b/client/lobby/SelectionTab.cpp
@@ -155,12 +155,12 @@ SelectionTab::SelectionTab(ESelectionScreen Type)
 	OBJ_CONSTRUCTION;
 		
 	generalSortingBy = getSortBySelectionScreen(tabType);
+	sortingBy = _format;
 
 	bool enableUiEnhancements = settings["general"]["enableUiEnhancements"].Bool();
 
 	if(tabType != ESelectionScreen::campaignList)
 	{
-		sortingBy = _format;
 		background = std::make_shared<CPicture>(ImagePath::builtin("SCSELBCK.bmp"), 0, 6);
 		pos = background->pos;
 		inputName = std::make_shared<CTextInput>(inputNameRect, Point(-32, -25), ImagePath::builtin("GSSTRIP.bmp"), 0);

--- a/client/mainmenu/CPrologEpilogVideo.cpp
+++ b/client/mainmenu/CPrologEpilogVideo.cpp
@@ -74,6 +74,7 @@ void CPrologEpilogVideo::show(Canvas & to)
 void CPrologEpilogVideo::clickPressed(const Point & cursorPosition)
 {
 	close();
+	CCS->soundh->resetCallback(voiceSoundHandle); // reset callback to avoid memory corruption since 'this' will be destroyed
 	CCS->soundh->stopSound(voiceSoundHandle);
 	CCS->soundh->stopSound(videoSoundHandle);
 	if(exitCb)

--- a/lib/CGameInterface.h
+++ b/lib/CGameInterface.h
@@ -71,7 +71,7 @@ using TTeleportExitsList = std::vector<std::pair<ObjectInstanceID, int3>>;
 class DLL_LINKAGE CBattleGameInterface : public IBattleEventsReceiver
 {
 public:
-	bool human;
+	bool human = false;
 	PlayerColor playerID;
 	std::string dllName;
 


### PR DESCRIPTION
Attempted to track recent AI and/or artifact-related crashes using gcc sanitizers. Was not able to catch those bugs specifically, but found few others.

Changes:
- enabled gcc 'hardening' flags to detect various memory corruption bugs in runtime. Not sure if they can be used on all platforms, will see what CI says. Linux distros often use these flags for all package builds, so should be safe.
- fixed use-after-free bug in EventDispatcher and in CPrologEpilogVideo
- fixed uninitialized variable in SelectionTab and in CBattleGameInterface