### PR TITLE
Optimize CMap::isInTheMap

### DIFF
--- a/lib/mapping/CMap.cpp
+++ b/lib/mapping/CMap.cpp
@@ -332,15 +332,6 @@ bool CMap::isCoastalTile(const int3 & pos) const
 	return false;
 }
 
-bool CMap::isInTheMap(const int3 & pos) const
-{
-	// Check whether coord < 0 is done implicitly. Negative signed int overflows to unsigned number larger than all signed ints.
-	return
-		static_cast<uint32_t>(pos.x) < static_cast<uint32_t>(width) &&
-		static_cast<uint32_t>(pos.y) < static_cast<uint32_t>(height) &&
-		static_cast<uint32_t>(pos.z) <= (twoLevel ? 1 : 0);
-}
-
 TerrainTile & CMap::getTile(const int3 & tile)
 {
 	assert(isInTheMap(tile));

--- a/lib/mapping/CMap.cpp
+++ b/lib/mapping/CMap.cpp
@@ -334,7 +334,11 @@ bool CMap::isCoastalTile(const int3 & pos) const
 
 bool CMap::isInTheMap(const int3 & pos) const
 {
-	return pos.x >= 0 && pos.y >= 0 && pos.z >= 0 && pos.x < width && pos.y < height && pos.z <= (twoLevel ? 1 : 0);
+	// Check whether coord < 0 is done implicitly. Negative signed int overflows to unsigned number larger than all signed ints.
+	return
+		static_cast<uint32_t>(pos.x) < static_cast<uint32_t>(width) &&
+		static_cast<uint32_t>(pos.y) < static_cast<uint32_t>(height) &&
+		static_cast<uint32_t>(pos.z) <= (twoLevel ? 1 : 0);
 }
 
 TerrainTile & CMap::getTile(const int3 & tile)

--- a/lib/mapping/CMap.h
+++ b/lib/mapping/CMap.h
@@ -84,8 +84,15 @@ public:
 	TerrainTile & getTile(const int3 & tile);
 	const TerrainTile & getTile(const int3 & tile) const;
 	bool isCoastalTile(const int3 & pos) const;
-	bool isInTheMap(const int3 & pos) const;
 	bool isWaterTile(const int3 & pos) const;
+	inline bool isInTheMap(const int3 & pos) const
+	{
+		// Check whether coord < 0 is done implicitly. Negative signed int overflows to unsigned number larger than all signed ints.
+		return
+			static_cast<uint32_t>(pos.x) < static_cast<uint32_t>(width) &&
+			static_cast<uint32_t>(pos.y) < static_cast<uint32_t>(height) &&
+			static_cast<uint32_t>(pos.z) <= (twoLevel ? 1 : 0);
+	}
 
 	bool canMoveBetween(const int3 &src, const int3 &dst) const;
 	bool checkForVisitableDir(const int3 & src, const TerrainTile * pom, const int3 & dst) const;


### PR DESCRIPTION
replace x >= 0 && x < size by (unsigned)x < size

By converting signed coordinate to unsigned number, negative values became very large positive ones, larger than every positive signed number and therefore also bigger than the map size. As a result check against size also implicitly checks if coordinate is negative.

Compiler cannot do this transformation automatically because it doesn't know that map dimensions are always positive.

The change shrinks isInTheMap from 19 instructions to 11 on x86.