### PR TITLE
[1.5.2?] Multiplayer voting

### DIFF
--- a/docs/players/Cheat_Codes.md
+++ b/docs/players/Cheat_Codes.md
@@ -87,13 +87,21 @@ By default, all cheat codes apply to current player. Alternatively, it is possib
 `vcminahar ai` - give 1000000 movement points to each hero of every AI player  
 
 ## Multiplayer chat commands
-Note: These commands are not a cheats, and can be used in multiplayer by host player to control the session
 
-- `game exit/quit/end` - finish the game  
-- `game save <filename>` - save the game into the specified file  
-- `game kick red/blue/tan/green/orange/purple/teal/pink` - kick player of specified color from the game  
-- `game kick 0/1/2/3/4/5/6/7/8` - kick player of specified ID from the game (_zero indexed!_) (`0: red, 1: blue, tan: 2, green: 3, orange: 4, purple: 5, teal: 6, pink: 7`)  
+Following commands can be used in multiplayer only by host player to control the session:
+- `!exit` - finish the game  
+- `!save <filename>` - save the game into the specified file  
+- `!kick red/blue/tan/green/orange/purple/teal/pink` - kick player of specified color from the game  
+- `!kick 0/1/2/3/4/5/6/7/8` - kick player of specified ID from the game (_zero indexed!_) (`0: red, 1: blue, tan: 2, green: 3, orange: 4, purple: 5, teal: 6, pink: 7`)  
 
+Following commands can be used by any player in multiplayer:
+- `!help` - displays in-game list of available commands
+- `!cheaters` - lists players that have entered cheat at any point of the game
+- `!vote` - initiates voting to change one of the possible options:
+- - `!vote simturns allow X` - allow simultaneous turns for specified number of days, or until contact
+- - `!vote simturns force X` - force simultaneous turns for specified number of days, blocking player contacts
+- - `!vote simturns abort` - abort simultaneous turns once this turn ends
+- - `!vote timer prolong X` - prolong base timer for all players by specified number of seconds
 
 # Client Commands
 

--- a/lib/serializer/ESerializationVersion.h
+++ b/lib/serializer/ESerializationVersion.h
@@ -43,6 +43,7 @@ enum class ESerializationVersion : int32_t
 	ARTIFACT_COSTUMES, // 840 swappable artifacts set added
 
 	RELEASE_150 = ARTIFACT_COSTUMES, // for convenience
+	VOTING_SIMTURNS, // 841 - allow modification of simturns duration via vote
 
 	CURRENT = ARTIFACT_COSTUMES
 };

--- a/server/CVCMIServer.cpp
+++ b/server/CVCMIServer.cpp
@@ -992,6 +992,8 @@ void CVCMIServer::multiplayerWelcomeMessage()
 	if(humanPlayer < 2) // Singleplayer
 		return;
 
+	gh->playerMessages->broadcastSystemMessage("Use '!help' to list available commands");
+
 	std::vector<std::string> optionIds;
 	if(si->extraOptionsInfo.cheatsAllowed)
 		optionIds.push_back("vcmi.optionsTab.cheatAllowed.hover");

--- a/server/TurnTimerHandler.cpp
+++ b/server/TurnTimerHandler.cpp
@@ -81,14 +81,20 @@ void TurnTimerHandler::onPlayerGetTurn(PlayerColor player)
 	}
 }
 
-void TurnTimerHandler::update(int waitTime)
+void TurnTimerHandler::prolongTimers(int durationMs)
+{
+	for (auto & timer : timers)
+		timer.second.baseTimer += durationMs;
+}
+
+void TurnTimerHandler::update(int waitTimeMs)
 {
 	if(!gameHandler.getStartInfo()->turnTimerInfo.isEnabled())
 		return;
 
 	for(PlayerColor player(0); player < PlayerColor::PLAYER_LIMIT; ++player)
 		if(gameHandler.gameState()->isPlayerMakingTurn(player))
-			onPlayerMakingTurn(player, waitTime);
+			onPlayerMakingTurn(player, waitTimeMs);
 
 	// create copy for iterations - battle might end during onBattleLoop call
 	std::vector<BattleID> ongoingBattles;
@@ -97,7 +103,7 @@ void TurnTimerHandler::update(int waitTime)
 		ongoingBattles.push_back(battle->battleID);
 
 	for (auto & battleID : ongoingBattles)
-		onBattleLoop(battleID, waitTime);
+		onBattleLoop(battleID, waitTimeMs);
 }
 
 bool TurnTimerHandler::timerCountDown(int & timer, int initialTimer, PlayerColor player, int waitTime)

--- a/server/TurnTimerHandler.h
+++ b/server/TurnTimerHandler.h
@@ -45,9 +45,11 @@ public:
 	void onBattleStart(const BattleID & battle);
 	void onBattleNextStack(const BattleID & battle, const CStack & stack);
 	void onBattleEnd(const BattleID & battleID);
-	void update(int waitTime);
+	void update(int waitTimeMs);
 	void setTimerEnabled(PlayerColor player, bool enabled);
 	void setEndTurnAllowed(PlayerColor player, bool enabled);
+
+	void prolongTimers(int durationMs);
 
 	template<typename Handler>
 	void serialize(Handler & h)

--- a/server/processors/PlayerMessageProcessor.h
+++ b/server/processors/PlayerMessageProcessor.h
@@ -20,13 +20,26 @@ VCMI_LIB_NAMESPACE_END
 
 class CGameHandler;
 
+enum class ECurrentChatVote : int8_t
+{
+	NONE = -1,
+	SIMTURNS_ALLOW,
+	SIMTURNS_FORCE,
+	SIMTURNS_ABORT,
+	TIMER_PROLONG,
+};
+
 class PlayerMessageProcessor
 {
 	CGameHandler * gameHandler;
 
+	ECurrentChatVote currentVote = ECurrentChatVote::NONE;
+	int currentVoteParameter = 0;
+	std::set<PlayerColor> awaitingPlayers;
+
 	void executeCheatCode(const std::string & cheatName, PlayerColor player, ObjectInstanceID currObj, const std::vector<std::string> & arguments );
 	bool handleCheatCode(const std::string & cheatFullCommand, PlayerColor player, ObjectInstanceID currObj);
-	bool handleHostCommand(PlayerColor player, const std::string & message);
+	void handleCommand(PlayerColor player, const std::string & message);
 
 	void cheatGiveSpells(PlayerColor player, const CGHeroInstance * hero);
 	void cheatBuildTown(PlayerColor player, const CGTownInstance * town);
@@ -44,6 +57,17 @@ class PlayerMessageProcessor
 	void cheatMaxLuck(PlayerColor player, const CGHeroInstance * hero);
 	void cheatMaxMorale(PlayerColor player, const CGHeroInstance * hero);
 	void cheatFly(PlayerColor player, const CGHeroInstance * hero);
+
+	void commandExit(PlayerColor player, const std::vector<std::string> & words);
+	void commandKick(PlayerColor player, const std::vector<std::string> & words);
+	void commandSave(PlayerColor player, const std::vector<std::string> & words);
+	void commandCheaters(PlayerColor player, const std::vector<std::string> & words);
+	void commandHelp(PlayerColor player, const std::vector<std::string> & words);
+	void commandVote(PlayerColor player, const std::vector<std::string> & words);
+
+	void finishVoting();
+	void abortVoting();
+	void startVoting(PlayerColor initiator, ECurrentChatVote what, int parameter);
 
 public:
 	PlayerMessageProcessor(CGameHandler * gameHandler);

--- a/server/processors/TurnOrderProcessor.cpp
+++ b/server/processors/TurnOrderProcessor.cpp
@@ -28,11 +28,15 @@ TurnOrderProcessor::TurnOrderProcessor(CGameHandler * owner):
 
 int TurnOrderProcessor::simturnsTurnsMaxLimit() const
 {
+	if (simturnsMaxDurationDays)
+		return *simturnsMaxDurationDays;
 	return gameHandler->getStartInfo()->simturnsInfo.optionalTurns;
 }
 
 int TurnOrderProcessor::simturnsTurnsMinLimit() const
 {
+	if (simturnsMinDurationDays)
+		return *simturnsMinDurationDays;
 	return gameHandler->getStartInfo()->simturnsInfo.requiredTurns;
 }
 
@@ -372,4 +376,14 @@ bool TurnOrderProcessor::isPlayerMakingTurn(PlayerColor which) const
 bool TurnOrderProcessor::isPlayerAwaitsNewDay(PlayerColor which) const
 {
 	return vstd::contains(actedPlayers, which);
+}
+
+void TurnOrderProcessor::setMinSimturnsDuration(int days)
+{
+	simturnsMinDurationDays = gameHandler->getDate(Date::DAY) + days;
+}
+
+void TurnOrderProcessor::setMaxSimturnsDuration(int days)
+{
+	simturnsMaxDurationDays = gameHandler->getDate(Date::DAY) + days;
 }

--- a/server/processors/TurnOrderProcessor.h
+++ b/server/processors/TurnOrderProcessor.h
@@ -41,6 +41,9 @@ class TurnOrderProcessor : boost::noncopyable
 	std::set<PlayerColor> actingPlayers;
 	std::set<PlayerColor> actedPlayers;
 
+	std::optional<int> simturnsMinDurationDays;
+	std::optional<int> simturnsMaxDurationDays;
+
 	/// Returns date on which simturns must end unconditionally
 	int simturnsTurnsMaxLimit() const;
 
@@ -91,6 +94,12 @@ public:
 	/// Start game (or resume from save) and send PlayerStartsTurn pack to player(s)
 	void onGameStarted();
 
+	/// Permanently override duration of contactless simultaneous turns
+	void setMinSimturnsDuration(int days);
+
+	/// Permanently override duration of simultaneous turns with contact detection
+	void setMaxSimturnsDuration(int days);
+
 	template<typename Handler>
 	void serialize(Handler & h)
 	{
@@ -98,5 +107,11 @@ public:
 		h & awaitingPlayers;
 		h & actingPlayers;
 		h & actedPlayers;
+
+		if (h.version >= Handler::Version::VOTING_SIMTURNS)
+		{
+			h & simturnsMinDurationDays;
+			h & simturnsMaxDurationDays;
+		}
 	}
 };


### PR DESCRIPTION
This is just a quick draft, not yet sure whether this feature is actually needed, in which form should it be and what else could it be used for.

At the moment it allows any player to initiate voting and once all players agree to it this request will be applied:
- change duration of simturns (including restarting them if simturns ended)
- aborting simturns (primary intended for cases when players set too long period for non-breaking simturns)
- prolong base timer by specified duration

Initiation of voting is done via `!vote` command, e.g. `!vote simturns abort`
Once voting has been initiated, all players other than initiator can vote  -`!vote yes` or `!vote no`
All player must agree to change before it applied. Can also be used in single-player games or in hotseat if needed for some reason.