### PR TITLE
Fix freezes (multiplayer and game loading)

### DIFF
--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -279,7 +279,14 @@ void CPlayerInterface::yourTurn(QueryID queryID)
 	CTutorialWindow::openWindowFirstTime(TutorialMode::TOUCH_ADVENTUREMAP);
 
 	EVENT_HANDLER_CALLED_BY_CLIENT;
-	{
+
+	int humanPlayersCount = 0;
+	for(const auto & info : cb->getStartInfo()->playerInfos)
+		if (info.second.isControlledByHuman())
+			humanPlayersCount++;
+
+	bool hotseatWait = humanPlayersCount > 1;
+
 		LOCPLINT = this;
 		GH.curInt = this;
 
@@ -289,12 +296,7 @@ void CPlayerInterface::yourTurn(QueryID queryID)
 			performAutosave();
 		}
 
-		int humanPlayersCount = 0;
-		for(const auto & info : cb->getStartInfo()->playerInfos)
-			if (info.second.isControlledByHuman())
-				humanPlayersCount++;
-
-		if (humanPlayersCount > 1) //hot seat or MP message
+		if (hotseatWait) //hot seat or MP message
 		{
 			adventureInt->onHotseatWaitStarted(playerID);
 
@@ -310,11 +312,11 @@ void CPlayerInterface::yourTurn(QueryID queryID)
 			makingTurn = true;
 			adventureInt->onPlayerTurnStarted(playerID);
 		}
-	}
-	acceptTurn(queryID);
+
+	acceptTurn(queryID, hotseatWait);
 }
 
-void CPlayerInterface::acceptTurn(QueryID queryID)
+void CPlayerInterface::acceptTurn(QueryID queryID, bool hotseatWait)
 {
 	if (settings["session"]["autoSkip"].Bool())
 	{
@@ -322,7 +324,7 @@ void CPlayerInterface::acceptTurn(QueryID queryID)
 			iw->close();
 	}
 
-	if(CSH->howManyPlayerInterfaces() > 1)
+	if(hotseatWait)
 	{
 		waitWhileDialog(); // wait for player to accept turn in hot-seat mode
 

--- a/client/CPlayerInterface.h
+++ b/client/CPlayerInterface.h
@@ -226,7 +226,7 @@ private:
 	void heroKilled(const CGHeroInstance* hero);
 	void garrisonsChanged(std::vector<const CArmedInstance *> objs);
 	void requestReturningToMainMenu(bool won);
-	void acceptTurn(QueryID queryID); //used during hot seat after your turn message is close
+	void acceptTurn(QueryID queryID, bool hotseatWait); //used during hot seat after your turn message is close
 	void initializeHeroTownList();
 	int getLastIndex(std::string namePrefix);
 };


### PR DESCRIPTION
- Fix app freeze on attempt to exit game during loading. Reported on Google Play, where it is rather common for some reason.
- Fix locked UI on starting multiplayer game