### PR TITLE
Fix compilation issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -365,7 +365,7 @@ if(MINGW OR MSVC)
 		# Prevent compiler issues when building Debug
 		# Assembler might fail with "too many sections"
 		# With big-obj or 64-bit build will take hours
-		if(CMAKE_BUILD_TYPE MATCHES Debug)
+		if(CMAKE_BUILD_TYPE STREQUAL "Debug")
 			set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Og")
 		endif()
 	endif(MINGW)
@@ -400,7 +400,7 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR NOT WIN32)
 		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error=array-bounds") # false positives in boost::multiarray during release build, keep as warning-only
 	endif()
 
-	if(CMAKE_BUILD_TYPE MATCHES Debug)
+	if(CMAKE_BUILD_TYPE STREQUAL "Debug")
 		if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND NOT WIN32)
 			# For gcc 14+ we can use -fhardened instead
 			set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_FORTIFY_SOURCE=2 -D_GLIBCXX_ASSERTIONS -fstack-protector-strong -fstack-clash-protection -fcf-protection=full")
@@ -742,7 +742,7 @@ if(WIN32)
 				"${CMAKE_FIND_ROOT_PATH}/bin/*.dll")
 	endif()
 
-	if(CMAKE_BUILD_TYPE MATCHES Debug)
+	if(CMAKE_BUILD_TYPE STREQUAL "Debug")
 		# Copy debug versions of libraries if build type is debug
 		set(debug_postfix d)
 	endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -403,7 +403,7 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR NOT WIN32)
 	if(CMAKE_BUILD_TYPE STREQUAL "Debug")
 		if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND NOT WIN32)
 			# For gcc 14+ we can use -fhardened instead
-			set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_FORTIFY_SOURCE=2 -D_GLIBCXX_ASSERTIONS -fstack-protector-strong -fstack-clash-protection -fcf-protection=full")
+			set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_GLIBCXX_ASSERTIONS -fstack-protector-strong -fstack-clash-protection -fcf-protection=full")
 		endif()
 	endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -400,9 +400,11 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR NOT WIN32)
 		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error=array-bounds") # false positives in boost::multiarray during release build, keep as warning-only
 	endif()
 
-	if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND NOT WIN32)
-		# For gcc 14+ we can use -fhardened instead
-		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_FORTIFY_SOURCE=2 -D_GLIBCXX_ASSERTIONS -fstack-protector-strong -fstack-clash-protection -fcf-protection=full")
+	if(CMAKE_BUILD_TYPE MATCHES Debug)
+		if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND NOT WIN32)
+			# For gcc 14+ we can use -fhardened instead
+			set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_FORTIFY_SOURCE=2 -D_GLIBCXX_ASSERTIONS -fstack-protector-strong -fstack-clash-protection -fcf-protection=full")
+		endif()
 	endif()
 
 	# Fix string inspection with lldb

--- a/lib/CThreadHelper.cpp
+++ b/lib/CThreadHelper.cpp
@@ -107,10 +107,14 @@ void setThreadName(const std::string &name)
 
 #elif defined(VCMI_APPLE)
 	pthread_setname_np(name.c_str());
+#elif defined(VCMI_FREEBSD)
+	pthread_setname_np(pthread_self(), name.c_str());
 #elif defined(VCMI_HAIKU)
 	rename_thread(find_thread(NULL), name.c_str());
 #elif defined(VCMI_UNIX)
 	prctl(PR_SET_NAME, name.c_str(), 0, 0, 0);
+#else
+	#error "Failed to find method to set thread name on this system. Please provide one (or disable this line if you just want code to compile)"
 #endif
 }
 


### PR DESCRIPTION
- gcc hardening options are now only used in debug builds - since most builders add similar (and sometimes - conflicting) flags
- fixed apparently broken compilation on FreeBSD