### PR TITLE
treat manually selected/dropped file as a file path instead of URL

### DIFF
--- a/launcher/modManager/cmodlistview_moc.h
+++ b/launcher/modManager/cmodlistview_moc.h
@@ -51,8 +51,9 @@ class CModListView : public QWidget
 	// find mods that depend on this one
 	QStringList findDependentMods(QString mod, bool excludeDisabled);
 
-	void manualInstallFile(QUrl url);
+	void manualInstallFile(QString filePath);
 	void downloadFile(QString file, QString url, QString description, qint64 size = 0);
+	void downloadFile(QString file, QUrl url, QString description, qint64 size = 0);
 
 	void installMods(QStringList archives);
 	void installMaps(QStringList maps);


### PR DESCRIPTION
fixes file installation on Android

tested on Android 11