### PR TITLE
#3876 - allow to embark after battle for AI pathfinder

### DIFF
--- a/AI/Nullkiller/Pathfinding/AIPathfinderConfig.cpp
+++ b/AI/Nullkiller/Pathfinding/AIPathfinderConfig.cpp
@@ -47,6 +47,7 @@ namespace AIPathfinding
 		:PathfinderConfig(nodeStorage, makeRuleset(cb, ai, nodeStorage, allowBypassObjects)), aiNodeStorage(nodeStorage)
 	{
 		options.canUseCast = true;
+		options.allowLayerTransitioningAfterBattle = true;
 	}
 
 	AIPathfinderConfig::~AIPathfinderConfig() = default;

--- a/AI/Nullkiller/Pathfinding/Rules/AILayerTransitionRule.cpp
+++ b/AI/Nullkiller/Pathfinding/Rules/AILayerTransitionRule.cpp
@@ -34,6 +34,14 @@ namespace AIPathfinding
 	{
 		LayerTransitionRule::process(source, destination, pathfinderConfig, pathfinderHelper);
 
+#if NKAI_PATHFINDER_TRACE_LEVEL >= 2
+		logAi->trace("Layer transitioning %s -> %s, action: %d, blocked: %s",
+			source.coord.toString(),
+			destination.coord.toString(),
+			static_cast<int32_t>(destination.action),
+			destination.blocked ? "true" : "false");
+#endif
+
 		if(!destination.blocked)
 		{
 			if(source.node->layer == EPathfindingLayer::LAND

--- a/AI/Nullkiller/Pathfinding/Rules/AIMovementAfterDestinationRule.cpp
+++ b/AI/Nullkiller/Pathfinding/Rules/AIMovementAfterDestinationRule.cpp
@@ -84,10 +84,11 @@ namespace AIPathfinding
 
 #if NKAI_PATHFINDER_TRACE_LEVEL >= 2
 		logAi->trace(
-			"Movement from tile %s is blocked. Try to bypass. Action: %d, blocker: %d",
+			"Movement from tile %s is blocked. Try to bypass. Action: %d, blocker: %d, source: %s",
 			destination.coord.toString(),
 			(int)destination.action,
-			(int)blocker);
+			(int)blocker,
+			source.coord.toString());
 #endif
 
 		auto destGuardians = cb->getGuardingCreatures(destination.coord);

--- a/lib/pathfinder/CPathfinder.cpp
+++ b/lib/pathfinder/CPathfinder.cpp
@@ -330,7 +330,7 @@ bool CPathfinder::isLayerTransitionPossible() const
 	ELayer destLayer = destination.node->layer;
 
 	/// No layer transition allowed when previous node action is BATTLE
-	if(source.node->action == EPathNodeAction::BATTLE)
+	if(!config->options.allowLayerTransitioningAfterBattle && source.node->action == EPathNodeAction::BATTLE)
 		return false;
 
 	switch(source.node->layer.toEnum())

--- a/lib/pathfinder/PathfinderOptions.cpp
+++ b/lib/pathfinder/PathfinderOptions.cpp
@@ -33,6 +33,7 @@ PathfinderOptions::PathfinderOptions()
 	, oneTurnSpecialLayersLimit(true)
 	, turnLimit(std::numeric_limits<uint8_t>::max())
 	, canUseCast(false)
+	, allowLayerTransitioningAfterBattle(false)
 {
 }
 

--- a/lib/pathfinder/PathfinderOptions.h
+++ b/lib/pathfinder/PathfinderOptions.h
@@ -79,6 +79,11 @@ struct DLL_LINKAGE PathfinderOptions
 	/// </summary>
 	bool canUseCast;
 
+	/// <summary>
+	/// For AI. AI pathfinder needs to ignore this rule as it simulates battles on the way
+	/// </summary>
+	bool allowLayerTransitioningAfterBattle;
+
 	PathfinderOptions();
 };
 


### PR DESCRIPTION
There was a rule that one can not embark from guarded tile. But AI simulates battles so this rule should be ignored as tile will not be guarded when transition actually happens