### PR TITLE
JsonParser::parse(): Print file name if there were errors while parsing

### DIFF
--- a/client/globalLobby/GlobalLobbyClient.cpp
+++ b/client/globalLobby/GlobalLobbyClient.cpp
@@ -43,7 +43,7 @@ void GlobalLobbyClient::onPacketReceived(const std::shared_ptr<INetworkConnectio
 {
 	boost::mutex::scoped_lock interfaceLock(GH.interfaceMutex);
 
-	JsonNode json(message.data(), message.size());
+	JsonNode json(message.data(), message.size(), "<lobby network packet>");
 
 	if(json["type"].String() == "accountCreated")
 		return receiveAccountCreated(json);

--- a/client/render/CAnimation.cpp
+++ b/client/render/CAnimation.cpp
@@ -191,7 +191,7 @@ void CAnimation::init()
 		std::unique_ptr<ui8[]> textData(new ui8[stream->getSize()]);
 		stream->read(textData.get(), stream->getSize());
 
-		const JsonNode config(reinterpret_cast<const std::byte*>(textData.get()), stream->getSize());
+		const JsonNode config(reinterpret_cast<const std::byte*>(textData.get()), stream->getSize(), jsonResource.getName());
 
 		initFromJson(config);
 	}

--- a/launcher/jsonutils.cpp
+++ b/launcher/jsonutils.cpp
@@ -89,7 +89,7 @@ QVariant JsonFromFile(QString filename)
 	}
 
 	const auto data = file.readAll();
-	JsonNode node(reinterpret_cast<const std::byte*>(data.data()), data.size());
+	JsonNode node(reinterpret_cast<const std::byte*>(data.data()), data.size(), filename.toStdString());
 	return toVariant(node);
 }
 

--- a/launcher/updatedialog_moc.cpp
+++ b/launcher/updatedialog_moc.cpp
@@ -67,7 +67,7 @@ UpdateDialog::UpdateDialog(bool calledManually, QWidget *parent):
 		}
 		
 		auto byteArray = response->readAll();
-		JsonNode node(reinterpret_cast<const std::byte*>(byteArray.constData()), byteArray.size());
+		JsonNode node(reinterpret_cast<const std::byte*>(byteArray.constData()), byteArray.size(), "<network packet from server at updateConfigUrl>");
 		loadFromJson(node);
 	});
 }

--- a/lib/campaign/CampaignHandler.cpp
+++ b/lib/campaign/CampaignHandler.cpp
@@ -46,7 +46,7 @@ void CampaignHandler::readCampaign(Campaign * ret, const std::vector<ui8> & inpu
 	}
 	else // text format (json)
 	{
-		JsonNode jsonCampaign(reinterpret_cast<const std::byte*>(input.data()), input.size());
+		JsonNode jsonCampaign(reinterpret_cast<const std::byte*>(input.data()), input.size(), filename);
 		readHeaderFromJson(*ret, jsonCampaign, filename, modName, encoding);
 
 		for(auto & scenario : jsonCampaign["scenarios"].Vector())

--- a/lib/filesystem/Filesystem.cpp
+++ b/lib/filesystem/Filesystem.cpp
@@ -117,7 +117,7 @@ void CFilesystemGenerator::loadJsonMap(const std::string &mountPoint, const Json
 	if (filename)
 	{
 		auto configData = CResourceHandler::get("initial")->load(JsonPath::builtin(URI))->readAll();
-		const JsonNode configInitial(reinterpret_cast<std::byte *>(configData.first.get()), configData.second);
+		const JsonNode configInitial(reinterpret_cast<std::byte *>(configData.first.get()), configData.second, URI);
 		filesystem->addLoader(new CMappedFileLoader(mountPoint, configInitial), false);
 	}
 }
@@ -212,7 +212,7 @@ void CResourceHandler::load(const std::string &fsConfigURI, bool extractArchives
 {
 	auto fsConfigData = get("initial")->load(JsonPath::builtin(fsConfigURI))->readAll();
 
-	const JsonNode fsConfig(reinterpret_cast<std::byte *>(fsConfigData.first.get()), fsConfigData.second);
+	const JsonNode fsConfig(reinterpret_cast<std::byte *>(fsConfigData.first.get()), fsConfigData.second, fsConfigURI);
 
 	addFilesystem("data", ModScope::scopeBuiltin(), createFileSystem("", fsConfig["filesystem"], extractArchives));
 }

--- a/lib/json/JsonNode.cpp
+++ b/lib/json/JsonNode.cpp
@@ -86,15 +86,15 @@ JsonNode::JsonNode(const std::string & string)
 {
 }
 
-JsonNode::JsonNode(const std::byte * data, size_t datasize)
-	: JsonNode(data, datasize, JsonParsingSettings())
+JsonNode::JsonNode(const std::byte * data, size_t datasize, const std::string fileName)
+	: JsonNode(data, datasize, JsonParsingSettings(), fileName)
 {
 }
 
-JsonNode::JsonNode(const std::byte * data, size_t datasize, const JsonParsingSettings & parserSettings)
+JsonNode::JsonNode(const std::byte * data, size_t datasize, const JsonParsingSettings & parserSettings, const std::string fileName)
 {
 	JsonParser parser(data, datasize, parserSettings);
-	*this = parser.parse("<unknown>");
+	*this = parser.parse(fileName);
 }
 
 JsonNode::JsonNode(const JsonPath & fileURI)

--- a/lib/json/JsonNode.cpp
+++ b/lib/json/JsonNode.cpp
@@ -86,12 +86,12 @@ JsonNode::JsonNode(const std::string & string)
 {
 }
 
-JsonNode::JsonNode(const std::byte * data, size_t datasize, const std::string fileName)
+JsonNode::JsonNode(const std::byte * data, size_t datasize, const std::string & fileName)
 	: JsonNode(data, datasize, JsonParsingSettings(), fileName)
 {
 }
 
-JsonNode::JsonNode(const std::byte * data, size_t datasize, const JsonParsingSettings & parserSettings, const std::string fileName)
+JsonNode::JsonNode(const std::byte * data, size_t datasize, const JsonParsingSettings & parserSettings, const std::string & fileName)
 {
 	JsonParser parser(data, datasize, parserSettings);
 	*this = parser.parse(fileName);

--- a/lib/json/JsonNode.h
+++ b/lib/json/JsonNode.h
@@ -72,8 +72,8 @@ public:
 	explicit JsonNode(const std::string & string);
 
 	/// Create tree from Json-formatted input
-	explicit JsonNode(const std::byte * data, size_t datasize);
-	explicit JsonNode(const std::byte * data, size_t datasize, const JsonParsingSettings & parserSettings);
+	explicit JsonNode(const std::byte * data, size_t datasize, const std::string fileName);
+	explicit JsonNode(const std::byte * data, size_t datasize, const JsonParsingSettings & parserSettings, const std::string fileName);
 
 	/// Create tree from JSON file
 	explicit JsonNode(const JsonPath & fileURI);

--- a/lib/json/JsonNode.h
+++ b/lib/json/JsonNode.h
@@ -72,8 +72,8 @@ public:
 	explicit JsonNode(const std::string & string);
 
 	/// Create tree from Json-formatted input
-	explicit JsonNode(const std::byte * data, size_t datasize, const std::string fileName);
-	explicit JsonNode(const std::byte * data, size_t datasize, const JsonParsingSettings & parserSettings, const std::string fileName);
+	explicit JsonNode(const std::byte * data, size_t datasize, const std::string & fileName);
+	explicit JsonNode(const std::byte * data, size_t datasize, const JsonParsingSettings & parserSettings, const std::string & fileName);
 
 	/// Create tree from JSON file
 	explicit JsonNode(const JsonPath & fileURI);

--- a/lib/json/JsonParser.cpp
+++ b/lib/json/JsonParser.cpp
@@ -57,6 +57,7 @@ JsonNode JsonParser::parse(const std::string & fileName)
 	{
 		logMod->warn("File %s is not a valid JSON file!", fileName);
 		logMod->warn(errors);
+		logMod->warn("%s", input);
 	}
 	return root;
 }

--- a/lib/json/JsonParser.cpp
+++ b/lib/json/JsonParser.cpp
@@ -55,9 +55,8 @@ JsonNode JsonParser::parse(const std::string & fileName)
 
 	if(!errors.empty())
 	{
-		logMod->warn("File %s is not a valid JSON file!", fileName);
+		logMod->warn("%s is not valid JSON!", fileName);
 		logMod->warn(errors);
-		logMod->warn("%s", input);
 	}
 	return root;
 }

--- a/lib/json/JsonUtils.cpp
+++ b/lib/json/JsonUtils.cpp
@@ -269,7 +269,7 @@ JsonNode JsonUtils::assembleFromFiles(const std::string & filename)
 	for(auto & loader : CResourceHandler::get()->getResourcesWithName(resID))
 	{
 		auto textData = loader->load(resID)->readAll();
-		JsonNode section(reinterpret_cast<std::byte *>(textData.first.get()), textData.second);
+		JsonNode section(reinterpret_cast<std::byte *>(textData.first.get()), textData.second, resID.getName());
 		merge(result, section);
 	}
 	return result;

--- a/lib/mapping/MapFormatJson.cpp
+++ b/lib/mapping/MapFormatJson.cpp
@@ -813,7 +813,7 @@ JsonNode CMapLoaderJson::getFromArchive(const std::string & archiveFilename)
 
 	auto data = loader.load(resource)->readAll();
 
-	JsonNode res(reinterpret_cast<const std::byte*>(data.first.get()), data.second);
+	JsonNode res(reinterpret_cast<const std::byte*>(data.first.get()), data.second, archiveFilename);
 
 	return res;
 }

--- a/lobby/LobbyServer.cpp
+++ b/lobby/LobbyServer.cpp
@@ -213,7 +213,7 @@ static JsonNode loadLobbyGameRoomToJson(const LobbyGameRoom & gameRoom)
 	jsonEntry["playerLimit"].Integer() = gameRoom.playerLimit;
 	jsonEntry["ageSeconds"].Integer() = gameRoom.age.count();
 	if (!gameRoom.modsJson.empty()) // not present in match history
-		jsonEntry["mods"] = JsonNode(reinterpret_cast<const std::byte *>(gameRoom.modsJson.data()), gameRoom.modsJson.size());
+		jsonEntry["mods"] = JsonNode(reinterpret_cast<const std::byte *>(gameRoom.modsJson.data()), gameRoom.modsJson.size(), "<lobby "+gameRoom.roomID+">");
 
 	for(const auto & account : gameRoom.participants)
 		jsonEntry["participants"].Vector().push_back(loadLobbyAccountToJson(account));
@@ -348,7 +348,7 @@ JsonNode LobbyServer::parseAndValidateMessage(const std::vector<std::byte> & mes
 	JsonNode json;
 	try
 	{
-		JsonNode jsonTemp(message.data(), message.size());
+		JsonNode jsonTemp(message.data(), message.size(), "<lobby message>");
 		json = std::move(jsonTemp);
 	}
 	catch (const JsonFormatException & e)

--- a/mapeditor/Animation.cpp
+++ b/mapeditor/Animation.cpp
@@ -599,7 +599,7 @@ void Animation::init()
 		std::unique_ptr<ui8[]> textData(new ui8[stream->getSize()]);
 		stream->read(textData.get(), stream->getSize());
 
-		const JsonNode config(reinterpret_cast<const std::byte*>(textData.get()), stream->getSize());
+		const JsonNode config(reinterpret_cast<const std::byte*>(textData.get()), stream->getSize(), resID.getName());
 
 		initFromJson(config);
 	}

--- a/mapeditor/jsonutils.cpp
+++ b/mapeditor/jsonutils.cpp
@@ -97,7 +97,7 @@ QVariant JsonFromFile(QString filename)
 	}
 	else
 	{
-		JsonNode node(reinterpret_cast<const std::byte*>(data.data()), data.size());
+		JsonNode node(reinterpret_cast<const std::byte*>(data.data()), data.size(), filename.toStdString());
 		return toVariant(node);
 	}
 }

--- a/server/GlobalLobbyProcessor.cpp
+++ b/server/GlobalLobbyProcessor.cpp
@@ -67,7 +67,7 @@ void GlobalLobbyProcessor::onPacketReceived(const std::shared_ptr<INetworkConnec
 {
 	if (connection == controlConnection)
 	{
-		JsonNode json(message.data(), message.size());
+		JsonNode json(message.data(), message.size(), "<lobby network packet>");
 
 		if(json["type"].String() == "operationFailed")
 			return receiveOperationFailed(json);

--- a/test/map/CMapFormatTest.cpp
+++ b/test/map/CMapFormatTest.cpp
@@ -95,7 +95,7 @@ static JsonNode getFromArchive(CZipLoader & archive, const std::string & archive
 
 	auto data = archive.load(resource)->readAll();
 
-	JsonNode res(reinterpret_cast<const std::byte *>(data.first.get()), data.second);
+	JsonNode res(reinterpret_cast<const std::byte *>(data.first.get()), data.second, resource.getName());
 
 	return res;
 }


### PR DESCRIPTION
In cases where the file name was not specified, the warning messages were not very useful.

Example:

```
File <unknown> is not a valid JSON file!
At line 33, position 1 warning: Comma expected!
```
```json
{
        "name" : "New Old Heroes",
        "description" : "New heroes based on old 3DO artwork and other game appearances. Requires Horn of the Abyss.",
        "modType" : "Heroes",
        "version" : "1.2.0",
        "author" : "Aphra",
        "contact" : "",

        "heroes" :
        [
                "config/gwenneth.json",
                "config/balindar.json",
                "config/nicolas.json",
                "config/kastore.json",
                "config/kydoimos.json",
                "config/athe.json",
                "config/miseria.json",
                "config/areshrak.json",
                "config/pactal.json",
                "config/zog.json"
        ],

        "changelog" :
    {
        "1.0.0"   : ["Initial release"],
        "1.1.0"   : ["Added Nicolas Gryphonheart and Kastore"],
        "1.1.1"   : ["Bug fixes"],
        "1.2.0"   : ["Added some HotA portrait-only campaign heroes"]
    },

        "depends" :
                [ "hota.neutralCreatures" ]
        "keepDisabled" : true
}
```