### PR TITLE
Fixes issue of bonuses not correctly removed

### DIFF
--- a/lib/bonuses/Bonus.cpp
+++ b/lib/bonuses/Bonus.cpp
@@ -147,6 +147,9 @@ std::string Bonus::Description(std::optional<si32> customValue) const
 			descriptionHelper.replaceRawString(std::to_string(valueToShow));
 		else
 			descriptionHelper.replaceRawString("-" + std::to_string(valueToShow));
+
+		if(type == BonusType::CREATURE_GROWTH_PERCENT)
+			descriptionHelper.appendRawString(" +" + std::to_string(valueToShow));
 	}
 
 	return descriptionHelper.toString();

--- a/lib/bonuses/CBonusSystemNode.cpp
+++ b/lib/bonuses/CBonusSystemNode.cpp
@@ -417,9 +417,9 @@ void CBonusSystemNode::unpropagateBonus(const std::shared_ptr<Bonus> & b)
 		if (bonuses -= b)
 			logBonus->trace("#$# %s #is no longer propagated to# %s",  b->Description(), nodeName());
 		else
-			logBonus->error("Error on unpropagateBonus. #$# %s is not propagated to %s", b->Description(), nodeName());
+			logBonus->warn("Attempt to remove #$# %s, which is not propagated to %s", b->Description(), nodeName());
 
-		bonuses.remove_if([this, b](const auto & bonus)
+		bonuses.remove_if([b](const auto & bonus)
 		{
 			if (bonus->propagationUpdater && bonus->propagationUpdater == b->propagationUpdater)
 			{

--- a/lib/bonuses/CBonusSystemNode.cpp
+++ b/lib/bonuses/CBonusSystemNode.cpp
@@ -414,8 +414,20 @@ void CBonusSystemNode::unpropagateBonus(const std::shared_ptr<Bonus> & b)
 {
 	if(b->propagator->shouldBeAttached(this))
 	{
-		bonuses -= b;
-		logBonus->trace("#$# %s #is no longer propagated to# %s",  b->Description(), nodeName());
+		if (bonuses -= b)
+			logBonus->trace("#$# %s #is no longer propagated to# %s",  b->Description(), nodeName());
+		else
+			logBonus->error("Error on unpropagateBonus. #$# %s is not propagated to %s", b->Description(), nodeName());
+
+		bonuses.remove_if([this, b](const auto & bonus)
+		{
+			if (bonus->propagationUpdater && bonus->propagationUpdater == b->propagationUpdater)
+			{
+				treeHasChanged();
+				return true;
+			}
+			return false;
+		});
 	}
 
 	TNodes lchildren;

--- a/lib/mapObjects/CGTownInstance.cpp
+++ b/lib/mapObjects/CGTownInstance.cpp
@@ -156,7 +156,10 @@ GrowthInfo CGTownInstance::getGrowthInfo(int level) const
 	for(const auto & b : *bonuses2)
 	{
 		const auto growth = b->val * (base + castleBonus) / 100;
-		ret.entries.emplace_back(growth, b->Description(growth));
+		if (growth)
+		{
+			ret.entries.emplace_back(growth, b->Description(growth));
+		}
 	}
 
 	//other *-of-legion-like bonuses (%d to growth cumulative with grail)


### PR DESCRIPTION
For some reason bonuses once added by propagatorUpdater are not identical to the bonuses we try to remove on unpropagate call.

Might need further investigation on why that happened in first place.