### PR TITLE
Fix crash caused by Penrose tiling

### DIFF
--- a/lib/rmg/PenroseTiling.cpp
+++ b/lib/rmg/PenroseTiling.cpp
@@ -134,10 +134,10 @@ void PenroseTiling::split(Triangle& p, std::vector<Point2D>& points,
 
 std::set<Point2D> PenroseTiling::generatePenroseTiling(size_t numZones, CRandomGenerator * rand)
 {
-	float scale = 100.f / (numZones * 1.5f + 20);
+	float scale = 173.2f / (numZones * 1.5f + 20);
 	float polyAngle = (2 * PI_CONSTANT) / POLY;
 
-	float randomAngle = rand->nextDouble(0, 2 * PI_CONSTANT);
+	float randomAngle = rand->nextDouble(0.25 * PI_CONSTANT, 0.75 * PI_CONSTANT);
 
 	std::vector<Point2D> points = { Point2D(0.0f, 0.0f), Point2D(0.0f, 1.0f).rotated(randomAngle) };
 	std::array<std::vector<uint32_t>, 5> indices;

--- a/lib/rmg/PenroseTiling.h
+++ b/lib/rmg/PenroseTiling.h
@@ -59,7 +59,7 @@ public:
 	const uint32_t POLY = 10; // Number of symmetries?
 
 	const float BASE_SIZE = 1.25f;
-	const uint32_t DEPTH = 7; //Recursion depth
+	const uint32_t DEPTH = 8; //Recursion depth
 	
 	const bool P2 = false; // Tiling type
 


### PR DESCRIPTION
Tweak numbers to ensure tiling covers entire map

For those curious: previously on 8XM8 without U tiling could end up like this:
![penrose3_8MX8_100](https://github.com/vcmi/vcmi/assets/2566990/a3f572c0-9581-4db0-85c8-b79ef39b7c5c)

So zones in top-right corner would not get any vertex assigned, resulting in zone of size 0.
