### PR TITLE
Add overlay that shows map objects and their name & status

### DIFF
--- a/client/mapView/IMapRendererContext.h
+++ b/client/mapView/IMapRendererContext.h
@@ -16,6 +16,7 @@ class Point;
 class CGObjectInstance;
 class ObjectInstanceID;
 struct TerrainTile;
+class ColorRGBA;
 struct CGPath;
 
 VCMI_LIB_NAMESPACE_END
@@ -67,6 +68,12 @@ public:
 	/// returns index of image for overlay on specific tile, or numeric_limits::max if none
 	virtual size_t overlayImageIndex(const int3 & coordinates) const = 0;
 
+	/// returns text that should be used as overlay for current tile
+	virtual std::string overlayText(const int3 & coordinates) const = 0;
+
+	/// returns text that should be used as overlay for current tile
+	virtual ColorRGBA overlayTextColor(const int3 & coordinates) const = 0;
+
 	/// returns animation frame for terrain
 	virtual size_t terrainImageIndex(size_t groupSize) const = 0;
 
@@ -80,7 +87,10 @@ public:
 	virtual bool showBorder() const = 0;
 
 	/// if true, world view overlay will be shown
-	virtual bool showOverlay() const = 0;
+	virtual bool showImageOverlay() const = 0;
+
+	// if true, new text overlay will be shown
+	virtual bool showTextOverlay() const = 0;
 
 	/// if true, map grid should be visible on map
 	virtual bool showGrid() const = 0;

--- a/client/mapView/MapRendererContext.cpp
+++ b/client/mapView/MapRendererContext.cpp
@@ -156,6 +156,16 @@ size_t MapRendererBaseContext::overlayImageIndex(const int3 & coordinates) const
 	return std::numeric_limits<size_t>::max();
 }
 
+std::string MapRendererBaseContext::overlayText(const int3 & coordinates) const
+{
+	return {};
+}
+
+ColorRGBA MapRendererBaseContext::overlayTextColor(const int3 & coordinates) const
+{
+	return {};
+}
+
 double MapRendererBaseContext::viewTransitionProgress() const
 {
 	return 0;
@@ -181,7 +191,12 @@ bool MapRendererBaseContext::showBorder() const
 	return false;
 }
 
-bool MapRendererBaseContext::showOverlay() const
+bool MapRendererBaseContext::showImageOverlay() const
+{
+	return false;
+}
+
+bool MapRendererBaseContext::showTextOverlay() const
 {
 	return false;
 }
@@ -253,6 +268,59 @@ size_t MapRendererAdventureContext::terrainImageIndex(size_t groupSize) const
 	return frameIndex;
 }
 
+std::string MapRendererAdventureContext::overlayText(const int3 & coordinates) const
+{
+	if(!isVisible(coordinates))
+		return {};
+
+	const auto & tile = getMapTile(coordinates);
+
+	if (!tile.visitable)
+		return {};
+
+	return tile.visitableObjects.back()->getObjectName();
+}
+
+ColorRGBA MapRendererAdventureContext::overlayTextColor(const int3 & coordinates) const
+{
+	if(!isVisible(coordinates))
+		return {};
+
+	const auto & tile = getMapTile(coordinates);
+
+	if (!tile.visitable)
+		return {};
+
+	auto * object = tile.visitableObjects.back();
+
+	if (object->getOwner() == LOCPLINT->playerID)
+		return { 0, 192, 0};
+
+	if (LOCPLINT->cb->getPlayerRelations(object->getOwner(), LOCPLINT->playerID) == PlayerRelations::ALLIES)
+		return { 0, 128, 255};
+
+	if (object->getOwner().isValidPlayer())
+		return { 255, 0, 0};
+
+	if (object->ID == MapObjectID::MONSTER)
+		return { 255, 0, 0};
+
+	auto hero = LOCPLINT->localState->getCurrentHero();
+
+	if (hero)
+	{
+		if (object->wasVisited(hero))
+			return { 160, 160, 160 };
+	}
+	else
+	{
+		if (object->wasVisited(LOCPLINT->playerID))
+			return { 160, 160, 160 };
+	}
+
+	return { 255, 192, 0 };
+}
+
 bool MapRendererAdventureContext::showBorder() const
 {
 	return true;
@@ -271,6 +339,11 @@ bool MapRendererAdventureContext::showVisitable() const
 bool MapRendererAdventureContext::showBlocked() const
 {
 	return settingShowBlocked;
+}
+
+bool MapRendererAdventureContext::showTextOverlay() const
+{
+	return settingTextOverlay;
 }
 
 bool MapRendererAdventureContext::showSpellRange(const int3 & position) const
@@ -411,7 +484,7 @@ MapRendererWorldViewContext::MapRendererWorldViewContext(const MapRendererContex
 {
 }
 
-bool MapRendererWorldViewContext::showOverlay() const
+bool MapRendererWorldViewContext::showImageOverlay() const
 {
 	return true;
 }

--- a/client/mapView/MapRendererContext.h
+++ b/client/mapView/MapRendererContext.h
@@ -48,13 +48,16 @@ public:
 	size_t objectImageIndex(ObjectInstanceID objectID, size_t groupSize) const override;
 	size_t terrainImageIndex(size_t groupSize) const override;
 	size_t overlayImageIndex(const int3 & coordinates) const override;
+	std::string overlayText(const int3 & coordinates) const override;
+	ColorRGBA overlayTextColor(const int3 & coordinates) const override;
 
 	double viewTransitionProgress() const override;
 	bool filterGrayscale() const override;
 	bool showRoads() const override;
 	bool showRivers() const override;
 	bool showBorder() const override;
-	bool showOverlay() const override;
+	bool showImageOverlay() const override;
+	bool showTextOverlay() const override;
 	bool showGrid() const override;
 	bool showVisitable() const override;
 	bool showBlocked() const override;
@@ -69,6 +72,7 @@ public:
 	bool settingShowVisitable = false;
 	bool settingShowBlocked = false;
 	bool settingSpellRange= false;
+	bool settingTextOverlay = false;
 	bool settingsAdventureObjectAnimation = true;
 	bool settingsAdventureTerrainAnimation = true;
 
@@ -77,11 +81,14 @@ public:
 	const CGPath * currentPath() const override;
 	size_t objectImageIndex(ObjectInstanceID objectID, size_t groupSize) const override;
 	size_t terrainImageIndex(size_t groupSize) const override;
+	std::string overlayText(const int3 & coordinates) const override;
+	ColorRGBA overlayTextColor(const int3 & coordinates) const override;
 
 	bool showBorder() const override;
 	bool showGrid() const override;
 	bool showVisitable() const override;
 	bool showBlocked() const override;
+	bool showTextOverlay() const override;
 
 	bool showSpellRange(const int3 & position) const override;
 };
@@ -133,7 +140,7 @@ public:
 	explicit MapRendererWorldViewContext(const MapRendererContextState & viewState);
 
 	size_t overlayImageIndex(const int3 & coordinates) const override;
-	bool showOverlay() const override;
+	bool showImageOverlay() const override;
 };
 
 class MapRendererSpellViewContext : public MapRendererWorldViewContext

--- a/client/mapView/MapViewCache.h
+++ b/client/mapView/MapViewCache.h
@@ -44,6 +44,7 @@ class MapViewCache
 	Point cachedSize;
 	Point cachedPosition;
 	int cachedLevel;
+	bool overlayWasVisible;
 
 	std::shared_ptr<MapViewModel> model;
 

--- a/client/mapView/MapViewController.cpp
+++ b/client/mapView/MapViewController.cpp
@@ -224,6 +224,7 @@ void MapViewController::updateState()
 		adventureContext->settingShowVisitable = settings["session"]["showVisitable"].Bool();
 		adventureContext->settingShowBlocked = settings["session"]["showBlocked"].Bool();
 		adventureContext->settingSpellRange = settings["session"]["showSpellRange"].Bool();
+		adventureContext->settingTextOverlay = GH.isKeyboardAltDown();
 	}
 }
 


### PR DESCRIPTION
Was suggested on Discord.

Pressing Alt will now show names of all visitable object as well as color-coded status:
- Green: objects owned by our player
- Blue: objects owned by our ally
- Red: enemies (both players and neutral monsters)
- Gray: objects that were already visited by current player/hero
- Yellow: not visited objects

![зображення](https://github.com/user-attachments/assets/601493ab-d63f-46ec-ac20-229b436bbc4d)
