### PR TITLE
[1.5.0] Fix freeze

### DIFF
--- a/lib/network/NetworkConnection.h
+++ b/lib/network/NetworkConnection.h
@@ -19,6 +19,7 @@ class NetworkConnection : public INetworkConnection, public std::enable_shared_f
 	static const int messageMaxSize = 64 * 1024 * 1024; // arbitrary size to prevent potential massive allocation if we receive garbage input
 
 	std::shared_ptr<NetworkSocket> socket;
+	std::mutex writeMutex;
 
 	NetworkBuffer readBuffer;
 	INetworkConnectionListener & listener;

--- a/lib/network/NetworkConnection.h
+++ b/lib/network/NetworkConnection.h
@@ -19,17 +19,15 @@ class NetworkConnection : public INetworkConnection, public std::enable_shared_f
 	static const int messageMaxSize = 64 * 1024 * 1024; // arbitrary size to prevent potential massive allocation if we receive garbage input
 
 	std::shared_ptr<NetworkSocket> socket;
-	std::shared_ptr<NetworkContext> context;
 
 	NetworkBuffer readBuffer;
 	INetworkConnectionListener & listener;
 
-	void heartbeat();
 	void onHeaderReceived(const boost::system::error_code & ec);
 	void onPacketReceived(const boost::system::error_code & ec, uint32_t expectedPacketSize);
 
 public:
-	NetworkConnection(INetworkConnectionListener & listener, const std::shared_ptr<NetworkSocket> & socket, const std::shared_ptr<NetworkContext> & context);
+	NetworkConnection(INetworkConnectionListener & listener, const std::shared_ptr<NetworkSocket> & socket);
 
 	void start();
 	void close() override;

--- a/lib/network/NetworkHandler.cpp
+++ b/lib/network/NetworkHandler.cpp
@@ -34,14 +34,14 @@ void NetworkHandler::connectToRemote(INetworkClientListener & listener, const st
 	auto socket = std::make_shared<NetworkSocket>(*io);
 	boost::asio::ip::tcp::resolver resolver(*io);
 	auto endpoints = resolver.resolve(host, std::to_string(port));
-	boost::asio::async_connect(*socket, endpoints, [this, socket, &listener](const boost::system::error_code& error, const boost::asio::ip::tcp::endpoint& endpoint)
+	boost::asio::async_connect(*socket, endpoints, [socket, &listener](const boost::system::error_code& error, const boost::asio::ip::tcp::endpoint& endpoint)
 	{
 		if (error)
 		{
 			listener.onConnectionFailed(error.message());
 			return;
 		}
-		auto connection = std::make_shared<NetworkConnection>(listener, socket, io);
+		auto connection = std::make_shared<NetworkConnection>(listener, socket);
 		connection->start();
 
 		listener.onConnectionEstablished(connection);

--- a/lib/network/NetworkServer.cpp
+++ b/lib/network/NetworkServer.cpp
@@ -39,7 +39,7 @@ void NetworkServer::connectionAccepted(std::shared_ptr<NetworkSocket> upcomingCo
 	}
 
 	logNetwork->info("We got a new connection! :)");
-	auto connection = std::make_shared<NetworkConnection>(*this, upcomingConnection, io);
+	auto connection = std::make_shared<NetworkConnection>(*this, upcomingConnection);
 	connections.insert(connection);
 	connection->start();
 	listener.onNewConnection(connection);

--- a/lib/networkPacks/NetPacksBase.h
+++ b/lib/networkPacks/NetPacksBase.h
@@ -30,7 +30,7 @@ struct DLL_LINKAGE CPack
 	template <typename Handler> void serialize(Handler &h)
 	{
 		logNetwork->error("CPack serialized... this should not happen!");
-		assert(false && "CPack serialized");
+		throw std::runtime_error("CPack serialized... this should not happen!");
 	}
 
 	void applyGs(CGameState * gs)


### PR DESCRIPTION
- Fixes #3903
- Reverts #3867
- Add checks to network connection to allow addition of heartbeat packet in future without breaking format compatibility
- Replaced one assert with exception since this is critical error