### PR TITLE
Video playback fixes

### DIFF
--- a/client/battle/BattleInterfaceClasses.cpp
+++ b/client/battle/BattleInterfaceClasses.cpp
@@ -741,7 +741,7 @@ BattleResultResources BattleResultWindow::getResources(const BattleResult & br)
 		else
 		{
 			resources.musicName = AudioPath::builtin("Music/Win Battle");
-			resources.prologueVideo = VideoPath();
+			resources.prologueVideo = VideoPath::builtin("WIN3.BIK");
 			resources.loopedVideo = VideoPath::builtin("WIN3.BIK");
 		}
 

--- a/client/media/CVideoHandler.cpp
+++ b/client/media/CVideoHandler.cpp
@@ -494,7 +494,11 @@ std::pair<std::unique_ptr<ui8 []>, si64> CAudioInstance::extractAudio(const Vide
 	if (!openInput(videoToOpen))
 		return { nullptr, 0};
 	openContext();
-	openCodec(findAudioStream());
+
+	int audioStreamIndex = findAudioStream();
+	if (audioStreamIndex == -1)
+		return { nullptr, 0};
+	openCodec(audioStreamIndex);
 
 	const auto * codecpar = getCodecParameters();
 

--- a/client/media/CVideoHandler.cpp
+++ b/client/media/CVideoHandler.cpp
@@ -551,7 +551,7 @@ std::pair<std::unique_ptr<ui8 []>, si64> CAudioInstance::extractAudio(const Vide
 		ui16 NumOfChan = 2;
 		ui32 SamplesPerSec = 22050;
 		ui32 bytesPerSec = 22050 * 2;
-		ui16 blockAlign = 2;
+		ui16 blockAlign = 1;
 		ui16 bitsPerSample = 32;
 		ui8 Subchunk2ID[4] = {'d', 'a', 't', 'a'};
 		ui32 Subchunk2Size;

--- a/client/media/CVideoHandler.cpp
+++ b/client/media/CVideoHandler.cpp
@@ -586,7 +586,7 @@ bool CVideoPlayer::openAndPlayVideoImpl(const VideoPath & name, const Point & po
 		return true;
 
 	instance.openVideo();
-	instance.prepareOutput(scale, useOverlay);
+	instance.prepareOutput(scale, true);
 
 	auto lastTimePoint = boost::chrono::steady_clock::now();
 
@@ -608,10 +608,7 @@ bool CVideoPlayer::openAndPlayVideoImpl(const VideoPath & name, const Point & po
 		rect.w = instance.dimensions.x;
 		rect.h = instance.dimensions.y;
 
-		if(useOverlay)
-			SDL_RenderFillRect(mainRenderer, &rect);
-		else
-			SDL_RenderClear(mainRenderer);
+		SDL_RenderFillRect(mainRenderer, &rect);
 
 		if(instance.textureYUV)
 			SDL_RenderCopy(mainRenderer, instance.textureYUV, nullptr, &rect);

--- a/client/media/CVideoHandler.cpp
+++ b/client/media/CVideoHandler.cpp
@@ -627,7 +627,6 @@ bool CVideoPlayer::openAndPlayVideoImpl(const VideoPath & name, const Point & po
 		auto timePointAfterPresent = boost::chrono::steady_clock::now();
 		auto timeSpentBusy = boost::chrono::duration_cast<boost::chrono::milliseconds>(timePointAfterPresent - lastTimePoint);
 
-		logGlobal->info("Sleeping for %d", (targetFrameTime - timeSpentBusy).count());
 		if(targetFrameTime > timeSpentBusy)
 			boost::this_thread::sleep_for(targetFrameTime - timeSpentBusy);
 


### PR DESCRIPTION
Fixes for regressions / missing pieces from my previous PR.

Changes:
- Fix crash on attempt to play audio from a file that has no audio streams
  - Fixes #4159
- Fix playback of 8-bit audio formats
    - Fixes #4160
- Remove debug logging
- Fixed missing video on battle win
- Fix spellbook page flip animation