### PR TITLE
Relax vcmi version compatibility checks in lobby

### DIFF
--- a/client/globalLobby/GlobalLobbyRoomWindow.cpp
+++ b/client/globalLobby/GlobalLobbyRoomWindow.cpp
@@ -76,7 +76,11 @@ static const std::string getJoinRoomErrorMessage(const GlobalLobbyRoom & roomDes
 	if (gameStarted)
 		return "vcmi.lobby.preview.error.busy";
 
-	if (VCMI_VERSION_STRING != roomDescription.gameVersion)
+	CModVersion localVersion = CModVersion::fromString(VCMI_VERSION_STRING);
+	CModVersion hostVersion = CModVersion::fromString(roomDescription.gameVersion);
+
+	// 1.5.X can play with each other, but not with 1.X.Y
+	if (localVersion.major != hostVersion.major || localVersion.minor != hostVersion.minor)
 		return "vcmi.lobby.preview.error.version";
 
 	if (roomDescription.playerLimit == roomDescription.participants.size())


### PR DESCRIPTION
VCMI will now allow joining game hosted by other VCMI versions if only patch version is different:
1.5.0 <-> 1.5.1 -> allowed
1.5.0 <-> 1.6.0 -> illegal