### PR TITLE
fix crash when computer player loses

### DIFF
--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -1066,10 +1066,13 @@ void CGameHandler::setOwner(const CGObjectInstance * obj, const PlayerColor owne
 
 	if ((obj->ID == Obj::CREATURE_GENERATOR1 || obj->ID == Obj::CREATURE_GENERATOR4))
 	{
-		for (const CGTownInstance * t : getPlayerState(owner)->getTowns())
+		if (owner.isValidPlayer())
 		{
-			if (t->hasBuilt(BuildingSubID::PORTAL_OF_SUMMONING))
-				setPortalDwelling(t);//set initial creatures for all portals of summoning
+			for (const CGTownInstance * t : getPlayerState(owner)->getTowns())
+			{
+				if (t->hasBuilt(BuildingSubID::PORTAL_OF_SUMMONING))
+					setPortalDwelling(t);//set initial creatures for all portals of summoning
+			}
 		}
 	}
 }


### PR DESCRIPTION
Changing dwelling's owner to neutral accesses a PlayerState but neutrals don't have a PlayerState and that leads to crash.