### PR TITLE
[1.5.6?] Fixes for issues with multiplayer

### DIFF
--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -169,40 +169,44 @@ void CPlayerInterface::initGameInterface(std::shared_ptr<Environment> ENV, std::
 	adventureInt.reset(new AdventureMapInterface());
 }
 
+void CPlayerInterface::closeAllDialogs()
+{
+	// remove all active dialogs that do not expect query answer
+	for (;;)
+	{
+		auto adventureWindow = GH.windows().topWindow<AdventureMapInterface>();
+		auto infoWindow = GH.windows().topWindow<CInfoWindow>();
+
+		if(adventureWindow != nullptr)
+			break;
+
+		if(infoWindow && infoWindow->ID != QueryID::NONE)
+			break;
+
+		if (infoWindow)
+			infoWindow->close();
+		else
+			GH.windows().popWindows(1);
+	}
+
+	if(castleInt)
+		castleInt->close();
+
+	castleInt = nullptr;
+
+	// remove all pending dialogs that do not expect query answer
+	vstd::erase_if(dialogs, [](const std::shared_ptr<CInfoWindow> & window){
+		return window->ID == QueryID::NONE;
+	});
+}
+
 void CPlayerInterface::playerEndsTurn(PlayerColor player)
 {
 	EVENT_HANDLER_CALLED_BY_CLIENT;
 	if (player == playerID)
 	{
 		makingTurn = false;
-
-		// remove all active dialogs that do not expect query answer
-		for (;;)
-		{
-			auto adventureWindow = GH.windows().topWindow<AdventureMapInterface>();
-			auto infoWindow = GH.windows().topWindow<CInfoWindow>();
-
-			if(adventureWindow != nullptr)
-				break;
-
-			if(infoWindow && infoWindow->ID != QueryID::NONE)
-				break;
-
-			if (infoWindow)
-				infoWindow->close();
-			else
-				GH.windows().popWindows(1);
-		}
-
-		if(castleInt)
-			castleInt->close();
-
-		castleInt = nullptr;
-
-		// remove all pending dialogs that do not expect query answer
-		vstd::erase_if(dialogs, [](const std::shared_ptr<CInfoWindow> & window){
-			return window->ID == QueryID::NONE;
-		});
+		closeAllDialogs();
 	}
 }
 
@@ -284,6 +288,7 @@ void CPlayerInterface::gamePause(bool pause)
 
 void CPlayerInterface::yourTurn(QueryID queryID)
 {
+	closeAllDialogs();
 	CTutorialWindow::openWindowFirstTime(TutorialMode::TOUCH_ADVENTUREMAP);
 
 	EVENT_HANDLER_CALLED_BY_CLIENT;

--- a/client/CPlayerInterface.h
+++ b/client/CPlayerInterface.h
@@ -203,6 +203,7 @@ public: // public interface for use by client via LOCPLINT access
 	void performAutosave();
 	void gamePause(bool pause);
 	void endNetwork();
+	void closeAllDialogs();
 
 	///returns true if all events are processed internally
 	bool capturedAllEvents();

--- a/client/adventureMap/AdventureMapShortcuts.cpp
+++ b/client/adventureMap/AdventureMapShortcuts.cpp
@@ -553,12 +553,12 @@ bool AdventureMapShortcuts::optionSpellcasting()
 
 bool AdventureMapShortcuts::optionInMapView()
 {
-	return state == EAdventureState::MAKING_TURN;
+	return state == EAdventureState::MAKING_TURN || state == EAdventureState::OTHER_HUMAN_PLAYER_TURN;
 }
 
 bool AdventureMapShortcuts::optionInWorldView()
 {
-	return state == EAdventureState::WORLD_VIEW;
+	return state == EAdventureState::WORLD_VIEW || state == EAdventureState::OTHER_HUMAN_PLAYER_TURN;
 }
 
 bool AdventureMapShortcuts::optionSidePanelActive()

--- a/client/widgets/CComponent.cpp
+++ b/client/widgets/CComponent.cpp
@@ -290,7 +290,10 @@ std::string CComponent::getSubtitle() const
 			return CGI->artifacts()->getById(data.subType.as<ArtifactID>())->getNameTranslated();
 		case ComponentType::SPELL_SCROLL:
 		case ComponentType::SPELL:
-			return CGI->spells()->getById(data.subType.as<SpellID>())->getNameTranslated();
+			if (data.value < 0)
+				return "{#A9A9A9|" + CGI->spells()->getById(data.subType.as<SpellID>())->getNameTranslated() + "}";
+			else
+				return CGI->spells()->getById(data.subType.as<SpellID>())->getNameTranslated();
 		case ComponentType::NONE:
 		case ComponentType::MORALE:
 		case ComponentType::LUCK:

--- a/config/objects/moddables.json
+++ b/config/objects/moddables.json
@@ -155,18 +155,21 @@
 		"types" : {
 			"boatNecropolis" : { 
 				"index" : 0,
+				"compatibilityIdentifiers" : [ "evil" ],
 				"actualAnimation" : "AB01_.def",
 				"overlayAnimation" : "ABM01_.def",
 				"flagAnimations" : ["ABF01L", "ABF01G", "ABF01R", "ABF01D", "ABF01B", "ABF01P", "ABF01W", "ABF01K"]
 			},
 			"boatCastle" : { 
 				"index" : 1, 
+				"compatibilityIdentifiers" : [ "good" ],
 				"actualAnimation" : "AB02_.def",
 				"overlayAnimation" : "ABM02_.def",
 				"flagAnimations" : ["ABF02L", "ABF02G", "ABF02R", "ABF02D", "ABF02B", "ABF02P", "ABF02W", "ABF02K"]
 			},
 			"boatFortress" : {
 				"index" : 2, 
+				"compatibilityIdentifiers" : [ "neutral" ],
 				"actualAnimation" : "AB03_.def",
 				"overlayAnimation" : "ABM03_.def",
 				"flagAnimations" : ["ABF03L", "ABF03G", "ABF03R", "ABF03D", "ABF03B", "ABF03P", "ABF03W", "ABF03K"]

--- a/lib/battle/CBattleInfoCallback.cpp
+++ b/lib/battle/CBattleInfoCallback.cpp
@@ -742,15 +742,15 @@ DamageEstimation CBattleInfoCallback::battleEstimateDamage(const battle::Unit * 
 {
 	RETURN_IF_NOT_BATTLE({});
 	auto reachability = battleGetDistances(attacker, attacker->getPosition());
-	int getMovementRange = attackerPosition.isValid() ? reachability[attackerPosition] : 0;
-	return battleEstimateDamage(attacker, defender, getMovementRange, retaliationDmg);
+	int movementRange = attackerPosition.isValid() ? reachability[attackerPosition] : 0;
+	return battleEstimateDamage(attacker, defender, movementRange, retaliationDmg);
 }
 
-DamageEstimation CBattleInfoCallback::battleEstimateDamage(const battle::Unit * attacker, const battle::Unit * defender, int getMovementRange, DamageEstimation * retaliationDmg) const
+DamageEstimation CBattleInfoCallback::battleEstimateDamage(const battle::Unit * attacker, const battle::Unit * defender, int movementRange, DamageEstimation * retaliationDmg) const
 {
 	RETURN_IF_NOT_BATTLE({});
 	const bool shooting = battleCanShoot(attacker, defender->getPosition());
-	const BattleAttackInfo bai(attacker, defender, getMovementRange, shooting);
+	const BattleAttackInfo bai(attacker, defender, movementRange, shooting);
 	return battleEstimateDamage(bai, retaliationDmg);
 }
 

--- a/lib/constants/VariantIdentifier.h
+++ b/lib/constants/VariantIdentifier.h
@@ -32,18 +32,14 @@ public:
 	int32_t getNum() const
 	{
 		int32_t result;
-
 		std::visit([&result] (const auto& v) { result = v.getNum(); }, value);
-
 		return result;
 	}
 
 	std::string toString() const
 	{
 		std::string result;
-
 		std::visit([&result] (const auto& v) { result = v.encode(v.getNum()); }, value);
-
 		return result;
 	}
 
@@ -56,6 +52,13 @@ public:
 			return *result;
 		else
 			return IdentifierType();
+	}
+
+	bool hasValue() const
+	{
+		bool result = false;
+		std::visit([&result] (const auto& v) { result = v.hasValue(); }, value);
+		return result;
 	}
 
 	template <typename Handler> void serialize(Handler &h)

--- a/lib/mapObjects/CGDwelling.cpp
+++ b/lib/mapObjects/CGDwelling.cpp
@@ -424,7 +424,7 @@ void CGDwelling::heroAcceptsCreatures( const CGHeroInstance *h) const
 		if(count) //there are available creatures
 		{
 
-			if (VLC->settings()->getBoolean(EGameSettings::DWELLINGS_ACCUMULATE_WHEN_OWNED))
+			if (VLC->settings()->getBoolean(EGameSettings::DWELLINGS_MERGE_ON_RECRUIT))
 			{
 				SlotID testSlot = h->getSlotFor(crid);
 				if(!testSlot.validSlot()) //no available slot - try merging army of visiting hero

--- a/lib/rewardable/Reward.cpp
+++ b/lib/rewardable/Reward.cpp
@@ -115,8 +115,7 @@ void Rewardable::Reward::loadComponents(std::vector<Component> & comps, const CG
 		comps.emplace_back(ComponentType::ARTIFACT, entry);
 
 	for(const auto & entry : spells)
-		if (!h || h->canLearnSpell(entry.toEntity(VLC), true))
-			comps.emplace_back(ComponentType::SPELL, entry);
+		comps.emplace_back(ComponentType::SPELL, entry);
 
 	for(const auto & entry : creatures)
 		comps.emplace_back(ComponentType::CREATURE, entry.type->getId(), entry.count);

--- a/lib/rewardable/Reward.cpp
+++ b/lib/rewardable/Reward.cpp
@@ -115,7 +115,10 @@ void Rewardable::Reward::loadComponents(std::vector<Component> & comps, const CG
 		comps.emplace_back(ComponentType::ARTIFACT, entry);
 
 	for(const auto & entry : spells)
-		comps.emplace_back(ComponentType::SPELL, entry);
+	{
+		bool learnable = !h || h->canLearnSpell(entry.toEntity(VLC), true);
+		comps.emplace_back(ComponentType::SPELL, entry, learnable ?	0 : -1);
+	}
 
 	for(const auto & entry : creatures)
 		comps.emplace_back(ComponentType::CREATURE, entry.type->getId(), entry.count);

--- a/server/battles/BattleActionProcessor.cpp
+++ b/server/battles/BattleActionProcessor.cpp
@@ -494,7 +494,7 @@ bool BattleActionProcessor::doHealAction(const CBattleInfoCallback & battle, con
 	else
 		destStack = battle.battleGetUnitByPos(target.at(0).hexValue);
 
-	if(stack == nullptr || destStack == nullptr || !healerAbility || healerAbility->subtype == BonusSubtypeID())
+	if(stack == nullptr || destStack == nullptr || !healerAbility || !healerAbility->subtype.hasValue())
 	{
 		gameHandler->complain("There is either no healer, no destination, or healer cannot heal :P");
 	}
@@ -971,7 +971,7 @@ void BattleActionProcessor::makeAttack(const CBattleInfoCallback & battle, const
 	}
 
 	std::shared_ptr<const Bonus> bonus = attacker->getFirstBonus(Selector::type()(BonusType::SPELL_LIKE_ATTACK));
-	if(bonus && ranged) //TODO: make it work in melee?
+	if(bonus && ranged && bonus->subtype.hasValue()) //TODO: make it work in melee?
 	{
 		//this is need for displaying hit animation
 		bat.flags |= BattleAttack::SPELL_LIKE;


### PR DESCRIPTION
Not sure whether to release this as 1.5.6, or whether to release 1.5.6 at all. But at the very least it should be possible for tournament players to use this build in place of 1.5.5

Fixed issues reported in #4326:
- Do not hide spells that hero can't learn on receiving them from rewardable object, e.g. Pandora.
  - Also, spells that can not be learned will now be displayed with gray text in name
- Fixed some shortcuts not active during enemy turn, such as thieves guild
- Fixed ranged mode always used for damage preview, even when forcing melee attack
- Close all open dialogs on start of our turn, to prevent weird bugs like locked right-click popups

Other safe fixes:
- Fixed typo where incorrect game settings was used for dwelling recruitment to full garrison
- Fixed possible crash on invalid SPELL_LIKE_ATTACK bonus
- Added compatibility check for loading maps with old names for boats