### PR TITLE
MSVC CI script: Don't run vswhere to find dumpbin.exe, since it is no…

### DIFF
--- a/CI/msvc/before_install.sh
+++ b/CI/msvc/before_install.sh
@@ -5,6 +5,3 @@ curl -LfsS -o "vcpkg-export-${VCMI_BUILD_PLATFORM}-windows-v143.7z" \
 #rm -r -f vcpkg/installed/${VCMI_BUILD_PLATFORM}-windows/debug
 #mkdir -p vcpkg/installed/${VCMI_BUILD_PLATFORM}-windows/debug/bin
 #cp vcpkg/installed/${VCMI_BUILD_PLATFORM}-windows/bin/* vcpkg/installed/${VCMI_BUILD_PLATFORM}-windows/debug/bin
-
-DUMPBIN_DIR=$(vswhere -latest -find **/dumpbin.exe | head -n 1)
-dirname "$DUMPBIN_DIR" > $GITHUB_PATH


### PR DESCRIPTION
…t used

Just the search took 3 to 15 min


Or is it used somewhere and I missed it?