### PR TITLE
Simple workaround to fix vcmiserver shutdown procedure

### DIFF
--- a/lib/network/NetworkConnection.h
+++ b/lib/network/NetworkConnection.h
@@ -13,7 +13,7 @@
 
 VCMI_LIB_NAMESPACE_BEGIN
 
-class NetworkConnection : public INetworkConnection, public std::enable_shared_from_this<NetworkConnection>
+class NetworkConnection final : public INetworkConnection, public std::enable_shared_from_this<NetworkConnection>
 {
 	static const int messageHeaderSize = sizeof(uint32_t);
 	static const int messageMaxSize = 64 * 1024 * 1024; // arbitrary size to prevent potential massive allocation if we receive garbage input
@@ -25,6 +25,7 @@ class NetworkConnection : public INetworkConnection, public std::enable_shared_f
 
 	NetworkBuffer readBuffer;
 	INetworkConnectionListener & listener;
+	bool asyncWritesEnabled = false;
 
 	void heartbeat();
 	void onError(const std::string & message);
@@ -42,6 +43,7 @@ public:
 	void start();
 	void close() override;
 	void sendPacket(const std::vector<std::byte> & message) override;
+	void setAsyncWritesEnabled(bool on) override;
 };
 
 VCMI_LIB_NAMESPACE_END

--- a/lib/network/NetworkInterface.h
+++ b/lib/network/NetworkInterface.h
@@ -17,6 +17,7 @@ class DLL_LINKAGE INetworkConnection : boost::noncopyable
 public:
 	virtual ~INetworkConnection() = default;
 	virtual void sendPacket(const std::vector<std::byte> & message) = 0;
+	virtual void setAsyncWritesEnabled(bool on) = 0;
 	virtual void close() = 0;
 };
 

--- a/lobby/LobbyServer.cpp
+++ b/lobby/LobbyServer.cpp
@@ -292,6 +292,7 @@ void LobbyServer::sendChatMessage(const NetworkConnectionPtr & target, const std
 
 void LobbyServer::onNewConnection(const NetworkConnectionPtr & connection)
 {
+	connection->setAsyncWritesEnabled(true);
 	// no-op - waiting for incoming data
 }
 


### PR DESCRIPTION
At the moment, vcmilobby *requires* async writes in order to handle multiple connections with different speeds and at optimal performance, without hanging if one player is too slow and can't eat all data server sent to him at once.

However vcmiserver (and potentially - vcmiclient) can not handle this mode and may shutdown either socket or entire asio service too early, before all writes are performed, leading to weird freeze on ending scenario where client would not receive notifications about end of game.

With this PR async writes would be used only by vcmilobby, while vcmiclient & vcmiserver would use blocking writes as before.

- Fixes #3977