### PR TITLE
Bind VCMI server to a random TCP port

### DIFF
--- a/client/CServerHandler.cpp
+++ b/client/CServerHandler.cpp
@@ -238,9 +238,9 @@ void CServerHandler::startLocalServerAndConnect(bool connectToLobby)
 	si->difficulty = lastDifficulty.Integer();
 
 	logNetwork->trace("\tStarting local server");
-	serverRunner->start(getLocalPort(), connectToLobby, si);
+	uint16_t srvport = serverRunner->start(getLocalPort(), connectToLobby, si);
 	logNetwork->trace("\tConnecting to local server");
-	connectToServer(getLocalHostname(), getLocalPort());
+	connectToServer(getLocalHostname(), srvport);
 	logNetwork->trace("\tWaiting for connection");
 }
 

--- a/client/ServerRunner.cpp
+++ b/client/ServerRunner.cpp
@@ -39,7 +39,6 @@ uint16_t ServerThreadRunner::start(uint16_t cfgport, bool connectToLobby, std::s
 
 	threadRunLocalServer = boost::thread([this, connectToLobby, &promise]{
 		setThreadName("runServer");
-		std::this_thread::sleep_for(std::chrono::seconds(5));
 		uint16_t port = server->prepare(connectToLobby);
 		promise.set_value(port);
 		server->run();

--- a/client/ServerRunner.cpp
+++ b/client/ServerRunner.cpp
@@ -20,6 +20,8 @@
 #include <boost/process/io.hpp>
 #endif
 
+#include <future>
+
 ServerThreadRunner::ServerThreadRunner() = default;
 ServerThreadRunner::~ServerThreadRunner() = default;
 

--- a/client/ServerRunner.cpp
+++ b/client/ServerRunner.cpp
@@ -23,19 +23,30 @@
 ServerThreadRunner::ServerThreadRunner() = default;
 ServerThreadRunner::~ServerThreadRunner() = default;
 
-void ServerThreadRunner::start(uint16_t port, bool connectToLobby, std::shared_ptr<StartInfo> startingInfo)
+uint16_t ServerThreadRunner::start(uint16_t port, bool connectToLobby, std::shared_ptr<StartInfo> startingInfo)
 {
-	server = std::make_unique<CVCMIServer>(port, connectToLobby, true);
+	server = std::make_unique<CVCMIServer>(port, true);
 
 	if (startingInfo)
 	{
 		server->si = startingInfo; //Else use default
 	}
 
-	threadRunLocalServer = boost::thread([this]{
+	uint16_t srvport = port;
+
+	threadRunLocalServer = boost::thread([this, connectToLobby, &srvport]{
 		setThreadName("runServer");
+		srvport = server->prepare(connectToLobby);
 		server->run();
 	});
+
+	while(srvport == 0) {
+		logNetwork->trace("Waiting for server port...");
+		boost::this_thread::sleep(boost::posix_time::milliseconds(100));
+		logNetwork->debug("Server port: %d", srvport);
+	}
+
+	return srvport;
 }
 
 void ServerThreadRunner::shutdown()
@@ -73,7 +84,7 @@ int ServerProcessRunner::exitCode()
 	return child->exit_code();
 }
 
-void ServerProcessRunner::start(uint16_t port, bool connectToLobby, std::shared_ptr<StartInfo> startingInfo)
+uint16_t ServerProcessRunner::start(uint16_t port, bool connectToLobby, std::shared_ptr<StartInfo> startingInfo)
 {
 	boost::filesystem::path serverPath = VCMIDirs::get().serverPath();
 	boost::filesystem::path logPath = VCMIDirs::get().userLogsPath() / "server_log.txt";
@@ -88,6 +99,8 @@ void ServerProcessRunner::start(uint16_t port, bool connectToLobby, std::shared_
 
 	if (ec)
 		throw std::runtime_error("Failed to start server! Reason: " + ec.message());
+
+	return port;
 }
 
 #endif

--- a/client/ServerRunner.h
+++ b/client/ServerRunner.h
@@ -20,7 +20,7 @@ class CVCMIServer;
 class IServerRunner
 {
 public:
-	virtual void start(uint16_t port, bool connectToLobby, std::shared_ptr<StartInfo> startingInfo) = 0;
+	virtual uint16_t start(uint16_t port, bool connectToLobby, std::shared_ptr<StartInfo> startingInfo) = 0;
 	virtual void shutdown() = 0;
 	virtual void wait() = 0;
 	virtual int exitCode() = 0;
@@ -34,7 +34,7 @@ class ServerThreadRunner : public IServerRunner, boost::noncopyable
 	std::unique_ptr<CVCMIServer> server;
 	boost::thread threadRunLocalServer;
 public:
-	void start(uint16_t port, bool connectToLobby, std::shared_ptr<StartInfo> startingInfo) override;
+	uint16_t start(uint16_t port, bool connectToLobby, std::shared_ptr<StartInfo> startingInfo) override;
 	void shutdown() override;
 	void wait() override;
 	int exitCode() override;
@@ -56,7 +56,7 @@ class ServerProcessRunner : public IServerRunner, boost::noncopyable
 	std::unique_ptr<boost::process::child> child;
 
 public:
-	void start(uint16_t port, bool connectToLobby, std::shared_ptr<StartInfo> startingInfo) override;
+	uint16_t start(uint16_t port, bool connectToLobby, std::shared_ptr<StartInfo> startingInfo) override;
 	void shutdown() override;
 	void wait() override;
 	int exitCode() override;

--- a/lib/network/NetworkInterface.h
+++ b/lib/network/NetworkInterface.h
@@ -40,7 +40,7 @@ class DLL_LINKAGE INetworkServer : boost::noncopyable
 public:
 	virtual ~INetworkServer() = default;
 
-	virtual void start(uint16_t port) = 0;
+	virtual uint16_t start(uint16_t port) = 0;
 };
 
 /// Base interface that must be implemented by user of networking API to handle any connection callbacks

--- a/lib/network/NetworkServer.cpp
+++ b/lib/network/NetworkServer.cpp
@@ -21,7 +21,7 @@ NetworkServer::NetworkServer(INetworkServerListener & listener, const std::share
 
 uint16_t NetworkServer::start(uint16_t port)
 {
-	acceptor = std::make_shared<NetworkAcceptor>(*io, boost::asio::ip::tcp::endpoint(boost::asio::ip::address::from_string("127.0.0.1"), port));
+	acceptor = std::make_shared<NetworkAcceptor>(*io, boost::asio::ip::tcp::endpoint(boost::asio::ip::tcp::v4(), port));
 	return startAsyncAccept();
 }
 

--- a/lib/network/NetworkServer.cpp
+++ b/lib/network/NetworkServer.cpp
@@ -19,16 +19,17 @@ NetworkServer::NetworkServer(INetworkServerListener & listener, const std::share
 {
 }
 
-void NetworkServer::start(uint16_t port)
+uint16_t NetworkServer::start(uint16_t port)
 {
-	acceptor = std::make_shared<NetworkAcceptor>(*io, boost::asio::ip::tcp::endpoint(boost::asio::ip::tcp::v4(), port));
-	startAsyncAccept();
+	acceptor = std::make_shared<NetworkAcceptor>(*io, boost::asio::ip::tcp::endpoint(boost::asio::ip::address::from_string("127.0.0.1"), port));
+	return startAsyncAccept();
 }
 
-void NetworkServer::startAsyncAccept()
+uint16_t NetworkServer::startAsyncAccept()
 {
 	auto upcomingConnection = std::make_shared<NetworkSocket>(*io);
 	acceptor->async_accept(*upcomingConnection, [this, upcomingConnection](const auto & ec) { connectionAccepted(upcomingConnection, ec); });
+	return acceptor->local_endpoint().port();
 }
 
 void NetworkServer::connectionAccepted(std::shared_ptr<NetworkSocket> upcomingConnection, const boost::system::error_code & ec)

--- a/lib/network/NetworkServer.h
+++ b/lib/network/NetworkServer.h
@@ -22,14 +22,14 @@ class NetworkServer : public INetworkConnectionListener, public INetworkServer
 	INetworkServerListener & listener;
 
 	void connectionAccepted(std::shared_ptr<NetworkSocket>, const boost::system::error_code & ec);
-	void startAsyncAccept();
+	uint16_t startAsyncAccept();
 
 	void onDisconnected(const std::shared_ptr<INetworkConnection> & connection, const std::string & errorMessage) override;
 	void onPacketReceived(const std::shared_ptr<INetworkConnection> & connection, const std::vector<std::byte> & message) override;
 public:
 	NetworkServer(INetworkServerListener & listener, const std::shared_ptr<NetworkContext> & context);
 
-	void start(uint16_t port) override;
+	uint16_t start(uint16_t port) override;
 };
 
 VCMI_LIB_NAMESPACE_END

--- a/server/CVCMIServer.h
+++ b/server/CVCMIServer.h
@@ -66,6 +66,8 @@ public:
 	/// List of all active connections
 	std::vector<std::shared_ptr<CConnection>> activeConnections;
 
+	uint16_t prepare(bool connectToLobby);
+
 	// INetworkListener impl
 	void onDisconnected(const std::shared_ptr<INetworkConnection> & connection, const std::string & errorMessage) override;
 	void onPacketReceived(const std::shared_ptr<INetworkConnection> & connection, const std::vector<std::byte> & message) override;
@@ -74,7 +76,7 @@ public:
 
 	std::shared_ptr<CGameHandler> gh;
 
-	CVCMIServer(uint16_t port, bool connectToLobby, bool runByClient);
+	CVCMIServer(uint16_t port, bool runByClient);
 	~CVCMIServer();
 
 	void run();
@@ -83,7 +85,7 @@ public:
 	bool prepareToStartGame();
 	void prepareToRestart();
 	void startGameImmediately();
-	void startAcceptingIncomingConnections();
+	uint16_t startAcceptingIncomingConnections();
 
 	void threadHandleClient(std::shared_ptr<CConnection> c);
 

--- a/serverapp/EntryPoint.cpp
+++ b/serverapp/EntryPoint.cpp
@@ -15,6 +15,7 @@
 #include "../lib/logging/CBasicLogConfigurator.h"
 #include "../lib/VCMIDirs.h"
 #include "../lib/VCMI_Lib.h"
+#include "../lib/CConfigHandler.h"
 
 #include <boost/program_options.hpp>
 
@@ -86,12 +87,12 @@ int main(int argc, const char * argv[])
 	{
 		bool connectToLobby = opts.count("lobby");
 		bool runByClient = opts.count("runByClient");
-		uint16_t port = 3030;
+		uint16_t port = settings["server"]["localPort"].Integer();
 		if(opts.count("port"))
 			port = opts["port"].as<uint16_t>();
 
-		CVCMIServer server(port, connectToLobby, runByClient);
-
+		CVCMIServer server(port, runByClient);
+		server.prepare(connectToLobby);
 		server.run();
 
 		// CVCMIServer destructor must be called here - before VLC cleanup


### PR DESCRIPTION
### Overview

This PR allows to set `settings["server"]["localPort"]=0` in order to bind VCMI server to a random TCP port.

### Problem statement

For the purposes of ML, being able to run multiple VCMI instances in parallel is essential in order to efficiently use the available hardware resources by training multiple AI agents simultaneously. Since there can only be one process bound to a given port, the workaround is to manually select a free TCP port prior to launching the application, but there are many issues with this approach.

In addition, when running VCMI server+client locally, there is a (small) chance of a port conflict with third party software using the same port.

### Changes summary

* `settings["server"]["localPort"]` can now be set to `0` (i.e. randomly assigned port)
* A new function `CVCMIServer::prepare` (naming suggestions are welcome) must now be called in order to bind to a network socket (this used to be part of the server constructor). This function returns the assigned port.
* Several functions (`IServerRunner::start`, `ServerProcessRunner::start`, `ServerThreadRunner::start`, `NetworkInterface::start`, etc.) return type was changed from `void` to `uint16_t` (the assigned port).

### Example

Using a `localPort` of `0`, we can see that a random port is assigned (63615 in this case):

```
[0x1eaadfac0][network] INFO Randomly assigned port will be used
[0x1eaadfac0][network] INFO Listening for connections at port 63615
```

Subsequently started VCMI server processes will bind to a different port without conflict.
