### PR TITLE
Crashfixes

### DIFF
--- a/AI/BattleAI/BattleExchangeVariant.cpp
+++ b/AI/BattleAI/BattleExchangeVariant.cpp
@@ -376,11 +376,14 @@ MoveTarget BattleExchangeEvaluator::findMoveTowardsUnreachable(
 				logAi->trace("New high score");
 #endif
 
-				for(BattleHex enemyHex : enemy->getAttackableHexes(activeStack))
+				for(const BattleHex & initialEnemyHex : enemy->getAttackableHexes(activeStack))
 				{
-					while(!flying && dists.distances[enemyHex] > speed)
+					BattleHex enemyHex = initialEnemyHex;
+
+					while(!flying && dists.distances[enemyHex] > speed && dists.predecessors.at(enemyHex).isValid())
 					{
 						enemyHex = dists.predecessors.at(enemyHex);
+
 						if(dists.accessibility[enemyHex] == EAccessibility::ALIVE_STACK)
 						{
 							auto defenderToBypass = hb->battleGetUnitByPos(enemyHex);

--- a/lib/CPlayerState.h
+++ b/lib/CPlayerState.h
@@ -104,7 +104,7 @@ public:
 
 	bool checkVanquished() const
 	{
-		return ownedObjects.empty();
+		return getHeroes().empty() && getTowns().empty();
 	}
 
 	template <typename Handler> void serialize(Handler &h)


### PR DESCRIPTION
- Fix player not being marked as defeated on losing all heroes and towns leading to player ending up in invalid state - no heroes/towns but still active in game
- Add workaround for very common crash in BattleAI