### PR TITLE
Fix debug non-amd64 builds with CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -403,7 +403,10 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR NOT WIN32)
 	if(CMAKE_BUILD_TYPE STREQUAL "Debug")
 		if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND NOT WIN32)
 			# For gcc 14+ we can use -fhardened instead
-			set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_GLIBCXX_ASSERTIONS -fstack-protector-strong -fstack-clash-protection -fcf-protection=full")
+			set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_GLIBCXX_ASSERTIONS -fstack-protector-strong -fstack-clash-protection")
+			if (CMAKE_SYSTEM_PROCESSOR STREQUAL "AMD64" OR CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
+				set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fcf-protection=full")
+			endif()
 		endif()
 	endif()
 


### PR DESCRIPTION
GCC -fcf-protection flag throws errors when building for non-amd64/x86_64 architectures
Adjust CMakeLists.txt to add this flag only for AMD64 processor

This is needed for debug AArch64 or riscv64 (RV64GC aka rv64imafd) builds.