### PR TITLE
Attempt to fix crash on moving artifact on Android

### DIFF
--- a/lib/CArtHandler.h
+++ b/lib/CArtHandler.h
@@ -192,7 +192,7 @@ class DLL_LINKAGE CArtifactSet
 public:
 	using ArtPlacementMap = std::map<CArtifactInstance*, ArtifactPosition>;
 
-	std::deque<ArtSlotInfo> artifactsInBackpack; //hero's artifacts from bag
+	std::vector<ArtSlotInfo> artifactsInBackpack; //hero's artifacts from bag
 	std::map<ArtifactPosition, ArtSlotInfo> artifactsWorn; //map<position,artifact_id>; positions: 0 - head; 1 - shoulders; 2 - neck; 3 - right hand; 4 - left hand; 5 - torso; 6 - right ring; 7 - left ring; 8 - feet; 9 - misc1; 10 - misc2; 11 - misc3; 12 - misc4; 13 - mach1; 14 - mach2; 15 - mach3; 16 - mach4; 17 - spellbook; 18 - misc5
 	std::vector<ArtSlotInfo> artifactsTransitionPos; // Used as transition position for dragAndDrop artifact exchange
 


### PR DESCRIPTION
After testing daily builds on Android I can confirm that crash comes from PR #3656
However I don't see any potentially dangerous changes in it. The only change that could have side-effects that I've found is replacement of std::vector with std::deque. Not a bad change, but perhaps we do some weird stuff with it, like assuming that its storage is continious. Or perhaps there is some bug with Android SDK since deque is very rarely used.