### PR TITLE
JsonParser::error(): Don't add trailing newline

### DIFF
--- a/lib/json/JsonParser.cpp
+++ b/lib/json/JsonParser.cpp
@@ -587,7 +587,12 @@ bool JsonParser::error(const std::string & message, bool warning)
 	std::ostringstream stream;
 	std::string type(warning ? " warning: " : " error: ");
 
-	stream << "At line " << lineCount << ", position " << pos - lineStart << type << message << "\n";
+	if(errors != "")
+	{
+		// only add the line breaks between error messages so we don't have a trailing line break
+		stream << "\n";
+	}
+	stream << "At line " << lineCount << ", position " << pos - lineStart << type << message;
 	errors += stream.str();
 
 	return warning;

--- a/lib/json/JsonParser.cpp
+++ b/lib/json/JsonParser.cpp
@@ -587,7 +587,7 @@ bool JsonParser::error(const std::string & message, bool warning)
 	std::ostringstream stream;
 	std::string type(warning ? " warning: " : " error: ");
 
-	if(errors != "")
+	if(!errors.empty())
 	{
 		// only add the line breaks between error messages so we don't have a trailing line break
 		stream << "\n";


### PR DESCRIPTION
Before:
```
alexander@PC:~/Technik/Development/vcmi/build/bin> ./vcmilauncher
Loading translation 'english.qm'
Failed to install translator
File <unknown> is not a valid JSON file!
At line 33, position 1 warning: Comma expected!

alexander@PC:~/Technik/Development/vcmi/build/bin>
```

After:
```
alexander@PC:~/Technik/Development/vcmi/build/bin> ./vcmilauncher
Loading translation 'english.qm'
Failed to install translator
File <unknown> is not a valid JSON file!
At line 33, position 1 warning: Comma expected!
alexander@PC:~/Technik/Development/vcmi/build/bin>
```