### PR TITLE
Fix server crash on mutual paralysis

### DIFF
--- a/server/battles/BattleFlowProcessor.cpp
+++ b/server/battles/BattleFlowProcessor.cpp
@@ -304,10 +304,20 @@ void BattleFlowProcessor::activateNextStack(const CBattleInfoCallback & battle)
 		if (!next)
 		{
 			// No stacks to move - start next round
-			startNextRound(battle, false);
-			next = getNextStack(battle);
-			if (!next)
-				throw std::runtime_error("Failed to find valid stack to act!");
+			// If no units are able to act, wait up to 3 rounds
+			// Example: scorpicore + medusa
+			// Scorpicore paralyzes medusa, medusa retaliates
+			// and petrifies scopricore => no units can act for 3 rounds
+			int skippedRounds = 0;
+			while(true)
+			{
+				startNextRound(battle, false);
+				next = getNextStack(battle);
+				if (next) break;
+				if (++skippedRounds == 3)
+					throw std::runtime_error("Failed to find valid stack to act for 3 consecutive rounds!");
+				// else no active stacks => next round
+			}
 		}
 
 		BattleUnitsChanged removeGhosts;


### PR DESCRIPTION
### Overview

This PR fixes a server-side crash when all units on the battlefield are inactive.

Error logs:
```
[runServer][global] ERROR Disaster happened.
[runServer][global] ERROR Reason: Failed to find valid stack to act!
```

### Steps to reproduce

Not too easy to reproduce due to low cast chance of paralyze/petrify:

1. Engage into a battle with only 2 stacks: scorpicore and medusa.
1. Attack with scorpicore, paralyzing the medusa. Medusa retaliates, petrifying the scorpicore.

### Changes summary

Added a loop which skips up to 3 rounds (duration of petrify/blind/paralyze) before throwing the exception.

The client does not properly update the UI - scorpicore color is gray as if petrified, but is otherwise active as normal and restores its color on any action. I don't know how to fix that, but it's a minor issue (does not break the game). The message bar shows "Next round begins" several times in a row, which is expected.

<img width="742" alt="image" src="https://github.com/user-attachments/assets/9fc31e7a-ddf3-4a07-9f59-cb2374ac1300">
 
