### PR TITLE
Disable 'catch everything' block in RMG in favor of clean crash

### DIFF
--- a/lib/rmg/CMapGenerator.cpp
+++ b/lib/rmg/CMapGenerator.cpp
@@ -130,6 +130,7 @@ std::unique_ptr<CMap> CMapGenerator::generate()
 	catch (rmgException &e)
 	{
 		logGlobal->error("Random map generation received exception: %s", e.what());
+		throw;
 	}
 	Load::Progress::finish();
 	return std::move(map->mapInstance);


### PR DESCRIPTION
Disable try-catch block in RMG that hides any exceptions, leading to weird crashes down the line, for example on attempt to access not placed starting heroes, not existing starting town, etc.

Alternatively, we could try to regenerate maps until RMG succeed, but don't want to hide potential bugs or create infinite loop by accident.