### PR TITLE
Generates prebuilt libraries package in CI

### DIFF
--- a/.github/workflows/prebuilts.yml
+++ b/.github/workflows/prebuilts.yml
@@ -12,72 +12,39 @@ jobs:
         include:
           - platform: mac-intel
             os: macos-13
-            test: 0
-            pack: 1
-            pack_type: Release
-            extension: dmg
             preset: macos-conan-ninja-release
             conan_profile: macos-intel
             conan_options: --options with_apple_system_libs=True
             artifact_platform: intel
           - platform: mac-arm
             os: macos-13
-            test: 0
-            pack: 1
-            pack_type: Release
-            extension: dmg
             preset: macos-arm-conan-ninja-release
             conan_profile: macos-arm
             conan_options: --options with_apple_system_libs=True
             artifact_platform: arm
           - platform: ios
             os: macos-13
-            test: 0
-            pack: 1
-            pack_type: Release
-            extension: ipa
             preset: ios-release-conan-ccache
             conan_profile: ios-arm64
             conan_options: --options with_apple_system_libs=True
-#          - platform: msvc
-#            os: windows-latest
-#            test: 0
-#            pack: 1
-#            pack_type: RelWithDebInfo
-#            extension: exe
-#            preset: windows-msvc-release
           - platform: mingw
             os: ubuntu-22.04
-            test: 0
-            pack: 1
-            pack_type: Release
-            extension: exe
-            cpack_args: -D CPACK_NSIS_EXECUTABLE=`which makensis`
-            cmake_args: -G Ninja
             preset: windows-mingw-conan-linux
             conan_profile: mingw64-linux.jinja
           - platform: mingw-32
             os: ubuntu-22.04
-            test: 0
-            pack: 1
-            pack_type: Release
-            extension: exe
-            cpack_args: -D CPACK_NSIS_EXECUTABLE=`which makensis`
-            cmake_args: -G Ninja
             preset: windows-mingw-conan-linux
             conan_profile: mingw32-linux.jinja
           - platform: android-32
             os: macos-14
-            extension: apk
             preset: android-conan-ninja-release
-            conan_profile: android-32
+            conan_profile: android-32-ndk
             conan_options: --conf tools.android:ndk_path=$ANDROID_NDK_ROOT
             artifact_platform: armeabi-v7a
           - platform: android-64
             os: macos-14
-            extension: apk
             preset: android-conan-ninja-release
-            conan_profile: android-64
+            conan_profile: android-64-ndk
             conan_options: --conf tools.android:ndk_path=$ANDROID_NDK_ROOT
             artifact_platform: arm64-v8a
     runs-on: ${{ matrix.os }}
@@ -86,9 +53,10 @@ jobs:
         shell: bash
 
     steps:
-    - uses: actions/checkout@v4
+    - name: Checkout repository
+      uses: actions/checkout@v4
 
-    - name: Dependencies
+    - name: Install dependencies
       run: source '${{github.workspace}}/CI/${{matrix.platform}}/before_install.sh'
       env:
         VCMI_BUILD_PLATFORM: x64
@@ -96,15 +64,20 @@ jobs:
     - name: Remove old packages
       run: rm -rf ~/.conan/data/ffmpeg/4.4.3/_/_/package
 
-    - uses: actions/setup-python@v5
+    - name: Setup Python
+      uses: actions/setup-python@v5
       if: "${{ matrix.conan_profile != '' }}"
       with:
         python-version: '3.10'
 
-    - name: Conan setup
+    - name: Setup Conan
+      if: "${{ matrix.conan_profile != '' }}"
+      run: pip3 install 'conan<2.0'
+
+
+    - name: Generate conan profile
       if: "${{ matrix.conan_profile != '' }}"
       run: |
-        pip3 install 'conan<2.0'
         conan profile new default --detect
         conan install . \
           --install-folder=conan-generated \
@@ -116,15 +89,19 @@ jobs:
       env:
         GENERATE_ONLY_BUILT_CONFIG: 1
 
-    - name: Conan cleanup
+    - name: Remove builds and source code
       if: "${{ matrix.conan_profile != '' }}"
       run: "conan remove --builds --src --force '*'"
       
+    - name: Remove Android SDK
+      if: "${{ matrix.conan_profile != '' }}"
+      run: rm -rf ~/.conan/data/android-ndk
+
     - name: Create dependencies archive
       if: "${{ matrix.conan_profile != '' }}"
       run: "tar -czvf dependencies.tgz -C ~/.conan data"
 
-    - name: Artifacts
+    - name: Upload artifacts
       uses: actions/upload-artifact@v4
       with:
         name: ${{ matrix.platform }}

--- a/.github/workflows/prebuilts.yml
+++ b/.github/workflows/prebuilts.yml
@@ -1,0 +1,137 @@
+name: VCMI - dependencies
+
+on:
+  push:
+  workflow_dispatch:
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+          - platform: mac-intel
+            os: macos-13
+            test: 0
+            pack: 1
+            pack_type: Release
+            extension: dmg
+            preset: macos-conan-ninja-release
+            conan_profile: macos-intel
+            conan_options: --options with_apple_system_libs=True
+            artifact_platform: intel
+          - platform: mac-arm
+            os: macos-13
+            test: 0
+            pack: 1
+            pack_type: Release
+            extension: dmg
+            preset: macos-arm-conan-ninja-release
+            conan_profile: macos-arm
+            conan_options: --options with_apple_system_libs=True
+            artifact_platform: arm
+          - platform: ios
+            os: macos-13
+            test: 0
+            pack: 1
+            pack_type: Release
+            extension: ipa
+            preset: ios-release-conan-ccache
+            conan_profile: ios-arm64
+            conan_options: --options with_apple_system_libs=True
+#          - platform: msvc
+#            os: windows-latest
+#            test: 0
+#            pack: 1
+#            pack_type: RelWithDebInfo
+#            extension: exe
+#            preset: windows-msvc-release
+          - platform: mingw
+            os: ubuntu-22.04
+            test: 0
+            pack: 1
+            pack_type: Release
+            extension: exe
+            cpack_args: -D CPACK_NSIS_EXECUTABLE=`which makensis`
+            cmake_args: -G Ninja
+            preset: windows-mingw-conan-linux
+            conan_profile: mingw64-linux.jinja
+          - platform: mingw-32
+            os: ubuntu-22.04
+            test: 0
+            pack: 1
+            pack_type: Release
+            extension: exe
+            cpack_args: -D CPACK_NSIS_EXECUTABLE=`which makensis`
+            cmake_args: -G Ninja
+            preset: windows-mingw-conan-linux
+            conan_profile: mingw32-linux.jinja
+#          - platform: android-32
+#            os: macos-14
+#            extension: apk
+#            preset: android-conan-ninja-release
+#            conan_profile: android-32
+#            conan_options: --conf tools.android:ndk_path=$ANDROID_NDK_ROOT
+#            artifact_platform: armeabi-v7a
+#          - platform: android-64
+#            os: macos-14
+#            extension: apk
+#            preset: android-conan-ninja-release
+#            conan_profile: android-64
+#            conan_options: --conf tools.android:ndk_path=$ANDROID_NDK_ROOT
+#            artifact_platform: arm64-v8a
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Dependencies
+      run: source '${{github.workspace}}/CI/${{matrix.platform}}/before_install.sh'
+      env:
+        VCMI_BUILD_PLATFORM: x64
+
+#    - uses: actions/setup-java@v4
+#      if: ${{ startsWith(matrix.platform, 'android') }}
+#      with:
+#        distribution: 'temurin'
+#        java-version: '11'
+
+    - name: Remove old packages
+      run: rm -rf ~/.conan/data/ffmpeg/4.4.3/_/_/package
+
+    - uses: actions/setup-python@v5
+      if: "${{ matrix.conan_profile != '' }}"
+      with:
+        python-version: '3.10'
+
+    - name: Conan setup
+      if: "${{ matrix.conan_profile != '' }}"
+      run: |
+        pip3 install 'conan<2.0'
+        conan profile new default --detect
+        conan install . \
+          --install-folder=conan-generated \
+          --no-imports \
+          --build=missing \
+          --profile:build=default \
+          --profile:host=CI/conan/${{ matrix.conan_profile }} \
+          ${{ matrix.conan_options }}
+      env:
+        GENERATE_ONLY_BUILT_CONFIG: 1
+
+    - name: Conan cleanup
+      if: "${{ matrix.conan_profile != '' }}"
+      run: "conan remove --builds --src --force '*'"
+      
+    - name: Create dependencies archive
+      if: "${{ matrix.conan_profile != '' }}"
+      run: "tar -czvf dependencies.tgz -C ~/.conan data"
+
+    - name: Artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ matrix.platform }}
+        compression-level: 0
+        path: 'dependencies.tgz'

--- a/.github/workflows/prebuilts.yml
+++ b/.github/workflows/prebuilts.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - platform: mac-intel
@@ -65,20 +66,20 @@ jobs:
             cmake_args: -G Ninja
             preset: windows-mingw-conan-linux
             conan_profile: mingw32-linux.jinja
-#          - platform: android-32
-#            os: macos-14
-#            extension: apk
-#            preset: android-conan-ninja-release
-#            conan_profile: android-32
-#            conan_options: --conf tools.android:ndk_path=$ANDROID_NDK_ROOT
-#            artifact_platform: armeabi-v7a
-#          - platform: android-64
-#            os: macos-14
-#            extension: apk
-#            preset: android-conan-ninja-release
-#            conan_profile: android-64
-#            conan_options: --conf tools.android:ndk_path=$ANDROID_NDK_ROOT
-#            artifact_platform: arm64-v8a
+          - platform: android-32
+            os: macos-14
+            extension: apk
+            preset: android-conan-ninja-release
+            conan_profile: android-32
+            conan_options: --conf tools.android:ndk_path=$ANDROID_NDK_ROOT
+            artifact_platform: armeabi-v7a
+          - platform: android-64
+            os: macos-14
+            extension: apk
+            preset: android-conan-ninja-release
+            conan_profile: android-64
+            conan_options: --conf tools.android:ndk_path=$ANDROID_NDK_ROOT
+            artifact_platform: arm64-v8a
     runs-on: ${{ matrix.os }}
     defaults:
       run:
@@ -91,12 +92,6 @@ jobs:
       run: source '${{github.workspace}}/CI/${{matrix.platform}}/before_install.sh'
       env:
         VCMI_BUILD_PLATFORM: x64
-
-#    - uses: actions/setup-java@v4
-#      if: ${{ startsWith(matrix.platform, 'android') }}
-#      with:
-#        distribution: 'temurin'
-#        java-version: '11'
 
     - name: Remove old packages
       run: rm -rf ~/.conan/data/ffmpeg/4.4.3/_/_/package

--- a/.github/workflows/prebuilts.yml
+++ b/.github/workflows/prebuilts.yml
@@ -62,7 +62,7 @@ jobs:
         VCMI_BUILD_PLATFORM: x64
 
     - name: Remove old packages
-      run: rm -rf ~/.conan/data/ffmpeg/4.4.3/_/_/package
+      run: rm -rf ~/.conan/data/ffmpeg
 
     - name: Setup Python
       uses: actions/setup-python@v5

--- a/conanfile.py
+++ b/conanfile.py
@@ -100,6 +100,9 @@ class VCMI(ConanFile):
         self.options["ffmpeg"].postproc = False
         self.options["ffmpeg"].swresample = True
         self.options["ffmpeg"].with_asm = False
+        self.options["ffmpeg"].with_libaom = False
+        self.options["ffmpeg"].with_libsvtav1 = False
+        self.options["ffmpeg"].with_libdav1d = False
         self.options["ffmpeg"].with_zlib = False
         self.options["ffmpeg"].with_bzip2 = False
         self.options["ffmpeg"].with_lzma = False
@@ -124,7 +127,7 @@ class VCMI(ConanFile):
         # H3:SoD - .bik and .smk
         # H3:HD  -  ogg container / theora video / vorbis sound
         # and for mods - webm container / vp8 or vp9 video / opus sound
-        # TODO: add av1 support for mods (likely require newer ffmpeg than 4.4.3
+        # TODO: add av1 support for mods (requires enabling libdav1d which currently fails to build via Conan)
         self.options["ffmpeg"].enable_protocols = "file"
         self.options["ffmpeg"].enable_demuxers = "bink,binka,ogg,smacker,webm_dash_manifest"
         self.options["ffmpeg"].enable_parsers = "opus,vorbis,vp8,vp9,webp"
@@ -135,10 +138,11 @@ class VCMI(ConanFile):
         self.options["ffmpeg"].with_sdl = False
 
         #optionally, for testing - enable ffplay/ffprobe binaries in conan package:
-        #self.options["ffmpeg"].with_programs = True
-        #self.options["ffmpeg"].avfilter = True
-        #self.options["ffmpeg"].with_sdl = True
-        #self.options["ffmpeg"].enable_filters = "aresample,scale"
+        #if self.settings.os == "Windows":
+        #    self.options["ffmpeg"].with_programs = True
+        #    self.options["ffmpeg"].avfilter = True
+        #    self.options["ffmpeg"].with_sdl = True
+        #    self.options["ffmpeg"].enable_filters = "aresample,scale"
 
         self.options["sdl"].sdl2main = self.settings.os != "iOS"
         self.options["sdl"].vulkan = False
@@ -232,7 +236,7 @@ class VCMI(ConanFile):
 
         # client
         if self.options.with_ffmpeg:
-            self.requires("ffmpeg/[^4.4]")
+            self.requires("ffmpeg/[^7.0]")
 
         # launcher
         if self.settings.os == "Android":

--- a/conanfile.py
+++ b/conanfile.py
@@ -87,24 +87,58 @@ class VCMI(ConanFile):
         self.options["boost"].without_type_erasure = True
         self.options["boost"].without_wave = True
 
+        self.options["ffmpeg"].disable_all_bitstream_filters = True
+        self.options["ffmpeg"].disable_all_filters = True
+        self.options["ffmpeg"].disable_all_muxers = True
+        self.options["ffmpeg"].disable_all_hardware_accelerators = True
+        self.options["ffmpeg"].disable_all_protocols = True
+        self.options["ffmpeg"].disable_all_encoders = True
+        self.options["ffmpeg"].disable_all_decoders = True
+        self.options["ffmpeg"].disable_all_parsers = True
+        self.options["ffmpeg"].disable_all_demuxers = True
         self.options["ffmpeg"].avdevice = False
-        self.options["ffmpeg"].avfilter = False
         self.options["ffmpeg"].postproc = False
-        self.options["ffmpeg"].swresample = False
-        self.options["ffmpeg"].with_asm = self.settings.os != "Android"
+        self.options["ffmpeg"].with_asm = False
+        self.options["ffmpeg"].with_zlib = False
+        self.options["ffmpeg"].with_bzip2 = False
+        self.options["ffmpeg"].with_lzma = False
+        self.options["ffmpeg"].with_libiconv = False
         self.options["ffmpeg"].with_freetype = False
-        self.options["ffmpeg"].with_libfdk_aac = False
-        self.options["ffmpeg"].with_libmp3lame = False
-        self.options["ffmpeg"].with_libvpx = False
-        self.options["ffmpeg"].with_libwebp = False
+        self.options["ffmpeg"].with_openjpeg = False
+        self.options["ffmpeg"].with_openh264 = False
+        self.options["ffmpeg"].with_opus = False
+        self.options["ffmpeg"].with_vorbis = False
         self.options["ffmpeg"].with_libx264 = False
         self.options["ffmpeg"].with_libx265 = False
-        self.options["ffmpeg"].with_openh264 = False
-        self.options["ffmpeg"].with_openjpeg = False
-        self.options["ffmpeg"].with_opus = False
-        self.options["ffmpeg"].with_programs = False
+        self.options["ffmpeg"].with_libvpx = False
+        self.options["ffmpeg"].with_libmp3lame = False
+        self.options["ffmpeg"].with_libfdk_aac = False
+        self.options["ffmpeg"].with_libwebp = False
         self.options["ffmpeg"].with_ssl = False
-        self.options["ffmpeg"].with_vorbis = False
+
+        self.options["ffmpeg"].avcodec = True
+        self.options["ffmpeg"].avformat = True
+        self.options["ffmpeg"].swscale = True
+        # We want following options supported:
+        # H3:SoD - .bik and .smk
+        # H3:HD  -  ogg container / theora video / vorbis sound
+        # and for mods - webm container / vp9 video / opus sound
+        self.options["ffmpeg"].enable_protocols = "file"
+        self.options["ffmpeg"].enable_demuxers = "bink,binka,ogg,smacker,webm_dash_manifest"
+        self.options["ffmpeg"].enable_parsers = "opus,ogg,vorbis,vp9,webp"
+        self.options["ffmpeg"].enable_decoders = "bink,binkaudio_dct,binkaudio_rdft,smackaud,smacker,theora,vorbis,vp9,opus"
+
+        self.options["ffmpeg"].with_programs = False
+        self.options["ffmpeg"].avfilter = False
+        self.options["ffmpeg"].swresample = False #Note: we might want to enable this option to allow audio resampling
+        self.options["ffmpeg"].with_sdl = False
+
+        #optionally, for testing - enable ffplay/ffprobe binaries in conan package:
+        #self.options["ffmpeg"].with_programs = True
+        #self.options["ffmpeg"].avfilter = True
+        #self.options["ffmpeg"].swresample = True
+        #self.options["ffmpeg"].with_sdl = True
+        #self.options["ffmpeg"].enable_filters = "aresample,scale"
 
         self.options["sdl"].sdl2main = self.settings.os != "iOS"
         self.options["sdl"].vulkan = False

--- a/conanfile.py
+++ b/conanfile.py
@@ -123,12 +123,12 @@ class VCMI(ConanFile):
         # We want following options supported:
         # H3:SoD - .bik and .smk
         # H3:HD  -  ogg container / theora video / vorbis sound
-        # and for mods - webm container / vp9 video / opus sound
+        # and for mods - webm container / vp8 or vp9 video / opus sound
         # TODO: add av1 support for mods (likely require newer ffmpeg than 4.4.3
         self.options["ffmpeg"].enable_protocols = "file"
         self.options["ffmpeg"].enable_demuxers = "bink,binka,ogg,smacker,webm_dash_manifest"
-        self.options["ffmpeg"].enable_parsers = "opus,vorbis,vp9,webp"
-        self.options["ffmpeg"].enable_decoders = "bink,binkaudio_dct,binkaudio_rdft,smackaud,smacker,theora,vorbis,vp9,opus"
+        self.options["ffmpeg"].enable_parsers = "opus,vorbis,vp8,vp9,webp"
+        self.options["ffmpeg"].enable_decoders = "bink,binkaudio_dct,binkaudio_rdft,smackaud,smacker,theora,vorbis,vp8,vp9,opus"
 
         self.options["ffmpeg"].with_programs = False
         self.options["ffmpeg"].avfilter = False

--- a/conanfile.py
+++ b/conanfile.py
@@ -98,6 +98,7 @@ class VCMI(ConanFile):
         self.options["ffmpeg"].disable_all_demuxers = True
         self.options["ffmpeg"].avdevice = False
         self.options["ffmpeg"].postproc = False
+        self.options["ffmpeg"].swresample = True
         self.options["ffmpeg"].with_asm = False
         self.options["ffmpeg"].with_zlib = False
         self.options["ffmpeg"].with_bzip2 = False
@@ -123,20 +124,19 @@ class VCMI(ConanFile):
         # H3:SoD - .bik and .smk
         # H3:HD  -  ogg container / theora video / vorbis sound
         # and for mods - webm container / vp9 video / opus sound
+        # TODO: add av1 support for mods (likely require newer ffmpeg than 4.4.3
         self.options["ffmpeg"].enable_protocols = "file"
         self.options["ffmpeg"].enable_demuxers = "bink,binka,ogg,smacker,webm_dash_manifest"
-        self.options["ffmpeg"].enable_parsers = "opus,ogg,vorbis,vp9,webp"
+        self.options["ffmpeg"].enable_parsers = "opus,vorbis,vp9,webp"
         self.options["ffmpeg"].enable_decoders = "bink,binkaudio_dct,binkaudio_rdft,smackaud,smacker,theora,vorbis,vp9,opus"
 
         self.options["ffmpeg"].with_programs = False
         self.options["ffmpeg"].avfilter = False
-        self.options["ffmpeg"].swresample = False #Note: we might want to enable this option to allow audio resampling
         self.options["ffmpeg"].with_sdl = False
 
         #optionally, for testing - enable ffplay/ffprobe binaries in conan package:
         #self.options["ffmpeg"].with_programs = True
         #self.options["ffmpeg"].avfilter = True
-        #self.options["ffmpeg"].swresample = True
         #self.options["ffmpeg"].with_sdl = True
         #self.options["ffmpeg"].enable_filters = "aresample,scale"
 


### PR DESCRIPTION
Very WIP, just to test whether it is doable.

Currently our prebuilt packages are compiled by one of our developers that has corresponding environment set up on his system. This works, but requires a lot of coordination whenever we need to update a package and if such developer unavailable or left the project, updating the package would be a pain.

One option (and one is recommended by conan) is to use persistent cache (artifactory), but it requires setup by somebody who known how to set it up. 

However another option is to build such packages as part of CI that we already have, especially since Conan can be used to build missing packages, e.g. after configuration change.

This PR:
- add separate workflow that instead of building vcmi will instead build missing packages for Conan.
- on success, this workflow will upload prebuilt libraries as artifacts, that can be used as input for our main CI.
- changes ffmpeg configuration to minimize its size by disabling most of its codecs which we don't use 

TODO:
- [x] find out what causes Android builds to fail
- [x] consider moving workflow to a separate repository, e.g. vcmi-dependencies
- [ ] try to create prebuilt package for msvc (with Win7 & 32-bit support), add CI for msvc+conan in addition to msvc+vcpkg
- [ ] move ffmpeg changes into separate PR and reupload prebuilt packages
- [x] consider upgrading ffmpeg from 4.4.3 to 7.0.1

Opinions? Especially @kambala-decapitator ?