### PR TITLE
#3824 - fix cluster unlock

### DIFF
--- a/AI/Nullkiller/Behaviors/ClusterBehavior.cpp
+++ b/AI/Nullkiller/Behaviors/ClusterBehavior.cpp
@@ -100,7 +100,7 @@ Goals::TGoalVec ClusterBehavior::decomposeCluster(const Nullkiller * ai, std::sh
 	logAi->trace("Decompose unlock paths");
 #endif
 
-	auto unlockTasks = CaptureObjectsBehavior::getVisitGoals(blockerPaths, ai);
+	auto unlockTasks = CaptureObjectsBehavior::getVisitGoals(blockerPaths, ai, cluster->blocker);
 
 	for(int i = 0; i < paths.size(); i++)
 	{

--- a/AI/Nullkiller/Engine/Nullkiller.cpp
+++ b/AI/Nullkiller/Engine/Nullkiller.cpp
@@ -375,12 +375,14 @@ void Nullkiller::makeTurn()
 			if(cb->getPlayerStatus(playerID) != EPlayerStatus::INGAME)
 				return;
 
-			std::string taskDescription = bestTask->toString();
-			HeroPtr hero = bestTask->getHero();
-			HeroRole heroRole = HeroRole::MAIN;
+			if(!areAffectedObjectsPresent(bestTask))
+			{
+				logAi->debug("Affected object not found. Canceling task.");
+				continue;
+			}
 
-			if(hero.validAndSet())
-				heroRole = heroManager->getHeroRole(hero);
+			std::string taskDescription = bestTask->toString();
+			HeroRole heroRole = getTaskRole(bestTask);
 
 			if(heroRole != HeroRole::MAIN || bestTask->getHeroExchangeCount() <= 1)
 				useHeroChain = false;
@@ -446,6 +448,30 @@ void Nullkiller::makeTurn()
 			logAi->warn("Maxpass exceeded. Terminating AI turn.");
 		}
 	}
+}
+
+bool Nullkiller::areAffectedObjectsPresent(Goals::TTask task) const
+{
+	auto affectedObjs = task->getAffectedObjects();
+
+	for(auto oid : affectedObjs)
+	{
+		if(!cb->getObj(oid, false))
+			return false;
+	}
+
+	return true;
+}
+
+HeroRole Nullkiller::getTaskRole(Goals::TTask task) const
+{
+	HeroPtr hero = task->getHero();
+	HeroRole heroRole = HeroRole::MAIN;
+
+	if(hero.validAndSet())
+		heroRole = heroManager->getHeroRole(hero);
+
+	return heroRole;
 }
 
 bool Nullkiller::executeTask(Goals::TTask task)

--- a/AI/Nullkiller/Engine/Nullkiller.h
+++ b/AI/Nullkiller/Engine/Nullkiller.h
@@ -124,6 +124,8 @@ private:
 	Goals::TTask choseBestTask(Goals::TGoalVec & tasks) const;
 	Goals::TTaskVec buildPlan(Goals::TGoalVec & tasks) const;
 	bool executeTask(Goals::TTask task);
+	bool areAffectedObjectsPresent(Goals::TTask task) const;
+	HeroRole getTaskRole(Goals::TTask task) const;
 };
 
 }

--- a/AI/Nullkiller/Markers/UnlockCluster.h
+++ b/AI/Nullkiller/Markers/UnlockCluster.h
@@ -34,6 +34,7 @@ namespace Goals
 		{
 			tile = cluster->blocker->visitablePos();
 			hero = pathToCenter.targetHero;
+			objid = cluster->blocker->id;
 		}
 
 		bool operator==(const UnlockCluster & other) const override;


### PR DESCRIPTION
Main issue was in attempt to simultaneously kill same guard by two different heroes. Also added generic protection against such cases.