### PR TITLE
[1.5.4] Bugfixing

### DIFF
--- a/AI/Nullkiller/Analyzers/ArmyManager.h
+++ b/AI/Nullkiller/Analyzers/ArmyManager.h
@@ -32,7 +32,7 @@ struct SlotInfo
 struct ArmyUpgradeInfo
 {
 	std::vector<SlotInfo> resultingArmy;
-	uint64_t upgradeValue = 0;
+	int64_t upgradeValue = 0;
 	TResources upgradeCost;
 
 	void addArmyToBuy(std::vector<SlotInfo> army);

--- a/client/adventureMap/AdventureMapInterface.cpp
+++ b/client/adventureMap/AdventureMapInterface.cpp
@@ -444,6 +444,8 @@ void AdventureMapInterface::onPlayerTurnStarted(PlayerColor playerID)
 		LOCPLINT->localState->setSelection(LOCPLINT->localState->getWanderingHero(0));
 	}
 
+	centerOnObject(LOCPLINT->localState->getCurrentArmy());
+
 	//show new day animation and sound on infobar, except for 1st day of the game
 	if (LOCPLINT->cb->getDate(Date::DAY) != 1)
 		widget->getInfoBar()->showDate();

--- a/docs/modders/Bonus/Bonus_Types.md
+++ b/docs/modders/Bonus/Bonus_Types.md
@@ -252,7 +252,7 @@ Gives creature under effect of this spell additional bonus, which is hardcoded a
 
 ### SPECIAL_ADD_VALUE_ENCHANT
 
-Increased effect of spell affecting creature, ie. Aenain makes Disrupting Ray decrease target's defense by additional 2 points:
+Modifies 'val' parameter of spell effects that give bonuses by specified value. For example, Aenain makes Disrupting Ray decrease target's defense by additional 2 points:
 
 ```jsonc
 "disruptingRay" : {
@@ -263,11 +263,11 @@ Increased effect of spell affecting creature, ie. Aenain makes Disrupting Ray de
 ```
 
 - subtype: affected spell identifier
-- additionalInfo: value to add
+- addInfo: value to modify 'val' parameter of targeted spell effects by
 
 ### SPECIAL_FIXED_VALUE_ENCHANT
 
-Spell affecting creature has fixed effect, eg. hero Melody has constant spell effect of +3:
+Changes 'val' parameter of spell effects that give bonuses to a specified value. For example, Fortune cast by Melody always modifies luck by +3:
 
 ```jsonc
 "fortune" : {
@@ -278,7 +278,7 @@ Spell affecting creature has fixed effect, eg. hero Melody has constant spell ef
 ```
 
 - subtype: affected spell identifier
-- additionalInfo = fixed value
+- addInfo: value to set 'val' parameter of targeted spell effects to
 
 ### SPECIAL_UPGRADE
 

--- a/lib/bonuses/Updaters.cpp
+++ b/lib/bonuses/Updaters.cpp
@@ -196,7 +196,7 @@ std::shared_ptr<Bonus> OwnerUpdater::createUpdatedBonus(const std::shared_ptr<Bo
 		owner = PlayerColor::NEUTRAL;
 
 	std::shared_ptr<Bonus> updated =
-		std::make_shared<Bonus>(b->duration, b->type, b->source, b->val, b->sid, b->subtype, b->valType);
+		std::make_shared<Bonus>(*b);
 	updated->limiter = std::make_shared<OppositeSideLimiter>(owner);
 	return updated;
 }

--- a/lib/networkPacks/NetPacksLib.cpp
+++ b/lib/networkPacks/NetPacksLib.cpp
@@ -2416,7 +2416,7 @@ void CatapultAttack::applyBattle(IBattleState * battleState)
 
 void BattleSetStackProperty::applyGs(CGameState * gs) const
 {
-	CStack * stack = gs->getBattle(battleID)->getStack(stackID);
+	CStack * stack = gs->getBattle(battleID)->getStack(stackID, false);
 	switch(which)
 	{
 		case CASTS:

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -441,6 +441,11 @@ void CGameHandler::changeSecSkill(const CGHeroInstance * hero, SecondarySkill wh
 
 	if (hero->visitedTown)
 		giveSpells(hero->visitedTown, hero);
+
+	// Our scouting range may have changed - update it
+	if (hero->getOwner().isValidPlayer())
+		changeFogOfWar(hero->getSightCenter(), hero->getSightRadius(), hero->getOwner(), ETileVisibility::REVEALED);
+
 }
 
 void CGameHandler::handleClientDisconnection(std::shared_ptr<CConnection> c)
@@ -4293,6 +4298,9 @@ void CGameHandler::changeFogOfWar(int3 center, ui32 radius, PlayerColor player, 
 
 void CGameHandler::changeFogOfWar(std::unordered_set<int3> &tiles, PlayerColor player, ETileVisibility mode)
 {
+	if (tiles.empty())
+		return;
+
 	FoWChange fow;
 	fow.tiles = tiles;
 	fow.player = player;

--- a/server/processors/TurnOrderProcessor.cpp
+++ b/server/processors/TurnOrderProcessor.cpp
@@ -177,13 +177,16 @@ bool TurnOrderProcessor::computeCanActSimultaneously(PlayerColor active, PlayerC
 	assert(activeInfo);
 	assert(waitingInfo);
 
-	if (gameHandler->hasBothPlayersAtSameConnection(active, waiting))
+	if (activeInfo->human != waitingInfo->human)
 	{
+		// only one AI and one human can play simultaneoulsy from single connection
 		if (!gameHandler->getStartInfo()->simturnsInfo.allowHumanWithAI)
 			return false;
-
-		// only one AI and one human can play simultaneoulsy from single connection
-		if (activeInfo->human == waitingInfo->human)
+	}
+	else
+	{
+		// two AI or two humans in hotseat can't play at the same time
+		if (gameHandler->hasBothPlayersAtSameConnection(active, waiting))
 			return false;
 	}
 


### PR DESCRIPTION
- Replace uint64_t with signed type to prevent overflow on substraction
- Reveal terrain whenever hero receives a secondary skill
- Clarified bonus types documentation to better match actual logic
- Block AI from acting at the same time as guest-human during simturns, as requested by pvp players
- Fixed addInfo not copied to updated bonus when owner updater is used
  - Fixes #4211, #4198
- Fix possible crash on Faerie Dragon killing themselves with Frost Ring
  - Fixes #4213
- Fix centering on selected map object on loading save
  - Fixes #4230
