### PR TITLE
[1.6] Render refactor

### DIFF
--- a/Mods/vcmi/Sprites/battle/rangeHighlights/rangeHighlightsGreen.json
+++ b/Mods/vcmi/Sprites/battle/rangeHighlights/rangeHighlightsGreen.json
@@ -2,33 +2,33 @@
 	"basepath" : "battle/rangeHighlights/green/",
 	"images" :
 	[
-		{ "frame" :  0, "file" : "empty.png"},						// 000001 -> 00 empty frame
+		{ "frame" :  0, "file" : "empty.png"},                                                              // 000001 -> 00 empty frame
 			
 		// load single edges
-		{ "frame" :  1, "file" : "topLeft.png"},                    //000001 -> 01 topLeft
-		{ "frame" :  2, "file" : "topLeft.png"},                    //000010 -> 02 topRight
-		{ "frame" :  3, "file" : "left.png"},                       //000100 -> 04 right
-		{ "frame" :  4, "file" : "topLeft.png"},                    //001000 -> 08 bottomRight
-		{ "frame" :  5, "file" : "topLeft.png"},                    //010000 -> 16 bottomLeft
-		{ "frame" :  6, "file" : "left.png"},                       //100000 -> 32 left
+		{ "frame" :  1, "file" : "topLeft.png"},                                                            //000001 -> 01 topLeft
+		{ "frame" :  2, "file" : "topLeft.png", "verticalFlip" : true },                                    //000010 -> 02 topRight
+		{ "frame" :  3, "file" : "left.png",    "verticalFlip" : true },                                    //000100 -> 04 right
+		{ "frame" :  4, "file" : "topLeft.png", "verticalFlip" : true, "horizontalFlip" : true },           //001000 -> 08 bottomRight
+		{ "frame" :  5, "file" : "topLeft.png", "horizontalFlip" : true },                                  //010000 -> 16 bottomLeft
+		{ "frame" :  6, "file" : "left.png"},                                                               //100000 -> 32 left
 		
 		// load double edges
-		{ "frame" :  7, "file" : "top.png"},                        //000011 -> 03 top
-		{ "frame" :  8, "file" : "top.png"},                        //011000 -> 24 bottom
-		{ "frame" :  9, "file" : "topLeftHalfCorner.png"},          //000110 -> 06 topRightHalfCorner
-		{ "frame" : 10, "file" : "topLeftHalfCorner.png"},          //001100 -> 12 bottomRightHalfCorner
-		{ "frame" : 11, "file" : "topLeftHalfCorner.png"},          //110000 -> 48 bottomLeftHalfCorner
-		{ "frame" : 12, "file" : "topLeftHalfCorner.png"},          //100001 -> 33 topLeftHalfCorner
+		{ "frame" :  7, "file" : "top.png"},                                                                //000011 -> 03 top
+		{ "frame" :  8, "file" : "top.png",               "horizontalFlip" : true },                        //011000 -> 24 bottom
+		{ "frame" :  9, "file" : "topLeftHalfCorner.png", "verticalFlip" : true },                          //000110 -> 06 topRightHalfCorner
+		{ "frame" : 10, "file" : "topLeftHalfCorner.png", "verticalFlip" : true, "horizontalFlip" : true }, //001100 -> 12 bottomRightHalfCorner
+		{ "frame" : 11, "file" : "topLeftHalfCorner.png", "horizontalFlip" : true },                        //110000 -> 48 bottomLeftHalfCorner
+		{ "frame" : 12, "file" : "topLeftHalfCorner.png"},                                                  //100001 -> 33 topLeftHalfCorner
 		
 		// load halves
-		{ "frame" : 13, "file" : "leftHalf.png"},                   //001110 -> 14 rightHalf
-		{ "frame" : 14, "file" : "leftHalf.png"},                   //110001 -> 49 leftHalf
+		{ "frame" : 13, "file" : "leftHalf.png", "verticalFlip" : true},                                    //001110 -> 14 rightHalf
+		{ "frame" : 14, "file" : "leftHalf.png"},                                                           //110001 -> 49 leftHalf
 		
 		// load corners
-		{ "frame" : 15, "file" : "topLeftCorner.png"},              //000111 -> 07 topRightCorner
-		{ "frame" : 16, "file" : "topLeftCorner.png"},              //011100 -> 28 bottomRightCorner
-		{ "frame" : 17, "file" : "topLeftCorner.png"},              //111000 -> 56 bottomLeftCorner
-		{ "frame" : 18, "file" : "topLeftCorner.png"}               //100011 -> 35 topLeftCorner
+		{ "frame" : 15, "file" : "topLeftCorner.png", "verticalFlip" : true },                              //000111 -> 07 topRightCorner
+		{ "frame" : 16, "file" : "topLeftCorner.png", "verticalFlip" : true, "horizontalFlip" : true },     //011100 -> 28 bottomRightCorner
+		{ "frame" : 17, "file" : "topLeftCorner.png", "horizontalFlip" : true },                            //111000 -> 56 bottomLeftCorner
+		{ "frame" : 18, "file" : "topLeftCorner.png"}                                                       //100011 -> 35 topLeftCorner
 	]
 }
 

--- a/Mods/vcmi/Sprites/battle/rangeHighlights/rangeHighlightsRed.json
+++ b/Mods/vcmi/Sprites/battle/rangeHighlights/rangeHighlightsRed.json
@@ -2,33 +2,33 @@
 	"basepath" : "battle/rangeHighlights/red/",
 	"images" :
 	[
-		{ "frame" :  0, "file" : "empty.png"},						// 000001 -> 00 empty frame
+		{ "frame" :  0, "file" : "empty.png"},                                                              // 000001 -> 00 empty frame
 			
 		// load single edges
-		{ "frame" :  1, "file" : "topLeft.png"},                    //000001 -> 01 topLeft
-		{ "frame" :  2, "file" : "topLeft.png"},                    //000010 -> 02 topRight
-		{ "frame" :  3, "file" : "left.png"},                       //000100 -> 04 right
-		{ "frame" :  4, "file" : "topLeft.png"},                    //001000 -> 08 bottomRight
-		{ "frame" :  5, "file" : "topLeft.png"},                    //010000 -> 16 bottomLeft
-		{ "frame" :  6, "file" : "left.png"},                       //100000 -> 32 left
+		{ "frame" :  1, "file" : "topLeft.png"},                                                            //000001 -> 01 topLeft
+		{ "frame" :  2, "file" : "topLeft.png", "verticalFlip" : true },                                    //000010 -> 02 topRight
+		{ "frame" :  3, "file" : "left.png",    "verticalFlip" : true },                                    //000100 -> 04 right
+		{ "frame" :  4, "file" : "topLeft.png", "verticalFlip" : true, "horizontalFlip" : true },           //001000 -> 08 bottomRight
+		{ "frame" :  5, "file" : "topLeft.png", "horizontalFlip" : true },                                  //010000 -> 16 bottomLeft
+		{ "frame" :  6, "file" : "left.png"},                                                               //100000 -> 32 left
 		
 		// load double edges
-		{ "frame" :  7, "file" : "top.png"},                        //000011 -> 03 top
-		{ "frame" :  8, "file" : "top.png"},                        //011000 -> 24 bottom
-		{ "frame" :  9, "file" : "topLeftHalfCorner.png"},          //000110 -> 06 topRightHalfCorner
-		{ "frame" : 10, "file" : "topLeftHalfCorner.png"},          //001100 -> 12 bottomRightHalfCorner
-		{ "frame" : 11, "file" : "topLeftHalfCorner.png"},          //110000 -> 48 bottomLeftHalfCorner
-		{ "frame" : 12, "file" : "topLeftHalfCorner.png"},          //100001 -> 33 topLeftHalfCorner
+		{ "frame" :  7, "file" : "top.png"},                                                                //000011 -> 03 top
+		{ "frame" :  8, "file" : "top.png",               "horizontalFlip" : true },                        //011000 -> 24 bottom
+		{ "frame" :  9, "file" : "topLeftHalfCorner.png", "verticalFlip" : true },                          //000110 -> 06 topRightHalfCorner
+		{ "frame" : 10, "file" : "topLeftHalfCorner.png", "verticalFlip" : true, "horizontalFlip" : true }, //001100 -> 12 bottomRightHalfCorner
+		{ "frame" : 11, "file" : "topLeftHalfCorner.png", "horizontalFlip" : true },                        //110000 -> 48 bottomLeftHalfCorner
+		{ "frame" : 12, "file" : "topLeftHalfCorner.png"},                                                  //100001 -> 33 topLeftHalfCorner
 		
 		// load halves
-		{ "frame" : 13, "file" : "leftHalf.png"},                   //001110 -> 14 rightHalf
-		{ "frame" : 14, "file" : "leftHalf.png"},                   //110001 -> 49 leftHalf
+		{ "frame" : 13, "file" : "leftHalf.png", "verticalFlip" : true},                                    //001110 -> 14 rightHalf
+		{ "frame" : 14, "file" : "leftHalf.png"},                                                           //110001 -> 49 leftHalf
 		
 		// load corners
-		{ "frame" : 15, "file" : "topLeftCorner.png"},              //000111 -> 07 topRightCorner
-		{ "frame" : 16, "file" : "topLeftCorner.png"},              //011100 -> 28 bottomRightCorner
-		{ "frame" : 17, "file" : "topLeftCorner.png"},              //111000 -> 56 bottomLeftCorner
-		{ "frame" : 18, "file" : "topLeftCorner.png"}               //100011 -> 35 topLeftCorner
+		{ "frame" : 15, "file" : "topLeftCorner.png", "verticalFlip" : true },                              //000111 -> 07 topRightCorner
+		{ "frame" : 16, "file" : "topLeftCorner.png", "verticalFlip" : true, "horizontalFlip" : true },     //011100 -> 28 bottomRightCorner
+		{ "frame" : 17, "file" : "topLeftCorner.png", "horizontalFlip" : true },                            //111000 -> 56 bottomLeftCorner
+		{ "frame" : 18, "file" : "topLeftCorner.png"}                                                       //100011 -> 35 topLeftCorner
 	]
 }
 

--- a/client/CMT.cpp
+++ b/client/CMT.cpp
@@ -28,6 +28,7 @@
 #include "windows/CMessage.h"
 #include "windows/InfoWindows.h"
 #include "render/IScreenHandler.h"
+#include "render/IRenderHandler.h"
 #include "render/Graphics.h"
 
 #include "../lib/CConfigHandler.h"
@@ -347,6 +348,7 @@ int main(int argc, char * argv[])
 	{
 		pomtime.getDiff();
 		graphics = new Graphics(); // should be before curh
+		GH.renderHandler().onLibraryLoadingFinished(CGI);
 
 		CCS->curh = new CursorHandler();
 		logGlobal->info("Screen handler: %d ms", pomtime.getDiff());

--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -88,6 +88,7 @@ set(client_SRCS
 	render/Colors.cpp
 	render/Graphics.cpp
 	render/IFont.cpp
+	render/ImageLocator.cpp
 
 	renderSDL/CBitmapFont.cpp
 	renderSDL/CBitmapHanFont.cpp
@@ -287,6 +288,7 @@ set(client_HEADERS
 	render/IFont.h
 	render/IImage.h
 	render/IImageLoader.h
+	render/ImageLocator.h
 	render/IRenderHandler.h
 	render/IScreenHandler.h
 

--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -1145,7 +1145,7 @@ void CPlayerInterface::showMapObjectSelectDialog(QueryID askID, const Component 
 		const CGTownInstance * t = dynamic_cast<const CGTownInstance *>(cb->getObj(obj));
 		if(t)
 		{
-			auto image = GH.renderHandler().loadImage(AnimationPath::builtin("ITPA"), t->town->clientInfo.icons[t->hasFort()][false] + 2, 0);
+			auto image = GH.renderHandler().loadImage(AnimationPath::builtin("ITPA"), t->town->clientInfo.icons[t->hasFort()][false] + 2, 0, EImageBlitMode::OPAQUE);
 			image->scaleFast(Point(35, 23));
 			images.push_back(image);
 		}

--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -442,18 +442,20 @@ void CPlayerInterface::heroPrimarySkillChanged(const CGHeroInstance * hero, Prim
 	EVENT_HANDLER_CALLED_BY_CLIENT;
 	if (which == PrimarySkill::EXPERIENCE)
 	{
-		for(auto ctw : GH.windows().findWindows<CMarketWindow>())
-			ctw->updateHero();
+		for(auto ctw : GH.windows().findWindows<IMarketHolder>())
+			ctw->updateExperience();
 	}
 	else
+	{
 		adventureInt->onHeroChanged(hero);
+	}
 }
 
 void CPlayerInterface::heroSecondarySkillChanged(const CGHeroInstance * hero, int which, int val)
 {
 	EVENT_HANDLER_CALLED_BY_CLIENT;
-	for (auto cuw : GH.windows().findWindows<CUniversityWindow>())
-		cuw->redraw();
+	for (auto cuw : GH.windows().findWindows<IMarketHolder>())
+		cuw->updateSecondarySkills();
 }
 
 void CPlayerInterface::heroManaPointsChanged(const CGHeroInstance * hero)
@@ -472,8 +474,8 @@ void CPlayerInterface::heroMovePointsChanged(const CGHeroInstance * hero)
 void CPlayerInterface::receivedResource()
 {
 	EVENT_HANDLER_CALLED_BY_CLIENT;
-	for (auto mw : GH.windows().findWindows<CMarketWindow>())
-		mw->updateResource();
+	for (auto mw : GH.windows().findWindows<IMarketHolder>())
+		mw->updateResources();
 
 	GH.windows().totalRedraw();
 }
@@ -1675,7 +1677,7 @@ void CPlayerInterface::showHillFortWindow(const CGObjectInstance *object, const 
 void CPlayerInterface::availableArtifactsChanged(const CGBlackMarket * bm)
 {
 	EVENT_HANDLER_CALLED_BY_CLIENT;
-	for (auto cmw : GH.windows().findWindows<CMarketWindow>())
+	for (auto cmw : GH.windows().findWindows<IMarketHolder>())
 		cmw->updateArtifacts();
 }
 

--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -1143,9 +1143,9 @@ void CPlayerInterface::showMapObjectSelectDialog(QueryID askID, const Component 
 		const CGTownInstance * t = dynamic_cast<const CGTownInstance *>(cb->getObj(obj));
 		if(t)
 		{
-			std::shared_ptr<CAnimation> a = GH.renderHandler().loadAnimation(AnimationPath::builtin("ITPA"));
-			a->preload();
-			images.push_back(a->getImage(t->town->clientInfo.icons[t->hasFort()][false] + 2)->scaleFast(Point(35, 23)));
+			auto image = GH.renderHandler().loadImage(AnimationPath::builtin("ITPA"), t->town->clientInfo.icons[t->hasFort()][false] + 2, 0);
+			image->scaleFast(Point(35, 23));
+			images.push_back(image);
 		}
 	}
 

--- a/client/ClientCommandManager.cpp
+++ b/client/ClientCommandManager.cpp
@@ -388,7 +388,7 @@ void ClientCommandManager::handleDef2bmpCommand(std::istringstream& singleWordBu
 {
 	std::string URI;
 	singleWordBuffer >> URI;
-	auto anim = GH.renderHandler().loadAnimation(AnimationPath::builtin(URI));
+	auto anim = GH.renderHandler().loadAnimation(AnimationPath::builtin(URI), EImageBlitMode::ALPHA);
 	anim->exportBitmaps(VCMIDirs::get().userExtractedPath());
 }
 

--- a/client/ClientCommandManager.cpp
+++ b/client/ClientCommandManager.cpp
@@ -389,7 +389,6 @@ void ClientCommandManager::handleDef2bmpCommand(std::istringstream& singleWordBu
 	std::string URI;
 	singleWordBuffer >> URI;
 	auto anim = GH.renderHandler().loadAnimation(AnimationPath::builtin(URI));
-	anim->preload();
 	anim->exportBitmaps(VCMIDirs::get().userExtractedPath());
 }
 

--- a/client/adventureMap/AdventureMapInterface.cpp
+++ b/client/adventureMap/AdventureMapInterface.cpp
@@ -399,7 +399,7 @@ void AdventureMapInterface::onCurrentPlayerChanged(PlayerColor playerID)
 		return;
 
 	currentPlayerID = playerID;
-	widget->setPlayer(playerID);
+	widget->setPlayerColor(playerID);
 }
 
 void AdventureMapInterface::onPlayerTurnStarted(PlayerColor playerID)
@@ -914,7 +914,7 @@ void AdventureMapInterface::onScreenResize()
 
 	widget = std::make_shared<AdventureMapWidget>(shortcuts);
 	widget->getMapView()->onViewMapActivated();
-	widget->setPlayer(currentPlayerID);
+	widget->setPlayerColor(currentPlayerID);
 	widget->updateActiveState();
 	widget->getMinimap()->update();
 	widget->getInfoBar()->showSelection();

--- a/client/adventureMap/AdventureMapInterface.cpp
+++ b/client/adventureMap/AdventureMapInterface.cpp
@@ -31,6 +31,7 @@
 #include "../gui/Shortcut.h"
 #include "../gui/WindowHandler.h"
 #include "../render/Canvas.h"
+#include "../render/IImage.h"
 #include "../render/IRenderHandler.h"
 #include "../CMT.h"
 #include "../PlayerLocalState.h"
@@ -178,7 +179,7 @@ void AdventureMapInterface::dim(Canvas & to)
 		{
 			if(!std::dynamic_pointer_cast<AdventureMapInterface>(window) && std::dynamic_pointer_cast<CIntObject>(window) && isBigWindow(window))
 			{
-				to.fillTexture(GH.renderHandler().loadImage(ImagePath::builtin("DiBoxBck")));
+				to.fillTexture(GH.renderHandler().loadImage(ImagePath::builtin("DiBoxBck"), EImageBlitMode::OPAQUE));
 				return;
 			}
 		}

--- a/client/adventureMap/AdventureMapInterface.h
+++ b/client/adventureMap/AdventureMapInterface.h
@@ -31,7 +31,6 @@ class CAnimImage;
 class CGStatusBar;
 class AdventureMapWidget;
 class AdventureMapShortcuts;
-class CAnimation;
 class MapView;
 class CResDataBar;
 class CHeroList;

--- a/client/adventureMap/AdventureMapWidget.cpp
+++ b/client/adventureMap/AdventureMapWidget.cpp
@@ -335,7 +335,7 @@ std::shared_ptr<CInfoBar> AdventureMapWidget::getInfoBar()
 	return infoBar;
 }
 
-void AdventureMapWidget::setPlayer(const PlayerColor & player)
+void AdventureMapWidget::setPlayerColor(const PlayerColor & player)
 {
 	setPlayerChildren(this, player);
 }
@@ -354,16 +354,16 @@ void AdventureMapWidget::setPlayerChildren(CIntObject * widget, const PlayerColo
 			button->setPlayerColor(player);
 
 		if(resDataBar)
-			resDataBar->colorize(player);
+			resDataBar->setPlayerColor(player);
 
 		if(icon)
-			icon->setPlayer(player);
+			icon->setPlayerColor(player);
 
 		if(container)
 			setPlayerChildren(container, player);
 
 		if (texture)
-			texture->playerColored(player);
+			texture->setPlayerColor(player);
 	}
 
 	redraw();
@@ -378,7 +378,7 @@ CAdventureMapIcon::CAdventureMapIcon(const Point & position, const AnimationPath
 	image = std::make_shared<CAnimImage>(animation, index);
 }
 
-void CAdventureMapIcon::setPlayer(const PlayerColor & player)
+void CAdventureMapIcon::setPlayerColor(const PlayerColor & player)
 {
 	image->setFrame(index + player.getNum() * iconsPerPlayer);
 }

--- a/client/adventureMap/AdventureMapWidget.cpp
+++ b/client/adventureMap/AdventureMapWidget.cpp
@@ -20,7 +20,6 @@
 #include "../gui/CGuiHandler.h"
 #include "../gui/Shortcut.h"
 #include "../mapView/MapView.h"
-#include "../render/CAnimation.h"
 #include "../render/IImage.h"
 #include "../render/IRenderHandler.h"
 #include "../widgets/Buttons.h"
@@ -125,26 +124,6 @@ Rect AdventureMapWidget::readArea(const JsonNode & source, const Rect & bounding
 	return Rect(topLeft + boundingBox.topLeft(), dimensions);
 }
 
-std::shared_ptr<IImage> AdventureMapWidget::loadImage(const JsonNode & name)
-{
-	ImagePath resource = ImagePath::fromJson(name);
-
-	if(images.count(resource) == 0)
-		images[resource] = GH.renderHandler().loadImage(resource);
-
-	return images[resource];
-}
-
-std::shared_ptr<CAnimation> AdventureMapWidget::loadAnimation(const JsonNode & name)
-{
-	AnimationPath resource = AnimationPath::fromJson(name);
-
-	if(animations.count(resource) == 0)
-		animations[resource] = GH.renderHandler().loadAnimation(resource);
-
-	return animations[resource];
-}
-
 std::shared_ptr<CIntObject> AdventureMapWidget::buildInfobox(const JsonNode & input)
 {
 	Rect area = readTargetArea(input["area"]);
@@ -157,7 +136,7 @@ std::shared_ptr<CIntObject> AdventureMapWidget::buildMapImage(const JsonNode & i
 	Rect targetArea = readTargetArea(input["area"]);
 	Rect sourceArea = readSourceArea(input["sourceArea"], input["area"]);
 
-	return std::make_shared<CFilledTexture>(loadImage(input["image"]), targetArea, sourceArea);
+	return std::make_shared<CFilledTexture>(ImagePath::fromJson(input["image"]), targetArea, sourceArea);
 }
 
 std::shared_ptr<CIntObject> AdventureMapWidget::buildMapButton(const JsonNode & input)
@@ -257,7 +236,7 @@ std::shared_ptr<CIntObject> AdventureMapWidget::buildMapIcon(const JsonNode & in
 	size_t index = input["index"].Integer();
 	size_t perPlayer = input["perPlayer"].Integer();
 
-	return std::make_shared<CAdventureMapIcon>(area.topLeft(), loadAnimation(input["image"]), index, perPlayer);
+	return std::make_shared<CAdventureMapIcon>(area.topLeft(), AnimationPath::fromJson(input["image"]), index, perPlayer);
 }
 
 std::shared_ptr<CIntObject> AdventureMapWidget::buildMapTownList(const JsonNode & input)
@@ -387,16 +366,10 @@ void AdventureMapWidget::setPlayerChildren(CIntObject * widget, const PlayerColo
 			texture->playerColored(player);
 	}
 
-	for(const auto & entry : playerColorerImages)
-	{
-		if(images.count(entry))
-			images[entry]->playerColored(player);
-	}
-
 	redraw();
 }
 
-CAdventureMapIcon::CAdventureMapIcon(const Point & position, std::shared_ptr<CAnimation> animation, size_t index, size_t iconsPerPlayer)
+CAdventureMapIcon::CAdventureMapIcon(const Point & position, const AnimationPath & animation, size_t index, size_t iconsPerPlayer)
 	: index(index)
 	, iconsPerPlayer(iconsPerPlayer)
 {

--- a/client/adventureMap/AdventureMapWidget.cpp
+++ b/client/adventureMap/AdventureMapWidget.cpp
@@ -59,7 +59,7 @@ AdventureMapWidget::AdventureMapWidget( std::shared_ptr<AdventureMapShortcuts> s
 	const JsonNode config(JsonPath::builtin("config/widgets/adventureMap.json"));
 
 	for(const auto & entry : config["options"]["imagesPlayerColored"].Vector())
-		playerColorerImages.push_back(ImagePath::fromJson(entry));
+		playerColoredImages.push_back(ImagePath::fromJson(entry));
 
 	build(config);
 	addUsedEvents(KEYBOARD);
@@ -135,8 +135,12 @@ std::shared_ptr<CIntObject> AdventureMapWidget::buildMapImage(const JsonNode & i
 {
 	Rect targetArea = readTargetArea(input["area"]);
 	Rect sourceArea = readSourceArea(input["sourceArea"], input["area"]);
+	ImagePath path = ImagePath::fromJson(input["image"]);
 
-	return std::make_shared<CFilledTexture>(ImagePath::fromJson(input["image"]), targetArea, sourceArea);
+	if (vstd::contains(playerColoredImages, path))
+		return std::make_shared<FilledTexturePlayerIndexed>(path, targetArea, sourceArea);
+	else
+		return std::make_shared<CFilledTexture>(path, targetArea, sourceArea);
 }
 
 std::shared_ptr<CIntObject> AdventureMapWidget::buildMapButton(const JsonNode & input)
@@ -348,7 +352,8 @@ void AdventureMapWidget::setPlayerChildren(CIntObject * widget, const PlayerColo
 		auto icon = dynamic_cast<CAdventureMapIcon *>(entry);
 		auto button = dynamic_cast<CButton *>(entry);
 		auto resDataBar = dynamic_cast<CResDataBar *>(entry);
-		auto texture = dynamic_cast<FilledTexturePlayerColored *>(entry);
+		auto textureColored = dynamic_cast<FilledTexturePlayerColored *>(entry);
+		auto textureIndexed = dynamic_cast<FilledTexturePlayerIndexed *>(entry);
 
 		if(button)
 			button->setPlayerColor(player);
@@ -362,8 +367,11 @@ void AdventureMapWidget::setPlayerChildren(CIntObject * widget, const PlayerColo
 		if(container)
 			setPlayerChildren(container, player);
 
-		if (texture)
-			texture->setPlayerColor(player);
+		if (textureColored)
+			textureColored->setPlayerColor(player);
+
+		if (textureIndexed)
+			textureIndexed->setPlayerColor(player);
 	}
 
 	redraw();

--- a/client/adventureMap/AdventureMapWidget.h
+++ b/client/adventureMap/AdventureMapWidget.h
@@ -28,7 +28,7 @@ class AdventureMapWidget : public InterfaceObjectConfigurable
 	std::vector<Rect> subwidgetSizes;
 
 	/// list of images on which player-colored palette will be applied
-	std::vector<ImagePath> playerColorerImages;
+	std::vector<ImagePath> playerColoredImages;
 
 	/// Widgets that require access from adventure map
 	std::shared_ptr<CHeroList> heroList;

--- a/client/adventureMap/AdventureMapWidget.h
+++ b/client/adventureMap/AdventureMapWidget.h
@@ -56,7 +56,6 @@ class AdventureMapWidget : public InterfaceObjectConfigurable
 	std::shared_ptr<CIntObject> buildStatusBar(const JsonNode & input);
 	std::shared_ptr<CIntObject> buildTexturePlayerColored(const JsonNode &);
 
-
 	void setPlayerChildren(CIntObject * widget, const PlayerColor & player);
 	void updateActiveStateChildden(CIntObject * widget);
 public:
@@ -68,7 +67,7 @@ public:
 	std::shared_ptr<MapView> getMapView();
 	std::shared_ptr<CInfoBar> getInfoBar();
 
-	void setPlayer(const PlayerColor & player);
+	void setPlayerColor(const PlayerColor & player);
 
 	void onMapViewMoved(const Rect & visibleArea, int mapLevel);
 	void updateActiveState();
@@ -98,5 +97,5 @@ class CAdventureMapIcon : public CIntObject
 public:
 	CAdventureMapIcon(const Point & position, const AnimationPath & image, size_t index, size_t iconsPerPlayer);
 
-	void setPlayer(const PlayerColor & player);
+	void setPlayerColor(const PlayerColor & player);
 };

--- a/client/adventureMap/AdventureMapWidget.h
+++ b/client/adventureMap/AdventureMapWidget.h
@@ -11,7 +11,6 @@
 
 #include "../gui/InterfaceObjectConfigurable.h"
 
-class CAnimation;
 class CHeroList;
 class CTownList;
 class CMinimap;
@@ -31,10 +30,6 @@ class AdventureMapWidget : public InterfaceObjectConfigurable
 	/// list of images on which player-colored palette will be applied
 	std::vector<ImagePath> playerColorerImages;
 
-	/// list of named images shared between widgets
-	std::map<ImagePath, std::shared_ptr<IImage>> images;
-	std::map<AnimationPath, std::shared_ptr<CAnimation>> animations;
-
 	/// Widgets that require access from adventure map
 	std::shared_ptr<CHeroList> heroList;
 	std::shared_ptr<CTownList> townList;
@@ -47,9 +42,6 @@ class AdventureMapWidget : public InterfaceObjectConfigurable
 	Rect readTargetArea(const JsonNode & source);
 	Rect readSourceArea(const JsonNode & source, const JsonNode & sourceCommon);
 	Rect readArea(const JsonNode & source, const Rect & boundingBox);
-
-	std::shared_ptr<IImage> loadImage(const JsonNode & name);
-	std::shared_ptr<CAnimation> loadAnimation(const JsonNode & name);
 
 	std::shared_ptr<CIntObject> buildInfobox(const JsonNode & input);
 	std::shared_ptr<CIntObject> buildMapImage(const JsonNode & input);
@@ -104,7 +96,7 @@ class CAdventureMapIcon : public CIntObject
 	size_t index;
 	size_t iconsPerPlayer;
 public:
-	CAdventureMapIcon(const Point & position, std::shared_ptr<CAnimation> image, size_t index, size_t iconsPerPlayer);
+	CAdventureMapIcon(const Point & position, const AnimationPath & image, size_t index, size_t iconsPerPlayer);
 
 	void setPlayer(const PlayerColor & player);
 };

--- a/client/adventureMap/CResDataBar.cpp
+++ b/client/adventureMap/CResDataBar.cpp
@@ -31,7 +31,7 @@ CResDataBar::CResDataBar(const ImagePath & imageName, const Point & position)
 
 	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
 	background = std::make_shared<CPicture>(imageName, 0, 0);
-	background->colorize(LOCPLINT->playerID);
+	background->setPlayerColor(LOCPLINT->playerID);
 
 	pos.w = background->pos.w;
 	pos.h = background->pos.h;
@@ -84,7 +84,7 @@ void CResDataBar::showAll(Canvas & to)
 		to.drawText(pos.topLeft() + *datePosition, FONT_SMALL, Colors::WHITE, ETextAlignment::TOPLEFT, buildDateString());
 }
 
-void CResDataBar::colorize(PlayerColor player)
+void CResDataBar::setPlayerColor(PlayerColor player)
 {
-	background->colorize(player);
+	background->setPlayerColor(player);
 }

--- a/client/adventureMap/CResDataBar.h
+++ b/client/adventureMap/CResDataBar.h
@@ -34,7 +34,7 @@ public:
 	void setDatePosition(const Point & position);
 	void setResourcePosition(const GameResID & resource, const Point & position);
 
-	void colorize(PlayerColor player);
+	void setPlayerColor(PlayerColor player);
 	void showAll(Canvas & to) override;
 };
 

--- a/client/battle/BattleAnimationClasses.cpp
+++ b/client/battle/BattleAnimationClasses.cpp
@@ -926,8 +926,6 @@ EffectAnimation::EffectAnimation(BattleInterface & owner, const AnimationPath & 
 
 bool EffectAnimation::init()
 {
-	animation->preload();
-
 	auto first = animation->getImage(0, 0, true);
 	if(!first)
 	{

--- a/client/battle/BattleAnimationClasses.cpp
+++ b/client/battle/BattleAnimationClasses.cpp
@@ -24,6 +24,7 @@
 #include "../gui/CursorHandler.h"
 #include "../gui/CGuiHandler.h"
 #include "../media/ISoundPlayer.h"
+#include "../render/CAnimation.h"
 #include "../render/IRenderHandler.h"
 
 #include "../../CCallback.h"

--- a/client/battle/BattleAnimationClasses.cpp
+++ b/client/battle/BattleAnimationClasses.cpp
@@ -883,7 +883,7 @@ uint32_t CastAnimation::getAttackClimaxFrame() const
 
 EffectAnimation::EffectAnimation(BattleInterface & owner, const AnimationPath & animationName, int effects, bool reversed):
 	BattleAnimation(owner),
-	animation(GH.renderHandler().loadAnimation(animationName)),
+	animation(GH.renderHandler().loadAnimation(animationName, EImageBlitMode::ALPHA)),
 	effectFlags(effects),
 	effectFinished(false),
 	reversed(reversed)

--- a/client/battle/BattleFieldController.cpp
+++ b/client/battle/BattleFieldController.cpp
@@ -123,17 +123,17 @@ BattleFieldController::BattleFieldController(BattleInterface & owner):
 
 	//preparing cells and hexes
 	cellBorder = GH.renderHandler().loadImage(ImagePath::builtin("CCELLGRD.BMP"), EImageBlitMode::COLORKEY);
-	cellShade = GH.renderHandler().loadImage(ImagePath::builtin("CCELLSHD.BMP"));
+	cellShade = GH.renderHandler().loadImage(ImagePath::builtin("CCELLSHD.BMP"), EImageBlitMode::ALPHA);
 	cellUnitMovementHighlight = GH.renderHandler().loadImage(ImagePath::builtin("UnitMovementHighlight.PNG"), EImageBlitMode::COLORKEY);
 	cellUnitMaxMovementHighlight = GH.renderHandler().loadImage(ImagePath::builtin("UnitMaxMovementHighlight.PNG"), EImageBlitMode::COLORKEY);
 
-	attackCursors = GH.renderHandler().loadAnimation(AnimationPath::builtin("CRCOMBAT"));
-	spellCursors = GH.renderHandler().loadAnimation(AnimationPath::builtin("CRSPELL"));
+	attackCursors = GH.renderHandler().loadAnimation(AnimationPath::builtin("CRCOMBAT"), EImageBlitMode::COLORKEY);
+	spellCursors = GH.renderHandler().loadAnimation(AnimationPath::builtin("CRSPELL"), EImageBlitMode::COLORKEY);
 
 	initializeHexEdgeMaskToFrameIndex();
 
-	rangedFullDamageLimitImages = GH.renderHandler().loadAnimation(AnimationPath::builtin("battle/rangeHighlights/rangeHighlightsGreen.json"));
-	shootingRangeLimitImages = GH.renderHandler().loadAnimation(AnimationPath::builtin("battle/rangeHighlights/rangeHighlightsRed.json"));
+	rangedFullDamageLimitImages = GH.renderHandler().loadAnimation(AnimationPath::builtin("battle/rangeHighlights/rangeHighlightsGreen.json"), EImageBlitMode::COLORKEY);
+	shootingRangeLimitImages = GH.renderHandler().loadAnimation(AnimationPath::builtin("battle/rangeHighlights/rangeHighlightsRed.json"), EImageBlitMode::COLORKEY);
 
 	flipRangeLimitImagesIntoPositions(rangedFullDamageLimitImages);
 	flipRangeLimitImagesIntoPositions(shootingRangeLimitImages);

--- a/client/battle/BattleFieldController.cpp
+++ b/client/battle/BattleFieldController.cpp
@@ -82,39 +82,30 @@ namespace HexMasks
 	};
 }
 
-std::map<int, int> hexEdgeMaskToFrameIndex;
-
-// Maps HexEdgesMask to "Frame" indexes for range highlight images
-void initializeHexEdgeMaskToFrameIndex()
+static const std::map<int, int> hexEdgeMaskToFrameIndex =
 {
-	hexEdgeMaskToFrameIndex[HexMasks::empty] = 0;
-
-    hexEdgeMaskToFrameIndex[HexMasks::topLeft] = 1;
-    hexEdgeMaskToFrameIndex[HexMasks::topRight] = 2;
-    hexEdgeMaskToFrameIndex[HexMasks::right] = 3;
-    hexEdgeMaskToFrameIndex[HexMasks::bottomRight] = 4;
-    hexEdgeMaskToFrameIndex[HexMasks::bottomLeft] = 5;
-    hexEdgeMaskToFrameIndex[HexMasks::left] = 6;
-
-    hexEdgeMaskToFrameIndex[HexMasks::top] = 7;
-    hexEdgeMaskToFrameIndex[HexMasks::bottom] = 8;
-
-    hexEdgeMaskToFrameIndex[HexMasks::topRightHalfCorner] = 9;
-    hexEdgeMaskToFrameIndex[HexMasks::bottomRightHalfCorner] = 10;
-    hexEdgeMaskToFrameIndex[HexMasks::bottomLeftHalfCorner] = 11;
-    hexEdgeMaskToFrameIndex[HexMasks::topLeftHalfCorner] = 12;
-
-    hexEdgeMaskToFrameIndex[HexMasks::rightTopAndBottom] = 13;
-    hexEdgeMaskToFrameIndex[HexMasks::leftTopAndBottom] = 14;
-	
-    hexEdgeMaskToFrameIndex[HexMasks::rightHalf] = 13;
-    hexEdgeMaskToFrameIndex[HexMasks::leftHalf] = 14;
-
-    hexEdgeMaskToFrameIndex[HexMasks::topRightCorner] = 15;
-    hexEdgeMaskToFrameIndex[HexMasks::bottomRightCorner] = 16;
-    hexEdgeMaskToFrameIndex[HexMasks::bottomLeftCorner] = 17;
-    hexEdgeMaskToFrameIndex[HexMasks::topLeftCorner] = 18;
-}
+    { HexMasks::empty, 0 },
+    { HexMasks::topLeft, 1 },
+    { HexMasks::topRight, 2 },
+    { HexMasks::right, 3 },
+    { HexMasks::bottomRight, 4 },
+    { HexMasks::bottomLeft, 5 },
+    { HexMasks::left, 6 },
+    { HexMasks::top, 7 },
+    { HexMasks::bottom, 8 },
+    { HexMasks::topRightHalfCorner, 9 },
+    { HexMasks::bottomRightHalfCorner, 10 },
+    { HexMasks::bottomLeftHalfCorner, 11 },
+    { HexMasks::topLeftHalfCorner, 12 },
+    { HexMasks::rightTopAndBottom, 13 },
+    { HexMasks::leftTopAndBottom, 14 },
+    { HexMasks::rightHalf, 13 },
+    { HexMasks::leftHalf, 14 },
+    { HexMasks::topRightCorner, 15 },
+    { HexMasks::bottomRightCorner, 16 },
+    { HexMasks::bottomLeftCorner, 17 },
+    { HexMasks::topLeftCorner, 18 }
+};
 
 BattleFieldController::BattleFieldController(BattleInterface & owner):
 	owner(owner)
@@ -130,13 +121,8 @@ BattleFieldController::BattleFieldController(BattleInterface & owner):
 	attackCursors = GH.renderHandler().loadAnimation(AnimationPath::builtin("CRCOMBAT"), EImageBlitMode::COLORKEY);
 	spellCursors = GH.renderHandler().loadAnimation(AnimationPath::builtin("CRSPELL"), EImageBlitMode::COLORKEY);
 
-	initializeHexEdgeMaskToFrameIndex();
-
 	rangedFullDamageLimitImages = GH.renderHandler().loadAnimation(AnimationPath::builtin("battle/rangeHighlights/rangeHighlightsGreen.json"), EImageBlitMode::COLORKEY);
 	shootingRangeLimitImages = GH.renderHandler().loadAnimation(AnimationPath::builtin("battle/rangeHighlights/rangeHighlightsRed.json"), EImageBlitMode::COLORKEY);
-
-	flipRangeLimitImagesIntoPositions(rangedFullDamageLimitImages);
-	flipRangeLimitImagesIntoPositions(shootingRangeLimitImages);
 
 	if(!owner.siegeController)
 	{
@@ -536,7 +522,7 @@ std::vector<std::shared_ptr<IImage>> BattleFieldController::calculateRangeLimitH
 			mask.set(direction);
 
 		uint8_t imageKey = static_cast<uint8_t>(mask.to_ulong());
-		output.push_back(limitImages->getImage(hexEdgeMaskToFrameIndex[imageKey]));
+		output.push_back(limitImages->getImage(hexEdgeMaskToFrameIndex.at(imageKey)));
 	}
 
 	return output;
@@ -548,25 +534,6 @@ void BattleFieldController::calculateRangeLimitAndHighlightImages(uint8_t distan
 		rangeLimitHexes = getRangeLimitHexes(hoveredHex, rangeHexes, distance);
 		std::vector<std::vector<BattleHex::EDir>> rangeLimitNeighbourDirections = getOutsideNeighbourDirectionsForLimitHexes(rangeHexes, rangeLimitHexes);
 		rangeLimitHexesHighlights = calculateRangeLimitHighlightImages(rangeLimitNeighbourDirections, rangeLimitImages);
-}
-
-void BattleFieldController::flipRangeLimitImagesIntoPositions(std::shared_ptr<CAnimation> images)
-{
-	images->verticalFlip(hexEdgeMaskToFrameIndex[HexMasks::topRight]);
-	images->verticalFlip(hexEdgeMaskToFrameIndex[HexMasks::right]);
-	images->verticalFlip(hexEdgeMaskToFrameIndex[HexMasks::bottomRight]);
-	images->horizontalFlip(hexEdgeMaskToFrameIndex[HexMasks::bottomRight]);
-	images->horizontalFlip(hexEdgeMaskToFrameIndex[HexMasks::bottomLeft]);
-	images->horizontalFlip(hexEdgeMaskToFrameIndex[HexMasks::bottom]);
-	images->verticalFlip(hexEdgeMaskToFrameIndex[HexMasks::topRightHalfCorner]);
-	images->verticalFlip(hexEdgeMaskToFrameIndex[HexMasks::bottomRightHalfCorner]);
-	images->horizontalFlip(hexEdgeMaskToFrameIndex[HexMasks::bottomRightHalfCorner]);
-	images->horizontalFlip(hexEdgeMaskToFrameIndex[HexMasks::bottomLeftHalfCorner]);
-	images->verticalFlip(hexEdgeMaskToFrameIndex[HexMasks::rightHalf]);
-	images->verticalFlip(hexEdgeMaskToFrameIndex[HexMasks::topRightCorner]);
-	images->verticalFlip(hexEdgeMaskToFrameIndex[HexMasks::bottomRightCorner]);
-	images->horizontalFlip(hexEdgeMaskToFrameIndex[HexMasks::bottomRightCorner]);
-	images->horizontalFlip(hexEdgeMaskToFrameIndex[HexMasks::bottomLeftCorner]);
 }
 
 void BattleFieldController::showHighlightedHexes(Canvas & canvas)

--- a/client/battle/BattleFieldController.cpp
+++ b/client/battle/BattleFieldController.cpp
@@ -128,18 +128,12 @@ BattleFieldController::BattleFieldController(BattleInterface & owner):
 	cellUnitMaxMovementHighlight = GH.renderHandler().loadImage(ImagePath::builtin("UnitMaxMovementHighlight.PNG"), EImageBlitMode::COLORKEY);
 
 	attackCursors = GH.renderHandler().loadAnimation(AnimationPath::builtin("CRCOMBAT"));
-	attackCursors->preload();
-
 	spellCursors = GH.renderHandler().loadAnimation(AnimationPath::builtin("CRSPELL"));
-	spellCursors->preload();
 
 	initializeHexEdgeMaskToFrameIndex();
 
 	rangedFullDamageLimitImages = GH.renderHandler().loadAnimation(AnimationPath::builtin("battle/rangeHighlights/rangeHighlightsGreen.json"));
-	rangedFullDamageLimitImages->preload();
-
 	shootingRangeLimitImages = GH.renderHandler().loadAnimation(AnimationPath::builtin("battle/rangeHighlights/rangeHighlightsRed.json"));
-	shootingRangeLimitImages->preload();
 
 	flipRangeLimitImagesIntoPositions(rangedFullDamageLimitImages);
 	flipRangeLimitImagesIntoPositions(shootingRangeLimitImages);

--- a/client/battle/BattleFieldController.cpp
+++ b/client/battle/BattleFieldController.cpp
@@ -552,25 +552,21 @@ void BattleFieldController::calculateRangeLimitAndHighlightImages(uint8_t distan
 
 void BattleFieldController::flipRangeLimitImagesIntoPositions(std::shared_ptr<CAnimation> images)
 {
-	images->getImage(hexEdgeMaskToFrameIndex[HexMasks::topRight])->verticalFlip();
-	images->getImage(hexEdgeMaskToFrameIndex[HexMasks::right])->verticalFlip();
-	images->getImage(hexEdgeMaskToFrameIndex[HexMasks::bottomRight])->verticalFlip();
-	images->getImage(hexEdgeMaskToFrameIndex[HexMasks::bottomRight])->horizontalFlip();
-	images->getImage(hexEdgeMaskToFrameIndex[HexMasks::bottomLeft])->horizontalFlip();
-
-	images->getImage(hexEdgeMaskToFrameIndex[HexMasks::bottom])->horizontalFlip();
-
-	images->getImage(hexEdgeMaskToFrameIndex[HexMasks::topRightHalfCorner])->verticalFlip();
-	images->getImage(hexEdgeMaskToFrameIndex[HexMasks::bottomRightHalfCorner])->verticalFlip();
-	images->getImage(hexEdgeMaskToFrameIndex[HexMasks::bottomRightHalfCorner])->horizontalFlip();
-	images->getImage(hexEdgeMaskToFrameIndex[HexMasks::bottomLeftHalfCorner])->horizontalFlip();
-
-	images->getImage(hexEdgeMaskToFrameIndex[HexMasks::rightHalf])->verticalFlip();
-
-	images->getImage(hexEdgeMaskToFrameIndex[HexMasks::topRightCorner])->verticalFlip();
-	images->getImage(hexEdgeMaskToFrameIndex[HexMasks::bottomRightCorner])->verticalFlip();
-	images->getImage(hexEdgeMaskToFrameIndex[HexMasks::bottomRightCorner])->horizontalFlip();
-	images->getImage(hexEdgeMaskToFrameIndex[HexMasks::bottomLeftCorner])->horizontalFlip();
+	images->verticalFlip(hexEdgeMaskToFrameIndex[HexMasks::topRight]);
+	images->verticalFlip(hexEdgeMaskToFrameIndex[HexMasks::right]);
+	images->verticalFlip(hexEdgeMaskToFrameIndex[HexMasks::bottomRight]);
+	images->horizontalFlip(hexEdgeMaskToFrameIndex[HexMasks::bottomRight]);
+	images->horizontalFlip(hexEdgeMaskToFrameIndex[HexMasks::bottomLeft]);
+	images->horizontalFlip(hexEdgeMaskToFrameIndex[HexMasks::bottom]);
+	images->verticalFlip(hexEdgeMaskToFrameIndex[HexMasks::topRightHalfCorner]);
+	images->verticalFlip(hexEdgeMaskToFrameIndex[HexMasks::bottomRightHalfCorner]);
+	images->horizontalFlip(hexEdgeMaskToFrameIndex[HexMasks::bottomRightHalfCorner]);
+	images->horizontalFlip(hexEdgeMaskToFrameIndex[HexMasks::bottomLeftHalfCorner]);
+	images->verticalFlip(hexEdgeMaskToFrameIndex[HexMasks::rightHalf]);
+	images->verticalFlip(hexEdgeMaskToFrameIndex[HexMasks::topRightCorner]);
+	images->verticalFlip(hexEdgeMaskToFrameIndex[HexMasks::bottomRightCorner]);
+	images->horizontalFlip(hexEdgeMaskToFrameIndex[HexMasks::bottomRightCorner]);
+	images->horizontalFlip(hexEdgeMaskToFrameIndex[HexMasks::bottomLeftCorner]);
 }
 
 void BattleFieldController::showHighlightedHexes(Canvas & canvas)

--- a/client/battle/BattleFieldController.cpp
+++ b/client/battle/BattleFieldController.cpp
@@ -560,19 +560,22 @@ void BattleFieldController::flipRangeLimitImagesIntoPositions(std::shared_ptr<CA
 {
 	images->getImage(hexEdgeMaskToFrameIndex[HexMasks::topRight])->verticalFlip();
 	images->getImage(hexEdgeMaskToFrameIndex[HexMasks::right])->verticalFlip();
-	images->getImage(hexEdgeMaskToFrameIndex[HexMasks::bottomRight])->doubleFlip();
+	images->getImage(hexEdgeMaskToFrameIndex[HexMasks::bottomRight])->verticalFlip();
+	images->getImage(hexEdgeMaskToFrameIndex[HexMasks::bottomRight])->horizontalFlip();
 	images->getImage(hexEdgeMaskToFrameIndex[HexMasks::bottomLeft])->horizontalFlip();
 
 	images->getImage(hexEdgeMaskToFrameIndex[HexMasks::bottom])->horizontalFlip();
 
 	images->getImage(hexEdgeMaskToFrameIndex[HexMasks::topRightHalfCorner])->verticalFlip();
-	images->getImage(hexEdgeMaskToFrameIndex[HexMasks::bottomRightHalfCorner])->doubleFlip();
+	images->getImage(hexEdgeMaskToFrameIndex[HexMasks::bottomRightHalfCorner])->verticalFlip();
+	images->getImage(hexEdgeMaskToFrameIndex[HexMasks::bottomRightHalfCorner])->horizontalFlip();
 	images->getImage(hexEdgeMaskToFrameIndex[HexMasks::bottomLeftHalfCorner])->horizontalFlip();
 
 	images->getImage(hexEdgeMaskToFrameIndex[HexMasks::rightHalf])->verticalFlip();
 
 	images->getImage(hexEdgeMaskToFrameIndex[HexMasks::topRightCorner])->verticalFlip();
-	images->getImage(hexEdgeMaskToFrameIndex[HexMasks::bottomRightCorner])->doubleFlip();
+	images->getImage(hexEdgeMaskToFrameIndex[HexMasks::bottomRightCorner])->verticalFlip();
+	images->getImage(hexEdgeMaskToFrameIndex[HexMasks::bottomRightCorner])->horizontalFlip();
 	images->getImage(hexEdgeMaskToFrameIndex[HexMasks::bottomLeftCorner])->horizontalFlip();
 }
 

--- a/client/battle/BattleFieldController.h
+++ b/client/battle/BattleFieldController.h
@@ -84,9 +84,6 @@ class BattleFieldController : public CIntObject
 	/// calculates all hexes for a range limit and what images to be shown as highlight for each of the hexes
 	void calculateRangeLimitAndHighlightImages(uint8_t distance, std::shared_ptr<CAnimation> rangeLimitImages, std::vector<BattleHex> & rangeLimitHexes, std::vector<std::shared_ptr<IImage>> & rangeLimitHexesHighlights);
 
-	/// to reduce the number of source images used, some images will be used as flipped versions of preloaded ones
-	void flipRangeLimitImagesIntoPositions(std::shared_ptr<CAnimation> images);
-
 	void showBackground(Canvas & canvas);
 	void showBackgroundImage(Canvas & canvas);
 	void showBackgroundImageWithHexes(Canvas & canvas);

--- a/client/battle/BattleInterface.h
+++ b/client/battle/BattleInterface.h
@@ -39,7 +39,6 @@ class Canvas;
 class BattleResultWindow;
 class StackQueue;
 class CPlayerInterface;
-class CAnimation;
 struct BattleEffect;
 class IImage;
 class StackQueue;

--- a/client/battle/BattleInterfaceClasses.cpp
+++ b/client/battle/BattleInterfaceClasses.cpp
@@ -398,7 +398,6 @@ BattleHero::BattleHero(const BattleInterface & owner, const CGHeroInstance * her
 		animationPath = hero->type->heroClass->imageBattleMale;
 
 	animation = GH.renderHandler().loadAnimation(animationPath);
-	animation->preload();
 
 	pos.w = 64;
 	pos.h = 136;
@@ -413,7 +412,6 @@ BattleHero::BattleHero(const BattleInterface & owner, const CGHeroInstance * her
 	else
 		flagAnimation = GH.renderHandler().loadAnimation(AnimationPath::builtin("CMFLAGL"));
 
-	flagAnimation->preload();
 	flagAnimation->playerColored(hero->tempOwner);
 
 	switchToNextPhase();

--- a/client/battle/BattleInterfaceClasses.cpp
+++ b/client/battle/BattleInterfaceClasses.cpp
@@ -397,7 +397,7 @@ BattleHero::BattleHero(const BattleInterface & owner, const CGHeroInstance * her
 	else
 		animationPath = hero->type->heroClass->imageBattleMale;
 
-	animation = GH.renderHandler().loadAnimation(animationPath);
+	animation = GH.renderHandler().loadAnimation(animationPath, EImageBlitMode::ALPHA);
 
 	pos.w = 64;
 	pos.h = 136;
@@ -408,9 +408,9 @@ BattleHero::BattleHero(const BattleInterface & owner, const CGHeroInstance * her
 		animation->verticalFlip();
 
 	if(defender)
-		flagAnimation = GH.renderHandler().loadAnimation(AnimationPath::builtin("CMFLAGR"));
+		flagAnimation = GH.renderHandler().loadAnimation(AnimationPath::builtin("CMFLAGR"), EImageBlitMode::COLORKEY);
 	else
-		flagAnimation = GH.renderHandler().loadAnimation(AnimationPath::builtin("CMFLAGL"));
+		flagAnimation = GH.renderHandler().loadAnimation(AnimationPath::builtin("CMFLAGL"), EImageBlitMode::COLORKEY);
 
 	flagAnimation->playerColored(hero->tempOwner);
 
@@ -503,7 +503,6 @@ HeroInfoBasicPanel::HeroInfoBasicPanel(const InfoAboutHero & hero, Point * posit
 	if(initializeBackground)
 	{
 		background = std::make_shared<CPicture>(ImagePath::builtin("CHRPOP"));
-		background->getSurface()->setBlitMode(EImageBlitMode::OPAQUE);
 		background->setPlayerColor(hero.owner);
 	}
 
@@ -571,10 +570,8 @@ StackInfoBasicPanel::StackInfoBasicPanel(const CStack * stack, bool initializeBa
 	{
 		background = std::make_shared<CPicture>(ImagePath::builtin("CCRPOP"));
 		background->pos.y += 37;
-		background->getSurface()->setBlitMode(EImageBlitMode::OPAQUE);
 		background->setPlayerColor(stack->getOwner());
 		background2 = std::make_shared<CPicture>(ImagePath::builtin("CHRPOP"));
-		background2->getSurface()->setBlitMode(EImageBlitMode::OPAQUE);
 		background2->setPlayerColor(stack->getOwner());
 	}
 

--- a/client/battle/BattleInterfaceClasses.cpp
+++ b/client/battle/BattleInterfaceClasses.cpp
@@ -934,9 +934,6 @@ StackQueue::StackQueue(bool Embedded, BattleInterface & owner)
 		pos.h = 49;
 		pos.x += parent->pos.w/2 - pos.w/2;
 		pos.y += queueSmallOutside ? -queueSmallOutsideYOffset : 10;
-
-		icons = GH.renderHandler().loadAnimation(AnimationPath::builtin("CPRSMALL"));
-		stateIcons = GH.renderHandler().loadAnimation(AnimationPath::builtin("VCMI/BATTLEQUEUE/STATESSMALL"));
 	}
 	else
 	{
@@ -946,13 +943,7 @@ StackQueue::StackQueue(bool Embedded, BattleInterface & owner)
 		pos.y -= pos.h;
 
 		background = std::make_shared<CFilledTexture>(ImagePath::builtin("DIBOXBCK"), Rect(0, 0, pos.w, pos.h));
-
-		icons = GH.renderHandler().loadAnimation(AnimationPath::builtin("TWCRPORT"));
-		stateIcons = GH.renderHandler().loadAnimation(AnimationPath::builtin("VCMI/BATTLEQUEUE/STATESSMALL"));
-		//TODO: where use big icons?
-		//stateIcons = GH.renderHandler().loadAnimation("VCMI/BATTLEQUEUE/STATESBIG");
 	}
-	stateIcons->preload();
 
 	stackBoxes.resize(queueSize);
 	for (int i = 0; i < stackBoxes.size(); i++)
@@ -1021,13 +1012,13 @@ StackQueue::StackBox::StackBox(StackQueue * owner):
 
 	if(owner->embedded)
 	{
-		icon = std::make_shared<CAnimImage>(owner->icons, 0, 0, 5, 2);
+		icon = std::make_shared<CAnimImage>(AnimationPath::builtin("CPRSMALL"), 0, 0, 5, 2);
 		amount = std::make_shared<CLabel>(pos.w/2, pos.h - 7, FONT_SMALL, ETextAlignment::CENTER, Colors::WHITE);
 		roundRect = std::make_shared<TransparentFilledRectangle>(Rect(0, 0, 2, 48), ColorRGBA(0, 0, 0, 255), ColorRGBA(0, 255, 0, 255));
 	}
 	else
 	{
-		icon = std::make_shared<CAnimImage>(owner->icons, 0, 0, 9, 1);
+		icon = std::make_shared<CAnimImage>(AnimationPath::builtin("TWCRPORT"), 0, 0, 9, 1);
 		amount = std::make_shared<CLabel>(pos.w/2, pos.h - 8, FONT_MEDIUM, ETextAlignment::CENTER, Colors::WHITE);
 		roundRect = std::make_shared<TransparentFilledRectangle>(Rect(0, 0, 15, 18), ColorRGBA(0, 0, 0, 255), ColorRGBA(241, 216, 120, 255));
 		round = std::make_shared<CLabel>(4, 2, FONT_SMALL, ETextAlignment::TOPLEFT, Colors::WHITE);
@@ -1035,7 +1026,7 @@ StackQueue::StackBox::StackBox(StackQueue * owner):
 		int icon_x = pos.w - 17;
 		int icon_y = pos.h - 18;
 
-		stateIcon = std::make_shared<CAnimImage>(owner->stateIcons, 0, 0, icon_x, icon_y);
+		stateIcon = std::make_shared<CAnimImage>(AnimationPath::builtin("VCMI/BATTLEQUEUE/STATESSMALL"), 0, 0, icon_x, icon_y);
 		stateIcon->visible = false;
 	}
 	roundRect->disable();

--- a/client/battle/BattleInterfaceClasses.cpp
+++ b/client/battle/BattleInterfaceClasses.cpp
@@ -506,7 +506,7 @@ HeroInfoBasicPanel::HeroInfoBasicPanel(const InfoAboutHero & hero, Point * posit
 	{
 		background = std::make_shared<CPicture>(ImagePath::builtin("CHRPOP"));
 		background->getSurface()->setBlitMode(EImageBlitMode::OPAQUE);
-		background->colorize(hero.owner);
+		background->setPlayerColor(hero.owner);
 	}
 
 	initializeData(hero);
@@ -574,10 +574,10 @@ StackInfoBasicPanel::StackInfoBasicPanel(const CStack * stack, bool initializeBa
 		background = std::make_shared<CPicture>(ImagePath::builtin("CCRPOP"));
 		background->pos.y += 37;
 		background->getSurface()->setBlitMode(EImageBlitMode::OPAQUE);
-		background->colorize(stack->getOwner());
+		background->setPlayerColor(stack->getOwner());
 		background2 = std::make_shared<CPicture>(ImagePath::builtin("CHRPOP"));
 		background2->getSurface()->setBlitMode(EImageBlitMode::OPAQUE);
-		background2->colorize(stack->getOwner());
+		background2->setPlayerColor(stack->getOwner());
 	}
 
 	initializeData(stack);
@@ -681,7 +681,7 @@ HeroInfoWindow::HeroInfoWindow(const InfoAboutHero & hero, Point * position)
 	if (position != nullptr)
 		moveTo(*position);
 
-	background->colorize(hero.owner); //maybe add this functionality to base class?
+	background->setPlayerColor(hero.owner); //maybe add this functionality to base class?
 
 	content = std::make_shared<HeroInfoBasicPanel>(hero, nullptr, false);
 }
@@ -692,7 +692,7 @@ BattleResultWindow::BattleResultWindow(const BattleResult & br, CPlayerInterface
 	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
 
 	background = std::make_shared<CPicture>(ImagePath::builtin("CPRESULT"));
-	background->colorize(owner.playerID);
+	background->setPlayerColor(owner.playerID);
 	pos = center(background->pos);
 
 	exit = std::make_shared<CButton>(Point(384, 505), AnimationPath::builtin("iok6432.def"), std::make_pair("", ""), [&](){ bExitf();}, EShortcut::GLOBAL_ACCEPT);
@@ -1037,7 +1037,7 @@ void StackQueue::StackBox::setUnit(const battle::Unit * unit, size_t turn, std::
 	if(unit)
 	{
 		boundUnitID = unit->unitId();
-		background->colorize(unit->unitOwner());
+		background->setPlayerColor(unit->unitOwner());
 		icon->visible = true;
 
 		// temporary code for mod compatibility:
@@ -1083,7 +1083,7 @@ void StackQueue::StackBox::setUnit(const battle::Unit * unit, size_t turn, std::
 	else
 	{
 		boundUnitID = std::nullopt;
-		background->colorize(PlayerColor::NEUTRAL);
+		background->setPlayerColor(PlayerColor::NEUTRAL);
 		icon->visible = false;
 		icon->setFrame(0);
 		amount->setText("");

--- a/client/battle/BattleInterfaceClasses.h
+++ b/client/battle/BattleInterfaceClasses.h
@@ -274,9 +274,6 @@ class StackQueue : public CIntObject
 	std::vector<std::shared_ptr<StackBox>> stackBoxes;
 	BattleInterface & owner;
 
-	std::shared_ptr<CAnimation> icons;
-	std::shared_ptr<CAnimation> stateIcons;
-
 	int32_t getSiegeShooterIconID();
 public:
 	const bool embedded;

--- a/client/battle/BattleObstacleController.cpp
+++ b/client/battle/BattleObstacleController.cpp
@@ -21,6 +21,7 @@
 #include "../CPlayerInterface.h"
 #include "../gui/CGuiHandler.h"
 #include "../media/ISoundPlayer.h"
+#include "../render/CAnimation.h"
 #include "../render/Canvas.h"
 #include "../render/IRenderHandler.h"
 

--- a/client/battle/BattleObstacleController.cpp
+++ b/client/battle/BattleObstacleController.cpp
@@ -55,13 +55,11 @@ void BattleObstacleController::loadObstacleImage(const CObstacleInstance & oi)
 			auto animation = GH.renderHandler().createAnimation();
 			animation->setCustom(animationName.getName(), 0, 0);
 			animationsCache[animationName] = animation;
-			animation->preload();
 		}
 		else
 		{
 			auto animation = GH.renderHandler().loadAnimation(animationName);
 			animationsCache[animationName] = animation;
-			animation->preload();
 		}
 	}
 	obstacleAnimations[oi.uniqueID] = animationsCache[animationName];
@@ -87,8 +85,6 @@ void BattleObstacleController::obstacleRemoved(const std::vector<ObstacleChanges
 			continue;
 
 		auto animation = GH.renderHandler().loadAnimation(animationPath);
-		animation->preload();
-
 		auto first = animation->getImage(0, 0);
 		if(!first)
 			continue;
@@ -115,8 +111,6 @@ void BattleObstacleController::obstaclePlaced(const std::vector<std::shared_ptr<
 			continue;
 
 		auto animation = GH.renderHandler().loadAnimation(oi->getAppearAnimation());
-		animation->preload();
-
 		auto first = animation->getImage(0, 0);
 		if(!first)
 			continue;

--- a/client/battle/BattleObstacleController.cpp
+++ b/client/battle/BattleObstacleController.cpp
@@ -58,7 +58,7 @@ void BattleObstacleController::loadObstacleImage(const CObstacleInstance & oi)
 		}
 		else
 		{
-			auto animation = GH.renderHandler().loadAnimation(animationName);
+			auto animation = GH.renderHandler().loadAnimation(animationName, EImageBlitMode::COLORKEY);
 			animationsCache[animationName] = animation;
 		}
 	}
@@ -84,7 +84,7 @@ void BattleObstacleController::obstacleRemoved(const std::vector<ObstacleChanges
 		if(animationPath.empty())
 			continue;
 
-		auto animation = GH.renderHandler().loadAnimation(animationPath);
+		auto animation = GH.renderHandler().loadAnimation(animationPath, EImageBlitMode::COLORKEY);
 		auto first = animation->getImage(0, 0);
 		if(!first)
 			continue;
@@ -110,7 +110,7 @@ void BattleObstacleController::obstaclePlaced(const std::vector<std::shared_ptr<
 		if(!oi->visibleForSide(side.value(), owner.getBattle()->battleHasNativeStack(side.value())))
 			continue;
 
-		auto animation = GH.renderHandler().loadAnimation(oi->getAppearAnimation());
+		auto animation = GH.renderHandler().loadAnimation(oi->getAppearAnimation(), EImageBlitMode::ALPHA);
 		auto first = animation->getImage(0, 0);
 		if(!first)
 			continue;

--- a/client/battle/BattleObstacleController.h
+++ b/client/battle/BattleObstacleController.h
@@ -36,11 +36,11 @@ class BattleObstacleController
 	/// total time, in seconds, since start of battle. Used for animating obstacles
 	float timePassed;
 
-	/// cached animations of all obstacles in current battle
-	std::map<AnimationPath, std::shared_ptr<CAnimation>> animationsCache;
-
 	/// list of all obstacles that are currently being rendered
 	std::map<si32, std::shared_ptr<CAnimation>> obstacleAnimations;
+
+	/// Current images for all present obstacles
+	std::map<si32, std::shared_ptr<IImage>> obstacleImages;
 
 	void loadObstacleImage(const CObstacleInstance & oi);
 

--- a/client/battle/BattleProjectileController.cpp
+++ b/client/battle/BattleProjectileController.cpp
@@ -193,7 +193,6 @@ void BattleProjectileController::initStackProjectile(const CStack * stack)
 std::shared_ptr<CAnimation> BattleProjectileController::createProjectileImage(const AnimationPath & path )
 {
 	std::shared_ptr<CAnimation> projectile = GH.renderHandler().loadAnimation(path);
-	projectile->preload();
 
 	if(projectile->size(1) != 0)
 		logAnim->error("Expected empty group 1 in stack projectile");

--- a/client/battle/BattleProjectileController.cpp
+++ b/client/battle/BattleProjectileController.cpp
@@ -15,6 +15,7 @@
 #include "BattleStacksController.h"
 #include "CreatureAnimation.h"
 
+#include "../render/CAnimation.h"
 #include "../render/Canvas.h"
 #include "../render/IRenderHandler.h"
 #include "../gui/CGuiHandler.h"

--- a/client/battle/BattleProjectileController.cpp
+++ b/client/battle/BattleProjectileController.cpp
@@ -192,7 +192,7 @@ void BattleProjectileController::initStackProjectile(const CStack * stack)
 
 std::shared_ptr<CAnimation> BattleProjectileController::createProjectileImage(const AnimationPath & path )
 {
-	std::shared_ptr<CAnimation> projectile = GH.renderHandler().loadAnimation(path);
+	std::shared_ptr<CAnimation> projectile = GH.renderHandler().loadAnimation(path, EImageBlitMode::COLORKEY);
 
 	if(projectile->size(1) != 0)
 		logAnim->error("Expected empty group 1 in stack projectile");

--- a/client/battle/BattleSiegeController.cpp
+++ b/client/battle/BattleSiegeController.cpp
@@ -182,7 +182,7 @@ BattleSiegeController::BattleSiegeController(BattleInterface & owner, const CGTo
 		if ( !getWallPieceExistence(EWallVisual::EWallVisual(g)) )
 			continue;
 
-		wallPieceImages[g] = GH.renderHandler().loadImage(getWallPieceImageName(EWallVisual::EWallVisual(g), EWallState::REINFORCED));
+		wallPieceImages[g] = GH.renderHandler().loadImage(getWallPieceImageName(EWallVisual::EWallVisual(g), EWallState::REINFORCED), EImageBlitMode::COLORKEY);
 	}
 }
 
@@ -248,7 +248,7 @@ void BattleSiegeController::gateStateChanged(const EGateState state)
 		wallPieceImages[EWallVisual::GATE] = nullptr;
 
 	if (stateId != EWallState::NONE)
-		wallPieceImages[EWallVisual::GATE] = GH.renderHandler().loadImage(getWallPieceImageName(EWallVisual::GATE,  stateId));
+		wallPieceImages[EWallVisual::GATE] = GH.renderHandler().loadImage(getWallPieceImageName(EWallVisual::GATE,  stateId), EImageBlitMode::COLORKEY);
 
 	if (playSound)
 		CCS->soundh->playSound(soundBase::DRAWBRG);
@@ -357,7 +357,7 @@ void BattleSiegeController::stackIsCatapulting(const CatapultAttack & ca)
 
 		auto wallState = EWallState(owner.getBattle()->battleGetWallState(attackInfo.attackedPart));
 
-		wallPieceImages[wallId] = GH.renderHandler().loadImage(getWallPieceImageName(EWallVisual::EWallVisual(wallId), wallState));
+		wallPieceImages[wallId] = GH.renderHandler().loadImage(getWallPieceImageName(EWallVisual::EWallVisual(wallId), wallState), EImageBlitMode::COLORKEY);
 	}
 }
 

--- a/client/battle/CreatureAnimation.cpp
+++ b/client/battle/CreatureAnimation.cpp
@@ -14,6 +14,7 @@
 #include "../../lib/CCreatureHandler.h"
 
 #include "../gui/CGuiHandler.h"
+#include "../render/CAnimation.h"
 #include "../render/Canvas.h"
 #include "../render/ColorFilter.h"
 #include "../render/IRenderHandler.h"

--- a/client/battle/CreatureAnimation.cpp
+++ b/client/battle/CreatureAnimation.cpp
@@ -199,8 +199,8 @@ CreatureAnimation::CreatureAnimation(const AnimationPath & name_, TSpeedControll
 	  speedController(controller),
 	  once(false)
 {
-	forward = GH.renderHandler().loadAnimation(name_);
-	reverse = GH.renderHandler().loadAnimation(name_);
+	forward = GH.renderHandler().loadAnimation(name_, EImageBlitMode::ALPHA);
+	reverse = GH.renderHandler().loadAnimation(name_, EImageBlitMode::ALPHA);
 
 	// if necessary, add one frame into vcmi-only group DEAD
 	if(forward->size(size_t(ECreatureAnimType::DEAD)) == 0)

--- a/client/battle/CreatureAnimation.cpp
+++ b/client/battle/CreatureAnimation.cpp
@@ -202,10 +202,6 @@ CreatureAnimation::CreatureAnimation(const AnimationPath & name_, TSpeedControll
 	forward = GH.renderHandler().loadAnimation(name_);
 	reverse = GH.renderHandler().loadAnimation(name_);
 
-	//todo: optimize
-	forward->preload();
-	reverse->preload();
-
 	// if necessary, add one frame into vcmi-only group DEAD
 	if(forward->size(size_t(ECreatureAnimType::DEAD)) == 0)
 	{

--- a/client/battle/CreatureAnimation.h
+++ b/client/battle/CreatureAnimation.h
@@ -12,7 +12,6 @@
 #include "../../lib/FunctionList.h"
 #include "../../lib/Color.h"
 #include "../widgets/Images.h"
-#include "../render/CAnimation.h"
 #include "../render/IImage.h"
 
 class CIntObject;

--- a/client/globalLobby/GlobalLobbyInviteWindow.cpp
+++ b/client/globalLobby/GlobalLobbyInviteWindow.cpp
@@ -79,7 +79,7 @@ GlobalLobbyInviteWindow::GlobalLobbyInviteWindow()
 	pos.h = 420;
 
 	filledBackground = std::make_shared<FilledTexturePlayerColored>(ImagePath::builtin("DiBoxBck"), Rect(0, 0, pos.w, pos.h));
-	filledBackground->playerColored(PlayerColor(1));
+	filledBackground->setPlayerColor(PlayerColor(1));
 	labelTitle = std::make_shared<CLabel>(
 		pos.w / 2, 20, FONT_BIG, ETextAlignment::CENTER, Colors::YELLOW, MetaString::createFromTextID("vcmi.lobby.invite.header").toString()
 	);

--- a/client/globalLobby/GlobalLobbyLoginWindow.cpp
+++ b/client/globalLobby/GlobalLobbyLoginWindow.cpp
@@ -70,7 +70,7 @@ GlobalLobbyLoginWindow::GlobalLobbyLoginWindow()
 	else
 		toggleMode->setSelected(1);
 
-	filledBackground->playerColored(PlayerColor(1));
+	filledBackground->setPlayerColor(PlayerColor(1));
 	inputUsername->setCallback([this](const std::string & text)
 	{
 		this->buttonLogin->block(text.empty());

--- a/client/globalLobby/GlobalLobbyRoomWindow.cpp
+++ b/client/globalLobby/GlobalLobbyRoomWindow.cpp
@@ -188,7 +188,7 @@ GlobalLobbyRoomWindow::GlobalLobbyRoomWindow(GlobalLobbyWindow * window, const s
 	modListTitle = std::make_shared<CLabel>( 182, 59, FONT_SMALL, ETextAlignment::CENTERLEFT, Colors::YELLOW, MetaString::createFromTextID("vcmi.lobby.preview.mods").toString());
 
 	buttonJoin->block(!errorMessage.empty());
-	filledBackground->playerColored(PlayerColor(1));
+	filledBackground->setPlayerColor(PlayerColor(1));
 	center();
 }
 

--- a/client/globalLobby/GlobalLobbyServerSetup.cpp
+++ b/client/globalLobby/GlobalLobbyServerSetup.cpp
@@ -78,7 +78,7 @@ GlobalLobbyServerSetup::GlobalLobbyServerSetup()
 	buttonCreate = std::make_shared<CButton>(Point(10, 300), AnimationPath::builtin("MuBchck"), CButton::tooltip(), [this](){ onCreate(); }, EShortcut::GLOBAL_ACCEPT);
 	buttonClose = std::make_shared<CButton>(Point(210, 300), AnimationPath::builtin("MuBcanc"), CButton::tooltip(), [this](){ onClose(); }, EShortcut::GLOBAL_CANCEL);
 
-	filledBackground->playerColored(PlayerColor(1));
+	filledBackground->setPlayerColor(PlayerColor(1));
 
 	updateDescription();
 	center();

--- a/client/gui/CIntObject.h
+++ b/client/gui/CIntObject.h
@@ -165,6 +165,15 @@ public:
 	virtual void updateGarrisons() = 0;
 };
 
+class IMarketHolder
+{
+public:
+	virtual void updateResources() {};
+	virtual void updateExperience() {};
+	virtual void updateSecondarySkills() {};
+	virtual void updateArtifacts() {};
+};
+
 class ITownHolder
 {
 public:

--- a/client/gui/CursorHandler.cpp
+++ b/client/gui/CursorHandler.cpp
@@ -47,10 +47,10 @@ CursorHandler::CursorHandler()
 
 	cursors =
 	{
-		GH.renderHandler().loadAnimation(AnimationPath::builtin("CRADVNTR")),
-		GH.renderHandler().loadAnimation(AnimationPath::builtin("CRCOMBAT")),
-		GH.renderHandler().loadAnimation(AnimationPath::builtin("CRDEFLT")),
-		GH.renderHandler().loadAnimation(AnimationPath::builtin("CRSPELL"))
+		GH.renderHandler().loadAnimation(AnimationPath::builtin("CRADVNTR"), EImageBlitMode::COLORKEY),
+		GH.renderHandler().loadAnimation(AnimationPath::builtin("CRCOMBAT"), EImageBlitMode::COLORKEY),
+		GH.renderHandler().loadAnimation(AnimationPath::builtin("CRDEFLT"), EImageBlitMode::COLORKEY),
+		GH.renderHandler().loadAnimation(AnimationPath::builtin("CRSPELL"), EImageBlitMode::COLORKEY)
 	};
 
 	set(Cursor::Map::POINTER);
@@ -101,7 +101,7 @@ void CursorHandler::dragAndDropCursor(std::shared_ptr<IImage> image)
 
 void CursorHandler::dragAndDropCursor (const AnimationPath & path, size_t index)
 {
-	auto anim = GH.renderHandler().loadAnimation(path);
+	auto anim = GH.renderHandler().loadAnimation(path, EImageBlitMode::COLORKEY);
 	dragAndDropCursor(anim->getImage(index));
 }
 

--- a/client/gui/CursorHandler.cpp
+++ b/client/gui/CursorHandler.cpp
@@ -53,9 +53,6 @@ CursorHandler::CursorHandler()
 		GH.renderHandler().loadAnimation(AnimationPath::builtin("CRSPELL"))
 	};
 
-	for (auto & cursor : cursors)
-		cursor->preload();
-
 	set(Cursor::Map::POINTER);
 	showType = dynamic_cast<CursorSoftware *>(cursor.get()) ? Cursor::ShowType::SOFTWARE : Cursor::ShowType::HARDWARE;
 }
@@ -105,7 +102,6 @@ void CursorHandler::dragAndDropCursor(std::shared_ptr<IImage> image)
 void CursorHandler::dragAndDropCursor (const AnimationPath & path, size_t index)
 {
 	auto anim = GH.renderHandler().loadAnimation(path);
-	anim->load(index);
 	dragAndDropCursor(anim->getImage(index));
 }
 

--- a/client/gui/InterfaceObjectConfigurable.cpp
+++ b/client/gui/InterfaceObjectConfigurable.cpp
@@ -333,7 +333,7 @@ std::shared_ptr<CPicture> InterfaceObjectConfigurable::buildPicture(const JsonNo
 	auto pic = std::make_shared<CPicture>(image, position.x, position.y);
 
 	if ( config["playerColored"].Bool() && LOCPLINT)
-		pic->colorize(LOCPLINT->playerID);
+		pic->setPlayerColor(LOCPLINT->playerID);
 	return pic;
 }
 
@@ -571,7 +571,7 @@ std::shared_ptr<CFilledTexture> InterfaceObjectConfigurable::buildTexture(const 
 	if(playerColor.isValidPlayer())
 	{
 		auto result = std::make_shared<FilledTexturePlayerColored>(image, rect);
-		result->playerColored(playerColor);
+		result->setPlayerColor(playerColor);
 		return result;
 	}
 	return std::make_shared<CFilledTexture>(image, rect);

--- a/client/lobby/CSelectionBase.cpp
+++ b/client/lobby/CSelectionBase.cpp
@@ -515,9 +515,6 @@ CFlagBox::CFlagBox(const Rect & rect)
 
 	labelAllies = std::make_shared<CLabel>(0, 0, FONT_SMALL, ETextAlignment::TOPLEFT, Colors::WHITE, CGI->generaltexth->allTexts[390] + ":");
 	labelEnemies = std::make_shared<CLabel>(133, 0, FONT_SMALL, ETextAlignment::TOPLEFT, Colors::WHITE, CGI->generaltexth->allTexts[391] + ":");
-
-	iconsTeamFlags = GH.renderHandler().loadAnimation(AnimationPath::builtin("ITGFLAGS.DEF"));
-	iconsTeamFlags->preload();
 }
 
 void CFlagBox::recreate()
@@ -529,7 +526,7 @@ void CFlagBox::recreate()
 	const int enemiesX = 5 + 133 + (int)labelEnemies->getWidth();
 	for(auto i = CSH->si->playerInfos.cbegin(); i != CSH->si->playerInfos.cend(); i++)
 	{
-		auto flag = std::make_shared<CAnimImage>(iconsTeamFlags, i->first.getNum(), 0);
+		auto flag = std::make_shared<CAnimImage>(AnimationPath::builtin("ITGFLAGS.DEF"), i->first.getNum(), 0);
 		if(i->first == CSH->myFirstColor() || CSH->getPlayerTeamId(i->first) == CSH->getPlayerTeamId(CSH->myFirstColor()))
 		{
 			flag->moveTo(Point(pos.x + alliesX + (int)flagsAllies.size()*flag->pos.w, pos.y));
@@ -546,10 +543,10 @@ void CFlagBox::recreate()
 void CFlagBox::showPopupWindow(const Point & cursorPosition)
 {
 	if(SEL->getMapInfo())
-		GH.windows().createAndPushWindow<CFlagBoxTooltipBox>(iconsTeamFlags);
+		GH.windows().createAndPushWindow<CFlagBoxTooltipBox>();
 }
 
-CFlagBox::CFlagBoxTooltipBox::CFlagBoxTooltipBox(std::shared_ptr<CAnimation> icons)
+CFlagBox::CFlagBoxTooltipBox::CFlagBoxTooltipBox()
 	: CWindowObject(BORDERED | RCLICK_POPUP | SHADOW_DISABLED, ImagePath::builtin("DIBOXBCK"))
 {
 	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
@@ -577,7 +574,7 @@ CFlagBox::CFlagBoxTooltipBox::CFlagBoxTooltipBox(std::shared_ptr<CAnimation> ico
 		int curx = 128 - 9 * team.size();
 		for(const auto & player : team)
 		{
-			iconsFlags.push_back(std::make_shared<CAnimImage>(icons, player, 0, curx, 75 + 50 * curIdx));
+			iconsFlags.push_back(std::make_shared<CAnimImage>(AnimationPath::builtin("ITGFLAGS.DEF"), player, 0, curx, 75 + 50 * curIdx));
 			curx += 18;
 		}
 		++curIdx;

--- a/client/lobby/CSelectionBase.cpp
+++ b/client/lobby/CSelectionBase.cpp
@@ -401,7 +401,7 @@ PvPBox::PvPBox(const Rect & rect)
 	setRedrawParent(true);
 
 	backgroundTexture = std::make_shared<FilledTexturePlayerColored>(ImagePath::builtin("DiBoxBck"), Rect(0, 0, rect.w, rect.h));
-	backgroundTexture->playerColored(PlayerColor(1));
+	backgroundTexture->setPlayerColor(PlayerColor(1));
 	backgroundBorder = std::make_shared<TransparentFilledRectangle>(Rect(0, 0, rect.w, rect.h), ColorRGBA(0, 0, 0, 64), ColorRGBA(96, 96, 96, 255), 1);
 
 	townSelector = std::make_shared<TownSelector>(Point(5, 3));

--- a/client/lobby/CSelectionBase.h
+++ b/client/lobby/CSelectionBase.h
@@ -174,7 +174,6 @@ public:
 
 class CFlagBox : public CIntObject
 {
-	std::shared_ptr<CAnimation> iconsTeamFlags;
 	std::shared_ptr<CLabel> labelAllies;
 	std::shared_ptr<CLabel> labelEnemies;
 	std::vector<std::shared_ptr<CAnimImage>> flagsAllies;
@@ -192,7 +191,7 @@ public:
 		std::shared_ptr<CLabelGroup> labelGroupTeams;
 		std::vector<std::shared_ptr<CAnimImage>> iconsFlags;
 	public:
-		CFlagBoxTooltipBox(std::shared_ptr<CAnimation> icons);
+		CFlagBoxTooltipBox();
 	};
 };
 

--- a/client/lobby/OptionsTab.cpp
+++ b/client/lobby/OptionsTab.cpp
@@ -518,9 +518,8 @@ void OptionsTab::SelectionWindow::recreate(int sliderPos)
 	int sliderWidth = ((amountLines > MAX_LINES) ? 16 : 0);
 
 	pos = Rect(pos.x, pos.y, x + sliderWidth, y);
-
 	backgroundTexture = std::make_shared<FilledTexturePlayerColored>(ImagePath::builtin("DiBoxBck"), Rect(0, 0, pos.w - sliderWidth, pos.h));
-	backgroundTexture->playerColored(PlayerColor(1));
+	backgroundTexture->setPlayerColor(PlayerColor(1));
 	updateShadow();
 
 	if(type == SelType::TOWN)

--- a/client/lobby/SelectionTab.cpp
+++ b/client/lobby/SelectionTab.cpp
@@ -884,7 +884,7 @@ SelectionTab::ListItem::ListItem(Point position)
 	: CIntObject(LCLICK, position)
 {
 	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
-	pictureEmptyLine = std::make_shared<CPicture>(GH.renderHandler().loadImage(ImagePath::builtin("camcust")), Rect(25, 121, 349, 26), -8, -14);
+	pictureEmptyLine = std::make_shared<CPicture>(ImagePath::builtin("camcust"), Rect(25, 121, 349, 26), -8, -14);
 	labelName = std::make_shared<CLabel>(184, 0, FONT_SMALL, ETextAlignment::CENTER, Colors::WHITE, "", 185);
 	labelName->setAutoRedraw(false);
 	labelAmountOfPlayers = std::make_shared<CLabel>(8, 0, FONT_SMALL, ETextAlignment::CENTER, Colors::WHITE);

--- a/client/lobby/SelectionTab.cpp
+++ b/client/lobby/SelectionTab.cpp
@@ -227,11 +227,8 @@ SelectionTab::SelectionTab(ESelectionScreen Type)
 		buttonsSortBy.push_back(sortByDate);
 	}
 
-	iconsMapFormats = GH.renderHandler().loadAnimation(AnimationPath::builtin("SCSELC.DEF"));
-	iconsVictoryCondition = GH.renderHandler().loadAnimation(AnimationPath::builtin("SCNRVICT.DEF"));
-	iconsLossCondition = GH.renderHandler().loadAnimation(AnimationPath::builtin("SCNRLOSS.DEF"));
 	for(int i = 0; i < positionsToShow; i++)
-		listItems.push_back(std::make_shared<ListItem>(Point(30, 129 + i * 25), iconsMapFormats, iconsVictoryCondition, iconsLossCondition));
+		listItems.push_back(std::make_shared<ListItem>(Point(30, 129 + i * 25)));
 
 	labelTabTitle = std::make_shared<CLabel>(205, 28, FONT_MEDIUM, ETextAlignment::CENTER, Colors::YELLOW, tabTitle);
 	slider = std::make_shared<CSlider>(Point(372, 86 + (enableUiEnhancements ? 30 : 0)), (tabType != ESelectionScreen::saveGame ? 480 : 430) - (enableUiEnhancements ? 30 : 0), std::bind(&SelectionTab::sliderMove, this, _1), positionsToShow, (int)curItems.size(), 0, Orientation::VERTICAL, CSlider::BLUE);
@@ -883,7 +880,7 @@ std::unordered_set<ResourcePath> SelectionTab::getFiles(std::string dirURI, ERes
 	return ret;
 }
 
-SelectionTab::ListItem::ListItem(Point position, std::shared_ptr<CAnimation> iconsFormats, std::shared_ptr<CAnimation> iconsVictory, std::shared_ptr<CAnimation> iconsLoss)
+SelectionTab::ListItem::ListItem(Point position)
 	: CIntObject(LCLICK, position)
 {
 	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
@@ -898,9 +895,9 @@ SelectionTab::ListItem::ListItem(Point position, std::shared_ptr<CAnimation> ico
 	labelMapSizeLetter->setAutoRedraw(false);
 	// FIXME: This -12 should not be needed, but for some reason CAnimImage displaced otherwise
 	iconFolder = std::make_shared<CPicture>(ImagePath::builtin("lobby/iconFolder.png"), -8, -12);
-	iconFormat = std::make_shared<CAnimImage>(iconsFormats, 0, 0, 59, -12);
-	iconVictoryCondition = std::make_shared<CAnimImage>(iconsVictory, 0, 0, 277, -12);
-	iconLossCondition = std::make_shared<CAnimImage>(iconsLoss, 0, 0, 310, -12);
+	iconFormat = std::make_shared<CAnimImage>(AnimationPath::builtin("SCSELC.DEF"), 0, 0, 59, -12);
+	iconVictoryCondition = std::make_shared<CAnimImage>(AnimationPath::builtin("SCNRVICT.DEF"), 0, 0, 277, -12);
+	iconLossCondition = std::make_shared<CAnimImage>(AnimationPath::builtin("SCNRLOSS.DEF"), 0, 0, 310, -12);
 }
 
 void SelectionTab::ListItem::updateItem(std::shared_ptr<ElementInfo> info, bool selected)

--- a/client/lobby/SelectionTab.h
+++ b/client/lobby/SelectionTab.h
@@ -59,7 +59,7 @@ class SelectionTab : public CIntObject
 		std::shared_ptr<CPicture> pictureEmptyLine;
 		std::shared_ptr<CLabel> labelName;
 
-		ListItem(Point position, std::shared_ptr<CAnimation> iconsFormats, std::shared_ptr<CAnimation> iconsVictory, std::shared_ptr<CAnimation> iconsLoss);
+		ListItem(Point position);
 		void updateItem(std::shared_ptr<ElementInfo> info = {}, bool selected = false);
 	};
 	std::vector<std::shared_ptr<ListItem>> listItems;

--- a/client/lobby/SelectionTab.h
+++ b/client/lobby/SelectionTab.h
@@ -20,6 +20,7 @@ class CSlider;
 class CLabel;
 class CPicture;
 class IImage;
+class CAnimation;
 
 enum ESortBy
 {

--- a/client/mainmenu/CMainMenu.h
+++ b/client/mainmenu/CMainMenu.h
@@ -24,7 +24,6 @@ class CGStatusBar;
 class CTextBox;
 class CTabbedInt;
 class CAnimImage;
-class CAnimation;
 class CButton;
 class CFilledTexture;
 class CLabel;

--- a/client/mapView/MapRenderer.cpp
+++ b/client/mapView/MapRenderer.cpp
@@ -105,21 +105,28 @@ void MapTileStorage::load(size_t index, const AnimationPath & filename, EImageBl
 	{
 		if (!filename.empty())
 			entry = GH.renderHandler().loadAnimation(filename, blitMode);
-		else
-			entry = GH.renderHandler().createAnimation();
 	}
 
-	terrainAnimations[1]->verticalFlip();
-	terrainAnimations[3]->verticalFlip();
+	if (terrainAnimations[1])
+		terrainAnimations[1]->verticalFlip();
 
-	terrainAnimations[2]->horizontalFlip();
-	terrainAnimations[3]->horizontalFlip();
+	if (terrainAnimations[3])
+		terrainAnimations[3]->verticalFlip();
+
+	if (terrainAnimations[2])
+		terrainAnimations[2]->horizontalFlip();
+
+	if (terrainAnimations[3])
+		terrainAnimations[3]->horizontalFlip();
 }
 
 std::shared_ptr<IImage> MapTileStorage::find(size_t fileIndex, size_t rotationIndex, size_t imageIndex)
 {
 	const auto & animation = animations[fileIndex][rotationIndex];
-	return animation->getImage(imageIndex);
+	if (animation)
+		return animation->getImage(imageIndex);
+	else
+		return nullptr;
 }
 
 MapRendererTerrain::MapRendererTerrain()

--- a/client/mapView/MapRenderer.cpp
+++ b/client/mapView/MapRenderer.cpp
@@ -104,12 +104,9 @@ void MapTileStorage::load(size_t index, const AnimationPath & filename, EImageBl
 	for(auto & entry : terrainAnimations)
 	{
 		if (!filename.empty())
-			entry = GH.renderHandler().loadAnimation(filename);
+			entry = GH.renderHandler().loadAnimation(filename, blitMode);
 		else
 			entry = GH.renderHandler().createAnimation();
-
-		for(size_t i = 0; i < entry->size(); ++i)
-			entry->getImage(i)->setBlitMode(blitMode);
 	}
 
 	terrainAnimations[1]->verticalFlip();
@@ -249,7 +246,7 @@ uint8_t MapRendererRoad::checksum(IMapRendererContext & context, const int3 & co
 
 MapRendererBorder::MapRendererBorder()
 {
-	animation = GH.renderHandler().loadAnimation(AnimationPath::builtin("EDG"));
+	animation = GH.renderHandler().loadAnimation(AnimationPath::builtin("EDG"), EImageBlitMode::OPAQUE);
 }
 
 size_t MapRendererBorder::getIndexForTile(IMapRendererContext & context, const int3 & tile)
@@ -310,11 +307,8 @@ uint8_t MapRendererBorder::checksum(IMapRendererContext & context, const int3 & 
 
 MapRendererFow::MapRendererFow()
 {
-	fogOfWarFullHide = GH.renderHandler().loadAnimation(AnimationPath::builtin("TSHRC"));
-	fogOfWarPartialHide = GH.renderHandler().loadAnimation(AnimationPath::builtin("TSHRE"));
-
-	for(size_t i = 0; i < fogOfWarFullHide->size(); ++i)
-		fogOfWarFullHide->getImage(i)->setBlitMode(EImageBlitMode::OPAQUE);
+	fogOfWarFullHide = GH.renderHandler().loadAnimation(AnimationPath::builtin("TSHRC"), EImageBlitMode::OPAQUE);
+	fogOfWarPartialHide = GH.renderHandler().loadAnimation(AnimationPath::builtin("TSHRE"), EImageBlitMode::ALPHA);
 
 	static const std::vector<int> rotations = {22, 15, 2, 13, 12, 16, 28, 17, 20, 19, 7, 24, 26, 25, 30, 32, 27};
 
@@ -398,7 +392,7 @@ std::shared_ptr<CAnimation> MapRendererObjects::getAnimation(const AnimationPath
 	if(it != animations.end())
 		return it->second;
 
-	auto ret = GH.renderHandler().loadAnimation(filename);
+	auto ret = GH.renderHandler().loadAnimation(filename, EImageBlitMode::ALPHA);
 	animations[filename] = ret;
 
 	if(generateMovementGroups)
@@ -619,7 +613,7 @@ uint8_t MapRendererOverlay::checksum(IMapRendererContext & context, const int3 &
 }
 
 MapRendererPath::MapRendererPath()
-	: pathNodes(GH.renderHandler().loadAnimation(AnimationPath::builtin("ADAG")))
+	: pathNodes(GH.renderHandler().loadAnimation(AnimationPath::builtin("ADAG"), EImageBlitMode::ALPHA))
 {
 }
 

--- a/client/mapView/MapRenderer.cpp
+++ b/client/mapView/MapRenderer.cpp
@@ -115,14 +115,11 @@ void MapTileStorage::load(size_t index, const AnimationPath & filename, EImageBl
 			entry->getImage(i)->setBlitMode(blitMode);
 	}
 
-	for(size_t i = 0; i < terrainAnimations[0]->size(); ++i)
-	{
-		terrainAnimations[1]->getImage(i)->verticalFlip();
-		terrainAnimations[3]->getImage(i)->verticalFlip();
+	terrainAnimations[1]->verticalFlip();
+	terrainAnimations[3]->verticalFlip();
 
-		terrainAnimations[2]->getImage(i)->horizontalFlip();
-		terrainAnimations[3]->getImage(i)->horizontalFlip();
-	}
+	terrainAnimations[2]->horizontalFlip();
+	terrainAnimations[3]->horizontalFlip();
 }
 
 std::shared_ptr<IImage> MapTileStorage::find(size_t fileIndex, size_t rotationIndex, size_t imageIndex)

--- a/client/mapView/MapRenderer.cpp
+++ b/client/mapView/MapRenderer.cpp
@@ -104,10 +104,7 @@ void MapTileStorage::load(size_t index, const AnimationPath & filename, EImageBl
 	for(auto & entry : terrainAnimations)
 	{
 		if (!filename.empty())
-		{
 			entry = GH.renderHandler().loadAnimation(filename);
-			entry->preload();
-		}
 		else
 			entry = GH.renderHandler().createAnimation();
 
@@ -253,7 +250,6 @@ uint8_t MapRendererRoad::checksum(IMapRendererContext & context, const int3 & co
 MapRendererBorder::MapRendererBorder()
 {
 	animation = GH.renderHandler().loadAnimation(AnimationPath::builtin("EDG"));
-	animation->preload();
 }
 
 size_t MapRendererBorder::getIndexForTile(IMapRendererContext & context, const int3 & tile)
@@ -315,9 +311,7 @@ uint8_t MapRendererBorder::checksum(IMapRendererContext & context, const int3 & 
 MapRendererFow::MapRendererFow()
 {
 	fogOfWarFullHide = GH.renderHandler().loadAnimation(AnimationPath::builtin("TSHRC"));
-	fogOfWarFullHide->preload();
 	fogOfWarPartialHide = GH.renderHandler().loadAnimation(AnimationPath::builtin("TSHRE"));
-	fogOfWarPartialHide->preload();
 
 	for(size_t i = 0; i < fogOfWarFullHide->size(); ++i)
 		fogOfWarFullHide->getImage(i)->setBlitMode(EImageBlitMode::OPAQUE);
@@ -407,7 +401,6 @@ std::shared_ptr<CAnimation> MapRendererObjects::getAnimation(const AnimationPath
 
 	auto ret = GH.renderHandler().loadAnimation(filename);
 	animations[filename] = ret;
-	ret->preload();
 
 	if(generateMovementGroups)
 	{
@@ -629,7 +622,6 @@ uint8_t MapRendererOverlay::checksum(IMapRendererContext & context, const int3 &
 MapRendererPath::MapRendererPath()
 	: pathNodes(GH.renderHandler().loadAnimation(AnimationPath::builtin("ADAG")))
 {
-	pathNodes->preload();
 }
 
 size_t MapRendererPath::selectImageReachability(bool reachableToday, size_t imageIndex)

--- a/client/mapView/MapRenderer.cpp
+++ b/client/mapView/MapRenderer.cpp
@@ -323,8 +323,7 @@ MapRendererFow::MapRendererFow()
 	for(const int rotation : rotations)
 	{
 		fogOfWarPartialHide->duplicateImage(0, rotation, 0);
-		auto image = fogOfWarPartialHide->getImage(size, 0);
-		image->verticalFlip();
+		fogOfWarPartialHide->verticalFlip(size, 0);
 		size++;
 	}
 }

--- a/client/mapView/MapViewCache.cpp
+++ b/client/mapView/MapViewCache.cpp
@@ -36,7 +36,6 @@ MapViewCache::MapViewCache(const std::shared_ptr<MapViewModel> & model)
 	, terrain(new Canvas(model->getCacheDimensionsPixels()))
 	, terrainTransition(new Canvas(model->getPixelsVisibleDimensions()))
 {
-	iconsStorage->preload();
 	for(size_t i = 0; i < iconsStorage->size(); ++i)
 		iconsStorage->getImage(i)->setBlitMode(EImageBlitMode::COLORKEY);
 

--- a/client/mapView/MapViewCache.cpp
+++ b/client/mapView/MapViewCache.cpp
@@ -31,14 +31,11 @@ MapViewCache::MapViewCache(const std::shared_ptr<MapViewModel> & model)
 	: model(model)
 	, cachedLevel(0)
 	, mapRenderer(new MapRenderer())
-	, iconsStorage(GH.renderHandler().loadAnimation(AnimationPath::builtin("VwSymbol")))
+	, iconsStorage(GH.renderHandler().loadAnimation(AnimationPath::builtin("VwSymbol"), EImageBlitMode::COLORKEY))
 	, intermediate(new Canvas(Point(32, 32)))
 	, terrain(new Canvas(model->getCacheDimensionsPixels()))
 	, terrainTransition(new Canvas(model->getPixelsVisibleDimensions()))
 {
-	for(size_t i = 0; i < iconsStorage->size(); ++i)
-		iconsStorage->getImage(i)->setBlitMode(EImageBlitMode::COLORKEY);
-
 	Point visibleSize = model->getTilesVisibleDimensions();
 	terrainChecksum.resize(boost::extents[visibleSize.x][visibleSize.y]);
 	tilesUpToDate.resize(boost::extents[visibleSize.x][visibleSize.y]);

--- a/client/render/CAnimation.cpp
+++ b/client/render/CAnimation.cpp
@@ -187,50 +187,6 @@ std::shared_ptr<IImage> CAnimation::getImageImpl(size_t frame, size_t group, boo
 	return nullptr;
 }
 
-void CAnimation::load()
-{
-	for (auto & elem : source)
-		for (size_t image=0; image < elem.second.size(); image++)
-			loadFrame(image, elem.first);
-}
-
-void CAnimation::unload()
-{
-	for (auto & elem : source)
-		for (size_t image=0; image < elem.second.size(); image++)
-			unloadFrame(image, elem.first);
-
-}
-
-void CAnimation::preload()
-{
-	// TODO: remove
-}
-
-void CAnimation::loadGroup(size_t group)
-{
-	if (vstd::contains(source, group))
-		for (size_t image=0; image < source[group].size(); image++)
-			loadFrame(image, group);
-}
-
-void CAnimation::unloadGroup(size_t group)
-{
-	if (vstd::contains(source, group))
-		for (size_t image=0; image < source[group].size(); image++)
-			unloadFrame(image, group);
-}
-
-void CAnimation::load(size_t frame, size_t group)
-{
-	loadFrame(frame, group);
-}
-
-void CAnimation::unload(size_t frame, size_t group)
-{
-	unloadFrame(frame, group);
-}
-
 size_t CAnimation::size(size_t group) const
 {
 	auto iter = source.find(group);
@@ -270,4 +226,3 @@ void CAnimation::createFlippedGroup(const size_t sourceGroup, const size_t targe
 		image->verticalFlip();
 	}
 }
-

--- a/client/render/CAnimation.cpp
+++ b/client/render/CAnimation.cpp
@@ -34,9 +34,9 @@ bool CAnimation::loadFrame(size_t frame, size_t group)
 
 	//try to get image from def
 	if(source[group][frame].isNull())
-		image = GH.renderHandler().loadImage(name, frame, group);
+		image = GH.renderHandler().loadImage(name, frame, group, mode);
 	else
-		image = GH.renderHandler().loadImage(source[group][frame]);
+		image = GH.renderHandler().loadImage(source[group][frame], mode);
 
 	if(image)
 	{
@@ -104,9 +104,10 @@ void CAnimation::printError(size_t frame, size_t group, std::string type) const
 	logGlobal->error("%s error: Request for frame not present in CAnimation! File name: %s, Group: %d, Frame: %d", type, name.getOriginalName(), group, frame);
 }
 
-CAnimation::CAnimation(const AnimationPath & Name, std::map<size_t, std::vector <JsonNode> > layout):
+CAnimation::CAnimation(const AnimationPath & Name, std::map<size_t, std::vector <JsonNode> > layout, EImageBlitMode mode):
 	name(boost::starts_with(Name.getName(), "SPRITES") ? Name : Name.addPrefix("SPRITES/")),
-	source(layout)
+	source(layout),
+	mode(mode)
 {
 	if(source.empty())
 		logAnim->error("Animation %s failed to load", Name.getOriginalName());

--- a/client/render/CAnimation.cpp
+++ b/client/render/CAnimation.cpp
@@ -12,7 +12,6 @@
 
 #include "CDefFile.h"
 
-#include "Graphics.h"
 #include "../../lib/filesystem/Filesystem.h"
 #include "../../lib/json/JsonUtils.h"
 #include "../renderSDL/SDLImage.h"
@@ -179,8 +178,8 @@ void CAnimation::init()
 			source[defEntry.first].resize(defEntry.second);
 	}
 
-	if (vstd::contains(graphics->imageLists, name.getName()))
-		initFromJson(graphics->imageLists[name.getName()]);
+//	if (vstd::contains(graphics->imageLists, name.getName()))
+//		initFromJson(graphics->imageLists[name.getName()]);
 
 	auto jsonResource = name.toType<EResType::JSON>();
 	auto configList = CResourceHandler::get()->getResourcesWithName(jsonResource);

--- a/client/render/CAnimation.cpp
+++ b/client/render/CAnimation.cpp
@@ -26,17 +26,9 @@ bool CAnimation::loadFrame(size_t frame, size_t group)
 	}
 
 	if(auto image = getImageImpl(frame, group, false))
-	{
 		return true;
-	}
 
-	std::shared_ptr<IImage> image;
-
-	//try to get image from def
-	if(source[group][frame].isNull())
-		image = GH.renderHandler().loadImage(name, frame, group, mode);
-	else
-		image = GH.renderHandler().loadImage(source[group][frame], mode);
+	std::shared_ptr<IImage> image = GH.renderHandler().loadImage(source[group][frame], mode);
 
 	if(image)
 	{
@@ -104,7 +96,7 @@ void CAnimation::printError(size_t frame, size_t group, std::string type) const
 	logGlobal->error("%s error: Request for frame not present in CAnimation! File name: %s, Group: %d, Frame: %d", type, name.getOriginalName(), group, frame);
 }
 
-CAnimation::CAnimation(const AnimationPath & Name, std::map<size_t, std::vector <JsonNode> > layout, EImageBlitMode mode):
+CAnimation::CAnimation(const AnimationPath & Name, std::map<size_t, std::vector <ImageLocator> > layout, EImageBlitMode mode):
 	name(boost::starts_with(Name.getName(), "SPRITES") ? Name : Name.addPrefix("SPRITES/")),
 	source(layout),
 	mode(mode)
@@ -129,15 +121,7 @@ void CAnimation::duplicateImage(const size_t sourceGroup, const size_t sourceFra
 		return;
 	}
 
-	JsonNode clone(source[sourceGroup][sourceFrame]);
-
-	if(clone.getType() == JsonNode::JsonType::DATA_NULL)
-	{
-		clone["animation"].String() = name.getName();
-		clone["group"].Integer() = sourceGroup;
-		clone["frame"].Integer() = sourceFrame;
-	}
-
+	ImageLocator clone(source[sourceGroup][sourceFrame]);
 	source[targetGroup].push_back(clone);
 }
 
@@ -195,15 +179,8 @@ void CAnimation::horizontalFlip(size_t frame, size_t group)
 		// ignore - image not loaded
 	}
 
-	JsonNode & config = source.at(group).at(frame);
-	if (config.isNull())
-	{
-		config["animation"].String() = name.getName();
-		config["frame"].Integer() = frame;
-		config["group"].Integer() = group;
-	}
-
-	config["horizontalFlip"].Bool() = !config["horizontalFlip"].Bool();
+	ImageLocator & locator = source.at(group).at(frame);
+	locator.horizontalFlip = !locator.horizontalFlip;
 }
 
 void CAnimation::verticalFlip(size_t frame, size_t group)
@@ -217,15 +194,8 @@ void CAnimation::verticalFlip(size_t frame, size_t group)
 		// ignore - image not loaded
 	}
 
-	JsonNode & config = source.at(group).at(frame);
-	if (config.isNull())
-	{
-		config["animation"].String() = name.getName();
-		config["frame"].Integer() = frame;
-		config["group"].Integer() = group;
-	}
-
-	config["verticalFlip"].Bool() = !config["verticalFlip"].Bool();
+	ImageLocator & locator = source.at(group).at(frame);
+	locator.verticalFlip = !locator.verticalFlip;
 }
 
 void CAnimation::playerColored(PlayerColor player)

--- a/client/render/CAnimation.cpp
+++ b/client/render/CAnimation.cpp
@@ -25,7 +25,6 @@ bool CAnimation::loadFrame(size_t frame, size_t group)
 		return false;
 	}
 
-
 	if(auto image = getImage(frame, group, false))
 	{
 		return true;

--- a/client/render/CAnimation.cpp
+++ b/client/render/CAnimation.cpp
@@ -113,7 +113,6 @@ CAnimation::CAnimation(const AnimationPath & Name, std::map<size_t, std::vector 
 		logAnim->error("Animation %s failed to load", Name.getOriginalName());
 }
 
-CAnimation::CAnimation() = default;
 CAnimation::~CAnimation() = default;
 
 void CAnimation::duplicateImage(const size_t sourceGroup, const size_t sourceFrame, const size_t targetGroup)
@@ -140,14 +139,6 @@ void CAnimation::duplicateImage(const size_t sourceGroup, const size_t sourceFra
 	}
 
 	source[targetGroup].push_back(clone);
-}
-
-void CAnimation::setCustom(std::string filename, size_t frame, size_t group)
-{
-	if (source[group].size() <= frame)
-		source[group].resize(frame+1);
-	source[group][frame]["file"].String() = filename;
-	//FIXME: update image if already loaded
 }
 
 std::shared_ptr<IImage> CAnimation::getImage(size_t frame, size_t group, bool verbose)

--- a/client/render/CAnimation.h
+++ b/client/render/CAnimation.h
@@ -48,15 +48,11 @@ private:
 	std::shared_ptr<IImage> getImageImpl(size_t frame, size_t group=0, bool verbose=true);
 public:
 	CAnimation(const AnimationPath & Name, std::map<size_t, std::vector <JsonNode> > layout, EImageBlitMode mode);
-	CAnimation();
 	~CAnimation();
 
 	//duplicates frame at [sourceGroup, sourceFrame] as last frame in targetGroup
 	//and loads it if animation is preloaded
 	void duplicateImage(const size_t sourceGroup, const size_t sourceFrame, const size_t targetGroup);
-
-	//add custom surface to the selected position.
-	void setCustom(std::string filename, size_t frame, size_t group=0);
 
 	std::shared_ptr<IImage> getImage(size_t frame, size_t group=0, bool verbose=true);
 

--- a/client/render/CAnimation.h
+++ b/client/render/CAnimation.h
@@ -33,8 +33,6 @@ private:
 	//animation file name
 	AnimationPath name;
 
-	bool preloaded;
-
 	//loader, will be called by load(), require opened def file for loading from it. Returns true if image is loaded
 	bool loadFrame(size_t frame, size_t group);
 
@@ -44,6 +42,7 @@ private:
 	//to get rid of copy-pasting error message :]
 	void printError(size_t frame, size_t group, std::string type) const;
 
+	std::shared_ptr<IImage> getImageImpl(size_t frame, size_t group=0, bool verbose=true);
 public:
 	CAnimation(const AnimationPath & Name, std::map<size_t, std::vector <JsonNode> > layout);
 	CAnimation();
@@ -56,7 +55,7 @@ public:
 	//add custom surface to the selected position.
 	void setCustom(std::string filename, size_t frame, size_t group=0);
 
-	std::shared_ptr<IImage> getImage(size_t frame, size_t group=0, bool verbose=true) const;
+	std::shared_ptr<IImage> getImage(size_t frame, size_t group=0, bool verbose=true);
 
 	void exportBitmaps(const boost::filesystem::path & path) const;
 

--- a/client/render/CAnimation.h
+++ b/client/render/CAnimation.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "IImage.h"
+#include "ImageLocator.h"
 
 #include "../../lib/GameConstants.h"
 #include "../../lib/filesystem/ResourcePath.h"
@@ -25,8 +26,8 @@ class RenderHandler;
 class CAnimation
 {
 private:
-	//source[group][position] - file with this frame, if string is empty - image located in def file
-	std::map<size_t, std::vector <JsonNode> > source;
+	//source[group][position] - location of this frame
+	std::map<size_t, std::vector <ImageLocator> > source;
 
 	//bitmap[group][position], store objects with loaded bitmaps
 	std::map<size_t, std::map<size_t, std::shared_ptr<IImage> > > images;
@@ -35,6 +36,9 @@ private:
 	AnimationPath name;
 
 	EImageBlitMode mode;
+
+	// current player color, if any
+	PlayerColor player = PlayerColor::CANNOT_DETERMINE;
 
 	//loader, will be called by load(), require opened def file for loading from it. Returns true if image is loaded
 	bool loadFrame(size_t frame, size_t group);
@@ -47,7 +51,7 @@ private:
 
 	std::shared_ptr<IImage> getImageImpl(size_t frame, size_t group=0, bool verbose=true);
 public:
-	CAnimation(const AnimationPath & Name, std::map<size_t, std::vector <JsonNode> > layout, EImageBlitMode mode);
+	CAnimation(const AnimationPath & Name, std::map<size_t, std::vector <ImageLocator> > layout, EImageBlitMode mode);
 	~CAnimation();
 
 	//duplicates frame at [sourceGroup, sourceFrame] as last frame in targetGroup

--- a/client/render/CAnimation.h
+++ b/client/render/CAnimation.h
@@ -62,6 +62,8 @@ public:
 	//total count of frames in group (including not loaded)
 	size_t size(size_t group=0) const;
 
+	void horizontalFlip(size_t frame, size_t group=0);
+	void verticalFlip(size_t frame, size_t group=0);
 	void horizontalFlip();
 	void verticalFlip();
 	void playerColored(PlayerColor player);

--- a/client/render/CAnimation.h
+++ b/client/render/CAnimation.h
@@ -9,6 +9,8 @@
  */
 #pragma once
 
+#include "IImage.h"
+
 #include "../../lib/GameConstants.h"
 #include "../../lib/filesystem/ResourcePath.h"
 
@@ -17,7 +19,6 @@ class JsonNode;
 VCMI_LIB_NAMESPACE_END
 
 class CDefFile;
-class IImage;
 class RenderHandler;
 
 /// Class for handling animation
@@ -33,6 +34,8 @@ private:
 	//animation file name
 	AnimationPath name;
 
+	EImageBlitMode mode;
+
 	//loader, will be called by load(), require opened def file for loading from it. Returns true if image is loaded
 	bool loadFrame(size_t frame, size_t group);
 
@@ -44,7 +47,7 @@ private:
 
 	std::shared_ptr<IImage> getImageImpl(size_t frame, size_t group=0, bool verbose=true);
 public:
-	CAnimation(const AnimationPath & Name, std::map<size_t, std::vector <JsonNode> > layout);
+	CAnimation(const AnimationPath & Name, std::map<size_t, std::vector <JsonNode> > layout, EImageBlitMode mode);
 	CAnimation();
 	~CAnimation();
 

--- a/client/render/CAnimation.h
+++ b/client/render/CAnimation.h
@@ -59,19 +59,6 @@ public:
 
 	void exportBitmaps(const boost::filesystem::path & path) const;
 
-	//all available frames
-	void load  ();
-	void unload();
-	void preload();
-
-	//all frames from group
-	void loadGroup  (size_t group);
-	void unloadGroup(size_t group);
-
-	//single image
-	void load  (size_t frame, size_t group=0);
-	void unload(size_t frame, size_t group=0);
-
 	//total count of frames in group (including not loaded)
 	size_t size(size_t group=0) const;
 

--- a/client/render/CAnimation.h
+++ b/client/render/CAnimation.h
@@ -35,27 +35,17 @@ private:
 
 	bool preloaded;
 
-	std::shared_ptr<CDefFile> defFile;
-
 	//loader, will be called by load(), require opened def file for loading from it. Returns true if image is loaded
 	bool loadFrame(size_t frame, size_t group);
 
 	//unloadFrame, returns true if image has been unloaded ( either deleted or decreased refCount)
 	bool unloadFrame(size_t frame, size_t group);
 
-	//initialize animation from file
-	void initFromJson(const JsonNode & input);
-	void init();
-
 	//to get rid of copy-pasting error message :]
 	void printError(size_t frame, size_t group, std::string type) const;
 
-	//not a very nice method to get image from another def file
-	//TODO: remove after implementing resource manager
-	std::shared_ptr<IImage> getFromExtraDef(std::string filename);
-
 public:
-	CAnimation(const AnimationPath & Name);
+	CAnimation(const AnimationPath & Name, std::map<size_t, std::vector <JsonNode> > layout);
 	CAnimation();
 	~CAnimation();
 

--- a/client/render/CAnimation.h
+++ b/client/render/CAnimation.h
@@ -50,6 +50,8 @@ private:
 	void printError(size_t frame, size_t group, std::string type) const;
 
 	std::shared_ptr<IImage> getImageImpl(size_t frame, size_t group=0, bool verbose=true);
+
+	ImageLocator getImageLocator(size_t frame, size_t group) const;
 public:
 	CAnimation(const AnimationPath & Name, std::map<size_t, std::vector <ImageLocator> > layout, EImageBlitMode mode);
 	~CAnimation();

--- a/client/render/Canvas.cpp
+++ b/client/render/Canvas.cpp
@@ -81,14 +81,14 @@ void Canvas::draw(const std::shared_ptr<IImage>& image, const Point & pos)
 {
 	assert(image);
 	if (image)
-		image->draw(surface, renderArea.x + pos.x, renderArea.y + pos.y);
+		image->draw(surface, pos + renderArea.topLeft());
 }
 
 void Canvas::draw(const std::shared_ptr<IImage>& image, const Point & pos, const Rect & sourceRect)
 {
 	assert(image);
 	if (image)
-		image->draw(surface, renderArea.x + pos.x, renderArea.y + pos.y, &sourceRect);
+		image->draw(surface, pos + renderArea.topLeft(), &sourceRect);
 }
 
 void Canvas::draw(const Canvas & image, const Point & pos)
@@ -192,7 +192,7 @@ void Canvas::fillTexture(const std::shared_ptr<IImage>& image)
 	for (int y=0; y < surface->h; y+= imageArea.h)
 	{
 		for (int x=0; x < surface->w; x+= imageArea.w)
-			image->draw(surface, renderArea.x + x, renderArea.y + y);
+			image->draw(surface, Point(renderArea.x + x, renderArea.y + y));
 	}
 }
 

--- a/client/render/Graphics.cpp
+++ b/client/render/Graphics.cpp
@@ -131,7 +131,6 @@ Graphics::Graphics()
 	loadPaletteAndColors();
 	initializeBattleGraphics();
 	loadErmuToPicture();
-	initializeImageLists();
 
 	//(!) do not load any CAnimation here
 }
@@ -243,52 +242,4 @@ void Graphics::loadErmuToPicture()
 		etp_idx ++;
 	}
 	assert (etp_idx == 44);
-}
-
-void Graphics::addImageListEntry(size_t index, size_t group, const std::string & listName, const std::string & imageName)
-{
-	if (!imageName.empty())
-	{
-		JsonNode entry;
-		if (group != 0)
-			entry["group"].Integer() = group;
-		entry["frame"].Integer() = index;
-		entry["file"].String() = imageName;
-
-		imageLists["SPRITES/" + listName]["images"].Vector().push_back(entry);
-	}
-}
-
-void Graphics::addImageListEntries(const EntityService * service)
-{
-	auto cb = std::bind(&Graphics::addImageListEntry, this, _1, _2, _3, _4);
-
-	auto loopCb = [&](const Entity * entity, bool & stop)
-	{
-		entity->registerIcons(cb);
-	};
-
-	service->forEachBase(loopCb);
-}
-
-void Graphics::initializeImageLists()
-{
-	addImageListEntries(CGI->creatures());
-	addImageListEntries(CGI->heroTypes());
-	addImageListEntries(CGI->artifacts());
-	addImageListEntries(CGI->factions());
-	addImageListEntries(CGI->spells());
-	addImageListEntries(CGI->skills());
-}
-
-std::shared_ptr<CAnimation> Graphics::getAnimation(const AnimationPath & path)
-{
-	if (cachedAnimations.count(path) != 0)
-		return cachedAnimations.at(path);
-
-	auto newAnimation = GH.renderHandler().loadAnimation(path);
-
-	newAnimation->preload();
-	cachedAnimations[path] = newAnimation;
-	return newAnimation;
 }

--- a/client/render/Graphics.cpp
+++ b/client/render/Graphics.cpp
@@ -135,71 +135,34 @@ Graphics::Graphics()
 	//(!) do not load any CAnimation here
 }
 
-void Graphics::blueToPlayersAdv(SDL_Surface * sur, PlayerColor player)
+void Graphics::setPlayerPalette(SDL_Palette * targetPalette, PlayerColor player)
 {
-	if(sur->format->palette)
+	SDL_Color palette[32];
+	if(player.isValidPlayer())
 	{
-		SDL_Color palette[32];
-		if(player.isValidPlayer())
-		{
-			for(int i=0; i<32; ++i)
-				palette[i] = CSDL_Ext::toSDL(playerColorPalette[player][i]);
-		}
-		else if(player == PlayerColor::NEUTRAL)
-		{
-			for(int i=0; i<32; ++i)
-				palette[i] = CSDL_Ext::toSDL(neutralColorPalette[i]);
-		}
-		else
-		{
-			logGlobal->error("Wrong player id in blueToPlayersAdv (%s)!", player.toString());
-			return;
-		}
-//FIXME: not all player colored images have player palette at last 32 indexes
-//NOTE: following code is much more correct but still not perfect (bugged with status bar)
-		CSDL_Ext::setColors(sur, palette, 224, 32);
-
-
-#if 0
-
-		SDL_Color * bluePalette = playerColorPalette + 32;
-
-		SDL_Palette * oldPalette = sur->format->palette;
-
-		SDL_Palette * newPalette = SDL_AllocPalette(256);
-
-		for(size_t destIndex = 0; destIndex < 256; destIndex++)
-		{
-			SDL_Color old = oldPalette->colors[destIndex];
-
-			bool found = false;
-
-			for(size_t srcIndex = 0; srcIndex < 32; srcIndex++)
-			{
-				if(old.b == bluePalette[srcIndex].b && old.g == bluePalette[srcIndex].g && old.r == bluePalette[srcIndex].r)
-				{
-					found = true;
-					newPalette->colors[destIndex] = palette[srcIndex];
-					break;
-				}
-			}
-			if(!found)
-				newPalette->colors[destIndex] = old;
-		}
-
-		SDL_SetSurfacePalette(sur, newPalette);
-
-		SDL_FreePalette(newPalette);
-
-#endif // 0
+		for(int i=0; i<32; ++i)
+			palette[i] = CSDL_Ext::toSDL(playerColorPalette[player][i]);
 	}
 	else
 	{
-		//TODO: implement. H3 method works only for images with palettes.
-		// Add some kind of player-colored overlay?
-		// Or keep palette approach here and replace only colors of specific value(s)
-		// Or just wait for OpenGL support?
-		logGlobal->warn("Image must have palette to be player-colored!");
+		for(int i=0; i<32; ++i)
+			palette[i] = CSDL_Ext::toSDL(neutralColorPalette[i]);
+	}
+
+	SDL_SetPaletteColors(targetPalette, palette, 224, 32);
+}
+
+void Graphics::setPlayerFlagColor(SDL_Palette * targetPalette, PlayerColor player)
+{
+	if(player.isValidPlayer())
+	{
+		SDL_Color color = CSDL_Ext::toSDL(playerColors[player.getNum()]);
+		SDL_SetPaletteColors(targetPalette, &color, 5, 1);
+	}
+	else
+	{
+		SDL_Color color = CSDL_Ext::toSDL(neutralColor);
+		SDL_SetPaletteColors(targetPalette, &color, 5, 1);
 	}
 }
 

--- a/client/render/Graphics.h
+++ b/client/render/Graphics.h
@@ -27,7 +27,7 @@ class JsonNode;
 
 VCMI_LIB_NAMESPACE_END
 
-struct SDL_Surface;
+struct SDL_Palette;
 class IFont;
 
 /// Handles fonts, hero images, town images, various graphics
@@ -60,7 +60,8 @@ public:
 	//functions
 	Graphics();
 
-	void blueToPlayersAdv(SDL_Surface * sur, PlayerColor player); //replaces blue interface colour with a color of player
+	void setPlayerPalette(SDL_Palette * sur, PlayerColor player);
+	void setPlayerFlagColor(SDL_Palette * sur, PlayerColor player);
 };
 
 extern Graphics * graphics;

--- a/client/render/Graphics.h
+++ b/client/render/Graphics.h
@@ -34,20 +34,12 @@ class IFont;
 /// Handles fonts, hero images, town images, various graphics
 class Graphics
 {
-	void addImageListEntry(size_t index, size_t group, const std::string & listName, const std::string & imageName);
-	void addImageListEntries(const EntityService * service);
-
 	void initializeBattleGraphics();
 	void loadPaletteAndColors();
 	void loadErmuToPicture();
 	void loadFonts();
-	void initializeImageLists();
-
-	std::map<AnimationPath, std::shared_ptr<CAnimation>> cachedAnimations;
 
 public:
-	std::shared_ptr<CAnimation> getAnimation(const AnimationPath & path);
-
 	//Fonts
 	static const int FONTS_NUMBER = 9;
 	std::array< std::shared_ptr<IFont>, FONTS_NUMBER> fonts;
@@ -60,8 +52,6 @@ public:
 
 	PlayerPalette neutralColorPalette;
 	ColorRGBA neutralColor;
-
-	std::map<std::string, JsonNode> imageLists;
 
 	//towns
 	std::map<int, std::string> ERMUtoPicture[GameConstants::F_NUMBER]; //maps building ID to it's picture's name for each town type

--- a/client/render/Graphics.h
+++ b/client/render/Graphics.h
@@ -28,7 +28,6 @@ class JsonNode;
 VCMI_LIB_NAMESPACE_END
 
 struct SDL_Surface;
-class CAnimation;
 class IFont;
 
 /// Handles fonts, hero images, town images, various graphics

--- a/client/render/IImage.h
+++ b/client/render/IImage.h
@@ -46,10 +46,10 @@ public:
 	static constexpr int32_t SPECIAL_PALETTE_MASK_CREATURES = 0b11110011;
 
 	//draws image on surface "where" at position
-	virtual void draw(SDL_Surface * where, int posX = 0, int posY = 0, const Rect * src = nullptr) const = 0;
-	virtual void draw(SDL_Surface * where, const Rect * dest, const Rect * src) const = 0;
+	virtual void draw(SDL_Surface * where, const Point & pos, const Rect * src = nullptr) const = 0;
+	//virtual void draw(SDL_Surface * where, const Rect * dest, const Rect * src) const = 0;
 
-	virtual std::shared_ptr<IImage> scaleFast(const Point & size) const = 0;
+	virtual void scaleFast(const Point & size) = 0;
 
 	virtual void exportBitmap(const boost::filesystem::path & path) const = 0;
 
@@ -80,4 +80,16 @@ public:
 	virtual void verticalFlip() = 0;
 
 	virtual ~IImage() = default;
+};
+
+class IConstImage
+{
+public:
+	virtual Point dimensions() const = 0;
+	virtual void exportBitmap(const boost::filesystem::path & path) const = 0;
+	virtual bool isTransparent(const Point & coords) const = 0;
+
+	virtual std::shared_ptr<IImage> createImageReference() = 0;
+
+	virtual ~IConstImage() = default;
 };

--- a/client/render/IImage.h
+++ b/client/render/IImage.h
@@ -26,13 +26,17 @@ class ColorFilter;
 /// Defines which blit method will be selected when image is used for rendering
 enum class EImageBlitMode
 {
-	/// Image can have no transparency and can be only used as background
+	/// Preferred for images that don't need any background
+	/// Indexed or RGBA: Image can have no transparency and can be only used as background
 	OPAQUE,
 
-	/// Image can have only a single color as transparency and has no semi-transparent areas
+	/// Preferred for images that may need transparency
+	/// Indexed: Image can have only a single color as transparency and has no semi-transparent areas
+	/// RGBA: full alpha transparency range, e.g. shadows
 	COLORKEY,
 
-	/// Image might have full alpha transparency range, e.g. shadows
+	/// Should be avoided if possible, use only for images that use def's with semi-transparency
+	/// Indexed or RGBA: Image might have full alpha transparency range, e.g. shadows
 	ALPHA
 };
 
@@ -85,7 +89,7 @@ public:
 	virtual void exportBitmap(const boost::filesystem::path & path) const = 0;
 	virtual bool isTransparent(const Point & coords) const = 0;
 
-	virtual std::shared_ptr<IImage> createImageReference() = 0;
+	virtual std::shared_ptr<IImage> createImageReference(EImageBlitMode mode) = 0;
 
 	virtual std::shared_ptr<IConstImage> horizontalFlip() const = 0;
 	virtual std::shared_ptr<IConstImage> verticalFlip() const = 0;

--- a/client/render/IImage.h
+++ b/client/render/IImage.h
@@ -69,8 +69,6 @@ public:
 	//only indexed bitmaps, 16 colors maximum
 	virtual void shiftPalette(uint32_t firstColorID, uint32_t colorsToMove, uint32_t distanceToMove) = 0;
 	virtual void adjustPalette(const ColorFilter & shifter, uint32_t colorsToSkipMask) = 0;
-	virtual void resetPalette(int colorID) = 0;
-	virtual void resetPalette() = 0;
 
 	virtual void setAlpha(uint8_t value) = 0;
 	virtual void setBlitMode(EImageBlitMode mode) = 0;
@@ -81,7 +79,5 @@ public:
 	virtual void horizontalFlip() = 0;
 	virtual void verticalFlip() = 0;
 
-	IImage() = default;
 	virtual ~IImage() = default;
 };
-

--- a/client/render/IImage.h
+++ b/client/render/IImage.h
@@ -80,7 +80,6 @@ public:
 
 	virtual void horizontalFlip() = 0;
 	virtual void verticalFlip() = 0;
-	virtual void doubleFlip() = 0;
 
 	IImage() = default;
 	virtual ~IImage() = default;

--- a/client/render/IImage.h
+++ b/client/render/IImage.h
@@ -47,17 +47,16 @@ public:
 
 	//draws image on surface "where" at position
 	virtual void draw(SDL_Surface * where, const Point & pos, const Rect * src = nullptr) const = 0;
-	//virtual void draw(SDL_Surface * where, const Rect * dest, const Rect * src) const = 0;
 
 	virtual void scaleFast(const Point & size) = 0;
 
 	virtual void exportBitmap(const boost::filesystem::path & path) const = 0;
 
 	//Change palette to specific player
-	virtual void playerColored(PlayerColor player)=0;
+	virtual void playerColored(PlayerColor player) = 0;
 
 	//set special color for flag
-	virtual void setFlagColor(PlayerColor player)=0;
+	virtual void setFlagColor(PlayerColor player) = 0;
 
 	//test transparency of specific pixel
 	virtual bool isTransparent(const Point & coords) const = 0;

--- a/client/render/IImage.h
+++ b/client/render/IImage.h
@@ -75,9 +75,6 @@ public:
 	//only indexed bitmaps with 7 special colors
 	virtual void setSpecialPalette(const SpecialPalette & SpecialPalette, uint32_t colorsToSkipMask) = 0;
 
-	virtual void horizontalFlip() = 0;
-	virtual void verticalFlip() = 0;
-
 	virtual ~IImage() = default;
 };
 
@@ -89,6 +86,10 @@ public:
 	virtual bool isTransparent(const Point & coords) const = 0;
 
 	virtual std::shared_ptr<IImage> createImageReference() = 0;
+
+	virtual std::shared_ptr<IConstImage> horizontalFlip() const = 0;
+	virtual std::shared_ptr<IConstImage> verticalFlip() const = 0;
+
 
 	virtual ~IConstImage() = default;
 };

--- a/client/render/IImageLoader.h
+++ b/client/render/IImageLoader.h
@@ -14,8 +14,6 @@ VCMI_LIB_NAMESPACE_BEGIN
 class Point;
 VCMI_LIB_NAMESPACE_END
 
-class SDLImage;
-
 struct SDL_Color;
 
 class IImageLoader

--- a/client/render/IRenderHandler.h
+++ b/client/render/IRenderHandler.h
@@ -30,6 +30,7 @@ public:
 	virtual void onLibraryLoadingFinished(const Services * services) = 0;
 
 	/// Loads image using given path
+	virtual std::shared_ptr<IImage> loadImage(const JsonNode & config) = 0;
 	virtual std::shared_ptr<IImage> loadImage(const ImagePath & path) = 0;
 	virtual std::shared_ptr<IImage> loadImage(const ImagePath & path, EImageBlitMode mode) = 0;
 	virtual std::shared_ptr<IImage> loadImage(const AnimationPath & path, int frame, int group) = 0;

--- a/client/render/IRenderHandler.h
+++ b/client/render/IRenderHandler.h
@@ -11,6 +11,10 @@
 
 #include "../../lib/filesystem/ResourcePath.h"
 
+VCMI_LIB_NAMESPACE_BEGIN
+class Services;
+VCMI_LIB_NAMESPACE_END
+
 struct SDL_Surface;
 
 class IImage;
@@ -21,6 +25,9 @@ class IRenderHandler : public boost::noncopyable
 {
 public:
 	virtual ~IRenderHandler() = default;
+
+	/// Must be called once VLC loading is over to initialize icons
+	virtual void onLibraryLoadingFinished(const Services * services) = 0;
 
 	/// Loads image using given path
 	virtual std::shared_ptr<IImage> loadImage(const ImagePath & path) = 0;

--- a/client/render/IRenderHandler.h
+++ b/client/render/IRenderHandler.h
@@ -9,7 +9,7 @@
  */
 #pragma once
 
-#include "../../lib/filesystem/ResourcePath.h"
+#include "ImageLocator.h"
 
 VCMI_LIB_NAMESPACE_BEGIN
 class Services;
@@ -30,7 +30,7 @@ public:
 	virtual void onLibraryLoadingFinished(const Services * services) = 0;
 
 	/// Loads image using given path
-	virtual std::shared_ptr<IImage> loadImage(const JsonNode & config, EImageBlitMode mode) = 0;
+	virtual std::shared_ptr<IImage> loadImage(const ImageLocator & locator, EImageBlitMode mode) = 0;
 	virtual std::shared_ptr<IImage> loadImage(const ImagePath & path, EImageBlitMode mode) = 0;
 	virtual std::shared_ptr<IImage> loadImage(const AnimationPath & path, int frame, int group, EImageBlitMode mode) = 0;
 

--- a/client/render/IRenderHandler.h
+++ b/client/render/IRenderHandler.h
@@ -25,7 +25,6 @@ public:
 	/// Loads image using given path
 	virtual std::shared_ptr<IImage> loadImage(const ImagePath & path) = 0;
 	virtual std::shared_ptr<IImage> loadImage(const ImagePath & path, EImageBlitMode mode) = 0;
-
 	virtual std::shared_ptr<IImage> loadImage(const AnimationPath & path, int frame, int group) = 0;
 
 	/// temporary compatibility method. Creates IImage from existing SDL_Surface
@@ -35,6 +34,6 @@ public:
 	/// Loads animation using given path
 	virtual std::shared_ptr<CAnimation> loadAnimation(const AnimationPath & path) = 0;
 
-	/// Creates empty CAnimation
+	/// Creates empty CAnimation. Temporary compatibility method
 	virtual std::shared_ptr<CAnimation> createAnimation() = 0;
 };

--- a/client/render/IRenderHandler.h
+++ b/client/render/IRenderHandler.h
@@ -26,6 +26,8 @@ public:
 	virtual std::shared_ptr<IImage> loadImage(const ImagePath & path) = 0;
 	virtual std::shared_ptr<IImage> loadImage(const ImagePath & path, EImageBlitMode mode) = 0;
 
+	virtual std::shared_ptr<IImage> loadImage(const AnimationPath & path, int frame, int group) = 0;
+
 	/// temporary compatibility method. Creates IImage from existing SDL_Surface
 	/// Surface will be shared, caller must still free it with SDL_FreeSurface
 	virtual std::shared_ptr<IImage> createImage(SDL_Surface * source) = 0;

--- a/client/render/IRenderHandler.h
+++ b/client/render/IRenderHandler.h
@@ -30,17 +30,16 @@ public:
 	virtual void onLibraryLoadingFinished(const Services * services) = 0;
 
 	/// Loads image using given path
-	virtual std::shared_ptr<IImage> loadImage(const JsonNode & config) = 0;
-	virtual std::shared_ptr<IImage> loadImage(const ImagePath & path) = 0;
+	virtual std::shared_ptr<IImage> loadImage(const JsonNode & config, EImageBlitMode mode) = 0;
 	virtual std::shared_ptr<IImage> loadImage(const ImagePath & path, EImageBlitMode mode) = 0;
-	virtual std::shared_ptr<IImage> loadImage(const AnimationPath & path, int frame, int group) = 0;
+	virtual std::shared_ptr<IImage> loadImage(const AnimationPath & path, int frame, int group, EImageBlitMode mode) = 0;
 
 	/// temporary compatibility method. Creates IImage from existing SDL_Surface
 	/// Surface will be shared, caller must still free it with SDL_FreeSurface
 	virtual std::shared_ptr<IImage> createImage(SDL_Surface * source) = 0;
 
 	/// Loads animation using given path
-	virtual std::shared_ptr<CAnimation> loadAnimation(const AnimationPath & path) = 0;
+	virtual std::shared_ptr<CAnimation> loadAnimation(const AnimationPath & path, EImageBlitMode mode) = 0;
 
 	/// Creates empty CAnimation. Temporary compatibility method
 	virtual std::shared_ptr<CAnimation> createAnimation() = 0;

--- a/client/render/IRenderHandler.h
+++ b/client/render/IRenderHandler.h
@@ -40,7 +40,4 @@ public:
 
 	/// Loads animation using given path
 	virtual std::shared_ptr<CAnimation> loadAnimation(const AnimationPath & path, EImageBlitMode mode) = 0;
-
-	/// Creates empty CAnimation. Temporary compatibility method
-	virtual std::shared_ptr<CAnimation> createAnimation() = 0;
 };

--- a/client/render/ImageLocator.cpp
+++ b/client/render/ImageLocator.cpp
@@ -49,3 +49,8 @@ bool ImageLocator::operator<(const ImageLocator & other) const
 		return verticalFlip < other.verticalFlip;
 	return horizontalFlip < other.horizontalFlip;
 }
+
+bool ImageLocator::empty() const
+{
+	return !image.has_value() && !defFile.has_value();
+}

--- a/client/render/ImageLocator.cpp
+++ b/client/render/ImageLocator.cpp
@@ -1,0 +1,51 @@
+/*
+ * ImageLocator.cpp, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
+#include "StdInc.h"
+#include "ImageLocator.h"
+
+#include "../../lib/json/JsonNode.h"
+
+
+ImageLocator::ImageLocator(const JsonNode & config)
+	: image(ImagePath::fromJson(config["file"]))
+	, defFile(AnimationPath::fromJson(config["defFile"]))
+	, defFrame(config["defFrame"].Integer())
+	, defGroup(config["defGroup"].Integer())
+	, verticalFlip(config["verticalFlip"].Bool())
+	, horizontalFlip(config["horizontalFlip"].Bool())
+{
+}
+
+ImageLocator::ImageLocator(const ImagePath & path)
+	: image(path)
+{
+}
+
+ImageLocator::ImageLocator(const AnimationPath & path, int frame, int group)
+	: defFile(path)
+	, defFrame(frame)
+	, defGroup(group)
+{
+}
+
+bool ImageLocator::operator<(const ImageLocator & other) const
+{
+	if(image != other.image)
+		return image < other.image;
+	if(defFile != other.defFile)
+		return defFile < other.defFile;
+	if(defGroup != other.defGroup)
+		return defGroup < other.defGroup;
+	if(defFrame != other.defFrame)
+		return defFrame < other.defFrame;
+	if(verticalFlip != other.verticalFlip)
+		return verticalFlip < other.verticalFlip;
+	return horizontalFlip < other.horizontalFlip;
+}

--- a/client/render/ImageLocator.h
+++ b/client/render/ImageLocator.h
@@ -1,0 +1,29 @@
+/*
+ * ImageLocator.h, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
+#pragma once
+
+#include "../../lib/filesystem/ResourcePath.h"
+
+struct ImageLocator
+{
+	std::optional<ImagePath> image;
+	std::optional<AnimationPath> defFile;
+	int defFrame = -1;
+	int defGroup = -1;
+
+	bool verticalFlip = false;
+	bool horizontalFlip = false;
+
+	ImageLocator() = default;
+	ImageLocator(const JsonNode & config);
+	ImageLocator(const ImagePath & path);
+	ImageLocator(const AnimationPath & path, int frame, int group);
+	bool operator < (const ImageLocator & other) const;
+};

--- a/client/render/ImageLocator.h
+++ b/client/render/ImageLocator.h
@@ -22,8 +22,10 @@ struct ImageLocator
 	bool horizontalFlip = false;
 
 	ImageLocator() = default;
-	ImageLocator(const JsonNode & config);
-	ImageLocator(const ImagePath & path);
 	ImageLocator(const AnimationPath & path, int frame, int group);
+	explicit ImageLocator(const JsonNode & config);
+	explicit ImageLocator(const ImagePath & path);
+
 	bool operator < (const ImageLocator & other) const;
+	bool empty() const;
 };

--- a/client/renderSDL/CBitmapFont.cpp
+++ b/client/renderSDL/CBitmapFont.cpp
@@ -125,7 +125,7 @@ void CBitmapFont::renderCharacter(SDL_Surface * surface, const BitmapChar & char
 
 	posX += character.leftOffset;
 
-	CSDL_Ext::TColorPutter colorPutter = CSDL_Ext::getPutterFor(surface, 0);
+	CSDL_Ext::TColorPutter colorPutter = CSDL_Ext::getPutterFor(surface);
 
 	uint8_t bpp = surface->format->BytesPerPixel;
 

--- a/client/renderSDL/CBitmapHanFont.cpp
+++ b/client/renderSDL/CBitmapHanFont.cpp
@@ -41,7 +41,7 @@ void CBitmapHanFont::renderCharacter(SDL_Surface * surface, int characterIndex, 
 	Rect clipRect;
 	CSDL_Ext::getClipRect(surface, clipRect);
 
-	CSDL_Ext::TColorPutter colorPutter = CSDL_Ext::getPutterFor(surface, 0);
+	CSDL_Ext::TColorPutter colorPutter = CSDL_Ext::getPutterFor(surface);
 	uint8_t bpp = surface->format->BytesPerPixel;
 
 	// start of line, may differ from 0 due to end of surface or clipped surface

--- a/client/renderSDL/CursorHardware.cpp
+++ b/client/renderSDL/CursorHardware.cpp
@@ -49,7 +49,7 @@ void CursorHardware::setImage(std::shared_ptr<IImage> image, const Point & pivot
 
 	CSDL_Ext::fillSurface(cursorSurface, CSDL_Ext::toSDL(Colors::TRANSPARENCY));
 
-	image->draw(cursorSurface);
+	image->draw(cursorSurface, Point(0,0));
 
 	auto oldCursor = cursor;
 	cursor = SDL_CreateColorCursor(cursorSurface, pivotOffset.x, pivotOffset.y);

--- a/client/renderSDL/CursorHardware.h
+++ b/client/renderSDL/CursorHardware.h
@@ -9,7 +9,6 @@
  */
 #pragma once
 
-class CAnimation;
 class IImage;
 struct SDL_Surface;
 struct SDL_Texture;

--- a/client/renderSDL/CursorSoftware.cpp
+++ b/client/renderSDL/CursorSoftware.cpp
@@ -58,7 +58,7 @@ void CursorSoftware::updateTexture()
 
 	CSDL_Ext::fillSurface(cursorSurface, CSDL_Ext::toSDL(Colors::TRANSPARENCY));
 
-	cursorImage->draw(cursorSurface);
+	cursorImage->draw(cursorSurface, Point(0,0));
 	SDL_UpdateTexture(cursorTexture, nullptr, cursorSurface->pixels, cursorSurface->pitch);
 	needUpdate = false;
 }

--- a/client/renderSDL/CursorSoftware.h
+++ b/client/renderSDL/CursorSoftware.h
@@ -9,7 +9,6 @@
  */
 #pragma once
 
-class CAnimation;
 class IImage;
 struct SDL_Surface;
 struct SDL_Texture;

--- a/client/renderSDL/RenderHandler.cpp
+++ b/client/renderSDL/RenderHandler.cpp
@@ -164,7 +164,7 @@ RenderHandler::AnimationLayoutMap & RenderHandler::getAnimationLayout(const Anim
 
 std::shared_ptr<IConstImage> RenderHandler::loadImageFromSingleFile(const ImagePath & path)
 {
-	auto result = std::make_shared<SDLImageConst>(path, EImageBlitMode::COLORKEY);
+	auto result = std::make_shared<SDLImageConst>(path);
 	imageFiles[ImageLocator(path)] = result;
 	return result;
 }
@@ -223,37 +223,32 @@ std::shared_ptr<IConstImage> RenderHandler::loadImageImpl(const ImageLocator & l
 	return result;
 }
 
-std::shared_ptr<IImage> RenderHandler::loadImage(const JsonNode & config)
+std::shared_ptr<IImage> RenderHandler::loadImage(const JsonNode & config, EImageBlitMode mode)
 {
 	if (config.isString())
-		return loadImageImpl(ImageLocator(ImagePath::fromJson(config)))->createImageReference();
+		return loadImageImpl(ImageLocator(ImagePath::fromJson(config)))->createImageReference(mode);
 	else
-		return loadImageImpl(ImageLocator(config))->createImageReference();
+		return loadImageImpl(ImageLocator(config))->createImageReference(mode);
 }
 
-std::shared_ptr<IImage> RenderHandler::loadImage(const AnimationPath & path, int frame, int group)
+std::shared_ptr<IImage> RenderHandler::loadImage(const AnimationPath & path, int frame, int group, EImageBlitMode mode)
 {
-	return loadImageImpl(ImageLocator(path, frame, group))->createImageReference();
-}
-
-std::shared_ptr<IImage> RenderHandler::loadImage(const ImagePath & path)
-{
-	return loadImage(path, EImageBlitMode::ALPHA);
+	return loadImageImpl(ImageLocator(path, frame, group))->createImageReference(mode);
 }
 
 std::shared_ptr<IImage> RenderHandler::loadImage(const ImagePath & path, EImageBlitMode mode)
 {
-	return loadImageImpl(ImageLocator(path))->createImageReference();
+	return loadImageImpl(ImageLocator(path))->createImageReference(mode);
 }
 
 std::shared_ptr<IImage> RenderHandler::createImage(SDL_Surface * source)
 {
-	return std::make_shared<SDLImageConst>(source, EImageBlitMode::ALPHA)->createImageReference();
+	return std::make_shared<SDLImageConst>(source)->createImageReference(EImageBlitMode::ALPHA);
 }
 
-std::shared_ptr<CAnimation> RenderHandler::loadAnimation(const AnimationPath & path)
+std::shared_ptr<CAnimation> RenderHandler::loadAnimation(const AnimationPath & path, EImageBlitMode mode)
 {
-	return std::make_shared<CAnimation>(path, getAnimationLayout(path));
+	return std::make_shared<CAnimation>(path, getAnimationLayout(path), mode);
 }
 
 std::shared_ptr<CAnimation> RenderHandler::createAnimation()

--- a/client/renderSDL/RenderHandler.cpp
+++ b/client/renderSDL/RenderHandler.cpp
@@ -68,7 +68,7 @@ void RenderHandler::initFromJson(AnimationLayoutMap & source, const JsonNode & c
 			JsonNode toAdd;
 			JsonUtils::inherit(toAdd, base);
 			toAdd["file"].String() = basepath + frame.String();
-			source[groupID].push_back(toAdd);
+			source[groupID].push_back(ImageLocator(toAdd));
 		}
 	}
 
@@ -83,7 +83,7 @@ void RenderHandler::initFromJson(AnimationLayoutMap & source, const JsonNode & c
 		JsonNode toAdd;
 		JsonUtils::inherit(toAdd, base);
 		toAdd["file"].String() = basepath + node["file"].String();
-		source[group][frame] = toAdd;
+		source[group][frame] = ImageLocator(toAdd);
 	}
 }
 
@@ -141,10 +141,10 @@ std::shared_ptr<IConstImage> RenderHandler::loadImageFromAnimationFileUncached(c
 	if (frame >= layout.at(group).size())
 		return loadImageFromSingleFile(ImagePath::builtin("DEFAULT"));
 
-	const auto & config = layout.at(group).at(frame);
-	if (config.image)
+	const auto & locator = layout.at(group).at(frame);
+	if (locator.image)
 	{
-		return loadImageImpl(ImageLocator(config));
+		return loadImageImpl(locator);
 	}
 	else
 	{
@@ -168,7 +168,7 @@ std::shared_ptr<IConstImage> RenderHandler::loadImageImpl(const ImageLocator & l
 
 	std::shared_ptr<IConstImage> result;
 
-	if (!locator.image)
+	if (locator.image)
 		result = loadImageFromSingleFile(*locator.image);
 	else if (locator.defFile)
 		result = loadImageFromAnimationFile(*locator.defFile, locator.defFrame, locator.defGroup);
@@ -228,7 +228,7 @@ void RenderHandler::addImageListEntries(const EntityService * service)
 			if (index >= layout[group].size())
 				layout[group].resize(index + 1);
 
-			layout[group][index] = entry;
+			layout[group][index] = ImageLocator(entry);
 		});
 	});
 }

--- a/client/renderSDL/RenderHandler.cpp
+++ b/client/renderSDL/RenderHandler.cpp
@@ -10,9 +10,66 @@
 #include "StdInc.h"
 #include "RenderHandler.h"
 
-#include "../render/CAnimation.h"
 #include "SDLImage.h"
 
+#include "../render/CAnimation.h"
+#include "../render/CDefFile.h"
+
+#include "../../lib/json/JsonNode.h"
+
+std::shared_ptr<CDefFile> RenderHandler::getAnimationFile(const AnimationPath & path)
+{
+	auto it = animationFiles.find(path);
+
+	if (it != animationFiles.end())
+		return it->second;
+
+	auto result = std::make_shared<CDefFile>(path);
+
+	animationFiles[path] = result;
+	return result;
+}
+
+std::shared_ptr<JsonNode> RenderHandler::getJsonFile(const JsonPath & path)
+{
+	auto it = jsonFiles.find(path);
+
+	if (it != jsonFiles.end())
+		return it->second;
+
+	auto result = std::make_shared<JsonNode>(path);
+
+	jsonFiles[path] = result;
+	return result;
+}
+
+std::shared_ptr<IImage> RenderHandler::loadImage(const AnimationPath & path, int frame, int group)
+{
+	AnimationLocator locator{path, frame, group};
+
+	auto it = animationFrames.find(locator);
+	if (it != animationFrames.end())
+		return it->second;
+
+	auto defFile = getAnimationFile(path);
+	auto result = std::make_shared<SDLImage>(defFile.get(), frame, group);
+
+	animationFrames[locator] = result;
+	return result;
+}
+
+//std::vector<std::shared_ptr<IImage>> RenderHandler::loadImageGroup(const AnimationPath & path, int group)
+//{
+//	const auto defFile = getAnimationFile(path);
+//
+//	size_t groupSize = defFile->getEntries().at(group);
+//
+//	std::vector<std::shared_ptr<IImage>> result;
+//	for (size_t i = 0; i < groupSize; ++i)
+//		loadImage(path, i, group);
+//
+//	return result;
+//}
 
 std::shared_ptr<IImage> RenderHandler::loadImage(const ImagePath & path)
 {
@@ -38,3 +95,52 @@ std::shared_ptr<CAnimation> RenderHandler::createAnimation()
 {
 	return std::make_shared<CAnimation>();
 }
+
+//
+//void Graphics::addImageListEntry(size_t index, size_t group, const std::string & listName, const std::string & imageName)
+//{
+//	if (!imageName.empty())
+//	{
+//		JsonNode entry;
+//		if (group != 0)
+//			entry["group"].Integer() = group;
+//		entry["frame"].Integer() = index;
+//		entry["file"].String() = imageName;
+//
+//		imageLists["SPRITES/" + listName]["images"].Vector().push_back(entry);
+//	}
+//}
+//
+//void Graphics::addImageListEntries(const EntityService * service)
+//{
+//	auto cb = std::bind(&Graphics::addImageListEntry, this, _1, _2, _3, _4);
+//
+//	auto loopCb = [&](const Entity * entity, bool & stop)
+//	{
+//		entity->registerIcons(cb);
+//	};
+//
+//	service->forEachBase(loopCb);
+//}
+//
+//void Graphics::initializeImageLists()
+//{
+//	addImageListEntries(CGI->creatures());
+//	addImageListEntries(CGI->heroTypes());
+//	addImageListEntries(CGI->artifacts());
+//	addImageListEntries(CGI->factions());
+//	addImageListEntries(CGI->spells());
+//	addImageListEntries(CGI->skills());
+//}
+//
+//std::shared_ptr<CAnimation> Graphics::getAnimation(const AnimationPath & path)
+//{
+//	if (cachedAnimations.count(path) != 0)
+//		return cachedAnimations.at(path);
+//
+//	auto newAnimation = GH.renderHandler().loadAnimation(path);
+//
+//	newAnimation->preload();
+//	cachedAnimations[path] = newAnimation;
+//	return newAnimation;
+//}

--- a/client/renderSDL/RenderHandler.cpp
+++ b/client/renderSDL/RenderHandler.cpp
@@ -188,7 +188,7 @@ std::shared_ptr<IConstImage> RenderHandler::loadImageImpl(const ImageLocator & l
 
 std::shared_ptr<IImage> RenderHandler::loadImage(const ImageLocator & locator, EImageBlitMode mode)
 {
-		return loadImageImpl(locator)->createImageReference(mode);
+	return loadImageImpl(locator)->createImageReference(mode);
 }
 
 std::shared_ptr<IImage> RenderHandler::loadImage(const AnimationPath & path, int frame, int group, EImageBlitMode mode)

--- a/client/renderSDL/RenderHandler.cpp
+++ b/client/renderSDL/RenderHandler.cpp
@@ -65,10 +65,10 @@ void RenderHandler::initFromJson(AnimationLayoutMap & source, const JsonNode & c
 
 		for(const JsonNode & frame : group["frames"].Vector())
 		{
-			JsonNode toAdd;
+			JsonNode toAdd = frame;
 			JsonUtils::inherit(toAdd, base);
 			toAdd["file"].String() = basepath + frame.String();
-			source[groupID].push_back(ImageLocator(toAdd));
+			source[groupID].emplace_back(toAdd);
 		}
 	}
 
@@ -80,7 +80,7 @@ void RenderHandler::initFromJson(AnimationLayoutMap & source, const JsonNode & c
 		if (source[group].size() <= frame)
 			source[group].resize(frame+1);
 
-		JsonNode toAdd;
+		JsonNode toAdd = node;
 		JsonUtils::inherit(toAdd, base);
 		toAdd["file"].String() = basepath + node["file"].String();
 		source[group][frame] = ImageLocator(toAdd);

--- a/client/renderSDL/RenderHandler.cpp
+++ b/client/renderSDL/RenderHandler.cpp
@@ -134,13 +134,13 @@ std::shared_ptr<IImage> RenderHandler::loadImage(const AnimationPath & path, int
 
 	auto it = animationFrames.find(locator);
 	if (it != animationFrames.end())
-		return it->second;
+		return it->second->createImageReference();
 
 	auto defFile = getAnimationFile(path);
-	auto result = std::make_shared<SDLImage>(defFile.get(), frame, group);
+	auto result = std::make_shared<SDLImageConst>(defFile.get(), frame, group);
 
 	animationFrames[locator] = result;
-	return result;
+	return result->createImageReference();
 }
 
 //std::vector<std::shared_ptr<IImage>> RenderHandler::loadImageGroup(const AnimationPath & path, int group)
@@ -165,16 +165,16 @@ std::shared_ptr<IImage> RenderHandler::loadImage(const ImagePath & path, EImageB
 {
 	auto it = imageFiles.find(path);
 	if (it != imageFiles.end())
-		return it->second;
+		return it->second->createImageReference();
 
-	auto result = std::make_shared<SDLImage>(path, mode);
+	auto result = std::make_shared<SDLImageConst>(path, mode);
 	imageFiles[path] = result;
-	return result;
+	return result->createImageReference();
 }
 
 std::shared_ptr<IImage> RenderHandler::createImage(SDL_Surface * source)
 {
-	return std::make_shared<SDLImage>(source, EImageBlitMode::ALPHA);
+	return std::make_shared<SDLImageConst>(source, EImageBlitMode::ALPHA)->createImageReference();
 }
 
 std::shared_ptr<CAnimation> RenderHandler::loadAnimation(const AnimationPath & path)

--- a/client/renderSDL/RenderHandler.cpp
+++ b/client/renderSDL/RenderHandler.cpp
@@ -251,11 +251,6 @@ std::shared_ptr<CAnimation> RenderHandler::loadAnimation(const AnimationPath & p
 	return std::make_shared<CAnimation>(path, getAnimationLayout(path), mode);
 }
 
-std::shared_ptr<CAnimation> RenderHandler::createAnimation()
-{
-	return std::make_shared<CAnimation>();
-}
-
 void RenderHandler::addImageListEntries(const EntityService * service)
 {
 	service->forEachBase([this](const Entity * entity, bool & stop)

--- a/client/renderSDL/RenderHandler.cpp
+++ b/client/renderSDL/RenderHandler.cpp
@@ -115,19 +115,6 @@ const RenderHandler::AnimationLayoutMap & RenderHandler::getAnimationLayout(cons
 	return animationLayouts[path];
 }
 
-//std::shared_ptr<JsonNode> RenderHandler::getJsonFile(const JsonPath & path)
-//{
-//	auto it = jsonFiles.find(path);
-//
-//	if (it != jsonFiles.end())
-//		return it->second;
-//
-//	auto result = std::make_shared<JsonNode>(path);
-//
-//	jsonFiles[path] = result;
-//	return result;
-//}
-
 std::shared_ptr<IImage> RenderHandler::loadImage(const AnimationPath & path, int frame, int group)
 {
 	AnimationLocator locator{path, frame, group};
@@ -142,19 +129,6 @@ std::shared_ptr<IImage> RenderHandler::loadImage(const AnimationPath & path, int
 	animationFrames[locator] = result;
 	return result->createImageReference();
 }
-
-//std::vector<std::shared_ptr<IImage>> RenderHandler::loadImageGroup(const AnimationPath & path, int group)
-//{
-//	const auto defFile = getAnimationFile(path);
-//
-//	size_t groupSize = defFile->getEntries().at(group);
-//
-//	std::vector<std::shared_ptr<IImage>> result;
-//	for (size_t i = 0; i < groupSize; ++i)
-//		loadImage(path, i, group);
-//
-//	return result;
-//}
 
 std::shared_ptr<IImage> RenderHandler::loadImage(const ImagePath & path)
 {

--- a/client/renderSDL/RenderHandler.h
+++ b/client/renderSDL/RenderHandler.h
@@ -22,26 +22,25 @@ class RenderHandler : public IRenderHandler
 {
 	using AnimationLayoutMap = std::map<size_t, std::vector<JsonNode>>;
 
-	struct AnimationLocator
+	struct ImageLocator
 	{
+		ImagePath image;
 		AnimationPath animation;
 		int frame = -1;
 		int group = -1;
 
-		bool operator < (const AnimationLocator & other) const
-		{
-			if (animation != other.animation)
-				return animation < other.animation;
-			if (group != other.group)
-				return group < other.group;
-			return frame < other.frame;
-		}
+		bool verticalFlip = false;
+		bool horizontalFlip = false;
+
+		ImageLocator(const JsonNode & config);
+		ImageLocator(const ImagePath & path);
+		ImageLocator(const AnimationPath & path, int frame, int group);
+		bool operator < (const ImageLocator & other) const;
 	};
 
 	std::map<AnimationPath, std::shared_ptr<CDefFile>> animationFiles;
 	std::map<AnimationPath, AnimationLayoutMap> animationLayouts;
-	std::map<ImagePath, std::shared_ptr<IConstImage>> imageFiles;
-	std::map<AnimationLocator, std::shared_ptr<IConstImage>> animationFrames;
+	std::map<ImageLocator, std::shared_ptr<IConstImage>> imageFiles;
 
 	std::shared_ptr<CDefFile> getAnimationFile(const AnimationPath & path);
 	AnimationLayoutMap & getAnimationLayout(const AnimationPath & path);
@@ -49,11 +48,17 @@ class RenderHandler : public IRenderHandler
 
 	void addImageListEntry(size_t index, size_t group, const std::string & listName, const std::string & imageName);
 	void addImageListEntries(const EntityService * service);
+
+	std::shared_ptr<IConstImage> loadImageFromSingleFile(const ImagePath & path);
+	std::shared_ptr<IConstImage> loadImageFromAnimationFileUncached(const AnimationPath & path, int frame, int group);
+	std::shared_ptr<IConstImage> loadImageFromAnimationFile(const AnimationPath & path, int frame, int group);
+	std::shared_ptr<IConstImage> loadImageImpl(const ImageLocator & config);
 public:
 
 	// IRenderHandler implementation
 	void onLibraryLoadingFinished(const Services * services) override;
 
+	std::shared_ptr<IImage> loadImage(const JsonNode & config) override;
 	std::shared_ptr<IImage> loadImage(const ImagePath & path) override;
 	std::shared_ptr<IImage> loadImage(const ImagePath & path, EImageBlitMode mode) override;
 	std::shared_ptr<IImage> loadImage(const AnimationPath & path, int frame, int group) override;

--- a/client/renderSDL/RenderHandler.h
+++ b/client/renderSDL/RenderHandler.h
@@ -65,5 +65,4 @@ public:
 	std::shared_ptr<CAnimation> loadAnimation(const AnimationPath & path, EImageBlitMode mode) override;
 
 	std::shared_ptr<IImage> createImage(SDL_Surface * source) override;
-	std::shared_ptr<CAnimation> createAnimation() override;
 };

--- a/client/renderSDL/RenderHandler.h
+++ b/client/renderSDL/RenderHandler.h
@@ -15,6 +15,8 @@ class CDefFile;
 
 class RenderHandler : public IRenderHandler
 {
+	using AnimationLayoutMap = std::map<size_t, std::vector<JsonNode>>;
+
 	struct AnimationLocator
 	{
 		AnimationPath animation;
@@ -32,21 +34,22 @@ class RenderHandler : public IRenderHandler
 	};
 
 	std::map<AnimationPath, std::shared_ptr<CDefFile>> animationFiles;
-	std::map<JsonPath, std::shared_ptr<JsonNode>> jsonFiles;
+	std::map<AnimationPath, AnimationLayoutMap> animationLayouts;
 	std::map<ImagePath, std::shared_ptr<IImage>> imageFiles;
 	std::map<AnimationLocator, std::shared_ptr<IImage>> animationFrames;
 
 	std::shared_ptr<CDefFile> getAnimationFile(const AnimationPath & path);
-	std::shared_ptr<JsonNode> getJsonFile(const JsonPath & path);
+	const AnimationLayoutMap & getAnimationLayout(const AnimationPath & path);
+	void initFromJson(AnimationLayoutMap & layout, const JsonNode & config);
 public:
+	// IRenderHandler implementation
+
 	std::shared_ptr<IImage> loadImage(const ImagePath & path) override;
 	std::shared_ptr<IImage> loadImage(const ImagePath & path, EImageBlitMode mode) override;
-
 	std::shared_ptr<IImage> loadImage(const AnimationPath & path, int frame, int group) override;
-
-	std::shared_ptr<IImage> createImage(SDL_Surface * source) override;
 
 	std::shared_ptr<CAnimation> loadAnimation(const AnimationPath & path) override;
 
+	std::shared_ptr<IImage> createImage(SDL_Surface * source) override;
 	std::shared_ptr<CAnimation> createAnimation() override;
 };

--- a/client/renderSDL/RenderHandler.h
+++ b/client/renderSDL/RenderHandler.h
@@ -12,6 +12,7 @@
 #include "../render/IRenderHandler.h"
 
 class CDefFile;
+class IConstImage;
 
 class RenderHandler : public IRenderHandler
 {
@@ -35,8 +36,8 @@ class RenderHandler : public IRenderHandler
 
 	std::map<AnimationPath, std::shared_ptr<CDefFile>> animationFiles;
 	std::map<AnimationPath, AnimationLayoutMap> animationLayouts;
-	std::map<ImagePath, std::shared_ptr<IImage>> imageFiles;
-	std::map<AnimationLocator, std::shared_ptr<IImage>> animationFrames;
+	std::map<ImagePath, std::shared_ptr<IConstImage>> imageFiles;
+	std::map<AnimationLocator, std::shared_ptr<IConstImage>> animationFrames;
 
 	std::shared_ptr<CDefFile> getAnimationFile(const AnimationPath & path);
 	const AnimationLayoutMap & getAnimationLayout(const AnimationPath & path);

--- a/client/renderSDL/RenderHandler.h
+++ b/client/renderSDL/RenderHandler.h
@@ -58,12 +58,11 @@ public:
 	// IRenderHandler implementation
 	void onLibraryLoadingFinished(const Services * services) override;
 
-	std::shared_ptr<IImage> loadImage(const JsonNode & config) override;
-	std::shared_ptr<IImage> loadImage(const ImagePath & path) override;
+	std::shared_ptr<IImage> loadImage(const JsonNode & config, EImageBlitMode mode) override;
 	std::shared_ptr<IImage> loadImage(const ImagePath & path, EImageBlitMode mode) override;
-	std::shared_ptr<IImage> loadImage(const AnimationPath & path, int frame, int group) override;
+	std::shared_ptr<IImage> loadImage(const AnimationPath & path, int frame, int group, EImageBlitMode mode) override;
 
-	std::shared_ptr<CAnimation> loadAnimation(const AnimationPath & path) override;
+	std::shared_ptr<CAnimation> loadAnimation(const AnimationPath & path, EImageBlitMode mode) override;
 
 	std::shared_ptr<IImage> createImage(SDL_Surface * source) override;
 	std::shared_ptr<CAnimation> createAnimation() override;

--- a/client/renderSDL/RenderHandler.h
+++ b/client/renderSDL/RenderHandler.h
@@ -11,11 +11,38 @@
 
 #include "../render/IRenderHandler.h"
 
+class CDefFile;
+
 class RenderHandler : public IRenderHandler
 {
+	struct AnimationLocator
+	{
+		AnimationPath animation;
+		int frame = -1;
+		int group = -1;
+
+		bool operator < (const AnimationLocator & other) const
+		{
+			if (animation != other.animation)
+				return animation < other.animation;
+			if (group != other.group)
+				return group < other.group;
+			return frame < other.frame;
+		}
+	};
+
+	std::map<AnimationPath, std::shared_ptr<CDefFile>> animationFiles;
+	std::map<JsonPath, std::shared_ptr<JsonNode>> jsonFiles;
+	std::map<ImagePath, std::shared_ptr<IImage>> imageFiles;
+	std::map<AnimationLocator, std::shared_ptr<IImage>> animationFrames;
+
+	std::shared_ptr<CDefFile> getAnimationFile(const AnimationPath & path);
+	std::shared_ptr<JsonNode> getJsonFile(const JsonPath & path);
 public:
 	std::shared_ptr<IImage> loadImage(const ImagePath & path) override;
 	std::shared_ptr<IImage> loadImage(const ImagePath & path, EImageBlitMode mode) override;
+
+	std::shared_ptr<IImage> loadImage(const AnimationPath & path, int frame, int group) override;
 
 	std::shared_ptr<IImage> createImage(SDL_Surface * source) override;
 

--- a/client/renderSDL/RenderHandler.h
+++ b/client/renderSDL/RenderHandler.h
@@ -20,23 +20,7 @@ class IConstImage;
 
 class RenderHandler : public IRenderHandler
 {
-	using AnimationLayoutMap = std::map<size_t, std::vector<JsonNode>>;
-
-	struct ImageLocator
-	{
-		ImagePath image;
-		AnimationPath animation;
-		int frame = -1;
-		int group = -1;
-
-		bool verticalFlip = false;
-		bool horizontalFlip = false;
-
-		ImageLocator(const JsonNode & config);
-		ImageLocator(const ImagePath & path);
-		ImageLocator(const AnimationPath & path, int frame, int group);
-		bool operator < (const ImageLocator & other) const;
-	};
+	using AnimationLayoutMap = std::map<size_t, std::vector<ImageLocator>>;
 
 	std::map<AnimationPath, std::shared_ptr<CDefFile>> animationFiles;
 	std::map<AnimationPath, AnimationLayoutMap> animationLayouts;
@@ -58,7 +42,7 @@ public:
 	// IRenderHandler implementation
 	void onLibraryLoadingFinished(const Services * services) override;
 
-	std::shared_ptr<IImage> loadImage(const JsonNode & config, EImageBlitMode mode) override;
+	std::shared_ptr<IImage> loadImage(const ImageLocator & locator, EImageBlitMode mode) override;
 	std::shared_ptr<IImage> loadImage(const ImagePath & path, EImageBlitMode mode) override;
 	std::shared_ptr<IImage> loadImage(const AnimationPath & path, int frame, int group, EImageBlitMode mode) override;
 

--- a/client/renderSDL/RenderHandler.h
+++ b/client/renderSDL/RenderHandler.h
@@ -11,6 +11,10 @@
 
 #include "../render/IRenderHandler.h"
 
+VCMI_LIB_NAMESPACE_BEGIN
+class EntityService;
+VCMI_LIB_NAMESPACE_END
+
 class CDefFile;
 class IConstImage;
 
@@ -40,10 +44,15 @@ class RenderHandler : public IRenderHandler
 	std::map<AnimationLocator, std::shared_ptr<IConstImage>> animationFrames;
 
 	std::shared_ptr<CDefFile> getAnimationFile(const AnimationPath & path);
-	const AnimationLayoutMap & getAnimationLayout(const AnimationPath & path);
+	AnimationLayoutMap & getAnimationLayout(const AnimationPath & path);
 	void initFromJson(AnimationLayoutMap & layout, const JsonNode & config);
+
+	void addImageListEntry(size_t index, size_t group, const std::string & listName, const std::string & imageName);
+	void addImageListEntries(const EntityService * service);
 public:
+
 	// IRenderHandler implementation
+	void onLibraryLoadingFinished(const Services * services) override;
 
 	std::shared_ptr<IImage> loadImage(const ImagePath & path) override;
 	std::shared_ptr<IImage> loadImage(const ImagePath & path, EImageBlitMode mode) override;

--- a/client/renderSDL/SDLImage.cpp
+++ b/client/renderSDL/SDLImage.cpp
@@ -142,7 +142,7 @@ std::shared_ptr<SDLImageConst> SDLImageConst::scaleFast(const Point & size) cons
 	float scaleX = float(size.x) / dimensions().x;
 	float scaleY = float(size.y) / dimensions().y;
 
-	auto scaled = CSDL_Ext::scaleSurfaceFast(surf, (int)(surf->w * scaleX), (int)(surf->h * scaleY));
+	auto scaled = CSDL_Ext::scaleSurface(surf, (int)(surf->w * scaleX), (int)(surf->h * scaleY));
 
 	if (scaled->format && scaled->format->palette) // fix color keying, because SDL loses it at this point
 		CSDL_Ext::setColorKey(scaled, scaled->format->palette->colors[0]);

--- a/client/renderSDL/SDLImage.cpp
+++ b/client/renderSDL/SDLImage.cpp
@@ -119,9 +119,9 @@ void SDLImageConst::draw(SDL_Surface * where, SDL_Palette * palette, const Point
 	if (palette && surf->format->palette)
 		SDL_SetSurfacePalette(surf, palette);
 
-	if(surf->format->palette && alpha == SDL_ALPHA_OPAQUE && mode == EImageBlitMode::ALPHA)
+	if(surf->format->palette && mode == EImageBlitMode::ALPHA)
 	{
-		CSDL_Ext::blit8bppAlphaTo24bpp(surf, sourceRect, where, destShift);
+		CSDL_Ext::blit8bppAlphaTo24bpp(surf, sourceRect, where, destShift, alpha);
 	}
 	else
 	{

--- a/client/renderSDL/SDLImage.cpp
+++ b/client/renderSDL/SDLImage.cpp
@@ -234,9 +234,9 @@ void SDLImageConst::savePalette()
 		return;
 
 	if(originalPalette == nullptr)
-		originalPalette = SDL_AllocPalette(DEFAULT_PALETTE_COLORS);
+		originalPalette = SDL_AllocPalette(surf->format->palette->ncolors);
 
-	SDL_SetPaletteColors(originalPalette, surf->format->palette->colors, 0, DEFAULT_PALETTE_COLORS);
+	SDL_SetPaletteColors(originalPalette, surf->format->palette->colors, 0, surf->format->palette->ncolors);
 }
 
 void SDLImageIndexed::shiftPalette(uint32_t firstColorID, uint32_t colorsToMove, uint32_t distanceToMove)

--- a/client/renderSDL/SDLImage.cpp
+++ b/client/renderSDL/SDLImage.cpp
@@ -279,7 +279,7 @@ SDLImageIndexed::~SDLImageIndexed()
 	SDL_FreePalette(currentPalette);
 }
 
-void SDLImageIndexed::setSpecialPallete(const IImage::SpecialPalette & specialPalette, uint32_t colorsToSkipMask)
+void SDLImageIndexed::setSpecialPalette(const IImage::SpecialPalette & specialPalette, uint32_t colorsToSkipMask)
 {
 	size_t last = std::min<size_t>(specialPalette.size(), currentPalette->ncolors);
 
@@ -342,7 +342,7 @@ void SDLImageBase::setBlitMode(EImageBlitMode mode)
 	blitMode = mode;
 }
 
-void SDLImageRGB::setSpecialPallete(const SpecialPalette & SpecialPalette, uint32_t colorsToSkipMask)
+void SDLImageRGB::setSpecialPalette(const SpecialPalette & SpecialPalette, uint32_t colorsToSkipMask)
 {}
 
 void SDLImageRGB::playerColored(PlayerColor player)

--- a/client/renderSDL/SDLImage.cpp
+++ b/client/renderSDL/SDLImage.cpp
@@ -266,12 +266,6 @@ void SDLImage::verticalFlip()
 	surf = flipped;
 }
 
-void SDLImage::doubleFlip()
-{
-	horizontalFlip();
-	verticalFlip();
-}
-
 // Keep the original palette, in order to do color switching operation
 void SDLImage::savePalette()
 {

--- a/client/renderSDL/SDLImage.cpp
+++ b/client/renderSDL/SDLImage.cpp
@@ -111,7 +111,7 @@ void SDLImageConst::draw(SDL_Surface * where, SDL_Palette * palette, const Point
 
 	SDL_SetSurfaceAlphaMod(surf, alpha);
 
-	if (mode != EImageBlitMode::OPAQUE && surf->format->Amask != 0)
+	if (alpha != SDL_ALPHA_OPAQUE || (mode != EImageBlitMode::OPAQUE && surf->format->Amask != 0))
 		SDL_SetSurfaceBlendMode(surf, SDL_BLENDMODE_BLEND);
 	else
 		SDL_SetSurfaceBlendMode(surf, SDL_BLENDMODE_NONE);
@@ -119,7 +119,7 @@ void SDLImageConst::draw(SDL_Surface * where, SDL_Palette * palette, const Point
 	if (palette && surf->format->palette)
 		SDL_SetSurfacePalette(surf, palette);
 
-	if(surf->format->BitsPerPixel == 8 && alpha == SDL_ALPHA_OPAQUE && mode == EImageBlitMode::ALPHA)
+	if(surf->format->palette && alpha == SDL_ALPHA_OPAQUE && mode == EImageBlitMode::ALPHA)
 	{
 		CSDL_Ext::blit8bppAlphaTo24bpp(surf, sourceRect, where, destShift);
 	}

--- a/client/renderSDL/SDLImage.cpp
+++ b/client/renderSDL/SDLImage.cpp
@@ -18,8 +18,6 @@
 #include "../render/CDefFile.h"
 #include "../render/Graphics.h"
 
-#include "../../lib/json/JsonNode.h"
-
 #include <SDL_surface.h>
 
 class SDLImageLoader;
@@ -63,39 +61,6 @@ SDLImage::SDLImage(SDL_Surface * from, EImageBlitMode mode)
 	surf->refcount++;
 	fullSize.x = surf->w;
 	fullSize.y = surf->h;
-}
-
-SDLImage::SDLImage(const JsonNode & conf, EImageBlitMode mode)
-	: surf(nullptr),
-	margins(0, 0),
-	fullSize(0, 0),
-	originalPalette(nullptr)
-{
-	surf = BitmapHandler::loadBitmap(ImagePath::fromJson(conf["file"]));
-
-	if(surf == nullptr)
-		return;
-
-	savePalette();
-	setBlitMode(mode);
-
-	const JsonNode & jsonMargins = conf["margins"];
-
-	margins.x = static_cast<int>(jsonMargins["left"].Integer());
-	margins.y = static_cast<int>(jsonMargins["top"].Integer());
-
-	fullSize.x = static_cast<int>(conf["width"].Integer());
-	fullSize.y = static_cast<int>(conf["height"].Integer());
-
-	if(fullSize.x == 0)
-	{
-		fullSize.x = margins.x + surf->w + (int)jsonMargins["right"].Integer();
-	}
-
-	if(fullSize.y == 0)
-	{
-		fullSize.y = margins.y + surf->h + (int)jsonMargins["bottom"].Integer();
-	}
 }
 
 SDLImage::SDLImage(const ImagePath & filename, EImageBlitMode mode)
@@ -310,24 +275,6 @@ void SDLImage::adjustPalette(const ColorFilter & shifter, uint32_t colorsToSkipM
 	}
 }
 
-void SDLImage::resetPalette()
-{
-	if(originalPalette == nullptr)
-		return;
-	
-	// Always keep the original palette not changed, copy a new palette to assign to surface
-	SDL_SetPaletteColors(surf->format->palette, originalPalette->colors, 0, originalPalette->ncolors);
-}
-
-void SDLImage::resetPalette( int colorID )
-{
-	if(originalPalette == nullptr)
-		return;
-
-	// Always keep the original palette not changed, copy a new palette to assign to surface
-	SDL_SetPaletteColors(surf->format->palette, originalPalette->colors + colorID, colorID, 1);
-}
-
 void SDLImage::setSpecialPalette(const IImage::SpecialPalette & specialPalette, uint32_t colorsToSkipMask)
 {
 	if(surf->format->palette)
@@ -345,11 +292,5 @@ void SDLImage::setSpecialPalette(const IImage::SpecialPalette & specialPalette, 
 SDLImage::~SDLImage()
 {
 	SDL_FreeSurface(surf);
-
-	if(originalPalette != nullptr)
-	{
-		SDL_FreePalette(originalPalette);
-		originalPalette = nullptr;
-	}
+	SDL_FreePalette(originalPalette);
 }
-

--- a/client/renderSDL/SDLImage.cpp
+++ b/client/renderSDL/SDLImage.cpp
@@ -202,7 +202,7 @@ std::shared_ptr<IImage> SDLImageConst::createImageReference()
 		return std::make_shared<SDLImageRGB>(shared_from_this());
 }
 
-std::shared_ptr<SDLImageConst> SDLImageConst::horizontalFlip() const
+std::shared_ptr<IConstImage> SDLImageConst::horizontalFlip() const
 {
 	SDL_Surface * flipped = CSDL_Ext::horizontalFlip(surf);
 	auto ret = std::make_shared<SDLImageConst>(flipped, EImageBlitMode::ALPHA);
@@ -214,7 +214,7 @@ std::shared_ptr<SDLImageConst> SDLImageConst::horizontalFlip() const
 	return ret;
 }
 
-std::shared_ptr<SDLImageConst> SDLImageConst::verticalFlip() const
+std::shared_ptr<IConstImage> SDLImageConst::verticalFlip() const
 {
 	SDL_Surface * flipped = CSDL_Ext::verticalFlip(surf);
 	auto ret = std::make_shared<SDLImageConst>(flipped, EImageBlitMode::ALPHA);
@@ -340,16 +340,6 @@ void SDLImageBase::setAlpha(uint8_t value)
 void SDLImageBase::setBlitMode(EImageBlitMode mode)
 {
 	blitMode = mode;
-}
-
-void SDLImageBase::horizontalFlip()
-{
-	image = image->horizontalFlip();
-}
-
-void SDLImageBase::verticalFlip()
-{
-	image = image->verticalFlip();
 }
 
 void SDLImageRGB::setSpecialPallete(const SpecialPalette & SpecialPalette, uint32_t colorsToSkipMask)

--- a/client/renderSDL/SDLImage.h
+++ b/client/renderSDL/SDLImage.h
@@ -90,7 +90,7 @@ public:
 	~SDLImageIndexed();
 
 	void draw(SDL_Surface * where, const Point & pos, const Rect * src) const override;
-	void setSpecialPallete(const SpecialPalette & SpecialPalette, uint32_t colorsToSkipMask) override;
+	void setSpecialPalette(const SpecialPalette & SpecialPalette, uint32_t colorsToSkipMask) override;
 	void playerColored(PlayerColor player) override;
 	void setFlagColor(PlayerColor player) override;
 	void shiftPalette(uint32_t firstColorID, uint32_t colorsToMove, uint32_t distanceToMove) override;
@@ -103,6 +103,7 @@ public:
 	using SDLImageBase::SDLImageBase;
 
 	void draw(SDL_Surface * where, const Point & pos, const Rect * src) const override;
+	void setSpecialPalette(const SpecialPalette & SpecialPalette, uint32_t colorsToSkipMask) override;
 	void playerColored(PlayerColor player) override;
 	void setFlagColor(PlayerColor player) override;
 	void shiftPalette(uint32_t firstColorID, uint32_t colorsToMove, uint32_t distanceToMove) override;

--- a/client/renderSDL/SDLImage.h
+++ b/client/renderSDL/SDLImage.h
@@ -26,12 +26,12 @@ struct SDL_Palette;
  */
 class SDLImage : public IImage
 {
-public:
-	
 	const static int DEFAULT_PALETTE_COLORS = 256;
 	
 	//Surface without empty borders
 	SDL_Surface * surf;
+
+	SDL_Palette * originalPalette;
 	//size of left and top borders
 	Point margins;
 	//total size including borders
@@ -45,7 +45,6 @@ public:
 	//Load from bitmap file
 	SDLImage(const ImagePath & filename, EImageBlitMode blitMode);
 
-	SDLImage(const JsonNode & conf, EImageBlitMode blitMode);
 	//Create using existing surface, extraRef will increase refcount on SDL_Surface
 	SDLImage(SDL_Surface * from, EImageBlitMode blitMode);
 	~SDLImage();
@@ -67,8 +66,6 @@ public:
 
 	void shiftPalette(uint32_t firstColorID, uint32_t colorsToMove, uint32_t distanceToMove) override;
 	void adjustPalette(const ColorFilter & shifter, uint32_t colorsToSkipMask) override;
-	void resetPalette(int colorID) override;
-	void resetPalette() override;
 
 	void setAlpha(uint8_t value) override;
 	void setBlitMode(EImageBlitMode mode) override;
@@ -76,7 +73,4 @@ public:
 	void setSpecialPalette(const SpecialPalette & SpecialPalette, uint32_t colorsToSkipMask) override;
 
 	friend class SDLImageLoader;
-
-private:
-	SDL_Palette * originalPalette;
 };

--- a/client/renderSDL/SDLImage.h
+++ b/client/renderSDL/SDLImage.h
@@ -64,7 +64,6 @@ public:
 
 	void horizontalFlip() override;
 	void verticalFlip() override;
-	void doubleFlip() override;
 
 	void shiftPalette(uint32_t firstColorID, uint32_t colorsToMove, uint32_t distanceToMove) override;
 	void adjustPalette(const ColorFilter & shifter, uint32_t colorsToSkipMask) override;

--- a/client/renderSDL/SDLImage.h
+++ b/client/renderSDL/SDLImage.h
@@ -53,8 +53,8 @@ public:
 	Point dimensions() const override;
 	bool isTransparent(const Point & coords) const override;
 	std::shared_ptr<IImage> createImageReference() override;
-	std::shared_ptr<SDLImageConst> horizontalFlip() const;
-	std::shared_ptr<SDLImageConst> verticalFlip() const;
+	std::shared_ptr<IConstImage> horizontalFlip() const override;
+	std::shared_ptr<IConstImage> verticalFlip() const override;
 	std::shared_ptr<SDLImageConst> scaleFast(const Point & size) const;
 
 	const SDL_Palette * getPalette() const;
@@ -79,8 +79,6 @@ public:
 	Point dimensions() const override;
 	void setAlpha(uint8_t value) override;
 	void setBlitMode(EImageBlitMode mode) override;
-	void horizontalFlip() override;
-	void verticalFlip() override;
 };
 
 class SDLImageIndexed final : public SDLImageBase

--- a/client/renderSDL/SDLImage.h
+++ b/client/renderSDL/SDLImage.h
@@ -24,9 +24,9 @@ struct SDL_Palette;
 /*
  * Wrapper around SDL_Surface
  */
-class SDLImage : public IImage
+class SDLImageConst final : public IConstImage, public std::enable_shared_from_this<SDLImageConst>, boost::noncopyable
 {
-	const static int DEFAULT_PALETTE_COLORS = 256;
+	static constexpr int DEFAULT_PALETTE_COLORS = 256;
 	
 	//Surface without empty borders
 	SDL_Surface * surf;
@@ -37,40 +37,78 @@ class SDLImage : public IImage
 	//total size including borders
 	Point fullSize;
 
-	EImageBlitMode blitMode;
-
-public:
-	//Load image from def file
-	SDLImage(CDefFile *data, size_t frame, size_t group=0);
-	//Load from bitmap file
-	SDLImage(const ImagePath & filename, EImageBlitMode blitMode);
-
-	//Create using existing surface, extraRef will increase refcount on SDL_Surface
-	SDLImage(SDL_Surface * from, EImageBlitMode blitMode);
-	~SDLImage();
-
 	// Keep the original palette, in order to do color switching operation
 	void savePalette();
 
-	void draw(SDL_Surface * where, int posX=0, int posY=0, const Rect *src=nullptr) const override;
-	void draw(SDL_Surface * where, const Rect * dest, const Rect * src) const override;
-	std::shared_ptr<IImage> scaleFast(const Point & size) const override;
+public:
+	//Load image from def file
+	SDLImageConst(CDefFile *data, size_t frame, size_t group=0);
+	//Load from bitmap file
+	SDLImageConst(const ImagePath & filename, EImageBlitMode blitMode);
+	//Create using existing surface, extraRef will increase refcount on SDL_Surface
+	SDLImageConst(SDL_Surface * from, EImageBlitMode blitMode);
+	~SDLImageConst();
+
+	void draw(SDL_Surface * where, SDL_Palette * palette, const Point & dest, const Rect * src, uint8_t alpha, EImageBlitMode mode) const;
+
 	void exportBitmap(const boost::filesystem::path & path) const override;
-	void playerColored(PlayerColor player) override;
-	void setFlagColor(PlayerColor player) override;
-	bool isTransparent(const Point & coords) const override;
 	Point dimensions() const override;
+	bool isTransparent(const Point & coords) const override;
+	std::shared_ptr<IImage> createImageReference() override;
+	std::shared_ptr<SDLImageConst> horizontalFlip() const;
+	std::shared_ptr<SDLImageConst> verticalFlip() const;
+	std::shared_ptr<SDLImageConst> scaleFast(const Point & size) const;
 
-	void horizontalFlip() override;
-	void verticalFlip() override;
-
-	void shiftPalette(uint32_t firstColorID, uint32_t colorsToMove, uint32_t distanceToMove) override;
-	void adjustPalette(const ColorFilter & shifter, uint32_t colorsToSkipMask) override;
-
-	void setAlpha(uint8_t value) override;
-	void setBlitMode(EImageBlitMode mode) override;
-
-	void setSpecialPalette(const SpecialPalette & SpecialPalette, uint32_t colorsToSkipMask) override;
+	const SDL_Palette * getPalette() const;
 
 	friend class SDLImageLoader;
+};
+
+class SDLImageBase : public IImage, boost::noncopyable
+{
+protected:
+	std::shared_ptr<SDLImageConst> image;
+
+	uint8_t alphaValue;
+	EImageBlitMode blitMode;
+
+public:
+	SDLImageBase(const std::shared_ptr<SDLImageConst> & image);
+
+	void scaleFast(const Point & size) override;
+	void exportBitmap(const boost::filesystem::path & path) const override;
+	bool isTransparent(const Point & coords) const override;
+	Point dimensions() const override;
+	void setAlpha(uint8_t value) override;
+	void setBlitMode(EImageBlitMode mode) override;
+	void horizontalFlip() override;
+	void verticalFlip() override;
+};
+
+class SDLImageIndexed final : public SDLImageBase
+{
+	SDL_Palette * currentPalette = nullptr;
+
+public:
+	SDLImageIndexed(const std::shared_ptr<SDLImageConst> & image);
+	~SDLImageIndexed();
+
+	void draw(SDL_Surface * where, const Point & pos, const Rect * src) const override;
+	void setSpecialPallete(const SpecialPalette & SpecialPalette, uint32_t colorsToSkipMask) override;
+	void playerColored(PlayerColor player) override;
+	void setFlagColor(PlayerColor player) override;
+	void shiftPalette(uint32_t firstColorID, uint32_t colorsToMove, uint32_t distanceToMove) override;
+	void adjustPalette(const ColorFilter & shifter, uint32_t colorsToSkipMask) override;
+};
+
+class SDLImageRGB final : public SDLImageBase
+{
+public:
+	using SDLImageBase::SDLImageBase;
+
+	void draw(SDL_Surface * where, const Point & pos, const Rect * src) const override;
+	void playerColored(PlayerColor player) override;
+	void setFlagColor(PlayerColor player) override;
+	void shiftPalette(uint32_t firstColorID, uint32_t colorsToMove, uint32_t distanceToMove) override;
+	void adjustPalette(const ColorFilter & shifter, uint32_t colorsToSkipMask) override;
 };

--- a/client/renderSDL/SDLImage.h
+++ b/client/renderSDL/SDLImage.h
@@ -42,9 +42,9 @@ public:
 	//Load image from def file
 	SDLImageConst(CDefFile *data, size_t frame, size_t group=0);
 	//Load from bitmap file
-	SDLImageConst(const ImagePath & filename, EImageBlitMode blitMode);
+	SDLImageConst(const ImagePath & filename);
 	//Create using existing surface, extraRef will increase refcount on SDL_Surface
-	SDLImageConst(SDL_Surface * from, EImageBlitMode blitMode);
+	SDLImageConst(SDL_Surface * from);
 	~SDLImageConst();
 
 	void draw(SDL_Surface * where, SDL_Palette * palette, const Point & dest, const Rect * src, uint8_t alpha, EImageBlitMode mode) const;
@@ -52,7 +52,7 @@ public:
 	void exportBitmap(const boost::filesystem::path & path) const override;
 	Point dimensions() const override;
 	bool isTransparent(const Point & coords) const override;
-	std::shared_ptr<IImage> createImageReference() override;
+	std::shared_ptr<IImage> createImageReference(EImageBlitMode mode) override;
 	std::shared_ptr<IConstImage> horizontalFlip() const override;
 	std::shared_ptr<IConstImage> verticalFlip() const override;
 	std::shared_ptr<SDLImageConst> scaleFast(const Point & size) const;
@@ -71,7 +71,7 @@ protected:
 	EImageBlitMode blitMode;
 
 public:
-	SDLImageBase(const std::shared_ptr<SDLImageConst> & image);
+	SDLImageBase(const std::shared_ptr<SDLImageConst> & image, EImageBlitMode mode);
 
 	void scaleFast(const Point & size) override;
 	void exportBitmap(const boost::filesystem::path & path) const override;
@@ -86,7 +86,7 @@ class SDLImageIndexed final : public SDLImageBase
 	SDL_Palette * currentPalette = nullptr;
 
 public:
-	SDLImageIndexed(const std::shared_ptr<SDLImageConst> & image);
+	SDLImageIndexed(const std::shared_ptr<SDLImageConst> & image, EImageBlitMode mode);
 	~SDLImageIndexed();
 
 	void draw(SDL_Surface * where, const Point & pos, const Rect * src) const override;

--- a/client/renderSDL/SDLImage.h
+++ b/client/renderSDL/SDLImage.h
@@ -26,8 +26,6 @@ struct SDL_Palette;
  */
 class SDLImageConst final : public IConstImage, public std::enable_shared_from_this<SDLImageConst>, boost::noncopyable
 {
-	static constexpr int DEFAULT_PALETTE_COLORS = 256;
-	
 	//Surface without empty borders
 	SDL_Surface * surf;
 

--- a/client/renderSDL/SDLImageLoader.cpp
+++ b/client/renderSDL/SDLImageLoader.cpp
@@ -32,8 +32,8 @@ void SDLImageLoader::init(Point SpriteSize, Point Margins, Point FullSize, SDL_C
 	image->fullSize = FullSize;
 
 	//Prepare surface
-	SDL_Palette * p = SDL_AllocPalette(SDLImageConst::DEFAULT_PALETTE_COLORS);
-	SDL_SetPaletteColors(p, pal, 0, SDLImageConst::DEFAULT_PALETTE_COLORS);
+	SDL_Palette * p = SDL_AllocPalette(DEFAULT_PALETTE_COLORS);
+	SDL_SetPaletteColors(p, pal, 0, DEFAULT_PALETTE_COLORS);
 	SDL_SetSurfacePalette(image->surf, p);
 	SDL_FreePalette(p);
 

--- a/client/renderSDL/SDLImageLoader.cpp
+++ b/client/renderSDL/SDLImageLoader.cpp
@@ -17,7 +17,7 @@
 
 #include <SDL_surface.h>
 
-SDLImageLoader::SDLImageLoader(SDLImage * Img):
+SDLImageLoader::SDLImageLoader(SDLImageConst * Img):
 	image(Img),
 	lineStart(nullptr),
 	position(nullptr)
@@ -32,8 +32,8 @@ void SDLImageLoader::init(Point SpriteSize, Point Margins, Point FullSize, SDL_C
 	image->fullSize = FullSize;
 
 	//Prepare surface
-	SDL_Palette * p = SDL_AllocPalette(SDLImage::DEFAULT_PALETTE_COLORS);
-	SDL_SetPaletteColors(p, pal, 0, SDLImage::DEFAULT_PALETTE_COLORS);
+	SDL_Palette * p = SDL_AllocPalette(SDLImageConst::DEFAULT_PALETTE_COLORS);
+	SDL_SetPaletteColors(p, pal, 0, SDLImageConst::DEFAULT_PALETTE_COLORS);
 	SDL_SetSurfacePalette(image->surf, p);
 	SDL_FreePalette(p);
 

--- a/client/renderSDL/SDLImageLoader.h
+++ b/client/renderSDL/SDLImageLoader.h
@@ -15,6 +15,8 @@ class SDLImageConst;
 
 class SDLImageLoader : public IImageLoader
 {
+	static constexpr int DEFAULT_PALETTE_COLORS = 256;
+
 	SDLImageConst * image;
 	ui8 * lineStart;
 	ui8 * position;

--- a/client/renderSDL/SDLImageLoader.h
+++ b/client/renderSDL/SDLImageLoader.h
@@ -11,9 +11,11 @@
 
 #include "../render/IImageLoader.h"
 
+class SDLImageConst;
+
 class SDLImageLoader : public IImageLoader
 {
-	SDLImage * image;
+	SDLImageConst * image;
 	ui8 * lineStart;
 	ui8 * position;
 public:
@@ -25,7 +27,7 @@ public:
 	//init image with these sizes and palette
 	void init(Point SpriteSize, Point Margins, Point FullSize, SDL_Color *pal);
 
-	SDLImageLoader(SDLImage * Img);
+	SDLImageLoader(SDLImageConst * Img);
 	~SDLImageLoader();
 };
 

--- a/client/renderSDL/SDL_Extensions.cpp
+++ b/client/renderSDL/SDL_Extensions.cpp
@@ -211,7 +211,7 @@ uint32_t CSDL_Ext::getPixel(SDL_Surface *surface, const int & x, const int & y, 
 }
 
 template<int bpp, bool useAlpha>
-int CSDL_Ext::blit8bppAlphaTo24bppT(const SDL_Surface * src, const Rect & srcRectInput, SDL_Surface * dst, const Point & dstPointInput, uint8_t alpha)
+int CSDL_Ext::blit8bppAlphaTo24bppT(const SDL_Surface * src, const Rect & srcRectInput, SDL_Surface * dst, const Point & dstPointInput, [[maybe_unused]] uint8_t alpha)
 {
 	SDL_Rect srcRectInstance = CSDL_Ext::toSDL(srcRectInput);
 	SDL_Rect dstRectInstance = CSDL_Ext::toSDL(Rect(dstPointInput, srcRectInput.dimensions()));

--- a/client/renderSDL/SDL_Extensions.cpp
+++ b/client/renderSDL/SDL_Extensions.cpp
@@ -19,6 +19,8 @@
 #include "../../lib/GameConstants.h"
 
 #include <SDL_render.h>
+#include <SDL_surface.h>
+#include <SDL_version.h>
 
 Rect CSDL_Ext::fromSDL(const SDL_Rect & rect)
 {
@@ -630,7 +632,11 @@ SDL_Surface * CSDL_Ext::scaleSurface(SDL_Surface * surf, int width, int height)
 	SDL_Surface * intermediate = SDL_ConvertSurface(surf, screen->format, 0);
 	SDL_Surface * ret = newSurface(width, height, intermediate);
 
+#if SDL_VERSION_ATLEAST(2,0,16)
 	SDL_SoftStretchLinear(intermediate, nullptr, ret, nullptr);
+#else
+	SDL_SoftStretch(intermediate, nullptr, ret, nullptr);
+#endif
 	SDL_FreeSurface(intermediate);
 
 	return ret;

--- a/client/renderSDL/SDL_Extensions.cpp
+++ b/client/renderSDL/SDL_Extensions.cpp
@@ -361,7 +361,6 @@ int CSDL_Ext::blit8bppAlphaTo24bpp(const SDL_Surface * src, const Rect & srcRect
 {
 	switch(dst->format->BytesPerPixel)
 	{
-	case 2: return blit8bppAlphaTo24bppT<2>(src, srcRect, dst, dstPoint);
 	case 3: return blit8bppAlphaTo24bppT<3>(src, srcRect, dst, dstPoint);
 	case 4: return blit8bppAlphaTo24bppT<4>(src, srcRect, dst, dstPoint);
 	default:

--- a/client/renderSDL/SDL_Extensions.cpp
+++ b/client/renderSDL/SDL_Extensions.cpp
@@ -63,19 +63,6 @@ void CSDL_Ext::setAlpha(SDL_Surface * bg, int value)
 	SDL_SetSurfaceAlphaMod(bg, value);
 }
 
-void CSDL_Ext::updateRect(SDL_Surface *surface, const Rect & rect )
-{
-	SDL_Rect rectSDL = CSDL_Ext::toSDL(rect);
-	if(0 !=SDL_UpdateTexture(screenTexture, &rectSDL, surface->pixels, surface->pitch))
-		logGlobal->error("%sSDL_UpdateTexture %s", __FUNCTION__, SDL_GetError());
-
-	SDL_RenderClear(mainRenderer);
-	if(0 != SDL_RenderCopy(mainRenderer, screenTexture, nullptr, nullptr))
-		logGlobal->error("%sSDL_RenderCopy %s", __FUNCTION__, SDL_GetError());
-	SDL_RenderPresent(mainRenderer);
-
-}
-
 SDL_Surface * CSDL_Ext::newSurface(int w, int h)
 {
 	return newSurface(w, h, screen);

--- a/client/renderSDL/SDL_Extensions.cpp
+++ b/client/renderSDL/SDL_Extensions.cpp
@@ -524,23 +524,6 @@ void CSDL_Ext::drawBorder( SDL_Surface * sur, const Rect &r, const SDL_Color &co
 	drawBorder(sur, r.x, r.y, r.w, r.h, color, depth);
 }
 
-void CSDL_Ext::setPlayerColor(SDL_Surface * sur, const PlayerColor & player)
-{
-	if(player==PlayerColor::UNFLAGGABLE)
-		return;
-	if(sur->format->BitsPerPixel==8)
-	{
-		ColorRGBA color = (player == PlayerColor::NEUTRAL
-							? graphics->neutralColor
-							: graphics->playerColors[player.getNum()]);
-
-		SDL_Color colorSDL = toSDL(color);
-		CSDL_Ext::setColors(sur, &colorSDL, 5, 1);
-	}
-	else
-		logGlobal->warn("Warning, setPlayerColor called on not 8bpp surface!");
-}
-
 CSDL_Ext::TColorPutter CSDL_Ext::getPutterFor(SDL_Surface * const &dest, int incrementing)
 {
 #define CASE_BPP(BytesPerPixel)							\

--- a/client/renderSDL/SDL_Extensions.h
+++ b/client/renderSDL/SDL_Extensions.h
@@ -86,7 +86,6 @@ using TColorPutterAlpha = void (*)(uint8_t *&, const uint8_t &, const uint8_t &,
 
 	void drawBorder(SDL_Surface * sur, int x, int y, int w, int h, const SDL_Color & color, int depth = 1);
 	void drawBorder(SDL_Surface * sur, const Rect & r, const SDL_Color & color, int depth = 1);
-	void setPlayerColor(SDL_Surface * sur, const PlayerColor & player); //sets correct color of flags; -1 for neutral
 
 	SDL_Surface * newSurface(int w, int h, SDL_Surface * mod); //creates new surface, with flags/format same as in surface given
 	SDL_Surface * newSurface(int w, int h); //creates new surface, with flags/format same as in screen surface

--- a/client/renderSDL/SDL_Extensions.h
+++ b/client/renderSDL/SDL_Extensions.h
@@ -73,8 +73,7 @@ using TColorPutterAlpha = void (*)(uint8_t *&, const uint8_t &, const uint8_t &,
 	bool isTransparent(SDL_Surface * srf, const Point & position); //checks if surface is transparent at given position
 
 	uint8_t * getPxPtr(const SDL_Surface * const & srf, const int x, const int y);
-	TColorPutter getPutterFor(SDL_Surface * const & dest, int incrementing); //incrementing: -1, 0, 1
-	TColorPutterAlpha getPutterAlphaFor(SDL_Surface * const & dest, int incrementing); //incrementing: -1, 0, 1
+	TColorPutter getPutterFor(SDL_Surface * const & dest);
 
 	template<int bpp>
 	int blit8bppAlphaTo24bppT(const SDL_Surface * src, const Rect & srcRect, SDL_Surface * dst, const Point & dstPoint); //blits 8 bpp surface with alpha channel to 24 bpp surface
@@ -93,10 +92,7 @@ using TColorPutterAlpha = void (*)(uint8_t *&, const uint8_t &, const uint8_t &,
 	template<int bpp>
 	SDL_Surface * createSurfaceWithBpp(int width, int height); //create surface with give bits per pixels value
 
-	//scale surface to required size.
-	//nearest neighbour algorithm
-	SDL_Surface * scaleSurfaceFast(SDL_Surface * surf, int width, int height);
-	// bilinear filtering. Uses fallback to scaleSurfaceFast in case of indexed surfaces
+	// bilinear filtering. Always returns rgba surface
 	SDL_Surface * scaleSurface(SDL_Surface * surf, int width, int height);
 
 	template<int bpp>

--- a/client/renderSDL/SDL_Extensions.h
+++ b/client/renderSDL/SDL_Extensions.h
@@ -73,9 +73,9 @@ using TColorPutterAlpha = void (*)(uint8_t *&, const uint8_t &, const uint8_t &,
 	uint8_t * getPxPtr(const SDL_Surface * const & srf, const int x, const int y);
 	TColorPutter getPutterFor(SDL_Surface * const & dest);
 
-	template<int bpp>
-	int blit8bppAlphaTo24bppT(const SDL_Surface * src, const Rect & srcRect, SDL_Surface * dst, const Point & dstPoint); //blits 8 bpp surface with alpha channel to 24 bpp surface
-	int blit8bppAlphaTo24bpp(const SDL_Surface * src, const Rect & srcRect, SDL_Surface * dst, const Point & dstPoint); //blits 8 bpp surface with alpha channel to 24 bpp surface
+	template<int bpp, bool useAlpha>
+	int blit8bppAlphaTo24bppT(const SDL_Surface * src, const Rect & srcRect, SDL_Surface * dst, const Point & dstPoint, uint8_t alpha); //blits 8 bpp surface with alpha channel to 24 bpp surface
+	int blit8bppAlphaTo24bpp(const SDL_Surface * src, const Rect & srcRect, SDL_Surface * dst, const Point & dstPoint, uint8_t alpha); //blits 8 bpp surface with alpha channel to 24 bpp surface
 	uint32_t colorTouint32_t(const SDL_Color * color); //little endian only
 
 	void drawLine(SDL_Surface * sur, const Point & from, const Point & dest, const SDL_Color & color1, const SDL_Color & color2);

--- a/client/renderSDL/SDL_Extensions.h
+++ b/client/renderSDL/SDL_Extensions.h
@@ -61,8 +61,6 @@ using TColorPutterAlpha = void (*)(uint8_t *&, const uint8_t &, const uint8_t &,
 	void fillRect(SDL_Surface * dst, const Rect & dstrect, const SDL_Color & color);
 	void fillRectBlended(SDL_Surface * dst, const Rect & dstrect, const SDL_Color & color);
 
-	void updateRect(SDL_Surface * surface, const Rect & rect);
-
 	void putPixelWithoutRefresh(SDL_Surface * ekran, const int & x, const int & y, const uint8_t & R, const uint8_t & G, const uint8_t & B, uint8_t A = 255);
 	void putPixelWithoutRefreshIfInSurf(SDL_Surface *ekran, const int & x, const int & y, const uint8_t & R, const uint8_t & G, const uint8_t & B, uint8_t A = 255);
 

--- a/client/widgets/Buttons.cpp
+++ b/client/widgets/Buttons.cpp
@@ -99,7 +99,7 @@ void ButtonBase::setImage(const AnimationPath & defName, bool playerColoredButto
 	pos = image->pos;
 
 	if (playerColoredButton)
-		image->playerColored(LOCPLINT->playerID);
+		image->setPlayerColor(LOCPLINT->playerID);
 }
 
 const JsonNode & ButtonBase::getCurrentConfig() const
@@ -134,7 +134,7 @@ void ButtonBase::setConfigurable(const JsonPath & jsonName, bool playerColoredBu
 	pos = configurable->pos;
 
 	if (playerColoredButton)
-		image->playerColored(LOCPLINT->playerID);
+		image->setPlayerColor(LOCPLINT->playerID);
 }
 
 void CButton::addHoverText(EButtonState state, const std::string & text)
@@ -364,7 +364,7 @@ CButton::CButton(Point position, const AnimationPath &defName, const std::pair<s
 void ButtonBase::setPlayerColor(PlayerColor player)
 {
 	if (image && image->isPlayerColored())
-		image->playerColored(player);
+		image->setPlayerColor(player);
 }
 
 void CButton::showAll(Canvas & to)

--- a/client/widgets/Buttons.cpp
+++ b/client/widgets/Buttons.cpp
@@ -24,7 +24,6 @@
 #include "../gui/InterfaceObjectConfigurable.h"
 #include "../media/ISoundPlayer.h"
 #include "../windows/InfoWindows.h"
-#include "../render/CAnimation.h"
 #include "../render/Canvas.h"
 #include "../render/IRenderHandler.h"
 

--- a/client/widgets/CGarrisonInt.cpp
+++ b/client/widgets/CGarrisonInt.cpp
@@ -17,7 +17,6 @@
 #include "../gui/CGuiHandler.h"
 #include "../gui/WindowHandler.h"
 #include "../render/IImage.h"
-#include "../render/Graphics.h"
 #include "../windows/CCreatureWindow.h"
 #include "../windows/CWindowWithArtifacts.h"
 #include "../windows/GUIClasses.h"
@@ -437,10 +436,10 @@ CGarrisonSlot::CGarrisonSlot(CGarrisonInt * Owner, int x, int y, SlotID IID, EGa
 
 	AnimationPath imgName = AnimationPath::builtin(owner->smallIcons ? "cprsmall" : "TWCRPORT");
 
-	creatureImage = std::make_shared<CAnimImage>(graphics->getAnimation(imgName), 0);
+	creatureImage = std::make_shared<CAnimImage>(imgName, 0);
 	creatureImage->disable();
 
-	selectionImage = std::make_shared<CAnimImage>(graphics->getAnimation(imgName), 1);
+	selectionImage = std::make_shared<CAnimImage>(imgName, 1);
 	selectionImage->disable();
 	selectionImage->center(creatureImage->pos.center());
 

--- a/client/widgets/Images.cpp
+++ b/client/widgets/Images.cpp
@@ -50,7 +50,7 @@ CPicture::CPicture( const ImagePath & bmpname )
 {}
 
 CPicture::CPicture( const ImagePath & bmpname, const Point & position )
-	: bg(GH.renderHandler().loadImage(bmpname))
+	: bg(GH.renderHandler().loadImage(bmpname, EImageBlitMode::COLORKEY))
 	, needRefresh(false)
 {
 	pos.x += position.x;
@@ -66,6 +66,14 @@ CPicture::CPicture( const ImagePath & bmpname, const Point & position )
 	{
 		pos.w = pos.h = 0;
 	}
+}
+
+CPicture::CPicture(const ImagePath & bmpname, const Rect &SrcRect, int x, int y)
+	: CPicture(bmpname, Point(x,y))
+{
+	srcRect = SrcRect;
+	pos.w = srcRect->w;
+	pos.h = srcRect->h;
 }
 
 CPicture::CPicture(std::shared_ptr<IImage> image, const Rect &SrcRect, int x, int y)
@@ -113,7 +121,7 @@ void CPicture::setPlayerColor(PlayerColor player)
 
 CFilledTexture::CFilledTexture(const ImagePath & imageName, Rect position)
 	: CIntObject(0, position.topLeft())
-	, texture(GH.renderHandler().loadImage(imageName))
+	, texture(GH.renderHandler().loadImage(imageName, EImageBlitMode::COLORKEY))
 {
 	pos.w = position.w;
 	pos.h = position.h;
@@ -122,7 +130,7 @@ CFilledTexture::CFilledTexture(const ImagePath & imageName, Rect position)
 
 CFilledTexture::CFilledTexture(const ImagePath & imageName, Rect position, Rect imageArea)
 	: CIntObject(0, position.topLeft())
-	, texture(GH.renderHandler().loadImage(imageName))
+	, texture(GH.renderHandler().loadImage(imageName, EImageBlitMode::COLORKEY))
 	, imageArea(imageArea)
 {
 	pos.w = position.w;
@@ -176,7 +184,7 @@ CAnimImage::CAnimImage(const AnimationPath & name, size_t Frame, size_t Group, i
 {
 	pos.x += x;
 	pos.y += y;
-	anim = GH.renderHandler().loadAnimation(name);
+	anim = GH.renderHandler().loadAnimation(name, EImageBlitMode::COLORKEY);
 	init();
 }
 
@@ -192,7 +200,7 @@ CAnimImage::CAnimImage(const AnimationPath & name, size_t Frame, size_t Group, i
 //}
 
 CAnimImage::CAnimImage(const AnimationPath & name, size_t Frame, Rect targetPos, size_t Group, ui8 Flags):
-	anim(GH.renderHandler().loadAnimation(name)),
+	anim(GH.renderHandler().loadAnimation(name, EImageBlitMode::COLORKEY)),
 	frame(Frame),
 	group(Group),
 	flags(Flags),
@@ -268,7 +276,7 @@ void CAnimImage::showAll(Canvas & to)
 void CAnimImage::setAnimationPath(const AnimationPath & name, size_t frame)
 {
 	this->frame = frame;
-	anim = GH.renderHandler().loadAnimation(name);
+	anim = GH.renderHandler().loadAnimation(name, EImageBlitMode::COLORKEY);
 	init();
 }
 
@@ -310,7 +318,7 @@ bool CAnimImage::isPlayerColored() const
 }
 
 CShowableAnim::CShowableAnim(int x, int y, const AnimationPath & name, ui8 Flags, ui32 frameTime, size_t Group, uint8_t alpha):
-	anim(GH.renderHandler().loadAnimation(name)),
+	anim(GH.renderHandler().loadAnimation(name, EImageBlitMode::ALPHA)),
 	group(Group),
 	frame(0),
 	first(0),

--- a/client/widgets/Images.cpp
+++ b/client/widgets/Images.cpp
@@ -111,18 +111,18 @@ void CPicture::colorize(PlayerColor player)
 	bg->playerColored(player);
 }
 
-CFilledTexture::CFilledTexture(const ImagePath & imageName, Rect position):
-    CIntObject(0, position.topLeft()),
-	texture(GH.renderHandler().loadImage(imageName))
+CFilledTexture::CFilledTexture(const ImagePath & imageName, Rect position)
+	: CIntObject(0, position.topLeft())
+	, texture(GH.renderHandler().loadImage(imageName))
 {
 	pos.w = position.w;
 	pos.h = position.h;
 	imageArea = Rect(Point(), texture->dimensions());
 }
 
-CFilledTexture::CFilledTexture(std::shared_ptr<IImage> image, Rect position, Rect imageArea)
+CFilledTexture::CFilledTexture(const ImagePath & imageName, Rect position, Rect imageArea)
 	: CIntObject(0, position.topLeft())
-	, texture(image)
+	, texture(GH.renderHandler().loadImage(imageName))
 	, imageArea(imageArea)
 {
 	pos.w = position.w;
@@ -191,8 +191,8 @@ CAnimImage::CAnimImage(std::shared_ptr<CAnimation> Anim, size_t Frame, size_t Gr
 	init();
 }
 
-CAnimImage::CAnimImage(std::shared_ptr<CAnimation> Anim, size_t Frame, Rect targetPos, size_t Group, ui8 Flags):
-	anim(Anim),
+CAnimImage::CAnimImage(const AnimationPath & name, size_t Frame, Rect targetPos, size_t Group, ui8 Flags):
+	anim(GH.renderHandler().loadAnimation(name)),
 	frame(Frame),
 	group(Group),
 	flags(Flags),

--- a/client/widgets/Images.cpp
+++ b/client/widgets/Images.cpp
@@ -318,7 +318,7 @@ bool CAnimImage::isPlayerColored() const
 }
 
 CShowableAnim::CShowableAnim(int x, int y, const AnimationPath & name, ui8 Flags, ui32 frameTime, size_t Group, uint8_t alpha):
-	anim(GH.renderHandler().loadAnimation(name, EImageBlitMode::ALPHA)),
+	anim(GH.renderHandler().loadAnimation(name, (Flags & PALETTE_ALPHA) ? EImageBlitMode::ALPHA : EImageBlitMode::COLORKEY)),
 	group(Group),
 	frame(0),
 	first(0),
@@ -451,7 +451,7 @@ void CShowableAnim::setDuration(int durationMs)
 }
 
 CCreatureAnim::CCreatureAnim(int x, int y, const AnimationPath & name, ui8 flags, ECreatureAnimType type):
-	CShowableAnim(x, y, name, flags, 100, size_t(type)) // H3 uses 100 ms per frame, irregardless of battle speed settings
+	CShowableAnim(x, y, name, flags | PALETTE_ALPHA, 100, size_t(type)) // H3 uses 100 ms per frame, irregardless of battle speed settings
 {
 	xOffset = 0;
 	yOffset = 0;

--- a/client/widgets/Images.cpp
+++ b/client/widgets/Images.cpp
@@ -180,16 +180,16 @@ CAnimImage::CAnimImage(const AnimationPath & name, size_t Frame, size_t Group, i
 	init();
 }
 
-CAnimImage::CAnimImage(std::shared_ptr<CAnimation> Anim, size_t Frame, size_t Group, int x, int y, ui8 Flags):
-	anim(Anim),
-	frame(Frame),
-	group(Group),
-	flags(Flags)
-{
-	pos.x += x;
-	pos.y += y;
-	init();
-}
+//CAnimImage::CAnimImage(std::shared_ptr<CAnimation> Anim, size_t Frame, size_t Group, int x, int y, ui8 Flags):
+//	anim(Anim),
+//	frame(Frame),
+//	group(Group),
+//	flags(Flags)
+//{
+//	pos.x += x;
+//	pos.y += y;
+//	init();
+//}
 
 CAnimImage::CAnimImage(const AnimationPath & name, size_t Frame, Rect targetPos, size_t Group, ui8 Flags):
 	anim(GH.renderHandler().loadAnimation(name)),

--- a/client/widgets/Images.cpp
+++ b/client/widgets/Images.cpp
@@ -100,7 +100,7 @@ void CPicture::setAlpha(uint8_t value)
 
 void CPicture::scaleTo(Point size)
 {
-	bg = bg->scaleFast(size);
+	bg->scaleFast(size);
 
 	pos.w = bg->width();
 	pos.h = bg->height();
@@ -262,12 +262,9 @@ void CAnimImage::showAll(Canvas & to)
 		if(auto img = anim->getImage(targetFrame, group))
 		{
 			if(isScaled())
-			{
-				auto scaled = img->scaleFast(scaledSize);
-				to.draw(scaled, pos.topLeft());
-			}
-			else
-				to.draw(img, pos.topLeft());
+				img->scaleFast(scaledSize);
+
+			to.draw(img, pos.topLeft());
 		}
 	}
 }

--- a/client/widgets/Images.cpp
+++ b/client/widgets/Images.cpp
@@ -19,7 +19,6 @@
 #include "../render/CAnimation.h"
 #include "../render/Canvas.h"
 #include "../render/ColorFilter.h"
-#include "../render/Graphics.h"
 
 #include "../battle/BattleInterface.h"
 #include "../battle/BattleInterfaceClasses.h"
@@ -177,7 +176,7 @@ CAnimImage::CAnimImage(const AnimationPath & name, size_t Frame, size_t Group, i
 {
 	pos.x += x;
 	pos.y += y;
-	anim = graphics->getAnimation(name);
+	anim = GH.renderHandler().loadAnimation(name);
 	init();
 }
 

--- a/client/widgets/Images.cpp
+++ b/client/widgets/Images.cpp
@@ -232,10 +232,6 @@ void CAnimImage::setSizeFromImage(const IImage &img)
 void CAnimImage::init()
 {
 	visible = true;
-	anim->load(frame, group);
-	if (flags & CShowableAnim::BASE)
-		anim->load(0,group);
-
 	auto img = anim->getImage(frame, group);
 	if (img)
 		setSizeFromImage(*img);
@@ -287,7 +283,6 @@ void CAnimImage::setFrame(size_t Frame, size_t Group)
 		return;
 	if (anim->size(Group) > Frame)
 	{
-		anim->load(Frame, Group);
 		frame = Frame;
 		group = Group;
 		if(auto img = anim->getImage(frame, group))
@@ -326,7 +321,6 @@ CShowableAnim::CShowableAnim(int x, int y, const AnimationPath & name, ui8 Flags
 	yOffset(0),
 	alpha(alpha)
 {
-	anim->loadGroup(group);
 	last = anim->size(group);
 
 	auto image = anim->getImage(0, group);
@@ -339,11 +333,6 @@ CShowableAnim::CShowableAnim(int x, int y, const AnimationPath & name, ui8 Flags
 	pos.y+= y;
 
 	addUsedEvents(TIME);
-}
-
-CShowableAnim::~CShowableAnim()
-{
-	anim->unloadGroup(group);
 }
 
 void CShowableAnim::setAlpha(ui32 alphaValue)
@@ -361,9 +350,6 @@ bool CShowableAnim::set(size_t Group, size_t from, size_t to)
 	if (max < from || max == 0)
 		return false;
 
-	anim->unloadGroup(group);
-	anim->loadGroup(Group);
-
 	group = Group;
 	frame = first = from;
 	last = max;
@@ -377,9 +363,6 @@ bool CShowableAnim::set(size_t Group)
 		return false;
 	if (group != Group)
 	{
-		anim->unloadGroup(group);
-		anim->loadGroup(Group);
-
 		first = 0;
 		group = Group;
 		last = anim->size(Group);

--- a/client/widgets/Images.cpp
+++ b/client/widgets/Images.cpp
@@ -106,7 +106,7 @@ void CPicture::scaleTo(Point size)
 	pos.h = bg->height();
 }
 
-void CPicture::colorize(PlayerColor player)
+void CPicture::setPlayerColor(PlayerColor player)
 {
 	bg->playerColored(player);
 }
@@ -145,7 +145,7 @@ FilledTexturePlayerColored::FilledTexturePlayerColored(const ImagePath & imageNa
 {
 }
 
-void FilledTexturePlayerColored::playerColored(PlayerColor player)
+void FilledTexturePlayerColored::setPlayerColor(PlayerColor player)
 {
 	// Color transform to make color of brown DIBOX.PCX texture match color of specified player
 	std::array<ColorFilter, PlayerColor::PLAYER_LIMIT_I> filters = {
@@ -301,7 +301,7 @@ void CAnimImage::setFrame(size_t Frame, size_t Group)
 		logGlobal->error("Error: accessing unavailable frame %d:%d in CAnimation!", Group, Frame);
 }
 
-void CAnimImage::playerColored(PlayerColor currPlayer)
+void CAnimImage::setPlayerColor(PlayerColor currPlayer)
 {
 	player = currPlayer;
 	anim->getImage(frame, group)->playerColored(*player);

--- a/client/widgets/Images.cpp
+++ b/client/widgets/Images.cpp
@@ -140,9 +140,9 @@ void CFilledTexture::showAll(Canvas & to)
 	}
 }
 
-FilledTexturePlayerColored::FilledTexturePlayerColored(const ImagePath & imageName, Rect position)
-	: CFilledTexture(imageName, position)
+void FilledTexturePlayerIndexed::setPlayerColor(PlayerColor player)
 {
+	texture->playerColored(player);
 }
 
 void FilledTexturePlayerColored::setPlayerColor(PlayerColor player)

--- a/client/widgets/Images.h
+++ b/client/widgets/Images.h
@@ -178,7 +178,6 @@ public:
 	void setAlpha(ui32 alphaValue);
 
 	CShowableAnim(int x, int y, const AnimationPath & name, ui8 flags, ui32 frameTime, size_t Group=0, uint8_t alpha = UINT8_MAX);
-	~CShowableAnim();
 
 	//set animation to group or part of group
 	bool set(size_t Group);

--- a/client/widgets/Images.h
+++ b/client/widgets/Images.h
@@ -68,8 +68,8 @@ protected:
 	Rect imageArea;
 
 public:
+	CFilledTexture(const ImagePath & imageName, Rect position, Rect imageArea);
 	CFilledTexture(const ImagePath & imageName, Rect position);
-	CFilledTexture(std::shared_ptr<IImage> image, Rect position, Rect imageArea);
 
 	void showAll(Canvas & to) override;
 };
@@ -104,7 +104,7 @@ public:
 
 	CAnimImage(const AnimationPath & name, size_t Frame, size_t Group=0, int x=0, int y=0, ui8 Flags=0);
 	CAnimImage(std::shared_ptr<CAnimation> Anim, size_t Frame, size_t Group=0, int x=0, int y=0, ui8 Flags=0);
-	CAnimImage(std::shared_ptr<CAnimation> Anim, size_t Frame, Rect targetPos, size_t Group=0, ui8 Flags=0);
+	CAnimImage(const AnimationPath & name, size_t Frame, Rect targetPos, size_t Group=0, ui8 Flags=0);
 	~CAnimImage();
 
 	/// size of animation

--- a/client/widgets/Images.h
+++ b/client/widgets/Images.h
@@ -74,10 +74,20 @@ public:
 	void showAll(Canvas & to) override;
 };
 
+/// area filled with specific texture, colorized to player color if image is indexed
+class FilledTexturePlayerIndexed : public CFilledTexture
+{
+public:
+	using CFilledTexture::CFilledTexture;
+
+	void setPlayerColor(PlayerColor player);
+};
+
+/// area filled with specific texture, with applied color filter to colorize it to specific player
 class FilledTexturePlayerColored : public CFilledTexture
 {
 public:
-	FilledTexturePlayerColored(const ImagePath & imageName, Rect position);
+	using CFilledTexture::CFilledTexture;
 
 	void setPlayerColor(PlayerColor player);
 };

--- a/client/widgets/Images.h
+++ b/client/widgets/Images.h
@@ -103,7 +103,7 @@ public:
 	bool visible;
 
 	CAnimImage(const AnimationPath & name, size_t Frame, size_t Group=0, int x=0, int y=0, ui8 Flags=0);
-	CAnimImage(std::shared_ptr<CAnimation> Anim, size_t Frame, size_t Group=0, int x=0, int y=0, ui8 Flags=0);
+//	CAnimImage(std::shared_ptr<CAnimation> Anim, size_t Frame, size_t Group=0, int x=0, int y=0, ui8 Flags=0);
 	CAnimImage(const AnimationPath & name, size_t Frame, Rect targetPos, size_t Group=0, ui8 Flags=0);
 	~CAnimImage();
 

--- a/client/widgets/Images.h
+++ b/client/widgets/Images.h
@@ -146,6 +146,7 @@ public:
 		BASE=1,            //base frame will be blitted before current one
 		HORIZONTAL_FLIP=2, //TODO: will be displayed rotated
 		VERTICAL_FLIP=4,   //TODO: will be displayed rotated
+		PALETTE_ALPHA=8,   // use alpha channel for images with palette. Required for creatures in battle and map objects
 		PLAY_ONCE=32       //play animation only once and stop at last frame
 	};
 protected:

--- a/client/widgets/Images.h
+++ b/client/widgets/Images.h
@@ -44,6 +44,7 @@ public:
 
 	/// wrap section of an existing Image
 	CPicture(std::shared_ptr<IImage> image, const Rect &SrcRext, int x = 0, int y = 0); //wrap subrect of given surface
+	CPicture(const ImagePath & bmpname, const Rect &SrcRext, int x = 0, int y = 0); //wrap subrect of given surface
 
 	/// Loads image from specified file name
 	CPicture(const ImagePath & bmpname);

--- a/client/widgets/Images.h
+++ b/client/widgets/Images.h
@@ -54,7 +54,7 @@ public:
 	/// 0=transparent, 255=opaque
 	void setAlpha(uint8_t value);
 	void scaleTo(Point size);
-	void colorize(PlayerColor player);
+	void setPlayerColor(PlayerColor player);
 
 	void show(Canvas & to) override;
 	void showAll(Canvas & to) override;
@@ -79,7 +79,7 @@ class FilledTexturePlayerColored : public CFilledTexture
 public:
 	FilledTexturePlayerColored(const ImagePath & imageName, Rect position);
 
-	void playerColored(PlayerColor player);
+	void setPlayerColor(PlayerColor player);
 };
 
 /// Class for displaying one image from animation
@@ -114,7 +114,7 @@ public:
 	void setFrame(size_t Frame, size_t Group=0);
 
 	/// makes image player-colored to specific player
-	void playerColored(PlayerColor player);
+	void setPlayerColor(PlayerColor player);
 
 	/// returns true if image has player-colored effect applied
 	bool isPlayerColored() const;

--- a/client/widgets/MiscWidgets.cpp
+++ b/client/widgets/MiscWidgets.cpp
@@ -28,7 +28,6 @@
 #include "../windows/CCastleInterface.h"
 #include "../windows/InfoWindows.h"
 #include "../render/Canvas.h"
-#include "../render/Graphics.h"
 
 #include "../../CCallback.h"
 
@@ -535,7 +534,7 @@ CreatureTooltip::CreatureTooltip(Point pos, const CGCreature * creature)
 	auto creatureID = creature->getCreature();
 	int32_t creatureIconIndex = CGI->creatures()->getById(creatureID)->getIconIndex();
 
-	creatureImage = std::make_shared<CAnimImage>(graphics->getAnimation(AnimationPath::builtin("TWCRPORT")), creatureIconIndex);
+	creatureImage = std::make_shared<CAnimImage>(AnimationPath::builtin("TWCRPORT"), creatureIconIndex);
 	creatureImage->center(Point(parent->pos.x + parent->pos.w / 2, parent->pos.y + creatureImage->pos.h / 2 + 11));
 
 	bool isHeroSelected = LOCPLINT->localState->getCurrentHero() != nullptr;

--- a/client/widgets/MiscWidgets.cpp
+++ b/client/widgets/MiscWidgets.cpp
@@ -248,7 +248,7 @@ CMinorResDataBar::CMinorResDataBar()
 	pos.y = 575;
 
 	background = std::make_shared<CPicture>(ImagePath::builtin("KRESBAR.bmp"));
-	background->colorize(LOCPLINT->playerID);
+	background->setPlayerColor(LOCPLINT->playerID);
 
 	pos.w = background->pos.w;
 	pos.h = background->pos.h;

--- a/client/widgets/ObjectLists.h
+++ b/client/widgets/ObjectLists.h
@@ -18,7 +18,6 @@ VCMI_LIB_NAMESPACE_END
 class CAnimImage;
 class CSlider;
 class CLabel;
-class CAnimation;
 
 /// Used as base for Tabs and List classes
 class CObjectList : public CIntObject

--- a/client/windows/CCastleInterface.cpp
+++ b/client/windows/CCastleInterface.cpp
@@ -885,7 +885,7 @@ void CCastleBuildings::enterCastleGate()
 			availableTowns.push_back(t->id.getNum());//add to the list
 			if(settings["general"]["enableUiEnhancements"].Bool())
 			{
-				auto image = GH.renderHandler().loadImage(AnimationPath::builtin("ITPA"), t->town->clientInfo.icons[t->hasFort()][false] + 2, 0);
+				auto image = GH.renderHandler().loadImage(AnimationPath::builtin("ITPA"), t->town->clientInfo.icons[t->hasFort()][false] + 2, 0, EImageBlitMode::OPAQUE);
 				image->scaleFast(Point(35, 23));
 				images.push_back(image);
 			}

--- a/client/windows/CCastleInterface.cpp
+++ b/client/windows/CCastleInterface.cpp
@@ -272,7 +272,7 @@ CDwellingInfoBox::CDwellingInfoBox(int centerX, int centerY, const CGTownInstanc
 	: CWindowObject(RCLICK_POPUP, ImagePath::builtin("CRTOINFO"), Point(centerX, centerY))
 {
 	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
-	background->colorize(Town->tempOwner);
+	background->setPlayerColor(Town->tempOwner);
 
 	const CCreature * creature = Town->creatures.at(level).second.back().toCreature();
 
@@ -1245,7 +1245,7 @@ CCastleInterface::CCastleInterface(const CGTownInstance * Town, const CGTownInst
 
 	builds = std::make_shared<CCastleBuildings>(town);
 	panel = std::make_shared<CPicture>(ImagePath::builtin("TOWNSCRN"), 0, builds->pos.h);
-	panel->colorize(LOCPLINT->playerID);
+	panel->setPlayerColor(LOCPLINT->playerID);
 	pos.w = panel->pos.w;
 	pos.h = builds->pos.h + panel->pos.h;
 	center();

--- a/client/windows/CCastleInterface.cpp
+++ b/client/windows/CCastleInterface.cpp
@@ -95,7 +95,7 @@ CBuildingRect::CBuildingRect(CCastleBuildings * Par, const CGTownInstance * Town
 	}
 
 	if(!str->borderName.empty())
-		border = GH.renderHandler().loadImage(str->borderName, EImageBlitMode::ALPHA);
+		border = GH.renderHandler().loadImage(str->borderName, EImageBlitMode::COLORKEY);
 
 	if(!str->areaName.empty())
 		area = GH.renderHandler().loadImage(str->areaName, EImageBlitMode::ALPHA);

--- a/client/windows/CCastleInterface.cpp
+++ b/client/windows/CCastleInterface.cpp
@@ -885,9 +885,9 @@ void CCastleBuildings::enterCastleGate()
 			availableTowns.push_back(t->id.getNum());//add to the list
 			if(settings["general"]["enableUiEnhancements"].Bool())
 			{
-				std::shared_ptr<CAnimation> a = GH.renderHandler().loadAnimation(AnimationPath::builtin("ITPA"));
-				a->preload();
-				images.push_back(a->getImage(t->town->clientInfo.icons[t->hasFort()][false] + 2)->scaleFast(Point(35, 23)));
+				auto image = GH.renderHandler().loadImage(AnimationPath::builtin("ITPA"), t->town->clientInfo.icons[t->hasFort()][false] + 2, 0);
+				image->scaleFast(Point(35, 23));
+				images.push_back(image);
 			}
 		}
 	}

--- a/client/windows/CExchangeWindow.cpp
+++ b/client/windows/CExchangeWindow.cpp
@@ -26,7 +26,6 @@
 #include "../widgets/TextControls.h"
 
 #include "../render/IRenderHandler.h"
-#include "../render/CAnimation.h"
 
 #include "../../CCallback.h"
 
@@ -66,17 +65,12 @@ CExchangeWindow::CExchangeWindow(ObjectInstanceID hero1, ObjectInstanceID hero2,
 	titles[0] = std::make_shared<CLabel>(147, 25, FONT_SMALL, ETextAlignment::CENTER, Colors::WHITE, genTitle(heroInst[0]));
 	titles[1] = std::make_shared<CLabel>(653, 25, FONT_SMALL, ETextAlignment::CENTER, Colors::WHITE, genTitle(heroInst[1]));
 
-	auto PSKIL32 = GH.renderHandler().loadAnimation(AnimationPath::builtin("PSKIL32"));
-	PSKIL32->preload();
-
-	auto SECSK32 = GH.renderHandler().loadAnimation(AnimationPath::builtin("SECSK32"));
-
 	for(int g = 0; g < 4; ++g)
 	{
 		if (qeLayout)
-			primSkillImages.push_back(std::make_shared<CAnimImage>(PSKIL32, g, Rect(389, 12 + 26 * g, 22, 22)));
+			primSkillImages.push_back(std::make_shared<CAnimImage>(AnimationPath::builtin("PSKIL32"), g, Rect(389, 12 + 26 * g, 22, 22)));
 		else
-			primSkillImages.push_back(std::make_shared<CAnimImage>(PSKIL32, g, 0, 385, 19 + 36 * g));
+			primSkillImages.push_back(std::make_shared<CAnimImage>(AnimationPath::builtin("PSKIL32"), g, 0, 385, 19 + 36 * g));
 	}
 
 	for(int leftRight : {0, 1})
@@ -88,14 +82,14 @@ CExchangeWindow::CExchangeWindow(ObjectInstanceID hero1, ObjectInstanceID hero2,
 
 
 		for(int m=0; m < hero->secSkills.size(); ++m)
-			secSkillIcons[leftRight].push_back(std::make_shared<CAnimImage>(SECSK32, 0, 0, 32 + 36 * m + 454 * leftRight, qeLayout ? 83 : 88));
+			secSkillIcons[leftRight].push_back(std::make_shared<CAnimImage>(AnimationPath::builtin("SECSK32"), 0, 0, 32 + 36 * m + 454 * leftRight, qeLayout ? 83 : 88));
 
 		specImages[leftRight] = std::make_shared<CAnimImage>(AnimationPath::builtin("UN32"), hero->type->imageIndex, 0, 67 + 490 * leftRight, qeLayout ? 41 : 45);
 
-		expImages[leftRight] = std::make_shared<CAnimImage>(PSKIL32, 4, 0, 103 + 490 * leftRight, qeLayout ? 41 : 45);
+		expImages[leftRight] = std::make_shared<CAnimImage>(AnimationPath::builtin("PSKIL32"), 4, 0, 103 + 490 * leftRight, qeLayout ? 41 : 45);
 		expValues[leftRight] = std::make_shared<CLabel>(119 + 490 * leftRight, qeLayout ? 66 : 71, FONT_SMALL, ETextAlignment::CENTER, Colors::WHITE);
 
-		manaImages[leftRight] = std::make_shared<CAnimImage>(PSKIL32, 5, 0, 139 + 490 * leftRight, qeLayout ? 41 : 45);
+		manaImages[leftRight] = std::make_shared<CAnimImage>(AnimationPath::builtin("PSKIL32"), 5, 0, 139 + 490 * leftRight, qeLayout ? 41 : 45);
 		manaValues[leftRight] = std::make_shared<CLabel>(155 + 490 * leftRight, qeLayout ? 66 : 71, FONT_SMALL, ETextAlignment::CENTER, Colors::WHITE);
 	}
 

--- a/client/windows/CHeroOverview.cpp
+++ b/client/windows/CHeroOverview.cpp
@@ -14,7 +14,6 @@
 #include "../gui/CGuiHandler.h"
 #include "../render/Canvas.h"
 #include "../render/Colors.h"
-#include "../render/Graphics.h"
 #include "../render/IImage.h"
 #include "../renderSDL/RenderHandler.h"
 #include "../widgets/CComponent.h"

--- a/client/windows/CHeroOverview.cpp
+++ b/client/windows/CHeroOverview.cpp
@@ -224,12 +224,12 @@ void CHeroOverview::genControls()
         {
             if((*CGI->heroh)[heroIdx]->haveSpellBook)
             {
-                imageSpells.push_back(std::make_shared<CAnimImage>(GH.renderHandler().loadAnimation(AnimationPath::builtin("ARTIFACT")), 0, Rect(302 + (292 / 2) + 2 * borderOffset, 7 * borderOffset + yOffset + 186 + i * (32 + borderOffset), 32, 32), 0));
+                imageSpells.push_back(std::make_shared<CAnimImage>(AnimationPath::builtin("ARTIFACT"), 0, Rect(302 + (292 / 2) + 2 * borderOffset, 7 * borderOffset + yOffset + 186 + i * (32 + borderOffset), 32, 32), 0));
             }
             i++;
         }
 
-        imageSpells.push_back(std::make_shared<CAnimImage>(GH.renderHandler().loadAnimation(AnimationPath::builtin("SPELLBON")), (*CGI->spellh)[spell]->getIconIndex(), Rect(302 + (292 / 2) + 2 * borderOffset, 7 * borderOffset + yOffset + 186 + i * (32 + borderOffset), 32, 32), 0));
+        imageSpells.push_back(std::make_shared<CAnimImage>(AnimationPath::builtin("SPELLBON"), (*CGI->spellh)[spell]->getIconIndex(), Rect(302 + (292 / 2) + 2 * borderOffset, 7 * borderOffset + yOffset + 186 + i * (32 + borderOffset), 32, 32), 0));
         labelSpellsNames.push_back(std::make_shared<CLabel>(302 + (292 / 2) + 3 * borderOffset + 32 + borderOffset, 8 * borderOffset + yOffset + 186 + i * (32 + borderOffset) + 3, FONT_SMALL, ETextAlignment::TOPLEFT, Colors::WHITE, (*CGI->spellh)[spell]->getNameTranslated()));
         i++;
     }

--- a/client/windows/CHeroWindow.cpp
+++ b/client/windows/CHeroWindow.cpp
@@ -149,12 +149,11 @@ CHeroWindow::CHeroWindow(const CGHeroInstance * hero)
 	expValue = std::make_shared<CLabel>(68, 252);
 	manaValue = std::make_shared<CLabel>(211, 252);
 
-	auto secSkills = GH.renderHandler().loadAnimation(AnimationPath::builtin("SECSKILL"));
 	for(int i = 0; i < std::min<size_t>(hero->secSkills.size(), 8u); ++i)
 	{
 		Rect r = Rect(i%2 == 0  ?  18  :  162,  276 + 48 * (i/2),  136,  42);
 		secSkillAreas.push_back(std::make_shared<LRClickableAreaWTextComp>(r, ComponentType::SEC_SKILL));
-		secSkillImages.push_back(std::make_shared<CAnimImage>(secSkills, 0, 0, r.x, r.y));
+		secSkillImages.push_back(std::make_shared<CAnimImage>(AnimationPath::builtin("SECSKILL"), 0, 0, r.x, r.y));
 
 		int x = (i % 2) ? 212 : 68;
 		int y = 280 + 48 * (i/2);

--- a/client/windows/CHeroWindow.cpp
+++ b/client/windows/CHeroWindow.cpp
@@ -28,7 +28,6 @@
 #include "../widgets/CGarrisonInt.h"
 #include "../widgets/TextControls.h"
 #include "../widgets/Buttons.h"
-#include "../render/CAnimation.h"
 #include "../render/IRenderHandler.h"
 
 #include "../../CCallback.h"
@@ -131,14 +130,12 @@ CHeroWindow::CHeroWindow(const CGHeroInstance * hero)
 		primSkillValues.push_back(value);
 	}
 
-	auto primSkills = GH.renderHandler().loadAnimation(AnimationPath::builtin("PSKIL42"));
-	primSkills->preload();
-	primSkillImages.push_back(std::make_shared<CAnimImage>(primSkills, 0, 0, 32, 111));
-	primSkillImages.push_back(std::make_shared<CAnimImage>(primSkills, 1, 0, 102, 111));
-	primSkillImages.push_back(std::make_shared<CAnimImage>(primSkills, 2, 0, 172, 111));
-	primSkillImages.push_back(std::make_shared<CAnimImage>(primSkills, 3, 0, 162, 230));
-	primSkillImages.push_back(std::make_shared<CAnimImage>(primSkills, 4, 0, 20, 230));
-	primSkillImages.push_back(std::make_shared<CAnimImage>(primSkills, 5, 0, 242, 111));
+	primSkillImages.push_back(std::make_shared<CAnimImage>(AnimationPath::builtin("PSKIL42"), 0, 0, 32, 111));
+	primSkillImages.push_back(std::make_shared<CAnimImage>(AnimationPath::builtin("PSKIL42"), 1, 0, 102, 111));
+	primSkillImages.push_back(std::make_shared<CAnimImage>(AnimationPath::builtin("PSKIL42"), 2, 0, 172, 111));
+	primSkillImages.push_back(std::make_shared<CAnimImage>(AnimationPath::builtin("PSKIL42"), 3, 0, 162, 230));
+	primSkillImages.push_back(std::make_shared<CAnimImage>(AnimationPath::builtin("PSKIL42"), 4, 0, 20, 230));
+	primSkillImages.push_back(std::make_shared<CAnimImage>(AnimationPath::builtin("PSKIL42"), 5, 0, 242, 111));
 
 	specImage = std::make_shared<CAnimImage>(AnimationPath::builtin("UN44"), 0, 0, 18, 180);
 	specArea = std::make_shared<LRClickableAreaWText>(Rect(18, 180, 136, 42), CGI->generaltexth->heroscrn[27]);

--- a/client/windows/CKingdomInterface.cpp
+++ b/client/windows/CKingdomInterface.cpp
@@ -692,7 +692,7 @@ CKingdHeroList::CKingdHeroList(size_t maxSize, const CreateHeroItemFunctor & onC
 {
 	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
 	title = std::make_shared<CPicture>(ImagePath::builtin("OVTITLE"),16,0);
-	title->colorize(LOCPLINT->playerID);
+	title->setPlayerColor(LOCPLINT->playerID);
 	heroLabel = std::make_shared<CLabel>(150, 10, FONT_MEDIUM, ETextAlignment::CENTER, Colors::WHITE, CGI->generaltexth->overview[0]);
 	skillsLabel = std::make_shared<CLabel>(500, 10, FONT_MEDIUM, ETextAlignment::CENTER, Colors::WHITE, CGI->generaltexth->overview[1]);
 
@@ -736,7 +736,7 @@ CKingdTownList::CKingdTownList(size_t maxSize)
 {
 	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
 	title = std::make_shared<CPicture>(ImagePath::builtin("OVTITLE"), 16, 0);
-	title->colorize(LOCPLINT->playerID);
+	title->setPlayerColor(LOCPLINT->playerID);
 	townLabel = std::make_shared<CLabel>(146, 10,FONT_MEDIUM, ETextAlignment::CENTER, Colors::WHITE, CGI->generaltexth->overview[3]);
 	garrHeroLabel = std::make_shared<CLabel>(375, 10, FONT_MEDIUM, ETextAlignment::CENTER, Colors::WHITE, CGI->generaltexth->overview[4]);
 	visitHeroLabel = std::make_shared<CLabel>(608, 10, FONT_MEDIUM, ETextAlignment::CENTER, Colors::WHITE, CGI->generaltexth->overview[5]);

--- a/client/windows/CMapOverview.cpp
+++ b/client/windows/CMapOverview.cpp
@@ -20,7 +20,6 @@
 #include "../widgets/TextControls.h"
 #include "../windows/GUIClasses.h"
 #include "../windows/InfoWindows.h"
-#include "../render/CAnimation.h"
 #include "../render/Canvas.h"
 #include "../render/IImage.h"
 #include "../render/IRenderHandler.h"

--- a/client/windows/CMarketWindow.cpp
+++ b/client/windows/CMarketWindow.cpp
@@ -70,12 +70,12 @@ void CMarketWindow::updateGarrisons()
 	update();
 }
 
-void CMarketWindow::updateResource()
+void CMarketWindow::updateResources()
 {
 	update();
 }
 
-void CMarketWindow::updateHero()
+void CMarketWindow::updateExperience()
 {
 	update();
 }
@@ -251,7 +251,7 @@ void CMarketWindow::createAltarArtifacts(const IMarket * market, const CGHeroIns
 	};
 	addSet(heroArts);
 	initWidgetInternals(EMarketMode::ARTIFACT_EXP, CGI->generaltexth->zelp[568]);
-	updateHero();
+	updateExperience();
 	quitButton->addCallback([altarArtifacts](){altarArtifacts->putBackArtifacts();});
 }
 
@@ -262,5 +262,5 @@ void CMarketWindow::createAltarCreatures(const IMarket * market, const CGHeroIns
 	background = createBg(ImagePath::builtin("ALTARMON.bmp"), PLAYER_COLORED);
 	marketWidget = std::make_shared<CAltarCreatures>(market, hero);
 	initWidgetInternals(EMarketMode::CREATURE_EXP, CGI->generaltexth->zelp[568]);
-	updateHero();
+	updateExperience();
 }

--- a/client/windows/CMarketWindow.h
+++ b/client/windows/CMarketWindow.h
@@ -12,14 +12,14 @@
 #include "../widgets/markets/CMarketBase.h"
 #include "CWindowWithArtifacts.h"
 
-class CMarketWindow : public CStatusbarWindow, public CWindowWithArtifacts, public IGarrisonHolder
+class CMarketWindow final : public CStatusbarWindow, public CWindowWithArtifacts, public IGarrisonHolder, public IMarketHolder
 {
 public:
 	CMarketWindow(const IMarket * market, const CGHeroInstance * hero, const std::function<void()> & onWindowClosed, EMarketMode mode);
-	void updateResource();
-	void updateArtifacts();
+	void updateResources() override;
+	void updateArtifacts() override;
 	void updateGarrisons() override;
-	void updateHero();
+	void updateExperience() override;
 	void update() override;
 	void close() override;
 	bool holdsGarrison(const CArmedInstance * army) override;

--- a/client/windows/CMessage.cpp
+++ b/client/windows/CMessage.cpp
@@ -42,7 +42,6 @@ void CMessage::init()
 	for(int i = 0; i < PlayerColor::PLAYER_LIMIT_I; i++)
 	{
 		dialogBorders[i] = GH.renderHandler().loadAnimation(AnimationPath::builtin("DIALGBOX"));
-		dialogBorders[i]->preload();
 
 		for(int j = 0; j < dialogBorders[i]->size(0); j++)
 		{

--- a/client/windows/CMessage.cpp
+++ b/client/windows/CMessage.cpp
@@ -41,7 +41,7 @@ void CMessage::init()
 {
 	for(int i = 0; i < PlayerColor::PLAYER_LIMIT_I; i++)
 	{
-		dialogBorders[i] = GH.renderHandler().loadAnimation(AnimationPath::builtin("DIALGBOX"));
+		dialogBorders[i] = GH.renderHandler().loadAnimation(AnimationPath::builtin("DIALGBOX"), EImageBlitMode::OPAQUE);
 
 		for(int j = 0; j < dialogBorders[i]->size(0); j++)
 		{

--- a/client/windows/CSpellWindow.cpp
+++ b/client/windows/CSpellWindow.cpp
@@ -215,7 +215,7 @@ CSpellWindow::~CSpellWindow()
 
 std::shared_ptr<IImage> CSpellWindow::createBigSpellBook()
 {
-	std::shared_ptr<IImage> img = GH.renderHandler().loadImage(ImagePath::builtin("SpelBack"));
+	std::shared_ptr<IImage> img = GH.renderHandler().loadImage(ImagePath::builtin("SpelBack"), EImageBlitMode::OPAQUE);
 	Canvas canvas = Canvas(Point(800, 600));
 	// edges
 	canvas.draw(img, Point(0, 0), Rect(15, 38, 90, 45));

--- a/client/windows/CSpellWindow.cpp
+++ b/client/windows/CSpellWindow.cpp
@@ -30,7 +30,6 @@
 #include "../widgets/CTextInput.h"
 #include "../widgets/TextControls.h"
 #include "../adventureMap/AdventureMapInterface.h"
-#include "../render/CAnimation.h"
 #include "../render/IRenderHandler.h"
 #include "../render/IImage.h"
 #include "../render/IImageLoader.h"
@@ -151,18 +150,9 @@ CSpellWindow::CSpellWindow(const CGHeroInstance * _myHero, CPlayerInterface * _m
 	leftCorner = std::make_shared<CPicture>(ImagePath::builtin("SpelTrnL.bmp"), 97 + offL, 77 + offT);
 	rightCorner = std::make_shared<CPicture>(ImagePath::builtin("SpelTrnR.bmp"), 487 + offR, 72 + offT);
 
-	spellIcons = GH.renderHandler().loadAnimation(AnimationPath::builtin("Spells"));
-
 	schoolTab = std::make_shared<CAnimImage>(AnimationPath::builtin("SpelTab"), selectedTab, 0, 524 + offR, 88);
 	schoolPicture = std::make_shared<CAnimImage>(AnimationPath::builtin("Schools"), 0, 0, 117 + offL, 74 + offT);
 
-	schoolBorders[0] = GH.renderHandler().loadAnimation(AnimationPath::builtin("SplevA.def"));
-	schoolBorders[1] = GH.renderHandler().loadAnimation(AnimationPath::builtin("SplevF.def"));
-	schoolBorders[2] = GH.renderHandler().loadAnimation(AnimationPath::builtin("SplevW.def"));
-	schoolBorders[3] = GH.renderHandler().loadAnimation(AnimationPath::builtin("SplevE.def"));
-
-	for(auto item : schoolBorders)
-		item->preload();
 	mana = std::make_shared<CLabel>(435 + (isBigSpellbook ? 159 : 0), 426 + offB, FONT_SMALL, ETextAlignment::CENTER, Colors::YELLOW, std::to_string(myHero->mana));
 
 	if(isBigSpellbook)
@@ -595,7 +585,7 @@ CSpellWindow::SpellArea::SpellArea(Rect pos, CSpellWindow * owner)
 
 	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
 
-	image = std::make_shared<CAnimImage>(owner->spellIcons, 0, 0);
+	image = std::make_shared<CAnimImage>(AnimationPath::builtin("Spells"), 0, 0);
 	image->visible = false;
 
 	name = std::make_shared<CLabel>(39, 70, FONT_TINY, ETextAlignment::CENTER);
@@ -744,14 +734,22 @@ void CSpellWindow::SpellArea::setSpell(const CSpell * spell)
 
 		{
 			OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+
+			static const std::array schoolBorders = {
+				AnimationPath::builtin("SplevA.def"),
+				AnimationPath::builtin("SplevF.def"),
+				AnimationPath::builtin("SplevW.def"),
+				AnimationPath::builtin("SplevE.def")
+			};
+
 			schoolBorder.reset();
 			if (owner->selectedTab >= 4)
 			{
 				if (whichSchool.getNum() != SpellSchool())
-					schoolBorder = std::make_shared<CAnimImage>(owner->schoolBorders.at(whichSchool.getNum()), schoolLevel);
+					schoolBorder = std::make_shared<CAnimImage>(schoolBorders.at(whichSchool.getNum()), schoolLevel);
 			}
 			else
-				schoolBorder = std::make_shared<CAnimImage>(owner->schoolBorders.at(owner->selectedTab), schoolLevel);
+				schoolBorder = std::make_shared<CAnimImage>(schoolBorders.at(owner->selectedTab), schoolLevel);
 		}
 
 		ColorRGBA firstLineColor, secondLineColor;

--- a/client/windows/CSpellWindow.h
+++ b/client/windows/CSpellWindow.h
@@ -19,7 +19,6 @@ class CSpell;
 VCMI_LIB_NAMESPACE_END
 
 class IImage;
-class CAnimation;
 class CAnimImage;
 class CPicture;
 class CLabel;
@@ -66,9 +65,6 @@ class CSpellWindow : public CWindowObject
 
 		InteractiveArea(const Rect &myRect, std::function<void()> funcL, int helpTextId, CSpellWindow * _owner);
 	};
-
-	std::shared_ptr<CAnimation> spellIcons;
-	std::array<std::shared_ptr<CAnimation>, 4> schoolBorders; //[0]: air, [1]: fire, [2]: water, [3]: earth
 
 	std::shared_ptr<CPicture> leftCorner;
 	std::shared_ptr<CPicture> rightCorner;

--- a/client/windows/CWindowObject.cpp
+++ b/client/windows/CWindowObject.cpp
@@ -93,7 +93,7 @@ std::shared_ptr<CPicture> CWindowObject::createBg(const ImagePath & imageName, b
 	auto image = std::make_shared<CPicture>(imageName);
 	image->getSurface()->setBlitMode(EImageBlitMode::OPAQUE);
 	if(playerColored)
-		image->colorize(LOCPLINT->playerID);
+		image->setPlayerColor(LOCPLINT->playerID);
 	return image;
 }
 

--- a/client/windows/CWindowObject.cpp
+++ b/client/windows/CWindowObject.cpp
@@ -202,8 +202,8 @@ void CWindowObject::setShadow(bool on)
 
 		//create base 8x8 piece of shadow
 		SDL_Surface * shadowCorner = CSDL_Ext::copySurface(shadowCornerTempl);
-		SDL_Surface * shadowBottom = CSDL_Ext::scaleSurfaceFast(shadowBottomTempl, fullsize.x - size, size);
-		SDL_Surface * shadowRight  = CSDL_Ext::scaleSurfaceFast(shadowRightTempl,  size, fullsize.y - size);
+		SDL_Surface * shadowBottom = CSDL_Ext::scaleSurface(shadowBottomTempl, fullsize.x - size, size);
+		SDL_Surface * shadowRight  = CSDL_Ext::scaleSurface(shadowRightTempl,  size, fullsize.y - size);
 
 		blitAlphaCol(shadowBottom, 0);
 		blitAlphaRow(shadowRight, 0);

--- a/client/windows/CWindowWithArtifacts.cpp
+++ b/client/windows/CWindowWithArtifacts.cpp
@@ -237,7 +237,7 @@ void CWindowWithArtifacts::setCursorAnimation(const CArtifactInstance & artInst)
 	if(artInst.isScroll() && settings["general"]["enableUiEnhancements"].Bool())
 	{
 		assert(artInst.getScrollSpellID().num >= 0);
-		auto image = GH.renderHandler().loadImage(AnimationPath::builtin("spellscr"), artInst.getScrollSpellID().num, 0);
+		auto image = GH.renderHandler().loadImage(AnimationPath::builtin("spellscr"), artInst.getScrollSpellID().num, 0, EImageBlitMode::COLORKEY);
 		image->scaleFast(Point(44,34));
 
 		CCS->curh->dragAndDropCursor(image);

--- a/client/windows/CWindowWithArtifacts.cpp
+++ b/client/windows/CWindowWithArtifacts.cpp
@@ -237,9 +237,10 @@ void CWindowWithArtifacts::setCursorAnimation(const CArtifactInstance & artInst)
 	if(artInst.isScroll() && settings["general"]["enableUiEnhancements"].Bool())
 	{
 		assert(artInst.getScrollSpellID().num >= 0);
-		const auto animation = GH.renderHandler().loadAnimation(AnimationPath::builtin("spellscr"));
-		animation->load(artInst.getScrollSpellID().num);
-		CCS->curh->dragAndDropCursor(animation->getImage(artInst.getScrollSpellID().num)->scaleFast(Point(44, 34)));
+		auto image = GH.renderHandler().loadImage(AnimationPath::builtin("spellscr"), artInst.getScrollSpellID().num, 0);
+		image->scaleFast(Point(44,34));
+
+		CCS->curh->dragAndDropCursor(image);
 	}
 	else
 	{

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -36,7 +36,6 @@
 #include "../widgets/VideoWidget.h"
 
 #include "../render/Canvas.h"
-#include "../render/CAnimation.h"
 #include "../render/IRenderHandler.h"
 #include "../render/IImage.h"
 
@@ -892,8 +891,13 @@ CUniversityWindow::CItem::CItem(CUniversityWindow * _parent, int _ID, int X, int
 	pos.x += X;
 	pos.y += Y;
 
-	topBar = std::make_shared<CAnimImage>(parent->bars, 0, 0, -28, -22);
-	bottomBar = std::make_shared<CAnimImage>(parent->bars, 0, 0, -28, 48);
+	// TODO: restore
+	//bars->setCustom("UNIVRED", 0, 0);
+	//bars->setCustom("UNIVGOLD", 1, 0);
+	//bars->setCustom("UNIVGREN", 2, 0);
+
+	topBar = std::make_shared<CPicture>(ImagePath::builtin("UNIVRED"), Point(-28, -22));
+	bottomBar = std::make_shared<CPicture>(ImagePath::builtin("UNIVRED"), Point(-28, 48));
 
 	icon = std::make_shared<CAnimImage>(AnimationPath::builtin("SECSKILL"), _ID * 3 + 3, 0);
 
@@ -932,16 +936,6 @@ int CUniversityWindow::CItem::state()
 	return 2;
 }
 
-void CUniversityWindow::CItem::showAll(Canvas & to)
-{
-	//TODO: update when state actually changes
-	auto stateIndex = state();
-	topBar->setFrame(stateIndex);
-	bottomBar->setFrame(stateIndex);
-
-	CIntObject::showAll(to);
-}
-
 CUniversityWindow::CUniversityWindow(const CGHeroInstance * _hero, const IMarket * _market, const std::function<void()> & onWindowClosed)
 	: CWindowObject(PLAYER_COLORED, ImagePath::builtin("UNIVERS1")),
 	hero(_hero),
@@ -950,12 +944,7 @@ CUniversityWindow::CUniversityWindow(const CGHeroInstance * _hero, const IMarket
 {
 	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
 
-	bars = GH.renderHandler().createAnimation();
-	bars->setCustom("UNIVRED", 0, 0);
-	bars->setCustom("UNIVGOLD", 1, 0);
-	bars->setCustom("UNIVGREN", 2, 0);
-	bars->preload();
-	
+
 	std::string titleStr = CGI->generaltexth->allTexts[602];
 	std::string speechStr = CGI->generaltexth->allTexts[603];
 
@@ -1331,17 +1320,11 @@ CThievesGuildWindow::CThievesGuildWindow(const CGObjectInstance * _owner):
 		rowHeaders.push_back(std::make_shared<CLabel>(135, y, FONT_MEDIUM, ETextAlignment::CENTER, Colors::YELLOW, text));
 	}
 
-	auto PRSTRIPS = GH.renderHandler().loadAnimation(AnimationPath::builtin("PRSTRIPS"));
-	PRSTRIPS->preload();
-
 	for(int g=1; g<tgi.playerColors.size(); ++g)
-		columnBackgrounds.push_back(std::make_shared<CAnimImage>(PRSTRIPS, g-1, 0, 250 + 66*g, 7));
+		columnBackgrounds.push_back(std::make_shared<CAnimImage>(AnimationPath::builtin("PRSTRIPS"), g-1, 0, 250 + 66*g, 7));
 
 	for(int g=0; g<tgi.playerColors.size(); ++g)
 		columnHeaders.push_back(std::make_shared<CLabel>(283 + 66*g, 24, FONT_BIG, ETextAlignment::CENTER, Colors::YELLOW, CGI->generaltexth->jktexts[16+g]));
-
-	auto itgflags = GH.renderHandler().loadAnimation(AnimationPath::builtin("itgflags"));
-	itgflags->preload();
 
 	//printing flags
 	for(int g = 0; g < std::size(fields); ++g) //by lines
@@ -1366,7 +1349,7 @@ CThievesGuildWindow::CThievesGuildWindow(const CGObjectInstance * _owner):
 				int rowStartY = ypos + (j ? 4 : 0);
 
 				for(size_t i=0; i < rowLength[j]; i++)
-					cells.push_back(std::make_shared<CAnimImage>(itgflags, players[i + j*4].getNum(), 0, rowStartX + (int)i*12, rowStartY));
+					cells.push_back(std::make_shared<CAnimImage>(AnimationPath::builtin("itgflags"), players[i + j*4].getNum(), 0, rowStartX + (int)i*12, rowStartY));
 			}
 		}
 	}

--- a/client/windows/GUIClasses.h
+++ b/client/windows/GUIClasses.h
@@ -358,9 +358,9 @@ public:
 	CTransformerWindow(const IMarket * _market, const CGHeroInstance * _hero, const std::function<void()> & onWindowClosed);
 };
 
-class CUniversityWindow : public CStatusbarWindow
+class CUniversityWindow final : public CStatusbarWindow, public IMarketHolder
 {
-	class CItem : public CIntObject
+	class CItem final : public CIntObject
 	{
 		std::shared_ptr<CAnimImage> icon;
 		std::shared_ptr<CPicture> topBar;
@@ -374,7 +374,7 @@ class CUniversityWindow : public CStatusbarWindow
 		void clickPressed(const Point & cursorPosition) override;
 		void showPopupWindow(const Point & cursorPosition) override;
 		void hover(bool on) override;
-		int state();//0=can't learn, 1=learned, 2=can learn
+		void update();
 		CItem(CUniversityWindow * _parent, int _ID, int X, int Y);
 	};
 
@@ -394,11 +394,14 @@ public:
 	CUniversityWindow(const CGHeroInstance * _hero, const IMarket * _market, const std::function<void()> & onWindowClosed);
 
 	void makeDeal(SecondarySkill skill);
-	void close();
+	void close() override;
+
+	// IMarketHolder impl
+	void updateSecondarySkills() override;
 };
 
 /// Confirmation window for University
-class CUnivConfirmWindow : public CStatusbarWindow
+class CUnivConfirmWindow final : public CStatusbarWindow
 {
 	std::shared_ptr<CTextBox> clerkSpeech;
 	std::shared_ptr<CLabel> name;

--- a/client/windows/GUIClasses.h
+++ b/client/windows/GUIClasses.h
@@ -363,15 +363,14 @@ class CUniversityWindow : public CStatusbarWindow
 	class CItem : public CIntObject
 	{
 		std::shared_ptr<CAnimImage> icon;
-		std::shared_ptr<CAnimImage> topBar;
-		std::shared_ptr<CAnimImage> bottomBar;
+		std::shared_ptr<CPicture> topBar;
+		std::shared_ptr<CPicture> bottomBar;
 		std::shared_ptr<CLabel> name;
 		std::shared_ptr<CLabel> level;
 	public:
 		SecondarySkill ID;//id of selected skill
 		CUniversityWindow * parent;
 
-		void showAll(Canvas & to) override;
 		void clickPressed(const Point & cursorPosition) override;
 		void showPopupWindow(const Point & cursorPosition) override;
 		void hover(bool on) override;
@@ -381,8 +380,6 @@ class CUniversityWindow : public CStatusbarWindow
 
 	const CGHeroInstance * hero;
 	const IMarket * market;
-
-	std::shared_ptr<CAnimation> bars;
 
 	std::vector<std::shared_ptr<CItem>> items;
 

--- a/lib/mapping/CMapEditManager.h
+++ b/lib/mapping/CMapEditManager.h
@@ -72,16 +72,16 @@ public:
 	CMap * getMap();
 
 	/// Clears the terrain. The free level is filled with water and the underground level with rock.
-	void clearTerrain(vstd::RNG * gen = nullptr);
+	void clearTerrain(vstd::RNG * gen);
 
 	/// Draws terrain at the current terrain selection. The selection will be cleared automatically.
-	void drawTerrain(TerrainId terType, int decorationsPercentage, vstd::RNG * gen = nullptr);
+	void drawTerrain(TerrainId terType, int decorationsPercentage, vstd::RNG * gen);
 
 	/// Draws roads at the current terrain selection. The selection will be cleared automatically.
-	void drawRoad(RoadId roadType, vstd::RNG * gen = nullptr);
+	void drawRoad(RoadId roadType, vstd::RNG * gen);
 	
 	/// Draws rivers at the current terrain selection. The selection will be cleared automatically.
-	void drawRiver(RiverId riverType, vstd::RNG * gen = nullptr);
+	void drawRiver(RiverId riverType, vstd::RNG * gen);
 
 	void insertObject(CGObjectInstance * obj);
 	void insertObjects(std::set<CGObjectInstance *> & objects);

--- a/mapeditor/Animation.cpp
+++ b/mapeditor/Animation.cpp
@@ -711,14 +711,6 @@ void Animation::duplicateImage(const size_t sourceGroup, const size_t sourceFram
 		load(index, targetGroup);
 }
 
-void Animation::setCustom(std::string filename, size_t frame, size_t group)
-{
-	if(source[group].size() <= frame)
-		source[group].resize(frame+1);
-	source[group][frame]["file"].String() = filename;
-	//FIXME: update image if already loaded
-}
-
 std::shared_ptr<QImage> Animation::getImage(size_t frame, size_t group, bool verbose) const
 {
 	auto groupIter = images.find(group);

--- a/mapeditor/Animation.h
+++ b/mapeditor/Animation.h
@@ -68,9 +68,6 @@ public:
 
 	// adjust the color of the animation, used in battle spell effects, e.g. Cloned objects
 
-	//add custom surface to the selected position.
-	void setCustom(std::string filename, size_t frame, size_t group = 0);
-
 	std::shared_ptr<QImage> getImage(size_t frame, size_t group = 0, bool verbose = true) const;
 
 	//all available frames

--- a/test/map/CMapEditManagerTest.cpp
+++ b/test/map/CMapEditManagerTest.cpp
@@ -25,15 +25,16 @@ TEST(MapManager, DrawTerrain_Type)
 	try
 	{
 		auto map = std::make_unique<CMap>(nullptr);
+		CRandomGenerator rand;
 		map->width = 52;
 		map->height = 52;
 		map->initTerrain();
 		auto editManager = map->getEditManager();
-		editManager->clearTerrain();
+		editManager->clearTerrain(&rand);
 
 		// 1x1 Blow up
 		editManager->getTerrainSelection().select(int3(5, 5, 0));
-		editManager->drawTerrain(ETerrainId::GRASS, 10);
+		editManager->drawTerrain(ETerrainId::GRASS, 10, &rand);
 		static const int3 squareCheck[] = { int3(5,5,0), int3(5,4,0), int3(4,4,0), int3(4,5,0) };
 		for(const auto & tile : squareCheck)
 		{
@@ -42,20 +43,20 @@ TEST(MapManager, DrawTerrain_Type)
 
 		// Concat to square
 		editManager->getTerrainSelection().select(int3(6, 5, 0));
-		editManager->drawTerrain(ETerrainId::GRASS, 10);
+		editManager->drawTerrain(ETerrainId::GRASS, 10, &rand);
 		EXPECT_EQ(map->getTile(int3(6, 4, 0)).terType->getId(), ETerrainId::GRASS);
 		editManager->getTerrainSelection().select(int3(6, 5, 0));
-		editManager->drawTerrain(ETerrainId::LAVA, 10);
+		editManager->drawTerrain(ETerrainId::LAVA, 10, &rand);
 		EXPECT_EQ(map->getTile(int3(4, 4, 0)).terType->getId(), ETerrainId::GRASS);
 		EXPECT_EQ(map->getTile(int3(7, 4, 0)).terType->getId(), ETerrainId::LAVA);
 
 		// Special case water,rock
 		editManager->getTerrainSelection().selectRange(MapRect(int3(10, 10, 0), 10, 5));
-		editManager->drawTerrain(ETerrainId::GRASS, 10);
+		editManager->drawTerrain(ETerrainId::GRASS, 10, &rand);
 		editManager->getTerrainSelection().selectRange(MapRect(int3(15, 17, 0), 10, 5));
-		editManager->drawTerrain(ETerrainId::GRASS, 10);
+		editManager->drawTerrain(ETerrainId::GRASS, 10, &rand);
 		editManager->getTerrainSelection().select(int3(21, 16, 0));
-		editManager->drawTerrain(ETerrainId::GRASS, 10);
+		editManager->drawTerrain(ETerrainId::GRASS, 10, &rand);
 		EXPECT_EQ(map->getTile(int3(20, 15, 0)).terType->getId(), ETerrainId::GRASS);
 
 		// Special case non water,rock
@@ -66,16 +67,16 @@ TEST(MapManager, DrawTerrain_Type)
 		{
 			editManager->getTerrainSelection().select(tile);
 		}
-		editManager->drawTerrain(ETerrainId::GRASS, 10);
+		editManager->drawTerrain(ETerrainId::GRASS, 10, &rand);
 		EXPECT_EQ(map->getTile(int3(35, 44, 0)).terType->getId(), ETerrainId::WATER);
 
 		// Rock case
 		editManager->getTerrainSelection().selectRange(MapRect(int3(1, 1, 1), 15, 15));
-		editManager->drawTerrain(ETerrainId::SUBTERRANEAN, 10);
+		editManager->drawTerrain(ETerrainId::SUBTERRANEAN, 10, &rand);
 		std::vector<int3> vec({ int3(6, 6, 1), int3(7, 6, 1), int3(8, 6, 1), int3(5, 7, 1), int3(6, 7, 1), int3(7, 7, 1),
 								int3(8, 7, 1), int3(4, 8, 1), int3(5, 8, 1), int3(6, 8, 1)});
 		editManager->getTerrainSelection().setSelection(vec);
-		editManager->drawTerrain(ETerrainId::ROCK, 10);
+		editManager->drawTerrain(ETerrainId::ROCK, 10, &rand);
 		EXPECT_TRUE(!map->getTile(int3(5, 6, 1)).terType->isPassable() || !map->getTile(int3(7, 8, 1)).terType->isPassable());
 
 		//todo: add checks here and enable, also use smaller size


### PR DESCRIPTION
Another part of reworking of our rendering logic, hopefully approaching finish line. All image loading logic is now part of (previously placeholder) RenderHandler class. Should also speed up game loading thanks to lazy loading & reduce data duplication caused by loading of same image multiple times.

- All images (whether animation frames or single bitmaps) are now loaded & managed by RenderHandler
- RenderHandler now caches all image access. Multiple requests for the same image will no longer lead to loading of duplicated image data. Similarly, any images that use vertical or horizontal flips are now also done via RenderHandler and tracked
- IImage interface implementations no longer own image data. Instead they hold reference to potentially shared image data and only own instance-specific data, such as transparency factor or transformed palette
- CAnimation class now uses lazy loading and only loads additional frames on request. This speeds up loading to adventure map and to battle since game no longer needs to decode hundreds of frames at once.
- Removed multiple now redundant animation caching implementations
- University window now receives updated hero skill via call on netpack instead of refreshing state on every frame
- Unified naming of `setPlayerColor` functions (colorize, playerColor, playerColored, etc)
- Fixed excessive (~200 Mb) memory allocation on adventure map (should be probably backported to 1.5)

TODO:
- [ ] Make image caching less aggressive and set upper limit to cache size instead of current unlimited cache
- [ ] Reduce number of palette copies. Instead use reference counting provided by SDL. For example, when loading .def there is no need to create separate palette for every tiny frame - we can share single palette between all frames. Memory usage savings are small for a single image, but H3 has thousands of such images.
- [x] Review cases in which we use SDL blit and in which - our slow custom blit that can use alpha channel in palettes. (In SDL3 we will be able to drop our custom blit completely, but that won't happen soon)
- [x] Remove custom animations generation from obstacle rendering in battle interface
- [x] Remove custom animation generation from ranged attack highlight and move it to json config
- [ ] Consider whether to move existing image scaling handling to RenderHandler (but probably without caching)

Things to check for regressions:
- [x] Creatures in battles
- [x] Obstacles in battles
- [x] 'Absolute' obstacles in battles