### PR TITLE
RMG: Enable only those roads, that are enabled in persistentStorage.json

### DIFF
--- a/client/lobby/RandomMapTab.cpp
+++ b/client/lobby/RandomMapTab.cpp
@@ -601,6 +601,12 @@ void RandomMapTab::loadOptions()
 		{
 			w->setItem(mapGenOptions->getMapTemplate());
 		}
+	} else
+	{
+		// Default settings
+		mapGenOptions->setRoadEnabled(RoadId(Road::DIRT_ROAD), true);
+		mapGenOptions->setRoadEnabled(RoadId(Road::GRAVEL_ROAD), true);
+		mapGenOptions->setRoadEnabled(RoadId(Road::COBBLESTONE_ROAD), true);
 	}
 	updateMapInfoByHost();
 

--- a/lib/rmg/CMapGenOptions.cpp
+++ b/lib/rmg/CMapGenOptions.cpp
@@ -30,9 +30,6 @@ CMapGenOptions::CMapGenOptions()
 	customizedPlayers(false)
 {
 	initPlayersMap();
-	setRoadEnabled(RoadId(Road::DIRT_ROAD), true);
-	setRoadEnabled(RoadId(Road::GRAVEL_ROAD), true);
-	setRoadEnabled(RoadId(Road::COBBLESTONE_ROAD), true);
 }
 
 si32 CMapGenOptions::getWidth() const


### PR DESCRIPTION
## What
Currently, all roads in `RandomMapGenerator` are all getting enabled before the game reads the `persistentStorage.json`. After that, settings are being read, but as `enabledRoads` are being saved in set data structure, the ones not present in the `persistentStorage.json` are not disabled. This resulted in the problem, that every time the user opens the "Random Map Generator Tab", all roads are enabled regardless of previously defined settings.

To address this issue, I removed all roads enabling from the `MapGenOptions` initialization, and instead enable them during persistentStorage.json, specifically, if `persistentStorage.json` is not present.

## Testing
1. Disabled some roads and confirmed that after the change, roads stay disabled.
2. Removed `persistentStorage.json` and confirmed, that without it all roads are enabled by default.