### PR TITLE
Fixes to help tab in Launcher

### DIFF
--- a/launcher/aboutProject/aboutproject_moc.cpp
+++ b/launcher/aboutProject/aboutproject_moc.cpp
@@ -16,6 +16,20 @@
 #include "../../lib/GameConstants.h"
 #include "../../lib/VCMIDirs.h"
 
+void AboutProjectView::hideAndStretchWidget(QGridLayout * layout, QWidget * toHide, QWidget * toStretch)
+{
+	toHide->hide();
+
+	int index = layout->indexOf(toStretch);
+	int row;
+	int col;
+	int unused;
+	layout->getItemPosition(index, &row, &col, &unused, &unused);
+	layout->removeWidget(toHide);
+	layout->removeWidget(toStretch);
+	layout->addWidget(toStretch, row, col, 1, -1);
+}
+
 AboutProjectView::AboutProjectView(QWidget * parent)
 	: QWidget(parent)
 	, ui(new Ui::AboutProjectView)
@@ -25,8 +39,18 @@ AboutProjectView::AboutProjectView(QWidget * parent)
 	ui->lineEditUserDataDir->setText(pathToQString(VCMIDirs::get().userDataPath()));
 	ui->lineEditGameDir->setText(pathToQString(VCMIDirs::get().binaryPath()));
 	ui->lineEditTempDir->setText(pathToQString(VCMIDirs::get().userLogsPath()));
+	ui->lineEditConfigDir->setText(pathToQString(VCMIDirs::get().userConfigPath()));
 	ui->lineEditBuildVersion->setText(QString::fromStdString(GameConstants::VCMI_VERSION));
 	ui->lineEditOperatingSystem->setText(QSysInfo::prettyProductName());
+
+#ifdef VCMI_MOBILE
+	// On mobile platforms these directories are generally not accessible from phone itself, only via USB connection from PC
+	// Remove "Open" buttons and stretch line with text into now-empty space
+	hideAndStretchWidget(ui->gridLayout, ui->openGameDataDir, ui->lineEditGameDir);
+	hideAndStretchWidget(ui->gridLayout, ui->openUserDataDir, ui->lineEditUserDataDir);
+	hideAndStretchWidget(ui->gridLayout, ui->openTempDir, ui->lineEditTempDir);
+	hideAndStretchWidget(ui->gridLayout, ui->openConfigDir, ui->lineEditConfigDir);
+#endif
 }
 
 void AboutProjectView::changeEvent(QEvent *event)
@@ -57,6 +81,11 @@ void AboutProjectView::on_openTempDir_clicked()
 	QDesktopServices::openUrl(QUrl::fromLocalFile(QFileInfo(ui->lineEditTempDir->text()).absoluteFilePath()));
 }
 
+void AboutProjectView::on_openConfigDir_clicked()
+{
+	QDesktopServices::openUrl(QUrl::fromLocalFile(QFileInfo(ui->lineEditConfigDir->text()).absoluteFilePath()));
+}
+
 void AboutProjectView::on_pushButtonDiscord_clicked()
 {
 	QDesktopServices::openUrl(QUrl("https://discord.gg/chBT42V"));
@@ -82,4 +111,3 @@ void AboutProjectView::on_pushButtonBugreport_clicked()
 {
 	QDesktopServices::openUrl(QUrl("https://github.com/vcmi/vcmi/issues"));
 }
-

--- a/launcher/aboutProject/aboutproject_moc.h
+++ b/launcher/aboutProject/aboutproject_moc.h
@@ -22,6 +22,9 @@ class AboutProjectView : public QWidget
 	Q_OBJECT
 
 	void changeEvent(QEvent *event) override;
+
+	/// Hides a widget and expands second widgets to take place of first widget in layout
+	void hideAndStretchWidget(QGridLayout * layout, QWidget * toHide, QWidget * toStretch);
 public:
 	explicit AboutProjectView(QWidget * parent = nullptr);
 
@@ -47,6 +50,8 @@ private slots:
 	void on_pushButtonHomepage_clicked();
 
 	void on_pushButtonBugreport_clicked();
+
+	void on_openConfigDir_clicked();
 
 private:
 	Ui::AboutProjectView * ui;

--- a/launcher/aboutProject/aboutproject_moc.ui
+++ b/launcher/aboutProject/aboutproject_moc.ui
@@ -38,7 +38,7 @@
       </widget>
      </item>
      <item row="0" column="0">
-      <widget class="QLabel" name="labelDataDirs_2">
+      <widget class="QLabel" name="labelCommunity">
        <property name="minimumSize">
         <size>
          <width>200</width>
@@ -47,7 +47,6 @@
        </property>
        <property name="font">
         <font>
-         <weight>75</weight>
          <bold>true</bold>
         </font>
        </property>
@@ -80,27 +79,8 @@
    </item>
    <item>
     <layout class="QGridLayout" name="gridLayout" columnstretch="2,4,1">
-     <item row="0" column="0">
-      <widget class="QLabel" name="labelDataDirs_3">
-       <property name="minimumSize">
-        <size>
-         <width>0</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="font">
-        <font>
-         <weight>75</weight>
-         <bold>true</bold>
-        </font>
-       </property>
-       <property name="text">
-        <string>Build Information</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="1">
-      <widget class="QLineEdit" name="lineEditBuildVersion">
+     <item row="2" column="1">
+      <widget class="QLineEdit" name="lineEditOperatingSystem">
        <property name="text">
         <string notr="true"/>
        </property>
@@ -109,10 +89,10 @@
        </property>
       </widget>
      </item>
-     <item row="5" column="0">
-      <widget class="QLabel" name="labelUserDataDir">
+     <item row="4" column="2">
+      <widget class="QPushButton" name="openGameDataDir">
        <property name="text">
-        <string>User data directory</string>
+        <string>Open</string>
        </property>
       </widget>
      </item>
@@ -123,37 +103,15 @@
        </property>
       </widget>
      </item>
-     <item row="6" column="2">
-      <widget class="QPushButton" name="openTempDir">
-       <property name="text">
-        <string>Open</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="2">
-      <widget class="QPushButton" name="updatesButton">
-       <property name="text">
-        <string>Check for updates</string>
-       </property>
-      </widget>
-     </item>
-     <item row="5" column="1">
-      <widget class="QLineEdit" name="lineEditUserDataDir">
-       <property name="enabled">
-        <bool>true</bool>
+     <item row="3" column="0">
+      <widget class="QLabel" name="labelDataDirs">
+       <property name="font">
+        <font>
+         <bold>true</bold>
+        </font>
        </property>
        <property name="text">
-        <string notr="true">/home/user/.vcmi</string>
-       </property>
-       <property name="readOnly">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="0">
-      <widget class="QLabel" name="labelBuildVersionDesc">
-       <property name="text">
-        <string>Game version</string>
+        <string>Data Directories</string>
        </property>
       </widget>
      </item>
@@ -164,33 +122,10 @@
        </property>
       </widget>
      </item>
-     <item row="3" column="0">
-      <widget class="QLabel" name="labelDataDirs">
-       <property name="font">
-        <font>
-         <weight>75</weight>
-         <bold>true</bold>
-        </font>
-       </property>
+     <item row="1" column="2">
+      <widget class="QPushButton" name="updatesButton">
        <property name="text">
-        <string>Data Directories</string>
-       </property>
-      </widget>
-     </item>
-     <item row="4" column="1">
-      <widget class="QLineEdit" name="lineEditGameDir">
-       <property name="enabled">
-        <bool>true</bool>
-       </property>
-       <property name="text">
-        <string notr="true">/usr/share/vcmi</string>
-       </property>
-      </widget>
-     </item>
-     <item row="4" column="2">
-      <widget class="QPushButton" name="openGameDataDir">
-       <property name="text">
-        <string>Open</string>
+        <string>Check for updates</string>
        </property>
       </widget>
      </item>
@@ -204,6 +139,33 @@
        </property>
        <property name="readOnly">
         <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="1">
+      <widget class="QLineEdit" name="lineEditGameDir">
+       <property name="enabled">
+        <bool>true</bool>
+       </property>
+       <property name="text">
+        <string notr="true">/usr/share/vcmi</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QLineEdit" name="lineEditBuildVersion">
+       <property name="text">
+        <string notr="true"/>
+       </property>
+       <property name="readOnly">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="2">
+      <widget class="QPushButton" name="openTempDir">
+       <property name="text">
+        <string>Open</string>
        </property>
       </widget>
      </item>
@@ -221,13 +183,75 @@
        </property>
       </widget>
      </item>
-     <item row="2" column="1">
-      <widget class="QLineEdit" name="lineEditOperatingSystem">
+     <item row="5" column="0">
+      <widget class="QLabel" name="labelUserDataDir">
        <property name="text">
-        <string notr="true"/>
+        <string>User data directory</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="labelBuildVersionDesc">
+       <property name="text">
+        <string>Game version</string>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="1">
+      <widget class="QLineEdit" name="lineEditUserDataDir">
+       <property name="enabled">
+        <bool>true</bool>
+       </property>
+       <property name="text">
+        <string notr="true">/home/user/.vcmi</string>
        </property>
        <property name="readOnly">
         <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="0">
+      <widget class="QLabel" name="labelBuildInformation">
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="font">
+        <font>
+         <bold>true</bold>
+        </font>
+       </property>
+       <property name="text">
+        <string>Build Information</string>
+       </property>
+      </widget>
+     </item>
+     <item row="7" column="0">
+      <widget class="QLabel" name="labelConfigDir">
+       <property name="text">
+        <string>Configuration files directory</string>
+       </property>
+      </widget>
+     </item>
+     <item row="7" column="1">
+      <widget class="QLineEdit" name="lineEditConfigDir">
+       <property name="enabled">
+        <bool>true</bool>
+       </property>
+       <property name="text">
+        <string notr="true">/home/user/.vcmi</string>
+       </property>
+       <property name="readOnly">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="7" column="2">
+      <widget class="QPushButton" name="openConfigDir">
+       <property name="text">
+        <string>Open</string>
        </property>
       </widget>
      </item>


### PR DESCRIPTION
Will merge after Android launcher PR

- Added "Configuration files directory" entry since it is located in different path at least on Linux and may be of interest to a player
- Removed non-functioning "Open directory" buttons on mobile systems and stretched text box into now-empty space

Screenshot (desktop):
![help-desktop](https://github.com/vcmi/vcmi/assets/1576820/5b4d2627-341d-4fc4-beab-d1450a6d0ddd)

Screenshot (mobile emulation):
![help-mobile](https://github.com/vcmi/vcmi/assets/1576820/b388b2eb-2f82-489e-9bec-9e376fc566ad)
