### PR TITLE
[1.6] Fix potential desync if client uses different stdlib with different random number generators

### DIFF
--- a/AI/BattleAI/StackWithBonuses.h
+++ b/AI/BattleAI/StackWithBonuses.h
@@ -24,20 +24,17 @@ class HypotheticBattle;
 class RNGStub : public vstd::RNG
 {
 public:
-	vstd::TRandI64 getInt64Range(int64_t lower, int64_t upper) override
+	int nextInt(int lower, int upper) override
 	{
-		return [=]()->int64_t
-		{
-			return (lower + upper)/2;
-		};
+		return (lower + upper) / 2;
 	}
-
-	vstd::TRand getDoubleRange(double lower, double upper) override
+	int64_t nextInt64(int64_t lower, int64_t upper) override
 	{
-		return [=]()->double
-		{
-			return (lower + upper)/2;
-		};
+		return (lower + upper) / 2;
+	}
+	double nextDouble(double lower, double upper) override
+	{
+		return (lower + upper) / 2;
 	}
 };
 

--- a/AI/BattleAI/StackWithBonuses.h
+++ b/AI/BattleAI/StackWithBonuses.h
@@ -21,9 +21,19 @@
 class HypotheticBattle;
 
 ///Fake random generator, used by AI to evaluate random server behavior
-class RNGStub : public vstd::RNG
+class RNGStub final : public vstd::RNG
 {
 public:
+	virtual int nextInt() override
+	{
+		return 0;
+	}
+
+	int nextBinomialInt(int coinsCount, double coinChance) override
+	{
+		return coinsCount * coinChance;
+	}
+
 	int nextInt(int lower, int upper) override
 	{
 		return (lower + upper) / 2;
@@ -35,6 +45,19 @@ public:
 	double nextDouble(double lower, double upper) override
 	{
 		return (lower + upper) / 2;
+	}
+
+	int nextInt(int upper) override
+	{
+		return upper / 2;
+	}
+	int64_t nextInt64(int64_t upper) override
+	{
+		return upper / 2;
+	}
+	double nextDouble(double upper) override
+	{
+		return upper / 2;
 	}
 };
 

--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -70,6 +70,7 @@
 #include "../lib/CGeneralTextHandler.h"
 #include "../lib/CHeroHandler.h"
 #include "../lib/CPlayerState.h"
+#include "../lib/CRandomGenerator.h"
 #include "../lib/CStack.h"
 #include "../lib/CStopWatch.h"
 #include "../lib/CThreadHelper.h"
@@ -413,8 +414,9 @@ void CPlayerInterface::heroVisit(const CGHeroInstance * visitor, const CGObjectI
 	EVENT_HANDLER_CALLED_BY_CLIENT;
 	if(start && visitedObj)
 	{
-		if(visitedObj->getVisitSound())
-			CCS->soundh->playSound(visitedObj->getVisitSound().value());
+		auto visitSound = visitedObj->getVisitSound(CRandomGenerator::getDefault());
+		if (visitSound)
+			CCS->soundh->playSound(visitSound.value());
 	}
 }
 
@@ -1410,10 +1412,14 @@ void CPlayerInterface::centerView (int3 pos, int focusTime)
 void CPlayerInterface::objectRemoved(const CGObjectInstance * obj, const PlayerColor & initiator)
 {
 	EVENT_HANDLER_CALLED_BY_CLIENT;
-	if(playerID == initiator && obj->getRemovalSound())
+	if(playerID == initiator)
 	{
-		waitWhileDialog();
-		CCS->soundh->playSound(obj->getRemovalSound().value());
+		auto removalSound = obj->getRemovalSound(CRandomGenerator::getDefault());
+		if (removalSound)
+		{
+			waitWhileDialog();
+			CCS->soundh->playSound(removalSound.value());
+		}
 	}
 	CGI->mh->waitForOngoingAnimations();
 

--- a/client/Client.cpp
+++ b/client/Client.cpp
@@ -556,6 +556,13 @@ void CClient::invalidatePaths()
 	pathCache.clear();
 }
 
+vstd::RNG & CClient::getRandomGenerator()
+{
+	// Client should use CRandomGenerator::getDefault() for UI logic
+	// Gamestate should never call this method on client!
+	throw std::runtime_error("Illegal access to random number generator from client code!");
+}
+
 std::shared_ptr<const CPathsInfo> CClient::getPathsInfo(const CGHeroInstance * h)
 {
 	assert(h);

--- a/client/Client.h
+++ b/client/Client.h
@@ -161,7 +161,7 @@ public:
 
 	void changeSpells(const CGHeroInstance * hero, bool give, const std::set<SpellID> & spells) override {};
 	bool removeObject(const CGObjectInstance * obj, const PlayerColor & initiator) override {return false;};
-	void createObject(const int3 & visitablePosition, const PlayerColor & initiator, MapObjectID type, MapObjectSubID subtype) override {};
+	void createBoat(const int3 & visitablePosition, BoatId type, PlayerColor initiator) override {};
 	void setOwner(const CGObjectInstance * obj, PlayerColor owner) override {};
 	void giveExperience(const CGHeroInstance * hero, TExpType val) override {};
 	void changePrimSkill(const CGHeroInstance * hero, PrimarySkill which, si64 val, bool abs = false) override {};

--- a/client/Client.h
+++ b/client/Client.h
@@ -214,6 +214,8 @@ public:
 
 	void setObjPropertyValue(ObjectInstanceID objid, ObjProperty prop, int32_t value) override {};
 	void setObjPropertyID(ObjectInstanceID objid, ObjProperty prop, ObjPropertyID identifier) override {};
+	void setRewardableObjectConfiguration(ObjectInstanceID objid, const Rewardable::Configuration & configuration) override {};
+	void setRewardableObjectConfiguration(ObjectInstanceID townInstanceID, BuildingID buildingID, const Rewardable::Configuration & configuration) override{};
 
 	void showInfoDialog(InfoWindow * iw) override {};
 	void removeGUI() const;

--- a/client/Client.h
+++ b/client/Client.h
@@ -25,6 +25,7 @@ class BinaryDeserializer;
 class BinarySerializer;
 class BattleAction;
 class BattleInfo;
+struct BankConfig;
 
 template<typename T> class CApplier;
 
@@ -214,6 +215,7 @@ public:
 
 	void setObjPropertyValue(ObjectInstanceID objid, ObjProperty prop, int32_t value) override {};
 	void setObjPropertyID(ObjectInstanceID objid, ObjProperty prop, ObjPropertyID identifier) override {};
+	void setBankObjectConfiguration(ObjectInstanceID objid, const BankConfig & configuration) override {};
 	void setRewardableObjectConfiguration(ObjectInstanceID objid, const Rewardable::Configuration & configuration) override {};
 	void setRewardableObjectConfiguration(ObjectInstanceID townInstanceID, BuildingID buildingID, const Rewardable::Configuration & configuration) override{};
 

--- a/client/Client.h
+++ b/client/Client.h
@@ -218,6 +218,8 @@ public:
 	void showInfoDialog(InfoWindow * iw) override {};
 	void removeGUI() const;
 
+	vstd::RNG & getRandomGenerator() override;
+
 #if SCRIPTING_ENABLED
 	scripting::Pool * getGlobalContextPool() const override;
 #endif

--- a/client/HeroMovementController.cpp
+++ b/client/HeroMovementController.cpp
@@ -24,6 +24,7 @@
 
 #include "ConditionalWait.h"
 #include "../lib/CConfigHandler.h"
+#include "../lib/CRandomGenerator.h"
 #include "../lib/pathfinder/CGPathNode.h"
 #include "../lib/mapObjects/CGHeroInstance.h"
 #include "../lib/networkPacks/PacksForClient.h"
@@ -153,8 +154,12 @@ void HeroMovementController::onTryMoveHero(const CGHeroInstance * hero, const Tr
 
 	if(details.result == TryMoveHero::EMBARK || details.result == TryMoveHero::DISEMBARK)
 	{
-		if(hero->getRemovalSound() && hero->tempOwner == LOCPLINT->playerID)
-			CCS->soundh->playSound(hero->getRemovalSound().value());
+		if (hero->tempOwner == LOCPLINT->playerID)
+		{
+			auto removalSound = hero->getRemovalSound(CRandomGenerator::getDefault());
+			if (removalSound)
+				CCS->soundh->playSound(removalSound.value());
+		}
 	}
 
 	bool directlyAttackingCreature =

--- a/client/NetPacksClient.cpp
+++ b/client/NetPacksClient.cpp
@@ -1048,7 +1048,7 @@ void ApplyClientNetPackVisitor::visitNewObject(NewObject & pack)
 {
 	cl.invalidatePaths();
 
-	const CGObjectInstance *obj = cl.getObj(pack.createdObjectID);
+	const CGObjectInstance *obj = pack.newObject;
 	if(CGI->mh)
 		CGI->mh->onObjectFadeIn(obj, pack.initiator);
 

--- a/client/adventureMap/MapAudioPlayer.cpp
+++ b/client/adventureMap/MapAudioPlayer.cpp
@@ -17,6 +17,7 @@
 #include "../media/IMusicPlayer.h"
 #include "../media/ISoundPlayer.h"
 
+#include "../../lib/CRandomGenerator.h"
 #include "../../lib/TerrainHandler.h"
 #include "../../lib/mapObjects/CArmedInstance.h"
 #include "../../lib/mapObjects/CGHeroInstance.h"
@@ -136,8 +137,12 @@ std::vector<AudioPath> MapAudioPlayer::getAmbientSounds(const int3 & tile)
 		if (!object)
 			logGlobal->warn("Already removed object %d found on tile! (%d %d %d)", objectID.getNum(), tile.x, tile.y, tile.z);
 
-		if(object && object->getAmbientSound())
-			result.push_back(object->getAmbientSound().value());
+		if(object)
+		{
+			auto ambientSound = object->getAmbientSound(CRandomGenerator::getDefault());
+			if (ambientSound)
+				result.push_back(ambientSound.value());
+		}
 	}
 
 	if(CGI->mh->getMap()->isCoastalTile(tile))

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -54,6 +54,7 @@
 #include "../lib/CHeroHandler.h"
 #include "../lib/GameSettings.h"
 #include "ConditionalWait.h"
+#include "../lib/CRandomGenerator.h"
 #include "../lib/CSkillHandler.h"
 #include "../lib/CSoundBase.h"
 

--- a/config/schemas/settings.json
+++ b/config/schemas/settings.json
@@ -437,7 +437,7 @@
 			"type" : "object",
 			"additionalProperties" : false,
 			"default" : {},
-			"required" : [ "localHostname", "localPort", "remoteHostname", "remotePort", "playerAI", "alliedAI", "friendlyAI", "neutralAI", "enemyAI" ],
+			"required" : [ "localHostname", "localPort", "remoteHostname", "remotePort", "seed", "playerAI", "alliedAI", "friendlyAI", "neutralAI", "enemyAI" ],
 			"properties" : {
 				"localHostname" : {
 					"type" : "string",
@@ -454,6 +454,10 @@
 				"remotePort" : {
 					"type" : "number",
 					"default" : 3030
+				},
+				"seed" : {
+					"type" : "number",
+					"default" : 0
 				},
 				"playerAI" : {
 					"type" : "string",
@@ -537,7 +541,7 @@
 				},
 				"loggers" : {
 					"type" : "array",
-					"default" : [ { "domain" : "global", "level" : "trace" } ],
+					"default" : [ { "domain" : "global", "level" : "trace" }, { "domain" : "rng", "level" : "info" } ],
 					"items" : {
 						"type" : "object",
 						"additionalProperties" : false,

--- a/include/vstd/CLoggerBase.h
+++ b/include/vstd/CLoggerBase.h
@@ -193,5 +193,6 @@ extern DLL_LINKAGE vstd::CLoggerBase * logNetwork;
 extern DLL_LINKAGE vstd::CLoggerBase * logAi;
 extern DLL_LINKAGE vstd::CLoggerBase * logAnim;
 extern DLL_LINKAGE vstd::CLoggerBase * logMod;
+extern DLL_LINKAGE vstd::CLoggerBase * logRng;
 
 VCMI_LIB_NAMESPACE_END

--- a/include/vstd/RNG.h
+++ b/include/vstd/RNG.h
@@ -15,18 +15,14 @@ VCMI_LIB_NAMESPACE_BEGIN
 namespace vstd
 {
 
-using TRandI64 = std::function<int64_t()>;
-using TRand = std::function<double()>;
-
 class DLL_LINKAGE RNG
 {
 public:
-
 	virtual ~RNG() = default;
 
-	virtual TRandI64 getInt64Range(int64_t lower, int64_t upper) = 0;
-
-	virtual TRand getDoubleRange(double lower, double upper) = 0;
+	virtual int nextInt(int lower, int upper) = 0;
+	virtual int64_t nextInt64(int64_t lower, int64_t upper) = 0;
+	virtual double nextDouble(double lower, double upper) = 0;
 };
 
 }
@@ -39,7 +35,7 @@ namespace RandomGeneratorUtil
 		if(container.empty())
 			throw std::runtime_error("Unable to select random item from empty container!");
 
-		return std::next(container.begin(), rand.getInt64Range(0, container.size() - 1)());
+		return std::next(container.begin(), rand.nextInt64(0, container.size() - 1));
 	}
 
 	template<typename Container>
@@ -48,7 +44,7 @@ namespace RandomGeneratorUtil
 		if(container.empty())
 			throw std::runtime_error("Unable to select random item from empty container!");
 
-		return std::next(container.begin(), rand.getInt64Range(0, container.size() - 1)());
+		return std::next(container.begin(), rand.nextInt64(0, container.size() - 1));
 	}
 
 	template<typename Container>
@@ -59,7 +55,7 @@ namespace RandomGeneratorUtil
 		int64_t totalWeight = std::accumulate(container.begin(), container.end(), 0);
 		assert(totalWeight > 0);
 
-		int64_t roll = rand.getInt64Range(0, totalWeight - 1)();
+		int64_t roll = rand.nextInt64(0, totalWeight - 1);
 
 		for (size_t i = 0; i < container.size(); ++i)
 		{
@@ -77,7 +73,7 @@ namespace RandomGeneratorUtil
 
 		for(int64_t i = n-1; i>0; --i)
 		{
-			std::swap(container.begin()[i],container.begin()[rand.getInt64Range(0, i)()]);
+			std::swap(container.begin()[i],container.begin()[rand.nextInt64(0, i)]);
 		}
 	}
 }

--- a/include/vstd/RNG.h
+++ b/include/vstd/RNG.h
@@ -20,9 +20,31 @@ class DLL_LINKAGE RNG
 public:
 	virtual ~RNG() = default;
 
+	/// Returns random number in range [lower, upper]
 	virtual int nextInt(int lower, int upper) = 0;
+
+	/// Returns random number in range [lower, upper]
 	virtual int64_t nextInt64(int64_t lower, int64_t upper) = 0;
+
+	/// Returns random number in range [lower, upper]
 	virtual double nextDouble(double lower, double upper) = 0;
+
+	/// Returns random number in range [0, upper]
+	virtual int nextInt(int upper) = 0;
+
+	/// Returns random number in range [0, upper]
+	virtual int64_t nextInt64(int64_t upper) = 0;
+
+	/// Returns random number in range [0, upper]
+	virtual double nextDouble(double upper) = 0;
+
+	/// Generates an integer between 0 and the maximum value it can hold.
+	/// Should be only used for seeding other generators
+	virtual int nextInt() = 0;
+
+	/// Returns integer using binomial distribution
+	/// returned value is number of successfull coin flips with chance 'coinChance' out of 'coinsCount' attempts
+	virtual int nextBinomialInt(int coinsCount, double coinChance) = 0;
 };
 
 }

--- a/lib/CArtHandler.h
+++ b/lib/CArtHandler.h
@@ -25,7 +25,6 @@ class CArtHandler;
 class CGHeroInstance;
 class CArtifactSet;
 class CArtifactInstance;
-class CRandomGenerator;
 class CMap;
 class JsonSerializeFormat;
 

--- a/lib/CCreatureHandler.cpp
+++ b/lib/CCreatureHandler.cpp
@@ -14,7 +14,6 @@
 #include "ResourceSet.h"
 #include "filesystem/Filesystem.h"
 #include "VCMI_Lib.h"
-#include "CRandomGenerator.h"
 #include "CTownHandler.h"
 #include "GameSettings.h"
 #include "constants/StringConstants.h"
@@ -27,6 +26,8 @@
 #include "mapObjectConstructors/CObjectClassesHandler.h"
 #include "modding/CModHandler.h"
 #include "ExceptionsCommon.h"
+
+#include <vstd/RNG.h>
 
 VCMI_LIB_NAMESPACE_BEGIN
 
@@ -1362,7 +1363,7 @@ CCreatureHandler::~CCreatureHandler()
 		p.first = nullptr;
 }
 
-CreatureID CCreatureHandler::pickRandomMonster(CRandomGenerator & rand, int tier) const
+CreatureID CCreatureHandler::pickRandomMonster(vstd::RNG & rand, int tier) const
 {
 	std::vector<CreatureID> allowed;
 	for(const auto & creature : objects)

--- a/lib/CCreatureHandler.h
+++ b/lib/CCreatureHandler.h
@@ -23,11 +23,15 @@
 
 VCMI_LIB_NAMESPACE_BEGIN
 
+namespace vstd
+{
+class RNG;
+}
+
 class CLegacyConfigParser;
 class CCreatureHandler;
 class CCreature;
 class JsonSerializeFormat;
-class CRandomGenerator;
 
 class DLL_LINKAGE CCreature : public Creature, public CBonusSystemNode
 {
@@ -225,7 +229,7 @@ public:
 	std::vector< std::vector <ui8> > skillLevels; //how much of a bonus will be given to commander with every level. SPELL_POWER also gives CASTS and RESISTANCE
 	std::vector <std::pair <std::shared_ptr<Bonus>, std::pair <ui8, ui8> > > skillRequirements; // first - Bonus, second - which two skills are needed to use it
 
-	CreatureID pickRandomMonster(CRandomGenerator & rand, int tier = -1) const; //tier <1 - CREATURES_PER_TOWN> or -1 for any
+	CreatureID pickRandomMonster(vstd::RNG & rand, int tier = -1) const; //tier <1 - CREATURES_PER_TOWN> or -1 for any
 
 	CCreatureHandler();
 	~CCreatureHandler();

--- a/lib/CGameInfoCallback.cpp
+++ b/lib/CGameInfoCallback.cpp
@@ -658,11 +658,11 @@ std::string CGameInfoCallback::getTavernRumor(const CGObjectInstance * townOrTav
 	text.appendLocalString(EMetaText::GENERAL_TXT, 216);
 	
 	std::string extraText;
-	if(gs->rumor.type == RumorState::TYPE_NONE)
+	if(gs->currentRumor.type == RumorState::TYPE_NONE)
 		return text.toString();
 
-	auto rumor = gs->rumor.last[gs->rumor.type];
-	switch(gs->rumor.type)
+	auto rumor = gs->currentRumor.last[gs->currentRumor.type];
+	switch(gs->currentRumor.type)
 	{
 	case RumorState::TYPE_SPECIAL:
 		text.replaceLocalString(EMetaText::GENERAL_TXT, rumor.first);

--- a/lib/CHeroHandler.cpp
+++ b/lib/CHeroHandler.cpp
@@ -17,7 +17,6 @@
 #include "battle/BattleHex.h"
 #include "CCreatureHandler.h"
 #include "GameSettings.h"
-#include "CRandomGenerator.h"
 #include "CTownHandler.h"
 #include "CSkillHandler.h"
 #include "BattleFieldHandler.h"
@@ -28,6 +27,8 @@
 #include "mapObjectConstructors/AObjectTypeHandler.h"
 #include "mapObjectConstructors/CObjectClassesHandler.h"
 #include "modding/IdentifierStorage.h"
+
+#include <vstd/RNG.h>
 
 VCMI_LIB_NAMESPACE_BEGIN
 
@@ -123,7 +124,7 @@ void CHero::serializeJson(JsonSerializeFormat & handler)
 }
 
 
-SecondarySkill CHeroClass::chooseSecSkill(const std::set<SecondarySkill> & possibles, CRandomGenerator & rand) const //picks secondary skill out from given possibilities
+SecondarySkill CHeroClass::chooseSecSkill(const std::set<SecondarySkill> & possibles, vstd::RNG & rand) const //picks secondary skill out from given possibilities
 {
 	assert(!possibles.empty());
 

--- a/lib/CHeroHandler.h
+++ b/lib/CHeroHandler.h
@@ -23,11 +23,15 @@
 
 VCMI_LIB_NAMESPACE_BEGIN
 
+namespace vstd
+{
+class RNG;
+}
+
 class CHeroClass;
 class CGHeroInstance;
 struct BattleHex;
 class JsonNode;
-class CRandomGenerator;
 class JsonSerializeFormat;
 class BattleField;
 
@@ -148,7 +152,7 @@ public:
 	std::string getNameTextID() const override;
 
 	bool isMagicHero() const;
-	SecondarySkill chooseSecSkill(const std::set<SecondarySkill> & possibles, CRandomGenerator & rand) const; //picks secondary skill out from given possibilities
+	SecondarySkill chooseSecSkill(const std::set<SecondarySkill> & possibles, vstd::RNG & rand) const; //picks secondary skill out from given possibilities
 
 	void updateFrom(const JsonNode & data);
 	void serializeJson(JsonSerializeFormat & handler);

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -529,6 +529,7 @@ set(lib_MAIN_HEADERS
 	networkPacks/PacksForClientBattle.h
 	networkPacks/PacksForLobby.h
 	networkPacks/PacksForServer.h
+	networkPacks/SetRewardableConfiguration.h
 	networkPacks/SetStackEffect.h
 	networkPacks/StackLocation.h
 	networkPacks/TradeItem.h

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -93,6 +93,7 @@ set(lib_MAIN_SRCS
 	gameState/CGameState.cpp
 	gameState/CGameStateCampaign.cpp
 	gameState/InfoAboutArmy.cpp
+	gameState/RumorState.cpp
 	gameState/TavernHeroesPool.cpp
 
 	mapObjectConstructors/AObjectTypeHandler.cpp
@@ -448,6 +449,7 @@ set(lib_MAIN_HEADERS
 	gameState/CGameStateCampaign.h
 	gameState/EVictoryLossCheckResult.h
 	gameState/InfoAboutArmy.h
+	gameState/RumorState.h
 	gameState/SThievesGuildInfo.h
 	gameState/TavernHeroesPool.h
 	gameState/TavernSlot.h

--- a/lib/CRandomGenerator.cpp
+++ b/lib/CRandomGenerator.cpp
@@ -35,28 +35,17 @@ void CRandomGenerator::resetSeed()
 	setSeed(static_cast<int>(threadIdHash * std::time(nullptr)));
 }
 
-TRandI CRandomGenerator::getIntRange(int lower, int upper)
-{
-	if (lower <= upper)
-		return std::bind(TIntDist(lower, upper), std::ref(rand));
-	throw std::runtime_error("Invalid range provided: " + std::to_string(lower) + " ... " + std::to_string(upper));
-}
-
-vstd::TRandI64 CRandomGenerator::getInt64Range(int64_t lower, int64_t upper)
-{
-	if(lower <= upper)
-		return std::bind(TInt64Dist(lower, upper), std::ref(rand));
-	throw std::runtime_error("Invalid range provided: " + std::to_string(lower) + " ... " + std::to_string(upper));
-}
-
 int CRandomGenerator::nextInt(int upper)
 {
-	return getIntRange(0, upper)();
+	return nextInt(0, upper);
 }
 
 int CRandomGenerator::nextInt(int lower, int upper)
 {
-	return getIntRange(lower, upper)();
+	if (lower > upper)
+		throw std::runtime_error("Invalid range provided: " + std::to_string(lower) + " ... " + std::to_string(upper));
+
+	return TIntDist(lower, upper)(rand);
 }
 
 int CRandomGenerator::nextInt()
@@ -64,28 +53,31 @@ int CRandomGenerator::nextInt()
 	return TIntDist()(rand);
 }
 
-vstd::TRand CRandomGenerator::getDoubleRange(double lower, double upper)
+int64_t CRandomGenerator::nextInt64(int64_t lower, int64_t upper)
 {
-	if(lower <= upper)
-		return std::bind(TRealDist(lower, upper), std::ref(rand));
-	throw std::runtime_error("Invalid range provided: " + std::to_string(lower) + " ... " + std::to_string(upper));
+	if (lower > upper)
+		throw std::runtime_error("Invalid range provided: " + std::to_string(lower) + " ... " + std::to_string(upper));
 
+	return TInt64Dist(lower, upper)(rand);
 }
 
 double CRandomGenerator::nextDouble(double upper)
 {
-	return getDoubleRange(0, upper)();
+	return nextDouble(0, upper);
 }
 
 double CRandomGenerator::nextDouble(double lower, double upper)
 {
-	return getDoubleRange(lower, upper)();
+	if(lower > upper)
+		throw std::runtime_error("Invalid range provided: " + std::to_string(lower) + " ... " + std::to_string(upper));
+
+	return TRealDist(lower, upper)(rand);
 }
 
-double CRandomGenerator::nextDouble()
-{
-	return TRealDist()(rand);
-}
+//double CRandomGenerator::nextDouble()
+//{
+//	return TRealDist()(rand);
+//}
 
 CRandomGenerator & CRandomGenerator::getDefault()
 {

--- a/lib/CRandomGenerator.cpp
+++ b/lib/CRandomGenerator.cpp
@@ -40,6 +40,11 @@ int CRandomGenerator::nextInt(int upper)
 	return nextInt(0, upper);
 }
 
+int64_t CRandomGenerator::nextInt64(int64_t upper)
+{
+	return nextInt64(0, upper);
+}
+
 int CRandomGenerator::nextInt(int lower, int upper)
 {
 	if (lower > upper)
@@ -51,6 +56,12 @@ int CRandomGenerator::nextInt(int lower, int upper)
 int CRandomGenerator::nextInt()
 {
 	return TIntDist()(rand);
+}
+
+int CRandomGenerator::nextBinomialInt(int coinsCount, double coinChance)
+{
+	std::binomial_distribution<> distribution(coinsCount, coinChance);
+	return distribution(rand);
 }
 
 int64_t CRandomGenerator::nextInt64(int64_t lower, int64_t upper)
@@ -74,20 +85,11 @@ double CRandomGenerator::nextDouble(double lower, double upper)
 	return TRealDist(lower, upper)(rand);
 }
 
-//double CRandomGenerator::nextDouble()
-//{
-//	return TRealDist()(rand);
-//}
-
 CRandomGenerator & CRandomGenerator::getDefault()
 {
 	static thread_local CRandomGenerator defaultRand;
 	return defaultRand;
 }
 
-TGenerator & CRandomGenerator::getStdGenerator()
-{
-	return rand;
-}
 
 VCMI_LIB_NAMESPACE_END

--- a/lib/CRandomGenerator.cpp
+++ b/lib/CRandomGenerator.cpp
@@ -15,21 +15,25 @@ VCMI_LIB_NAMESPACE_BEGIN
 
 CRandomGenerator::CRandomGenerator()
 {
+	logRng->trace("CRandomGenerator constructed");
 	resetSeed();
 }
 
 CRandomGenerator::CRandomGenerator(int seed)
 {
+	logRng->trace("CRandomGenerator constructed (%d)", seed);
 	setSeed(seed);
 }
 
 void CRandomGenerator::setSeed(int seed)
 {
+	logRng->trace("CRandomGenerator::setSeed (%d)", seed);
 	rand.seed(seed);
 }
 
 void CRandomGenerator::resetSeed()
 {
+	logRng->trace("CRandomGenerator::resetSeed");
 	boost::hash<std::string> stringHash;
 	auto threadIdHash = stringHash(boost::lexical_cast<std::string>(boost::this_thread::get_id()));
 	setSeed(static_cast<int>(threadIdHash * std::time(nullptr)));
@@ -37,16 +41,20 @@ void CRandomGenerator::resetSeed()
 
 int CRandomGenerator::nextInt(int upper)
 {
+	logRng->trace("CRandomGenerator::nextInt (%d)", upper);
 	return nextInt(0, upper);
 }
 
 int64_t CRandomGenerator::nextInt64(int64_t upper)
 {
+	logRng->trace("CRandomGenerator::nextInt64 (%d)", upper);
 	return nextInt64(0, upper);
 }
 
 int CRandomGenerator::nextInt(int lower, int upper)
 {
+	logRng->trace("CRandomGenerator::nextInt64 (%d, %d)", lower, upper);
+
 	if (lower > upper)
 		throw std::runtime_error("Invalid range provided: " + std::to_string(lower) + " ... " + std::to_string(upper));
 
@@ -55,17 +63,20 @@ int CRandomGenerator::nextInt(int lower, int upper)
 
 int CRandomGenerator::nextInt()
 {
+	logRng->trace("CRandomGenerator::nextInt64");
 	return TIntDist()(rand);
 }
 
 int CRandomGenerator::nextBinomialInt(int coinsCount, double coinChance)
 {
+	logRng->trace("CRandomGenerator::nextBinomialInt (%d, %f)", coinsCount, coinChance);
 	std::binomial_distribution<> distribution(coinsCount, coinChance);
 	return distribution(rand);
 }
 
 int64_t CRandomGenerator::nextInt64(int64_t lower, int64_t upper)
 {
+	logRng->trace("CRandomGenerator::nextInt64 (%d, %d)", lower, upper);
 	if (lower > upper)
 		throw std::runtime_error("Invalid range provided: " + std::to_string(lower) + " ... " + std::to_string(upper));
 
@@ -74,11 +85,13 @@ int64_t CRandomGenerator::nextInt64(int64_t lower, int64_t upper)
 
 double CRandomGenerator::nextDouble(double upper)
 {
+	logRng->trace("CRandomGenerator::nextDouble (%f)", upper);
 	return nextDouble(0, upper);
 }
 
 double CRandomGenerator::nextDouble(double lower, double upper)
 {
+	logRng->trace("CRandomGenerator::nextDouble (%f, %f)", lower, upper);
 	if(lower > upper)
 		throw std::runtime_error("Invalid range provided: " + std::to_string(lower) + " ... " + std::to_string(upper));
 

--- a/lib/CRandomGenerator.h
+++ b/lib/CRandomGenerator.h
@@ -46,18 +46,23 @@ public:
 
 	/// Generates an integer between 0 and upper.
 	/// requires: 0 <= upper
-	int nextInt(int upper);
+	int nextInt(int upper) override;
+	int64_t nextInt64(int64_t upper) override;
 
 	/// requires: lower <= upper
 	int nextInt(int lower, int upper) override;
 	int64_t nextInt64(int64_t lower, int64_t upper) override;
 
 	/// Generates an integer between 0 and the maximum value it can hold.
-	int nextInt();
+	int nextInt() override;
+
+	///
+	int nextBinomialInt(int coinsCount, double coinChance) override;
+
 
 	/// Generates a double between 0 and upper.
 	/// requires: 0 <= upper
-	double nextDouble(double upper);
+	double nextDouble(double upper) override;
 
 	/// requires: lower <= upper
 	double nextDouble(double lower, double upper) override;
@@ -65,9 +70,6 @@ public:
 	/// Gets a globally accessible RNG which will be constructed once per thread. For the
 	/// seed a combination of the thread ID and current time in milliseconds will be used.
 	static CRandomGenerator & getDefault();
-
-	/// Provide method so that this RNG can be used with legacy std:: API
-	TGenerator & getStdGenerator();
 
 private:
 	TGenerator rand;

--- a/lib/CRandomGenerator.h
+++ b/lib/CRandomGenerator.h
@@ -15,6 +15,7 @@
 
 VCMI_LIB_NAMESPACE_BEGIN
 
+
 /// Generator to use for all randomization in game
 /// minstd_rand is selected due to following reasons:
 /// 1. Its randomization quality is below mt_19937 however this is unlikely to be noticeable in game
@@ -23,12 +24,11 @@ using TGenerator = std::minstd_rand;
 using TIntDist = std::uniform_int_distribution<int>;
 using TInt64Dist = std::uniform_int_distribution<int64_t>;
 using TRealDist = std::uniform_real_distribution<double>;
-using TRandI = std::function<int()>;
 
 /// The random generator randomly generates integers and real numbers("doubles") between
 /// a given range. This is a header only class and mainly a wrapper for
 /// convenient usage of the standard random API. An instance of this RNG is not thread safe.
-class DLL_LINKAGE CRandomGenerator : public vstd::RNG, boost::noncopyable, public Serializeable
+class DLL_LINKAGE CRandomGenerator final : public vstd::RNG, boost::noncopyable, public Serializeable
 {
 public:
 	/// Seeds the generator by default with the product of the current time in milliseconds and the
@@ -44,37 +44,23 @@ public:
 	/// current thread ID.
 	void resetSeed();
 
-	/// Generate several integer numbers within the same range.
-	/// e.g.: auto a = gen.getIntRange(0,10); a(); a(); a();
-	/// requires: lower <= upper
-	TRandI getIntRange(int lower, int upper);
-
-	vstd::TRandI64 getInt64Range(int64_t lower, int64_t upper) override;
-
 	/// Generates an integer between 0 and upper.
 	/// requires: 0 <= upper
 	int nextInt(int upper);
 
 	/// requires: lower <= upper
-	int nextInt(int lower, int upper);
+	int nextInt(int lower, int upper) override;
+	int64_t nextInt64(int64_t lower, int64_t upper) override;
 
 	/// Generates an integer between 0 and the maximum value it can hold.
 	int nextInt();
-
-	/// Generate several double/real numbers within the same range.
-	/// e.g.: auto a = gen.getDoubleRange(4.5,10.2); a(); a(); a();
-	/// requires: lower <= upper
-	vstd::TRand getDoubleRange(double lower, double upper) override;
 
 	/// Generates a double between 0 and upper.
 	/// requires: 0 <= upper
 	double nextDouble(double upper);
 
 	/// requires: lower <= upper
-	double nextDouble(double lower, double upper);
-
-	/// Generates a double between 0.0 and 1.0.
-	double nextDouble();
+	double nextDouble(double lower, double upper) override;
 
 	/// Gets a globally accessible RNG which will be constructed once per thread. For the
 	/// seed a combination of the thread ID and current time in milliseconds will be used.

--- a/lib/CStack.cpp
+++ b/lib/CStack.cpp
@@ -212,11 +212,9 @@ void CStack::prepareAttacked(BattleStackAttacked & bsa, vstd::RNG & rand, const 
 
 			auto resurrectedAdd = static_cast<int32_t>(baseAmount - (resurrectedCount / resurrectFactor));
 
-			auto rangeGen = rand.getInt64Range(0, 99);
-
 			for(int32_t i = 0; i < resurrectedAdd; i++)
 			{
-				if(resurrectValue > rangeGen())
+				if(resurrectValue > rand.nextInt(0, 99))
 					resurrectedCount += 1;
 			}
 

--- a/lib/IGameCallback.cpp
+++ b/lib/IGameCallback.cpp
@@ -14,7 +14,6 @@
 #include "spells/CSpellHandler.h"// for CSpell
 #include "CSkillHandler.h"// for CSkill
 #include "CBonusTypeHandler.h"
-#include "CRandomGenerator.h"
 #include "BattleFieldHandler.h"
 #include "ObstacleHandler.h"
 #include "bonuses/Limiters.h"

--- a/lib/IGameCallback.cpp
+++ b/lib/IGameCallback.cpp
@@ -14,6 +14,7 @@
 #include "spells/CSpellHandler.h"// for CSpell
 #include "CSkillHandler.h"// for CSkill
 #include "CBonusTypeHandler.h"
+#include "CRandomGenerator.h"
 #include "BattleFieldHandler.h"
 #include "ObstacleHandler.h"
 #include "bonuses/Limiters.h"
@@ -50,6 +51,8 @@
 #include "RoadHandler.h"
 #include "RiverHandler.h"
 #include "TerrainHandler.h"
+
+#include <vstd/RNG.h>
 
 VCMI_LIB_NAMESPACE_BEGIN
 
@@ -146,7 +149,7 @@ void CPrivilegedInfoCallback::getAllTiles(std::unordered_set<int3> & tiles, std:
 	}
 }
 
-void CPrivilegedInfoCallback::pickAllowedArtsSet(std::vector<const CArtifact *> & out, CRandomGenerator & rand)
+void CPrivilegedInfoCallback::pickAllowedArtsSet(std::vector<const CArtifact *> & out, vstd::RNG & rand)
 {
 	for (int j = 0; j < 3 ; j++)
 		out.push_back(gameState()->pickRandomArtifact(rand, CArtifact::ART_TREASURE).toArtifact());

--- a/lib/IGameCallback.h
+++ b/lib/IGameCallback.h
@@ -16,13 +16,17 @@
 
 VCMI_LIB_NAMESPACE_BEGIN
 
+namespace vstd
+{
+class RNG;
+}
+
 struct SetMovePoints;
 struct GiveBonus;
 struct BlockingDialog;
 struct TeleportDialog;
 struct StackLocation;
 struct ArtifactLocation;
-class CRandomGenerator;
 class CCreatureSet;
 class CStackBasicDescriptor;
 class CGCreature;
@@ -61,7 +65,7 @@ public:
 	void getAllTiles(std::unordered_set<int3> &tiles, std::optional<PlayerColor> player, int level, std::function<bool(const TerrainTile *)> filter) const;
 
 	//gives 3 treasures, 3 minors, 1 major -> used by Black Market and Artifact Merchant
-	void pickAllowedArtsSet(std::vector<const CArtifact *> & out, CRandomGenerator & rand);
+	void pickAllowedArtsSet(std::vector<const CArtifact *> & out, vstd::RNG & rand);
 	void getAllowedSpells(std::vector<SpellID> &out, std::optional<ui16> level = std::nullopt);
 
 	template<typename Saver>

--- a/lib/IGameCallback.h
+++ b/lib/IGameCallback.h
@@ -37,6 +37,11 @@ namespace spells
 	class Caster;
 }
 
+namespace Rewardable
+{
+	struct Configuration;
+}
+
 #if SCRIPTING_ENABLED
 namespace scripting
 {
@@ -79,6 +84,8 @@ class DLL_LINKAGE IGameEventCallback
 {
 public:
 	virtual void setObjPropertyValue(ObjectInstanceID objid, ObjProperty prop, int32_t value = 0) = 0;
+	virtual void setRewardableObjectConfiguration(ObjectInstanceID mapObjectID, const Rewardable::Configuration & configuration) = 0;
+	virtual void setRewardableObjectConfiguration(ObjectInstanceID townInstanceID, BuildingID buildingID, const Rewardable::Configuration & configuration) = 0;
 	virtual void setObjPropertyID(ObjectInstanceID objid, ObjProperty prop, ObjPropertyID identifier) = 0;
 
 	virtual void showInfoDialog(InfoWindow * iw) = 0;

--- a/lib/IGameCallback.h
+++ b/lib/IGameCallback.h
@@ -92,7 +92,7 @@ public:
 
 	virtual void changeSpells(const CGHeroInstance * hero, bool give, const std::set<SpellID> &spells)=0;
 	virtual bool removeObject(const CGObjectInstance * obj, const PlayerColor & initiator) = 0;
-	virtual void createObject(const int3 & visitablePosition, const PlayerColor & initiator, MapObjectID type, MapObjectSubID subtype) = 0;
+	virtual void createBoat(const int3 & visitablePosition, BoatId type, PlayerColor initiator) = 0;
 	virtual void setOwner(const CGObjectInstance * objid, PlayerColor owner)=0;
 	virtual void giveExperience(const CGHeroInstance * hero, TExpType val) =0;
 	virtual void changePrimSkill(const CGHeroInstance * hero, PrimarySkill which, si64 val, bool abs=false)=0;

--- a/lib/IGameCallback.h
+++ b/lib/IGameCallback.h
@@ -135,6 +135,9 @@ public:
 	virtual void changeFogOfWar(std::unordered_set<int3> &tiles, PlayerColor player, ETileVisibility mode) = 0;
 	
 	virtual void castSpell(const spells::Caster * caster, SpellID spellID, const int3 &pos) = 0;
+
+	virtual vstd::RNG & getRandomGenerator() = 0;
+
 };
 
 class DLL_LINKAGE CNonConstInfoCallback : public CPrivilegedInfoCallback

--- a/lib/IGameCallback.h
+++ b/lib/IGameCallback.h
@@ -27,6 +27,7 @@ struct BlockingDialog;
 struct TeleportDialog;
 struct StackLocation;
 struct ArtifactLocation;
+struct BankConfig;
 class CCreatureSet;
 class CStackBasicDescriptor;
 class CGCreature;
@@ -84,6 +85,7 @@ class DLL_LINKAGE IGameEventCallback
 {
 public:
 	virtual void setObjPropertyValue(ObjectInstanceID objid, ObjProperty prop, int32_t value = 0) = 0;
+	virtual void setBankObjectConfiguration(ObjectInstanceID objid, const BankConfig & configuration) = 0;
 	virtual void setRewardableObjectConfiguration(ObjectInstanceID mapObjectID, const Rewardable::Configuration & configuration) = 0;
 	virtual void setRewardableObjectConfiguration(ObjectInstanceID townInstanceID, BuildingID buildingID, const Rewardable::Configuration & configuration) = 0;
 	virtual void setObjPropertyID(ObjectInstanceID objid, ObjProperty prop, ObjPropertyID identifier) = 0;

--- a/lib/StartInfo.h
+++ b/lib/StartInfo.h
@@ -152,7 +152,7 @@ struct DLL_LINKAGE StartInfo : public Serializeable
 		h & playerInfos;
 		if (h.version < Handler::Version::REMOVE_LIB_RNG)
 		{
-			uint32_t oldSeeds;
+			uint32_t oldSeeds = 0;
 			h & oldSeeds;
 			h & oldSeeds;
 			h & oldSeeds;

--- a/lib/StartInfo.h
+++ b/lib/StartInfo.h
@@ -123,9 +123,6 @@ struct DLL_LINKAGE StartInfo : public Serializeable
 	using TPlayerInfos = std::map<PlayerColor, PlayerSettings>;
 	TPlayerInfos playerInfos; //color indexed
 
-	ui32 seedToBeUsed; //0 if not sure (client requests server to decide, will be send in reply pack)
-	ui32 seedPostInit; //so we know that game is correctly synced at the start; 0 if not known yet
-	ui32 mapfileChecksum; //0 if not relevant
 	std::string startTimeIso8601;
 	std::string fileURI;
 	SimturnsInfo simturnsInfo;
@@ -153,9 +150,13 @@ struct DLL_LINKAGE StartInfo : public Serializeable
 		h & mode;
 		h & difficulty;
 		h & playerInfos;
-		h & seedToBeUsed;
-		h & seedPostInit;
-		h & mapfileChecksum;
+		if (h.version < Handler::Version::REMOVE_LIB_RNG)
+		{
+			uint32_t oldSeeds;
+			h & oldSeeds;
+			h & oldSeeds;
+			h & oldSeeds;
+		}
 		h & startTimeIso8601;
 		h & fileURI;
 		h & simturnsInfo;
@@ -169,8 +170,10 @@ struct DLL_LINKAGE StartInfo : public Serializeable
 		h & campState;
 	}
 
-	StartInfo() : mode(EStartMode::INVALID), difficulty(1), seedToBeUsed(0), seedPostInit(0),
-		mapfileChecksum(0), startTimeIso8601(vstd::getDateTimeISO8601Basic(std::time(nullptr))), fileURI("")
+	StartInfo()
+		: mode(EStartMode::INVALID)
+		, difficulty(1)
+		, startTimeIso8601(vstd::getDateTimeISO8601Basic(std::time(nullptr)))
 	{
 
 	}

--- a/lib/battle/BattleInfo.cpp
+++ b/lib/battle/BattleInfo.cpp
@@ -662,10 +662,9 @@ int64_t BattleInfo::getActualDamage(const DamageRange & damage, int32_t attacker
 		int64_t sum = 0;
 
 		auto howManyToAv = std::min<int32_t>(10, attackerCount);
-		auto rangeGen = rng.getInt64Range(damage.min, damage.max);
 
 		for(int32_t g = 0; g < howManyToAv; ++g)
-			sum += rangeGen();
+			sum += rng.nextInt64(damage.min, damage.max);
 
 		return sum / howManyToAv;
 	}

--- a/lib/battle/BattleInfo.cpp
+++ b/lib/battle/BattleInfo.cpp
@@ -12,7 +12,6 @@
 #include "CObstacleInstance.h"
 #include "bonuses/Limiters.h"
 #include "bonuses/Updaters.h"
-#include "../CRandomGenerator.h"
 #include "../CStack.h"
 #include "../CHeroHandler.h"
 #include "../filesystem/Filesystem.h"
@@ -21,6 +20,7 @@
 #include "../BattleFieldHandler.h"
 #include "../ObstacleHandler.h"
 
+#include <vstd/RNG.h>
 
 //TODO: remove
 #include "../IGameCallback.h"

--- a/lib/battle/CBattleInfoCallback.cpp
+++ b/lib/battle/CBattleInfoCallback.cpp
@@ -11,6 +11,7 @@
 #include "CBattleInfoCallback.h"
 
 #include <vcmi/scripting/Service.h>
+#include <vstd/RNG.h>
 
 #include "../CStack.h"
 #include "BattleInfo.h"
@@ -25,7 +26,6 @@
 #include "../networkPacks/PacksForClientBattle.h"
 #include "../BattleFieldHandler.h"
 #include "../Rect.h"
-#include "../CRandomGenerator.h"
 
 VCMI_LIB_NAMESPACE_BEGIN
 
@@ -1602,7 +1602,7 @@ std::set<const battle::Unit *> CBattleInfoCallback::battleAdjacentUnits(const ba
 	return ret;
 }
 
-SpellID CBattleInfoCallback::getRandomBeneficialSpell(CRandomGenerator & rand, const battle::Unit * caster, const battle::Unit * subject) const
+SpellID CBattleInfoCallback::getRandomBeneficialSpell(vstd::RNG & rand, const battle::Unit * caster, const battle::Unit * subject) const
 {
 	RETURN_IF_NOT_BATTLE(SpellID::NONE);
 	//This is complete list. No spells from mods.
@@ -1748,7 +1748,7 @@ SpellID CBattleInfoCallback::getRandomBeneficialSpell(CRandomGenerator & rand, c
 	}
 }
 
-SpellID CBattleInfoCallback::getRandomCastedSpell(CRandomGenerator & rand,const CStack * caster) const
+SpellID CBattleInfoCallback::getRandomCastedSpell(vstd::RNG & rand,const CStack * caster) const
 {
 	RETURN_IF_NOT_BATTLE(SpellID::NONE);
 

--- a/lib/battle/CBattleInfoCallback.h
+++ b/lib/battle/CBattleInfoCallback.h
@@ -23,8 +23,12 @@ class SpellCastEnvironment;
 class CSpell;
 struct CObstacleInstance;
 class IBonusBearer;
-class CRandomGenerator;
 class PossiblePlayerBattleAction;
+
+namespace vstd
+{
+class RNG;
+}
 
 namespace spells
 {
@@ -116,8 +120,8 @@ public:
 	int32_t battleGetSpellCost(const spells::Spell * sp, const CGHeroInstance * caster) const; //returns cost of given spell
 	ESpellCastProblem battleCanCastSpell(const spells::Caster * caster, spells::Mode mode) const; //returns true if there are no general issues preventing from casting a spell
 
-	SpellID getRandomBeneficialSpell(CRandomGenerator & rand, const battle::Unit * caster, const battle::Unit * target) const;
-	SpellID getRandomCastedSpell(CRandomGenerator & rand, const CStack * caster) const; //called at the beginning of turn for Faerie Dragon
+	SpellID getRandomBeneficialSpell(vstd::RNG & rand, const battle::Unit * caster, const battle::Unit * target) const;
+	SpellID getRandomCastedSpell(vstd::RNG & rand, const CStack * caster) const; //called at the beginning of turn for Faerie Dragon
 
 	std::vector<PossiblePlayerBattleAction> getClientActionsForStack(const CStack * stack, const BattleClientInterfaceData & data);
 	PossiblePlayerBattleAction getCasterAction(const CSpell * spell, const spells::Caster * caster, spells::Mode mode) const;

--- a/lib/gameState/CGameState.cpp
+++ b/lib/gameState/CGameState.cpp
@@ -21,7 +21,6 @@
 #include "../CGeneralTextHandler.h"
 #include "../CHeroHandler.h"
 #include "../CPlayerState.h"
-#include "../CRandomGenerator.h"
 #include "../CStopWatch.h"
 #include "../GameSettings.h"
 #include "../StartInfo.h"
@@ -311,7 +310,7 @@ void CGameState::initNewGame(const IMapService * mapService, bool allowSavingRan
 				const std::string templateName = options->getMapTemplate()->getName();
 				const std::string dt = vstd::getDateTimeISO8601Basic(std::time(nullptr));
 
-				const std::string fileName = boost::str(boost::format("%s_%s_%d.vmap") % dt % templateName );
+				const std::string fileName = boost::str(boost::format("%s_%s.vmap") % dt % templateName );
 				const auto fullPath = path / fileName;
 
 				randomMap->name.appendRawString(boost::str(boost::format(" %s") % dt));

--- a/lib/gameState/CGameState.cpp
+++ b/lib/gameState/CGameState.cpp
@@ -185,8 +185,6 @@ void CGameState::init(const IMapService * mapService, StartInfo * si, Load::Prog
 {
 	assert(services);
 	assert(callback);
-	logGlobal->info("\tUsing random seed: %d", si->seedToBeUsed);
-	rand = std::make_unique<CRandomGenerator>(si->seedToBeUsed);
 	scenarioOps = CMemorySerializer::deepCopy(*si).release();
 	initialOpts = CMemorySerializer::deepCopy(*si).release();
 	si = nullptr;
@@ -1966,7 +1964,7 @@ TeamState::TeamState()
 
 vstd::RNG & CGameState::getRandomGenerator()
 {
-	return *rand;
+	return callback->getRandomGenerator();
 }
 
 ArtifactID CGameState::pickRandomArtifact(vstd::RNG & rand, int flags, std::function<bool(ArtifactID)> accepts)

--- a/lib/gameState/CGameState.h
+++ b/lib/gameState/CGameState.h
@@ -201,7 +201,6 @@ public:
 private:
 	// ----- initialization -----
 	void initNewGame(const IMapService * mapService, bool allowSavingRandomMap, Load::ProgressAccumulator & progressTracking);
-	void checkMapChecksum();
 	void initGlobalBonuses();
 	void initGrailPosition();
 	void initRandomFactionsForPlayers();

--- a/lib/gameState/CGameState.h
+++ b/lib/gameState/CGameState.h
@@ -14,6 +14,8 @@
 #include "../LoadProgress.h"
 #include "../ConstTransitivePtr.h"
 
+#include "RumorState.h"
+
 namespace boost
 {
 class shared_mutex;
@@ -37,35 +39,6 @@ class CRandomGenerator;
 
 template<typename T> class CApplier;
 class CBaseForGSApply;
-
-struct DLL_LINKAGE RumorState
-{
-	enum ERumorType : ui8
-	{
-		TYPE_NONE = 0, TYPE_RAND, TYPE_SPECIAL, TYPE_MAP
-	};
-
-	enum ERumorTypeSpecial : ui8
-	{
-		RUMOR_OBELISKS = 208,
-		RUMOR_ARTIFACTS = 209,
-		RUMOR_ARMY = 210,
-		RUMOR_INCOME = 211,
-		RUMOR_GRAIL = 212
-	};
-
-	ERumorType type;
-	std::map<ERumorType, std::pair<int, int>> last;
-
-	RumorState(){type = TYPE_NONE;};
-	bool update(int id, int extra);
-
-	template <typename Handler> void serialize(Handler &h)
-	{
-		h & type;
-		h & last;
-	}
-};
 
 struct UpgradeInfo
 {
@@ -115,7 +88,7 @@ public:
 	std::map<PlayerColor, PlayerState> players;
 	std::map<TeamID, TeamState> teams;
 	CBonusSystemNode globalEffects;
-	RumorState rumor;
+	RumorState currentRumor;
 
 	static boost::shared_mutex mutex;
 
@@ -135,7 +108,7 @@ public:
 	void calculatePaths(const std::shared_ptr<PathfinderConfig> & config) override;
 	int3 guardingCreaturePosition (int3 pos) const override;
 	std::vector<CGObjectInstance*> guardingCreatures (int3 pos) const;
-	void updateRumor();
+	RumorState pickNewRumor();
 
 	/// Gets a artifact ID randomly and removes the selected artifact from this handler.
 	ArtifactID pickRandomArtifact(vstd::RNG & rand, int flags);
@@ -191,7 +164,7 @@ public:
 			std::string oldStateOfRNG;
 			h & oldStateOfRNG;
 		}
-		h & rumor;
+		h & currentRumor;
 		h & campaign;
 		h & allocatedArtifacts;
 

--- a/lib/gameState/CGameState.h
+++ b/lib/gameState/CGameState.h
@@ -9,10 +9,10 @@
  */
 #pragma once
 
-#include "bonuses/CBonusSystemNode.h"
-#include "IGameCallback.h"
-#include "LoadProgress.h"
-#include "ConstTransitivePtr.h"
+#include "../bonuses/CBonusSystemNode.h"
+#include "../IGameCallback.h"
+#include "../LoadProgress.h"
+#include "../ConstTransitivePtr.h"
 
 namespace boost
 {
@@ -186,7 +186,11 @@ public:
 		h & teams;
 		h & heroesPool;
 		h & globalEffects;
-		h & rand;
+		if (h.version < Handler::Version::REMOVE_LIB_RNG)
+		{
+			std::string oldStateOfRNG;
+			h & oldStateOfRNG;
+		}
 		h & rumor;
 		h & campaign;
 		h & allocatedArtifacts;
@@ -234,7 +238,6 @@ private:
 
 	// ---- data -----
 	std::shared_ptr<CApplier<CBaseForGSApply>> applier;
-	std::unique_ptr<CRandomGenerator> rand;
 	Services * services;
 
 	/// Pointer to campaign state manager. Nullptr for single scenarios

--- a/lib/gameState/CGameState.h
+++ b/lib/gameState/CGameState.h
@@ -13,7 +13,6 @@
 #include "IGameCallback.h"
 #include "LoadProgress.h"
 #include "ConstTransitivePtr.h"
-#include "../CRandomGenerator.h"
 
 namespace boost
 {
@@ -34,6 +33,7 @@ class CStackInstance;
 class CGameStateCampaign;
 class TavernHeroesPool;
 struct SThievesGuildInfo;
+class CRandomGenerator;
 
 template<typename T> class CApplier;
 class CBaseForGSApply;
@@ -126,7 +126,7 @@ public:
 	HeroTypeID pickNextHeroType(const PlayerColor & owner);
 
 	void apply(CPack *pack);
-	BattleField battleGetBattlefieldType(int3 tile, CRandomGenerator & rand);
+	BattleField battleGetBattlefieldType(int3 tile, vstd::RNG & rand);
 
 	void fillUpgradeInfo(const CArmedInstance *obj, SlotID stackPos, UpgradeInfo &out) const override;
 	PlayerRelations getPlayerRelations(PlayerColor color1, PlayerColor color2) const override;
@@ -138,10 +138,10 @@ public:
 	void updateRumor();
 
 	/// Gets a artifact ID randomly and removes the selected artifact from this handler.
-	ArtifactID pickRandomArtifact(CRandomGenerator & rand, int flags);
-	ArtifactID pickRandomArtifact(CRandomGenerator & rand, std::function<bool(ArtifactID)> accepts);
-	ArtifactID pickRandomArtifact(CRandomGenerator & rand, int flags, std::function<bool(ArtifactID)> accepts);
-	ArtifactID pickRandomArtifact(CRandomGenerator & rand, std::set<ArtifactID> filtered);
+	ArtifactID pickRandomArtifact(vstd::RNG & rand, int flags);
+	ArtifactID pickRandomArtifact(vstd::RNG & rand, std::function<bool(ArtifactID)> accepts);
+	ArtifactID pickRandomArtifact(vstd::RNG & rand, int flags, std::function<bool(ArtifactID)> accepts);
+	ArtifactID pickRandomArtifact(vstd::RNG & rand, std::set<ArtifactID> filtered);
 
 	/// Returns battle in which selected player is engaged, or nullptr if none.
 	/// Can NOT be used with neutral player, use battle by ID instead
@@ -169,11 +169,11 @@ public:
 	/// This RNG should only be used inside GS or CPackForClient-derived applyGs
 	/// If this doesn't work for your code that mean you need a new netpack
 	///
-	/// Client-side must use CRandomGenerator::getDefault which is not serialized
+	/// Client-side must use vstd::RNG::getDefault which is not serialized
 	///
-	/// CGameHandler have it's own getter for CRandomGenerator::getDefault
-	/// Any server-side code outside of GH must use CRandomGenerator::getDefault
-	CRandomGenerator & getRandomGenerator();
+	/// CGameHandler have it's own getter for vstd::RNG::getDefault
+	/// Any server-side code outside of GH must use vstd::RNG::getDefault
+	vstd::RNG & getRandomGenerator();
 
 	template <typename Handler> void serialize(Handler &h)
 	{
@@ -234,7 +234,7 @@ private:
 
 	// ---- data -----
 	std::shared_ptr<CApplier<CBaseForGSApply>> applier;
-	CRandomGenerator rand;
+	std::unique_ptr<CRandomGenerator> rand;
 	Services * services;
 
 	/// Pointer to campaign state manager. Nullptr for single scenarios

--- a/lib/gameState/CGameStateCampaign.cpp
+++ b/lib/gameState/CGameStateCampaign.cpp
@@ -28,6 +28,8 @@
 #include "../CPlayerState.h"
 #include "../serializer/CMemorySerializer.h"
 
+#include <vstd/RNG.h>
+
 VCMI_LIB_NAMESPACE_BEGIN
 
 CampaignHeroReplacement::CampaignHeroReplacement(CGHeroInstance * hero, const ObjectInstanceID & heroPlaceholderId):

--- a/lib/gameState/RumorState.cpp
+++ b/lib/gameState/RumorState.cpp
@@ -10,6 +10,8 @@
 #include "StdInc.h"
 #include "RumorState.h"
 
+VCMI_LIB_NAMESPACE_BEGIN
+
 bool RumorState::update(int id, int extra)
 {
 	if(vstd::contains(last, type))
@@ -27,3 +29,5 @@ bool RumorState::update(int id, int extra)
 
 	return true;
 }
+
+VCMI_LIB_NAMESPACE_END

--- a/lib/gameState/RumorState.cpp
+++ b/lib/gameState/RumorState.cpp
@@ -1,0 +1,29 @@
+/*
+ * RumorState.cpp, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
+#include "StdInc.h"
+#include "RumorState.h"
+
+bool RumorState::update(int id, int extra)
+{
+	if(vstd::contains(last, type))
+	{
+		if(last[type].first != id)
+		{
+			last[type].first = id;
+			last[type].second = extra;
+		}
+		else
+			return false;
+	}
+	else
+		last[type] = std::make_pair(id, extra);
+
+	return true;
+}

--- a/lib/gameState/RumorState.h
+++ b/lib/gameState/RumorState.h
@@ -1,0 +1,43 @@
+/*
+ * RumorState.h, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
+#pragma once
+
+VCMI_LIB_NAMESPACE_BEGIN
+
+struct DLL_LINKAGE RumorState
+{
+	enum ERumorType : ui8
+	{
+		TYPE_NONE = 0, TYPE_RAND, TYPE_SPECIAL, TYPE_MAP
+	};
+
+	enum ERumorTypeSpecial : ui8
+	{
+		RUMOR_OBELISKS = 208,
+		RUMOR_ARTIFACTS = 209,
+		RUMOR_ARMY = 210,
+		RUMOR_INCOME = 211,
+		RUMOR_GRAIL = 212
+	};
+
+	ERumorType type;
+	std::map<ERumorType, std::pair<int, int>> last;
+
+	RumorState(){type = TYPE_NONE;};
+	bool update(int id, int extra);
+
+	template <typename Handler> void serialize(Handler &h)
+	{
+		h & type;
+		h & last;
+	}
+};
+
+VCMI_LIB_NAMESPACE_END

--- a/lib/gameState/TavernHeroesPool.h
+++ b/lib/gameState/TavernHeroesPool.h
@@ -18,7 +18,6 @@ VCMI_LIB_NAMESPACE_BEGIN
 
 class CGHeroInstance;
 class CTown;
-class CRandomGenerator;
 class CHeroClass;
 class CGameState;
 class CSimpleArmy;

--- a/lib/json/JsonRandom.cpp
+++ b/lib/json/JsonRandom.cpp
@@ -63,7 +63,7 @@ VCMI_LIB_NAMESPACE_BEGIN
 		{
 			const auto & vector = value.Vector();
 
-			size_t index= rng.getIntRange(0, vector.size()-1)();
+			size_t index= rng.nextInt64(0, vector.size()-1);
 			return loadValue(vector[index], rng, variables, 0);
 		}
 		if(value.isStruct())
@@ -72,7 +72,7 @@ VCMI_LIB_NAMESPACE_BEGIN
 				return loadValue(value["amount"], rng, variables, defaultValue);
 			si32 min = loadValue(value["min"], rng, variables, 0);
 			si32 max = loadValue(value["max"], rng, variables, 0);
-			return rng.getIntRange(min, max)();
+			return rng.nextInt64(min, max);
 		}
 		return defaultValue;
 	}

--- a/lib/json/JsonRandom.cpp
+++ b/lib/json/JsonRandom.cpp
@@ -12,10 +12,10 @@
 #include "JsonRandom.h"
 
 #include <vstd/StringUtils.h>
+#include <vstd/RNG.h>
 
 #include "JsonBonus.h"
 
-#include "../CRandomGenerator.h"
 #include "../constants/StringConstants.h"
 #include "../VCMI_Lib.h"
 #include "../CArtHandler.h"
@@ -50,7 +50,7 @@ VCMI_LIB_NAMESPACE_BEGIN
 		return variables.at(variableID);
 	}
 
-	si32 JsonRandom::loadValue(const JsonNode & value, CRandomGenerator & rng, const Variables & variables, si32 defaultValue)
+	si32 JsonRandom::loadValue(const JsonNode & value, vstd::RNG & rng, const Variables & variables, si32 defaultValue)
 	{
 		if(value.isNull())
 			return defaultValue;
@@ -256,7 +256,7 @@ VCMI_LIB_NAMESPACE_BEGIN
 		return valuesSet;
 	}
 
-	TResources JsonRandom::loadResources(const JsonNode & value, CRandomGenerator & rng, const Variables & variables)
+	TResources JsonRandom::loadResources(const JsonNode & value, vstd::RNG & rng, const Variables & variables)
 	{
 		TResources ret;
 
@@ -274,7 +274,7 @@ VCMI_LIB_NAMESPACE_BEGIN
 		return ret;
 	}
 
-	TResources JsonRandom::loadResource(const JsonNode & value, CRandomGenerator & rng, const Variables & variables)
+	TResources JsonRandom::loadResource(const JsonNode & value, vstd::RNG & rng, const Variables & variables)
 	{
 		std::set<GameResID> defaultResources{
 			GameResID::WOOD,
@@ -295,7 +295,7 @@ VCMI_LIB_NAMESPACE_BEGIN
 		return ret;
 	}
 
-	PrimarySkill JsonRandom::loadPrimary(const JsonNode & value, CRandomGenerator & rng, const Variables & variables)
+	PrimarySkill JsonRandom::loadPrimary(const JsonNode & value, vstd::RNG & rng, const Variables & variables)
 	{
 		std::set<PrimarySkill> defaultSkills{
 			PrimarySkill::ATTACK,
@@ -307,7 +307,7 @@ VCMI_LIB_NAMESPACE_BEGIN
 		return *RandomGeneratorUtil::nextItem(potentialPicks, rng);
 	}
 
-	std::vector<si32> JsonRandom::loadPrimaries(const JsonNode & value, CRandomGenerator & rng, const Variables & variables)
+	std::vector<si32> JsonRandom::loadPrimaries(const JsonNode & value, vstd::RNG & rng, const Variables & variables)
 	{
 		std::vector<si32> ret(GameConstants::PRIMARY_SKILLS, 0);
 		std::set<PrimarySkill> defaultSkills{
@@ -339,7 +339,7 @@ VCMI_LIB_NAMESPACE_BEGIN
 		return ret;
 	}
 
-	SecondarySkill JsonRandom::loadSecondary(const JsonNode & value, CRandomGenerator & rng, const Variables & variables)
+	SecondarySkill JsonRandom::loadSecondary(const JsonNode & value, vstd::RNG & rng, const Variables & variables)
 	{
 		std::set<SecondarySkill> defaultSkills;
 		for(const auto & skill : VLC->skillh->objects)
@@ -350,7 +350,7 @@ VCMI_LIB_NAMESPACE_BEGIN
 		return *RandomGeneratorUtil::nextItem(potentialPicks, rng);
 	}
 
-	std::map<SecondarySkill, si32> JsonRandom::loadSecondaries(const JsonNode & value, CRandomGenerator & rng, const Variables & variables)
+	std::map<SecondarySkill, si32> JsonRandom::loadSecondaries(const JsonNode & value, vstd::RNG & rng, const Variables & variables)
 	{
 		std::map<SecondarySkill, si32> ret;
 		if(value.isStruct())
@@ -380,7 +380,7 @@ VCMI_LIB_NAMESPACE_BEGIN
 		return ret;
 	}
 
-	ArtifactID JsonRandom::loadArtifact(const JsonNode & value, CRandomGenerator & rng, const Variables & variables)
+	ArtifactID JsonRandom::loadArtifact(const JsonNode & value, vstd::RNG & rng, const Variables & variables)
 	{
 		std::set<ArtifactID> allowedArts;
 		for(const auto & artifact : VLC->arth->objects)
@@ -392,7 +392,7 @@ VCMI_LIB_NAMESPACE_BEGIN
 		return cb->gameState()->pickRandomArtifact(rng, potentialPicks);
 	}
 
-	std::vector<ArtifactID> JsonRandom::loadArtifacts(const JsonNode & value, CRandomGenerator & rng, const Variables & variables)
+	std::vector<ArtifactID> JsonRandom::loadArtifacts(const JsonNode & value, vstd::RNG & rng, const Variables & variables)
 	{
 		std::vector<ArtifactID> ret;
 		for (const JsonNode & entry : value.Vector())
@@ -402,7 +402,7 @@ VCMI_LIB_NAMESPACE_BEGIN
 		return ret;
 	}
 
-	SpellID JsonRandom::loadSpell(const JsonNode & value, CRandomGenerator & rng, const Variables & variables)
+	SpellID JsonRandom::loadSpell(const JsonNode & value, vstd::RNG & rng, const Variables & variables)
 	{
 		std::set<SpellID> defaultSpells;
 		for(const auto & spell : VLC->spellh->objects)
@@ -419,7 +419,7 @@ VCMI_LIB_NAMESPACE_BEGIN
 		return *RandomGeneratorUtil::nextItem(potentialPicks, rng);
 	}
 
-	std::vector<SpellID> JsonRandom::loadSpells(const JsonNode & value, CRandomGenerator & rng, const Variables & variables)
+	std::vector<SpellID> JsonRandom::loadSpells(const JsonNode & value, vstd::RNG & rng, const Variables & variables)
 	{
 		std::vector<SpellID> ret;
 		for (const JsonNode & entry : value.Vector())
@@ -429,7 +429,7 @@ VCMI_LIB_NAMESPACE_BEGIN
 		return ret;
 	}
 
-	std::vector<PlayerColor> JsonRandom::loadColors(const JsonNode & value, CRandomGenerator & rng, const Variables & variables)
+	std::vector<PlayerColor> JsonRandom::loadColors(const JsonNode & value, vstd::RNG & rng, const Variables & variables)
 	{
 		std::vector<PlayerColor> ret;
 		std::set<PlayerColor> defaultPlayers;
@@ -445,7 +445,7 @@ VCMI_LIB_NAMESPACE_BEGIN
 		return ret;
 	}
 
-	std::vector<HeroTypeID> JsonRandom::loadHeroes(const JsonNode & value, CRandomGenerator & rng)
+	std::vector<HeroTypeID> JsonRandom::loadHeroes(const JsonNode & value, vstd::RNG & rng)
 	{
 		std::vector<HeroTypeID> ret;
 		for(auto & entry : value.Vector())
@@ -455,7 +455,7 @@ VCMI_LIB_NAMESPACE_BEGIN
 		return ret;
 	}
 
-	std::vector<HeroClassID> JsonRandom::loadHeroClasses(const JsonNode & value, CRandomGenerator & rng)
+	std::vector<HeroClassID> JsonRandom::loadHeroClasses(const JsonNode & value, vstd::RNG & rng)
 	{
 		std::vector<HeroClassID> ret;
 		for(auto & entry : value.Vector())
@@ -465,7 +465,7 @@ VCMI_LIB_NAMESPACE_BEGIN
 		return ret;
 	}
 
-	CStackBasicDescriptor JsonRandom::loadCreature(const JsonNode & value, CRandomGenerator & rng, const Variables & variables)
+	CStackBasicDescriptor JsonRandom::loadCreature(const JsonNode & value, vstd::RNG & rng, const Variables & variables)
 	{
 		CStackBasicDescriptor stack;
 
@@ -494,7 +494,7 @@ VCMI_LIB_NAMESPACE_BEGIN
 		return stack;
 	}
 
-	std::vector<CStackBasicDescriptor> JsonRandom::loadCreatures(const JsonNode & value, CRandomGenerator & rng, const Variables & variables)
+	std::vector<CStackBasicDescriptor> JsonRandom::loadCreatures(const JsonNode & value, vstd::RNG & rng, const Variables & variables)
 	{
 		std::vector<CStackBasicDescriptor> ret;
 		for (const JsonNode & node : value.Vector())

--- a/lib/json/JsonRandom.h
+++ b/lib/json/JsonRandom.h
@@ -15,9 +15,13 @@
 
 VCMI_LIB_NAMESPACE_BEGIN
 
+namespace vstd
+{
+class RNG;
+}
+
 class JsonNode;
 using JsonVector = std::vector<JsonNode>;
-class CRandomGenerator;
 
 struct Bonus;
 struct Component;
@@ -53,28 +57,28 @@ public:
 		si32 maxAmount;
 	};
 
-	si32 loadValue(const JsonNode & value, CRandomGenerator & rng, const Variables & variables, si32 defaultValue = 0);
+	si32 loadValue(const JsonNode & value, vstd::RNG & rng, const Variables & variables, si32 defaultValue = 0);
 
-	TResources loadResources(const JsonNode & value, CRandomGenerator & rng, const Variables & variables);
-	TResources loadResource(const JsonNode & value, CRandomGenerator & rng, const Variables & variables);
-	PrimarySkill loadPrimary(const JsonNode & value, CRandomGenerator & rng, const Variables & variables);
-	std::vector<si32> loadPrimaries(const JsonNode & value, CRandomGenerator & rng, const Variables & variables);
-	SecondarySkill loadSecondary(const JsonNode & value, CRandomGenerator & rng, const Variables & variables);
-	std::map<SecondarySkill, si32> loadSecondaries(const JsonNode & value, CRandomGenerator & rng, const Variables & variables);
+	TResources loadResources(const JsonNode & value, vstd::RNG & rng, const Variables & variables);
+	TResources loadResource(const JsonNode & value, vstd::RNG & rng, const Variables & variables);
+	PrimarySkill loadPrimary(const JsonNode & value, vstd::RNG & rng, const Variables & variables);
+	std::vector<si32> loadPrimaries(const JsonNode & value, vstd::RNG & rng, const Variables & variables);
+	SecondarySkill loadSecondary(const JsonNode & value, vstd::RNG & rng, const Variables & variables);
+	std::map<SecondarySkill, si32> loadSecondaries(const JsonNode & value, vstd::RNG & rng, const Variables & variables);
 
-	ArtifactID loadArtifact(const JsonNode & value, CRandomGenerator & rng, const Variables & variables);
-	std::vector<ArtifactID> loadArtifacts(const JsonNode & value, CRandomGenerator & rng, const Variables & variables);
+	ArtifactID loadArtifact(const JsonNode & value, vstd::RNG & rng, const Variables & variables);
+	std::vector<ArtifactID> loadArtifacts(const JsonNode & value, vstd::RNG & rng, const Variables & variables);
 
-	SpellID loadSpell(const JsonNode & value, CRandomGenerator & rng, const Variables & variables);
-	std::vector<SpellID> loadSpells(const JsonNode & value, CRandomGenerator & rng, const Variables & variables);
+	SpellID loadSpell(const JsonNode & value, vstd::RNG & rng, const Variables & variables);
+	std::vector<SpellID> loadSpells(const JsonNode & value, vstd::RNG & rng, const Variables & variables);
 
-	CStackBasicDescriptor loadCreature(const JsonNode & value, CRandomGenerator & rng, const Variables & variables);
-	std::vector<CStackBasicDescriptor> loadCreatures(const JsonNode & value, CRandomGenerator & rng, const Variables & variables);
+	CStackBasicDescriptor loadCreature(const JsonNode & value, vstd::RNG & rng, const Variables & variables);
+	std::vector<CStackBasicDescriptor> loadCreatures(const JsonNode & value, vstd::RNG & rng, const Variables & variables);
 	std::vector<RandomStackInfo> evaluateCreatures(const JsonNode & value, const Variables & variables);
 
-	std::vector<PlayerColor> loadColors(const JsonNode & value, CRandomGenerator & rng, const Variables & variables);
-	std::vector<HeroTypeID> loadHeroes(const JsonNode & value, CRandomGenerator & rng);
-	std::vector<HeroClassID> loadHeroClasses(const JsonNode & value, CRandomGenerator & rng);
+	std::vector<PlayerColor> loadColors(const JsonNode & value, vstd::RNG & rng, const Variables & variables);
+	std::vector<HeroTypeID> loadHeroes(const JsonNode & value, vstd::RNG & rng);
+	std::vector<HeroClassID> loadHeroClasses(const JsonNode & value, vstd::RNG & rng);
 
 	static std::vector<Bonus> loadBonuses(const JsonNode & value);
 };

--- a/lib/logging/CLogger.cpp
+++ b/lib/logging/CLogger.cpp
@@ -96,6 +96,7 @@ DLL_LINKAGE vstd::CLoggerBase * logNetwork = CLogger::getLogger(CLoggerDomain("n
 DLL_LINKAGE vstd::CLoggerBase * logAi = CLogger::getLogger(CLoggerDomain("ai"));
 DLL_LINKAGE vstd::CLoggerBase * logAnim = CLogger::getLogger(CLoggerDomain("animation"));
 DLL_LINKAGE vstd::CLoggerBase * logMod = CLogger::getLogger(CLoggerDomain("mod"));
+DLL_LINKAGE vstd::CLoggerBase * logRng = CLogger::getLogger(CLoggerDomain("rng"));
 
 CLogger * CLogger::getLogger(const CLoggerDomain & domain)
 {

--- a/lib/mapObjectConstructors/AObjectTypeHandler.h
+++ b/lib/mapObjectConstructors/AObjectTypeHandler.h
@@ -15,9 +15,13 @@
 
 VCMI_LIB_NAMESPACE_BEGIN
 
+namespace vstd
+{
+class RNG;
+}
+
 class ObjectTemplate;
 class CGObjectInstance;
-class CRandomGenerator;
 class IObjectInfo;
 class IGameCallback;
 
@@ -114,7 +118,7 @@ public:
 
 	/// Configures object properties. Should be re-entrable, resetting state of the object if necessarily
 	/// This should set remaining properties, including randomized or depending on map
-	virtual void configureObject(CGObjectInstance * object, CRandomGenerator & rng) const = 0;
+	virtual void configureObject(CGObjectInstance * object, vstd::RNG & rng) const = 0;
 
 	/// Returns object configuration, if available. Otherwise returns NULL
 	virtual std::unique_ptr<IObjectInfo> getObjectInfo(std::shared_ptr<const ObjectTemplate> tmpl) const;

--- a/lib/mapObjectConstructors/CBankInstanceConstructor.cpp
+++ b/lib/mapObjectConstructors/CBankInstanceConstructor.cpp
@@ -13,7 +13,8 @@
 #include "../json/JsonRandom.h"
 #include "../CGeneralTextHandler.h"
 #include "../IGameCallback.h"
-#include "../CRandomGenerator.h"
+
+#include <vstd/RNG.h>
 
 VCMI_LIB_NAMESPACE_BEGIN
 
@@ -36,7 +37,7 @@ void CBankInstanceConstructor::initTypeData(const JsonNode & input)
 	regularUnitPlacement = input["regularUnitPlacement"].Bool();
 }
 
-BankConfig CBankInstanceConstructor::generateConfig(IGameCallback * cb, const JsonNode & level, CRandomGenerator & rng) const
+BankConfig CBankInstanceConstructor::generateConfig(IGameCallback * cb, const JsonNode & level, vstd::RNG & rng) const
 {
 	BankConfig bc;
 	JsonRandom randomizer(cb);
@@ -53,7 +54,7 @@ BankConfig CBankInstanceConstructor::generateConfig(IGameCallback * cb, const Js
 	return bc;
 }
 
-void CBankInstanceConstructor::randomizeObject(CBank * bank, CRandomGenerator & rng) const
+void CBankInstanceConstructor::randomizeObject(CBank * bank, vstd::RNG & rng) const
 {
 	bank->resetDuration = bankResetDuration;
 	bank->blockVisit = blockVisit;

--- a/lib/mapObjectConstructors/CBankInstanceConstructor.cpp
+++ b/lib/mapObjectConstructors/CBankInstanceConstructor.cpp
@@ -37,7 +37,7 @@ void CBankInstanceConstructor::initTypeData(const JsonNode & input)
 	regularUnitPlacement = input["regularUnitPlacement"].Bool();
 }
 
-BankConfig CBankInstanceConstructor::generateConfig(IGameCallback * cb, const JsonNode & level, vstd::RNG & rng) const
+BankConfig CBankInstanceConstructor::generateLevelConfiguration(IGameCallback * cb, const JsonNode & level, vstd::RNG & rng) const
 {
 	BankConfig bc;
 	JsonRandom randomizer(cb);
@@ -60,7 +60,11 @@ void CBankInstanceConstructor::randomizeObject(CBank * bank, vstd::RNG & rng) co
 	bank->blockVisit = blockVisit;
 	bank->coastVisitable = coastVisitable;
 	bank->regularUnitPlacement = regularUnitPlacement;
+	bank->setConfig(generateConfiguration(bank->cb, rng, bank->ID));
+}
 
+BankConfig CBankInstanceConstructor::generateConfiguration(IGameCallback * cb, vstd::RNG & rng, MapObjectID objectID) const
+{
 	si32 totalChance = 0;
 	for(const auto & node : levels)
 		totalChance += static_cast<si32>(node["chance"].Float());
@@ -74,11 +78,10 @@ void CBankInstanceConstructor::randomizeObject(CBank * bank, vstd::RNG & rng) co
 	{
 		cumulativeChance += static_cast<int>(node["chance"].Float());
 		if(selectedChance < cumulativeChance)
-		{
-			bank->setConfig(generateConfig(bank->cb, node, rng));
-			break;
-		}
+			return generateLevelConfiguration(cb, node, rng);
 	}
+
+	throw std::runtime_error("Failed to select bank configuration");
 }
 
 CBankInfo::CBankInfo(const JsonVector & Config) :

--- a/lib/mapObjectConstructors/CBankInstanceConstructor.h
+++ b/lib/mapObjectConstructors/CBankInstanceConstructor.h
@@ -69,7 +69,7 @@ public:
 
 class CBankInstanceConstructor : public CDefaultObjectTypeHandler<CBank>
 {
-	BankConfig generateConfig(IGameCallback * cb, const JsonNode & conf, vstd::RNG & rng) const;
+	BankConfig generateLevelConfiguration(IGameCallback * cb, const JsonNode & conf, vstd::RNG & rng) const;
 
 	JsonVector levels;
 
@@ -92,6 +92,8 @@ public:
 	bool hasNameTextID() const override;
 
 	std::unique_ptr<IObjectInfo> getObjectInfo(std::shared_ptr<const ObjectTemplate> tmpl) const override;
+
+	BankConfig generateConfiguration(IGameCallback * cb, vstd::RNG & rand, MapObjectID objectID) const;
 };
 
 VCMI_LIB_NAMESPACE_END

--- a/lib/mapObjectConstructors/CBankInstanceConstructor.h
+++ b/lib/mapObjectConstructors/CBankInstanceConstructor.h
@@ -69,7 +69,7 @@ public:
 
 class CBankInstanceConstructor : public CDefaultObjectTypeHandler<CBank>
 {
-	BankConfig generateConfig(IGameCallback * cb, const JsonNode & conf, CRandomGenerator & rng) const;
+	BankConfig generateConfig(IGameCallback * cb, const JsonNode & conf, vstd::RNG & rng) const;
 
 	JsonVector levels;
 
@@ -87,7 +87,7 @@ protected:
 
 public:
 
-	void randomizeObject(CBank * object, CRandomGenerator & rng) const override;
+	void randomizeObject(CBank * object, vstd::RNG & rng) const override;
 
 	bool hasNameTextID() const override;
 

--- a/lib/mapObjectConstructors/CDefaultObjectTypeHandler.h
+++ b/lib/mapObjectConstructors/CDefaultObjectTypeHandler.h
@@ -17,7 +17,7 @@ VCMI_LIB_NAMESPACE_BEGIN
 template<class ObjectType>
 class CDefaultObjectTypeHandler : public AObjectTypeHandler
 {
-	void configureObject(CGObjectInstance * object, CRandomGenerator & rng) const final
+	void configureObject(CGObjectInstance * object, vstd::RNG & rng) const final
 	{
 		ObjectType * castedObject = dynamic_cast<ObjectType*>(object);
 
@@ -43,7 +43,7 @@ class CDefaultObjectTypeHandler : public AObjectTypeHandler
 
 protected:
 	virtual void initializeObject(ObjectType * object) const {}
-	virtual void randomizeObject(ObjectType * object, CRandomGenerator & rng) const {}
+	virtual void randomizeObject(ObjectType * object, vstd::RNG & rng) const {}
 	virtual ObjectType * createObject(IGameCallback * cb) const
 	{
 		return new ObjectType(cb);

--- a/lib/mapObjectConstructors/CObjectClassesHandler.h
+++ b/lib/mapObjectConstructors/CObjectClassesHandler.h
@@ -15,7 +15,6 @@
 
 VCMI_LIB_NAMESPACE_BEGIN
 
-class CRandomGenerator;
 class AObjectTypeHandler;
 class ObjectTemplate;
 struct SObjectSounds;

--- a/lib/mapObjectConstructors/CRewardableConstructor.cpp
+++ b/lib/mapObjectConstructors/CRewardableConstructor.cpp
@@ -40,19 +40,29 @@ CGObjectInstance * CRewardableConstructor::create(IGameCallback * cb, std::share
 	return ret;
 }
 
+Rewardable::Configuration CRewardableConstructor::generateConfiguration(IGameCallback * cb, vstd::RNG & rand, MapObjectID objectID) const
+{
+	Rewardable::Configuration result;
+	objectInfo.configureObject(result, rand, cb);
+
+	for(auto & rewardInfo : result.info)
+	{
+		for (auto & bonus : rewardInfo.reward.bonuses)
+		{
+			bonus.source = BonusSource::OBJECT_TYPE;
+			bonus.sid = BonusSourceID(objectID);
+		}
+	}
+
+	return result;
+}
+
 void CRewardableConstructor::configureObject(CGObjectInstance * object, vstd::RNG & rng) const
 {
 	if(auto * rewardableObject = dynamic_cast<CRewardableObject*>(object))
 	{
-		objectInfo.configureObject(rewardableObject->configuration, rng, object->cb);
-		for(auto & rewardInfo : rewardableObject->configuration.info)
-		{
-			for (auto & bonus : rewardInfo.reward.bonuses)
-			{
-				bonus.source = BonusSource::OBJECT_TYPE;
-				bonus.sid = BonusSourceID(rewardableObject->ID);
-			}
-		}
+		rewardableObject->configuration = generateConfiguration(object->cb, rng, object->ID);
+
 		if (rewardableObject->configuration.info.empty())
 		{
 			if (objectInfo.getParameters()["rewards"].isNull())

--- a/lib/mapObjectConstructors/CRewardableConstructor.cpp
+++ b/lib/mapObjectConstructors/CRewardableConstructor.cpp
@@ -40,7 +40,7 @@ CGObjectInstance * CRewardableConstructor::create(IGameCallback * cb, std::share
 	return ret;
 }
 
-void CRewardableConstructor::configureObject(CGObjectInstance * object, CRandomGenerator & rng) const
+void CRewardableConstructor::configureObject(CGObjectInstance * object, vstd::RNG & rng) const
 {
 	if(auto * rewardableObject = dynamic_cast<CRewardableObject*>(object))
 	{

--- a/lib/mapObjectConstructors/CRewardableConstructor.h
+++ b/lib/mapObjectConstructors/CRewardableConstructor.h
@@ -27,7 +27,7 @@ public:
 
 	CGObjectInstance * create(IGameCallback * cb, std::shared_ptr<const ObjectTemplate> tmpl = nullptr) const override;
 
-	void configureObject(CGObjectInstance * object, CRandomGenerator & rng) const override;
+	void configureObject(CGObjectInstance * object, vstd::RNG & rng) const override;
 
 	std::unique_ptr<IObjectInfo> getObjectInfo(std::shared_ptr<const ObjectTemplate> tmpl) const override;
 };

--- a/lib/mapObjectConstructors/CRewardableConstructor.h
+++ b/lib/mapObjectConstructors/CRewardableConstructor.h
@@ -30,6 +30,8 @@ public:
 	void configureObject(CGObjectInstance * object, vstd::RNG & rng) const override;
 
 	std::unique_ptr<IObjectInfo> getObjectInfo(std::shared_ptr<const ObjectTemplate> tmpl) const override;
+
+	Rewardable::Configuration generateConfiguration(IGameCallback * cb, vstd::RNG & rand, MapObjectID objectID) const;
 };
 
 VCMI_LIB_NAMESPACE_END

--- a/lib/mapObjectConstructors/CommonConstructors.cpp
+++ b/lib/mapObjectConstructors/CommonConstructors.cpp
@@ -100,7 +100,7 @@ void CTownInstanceConstructor::initializeObject(CGTownInstance * obj) const
 	obj->tempOwner = PlayerColor::NEUTRAL;
 }
 
-void CTownInstanceConstructor::randomizeObject(CGTownInstance * object, CRandomGenerator & rng) const
+void CTownInstanceConstructor::randomizeObject(CGTownInstance * object, vstd::RNG & rng) const
 {
 	auto templ = getOverride(object->cb->getTile(object->pos)->terType->getId(), object);
 	if(templ)
@@ -159,7 +159,7 @@ void CHeroInstanceConstructor::initializeObject(CGHeroInstance * obj) const
 	obj->type = nullptr; //FIXME: set to valid value. somehow.
 }
 
-void CHeroInstanceConstructor::randomizeObject(CGHeroInstance * object, CRandomGenerator & rng) const
+void CHeroInstanceConstructor::randomizeObject(CGHeroInstance * object, vstd::RNG & rng) const
 {
 
 }
@@ -259,7 +259,7 @@ void MarketInstanceConstructor::initializeObject(CGMarket * market) const
 		market->speech = VLC->generaltexth->translate(speech);
 }
 
-void MarketInstanceConstructor::randomizeObject(CGMarket * object, CRandomGenerator & rng) const
+void MarketInstanceConstructor::randomizeObject(CGMarket * object, vstd::RNG & rng) const
 {
 	JsonRandom randomizer(object->cb);
 	JsonRandom::Variables emptyVariables;

--- a/lib/mapObjectConstructors/CommonConstructors.h
+++ b/lib/mapObjectConstructors/CommonConstructors.h
@@ -63,7 +63,7 @@ public:
 	std::map<std::string, LogicalExpression<BuildingID>> filters;
 
 	void initializeObject(CGTownInstance * object) const override;
-	void randomizeObject(CGTownInstance * object, CRandomGenerator & rng) const override;
+	void randomizeObject(CGTownInstance * object, vstd::RNG & rng) const override;
 	void afterLoadFinalization() override;
 
 	bool hasNameTextID() const override;
@@ -82,7 +82,7 @@ public:
 	std::map<std::string, LogicalExpression<HeroTypeID>> filters;
 
 	void initializeObject(CGHeroInstance * object) const override;
-	void randomizeObject(CGHeroInstance * object, CRandomGenerator & rng) const override;
+	void randomizeObject(CGHeroInstance * object, vstd::RNG & rng) const override;
 	void afterLoadFinalization() override;
 
 	bool hasNameTextID() const override;
@@ -125,7 +125,7 @@ protected:
 public:
 	CGMarket * createObject(IGameCallback * cb) const override;
 	void initializeObject(CGMarket * object) const override;
-	void randomizeObject(CGMarket * object, CRandomGenerator & rng) const override;
+	void randomizeObject(CGMarket * object, vstd::RNG & rng) const override;
 
 };
 

--- a/lib/mapObjectConstructors/DwellingInstanceConstructor.cpp
+++ b/lib/mapObjectConstructors/DwellingInstanceConstructor.cpp
@@ -74,7 +74,7 @@ void DwellingInstanceConstructor::initializeObject(CGDwelling * obj) const
 	}
 }
 
-void DwellingInstanceConstructor::randomizeObject(CGDwelling * dwelling, CRandomGenerator &rng) const
+void DwellingInstanceConstructor::randomizeObject(CGDwelling * dwelling, vstd::RNG &rng) const
 {
 	JsonRandom randomizer(dwelling->cb);
 

--- a/lib/mapObjectConstructors/DwellingInstanceConstructor.h
+++ b/lib/mapObjectConstructors/DwellingInstanceConstructor.h
@@ -33,7 +33,7 @@ public:
 	bool hasNameTextID() const override;
 
 	void initializeObject(CGDwelling * object) const override;
-	void randomizeObject(CGDwelling * object, CRandomGenerator & rng) const override;
+	void randomizeObject(CGDwelling * object, vstd::RNG & rng) const override;
 
 	bool isBannedForRandomDwelling() const;
 	bool producesCreature(const CCreature * crea) const;

--- a/lib/mapObjects/CBank.cpp
+++ b/lib/mapObjects/CBank.cpp
@@ -97,6 +97,8 @@ void CBank::setConfig(const BankConfig & config)
 
 	for(const auto & stack : config.guards)
 		setCreature (SlotID(stacksCount()), stack.type->getId(), stack.count);
+
+	daycounter = 1; //yes, 1 since "today" daycounter won't be incremented
 }
 
 void CBank::setPropertyDer (ObjProperty what, ObjPropertyID identifier)
@@ -105,11 +107,6 @@ void CBank::setPropertyDer (ObjProperty what, ObjPropertyID identifier)
 	{
 		case ObjProperty::BANK_DAYCOUNTER: //daycounter
 				daycounter+= identifier.getNum();
-			break;
-		case ObjProperty::BANK_RESET:
-			// FIXME: Object reset must be done by separate netpack from server
-			initObj(cb->gameState()->getRandomGenerator());
-			daycounter = 1; //yes, 1 since "today" daycounter won't be incremented
 			break;
 		case ObjProperty::BANK_CLEAR:
 			bankConfig.reset();
@@ -124,7 +121,11 @@ void CBank::newTurn(vstd::RNG & rand) const
 		if (resetDuration != 0)
 		{
 			if (daycounter >= resetDuration)
-				cb->setObjPropertyValue(id, ObjProperty::BANK_RESET); //daycounter 0
+			{
+				auto handler = std::dynamic_pointer_cast<CBankInstanceConstructor>(getObjectHandler());
+				auto config = handler->generateConfiguration(cb, rand, ID);
+				cb->setBankObjectConfiguration(id, config);
+			}
 			else
 				cb->setObjPropertyValue(id, ObjProperty::BANK_DAYCOUNTER, 1); //daycounter++
 		}

--- a/lib/mapObjects/CBank.cpp
+++ b/lib/mapObjects/CBank.cpp
@@ -44,7 +44,7 @@ CBank::CBank(IGameCallback *cb)
 //must be instantiated in .cpp file for access to complete types of all member fields
 CBank::~CBank() = default;
 
-void CBank::initObj(CRandomGenerator & rand)
+void CBank::initObj(vstd::RNG & rand)
 {
 	daycounter = 0;
 	resetDuration = 0;
@@ -117,7 +117,7 @@ void CBank::setPropertyDer (ObjProperty what, ObjPropertyID identifier)
 	}
 }
 
-void CBank::newTurn(CRandomGenerator & rand) const
+void CBank::newTurn(vstd::RNG & rand) const
 {
 	if (bankConfig == nullptr)
 	{

--- a/lib/mapObjects/CBank.h
+++ b/lib/mapObjects/CBank.h
@@ -33,9 +33,9 @@ public:
 
 	void setConfig(const BankConfig & bc);
 
-	void initObj(CRandomGenerator & rand) override;
+	void initObj(vstd::RNG & rand) override;
 	std::string getHoverText(PlayerColor player) const override;
-	void newTurn(CRandomGenerator & rand) const override;
+	void newTurn(vstd::RNG & rand) const override;
 	bool wasVisited (PlayerColor player) const override;
 	bool isCoastVisitable() const override;
 	void onHeroVisit(const CGHeroInstance * h) const override;

--- a/lib/mapObjects/CGCreature.cpp
+++ b/lib/mapObjects/CGCreature.cpp
@@ -16,12 +16,14 @@
 #include "../CConfigHandler.h"
 #include "../GameSettings.h"
 #include "../IGameCallback.h"
+#include "../gameState/CGameState.h"
 #include "../mapObjectConstructors/CObjectClassesHandler.h"
 #include "../networkPacks/PacksForClient.h"
 #include "../networkPacks/PacksForClientBattle.h"
 #include "../networkPacks/StackLocation.h"
 #include "../serializer/JsonSerializeFormat.h"
-#include "../CRandomGenerator.h"
+
+#include <vstd/RNG.h>
 
 VCMI_LIB_NAMESPACE_BEGIN
 
@@ -189,7 +191,7 @@ CreatureID CGCreature::getCreature() const
 	return CreatureID(getObjTypeIndex().getNum());
 }
 
-void CGCreature::pickRandomObject(CRandomGenerator & rand)
+void CGCreature::pickRandomObject(vstd::RNG & rand)
 {
 	switch(ID.toEnum())
 	{
@@ -234,7 +236,7 @@ void CGCreature::pickRandomObject(CRandomGenerator & rand)
 	setType(ID, subID);
 }
 
-void CGCreature::initObj(CRandomGenerator & rand)
+void CGCreature::initObj(vstd::RNG & rand)
 {
 	blockVisit = true;
 	switch(character)
@@ -274,7 +276,7 @@ void CGCreature::initObj(CRandomGenerator & rand)
 	refusedJoining = false;
 }
 
-void CGCreature::newTurn(CRandomGenerator & rand) const
+void CGCreature::newTurn(vstd::RNG & rand) const
 {//Works only for stacks of single type of size up to 2 millions
 	if (!notGrowingTeam)
 	{
@@ -457,7 +459,7 @@ void CGCreature::fight( const CGHeroInstance *h ) const
 			const auto & upgrades = getStack(slotID).type->upgrades;
 			if(!upgrades.empty())
 			{
-				auto it = RandomGeneratorUtil::nextItem(upgrades, CRandomGenerator::getDefault());
+				auto it = RandomGeneratorUtil::nextItem(upgrades, cb->gameState()->getRandomGenerator());
 				cb->changeStackType(StackLocation(this, slotID), it->toCreature());
 			}
 		}

--- a/lib/mapObjects/CGCreature.h
+++ b/lib/mapObjects/CGCreature.h
@@ -45,9 +45,9 @@ public:
 	std::string getPopupText(PlayerColor player) const override;
 	std::string getPopupText(const CGHeroInstance * hero) const override;
 	std::vector<Component> getPopupComponents(PlayerColor player) const override;
-	void initObj(CRandomGenerator & rand) override;
-	void pickRandomObject(CRandomGenerator & rand) override;
-	void newTurn(CRandomGenerator & rand) const override;
+	void initObj(vstd::RNG & rand) override;
+	void pickRandomObject(vstd::RNG & rand) override;
+	void newTurn(vstd::RNG & rand) const override;
 	void battleFinished(const CGHeroInstance *hero, const BattleResult &result) const override;
 	void blockingDialogAnswered(const CGHeroInstance *hero, ui32 answer) const override;
 	CreatureID getCreature() const;

--- a/lib/mapObjects/CGDwelling.cpp
+++ b/lib/mapObjects/CGDwelling.cpp
@@ -27,6 +27,8 @@
 #include "../GameSettings.h"
 #include "../CConfigHandler.h"
 
+#include <vstd/RNG.h>
+
 VCMI_LIB_NAMESPACE_BEGIN
 
 void CGDwellingRandomizationInfo::serializeJson(JsonSerializeFormat & handler)
@@ -50,7 +52,7 @@ CGDwelling::CGDwelling(IGameCallback *cb):
 
 CGDwelling::~CGDwelling() = default;
 
-FactionID CGDwelling::randomizeFaction(CRandomGenerator & rand)
+FactionID CGDwelling::randomizeFaction(vstd::RNG & rand)
 {
 	if (ID == Obj::RANDOM_DWELLING_FACTION)
 		return FactionID(subID.getNum());
@@ -108,7 +110,7 @@ FactionID CGDwelling::randomizeFaction(CRandomGenerator & rand)
 	return *RandomGeneratorUtil::nextItem(potentialPicks, rand);
 }
 
-int CGDwelling::randomizeLevel(CRandomGenerator & rand)
+int CGDwelling::randomizeLevel(vstd::RNG & rand)
 {
 	if (ID == Obj::RANDOM_DWELLING_LVL)
 		return subID.getNum();
@@ -125,7 +127,7 @@ int CGDwelling::randomizeLevel(CRandomGenerator & rand)
 	return rand.nextInt(randomizationInfo->minLevel, randomizationInfo->maxLevel) - 1;
 }
 
-void CGDwelling::pickRandomObject(CRandomGenerator & rand)
+void CGDwelling::pickRandomObject(vstd::RNG & rand)
 {
 	if (ID == Obj::RANDOM_DWELLING || ID == Obj::RANDOM_DWELLING_LVL || ID == Obj::RANDOM_DWELLING_FACTION)
 	{
@@ -172,7 +174,7 @@ void CGDwelling::pickRandomObject(CRandomGenerator & rand)
 	}
 }
 
-void CGDwelling::initObj(CRandomGenerator & rand)
+void CGDwelling::initObj(vstd::RNG & rand)
 {
 	switch(ID.toEnum())
 	{
@@ -298,7 +300,7 @@ void CGDwelling::onHeroVisit( const CGHeroInstance * h ) const
 	cb->showBlockingDialog(&bd);
 }
 
-void CGDwelling::newTurn(CRandomGenerator & rand) const
+void CGDwelling::newTurn(vstd::RNG & rand) const
 {
 	if(cb->getDate(Date::DAY_OF_WEEK) != 1) //not first day of week
 		return;

--- a/lib/mapObjects/CGDwelling.h
+++ b/lib/mapObjects/CGDwelling.h
@@ -45,13 +45,13 @@ protected:
 	void serializeJsonOptions(JsonSerializeFormat & handler) override;
 
 private:
-	FactionID randomizeFaction(CRandomGenerator & rand);
-	int randomizeLevel(CRandomGenerator & rand);
+	FactionID randomizeFaction(vstd::RNG & rand);
+	int randomizeLevel(vstd::RNG & rand);
 
-	void pickRandomObject(CRandomGenerator & rand) override;
-	void initObj(CRandomGenerator & rand) override;
+	void pickRandomObject(vstd::RNG & rand) override;
+	void initObj(vstd::RNG & rand) override;
 	void onHeroVisit(const CGHeroInstance * h) const override;
-	void newTurn(CRandomGenerator & rand) const override;
+	void newTurn(vstd::RNG & rand) const override;
 	void setPropertyDer(ObjProperty what, ObjPropertyID identifier) override;
 	void battleFinished(const CGHeroInstance *hero, const BattleResult &result) const override;
 	void blockingDialogAnswered(const CGHeroInstance *hero, ui32 answer) const override;

--- a/lib/mapObjects/CGHeroInstance.cpp
+++ b/lib/mapObjects/CGHeroInstance.cpp
@@ -532,7 +532,7 @@ void CGHeroInstance::onHeroVisit(const CGHeroInstance * h) const
 				if (!boat)
 				{
 					//Create a new boat for hero
-					cb->createObject(boatPos, h->getOwner(), Obj::BOAT, getBoatType().getNum());
+					cb->createBoat(boatPos, getBoatType(), h->getOwner());
 					boatId = cb->getTopObj(boatPos)->id;
 				}
 			}
@@ -612,11 +612,6 @@ void CGHeroInstance::pickRandomObject(vstd::RNG & rand)
 		setType(ID, type->heroClass->getIndex());
 
 	this->subID = oldSubID;
-}
-
-void CGHeroInstance::initObj(vstd::RNG & rand)
-{
-
 }
 
 void CGHeroInstance::recreateSecondarySkillsBonuses()

--- a/lib/mapObjects/CGHeroInstance.cpp
+++ b/lib/mapObjects/CGHeroInstance.cpp
@@ -313,13 +313,13 @@ void CGHeroInstance::setHeroType(HeroTypeID heroType)
 	subID = heroType;
 }
 
-void CGHeroInstance::initHero(CRandomGenerator & rand, const HeroTypeID & SUBID)
+void CGHeroInstance::initHero(vstd::RNG & rand, const HeroTypeID & SUBID)
 {
 	subID = SUBID.getNum();
 	initHero(rand);
 }
 
-void CGHeroInstance::initHero(CRandomGenerator & rand)
+void CGHeroInstance::initHero(vstd::RNG & rand)
 {
 	assert(validTypes(true));
 	if(!type)
@@ -422,7 +422,7 @@ void CGHeroInstance::initHero(CRandomGenerator & rand)
 	mana = manaLimit(); //after all bonuses are taken into account, make sure this line is the last one
 }
 
-void CGHeroInstance::initArmy(CRandomGenerator & rand, IArmyDescriptor * dst)
+void CGHeroInstance::initArmy(vstd::RNG & rand, IArmyDescriptor * dst)
 {
 	if(!dst)
 		dst = this;
@@ -589,7 +589,7 @@ void CGHeroInstance::SecondarySkillsInfo::resetWisdomCounter()
 	wisdomCounter = 0;
 }
 
-void CGHeroInstance::pickRandomObject(CRandomGenerator & rand)
+void CGHeroInstance::pickRandomObject(vstd::RNG & rand)
 {
 	assert(ID == Obj::HERO || ID == Obj::PRISON || ID == Obj::RANDOM_HERO);
 
@@ -614,7 +614,7 @@ void CGHeroInstance::pickRandomObject(CRandomGenerator & rand)
 	this->subID = oldSubID;
 }
 
-void CGHeroInstance::initObj(CRandomGenerator & rand)
+void CGHeroInstance::initObj(vstd::RNG & rand)
 {
 
 }
@@ -959,7 +959,7 @@ CStackBasicDescriptor CGHeroInstance::calculateNecromancy (const BattleResult &b
  * @param raisedStack Pair where the first element represents ID of the raised creature
  * and the second element the amount.
  */
-void CGHeroInstance::showNecromancyDialog(const CStackBasicDescriptor &raisedStack, CRandomGenerator & rand) const
+void CGHeroInstance::showNecromancyDialog(const CStackBasicDescriptor &raisedStack, vstd::RNG & rand) const
 {
 	InfoWindow iw;
 	iw.type = EInfoWindowMode::AUTO;
@@ -1068,7 +1068,7 @@ EAlignment CGHeroInstance::getAlignment() const
 	return type->heroClass->getAlignment();
 }
 
-void CGHeroInstance::initExp(CRandomGenerator & rand)
+void CGHeroInstance::initExp(vstd::RNG & rand)
 {
 	exp = rand.nextInt(40, 89);
 }
@@ -1286,7 +1286,7 @@ ArtBearer::ArtBearer CGHeroInstance::bearerType() const
 	return ArtBearer::HERO;
 }
 
-std::vector<SecondarySkill> CGHeroInstance::getLevelUpProposedSecondarySkills(CRandomGenerator & rand) const
+std::vector<SecondarySkill> CGHeroInstance::getLevelUpProposedSecondarySkills(vstd::RNG & rand) const
 {
 	auto getObligatorySkills = [](CSkill::Obligatory obl){
 		std::set<SecondarySkill> obligatory;
@@ -1365,7 +1365,7 @@ std::vector<SecondarySkill> CGHeroInstance::getLevelUpProposedSecondarySkills(CR
 	return skills;
 }
 
-PrimarySkill CGHeroInstance::nextPrimarySkill(CRandomGenerator & rand) const
+PrimarySkill CGHeroInstance::nextPrimarySkill(vstd::RNG & rand) const
 {
 	assert(gainsLevel());
 	const auto isLowLevelHero = level < GameConstants::HERO_HIGH_LEVEL;
@@ -1381,7 +1381,7 @@ PrimarySkill CGHeroInstance::nextPrimarySkill(CRandomGenerator & rand) const
 	return static_cast<PrimarySkill>(RandomGeneratorUtil::nextItemWeighted(skillChances, rand));
 }
 
-std::optional<SecondarySkill> CGHeroInstance::nextSecondarySkill(CRandomGenerator & rand) const
+std::optional<SecondarySkill> CGHeroInstance::nextSecondarySkill(vstd::RNG & rand) const
 {
 	assert(gainsLevel());
 
@@ -1469,7 +1469,7 @@ void CGHeroInstance::levelUp(const std::vector<SecondarySkill> & skills)
 	treeHasChanged();
 }
 
-void CGHeroInstance::levelUpAutomatically(CRandomGenerator & rand)
+void CGHeroInstance::levelUpAutomatically(vstd::RNG & rand)
 {
 	while(gainsLevel())
 	{

--- a/lib/mapObjects/CGHeroInstance.h
+++ b/lib/mapObjects/CGHeroInstance.h
@@ -187,13 +187,13 @@ public:
 	bool gainsLevel() const;
 
 	/// Returns the next primary skill on level up. Can only be called if hero can gain a level up.
-	PrimarySkill nextPrimarySkill(CRandomGenerator & rand) const;
+	PrimarySkill nextPrimarySkill(vstd::RNG & rand) const;
 
 	/// Returns the next secondary skill randomly on level up. Can only be called if hero can gain a level up.
-	std::optional<SecondarySkill> nextSecondarySkill(CRandomGenerator & rand) const;
+	std::optional<SecondarySkill> nextSecondarySkill(vstd::RNG & rand) const;
 
 	/// Gets 0, 1 or 2 secondary skills which are proposed on hero level up.
-	std::vector<SecondarySkill> getLevelUpProposedSecondarySkills(CRandomGenerator & rand) const;
+	std::vector<SecondarySkill> getLevelUpProposedSecondarySkills(vstd::RNG & rand) const;
 
 	ui8 getSecSkillLevel(const SecondarySkill & skill) const; //0 - no skill
 
@@ -225,7 +225,7 @@ public:
 	TExpType calculateXp(TExpType exp) const; //apply learning skill
 
 	CStackBasicDescriptor calculateNecromancy (const BattleResult &battleResult) const;
-	void showNecromancyDialog(const CStackBasicDescriptor &raisedStack, CRandomGenerator & rand) const;
+	void showNecromancyDialog(const CStackBasicDescriptor &raisedStack, vstd::RNG & rand) const;
 	EDiggingStatus diggingStatus() const;
 
 	//////////////////////////////////////////////////////////////////////////
@@ -233,13 +233,13 @@ public:
 	HeroTypeID getHeroType() const;
 	void setHeroType(HeroTypeID type);
 
-	void initHero(CRandomGenerator & rand);
-	void initHero(CRandomGenerator & rand, const HeroTypeID & SUBID);
+	void initHero(vstd::RNG & rand);
+	void initHero(vstd::RNG & rand, const HeroTypeID & SUBID);
 
 	ArtPlacementMap putArtifact(ArtifactPosition pos, CArtifactInstance * art) override;
 	void removeArtifact(ArtifactPosition pos) override;
-	void initExp(CRandomGenerator & rand);
-	void initArmy(CRandomGenerator & rand, IArmyDescriptor *dst = nullptr);
+	void initExp(vstd::RNG & rand);
+	void initArmy(vstd::RNG & rand, IArmyDescriptor *dst = nullptr);
 	void pushPrimSkill(PrimarySkill which, int val);
 	ui8 maxlevelsToMagicSchool() const;
 	ui8 maxlevelsToWisdom() const;
@@ -293,8 +293,8 @@ public:
 	void boatDeserializationFix();
 	void deserializationFix();
 
-	void initObj(CRandomGenerator & rand) override;
-	void pickRandomObject(CRandomGenerator & rand) override;
+	void initObj(vstd::RNG & rand) override;
+	void pickRandomObject(vstd::RNG & rand) override;
 	void onHeroVisit(const CGHeroInstance * h) const override;
 	std::string getObjectName() const override;
 
@@ -318,7 +318,7 @@ protected:
 	void serializeJsonOptions(JsonSerializeFormat & handler) override;
 
 private:
-	void levelUpAutomatically(CRandomGenerator & rand);
+	void levelUpAutomatically(vstd::RNG & rand);
 
 public:
 	std::string getHeroTypeName() const;

--- a/lib/mapObjects/CGHeroInstance.h
+++ b/lib/mapObjects/CGHeroInstance.h
@@ -293,7 +293,6 @@ public:
 	void boatDeserializationFix();
 	void deserializationFix();
 
-	void initObj(vstd::RNG & rand) override;
 	void pickRandomObject(vstd::RNG & rand) override;
 	void onHeroVisit(const CGHeroInstance * h) const override;
 	std::string getObjectName() const override;

--- a/lib/mapObjects/CGMarket.cpp
+++ b/lib/mapObjects/CGMarket.cpp
@@ -23,7 +23,7 @@
 
 VCMI_LIB_NAMESPACE_BEGIN
 
-void CGMarket::initObj(CRandomGenerator & rand)
+void CGMarket::initObj(vstd::RNG & rand)
 {
 	getObjectHandler()->configureObject(this, rand);
 }
@@ -80,7 +80,7 @@ std::vector<TradeItemBuy> CGBlackMarket::availableItemsIds(EMarketMode mode) con
 	}
 }
 
-void CGBlackMarket::newTurn(CRandomGenerator & rand) const
+void CGBlackMarket::newTurn(vstd::RNG & rand) const
 {
 	int resetPeriod = VLC->settings()->getInteger(EGameSettings::MARKETS_BLACK_MARKET_RESTOCK_PERIOD);
 

--- a/lib/mapObjects/CGMarket.h
+++ b/lib/mapObjects/CGMarket.h
@@ -29,7 +29,7 @@ public:
 	CGMarket(IGameCallback *cb);
 	///IObjectInterface
 	void onHeroVisit(const CGHeroInstance * h) const override; //open trading window
-	void initObj(CRandomGenerator & rand) override;//set skills for trade
+	void initObj(vstd::RNG & rand) override;//set skills for trade
 
 	///IMarket
 	int getMarketEfficiency() const override;
@@ -54,7 +54,7 @@ public:
 
 	std::vector<const CArtifact *> artifacts; //available artifacts
 
-	void newTurn(CRandomGenerator & rand) const override; //reset artifacts for black market every month
+	void newTurn(vstd::RNG & rand) const override; //reset artifacts for black market every month
 	std::vector<TradeItemBuy> availableItemsIds(EMarketMode mode) const override;
 
 	template <typename Handler> void serialize(Handler &h)

--- a/lib/mapObjects/CGObjectInstance.cpp
+++ b/lib/mapObjects/CGObjectInstance.cpp
@@ -25,6 +25,8 @@
 #include "../networkPacks/PacksForClient.h"
 #include "../serializer/JsonSerializeFormat.h"
 
+#include <vstd/RNG.h>
+
 VCMI_LIB_NAMESPACE_BEGIN
 
 //TODO: remove constructor
@@ -164,12 +166,12 @@ void CGObjectInstance::setType(MapObjectID newID, MapObjectSubID newSubID)
 	cb->gameState()->map->addBlockVisTiles(this);
 }
 
-void CGObjectInstance::pickRandomObject(CRandomGenerator & rand)
+void CGObjectInstance::pickRandomObject(vstd::RNG & rand)
 {
 	// no-op
 }
 
-void CGObjectInstance::initObj(CRandomGenerator & rand)
+void CGObjectInstance::initObj(vstd::RNG & rand)
 {
 	// no-op
 }
@@ -232,7 +234,7 @@ std::string CGObjectInstance::getObjectName() const
 	return VLC->objtypeh->getObjectName(ID, subID);
 }
 
-std::optional<AudioPath> CGObjectInstance::getAmbientSound() const
+std::optional<AudioPath> CGObjectInstance::getAmbientSound(vstd::RNG & rng) const
 {
 	const auto & sounds = VLC->objtypeh->getObjectSounds(ID, subID).ambient;
 	if(!sounds.empty())
@@ -241,20 +243,20 @@ std::optional<AudioPath> CGObjectInstance::getAmbientSound() const
 	return std::nullopt;
 }
 
-std::optional<AudioPath> CGObjectInstance::getVisitSound() const
+std::optional<AudioPath> CGObjectInstance::getVisitSound(vstd::RNG & rng) const
 {
 	const auto & sounds = VLC->objtypeh->getObjectSounds(ID, subID).visit;
 	if(!sounds.empty())
-		return *RandomGeneratorUtil::nextItem(sounds, CRandomGenerator::getDefault());
+		return *RandomGeneratorUtil::nextItem(sounds, rng);
 
 	return std::nullopt;
 }
 
-std::optional<AudioPath> CGObjectInstance::getRemovalSound() const
+std::optional<AudioPath> CGObjectInstance::getRemovalSound(vstd::RNG & rng) const
 {
 	const auto & sounds = VLC->objtypeh->getObjectSounds(ID, subID).removal;
 	if(!sounds.empty())
-		return *RandomGeneratorUtil::nextItem(sounds, CRandomGenerator::getDefault());
+		return *RandomGeneratorUtil::nextItem(sounds, rng);
 
 	return std::nullopt;
 }

--- a/lib/mapObjects/CGObjectInstance.h
+++ b/lib/mapObjects/CGObjectInstance.h
@@ -97,9 +97,9 @@ public:
 
 	virtual bool isTile2Terrain() const { return false; }
 
-	std::optional<AudioPath> getAmbientSound() const;
-	std::optional<AudioPath> getVisitSound() const;
-	std::optional<AudioPath> getRemovalSound() const;
+	std::optional<AudioPath> getAmbientSound(vstd::RNG & rng) const;
+	std::optional<AudioPath> getVisitSound(vstd::RNG & rng) const;
+	std::optional<AudioPath> getRemovalSound(vstd::RNG & rng) const;
 
 	TObjectTypeHandler getObjectHandler() const;
 
@@ -128,8 +128,8 @@ public:
 
 	/** OVERRIDES OF IObjectInterface **/
 
-	void initObj(CRandomGenerator & rand) override;
-	void pickRandomObject(CRandomGenerator & rand) override;
+	void initObj(vstd::RNG & rand) override;
+	void pickRandomObject(vstd::RNG & rand) override;
 	void onHeroVisit(const CGHeroInstance * h) const override;
 	/// method for synchronous update. Note: For new properties classes should override setPropertyDer instead
 	void setProperty(ObjProperty what, ObjPropertyID identifier) final;

--- a/lib/mapObjects/CGPandoraBox.cpp
+++ b/lib/mapObjects/CGPandoraBox.cpp
@@ -41,7 +41,7 @@ void CGPandoraBox::init()
 	}
 }
 
-void CGPandoraBox::initObj(CRandomGenerator & rand)
+void CGPandoraBox::initObj(vstd::RNG & rand)
 {
 	init();
 	

--- a/lib/mapObjects/CGPandoraBox.h
+++ b/lib/mapObjects/CGPandoraBox.h
@@ -23,7 +23,7 @@ public:
 
 	MetaString message;
 
-	void initObj(CRandomGenerator & rand) override;
+	void initObj(vstd::RNG & rand) override;
 	void onHeroVisit(const CGHeroInstance * h) const override;
 	void battleFinished(const CGHeroInstance *hero, const BattleResult &result) const override;
 	void blockingDialogAnswered(const CGHeroInstance *hero, ui32 answer) const override;

--- a/lib/mapObjects/CGTownBuilding.cpp
+++ b/lib/mapObjects/CGTownBuilding.cpp
@@ -17,6 +17,8 @@
 #include "../mapObjects/CGHeroInstance.h"
 #include "../networkPacks/PacksForClient.h"
 
+#include <vstd/RNG.h>
+
 VCMI_LIB_NAMESPACE_BEGIN
 
 CGTownBuilding::CGTownBuilding(IGameCallback * cb)
@@ -314,7 +316,7 @@ CTownRewardableBuilding::CTownRewardableBuilding(IGameCallback *cb)
 	: CGTownBuilding(cb)
 {}
 
-CTownRewardableBuilding::CTownRewardableBuilding(const BuildingID & index, BuildingSubID::EBuildingSubID subId, CGTownInstance * cgTown, CRandomGenerator & rand)
+CTownRewardableBuilding::CTownRewardableBuilding(const BuildingID & index, BuildingSubID::EBuildingSubID subId, CGTownInstance * cgTown, vstd::RNG & rand)
 	: CGTownBuilding(cgTown)
 {
 	bID = index;
@@ -323,7 +325,7 @@ CTownRewardableBuilding::CTownRewardableBuilding(const BuildingID & index, Build
 	initObj(rand);
 }
 
-void CTownRewardableBuilding::initObj(CRandomGenerator & rand)
+void CTownRewardableBuilding::initObj(vstd::RNG & rand)
 {
 	assert(town && town->town);
 
@@ -340,7 +342,7 @@ void CTownRewardableBuilding::initObj(CRandomGenerator & rand)
 	}
 }
 
-void CTownRewardableBuilding::newTurn(CRandomGenerator & rand) const
+void CTownRewardableBuilding::newTurn(vstd::RNG & rand) const
 {
 	if (configuration.resetParameters.period != 0 && cb->getDate(Date::DAY) > 1 && ((cb->getDate(Date::DAY)-1) % configuration.resetParameters.period) == 0)
 	{

--- a/lib/mapObjects/CGTownBuilding.h
+++ b/lib/mapObjects/CGTownBuilding.h
@@ -123,17 +123,17 @@ public:
 	void setProperty(ObjProperty what, ObjPropertyID identifier) override;
 	void onHeroVisit(const CGHeroInstance * h) const override;
 	
-	void newTurn(CRandomGenerator & rand) const override;
+	void newTurn(vstd::RNG & rand) const override;
 	
 	/// gives second part of reward after hero level-ups for proper granting of spells/mana
 	void heroLevelUpDone(const CGHeroInstance *hero) const override;
 	
-	void initObj(CRandomGenerator & rand) override;
+	void initObj(vstd::RNG & rand) override;
 	
 	/// applies player selection of reward
 	void blockingDialogAnswered(const CGHeroInstance *hero, ui32 answer) const override;
 	
-	CTownRewardableBuilding(const BuildingID & index, BuildingSubID::EBuildingSubID subId, CGTownInstance * town, CRandomGenerator & rand);
+	CTownRewardableBuilding(const BuildingID & index, BuildingSubID::EBuildingSubID subId, CGTownInstance * town, vstd::RNG & rand);
 	CTownRewardableBuilding(IGameCallback *cb);
 	
 	template <typename Handler> void serialize(Handler &h)

--- a/lib/mapObjects/CGTownBuilding.h
+++ b/lib/mapObjects/CGTownBuilding.h
@@ -118,6 +118,8 @@ class DLL_LINKAGE CTownRewardableBuilding : public CGTownBuilding, public Reward
 	bool wasVisitedBefore(const CGHeroInstance * contextHero) const;
 	
 	void grantReward(ui32 rewardID, const CGHeroInstance * hero) const;
+
+	Rewardable::Configuration generateConfiguration(vstd::RNG & rand) const;
 	
 public:
 	void setProperty(ObjProperty what, ObjPropertyID identifier) override;

--- a/lib/mapObjects/CGTownInstance.cpp
+++ b/lib/mapObjects/CGTownInstance.cpp
@@ -31,6 +31,8 @@
 #include "../networkPacks/PacksForClientBattle.h"
 #include "../serializer/JsonSerializeFormat.h"
 
+#include <vstd/RNG.h>
+
 VCMI_LIB_NAMESPACE_BEGIN
 
 int CGTownInstance::getSightRadius() const //returns sight distance
@@ -379,7 +381,7 @@ bool CGTownInstance::isBonusingBuildingAdded(BuildingID bid) const
 	return present != bonusingBuildings.end();
 }
 
-void CGTownInstance::addTownBonuses(CRandomGenerator & rand)
+void CGTownInstance::addTownBonuses(vstd::RNG & rand)
 {
 	for(const auto & kvp : town->buildings)
 	{
@@ -461,7 +463,7 @@ void CGTownInstance::deleteTownBonus(BuildingID bid)
 	delete freeIt;
 }
 
-FactionID CGTownInstance::randomizeFaction(CRandomGenerator & rand)
+FactionID CGTownInstance::randomizeFaction(vstd::RNG & rand)
 {
 	if(getOwner().isValidPlayer())
 		return cb->gameState()->scenarioOps->getIthPlayersSettings(getOwner()).castle;
@@ -479,7 +481,7 @@ FactionID CGTownInstance::randomizeFaction(CRandomGenerator & rand)
 	return *RandomGeneratorUtil::nextItem(potentialPicks, rand);
 }
 
-void CGTownInstance::pickRandomObject(CRandomGenerator & rand)
+void CGTownInstance::pickRandomObject(vstd::RNG & rand)
 {
 	assert(ID == MapObjectID::TOWN || ID == MapObjectID::RANDOM_TOWN);
 	if (ID == MapObjectID::RANDOM_TOWN)
@@ -495,7 +497,7 @@ void CGTownInstance::pickRandomObject(CRandomGenerator & rand)
 	updateAppearance();
 }
 
-void CGTownInstance::initObj(CRandomGenerator & rand) ///initialize town structures
+void CGTownInstance::initObj(vstd::RNG & rand) ///initialize town structures
 {
 	blockVisit = true;
 
@@ -521,7 +523,7 @@ void CGTownInstance::initObj(CRandomGenerator & rand) ///initialize town structu
 	updateAppearance();
 }
 
-void CGTownInstance::newTurn(CRandomGenerator & rand) const
+void CGTownInstance::newTurn(vstd::RNG & rand) const
 {
 	if (cb->getDate(Date::DAY_OF_WEEK) == 1) //reset on new week
 	{

--- a/lib/mapObjects/CGTownInstance.cpp
+++ b/lib/mapObjects/CGTownInstance.cpp
@@ -71,9 +71,6 @@ void CGTownInstance::setPropertyDer(ObjProperty what, ObjPropertyID identifier)
 		case ObjProperty::BONUS_VALUE_SECOND:
 			bonusValue.second = identifier.getNum();
 			break;
-		case ObjProperty::REWARD_RANDOMIZE:
-			bonusingBuildings[identifier.getNum()]->setProperty(ObjProperty::REWARD_RANDOMIZE, NumericID(0));
-			break;
 	}
 }
 CGTownInstance::EFortLevel CGTownInstance::fortLevel() const //0 - none, 1 - fort, 2 - citadel, 3 - castle

--- a/lib/mapObjects/CGTownInstance.h
+++ b/lib/mapObjects/CGTownInstance.h
@@ -201,11 +201,11 @@ public:
 	virtual ~CGTownInstance();
 
 	///IObjectInterface overrides
-	void newTurn(CRandomGenerator & rand) const override;
+	void newTurn(vstd::RNG & rand) const override;
 	void onHeroVisit(const CGHeroInstance * h) const override;
 	void onHeroLeave(const CGHeroInstance * h) const override;
-	void initObj(CRandomGenerator & rand) override;
-	void pickRandomObject(CRandomGenerator & rand) override;
+	void initObj(vstd::RNG & rand) override;
+	void pickRandomObject(vstd::RNG & rand) override;
 	void battleFinished(const CGHeroInstance * hero, const BattleResult & result) const override;
 	std::string getObjectName() const override;
 
@@ -224,14 +224,14 @@ protected:
 	void blockingDialogAnswered(const CGHeroInstance *hero, ui32 answer) const override;
 
 private:
-	FactionID randomizeFaction(CRandomGenerator & rand);
+	FactionID randomizeFaction(vstd::RNG & rand);
 	void setOwner(const PlayerColor & owner) const;
 	void onTownCaptured(const PlayerColor & winner) const;
 	int getDwellingBonus(const std::vector<CreatureID>& creatureIds, const std::vector<ConstTransitivePtr<CGDwelling> >& dwellings) const;
 	bool townEnvisagesBuilding(BuildingSubID::EBuildingSubID bid) const;
 	bool isBonusingBuildingAdded(BuildingID bid) const;
 	void initOverriddenBids();
-	void addTownBonuses(CRandomGenerator & rand);
+	void addTownBonuses(vstd::RNG & rand);
 };
 
 VCMI_LIB_NAMESPACE_END

--- a/lib/mapObjects/CQuest.cpp
+++ b/lib/mapObjects/CQuest.cpp
@@ -31,7 +31,8 @@
 #include "../modding/ModUtility.h"
 #include "../networkPacks/PacksForClient.h"
 #include "../spells/CSpellHandler.h"
-#include "../CRandomGenerator.h"
+
+#include <vstd/RNG.h>
 
 VCMI_LIB_NAMESPACE_BEGIN
 
@@ -441,7 +442,7 @@ void CGSeerHut::setObjToKill()
 	}
 }
 
-void CGSeerHut::init(CRandomGenerator & rand)
+void CGSeerHut::init(vstd::RNG & rand)
 {
 	auto names = VLC->generaltexth->findStringsWithPrefix("core.seerhut.names");
 
@@ -455,7 +456,7 @@ void CGSeerHut::init(CRandomGenerator & rand)
 	configuration.selectMode = Rewardable::ESelectMode::SELECT_PLAYER;
 }
 
-void CGSeerHut::initObj(CRandomGenerator & rand)
+void CGSeerHut::initObj(vstd::RNG & rand)
 {
 	init(rand);
 	
@@ -562,7 +563,7 @@ void CGSeerHut::setPropertyDer(ObjProperty what, ObjPropertyID identifier)
 	}
 }
 
-void CGSeerHut::newTurn(CRandomGenerator & rand) const
+void CGSeerHut::newTurn(vstd::RNG & rand) const
 {
 	CRewardableObject::newTurn(rand);
 	if(quest->lastDay >= 0 && quest->lastDay <= cb->getDate() - 1) //time is up
@@ -750,7 +751,7 @@ void CGSeerHut::serializeJsonOptions(JsonSerializeFormat & handler)
 	}
 }
 
-void CGQuestGuard::init(CRandomGenerator & rand)
+void CGQuestGuard::init(vstd::RNG & rand)
 {
 	blockVisit = true;
 	quest->textOption = rand.nextInt(3, 5);
@@ -818,7 +819,7 @@ void CGKeymasterTent::onHeroVisit( const CGHeroInstance * h ) const
 	h->showInfoDialog(txt_id);
 }
 
-void CGBorderGuard::initObj(CRandomGenerator & rand)
+void CGBorderGuard::initObj(vstd::RNG & rand)
 {
 	blockVisit = true;
 }

--- a/lib/mapObjects/CQuest.h
+++ b/lib/mapObjects/CQuest.h
@@ -141,19 +141,19 @@ public:
 
 	std::string seerName;
 
-	void initObj(CRandomGenerator & rand) override;
+	void initObj(vstd::RNG & rand) override;
 	std::string getHoverText(PlayerColor player) const override;
 	std::string getHoverText(const CGHeroInstance * hero) const override;
 	std::string getPopupText(PlayerColor player) const override;
 	std::string getPopupText(const CGHeroInstance * hero) const override;
 	std::vector<Component> getPopupComponents(PlayerColor player) const override;
 	std::vector<Component> getPopupComponents(const CGHeroInstance * hero) const override;
-	void newTurn(CRandomGenerator & rand) const override;
+	void newTurn(vstd::RNG & rand) const override;
 	void onHeroVisit(const CGHeroInstance * h) const override;
 	void blockingDialogAnswered(const CGHeroInstance *hero, ui32 answer) const override;
 	void getVisitText (MetaString &text, std::vector<Component> &components, bool FirstVisit, const CGHeroInstance * h = nullptr) const override;
 
-	virtual void init(CRandomGenerator & rand);
+	virtual void init(vstd::RNG & rand);
 	int checkDirection() const; //calculates the region of map where monster is placed
 	void setObjToKill(); //remember creatures / heroes to kill after they are initialized
 	const CGHeroInstance *getHeroToKill(bool allowNull) const;
@@ -179,7 +179,7 @@ class DLL_LINKAGE CGQuestGuard : public CGSeerHut
 public:
 	using CGSeerHut::CGSeerHut;
 
-	void init(CRandomGenerator & rand) override;
+	void init(vstd::RNG & rand) override;
 	
 	void onHeroVisit(const CGHeroInstance * h) const override;
 	bool passableFor(PlayerColor color) const override;
@@ -227,7 +227,7 @@ class DLL_LINKAGE CGBorderGuard : public CGKeys, public IQuestObject
 public:
 	using CGKeys::CGKeys;
 
-	void initObj(CRandomGenerator & rand) override;
+	void initObj(vstd::RNG & rand) override;
 	void onHeroVisit(const CGHeroInstance * h) const override;
 	void blockingDialogAnswered(const CGHeroInstance *hero, ui32 answer) const override;
 

--- a/lib/mapObjects/CRewardableObject.cpp
+++ b/lib/mapObjects/CRewardableObject.cpp
@@ -16,6 +16,7 @@
 #include "../IGameCallback.h"
 #include "../mapObjectConstructors/AObjectTypeHandler.h"
 #include "../mapObjectConstructors/CObjectClassesHandler.h"
+#include "../mapObjectConstructors/CRewardableConstructor.h"
 #include "../mapObjects/CGHeroInstance.h"
 #include "../networkPacks/PacksForClient.h"
 #include "../serializer/JsonSerializeFormat.h"
@@ -377,9 +378,6 @@ void CRewardableObject::setPropertyDer(ObjProperty what, ObjPropertyID identifie
 {
 	switch (what)
 	{
-		case ObjProperty::REWARD_RANDOMIZE:
-			initObj(cb->gameState()->getRandomGenerator());
-			break;
 		case ObjProperty::REWARD_SELECT:
 			selectedReward = identifier.getNum();
 			break;
@@ -395,7 +393,9 @@ void CRewardableObject::newTurn(vstd::RNG & rand) const
 	{
 		if (configuration.resetParameters.rewards)
 		{
-			cb->setObjPropertyValue(id, ObjProperty::REWARD_RANDOMIZE, 0);
+			auto handler = std::dynamic_pointer_cast<const CRewardableConstructor>(getObjectHandler());
+			auto newConfiguration = handler->generateConfiguration(cb, rand, ID);
+			cb->setRewardableObjectConfiguration(id, newConfiguration);
 		}
 		if (configuration.resetParameters.visitors)
 		{

--- a/lib/mapObjects/CRewardableObject.cpp
+++ b/lib/mapObjects/CRewardableObject.cpp
@@ -20,6 +20,8 @@
 #include "../networkPacks/PacksForClient.h"
 #include "../serializer/JsonSerializeFormat.h"
 
+#include <vstd/RNG.h>
+
 VCMI_LIB_NAMESPACE_BEGIN
 
 void CRewardableObject::grantRewardWithMessage(const CGHeroInstance * contextHero, int index, bool markAsVisit) const
@@ -387,7 +389,7 @@ void CRewardableObject::setPropertyDer(ObjProperty what, ObjPropertyID identifie
 	}
 }
 
-void CRewardableObject::newTurn(CRandomGenerator & rand) const
+void CRewardableObject::newTurn(vstd::RNG & rand) const
 {
 	if (configuration.resetParameters.period != 0 && cb->getDate(Date::DAY) > 1 && ((cb->getDate(Date::DAY)-1) % configuration.resetParameters.period) == 0)
 	{
@@ -404,7 +406,7 @@ void CRewardableObject::newTurn(CRandomGenerator & rand) const
 	}
 }
 
-void CRewardableObject::initObj(CRandomGenerator & rand)
+void CRewardableObject::initObj(vstd::RNG & rand)
 {
 	getObjectHandler()->configureObject(this, rand);
 }

--- a/lib/mapObjects/CRewardableObject.h
+++ b/lib/mapObjects/CRewardableObject.h
@@ -57,7 +57,7 @@ public:
 	void onHeroVisit(const CGHeroInstance *h) const override;
 
 	///possibly resets object state
-	void newTurn(CRandomGenerator & rand) const override;
+	void newTurn(vstd::RNG & rand) const override;
 
 	/// gives second part of reward after hero level-ups for proper granting of spells/mana
 	void heroLevelUpDone(const CGHeroInstance *hero) const override;
@@ -65,7 +65,7 @@ public:
 	/// applies player selection of reward
 	void blockingDialogAnswered(const CGHeroInstance *hero, ui32 answer) const override;
 
-	void initObj(CRandomGenerator & rand) override;
+	void initObj(vstd::RNG & rand) override;
 	
 	void setPropertyDer(ObjProperty what, ObjPropertyID identifier) override;
 

--- a/lib/mapObjects/IObjectInterface.cpp
+++ b/lib/mapObjects/IObjectInterface.cpp
@@ -38,13 +38,13 @@ void IObjectInterface::onHeroVisit(const CGHeroInstance * h) const
 void IObjectInterface::onHeroLeave(const CGHeroInstance * h) const
 {}
 
-void IObjectInterface::newTurn(CRandomGenerator & rand) const
+void IObjectInterface::newTurn(vstd::RNG & rand) const
 {}
 
-void IObjectInterface::initObj(CRandomGenerator & rand)
+void IObjectInterface::initObj(vstd::RNG & rand)
 {}
 
-void IObjectInterface::pickRandomObject(CRandomGenerator & rand)
+void IObjectInterface::pickRandomObject(vstd::RNG & rand)
 {}
 
 void IObjectInterface::setProperty(ObjProperty what, ObjPropertyID identifier)

--- a/lib/mapObjects/IObjectInterface.h
+++ b/lib/mapObjects/IObjectInterface.h
@@ -50,6 +50,9 @@ public:
 
 	virtual void onHeroVisit(const CGHeroInstance * h) const;
 	virtual void onHeroLeave(const CGHeroInstance * h) const;
+
+	/// Called on new turn by server. This method can not modify object state on its own
+	/// Instead all changes must be propagated via netpacks
 	virtual void newTurn(vstd::RNG & rand) const;
 	virtual void initObj(vstd::RNG & rand); //synchr
 	virtual void pickRandomObject(vstd::RNG & rand);

--- a/lib/mapObjects/IObjectInterface.h
+++ b/lib/mapObjects/IObjectInterface.h
@@ -17,11 +17,15 @@
 
 VCMI_LIB_NAMESPACE_BEGIN
 
+namespace vstd
+{
+class RNG;
+}
+
 struct BattleResult;
 struct UpgradeInfo;
 class BoatId;
 class CGObjectInstance;
-class CRandomGenerator;
 class CStackInstance;
 class CGHeroInstance;
 class IGameCallback;
@@ -46,9 +50,9 @@ public:
 
 	virtual void onHeroVisit(const CGHeroInstance * h) const;
 	virtual void onHeroLeave(const CGHeroInstance * h) const;
-	virtual void newTurn(CRandomGenerator & rand) const;
-	virtual void initObj(CRandomGenerator & rand); //synchr
-	virtual void pickRandomObject(CRandomGenerator & rand);
+	virtual void newTurn(vstd::RNG & rand) const;
+	virtual void initObj(vstd::RNG & rand); //synchr
+	virtual void pickRandomObject(vstd::RNG & rand);
 	virtual void setProperty(ObjProperty what, ObjPropertyID identifier);//synchr
 
 	//Called when queries created DURING HERO VISIT are resolved

--- a/lib/mapObjects/MiscObjects.cpp
+++ b/lib/mapObjects/MiscObjects.cpp
@@ -705,7 +705,7 @@ void CGWhirlpool::teleportDialogAnswered(const CGHeroInstance *hero, ui32 answer
 
 		const auto * obj = cb->getObj(exit);
 		std::set<int3> tiles = obj->getBlockedPos();
-		dPos = *RandomGeneratorUtil::nextItem(tiles, cb->gameState()->getRandomGenerator()));
+		dPos = *RandomGeneratorUtil::nextItem(tiles, cb->gameState()->getRandomGenerator());
 	}
 
 	cb->moveHero(hero->id, hero->convertFromVisitablePos(dPos), EMovementMode::MONOLITH);

--- a/lib/mapObjects/MiscObjects.cpp
+++ b/lib/mapObjects/MiscObjects.cpp
@@ -32,6 +32,8 @@
 #include "../networkPacks/PacksForClientBattle.h"
 #include "../networkPacks/StackLocation.h"
 
+#include <vstd/RNG.h>
+
 VCMI_LIB_NAMESPACE_BEGIN
 
 ///helpers
@@ -93,7 +95,7 @@ void CGMine::onHeroVisit( const CGHeroInstance * h ) const
 
 }
 
-void CGMine::newTurn(CRandomGenerator & rand) const
+void CGMine::newTurn(vstd::RNG & rand) const
 {
 	if(cb->getDate() == 1)
 		return;
@@ -104,7 +106,7 @@ void CGMine::newTurn(CRandomGenerator & rand) const
 	cb->giveResource(tempOwner, producedResource, producedQuantity);
 }
 
-void CGMine::initObj(CRandomGenerator & rand)
+void CGMine::initObj(vstd::RNG & rand)
 {
 	if(isAbandoned())
 	{
@@ -254,7 +256,7 @@ std::string CGResource::getHoverText(PlayerColor player) const
 	return VLC->generaltexth->restypes[resourceID().getNum()];
 }
 
-void CGResource::pickRandomObject(CRandomGenerator & rand)
+void CGResource::pickRandomObject(vstd::RNG & rand)
 {
 	assert(ID == Obj::RESOURCE || ID == Obj::RANDOM_RESOURCE);
 
@@ -269,7 +271,7 @@ void CGResource::pickRandomObject(CRandomGenerator & rand)
 	}
 }
 
-void CGResource::initObj(CRandomGenerator & rand)
+void CGResource::initObj(vstd::RNG & rand)
 {
 	blockVisit = true;
 
@@ -327,7 +329,7 @@ void CGResource::collectRes(const PlayerColor & player) const
 		sii.text.replaceName(resourceID());
 	}
 	sii.components.emplace_back(ComponentType::RESOURCE, resourceID(), amount);
-	sii.soundID = soundBase::pickup01 + CRandomGenerator::getDefault().nextInt(6);
+	sii.soundID = soundBase::pickup01 + cb->gameState()->getRandomGenerator().nextInt(6);
 	cb->showInfoDialog(&sii);
 	cb->removeObject(this, player);
 }
@@ -395,7 +397,7 @@ ObjectInstanceID CGTeleport::getRandomExit(const CGHeroInstance * h) const
 {
 	auto passableExits = getPassableExits(cb->gameState(), h, getAllExits(true));
 	if(!passableExits.empty())
-		return *RandomGeneratorUtil::nextItem(passableExits, CRandomGenerator::getDefault());
+		return *RandomGeneratorUtil::nextItem(passableExits, cb->gameState()->getRandomGenerator());
 
 	return ObjectInstanceID();
 }
@@ -530,7 +532,7 @@ void CGMonolith::teleportDialogAnswered(const CGHeroInstance *hero, ui32 answer,
 	cb->moveHero(hero->id, hero->convertFromVisitablePos(dPos), EMovementMode::MONOLITH);
 }
 
-void CGMonolith::initObj(CRandomGenerator & rand)
+void CGMonolith::initObj(vstd::RNG & rand)
 {
 	std::vector<Obj> IDs;
 	IDs.push_back(ID);
@@ -575,7 +577,7 @@ void CGSubterraneanGate::onHeroVisit( const CGHeroInstance * h ) const
 	cb->showTeleportDialog(&td);
 }
 
-void CGSubterraneanGate::initObj(CRandomGenerator & rand)
+void CGSubterraneanGate::initObj(vstd::RNG & rand)
 {
 	type = BOTH;
 }
@@ -703,7 +705,7 @@ void CGWhirlpool::teleportDialogAnswered(const CGHeroInstance *hero, ui32 answer
 
 		const auto * obj = cb->getObj(exit);
 		std::set<int3> tiles = obj->getBlockedPos();
-		dPos = *RandomGeneratorUtil::nextItem(tiles, CRandomGenerator::getDefault());
+		dPos = *RandomGeneratorUtil::nextItem(tiles, cb->gameState()->getRandomGenerator()));
 	}
 
 	cb->moveHero(hero->id, hero->convertFromVisitablePos(dPos), EMovementMode::MONOLITH);
@@ -724,7 +726,7 @@ ArtifactID CGArtifact::getArtifact() const
 		return getObjTypeIndex().getNum();
 }
 
-void CGArtifact::pickRandomObject(CRandomGenerator & rand)
+void CGArtifact::pickRandomObject(vstd::RNG & rand)
 {
 	switch(ID.toEnum())
 	{
@@ -754,7 +756,7 @@ void CGArtifact::pickRandomObject(CRandomGenerator & rand)
 		ID = MapObjectID::ARTIFACT;
 }
 
-void CGArtifact::initObj(CRandomGenerator & rand)
+void CGArtifact::initObj(vstd::RNG & rand)
 {
 	blockVisit = true;
 	if(ID == Obj::ARTIFACT)
@@ -936,7 +938,7 @@ void CGArtifact::serializeJsonOptions(JsonSerializeFormat& handler)
 	}
 }
 
-void CGSignBottle::initObj(CRandomGenerator & rand)
+void CGSignBottle::initObj(vstd::RNG & rand)
 {
 	//if no text is set than we pick random from the predefined ones
 	if(message.empty())
@@ -1011,7 +1013,7 @@ void CGGarrison::serializeJsonOptions(JsonSerializeFormat& handler)
 	CArmedInstance::serializeJsonOptions(handler);
 }
 
-void CGGarrison::initObj(CRandomGenerator &rand)
+void CGGarrison::initObj(vstd::RNG &rand)
 {
 	if(this->subID == MapObjectSubID::decode(this->ID, "antiMagic"))
 		addAntimagicGarrisonBonus();
@@ -1028,7 +1030,7 @@ void CGGarrison::addAntimagicGarrisonBonus()
 	this->addNewBonus(bonus);
 }
 
-void CGMagi::initObj(CRandomGenerator & rand)
+void CGMagi::initObj(vstd::RNG & rand)
 {
 	if (ID == Obj::EYE_OF_MAGI)
 		blockVisit = true;
@@ -1091,7 +1093,7 @@ bool CGBoat::isCoastVisitable() const
 	return true;
 }
 
-void CGSirens::initObj(CRandomGenerator & rand)
+void CGSirens::initObj(vstd::RNG & rand)
 {
 	blockVisit = true;
 }
@@ -1238,7 +1240,7 @@ void CGObelisk::onHeroVisit( const CGHeroInstance * h ) const
 
 }
 
-void CGObelisk::initObj(CRandomGenerator & rand)
+void CGObelisk::initObj(vstd::RNG & rand)
 {
 	cb->gameState()->map->obeliskCount++;
 }
@@ -1291,7 +1293,7 @@ void CGLighthouse::onHeroVisit( const CGHeroInstance * h ) const
 	}
 }
 
-void CGLighthouse::initObj(CRandomGenerator & rand)
+void CGLighthouse::initObj(vstd::RNG & rand)
 {
 	if(tempOwner.isValidPlayer())
 	{

--- a/lib/mapObjects/MiscObjects.h
+++ b/lib/mapObjects/MiscObjects.h
@@ -48,7 +48,7 @@ public:
 	MetaString message;
 
 	void onHeroVisit(const CGHeroInstance * h) const override;
-	void initObj(CRandomGenerator & rand) override;
+	void initObj(vstd::RNG & rand) override;
 
 	template <typename Handler> void serialize(Handler &h)
 	{
@@ -66,7 +66,7 @@ public:
 
 	bool removableUnits;
 
-	void initObj(CRandomGenerator &rand) override;
+	void initObj(vstd::RNG &rand) override;
 	bool passableFor(PlayerColor color) const override;
 	void onHeroVisit(const CGHeroInstance * h) const override;
 	void battleFinished(const CGHeroInstance *hero, const BattleResult &result) const override;
@@ -99,8 +99,8 @@ public:
 	std::vector<Component> getPopupComponents(PlayerColor player) const override;
 
 	void pick( const CGHeroInstance * h ) const;
-	void initObj(CRandomGenerator & rand) override;
-	void pickRandomObject(CRandomGenerator & rand) override;
+	void initObj(vstd::RNG & rand) override;
+	void pickRandomObject(vstd::RNG & rand) override;
 
 	void afterAddToMap(CMap * map) override;
 	BattleField getBattlefield() const override;
@@ -129,8 +129,8 @@ public:
 	MetaString message;
 
 	void onHeroVisit(const CGHeroInstance * h) const override;
-	void initObj(CRandomGenerator & rand) override;
-	void pickRandomObject(CRandomGenerator & rand) override;
+	void initObj(vstd::RNG & rand) override;
+	void pickRandomObject(vstd::RNG & rand) override;
 	void battleFinished(const CGHeroInstance *hero, const BattleResult &result) const override;
 	void blockingDialogAnswered(const CGHeroInstance *hero, ui32 answer) const override;
 	std::string getHoverText(PlayerColor player) const override;
@@ -166,8 +166,8 @@ private:
 	void blockingDialogAnswered(const CGHeroInstance *hero, ui32 answer) const override;
 
 	void flagMine(const PlayerColor & player) const;
-	void newTurn(CRandomGenerator & rand) const override;
-	void initObj(CRandomGenerator & rand) override;
+	void newTurn(vstd::RNG & rand) const override;
+	void initObj(vstd::RNG & rand) override;
 
 	std::string getObjectName() const override;
 	std::string getHoverText(PlayerColor player) const override;
@@ -248,7 +248,7 @@ class DLL_LINKAGE CGMonolith : public CGTeleport
 protected:
 	void onHeroVisit(const CGHeroInstance * h) const override;
 	void teleportDialogAnswered(const CGHeroInstance *hero, ui32 answer, TTeleportExitsList exits) const override;
-	void initObj(CRandomGenerator & rand) override;
+	void initObj(vstd::RNG & rand) override;
 
 public:
 	using CGTeleport::CGTeleport;
@@ -262,7 +262,7 @@ public:
 class DLL_LINKAGE CGSubterraneanGate : public CGMonolith
 {
 	void onHeroVisit(const CGHeroInstance * h) const override;
-	void initObj(CRandomGenerator & rand) override;
+	void initObj(vstd::RNG & rand) override;
 
 public:
 	using CGMonolith::CGMonolith;
@@ -297,7 +297,7 @@ public:
 
 	void onHeroVisit(const CGHeroInstance * h) const override;
 	std::string getHoverText(const CGHeroInstance * hero) const override;
-	void initObj(CRandomGenerator & rand) override;
+	void initObj(vstd::RNG & rand) override;
 
 	template <typename Handler> void serialize(Handler &h)
 	{
@@ -369,7 +369,7 @@ class DLL_LINKAGE CGMagi : public CGObjectInstance
 public:
 	using CGObjectInstance::CGObjectInstance;
 
-	void initObj(CRandomGenerator & rand) override;
+	void initObj(vstd::RNG & rand) override;
 	void onHeroVisit(const CGHeroInstance * h) const override;
 
 	template <typename Handler> void serialize(Handler &h)
@@ -391,7 +391,7 @@ public:
 	using CTeamVisited::CTeamVisited;
 
 	void onHeroVisit(const CGHeroInstance * h) const override;
-	void initObj(CRandomGenerator & rand) override;
+	void initObj(vstd::RNG & rand) override;
 	std::string getHoverText(PlayerColor player) const override;
 
 	template <typename Handler> void serialize(Handler &h)
@@ -408,7 +408,7 @@ public:
 	using CGObjectInstance::CGObjectInstance;
 
 	void onHeroVisit(const CGHeroInstance * h) const override;
-	void initObj(CRandomGenerator & rand) override;
+	void initObj(vstd::RNG & rand) override;
 
 	template <typename Handler> void serialize(Handler &h)
 	{

--- a/lib/mapping/CDrawRoadsOperation.cpp
+++ b/lib/mapping/CDrawRoadsOperation.cpp
@@ -12,10 +12,11 @@
 #include "CDrawRoadsOperation.h"
 #include "CMap.h"
 
-#include "../CRandomGenerator.h"
 #include "../RoadHandler.h"
 #include "../RiverHandler.h"
 #include "../VCMI_Lib.h"
+
+#include <vstd/RNG.h>
 
 VCMI_LIB_NAMESPACE_BEGIN
 
@@ -155,7 +156,7 @@ static bool ruleIsAny(const std::string & rule)
 #endif
 
 ///CDrawLinesOperation
-CDrawLinesOperation::CDrawLinesOperation(CMap * map, CTerrainSelection terrainSel, CRandomGenerator * gen):
+CDrawLinesOperation::CDrawLinesOperation(CMap * map, CTerrainSelection terrainSel, vstd::RNG * gen):
 	CMapOperation(map),
 	terrainSel(std::move(terrainSel)),
 	gen(gen)
@@ -163,14 +164,14 @@ CDrawLinesOperation::CDrawLinesOperation(CMap * map, CTerrainSelection terrainSe
 }
 
 ///CDrawRoadsOperation
-CDrawRoadsOperation::CDrawRoadsOperation(CMap * map, const CTerrainSelection & terrainSel, RoadId roadType, CRandomGenerator * gen):
+CDrawRoadsOperation::CDrawRoadsOperation(CMap * map, const CTerrainSelection & terrainSel, RoadId roadType, vstd::RNG * gen):
 	CDrawLinesOperation(map, terrainSel,gen),
 	roadType(roadType)
 {
 }
 
 ///CDrawRiversOperation
-CDrawRiversOperation::CDrawRiversOperation(CMap * map, const CTerrainSelection & terrainSel, RiverId riverType, CRandomGenerator * gen):
+CDrawRiversOperation::CDrawRiversOperation(CMap * map, const CTerrainSelection & terrainSel, RiverId riverType, vstd::RNG * gen):
 	CDrawLinesOperation(map, terrainSel, gen),
 	riverType(riverType)
 {

--- a/lib/mapping/CDrawRoadsOperation.h
+++ b/lib/mapping/CDrawRoadsOperation.h
@@ -41,7 +41,7 @@ protected:
 		int flip;
 	};
 
-	CDrawLinesOperation(CMap * map, CTerrainSelection terrainSel, CRandomGenerator * gen);
+	CDrawLinesOperation(CMap * map, CTerrainSelection terrainSel, vstd::RNG * gen);
 
 	virtual void executeTile(TerrainTile & tile) = 0;
 	virtual bool canApplyPattern(const CDrawLinesOperation::LinePattern & pattern) const = 0;
@@ -58,13 +58,13 @@ protected:
 	ValidationResult validateTile(const LinePattern & pattern, const int3 & pos);
 	
 	CTerrainSelection terrainSel;
-	CRandomGenerator * gen;
+	vstd::RNG * gen;
 };
 
 class CDrawRoadsOperation : public CDrawLinesOperation
 {
 public:
-	CDrawRoadsOperation(CMap * map, const CTerrainSelection & terrainSel, RoadId roadType, CRandomGenerator * gen);
+	CDrawRoadsOperation(CMap * map, const CTerrainSelection & terrainSel, RoadId roadType, vstd::RNG * gen);
 	std::string getLabel() const override;
 	
 protected:
@@ -81,7 +81,7 @@ private:
 class CDrawRiversOperation : public CDrawLinesOperation
 {
 public:
-	CDrawRiversOperation(CMap * map, const CTerrainSelection & terrainSel, RiverId roadType, CRandomGenerator * gen);
+	CDrawRiversOperation(CMap * map, const CTerrainSelection & terrainSel, RiverId roadType, vstd::RNG * gen);
 	std::string getLabel() const override;
 	
 protected:

--- a/lib/mapping/CMap.cpp
+++ b/lib/mapping/CMap.cpp
@@ -29,6 +29,8 @@
 #include "CMapOperation.h"
 #include "../serializer/JsonSerializeFormat.h"
 
+#include <vstd/RNG.h>
+
 VCMI_LIB_NAMESPACE_BEGIN
 
 void Rumor::serializeJson(JsonSerializeFormat & handler)

--- a/lib/mapping/CMapEditManager.cpp
+++ b/lib/mapping/CMapEditManager.cpp
@@ -115,8 +115,9 @@ void CMapUndoManager::setUndoCallback(std::function<void(bool, bool)> functor)
 CMapEditManager::CMapEditManager(CMap * map)
 	: map(map), terrainSel(map), objectSel(map)
 {
-
 }
+
+CMapEditManager::~CMapEditManager() = default;
 
 CMap * CMapEditManager::getMap()
 {

--- a/lib/mapping/CMapEditManager.cpp
+++ b/lib/mapping/CMapEditManager.cpp
@@ -15,6 +15,8 @@
 #include "CDrawRoadsOperation.h"
 #include "CMapOperation.h"
 
+#include <vstd/RNG.h>
+
 VCMI_LIB_NAMESPACE_BEGIN
 
 CMapUndoManager::CMapUndoManager() :
@@ -121,26 +123,26 @@ CMap * CMapEditManager::getMap()
 	return map;
 }
 
-void CMapEditManager::clearTerrain(CRandomGenerator * gen)
+void CMapEditManager::clearTerrain(vstd::RNG * gen)
 {
-	execute(std::make_unique<CClearTerrainOperation>(map, gen ? gen : &(this->gen)));
+	execute(std::make_unique<CClearTerrainOperation>(map, gen ? gen : this->gen.get()));
 }
 
-void CMapEditManager::drawTerrain(TerrainId terType, int decorationsPercentage, CRandomGenerator * gen)
+void CMapEditManager::drawTerrain(TerrainId terType, int decorationsPercentage, vstd::RNG * gen)
 {
-	execute(std::make_unique<CDrawTerrainOperation>(map, terrainSel, terType, decorationsPercentage, gen ? gen : &(this->gen)));
+	execute(std::make_unique<CDrawTerrainOperation>(map, terrainSel, terType, decorationsPercentage, gen ? gen : this->gen.get()));
 	terrainSel.clearSelection();
 }
 
-void CMapEditManager::drawRoad(RoadId roadType, CRandomGenerator* gen)
+void CMapEditManager::drawRoad(RoadId roadType, vstd::RNG* gen)
 {
-	execute(std::make_unique<CDrawRoadsOperation>(map, terrainSel, roadType, gen ? gen : &(this->gen)));
+	execute(std::make_unique<CDrawRoadsOperation>(map, terrainSel, roadType, gen ? gen : this->gen.get()));
 	terrainSel.clearSelection();
 }
 
-void CMapEditManager::drawRiver(RiverId riverType, CRandomGenerator* gen)
+void CMapEditManager::drawRiver(RiverId riverType, vstd::RNG* gen)
 {
-	execute(std::make_unique<CDrawRiversOperation>(map, terrainSel, riverType, gen ? gen : &(this->gen)));
+	execute(std::make_unique<CDrawRiversOperation>(map, terrainSel, riverType, gen ? gen : this->gen.get()));
 	terrainSel.clearSelection();
 }
 

--- a/lib/mapping/CMapEditManager.h
+++ b/lib/mapping/CMapEditManager.h
@@ -68,6 +68,7 @@ class DLL_LINKAGE CMapEditManager : boost::noncopyable
 {
 public:
 	CMapEditManager(CMap * map);
+	~CMapEditManager();
 	CMap * getMap();
 
 	/// Clears the terrain. The free level is filled with water and the underground level with rock.

--- a/lib/mapping/CMapEditManager.h
+++ b/lib/mapping/CMapEditManager.h
@@ -11,12 +11,16 @@
 #pragma once
 
 #include "../GameConstants.h"
-#include "../CRandomGenerator.h"
 #include "MapEditUtils.h"
 
 VCMI_LIB_NAMESPACE_BEGIN
 
 class CMapOperation;
+
+namespace vstd
+{
+class RNG;
+}
 
 /// The CMapUndoManager provides the functionality to save operations and undo/redo them.
 class DLL_LINKAGE CMapUndoManager : boost::noncopyable
@@ -67,16 +71,16 @@ public:
 	CMap * getMap();
 
 	/// Clears the terrain. The free level is filled with water and the underground level with rock.
-	void clearTerrain(CRandomGenerator * gen = nullptr);
+	void clearTerrain(vstd::RNG * gen = nullptr);
 
 	/// Draws terrain at the current terrain selection. The selection will be cleared automatically.
-	void drawTerrain(TerrainId terType, int decorationsPercentage, CRandomGenerator * gen = nullptr);
+	void drawTerrain(TerrainId terType, int decorationsPercentage, vstd::RNG * gen = nullptr);
 
 	/// Draws roads at the current terrain selection. The selection will be cleared automatically.
-	void drawRoad(RoadId roadType, CRandomGenerator * gen = nullptr);
+	void drawRoad(RoadId roadType, vstd::RNG * gen = nullptr);
 	
 	/// Draws rivers at the current terrain selection. The selection will be cleared automatically.
-	void drawRiver(RiverId riverType, CRandomGenerator * gen = nullptr);
+	void drawRiver(RiverId riverType, vstd::RNG * gen = nullptr);
 
 	void insertObject(CGObjectInstance * obj);
 	void insertObjects(std::set<CGObjectInstance *> & objects);
@@ -94,7 +98,7 @@ private:
 
 	CMap * map;
 	CMapUndoManager undoManager;
-	CRandomGenerator gen;
+	std::unique_ptr<vstd::RNG> gen;
 	CTerrainSelection terrainSel;
 	CObjectSelection objectSel;
 };

--- a/lib/mapping/CMapOperation.cpp
+++ b/lib/mapping/CMapOperation.cpp
@@ -12,11 +12,12 @@
 #include "CMapOperation.h"
 
 #include "../VCMI_Lib.h"
-#include "../CRandomGenerator.h"
 #include "../TerrainHandler.h"
 #include "../mapObjects/CGObjectInstance.h"
 #include "CMap.h"
 #include "MapEditUtils.h"
+
+#include <vstd/RNG.h>
 
 VCMI_LIB_NAMESPACE_BEGIN
 
@@ -87,7 +88,7 @@ void CComposedOperation::addOperation(std::unique_ptr<CMapOperation>&& operation
 	operations.push_back(std::move(operation));
 }
 
-CDrawTerrainOperation::CDrawTerrainOperation(CMap * map, CTerrainSelection terrainSel, TerrainId terType, int decorationsPercentage, CRandomGenerator * gen):
+CDrawTerrainOperation::CDrawTerrainOperation(CMap * map, CTerrainSelection terrainSel, TerrainId terType, int decorationsPercentage, vstd::RNG * gen):
 	CMapOperation(map),
 	terrainSel(std::move(terrainSel)),
 	terType(terType),
@@ -560,7 +561,7 @@ CDrawTerrainOperation::ValidationResult::ValidationResult(bool result, std::stri
 
 }
 
-CClearTerrainOperation::CClearTerrainOperation(CMap* map, CRandomGenerator* gen) : CComposedOperation(map)
+CClearTerrainOperation::CClearTerrainOperation(CMap* map, vstd::RNG* gen) : CComposedOperation(map)
 {
 	CTerrainSelection terrainSel(map);
 	terrainSel.selectRange(MapRect(int3(0, 0, 0), map->width, map->height));

--- a/lib/mapping/CMapOperation.h
+++ b/lib/mapping/CMapOperation.h
@@ -17,7 +17,11 @@ VCMI_LIB_NAMESPACE_BEGIN
 
 class CGObjectInstance;
 class CMap;
-class CRandomGenerator;
+
+namespace vstd
+{
+class RNG;
+}
 
 /// The abstract base class CMapOperation defines an operation that can be executed, undone and redone.
 class DLL_LINKAGE CMapOperation : public boost::noncopyable
@@ -63,7 +67,7 @@ private:
 class CDrawTerrainOperation : public CMapOperation
 {
 public:
-	CDrawTerrainOperation(CMap * map, CTerrainSelection terrainSel, TerrainId terType, int decorationsPercentage, CRandomGenerator * gen);
+	CDrawTerrainOperation(CMap * map, CTerrainSelection terrainSel, TerrainId terType, int decorationsPercentage, vstd::RNG * gen);
 
 	void execute() override;
 	void undo() override;
@@ -103,7 +107,7 @@ private:
 	CTerrainSelection terrainSel;
 	TerrainId terType;
 	int decorationsPercentage;
-	CRandomGenerator* gen;
+	vstd::RNG* gen;
 	std::set<int3> invalidatedTerViews;
 };
 
@@ -111,7 +115,7 @@ private:
 class CClearTerrainOperation : public CComposedOperation
 {
 public:
-	CClearTerrainOperation(CMap * map, CRandomGenerator * gen);
+	CClearTerrainOperation(CMap * map, vstd::RNG * gen);
 
 	std::string getLabel() const override;
 };

--- a/lib/mapping/ObstacleProxy.cpp
+++ b/lib/mapping/ObstacleProxy.cpp
@@ -18,6 +18,8 @@
 #include "../mapObjects/ObstacleSetHandler.h"
 #include "../VCMI_Lib.h"
 
+#include <vstd/RNG.h>
+
 VCMI_LIB_NAMESPACE_BEGIN
 
 void ObstacleProxy::collectPossibleObstacles(TerrainId terrain)
@@ -53,7 +55,7 @@ void ObstacleProxy::sortObstacles()
 	});
 }
 
-bool ObstacleProxy::prepareBiome(const ObstacleSetFilter & filter, CRandomGenerator & rand)
+bool ObstacleProxy::prepareBiome(const ObstacleSetFilter & filter, vstd::RNG & rand)
 {
 	possibleObstacles.clear();
 
@@ -228,7 +230,7 @@ bool ObstacleProxy::isProhibited(const rmg::Area& objArea) const
 	return false;
 };
 
-int ObstacleProxy::getWeightedObjects(const int3 & tile, CRandomGenerator & rand, IGameCallback * cb, std::list<rmg::Object> & allObjects, std::vector<std::pair<rmg::Object*, int3>> & weightedObjects)
+int ObstacleProxy::getWeightedObjects(const int3 & tile, vstd::RNG & rand, IGameCallback * cb, std::list<rmg::Object> & allObjects, std::vector<std::pair<rmg::Object*, int3>> & weightedObjects)
 {
 	int maxWeight = std::numeric_limits<int>::min();
 	for(auto & possibleObstacle : possibleObstacles)
@@ -309,7 +311,7 @@ int ObstacleProxy::getWeightedObjects(const int3 & tile, CRandomGenerator & rand
 	return maxWeight;
 }
 
-std::set<CGObjectInstance*> ObstacleProxy::createObstacles(CRandomGenerator & rand, IGameCallback * cb)
+std::set<CGObjectInstance*> ObstacleProxy::createObstacles(vstd::RNG & rand, IGameCallback * cb)
 {
 	//reverse order, since obstacles begin in bottom-right corner, while the map coordinates begin in top-left
 	auto blockedTiles = blockedArea.getTilesVector();
@@ -382,7 +384,7 @@ bool EditorObstaclePlacer::isInTheMap(const int3& tile)
 	return map->isInTheMap(tile);
 }
 
-std::set<CGObjectInstance*> EditorObstaclePlacer::placeObstacles(CRandomGenerator & rand)
+std::set<CGObjectInstance*> EditorObstaclePlacer::placeObstacles(vstd::RNG & rand)
 {
 	auto obstacles = createObstacles(rand, map->cb);
 	finalInsertion(map->getEditManager(), obstacles);

--- a/lib/mapping/ObstacleProxy.h
+++ b/lib/mapping/ObstacleProxy.h
@@ -18,7 +18,6 @@ VCMI_LIB_NAMESPACE_BEGIN
 class CMapEditManager;
 class CGObjectInstance;
 class ObjectTemplate;
-class CRandomGenerator;
 class IGameCallback;
 class ObstacleSetFilter;
 
@@ -30,7 +29,7 @@ public:
 	virtual ~ObstacleProxy() = default;
 
 	void collectPossibleObstacles(TerrainId terrain);
-	bool prepareBiome(const ObstacleSetFilter & filter, CRandomGenerator & rand);
+	bool prepareBiome(const ObstacleSetFilter & filter, vstd::RNG & rand);
 
 	void addBlockedTile(const int3 & tile);
 
@@ -44,7 +43,7 @@ public:
 
 	virtual void placeObject(rmg::Object & object, std::set<CGObjectInstance*> & instances);
 
-	virtual std::set<CGObjectInstance*> createObstacles(CRandomGenerator & rand, IGameCallback * cb);
+	virtual std::set<CGObjectInstance*> createObstacles(vstd::RNG & rand, IGameCallback * cb);
 
 	virtual bool isInTheMap(const int3& tile) = 0;
 	
@@ -53,7 +52,7 @@ public:
 	virtual void postProcess(const rmg::Object& object) {};
 
 protected:
-	int getWeightedObjects(const int3& tile, CRandomGenerator& rand, IGameCallback * cb, std::list<rmg::Object>& allObjects, std::vector<std::pair<rmg::Object*, int3>>& weightedObjects);
+	int getWeightedObjects(const int3& tile, vstd::RNG& rand, IGameCallback * cb, std::list<rmg::Object>& allObjects, std::vector<std::pair<rmg::Object*, int3>>& weightedObjects);
 	void sortObstacles();
 
 	rmg::Area blockedArea;
@@ -71,7 +70,7 @@ public:
 
 	bool isInTheMap(const int3& tile) override;
 
-	std::set<CGObjectInstance*> placeObstacles(CRandomGenerator& rand);
+	std::set<CGObjectInstance*> placeObstacles(vstd::RNG& rand);
 
 private:
 	CMap* map;

--- a/lib/networkPacks/NetPackVisitor.h
+++ b/lib/networkPacks/NetPackVisitor.h
@@ -36,6 +36,7 @@ public:
 	virtual void visitGamePause(GamePause & pack) {}
 	virtual void visitEntitiesChanged(EntitiesChanged & pack) {}
 	virtual void visitSetRewardableConfiguration(SetRewardableConfiguration & pack) {}
+	virtual void visitSetBankConfiguration(SetBankConfiguration & pack) {}
 	virtual void visitSetResources(SetResources & pack) {}
 	virtual void visitSetPrimSkill(SetPrimSkill & pack) {}
 	virtual void visitSetSecSkill(SetSecSkill & pack) {}

--- a/lib/networkPacks/NetPackVisitor.h
+++ b/lib/networkPacks/NetPackVisitor.h
@@ -13,6 +13,7 @@
 #include "PacksForClientBattle.h"
 #include "PacksForServer.h"
 #include "PacksForLobby.h"
+#include "SetRewardableConfiguration.h"
 #include "SetStackEffect.h"
 
 VCMI_LIB_NAMESPACE_BEGIN
@@ -34,6 +35,7 @@ public:
 	virtual void visitTurnTimeUpdate(TurnTimeUpdate & pack) {}
 	virtual void visitGamePause(GamePause & pack) {}
 	virtual void visitEntitiesChanged(EntitiesChanged & pack) {}
+	virtual void visitSetRewardableConfiguration(SetRewardableConfiguration & pack) {}
 	virtual void visitSetResources(SetResources & pack) {}
 	virtual void visitSetPrimSkill(SetPrimSkill & pack) {}
 	virtual void visitSetSecSkill(SetSecSkill & pack) {}

--- a/lib/networkPacks/NetPacksLib.cpp
+++ b/lib/networkPacks/NetPacksLib.cpp
@@ -33,6 +33,7 @@
 #include "StartInfo.h"
 #include "CPlayerState.h"
 #include "TerrainHandler.h"
+#include "mapObjects/CBank.h"
 #include "mapObjects/CGCreature.h"
 #include "mapObjects/CGMarket.h"
 #include "mapObjects/CGTownInstance.h"
@@ -127,6 +128,11 @@ void EntitiesChanged::visitTyped(ICPackVisitor & visitor)
 void SetRewardableConfiguration::visitTyped(ICPackVisitor & visitor)
 {
 	visitor.visitSetRewardableConfiguration(*this);
+}
+
+void SetBankConfiguration::visitTyped(ICPackVisitor & visitor)
+{
+	visitor.visitSetBankConfiguration(*this);
 }
 
 void SetResources::visitTyped(ICPackVisitor & visitor)
@@ -2446,6 +2452,16 @@ void SetRewardableConfiguration::applyGs(CGameState * gs)
 	assert(rewardablePtr);
 
 	rewardablePtr->configuration = configuration;
+}
+
+void SetBankConfiguration::applyGs(CGameState * gs)
+{
+	auto * objectPtr = gs->getObjInstance(objectID);
+	auto * bankPtr = dynamic_cast<CBank *>(objectPtr);
+
+	assert(bankPtr);
+
+	bankPtr->setConfig(configuration);
 }
 
 const CArtifactInstance * ArtSlotInfo::getArt() const

--- a/lib/networkPacks/NetPacksLib.cpp
+++ b/lib/networkPacks/NetPacksLib.cpp
@@ -1984,8 +1984,8 @@ void NewTurn::applyGs(CGameState *gs)
 	for(CGTownInstance* t : gs->map->towns)
 		t->built = 0;
 
-	if(gs->getDate(Date::DAY_OF_WEEK) == 1)
-		gs->updateRumor();
+	if(newRumor)
+		gs->currentRumor = *newRumor;
 }
 
 void SetObjectProperty::applyGs(CGameState * gs) const

--- a/lib/networkPacks/NetPacksLib.cpp
+++ b/lib/networkPacks/NetPacksLib.cpp
@@ -12,6 +12,7 @@
 #include "PacksForClient.h"
 #include "PacksForClientBattle.h"
 #include "PacksForServer.h"
+#include "SetRewardableConfiguration.h"
 #include "StackLocation.h"
 #include "PacksForLobby.h"
 #include "SetStackEffect.h"
@@ -121,6 +122,11 @@ void DaysWithoutTown::visitTyped(ICPackVisitor & visitor)
 void EntitiesChanged::visitTyped(ICPackVisitor & visitor)
 {
 	visitor.visitEntitiesChanged(*this);
+}
+
+void SetRewardableConfiguration::visitTyped(ICPackVisitor & visitor)
+{
+	visitor.visitSetRewardableConfiguration(*this);
 }
 
 void SetResources::visitTyped(ICPackVisitor & visitor)
@@ -2477,6 +2483,16 @@ void EntitiesChanged::applyGs(CGameState * gs)
 {
 	for(const auto & change : changes)
 		gs->updateEntity(change.metatype, change.entityIndex, change.data);
+}
+
+void SetRewardableConfiguration::applyGs(CGameState * gs)
+{
+	auto * objectPtr = gs->getObjInstance(objectID);
+	auto * rewardablePtr = dynamic_cast<CRewardableObject *>(objectPtr);
+
+	assert(rewardablePtr);
+
+	rewardablePtr->configuration = configuration;
 }
 
 const CArtifactInstance * ArtSlotInfo::getArt() const

--- a/lib/networkPacks/ObjProperty.h
+++ b/lib/networkPacks/ObjProperty.h
@@ -47,7 +47,6 @@ enum class ObjProperty : int8_t
 	BANK_CLEAR,
 
 	//object with reward
-	REWARD_RANDOMIZE,
 	REWARD_SELECT,
 	REWARD_CLEARED
 };

--- a/lib/networkPacks/ObjProperty.h
+++ b/lib/networkPacks/ObjProperty.h
@@ -43,7 +43,6 @@ enum class ObjProperty : int8_t
 
 	//creature-bank specific
 	BANK_DAYCOUNTER,
-	BANK_RESET,
 	BANK_CLEAR,
 
 	//object with reward

--- a/lib/networkPacks/PacksForClient.h
+++ b/lib/networkPacks/PacksForClient.h
@@ -22,6 +22,7 @@
 #include "../ResourceSet.h"
 #include "../TurnTimerInfo.h"
 #include "../gameState/EVictoryLossCheckResult.h"
+#include "../gameState/RumorState.h"
 #include "../gameState/QuestInfo.h"
 #include "../gameState/TavernSlot.h"
 #include "../int3.h"
@@ -1169,6 +1170,7 @@ struct DLL_LINKAGE NewTurn : public CPackForClient
 	ui32 day = 0;
 	ui8 specialWeek = 0; //weekType
 	CreatureID creatureid; //for creature weeks
+	std::optional<RumorState> newRumor; // only on new weeks
 
 	NewTurn() = default;
 
@@ -1180,6 +1182,7 @@ struct DLL_LINKAGE NewTurn : public CPackForClient
 		h & day;
 		h & specialWeek;
 		h & creatureid;
+		h & newRumor;
 	}
 };
 

--- a/lib/networkPacks/PacksForClient.h
+++ b/lib/networkPacks/PacksForClient.h
@@ -787,23 +787,15 @@ struct DLL_LINKAGE NewObject : public CPackForClient
 	void applyGs(CGameState * gs);
 
 	/// Object ID to create
-	MapObjectID ID;
-	/// Object secondary ID to create
-	MapObjectSubID subID;
-	/// Position of visitable tile of created object
-	int3 targetPos;
+	CGObjectInstance * newObject;
 	/// Which player initiated creation of this object
 	PlayerColor initiator;
-
-	ObjectInstanceID createdObjectID; //used locally, filled during applyGs
 
 	void visitTyped(ICPackVisitor & visitor) override;
 
 	template <typename Handler> void serialize(Handler & h)
 	{
-		h & ID;
-		subID.serializeIdentifier(h, ID);
-		h & targetPos;
+		h & newObject;
 		h & initiator;
 	}
 };

--- a/lib/networkPacks/SetRewardableConfiguration.h
+++ b/lib/networkPacks/SetRewardableConfiguration.h
@@ -12,6 +12,7 @@
 #include "NetPacksBase.h"
 
 #include "../rewardable/Configuration.h"
+#include "../mapObjectConstructors/CBankInstanceConstructor.h"
 
 VCMI_LIB_NAMESPACE_BEGIN
 
@@ -28,6 +29,21 @@ struct DLL_LINKAGE SetRewardableConfiguration : public CPackForClient
 	{
 		h & objectID;
 		h & buildingID;
+		h & configuration;
+	}
+};
+
+struct DLL_LINKAGE SetBankConfiguration : public CPackForClient
+{
+	void applyGs(CGameState * gs);
+	void visitTyped(ICPackVisitor & visitor) override;
+
+	ObjectInstanceID objectID;
+	BankConfig configuration;
+
+	template <typename Handler> void serialize(Handler & h)
+	{
+		h & objectID;
 		h & configuration;
 	}
 };

--- a/lib/networkPacks/SetRewardableConfiguration.h
+++ b/lib/networkPacks/SetRewardableConfiguration.h
@@ -1,0 +1,35 @@
+/*
+ * SetRewardableConfiguration.h, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
+#pragma once
+
+#include "NetPacksBase.h"
+
+#include "../rewardable/Configuration.h"
+
+VCMI_LIB_NAMESPACE_BEGIN
+
+struct DLL_LINKAGE SetRewardableConfiguration : public CPackForClient
+{
+	void applyGs(CGameState * gs);
+	void visitTyped(ICPackVisitor & visitor) override;
+
+	ObjectInstanceID objectID;
+	BuildingID buildingID;
+	Rewardable::Configuration configuration;
+
+	template <typename Handler> void serialize(Handler & h)
+	{
+		h & objectID;
+		h & buildingID;
+		h & configuration;
+	}
+};
+
+VCMI_LIB_NAMESPACE_END

--- a/lib/registerTypes/RegisterTypesClientPacks.h
+++ b/lib/registerTypes/RegisterTypesClientPacks.h
@@ -122,6 +122,7 @@ void registerTypesClientPacks(Serializer &s)
 	s.template registerType<CGarrisonOperationPack, BulkSmartRebalanceStacks>();
 
 	s.template registerType<SetRewardableConfiguration, CPackForClient>();
+	s.template registerType<SetBankConfiguration, CPackForClient>();
 }
 
 VCMI_LIB_NAMESPACE_END

--- a/lib/registerTypes/RegisterTypesClientPacks.h
+++ b/lib/registerTypes/RegisterTypesClientPacks.h
@@ -12,6 +12,7 @@
 #include "../networkPacks/PacksForClient.h"
 #include "../networkPacks/PacksForClientBattle.h"
 #include "../networkPacks/SetStackEffect.h"
+#include "../networkPacks/SetRewardableConfiguration.h"
 
 VCMI_LIB_NAMESPACE_BEGIN
 
@@ -119,6 +120,8 @@ void registerTypesClientPacks(Serializer &s)
 	s.template registerType<CPackForClient, PlayerMessageClient>();
 	s.template registerType<CGarrisonOperationPack, BulkRebalanceStacks>();
 	s.template registerType<CGarrisonOperationPack, BulkSmartRebalanceStacks>();
+
+	s.template registerType<SetRewardableConfiguration, CPackForClient>();
 }
 
 VCMI_LIB_NAMESPACE_END

--- a/lib/registerTypes/RegisterTypesLobbyPacks.h
+++ b/lib/registerTypes/RegisterTypesLobbyPacks.h
@@ -17,7 +17,6 @@
 #include "../gameState/TavernHeroesPool.h"
 #include "../gameState/CGameStateCampaign.h"
 #include "../mapping/CMap.h"
-#include "../CRandomGenerator.h"
 #include "../TerrainHandler.h"
 #include "../RiverHandler.h"
 #include "../RoadHandler.h"

--- a/lib/registerTypes/RegisterTypesLobbyPacks.h
+++ b/lib/registerTypes/RegisterTypesLobbyPacks.h
@@ -17,6 +17,7 @@
 #include "../gameState/TavernHeroesPool.h"
 #include "../gameState/CGameStateCampaign.h"
 #include "../mapping/CMap.h"
+#include "../CRandomGenerator.h"
 #include "../TerrainHandler.h"
 #include "../RiverHandler.h"
 #include "../RoadHandler.h"

--- a/lib/rewardable/Info.cpp
+++ b/lib/rewardable/Info.cpp
@@ -20,7 +20,8 @@
 #include "../json/JsonRandom.h"
 #include "../mapObjects/IObjectInterface.h"
 #include "../modding/IdentifierStorage.h"
-#include "../CRandomGenerator.h"
+
+#include <vstd/RNG.h>
 
 VCMI_LIB_NAMESPACE_BEGIN
 
@@ -106,7 +107,7 @@ void Rewardable::Info::init(const JsonNode & objectConfig, const std::string & o
 	loadString(parameters["onEmptyMessage"], TextIdentifier(objectName, "onEmpty"));
 }
 
-Rewardable::LimitersList Rewardable::Info::configureSublimiters(Rewardable::Configuration & object, CRandomGenerator & rng, IGameCallback * cb, const JsonNode & source) const
+Rewardable::LimitersList Rewardable::Info::configureSublimiters(Rewardable::Configuration & object, vstd::RNG & rng, IGameCallback * cb, const JsonNode & source) const
 {
 	Rewardable::LimitersList result;
 	for (const auto & input : source.Vector())
@@ -121,7 +122,7 @@ Rewardable::LimitersList Rewardable::Info::configureSublimiters(Rewardable::Conf
 	return result;
 }
 
-void Rewardable::Info::configureLimiter(Rewardable::Configuration & object, CRandomGenerator & rng, IGameCallback * cb, Rewardable::Limiter & limiter, const JsonNode & source) const
+void Rewardable::Info::configureLimiter(Rewardable::Configuration & object, vstd::RNG & rng, IGameCallback * cb, Rewardable::Limiter & limiter, const JsonNode & source) const
 {
 	auto const & variables = object.variables.values;
 	JsonRandom randomizer(cb);
@@ -153,7 +154,7 @@ void Rewardable::Info::configureLimiter(Rewardable::Configuration & object, CRan
 	limiter.noneOf = configureSublimiters(object, rng, cb, source["noneOf"] );
 }
 
-void Rewardable::Info::configureReward(Rewardable::Configuration & object, CRandomGenerator & rng, IGameCallback * cb, Rewardable::Reward & reward, const JsonNode & source) const
+void Rewardable::Info::configureReward(Rewardable::Configuration & object, vstd::RNG & rng, IGameCallback * cb, Rewardable::Reward & reward, const JsonNode & source) const
 {
 	auto const & variables = object.variables.values;
 	JsonRandom randomizer(cb);
@@ -210,14 +211,14 @@ void Rewardable::Info::configureReward(Rewardable::Configuration & object, CRand
 	}
 }
 
-void Rewardable::Info::configureResetInfo(Rewardable::Configuration & object, CRandomGenerator & rng, Rewardable::ResetInfo & resetParameters, const JsonNode & source) const
+void Rewardable::Info::configureResetInfo(Rewardable::Configuration & object, vstd::RNG & rng, Rewardable::ResetInfo & resetParameters, const JsonNode & source) const
 {
 	resetParameters.period   = static_cast<ui32>(source["period"].Float());
 	resetParameters.visitors = source["visitors"].Bool();
 	resetParameters.rewards  = source["rewards"].Bool();
 }
 
-void Rewardable::Info::configureVariables(Rewardable::Configuration & object, CRandomGenerator & rng, IGameCallback * cb, const JsonNode & source) const
+void Rewardable::Info::configureVariables(Rewardable::Configuration & object, vstd::RNG & rng, IGameCallback * cb, const JsonNode & source) const
 {
 	JsonRandom randomizer(cb);
 
@@ -277,7 +278,7 @@ void Rewardable::Info::replaceTextPlaceholders(MetaString & target, const Variab
 
 void Rewardable::Info::configureRewards(
 		Rewardable::Configuration & object,
-		CRandomGenerator & rng,
+		vstd::RNG & rng,
 		IGameCallback * cb,
 		const JsonNode & source,
 		Rewardable::EEventType event,
@@ -335,7 +336,7 @@ void Rewardable::Info::configureRewards(
 	}
 }
 
-void Rewardable::Info::configureObject(Rewardable::Configuration & object, CRandomGenerator & rng, IGameCallback * cb) const
+void Rewardable::Info::configureObject(Rewardable::Configuration & object, vstd::RNG & rng, IGameCallback * cb) const
 {
 	object.info.clear();
 

--- a/lib/rewardable/Info.cpp
+++ b/lib/rewardable/Info.cpp
@@ -298,7 +298,7 @@ void Rewardable::Info::configureRewards(
 			{
 				const JsonNode & preset = object.getPresetVariable("dice", diceID);
 				if (preset.isNull())
-					object.initVariable("dice", diceID, rng.getIntRange(0, 99)());
+					object.initVariable("dice", diceID, rng.nextInt(0, 99));
 				else
 					object.initVariable("dice", diceID, preset.Integer());
 

--- a/lib/rewardable/Info.h
+++ b/lib/rewardable/Info.h
@@ -15,13 +15,16 @@
 
 VCMI_LIB_NAMESPACE_BEGIN
 
-class CRandomGenerator;
+namespace vstd
+{
+class RNG;
+}
+
 class MetaString;
 class IGameCallback;
 
 namespace Rewardable
 {
-
 struct Limiter;
 using LimitersList = std::vector<std::shared_ptr<Rewardable::Limiter>>;
 struct Reward;
@@ -39,14 +42,14 @@ class DLL_LINKAGE Info : public IObjectInfo
 	void replaceTextPlaceholders(MetaString & target, const Variables & variables) const;
 	void replaceTextPlaceholders(MetaString & target, const Variables & variables, const VisitInfo & info) const;
 
-	void configureVariables(Rewardable::Configuration & object, CRandomGenerator & rng, IGameCallback * cb, const JsonNode & source) const;
-	void configureRewards(Rewardable::Configuration & object, CRandomGenerator & rng, IGameCallback * cb, const JsonNode & source, Rewardable::EEventType mode, const std::string & textPrefix) const;
+	void configureVariables(Rewardable::Configuration & object, vstd::RNG & rng, IGameCallback * cb, const JsonNode & source) const;
+	void configureRewards(Rewardable::Configuration & object, vstd::RNG & rng, IGameCallback * cb, const JsonNode & source, Rewardable::EEventType mode, const std::string & textPrefix) const;
 
-	void configureLimiter(Rewardable::Configuration & object, CRandomGenerator & rng, IGameCallback * cb, Rewardable::Limiter & limiter, const JsonNode & source) const;
-	Rewardable::LimitersList configureSublimiters(Rewardable::Configuration & object, CRandomGenerator & rng, IGameCallback * cb, const JsonNode & source) const;
+	void configureLimiter(Rewardable::Configuration & object, vstd::RNG & rng, IGameCallback * cb, Rewardable::Limiter & limiter, const JsonNode & source) const;
+	Rewardable::LimitersList configureSublimiters(Rewardable::Configuration & object, vstd::RNG & rng, IGameCallback * cb, const JsonNode & source) const;
 
-	void configureReward(Rewardable::Configuration & object, CRandomGenerator & rng, IGameCallback * cb, Rewardable::Reward & info, const JsonNode & source) const;
-	void configureResetInfo(Rewardable::Configuration & object, CRandomGenerator & rng, Rewardable::ResetInfo & info, const JsonNode & source) const;
+	void configureReward(Rewardable::Configuration & object, vstd::RNG & rng, IGameCallback * cb, Rewardable::Reward & info, const JsonNode & source) const;
+	void configureResetInfo(Rewardable::Configuration & object, vstd::RNG & rng, Rewardable::ResetInfo & info, const JsonNode & source) const;
 public:
 	const JsonNode & getParameters() const;
 
@@ -65,7 +68,7 @@ public:
 
 	bool givesBonuses() const override;
 
-	void configureObject(Rewardable::Configuration & object, CRandomGenerator & rng, IGameCallback * cb) const;
+	void configureObject(Rewardable::Configuration & object, vstd::RNG & rng, IGameCallback * cb) const;
 
 	void init(const JsonNode & objectConfig, const std::string & objectTextID);
 

--- a/lib/rmg/CMapGenOptions.cpp
+++ b/lib/rmg/CMapGenOptions.cpp
@@ -14,10 +14,11 @@
 #include "../mapping/CMapHeader.h"
 #include "CRmgTemplateStorage.h"
 #include "CRmgTemplate.h"
-#include "CRandomGenerator.h"
 #include "../VCMI_Lib.h"
 #include "../CTownHandler.h"
 #include "serializer/JsonSerializeFormat.h"
+
+#include <vstd/RNG.h>
 
 VCMI_LIB_NAMESPACE_BEGIN
 
@@ -487,7 +488,7 @@ void CMapGenOptions::setPlayerTeam(const PlayerColor & color, const TeamID & tea
 	customizedPlayers = true;
 }
 
-void CMapGenOptions::finalize(CRandomGenerator & rand)
+void CMapGenOptions::finalize(vstd::RNG & rand)
 {
 	logGlobal->info("RMG map: %dx%d, %s underground", getWidth(), getHeight(), getHasTwoLevels() ? "WITH" : "NO");
 	logGlobal->info("RMG settings: players %d, teams %d, computer players %d, computer teams %d, water %d, monsters %d",
@@ -690,8 +691,7 @@ bool CMapGenOptions::checkOptions() const
 	}
 	else
 	{
-		CRandomGenerator gen;
-		return getPossibleTemplate(gen) != nullptr;
+		return !getPossibleTemplates().empty();
 	}
 }
 
@@ -750,7 +750,7 @@ std::vector<const CRmgTemplate *> CMapGenOptions::getPossibleTemplates() const
 	return templates;
 }
 
-const CRmgTemplate * CMapGenOptions::getPossibleTemplate(CRandomGenerator & rand) const
+const CRmgTemplate * CMapGenOptions::getPossibleTemplate(vstd::RNG & rand) const
 {
 	auto templates = getPossibleTemplates();
 

--- a/lib/rmg/CMapGenOptions.h
+++ b/lib/rmg/CMapGenOptions.h
@@ -16,7 +16,10 @@
 
 VCMI_LIB_NAMESPACE_BEGIN
 
-class CRandomGenerator;
+namespace vstd
+{
+class RNG;
+}
 
 enum class EPlayerType
 {
@@ -148,7 +151,7 @@ public:
 	/// Finalizes the options. All random sizes for various properties will be overwritten by numbers from
 	/// a random number generator by keeping the options in a valid state. Check options should return true, otherwise
 	/// this function fails.
-	void finalize(CRandomGenerator & rand);
+	void finalize(vstd::RNG & rand);
 
 	/// Returns false if there is no template available which fits to the currently selected options.
 	bool checkOptions() const;
@@ -166,7 +169,7 @@ private:
 	PlayerColor getNextPlayerColor() const;
 	void updateCompOnlyPlayers();
 	void updatePlayers();
-	const CRmgTemplate * getPossibleTemplate(CRandomGenerator & rand) const;
+	const CRmgTemplate * getPossibleTemplate(vstd::RNG & rand) const;
 
 	si32 width;
 	si32 height;

--- a/lib/rmg/CMapGenerator.h
+++ b/lib/rmg/CMapGenerator.h
@@ -11,7 +11,6 @@
 #pragma once
 
 #include "../GameConstants.h"
-#include "../CRandomGenerator.h"
 #include "CMapGenOptions.h"
 #include "../int3.h"
 #include "CRmgTemplate.h"
@@ -79,7 +78,7 @@ public:
 	int getRandomSeed() const;
 	
 private:
-	CRandomGenerator rand;
+	std::unique_ptr<vstd::RNG> rand;
 	int randomSeed;
 	CMapGenOptions& mapGenOptions;
 	Config config;

--- a/lib/rmg/CZonePlacer.cpp
+++ b/lib/rmg/CZonePlacer.cpp
@@ -11,7 +11,6 @@
 #include "StdInc.h"
 #include "CZonePlacer.h"
 
-#include "../CRandomGenerator.h"
 #include "../CTownHandler.h"
 #include "../TerrainHandler.h"
 #include "../mapping/CMap.h"
@@ -23,11 +22,11 @@
 #include "Functions.h"
 #include "PenroseTiling.h"
 
+#include <vstd/RNG.h>
+
 VCMI_LIB_NAMESPACE_BEGIN
 
 //#define ZONE_PLACEMENT_LOG true
-
-class CRandomGenerator;
 
 CZonePlacer::CZonePlacer(RmgMap & map)
 	: width(0), height(0), mapSize(0),
@@ -97,7 +96,7 @@ void CZonePlacer::findPathsBetweenZones()
 	}
 }
 
-void CZonePlacer::placeOnGrid(CRandomGenerator* rand)
+void CZonePlacer::placeOnGrid(vstd::RNG* rand)
 {
 	auto zones = map.getZones();
 	assert(zones.size());
@@ -118,7 +117,7 @@ void CZonePlacer::placeOnGrid(CRandomGenerator* rand)
 
 	auto getRandomEdge = [rand, gridSize](size_t& x, size_t& y)
 	{
-		switch (rand->nextInt() % 4)
+		switch (rand->nextInt(0, 3) % 4)
 		{
 		case 0:
 			x = 0;
@@ -150,7 +149,7 @@ void CZonePlacer::placeOnGrid(CRandomGenerator* rand)
 			else
 			{
 				//Random corner
-				if (rand->nextInt() % 2)
+				if (rand->nextInt(0, 1) == 1)
 				{
 					x = 0;
 				}
@@ -158,7 +157,7 @@ void CZonePlacer::placeOnGrid(CRandomGenerator* rand)
 				{
 					x = gridSize - 1;
 				}
-				if (rand->nextInt() % 2)
+				if (rand->nextInt(0, 1) == 1)
 				{
 					y = 0;
 				}
@@ -176,8 +175,8 @@ void CZonePlacer::placeOnGrid(CRandomGenerator* rand)
 			else
 			{
 				//One of 4 squares in the middle
-				x = (gridSize / 2) - 1 + rand->nextInt() % 2;
-				y = (gridSize / 2) - 1 + rand->nextInt() % 2;
+				x = (gridSize / 2) - 1 + rand->nextInt(0, 1);
+				y = (gridSize / 2) - 1 + rand->nextInt(0, 1);
 			}
 			break;
 		case ETemplateZoneType::JUNCTION:
@@ -308,7 +307,7 @@ float CZonePlacer::scaleForceBetweenZones(const std::shared_ptr<Zone> zoneA, con
 	}
 }
 
-void CZonePlacer::placeZones(CRandomGenerator * rand)
+void CZonePlacer::placeZones(vstd::RNG * rand)
 {
 	logGlobal->info("Starting zone placement");
 
@@ -432,7 +431,7 @@ void CZonePlacer::placeZones(CRandomGenerator * rand)
 	}
 }
 
-void CZonePlacer::prepareZones(TZoneMap &zones, TZoneVector &zonesVector, const bool underground, CRandomGenerator * rand)
+void CZonePlacer::prepareZones(TZoneMap &zones, TZoneVector &zonesVector, const bool underground, vstd::RNG * rand)
 {
 	std::vector<float> totalSize = { 0, 0 }; //make sure that sum of zone sizes on surface and uderground match size of the map
 
@@ -824,7 +823,7 @@ float CZonePlacer::metric (const int3 &A, const int3 &B) const
 
 }
 
-void CZonePlacer::assignZones(CRandomGenerator * rand)
+void CZonePlacer::assignZones(vstd::RNG * rand)
 {
 	logGlobal->info("Starting zone colouring");
 

--- a/lib/rmg/CZonePlacer.h
+++ b/lib/rmg/CZonePlacer.h
@@ -16,9 +16,13 @@
 
 VCMI_LIB_NAMESPACE_BEGIN
 
+namespace vstd
+{
+class RNG;
+}
+
 class CZoneGraph;
 class CMap;
-class CRandomGenerator;
 class RmgMap;
 class Zone;
 
@@ -37,16 +41,16 @@ public:
 	float getDistance(float distance) const; //additional scaling without 0 division
 	~CZonePlacer() = default;
 
-	void placeZones(CRandomGenerator * rand);
+	void placeZones(vstd::RNG * rand);
 	void findPathsBetweenZones();
-	void placeOnGrid(CRandomGenerator* rand);
+	void placeOnGrid(vstd::RNG* rand);
 	float scaleForceBetweenZones(const std::shared_ptr<Zone> zoneA, const std::shared_ptr<Zone> zoneB) const;
-	void assignZones(CRandomGenerator * rand);
+	void assignZones(vstd::RNG * rand);
 
 	const TDistanceMap & getDistanceMap();
 	
 private:
-	void prepareZones(TZoneMap &zones, TZoneVector &zonesVector, const bool underground, CRandomGenerator * rand);
+	void prepareZones(TZoneMap &zones, TZoneVector &zonesVector, const bool underground, vstd::RNG * rand);
 	void attractConnectedZones(TZoneMap & zones, TForceVector & forces, TDistanceVector & distances) const;
 	void separateOverlappingZones(TZoneMap &zones, TForceVector &forces, TDistanceVector &overlaps);
 	void moveOneZone(TZoneMap & zones, TForceVector & totalForces, TDistanceVector & distances, TDistanceVector & overlaps);

--- a/lib/rmg/Functions.cpp
+++ b/lib/rmg/Functions.cpp
@@ -21,6 +21,8 @@
 #include "../mapObjectConstructors/CObjectClassesHandler.h"
 #include "../VCMI_Lib.h"
 
+#include <vstd/RNG.h>
+
 VCMI_LIB_NAMESPACE_BEGIN
 
 rmg::Tileset collectDistantTiles(const Zone& zone, int distance)
@@ -34,7 +36,7 @@ rmg::Tileset collectDistantTiles(const Zone& zone, int distance)
 	return subarea.getTiles();
 }
 
-int chooseRandomAppearance(CRandomGenerator & generator, si32 ObjID, TerrainId terrain)
+int chooseRandomAppearance(vstd::RNG & generator, si32 ObjID, TerrainId terrain)
 {
 	auto factories = VLC->objtypeh->knownSubObjects(ObjID);
 	vstd::erase_if(factories, [ObjID, &terrain](si32 f)

--- a/lib/rmg/Functions.h
+++ b/lib/rmg/Functions.h
@@ -19,7 +19,6 @@ class RmgMap;
 class ObjectManager;
 class ObjectTemplate;
 class CMapGenerator;
-class CRandomGenerator;
 
 class rmgException : public std::exception
 {
@@ -37,7 +36,7 @@ public:
 
 rmg::Tileset collectDistantTiles(const Zone & zone, int distance);
 
-int chooseRandomAppearance(CRandomGenerator & generator, si32 ObjID, TerrainId terrain);
+int chooseRandomAppearance(vstd::RNG & generator, si32 ObjID, TerrainId terrain);
 
 
 VCMI_LIB_NAMESPACE_END

--- a/lib/rmg/PenroseTiling.cpp
+++ b/lib/rmg/PenroseTiling.cpp
@@ -13,6 +13,8 @@
 #include "StdInc.h"
 #include "PenroseTiling.h"
 
+#include <vstd/RNG.h>
+
 VCMI_LIB_NAMESPACE_BEGIN
 
 
@@ -143,7 +145,7 @@ void PenroseTiling::split(Triangle& p, std::vector<Point2D>& points,
 	return;
 }
 
-std::set<Point2D> PenroseTiling::generatePenroseTiling(size_t numZones, CRandomGenerator * rand)
+std::set<Point2D> PenroseTiling::generatePenroseTiling(size_t numZones, vstd::RNG * rand)
 {
 	float scale = 173.2f / (numZones * 1.5f + 20);
 	float polyAngle = (2 * PI_CONSTANT) / POLY;

--- a/lib/rmg/PenroseTiling.h
+++ b/lib/rmg/PenroseTiling.h
@@ -11,11 +11,15 @@
 #pragma once
 
 #include "../GameConstants.h"
-#include "../CRandomGenerator.h"
 #include <boost/geometry.hpp>
 #include <boost/geometry/geometries/point_xy.hpp>
 
 VCMI_LIB_NAMESPACE_BEGIN
+
+namespace vstd
+{
+class RNG;
+}
 
 using namespace boost::geometry;
 typedef std::array<uint32_t, 3> TIndices;
@@ -66,7 +70,7 @@ public:
 	
 	const bool P2 = false; // Tiling type
 
-	std::set<Point2D> generatePenroseTiling(size_t numZones, CRandomGenerator * rand);
+	std::set<Point2D> generatePenroseTiling(size_t numZones, vstd::RNG * rand);
 
 private:
 	void split(Triangle& p, std::vector<Point2D>& points, std::array<std::vector<uint32_t>, 5>& indices, uint32_t depth); 

--- a/lib/rmg/RmgMap.cpp
+++ b/lib/rmg/RmgMap.cpp
@@ -84,7 +84,7 @@ void RmgMap::foreachDiagonalNeighbour(const int3 & pos, const std::function<void
 	}
 }
 
-void RmgMap::initTiles(CMapGenerator & generator, CRandomGenerator & rand)
+void RmgMap::initTiles(CMapGenerator & generator, vstd::RNG & rand)
 {
 	mapInstance->initTerrain();
 	

--- a/lib/rmg/RmgMap.h
+++ b/lib/rmg/RmgMap.h
@@ -17,13 +17,17 @@ VCMI_LIB_NAMESPACE_BEGIN
 
 class CMap;
 class CMapEditManager;
-class CRandomGenerator;
 class TileInfo;
 class CMapGenOptions;
 class Zone;
 class CMapGenerator;
 class MapProxy;
 class playerInfo;
+
+namespace vstd
+{
+class RNG;
+}
 
 class RmgMap
 {
@@ -79,7 +83,7 @@ public:
 	void registerZone(FactionID faction);
 	ui32 getZoneCount(FactionID faction);
 	ui32 getTotalZoneCount() const;
-	void initTiles(CMapGenerator & generator, CRandomGenerator & rand);
+	void initTiles(CMapGenerator & generator, vstd::RNG & rand);
 	void addModificators();
 
 	bool isAllowedSpell(const SpellID & sid) const;

--- a/lib/rmg/RmgObject.cpp
+++ b/lib/rmg/RmgObject.cpp
@@ -21,6 +21,8 @@
 #include "Functions.h"
 #include "../TerrainHandler.h"
 
+#include <vstd/RNG.h>
+
 VCMI_LIB_NAMESPACE_BEGIN
 
 using namespace rmg;
@@ -111,7 +113,7 @@ void Object::Instance::setPositionRaw(const int3 & position)
 	dObject.pos = dPosition + dParent.getPosition();
 }
 
-void Object::Instance::setAnyTemplate(CRandomGenerator & rng)
+void Object::Instance::setAnyTemplate(vstd::RNG & rng)
 {
 	auto templates = dObject.getObjectHandler()->getTemplates();
 	if(templates.empty())
@@ -122,7 +124,7 @@ void Object::Instance::setAnyTemplate(CRandomGenerator & rng)
 	setPosition(getPosition(false));
 }
 
-void Object::Instance::setTemplate(TerrainId terrain, CRandomGenerator & rng)
+void Object::Instance::setTemplate(TerrainId terrain, vstd::RNG & rng)
 {
 	auto templates = dObject.getObjectHandler()->getMostSpecificTemplates(terrain);
 
@@ -366,7 +368,7 @@ void Object::setPosition(const int3 & position)
 		i.setPositionRaw(i.getPosition());
 }
 
-void Object::setTemplate(const TerrainId & terrain, CRandomGenerator & rng)
+void Object::setTemplate(const TerrainId & terrain, vstd::RNG & rng)
 {
 	for(auto& i : dInstances)
 		i.setTemplate(terrain, rng);
@@ -474,7 +476,7 @@ rmg::Area Object::Instance::getBorderAbove() const
 	return borderAbove;
 }
 
-void Object::Instance::finalize(RmgMap & map, CRandomGenerator & rng)
+void Object::Instance::finalize(RmgMap & map, vstd::RNG & rng)
 {
 	if(!map.isOnMap(getPosition(true)))
 		throw rmgException(boost::str(boost::format("Position of object %d at %s is outside the map") % dObject.id % getPosition(true).toString()));
@@ -511,7 +513,7 @@ void Object::Instance::finalize(RmgMap & map, CRandomGenerator & rng)
 	map.getMapProxy()->insertObject(&dObject);
 }
 
-void Object::finalize(RmgMap & map, CRandomGenerator & rng)
+void Object::finalize(RmgMap & map, vstd::RNG & rng)
 {
 	if(dInstances.empty())
 		throw rmgException("Cannot finalize object without instances");

--- a/lib/rmg/RmgObject.h
+++ b/lib/rmg/RmgObject.h
@@ -16,8 +16,12 @@
 
 VCMI_LIB_NAMESPACE_BEGIN
 
+namespace vstd
+{
+class RNG;
+}
+
 class CGObjectInstance;
-class CRandomGenerator;
 class RmgMap;
 
 namespace rmg {
@@ -39,8 +43,8 @@ public:
 		bool isRemovable() const;
 		const Area & getAccessibleArea() const;
 		Area getBorderAbove() const;
-		void setTemplate(TerrainId terrain, CRandomGenerator &); //cache invalidation
-		void setAnyTemplate(CRandomGenerator &); //cache invalidation
+		void setTemplate(TerrainId terrain, vstd::RNG &); //cache invalidation
+		void setAnyTemplate(vstd::RNG &); //cache invalidation
 		
 		int3 getTopTile() const;
 		int3 getPosition(bool isAbsolute = false) const;
@@ -49,7 +53,7 @@ public:
 		const CGObjectInstance & object() const;
 		CGObjectInstance & object();
 		
-		void finalize(RmgMap & map, CRandomGenerator &); //cache invalidation
+		void finalize(RmgMap & map, vstd::RNG &); //cache invalidation
 		void clear();
 		
 		std::function<void(CGObjectInstance *)> onCleared;
@@ -83,7 +87,7 @@ public:
 	
 	const int3 & getPosition() const;
 	void setPosition(const int3 & position);
-	void setTemplate(const TerrainId & terrain, CRandomGenerator &);
+	void setTemplate(const TerrainId & terrain, vstd::RNG &);
 	
 	const Area & getArea() const;  //lazy cache invalidation
 	const int3 getVisibleTop() const;
@@ -94,7 +98,7 @@ public:
 	void setValue(uint32_t value);
 	uint32_t getValue() const;
 	
-	void finalize(RmgMap & map, CRandomGenerator &);
+	void finalize(RmgMap & map, vstd::RNG &);
 	void clearCachedArea() const;
 	void clear();
 	

--- a/lib/rmg/Zone.cpp
+++ b/lib/rmg/Zone.cpp
@@ -17,6 +17,10 @@
 #include "RmgPath.h"
 #include "modificators/ObjectManager.h"
 
+#include "../CRandomGenerator.h"
+
+#include <vstd/RNG.h>
+
 VCMI_LIB_NAMESPACE_BEGIN
 
 const std::function<bool(const int3 &)> AREA_NO_FILTER = [](const int3 & t)
@@ -24,15 +28,17 @@ const std::function<bool(const int3 &)> AREA_NO_FILTER = [](const int3 & t)
 	return true;
 };
 
-Zone::Zone(RmgMap & map, CMapGenerator & generator, CRandomGenerator & r)
+Zone::Zone(RmgMap & map, CMapGenerator & generator, vstd::RNG & r)
 	: finished(false)
 	, townType(ETownType::NEUTRAL)
 	, terrainType(ETerrainId::GRASS)
 	, map(map)
+	, rand(std::make_unique<CRandomGenerator>(r.nextInt()))
 	, generator(generator)
 {
-	rand.setSeed(r.nextInt());
 }
+
+Zone::~Zone() = default;
 
 bool Zone::isUnderground() const
 {
@@ -401,9 +407,9 @@ void Zone::initModificators()
 	}
 }
 
-CRandomGenerator& Zone::getRand()
+vstd::RNG& Zone::getRand()
 {
-	return rand;
+	return *rand;
 }
 
 VCMI_LIB_NAMESPACE_END

--- a/lib/rmg/Zone.h
+++ b/lib/rmg/Zone.h
@@ -13,7 +13,6 @@
 #include "../GameConstants.h"
 #include "float3.h"
 #include "../int3.h"
-#include "../CRandomGenerator.h"
 #include "CRmgTemplate.h"
 #include "RmgArea.h"
 #include "RmgPath.h"
@@ -28,7 +27,6 @@ VCMI_LIB_NAMESPACE_BEGIN
 class RmgMap;
 class CMapGenerator;
 class Modificator;
-class CRandomGenerator;
 
 extern const std::function<bool(const int3 &)> AREA_NO_FILTER;
 
@@ -74,8 +72,9 @@ private:
 class Zone : public rmg::ZoneOptions
 {
 public:
-	Zone(RmgMap & map, CMapGenerator & generator, CRandomGenerator & rand);
+	Zone(RmgMap & map, CMapGenerator & generator, vstd::RNG & rand);
 	Zone(const Zone &) = delete;
+	~Zone();
 	
 	void setOptions(const rmg::ZoneOptions & options);
 	bool isUnderground() const;
@@ -127,14 +126,14 @@ public:
 	
 	void initModificators();
 	
-	CRandomGenerator & getRand();
+	vstd::RNG & getRand();
 public:
 	mutable boost::recursive_mutex areaMutex;
 	using Lock = boost::unique_lock<boost::recursive_mutex>;
 	
 protected:
 	CMapGenerator & generator;
-	CRandomGenerator rand;
+	std::unique_ptr<vstd::RNG> rand;
 	RmgMap & map;
 	TModificators modificators;
 	bool finished;

--- a/lib/rmg/modificators/ConnectionsPlacer.cpp
+++ b/lib/rmg/modificators/ConnectionsPlacer.cpp
@@ -444,7 +444,7 @@ void ConnectionsPlacer::collectNeighbourZones()
 bool ConnectionsPlacer::shouldGenerateRoad(const rmg::ZoneConnection& connection) const
 {
 	return connection.getRoadOption() == rmg::ERoadOption::ROAD_TRUE ||
-		(connection.getRoadOption() == rmg::ERoadOption::ROAD_RANDOM && zone.getRand().nextDouble() >= 0.5f);
+		(connection.getRoadOption() == rmg::ERoadOption::ROAD_RANDOM && zone.getRand().nextDouble(0, 1) >= 0.5f);
 }
 
 void ConnectionsPlacer::createBorder()

--- a/lib/rmg/modificators/ConnectionsPlacer.cpp
+++ b/lib/rmg/modificators/ConnectionsPlacer.cpp
@@ -26,6 +26,8 @@
 #include "WaterProxy.h"
 #include "TownPlacer.h"
 
+#include <vstd/RNG.h>
+
 VCMI_LIB_NAMESPACE_BEGIN
 
 std::pair<Zone::Lock, Zone::Lock> ConnectionsPlacer::lockZones(std::shared_ptr<Zone> otherZone)

--- a/lib/rmg/modificators/MinePlacer.cpp
+++ b/lib/rmg/modificators/MinePlacer.cpp
@@ -22,6 +22,8 @@
 #include "WaterAdopter.h"
 #include "../TileInfo.h"
 
+#include <vstd/RNG.h>
+
 VCMI_LIB_NAMESPACE_BEGIN
 
 void MinePlacer::process()

--- a/lib/rmg/modificators/ObjectDistributor.cpp
+++ b/lib/rmg/modificators/ObjectDistributor.cpp
@@ -25,6 +25,8 @@
 #include "../Functions.h"
 #include "../RmgObject.h"
 
+#include <vstd/RNG.h>
+
 VCMI_LIB_NAMESPACE_BEGIN
 
 void ObjectDistributor::process()

--- a/lib/rmg/modificators/ObjectManager.cpp
+++ b/lib/rmg/modificators/ObjectManager.cpp
@@ -29,6 +29,8 @@
 #include "../Functions.h"
 #include "../RmgObject.h"
 
+#include <vstd/RNG.h>
+
 VCMI_LIB_NAMESPACE_BEGIN
 
 void ObjectManager::process()

--- a/lib/rmg/modificators/ObstaclePlacer.cpp
+++ b/lib/rmg/modificators/ObstaclePlacer.cpp
@@ -19,7 +19,6 @@
 #include "RiverPlacer.h"
 #include "../RmgMap.h"
 #include "../CMapGenerator.h"
-#include "../../CRandomGenerator.h"
 #include "../Functions.h"
 #include "../../mapping/CMapEditManager.h"
 #include "../../mapping/CMap.h"

--- a/lib/rmg/modificators/PrisonHeroPlacer.cpp
+++ b/lib/rmg/modificators/PrisonHeroPlacer.cpp
@@ -17,7 +17,9 @@
 #include "../../VCMI_Lib.h"
 #include "../../mapObjectConstructors/AObjectTypeHandler.h"
 #include "../../mapObjectConstructors/CObjectClassesHandler.h"
-#include "../../mapObjects/MapObjects.h" 
+#include "../../mapObjects/MapObjects.h"
+
+#include <vstd/RNG.h>
 
 VCMI_LIB_NAMESPACE_BEGIN
 

--- a/lib/rmg/modificators/PrisonHeroPlacer.h
+++ b/lib/rmg/modificators/PrisonHeroPlacer.h
@@ -15,8 +15,6 @@
 
 VCMI_LIB_NAMESPACE_BEGIN
 
-class CRandomGenerator;
-
 class PrisonHeroPlacer : public Modificator
 {
 public:

--- a/lib/rmg/modificators/QuestArtifactPlacer.cpp
+++ b/lib/rmg/modificators/QuestArtifactPlacer.cpp
@@ -17,7 +17,9 @@
 #include "../../VCMI_Lib.h"
 #include "../../mapObjectConstructors/AObjectTypeHandler.h"
 #include "../../mapObjectConstructors/CObjectClassesHandler.h"
-#include "../../mapObjects/MapObjects.h" 
+#include "../../mapObjects/MapObjects.h"
+
+#include <vstd/RNG.h>
 
 VCMI_LIB_NAMESPACE_BEGIN
 
@@ -95,7 +97,7 @@ void QuestArtifactPlacer::findZonesForQuestArts()
 	logGlobal->trace("Number of nearby zones suitable for quest artifacts: %d", questArtZones.size());
 }
 
-void QuestArtifactPlacer::placeQuestArtifacts(CRandomGenerator & rand)
+void QuestArtifactPlacer::placeQuestArtifacts(vstd::RNG & rand)
 {
 	for (const auto & artifactToPlace : questArtifactsToPlace)
 	{

--- a/lib/rmg/modificators/QuestArtifactPlacer.h
+++ b/lib/rmg/modificators/QuestArtifactPlacer.h
@@ -15,8 +15,6 @@
 
 VCMI_LIB_NAMESPACE_BEGIN
 
-class CRandomGenerator;
-
 class QuestArtifactPlacer : public Modificator
 {
 public:
@@ -33,7 +31,7 @@ public:
 	void rememberPotentialArtifactToReplace(CGObjectInstance* obj);
 	CGObjectInstance * drawObjectToReplace();
 	std::vector<CGObjectInstance*> getPossibleArtifactsToReplace() const;
-	void placeQuestArtifacts(CRandomGenerator & rand);
+	void placeQuestArtifacts(vstd::RNG & rand);
 	void dropReplacedArtifact(CGObjectInstance* obj);
 
 	size_t getMaxQuestArtifactCount() const;

--- a/lib/rmg/modificators/RiverPlacer.cpp
+++ b/lib/rmg/modificators/RiverPlacer.cpp
@@ -27,6 +27,8 @@
 #include "WaterProxy.h"
 #include "RoadPlacer.h"
 
+#include <vstd/RNG.h>
+
 VCMI_LIB_NAMESPACE_BEGIN
 
 const int RIVER_DELTA_ID = 143;

--- a/lib/rmg/modificators/RockFiller.cpp
+++ b/lib/rmg/modificators/RockFiller.cpp
@@ -19,7 +19,6 @@
 #include "../CMapGenerator.h"
 #include "../Functions.h"
 #include "../../TerrainHandler.h"
-#include "../../CRandomGenerator.h"
 #include "../lib/mapping/CMapEditManager.h"
 #include "../TileInfo.h"
 #include "../threadpool/MapProxy.h"

--- a/lib/rmg/modificators/RockPlacer.cpp
+++ b/lib/rmg/modificators/RockPlacer.cpp
@@ -18,7 +18,6 @@
 #include "../CMapGenerator.h"
 #include "../Functions.h"
 #include "../../TerrainHandler.h"
-#include "../../CRandomGenerator.h"
 #include "../../mapping/CMapEditManager.h"
 #include "../../VCMI_Lib.h"
 #include "../TileInfo.h"

--- a/lib/rmg/modificators/TerrainPainter.cpp
+++ b/lib/rmg/modificators/TerrainPainter.cpp
@@ -22,6 +22,8 @@
 #include "../../TerrainHandler.h"
 #include "../../CTownHandler.h"
 
+#include <vstd/RNG.h>
+
 VCMI_LIB_NAMESPACE_BEGIN
 
 void TerrainPainter::process()

--- a/lib/rmg/modificators/TownPlacer.cpp
+++ b/lib/rmg/modificators/TownPlacer.cpp
@@ -27,6 +27,8 @@
 #include "WaterAdopter.h"
 #include "../TileInfo.h"
 
+#include <vstd/RNG.h>
+
 VCMI_LIB_NAMESPACE_BEGIN
 
 void TownPlacer::process()

--- a/lib/rmg/modificators/TreasurePlacer.cpp
+++ b/lib/rmg/modificators/TreasurePlacer.cpp
@@ -33,6 +33,8 @@
 #include "../../mapping/CMap.h"
 #include "../../mapping/CMapEditManager.h"
 
+#include <vstd/RNG.h>
+
 VCMI_LIB_NAMESPACE_BEGIN
 
 ObjectInfo::ObjectInfo():
@@ -649,7 +651,7 @@ std::vector<ObjectInfo*> TreasurePlacer::prepareTreasurePile(const CTreasureInfo
 		if (currentValue >= minValue)
 		{
 			// 50% chance to end right here
-			if (zone.getRand().nextInt() & 1)
+			if (zone.getRand().nextInt(0, 1) == 1)
 				break;
 		}
 	}

--- a/lib/rmg/modificators/TreasurePlacer.h
+++ b/lib/rmg/modificators/TreasurePlacer.h
@@ -18,7 +18,6 @@ class CGObjectInstance;
 class ObjectManager;
 class RmgMap;
 class CMapGenerator;
-class CRandomGenerator;
 
 struct ObjectInfo
 {

--- a/lib/rmg/modificators/WaterAdopter.cpp
+++ b/lib/rmg/modificators/WaterAdopter.cpp
@@ -23,6 +23,8 @@
 #include "ConnectionsPlacer.h"
 #include "../TileInfo.h"
 
+#include <vstd/RNG.h>
+
 VCMI_LIB_NAMESPACE_BEGIN
 
 void WaterAdopter::process()

--- a/lib/rmg/modificators/WaterProxy.cpp
+++ b/lib/rmg/modificators/WaterProxy.cpp
@@ -30,6 +30,8 @@
 #include "WaterAdopter.h"
 #include "../RmgArea.h"
 
+#include <vstd/RNG.h>
+
 VCMI_LIB_NAMESPACE_BEGIN
 
 void WaterProxy::process()

--- a/lib/rmg/threadpool/MapProxy.cpp
+++ b/lib/rmg/threadpool/MapProxy.cpp
@@ -37,21 +37,21 @@ void MapProxy::removeObject(CGObjectInstance * obj)
 	map.getEditManager()->removeObject(obj);
 }
 
-void MapProxy::drawTerrain(CRandomGenerator & generator, std::vector<int3> & tiles, TerrainId terrain)
+void MapProxy::drawTerrain(vstd::RNG & generator, std::vector<int3> & tiles, TerrainId terrain)
 {
 	Lock lock(mx);
 	map.getEditManager()->getTerrainSelection().setSelection(tiles);
 	map.getEditManager()->drawTerrain(terrain, map.getDecorationsPercentage(), &generator);
 }
 
-void MapProxy::drawRivers(CRandomGenerator & generator, std::vector<int3> & tiles, TerrainId terrain)
+void MapProxy::drawRivers(vstd::RNG & generator, std::vector<int3> & tiles, TerrainId terrain)
 {
 	Lock lock(mx);
 	map.getEditManager()->getTerrainSelection().setSelection(tiles);
 	map.getEditManager()->drawRiver(VLC->terrainTypeHandler->getById(terrain)->river, &generator);
 }
 
-void MapProxy::drawRoads(CRandomGenerator & generator, std::vector<int3> & tiles, RoadId roadType)
+void MapProxy::drawRoads(vstd::RNG & generator, std::vector<int3> & tiles, RoadId roadType)
 {
 	Lock lock(mx);
 	map.getEditManager()->getTerrainSelection().setSelection(tiles);

--- a/lib/rmg/threadpool/MapProxy.h
+++ b/lib/rmg/threadpool/MapProxy.h
@@ -28,9 +28,9 @@ public:
 	void insertObjects(std::set<CGObjectInstance*>& objects);
 	void removeObject(CGObjectInstance* obj);
 
-	void drawTerrain(CRandomGenerator & generator, std::vector<int3> & tiles, TerrainId terrain);
-	void drawRivers(CRandomGenerator & generator, std::vector<int3> & tiles, TerrainId terrain);
-	void drawRoads(CRandomGenerator & generator, std::vector<int3> & tiles, RoadId roadType);
+	void drawTerrain(vstd::RNG & generator, std::vector<int3> & tiles, TerrainId terrain);
+	void drawRivers(vstd::RNG & generator, std::vector<int3> & tiles, TerrainId terrain);
+	void drawRoads(vstd::RNG & generator, std::vector<int3> & tiles, RoadId roadType);
 
 private:
 	mutable boost::shared_mutex mx;

--- a/lib/serializer/ESerializationVersion.h
+++ b/lib/serializer/ESerializationVersion.h
@@ -56,6 +56,7 @@ enum class ESerializationVersion : int32_t
 	REMOVE_FOG_OF_WAR_POINTER, // 846 - fog of war is serialized as reference instead of pointer
 	SIMPLE_TEXT_CONTAINER_SERIALIZATION, // 847 - text container is serialized using common routine instead of custom approach
 	MAP_FORMAT_ADDITIONAL_INFOS, // 848 - serialize new infos in map format
+	REMOVE_LIB_RNG, // 849 - removed random number generators from library classes
 
-	CURRENT = MAP_FORMAT_ADDITIONAL_INFOS
+	CURRENT = REMOVE_LIB_RNG
 };

--- a/lib/spells/AdventureSpellMechanics.cpp
+++ b/lib/spells/AdventureSpellMechanics.cpp
@@ -187,7 +187,7 @@ ESpellCastResult SummonBoatMechanics::applyAdventureEffects(SpellCastEnvironment
 	const auto schoolLevel = parameters.caster->getSpellSchoolLevel(owner);
 
 	//check if spell works at all
-	if(env->getRNG()->getInt64Range(0, 99)() >= owner->getLevelPower(schoolLevel)) //power is % chance of success
+	if(env->getRNG()->nextInt(0, 99) >= owner->getLevelPower(schoolLevel)) //power is % chance of success
 	{
 		InfoWindow iw;
 		iw.player = parameters.caster->getCasterOwner();
@@ -280,7 +280,7 @@ ESpellCastResult ScuttleBoatMechanics::applyAdventureEffects(SpellCastEnvironmen
 {
 	const auto schoolLevel = parameters.caster->getSpellSchoolLevel(owner);
 	//check if spell works at all
-	if(env->getRNG()->getInt64Range(0, 99)() >= owner->getLevelPower(schoolLevel)) //power is % chance of success
+	if(env->getRNG()->nextInt(0, 99) >= owner->getLevelPower(schoolLevel)) //power is % chance of success
 	{
 		InfoWindow iw;
 		iw.player = parameters.caster->getCasterOwner();

--- a/lib/spells/AdventureSpellMechanics.cpp
+++ b/lib/spells/AdventureSpellMechanics.cpp
@@ -17,13 +17,14 @@
 
 #include "../CGameInfoCallback.h"
 #include "../CPlayerState.h"
-#include "../CRandomGenerator.h"
 #include "../GameSettings.h"
 #include "../mapObjects/CGHeroInstance.h"
 #include "../mapObjects/CGTownInstance.h"
 #include "../mapObjects/MiscObjects.h"
 #include "../mapping/CMap.h"
 #include "../networkPacks/PacksForClient.h"
+
+#include <vstd/RNG.h>
 
 VCMI_LIB_NAMESPACE_BEGIN
 

--- a/lib/spells/AdventureSpellMechanics.cpp
+++ b/lib/spells/AdventureSpellMechanics.cpp
@@ -238,12 +238,7 @@ ESpellCastResult SummonBoatMechanics::applyAdventureEffects(SpellCastEnvironment
 	}
 	else //create boat
 	{
-		NewObject no;
-		no.ID = Obj::BOAT;
-		no.subID = BoatId::NECROPOLIS;
-		no.targetPos = summonPos;
-		no.initiator = parameters.caster->getCasterOwner();
-		env->apply(&no);
+		env->createBoat(summonPos, BoatId::NECROPOLIS, parameters.caster->getCasterOwner());
 	}
 	return ESpellCastResult::OK;
 }

--- a/lib/spells/BattleSpellMechanics.cpp
+++ b/lib/spells/BattleSpellMechanics.cpp
@@ -19,7 +19,8 @@
 #include "../networkPacks/PacksForClientBattle.h"
 #include "../networkPacks/SetStackEffect.h"
 #include "../CStack.h"
-#include "../CRandomGenerator.h"
+
+#include <vstd/RNG.h>
 
 VCMI_LIB_NAMESPACE_BEGIN
 

--- a/lib/spells/BattleSpellMechanics.cpp
+++ b/lib/spells/BattleSpellMechanics.cpp
@@ -377,15 +377,13 @@ void BattleSpellMechanics::beforeCast(BattleSpellCast & sc, vstd::RNG & rng, con
 
 	std::vector <const battle::Unit *> resisted;
 
-	auto rangeGen = rng.getInt64Range(0, 99);
-
 	auto filterResisted = [&, this](const battle::Unit * unit) -> bool
 	{
 		if(isNegativeSpell() && isMagicalEffect())
 		{
 			//magic resistance
 			const int prob = std::min(unit->magicResistance(), 100); //probability of resistance in %
-			if(rangeGen() < prob)
+			if(rng.nextInt(0, 99) < prob)
 				return true;
 		}
 		return false;

--- a/lib/spells/ISpellMechanics.cpp
+++ b/lib/spells/ISpellMechanics.cpp
@@ -11,7 +11,6 @@
 #include "StdInc.h"
 #include "ISpellMechanics.h"
 
-#include "../CRandomGenerator.h"
 #include "../VCMI_Lib.h"
 
 #include "../bonuses/Bonus.h"
@@ -40,6 +39,8 @@
 #include "../CHeroHandler.h"//todo: remove
 #include "../IGameCallback.h"//todo: remove
 #include "../BattleFieldHandler.h"
+
+#include <vstd/RNG.h>
 
 VCMI_LIB_NAMESPACE_BEGIN
 

--- a/lib/spells/ISpellMechanics.cpp
+++ b/lib/spells/ISpellMechanics.cpp
@@ -268,11 +268,9 @@ void BattleCast::cast(ServerCallback * server, Target target)
 		const std::string magicMirrorCacheStr = "type_MAGIC_MIRROR";
 		static const auto magicMirrorSelector = Selector::type()(BonusType::MAGIC_MIRROR);
 
-		auto rangeGen = server->getRNG()->getInt64Range(0, 99);
-
 		const int mirrorChance = mainTarget->valOfBonuses(magicMirrorSelector, magicMirrorCacheStr);
 
-		if(rangeGen() < mirrorChance)
+		if(server->getRNG()->nextInt(0, 99) < mirrorChance)
 		{
 			auto mirrorTargets = cb->battleGetUnitsIf([this](const battle::Unit * unit)
 			{

--- a/lib/spells/ISpellMechanics.h
+++ b/lib/spells/ISpellMechanics.h
@@ -22,7 +22,6 @@ VCMI_LIB_NAMESPACE_BEGIN
 
 struct Query;
 class IBattleState;
-class CRandomGenerator;
 class CreatureService;
 class CMap;
 class CGameInfoCallback;

--- a/lib/spells/ISpellMechanics.h
+++ b/lib/spells/ISpellMechanics.h
@@ -58,6 +58,7 @@ public:
 	virtual const CMap * getMap() const = 0;
 	virtual const CGameInfoCallback * getCb() const = 0;
 
+	virtual void createBoat(const int3 & visitablePosition, BoatId type, PlayerColor initiator) = 0;
 	virtual bool moveHero(ObjectInstanceID hid, int3 dst, EMovementMode mode) = 0;	//TODO: remove
 
 	virtual void genericQuery(Query * request, PlayerColor color, std::function<void(std::optional<int32_t>)> callback) = 0;//TODO: type safety on query, use generic query packet when implemented

--- a/lib/spells/effects/Catapult.cpp
+++ b/lib/spells/effects/Catapult.cpp
@@ -118,7 +118,7 @@ void Catapult::applyTargeted(ServerCallback * server, const Mechanics * m, const
 		auto actualTarget = EWallPart::INVALID;
 
 		if ( m->battle()->isWallPartAttackable(desiredTarget) &&
-				server->getRNG()->getInt64Range(0, 99)() < getCatapultHitChance(desiredTarget))
+				server->getRNG()->nextInt(0, 99) < getCatapultHitChance(desiredTarget))
 		{
 			actualTarget = desiredTarget;
 		}
@@ -172,7 +172,7 @@ int Catapult::getRandomDamage (ServerCallback * server) const
 {
 	std::array<int, 3> damageChances = { noDmg, hit, crit }; //dmgChance[i] - chance for doing i dmg when hit is successful
 	int totalChance = std::accumulate(damageChances.begin(), damageChances.end(), 0);
-	int damageRandom = server->getRNG()->getInt64Range(0, totalChance - 1)();
+	int damageRandom = server->getRNG()->nextInt(0, totalChance - 1);
 	int dealtDamage = 0;
 
 	//calculating dealt damage

--- a/lib/spells/effects/Catapult.cpp
+++ b/lib/spells/effects/Catapult.cpp
@@ -20,7 +20,8 @@
 #include "../../mapObjects/CGTownInstance.h"
 #include "../../networkPacks/PacksForClientBattle.h"
 #include "../../serializer/JsonSerializeFormat.h"
-#include "../../CRandomGenerator.h"
+
+#include <vstd/RNG.h>
 
 VCMI_LIB_NAMESPACE_BEGIN
 

--- a/lib/spells/effects/Obstacle.cpp
+++ b/lib/spells/effects/Obstacle.cpp
@@ -18,7 +18,8 @@
 #include "../../battle/CBattleInfoCallback.h"
 #include "../../networkPacks/PacksForClientBattle.h"
 #include "../../serializer/JsonSerializeFormat.h"
-#include "../../CRandomGenerator.h"
+
+#include <vstd/RNG.h>
 
 VCMI_LIB_NAMESPACE_BEGIN
 

--- a/mapeditor/mapcontroller.cpp
+++ b/mapeditor/mapcontroller.cpp
@@ -26,6 +26,7 @@
 #include "../lib/CSkillHandler.h"
 #include "../lib/spells/CSpellHandler.h"
 #include "../lib/CHeroHandler.h"
+#include "../lib/CRandomGenerator.h"
 #include "../lib/serializer/CMemorySerializer.h"
 #include "mapview.h"
 #include "scenelayer.h"

--- a/mapeditor/windownewmap.cpp
+++ b/mapeditor/windownewmap.cpp
@@ -17,6 +17,7 @@
 #include "../lib/mapping/CMapEditManager.h"
 #include "../lib/mapping/MapFormat.h"
 #include "../lib/CGeneralTextHandler.h"
+#include "../lib/CRandomGenerator.h"
 #include "../lib/serializer/JsonSerializer.h"
 #include "../lib/serializer/JsonDeserializer.h"
 

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -24,6 +24,7 @@
 #include "../lib/ArtifactUtils.h"
 #include "../lib/CArtHandler.h"
 #include "../lib/CBuildingHandler.h"
+#include "../lib/CConfigHandler.h"
 #include "../lib/CCreatureHandler.h"
 #include "../lib/CCreatureSet.h"
 #include "../lib/CGeneralTextHandler.h"
@@ -552,6 +553,9 @@ void CGameHandler::reinitScripting()
 void CGameHandler::init(StartInfo *si, Load::ProgressAccumulator & progressTracking)
 {
 	randomNumberGenerator = std::make_unique<CRandomGenerator>();
+	int requestedSeed = settings["server"]["seed"].Integer();
+	if (requestedSeed != 0)
+		randomNumberGenerator->setSeed(requestedSeed);
 	logGlobal->info("Using random seed: %d", randomNumberGenerator->nextInt());
 
 	CMapService mapService;

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -29,6 +29,7 @@
 #include "../lib/CGeneralTextHandler.h"
 #include "../lib/CHeroHandler.h"
 #include "../lib/CPlayerState.h"
+#include "../lib/CRandomGenerator.h"
 #include "../lib/CSoundBase.h"
 #include "../lib/CThreadHelper.h"
 #include "../lib/CTownHandler.h"
@@ -68,7 +69,8 @@
 
 #include "../lib/spells/CSpellHandler.h"
 
-#include "vstd/CLoggerBase.h"
+#include <vstd/RNG.h>
+#include <vstd/CLoggerBase.h>
 #include <vcmi/events/EventBus.h>
 #include <vcmi/events/GenericEvents.h>
 #include <vcmi/events/AdventureEvents.h>
@@ -558,7 +560,7 @@ void CGameHandler::init(StartInfo *si, Load::ProgressAccumulator & progressTrack
 	logGlobal->info("Gamestate initialized!");
 
 	// reset seed, so that clients can't predict any following random values
-	getRandomGenerator().resetSeed();
+	randomNumberGenerator = std::make_unique<CRandomGenerator>();
 
 	for (auto & elem : gs->players)
 		turnOrder->addPlayer(elem.first);
@@ -4378,9 +4380,9 @@ void CGameHandler::showInfoDialog(InfoWindow * iw)
 	sendAndApply(iw);
 }
 
-CRandomGenerator & CGameHandler::getRandomGenerator()
+vstd::RNG & CGameHandler::getRandomGenerator()
 {
-	return CRandomGenerator::getDefault();
+	return *randomNumberGenerator;
 }
 
 #if SCRIPTING_ENABLED

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -549,9 +549,11 @@ void CGameHandler::reinitScripting()
 void CGameHandler::init(StartInfo *si, Load::ProgressAccumulator & progressTracking)
 {
 	if (si->seedToBeUsed == 0)
-	{
 		si->seedToBeUsed = CRandomGenerator::getDefault().nextInt();
-	}
+
+	logGlobal->info("Using random seed: %d", si->seedToBeUsed);
+	randomNumberGenerator = std::make_unique<CRandomGenerator>(si->seedToBeUsed);
+
 	CMapService mapService;
 	gs = new CGameState();
 	gs->preInit(VLC, this);

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -908,6 +908,9 @@ void CGameHandler::onNewTurn()
 		}
 	}
 
+	if (newWeek)
+		n.newRumor = gameState()->pickNewRumor();
+
 	if (newMonth)
 	{
 		SetAvailableArtifacts saa;

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -548,11 +548,8 @@ void CGameHandler::reinitScripting()
 
 void CGameHandler::init(StartInfo *si, Load::ProgressAccumulator & progressTracking)
 {
-	if (si->seedToBeUsed == 0)
-		si->seedToBeUsed = CRandomGenerator::getDefault().nextInt();
-
-	logGlobal->info("Using random seed: %d", si->seedToBeUsed);
-	randomNumberGenerator = std::make_unique<CRandomGenerator>(si->seedToBeUsed);
+	randomNumberGenerator = std::make_unique<CRandomGenerator>();
+	logGlobal->info("Using random seed: %d", randomNumberGenerator->nextInt());
 
 	CMapService mapService;
 	gs = new CGameState();
@@ -560,9 +557,6 @@ void CGameHandler::init(StartInfo *si, Load::ProgressAccumulator & progressTrack
 	logGlobal->info("Gamestate created!");
 	gs->init(&mapService, si, progressTracking);
 	logGlobal->info("Gamestate initialized!");
-
-	// reset seed, so that clients can't predict any following random values
-	randomNumberGenerator = std::make_unique<CRandomGenerator>();
 
 	for (auto & elem : gs->players)
 		turnOrder->addPlayer(elem.first);

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -4374,6 +4374,23 @@ void CGameHandler::setObjPropertyID(ObjectInstanceID objid, ObjProperty prop, Ob
 	sendAndApply(&sob);
 }
 
+void CGameHandler::setRewardableObjectConfiguration(ObjectInstanceID objid, const Rewardable::Configuration & configuration)
+{
+	SetRewardableConfiguration srb;
+	srb.objectID = objid;
+	srb.configuration = configuration;
+	sendAndApply(&srb);
+}
+
+void CGameHandler::setRewardableObjectConfiguration(ObjectInstanceID townInstanceID, BuildingID buildingID, const Rewardable::Configuration & configuration)
+{
+	SetRewardableConfiguration srb;
+	srb.objectID = townInstanceID;
+	srb.buildingID = buildingID;
+	srb.configuration = configuration;
+	sendAndApply(&srb);
+}
+
 void CGameHandler::showInfoDialog(InfoWindow * iw)
 {
 	sendAndApply(iw);

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -4377,6 +4377,14 @@ void CGameHandler::setObjPropertyID(ObjectInstanceID objid, ObjProperty prop, Ob
 	sendAndApply(&sob);
 }
 
+void CGameHandler::setBankObjectConfiguration(ObjectInstanceID objid, const BankConfig & configuration)
+{
+	SetBankConfiguration srb;
+	srb.objectID = objid;
+	srb.configuration = configuration;
+	sendAndApply(&srb);
+}
+
 void CGameHandler::setRewardableObjectConfiguration(ObjectInstanceID objid, const Rewardable::Configuration & configuration)
 {
 	SetRewardableConfiguration srb;

--- a/server/CGameHandler.h
+++ b/server/CGameHandler.h
@@ -23,6 +23,7 @@ class SpellCastEnvironment;
 class CConnection;
 class CCommanderInstance;
 class EVictoryLossCheckResult;
+class CRandomGenerator;
 
 struct CPack;
 struct CPackForServer;
@@ -63,6 +64,7 @@ public:
 	std::unique_ptr<QueriesProcessor> queries;
 	std::unique_ptr<TurnOrderProcessor> turnOrder;
 	std::unique_ptr<TurnTimerHandler> turnTimerHandler;
+	std::unique_ptr<CRandomGenerator> randomNumberGenerator;
 
 	//use enums as parameters, because doMove(sth, true, false, true) is not readable
 	enum EGuardLook {CHECK_FOR_GUARDS, IGNORE_GUARDS};
@@ -226,7 +228,7 @@ public:
 	template <typename Handler> void serialize(Handler &h)
 	{
 		h & QID;
-		h & getRandomGenerator();
+		h & randomNumberGenerator;
 		h & *battles;
 		h & *heroPool;
 		h & *playerMessages;
@@ -275,7 +277,7 @@ public:
 	void checkVictoryLossConditions(const std::set<PlayerColor> & playerColors);
 	void checkVictoryLossConditionsForAll();
 
-	CRandomGenerator & getRandomGenerator();
+	vstd::RNG & getRandomGenerator();
 
 #if SCRIPTING_ENABLED
 	scripting::Pool * getGlobalContextPool() const override;

--- a/server/CGameHandler.h
+++ b/server/CGameHandler.h
@@ -92,6 +92,14 @@ public:
 	bool isAllowedExchange(ObjectInstanceID id1, ObjectInstanceID id2);
 	void giveSpells(const CGTownInstance *t, const CGHeroInstance *h);
 
+	// Helpers to create new object of specified type
+
+	CGObjectInstance * createNewObject(const int3 & visitablePosition, MapObjectID objectID, MapObjectSubID subID);
+	void createWanderingMonster(const int3 & visitablePosition, CreatureID creature);
+	void createBoat(const int3 & visitablePosition, BoatId type, PlayerColor initiator) override;
+	void createHole(const int3 & visitablePosition, PlayerColor initiator);
+	void newObject(CGObjectInstance * object, PlayerColor initiator);
+
 	explicit CGameHandler(CVCMIServer * lobby);
 	~CGameHandler();
 
@@ -100,7 +108,6 @@ public:
 	//do sth
 	void changeSpells(const CGHeroInstance * hero, bool give, const std::set<SpellID> &spells) override;
 	bool removeObject(const CGObjectInstance * obj, const PlayerColor & initiator) override;
-	void createObject(const int3 & visitablePosition, const PlayerColor & initiator, MapObjectID type, MapObjectSubID subtype) override;
 	void setOwner(const CGObjectInstance * obj, PlayerColor owner) override;
 	void giveExperience(const CGHeroInstance * hero, TExpType val) override;
 	void changePrimSkill(const CGHeroInstance * hero, PrimarySkill which, si64 val, bool abs=false) override;

--- a/server/CGameHandler.h
+++ b/server/CGameHandler.h
@@ -162,6 +162,8 @@ public:
 	bool isVisitCoveredByAnotherQuery(const CGObjectInstance *obj, const CGHeroInstance *hero) override;
 	void setObjPropertyValue(ObjectInstanceID objid, ObjProperty prop, int32_t value) override;
 	void setObjPropertyID(ObjectInstanceID objid, ObjProperty prop, ObjPropertyID identifier) override;
+	void setRewardableObjectConfiguration(ObjectInstanceID objid, const Rewardable::Configuration & configuration) override;
+	void setRewardableObjectConfiguration(ObjectInstanceID townInstanceID, BuildingID buildingID, const Rewardable::Configuration & configuration) override;
 	void showInfoDialog(InfoWindow * iw) override;
 
 	//////////////////////////////////////////////////////////////////////////

--- a/server/CGameHandler.h
+++ b/server/CGameHandler.h
@@ -169,6 +169,7 @@ public:
 	bool isVisitCoveredByAnotherQuery(const CGObjectInstance *obj, const CGHeroInstance *hero) override;
 	void setObjPropertyValue(ObjectInstanceID objid, ObjProperty prop, int32_t value) override;
 	void setObjPropertyID(ObjectInstanceID objid, ObjProperty prop, ObjPropertyID identifier) override;
+	void setBankObjectConfiguration(ObjectInstanceID objid, const BankConfig & configuration) override;
 	void setRewardableObjectConfiguration(ObjectInstanceID objid, const Rewardable::Configuration & configuration) override;
 	void setRewardableObjectConfiguration(ObjectInstanceID townInstanceID, BuildingID buildingID, const Rewardable::Configuration & configuration) override;
 	void showInfoDialog(InfoWindow * iw) override;

--- a/server/CGameHandler.h
+++ b/server/CGameHandler.h
@@ -277,7 +277,7 @@ public:
 	void checkVictoryLossConditions(const std::set<PlayerColor> & playerColors);
 	void checkVictoryLossConditionsForAll();
 
-	vstd::RNG & getRandomGenerator();
+	vstd::RNG & getRandomGenerator() override;
 
 #if SCRIPTING_ENABLED
 	scripting::Pool * getGlobalContextPool() const override;

--- a/server/CVCMIServer.cpp
+++ b/server/CVCMIServer.cpp
@@ -253,7 +253,6 @@ void CVCMIServer::prepareToRestart()
 	}
 
 	* si = * gh->gs->initialOpts;
-	si->seedToBeUsed = si->seedPostInit = 0;
 	setState(EServerState::LOBBY);
 	if (si->campState)
 	{

--- a/server/ServerSpellCastEnvironment.cpp
+++ b/server/ServerSpellCastEnvironment.cpp
@@ -94,6 +94,11 @@ bool ServerSpellCastEnvironment::moveHero(ObjectInstanceID hid, int3 dst, EMovem
 	return gh->moveHero(hid, dst, mode, false);
 }
 
+void ServerSpellCastEnvironment::createBoat(const int3 & visitablePosition, BoatId type, PlayerColor initiator)
+{
+	return gh->createBoat(visitablePosition, type, initiator);
+}
+
 void ServerSpellCastEnvironment::genericQuery(Query * request, PlayerColor color, std::function<void(std::optional<int32_t>)> callback)
 {
 	auto query = std::make_shared<CGenericQuery>(gh, color, callback);

--- a/server/ServerSpellCastEnvironment.h
+++ b/server/ServerSpellCastEnvironment.h
@@ -37,6 +37,7 @@ public:
 	const CMap * getMap() const override;
 	const CGameInfoCallback * getCb() const override;
 	bool moveHero(ObjectInstanceID hid, int3 dst, EMovementMode mode) override;
+	void createBoat(const int3 & visitablePosition, BoatId type, PlayerColor initiator) override;
 	void genericQuery(Query * request, PlayerColor color, std::function<void(std::optional<int32_t>)> callback) override;
 private:
 	CGameHandler * gh;

--- a/server/battles/BattleActionProcessor.cpp
+++ b/server/battles/BattleActionProcessor.cpp
@@ -1341,7 +1341,7 @@ void BattleActionProcessor::handleAfterAttackCasting(const CBattleInfoCallback &
 		double chanceToTrigger = attacker->valOfBonuses(BonusType::TRANSMUTATION) / 100.0f;
 		vstd::amin(chanceToTrigger, 1); //cap at 100%
 
-		if(gameHandler->getRandomGenerator().getDoubleRange(0, 1)() > chanceToTrigger)
+		if(gameHandler->getRandomGenerator().nextDouble(0, 1) > chanceToTrigger)
 			return;
 
 		int bonusAdditionalInfo = attacker->getBonus(Selector::type()(BonusType::TRANSMUTATION))->additionalInfo[0];
@@ -1405,7 +1405,7 @@ void BattleActionProcessor::handleAfterAttackCasting(const CBattleInfoCallback &
 
 		vstd::amin(chanceToTrigger, 1); //cap trigger chance at 100%
 
-		if(gameHandler->getRandomGenerator().getDoubleRange(0, 1)() > chanceToTrigger)
+		if(gameHandler->getRandomGenerator().nextDouble(0, 1) > chanceToTrigger)
 			return;
 
 		BattleStackAttacked bsa;

--- a/server/battles/BattleActionProcessor.cpp
+++ b/server/battles/BattleActionProcessor.cpp
@@ -29,6 +29,8 @@
 #include "../../lib/spells/ISpellMechanics.h"
 #include "../../lib/spells/Problem.h"
 
+#include <vstd/RNG.h>
+
 BattleActionProcessor::BattleActionProcessor(BattleProcessor * owner, CGameHandler * newGameHandler)
 	: owner(owner)
 	, gameHandler(newGameHandler)
@@ -1263,8 +1265,7 @@ void BattleActionProcessor::handleDeathStare(const CBattleInfoCallback & battle,
 	int singleCreatureKillChancePercent = attacker->valOfBonuses(BonusType::DEATH_STARE, subtype);
 	double chanceToKill = singleCreatureKillChancePercent / 100.0;
 	vstd::amin(chanceToKill, 1); //cap at 100%
-	std::binomial_distribution<> distribution(attacker->getCount(), chanceToKill);
-	int killedCreatures = distribution(gameHandler->getRandomGenerator().getStdGenerator());
+	int killedCreatures = gameHandler->getRandomGenerator().nextBinomialInt(attacker->getCount(), chanceToKill);
 
 	int maxToKill = (attacker->getCount() * singleCreatureKillChancePercent + 99) / 100;
 	vstd::amin(killedCreatures, maxToKill);

--- a/server/battles/BattleFlowProcessor.cpp
+++ b/server/battles/BattleFlowProcessor.cpp
@@ -26,6 +26,8 @@
 #include "../../lib/spells/ISpellMechanics.h"
 #include "../../lib/spells/ObstacleCasterProxy.h"
 
+#include <vstd/RNG.h>
+
 BattleFlowProcessor::BattleFlowProcessor(BattleProcessor * owner, CGameHandler * newGameHandler)
 	: owner(owner)
 	, gameHandler(newGameHandler)

--- a/server/battles/BattleResultProcessor.cpp
+++ b/server/battles/BattleResultProcessor.cpp
@@ -30,6 +30,8 @@
 #include "../../lib/serializer/Cast.h"
 #include "../../lib/spells/CSpellHandler.h"
 
+#include <vstd/RNG.h>
+
 BattleResultProcessor::BattleResultProcessor(BattleProcessor * owner, CGameHandler * newGameHandler)
 //	: owner(owner)
 	: gameHandler(newGameHandler)

--- a/server/processors/HeroPoolProcessor.cpp
+++ b/server/processors/HeroPoolProcessor.cpp
@@ -13,6 +13,7 @@
 #include "TurnOrderProcessor.h"
 #include "../CGameHandler.h"
 
+#include "../../lib/CRandomGenerator.h"
 #include "../../lib/CHeroHandler.h"
 #include "../../lib/CPlayerState.h"
 #include "../../lib/GameSettings.h"
@@ -368,7 +369,7 @@ CGHeroInstance * HeroPoolProcessor::pickHeroFor(bool isNative, const PlayerColor
 	return *RandomGeneratorUtil::nextItem(possibleHeroes, getRandomGenerator(player));
 }
 
-CRandomGenerator & HeroPoolProcessor::getHeroSkillsRandomGenerator(const HeroTypeID & hero)
+vstd::RNG & HeroPoolProcessor::getHeroSkillsRandomGenerator(const HeroTypeID & hero)
 {
 	if (heroSeed.count(hero) == 0)
 	{
@@ -379,7 +380,7 @@ CRandomGenerator & HeroPoolProcessor::getHeroSkillsRandomGenerator(const HeroTyp
 	return *heroSeed.at(hero);
 }
 
-CRandomGenerator & HeroPoolProcessor::getRandomGenerator(const PlayerColor & player)
+vstd::RNG & HeroPoolProcessor::getRandomGenerator(const PlayerColor & player)
 {
 	if (playerSeed.count(player) == 0)
 	{

--- a/server/processors/HeroPoolProcessor.cpp
+++ b/server/processors/HeroPoolProcessor.cpp
@@ -227,8 +227,7 @@ bool HeroPoolProcessor::hireHero(const ObjectInstanceID & objectID, const HeroTy
 	if(gameHandler->getTile(targetPos)->isWater() && !recruitedHero->boat)
 	{
 		//Create a new boat for hero
-		gameHandler->createObject(targetPos, player, Obj::BOAT, recruitedHero->getBoatType().getNum());
-
+		gameHandler->createBoat(targetPos, recruitedHero->getBoatType(), player);
 		hr.boatId = gameHandler->getTopObj(targetPos)->id;
 	}
 

--- a/server/processors/HeroPoolProcessor.h
+++ b/server/processors/HeroPoolProcessor.h
@@ -19,8 +19,13 @@ class PlayerColor;
 class CGHeroInstance;
 class HeroTypeID;
 class ObjectInstanceID;
-class CRandomGenerator;
 class CHeroClass;
+class CRandomGenerator;
+
+namespace vstd
+{
+class RNG;
+}
 
 VCMI_LIB_NAMESPACE_END
 
@@ -46,7 +51,7 @@ class HeroPoolProcessor : boost::noncopyable
 
 	CGHeroInstance * pickHeroFor(bool isNative, const PlayerColor & player);
 
-	CRandomGenerator & getRandomGenerator(const PlayerColor & player);
+	vstd::RNG & getRandomGenerator(const PlayerColor & player);
 
 	TavernHeroSlot selectSlotForRole(const PlayerColor & player, TavernSlotRole roleID);
 
@@ -58,7 +63,7 @@ public:
 
 	void onNewWeek(const PlayerColor & color);
 
-	CRandomGenerator & getHeroSkillsRandomGenerator(const HeroTypeID & hero);
+	vstd::RNG & getHeroSkillsRandomGenerator(const HeroTypeID & hero);
 
 	/// Incoming net pack handling
 	bool hireHero(const ObjectInstanceID & objectID, const HeroTypeID & hid, const PlayerColor & player, const HeroTypeID & nextHero);

--- a/test/game/CGameStateTest.cpp
+++ b/test/game/CGameStateTest.cpp
@@ -121,6 +121,10 @@ public:
 		return gameState.get();
 	}
 
+	void createBoat(const int3 & visitablePosition, BoatId type, PlayerColor initiator) override
+	{
+	}
+
 	bool moveHero(ObjectInstanceID hid, int3 dst, EMovementMode movementMode) override
 	{
 		return false;

--- a/test/game/CGameStateTest.cpp
+++ b/test/game/CGameStateTest.cpp
@@ -142,9 +142,7 @@ public:
 		StartInfo si;
 		si.mapname = "anything";//does not matter, map service mocked
 		si.difficulty = 0;
-		si.mapfileChecksum = 0;
 		si.mode = EStartMode::NEW_GAME;
-		si.seedToBeUsed = 42;
 
 		std::unique_ptr<CMapHeader> header = mapService.loadMapHeader(ResourcePath(si.mapname));
 

--- a/test/mock/mock_IGameCallback.cpp
+++ b/test/mock/mock_IGameCallback.cpp
@@ -31,3 +31,8 @@ void GameCallbackMock::sendAndApply(CPackForClient * pack)
 {
 	upperCallback->apply(pack);
 }
+
+vstd::RNG & GameCallbackMock::getRandomGenerator()
+{
+	throw std::runtime_error("Not implemented!");
+}

--- a/test/mock/mock_IGameCallback.h
+++ b/test/mock/mock_IGameCallback.h
@@ -37,11 +37,15 @@ public:
 
 	void setObjPropertyValue(ObjectInstanceID objid, ObjProperty prop, int32_t value = 0) override {}
 	void setObjPropertyID(ObjectInstanceID objid, ObjProperty prop, ObjPropertyID identifier) override {}
+	void setBankObjectConfiguration(ObjectInstanceID objid, const BankConfig & configuration) override {}
+	void setRewardableObjectConfiguration(ObjectInstanceID mapObjectID, const Rewardable::Configuration & configuration) override {}
+	void setRewardableObjectConfiguration(ObjectInstanceID townInstanceID, BuildingID buildingID, const Rewardable::Configuration & configuration) override {}
+
 	void showInfoDialog(InfoWindow * iw) override {}
 
 	void changeSpells(const CGHeroInstance * hero, bool give, const std::set<SpellID> &spells) override {}
 	bool removeObject(const CGObjectInstance * obj, const PlayerColor & initiator) override {return false;}
-	void createObject(const int3 & visitablePosition, const PlayerColor & initiator, MapObjectID type, MapObjectSubID subtype) override {};
+	void createBoat(const int3 & visitablePosition, BoatId type, PlayerColor initiator) override {}
 	void setOwner(const CGObjectInstance * objid, PlayerColor owner) override {}
 	void giveExperience(const CGHeroInstance * hero, TExpType val) override {}
 	void changePrimSkill(const CGHeroInstance * hero, PrimarySkill which, si64 val, bool abs=false) override {}

--- a/test/mock/mock_IGameCallback.h
+++ b/test/mock/mock_IGameCallback.h
@@ -93,6 +93,8 @@ public:
 	///useful callback methods
 	void sendAndApply(CPackForClient * pack) override;
 
+	vstd::RNG & getRandomGenerator() override;
+
 #if SCRIPTING_ENABLED
 	MOCK_CONST_METHOD0(getGlobalContextPool, scripting::Pool *());
 #endif

--- a/test/mock/mock_vstd_RNG.h
+++ b/test/mock/mock_vstd_RNG.h
@@ -21,6 +21,13 @@ public:
 	MOCK_METHOD2(nextInt, int(int lower, int upper));
 	MOCK_METHOD2(nextInt64, int64_t(int64_t lower, int64_t upper));
 	MOCK_METHOD2(nextDouble, double(double lower, double upper));
+
+	MOCK_METHOD1(nextInt, int(int upper));
+	MOCK_METHOD1(nextInt64, int64_t(int64_t upper));
+	MOCK_METHOD1(nextDouble, double(double upper));
+
+	MOCK_METHOD0(nextInt, int());
+	MOCK_METHOD2(nextBinomialInt, int(int coinsCount, double coinChance));
 };
 
 }

--- a/test/mock/mock_vstd_RNG.h
+++ b/test/mock/mock_vstd_RNG.h
@@ -18,8 +18,9 @@ namespace vstd
 class RNGMock : public RNG
 {
 public:
-	MOCK_METHOD2(getInt64Range, TRandI64(int64_t, int64_t));
-	MOCK_METHOD2(getDoubleRange, TRand(double, double));
+	MOCK_METHOD2(nextInt, int(int lower, int upper));
+	MOCK_METHOD2(nextInt64, int64_t(int64_t lower, int64_t upper));
+	MOCK_METHOD2(nextDouble, double(double lower, double upper));
 };
 
 }

--- a/test/spells/effects/EffectFixture.cpp
+++ b/test/spells/effects/EffectFixture.cpp
@@ -101,27 +101,21 @@ void EffectFixture::setUp()
 	ON_CALL(serverMock, apply(Matcher<CatapultAttack *>(_))).WillByDefault(Invoke(battleFake.get(),  &battle::BattleFake::accept<CatapultAttack>));
 }
 
-static vstd::TRandI64 getInt64RangeDef(int64_t lower, int64_t upper)
+static int64_t getInt64Range(int64_t lower, int64_t upper)
 {
-	return [=]()->int64_t
-	{
-		return (lower + upper)/2;
-	};
+	return (lower + upper)/2;
 }
 
-static vstd::TRand getDoubleRangeDef(double lower, double upper)
+static double getDoubleRange(double lower, double upper)
 {
-	return [=]()->double
-	{
-		return (lower + upper)/2;
-	};
+	return (lower + upper)/2;
 }
 
 void EffectFixture::setupDefaultRNG()
 {
 	EXPECT_CALL(serverMock, getRNG()).Times(AtLeast(0));
-	EXPECT_CALL(rngMock, getInt64Range(_,_)).WillRepeatedly(Invoke(&getInt64RangeDef));
-	EXPECT_CALL(rngMock, getDoubleRange(_,_)).WillRepeatedly(Invoke(&getDoubleRangeDef));
+	EXPECT_CALL(rngMock, nextInt64(_,_)).WillRepeatedly(Invoke(&getInt64Range));
+	EXPECT_CALL(rngMock, nextDouble(_,_)).WillRepeatedly(Invoke(&getDoubleRange));
 }
 
 }


### PR DESCRIPTION
While this is only potential problem, it may still lead to extremely hard to track issues if client and server end up with different states.

Standard has no guarantees that random numbers generators (or distributions) produce identical results on every platform. In addition we also serialize generators to string, which is very likely to have different results.

To solve this, all random number rolls that involve game mechanics must be performed only on server. This is already *mostly* the case, but there are some exceptions that are not immediately obvious. This PR should track down such cases & resolve them

Changes in this PR:
- Library and server now primary use vstd::RNG interface instead of direct access to CRandomGenerator class
- Simplified logic of CRandomGenerator and moved some its methods to vstd::RNG interface
- CGameState no longer has own random number generator, instead it uses generator provided by server. Attempt to use it on client will throw an exception.
- Removed mostly unused seeds from StartInfo. Game seed is now only known to server.

TODO:
- [x] Make rumors generation server-sided
- [x] Make rewardable objects re-randomization server-sided
- [x] Make creature banks reset server-sided
- [x] Look for any other cases of rng access from client