### PR TITLE
[1.5.4] AI optimizations

### DIFF
--- a/AI/Nullkiller/AIGateway.cpp
+++ b/AI/Nullkiller/AIGateway.cpp
@@ -649,7 +649,7 @@ void AIGateway::showBlockingDialog(const std::string & text, const std::vector<C
 				auto ratio = static_cast<float>(danger) / hero->getTotalStrength();
 
 				answer = topObj->id == goalObjectID; // no if we do not aim to visit this object
-				logAi->trace("Query hook: %s(%s) by %s danger ratio %f", target.toString(), topObj->getObjectName(), hero.name, ratio);
+				logAi->trace("Query hook: %s(%s) by %s danger ratio %f", target.toString(), topObj->getObjectName(), hero.name(), ratio);
 
 				if(cb->getObj(goalObjectID, false))
 				{
@@ -1574,7 +1574,7 @@ void AIGateway::requestActionASAP(std::function<void()> whatToDo)
 
 void AIGateway::lostHero(HeroPtr h)
 {
-	logAi->debug("I lost my hero %s. It's best to forget and move on.", h.name);
+	logAi->debug("I lost my hero %s. It's best to forget and move on.", h.name());
 }
 
 void AIGateway::answerQuery(QueryID queryID, int selection)

--- a/AI/Nullkiller/AIUtility.cpp
+++ b/AI/Nullkiller/AIUtility.cpp
@@ -67,7 +67,6 @@ HeroPtr::HeroPtr(const CGHeroInstance * H)
 	}
 
 	h = H;
-	name = h->getNameTranslated();
 	hid = H->id;
 //	infosCount[ai->playerID][hid]++;
 }
@@ -87,6 +86,14 @@ HeroPtr::~HeroPtr()
 bool HeroPtr::operator<(const HeroPtr & rhs) const
 {
 	return hid < rhs.hid;
+}
+
+std::string HeroPtr::name() const
+{
+	if (h)
+		return h->getNameTextID();
+	else
+		return "<NO HERO>";
 }
 
 const CGHeroInstance * HeroPtr::get(bool doWeExpectNull) const

--- a/AI/Nullkiller/AIUtility.h
+++ b/AI/Nullkiller/AIUtility.h
@@ -87,8 +87,7 @@ struct DLL_EXPORT HeroPtr
 	ObjectInstanceID hid;
 
 public:
-	std::string name;
-
+	std::string name() const;
 
 	HeroPtr();
 	HeroPtr(const CGHeroInstance * H);
@@ -117,7 +116,6 @@ public:
 	{
 		handler & h;
 		handler & hid;
-		handler & name;
 	}
 };
 

--- a/AI/Nullkiller/Analyzers/HeroManager.cpp
+++ b/AI/Nullkiller/Analyzers/HeroManager.cpp
@@ -204,6 +204,7 @@ float HeroManager::getFightingStrengthCached(const CGHeroInstance * hero) const
 {
 	auto cached = knownFightingStrength.find(hero->id);
 
+	//FIXME: fallback to hero->getFightingStrength() is VERY slow on higher difficulties (no object graph? map reveal?)
 	return cached != knownFightingStrength.end() ? cached->second : hero->getFightingStrength();
 }
 

--- a/AI/Nullkiller/Analyzers/HeroManager.cpp
+++ b/AI/Nullkiller/Analyzers/HeroManager.cpp
@@ -176,7 +176,7 @@ int HeroManager::selectBestSkill(const HeroPtr & hero, const std::vector<Seconda
 
 		logAi->trace(
 			"Hero %s is proposed to learn %d with score %f",
-			hero.name,
+			hero.name(),
 			skills[i].toEnum(),
 			score);
 	}

--- a/AI/Nullkiller/Behaviors/CaptureObjectsBehavior.cpp
+++ b/AI/Nullkiller/Behaviors/CaptureObjectsBehavior.cpp
@@ -212,7 +212,7 @@ void CaptureObjectsBehavior::decomposeObjects(
 				vstd::concatenate(tasksLocal, getVisitGoals(paths, nullkiller, objToVisit, specificObjects));
 			}
 
-			std::lock_guard<std::mutex> lock(sync);
+			std::lock_guard<std::mutex> lock(sync); // FIXME: consider using tbb::parallel_reduce instead to avoid mutex overhead
 			vstd::concatenate(result, tasksLocal);
 		});
 }

--- a/AI/Nullkiller/Goals/CaptureObject.h
+++ b/AI/Nullkiller/Goals/CaptureObject.h
@@ -31,7 +31,7 @@ namespace Goals
 		{
 			objid = obj->id.getNum();
 			tile = obj->visitablePos();
-			name = obj->getObjectName();
+			name = obj->typeName;
 		}
 
 		bool operator==(const CaptureObject & other) const override;

--- a/AI/Nullkiller/Goals/ExecuteHeroChain.cpp
+++ b/AI/Nullkiller/Goals/ExecuteHeroChain.cpp
@@ -106,7 +106,7 @@ void ExecuteHeroChain::accept(AIGateway * ai)
 
 		if(!heroPtr.validAndSet())
 		{
-			logAi->error("Hero %s was lost. Exit hero chain.", heroPtr.name);
+			logAi->error("Hero %s was lost. Exit hero chain.", heroPtr.name());
 
 			return;
 		}
@@ -143,7 +143,7 @@ void ExecuteHeroChain::accept(AIGateway * ai)
 					
 					if(!heroPtr.validAndSet())
 					{
-						logAi->error("Hero %s was lost trying to execute special action. Exit hero chain.", heroPtr.name);
+						logAi->error("Hero %s was lost trying to execute special action. Exit hero chain.", heroPtr.name());
 
 						return;
 					}
@@ -204,7 +204,7 @@ void ExecuteHeroChain::accept(AIGateway * ai)
 					{
 						if(!heroPtr.validAndSet())
 						{
-							logAi->error("Hero %s was lost. Exit hero chain.", heroPtr.name);
+							logAi->error("Hero %s was lost. Exit hero chain.", heroPtr.name());
 
 							return;
 						}
@@ -250,7 +250,7 @@ void ExecuteHeroChain::accept(AIGateway * ai)
 		{
 			if(!heroPtr.validAndSet())
 			{
-				logAi->debug("Hero %s was killed while attempting to reach %s", heroPtr.name, node->coord.toString());
+				logAi->debug("Hero %s was killed while attempting to reach %s", heroPtr.name(), node->coord.toString());
 
 				return;
 			}

--- a/AI/Nullkiller/Goals/ExecuteHeroChain.cpp
+++ b/AI/Nullkiller/Goals/ExecuteHeroChain.cpp
@@ -26,7 +26,7 @@ ExecuteHeroChain::ExecuteHeroChain(const AIPath & path, const CGObjectInstance *
 	if(obj)
 	{
 		objid = obj->id.getNum();
-		targetName = obj->getObjectName() + tile.toString();
+		targetName = obj->typeName + tile.toString();
 	}
 	else
 	{

--- a/AI/Nullkiller/Helpers/ExplorationHelper.h
+++ b/AI/Nullkiller/Helpers/ExplorationHelper.h
@@ -46,7 +46,6 @@ public:
 private:
 	void scanTile(const int3 & tile);
 	bool hasReachableNeighbor(const int3 & pos) const;
-	void getVisibleNeighbours(const std::vector<int3> & tiles, std::vector<int3> & out) const;
 };
 
 }

--- a/AI/Nullkiller/Pathfinding/AINodeStorage.cpp
+++ b/AI/Nullkiller/Pathfinding/AINodeStorage.cpp
@@ -320,11 +320,9 @@ void AINodeStorage::calculateNeighbours(
 	const PathfinderConfig * pathfinderConfig,
 	const CPathfinderHelper * pathfinderHelper)
 {
-	std::vector<int3> accessibleNeighbourTiles;
+	NeighbourTilesVector accessibleNeighbourTiles;
 
 	result.clear();
-	accessibleNeighbourTiles.reserve(8);
-
 	pathfinderHelper->calculateNeighbourTiles(accessibleNeighbourTiles, source);
 
 	const AIPathNode * srcNode = getAINode(source.node);

--- a/AI/Nullkiller/Pathfinding/AINodeStorage.h
+++ b/AI/Nullkiller/Pathfinding/AINodeStorage.h
@@ -23,6 +23,8 @@ constexpr int NKAI_GRAPH_TRACE_LEVEL = 0;
 #include "Actions/SpecialAction.h"
 #include "Actors.h"
 
+#include <boost/container/small_vector.hpp>
+
 namespace NKAI
 {
 namespace AIPathfinding
@@ -85,7 +87,9 @@ struct AIPathNodeInfo
 
 struct AIPath
 {
-	std::vector<AIPathNodeInfo> nodes;
+	using NodesVector = boost::container::small_vector<AIPathNodeInfo, 16>;
+
+	NodesVector nodes;
 	uint64_t targetObjectDanger;
 	uint64_t armyLoss;
 	uint64_t targetObjectArmyLoss;

--- a/AI/Nullkiller/Pathfinding/Actions/BoatActions.cpp
+++ b/AI/Nullkiller/Pathfinding/Actions/BoatActions.cpp
@@ -141,7 +141,8 @@ namespace AIPathfinding
 	{
 		SpellID summonBoat = SpellID::SUMMON_BOAT;
 
-		return hero->getSpellCost(summonBoat.toSpell());
+		// FIXME: this should be hero->getSpellCost, however currently queries to bonus system are too slow
+		return summonBoat.toSpell()->getCost(0);
 	}
 }
 

--- a/AI/Nullkiller/Pathfinding/GraphPaths.cpp
+++ b/AI/Nullkiller/Pathfinding/GraphPaths.cpp
@@ -118,7 +118,7 @@ void GraphPaths::calculatePaths(const CGHeroInstance * targetHero, const Nullkil
 
 					targetNode.specialAction = compositeAction;
 
-					auto targetGraphNode = graph.getNode(target);
+					const auto & targetGraphNode = graph.getNode(target);
 
 					if(targetGraphNode.objID.hasValue())
 					{

--- a/AI/VCAI/Pathfinding/AINodeStorage.cpp
+++ b/AI/VCAI/Pathfinding/AINodeStorage.cpp
@@ -162,10 +162,9 @@ void AINodeStorage::calculateNeighbours(
 	const PathfinderConfig * pathfinderConfig,
 	const CPathfinderHelper * pathfinderHelper)
 {
-	std::vector<int3> accessibleNeighbourTiles;
+	NeighbourTilesVector accessibleNeighbourTiles;
 
 	result.clear();
-	accessibleNeighbourTiles.reserve(8);
 
 	pathfinderHelper->calculateNeighbourTiles(accessibleNeighbourTiles, source);
 

--- a/lib/logging/CLogger.cpp
+++ b/lib/logging/CLogger.cpp
@@ -157,7 +157,6 @@ void CLogger::log(ELogLevel::ELogLevel level, const boost::format & fmt) const
 
 ELogLevel::ELogLevel CLogger::getLevel() const
 {
-	TLockGuard _(mx);
 	return level;
 }
 

--- a/lib/networkPacks/NetPacksLib.cpp
+++ b/lib/networkPacks/NetPacksLib.cpp
@@ -1231,7 +1231,7 @@ void RemoveObject::applyGs(CGameState *gs)
 
 	gs->map->instanceNames.erase(obj->instanceName);
 	gs->map->objects[objectID.getNum()].dellNull();
-	gs->map->calculateGuardingGreaturePositions();
+	gs->map->calculateGuardingGreaturePositions();//FIXME: excessive, update only affected tiles
 }
 
 static int getDir(const int3 & src, const int3 & dst)

--- a/lib/pathfinder/CPathfinder.cpp
+++ b/lib/pathfinder/CPathfinder.cpp
@@ -49,7 +49,7 @@ bool CPathfinderHelper::canMoveFromNode(const PathNodeInfo & source) const
 	return true;
 }
 
-void CPathfinderHelper::calculateNeighbourTiles(std::vector<int3> & result, const PathNodeInfo & source) const
+void CPathfinderHelper::calculateNeighbourTiles(NeighbourTilesVector & result, const PathNodeInfo & source) const
 {
 	result.clear();
 
@@ -239,9 +239,9 @@ void CPathfinder::calculatePaths()
 	logAi->trace("CPathfinder finished with %s iterations", std::to_string(counter));
 }
 
-std::vector<int3> CPathfinderHelper::getAllowedTeleportChannelExits(const TeleportChannelID & channelID) const
+TeleporterTilesVector CPathfinderHelper::getAllowedTeleportChannelExits(const TeleportChannelID & channelID) const
 {
-	std::vector<int3> allowedExits;
+	TeleporterTilesVector allowedExits;
 
 	for(const auto & objId : getTeleportChannelExits(channelID, hero->tempOwner))
 	{
@@ -262,9 +262,9 @@ std::vector<int3> CPathfinderHelper::getAllowedTeleportChannelExits(const Telepo
 	return allowedExits;
 }
 
-std::vector<int3> CPathfinderHelper::getCastleGates(const PathNodeInfo & source) const
+TeleporterTilesVector CPathfinderHelper::getCastleGates(const PathNodeInfo & source) const
 {
-	std::vector<int3> allowedExits;
+	TeleporterTilesVector allowedExits;
 
 	auto towns = getPlayerState(hero->tempOwner)->towns;
 	for(const auto & town : towns)
@@ -279,9 +279,9 @@ std::vector<int3> CPathfinderHelper::getCastleGates(const PathNodeInfo & source)
 	return allowedExits;
 }
 
-std::vector<int3> CPathfinderHelper::getTeleportExits(const PathNodeInfo & source) const
+TeleporterTilesVector CPathfinderHelper::getTeleportExits(const PathNodeInfo & source) const
 {
-	std::vector<int3> teleportationExits;
+	TeleporterTilesVector teleportationExits;
 
 	const auto * objTeleport = dynamic_cast<const CGTeleport *>(source.nodeObject);
 	if(isAllowedTeleportEntrance(objTeleport))
@@ -578,7 +578,7 @@ int CPathfinderHelper::getMaxMovePoints(const EPathfindingLayer & layer) const
 void CPathfinderHelper::getNeighbours(
 	const TerrainTile & srcTile,
 	const int3 & srcCoord,
-	std::vector<int3> & vec,
+	NeighbourTilesVector & vec,
 	const boost::logic::tribool & onLand,
 	const bool limitCoastSailing) const
 {
@@ -702,8 +702,8 @@ int CPathfinderHelper::getMovementCost(
 	constexpr auto maxCostOfOneStep = static_cast<int>(175 * M_SQRT2); // diagonal move on Swamp - 247 MP
 	if(checkLast && left > 0 && left <= maxCostOfOneStep) //it might be the last tile - if no further move possible we take all move points
 	{
-		std::vector<int3> vec;
-		vec.reserve(8); //optimization
+		NeighbourTilesVector vec;
+
 		getNeighbours(*dt, dst, vec, ct->terType->isLand(), true);
 		for(const auto & elem : vec)
 		{

--- a/lib/pathfinder/NodeStorage.cpp
+++ b/lib/pathfinder/NodeStorage.cpp
@@ -40,7 +40,7 @@ void NodeStorage::initialize(const PathfinderOptions & options, const CGameState
 		{
 			for(pos.y=0; pos.y < sizes.y; ++pos.y)
 			{
-				const TerrainTile tile = gs->map->getTile(pos);
+				const TerrainTile & tile = gs->map->getTile(pos);
 				if(tile.terType->isWater())
 				{
 					resetTile(pos, ELayer::SAIL, PathfinderUtil::evaluateAccessibility<ELayer::SAIL>(pos, tile, fow, player, gs));

--- a/lib/pathfinder/NodeStorage.cpp
+++ b/lib/pathfinder/NodeStorage.cpp
@@ -67,10 +67,9 @@ void NodeStorage::calculateNeighbours(
 	const PathfinderConfig * pathfinderConfig,
 	const CPathfinderHelper * pathfinderHelper)
 {
-	std::vector<int3> accessibleNeighbourTiles;
+	NeighbourTilesVector accessibleNeighbourTiles;
 	
 	result.clear();
-	accessibleNeighbourTiles.reserve(8);
 	
 	pathfinderHelper->calculateNeighbourTiles(accessibleNeighbourTiles, source);
 


### PR DESCRIPTION
Several optimizations for cases discovered when profiling AI. Some are not actually in AI code, but parts of library used by AI. In my tests autoskip on XL-U map with 6 AI's for 1 month went down from ~1:40-1:50 to ~1:10-1:20. Tests were done on minimal difficulty so exploration mode (and not graph). I have profiled high difficulty with no allies (graph mode) as well, but have not run time measurements in this mode.

List of changes: 
- Removed commonly used attempts to translate strings in AI code, for example access to translated hero name in HeroPtr. This code was fine before, but right now translations need access via mutex which is slow for AI to access.
- Replaced std::vector in several cases with containers with static allocation form boost to reduce massive amount of calls to memory allocations. Specifically:
  - Use boost::container::static_vector if maximum possible elements in vector is known. For example, tile can never have more than 8 direct neighbours.
  - Use boost::container::small_vector if container generally stays small, but may grow in some edge cases. For example, monoliths & subterra gates generally have 1 exits, but some may have more. (or whirlpools with 6 exits per instance)
- Rewrote ExplorationHelper::scanMap method in a more efficient fashion. Old version was very excessive and was calling sort and erase multiple times on vector with massive number of elements.
- Replaced some costly unintended copies with references
- Added several TODO's to places that show up on profiler for no good reason. Probably will keep them as it unless I have a good idea how to handle them.