### PR TITLE
[1.5.3] Fix rmg generation if player list is not continuous

### DIFF
--- a/lib/rmg/CMapGenOptions.cpp
+++ b/lib/rmg/CMapGenOptions.cpp
@@ -284,9 +284,12 @@ void CMapGenOptions::resetPlayersMap()
 
 	while (players.size() > realPlayersCnt)
 	{
-		while (eraseLastPlayer(EPlayerType::AI));
-		while (eraseLastPlayer(EPlayerType::COMP_ONLY));
-		while (eraseLastPlayer(EPlayerType::HUMAN));
+		if (eraseLastPlayer(EPlayerType::AI))
+			continue;
+		if (eraseLastPlayer(EPlayerType::COMP_ONLY))
+			continue;
+		if (eraseLastPlayer(EPlayerType::HUMAN))
+			continue;
 	}
 
 	//First colors from the list are assigned to human players, then to CPU players
@@ -503,8 +506,9 @@ void CMapGenOptions::finalize(CRandomGenerator & rand)
 	if (getHumanOrCpuPlayerCount() == RANDOM_SIZE)
 	{
 		auto possiblePlayers = mapTemplate->getPlayers().getNumbers();
+		int requiredPlayers = countHumanPlayers() + countCompOnlyPlayers();
 		//ignore all non-randomized players, make sure these players will not be missing after roll
-		possiblePlayers.erase(possiblePlayers.begin(), possiblePlayers.lower_bound(countHumanPlayers() + countCompOnlyPlayers()));
+		possiblePlayers.erase(possiblePlayers.begin(), possiblePlayers.lower_bound(requiredPlayers));
 
 		vstd::erase_if(possiblePlayers, [maxPlayers](int i)
 		{
@@ -598,7 +602,9 @@ void CMapGenOptions::updatePlayers()
 	{
 		auto it = itrev;
 		--it;
-		if (players.size() == getHumanOrCpuPlayerCount()) break;
+		if (players.size() == getHumanOrCpuPlayerCount())
+			break;
+
 		if(it->second.getPlayerType() != EPlayerType::HUMAN)
 		{
 			players.erase(it);

--- a/lib/rmg/CZonePlacer.cpp
+++ b/lib/rmg/CZonePlacer.cpp
@@ -454,9 +454,9 @@ void CZonePlacer::prepareZones(TZoneMap &zones, TZoneVector &zonesVector, const 
 				auto player = PlayerColor(*owner - 1);
 				auto playerSettings = map.getMapGenOptions().getPlayersSettings();
 				FactionID faction = FactionID::RANDOM;
-				if (vstd::contains(playerSettings, player))
+				if (playerSettings.size() > player)
 				{
-					faction = playerSettings[player].getStartingTown();
+					faction = std::next(playerSettings.begin(), player)->second.getStartingTown();
 				}
 				else
 				{

--- a/server/CVCMIServer.cpp
+++ b/server/CVCMIServer.cpp
@@ -662,6 +662,10 @@ void CVCMIServer::updateAndPropagateLobbyState()
 			{
 				si->mapGenOptions->setPlayerTypeForStandardPlayer(pset.color, EPlayerType::HUMAN);
 			}
+			else
+			{
+				si->mapGenOptions->setPlayerTypeForStandardPlayer(pset.color, EPlayerType::AI);
+			}
 		}
 	}
 


### PR DESCRIPTION
Since most common crashes are now fixed, this crash became one of the most common crashes on Google Play stats.

Main source of the crash is that when player selects 'random' number of players and then selects pink color to play as, game can roll 2 for random number of players and generate map with red & blue players, without pink human player.

With this change, game will always keep colors that were allocated to human players when 'random' number of players is chosen, so:
a) if player selects random template, random number of players and pink human player, and game rolls for 4 players, then map would have red, blue, brown, and pink player.
b) if player selects template with 3+ players (e.g. Jebus), picks green human player, and game rolls for 2 players, then map would have red & green players on map.

Also, fixes bug where changing player color would mark new color as 'human-controlled' (correct), but would not erase such mark from old color.

- Fixes #1233 