### PR TITLE
Simple implementation of heartbeat package

### DIFF
--- a/lib/network/NetworkConnection.cpp
+++ b/lib/network/NetworkConnection.cpp
@@ -12,12 +12,12 @@
 
 VCMI_LIB_NAMESPACE_BEGIN
 
-NetworkConnection::NetworkConnection(INetworkConnectionListener & listener, const std::shared_ptr<NetworkSocket> & socket)
+NetworkConnection::NetworkConnection(INetworkConnectionListener & listener, const std::shared_ptr<NetworkSocket> & socket, const std::shared_ptr<NetworkContext> & context)
 	: socket(socket)
+	, context(context)
 	, listener(listener)
 {
 	socket->set_option(boost::asio::ip::tcp::no_delay(true));
-	socket->set_option(boost::asio::socket_base::keep_alive(true));
 
 	// iOS throws exception on attempt to set buffer size
 	constexpr auto bufferSize = 4 * 1024 * 1024;
@@ -43,10 +43,30 @@ NetworkConnection::NetworkConnection(INetworkConnectionListener & listener, cons
 
 void NetworkConnection::start()
 {
+	heartbeat();
+
 	boost::asio::async_read(*socket,
 							readBuffer,
 							boost::asio::transfer_exactly(messageHeaderSize),
 							[self = shared_from_this()](const auto & ec, const auto & endpoint) { self->onHeaderReceived(ec); });
+}
+
+void NetworkConnection::heartbeat()
+{
+	constexpr auto heartbeatInterval = std::chrono::seconds(10);
+
+	auto timer = std::make_shared<NetworkTimer>(*context, heartbeatInterval);
+	timer->async_wait( [self = shared_from_this(), timer](const auto & ec)
+	{
+		if (ec)
+			return;
+
+		if (!self->socket->is_open())
+			return;
+
+		self->sendPacket({});
+		self->heartbeat();
+	});
 }
 
 void NetworkConnection::onHeaderReceived(const boost::system::error_code & ecHeader)
@@ -71,7 +91,8 @@ void NetworkConnection::onHeaderReceived(const boost::system::error_code & ecHea
 
 	if (messageSize == 0)
 	{
-		listener.onDisconnected(shared_from_this(), "Zero-sized packet!");
+		//heartbeat package with no payload - wait for next packet
+		start();
 		return;
 	}
 

--- a/lib/network/NetworkConnection.h
+++ b/lib/network/NetworkConnection.h
@@ -19,15 +19,17 @@ class NetworkConnection : public INetworkConnection, public std::enable_shared_f
 	static const int messageMaxSize = 64 * 1024 * 1024; // arbitrary size to prevent potential massive allocation if we receive garbage input
 
 	std::shared_ptr<NetworkSocket> socket;
+	std::shared_ptr<NetworkContext> context;
 
 	NetworkBuffer readBuffer;
 	INetworkConnectionListener & listener;
 
+	void heartbeat();
 	void onHeaderReceived(const boost::system::error_code & ec);
 	void onPacketReceived(const boost::system::error_code & ec, uint32_t expectedPacketSize);
 
 public:
-	NetworkConnection(INetworkConnectionListener & listener, const std::shared_ptr<NetworkSocket> & socket);
+	NetworkConnection(INetworkConnectionListener & listener, const std::shared_ptr<NetworkSocket> & socket, const std::shared_ptr<NetworkContext> & context);
 
 	void start();
 	void close() override;

--- a/lib/network/NetworkHandler.cpp
+++ b/lib/network/NetworkHandler.cpp
@@ -34,14 +34,14 @@ void NetworkHandler::connectToRemote(INetworkClientListener & listener, const st
 	auto socket = std::make_shared<NetworkSocket>(*io);
 	boost::asio::ip::tcp::resolver resolver(*io);
 	auto endpoints = resolver.resolve(host, std::to_string(port));
-	boost::asio::async_connect(*socket, endpoints, [socket, &listener](const boost::system::error_code& error, const boost::asio::ip::tcp::endpoint& endpoint)
+	boost::asio::async_connect(*socket, endpoints, [this, socket, &listener](const boost::system::error_code& error, const boost::asio::ip::tcp::endpoint& endpoint)
 	{
 		if (error)
 		{
 			listener.onConnectionFailed(error.message());
 			return;
 		}
-		auto connection = std::make_shared<NetworkConnection>(listener, socket);
+		auto connection = std::make_shared<NetworkConnection>(listener, socket, io);
 		connection->start();
 
 		listener.onConnectionEstablished(connection);

--- a/lib/network/NetworkServer.cpp
+++ b/lib/network/NetworkServer.cpp
@@ -39,7 +39,7 @@ void NetworkServer::connectionAccepted(std::shared_ptr<NetworkSocket> upcomingCo
 	}
 
 	logNetwork->info("We got a new connection! :)");
-	auto connection = std::make_shared<NetworkConnection>(*this, upcomingConnection);
+	auto connection = std::make_shared<NetworkConnection>(*this, upcomingConnection, io);
 	connections.insert(connection);
 	connection->start();
 	listener.onNewConnection(connection);


### PR DESCRIPTION
Not yet sure about this change.

Open sockets will now send empty 'heartbeat' packet to show that connection is alive every 10 seconds. This should fix bug where due to vcmiserver crash lobby will still show crashed room for a rather long period. 

However since in vcmi network thread may wait for long periods (blocking dialogs on client, RMG generation on server) proper heartbeat tracking with timestamps of last received message is not possible - it is completely legal for network to be idle for long periods of time if player has blocking dialog open.

Before this PR, lobby used TCP keepalive signal to discover dead connections. However it is too slow (2+ hours). Version from this PR should work better, since interval between packets is now 10 seconds (and can be changed by us at any point), but it still relies on TCP mechanics - even if network thread on client is waiting for blocking dialog, OS would still notify server that TCP connection is alive and empty heartbeat package has been delivered. And if client actually crashed - then server will close connection by timeout.