### PR TITLE
Fix creature min damage greater than max will cause game crash. #3780

### DIFF
--- a/lib/battle/DamageCalculator.cpp
+++ b/lib/battle/DamageCalculator.cpp
@@ -33,9 +33,8 @@ DamageRange DamageCalculator::getBaseDamageSingle() const
 
     if(minDmg > maxDmg)
     {
-        auto creature = VLC->creatures()->getById(info.attacker->creatureId());
-        const auto & creatureName = creature->getNamePluralTranslated();
-        logGlobal->error("Creature %s min damage %lld exceed max damage %lld.", creatureName.c_str(), minDmg, maxDmg);
+		const auto & creatureName = info.attacker->creatureId().toEntity(VLC)->getNamePluralTranslated();
+		logGlobal->error("Creature %s min damage %lld exceed max damage %lld.", creatureName, minDmg, maxDmg);
         logGlobal->error("This problem may lead to unexpected result, please report it to modder.");
         // to avoid RNG crash. and make bless and curse spell correct
         std::swap(minDmg, maxDmg);

--- a/lib/battle/DamageCalculator.cpp
+++ b/lib/battle/DamageCalculator.cpp
@@ -18,6 +18,8 @@
 #include "../mapObjects/CGTownInstance.h"
 #include "../spells/CSpellHandler.h"
 #include "../GameSettings.h"
+#include "../VCMI_Lib.h"
+
 
 VCMI_LIB_NAMESPACE_BEGIN
 
@@ -28,6 +30,16 @@ DamageRange DamageCalculator::getBaseDamageSingle() const
 
 	minDmg = info.attacker->getMinDamage(info.shooting);
 	maxDmg = info.attacker->getMaxDamage(info.shooting);
+
+    if(minDmg > maxDmg)
+    {
+        auto creature = VLC->creatures()->getById(info.attacker->creatureId());
+        const auto & creatureName = creature->getNamePluralTranslated();
+        logGlobal->error("Creature %s min damage %lld exceed max damage %lld.", creatureName.c_str(), minDmg, maxDmg);
+        logGlobal->error("This problem may lead to unexpected result, please report it to modder.");
+        // to avoid RNG crash. and make bless and curse spell correct
+        std::swap(minDmg, maxDmg);
+    }
 
 	if(info.attacker->creatureIndex() == CreatureID::ARROW_TOWERS)
 	{

--- a/lib/battle/DamageCalculator.cpp
+++ b/lib/battle/DamageCalculator.cpp
@@ -33,10 +33,10 @@ DamageRange DamageCalculator::getBaseDamageSingle() const
 
     if(minDmg > maxDmg)
     {
-		const auto & creatureName = info.attacker->creatureId().toEntity(VLC)->getNamePluralTranslated();
-		logGlobal->error("Creature %s min damage %lld exceed max damage %lld.", creatureName, minDmg, maxDmg);
-        logGlobal->error("This problem may lead to unexpected result, please report it to modder.");
-        // to avoid RNG crash. and make bless and curse spell correct
+	const auto & creatureName = info.attacker->creatureId().toEntity(VLC)->getNamePluralTranslated();
+	logGlobal->error("Creature %s: min damage %lld exceeds max damage %lld.", creatureName, minDmg, maxDmg);
+        logGlobal->error("This may lead to unexpected results, please report it to the mod's creator.");
+        // to avoid an RNG crash and make bless and curse spells work as expected
         std::swap(minDmg, maxDmg);
     }
 


### PR DESCRIPTION
in 1.5.0, RNG will throw a exception when min value greater than max value. My friend encounter this problem when he play 3 mouths. The game crashed in AI turn and he doesnt know which mod cause it. And    finally ask me to fixed. 

I spend a whole night to locate this problem, asI mentioned in #3780.  I told him that refugee-town mod modify the enchanter's stack bounse and lead to this problem, And help him to make the data right, but he is still worried about if there is another mod will cause it again.

So I do a fix problem. And I found that when min damage is less than max damage, both increasing 1 mini damage and 1 max damage can increase the average damage by 0.5. when min damage greater than max damage，if I exchange min damage and max damage，this formula is still established.

Athouth the display damage will be 19 -18, it read as 19 to 18, most people will treat it as 18 ~ 19.

bless and curse are also considered in this commit.

I also display the creature name to error log,  user can report it to modder. 

Now the game can be continued finally.