### PR TITLE
[1.5.2] Fixes for crashes in 1.5.1

### DIFF
--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -137,7 +137,7 @@ CPlayerInterface::CPlayerInterface(PlayerColor Player):
 	LOCPLINT = this;
 	playerID=Player;
 	human=true;
-	battleInt = nullptr;
+	battleInt.reset();
 	castleInt = nullptr;
 	makingTurn = false;
 	showingDialog = new ConditionalWait();

--- a/client/battle/BattleInterface.cpp
+++ b/client/battle/BattleInterface.cpp
@@ -332,7 +332,7 @@ void BattleInterface::battleFinished(const BattleResult& br, QueryID queryID)
 	GH.windows().pushWindow(wnd);
 
 	curInt->waitWhileDialog(); // Avoid freeze when AI end turn after battle. Check bug #1897
-	CPlayerInterface::battleInt = nullptr;
+	CPlayerInterface::battleInt.reset();
 }
 
 void BattleInterface::spellCast(const BattleSpellCast * sc)

--- a/client/battle/BattleWindow.cpp
+++ b/client/battle/BattleWindow.cpp
@@ -192,11 +192,6 @@ void BattleWindow::createTimerInfoWindows()
 	}
 }
 
-BattleWindow::~BattleWindow()
-{
-	CPlayerInterface::battleInt = nullptr;
-}
-
 std::shared_ptr<BattleConsole> BattleWindow::buildBattleConsole(const JsonNode & config) const
 {
 	auto rect = readRect(config["rect"]);

--- a/client/battle/BattleWindow.h
+++ b/client/battle/BattleWindow.h
@@ -82,7 +82,6 @@ class BattleWindow : public InterfaceObjectConfigurable
 
 public:
 	BattleWindow(BattleInterface & owner );
-	~BattleWindow();
 
 	/// Closes window once battle finished
 	void close();

--- a/lib/CCreatureHandler.cpp
+++ b/lib/CCreatureHandler.cpp
@@ -26,6 +26,7 @@
 #include "mapObjectConstructors/AObjectTypeHandler.h"
 #include "mapObjectConstructors/CObjectClassesHandler.h"
 #include "modding/CModHandler.h"
+#include "ExceptionsCommon.h"
 
 VCMI_LIB_NAMESPACE_BEGIN
 
@@ -670,9 +671,9 @@ CCreature * CCreatureHandler::loadFromJson(const std::string & scope, const Json
 		// object does not have any templates - this is not usable object (e.g. pseudo-creature like Arrow Tower)
 		if (VLC->objtypeh->getHandlerFor(Obj::MONSTER, cre->getId().num)->getTemplates().empty())
 		{
-			assert(cre->special);
 			if (!cre->special)
-				logMod->error("Creature %s does not have valid map object but is not marked as special!", cre->getJsonKey());
+				throw DataLoadingException("Mod " + scope + " is corrupted! Please disable or reinstall this mod. Reason: creature " + cre->getJsonKey() + " has no adventure map animation but is not marked as special!" );
+
 			VLC->objtypeh->removeSubObject(Obj::MONSTER, cre->getId().num);
 		}
 	});

--- a/lib/CGeneralTextHandler.h
+++ b/lib/CGeneralTextHandler.h
@@ -202,7 +202,18 @@ public:
 
 		std::string key;
 		auto sz = stringsLocalizations.size();
-		h & sz;
+
+		if (h.version >= Handler::Version::REMOVE_TEXT_CONTAINER_SIZE_T)
+		{
+			int32_t size = sz;
+			h & size;
+			sz = size;
+		}
+		else
+		{
+			h & sz;
+		}
+
 		if(h.saving)
 		{
 			for(auto s : stringsLocalizations)

--- a/lib/CGeneralTextHandler.h
+++ b/lib/CGeneralTextHandler.h
@@ -205,7 +205,7 @@ public:
 
 		if (h.version >= Handler::Version::REMOVE_TEXT_CONTAINER_SIZE_T)
 		{
-			int32_t size = sz;
+			int64_t size = sz;
 			h & size;
 			sz = size;
 		}

--- a/lib/constants/VariantIdentifier.h
+++ b/lib/constants/VariantIdentifier.h
@@ -51,7 +51,6 @@ public:
 	IdentifierType as() const
 	{
 		auto * result = std::get_if<IdentifierType>(&value);
-		assert(result);
 
 		if (result)
 			return *result;

--- a/lib/serializer/ESerializationVersion.h
+++ b/lib/serializer/ESerializationVersion.h
@@ -44,5 +44,7 @@ enum class ESerializationVersion : int32_t
 
 	RELEASE_150 = ARTIFACT_COSTUMES, // for convenience
 
-	CURRENT = ARTIFACT_COSTUMES
+	REMOVE_TEXT_CONTAINER_SIZE_T, // Fixed serialization of size_t from text containers
+
+	CURRENT = REMOVE_TEXT_CONTAINER_SIZE_T
 };

--- a/server/battles/BattleActionProcessor.cpp
+++ b/server/battles/BattleActionProcessor.cpp
@@ -971,7 +971,7 @@ void BattleActionProcessor::makeAttack(const CBattleInfoCallback & battle, const
 	}
 
 	std::shared_ptr<const Bonus> bonus = attacker->getFirstBonus(Selector::type()(BonusType::SPELL_LIKE_ATTACK));
-	if(bonus && ranged && bonus->subtype.as<SpellID>().hasValue()) //TODO: make it work in melee?
+	if(bonus && ranged) //TODO: make it work in melee?
 	{
 		//this is need for displaying hit animation
 		bat.flags |= BattleAttack::SPELL_LIKE;

--- a/server/battles/BattleActionProcessor.cpp
+++ b/server/battles/BattleActionProcessor.cpp
@@ -971,7 +971,7 @@ void BattleActionProcessor::makeAttack(const CBattleInfoCallback & battle, const
 	}
 
 	std::shared_ptr<const Bonus> bonus = attacker->getFirstBonus(Selector::type()(BonusType::SPELL_LIKE_ATTACK));
-	if(bonus && ranged) //TODO: make it work in melee?
+	if(bonus && ranged && bonus->subtype.as<SpellID>().hasValue()) //TODO: make it work in melee?
 	{
 		//this is need for displaying hit animation
 		bat.flags |= BattleAttack::SPELL_LIKE;

--- a/server/battles/BattleResultProcessor.cpp
+++ b/server/battles/BattleResultProcessor.cpp
@@ -142,6 +142,9 @@ CasualtiesAfterBattle::CasualtiesAfterBattle(const CBattleInfoCallback & battle,
 
 void CasualtiesAfterBattle::updateArmy(CGameHandler *gh)
 {
+	if (gh->getObjInstance(army->id) == nullptr)
+		throw std::runtime_error("Object " + army->getObjectName() + " is not on the map!");
+
 	for (TStackAndItsNewCount &ncount : newStackCounts)
 	{
 		if (ncount.second > 0)

--- a/server/battles/BattleResultProcessor.cpp
+++ b/server/battles/BattleResultProcessor.cpp
@@ -544,7 +544,7 @@ void BattleResultProcessor::battleAfterLevelUp(const BattleID & battleID, const 
 	// units will be given after casualties are taken
 	const SlotID necroSlot = raisedStack.type ? finishingBattle->winnerHero->getSlotFor(raisedStack.type) : SlotID();
 
-	if (necroSlot != SlotID())
+	if (necroSlot != SlotID() && !finishingBattle->isDraw())
 	{
 		finishingBattle->winnerHero->showNecromancyDialog(raisedStack, gameHandler->getRandomGenerator());
 		gameHandler->addToSlot(StackLocation(finishingBattle->winnerHero, necroSlot), raisedStack.type, raisedStack.count);


### PR DESCRIPTION
- Fixes possible crash on replaying manually played battle with 'unlimited battle replay' option set
- Fixes crash on loading save made on 64-bit system or connecting to multiplayer game with 64-bit host on 32-bit systems (and vice versa)
- Fixes crash on ending battle in a draw when a hero has Necromancy skill
- Fixes crash on having SPELL_LIKE_ATTACK bonus with invalid spell ID

TODO:
- try to find a way to properly shutdown AI threads when player attempts to close the game
- fix any other crashes that show up on Google Play