### PR TITLE
[1.5.2] Use Ubuntu 24.04 runner for some presets

### DIFF
--- a/.github/workflows/github.yml
+++ b/.github/workflows/github.yml
@@ -20,11 +20,11 @@ jobs:
       matrix:
         include:
           - platform: linux-qt6
-            os: ubuntu-22.04
+            os: ubuntu-24.04
             test: 0
             preset: linux-clang-test
           - platform: linux
-            os: ubuntu-22.04
+            os: ubuntu-24.04
             test: 1
             preset: linux-gcc-test
           - platform: linux
@@ -124,7 +124,7 @@ jobs:
       # also, running it on multiple presets is redundant and slightly increases already long CI built times
       if: ${{ startsWith(matrix.preset, 'linux-clang-test') }}
       run: |
-        pip3 install jstyleson
+        sudo apt install python3-jstyleson
         python3 CI/linux-qt6/validate_json.py
 
     - name: Dependencies
@@ -201,8 +201,8 @@ jobs:
 
     - name: Configure
       run: |
-        if [[ ${{matrix.preset}} == linux-gcc-test ]]; then GCC12=1; fi
-        cmake -DENABLE_CCACHE:BOOL=ON --preset ${{ matrix.preset }} ${GCC12:+-DCMAKE_C_COMPILER=gcc-12 -DCMAKE_CXX_COMPILER=g++-12}
+        if [[ ${{matrix.preset}} == linux-gcc-test ]]; then GCC14=1; fi
+        cmake -DENABLE_CCACHE:BOOL=ON --preset ${{ matrix.preset }} ${GCC14:+-DCMAKE_C_COMPILER=gcc-14 -DCMAKE_CXX_COMPILER=g++-14}
 
     - name: Build
       run: |

--- a/AI/Nullkiller/Goals/CGoal.h
+++ b/AI/Nullkiller/Goals/CGoal.h
@@ -18,10 +18,11 @@ class AIGateway;
 
 namespace Goals
 {
-	template<typename T> class DLL_EXPORT CGoal : public AbstractGoal
+	template<typename T>
+	class DLL_EXPORT CGoal : public AbstractGoal
 	{
 	public:
-		CGoal<T>(EGoals goal = INVALID) : AbstractGoal(goal)
+		CGoal(EGoals goal = INVALID) : AbstractGoal(goal)
 		{
 			isAbstract = true;
 			value = 0;
@@ -32,7 +33,7 @@ namespace Goals
 			town = nullptr;
 		}
 
-		CGoal<T> * clone() const override
+		CGoal * clone() const override
 		{
 			return new T(static_cast<T const &>(*this)); //casting enforces template instantiation
 		}
@@ -70,15 +71,16 @@ namespace Goals
 		}
 	};
 
-	template<typename T> class DLL_EXPORT ElementarGoal : public CGoal<T>, public ITask
+	template<typename T>
+	class DLL_EXPORT ElementarGoal : public CGoal<T>, public ITask
 	{
 	public:
-		ElementarGoal<T>(EGoals goal = INVALID) : CGoal<T>(goal), ITask()
+		ElementarGoal(EGoals goal = INVALID) : CGoal<T>(goal), ITask()
 		{
 			AbstractGoal::isAbstract = false;
 		}
 
-		ElementarGoal<T>(const ElementarGoal<T> & other) : CGoal<T>(other), ITask(other)
+		ElementarGoal(const ElementarGoal<T> & other) : CGoal<T>(other), ITask(other)
 		{
 		}
 

--- a/AI/VCAI/Goals/CGoal.h
+++ b/AI/VCAI/Goals/CGoal.h
@@ -18,10 +18,11 @@ class VCAI;
 
 namespace Goals
 {
-	template<typename T> class DLL_EXPORT CGoal : public AbstractGoal
+	template<typename T>
+	class DLL_EXPORT CGoal : public AbstractGoal
 	{
 	public:
-		CGoal<T>(EGoals goal = INVALID) : AbstractGoal(goal)
+		CGoal(EGoals goal = INVALID) : AbstractGoal(goal)
 		{
 			priority = 0;
 			isElementar = false;
@@ -56,7 +57,7 @@ namespace Goals
 			return f->evaluate(static_cast<T &>(*this)); //casting enforces template instantiation
 		}
 
-		CGoal<T> * clone() const override
+		CGoal * clone() const override
 		{
 			return new T(static_cast<T const &>(*this)); //casting enforces template instantiation
 		}


### PR DESCRIPTION
Changes non-crosscompiled Ubuntu runners to use Ubuntu-24.04 preset with gcc-14. These runners don't produce any artifacts so as long as run succeeds there should be no unexpected side effects.

- mingw runners use 22.04 preset as before. Can be changed later, e.g. for 1.6. May require rebuilding package & testing, so will keep 22.04 for now
- android runners use 22.04 preset as before - since OS was changed in Android branch.