### PR TITLE
VCMP format -> change to zip

### DIFF
--- a/client/lobby/SelectionTab.cpp
+++ b/client/lobby/SelectionTab.cpp
@@ -390,14 +390,28 @@ void SelectionTab::showPopupWindow(const Point & cursorPosition)
 
 	if(!curItems[py]->isFolder)
 	{
-		auto creationDateTime = tabType == ESelectionScreen::newGame && curItems[py]->mapHeader->creationDateTime ? TextOperations::getFormattedDateTimeLocal(curItems[py]->mapHeader->creationDateTime) : curItems[py]->date;
-		auto author = curItems[py]->mapHeader->author.toString() + (!curItems[py]->mapHeader->authorContact.toString().empty() ? (" <" + curItems[py]->mapHeader->authorContact.toString() + ">") : "");
+		std::string creationDateTime;
+		std::string author;
+		std::string mapVersion;
+		if(tabType != ESelectionScreen::campaignList)
+		{
+			author = curItems[py]->mapHeader->author.toString() + (!curItems[py]->mapHeader->authorContact.toString().empty() ? (" <" + curItems[py]->mapHeader->authorContact.toString() + ">") : "");
+			mapVersion = curItems[py]->mapHeader->mapVersion.toString();
+			creationDateTime = tabType == ESelectionScreen::newGame && curItems[py]->mapHeader->creationDateTime ? TextOperations::getFormattedDateTimeLocal(curItems[py]->mapHeader->creationDateTime) : curItems[py]->date;
+		}
+		else
+		{
+			author = curItems[py]->campaign->getAuthor() + (!curItems[py]->campaign->getAuthorContact().empty() ? (" <" + curItems[py]->campaign->getAuthorContact() + ">") : "");
+			mapVersion = curItems[py]->campaign->getCampaignVersion();
+			creationDateTime = curItems[py]->campaign->getCreationDateTime() ? TextOperations::getFormattedDateTimeLocal(curItems[py]->campaign->getCreationDateTime()) : curItems[py]->date;
+		}
+
 		GH.windows().createAndPushWindow<CMapOverview>(
 			curItems[py]->getNameTranslated(),
 			curItems[py]->fullFileURI,
 			creationDateTime,
 			author,
-			curItems[py]->mapHeader->mapVersion.toString(),
+			mapVersion,
 			ResourcePath(curItems[py]->fileURI),
 			tabType
 		);

--- a/docs/modders/Campaign_Format.md
+++ b/docs/modders/Campaign_Format.md
@@ -5,7 +5,7 @@
 Starting from version 1.3, VCMI supports its own campaign format.
 Campaigns have *.vcmp file format and it consists from campaign json and set of scenarios (can be both *.vmap and *.h3m)
 
-To start making campaign, create file named `00.json`. See also [Packing campaign](#packing-campaign)
+To start making campaign, create file named `header.json`. See also [Packing campaign](#packing-campaign)
 
 Basic structure of this file is here, each section is described in details below
 ```js
@@ -199,24 +199,9 @@ Predefined campaign regions are located in file `campaign_regions.json`
 ## Packing campaign
 
 After campaign scenarios and campaign description are ready, you should pack them into *.vcmp file.
-This file is basically headless gz archive.
+This file is a zip archive.
 
-Your campaign should be stored in some folder with json describing campaign information.
-Place all your scenarios inside same folder and enumerate their filenames, e.g `01.vmap`, '02.vmap', etc.
-```
-my-campaign/
-|-- 00.json
-|-- 01.vmap
-|-- 02.vmap
-|-- 03.vmap
-```
-
-If you use unix system, execute this command to pack your campaign:
-```
-gzip -c -n ./* >> my-campaign.vcmp
-```
-
-If you are using Windows system, try this https://gnuwin32.sourceforge.net/packages/gzip.htm
+The scenarios should be named as in `"map"` field from header. Subfolders are allowed.
 
 ## Compatibility table
 | Version | Min VCMI | Max VCMI | Description |

--- a/lib/campaign/CampaignHandler.cpp
+++ b/lib/campaign/CampaignHandler.cpp
@@ -127,14 +127,19 @@ static std::string convertMapName(std::string input)
 
 std::string CampaignHandler::readLocalizedString(CampaignHeader & target, CBinaryReader & reader, std::string filename, std::string modName, std::string encoding, std::string identifier)
 {
-	TextIdentifier stringID( "campaign", convertMapName(filename), identifier);
-
 	std::string input = TextOperations::toUnicode(reader.readBaseString(), encoding);
 
-	if (input.empty())
+	return readLocalizedString(target, input, filename, modName, identifier);
+}
+
+std::string CampaignHandler::readLocalizedString(CampaignHeader & target, std::string text, std::string filename, std::string modName, std::string identifier)
+{
+	TextIdentifier stringID( "campaign", convertMapName(filename), identifier);
+
+	if (text.empty())
 		return "";
 
-	target.getTexts().registerString(modName, stringID, input);
+	target.getTexts().registerString(modName, stringID, text);
 	return stringID.get();
 }
 
@@ -150,8 +155,8 @@ void CampaignHandler::readHeaderFromJson(CampaignHeader & ret, JsonNode & reader
 	ret.version = CampaignVersion::VCMI;
 	ret.campaignRegions = CampaignRegions::fromJson(reader["regions"]);
 	ret.numberOfScenarios = reader["scenarios"].Vector().size();
-	ret.name.appendTextID(reader["name"].String());
-	ret.description.appendTextID(reader["description"].String());
+	ret.name.appendTextID(readLocalizedString(ret, reader["name"].String(), filename, modName, "name"));
+	ret.description.appendTextID(readLocalizedString(ret, reader["description"].String(), filename, modName, "name"));
 	ret.author.appendRawString(reader["author"].String());
 	ret.authorContact.appendRawString(reader["authorContact"].String());
 	ret.campaignVersion.appendRawString(reader["campaignVersion"].String());

--- a/lib/campaign/CampaignHandler.cpp
+++ b/lib/campaign/CampaignHandler.cpp
@@ -608,6 +608,9 @@ std::vector< std::vector<ui8> > CampaignHandler::getFile(std::unique_ptr<CInputS
 		auto data = loader.load(resource)->readAll();
 		ret.push_back(std::vector<ui8>(data.first.get(), data.first.get() + data.second));
 
+		if(headerOnly)
+			return ret;
+
 		// load scenarios
 		JsonNode header(reinterpret_cast<const std::byte*>(data.first.get()), data.second, VCMP_HEADER_FILE_NAME);
 		for(auto scenario : header["scenarios"].Vector())

--- a/lib/campaign/CampaignHandler.h
+++ b/lib/campaign/CampaignHandler.h
@@ -17,6 +17,7 @@ VCMI_LIB_NAMESPACE_BEGIN
 class DLL_LINKAGE CampaignHandler
 {
 	static std::string readLocalizedString(CampaignHeader & target, CBinaryReader & reader, std::string filename, std::string modName, std::string encoding, std::string identifier);
+	static std::string readLocalizedString(CampaignHeader & target, std::string text, std::string filename, std::string modName, std::string identifier);
 
 	static void readCampaign(Campaign * target, const std::vector<ui8> & stream, std::string filename, std::string modName, std::string encoding);
 

--- a/lib/campaign/CampaignHandler.h
+++ b/lib/campaign/CampaignHandler.h
@@ -37,6 +37,7 @@ class DLL_LINKAGE CampaignHandler
 	static AudioPath prologMusicName(ui8 index);
 	static AudioPath prologVoiceName(ui8 index);
 
+	static constexpr auto VCMP_HEADER_FILE_NAME = "header.json";
 public:
 	static std::unique_ptr<Campaign> getHeader( const std::string & name); //name - name of appropriate file
 

--- a/lib/campaign/CampaignState.cpp
+++ b/lib/campaign/CampaignState.cpp
@@ -144,6 +144,26 @@ std::string CampaignHeader::getNameTranslated() const
 	return name.toString();
 }
 
+std::string CampaignHeader::getAuthor() const
+{
+	return authorContact.toString();
+}
+
+std::string CampaignHeader::getAuthorContact() const
+{
+	return authorContact.toString();
+}
+
+std::string CampaignHeader::getCampaignVersion() const
+{
+	return campaignVersion.toString();
+}
+
+time_t CampaignHeader::getCreationDateTime() const
+{
+	return creationDateTime;
+}
+
 std::string CampaignHeader::getFilename() const
 {
 	return filename;

--- a/lib/campaign/CampaignState.h
+++ b/lib/campaign/CampaignState.h
@@ -103,6 +103,10 @@ public:
 
 	std::string getDescriptionTranslated() const;
 	std::string getNameTranslated() const;
+	std::string getAuthor() const;
+	std::string getAuthorContact() const;
+	std::string getCampaignVersion() const;
+	time_t getCreationDateTime() const;
 	std::string getFilename() const;
 	std::string getModName() const;
 	std::string getEncoding() const;


### PR DESCRIPTION
As some modders want to use it it's time to get rid of this painful GZIP stuff.

Now VCMP is a simple zip file with an header.json (like in VMAP). And map path defined in this file.

Loading of old VCMP files should still work...