### PR TITLE
Fixes for recent regressions

### DIFF
--- a/client/eventsSDL/InputSourceMouse.cpp
+++ b/client/eventsSDL/InputSourceMouse.cpp
@@ -23,6 +23,7 @@
 
 #include <SDL_events.h>
 #include <SDL_hints.h>
+#include <SDL_version.h>
 
 InputSourceMouse::InputSourceMouse()
 	:mouseToleranceDistance(settings["input"]["mouseToleranceDistance"].Integer())
@@ -69,7 +70,11 @@ void InputSourceMouse::handleEventMouseButtonDown(const SDL_MouseButtonEvent & b
 
 void InputSourceMouse::handleEventMouseWheel(const SDL_MouseWheelEvent & wheel)
 {
-	GH.events().dispatchMouseScrolled(Point(wheel.x, wheel.y) / GH.screenHandler().getScalingFactor(), GH.getCursorPosition());
+#if SDL_VERSION_ATLEAST(2,26,0)
+	GH.events().dispatchMouseScrolled(Point(wheel.x, wheel.y), Point(wheel.mouseX, wheel.mouseY) / GH.screenHandler().getScalingFactor());
+#else
+	GH.events().dispatchMouseScrolled(Point(wheel.x, wheel.y), GH.getCursorPosition());
+#endif
 }
 
 void InputSourceMouse::handleEventMouseButtonUp(const SDL_MouseButtonEvent & button)

--- a/client/mainmenu/CMainMenu.cpp
+++ b/client/mainmenu/CMainMenu.cpp
@@ -80,6 +80,12 @@ CMenuScreen::CMenuScreen(const JsonNode & configNode)
 
 	pos = background->center();
 
+	if(!config["video"].isNull())
+	{
+		Point videoPosition(config["video"]["x"].Integer(), config["video"]["y"].Integer());
+		videoPlayer = std::make_shared<VideoWidget>(videoPosition, VideoPath::fromJson(config["video"]["name"]), false);
+	}
+
 	for(const JsonNode & node : config["items"].Vector())
 		menuNameToEntry.push_back(node["name"].String());
 
@@ -90,12 +96,7 @@ CMenuScreen::CMenuScreen(const JsonNode & configNode)
 	menuNameToEntry.push_back("credits");
 
 	tabs = std::make_shared<CTabbedInt>(std::bind(&CMenuScreen::createTab, this, _1));
-	if(!config["video"].isNull())
-	{
-		Point videoPosition(config["video"]["x"].Integer(), config["video"]["y"].Integer());
-		videoPlayer = std::make_shared<VideoWidget>(videoPosition, VideoPath::fromJson(config["video"]["name"]), false);
-	}
-	else
+	if(config["video"].isNull())
 		tabs->setRedrawParent(true);
 
 }

--- a/lib/gameState/CGameState.cpp
+++ b/lib/gameState/CGameState.cpp
@@ -194,6 +194,7 @@ void CGameState::init(const IMapService * mapService, StartInfo * si, Load::Prog
 	initRandomFactionsForPlayers();
 	randomizeMapObjects();
 	placeStartingHeroes();
+	initOwnedObjects();
 	initDifficulty();
 	initHeroes();
 	initStartingBonus();
@@ -492,8 +493,14 @@ void CGameState::randomizeMapObjects()
 				}
 			}
 		}
+	}
+}
 
-		if (object->getOwner().isValidPlayer())
+void CGameState::initOwnedObjects()
+{
+	for(CGObjectInstance *object : map->objects)
+	{
+		if (object && object->getOwner().isValidPlayer())
 			getPlayerState(object->getOwner())->addOwnedObject(object);
 	}
 }

--- a/lib/gameState/CGameState.h
+++ b/lib/gameState/CGameState.h
@@ -181,6 +181,7 @@ private:
 	void initGlobalBonuses();
 	void initGrailPosition();
 	void initRandomFactionsForPlayers();
+	void initOwnedObjects();
 	void randomizeMapObjects();
 	void initPlayerStates();
 	void placeStartingHeroes();


### PR DESCRIPTION
Fixes for several issues that were recently reported on Discord:
- Fixed mouse wheel not working in xbrz mode
- Use mouse position information for mouse wheel events if provided by SDL (new addition since 2.26)
- Change ordering of UI elements in main menu to fix hota 1.7 menu - video will now be below all other elements other than background image.
- Change gamestate initialization order - list of owned objects must be initialized before connecting towns with visiting heroes, but after generateion of starting heroes. This fixes starting heroes not visiting towns on map load