### PR TITLE
set save name by default

### DIFF
--- a/client/lobby/SelectionTab.cpp
+++ b/client/lobby/SelectionTab.cpp
@@ -677,6 +677,9 @@ void SelectionTab::selectFileName(std::string fname)
 
 	filter(-1);
 	selectAbs(-1);
+
+	if(inputName->getText().empty())
+		inputName->setText("NEWGAME");
 }
 
 std::shared_ptr<ElementInfo> SelectionTab::getSelectedMapInfo() const


### PR DESCRIPTION
fixed problem from discord

Instead of Empty filename show "NEWGAME" if file list is empty.