### PR TITLE
make armageddon can effect to allied creatures in ENCHANTER bonus

### DIFF
--- a/server/battles/BattleFlowProcessor.cpp
+++ b/server/battles/BattleFlowProcessor.cpp
@@ -326,8 +326,10 @@ void BattleFlowProcessor::activateNextStack(const CBattleInfoCallback & battle)
 
 		if (!tryMakeAutomaticAction(battle, next))
 		{
-			setActiveStack(battle, next);
-			break;
+			if(next->alive()) {
+				setActiveStack(battle, next);
+				break;
+			}
 		}
 	}
 }
@@ -757,8 +759,11 @@ void BattleFlowProcessor::stackTurnTrigger(const CBattleInfoCallback & battle, c
 				});
 				spells::BattleCast parameters(&battle, st, spells::Mode::ENCHANTER, spell);
 				parameters.setSpellLevel(bonus->val);
-				parameters.massive = true;
-				parameters.smart = true;
+				//todo: not hardcode
+				if (spellID != SpellID::ARMAGEDDON) {
+					parameters.massive = true;
+					parameters.smart = true;
+				}
 				//todo: recheck effect level
 				if(parameters.castIfPossible(gameHandler->spellEnv, spells::Target(1, spells::Destination())))
 				{

--- a/server/battles/BattleFlowProcessor.cpp
+++ b/server/battles/BattleFlowProcessor.cpp
@@ -23,6 +23,7 @@
 #include "../../lib/mapObjects/CGTownInstance.h"
 #include "../../lib/networkPacks/PacksForClientBattle.h"
 #include "../../lib/spells/BonusCaster.h"
+#include "../../lib/spells/CSpellHandler.h"
 #include "../../lib/spells/ISpellMechanics.h"
 #include "../../lib/spells/ObstacleCasterProxy.h"
 
@@ -128,7 +129,7 @@ void BattleFlowProcessor::tryPlaceMoats(const CBattleInfoCallback & battle)
 void BattleFlowProcessor::onBattleStarted(const CBattleInfoCallback & battle)
 {
 	tryPlaceMoats(battle);
-	
+
 	gameHandler->turnTimerHandler->onBattleStart(battle.getBattle()->getBattleID());
 
 	if (battle.battleGetTacticDist() == 0)
@@ -321,7 +322,7 @@ void BattleFlowProcessor::activateNextStack(const CBattleInfoCallback & battle)
 
 		if(!removeGhosts.changedStacks.empty())
 			gameHandler->sendAndApply(&removeGhosts);
-		
+
 		gameHandler->turnTimerHandler->onBattleNextStack(battle.getBattle()->getBattleID(), *next);
 
 		if (!tryMakeAutomaticAction(battle, next))
@@ -759,8 +760,11 @@ void BattleFlowProcessor::stackTurnTrigger(const CBattleInfoCallback & battle, c
 				});
 				spells::BattleCast parameters(&battle, st, spells::Mode::ENCHANTER, spell);
 				parameters.setSpellLevel(bonus->val);
-				//todo: not hardcode
-				if (spellID != SpellID::ARMAGEDDON) {
+
+				auto &levelInfo = spell->getLevelInfo(bonus->val);
+				bool isDamageSpell = spell->isDamage() || spell->isOffensive();
+				if (!isDamageSpell || levelInfo.smartTarget || levelInfo.range != "X")
+				{
 					parameters.massive = true;
 					parameters.smart = true;
 				}


### PR DESCRIPTION
in ENCHANTER bonus, when spell is armageddon, only empty will be effected. So I not setting massive and smart mark when spell ID is armageddon.