### PR TITLE
[1.5.3] Crashfixes

### DIFF
--- a/client/Client.cpp
+++ b/client/Client.cpp
@@ -735,6 +735,8 @@ void CClient::removeGUI() const
 #ifdef VCMI_ANDROID
 extern "C" JNIEXPORT jboolean JNICALL Java_eu_vcmi_vcmi_NativeMethods_tryToSaveTheGame(JNIEnv * env, jclass cls)
 {
+	boost::mutex::scoped_lock interfaceLock(GH.interfaceMutex);
+
 	logGlobal->info("Received emergency save game request");
 	if(!LOCPLINT || !LOCPLINT->cb)
 	{

--- a/client/Client.cpp
+++ b/client/Client.cpp
@@ -738,6 +738,13 @@ extern "C" JNIEXPORT jboolean JNICALL Java_eu_vcmi_vcmi_NativeMethods_tryToSaveT
 	logGlobal->info("Received emergency save game request");
 	if(!LOCPLINT || !LOCPLINT->cb)
 	{
+		logGlobal->info("... but no active player interface found!");
+		return false;
+	}
+
+	if (!CSH || !CSH->logicConnection)
+	{
+		logGlobal->info("... but no active connection found!");
 		return false;
 	}
 

--- a/client/renderSDL/SDLImage.cpp
+++ b/client/renderSDL/SDLImage.cpp
@@ -235,7 +235,10 @@ void SDLImage::setFlagColor(PlayerColor player)
 
 bool SDLImage::isTransparent(const Point & coords) const
 {
-	return CSDL_Ext::isTransparent(surf, coords.x, coords.y);
+	if (surf)
+		return CSDL_Ext::isTransparent(surf, coords.x, coords.y);
+	else
+		return true;
 }
 
 Point SDLImage::dimensions() const

--- a/client/widgets/MiscWidgets.cpp
+++ b/client/widgets/MiscWidgets.cpp
@@ -637,6 +637,9 @@ CCreaturePic::CCreaturePic(int x, int y, const CCreature * cre, bool Big, bool A
 
 	assert(CGI->townh->size() > faction);
 
+	if (cre->animDefName.empty())
+		throw std::runtime_error("Creature " + cre->getJsonKey() + " has no valid combat animation!");
+
 	if(Big)
 		bg = std::make_shared<CPicture>((*CGI->townh)[faction]->creatureBg130);
 	else

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -491,14 +491,21 @@ CTavernWindow::CTavernWindow(const CGObjectInstance * TavernObj, const std::func
 	}
 	else if(LOCPLINT->cb->howManyHeroes(true) >= CGI->settings()->getInteger(EGameSettings::HEROES_PER_PLAYER_TOTAL_CAP))
 	{
+		MetaString message;
+		message.appendTextID("core.tvrninfo.1");
+		message.replaceNumber(LOCPLINT->cb->howManyHeroes(true));
+
 		//Cannot recruit. You already have %d Heroes.
-		recruit->addHoverText(EButtonState::NORMAL, boost::str(boost::format(CGI->generaltexth->tavernInfo[1]) % LOCPLINT->cb->howManyHeroes(true)));
+		recruit->addHoverText(EButtonState::NORMAL, message.toString());
 		recruit->block(true);
 	}
 	else if(LOCPLINT->cb->howManyHeroes(false) >= CGI->settings()->getInteger(EGameSettings::HEROES_PER_PLAYER_ON_MAP_CAP))
 	{
-		//Cannot recruit. You already have %d Heroes.
-		recruit->addHoverText(EButtonState::NORMAL, boost::str(boost::format(CGI->generaltexth->tavernInfo[1]) % LOCPLINT->cb->howManyHeroes(false)));
+		MetaString message;
+		message.appendTextID("core.tvrninfo.1");
+		message.replaceNumber(LOCPLINT->cb->howManyHeroes(false));
+
+		recruit->addHoverText(EButtonState::NORMAL, message.toString());
 		recruit->block(true);
 	}
 	else if(dynamic_cast<const CGTownInstance *>(TavernObj) && dynamic_cast<const CGTownInstance *>(TavernObj)->visitingHero)

--- a/config/highscoreCreatures.json
+++ b/config/highscoreCreatures.json
@@ -1,6 +1,6 @@
 {
     "creatures": [
-        { "min" : 1, "max" : 4, "creature": "imp" },
+        {            "max" : 4, "creature": "imp" },
         { "min" : 5, "max" : 8, "creature": "gremlin" },
         { "min" : 9, "max" : 12, "creature": "gnoll" },
         { "min" : 13, "max" : 16, "creature": "troglodyte" },
@@ -117,6 +117,6 @@
         { "min" : 389, "max" : 391, "creature": "titan" },
         { "min" : 392, "max" : 394, "creature": "goldDragon" },
         { "min" : 395, "max" : 397, "creature": "blackDragon" },
-        { "min" : 398, "max" : 500, "creature": "archangel" }
+        { "min" : 398,              "creature": "archangel" }
     ]
 }


### PR DESCRIPTION
Fixes for few more crashes from Google Play:
- Attempt to fix crash on 'emergency save' when Android requests complete app shutdown to free resources
- Add better crash message for creatures with missing battle animation
- Fix crash on receiving high score value outside of 0...500 range.
- Avoid crash if town building selection highlight area image is missing
- Replace boost with MetaString in tavern window to avoid crash in some localizations (no '%d' placeholder in string)