### PR TITLE
Add .directory files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ VCMI_VS11.sdf
 *.ipch
 VCMI_VS11.opensdf
 .DS_Store
+.directory
 CMakeUserPresets.json
 compile_commands.json
 fuzzylite.pc


### PR DESCRIPTION
KDE's file manager Dolphin will create a hidden .directory file in each folder one changes view properties for