### PR TITLE
[1.5.1] Fixes for issues with lobby server

### DIFF
--- a/lib/network/NetworkConnection.cpp
+++ b/lib/network/NetworkConnection.cpp
@@ -12,12 +12,12 @@
 
 VCMI_LIB_NAMESPACE_BEGIN
 
-NetworkConnection::NetworkConnection(INetworkConnectionListener & listener, const std::shared_ptr<NetworkSocket> & socket)
+NetworkConnection::NetworkConnection(INetworkConnectionListener & listener, const std::shared_ptr<NetworkSocket> & socket, const std::shared_ptr<NetworkContext> & context)
 	: socket(socket)
+	, context(context)
 	, listener(listener)
 {
 	socket->set_option(boost::asio::ip::tcp::no_delay(true));
-	socket->set_option(boost::asio::socket_base::keep_alive(true));
 
 	// iOS throws exception on attempt to set buffer size
 	constexpr auto bufferSize = 4 * 1024 * 1024;
@@ -43,10 +43,30 @@ NetworkConnection::NetworkConnection(INetworkConnectionListener & listener, cons
 
 void NetworkConnection::start()
 {
+	heartbeat();
+
 	boost::asio::async_read(*socket,
 							readBuffer,
 							boost::asio::transfer_exactly(messageHeaderSize),
 							[self = shared_from_this()](const auto & ec, const auto & endpoint) { self->onHeaderReceived(ec); });
+}
+
+void NetworkConnection::heartbeat()
+{
+	constexpr auto heartbeatInterval = std::chrono::seconds(10);
+
+	auto timer = std::make_shared<NetworkTimer>(*context, heartbeatInterval);
+	timer->async_wait( [self = shared_from_this(), timer](const auto & ec)
+	{
+		if (ec)
+			return;
+
+		if (!self->socket->is_open())
+			return;
+
+		self->sendPacket({});
+		self->heartbeat();
+	});
 }
 
 void NetworkConnection::onHeaderReceived(const boost::system::error_code & ecHeader)
@@ -71,7 +91,7 @@ void NetworkConnection::onHeaderReceived(const boost::system::error_code & ecHea
 
 	if (messageSize == 0)
 	{
-		// Zero-sized packet. Strange, but safe to ignore. Start reading next packet
+		//heartbeat package with no payload - wait for next packet
 		start();
 		return;
 	}

--- a/lib/network/NetworkConnection.h
+++ b/lib/network/NetworkConnection.h
@@ -18,6 +18,7 @@ class NetworkConnection : public INetworkConnection, public std::enable_shared_f
 	static const int messageHeaderSize = sizeof(uint32_t);
 	static const int messageMaxSize = 64 * 1024 * 1024; // arbitrary size to prevent potential massive allocation if we receive garbage input
 
+	std::list<std::vector<std::byte>> dataToSend;
 	std::shared_ptr<NetworkSocket> socket;
 	std::mutex writeMutex;
 
@@ -26,6 +27,9 @@ class NetworkConnection : public INetworkConnection, public std::enable_shared_f
 
 	void onHeaderReceived(const boost::system::error_code & ec);
 	void onPacketReceived(const boost::system::error_code & ec, uint32_t expectedPacketSize);
+
+	void doSendData();
+	void onDataSent(const boost::system::error_code & ec);
 
 public:
 	NetworkConnection(INetworkConnectionListener & listener, const std::shared_ptr<NetworkSocket> & socket);

--- a/lib/network/NetworkConnection.h
+++ b/lib/network/NetworkConnection.h
@@ -20,11 +20,13 @@ class NetworkConnection : public INetworkConnection, public std::enable_shared_f
 
 	std::list<std::vector<std::byte>> dataToSend;
 	std::shared_ptr<NetworkSocket> socket;
+	std::shared_ptr<NetworkContext> context;
 	std::mutex writeMutex;
 
 	NetworkBuffer readBuffer;
 	INetworkConnectionListener & listener;
 
+	void heartbeat();
 	void onHeaderReceived(const boost::system::error_code & ec);
 	void onPacketReceived(const boost::system::error_code & ec, uint32_t expectedPacketSize);
 
@@ -32,7 +34,7 @@ class NetworkConnection : public INetworkConnection, public std::enable_shared_f
 	void onDataSent(const boost::system::error_code & ec);
 
 public:
-	NetworkConnection(INetworkConnectionListener & listener, const std::shared_ptr<NetworkSocket> & socket);
+	NetworkConnection(INetworkConnectionListener & listener, const std::shared_ptr<NetworkSocket> & socket, const std::shared_ptr<NetworkContext> & context);
 
 	void start();
 	void close() override;

--- a/lib/network/NetworkConnection.h
+++ b/lib/network/NetworkConnection.h
@@ -20,13 +20,15 @@ class NetworkConnection : public INetworkConnection, public std::enable_shared_f
 
 	std::list<std::vector<std::byte>> dataToSend;
 	std::shared_ptr<NetworkSocket> socket;
-	std::shared_ptr<NetworkContext> context;
+	std::shared_ptr<NetworkTimer> timer;
 	std::mutex writeMutex;
 
 	NetworkBuffer readBuffer;
 	INetworkConnectionListener & listener;
 
 	void heartbeat();
+
+	void startReceiving();
 	void onHeaderReceived(const boost::system::error_code & ec);
 	void onPacketReceived(const boost::system::error_code & ec, uint32_t expectedPacketSize);
 

--- a/lib/network/NetworkHandler.cpp
+++ b/lib/network/NetworkHandler.cpp
@@ -35,7 +35,7 @@ void NetworkHandler::connectToRemote(INetworkClientListener & listener, const st
 	auto resolver = std::make_shared<boost::asio::ip::tcp::resolver>(*io);
 
 	resolver->async_resolve(host, std::to_string(port),
-	[&listener, resolver, socket](const boost::system::error_code& error, const boost::asio::ip::tcp::resolver::results_type & endpoints)
+	[this, &listener, resolver, socket](const boost::system::error_code& error, const boost::asio::ip::tcp::resolver::results_type & endpoints)
 	{
 		if (error)
 		{
@@ -43,7 +43,7 @@ void NetworkHandler::connectToRemote(INetworkClientListener & listener, const st
 			return;
 		}
 
-		boost::asio::async_connect(*socket, endpoints, [socket, &listener](const boost::system::error_code& error, const boost::asio::ip::tcp::endpoint& endpoint)
+		boost::asio::async_connect(*socket, endpoints, [this, socket, &listener](const boost::system::error_code& error, const boost::asio::ip::tcp::endpoint& endpoint)
 		{
 			if (error)
 			{

--- a/lib/network/NetworkHandler.cpp
+++ b/lib/network/NetworkHandler.cpp
@@ -50,7 +50,7 @@ void NetworkHandler::connectToRemote(INetworkClientListener & listener, const st
 				listener.onConnectionFailed(error.message());
 				return;
 			}
-			auto connection = std::make_shared<NetworkConnection>(listener, socket);
+			auto connection = std::make_shared<NetworkConnection>(listener, socket, io);
 			connection->start();
 
 			listener.onConnectionEstablished(connection);

--- a/lib/network/NetworkServer.cpp
+++ b/lib/network/NetworkServer.cpp
@@ -39,7 +39,7 @@ void NetworkServer::connectionAccepted(std::shared_ptr<NetworkSocket> upcomingCo
 	}
 
 	logNetwork->info("We got a new connection! :)");
-	auto connection = std::make_shared<NetworkConnection>(*this, upcomingConnection);
+	auto connection = std::make_shared<NetworkConnection>(*this, upcomingConnection, io);
 	connections.insert(connection);
 	connection->start();
 	listener.onNewConnection(connection);


### PR DESCRIPTION
- Use async_write to prevent locks if receiver is too slow causing TCP stream to pause and wait for buffers to free. Likely the cause of lobby freeze yesterday evening. 
- Restored (and fixed) heartbeat PR to detect disconnections