### PR TITLE
IMarket refactoring

### DIFF
--- a/AI/Nullkiller/AIGateway.cpp
+++ b/AI/Nullkiller/AIGateway.cpp
@@ -1490,7 +1490,7 @@ void AIGateway::tryRealize(Goals::Trade & g) //trade
 				//TODO trade only as much as needed
 				if (toGive) //don't try to sell 0 resources
 				{
-					cb->trade(m, EMarketMode::RESOURCE_RESOURCE, res, GameResID(g.resID), toGive);
+					cb->trade(m->getObjInstanceID(), EMarketMode::RESOURCE_RESOURCE, res, GameResID(g.resID), toGive);
 					acquiredResources = static_cast<int>(toGet * (it->resVal / toGive));
 					logAi->debug("Traded %d of %s for %d of %s at %s", toGive, res, acquiredResources, g.resID, obj->getObjectName());
 				}

--- a/AI/Nullkiller/AIGateway.cpp
+++ b/AI/Nullkiller/AIGateway.cpp
@@ -526,7 +526,7 @@ void AIGateway::heroBonusChanged(const CGHeroInstance * hero, const Bonus & bonu
 	NET_EVENT_HANDLER;
 }
 
-void AIGateway::showMarketWindow(const IMarket * market, const CGHeroInstance * visitor, QueryID queryID)
+void AIGateway::showMarketWindow(const IMarket * market, const ObjectInstanceID & marketId, const CGHeroInstance * visitor, QueryID queryID)
 {
 	LOG_TRACE(logAi);
 	NET_EVENT_HANDLER;

--- a/AI/Nullkiller/AIGateway.cpp
+++ b/AI/Nullkiller/AIGateway.cpp
@@ -526,7 +526,7 @@ void AIGateway::heroBonusChanged(const CGHeroInstance * hero, const Bonus & bonu
 	NET_EVENT_HANDLER;
 }
 
-void AIGateway::showMarketWindow(const IMarket * market, const ObjectInstanceID & marketId, const CGHeroInstance * visitor, QueryID queryID)
+void AIGateway::showMarketWindow(const IMarket * market, const CGHeroInstance * visitor, QueryID queryID)
 {
 	LOG_TRACE(logAi);
 	NET_EVENT_HANDLER;

--- a/AI/Nullkiller/AIGateway.h
+++ b/AI/Nullkiller/AIGateway.h
@@ -152,7 +152,7 @@ public:
 	void objectPropertyChanged(const SetObjectProperty * sop) override;
 	void buildChanged(const CGTownInstance * town, BuildingID buildingID, int what) override;
 	void heroBonusChanged(const CGHeroInstance * hero, const Bonus & bonus, bool gain) override;
-	void showMarketWindow(const IMarket * market, const ObjectInstanceID & marketId, const CGHeroInstance * visitor, QueryID queryID) override;
+	void showMarketWindow(const IMarket * market, const CGHeroInstance * visitor, QueryID queryID) override;
 	void showWorldViewEx(const std::vector<ObjectPosInfo> & objectPositions, bool showTerrain) override;
 	std::optional<BattleAction> makeSurrenderRetreatDecision(const BattleID & battleID, const BattleStateInfoForRetreat & battleState) override;
 

--- a/AI/Nullkiller/AIGateway.h
+++ b/AI/Nullkiller/AIGateway.h
@@ -152,7 +152,7 @@ public:
 	void objectPropertyChanged(const SetObjectProperty * sop) override;
 	void buildChanged(const CGTownInstance * town, BuildingID buildingID, int what) override;
 	void heroBonusChanged(const CGHeroInstance * hero, const Bonus & bonus, bool gain) override;
-	void showMarketWindow(const IMarket * market, const CGHeroInstance * visitor, QueryID queryID) override;
+	void showMarketWindow(const IMarket * market, const ObjectInstanceID & marketId, const CGHeroInstance * visitor, QueryID queryID) override;
 	void showWorldViewEx(const std::vector<ObjectPosInfo> & objectPositions, bool showTerrain) override;
 	std::optional<BattleAction> makeSurrenderRetreatDecision(const BattleID & battleID, const BattleStateInfoForRetreat & battleState) override;
 

--- a/AI/VCAI/BuildingManager.cpp
+++ b/AI/VCAI/BuildingManager.cpp
@@ -196,7 +196,7 @@ bool BuildingManager::getBuildingOptions(const CGTownInstance * t)
 		return true;
 
 	//workaround for mantis #2696 - build capitol with separate algorithm if it is available
-	if(vstd::contains(t->builtBuildings, BuildingID::CITY_HALL) && getMaxPossibleGoldBuilding(t) == BuildingID::CAPITOL)
+	if(t->hasBuilt(BuildingID::CITY_HALL) && getMaxPossibleGoldBuilding(t) == BuildingID::CAPITOL)
 	{
 		if(tryBuildNextStructure(t, capitolAndRequirements))
 			return true;

--- a/AI/VCAI/VCAI.cpp
+++ b/AI/VCAI/VCAI.cpp
@@ -594,7 +594,7 @@ void VCAI::heroBonusChanged(const CGHeroInstance * hero, const Bonus & bonus, bo
 	NET_EVENT_HANDLER;
 }
 
-void VCAI::showMarketWindow(const IMarket * market, const CGHeroInstance * visitor, QueryID queryID)
+void VCAI::showMarketWindow(const IMarket * market, const ObjectInstanceID & marketId, const CGHeroInstance * visitor, QueryID queryID)
 {
 	LOG_TRACE(logAi);
 	NET_EVENT_HANDLER;

--- a/AI/VCAI/VCAI.cpp
+++ b/AI/VCAI/VCAI.cpp
@@ -2130,7 +2130,7 @@ void VCAI::tryRealize(Goals::Trade & g) //trade
 				//TODO trade only as much as needed
 				if (toGive) //don't try to sell 0 resources
 				{
-					cb->trade(m, EMarketMode::RESOURCE_RESOURCE, res, GameResID(g.resID), toGive);
+					cb->trade(m->getObjInstanceID(), EMarketMode::RESOURCE_RESOURCE, res, GameResID(g.resID), toGive);
 					acquiredResources = static_cast<int>(toGet * (it->resVal / toGive));
 					logAi->debug("Traded %d of %s for %d of %s at %s", toGive, res, acquiredResources, g.resID, obj->getObjectName());
 				}

--- a/AI/VCAI/VCAI.cpp
+++ b/AI/VCAI/VCAI.cpp
@@ -594,7 +594,7 @@ void VCAI::heroBonusChanged(const CGHeroInstance * hero, const Bonus & bonus, bo
 	NET_EVENT_HANDLER;
 }
 
-void VCAI::showMarketWindow(const IMarket * market, const ObjectInstanceID & marketId, const CGHeroInstance * visitor, QueryID queryID)
+void VCAI::showMarketWindow(const IMarket * market, const CGHeroInstance * visitor, QueryID queryID)
 {
 	LOG_TRACE(logAi);
 	NET_EVENT_HANDLER;

--- a/AI/VCAI/VCAI.h
+++ b/AI/VCAI/VCAI.h
@@ -184,7 +184,7 @@ public:
 	void objectPropertyChanged(const SetObjectProperty * sop) override;
 	void buildChanged(const CGTownInstance * town, BuildingID buildingID, int what) override;
 	void heroBonusChanged(const CGHeroInstance * hero, const Bonus & bonus, bool gain) override;
-	void showMarketWindow(const IMarket * market, const ObjectInstanceID & marketId, const CGHeroInstance * visitor, QueryID queryID) override;
+	void showMarketWindow(const IMarket * market, const CGHeroInstance * visitor, QueryID queryID) override;
 	void showWorldViewEx(const std::vector<ObjectPosInfo> & objectPositions, bool showTerrain) override;
 
 	void battleStart(const BattleID & battleID, const CCreatureSet * army1, const CCreatureSet * army2, int3 tile, const CGHeroInstance * hero1, const CGHeroInstance * hero2, BattleSide side, bool replayAllowed) override;

--- a/AI/VCAI/VCAI.h
+++ b/AI/VCAI/VCAI.h
@@ -184,7 +184,7 @@ public:
 	void objectPropertyChanged(const SetObjectProperty * sop) override;
 	void buildChanged(const CGTownInstance * town, BuildingID buildingID, int what) override;
 	void heroBonusChanged(const CGHeroInstance * hero, const Bonus & bonus, bool gain) override;
-	void showMarketWindow(const IMarket * market, const CGHeroInstance * visitor, QueryID queryID) override;
+	void showMarketWindow(const IMarket * market, const ObjectInstanceID & marketId, const CGHeroInstance * visitor, QueryID queryID) override;
 	void showWorldViewEx(const std::vector<ObjectPosInfo> & objectPositions, bool showTerrain) override;
 
 	void battleStart(const BattleID & battleID, const CCreatureSet * army1, const CCreatureSet * army2, int3 tile, const CGHeroInstance * hero1, const CGHeroInstance * hero2, BattleSide side, bool replayAllowed) override;

--- a/CCallback.cpp
+++ b/CCallback.cpp
@@ -266,15 +266,15 @@ void CCallback::buyArtifact(const CGHeroInstance *hero, ArtifactID aid)
 	sendRequest(&pack);
 }
 
-void CCallback::trade(const IMarket * market, EMarketMode mode, TradeItemSell id1, TradeItemBuy id2, ui32 val1, const CGHeroInstance * hero)
+void CCallback::trade(const ObjectInstanceID marketId, EMarketMode mode, TradeItemSell id1, TradeItemBuy id2, ui32 val1, const CGHeroInstance * hero)
 {
-	trade(market, mode, std::vector(1, id1), std::vector(1, id2), std::vector(1, val1), hero);
+	trade(marketId, mode, std::vector(1, id1), std::vector(1, id2), std::vector(1, val1), hero);
 }
 
-void CCallback::trade(const IMarket * market, EMarketMode mode, const std::vector<TradeItemSell> & id1, const std::vector<TradeItemBuy> & id2, const std::vector<ui32> & val1, const CGHeroInstance * hero)
+void CCallback::trade(const ObjectInstanceID marketId, EMarketMode mode, const std::vector<TradeItemSell> & id1, const std::vector<TradeItemBuy> & id2, const std::vector<ui32> & val1, const CGHeroInstance * hero)
 {
 	TradeOnMarketplace pack;
-	pack.marketId = dynamic_cast<const CGObjectInstance *>(market)->id;
+	pack.marketId = marketId;
 	pack.heroId = hero ? hero->id : ObjectInstanceID();
 	pack.mode = mode;
 	pack.r1 = id1;

--- a/CCallback.h
+++ b/CCallback.h
@@ -80,8 +80,8 @@ public:
 	virtual bool upgradeCreature(const CArmedInstance *obj, SlotID stackPos, CreatureID newID=CreatureID::NONE)=0; //if newID==-1 then best possible upgrade will be made
 	virtual void swapGarrisonHero(const CGTownInstance *town)=0;
 
-	virtual void trade(const ObjectInstanceID marketId, EMarketMode mode, TradeItemSell id1, TradeItemBuy id2, ui32 val1, const CGHeroInstance * hero = nullptr)=0; //mode==0: sell val1 units of id1 resource for id2 resiurce
-	virtual void trade(const ObjectInstanceID marketId, EMarketMode mode, const std::vector<TradeItemSell> & id1, const std::vector<TradeItemBuy> & id2, const std::vector<ui32> & val1, const CGHeroInstance * hero = nullptr)=0;
+	virtual void trade(const ObjectInstanceID marketId, EMarketMode mode, TradeItemSell id1, TradeItemBuy id2, ui32 val1, const CGHeroInstance * hero)=0; //mode==0: sell val1 units of id1 resource for id2 resiurce
+	virtual void trade(const ObjectInstanceID marketId, EMarketMode mode, const std::vector<TradeItemSell> & id1, const std::vector<TradeItemBuy> & id2, const std::vector<ui32> & val1, const CGHeroInstance * hero)=0;
 
 	virtual int selectionMade(int selection, QueryID queryID) =0;
 	virtual int sendQueryReply(std::optional<int32_t> reply, QueryID queryID) =0;

--- a/CCallback.h
+++ b/CCallback.h
@@ -34,7 +34,6 @@ class IBattleEventsReceiver;
 class IGameEventsReceiver;
 struct ArtifactLocation;
 class BattleStateInfoForRetreat;
-class IMarket;
 
 VCMI_LIB_NAMESPACE_END
 
@@ -81,8 +80,8 @@ public:
 	virtual bool upgradeCreature(const CArmedInstance *obj, SlotID stackPos, CreatureID newID=CreatureID::NONE)=0; //if newID==-1 then best possible upgrade will be made
 	virtual void swapGarrisonHero(const CGTownInstance *town)=0;
 
-	virtual void trade(const IMarket * market, EMarketMode mode, TradeItemSell id1, TradeItemBuy id2, ui32 val1, const CGHeroInstance * hero = nullptr)=0; //mode==0: sell val1 units of id1 resource for id2 resiurce
-	virtual void trade(const IMarket * market, EMarketMode mode, const std::vector<TradeItemSell> & id1, const std::vector<TradeItemBuy> & id2, const std::vector<ui32> & val1, const CGHeroInstance * hero = nullptr)=0;
+	virtual void trade(const ObjectInstanceID marketId, EMarketMode mode, TradeItemSell id1, TradeItemBuy id2, ui32 val1, const CGHeroInstance * hero = nullptr)=0; //mode==0: sell val1 units of id1 resource for id2 resiurce
+	virtual void trade(const ObjectInstanceID marketId, EMarketMode mode, const std::vector<TradeItemSell> & id1, const std::vector<TradeItemBuy> & id2, const std::vector<ui32> & val1, const CGHeroInstance * hero = nullptr)=0;
 
 	virtual int selectionMade(int selection, QueryID queryID) =0;
 	virtual int sendQueryReply(std::optional<int32_t> reply, QueryID queryID) =0;
@@ -190,8 +189,8 @@ public:
 	void endTurn() override;
 	void swapGarrisonHero(const CGTownInstance *town) override;
 	void buyArtifact(const CGHeroInstance *hero, ArtifactID aid) override;
-	void trade(const IMarket * market, EMarketMode mode, TradeItemSell id1, TradeItemBuy id2, ui32 val1, const CGHeroInstance * hero = nullptr) override;
-	void trade(const IMarket * market, EMarketMode mode, const std::vector<TradeItemSell> & id1, const std::vector<TradeItemBuy> & id2, const std::vector<ui32> & val1, const CGHeroInstance * hero = nullptr) override;
+	void trade(const ObjectInstanceID marketId, EMarketMode mode, TradeItemSell id1, TradeItemBuy id2, ui32 val1, const CGHeroInstance * hero = nullptr) override;
+	void trade(const ObjectInstanceID marketId, EMarketMode mode, const std::vector<TradeItemSell> & id1, const std::vector<TradeItemBuy> & id2, const std::vector<ui32> & val1, const CGHeroInstance * hero = nullptr) override;
 	void setFormation(const CGHeroInstance * hero, EArmyFormation mode) override;
 	void recruitHero(const CGObjectInstance *townOrTavern, const CGHeroInstance *hero, const HeroTypeID & nextHero=HeroTypeID::NONE) override;
 	void save(const std::string &fname) override;

--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -1632,7 +1632,7 @@ void CPlayerInterface::battleNewRoundFirst(const BattleID & battleID)
 	battleInt->newRoundFirst();
 }
 
-void CPlayerInterface::showMarketWindow(const IMarket *market, const CGHeroInstance *visitor, QueryID queryID)
+void CPlayerInterface::showMarketWindow(const IMarket * market, const ObjectInstanceID & marketId, const CGHeroInstance * visitor, QueryID queryID)
 {
 	EVENT_HANDLER_CALLED_BY_CLIENT;
 	auto onWindowClosed = [this, queryID](){
@@ -1649,13 +1649,13 @@ void CPlayerInterface::showMarketWindow(const IMarket *market, const CGHeroInsta
 	}
 
 	if(market->allowsTrade(EMarketMode::ARTIFACT_EXP) && visitor->getAlignment() != EAlignment::EVIL)
-		GH.windows().createAndPushWindow<CMarketWindow>(market, visitor, onWindowClosed, EMarketMode::ARTIFACT_EXP);
+		GH.windows().createAndPushWindow<CMarketWindow>(market, visitor, marketId, onWindowClosed, EMarketMode::ARTIFACT_EXP);
 	else if(market->allowsTrade(EMarketMode::CREATURE_EXP) && visitor->getAlignment() != EAlignment::GOOD)
-		GH.windows().createAndPushWindow<CMarketWindow>(market, visitor, onWindowClosed, EMarketMode::CREATURE_EXP);
+		GH.windows().createAndPushWindow<CMarketWindow>(market, visitor, marketId, onWindowClosed, EMarketMode::CREATURE_EXP);
 	else if(market->allowsTrade(EMarketMode::CREATURE_UNDEAD))
 		GH.windows().createAndPushWindow<CTransformerWindow>(market, visitor, onWindowClosed);
 	else if(!market->availableModes().empty())
-		GH.windows().createAndPushWindow<CMarketWindow>(market, visitor, onWindowClosed, market->availableModes().front());
+		GH.windows().createAndPushWindow<CMarketWindow>(market, visitor, marketId, onWindowClosed, market->availableModes().front());
 }
 
 void CPlayerInterface::showUniversityWindow(const IMarket *market, const CGHeroInstance *visitor, QueryID queryID)

--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -1639,7 +1639,7 @@ void CPlayerInterface::showMarketWindow(const IMarket * market, const ObjectInst
 		cb->selectionMade(0, queryID);
 	};
 
-	if (market->allowsTrade(EMarketMode::ARTIFACT_EXP) && dynamic_cast<const CGArtifactsAltar*>(market) == nullptr)
+	if (market->allowsTrade(EMarketMode::ARTIFACT_EXP) && market->getArtifactsStorage() == nullptr)
 	{
 		// compatibility check, safe to remove for 1.6
 		// 1.4 saves loaded in 1.5 will not be able to visit Altar of Sacrifice due to Altar now requiring different map object class
@@ -1654,8 +1654,8 @@ void CPlayerInterface::showMarketWindow(const IMarket * market, const ObjectInst
 		GH.windows().createAndPushWindow<CMarketWindow>(market, visitor, marketId, onWindowClosed, EMarketMode::CREATURE_EXP);
 	else if(market->allowsTrade(EMarketMode::CREATURE_UNDEAD))
 		GH.windows().createAndPushWindow<CTransformerWindow>(market, visitor, onWindowClosed);
-	else if(!market->availableModes().empty())
-		GH.windows().createAndPushWindow<CMarketWindow>(market, visitor, marketId, onWindowClosed, market->availableModes().front());
+	else if(vstd::contains(market->availableModes(), EMarketMode::RESOURCE_RESOURCE))
+		GH.windows().createAndPushWindow<CMarketWindow>(market, visitor, marketId, onWindowClosed, EMarketMode::RESOURCE_RESOURCE);
 }
 
 void CPlayerInterface::showUniversityWindow(const IMarket *market, const CGHeroInstance *visitor, QueryID queryID)

--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -1632,7 +1632,7 @@ void CPlayerInterface::battleNewRoundFirst(const BattleID & battleID)
 	battleInt->newRoundFirst();
 }
 
-void CPlayerInterface::showMarketWindow(const IMarket * market, const ObjectInstanceID & marketId, const CGHeroInstance * visitor, QueryID queryID)
+void CPlayerInterface::showMarketWindow(const IMarket * market, const CGHeroInstance * visitor, QueryID queryID)
 {
 	EVENT_HANDLER_CALLED_BY_CLIENT;
 	auto onWindowClosed = [this, queryID](){
@@ -1649,13 +1649,13 @@ void CPlayerInterface::showMarketWindow(const IMarket * market, const ObjectInst
 	}
 
 	if(market->allowsTrade(EMarketMode::ARTIFACT_EXP) && visitor->getAlignment() != EAlignment::EVIL)
-		GH.windows().createAndPushWindow<CMarketWindow>(market, visitor, marketId, onWindowClosed, EMarketMode::ARTIFACT_EXP);
+		GH.windows().createAndPushWindow<CMarketWindow>(market, visitor, onWindowClosed, EMarketMode::ARTIFACT_EXP);
 	else if(market->allowsTrade(EMarketMode::CREATURE_EXP) && visitor->getAlignment() != EAlignment::GOOD)
-		GH.windows().createAndPushWindow<CMarketWindow>(market, visitor, marketId, onWindowClosed, EMarketMode::CREATURE_EXP);
+		GH.windows().createAndPushWindow<CMarketWindow>(market, visitor, onWindowClosed, EMarketMode::CREATURE_EXP);
 	else if(market->allowsTrade(EMarketMode::CREATURE_UNDEAD))
 		GH.windows().createAndPushWindow<CTransformerWindow>(market, visitor, onWindowClosed);
 	else if(vstd::contains(market->availableModes(), EMarketMode::RESOURCE_RESOURCE))
-		GH.windows().createAndPushWindow<CMarketWindow>(market, visitor, marketId, onWindowClosed, EMarketMode::RESOURCE_RESOURCE);
+		GH.windows().createAndPushWindow<CMarketWindow>(market, visitor, onWindowClosed, EMarketMode::RESOURCE_RESOURCE);
 }
 
 void CPlayerInterface::showUniversityWindow(const IMarket *market, const CGHeroInstance *visitor, QueryID queryID)

--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -1654,8 +1654,17 @@ void CPlayerInterface::showMarketWindow(const IMarket * market, const CGHeroInst
 		GH.windows().createAndPushWindow<CMarketWindow>(market, visitor, onWindowClosed, EMarketMode::CREATURE_EXP);
 	else if(market->allowsTrade(EMarketMode::CREATURE_UNDEAD))
 		GH.windows().createAndPushWindow<CTransformerWindow>(market, visitor, onWindowClosed);
-	else if(vstd::contains(market->availableModes(), EMarketMode::RESOURCE_RESOURCE))
-		GH.windows().createAndPushWindow<CMarketWindow>(market, visitor, onWindowClosed, EMarketMode::RESOURCE_RESOURCE);
+	else if (!market->availableModes().empty())
+		for(auto mode = EMarketMode::RESOURCE_RESOURCE; mode != EMarketMode::MARKET_AFTER_LAST_PLACEHOLDER; mode = vstd::next(mode, 1))
+		{
+			if(vstd::contains(market->availableModes(), mode))
+			{
+				GH.windows().createAndPushWindow<CMarketWindow>(market, visitor, onWindowClosed, mode);
+				break;
+			}
+		}
+	else
+		onWindowClosed();
 }
 
 void CPlayerInterface::showUniversityWindow(const IMarket *market, const CGHeroInstance *visitor, QueryID queryID)

--- a/client/CPlayerInterface.h
+++ b/client/CPlayerInterface.h
@@ -120,7 +120,7 @@ protected: // Call-ins from server, should not be called directly, but only via 
 	void showTeleportDialog(const CGHeroInstance * hero, TeleportChannelID channel, TTeleportExitsList exits, bool impassable, QueryID askID) override;
 	void showGarrisonDialog(const CArmedInstance *up, const CGHeroInstance *down, bool removableUnits, QueryID queryID) override;
 	void showMapObjectSelectDialog(QueryID askID, const Component & icon, const MetaString & title, const MetaString & description, const std::vector<ObjectInstanceID> & objects) override;
-	void showMarketWindow(const IMarket *market, const CGHeroInstance *visitor, QueryID queryID) override;
+	void showMarketWindow(const IMarket * market, const ObjectInstanceID & marketId, const CGHeroInstance * visitor, QueryID queryID) override;
 	void showUniversityWindow(const IMarket *market, const CGHeroInstance *visitor, QueryID queryID) override;
 	void showHillFortWindow(const CGObjectInstance *object, const CGHeroInstance *visitor) override;
 	void advmapSpellCast(const CGHeroInstance * caster, SpellID spellID) override; //called when a hero casts a spell

--- a/client/CPlayerInterface.h
+++ b/client/CPlayerInterface.h
@@ -120,7 +120,7 @@ protected: // Call-ins from server, should not be called directly, but only via 
 	void showTeleportDialog(const CGHeroInstance * hero, TeleportChannelID channel, TTeleportExitsList exits, bool impassable, QueryID askID) override;
 	void showGarrisonDialog(const CArmedInstance *up, const CGHeroInstance *down, bool removableUnits, QueryID queryID) override;
 	void showMapObjectSelectDialog(QueryID askID, const Component & icon, const MetaString & title, const MetaString & description, const std::vector<ObjectInstanceID> & objects) override;
-	void showMarketWindow(const IMarket * market, const ObjectInstanceID & marketId, const CGHeroInstance * visitor, QueryID queryID) override;
+	void showMarketWindow(const IMarket * market, const CGHeroInstance * visitor, QueryID queryID) override;
 	void showUniversityWindow(const IMarket *market, const CGHeroInstance *visitor, QueryID queryID) override;
 	void showHillFortWindow(const CGObjectInstance *object, const CGHeroInstance *visitor) override;
 	void advmapSpellCast(const CGHeroInstance * caster, SpellID spellID) override; //called when a hero casts a spell

--- a/client/NetPacksClient.cpp
+++ b/client/NetPacksClient.cpp
@@ -1010,7 +1010,7 @@ void ApplyClientNetPackVisitor::visitOpenWindow(OpenWindow & pack)
 			const CGObjectInstance *obj = cl.getObj(ObjectInstanceID(pack.object));
 			const CGHeroInstance *hero = cl.getHero(ObjectInstanceID(pack.visitor));
 			const auto *market = dynamic_cast<const IMarket*>(obj);
-			callInterfaceIfPresent(cl, cl.getTile(obj->visitablePos())->visitableObjects.back()->tempOwner, &IGameEventsReceiver::showMarketWindow, market, pack.object, hero, pack.queryID);
+			callInterfaceIfPresent(cl, cl.getTile(obj->visitablePos())->visitableObjects.back()->tempOwner, &IGameEventsReceiver::showMarketWindow, market, hero, pack.queryID);
 		}
 		break;
 	case EOpenWindowMode::HILL_FORT_WINDOW:

--- a/client/NetPacksClient.cpp
+++ b/client/NetPacksClient.cpp
@@ -999,7 +999,7 @@ void ApplyClientNetPackVisitor::visitOpenWindow(OpenWindow & pack)
 	case EOpenWindowMode::UNIVERSITY_WINDOW:
 		{
 			//displays University window (when hero enters University on adventure map)
-			const auto * market = dynamic_cast<const IMarket*>(cl.getObj(ObjectInstanceID(pack.object)));
+			const auto * market = cl.getMarket(ObjectInstanceID(pack.object));
 			const CGHeroInstance *hero = cl.getHero(ObjectInstanceID(pack.visitor));
 			callInterfaceIfPresent(cl, hero->tempOwner, &IGameEventsReceiver::showUniversityWindow, market, hero, pack.queryID);
 		}
@@ -1009,7 +1009,7 @@ void ApplyClientNetPackVisitor::visitOpenWindow(OpenWindow & pack)
 			//displays Thieves' Guild window (when hero enters Den of Thieves)
 			const CGObjectInstance *obj = cl.getObj(ObjectInstanceID(pack.object));
 			const CGHeroInstance *hero = cl.getHero(ObjectInstanceID(pack.visitor));
-			const auto *market = dynamic_cast<const IMarket*>(obj);
+			const auto market = cl.getMarket(pack.object);
 			callInterfaceIfPresent(cl, cl.getTile(obj->visitablePos())->visitableObjects.back()->tempOwner, &IGameEventsReceiver::showMarketWindow, market, hero, pack.queryID);
 		}
 		break;

--- a/client/NetPacksClient.cpp
+++ b/client/NetPacksClient.cpp
@@ -1010,7 +1010,7 @@ void ApplyClientNetPackVisitor::visitOpenWindow(OpenWindow & pack)
 			const CGObjectInstance *obj = cl.getObj(ObjectInstanceID(pack.object));
 			const CGHeroInstance *hero = cl.getHero(ObjectInstanceID(pack.visitor));
 			const auto *market = dynamic_cast<const IMarket*>(obj);
-			callInterfaceIfPresent(cl, cl.getTile(obj->visitablePos())->visitableObjects.back()->tempOwner, &IGameEventsReceiver::showMarketWindow, market, hero, pack.queryID);
+			callInterfaceIfPresent(cl, cl.getTile(obj->visitablePos())->visitableObjects.back()->tempOwner, &IGameEventsReceiver::showMarketWindow, market, pack.object, hero, pack.queryID);
 		}
 		break;
 	case EOpenWindowMode::HILL_FORT_WINDOW:

--- a/client/adventureMap/AdventureMapShortcuts.cpp
+++ b/client/adventureMap/AdventureMapShortcuts.cpp
@@ -432,7 +432,7 @@ void AdventureMapShortcuts::showMarketplace()
 	}
 
 	if(townWithMarket) //if any town has marketplace, open window
-		GH.windows().createAndPushWindow<CMarketWindow>(townWithMarket, nullptr, townWithMarket->id, nullptr, EMarketMode::RESOURCE_RESOURCE);
+		GH.windows().createAndPushWindow<CMarketWindow>(townWithMarket, nullptr, nullptr, EMarketMode::RESOURCE_RESOURCE);
 	else //if not - complain
 		LOCPLINT->showInfoDialog(CGI->generaltexth->translate("vcmi.adventureMap.noTownWithMarket"));
 }

--- a/client/adventureMap/AdventureMapShortcuts.cpp
+++ b/client/adventureMap/AdventureMapShortcuts.cpp
@@ -432,7 +432,7 @@ void AdventureMapShortcuts::showMarketplace()
 	}
 
 	if(townWithMarket) //if any town has marketplace, open window
-		GH.windows().createAndPushWindow<CMarketWindow>(townWithMarket, nullptr, nullptr, EMarketMode::RESOURCE_RESOURCE);
+		GH.windows().createAndPushWindow<CMarketWindow>(townWithMarket, nullptr, townWithMarket->id, nullptr, EMarketMode::RESOURCE_RESOURCE);
 	else //if not - complain
 		LOCPLINT->showInfoDialog(CGI->generaltexth->translate("vcmi.adventureMap.noTownWithMarket"));
 }

--- a/client/widgets/MiscWidgets.cpp
+++ b/client/widgets/MiscWidgets.cpp
@@ -478,7 +478,7 @@ void CInteractableTownTooltip::init(const CGTownInstance * town)
 		{
 			if(town->builtBuildings.count(BuildingID::MARKETPLACE))
 			{
-				GH.windows().createAndPushWindow<CMarketWindow>(town, nullptr, nullptr, EMarketMode::RESOURCE_RESOURCE);
+				GH.windows().createAndPushWindow<CMarketWindow>(town, nullptr, town->id, nullptr, EMarketMode::RESOURCE_RESOURCE);
 				return;
 			}
 		}

--- a/client/widgets/MiscWidgets.cpp
+++ b/client/widgets/MiscWidgets.cpp
@@ -464,7 +464,7 @@ void CInteractableTownTooltip::init(const CGTownInstance * town)
 		std::vector<const CGTownInstance*> towns = LOCPLINT->cb->getTownsInfo(true);
 		for(auto & town : towns)
 		{
-			if(town->id == townId && town->builtBuildings.count(BuildingID::TAVERN))
+			if(town->id == townId && town->hasBuilt(BuildingID::TAVERN))
 				LOCPLINT->showTavernWindow(town, nullptr, QueryID::NONE);
 		}
 	}, [town]{
@@ -476,9 +476,9 @@ void CInteractableTownTooltip::init(const CGTownInstance * town)
 		std::vector<const CGTownInstance*> towns = LOCPLINT->cb->getTownsInfo(true);
 		for(auto & town : towns)
 		{
-			if(town->builtBuildings.count(BuildingID::MARKETPLACE))
+			if(town->hasBuilt(BuildingID::MARKETPLACE))
 			{
-				GH.windows().createAndPushWindow<CMarketWindow>(town, nullptr, town->id, nullptr, EMarketMode::RESOURCE_RESOURCE);
+				GH.windows().createAndPushWindow<CMarketWindow>(town, nullptr, nullptr, EMarketMode::RESOURCE_RESOURCE);
 				return;
 			}
 		}

--- a/client/widgets/markets/CAltarArtifacts.cpp
+++ b/client/widgets/markets/CAltarArtifacts.cpp
@@ -31,8 +31,8 @@ CAltarArtifacts::CAltarArtifacts(const IMarket * market, const CGHeroInstance * 
 {
 	OBJECT_CONSTRUCTION;
 
-	assert(dynamic_cast<const CGArtifactsAltar*>(market));
-	altarArtifacts = dynamic_cast<const CGArtifactsAltar*>(market);
+	assert(market->getArtifactsStorage());
+	altarArtifactsStorage = market->getArtifactsStorage();
 
 	deal = std::make_shared<CButton>(Point(269, 520), AnimationPath::builtin("ALTSACR.DEF"),
 		CGI->generaltexth->zelp[585], [this]() {CAltarArtifacts::makeDeal(); }, EShortcut::MARKET_DEAL);
@@ -124,7 +124,7 @@ std::shared_ptr<CArtifactsOfHeroAltar> CAltarArtifacts::getAOHset() const
 
 void CAltarArtifacts::updateAltarSlots()
 {
-	assert(altarArtifacts->artifactsInBackpack.size() <= GameConstants::ALTAR_ARTIFACTS_SLOTS);
+	assert(altarArtifactsStorage->artifactsInBackpack.size() <= GameConstants::ALTAR_ARTIFACTS_SLOTS);
 	assert(tradeSlotsMap.size() <= GameConstants::ALTAR_ARTIFACTS_SLOTS);
 	
 	auto tradeSlotsMapNewArts = tradeSlotsMap;
@@ -145,12 +145,12 @@ void CAltarArtifacts::updateAltarSlots()
 	for(auto & tradeSlot : tradeSlotsMapNewArts)
 	{
 		assert(tradeSlot.first->id == -1);
-		assert(altarArtifacts->getArtPos(tradeSlot.second) != ArtifactPosition::PRE_FIRST);
+		assert(altarArtifactsStorage->getArtPos(tradeSlot.second) != ArtifactPosition::PRE_FIRST);
 		tradeSlot.first->setID(tradeSlot.second->getTypeId().num);
 		tradeSlot.first->subtitle->setText(std::to_string(calcExpCost(tradeSlot.second->getTypeId())));
 	}
 
-	auto newArtsFromBulkMove = altarArtifacts->artifactsInBackpack;
+	auto newArtsFromBulkMove = altarArtifactsStorage->artifactsInBackpack;
 	for(const auto & [altarSlot, art] : tradeSlotsMap)
 	{
 		newArtsFromBulkMove.erase(std::remove_if(newArtsFromBulkMove.begin(), newArtsFromBulkMove.end(), [artForRemove = art](auto & slotInfo)
@@ -178,7 +178,7 @@ void CAltarArtifacts::putBackArtifacts()
 {
 	// TODO: If the backpack capacity limit is enabled, artifacts may remain on the altar.
 	// Perhaps should be erased in CGameHandler::objectVisitEnded if id of visited object will be available
-	if(!altarArtifacts->artifactsInBackpack.empty())
+	if(!altarArtifactsStorage->artifactsInBackpack.empty())
 		LOCPLINT->cb->bulkMoveArtifacts(heroArts->altarId, heroArts->getHero()->id, false, true, true);
 }
 
@@ -199,7 +199,7 @@ void CAltarArtifacts::onSlotClickPressed(const std::shared_ptr<CTradeableItem> &
 
 	if(const auto pickedArtInst = heroArts->getPickedArtifact())
 	{
-		if(pickedArtInst->canBePutAt(altarArtifacts))
+		if(pickedArtInst->canBePutAt(altarArtifactsStorage.get()))
 		{
 			if(pickedArtInst->artType->isTradable())
 			{
@@ -220,7 +220,7 @@ void CAltarArtifacts::onSlotClickPressed(const std::shared_ptr<CTradeableItem> &
 	else if(altarSlot->id != -1)
 	{
 		assert(tradeSlotsMap.at(altarSlot));
-		const auto slot = altarArtifacts->getArtPos(tradeSlotsMap.at(altarSlot));
+		const auto slot = altarArtifactsStorage->getArtPos(tradeSlotsMap.at(altarSlot));
 		assert(slot != ArtifactPosition::PRE_FIRST);
 		LOCPLINT->cb->swapArtifacts(ArtifactLocation(heroArts->altarId, slot),
 			ArtifactLocation(hero->id, GH.isKeyboardCtrlDown() ? ArtifactPosition::FIRST_AVAILABLE : ArtifactPosition::TRANSITION_POS));

--- a/client/widgets/markets/CAltarArtifacts.cpp
+++ b/client/widgets/markets/CAltarArtifacts.cpp
@@ -26,7 +26,7 @@
 #include "../../../lib/mapObjects/CGHeroInstance.h"
 #include "../../../lib/mapObjects/CGMarket.h"
 
-CAltarArtifacts::CAltarArtifacts(const IMarket * market, const CGHeroInstance * hero, const ObjectInstanceID & marketId)
+CAltarArtifacts::CAltarArtifacts(const IMarket * market, const CGHeroInstance * hero)
 	: CMarketBase(market, hero)
 {
 	OBJECT_CONSTRUCTION;
@@ -50,7 +50,9 @@ CAltarArtifacts::CAltarArtifacts(const IMarket * market, const CGHeroInstance * 
 	// Hero's artifacts
 	heroArts = std::make_shared<CArtifactsOfHeroAltar>(Point(-365, -11));
 	heroArts->setHero(hero);
-	heroArts->altarId = marketId;
+	const auto mapObj = dynamic_cast<const CGObjectInstance*>(market);
+	assert(mapObj);
+	heroArts->altarId = mapObj->id;
 
 	// Altar
 	offerTradePanel = std::make_shared<ArtifactsAltarPanel>([this](const std::shared_ptr<CTradeableItem> & altarSlot)

--- a/client/widgets/markets/CAltarArtifacts.cpp
+++ b/client/widgets/markets/CAltarArtifacts.cpp
@@ -26,14 +26,13 @@
 #include "../../../lib/mapObjects/CGHeroInstance.h"
 #include "../../../lib/mapObjects/CGMarket.h"
 
-CAltarArtifacts::CAltarArtifacts(const IMarket * market, const CGHeroInstance * hero)
+CAltarArtifacts::CAltarArtifacts(const IMarket * market, const CGHeroInstance * hero, const ObjectInstanceID & marketId)
 	: CMarketBase(market, hero)
 {
 	OBJECT_CONSTRUCTION;
 
 	assert(dynamic_cast<const CGArtifactsAltar*>(market));
-	auto altarObj = dynamic_cast<const CGArtifactsAltar*>(market);
-	altarArtifacts = altarObj;
+	altarArtifacts = dynamic_cast<const CGArtifactsAltar*>(market);
 
 	deal = std::make_shared<CButton>(Point(269, 520), AnimationPath::builtin("ALTSACR.DEF"),
 		CGI->generaltexth->zelp[585], [this]() {CAltarArtifacts::makeDeal(); }, EShortcut::MARKET_DEAL);
@@ -51,7 +50,7 @@ CAltarArtifacts::CAltarArtifacts(const IMarket * market, const CGHeroInstance * 
 	// Hero's artifacts
 	heroArts = std::make_shared<CArtifactsOfHeroAltar>(Point(-365, -11));
 	heroArts->setHero(hero);
-	heroArts->altarId = altarObj->id;
+	heroArts->altarId = marketId;
 
 	// Altar
 	offerTradePanel = std::make_shared<ArtifactsAltarPanel>([this](const std::shared_ptr<CTradeableItem> & altarSlot)

--- a/client/widgets/markets/CAltarArtifacts.cpp
+++ b/client/widgets/markets/CAltarArtifacts.cpp
@@ -24,7 +24,7 @@
 #include "../../../lib/networkPacks/ArtifactLocation.h"
 #include "../../../lib/texts/CGeneralTextHandler.h"
 #include "../../../lib/mapObjects/CGHeroInstance.h"
-#include "../../../lib/mapObjects/CGMarket.h"
+#include "../../../lib/mapObjects/IMarket.h"
 
 CAltarArtifacts::CAltarArtifacts(const IMarket * market, const CGHeroInstance * hero)
 	: CMarketBase(market, hero)
@@ -50,9 +50,7 @@ CAltarArtifacts::CAltarArtifacts(const IMarket * market, const CGHeroInstance * 
 	// Hero's artifacts
 	heroArts = std::make_shared<CArtifactsOfHeroAltar>(Point(-365, -11));
 	heroArts->setHero(hero);
-	const auto mapObj = dynamic_cast<const CGObjectInstance*>(market);
-	assert(mapObj);
-	heroArts->altarId = mapObj->id;
+	heroArts->altarId = market->getObjInstanceID();
 
 	// Altar
 	offerTradePanel = std::make_shared<ArtifactsAltarPanel>([this](const std::shared_ptr<CTradeableItem> & altarSlot)
@@ -105,7 +103,7 @@ void CAltarArtifacts::makeDeal()
 	{
 		positions.push_back(artInst->getId());
 	}
-	LOCPLINT->cb->trade(market, EMarketMode::ARTIFACT_EXP, positions, std::vector<TradeItemBuy>(), std::vector<ui32>(), hero);
+	LOCPLINT->cb->trade(market->getObjInstanceID(), EMarketMode::ARTIFACT_EXP, positions, std::vector<TradeItemBuy>(), std::vector<ui32>(), hero);
 	deselect();
 }
 

--- a/client/widgets/markets/CAltarArtifacts.h
+++ b/client/widgets/markets/CAltarArtifacts.h
@@ -26,7 +26,7 @@ public:
 	void putBackArtifacts();
 
 private:
-	const CArtifactSet * altarArtifacts;
+	std::shared_ptr<CArtifactSet> altarArtifactsStorage;
 	std::shared_ptr<CButton> sacrificeBackpackButton;
 	std::shared_ptr<CArtifactsOfHeroAltar> heroArts;
 	std::map<std::shared_ptr<CTradeableItem>, const CArtifactInstance*> tradeSlotsMap;

--- a/client/widgets/markets/CAltarArtifacts.h
+++ b/client/widgets/markets/CAltarArtifacts.h
@@ -15,7 +15,7 @@
 class CAltarArtifacts : public CExperienceAltar
 {
 public:
-	CAltarArtifacts(const IMarket * market, const CGHeroInstance * hero);
+	CAltarArtifacts(const IMarket * market, const CGHeroInstance * hero, const ObjectInstanceID & marketId);
 	TExpType calcExpAltarForHero() override;
 	void deselect() override;
 	void makeDeal() override;

--- a/client/widgets/markets/CAltarArtifacts.h
+++ b/client/widgets/markets/CAltarArtifacts.h
@@ -15,7 +15,7 @@
 class CAltarArtifacts : public CExperienceAltar
 {
 public:
-	CAltarArtifacts(const IMarket * market, const CGHeroInstance * hero, const ObjectInstanceID & marketId);
+	CAltarArtifacts(const IMarket * market, const CGHeroInstance * hero);
 	TExpType calcExpAltarForHero() override;
 	void deselect() override;
 	void makeDeal() override;

--- a/client/widgets/markets/CAltarCreatures.cpp
+++ b/client/widgets/markets/CAltarCreatures.cpp
@@ -23,7 +23,7 @@
 
 #include "../../../lib/texts/CGeneralTextHandler.h"
 #include "../../../lib/mapObjects/CGHeroInstance.h"
-#include "../../../lib/mapObjects/CGMarket.h"
+#include "../../../lib/mapObjects/IMarket.h"
 
 CAltarCreatures::CAltarCreatures(const IMarket * market, const CGHeroInstance * hero)
 	: CMarketBase(market, hero)
@@ -157,7 +157,7 @@ void CAltarCreatures::makeDeal()
 		}
 	}
 
-	LOCPLINT->cb->trade(market, EMarketMode::CREATURE_EXP, ids, {}, toSacrifice, hero);
+	LOCPLINT->cb->trade(market->getObjInstanceID(), EMarketMode::CREATURE_EXP, ids, {}, toSacrifice, hero);
 
 	for(int & units : unitsOnAltar)
 		units = 0;

--- a/client/widgets/markets/CArtifactsBuying.cpp
+++ b/client/widgets/markets/CArtifactsBuying.cpp
@@ -68,7 +68,7 @@ void CArtifactsBuying::makeDeal()
 {
 	if(ArtifactID(offerTradePanel->getSelectedItemId()).toArtifact()->canBePutAt(hero))
 	{
-		LOCPLINT->cb->trade(market, EMarketMode::RESOURCE_ARTIFACT, GameResID(bidTradePanel->getSelectedItemId()),
+		LOCPLINT->cb->trade(market->getObjInstanceID(), EMarketMode::RESOURCE_ARTIFACT, GameResID(bidTradePanel->getSelectedItemId()),
 			ArtifactID(offerTradePanel->getSelectedItemId()), offerQty, hero);
 		CMarketTraderText::makeDeal();
 		deselect();

--- a/client/widgets/markets/CArtifactsBuying.cpp
+++ b/client/widgets/markets/CArtifactsBuying.cpp
@@ -11,7 +11,6 @@
 #include "StdInc.h"
 #include "CArtifactsBuying.h"
 
-#include "../../gui/CGuiHandler.h"
 #include "../../gui/Shortcut.h"
 #include "../../widgets/Buttons.h"
 #include "../../widgets/TextControls.h"
@@ -21,24 +20,16 @@
 
 #include "../../../CCallback.h"
 
-#include "../../../lib/entities/building/CBuilding.h"
-#include "../../../lib/entities/faction/CTownHandler.h"
 #include "../../../lib/mapObjects/CGHeroInstance.h"
-#include "../../../lib/mapObjects/CGMarket.h"
-#include "../../../lib/mapObjects/CGTownInstance.h"
+#include "../../../lib/mapObjects/IMarket.h"
 #include "../../../lib/texts/CGeneralTextHandler.h"
 
-CArtifactsBuying::CArtifactsBuying(const IMarket * market, const CGHeroInstance * hero)
+CArtifactsBuying::CArtifactsBuying(const IMarket * market, const CGHeroInstance * hero, const std::string & title)
 	: CMarketBase(market, hero)
 	, CResourcesSelling([this](const std::shared_ptr<CTradeableItem> & heroSlot){CArtifactsBuying::onSlotClickPressed(heroSlot, bidTradePanel);})
 {
 	OBJECT_CONSTRUCTION;
 
-	std::string title;
-	if(auto townMarket = dynamic_cast<const CGTownInstance*>(market))
-		title = (*CGI->townh)[townMarket->getFaction()]->town->buildings[BuildingID::ARTIFACT_MERCHANT]->getNameTranslated();
-	else
-		title = CGI->generaltexth->allTexts[349];
 	labels.emplace_back(std::make_shared<CLabel>(titlePos.x, titlePos.y, FONT_BIG, ETextAlignment::CENTER, Colors::YELLOW, title));
 	deal = std::make_shared<CButton>(dealButtonPos, AnimationPath::builtin("TPMRKB.DEF"),
 		CGI->generaltexth->zelp[595], [this](){CArtifactsBuying::makeDeal();}, EShortcut::MARKET_DEAL);

--- a/client/widgets/markets/CArtifactsBuying.h
+++ b/client/widgets/markets/CArtifactsBuying.h
@@ -14,7 +14,7 @@
 class CArtifactsBuying : public CResourcesSelling, public CMarketTraderText
 {
 public:
-	CArtifactsBuying(const IMarket * market, const CGHeroInstance * hero);
+	CArtifactsBuying(const IMarket * market, const CGHeroInstance * hero, const std::string & title);
 	void deselect() override;
 	void makeDeal() override;
 

--- a/client/widgets/markets/CArtifactsSelling.cpp
+++ b/client/widgets/markets/CArtifactsSelling.cpp
@@ -78,7 +78,8 @@ void CArtifactsSelling::makeDeal()
 {
 	const auto art = hero->getArt(selectedHeroSlot);
 	assert(art);
-	LOCPLINT->cb->trade(market, EMarketMode::ARTIFACT_RESOURCE, art->getId(), GameResID(offerTradePanel->getSelectedItemId()), offerQty, hero);
+	LOCPLINT->cb->trade(market->getObjInstanceID(), EMarketMode::ARTIFACT_RESOURCE, art->getId(),
+		GameResID(offerTradePanel->getSelectedItemId()), offerQty, hero);
 	CMarketTraderText::makeDeal();
 }
 

--- a/client/widgets/markets/CArtifactsSelling.cpp
+++ b/client/widgets/markets/CArtifactsSelling.cpp
@@ -22,26 +22,17 @@
 #include "../../../CCallback.h"
 
 #include "../../../lib/CArtifactInstance.h"
-#include "../../../lib/entities/building/CBuilding.h"
-#include "../../../lib/entities/faction/CTownHandler.h"
 #include "../../../lib/mapObjects/CGHeroInstance.h"
-#include "../../../lib/mapObjects/CGMarket.h"
-#include "../../../lib/mapObjects/CGTownInstance.h"
+#include "../../../lib/mapObjects/IMarket.h"
 #include "../../../lib/texts/CGeneralTextHandler.h"
 
-CArtifactsSelling::CArtifactsSelling(const IMarket * market, const CGHeroInstance * hero)
+CArtifactsSelling::CArtifactsSelling(const IMarket * market, const CGHeroInstance * hero, const std::string & title)
 	: CMarketBase(market, hero)
 	, CResourcesBuying(
 		[this](const std::shared_ptr<CTradeableItem> & resSlot){CArtifactsSelling::onSlotClickPressed(resSlot, offerTradePanel);},
 		[this](){CArtifactsSelling::updateSubtitles();})
 {
 	OBJECT_CONSTRUCTION;
-
-	std::string title;
-	if(const auto townMarket = dynamic_cast<const CGTownInstance*>(market))
-		title = (*CGI->townh)[townMarket->getFaction()]->town->buildings[BuildingID::ARTIFACT_MERCHANT]->getNameTranslated();
-	else if(const auto mapMarket = dynamic_cast<const CGMarket*>(market))
-		title = mapMarket->title;
 
 	labels.emplace_back(std::make_shared<CLabel>(titlePos.x, titlePos.y, FONT_BIG, ETextAlignment::CENTER, Colors::YELLOW, title));
 	labels.push_back(std::make_shared<CLabel>(155, 56, FONT_SMALL, ETextAlignment::CENTER, Colors::WHITE, boost::str(boost::format(CGI->generaltexth->allTexts[271]) % hero->getNameTranslated())));

--- a/client/widgets/markets/CArtifactsSelling.h
+++ b/client/widgets/markets/CArtifactsSelling.h
@@ -15,7 +15,7 @@
 class CArtifactsSelling : public CResourcesBuying, public CMarketTraderText
 {
 public:
-	CArtifactsSelling(const IMarket * market, const CGHeroInstance * hero);
+	CArtifactsSelling(const IMarket * market, const CGHeroInstance * hero, const std::string & title);
 	void deselect() override;
 	void makeDeal() override;
 	void updateShowcases() override;

--- a/client/widgets/markets/CFreelancerGuild.cpp
+++ b/client/widgets/markets/CFreelancerGuild.cpp
@@ -23,7 +23,7 @@
 
 #include "../../../lib/texts/CGeneralTextHandler.h"
 #include "../../../lib/mapObjects/CGHeroInstance.h"
-#include "../../../lib/mapObjects/CGMarket.h"
+#include "../../../lib/mapObjects/IMarket.h"
 
 CFreelancerGuild::CFreelancerGuild(const IMarket * market, const CGHeroInstance * hero)
 	: CMarketBase(market, hero)
@@ -69,7 +69,7 @@ void CFreelancerGuild::makeDeal()
 {
 	if(auto toTrade = offerSlider->getValue(); toTrade != 0)
 	{
-		LOCPLINT->cb->trade(market, EMarketMode::CREATURE_RESOURCE, SlotID(bidTradePanel->highlightedSlot->serial), GameResID(offerTradePanel->getSelectedItemId()), bidQty * toTrade, hero);
+		LOCPLINT->cb->trade(market->getObjInstanceID(), EMarketMode::CREATURE_RESOURCE, SlotID(bidTradePanel->highlightedSlot->serial), GameResID(offerTradePanel->getSelectedItemId()), bidQty * toTrade, hero);
 		CMarketTraderText::makeDeal();
 		deselect();
 	}

--- a/client/widgets/markets/CMarketResources.cpp
+++ b/client/widgets/markets/CMarketResources.cpp
@@ -22,7 +22,7 @@
 #include "../../../CCallback.h"
 
 #include "../../../lib/texts/CGeneralTextHandler.h"
-#include "../../../lib/mapObjects/CGMarket.h"
+#include "../../../lib/mapObjects/IMarket.h"
 
 CMarketResources::CMarketResources(const IMarket * market, const CGHeroInstance * hero)
 	: CMarketBase(market, hero)
@@ -60,7 +60,7 @@ void CMarketResources::makeDeal()
 {
 	if(auto toTrade = offerSlider->getValue(); toTrade != 0)
 	{
-		LOCPLINT->cb->trade(market, EMarketMode::RESOURCE_RESOURCE, GameResID(bidTradePanel->getSelectedItemId()),
+		LOCPLINT->cb->trade(market->getObjInstanceID(), EMarketMode::RESOURCE_RESOURCE, GameResID(bidTradePanel->getSelectedItemId()),
 			GameResID(offerTradePanel->highlightedSlot->id), bidQty * toTrade, hero);
 		CMarketTraderText::makeDeal();
 		deselect();

--- a/client/widgets/markets/CTransferResources.cpp
+++ b/client/widgets/markets/CTransferResources.cpp
@@ -22,6 +22,7 @@
 #include "../../../CCallback.h"
 
 #include "../../../lib/texts/CGeneralTextHandler.h"
+#include "../../../lib/mapObjects/IMarket.h"
 #include "../../../lib/texts/MetaString.h"
 
 CTransferResources::CTransferResources(const IMarket * market, const CGHeroInstance * hero)
@@ -63,7 +64,7 @@ void CTransferResources::makeDeal()
 {
 	if(auto toTrade = offerSlider->getValue(); toTrade != 0)
 	{
-		LOCPLINT->cb->trade(market, EMarketMode::RESOURCE_PLAYER, GameResID(bidTradePanel->getSelectedItemId()),
+		LOCPLINT->cb->trade(market->getObjInstanceID(), EMarketMode::RESOURCE_PLAYER, GameResID(bidTradePanel->getSelectedItemId()),
 			PlayerColor(offerTradePanel->getSelectedItemId()), toTrade, hero);
 		CMarketTraderText::makeDeal();
 		deselect();

--- a/client/windows/CCastleInterface.cpp
+++ b/client/windows/CCastleInterface.cpp
@@ -586,9 +586,9 @@ void CCastleBuildings::recreate()
 
 	//Generate buildings list
 
-	auto buildingsCopy = town->builtBuildings;// a bit modified copy of built buildings
+	auto buildingsCopy = town->getBuildings();// a bit modified copy of built buildings
 
-	if(vstd::contains(town->builtBuildings, BuildingID::SHIPYARD))
+	if(town->hasBuilt(BuildingID::SHIPYARD))
 	{
 		auto bayPos = town->bestLocation();
 		if(!bayPos.valid())
@@ -729,7 +729,7 @@ void CCastleBuildings::buildingClicked(BuildingID building, BuildingSubID::EBuil
 		case BuildingID::MARKETPLACE:
 				// can't use allied marketplace
 				if (town->getOwner() == LOCPLINT->playerID)
-					GH.windows().createAndPushWindow<CMarketWindow>(town, town->visitingHero, town->id, nullptr, EMarketMode::RESOURCE_RESOURCE);
+					GH.windows().createAndPushWindow<CMarketWindow>(town, town->visitingHero, nullptr, EMarketMode::RESOURCE_RESOURCE);
 				else
 					enterBuilding(building);
 				break;
@@ -758,7 +758,7 @@ void CCastleBuildings::buildingClicked(BuildingID building, BuildingSubID::EBuil
 
 				case BuildingSubID::ARTIFACT_MERCHANT:
 						if(town->visitingHero)
-							GH.windows().createAndPushWindow<CMarketWindow>(town, town->visitingHero, town->id, nullptr, EMarketMode::RESOURCE_ARTIFACT);
+							GH.windows().createAndPushWindow<CMarketWindow>(town, town->visitingHero, nullptr, EMarketMode::RESOURCE_ARTIFACT);
 						else
 							LOCPLINT->showInfoDialog(boost::str(boost::format(CGI->generaltexth->allTexts[273]) % b->getNameTranslated())); //Only visiting heroes may use the %s.
 						break;
@@ -769,7 +769,7 @@ void CCastleBuildings::buildingClicked(BuildingID building, BuildingSubID::EBuil
 
 				case BuildingSubID::FREELANCERS_GUILD:
 						if(getHero())
-							GH.windows().createAndPushWindow<CMarketWindow>(town, getHero(), town->id, nullptr, EMarketMode::CREATURE_RESOURCE);
+							GH.windows().createAndPushWindow<CMarketWindow>(town, getHero(), nullptr, EMarketMode::CREATURE_RESOURCE);
 						else
 							LOCPLINT->showInfoDialog(boost::str(boost::format(CGI->generaltexth->allTexts[273]) % b->getNameTranslated())); //Only visiting heroes may use the %s.
 						break;
@@ -996,7 +996,7 @@ void CCastleBuildings::enterMagesGuild()
 void CCastleBuildings::enterTownHall()
 {
 	if(town->visitingHero && town->visitingHero->hasArt(ArtifactID::GRAIL) &&
-		!vstd::contains(town->builtBuildings, BuildingID::GRAIL)) //hero has grail, but town does not have it
+		!town->hasBuilt(BuildingID::GRAIL)) //hero has grail, but town does not have it
 	{
 		if(!vstd::contains(town->forbiddenBuildings, BuildingID::GRAIL))
 		{
@@ -1033,7 +1033,7 @@ void CCastleBuildings::enterAnyThievesGuild()
 	std::vector<const CGTownInstance*> towns = LOCPLINT->cb->getTownsInfo(true);
 	for(auto & ownedTown : towns)
 	{
-		if(ownedTown->builtBuildings.count(BuildingID::TAVERN))
+		if(ownedTown->hasBuilt(BuildingID::TAVERN))
 		{
 			LOCPLINT->showThievesGuildWindow(ownedTown);
 			return;
@@ -1059,18 +1059,18 @@ void CCastleBuildings::enterBank()
 
 void CCastleBuildings::enterAnyMarket()
 {
-	if(town->builtBuildings.count(BuildingID::MARKETPLACE))
+	if(town->hasBuilt(BuildingID::MARKETPLACE))
 	{
-		GH.windows().createAndPushWindow<CMarketWindow>(town, nullptr, town->id, nullptr, EMarketMode::RESOURCE_RESOURCE);
+		GH.windows().createAndPushWindow<CMarketWindow>(town, nullptr, nullptr, EMarketMode::RESOURCE_RESOURCE);
 		return;
 	}
 
 	std::vector<const CGTownInstance*> towns = LOCPLINT->cb->getTownsInfo(true);
 	for(auto & town : towns)
 	{
-		if(town->builtBuildings.count(BuildingID::MARKETPLACE))
+		if(town->hasBuilt(BuildingID::MARKETPLACE))
 		{
-			GH.windows().createAndPushWindow<CMarketWindow>(town, nullptr, town->id, nullptr, EMarketMode::RESOURCE_RESOURCE);
+			GH.windows().createAndPushWindow<CMarketWindow>(town, nullptr, nullptr, EMarketMode::RESOURCE_RESOURCE);
 			return;
 		}
 	}
@@ -1385,7 +1385,7 @@ void CCastleInterface::recreateIcons()
 	fastMarket = std::make_shared<LRClickableArea>(Rect(163, 410, 64, 42), [this]() { builds->enterAnyMarket(); });
 	fastTavern = std::make_shared<LRClickableArea>(Rect(15, 387, 58, 64), [&]()
 	{
-		if(town->builtBuildings.count(BuildingID::TAVERN))
+		if(town->hasBuilt(BuildingID::TAVERN))
 			LOCPLINT->showTavernWindow(town, nullptr, QueryID::NONE);
 	}, [this]{
 		if(!town->town->faction->getDescriptionTranslated().empty())
@@ -1563,7 +1563,7 @@ CHallInterface::CHallInterface(const CGTownInstance * Town):
 				}
 
 				const CBuilding * current = town->town->buildings.at(buildingID);
-				if(vstd::contains(town->builtBuildings, buildingID))
+				if(town->hasBuilt(buildingID))
 				{
 					building = current;
 				}
@@ -1776,7 +1776,7 @@ CFortScreen::CFortScreen(const CGTownInstance * town):
 		{
 			BuildingID dwelling = BuildingID::getDwellingFromLevel(i, 1);
 
-			if(vstd::contains(town->builtBuildings, dwelling))
+			if(town->hasBuilt(dwelling))
 				buildingID = BuildingID(BuildingID::getDwellingFromLevel(i, 1));
 			else
 				buildingID = BuildingID(BuildingID::getDwellingFromLevel(i, 0));
@@ -1841,7 +1841,7 @@ CFortScreen::RecruitArea::RecruitArea(int posX, int posY, const CGTownInstance *
 		buildingIcon = std::make_shared<CAnimImage>(town->town->clientInfo.buildingsIcons, getMyBuilding()->bid, 0, 4, 21);
 		buildingName = std::make_shared<CLabel>(78, 101, FONT_SMALL, ETextAlignment::CENTER, Colors::WHITE, getMyBuilding()->getNameTranslated(), 152);
 
-		if(vstd::contains(town->builtBuildings, getMyBuilding()->bid))
+		if(town->hasBuilt(getMyBuilding()->bid))
 		{
 			ui32 available = town->creatures[level].first;
 			std::string availableText = CGI->generaltexth->allTexts[217]+ std::to_string(available);

--- a/client/windows/CCastleInterface.cpp
+++ b/client/windows/CCastleInterface.cpp
@@ -729,7 +729,7 @@ void CCastleBuildings::buildingClicked(BuildingID building, BuildingSubID::EBuil
 		case BuildingID::MARKETPLACE:
 				// can't use allied marketplace
 				if (town->getOwner() == LOCPLINT->playerID)
-					GH.windows().createAndPushWindow<CMarketWindow>(town, town->visitingHero, nullptr, EMarketMode::RESOURCE_RESOURCE);
+					GH.windows().createAndPushWindow<CMarketWindow>(town, town->visitingHero, town->id, nullptr, EMarketMode::RESOURCE_RESOURCE);
 				else
 					enterBuilding(building);
 				break;
@@ -758,7 +758,7 @@ void CCastleBuildings::buildingClicked(BuildingID building, BuildingSubID::EBuil
 
 				case BuildingSubID::ARTIFACT_MERCHANT:
 						if(town->visitingHero)
-							GH.windows().createAndPushWindow<CMarketWindow>(town, town->visitingHero, nullptr, EMarketMode::RESOURCE_ARTIFACT);
+							GH.windows().createAndPushWindow<CMarketWindow>(town, town->visitingHero, town->id, nullptr, EMarketMode::RESOURCE_ARTIFACT);
 						else
 							LOCPLINT->showInfoDialog(boost::str(boost::format(CGI->generaltexth->allTexts[273]) % b->getNameTranslated())); //Only visiting heroes may use the %s.
 						break;
@@ -769,7 +769,7 @@ void CCastleBuildings::buildingClicked(BuildingID building, BuildingSubID::EBuil
 
 				case BuildingSubID::FREELANCERS_GUILD:
 						if(getHero())
-							GH.windows().createAndPushWindow<CMarketWindow>(town, getHero(), nullptr, EMarketMode::CREATURE_RESOURCE);
+							GH.windows().createAndPushWindow<CMarketWindow>(town, getHero(), town->id, nullptr, EMarketMode::CREATURE_RESOURCE);
 						else
 							LOCPLINT->showInfoDialog(boost::str(boost::format(CGI->generaltexth->allTexts[273]) % b->getNameTranslated())); //Only visiting heroes may use the %s.
 						break;
@@ -1061,7 +1061,7 @@ void CCastleBuildings::enterAnyMarket()
 {
 	if(town->builtBuildings.count(BuildingID::MARKETPLACE))
 	{
-		GH.windows().createAndPushWindow<CMarketWindow>(town, nullptr, nullptr, EMarketMode::RESOURCE_RESOURCE);
+		GH.windows().createAndPushWindow<CMarketWindow>(town, nullptr, town->id, nullptr, EMarketMode::RESOURCE_RESOURCE);
 		return;
 	}
 
@@ -1070,7 +1070,7 @@ void CCastleBuildings::enterAnyMarket()
 	{
 		if(town->builtBuildings.count(BuildingID::MARKETPLACE))
 		{
-			GH.windows().createAndPushWindow<CMarketWindow>(town, nullptr, nullptr, EMarketMode::RESOURCE_RESOURCE);
+			GH.windows().createAndPushWindow<CMarketWindow>(town, nullptr, town->id, nullptr, EMarketMode::RESOURCE_RESOURCE);
 			return;
 		}
 	}

--- a/client/windows/CKingdomInterface.cpp
+++ b/client/windows/CKingdomInterface.cpp
@@ -822,7 +822,7 @@ CTownItem::CTownItem(const CGTownInstance * Town)
 
 	fastTavern = std::make_shared<LRClickableArea>(Rect(5, 6, 58, 64), [&]()
 	{
-		if(town->builtBuildings.count(BuildingID::TAVERN))
+		if(town->hasBuilt(BuildingID::TAVERN))
 			LOCPLINT->showTavernWindow(town, nullptr, QueryID::NONE);
 	}, [&]{
 		if(!town->town->faction->getDescriptionTranslated().empty())
@@ -833,9 +833,9 @@ CTownItem::CTownItem(const CGTownInstance * Town)
 		std::vector<const CGTownInstance*> towns = LOCPLINT->cb->getTownsInfo(true);
 		for(auto & town : towns)
 		{
-			if(town->builtBuildings.count(BuildingID::MARKETPLACE))
+			if(town->hasBuilt(BuildingID::MARKETPLACE))
 			{
-				GH.windows().createAndPushWindow<CMarketWindow>(town, nullptr, town->id, nullptr, EMarketMode::RESOURCE_RESOURCE);
+				GH.windows().createAndPushWindow<CMarketWindow>(town, nullptr, nullptr, EMarketMode::RESOURCE_RESOURCE);
 				return;
 			}
 		}

--- a/client/windows/CKingdomInterface.cpp
+++ b/client/windows/CKingdomInterface.cpp
@@ -835,7 +835,7 @@ CTownItem::CTownItem(const CGTownInstance * Town)
 		{
 			if(town->builtBuildings.count(BuildingID::MARKETPLACE))
 			{
-				GH.windows().createAndPushWindow<CMarketWindow>(town, nullptr, nullptr, EMarketMode::RESOURCE_RESOURCE);
+				GH.windows().createAndPushWindow<CMarketWindow>(town, nullptr, town->id, nullptr, EMarketMode::RESOURCE_RESOURCE);
 				return;
 			}
 		}

--- a/client/windows/CMarketWindow.cpp
+++ b/client/windows/CMarketWindow.cpp
@@ -239,10 +239,10 @@ void CMarketWindow::createAltarArtifacts(const IMarket * market, const CGHeroIns
 	OBJECT_CONSTRUCTION;
 
 	background = createBg(ImagePath::builtin("ALTRART2.bmp"), PLAYER_COLORED);
-	auto altarArtifacts = std::make_shared<CAltarArtifacts>(market, hero, marketId);
-	marketWidget = altarArtifacts;
+	auto altarArtifactsStorage = std::make_shared<CAltarArtifacts>(market, hero, marketId);
+	marketWidget = altarArtifactsStorage;
 	artSets.clear();
-	const auto heroArts = altarArtifacts->getAOHset();
+	const auto heroArts = altarArtifactsStorage->getAOHset();
 	heroArts->clickPressedCallback = [this, heroArts](const CArtPlace & artPlace, const Point & cursorPosition)
 	{
 		clickPressedOnArtPlace(heroArts->getHero(), artPlace.slot, true, true, false);
@@ -258,7 +258,7 @@ void CMarketWindow::createAltarArtifacts(const IMarket * market, const CGHeroIns
 	addSet(heroArts);
 	initWidgetInternals(EMarketMode::ARTIFACT_EXP, CGI->generaltexth->zelp[568]);
 	updateExperience();
-	quitButton->addCallback([altarArtifacts](){altarArtifacts->putBackArtifacts();});
+	quitButton->addCallback([altarArtifactsStorage](){altarArtifactsStorage->putBackArtifacts();});
 }
 
 void CMarketWindow::createAltarCreatures(const IMarket * market, const CGHeroInstance * hero)

--- a/client/windows/CMarketWindow.cpp
+++ b/client/windows/CMarketWindow.cpp
@@ -32,9 +32,13 @@
 #include "../../lib/mapObjects/CGMarket.h"
 #include "../../lib/mapObjects/CGHeroInstance.h"
 
-CMarketWindow::CMarketWindow(const IMarket * market, const CGHeroInstance * hero, const std::function<void()> & onWindowClosed, EMarketMode mode)
+#include "../../CCallback.h"
+
+CMarketWindow::CMarketWindow(const IMarket * market, const CGHeroInstance * hero, const ObjectInstanceID & marketId,
+	const std::function<void()> & onWindowClosed, EMarketMode mode)
 	: CWindowObject(PLAYER_COLORED)
 	, windowClosedCallback(onWindowClosed)
+	, marketId(marketId)
 {
 	assert(mode == EMarketMode::RESOURCE_RESOURCE || mode == EMarketMode::RESOURCE_PLAYER || mode == EMarketMode::CREATURE_RESOURCE ||
 		mode == EMarketMode::RESOURCE_ARTIFACT || mode == EMarketMode::ARTIFACT_RESOURCE || mode == EMarketMode::ARTIFACT_EXP ||
@@ -180,7 +184,8 @@ void CMarketWindow::createArtifactsBuying(const IMarket * market, const CGHeroIn
 	OBJECT_CONSTRUCTION;
 
 	background = createBg(ImagePath::builtin("TPMRKABS.bmp"), PLAYER_COLORED);
-	marketWidget = std::make_shared<CArtifactsBuying>(market, hero);
+	marketWidget = std::make_shared<CArtifactsBuying>(market, hero, LOCPLINT->cb->getTown(marketId) ?
+		VLC->generaltexth->translate("building.core.conflux.special1.name") : CGI->generaltexth->allTexts[349]);
 	initWidgetInternals(EMarketMode::RESOURCE_ARTIFACT, CGI->generaltexth->zelp[600]);
 }
 
@@ -192,13 +197,14 @@ void CMarketWindow::createArtifactsSelling(const IMarket * market, const CGHeroI
 	// Create image that copies part of background containing slot MISC_1 into position of slot MISC_5
 	artSlotBack = std::make_shared<CPicture>(background->getSurface(), Rect(20, 187, 47, 47), 0, 0);
 	artSlotBack->moveTo(pos.topLeft() + Point(18, 339));
-	auto artsSellingMarket = std::make_shared<CArtifactsSelling>(market, hero);
+	auto artsSellingMarket = std::make_shared<CArtifactsSelling>(market, hero, LOCPLINT->cb->getTown(marketId) ?
+		VLC->generaltexth->translate("building.core.conflux.special1.name") : LOCPLINT->cb->getObj(marketId)->getObjectName());
 	artSets.clear();
 	const auto heroArts = artsSellingMarket->getAOHset();
 	heroArts->showPopupCallback = [this, heroArts](CArtPlace & artPlace, const Point & cursorPosition){showArifactInfo(*heroArts, artPlace, cursorPosition);};
 	addSet(heroArts);
 	marketWidget = artsSellingMarket;
-	initWidgetInternals(EMarketMode::ARTIFACT_RESOURCE, CGI->generaltexth->zelp[600]);	
+	initWidgetInternals(EMarketMode::ARTIFACT_RESOURCE, CGI->generaltexth->zelp[600]);
 }
 
 void CMarketWindow::createMarketResources(const IMarket * market, const CGHeroInstance * hero)
@@ -233,7 +239,7 @@ void CMarketWindow::createAltarArtifacts(const IMarket * market, const CGHeroIns
 	OBJECT_CONSTRUCTION;
 
 	background = createBg(ImagePath::builtin("ALTRART2.bmp"), PLAYER_COLORED);
-	auto altarArtifacts = std::make_shared<CAltarArtifacts>(market, hero);
+	auto altarArtifacts = std::make_shared<CAltarArtifacts>(market, hero, marketId);
 	marketWidget = altarArtifacts;
 	artSets.clear();
 	const auto heroArts = altarArtifacts->getAOHset();

--- a/client/windows/CMarketWindow.cpp
+++ b/client/windows/CMarketWindow.cpp
@@ -34,11 +34,9 @@
 
 #include "../../CCallback.h"
 
-CMarketWindow::CMarketWindow(const IMarket * market, const CGHeroInstance * hero, const ObjectInstanceID & marketId,
-	const std::function<void()> & onWindowClosed, EMarketMode mode)
+CMarketWindow::CMarketWindow(const IMarket * market, const CGHeroInstance * hero, const std::function<void()> & onWindowClosed, EMarketMode mode)
 	: CWindowObject(PLAYER_COLORED)
 	, windowClosedCallback(onWindowClosed)
-	, marketId(marketId)
 {
 	assert(mode == EMarketMode::RESOURCE_RESOURCE || mode == EMarketMode::RESOURCE_PLAYER || mode == EMarketMode::CREATURE_RESOURCE ||
 		mode == EMarketMode::RESOURCE_ARTIFACT || mode == EMarketMode::ARTIFACT_RESOURCE || mode == EMarketMode::ARTIFACT_EXP ||
@@ -115,6 +113,11 @@ void CMarketWindow::createChangeModeButtons(EMarketMode currentMode, const IMark
 		if(!market->allowsTrade(modeButton))
 			return false;
 
+		if(currentMode == EMarketMode::ARTIFACT_EXP && modeButton != EMarketMode::CREATURE_EXP)
+			return false;
+		if(currentMode == EMarketMode::CREATURE_EXP && modeButton != EMarketMode::ARTIFACT_EXP)
+			return false;
+
 		if(modeButton == EMarketMode::RESOURCE_RESOURCE || modeButton == EMarketMode::RESOURCE_PLAYER)
 		{
 			if(const auto town = dynamic_cast<const CGTownInstance*>(market))
@@ -184,7 +187,9 @@ void CMarketWindow::createArtifactsBuying(const IMarket * market, const CGHeroIn
 	OBJECT_CONSTRUCTION;
 
 	background = createBg(ImagePath::builtin("TPMRKABS.bmp"), PLAYER_COLORED);
-	marketWidget = std::make_shared<CArtifactsBuying>(market, hero, LOCPLINT->cb->getTown(marketId) ?
+	const auto mapObj = dynamic_cast<const CGObjectInstance*>(market);
+	assert(market);
+	marketWidget = std::make_shared<CArtifactsBuying>(market, hero, LOCPLINT->cb->getTown(mapObj->id) ?
 		VLC->generaltexth->translate("building.core.conflux.special1.name") : CGI->generaltexth->allTexts[349]);
 	initWidgetInternals(EMarketMode::RESOURCE_ARTIFACT, CGI->generaltexth->zelp[600]);
 }
@@ -197,8 +202,10 @@ void CMarketWindow::createArtifactsSelling(const IMarket * market, const CGHeroI
 	// Create image that copies part of background containing slot MISC_1 into position of slot MISC_5
 	artSlotBack = std::make_shared<CPicture>(background->getSurface(), Rect(20, 187, 47, 47), 0, 0);
 	artSlotBack->moveTo(pos.topLeft() + Point(18, 339));
-	auto artsSellingMarket = std::make_shared<CArtifactsSelling>(market, hero, LOCPLINT->cb->getTown(marketId) ?
-		VLC->generaltexth->translate("building.core.conflux.special1.name") : LOCPLINT->cb->getObj(marketId)->getObjectName());
+	const auto mapObj = dynamic_cast<const CGObjectInstance*>(market);
+	assert(market);
+	auto artsSellingMarket = std::make_shared<CArtifactsSelling>(market, hero, LOCPLINT->cb->getTown(mapObj->id) ?
+		VLC->generaltexth->translate("building.core.conflux.special1.name") : mapObj->getObjectName());
 	artSets.clear();
 	const auto heroArts = artsSellingMarket->getAOHset();
 	heroArts->showPopupCallback = [this, heroArts](CArtPlace & artPlace, const Point & cursorPosition){showArifactInfo(*heroArts, artPlace, cursorPosition);};
@@ -239,7 +246,7 @@ void CMarketWindow::createAltarArtifacts(const IMarket * market, const CGHeroIns
 	OBJECT_CONSTRUCTION;
 
 	background = createBg(ImagePath::builtin("ALTRART2.bmp"), PLAYER_COLORED);
-	auto altarArtifactsStorage = std::make_shared<CAltarArtifacts>(market, hero, marketId);
+	auto altarArtifactsStorage = std::make_shared<CAltarArtifacts>(market, hero);
 	marketWidget = altarArtifactsStorage;
 	artSets.clear();
 	const auto heroArts = altarArtifactsStorage->getAOHset();

--- a/client/windows/CMarketWindow.cpp
+++ b/client/windows/CMarketWindow.cpp
@@ -187,9 +187,7 @@ void CMarketWindow::createArtifactsBuying(const IMarket * market, const CGHeroIn
 	OBJECT_CONSTRUCTION;
 
 	background = createBg(ImagePath::builtin("TPMRKABS.bmp"), PLAYER_COLORED);
-	const auto mapObj = dynamic_cast<const CGObjectInstance*>(market);
-	assert(market);
-	marketWidget = std::make_shared<CArtifactsBuying>(market, hero, LOCPLINT->cb->getTown(mapObj->id) ?
+	marketWidget = std::make_shared<CArtifactsBuying>(market, hero, LOCPLINT->cb->getTown(market->getObjInstanceID()) ?
 		VLC->generaltexth->translate("building.core.conflux.special1.name") : CGI->generaltexth->allTexts[349]);
 	initWidgetInternals(EMarketMode::RESOURCE_ARTIFACT, CGI->generaltexth->zelp[600]);
 }
@@ -202,8 +200,7 @@ void CMarketWindow::createArtifactsSelling(const IMarket * market, const CGHeroI
 	// Create image that copies part of background containing slot MISC_1 into position of slot MISC_5
 	artSlotBack = std::make_shared<CPicture>(background->getSurface(), Rect(20, 187, 47, 47), 0, 0);
 	artSlotBack->moveTo(pos.topLeft() + Point(18, 339));
-	const auto mapObj = dynamic_cast<const CGObjectInstance*>(market);
-	assert(market);
+	const auto mapObj = LOCPLINT->cb->getObj(market->getObjInstanceID());
 	auto artsSellingMarket = std::make_shared<CArtifactsSelling>(market, hero, LOCPLINT->cb->getTown(mapObj->id) ?
 		VLC->generaltexth->translate("building.core.conflux.special1.name") : mapObj->getObjectName());
 	artSets.clear();

--- a/client/windows/CMarketWindow.h
+++ b/client/windows/CMarketWindow.h
@@ -27,6 +27,7 @@ public:
 private:
 	void createChangeModeButtons(EMarketMode currentMode, const IMarket * market, const CGHeroInstance * hero);
 	void initWidgetInternals(const EMarketMode mode, const std::pair<std::string, std::string> & quitButtonHelpContainer);
+	std::string getMarketTitle(const ObjectInstanceID marketId, const EMarketMode mode) const;
 
 	void createArtifactsBuying(const IMarket * market, const CGHeroInstance * hero);
 	void createArtifactsSelling(const IMarket * market, const CGHeroInstance * hero);

--- a/client/windows/CMarketWindow.h
+++ b/client/windows/CMarketWindow.h
@@ -15,8 +15,7 @@
 class CMarketWindow final : public CStatusbarWindow, public CWindowWithArtifacts, public IGarrisonHolder, public IMarketHolder
 {
 public:
-	CMarketWindow(const IMarket * market, const CGHeroInstance * hero, const ObjectInstanceID & marketId,
-		const std::function<void()> & onWindowClosed, EMarketMode mode);
+	CMarketWindow(const IMarket * market, const CGHeroInstance * hero, const std::function<void()> & onWindowClosed, EMarketMode mode);
 	void updateResources() override;
 	void updateArtifacts() override;
 	void updateGarrisons() override;
@@ -43,7 +42,6 @@ private:
 	std::function<void()> windowClosedCallback;
 	const Point quitButtonPos = Point(516, 520);
 	std::shared_ptr<CMarketBase> marketWidget;
-	const ObjectInstanceID marketId;
 
 	// This is workaround for bug in H3 files where this slot for ragdoll on this screen is missing
 	std::shared_ptr<CPicture> artSlotBack;

--- a/client/windows/CMarketWindow.h
+++ b/client/windows/CMarketWindow.h
@@ -15,7 +15,8 @@
 class CMarketWindow final : public CStatusbarWindow, public CWindowWithArtifacts, public IGarrisonHolder, public IMarketHolder
 {
 public:
-	CMarketWindow(const IMarket * market, const CGHeroInstance * hero, const std::function<void()> & onWindowClosed, EMarketMode mode);
+	CMarketWindow(const IMarket * market, const CGHeroInstance * hero, const ObjectInstanceID & marketId,
+		const std::function<void()> & onWindowClosed, EMarketMode mode);
 	void updateResources() override;
 	void updateArtifacts() override;
 	void updateGarrisons() override;
@@ -42,6 +43,7 @@ private:
 	std::function<void()> windowClosedCallback;
 	const Point quitButtonPos = Point(516, 520);
 	std::shared_ptr<CMarketBase> marketWidget;
+	const ObjectInstanceID marketId;
 
 	// This is workaround for bug in H3 files where this slot for ragdoll on this screen is missing
 	std::shared_ptr<CPicture> artSlotBack;

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -819,7 +819,7 @@ void CTransformerWindow::makeDeal()
 	for(auto & elem : items)
 	{
 		if(!elem->left)
-			LOCPLINT->cb->trade(market, EMarketMode::CREATURE_UNDEAD, SlotID(elem->id), {}, {}, hero);
+			LOCPLINT->cb->trade(market->getObjInstanceID(), EMarketMode::CREATURE_UNDEAD, SlotID(elem->id), {}, {}, hero);
 	}
 }
 
@@ -1005,7 +1005,7 @@ void CUniversityWindow::updateSecondarySkills()
 
 void CUniversityWindow::makeDeal(SecondarySkill skill)
 {
-	LOCPLINT->cb->trade(market, EMarketMode::RESOURCE_SKILL, GameResID(GameResID::GOLD), skill, 1, hero);
+	LOCPLINT->cb->trade(market->getObjInstanceID(), EMarketMode::RESOURCE_SKILL, GameResID(GameResID::GOLD), skill, 1, hero);
 }
 
 CUnivConfirmWindow::CUnivConfirmWindow(CUniversityWindow * owner_, SecondarySkill SKILL, bool available)

--- a/config/factions/castle.json
+++ b/config/factions/castle.json
@@ -166,7 +166,7 @@
 				"townHall":       { },
 				"cityHall":       { },
 				"capitol":        { },
-				"marketplace":    { },
+				"marketplace":    { "marketModes" : ["resource-resource", "resource-player"] },
 				"resourceSilo":   { "produce": { "ore": 1, "wood": 1 } },
 				"blacksmith":     { },
 

--- a/config/factions/conflux.json
+++ b/config/factions/conflux.json
@@ -171,11 +171,11 @@
 				"townHall":       { },
 				"cityHall":       { },
 				"capitol":        { },
-				"marketplace":    { },
+				"marketplace":    { "marketModes" : ["resource-resource", "resource-player"] },
 				"resourceSilo":   { "produce": { "mercury": 1 } },
 				"blacksmith":     { },
 
-				"special1":       { "type" : "artifactMerchant", "requires" : [ "marketplace" ] },
+				"special1":       { "type" : "artifactMerchant", "requires" : [ "marketplace" ], "marketModes" : ["resource-artifact", "artifact-resource"] },
 				"horde1":         { "id" : 18, "upgrades" : "dwellingLvl1" },
 				"horde1Upgr":     { "id" : 19, "upgrades" : "dwellingUpLvl1", "requires" : [ "horde1" ], "mode" : "auto" },
 				"ship":           { "id" : 20, "upgrades" : "shipyard" },

--- a/config/factions/dungeon.json
+++ b/config/factions/dungeon.json
@@ -167,11 +167,11 @@
 				"townHall":       { },
 				"cityHall":       { },
 				"capitol":        { },
-				"marketplace":    { },
+				"marketplace":    { "marketModes" : ["resource-resource", "resource-player"] },
 				"resourceSilo":   { "produce": { "sulfur": 1 } },
 				"blacksmith":     { },
 
-				"special1":       { "type" : "artifactMerchant", "requires" : [ "marketplace" ] },
+				"special1":       { "type" : "artifactMerchant", "requires" : [ "marketplace" ], "marketModes" : ["resource-artifact", "artifact-resource"] },
 				"horde1":         { "id" : 18, "upgrades" : "dwellingLvl1" },
 				"horde1Upgr":     { "id" : 19, "upgrades" : "dwellingUpLvl1", "requires" : [ "horde1" ], "mode" : "auto" },
 				"special2":       {

--- a/config/factions/fortress.json
+++ b/config/factions/fortress.json
@@ -165,7 +165,7 @@
 				"townHall":       { },
 				"cityHall":       { },
 				"capitol":        { },
-				"marketplace":    { },
+				"marketplace":    { "marketModes" : ["resource-resource", "resource-player"] },
 				"resourceSilo":   { "produce": { "wood": 1, "ore": 1 } },
 				"blacksmith":     { },
 

--- a/config/factions/inferno.json
+++ b/config/factions/inferno.json
@@ -167,7 +167,7 @@
 				"townHall":       { },
 				"cityHall":       { },
 				"capitol":        { },
-				"marketplace":    { },
+				"marketplace":    { "marketModes" : ["resource-resource", "resource-player"] },
 				"resourceSilo":   { "produce": { "mercury": 1 } },
 				"blacksmith":     { },
 

--- a/config/factions/necropolis.json
+++ b/config/factions/necropolis.json
@@ -172,7 +172,7 @@
 				"townHall":       { },
 				"cityHall":       { },
 				"capitol":        { },
-				"marketplace":    { },
+				"marketplace":    { "marketModes" : ["resource-resource", "resource-player"] },
 				"resourceSilo":   { "produce": { "ore": 1, "wood": 1 } },
 				"blacksmith":     { },
 
@@ -182,7 +182,7 @@
 				"ship":           { "id" : 20, "upgrades" : "shipyard" },
 				"special2":       { "requires" : [ "mageGuild1" ],
 					"bonuses": [ { "type": "UNDEAD_RAISE_PERCENTAGE", "val": 10, "propagator": "PLAYER_PROPAGATOR" } ] },
-				"special3":       { "type" : "creatureTransformer", "requires" : [ "dwellingLvl1" ] },
+				"special3":       { "type" : "creatureTransformer", "requires" : [ "dwellingLvl1" ], "marketModes" : ["creature-undead"] },
 				"grail":          { "id" : 26, "mode" : "grail", "produce": { "gold": 5000 },
 					"bonuses": [ { "type": "UNDEAD_RAISE_PERCENTAGE", "val": 20, "propagator": "PLAYER_PROPAGATOR" } ] },
 

--- a/config/factions/rampart.json
+++ b/config/factions/rampart.json
@@ -170,7 +170,7 @@
 				"townHall":       { },
 				"cityHall":       { },
 				"capitol":        { },
-				"marketplace":    { },
+				"marketplace":    { "marketModes" : ["resource-resource", "resource-player"] },
 				"resourceSilo":   { "produce": { "crystal": 1 } },
 				"blacksmith":     { },
 

--- a/config/factions/stronghold.json
+++ b/config/factions/stronghold.json
@@ -162,14 +162,14 @@
 				"townHall":       { },
 				"cityHall":       { },
 				"capitol":        { },
-				"marketplace":    { },
+				"marketplace":    { "marketModes" : ["resource-resource", "resource-player"] },
 				"resourceSilo":   { "produce": { "ore": 1, "wood": 1 } },
 				"blacksmith":     { },
 
 				"special1":       { "type" : "escapeTunnel", "requires" : [ "fort" ] },
 				"horde1":         { "id" : 18, "upgrades" : "dwellingLvl1" },
 				"horde1Upgr":     { "id" : 19, "upgrades" : "dwellingUpLvl1", "requires" : [ "horde1" ], "mode" : "auto" },
-				"special2":       { "type" : "freelancersGuild", "requires" : [ "marketplace" ] },
+				"special2":       { "type" : "freelancersGuild", "requires" : [ "marketplace" ], "marketModes" : ["creature-resource"] },
 				"special3":       { "type" : "ballistaYard", "requires" : [ "blacksmith" ] },
 				"special4":       { 
 					"requires" : [ "fort" ],

--- a/config/factions/tower.json
+++ b/config/factions/tower.json
@@ -165,11 +165,11 @@
 				"townHall":       { },
 				"cityHall":       { },
 				"capitol":        { },
-				"marketplace":    { },
+				"marketplace":    { "marketModes" : ["resource-resource", "resource-player"] },
 				"resourceSilo":   { "produce" : { "gems": 1 } },
 				"blacksmith":     { },
 
-				"special1":       { "type" : "artifactMerchant", "requires" : [ "marketplace" ] },
+				"special1":       { "type" : "artifactMerchant", "requires" : [ "marketplace" ], "marketModes" : ["resource-artifact", "artifact-resource"] },
 				"horde1":         { "id" : 18, "upgrades" : "dwellingLvl2" },
 				"horde1Upgr":     { "id" : 19, "upgrades" : "dwellingUpLvl2", "requires" : [ "horde1" ], "mode" : "auto" },
 				"special2":       { "height" : "high", "requires" : [ "fort" ] },

--- a/config/schemas/townBuilding.json
+++ b/config/schemas/townBuilding.json
@@ -97,7 +97,7 @@
 			"type" : "array",
 			"description" : "Bonuses that are provided by this building in any town where this building has been built. Only affects town itself (including siege), to propagate effect to player or team please use bonus propagators",
 			"items" : { "$ref" : "bonus.json" }
-		}
+		},
 		"marketModes" : {
 			"type" : "array",
 			"enum" : [ "resource-resource", "resource-player", "creature-resource", "resource-artifact", "artifact-resource", "artifact-experience", "creature-experience", "creature-undead", "resource-skill"],

--- a/config/schemas/townBuilding.json
+++ b/config/schemas/townBuilding.json
@@ -98,5 +98,10 @@
 			"description" : "Bonuses that are provided by this building in any town where this building has been built. Only affects town itself (including siege), to propagate effect to player or team please use bonus propagators",
 			"items" : { "$ref" : "bonus.json" }
 		}
+		"marketModes" : {
+			"type" : "array",
+			"enum" : [ "resource-resource", "resource-player", "creature-resource", "resource-artifact", "artifact-resource", "artifact-experience", "creature-experience", "creature-undead", "resource-skill"],
+			"description" : "List of modes available in this market"
+		}
 	}
 }

--- a/docs/modders/Entities_Format/Town_Building_Format.md
+++ b/docs/modders/Entities_Format/Town_Building_Format.md
@@ -171,6 +171,9 @@ These are just a couple of examples of what can be done in VCMI. See vcmi config
 	
     // If set to true, this building will replace all bonuses from base building, leaving only bonuses defined by this building"
 	"upgradeReplacesBonuses" : false,
+	
+	// If the building is a market, it requires market mode.
+	"marketModes" : [ "resource-resource", "resource-player" ],
 }
 ```
 
@@ -217,7 +220,6 @@ Following HotA buildings can be used as unique building for a town. Functionalit
 #### Custom buildings
 In addition to above, it is possible to use same format as [Rewardable](../Map_Objects/Rewardable.md) map objects for town buildings. In order to do that, configuration of a rewardable object must be placed into `configuration` json node in building config.
 
-```
 
 ### Town Structure node
 
@@ -247,4 +249,18 @@ In addition to above, it is possible to use same format as [Rewardable](../Map_O
 	// If upgrade, this building will replace parent animation but will not alter its behaviour
 	"hidden" : false 
 }
+```
+
+
+#### Markets in towns
+Market buildings require list of available [modes](../Map_Objects/Market.md)
+
+##### Marketplace
+```jsonc
+	"marketplace":    { "marketModes" : ["resource-resource", "resource-player"] },
+```
+
+##### Artifact merchant
+```jsonc
+	"special1":       { "type" : "artifactMerchant", "requires" : [ "marketplace" ], "marketModes" : ["resource-artifact", "artifact-resource"] },
 ```

--- a/lib/CGameInfoCallback.cpp
+++ b/lib/CGameInfoCallback.cpp
@@ -174,6 +174,15 @@ const CGTownInstance* CGameInfoCallback::getTown(ObjectInstanceID objid) const
 		return nullptr;
 }
 
+const IMarket * CGameInfoCallback::getMarket(ObjectInstanceID objid) const
+{
+	const CGObjectInstance * obj = getObj(objid, false);
+	if(obj)
+		return dynamic_cast<const IMarket*>(obj);
+	else
+		return nullptr;
+}
+
 void CGameInfoCallback::fillUpgradeInfo(const CArmedInstance *obj, SlotID stackPos, UpgradeInfo &out) const
 {
 	//boost::shared_lock<boost::shared_mutex> lock(*gs->mx);

--- a/lib/CGameInfoCallback.h
+++ b/lib/CGameInfoCallback.h
@@ -48,6 +48,7 @@ class CGHeroInstance;
 class CGDwelling;
 class CGTeleport;
 class CGTownInstance;
+class IMarket;
 
 class DLL_LINKAGE IGameInfoCallback : boost::noncopyable
 {
@@ -189,6 +190,7 @@ public:
 	virtual std::vector <const CGObjectInstance * > getFlaggableObjects(int3 pos) const;
 	virtual const CGObjectInstance * getTopObj (int3 pos) const;
 	virtual PlayerColor getOwner(ObjectInstanceID heroID) const;
+	virtual const IMarket * getMarket(ObjectInstanceID objid) const;
 
 	//map
 	virtual int3 guardingCreaturePosition (int3 pos) const;

--- a/lib/IGameCallback.cpp
+++ b/lib/IGameCallback.cpp
@@ -287,7 +287,7 @@ CArtifactSet * CNonConstInfoCallback::getArtSet(const ArtifactLocation & loc)
 			return hero;
 		}
 	}
-	else if(auto market = dynamic_cast<IMarket*>(getObjInstance(loc.artHolder)))
+	else if(auto market = getMarket(loc.artHolder))
 	{
 		if(auto artSet = market->getArtifactsStorage())
 			return artSet.get();

--- a/lib/IGameCallback.cpp
+++ b/lib/IGameCallback.cpp
@@ -291,14 +291,12 @@ CArtifactSet * CNonConstInfoCallback::getArtSet(const ArtifactLocation & loc)
 	{
 		return army->getStackPtr(loc.creature.value());
 	}
-	else if(auto market = dynamic_cast<CGArtifactsAltar*>(getObjInstance(loc.artHolder)))
+	else if(auto market = dynamic_cast<IMarket*>(getObjInstance(loc.artHolder)))
 	{
-		return market;
+		if(auto artSet = market->getArtifactsStorage())
+			return artSet.get();
 	}
-	else
-	{
-		return nullptr;
-	}
+	return nullptr;
 }
 
 bool IGameCallback::isVisitCoveredByAnotherQuery(const CGObjectInstance *obj, const CGHeroInstance *hero)

--- a/lib/IGameCallback.cpp
+++ b/lib/IGameCallback.cpp
@@ -287,14 +287,14 @@ CArtifactSet * CNonConstInfoCallback::getArtSet(const ArtifactLocation & loc)
 			return hero;
 		}
 	}
-	else if(auto army = getArmyInstance(loc.artHolder))
-	{
-		return army->getStackPtr(loc.creature.value());
-	}
 	else if(auto market = dynamic_cast<IMarket*>(getObjInstance(loc.artHolder)))
 	{
 		if(auto artSet = market->getArtifactsStorage())
 			return artSet.get();
+	}
+	else if(auto army = getArmyInstance(loc.artHolder))
+	{
+		return army->getStackPtr(loc.creature.value());
 	}
 	return nullptr;
 }

--- a/lib/IGameEventsReceiver.h
+++ b/lib/IGameEventsReceiver.h
@@ -109,7 +109,7 @@ public:
 
 	virtual void showPuzzleMap(){};
 	virtual void viewWorldMap(){};
-	virtual void showMarketWindow(const IMarket * market, const ObjectInstanceID & marketId, const CGHeroInstance * visitor, QueryID queryID){};
+	virtual void showMarketWindow(const IMarket * market, const CGHeroInstance * visitor, QueryID queryID){};
 	virtual void showUniversityWindow(const IMarket *market, const CGHeroInstance *visitor, QueryID queryID){};
 	virtual void showHillFortWindow(const CGObjectInstance *object, const CGHeroInstance *visitor){};
 	virtual void showThievesGuildWindow (const CGObjectInstance * obj){};

--- a/lib/IGameEventsReceiver.h
+++ b/lib/IGameEventsReceiver.h
@@ -109,7 +109,7 @@ public:
 
 	virtual void showPuzzleMap(){};
 	virtual void viewWorldMap(){};
-	virtual void showMarketWindow(const IMarket *market, const CGHeroInstance *visitor, QueryID queryID){};
+	virtual void showMarketWindow(const IMarket * market, const ObjectInstanceID & marketId, const CGHeroInstance * visitor, QueryID queryID){};
 	virtual void showUniversityWindow(const IMarket *market, const CGHeroInstance *visitor, QueryID queryID){};
 	virtual void showHillFortWindow(const CGObjectInstance *object, const CGHeroInstance *visitor){};
 	virtual void showThievesGuildWindow (const CGObjectInstance * obj){};

--- a/lib/entities/building/CBuilding.h
+++ b/lib/entities/building/CBuilding.h
@@ -86,7 +86,7 @@ public:
 	STRONG_INLINE
 		bool IsTradeBuilding() const
 	{
-		return bid == BuildingID::MARKETPLACE || subId == BuildingSubID::ARTIFACT_MERCHANT || subId == BuildingSubID::FREELANCERS_GUILD;
+		return !marketModes.empty();
 	}
 
 	void addNewBonus(const std::shared_ptr<Bonus> & b, BonusList & bonusList) const;

--- a/lib/entities/building/CBuilding.h
+++ b/lib/entities/building/CBuilding.h
@@ -34,6 +34,7 @@ public:
 	TResources resources;
 	TResources produce;
 	TRequired requirements;
+	std::set<EMarketMode> marketModes;
 
 	BuildingID bid; //structure ID
 	BuildingID upgrade; /// indicates that building "upgrade" can be improved by this, -1 = empty

--- a/lib/entities/faction/CTownHandler.cpp
+++ b/lib/entities/faction/CTownHandler.cpp
@@ -342,6 +342,11 @@ void CTownHandler::loadBuilding(CTown * town, const std::string & stringID, cons
 		ret->upgrade = BuildingID::NONE;
 
 	ret->town->buildings[ret->bid] = ret;
+	for(const auto & element : source["marketModes"].Vector())
+	{
+		if(MappedKeys::MARKET_NAMES_TO_TYPES.count(element.String()))
+			ret->marketModes.insert(MappedKeys::MARKET_NAMES_TO_TYPES.at(element.String()));
+	}
 
 	registerObject(source.getModScope(), ret->town->getBuildingScope(), ret->identifier, ret->bid.getNum());
 }

--- a/lib/gameState/CGameState.cpp
+++ b/lib/gameState/CGameState.cpp
@@ -802,7 +802,7 @@ void CGameState::initTowns()
 		constexpr std::array hordes = { BuildingID::HORDE_PLACEHOLDER1, BuildingID::HORDE_PLACEHOLDER2, BuildingID::HORDE_PLACEHOLDER3, BuildingID::HORDE_PLACEHOLDER4, BuildingID::HORDE_PLACEHOLDER5, BuildingID::HORDE_PLACEHOLDER6, BuildingID::HORDE_PLACEHOLDER7, BuildingID::HORDE_PLACEHOLDER8 };
 
 		//init buildings
-		if(vstd::contains(vti->builtBuildings, BuildingID::DEFAULT)) //give standard set of buildings
+		if(vti->hasBuilt(BuildingID::DEFAULT)) //give standard set of buildings
 		{
 			vti->removeBuilding(BuildingID::DEFAULT);
 			vti->addBuilding(BuildingID::VILLAGE_HALL);
@@ -826,20 +826,20 @@ void CGameState::initTowns()
 		//init hordes
 		for (int i = 0; i < vti->town->creatures.size(); i++)
 		{
-			if (vstd::contains(vti->builtBuildings, hordes[i])) //if we have horde for this level
+			if(vti->hasBuilt(hordes[i])) //if we have horde for this level
 			{
 				vti->removeBuilding(hordes[i]);//remove old ID
 				if (vti->getTown()->hordeLvl.at(0) == i)//if town first horde is this one
 				{
 					vti->addBuilding(BuildingID::HORDE_1);//add it
 					//if we have upgraded dwelling as well
-					if (vstd::contains(vti->builtBuildings, upgradedDwellings[i]))
+					if(vti->hasBuilt(upgradedDwellings[i]))
 						vti->addBuilding(BuildingID::HORDE_1_UPGR);//add it as well
 				}
 				if (vti->getTown()->hordeLvl.at(1) == i)//if town second horde is this one
 				{
 					vti->addBuilding(BuildingID::HORDE_2);
-					if (vstd::contains(vti->builtBuildings, upgradedDwellings[i]))
+					if(vti->hasBuilt(upgradedDwellings[i]))
 						vti->addBuilding(BuildingID::HORDE_2_UPGR);
 				}
 			}
@@ -847,16 +847,17 @@ void CGameState::initTowns()
 
 		//#1444 - remove entries that don't have buildings defined (like some unused extra town hall buildings)
 		//But DO NOT remove horde placeholders before they are replaced
-		vstd::erase_if(vti->builtBuildings, [vti](const BuildingID & bid)
-			{
-				return !vti->getTown()->buildings.count(bid) || !vti->getTown()->buildings.at(bid);
-			});
+		for(const auto & building : vti->getBuildings())
+		{
+			if(!vti->getTown()->buildings.count(building) || !vti->getTown()->buildings.at(building))
+				vti->removeBuilding(building);
+		}
 
-		if (vstd::contains(vti->builtBuildings, BuildingID::SHIPYARD) && vti->shipyardStatus()==IBoatGenerator::TILE_BLOCKED)
+		if(vti->hasBuilt(BuildingID::SHIPYARD) && vti->shipyardStatus()==IBoatGenerator::TILE_BLOCKED)
 			vti->removeBuilding(BuildingID::SHIPYARD);//if we have harbor without water - erase it (this is H3 behaviour)
 
 		//Early check for #1444-like problems
-		for([[maybe_unused]] const auto & building : vti->builtBuildings)
+		for([[maybe_unused]] const auto & building : vti->getBuildings())
 		{
 			assert(vti->getTown()->buildings.at(building) != nullptr);
 		}

--- a/lib/gameState/CGameState.cpp
+++ b/lib/gameState/CGameState.cpp
@@ -804,10 +804,10 @@ void CGameState::initTowns()
 		//init buildings
 		if(vstd::contains(vti->builtBuildings, BuildingID::DEFAULT)) //give standard set of buildings
 		{
-			vti->builtBuildings.erase(BuildingID::DEFAULT);
-			vti->builtBuildings.insert(BuildingID::VILLAGE_HALL);
+			vti->removeBuilding(BuildingID::DEFAULT);
+			vti->addBuilding(BuildingID::VILLAGE_HALL);
 			if(vti->tempOwner != PlayerColor::NEUTRAL)
-				vti->builtBuildings.insert(BuildingID::TAVERN);
+				vti->addBuilding(BuildingID::TAVERN);
 
 			auto definesBuildingsChances = VLC->settings()->getVector(EGameSettings::TOWNS_STARTING_DWELLING_CHANCES);
 
@@ -815,32 +815,32 @@ void CGameState::initTowns()
 			{
 				if((getRandomGenerator().nextInt(1,100) <= definesBuildingsChances[i]))
 				{
-					vti->builtBuildings.insert(basicDwellings[i]);
+					vti->addBuilding(basicDwellings[i]);
 				}
 			}
 		}
 
 		// village hall must always exist
-		vti->builtBuildings.insert(BuildingID::VILLAGE_HALL);
+		vti->addBuilding(BuildingID::VILLAGE_HALL);
 
 		//init hordes
 		for (int i = 0; i < vti->town->creatures.size(); i++)
 		{
 			if (vstd::contains(vti->builtBuildings, hordes[i])) //if we have horde for this level
 			{
-				vti->builtBuildings.erase(hordes[i]);//remove old ID
+				vti->removeBuilding(hordes[i]);//remove old ID
 				if (vti->getTown()->hordeLvl.at(0) == i)//if town first horde is this one
 				{
-					vti->builtBuildings.insert(BuildingID::HORDE_1);//add it
+					vti->addBuilding(BuildingID::HORDE_1);//add it
 					//if we have upgraded dwelling as well
 					if (vstd::contains(vti->builtBuildings, upgradedDwellings[i]))
-						vti->builtBuildings.insert(BuildingID::HORDE_1_UPGR);//add it as well
+						vti->addBuilding(BuildingID::HORDE_1_UPGR);//add it as well
 				}
 				if (vti->getTown()->hordeLvl.at(1) == i)//if town second horde is this one
 				{
-					vti->builtBuildings.insert(BuildingID::HORDE_2);
+					vti->addBuilding(BuildingID::HORDE_2);
 					if (vstd::contains(vti->builtBuildings, upgradedDwellings[i]))
-						vti->builtBuildings.insert(BuildingID::HORDE_2_UPGR);
+						vti->addBuilding(BuildingID::HORDE_2_UPGR);
 				}
 			}
 		}
@@ -853,7 +853,7 @@ void CGameState::initTowns()
 			});
 
 		if (vstd::contains(vti->builtBuildings, BuildingID::SHIPYARD) && vti->shipyardStatus()==IBoatGenerator::TILE_BLOCKED)
-			vti->builtBuildings.erase(BuildingID::SHIPYARD);//if we have harbor without water - erase it (this is H3 behaviour)
+			vti->removeBuilding(BuildingID::SHIPYARD);//if we have harbor without water - erase it (this is H3 behaviour)
 
 		//Early check for #1444-like problems
 		for([[maybe_unused]] const auto & building : vti->builtBuildings)

--- a/lib/gameState/CGameStateCampaign.cpp
+++ b/lib/gameState/CGameStateCampaign.cpp
@@ -664,10 +664,10 @@ void CGameStateCampaign::initTowns()
 			if (newBuilding == BuildingID::NONE)
 				break;
 
-			if (town->builtBuildings.count(newBuilding) != 0)
+			if(town->hasBuilt(newBuilding))
 				break;
 
-			town->builtBuildings.insert(newBuilding);
+			town->addBuilding(newBuilding);
 
 			auto building = town->town->buildings.at(newBuilding);
 			newBuilding = building->upgrade;

--- a/lib/gameState/CGameStateCampaign.cpp
+++ b/lib/gameState/CGameStateCampaign.cpp
@@ -656,7 +656,7 @@ void CGameStateCampaign::initTowns()
 		if(gameState->scenarioOps->campState->formatVCMI())
 			newBuilding = BuildingID(chosenBonus->info1);
 		else
-			newBuilding = CBuildingHandler::campToERMU(chosenBonus->info1, town->getFaction(), town->builtBuildings);
+			newBuilding = CBuildingHandler::campToERMU(chosenBonus->info1, town->getFaction(), town->getBuildings());
 
 		// Build granted building & all prerequisites - e.g. Mages Guild Lvl 3 should also give Mages Guild Lvl 1 & 2
 		while(true)

--- a/lib/gameState/GameStatistics.cpp
+++ b/lib/gameState/GameStatistics.cpp
@@ -349,7 +349,7 @@ float Statistic::getTownBuiltRatio(const PlayerState * ps)
 
 	for(const auto & t : ps->towns)
 	{
-		built += t->builtBuildings.size();
+		built += t->getBuildings().size();
 		for(const auto & b : t->town->buildings)
 			if(!t->forbiddenBuildings.count(b.first))
 				total += 1;

--- a/lib/gameState/HighScore.cpp
+++ b/lib/gameState/HighScore.cpp
@@ -33,7 +33,7 @@ HighScoreParameter HighScore::prepareHighScores(const CGameState * gs, PlayerCol
 		if(h->hasArt(ArtifactID::GRAIL))
 			param.hasGrail = true;
 	for(const CGTownInstance * t : playerState->towns)
-		if(t->builtBuildings.count(BuildingID::GRAIL))
+		if(t->hasBuilt(BuildingID::GRAIL))
 			param.hasGrail = true;
 	param.allEnemiesDefeated = true;
 	for (PlayerColor otherPlayer(0); otherPlayer < PlayerColor::PLAYER_LIMIT; ++otherPlayer)

--- a/lib/mapObjectConstructors/CommonConstructors.cpp
+++ b/lib/mapObjectConstructors/CommonConstructors.cpp
@@ -251,12 +251,15 @@ void MarketInstanceConstructor::initializeObject(CGMarket * market) const
 	market->marketModes = marketModes;
 	market->marketEfficiency = marketEfficiency;
 	
-	market->title = market->getObjectName();
-	if(!title.empty())
-		market->title = VLC->generaltexth->translate(title);
-	
-	if (!speech.empty())
-		market->speech = VLC->generaltexth->translate(speech);
+	if(auto univercity = dynamic_cast<CGUniversity*>(market))
+	{
+		univercity->title = market->getObjectName();
+		if(!title.empty())
+			univercity->title = VLC->generaltexth->translate(title);
+
+		if(!speech.empty())
+			univercity->speech = VLC->generaltexth->translate(speech);
+	}
 }
 
 void MarketInstanceConstructor::randomizeObject(CGMarket * object, vstd::RNG & rng) const

--- a/lib/mapObjectConstructors/CommonConstructors.cpp
+++ b/lib/mapObjectConstructors/CommonConstructors.cpp
@@ -238,11 +238,6 @@ CGMarket * MarketInstanceConstructor::createObject(IGameCallback * cb) const
 				return new CGUniversity(cb);
 		}
 	}
-	else if(marketModes.size() == 2)
-	{
-		if(vstd::contains(marketModes, EMarketMode::ARTIFACT_EXP))
-			return new CGArtifactsAltar(cb);
-	}
 	return new CGMarket(cb);
 }
 

--- a/lib/mapObjectConstructors/CommonConstructors.cpp
+++ b/lib/mapObjectConstructors/CommonConstructors.cpp
@@ -248,7 +248,7 @@ CGMarket * MarketInstanceConstructor::createObject(IGameCallback * cb) const
 
 void MarketInstanceConstructor::initializeObject(CGMarket * market) const
 {
-	market->marketModes = marketModes;
+	market->addMarketMode(marketModes);
 	market->marketEfficiency = marketEfficiency;
 	
 	if(auto univercity = dynamic_cast<CGUniversity*>(market))

--- a/lib/mapObjectConstructors/CommonConstructors.cpp
+++ b/lib/mapObjectConstructors/CommonConstructors.cpp
@@ -246,14 +246,14 @@ void MarketInstanceConstructor::initializeObject(CGMarket * market) const
 	market->addMarketMode(marketModes);
 	market->marketEfficiency = marketEfficiency;
 	
-	if(auto univercity = dynamic_cast<CGUniversity*>(market))
+	if(auto university = dynamic_cast<CGUniversity*>(market))
 	{
-		univercity->title = market->getObjectName();
+		university->title = market->getObjectName();
 		if(!title.empty())
-			univercity->title = VLC->generaltexth->translate(title);
+			university->title = VLC->generaltexth->translate(title);
 
 		if(!speech.empty())
-			univercity->speech = VLC->generaltexth->translate(speech);
+			university->speech = VLC->generaltexth->translate(speech);
 	}
 }
 

--- a/lib/mapObjects/CGMarket.cpp
+++ b/lib/mapObjects/CGMarket.cpp
@@ -38,11 +38,6 @@ int CGMarket::getMarketEfficiency() const
 	return marketEfficiency;
 }
 
-bool CGMarket::allowsTrade(EMarketMode mode) const
-{
-	return marketModes.count(mode);
-}
-
 int CGMarket::availableUnits(EMarketMode mode, int marketItemSerial) const
 {
 	return -1;

--- a/lib/mapObjects/CGMarket.cpp
+++ b/lib/mapObjects/CGMarket.cpp
@@ -108,9 +108,4 @@ void CGUniversity::onHeroVisit(const CGHeroInstance * h) const
 	cb->showObjectWindow(this, EOpenWindowMode::UNIVERSITY_WINDOW, h, true);
 }
 
-ArtBearer::ArtBearer CGArtifactsAltar::bearerType() const
-{
-	return ArtBearer::ALTAR;
-}
-
 VCMI_LIB_NAMESPACE_END

--- a/lib/mapObjects/CGMarket.cpp
+++ b/lib/mapObjects/CGMarket.cpp
@@ -23,6 +23,11 @@
 
 VCMI_LIB_NAMESPACE_BEGIN
 
+ObjectInstanceID CGMarket::getObjInstanceID() const
+{
+	return id;
+}
+
 void CGMarket::initObj(vstd::RNG & rand)
 {
 	getObjectHandler()->configureObject(this, rand);
@@ -43,13 +48,6 @@ int CGMarket::availableUnits(EMarketMode mode, int marketItemSerial) const
 	return -1;
 }
 
-std::vector<TradeItemBuy> CGMarket::availableItemsIds(EMarketMode mode) const
-{
-	if(allowsTrade(mode))
-		return IMarket::availableItemsIds(mode);
-	return std::vector<TradeItemBuy>();
-}
-
 CGMarket::CGMarket(IGameCallback *cb):
 	CGObjectInstance(cb)
 {}
@@ -58,8 +56,6 @@ std::vector<TradeItemBuy> CGBlackMarket::availableItemsIds(EMarketMode mode) con
 {
 	switch(mode)
 	{
-	case EMarketMode::ARTIFACT_RESOURCE:
-		return IMarket::availableItemsIds(mode);
 	case EMarketMode::RESOURCE_ARTIFACT:
 		{
 			std::vector<TradeItemBuy> ret;

--- a/lib/mapObjects/CGMarket.h
+++ b/lib/mapObjects/CGMarket.h
@@ -18,8 +18,6 @@ VCMI_LIB_NAMESPACE_BEGIN
 class DLL_LINKAGE CGMarket : public CGObjectInstance, public IMarket
 {
 public:
-	
-	std::set<EMarketMode> marketModes;
 	int marketEfficiency;
 	
 	CGMarket(IGameCallback *cb);
@@ -29,7 +27,6 @@ public:
 
 	///IMarket
 	int getMarketEfficiency() const override;
-	bool allowsTrade(EMarketMode mode) const override;
 	int availableUnits(EMarketMode mode, int marketItemSerial) const override; //-1 if unlimited
 	std::vector<TradeItemBuy> availableItemsIds(EMarketMode mode) const override;
 
@@ -37,7 +34,6 @@ public:
 	{
 		h & static_cast<CGObjectInstance&>(*this);
 		h & static_cast<IMarket&>(*this);
-		h & marketModes;
 		h & marketEfficiency;
 	}
 };

--- a/lib/mapObjects/CGMarket.h
+++ b/lib/mapObjects/CGMarket.h
@@ -26,9 +26,9 @@ public:
 	void initObj(vstd::RNG & rand) override;//set skills for trade
 
 	///IMarket
+	ObjectInstanceID getObjInstanceID() const override;
 	int getMarketEfficiency() const override;
 	int availableUnits(EMarketMode mode, int marketItemSerial) const override; //-1 if unlimited
-	std::vector<TradeItemBuy> availableItemsIds(EMarketMode mode) const override;
 
 	template <typename Handler> void serialize(Handler &h)
 	{

--- a/lib/mapObjects/CGMarket.h
+++ b/lib/mapObjects/CGMarket.h
@@ -76,18 +76,4 @@ public:
 	}
 };
 
-class DLL_LINKAGE CGArtifactsAltar : public CGMarket, public CArtifactSet
-{
-public:
-	using CGMarket::CGMarket;
-
-	ArtBearer::ArtBearer bearerType() const override;
-
-	template <typename Handler> void serialize(Handler & h)
-	{
-		h & static_cast<CGMarket&>(*this);
-		h & static_cast<CArtifactSet&>(*this);
-	}
-};
-
 VCMI_LIB_NAMESPACE_END

--- a/lib/mapObjects/CGMarket.h
+++ b/lib/mapObjects/CGMarket.h
@@ -22,10 +22,6 @@ public:
 	std::set<EMarketMode> marketModes;
 	int marketEfficiency;
 	
-	//window variables
-	std::string title;
-	std::string speech; //currently shown only in university
-	
 	CGMarket(IGameCallback *cb);
 	///IObjectInterface
 	void onHeroVisit(const CGHeroInstance * h) const override; //open trading window
@@ -40,10 +36,9 @@ public:
 	template <typename Handler> void serialize(Handler &h)
 	{
 		h & static_cast<CGObjectInstance&>(*this);
+		h & static_cast<IMarket&>(*this);
 		h & marketModes;
 		h & marketEfficiency;
-		h & title;
-		h & speech;
 	}
 };
 
@@ -68,6 +63,8 @@ class DLL_LINKAGE CGUniversity : public CGMarket
 {
 public:
 	using CGMarket::CGMarket;
+	std::string speech; //currently shown only in university
+	std::string title;
 
 	std::vector<TradeItemBuy> skills; //available skills
 
@@ -78,6 +75,8 @@ public:
 	{
 		h & static_cast<CGMarket&>(*this);
 		h & skills;
+		h & speech;
+		h & title;
 	}
 };
 

--- a/lib/mapObjects/CGTownInstance.cpp
+++ b/lib/mapObjects/CGTownInstance.cpp
@@ -943,8 +943,12 @@ void CGTownInstance::addBuilding(const BuildingID & buildingID)
 	if(buildingID == BuildingID::NONE)
 		return;
 
-	builtBuildings.insert(buildingID);
-	marketBuildingModeMapper(buildingID, [this](const EMarketMode mode) {addMarketMode(mode);});
+	const auto townType = (*VLC->townh)[getFaction()]->town;
+	if(const auto & building = townType->buildings.find(buildingID); building != townType->buildings.end())
+	{
+		builtBuildings.insert(buildingID);
+		addMarketMode(building->second->marketModes);
+	}
 }
 
 void CGTownInstance::removeBuilding(const BuildingID & buildingID)
@@ -952,8 +956,11 @@ void CGTownInstance::removeBuilding(const BuildingID & buildingID)
 	if(!vstd::contains(builtBuildings, buildingID))
 		return;
 
-	builtBuildings.erase(buildingID);
-	marketBuildingModeMapper(buildingID, [this](const EMarketMode mode) {removeMarketMode(mode);});
+	if(const auto & building = town->buildings.find(buildingID); building != town->buildings.end())
+	{
+		builtBuildings.erase(buildingID);
+		removeMarketMode(building->second->marketModes);
+	}
 }
 
 void CGTownInstance::removeAllBuildings()
@@ -965,37 +972,6 @@ void CGTownInstance::removeAllBuildings()
 std::set<BuildingID> CGTownInstance::getBuildings() const
 {
 	return builtBuildings;
-}
-
-void CGTownInstance::marketBuildingModeMapper(const BuildingID & buildingID, const std::function<void(const EMarketMode)> & func)
-{
-	const auto townType = (*VLC->townh)[getFaction()]->town;
-	if(townType->buildings.find(buildingID) == townType->buildings.end())
-		return;
-
-	// TODO how to remove hardcoded buildings?
-	if(buildingID == BuildingID::MARKETPLACE)
-	{
-		func(EMarketMode::RESOURCE_RESOURCE);
-		func(EMarketMode::RESOURCE_PLAYER);
-	}
-	else if(townType->buildings.at(buildingID)->subId == BuildingSubID::ARTIFACT_MERCHANT)
-	{
-		func(EMarketMode::ARTIFACT_RESOURCE);
-		func(EMarketMode::RESOURCE_ARTIFACT);
-	}
-	else if(townType->buildings.at(buildingID)->subId == BuildingSubID::FREELANCERS_GUILD)
-	{
-		func(EMarketMode::CREATURE_RESOURCE);
-	}
-	else if(townType->buildings.at(buildingID)->subId == BuildingSubID::CREATURE_TRANSFORMER)
-	{
-		func(EMarketMode::CREATURE_UNDEAD);
-	}
-	else if(townType->buildings.at(buildingID)->subId == BuildingSubID::MAGIC_UNIVERSITY)
-	{
-		func(EMarketMode::RESOURCE_SKILL);
-	}
 }
 
 TResources CGTownInstance::getBuildingCost(const BuildingID & buildingID) const

--- a/lib/mapObjects/CGTownInstance.cpp
+++ b/lib/mapObjects/CGTownInstance.cpp
@@ -951,6 +951,17 @@ void CGTownInstance::removeBuilding(const BuildingID & buildingID)
 	marketBuildingModeMapper(buildingID, [this](const EMarketMode mode) {removeMarketMode(mode);});
 }
 
+void CGTownInstance::removeAllBuildings()
+{
+	builtBuildings.clear();
+	removeAllMarketModes();
+}
+
+std::set<BuildingID> CGTownInstance::getBuildings() const
+{
+	return builtBuildings;
+}
+
 void CGTownInstance::marketBuildingModeMapper(const BuildingID & buildingID, const std::function<void(const EMarketMode)> & func)
 {
 	const auto townType = (*VLC->townh)[getFaction()]->town;

--- a/lib/mapObjects/CGTownInstance.cpp
+++ b/lib/mapObjects/CGTownInstance.cpp
@@ -710,6 +710,11 @@ std::vector<TradeItemBuy> CGTownInstance::availableItemsIds(EMarketMode mode) co
 		return IMarket::availableItemsIds(mode);
 }
 
+ObjectInstanceID CGTownInstance::getObjInstanceID() const
+{
+	return id;
+}
+
 void CGTownInstance::updateAppearance()
 {
 	auto terrain = cb->gameState()->getTile(visitablePos())->terType->getId();

--- a/lib/mapObjects/CGTownInstance.cpp
+++ b/lib/mapObjects/CGTownInstance.cpp
@@ -908,12 +908,7 @@ const CArmedInstance * CGTownInstance::getUpperArmy() const
 
 bool CGTownInstance::hasBuiltSomeTradeBuilding() const
 {
-	for(const auto & bid : builtBuildings)
-	{
-		if(town->buildings.at(bid)->IsTradeBuilding())
-			return true;
-	}
-	return false;
+	return availableModes().empty() ? false : true;
 }
 
 bool CGTownInstance::hasBuilt(BuildingSubID::EBuildingSubID buildingID) const

--- a/lib/mapObjects/CGTownInstance.h
+++ b/lib/mapObjects/CGTownInstance.h
@@ -52,6 +52,8 @@ class DLL_LINKAGE CGTownInstance : public CGDwelling, public IShipyard, public I
 	std::string nameTextId; // name of town
 
 	std::map<BuildingID, TownRewardableBuildingInstance*> convertOldBuildings(std::vector<TownRewardableBuildingInstance*> oldVector);
+	std::set<BuildingID> builtBuildings;
+
 public:
 	using CGDwelling::getPosition;
 
@@ -65,7 +67,6 @@ public:
 	ui32 identifier; //special identifier from h3m (only > RoE maps)
 	PlayerColor alignmentToPlayer; // if set to non-neutral, random town will have same faction as specified player
 	std::set<BuildingID> forbiddenBuildings;
-	std::set<BuildingID> builtBuildings;
 	std::map<BuildingID, TownRewardableBuildingInstance*> rewardableBuildings;
 	std::vector<SpellID> possibleSpells, obligatorySpells;
 	std::vector<std::vector<SpellID> > spells; //spells[level] -> vector of spells, first will be available in guild
@@ -176,6 +177,8 @@ public:
 	bool hasBuilt(const BuildingID & buildingID, FactionID townID) const;
 	void addBuilding(const BuildingID & buildingID);
 	void removeBuilding(const BuildingID & buildingID);
+	void removeAllBuildings();
+	std::set<BuildingID> getBuildings() const;
 
 	TResources getBuildingCost(const BuildingID & buildingID) const;
 	TResources dailyIncome() const; //calculates daily income of this town

--- a/lib/mapObjects/CGTownInstance.h
+++ b/lib/mapObjects/CGTownInstance.h
@@ -231,7 +231,6 @@ protected:
 	void setPropertyDer(ObjProperty what, ObjPropertyID identifier) override;
 	void serializeJsonOptions(JsonSerializeFormat & handler) override;
 	void blockingDialogAnswered(const CGHeroInstance *hero, int32_t answer) const override;
-	void marketBuildingModeMapper(const BuildingID & buildingID, const std::function<void(const EMarketMode)> & func);
 
 private:
 	FactionID randomizeFaction(vstd::RNG & rand);

--- a/lib/mapObjects/CGTownInstance.h
+++ b/lib/mapObjects/CGTownInstance.h
@@ -153,7 +153,6 @@ public:
 	EGeneratorState shipyardStatus() const override;
 	const IObjectInterface * getObject() const override;
 	int getMarketEfficiency() const override; //=market count
-	bool allowsTrade(EMarketMode mode) const override;
 	std::vector<TradeItemBuy> availableItemsIds(EMarketMode mode) const override;
 
 	void updateAppearance();
@@ -175,6 +174,8 @@ public:
 	//checks if building is constructed and town has same subID
 	bool hasBuilt(const BuildingID & buildingID) const;
 	bool hasBuilt(const BuildingID & buildingID, FactionID townID) const;
+	void addBuilding(const BuildingID & buildingID);
+	void removeBuilding(const BuildingID & buildingID);
 
 	TResources getBuildingCost(const BuildingID & buildingID) const;
 	TResources dailyIncome() const; //calculates daily income of this town
@@ -227,6 +228,7 @@ protected:
 	void setPropertyDer(ObjProperty what, ObjPropertyID identifier) override;
 	void serializeJsonOptions(JsonSerializeFormat & handler) override;
 	void blockingDialogAnswered(const CGHeroInstance *hero, int32_t answer) const override;
+	void marketBuildingModeMapper(const BuildingID & buildingID, const std::function<void(const EMarketMode)> & func);
 
 private:
 	FactionID randomizeFaction(vstd::RNG & rand);

--- a/lib/mapObjects/CGTownInstance.h
+++ b/lib/mapObjects/CGTownInstance.h
@@ -76,6 +76,7 @@ public:
 	template <typename Handler> void serialize(Handler &h)
 	{
 		h & static_cast<CGDwelling&>(*this);
+		h & static_cast<IMarket&>(*this);
 		h & nameTextId;
 		h & built;
 		h & destroyed;

--- a/lib/mapObjects/CGTownInstance.h
+++ b/lib/mapObjects/CGTownInstance.h
@@ -155,7 +155,7 @@ public:
 	const IObjectInterface * getObject() const override;
 	int getMarketEfficiency() const override; //=market count
 	std::vector<TradeItemBuy> availableItemsIds(EMarketMode mode) const override;
-
+	ObjectInstanceID getObjInstanceID() const override;
 	void updateAppearance();
 
 	//////////////////////////////////////////////////////////////////////////

--- a/lib/mapObjects/IMarket.cpp
+++ b/lib/mapObjects/IMarket.cpp
@@ -145,7 +145,7 @@ void IMarket::addMarketMode(const EMarketMode mode)
 	marketModes.insert(mode);
 
 	if(mode == EMarketMode::ARTIFACT_EXP)
-		altarArtifacts = std::make_shared<CArtifactSetAltar>();
+		altarArtifactsStorage = std::make_shared<CArtifactSetAltar>();
 }
 
 void IMarket::addMarketMode(const std::set<EMarketMode> & modes)
@@ -159,7 +159,12 @@ void IMarket::removeMarketMode(const EMarketMode mode)
 	marketModes.erase(mode);
 
 	if(mode == EMarketMode::ARTIFACT_EXP)
-		altarArtifacts.reset();
+		altarArtifactsStorage.reset();
+}
+
+std::shared_ptr<CArtifactSet> IMarket::getArtifactsStorage() const
+{
+	return altarArtifactsStorage;
 }
 
 std::vector<TradeItemBuy> IMarket::availableItemsIds(const EMarketMode mode) const
@@ -176,14 +181,9 @@ std::vector<TradeItemBuy> IMarket::availableItemsIds(const EMarketMode mode) con
 	return ret;
 }
 
-std::vector<EMarketMode> IMarket::availableModes() const
+std::set<EMarketMode> IMarket::availableModes() const
 {
-	std::vector<EMarketMode> ret;
-	for (EMarketMode i = static_cast<EMarketMode>(0); i < EMarketMode::MARKET_AFTER_LAST_PLACEHOLDER; i = vstd::next(i, 1))
-	if(allowsTrade(i))
-		ret.push_back(i);
-
-	return ret;
+	return marketModes;
 }
 
 VCMI_LIB_NAMESPACE_END

--- a/lib/mapObjects/IMarket.cpp
+++ b/lib/mapObjects/IMarket.cpp
@@ -162,6 +162,11 @@ void IMarket::removeMarketMode(const EMarketMode mode)
 		altarArtifactsStorage.reset();
 }
 
+void IMarket::removeAllMarketModes()
+{
+	marketModes.clear();
+}
+
 std::shared_ptr<CArtifactSet> IMarket::getArtifactsStorage() const
 {
 	return altarArtifactsStorage;

--- a/lib/mapObjects/IMarket.cpp
+++ b/lib/mapObjects/IMarket.cpp
@@ -162,6 +162,12 @@ void IMarket::removeMarketMode(const EMarketMode mode)
 		altarArtifactsStorage.reset();
 }
 
+void IMarket::removeMarketMode(const std::set<EMarketMode> & modes)
+{
+	for(const auto & mode : modes)
+		removeMarketMode(mode);
+}
+
 void IMarket::removeAllMarketModes()
 {
 	marketModes.clear();

--- a/lib/mapObjects/IMarket.cpp
+++ b/lib/mapObjects/IMarket.cpp
@@ -122,12 +122,7 @@ bool IMarket::getOffer(int id1, int id2, int &val1, int &val2, EMarketMode mode)
 	return true;
 }
 
-bool IMarket::allowsTrade(EMarketMode mode) const
-{
-	return false;
-}
-
-int IMarket::availableUnits(EMarketMode mode, int marketItemSerial) const
+int IMarket::availableUnits(const EMarketMode mode, const int marketItemSerial) const
 {
 	switch(mode)
 	{
@@ -140,7 +135,7 @@ int IMarket::availableUnits(EMarketMode mode, int marketItemSerial) const
 	}
 }
 
-std::vector<TradeItemBuy> IMarket::availableItemsIds(EMarketMode mode) const
+std::vector<TradeItemBuy> IMarket::availableItemsIds(const EMarketMode mode) const
 {
 	std::vector<TradeItemBuy> ret;
 	switch(mode)
@@ -152,10 +147,6 @@ std::vector<TradeItemBuy> IMarket::availableItemsIds(EMarketMode mode) const
 			ret.push_back(res);
 	}
 	return ret;
-}
-
-IMarket::IMarket()
-{
 }
 
 std::vector<EMarketMode> IMarket::availableModes() const

--- a/lib/mapObjects/IMarket.cpp
+++ b/lib/mapObjects/IMarket.cpp
@@ -22,7 +22,7 @@ VCMI_LIB_NAMESPACE_BEGIN
 
 bool IMarket::allowsTrade(const EMarketMode mode) const
 {
-	return marketModes.count(mode) > 0;
+	return vstd::contains(marketModes, mode);
 }
 
 bool IMarket::getOffer(int id1, int id2, int &val1, int &val2, EMarketMode mode) const
@@ -180,7 +180,7 @@ std::vector<TradeItemBuy> IMarket::availableItemsIds(const EMarketMode mode) con
 	case EMarketMode::RESOURCE_RESOURCE:
 	case EMarketMode::ARTIFACT_RESOURCE:
 	case EMarketMode::CREATURE_RESOURCE:
-		for (auto res : GameResID::ALL_RESOURCES())
+		for(const auto & res : GameResID::ALL_RESOURCES())
 			ret.push_back(res);
 	}
 	return ret;

--- a/lib/mapObjects/IMarket.cpp
+++ b/lib/mapObjects/IMarket.cpp
@@ -20,6 +20,11 @@
 
 VCMI_LIB_NAMESPACE_BEGIN
 
+bool IMarket::allowsTrade(const EMarketMode mode) const
+{
+	return marketModes.count(mode) > 0;
+}
+
 bool IMarket::getOffer(int id1, int id2, int &val1, int &val2, EMarketMode mode) const
 {
 	switch(mode)
@@ -133,6 +138,28 @@ int IMarket::availableUnits(const EMarketMode mode, const int marketItemSerial) 
 	default:
 			return 1;
 	}
+}
+
+void IMarket::addMarketMode(const EMarketMode mode)
+{
+	marketModes.insert(mode);
+
+	if(mode == EMarketMode::ARTIFACT_EXP)
+		altarArtifacts = std::make_shared<CArtifactSetAltar>();
+}
+
+void IMarket::addMarketMode(const std::set<EMarketMode> & modes)
+{
+	for(const auto & mode : modes)
+		addMarketMode(mode);
+}
+
+void IMarket::removeMarketMode(const EMarketMode mode)
+{
+	marketModes.erase(mode);
+
+	if(mode == EMarketMode::ARTIFACT_EXP)
+		altarArtifacts.reset();
 }
 
 std::vector<TradeItemBuy> IMarket::availableItemsIds(const EMarketMode mode) const

--- a/lib/mapObjects/IMarket.h
+++ b/lib/mapObjects/IMarket.h
@@ -31,6 +31,7 @@ public:
 	void addMarketMode(const EMarketMode mode);
 	void addMarketMode(const std::set<EMarketMode> & modes);
 	void removeMarketMode(const EMarketMode mode);
+	void removeAllMarketModes();
 	std::set<EMarketMode> availableModes() const;
 	std::shared_ptr<CArtifactSet> getArtifactsStorage() const;
 	bool getOffer(int id1, int id2, int &val1, int &val2, EMarketMode mode) const; //val1 - how many units of id1 player has to give to receive val2 units

--- a/lib/mapObjects/IMarket.h
+++ b/lib/mapObjects/IMarket.h
@@ -32,6 +32,7 @@ public:
 	void addMarketMode(const EMarketMode mode);
 	void addMarketMode(const std::set<EMarketMode> & modes);
 	void removeMarketMode(const EMarketMode mode);
+	void removeMarketMode(const std::set<EMarketMode> & modes);
 	void removeAllMarketModes();
 	std::set<EMarketMode> availableModes() const;
 	std::shared_ptr<CArtifactSet> getArtifactsStorage() const;

--- a/lib/mapObjects/IMarket.h
+++ b/lib/mapObjects/IMarket.h
@@ -25,22 +25,27 @@ public:
 	};
 
 	virtual int getMarketEfficiency() const = 0;
-	virtual bool allowsTrade(const EMarketMode mode) const = 0;
+	virtual bool allowsTrade(const EMarketMode mode) const;
 	virtual int availableUnits(const EMarketMode mode, const int marketItemSerial) const; //-1 if unlimited
 	virtual std::vector<TradeItemBuy> availableItemsIds(const EMarketMode mode) const;
+	void addMarketMode(const EMarketMode mode);
+	void addMarketMode(const std::set<EMarketMode> & modes);
+	void removeMarketMode(const EMarketMode mode);
 
 	bool getOffer(int id1, int id2, int &val1, int &val2, EMarketMode mode) const; //val1 - how many units of id1 player has to give to receive val2 units
 	std::vector<EMarketMode> availableModes() const;
 
 	template <typename Handler> void serialize(Handler & h)
 	{
-		if(h.loadingGamestate)
-		{
-		}
+		h & marketModes;
+
+		if(h.loadingGamestate && vstd::contains(marketModes, EMarketMode::ARTIFACT_EXP))
+			altarArtifacts = std::make_shared<CArtifactSetAltar>();
 	}
 
 private:
 	std::shared_ptr<CArtifactSetAltar> altarArtifacts;
+	std::set<EMarketMode> marketModes;
 };
 
 VCMI_LIB_NAMESPACE_END

--- a/lib/mapObjects/IMarket.h
+++ b/lib/mapObjects/IMarket.h
@@ -11,24 +11,36 @@
 
 #include "../networkPacks/TradeItem.h"
 #include "../constants/Enumerations.h"
+#include "../CArtHandler.h"
 
 VCMI_LIB_NAMESPACE_BEGIN
 
-class CGObjectInstance;
-
-class DLL_LINKAGE IMarket
+class DLL_LINKAGE IMarket : public virtual Serializeable
 {
 public:
-	IMarket();
-	virtual ~IMarket() {}
+	class CArtifactSetAltar : public CArtifactSet
+	{
+	public:
+		ArtBearer::ArtBearer bearerType() const override {return ArtBearer::ALTAR;};
+	};
 
 	virtual int getMarketEfficiency() const = 0;
-	virtual bool allowsTrade(EMarketMode mode) const;
-	virtual int availableUnits(EMarketMode mode, int marketItemSerial) const; //-1 if unlimited
-	virtual std::vector<TradeItemBuy> availableItemsIds(EMarketMode mode) const;
+	virtual bool allowsTrade(const EMarketMode mode) const = 0;
+	virtual int availableUnits(const EMarketMode mode, const int marketItemSerial) const; //-1 if unlimited
+	virtual std::vector<TradeItemBuy> availableItemsIds(const EMarketMode mode) const;
 
 	bool getOffer(int id1, int id2, int &val1, int &val2, EMarketMode mode) const; //val1 - how many units of id1 player has to give to receive val2 units
 	std::vector<EMarketMode> availableModes() const;
+
+	template <typename Handler> void serialize(Handler & h)
+	{
+		if(h.loadingGamestate)
+		{
+		}
+	}
+
+private:
+	std::shared_ptr<CArtifactSetAltar> altarArtifacts;
 };
 
 VCMI_LIB_NAMESPACE_END

--- a/lib/mapObjects/IMarket.h
+++ b/lib/mapObjects/IMarket.h
@@ -24,6 +24,7 @@ public:
 		ArtBearer::ArtBearer bearerType() const override {return ArtBearer::ALTAR;};
 	};
 
+	virtual ObjectInstanceID getObjInstanceID() const = 0;	// The market is always an object on the map
 	virtual int getMarketEfficiency() const = 0;
 	virtual bool allowsTrade(const EMarketMode mode) const;
 	virtual int availableUnits(const EMarketMode mode, const int marketItemSerial) const; //-1 if unlimited

--- a/lib/mapObjects/IMarket.h
+++ b/lib/mapObjects/IMarket.h
@@ -31,20 +31,20 @@ public:
 	void addMarketMode(const EMarketMode mode);
 	void addMarketMode(const std::set<EMarketMode> & modes);
 	void removeMarketMode(const EMarketMode mode);
-
+	std::set<EMarketMode> availableModes() const;
+	std::shared_ptr<CArtifactSet> getArtifactsStorage() const;
 	bool getOffer(int id1, int id2, int &val1, int &val2, EMarketMode mode) const; //val1 - how many units of id1 player has to give to receive val2 units
-	std::vector<EMarketMode> availableModes() const;
 
 	template <typename Handler> void serialize(Handler & h)
 	{
 		h & marketModes;
 
 		if(h.loadingGamestate && vstd::contains(marketModes, EMarketMode::ARTIFACT_EXP))
-			altarArtifacts = std::make_shared<CArtifactSetAltar>();
+			altarArtifactsStorage = std::make_shared<CArtifactSetAltar>();
 	}
 
 private:
-	std::shared_ptr<CArtifactSetAltar> altarArtifacts;
+	std::shared_ptr<CArtifactSetAltar> altarArtifactsStorage;
 	std::set<EMarketMode> marketModes;
 };
 

--- a/lib/mapping/MapFormatH3M.cpp
+++ b/lib/mapping/MapFormatH3M.cpp
@@ -2199,9 +2199,11 @@ CGObjectInstance * CMapLoaderH3M::readTown(const int3 & position, std::shared_pt
 	if(hasCustomBuildings)
 	{
 		object->subID = faction.value();
-		for(const auto & building : reader->readBitmaskBuildings(faction))
+		std::set<BuildingID> builtBuildings;
+		reader->readBitmaskBuildings(builtBuildings, faction);
+		for(const auto & building : builtBuildings)
 			object->addBuilding(building);
-		object->forbiddenBuildings = reader->readBitmaskBuildings(faction);
+		reader->readBitmaskBuildings(object->forbiddenBuildings, faction);
 	}
 	// Standard buildings
 	else
@@ -2259,7 +2261,7 @@ CGObjectInstance * CMapLoaderH3M::readTown(const int3 & position, std::shared_pt
 		reader->skipZero(17);
 
 		// New buildings
-		event.buildings = reader->readBitmaskBuildings(faction);
+		reader->readBitmaskBuildings(event.buildings, faction);
 
 		event.creatures.resize(7);
 		for(int i = 0; i < 7; ++i)

--- a/lib/mapping/MapFormatH3M.cpp
+++ b/lib/mapping/MapFormatH3M.cpp
@@ -2198,18 +2198,20 @@ CGObjectInstance * CMapLoaderH3M::readTown(const int3 & position, std::shared_pt
 	bool hasCustomBuildings = reader->readBool();
 	if(hasCustomBuildings)
 	{
-		reader->readBitmaskBuildings(object->builtBuildings, faction);
-		reader->readBitmaskBuildings(object->forbiddenBuildings, faction);
+		object->subID = faction.value();
+		for(const auto & building : reader->readBitmaskBuildings(faction))
+			object->addBuilding(building);
+		object->forbiddenBuildings = reader->readBitmaskBuildings(faction);
 	}
 	// Standard buildings
 	else
 	{
 		bool hasFort = reader->readBool();
 		if(hasFort)
-			object->builtBuildings.insert(BuildingID::FORT);
+			object->addBuilding(BuildingID::FORT);
 
 		//means that set of standard building should be included
-		object->builtBuildings.insert(BuildingID::DEFAULT);
+		object->addBuilding(BuildingID::DEFAULT);
 	}
 
 	if(features.levelAB)
@@ -2257,7 +2259,7 @@ CGObjectInstance * CMapLoaderH3M::readTown(const int3 & position, std::shared_pt
 		reader->skipZero(17);
 
 		// New buildings
-		reader->readBitmaskBuildings(event.buildings, faction);
+		event.buildings = reader->readBitmaskBuildings(faction);
 
 		event.creatures.resize(7);
 		for(int i = 0; i < 7; ++i)

--- a/lib/mapping/MapReaderH3M.cpp
+++ b/lib/mapping/MapReaderH3M.cpp
@@ -257,10 +257,9 @@ PlayerColor MapReaderH3M::readPlayer32()
 	return PlayerColor(value);
 }
 
-std::set<BuildingID> MapReaderH3M::readBitmaskBuildings(std::optional<FactionID> faction)
+void MapReaderH3M::readBitmaskBuildings(std::set<BuildingID> & dest, std::optional<FactionID> faction)
 {
 	std::set<BuildingID> h3m;
-	std::set<BuildingID> dest;
 	readBitmask(h3m, features.buildingsBytes, features.buildingsCount, false);
 
 	for (auto const & h3mEntry : h3m)
@@ -270,7 +269,6 @@ std::set<BuildingID> MapReaderH3M::readBitmaskBuildings(std::optional<FactionID>
 		if (mapped != BuildingID::NONE) // artifact merchant may be set in random town, but not present in actual town
 			dest.insert(mapped);
 	}
-	return dest;
 }
 
 void MapReaderH3M::readBitmaskFactions(std::set<FactionID> & dest, bool invert)

--- a/lib/mapping/MapReaderH3M.cpp
+++ b/lib/mapping/MapReaderH3M.cpp
@@ -257,9 +257,10 @@ PlayerColor MapReaderH3M::readPlayer32()
 	return PlayerColor(value);
 }
 
-void MapReaderH3M::readBitmaskBuildings(std::set<BuildingID> & dest, std::optional<FactionID> faction)
+std::set<BuildingID> MapReaderH3M::readBitmaskBuildings(std::optional<FactionID> faction)
 {
 	std::set<BuildingID> h3m;
+	std::set<BuildingID> dest;
 	readBitmask(h3m, features.buildingsBytes, features.buildingsCount, false);
 
 	for (auto const & h3mEntry : h3m)
@@ -269,6 +270,7 @@ void MapReaderH3M::readBitmaskBuildings(std::set<BuildingID> & dest, std::option
 		if (mapped != BuildingID::NONE) // artifact merchant may be set in random town, but not present in actual town
 			dest.insert(mapped);
 	}
+	return dest;
 }
 
 void MapReaderH3M::readBitmaskFactions(std::set<FactionID> & dest, bool invert)

--- a/lib/mapping/MapReaderH3M.h
+++ b/lib/mapping/MapReaderH3M.h
@@ -48,7 +48,7 @@ public:
 	PlayerColor readPlayer();
 	PlayerColor readPlayer32();
 
-	std::set<BuildingID> readBitmaskBuildings(std::optional<FactionID> faction);
+	void readBitmaskBuildings(std::set<BuildingID> & dest, std::optional<FactionID> faction);
 	void readBitmaskFactions(std::set<FactionID> & dest, bool invert);
 	void readBitmaskPlayers(std::set<PlayerColor> & dest, bool invert);
 	void readBitmaskResources(std::set<GameResID> & dest, bool invert);

--- a/lib/mapping/MapReaderH3M.h
+++ b/lib/mapping/MapReaderH3M.h
@@ -48,7 +48,7 @@ public:
 	PlayerColor readPlayer();
 	PlayerColor readPlayer32();
 
-	void readBitmaskBuildings(std::set<BuildingID> & dest, std::optional<FactionID> faction);
+	std::set<BuildingID> readBitmaskBuildings(std::optional<FactionID> faction);
 	void readBitmaskFactions(std::set<FactionID> & dest, bool invert);
 	void readBitmaskPlayers(std::set<PlayerColor> & dest, bool invert);
 	void readBitmaskResources(std::set<GameResID> & dest, bool invert);

--- a/lib/networkPacks/NetPacksLib.cpp
+++ b/lib/networkPacks/NetPacksLib.cpp
@@ -1332,7 +1332,7 @@ void NewStructures::applyGs(CGameState *gs)
 	for(const auto & id : bid)
 	{
 		assert(t->town->buildings.at(id) != nullptr);
-		t->builtBuildings.insert(id);
+		t->addBuilding(id);
 	}
 	t->updateAppearance();
 	t->built = built;
@@ -1344,7 +1344,7 @@ void RazeStructures::applyGs(CGameState *gs)
 	CGTownInstance *t = gs->getTown(tid);
 	for(const auto & id : bid)
 	{
-		t->builtBuildings.erase(id);
+		t->removeBuilding(id);
 
 		t->updateAppearance();
 	}

--- a/lib/registerTypes/RegisterTypesMapObjects.h
+++ b/lib/registerTypes/RegisterTypesMapObjects.h
@@ -55,7 +55,6 @@ void registerTypesMapObjects(Serializer &s)
 		s.template registerType<CGMarket, CGBlackMarket>();
 		s.template registerType<CGMarket, CGUniversity>();
 	s.template registerType<CGObjectInstance, CGHeroPlaceholder>();
-	s.template registerType<IMarket, CGMarket>();
 
 	s.template registerType<CGObjectInstance, CArmedInstance>(); s.template registerType<CBonusSystemNode, CArmedInstance>(); s.template registerType<CCreatureSet, CArmedInstance>();
 
@@ -133,6 +132,7 @@ void registerTypesMapObjects(Serializer &s)
 
 	//s.template registerType<CObstacleInstance>();
 		s.template registerType<CObstacleInstance, SpellCreatedObstacle>();
+	s.template registerType<IMarket, CGMarket>();
 }
 
 VCMI_LIB_NAMESPACE_END

--- a/lib/registerTypes/RegisterTypesMapObjects.h
+++ b/lib/registerTypes/RegisterTypesMapObjects.h
@@ -51,7 +51,7 @@ void registerTypesMapObjects(Serializer &s)
 	s.template registerType<CGObjectInstance, CGLighthouse>();
 	s.template registerType<CGObjectInstance, CGTerrainPatch>();
 	s.template registerType<CGObjectInstance, HillFort>();
-	s.template registerType<CGObjectInstance, CGMarket>();
+	s.template registerType<CGObjectInstance, CGMarket>(); s.template registerType<IMarket, CGMarket>();
 		s.template registerType<CGMarket, CGBlackMarket>();
 		s.template registerType<CGMarket, CGUniversity>();
 	s.template registerType<CGObjectInstance, CGHeroPlaceholder>();

--- a/lib/registerTypes/RegisterTypesMapObjects.h
+++ b/lib/registerTypes/RegisterTypesMapObjects.h
@@ -132,8 +132,6 @@ void registerTypesMapObjects(Serializer &s)
 
 	//s.template registerType<CObstacleInstance>();
 		s.template registerType<CObstacleInstance, SpellCreatedObstacle>();
-
-	s.template registerType<CGMarket, CGArtifactsAltar>();
 }
 
 VCMI_LIB_NAMESPACE_END

--- a/lib/registerTypes/RegisterTypesMapObjects.h
+++ b/lib/registerTypes/RegisterTypesMapObjects.h
@@ -51,10 +51,11 @@ void registerTypesMapObjects(Serializer &s)
 	s.template registerType<CGObjectInstance, CGLighthouse>();
 	s.template registerType<CGObjectInstance, CGTerrainPatch>();
 	s.template registerType<CGObjectInstance, HillFort>();
-	s.template registerType<CGObjectInstance, CGMarket>(); s.template registerType<IMarket, CGMarket>();
+	s.template registerType<CGObjectInstance, CGMarket>();
 		s.template registerType<CGMarket, CGBlackMarket>();
 		s.template registerType<CGMarket, CGUniversity>();
 	s.template registerType<CGObjectInstance, CGHeroPlaceholder>();
+	s.template registerType<IMarket, CGMarket>();
 
 	s.template registerType<CGObjectInstance, CArmedInstance>(); s.template registerType<CBonusSystemNode, CArmedInstance>(); s.template registerType<CCreatureSet, CArmedInstance>();
 

--- a/lib/rmg/modificators/TownPlacer.cpp
+++ b/lib/rmg/modificators/TownPlacer.cpp
@@ -79,8 +79,8 @@ void TownPlacer::placeTowns(ObjectManager & manager)
 
 		CGTownInstance * town = dynamic_cast<CGTownInstance *>(townFactory->create(map.mapInstance->cb, nullptr));
 		town->tempOwner = player;
-		town->builtBuildings.insert(BuildingID::FORT);
-		town->builtBuildings.insert(BuildingID::DEFAULT);
+		town->addBuilding(BuildingID::FORT);
+		town->addBuilding(BuildingID::DEFAULT);
 		
 
 		for(auto spellID : VLC->spellh->getDefaultAllowed()) //add all regular spells to town
@@ -203,8 +203,8 @@ void TownPlacer::addNewTowns(int count, bool hasFort, const PlayerColor & player
 		
 		town->tempOwner = player;
 		if (hasFort)
-			town->builtBuildings.insert(BuildingID::FORT);
-		town->builtBuildings.insert(BuildingID::DEFAULT);
+			town->addBuilding(BuildingID::FORT);
+		town->addBuilding(BuildingID::DEFAULT);
 		
 		for(auto spellID : VLC->spellh->getDefaultAllowed()) //add all regular spells to town
 			town->possibleSpells.push_back(spellID);

--- a/mapeditor/inspector/inspector.cpp
+++ b/mapeditor/inspector/inspector.cpp
@@ -166,12 +166,12 @@ void Initializer::initialize(CGTownInstance * o)
 
 	const std::vector<std::string> castleLevels{"village", "fort", "citadel", "castle", "capitol"};
 	int lvl = vstd::find_pos(castleLevels, o->appearance->stringID);
-	o->builtBuildings.insert(BuildingID::DEFAULT);
-	if(lvl > -1) o->builtBuildings.insert(BuildingID::TAVERN);
-	if(lvl > 0) o->builtBuildings.insert(BuildingID::FORT);
-	if(lvl > 1) o->builtBuildings.insert(BuildingID::CITADEL);
-	if(lvl > 2) o->builtBuildings.insert(BuildingID::CASTLE);
-	if(lvl > 3) o->builtBuildings.insert(BuildingID::CAPITOL);
+	o->addBuilding(BuildingID::DEFAULT);
+	if(lvl > -1) o->addBuilding(BuildingID::TAVERN);
+	if(lvl > 0) o->addBuilding(BuildingID::FORT);
+	if(lvl > 1) o->addBuilding(BuildingID::CITADEL);
+	if(lvl > 2) o->addBuilding(BuildingID::CASTLE);
+	if(lvl > 3) o->addBuilding(BuildingID::CAPITOL);
 
 	for(auto const & spell : VLC->spellh->objects) //add all regular spells to town
 	{

--- a/mapeditor/inspector/townbuildingswidget.cpp
+++ b/mapeditor/inspector/townbuildingswidget.cpp
@@ -166,7 +166,7 @@ QStandardItem * TownBuildingsWidget::addBuilding(const CTown & ctown, int bId, s
 	
 	checks << new QStandardItem;
 	checks.back()->setCheckable(true);
-	checks.back()->setCheckState(town.builtBuildings.count(buildingId) ? Qt::Checked : Qt::Unchecked);
+	checks.back()->setCheckState(town.hasBuilt(buildingId) ? Qt::Checked : Qt::Unchecked);
 	checks.back()->setData(bId, MapEditorRoles::BuildingIDRole);
 	
 	if(building->getBase() == buildingId)
@@ -350,7 +350,9 @@ void TownBuildingsDelegate::setModelData(QWidget *editor, QAbstractItemModel *mo
 	if(auto * ed = qobject_cast<TownBuildingsWidget *>(editor))
 	{
 		town.forbiddenBuildings = ed->getForbiddenBuildings();
-		town.builtBuildings = ed->getBuiltBuildings();
+		town.removeAllBuildings();
+		for(const auto & building : ed->getBuiltBuildings())
+			town.addBuilding(building);
 	}
 	else
 	{

--- a/mapeditor/mapcontroller.cpp
+++ b/mapeditor/mapcontroller.cpp
@@ -174,10 +174,11 @@ void MapController::repairMap(CMap * map) const
 		{
 			if(tnh->getTown())
 			{
-				vstd::erase_if(tnh->builtBuildings, [tnh](BuildingID bid)
+				for(const auto & building : tnh->getBuildings())
 				{
-					return !tnh->getTown()->buildings.count(bid);
-				});
+					if(!tnh->getTown()->buildings.count(building))
+						tnh->removeBuilding(building);
+				}
 				vstd::erase_if(tnh->forbiddenBuildings, [tnh](BuildingID bid)
 				{
 					return !tnh->getTown()->buildings.count(bid);

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -3909,15 +3909,15 @@ bool CGameHandler::sacrificeCreatures(const IMarket * market, const CGHeroInstan
 	return true;
 }
 
-bool CGameHandler::sacrificeArtifact(const IMarket * m, const CGHeroInstance * hero, const std::vector<ArtifactInstanceID> & arts)
+bool CGameHandler::sacrificeArtifact(const IMarket * market, const CGHeroInstance * hero, const ObjectInstanceID & marketId, const std::vector<ArtifactInstanceID> & arts)
 {
 	if (!hero)
 		COMPLAIN_RET("You need hero to sacrifice artifact!");
 	if(hero->getAlignment() == EAlignment::EVIL)
 		COMPLAIN_RET("Evil hero can't sacrifice artifact!");
 
-	assert(m);
-	auto altarObj = dynamic_cast<const CGArtifactsAltar*>(m);
+	assert(market);
+	const auto artSet = getArtSet(marketId);
 
 	int expSum = 0;
 	auto finish = [this, &hero, &expSum]()
@@ -3927,15 +3927,15 @@ bool CGameHandler::sacrificeArtifact(const IMarket * m, const CGHeroInstance * h
 
 	for(const auto & artInstId : arts)
 	{
-		if(auto art = altarObj->getArtByInstanceId(artInstId))
+		if(auto art = artSet->getArtByInstanceId(artInstId))
 		{
 			if(art->artType->isTradable())
 			{
 				int dmp;
 				int expToGive;
-				m->getOffer(art->getTypeId(), 0, dmp, expToGive, EMarketMode::ARTIFACT_EXP);
+				market->getOffer(art->getTypeId(), 0, dmp, expToGive, EMarketMode::ARTIFACT_EXP);
 				expSum += expToGive;
-				removeArtifact(ArtifactLocation(altarObj->id, altarObj->getArtPos(art)));
+				removeArtifact(ArtifactLocation(marketId, artSet->getArtPos(art)));
 			}
 			else
 			{

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -3560,9 +3560,9 @@ bool CGameHandler::isAllowedExchange(ObjectInstanceID id1, ObjectInstanceID id2)
 				return true;
 		}
 
-		auto market = dynamic_cast<const IMarket*>(o1);
+		auto market = getMarket(id1);
 		if(market == nullptr)
-			market = dynamic_cast<const IMarket*>(o2);
+			market = getMarket(id2);
 		if(market)
 			return market->allowsTrade(EMarketMode::ARTIFACT_EXP);
 
@@ -3917,9 +3917,7 @@ bool CGameHandler::sacrificeArtifact(const IMarket * market, const CGHeroInstanc
 		COMPLAIN_RET("Evil hero can't sacrifice artifact!");
 
 	assert(market);
-	const auto mapObj = dynamic_cast<const CGObjectInstance*>(market);
-	assert(mapObj);
-	const auto artSet = getArtSet(mapObj->id);
+	const auto artSet = market->getArtifactsStorage();
 
 	int expSum = 0;
 	auto finish = [this, &hero, &expSum]()
@@ -3937,7 +3935,7 @@ bool CGameHandler::sacrificeArtifact(const IMarket * market, const CGHeroInstanc
 				int expToGive;
 				market->getOffer(art->getTypeId(), 0, dmp, expToGive, EMarketMode::ARTIFACT_EXP);
 				expSum += expToGive;
-				removeArtifact(ArtifactLocation(mapObj->id, artSet->getArtPos(art)));
+				removeArtifact(ArtifactLocation(market->getObjInstanceID(), artSet->getArtPos(art)));
 			}
 			else
 			{

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -2521,7 +2521,7 @@ bool CGameHandler::razeStructure (ObjectInstanceID tid, BuildingID bid)
 {
 ///incomplete, simply erases target building
 	const CGTownInstance * t = getTown(tid);
-	if (!vstd::contains(t->builtBuildings, bid))
+	if(!t->hasBuilt(bid))
 		return false;
 	RazeStructures rs;
 	rs.tid = tid;
@@ -3909,7 +3909,7 @@ bool CGameHandler::sacrificeCreatures(const IMarket * market, const CGHeroInstan
 	return true;
 }
 
-bool CGameHandler::sacrificeArtifact(const IMarket * market, const CGHeroInstance * hero, const ObjectInstanceID & marketId, const std::vector<ArtifactInstanceID> & arts)
+bool CGameHandler::sacrificeArtifact(const IMarket * market, const CGHeroInstance * hero, const std::vector<ArtifactInstanceID> & arts)
 {
 	if (!hero)
 		COMPLAIN_RET("You need hero to sacrifice artifact!");
@@ -3917,7 +3917,9 @@ bool CGameHandler::sacrificeArtifact(const IMarket * market, const CGHeroInstanc
 		COMPLAIN_RET("Evil hero can't sacrifice artifact!");
 
 	assert(market);
-	const auto artSet = getArtSet(marketId);
+	const auto mapObj = dynamic_cast<const CGObjectInstance*>(market);
+	assert(mapObj);
+	const auto artSet = getArtSet(mapObj->id);
 
 	int expSum = 0;
 	auto finish = [this, &hero, &expSum]()
@@ -3935,7 +3937,7 @@ bool CGameHandler::sacrificeArtifact(const IMarket * market, const CGHeroInstanc
 				int expToGive;
 				market->getOffer(art->getTypeId(), 0, dmp, expToGive, EMarketMode::ARTIFACT_EXP);
 				expSum += expToGive;
-				removeArtifact(ArtifactLocation(marketId, artSet->getArtPos(art)));
+				removeArtifact(ArtifactLocation(mapObj->id, artSet->getArtPos(art)));
 			}
 			else
 			{

--- a/server/CGameHandler.h
+++ b/server/CGameHandler.h
@@ -281,7 +281,7 @@ public:
 
 	void start(bool resume);
 	void tick(int millisecondsPassed);
-	bool sacrificeArtifact(const IMarket * m, const CGHeroInstance * hero, const std::vector<ArtifactInstanceID> & arts);
+	bool sacrificeArtifact(const IMarket * market, const CGHeroInstance * hero, const ObjectInstanceID & marketId, const std::vector<ArtifactInstanceID> & arts);
 	void spawnWanderingMonsters(CreatureID creatureID);
 
 	// Check for victory and loss conditions

--- a/server/CGameHandler.h
+++ b/server/CGameHandler.h
@@ -281,7 +281,7 @@ public:
 
 	void start(bool resume);
 	void tick(int millisecondsPassed);
-	bool sacrificeArtifact(const IMarket * market, const CGHeroInstance * hero, const ObjectInstanceID & marketId, const std::vector<ArtifactInstanceID> & arts);
+	bool sacrificeArtifact(const IMarket * market, const CGHeroInstance * hero, const std::vector<ArtifactInstanceID> & arts);
 	void spawnWanderingMonsters(CreatureID creatureID);
 
 	// Check for victory and loss conditions

--- a/server/NetPacksServer.cpp
+++ b/server/NetPacksServer.cpp
@@ -347,7 +347,7 @@ void ApplyGhNetPackVisitor::visitTradeOnMarketplace(TradeOnMarketplace & pack)
 		for(auto const & artInstId : pack.r1)
 			positions.push_back(artInstId.as<ArtifactInstanceID>());
 
-		result = gh.sacrificeArtifact(market, hero, pack.marketId, positions);
+		result = gh.sacrificeArtifact(market, hero, positions);
 		return;
 	}
 	default:

--- a/server/NetPacksServer.cpp
+++ b/server/NetPacksServer.cpp
@@ -347,7 +347,7 @@ void ApplyGhNetPackVisitor::visitTradeOnMarketplace(TradeOnMarketplace & pack)
 		for(auto const & artInstId : pack.r1)
 			positions.push_back(artInstId.as<ArtifactInstanceID>());
 
-		result = gh.sacrificeArtifact(market, hero, positions);
+		result = gh.sacrificeArtifact(market, hero, pack.marketId, positions);
 		return;
 	}
 	default:

--- a/server/NetPacksServer.cpp
+++ b/server/NetPacksServer.cpp
@@ -184,7 +184,7 @@ void ApplyGhNetPackVisitor::visitExchangeArtifacts(ExchangeArtifacts & pack)
 
 void ApplyGhNetPackVisitor::visitBulkExchangeArtifacts(BulkExchangeArtifacts & pack)
 {
-	if(dynamic_cast<const IMarket*>(gh.getObj(pack.srcHero)) == nullptr)
+	if(gh.getMarket(pack.srcHero) == nullptr)
 		gh.throwIfWrongOwner(&pack, pack.srcHero);
 	if(pack.swap)
 		gh.throwIfWrongOwner(&pack, pack.dstHero);
@@ -250,7 +250,7 @@ void ApplyGhNetPackVisitor::visitTradeOnMarketplace(TradeOnMarketplace & pack)
 {
 	const CGObjectInstance * object = gh.getObj(pack.marketId);
 	const CGHeroInstance * hero = gh.getHero(pack.heroId);
-	const auto * market = dynamic_cast<const IMarket*>(object);
+	const auto * market = gh.getMarket(pack.marketId);
 
 	gh.throwIfWrongPlayer(&pack);
 	gh.throwIfPlayerNotActive(&pack);

--- a/test/spells/effects/CatapultTest.cpp
+++ b/test/spells/effects/CatapultTest.cpp
@@ -64,7 +64,7 @@ TEST_F(CatapultTest, NotApplicableInVillage)
 TEST_F(CatapultTest, NotApplicableForDefenderIfSmart)
 {
 	auto fakeTown = std::make_shared<CGTownInstance>(nullptr);
-	fakeTown->builtBuildings.insert(BuildingID::FORT);
+	fakeTown->addBuilding(BuildingID::FORT);
 	mechanicsMock.casterSide = BattleSide::DEFENDER;
 
 	EXPECT_CALL(*battleFake, getDefendedTown()).WillRepeatedly(Return(fakeTown.get()));
@@ -78,7 +78,7 @@ TEST_F(CatapultTest, NotApplicableForDefenderIfSmart)
 TEST_F(CatapultTest, DISABLED_ApplicableInTown)
 {
 	auto fakeTown = std::make_shared<CGTownInstance>(nullptr);
-	fakeTown->builtBuildings.insert(BuildingID::FORT);
+	fakeTown->addBuilding(BuildingID::FORT);
 
 	EXPECT_CALL(*battleFake, getDefendedTown()).WillRepeatedly(Return(fakeTown.get()));
 	EXPECT_CALL(mechanicsMock, adaptProblem(_, _)).Times(0);
@@ -108,7 +108,7 @@ protected:
 	{
 		EffectFixture::setUp();
 		fakeTown = std::make_shared<CGTownInstance>(nullptr);
-		fakeTown->builtBuildings.insert(BuildingID::FORT);
+		fakeTown->addBuilding(BuildingID::FORT);
 	}
 private:
 	std::shared_ptr<CGTownInstance> fakeTown;


### PR DESCRIPTION
IMarket now directly owns the CArtifactSet, which is required for the artifact altar. 
To save memory, IMarket itself allocates/deallocates the internal CArtifactSet if necessary. 
The CGArtifactsAltar class has been removed as no longer needed. 
IMarket is also now a serializable class. (This PR breaks save compatibility)

@Laserlicht  Now you can enable grotto at the cove.