### PR TITLE
Better handling of Ctrl / Cmd modifier keys on Apple systems

### DIFF
--- a/client/adventureMap/AdventureMapInterface.cpp
+++ b/client/adventureMap/AdventureMapInterface.cpp
@@ -564,7 +564,7 @@ void AdventureMapInterface::onTileLeftClicked(const int3 &targetPosition)
 			}
 			else
 			{
-				if(GH.isKeyboardCtrlDown()) //normal click behaviour (as no hero selected)
+				if(GH.isKeyboardCmdDown()) //normal click behaviour (as no hero selected)
 				{
 					if(canSelect)
 						LOCPLINT->localState->setSelection(static_cast<const CArmedInstance*>(topBlocking));

--- a/client/eventsSDL/InputHandler.cpp
+++ b/client/eventsSDL/InputHandler.cpp
@@ -300,6 +300,11 @@ void InputHandler::fetchEvents()
 	}
 }
 
+bool InputHandler::isKeyboardCmdDown() const
+{
+	return keyboardHandler->isKeyboardCmdDown();
+}
+
 bool InputHandler::isKeyboardCtrlDown() const
 {
 	return keyboardHandler->isKeyboardCtrlDown();

--- a/client/eventsSDL/InputHandler.h
+++ b/client/eventsSDL/InputHandler.h
@@ -88,6 +88,7 @@ public:
 
 	/// returns true if chosen keyboard key is currently pressed down
 	bool isKeyboardAltDown() const;
+	bool isKeyboardCmdDown() const;
 	bool isKeyboardCtrlDown() const;
 	bool isKeyboardShiftDown() const;
 };

--- a/client/eventsSDL/InputSourceKeyboard.cpp
+++ b/client/eventsSDL/InputSourceKeyboard.cpp
@@ -120,10 +120,20 @@ void InputSourceKeyboard::handleEventKeyUp(const SDL_KeyboardEvent & key)
 	GH.events().dispatchShortcutReleased(shortcutsVector);
 }
 
+bool InputSourceKeyboard::isKeyboardCmdDown() const
+{
+#ifdef VCMI_APPLE
+	return SDL_GetKeyboardState(nullptr)[SDL_SCANCODE_LGUI] || SDL_GetKeyboardState(nullptr)[SDL_SCANCODE_RGUI];
+#else
+	return SDL_GetKeyboardState(nullptr)[SDL_SCANCODE_LCTRL] || SDL_GetKeyboardState(nullptr)[SDL_SCANCODE_RCTRL];
+#endif
+}
+
 bool InputSourceKeyboard::isKeyboardCtrlDown() const
 {
-#ifdef VCMI_MAC
-	return SDL_GetKeyboardState(nullptr)[SDL_SCANCODE_LGUI] || SDL_GetKeyboardState(nullptr)[SDL_SCANCODE_RGUI];
+#ifdef VCMI_APPLE
+	return SDL_GetKeyboardState(nullptr)[SDL_SCANCODE_LCTRL] || SDL_GetKeyboardState(nullptr)[SDL_SCANCODE_RCTRL] ||
+		   SDL_GetKeyboardState(nullptr)[SDL_SCANCODE_LGUI] || SDL_GetKeyboardState(nullptr)[SDL_SCANCODE_RGUI];
 #else
 	return SDL_GetKeyboardState(nullptr)[SDL_SCANCODE_LCTRL] || SDL_GetKeyboardState(nullptr)[SDL_SCANCODE_RCTRL];
 #endif

--- a/client/eventsSDL/InputSourceKeyboard.h
+++ b/client/eventsSDL/InputSourceKeyboard.h
@@ -23,6 +23,7 @@ public:
 	void handleEventKeyUp(const SDL_KeyboardEvent & current);
 
 	bool isKeyboardAltDown() const;
+	bool isKeyboardCmdDown() const;
 	bool isKeyboardCtrlDown() const;
 	bool isKeyboardShiftDown() const;
 };

--- a/client/gui/CGuiHandler.cpp
+++ b/client/gui/CGuiHandler.cpp
@@ -165,6 +165,11 @@ bool CGuiHandler::isKeyboardCtrlDown() const
 	return inputHandlerInstance->isKeyboardCtrlDown();
 }
 
+bool CGuiHandler::isKeyboardCmdDown() const
+{
+	return inputHandlerInstance->isKeyboardCmdDown();
+}
+
 bool CGuiHandler::isKeyboardAltDown() const
 {
 	return inputHandlerInstance->isKeyboardAltDown();

--- a/client/gui/CGuiHandler.h
+++ b/client/gui/CGuiHandler.h
@@ -62,9 +62,17 @@ public:
 	/// May not match size of window if user has UI scaling different from 100%
 	Point screenDimensions() const;
 
-	/// returns true if chosen keyboard key is currently pressed down
+	/// returns true if Alt is currently pressed down
 	bool isKeyboardAltDown() const;
+	/// returns true if Ctrl is currently pressed down
+	/// on Apple system, this also tests for Cmd key
+	/// For use with keyboard-based events
 	bool isKeyboardCtrlDown() const;
+	/// on Apple systems, returns true if Cmd key is pressed
+	/// on other systems, returns true if Ctrl is pressed
+	/// /// For use with mouse-based events
+	bool isKeyboardCmdDown() const;
+	/// returns true if Shift is currently pressed down
 	bool isKeyboardShiftDown() const;
 
 	void startTextInput(const Rect & where);

--- a/client/widgets/CGarrisonInt.cpp
+++ b/client/widgets/CGarrisonInt.cpp
@@ -485,7 +485,7 @@ bool CGarrisonSlot::handleSplittingShortcuts()
 {
 	const bool isAlt = GH.isKeyboardAltDown();
 	const bool isLShift = GH.isKeyboardShiftDown();
-	const bool isLCtrl = GH.isKeyboardCtrlDown();
+	const bool isLCtrl = GH.isKeyboardCmdDown();
 
 	if(!isAlt && !isLShift && !isLCtrl)
 		return false; // This is only case when return false

--- a/client/windows/CWindowWithArtifacts.cpp
+++ b/client/windows/CWindowWithArtifacts.cpp
@@ -151,7 +151,7 @@ void CWindowWithArtifacts::clickPressedArtPlaceHero(const CArtifactsOfHeroBase &
 						{
 							assert(artSetPtr->getHero()->getSlotByInstance(art) != ArtifactPosition::PRE_FIRST);
 
-							if(GH.isKeyboardCtrlDown())
+							if(GH.isKeyboardCmdDown())
 							{
 								std::shared_ptr<CArtifactsOfHeroMain> anotherHeroEquipmentPointer = nullptr;
 

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -851,7 +851,7 @@ CExchangeWindow::CExchangeWindow(ObjectInstanceID hero1, ObjectInstanceID hero2,
 			bool moveEquipped = true;
 			bool moveBackpack = true;
 
-			if(GH.isKeyboardCtrlDown())
+			if(GH.isKeyboardCmdDown())
 				moveBackpack = false;
 			else if(GH.isKeyboardShiftDown())
 				moveEquipped = false;


### PR DESCRIPTION
- Test only for Cmd modifier key when processing mouse clicks
- Test both Ctrl and Cmd modifier key when processing keyboard input
- This logic is now used for all Apple systems - macOS and iOS