### PR TITLE
Hill Fort unavailable upgrade and status bar new messages

### DIFF
--- a/Mods/vcmi/config/vcmi/english.json
+++ b/Mods/vcmi/config/vcmi/english.json
@@ -517,7 +517,7 @@
 	"core.seerhut.quest.reachDate.visit.4" : "Closed till %s.",
 	"core.seerhut.quest.reachDate.visit.5" : "Closed till %s.",
 	
-	"mapObject.core.hillFort.object.description" : "Upgrades creatures. Levels 1 - 4 are less expensive than in associated town",
+	"mapObject.core.hillFort.object.description" : "Upgrades creatures. Levels 1 - 4 are less expensive than in associated town.",
 	
 	"core.bonus.ADDITIONAL_ATTACK.name": "Double Strike",
 	"core.bonus.ADDITIONAL_ATTACK.description": "Attacks twice",

--- a/Mods/vcmi/config/vcmi/english.json
+++ b/Mods/vcmi/config/vcmi/english.json
@@ -283,9 +283,6 @@
 
 	"vcmi.adventureMap.revisitObject.hover" : "Revisit Object",
 	"vcmi.adventureMap.revisitObject.help" : "{Revisit Object}\n\nIf a hero currently stands on a Map Object, he can revisit the location.",
-	"vcmi.adventureMap.miniHillFort.notAvailableUpgrade.message" : "This building cannot upgrade creatures of level 5 and higher.",
-	"vcmi.adventureMap.miniHillFort.statusBar.info" : "Upgrade creatures levels 1 - 5 at double the normal price",
-	"vcmi.adventureMap.HillFort.statusBar.info" : "Upgrades creatures. Levels 1 - 4 are less expensive than in associated town",
 
 	"vcmi.battleWindow.pressKeyToSkipIntro" : "Press any key to start battle immediately",
 	"vcmi.battleWindow.damageEstimation.melee" : "Attack %CREATURE (%DAMAGE).",
@@ -519,7 +516,9 @@
 	"core.seerhut.quest.reachDate.visit.3" : "Closed till %s.",
 	"core.seerhut.quest.reachDate.visit.4" : "Closed till %s.",
 	"core.seerhut.quest.reachDate.visit.5" : "Closed till %s.",
-
+	
+	"mapObject.core.hillFort.object.description" : "Upgrades creatures. Levels 1 - 4 are less expensive than in associated town",
+	
 	"core.bonus.ADDITIONAL_ATTACK.name": "Double Strike",
 	"core.bonus.ADDITIONAL_ATTACK.description": "Attacks twice",
 	"core.bonus.ADDITIONAL_RETALIATION.name": "Additional retaliations",

--- a/Mods/vcmi/config/vcmi/english.json
+++ b/Mods/vcmi/config/vcmi/english.json
@@ -283,6 +283,9 @@
 
 	"vcmi.adventureMap.revisitObject.hover" : "Revisit Object",
 	"vcmi.adventureMap.revisitObject.help" : "{Revisit Object}\n\nIf a hero currently stands on a Map Object, he can revisit the location.",
+	"vcmi.adventureMap.miniHillFort.notAvailableUpgrade.message" : "This building cannot upgrade creatures of level 5 and higher.",
+	"vcmi.adventureMap.miniHillFort.statusBar.info" : "Upgrade creatures levels 1 - 5 at double the normal price",
+	"vcmi.adventureMap.HillFort.statusBar.info" : "Upgrades creatures. Levels 1 - 4 are less expensive than in associated town",
 
 	"vcmi.battleWindow.pressKeyToSkipIntro" : "Press any key to start battle immediately",
 	"vcmi.battleWindow.damageEstimation.melee" : "Attack %CREATURE (%DAMAGE).",

--- a/Mods/vcmi/config/vcmi/polish.json
+++ b/Mods/vcmi/config/vcmi/polish.json
@@ -513,7 +513,9 @@
 	"core.seerhut.quest.reachDate.visit.3" : "Zamknięte do %s.",
 	"core.seerhut.quest.reachDate.visit.4" : "Zamknięte do %s.",
 	"core.seerhut.quest.reachDate.visit.5" : "Zamknięte do %s.",
-	"mapObject.core.hillFort.object.description" : "Ulepsza jednostki. Koszt ulepszenia dla poziomów 1 - 4 jest bardziej korzystny niż w mieście",
+	
+	"mapObject.core.hillFort.object.description" : "Ulepsza jednostki. Koszt ulepszenia dla poziomów 1 - 4 jest bardziej korzystny niż w mieście.",
+	
 	"core.bonus.ADDITIONAL_ATTACK.name": "Podwójne Uderzenie",
 	"core.bonus.ADDITIONAL_ATTACK.description": "Atakuje dwa razy",
 	"core.bonus.ADDITIONAL_RETALIATION.name": "Dodatkowy odwet",

--- a/Mods/vcmi/config/vcmi/polish.json
+++ b/Mods/vcmi/config/vcmi/polish.json
@@ -280,9 +280,6 @@
 
 	"vcmi.adventureMap.revisitObject.hover" : "Odwiedź obiekt ponownie",
 	"vcmi.adventureMap.revisitObject.help" : "{Odwiedź obiekt ponownie}\n\nJeżeli bohater aktualnie stoi na polu odwiedzającym obiekt za pomocą tego przycisku może go odwiedzić ponownie.",
-	"vcmi.adventureMap.miniHillFort.notAvailableUpgrade.message" : "Ten budynek nie ma możliwości ulepszenia jednostek poziomu 5 i wyższych.",
-	"vcmi.adventureMap.miniHillFort.statusBar.info" : "Ulepsza jednostki poziomu 1 - 5 za podwójną cenę",
-	"vcmi.adventureMap.HillFort.statusBar.info" : "Ulepsza jednostki. Koszt ulepszenia dla poziomów 1 - 4 są bardziej korzystne niż w mieście",
 
 	"vcmi.battleWindow.pressKeyToSkipIntro" : "Naciśnij dowolny klawisz by rozpocząć bitwę natychmiastowo",
 	"vcmi.battleWindow.damageEstimation.melee" : "Atakuj %CREATURE (%DAMAGE).",
@@ -516,7 +513,7 @@
 	"core.seerhut.quest.reachDate.visit.3" : "Zamknięte do %s.",
 	"core.seerhut.quest.reachDate.visit.4" : "Zamknięte do %s.",
 	"core.seerhut.quest.reachDate.visit.5" : "Zamknięte do %s.",
-
+	"mapObject.core.hillFort.object.description" : "Ulepsza jednostki. Koszt ulepszenia dla poziomów 1 - 4 są bardziej korzystne niż w mieście",
 	"core.bonus.ADDITIONAL_ATTACK.name": "Podwójne Uderzenie",
 	"core.bonus.ADDITIONAL_ATTACK.description": "Atakuje dwa razy",
 	"core.bonus.ADDITIONAL_RETALIATION.name": "Dodatkowy odwet",

--- a/Mods/vcmi/config/vcmi/polish.json
+++ b/Mods/vcmi/config/vcmi/polish.json
@@ -280,6 +280,9 @@
 
 	"vcmi.adventureMap.revisitObject.hover" : "Odwiedź obiekt ponownie",
 	"vcmi.adventureMap.revisitObject.help" : "{Odwiedź obiekt ponownie}\n\nJeżeli bohater aktualnie stoi na polu odwiedzającym obiekt za pomocą tego przycisku może go odwiedzić ponownie.",
+	"vcmi.adventureMap.miniHillFort.notAvailableUpgrade.message" : "Ten budynek nie ma możliwości ulepszenia jednostek poziomu 5 i wyższych.",
+	"vcmi.adventureMap.miniHillFort.statusBar.info" : "Ulepsza jednostki poziomu 1 - 5 za podwójną cenę",
+	"vcmi.adventureMap.HillFort.statusBar.info" : "Ulepsza jednostki. Koszt ulepszenia dla poziomów 1 - 4 są bardziej korzystne niż w mieście",
 
 	"vcmi.battleWindow.pressKeyToSkipIntro" : "Naciśnij dowolny klawisz by rozpocząć bitwę natychmiastowo",
 	"vcmi.battleWindow.damageEstimation.melee" : "Atakuj %CREATURE (%DAMAGE).",

--- a/Mods/vcmi/config/vcmi/polish.json
+++ b/Mods/vcmi/config/vcmi/polish.json
@@ -513,7 +513,7 @@
 	"core.seerhut.quest.reachDate.visit.3" : "Zamknięte do %s.",
 	"core.seerhut.quest.reachDate.visit.4" : "Zamknięte do %s.",
 	"core.seerhut.quest.reachDate.visit.5" : "Zamknięte do %s.",
-	"mapObject.core.hillFort.object.description" : "Ulepsza jednostki. Koszt ulepszenia dla poziomów 1 - 4 są bardziej korzystne niż w mieście",
+	"mapObject.core.hillFort.object.description" : "Ulepsza jednostki. Koszt ulepszenia dla poziomów 1 - 4 jest bardziej korzystny niż w mieście",
 	"core.bonus.ADDITIONAL_ATTACK.name": "Podwójne Uderzenie",
 	"core.bonus.ADDITIONAL_ATTACK.description": "Atakuje dwa razy",
 	"core.bonus.ADDITIONAL_RETALIATION.name": "Dodatkowy odwet",

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -1129,6 +1129,12 @@ CHillFortWindow::CHillFortWindow(const CGHeroInstance * visitor, const CGObjectI
 	statusbar = CGStatusBar::create(std::make_shared<CPicture>(background->getSurface(), Rect(8, pos.h - 26, pos.w - 16, 19), 8, pos.h - 26));
 
 	garr = std::make_shared<CGarrisonInt>(Point(108, 60), 18, Point(), hero, nullptr);
+
+	if(object->typeName == "miniHillFort")
+		statusbar->write(VLC->generaltexth->translate("vcmi.adventureMap.miniHillFort.statusBar.info"));
+	else if(object->typeName == "hillFort")
+		statusbar->write(VLC->generaltexth->translate("vcmi.adventureMap.HillFort.statusBar.info"));
+
 	updateGarrisons();
 }
 
@@ -1146,11 +1152,25 @@ void CHillFortWindow::updateGarrisons()
 
 	TResources totalSum; // totalSum[resource ID] = value
 
+	auto getImgIdx = [](CHillFortWindow::State st) -> std::size_t
+	{
+		switch (st)
+		{
+		case State::EMPTY:
+			return 0;
+		case State::UNAVAILABLE:
+		case State::ALREADY_UPGRADED:
+			return 1;
+		default:
+			return static_cast<std::size_t>(st);
+		}
+	};
+
 	for(int i=0; i<slotsCount; i++)
 	{
 		std::fill(costs[i].begin(), costs[i].end(), 0);
-		int newState = getState(SlotID(i));
-		if(newState != -1)
+		State newState = getState(SlotID(i));
+		if(newState != State::EMPTY)
 		{
 			UpgradeInfo info;
 			LOCPLINT->cb->fillUpgradeInfo(hero, SlotID(i), info);
@@ -1162,29 +1182,29 @@ void CHillFortWindow::updateGarrisons()
 		}
 
 		currState[i] = newState;
-		upgrade[i]->setImage(AnimationPath::builtin(currState[i] == -1 ? slotImages[0] : slotImages[currState[i]]));
-		upgrade[i]->block(currState[i] == -1);
+		upgrade[i]->setImage(AnimationPath::builtin(slotImages[getImgIdx(currState[i])]));
+		upgrade[i]->block(currState[i] == State::EMPTY);
 		upgrade[i]->addHoverText(EButtonState::NORMAL, getTextForSlot(SlotID(i)));
 	}
 
 	//"Upgrade all" slot
-	int newState = 2;
+	State newState = State::MAKE_UPGRADE;
 	{
 		TResources myRes = LOCPLINT->cb->getResourceAmount();
 
 		bool allUpgraded = true;//All creatures are upgraded?
 		for(int i=0; i<slotsCount; i++)
-			allUpgraded &= currState[i] == 1 || currState[i] == -1;
+			allUpgraded &= currState[i] == State::ALREADY_UPGRADED || currState[i] == State::EMPTY || currState[i] == State::UNAVAILABLE;
 
-		if(allUpgraded)
-			newState = 1;
+		if (allUpgraded)
+			newState = State::ALREADY_UPGRADED;
 
 		if(!totalSum.canBeAfforded(myRes))
-			newState = 0;
+			newState = State::UNAFORDABLE;
 	}
 
 	currState[slotsCount] = newState;
-	upgradeAll->setImage(AnimationPath::builtin(allImages[newState]));
+	upgradeAll->setImage(AnimationPath::builtin(allImages[static_cast<std::size_t>(newState)]));
 
 	garr->recreateSlots();
 
@@ -1197,7 +1217,7 @@ void CHillFortWindow::updateGarrisons()
 			slotLabels[i][j]->setText("");
 		}
 		//if can upgrade or can not afford, draw cost
-		if(currState[i] == 0 || currState[i] == 2)
+		if(currState[i] == State::UNAFORDABLE || currState[i] == State::MAKE_UPGRADE)
 		{
 			if(costs[i].nonZero())
 			{
@@ -1246,16 +1266,20 @@ void CHillFortWindow::makeDeal(SlotID slot)
 	int offset = (slot.getNum() == slotsCount)?2:0;
 	switch(currState[slot.getNum()])
 	{
-		case 0:
-			LOCPLINT->showInfoDialog(CGI->generaltexth->allTexts[314 + offset], std::vector<std::shared_ptr<CComponent>>(), soundBase::sound_todo);
-			break;
-		case 1:
+		case State::ALREADY_UPGRADED:
 			LOCPLINT->showInfoDialog(CGI->generaltexth->allTexts[313 + offset], std::vector<std::shared_ptr<CComponent>>(), soundBase::sound_todo);
 			break;
-		case 2:
-			for(int i=0; i<slotsCount; i++)
+		case State::UNAFORDABLE:
+			LOCPLINT->showInfoDialog(CGI->generaltexth->allTexts[314 + offset], std::vector<std::shared_ptr<CComponent>>(), soundBase::sound_todo);
+			break;
+		case State::UNAVAILABLE:
+			LOCPLINT->showInfoDialog(VLC->generaltexth->translate("vcmi.adventureMap.miniHillFort.notAvailableUpgrade.message"), 
+									 std::vector<std::shared_ptr<CComponent>>(), soundBase::sound_todo);
+			break;
+		case State::MAKE_UPGRADE:
+			for(int i = 0; i < slotsCount; i++)
 			{
-				if(slot.getNum() ==i || ( slot.getNum() == slotsCount && currState[i] == 2 ))//this is activated slot or "upgrade all"
+				if(slot.getNum() == i || ( slot.getNum() == slotsCount && currState[i] == State::MAKE_UPGRADE ))//this is activated slot or "upgrade all"
 				{
 					UpgradeInfo info;
 					LOCPLINT->cb->fillUpgradeInfo(hero, SlotID(i), info);
@@ -1281,22 +1305,28 @@ std::string CHillFortWindow::getTextForSlot(SlotID slot)
 	return str;
 }
 
-int CHillFortWindow::getState(SlotID slot)
+CHillFortWindow::State CHillFortWindow::getState(SlotID slot)
 {
 	TResources myRes = LOCPLINT->cb->getResourceAmount();
 
-	if(hero->slotEmpty(slot))//no creature here
-		return -1;
+	if(hero->slotEmpty(slot))
+		return State::EMPTY;
 
 	UpgradeInfo info;
 	LOCPLINT->cb->fillUpgradeInfo(hero, slot, info);
-	if(!info.newID.size())//already upgraded
-		return 1;
+	if (!info.newID.size())
+	{
+		// new Hill Fort allows upgrades level 5 and below
+		if (hero->getStack(slot).type->getLevel() >= 5 && hero->getCreature(slot)->hasUpgrades())
+			return State::UNAVAILABLE;
+
+		return State::ALREADY_UPGRADED;
+	}
 
 	if(!(info.cost[0] * hero->getStackCount(slot)).canBeAfforded(myRes))
-		return 0;
+		return State::UNAFORDABLE;
 
-	return 2;//can upgrade
+	return State::MAKE_UPGRADE;
 }
 
 CThievesGuildWindow::CThievesGuildWindow(const CGObjectInstance * _owner):

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -1130,10 +1130,7 @@ CHillFortWindow::CHillFortWindow(const CGHeroInstance * visitor, const CGObjectI
 
 	garr = std::make_shared<CGarrisonInt>(Point(108, 60), 18, Point(), hero, nullptr);
 
-	if(object->typeName == "miniHillFort")
-		statusbar->write(VLC->generaltexth->translate("vcmi.adventureMap.miniHillFort.statusBar.info"));
-	else if(object->typeName == "hillFort")
-		statusbar->write(VLC->generaltexth->translate("vcmi.adventureMap.HillFort.statusBar.info"));
+	statusbar->write(dynamic_cast<const HillFort *>(fort)->getDescriptionToolTip());
 
 	updateGarrisons();
 }
@@ -1273,7 +1270,7 @@ void CHillFortWindow::makeDeal(SlotID slot)
 			LOCPLINT->showInfoDialog(CGI->generaltexth->allTexts[314 + offset], std::vector<std::shared_ptr<CComponent>>(), soundBase::sound_todo);
 			break;
 		case State::UNAVAILABLE:
-			LOCPLINT->showInfoDialog(VLC->generaltexth->translate("vcmi.adventureMap.miniHillFort.notAvailableUpgrade.message"), 
+			LOCPLINT->showInfoDialog(dynamic_cast<const HillFort*>(fort)->getUnavailableUpgradeMessage(),
 									 std::vector<std::shared_ptr<CComponent>>(), soundBase::sound_todo);
 			break;
 		case State::MAKE_UPGRADE:
@@ -1314,10 +1311,10 @@ CHillFortWindow::State CHillFortWindow::getState(SlotID slot)
 
 	UpgradeInfo info;
 	LOCPLINT->cb->fillUpgradeInfo(hero, slot, info);
-	if (!info.newID.size())
+	if (info.newID.empty())
 	{
-		// new Hill Fort allows upgrades level 5 and below
-		if (hero->getStack(slot).type->getLevel() >= 5 && hero->getCreature(slot)->hasUpgrades())
+		// Hill Fort may limit level of upgradeable creatures, e.g. mini Hill Fort from HOTA
+		if (hero->getCreature(slot)->hasUpgrades())
 			return State::UNAVAILABLE;
 
 		return State::ALREADY_UPGRADED;

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -1173,7 +1173,7 @@ void CHillFortWindow::updateGarrisons()
 			LOCPLINT->cb->fillUpgradeInfo(hero, SlotID(i), info);
 			if(info.newID.size())//we have upgrades here - update costs
 			{
-				costs[i] = info.cost[0] * hero->getStackCount(SlotID(i));
+				costs[i] = info.cost.back() * hero->getStackCount(SlotID(i));
 				totalSum += costs[i];
 			}
 		}
@@ -1259,8 +1259,8 @@ void CHillFortWindow::updateGarrisons()
 
 void CHillFortWindow::makeDeal(SlotID slot)
 {
-	assert(slot.getNum()>=0);
-	int offset = (slot.getNum() == slotsCount)?2:0;
+	assert(slot.getNum() >= 0);
+	int offset = (slot.getNum() == slotsCount) ? 2 : 0;
 	switch(currState[slot.getNum()])
 	{
 		case State::ALREADY_UPGRADED:
@@ -1280,7 +1280,7 @@ void CHillFortWindow::makeDeal(SlotID slot)
 				{
 					UpgradeInfo info;
 					LOCPLINT->cb->fillUpgradeInfo(hero, SlotID(i), info);
-					LOCPLINT->cb->upgradeCreature(hero, SlotID(i), info.newID[0]);
+					LOCPLINT->cb->upgradeCreature(hero, SlotID(i), info.newID.back());
 				}
 			}
 			break;
@@ -1320,7 +1320,7 @@ CHillFortWindow::State CHillFortWindow::getState(SlotID slot)
 		return State::ALREADY_UPGRADED;
 	}
 
-	if(!(info.cost[0] * hero->getStackCount(slot)).canBeAfforded(myRes))
+	if(!(info.cost.back() * hero->getStackCount(slot)).canBeAfforded(myRes))
 		return State::UNAFFORDABLE;
 
 	return State::MAKE_UPGRADE;

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -1130,7 +1130,7 @@ CHillFortWindow::CHillFortWindow(const CGHeroInstance * visitor, const CGObjectI
 
 	garr = std::make_shared<CGarrisonInt>(Point(108, 60), 18, Point(), hero, nullptr);
 
-	statusbar->write(dynamic_cast<const HillFort *>(fort)->getDescriptionToolTip());
+	statusbar->write(VLC->generaltexth->translate(dynamic_cast<const HillFort *>(fort)->getDescriptionToolTip()));
 
 	updateGarrisons();
 }
@@ -1270,9 +1270,11 @@ void CHillFortWindow::makeDeal(SlotID slot)
 			LOCPLINT->showInfoDialog(CGI->generaltexth->allTexts[314 + offset], std::vector<std::shared_ptr<CComponent>>(), soundBase::sound_todo);
 			break;
 		case State::UNAVAILABLE:
-			LOCPLINT->showInfoDialog(dynamic_cast<const HillFort*>(fort)->getUnavailableUpgradeMessage(),
-									 std::vector<std::shared_ptr<CComponent>>(), soundBase::sound_todo);
+		{
+			std::string message = VLC->generaltexth->translate(dynamic_cast<const HillFort *>(fort)->getUnavailableUpgradeMessage());
+			LOCPLINT->showInfoDialog(message, std::vector<std::shared_ptr<CComponent>>(), soundBase::sound_todo);
 			break;
+		}
 		case State::MAKE_UPGRADE:
 			for(int i = 0; i < slotsCount; i++)
 			{

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -1200,7 +1200,7 @@ void CHillFortWindow::updateGarrisons()
 			newState = State::ALREADY_UPGRADED;
 
 		if(!totalSum.canBeAfforded(myRes))
-			newState = State::UNAFORDABLE;
+			newState = State::UNAFFORDABLE;
 	}
 
 	currState[slotsCount] = newState;
@@ -1217,7 +1217,7 @@ void CHillFortWindow::updateGarrisons()
 			slotLabels[i][j]->setText("");
 		}
 		//if can upgrade or can not afford, draw cost
-		if(currState[i] == State::UNAFORDABLE || currState[i] == State::MAKE_UPGRADE)
+		if(currState[i] == State::UNAFFORDABLE || currState[i] == State::MAKE_UPGRADE)
 		{
 			if(costs[i].nonZero())
 			{
@@ -1269,7 +1269,7 @@ void CHillFortWindow::makeDeal(SlotID slot)
 		case State::ALREADY_UPGRADED:
 			LOCPLINT->showInfoDialog(CGI->generaltexth->allTexts[313 + offset], std::vector<std::shared_ptr<CComponent>>(), soundBase::sound_todo);
 			break;
-		case State::UNAFORDABLE:
+		case State::UNAFFORDABLE:
 			LOCPLINT->showInfoDialog(CGI->generaltexth->allTexts[314 + offset], std::vector<std::shared_ptr<CComponent>>(), soundBase::sound_todo);
 			break;
 		case State::UNAVAILABLE:
@@ -1324,7 +1324,7 @@ CHillFortWindow::State CHillFortWindow::getState(SlotID slot)
 	}
 
 	if(!(info.cost[0] * hero->getStackCount(slot)).canBeAfforded(myRes))
-		return State::UNAFORDABLE;
+		return State::UNAFFORDABLE;
 
 	return State::MAKE_UPGRADE;
 }

--- a/client/windows/GUIClasses.h
+++ b/client/windows/GUIClasses.h
@@ -445,7 +445,7 @@ class CHillFortWindow : public CStatusbarWindow, public IGarrisonHolder
 {
 private:
 
-	enum class State { UNAFORDABLE, ALREADY_UPGRADED, MAKE_UPGRADE, EMPTY, UNAVAILABLE };
+	enum class State { UNAFFORDABLE, ALREADY_UPGRADED, MAKE_UPGRADE, EMPTY, UNAVAILABLE };
 	static constexpr std::size_t slotsCount = 7;
 	//todo: mithril support
 	static constexpr std::size_t resCount = 7;

--- a/client/windows/GUIClasses.h
+++ b/client/windows/GUIClasses.h
@@ -444,9 +444,11 @@ public:
 class CHillFortWindow : public CStatusbarWindow, public IGarrisonHolder
 {
 private:
-	static const int slotsCount = 7;
+
+	enum class State { UNAFORDABLE, ALREADY_UPGRADED, MAKE_UPGRADE, EMPTY, UNAVAILABLE };
+	static constexpr std::size_t slotsCount = 7;
 	//todo: mithril support
-	static const int resCount = 7;
+	static constexpr std::size_t resCount = 7;
 
 	const CGObjectInstance * fort;
 	const CGHeroInstance * hero;
@@ -458,7 +460,7 @@ private:
 	std::array<std::shared_ptr<CLabel>, resCount> totalLabels;
 
 	std::array<std::shared_ptr<CButton>, slotsCount> upgrade;//upgrade single creature
-	std::array<int, slotsCount + 1> currState;//current state of slot - to avoid calls to getState or updating buttons
+	std::array<State, slotsCount + 1> currState;//current state of slot - to avoid calls to getState or updating buttons
 
 	//there is a place for only 2 resources per slot
 	std::array< std::array<std::shared_ptr<CAnimImage>, 2>, slotsCount> slotIcons;
@@ -473,7 +475,7 @@ private:
 	std::string getTextForSlot(SlotID slot);
 
 	void makeDeal(SlotID slot);//-1 for upgrading all creatures
-	int getState(SlotID slot); //-1 = no creature 0=can't upgrade, 1=upgraded, 2=can upgrade
+	State getState(SlotID slot);
 public:
 	CHillFortWindow(const CGHeroInstance * visitor, const CGObjectInstance * object);
 	void updateGarrisons() override;//update buttons after garrison changes

--- a/config/objects/generic.json
+++ b/config/objects/generic.json
@@ -683,6 +683,7 @@
 			"object" : {
 				"index" : 0,
 				"aiValue" : 7000,
+				"description" : "",
 				"rmg" : {
 					"zoneLimit"	: 1,
 					"value"		: 7000,

--- a/lib/mapObjectConstructors/HillFortInstanceConstructor.cpp
+++ b/lib/mapObjectConstructors/HillFortInstanceConstructor.cpp
@@ -25,13 +25,6 @@ void HillFortInstanceConstructor::initTypeData(const JsonNode & config)
 void HillFortInstanceConstructor::initializeObject(HillFort * fort) const
 {
 	fort->upgradeCostPercentage = parameters["upgradeCostFactor"].convertTo<std::vector<int>>();
-	fort->descriptionToolTip = VLC->generaltexth->translate(TextIdentifier(getBaseTextID(), "description").get());
-	if (fort->descriptionToolTip.empty())
-		fort->descriptionToolTip = parameters["description"].String();		
-
-	fort->unavailableUpgradeMessage = VLC->generaltexth->translate(TextIdentifier(getBaseTextID(), "unavailableUpgradeMessage").get());
-	if (fort->unavailableUpgradeMessage.empty())
-		fort->unavailableUpgradeMessage = parameters["unavailableUpgradeMessage"].String();
 }
 
 VCMI_LIB_NAMESPACE_END

--- a/lib/mapObjectConstructors/HillFortInstanceConstructor.cpp
+++ b/lib/mapObjectConstructors/HillFortInstanceConstructor.cpp
@@ -11,17 +11,27 @@
 #include "HillFortInstanceConstructor.h"
 
 #include "../mapObjects/MiscObjects.h"
+#include "../texts/CGeneralTextHandler.h"
 
 VCMI_LIB_NAMESPACE_BEGIN
 
 void HillFortInstanceConstructor::initTypeData(const JsonNode & config)
 {
 	parameters = config;
+	VLC->generaltexth->registerString(parameters.getModScope(), TextIdentifier(getBaseTextID(), "unavailableUpgradeMessage"), parameters["unavailableUpgradeMessage"].String());
+	VLC->generaltexth->registerString(parameters.getModScope(), TextIdentifier(getBaseTextID(), "description"), parameters["description"].String());
 }
 
 void HillFortInstanceConstructor::initializeObject(HillFort * fort) const
 {
 	fort->upgradeCostPercentage = parameters["upgradeCostFactor"].convertTo<std::vector<int>>();
+	fort->descriptionToolTip = VLC->generaltexth->translate(TextIdentifier(getBaseTextID(), "description").get());
+	if (fort->descriptionToolTip.empty())
+		fort->descriptionToolTip = parameters["description"].String();		
+
+	fort->unavailableUpgradeMessage = VLC->generaltexth->translate(TextIdentifier(getBaseTextID(), "unavailableUpgradeMessage").get());
+	if (fort->unavailableUpgradeMessage.empty())
+		fort->unavailableUpgradeMessage = parameters["unavailableUpgradeMessage"].String();
 }
 
 VCMI_LIB_NAMESPACE_END

--- a/lib/mapObjects/MiscObjects.cpp
+++ b/lib/mapObjects/MiscObjects.cpp
@@ -1403,4 +1403,14 @@ void HillFort::fillUpgradeInfo(UpgradeInfo & info, const CStackInstance &stack) 
 	}
 }
 
+std::string HillFort::getDescriptionToolTip() const
+{
+	return TextIdentifier(getObjectHandler()->getBaseTextID(), "description").get();
+}
+
+std::string HillFort::getUnavailableUpgradeMessage() const
+{
+	return TextIdentifier(getObjectHandler()->getBaseTextID(), "unavailableUpgradeMessage").get();
+}
+
 VCMI_LIB_NAMESPACE_END

--- a/lib/mapObjects/MiscObjects.h
+++ b/lib/mapObjects/MiscObjects.h
@@ -451,8 +451,6 @@ class DLL_LINKAGE HillFort : public CGObjectInstance, public ICreatureUpgrader
 	friend class HillFortInstanceConstructor;
 
 	std::vector<int> upgradeCostPercentage;
-	std::string descriptionToolTip;
-	std::string unavailableUpgradeMessage;
 
 protected:
 	void onHeroVisit(const CGHeroInstance * h) const override;
@@ -461,22 +459,13 @@ protected:
 public:
 	using CGObjectInstance::CGObjectInstance;
 
-	const std::string & getDescriptionToolTip() const
-	{
-		return descriptionToolTip;
-	}
-
-	const std::string & getUnavailableUpgradeMessage() const
-	{
-		return unavailableUpgradeMessage;
-	}
+	std::string getDescriptionToolTip() const;
+	std::string getUnavailableUpgradeMessage() const;
 
 	template <typename Handler> void serialize(Handler &h)
 	{
 		h & static_cast<CGObjectInstance&>(*this);
 		h & upgradeCostPercentage;
-		h & descriptionToolTip;
-		h & unavailableUpgradeMessage;
 	}
 };
 

--- a/lib/mapObjects/MiscObjects.h
+++ b/lib/mapObjects/MiscObjects.h
@@ -451,6 +451,8 @@ class DLL_LINKAGE HillFort : public CGObjectInstance, public ICreatureUpgrader
 	friend class HillFortInstanceConstructor;
 
 	std::vector<int> upgradeCostPercentage;
+	std::string descriptionToolTip;
+	std::string unavailableUpgradeMessage;
 
 protected:
 	void onHeroVisit(const CGHeroInstance * h) const override;
@@ -459,10 +461,22 @@ protected:
 public:
 	using CGObjectInstance::CGObjectInstance;
 
+	const std::string & getDescriptionToolTip() const
+	{
+		return descriptionToolTip;
+	}
+
+	const std::string & getUnavailableUpgradeMessage() const
+	{
+		return unavailableUpgradeMessage;
+	}
+
 	template <typename Handler> void serialize(Handler &h)
 	{
 		h & static_cast<CGObjectInstance&>(*this);
 		h & upgradeCostPercentage;
+		h & descriptionToolTip;
+		h & unavailableUpgradeMessage;
 	}
 };
 


### PR DESCRIPTION
Some players get confused when they can't upgrade their units in Hota's (aka wooden or mini) Hill Fort. They get rather misleading message that the creature is already upgraded, when in fact it is in its basic level.
This PR adds new message for that case and also shows some additional info on the status bar about the building.