### PR TITLE
[1.5.2] Exclude some AB creatures from randomization picks

### DIFF
--- a/config/creatures/neutral.json
+++ b/config/creatures/neutral.json
@@ -67,6 +67,7 @@
 		"index": 132,
 		"level": 10,
 		"faction": "neutral",
+		"excludeFromRandomization" : true,
 		"abilities":
 		{
 			"dragon" : 
@@ -109,6 +110,7 @@
 		"index": 133,
 		"level": 10,
 		"faction": "neutral",
+		"excludeFromRandomization" : true,
 		"abilities":
 		{
 			"dragon" :
@@ -144,6 +146,7 @@
 		"index": 134,
 		"level": 8,
 		"faction": "neutral",
+		"excludeFromRandomization" : true,
 		"abilities":
 		{
 			"dragon" :
@@ -241,6 +244,7 @@
 		"index": 135,
 		"level": 10,
 		"faction": "neutral",
+		"excludeFromRandomization" : true,
 		"abilities":
 		{
 			"dragon" : 
@@ -283,6 +287,7 @@
 		"level": 6,
 		"extraNames": [ "enchanters" ],
 		"faction": "neutral",
+		"excludeFromRandomization" : true,
 		"abilities":
 		{
 			"noPenalty" : 
@@ -362,6 +367,7 @@
 		"level": 4,
 		"extraNames": [ "sharpshooters" ],
 		"faction": "neutral",
+		"excludeFromRandomization" : true,
 		"abilities":
 		{
 			"noPenalty" : 

--- a/config/schemas/creature.json
+++ b/config/schemas/creature.json
@@ -25,6 +25,10 @@
 			"type" : "boolean",
 			"description" : "Internal. Object is competely disabled and may not be even loaded in-game"
 		},
+		"excludeFromRandomization" : {
+			"type" : "boolean",
+			"description" : "If set, this creature will never be picked as random monster and will not appear in Refugee Camp. Random map generator can still pick this creature"
+		},
 		"name" : {
 			"type" : "object",
 			"additionalProperties" : false,

--- a/docs/modders/Entities_Format/Creature_Format.md
+++ b/docs/modders/Entities_Format/Creature_Format.md
@@ -37,6 +37,10 @@ In order to make functional creature you also need:
 
 	// Marks this object as special and not available by default
 	"special" : true, 
+	
+	// If set, this creature will never be picked as random monster on premade maps and will not appear in Refugee Camp
+	// Random map generator does not checks for this flag and can still pick this creature
+	"excludeFromRandomization" : false,
 
 	// Faction this creature belongs to. Examples: castle, rampart
 	"faction" : "", 

--- a/lib/CCreatureHandler.cpp
+++ b/lib/CCreatureHandler.cpp
@@ -957,6 +957,7 @@ void CCreatureHandler::loadCreatureJson(CCreature * creature, const JsonNode & c
 	}
 
 	creature->special = config["special"].Bool() || config["disabled"].Bool();
+	creature->excludeFromRandomization = config["excludeFromRandomization"].Bool();
 
 	const JsonNode & sounds = config["sound"];
 	creature->sounds.attack = AudioPath::fromJson(sounds["attack"]);
@@ -1355,6 +1356,9 @@ CreatureID CCreatureHandler::pickRandomMonster(CRandomGenerator & rand, int tier
 	for(const auto & creature : objects)
 	{
 		if(creature->special)
+			continue;
+
+		if(creature->excludeFromRandomization)
 			continue;
 
 		if (creature->level == tier || tier == -1)

--- a/lib/CCreatureHandler.h
+++ b/lib/CCreatureHandler.h
@@ -58,6 +58,7 @@ public:
 	ui32 ammMax;
 
 	bool special = true; // Creature is not available normally (war machines, commanders, several unused creatures, etc
+	bool excludeFromRandomization = false;
 
 	std::set<CreatureID> upgrades; // IDs of creatures to which this creature can be upgraded
 


### PR DESCRIPTION
This changes handling of several campaign-only creatures to be in line with H3 - Sharpshooters, Enchanters and Azure/Rust/Faerie/Crystal dragons.

Now these creatures will not be picked for:
- random creatures in Refugee Camp
- as replacement for Random Monster object from map editor, including Random Monster Level X objects

Random map generator is not affected and can still pick this creatures (confirmed to be same in H3)

- Fixes #2402