### PR TITLE
Update ffmpeg

### DIFF
--- a/CI/android-32/before_install.sh
+++ b/CI/android-32/before_install.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
-DEPS_FILENAME=armeabi-v7a
+DEPS_FILENAME=dependencies-android-32
 . CI/android/before_install.sh

--- a/CI/android-64/before_install.sh
+++ b/CI/android-64/before_install.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
-DEPS_FILENAME=aarch64-v8a
+DEPS_FILENAME=dependencies-android-64
 . CI/android/before_install.sh

--- a/CI/android/before_install.sh
+++ b/CI/android/before_install.sh
@@ -5,5 +5,5 @@ echo "ANDROID_NDK_ROOT=$ANDROID_HOME/ndk/25.2.9519653" >> $GITHUB_ENV
 brew install ninja
 
 mkdir ~/.conan ; cd ~/.conan
-curl -L "https://github.com/vcmi/vcmi-dependencies/releases/download/android-1.1/$DEPS_FILENAME.txz" \
-	| tar -xf - --xz
+curl -L "https://github.com/vcmi/vcmi-dependencies/releases/download/1.2/$DEPS_FILENAME.tgz" \
+	| tar -xzf -

--- a/CI/android/before_install.sh
+++ b/CI/android/before_install.sh
@@ -4,6 +4,4 @@ echo "ANDROID_NDK_ROOT=$ANDROID_HOME/ndk/25.2.9519653" >> $GITHUB_ENV
 
 brew install ninja
 
-mkdir ~/.conan ; cd ~/.conan
-curl -L "https://github.com/vcmi/vcmi-dependencies/releases/download/1.2/$DEPS_FILENAME.tgz" \
-	| tar -xzf -
+. CI/install_conan_dependencies.sh "$DEPS_FILENAME"

--- a/CI/install_conan_dependencies.sh
+++ b/CI/install_conan_dependencies.sh
@@ -2,8 +2,8 @@
 
 RELEASE_TAG="1.2"
 FILENAME="$1"
-DOWNLOAD_URL="https://github.com/vcmi/vcmi-dependencies/releases/download/$RELEASE_TAG/$FILENAME.tgz"
+DOWNLOAD_URL="https://github.com/vcmi/vcmi-dependencies/releases/download/$RELEASE_TAG/$FILENAME.txz"
 
 mkdir ~/.conan
 cd ~/.conan
-curl -L "$DOWNLOAD_URL" | tar -xzf -
+curl -L "$DOWNLOAD_URL" | tar -xf - --xz

--- a/CI/install_conan_dependencies.sh
+++ b/CI/install_conan_dependencies.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+RELEASE_TAG="1.2"
+FILENAME="$1"
+DOWNLOAD_URL="https://github.com/vcmi/vcmi-dependencies/releases/download/$RELEASE_TAG/$FILENAME.tgz"
+
+mkdir ~/.conan
+cd ~/.conan
+curl -L "$DOWNLOAD_URL" | tar -xzf -

--- a/CI/ios/before_install.sh
+++ b/CI/ios/before_install.sh
@@ -2,6 +2,4 @@
 
 echo DEVELOPER_DIR=/Applications/Xcode_14.2.app >> $GITHUB_ENV
 
-mkdir ~/.conan ; cd ~/.conan
-curl -L 'https://github.com/vcmi/vcmi-dependencies/releases/download/1.2/dependencies-ios.tgz' \
-	| tar -xzf -
+. CI/install_conan_dependencies.sh "dependencies-ios"

--- a/CI/ios/before_install.sh
+++ b/CI/ios/before_install.sh
@@ -3,5 +3,5 @@
 echo DEVELOPER_DIR=/Applications/Xcode_14.2.app >> $GITHUB_ENV
 
 mkdir ~/.conan ; cd ~/.conan
-curl -L 'https://github.com/vcmi/vcmi-ios-deps/releases/download/1.2.1/ios-arm64.txz' \
-	| tar -xf -
+curl -L 'https://github.com/vcmi/vcmi-dependencies/releases/download/1.2/dependencies-ios.tgz' \
+	| tar -xzf -

--- a/CI/mac-arm/before_install.sh
+++ b/CI/mac-arm/before_install.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
-DEPS_FILENAME=intel-cross-arm
+DEPS_FILENAME=dependencies-mac-arm
 . CI/mac/before_install.sh

--- a/CI/mac-intel/before_install.sh
+++ b/CI/mac-intel/before_install.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
-DEPS_FILENAME=intel
+DEPS_FILENAME=dependencies-mac-intel
 . CI/mac/before_install.sh

--- a/CI/mac/before_install.sh
+++ b/CI/mac/before_install.sh
@@ -4,6 +4,4 @@ echo DEVELOPER_DIR=/Applications/Xcode_14.2.app >> $GITHUB_ENV
 
 brew install ninja
 
-mkdir ~/.conan ; cd ~/.conan
-curl -L "https://github.com/vcmi/vcmi-dependencies/releases/download/1.2/$DEPS_FILENAME.tgz" \
-	| tar -xzf -
+. CI/install_conan_dependencies.sh "$DEPS_FILENAME"

--- a/CI/mac/before_install.sh
+++ b/CI/mac/before_install.sh
@@ -5,5 +5,5 @@ echo DEVELOPER_DIR=/Applications/Xcode_14.2.app >> $GITHUB_ENV
 brew install ninja
 
 mkdir ~/.conan ; cd ~/.conan
-curl -L "https://github.com/vcmi/vcmi-deps-macos/releases/download/1.2.1/$DEPS_FILENAME.txz" \
-	| tar -xf -
+curl -L "https://github.com/vcmi/vcmi-dependencies/releases/download/1.2/$DEPS_FILENAME.tgz" \
+	| tar -xzf -

--- a/CI/mingw-32/before_install.sh
+++ b/CI/mingw-32/before_install.sh
@@ -12,5 +12,5 @@ curl -O -L http://mirrors.kernel.org/ubuntu/pool/universe/m/mingw-w64/mingw-w64-
   && sudo dpkg -i mingw-w64-i686-dev_10.0.0-3_all.deb;
 
 mkdir ~/.conan ; cd ~/.conan
-curl -L "https://github.com/vcmi/vcmi-deps-windows-conan/releases/download/1.2/vcmi-deps-windows-conan-w32.tgz" \
+curl -L "https://github.com/vcmi/vcmi-dependencies/releases/download/1.2/dependencies-mingw-32.tgz" \
 	| tar -xzf -

--- a/CI/mingw-32/before_install.sh
+++ b/CI/mingw-32/before_install.sh
@@ -11,6 +11,4 @@ curl -O -L http://mirrors.kernel.org/ubuntu/pool/universe/m/mingw-w64/mingw-w64-
 curl -O -L http://mirrors.kernel.org/ubuntu/pool/universe/m/mingw-w64/mingw-w64-i686-dev_10.0.0-3_all.deb \
   && sudo dpkg -i mingw-w64-i686-dev_10.0.0-3_all.deb;
 
-mkdir ~/.conan ; cd ~/.conan
-curl -L "https://github.com/vcmi/vcmi-dependencies/releases/download/1.2/dependencies-mingw-32.tgz" \
-	| tar -xzf -
+. CI/install_conan_dependencies.sh "dependencies-mingw-32"

--- a/CI/mingw/before_install.sh
+++ b/CI/mingw/before_install.sh
@@ -12,5 +12,5 @@ curl -O -L http://mirrors.kernel.org/ubuntu/pool/universe/m/mingw-w64/mingw-w64-
   && sudo dpkg -i mingw-w64-x86-64-dev_10.0.0-3_all.deb;
 
 mkdir ~/.conan ; cd ~/.conan
-curl -L "https://github.com/vcmi/vcmi-deps-windows-conan/releases/download/1.2/vcmi-deps-windows-conan-w64.tgz" \
+curl -L "https://github.com/vcmi/vcmi-dependencies/releases/download/1.2/dependencies-mingw.tgz" \
 	| tar -xzf -

--- a/CI/mingw/before_install.sh
+++ b/CI/mingw/before_install.sh
@@ -11,6 +11,4 @@ curl -O -L http://mirrors.kernel.org/ubuntu/pool/universe/m/mingw-w64/mingw-w64-
 curl -O -L http://mirrors.kernel.org/ubuntu/pool/universe/m/mingw-w64/mingw-w64-x86-64-dev_10.0.0-3_all.deb \
   && sudo dpkg -i mingw-w64-x86-64-dev_10.0.0-3_all.deb;
 
-mkdir ~/.conan ; cd ~/.conan
-curl -L "https://github.com/vcmi/vcmi-dependencies/releases/download/1.2/dependencies-mingw.tgz" \
-	| tar -xzf -
+. CI/install_conan_dependencies.sh "dependencies-mingw"

--- a/client/media/CVideoHandler.cpp
+++ b/client/media/CVideoHandler.cpp
@@ -339,10 +339,11 @@ FFMpegStream::~FFMpegStream()
 {
 	av_frame_free(&frame);
 
+#if (LIBAVCODEC_VERSION_MAJOR < 61 )
+	// deprecated, apparently no longer necessary - avcodec_free_context should suffice
 	avcodec_close(codecContext);
-	avcodec_free_context(&codecContext);
+#endif
 
-	avcodec_close(codecContext);
 	avcodec_free_context(&codecContext);
 
 	avformat_close_input(&formatContext);

--- a/docs/developers/Conan.md
+++ b/docs/developers/Conan.md
@@ -27,12 +27,12 @@ The following platforms are supported and known to work, others might require ch
     - **Windows**: libraries are built with x86_64-mingw-w64-gcc version 10 (which is available in repositories of Ubuntu 22.04)
     - **Android**: libraries are built with NDK r25c (25.2.9519653)
 
-2. Download the binaries archive and unpack it to `~/.conan` directory:
+2. Download the binaries archive and unpack it to `~/.conan` directory from https://github.com/vcmi/vcmi-dependencies/releases/latest
 
-    - [macOS](https://github.com/vcmi/vcmi-deps-macos/releases/latest): pick **intel.txz** if you have Intel Mac, otherwise - **intel-cross-arm.txz**
-    - [iOS](https://github.com/vcmi/vcmi-ios-deps/releases/latest)
-    - [Windows](https://github.com/vcmi/vcmi-deps-windows-conan/releases/latest): pick **vcmi-deps-windows-conan-w64.tgz** if you want x86_64, otherwise pick **vcmi-deps-windows-conan-w32.tgz**
-    - [Android](https://github.com/vcmi/vcmi-dependencies/releases): current limitation is that building works only on a macOS host due to Qt 5 for Android being compiled on macOS. Simply delete directory `~/.conan/data/qt/5.15.x/_/_/package` (`5.15.x` is a placeholder) after unpacking the archive and build Qt from source. Alternatively, if you have (or are [willing to build](https://github.com/vcmi/vcmi-ios-deps#note-for-arm-macs)) Qt host tools for your platform, then simply replace those in the archive with yours and most probably it would work.
+    - macOS: pick **dependencies-mac-intel.txz** if you have Intel Mac, otherwise - **dependencies-mac-arm.txz**
+    - iOS: pick ***dependencies-ios.txz***
+    - Windows: currently only mingw is supported. Pick **dependencies-mingw.tgz** if you want x86_64, otherwise pick **dependencies-mingw-32.tgz**
+    - Android: current limitation is that building works only on a macOS host due to Qt 5 for Android being compiled on macOS. Simply delete directory `~/.conan/data/qt/5.15.x/_/_/package` (`5.15.x` is a placeholder) after unpacking the archive and build Qt from source. Alternatively, if you have (or are [willing to build](https://github.com/vcmi/vcmi-ios-deps#note-for-arm-macs)) Qt host tools for your platform, then simply replace those in the archive with yours and most probably it would work.
 
 3. Only if you have Apple Silicon Mac and trying to build for macOS or iOS:
 

--- a/docs/modders/File_Formats.md
+++ b/docs/modders/File_Formats.md
@@ -1,0 +1,80 @@
+# File Formats
+
+This page describes which file formats are supported by vcmi. 
+
+In most cases, VCMI supports formats that were supported by Heroes III, with addition of new formats that are more convenient to use without specialized tools. See categories below for more details on specific formats
+
+### Images
+
+For images VCMI supports:
+- png. Recommended for usage in mods
+- bmp. While this format is supported, bmp images have no compressions leading to large file sizes
+- pcx (h3 version). Note that this is format that is specific to Heroes III and has nothing in common with widely known .pcx format. Files in this format generally can only be found inside of .lod archive of Heroes III and are usually extracted as .bmp files
+
+Transparency support:
+VCMI supports transparency (alpha) channel, both in png and in bmp images. There may be cases where transparency is not fully supported. If you discover such cases, please report them.
+
+For performance reasons, please use alpha channel only in places where transparency is actually required and remove alpha channel from image othervice
+
+Palette support:
+TODO: describe how palettes work in vcmi
+
+### Animations
+
+For animations VCMI supports .def format from Heroes III as well as alternative json-based. See [Animation Format](Animation_Format.md) for more details
+
+### Sounds
+
+For sounds VCMI currently requires .wav format. Generally, VCMI will support any .wav parameters, however you might want to use high-bitrate versions, such as 44100 Hz or 48000 Hz, 32 bit, 1 or 2 channels
+
+Support for additional formats, such as ogg/vorbis and ogg/opus is likely to be added in future
+
+### Music
+
+For sounds VCMI currently requires .mp3 format. Support for additional formats, such as ogg/vorbis and ogg/opus is likely to be added in future
+
+### Video
+
+Starting from VCMI 1.6, following video container formats are supported by VCMI:
+
+- .bik - one of the formats used by Heroes III
+- .smk - one of the formats used by Heroes III. Note that these videos generally have lower quality and are only used as fallback if no other formats are found
+- .ogv - format used by Heroes III: HD Edition
+- .webm - modern, free format that is recommended for modding.
+
+Supported video codecs:
+- bink and smacker - formats used by Heroes III, should be used only to avoid re-encoding
+- theora - used by Heroes III: HD Edition
+- vp8 - modern format with way better compression compared to formats used by Heroes III
+- vp9 - recommended, this format is improvement of vp9 format and should be used as a default option
+
+Support for av1 video codec is likely to be added in future.
+
+Supported audio codecs:
+- binkaudio and smackaud - formats used by Heroes III
+- vorbis - modern format with good compression level
+- opus - recommended, improvement over vorbis. Any bitrate is supported, with 128 kbit probably being the best option
+
+### Json
+
+For most of configuration files, VCMI uses [JSON format](http://en.wikipedia.org/wiki/Json) with some extensions from [JSON5](https://spec.json5.org/) format, such as comments.
+
+### Maps
+
+TODO: describe
+
+### Campaigns
+
+TODO: describe
+
+### Map Templates
+
+TODO: describe
+
+### Archives
+
+TODO: describe
+
+### Txt
+
+TODO: describe

--- a/docs/modders/Readme.md
+++ b/docs/modders/Readme.md
@@ -19,8 +19,10 @@ Example of how directory structure of your mod may look like:
                 music/   - music files. Mp3 and ogg/vorbis are supported
                 sounds/  - sound files, in wav format.
                 sprites/ - animation, image sets (H3 .def files or VCMI .json files)
-                video/   - video files, .bik or .smk
+                video/   - video files, .bik, .smk, .ogv .webm
 ```
+See [File Formats](File_Formats.md) page for more information on which formats are supported or recommended for vcmi
+
 
 ## Creating mod file
 

--- a/lib/filesystem/ResourcePath.cpp
+++ b/lib/filesystem/ResourcePath.cpp
@@ -115,6 +115,7 @@ EResType EResTypeHelper::getTypeFromExtension(std::string extension)
 		{".FLAC",  EResType::SOUND},
 		{".SMK",   EResType::VIDEO_LOW_QUALITY},
 		{".BIK",   EResType::VIDEO},
+		{".OGV",   EResType::VIDEO},
 		{".WEBM",  EResType::VIDEO},
 		{".ZIP",   EResType::ARCHIVE_ZIP},
 		{".LOD",   EResType::ARCHIVE_LOD},

--- a/lib/filesystem/ResourcePath.h
+++ b/lib/filesystem/ResourcePath.h
@@ -28,7 +28,7 @@ class JsonSerializeFormat;
  * Font: .fnt
  * Image: .bmp, .jpg, .pcx, .png, .tga
  * Sound: .wav .82m
- * Video: .smk, .bik .mjpg .mpg .webm
+ * Video: .smk, .bik .ogv .webm
  * Music: .mp3, .ogg
  * Archive: .lod, .snd, .vid .pac .zip
  * Palette: .pal


### PR DESCRIPTION
Continuation of https://github.com/vcmi/vcmi/pull/4461

Part 1 - update conan ffmpeg configuration:
- updated options to include new options added in upstream
- enabled swresample to allow audio resampling via ffmpeg instead of custom methods
- disabled all components other than those that are needed for vcmi
- changed required version to allow newer ffmpeg versions

Part 2 - use newer dependencies package from shared repository (instead of repository-per-platform)

Part 3 - update code to reflect changes
- [x] make sure that code compiles with new ffmpeg
- [x] test new package on all affected platforms
- [x] update documentation for modders on what video formats are supported
- [x] check our virtual filesystem to make sure that list of extensions recognized as video files matches with actually supported formats