### PR TITLE
Fixes for regressions found on stream

### DIFF
--- a/lib/mapObjects/CGDwelling.cpp
+++ b/lib/mapObjects/CGDwelling.cpp
@@ -536,7 +536,14 @@ void CGDwelling::serializeJsonOptions(JsonSerializeFormat & handler)
 
 const IOwnableObject * CGDwelling::asOwnable() const
 {
-	return this;
+	switch (ID.toEnum())
+	{
+		case Obj::WAR_MACHINE_FACTORY:
+		case Obj::REFUGEE_CAMP:
+			return nullptr; // can't be owned
+		default:
+			return this;
+	}
 }
 
 ResourceSet CGDwelling::dailyIncome() const

--- a/lib/mapObjects/MiscObjects.cpp
+++ b/lib/mapObjects/MiscObjects.cpp
@@ -1227,6 +1227,21 @@ BoatId CGShipyard::getBoatType() const
 	return createdBoat;
 }
 
+const IOwnableObject * CGShipyard::asOwnable() const
+{
+	return this;
+}
+
+ResourceSet CGShipyard::dailyIncome() const
+{
+	return {};
+}
+
+std::vector<CreatureID> CGShipyard::providedCreatures() const
+{
+	return {};
+}
+
 void CGDenOfthieves::onHeroVisit (const CGHeroInstance * h) const
 {
 	cb->showObjectWindow(this, EOpenWindowMode::THIEVES_GUILD, h, false);

--- a/lib/mapObjects/MiscObjects.h
+++ b/lib/mapObjects/MiscObjects.h
@@ -346,7 +346,7 @@ public:
 	}
 };
 
-class DLL_LINKAGE CGShipyard : public CGObjectInstance, public IShipyard
+class DLL_LINKAGE CGShipyard : public CGObjectInstance, public IShipyard, public IOwnableObject
 {
 	friend class ShipyardInstanceConstructor;
 
@@ -357,6 +357,10 @@ protected:
 	void onHeroVisit(const CGHeroInstance * h) const override;
 	const IObjectInterface * getObject() const override;
 	BoatId getBoatType() const override;
+
+	const IOwnableObject * asOwnable() const final;
+	ResourceSet dailyIncome() const override;
+	std::vector<CreatureID> providedCreatures() const override;
 
 public:
 	using CGObjectInstance::CGObjectInstance;

--- a/server/processors/NewTurnProcessor.cpp
+++ b/server/processors/NewTurnProcessor.cpp
@@ -280,7 +280,7 @@ SetAvailableCreatures NewTurnProcessor::generateTownGrowth(const CGTownInstance 
 
 		if (weekType == EWeekType::PLAGUE)
 			resultingCreatures = creaturesBefore / 2;
-		else if (weekType == EWeekType::DOUBLE_GROWTH)
+		else if (weekType == EWeekType::DOUBLE_GROWTH && vstd::contains(t->creatures.at(k).second, creatureWeek))
 			resultingCreatures = (creaturesBefore + creatureGrowth) * 2;
 		else
 			resultingCreatures = creaturesBefore + creatureGrowth;


### PR DESCRIPTION
- Apply x2 bonus only to creature growth of affected creature on new month instead of applying it to everyone
- Implement IOwnableObject interface for shipyard. Fixed crashes on computing growth/income
- Block IOwnableObject access for refugee camp and war machines factory