### PR TITLE
reorder fields to shrink struct TerrainTile from 96 to 80 bytes

### DIFF
--- a/lib/mapping/CMapDefines.h
+++ b/lib/mapping/CMapDefines.h
@@ -97,10 +97,10 @@ struct DLL_LINKAGE TerrainTile
 	bool hasFavorableWinds() const;
 
 	const TerrainType * terType;
-	ui8 terView;
 	const RiverType * riverType;
-	ui8 riverDir;
 	const RoadType * roadType;
+	ui8 terView;
+	ui8 riverDir;
 	ui8 roadDir;
 	/// first two bits - how to rotate terrain graphic (next two - river graphic, next two - road);
 	///	7th bit - whether tile is coastal (allows disembarking if land or block movement if water); 8th bit - Favorable Winds effect


### PR DESCRIPTION
When I was playing a very large map, computer's turn took up to 2 minutes and that give me time to fire up perf and profile the code while waiting.

I noticed that 1.7% of time was spent in function CPathfinderHelper::getNeighbors and half of that on a single load from an array backing multi_array of TerrainTiles. That signals the CMap::terrain is too big to fit in CPU caches.

This patch reorders fields in TerrainTile struct, shrinking it from 96 bytes to 80 bytes and hopefully helping to keep more tiles in the cache and speeding things up a little bit.