### PR TITLE
Mod install fixes

### DIFF
--- a/launcher/modManager/cmodlistview_moc.cpp
+++ b/launcher/modManager/cmodlistview_moc.cpp
@@ -603,7 +603,7 @@ void CModListView::on_installButton_clicked()
 	for(auto & name : modModel->getRequirements(modName))
 	{
 		auto mod = modModel->getMod(name);
-		if(!mod.isInstalled())
+		if(mod.isAvailable())
 			downloadFile(name + ".zip", mod.getValue("download").toString(), name, mbToBytes(mod.getValue("downloadSize").toDouble()));
 		else if(!mod.isEnabled())
 			enableModByName(name);

--- a/launcher/modManager/cmodlistview_moc.cpp
+++ b/launcher/modManager/cmodlistview_moc.cpp
@@ -876,6 +876,13 @@ void CModListView::installMods(QStringList archives)
 		auto mod = modModel->getMod(modName);
 		if(mod.isInstalled() && !mod.getValue("keepDisabled").toBool())
 		{
+			for (auto const & dependencyName : mod.getDependencies())
+			{
+				auto dependency = modModel->getMod(dependencyName);
+				if(dependency.isDisabled())
+					manager->enableMod(dependencyName);
+			}
+
 			if(mod.isDisabled() && manager->enableMod(modName))
 			{
 				for(QString child : modModel->getChildren(modName))


### PR DESCRIPTION
Fixes issues with mod install related to new pvp balance mod:
- Do not attempt to install mods not available in repo, such as submods
- Enable dependencies first before enabling newly downloaded mod
- - Also handles the case when mod dependency is scheduled to be enabled only after dependent mod