### PR TITLE
NKAI: reduce double army loss cases

### DIFF
--- a/AI/Nullkiller/Goals/ExecuteHeroChain.cpp
+++ b/AI/Nullkiller/Goals/ExecuteHeroChain.cpp
@@ -26,7 +26,12 @@ ExecuteHeroChain::ExecuteHeroChain(const AIPath & path, const CGObjectInstance *
 	if(obj)
 	{
 		objid = obj->id.getNum();
+
+#if NKAI_TRACE_LEVEL >= 1
+		targetName = obj->getObjectName() + tile.toString();
+#else
 		targetName = obj->typeName + tile.toString();
+#endif
 	}
 	else
 	{
@@ -260,7 +265,11 @@ void ExecuteHeroChain::accept(AIGateway * ai)
 
 std::string ExecuteHeroChain::toString() const
 {
+#if NKAI_TRACE_LEVEL >= 1
+	return "ExecuteHeroChain " + targetName + " by " + chainPath.toString();
+#else
 	return "ExecuteHeroChain " + targetName + " by " + chainPath.targetHero->getNameTranslated();
+#endif
 }
 
 bool ExecuteHeroChain::moveHeroToTile(AIGateway * ai, const CGHeroInstance * hero, const int3 & tile)

--- a/AI/Nullkiller/Pathfinding/AINodeStorage.cpp
+++ b/AI/Nullkiller/Pathfinding/AINodeStorage.cpp
@@ -1385,6 +1385,28 @@ void AINodeStorage::calculateChainInfo(std::vector<AIPath> & paths, const int3 &
 		path.armyLoss = node.armyLoss;
 		path.targetObjectDanger = evaluateDanger(pos, path.targetHero, !node.actor->allowBattle);
 
+		if(path.targetObjectDanger > 0)
+		{
+			if(node.theNodeBefore)
+			{
+				auto prevNode = getAINode(node.theNodeBefore);
+
+				if(node.coord == prevNode->coord && node.actor->hero == prevNode->actor->hero)
+				{
+					paths.pop_back();
+					continue;
+				}
+				else
+				{
+					path.armyLoss = prevNode->armyLoss;
+				}
+			}
+			else
+			{
+				path.armyLoss = 0;
+			}
+		}
+
 		path.targetObjectArmyLoss = evaluateArmyLoss(
 			path.targetHero,
 			getHeroArmyStrengthWithCommander(path.targetHero, path.heroArmy),

--- a/AI/Nullkiller/Pathfinding/GraphPaths.h
+++ b/AI/Nullkiller/Pathfinding/GraphPaths.h
@@ -67,7 +67,7 @@ struct GraphPathNode
 	GrapthPathNodeType nodeType = GrapthPathNodeType::NORMAL;
 	GraphPathNodePointer previous;
 	float cost = BAD_COST;
-	uint64_t danger = 0;
+	uint64_t linkDanger = 0;
 	const CGObjectInstance * obj = nullptr;
 	std::shared_ptr<SpecialAction> specialAction;
 

--- a/client/ClientCommandManager.cpp
+++ b/client/ClientCommandManager.cpp
@@ -89,7 +89,7 @@ void ClientCommandManager::handleGoSoloCommand()
 		// unlikely it will work but just in case to be consistent
 		for(auto & color : CSH->getAllClientPlayers(CSH->logicConnection->connectionID))
 		{
-			if(CSH->client->getStartInfo()->playerInfos.at(color).isControlledByHuman())
+			if(color.isValidPlayer() && CSH->client->getStartInfo()->playerInfos.at(color).isControlledByHuman())
 			{
 				CSH->client->installNewPlayerInterface(std::make_shared<CPlayerInterface>(color), color);
 			}
@@ -102,7 +102,7 @@ void ClientCommandManager::handleGoSoloCommand()
 		
 		for(auto & color : CSH->getAllClientPlayers(CSH->logicConnection->connectionID))
 		{
-			if(CSH->client->getStartInfo()->playerInfos.at(color).isControlledByHuman())
+			if(color.isValidPlayer() && CSH->client->getStartInfo()->playerInfos.at(color).isControlledByHuman())
 			{
 				auto AiToGive = CSH->client->aiNameForPlayer(*CSH->client->getPlayerSettings(color), false, false);
 				printCommandMessage("Player " + color.toString() + " will be lead by " + AiToGive, ELogLevel::INFO);


### PR DESCRIPTION
Known issue plaguing AI for long time. Sometimes AI can count some dangerous object twice doubling its army loss. Fixed a few such cases.