### PR TITLE
NKAI: fix patrolling heroes never retreat and town danger evaluation

### DIFF
--- a/AI/Nullkiller/AIGateway.cpp
+++ b/AI/Nullkiller/AIGateway.cpp
@@ -544,6 +544,11 @@ std::optional<BattleAction> AIGateway::makeSurrenderRetreatDecision(const Battle
 	LOG_TRACE(logAi);
 	NET_EVENT_HANDLER;
 
+	if(battleState.ourHero && battleState.ourHero->patrol.patrolling)
+	{
+		return std::nullopt;
+	}
+
 	double ourStrength = battleState.getOurStrength();
 	double fightRatio = ourStrength / (double)battleState.getEnemyStrength();
 

--- a/AI/Nullkiller/Analyzers/HeroManager.cpp
+++ b/AI/Nullkiller/Analyzers/HeroManager.cpp
@@ -130,7 +130,14 @@ void HeroManager::update()
 
 	for(auto hero : myHeroes)
 	{
-		heroRoles[hero] = (globalMainCount--) > 0 ? HeroRole::MAIN : HeroRole::SCOUT;
+		if(hero->patrol.patrolling)
+		{
+			heroRoles[hero] = HeroRole::MAIN;
+		}
+		else
+		{
+			heroRoles[hero] = (globalMainCount--) > 0 ? HeroRole::MAIN : HeroRole::SCOUT;
+		}
 	}
 
 	for(auto hero : myHeroes)

--- a/AI/Nullkiller/Engine/FuzzyHelper.cpp
+++ b/AI/Nullkiller/Engine/FuzzyHelper.cpp
@@ -53,15 +53,26 @@ ui64 FuzzyHelper::evaluateDanger(const int3 & tile, const CGHeroInstance * visit
 	// in some scenarios hero happens to be "under" the object (eg town). Then we consider ONLY the hero.
 	if(vstd::contains_if(visitableObjects, objWithID<Obj::HERO>))
 	{
-		vstd::erase_if(visitableObjects, [](const CGObjectInstance * obj)
+		vstd::erase_if(visitableObjects, [](const CGObjectInstance * obj) -> bool
 		{
-			return !objWithID<Obj::HERO>(obj);
+				return !objWithID<Obj::HERO>(obj);
 		});
 	}
 
 	if(const CGObjectInstance * dangerousObject = vstd::backOrNull(visitableObjects))
 	{
 		objectDanger = evaluateDanger(dangerousObject); //unguarded objects can also be dangerous or unhandled
+
+		if(objWithID<Obj::HERO>(dangerousObject))
+		{
+			auto hero = dynamic_cast<const CGHeroInstance *>(dangerousObject);
+
+			if(hero->visitedTown && !hero->visitedTown->garrisonHero)
+			{
+				objectDanger += evaluateDanger(hero->visitedTown.get());
+			}
+		}
+
 		if(objectDanger)
 		{
 			//TODO: don't downcast objects AI shouldn't know about!


### PR DESCRIPTION
Patrolling heroes should never retreat
Visiting town is also considered when evaluating hero strength