### PR TITLE
fix Ballista Bank Mod auto combat crash

### DIFF
--- a/AI/BattleAI/BattleExchangeVariant.cpp
+++ b/AI/BattleAI/BattleExchangeVariant.cpp
@@ -290,7 +290,7 @@ ReachabilityInfo getReachabilityWithEnemyBypass(
 				continue;
 
 			auto dmg = damageCache.getOriginalDamage(activeStack, unit, state);
-			auto turnsToKill = unit->getAvailableHealth() / std::max(dmg, 1);
+			auto turnsToKill = unit->getAvailableHealth() / std::max(dmg, 1LL);
 
 			vstd::amin(turnsToKill, 100);
 

--- a/AI/BattleAI/BattleExchangeVariant.cpp
+++ b/AI/BattleAI/BattleExchangeVariant.cpp
@@ -290,7 +290,7 @@ ReachabilityInfo getReachabilityWithEnemyBypass(
 				continue;
 
 			auto dmg = damageCache.getOriginalDamage(activeStack, unit, state);
-			auto turnsToKill = unit->getAvailableHealth() / dmg;
+			auto turnsToKill = unit->getAvailableHealth() / vstd::amax(dmg, 1);
 
 			vstd::amin(turnsToKill, 100);
 

--- a/AI/BattleAI/BattleExchangeVariant.cpp
+++ b/AI/BattleAI/BattleExchangeVariant.cpp
@@ -290,7 +290,7 @@ ReachabilityInfo getReachabilityWithEnemyBypass(
 				continue;
 
 			auto dmg = damageCache.getOriginalDamage(activeStack, unit, state);
-			auto turnsToKill = unit->getAvailableHealth() / vstd::amax(dmg, 1);
+			auto turnsToKill = unit->getAvailableHealth() / std::max(dmg, 1);
 
 			vstd::amin(turnsToKill, 100);
 

--- a/AI/BattleAI/BattleExchangeVariant.cpp
+++ b/AI/BattleAI/BattleExchangeVariant.cpp
@@ -290,7 +290,7 @@ ReachabilityInfo getReachabilityWithEnemyBypass(
 				continue;
 
 			auto dmg = damageCache.getOriginalDamage(activeStack, unit, state);
-			auto turnsToKill = unit->getAvailableHealth() / std::max(dmg, 1LL);
+			auto turnsToKill = unit->getAvailableHealth() / std::max(dmg, (int64_t)1);
 
 			vstd::amin(turnsToKill, 100);
 


### PR DESCRIPTION
Ballista Bank Mod creature ballista reduce 100% damage, only one damge is dealt to ballista per attack. In this case the dmg is 0  and it will lead to a crash.