### PR TITLE
Map editor fix seer crash

### DIFF
--- a/mapeditor/inspector/rewardswidget.cpp
+++ b/mapeditor/inspector/rewardswidget.cpp
@@ -636,10 +636,12 @@ void RewardsWidget::on_visitInfoList_itemSelectionChanged()
 	if(ui->visitInfoList->currentItem() == nullptr)
 	{
 		ui->eventInfoGroup->hide();
+		ui->removeVisitInfo->setEnabled(false);
 		return;
 	}
 	
 	ui->eventInfoGroup->show();
+	ui->removeVisitInfo->setEnabled(true);
 }
 
 void RewardsWidget::on_visitInfoList_currentItemChanged(QListWidgetItem * current, QListWidgetItem * previous)

--- a/mapeditor/inspector/rewardswidget.cpp
+++ b/mapeditor/inspector/rewardswidget.cpp
@@ -34,7 +34,7 @@ RewardsWidget::RewardsWidget(CMap & m, CRewardableObject & p, QWidget *parent) :
 	
 	//fill core elements
 	for(const auto & s : Rewardable::VisitModeString)
-		ui->selectMode->addItem(QString::fromUtf8(s.data(), s.size()));
+		ui->visitMode->addItem(QString::fromUtf8(s.data(), s.size()));
 	
 	for(const auto & s : Rewardable::SelectModeString)
 		ui->selectMode->addItem(QString::fromUtf8(s.data(), s.size()));

--- a/mapeditor/inspector/rewardswidget.ui
+++ b/mapeditor/inspector/rewardswidget.ui
@@ -36,6 +36,9 @@
        </item>
        <item>
         <widget class="QPushButton" name="removeVisitInfo">
+         <property name="enabled">
+          <bool>false</bool>
+         </property>
          <property name="text">
           <string>Remove</string>
          </property>


### PR DESCRIPTION
1. Remove button in rewards widget was always enabled, clicking it while there is no reward lead to map editor crash
2. `ui->visitMode` wasn't properly initialized, lead to error on attempt to save map if rewards widget was opened - reported on discord