### PR TITLE
lobby server - Heartbeat fix

### DIFF
--- a/lib/network/NetworkConnection.h
+++ b/lib/network/NetworkConnection.h
@@ -27,6 +27,7 @@ class NetworkConnection : public INetworkConnection, public std::enable_shared_f
 	INetworkConnectionListener & listener;
 
 	void heartbeat();
+	void onError(const std::string & message);
 
 	void startReceiving();
 	void onHeaderReceived(const boost::system::error_code & ec);

--- a/lobby/LobbyServer.cpp
+++ b/lobby/LobbyServer.cpp
@@ -212,7 +212,8 @@ static JsonNode loadLobbyGameRoomToJson(const LobbyGameRoom & gameRoom)
 	jsonEntry["status"].String() = LOBBY_ROOM_STATE_NAMES[vstd::to_underlying(gameRoom.roomState)];
 	jsonEntry["playerLimit"].Integer() = gameRoom.playerLimit;
 	jsonEntry["ageSeconds"].Integer() = gameRoom.age.count();
-	jsonEntry["mods"] = JsonNode(reinterpret_cast<const std::byte *>(gameRoom.modsJson.data()), gameRoom.modsJson.size());
+	if (!gameRoom.modsJson.empty()) // not present in match history
+		jsonEntry["mods"] = JsonNode(reinterpret_cast<const std::byte *>(gameRoom.modsJson.data()), gameRoom.modsJson.size());
 
 	for(const auto & account : gameRoom.participants)
 		jsonEntry["participants"].Vector().push_back(loadLobbyAccountToJson(account));


### PR DESCRIPTION
- Fixes heartbeat timer potentially holding locked shared_ptr even after connection has died
- Fixes attempts to parse empty string as json leading to warnings in lobby server log

Will deploy tomorrow morning while lobby is empty