### PR TITLE
[1.5.2] Bonus updaters fix

### DIFF
--- a/lib/battle/BattleInfo.cpp
+++ b/lib/battle/BattleInfo.cpp
@@ -930,7 +930,7 @@ uint32_t BattleInfo::nextUnitId() const
 
 void BattleInfo::addOrUpdateUnitBonus(CStack * sta, const Bonus & value, bool forceAdd)
 {
-	if(forceAdd || !sta->hasBonus(Selector::source(BonusSource::SPELL_EFFECT, value.sid).And(Selector::typeSubtype(value.type, value.subtype))))
+	if(forceAdd || !sta->hasBonus(Selector::source(BonusSource::SPELL_EFFECT, value.sid).And(Selector::typeSubtypeValueType(value.type, value.subtype, value.valType))))
 	{
 		//no such effect or cumulative - add new
 		logBonus->trace("%s receives a new bonus: %s", sta->nodeName(), value.Description());
@@ -942,7 +942,7 @@ void BattleInfo::addOrUpdateUnitBonus(CStack * sta, const Bonus & value, bool fo
 
 		for(const auto & stackBonus : sta->getExportedBonusList()) //TODO: optimize
 		{
-			if(stackBonus->source == value.source && stackBonus->sid == value.sid && stackBonus->type == value.type && stackBonus->subtype == value.subtype)
+			if(stackBonus->source == value.source && stackBonus->sid == value.sid && stackBonus->type == value.type && stackBonus->subtype == value.subtype && stackBonus->valType == value.valType)
 			{
 				stackBonus->turnsRemain = std::max(stackBonus->turnsRemain, value.turnsRemain);
 			}

--- a/lib/bonuses/Updaters.cpp
+++ b/lib/bonuses/Updaters.cpp
@@ -19,14 +19,6 @@
 
 VCMI_LIB_NAMESPACE_BEGIN
 
-const std::map<std::string, TUpdaterPtr> bonusUpdaterMap =
-{
-	{"TIMES_HERO_LEVEL", std::make_shared<TimesHeroLevelUpdater>()},
-	{"TIMES_STACK_LEVEL", std::make_shared<TimesStackLevelUpdater>()},
-	{"ARMY_MOVEMENT", std::make_shared<ArmyMovementUpdater>()},
-	{"BONUS_OWNER_UPDATER", std::make_shared<OwnerUpdater>()}
-};
-
 std::shared_ptr<Bonus> IUpdater::createUpdatedBonus(const std::shared_ptr<Bonus> & b, const CBonusSystemNode & context) const
 {
 	return b;

--- a/lib/bonuses/Updaters.h
+++ b/lib/bonuses/Updaters.h
@@ -13,8 +13,6 @@
 
 VCMI_LIB_NAMESPACE_BEGIN
 
-extern DLL_LINKAGE const std::map<std::string, TUpdaterPtr> bonusUpdaterMap;
-
 // observers for updating bonuses based on certain events (e.g. hero gaining level)
 
 class DLL_LINKAGE IUpdater

--- a/lib/json/JsonBonus.cpp
+++ b/lib/json/JsonBonus.cpp
@@ -325,11 +325,25 @@ static BonusParams convertDeprecatedBonus(const JsonNode &ability)
 
 static TUpdaterPtr parseUpdater(const JsonNode & updaterJson)
 {
+	const std::map<std::string, std::function<TUpdaterPtr()>> bonusUpdaterMap =
+	{
+			{"TIMES_HERO_LEVEL", std::make_shared<TimesHeroLevelUpdater>},
+			{"TIMES_STACK_LEVEL", std::make_shared<TimesStackLevelUpdater>},
+			{"ARMY_MOVEMENT", std::make_shared<ArmyMovementUpdater>},
+			{"BONUS_OWNER_UPDATER", std::make_shared<OwnerUpdater>}
+	};
+
 	switch(updaterJson.getType())
 	{
 	case JsonNode::JsonType::DATA_STRING:
-		return parseByMap(bonusUpdaterMap, &updaterJson, "updater type ");
-		break;
+		{
+			auto it = bonusUpdaterMap.find(updaterJson.String());
+			if (it != bonusUpdaterMap.end())
+				return it->second();
+
+			logGlobal->error("Unknown bonus updater type '%s'", updaterJson.String());
+			return nullptr;
+		}
 	case JsonNode::JsonType::DATA_STRUCT:
 		if(updaterJson["type"].String() == "GROWS_WITH_LEVEL")
 		{


### PR DESCRIPTION
- All loaded bonuses now receive separate instance of updater instead of shared one
- - Fixes #3949
- Bonuses from timed same timed spell that have same type & subtype, but different valueType will no longer stack
- - Alleviates #4048