### PR TITLE
CModListView::loadScreenshots(): Ensure a mod is selected in allModsView

### DIFF
--- a/launcher/modManager/cmodlistview_moc.cpp
+++ b/launcher/modManager/cmodlistview_moc.cpp
@@ -962,6 +962,12 @@ void CModListView::loadScreenshots()
 {
 	if(ui->tabWidget->currentIndex() == 2)
 	{
+		if(ui->allModsView->currentIndex().row() == -1 || ui->allModsView->currentIndex().column() == -1)
+		{
+			// select the first mod, so we can access its data
+			ui->allModsView->setCurrentIndex(filterModel->index(0, 0));
+		}
+		
 		ui->screenshotsList->clear();
 		QString modName = ui->allModsView->currentIndex().data(ModRoles::ModNameRole).toString();
 		assert(modModel->hasMod(modName)); //should be filtered out by check above

--- a/launcher/modManager/cmodlistview_moc.cpp
+++ b/launcher/modManager/cmodlistview_moc.cpp
@@ -962,7 +962,7 @@ void CModListView::loadScreenshots()
 {
 	if(ui->tabWidget->currentIndex() == 2)
 	{
-		if(ui->allModsView->currentIndex().row() == -1 || ui->allModsView->currentIndex().column() == -1)
+		if(!ui->allModsView->currentIndex().isValid())
 		{
 			// select the first mod, so we can access its data
 			ui->allModsView->setCurrentIndex(filterModel->index(0, 0));


### PR DESCRIPTION
Fixes #989
Fixes #3811

I tried setting the index in the constructor, but that didn't work.