### PR TITLE
Fix lag on dragging mod list in Launcher on Android

### DIFF
--- a/launcher/modManager/cmodlist.h
+++ b/launcher/modManager/cmodlist.h
@@ -82,8 +82,11 @@ class CModList
 	QVariantMap localModList;
 	QVariantMap modSettings;
 
+	mutable QMap<QString, CModEntry> cachedMods;
+
 	QVariantMap copyField(QVariantMap data, QString from, QString to) const;
 
+	CModEntry getModUncached(QString modname) const;
 public:
 	virtual void resetRepositories();
 	virtual void reloadRepositories();
@@ -93,7 +96,7 @@ public:
 	virtual void modChanged(QString modID);
 
 	// returns mod by name. Note: mod MUST exist
-	CModEntry getMod(QString modname) const;
+	const CModEntry & getMod(QString modname) const;
 
 	// returns list of all mods necessary to run selected one, including mod itself
 	// order is: first mods in list don't have any dependencies, last mod is modname


### PR DESCRIPTION
Tested by enabling dragging on desktop. According to profiler, most of time was spent on generating mod information. Cheap to do once, but it looks like Qt does this A LOT.

Added simple caching & reduced copying. Seems to be working fine on PC, but not yet confirmed whether same goes for mobile.
Cache resets may be to excessive, but better to play it safe. Seems to be fast enough anyway. Method that previously took ~90% of time before is now completely gone from profiler view.