### PR TITLE
Fix crash on accessing nullptr quest

### DIFF
--- a/lib/networkPacks/NetPacksLib.cpp
+++ b/lib/networkPacks/NetPacksLib.cpp
@@ -1199,13 +1199,9 @@ void RemoveObject::applyGs(CGameState *gs)
 		gs->map->quests[quest->quest->qid] = nullptr;
 		for (auto &player : gs->players)
 		{
-			for (auto &q : player.second.quests)
-			{
-				if (q.obj == obj)
-				{
-					q.obj = nullptr;
-				}
-			}
+			vstd::erase_if(player.second.quests, [obj](const QuestInfo & q){
+				return q.obj == obj;
+			});
 		}
 	}
 


### PR DESCRIPTION
Completely remove dead quest instead of leaving nullptr. All code that uses this container assumes non-null content

- Fixes #3729