### PR TITLE
Implemented simple target selection logic for arrow towers

### DIFF
--- a/lib/battle/CBattleInfoCallback.cpp
+++ b/lib/battle/CBattleInfoCallback.cpp
@@ -50,6 +50,12 @@ static bool sameSideOfWall(BattleHex pos1, BattleHex pos2)
 	return stackLeft == destLeft;
 }
 
+static bool isInsideWalls(BattleHex pos)
+{
+	const int wallInStackLine = lineToWallHex(pos.getY());
+	return wallInStackLine < pos;
+}
+
 // parts of wall
 static const std::pair<int, EWallPart> wallParts[] =
 {
@@ -156,6 +162,11 @@ std::pair< std::vector<BattleHex>, int > CBattleInfoCallback::getPath(BattleHex 
 	}
 
 	return std::make_pair(path, reachability.distances[dest]);
+}
+
+bool CBattleInfoCallback::battleIsInsideWalls(BattleHex from) const
+{
+	return isInsideWalls(from);
 }
 
 bool CBattleInfoCallback::battleHasPenaltyOnLine(BattleHex from, BattleHex dest, bool checkWall, bool checkMoat) const

--- a/lib/battle/CBattleInfoCallback.h
+++ b/lib/battle/CBattleInfoCallback.h
@@ -104,6 +104,7 @@ public:
 	DamageEstimation battleEstimateDamage(const battle::Unit * attacker, const battle::Unit * defender, BattleHex attackerPosition, DamageEstimation * retaliationDmg = nullptr) const;
 	DamageEstimation battleEstimateDamage(const battle::Unit * attacker, const battle::Unit * defender, int getMovementRange, DamageEstimation * retaliationDmg = nullptr) const;
 
+	bool battleIsInsideWalls(BattleHex from) const;
 	bool battleHasPenaltyOnLine(BattleHex from, BattleHex dest, bool checkWall, bool checkMoat) const;
 	bool battleHasDistancePenalty(const IBonusBearer * shooter, BattleHex shooterPosition, BattleHex destHex) const;
 	bool battleHasWallPenalty(const IBonusBearer * shooter, BattleHex shooterPosition, BattleHex destHex) const;


### PR DESCRIPTION
Apparently when hero can't control arrow towers their target selection logic would be completely empty - it would simply select first alive unit. End of logic.

Now automatic arrow towers will use following priorities for target selection:
1. Enemies inside fort walls
2. Enemy shooters
3. Melee units outside walls (everyone else actually)

If there are multiple potential targets within same group, such as multiple shooters, towers would target most dangerous target (which is ai value * stack size)