### PR TITLE
Tweaks to modding docs

### DIFF
--- a/docs/modders/Map_Objects/Rewardable.md
+++ b/docs/modders/Map_Objects/Rewardable.md
@@ -230,7 +230,12 @@ This property describes how object state should be reset. Objects without this f
 
 ## Appear Chance definition
 This property describes chance for reward to be selected.
-When object is initialized on map load, game will roll a "dice" - random number in range 0-99, and pick all awards that have appear chance within selected number
+When object is initialized on map load, game will roll a "dice" - random number in range 0-99, and pick all awards that have appear chance within selected number.
+Note that object that uses appearChance MUST have continious range for every value in 0-99 range. For example, object with 3 different rewards may want to define them as
+- `"min" :  0, "max" : 33`
+- `"min" : 33, "max" : 66`
+- `"min" : 66, "max" : 100`
+In other words, min chance of second reward must be equal to max chance of previous reward
 
 ```jsonc
     "appearChance": 

--- a/lib/mapObjectConstructors/CRewardableConstructor.cpp
+++ b/lib/mapObjectConstructors/CRewardableConstructor.cpp
@@ -53,7 +53,13 @@ void CRewardableConstructor::configureObject(CGObjectInstance * object, CRandomG
 				bonus.sid = BonusSourceID(rewardableObject->ID);
 			}
 		}
-		assert(!rewardableObject->configuration.info.empty());
+		if (rewardableObject->configuration.info.empty())
+		{
+			if (objectInfo.getParameters()["rewards"].isNull())
+				logMod->error("Object %s has invalid configuration! No defined rewards found!", getJsonKey());
+			else
+				logMod->error("Object %s has invalid configuration! Make sure that defined appear chances are continious!", getJsonKey());
+		}
 	}
 }
 

--- a/lib/modding/IdentifierStorage.cpp
+++ b/lib/modding/IdentifierStorage.cpp
@@ -333,8 +333,12 @@ void CIdentifierStorage::registerObject(const std::string & scope, const std::st
 	std::pair<const std::string, ObjectData> mapping = std::make_pair(fullID, data);
 	if(!vstd::containsMapping(registeredObjects, mapping))
 	{
-		logMod->trace("registered %s as %s:%s", fullID, scope, identifier);
+		logMod->trace("registered '%s' as %s:%s", fullID, scope, identifier);
 		registeredObjects.insert(mapping);
+	}
+	else
+	{
+		logMod->trace("Duplicate object '%s' found!", fullID);
 	}
 }
 


### PR DESCRIPTION
Based on issues discovered in hota / antagarich burning mods:
- Added docs to clarify how ranges for reward random selection should be setup
- Added warnings if invalid object configuration was found
- Added logging for duplicated registered objects (log file only since this may be legal in some cases)