### PR TITLE
fix CGObjectInstance `subTypeName` to include mod id

### DIFF
--- a/lib/mapObjectConstructors/AObjectTypeHandler.cpp
+++ b/lib/mapObjectConstructors/AObjectTypeHandler.cpp
@@ -129,7 +129,7 @@ void AObjectTypeHandler::preInitObject(CGObjectInstance * obj) const
 	obj->ID = Obj(type);
 	obj->subID = subtype;
 	obj->typeName = typeName;
-	obj->subTypeName = subTypeName;
+	obj->subTypeName = getJsonKey();
 	obj->blockVisit = blockVisit;
 	obj->removable = removable;
 }


### PR DESCRIPTION
Fix #4162 
Tested with map created in editor and 10 randoms G maps
creatures are saved as `new-pavilion:sphinx` and `axolotl-creatures-pack:sphinx`, prison is saved as 
```json
"options" :{
  "experience": 90000,
  "gender": -1,
  "type": "tides-of-war.heroes:eyzeaDemoniac"
}
"subtype" : "core:prison",
	