### PR TITLE
Minor cleanup of SpellHandler

### DIFF
--- a/lib/spells/BattleSpellMechanics.cpp
+++ b/lib/spells/BattleSpellMechanics.cpp
@@ -505,62 +505,14 @@ std::set<BattleHex> BattleSpellMechanics::spellRangeInHexes(BattleHex centralHex
 	using namespace SRSLPraserHelpers;
 
 	std::set<BattleHex> ret;
-	std::string rng = owner->getLevelInfo(getRangeLevel()).range + ','; //copy + artificial comma for easier handling
+	std::vector<int> rng = owner->getLevelInfo(getRangeLevel()).range;
 
-	if(rng.size() >= 2 && rng[0] != 'X') //there is at least one hex in range (+artificial comma)
+	for(auto & elem : rng)
 	{
-		std::string number1;
-		std::string number2;
-		int beg = 0;
-		int end = 0;
-		bool readingFirst = true;
-		for(auto & elem : rng)
-		{
-			if(std::isdigit(elem) ) //reading number
-			{
-				if(readingFirst)
-					number1 += elem;
-				else
-					number2 += elem;
-			}
-			else if(elem == ',') //comma
-			{
-				//calculating variables
-				if(readingFirst)
-				{
-					beg = std::stoi(number1);
-					number1 = "";
-				}
-				else
-				{
-					end = std::stoi(number2);
-					number2 = "";
-				}
-				//obtaining new hexes
-				std::set<ui16> curLayer;
-				if(readingFirst)
-				{
-					curLayer = getInRange(centralHex, beg, beg);
-				}
-				else
-				{
-					curLayer = getInRange(centralHex, beg, end);
-					readingFirst = true;
-				}
-				//adding obtained hexes
-				for(const auto & curLayer_it : curLayer)
-				{
-					ret.insert(curLayer_it);
-				}
-
-			}
-			else if(elem == '-') //dash
-			{
-				beg = std::stoi(number1);
-				number1 = "";
-				readingFirst = false;
-			}
-		}
+		std::set<ui16> curLayer = getInRange(centralHex, elem, elem);
+		//adding obtained hexes
+		for(const auto & curLayer_it : curLayer)
+			ret.insert(curLayer_it);
 	}
 
 	return ret;

--- a/lib/spells/CSpellHandler.h
+++ b/lib/spells/CSpellHandler.h
@@ -67,12 +67,6 @@ public:
 
 		///resource name
 		AnimationPath resourceName;
-
-		template <typename Handler> void serialize(Handler & h)
-		{
-			h & minimumAngle;
-			h & resourceName;
-		}
 	};
 
 	struct AnimationItem
@@ -83,14 +77,6 @@ public:
 		int pause;
 
 		AnimationItem();
-
-		template <typename Handler> void serialize(Handler & h)
-		{
-			h & resourceName;
-			h & effectName;
-			h & verticalPosition;
-			h & pause;
-		}
 	};
 
 	using TAnimation = AnimationItem;
@@ -110,14 +96,6 @@ public:
 		///displayed "between" caster and (first) target. Ignored if spell was cast with no target selection.
 		///use selectProjectile to access
 		std::vector<ProjectileInfo> projectile;
-
-		template <typename Handler> void serialize(Handler & h)
-		{
-			h & projectile;
-			h & hit;
-			h & cast;
-			h & affect;
-		}
 
 		AnimationPath selectProjectile(const double angle) const;
 	} animationInfo;
@@ -139,20 +117,6 @@ public:
 		std::vector<std::shared_ptr<Bonus>> cumulativeEffects; //deprecated
 
 		JsonNode battleEffects;
-
-		template <typename Handler> void serialize(Handler & h)
-		{
-			h & cost;
-			h & power;
-			h & AIValue;
-			h & smartTarget;
-			h & range;
-			h & effects;
-			h & cumulativeEffects;
-			h & clearTarget;
-			h & clearAffected;
-			h & battleEffects;
-		}
 	};
 
 	/** \brief Low level accessor. Don`t use it if absolutely necessary

--- a/lib/spells/CSpellHandler.h
+++ b/lib/spells/CSpellHandler.h
@@ -110,7 +110,7 @@ public:
 		bool smartTarget = true;
 		bool clearTarget = false;
 		bool clearAffected = false;
-		std::string range = "0";
+		std::vector<int> range = { 0 };
 
 		//TODO: remove these two when AI will understand special effects
 		std::vector<std::shared_ptr<Bonus>> effects; //deprecated
@@ -305,6 +305,8 @@ bool DLL_LINKAGE isInScreenRange(const int3 &center, const int3 &pos); //for spe
 
 class DLL_LINKAGE CSpellHandler: public CHandlerBase<SpellID, spells::Spell, CSpell, spells::Service>
 {
+	std::vector<int> spellRangeInHexes(std::string rng) const;
+
 public:
 	///IHandler base
 	std::vector<JsonNode> loadLegacyData() override;


### PR DESCRIPTION
- removed some old serialization code from components of SpellHandler - leftover from times when VLC was serialized
- removed parsing of spell range on every cast. Now spell range is parsed & loaded only once, on game load