### PR TITLE
Add amount of resurrected Vampires to the battle log

### DIFF
--- a/lib/battle/CUnitState.cpp
+++ b/lib/battle/CUnitState.cpp
@@ -228,7 +228,7 @@ void CHealth::damage(int64_t & amount)
 	addResurrected(getCount() - oldCount);
 }
 
-void CHealth::heal(int64_t & amount, EHealLevel level, EHealPower power)
+HealInfo CHealth::heal(int64_t & amount, EHealLevel level, EHealPower power)
 {
 	const int32_t unitHealth = owner->getMaxHealth();
 	const int32_t oldCount = getCount();
@@ -252,7 +252,7 @@ void CHealth::heal(int64_t & amount, EHealLevel level, EHealPower power)
 	vstd::abetween(amount, int64_t(0), maxHeal);
 
 	if(amount == 0)
-		return;
+		return {};
 
 	int64_t availableHealth = available();
 
@@ -263,6 +263,8 @@ void CHealth::heal(int64_t & amount, EHealLevel level, EHealPower power)
 		addResurrected(getCount() - oldCount);
 	else
 		assert(power == EHealPower::PERMANENT);
+
+	return HealInfo(amount, getCount() - oldCount);
 }
 
 void CHealth::setFromTotal(const int64_t totalHealth)
@@ -834,14 +836,16 @@ void CUnitState::damage(int64_t & amount)
 		ghostPending = true;
 }
 
-void CUnitState::heal(int64_t & amount, EHealLevel level, EHealPower power)
+HealInfo CUnitState::heal(int64_t & amount, EHealLevel level, EHealPower power)
 {
 	if(level == EHealLevel::HEAL && power == EHealPower::ONE_BATTLE)
 		logGlobal->error("Heal for one battle does not make sense");
 	else if(cloned)
 		logGlobal->error("Attempt to heal clone");
 	else
-		health.heal(amount, level, power);
+		return health.heal(amount, level, power);
+
+	return {};
 }
 
 void CUnitState::afterAttack(bool ranged, bool counter)

--- a/lib/battle/CUnitState.h
+++ b/lib/battle/CUnitState.h
@@ -107,7 +107,7 @@ public:
 	void reset();
 
 	void damage(int64_t & amount);
-	void heal(int64_t & amount, EHealLevel level, EHealPower power);
+	HealInfo heal(int64_t & amount, EHealLevel level, EHealPower power);
 
 	int32_t getCount() const;
 	int32_t getFirstHPleft() const;
@@ -247,7 +247,7 @@ public:
 	void load(const JsonNode & data) override;
 
 	void damage(int64_t & amount) override;
-	void heal(int64_t & amount, EHealLevel level, EHealPower power) override;
+	HealInfo heal(int64_t & amount, EHealLevel level, EHealPower power) override;
 
 	void localInit(const IUnitEnvironment * env_);
 	void serializeJson(JsonSerializeFormat & handler);

--- a/lib/battle/Unit.h
+++ b/lib/battle/Unit.h
@@ -41,6 +41,27 @@ namespace BattlePhases
 	};
 }
 
+// Healed HP (also drained life) and resurrected units info
+struct HealInfo
+{
+	HealInfo()
+		: healedHealthPoints(0), resurrectedCount(0)
+	{ }
+	HealInfo(int64_t healedHP, int32_t resurrected)
+		: healedHealthPoints(healedHP), resurrectedCount(resurrected)
+	{ }
+
+	int64_t healedHealthPoints;
+	int32_t resurrectedCount;
+
+	HealInfo& operator +=(const HealInfo& other)
+	{
+		healedHealthPoints += other.healedHealthPoints;
+		resurrectedCount += other.resurrectedCount;
+		return *this;
+	}
+};
+
 class CUnitState;
 
 class DLL_LINKAGE Unit : public IUnitInfo, public spells::Caster, public virtual IBonusBearer, public ACreature
@@ -138,7 +159,7 @@ public:
 	virtual void load(const JsonNode & data) = 0;
 
 	virtual void damage(int64_t & amount) = 0;
-	virtual void heal(int64_t & amount, EHealLevel level, EHealPower power) = 0;
+	virtual HealInfo heal(int64_t & amount, EHealLevel level, EHealPower power) = 0;
 };
 
 class DLL_LINKAGE UnitInfo

--- a/lib/battle/Unit.h
+++ b/lib/battle/Unit.h
@@ -44,17 +44,15 @@ namespace BattlePhases
 // Healed HP (also drained life) and resurrected units info
 struct HealInfo
 {
-	HealInfo()
-		: healedHealthPoints(0), resurrectedCount(0)
-	{ }
+	HealInfo() = default;
 	HealInfo(int64_t healedHP, int32_t resurrected)
 		: healedHealthPoints(healedHP), resurrectedCount(resurrected)
 	{ }
 
-	int64_t healedHealthPoints;
-	int32_t resurrectedCount;
+	int64_t healedHealthPoints = 0;
+	int32_t resurrectedCount = 0;
 
-	HealInfo& operator +=(const HealInfo& other)
+	HealInfo & operator+=(const HealInfo & other)
 	{
 		healedHealthPoints += other.healedHealthPoints;
 		resurrectedCount += other.resurrectedCount;

--- a/lib/spells/effects/Summon.cpp
+++ b/lib/spells/effects/Summon.cpp
@@ -122,6 +122,7 @@ int32_t Summon::summonedCreatureAmount(const Mechanics * m) const
 
 void Summon::apply(ServerCallback * server, const Mechanics * m, const EffectTarget & target) const
 {
+	using battle::HealInfo;
 	BattleUnitsChanged pack;
 	pack.battleID = m->battle()->getBattle()->getBattleID();
 

--- a/lib/spells/effects/Summon.cpp
+++ b/lib/spells/effects/Summon.cpp
@@ -122,7 +122,6 @@ int32_t Summon::summonedCreatureAmount(const Mechanics * m) const
 
 void Summon::apply(ServerCallback * server, const Mechanics * m, const EffectTarget & target) const
 {
-	using battle::HealInfo;
 	BattleUnitsChanged pack;
 	pack.battleID = m->battle()->getBattle()->getBattleID();
 

--- a/server/battles/BattleActionProcessor.h
+++ b/server/battles/BattleActionProcessor.h
@@ -54,7 +54,7 @@ class BattleActionProcessor : boost::noncopyable
 	std::set<SpellID> getSpellsForAttackCasting(TConstBonusListPtr spells, const CStack *defender);
 
 	// damage, drain life & fire shield; returns amount of drained life
-	void applyBattleEffects(const CBattleInfoCallback & battle, BattleAttack & bat, std::shared_ptr<battle::CUnitState> attackerState, FireShieldInfo & fireShield, const CStack * def, battle::HealInfo * healInfo, int distance, bool secondary) const;
+	void applyBattleEffects(const CBattleInfoCallback & battle, BattleAttack & bat, std::shared_ptr<battle::CUnitState> attackerState, FireShieldInfo & fireShield, const CStack * def, battle::HealInfo & healInfo, int distance, bool secondary) const;
 
 	void sendGenericKilledLog(const CBattleInfoCallback & battle, const CStack * defender, int32_t killed, bool multiple);
 	void addGenericKilledLog(BattleLogMessage & blm, const CStack * defender, int32_t killed, bool multiple) const;

--- a/server/battles/BattleActionProcessor.h
+++ b/server/battles/BattleActionProcessor.h
@@ -24,6 +24,7 @@ enum class BonusType;
 namespace battle
 {
 class Unit;
+struct HealInfo;
 class CUnitState;
 }
 
@@ -53,10 +54,13 @@ class BattleActionProcessor : boost::noncopyable
 	std::set<SpellID> getSpellsForAttackCasting(TConstBonusListPtr spells, const CStack *defender);
 
 	// damage, drain life & fire shield; returns amount of drained life
-	int64_t applyBattleEffects(const CBattleInfoCallback & battle, BattleAttack & bat, std::shared_ptr<battle::CUnitState> attackerState, FireShieldInfo & fireShield, const CStack * def, int distance, bool secondary);
+	void applyBattleEffects(const CBattleInfoCallback & battle, BattleAttack & bat, std::shared_ptr<battle::CUnitState> attackerState, FireShieldInfo & fireShield, const CStack * def, battle::HealInfo * healInfo, int distance, bool secondary) const;
 
 	void sendGenericKilledLog(const CBattleInfoCallback & battle, const CStack * defender, int32_t killed, bool multiple);
-	void addGenericKilledLog(BattleLogMessage & blm, const CStack * defender, int32_t killed, bool multiple);
+	void addGenericKilledLog(BattleLogMessage & blm, const CStack * defender, int32_t killed, bool multiple) const;
+	void addGenericDamageLog(BattleLogMessage& blm, const std::shared_ptr<battle::CUnitState> &attackerState, int64_t damageDealt) const;
+	void addGenericDrainedLifeLog(BattleLogMessage& blm, const std::shared_ptr<battle::CUnitState> &attackerState, const CStack* defender, int64_t drainedLife) const;
+	void addGenericResurrectedLog(BattleLogMessage& blm, const std::shared_ptr<battle::CUnitState> &attackerState, const CStack* defender, int64_t resurrected) const;
 
 	bool canStackAct(const CBattleInfoCallback & battle, const CStack * stack);
 

--- a/test/mock/mock_battle_Unit.h
+++ b/test/mock/mock_battle_Unit.h
@@ -93,7 +93,7 @@ public:
 	MOCK_METHOD1(load, void(const JsonNode &));
 
 	MOCK_METHOD1(damage, void(int64_t &));
-	MOCK_METHOD3(heal, void(int64_t &, EHealLevel, EHealPower));
+	MOCK_METHOD3(heal, battle::HealInfo(int64_t &, EHealLevel, EHealPower));
 };
 
 


### PR DESCRIPTION
Fix issue #3957: amount of resurrected Vampires doesn't appear in battle log 
Fixed plurar / singular text choice for battle log - creatures after life drain action