### PR TITLE
[1.5.0] Slightly better randomization of map template

### DIFF
--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -543,7 +543,7 @@ void CGameHandler::init(StartInfo *si, Load::ProgressAccumulator & progressTrack
 {
 	if (si->seedToBeUsed == 0)
 	{
-		si->seedToBeUsed = static_cast<ui32>(std::time(nullptr));
+		si->seedToBeUsed = CRandomGenerator::getDefault().nextInt();
 	}
 	CMapService mapService;
 	gs = new CGameState();


### PR DESCRIPTION
Seeding using `std::time()` returns almost exact value - seconds since epoch, leading to a bug where picking random template for random map will always result in the same template, even after restarting the game. Since apparently, first roll on generator newly seeded with std::time() will often return same value as before (probably low bits of seed are not used for low bits of resulting number).

With this change this patter should break - our generator, even if default-constructed should give better randomization than old code.