### PR TITLE
[1.5.3] Reduce memory usage of adventure map

### DIFF
--- a/client/mapView/MapViewModel.cpp
+++ b/client/mapView/MapViewModel.cpp
@@ -102,7 +102,7 @@ int3 MapViewModel::getTileAtPoint(const Point & position) const
 
 Point MapViewModel::getCacheDimensionsPixels() const
 {
-	return getTilesVisibleDimensions() * getSingleTileSizeUpperLimit();
+	return getPixelsVisibleDimensions() + getSingleTileSizeUpperLimit() * 2;
 }
 
 Rect MapViewModel::getCacheTileArea(const int3 & coordinates) const


### PR DESCRIPTION
Discovered while working on #4097

For map rendering VCMI allocates helper Canvas that is used as intermediate - to avoid full redraws if player moves map by a few pixels.

However right now size of this Canvas is too excessive. For FullHD VCMI would allocate ~13000x8000px-sized surface (and even larger for 4K). Size of such Canvas is measured in hundreds of MB's.

Now size of this surface is size of adventure map view + 2*256-wide px borders from each side (where 256 is size of a single tile on maximum zoom). This should reduce memory footprint of this Canvas to less than 50 Mb even in 4K (and even less for smaller screens)