### PR TITLE
fix headings of md files

### DIFF
--- a/docs/developers/AI.md
+++ b/docs/developers/AI.md
@@ -1,3 +1,5 @@
+# AI
+
 There are two types of AI: adventure and battle.
 
 **Adventure AIs** are responsible for moving heroes across the map and developing towns  
@@ -15,7 +17,7 @@ When you call unit->getAttack() it summarizes all these bonuses and returns the 
 
 One important class is HypotheticBattle. It is used to evaluate the effects of an action without changing the actual gamestate. It is a wrapper around CPlayerSpecificCallback or another HypotheticBattle so it can provide you data, Internally it has a set of modified unit states and intercepts some calls to underlying callback and returns these internal states instead. These states in turn are wrappers around original units and contain modified bonuses (CStackWithBonuses). So if you need to emulate an attack you can call hypotheticbattle.getforupdate() and it will return the CStackWithBonuses which you can safely change.  
 
-# BattleAI  
+## BattleAI  
 
 BattleAI's most important classes are the following:
 
@@ -31,11 +33,11 @@ BattleAI's most important classes are the following:
 
 BattleAI itself handles all the rest and issues actual commands
 
-# Nullkiller AI
+## Nullkiller AI
 
 Adventure AI responsible for moving heroes on map, gathering things, developing town. Main idea is to gather all possible tasks on map, prioritize them and select the best one for each heroes. Initially was a fork of VCAI
 
-## Parts
+### Parts
 Gateway - a callback for server used to invoke AI actions when server thinks it is time to do something. Through this callback AI is informed about various events like hero level up, tile revialed, blocking dialogs and so on. In order to do this Gaateway implements specific interface. The interface is exactly the same for human and AI
 Another important actor for server interaction is CCallback * cb. This one is used to retrieve gamestate information and ask server to do things like hero moving, spell casting and so on. Each AI has own instance of Gateway and it is a root object which holds all AI state. Gateway has an event method yourTurn which invokes makeTurn in another thread. The last passes control to Nullkiller engine.
 
@@ -58,7 +60,7 @@ Analyzer - a module gathering data from CCallback *. Its goal to make some stati
 * FuzzyEngines - looks like some legacy from VCAI
 * PriorityEvaluator - gathers information on task rewards, evaluates their priority using Fuzzy Light library (fuzzy logic)
 
-## Goals
+### Goals
 Units of activity in AI. Can be AbstractGoal, Task, Marker and Behavior
 
 Task - simple thing which can be done right away in order to gain some reward. Or a composition of simple things in case if more than one action is needed to gain the reward.

--- a/docs/developers/Bonus_System.md
+++ b/docs/developers/Bonus_System.md
@@ -1,3 +1,5 @@
+# Bonus System
+
 The bonus system of VCMI is a set of mechanisms that make handling of different bonuses for heroes, towns, players and units easier. The system consists of a set of nodes representing objects that can be a source or a subject of a bonus and two directed acyclic graphs (DAGs) representing inheritance and propagation of bonuses. Core of bonus system is defined in HeroBonus.h file.
 
 ## Propagation and inheritance

--- a/docs/developers/Building_Android.md
+++ b/docs/developers/Building_Android.md
@@ -1,3 +1,5 @@
+# Building Android
+
 The following instructions apply to **v1.2 and later**. For earlier versions the best documentation is https://github.com/vcmi/vcmi-android/blob/master/building.txt (and reading scripts in that repo), however very limited to no support will be provided from our side if you wish to go down that rabbit hole.
 
 *Note*: building has been tested only on Linux and macOS. It may or may not work on Windows out of the box.

--- a/docs/developers/Building_Linux.md
+++ b/docs/developers/Building_Linux.md
@@ -1,13 +1,15 @@
-# Compiling VCMI
+# Building Linux
+
+## Compiling VCMI
 
 - Current baseline requirement for building is Ubuntu 20.04
 - Supported C++ compilers for UNIX-like systems are GCC 9+ and Clang 13+
 
 Older distributions and compilers might work, but they aren't tested by Github CI (Actions)
 
-# Installing dependencies
+## Installing dependencies
 
-## Prerequisites
+### Prerequisites
 
 To compile, the following packages (and their development counterparts) are needed to build:
 
@@ -21,7 +23,7 @@ To compile, the following packages (and their development counterparts) are need
     - if you want to build scripting modules: LuaJIT
     - to speed up recompilation: Ccache
 
-## On Debian-based systems (e.g. Ubuntu)
+### On Debian-based systems (e.g. Ubuntu)
 
 For Ubuntu and Debian you need to install this list of packages:
 
@@ -31,13 +33,13 @@ Alternatively if you have VCMI installed from repository or PPA you can use:
 
 `sudo apt-get build-dep vcmi`
 
-## On RPM-based distributions (e.g. Fedora)
+### On RPM-based distributions (e.g. Fedora)
 
 `sudo yum install cmake gcc-c++ SDL2-devel SDL2_image-devel SDL2_ttf-devel SDL2_mixer-devel boost boost-devel boost-filesystem boost-system boost-thread boost-program-options boost-locale boost-iostreams zlib-devel ffmpeg-devel ffmpeg-libs qt5-qtbase-devel tbb-devel luajit-devel liblzma-devel libsqlite3-devel fuzzylite-devel ccache`
 
 NOTE: `fuzzylite-devel` package is no longer available in recent version of Fedora, for example Fedora 38. It's not a blocker because VCMI bundles fuzzylite lib in its source code.
 
-## On Arch-based distributions
+### On Arch-based distributions
 
 On Arch-based distributions, there is a development package available for VCMI on the AUR.
 
@@ -45,7 +47,7 @@ It can be found at: <https://aur.archlinux.org/packages/vcmi-git/>
 
 Information about building packages from the Arch User Repository (AUR) can be found at the Arch wiki.
 
-# Getting the sources
+## Getting the sources
 
 We recommend the following directory structure:
 
@@ -59,35 +61,35 @@ You can get latest sources with:
 
 `git clone -b develop --recursive https://github.com/vcmi/vcmi.git`
 
-# Compilation
+## Compilation
 
-## Configuring Makefiles
+### Configuring Makefiles
 
 ```sh
 mkdir build && cd build
 cmake -S ../vcmi
 ```
 
-# Additional options that you may want to use:
+## Additional options that you may want to use:
 
-## To enable debugging:
+### To enable debugging:
 `cmake -S ../vcmi -D CMAKE_BUILD_TYPE=Debug`
 
 **Notice**: The ../vcmi/ is not a typo, it will place makefile scripts into the build dir as the build dir is your working dir when calling CMake.
 
-## To use ccache:
+### To use ccache:
 `cmake -S ../vcmi -D ENABLE_CCACHE:BOOL=ON`
 
-## Trigger build
+### Trigger build
 
 `cmake --build . -- -j2`
 (-j2 = compile with 2 threads, you can specify any value)
 
 That will generate vcmiclient, vcmiserver, vcmilauncher as well as .so libraries in the **build/bin/** directory.
 
-# Package building
+## Package building
 
-## RPM package
+### RPM package
 
 The first step is to prepare a RPM build environment. On Fedora systems you can follow this guide: http://fedoraproject.org/wiki/How_to_create_an_RPM_package#SPEC_file_overview
 
@@ -136,7 +138,7 @@ For other distributions that uses RPM, chances are there might be a spec file fo
 
 Available root environments and their names are listed in /etc/mock.
 
-## Debian/Ubuntu
+### Debian/Ubuntu
 
 1. Install debhelper and devscripts packages
 

--- a/docs/developers/Building_Windows.md
+++ b/docs/developers/Building_Windows.md
@@ -1,7 +1,9 @@
-# Preparations
+# Building Windows
+
+## Preparations
 Windows builds can be made in more than one way and with more than one tool. This guide focuses on the simplest building process using Microsoft Visual Studio 2022
 
-# Prerequisites
+## Prerequisites
 
 - Windows Vista or newer.
 - [Microsoft Visual Studio](https://visualstudio.microsoft.com/downloads/)
@@ -12,7 +14,7 @@ Windows builds can be made in more than one way and with more than one tool. Thi
     - To create installer: [NSIS](http://nsis.sourceforge.net/Main_Page)
     - To speed up recompilation: [CCache](https://github.com/ccache/ccache/releases)
 
-## Choose an installation directory
+### Choose an installation directory
 
 Create a directory for VCMI development, eg. `C:\VCMI` We will call this directory `%VCMI_DIR%`
 
@@ -27,13 +29,13 @@ Bad locations:
 - `C:\Users\Michał\VCMI (non-ascii character)`
 - `C:\Program Files (x86)\VCMI (write protection)`
 
-# Install VCMI dependencies
+## Install VCMI dependencies
 
 You have two options: to use pre-built libraries or build your own. We strongly recommend start with using pre-built ones.
 
-## Option A. Use pre-built Vcpkg
+### Option A. Use pre-built Vcpkg
 
-### Download and unpack archive
+#### Download and unpack archive
 
 Vcpkg Archives are available at our GitHub: https://github.com/vcmi/vcmi-deps-windows/releases
 
@@ -41,18 +43,18 @@ Vcpkg Archives are available at our GitHub: https://github.com/vcmi/vcmi-deps-wi
 EG: v1.6 assets - [vcpkg-export-x64-windows-v143.7z](https://github.com/vcmi/vcmi-deps-windows/releases/download/v1.6/vcpkg-export-x64-windows-v143.7z)  
 - Extract archive by right clicking on it and choosing "7-zip -> Extract Here".
 
-### Move dependencies to target directory
+#### Move dependencies to target directory
 Once extracted, a `vcpkg` directory will appear with `installed` and `scripts` subfolders inside.
 Move extracted `vcpkg` directory into your `%VCMI_DIR%`
 
-## Option B. Build Vcpkg on your own
+### Option B. Build Vcpkg on your own
 
 Please be aware that if you're running 32-bit Windows version, then this is impossible due to <https://github.com/microsoft/vcpkg/issues/26036>
 Be aware that building Vcpkg might take a lot of time depend on your CPU model and 10-20GB of disk space.
 
-### Create initial directory
+#### Create initial directory
 
-### Clone vcpkg
+#### Clone vcpkg
 
 1.  open SourceTree
 2.  File -\> Clone
@@ -64,7 +66,7 @@ From command line use:
 
     git clone https://github.com/microsoft/vcpkg.git %VCMI_DIR%/vcpkg
 
-### Build vcpkg and dependencies
+#### Build vcpkg and dependencies
 
 - Run 
 `%VCMI_DIR%/vcpkg/bootstrap-vcpkg.bat`
@@ -75,11 +77,11 @@ From command line use:
 
 For the list of the packages used you can also consult [vcmi-deps-windows readme](https://github.com/vcmi/vcmi-deps-windows) in case this article gets outdated a bit.
 
-# Install CCache
+## Install CCache
 
 Extract `ccache` to a folder of your choosing, add the folder to the `PATH` environment variable and log out and back in.
 
-# Build VCMI
+## Build VCMI
 
 #### From GIT GUI
 - Open SourceTree
@@ -93,13 +95,13 @@ Extract `ccache` to a folder of your choosing, add the folder to the `PATH` envi
 #### From command line  
 - `git clone --recursive https://github.com/vcmi/vcmi.git %VCMI_DIR%/source`  
 
-## Generate solution for VCMI  
+### Generate solution for VCMI  
 - Create `%VCMI_DIR%/build` folder  
 - Open a command line prompt at `%VCMI_DIR%/build`  
 - Execute `cd %VCMI_DIR%/build`    
 - Create solution (Visual Studio 2022 64-bit) `cmake %VCMI_DIR%/source -DCMAKE_TOOLCHAIN_FILE=%VCMI_DIR%/vcpkg/scripts/buildsystems/vcpkg.cmake -G "Visual Studio 17 2022" -A x64`
 
-## Compile VCMI with Visual Studio
+### Compile VCMI with Visual Studio
 - Open `%VCMI_DIR%/build/VCMI.sln` in Visual Studio
 - Select `Release` build type in the combobox
 - If you want to use ccache:
@@ -109,7 +111,7 @@ Extract `ccache` to a folder of your choosing, add the folder to the `PATH` envi
 - Right click on `BUILD_ALL` project. This `BUILD_ALL` project should be in `CMakePredefinedTargets` tree in Solution Explorer.
 - VCMI will be built in `%VCMI_DIR%/build/bin` folder!
 
-## Compile VCMI with MinGW via MSYS2
+### Compile VCMI with MinGW via MSYS2
 - Install MSYS2 from https://www.msys2.org/
 - Start the `MSYS MinGW x64`-shell
 - Install dependencies: `pacman -S mingw-w64-x86_64-SDL2 mingw-w64-x86_64-SDL2_image mingw-w64-x86_64-SDL2_mixer mingw-w64-x86_64-SDL2_ttf mingw-w64-x86_64-boost mingw-w64-x86_64-gcc mingw-w64-x86_64-ninja mingw-w64-x86_64-qt5-static`
@@ -117,7 +119,7 @@ Extract `ccache` to a folder of your choosing, add the folder to the `PATH` envi
 
 **NOTE:** This will link Qt5 statically to `VCMI_launcher.exe` and `VCMI_Mapeditor.exe`. See [PR #3421](https://github.com/vcmi/vcmi/pull/3421) for some background.
 
-# Create VCMI installer (This step is not required for just building & development)
+## Create VCMI installer (This step is not required for just building & development)
 
 Make sure NSIS is installed to default directory or have registry entry so CMake can find it.
 After you build VCMI execute following commands from `%VCMI_DIR%/build`.
@@ -125,7 +127,7 @@ After you build VCMI execute following commands from `%VCMI_DIR%/build`.
 - for release build: `cpack`
 - for debug build: `cpack -C Debug`
 
-# Troubleshooting and workarounds
+## Troubleshooting and workarounds
 
 Vcpkg might be very unstable due to limited popularity and fact of using bleeding edge packages (such as most recent Boost). Using latest version of dependencies could also expose both problems in VCMI code or library interface changes that developers not checked yet. So if you're built Vcpkg yourself and can't get it working please try to use binary package.
 

--- a/docs/developers/Building_iOS.md
+++ b/docs/developers/Building_iOS.md
@@ -1,3 +1,5 @@
+# Building iOS
+
 ## Requirements
 
 1. **macOS**

--- a/docs/developers/Building_macOS.md
+++ b/docs/developers/Building_macOS.md
@@ -1,3 +1,5 @@
+# Building macOS
+
 ## Requirements
 
 1. C++ toolchain, either of:

--- a/docs/developers/Code_Structure.md
+++ b/docs/developers/Code_Structure.md
@@ -1,6 +1,8 @@
+# Code Structure
+
 The code of VCMI is divided into several main parts: client, server, lib and AIs, each one in a separate binary file.
 
-# The big picture
+## The big picture
 
 VCMI contains three core projects: VCMI_lib (dll / so), VCMI_client (executable) and VCMI_server (executable). Server handles all game mechanics and events. Client presents game state and events to player and collects input from him.
 
@@ -8,37 +10,37 @@ During the game, we have one (and only one) server and one or more (one for each
 
 Important: State of the game and its mechanics are synchronized between clients and server. All changes to the game state or mechanics must be done by server which will send appropriate notices to clients.
 
-## Game state
+### Game state
 
 It's basically CGameState class object and everything that's accessible from it: map (with objects), player statuses, game options, etc.
 
-## Bonus system
+### Bonus system
 
 One of the more important pieces of VCMI is the [bonus system](Bonus_System.md). It's described in a separate article.
 
-## Configuration
+### Configuration
 
 Most of VCMI configuration files uses Json format and located in "config" directory
 
-### Json parser and writer
+#### Json parser and writer
 
-# Client
+## Client
 
-## Main purposes of client
+### Main purposes of client
 
 Client is responsible for:
 -   displaying state of game to human player
 -   capturing player's actions and sending requests to server
 -   displaying changes in state of game indicated by server
 
-## Rendering of graphics
+### Rendering of graphics
 
 Rendering of graphics relies heavily on SDL. Currently we do not have any wrapper for SDL internal structures and most of rendering is about blitting surfaces using SDL_BlitSurface. We have a few function that make rendering easier or make specific parts of rendering (like printing text). They are places in client/SDL_Extensions and client/SDL_Framerate (the second one contains code responsible for keeping appropriate framerate, it should work more smart than just SDL_Delay(milliseconds)).
 In rendering, Interface object system is quite helpful. Its base is CIntObject class that is basically a base class for our library of GUI components and other objects.
 
-# Server
+## Server
 
-## Main purposes of server
+### Main purposes of server
 
 Server is responsible for:
 
@@ -47,9 +49,9 @@ Server is responsible for:
 -   informing all clients about changes in state of the game that are
     visible to them
 
-# Lib
+## Lib
 
-## Main purposes of lib
+### Main purposes of lib
 
 VCMI_Lib is a library that contains code common to server and client, so we avoid it's duplication. Important: the library code is common for client and server and used by them, but the library instance (in opposition to the library as file) is not shared by them! Both client and server create their own "copies" of lib with all its class instances.
 
@@ -63,16 +65,16 @@ Lib contains code responsible for:
 -   handling general game mechanics and related actions (only adventure map objects; it's an unwanted remnant of past development - all game mechanics should be handled by the server)
 -   networking and serialization
 
-### Serialization
+#### Serialization
 
 The serialization framework can serialize basic types, several standard containers among smart pointers and custom objects. Its design is based on the [boost serialization libraries](http://www.boost.org/doc/libs/1_52_0/libs/serialization/doc/index.html).
 In addition to the basic functionality it provides light-weight transfer of CGObjectInstance objects by sending only the index/id.
 
 Serialization page for all the details.
 
-### Wrapped namespace examples
+#### Wrapped namespace examples
 
-#### Inside the lib
+##### Inside the lib
 
 Both header and implementation of a new class inside the lib should have the following structure:
 
@@ -81,7 +83,7 @@ Both header and implementation of a new class inside the lib should have the fol
 `<code>`  
 `VCMI_LIB_NAMESPACE_END`
 
-#### Headers outside the lib
+##### Headers outside the lib
 
 Forward declarations of the lib in headers of other parts of the project need to be wrapped in the macros:
 
@@ -93,30 +95,30 @@ Forward declarations of the lib in headers of other parts of the project need to
 `<classes>`
 
 
-#### New project part
+##### New project part
 
 If you're creating new project part, place `VCMI_LIB_USING_NAMESPACE` in its `StdInc.h` to be able to use lib classes without explicit namespace in implementation files. Example: <https://github.com/vcmi/vcmi/blob/develop/launcher/StdInc.h>
 
-# Artificial Intelligence
+## Artificial Intelligence
 
-## StupidAI
+### StupidAI
 
 Stupid AI is recent and used battle AI.
 
-## Adventure AI
+### Adventure AI
 
 VCAI module is currently developed agent-based system driven by goals and heroes.
 
-## Programming challenge
+### Programming challenge
 
-## Fuzzy logic
+### Fuzzy logic
 
 VCMI includes [FuzzyLite](http://code.google.com/p/fuzzy-lite/) library to make use of fuzzy rule-based algorithms. They are useful to handle uncertainty and resemble human behaviour who takes decisions based on rough observations. FuzzyLite is linked as separate static library in AI/FuzzyLite.lib file.
 
-# Utilities
+## Utilities
 
-## Launcher
+### Launcher
 
-## Duels
+### Duels
 
-## ERM parser
+### ERM parser

--- a/docs/developers/Coding_Guidelines.md
+++ b/docs/developers/Coding_Guidelines.md
@@ -1,3 +1,5 @@
+# Coding Guidelines
+
 ## C++ Standard
 
 VCMI implementation bases on C++17 standard. Any feature is acceptable as long as it's will pass build on our CI, but there is list below on what is already being used.

--- a/docs/developers/Conan.md
+++ b/docs/developers/Conan.md
@@ -1,4 +1,4 @@
-# Using dependencies from Conan
+# Conan Dependencies
 
 [Conan](https://conan.io/) is a package manager for C/C++. We provide prebuilt binary dependencies for some platforms that are used by our CI, but they can also be consumed by users to build VCMI. However, it's not required to use only the prebuilt binaries: you can build them from source as well.
 

--- a/docs/developers/Development_with_Qt_Creator.md
+++ b/docs/developers/Development_with_Qt_Creator.md
@@ -1,4 +1,4 @@
-# Introduction to Qt Creator
+# Development with Qt Creator
 
 Qt Creator is the recommended IDE for VCMI development on Linux distributions, but it may be used on other operating systems as well. It has the following advantages compared to other IDEs:
 

--- a/docs/developers/Logging_API.md
+++ b/docs/developers/Logging_API.md
@@ -1,4 +1,6 @@
-# Features
+# Logging API
+
+## Features
 
 -   A logger belongs to a "domain", this enables us to change log level settings more selectively
 -   The log format can be customized
@@ -9,7 +11,7 @@
 -   Macros for tracing the application flow
 -   Provides stream-like and function-like logging
 
-# Class diagram
+## Class diagram
 
 ![Logging_Class_Diagram](https://github.com/IvanSavenko/vcmi/assets/1576820/31c9b14e-a055-4b07-87fe-00da43430a2b)
 
@@ -18,9 +20,9 @@ Some notes:
 -   There are two methods `configure` and `configureDefault` of the class `CBasicLogConfigurator` to initialize and setup the logging system. The latter one setups default logging and isn't dependent on VCMI's filesystem, whereas the first one setups logging based on the user's settings which can be configured in the settings.json.
 -   The methods `isDebugEnabled` and `isTraceEnabled` return true if a log record of level debug respectively trace will be logged. This can be useful if composing the log message is a expensive task and performance is important.
 
-# Usage
+## Usage
 
-## Setup settings.json
+### Setup settings.json
 
 ``` javascript
 {
@@ -51,7 +53,7 @@ Some notes:
 
 The above code is an example on how to configure logging. It sets the log level to debug globally and the log level of the domain ai to trace. In addition, it tells the console to log debug messages as well with the threshold attribute. Finally, it configures the console so that it logs network trace messages in magenta.
 
-## Configuration
+### Configuration
 
 The following code shows how the logging system can be configured:
 
@@ -82,14 +84,14 @@ Format: %d %l %n \[%t\] - %m
 
 global -\> info
 
-## How to get a logger
+### How to get a logger
 
 There exist only one logger object per domain. A logger object cannot be copied. You can get access to a logger object by using the globally defined ones like `logGlobal` or `logAi`, etc... or by getting one manually:
 ```cpp
 Logger * logger = CLogger::getLogger(CLoggerDomain("rmg"));
 ```
 
-## Logging
+### Logging
 
 Logging can be done via two ways, stream-like or function-like.
 
@@ -119,7 +121,7 @@ The following colors are available for console output:
 -   gray
 -   teal
 
-## How to trace execution
+### How to trace execution
 
 The program execution can be traced by using the macros TRACE_BEGIN, TRACE_END and their \_PARAMS counterparts. This can be important if you want to analyze the operations/internal workings of the AI or the communication of the client-server. In addition, it can help you to find bugs on a foreign VCMI installation with a custom mod configuration.
 
@@ -135,9 +137,9 @@ The program execution can be traced by using the macros TRACE_BEGIN, TRACE_END a
     }
 ```
 
-# Concepts
+## Concepts
 
-## Domain
+### Domain
 
 A domain is a specific part of the software. In VCMI there exist several domains:
 

--- a/docs/developers/Lua_Scripting_System.md
+++ b/docs/developers/Lua_Scripting_System.md
@@ -1,4 +1,6 @@
-# Configuration
+# Lua Scripting System
+
+## Configuration
 
 ``` javascript
 {
@@ -32,13 +34,13 @@
 }
 ```
 
-# Lua
+## Lua
 
-## API Reference
+### API Reference
 
 TODO **In near future Lua API may change drastically several times. Information here may be outdated**
 
-### Globals
+#### Globals
 
 - DATA - persistent table
 - - DATA.ERM contains ERM state, anything else is free to use.
@@ -61,7 +63,7 @@ TODO **In near future Lua API may change drastically several times. Information 
 - -TODO require(":relative.path.to.module") - loads module from same mod
 - logError(text) - backup error log function
 
-### Low level events API
+#### Low level events API
 
 ``` Lua
 
@@ -79,7 +81,7 @@ sub2 = 	PlayerGotTurn.subscribeBefore(EVENT_BUS, function(event)
 	end)
 ```
 
-### Lua standard library
+#### Lua standard library
 
 VCMI uses LuaJIT, which is Lua 5.1 API, see [upstream documentation](https://www.lua.org/manual/5.1/manual.html)
 
@@ -91,19 +93,19 @@ Following libraries are supported
 -   math
 -   bit
 
-# ERM
+## ERM
 
-## Features
+### Features
 
 -   no strict limit on function/variable numbers (technical limit 32 bit integer except 0))
 -   TODO semi compare
 -   DONE macros
 
-## Bugs
+### Bugs
 
 -   TODO Broken XOR support (clashes with \`X\` option)
 
-## Triggers
+### Triggers
 
 -   TODO **!?AE** Equip/Unequip artifact
 -   WIP **!?BA** when any battle occurs
@@ -134,22 +136,22 @@ Following libraries are supported
 -   TODO **!?TL** Real-Time Timer
 -   TODO **!?TM** timed events
 
-## Receivers
+### Receivers
 
-### VCMI
+#### VCMI
 
 -   **!!MC:S@varName@** - declare new "normal" variable (technically
     v-var with string key)
 -   TODO Identifier resolver
 -   WIP Bonus system
 
-### ERA
+#### ERA
 
 -   DONE !!if !!el !!en
 -   TODO !!br !!co
 -   TODO !!SN:X
 
-### WoG
+#### WoG
 
 - TODO !!AR Артефакт (ресурс) в определенной позиции
 - TODO !!BA Битва
@@ -199,4 +201,4 @@ Following libraries are supported
 - *!#VC Контроль переменных*
 - WIP !!VR Установка переменных
 
-## Persistence
+### Persistence

--- a/docs/developers/Networking.md
+++ b/docs/developers/Networking.md
@@ -1,4 +1,6 @@
-# The big picture
+# Networking
+
+## The big picture
 
 For implementation details see files located at `lib/network` directory.
 
@@ -19,11 +21,11 @@ Following connections can be established during game lifetime:
 - game client -> lobby server: This connection is used to access global lobby, for multiplayer over Internet. Created when player logs into a lobby (Multiplayer -> Connect to global service)
 - match server -> lobby server: This connection is established when player creates new multiplayer room via lobby. It is used by lobby server to send commands to match server
 
-# Gameplay communication
+## Gameplay communication
 
 For gameplay, VCMI serializes data into a binary stream. See [Serialization](Serialization.md) for more information.
 
-# Global lobby communication
+## Global lobby communication
 
 For implementation details see:
 - game client: `client/globalLobby/GlobalLobbyClient.h
@@ -38,29 +40,29 @@ char jsonString[messageSize];
 
 Every message must be a struct (json object) that contains "type" field. Unlike rest of VCMI codebase, this message is validated as strict json, without any extensions, such as comments.
 
-## Communication flow
+### Communication flow
 
 Notes:
 - invalid message, such as corrupted json format or failure to validate message will result in no reply from server
 - in addition to specified messages, match server will send `operationFailed` message on failure to apply player request
 
-### New Account Creation
+#### New Account Creation
 
 - client -> lobby: `clientRegister`
 - lobby -> client: `accountCreated`
 
-### Login 
+#### Login 
 - client -> lobby: `clientLogin`
 - lobby -> client: `loginSuccess`
 - lobby -> client: `chatHistory`
 - lobby -> client: `activeAccounts`
 - lobby -> client: `activeGameRooms`
 
-### Chat Message
+#### Chat Message
 - client -> lobby: `sendChatMessage`
 - lobby -> every client: `chatMessage`
 
-### New Game Room
+#### New Game Room
 - client starts match server instance
 - match -> lobby: `serverLogin`
 - lobby -> match: `loginSuccess`
@@ -70,24 +72,24 @@ Notes:
 - lobby -> every client: `activeAccounts`
 - lobby -> every client: `activeGameRooms`
 
-### Joining a game room
+#### Joining a game room
 See [#Proxy mode](proxy-mode)
 
-### Leaving a game room
+#### Leaving a game room
 - client closes connection to match server
 - match -> lobby: `leaveGameRoom`
 
-### Sending an invite:
+#### Sending an invite:
 - client -> lobby: `sendInvite`
 - lobby -> target client: `inviteReceived`
 
 Note: there is no dedicated procedure to accept an invite. Instead, invited player will use same flow as when joining public game room
 
-### Logout
+#### Logout
 - client closes connection
 - lobby -> every client: `activeAccounts`
 
-## Proxy mode
+### Proxy mode
 
 In order to connect players located behind NAT, VCMI lobby can operate in "proxy" mode. In this mode, connection will be act as proxy and will transmit gameplay data from client to a match server, without any data processing on lobby server.
 

--- a/docs/developers/RMG_Description.md
+++ b/docs/developers/RMG_Description.md
@@ -1,46 +1,48 @@
-# Fundamentals
+# RMG Description
+
+## Fundamentals
 
 Random maps are represented by undirected graph of zones linked with connections.
 
 On maps with water, a single extra water zone is created.
 
-## Modifiers
+### Modifiers
 
 Zone filling process is split into multiple phases, each of them represented as a modifier. A modifier can require other modifiers to finish their job before launching. A modifier might be preceded by other modifier from every zone, or many modifiers from all zones. For instance, placing underground rock requires all underground zones to finish treasure placement first.
 
-## Thread pool
+### Thread pool
 
 A queue of Modifiers jobs is created in roughly topological order, so that Modificators with no dependencies are placed first. The queue is iterated in a circular manner and if Modificator with no remaining preceders is found, it is picked for execution in a separate thread. After job completion, Modifier is erased from dependencies of Modifiers which depend on it.
 
-# Placing Zones
+## Placing Zones
 
-## Generating distance graph
+### Generating distance graph
 
 Based on zone connections, a simple distance graph is created using Dijkstra algorithm.
 
-## Initial zone placement
+### Initial zone placement
 
 Based on distance graph, zones are placed one by one on N x N grid of size just enough to fit all the zones (for instance, 5 zones are placed on a 3 x 3 grid and 24 zones on 5 x 5 grid). Adjacent zones are placed close while distant zones are placed as far away from each other as possible.
 
-## Iterative optimization
+### Iterative optimization
 
 Finally, zones are moved from their initial positions using Fruchterman-Reingold algorithm. It assumes all the zones are soft spheres, which attract connected zones as springs but push back not overlapping zones crossing their borders. These forces are summend and determine the vector shift of the zone position. The algorithm uses classic "simulated annealing" approach - zones start with high "temperature" (are very soft and squishy) and then gradually become colder (harder) and push away overlapping zones with stronger force.
 
 To prevent getting stuck in local minima, sometimes most misplaced zones swap placed manually.
 
-## Penrose Tiling
+### Penrose Tiling
 
 Using iterative subdivision, a set of Penrose tiling vertices ic created at random orientation and centered over middle of the map. All the tiles on a map are assigned to the closes vertex. Then, every vertex is assigned to the closest zone, creating irregular shapes.
 
-# Zone connections
+## Zone connections
 
 Directly adjacent zones are connected with a guard and a road, and overlapping zones on different levels are connected with Subterranean Gate. Zones which are not directly adjacent might be covered through water zone. If a zone shouldn't be connected with nearby zones adjacent to body of water, it's coast is sealed with obstacles.
 
-## Water routes
+### Water routes
 
 **TODO**
 
-## Fractalization
+### Fractalization
 
 Every zone starts with at least one free tile in the center. Now, from every tiles at a distant greater than some number, a random tile is chosen. From it, algorithm routes a free path connected to already existing free paths. Process is repetaed until no tiles distant from free paths are left. Tiles used for connections are marked `free` and nothing else can be placed on them.
 
@@ -48,28 +50,28 @@ Zones with type `junction` are not fractalized.
 
 The remaining tiles that are not obstacles (such as zone edges) are marked as `possible"` so they can be either filled with treasures or left `free.`
 
-# Treasures
+## Treasures
 
 Every object or treasure pile in the zone is placed as far away from existing objects as possible. This includes towns and zone guards placed first. Zone keeps a priority queue of tiles sorted by their distance to closest object. Whenever an object is placed, these distances are updated.
 
-## Treasure generation
+### Treasure generation
 
 Treasures are separated in value ranges. The highest range is picked first. A large number of treasure piles is generated, then RMG tries to fit each of treasure piles into a zone. Then, lower treasure ranges are generated
 
-## Treasure placement
+### Treasure placement
 
 New treasure pile can't be closer to any previous object than some distance determined by total treasure density and value. Lower value piles and placed with lower minimal distance.
 
 Any new treasure is placed so that it can't join two previously separated blocked islands, to prevent sealing a gap and ensuring entire zone is passable.
 
-# Obstacles
+## Obstacles
 
 After all the treasures are placed, tiles marked as `possible` are iteratively stripped and cleared from lose appendages, leaving `free` space. Then remaining ones are marked as `blocked`, and covered with obstacles.
 
-## Biomes
+### Biomes
 
 For every zone, a few random obstacle sets are selected. [Details](https://github.com/vcmi/vcmi/blob/develop/docs/modders/Entities_Format/Biome_Format.md)
 
-## Filling space
+### Filling space
 
 Tiles which need to be `blocked` but are not `used` are filled with obstacles. Largest obstacles which cover the most tiles are picked first, other than that they are chosen randomly.

--- a/docs/maintainers/Release_Process.md
+++ b/docs/maintainers/Release_Process.md
@@ -1,3 +1,5 @@
+# Release Process
+
 ## Versioning
 For releases VCMI uses version numbering in form "1.X.Y", where:
 - 'X' indicates major release. Different major versions are generally not compatible with each other. Save format is different, network protocol is different, mod format likely different.

--- a/docs/maintainers/Ubuntu_PPA.md
+++ b/docs/maintainers/Ubuntu_PPA.md
@@ -1,3 +1,5 @@
+# Ubuntu PPA
+
 ## Main links
 - [Team](https://launchpad.net/~vcmi)
 - [Project](https://launchpad.net/vcmi)

--- a/docs/modders/Animation_Format.md
+++ b/docs/modders/Animation_Format.md
@@ -1,3 +1,5 @@
+# Animation Format
+
 VCMI allows overriding HoMM3 .def files with .json replacement. Compared to .def this format allows:
 
 -   Overriding individual frames from json file (e.g. icons)

--- a/docs/modders/Bonus/Bonus_Duration_Types.md
+++ b/docs/modders/Bonus/Bonus_Duration_Types.md
@@ -1,3 +1,5 @@
+# Bonus Duration Types
+
 Bonus may have any of these durations. They acts in disjunction.
 
 ## List of all bonus duration types

--- a/docs/modders/Bonus/Bonus_Limiters.md
+++ b/docs/modders/Bonus/Bonus_Limiters.md
@@ -1,3 +1,5 @@
+# Bonus Limiters
+
 ## Predefined Limiters
 
 The limiters take no parameters:

--- a/docs/modders/Bonus/Bonus_Propagators.md
+++ b/docs/modders/Bonus/Bonus_Propagators.md
@@ -1,3 +1,5 @@
+# Bonus Propagators
+
 ## Available propagators
 
 -   BATTLE_WIDE: Affects both sides during battle

--- a/docs/modders/Bonus/Bonus_Range_Types.md
+++ b/docs/modders/Bonus/Bonus_Range_Types.md
@@ -1,3 +1,5 @@
+# Bonus Range Types
+
 ## List of all Bonus range types
 
 - NO_LIMIT

--- a/docs/modders/Bonus/Bonus_Sources.md
+++ b/docs/modders/Bonus/Bonus_Sources.md
@@ -1,3 +1,5 @@
+# Bonus Sources
+
 ## List of all possible bonus sources
 
 - ARTIFACT

--- a/docs/modders/Bonus/Bonus_Types.md
+++ b/docs/modders/Bonus/Bonus_Types.md
@@ -1,3 +1,5 @@
+# Bonus Types
+
 The bonuses were grouped according to their original purpose. The bonus system allows them to propagate freely between the nodes, however they may not be recognized properly beyond the scope of original use.
 
 ## General-purpose bonuses

--- a/docs/modders/Bonus/Bonus_Updaters.md
+++ b/docs/modders/Bonus/Bonus_Updaters.md
@@ -1,3 +1,5 @@
+# Bonus Updaters
+
 TODO: this page may be incorrect or outdated
 
 Updaters come in two forms: simple and complex. Simple updaters take no

--- a/docs/modders/Bonus/Bonus_Value_Types.md
+++ b/docs/modders/Bonus/Bonus_Value_Types.md
@@ -1,3 +1,5 @@
+# Bonus Value Types
+
 Total value of Bonus is calculated using the following:
 
 -   For each bonus source type we calculate new source value (for all bonus value types except PERCENT_TO_SOURCE and PERCENT_TO_TARGET_TYPE) using the following:

--- a/docs/modders/Bonus_Format.md
+++ b/docs/modders/Bonus_Format.md
@@ -1,3 +1,5 @@
+# Bonus Format
+
 ## Full format
 
 All parameters but type are optional.

--- a/docs/modders/Building_Bonuses.md
+++ b/docs/modders/Building_Bonuses.md
@@ -1,9 +1,11 @@
+# Building Bonuses
+
 Work-in-progress page do describe all bonuses provided by town buildings
 for future configuration.
 
 TODO: This page is outdated and may not represent VCMI 1.3 state
 
-## unique buildings
+### unique buildings
 
 Hardcoded functionalities, selectable but not configurable. In future
 should be moved to scripting.
@@ -24,7 +26,7 @@ Function of all of these objects can be enabled by this:
  "function" : "castleGates" 
 ```
 
-## trade-related
+### trade-related
 
 Hardcoded functionality for now due to complexity of these objects.
 Temporary can be handles as unique buildings. Includes:
@@ -37,7 +39,7 @@ Temporary can be handles as unique buildings. Includes:
 -   resource - skills
 -   creature - skeleton
 
-## hero visitables
+### hero visitables
 
 Buildings that give one or another bonus to visiting hero. All should be
 handled via configurable objects system.
@@ -49,76 +51,76 @@ Includes:
 -   give bonus to visitor
 -   permanent bonus to hero
 
-## generic functions
+### generic functions
 
 Generic town-specific functions that can be implemented as part of
 CBuilding class.
 
-### unlock guild level
+#### unlock guild level
 
 ``` javascript
  "guildLevels" : 1 
 ```
 
-### unlock hero recruitment
+#### unlock hero recruitment
 
 ``` javascript
  "allowsHeroPurchase" : true 
 ```
 
-### unlock ship purchase
+#### unlock ship purchase
 
 ``` javascript
  "allowsShipPurchase" : true 
 ```
 
-### unlock building purchase
+#### unlock building purchase
 
 ``` javascript
  "allowsBuildingPurchase" : true 
 ```
 
-### unlocks creatures
+#### unlocks creatures
 
 ``` javascript
  "dwelling" : { "level" : 1, "creature" : "archer" } 
 ```
 
-### creature growth bonus
+#### creature growth bonus
 
 Turn into town bonus? What about creature-specific bonuses from hordes?
 
-### gives resources
+#### gives resources
 
 ``` javascript
  "provides" : { "gold" : 500 } 
 ```
 
-### gives guild spells
+#### gives guild spells
 
 ``` javascript
  "guildSpells" : [5, 0, 0, 0, 0] 
 ```
 
-### gives thieves guild
+#### gives thieves guild
 
 ``` javascript
  "thievesGuildLevels" : 1 
 ```
 
-### gives fortifications
+#### gives fortifications
 
 ``` javascript
  "fortificationLevels" : 1 
 ```
 
-### gives war machine
+#### gives war machine
 
 ``` javascript
  "warMachine" : "ballista" 
 ```
 
-## simple bonuses
+### simple bonuses
 
 Bonuses that can be made part of CBuilding. Note that due to how bonus
 system works this bonuses won't be stackable.
@@ -149,12 +151,12 @@ Includes:
 	}
 ```
 
-## misc
+### misc
 
 Some other properties of town building that does not fall under "bonus"
 category.
 
-### unique building
+#### unique building
 
 Possible issue - with removing of fixed ID's buildings in different town
 may no longer share same ID. However Capitol must be unique across all
@@ -164,7 +166,7 @@ town. Should be fixed somehow.
  "onePerPlayer" : true 
 ```
 
-### chance to be built on start
+#### chance to be built on start
 
 ``` javascript
  "prebuiltChance" : 75 

--- a/docs/modders/Campaign_Format.md
+++ b/docs/modders/Campaign_Format.md
@@ -1,4 +1,6 @@
-# Introduction
+# Campaign Format
+
+## Introduction
 
 Starting from version 1.3, VCMI supports its own campaign format.
 Campaigns have *.vcmp file format and it consists from campaign json and set of scenarios (can be both *.vmap and *.h3m)
@@ -27,7 +29,7 @@ Basic structure of this file is here, each section is described in details below
 
 `"version"` defines version of campaign file. Larger versions should have more features and flexibility, but may not be supported by older VCMI engines. See [compatibility table](#compatibility-table)
 
-# Header properties
+## Header properties
 
 In header are parameters describing campaign properties
 ```js
@@ -51,7 +53,7 @@ In header are parameters describing campaign properties
 - `"creationDateTime"` unix time of campaign creation
 - `"allowDifficultySelection"` is a boolean field (`true`/`false`) which allows or disallows to choose difficulty before scenario start
 
-# Scenario description
+## Scenario description
 
 Scenario description looks like follow:
 ```js
@@ -87,7 +89,7 @@ Scenario description looks like follow:
 - `"playerColor"` defines color id of flag which player will play for. Possible values are `0: red, 1: blue, tan: 2, green: 3, orange: 4, purple: 5, teal: 6, pink: 7`
 - "bonuses" array of possible bonus objects, format depends on `"startOptions"` parameter
 
-## Prolog/Epilog
+### Prolog/Epilog
 
 Prolog and epilog properties are optional
 ```js
@@ -99,13 +101,13 @@ Prolog and epilog properties are optional
 }
 ```
 
-## Start options and bonuses
+### Start options and bonuses
 
-### None start option
+#### None start option
 
 If `startOptions` is `none`, `bonuses` field will be ignored
 
-### Bonus start option
+#### Bonus start option
 
 If `startOptions` is `bonus`, bonus format may vary depending on its type.
 
@@ -148,7 +150,7 @@ If `startOptions` is `bonus`, bonus format may vary depending on its type.
     - `"amount"`: amount of resources
 - `"hero"` can be specified as explicit hero name and as one of keywords: `strongest`, `generated`
 
-### Crossover start option
+#### Crossover start option
 
 If `startOptions` is `crossover`, heroes from specific scenario will be moved to this scenario. Bonus format is following
 
@@ -161,7 +163,7 @@ If `startOptions` is `crossover`, heroes from specific scenario will be moved to
 - `"playerColor"` from what player color heroes shall be taken. Possible values are `0: red, 1: blue, tan: 2, green: 3, orange: 4, purple: 5, teal: 6, pink: 7`
 - `"scenario"` from which scenario heroes shall be taken. 0 means first scenario
 
-### Hero start option
+#### Hero start option
 
 If `startOptions` is `hero`, hero can be chosen as a starting bonus. Bonus format is following
 ```js
@@ -174,7 +176,7 @@ If `startOptions` is `hero`, hero can be chosen as a starting bonus. Bonus forma
 - `"playerColor"` from what player color heroes shall be taken. Possible values are `0: red, 1: blue, tan: 2, green: 3, orange: 4, purple: 5, teal: 6, pink: 7`
 - `"hero"` can be specified as explicit hero name and as one of keywords: `random`
 
-## Regions description
+### Regions description
 
 Predefined campaign regions are located in file `campaign_regions.json`
 
@@ -194,7 +196,7 @@ Predefined campaign regions are located in file `campaign_regions.json`
 - `"inflix"` ised to identify all images related to region. In this example, it will be pictures starting from `G3A_..., G3B_..., G3C_..."` 
 - `"color_suffix_length"` identifies suffix length for region colourful frames. 1 is used for `R, B, N, G, O, V, T, P`, value 2 is used for `Re, Bl, Br, Gr, Or, Vi, Te, Pi`
 
-# Packing campaign
+## Packing campaign
 
 After campaign scenarios and campaign description are ready, you should pack them into *.vcmp file.
 This file is basically headless gz archive.
@@ -216,7 +218,7 @@ gzip -c -n ./* >> my-campaign.vcmp
 
 If you are using Windows system, try this https://gnuwin32.sourceforge.net/packages/gzip.htm
 
-# Compatibility table
+## Compatibility table
 | Version | Min VCMI | Max VCMI | Description |
 |---------|----------|----------|-------------|
 | 1       | 1.3      |          | Initial release |

--- a/docs/modders/Configurable_Widgets.md
+++ b/docs/modders/Configurable_Widgets.md
@@ -1,10 +1,12 @@
-# Introduction
+# Configurable Widgets
+
+## Introduction
 
 VCMI has capabilities to change some UI elements in your mods beyond only replacing one image with another. Not all UI elements are possible to modify currently, but development team is expanding them.
 
 Elements possible to modify are located in `config/widgets`.
 
-# Tutorial
+## Tutorial
 
 Let's take `extendedLobby` mod from `vcmi-extras` as an example for VCMI-1.4. [Example sources](https://github.com/vcmi-mods/vcmi-extras/tree/vcmi-1.4/Mods/extendedLobby).
 
@@ -16,7 +18,7 @@ For options tab it introduces UI for chess timers.
 
 In this tutorial we will recreate options tab to support chess timers UI.
 
-## Creating mod structure
+### Creating mod structure
 
 To start making mod, create following folders structure;
 ```
@@ -44,7 +46,7 @@ File `mod.json` is generic and could look like this:
 
 After that you can copy `extendedLobby/ folder to `mods/` folder and your mod will immediately appear in launcher but it does nothing for now.
 
-## Making layout for timer
+### Making layout for timer
 
 Let's copy `config/widgets/optionsTab.json` file from VCMI folder to `content/config/widgets/` folder from our mod.
 It defines UI for options tab as it designed in original game, we will keep everything related to player settings and will modify only timer area.
@@ -111,7 +113,7 @@ In order to make it work, add file `RmgTTBk.bmp` to `content/sprites/`
 
 Elements named `labelTurnDurationValue` and `sliderTurnDuration` we will keep without change - they are needed to configure classic timer.
 
-## Adding combo box
+### Adding combo box
 
 Now, let's add combo box.
 
@@ -264,7 +266,7 @@ Now specify items inside `dropDown` field
 
 Now we can press drop-down menu and even select elements.
 
-## Switching timer modes
+### Switching timer modes
 
 After view part is done, let's make behavioural part.
 Let's hide elements, related to classic timer when chess timer is selected and show them back if classic selected.
@@ -322,7 +324,7 @@ This background must be visible for chess timer and hidden for classic timer. Ju
 
 It works and can switch elements, the only missing part is chess timer configuration.
 
-## Chess timer configuration
+### Chess timer configuration
 
 We should add text input fields, to specify different timers. We will use background for them `timerField.bmp`, copy it to `content/sprites/` folder of your mod.
 
@@ -352,39 +354,39 @@ And what we want to do is to hide/show those fields when classic/chess times is 
 
 We are done! You can find more information about configurable UI elements in documentation section.
 
-# Documentation
+## Documentation
 
-## Types
+### Types
 
 All fields have format `"key": value`
 There are different basic types, which can be used as value.
 
-### Primitive types
+#### Primitive types
 
 Read JSON documentation for primitive types description: https://www.json.org/json-en.html
 
-### Text
+#### Text
 
 Load predefined text which can be localised, examples:
 `"vcmi.otherOptions.availableCreaturesAsDwellingLabel"`
 `"core.genrltxt.738"`
 
-### Position
+#### Position
 
 Point with two coordinates, example:
 `{ "x": 43, "y": -28 }`
 
-### Rect
+#### Rect
 
 Rectangle ares, example:
 `{ "x": 28, "y": 220, "w": 108, "h": 50 }`
 
-### Text alignment
+#### Text alignment
 
 Defines text alignment, can be one of values:
 `"center"`, `"left"`, `"right"`
 
-### Color
+#### Color
 
 Predefined colors:
 `"yellow"`, `"white"`, `"gold"`, `"green"`, `"orange"`, `"bright-yellow"`
@@ -392,12 +394,12 @@ Predefined colors:
 To have custom color make an array of four elements in RGBA notation:
 `[255, 128, 0, 255]`
 
-### Font
+#### Font
 
 Predefined fonts:
 `"big"`, `"medium"`, `"small"`, `"tiny"`, `"calisto"`
 
-### Hint text
+#### Hint text
 
 Hint text is a pair of strings, one is usually shown in status bar when cursor hovers element, another hint while right button pressed.
 Each of elements is a [Text](#text)
@@ -413,19 +415,19 @@ If one string specified, it will be applied for both hover and help.
 
 `"text"`
 
-### Shortcut
+#### Shortcut
 
 String value defines shortcut. Some examples of shortcuts:
 `"globalAccept", "globalCancel", "globalReturn","globalFullscreen", "globalOptions", "globalBackspace", "globalMoveFocus"`
 
 Full list is TBD
 
-### [VCMI-1.4] Player color
+#### [VCMI-1.4] Player color
 
 One of predefined values:
 `"red"`, `"blue"`, `"tan"`, `"green"`, `"orange"`, `"purple"`, `"teal"`, `"pink"`
 
-## Configurable objects
+### Configurable objects
 
 Configurable object has following structure:
 ```json
@@ -445,9 +447,9 @@ Configurable object has following structure:
 
 `library` - same as above, but custom widgets are described in separate json, this parameter should contain path to library json is specified
 
-## Basic widgets
+### Basic widgets
 
-### Label
+#### Label
 
 `"type": "label"`
 
@@ -463,7 +465,7 @@ Configurable object has following structure:
 
 `"position"`: [position](#position)
 
-### [VCMI-1.4] Multi-line label
+#### [VCMI-1.4] Multi-line label
 
 `"type": "multiLineLabel"`
 
@@ -483,7 +485,7 @@ Configurable object has following structure:
 
 `"adoptHeight": bool` //if true, text area height will be adopted automatically based on content
 
-### Label group
+#### Label group
 
 `"type": "labelGroup"`
 
@@ -503,7 +505,7 @@ Configurable object has following structure:
 
 `"text"`: [text](#text),
 
-### TextBox
+#### TextBox
 
 `"type": "textBox"`
 
@@ -519,7 +521,7 @@ Configurable object has following structure:
 
 `"rect"`: [rect](#rect)
 
-### Picture
+#### Picture
 
 `"type": "picture"`
 
@@ -533,7 +535,7 @@ Configurable object has following structure:
 
 `"playerColored", bool`, optional, if true will be colorised to current player
 
-### Image
+#### Image
 
 Use to show single frame from animation
 
@@ -549,7 +551,7 @@ Use to show single frame from animation
 
 `"frame": integer` optional, specify animation frame
 
-### Texture
+#### Texture
 
 Filling area with texture
 
@@ -561,7 +563,7 @@ Filling area with texture
 
 `"rect"`: [rect](#rect)
 
-### TransparentFilledRectangle
+#### TransparentFilledRectangle
 
 `"type": "transparentFilledRectangle"`
 
@@ -573,7 +575,7 @@ Filling area with texture
 
 `"rect"`: [rect](#rect)
 
-### Animation
+#### Animation
 
 `"type": "animation"`
 
@@ -599,7 +601,7 @@ Filling area with texture
 
 `"end": integer`, last frame
 
-### [VCMI-1.4] Text input
+#### [VCMI-1.4] Text input
 
 `"type": "textInput"`
 
@@ -625,7 +627,7 @@ Filling area with texture
 
 `"callback": string` optional, callback to be called on text changed. Input text is passed to callback function as an argument.
 
-### Button
+#### Button
 
 `"type": "button"`
 
@@ -647,7 +649,7 @@ Filling area with texture
 
 `"items": []` array of widgets to be shown as overlay (caption [label](#label), for example)
 
-### Toggle button
+#### Toggle button
 
 `"type": "toggleButton"`
 
@@ -667,7 +669,7 @@ Filling area with texture
 
 `"items": []` array of widgets to be shown as overlay (caption [label](#label), for example)
 
-### Toggle group
+#### Toggle group
 
 Group of [toggle buttons](#toggle-button), when one is selected, other will be de-selected
 
@@ -681,7 +683,7 @@ Group of [toggle buttons](#toggle-button), when one is selected, other will be d
 
 `"items": []` array of [toggle buttons](#toggle-button)
 
-### Slider
+#### Slider
 
 `"type": "slider"`
 
@@ -707,7 +709,7 @@ Group of [toggle buttons](#toggle-button), when one is selected, other will be d
 
 `"panningStep": integer`, optional
 
-### Combo box
+#### Combo box
 
 `"type": "comboBox"`
 
@@ -729,7 +731,7 @@ Group of [toggle buttons](#toggle-button), when one is selected, other will be d
 
 `"dropDown" : {}` description of [drop down](#drop-down) menu widget
 
-### Drop down
+#### Drop down
 
 Used only as special object for [combo box](#combo-box)
 
@@ -750,17 +752,17 @@ Used only as special object for [combo box](#combo-box)
 **Callbacks**
  - `sliderMove` connect to slider callback to correctly navigate over elements
 
-### Layout
+#### Layout
 
 `"type": "layout"`
 
 `"name": "string"` optional, object name
 
-## High-level widgets
+### High-level widgets
 
-## Custom widgets
+### Custom widgets
 
-# For developers
+## For developers
 
 While designing a new element, you can make it configurable to reuse all functionality described above. It will provide flexibility to further changes as well as modding capabilities.
 
@@ -798,9 +800,9 @@ MyYesNoDialog::MyYesNoDialog(const JsonNode & config):
 }
 ```
 
-## Callbacks
+### Callbacks
 
-## Custom widgets
+### Custom widgets
 
 You can build custom widgets, related to your UI element specifically. Like in example above, there is Item widget, which can be also used on JSON config.
 
@@ -832,7 +834,7 @@ After that, if your JSON file has items with type "MyItem", the new Item element
 }
 ```
 
-## Variables
+### Variables
 
 After calling `build(config)` variables defined in config JSON file become available. You can interpret them and use in callbacks or in element code
 

--- a/docs/modders/Difficulty.md
+++ b/docs/modders/Difficulty.md
@@ -1,3 +1,5 @@
+# Difficulty
+
 Since VCMI 1.4.0 there are more capabilities to configure difficulty parameters.
 It means, that modders can give different bonuses to AI or human players depending on selected difficulty
 

--- a/docs/modders/Entities_Format/Artifact_Format.md
+++ b/docs/modders/Entities_Format/Artifact_Format.md
@@ -1,3 +1,5 @@
+# Artifact Format
+
 Artifact bonuses use [Bonus Format](../Bonus_Format.md)
 
 ## Required data

--- a/docs/modders/Entities_Format/Battle_Obstacle_Format.md
+++ b/docs/modders/Entities_Format/Battle_Obstacle_Format.md
@@ -1,3 +1,5 @@
+# Battle Obstacle Format
+
 ```jsonc
 	// List of terrains on which this obstacle can be used
 	"allowedTerrains" : []

--- a/docs/modders/Entities_Format/Battlefield_Format.md
+++ b/docs/modders/Entities_Format/Battlefield_Format.md
@@ -1,3 +1,5 @@
+# Battlefield Format
+
 ```jsonc
 	// Human-readable name of the battlefield
 	"name" : ""

--- a/docs/modders/Entities_Format/Biome_Format.md
+++ b/docs/modders/Entities_Format/Biome_Format.md
@@ -1,3 +1,5 @@
+# Biome Format
+
 ## General description
 
 Biome is a new entity type added in VCMI 1.5.0. It defines a set of random map obstacles which will be generated together. For each zone different obstacle sets is randomized and then only obstacles from that set will be used to fill this zone.

--- a/docs/modders/Entities_Format/Creature_Format.md
+++ b/docs/modders/Entities_Format/Creature_Format.md
@@ -1,3 +1,5 @@
+# Creature Format
+
 ## Required data
 
 In order to make functional creature you also need:

--- a/docs/modders/Entities_Format/Faction_Format.md
+++ b/docs/modders/Entities_Format/Faction_Format.md
@@ -1,3 +1,5 @@
+# Faction Format
+
 ## Required data
 
 In order to make functional town you also need:

--- a/docs/modders/Entities_Format/Hero_Class_Format.md
+++ b/docs/modders/Entities_Format/Hero_Class_Format.md
@@ -1,3 +1,5 @@
+# Hero Class Format
+
 ## Required data
 
 In order to make functional hero class you also need:

--- a/docs/modders/Entities_Format/Hero_Type_Format.md
+++ b/docs/modders/Entities_Format/Hero_Type_Format.md
@@ -1,3 +1,5 @@
+# Hero Type Format
+
 ## Required data
 
 In order to make functional hero you also need:

--- a/docs/modders/Entities_Format/River_Format.md
+++ b/docs/modders/Entities_Format/River_Format.md
@@ -1,3 +1,5 @@
+# River Format
+
 ## Format
 
 ```jsonc

--- a/docs/modders/Entities_Format/Road_Format.md
+++ b/docs/modders/Entities_Format/Road_Format.md
@@ -1,3 +1,5 @@
+# Road Format
+
 ## Format
 
 ```jsonc

--- a/docs/modders/Entities_Format/Secondary_Skill_Format.md
+++ b/docs/modders/Entities_Format/Secondary_Skill_Format.md
@@ -1,3 +1,5 @@
+# Secondary Skill Format
+
 ## Main format
 
 ```jsonc

--- a/docs/modders/Entities_Format/Spell_Format.md
+++ b/docs/modders/Entities_Format/Spell_Format.md
@@ -1,3 +1,5 @@
+# Spell Format
+
 ## Main format
 
 ``` javascript

--- a/docs/modders/Entities_Format/Terrain_Format.md
+++ b/docs/modders/Entities_Format/Terrain_Format.md
@@ -1,3 +1,5 @@
+# Terrain Format
+
 ## Format
 
 ```jsonc

--- a/docs/modders/Game_Identifiers.md
+++ b/docs/modders/Game_Identifiers.md
@@ -1,3 +1,5 @@
+# Game Identifiers
+
 ## List of all game identifiers
 
 This is a list of all game identifiers available to modders. Note that only identifiers from base game have been included. For identifiers from mods please look up corresponding mod

--- a/docs/modders/Map_Editor.md
+++ b/docs/modders/Map_Editor.md
@@ -1,16 +1,18 @@
-# Interface
+# Map Editor
+
+## Interface
 
 <img width="738" src="https://user-images.githubusercontent.com/9308612/188775648-8551107d-9f0b-4743-8980-56c2c1c58bbc.png">
 
-# Create the map
+## Create the map
 
 <img width="145" src="https://user-images.githubusercontent.com/9308612/188782248-b7895eb1-86a9-4f06-9309-43c6b3a3a728.png">
 
-## New map
+### New map
 
 Create the new map by pressing **New** button from the toolbar
 
-### Empty map
+#### Empty map
 
 To create empty map, define its size by choosing option from drop-down list or enter required size manually in the text fields and press Ok button. Check **Two level map** option to create map with underground.
 `Note: there are no limits on map size but be careful with sizes larger predefined XL size. It will be processed quite long to create even empty map. Also, it will be difficult to work with the huge maps because of possible performance issues`
@@ -19,7 +21,7 @@ Other parameters won't be used for empty map.
 
 <img width="413" src="https://user-images.githubusercontent.com/9308612/188782588-c9f1a164-df1e-46bc-a6d3-24ff1e5396c2.png">
 
-### Random map
+#### Random map
 
 To generate random map, check the **Random map** option and configure map parameters. You can select template from the drop-down list.
 
@@ -32,27 +34,27 @@ Templates are dynamically filtered depending on parameters you choose.
 
 <img width="412" src="https://user-images.githubusercontent.com/9308612/188783360-1c042782-328d-4692-952f-58fa5110d0d0.png">
 
-## Map load & save
+### Map load & save
 
 To load the map, press open and select map file from the browser.
 
 You can load both *.h3m and *.vmap formats but for saving *.vmap is allowed only.
 
-# Views
+## Views
 
 There are 3 buttons switching views <img width="131" alt="Снимок экрана 2022-09-07 в 06 48 08" src="https://user-images.githubusercontent.com/9308612/188777527-b7106146-0d8c-4f14-b78d-f13512bc7bad.png">
 
-### Ground/underground
+#### Ground/underground
 
 **"U/G"** switches you between ground and underground
 
-### Grid view
+#### Grid view
 
 **Grid** show/hide grid
 
 <img width="153" src="https://user-images.githubusercontent.com/9308612/188777723-934d693b-247d-42a6-815c-aecd0d34f653.png">
 
-### Passability view
+#### Passability view
 
 **Pass** show/hide passability map
 
@@ -73,7 +75,7 @@ There are 3 buttons switching views <img width="131" alt="Снимок экра�
 
 <img width="116" src="https://user-images.githubusercontent.com/9308612/188777176-1167561a-f23c-400a-a57b-be7fc90accae.png">
 
-### Drawing roads and rivers
+#### Drawing roads and rivers
 
 Actually, the process to draw rivers or roads is exactly the same as for terrains. You need to select tiles and then choose road/river type from the panel. 
 
@@ -85,13 +87,13 @@ To erase roads or rivers, you need to select tiles to be cleaned and press empty
 
 _Erasing works either for roads or for rivers, e.g. empty button from the roads tab erases roads only, but not rivers. You also can safely select bigger area, because it won't erase anything on tiles without roads/rivers accordingly_
 
-## About brushes
+### About brushes
 * Buttons "1", "2", "4" - 1x1, 2x2, 4x4 brush sizes accordingly
 * Button "[]" - non-additive rectangle selection
 * Button "O" - lasso brush (not implemented yet)
 * Button "E" - object erase, not a brush
 
-## Fill obstacles
+### Fill obstacles
 
 Map editor supports automatic obstacle placement.
 Obstacle types are automatically selected for appropriate terrain types
@@ -105,9 +107,9 @@ To do that, select area (see Setup terrains) and press **Fill** button from the 
 
 `Note: obstacle placer may occupy few neighbour tiles outside of selected area`
 
-# Manipulating objects
+## Manipulating objects
 
-## Adding new objects
+### Adding new objects
 
 1. Find the object you'd like to place in the object browser
 
@@ -125,7 +127,7 @@ To do that, select area (see Setup terrains) and press **Fill** button from the 
 
 **Right click over the scene - cancel object placement**
 
-## Removing objects
+### Removing objects
 
 1. **Make sure that no one terrain brush is selected.** To de-select brush click on selected brush again.
 
@@ -134,7 +136,7 @@ To do that, select area (see Setup terrains) and press **Fill** button from the 
 
 3. Press **"E"** button from the brush panel or press **delete** on keyboard
 
-## Changing object's properties
+### Changing object's properties
 
 1. **Make sure that no one terrain brush is selected.** To de-select brush click on selected brush again.
 
@@ -147,15 +149,15 @@ To do that, select area (see Setup terrains) and press **Fill** button from the 
 4. You are able to modify properties which are not gray
 `Note: sometimes there are empty editable fields`
 
-### Assigning player to the object
+#### Assigning player to the object
 
 Objects with flags can be assigned to the player. Find Owner property in the inspector for selected object, press twice to modify right cell. Type player number from **0 to 7 or type NEUTRAL** for neutral objects.
 
-# Set up the map
+## Set up the map
 
 You can modify general properties of the map
 
-## Map name and description
+### Map name and description
 
 1. Open **Map** menu on the top and select **General**
 
@@ -167,7 +169,7 @@ You can modify general properties of the map
 
 <img width="307" src="https://user-images.githubusercontent.com/9308612/188781063-50ce65f8-aab4-43c3-a308-22acafa7d0a2.png">
 
-# Player settings
+## Player settings
 
 Open **Map** menu on the top and select **Player settings" 
 
@@ -179,29 +181,29 @@ You will see a window with player settings. Combobox players defines amount of p
 
 <img width="641" src="https://user-images.githubusercontent.com/9308612/188781400-7d5ba463-4f82-4dba-83ff-56210995e2c7.png">
 
-# Compatibility questions
+## Compatibility questions
 
-## Platform compatibility
+### Platform compatibility
 
 vcmieditor is a cross-platform application, so in general can support all platforms, supported by VCMI.
 
 However, currently it doesn't support mobile platforms.
 
-## Engine compatibility
+### Engine compatibility
 
 vcmieditor is independent application so potentially it can be installed just in the folder with existing stable vcmi. However, on the initial stages of development compatibility was not preserved because major changes were needed to introduce into vcmi library. So it's recommended to download full package to use editor.
 
-## Map compatibility
+### Map compatibility
 
 vcmieditor haven't introduced any change into map format yet, so all maps made by vcmieditor can be easily played with any version of vcmi. At the same time, those maps can be open and read in the old map editor and vice verse - maps from old editor can be imported in the new editor. So, full compatibility is ensured here.
 
-## Mod compatibility
+### Mod compatibility
 
 vcmieditor loads set of mods using exactly same mechanism as game uses and mod manipulations can be done using vcmilaucnher application, just enable or disable mods you want and open editor to use content from those mods. In regards on compatibility, of course you need to play maps with same set of mods as you used in the editor. Good part is that is maps don't use content from the mods (even mods were enabled), it can be played on vcmi without mods as well
 
-# Working With Mods
+## Working With Mods
 
-## Enabling and disabling mods
+### Enabling and disabling mods
 
 The mods mechanism used in map editor is the same as in game.
 
@@ -212,7 +214,7 @@ To enable or disable mods
 
 There is no button to start map editor directly from launcher, however you may use this approach to control active mods from any version of vcmi.
 
-## Placing objects from mods
+### Placing objects from mods
 
 * All objects from mods will be automatically added into objects Browser. You can type mod name into filter field to find them.
 
@@ -222,13 +224,13 @@ There is no button to start map editor directly from launcher, however you may u
 
 <img width="271" src="https://user-images.githubusercontent.com/9308612/189965836-de1fd196-2f6d-4996-a62a-e2fcb52b8d74.png">
 
-## Playing maps with mods
+### Playing maps with mods
 
 If you place any kind of objects from the mods, obviously, you need those mods to be installed to play the map.
 Also, you need to activate them.
 
 You also may have other mods being activated in addition to what was used during map designing.
 
-### Mod versions
+#### Mod versions
 
 In the future, the will be support of mods versioning so map will contain information about mods used and game can automatically search and activate required mods or let user know which are required. However, it's not implemented yet

--- a/docs/modders/Map_Object_Format.md
+++ b/docs/modders/Map_Object_Format.md
@@ -1,3 +1,5 @@
+# Map Object Format
+
 ## Description
 
 Full object consists from 3 parts:

--- a/docs/modders/Map_Objects/Boat.md
+++ b/docs/modders/Map_Objects/Boat.md
@@ -1,3 +1,5 @@
+# Boat
+
 ``` javascript
 {
 	// Layer on which this boat moves. Possible values:

--- a/docs/modders/Map_Objects/Creature_Bank.md
+++ b/docs/modders/Map_Objects/Creature_Bank.md
@@ -1,3 +1,5 @@
+# Creature Bank
+
 Reward types for clearing creature bank are limited to resources, creatures, artifacts and spell.
 Format of rewards is same as in [Rewardable Objects](Rewardable.md)
 

--- a/docs/modders/Map_Objects/Dwelling.md
+++ b/docs/modders/Map_Objects/Dwelling.md
@@ -1,3 +1,5 @@
+# Dwelling
+
 ``` javascript
 {
 	/// List of creatures in this bank. Each list represents one "level" of bank

--- a/docs/modders/Map_Objects/Market.md
+++ b/docs/modders/Map_Objects/Market.md
@@ -1,3 +1,5 @@
+# Market
+
 ## Market schema
 
 Since VCMI-1.3 it's possible to create customizable markets on adventure map.

--- a/docs/modders/Map_Objects/Rewardable.md
+++ b/docs/modders/Map_Objects/Rewardable.md
@@ -1,3 +1,5 @@
+# Rewardable
+
 ## Base object definition
 Rewardable object is defined similarly to other objects, with key difference being `handler`. This field must be set to `"handler" : "configurable"` in order for vcmi to use this mode.
 ```jsonc

--- a/docs/modders/Mod_File_Format.md
+++ b/docs/modders/Mod_File_Format.md
@@ -1,3 +1,5 @@
+# Mod File Format
+
 ## Fields with description of mod
 
 ``` javascript

--- a/docs/modders/Random_Map_Template.md
+++ b/docs/modders/Random_Map_Template.md
@@ -1,3 +1,5 @@
+# Random Map Template
+
 ## Template format
 
 ``` javascript

--- a/docs/modders/Readme.md
+++ b/docs/modders/Readme.md
@@ -1,3 +1,5 @@
+# Modding Readme
+
 ## Creating mod
 
 To make your own mod you need to create subdirectory in **<data dir>/Mods/** with name that will be used as identifier for your mod.

--- a/docs/modders/Translations.md
+++ b/docs/modders/Translations.md
@@ -1,3 +1,5 @@
+# Translations
+
 ## List of currently supported languages
 
 This is list of all languages that are currently supported by VCMI. If your languages is missing from the list and you wish to translate VCMI - please contact our team and we'll add support for your language in next release.

--- a/docs/players/Bug_Reporting_Guidelines.md
+++ b/docs/players/Bug_Reporting_Guidelines.md
@@ -1,3 +1,5 @@
+# Bug Reporting Guidelines
+
 First of all, thanks for your support! If you report a bug we can fix it. But keep in mind that reporting your bugs appropriately makes our (developers') lives easier. Here are a few guidelines that will help you write good bug reports.
 
 ## Github bugtracker

--- a/docs/players/Cheat_Codes.md
+++ b/docs/players/Cheat_Codes.md
@@ -1,4 +1,6 @@
-## Cheat Codes
+# Cheat Codes
+
+## Codes
 
 Similar to H3, VCMI provides cheat codes to make testing game more convenient.
 

--- a/docs/players/Game_Mechanics.md
+++ b/docs/players/Game_Mechanics.md
@@ -1,3 +1,5 @@
+# Game Mechanics
+
 ## List of features added in VCMI
 
 ### High resolutions

--- a/docs/players/Installation_Android.md
+++ b/docs/players/Installation_Android.md
@@ -1,3 +1,5 @@
+# Installation Android
+
 ## Step 1: Download and install VCMI
 
 **This app requires original heroes 3 sod / complete files to operate, they are not supplied with this installer. it is recommended to purchase version from gog.com. Heroes 3 "hd edition" (steam version) files are not supported !!!**  

--- a/docs/players/Installation_Linux.md
+++ b/docs/players/Installation_Linux.md
@@ -1,6 +1,8 @@
+# Installation Linux
+
 VCMI requires data from original Heroes 3: Shadow of Death or Complete editions. Data from native Linux version made by LOKI will not work.
 
-# Step 1: Binaries installation
+## Step 1: Binaries installation
 
 ### Ubuntu - Latest stable build from PPA (recommended)
 

--- a/docs/players/Installation_Windows.md
+++ b/docs/players/Installation_Windows.md
@@ -1,3 +1,5 @@
+# Installation Windows
+
 ## Prerequisites
 
 As of VCMI 1.2 and newer Windows 10 or newer is required since our automated system uses elements incompatible with older Windows.

--- a/docs/players/Installation_iOS.md
+++ b/docs/players/Installation_iOS.md
@@ -1,3 +1,5 @@
+# Installation iOS
+
 You can run VCMI on iOS 12.0 and later, all devices are supported. If you wish to run on iOS 10 or 11, you should build from source, see [How to build VCMI (iOS)](../developers/Building_iOS.md).
 
 ## Step 1: Download and install VCMI

--- a/docs/players/Installation_macOS.md
+++ b/docs/players/Installation_macOS.md
@@ -1,3 +1,5 @@
+# Installation macOS
+
 For iOS installation look here: (Installation on iOS)[Installation_iOS.md]
 
 ## Step 1: Download and install VCMI

--- a/docs/players/Privacy_Policy.md
+++ b/docs/players/Privacy_Policy.md
@@ -1,14 +1,16 @@
+# Privacy Policy
+
 **Last Updated: 24th December, 2022**
 
-### Glossary
+## Glossary
 
 * VCMI team - a community of VCMI developers, mod makers and testers. It is not some officially registered organization.
 * VCMI app - an application provided by VCMI team.
 
-### Single player
+## Single player
 
 VCMI team does not collect any data produced by VCMI app. All game files, logs, saves, mods are stored in app's internal directory and will be removed upon app uninstallation. It should be possible to backup this data by standard ways provided by your device.
 
-### Multiplayer
+## Multiplayer
 
 If you decide to play with other users via Internet there are two roles. The host is the one who provides the game server. The clients are the other players who connect to the host. The host provides to the client its IP address in order to establish connections. The clients and the host during the gameplay exchange their usernames, messages and other game activity. All this data is collected and stored by the host. VCMI team does not collect and store any multiplayer data.


### PR DESCRIPTION
- h1 is now in every case the page title
- moved some old h1 to h2, h2 to h3 and so on...

Now the titles on Web page should be correct. And the table of content should work.