### PR TITLE
[launcher][iOS] reveal game directories in Files app

### DIFF
--- a/launcher/CMakeLists.txt
+++ b/launcher/CMakeLists.txt
@@ -26,6 +26,8 @@ set(launcher_SRCS
 if(APPLE_IOS)
 	list(APPEND launcher_SRCS
 		ios/launchGame.m
+		ios/revealdirectoryinfiles.h
+		ios/revealdirectoryinfiles.mm
 		ios/selectdirectory.h
 		ios/selectdirectory.mm
 	)

--- a/launcher/aboutProject/aboutproject_moc.cpp
+++ b/launcher/aboutProject/aboutproject_moc.cpp
@@ -16,6 +16,24 @@
 #include "../../lib/GameConstants.h"
 #include "../../lib/VCMIDirs.h"
 
+#ifdef VCMI_IOS
+#include "ios/revealdirectoryinfiles.h"
+#endif
+
+namespace
+{
+void revealDirectoryInFileBrowser(QLineEdit * dirLineEdit)
+{
+	const auto dirUrl = QUrl::fromLocalFile(QFileInfo{dirLineEdit->text()}.absoluteFilePath());
+#ifdef VCMI_IOS
+	iOS_utils::revealDirectoryInFiles(dirUrl);
+#else
+	QDesktopServices::openUrl(dirUrl);
+#endif
+}
+}
+
+
 void AboutProjectView::hideAndStretchWidget(QGridLayout * layout, QWidget * toHide, QWidget * toStretch)
 {
 	toHide->hide();
@@ -47,9 +65,11 @@ AboutProjectView::AboutProjectView(QWidget * parent)
 	// On mobile platforms these directories are generally not accessible from phone itself, only via USB connection from PC
 	// Remove "Open" buttons and stretch line with text into now-empty space
 	hideAndStretchWidget(ui->gridLayout, ui->openGameDataDir, ui->lineEditGameDir);
+#ifdef VCMI_ANDROID
 	hideAndStretchWidget(ui->gridLayout, ui->openUserDataDir, ui->lineEditUserDataDir);
 	hideAndStretchWidget(ui->gridLayout, ui->openTempDir, ui->lineEditTempDir);
 	hideAndStretchWidget(ui->gridLayout, ui->openConfigDir, ui->lineEditConfigDir);
+#endif
 #endif
 }
 
@@ -68,22 +88,22 @@ void AboutProjectView::on_updatesButton_clicked()
 
 void AboutProjectView::on_openGameDataDir_clicked()
 {
-	QDesktopServices::openUrl(QUrl::fromLocalFile(QFileInfo(ui->lineEditGameDir->text()).absoluteFilePath()));
+	revealDirectoryInFileBrowser(ui->lineEditGameDir);
 }
 
 void AboutProjectView::on_openUserDataDir_clicked()
 {
-	QDesktopServices::openUrl(QUrl::fromLocalFile(QFileInfo(ui->lineEditUserDataDir->text()).absoluteFilePath()));
+	revealDirectoryInFileBrowser(ui->lineEditUserDataDir);
 }
 
 void AboutProjectView::on_openTempDir_clicked()
 {
-	QDesktopServices::openUrl(QUrl::fromLocalFile(QFileInfo(ui->lineEditTempDir->text()).absoluteFilePath()));
+	revealDirectoryInFileBrowser(ui->lineEditTempDir);
 }
 
 void AboutProjectView::on_openConfigDir_clicked()
 {
-	QDesktopServices::openUrl(QUrl::fromLocalFile(QFileInfo(ui->lineEditConfigDir->text()).absoluteFilePath()));
+	revealDirectoryInFileBrowser(ui->lineEditConfigDir);
 }
 
 void AboutProjectView::on_pushButtonDiscord_clicked()
@@ -105,7 +125,6 @@ void AboutProjectView::on_pushButtonHomepage_clicked()
 {
 	QDesktopServices::openUrl(QUrl("https://vcmi.eu/"));
 }
-
 
 void AboutProjectView::on_pushButtonBugreport_clicked()
 {

--- a/launcher/aboutProject/aboutproject_moc.h
+++ b/launcher/aboutProject/aboutproject_moc.h
@@ -25,14 +25,11 @@ class AboutProjectView : public QWidget
 
 	/// Hides a widget and expands second widgets to take place of first widget in layout
 	void hideAndStretchWidget(QGridLayout * layout, QWidget * toHide, QWidget * toStretch);
+
 public:
 	explicit AboutProjectView(QWidget * parent = nullptr);
 
-public slots:
-
 private slots:
-
-
 	void on_updatesButton_clicked();
 
 	void on_openGameDataDir_clicked();
@@ -55,5 +52,4 @@ private slots:
 
 private:
 	Ui::AboutProjectView * ui;
-
 };

--- a/launcher/ios/revealdirectoryinfiles.h
+++ b/launcher/ios/revealdirectoryinfiles.h
@@ -1,0 +1,17 @@
+/*
+ * revealdirectoryinfiles.h, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
+#pragma once
+
+#include <QUrl>
+
+namespace iOS_utils
+{
+void revealDirectoryInFiles(QUrl dirUrl);
+}

--- a/launcher/ios/revealdirectoryinfiles.mm
+++ b/launcher/ios/revealdirectoryinfiles.mm
@@ -1,0 +1,22 @@
+/*
+ * revealdirectoryinfiles.mm, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
+#include "revealdirectoryinfiles.h"
+
+#import <UIKit/UIKit.h>
+
+namespace iOS_utils
+{
+void revealDirectoryInFiles(QUrl dirUrl)
+{
+	auto urlComponents = [NSURLComponents componentsWithURL:dirUrl.toNSURL() resolvingAgainstBaseURL:NO];
+	urlComponents.scheme = @"shareddocuments";
+	[UIApplication.sharedApplication openURL:urlComponents.URL options:@{} completionHandler:nil];
+}
+}


### PR DESCRIPTION
now all but the "game data" dirs can be opened in the standard file browser - Files app