### PR TITLE
CWindowWithArtifacts refactoring part2

### DIFF
--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -1780,7 +1780,10 @@ void CPlayerInterface::artifactMoved(const ArtifactLocation &src, const Artifact
 	{
 		artWin->artifactMoved(src, dst);
 		if(numOfMovedArts == 0)
+		{
 			artWin->update();
+			artWin->redraw();
+		}
 	}
 	waitWhileDialog();
 }

--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -1772,18 +1772,16 @@ void CPlayerInterface::artifactMoved(const ArtifactLocation &src, const Artifact
 	EVENT_HANDLER_CALLED_BY_CLIENT;
 	adventureInt->onHeroChanged(cb->getHero(dst.artHolder));
 
-	bool redraw = true;
 	// If a bulk transfer has arrived, then redrawing only the last art movement.
 	if(numOfMovedArts != 0)
-	{
 		numOfMovedArts--;
-		if(numOfMovedArts != 0)
-			redraw = false;
-	}
 
 	for(auto artWin : GH.windows().findWindows<CWindowWithArtifacts>())
-		artWin->artifactMoved(src, dst, redraw);
-
+	{
+		artWin->artifactMoved(src, dst);
+		if(numOfMovedArts == 0)
+			artWin->update();
+	}
 	waitWhileDialog();
 }
 

--- a/client/widgets/CArtifactsOfHeroAltar.cpp
+++ b/client/widgets/CArtifactsOfHeroAltar.cpp
@@ -21,12 +21,8 @@
 
 CArtifactsOfHeroAltar::CArtifactsOfHeroAltar(const Point & position)
 {
-	init(
-		std::bind(&CArtifactsOfHeroBase::clickPrassedArtPlace, this, _1, _2),
-		std::bind(&CArtifactsOfHeroBase::showPopupArtPlace, this, _1, _2),
-		position,
-		std::bind(&CArtifactsOfHeroBase::scrollBackpack, this, _1));
-
+	init(position, std::bind(&CArtifactsOfHeroBase::scrollBackpack, this, _1));
+	enableGesture();
 	// The backpack is in the altar window above and to the right
 	for(auto & slot : backpack)
 		slot->moveBy(Point(2, -1));

--- a/client/widgets/CArtifactsOfHeroAltar.h
+++ b/client/widgets/CArtifactsOfHeroAltar.h
@@ -16,6 +16,8 @@
 class CArtifactsOfHeroAltar : public CArtifactsOfHeroBase
 {
 public:
+	ObjectInstanceID altarId;
+
 	CArtifactsOfHeroAltar(const Point & position);
 	void deactivate() override;
 };

--- a/client/widgets/CArtifactsOfHeroBackpack.cpp
+++ b/client/widgets/CArtifactsOfHeroBackpack.cpp
@@ -126,7 +126,7 @@ size_t CArtifactsOfHeroBackpack::calcRows(size_t slots)
 CArtifactsOfHeroQuickBackpack::CArtifactsOfHeroQuickBackpack(const ArtifactPosition filterBySlot)
 	: CArtifactsOfHeroBackpack(0, 0)
 {
-	assert(filterBySlot != ArtifactPosition::FIRST_AVAILABLE);
+	assert(ArtifactUtils::checkIfSlotValid(*getHero(), filterBySlot));
 
 	if(!ArtifactUtils::isSlotEquipment(filterBySlot))
 		return;

--- a/client/widgets/CArtifactsOfHeroBase.cpp
+++ b/client/widgets/CArtifactsOfHeroBase.cpp
@@ -240,6 +240,11 @@ const CArtifactInstance * CArtifactsOfHeroBase::getArt(const ArtifactPosition & 
 	return curHero ? curHero->getArt(slot) : nullptr;
 }
 
+void CArtifactsOfHeroBase::enableKeyboardShortcuts()
+{
+	addUsedEvents(AEventsReceiver::KEYBOARD);
+}
+
 void CArtifactsOfHeroBase::setSlotData(ArtPlacePtr artPlace, const ArtifactPosition & slot)
 {
 	// Spurious call from artifactMoved in attempt to update hidden backpack slot

--- a/client/widgets/CArtifactsOfHeroBase.cpp
+++ b/client/widgets/CArtifactsOfHeroBase.cpp
@@ -166,6 +166,21 @@ CArtifactsOfHeroBase::ArtPlacePtr CArtifactsOfHeroBase::getArtPlace(const Artifa
 	}
 }
 
+CArtifactsOfHeroBase::ArtPlacePtr CArtifactsOfHeroBase::getArtPlace(const Point & cursorPosition)
+{
+	for(const auto & [slot, artPlace] : artWorn)
+	{
+		if(artPlace->pos.isInside(cursorPosition))
+			return artPlace;
+	}
+	for(const auto & artPlace : backpack)
+	{
+		if(artPlace->pos.isInside(cursorPosition))
+			return artPlace;
+	}
+	return nullptr;
+}
+
 void CArtifactsOfHeroBase::updateWornSlots()
 {
 	for(auto place : artWorn)

--- a/client/widgets/CArtifactsOfHeroBase.cpp
+++ b/client/widgets/CArtifactsOfHeroBase.cpp
@@ -235,7 +235,7 @@ void CArtifactsOfHeroBase::addGestureCallback(CArtPlace::ClickFunctor callback)
 	}
 }
 
-const CArtifactInstance * CArtifactsOfHeroBase::getArt(const ArtifactPosition & slot)
+const CArtifactInstance * CArtifactsOfHeroBase::getArt(const ArtifactPosition & slot) const
 {
 	return curHero ? curHero->getArt(slot) : nullptr;
 }

--- a/client/widgets/CArtifactsOfHeroBase.cpp
+++ b/client/widgets/CArtifactsOfHeroBase.cpp
@@ -47,8 +47,6 @@ void CArtifactsOfHeroBase::putBackPickedArtifact()
 }
 
 void CArtifactsOfHeroBase::init(
-	const CArtPlace::ClickFunctor & onClickPressedCallback,
-	const CArtPlace::ClickFunctor & onShowPopupCallback,
 	const Point & position,
 	const BpackScrollFunctor & scrollCallback)
 {
@@ -69,14 +67,14 @@ void CArtifactsOfHeroBase::init(
 	{
 		artPlace.second->slot = artPlace.first;
 		artPlace.second->setArtifact(nullptr);
-		artPlace.second->setClickPressedCallback(onClickPressedCallback);
-		artPlace.second->setShowPopupCallback(onShowPopupCallback);
+		artPlace.second->setClickPressedCallback(std::bind(&CArtifactsOfHeroBase::clickPrassedArtPlace, this, _1, _2));
+		artPlace.second->setShowPopupCallback(std::bind(&CArtifactsOfHeroBase::showPopupArtPlace, this, _1, _2));
 	}
 	for(auto artPlace : backpack)
 	{
 		artPlace->setArtifact(nullptr);
-		artPlace->setClickPressedCallback(onClickPressedCallback);
-		artPlace->setShowPopupCallback(onShowPopupCallback);
+		artPlace->setClickPressedCallback(std::bind(&CArtifactsOfHeroBase::clickPrassedArtPlace, this, _1, _2));
+		artPlace->setShowPopupCallback(std::bind(&CArtifactsOfHeroBase::showPopupArtPlace, this, _1, _2));
 	}
 	leftBackpackRoll = std::make_shared<CButton>(Point(379, 364), AnimationPath::builtin("hsbtns3.def"), CButton::tooltip(),
 		[scrollCallback](){scrollCallback(true);}, EShortcut::MOVE_LEFT);
@@ -226,11 +224,11 @@ const CArtifactInstance * CArtifactsOfHeroBase::getPickedArtifact()
 		return nullptr;
 }
 
-void CArtifactsOfHeroBase::addGestureCallback(CArtPlace::ClickFunctor callback)
+void CArtifactsOfHeroBase::enableGesture()
 {
 	for(auto & artPlace : artWorn)
 	{
-		artPlace.second->setGestureCallback(callback);
+		artPlace.second->setGestureCallback(std::bind(&CArtifactsOfHeroBase::gestureArtPlace, this, _1, _2));
 		artPlace.second->addUsedEvents(GESTURE);
 	}
 }

--- a/client/widgets/CArtifactsOfHeroBase.cpp
+++ b/client/widgets/CArtifactsOfHeroBase.cpp
@@ -32,9 +32,9 @@ CArtifactsOfHeroBase::CArtifactsOfHeroBase()
 void CArtifactsOfHeroBase::putBackPickedArtifact()
 {
 	// Artifact located in artifactsTransitionPos should be returned
-	if(getPickedArtifact())
+	if(const auto art = getPickedArtifact())
 	{
-		auto slot = ArtifactUtils::getArtAnyPosition(curHero, curHero->artifactsTransitionPos.begin()->artifact->getTypeId());
+		auto slot = ArtifactUtils::getArtAnyPosition(curHero, art->getTypeId());
 		if(slot == ArtifactPosition::PRE_FIRST)
 		{
 			LOCPLINT->cb->eraseArtifactByClient(ArtifactLocation(curHero->id, ArtifactPosition::TRANSITION_POS));
@@ -196,10 +196,10 @@ void CArtifactsOfHeroBase::updateSlot(const ArtifactPosition & slot)
 const CArtifactInstance * CArtifactsOfHeroBase::getPickedArtifact()
 {
 	// Returns only the picked up artifact. Not just highlighted like in the trading window.
-	if(!curHero || curHero->artifactsTransitionPos.empty())
-		return nullptr;
-	else
+	if(curHero)
 		return curHero->getArt(ArtifactPosition::TRANSITION_POS);
+	else
+		return nullptr;
 }
 
 void CArtifactsOfHeroBase::addGestureCallback(CArtPlace::ClickFunctor callback)

--- a/client/widgets/CArtifactsOfHeroBase.cpp
+++ b/client/widgets/CArtifactsOfHeroBase.cpp
@@ -90,20 +90,29 @@ void CArtifactsOfHeroBase::init(
 
 void CArtifactsOfHeroBase::clickPrassedArtPlace(CArtPlace & artPlace, const Point & cursorPosition)
 {
+	if(artPlace.isLocked())
+		return;
+
 	if(clickPressedCallback)
-		clickPressedCallback(*this, artPlace, cursorPosition);
+		clickPressedCallback(artPlace, cursorPosition);
 }
 
 void CArtifactsOfHeroBase::showPopupArtPlace(CArtPlace & artPlace, const Point & cursorPosition)
 {
+	if(artPlace.isLocked())
+		return;
+
 	if(showPopupCallback)
-		showPopupCallback(*this, artPlace, cursorPosition);
+		showPopupCallback(artPlace, cursorPosition);
 }
 
 void CArtifactsOfHeroBase::gestureArtPlace(CArtPlace & artPlace, const Point & cursorPosition)
 {
+	if(artPlace.isLocked())
+		return;
+
 	if(gestureCallback)
-		gestureCallback(*this, artPlace, cursorPosition);
+		gestureCallback(artPlace, cursorPosition);
 }
 
 void CArtifactsOfHeroBase::setHero(const CGHeroInstance * hero)
@@ -224,6 +233,11 @@ void CArtifactsOfHeroBase::addGestureCallback(CArtPlace::ClickFunctor callback)
 		artPlace.second->setGestureCallback(callback);
 		artPlace.second->addUsedEvents(GESTURE);
 	}
+}
+
+const CArtifactInstance * CArtifactsOfHeroBase::getArt(const ArtifactPosition & slot)
+{
+	return curHero ? curHero->getArt(slot) : nullptr;
 }
 
 void CArtifactsOfHeroBase::setSlotData(ArtPlacePtr artPlace, const ArtifactPosition & slot)

--- a/client/widgets/CArtifactsOfHeroBase.h
+++ b/client/widgets/CArtifactsOfHeroBase.h
@@ -11,9 +11,11 @@
 
 #include "CArtPlace.h"
 
+#include "../gui/Shortcut.h"
+
 class CButton;
 
-class CArtifactsOfHeroBase : virtual public CIntObject
+class CArtifactsOfHeroBase : virtual public CIntObject, public CKeyShortcut
 {
 protected:
 	using ArtPlacePtr = std::shared_ptr<CHeroArtPlace>;
@@ -45,6 +47,7 @@ public:
 	virtual const CArtifactInstance * getPickedArtifact();
 	void addGestureCallback(CArtPlace::ClickFunctor callback);
 	const CArtifactInstance * getArt(const ArtifactPosition & slot) const;
+	void enableKeyboardShortcuts();
 
 protected:
 	const CGHeroInstance * curHero;

--- a/client/widgets/CArtifactsOfHeroBase.h
+++ b/client/widgets/CArtifactsOfHeroBase.h
@@ -38,6 +38,7 @@ public:
 	virtual void markPossibleSlots(const CArtifactInstance * art, bool assumeDestRemoved = true);
 	virtual void unmarkSlots();
 	virtual ArtPlacePtr getArtPlace(const ArtifactPosition & slot);
+	virtual ArtPlacePtr getArtPlace(const Point & cursorPosition);
 	virtual void updateWornSlots();
 	virtual void updateBackpackSlots();
 	virtual void updateSlot(const ArtifactPosition & slot);

--- a/client/widgets/CArtifactsOfHeroBase.h
+++ b/client/widgets/CArtifactsOfHeroBase.h
@@ -45,11 +45,10 @@ public:
 	virtual void updateBackpackSlots();
 	virtual void updateSlot(const ArtifactPosition & slot);
 	virtual const CArtifactInstance * getPickedArtifact();
-	void addGestureCallback(CArtPlace::ClickFunctor callback);
+	void enableGesture();
 	const CArtifactInstance * getArt(const ArtifactPosition & slot) const;
 	void enableKeyboardShortcuts();
 
-protected:
 	const CGHeroInstance * curHero;
 	ArtPlaceMap artWorn;
 	std::vector<ArtPlacePtr> backpack;
@@ -67,8 +66,8 @@ protected:
 		Point(381,295) //18
 	};
 
-	virtual void init(const CHeroArtPlace::ClickFunctor & lClickCallback, const CHeroArtPlace::ClickFunctor & showPopupCallback,
-		const Point & position, const BpackScrollFunctor & scrollCallback);
+protected:
+	virtual void init(const Point & position, const BpackScrollFunctor & scrollCallback);
 	// Assigns an artifacts to an artifact place depending on it's new slot ID
 	virtual void setSlotData(ArtPlacePtr artPlace, const ArtifactPosition & slot);
 };

--- a/client/widgets/CArtifactsOfHeroBase.h
+++ b/client/widgets/CArtifactsOfHeroBase.h
@@ -44,7 +44,7 @@ public:
 	virtual void updateSlot(const ArtifactPosition & slot);
 	virtual const CArtifactInstance * getPickedArtifact();
 	void addGestureCallback(CArtPlace::ClickFunctor callback);
-	const CArtifactInstance * getArt(const ArtifactPosition & slot);
+	const CArtifactInstance * getArt(const ArtifactPosition & slot) const;
 
 protected:
 	const CGHeroInstance * curHero;

--- a/client/widgets/CArtifactsOfHeroBase.h
+++ b/client/widgets/CArtifactsOfHeroBase.h
@@ -21,7 +21,7 @@ protected:
 
 public:
 	using ArtPlaceMap = std::map<ArtifactPosition, ArtPlacePtr>;
-	using ClickFunctor = std::function<void(CArtifactsOfHeroBase&, CArtPlace&, const Point&)>;
+	using ClickFunctor = std::function<void(CArtPlace&, const Point&)>;
 
 	ClickFunctor clickPressedCallback;
 	ClickFunctor showPopupCallback;
@@ -44,6 +44,7 @@ public:
 	virtual void updateSlot(const ArtifactPosition & slot);
 	virtual const CArtifactInstance * getPickedArtifact();
 	void addGestureCallback(CArtPlace::ClickFunctor callback);
+	const CArtifactInstance * getArt(const ArtifactPosition & slot);
 
 protected:
 	const CGHeroInstance * curHero;

--- a/client/widgets/CArtifactsOfHeroKingdom.cpp
+++ b/client/widgets/CArtifactsOfHeroKingdom.cpp
@@ -33,7 +33,7 @@ CArtifactsOfHeroKingdom::CArtifactsOfHeroKingdom(ArtPlaceMap ArtWorn, std::vecto
 		artPlace.second->setClickPressedCallback(std::bind(&CArtifactsOfHeroBase::clickPrassedArtPlace, this, _1, _2));
 		artPlace.second->setShowPopupCallback(std::bind(&CArtifactsOfHeroBase::showPopupArtPlace, this, _1, _2));
 	}
-	addGestureCallback(std::bind(&CArtifactsOfHeroBase::gestureArtPlace, this, _1, _2));
+	enableGesture();
 	for(auto artPlace : backpack)
 	{
 		artPlace->setArtifact(nullptr);

--- a/client/widgets/CArtifactsOfHeroMain.cpp
+++ b/client/widgets/CArtifactsOfHeroMain.cpp
@@ -33,11 +33,6 @@ CArtifactsOfHeroMain::~CArtifactsOfHeroMain()
 	CArtifactsOfHeroBase::putBackPickedArtifact();
 }
 
-void CArtifactsOfHeroMain::enableArtifactsCostumeSwitcher()
-{
-	addUsedEvents(AEventsReceiver::KEYBOARD);
-}
-
 void CArtifactsOfHeroMain::keyPressed(EShortcut key)
 {
 	if(!shortcutPressed)

--- a/client/widgets/CArtifactsOfHeroMain.cpp
+++ b/client/widgets/CArtifactsOfHeroMain.cpp
@@ -20,12 +20,8 @@
 
 CArtifactsOfHeroMain::CArtifactsOfHeroMain(const Point & position)
 {
-	init(
-		std::bind(&CArtifactsOfHeroBase::clickPrassedArtPlace, this, _1, _2),
-		std::bind(&CArtifactsOfHeroBase::showPopupArtPlace, this, _1, _2),
-		position,
-		std::bind(&CArtifactsOfHeroBase::scrollBackpack, this, _1));
-	addGestureCallback(std::bind(&CArtifactsOfHeroBase::gestureArtPlace, this, _1, _2));
+	init(position, std::bind(&CArtifactsOfHeroBase::scrollBackpack, this, _1));
+	enableGesture();
 }
 
 CArtifactsOfHeroMain::~CArtifactsOfHeroMain()

--- a/client/widgets/CArtifactsOfHeroMain.h
+++ b/client/widgets/CArtifactsOfHeroMain.h
@@ -11,14 +11,11 @@
 
 #include "CArtifactsOfHeroBase.h"
 
-#include "../gui/Shortcut.h"
-
-class CArtifactsOfHeroMain : public CArtifactsOfHeroBase, public CKeyShortcut
+class CArtifactsOfHeroMain : public CArtifactsOfHeroBase
 {
 public:
 	CArtifactsOfHeroMain(const Point & position);
 	~CArtifactsOfHeroMain() override;
-	void enableArtifactsCostumeSwitcher();
 	void keyPressed(EShortcut key) override;
 	void keyReleased(EShortcut key) override;
 

--- a/client/widgets/CArtifactsOfHeroMarket.cpp
+++ b/client/widgets/CArtifactsOfHeroMarket.cpp
@@ -26,7 +26,7 @@ CArtifactsOfHeroMarket::CArtifactsOfHeroMarket(const Point & position, const int
 		artPlace->setSelectionWidth(selectionWidth);
 };
 
-void CArtifactsOfHeroMarket::onClickPrassedArtPlace(CArtPlace & artPlace)
+void CArtifactsOfHeroMarket::onClickPressedArtPlace(CArtPlace & artPlace)
 {
 	if(const auto art = getArt(artPlace.slot))
 	{

--- a/client/widgets/CArtifactsOfHeroMarket.cpp
+++ b/client/widgets/CArtifactsOfHeroMarket.cpp
@@ -25,3 +25,21 @@ CArtifactsOfHeroMarket::CArtifactsOfHeroMarket(const Point & position, const int
 	for(auto artPlace : backpack)
 		artPlace->setSelectionWidth(selectionWidth);
 };
+
+void CArtifactsOfHeroMarket::onClickPrassedArtPlace(CArtPlace & artPlace)
+{
+	if(const auto art = getArt(artPlace.slot))
+	{
+		if(onSelectArtCallback && art->artType->isTradable())
+		{
+			unmarkSlots();
+			artPlace.selectSlot(true);
+			onSelectArtCallback(&artPlace);
+		}
+		else
+		{
+			if(onClickNotTradableCallback)
+				onClickNotTradableCallback();
+		}
+	}
+}

--- a/client/widgets/CArtifactsOfHeroMarket.cpp
+++ b/client/widgets/CArtifactsOfHeroMarket.cpp
@@ -14,11 +14,7 @@
 
 CArtifactsOfHeroMarket::CArtifactsOfHeroMarket(const Point & position, const int selectionWidth)
 {
-	init(
-		std::bind(&CArtifactsOfHeroBase::clickPrassedArtPlace, this, _1, _2),
-		std::bind(&CArtifactsOfHeroBase::showPopupArtPlace, this, _1, _2),
-		position,
-		std::bind(&CArtifactsOfHeroBase::scrollBackpack, this, _1));
+	init(position, std::bind(&CArtifactsOfHeroBase::scrollBackpack, this, _1));
 
 	for(const auto & [slot, artPlace] : artWorn)
 		artPlace->setSelectionWidth(selectionWidth);
@@ -26,8 +22,11 @@ CArtifactsOfHeroMarket::CArtifactsOfHeroMarket(const Point & position, const int
 		artPlace->setSelectionWidth(selectionWidth);
 };
 
-void CArtifactsOfHeroMarket::onClickPressedArtPlace(CArtPlace & artPlace)
+void CArtifactsOfHeroMarket::clickPrassedArtPlace(CArtPlace & artPlace, const Point & cursorPosition)
 {
+	if(artPlace.isLocked())
+		return;
+
 	if(const auto art = getArt(artPlace.slot))
 	{
 		if(onSelectArtCallback && art->artType->isTradable())

--- a/client/widgets/CArtifactsOfHeroMarket.h
+++ b/client/widgets/CArtifactsOfHeroMarket.h
@@ -18,5 +18,5 @@ public:
 	std::function<void()> onClickNotTradableCallback;
 
 	CArtifactsOfHeroMarket(const Point & position, const int selectionWidth);
-	void onClickPrassedArtPlace(CArtPlace & artPlace);
+	void onClickPressedArtPlace(CArtPlace & artPlace);
 };

--- a/client/widgets/CArtifactsOfHeroMarket.h
+++ b/client/widgets/CArtifactsOfHeroMarket.h
@@ -18,5 +18,5 @@ public:
 	std::function<void()> onClickNotTradableCallback;
 
 	CArtifactsOfHeroMarket(const Point & position, const int selectionWidth);
-	void onClickPressedArtPlace(CArtPlace & artPlace);
+	void clickPrassedArtPlace(CArtPlace & artPlace, const Point & cursorPosition) override;
 };

--- a/client/widgets/CArtifactsOfHeroMarket.h
+++ b/client/widgets/CArtifactsOfHeroMarket.h
@@ -14,7 +14,9 @@
 class CArtifactsOfHeroMarket : public CArtifactsOfHeroBase
 {
 public:
-	std::function<void(const CArtPlace*)> selectArtCallback;
+	std::function<void(const CArtPlace*)> onSelectArtCallback;
+	std::function<void()> onClickNotTradableCallback;
 
 	CArtifactsOfHeroMarket(const Point & position, const int selectionWidth);
+	void onClickPrassedArtPlace(CArtPlace & artPlace);
 };

--- a/client/widgets/markets/CAltarArtifacts.cpp
+++ b/client/widgets/markets/CAltarArtifacts.cpp
@@ -32,7 +32,6 @@ CAltarArtifacts::CAltarArtifacts(const IMarket * market, const CGHeroInstance * 
 
 	assert(dynamic_cast<const CGArtifactsAltar*>(market));
 	auto altarObj = dynamic_cast<const CGArtifactsAltar*>(market);
-	altarId = altarObj->id;
 	altarArtifacts = altarObj;
 
 	deal = std::make_shared<CButton>(Point(269, 520), AnimationPath::builtin("ALTSACR.DEF"),
@@ -51,6 +50,7 @@ CAltarArtifacts::CAltarArtifacts(const IMarket * market, const CGHeroInstance * 
 	// Hero's artifacts
 	heroArts = std::make_shared<CArtifactsOfHeroAltar>(Point(-365, -11));
 	heroArts->setHero(hero);
+	heroArts->altarId = altarObj->id;
 
 	// Altar
 	offerTradePanel = std::make_shared<ArtifactsAltarPanel>([this](const std::shared_ptr<CTradeableItem> & altarSlot)
@@ -109,12 +109,12 @@ void CAltarArtifacts::makeDeal()
 
 void CAltarArtifacts::sacrificeAll()
 {
-	LOCPLINT->cb->bulkMoveArtifacts(heroArts->getHero()->id, altarId, false, true, true);
+	LOCPLINT->cb->bulkMoveArtifacts(heroArts->getHero()->id, heroArts->altarId, false, true, true);
 }
 
 void CAltarArtifacts::sacrificeBackpack()
 {
-	LOCPLINT->cb->bulkMoveArtifacts(heroArts->getHero()->id, altarId, false, false, true);
+	LOCPLINT->cb->bulkMoveArtifacts(heroArts->getHero()->id, heroArts->altarId, false, false, true);
 }
 
 std::shared_ptr<CArtifactsOfHeroAltar> CAltarArtifacts::getAOHset() const
@@ -179,7 +179,7 @@ void CAltarArtifacts::putBackArtifacts()
 	// TODO: If the backpack capacity limit is enabled, artifacts may remain on the altar.
 	// Perhaps should be erased in CGameHandler::objectVisitEnded if id of visited object will be available
 	if(!altarArtifacts->artifactsInBackpack.empty())
-		LOCPLINT->cb->bulkMoveArtifacts(altarId, heroArts->getHero()->id, false, true, true);
+		LOCPLINT->cb->bulkMoveArtifacts(heroArts->altarId, heroArts->getHero()->id, false, true, true);
 }
 
 CMarketBase::MarketShowcasesParams CAltarArtifacts::getShowcasesParams() const
@@ -208,7 +208,7 @@ void CAltarArtifacts::onSlotClickPressed(const std::shared_ptr<CTradeableItem> &
 				deal->block(!LOCPLINT->makingTurn);
 
 				LOCPLINT->cb->swapArtifacts(ArtifactLocation(heroArts->getHero()->id, ArtifactPosition::TRANSITION_POS),
-					ArtifactLocation(altarId, ArtifactPosition::ALTAR));
+					ArtifactLocation(heroArts->altarId, ArtifactPosition::ALTAR));
 			}
 			else
 			{
@@ -222,7 +222,7 @@ void CAltarArtifacts::onSlotClickPressed(const std::shared_ptr<CTradeableItem> &
 		assert(tradeSlotsMap.at(altarSlot));
 		const auto slot = altarArtifacts->getSlotByInstance(tradeSlotsMap.at(altarSlot));
 		assert(slot != ArtifactPosition::PRE_FIRST);
-		LOCPLINT->cb->swapArtifacts(ArtifactLocation(altarId, slot),
+		LOCPLINT->cb->swapArtifacts(ArtifactLocation(heroArts->altarId, slot),
 			ArtifactLocation(hero->id, GH.isKeyboardCtrlDown() ? ArtifactPosition::FIRST_AVAILABLE : ArtifactPosition::TRANSITION_POS));
 		tradeSlotsMap.erase(altarSlot);
 	}

--- a/client/widgets/markets/CAltarArtifacts.cpp
+++ b/client/widgets/markets/CAltarArtifacts.cpp
@@ -222,7 +222,8 @@ void CAltarArtifacts::onSlotClickPressed(const std::shared_ptr<CTradeableItem> &
 		assert(tradeSlotsMap.at(altarSlot));
 		const auto slot = altarArtifacts->getSlotByInstance(tradeSlotsMap.at(altarSlot));
 		assert(slot != ArtifactPosition::PRE_FIRST);
-		LOCPLINT->cb->swapArtifacts(ArtifactLocation(altarId, slot), ArtifactLocation(hero->id, ArtifactPosition::TRANSITION_POS));
+		LOCPLINT->cb->swapArtifacts(ArtifactLocation(altarId, slot),
+			ArtifactLocation(hero->id, GH.isKeyboardCtrlDown() ? ArtifactPosition::FIRST_AVAILABLE : ArtifactPosition::TRANSITION_POS));
 		tradeSlotsMap.erase(altarSlot);
 	}
 }

--- a/client/widgets/markets/CAltarArtifacts.h
+++ b/client/widgets/markets/CAltarArtifacts.h
@@ -26,7 +26,6 @@ public:
 	void putBackArtifacts();
 
 private:
-	ObjectInstanceID altarId;
 	const CArtifactSet * altarArtifacts;
 	std::shared_ptr<CButton> sacrificeBackpackButton;
 	std::shared_ptr<CArtifactsOfHeroAltar> heroArts;

--- a/client/widgets/markets/CArtifactsSelling.cpp
+++ b/client/widgets/markets/CArtifactsSelling.cpp
@@ -55,14 +55,18 @@ CArtifactsSelling::CArtifactsSelling(const IMarket * market, const CGHeroInstanc
 	// Hero's artifacts
 	heroArts = std::make_shared<CArtifactsOfHeroMarket>(Point(-361, 46), offerTradePanel->selectionWidth);
 	heroArts->setHero(hero);
-	heroArts->selectArtCallback = [this](const CArtPlace * artPlace)
+	heroArts->onSelectArtCallback = [this](const CArtPlace * artPlace)
 	{
 		assert(artPlace);
 		selectedHeroSlot = artPlace->slot;
 		CArtifactsSelling::highlightingChanged();
 		CIntObject::redraw();
 	};
-
+	heroArts->onClickNotTradableCallback = []()
+	{
+		// This item can't be traded
+		LOCPLINT->showInfoDialog(CGI->generaltexth->allTexts[21]);
+	};
 	CArtifactsSelling::updateShowcases();
 	CArtifactsSelling::deselect();
 }

--- a/client/windows/CHeroBackpackWindow.cpp
+++ b/client/windows/CHeroBackpackWindow.cpp
@@ -20,7 +20,7 @@
 #include "render/Canvas.h"
 #include "CPlayerInterface.h"
 
-CHeroBackpackWindow::CHeroBackpackWindow(const CGHeroInstance * hero, const std::vector<CArtifactsOfHeroPtr> & artsSets)
+CHeroBackpackWindow::CHeroBackpackWindow(const CGHeroInstance * hero, const std::vector<ArtifactsOfHeroVar> & artsSets)
 	: CWindowWithArtifacts(&artsSets)
 {
 	OBJECT_CONSTRUCTION_CAPTURING(255 - DISPOSE);

--- a/client/windows/CHeroBackpackWindow.cpp
+++ b/client/windows/CHeroBackpackWindow.cpp
@@ -20,7 +20,10 @@
 #include "render/Canvas.h"
 #include "CPlayerInterface.h"
 
-CHeroBackpackWindow::CHeroBackpackWindow(const CGHeroInstance * hero, const std::vector<ArtifactsOfHeroVar> & artsSets)
+#include "../../lib/mapObjects/CGHeroInstance.h"
+#include "../../lib/networkPacks/ArtifactLocation.h"
+
+CHeroBackpackWindow::CHeroBackpackWindow(const CGHeroInstance * hero, const std::vector<CArtifactsOfHeroPtr> & artsSets)
 	: CWindowWithArtifacts(&artsSets)
 {
 	OBJECT_CONSTRUCTION_CAPTURING(255 - DISPOSE);
@@ -28,7 +31,15 @@ CHeroBackpackWindow::CHeroBackpackWindow(const CGHeroInstance * hero, const std:
 	stretchedBackground = std::make_shared<CFilledTexture>(ImagePath::builtin("DIBOXBCK"), Rect(0, 0, 0, 0));
 	arts = std::make_shared<CArtifactsOfHeroBackpack>();
 	arts->moveBy(Point(windowMargin, windowMargin));
-	addSetAndCallbacks(arts);
+	arts->clickPressedCallback = [this](CArtPlace & artPlace, const Point & cursorPosition)
+	{
+		clickPressedOnArtPlace(arts->getHero(), artPlace.slot, true, false, true);
+	};
+	arts->showPopupCallback = [this](CArtPlace & artPlace, const Point & cursorPosition)
+	{
+		showArtifactAssembling(*arts, artPlace, cursorPosition);
+	};
+	addSet(arts);
 	arts->setHero(hero);
 	addCloseCallback(std::bind(&CHeroBackpackWindow::close, this));
 	quitButton = std::make_shared<CButton>(Point(), AnimationPath::builtin("IOKAY32.def"), CButton::tooltip(""),
@@ -55,7 +66,16 @@ CHeroQuickBackpackWindow::CHeroQuickBackpackWindow(const CGHeroInstance * hero, 
 	stretchedBackground = std::make_shared<CFilledTexture>(ImagePath::builtin("DIBOXBCK"), Rect(0, 0, 0, 0));
 	arts = std::make_shared<CArtifactsOfHeroQuickBackpack>(targetSlot);
 	arts->moveBy(Point(windowMargin, windowMargin));
-	addSetAndCallbacks(static_cast<std::shared_ptr<CArtifactsOfHeroQuickBackpack>>(arts));
+	arts->clickPressedCallback = [this](CArtPlace & artPlace, const Point & cursorPosition)
+	{
+		if(const auto curHero = arts->getHero())
+			swapArtifactAndClose(*arts, artPlace.slot, ArtifactLocation(curHero->id, arts->getFilterSlot()));
+	};
+	arts->showPopupCallback = [this](CArtPlace & artPlace, const Point & cursorPosition)
+	{
+		showArifactInfo(artPlace, cursorPosition);
+	};
+	addSet(arts);
 	arts->setHero(hero);
 	addCloseCallback(std::bind(&CHeroQuickBackpackWindow::close, this));
 	addUsedEvents(GESTURE);

--- a/client/windows/CHeroBackpackWindow.cpp
+++ b/client/windows/CHeroBackpackWindow.cpp
@@ -31,7 +31,7 @@ CHeroBackpackWindow::CHeroBackpackWindow(const CGHeroInstance * hero, const std:
 	stretchedBackground = std::make_shared<CFilledTexture>(ImagePath::builtin("DIBOXBCK"), Rect(0, 0, 0, 0));
 	arts = std::make_shared<CArtifactsOfHeroBackpack>();
 	arts->moveBy(Point(windowMargin, windowMargin));
-	arts->clickPressedCallback = [this](CArtPlace & artPlace, const Point & cursorPosition)
+	arts->clickPressedCallback = [this](const CArtPlace & artPlace, const Point & cursorPosition)
 	{
 		clickPressedOnArtPlace(arts->getHero(), artPlace.slot, true, false, true);
 	};
@@ -41,7 +41,6 @@ CHeroBackpackWindow::CHeroBackpackWindow(const CGHeroInstance * hero, const std:
 	};
 	addSet(arts);
 	arts->setHero(hero);
-	addCloseCallback(std::bind(&CHeroBackpackWindow::close, this));
 	quitButton = std::make_shared<CButton>(Point(), AnimationPath::builtin("IOKAY32.def"), CButton::tooltip(""),
 		[this]() { WindowBase::close(); }, EShortcut::GLOBAL_RETURN);
 	pos.w = stretchedBackground->pos.w = arts->pos.w + 2 * windowMargin;
@@ -66,18 +65,17 @@ CHeroQuickBackpackWindow::CHeroQuickBackpackWindow(const CGHeroInstance * hero, 
 	stretchedBackground = std::make_shared<CFilledTexture>(ImagePath::builtin("DIBOXBCK"), Rect(0, 0, 0, 0));
 	arts = std::make_shared<CArtifactsOfHeroQuickBackpack>(targetSlot);
 	arts->moveBy(Point(windowMargin, windowMargin));
-	arts->clickPressedCallback = [this](CArtPlace & artPlace, const Point & cursorPosition)
+	arts->clickPressedCallback = [this](const CArtPlace & artPlace, const Point & cursorPosition)
 	{
 		if(const auto curHero = arts->getHero())
 			swapArtifactAndClose(*arts, artPlace.slot, ArtifactLocation(curHero->id, arts->getFilterSlot()));
 	};
 	arts->showPopupCallback = [this](CArtPlace & artPlace, const Point & cursorPosition)
 	{
-		showArifactInfo(artPlace, cursorPosition);
+		showArifactInfo(*arts, artPlace, cursorPosition);
 	};
 	addSet(arts);
 	arts->setHero(hero);
-	addCloseCallback(std::bind(&CHeroQuickBackpackWindow::close, this));
 	addUsedEvents(GESTURE);
 	pos.w = stretchedBackground->pos.w = arts->pos.w + 2 * windowMargin;
 	pos.h = stretchedBackground->pos.h = arts->pos.h + windowMargin;

--- a/client/windows/CHeroBackpackWindow.cpp
+++ b/client/windows/CHeroBackpackWindow.cpp
@@ -55,7 +55,7 @@ CHeroQuickBackpackWindow::CHeroQuickBackpackWindow(const CGHeroInstance * hero, 
 	stretchedBackground = std::make_shared<CFilledTexture>(ImagePath::builtin("DIBOXBCK"), Rect(0, 0, 0, 0));
 	arts = std::make_shared<CArtifactsOfHeroQuickBackpack>(targetSlot);
 	arts->moveBy(Point(windowMargin, windowMargin));
-	addSetAndCallbacks(static_cast<std::weak_ptr<CArtifactsOfHeroQuickBackpack>>(arts));
+	addSetAndCallbacks(static_cast<std::shared_ptr<CArtifactsOfHeroQuickBackpack>>(arts));
 	arts->setHero(hero);
 	addCloseCallback(std::bind(&CHeroQuickBackpackWindow::close, this));
 	addUsedEvents(GESTURE);

--- a/client/windows/CHeroBackpackWindow.h
+++ b/client/windows/CHeroBackpackWindow.h
@@ -16,7 +16,7 @@ class CFilledTexture;
 class CHeroBackpackWindow : public CStatusbarWindow, public CWindowWithArtifacts
 {
 public:
-	CHeroBackpackWindow(const CGHeroInstance * hero, const std::vector<ArtifactsOfHeroVar> & artsSets);
+	CHeroBackpackWindow(const CGHeroInstance * hero, const std::vector<CArtifactsOfHeroPtr> & artsSets);
 	
 protected:
 	std::shared_ptr<CArtifactsOfHeroBackpack> arts;

--- a/client/windows/CHeroBackpackWindow.h
+++ b/client/windows/CHeroBackpackWindow.h
@@ -16,7 +16,7 @@ class CFilledTexture;
 class CHeroBackpackWindow : public CStatusbarWindow, public CWindowWithArtifacts
 {
 public:
-	CHeroBackpackWindow(const CGHeroInstance * hero, const std::vector<CArtifactsOfHeroPtr> & artsSets);
+	CHeroBackpackWindow(const CGHeroInstance * hero, const std::vector<ArtifactsOfHeroVar> & artsSets);
 	
 protected:
 	std::shared_ptr<CArtifactsOfHeroBackpack> arts;

--- a/client/windows/CHeroWindow.cpp
+++ b/client/windows/CHeroWindow.cpp
@@ -213,19 +213,10 @@ void CHeroWindow::update()
 		if(!arts)
 		{
 			arts = std::make_shared<CArtifactsOfHeroMain>(Point(-65, -8));
+			arts->clickPressedCallback = [this](const CArtPlace & artPlace, const Point & cursorPosition){clickPressedOnArtPlace(curHero, artPlace.slot, true, false, false);};
+			arts->showPopupCallback = [this](CArtPlace & artPlace, const Point & cursorPosition){showArtifactAssembling(*arts, artPlace, cursorPosition);};
+			arts->gestureCallback = [this](const CArtPlace & artPlace, const Point & cursorPosition){showQuickBackpackWindow(curHero, artPlace.slot, cursorPosition);};
 			arts->setHero(curHero);
-			arts->clickPressedCallback = [this](CArtPlace & artPlace, const Point & cursorPosition)
-			{
-				clickPressedOnArtPlace(arts->getHero(), artPlace.slot, true, false, false);
-			};
-			arts->showPopupCallback = [this](CArtPlace & artPlace, const Point & cursorPosition)
-			{
-				showArtifactAssembling(*arts, artPlace, cursorPosition);
-			};
-			arts->gestureCallback = [this](CArtPlace & artPlace, const Point & cursorPosition)
-			{
-				showQuickBackpackWindow(arts->getHero(), artPlace.slot, cursorPosition);
-			};
 			addSet(arts);
 			enableKeyboardShortcuts();
 		}

--- a/client/windows/CHeroWindow.cpp
+++ b/client/windows/CHeroWindow.cpp
@@ -214,8 +214,20 @@ void CHeroWindow::update()
 		{
 			arts = std::make_shared<CArtifactsOfHeroMain>(Point(-65, -8));
 			arts->setHero(curHero);
-			addSetAndCallbacks(arts);
-			enableArtifactsCostumeSwitcher();
+			arts->clickPressedCallback = [this](CArtPlace & artPlace, const Point & cursorPosition)
+			{
+				clickPressedOnArtPlace(arts->getHero(), artPlace.slot, true, false, false);
+			};
+			arts->showPopupCallback = [this](CArtPlace & artPlace, const Point & cursorPosition)
+			{
+				showArtifactAssembling(*arts, artPlace, cursorPosition);
+			};
+			arts->gestureCallback = [this](CArtPlace & artPlace, const Point & cursorPosition)
+			{
+				showQuickBackpackWindow(arts->getHero(), artPlace.slot, cursorPosition);
+			};
+			addSet(arts);
+			enableKeyboardShortcuts();
 		}
 
 		int serial = LOCPLINT->cb->getHeroSerial(curHero, false);

--- a/client/windows/CHeroWindow.cpp
+++ b/client/windows/CHeroWindow.cpp
@@ -46,7 +46,7 @@ void CHeroSwitcher::clickPressed(const Point & cursorPosition)
 	//TODO: do not recreate window
 	if (false)
 	{
-		owner->update(hero, true);
+		owner->update();
 	}
 	else
 	{
@@ -175,20 +175,14 @@ CHeroWindow::CHeroWindow(const CGHeroInstance * hero)
 	labels.push_back(std::make_shared<CLabel>(69, 232, FONT_SMALL, ETextAlignment::TOPLEFT, Colors::YELLOW, CGI->generaltexth->jktexts[6]));
 	labels.push_back(std::make_shared<CLabel>(213, 232, FONT_SMALL, ETextAlignment::TOPLEFT, Colors::YELLOW, CGI->generaltexth->jktexts[7]));
 
-	update(hero);
+	CHeroWindow::update();
 }
 
-void CHeroWindow::update(const CGHeroInstance * hero, bool redrawNeeded)
+void CHeroWindow::update()
 {
+	CWindowWithArtifacts::update();
 	auto & heroscrn = CGI->generaltexth->heroscrn;
-
-	if(!hero) //something strange... no hero? it shouldn't happen
-	{
-		logGlobal->error("Set nullptr hero? no way...");
-		return;
-	}
-
-	assert(hero == curHero);
+	assert(curHero);
 
 	name->setText(curHero->getNameTranslated());
 	title->setText((boost::format(CGI->generaltexth->allTexts[342]) % curHero->level % curHero->getClassNameTranslated()).str());
@@ -313,8 +307,7 @@ void CHeroWindow::update(const CGHeroInstance * hero, bool redrawNeeded)
 	morale->set(curHero);
 	luck->set(curHero);
 
-	if(redrawNeeded)
-		redraw();
+	redraw();
 }
 
 void CHeroWindow::dismissCurrent()

--- a/client/windows/CHeroWindow.h
+++ b/client/windows/CHeroWindow.h
@@ -100,7 +100,7 @@ public:
 
 	CHeroWindow(const CGHeroInstance * hero);
 
-	void update(const CGHeroInstance * hero, bool redrawNeeded = false); //sets main displayed hero
+	void update() override;
 
 	void dismissCurrent(); //dissmissed currently displayed hero (curHero)
 	void commanderWindow();

--- a/client/windows/CKingdomInterface.cpp
+++ b/client/windows/CKingdomInterface.cpp
@@ -550,7 +550,7 @@ std::shared_ptr<CIntObject> CKingdomInterface::createMainTab(size_t index)
 	case 0:
 		return std::make_shared<CKingdHeroList>(size, [this](const CWindowWithArtifacts::CArtifactsOfHeroPtr & newHeroSet)
 			{
-				newHeroSet->clickPressedCallback = [this, newHeroSet](CArtPlace & artPlace, const Point & cursorPosition)
+				newHeroSet->clickPressedCallback = [this, newHeroSet](const CArtPlace & artPlace, const Point & cursorPosition)
 				{
 					clickPressedOnArtPlace(newHeroSet->getHero(), artPlace.slot, false, false, false);
 				};
@@ -558,7 +558,7 @@ std::shared_ptr<CIntObject> CKingdomInterface::createMainTab(size_t index)
 				{
 					showArtifactAssembling(*newHeroSet, artPlace, cursorPosition);
 				};
-				newHeroSet->gestureCallback = [this, newHeroSet](CArtPlace & artPlace, const Point & cursorPosition)
+				newHeroSet->gestureCallback = [this, newHeroSet](const CArtPlace & artPlace, const Point & cursorPosition)
 				{
 					showQuickBackpackWindow(newHeroSet->getHero(), artPlace.slot, cursorPosition);
 				};

--- a/client/windows/CKingdomInterface.cpp
+++ b/client/windows/CKingdomInterface.cpp
@@ -548,7 +548,7 @@ std::shared_ptr<CIntObject> CKingdomInterface::createMainTab(size_t index)
 	switch(index)
 	{
 	case 0:
-		return std::make_shared<CKingdHeroList>(size, [this](const CWindowWithArtifacts::CArtifactsOfHeroPtr & newHeroSet)
+		return std::make_shared<CKingdHeroList>(size, [this](const CWindowWithArtifacts::ArtifactsOfHeroVar & newHeroSet)
 			{
 				addSetAndCallbacks(newHeroSet);
 			});

--- a/client/windows/CKingdomInterface.cpp
+++ b/client/windows/CKingdomInterface.cpp
@@ -548,9 +548,21 @@ std::shared_ptr<CIntObject> CKingdomInterface::createMainTab(size_t index)
 	switch(index)
 	{
 	case 0:
-		return std::make_shared<CKingdHeroList>(size, [this](const CWindowWithArtifacts::ArtifactsOfHeroVar & newHeroSet)
+		return std::make_shared<CKingdHeroList>(size, [this](const CWindowWithArtifacts::CArtifactsOfHeroPtr & newHeroSet)
 			{
-				addSetAndCallbacks(newHeroSet);
+				newHeroSet->clickPressedCallback = [this, newHeroSet](CArtPlace & artPlace, const Point & cursorPosition)
+				{
+					clickPressedOnArtPlace(newHeroSet->getHero(), artPlace.slot, false, false, false);
+				};
+				newHeroSet->showPopupCallback = [this, newHeroSet](CArtPlace & artPlace, const Point & cursorPosition)
+				{
+					showArtifactAssembling(*newHeroSet, artPlace, cursorPosition);
+				};
+				newHeroSet->gestureCallback = [this, newHeroSet](CArtPlace & artPlace, const Point & cursorPosition)
+				{
+					showQuickBackpackWindow(newHeroSet->getHero(), artPlace.slot, cursorPosition);
+				};
+				addSet(newHeroSet);
 			});
 	case 1:
 		return std::make_shared<CKingdTownList>(size);

--- a/client/windows/CKingdomInterface.h
+++ b/client/windows/CKingdomInterface.h
@@ -334,7 +334,7 @@ private:
 	std::shared_ptr<CLabel> skillsLabel;
 
 public:
-	using CreateHeroItemFunctor = std::function<void(const CWindowWithArtifacts::CArtifactsOfHeroPtr)>;
+	using CreateHeroItemFunctor = std::function<void(const CWindowWithArtifacts::ArtifactsOfHeroVar)>;
 
 	CKingdHeroList(size_t maxSize, const CreateHeroItemFunctor & onCreateHeroItemCallback);
 	void updateGarrisons() override;

--- a/client/windows/CKingdomInterface.h
+++ b/client/windows/CKingdomInterface.h
@@ -334,7 +334,7 @@ private:
 	std::shared_ptr<CLabel> skillsLabel;
 
 public:
-	using CreateHeroItemFunctor = std::function<void(const CWindowWithArtifacts::ArtifactsOfHeroVar)>;
+	using CreateHeroItemFunctor = std::function<void(const CWindowWithArtifacts::CArtifactsOfHeroPtr)>;
 
 	CKingdHeroList(size_t maxSize, const CreateHeroItemFunctor & onCreateHeroItemCallback);
 	void updateGarrisons() override;

--- a/client/windows/CMarketWindow.cpp
+++ b/client/windows/CMarketWindow.cpp
@@ -62,24 +62,27 @@ CMarketWindow::CMarketWindow(const IMarket * market, const CGHeroInstance * hero
 
 void CMarketWindow::updateArtifacts()
 {
-	assert(marketWidget);
-	marketWidget->update();
+	update();
 }
 
 void CMarketWindow::updateGarrisons()
 {
-	assert(marketWidget);
-	marketWidget->update();
+	update();
 }
 
 void CMarketWindow::updateResource()
 {
-	assert(marketWidget);
-	marketWidget->update();
+	update();
 }
 
 void CMarketWindow::updateHero()
 {
+	update();
+}
+
+void CMarketWindow::update()
+{
+	CWindowWithArtifacts::update();
 	assert(marketWidget);
 	marketWidget->update();
 }
@@ -96,19 +99,6 @@ bool CMarketWindow::holdsGarrison(const CArmedInstance * army)
 {
 	assert(marketWidget);
 	return marketWidget->hero == army;
-}
-
-void CMarketWindow::artifactRemoved(const ArtifactLocation & artLoc)
-{
-	marketWidget->update();
-	CWindowWithArtifacts::artifactRemoved(artLoc);
-}
-
-void CMarketWindow::artifactMoved(const ArtifactLocation & srcLoc, const ArtifactLocation & destLoc, bool withRedraw)
-{
-	CWindowWithArtifacts::artifactMoved(srcLoc, destLoc, withRedraw);
-	assert(marketWidget);
-	marketWidget->update();
 }
 
 void CMarketWindow::createChangeModeButtons(EMarketMode currentMode, const IMarket * market, const CGHeroInstance * hero)

--- a/client/windows/CMarketWindow.cpp
+++ b/client/windows/CMarketWindow.cpp
@@ -195,14 +195,7 @@ void CMarketWindow::createArtifactsSelling(const IMarket * market, const CGHeroI
 	auto artsSellingMarket = std::make_shared<CArtifactsSelling>(market, hero);
 	artSets.clear();
 	const auto heroArts = artsSellingMarket->getAOHset();
-	heroArts->clickPressedCallback = [heroArts](CArtPlace & artPlace, const Point & cursorPosition)
-	{
-		heroArts->onClickPressedArtPlace(artPlace);
-	};
-	heroArts->showPopupCallback = [this](CArtPlace & artPlace, const Point & cursorPosition)
-	{
-		showArifactInfo(artPlace, cursorPosition);
-	};
+	heroArts->showPopupCallback = [this, heroArts](CArtPlace & artPlace, const Point & cursorPosition){showArifactInfo(*heroArts, artPlace, cursorPosition);};
 	addSet(heroArts);
 	marketWidget = artsSellingMarket;
 	initWidgetInternals(EMarketMode::ARTIFACT_RESOURCE, CGI->generaltexth->zelp[600]);	
@@ -244,7 +237,7 @@ void CMarketWindow::createAltarArtifacts(const IMarket * market, const CGHeroIns
 	marketWidget = altarArtifacts;
 	artSets.clear();
 	const auto heroArts = altarArtifacts->getAOHset();
-	heroArts->clickPressedCallback = [this, heroArts](CArtPlace & artPlace, const Point & cursorPosition)
+	heroArts->clickPressedCallback = [this, heroArts](const CArtPlace & artPlace, const Point & cursorPosition)
 	{
 		clickPressedOnArtPlace(heroArts->getHero(), artPlace.slot, true, true, false);
 	};
@@ -252,7 +245,7 @@ void CMarketWindow::createAltarArtifacts(const IMarket * market, const CGHeroIns
 	{
 		showArtifactAssembling(*heroArts, artPlace, cursorPosition);
 	};
-	heroArts->gestureCallback = [this, heroArts](CArtPlace & artPlace, const Point & cursorPosition)
+	heroArts->gestureCallback = [this, heroArts](const CArtPlace & artPlace, const Point & cursorPosition)
 	{
 		showQuickBackpackWindow(heroArts->getHero(), artPlace.slot, cursorPosition);
 	};

--- a/client/windows/CMarketWindow.cpp
+++ b/client/windows/CMarketWindow.cpp
@@ -106,8 +106,6 @@ void CMarketWindow::artifactRemoved(const ArtifactLocation & artLoc)
 
 void CMarketWindow::artifactMoved(const ArtifactLocation & srcLoc, const ArtifactLocation & destLoc, bool withRedraw)
 {
-	if(!getState().has_value())
-		return;
 	CWindowWithArtifacts::artifactMoved(srcLoc, destLoc, withRedraw);
 	assert(marketWidget);
 	marketWidget->update();

--- a/client/windows/CMarketWindow.cpp
+++ b/client/windows/CMarketWindow.cpp
@@ -194,7 +194,16 @@ void CMarketWindow::createArtifactsSelling(const IMarket * market, const CGHeroI
 	artSlotBack->moveTo(pos.topLeft() + Point(18, 339));
 	auto artsSellingMarket = std::make_shared<CArtifactsSelling>(market, hero);
 	artSets.clear();
-	addSetAndCallbacks(artsSellingMarket->getAOHset());
+	const auto heroArts = artsSellingMarket->getAOHset();
+	heroArts->clickPressedCallback = [heroArts](CArtPlace & artPlace, const Point & cursorPosition)
+	{
+		heroArts->onClickPressedArtPlace(artPlace);
+	};
+	heroArts->showPopupCallback = [this](CArtPlace & artPlace, const Point & cursorPosition)
+	{
+		showArifactInfo(artPlace, cursorPosition);
+	};
+	addSet(heroArts);
 	marketWidget = artsSellingMarket;
 	initWidgetInternals(EMarketMode::ARTIFACT_RESOURCE, CGI->generaltexth->zelp[600]);	
 }
@@ -234,7 +243,20 @@ void CMarketWindow::createAltarArtifacts(const IMarket * market, const CGHeroIns
 	auto altarArtifacts = std::make_shared<CAltarArtifacts>(market, hero);
 	marketWidget = altarArtifacts;
 	artSets.clear();
-	addSetAndCallbacks(altarArtifacts->getAOHset());
+	const auto heroArts = altarArtifacts->getAOHset();
+	heroArts->clickPressedCallback = [this, heroArts](CArtPlace & artPlace, const Point & cursorPosition)
+	{
+		clickPressedOnArtPlace(heroArts->getHero(), artPlace.slot, true, true, false);
+	};
+	heroArts->showPopupCallback = [this, heroArts](CArtPlace & artPlace, const Point & cursorPosition)
+	{
+		showArtifactAssembling(*heroArts, artPlace, cursorPosition);
+	};
+	heroArts->gestureCallback = [this, heroArts](CArtPlace & artPlace, const Point & cursorPosition)
+	{
+		showQuickBackpackWindow(heroArts->getHero(), artPlace.slot, cursorPosition);
+	};
+	addSet(heroArts);
 	initWidgetInternals(EMarketMode::ARTIFACT_EXP, CGI->generaltexth->zelp[568]);
 	updateHero();
 	quitButton->addCallback([altarArtifacts](){altarArtifacts->putBackArtifacts();});

--- a/client/windows/CMarketWindow.h
+++ b/client/windows/CMarketWindow.h
@@ -20,10 +20,9 @@ public:
 	void updateArtifacts();
 	void updateGarrisons() override;
 	void updateHero();
+	void update() override;
 	void close() override;
 	bool holdsGarrison(const CArmedInstance * army) override;
-	void artifactRemoved(const ArtifactLocation & artLoc) override;
-	void artifactMoved(const ArtifactLocation & srcLoc, const ArtifactLocation & destLoc, bool withRedraw) override;
 
 private:
 	void createChangeModeButtons(EMarketMode currentMode, const IMarket * market, const CGHeroInstance * hero);

--- a/client/windows/CWindowWithArtifacts.h
+++ b/client/windows/CWindowWithArtifacts.h
@@ -20,12 +20,12 @@ class CWindowWithArtifacts : virtual public CWindowObject
 {
 public:
 	using ArtifactsOfHeroVar = std::variant<
-		std::weak_ptr<CArtifactsOfHeroMarket>,
-		std::weak_ptr<CArtifactsOfHeroAltar>,
-		std::weak_ptr<CArtifactsOfHeroKingdom>,
-		std::weak_ptr<CArtifactsOfHeroMain>,
-		std::weak_ptr<CArtifactsOfHeroBackpack>,
-		std::weak_ptr<CArtifactsOfHeroQuickBackpack>>;
+		std::shared_ptr<CArtifactsOfHeroMarket>,
+		std::shared_ptr<CArtifactsOfHeroAltar>,
+		std::shared_ptr<CArtifactsOfHeroKingdom>,
+		std::shared_ptr<CArtifactsOfHeroMain>,
+		std::shared_ptr<CArtifactsOfHeroBackpack>,
+		std::shared_ptr<CArtifactsOfHeroQuickBackpack>>;
 	using CloseCallback = std::function<void()>;
 
 	std::vector<ArtifactsOfHeroVar> artSets;
@@ -50,7 +50,7 @@ public:
 	virtual void artifactAssembled(const ArtifactLocation & artLoc);
 
 protected:
-	void update() const;
+	void update();
 	std::optional<ArtifactsOfHeroVar> findAOHbyRef(const CArtifactsOfHeroBase & artsInst);
 	void markPossibleSlots();
 	bool checkSpecialArts(const CArtifactInstance & artInst, const CGHeroInstance * hero, bool isTrade) const;

--- a/client/windows/CWindowWithArtifacts.h
+++ b/client/windows/CWindowWithArtifacts.h
@@ -37,9 +37,12 @@ public:
 	void addCloseCallback(const CloseCallback & callback);
 	const CGHeroInstance * getHeroPickedArtifact();
 	const CArtifactInstance * getPickedArtifact();
-	void clickPressedArtPlaceHero(const CArtifactsOfHeroBase & artsInst, CArtPlace & artPlace, const Point & cursorPosition);
-	void showPopupArtPlaceHero(const CArtifactsOfHeroBase & artsInst, CArtPlace & artPlace, const Point & cursorPosition);
-	void gestureArtPlaceHero(const CArtifactsOfHeroBase & artsInst, CArtPlace & artPlace, const Point & cursorPosition);
+	void clickPressedOnArtPlace(const CGHeroInstance & hero, const ArtifactPosition & slot,
+		bool allowExchange, bool altarTrading, bool closeWindow);
+	void swapArtifactAndClose(const CArtifactsOfHeroBase & artsInst, CArtPlace & artPlace, const ArtifactLocation & dstLoc);
+	void showArtifactAssembling(const CArtifactsOfHeroBase & artsInst, CArtPlace & artPlace, const Point & cursorPosition);
+	void showArifactInfo(CArtPlace & artPlace, const Point & cursorPosition);
+	void showQuickBackpackWindow(const CArtifactsOfHeroBase & artsInst, CArtPlace & artPlace, const Point & cursorPosition);
 	void activate() override;
 	void deactivate() override;
 	void enableArtifactsCostumeSwitcher() const;
@@ -51,8 +54,8 @@ public:
 
 protected:
 	void update();
-	std::optional<ArtifactsOfHeroVar> findAOHbyRef(const CArtifactsOfHeroBase & artsInst);
 	void markPossibleSlots();
-	bool checkSpecialArts(const CArtifactInstance & artInst, const CGHeroInstance * hero, bool isTrade) const;
+	bool checkSpecialArts(const CArtifactInstance & artInst, const CGHeroInstance & hero, bool isTrade) const;
 	void setCursorAnimation(const CArtifactInstance & artInst);
+	void putPickedArtifact(const CGHeroInstance & curHero, const ArtifactPosition & targetSlot);
 };

--- a/client/windows/CWindowWithArtifacts.h
+++ b/client/windows/CWindowWithArtifacts.h
@@ -20,21 +20,18 @@ class CWindowWithArtifacts : virtual public CWindowObject
 {
 public:
 	using CArtifactsOfHeroPtr = std::shared_ptr<CArtifactsOfHeroBase>;
-	using CloseCallback = std::function<void()>;
 
 	std::vector<CArtifactsOfHeroPtr> artSets;
-	CloseCallback closeCallback;
 
 	explicit CWindowWithArtifacts(const std::vector<CArtifactsOfHeroPtr> * artSets = nullptr);
 	void addSet(const std::shared_ptr<CArtifactsOfHeroBase> & newArtSet);
-	void addCloseCallback(const CloseCallback & callback);
-	const CGHeroInstance * getHeroPickedArtifact();
-	const CArtifactInstance * getPickedArtifact();
+	const CGHeroInstance * getHeroPickedArtifact() const;
+	const CArtifactInstance * getPickedArtifact() const;
 	void clickPressedOnArtPlace(const CGHeroInstance * hero, const ArtifactPosition & slot,
 		bool allowExchange, bool altarTrading, bool closeWindow);
-	void swapArtifactAndClose(const CArtifactsOfHeroBase & artsInst, const ArtifactPosition & slot, const ArtifactLocation & dstLoc) const;
+	void swapArtifactAndClose(const CArtifactsOfHeroBase & artsInst, const ArtifactPosition & slot, const ArtifactLocation & dstLoc);
 	void showArtifactAssembling(const CArtifactsOfHeroBase & artsInst, CArtPlace & artPlace, const Point & cursorPosition) const;
-	void showArifactInfo(CArtPlace & artPlace, const Point & cursorPosition) const;
+	void showArifactInfo(const CArtifactsOfHeroBase & artsInst, CArtPlace & artPlace, const Point & cursorPosition) const;
 	void showQuickBackpackWindow(const CGHeroInstance * hero, const ArtifactPosition & slot, const Point & cursorPosition) const;
 	void activate() override;
 	void deactivate() override;
@@ -47,9 +44,9 @@ public:
 	virtual void update();
 
 protected:
-	void markPossibleSlots();
+	void markPossibleSlots() const;
 	bool checkSpecialArts(const CArtifactInstance & artInst, const CGHeroInstance & hero, bool isTrade) const;
-	void setCursorAnimation(const CArtifactInstance & artInst);
-	void putPickedArtifact(const CGHeroInstance & curHero, const ArtifactPosition & targetSlot);
+	void setCursorAnimation(const CArtifactInstance & artInst) const;
+	void putPickedArtifact(const CGHeroInstance & curHero, const ArtifactPosition & targetSlot) const;
 	void onClickPressedCommonArtifact(const CGHeroInstance & curHero, const ArtifactPosition & slot, bool closeWindow);
 };

--- a/client/windows/CWindowWithArtifacts.h
+++ b/client/windows/CWindowWithArtifacts.h
@@ -19,33 +19,26 @@
 class CWindowWithArtifacts : virtual public CWindowObject
 {
 public:
-	using ArtifactsOfHeroVar = std::variant<
-		std::shared_ptr<CArtifactsOfHeroMarket>,
-		std::shared_ptr<CArtifactsOfHeroAltar>,
-		std::shared_ptr<CArtifactsOfHeroKingdom>,
-		std::shared_ptr<CArtifactsOfHeroMain>,
-		std::shared_ptr<CArtifactsOfHeroBackpack>,
-		std::shared_ptr<CArtifactsOfHeroQuickBackpack>>;
+	using CArtifactsOfHeroPtr = std::shared_ptr<CArtifactsOfHeroBase>;
 	using CloseCallback = std::function<void()>;
 
-	std::vector<ArtifactsOfHeroVar> artSets;
+	std::vector<CArtifactsOfHeroPtr> artSets;
 	CloseCallback closeCallback;
 
-	explicit CWindowWithArtifacts(const std::vector<ArtifactsOfHeroVar> * artSets = nullptr);
-	void addSet(ArtifactsOfHeroVar newArtSet);
-	void addSetAndCallbacks(ArtifactsOfHeroVar newArtSet);
+	explicit CWindowWithArtifacts(const std::vector<CArtifactsOfHeroPtr> * artSets = nullptr);
+	void addSet(const std::shared_ptr<CArtifactsOfHeroBase> & newArtSet);
 	void addCloseCallback(const CloseCallback & callback);
 	const CGHeroInstance * getHeroPickedArtifact();
 	const CArtifactInstance * getPickedArtifact();
-	void clickPressedOnArtPlace(const CGHeroInstance & hero, const ArtifactPosition & slot,
+	void clickPressedOnArtPlace(const CGHeroInstance * hero, const ArtifactPosition & slot,
 		bool allowExchange, bool altarTrading, bool closeWindow);
 	void swapArtifactAndClose(const CArtifactsOfHeroBase & artsInst, const ArtifactPosition & slot, const ArtifactLocation & dstLoc) const;
 	void showArtifactAssembling(const CArtifactsOfHeroBase & artsInst, CArtPlace & artPlace, const Point & cursorPosition) const;
 	void showArifactInfo(CArtPlace & artPlace, const Point & cursorPosition) const;
-	void showQuickBackpackWindow(const CGHeroInstance & hero, const ArtifactPosition & slot, const Point & cursorPosition) const;
+	void showQuickBackpackWindow(const CGHeroInstance * hero, const ArtifactPosition & slot, const Point & cursorPosition) const;
 	void activate() override;
 	void deactivate() override;
-	void enableArtifactsCostumeSwitcher() const;
+	void enableKeyboardShortcuts() const;
 
 	virtual void artifactRemoved(const ArtifactLocation & artLoc);
 	virtual void artifactMoved(const ArtifactLocation & srcLoc, const ArtifactLocation & destLoc);

--- a/client/windows/CWindowWithArtifacts.h
+++ b/client/windows/CWindowWithArtifacts.h
@@ -19,7 +19,7 @@
 class CWindowWithArtifacts : virtual public CWindowObject
 {
 public:
-	using CArtifactsOfHeroPtr = std::variant<
+	using ArtifactsOfHeroVar = std::variant<
 		std::weak_ptr<CArtifactsOfHeroMarket>,
 		std::weak_ptr<CArtifactsOfHeroAltar>,
 		std::weak_ptr<CArtifactsOfHeroKingdom>,
@@ -28,12 +28,12 @@ public:
 		std::weak_ptr<CArtifactsOfHeroQuickBackpack>>;
 	using CloseCallback = std::function<void()>;
 
-	std::vector<CArtifactsOfHeroPtr> artSets;
+	std::vector<ArtifactsOfHeroVar> artSets;
 	CloseCallback closeCallback;
 
-	explicit CWindowWithArtifacts(const std::vector<CArtifactsOfHeroPtr> * artSets = nullptr);
-	void addSet(CArtifactsOfHeroPtr newArtSet);
-	void addSetAndCallbacks(CArtifactsOfHeroPtr newArtSet);
+	explicit CWindowWithArtifacts(const std::vector<ArtifactsOfHeroVar> * artSets = nullptr);
+	void addSet(ArtifactsOfHeroVar newArtSet);
+	void addSetAndCallbacks(ArtifactsOfHeroVar newArtSet);
 	void addCloseCallback(const CloseCallback & callback);
 	const CGHeroInstance * getHeroPickedArtifact();
 	const CArtifactInstance * getPickedArtifact();
@@ -51,8 +51,7 @@ public:
 
 protected:
 	void update() const;
-	std::optional<std::tuple<const CGHeroInstance*, const CArtifactInstance*>> getState();
-	std::optional<CArtifactsOfHeroPtr> findAOHbyRef(const CArtifactsOfHeroBase & artsInst);
+	std::optional<ArtifactsOfHeroVar> findAOHbyRef(const CArtifactsOfHeroBase & artsInst);
 	void markPossibleSlots();
 	bool checkSpecialArts(const CArtifactInstance & artInst, const CGHeroInstance * hero, bool isTrade) const;
 	void setCursorAnimation(const CArtifactInstance & artInst);

--- a/client/windows/CWindowWithArtifacts.h
+++ b/client/windows/CWindowWithArtifacts.h
@@ -39,23 +39,24 @@ public:
 	const CArtifactInstance * getPickedArtifact();
 	void clickPressedOnArtPlace(const CGHeroInstance & hero, const ArtifactPosition & slot,
 		bool allowExchange, bool altarTrading, bool closeWindow);
-	void swapArtifactAndClose(const CArtifactsOfHeroBase & artsInst, CArtPlace & artPlace, const ArtifactLocation & dstLoc);
-	void showArtifactAssembling(const CArtifactsOfHeroBase & artsInst, CArtPlace & artPlace, const Point & cursorPosition);
-	void showArifactInfo(CArtPlace & artPlace, const Point & cursorPosition);
-	void showQuickBackpackWindow(const CArtifactsOfHeroBase & artsInst, CArtPlace & artPlace, const Point & cursorPosition);
+	void swapArtifactAndClose(const CArtifactsOfHeroBase & artsInst, const ArtifactPosition & slot, const ArtifactLocation & dstLoc) const;
+	void showArtifactAssembling(const CArtifactsOfHeroBase & artsInst, CArtPlace & artPlace, const Point & cursorPosition) const;
+	void showArifactInfo(CArtPlace & artPlace, const Point & cursorPosition) const;
+	void showQuickBackpackWindow(const CGHeroInstance & hero, const ArtifactPosition & slot, const Point & cursorPosition) const;
 	void activate() override;
 	void deactivate() override;
 	void enableArtifactsCostumeSwitcher() const;
 
 	virtual void artifactRemoved(const ArtifactLocation & artLoc);
-	virtual void artifactMoved(const ArtifactLocation & srcLoc, const ArtifactLocation & destLoc, bool withRedraw);
+	virtual void artifactMoved(const ArtifactLocation & srcLoc, const ArtifactLocation & destLoc);
 	virtual void artifactDisassembled(const ArtifactLocation & artLoc);
 	virtual void artifactAssembled(const ArtifactLocation & artLoc);
+	virtual void update();
 
 protected:
-	void update();
 	void markPossibleSlots();
 	bool checkSpecialArts(const CArtifactInstance & artInst, const CGHeroInstance & hero, bool isTrade) const;
 	void setCursorAnimation(const CArtifactInstance & artInst);
 	void putPickedArtifact(const CGHeroInstance & curHero, const ArtifactPosition & targetSlot);
+	void onClickPressedCommonArtifact(const CGHeroInstance & curHero, const ArtifactPosition & slot, bool closeWindow);
 };

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -925,7 +925,7 @@ CExchangeWindow::CExchangeWindow(ObjectInstanceID hero1, ObjectInstanceID hero2,
 		}
 	}
 
-	updateWidgets();
+	update();
 }
 
 const CGarrisonSlot * CExchangeWindow::getSelectedSlotID() const
@@ -937,7 +937,7 @@ void CExchangeWindow::updateGarrisons()
 {
 	garr->recreateSlots();
 
-	updateWidgets();
+	update();
 }
 
 bool CExchangeWindow::holdsGarrison(const CArmedInstance * army)
@@ -951,8 +951,9 @@ void CExchangeWindow::questlog(int whichHero)
 	LOCPLINT->showQuestLog();
 }
 
-void CExchangeWindow::updateWidgets()
+void CExchangeWindow::update()
 {
+	CWindowWithArtifacts::update();
 	for(size_t leftRight : {0, 1})
 	{
 		const CGHeroInstance * hero = heroInst.at(leftRight);

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -763,8 +763,33 @@ CExchangeWindow::CExchangeWindow(ObjectInstanceID hero1, ObjectInstanceID hero2,
 	artifs[1] = std::make_shared<CArtifactsOfHeroMain>(Point(98, 151));
 	artifs[1]->setHero(heroInst[1]);
 
-	addSetAndCallbacks(artifs[0]);
-	addSetAndCallbacks(artifs[1]);
+	artifs[0]->clickPressedCallback = [this, heroArts = artifs[0]](CArtPlace & artPlace, const Point & cursorPosition)
+	{
+		clickPressedOnArtPlace(heroArts->getHero(), artPlace.slot, true, false, false);
+	};
+	artifs[0]->showPopupCallback = [this, heroArts = artifs[0]](CArtPlace & artPlace, const Point & cursorPosition)
+	{
+		showArtifactAssembling(*heroArts, artPlace, cursorPosition);
+	};
+	artifs[0]->gestureCallback = [this, heroArts = artifs[0]](CArtPlace & artPlace, const Point & cursorPosition)
+	{
+		showQuickBackpackWindow(heroArts->getHero(), artPlace.slot, cursorPosition);
+	};
+	artifs[1]->clickPressedCallback = [this, heroArts = artifs[1]](CArtPlace & artPlace, const Point & cursorPosition)
+	{
+		clickPressedOnArtPlace(heroArts->getHero(), artPlace.slot, true, false, false);
+	};
+	artifs[1]->showPopupCallback = [this, heroArts = artifs[1]](CArtPlace & artPlace, const Point & cursorPosition)
+	{
+		showArtifactAssembling(*heroArts, artPlace, cursorPosition);
+	};
+	artifs[1]->gestureCallback = [this, heroArts = artifs[1]](CArtPlace & artPlace, const Point & cursorPosition)
+	{
+		showQuickBackpackWindow(heroArts->getHero(), artPlace.slot, cursorPosition);
+	};
+
+	addSet(artifs[0]);
+	addSet(artifs[1]);
 
 	for(int g=0; g<4; ++g)
 	{

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -759,34 +759,15 @@ CExchangeWindow::CExchangeWindow(ObjectInstanceID hero1, ObjectInstanceID hero2,
 	}
 
 	artifs[0] = std::make_shared<CArtifactsOfHeroMain>(Point(-334, 151));
+	artifs[0]->clickPressedCallback = [this, hero = heroInst[0]](const CArtPlace & artPlace, const Point & cursorPosition){clickPressedOnArtPlace(hero, artPlace.slot, true, false, false);};
+	artifs[0]->showPopupCallback = [this, heroArts = artifs[0]](CArtPlace & artPlace, const Point & cursorPosition){showArtifactAssembling(*heroArts, artPlace, cursorPosition);};
+	artifs[0]->gestureCallback = [this, hero = heroInst[0]](const CArtPlace & artPlace, const Point & cursorPosition){showQuickBackpackWindow(hero, artPlace.slot, cursorPosition);};
 	artifs[0]->setHero(heroInst[0]);
 	artifs[1] = std::make_shared<CArtifactsOfHeroMain>(Point(98, 151));
+	artifs[1]->clickPressedCallback = [this, hero = heroInst[1]](const CArtPlace & artPlace, const Point & cursorPosition){clickPressedOnArtPlace(hero, artPlace.slot, true, false, false);};
+	artifs[1]->showPopupCallback = [this, heroArts = artifs[1]](CArtPlace & artPlace, const Point & cursorPosition){showArtifactAssembling(*heroArts, artPlace, cursorPosition);};
+	artifs[1]->gestureCallback = [this, hero = heroInst[1]](const CArtPlace & artPlace, const Point & cursorPosition){showQuickBackpackWindow(hero, artPlace.slot, cursorPosition);};
 	artifs[1]->setHero(heroInst[1]);
-
-	artifs[0]->clickPressedCallback = [this, heroArts = artifs[0]](CArtPlace & artPlace, const Point & cursorPosition)
-	{
-		clickPressedOnArtPlace(heroArts->getHero(), artPlace.slot, true, false, false);
-	};
-	artifs[0]->showPopupCallback = [this, heroArts = artifs[0]](CArtPlace & artPlace, const Point & cursorPosition)
-	{
-		showArtifactAssembling(*heroArts, artPlace, cursorPosition);
-	};
-	artifs[0]->gestureCallback = [this, heroArts = artifs[0]](CArtPlace & artPlace, const Point & cursorPosition)
-	{
-		showQuickBackpackWindow(heroArts->getHero(), artPlace.slot, cursorPosition);
-	};
-	artifs[1]->clickPressedCallback = [this, heroArts = artifs[1]](CArtPlace & artPlace, const Point & cursorPosition)
-	{
-		clickPressedOnArtPlace(heroArts->getHero(), artPlace.slot, true, false, false);
-	};
-	artifs[1]->showPopupCallback = [this, heroArts = artifs[1]](CArtPlace & artPlace, const Point & cursorPosition)
-	{
-		showArtifactAssembling(*heroArts, artPlace, cursorPosition);
-	};
-	artifs[1]->gestureCallback = [this, heroArts = artifs[1]](CArtPlace & artPlace, const Point & cursorPosition)
-	{
-		showQuickBackpackWindow(heroArts->getHero(), artPlace.slot, cursorPosition);
-	};
 
 	addSet(artifs[0]);
 	addSet(artifs[1]);
@@ -950,7 +931,7 @@ CExchangeWindow::CExchangeWindow(ObjectInstanceID hero1, ObjectInstanceID hero2,
 		}
 	}
 
-	update();
+	CWindowWithArtifacts::update();
 }
 
 const CGarrisonSlot * CExchangeWindow::getSelectedSlotID() const

--- a/client/windows/GUIClasses.h
+++ b/client/windows/GUIClasses.h
@@ -328,7 +328,7 @@ public:
 
 	void questlog(int whichHero); //questlog button callback; whichHero: 0 - left, 1 - right
 
-	void updateWidgets();
+	void update() override;
 
 	const CGarrisonSlot * getSelectedSlotID() const;
 

--- a/lib/ArtifactUtils.cpp
+++ b/lib/ArtifactUtils.cpp
@@ -19,7 +19,39 @@
 
 VCMI_LIB_NAMESPACE_BEGIN
 
+DLL_LINKAGE bool ArtifactUtils::checkIfSlotValid(const CArtifactSet & artSet, const ArtifactPosition & slot)
+{
+	if(artSet.bearerType() == ArtBearer::HERO)
+	{
+		if(isSlotEquipment(slot) || isSlotBackpack(slot) || slot == ArtifactPosition::TRANSITION_POS)
+			return true;
+	}
+	else if(artSet.bearerType() == ArtBearer::ALTAR)
+	{
+		if(isSlotBackpack(slot))
+			return true;
+	}
+	else if(artSet.bearerType() == ArtBearer::COMMANDER)
+	{
+		if(vstd::contains(commanderSlots(), slot))
+			return true;
+	}
+	else if(artSet.bearerType() == ArtBearer::CREATURE)
+	{
+		if(slot == ArtifactPosition::CREATURE_SLOT)
+			return true;
+	}
+	return false;
+}
+
 DLL_LINKAGE ArtifactPosition ArtifactUtils::getArtAnyPosition(const CArtifactSet * target, const ArtifactID & aid)
+{
+	if(auto targetSlot = getArtEquippedPosition(target, aid); targetSlot != ArtifactPosition::PRE_FIRST)
+		return targetSlot;
+	return getArtBackpackPosition(target, aid);
+}
+
+DLL_LINKAGE ArtifactPosition ArtifactUtils::getArtEquippedPosition(const CArtifactSet * target, const ArtifactID & aid)
 {
 	const auto * art = aid.toArtifact();
 	for(const auto & slot : art->getPossibleSlots().at(target->bearerType()))
@@ -27,7 +59,7 @@ DLL_LINKAGE ArtifactPosition ArtifactUtils::getArtAnyPosition(const CArtifactSet
 		if(art->canBePutAt(target, slot))
 			return slot;
 	}
-	return getArtBackpackPosition(target, aid);
+	return ArtifactPosition::PRE_FIRST;
 }
 
 DLL_LINKAGE ArtifactPosition ArtifactUtils::getArtBackpackPosition(const CArtifactSet * target, const ArtifactID & aid)

--- a/lib/ArtifactUtils.h
+++ b/lib/ArtifactUtils.h
@@ -25,8 +25,9 @@ class CMap;
 
 namespace ArtifactUtils
 {
-	// Calculates where an artifact gets placed when it gets transferred from one hero to another.
+	DLL_LINKAGE bool checkIfSlotValid(const CArtifactSet & artSet, const ArtifactPosition & slot);
 	DLL_LINKAGE ArtifactPosition getArtAnyPosition(const CArtifactSet * target, const ArtifactID & aid);
+	DLL_LINKAGE ArtifactPosition getArtEquippedPosition(const CArtifactSet * target, const ArtifactID & aid);
 	DLL_LINKAGE ArtifactPosition getArtBackpackPosition(const CArtifactSet * target, const ArtifactID & aid);
 	// TODO: Make this constexpr when the toolset is upgraded
 	DLL_LINKAGE const std::vector<ArtifactPosition> & unmovableSlots();

--- a/lib/CArtHandler.cpp
+++ b/lib/CArtHandler.cpp
@@ -897,13 +897,7 @@ const CArtifactInstance * CArtifactSet::getAssemblyByConstituent(const ArtifactI
 const ArtSlotInfo * CArtifactSet::getSlot(const ArtifactPosition & pos) const
 {
 	if(pos == ArtifactPosition::TRANSITION_POS)
-	{
-		// Always add to the end. Always take from the beginning.
-		if(artifactsTransitionPos.empty())
-			return nullptr;
-		else
-			return &(*artifactsTransitionPos.begin());
-	}
+		return &artifactsTransitionPos;
 	if(vstd::contains(artifactsWorn, pos))
 		return &artifactsWorn.at(pos);
 	if(ArtifactUtils::isSlotBackpack(pos))
@@ -936,9 +930,7 @@ void CArtifactSet::setNewArtSlot(const ArtifactPosition & slot, ConstTransitiveP
 	ArtSlotInfo * slotInfo;
 	if(slot == ArtifactPosition::TRANSITION_POS)
 	{
-		// Always add to the end. Always take from the beginning.
-		artifactsTransitionPos.emplace_back();
-		slotInfo = &artifactsTransitionPos.back();
+		slotInfo = &artifactsTransitionPos;
 	}
 	else if(ArtifactUtils::isSlotEquipment(slot))
 	{
@@ -957,8 +949,7 @@ void CArtifactSet::eraseArtSlot(const ArtifactPosition & slot)
 {
 	if(slot == ArtifactPosition::TRANSITION_POS)
 	{
-		assert(!artifactsTransitionPos.empty());
-		artifactsTransitionPos.erase(artifactsTransitionPos.begin());
+		artifactsTransitionPos.artifact = nullptr;
 	}
 	else if(ArtifactUtils::isSlotBackpack(slot))
 	{

--- a/lib/CArtHandler.h
+++ b/lib/CArtHandler.h
@@ -194,7 +194,7 @@ public:
 
 	std::vector<ArtSlotInfo> artifactsInBackpack; //hero's artifacts from bag
 	std::map<ArtifactPosition, ArtSlotInfo> artifactsWorn; //map<position,artifact_id>; positions: 0 - head; 1 - shoulders; 2 - neck; 3 - right hand; 4 - left hand; 5 - torso; 6 - right ring; 7 - left ring; 8 - feet; 9 - misc1; 10 - misc2; 11 - misc3; 12 - misc4; 13 - mach1; 14 - mach2; 15 - mach3; 16 - mach4; 17 - spellbook; 18 - misc5
-	std::vector<ArtSlotInfo> artifactsTransitionPos; // Used as transition position for dragAndDrop artifact exchange
+	ArtSlotInfo artifactsTransitionPos; // Used as transition position for dragAndDrop artifact exchange
 
 	void setNewArtSlot(const ArtifactPosition & slot, ConstTransitivePtr<CArtifactInstance> art, bool locked);
 	void eraseArtSlot(const ArtifactPosition & slot);


### PR DESCRIPTION
- [X] CWindowWithArtifacts - refactoring. Reducing code complexity.
- [X] ctrl+click; alt+click now works in the backpack window.
- [x] ctrl+click now works in the artifact altar window.
- [X] ArtifactPosition::TRANSITION_POS is now simple ArtSlotInfo. Not a vector.
- ~~Shift+click on the artifact slot should open the quick backpack window.~~