### PR TITLE
docs: update reference to Conan

### DIFF
--- a/docs/developers/Building_Android.md
+++ b/docs/developers/Building_Android.md
@@ -26,8 +26,7 @@ git clone --recurse-submodules https://github.com/vcmi/vcmi.git
 
 ## Obtaining dependencies
 
-We use Conan package manager to build/consume dependencies, find detailed usage instructions [here](./Conan.md). Note that the link points to the cutting-edge state in `develop` branch, for the latest release check the same document in the [master
-branch](./Conan.md).
+We use Conan package manager to build/consume dependencies, find detailed usage instructions [here](./Conan.md). Note that the link points to the state of the current branch, for the latest release check the same document in the [master branch](https://github.com/vcmi/vcmi/blob/master/docs/developers/Сonan.md).
 
 On the step where you need to replace **PROFILE**, choose:
 - `android-32` to build for 32-bit architecture (armeabi-v7a)

--- a/docs/developers/Building_Android.md
+++ b/docs/developers/Building_Android.md
@@ -26,8 +26,8 @@ git clone --recurse-submodules https://github.com/vcmi/vcmi.git
 
 ## Obtaining dependencies
 
-We use Conan package manager to build/consume dependencies, find detailed usage instructions [here](https://github.com/vcmi/vcmi/tree/develop/docs/conan.md). Note that the link points to the cutting-edge state in `develop` branch, for the latest release check the same document in the [master
-branch](https://github.com/vcmi/vcmi/tree/master/docs/conan.md).
+We use Conan package manager to build/consume dependencies, find detailed usage instructions [here](./Conan.md). Note that the link points to the cutting-edge state in `develop` branch, for the latest release check the same document in the [master
+branch](./Conan.md).
 
 On the step where you need to replace **PROFILE**, choose:
 - `android-32` to build for 32-bit architecture (armeabi-v7a)

--- a/docs/developers/Building_iOS.md
+++ b/docs/developers/Building_iOS.md
@@ -18,7 +18,7 @@ git clone --recurse-submodules https://github.com/vcmi/vcmi.git
 
 There are 2 ways to get prebuilt dependencies:
 
-- [Conan package manager](https://github.com/vcmi/vcmi/tree/develop/docs/conan.md) - recommended. Note that the link points to the cutting-edge state in `develop` branch, for the latest release check the same document in the [master branch (https://github.com/vcmi/vcmi/tree/master/docs/conan.md).
+- [Conan package manager](./Conan.md) - recommended. Note that the link points to the cutting-edge state in `develop` branch, for the latest release check the same document in the [master branch](./Conan.md).
 - [legacy manually built libraries](https://github.com/vcmi/vcmi-ios-deps) - can be used if you have Xcode 11/12 or to build for simulator / armv7 device
 
 ## Configuring project

--- a/docs/developers/Building_iOS.md
+++ b/docs/developers/Building_iOS.md
@@ -18,7 +18,7 @@ git clone --recurse-submodules https://github.com/vcmi/vcmi.git
 
 There are 2 ways to get prebuilt dependencies:
 
-- [Conan package manager](./Conan.md) - recommended. Note that the link points to the cutting-edge state in `develop` branch, for the latest release check the same document in the [master branch](./Conan.md).
+- [Conan package manager](./Conan.md) - recommended. Note that the link points to the state of the current branch, for the latest release check the same document in the [master branch](https://github.com/vcmi/vcmi/blob/master/docs/developers/Сonan.md).
 - [legacy manually built libraries](https://github.com/vcmi/vcmi-ios-deps) - can be used if you have Xcode 11/12 or to build for simulator / armv7 device
 
 ## Configuring project

--- a/docs/developers/Building_macOS.md
+++ b/docs/developers/Building_macOS.md
@@ -23,7 +23,7 @@ There're 2 ways to get dependencies automatically.
 
 ## Conan package manager
 
-Please find detailed instructions in [VCMI repository](https://github.com/vcmi/vcmi/tree/develop/docs/conan.md). Note that the link points to the cutting-edge state in `develop` branch, for the latest release check the same document in the [master branch](https://github.com/vcmi/vcmi/tree/master/docs/conan.md).
+Please find detailed instructions in [VCMI repository](./Conan.md). Note that the link points to the cutting-edge state in `develop` branch, for the latest release check the same document in the [master branch](./Conan.md).
 
 On the step where you need to replace **PROFILE**, choose:
 

--- a/docs/developers/Building_macOS.md
+++ b/docs/developers/Building_macOS.md
@@ -23,7 +23,7 @@ There're 2 ways to get dependencies automatically.
 
 ## Conan package manager
 
-Please find detailed instructions in [VCMI repository](./Conan.md). Note that the link points to the cutting-edge state in `develop` branch, for the latest release check the same document in the [master branch](./Conan.md).
+Please find detailed instructions [here](./Conan.md). Note that the link points to the state of the current branch, for the latest release check the same document in the [master branch](https://github.com/vcmi/vcmi/blob/master/docs/developers/Сonan.md).
 
 On the step where you need to replace **PROFILE**, choose:
 


### PR DESCRIPTION
# PR Summary
The `Conan.md` file was moved and renamed a few times. This PR adjusts sources to changes. Also it fixes a broken link syntax in the `docs/developers/Building_iOS.md` file.