### PR TITLE
Fix .ui files not visible in generated project (QtCreator/CMake/Ninja)

### DIFF
--- a/launcher/CMakeLists.txt
+++ b/launcher/CMakeLists.txt
@@ -170,6 +170,7 @@ target_sources(vcmilauncher PRIVATE
 	${launcher_SRCS}
 	${launcher_HEADERS}
 	${launcher_RESOURCES}
+	${launcher_FORMS}
 )
 
 if(WIN32)


### PR DESCRIPTION
Seems to be caused by #3817
Qt .ui files are no longer visible in generated project. Project builds successfully, and you can still open .ui files manually, but it is less convenient than before.

Probably caused by enabling AUTO_UIC
Not sure if there is proper/better fix, but this change seems to be working on my system