### PR TITLE
map editor: fix prison hero selection

### DIFF
--- a/mapeditor/inspector/inspector.cpp
+++ b/mapeditor/inspector/inspector.cpp
@@ -317,7 +317,7 @@ void Inspector::updateProperties(CGHeroInstance * o)
 	addProperty("Skills", PropertyEditorPlaceholder(), delegate, false);
 	addProperty("Spells", PropertyEditorPlaceholder(), new HeroSpellDelegate(*o), false);
 	
-	if(o->type)
+	if(o->type || o->ID == Obj::PRISON)
 	{ //Hero type
 		auto * delegate = new InspectorDelegate;
 		for(int i = 0; i < VLC->heroh->objects.size(); ++i)
@@ -330,7 +330,7 @@ void Inspector::updateProperties(CGHeroInstance * o)
 				}
 			}
 		}
-		addProperty("Hero type", o->type->getNameTranslated(), delegate, false);
+		addProperty("Hero type", o->type ? o->type->getNameTranslated() : "", delegate, false);
 	}
 }
 


### PR DESCRIPTION
allow to select any hero if this is prison, rather quick fix, would be better to have more user friendly thing than flat list with all heroes but better than nothing