### PR TITLE
Do not darken background for small windows by default

### DIFF
--- a/config/schemas/settings.json
+++ b/config/schemas/settings.json
@@ -374,7 +374,7 @@
 				},
 				"backgroundDimSmallWindows" : {
 					"type" : "boolean",
-					"default" : true
+					"default" : false
 				}
 			}
 		},


### PR DESCRIPTION
Changes behavior to fit base H3, and in case for windows with size larger than 800x600 the behavior will be in-line with HD mod