### PR TITLE
update docs

### DIFF
--- a/docs/developers/AI.md
+++ b/docs/developers/AI.md
@@ -1,5 +1,3 @@
-< [Documentation](../Readme.md) /  AI Description
-
 There are two types of AI: adventure and battle.
 
 **Adventure AIs** are responsible for moving heroes across the map and developing towns  

--- a/docs/developers/Bonus_System.md
+++ b/docs/developers/Bonus_System.md
@@ -1,5 +1,3 @@
-< [Documentation](../Readme.md) / Bonus System
-
 The bonus system of VCMI is a set of mechanisms that make handling of different bonuses for heroes, towns, players and units easier. The system consists of a set of nodes representing objects that can be a source or a subject of a bonus and two directed acyclic graphs (DAGs) representing inheritance and propagation of bonuses. Core of bonus system is defined in HeroBonus.h file.
 
 ## Propagation and inheritance

--- a/docs/developers/Building_Android.md
+++ b/docs/developers/Building_Android.md
@@ -1,5 +1,3 @@
-< [Documentation](../Readme.md) / Building for Android
-
 The following instructions apply to **v1.2 and later**. For earlier versions the best documentation is https://github.com/vcmi/vcmi-android/blob/master/building.txt (and reading scripts in that repo), however very limited to no support will be provided from our side if you wish to go down that rabbit hole.
 
 *Note*: building has been tested only on Linux and macOS. It may or may not work on Windows out of the box.

--- a/docs/developers/Building_Linux.md
+++ b/docs/developers/Building_Linux.md
@@ -1,5 +1,3 @@
-< [Documentation](../Readme.md) / Building on Linux
-
 # Compiling VCMI
 
 - Current baseline requirement for building is Ubuntu 20.04

--- a/docs/developers/Building_Windows.md
+++ b/docs/developers/Building_Windows.md
@@ -1,5 +1,3 @@
-< [Documentation](../Readme.md) / Building on Windows
-
 # Preparations
 Windows builds can be made in more than one way and with more than one tool. This guide focuses on the simplest building process using Microsoft Visual Studio 2022
 

--- a/docs/developers/Building_iOS.md
+++ b/docs/developers/Building_iOS.md
@@ -1,5 +1,3 @@
-< [Documentation](../Readme.md) / Building for iOS
-
 ## Requirements
 
 1. **macOS**

--- a/docs/developers/Building_macOS.md
+++ b/docs/developers/Building_macOS.md
@@ -1,5 +1,3 @@
-< [Documentation](../Readme.md) / Building on macOS
-
 # Requirements
 
 1. C++ toolchain, either of:

--- a/docs/developers/Code_Structure.md
+++ b/docs/developers/Code_Structure.md
@@ -1,5 +1,3 @@
-< [Documentation](../Readme.md) / Code Structure
-
 The code of VCMI is divided into several main parts: client, server, lib and AIs, each one in a separate binary file.
 
 # The big picture

--- a/docs/developers/Coding_Guidelines.md
+++ b/docs/developers/Coding_Guidelines.md
@@ -1,5 +1,3 @@
-< [Documentation](../Readme.md) / Coding Guidelines
-
 ## C++ Standard
 
 VCMI implementation bases on C++17 standard. Any feature is acceptable as long as it's will pass build on our CI, but there is list below on what is already being used.

--- a/docs/developers/Conan.md
+++ b/docs/developers/Conan.md
@@ -1,5 +1,3 @@
-< [Documentation](../Readme.md) / Using Conan
-
 # Using dependencies from Conan
 
 [Conan](https://conan.io/) is a package manager for C/C++. We provide prebuilt binary dependencies for some platforms that are used by our CI, but they can also be consumed by users to build VCMI. However, it's not required to use only the prebuilt binaries: you can build them from source as well.

--- a/docs/developers/Development_with_Qt_Creator.md
+++ b/docs/developers/Development_with_Qt_Creator.md
@@ -1,5 +1,3 @@
-< [Documentation](../Readme.md) / Development with Qt Creator
-
 # Introduction to Qt Creator
 
 Qt Creator is the recommended IDE for VCMI development on Linux distributions, but it may be used on other operating systems as well. It has the following advantages compared to other IDEs:

--- a/docs/developers/Logging_API.md
+++ b/docs/developers/Logging_API.md
@@ -1,5 +1,3 @@
-< [Documentation](../Readme.md) /  Logging System
-
 # Features
 
 -   A logger belongs to a "domain", this enables us to change log level settings more selectively

--- a/docs/developers/Lua_Scripting_System.md
+++ b/docs/developers/Lua_Scripting_System.md
@@ -1,5 +1,3 @@
-< [Documentation](../Readme.md) / Lua Scripting System
-
 # Configuration
 
 ``` javascript

--- a/docs/developers/Networking.md
+++ b/docs/developers/Networking.md
@@ -1,5 +1,3 @@
-< [Documentation](../Readme.md) / Networking
-
 # The big picture
 
 For implementation details see files located at `lib/network` directory.

--- a/docs/developers/Serialization.md
+++ b/docs/developers/Serialization.md
@@ -1,5 +1,3 @@
-< [Documentation](../Readme.md) / Serialization System
-
 # Introduction
 
 The serializer translates between objects living in our code (like int or CGameState\*) and stream of bytes. Having objects represented as a stream of bytes is useful. Such bytes can send through the network connection (so client and server can communicate) or written to the disk (savegames).

--- a/docs/maintainers/Project_Infrastructure.md
+++ b/docs/maintainers/Project_Infrastructure.md
@@ -1,5 +1,3 @@
-< [Documentation](../Readme.md) / Project Infrastructure
-
 # Project Infrastructure
 
 This section hold important information about project infrastructure for current and future contributors. At moment it's all maintained by me (SXX), but following information will be useful if someone going to replace me in future.

--- a/docs/maintainers/Release_Process.md
+++ b/docs/maintainers/Release_Process.md
@@ -1,5 +1,3 @@
-< [Documentation](../Readme.md) / Release Process
-
 # Versioning
 For releases VCMI uses version numbering in form "1.X.Y", where:
 - 'X' indicates major release. Different major versions are generally not compatible with each other. Save format is different, network protocol is different, mod format likely different.

--- a/docs/maintainers/Ubuntu_PPA.md
+++ b/docs/maintainers/Ubuntu_PPA.md
@@ -1,5 +1,3 @@
-< [Documentation](../Readme.md) / Ubuntu PPA
-
 ## Main links
 - [Team](https://launchpad.net/~vcmi)
 - [Project](https://launchpad.net/vcmi)

--- a/docs/modders/Animation_Format.md
+++ b/docs/modders/Animation_Format.md
@@ -1,5 +1,3 @@
-< [Documentation](../Readme.md) / [Modding](Readme.md) / Animation Format
-
 VCMI allows overriding HoMM3 .def files with .json replacement. Compared to .def this format allows:
 
 -   Overriding individual frames from json file (e.g. icons)

--- a/docs/modders/Bonus/Bonus_Duration_Types.md
+++ b/docs/modders/Bonus/Bonus_Duration_Types.md
@@ -1,5 +1,3 @@
-< [Documentation](../../Readme.md) / [Modding](../Readme.md) / [Bonus Format](../Bonus_Format.md) / Bonus Duration Types
-
 Bonus may have any of these durations. They acts in disjunction.
 
 ## List of all bonus duration types

--- a/docs/modders/Bonus/Bonus_Limiters.md
+++ b/docs/modders/Bonus/Bonus_Limiters.md
@@ -1,5 +1,3 @@
-< [Documentation](../../Readme.md) / [Modding](../Readme.md) / [Bonus Format](../Bonus_Format.md) / Bonus Limiters
-
 ## Predefined Limiters
 
 The limiters take no parameters:

--- a/docs/modders/Bonus/Bonus_Propagators.md
+++ b/docs/modders/Bonus/Bonus_Propagators.md
@@ -1,5 +1,3 @@
-< [Documentation](../../Readme.md) / [Modding](../Readme.md) / [Bonus Format](../Bonus_Format.md) / Bonus Propagators
-
 ## Available propagators
 
 -   BATTLE_WIDE: Affects both sides during battle

--- a/docs/modders/Bonus/Bonus_Range_Types.md
+++ b/docs/modders/Bonus/Bonus_Range_Types.md
@@ -1,5 +1,3 @@
-< [Documentation](../../Readme.md) / [Modding](../Readme.md) / [Bonus Format](../Bonus_Format.md) / Bonus Range Types
-
 # List of all Bonus range types
 
 - NO_LIMIT

--- a/docs/modders/Bonus/Bonus_Sources.md
+++ b/docs/modders/Bonus/Bonus_Sources.md
@@ -1,5 +1,3 @@
-< [Documentation](../../Readme.md) / [Modding](../Readme.md) / [Bonus Format](../Bonus_Format.md) / Bonus Sources
-
 # List of all possible bonus sources
 
 - ARTIFACT

--- a/docs/modders/Bonus/Bonus_Types.md
+++ b/docs/modders/Bonus/Bonus_Types.md
@@ -1,5 +1,3 @@
-< [Documentation](../../Readme.md) / [Modding](../Readme.md) / [Bonus Format](../Bonus_Format.md) / Bonus Types
-
 The bonuses were grouped according to their original purpose. The bonus system allows them to propagate freely betwen the nodes, however they may not be recognized properly beyond the scope of original use.
 
 # General-purpose bonuses

--- a/docs/modders/Bonus/Bonus_Updaters.md
+++ b/docs/modders/Bonus/Bonus_Updaters.md
@@ -1,5 +1,3 @@
-< [Documentation](../../Readme.md) / [Modding](../Readme.md) / [Bonus Format](../Bonus_Format.md) / Bonus Updaters
-
 TODO: this page may be incorrect or outdated
 
 # List of Bonus Updaters

--- a/docs/modders/Bonus/Bonus_Value_Types.md
+++ b/docs/modders/Bonus/Bonus_Value_Types.md
@@ -1,5 +1,3 @@
-< [Documentation](../../Readme.md) / [Modding](../Readme.md) / [Bonus Format](../Bonus_Format.md) / Bonus Value Types
-
 Total value of Bonus is calculated using the following:
 
 -   For each bonus source type we calculate new source value (for all bonus value types except PERCENT_TO_SOURCE and PERCENT_TO_TARGET_TYPE) using the following:

--- a/docs/modders/Bonus_Format.md
+++ b/docs/modders/Bonus_Format.md
@@ -1,5 +1,3 @@
-< [Documentation](../Readme.md) / [Modding](Readme.md) / Bonus Format
-
 ## Full format
 
 All parameters but type are optional.

--- a/docs/modders/Building_Bonuses.md
+++ b/docs/modders/Building_Bonuses.md
@@ -1,5 +1,3 @@
-< [Documentation](../Readme.md) / [Modding](Readme.md) / Building Bonuses
-
 Work-in-progress page do describe all bonuses provided by town buildings
 for future configuration.
 

--- a/docs/modders/Campaign_Format.md
+++ b/docs/modders/Campaign_Format.md
@@ -1,5 +1,3 @@
-< [Documentation](../Readme.md) / [Modding](Readme.md) / Campaign Format
-
 # Introduction
 
 Starting from version 1.3, VCMI supports its own campaign format.

--- a/docs/modders/Configurable_Widgets.md
+++ b/docs/modders/Configurable_Widgets.md
@@ -1,5 +1,3 @@
-< [Documentation](../Readme.md) / [Modding](Readme.md) / Configurable Widgets
-
 # Table of contents
 
 - [Introduction](#introduction)

--- a/docs/modders/Difficulty.md
+++ b/docs/modders/Difficulty.md
@@ -1,6 +1,3 @@
-< [Documentation](../Readme.md) / [Modding](Readme.md) / Difficulty
-
-
 Since VCMI 1.4.0 there are more capabilities to configure difficulty parameters.
 It means, that modders can give different bonuses to AI or human players depending on selected difficulty
 

--- a/docs/modders/Entities_Format/Artifact_Format.md
+++ b/docs/modders/Entities_Format/Artifact_Format.md
@@ -1,5 +1,3 @@
-< [Documentation](../../Readme.md) / [Modding](../Readme.md) / Entities Format / Artifact Format
-
 Artifact bonuses use [Bonus Format](../Bonus_Format.md)
 
 ## Required data

--- a/docs/modders/Entities_Format/Battle_Obstacle_Format.md
+++ b/docs/modders/Entities_Format/Battle_Obstacle_Format.md
@@ -1,5 +1,3 @@
-< [Documentation](../../Readme.md) / [Modding](../Readme.md) / Entities Format / Battle Obstacle Format
-
 ```jsonc
 	// List of terrains on which this obstacle can be used
 	"allowedTerrains" : []

--- a/docs/modders/Entities_Format/Battlefield_Format.md
+++ b/docs/modders/Entities_Format/Battlefield_Format.md
@@ -1,5 +1,3 @@
-< [Documentation](../../Readme.md) / [Modding](../Readme.md) / Entities Format / Battlefield Format
-
 ```jsonc
 	// Human-readable name of the battlefield
 	"name" : ""

--- a/docs/modders/Entities_Format/Creature_Format.md
+++ b/docs/modders/Entities_Format/Creature_Format.md
@@ -1,5 +1,3 @@
-< [Documentation](../../Readme.md) / [Modding](../Readme.md) / Entities Format / Creature Format
-
 ## Required data
 
 In order to make functional creature you also need:

--- a/docs/modders/Entities_Format/Faction_Format.md
+++ b/docs/modders/Entities_Format/Faction_Format.md
@@ -1,5 +1,3 @@
-< [Documentation](../../Readme.md) / [Modding](../Readme.md) / Entities Format / Faction Format
-
 ## Required data
 
 In order to make functional town you also need:

--- a/docs/modders/Entities_Format/Hero_Class_Format.md
+++ b/docs/modders/Entities_Format/Hero_Class_Format.md
@@ -1,5 +1,3 @@
-< [Documentation](../../Readme.md) / [Modding](../Readme.md) / Entities Format / Hero Class Format
-
 ## Required data
 
 In order to make functional hero class you also need:

--- a/docs/modders/Entities_Format/Hero_Type_Format.md
+++ b/docs/modders/Entities_Format/Hero_Type_Format.md
@@ -1,5 +1,3 @@
-< [Documentation](../../Readme.md) / [Modding](../Readme.md) / Entities Format / Hero Type Format
-
 ## Required data
 
 In order to make functional hero you also need:

--- a/docs/modders/Entities_Format/River_Format.md
+++ b/docs/modders/Entities_Format/River_Format.md
@@ -1,5 +1,3 @@
-< [Documentation](../../Readme.md) / [Modding](../Readme.md) / Entities Format / River Format
-
 ## Format
 
 ```jsonc

--- a/docs/modders/Entities_Format/Road_Format.md
+++ b/docs/modders/Entities_Format/Road_Format.md
@@ -1,5 +1,3 @@
-< [Documentation](../../Readme.md) / [Modding](../Readme.md) / Entities Format / Road Format
-
 ## Format
 
 ```jsonc

--- a/docs/modders/Entities_Format/Secondary_Skill_Format.md
+++ b/docs/modders/Entities_Format/Secondary_Skill_Format.md
@@ -1,5 +1,3 @@
-< [Documentation](../../Readme.md) / [Modding](../Readme.md) / Entities Format / Secondary Skill Format
-
 ## Main format
 
 ```jsonc

--- a/docs/modders/Entities_Format/Spell_Format.md
+++ b/docs/modders/Entities_Format/Spell_Format.md
@@ -1,5 +1,3 @@
-< [Documentation](../../Readme.md) / [Modding](../Readme.md) / Entities Format / Spell Format
-
 # Main format
 
 ``` javascript

--- a/docs/modders/Entities_Format/Terrain_Format.md
+++ b/docs/modders/Entities_Format/Terrain_Format.md
@@ -1,5 +1,3 @@
-< [Documentation](../../Readme.md) / [Modding](../Readme.md) / Entities Format / Terrain Format
-
 ## Format
 
 ```jsonc

--- a/docs/modders/Game_Identifiers.md
+++ b/docs/modders/Game_Identifiers.md
@@ -1,5 +1,3 @@
-< [Documentation](../Readme.md) / [Modding](Readme.md) / Game Identifiers
-
 ## List of all game identifiers
 
 This is a list of all game identifiers available to modders. Note that only identifiers from base game have been included. For identifiers from mods please look up corresponding mod

--- a/docs/modders/Map_Editor.md
+++ b/docs/modders/Map_Editor.md
@@ -1,5 +1,3 @@
-< [Documentation](../Readme.md) / [Modding](Readme.md) / Map Editor
-
 # Interface
 
 <img width="738" src="https://user-images.githubusercontent.com/9308612/188775648-8551107d-9f0b-4743-8980-56c2c1c58bbc.png">

--- a/docs/modders/Map_Object_Format.md
+++ b/docs/modders/Map_Object_Format.md
@@ -1,5 +1,3 @@
-< [Documentation](../Readme.md) / [Modding](Readme.md) / Map Object Format
-
 ## Description
 
 Full object consists from 3 parts:

--- a/docs/modders/Map_Objects/Boat.md
+++ b/docs/modders/Map_Objects/Boat.md
@@ -1,5 +1,3 @@
-< [Documentation](../../Readme.md) / [Modding](../Readme.md) / [Map Object Format](../Map_Object_Format.md) / Boat
-
 ``` javascript
 {
 	// Layer on which this boat moves. Possible values:

--- a/docs/modders/Map_Objects/Creature_Bank.md
+++ b/docs/modders/Map_Objects/Creature_Bank.md
@@ -1,5 +1,3 @@
-< [Documentation](../../Readme.md) / [Modding](../Readme.md) / [Map Object Format](../Map_Object_Format.md) / Creature Bank
-
 Reward types for clearing creature bank are limited to resources, creatures, artifacts and spell.
 Format of rewards is same as in [Rewardable Objects](Rewardable.md)
 

--- a/docs/modders/Map_Objects/Dwelling.md
+++ b/docs/modders/Map_Objects/Dwelling.md
@@ -1,5 +1,3 @@
-< [Documentation](../../Readme.md) / [Modding](../Readme.md) / [Map Object Format](../Map_Object_Format.md) / Dwelling
-
 ``` javascript
 {
 	/// List of creatures in this bank. Each list represents one "level" of bank

--- a/docs/modders/Map_Objects/Market.md
+++ b/docs/modders/Map_Objects/Market.md
@@ -1,5 +1,3 @@
-< [Documentation](../../Readme.md) / [Modding](../Readme.md) / [Map Object Format](../Map_Object_Format.md) / Market
-
 # Market schema
 
 Since VCMI-1.3 it's possible to create customizable markets on adventure map.

--- a/docs/modders/Map_Objects/Rewardable.md
+++ b/docs/modders/Map_Objects/Rewardable.md
@@ -1,5 +1,3 @@
-< [Documentation](../../Readme.md) / [Modding](../Readme.md) / [Map Object Format](../Map_Object_Format.md) / Rewardable
-
 ## Table of Contents
 - [Base object definition](#base-object-definition)
 - [Configurable object definition](#configurable-object-definition)

--- a/docs/modders/Mod_File_Format.md
+++ b/docs/modders/Mod_File_Format.md
@@ -1,5 +1,3 @@
-< [Documentation](../Readme.md) / [Modding](Readme.md) / Mod File Format
-
 ## Fields with description of mod
 
 ``` javascript

--- a/docs/modders/Random_Map_Template.md
+++ b/docs/modders/Random_Map_Template.md
@@ -1,5 +1,3 @@
-< [Documentation](../Readme.md) / [Modding](Readme.md) / Random Map Template Format
-
 ## Template format
 
 ``` javascript

--- a/docs/modders/Readme.md
+++ b/docs/modders/Readme.md
@@ -1,5 +1,3 @@
-< [Documentation](../Readme.md) / Modding
-
 # Creating mod
 
 To make your own mod you need to create subdirectory in **<data dir>/Mods/** with name that will be used as identifier for your mod.

--- a/docs/modders/Translations.md
+++ b/docs/modders/Translations.md
@@ -1,5 +1,3 @@
-< [Documentation](../Readme.md) / [Modding](Readme.md) / Translations
-
 # Translation system
 
 ## List of currently supported languages
@@ -23,6 +21,12 @@ This is list of all languages that are currently supported by VCMI. If your lang
 - Turkish
 - Ukrainian
 - Vietnamese
+
+## Progress of the translations
+You can see the current progress of the different translations here:
+[Translation progress](https://github.com/vcmi/vcmi-translation-status)
+
+The page will be automatically updated once a week.
 
 ## Translating Heroes III data
 

--- a/docs/players/Bug_Reporting_Guidelines.md
+++ b/docs/players/Bug_Reporting_Guidelines.md
@@ -1,5 +1,3 @@
-< [Documentation](../Readme.md) / Bug Reporting Guidelines
-
 First of all, thanks for your support! If you report a bug we can fix it. But keep in mind that reporting your bugs appropriately makes our (developers') lifes easier. Here are a few guidelines that will help you write good bug reports.
 
 # Github bugtracker

--- a/docs/players/Cheat_Codes.md
+++ b/docs/players/Cheat_Codes.md
@@ -1,5 +1,3 @@
-< [Documentation](../Readme.md) / Cheat Codes
-
 # Cheat Codes
 
 Similar to H3, VCMI provides cheat codes to make testing game more convenient.

--- a/docs/players/Game_Mechanics.md
+++ b/docs/players/Game_Mechanics.md
@@ -1,5 +1,3 @@
-< [Documentation](../Readme.md) / Game Mechanics
-
 # List of features added in VCMI
 
 ## High resolutions

--- a/docs/players/Installation_Android.md
+++ b/docs/players/Installation_Android.md
@@ -1,5 +1,3 @@
-< [Documentation](../Readme.md) / Installation on Android
-
 ## Step 1: Download and install VCMI
 
 **This app requires original heroes 3 sod / complete files to operate, they are not supplied with this installer. it is recommended to purchase version from gog.com. Heroes 3 "hd edition" (steam version) files are not supported !!!**  

--- a/docs/players/Installation_Linux.md
+++ b/docs/players/Installation_Linux.md
@@ -1,5 +1,3 @@
-< [Documentation](../Readme.md) / Installation on Linux
-
 VCMI requires data from original Heroes 3: Shadow of Death or Complete editions. Data from native Linux version made by LOKI will not work.
 
 # Step 1: Binaries installation

--- a/docs/players/Installation_Windows.md
+++ b/docs/players/Installation_Windows.md
@@ -1,5 +1,3 @@
-< [Documentation](../Readme.md) / Installation on Windows
-
 # Prerequisites
 
 As of VCMI 1.2 and newer Windows 10 or newer is required since our automated system uses elements incompatible with older Windows.

--- a/docs/players/Installation_iOS.md
+++ b/docs/players/Installation_iOS.md
@@ -1,5 +1,3 @@
-< [Documentation](../Readme.md) / Installation on iOS
-
 You can run VCMI on iOS 12.0 and later, all devices are supported. If you wish to run on iOS 10 or 11, you should build from source, see [How to build VCMI (iOS)](../developers/Building_iOS.md).
 
 ## Step 1: Download and install VCMI

--- a/docs/players/Installation_macOS.md
+++ b/docs/players/Installation_macOS.md
@@ -1,5 +1,3 @@
-< [Documentation](../Readme.md) / Installation on macOS
-
 **For iOS installation look here: (Installation on iOS)[Installation_iOS.md]
 
 # Step 1: Download and install VCMI

--- a/docs/players/Privacy_Policy.md
+++ b/docs/players/Privacy_Policy.md
@@ -1,5 +1,3 @@
-< [Documentation](../Readme.md) / Privacy Policy
-
 **Last Updated: 24th December, 2022**
 
 ### Glossary


### PR DESCRIPTION
- removing navigation (navigation is incorrect for new homepage, can be added later to homepage if [this](https://squidfunk.github.io/mkdocs-material/setup/setting-up-navigation/?h=bread#navigation-path) leaves "insider", alternatively we could add it in python)
- added link to translation progress