### PR TITLE
Removed save compatibility with 1.4

### DIFF
--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -1639,15 +1639,6 @@ void CPlayerInterface::showMarketWindow(const IMarket * market, const CGHeroInst
 		cb->selectionMade(0, queryID);
 	};
 
-	if (market->allowsTrade(EMarketMode::ARTIFACT_EXP) && market->getArtifactsStorage() == nullptr)
-	{
-		// compatibility check, safe to remove for 1.6
-		// 1.4 saves loaded in 1.5 will not be able to visit Altar of Sacrifice due to Altar now requiring different map object class
-		static_assert(ESerializationVersion::RELEASE_143 < ESerializationVersion::CURRENT, "Please remove this compatibility check once it no longer needed");
-		onWindowClosed();
-		return;
-	}
-
 	if(market->allowsTrade(EMarketMode::ARTIFACT_EXP) && visitor->getAlignment() != EAlignment::EVIL)
 		GH.windows().createAndPushWindow<CMarketWindow>(market, visitor, onWindowClosed, EMarketMode::ARTIFACT_EXP);
 	else if(market->allowsTrade(EMarketMode::CREATURE_EXP) && visitor->getAlignment() != EAlignment::GOOD)

--- a/lib/CPlayerState.h
+++ b/lib/CPlayerState.h
@@ -137,13 +137,11 @@ public:
 		h & daysWithoutCastle;
 		h & cheated;
 		h & battleBonuses;
-		if (h.version >= Handler::Version::ARTIFACT_COSTUMES)
-			h & costumesArtifacts;
+		h & costumesArtifacts;
 		h & enteredLosingCheatCode;
 		h & enteredWinningCheatCode;
 		h & static_cast<CBonusSystemNode&>(*this);
-		if (h.version >= Handler::Version::DESTROYED_OBJECTS)
-			h & destroyedObjects;
+		h & destroyedObjects;
 	}
 };
 

--- a/lib/StartInfo.h
+++ b/lib/StartInfo.h
@@ -52,9 +52,10 @@ struct DLL_LINKAGE SimturnsInfo
 		h & optionalTurns;
 		h & allowHumanWithAI;
 
-		static_assert(Handler::Version::RELEASE_143 < Handler::Version::CURRENT, "Please add ignoreAlliedContacts to serialization for 1.6");
-		// disabled to allow multiplayer compatibility between 1.5.2 and 1.5.1
-		// h & ignoreAlliedContacts
+		if (h.version >= Handler::Version::SAVE_COMPATIBILITY_FIXES)
+			h & ignoreAlliedContacts;
+		else
+			ignoreAlliedContacts = true;
 	}
 };
 
@@ -183,10 +184,7 @@ struct DLL_LINKAGE StartInfo : public Serializeable
 		h & fileURI;
 		h & simturnsInfo;
 		h & turnTimerInfo;
-		if(h.version >= Handler::Version::HAS_EXTRA_OPTIONS)
-			h & extraOptionsInfo;
-		else
-			extraOptionsInfo = ExtraOptionsInfo();
+		h & extraOptionsInfo;
 		h & mapname;
 		h & mapGenOptions;
 		h & campState;

--- a/lib/bonuses/Bonus.h
+++ b/lib/bonuses/Bonus.h
@@ -95,15 +95,7 @@ struct DLL_LINKAGE Bonus : public std::enable_shared_from_this<Bonus>, public Se
 		h & source;
 		h & val;
 		h & sid;
-		if (h.version < Handler::Version::BONUS_META_STRING)
-		{
-			std::string oldDescription;
-			h & oldDescription;
-			description = MetaString::createFromRawString(oldDescription);
-		}
-		else
-			h & description;
-
+		h & description;
 		h & additionalInfo;
 		h & turnsRemain;
 		h & valType;
@@ -114,11 +106,6 @@ struct DLL_LINKAGE Bonus : public std::enable_shared_from_this<Bonus>, public Se
 		h & updater;
 		h & propagationUpdater;
 		h & targetSourceType;
-		if (h.version < Handler::Version::MANA_LIMIT && type == BonusType::MANA_PER_KNOWLEDGE_PERCENTAGE)
-		{
-			if (valType == BonusValueType::ADDITIVE_VALUE || valType == BonusValueType::BASE_NUMBER)
-				val *= 100;
-		}
 	}
 
 	template <typename Ptr>

--- a/lib/campaign/CampaignState.h
+++ b/lib/campaign/CampaignState.h
@@ -141,8 +141,7 @@ public:
 		h & modName;
 		h & music;
 		h & encoding;
-		if (h.version >= Handler::Version::RELEASE_143)
-			h & textContainer;
+		h & textContainer;
 	}
 };
 
@@ -342,8 +341,7 @@ public:
 		h & currentMap;
 		h & chosenCampaignBonuses;
 		h & campaignSet;
-		if (h.version >= Handler::Version::CAMPAIGN_MAP_TRANSLATIONS)
-			h & mapTranslations;
+		h & mapTranslations;
 		if (h.version >= Handler::Version::HIGHSCORE_PARAMETERS)
 			h & highscoreParameters;
 	}

--- a/lib/json/JsonNode.h
+++ b/lib/json/JsonNode.h
@@ -152,16 +152,7 @@ public:
 	void serialize(Handler & h)
 	{
 		h & modScope;
-
-		if(h.version >= Handler::Version::JSON_FLAGS)
-		{
-			h & overrideFlag;
-		}
-		else
-		{
-			std::vector<std::string> oldFlags;
-			h & oldFlags;
-		}
+		h & overrideFlag;
 		h & data;
 	}
 };

--- a/lib/mapObjects/CGMarket.h
+++ b/lib/mapObjects/CGMarket.h
@@ -31,7 +31,8 @@ public:
 	int availableUnits(EMarketMode mode, int marketItemSerial) const override; //-1 if unlimited
 	std::set<EMarketMode> availableModes() const override;
 
-	template <typename Handler> void serialize(Handler &h)
+	template <typename Handler>
+	void serialize(Handler &h)
 	{
 		h & static_cast<CGObjectInstance&>(*this);
 		if (h.version < Handler::Version::NEW_MARKETS)
@@ -53,6 +54,7 @@ public:
 	template <typename Handler> void serializeArtifactsAltar(Handler &h)
 	{
 		serialize(h);
+		IMarket::serializeArtifactsAltar(h);
 	}
 };
 

--- a/lib/mapObjects/IMarket.h
+++ b/lib/mapObjects/IMarket.h
@@ -36,6 +36,11 @@ public:
 	CArtifactSet * getArtifactsStorage() const;
 	bool getOffer(int id1, int id2, int &val1, int &val2, EMarketMode mode) const; //val1 - how many units of id1 player has to give to receive val2 units
 
+	template <typename Handler> void serializeArtifactsAltar(Handler &h)
+	{
+		h & *altarArtifactsStorage;
+	}
+
 private:
 	std::unique_ptr<CArtifactSetAltar> altarArtifactsStorage;
 };

--- a/lib/mapping/CMap.h
+++ b/lib/mapping/CMap.h
@@ -196,14 +196,6 @@ public:
 		h & quests;
 		h & allHeroes;
 
-		if (h.version < Handler::Version::DESTROYED_OBJECTS)
-		{
-			// old save compatibility
-			//FIXME: remove this field after save-breaking change
-			h & questIdentifierToId;
-			resolveQuestIdentifiers();
-		}
-
 		//TODO: viccondetails
 		h & terrain;
 		h & guardingCreaturePositions;

--- a/lib/mapping/CMapHeader.h
+++ b/lib/mapping/CMapHeader.h
@@ -277,12 +277,16 @@ public:
 		h & width;
 		h & height;
 		h & twoLevel;
-		// FIXME: we should serialize enum's according to their underlying type
-		// should be fixed when we are making breaking change to save compatibility
-		static_assert(Handler::Version::MINIMAL < Handler::Version::RELEASE_143);
-		uint8_t difficultyInteger = static_cast<uint8_t>(difficulty);
-		h & difficultyInteger;
-		difficulty = static_cast<EMapDifficulty>(difficultyInteger);
+
+		if (h.version >= Handler::Version::SAVE_COMPATIBILITY_FIXES)
+			h & difficulty;
+		else
+		{
+			uint8_t difficultyInteger = static_cast<uint8_t>(difficulty);
+			h & difficultyInteger;
+			difficulty = static_cast<EMapDifficulty>(difficultyInteger);
+		}
+
 		h & levelLimit;
 		h & areAnyPlayers;
 		h & players;

--- a/lib/networkPacks/PacksForLobby.h
+++ b/lib/networkPacks/PacksForLobby.h
@@ -55,18 +55,7 @@ struct DLL_LINKAGE LobbyClientConnected : public CLobbyPackToPropagate
 
 		h & clientId;
 		h & hostClientId;
-
-		try
-		{
-			if (h.version >= Handler::Version::RELEASE_152)
-				h & version;
-			else
-				version = ESerializationVersion::RELEASE_150;
-		}
-		 catch (const std::runtime_error &)
-		{
-			version = ESerializationVersion::RELEASE_150;
-		}
+		h & version;
 	}
 };
 

--- a/lib/rmg/CMapGenOptions.h
+++ b/lib/rmg/CMapGenOptions.h
@@ -77,10 +77,7 @@ public:
 			h & startingTown;
 			h & playerType;
 			h & team;
-			if (h.version >= Handler::Version::RELEASE_143)
-				h & startingHero;
-			else
-				startingHero = HeroTypeID::RANDOM;
+			h & startingHero;
 		}
 	};
 

--- a/lib/serializer/ESerializationVersion.h
+++ b/lib/serializer/ESerializationVersion.h
@@ -31,25 +31,13 @@ enum class ESerializationVersion : int32_t
 {
 	NONE = 0,
 
-	MINIMAL = 831,
-
-	RELEASE_143, // 832 +text container in campaigns, +starting hero in RMG options
-	HAS_EXTRA_OPTIONS, // 833 +extra options struct as part of startinfo
-	DESTROYED_OBJECTS, // 834 +list of objects destroyed by player
-	CAMPAIGN_MAP_TRANSLATIONS, // 835 +campaigns include translations for its maps
-	JSON_FLAGS, // 836 json uses new format for flags
-	MANA_LIMIT,	// 837 change MANA_PER_KNOWLEDGE to percentage
-	BONUS_META_STRING,	// 838 bonuses use MetaString instead of std::string for descriptions
-	TURN_TIMERS_STATE, // 839 current state of turn timers is serialized
-	ARTIFACT_COSTUMES, // 840 swappable artifacts set added
-
-	RELEASE_150 = ARTIFACT_COSTUMES, // for convenience
+	RELEASE_150 = 840,
+	MINIMAL = RELEASE_150,
 
 	VOTING_SIMTURNS, // 841 - allow modification of simturns duration via vote
 	REMOVE_TEXT_CONTAINER_SIZE_T, // 842 Fixed serialization of size_t from text containers
 	BANK_UNIT_PLACEMENT, // 843 Banks have unit placement flag
 
-	RELEASE_152 = BANK_UNIT_PLACEMENT,
 	RELEASE_156 = BANK_UNIT_PLACEMENT,
 
 	COMPACT_STRING_SERIALIZATION, // 844 - optimized serialization of previously encountered strings
@@ -67,6 +55,7 @@ enum class ESerializationVersion : int32_t
 	STATISTICS_SCREEN, // 856 - extent statistic functions
 	NEW_MARKETS, // 857 - reworked market classes
 	PLAYER_STATE_OWNED_OBJECTS, // 858 - player state stores all owned objects in a single list
+	SAVE_COMPATIBILITY_FIXES, // 859 - implementation of previoulsy postponed changes to serialization
 
-	CURRENT = PLAYER_STATE_OWNED_OBJECTS
+	CURRENT = SAVE_COMPATIBILITY_FIXES
 };

--- a/server/CGameHandler.h
+++ b/server/CGameHandler.h
@@ -243,9 +243,7 @@ public:
 		h & *heroPool;
 		h & *playerMessages;
 		h & *turnOrder;
-
-		if (h.version >= Handler::Version::TURN_TIMERS_STATE)
-			h & *turnTimerHandler;
+		h & *turnTimerHandler;
 
 #if SCRIPTING_ENABLED
 		JsonNode scriptsState;


### PR DESCRIPTION
All save compatibility checks targeting 1.4 saves have now been removed. Saves from 1.5 can still be loaded in 1.6

Implemeted few TODO's in serialization that were postponed to avoid breaking save compatibility in MP for 1.5.X releases.

Fixed missed case for loading black market object from 1.5 saves