### PR TITLE
[1.5.4] Bugfixing

### DIFF
--- a/client/eventsSDL/InputSourceTouch.cpp
+++ b/client/eventsSDL/InputSourceTouch.cpp
@@ -58,6 +58,9 @@ InputSourceTouch::InputSourceTouch()
 
 void InputSourceTouch::handleEventFingerMotion(const SDL_TouchFingerEvent & tfinger)
 {
+	if (CCS && CCS->curh && settings["video"]["cursor"].String() == "software" && state != TouchState::RELATIVE_MODE)
+		CCS->curh->cursorMove(GH.getCursorPosition().x, GH.getCursorPosition().y);
+
 	switch(state)
 	{
 		case TouchState::RELATIVE_MODE:

--- a/client/lobby/CBonusSelection.cpp
+++ b/client/lobby/CBonusSelection.cpp
@@ -215,7 +215,7 @@ void CBonusSelection::createBonusesIcons()
 			break;
 		case CampaignBonusType::SPELL_SCROLL:
 			desc.appendLocalString(EMetaText::GENERAL_TXT, 716);
-			desc.replaceName(ArtifactID(bonDescs[i].info2));
+			desc.replaceName(SpellID(bonDescs[i].info2));
 			break;
 		case CampaignBonusType::PRIMARY_SKILL:
 		{

--- a/client/windows/CCastleInterface.cpp
+++ b/client/windows/CCastleInterface.cpp
@@ -1540,8 +1540,11 @@ CHallInterface::CHallInterface(const CGTownInstance * Town):
 			const CBuilding * building = nullptr;
 			for(auto & buildingID : boxList[row][col])//we are looking for the first not built structure
 			{
-				if (town->town->buildings.count(buildingID) == 0)
-					throw std::runtime_error("Town " + Town->town->faction->getJsonKey() + " has no building with ID " + std::to_string(buildingID.getNum()));
+				if (!buildingID.hasValue())
+				{
+					logMod->warn("Invalid building ID found in hallSlots of town '%s'", town->town->faction->getJsonKey() );
+					continue;
+				}
 
 				const CBuilding * current = town->town->buildings.at(buildingID);
 				if(vstd::contains(town->builtBuildings, buildingID))

--- a/launcher/modManager/cmodmanager.cpp
+++ b/launcher/modManager/cmodmanager.cpp
@@ -26,9 +26,15 @@ namespace
 {
 QString detectModArchive(QString path, QString modName, std::vector<std::string> & filesToExtract)
 {
-	ZipArchive archive(qstringToPath(path));
-
-	filesToExtract = archive.listFiles();
+	try {
+		ZipArchive archive(qstringToPath(path));
+		filesToExtract = archive.listFiles();
+	}
+	catch (const std::runtime_error & e)
+	{
+		logGlobal->error("Failed to open zip archive. Reason: %s", e.what());
+		return "";
+	}
 
 	QString modDirName;
 

--- a/launcher/settingsView/csettingsview_moc.cpp
+++ b/launcher/settingsView/csettingsview_moc.cpp
@@ -705,12 +705,12 @@ void CSettingsView::on_spinBoxNetworkPortLobby_valueChanged(int arg1)
 
 void CSettingsView::on_sliderControllerSticksAcceleration_valueChanged(int value)
 {
-	Settings node = settings.write["input"]["configAxisScale"];
+	Settings node = settings.write["input"]["controllerAxisScale"];
 	node->Integer() = value / 100.0;
 }
 
 void CSettingsView::on_sliderControllerSticksSensitivity_valueChanged(int value)
 {
-	Settings node = settings.write["input"]["configAxisSpeed"];
+	Settings node = settings.write["input"]["controllerAxisSpeed"];
 	node->Integer() = value;
 }

--- a/lib/filesystem/CZipLoader.cpp
+++ b/lib/filesystem/CZipLoader.cpp
@@ -191,7 +191,7 @@ ZipArchive::ZipArchive(const boost::filesystem::path & from)
 #endif
 
 	if (archive == nullptr)
-		throw std::runtime_error("Failed to open file '" + from.string() + "' - unable to list files!");
+		throw std::runtime_error("Failed to open file '" + from.string());
 }
 
 ZipArchive::~ZipArchive()

--- a/lib/rewardable/Interface.cpp
+++ b/lib/rewardable/Interface.cpp
@@ -106,12 +106,12 @@ void Rewardable::Interface::grantRewardBeforeLevelup(IGameCallback * cb, const R
 
 	for(const auto & entry : info.reward.secondary)
 	{
-		int current = hero->getSecSkillLevel(entry.first);
-		if( (current != 0 && current < entry.second) ||
-			(hero->canLearnSkill() ))
-		{
-			cb->changeSecSkill(hero, entry.first, entry.second);
-		}
+		auto currentLevel = static_cast<MasteryLevel::Type>(hero->getSecSkillLevel(entry.first));
+		if(currentLevel == MasteryLevel::EXPERT)
+			continue;
+
+		if(currentLevel != MasteryLevel::NONE || hero->canLearnSkill())
+			cb->changeSecSkill(hero, entry.first, entry.second, false);
 	}
 
 	for(int i=0; i< info.reward.primary.size(); i++)

--- a/lib/rewardable/Reward.cpp
+++ b/lib/rewardable/Reward.cpp
@@ -103,7 +103,13 @@ void Rewardable::Reward::loadComponents(std::vector<Component> & comps, const CG
 	}
 
 	for(const auto & entry : secondary)
-		comps.emplace_back(ComponentType::SEC_SKILL, entry.first, entry.second);
+	{
+		auto skillID = entry.first;
+		int levelsGained = entry.second;
+		int currentLevel = h->getSecSkillLevel(skillID);
+		int finalLevel = std::min(static_cast<int>(MasteryLevel::EXPERT), currentLevel + levelsGained);
+		comps.emplace_back(ComponentType::SEC_SKILL, entry.first, finalLevel);
+	}
 
 	for(const auto & entry : artifacts)
 		comps.emplace_back(ComponentType::ARTIFACT, entry);


### PR DESCRIPTION
- Add workaround to make cursor visible when using software cursor on systems with touchscreen input
- Fixed invalid config key used for controller axes sensitivity configuration
- Show message to player instead of crashing silently on zip extraction error. Seems to be happening for some reason from time to time.
- Warn in log instead of crash on invalid building ID from mod
- Use spell name for spell scroll campaign bonus
  - Fixes #4183 
- Fix leveling up secondary skills via Scholar (map object) visit
  - Fixes #4178
