### PR TITLE
[1.5.2] background for multiple windows

### DIFF
--- a/client/mainmenu/CHighScoreScreen.cpp
+++ b/client/mainmenu/CHighScoreScreen.cpp
@@ -292,7 +292,7 @@ int CHighScoreInputScreen::addEntry(std::string text) {
 void CHighScoreInputScreen::show(Canvas & to)
 {
 	if(background)
-		background->redraw();
+		background->show(to);
 
 	CCS->videoh->update(pos.x, pos.y, to.getInternalSurface(), true, false,
 	[&]()
@@ -310,12 +310,9 @@ void CHighScoreInputScreen::show(Canvas & to)
 	});
 
 	if(input)
-		input->redraw();
+		input->showAll(to);
 	for(auto & text : texts)
-	{
-		text->setRedrawParent(false);
-		text->redraw();
-	}
+		text->showAll(to);
 
 	CIntObject::show(to);
 }

--- a/client/mainmenu/CHighScoreScreen.cpp
+++ b/client/mainmenu/CHighScoreScreen.cpp
@@ -21,6 +21,7 @@
 #include "../windows/InfoWindows.h"
 #include "../widgets/TextControls.h"
 #include "../render/Canvas.h"
+#include "../render/IRenderHandler.h"
 
 #include "../CGameInfo.h"
 #include "../CVideoHandler.h"
@@ -81,7 +82,8 @@ CHighScoreScreen::CHighScoreScreen(HighScorePage highscorepage, int highlighted)
 
 	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
 	pos = center(Rect(0, 0, 800, 600));
-	updateShadow();
+
+	backgroundAroundMenu = std::make_shared<CFilledTexture>(ImagePath::builtin("DIBOXBCK"), Rect(-pos.x, -pos.y, GH.screenDimensions().x, GH.screenDimensions().y));
 
 	addHighScores();
 	addButtons();
@@ -222,8 +224,8 @@ CHighScoreInputScreen::CHighScoreInputScreen(bool won, HighScoreCalculation calc
 
 	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
 	pos = center(Rect(0, 0, 800, 600));
-	updateShadow();
 
+	backgroundAroundMenu = std::make_shared<CFilledTexture>(ImagePath::builtin("DIBOXBCK"), Rect(-pos.x, -pos.y, GH.screenDimensions().x, GH.screenDimensions().y));
 	background = std::make_shared<TransparentFilledRectangle>(Rect(0, 0, pos.w, pos.h), Colors::BLACK);
 
 	if(won)
@@ -289,6 +291,9 @@ int CHighScoreInputScreen::addEntry(std::string text) {
 
 void CHighScoreInputScreen::show(Canvas & to)
 {
+	if(background)
+		background->redraw();
+
 	CCS->videoh->update(pos.x, pos.y, to.getInternalSurface(), true, false,
 	[&]()
 	{
@@ -303,7 +308,14 @@ void CHighScoreInputScreen::show(Canvas & to)
 		else
 			close();
 	});
-	redraw();
+
+	if(input)
+		input->redraw();
+	for(auto & text : texts)
+	{
+		text->setRedrawParent(false);
+		text->redraw();
+	}
 
 	CIntObject::show(to);
 }

--- a/client/mainmenu/CHighScoreScreen.h
+++ b/client/mainmenu/CHighScoreScreen.h
@@ -15,6 +15,7 @@ class CLabel;
 class CMultiLineLabel;
 class CAnimImage;
 class CTextInput;
+class CFilledTexture;
 
 class TransparentFilledRectangle;
 
@@ -61,6 +62,7 @@ private:
 	HighScorePage highscorepage;
 
 	std::shared_ptr<CPicture> background;
+	std::shared_ptr<CFilledTexture> backgroundAroundMenu;
 	std::vector<std::shared_ptr<CButton>> buttons;
 	std::vector<std::shared_ptr<CLabel>> texts;
 	std::vector<std::shared_ptr<CAnimImage>> images;
@@ -93,6 +95,7 @@ class CHighScoreInputScreen : public CWindowObject
 	std::vector<std::shared_ptr<CMultiLineLabel>> texts;
 	std::shared_ptr<CHighScoreInput> input;
 	std::shared_ptr<TransparentFilledRectangle> background;
+	std::shared_ptr<CFilledTexture> backgroundAroundMenu;
 
 	std::string video;
 	int videoSoundHandle;

--- a/client/mainmenu/CMainMenu.cpp
+++ b/client/mainmenu/CMainMenu.cpp
@@ -109,9 +109,9 @@ void CMenuScreen::show(Canvas & to)
 	if(!config["video"].isNull())
 	{
 		// redraw order: background -> video -> buttons and pictures
-		background->redraw();
+		background->showAll(to);
 		CCS->videoh->update((int)config["video"]["x"].Float() + pos.x, (int)config["video"]["y"].Float() + pos.y, to.getInternalSurface(), true, false);
-		tabs->redraw();
+		tabs->showAll(to);
 	}
 	CIntObject::show(to);
 }

--- a/client/mainmenu/CPrologEpilogVideo.cpp
+++ b/client/mainmenu/CPrologEpilogVideo.cpp
@@ -18,6 +18,7 @@
 #include "../gui/CGuiHandler.h"
 #include "../gui/FramerateManager.h"
 #include "../widgets/TextControls.h"
+#include "../widgets/Images.h"
 #include "../render/Canvas.h"
 
 
@@ -27,7 +28,8 @@ CPrologEpilogVideo::CPrologEpilogVideo(CampaignScenarioPrologEpilog _spe, std::f
 	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
 	addUsedEvents(LCLICK | TIME);
 	pos = center(Rect(0, 0, 800, 600));
-	updateShadow();
+
+	backgroundAroundMenu = std::make_shared<CFilledTexture>(ImagePath::builtin("DIBOXBCK"), Rect(-pos.x, -pos.y, GH.screenDimensions().x, GH.screenDimensions().y));
 
 	auto audioData = CCS->videoh->getAudio(spe.prologVideo);
 	videoSoundHandle = CCS->soundh->playSound(audioData, -1);

--- a/client/mainmenu/CPrologEpilogVideo.h
+++ b/client/mainmenu/CPrologEpilogVideo.h
@@ -13,6 +13,7 @@
 #include "../../lib/campaign/CampaignScenarioPrologEpilog.h"
 
 class CMultiLineLabel;
+class CFilledTexture;
 
 class CPrologEpilogVideo : public CWindowObject
 {
@@ -25,6 +26,7 @@ class CPrologEpilogVideo : public CWindowObject
 	std::function<void()> exitCb;
 
 	std::shared_ptr<CMultiLineLabel> text;
+	std::shared_ptr<CFilledTexture> backgroundAroundMenu;
 
 	bool voiceStopped = false;
 


### PR DESCRIPTION
Draw standard background for:
- campaign end video
- highscore input
- highscore screen

Looks more clean as these screens aren't part of the current game anymore.