### PR TITLE
[1.5.1] Fixes for lobby UI

### DIFF
--- a/client/globalLobby/GlobalLobbyClient.cpp
+++ b/client/globalLobby/GlobalLobbyClient.cpp
@@ -169,9 +169,10 @@ void GlobalLobbyClient::receiveChatMessage(const JsonNode & json)
 	{
 		lobbyWindowPtr->onGameChatMessage(message.displayName, message.messageText, message.timeFormatted, channelType, channelName);
 		lobbyWindowPtr->refreshChatText();
-	}
 
-	CCS->soundh->playSound(AudioPath::builtin("CHAT"));
+		if(channelType == "player" || lobbyWindowPtr->isChannelOpen(channelType, channelName))
+			CCS->soundh->playSound(AudioPath::builtin("CHAT"));
+	}
 }
 
 void GlobalLobbyClient::receiveActiveAccounts(const JsonNode & json)

--- a/client/globalLobby/GlobalLobbyClient.cpp
+++ b/client/globalLobby/GlobalLobbyClient.cpp
@@ -144,6 +144,9 @@ void GlobalLobbyClient::receiveChatHistory(const JsonNode & json)
 		if(lobbyWindowPtr && lobbyWindowPtr->isChannelOpen(channelType, channelName))
 			lobbyWindowPtr->onGameChatMessage(message.displayName, message.messageText, message.timeFormatted, channelType, channelName);
 	}
+
+	if(lobbyWindowPtr && lobbyWindowPtr->isChannelOpen(channelType, channelName))
+		lobbyWindowPtr->refreshChatText();
 }
 
 void GlobalLobbyClient::receiveChatMessage(const JsonNode & json)
@@ -163,7 +166,10 @@ void GlobalLobbyClient::receiveChatMessage(const JsonNode & json)
 
 	auto lobbyWindowPtr = lobbyWindow.lock();
 	if(lobbyWindowPtr)
+	{
 		lobbyWindowPtr->onGameChatMessage(message.displayName, message.messageText, message.timeFormatted, channelType, channelName);
+		lobbyWindowPtr->refreshChatText();
+	}
 
 	CCS->soundh->playSound(AudioPath::builtin("CHAT"));
 }
@@ -270,6 +276,7 @@ void GlobalLobbyClient::receiveInviteReceived(const JsonNode & json)
 
 		lobbyWindowPtr->onGameChatMessage("System", message, time, "player", accountID);
 		lobbyWindowPtr->onInviteReceived(gameRoomID);
+		lobbyWindowPtr->refreshChatText();
 	}
 
 	CCS->soundh->playSound(AudioPath::builtin("CHAT"));

--- a/client/globalLobby/GlobalLobbyWindow.cpp
+++ b/client/globalLobby/GlobalLobbyWindow.cpp
@@ -58,6 +58,8 @@ void GlobalLobbyWindow::doOpenChannel(const std::string & channelType, const std
 	for(const auto & entry : history)
 		onGameChatMessage(entry.displayName, entry.messageText, entry.timeFormatted, channelType, channelName);
 
+	refreshChatText();
+
 	MetaString text;
 	text.appendTextID("vcmi.lobby.header.chat." + channelType);
 	text.replaceRawString(roomDescription);
@@ -133,7 +135,9 @@ void GlobalLobbyWindow::onGameChatMessage(const std::string & sender, const std:
 	chatMessageFormatted.replaceRawString(message);
 
 	chatHistory += chatMessageFormatted.toString();
-
+}
+void GlobalLobbyWindow::refreshChatText()
+{
 	widget->getGameChat()->setText(chatHistory);
 }
 

--- a/client/globalLobby/GlobalLobbyWindow.cpp
+++ b/client/globalLobby/GlobalLobbyWindow.cpp
@@ -19,9 +19,9 @@
 #include "../gui/CGuiHandler.h"
 #include "../gui/WindowHandler.h"
 #include "../widgets/TextControls.h"
+#include "../widgets/Slider.h"
 #include "../widgets/ObjectLists.h"
 
-#include "../../lib/CConfigHandler.h"
 #include "../../lib/Languages.h"
 #include "../../lib/MetaString.h"
 #include "../../lib/TextOperations.h"
@@ -139,6 +139,8 @@ void GlobalLobbyWindow::onGameChatMessage(const std::string & sender, const std:
 void GlobalLobbyWindow::refreshChatText()
 {
 	widget->getGameChat()->setText(chatHistory);
+	if (widget->getGameChat()->slider)
+		widget->getGameChat()->slider->scrollToMax();
 }
 
 bool GlobalLobbyWindow::isChannelUnread(const std::string & channelType, const std::string & channelName) const

--- a/client/globalLobby/GlobalLobbyWindow.cpp
+++ b/client/globalLobby/GlobalLobbyWindow.cpp
@@ -51,7 +51,6 @@ void GlobalLobbyWindow::doOpenChannel(const std::string & channelType, const std
 	currentChannelName = channelName;
 	chatHistory.clear();
 	unreadChannels.erase(channelType + "_" + channelName);
-	widget->getGameChat()->setText("");
 
 	auto history = CSH->getGlobalLobby().getChannelHistory(channelType, channelName);
 

--- a/client/globalLobby/GlobalLobbyWindow.h
+++ b/client/globalLobby/GlobalLobbyWindow.h
@@ -44,6 +44,7 @@ public:
 	// Callbacks for network packs
 
 	void onGameChatMessage(const std::string & sender, const std::string & message, const std::string & when, const std::string & channelType, const std::string & channelName);
+	void refreshChatText();
 	void onActiveAccounts(const std::vector<GlobalLobbyAccount> & accounts);
 	void onActiveRooms(const std::vector<GlobalLobbyRoom> & rooms);
 	void onMatchesHistory(const std::vector<GlobalLobbyRoom> & history);

--- a/client/widgets/TextControls.cpp
+++ b/client/widgets/TextControls.cpp
@@ -409,6 +409,7 @@ void CTextBox::setText(const std::string & text)
 	{
 		// slider is no longer needed
 		slider.reset();
+		label->scrollTextTo(0);
 	}
 	else if(slider)
 	{


### PR DESCRIPTION
- Fixed text not being visible after switching between channels. Was caused by textbox keeping its scroll position even after slider has been removed
- Fixed noticeable UI lag on switching to channel with large number of chat messages
- Chat history will be automatically scrolled to the end on new chat message
- Chat sound will now be played only for new messages in current channel or for all private messages

All fixes in this PR are client-side, so no need to update lobby server

(will add more fixes tomorrow)