### PR TITLE
Fix "bonusing" town building visiting hero order

### DIFF
--- a/lib/mapObjects/CGTownInstance.cpp
+++ b/lib/mapObjects/CGTownInstance.cpp
@@ -544,11 +544,11 @@ void CGTownInstance::newTurn(CRandomGenerator & rand) const
 
 		//get Mana Vortex or Stables bonuses
 		//same code is in the CGameHandler::buildStructure method
+		if (garrisonHero != nullptr) //garrison hero first - consistent with original H3 Mana Vortex and Battle Scholar Academy levelup windows order
+			cb->visitCastleObjects(this, garrisonHero);
+
 		if (visitingHero != nullptr)
 			cb->visitCastleObjects(this, visitingHero);
-
-		if (garrisonHero != nullptr)
-			cb->visitCastleObjects(this, garrisonHero);
 
 		if (tempOwner == PlayerColor::NEUTRAL) //garrison growth for neutral towns
 		{

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -2434,10 +2434,10 @@ bool CGameHandler::buildStructure(ObjectInstanceID tid, BuildingID requestedID, 
 	// now when everything is built - reveal tiles for lookout tower
 	changeFogOfWar(t->getSightCenter(), t->getSightRadius(), t->getOwner(), ETileVisibility::REVEALED);
 
+	if(t->garrisonHero) //garrison hero first - consistent with original H3 Mana Vortex and Battle Scholar Academy levelup windows order
+		visitCastleObjects(t, t->garrisonHero);
 	if(t->visitingHero)
 		visitCastleObjects(t, t->visitingHero);
-	if(t->garrisonHero)
-		visitCastleObjects(t, t->garrisonHero);
 
 	checkVictoryLossConditionsForPlayer(t->tempOwner);
 	return true;


### PR DESCRIPTION
Caught on Keszu's stream

Fixes priority of heroes for mana vortex and battle scholar academy to match H3 (garrisoned hero first). Tested battle scholar academy, spellbook purchasing, blacksmith, freelancers guild and magic university for potential problems and all work OK.

Additional info: before this PR bonus was autogranted to garrisoned hero automatically without town visit on new week if there was no visiting hero, so new behavior is more in-line with this as well.