### PR TITLE
[1.5.1] Retaliation preview

### DIFF
--- a/Mods/vcmi/config/vcmi/english.json
+++ b/Mods/vcmi/config/vcmi/english.json
@@ -252,6 +252,13 @@
 	"vcmi.battleWindow.damageEstimation.damage.1" : "%d damage",
 	"vcmi.battleWindow.damageEstimation.kills" : "%d will perish",
 	"vcmi.battleWindow.damageEstimation.kills.1" : "%d will perish",
+	
+	"vcmi.battleWindow.damageRetaliation.will" : "Will retaliate ",
+	"vcmi.battleWindow.damageRetaliation.may" : "May retaliate ",
+	"vcmi.battleWindow.damageRetaliation.never" : "Will not retaliate.",
+	"vcmi.battleWindow.damageRetaliation.damage" : "(%DAMAGE).",
+	"vcmi.battleWindow.damageRetaliation.damageKills" : "(%DAMAGE, %KILLS).",
+	
 	"vcmi.battleWindow.killed" : "Killed",
 	"vcmi.battleWindow.accurateShot.resultDescription.0" : "%d %s were killed by accurate shots!",
 	"vcmi.battleWindow.accurateShot.resultDescription.1" : "%d %s was killed with an accurate shot!",

--- a/Mods/vcmi/config/vcmi/ukrainian.json
+++ b/Mods/vcmi/config/vcmi/ukrainian.json
@@ -241,11 +241,19 @@
 	"vcmi.battleWindow.damageEstimation.rangedKills" : "Стріляти в %CREATURE (%SHOTS, %DAMAGE, %KILLS).",
 	"vcmi.battleWindow.damageEstimation.shots" : "%d пострілів залишилось",
 	"vcmi.battleWindow.damageEstimation.shots.1" : "%d постріл залишився",
-	"vcmi.battleWindow.damageEstimation.damage" : "%d одиниць пошкоджень",
-	"vcmi.battleWindow.damageEstimation.damage.1" : "%d одиниця пошкодження",
+	"vcmi.battleWindow.damageEstimation.damage" : "%d пошкоджень",
+	"vcmi.battleWindow.damageEstimation.damage.1" : "%d пошкодження",
 	"vcmi.battleWindow.damageEstimation.kills" : "%d загинуть",
 	"vcmi.battleWindow.damageEstimation.kills.1" : "%d загине",
+	
+	"vcmi.battleWindow.damageRetaliation.will" : "Буде відповідати ",
+	"vcmi.battleWindow.damageRetaliation.may" : "Може відповісти ",
+	"vcmi.battleWindow.damageRetaliation.never" : "Не буде відповідати.",
+	"vcmi.battleWindow.damageRetaliation.damage" : "(%DAMAGE).",
+	"vcmi.battleWindow.damageRetaliation.damageKills" : "(%DAMAGE, %KILLS).",
+	
 	"vcmi.battleWindow.killed" : "Загинуло",
+	
 	"vcmi.battleWindow.accurateShot.resultDescription.0" : "%d %s було вбито влучними пострілами!",
 	"vcmi.battleWindow.accurateShot.resultDescription.1" : "%d %s було вбито влучним пострілом!",
 	"vcmi.battleWindow.accurateShot.resultDescription.2" : "%d %s було вбито влучними пострілами!",

--- a/client/battle/BattleActionsController.cpp
+++ b/client/battle/BattleActionsController.cpp
@@ -114,6 +114,22 @@ static std::string formatRangedAttack(const DamageEstimation & estimation, const
 	return formatAttack(estimation, creatureName, baseTextID, shotsLeft);
 }
 
+static std::string formatRetaliation(const DamageEstimation & estimation, bool mayBeKilled)
+{
+	if (estimation.damage.max == 0)
+		return CGI->generaltexth->translate("vcmi.battleWindow.damageRetaliation.never");
+
+	std::string baseTextID = estimation.kills.max == 0 ?
+								 "vcmi.battleWindow.damageRetaliation.damage" :
+								 "vcmi.battleWindow.damageRetaliation.damageKills";
+
+	std::string prefixTextID = mayBeKilled ?
+		"vcmi.battleWindow.damageRetaliation.will" :
+		"vcmi.battleWindow.damageRetaliation.may";
+
+	return CGI->generaltexth->translate(prefixTextID) + formatAttack(estimation, "", baseTextID, 0);
+}
+
 BattleActionsController::BattleActionsController(BattleInterface & owner):
 	owner(owner),
 	selectedStack(nullptr),
@@ -484,22 +500,31 @@ std::string BattleActionsController::actionGetStatusMessage(PossiblePlayerBattle
 		case PossiblePlayerBattleAction::ATTACK_AND_RETURN: //TODO: allow to disable return
 			{
 				BattleHex attackFromHex = owner.fieldController->fromWhichHexAttack(targetHex);
-				DamageEstimation estimation = owner.getBattle()->battleEstimateDamage(owner.stacksController->getActiveStack(), targetStack, attackFromHex);
+				DamageEstimation retaliation;
+				DamageEstimation estimation = owner.getBattle()->battleEstimateDamage(owner.stacksController->getActiveStack(), targetStack, attackFromHex, &retaliation);
 				estimation.kills.max = std::min<int64_t>(estimation.kills.max, targetStack->getCount());
 				estimation.kills.min = std::min<int64_t>(estimation.kills.min, targetStack->getCount());
+				bool enemyMayBeKilled = estimation.kills.max == targetStack->getCount();
 
-				return formatMeleeAttack(estimation, targetStack->getName());
+				return formatMeleeAttack(estimation, targetStack->getName()) + "\n" + formatRetaliation(retaliation, enemyMayBeKilled);
 			}
 
 		case PossiblePlayerBattleAction::SHOOT:
 		{
 			const auto * shooter = owner.stacksController->getActiveStack();
 
-			DamageEstimation estimation = owner.getBattle()->battleEstimateDamage(shooter, targetStack, shooter->getPosition());
+			DamageEstimation retaliation;
+			DamageEstimation estimation = owner.getBattle()->battleEstimateDamage(shooter, targetStack, shooter->getPosition(), &retaliation);
 			estimation.kills.max = std::min<int64_t>(estimation.kills.max, targetStack->getCount());
 			estimation.kills.min = std::min<int64_t>(estimation.kills.min, targetStack->getCount());
+			bool enemyMayBeKilled = estimation.kills.max == targetStack->getCount();
+			bool mayRetaliate = retaliation.damage.max > 0;
 
-			return formatRangedAttack(estimation, targetStack->getName(), shooter->shots.available());
+			// for ranged attacks only show retaliation info if retaliation actually happens - since most shooters don't retaliate
+			if (mayRetaliate)
+				return formatRangedAttack(estimation, targetStack->getName(), shooter->shots.available()) + "\n" + formatRetaliation(retaliation, enemyMayBeKilled);
+			else
+				return formatRangedAttack(estimation, targetStack->getName(), shooter->shots.available());
 		}
 
 		case PossiblePlayerBattleAction::AIMED_SPELL_CREATURE:

--- a/client/battle/BattleActionsController.cpp
+++ b/client/battle/BattleActionsController.cpp
@@ -124,8 +124,8 @@ static std::string formatRetaliation(const DamageEstimation & estimation, bool m
 								 "vcmi.battleWindow.damageRetaliation.damageKills";
 
 	std::string prefixTextID = mayBeKilled ?
-		"vcmi.battleWindow.damageRetaliation.will" :
-		"vcmi.battleWindow.damageRetaliation.may";
+		"vcmi.battleWindow.damageRetaliation.may" :
+		"vcmi.battleWindow.damageRetaliation.will";
 
 	return CGI->generaltexth->translate(prefixTextID) + formatAttack(estimation, "", baseTextID, 0);
 }
@@ -517,14 +517,7 @@ std::string BattleActionsController::actionGetStatusMessage(PossiblePlayerBattle
 			DamageEstimation estimation = owner.getBattle()->battleEstimateDamage(shooter, targetStack, shooter->getPosition(), &retaliation);
 			estimation.kills.max = std::min<int64_t>(estimation.kills.max, targetStack->getCount());
 			estimation.kills.min = std::min<int64_t>(estimation.kills.min, targetStack->getCount());
-			bool enemyMayBeKilled = estimation.kills.max == targetStack->getCount();
-			bool mayRetaliate = retaliation.damage.max > 0;
-
-			// for ranged attacks only show retaliation info if retaliation actually happens - since most shooters don't retaliate
-			if (mayRetaliate)
-				return formatRangedAttack(estimation, targetStack->getName(), shooter->shots.available()) + "\n" + formatRetaliation(retaliation, enemyMayBeKilled);
-			else
-				return formatRangedAttack(estimation, targetStack->getName(), shooter->shots.available());
+			return formatRangedAttack(estimation, targetStack->getName(), shooter->shots.available());
 		}
 
 		case PossiblePlayerBattleAction::AIMED_SPELL_CREATURE:

--- a/lib/battle/CBattleInfoCallback.cpp
+++ b/lib/battle/CBattleInfoCallback.cpp
@@ -760,7 +760,7 @@ DamageEstimation CBattleInfoCallback::battleEstimateDamage(const BattleAttackInf
 
 	DamageEstimation ret = calculateDmgRange(bai);
 
-	if(retaliationDmg)
+	if(retaliationDmg && bai.defender->ableToRetaliate())
 	{
 		if(bai.shooting)
 		{
@@ -782,7 +782,7 @@ DamageEstimation CBattleInfoCallback::battleEstimateDamage(const BattleAttackInf
 			};
 
 			DamageEstimation retaliationMin = estimateRetaliation(ret.damage.min);
-			DamageEstimation retaliationMax = estimateRetaliation(ret.damage.min);
+			DamageEstimation retaliationMax = estimateRetaliation(ret.damage.max);
 
 			retaliationDmg->damage.min = std::min(retaliationMin.damage.min, retaliationMax.damage.min);
 			retaliationDmg->damage.max = std::max(retaliationMin.damage.max, retaliationMax.damage.max);


### PR DESCRIPTION
Show retaliation preview when hovering over units that can be attacked.

Does not accounts for luck / abilities for both sides.
If enemy will be killed or spent all retaliations text would change to "Will not retaliate".
In case if enemy may be killed (and retaliation might not happen) text would change to "May retaliate" instead of "Will retaliate"

- Fixes #1760 

![зображення](https://github.com/vcmi/vcmi/assets/1576820/27f39ef5-d503-4e4e-96aa-87379b36dbfc)
