### PR TITLE
[1.5.2] Campaign fixes

### DIFF
--- a/client/lobby/SelectionTab.cpp
+++ b/client/lobby/SelectionTab.cpp
@@ -677,7 +677,6 @@ void SelectionTab::selectFileName(std::string fname)
 	}
 
 	filter(-1);
-	selectAbs(-1);
 
 	for(int i = (int)curItems.size() - 1; i >= 0; i--)
 	{
@@ -688,6 +687,8 @@ void SelectionTab::selectFileName(std::string fname)
 			return;
 		}
 	}
+
+	selectAbs(-1);
 
 	if(tabType == ESelectionScreen::saveGame && inputName->getText().empty())
 		inputName->setText("NEWGAME");

--- a/config/mapOverrides.json
+++ b/config/mapOverrides.json
@@ -295,6 +295,14 @@
 				},
 				"message" : "core.genrltxt.252"
 			},
+			"standardVictory" : {
+				"condition" : [ "standardWin" ],
+				"effect" : {
+					"messageToSend" : "core.genrltxt.5",
+					"type" : "victory"
+				},
+				"message" : "core.genrltxt.659"
+			},
 			"standardDefeat" : {
 				"condition" : [ "daysWithoutTown", { "value" : 7 } ],
 				"effect" : {

--- a/lib/mapping/MapFormatH3M.cpp
+++ b/lib/mapping/MapFormatH3M.cpp
@@ -1866,7 +1866,12 @@ CGObjectInstance * CMapLoaderH3M::readHero(const int3 & mapPosition, const Objec
 		//we can read one spell
 		SpellID spell = reader->readSpell();
 
-		if(spell != SpellID::NONE)
+		// workaround: VCMI uses 'PRESET' spell to indicate that spellbook has been preconfigured on map
+		// but H3 uses 'PRESET' spell (-2) to indicate that game should give standard spell to hero
+		if(spell == SpellID::NONE)
+			object->spells.insert(SpellID::PRESET); //spellbook is preconfigured to be empty
+
+		if (spell.hasValue())
 			object->spells.insert(spell);
 	}
 

--- a/server/battles/BattleResultProcessor.cpp
+++ b/server/battles/BattleResultProcessor.cpp
@@ -481,12 +481,12 @@ void BattleResultProcessor::endBattleConfirm(const CBattleInfoCallback & battle)
 
 	if(finishingBattle->loserHero) //remove beaten hero
 	{
-		RemoveObject ro(finishingBattle->loserHero->id, battle.battleGetArmyObject(0)->getOwner());
+		RemoveObject ro(finishingBattle->loserHero->id, finishingBattle->victor);
 		gameHandler->sendAndApply(&ro);
 	}
 	if(finishingBattle->isDraw() && finishingBattle->winnerHero) //for draw case both heroes should be removed
 	{
-		RemoveObject ro(finishingBattle->winnerHero->id, battle.battleGetArmyObject(0)->getOwner());
+		RemoveObject ro(finishingBattle->winnerHero->id, finishingBattle->loser);
 		gameHandler->sendAndApply(&ro);
 	}
 


### PR DESCRIPTION
- Fixes bug leading to heroes that were defeated while defending not registered as defeated by this player
- Allow standard victory condition on 'To kill a hero' campaign mission in line with H3
- Fixes regression leading to freeze on opening campaign load screen
- Fixes Adrienne starting without Inferno spell in campaign