### PR TITLE
[1.5.1] Improve performance of parsing of map headers for map list

### DIFF
--- a/lib/filesystem/CCompressedStream.cpp
+++ b/lib/filesystem/CCompressedStream.cpp
@@ -66,7 +66,9 @@ void CBufferedStream::ensureSize(si64 size)
 	{
 		si64 initialSize = buffer.size();
 		si64 currentStep = std::min<si64>(size, buffer.size());
-		vstd::amax(currentStep, 1024); // to avoid large number of calls at start
+		// to avoid large number of calls at start
+		// this is often used to load h3m map headers, most of which are ~300 bytes in size
+		vstd::amax(currentStep, 512);
 
 		buffer.resize(initialSize + currentStep);
 


### PR DESCRIPTION
Discovered by accident.

Apparently VCMI spends quite a lot time on loading & validating h3m support config from json. Normally this is quite fast operation, but when player opens map list vcmi would load this config for every map entry separately. So if you have 100 maps vcmi would load map format config 100 times.

With this change map format info will be loaded only once, on first map access.