### PR TITLE
Miscellaneous fixes

### DIFF
--- a/client/adventureMap/AdventureMapShortcuts.cpp
+++ b/client/adventureMap/AdventureMapShortcuts.cpp
@@ -71,6 +71,8 @@ std::vector<AdventureMapShortcutState> AdventureMapShortcuts::getShortcuts()
 		{ EShortcut::ADVENTURE_QUEST_LOG,        optionCanViewQuests(),  [this]() { this->showQuestlog(); } },
 		{ EShortcut::ADVENTURE_TOGGLE_SLEEP,     optionHeroSelected(),   [this]() { this->toggleSleepWake(); } },
 		{ EShortcut::ADVENTURE_TOGGLE_GRID,      optionInMapView(),      [this]() { this->toggleGrid(); } },
+		{ EShortcut::ADVENTURE_TOGGLE_VISITABLE, optionInMapView(),      [this]() { this->toggleVisitable(); } },
+		{ EShortcut::ADVENTURE_TOGGLE_BLOCKED,   optionInMapView(),      [this]() { this->toggleBlocked(); } },
 		{ EShortcut::ADVENTURE_TRACK_HERO,       optionInMapView(),      [this]() { this->toggleTrackHero(); } },
 		{ EShortcut::ADVENTURE_SET_HERO_ASLEEP,  optionHeroAwake(),      [this]() { this->setHeroSleeping(); } },
 		{ EShortcut::ADVENTURE_SET_HERO_AWAKE,   optionHeroSleeping(),   [this]() { this->setHeroAwake(); } },
@@ -166,6 +168,18 @@ void AdventureMapShortcuts::toggleGrid()
 {
 	Settings s = settings.write["gameTweaks"];
 	s["showGrid"].Bool() = !settings["gameTweaks"]["showGrid"].Bool();
+}
+
+void AdventureMapShortcuts::toggleVisitable()
+{
+	Settings s = settings.write["session"];
+	s["showVisitable"].Bool() = !settings["session"]["showVisitable"].Bool();
+}
+
+void AdventureMapShortcuts::toggleBlocked()
+{
+	Settings s = settings.write["session"];
+	s["showBlocked"].Bool() = !settings["session"]["showBlocked"].Bool();
 }
 
 void AdventureMapShortcuts::toggleSleepWake()

--- a/client/adventureMap/AdventureMapShortcuts.h
+++ b/client/adventureMap/AdventureMapShortcuts.h
@@ -42,6 +42,8 @@ class AdventureMapShortcuts
 	void showQuestlog();
 	void toggleTrackHero();
 	void toggleGrid();
+	void toggleVisitable();
+	void toggleBlocked();
 	void toggleSleepWake();
 	void setHeroSleeping();
 	void setHeroAwake();

--- a/client/battle/BattleFieldController.cpp
+++ b/client/battle/BattleFieldController.cpp
@@ -356,9 +356,6 @@ std::set<BattleHex> BattleFieldController::getHighlightedHexesForSpellRange()
 	std::set<BattleHex> result;
 	auto hoveredHex = getHoveredHex();
 
-	if(!settings["battle"]["mouseShadow"].Bool())
-		return result;
-
 	const spells::Caster *caster = nullptr;
 	const CSpell *spell = nullptr;
 
@@ -549,6 +546,8 @@ void BattleFieldController::showHighlightedHexes(Canvas & canvas)
 	std::set<BattleHex> hoveredMoveHexes  = getHighlightedHexesForMovementTarget();
 
 	BattleHex hoveredHex = getHoveredHex();
+	std::set<BattleHex> hoveredMouseHex = hoveredHex.isValid() ? std::set<BattleHex>({ hoveredHex }) : std::set<BattleHex>();
+
 	const CStack * hoveredStack = getHoveredStack();
 	if(!hoveredStack && hoveredHex == BattleHex::INVALID)
 		return;
@@ -565,7 +564,10 @@ void BattleFieldController::showHighlightedHexes(Canvas & canvas)
 		calculateRangeLimitAndHighlightImages(shootingRangeDistance, shootingRangeLimitImages, shootingRangeLimitHexes, shootingRangeLimitHexesHighlights);
 	}
 
-	auto const & hoveredMouseHexes = hoveredHex != BattleHex::INVALID && owner.actionsController->currentActionSpellcasting(getHoveredHex()) ? hoveredSpellHexes : hoveredMoveHexes;
+	bool useSpellRangeForMouse = hoveredHex != BattleHex::INVALID && owner.actionsController->currentActionSpellcasting(getHoveredHex());
+	bool useMoveRangeForMouse = !hoveredMoveHexes.empty() || !settings["battle"]["mouseShadow"].Bool();
+
+	const auto & hoveredMouseHexes = useSpellRangeForMouse ? hoveredSpellHexes : ( useMoveRangeForMouse ? hoveredMoveHexes : hoveredMouseHex);
 
 	for(int hex = 0; hex < GameConstants::BFIELD_SIZE; ++hex)
 	{

--- a/client/gui/Shortcut.h
+++ b/client/gui/Shortcut.h
@@ -120,6 +120,8 @@ enum class EShortcut
 	// Adventure map screen
 	ADVENTURE_GAME_OPTIONS, // 'o', Open CAdventureOptions window
 	ADVENTURE_TOGGLE_GRID,  // F6, Toggles map grid
+	ADVENTURE_TOGGLE_VISITABLE,  // Toggles visitable tiles overlay
+	ADVENTURE_TOGGLE_BLOCKED,  // Toggles blocked tiles overlay
 	ADVENTURE_TOGGLE_SLEEP, // Toggles hero sleep status
 	ADVENTURE_SET_HERO_ASLEEP, // Moves hero to sleep state
 	ADVENTURE_SET_HERO_AWAKE, // Move hero to awake state

--- a/client/gui/ShortcutHandler.cpp
+++ b/client/gui/ShortcutHandler.cpp
@@ -171,6 +171,8 @@ EShortcut ShortcutHandler::findShortcut(const std::string & identifier ) const
 		{"gameActivateConsole",      EShortcut::GAME_ACTIVATE_CONSOLE     },
 		{"adventureGameOptions",     EShortcut::ADVENTURE_GAME_OPTIONS    },
 		{"adventureToggleGrid",      EShortcut::ADVENTURE_TOGGLE_GRID     },
+		{"adventureToggleVisitable", EShortcut::ADVENTURE_TOGGLE_VISITABLE},
+		{"adventureToggleBlocked",   EShortcut::ADVENTURE_TOGGLE_BLOCKED  },
 		{"adventureToggleSleep",     EShortcut::ADVENTURE_TOGGLE_SLEEP    },
 		{"adventureSetHeroAsleep",   EShortcut::ADVENTURE_SET_HERO_ASLEEP },
 		{"adventureSetHeroAwake",    EShortcut::ADVENTURE_SET_HERO_AWAKE  },

--- a/client/mainmenu/CreditsScreen.cpp
+++ b/client/mainmenu/CreditsScreen.cpp
@@ -22,12 +22,14 @@
 #include "../../AUTHORS.h"
 
 CreditsScreen::CreditsScreen(Rect rect)
-	: CIntObject(LCLICK), positionCounter(0)
+	: CIntObject(LCLICK), timePassed(0)
 {
 	pos.w = rect.w;
 	pos.h = rect.h;
 	setRedrawParent(true);
 	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
+
+	addUsedEvents(TIME);
 
 	std::string contributorsText = "";
 	std::string contributorsTask = "";
@@ -48,15 +50,15 @@ CreditsScreen::CreditsScreen(Rect rect)
 	credits->scrollTextTo(-600); // move all text below the screen
 }
 
-void CreditsScreen::show(Canvas & to)
+void CreditsScreen::tick(uint32_t msPassed)
 {
-	CIntObject::show(to);
-	positionCounter++;
-	if(positionCounter % 2 == 0)
-		credits->scrollTextBy(1);
+	static const int timeToScrollByOnePx = 20;
+	timePassed += msPassed;
+	int scrollPosition = timePassed / timeToScrollByOnePx - 600;
+	credits->scrollTextTo(scrollPosition);
 
 	//end of credits, close this screen
-	if(credits->textSize.y + 600 < positionCounter / 2)
+	if(credits->textSize.y < scrollPosition)
 		clickPressed(GH.getCursorPosition());
 }
 

--- a/client/mainmenu/CreditsScreen.h
+++ b/client/mainmenu/CreditsScreen.h
@@ -15,11 +15,11 @@ class CMultiLineLabel;
 
 class CreditsScreen : public CIntObject
 {
-	int positionCounter;
+	int timePassed;
 	std::shared_ptr<CMultiLineLabel> credits;
 
 public:
 	CreditsScreen(Rect rect);
-	void show(Canvas & to) override;
+	void tick(uint32_t msPassed) override;
 	void clickPressed(const Point & cursorPosition) override;
 };

--- a/client/renderSDL/SDLImage.cpp
+++ b/client/renderSDL/SDLImage.cpp
@@ -196,7 +196,7 @@ Point SDLImageConst::dimensions() const
 
 std::shared_ptr<IImage> SDLImageConst::createImageReference(EImageBlitMode mode)
 {
-	if (surf->format->palette)
+	if (surf && surf->format->palette)
 		return std::make_shared<SDLImageIndexed>(shared_from_this(), mode);
 	else
 		return std::make_shared<SDLImageRGB>(shared_from_this(), mode);

--- a/client/windows/InfoWindows.cpp
+++ b/client/windows/InfoWindows.cpp
@@ -248,7 +248,7 @@ void CRClickPopup::createAndPush(const CGObjectInstance * obj, const Point & p, 
 CRClickPopupInt::CRClickPopupInt(const std::shared_ptr<CIntObject> & our)
 {
 	CCS->curh->hide();
-	defActions = SHOWALL | UPDATE;
+	defActions = 255-DISPOSE;
 	our->recActions = defActions;
 	inner = our;
 	addChild(our.get(), false);

--- a/config/shortcutsConfig.json
+++ b/config/shortcutsConfig.json
@@ -40,6 +40,8 @@
 		"adventureSetHeroAwake":    "W",
 		"adventureThievesGuild":    "G",
 		"adventureToggleGrid":      "F6",
+		"adventureToggleVisitable": [],
+		"adventureToggleBlocked":   [],
 		"adventureToggleMapLevel":  "U",
 		"adventureToggleSleep":     [],
 		"adventureTrackHero":       "F5",


### PR DESCRIPTION
Fixes for issues reported on Discord:
- Added unassigned by default shortcuts for toggling visitable and blocked tiles
- Fix broken cursor shadow option in battle
- Fix crash on opening window of some creatures (regressions from my earlier PR)
- Fix mouse scroll not working in right-click popups (better fix than one in #4293)
- Fix scrolling on credits screen