### PR TITLE
[1.5.0] Bugfixing

### DIFF
--- a/client/HeroMovementController.cpp
+++ b/client/HeroMovementController.cpp
@@ -205,6 +205,9 @@ void HeroMovementController::onTryMoveHero(const CGHeroInstance * hero, const Tr
 
 void HeroMovementController::onQueryReplyApplied()
 {
+	if (!waitingForQueryApplyReply)
+		return;
+
 	waitingForQueryApplyReply = false;
 
 	// Server accepted our TeleportDialog query reply and moved hero

--- a/client/mainmenu/CPrologEpilogVideo.cpp
+++ b/client/mainmenu/CPrologEpilogVideo.cpp
@@ -30,7 +30,7 @@ CPrologEpilogVideo::CPrologEpilogVideo(CampaignScenarioPrologEpilog _spe, std::f
 	updateShadow();
 
 	auto audioData = CCS->videoh->getAudio(spe.prologVideo);
-	videoSoundHandle = CCS->soundh->playSound(audioData);
+	videoSoundHandle = CCS->soundh->playSound(audioData, -1);
 	CCS->videoh->open(spe.prologVideo);
 	CCS->musich->playMusic(spe.prologMusic, true, true);
 	voiceDurationMilliseconds = CCS->soundh->getSoundDurationMilliseconds(spe.prologVoice);

--- a/client/mapView/MapViewController.cpp
+++ b/client/mapView/MapViewController.cpp
@@ -277,6 +277,9 @@ bool MapViewController::isEventInstant(const CGObjectInstance * obj, const Playe
 	if (!isEventVisible(obj, initiator))
 		return true;
 
+	if (!initiator.isValidPlayer())
+		return true; // skip effects such as new monsters on new month
+
 	if(initiator != LOCPLINT->playerID && settings["adventure"]["enemyMoveTime"].Float() <= 0)
 		return true; // instant movement speed
 
@@ -324,7 +327,7 @@ bool MapViewController::isEventVisible(const CGHeroInstance * obj, const int3 & 
 		return false;
 
 	// do not focus on actions of other players except for AI with simturns off
-	if (obj->getOwner() != LOCPLINT->playerID && obj->getOwner().isValidPlayer())
+	if (obj->getOwner() != LOCPLINT->playerID)
 	{
 		if (LOCPLINT->makingTurn)
 			return false;

--- a/client/mapView/MapViewController.cpp
+++ b/client/mapView/MapViewController.cpp
@@ -298,7 +298,7 @@ bool MapViewController::isEventVisible(const CGObjectInstance * obj, const Playe
 		return false;
 
 	// do not focus on actions of other players except for AI with simturns off
-	if (initiator != LOCPLINT->playerID)
+	if (initiator != LOCPLINT->playerID && initiator.isValidPlayer())
 	{
 		if (LOCPLINT->makingTurn)
 			return false;
@@ -324,7 +324,7 @@ bool MapViewController::isEventVisible(const CGHeroInstance * obj, const int3 & 
 		return false;
 
 	// do not focus on actions of other players except for AI with simturns off
-	if (obj->getOwner() != LOCPLINT->playerID)
+	if (obj->getOwner() != LOCPLINT->playerID && obj->getOwner().isValidPlayer())
 	{
 		if (LOCPLINT->makingTurn)
 			return false;

--- a/config/filesystem.json
+++ b/config/filesystem.json
@@ -18,8 +18,8 @@
 		"SPRITES/":
 		[
 			{"type" : "lod", "path" : "Data/H3ab_spr.lod"}, // Contains H3:AB data
-			{"type" : "lod", "path" : "Data/H3sprite.lod"}, // Localized versions only, contains H3:AB patch data
-			{"type" : "lod", "path" : "Data/h3abp_sp.lod"}, // Contains H3:SoD data (overrides H3:AB data)
+			{"type" : "lod", "path" : "Data/h3abp_sp.lod"}, // Localized versions only, contains H3:AB patch data
+			{"type" : "lod", "path" : "Data/H3sprite.lod"}, // Contains H3:SoD data (overrides H3:AB data)
 //			{"type" : "lod", "path" : "Data/H3psprit.lod"}, // Localized versions only, contains H3:SoD patch data. Unused? Has corrupted data, e.g. lock icon for artifacts
 			{"type" : "dir",  "path" : "Sprites"}
 		],

--- a/config/filesystem.json
+++ b/config/filesystem.json
@@ -27,9 +27,7 @@
 		[
 			{"type" : "snd", "path" : "Data/H3ab_ahd.snd"},
 			{"type" : "snd", "path" : "Data/Heroes3.snd"},
-			{"type" : "snd", "path" : "Data/Heroes3-cd2.snd"},
-			//WoG have overridden sounds with .82m extension in Data
-			{"type" : "dir",  "path" : "Data", "depth": 0}
+			{"type" : "snd", "path" : "Data/Heroes3-cd2.snd"}
 		],
 		"MUSIC/":
 		[

--- a/lib/mapObjects/CGCreature.cpp
+++ b/lib/mapObjects/CGCreature.cpp
@@ -332,7 +332,7 @@ int CGCreature::takenAction(const CGHeroInstance *h, bool allowJoin) const
 	myKindCres.insert(myCreature->getId()); //we
 	myKindCres.insert(myCreature->upgrades.begin(), myCreature->upgrades.end()); //our upgrades
 
-	for(auto const & crea : VLC->creh->objects)
+	for(const auto & crea : VLC->creh->objects)
 	{
 		if(vstd::contains(crea->upgrades, myCreature->getId())) //it's our base creatures
 			myKindCres.insert(crea->getId());
@@ -365,8 +365,12 @@ int CGCreature::takenAction(const CGHeroInstance *h, bool allowJoin) const
 		if(diplomacy + sympathy + 1 >= character)
 			return JOIN_FOR_FREE;
 
-		else if(diplomacy * 2  +  sympathy  +  1 >= character)
-			return VLC->creatures()->getById(getCreature())->getRecruitCost(EGameResID::GOLD) * getStackCount(SlotID(0)); //join for gold
+		if(diplomacy * 2 + sympathy + 1 >= character)
+		{
+			int32_t recruitCost = VLC->creatures()->getById(getCreature())->getRecruitCost(EGameResID::GOLD);
+			uint32_t stackCount = getStackCount(SlotID(0));
+			return recruitCost * stackCount; //join for gold
+		}
 	}
 
 	//we are still here - creatures have not joined hero, flee or fight
@@ -598,7 +602,7 @@ void CGCreature::giveReward(const CGHeroInstance * h) const
 	if(!resources.empty())
 	{
 		cb->giveResources(h->tempOwner, resources);
-		for(auto const & res : GameResID::ALL_RESOURCES())
+		for(const auto & res : GameResID::ALL_RESOURCES())
 		{
 			if(resources[res] > 0)
 				iw.components.emplace_back(ComponentType::RESOURCE, res, resources[res]);

--- a/lib/mapObjects/CGCreature.cpp
+++ b/lib/mapObjects/CGCreature.cpp
@@ -327,23 +327,15 @@ int CGCreature::takenAction(const CGHeroInstance *h, bool allowJoin) const
 	else
 		powerFactor = -3;
 
-	std::set<CreatureID> myKindCres; //what creatures are the same kind as we
-	const CCreature * myCreature = getCreature().toCreature();
-	myKindCres.insert(myCreature->getId()); //we
-	myKindCres.insert(myCreature->upgrades.begin(), myCreature->upgrades.end()); //our upgrades
-
-	for(const auto & crea : VLC->creh->objects)
-	{
-		if(vstd::contains(crea->upgrades, myCreature->getId())) //it's our base creatures
-			myKindCres.insert(crea->getId());
-	}
-
 	int count = 0; //how many creatures of similar kind has hero
 	int totalCount = 0;
 
 	for(const auto & elem : h->Slots())
 	{
-		if(vstd::contains(myKindCres,elem.second->type->getId()))
+		bool isOurUpgrade = vstd::contains(getCreature().toCreature()->upgrades, elem.second->getCreatureID());
+		bool isOurDowngrade = vstd::contains(elem.second->type->upgrades, getCreature());
+
+		if(isOurUpgrade || isOurDowngrade)
 			count += elem.second->count;
 		totalCount += elem.second->count;
 	}
@@ -368,7 +360,7 @@ int CGCreature::takenAction(const CGHeroInstance *h, bool allowJoin) const
 		if(diplomacy * 2 + sympathy + 1 >= character)
 		{
 			int32_t recruitCost = VLC->creatures()->getById(getCreature())->getRecruitCost(EGameResID::GOLD);
-			uint32_t stackCount = getStackCount(SlotID(0));
+			int32_t stackCount = getStackCount(SlotID(0));
 			return recruitCost * stackCount; //join for gold
 		}
 	}

--- a/lib/mapObjects/CGCreature.h
+++ b/lib/mapObjects/CGCreature.h
@@ -29,15 +29,15 @@ public:
 	};
 
 	ui32 identifier; //unique code for this monster (used in missions)
-	si8 character; //character of this set of creatures (0 - the most friendly, 4 - the most hostile) => on init changed to -4 (compliant) ... 10 value (savage)
+	si8 character = 0; //character of this set of creatures (0 - the most friendly, 4 - the most hostile) => on init changed to -4 (compliant) ... 10 value (savage)
 	MetaString message; //message printed for attacking hero
 	TResources resources; // resources given to hero that has won with monsters
 	ArtifactID gainedArtifact; //ID of artifact gained to hero, -1 if none
-	bool neverFlees; //if true, the troops will never flee
-	bool notGrowingTeam; //if true, number of units won't grow
-	ui64 temppower; //used to handle fractional stack growth for tiny stacks
+	bool neverFlees = false; //if true, the troops will never flee
+	bool notGrowingTeam = false; //if true, number of units won't grow
+	ui64 temppower = 0; //used to handle fractional stack growth for tiny stacks
 
-	bool refusedJoining;
+	bool refusedJoining = false;
 
 	void onHeroVisit(const CGHeroInstance * h) const override;
 	std::string getHoverText(PlayerColor player) const override;


### PR DESCRIPTION
- Newly spawned monsters no longer have fade-in effect
- - Fixes #1683 
- Fix server error messages on moving through garrisons
- Fixed uninitialized variables in CGCreature leading to weird bugs with diplomacy
- Fix loading order of archive to fix broken lock icon in Polish version
- - Fixes #3794
- Fix possible crash on actions with no initiator set, such as spawning of new wandering monsters on new month
- - Fixes #3877
- Remove no longer used path to audio files from old version of wog mod
- Loop audio stream from video file on campaing prolog/epilog window (reported on Discord)
