### PR TITLE
Change fly spell rules to match SoD possibilities by default

### DIFF
--- a/config/gameConfig.json
+++ b/config/gameConfig.json
@@ -135,7 +135,7 @@
 			"object"     : 256,
 			"terrain"    : 10,
 			"river"      : 5,
-			"road"       : 4,
+			"road"       : 4
 		},
 		
 		"mapFormat" : {
@@ -391,7 +391,7 @@
 			// if enabled and hero has whirlpool protection effect, pathfinder will take use of whirpools
 			"useWhirlpool" : true,
 			// if enabled flying will work like in original game, otherwise nerf similar to HotA flying is applied
-			"originalFlyRules" : false
+			"originalFlyRules" : true
 		},
 
 		"spells":


### PR DESCRIPTION
Previous rules are currently available as part of hota's "game balance" submod.