### PR TITLE
Launcher mod list tweaks

### DIFF
--- a/launcher/firstLaunch/firstlaunch_moc.cpp
+++ b/launcher/firstLaunch/firstlaunch_moc.cpp
@@ -159,7 +159,10 @@ void FirstLaunchView::activateTabHeroesData()
 	ui->labelDataHelp->hide();
 #endif
 	if(heroesDataUpdate())
+	{
+		activateTabModPreset();
 		return;
+	}
 
 	QString installPath = getHeroesInstallDir();
 	if(!installPath.isEmpty())

--- a/launcher/helper.cpp
+++ b/launcher/helper.cpp
@@ -15,6 +15,19 @@
 #include <QObject>
 #include <QScroller>
 
+#ifdef VCMI_MOBILE
+static QScrollerProperties generateScrollerProperties()
+{
+	QScrollerProperties result;
+
+	result.setScrollMetric(QScrollerProperties::OvershootDragResistanceFactor, 0.25);
+	result.setScrollMetric(QScrollerProperties::OvershootDragDistanceFactor, 0.25);
+	result.setScrollMetric(QScrollerProperties::HorizontalOvershootPolicy, QScrollerProperties::OvershootAlwaysOff);
+
+	return result;
+}
+#endif
+
 namespace Helper
 {
 void loadSettings()
@@ -26,6 +39,8 @@ void enableScrollBySwiping(QObject * scrollTarget)
 {
 #ifdef VCMI_MOBILE
 	QScroller::grabGesture(scrollTarget, QScroller::LeftMouseButtonGesture);
+	QScroller * scroller = QScroller::scroller(scrollTarget);
+	scroller->setScrollerProperties(generateScrollerProperties());
 #endif
 }
 }

--- a/launcher/modManager/cmodlistmodel_moc.cpp
+++ b/launcher/modManager/cmodlistmodel_moc.cpp
@@ -82,9 +82,6 @@ QVariant CModListModel::getValue(const CModEntry & mod, int field) const
 		case ModFields::NAME:
 			return mod.getValue("name");
 
-		case ModFields::VERSION:
-			return mod.getValue("version");
-
 		case ModFields::TYPE:
 			return modTypeName(mod.getValue("modType").toString());
 
@@ -173,7 +170,6 @@ QVariant CModListModel::headerData(int section, Qt::Orientation orientation, int
 		QT_TRANSLATE_NOOP("ModFields", ""), // status icon
 		QT_TRANSLATE_NOOP("ModFields", ""), // status icon
 		QT_TRANSLATE_NOOP("ModFields", "Type"),
-		QT_TRANSLATE_NOOP("ModFields", "Version"),
 	};
 
 	if(role == Qt::DisplayRole && orientation == Qt::Horizontal)

--- a/launcher/modManager/cmodlistmodel_moc.h
+++ b/launcher/modManager/cmodlistmodel_moc.h
@@ -22,7 +22,6 @@ enum EModFields
 	STATUS_ENABLED,
 	STATUS_UPDATE,
 	TYPE,
-	VERSION,
 	COUNT
 };
 }

--- a/launcher/modManager/cmodlistview_moc.cpp
+++ b/launcher/modManager/cmodlistview_moc.cpp
@@ -102,9 +102,8 @@ void CModListView::setupModsView()
 	}
 	else //default //TODO: default high-DPI scaling
 	{
-		ui->allModsView->setColumnWidth(ModFields::NAME, 185);
+		ui->allModsView->setColumnWidth(ModFields::NAME, 220);
 		ui->allModsView->setColumnWidth(ModFields::TYPE, 75);
-		ui->allModsView->setColumnWidth(ModFields::VERSION, 60);
 	}
 
 	ui->allModsView->resizeColumnToContents(ModFields::STATUS_ENABLED);

--- a/launcher/modManager/cmodlistview_moc.ui
+++ b/launcher/modManager/cmodlistview_moc.ui
@@ -15,7 +15,7 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_3">
+    <layout class="QHBoxLayout" name="horizontalLayout_3" stretch="1,0,0">
      <item>
       <widget class="QLineEdit" name="lineEdit">
        <property name="sizePolicy">

--- a/launcher/modManager/cmodlistview_moc.ui
+++ b/launcher/modManager/cmodlistview_moc.ui
@@ -102,7 +102,7 @@
         </sizepolicy>
        </property>
        <property name="text">
-        <string>Download &amp;&amp; refresh repositories</string>
+        <string>Reload repositories</string>
        </property>
       </widget>
      </item>


### PR DESCRIPTION
Probably last change to launcher from me for now:
- Removed 'version' field from mod list - not really useful and uses valuable space on mobiles. Of course it is still available in mod description
- Reduced size of mod filter dropdown (all/installed/active) and of repository reload button to give more space to search field
- Launcher would skip "Heroes 3 data files setup" step in Launcher if data has been found
- Reduced 'overshot' strength when dragging controls with touch input