### PR TITLE
[1.5.7] Minor fixes

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,9 +3,11 @@
 * Fixed game freeze if player is attacked in online multiplayer game by another player when he has unread dialogs, such as new week notification
 * Fixed heroes on map limit game setting not respected when moving hero from town garrison.
 * Add workaround to fix possible crash on attempt to start previously generated random map that has players without owned heroes or towns
-* Fix crash on right-clicking spell icon when receiving unlearnable spells from Pandora
+* Fixed crash on right-clicking spell icon when receiving unlearnable spells from Pandora
 * Fixed possible text overflow in match information box in online lobby
 * Fixed overlapping text in lobby login window
+* Fixed excessive removal of open dialogs such as new week or map events on new turn
+* Fixed objects like Mystical Gardens not resetting their state on new week correctly
 
 # 1.5.5 -> 1.5.6
 

--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -193,11 +193,6 @@ void CPlayerInterface::closeAllDialogs()
 		castleInt->close();
 
 	castleInt = nullptr;
-
-	// remove all pending dialogs that do not expect query answer
-	vstd::erase_if(dialogs, [](const std::shared_ptr<CInfoWindow> & window){
-		return window->ID == QueryID::NONE;
-	});
 }
 
 void CPlayerInterface::playerEndsTurn(PlayerColor player)
@@ -207,6 +202,11 @@ void CPlayerInterface::playerEndsTurn(PlayerColor player)
 	{
 		makingTurn = false;
 		closeAllDialogs();
+
+		// remove all pending dialogs that do not expect query answer
+		vstd::erase_if(dialogs, [](const std::shared_ptr<CInfoWindow> & window){
+						   return window->ID == QueryID::NONE;
+					   });
 	}
 }
 
@@ -1511,7 +1511,7 @@ void CPlayerInterface::update()
 		return;
 
 	//if there are any waiting dialogs, show them
-	if ((CSH->howManyPlayerInterfaces() <= 1 || makingTurn) && !dialogs.empty() && !showingDialog->isBusy())
+	if (makingTurn && !dialogs.empty() && !showingDialog->isBusy())
 	{
 		showingDialog->setBusy();
 		GH.windows().pushWindow(dialogs.front());

--- a/lib/rewardable/Info.cpp
+++ b/lib/rewardable/Info.cpp
@@ -338,6 +338,7 @@ void Rewardable::Info::configureRewards(
 void Rewardable::Info::configureObject(Rewardable::Configuration & object, CRandomGenerator & rng, IGameCallback * cb) const
 {
 	object.info.clear();
+	object.variables.values.clear();
 
 	configureVariables(object, rng, cb, parameters["variables"]);
 


### PR DESCRIPTION
Few more minor fixes for 1.5.7 that were reported recently:
- Fixed excessive removal of dialogs on new day, e.g. new week dialog and map timed events
- Fixed reset of objects like Mystical Garden
  - Fixes #4489