### PR TITLE
Save all human player names in the configuration

### DIFF
--- a/client/mainmenu/CMainMenu.cpp
+++ b/client/mainmenu/CMainMenu.cpp
@@ -485,9 +485,9 @@ const std::vector<std::string> CMultiMode::getPlayersNames()
 		playerNameStr = CGI->generaltexth->translate("core.genrltxt.434");
 	playerNames.push_back(playerNameStr);
 
-	for (JsonNode playerName : settings["general"]["multiPlayerNames"].Vector())
+	for (const auto & playerName : settings["general"]["multiPlayerNames"].Vector())
 	{
-		std::string &nameStr = playerName.String();
+		const std::string &nameStr = playerName.String();
 		if (!nameStr.empty())
 		{
 			playerNames.push_back(nameStr);
@@ -549,10 +549,10 @@ void CMultiPlayers::enterSelectionScreen()
 	Settings playerName = settings.write["general"]["playerName"];
 	Settings multiPlayerNames = settings.write["general"]["multiPlayerNames"];
 	multiPlayerNames->Vector().clear();
-	if (playerNames.size() > 0)
+	if (!playerNames.empty())
 	{
 		playerName->String() = playerNames.front();
-		for (std::vector<std::string>::iterator playerNameIt = playerNames.begin()+1; playerNameIt != playerNames.end(); playerNameIt++)
+		for (auto playerNameIt = playerNames.begin()+1; playerNameIt != playerNames.end(); playerNameIt++)
 		{
 			multiPlayerNames->Vector().push_back(JsonNode(*playerNameIt));
 		}

--- a/client/mainmenu/CMainMenu.cpp
+++ b/client/mainmenu/CMainMenu.cpp
@@ -444,7 +444,7 @@ CMultiMode::CMultiMode(ESelectionScreen ScreenType)
 
 	statusBar = CGStatusBar::create(std::make_shared<CPicture>(background->getSurface(), Rect(7, 465, 440, 18), 7, 465));
 	playerName = std::make_shared<CTextInput>(Rect(19, 436, 334, 16), background->getSurface());
-	playerName->setText(getPlayerName());
+	playerName->setText(getPlayersNames()[0]);
 	playerName->setCallback(std::bind(&CMultiMode::onNameChange, this, _1));
 
 	buttonHotseat = std::make_shared<CButton>(Point(373, 78 + 57 * 0), AnimationPath::builtin("MUBHOT.DEF"), CGI->generaltexth->zelp[266], std::bind(&CMultiMode::hostTCP, this), EShortcut::MAIN_MENU_HOTSEAT);
@@ -466,22 +466,35 @@ void CMultiMode::hostTCP()
 {
 	auto savedScreenType = screenType;
 	close();
-	GH.windows().createAndPushWindow<CMultiPlayers>(getPlayerName(), savedScreenType, true, ELoadMode::MULTI);
+	GH.windows().createAndPushWindow<CMultiPlayers>(getPlayersNames(), savedScreenType, true, ELoadMode::MULTI);
 }
 
 void CMultiMode::joinTCP()
 {
 	auto savedScreenType = screenType;
 	close();
-	GH.windows().createAndPushWindow<CMultiPlayers>(getPlayerName(), savedScreenType, false, ELoadMode::MULTI);
+	GH.windows().createAndPushWindow<CMultiPlayers>(getPlayersNames(), savedScreenType, false, ELoadMode::MULTI);
 }
 
-std::string CMultiMode::getPlayerName()
+const std::vector<std::string> CMultiMode::getPlayersNames()
 {
-	std::string name = settings["general"]["playerName"].String();
-	if(name == "Player")
-		name = CGI->generaltexth->translate("core.genrltxt.434");
-	return name;
+	std::vector<std::string> playerNames;
+
+	std::string playerNameStr = settings["general"]["playerName"].String();
+	if (playerNameStr == "Player")
+		playerNameStr = CGI->generaltexth->translate("core.genrltxt.434");
+	playerNames.push_back(playerNameStr);
+
+	for (JsonNode playerName : settings["general"]["multiPlayerNames"].Vector())
+	{
+		std::string &nameStr = playerName.String();
+		if (!nameStr.empty())
+		{
+			playerNames.push_back(nameStr);
+		}
+	}
+
+	return playerNames;
 }
 
 void CMultiMode::onNameChange(std::string newText)
@@ -490,7 +503,7 @@ void CMultiMode::onNameChange(std::string newText)
 	name->String() = newText;
 }
 
-CMultiPlayers::CMultiPlayers(const std::string & firstPlayer, ESelectionScreen ScreenType, bool Host, ELoadMode LoadMode)
+CMultiPlayers::CMultiPlayers(const std::vector<std::string> & playerNames, ESelectionScreen ScreenType, bool Host, ELoadMode LoadMode)
 	: loadMode(LoadMode), screenType(ScreenType), host(Host)
 {
 	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
@@ -511,7 +524,10 @@ CMultiPlayers::CMultiPlayers(const std::string & firstPlayer, ESelectionScreen S
 	buttonCancel = std::make_shared<CButton>(Point(205, 338), AnimationPath::builtin("MUBCANC.DEF"), CGI->generaltexth->zelp[561], [=](){ close();}, EShortcut::GLOBAL_CANCEL);
 	statusBar = CGStatusBar::create(std::make_shared<CPicture>(background->getSurface(), Rect(7, 381, 348, 18), 7, 381));
 
-	inputNames[0]->setText(firstPlayer);
+	for(int i = 0; i < playerNames.size(); i++)
+	{
+		inputNames[i]->setText(playerNames[i]);
+	}
 #ifndef VCMI_MOBILE
 	inputNames[0]->giveFocus();
 #endif
@@ -523,17 +539,34 @@ void CMultiPlayers::onChange(std::string newText)
 
 void CMultiPlayers::enterSelectionScreen()
 {
-	std::vector<std::string> names;
-	for(auto name : inputNames)
+	std::vector<std::string> playerNames;
+	for(auto playerName : inputNames)
 	{
-		if(name->getText().length())
-			names.push_back(name->getText());
+		if (playerName->getText().length())
+			playerNames.push_back(playerName->getText());
 	}
 
-	Settings name = settings.write["general"]["playerName"];
-	name->String() = names[0];
+	Settings playerName = settings.write["general"]["playerName"];
+	Settings multiPlayerNames = settings.write["general"]["multiPlayerNames"];
+	multiPlayerNames->Vector().clear();
+	if (playerNames.size() > 0)
+	{
+		playerName->String() = playerNames.front();
+		for (std::vector<std::string>::iterator playerNameIt = playerNames.begin()+1; playerNameIt != playerNames.end(); playerNameIt++)
+		{
+			multiPlayerNames->Vector().push_back(JsonNode(*playerNameIt));
+		}
+	}
+	else
+	{
+		// Without the check the saving crashes directly.
+		// When empty reset the player's name. This would translate to it being
+		// the default for the next run. But enables deleting players, by just
+		// deleting the names, otherwise some UI element should have been added.
+		playerName->clear();
+	}
 
-	CMainMenu::openLobby(screenType, host, names, loadMode);
+	CMainMenu::openLobby(screenType, host, playerNames, loadMode);
 }
 
 CSimpleJoinScreen::CSimpleJoinScreen(bool host)

--- a/client/mainmenu/CMainMenu.h
+++ b/client/mainmenu/CMainMenu.h
@@ -96,7 +96,9 @@ public:
 	void openLobby();
 	void hostTCP();
 	void joinTCP();
-	std::string getPlayerName();
+
+	/// Get all configured player names. The first name would always be present and initialized to its default value.
+	const std::vector<std::string> getPlayersNames();
 
 	void onNameChange(std::string newText);
 };
@@ -118,7 +120,7 @@ class CMultiPlayers : public WindowBase
 	void enterSelectionScreen();
 
 public:
-	CMultiPlayers(const std::string & firstPlayer, ESelectionScreen ScreenType, bool Host, ELoadMode LoadMode);
+	CMultiPlayers(const std::vector<std::string> & playerNames, ESelectionScreen ScreenType, bool Host, ELoadMode LoadMode);
 };
 
 /// Manages the configuration of pregame GUI elements like campaign screen, main menu, loading screen,...

--- a/config/schemas/settings.json
+++ b/config/schemas/settings.json
@@ -19,6 +19,7 @@
 			"additionalProperties" : false,
 			"required" : [
 				"playerName",
+				"multiPlayerNames",
 				"music",
 				"sound",
 				"saveRandomMaps",
@@ -47,6 +48,10 @@
 				"playerName" : {
 					"type" : "string",
 					"default" : "Player"
+				},
+				"multiPlayerNames" : {
+					"type" : "array",
+					"default" : []
 				},
 				"music" : {
 					"type" : "number",


### PR DESCRIPTION
Add up to 8 human player names to the configuration schema and save/load them to avoid entering them each time.