### PR TITLE
Fix crash on visiting misconfigured rewardable object

### DIFF
--- a/client/adventureMap/CInfoBar.cpp
+++ b/client/adventureMap/CInfoBar.cpp
@@ -386,6 +386,7 @@ void CInfoBar::pushComponents(const std::vector<Component> & components, std::st
 					reward_map.at(0).first.push_back(c);
 					reward_map.at(0).second = 8; //At most 8, cannot be more
 					break;
+				case ComponentType::NONE:
 				case ComponentType::SEC_SKILL:
 					reward_map.at(1).first.push_back(c);
 					reward_map.at(1).second = 4; //At most 4

--- a/client/widgets/CComponent.cpp
+++ b/client/widgets/CComponent.cpp
@@ -133,6 +133,7 @@ std::vector<AnimationPath> CComponent::getFileName() const
 		case ComponentType::MANA:
 		case ComponentType::LEVEL:
 			return gen(primSkillsArr);
+		case ComponentType::NONE:
 		case ComponentType::SEC_SKILL:
 			return gen(secSkillsArr);
 		case ComponentType::RESOURCE:
@@ -165,6 +166,8 @@ size_t CComponent::getIndex() const
 {
 	switch(data.type)
 	{
+		case ComponentType::NONE:
+			return 0;
 		case ComponentType::PRIM_SKILL:
 			return data.subType.getNum();
 		case ComponentType::EXPERIENCE:
@@ -216,6 +219,7 @@ std::string CComponent::getDescription() const
 		case ComponentType::RESOURCE:
 		case ComponentType::RESOURCE_PER_DAY:
 			return CGI->generaltexth->allTexts[242];
+		case ComponentType::NONE:
 		case ComponentType::CREATURE:
 			return "";
 		case ComponentType::ARTIFACT:
@@ -288,9 +292,10 @@ std::string CComponent::getSubtitle() const
 		case ComponentType::SPELL_SCROLL:
 		case ComponentType::SPELL:
 			return CGI->spells()->getById(data.subType.as<SpellID>())->getNameTranslated();
+		case ComponentType::NONE:
 		case ComponentType::MORALE:
-			return "";
 		case ComponentType::LUCK:
+		case ComponentType::HERO_PORTRAIT:
 			return "";
 		case ComponentType::BUILDING:
 			{
@@ -303,8 +308,6 @@ std::string CComponent::getSubtitle() const
 				}
 				return building->getNameTranslated();
 			}
-		case ComponentType::HERO_PORTRAIT:
-			return "";
 		case ComponentType::FLAG:
 			return CGI->generaltexth->capColors[data.subType.as<PlayerColor>().getNum()];
 		default:

--- a/lib/rewardable/Reward.cpp
+++ b/lib/rewardable/Reward.cpp
@@ -63,8 +63,15 @@ Component Rewardable::Reward::getDisplayedComponent(const CGHeroInstance * h) co
 {
 	std::vector<Component> comps;
 	loadComponents(comps, h);
-	assert(!comps.empty());
-	return comps.front();
+
+	if (!comps.empty())
+		return comps.front();
+
+	// Rewardable requested component that represent such rewards, to be used as button in UI selection dialog, e.g. Chest with its experience / money pick
+	// However reward is either completely empty OR has no rewards that target hero can receive OR these rewards have no visible component (e.g. movement)
+	// Such cases are unreachable in H3, however can be reached by mods
+	logMod->warn("Failed to find displayed component for reward!");
+	return Component(ComponentType::NONE, 0);
 }
 
 void Rewardable::Reward::loadComponents(std::vector<Component> & comps, const CGHeroInstance * h) const


### PR DESCRIPTION
Fixes crash that happens with "Worn-out spellbook" object from Antagarich Burning.
Crash happens if 
1) Object offers multiple rewards to pick from, similar to treasure chest
2) One of offered rewards does not have any visual component to represent it. 

In this particular case, there is a reward that normally has suitable preview icon (spell), but if hero already knows said spell, he can no longer acquire it. And since spell is the only reward, there are no other suitable component to represent such reward.

Now vcmi will present empty image in case of such scenario + warning in console instead of silent crash