### PR TITLE
Reduce size of CGPathNode and AIPathNode

### DIFF
--- a/AI/Nullkiller/Pathfinding/AINodeStorage.cpp
+++ b/AI/Nullkiller/Pathfinding/AINodeStorage.cpp
@@ -25,7 +25,7 @@ namespace NKAI
 {
 
 std::shared_ptr<boost::multi_array<AIPathNode, 4>> AISharedStorage::shared;
-uint64_t AISharedStorage::version = 0;
+uint32_t AISharedStorage::version = 0;
 boost::mutex AISharedStorage::locker;
 std::set<int3> committedTiles;
 std::set<int3> committedTilesInitial;
@@ -224,7 +224,6 @@ std::vector<CGPathNode *> AINodeStorage::getInitialNodes()
 
 		AIPathNode * initialNode = allocated.value();
 
-		initialNode->inPQ = false;
 		initialNode->pq = nullptr;
 		initialNode->turns = actor->initialTurn;
 		initialNode->moveRemains = actor->initialMovement;

--- a/AI/Nullkiller/Pathfinding/AINodeStorage.h
+++ b/AI/Nullkiller/Pathfinding/AINodeStorage.h
@@ -44,14 +44,17 @@ enum DayFlags : ui8
 
 struct AIPathNode : public CGPathNode
 {
+	std::shared_ptr<const SpecialAction> specialAction;
+
+	const AIPathNode * chainOther;
+	const ChainActor * actor;
+
 	uint64_t danger;
 	uint64_t armyLoss;
+	uint32_t version;
+
 	int16_t manaCost;
 	DayFlags dayFlags;
-	const AIPathNode * chainOther;
-	std::shared_ptr<const SpecialAction> specialAction;
-	const ChainActor * actor;
-	uint64_t version;
 
 	void addSpecialAction(std::shared_ptr<const SpecialAction> action);
 
@@ -152,7 +155,7 @@ class AISharedStorage
 	std::shared_ptr<boost::multi_array<AIPathNode, 4>> nodes;
 public:
 	static boost::mutex locker;
-	static uint64_t version;
+	static uint32_t version;
 
 	AISharedStorage(int3 mapSize);
 	~AISharedStorage();

--- a/lib/pathfinder/CPathfinder.cpp
+++ b/lib/pathfinder/CPathfinder.cpp
@@ -82,9 +82,8 @@ CPathfinder::CPathfinder(CGameState * _gs, std::shared_ptr<PathfinderConfig> con
 
 void CPathfinder::push(CGPathNode * node)
 {
-	if(node && !node->inPQ)
+	if(node && !node->inPQ())
 	{
-		node->inPQ = true;
 		node->pq = &this->pq;
 		auto handle = pq.push(node);
 		node->pqHandle = handle;
@@ -96,7 +95,6 @@ CGPathNode * CPathfinder::topAndPop()
 	auto * node = pq.top();
 
 	pq.pop();
-	node->inPQ = false;
 	node->pq = nullptr;
 	return node;
 }


### PR DESCRIPTION
Similar to other recent PR's, reduced size of pathfinder types that are allocated in massive numbers by client for player hero pathfinder, and in even greater number - by AI:
- AIPathNode: 128 -> 112 bytes
- CGPathNode: 64 -> 56 bytes

Should reduce memory usage a bit, but nothing extreme. I guess we could reduce size a bit further by making int3 use int16_t (so 12 -> 6 bytes size reduction for int3), but needs investigation.