### PR TITLE
(partially) fix campaign highscore sum

### DIFF
--- a/client/CServerHandler.cpp
+++ b/client/CServerHandler.cpp
@@ -648,14 +648,14 @@ void CServerHandler::startGameplay(VCMI_LIB_WRAP_NAMESPACE(CGameState) * gameSta
 	if(CMM)
 		CMM->disable();
 
-	campaignScoreCalculator = nullptr;
-
 	switch(si->mode)
 	{
 	case EStartMode::NEW_GAME:
 		client->newGame(gameState);
 		break;
 	case EStartMode::CAMPAIGN:
+		if(si->campState->conqueredScenarios().empty())
+			campaignScoreCalculator.reset();
 		client->newGame(gameState);
 		break;
 	case EStartMode::LOAD_GAME:


### PR DESCRIPTION
partially fixes #4180

Edit: Only when playing all scenarios in one row. Not if you loading campaign from e.g. second scenario. Otherwise we need to extend save format to save scores from previous scenarios. Will not do this for now.