### PR TITLE
Fix assertion failure with drag-and-drop cursor

### DIFF
--- a/client/CMT.cpp
+++ b/client/CMT.cpp
@@ -502,8 +502,6 @@ void handleQuit(bool ask)
 		return;
 	}
 
-	CCS->curh->set(Cursor::Map::POINTER);
-
 	if (LOCPLINT)
 		LOCPLINT->showYesNoDialog(CGI->generaltexth->allTexts[69], quitApplication, nullptr);
 	else

--- a/client/widgets/CArtifactsOfHeroAltar.cpp
+++ b/client/widgets/CArtifactsOfHeroAltar.cpp
@@ -34,7 +34,8 @@ CArtifactsOfHeroAltar::CArtifactsOfHeroAltar(const Point & position)
 	rightBackpackRoll->moveBy(Point(2, -1));
 };
 
-CArtifactsOfHeroAltar::~CArtifactsOfHeroAltar()
+void CArtifactsOfHeroAltar::deactivate()
 {
 	putBackPickedArtifact();
+	CArtifactsOfHeroBase::deactivate();
 }

--- a/client/widgets/CArtifactsOfHeroAltar.h
+++ b/client/widgets/CArtifactsOfHeroAltar.h
@@ -17,5 +17,5 @@ class CArtifactsOfHeroAltar : public CArtifactsOfHeroBase
 {
 public:
 	CArtifactsOfHeroAltar(const Point & position);
-	~CArtifactsOfHeroAltar();
+	void deactivate() override;
 };

--- a/client/widgets/CArtifactsOfHeroKingdom.cpp
+++ b/client/widgets/CArtifactsOfHeroKingdom.cpp
@@ -46,7 +46,8 @@ CArtifactsOfHeroKingdom::CArtifactsOfHeroKingdom(ArtPlaceMap ArtWorn, std::vecto
 	setRedrawParent(true);
 }
 
-CArtifactsOfHeroKingdom::~CArtifactsOfHeroKingdom()
+void CArtifactsOfHeroKingdom::deactivate()
 {
 	putBackPickedArtifact();
+	CArtifactsOfHeroBase::deactivate();
 }

--- a/client/widgets/CArtifactsOfHeroKingdom.h
+++ b/client/widgets/CArtifactsOfHeroKingdom.h
@@ -23,5 +23,6 @@ public:
 	CArtifactsOfHeroKingdom() = delete;
 	CArtifactsOfHeroKingdom(ArtPlaceMap ArtWorn, std::vector<ArtPlacePtr> Backpack,
 		std::shared_ptr<CButton> leftScroll, std::shared_ptr<CButton> rightScroll);
-	~CArtifactsOfHeroKingdom();
+
+	void deactivate() override;
 };

--- a/client/widgets/CArtifactsOfHeroMain.cpp
+++ b/client/widgets/CArtifactsOfHeroMain.cpp
@@ -26,7 +26,8 @@ CArtifactsOfHeroMain::CArtifactsOfHeroMain(const Point & position)
 	addGestureCallback(std::bind(&CArtifactsOfHeroBase::gestureArtPlace, this, _1, _2));
 }
 
-CArtifactsOfHeroMain::~CArtifactsOfHeroMain()
+void CArtifactsOfHeroMain::deactivate()
 {
 	putBackPickedArtifact();
+	CArtifactsOfHeroBase::deactivate();
 }

--- a/client/widgets/CArtifactsOfHeroMain.h
+++ b/client/widgets/CArtifactsOfHeroMain.h
@@ -21,5 +21,5 @@ class CArtifactsOfHeroMain : public CArtifactsOfHeroBase
 {
 public:
 	CArtifactsOfHeroMain(const Point & position);
-	~CArtifactsOfHeroMain();
+	void deactivate() override;
 };


### PR DESCRIPTION
Artifact windows will now drop picked artifact on window deactivation instead of on destruction. Removed excessive call to setCursor since it is called before artifact windows can remove their dnd cursor. Cursor on message box still appears normally since it will be reset to pointer when new window is pushed on stack

- Fixes #3740