### PR TITLE
Fix battle turn order for current turn

### DIFF
--- a/lib/battle/CBattleInfoCallback.cpp
+++ b/lib/battle/CBattleInfoCallback.cpp
@@ -475,7 +475,7 @@ void CBattleInfoCallback::battleGetTurnOrder(std::vector<battle::Units> & turns,
 	if(activeUnit)
 	{
 		//its first turn and active unit hasn't taken any action yet - must be placed at the beginning of queue, no matter what
-		if(turn == 0 && activeUnit->willMove() && !activeUnit->waited())
+		if(turn == 0 && activeUnit->willMove())
 		{
 			turns.back().push_back(activeUnit);
 			if(turnsIsFull())


### PR DESCRIPTION
### Overview

This PR fixes the battle turn order for cases where all units have waited.

### Problem statement

The battle queue occasionally displays incorrect turn order, see screenshot below:

<img width="396" alt="Screenshot 2024-07-12 at 11 33 13" src="https://github.com/user-attachments/assets/61033534-b24f-43d4-9ce8-38474197bdf2">

The **active** stack is displayed as **second** on the queue.

#### Steps to reproduce

1. Start a hot-seat game with 2 players
1. Engage the 2 players into a battle
1. Press "Wait" on each turn until all creatures have waited
1. Observe how the queue bar incorrectly shows the active unit in second place

I have prepared a simple [test map](https://drive.google.com/file/d/1cRNfNwgtA99dtxO5547FrthfRVta-QF9/view?usp=sharing) (will keep this link alive for a while)

### Changes summary

* Changed boolean expression in `CBattleInfoCallback::battleGetTurnOrder`, removing condition `!activeUnit->waited()`: contradictory to the code comment above it, this condition was preventing the active stack from being placed first in the queue.

This change has no effect server-side, as the server calls this function [here](https://github.com/vcmi/vcmi/blob/1.5.3/server/battles/BattleFlowProcessor.cpp#L256), with a `turn` argument of `1`.

