### PR TITLE
little optimization in MapRenderer

### DIFF
--- a/client/mapView/MapRendererContext.cpp
+++ b/client/mapView/MapRendererContext.cpp
@@ -113,7 +113,7 @@ const CGPath * MapRendererBaseContext::currentPath() const
 
 size_t MapRendererBaseContext::objectGroupIndex(ObjectInstanceID objectID) const
 {
-	static const std::vector<size_t> idleGroups = {0, 13, 0, 1, 2, 3, 4, 15, 14};
+	static const std::array<size_t, 9> idleGroups = {0, 13, 0, 1, 2, 3, 4, 15, 14};
 	return idleGroups[getObjectRotation(objectID)];
 }
 
@@ -403,7 +403,7 @@ size_t MapRendererAdventureMovingContext::objectGroupIndex(ObjectInstanceID obje
 {
 	if(target == objectID)
 	{
-		static const std::vector<size_t> moveGroups = {0, 10, 5, 6, 7, 8, 9, 12, 11};
+		static const std::array<size_t, 9> moveGroups = {0, 10, 5, 6, 7, 8, 9, 12, 11};
 		return moveGroups[getObjectRotation(objectID)];
 	}
 	return MapRendererAdventureContext::objectGroupIndex(objectID);


### PR DESCRIPTION
When we replace static const std::vector by std::array the compiler generates much shorter and nicer binary which doesn't waste time initializing data structure during runtime.