### PR TITLE
Improvements for fonts when xbrz is in use

### DIFF
--- a/client/renderSDL/CBitmapFont.cpp
+++ b/client/renderSDL/CBitmapFont.cpp
@@ -16,13 +16,14 @@
 #include "../render/Colors.h"
 #include "../render/IScreenHandler.h"
 
+#include "../../lib/CConfigHandler.h"
 #include "../../lib/Rect.h"
+#include "../../lib/VCMI_Lib.h"
 #include "../../lib/filesystem/Filesystem.h"
 #include "../../lib/modding/CModHandler.h"
 #include "../../lib/texts/Languages.h"
 #include "../../lib/texts/TextOperations.h"
 #include "../../lib/vcmi_endian.h"
-#include "../../lib/VCMI_Lib.h"
 
 #include <SDL_surface.h>
 #include <SDL_image.h>
@@ -200,9 +201,15 @@ CBitmapFont::CBitmapFont(const std::string & filename):
 
 	if (GH.screenHandler().getScalingFactor() != 1)
 	{
-		// scale using nearest neighbour - looks way better with H3 fonts than more high-quality xBRZ
-		// TODO: make configurable?
-		auto scaledSurface = CSDL_Ext::scaleSurfaceIntegerFactor(atlasImage, GH.screenHandler().getScalingFactor(), EScalingAlgorithm::NEAREST);
+		static const std::map<std::string, EScalingAlgorithm> filterNameToEnum = {
+			{ "nearest", EScalingAlgorithm::NEAREST},
+			{ "bilinear", EScalingAlgorithm::BILINEAR},
+			{ "xbrz", EScalingAlgorithm::XBRZ}
+		};
+
+		auto filterName = settings["video"]["fontUpscalingFilter"].String();
+		EScalingAlgorithm algorithm = filterNameToEnum.at(filterName);
+		auto scaledSurface = CSDL_Ext::scaleSurfaceIntegerFactor(atlasImage, GH.screenHandler().getScalingFactor(), algorithm);
 		SDL_FreeSurface(atlasImage);
 		atlasImage = scaledSurface;
 	}

--- a/client/renderSDL/CBitmapFont.cpp
+++ b/client/renderSDL/CBitmapFont.cpp
@@ -25,6 +25,7 @@
 #include "../../lib/VCMI_Lib.h"
 
 #include <SDL_surface.h>
+#include <SDL_image.h>
 
 struct AtlasLayout
 {
@@ -199,10 +200,14 @@ CBitmapFont::CBitmapFont(const std::string & filename):
 
 	if (GH.screenHandler().getScalingFactor() != 1)
 	{
-		auto scaledSurface = CSDL_Ext::scaleSurfaceIntegerFactor(atlasImage, GH.screenHandler().getScalingFactor());
+		// scale using nearest neighbour - looks way better with H3 fonts than more high-quality xBRZ
+		// TODO: make configurable?
+		auto scaledSurface = CSDL_Ext::scaleSurfaceIntegerFactor(atlasImage, GH.screenHandler().getScalingFactor(), EScalingAlgorithm::NEAREST);
 		SDL_FreeSurface(atlasImage);
 		atlasImage = scaledSurface;
 	}
+
+	IMG_SavePNG(atlasImage, ("/home/ivan/font_" + filename).c_str());
 }
 
 CBitmapFont::~CBitmapFont()

--- a/client/renderSDL/CTrueTypeFont.cpp
+++ b/client/renderSDL/CTrueTypeFont.cpp
@@ -27,19 +27,25 @@ std::pair<std::unique_ptr<ui8[]>, ui64> CTrueTypeFont::loadData(const JsonNode &
 	return CResourceHandler::get()->load(ResourcePath(filename, EResType::TTF_FONT))->readAll();
 }
 
+int CTrueTypeFont::getPointSize(const JsonNode & config) const
+{
+	int scalingFactor = getScalingFactor();
+
+	if (config.isNumber())
+		return config.Integer() * scalingFactor;
+	else
+		return config[scalingFactor-1].Integer();
+}
+
 TTF_Font * CTrueTypeFont::loadFont(const JsonNode &config)
 {
-	int pointSizeBase = static_cast<int>(config["size"].Float());
-	int scalingFactor = getScalingFactor();
-	int pointSize = pointSizeBase * scalingFactor;
-
 	if(!TTF_WasInit() && TTF_Init()==-1)
 		throw std::runtime_error(std::string("Failed to initialize true type support: ") + TTF_GetError() + "\n");
 
-	return TTF_OpenFontRW(SDL_RWFromConstMem(data.first.get(), (int)data.second), 1, pointSize);
+	return TTF_OpenFontRW(SDL_RWFromConstMem(data.first.get(), data.second), 1, getPointSize(config["size"]));
 }
 
-int CTrueTypeFont::getFontStyle(const JsonNode &config)
+int CTrueTypeFont::getFontStyle(const JsonNode &config) const
 {
 	const JsonVector & names = config["style"].Vector();
 	int ret = 0;

--- a/client/renderSDL/CTrueTypeFont.h
+++ b/client/renderSDL/CTrueTypeFont.h
@@ -30,7 +30,8 @@ class CTrueTypeFont final : public IFont
 
 	std::pair<std::unique_ptr<ui8[]>, ui64> loadData(const JsonNode & config);
 	TTF_Font * loadFont(const JsonNode & config);
-	int getFontStyle(const JsonNode & config);
+	int getPointSize(const JsonNode & config) const;
+	int getFontStyle(const JsonNode & config) const;
 
 	void renderText(SDL_Surface * surface, const std::string & data, const ColorRGBA & color, const Point & pos) const override;
 public:

--- a/client/renderSDL/SDLImage.cpp
+++ b/client/renderSDL/SDLImage.cpp
@@ -270,7 +270,7 @@ std::shared_ptr<ISharedImage> SDLImageShared::scaleInteger(int factor, SDL_Palet
 	if (factor <= 0)
 		throw std::runtime_error("Unable to scale by integer value of " + std::to_string(factor));
 
-	if (palette && surf->format->palette)
+	if (palette && surf && surf->format->palette)
 		SDL_SetSurfacePalette(surf, palette);
 
 	SDL_Surface * scaled = CSDL_Ext::scaleSurfaceIntegerFactor(surf, factor, EScalingAlgorithm::XBRZ);
@@ -287,7 +287,7 @@ std::shared_ptr<ISharedImage> SDLImageShared::scaleInteger(int factor, SDL_Palet
 	// erase our own reference
 	SDL_FreeSurface(scaled);
 
-	if (surf->format->palette)
+	if (surf && surf->format->palette)
 		SDL_SetSurfacePalette(surf, originalPalette);
 
 	return ret;

--- a/client/renderSDL/SDL_Extensions.h
+++ b/client/renderSDL/SDL_Extensions.h
@@ -27,6 +27,13 @@ class Point;
 
 VCMI_LIB_NAMESPACE_END
 
+enum class EScalingAlgorithm : int8_t
+{
+	NEAREST,
+	BILINEAR,
+	XBRZ
+};
+
 namespace CSDL_Ext
 {
 
@@ -92,7 +99,7 @@ using TColorPutterAlpha = void (*)(uint8_t *&, const uint8_t &, const uint8_t &,
 
 	// bilinear filtering. Always returns rgba surface
 	SDL_Surface * scaleSurface(SDL_Surface * surf, int width, int height);
-	SDL_Surface * scaleSurfaceIntegerFactor(SDL_Surface * surf, int factor);
+	SDL_Surface * scaleSurfaceIntegerFactor(SDL_Surface * surf, int factor, EScalingAlgorithm scaler);
 
 	template<int bpp>
 	void convertToGrayscaleBpp(SDL_Surface * surf, const Rect & rect);

--- a/client/windows/CMessage.cpp
+++ b/client/windows/CMessage.cpp
@@ -73,20 +73,19 @@ std::vector<std::string> CMessage::breakText(std::string text, size_t maxLineWid
 	// each iteration generates one output line
 	while(text.length())
 	{
-		ui32 lineWidth = 0; //in characters or given char metric
 		ui32 wordBreak = -1; //last position for line break (last space character)
 		ui32 currPos = 0; //current position in text
 		bool opened = false; //set to true when opening brace is found
 		std::string color; //color found
 
 		size_t symbolSize = 0; // width of character, in bytes
-		size_t glyphWidth = 0; // width of printable glyph, pixels
+
+		std::string printableString;
 
 		// loops till line is full or end of text reached
-		while(currPos < text.length() && text[currPos] != 0x0a && lineWidth < maxLineWidth)
+		while(currPos < text.length() && text[currPos] != 0x0a)
 		{
 			symbolSize = TextOperations::getUnicodeCharacterSize(text[currPos]);
-			glyphWidth = graphics->fonts[font]->getGlyphWidth(text.data() + currPos);
 
 			// candidate for line break
 			if(ui8(text[currPos]) <= ui8(' '))
@@ -116,7 +115,14 @@ std::vector<std::string> CMessage::breakText(std::string text, size_t maxLineWid
 				color = "";
 			}
 			else
-				lineWidth += glyphWidth;
+			{
+				std::string newPrintableString = printableString;
+				newPrintableString.append(text.data() + currPos, symbolSize);
+				if (graphics->fonts[font]->getStringWidth(newPrintableString) < maxLineWidth)
+					printableString.append(text.data() + currPos, symbolSize);
+				else
+					break;
+			}
 			currPos += symbolSize;
 		}
 

--- a/config/fonts.json
+++ b/config/fonts.json
@@ -19,7 +19,11 @@
 	// Should be in format:
 	// <replaced bitmap font name, case-sensetive> : <true type font description>
 	// "file" - file to load font from, must be in data/ directory
-	// "size" - point size of font
+	// "size" - point size of font. Can be defined in two forms:
+	// a) single number, e.g. 10. In this case, game will automatically multiply font size by upscaling factor when xBRZ is in use, 
+	//    so xbrz 2x will use 20px, xbrz 3x will use 30px, etc
+	// b) list of scaling factors for each scaling mode, e.g. [ 10, 16, 22, 26]. In this case game will select point size according to xBRZ scaling factor
+	//    so unscaled mode will use 10px, xbrz2 will use 16px, and xbrz3 will use 22
 	// "style" - italic and\or bold, indicates font style
 	// "blend" - if set to true, font will be antialiased
 	"trueType":

--- a/config/schemas/settings.json
+++ b/config/schemas/settings.json
@@ -167,6 +167,7 @@
 				"targetfps",
 				"vsync",
 				"upscalingFilter",
+				"fontUpscalingFilter",
 				"downscalingFilter"
 			],
 			"properties" : {
@@ -230,6 +231,11 @@
 				"vsync" : {
 					"type" : "boolean",
 					"default" : true
+				},
+				"fontUpscalingFilter" : {
+					"type" : "string",
+					"enum" : [ "nearest", "bilinear", "xbrz" ],
+					"default" : "nearest"
 				},
 				"upscalingFilter" : {
 					"type" : "string",


### PR DESCRIPTION
- Native H3 bitmap fonts now use nearest-neighbor upscaling instead of xbrz. Added option to config (with no UI) to select preferred upscaler for h3 fonts.
- Added options to manually define point size of true type fonts for xbrz mode, overriding internal multiplication, e.g. `"size" : [ 10, 16, 22, 26 ]` will have font at 10px in unscaled mode and 16px in xbrz2 mode instead of 10*2 = 20px
- Fixed crash on attempt to upscale nonexisting image - reported in hota mod
- Removed duplicated code in image upscaling logic
- Fixed string width computation errors sometimes leading to text overflow, e.g. in scenario description.
  - Fixed rounding error caused by xbrz scaling factor - 9px-wide symbol would be interpreted as 4px-wide instead of 4.5px wide if xbrz 2x is in use
  - String width is now computed for entire string at once using SDL_ttf instead of being sum of widths of all characters (may not match due to ttf features like hinting / fractional widths)
  - Last character in string is now properly accounted for and won't cause text overflow