### PR TITLE
[1.5.2] Retaliation preview tweaks

### DIFF
--- a/client/battle/BattleInterfaceClasses.cpp
+++ b/client/battle/BattleInterfaceClasses.cpp
@@ -83,6 +83,13 @@ std::vector<std::string> BattleConsole::getVisibleText()
 
 		auto result = CMessage::breakText(text, pos.w, FONT_SMALL);
 
+		if(result.size() > 2 && text.find('\n') != std::string::npos)
+		{
+			// Text has too many lines to fit into console, but has line breaks. Try ignore them and fit text that way
+			std::string cleanText = boost::algorithm::replace_all_copy(text, "\n", " ");
+			result = CMessage::breakText(cleanText, pos.w, FONT_SMALL);
+		}
+
 		if(result.size() > 2)
 			result.resize(2);
 		return result;


### PR DESCRIPTION
- place retaliation info in same line as damage info when damage info is too long to fit into single line (e.g. due to long creature name and / or different localization)
- fixed displaying retaliation damage as "1 damage" if target will die from attack
- retaliation preview now correctly shows that there will be no retaliation if attacker has BLOCKS_RETALIATION bonus