### PR TITLE
Mod install / enabling tweaks

### DIFF
--- a/launcher/modManager/cmodlist.cpp
+++ b/launcher/modManager/cmodlist.cpp
@@ -94,13 +94,13 @@ bool CModEntry::isInstalled() const
 
 bool CModEntry::isVisible() const
 {
-	if (getBaseValue("modType").toString() == "Compatibility")
+	if (isCompatibilityPatch())
 	{
 		if (isSubmod())
 			return false;
 	}
 
-	if (getBaseValue("modType").toString() == "Translation")
+	if (isTranslation())
 	{
 		// Do not show not installed translation mods to languages other than player language
 		if (localData.empty() && getBaseValue("language") != QString::fromStdString(settings["general"]["language"].String()) )
@@ -113,6 +113,11 @@ bool CModEntry::isVisible() const
 bool CModEntry::isTranslation() const
 {
 	return getBaseValue("modType").toString() == "Translation";
+}
+
+bool CModEntry::isCompatibilityPatch() const
+{
+	return getBaseValue("modType").toString() == "Compatibility";
 }
 
 bool CModEntry::isSubmod() const

--- a/launcher/modManager/cmodlist.h
+++ b/launcher/modManager/cmodlist.h
@@ -54,8 +54,10 @@ public:
 	bool isCompatible() const;
 	// returns true if mod should be visible in Launcher
 	bool isVisible() const;
-	// installed and enabled
+	// returns true if mod type is Translation
 	bool isTranslation() const;
+	// returns true if mod type is Compatibility
+	bool isCompatibilityPatch() const;
 	// returns true if this is a submod
 	bool isSubmod() const;
 

--- a/launcher/modManager/cmodlistview_moc.cpp
+++ b/launcher/modManager/cmodlistview_moc.cpp
@@ -483,10 +483,10 @@ void CModListView::on_comboBox_currentIndexChanged(int index)
 QStringList CModListView::findInvalidDependencies(QString mod)
 {
 	QStringList ret;
-	for(QString requrement : modModel->getRequirements(mod))
+	for(QString requirement : modModel->getRequirements(mod))
 	{
-		if(!modModel->hasMod(requrement))
-			ret += requrement;
+		if(!modModel->hasMod(requirement) && !modModel->hasMod(requirement.split(QChar('.'), Qt::SkipEmptyParts)[0]))
+			ret += requirement;
 	}
 	return ret;
 }
@@ -614,6 +614,20 @@ void CModListView::on_installButton_clicked()
 		auto mod = modModel->getMod(name);
 		if(!mod.isInstalled())
 			downloadFile(name + ".zip", mod.getValue("download").toString(), "mods", mbToBytes(mod.getValue("downloadSize").toDouble()));
+		else if(!mod.isEnabled())
+			enableModByName(name);
+	}
+
+	for(auto & name : modModel->getMod(modName).getConflicts())
+	{
+		auto mod = modModel->getMod(name);
+		if(mod.isEnabled())
+		{
+			//TODO: consider reverse dependencies disabling
+			//TODO: consider if it may be possible for subdependencies to block disabling conflicting mod?
+			//TODO: consider if it may be possible to get subconflicts that will block disabling conflicting mod?
+			disableModByName(name);
+		}
 	}
 }
 

--- a/launcher/modManager/cmodlistview_moc.cpp
+++ b/launcher/modManager/cmodlistview_moc.cpp
@@ -485,7 +485,7 @@ QStringList CModListView::findInvalidDependencies(QString mod)
 	QStringList ret;
 	for(QString requirement : modModel->getRequirements(mod))
 	{
-		if(!modModel->hasMod(requirement) && !modModel->hasMod(requirement.split(QChar('.'), Qt::SkipEmptyParts)[0]))
+		if(!modModel->hasMod(requirement) && !modModel->hasMod(requirement.split(QChar('.'))[0]))
 			ret += requirement;
 	}
 	return ret;

--- a/launcher/modManager/cmodmanager.cpp
+++ b/launcher/modManager/cmodmanager.cpp
@@ -195,7 +195,10 @@ bool CModManager::canEnableMod(QString modname)
 	{
 		if(!modList->hasMod(modEntry)) // required mod is not available
 			return addError(modname, QString("Required mod %1 is missing").arg(modEntry));
-		if(!modList->getMod(modEntry).isEnabled())
+
+		CModEntry modData = modList->getMod(modEntry);
+
+		if(!modData.isCompatibilityPatch() && !modData.isEnabled())
 			return addError(modname, QString("Required mod %1 is not enabled").arg(modEntry));
 	}
 


### PR DESCRIPTION
Still not very good, but better than what it was. Now mod can be installable if it has non-installed submod dependency, compatibility patches won't block enabling. This does not solve all cases and more complex logic that works recursively will be needed when enabling/installing particular mod to handle its conflicts being requirements for other submods, and those may have their own requirements etc.