### PR TITLE
remove never used code in CBonusSystemNode

### DIFF
--- a/AI/BattleAI/StackWithBonuses.cpp
+++ b/AI/BattleAI/StackWithBonuses.cpp
@@ -132,10 +132,10 @@ SlotID StackWithBonuses::unitSlot() const
 }
 
 TConstBonusListPtr StackWithBonuses::getAllBonuses(const CSelector & selector, const CSelector & limit,
-	const CBonusSystemNode * root, const std::string & cachingStr) const
+	const std::string & cachingStr) const
 {
 	auto ret = std::make_shared<BonusList>();
-	TConstBonusListPtr originalList = origBearer->getAllBonuses(selector, limit, root, cachingStr);
+	TConstBonusListPtr originalList = origBearer->getAllBonuses(selector, limit, cachingStr);
 
 	vstd::copy_if(*originalList, std::back_inserter(*ret), [this](const std::shared_ptr<Bonus> & b)
 	{

--- a/AI/BattleAI/StackWithBonuses.h
+++ b/AI/BattleAI/StackWithBonuses.h
@@ -91,7 +91,7 @@ public:
 
 	///IBonusBearer
 	TConstBonusListPtr getAllBonuses(const CSelector & selector, const CSelector & limit,
-		const CBonusSystemNode * root = nullptr, const std::string & cachingStr = "") const override;
+		const std::string & cachingStr = "") const override;
 
 	int64_t getTreeVersion() const override;
 

--- a/lib/battle/CUnitState.cpp
+++ b/lib/battle/CUnitState.cpp
@@ -900,9 +900,9 @@ CUnitStateDetached::CUnitStateDetached(const IUnitInfo * unit_, const IBonusBear
 {
 }
 
-TConstBonusListPtr CUnitStateDetached::getAllBonuses(const CSelector & selector, const CSelector & limit, const CBonusSystemNode * root, const std::string & cachingStr) const
+TConstBonusListPtr CUnitStateDetached::getAllBonuses(const CSelector & selector, const CSelector & limit, const std::string & cachingStr) const
 {
-	return bonus->getAllBonuses(selector, limit, root, cachingStr);
+	return bonus->getAllBonuses(selector, limit, cachingStr);
 }
 
 int64_t CUnitStateDetached::getTreeVersion() const

--- a/lib/battle/CUnitState.h
+++ b/lib/battle/CUnitState.h
@@ -282,7 +282,7 @@ public:
 	explicit CUnitStateDetached(const IUnitInfo * unit_, const IBonusBearer * bonus_);
 
 	TConstBonusListPtr getAllBonuses(const CSelector & selector, const CSelector & limit,
-		const CBonusSystemNode * root = nullptr, const std::string & cachingStr = "") const override;
+		const std::string & cachingStr = "") const override;
 
 	int64_t getTreeVersion() const override;
 

--- a/lib/bonuses/CBonusSystemNode.cpp
+++ b/lib/bonuses/CBonusSystemNode.cpp
@@ -107,10 +107,9 @@ void CBonusSystemNode::getAllBonusesRec(BonusList &out, const CSelector & select
 	}
 }
 
-TConstBonusListPtr CBonusSystemNode::getAllBonuses(const CSelector &selector, const CSelector &limit, const CBonusSystemNode *root, const std::string &cachingStr) const
+TConstBonusListPtr CBonusSystemNode::getAllBonuses(const CSelector &selector, const CSelector &limit, const std::string &cachingStr) const
 {
-	bool limitOnUs = (!root || root == this); //caching won't work when we want to limit bonuses against an external node
-	if (CBonusSystemNode::cachingEnabled && limitOnUs)
+	if (CBonusSystemNode::cachingEnabled)
 	{
 		// Exclusive access for one thread
 		boost::lock_guard<boost::mutex> lock(sync);
@@ -157,11 +156,11 @@ TConstBonusListPtr CBonusSystemNode::getAllBonuses(const CSelector &selector, co
 	}
 	else
 	{
-		return getAllBonusesWithoutCaching(selector, limit, root);
+		return getAllBonusesWithoutCaching(selector, limit);
 	}
 }
 
-TConstBonusListPtr CBonusSystemNode::getAllBonusesWithoutCaching(const CSelector &selector, const CSelector &limit, const CBonusSystemNode *root) const
+TConstBonusListPtr CBonusSystemNode::getAllBonusesWithoutCaching(const CSelector &selector, const CSelector &limit) const
 {
 	auto ret = std::make_shared<BonusList>();
 
@@ -169,29 +168,7 @@ TConstBonusListPtr CBonusSystemNode::getAllBonusesWithoutCaching(const CSelector
 	BonusList beforeLimiting;
 	BonusList afterLimiting;
 	getAllBonusesRec(beforeLimiting, selector);
-
-	if(!root || root == this)
-	{
-		limitBonuses(beforeLimiting, afterLimiting);
-	}
-	else if(root)
-	{
-		//We want to limit our query against an external node. We get all its bonuses,
-		// add the ones we're considering and see if they're cut out by limiters
-		BonusList rootBonuses;
-		BonusList limitedRootBonuses;
-		getAllBonusesRec(rootBonuses, selector);
-
-		for(const auto & b : beforeLimiting)
-			rootBonuses.push_back(b);
-
-		root->limitBonuses(rootBonuses, limitedRootBonuses);
-
-		for(const auto & b : beforeLimiting)
-			if(vstd::contains(limitedRootBonuses, b))
-				afterLimiting.push_back(b);
-
-	}
+	limitBonuses(beforeLimiting, afterLimiting);
 	afterLimiting.getBonuses(*ret, selector, limit);
 	ret->stackBonuses();
 	return ret;

--- a/lib/bonuses/CBonusSystemNode.h
+++ b/lib/bonuses/CBonusSystemNode.h
@@ -53,7 +53,7 @@ private:
 	mutable boost::mutex sync;
 
 	void getAllBonusesRec(BonusList &out, const CSelector & selector) const;
-	TConstBonusListPtr getAllBonusesWithoutCaching(const CSelector &selector, const CSelector &limit, const CBonusSystemNode *root = nullptr) const;
+	TConstBonusListPtr getAllBonusesWithoutCaching(const CSelector &selector, const CSelector &limit) const;
 	std::shared_ptr<Bonus> getUpdatedBonus(const std::shared_ptr<Bonus> & b, const TUpdaterPtr & updater) const;
 
 	void getRedParents(TCNodes &out) const;  //retrieves list of red parent nodes (nodes bonuses propagate from)
@@ -86,7 +86,7 @@ public:
 
 	void limitBonuses(const BonusList &allBonuses, BonusList &out) const; //out will bo populed with bonuses that are not limited here
 	TBonusListPtr limitBonuses(const BonusList &allBonuses) const; //same as above, returns out by val for convenience
-	TConstBonusListPtr getAllBonuses(const CSelector &selector, const CSelector &limit, const CBonusSystemNode *root = nullptr, const std::string &cachingStr = "") const override;
+	TConstBonusListPtr getAllBonuses(const CSelector &selector, const CSelector &limit, const std::string &cachingStr = "") const override;
 	void getParents(TCNodes &out) const;  //retrieves list of parent nodes (nodes to inherit bonuses from),
 
 	/// Returns first bonus matching selector

--- a/lib/bonuses/IBonusBearer.cpp
+++ b/lib/bonuses/IBonusBearer.cpp
@@ -17,7 +17,7 @@ VCMI_LIB_NAMESPACE_BEGIN
 
 int IBonusBearer::valOfBonuses(const CSelector &selector, const std::string &cachingStr) const
 {
-	TConstBonusListPtr hlp = getAllBonuses(selector, nullptr, nullptr, cachingStr);
+	TConstBonusListPtr hlp = getAllBonuses(selector, nullptr, cachingStr);
 	return hlp->totalValue();
 }
 
@@ -34,12 +34,12 @@ bool IBonusBearer::hasBonus(const CSelector &selector, const CSelector &limit, c
 
 TConstBonusListPtr IBonusBearer::getBonuses(const CSelector &selector, const std::string &cachingStr) const
 {
-	return getAllBonuses(selector, nullptr, nullptr, cachingStr);
+	return getAllBonuses(selector, nullptr, cachingStr);
 }
 
 TConstBonusListPtr IBonusBearer::getBonuses(const CSelector &selector, const CSelector &limit, const std::string &cachingStr) const
 {
-	return getAllBonuses(selector, limit, nullptr, cachingStr);
+	return getAllBonuses(selector, limit, cachingStr);
 }
 
 int IBonusBearer::valOfBonuses(BonusType type) const

--- a/lib/bonuses/IBonusBearer.h
+++ b/lib/bonuses/IBonusBearer.h
@@ -22,7 +22,7 @@ public:
 	//interface
 	IBonusBearer() = default;
 	virtual ~IBonusBearer() = default;
-	virtual TConstBonusListPtr getAllBonuses(const CSelector &selector, const CSelector &limit, const CBonusSystemNode *root = nullptr, const std::string &cachingStr = "") const = 0;
+	virtual TConstBonusListPtr getAllBonuses(const CSelector &selector, const CSelector &limit, const std::string &cachingStr = "") const = 0;
 	int valOfBonuses(const CSelector &selector, const std::string &cachingStr = "") const;
 	bool hasBonus(const CSelector &selector, const std::string &cachingStr = "") const;
 	bool hasBonus(const CSelector &selector, const CSelector &limit, const std::string &cachingStr = "") const;

--- a/lib/pathfinder/TurnInfo.cpp
+++ b/lib/pathfinder/TurnInfo.cpp
@@ -41,7 +41,7 @@ TurnInfo::TurnInfo(const CGHeroInstance * Hero, const int turn):
 	maxMovePointsWater(-1),
 	turn(turn)
 {
-	bonuses = hero->getAllBonuses(Selector::days(turn), Selector::all, nullptr, "");
+	bonuses = hero->getAllBonuses(Selector::days(turn), Selector::all, "");
 	bonusCache = std::make_unique<BonusCache>(bonuses);
 	nativeTerrain = hero->getNativeTerrain();
 }
@@ -144,7 +144,7 @@ void TurnInfo::updateHeroBonuses(BonusType type, const CSelector& sel) const
 		bonusCache->pathfindingVal = bonuses->valOfBonuses(Selector::type()(BonusType::ROUGH_TERRAIN_DISCOUNT));
 		break;
 	default:
-		bonuses = hero->getAllBonuses(Selector::days(turn), Selector::all, nullptr, "");
+		bonuses = hero->getAllBonuses(Selector::days(turn), Selector::all, "");
 	}
 }
 

--- a/test/battle/CBattleInfoCallbackTest.cpp
+++ b/test/battle/CBattleInfoCallbackTest.cpp
@@ -73,13 +73,13 @@ public:
 
 	void redirectBonusesToFake()
 	{
-		ON_CALL(*this, getAllBonuses(_, _, _, _)).WillByDefault(Invoke(&bonusFake, &BonusBearerMock::getAllBonuses));
+		ON_CALL(*this, getAllBonuses(_, _, _)).WillByDefault(Invoke(&bonusFake, &BonusBearerMock::getAllBonuses));
 		ON_CALL(*this, getTreeVersion()).WillByDefault(Invoke(&bonusFake, &BonusBearerMock::getTreeVersion));
 	}
 
 	void expectAnyBonusSystemCall()
 	{
-		EXPECT_CALL(*this, getAllBonuses(_, _, _, _)).Times(AtLeast(0));
+		EXPECT_CALL(*this, getAllBonuses(_, _, _)).Times(AtLeast(0));
 		EXPECT_CALL(*this, getTreeVersion()).Times(AtLeast(0));
 	}
 

--- a/test/battle/CHealthTest.cpp
+++ b/test/battle/CHealthTest.cpp
@@ -29,7 +29,7 @@ public:
 
 	void setDefaultExpectations()
 	{
-		EXPECT_CALL(mock, getAllBonuses(_, _, _, _)).WillRepeatedly(Invoke(&bonusMock, &BonusBearerMock::getAllBonuses));
+		EXPECT_CALL(mock, getAllBonuses(_, _, _)).WillRepeatedly(Invoke(&bonusMock, &BonusBearerMock::getAllBonuses));
 		EXPECT_CALL(mock, getTreeVersion()).WillRepeatedly(Return(1));
 
 		bonusMock.addNewBonus(std::make_shared<Bonus>(BonusDuration::PERMANENT, BonusType::STACK_HEALTH, BonusSource::CREATURE_ABILITY, UNIT_HEALTH, BonusSourceID()));
@@ -235,7 +235,7 @@ TEST_F(HealthTest, singleUnitStack)
 
 	//one Titan
 
-	EXPECT_CALL(mock, getAllBonuses(_, _, _, _)).WillRepeatedly(Invoke(&bonusMock, &BonusBearerMock::getAllBonuses));
+	EXPECT_CALL(mock, getAllBonuses(_, _, _)).WillRepeatedly(Invoke(&bonusMock, &BonusBearerMock::getAllBonuses));
 	EXPECT_CALL(mock, getTreeVersion()).WillRepeatedly(Return(1));
 
 	bonusMock.addNewBonus(std::make_shared<Bonus>(BonusDuration::PERMANENT, BonusType::STACK_HEALTH, BonusSource::CREATURE_ABILITY, 300, BonusSourceID()));

--- a/test/mock/BattleFake.cpp
+++ b/test/mock/BattleFake.cpp
@@ -34,13 +34,13 @@ void UnitFake::makeDead()
 
 void UnitFake::redirectBonusesToFake()
 {
-	ON_CALL(*this, getAllBonuses(_, _, _, _)).WillByDefault(Invoke(&bonusFake, &BonusBearerMock::getAllBonuses));
+	ON_CALL(*this, getAllBonuses(_, _, _)).WillByDefault(Invoke(&bonusFake, &BonusBearerMock::getAllBonuses));
 	ON_CALL(*this, getTreeVersion()).WillByDefault(Invoke(&bonusFake, &BonusBearerMock::getTreeVersion));
 }
 
 void UnitFake::expectAnyBonusSystemCall()
 {
-	EXPECT_CALL(*this, getAllBonuses(_, _, _, _)).Times(AtLeast(0));
+	EXPECT_CALL(*this, getAllBonuses(_, _, _)).Times(AtLeast(0));
 	EXPECT_CALL(*this, getTreeVersion()).Times(AtLeast(0));
 }
 

--- a/test/mock/mock_BonusBearer.cpp
+++ b/test/mock/mock_BonusBearer.cpp
@@ -25,7 +25,7 @@ void BonusBearerMock::addNewBonus(const std::shared_ptr<Bonus> & b)
 	treeVersion++;
 }
 
-TConstBonusListPtr BonusBearerMock::getAllBonuses(const CSelector & selector, const CSelector & limit, const CBonusSystemNode * root, const std::string & cachingStr) const
+TConstBonusListPtr BonusBearerMock::getAllBonuses(const CSelector & selector, const CSelector & limit, const std::string & cachingStr) const
 {
 	if(cachedLast != treeVersion)
 	{

--- a/test/mock/mock_BonusBearer.h
+++ b/test/mock/mock_BonusBearer.h
@@ -23,7 +23,7 @@ public:
 
 	void addNewBonus(const std::shared_ptr<Bonus> & b);
 
-	TConstBonusListPtr getAllBonuses(const CSelector & selector, const CSelector & limit, const CBonusSystemNode * root = nullptr, const std::string & cachingStr = "") const override;
+	TConstBonusListPtr getAllBonuses(const CSelector & selector, const CSelector & limit, const std::string & cachingStr = "") const override;
 
 	int64_t getTreeVersion() const override;
 private:

--- a/test/mock/mock_battle_Unit.h
+++ b/test/mock/mock_battle_Unit.h
@@ -15,7 +15,7 @@
 class UnitMock : public battle::Unit
 {
 public:
-	MOCK_CONST_METHOD4(getAllBonuses, TConstBonusListPtr(const CSelector &, const CSelector &, const CBonusSystemNode *, const std::string &));
+	MOCK_CONST_METHOD3(getAllBonuses, TConstBonusListPtr(const CSelector &, const CSelector &, const std::string &));
 	MOCK_CONST_METHOD0(getTreeVersion, int64_t());
 
 	MOCK_CONST_METHOD0(getCasterUnitId, int32_t());

--- a/test/spells/AbilityCasterTest.cpp
+++ b/test/spells/AbilityCasterTest.cpp
@@ -33,7 +33,7 @@ public:
 protected:
 	void SetUp() override
 	{
-		ON_CALL(actualCaster, getAllBonuses(_, _, _, _)).WillByDefault(Invoke(&casterBonuses, &BonusBearerMock::getAllBonuses));
+		ON_CALL(actualCaster, getAllBonuses(_, _, _)).WillByDefault(Invoke(&casterBonuses, &BonusBearerMock::getAllBonuses));
 		ON_CALL(actualCaster, getTreeVersion()).WillByDefault(Invoke(&casterBonuses, &BonusBearerMock::getTreeVersion));
 	}
 
@@ -57,7 +57,7 @@ TEST_F(AbilityCasterTest, MagicAbilityAffectedByGenericBonus)
 
 	casterBonuses.addNewBonus(std::make_shared<Bonus>(BonusDuration::ONE_BATTLE, BonusType::MAGIC_SCHOOL_SKILL, BonusSource::OTHER, 2, BonusSourceID(), BonusSubtypeID(SpellSchool::ANY)));
 
-	EXPECT_CALL(actualCaster, getAllBonuses(_, _, _, _)).Times(AtLeast(1));
+	EXPECT_CALL(actualCaster, getAllBonuses(_, _, _)).Times(AtLeast(1));
 	EXPECT_CALL(actualCaster, getTreeVersion()).Times(AtLeast(0));
 
 	setupSubject(1);
@@ -71,7 +71,7 @@ TEST_F(AbilityCasterTest, MagicAbilityIgnoresSchoolBonus)
 
 	casterBonuses.addNewBonus(std::make_shared<Bonus>(BonusDuration::ONE_BATTLE, BonusType::MAGIC_SCHOOL_SKILL, BonusSource::OTHER, 2, BonusSourceID(), BonusSubtypeID(SpellSchool::AIR)));
 
-	EXPECT_CALL(actualCaster, getAllBonuses(_, _, _, _)).Times(AtLeast(1));
+	EXPECT_CALL(actualCaster, getAllBonuses(_, _, _)).Times(AtLeast(1));
 	EXPECT_CALL(actualCaster, getTreeVersion()).Times(AtLeast(0));
 
 	setupSubject(1);

--- a/test/spells/targetConditions/AbsoluteLevelConditionTest.cpp
+++ b/test/spells/targetConditions/AbsoluteLevelConditionTest.cpp
@@ -24,7 +24,7 @@ public:
 	void setDefaultExpectations()
 	{
 		EXPECT_CALL(mechanicsMock, isMagicalEffect()).WillRepeatedly(Return(true));
-		EXPECT_CALL(unitMock, getAllBonuses(_, _, _, _)).Times(AtLeast(1));
+		EXPECT_CALL(unitMock, getAllBonuses(_, _, _)).Times(AtLeast(1));
 		EXPECT_CALL(unitMock, getTreeVersion()).Times(AtLeast(0));
 	}
 

--- a/test/spells/targetConditions/AbsoluteSpellConditionTest.cpp
+++ b/test/spells/targetConditions/AbsoluteSpellConditionTest.cpp
@@ -24,7 +24,7 @@ public:
 
 	void setDefaultExpectations()
 	{
-		EXPECT_CALL(unitMock, getAllBonuses(_, _, _, _)).Times(AtLeast(1));
+		EXPECT_CALL(unitMock, getAllBonuses(_, _, _)).Times(AtLeast(1));
 		EXPECT_CALL(unitMock, getTreeVersion()).Times(AtLeast(0));
 		EXPECT_CALL(mechanicsMock, getSpellIndex()).WillRepeatedly(Return(castSpell));
 	}

--- a/test/spells/targetConditions/BonusConditionTest.cpp
+++ b/test/spells/targetConditions/BonusConditionTest.cpp
@@ -21,7 +21,7 @@ class BonusConditionTest : public TargetConditionItemTest
 public:
 	void setDefaultExpectations()
 	{
-		EXPECT_CALL(unitMock, getAllBonuses(_, _, _, _)).Times(AtLeast(1));
+		EXPECT_CALL(unitMock, getAllBonuses(_, _, _)).Times(AtLeast(1));
 		EXPECT_CALL(unitMock, getTreeVersion()).Times(AtLeast(0));
 	}
 

--- a/test/spells/targetConditions/CreatureConditionTest.cpp
+++ b/test/spells/targetConditions/CreatureConditionTest.cpp
@@ -21,7 +21,7 @@ class CreatureConditionTest : public TargetConditionItemTest
 public:
 	void setDefaultExpectations()
 	{
-		EXPECT_CALL(unitMock, getAllBonuses(_, _, _, _)).Times(0);
+		EXPECT_CALL(unitMock, getAllBonuses(_, _, _)).Times(0);
 		EXPECT_CALL(unitMock, getTreeVersion()).Times(0);
 	}
 

--- a/test/spells/targetConditions/ElementalConditionTest.cpp
+++ b/test/spells/targetConditions/ElementalConditionTest.cpp
@@ -23,7 +23,7 @@ public:
 
 	void setDefaultExpectations()
 	{
-		EXPECT_CALL(unitMock, getAllBonuses(_, _, _, _)).Times(AtLeast(1));
+		EXPECT_CALL(unitMock, getAllBonuses(_, _, _)).Times(AtLeast(1));
 		EXPECT_CALL(unitMock, getTreeVersion()).Times(AtLeast(0));
 
 		EXPECT_CALL(mechanicsMock, getSpell()).Times(AtLeast(1)).WillRepeatedly(Return(&spellMock));

--- a/test/spells/targetConditions/HealthValueConditionTest.cpp
+++ b/test/spells/targetConditions/HealthValueConditionTest.cpp
@@ -23,7 +23,7 @@ public:
 	const int64_t EFFECT_VALUE = 101;
 	void setDefaultExpectations()
 	{
-		EXPECT_CALL(unitMock, getAllBonuses(_, _, _, _)).Times(0);
+		EXPECT_CALL(unitMock, getAllBonuses(_, _, _)).Times(0);
 		EXPECT_CALL(unitMock, getTreeVersion()).Times(0);
 		EXPECT_CALL(unitMock, getAvailableHealth()).WillOnce(Return(UNIT_HP));
 		EXPECT_CALL(mechanicsMock, getEffectValue()).WillOnce(Return(EFFECT_VALUE));

--- a/test/spells/targetConditions/ImmunityNegationConditionTest.cpp
+++ b/test/spells/targetConditions/ImmunityNegationConditionTest.cpp
@@ -30,7 +30,7 @@ public:
 	{
 		ownerMatches = ::testing::get<0>(GetParam());
 		isMagicalEffect = ::testing::get<1>(GetParam());
-		EXPECT_CALL(unitMock, getAllBonuses(_, _, _, _)).Times(AtLeast(0));
+		EXPECT_CALL(unitMock, getAllBonuses(_, _, _)).Times(AtLeast(0));
 		EXPECT_CALL(unitMock, getTreeVersion()).Times(AtLeast(0));
 		EXPECT_CALL(mechanicsMock, isMagicalEffect()).Times(AtLeast(0)).WillRepeatedly(Return(isMagicalEffect));
 		EXPECT_CALL(mechanicsMock, ownerMatches(Eq(&unitMock), Field(&boost::logic::tribool::value, boost::logic::tribool::false_value))).WillRepeatedly(Return(ownerMatches));

--- a/test/spells/targetConditions/NormalLevelConditionTest.cpp
+++ b/test/spells/targetConditions/NormalLevelConditionTest.cpp
@@ -27,7 +27,7 @@ public:
 		isMagicalEffect = GetParam();
 		EXPECT_CALL(mechanicsMock, isMagicalEffect()).WillRepeatedly(Return(isMagicalEffect));
 		if(isMagicalEffect)
-			EXPECT_CALL(unitMock, getAllBonuses(_, _, _, _)).Times(AtLeast(1));
+			EXPECT_CALL(unitMock, getAllBonuses(_, _, _)).Times(AtLeast(1));
 		EXPECT_CALL(unitMock, getTreeVersion()).Times(AtLeast(0));
 	}
 

--- a/test/spells/targetConditions/NormalSpellConditionTest.cpp
+++ b/test/spells/targetConditions/NormalSpellConditionTest.cpp
@@ -24,7 +24,7 @@ public:
 
 	void setDefaultExpectations()
 	{
-		EXPECT_CALL(unitMock, getAllBonuses(_, _, _, _)).Times(AtLeast(1));
+		EXPECT_CALL(unitMock, getAllBonuses(_, _, _)).Times(AtLeast(1));
 		EXPECT_CALL(unitMock, getTreeVersion()).Times(AtLeast(0));
 		EXPECT_CALL(mechanicsMock, getSpellIndex()).WillRepeatedly(Return(castSpell));
 	}

--- a/test/spells/targetConditions/ReceptiveFeatureConditionTest.cpp
+++ b/test/spells/targetConditions/ReceptiveFeatureConditionTest.cpp
@@ -27,7 +27,7 @@ public:
 		isPositive = ::testing::get<0>(GetParam());
 		hasBonus = ::testing::get<1>(GetParam());
 
-		EXPECT_CALL(unitMock, getAllBonuses(_, _, _, _)).Times(AtLeast(0));
+		EXPECT_CALL(unitMock, getAllBonuses(_, _, _)).Times(AtLeast(0));
 		EXPECT_CALL(unitMock, getTreeVersion()).Times(AtLeast(0));
 		EXPECT_CALL(mechanicsMock, isPositiveSpell()).WillRepeatedly(Return(isPositive));
 		if(hasBonus)

--- a/test/spells/targetConditions/SpellEffectConditionTest.cpp
+++ b/test/spells/targetConditions/SpellEffectConditionTest.cpp
@@ -21,7 +21,7 @@ class SpellEffectConditionTest : public TargetConditionItemTest
 public:
 	void setDefaultExpectations()
 	{
-		EXPECT_CALL(unitMock, getAllBonuses(_, _, _, _)).Times(AtLeast(1));
+		EXPECT_CALL(unitMock, getAllBonuses(_, _, _)).Times(AtLeast(1));
 		EXPECT_CALL(unitMock, getTreeVersion()).Times(AtLeast(0));
 	}
 

--- a/test/spells/targetConditions/TargetConditionItemFixture.h
+++ b/test/spells/targetConditions/TargetConditionItemFixture.h
@@ -37,7 +37,7 @@ protected:
 	void SetUp() override
 	{
 		using namespace ::testing;
-		ON_CALL(unitMock, getAllBonuses(_, _, _, _)).WillByDefault(Invoke(&unitBonuses, &BonusBearerMock::getAllBonuses));
+		ON_CALL(unitMock, getAllBonuses(_, _, _)).WillByDefault(Invoke(&unitBonuses, &BonusBearerMock::getAllBonuses));
 		ON_CALL(unitMock, getTreeVersion()).WillByDefault(Invoke(&unitBonuses, &BonusBearerMock::getTreeVersion));
 	}
 };


### PR DESCRIPTION
Method CBonusSystemNode::getAllBonuses have 'root' parameter which is never set to anythig else than nullptr. This patch removes the parameter and all code that depends on it as preparatory work for further bonus system optimization.