### PR TITLE
[1.5.2] Simturn tweaks

### DIFF
--- a/lib/StartInfo.h
+++ b/lib/StartInfo.h
@@ -32,11 +32,14 @@ struct DLL_LINKAGE SimturnsInfo
 	int optionalTurns = 0;
 	/// If set to true, human and 1 AI can act at the same time
 	bool allowHumanWithAI = false;
+	/// If set to true, allied players can play simultaneously even after contacting each other
+	bool ignoreAlliedContacts = true;
 
 	bool operator == (const SimturnsInfo & other) const
 	{
 		return requiredTurns == other.requiredTurns &&
 				optionalTurns == other.optionalTurns &&
+				ignoreAlliedContacts == other.ignoreAlliedContacts &&
 				allowHumanWithAI == other.allowHumanWithAI;
 	}
 
@@ -46,6 +49,10 @@ struct DLL_LINKAGE SimturnsInfo
 		h & requiredTurns;
 		h & optionalTurns;
 		h & allowHumanWithAI;
+
+		static_assert(Handler::Version::RELEASE_143 < Handler::Version::CURRENT, "Please add ignoreAlliedContacts to serialization for 1.6");
+		// disabled to allow multiplayer compatibility between 1.5.2 and 1.5.1
+		// h & ignoreAlliedContacts
 	}
 };
 

--- a/server/processors/TurnOrderProcessor.cpp
+++ b/server/processors/TurnOrderProcessor.cpp
@@ -17,6 +17,9 @@
 #include "../CVCMIServer.h"
 
 #include "../../lib/CPlayerState.h"
+#include "../../lib/mapping/CMap.h"
+#include "../../lib/mapObjects/CGObjectInstance.h"
+#include "../../lib/gameState/CGameState.h"
 #include "../../lib/pathfinder/CPathfinder.h"
 #include "../../lib/pathfinder/PathfinderOptions.h"
 
@@ -101,6 +104,18 @@ bool TurnOrderProcessor::playersInContact(PlayerColor left, PlayerColor right) c
 
 	const auto * leftInfo = gameHandler->getPlayerState(left, false);
 	const auto * rightInfo = gameHandler->getPlayerState(right, false);
+
+	for (auto obj : gameHandler->gameState()->map->objects)
+	{
+		if (obj && obj->isVisitable())
+		{
+			int3 pos = obj->visitablePos();
+			if (obj->tempOwner == left)
+				leftReachability[pos.z][pos.x][pos.y] = true;
+			if (obj->tempOwner == right)
+				rightReachability[pos.z][pos.x][pos.y] = true;
+		}
+	}
 
 	for(const auto & hero : leftInfo->heroes)
 	{

--- a/server/processors/TurnOrderProcessor.cpp
+++ b/server/processors/TurnOrderProcessor.cpp
@@ -189,6 +189,9 @@ bool TurnOrderProcessor::computeCanActSimultaneously(PlayerColor active, PlayerC
 	if (gameHandler->getDate(Date::DAY) > simturnsTurnsMaxLimit())
 		return false;
 
+	if (gameHandler->getStartInfo()->simturnsInfo.ignoreAlliedContacts && activeInfo->team == waitingInfo->team)
+		return true;
+
 	if (playersInContact(active, waiting))
 		return false;
 


### PR DESCRIPTION
Two minor changes to simultaneous turns that were proposed on Discord:
- now contact between allied players will not break simturns.
- Having hero in range of object owned by another players will now be registered as contact

No UI for 1st option to avoid breaking MP between different versions of 1.5