### PR TITLE
Update googletest submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "test/googletest"]
 	path = test/googletest
 	url = https://github.com/google/googletest
-	branch = v1.13.x
+	branch = v1.15.x
 [submodule "AI/FuzzyLite"]
 	path = AI/FuzzyLite
 	url = https://github.com/fuzzylite/fuzzylite.git


### PR DESCRIPTION
Fixes the following warning occurring during the linux-clang-test CI builds:

```
[824/832] Building CXX object test/googletest/googletest/CMakeFiles/gtest.dir/src/gtest-all.cc.o In file included from /home/runner/work/vcmi/vcmi/test/googletest/googletest/src/gtest-all.cc:38: In file included from /home/runner/work/vcmi/vcmi/test/googletest/googletest/include/gtest/gtest.h:65: In file included from /home/runner/work/vcmi/vcmi/test/googletest/googletest/include/gtest/gtest-death-test.h:43: In file included from /home/runner/work/vcmi/vcmi/test/googletest/googletest/include/gtest/internal/gtest-death-test-internal.h:47: In file included from /home/runner/work/vcmi/vcmi/test/googletest/googletest/include/gtest/gtest-matchers.h:48: /home/runner/work/vcmi/vcmi/test/googletest/googletest/include/gtest/gtest-printers.h:532:9: warning: implicit conversion from 'int32_t' (aka 'int') to 'float' may lose precision [-Wimplicit-int-float-conversion]
  532 |     if (static_cast<int32_t>(val * mulfor6 + 0.5) / mulfor6 == val) return 6;
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ~
/home/runner/work/vcmi/vcmi/test/googletest/googletest/include/gtest/gtest-printers.h:551:17: note: in instantiation of function template specialization 'testing::internal::AppropriateResolution<float>' requested here
  551 |   os->precision(AppropriateResolution(f));
      |                 ^
/home/runner/work/vcmi/vcmi/test/googletest/googletest/include/gtest/gtest-printers.h:544:9: warning: implicit conversion from 'int32_t' (aka 'int') to 'float' may lose precision [-Wimplicit-int-float-conversion]
  544 |     if (static_cast<int32_t>(val / divfor6 + 0.5) * divfor6 == val) return 6;
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ~
2 warnings generated.
```