### PR TITLE
Fix regressions

### DIFF
--- a/client/HeroMovementController.cpp
+++ b/client/HeroMovementController.cpp
@@ -22,6 +22,7 @@
 
 #include "../CCallback.h"
 
+#include "../lib/CondSh.h"
 #include "../lib/pathfinder/CGPathNode.h"
 #include "../lib/mapObjects/CGHeroInstance.h"
 #include "../lib/networkPacks/PacksForClient.h"
@@ -233,7 +234,7 @@ void HeroMovementController::onMoveHeroApplied()
 	assert(currentlyMovingHero);
 	const auto * hero = currentlyMovingHero;
 
-	bool canMove = LOCPLINT->localState->hasPath(hero) && LOCPLINT->localState->getPath(hero).nextNode().turns == 0;
+	bool canMove = LOCPLINT->localState->hasPath(hero) && LOCPLINT->localState->getPath(hero).nextNode().turns == 0 && !LOCPLINT->showingDialog->get();
 	bool wantStop = stoppingMovement;
 	bool canStop = !canMove || canHeroStopAtNode(LOCPLINT->localState->getPath(hero).currNode());
 

--- a/client/windows/CKingdomInterface.cpp
+++ b/client/windows/CKingdomInterface.cpp
@@ -821,11 +821,11 @@ CTownItem::CTownItem(const CGTownInstance * Town)
 		available.push_back(std::make_shared<CCreaInfo>(Point(48+37*(int)i, 78), town, (int)i, true, false));
 	}
 
-	fastTownHall = std::make_shared<CButton>(Point(69, 31), AnimationPath::builtin("castleInterfaceQuickAccessz"), CButton::tooltip(), [this]() { std::make_shared<CCastleBuildings>(town)->enterTownHall(); });
+	fastTownHall = std::make_shared<CButton>(Point(69, 31), AnimationPath::builtin("castleInterfaceQuickAccess"), CButton::tooltip(), [this]() { std::make_shared<CCastleBuildings>(town)->enterTownHall(); });
 	fastTownHall->setOverlay(std::make_shared<CAnimImage>(AnimationPath::builtin("ITMTL"), town->hallLevel()));
 
 	int imageIndex = town->fortLevel() == CGTownInstance::EFortLevel::NONE ? 3 : town->fortLevel() - 1;
-	fastArmyPurchase = std::make_shared<CButton>(Point(111, 31), AnimationPath::builtin("castleInterfaceQuickAccessz"), CButton::tooltip(), [this]() { std::make_shared<CCastleBuildings>(town)->enterToTheQuickRecruitmentWindow(); });
+	fastArmyPurchase = std::make_shared<CButton>(Point(111, 31), AnimationPath::builtin("castleInterfaceQuickAccess"), CButton::tooltip(), [this]() { std::make_shared<CCastleBuildings>(town)->enterToTheQuickRecruitmentWindow(); });
 	fastArmyPurchase->setOverlay(std::make_shared<CAnimImage>(AnimationPath::builtin("itmcl"), imageIndex));
 
 	fastTavern = std::make_shared<LRClickableArea>(Rect(5, 6, 58, 64), [&]()

--- a/client/windows/InfoWindows.cpp
+++ b/client/windows/InfoWindows.cpp
@@ -54,10 +54,7 @@ CSelWindow::CSelWindow( const std::string & Text, PlayerColor player, int charpe
 	text = std::make_shared<CTextBox>(Text, Rect(0, 0, 250, 100), 0, FONT_MEDIUM, ETextAlignment::CENTER, Colors::WHITE);
 
 	if(buttons.size() > 1 && askID.getNum() >= 0) //cancel button functionality
-	{
 		buttons.back()->addCallback([askID](){LOCPLINT->cb->selectionMade(0, askID);});
-		//buttons.back()->addCallback(std::bind(&CCallback::selectionMade, LOCPLINT->cb.get(), 0, askID));
-	}
 
 	if(buttons.size() == 1)
 		buttons.front()->assignedKey = EShortcut::GLOBAL_RETURN;
@@ -69,7 +66,11 @@ CSelWindow::CSelWindow( const std::string & Text, PlayerColor player, int charpe
 	}
 
 	if(!comps.empty())
+	{
 		components = std::make_shared<CComponentBox>(comps, Rect(0,0,0,0));
+		for (auto & comp : comps)
+			comp->onChoose = [this](){ madeChoiceAndClose(); };
+	}
 
 	CMessage::drawIWindow(this, Text, player);
 }

--- a/lib/spells/AdventureSpellMechanics.cpp
+++ b/lib/spells/AdventureSpellMechanics.cpp
@@ -538,7 +538,7 @@ ESpellCastResult TownPortalMechanics::applyAdventureEffects(SpellCastEnvironment
 	const TerrainTile & from = env->getMap()->getTile(parameters.caster->getHeroCaster()->visitablePos());
 	const TerrainTile & dest = env->getMap()->getTile(destination->visitablePos());
 
-	if(!dest.isClear(&from))
+	if(!dest.entrableTerrain(&from))
 	{
 		InfoWindow iw;
 		iw.player = parameters.caster->getCasterOwner();


### PR DESCRIPTION
- Fixes town portal casting when on land - regression from my spell PR
- Fixes movement over event that generates queries (e.g. levelup)
- Fixes #3755
- Fixes #3760
- Fixed misplaced buttons in kingdom overview
- Restored double-click handling in message boxes