### PR TITLE
Fixes for 1.5.6 release

### DIFF
--- a/client/gui/CGuiHandler.cpp
+++ b/client/gui/CGuiHandler.cpp
@@ -19,6 +19,7 @@
 #include "../eventsSDL/InputHandler.h"
 
 #include "../CGameInfo.h"
+#include "../adventureMap/AdventureMapInterface.h"
 #include "../render/Colors.h"
 #include "../render/Graphics.h"
 #include "../render/IFont.h"
@@ -145,7 +146,13 @@ CGuiHandler::CGuiHandler()
 {
 }
 
-CGuiHandler::~CGuiHandler() = default;
+CGuiHandler::~CGuiHandler()
+{
+	// enforce deletion order on shutdown
+	// all UI elements including adventure map must be destroyed before Gui Handler
+	// proper solution would be removal of adventureInt global
+	adventureInt.reset();
+}
 
 ShortcutHandler & CGuiHandler::shortcuts()
 {

--- a/lib/gameState/CGameStateCampaign.cpp
+++ b/lib/gameState/CGameStateCampaign.cpp
@@ -130,13 +130,15 @@ void CGameStateCampaign::trimCrossoverHeroesParameters(const CampaignTravel & tr
 				if(!art)
 					return false;
 
-				bool takeable = travelOptions.artifactsKeptByHero.count(art->artType->getId());
+				ArtifactLocation al(hero.hero->id, artifactPosition);
 
-				if (takeable)
+				bool takeable = travelOptions.artifactsKeptByHero.count(art->artType->getId());
+				bool locked = hero.hero->getSlot(al.slot)->locked;
+
+				if (!locked && takeable)
 					hero.transferrableArtifacts.push_back(artifactPosition);
 
-				ArtifactLocation al(hero.hero->id, artifactPosition);
-				if(!takeable && !hero.hero->getSlot(al.slot)->locked)  //don't try removing locked artifacts -> it crashes #1719
+				if (!locked && !takeable)
 				{
 					hero.hero->getArt(al.slot)->removeFrom(*hero.hero, al.slot);
 					return true;

--- a/lib/mapObjects/CGDwelling.cpp
+++ b/lib/mapObjects/CGDwelling.cpp
@@ -346,15 +346,19 @@ void CGDwelling::newTurn(CRandomGenerator & rand) const
 
 std::vector<Component> CGDwelling::getPopupComponents(PlayerColor player) const
 {
-	if (getOwner() != player)
-		return {};
+	bool visitedByOwner = getOwner() == player;
 
 	std::vector<Component> result;
 
 	if (ID == Obj::CREATURE_GENERATOR1 && !creatures.empty())
 	{
 		for (auto const & creature : creatures.front().second)
-			result.emplace_back(ComponentType::CREATURE, creature, creatures.front().first);
+		{
+			if (visitedByOwner)
+				result.emplace_back(ComponentType::CREATURE, creature, creatures.front().first);
+			else
+				result.emplace_back(ComponentType::CREATURE, creature);
+		}
 	}
 
 	if (ID == Obj::CREATURE_GENERATOR4)
@@ -362,7 +366,12 @@ std::vector<Component> CGDwelling::getPopupComponents(PlayerColor player) const
 		for (auto const & creatureLevel : creatures)
 		{
 			if (!creatureLevel.second.empty())
-				result.emplace_back(ComponentType::CREATURE, creatureLevel.second.back(), creatureLevel.first);
+			{
+				if (visitedByOwner)
+					result.emplace_back(ComponentType::CREATURE, creatureLevel.second.back(), creatureLevel.first);
+				else
+					result.emplace_back(ComponentType::CREATURE, creatureLevel.second.back());
+			}
 		}
 	}
 	return result;

--- a/lib/mapObjects/CGHeroInstance.cpp
+++ b/lib/mapObjects/CGHeroInstance.cpp
@@ -1709,6 +1709,16 @@ void CGHeroInstance::serializeJsonOptions(JsonSerializeFormat & handler)
 			setHeroTypeName(typeName);
 	}
 
+	if(!handler.saving)
+	{
+		if(!appearance)
+		{
+			// crossoverDeserialize
+			type = getHeroType().toHeroType();
+			appearance = VLC->objtypeh->getHandlerFor(Obj::HERO, type->heroClass->getIndex())->getTemplates().front();
+		}
+	}
+
 	CArmedInstance::serializeJsonOptions(handler);
 
 	{
@@ -1724,13 +1734,6 @@ void CGHeroInstance::serializeJsonOptions(JsonSerializeFormat & handler)
 
 		if(!handler.saving)
 		{
-			if(!appearance)
-			{
-				// crossoverDeserialize
-				type = getHeroType().toHeroType();
-				appearance = VLC->objtypeh->getHandlerFor(Obj::HERO, type->heroClass->getIndex())->getTemplates().front();
-			}
-
 			patrol.patrolling = (rawPatrolRadius > NO_PATROLING);
 			patrol.initialPos = visitablePos();
 			patrol.patrolRadius = (rawPatrolRadius > NO_PATROLING) ? rawPatrolRadius : 0;

--- a/lib/mapObjects/CRewardableObject.cpp
+++ b/lib/mapObjects/CRewardableObject.cpp
@@ -181,7 +181,26 @@ void CRewardableObject::heroLevelUpDone(const CGHeroInstance *hero) const
 void CRewardableObject::blockingDialogAnswered(const CGHeroInstance *hero, ui32 answer) const
 {
 	if(answer == 0)
+	{
+		switch (configuration.visitMode)
+		{
+			case Rewardable::VISIT_UNLIMITED:
+			case Rewardable::VISIT_BONUS:
+			case Rewardable::VISIT_HERO:
+			case Rewardable::VISIT_LIMITER:
+			{
+				// workaround for object with refusable reward not getting marked as visited
+				// TODO: better solution that would also work for player-visitable objects
+				if (!wasScouted(hero->getOwner()))
+				{
+					ChangeObjectVisitors cov(ChangeObjectVisitors::VISITOR_ADD_TEAM, id, hero->id);
+					cb->sendAndApply(&cov);
+				}
+			}
+		}
+
 		return; // player refused
+	}
 
 	if(answer > 0 && answer-1 < configuration.info.size())
 	{

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -682,6 +682,15 @@ void CGameHandler::onNewTurn()
 		}
 	}
 
+	for (auto & player : gs->players)
+	{
+		if (player.second.status != EPlayerStatus::INGAME)
+			continue;
+
+		if (player.second.heroes.empty() && player.second.towns.empty())
+			throw std::runtime_error("Invalid player in player state! Player " + std::to_string(player.first.getNum()) + ", map name: " + gs->map->name.toString() + ", map description: " + gs->map->description.toString());
+	}
+
 	if (newWeek && !firstTurn)
 	{
 		n.specialWeek = NewTurn::NORMAL;


### PR DESCRIPTION
UI fixes:
- If hota mod is active and visiting witch hut but refusing skill, right-clicking witch hut will now show contained skill
- Right-click tooltip on dwellings will now always show contained creatures. However only owner can see amount of creatures to recruit.

Fixed crashes:
- Try to fix possible crash on transferring hero to next campaign scenario if hero combined artifact some components of which can be transferred
- Try to fix possible crash on transferring hero to next campaign scenario that has creature with faction limiter in his army
- Fix possible crash on shutdown if active adventure map is deleted after gui handler (both are global variables)
- Added better crash message for crash on map start, likely related to having invalid player with no heroes & towns on game start