### PR TITLE
On armel link with -latomic if necessary

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -632,6 +632,23 @@ if(ENABLE_LAUNCHER OR ENABLE_EDITOR)
 	set(qtBinDir "${qtDir}/bin")
 endif()
 
+# link with -latomic if necessary
+# on armel the build will otherwise fail with
+# /usr/bin/ld: ../bin/libvcmi.so: undefined reference to `__atomic_fetch_add_8'
+# /usr/bin/ld: ../bin/libvcmi.so: undefined reference to `__atomic_load_8'
+if(CMAKE_LIBRARY_ARCHITECTURE STREQUAL "arm-linux-gnueabi")
+	file(WRITE ${CMAKE_BINARY_DIR}/test_atomics.cpp
+	"#include <stdint.h>\nint main(void){uint64_t x=0,y=0;return (int)__atomic_fetch_add_8(&x,y,0);}\n")
+	try_compile(ATOMICS_BUILD_SUCCEEDED ${CMAKE_BINARY_DIR} ${CMAKE_BINARY_DIR}/test_atomics.cpp)
+	message(STATUS "Found __sync_add_and_fetch_8(): ${ATOMICS_BUILD_SUCCEEDED}")
+	if (NOT ATOMICS_BUILD_SUCCEEDED)
+		set(VCMI_LINK_ATOMIC ON)
+	else()
+		set(VCMI_LINK_ATOMIC OFF)
+	endif ()
+	file(REMOVE ${CMAKE_BINARY_DIR}/test_atomics.cpp)
+endif()
+
 #######################################
 #        Add subdirectories           #
 #######################################

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -713,6 +713,10 @@ target_link_libraries(vcmi PUBLIC
 	${SYSTEM_LIBS} Boost::boost Boost::thread Boost::filesystem Boost::program_options Boost::locale Boost::date_time
 )
 
+if (VCMI_LINK_ATOMIC)
+	target_link_options(vcmi PRIVATE "-Wl,--push-state,--no-as-needed,-latomic,--pop-state")
+endif()
+
 if(ENABLE_STATIC_LIBS AND ENABLE_CLIENT)
 	target_compile_definitions(vcmi PRIVATE STATIC_AI)
 	target_link_libraries(vcmi PRIVATE

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -61,6 +61,10 @@ endif()
 
 target_link_libraries(vcmiservercommon PRIVATE ${vcmiservercommon_LIBS} minizip::minizip)
 
+if (VCMI_LINK_ATOMIC)
+	target_link_options(vcmiservercommon PRIVATE "-Wl,--push-state,--no-as-needed,-latomic,--pop-state")
+endif()
+
 target_include_directories(vcmiservercommon
 	PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
 )


### PR DESCRIPTION
Otherwise, the build will fail with:

   /usr/bin/ld: ../bin/libvcmi.so: undefined reference to `__atomic_fetch_add_8'
   /usr/bin/ld: ../bin/libvcmi.so: undefined reference to `__atomic_load_8'

This problem only happens on architectures without native atomics, so this might also happen on parisc or sh architectures.

Other projects are taking very similar approaches: https://github.com/google/highway/pull/1008

Closes: https://github.com/vcmi/vcmi/issues/3109