### PR TITLE
Android buildid increment hack

### DIFF
--- a/.github/workflows/github.yml
+++ b/.github/workflows/github.yml
@@ -177,6 +177,11 @@ jobs:
         distribution: 'temurin'
         java-version: '11'
 
+    # a hack to build ID for x64 build in order for Google Play to allow upload of both 32 and 64 bit builds
+    - name: Bump Android x64 build ID
+      if: ${{ matrix.platform == 'android-64' }}
+      run: perl -i -pe 's/versionCode (\d+)/$x=$1+1; "versionCode $x"/e' android/vcmi-app/build.gradle
+
     - name: Build Number
       run: |
         source '${{github.workspace}}/CI/get_package_name.sh'


### PR DESCRIPTION
Increment build ID for x64 android build automatically in CI.

Doing this manual for every release is too tiring. If somebody comes up with a better solution - feel free to replace it.