### PR TITLE
[1.5.1] Fixed mouse double-click handling in some widgets

### DIFF
--- a/client/lobby/SelectionTab.cpp
+++ b/client/lobby/SelectionTab.cpp
@@ -358,6 +358,17 @@ void SelectionTab::clickDouble(const Point & cursorPosition)
 	if(itemIndex >= curItems.size())
 		return;
 
+	auto clickedItem = curItems[itemIndex];
+	auto selectedItem = getSelectedMapInfo();
+
+	if (clickedItem != selectedItem)
+	{
+		// double-click BUT player hit different item than he had selected
+		// ignore - clickReleased would still trigger and update selection.
+		// After which another (3rd) click if it happens would still register as double-click
+		return;
+	}
+
 	if(itemIndex >= 0 && curItems[itemIndex]->isFolder)
 	{
 		select(position);

--- a/client/widgets/CComponent.cpp
+++ b/client/widgets/CComponent.cpp
@@ -335,8 +335,15 @@ void CSelectableComponent::clickPressed(const Point & cursorPosition)
 
 void CSelectableComponent::clickDouble(const Point & cursorPosition)
 {
-	if(onChoose)
-		onChoose();
+	if (!selected)
+	{
+		clickPressed(cursorPosition);
+	}
+	else
+	{
+		if (onChoose)
+			onChoose();
+	}
 }
 
 void CSelectableComponent::init()

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -616,6 +616,9 @@ void CTavernWindow::HeroPortrait::clickDouble(const Point & cursorPosition)
 
 void CTavernWindow::HeroPortrait::showPopupWindow(const Point & cursorPosition)
 {
+	// h3 behavior - right-click also selects hero
+	clickPressed(cursorPosition);
+
 	if(h)
 		GH.windows().createAndPushWindow<CRClickPopupInt>(std::make_shared<CHeroWindow>(h));
 }
@@ -1712,6 +1715,12 @@ void CObjectListWindow::CItem::clickPressed(const Point & cursorPosition)
 
 void CObjectListWindow::CItem::clickDouble(const Point & cursorPosition)
 {
+	if (parent->selected != index)
+	{
+		clickPressed(cursorPosition);
+		return;
+	}
+
 	parent->elementSelected();
 }
 


### PR DESCRIPTION
Now double-click when 1st click was not inside widget should work as expected:
- scenario list: 2nd click on non-selected scenario will select it instead of starting unselected map
- component selection (e.g. levelup): 2nd click on non-selected component would select it instead of confirming choice
- town portal dialog: 2nd click on non-selected town would only select it
- tavern window: right-click would now also select this hero (h3 logic)