### PR TITLE
Empty treasure bank does not ask for enter anymore

### DIFF
--- a/lib/mapObjects/CBank.cpp
+++ b/lib/mapObjects/CBank.cpp
@@ -61,7 +61,7 @@ std::string CBank::getHoverText(PlayerColor player) const
 	if (!wasVisited(player))
 		return getObjectName();
 
-	return getObjectName() + "\n" + visitedTxt(bc == nullptr);
+	return getObjectName() + "\n" + visitedTxt(bankConfig == nullptr);
 }
 
 std::vector<Component> CBank::getPopupComponents(PlayerColor player) const
@@ -72,7 +72,7 @@ std::vector<Component> CBank::getPopupComponents(PlayerColor player) const
 	if (!VLC->settings()->getBoolean(EGameSettings::BANKS_SHOW_GUARDS_COMPOSITION))
 		return {};
 
-	if (bc == nullptr)
+	if (bankConfig == nullptr)
 		return {};
 
 	std::map<CreatureID, int> guardsAmounts;
@@ -92,7 +92,7 @@ std::vector<Component> CBank::getPopupComponents(PlayerColor player) const
 
 void CBank::setConfig(const BankConfig & config)
 {
-	bc = std::make_unique<BankConfig>(config);
+	bankConfig = std::make_unique<BankConfig>(config);
 	clearSlots(); // remove all stacks, if any
 
 	for(const auto & stack : config.guards)
@@ -112,14 +112,14 @@ void CBank::setPropertyDer (ObjProperty what, ObjPropertyID identifier)
 			daycounter = 1; //yes, 1 since "today" daycounter won't be incremented
 			break;
 		case ObjProperty::BANK_CLEAR:
-			bc.reset();
+			bankConfig.reset();
 			break;
 	}
 }
 
 void CBank::newTurn(CRandomGenerator & rand) const
 {
-	if (bc == nullptr)
+	if (bankConfig == nullptr)
 	{
 		if (resetDuration != 0)
 		{
@@ -140,6 +140,12 @@ void CBank::onHeroVisit(const CGHeroInstance * h) const
 {
 	ChangeObjectVisitors cov(ChangeObjectVisitors::VISITOR_ADD_TEAM, id, h->id);
 	cb->sendAndApply(&cov);
+
+	if(!bankConfig)
+	{
+		blockingDialogAnswered(h, 1);
+		return;
+	}
 
 	int banktext = 0;
 	switch (ID.toEnum())
@@ -183,7 +189,7 @@ void CBank::doVisit(const CGHeroInstance * hero) const
 	iw.player = hero->getOwner();
 	MetaString loot;
 
-	if (bc)
+	if (bankConfig)
 	{
 		switch (ID.toEnum())
 		{
@@ -267,21 +273,21 @@ void CBank::doVisit(const CGHeroInstance * hero) const
 
 
 	//grant resources
-	if (bc)
+	if (bankConfig)
 	{
 		for (GameResID it : GameResID::ALL_RESOURCES())
 		{
-			if (bc->resources[it] != 0)
+			if (bankConfig->resources[it] != 0)
 			{
-				iw.components.emplace_back(ComponentType::RESOURCE, it, bc->resources[it]);
+				iw.components.emplace_back(ComponentType::RESOURCE, it, bankConfig->resources[it]);
 				loot.appendRawString("%d %s");
-				loot.replaceNumber(bc->resources[it]);
+				loot.replaceNumber(bankConfig->resources[it]);
 				loot.replaceName(it);
-				cb->giveResource(hero->getOwner(), it, bc->resources[it]);
+				cb->giveResource(hero->getOwner(), it, bankConfig->resources[it]);
 			}
 		}
 		//grant artifacts
-		for (auto & elem : bc->artifacts)
+		for (auto & elem : bankConfig->artifacts)
 		{
 			iw.components.emplace_back(ComponentType::ARTIFACT, elem);
 			loot.appendRawString("%s");
@@ -294,7 +300,7 @@ void CBank::doVisit(const CGHeroInstance * hero) const
 			iw.text.appendLocalString(EMetaText::ADVOB_TXT, textID);
 			if (textID == 34)
 			{
-				const auto * strongest = boost::range::max_element(bc->guards, [](const CStackBasicDescriptor & a, const CStackBasicDescriptor & b)
+				const auto * strongest = boost::range::max_element(bankConfig->guards, [](const CStackBasicDescriptor & a, const CStackBasicDescriptor & b)
 				{
 					return a.type->getFightValue() < b.type->getFightValue();
 				})->type;
@@ -309,7 +315,7 @@ void CBank::doVisit(const CGHeroInstance * hero) const
 		iw.components.clear();
 		iw.text.clear();
 
-		if (!bc->spells.empty())
+		if (!bankConfig->spells.empty())
 		{
 			std::set<SpellID> spells;
 
@@ -318,7 +324,7 @@ void CBank::doVisit(const CGHeroInstance * hero) const
 			{
 				iw.text.appendLocalString(EMetaText::ADVOB_TXT, textID); //pyramid
 			}
-			for(const SpellID & spellId : bc->spells)
+			for(const SpellID & spellId : bankConfig->spells)
 			{
 				const auto * spell = spellId.toEntity(VLC);
 				iw.text.appendName(spellId);
@@ -351,7 +357,7 @@ void CBank::doVisit(const CGHeroInstance * hero) const
 
 		//grant creatures
 		CCreatureSet ourArmy;
-		for(const auto & slot : bc->creatures)
+		for(const auto & slot : bankConfig->creatures)
 		{
 			ourArmy.addToSlot(ourArmy.getSlotFor(slot.type->getId()), slot.type->getId(), slot.count);
 		}
@@ -391,7 +397,7 @@ void CBank::blockingDialogAnswered(const CGHeroInstance *hero, ui32 answer) cons
 {
 	if (answer)
 	{
-		if (bc) // not looted bank
+		if (bankConfig) // not looted bank
 			cb->startBattleI(hero, this, true);
 		else
 			doVisit(hero);

--- a/lib/mapObjects/CBank.h
+++ b/lib/mapObjects/CBank.h
@@ -18,7 +18,7 @@ class CBankInstanceConstructor;
 
 class DLL_LINKAGE CBank : public CArmedInstance
 {
-	std::unique_ptr<BankConfig> bc;
+	std::unique_ptr<BankConfig> bankConfig;
 	ui32 daycounter;
 	ui32 resetDuration;
 	bool coastVisitable;
@@ -47,7 +47,7 @@ public:
 	{
 		h & static_cast<CArmedInstance&>(*this);
 		h & daycounter;
-		h & bc;
+		h & bankConfig;
 		h & resetDuration;
 		h & coastVisitable;
 	}


### PR DESCRIPTION
When visiting empty treasure bank player is prompted if he wants to enter. In H3 the prompt happens only when the bank was not looted.