### PR TITLE
Fix alternative actions to support more than 2 actions + simplify logic

### DIFF
--- a/client/battle/BattleActionsController.cpp
+++ b/client/battle/BattleActionsController.cpp
@@ -998,8 +998,12 @@ void BattleActionsController::activateStack()
 				};
 				bool hasShootSecondaryAction = std::any_of(possibleActions.begin() + 1, possibleActions.end(), shootActionPredicate);
 
-				if(hasShootSecondaryAction)
+				if(hasShootSecondaryAction) //casters may have shooting capabilities, for example storm elementals
 					actionsToSelect.emplace_back(PossiblePlayerBattleAction::SHOOT);
+
+				/* TODO: maybe it would also make sense to check spellcast as non-top priority action ("NO_SPELLCAST_BY_DEFAULT" bonus)?
+				 * it would require going beyond this "if" block for melee casters
+				 * F button helps, but some mod creatures may have that bonus and more than 1 castable spell */
 
 				actionsToSelect.emplace_back(PossiblePlayerBattleAction::ATTACK); //always allow melee attack as last option
 			}

--- a/client/battle/BattleActionsController.h
+++ b/client/battle/BattleActionsController.h
@@ -122,4 +122,7 @@ public:
 	
 	/// inserts possible action in the beggining in order to prioritize it
 	void pushFrontPossibleAction(PossiblePlayerBattleAction);
+
+	/// resets possible actions to original state
+	void resetCurrentStackPossibleActions();
 };

--- a/client/battle/BattleWindow.cpp
+++ b/client/battle/BattleWindow.cpp
@@ -48,7 +48,7 @@
 
 BattleWindow::BattleWindow(BattleInterface & owner):
 	owner(owner),
-	defaultAction(PossiblePlayerBattleAction::INVALID)
+	lastAlternativeAction(PossiblePlayerBattleAction::INVALID)
 {
 	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
 	pos.w = 800;
@@ -568,14 +568,18 @@ void BattleWindow::showAlternativeActionIcon(PossiblePlayerBattleAction action)
 
 void BattleWindow::setAlternativeActions(const std::list<PossiblePlayerBattleAction> & actions)
 {
+	assert(actions.size() != 1);
+
 	alternativeActions = actions;
-	defaultAction = PossiblePlayerBattleAction::INVALID;
+	lastAlternativeAction = PossiblePlayerBattleAction::INVALID;
+
 	if(alternativeActions.size() > 1)
-		defaultAction = alternativeActions.back();
-	if(!alternativeActions.empty())
+	{
+		lastAlternativeAction = alternativeActions.back();
 		showAlternativeActionIcon(alternativeActions.front());
+	}
 	else
-		showAlternativeActionIcon(defaultAction);
+		showAlternativeActionIcon(PossiblePlayerBattleAction::INVALID);
 }
 
 void BattleWindow::bAutofightf()
@@ -670,23 +674,18 @@ void BattleWindow::bSwitchActionf()
 {
 	if(alternativeActions.empty())
 		return;
-	
-	if(alternativeActions.front() == defaultAction)
-	{
-		alternativeActions.push_back(alternativeActions.front());
-		alternativeActions.pop_front();
-	}
-	
+
 	auto actions = owner.actionsController->getPossibleActions();
-	if(!actions.empty() && actions.front() == alternativeActions.front())
+
+	if(!actions.empty() && actions.front() != lastAlternativeAction)
 	{
 		owner.actionsController->removePossibleAction(alternativeActions.front());
-		showAlternativeActionIcon(defaultAction);
+		showAlternativeActionIcon(*std::next(alternativeActions.begin()));
 	}
 	else
 	{
-		owner.actionsController->pushFrontPossibleAction(alternativeActions.front());
-		showAlternativeActionIcon(alternativeActions.front());
+		owner.actionsController->resetCurrentStackPossibleActions();
+		showAlternativeActionIcon(owner.actionsController->getPossibleActions().front());
 	}
 	
 	alternativeActions.push_back(alternativeActions.front());

--- a/client/battle/BattleWindow.h
+++ b/client/battle/BattleWindow.h
@@ -65,7 +65,7 @@ class BattleWindow : public InterfaceObjectConfigurable
 	
 	/// management of alternative actions
 	std::list<PossiblePlayerBattleAction> alternativeActions;
-	PossiblePlayerBattleAction defaultAction;
+	PossiblePlayerBattleAction lastAlternativeAction;
 	void showAlternativeActionIcon(PossiblePlayerBattleAction);
 
 	/// flip battle queue visibility to opposite

--- a/lib/battle/PossiblePlayerBattleAction.h
+++ b/lib/battle/PossiblePlayerBattleAction.h
@@ -74,6 +74,11 @@ public:
 	{
 		return action == other.action && spellToCast == other.spellToCast;
 	}
+
+	bool operator != (const PossiblePlayerBattleAction & other) const
+	{
+		return action != other.action || spellToCast != other.spellToCast;
+	}
 };
 
 VCMI_LIB_NAMESPACE_END


### PR DESCRIPTION
As in title

Lost feature in this PR: separate non-returning attack icon for harpies and other "attack & return" creatures