### PR TITLE
map editor: check hero and town spells during mod assessment

### DIFF
--- a/include/vcmi/Entity.h
+++ b/include/vcmi/Entity.h
@@ -40,6 +40,7 @@ public:
 	virtual int32_t getIndex() const = 0;
 	virtual int32_t getIconIndex() const = 0;
 	virtual std::string getJsonKey() const = 0;
+	virtual std::string getModScope() const = 0;
 	virtual std::string getNameTranslated() const = 0;
 	virtual std::string getNameTextID() const = 0;
 

--- a/lib/BattleFieldHandler.cpp
+++ b/lib/BattleFieldHandler.cpp
@@ -73,6 +73,11 @@ std::string BattleFieldInfo::getJsonKey() const
 	return modScope + ':' + identifier;
 }
 
+std::string BattleFieldInfo::getModScope() const
+{
+	return modScope;
+}
+
 std::string BattleFieldInfo::getNameTextID() const
 {
 	return name;

--- a/lib/BattleFieldHandler.h
+++ b/lib/BattleFieldHandler.h
@@ -52,6 +52,7 @@ public:
 	int32_t getIndex() const override;
 	int32_t getIconIndex() const override;
 	std::string getJsonKey() const override;
+	std::string getModScope() const override;
 	std::string getNameTextID() const override;
 	std::string getNameTranslated() const override;
 	void registerIcons(const IconRegistar & cb) const override;

--- a/lib/CArtHandler.cpp
+++ b/lib/CArtHandler.cpp
@@ -106,6 +106,11 @@ std::string CArtifact::getJsonKey() const
 	return modScope + ':' + identifier;
 }
 
+std::string CArtifact::getModScope() const
+{
+	return modScope;
+}
+
 void CArtifact::registerIcons(const IconRegistar & cb) const
 {
 	cb(getIconIndex(), 0, "ARTIFACT", image);

--- a/lib/CArtHandler.h
+++ b/lib/CArtHandler.h
@@ -106,6 +106,7 @@ public:
 	int32_t getIndex() const override;
 	int32_t getIconIndex() const override;
 	std::string getJsonKey() const override;
+	std::string getModScope() const override;
 	void registerIcons(const IconRegistar & cb) const override;
 	ArtifactID getId() const override;
 	const IBonusBearer * getBonusBearer() const override;

--- a/lib/CCreatureHandler.cpp
+++ b/lib/CCreatureHandler.cpp
@@ -61,6 +61,11 @@ std::string CCreature::getJsonKey() const
 	return modScope + ':' + identifier;
 }
 
+std::string CCreature::getModScope() const
+{
+	return modScope;
+}
+
 void CCreature::registerIcons(const IconRegistar & cb) const
 {
 	cb(getIconIndex(), 0, "CPRSMALL", smallIconName);

--- a/lib/CCreatureHandler.h
+++ b/lib/CCreatureHandler.h
@@ -131,6 +131,7 @@ public:
 	int32_t getIndex() const override;
 	int32_t getIconIndex() const override;
 	std::string getJsonKey() const override;
+	std::string getModScope() const override;
 	void registerIcons(const IconRegistar & cb) const override;
 	CreatureID getId() const override;
 	const IBonusBearer * getBonusBearer() const override;

--- a/lib/CHeroHandler.cpp
+++ b/lib/CHeroHandler.cpp
@@ -53,6 +53,11 @@ std::string CHero::getJsonKey() const
 	return modScope + ':' + identifier;
 }
 
+std::string CHero::getModScope() const
+{
+	return modScope;
+}
+
 HeroTypeID CHero::getId() const
 {
 	return ID;
@@ -187,6 +192,11 @@ int32_t CHeroClass::getIconIndex() const
 std::string CHeroClass::getJsonKey() const
 {
 	return modScope + ':' + identifier;
+}
+
+std::string CHeroClass::getModScope() const
+{
+	return modScope;
 }
 
 HeroClassID CHeroClass::getId() const

--- a/lib/CHeroHandler.h
+++ b/lib/CHeroHandler.h
@@ -84,6 +84,7 @@ public:
 	int32_t getIndex() const override;
 	int32_t getIconIndex() const override;
 	std::string getJsonKey() const override;
+	std::string getModScope() const override;
 	HeroTypeID getId() const override;
 	void registerIcons(const IconRegistar & cb) const override;
 
@@ -145,6 +146,7 @@ public:
 	int32_t getIndex() const override;
 	int32_t getIconIndex() const override;
 	std::string getJsonKey() const override;
+	std::string getModScope() const override;
 	HeroClassID getId() const override;
 	void registerIcons(const IconRegistar & cb) const override;
 

--- a/lib/CPlayerState.cpp
+++ b/lib/CPlayerState.cpp
@@ -50,6 +50,11 @@ std::string PlayerState::getJsonKey() const
 	return color.toString();
 }
 
+std::string PlayerState::getModScope() const
+{
+	return "core";
+}
+
 std::string PlayerState::getNameTranslated() const
 {
 	return VLC->generaltexth->translate(getNameTextID());

--- a/lib/CPlayerState.h
+++ b/lib/CPlayerState.h
@@ -85,6 +85,7 @@ public:
 	int32_t getIndex() const override;
 	int32_t getIconIndex() const override;
 	std::string getJsonKey() const override;
+	std::string getModScope() const override;
 	std::string getNameTranslated() const override;
 	std::string getNameTextID() const override;
 	void registerIcons(const IconRegistar & cb) const override;

--- a/lib/CSkillHandler.cpp
+++ b/lib/CSkillHandler.cpp
@@ -64,6 +64,11 @@ std::string CSkill::getJsonKey() const
 	return modScope + ':' + identifier;
 }
 
+std::string CSkill::getModScope() const
+{
+	return modScope;
+}
+
 std::string CSkill::getDescriptionTextID(int level) const
 {
 	TextIdentifier id("skill", modScope, identifier, "description", NSecondarySkill::levels[level]);

--- a/lib/CSkillHandler.h
+++ b/lib/CSkillHandler.h
@@ -52,6 +52,7 @@ public:
 	int32_t getIndex() const override;
 	int32_t getIconIndex() const override;
 	std::string getJsonKey() const override;
+	std::string getModScope() const override;
 	void registerIcons(const IconRegistar & cb) const override;
 	SecondarySkill getId() const override;
 

--- a/lib/ObstacleHandler.cpp
+++ b/lib/ObstacleHandler.cpp
@@ -31,6 +31,11 @@ std::string ObstacleInfo::getJsonKey() const
 	return identifier;
 }
 
+std::string ObstacleInfo::getModScope() const
+{
+	return "core";
+}
+
 std::string ObstacleInfo::getNameTranslated() const
 {
 	return identifier;

--- a/lib/ObstacleHandler.cpp
+++ b/lib/ObstacleHandler.cpp
@@ -28,12 +28,12 @@ int32_t ObstacleInfo::getIconIndex() const
 
 std::string ObstacleInfo::getJsonKey() const
 {
-	return identifier;
+	return modScope + ':' + identifier;
 }
 
 std::string ObstacleInfo::getModScope() const
 {
-	return "core";
+	return modScope;
 }
 
 std::string ObstacleInfo::getNameTranslated() const
@@ -96,6 +96,7 @@ std::shared_ptr<ObstacleInfo> ObstacleHandler::loadFromJson(const std::string & 
 
 	auto info = std::make_shared<ObstacleInfo>(Obstacle(index), identifier);
 	
+	info->modScope = scope;
 	info->animation = AnimationPath::fromJson(json["animation"]);
 	info->width = json["width"].Integer();
 	info->height = json["height"].Integer();

--- a/lib/ObstacleHandler.h
+++ b/lib/ObstacleHandler.h
@@ -31,6 +31,7 @@ public:
 	
 	Obstacle obstacle;
 	si32 iconIndex;
+	std::string modScope;
 	std::string identifier;
 	AudioPath appearSound;
 	AnimationPath appearAnimation;

--- a/lib/ObstacleHandler.h
+++ b/lib/ObstacleHandler.h
@@ -47,6 +47,7 @@ public:
 	int32_t getIndex() const override;
 	int32_t getIconIndex() const override;
 	std::string getJsonKey() const override;
+	std::string getModScope() const override;
 	std::string getNameTranslated() const override;
 	std::string getNameTextID() const override;
 	void registerIcons(const IconRegistar & cb) const override;

--- a/lib/RiverHandler.cpp
+++ b/lib/RiverHandler.cpp
@@ -74,6 +74,11 @@ std::string RiverType::getJsonKey() const
 	return modScope + ":" + identifier;
 }
 
+std::string RiverType::getModScope() const
+{
+	return modScope;
+}
+
 std::string RiverType::getNameTextID() const
 {
 	return TextIdentifier( "river", modScope, identifier, "name" ).get();

--- a/lib/RiverHandler.h
+++ b/lib/RiverHandler.h
@@ -37,6 +37,7 @@ public:
 	int32_t getIndex() const override { return id.getNum(); }
 	int32_t getIconIndex() const override { return 0; }
 	std::string getJsonKey() const override;
+	std::string getModScope() const override;
 	void registerIcons(const IconRegistar & cb) const override {}
 	RiverId getId() const override { return id;}
 	void updateFrom(const JsonNode & data) {};

--- a/lib/RoadHandler.cpp
+++ b/lib/RoadHandler.cpp
@@ -65,6 +65,11 @@ std::string RoadType::getJsonKey() const
 	return modScope + ":" + identifier;
 }
 
+std::string RoadType::getModScope() const
+{
+	return modScope;
+}
+
 std::string RoadType::getNameTextID() const
 {
 	return TextIdentifier( "road", modScope, identifier, "name" ).get();

--- a/lib/RoadHandler.h
+++ b/lib/RoadHandler.h
@@ -29,6 +29,7 @@ public:
 	int32_t getIndex() const override { return id.getNum(); }
 	int32_t getIconIndex() const override { return 0; }
 	std::string getJsonKey() const override;
+	std::string getModScope() const override;
 	void registerIcons(const IconRegistar & cb) const override {}
 	RoadId getId() const override { return id;}
 	void updateFrom(const JsonNode & data) {};

--- a/lib/TerrainHandler.cpp
+++ b/lib/TerrainHandler.cpp
@@ -191,6 +191,11 @@ std::string TerrainType::getJsonKey() const
 	return modScope + ":" + identifier;
 }
 
+std::string TerrainType::getModScope() const
+{
+	return modScope;
+}
+
 std::string TerrainType::getNameTextID() const
 {
 	return TextIdentifier( "terrain", modScope, identifier, "name" ).get();

--- a/lib/TerrainHandler.h
+++ b/lib/TerrainHandler.h
@@ -55,6 +55,7 @@ public:
 	int32_t getIndex() const override { return id.getNum(); }
 	int32_t getIconIndex() const override { return 0; }
 	std::string getJsonKey() const override;
+	std::string getModScope() const override;
 	void registerIcons(const IconRegistar & cb) const override {}
 	TerrainId getId() const override { return id;}
 	void updateFrom(const JsonNode & data) {};

--- a/lib/entities/faction/CFaction.cpp
+++ b/lib/entities/faction/CFaction.cpp
@@ -41,6 +41,11 @@ std::string CFaction::getJsonKey() const
 	return modScope + ':' + identifier;
 }
 
+std::string CFaction::getModScope() const
+{
+	return modScope;
+}
+
 void CFaction::registerIcons(const IconRegistar & cb) const
 {
 	if(town)

--- a/lib/entities/faction/CFaction.h
+++ b/lib/entities/faction/CFaction.h
@@ -63,6 +63,7 @@ public:
 	int32_t getIndex() const override;
 	int32_t getIconIndex() const override;
 	std::string getJsonKey() const override;
+	std::string getModScope() const override;
 	void registerIcons(const IconRegistar & cb) const override;
 	FactionID getId() const override;
 

--- a/lib/mapObjectConstructors/AObjectTypeHandler.cpp
+++ b/lib/mapObjectConstructors/AObjectTypeHandler.cpp
@@ -29,6 +29,11 @@ std::string AObjectTypeHandler::getJsonKey() const
 	return modScope + ':' + subTypeName;
 }
 
+std::string AObjectTypeHandler::getModScope() const
+{
+	return modScope;
+}
+
 si32 AObjectTypeHandler::getIndex() const
 {
 	return type;

--- a/lib/mapObjectConstructors/AObjectTypeHandler.h
+++ b/lib/mapObjectConstructors/AObjectTypeHandler.h
@@ -74,6 +74,8 @@ public:
 	/// returns full form of identifier of this object in form of modName:objectName
 	std::string getJsonKey() const;
 
+	std::string getModScope() const;
+
 	/// Returns object-specific name, if set
 	SObjectSounds getSounds() const;
 

--- a/lib/spells/CSpellHandler.cpp
+++ b/lib/spells/CSpellHandler.cpp
@@ -200,6 +200,11 @@ std::string CSpell::getJsonKey() const
 	return modScope + ':' + identifier;
 }
 
+std::string CSpell::getModScope() const
+{
+	return modScope;
+}
+
 int32_t CSpell::getIndex() const
 {
 	return id.toEnum();

--- a/lib/spells/CSpellHandler.h
+++ b/lib/spells/CSpellHandler.h
@@ -228,6 +228,7 @@ public:
 	int32_t getIndex() const override;
 	int32_t getIconIndex() const override;
 	std::string getJsonKey() const override;
+	std::string getModScope() const override;
 	SpellID getId() const override;
 
 	std::string getNameTextID() const override;

--- a/mapeditor/mapcontroller.cpp
+++ b/mapeditor/mapcontroller.cpp
@@ -613,16 +613,49 @@ ModCompatibilityInfo MapController::modAssessmentAll()
 ModCompatibilityInfo MapController::modAssessmentMap(const CMap & map)
 {
 	ModCompatibilityInfo result;
+
+	auto extractEntityMod = [&result](const auto & entity) 
+	{
+		auto modName = QString::fromStdString(entity->getJsonKey()).split(":").at(0).toStdString();
+		if(modName != "core")
+			result[modName] = VLC->modh->getModInfo(modName).getVerificationInfo();
+	};
+
 	for(auto obj : map.objects)
 	{
-		if(obj->ID == Obj::HERO)
-			continue; //stub! 
-		
 		auto handler = obj->getObjectHandler();
 		auto modName = QString::fromStdString(handler->getJsonKey()).split(":").at(0).toStdString();
 		if(modName != "core")
 			result[modName] = VLC->modh->getModInfo(modName).getVerificationInfo();
+
+		if(obj->ID == Obj::TOWN || obj->ID == Obj::RANDOM_TOWN)
+		{
+			auto town = dynamic_cast<CGTownInstance *>(obj.get());
+			for(const auto & spellID : town->possibleSpells)
+			{
+				if(spellID == SpellID::PRESET)
+					continue;
+				extractEntityMod(spellID.toEntity(VLC));
+			}
+
+			for(const auto & spellID : town->obligatorySpells)
+			{
+				extractEntityMod(spellID.toEntity(VLC));
+			}
+		}
+
+		if(obj->ID == Obj::HERO || obj->ID == Obj::RANDOM_HERO)
+		{
+			auto hero = dynamic_cast<CGHeroInstance *>(obj.get());
+			for(const auto & spellID : hero->getSpellsInSpellbook())
+			{
+				if(spellID == SpellID::PRESET || spellID == SpellID::SPELLBOOK_PRESET)
+					continue;
+				extractEntityMod(spellID.toEntity(VLC));
+			}
+		}
 	}
-	//TODO: terrains?
+
+	//TODO: terrains, artifacts?
 	return result;
 }

--- a/mapeditor/mapcontroller.cpp
+++ b/mapeditor/mapcontroller.cpp
@@ -624,7 +624,7 @@ ModCompatibilityInfo MapController::modAssessmentMap(const CMap & map)
 	for(auto obj : map.objects)
 	{
 		auto handler = obj->getObjectHandler();
-		auto modScope = QString::fromStdString(handler->getJsonKey()).split(":").at(0).toStdString();
+		auto modScope = handler->getModScope();
 		if(modScope != "core")
 			result[modScope] = VLC->modh->getModInfo(modScope).getVerificationInfo();
 

--- a/mapeditor/mapcontroller.cpp
+++ b/mapeditor/mapcontroller.cpp
@@ -616,17 +616,17 @@ ModCompatibilityInfo MapController::modAssessmentMap(const CMap & map)
 
 	auto extractEntityMod = [&result](const auto & entity) 
 	{
-		auto modName = QString::fromStdString(entity->getJsonKey()).split(":").at(0).toStdString();
-		if(modName != "core")
-			result[modName] = VLC->modh->getModInfo(modName).getVerificationInfo();
+		auto modScope = entity->getModScope();
+		if(modScope != "core")
+			result[modScope] = VLC->modh->getModInfo(modScope).getVerificationInfo();
 	};
 
 	for(auto obj : map.objects)
 	{
 		auto handler = obj->getObjectHandler();
-		auto modName = QString::fromStdString(handler->getJsonKey()).split(":").at(0).toStdString();
-		if(modName != "core")
-			result[modName] = VLC->modh->getModInfo(modName).getVerificationInfo();
+		auto modScope = QString::fromStdString(handler->getJsonKey()).split(":").at(0).toStdString();
+		if(modScope != "core")
+			result[modScope] = VLC->modh->getModInfo(modScope).getVerificationInfo();
 
 		if(obj->ID == Obj::TOWN || obj->ID == Obj::RANDOM_TOWN)
 		{

--- a/test/mock/mock_Creature.h
+++ b/test/mock/mock_Creature.h
@@ -27,6 +27,7 @@ public:
 	MOCK_CONST_METHOD0(getIndex, int32_t());
 	MOCK_CONST_METHOD0(getIconIndex, int32_t());
 	MOCK_CONST_METHOD0(getJsonKey, std::string ());
+	MOCK_CONST_METHOD0(getModScope, std::string ());
 	MOCK_CONST_METHOD0(getName, const std::string &());
 	MOCK_CONST_METHOD0(getId, CreatureID());
 	MOCK_CONST_METHOD0(getBonusBearer, const IBonusBearer *());

--- a/test/mock/mock_spells_Spell.h
+++ b/test/mock/mock_spells_Spell.h
@@ -27,6 +27,7 @@ public:
 	MOCK_CONST_METHOD0(getIndex, int32_t());
 	MOCK_CONST_METHOD0(getIconIndex, int32_t());
 	MOCK_CONST_METHOD0(getJsonKey, std::string ());
+	MOCK_CONST_METHOD0(getModScope, std::string ());
 	MOCK_CONST_METHOD0(getName, const std::string &());
 	MOCK_CONST_METHOD0(getId, SpellID());
 	MOCK_CONST_METHOD0(getLevel, int32_t());


### PR DESCRIPTION
While looking at some test campaigns (like one from #4376) I noticed that town possibleSpells list have all spells from all mods active while adding town. Map creator wasn't aware that there is some reference to mod in his map so it wasn't marked as required. This PR should both add error on validation and improve marking required mods based on map objects