### PR TITLE
Implement github action to produce source code archive with submodules for release

### DIFF
--- a/.github/workflows/github.yml
+++ b/.github/workflows/github.yml
@@ -387,25 +387,31 @@ jobs:
 
 
   deploy-src:
+    if: always() && github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     defaults:
       run:
-        shell: pwsh
+        shell: bash
     steps:
         - uses: actions/checkout@v4
           with:
             submodules: recursive
+
+        - name: Build Number
+          run: |
+            source '${{github.workspace}}/CI/get_package_name.sh'
+            echo VCMI_PACKAGE_FILE_NAME="$VCMI_PACKAGE_FILE_NAME" >> $GITHUB_ENV
             
         - name: Create source code archive (including submodules)
           run: |
-            git archive HEAD -o "release.zip" --worktree-attributes -v
+            git archive HEAD -o "release.tar" --worktree-attributes -v
             git submodule update --init --recursive
-            git submodule --quiet foreach 'cd "$toplevel"; zip -ru "release.zip" "$sm_path"'
-            unzip -q release.zip -d ./src
+            git submodule --quiet foreach 'cd "$toplevel"; tar -rvf "release.tar" "$sm_path"'
+            gzip release.tar
             
         - name: Upload source code archive
           uses: actions/upload-artifact@v4
           with:
-            name: src
+            name: ${{ env.VCMI_PACKAGE_FILE_NAME }}
             path: |
-              ./src
+              ./release.tar.gz

--- a/.github/workflows/github.yml
+++ b/.github/workflows/github.yml
@@ -384,3 +384,28 @@ jobs:
         name: ${{ env.VCMI_PACKAGE_FILE_NAME }}
         path: |
           ${{ env.ANDROID_APK_PATH }}
+
+
+  deploy-src:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: pwsh
+    steps:
+        - uses: actions/checkout@v4
+          with:
+            submodules: recursive
+            
+        - name: Create source code archive (including submodules)
+          run: |
+            git archive HEAD -o "release.zip" --worktree-attributes -v
+            git submodule update --init --recursive
+            git submodule --quiet foreach 'cd "$toplevel"; zip -ru "release.zip" "$sm_path"'
+            unzip -q release.zip -d ./src
+            
+        - name: Upload source code archive
+          uses: actions/upload-artifact@v4
+          with:
+            name: src
+            path: |
+              ./src


### PR DESCRIPTION
After giving some thoughts at #3923, I realized that shouldn't be too hard and won't add much burden to support. Please, feel free to close the PR if you think this doesn't fit the project well.
I also had to add the `unzip -q release.zip -d ./src` part, because github upload action always wraps result in a `.zip` archive, and that would produce archive in archive.. ugh.