### PR TITLE
Fix CI on beta and master branches

### DIFF
--- a/.github/workflows/github.yml
+++ b/.github/workflows/github.yml
@@ -148,7 +148,7 @@ jobs:
 
     - name: ccache for everything but PRs
       uses: hendrikmuhs/ccache-action@v1.2
-      if: ${{ (github.repository == 'vcmi/vcmi' && github.event.number == '' && github.ref == 'refs/heads/develop') ||  github.repository != 'vcmi/vcmi' }}
+      if: ${{ (github.repository == 'vcmi/vcmi' && github.event.number == '' && (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/beta' || github.ref == 'refs/heads/master')) ||  github.repository != 'vcmi/vcmi' }}
       with:
         key: ${{ matrix.preset }}-no-PR
         restore-keys: |


### PR DESCRIPTION
Looks like on these branches CI runs, but since there is no ccache setup stage CI fails, e.g. this:
https://github.com/vcmi/vcmi/actions/runs/8851178049/job/24307152828

Not 100% sure if this is correct fix, so will test by merging