### PR TITLE
Fix campaign hero placeholder

### DIFF
--- a/lib/mapObjectConstructors/CObjectClassesHandler.cpp
+++ b/lib/mapObjectConstructors/CObjectClassesHandler.cpp
@@ -343,7 +343,7 @@ TObjectTypeHandler CObjectClassesHandler::getHandlerFor(MapObjectID type, MapObj
 			return objects.front()->objects.front();
 
 		auto subID = subtype.getNum();
-		if (type == Obj::PRISON)
+		if (type == Obj::PRISON || type == Obj::HERO_PLACEHOLDER)
 			subID = 0;
 		auto result = objects.at(type.getNum())->objects.at(subID);
 

--- a/lib/mapping/MapFormatJson.cpp
+++ b/lib/mapping/MapFormatJson.cpp
@@ -329,6 +329,8 @@ void CMapFormatJson::serializeHeader(JsonSerializeFormat & handler)
 
 	handler.serializeStruct("defeatMessage", mapHeader->defeatMessage);
 	handler.serializeInt("defeatIconIndex", mapHeader->defeatIconIndex);
+
+	handler.serializeIdArray("reservedCampaignHeroes", mapHeader->reservedCampaignHeroes);
 }
 
 void CMapFormatJson::serializePlayerInfo(JsonSerializeFormat & handler)

--- a/mapeditor/inspector/inspector.cpp
+++ b/mapeditor/inspector/inspector.cpp
@@ -475,7 +475,7 @@ void Inspector::updateProperties()
 	addProperty("TypeName", obj->typeName);
 	addProperty("SubTypeName", obj->subTypeName);
 	
-	if(!dynamic_cast<CGHeroInstance*>(obj))
+	if(!dynamic_cast<CGHeroInstance*>(obj) && obj->ID != Obj::HERO_PLACEHOLDER)
 	{
 		auto factory = VLC->objtypeh->getHandlerFor(obj->ID, obj->subID);
 		addProperty("IsStatic", factory->isStaticObject());

--- a/mapeditor/inspector/inspector.cpp
+++ b/mapeditor/inspector/inspector.cpp
@@ -475,7 +475,7 @@ void Inspector::updateProperties()
 	addProperty("TypeName", obj->typeName);
 	addProperty("SubTypeName", obj->subTypeName);
 	
-	if(!dynamic_cast<CGHeroInstance*>(obj) && obj->ID != Obj::HERO_PLACEHOLDER)
+	if(obj->ID != Obj::HERO_PLACEHOLDER && !dynamic_cast<CGHeroInstance*>(obj))
 	{
 		auto factory = VLC->objtypeh->getHandlerFor(obj->ID, obj->subID);
 		addProperty("IsStatic", factory->isStaticObject());

--- a/mapeditor/mainwindow.cpp
+++ b/mapeditor/mainwindow.cpp
@@ -452,6 +452,18 @@ void MainWindow::saveMap()
 	
 	Translations::cleanupRemovedItems(*controller.map());
 
+	for(auto obj : controller.map()->objects)
+	{
+		if(obj->ID == Obj::HERO_PLACEHOLDER)
+		{
+			auto hero = dynamic_cast<CGHeroPlaceholder *>(obj.get());
+			if(hero->heroType.has_value())
+			{
+				controller.map()->reservedCampaignHeroes.insert(hero->heroType.value());
+			}
+		}
+	}
+
 	CMapService mapService;
 	try
 	{


### PR DESCRIPTION
Added missing `reservedCampaignHeroes` to vmap serialization
Added populating `reservedCampaignHeroes` while saving map in map editor
Fixed reading hero placeholder from h3m maps

Fixes #4376
Fixes #4258