### PR TITLE
Do not try to shoot at 2nd hex of wide creatures

### DIFF
--- a/AI/BattleAI/AttackPossibility.cpp
+++ b/AI/BattleAI/AttackPossibility.cpp
@@ -245,7 +245,7 @@ AttackPossibility AttackPossibility::evaluate(
 
 	std::vector<BattleHex> defenderHex;
 	if(attackInfo.shooting)
-		defenderHex = defender->getHexes();
+		defenderHex.push_back(defender->getPosition());
 	else
 		defenderHex = CStack::meleeAttackHexes(attacker, defender, hex);
 

--- a/lib/CConsoleHandler.cpp
+++ b/lib/CConsoleHandler.cpp
@@ -168,6 +168,7 @@ LONG WINAPI onUnhandledException(EXCEPTION_POINTERS* exception)
 
 #endif
 
+#ifdef NDEBUG
 [[noreturn]] static void onTerminate()
 {
 	logGlobal->error("Disaster happened.");
@@ -205,6 +206,7 @@ LONG WINAPI onUnhandledException(EXCEPTION_POINTERS* exception)
 #endif
 	std::abort();
 }
+#endif
 
 void CConsoleHandler::setColor(EConsoleTextColor::EConsoleTextColor color)
 {
@@ -296,14 +298,14 @@ CConsoleHandler::CConsoleHandler():
 
 	GetConsoleScreenBufferInfo(handleErr, &csbi);
 	defErrColor = csbi.wAttributes;
-#ifndef _DEBUG
+#ifdef NDEBUG
 	SetUnhandledExceptionFilter(onUnhandledException);
 #endif
 #else
 	defColor = "\x1b[0m";
 #endif
 
-#ifndef _DEBUG
+#ifdef NDEBUG
 	std::set_terminate(onTerminate);
 #endif
 }

--- a/lib/battle/CBattleInfoCallback.cpp
+++ b/lib/battle/CBattleInfoCallback.cpp
@@ -173,6 +173,9 @@ bool CBattleInfoCallback::battleIsInsideWalls(BattleHex from) const
 
 bool CBattleInfoCallback::battleHasPenaltyOnLine(BattleHex from, BattleHex dest, bool checkWall, bool checkMoat) const
 {
+	if (!from.isAvailable() || !dest.isAvailable())
+		throw std::runtime_error("Invalid hex (" + std::to_string(from.hex) + " and " + std::to_string(dest.hex) + ") received in battleHasPenaltyOnLine!" );
+
 	auto isTileBlocked = [&](BattleHex tile)
 	{
 		EWallPart wallPart = battleHexToWallPart(tile);


### PR DESCRIPTION
Reported on Discord, regression from recent AI PR. AI attempts to attack 2nd hex of a ballista, which is outside of map borders.

AI will now only check main hex of a unit and will no longer check 2nd hex of wide units.

Also added check in battleHasPenaltyOnLine to throw on such case instead of entering infinite loop