### PR TITLE
#3842 - fix negative link cost because of bonuses

### DIFF
--- a/AI/Nullkiller/Pathfinding/ObjectGraph.cpp
+++ b/AI/Nullkiller/Pathfinding/ObjectGraph.cpp
@@ -504,11 +504,11 @@ void ObjectGraph::connectHeroes(const Nullkiller * ai)
 			auto heroPos = path.targetHero->visitablePos();
 
 			nodes[pos].connections[heroPos].update(
-				path.movementCost(),
+				std::max(0.0f, path.movementCost()),
 				path.getPathDanger());
 
 			nodes[heroPos].connections[pos].update(
-				path.movementCost(),
+				std::max(0.0f, path.movementCost()),
 				path.getPathDanger());
 		}
 	}


### PR DESCRIPTION
Sometimes movement cost on sea can be negative due to a lot of bonuses. At least let graph not hang in endless loop.