### PR TITLE
Instant movement

### DIFF
--- a/AI/Nullkiller/AIGateway.cpp
+++ b/AI/Nullkiller/AIGateway.cpp
@@ -1216,7 +1216,7 @@ bool AIGateway::moveHeroToTile(int3 dst, HeroPtr h)
 	{
 		//FIXME: this assertion fails also if AI moves onto defeated guarded object
 		//assert(cb->getVisitableObjs(dst).size() > 1); //there's no point in revisiting tile where there is no visitable object
-		cb->moveHero(*h, h->convertFromVisitablePos(dst));
+		cb->moveHero(*h, h->convertFromVisitablePos(dst), false);
 		afterMovementCheck(); // TODO: is it feasible to hero get killed there if game work properly?
 		// If revisiting, teleport probing is never done, and so the entries into the list would remain unused and uncleared
 		teleportChannelProbingList.clear();
@@ -1278,7 +1278,7 @@ bool AIGateway::moveHeroToTile(int3 dst, HeroPtr h)
 			destinationTeleport = exitId;
 			if(exitPos.valid())
 				destinationTeleportPos = h->convertFromVisitablePos(exitPos);
-			cb->moveHero(*h, h->pos);
+			cb->moveHero(*h, h->pos, false);
 			destinationTeleport = ObjectInstanceID();
 			destinationTeleportPos = int3(-1);
 			afterMovementCheck();

--- a/AI/VCAI/VCAI.cpp
+++ b/AI/VCAI/VCAI.cpp
@@ -1837,7 +1837,7 @@ bool VCAI::moveHeroToTile(int3 dst, HeroPtr h)
 	{
 		//FIXME: this assertion fails also if AI moves onto defeated guarded object
 		assert(cb->getVisitableObjs(dst).size() > 1); //there's no point in revisiting tile where there is no visitable object
-		cb->moveHero(*h, h->convertFromVisitablePos(dst));
+		cb->moveHero(*h, h->convertFromVisitablePos(dst), false);
 		afterMovementCheck(); // TODO: is it feasible to hero get killed there if game work properly?
 		// If revisiting, teleport probing is never done, and so the entries into the list would remain unused and uncleared
 		teleportChannelProbingList.clear();
@@ -1899,7 +1899,7 @@ bool VCAI::moveHeroToTile(int3 dst, HeroPtr h)
 			destinationTeleport = exitId;
 			if(exitPos.valid())
 				destinationTeleportPos = h->convertFromVisitablePos(exitPos);
-			cb->moveHero(*h, h->pos);
+			cb->moveHero(*h, h->pos, false);
 			destinationTeleport = ObjectInstanceID();
 			destinationTeleportPos = int3(-1);
 			afterMovementCheck();

--- a/CCallback.cpp
+++ b/CCallback.cpp
@@ -34,11 +34,16 @@ bool CCallback::teleportHero(const CGHeroInstance *who, const CGTownInstance *wh
 	return true;
 }
 
-bool CCallback::moveHero(const CGHeroInstance *h, int3 dst, bool transit)
+void CCallback::moveHero(const CGHeroInstance *h, const int3 & destination, bool transit)
 {
-	MoveHero pack(dst,h->id,transit);
+	MoveHero pack({destination}, h->id, transit);
 	sendRequest(&pack);
-	return true;
+}
+
+void CCallback::moveHero(const CGHeroInstance *h, const std::vector<int3> & path, bool transit)
+{
+	MoveHero pack(path, h->id, transit);
+	sendRequest(&pack);
 }
 
 int CCallback::selectionMade(int selection, QueryID queryID)

--- a/CCallback.h
+++ b/CCallback.h
@@ -67,7 +67,8 @@ class IGameActionCallback
 {
 public:
 	//hero
-	virtual bool moveHero(const CGHeroInstance *h, int3 dst, bool transit) =0; //dst must be free, neighbouring tile (this function can move hero only by one tile)
+	virtual void moveHero(const CGHeroInstance *h, const std::vector<int3> & path, bool transit) =0; //moves hero alongside provided path
+	virtual void moveHero(const CGHeroInstance *h, const int3 & destination, bool transit) =0; //moves hero alongside provided path
 	virtual bool dismissHero(const CGHeroInstance * hero)=0; //dismisses given hero; true - successfuly, false - not successfuly
 	virtual void dig(const CGObjectInstance *hero)=0;
 	virtual void castSpell(const CGHeroInstance *hero, SpellID spellID, const int3 &pos = int3(-1, -1, -1))=0; //cast adventure map spell
@@ -159,7 +160,8 @@ public:
 	void unregisterBattleInterface(std::shared_ptr<IBattleEventsReceiver> battleEvents);
 
 //commands
-	bool moveHero(const CGHeroInstance *h, int3 dst, bool transit = false) override; //dst must be free, neighbouring tile (this function can move hero only by one tile)
+	void moveHero(const CGHeroInstance *h, const std::vector<int3> & path, bool transit) override;
+	void moveHero(const CGHeroInstance *h, const int3 & destination, bool transit) override;
 	bool teleportHero(const CGHeroInstance *who, const CGTownInstance *where);
 	int selectionMade(int selection, QueryID queryID) override;
 	int sendQueryReply(std::optional<int32_t> reply, QueryID queryID) override;

--- a/client/Client.cpp
+++ b/client/Client.cpp
@@ -518,15 +518,15 @@ void CClient::handlePack(CPack * pack)
 	if(apply)
 	{
 		apply->applyOnClBefore(this, pack);
-		logNetwork->trace("\tMade first apply on cl: %s", typeid(pack).name());
+		logNetwork->trace("\tMade first apply on cl: %s", typeid(*pack).name());
 		gs->apply(pack);
-		logNetwork->trace("\tApplied on gs: %s", typeid(pack).name());
+		logNetwork->trace("\tApplied on gs: %s", typeid(*pack).name());
 		apply->applyOnClAfter(this, pack);
-		logNetwork->trace("\tMade second apply on cl: %s", typeid(pack).name());
+		logNetwork->trace("\tMade second apply on cl: %s", typeid(*pack).name());
 	}
 	else
 	{
-		logNetwork->error("Message %s cannot be applied, cannot find applier!", typeid(pack).name());
+		logNetwork->error("Message %s cannot be applied, cannot find applier!", typeid(*pack).name());
 	}
 	delete pack;
 }

--- a/client/HeroMovementController.h
+++ b/client/HeroMovementController.h
@@ -42,10 +42,9 @@ class HeroMovementController
 
 	void updatePath(const CGHeroInstance * hero, const TryMoveHero & details);
 
-	/// Moves hero 1 tile / path node
-	void moveOnce(const CGHeroInstance * h, const CGPath & path);
-
-	void moveInstant(const CGHeroInstance * h, const CGPath & path);
+	/// Sends one request to server to move selected hero alongside path.
+	/// Automatically selects between single-tile and multi-tile movement modes
+	void sendMovementRequest(const CGHeroInstance * h, const CGPath & path);
 
 	void endMove(const CGHeroInstance * h);
 

--- a/client/HeroMovementController.h
+++ b/client/HeroMovementController.h
@@ -45,6 +45,8 @@ class HeroMovementController
 	/// Moves hero 1 tile / path node
 	void moveOnce(const CGHeroInstance * h, const CGPath & path);
 
+	void moveInstant(const CGHeroInstance * h, const CGPath & path);
+
 	void endMove(const CGHeroInstance * h);
 
 	AudioPath getMovementSoundFor(const CGHeroInstance * hero, int3 posPrev, int3 posNext, EPathNodeAction moveType);

--- a/client/adventureMap/AdventureMapShortcuts.cpp
+++ b/client/adventureMap/AdventureMapShortcuts.cpp
@@ -314,7 +314,7 @@ void AdventureMapShortcuts::visitObject()
 	const CGHeroInstance *h = LOCPLINT->localState->getCurrentHero();
 
 	if(h)
-		LOCPLINT->cb->moveHero(h, h->pos);
+		LOCPLINT->cb->moveHero(h, h->pos, false);
 }
 
 void AdventureMapShortcuts::openObject()

--- a/client/widgets/Images.cpp
+++ b/client/widgets/Images.cpp
@@ -19,6 +19,7 @@
 #include "../render/CAnimation.h"
 #include "../render/Canvas.h"
 #include "../render/ColorFilter.h"
+#include "../render/Graphics.h"
 
 #include "../battle/BattleInterface.h"
 #include "../battle/BattleInterfaceClasses.h"
@@ -177,7 +178,7 @@ CAnimImage::CAnimImage(const AnimationPath & name, size_t Frame, size_t Group, i
 {
 	pos.x += x;
 	pos.y += y;
-	anim = GH.renderHandler().loadAnimation(name);
+	anim = graphics->getAnimation(name);
 	init();
 }
 

--- a/lib/networkPacks/PacksForServer.h
+++ b/lib/networkPacks/PacksForServer.h
@@ -59,22 +59,23 @@ struct DLL_LINKAGE DismissHero : public CPackForServer
 struct DLL_LINKAGE MoveHero : public CPackForServer
 {
 	MoveHero() = default;
-	MoveHero(const int3 & Dest, const ObjectInstanceID & HID, bool Transit)
-		: dest(Dest)
+	MoveHero(const std::vector<int3> & path, const ObjectInstanceID & HID, bool Transit)
+		: path(path)
 		, hid(HID)
 		, transit(Transit)
 	{
 	}
-	int3 dest;
+	std::vector<int3> path;
 	ObjectInstanceID hid;
 	bool transit = false;
 
 	void visitTyped(ICPackVisitor & visitor) override;
 
-	template <typename Handler> void serialize(Handler & h)
+	template<typename Handler>
+	void serialize(Handler & h)
 	{
 		h & static_cast<CPackForServer &>(*this);
-		h & dest;
+		h & path;
 		h & hid;
 		h & transit;
 	}

--- a/server/NetPacksServer.cpp
+++ b/server/NetPacksServer.cpp
@@ -59,7 +59,17 @@ void ApplyGhNetPackVisitor::visitDismissHero(DismissHero & pack)
 void ApplyGhNetPackVisitor::visitMoveHero(MoveHero & pack)
 {
 	gh.throwIfWrongOwner(&pack, pack.hid);
-	result = gh.moveHero(pack.hid, pack.dest, 0, pack.transit, pack.player);
+
+	for (auto const & dest : pack.path)
+	{
+		if (!gh.moveHero(pack.hid, dest, 0, pack.transit, pack.player))
+		{
+			result = false;
+			return;
+		}
+	}
+
+	result = true;
 }
 
 void ApplyGhNetPackVisitor::visitCastleTeleportHero(CastleTeleportHero & pack)


### PR DESCRIPTION
If player uses 'instant' movement speed, game will now send multiple movement requests at once, instead of waiting for server to confirm each of them.
This should help with multiplayer, where server confirmation delay is extremely noticeable due to ping.

As a side effect, it is no longer possible to stop movement with instant speed. 

There is still small delay between each move - around 20 ms in debug build, seems to be caused by UI updates. Might investigate it later, but should not be a problem in release builds

- Should alleviate #1133