### PR TITLE
[1.5.6?] online lobby - mod compatibility improvements

### DIFF
--- a/client/globalLobby/GlobalLobbyRoomWindow.cpp
+++ b/client/globalLobby/GlobalLobbyRoomWindow.cpp
@@ -58,7 +58,12 @@ GlobalLobbyRoomModCard::GlobalLobbyRoomModCard(const GlobalLobbyRoomModInfo & mo
 
 	labelName = std::make_shared<CLabel>(5, 10, FONT_SMALL, ETextAlignment::CENTERLEFT, Colors::WHITE, modInfo.modName);
 	labelVersion = std::make_shared<CLabel>(195, 30, FONT_SMALL, ETextAlignment::CENTERRIGHT, Colors::YELLOW, modInfo.version);
-	labelStatus = std::make_shared<CLabel>(5, 30, FONT_SMALL, ETextAlignment::CENTERLEFT, modInfo.status == ModVerificationStatus::FULL_MATCH ? Colors::YELLOW : Colors::RED, CGI->generaltexth->translate("vcmi.lobby.mod.state." + statusToString.at(modInfo.status)));
+	auto statusColor = Colors::RED;
+	if(modInfo.status == ModVerificationStatus::FULL_MATCH)
+		statusColor = ColorRGBA(128, 128, 128);
+	else if(modInfo.status == ModVerificationStatus::VERSION_MISMATCH)
+		statusColor = Colors::YELLOW;
+	labelStatus = std::make_shared<CLabel>(5, 30, FONT_SMALL, ETextAlignment::CENTERLEFT, statusColor, CGI->generaltexth->translate("vcmi.lobby.mod.state." + statusToString.at(modInfo.status)));
 }
 
 static const std::string getJoinRoomErrorMessage(const GlobalLobbyRoom & roomDescription, const std::vector<GlobalLobbyRoomModInfo> & modVerificationList)

--- a/client/globalLobby/GlobalLobbyRoomWindow.cpp
+++ b/client/globalLobby/GlobalLobbyRoomWindow.cpp
@@ -58,7 +58,7 @@ GlobalLobbyRoomModCard::GlobalLobbyRoomModCard(const GlobalLobbyRoomModInfo & mo
 
 	labelName = std::make_shared<CLabel>(5, 10, FONT_SMALL, ETextAlignment::CENTERLEFT, Colors::WHITE, modInfo.modName);
 	labelVersion = std::make_shared<CLabel>(195, 30, FONT_SMALL, ETextAlignment::CENTERRIGHT, Colors::YELLOW, modInfo.version);
-	labelStatus = std::make_shared<CLabel>(5, 30, FONT_SMALL, ETextAlignment::CENTERLEFT, Colors::YELLOW, CGI->generaltexth->translate("vcmi.lobby.mod.state." + statusToString.at(modInfo.status)));
+	labelStatus = std::make_shared<CLabel>(5, 30, FONT_SMALL, ETextAlignment::CENTERLEFT, modInfo.status == ModVerificationStatus::FULL_MATCH ? Colors::YELLOW : Colors::RED, CGI->generaltexth->translate("vcmi.lobby.mod.state." + statusToString.at(modInfo.status)));
 }
 
 static const std::string getJoinRoomErrorMessage(const GlobalLobbyRoom & roomDescription, const std::vector<GlobalLobbyRoomModInfo> & modVerificationList)
@@ -134,6 +134,13 @@ GlobalLobbyRoomWindow::GlobalLobbyRoomWindow(GlobalLobbyWindow * window, const s
 
 		modVerificationList.push_back(modInfo);
 	}
+	std::sort(modVerificationList.begin(), modVerificationList.end(), [](const GlobalLobbyRoomModInfo &a, const GlobalLobbyRoomModInfo &b)
+	{ 
+		if(a.status == b.status)
+			return a.modName < b.modName;
+
+		return a.status < b.status; 
+	});
 
 	MetaString subtitleText;
 	subtitleText.appendTextID("vcmi.lobby.preview.subtitle");


### PR DESCRIPTION
Fixes #4342

- compatible -> gray
- version conflict -> yellow
- other error -> red
- order for status: -> errors first -> then for name

![grafik](https://github.com/user-attachments/assets/28ba1bed-761b-46c8-b87b-75a5cf0420c1)