### PR TITLE
Remove old code from UI system

### DIFF
--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -137,7 +137,6 @@ CPlayerInterface::CPlayerInterface(PlayerColor Player):
 	
 {
 	logGlobal->trace("\tHuman player interface for player %s being constructed", Player.toString());
-	GH.defActionsDef = 0;
 	LOCPLINT = this;
 	playerID=Player;
 	human=true;
@@ -1776,7 +1775,6 @@ void CPlayerInterface::proposeLoadingGame()
 		[]()
 		{
 			CSH->endGameplay();
-			GH.defActionsDef = 63;
 			CMM->menu->switchToTab("load");
 		},
 		nullptr

--- a/client/CServerHandler.cpp
+++ b/client/CServerHandler.cpp
@@ -717,7 +717,6 @@ void CServerHandler::showHighScoresAndEndGameplay(PlayerColor player, bool victo
 		scenarioHighScores.isCampaign = false;
 
 		endGameplay();
-		GH.defActionsDef = 63;
 		CMM->menu->switchToTab("main");
 		GH.windows().createAndPushWindow<CHighScoreInputScreen>(victory, scenarioHighScores);
 	}
@@ -948,7 +947,6 @@ void CServerHandler::onDisconnected(const std::shared_ptr<INetworkConnection> & 
 	if(client)
 	{
 		endGameplay();
-		GH.defActionsDef = 63;
 		CMM->menu->switchToTab("main");
 		showServerError(CGI->generaltexth->translate("vcmi.server.errors.disconnected"));
 	}

--- a/client/adventureMap/AdventureMapInterface.cpp
+++ b/client/adventureMap/AdventureMapInterface.cpp
@@ -58,7 +58,7 @@ AdventureMapInterface::AdventureMapInterface():
 	scrollingWasBlocked(false),
 	backgroundDimLevel(settings["adventure"]["backgroundDimLevel"].Integer())
 {
-	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
+	OBJECT_CONSTRUCTION;
 	pos.x = pos.y = 0;
 	pos.w = GH.screenDimensions().x;
 	pos.h = GH.screenDimensions().y;
@@ -898,7 +898,7 @@ void AdventureMapInterface::hotkeyZoom(int delta, bool useDeadZone)
 
 void AdventureMapInterface::onScreenResize()
 {
-	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
+	OBJECT_CONSTRUCTION;
 
 	// remember our activation state and reactive after reconstruction
 	// since othervice activate() calls for created elements will bypass virtual dispatch

--- a/client/adventureMap/AdventureMapShortcuts.cpp
+++ b/client/adventureMap/AdventureMapShortcuts.cpp
@@ -325,7 +325,6 @@ void AdventureMapShortcuts::toMainMenu()
 		[]()
 		{
 			CSH->endGameplay();
-			GH.defActionsDef = 63;
 			CMM->menu->switchToTab("main");
 		},
 		0
@@ -339,7 +338,6 @@ void AdventureMapShortcuts::newGame()
 		[]()
 		{
 			CSH->endGameplay();
-			GH.defActionsDef = 63;
 			CMM->menu->switchToTab("new");
 		},
 		nullptr

--- a/client/adventureMap/AdventureMapWidget.cpp
+++ b/client/adventureMap/AdventureMapWidget.cpp
@@ -381,7 +381,7 @@ CAdventureMapIcon::CAdventureMapIcon(const Point & position, const AnimationPath
 	: index(index)
 	, iconsPerPlayer(iconsPerPlayer)
 {
-	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
+	OBJECT_CONSTRUCTION;
 	pos += position;
 	image = std::make_shared<CAnimImage>(animation, index);
 }

--- a/client/adventureMap/AdventureOptions.cpp
+++ b/client/adventureMap/AdventureOptions.cpp
@@ -28,7 +28,7 @@
 AdventureOptions::AdventureOptions()
 	: CWindowObject(PLAYER_COLORED, ImagePath::builtin("ADVOPTS"))
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 
 	viewWorld = std::make_shared<CButton>(Point(24, 23), AnimationPath::builtin("ADVVIEW.DEF"), CButton::tooltip(), [&](){ close(); }, EShortcut::ADVENTURE_VIEW_WORLD);
 	viewWorld->addCallback([] { LOCPLINT->viewWorldMap(); });

--- a/client/adventureMap/CInfoBar.cpp
+++ b/client/adventureMap/CInfoBar.cpp
@@ -51,7 +51,7 @@ CInfoBar::EmptyVisibleInfo::EmptyVisibleInfo()
 
 CInfoBar::VisibleHeroInfo::VisibleHeroInfo(const CGHeroInstance * hero)
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 	background = std::make_shared<CPicture>(ImagePath::builtin("ADSTATHR"));
 
 	if(settings["gameTweaks"]["infoBarCreatureManagement"].Bool())
@@ -62,7 +62,7 @@ CInfoBar::VisibleHeroInfo::VisibleHeroInfo(const CGHeroInstance * hero)
 
 CInfoBar::VisibleTownInfo::VisibleTownInfo(const CGTownInstance * town)
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 	background = std::make_shared<CPicture>(ImagePath::builtin("ADSTATCS"));
 
 	if(settings["gameTweaks"]["infoBarCreatureManagement"].Bool())
@@ -73,7 +73,7 @@ CInfoBar::VisibleTownInfo::VisibleTownInfo(const CGTownInstance * town)
 
 CInfoBar::VisibleDateInfo::VisibleDateInfo()
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 
 	animation = std::make_shared<CShowableAnim>(1, 0, getNewDayName(), CShowableAnim::PLAY_ONCE, 180);// H3 uses around 175-180 ms per frame
 	animation->setDuration(1500);
@@ -114,7 +114,7 @@ AnimationPath CInfoBar::VisibleDateInfo::getNewDayName()
 
 CInfoBar::VisibleEnemyTurnInfo::VisibleEnemyTurnInfo(PlayerColor player)
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 	background = std::make_shared<CPicture>(ImagePath::builtin("ADSTATNX"));
 	banner = std::make_shared<CAnimImage>(AnimationPath::builtin("CREST58"), player.getNum(), 0, 20, 51);
 	sand = std::make_shared<CShowableAnim>(99, 51, AnimationPath::builtin("HOURSAND"), 0, 100); // H3 uses around 100 ms per frame
@@ -123,7 +123,7 @@ CInfoBar::VisibleEnemyTurnInfo::VisibleEnemyTurnInfo(PlayerColor player)
 
 CInfoBar::VisibleGameStatusInfo::VisibleGameStatusInfo()
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 	//get amount of halls of each level
 	std::vector<int> halls(4, 0);
 	for(auto town : LOCPLINT->localState->getOwnedTowns())
@@ -180,7 +180,7 @@ CInfoBar::VisibleGameStatusInfo::VisibleGameStatusInfo()
 
 CInfoBar::VisibleComponentInfo::VisibleComponentInfo(const std::vector<Component> & compsToDisplay, std::string message, int textH, bool tiny)
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 
 	background = std::make_shared<CPicture>(ImagePath::builtin("ADSTATOT"), 1, 0);
 	auto fullRect = Rect(CInfoBar::offset, CInfoBar::offset, data_width - 2 * CInfoBar::offset, data_height - 2 * CInfoBar::offset);
@@ -250,14 +250,14 @@ void CInfoBar::playNewDaySound()
 
 void CInfoBar::reset()
 {
-	OBJECT_CONSTRUCTION_CUSTOM_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 	state = EMPTY;
 	visibleInfo = std::make_shared<EmptyVisibleInfo>();
 }
 
 void CInfoBar::showSelection()
 {
-	OBJECT_CONSTRUCTION_CUSTOM_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 	if(LOCPLINT->localState->getCurrentHero())
 	{
 		showHeroSelection(LOCPLINT->localState->getCurrentHero());
@@ -325,7 +325,7 @@ CInfoBar::CInfoBar(const Rect & position)
 	state(EMPTY),
 	listener(settings.listen["gameTweaks"]["infoBarCreatureManagement"])
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 	pos.w = position.w;
 	pos.h = position.h;
 	listener(std::bind(&CInfoBar::OnInfoBarCreatureManagementChanged, this));
@@ -349,7 +349,7 @@ void CInfoBar::setTimer(uint32_t msToTrigger)
 
 void CInfoBar::showDate()
 {
-	OBJECT_CONSTRUCTION_CUSTOM_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 	playNewDaySound();
 	state = DATE;
 	visibleInfo = std::make_shared<VisibleDateInfo>();
@@ -475,7 +475,7 @@ void CInfoBar::popAll()
 
 void CInfoBar::popComponents(bool remove)
 {
-	OBJECT_CONSTRUCTION_CUSTOM_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 	if(remove && !componentsQueue.empty())
 		componentsQueue.pop();
 	if(!componentsQueue.empty())
@@ -492,7 +492,7 @@ void CInfoBar::popComponents(bool remove)
 
 void CInfoBar::pushComponents(const std::vector<Component> & comps, std::string message, int textH, bool tiny, int timer)
 {
-	OBJECT_CONSTRUCTION_CUSTOM_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 	componentsQueue.emplace(VisibleComponentInfo::Cache(comps, message, textH, tiny), timer);
 }
 
@@ -503,7 +503,7 @@ bool CInfoBar::showingComponents()
 
 void CInfoBar::startEnemyTurn(PlayerColor color)
 {
-	OBJECT_CONSTRUCTION_CUSTOM_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 	state = AITURN;
 	visibleInfo = std::make_shared<VisibleEnemyTurnInfo>(color);
 	redraw();
@@ -511,7 +511,7 @@ void CInfoBar::startEnemyTurn(PlayerColor color)
 
 void CInfoBar::showHeroSelection(const CGHeroInstance * hero)
 {
-	OBJECT_CONSTRUCTION_CUSTOM_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 	if(!hero)
 	{
 		reset();
@@ -526,7 +526,7 @@ void CInfoBar::showHeroSelection(const CGHeroInstance * hero)
 
 void CInfoBar::showTownSelection(const CGTownInstance * town)
 {
-	OBJECT_CONSTRUCTION_CUSTOM_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 	if(!town)
 	{
 		reset();
@@ -541,7 +541,7 @@ void CInfoBar::showTownSelection(const CGTownInstance * town)
 
 void CInfoBar::showGameStatus()
 {
-	OBJECT_CONSTRUCTION_CUSTOM_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 	state = GAME;
 	visibleInfo = std::make_shared<VisibleGameStatusInfo>();
 	setTimer(3000);

--- a/client/adventureMap/CList.cpp
+++ b/client/adventureMap/CList.cpp
@@ -70,7 +70,7 @@ void CList::CListItem::hover(bool on)
 
 void CList::CListItem::onSelect(bool on)
 {
-	OBJECT_CONSTRUCTION_CUSTOM_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 	selection.reset();
 	if(on)
 		selection = genSelection();
@@ -95,7 +95,7 @@ void CList::showAll(Canvas & to)
 
 void CList::createList(Point firstItemPosition, Point itemPositionDelta, size_t listAmount)
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 	listBox = std::make_shared<CListBox>(std::bind(&CList::createItem, this, _1), firstItemPosition, itemPositionDelta, size, listAmount);
 }
 
@@ -206,7 +206,7 @@ void CList::selectPrev()
 
 CHeroList::CEmptyHeroItem::CEmptyHeroItem()
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 	movement = std::make_shared<CAnimImage>(AnimationPath::builtin("IMOBIL"), 0, 0, 0, 1);
 	portrait = std::make_shared<CPicture>(ImagePath::builtin("HPSXXX"), movement->pos.w + 1, 0);
 	mana = std::make_shared<CAnimImage>(AnimationPath::builtin("IMANA"), 0, 0, movement->pos.w + portrait->pos.w + 2, 1 );
@@ -219,7 +219,7 @@ CHeroList::CHeroItem::CHeroItem(CHeroList *parent, const CGHeroInstance * Hero)
 	: CListItem(parent),
 	hero(Hero)
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 	movement = std::make_shared<CAnimImage>(AnimationPath::builtin("IMOBIL"), 0, 0, 0, 1);
 	portrait = std::make_shared<CAnimImage>(AnimationPath::builtin("PortraitsSmall"), hero->getIconIndex(), 0, movement->pos.w + 1);
 	mana = std::make_shared<CAnimImage>(AnimationPath::builtin("IMANA"), 0, 0, movement->pos.w + portrait->pos.w + 2, 1);
@@ -364,7 +364,7 @@ CTownList::CTownItem::CTownItem(CTownList *parent, const CGTownInstance *Town):
 	CListItem(parent),
 	town(Town)
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 	picture = std::make_shared<CAnimImage>(AnimationPath::builtin("ITPA"), 0);
 	pos = picture->pos;
 	update();

--- a/client/adventureMap/CList.cpp
+++ b/client/adventureMap/CList.cpp
@@ -37,7 +37,6 @@ CList::CListItem::CListItem(CList * Parent)
 	parent(Parent),
 	selection()
 {
-	defActions = 255-DISPOSE;
 }
 
 CList::CListItem::~CListItem() = default;

--- a/client/adventureMap/CMinimap.cpp
+++ b/client/adventureMap/CMinimap.cpp
@@ -90,7 +90,7 @@ CMinimap::CMinimap(const Rect & position)
 	: CIntObject(LCLICK | SHOW_POPUP | DRAG | MOVE | GESTURE, position.topLeft()),
 	level(0)
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 
 	double maxSideLengthSrc = std::max(LOCPLINT->cb->getMapSize().x, LOCPLINT->cb->getMapSize().y);
 	double maxSideLengthDst = std::max(position.w, position.h);
@@ -202,7 +202,7 @@ void CMinimap::update()
 	if(aiShield->recActions & UPDATE) //AI turn is going on. There is no need to update minimap
 		return;
 
-	OBJECT_CONSTRUCTION_CUSTOM_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 	minimap = std::make_shared<CMinimapInstance>(this, level);
 	redraw();
 }

--- a/client/adventureMap/CResDataBar.cpp
+++ b/client/adventureMap/CResDataBar.cpp
@@ -29,7 +29,7 @@ CResDataBar::CResDataBar(const ImagePath & imageName, const Point & position)
 	pos.x += position.x;
 	pos.y += position.y;
 
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 	background = std::make_shared<CPicture>(imageName, 0, 0);
 	background->setPlayerColor(LOCPLINT->playerID);
 

--- a/client/adventureMap/TurnTimerWidget.cpp
+++ b/client/adventureMap/TurnTimerWidget.cpp
@@ -35,7 +35,7 @@ TurnTimerWidget::TurnTimerWidget(const Point & position, PlayerColor player)
 	, lastSoundCheckSeconds(0)
 	, isBattleMode(player.isValidPlayer())
 {
-	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
+	OBJECT_CONSTRUCTION;
 
 	pos += position;
 	pos.w = 0;

--- a/client/battle/BattleFieldController.cpp
+++ b/client/battle/BattleFieldController.cpp
@@ -110,7 +110,7 @@ static const std::map<int, int> hexEdgeMaskToFrameIndex =
 BattleFieldController::BattleFieldController(BattleInterface & owner):
 	owner(owner)
 {
-	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
+	OBJECT_CONSTRUCTION;
 
 	//preparing cells and hexes
 	cellBorder = GH.renderHandler().loadImage(ImagePath::builtin("CCELLGRD.BMP"), EImageBlitMode::COLORKEY);
@@ -156,7 +156,7 @@ void BattleFieldController::activate()
 
 void BattleFieldController::createHeroes()
 {
-	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
+	OBJECT_CONSTRUCTION;
 
 	// create heroes as part of our constructor for correct positioning inside battlefield
 	if(owner.attackingHeroInstance)

--- a/client/battle/BattleInterfaceClasses.cpp
+++ b/client/battle/BattleInterfaceClasses.cpp
@@ -158,7 +158,7 @@ BattleConsole::BattleConsole(const BattleInterface & owner, std::shared_ptr<CPic
 	, scrollPosition(-1)
 	, enteringText(false)
 {
-	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
+	OBJECT_CONSTRUCTION;
 	pos += objectPos;
 	pos.w = size.x;
 	pos.h = size.y;
@@ -227,7 +227,7 @@ void BattleConsole::clear()
 BattleConsoleWindow::BattleConsoleWindow(const std::string & text)
 	: CWindowObject(BORDERED)
 {
-	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
+	OBJECT_CONSTRUCTION;
 
 	pos.w = 429;
 	pos.h = 434;
@@ -422,7 +422,7 @@ BattleHero::BattleHero(const BattleInterface & owner, const CGHeroInstance * her
 QuickSpellPanel::QuickSpellPanel(BattleInterface & owner)
 	: CIntObject(0), owner(owner)
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 
 	addUsedEvents(LCLICK | SHOW_POPUP | MOVE | INPUT_MODE_CHANGE);
 
@@ -479,7 +479,7 @@ std::vector<std::tuple<SpellID, bool>> QuickSpellPanel::getSpells()
 
 void QuickSpellPanel::create()
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 
 	const JsonNode config = JsonUtils::assembleFromFiles("config/shortcutsConfig");
 
@@ -542,7 +542,7 @@ void QuickSpellPanel::inputModeChanged(InputMode modi)
 HeroInfoBasicPanel::HeroInfoBasicPanel(const InfoAboutHero & hero, Point * position, bool initializeBackground)
 	: CIntObject(0)
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 	if (position != nullptr)
 		moveTo(*position);
 
@@ -557,7 +557,7 @@ HeroInfoBasicPanel::HeroInfoBasicPanel(const InfoAboutHero & hero, Point * posit
 
 void HeroInfoBasicPanel::initializeData(const InfoAboutHero & hero)
 {
-	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
+	OBJECT_CONSTRUCTION;
 	auto attack = hero.details->primskills[0];
 	auto defense = hero.details->primskills[1];
 	auto power = hero.details->primskills[2];
@@ -610,7 +610,7 @@ void HeroInfoBasicPanel::show(Canvas & to)
 StackInfoBasicPanel::StackInfoBasicPanel(const CStack * stack, bool initializeBackground)
 	: CIntObject(0)
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 
 	if(initializeBackground)
 	{
@@ -626,7 +626,7 @@ StackInfoBasicPanel::StackInfoBasicPanel(const CStack * stack, bool initializeBa
 
 void StackInfoBasicPanel::initializeData(const CStack * stack)
 {
-	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
+	OBJECT_CONSTRUCTION;
 
 	icons.push_back(std::make_shared<CAnimImage>(AnimationPath::builtin("TWCRPORT"), stack->creatureId() + 2, 0, 10, 6));
 	labels.push_back(std::make_shared<CLabel>(10 + 58, 6 + 64, FONT_MEDIUM, ETextAlignment::BOTTOMRIGHT, Colors::WHITE, TextOperations::formatMetric(stack->getCount(), 4)));
@@ -718,7 +718,7 @@ void StackInfoBasicPanel::show(Canvas & to)
 HeroInfoWindow::HeroInfoWindow(const InfoAboutHero & hero, Point * position)
 	: CWindowObject(RCLICK_POPUP | SHADOW_DISABLED, ImagePath::builtin("CHRPOP"))
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 	if (position != nullptr)
 		moveTo(*position);
 
@@ -730,7 +730,7 @@ HeroInfoWindow::HeroInfoWindow(const InfoAboutHero & hero, Point * position)
 BattleResultWindow::BattleResultWindow(const BattleResult & br, CPlayerInterface & _owner, bool allowReplay)
 	: owner(_owner)
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 
 	background = std::make_shared<CPicture>(ImagePath::builtin("CPRESULT"));
 	background->setPlayerColor(owner.playerID);
@@ -961,7 +961,7 @@ StackQueue::StackQueue(bool Embedded, BattleInterface & owner)
 	: embedded(Embedded),
 	owner(owner)
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 
 	uint32_t queueSize = QUEUE_SIZE_BIG;
 
@@ -1045,7 +1045,7 @@ std::optional<uint32_t> StackQueue::getHoveredUnitIdIfAny() const
 StackQueue::StackBox::StackBox(StackQueue * owner):
 	CIntObject(SHOW_POPUP | HOVER), owner(owner)
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 	background = std::make_shared<CPicture>(ImagePath::builtin(owner->embedded ? "StackQueueSmall" : "StackQueueLarge"));
 
 	pos.w = background->pos.w;

--- a/client/battle/BattleWindow.cpp
+++ b/client/battle/BattleWindow.cpp
@@ -49,7 +49,7 @@ BattleWindow::BattleWindow(BattleInterface & Owner):
 	owner(Owner),
 	lastAlternativeAction(PossiblePlayerBattleAction::INVALID)
 {
-	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
+	OBJECT_CONSTRUCTION;
 	pos.w = 800;
 	pos.h = 600;
 	pos = center();
@@ -123,7 +123,7 @@ BattleWindow::BattleWindow(BattleInterface & Owner):
 
 void BattleWindow::createQueue()
 {
-	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
+	OBJECT_CONSTRUCTION;
 
 	//create stack queue and adjust our own position
 	bool embedQueue;
@@ -150,7 +150,7 @@ void BattleWindow::createQueue()
 
 void BattleWindow::createStickyHeroInfoWindows()
 {
-	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
+	OBJECT_CONSTRUCTION;
 
 	if(owner.defendingHeroInstance)
 	{
@@ -181,7 +181,7 @@ void BattleWindow::createStickyHeroInfoWindows()
 
 void BattleWindow::createQuickSpellWindow()
 {
-	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
+	OBJECT_CONSTRUCTION;
 
 	quickSpellWindow = std::make_shared<QuickSpellPanel>(owner);
 	quickSpellWindow->moveTo(Point(pos.x - 67, pos.y));
@@ -238,7 +238,7 @@ void BattleWindow::showStickyQuickSpellWindow()
 
 void BattleWindow::createTimerInfoWindows()
 {
-	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
+	OBJECT_CONSTRUCTION;
 
 	int xOffsetAttacker = quickSpellWindow->isEnabled ? -53 : 0;
 
@@ -416,7 +416,7 @@ void BattleWindow::updateHeroInfoWindow(uint8_t side, const InfoAboutHero & hero
 
 void BattleWindow::updateStackInfoWindow(const CStack * stack)
 {
-	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
+	OBJECT_CONSTRUCTION;
 
 	bool showInfoWindows = settings["battle"]["stickyHeroInfoWindows"].Bool();
 

--- a/client/globalLobby/GlobalLobbyInviteWindow.cpp
+++ b/client/globalLobby/GlobalLobbyInviteWindow.cpp
@@ -47,7 +47,7 @@ GlobalLobbyInviteAccountCard::GlobalLobbyInviteAccountCard(const GlobalLobbyAcco
 		}
 	}
 
-	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
+	OBJECT_CONSTRUCTION;
 	if (thisAccountInvited)
 		backgroundOverlay = std::make_shared<TransparentFilledRectangle>(Rect(0, 0, pos.w, pos.h), ColorRGBA(0, 0, 0, 128), Colors::WHITE, 1);
 	else
@@ -73,7 +73,7 @@ void GlobalLobbyInviteAccountCard::clickPressed(const Point & cursorPosition)
 GlobalLobbyInviteWindow::GlobalLobbyInviteWindow()
 	: CWindowObject(BORDERED)
 {
-	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
+	OBJECT_CONSTRUCTION;
 
 	pos.w = 236;
 	pos.h = 420;

--- a/client/globalLobby/GlobalLobbyLoginWindow.cpp
+++ b/client/globalLobby/GlobalLobbyLoginWindow.cpp
@@ -31,7 +31,7 @@
 GlobalLobbyLoginWindow::GlobalLobbyLoginWindow()
 	: CWindowObject(BORDERED)
 {
-	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
+	OBJECT_CONSTRUCTION;
 
 	pos.w = 284;
 	pos.h = 220;

--- a/client/globalLobby/GlobalLobbyRoomWindow.cpp
+++ b/client/globalLobby/GlobalLobbyRoomWindow.cpp
@@ -33,7 +33,7 @@
 
 GlobalLobbyRoomAccountCard::GlobalLobbyRoomAccountCard(const GlobalLobbyAccount & accountDescription)
 {
-	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
+	OBJECT_CONSTRUCTION;
 	pos.w = 130;
 	pos.h = 40;
 	backgroundOverlay = std::make_shared<TransparentFilledRectangle>(Rect(0, 0, pos.w, pos.h), ColorRGBA(0, 0, 0, 128), ColorRGBA(64, 64, 64, 64), 1);
@@ -51,7 +51,7 @@ GlobalLobbyRoomModCard::GlobalLobbyRoomModCard(const GlobalLobbyRoomModInfo & mo
 		{ ModVerificationStatus::FULL_MATCH, "compatible" }
 	};
 
-	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
+	OBJECT_CONSTRUCTION;
 	pos.w = 200;
 	pos.h = 40;
 	backgroundOverlay = std::make_shared<TransparentFilledRectangle>(Rect(0, 0, pos.w, pos.h), ColorRGBA(0, 0, 0, 128), ColorRGBA(64, 64, 64, 64), 1);
@@ -117,7 +117,7 @@ GlobalLobbyRoomWindow::GlobalLobbyRoomWindow(GlobalLobbyWindow * window, const s
 	, window(window)
 	, roomUUID(roomUUID)
 {
-	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
+	OBJECT_CONSTRUCTION;
 
 	pos.w = 400;
 	pos.h = 400;

--- a/client/globalLobby/GlobalLobbyServerSetup.cpp
+++ b/client/globalLobby/GlobalLobbyServerSetup.cpp
@@ -29,7 +29,7 @@
 GlobalLobbyServerSetup::GlobalLobbyServerSetup()
 	: CWindowObject(BORDERED)
 {
-	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
+	OBJECT_CONSTRUCTION;
 
 	pos.w = 284;
 	pos.h = 340;

--- a/client/globalLobby/GlobalLobbyWidget.cpp
+++ b/client/globalLobby/GlobalLobbyWidget.cpp
@@ -187,7 +187,7 @@ GlobalLobbyChannelCardBase::GlobalLobbyChannelCardBase(GlobalLobbyWindow * windo
 	pos.h = dimensions.y;
 	addUsedEvents(LCLICK);
 
-	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
+	OBJECT_CONSTRUCTION;
 
 	if (window->isChannelOpen(channelType, channelName))
 		backgroundOverlay = std::make_shared<TransparentFilledRectangle>(Rect(0, 0, pos.w, pos.h), ColorRGBA(0, 0, 0, 128), Colors::YELLOW, 2);
@@ -206,7 +206,7 @@ void GlobalLobbyChannelCardBase::clickPressed(const Point & cursorPosition)
 GlobalLobbyAccountCard::GlobalLobbyAccountCard(GlobalLobbyWindow * window, const GlobalLobbyAccount & accountDescription)
 	: GlobalLobbyChannelCardBase(window, Point(130, 40), "player", accountDescription.accountID, accountDescription.displayName)
 {
-	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
+	OBJECT_CONSTRUCTION;
 	labelName = std::make_shared<CLabel>(5, 10, FONT_SMALL, ETextAlignment::CENTERLEFT, Colors::WHITE, accountDescription.displayName, 120);
 	labelStatus = std::make_shared<CLabel>(5, 30, FONT_SMALL, ETextAlignment::CENTERLEFT, Colors::YELLOW, accountDescription.status);
 }
@@ -215,7 +215,7 @@ GlobalLobbyRoomCard::GlobalLobbyRoomCard(GlobalLobbyWindow * window, const Globa
 	: window(window)
 	, roomUUID(roomDescription.gameRoomID)
 {
-	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
+	OBJECT_CONSTRUCTION;
 	addUsedEvents(LCLICK);
 
 	bool hasInvite = CSH->getGlobalLobby().isInvitedToRoom(roomDescription.gameRoomID);
@@ -253,14 +253,14 @@ void GlobalLobbyRoomCard::clickPressed(const Point & cursorPosition)
 GlobalLobbyChannelCard::GlobalLobbyChannelCard(GlobalLobbyWindow * window, const std::string & channelName)
 	: GlobalLobbyChannelCardBase(window, Point(146, 40), "global", channelName, Languages::getLanguageOptions(channelName).nameNative)
 {
-	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
+	OBJECT_CONSTRUCTION;
 	labelName = std::make_shared<CLabel>(5, 20, FONT_SMALL, ETextAlignment::CENTERLEFT, Colors::WHITE, Languages::getLanguageOptions(channelName).nameNative);
 }
 
 GlobalLobbyMatchCard::GlobalLobbyMatchCard(GlobalLobbyWindow * window, const GlobalLobbyRoom & matchDescription)
 	: GlobalLobbyChannelCardBase(window, Point(130, 40), "match", matchDescription.gameRoomID, matchDescription.startDateFormatted)
 {
-	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
+	OBJECT_CONSTRUCTION;
 	labelMatchDate = std::make_shared<CLabel>(5, 10, FONT_SMALL, ETextAlignment::CENTERLEFT, Colors::WHITE, matchDescription.startDateFormatted);
 
 	MetaString opponentDescription;

--- a/client/globalLobby/GlobalLobbyWindow.cpp
+++ b/client/globalLobby/GlobalLobbyWindow.cpp
@@ -30,7 +30,7 @@
 GlobalLobbyWindow::GlobalLobbyWindow()
 	: CWindowObject(BORDERED)
 {
-	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
+	OBJECT_CONSTRUCTION;
 	widget = std::make_shared<GlobalLobbyWidget>(this);
 	pos = widget->pos;
 	center();

--- a/client/gui/CGuiHandler.cpp
+++ b/client/gui/CGuiHandler.cpp
@@ -58,14 +58,11 @@ SSetCaptureState::SSetCaptureState(bool allow, ui8 actions)
 {
 	previousCapture = GH.captureChildren;
 	GH.captureChildren = false;
-	prevActions = GH.defActionsDef;
-	GH.defActionsDef = actions;
 }
 
 SSetCaptureState::~SSetCaptureState()
 {
 	GH.captureChildren = previousCapture;
-	GH.defActionsDef = prevActions;
 }
 
 void CGuiHandler::init()
@@ -139,8 +136,7 @@ void CGuiHandler::renderFrame()
 }
 
 CGuiHandler::CGuiHandler()
-	: defActionsDef(0)
-	, captureChildren(false)
+	: captureChildren(false)
 	, curInt(nullptr)
 	, fakeStatusBar(std::make_shared<EmptyStatusBar>())
 {

--- a/client/gui/CGuiHandler.cpp
+++ b/client/gui/CGuiHandler.cpp
@@ -40,7 +40,6 @@ CGuiHandler GH;
 static thread_local bool inGuiThread = false;
 
 ObjectConstruction::ObjectConstruction(CIntObject *obj)
-:myObj(obj)
 {
 	GH.createdObj.push_front(obj);
 	GH.captureChildren = true;
@@ -48,10 +47,9 @@ ObjectConstruction::ObjectConstruction(CIntObject *obj)
 
 ObjectConstruction::~ObjectConstruction()
 {
-	assert(GH.createdObj.size());
-	assert(GH.createdObj.front() == myObj);
+	assert(!GH.createdObj.empty());
 	GH.createdObj.pop_front();
-	GH.captureChildren = GH.createdObj.size();
+	GH.captureChildren = !GH.createdObj.empty();
 }
 
 void CGuiHandler::init()

--- a/client/gui/CGuiHandler.cpp
+++ b/client/gui/CGuiHandler.cpp
@@ -39,30 +39,19 @@ CGuiHandler GH;
 
 static thread_local bool inGuiThread = false;
 
-SObjectConstruction::SObjectConstruction(CIntObject *obj)
+ObjectConstruction::ObjectConstruction(CIntObject *obj)
 :myObj(obj)
 {
 	GH.createdObj.push_front(obj);
 	GH.captureChildren = true;
 }
 
-SObjectConstruction::~SObjectConstruction()
+ObjectConstruction::~ObjectConstruction()
 {
 	assert(GH.createdObj.size());
 	assert(GH.createdObj.front() == myObj);
 	GH.createdObj.pop_front();
 	GH.captureChildren = GH.createdObj.size();
-}
-
-SSetCaptureState::SSetCaptureState(bool allow, ui8 actions)
-{
-	previousCapture = GH.captureChildren;
-	GH.captureChildren = false;
-}
-
-SSetCaptureState::~SSetCaptureState()
-{
-	GH.captureChildren = previousCapture;
 }
 
 void CGuiHandler::init()

--- a/client/gui/CGuiHandler.h
+++ b/client/gui/CGuiHandler.h
@@ -89,7 +89,6 @@ public:
 
 	IUpdateable *curInt;
 
-	ui8 defActionsDef; //default auto actions
 	bool captureChildren; //all newly created objects will get their parents from stack and will be added to parents children list
 	std::list<CIntObject *> createdObj; //stack of objs being created
 
@@ -124,14 +123,13 @@ struct SObjectConstruction
 struct SSetCaptureState
 {
 	bool previousCapture;
-	ui8 prevActions;
 	SSetCaptureState(bool allow, ui8 actions);
 	~SSetCaptureState();
 };
 
 #define OBJ_CONSTRUCTION SObjectConstruction obj__i(this)
 #define OBJ_CONSTRUCTION_TARGETED(obj) SObjectConstruction obj__i(obj)
-#define OBJECT_CONSTRUCTION_CAPTURING(actions) defActions = actions; SSetCaptureState obj__i1(true, actions); SObjectConstruction obj__i(this)
+#define OBJECT_CONSTRUCTION_CAPTURING(actions) SSetCaptureState obj__i1(true, actions); SObjectConstruction obj__i(this)
 #define OBJECT_CONSTRUCTION_CUSTOM_CAPTURING(actions) SSetCaptureState obj__i1(true, actions); SObjectConstruction obj__i(this)
 
-#define OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE defActions = 255 - DISPOSE; SSetCaptureState obj__i1(true, 255 - DISPOSE); SObjectConstruction obj__i(this)
+#define OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE SSetCaptureState obj__i1(true, 255 - DISPOSE); SObjectConstruction obj__i(this)

--- a/client/gui/CGuiHandler.h
+++ b/client/gui/CGuiHandler.h
@@ -112,24 +112,3 @@ public:
 };
 
 extern CGuiHandler GH; //global gui handler
-
-struct SObjectConstruction
-{
-	CIntObject *myObj;
-	SObjectConstruction(CIntObject *obj);
-	~SObjectConstruction();
-};
-
-struct SSetCaptureState
-{
-	bool previousCapture;
-	SSetCaptureState(bool allow, ui8 actions);
-	~SSetCaptureState();
-};
-
-#define OBJ_CONSTRUCTION SObjectConstruction obj__i(this)
-#define OBJ_CONSTRUCTION_TARGETED(obj) SObjectConstruction obj__i(obj)
-#define OBJECT_CONSTRUCTION_CAPTURING(actions) SSetCaptureState obj__i1(true, actions); SObjectConstruction obj__i(this)
-#define OBJECT_CONSTRUCTION_CUSTOM_CAPTURING(actions) SSetCaptureState obj__i1(true, actions); SObjectConstruction obj__i(this)
-
-#define OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE SSetCaptureState obj__i1(true, 255 - DISPOSE); SObjectConstruction obj__i(this)

--- a/client/gui/CIntObject.cpp
+++ b/client/gui/CIntObject.cpp
@@ -106,6 +106,8 @@ void CIntObject::disable()
 {
 	if(isActive())
 		deactivate();
+
+	recActions = NO_ACTIONS;
 }
 
 void CIntObject::enable()
@@ -116,7 +118,7 @@ void CIntObject::enable()
 		redraw();
 	}
 
-	recActions = 255;
+	recActions = ALL_ACTIONS;
 }
 
 void CIntObject::setEnabled(bool on)

--- a/client/gui/CIntObject.cpp
+++ b/client/gui/CIntObject.cpp
@@ -37,12 +37,7 @@ CIntObject::~CIntObject()
 		deactivate();
 
 	while(!children.empty())
-	{
-		if(children.front()->recActions & DISPOSE)
-			delete children.front();
-		else
-			removeChild(children.front());
-	}
+		removeChild(children.front());
 
 	if(parent_m)
 		parent_m->removeChild(this);
@@ -111,8 +106,6 @@ void CIntObject::disable()
 {
 	if(isActive())
 		deactivate();
-
-	recActions = DISPOSE;
 }
 
 void CIntObject::enable()

--- a/client/gui/CIntObject.cpp
+++ b/client/gui/CIntObject.cpp
@@ -24,8 +24,7 @@ CIntObject::CIntObject(int used_, Point pos_):
 	redrawParent(false),
 	inputEnabled(true),
 	used(used_),
-	recActions(GH.defActionsDef),
-	defActions(GH.defActionsDef),
+	recActions(ALL_ACTIONS),
 	pos(pos_, Point())
 {
 	if(GH.captureChildren)
@@ -39,7 +38,7 @@ CIntObject::~CIntObject()
 
 	while(!children.empty())
 	{
-		if((defActions & DISPOSE) && (children.front()->recActions & DISPOSE))
+		if(children.front()->recActions & DISPOSE)
 			delete children.front();
 		else
 			removeChild(children.front());
@@ -51,20 +50,16 @@ CIntObject::~CIntObject()
 
 void CIntObject::show(Canvas & to)
 {
-	if(defActions & UPDATE)
-		for(auto & elem : children)
-			if(elem->recActions & UPDATE)
-				elem->show(to);
+	for(auto & elem : children)
+		if(elem->recActions & UPDATE)
+			elem->show(to);
 }
 
 void CIntObject::showAll(Canvas & to)
 {
-	if(defActions & SHOWALL)
-	{
-		for(auto & elem : children)
-			if(elem->recActions & SHOWALL)
-				elem->showAll(to);
-	}
+	for(auto & elem : children)
+		if(elem->recActions & SHOWALL)
+			elem->showAll(to);
 }
 
 void CIntObject::activate()
@@ -79,10 +74,9 @@ void CIntObject::activate()
 
 	assert(isActive());
 
-	if(defActions & ACTIVATE)
-		for(auto & elem : children)
-			if(elem->recActions & ACTIVATE)
-				elem->activate();
+	for(auto & elem : children)
+		if(elem->recActions & ACTIVATE)
+			elem->activate();
 }
 
 void CIntObject::deactivate()
@@ -94,10 +88,9 @@ void CIntObject::deactivate()
 
 	assert(!isActive());
 
-	if(defActions & DEACTIVATE)
-		for(auto & elem : children)
-			if(elem->recActions & DEACTIVATE)
-				elem->deactivate();
+	for(auto & elem : children)
+		if(elem->recActions & DEACTIVATE)
+			elem->deactivate();
 }
 
 void CIntObject::addUsedEvents(ui16 newActions)

--- a/client/gui/CIntObject.h
+++ b/client/gui/CIntObject.h
@@ -211,3 +211,24 @@ class EmptyStatusBar : public IStatusBar
 	virtual void setEnteringMode(bool on){};
 	virtual void setEnteredText(const std::string & text){};
 };
+
+struct SObjectConstruction
+{
+	CIntObject *myObj;
+	SObjectConstruction(CIntObject *obj);
+	~SObjectConstruction();
+};
+
+struct SSetCaptureState
+{
+	bool previousCapture;
+	SSetCaptureState(bool allow, ui8 actions);
+	~SSetCaptureState();
+};
+
+#define OBJ_CONSTRUCTION SObjectConstruction obj__i(this)
+#define OBJ_CONSTRUCTION_TARGETED(obj) SObjectConstruction obj__i(obj)
+#define OBJECT_CONSTRUCTION_CAPTURING(actions) SSetCaptureState obj__i1(true, actions); SObjectConstruction obj__i(this)
+#define OBJECT_CONSTRUCTION_CUSTOM_CAPTURING(actions) SSetCaptureState obj__i1(true, actions); SObjectConstruction obj__i(this)
+
+#define OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE SSetCaptureState obj__i1(true, ALL_ACTIONS); SObjectConstruction obj__i(this)

--- a/client/gui/CIntObject.h
+++ b/client/gui/CIntObject.h
@@ -212,23 +212,13 @@ class EmptyStatusBar : public IStatusBar
 	virtual void setEnteredText(const std::string & text){};
 };
 
-struct SObjectConstruction
+class ObjectConstruction
 {
 	CIntObject *myObj;
-	SObjectConstruction(CIntObject *obj);
-	~SObjectConstruction();
+public:
+	ObjectConstruction(CIntObject *obj);
+	~ObjectConstruction();
 };
 
-struct SSetCaptureState
-{
-	bool previousCapture;
-	SSetCaptureState(bool allow, ui8 actions);
-	~SSetCaptureState();
-};
-
-#define OBJ_CONSTRUCTION SObjectConstruction obj__i(this)
-#define OBJ_CONSTRUCTION_TARGETED(obj) SObjectConstruction obj__i(obj)
-#define OBJECT_CONSTRUCTION_CAPTURING(actions) SSetCaptureState obj__i1(true, actions); SObjectConstruction obj__i(this)
-#define OBJECT_CONSTRUCTION_CUSTOM_CAPTURING(actions) SSetCaptureState obj__i1(true, actions); SObjectConstruction obj__i(this)
-
-#define OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE SSetCaptureState obj__i1(true, ALL_ACTIONS); SObjectConstruction obj__i(this)
+#define OBJECT_CONSTRUCTION ObjectConstruction obj__i(this)
+#define OBJECT_CONSTRUCTION_TARGETED(obj) ObjectConstruction obj__i(obj)

--- a/client/gui/CIntObject.h
+++ b/client/gui/CIntObject.h
@@ -73,7 +73,7 @@ public:
 	void addUsedEvents(ui16 newActions);
 	void removeUsedEvents(ui16 newActions);
 
-	enum {ACTIVATE=1, DEACTIVATE=2, UPDATE=4, SHOWALL=8, DISPOSE=16, SHARE_POS=32, ALL_ACTIONS=255-DISPOSE};
+	enum {ACTIVATE=1, DEACTIVATE=2, UPDATE=4, SHOWALL=8, SHARE_POS=16, ALL_ACTIONS=31};
 	ui8 recActions; //which calls we allow to receive from parent
 
 	/// deactivates if needed, blocks all automatic activity, allows only disposal

--- a/client/gui/CIntObject.h
+++ b/client/gui/CIntObject.h
@@ -73,8 +73,7 @@ public:
 	void addUsedEvents(ui16 newActions);
 	void removeUsedEvents(ui16 newActions);
 
-	enum {ACTIVATE=1, DEACTIVATE=2, UPDATE=4, SHOWALL=8, DISPOSE=16, SHARE_POS=32};
-	ui8 defActions; //which calls will be tried to be redirected to children
+	enum {ACTIVATE=1, DEACTIVATE=2, UPDATE=4, SHOWALL=8, DISPOSE=16, SHARE_POS=32, ALL_ACTIONS=255-DISPOSE};
 	ui8 recActions; //which calls we allow to receive from parent
 
 	/// deactivates if needed, blocks all automatic activity, allows only disposal

--- a/client/gui/CIntObject.h
+++ b/client/gui/CIntObject.h
@@ -73,7 +73,7 @@ public:
 	void addUsedEvents(ui16 newActions);
 	void removeUsedEvents(ui16 newActions);
 
-	enum {ACTIVATE=1, DEACTIVATE=2, UPDATE=4, SHOWALL=8, SHARE_POS=16, ALL_ACTIONS=31};
+	enum {NO_ACTIONS = 0, ACTIVATE=1, DEACTIVATE=2, UPDATE=4, SHOWALL=8, SHARE_POS=16, ALL_ACTIONS=31};
 	ui8 recActions; //which calls we allow to receive from parent
 
 	/// deactivates if needed, blocks all automatic activity, allows only disposal
@@ -214,7 +214,6 @@ class EmptyStatusBar : public IStatusBar
 
 class ObjectConstruction
 {
-	CIntObject *myObj;
 public:
 	ObjectConstruction(CIntObject *obj);
 	~ObjectConstruction();

--- a/client/gui/CIntObject.h
+++ b/client/gui/CIntObject.h
@@ -220,5 +220,8 @@ public:
 	~ObjectConstruction();
 };
 
+/// If used, all UI widgets created inside this scope will be added to children of 'this'
 #define OBJECT_CONSTRUCTION ObjectConstruction obj__i(this)
+
+/// If used, all UI widgets created inside this scope will be added to children of provided object
 #define OBJECT_CONSTRUCTION_TARGETED(obj) ObjectConstruction obj__i(obj)

--- a/client/gui/InterfaceObjectConfigurable.cpp
+++ b/client/gui/InterfaceObjectConfigurable.cpp
@@ -106,7 +106,7 @@ void InterfaceObjectConfigurable::loadCustomBuilders(const JsonNode & config)
 
 void InterfaceObjectConfigurable::build(const JsonNode &config)
 {
-	OBJ_CONSTRUCTION;
+	OBJECT_CONSTRUCTION;
 
 	logGlobal->debug("Building configurable interface object");
 	auto * items = &config;
@@ -371,7 +371,7 @@ std::shared_ptr<CToggleGroup> InterfaceObjectConfigurable::buildToggleGroup(cons
 	group->pos += position;
 	if(!config["items"].isNull())
 	{
-		OBJ_CONSTRUCTION_TARGETED(group.get());
+		OBJECT_CONSTRUCTION_TARGETED(group.get());
 		int itemIdx = -1;
 		for(const auto & item : config["items"].Vector())
 		{

--- a/client/lobby/CBonusSelection.cpp
+++ b/client/lobby/CBonusSelection.cpp
@@ -66,7 +66,7 @@ std::shared_ptr<CampaignState> CBonusSelection::getCampaign()
 CBonusSelection::CBonusSelection()
 	: CWindowObject(BORDERED)
 {
-	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
+	OBJECT_CONSTRUCTION;
 
 	setBackground(getCampaign()->getRegions().getBackgroundName());
 
@@ -145,7 +145,7 @@ CBonusSelection::CBonusSelection()
 
 void CBonusSelection::createBonusesIcons()
 {
-	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
+	OBJECT_CONSTRUCTION;
 	const CampaignScenario & scenario = getCampaign()->scenario(CSH->campaignMap);
 	const std::vector<CampaignBonus> & bonDescs = scenario.travelOptions.bonusesToChoose;
 	groupBonuses = std::make_shared<CToggleGroup>(std::bind(&IServerAPI::setCampaignBonus, CSH, _1));
@@ -474,7 +474,7 @@ void CBonusSelection::decreaseDifficulty()
 CBonusSelection::CRegion::CRegion(CampaignScenarioID id, bool accessible, bool selectable, const CampaignRegions & campDsc)
 	: CIntObject(LCLICK | SHOW_POPUP), idOfMapAndRegion(id), accessible(accessible), selectable(selectable)
 {
-	OBJ_CONSTRUCTION;
+	OBJECT_CONSTRUCTION;
 
 	pos += campDsc.getPosition(id);
 

--- a/client/lobby/CCampaignInfoScreen.cpp
+++ b/client/lobby/CCampaignInfoScreen.cpp
@@ -22,7 +22,7 @@
 
 CCampaignInfoScreen::CCampaignInfoScreen()
 {
-	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
+	OBJECT_CONSTRUCTION;
 	localSi = new StartInfo(*LOCPLINT->cb->getStartInfo());
 	localMi = new CMapInfo();
 	localMi->mapHeader = std::unique_ptr<CMapHeader>(new CMapHeader(*LOCPLINT->cb->getMapHeader()));

--- a/client/lobby/CLobbyScreen.cpp
+++ b/client/lobby/CLobbyScreen.cpp
@@ -38,7 +38,7 @@
 CLobbyScreen::CLobbyScreen(ESelectionScreen screenType)
 	: CSelectionBase(screenType), bonusSel(nullptr)
 {
-	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
+	OBJECT_CONSTRUCTION;
 	tabSel = std::make_shared<SelectionTab>(screenType);
 	curTab = tabSel;
 

--- a/client/lobby/CSavingScreen.cpp
+++ b/client/lobby/CSavingScreen.cpp
@@ -30,7 +30,7 @@
 CSavingScreen::CSavingScreen()
 	: CSelectionBase(ESelectionScreen::saveGame)
 {
-	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
+	OBJECT_CONSTRUCTION;
 	center(pos);
 	localMi = std::make_shared<CMapInfo>();
 	localMi->mapHeader = std::unique_ptr<CMapHeader>(new CMapHeader(*LOCPLINT->cb->getMapHeader()));

--- a/client/lobby/CScenarioInfoScreen.cpp
+++ b/client/lobby/CScenarioInfoScreen.cpp
@@ -27,7 +27,7 @@
 
 CScenarioInfoScreen::CScenarioInfoScreen()
 {
-	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
+	OBJECT_CONSTRUCTION;
 	pos.w = 800;
 	pos.h = 600;
 	pos = center();

--- a/client/lobby/CSelectionBase.cpp
+++ b/client/lobby/CSelectionBase.cpp
@@ -81,7 +81,7 @@ PlayerInfo ISelectionScreenInfo::getPlayerInfo(PlayerColor color)
 CSelectionBase::CSelectionBase(ESelectionScreen type)
 	: CWindowObject(BORDERED | SHADOW_DISABLED), ISelectionScreenInfo(type)
 {
-	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
+	OBJECT_CONSTRUCTION;
 	pos.w = 762;
 	pos.h = 584;
 	if(screenType == ESelectionScreen::campaignList)
@@ -130,7 +130,7 @@ void CSelectionBase::toggleTab(std::shared_ptr<CIntObject> tab)
 InfoCard::InfoCard()
 	: showChat(true)
 {
-	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
+	OBJECT_CONSTRUCTION;
 	setRedrawParent(true);
 	pos.x += 393;
 	pos.y += 6;
@@ -252,7 +252,7 @@ void InfoCard::changeSelection()
 	const std::array<std::string, 5> difficultyPercent = {"80%", "100%", "130%", "160%", "200%"};
 	labelDifficultyPercent->setText(difficultyPercent[SEL->getCurrentDifficulty()]);
 
-	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
+	OBJECT_CONSTRUCTION;
 	// FIXME: We recreate them each time because CLabelGroup don't use smart pointers
 	labelGroupPlayers = std::make_shared<CLabelGroup>(FONT_SMALL, ETextAlignment::TOPLEFT, Colors::WHITE);
 	if(!showChat)
@@ -356,7 +356,7 @@ void InfoCard::setChat(bool activateChat)
 CChatBox::CChatBox(const Rect & rect)
 	: CIntObject(KEYBOARD | TEXTINPUT)
 {
-	OBJ_CONSTRUCTION;
+	OBJECT_CONSTRUCTION;
 	pos += rect.topLeft();
 	setRedrawParent(true);
 
@@ -397,7 +397,7 @@ void CChatBox::addNewMessage(const std::string & text)
 
 PvPBox::PvPBox(const Rect & rect)
 {
-	OBJ_CONSTRUCTION;
+	OBJECT_CONSTRUCTION;
 	pos += rect.topLeft();
 	setRedrawParent(true);
 
@@ -448,7 +448,7 @@ PvPBox::PvPBox(const Rect & rect)
 
 TownSelector::TownSelector(const Point & loc)
 {
-	OBJ_CONSTRUCTION;
+	OBJECT_CONSTRUCTION;
 	pos += loc;
 	setRedrawParent(true);
 
@@ -473,7 +473,7 @@ TownSelector::TownSelector(const Point & loc)
 
 void TownSelector::updateListItems()
 {
-	OBJ_CONSTRUCTION;
+	OBJECT_CONSTRUCTION;
 	int line = slider ? slider->getValue() : 0;
 	int x_offset = slider ? 0 : 8;
 	
@@ -519,7 +519,7 @@ CFlagBox::CFlagBox(const Rect & rect)
 	pos += rect.topLeft();
 	pos.w = rect.w;
 	pos.h = rect.h;
-	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
+	OBJECT_CONSTRUCTION;
 
 	labelAllies = std::make_shared<CLabel>(0, 0, FONT_SMALL, ETextAlignment::TOPLEFT, Colors::WHITE, CGI->generaltexth->allTexts[390] + ":");
 	labelEnemies = std::make_shared<CLabel>(133, 0, FONT_SMALL, ETextAlignment::TOPLEFT, Colors::WHITE, CGI->generaltexth->allTexts[391] + ":");
@@ -529,7 +529,7 @@ void CFlagBox::recreate()
 {
 	flagsAllies.clear();
 	flagsEnemies.clear();
-	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
+	OBJECT_CONSTRUCTION;
 	const int alliesX = 5 + (int)labelAllies->getWidth();
 	const int enemiesX = 5 + 133 + (int)labelEnemies->getWidth();
 	for(auto i = CSH->si->playerInfos.cbegin(); i != CSH->si->playerInfos.cend(); i++)
@@ -557,7 +557,7 @@ void CFlagBox::showPopupWindow(const Point & cursorPosition)
 CFlagBox::CFlagBoxTooltipBox::CFlagBoxTooltipBox()
 	: CWindowObject(BORDERED | RCLICK_POPUP | SHADOW_DISABLED, ImagePath::builtin("DIBOXBCK"))
 {
-	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
+	OBJECT_CONSTRUCTION;
 
 	labelTeamAlignment = std::make_shared<CLabel>(128, 30, FONT_MEDIUM, ETextAlignment::CENTER, Colors::YELLOW, CGI->generaltexth->allTexts[657]);
 	labelGroupTeams = std::make_shared<CLabelGroup>(FONT_SMALL, ETextAlignment::CENTER, Colors::WHITE);

--- a/client/lobby/CSelectionBase.cpp
+++ b/client/lobby/CSelectionBase.cpp
@@ -108,7 +108,6 @@ void CSelectionBase::toggleTab(std::shared_ptr<CIntObject> tab)
 
 	if(curTab != tab)
 	{
-		tab->recActions = 255 - DISPOSE;
 		tab->activate();
 		curTab = tab;
 	}

--- a/client/lobby/OptionsTab.cpp
+++ b/client/lobby/OptionsTab.cpp
@@ -993,7 +993,6 @@ OptionsTab::PlayerOptionsEntry::PlayerOptionsEntry(const PlayerSettings & S, con
 	, name(S.name)
 {
 	OBJ_CONSTRUCTION;
-	defActions |= SHARE_POS;
 
 	int serial = 0;
 	for(PlayerColor g = PlayerColor(0); g < s->color; ++g)

--- a/client/lobby/OptionsTab.cpp
+++ b/client/lobby/OptionsTab.cpp
@@ -71,7 +71,7 @@ void OptionsTab::recreate()
 		selectionWindow->reopen();
 	}
 
-	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
+	OBJECT_CONSTRUCTION;
 	for(auto & pInfo : SEL->getStartInfo()->playerInfos)
 	{
 		if(pInfo.second.isControlledByHuman())
@@ -333,7 +333,7 @@ std::string OptionsTab::CPlayerSettingsHelper::getDescription()
 OptionsTab::CPlayerOptionTooltipBox::CPlayerOptionTooltipBox(CPlayerSettingsHelper & helper)
 	: CWindowObject(BORDERED | RCLICK_POPUP), CPlayerSettingsHelper(helper)
 {
-	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
+	OBJECT_CONSTRUCTION;
 
 	switch(selectionType)
 	{
@@ -503,7 +503,7 @@ void OptionsTab::SelectionWindow::reopen()
 
 void OptionsTab::SelectionWindow::recreate(int sliderPos)
 {
-	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
+	OBJECT_CONSTRUCTION;
 
 	int amountLines = 1;
 	if(type == SelType::BONUS)
@@ -797,7 +797,7 @@ void OptionsTab::SelectionWindow::showPopupWindow(const Point & cursorPosition)
 OptionsTab::HandicapWindow::HandicapWindow()
 	: CWindowObject(BORDERED)
 {
-	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
+	OBJECT_CONSTRUCTION;
 
 	addUsedEvents(LCLICK);
 
@@ -911,7 +911,7 @@ OptionsTab::SelectedBox::SelectedBox(Point position, PlayerSettings & playerSett
 	: Scrollable(LCLICK | SHOW_POPUP, position, Orientation::HORIZONTAL)
 	, CPlayerSettingsHelper(playerSettings, type)
 {
-	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
+	OBJECT_CONSTRUCTION;
 
 	image = std::make_shared<CAnimImage>(getImageName(), getImageIndex());
 	subtitle = std::make_shared<CLabel>(24, 39, FONT_TINY, ETextAlignment::CENTER, Colors::WHITE, getName(), 71);
@@ -992,7 +992,7 @@ OptionsTab::PlayerOptionsEntry::PlayerOptionsEntry(const PlayerSettings & S, con
 	, parentTab(parent)
 	, name(S.name)
 {
-	OBJ_CONSTRUCTION;
+	OBJECT_CONSTRUCTION;
 
 	int serial = 0;
 	for(PlayerColor g = PlayerColor(0); g < s->color; ++g)

--- a/client/lobby/RandomMapTab.cpp
+++ b/client/lobby/RandomMapTab.cpp
@@ -447,7 +447,7 @@ void TeamAlignmentsWidget::checkTeamCount()
 TeamAlignments::TeamAlignments(RandomMapTab & randomMapTab)
 	: CWindowObject(BORDERED)
 {
-	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
+	OBJECT_CONSTRUCTION;
 
 	widget = std::make_shared<TeamAlignmentsWidget>(randomMapTab);
 	pos = widget->pos;
@@ -501,7 +501,7 @@ TeamAlignmentsWidget::TeamAlignmentsWidget(RandomMapTab & randomMapTab):
 	
 	center(pos);
 	
-	OBJ_CONSTRUCTION;
+	OBJECT_CONSTRUCTION;
 	
 	// Window should have X * X columns, where X is max players allowed for current settings
 	// For random player count, X is 8
@@ -529,7 +529,7 @@ TeamAlignmentsWidget::TeamAlignmentsWidget(RandomMapTab & randomMapTab):
 		players.push_back(std::make_shared<CToggleGroup>([&, totalPlayers, plId](int sel)
 		{
 			variables["player_id"].Integer() = plId;
-			OBJ_CONSTRUCTION_TARGETED(players[plId].get());
+			OBJECT_CONSTRUCTION_TARGETED(players[plId].get());
 			for(int teamId = 0; teamId < totalPlayers; ++teamId)
 			{
 				auto button = std::dynamic_pointer_cast<CToggleButton>(players[plId]->buttons[teamId]);
@@ -549,7 +549,7 @@ TeamAlignmentsWidget::TeamAlignmentsWidget(RandomMapTab & randomMapTab):
 			}
 		}));
 		
-		OBJ_CONSTRUCTION_TARGETED(players.back().get());
+		OBJECT_CONSTRUCTION_TARGETED(players.back().get());
 
 		for(int teamId = 0; teamId < totalPlayers; ++teamId)
 		{

--- a/client/lobby/SelectionTab.cpp
+++ b/client/lobby/SelectionTab.cpp
@@ -154,7 +154,7 @@ static ESortBy getSortBySelectionScreen(ESelectionScreen Type)
 SelectionTab::SelectionTab(ESelectionScreen Type)
 	: CIntObject(LCLICK | SHOW_POPUP | KEYBOARD | DOUBLECLICK), callOnSelect(nullptr), tabType(Type), selectionPos(0), sortModeAscending(true), inputNameRect{32, 539, 350, 20}, curFolder(""), currentMapSizeFilter(0), showRandom(false)
 {
-	OBJ_CONSTRUCTION;
+	OBJECT_CONSTRUCTION;
 		
 	generalSortingBy = getSortBySelectionScreen(tabType);
 	sortingBy = _format;
@@ -883,7 +883,7 @@ std::unordered_set<ResourcePath> SelectionTab::getFiles(std::string dirURI, ERes
 SelectionTab::ListItem::ListItem(Point position)
 	: CIntObject(LCLICK, position)
 {
-	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
+	OBJECT_CONSTRUCTION;
 	pictureEmptyLine = std::make_shared<CPicture>(ImagePath::builtin("camcust"), Rect(25, 121, 349, 26), -8, -14);
 	labelName = std::make_shared<CLabel>(184, 0, FONT_SMALL, ETextAlignment::CENTER, Colors::WHITE, "", 185);
 	labelName->setAutoRedraw(false);

--- a/client/mainmenu/CCampaignScreen.cpp
+++ b/client/mainmenu/CCampaignScreen.cpp
@@ -48,7 +48,7 @@
 CCampaignScreen::CCampaignScreen(const JsonNode & config, std::string name)
 	: CWindowObject(BORDERED), campaignSet(name)
 {
-	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
+	OBJECT_CONSTRUCTION;
 
 	for(const JsonNode & node : config[name]["images"].Vector())
 		images.push_back(CMainMenu::createPicture(node));
@@ -90,7 +90,7 @@ std::shared_ptr<CButton> CCampaignScreen::createExitButton(const JsonNode & butt
 CCampaignScreen::CCampaignButton::CCampaignButton(const JsonNode & config, const JsonNode & parentConfig, std::string campaignSet)
 	: campaignSet(campaignSet)
 {
-	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
+	OBJECT_CONSTRUCTION;
 
 	pos.x += static_cast<int>(config["x"].Float());
 	pos.y += static_cast<int>(config["y"].Float());
@@ -140,7 +140,7 @@ void CCampaignScreen::CCampaignButton::clickReleased(const Point & cursorPositio
 
 void CCampaignScreen::CCampaignButton::hover(bool on)
 {
-	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
+	OBJECT_CONSTRUCTION;
 
 	if (on && !videoPath.empty())
 		videoPlayer = std::make_shared<VideoWidget>(Point(), videoPath, false);

--- a/client/mainmenu/CHighScoreScreen.cpp
+++ b/client/mainmenu/CHighScoreScreen.cpp
@@ -107,7 +107,7 @@ CHighScoreScreen::CHighScoreScreen(HighScorePage highscorepage, int highlighted)
 {
 	addUsedEvents(SHOW_POPUP);
 
-	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
+	OBJECT_CONSTRUCTION;
 	pos = center(Rect(0, 0, 800, 600));
 
 	backgroundAroundMenu = std::make_shared<CFilledTexture>(ImagePath::builtin("DIBOXBCK"), Rect(-pos.x, -pos.y, GH.screenDimensions().x, GH.screenDimensions().y));
@@ -134,7 +134,7 @@ void CHighScoreScreen::showPopupWindow(const Point & cursorPosition)
 
 void CHighScoreScreen::addButtons()
 {
-	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
+	OBJECT_CONSTRUCTION;
 	
 	buttons.clear();
 
@@ -146,7 +146,7 @@ void CHighScoreScreen::addButtons()
 
 void CHighScoreScreen::addHighScores()
 {
-	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
+	OBJECT_CONSTRUCTION;
 
 	background = std::make_shared<CPicture>(ImagePath::builtin(highscorepage == HighScorePage::SCENARIO ? "HISCORE" : "HISCORE2"));
 
@@ -209,7 +209,7 @@ void CHighScoreScreen::buttonCampaignClick()
 
 void CHighScoreScreen::buttonScenarioClick()
 {
-	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
+	OBJECT_CONSTRUCTION;
 	highscorepage = HighScorePage::SCENARIO;
 	addHighScores();
 	addButtons();
@@ -243,7 +243,7 @@ CHighScoreInputScreen::CHighScoreInputScreen(bool won, HighScoreCalculation calc
 {
 	addUsedEvents(LCLICK | KEYBOARD);
 
-	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
+	OBJECT_CONSTRUCTION;
 	pos = center(Rect(0, 0, 800, 600));
 
 	backgroundAroundMenu = std::make_shared<CFilledTexture>(ImagePath::builtin("DIBOXBCK"), Rect(-pos.x, -pos.y, GH.screenDimensions().x, GH.screenDimensions().y));
@@ -321,7 +321,7 @@ void CHighScoreInputScreen::show(Canvas & to)
 
 void CHighScoreInputScreen::clickPressed(const Point & cursorPosition)
 {
-	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
+	OBJECT_CONSTRUCTION;
 
 	if(!won)
 	{
@@ -354,7 +354,7 @@ void CHighScoreInputScreen::keyPressed(EShortcut key)
 CHighScoreInput::CHighScoreInput(std::string playerName, std::function<void(std::string text)> readyCB)
 	: CWindowObject(NEEDS_ANIMATED_BACKGROUND, ImagePath::builtin("HIGHNAME")), ready(readyCB)
 {
-	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
+	OBJECT_CONSTRUCTION;
 
 	pos = center(Rect(0, 0, 232, 212));
 	updateShadow();

--- a/client/mainmenu/CMainMenu.cpp
+++ b/client/mainmenu/CMainMenu.cpp
@@ -73,7 +73,7 @@ static void do_quit()
 CMenuScreen::CMenuScreen(const JsonNode & configNode)
 	: CWindowObject(BORDERED), config(configNode)
 {
-	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
+	OBJECT_CONSTRUCTION;
 
 	background = std::make_shared<CPicture>(ImagePath::fromJson(config["background"]));
 	if(config["scalable"].Bool())
@@ -245,7 +245,7 @@ std::shared_ptr<CButton> CMenuEntry::createButton(CMenuScreen * parent, const Js
 
 CMenuEntry::CMenuEntry(CMenuScreen * parent, const JsonNode & config)
 {
-	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
+	OBJECT_CONSTRUCTION;
 	setRedrawParent(true);
 	pos = parent->pos;
 
@@ -290,7 +290,7 @@ CMainMenu::CMainMenu()
 	pos.h = GH.screenDimensions().y;
 
 	menu = std::make_shared<CMenuScreen>(CMainMenuConfig::get().getConfig()["window"]);
-	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
+	OBJECT_CONSTRUCTION;
 	backgroundAroundMenu = std::make_shared<CFilledTexture>(ImagePath::builtin("DIBOXBCK"), pos);
 }
 
@@ -434,7 +434,7 @@ std::shared_ptr<CPicture> CMainMenu::createPicture(const JsonNode & config)
 CMultiMode::CMultiMode(ESelectionScreen ScreenType)
 	: screenType(ScreenType)
 {
-	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
+	OBJECT_CONSTRUCTION;
 
 	background = std::make_shared<CPicture>(ImagePath::builtin("MUPOPUP.bmp"));
 	pos = background->center(); //center, window has size of bg graphic
@@ -505,7 +505,7 @@ void CMultiMode::onNameChange(std::string newText)
 CMultiPlayers::CMultiPlayers(const std::vector<std::string> & playerNames, ESelectionScreen ScreenType, bool Host, ELoadMode LoadMode)
 	: loadMode(LoadMode), screenType(ScreenType), host(Host)
 {
-	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
+	OBJECT_CONSTRUCTION;
 	background = std::make_shared<CPicture>(ImagePath::builtin("MUHOTSEA.bmp"));
 	pos = background->center(); //center, window has size of bg graphic
 
@@ -570,7 +570,7 @@ void CMultiPlayers::enterSelectionScreen()
 
 CSimpleJoinScreen::CSimpleJoinScreen(bool host)
 {
-	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
+	OBJECT_CONSTRUCTION;
 	background = std::make_shared<CPicture>(ImagePath::builtin("MUDIALOG.bmp")); // address background
 	pos = background->center(); //center, window has size of bg graphic (x,y = 396,278 w=232 h=212)
 
@@ -631,7 +631,7 @@ void CSimpleJoinScreen::startConnection(const std::string & addr, ui16 port)
 CLoadingScreen::CLoadingScreen()
 	: CWindowObject(BORDERED, getBackground())
 {
-	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
+	OBJECT_CONSTRUCTION;
 	
 	addUsedEvents(TIME);
 	

--- a/client/mainmenu/CMainMenu.cpp
+++ b/client/mainmenu/CMainMenu.cpp
@@ -289,7 +289,6 @@ CMainMenu::CMainMenu()
 	pos.w = GH.screenDimensions().x;
 	pos.h = GH.screenDimensions().y;
 
-	GH.defActionsDef = 63;
 	menu = std::make_shared<CMenuScreen>(CMainMenuConfig::get().getConfig()["window"]);
 	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
 	backgroundAroundMenu = std::make_shared<CFilledTexture>(ImagePath::builtin("DIBOXBCK"), pos);

--- a/client/mainmenu/CPrologEpilogVideo.cpp
+++ b/client/mainmenu/CPrologEpilogVideo.cpp
@@ -25,7 +25,7 @@
 CPrologEpilogVideo::CPrologEpilogVideo(CampaignScenarioPrologEpilog _spe, std::function<void()> callback)
 	: CWindowObject(BORDERED), spe(_spe), positionCounter(0), voiceSoundHandle(-1), videoSoundHandle(-1), exitCb(callback), elapsedTimeMilliseconds(0)
 {
-	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
+	OBJECT_CONSTRUCTION;
 	addUsedEvents(LCLICK | TIME);
 	pos = center(Rect(0, 0, 800, 600));
 

--- a/client/mainmenu/CreditsScreen.cpp
+++ b/client/mainmenu/CreditsScreen.cpp
@@ -27,7 +27,7 @@ CreditsScreen::CreditsScreen(Rect rect)
 	pos.w = rect.w;
 	pos.h = rect.h;
 	setRedrawParent(true);
-	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
+	OBJECT_CONSTRUCTION;
 
 	addUsedEvents(TIME);
 

--- a/client/mapView/MapView.cpp
+++ b/client/mapView/MapView.cpp
@@ -52,7 +52,7 @@ BasicMapView::BasicMapView(const Point & offset, const Point & dimensions)
 	, tilesCache(new MapViewCache(model))
 	, controller(new MapViewController(model, tilesCache))
 {
-	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
+	OBJECT_CONSTRUCTION;
 	pos += offset;
 	pos.w = dimensions.x;
 	pos.h = dimensions.y;
@@ -141,7 +141,7 @@ void MapView::show(Canvas & to)
 MapView::MapView(const Point & offset, const Point & dimensions)
 	: BasicMapView(offset, dimensions)
 {
-	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
+	OBJECT_CONSTRUCTION;
 	actions = std::make_shared<MapViewActions>(*this, model);
 	actions->setContext(controller->getContext());
 

--- a/client/widgets/Buttons.cpp
+++ b/client/widgets/Buttons.cpp
@@ -73,7 +73,7 @@ void CButton::addPopupCallback(const std::function<void()> & callback)
 
 void ButtonBase::setTextOverlay(const std::string & Text, EFonts font, ColorRGBA color)
 {
-	OBJECT_CONSTRUCTION_CUSTOM_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 	setOverlay(std::make_shared<CLabel>(pos.w/2, pos.h/2, font, ETextAlignment::CENTER, color, Text));
 	update();
 }
@@ -92,7 +92,7 @@ void ButtonBase::setOverlay(const std::shared_ptr<CIntObject>& newOverlay)
 
 void ButtonBase::setImage(const AnimationPath & defName, bool playerColoredButton)
 {
-	OBJECT_CONSTRUCTION_CUSTOM_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 
 	configurable.reset();
 	image = std::make_shared<CAnimImage>(defName, vstd::to_underlying(getState()));
@@ -125,7 +125,7 @@ const JsonNode & ButtonBase::getCurrentConfig() const
 
 void ButtonBase::setConfigurable(const JsonPath & jsonName, bool playerColoredButton)
 {
-	OBJECT_CONSTRUCTION_CUSTOM_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 
 	config = std::make_unique<JsonNode>(jsonName);
 
@@ -162,7 +162,7 @@ void ButtonBase::setStateImpl(EButtonState newState)
 
 	if (configurable)
 	{
-		OBJECT_CONSTRUCTION_CUSTOM_CAPTURING(255-DISPOSE);
+		OBJECT_CONSTRUCTION;
 		configurable = std::make_shared<InterfaceObjectConfigurable>(getCurrentConfig());
 		pos = configurable->pos;
 

--- a/client/widgets/Buttons.cpp
+++ b/client/widgets/Buttons.cpp
@@ -356,7 +356,6 @@ CButton::CButton(Point position, const AnimationPath &defName, const std::pair<s
 	hoverable(false),
 	soundDisabled(false)
 {
-	defActions = 255-DISPOSE;
 	addUsedEvents(LCLICK | SHOW_POPUP | HOVER | KEYBOARD);
 	hoverTexts[0] = help.first;
 }

--- a/client/widgets/CArtPlace.cpp
+++ b/client/widgets/CArtPlace.cpp
@@ -80,7 +80,7 @@ CArtPlace::CArtPlace(Point position, const CArtifactInstance * art)
 	, ourArt(art)
 	, locked(false)
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255 - DISPOSE);
+	OBJECT_CONSTRUCTION;
 
 	imageIndex = 0;
 	if(locked)

--- a/client/widgets/CArtifactsOfHeroBackpack.cpp
+++ b/client/widgets/CArtifactsOfHeroBackpack.cpp
@@ -73,7 +73,7 @@ size_t CArtifactsOfHeroBackpack::getSlotsNum()
 
 void CArtifactsOfHeroBackpack::initAOHbackpack(size_t slots, bool slider)
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255 - DISPOSE);
+	OBJECT_CONSTRUCTION;
 
 	backpack.resize(slots);
 	size_t artPlaceIdx = 0;

--- a/client/widgets/CArtifactsOfHeroBase.cpp
+++ b/client/widgets/CArtifactsOfHeroBase.cpp
@@ -50,8 +50,8 @@ void CArtifactsOfHeroBase::init(
 	const Point & position,
 	const BpackScrollFunctor & scrollCallback)
 {
-	// CArtifactsOfHeroBase::init may be transform to CArtifactsOfHeroBase::CArtifactsOfHeroBase if OBJECT_CONSTRUCTION_CAPTURING is removed
-	OBJECT_CONSTRUCTION_CAPTURING(255 - DISPOSE);
+	// CArtifactsOfHeroBase::init may be transform to CArtifactsOfHeroBase::CArtifactsOfHeroBase if OBJECT_CONSTRUCTION is removed
+	OBJECT_CONSTRUCTION;
 	pos += position;
 	for(int g = 0; g < ArtifactPosition::BACKPACK_START; g++)
 	{

--- a/client/widgets/CComponent.cpp
+++ b/client/widgets/CComponent.cpp
@@ -442,7 +442,6 @@ void CComponentBox::placeComponents(bool selectable)
 	for(auto & comp : components)
 	{
 		addChild(comp.get());
-		comp->recActions = defActions; //FIXME: for some reason, received component might have recActions set to 0
 		comp->moveTo(Point(pos.x, pos.y));
 	}
 

--- a/client/widgets/CComponent.cpp
+++ b/client/widgets/CComponent.cpp
@@ -58,7 +58,7 @@ CComponent::CComponent(const Component & c, ESize imageSize, EFonts font)
 
 void CComponent::init(ComponentType Type, ComponentSubType Subtype, std::optional<int32_t> Val, ESize imageSize, EFonts fnt, const std::string & ValText)
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 
 	addUsedEvents(SHOW_POPUP);
 
@@ -323,7 +323,7 @@ std::string CComponent::getSubtitle() const
 
 void CComponent::setSurface(const AnimationPath & defName, int imgPos)
 {
-	OBJECT_CONSTRUCTION_CUSTOM_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 	image = std::make_shared<CAnimImage>(defName, imgPos);
 }
 
@@ -434,7 +434,7 @@ int CComponentBox::getDistance(CComponent *left, CComponent *right)
 
 void CComponentBox::placeComponents(bool selectable)
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 	if (components.empty())
 		return;
 

--- a/client/widgets/CGarrisonInt.cpp
+++ b/client/widgets/CGarrisonInt.cpp
@@ -534,7 +534,6 @@ bool CGarrisonSlot::handleSplittingShortcuts()
 void CGarrisonInt::addSplitBtn(std::shared_ptr<CButton> button)
 {
 	addChild(button.get());
-	button->recActions &= ~DISPOSE;
 	splitButtons.push_back(button);
 	button->block(getSelection() == nullptr);
 }

--- a/client/widgets/CGarrisonInt.cpp
+++ b/client/widgets/CGarrisonInt.cpp
@@ -429,7 +429,7 @@ CGarrisonSlot::CGarrisonSlot(CGarrisonInt * Owner, int x, int y, SlotID IID, EGa
 	creature(creature_ ? creature_->type : nullptr),
 	upg(Upg)
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 
 	pos.x += x;
 	pos.y += y;
@@ -715,7 +715,7 @@ CGarrisonInt::CGarrisonInt(const Point & position, int inx, const Point & garsOf
 	, removableUnits(_removableUnits)
 	, layout(_layout)
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 
 	setArmy(s1, EGarrisonType::UPPER);
 	setArmy(s2, EGarrisonType::LOWER);

--- a/client/widgets/CTextInput.cpp
+++ b/client/widgets/CTextInput.cpp
@@ -35,7 +35,7 @@ CTextInput::CTextInput(const Rect & Pos)
 
 void CTextInput::createLabel(bool giveFocusToInput)
 {
-	OBJ_CONSTRUCTION;
+	OBJECT_CONSTRUCTION;
 	label = std::make_shared<CLabel>();
 	label->pos = pos;
 	label->alignment = originalAlignment;
@@ -59,7 +59,7 @@ CTextInput::CTextInput(const Rect & Pos, EFonts font, ETextAlignment alignment, 
 CTextInput::CTextInput(const Rect & Pos, const Point & bgOffset, const ImagePath & bgName)
 	: CTextInput(Pos)
 {
-	OBJ_CONSTRUCTION;
+	OBJECT_CONSTRUCTION;
 	if (!bgName.empty())
 		background = std::make_shared<CPicture>(bgName, bgOffset.x, bgOffset.y);
 	else
@@ -71,7 +71,7 @@ CTextInput::CTextInput(const Rect & Pos, const Point & bgOffset, const ImagePath
 CTextInput::CTextInput(const Rect & Pos, std::shared_ptr<IImage> srf)
 	: CTextInput(Pos)
 {
-	OBJ_CONSTRUCTION;
+	OBJECT_CONSTRUCTION;
 	background = std::make_shared<CPicture>(srf, Pos);
 	pos.w = background->pos.w;
 	pos.h = background->pos.h;

--- a/client/widgets/CreatureCostBox.cpp
+++ b/client/widgets/CreatureCostBox.cpp
@@ -15,7 +15,7 @@
 
 CreatureCostBox::CreatureCostBox(Rect position, std::string titleText)
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 
 	setRedrawParent(true);
 	pos = position + pos.topLeft();
@@ -33,7 +33,7 @@ void CreatureCostBox::createItems(TResources res)
 {
 	resources.clear();
 
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 
 	TResources::nziterator iter(res);
 	while(iter.valid())

--- a/client/widgets/MiscWidgets.cpp
+++ b/client/widgets/MiscWidgets.cpp
@@ -625,7 +625,6 @@ MoraleLuckBox::MoraleLuckBox(bool Morale, const Rect &r, bool Small)
 	small(Small)
 {
 	pos = r + pos.topLeft();
-	defActions = 255-DISPOSE;
 }
 
 CCreaturePic::CCreaturePic(int x, int y, const CCreature * cre, bool Big, bool Animated)

--- a/client/widgets/MiscWidgets.cpp
+++ b/client/widgets/MiscWidgets.cpp
@@ -128,7 +128,7 @@ CHeroArea::CHeroArea(int x, int y, const CGHeroInstance * hero)
 	clickFunctor(nullptr),
 	clickRFunctor(nullptr)
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 
 	pos.x += x;
 	pos.w = 58;
@@ -243,7 +243,7 @@ void CMinorResDataBar::showAll(Canvas & to)
 
 CMinorResDataBar::CMinorResDataBar()
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 
 	pos.x = 7;
 	pos.y = 575;
@@ -259,7 +259,7 @@ CMinorResDataBar::~CMinorResDataBar() = default;
 
 void CArmyTooltip::init(const InfoAboutArmy &army)
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 
 	title = std::make_shared<CLabel>(66, 2, FONT_SMALL, ETextAlignment::TOPLEFT, Colors::WHITE, army.name);
 
@@ -322,7 +322,7 @@ CArmyTooltip::CArmyTooltip(Point pos, const CArmedInstance * army):
 
 void CHeroTooltip::init(const InfoAboutHero & hero)
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 	portrait = std::make_shared<CAnimImage>(AnimationPath::builtin("PortraitsLarge"), hero.getIconIndex(), 0, 3, 2);
 
 	if(hero.details)
@@ -354,13 +354,13 @@ CInteractableHeroTooltip::CInteractableHeroTooltip(Point pos, const CGHeroInstan
 {
 	init(InfoAboutHero(hero, InfoAboutHero::EInfoLevel::DETAILED));
 
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 	garrison = std::make_shared<CGarrisonInt>(pos + Point(0, 73), 4, Point(0, 0), hero, nullptr, true, true, CGarrisonInt::ESlotsLayout::REVERSED_TWO_ROWS);
 }
 
 void CInteractableHeroTooltip::init(const InfoAboutHero & hero)
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 	portrait = std::make_shared<CAnimImage>(AnimationPath::builtin("PortraitsLarge"), hero.getIconIndex(), 0, 3, 2);
 	title = std::make_shared<CLabel>(66, 2, FONT_SMALL, ETextAlignment::TOPLEFT, Colors::WHITE, hero.name);
 
@@ -379,7 +379,7 @@ void CInteractableHeroTooltip::init(const InfoAboutHero & hero)
 
 void CTownTooltip::init(const InfoAboutTown & town)
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 
 	//order of icons in def: fort, citadel, castle, no fort
 	size_t fortIndex = town.fortLevel ? town.fortLevel - 1 : 3;
@@ -435,13 +435,13 @@ CInteractableTownTooltip::CInteractableTownTooltip(Point pos, const CGTownInstan
 {
 	init(town);
 
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 	garrison = std::make_shared<CGarrisonInt>(pos + Point(0, 73), 4, Point(0, 0), town->getUpperArmy(), nullptr, true, true, CGarrisonInt::ESlotsLayout::REVERSED_TWO_ROWS);
 }
 
 void CInteractableTownTooltip::init(const CGTownInstance * town)
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 
 	const InfoAboutTown townInfo = InfoAboutTown(town, true);
 	int townId = town->id;
@@ -530,7 +530,7 @@ void CInteractableTownTooltip::init(const CGTownInstance * town)
 
 CreatureTooltip::CreatureTooltip(Point pos, const CGCreature * creature)
 {
-	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
+	OBJECT_CONSTRUCTION;
 
 	auto creatureID = creature->getCreature();
 	int32_t creatureIconIndex = CGI->creatures()->getById(creatureID)->getIconIndex();
@@ -553,7 +553,7 @@ CreatureTooltip::CreatureTooltip(Point pos, const CGCreature * creature)
 
 void MoraleLuckBox::set(const AFactionMember * node)
 {
-	OBJECT_CONSTRUCTION_CUSTOM_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 
 	const std::array textId = {62, 88}; //eg %s \n\n\n {Current Luck Modifiers:}
 	const int noneTxtId = 108; //Russian version uses same text for neutral morale\luck
@@ -629,7 +629,7 @@ MoraleLuckBox::MoraleLuckBox(bool Morale, const Rect &r, bool Small)
 
 CCreaturePic::CCreaturePic(int x, int y, const CCreature * cre, bool Big, bool Animated)
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 	pos.x+=x;
 	pos.y+=y;
 
@@ -680,7 +680,7 @@ SelectableSlot::SelectableSlot(Rect area, Point oversize, const int width)
 	: LRClickableAreaWTextComp(area)
 	, selected(false)
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 
 	selection = std::make_shared<TransparentFilledRectangle>( Rect(-oversize, area.dimensions() + oversize * 2), Colors::TRANSPARENCY, Colors::YELLOW, width);
 	selectSlot(false);
@@ -709,7 +709,7 @@ bool SelectableSlot::isSelected() const
 
 void SelectableSlot::setSelectionWidth(int width)
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 	selection = std::make_shared<TransparentFilledRectangle>( selection->pos - pos.topLeft(), Colors::TRANSPARENCY, Colors::YELLOW, width);
 	selectSlot(selected);
 }

--- a/client/widgets/ObjectLists.cpp
+++ b/client/widgets/ObjectLists.cpp
@@ -33,7 +33,6 @@ std::shared_ptr<CIntObject> CObjectList::createItem(size_t index)
 	if(!item)
 		item = std::make_shared<CIntObject>();
 
-	item->recActions = defActions;
 	addChild(item.get());
 	if (isActive())
 		item->activate();
@@ -45,7 +44,6 @@ CTabbedInt::CTabbedInt(CreateFunc create, Point position, size_t ActiveID)
 	activeTab(nullptr),
 	activeID(ActiveID)
 {
-	defActions &= ~DISPOSE;
 	pos += position;
 	reset();
 }

--- a/client/widgets/ObjectLists.cpp
+++ b/client/widgets/ObjectLists.cpp
@@ -28,7 +28,7 @@ void CObjectList::deleteItem(std::shared_ptr<CIntObject> item)
 
 std::shared_ptr<CIntObject> CObjectList::createItem(size_t index)
 {
-	OBJECT_CONSTRUCTION_CUSTOM_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 	std::shared_ptr<CIntObject> item = createObject(index);
 	if(!item)
 		item = std::make_shared<CIntObject>();
@@ -90,7 +90,7 @@ CListBox::CListBox(CreateFunc create, Point Pos, Point ItemOffset, size_t Visibl
 
 	if(Slider & 1)
 	{
-		OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+		OBJECT_CONSTRUCTION;
 		slider = std::make_shared<CSlider>(
 			SliderPos.topLeft(),
 			SliderPos.w,

--- a/client/widgets/RadialMenu.cpp
+++ b/client/widgets/RadialMenu.cpp
@@ -25,7 +25,7 @@ RadialMenuItem::RadialMenuItem(const std::string & imageName, const std::string 
 	: callback(callback)
 	, hoverText(hoverText)
 {
-	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
+	OBJECT_CONSTRUCTION;
 
 	inactiveImage = std::make_shared<CPicture>(ImagePath::builtin(alternativeLayout ? "radialMenu/itemInactiveAlt" : "radialMenu/itemInactive"), Point(0, 0));
 	selectedImage = std::make_shared<CPicture>(ImagePath::builtin(alternativeLayout ? "radialMenu/itemEmptyAlt" : "radialMenu/itemEmpty"), Point(0, 0));
@@ -45,7 +45,7 @@ void RadialMenuItem::setSelected(bool selected)
 RadialMenu::RadialMenu(const Point & positionToCenter, const std::vector<RadialMenuConfig> & menuConfig, bool alternativeLayout):
 	centerPosition(positionToCenter), alternativeLayout(alternativeLayout)
 {
-	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
+	OBJECT_CONSTRUCTION;
 	pos += positionToCenter;
 
 	Point itemSize = alternativeLayout ? Point(80, 70) : Point(70, 80);

--- a/client/widgets/Slider.cpp
+++ b/client/widgets/Slider.cpp
@@ -183,7 +183,7 @@ CSlider::CSlider(Point position, int totalw, const SliderMovingFunctor & Moved, 
 	value(Value),
 	moved(Moved)
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 	setAmount(amount);
 	vstd::amax(value, 0);
 	vstd::amin(value, positions);

--- a/client/widgets/TextControls.cpp
+++ b/client/widgets/TextControls.cpp
@@ -343,7 +343,7 @@ CLabelGroup::CLabelGroup(EFonts Font, ETextAlignment Align, const ColorRGBA & Co
 
 void CLabelGroup::add(int x, int y, const std::string & text)
 {
-	OBJECT_CONSTRUCTION_CUSTOM_CAPTURING(255 - DISPOSE);
+	OBJECT_CONSTRUCTION;
 	labels.push_back(std::make_shared<CLabel>(x, y, font, align, color, text));
 }
 
@@ -356,7 +356,7 @@ CTextBox::CTextBox(std::string Text, const Rect & rect, int SliderStyle, EFonts 
 	sliderStyle(SliderStyle),
 	slider(nullptr)
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255 - DISPOSE);
+	OBJECT_CONSTRUCTION;
 	label = std::make_shared<CMultiLineLabel>(rect, Font, Align, Color);
 
 	setRedrawParent(true);
@@ -421,7 +421,7 @@ void CTextBox::setText(const std::string & text)
 		assert(label->pos.w > 0);
 		label->setText(text);
 
-		OBJECT_CONSTRUCTION_CUSTOM_CAPTURING(255 - DISPOSE);
+		OBJECT_CONSTRUCTION;
 		slider = std::make_shared<CSlider>(Point(pos.w - 16, 0), pos.h, std::bind(&CTextBox::sliderMoved, this, _1),
 			label->pos.h, label->textSize.y, 0, Orientation::VERTICAL, CSlider::EStyle(sliderStyle));
 		slider->setScrollStep((int)graphics->fonts[label->font]->getLineHeight());
@@ -504,7 +504,7 @@ CGStatusBar::CGStatusBar(int x, int y, const ImagePath & name, int maxw)
 {
 	addUsedEvents(LCLICK);
 
-	OBJECT_CONSTRUCTION_CAPTURING(255 - DISPOSE);
+	OBJECT_CONSTRUCTION;
 
 	auto backgroundImage = std::make_shared<CPicture>(name);
 	background = backgroundImage;

--- a/client/widgets/TextControls.cpp
+++ b/client/widgets/TextControls.cpp
@@ -339,7 +339,6 @@ Rect CMultiLineLabel::getTextLocation()
 CLabelGroup::CLabelGroup(EFonts Font, ETextAlignment Align, const ColorRGBA & Color)
 	: font(Font), align(Align), color(Color)
 {
-	defActions = 255 - DISPOSE;
 }
 
 void CLabelGroup::add(int x, int y, const std::string & text)

--- a/client/widgets/markets/CAltarArtifacts.cpp
+++ b/client/widgets/markets/CAltarArtifacts.cpp
@@ -29,7 +29,7 @@
 CAltarArtifacts::CAltarArtifacts(const IMarket * market, const CGHeroInstance * hero)
 	: CMarketBase(market, hero)
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255 - DISPOSE);
+	OBJECT_CONSTRUCTION;
 
 	assert(dynamic_cast<const CGArtifactsAltar*>(market));
 	auto altarObj = dynamic_cast<const CGArtifactsAltar*>(market);

--- a/client/widgets/markets/CAltarCreatures.cpp
+++ b/client/widgets/markets/CAltarCreatures.cpp
@@ -30,7 +30,7 @@ CAltarCreatures::CAltarCreatures(const IMarket * market, const CGHeroInstance * 
 	, CMarketSlider(std::bind(&CAltarCreatures::onOfferSliderMoved, this, _1))
 	, CMarketTraderText(Point(28, 31), FONT_MEDIUM, Colors::YELLOW)
 {
-	OBJECT_CONSTRUCTION_CUSTOM_CAPTURING(255 - DISPOSE);
+	OBJECT_CONSTRUCTION;
 
 	deal = std::make_shared<CButton>(dealButtonPosWithSlider, AnimationPath::builtin("ALTSACR.DEF"),
 		CGI->generaltexth->zelp[584], [this]() {CAltarCreatures::makeDeal();}, EShortcut::MARKET_DEAL);

--- a/client/widgets/markets/CArtifactsBuying.cpp
+++ b/client/widgets/markets/CArtifactsBuying.cpp
@@ -32,7 +32,7 @@ CArtifactsBuying::CArtifactsBuying(const IMarket * market, const CGHeroInstance 
 	: CMarketBase(market, hero)
 	, CResourcesSelling([this](const std::shared_ptr<CTradeableItem> & heroSlot){CArtifactsBuying::onSlotClickPressed(heroSlot, bidTradePanel);})
 {
-	OBJECT_CONSTRUCTION_CUSTOM_CAPTURING(255 - DISPOSE);
+	OBJECT_CONSTRUCTION;
 
 	std::string title;
 	if(auto townMarket = dynamic_cast<const CGTownInstance*>(market))

--- a/client/widgets/markets/CArtifactsSelling.cpp
+++ b/client/widgets/markets/CArtifactsSelling.cpp
@@ -35,7 +35,7 @@ CArtifactsSelling::CArtifactsSelling(const IMarket * market, const CGHeroInstanc
 		[this](const std::shared_ptr<CTradeableItem> & resSlot){CArtifactsSelling::onSlotClickPressed(resSlot, offerTradePanel);},
 		[this](){CArtifactsSelling::updateSubtitles();})
 {
-	OBJECT_CONSTRUCTION_CUSTOM_CAPTURING(255 - DISPOSE);
+	OBJECT_CONSTRUCTION;
 
 	std::string title;
 	if(const auto townMarket = dynamic_cast<const CGTownInstance*>(market))

--- a/client/widgets/markets/CFreelancerGuild.cpp
+++ b/client/widgets/markets/CFreelancerGuild.cpp
@@ -32,7 +32,7 @@ CFreelancerGuild::CFreelancerGuild(const IMarket * market, const CGHeroInstance 
 		[this](){CMarketBase::updateSubtitlesForBid(EMarketMode::CREATURE_RESOURCE, bidTradePanel->getSelectedItemId());})
 	, CMarketSlider([this](int newVal){CMarketSlider::onOfferSliderMoved(newVal);})
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255 - DISPOSE);
+	OBJECT_CONSTRUCTION;
 
 	labels.emplace_back(std::make_shared<CLabel>(titlePos.x, titlePos.y, FONT_BIG, ETextAlignment::CENTER, Colors::YELLOW,
 		VLC->generaltexth->translate("object.core.freelancersGuild.name")));

--- a/client/widgets/markets/CMarketBase.cpp
+++ b/client/widgets/markets/CMarketBase.cpp
@@ -122,7 +122,7 @@ void CMarketBase::highlightingChanged()
 
 CExperienceAltar::CExperienceAltar()
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255 - DISPOSE);
+	OBJECT_CONSTRUCTION;
 
 	// Experience needed to reach next level
 	texts.emplace_back(std::make_shared<CTextBox>(CGI->generaltexth->allTexts[475], Rect(15, 415, 125, 50), 0, FONT_SMALL, ETextAlignment::CENTER, Colors::YELLOW));
@@ -144,7 +144,7 @@ void CExperienceAltar::update()
 
 CCreaturesSelling::CCreaturesSelling()
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255 - DISPOSE);
+	OBJECT_CONSTRUCTION;
 
 	assert(hero);
 	CreaturesPanel::slotsData slots;
@@ -171,7 +171,7 @@ void CCreaturesSelling::updateSubtitles() const
 CResourcesBuying::CResourcesBuying(const CTradeableItem::ClickPressedFunctor & clickPressedCallback,
 	const TradePanelBase::UpdateSlotsFunctor & updSlotsCallback)
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255 - DISPOSE);
+	OBJECT_CONSTRUCTION;
 
 	offerTradePanel = std::make_shared<ResourcesPanel>(clickPressedCallback, updSlotsCallback);
 	offerTradePanel->moveTo(pos.topLeft() + Point(327, 182));
@@ -180,7 +180,7 @@ CResourcesBuying::CResourcesBuying(const CTradeableItem::ClickPressedFunctor & c
 
 CResourcesSelling::CResourcesSelling(const CTradeableItem::ClickPressedFunctor & clickPressedCallback)
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255 - DISPOSE);
+	OBJECT_CONSTRUCTION;
 
 	bidTradePanel = std::make_shared<ResourcesPanel>(clickPressedCallback, std::bind(&CResourcesSelling::updateSubtitles, this));
 	labels.emplace_back(std::make_shared<CLabel>(156, 148, FONT_SMALL, ETextAlignment::CENTER, Colors::WHITE, CGI->generaltexth->allTexts[270]));
@@ -194,7 +194,7 @@ void CResourcesSelling::updateSubtitles() const
 
 CMarketSlider::CMarketSlider(const CSlider::SliderMovingFunctor & movingCallback)
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255 - DISPOSE);
+	OBJECT_CONSTRUCTION;
 
 	offerSlider = std::make_shared<CSlider>(Point(230, 489), 137, movingCallback, 0, 0, 0, Orientation::HORIZONTAL);
 	maxAmount = std::make_shared<CButton>(Point(228, 520), AnimationPath::builtin("IRCBTNS.DEF"), CGI->generaltexth->zelp[596],
@@ -224,7 +224,7 @@ void CMarketSlider::onOfferSliderMoved(int newVal)
 CMarketTraderText::CMarketTraderText(const Point & pos, const EFonts & font, const ColorRGBA & color)
 	: madeTransaction(false)
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255 - DISPOSE);
+	OBJECT_CONSTRUCTION;
 
 	traderText = std::make_shared<CTextBox>("", Rect(pos, traderTextDimensions), 0, font, ETextAlignment::CENTER, color);
 }

--- a/client/widgets/markets/CMarketResources.cpp
+++ b/client/widgets/markets/CMarketResources.cpp
@@ -32,7 +32,7 @@ CMarketResources::CMarketResources(const IMarket * market, const CGHeroInstance 
 		[this](){CMarketResources::updateSubtitles();})
 	, CMarketSlider([this](int newVal){CMarketSlider::onOfferSliderMoved(newVal);})
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255 - DISPOSE);
+	OBJECT_CONSTRUCTION;
 
 	labels.emplace_back(std::make_shared<CLabel>(titlePos.x, titlePos.y, FONT_BIG, ETextAlignment::CENTER, Colors::YELLOW, CGI->generaltexth->allTexts[158]));
 	deal = std::make_shared<CButton>(dealButtonPosWithSlider, AnimationPath::builtin("TPMRKB.DEF"),

--- a/client/widgets/markets/CTransferResources.cpp
+++ b/client/widgets/markets/CTransferResources.cpp
@@ -30,7 +30,7 @@ CTransferResources::CTransferResources(const IMarket * market, const CGHeroInsta
 	, CMarketSlider([this](int newVal){CMarketSlider::onOfferSliderMoved(newVal);})
 	, CMarketTraderText(Point(28, 48))
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255 - DISPOSE);
+	OBJECT_CONSTRUCTION;
 
 	labels.emplace_back(std::make_shared<CLabel>(titlePos.x, titlePos.y, FONT_BIG, ETextAlignment::CENTER, Colors::YELLOW, CGI->generaltexth->allTexts[158]));
 	labels.emplace_back(std::make_shared<CLabel>(445, 56, FONT_SMALL, ETextAlignment::CENTER, Colors::WHITE, CGI->generaltexth->allTexts[169]));

--- a/client/widgets/markets/TradePanels.cpp
+++ b/client/widgets/markets/TradePanels.cpp
@@ -29,7 +29,7 @@ CTradeableItem::CTradeableItem(const Rect & area, EType Type, int ID, int Serial
 	, id(ID)
 	, serial(Serial)
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255 - DISPOSE);
+	OBJECT_CONSTRUCTION;
 
 	addUsedEvents(LCLICK);
 	addUsedEvents(HOVER);
@@ -46,7 +46,7 @@ void CTradeableItem::setType(EType newType)
 {
 	if(type != newType)
 	{
-		OBJECT_CONSTRUCTION_CUSTOM_CAPTURING(255 - DISPOSE);
+		OBJECT_CONSTRUCTION;
 		type = newType;
 
 		if(getIndex() < 0)
@@ -270,7 +270,7 @@ ResourcesPanel::ResourcesPanel(const CTradeableItem::ClickPressedFunctor & click
 	const UpdateSlotsFunctor & updateSubtitles)
 {
 	assert(resourcesForTrade.size() == slotsPos.size());
-	OBJECT_CONSTRUCTION_CUSTOM_CAPTURING(255 - DISPOSE);
+	OBJECT_CONSTRUCTION;
 
 	for(const auto & res : resourcesForTrade)
 	{
@@ -287,7 +287,7 @@ ArtifactsPanel::ArtifactsPanel(const CTradeableItem::ClickPressedFunctor & click
 {
 	assert(slotsForTrade == slotsPos.size());
 	assert(slotsForTrade == arts.size());
-	OBJECT_CONSTRUCTION_CUSTOM_CAPTURING(255 - DISPOSE);
+	OBJECT_CONSTRUCTION;
 
 	for(auto slotIdx = 0; slotIdx < slotsForTrade; slotIdx++)
 	{
@@ -308,7 +308,7 @@ ArtifactsPanel::ArtifactsPanel(const CTradeableItem::ClickPressedFunctor & click
 PlayersPanel::PlayersPanel(const CTradeableItem::ClickPressedFunctor & clickPressedCallback)
 {
 	assert(PlayerColor::PLAYER_LIMIT_I <= slotsPos.size() + 1);
-	OBJECT_CONSTRUCTION_CUSTOM_CAPTURING(255 - DISPOSE);
+	OBJECT_CONSTRUCTION;
 
 	std::vector<PlayerColor> players;
 	for(auto player = PlayerColor(0); player < PlayerColor::PLAYER_LIMIT_I; player++)
@@ -334,7 +334,7 @@ CreaturesPanel::CreaturesPanel(const CTradeableItem::ClickPressedFunctor & click
 {
 	assert(initialSlots.size() <= GameConstants::ARMY_SIZE);
 	assert(slotsPos.size() <= GameConstants::ARMY_SIZE);
-	OBJECT_CONSTRUCTION_CUSTOM_CAPTURING(255 - DISPOSE);
+	OBJECT_CONSTRUCTION;
 
 	for(const auto & [creatureId, slotId, creaturesNum] : initialSlots)
 	{
@@ -352,7 +352,7 @@ CreaturesPanel::CreaturesPanel(const CTradeableItem::ClickPressedFunctor & click
 	const std::vector<std::shared_ptr<CTradeableItem>> & srcSlots, bool emptySlots)
 {
 	assert(slots.size() <= GameConstants::ARMY_SIZE);
-	OBJECT_CONSTRUCTION_CUSTOM_CAPTURING(255 - DISPOSE);
+	OBJECT_CONSTRUCTION;
 
 	for(const auto & srcSlot : srcSlots)
 	{
@@ -367,7 +367,7 @@ CreaturesPanel::CreaturesPanel(const CTradeableItem::ClickPressedFunctor & click
 
 ArtifactsAltarPanel::ArtifactsAltarPanel(const CTradeableItem::ClickPressedFunctor & clickPressedCallback)
 {
-	OBJECT_CONSTRUCTION_CUSTOM_CAPTURING(255 - DISPOSE);
+	OBJECT_CONSTRUCTION;
 
 	int slotNum = 0;
 	for(auto & altarSlotPos : slotsPos)

--- a/client/windows/CCastleInterface.cpp
+++ b/client/windows/CCastleInterface.cpp
@@ -270,7 +270,7 @@ bool CBuildingRect::receiveEvent(const Point & position, int eventType) const
 CDwellingInfoBox::CDwellingInfoBox(int centerX, int centerY, const CGTownInstance * Town, int level)
 	: CWindowObject(RCLICK_POPUP, ImagePath::builtin("CRTOINFO"), Point(centerX, centerY))
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 	background->setPlayerColor(Town->tempOwner);
 
 	const CCreature * creature = Town->creatures.at(level).second.back().toCreature();
@@ -306,7 +306,7 @@ CDwellingInfoBox::~CDwellingInfoBox() = default;
 
 CHeroGSlot::CHeroGSlot(int x, int y, int updown, const CGHeroInstance * h, HeroSlots * Owner)
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 
 	owner = Owner;
 	pos.x += x;
@@ -482,7 +482,7 @@ void CHeroGSlot::setHighlight(bool on)
 
 void CHeroGSlot::set(const CGHeroInstance * newHero)
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 
 	hero = newHero;
 
@@ -507,7 +507,7 @@ HeroSlots::HeroSlots(const CGTownInstance * Town, Point garrPos, Point visitPos,
 	town(Town),
 	garr(Garrison)
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 	garrisonedHero = std::make_shared<CHeroGSlot>(garrPos.x, garrPos.y, 0, town->garrisonHero, this);
 	visitingHero = std::make_shared<CHeroGSlot>(visitPos.x, visitPos.y, 1, town->visitingHero, this);
 }
@@ -563,7 +563,7 @@ CCastleBuildings::CCastleBuildings(const CGTownInstance* Town):
 	town(Town),
 	selectedBuilding(nullptr)
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 
 	background = std::make_shared<CPicture>(town->town->clientInfo.townBackground);
 	background->needRefresh = true;
@@ -579,7 +579,7 @@ CCastleBuildings::~CCastleBuildings() = default;
 void CCastleBuildings::recreate()
 {
 	selectedBuilding = nullptr;
-	OBJECT_CONSTRUCTION_CUSTOM_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 
 	buildings.clear();
 	groups.clear();
@@ -1079,7 +1079,7 @@ CCreaInfo::CCreaInfo(Point position, const CGTownInstance * Town, int Level, boo
 	level(Level),
 	showAvailable(_showAvailable)
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 	pos += position;
 
 	if(town->creatures.size() <= level || town->creatures[level].second.empty())
@@ -1189,7 +1189,7 @@ CTownInfo::CTownInfo(int posX, int posY, const CGTownInstance * Town, bool townH
 	: town(Town),
 	building(nullptr)
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 	addUsedEvents(SHOW_POPUP | HOVER);
 	pos.x += posX;
 	pos.y += posY;
@@ -1237,7 +1237,7 @@ CCastleInterface::CCastleInterface(const CGTownInstance * Town, const CGTownInst
 	CWindowObject(PLAYER_COLORED | BORDERED),
 	town(Town)
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 
 	LOCPLINT->castleInt = this;
 	addUsedEvents(KEYBOARD);
@@ -1362,7 +1362,7 @@ void CCastleInterface::removeBuilding(BuildingID bid)
 
 void CCastleInterface::recreateIcons()
 {
-	OBJECT_CONSTRUCTION_CUSTOM_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 	size_t iconIndex = town->town->clientInfo.icons[town->hasFort()][town->built >= CGI->settings()->getInteger(EGameSettings::TOWNS_BUILDINGS_PER_TURN_CAP)];
 
 	icon->setFrame(iconIndex);
@@ -1469,7 +1469,7 @@ CHallInterface::CBuildingBox::CBuildingBox(int x, int y, const CGTownInstance * 
 	town(Town),
 	building(Building)
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 	addUsedEvents(LCLICK | SHOW_POPUP | HOVER);
 	pos.x += x;
 	pos.y += y;
@@ -1532,7 +1532,7 @@ CHallInterface::CHallInterface(const CGTownInstance * Town):
 	CWindowObject(PLAYER_COLORED | BORDERED, Town->town->clientInfo.hallBackground),
 	town(Town)
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 
 	resdatabar = std::make_shared<CMinorResDataBar>();
 	resdatabar->moveBy(pos.topLeft(), true);
@@ -1587,7 +1587,7 @@ CBuildWindow::CBuildWindow(const CGTownInstance *Town, const CBuilding * Buildin
 	town(Town),
 	building(Building)
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 
 	icon = std::make_shared<CAnimImage>(town->town->clientInfo.buildingsIcons, building->bid, 0, 125, 50);
 	auto statusbarBackground = std::make_shared<CPicture>(background->getSurface(), Rect(8, pos.h - 26, pos.w - 16, 19), 8, pos.h - 26);
@@ -1690,7 +1690,7 @@ std::string CBuildWindow::getTextForState(EBuildingState state)
 
 LabeledValue::LabeledValue(Rect size, std::string name, std::string descr, int min, int max)
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 	pos.x+=size.x;
 	pos.y+=size.y;
 	pos.w = size.w;
@@ -1700,7 +1700,7 @@ LabeledValue::LabeledValue(Rect size, std::string name, std::string descr, int m
 
 LabeledValue::LabeledValue(Rect size, std::string name, std::string descr, int val)
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 	pos.x+=size.x;
 	pos.y+=size.y;
 	pos.w = size.w;
@@ -1738,7 +1738,7 @@ void LabeledValue::hover(bool on)
 CFortScreen::CFortScreen(const CGTownInstance * town):
 	CWindowObject(PLAYER_COLORED | BORDERED, getBgName(town))
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 	ui32 fortSize = static_cast<ui32>(town->creatures.size());
 	if(fortSize > GameConstants::CREATURES_PER_TOWN && town->creatures.back().second.empty())
 		fortSize--;
@@ -1820,7 +1820,7 @@ CFortScreen::RecruitArea::RecruitArea(int posX, int posY, const CGTownInstance *
 	level(Level),
 	availableCount(nullptr)
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 	pos.x +=posX;
 	pos.y +=posY;
 	pos.w = 386;
@@ -1927,7 +1927,7 @@ void CFortScreen::RecruitArea::showPopupWindow(const Point & cursorPosition)
 CMageGuildScreen::CMageGuildScreen(CCastleInterface * owner, const ImagePath & imagename)
 	: CWindowObject(BORDERED, imagename)
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 
 	window = std::make_shared<CPicture>(owner->town->town->clientInfo.guildWindow, 332, 76);
 
@@ -1966,7 +1966,7 @@ CMageGuildScreen::CMageGuildScreen(CCastleInterface * owner, const ImagePath & i
 CMageGuildScreen::Scroll::Scroll(Point position, const CSpell *Spell)
 	: spell(Spell)
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 
 	addUsedEvents(LCLICK | SHOW_POPUP | HOVER);
 	pos += position;
@@ -1996,7 +1996,7 @@ void CMageGuildScreen::Scroll::hover(bool on)
 CBlacksmithDialog::CBlacksmithDialog(bool possible, CreatureID creMachineID, ArtifactID aid, ObjectInstanceID hid):
 	CWindowObject(PLAYER_COLORED, ImagePath::builtin("TPSMITH"))
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 
 	Rect barRect(8, pos.h - 26, pos.w - 16, 19);
 

--- a/client/windows/CCreatureWindow.cpp
+++ b/client/windows/CCreatureWindow.cpp
@@ -187,7 +187,7 @@ CStackWindow::CWindowSection::CWindowSection(CStackWindow * parent, const ImageP
 	: parent(parent)
 {
 	pos.y += yOffset;
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 	if(!backgroundPath.empty())
 	{
 		background = std::make_shared<CPicture>(backgroundPath);
@@ -202,7 +202,7 @@ CStackWindow::ActiveSpellsSection::ActiveSpellsSection(CStackWindow * owner, int
 	static const Point firstPos(6, 2); // position of 1st spell box
 	static const Point offset(54, 0);  // offset of each spell box from previous
 
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 
 	const CStack * battleStack = parent->info->stack;
 
@@ -241,7 +241,7 @@ CStackWindow::ActiveSpellsSection::ActiveSpellsSection(CStackWindow * owner, int
 CStackWindow::BonusLineSection::BonusLineSection(CStackWindow * owner, size_t lineIndex)
 	: CWindowSection(owner, ImagePath::builtin("stackWindow/bonus-effects"), 0)
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 
 	static const std::array<Point, 2> offset =
 	{
@@ -267,7 +267,7 @@ CStackWindow::BonusLineSection::BonusLineSection(CStackWindow * owner, size_t li
 CStackWindow::BonusesSection::BonusesSection(CStackWindow * owner, int yOffset, std::optional<size_t> preferredSize):
 	CWindowSection(owner, {}, yOffset)
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 
 	// size of single image for an item
 	static const int itemHeight = 59;
@@ -289,7 +289,7 @@ CStackWindow::BonusesSection::BonusesSection(CStackWindow * owner, int yOffset, 
 CStackWindow::ButtonsSection::ButtonsSection(CStackWindow * owner, int yOffset)
 	: CWindowSection(owner, ImagePath::builtin("stackWindow/button-panel"), yOffset)
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 
 	if(parent->info->dismissInfo && parent->info->dismissInfo->callback)
 	{
@@ -378,7 +378,7 @@ CStackWindow::ButtonsSection::ButtonsSection(CStackWindow * owner, int yOffset)
 CStackWindow::CommanderMainSection::CommanderMainSection(CStackWindow * owner, int yOffset)
 	: CWindowSection(owner, ImagePath::builtin("stackWindow/commander-bg"), yOffset)
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 
 	auto getSkillPos = [](int index)
 	{
@@ -489,7 +489,7 @@ CStackWindow::CommanderMainSection::CommanderMainSection(CStackWindow * owner, i
 CStackWindow::MainSection::MainSection(CStackWindow * owner, int yOffset, bool showExp, bool showArt)
 	: CWindowSection(owner, getBackgroundName(showExp, showArt), yOffset)
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 
 	statNames =
 	{
@@ -752,7 +752,7 @@ CStackWindow::~CStackWindow()
 
 void CStackWindow::init()
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 
 	if(!info->stackNode)
 		info->stackNode = new CStackInstance(info->creature, 1, true);// FIXME: free data
@@ -798,7 +798,7 @@ void CStackWindow::initBonusesList()
 
 void CStackWindow::initSections()
 {
-	OBJECT_CONSTRUCTION_CUSTOM_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 
 	bool showArt = CGI->settings()->getBoolean(EGameSettings::MODULE_STACK_ARTIFACT) && info->commander == nullptr && info->stackNode;
 	bool showExp = (CGI->settings()->getBoolean(EGameSettings::MODULE_STACK_EXPERIENCE) || info->commander != nullptr) && info->stackNode;
@@ -920,7 +920,7 @@ void CStackWindow::setSelection(si32 newSkill, std::shared_ptr<CCommanderSkillIc
 		return skillToFile(skillIndex, info->commander->secondarySkills[skillIndex], selected);
 	};
 
-	OBJECT_CONSTRUCTION_CUSTOM_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 	int oldSelection = selectedSkill; // update selection
 	selectedSkill = newSkill;
 

--- a/client/windows/CExchangeWindow.cpp
+++ b/client/windows/CExchangeWindow.cpp
@@ -49,7 +49,7 @@ CExchangeWindow::CExchangeWindow(ObjectInstanceID hero1, ObjectInstanceID hero2,
 {
 	const bool qeLayout = isQuickExchangeLayoutAvailable();
 
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 	addUsedEvents(KEYBOARD);
 
 	heroInst[0] = LOCPLINT->cb->getHero(hero1);

--- a/client/windows/CHeroBackpackWindow.cpp
+++ b/client/windows/CHeroBackpackWindow.cpp
@@ -26,7 +26,7 @@
 CHeroBackpackWindow::CHeroBackpackWindow(const CGHeroInstance * hero, const std::vector<CArtifactsOfHeroPtr> & artsSets)
 	: CWindowWithArtifacts(&artsSets)
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255 - DISPOSE);
+	OBJECT_CONSTRUCTION;
 
 	stretchedBackground = std::make_shared<CFilledTexture>(ImagePath::builtin("DIBOXBCK"), Rect(0, 0, 0, 0));
 	arts = std::make_shared<CArtifactsOfHeroBackpack>();
@@ -60,7 +60,7 @@ void CHeroBackpackWindow::showAll(Canvas & to)
 
 CHeroQuickBackpackWindow::CHeroQuickBackpackWindow(const CGHeroInstance * hero, ArtifactPosition targetSlot)
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255 - DISPOSE);
+	OBJECT_CONSTRUCTION;
 
 	stretchedBackground = std::make_shared<CFilledTexture>(ImagePath::builtin("DIBOXBCK"), Rect(0, 0, 0, 0));
 	arts = std::make_shared<CArtifactsOfHeroQuickBackpack>(targetSlot);

--- a/client/windows/CHeroOverview.cpp
+++ b/client/windows/CHeroOverview.cpp
@@ -31,7 +31,7 @@
 CHeroOverview::CHeroOverview(const HeroTypeID & h)
 	: CWindowObject(BORDERED | RCLICK_POPUP), hero { h }
 {
-	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
+	OBJECT_CONSTRUCTION;
 
     heroIdx = hero.getNum();
 

--- a/client/windows/CHeroWindow.cpp
+++ b/client/windows/CHeroWindow.cpp
@@ -61,7 +61,7 @@ CHeroSwitcher::CHeroSwitcher(CHeroWindow * owner_, Point pos_, const CGHeroInsta
 	owner(owner_),
 	hero(hero_)
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 	pos += pos_;
 
 	image = std::make_shared<CAnimImage>(AnimationPath::builtin("PortraitsSmall"), hero->getIconIndex());
@@ -74,7 +74,7 @@ CHeroWindow::CHeroWindow(const CGHeroInstance * hero)
 {
 	auto & heroscrn = CGI->generaltexth->heroscrn;
 
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 	curHero = hero;
 
 	banner = std::make_shared<CAnimImage>(AnimationPath::builtin("CREST58"), LOCPLINT->playerID.getNum(), 0, 606, 8);
@@ -197,7 +197,7 @@ void CHeroWindow::update()
 	portraitImage->setFrame(curHero->getIconIndex());
 
 	{
-		OBJECT_CONSTRUCTION_CUSTOM_CAPTURING(255-DISPOSE);
+		OBJECT_CONSTRUCTION;
 		if(!garr)
 		{
 			std::string helpBox = heroscrn[32];

--- a/client/windows/CKingdomInterface.cpp
+++ b/client/windows/CKingdomInterface.cpp
@@ -56,7 +56,7 @@ InfoBox::InfoBox(Point position, InfoPos Pos, InfoSize Size, std::shared_ptr<IIn
 	addUsedEvents(LCLICK | SHOW_POPUP);
 	EFonts font = (size < SIZE_MEDIUM)? FONT_SMALL: FONT_MEDIUM;
 
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 	pos+=position;
 
 	image = std::make_shared<CAnimImage>(data->getImageName(size), data->getImageIndex());
@@ -462,7 +462,7 @@ void InfoBoxCustom::prepareMessage(std::string & text, std::shared_ptr<CComponen
 CKingdomInterface::CKingdomInterface()
 	: CWindowObject(PLAYER_COLORED | BORDERED, ImagePath::builtin(OVERVIEW_BACKGROUND))
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 	ui32 footerPos = OVERVIEW_SIZE * 116;
 
 	tabArea = std::make_shared<CTabbedInt>(std::bind(&CKingdomInterface::createMainTab, this, _1), Point(4,4));
@@ -691,7 +691,7 @@ bool CKingdomInterface::holdsGarrison(const CArmedInstance * army)
 
 CKingdHeroList::CKingdHeroList(size_t maxSize, const CreateHeroItemFunctor & onCreateHeroItemCallback)
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 	title = std::make_shared<CPicture>(ImagePath::builtin("OVTITLE"),16,0);
 	title->setPlayerColor(LOCPLINT->playerID);
 	heroLabel = std::make_shared<CLabel>(150, 10, FONT_MEDIUM, ETextAlignment::CENTER, Colors::WHITE, CGI->generaltexth->overview[0]);
@@ -735,7 +735,7 @@ bool CKingdHeroList::holdsGarrison(const CArmedInstance * army)
 
 CKingdTownList::CKingdTownList(size_t maxSize)
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 	title = std::make_shared<CPicture>(ImagePath::builtin("OVTITLE"), 16, 0);
 	title->setPlayerColor(LOCPLINT->playerID);
 	townLabel = std::make_shared<CLabel>(146, 10,FONT_MEDIUM, ETextAlignment::CENTER, Colors::WHITE, CGI->generaltexth->overview[3]);
@@ -791,7 +791,7 @@ std::shared_ptr<CIntObject> CKingdTownList::createTownItem(size_t index)
 CTownItem::CTownItem(const CGTownInstance * Town)
 	: town(Town)
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 	background = std::make_shared<CAnimImage>(AnimationPath::builtin("OVSLOT"), 6);
 	name = std::make_shared<CLabel>(74, 8, FONT_SMALL, ETextAlignment::TOPLEFT, Colors::WHITE, town->getNameTranslated());
 
@@ -883,7 +883,7 @@ public:
 
 	ArtSlotsTab()
 	{
-		OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+		OBJECT_CONSTRUCTION;
 		background = std::make_shared<CAnimImage>(AnimationPath::builtin("OVSLOT"), 4);
 		pos = background->pos;
 		for(int i=0; i<9; i++)
@@ -901,7 +901,7 @@ public:
 
 	BackpackTab()
 	{
-		OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+		OBJECT_CONSTRUCTION;
 		background = std::make_shared<CAnimImage>(AnimationPath::builtin("OVSLOT"), 5);
 		pos = background->pos;
 		btnLeft = std::make_shared<CButton>(Point(269, 66), AnimationPath::builtin("HSBTNS3"), CButton::tooltip(), 0);
@@ -914,7 +914,7 @@ public:
 CHeroItem::CHeroItem(const CGHeroInstance * Hero)
 	: hero(Hero)
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 
 	artTabs.resize(3);
 	auto arts1 = std::make_shared<ArtSlotsTab>();

--- a/client/windows/CMapOverview.cpp
+++ b/client/windows/CMapOverview.cpp
@@ -45,7 +45,7 @@ CMapOverview::CMapOverview(std::string mapName, std::string fileName, std::strin
 	: CWindowObject(BORDERED | RCLICK_POPUP), resource(resource), mapName(mapName), fileName(fileName), date(date), author(author), version(version), tabType(tabType)
 {
 
-	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
+	OBJECT_CONSTRUCTION;
 
 	widget = std::make_shared<CMapOverviewWidget>(*this);
 

--- a/client/windows/CMarketWindow.cpp
+++ b/client/windows/CMarketWindow.cpp
@@ -40,7 +40,7 @@ CMarketWindow::CMarketWindow(const IMarket * market, const CGHeroInstance * hero
 		mode == EMarketMode::RESOURCE_ARTIFACT || mode == EMarketMode::ARTIFACT_RESOURCE || mode == EMarketMode::ARTIFACT_EXP ||
 		mode == EMarketMode::CREATURE_EXP);
 	
-	OBJECT_CONSTRUCTION_CUSTOM_CAPTURING(255 - DISPOSE);
+	OBJECT_CONSTRUCTION;
 
 	if(mode == EMarketMode::RESOURCE_RESOURCE)
 		createMarketResources(market, hero);
@@ -177,7 +177,7 @@ void CMarketWindow::initWidgetInternals(const EMarketMode mode, const std::pair<
 
 void CMarketWindow::createArtifactsBuying(const IMarket * market, const CGHeroInstance * hero)
 {
-	OBJECT_CONSTRUCTION_CUSTOM_CAPTURING(255 - DISPOSE);
+	OBJECT_CONSTRUCTION;
 
 	background = createBg(ImagePath::builtin("TPMRKABS.bmp"), PLAYER_COLORED);
 	marketWidget = std::make_shared<CArtifactsBuying>(market, hero);
@@ -186,7 +186,7 @@ void CMarketWindow::createArtifactsBuying(const IMarket * market, const CGHeroIn
 
 void CMarketWindow::createArtifactsSelling(const IMarket * market, const CGHeroInstance * hero)
 {
-	OBJECT_CONSTRUCTION_CUSTOM_CAPTURING(255 - DISPOSE);
+	OBJECT_CONSTRUCTION;
 
 	background = createBg(ImagePath::builtin("TPMRKASS.bmp"), PLAYER_COLORED);
 	// Create image that copies part of background containing slot MISC_1 into position of slot MISC_5
@@ -203,7 +203,7 @@ void CMarketWindow::createArtifactsSelling(const IMarket * market, const CGHeroI
 
 void CMarketWindow::createMarketResources(const IMarket * market, const CGHeroInstance * hero)
 {
-	OBJECT_CONSTRUCTION_CUSTOM_CAPTURING(255 - DISPOSE);
+	OBJECT_CONSTRUCTION;
 
 	background = createBg(ImagePath::builtin("TPMRKRES.bmp"), PLAYER_COLORED);
 	marketWidget = std::make_shared<CMarketResources>(market, hero);
@@ -212,7 +212,7 @@ void CMarketWindow::createMarketResources(const IMarket * market, const CGHeroIn
 
 void CMarketWindow::createFreelancersGuild(const IMarket * market, const CGHeroInstance * hero)
 {
-	OBJECT_CONSTRUCTION_CUSTOM_CAPTURING(255 - DISPOSE);
+	OBJECT_CONSTRUCTION;
 
 	background = createBg(ImagePath::builtin("TPMRKCRS.bmp"), PLAYER_COLORED);
 	marketWidget = std::make_shared<CFreelancerGuild>(market, hero);
@@ -221,7 +221,7 @@ void CMarketWindow::createFreelancersGuild(const IMarket * market, const CGHeroI
 
 void CMarketWindow::createTransferResources(const IMarket * market, const CGHeroInstance * hero)
 {
-	OBJECT_CONSTRUCTION_CUSTOM_CAPTURING(255 - DISPOSE);
+	OBJECT_CONSTRUCTION;
 
 	background = createBg(ImagePath::builtin("TPMRKPTS.bmp"), PLAYER_COLORED);
 	marketWidget = std::make_shared<CTransferResources>(market, hero);
@@ -230,7 +230,7 @@ void CMarketWindow::createTransferResources(const IMarket * market, const CGHero
 
 void CMarketWindow::createAltarArtifacts(const IMarket * market, const CGHeroInstance * hero)
 {
-	OBJECT_CONSTRUCTION_CUSTOM_CAPTURING(255 - DISPOSE);
+	OBJECT_CONSTRUCTION;
 
 	background = createBg(ImagePath::builtin("ALTRART2.bmp"), PLAYER_COLORED);
 	auto altarArtifacts = std::make_shared<CAltarArtifacts>(market, hero);
@@ -257,7 +257,7 @@ void CMarketWindow::createAltarArtifacts(const IMarket * market, const CGHeroIns
 
 void CMarketWindow::createAltarCreatures(const IMarket * market, const CGHeroInstance * hero)
 {
-	OBJECT_CONSTRUCTION_CUSTOM_CAPTURING(255 - DISPOSE);
+	OBJECT_CONSTRUCTION;
 
 	background = createBg(ImagePath::builtin("ALTARMON.bmp"), PLAYER_COLORED);
 	marketWidget = std::make_shared<CAltarCreatures>(market, hero);

--- a/client/windows/CPuzzleWindow.cpp
+++ b/client/windows/CPuzzleWindow.cpp
@@ -33,7 +33,7 @@ CPuzzleWindow::CPuzzleWindow(const int3 & GrailPos, double discoveredRatio)
 	grailPos(GrailPos),
 	currentAlpha(ColorRGBA::ALPHA_OPAQUE)
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 
 	CCS->soundh->playSound(soundBase::OBELISK);
 

--- a/client/windows/CQuestLog.cpp
+++ b/client/windows/CQuestLog.cpp
@@ -73,7 +73,7 @@ CQuestMinimap::CQuestMinimap(const Rect & position)
 
 void CQuestMinimap::addQuestMarks (const QuestInfo * q)
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 	icons.clear();
 
 	int3 tile;
@@ -122,7 +122,7 @@ CQuestLog::CQuestLog (const std::vector<QuestInfo> & Quests)
 	hideComplete(false),
 	quests(Quests)
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 
 	minimap = std::make_shared<CQuestMinimap>(Rect(12, 12, 169, 169));
 	// TextBox have it's own 4 pixel padding from top at least for English. To achieve 10px from both left and top only add 6px margin
@@ -140,7 +140,7 @@ CQuestLog::CQuestLog (const std::vector<QuestInfo> & Quests)
 
 void CQuestLog::recreateLabelList()
 {
-	OBJECT_CONSTRUCTION_CUSTOM_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 	labels.clear();
 
 	bool completeMissing = true;
@@ -292,7 +292,7 @@ void CQuestLog::selectQuest(int which, int labelId)
 				break;
 		}*/
 
-		OBJECT_CONSTRUCTION_CUSTOM_CAPTURING(255-DISPOSE);
+		OBJECT_CONSTRUCTION;
 
 		std::vector<std::shared_ptr<CComponent>> comps;
 		for(auto & component : components)

--- a/client/windows/CSpellWindow.cpp
+++ b/client/windows/CSpellWindow.cpp
@@ -115,7 +115,7 @@ CSpellWindow::CSpellWindow(const CGHeroInstance * _myHero, CPlayerInterface * _m
 	offT(-37),
 	offB(56)
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 
 	if(isBigSpellbook)
 	{
@@ -594,7 +594,7 @@ CSpellWindow::SpellArea::SpellArea(Rect pos, CSpellWindow * owner)
 	schoolLevel = -1;
 	mySpell = nullptr;
 
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 
 	image = std::make_shared<CAnimImage>(AnimationPath::builtin("Spells"), 0, 0);
 	image->visible = false;
@@ -744,7 +744,7 @@ void CSpellWindow::SpellArea::setSpell(const CSpell * spell)
 		image->visible = true;
 
 		{
-			OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+			OBJECT_CONSTRUCTION;
 
 			static const std::array schoolBorders = {
 				AnimationPath::builtin("SplevA.def"),

--- a/client/windows/CTutorialWindow.cpp
+++ b/client/windows/CTutorialWindow.cpp
@@ -29,7 +29,7 @@
 CTutorialWindow::CTutorialWindow(const TutorialMode & m)
 	: CWindowObject(BORDERED, ImagePath::builtin("DIBOXBCK")), mode { m }, page { 0 }
 {
-	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
+	OBJECT_CONSTRUCTION;
 
 	pos = Rect(pos.x, pos.y, 380, 400); //video: 320x240
 	background = std::make_shared<CFilledTexture>(ImagePath::builtin("DIBOXBCK"), Rect(0, 0, pos.w, pos.h));
@@ -54,7 +54,7 @@ CTutorialWindow::CTutorialWindow(const TutorialMode & m)
 
 void CTutorialWindow::setContent()
 {
-	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
+	OBJECT_CONSTRUCTION;
 	auto video = VideoPath::builtin("tutorial/" + videos[page]);
 
 	videoPlayer = std::make_shared<VideoWidget>(Point(30, 120), video, false);

--- a/client/windows/CWindowObject.cpp
+++ b/client/windows/CWindowObject.cpp
@@ -41,8 +41,6 @@ CWindowObject::CWindowObject(int options_, const ImagePath & imageName, Point ce
 	if(!(options & NEEDS_ANIMATED_BACKGROUND)) //currently workaround for highscores (currently uses window as normal control, because otherwise videos are not played in background yet)
 		assert(parent == nullptr); //Safe to remove, but windows should not have parent
 
-	defActions = 255-DISPOSE;
-
 	if (options & RCLICK_POPUP)
 		CCS->curh->hide();
 
@@ -62,8 +60,6 @@ CWindowObject::CWindowObject(int options_, const ImagePath & imageName):
 {
 	if(!(options & NEEDS_ANIMATED_BACKGROUND)) //currently workaround for highscores (currently uses window as normal control, because otherwise videos are not played in background yet)
 		assert(parent == nullptr); //Safe to remove, but windows should not have parent
-
-	defActions = 255-DISPOSE;
 
 	if(options & RCLICK_POPUP)
 		CCS->curh->hide();

--- a/client/windows/CWindowObject.cpp
+++ b/client/windows/CWindowObject.cpp
@@ -81,7 +81,7 @@ CWindowObject::~CWindowObject()
 
 std::shared_ptr<CPicture> CWindowObject::createBg(const ImagePath & imageName, bool playerColored)
 {
-	OBJECT_CONSTRUCTION_CUSTOM_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 
 	if(imageName.empty())
 		return nullptr;
@@ -95,7 +95,7 @@ std::shared_ptr<CPicture> CWindowObject::createBg(const ImagePath & imageName, b
 
 void CWindowObject::setBackground(const ImagePath & filename)
 {
-	OBJECT_CONSTRUCTION_CUSTOM_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 
 	background = createBg(filename, options & PLAYER_COLORED);
 
@@ -206,7 +206,7 @@ void CWindowObject::setShadow(bool on)
 
 		//generate "shadow" object with these 3 pieces in it
 		{
-			OBJECT_CONSTRUCTION_CUSTOM_CAPTURING(255-DISPOSE);
+			OBJECT_CONSTRUCTION;
 
 			shadowParts.push_back(std::make_shared<CPicture>( GH.renderHandler().createImage(shadowCorner), Point(shadowPos.x,   shadowPos.y)));
 			shadowParts.push_back(std::make_shared<CPicture>( GH.renderHandler().createImage(shadowRight ),  Point(shadowPos.x,   shadowStart.y)));

--- a/client/windows/CreaturePurchaseCard.cpp
+++ b/client/windows/CreaturePurchaseCard.cpp
@@ -50,7 +50,7 @@ void CreaturePurchaseCard::initCreatureSwitcherButton()
 
 void CreaturePurchaseCard::switchCreatureLevel()
 {
-	OBJECT_CONSTRUCTION_CAPTURING(ACTIVATE + DEACTIVATE + UPDATE + SHOWALL + SHARE_POS);
+	OBJECT_CONSTRUCTION;
 	auto index = vstd::find_pos(upgradesID, creatureOnTheCard->getId());
 	auto nextCreatureId = vstd::circularAt(upgradesID, ++index);
 	creatureOnTheCard = nextCreatureId.toCreature();

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -1521,7 +1521,6 @@ void CObjectListWindow::init(std::shared_ptr<CIntObject> titleWidget_, std::stri
 	if(titleWidget)
 	{
 		addChild(titleWidget.get());
-		titleWidget->recActions = 255-DISPOSE;
 		titleWidget->pos.x = pos.w/2 + pos.x - titleWidget->pos.w/2;
 		titleWidget->pos.y =75 + pos.y - titleWidget->pos.h/2;
 	}

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -66,7 +66,7 @@ CRecruitmentWindow::CCreatureCard::CCreatureCard(CRecruitmentWindow * window, co
 	creature(crea),
 	amount(totalAmount)
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 	animation = std::make_shared<CCreaturePic>(1, 1, creature, true, true);
 	// 1 + 1 px for borders
 	pos.w = animation->pos.w + 2;
@@ -213,7 +213,7 @@ CRecruitmentWindow::CRecruitmentWindow(const CGDwelling * Dwelling, int Level, c
 {
 	moveBy(Point(0, y_offset));
 
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 
 	statusbar = CGStatusBar::create(std::make_shared<CPicture>(background->getSurface(), Rect(8, pos.h - 26, pos.w - 16, 19), 8, pos.h - 26));
 
@@ -238,7 +238,7 @@ CRecruitmentWindow::CRecruitmentWindow(const CGDwelling * Dwelling, int Level, c
 
 void CRecruitmentWindow::availableCreaturesChanged()
 {
-	OBJECT_CONSTRUCTION_CUSTOM_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 
 	size_t selectedIndex = 0;
 
@@ -316,7 +316,7 @@ CSplitWindow::CSplitWindow(const CCreature * creature, std::function<void(int, i
 	leftMin(leftMin_),
 	rightMin(rightMin_)
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 
 	int total = leftAmount + rightAmount;
 	int leftMax = total - rightMin;
@@ -398,7 +398,7 @@ CLevelWindow::CLevelWindow(const CGHeroInstance * hero, PrimarySkill pskill, std
 	: CWindowObject(PLAYER_COLORED, ImagePath::builtin("LVLUPBKG")),
 	cb(callback)
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 
 	LOCPLINT->showingDialog->setBusy();
 
@@ -453,7 +453,7 @@ CTavernWindow::CTavernWindow(const CGObjectInstance * TavernObj, const std::func
 	tavernObj(TavernObj),
 	heroToInvite(nullptr)
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 
 	std::vector<const CGHeroInstance*> h = LOCPLINT->cb->getAvailableHeroes(TavernObj);
 	if(h.size() < 2)
@@ -532,7 +532,7 @@ CTavernWindow::CTavernWindow(const CGObjectInstance * TavernObj, const std::func
 
 void CTavernWindow::addInvite()
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 
 	if(!VLC->settings()->getBoolean(EGameSettings::HEROES_TAVERN_INVITE))
 		return;
@@ -630,7 +630,7 @@ CTavernWindow::HeroPortrait::HeroPortrait(int & sel, int id, int x, int y, const
 	: CIntObject(LCLICK | DOUBLECLICK | SHOW_POPUP | HOVER),
 	h(H), _sel(&sel), _id(id), onChoose(OnChoose)
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 	h = H;
 	pos.x += x;
 	pos.y += y;
@@ -669,7 +669,7 @@ void CTavernWindow::HeroPortrait::hover(bool on)
 CTavernWindow::HeroSelector::HeroSelector(std::map<HeroTypeID, CGHeroInstance*> InviteableHeroes, std::function<void(CGHeroInstance*)> OnChoose)
 	: CWindowObject(BORDERED), inviteableHeroes(InviteableHeroes), onChoose(OnChoose)
 {
-	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
+	OBJECT_CONSTRUCTION;
 
 	pos = Rect(
 		pos.x,
@@ -701,7 +701,7 @@ void CTavernWindow::HeroSelector::sliderMove(int slidPos)
 
 void CTavernWindow::HeroSelector::recreate()
 {
-	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
+	OBJECT_CONSTRUCTION;
 
 	int sliderLine = slider ? slider->getValue() : 0;
 	int x = 0;
@@ -729,7 +729,7 @@ void CTavernWindow::HeroSelector::recreate()
 CShipyardWindow::CShipyardWindow(const TResources & cost, int state, BoatId boatType, const std::function<void()> & onBuy)
 	: CWindowObject(PLAYER_COLORED, ImagePath::builtin("TPSHIP"))
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 
 	bgWater = std::make_shared<CPicture>(ImagePath::builtin("TPSHIPBK"), 100, 69);
 
@@ -803,7 +803,7 @@ CTransformerWindow::CItem::CItem(CTransformerWindow * parent_, int size_, int id
 	size(size_),
 	parent(parent_)
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 	left = true;
 	pos.w = 58;
 	pos.h = 64;
@@ -850,7 +850,7 @@ CTransformerWindow::CTransformerWindow(const IMarket * _market, const CGHeroInst
 	onWindowClosed(onWindowClosed),
 	market(_market)
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 	if(hero)
 		army = hero;
 	else
@@ -889,7 +889,7 @@ CUniversityWindow::CItem::CItem(CUniversityWindow * _parent, int _ID, int X, int
 	ID(_ID),
 	parent(_parent)
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 	pos.x += X;
 	pos.y += Y;
 
@@ -929,7 +929,7 @@ void CUniversityWindow::CItem::update()
 	else
 		image = ImagePath::builtin("UNIVRED");
 
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 	topBar = std::make_shared<CPicture>(image, Point(-28, -22));
 	bottomBar = std::make_shared<CPicture>(image, Point(-28, 48));
 
@@ -952,7 +952,7 @@ CUniversityWindow::CUniversityWindow(const CGHeroInstance * _hero, const IMarket
 	onWindowClosed(onWindowClosed),
 	market(_market)
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 
 
 	std::string titleStr = CGI->generaltexth->allTexts[602];
@@ -1012,7 +1012,7 @@ CUnivConfirmWindow::CUnivConfirmWindow(CUniversityWindow * owner_, SecondarySkil
 	: CWindowObject(PLAYER_COLORED, ImagePath::builtin("UNIVERS2.PCX")),
 	owner(owner_)
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 
 	std::string text = CGI->generaltexth->allTexts[608];
 	boost::replace_first(text, "%s", CGI->generaltexth->levels[0]);
@@ -1052,7 +1052,7 @@ void CUnivConfirmWindow::makeDeal(SecondarySkill skill)
 CGarrisonWindow::CGarrisonWindow(const CArmedInstance * up, const CGHeroInstance * down, bool removableUnits)
 	: CWindowObject(PLAYER_COLORED, ImagePath::builtin("GARRISON"))
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 
 	garr = std::make_shared<CGarrisonInt>(Point(92, 127), 4, Point(0,96), up, down, removableUnits);
 	{
@@ -1100,7 +1100,7 @@ CHillFortWindow::CHillFortWindow(const CGHeroInstance * visitor, const CGObjectI
 	fort(object),
 	hero(visitor)
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 
 	title = std::make_shared<CLabel>(325, 32, FONT_BIG, ETextAlignment::CENTER, Colors::YELLOW, fort->getObjectName());
 
@@ -1303,7 +1303,7 @@ CThievesGuildWindow::CThievesGuildWindow(const CGObjectInstance * _owner):
 	CWindowObject(PLAYER_COLORED | BORDERED, ImagePath::builtin("TpRank")),
 	owner(_owner)
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 
 	SThievesGuildInfo tgi; //info to be displayed
 	LOCPLINT->cb->getThievesGuildInfo(tgi, owner);
@@ -1431,7 +1431,7 @@ CObjectListWindow::CItem::CItem(CObjectListWindow * _parent, size_t _id, std::st
 	parent(_parent),
 	index(_id)
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 	if(parent->images.size() > index)
 		icon = std::make_shared<CPicture>(parent->images[index], Point(1, 1));
 	border = std::make_shared<CPicture>(ImagePath::builtin("TPGATES"));
@@ -1484,7 +1484,7 @@ CObjectListWindow::CObjectListWindow(const std::vector<int> & _items, std::share
 	selected(initialSelection),
 	images(images)
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 	items.reserve(_items.size());
 
 	for(int id : _items)
@@ -1501,7 +1501,7 @@ CObjectListWindow::CObjectListWindow(const std::vector<std::string> & _items, st
 	selected(initialSelection),
 	images(images)
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255-DISPOSE);
+	OBJECT_CONSTRUCTION;
 	items.reserve(_items.size());
 
 	for(size_t i=0; i<_items.size(); i++)

--- a/client/windows/InfoWindows.cpp
+++ b/client/windows/InfoWindows.cpp
@@ -38,7 +38,7 @@
 
 CSelWindow::CSelWindow( const std::string & Text, PlayerColor player, int charperline, const std::vector<std::shared_ptr<CSelectableComponent>> & comps, const std::vector<std::pair<AnimationPath, CFunctionList<void()>>> & Buttons, QueryID askID)
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255 - DISPOSE);
+	OBJECT_CONSTRUCTION;
 
 	backgroundTexture = std::make_shared<CFilledTexture>(ImagePath::builtin("DiBoxBck"), pos);
 
@@ -94,7 +94,7 @@ void CSelWindow::madeChoiceAndClose()
 
 CInfoWindow::CInfoWindow(const std::string & Text, PlayerColor player, const TCompsInfo & comps, const TButtonsInfo & Buttons)
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255 - DISPOSE);
+	OBJECT_CONSTRUCTION;
 
 	backgroundTexture = std::make_shared<CFilledTexture>(ImagePath::builtin("DiBoxBck"), pos);
 
@@ -273,7 +273,7 @@ CInfoBoxPopup::CInfoBoxPopup(Point position, const CGTownInstance * town)
 	InfoAboutTown iah;
 	LOCPLINT->cb->getTownInfo(town, iah, LOCPLINT->localState->getCurrentTown()); //todo: should this be nearest hero?
 
-	OBJECT_CONSTRUCTION_CAPTURING(255 - DISPOSE);
+	OBJECT_CONSTRUCTION;
 	tooltip = std::make_shared<CTownTooltip>(Point(9, 10), iah);
 }
 
@@ -283,7 +283,7 @@ CInfoBoxPopup::CInfoBoxPopup(Point position, const CGHeroInstance * hero)
 	InfoAboutHero iah;
 	LOCPLINT->cb->getHeroInfo(hero, iah, LOCPLINT->localState->getCurrentHero()); //todo: should this be nearest hero?
 
-	OBJECT_CONSTRUCTION_CAPTURING(255 - DISPOSE);
+	OBJECT_CONSTRUCTION;
 	tooltip = std::make_shared<CHeroTooltip>(Point(9, 10), iah);
 }
 
@@ -293,14 +293,14 @@ CInfoBoxPopup::CInfoBoxPopup(Point position, const CGGarrison * garr)
 	InfoAboutTown iah;
 	LOCPLINT->cb->getTownInfo(garr, iah);
 
-	OBJECT_CONSTRUCTION_CAPTURING(255 - DISPOSE);
+	OBJECT_CONSTRUCTION;
 	tooltip = std::make_shared<CArmyTooltip>(Point(9, 10), iah);
 }
 
 CInfoBoxPopup::CInfoBoxPopup(Point position, const CGCreature * creature)
 	: CWindowObject(RCLICK_POPUP | BORDERED, ImagePath::builtin("DIBOXBCK"), toScreen(position))
 {
-	OBJECT_CONSTRUCTION_CAPTURING(255 - DISPOSE);
+	OBJECT_CONSTRUCTION;
 	tooltip = std::make_shared<CreatureTooltip>(Point(9, 10), creature);
 }
 

--- a/client/windows/InfoWindows.cpp
+++ b/client/windows/InfoWindows.cpp
@@ -248,8 +248,6 @@ void CRClickPopup::createAndPush(const CGObjectInstance * obj, const Point & p, 
 CRClickPopupInt::CRClickPopupInt(const std::shared_ptr<CIntObject> & our)
 {
 	CCS->curh->hide();
-	defActions = 255-DISPOSE;
-	our->recActions = defActions;
 	inner = our;
 	addChild(our.get(), false);
 }

--- a/client/windows/QuickRecruitmentWindow.cpp
+++ b/client/windows/QuickRecruitmentWindow.cpp
@@ -151,7 +151,7 @@ QuickRecruitmentWindow::QuickRecruitmentWindow(const CGTownInstance * townd, Rec
 	: CWindowObject(PLAYER_COLORED | BORDERED),
 	town(townd)
 {
-	OBJECT_CONSTRUCTION_CAPTURING(ACTIVATE + DEACTIVATE + UPDATE + SHOWALL);
+	OBJECT_CONSTRUCTION;
 
 	initWindow(startupPosition);
 	setButtons();

--- a/client/windows/settings/AdventureOptionsTab.cpp
+++ b/client/windows/settings/AdventureOptionsTab.cpp
@@ -33,7 +33,7 @@ static void setIntSetting(std::string group, std::string field, int value)
 AdventureOptionsTab::AdventureOptionsTab()
 		: InterfaceObjectConfigurable()
 {
-	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
+	OBJECT_CONSTRUCTION;
 	setRedrawParent(true);
 
 #ifdef VCMI_MOBILE

--- a/client/windows/settings/BattleOptionsTab.cpp
+++ b/client/windows/settings/BattleOptionsTab.cpp
@@ -20,7 +20,7 @@
 
 BattleOptionsTab::BattleOptionsTab(BattleInterface * owner)
 {
-	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
+	OBJECT_CONSTRUCTION;
 	setRedrawParent(true);
 
 	const JsonNode config(JsonPath::builtin("config/widgets/settings/battleOptionsTab.json"));

--- a/client/windows/settings/GeneralOptionsTab.cpp
+++ b/client/windows/settings/GeneralOptionsTab.cpp
@@ -94,7 +94,7 @@ GeneralOptionsTab::GeneralOptionsTab()
 		: InterfaceObjectConfigurable(),
 		  onFullscreenChanged(settings.listen["video"]["fullscreen"])
 {
-	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
+	OBJECT_CONSTRUCTION;
 	setRedrawParent(true);
 
 	addConditional("touchscreen", GH.input().hasTouchInputDevice());

--- a/client/windows/settings/OtherOptionsTab.cpp
+++ b/client/windows/settings/OtherOptionsTab.cpp
@@ -24,7 +24,7 @@ static void setBoolSetting(std::string group, std::string field, bool value)
 
 OtherOptionsTab::OtherOptionsTab() : InterfaceObjectConfigurable()
 {
-	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
+	OBJECT_CONSTRUCTION;
 
 	const JsonNode config(JsonPath::builtin("config/widgets/settings/otherOptionsTab.json"));
 	addCallback("availableCreaturesAsDwellingLabelChanged", [](bool value)

--- a/client/windows/settings/SettingsMainWindow.cpp
+++ b/client/windows/settings/SettingsMainWindow.cpp
@@ -144,7 +144,6 @@ void SettingsMainWindow::mainMenuButtonCallback()
 		{
 			close();
 			CSH->endGameplay();
-			GH.defActionsDef = 63;
 			CMM->menu->switchToTab("main");
 		},
 		0

--- a/client/windows/settings/SettingsMainWindow.cpp
+++ b/client/windows/settings/SettingsMainWindow.cpp
@@ -33,7 +33,7 @@
 
 SettingsMainWindow::SettingsMainWindow(BattleInterface * parentBattleUi) : InterfaceObjectConfigurable()
 {
-	OBJ_CONSTRUCTION_CAPTURING_ALL_NO_DISPOSE;
+	OBJECT_CONSTRUCTION;
 
 	const JsonNode config(JsonPath::builtin("config/widgets/settings/settingsMainContainer.json"));
 	addCallback("activateSettingsTab", [this](int tabId) { openTab(tabId); });


### PR DESCRIPTION
Cleanup of old parts of our UI system.

1. Removed `defActions` member from CIntObject. It was used to limit propagation of event (e.g. activation / redraws) to children. However by now all objects use such propagation and remaining places where this member is used is old, unclear code. Have not found not a single place where `defActions` were actually used for some non-zero effect.
2. Replaced 5 of various `OBJ_CONSTRUCTION_XXX` macros with two - one for use in self-construction (e.g. inside object constructor) and second one - for initiating same logic for specific UI element
3. Removed magical `255-DISPOSE` parameter from construction macro. Seems to be part of UI refactoring that was never cleaned up. Also completely remove DISPOSE flag since UI now always uses smart pointers with auto-deletion, have not found a single case where this flag was actually active