### PR TITLE
Fix thrown exception on random monster initialization

### DIFF
--- a/lib/mapObjects/CGCreature.cpp
+++ b/lib/mapObjects/CGCreature.cpp
@@ -221,7 +221,7 @@ void CGCreature::pickRandomObject(CRandomGenerator & rand)
 
 	try {
 		// sanity check
-		VLC->objtypeh->getHandlerFor(ID, subID);
+		VLC->objtypeh->getHandlerFor(MapObjectID::MONSTER, subID);
 	}
 	catch (const std::out_of_range & )
 	{


### PR DESCRIPTION
Fixes regression from #3820 leading to crash on starting maps with random monsters