### PR TITLE
Allow lowercase 'X' in spellRangeInHexes JSON property

### DIFF
--- a/lib/spells/CSpellHandler.cpp
+++ b/lib/spells/CSpellHandler.cpp
@@ -687,7 +687,7 @@ std::vector<int> CSpellHandler::spellRangeInHexes(std::string input) const
 	std::set<BattleHex> ret;
 	std::string rng = input + ','; //copy + artificial comma for easier handling
 
-	if(rng.size() >= 2 && rng[0] != 'X') //there is at least one hex in range (+artificial comma)
+	if(rng.size() >= 2 && rng[0] != 'X' && rng[0] != 'x') //there is at least one hex in range (+artificial comma)
 	{
 		std::string number1;
 		std::string number2;


### PR DESCRIPTION
When JSON property has lowercase 'X' instead of uppercase it throws unhandled exception on the line: https://github.com/vcmi/vcmi/blob/11ac76859932ce3cb8338d01d5efc8963465bde7/lib/spells/CSpellHandler.cpp#L711