### PR TITLE
make TimesStackLevelUpdater support commander

### DIFF
--- a/lib/bonuses/Updaters.cpp
+++ b/lib/bonuses/Updaters.cpp
@@ -145,7 +145,7 @@ JsonNode ArmyMovementUpdater::toJsonNode() const
 }
 std::shared_ptr<Bonus> TimesStackLevelUpdater::createUpdatedBonus(const std::shared_ptr<Bonus> & b, const CBonusSystemNode & context) const
 {
-	if(context.getNodeType() == CBonusSystemNode::STACK_INSTANCE)
+	if(context.getNodeType() == CBonusSystemNode::STACK_INSTANCE || context.getNodeType() == CBonusSystemNode::COMMANDER)
 	{
 		int level = dynamic_cast<const CStackInstance &>(context).getLevel();
 		auto newBonus = std::make_shared<Bonus>(*b);
@@ -155,11 +155,18 @@ std::shared_ptr<Bonus> TimesStackLevelUpdater::createUpdatedBonus(const std::sha
 	else if(context.getNodeType() == CBonusSystemNode::STACK_BATTLE)
 	{
 		const auto & stack = dynamic_cast<const CStack &>(context);
-		//only update if stack doesn't have an instance (summons, war machines)
-		//otherwise we'd end up multiplying twice
+		//update if stack doesn't have an instance (summons, war machines)
 		if(stack.base == nullptr)
 		{
 			int level = stack.unitType()->getLevel();
+			auto newBonus = std::make_shared<Bonus>(*b);
+			newBonus->val *= level;
+			return newBonus;
+		}
+		// If these are not handled here, the final outcome may potentially be incorrect.
+		else
+		{
+			int level = dynamic_cast<const CStackInstance*>(stack.base)->getLevel();
 			auto newBonus = std::make_shared<Bonus>(*b);
 			newBonus->val *= level;
 			return newBonus;


### PR DESCRIPTION
make TimesStackLevelUpdater can affect comander

In the code, The `CCommanderInstance` class inherits from `CStackInstance`. We can treat comander as a stack. So I extend `TIMES_STACK_LEVEL` to comander to support some bonus value multiplies by commader level.

There is a problem in the implement before. In  `CBonusSystemNode::STACK_BATTLE` case the comment say that  if stack.base != nullptr, if we multiply it, we'd end up multiplying twice. but the actual isf we don't multiply it, we will probability get the wrong result. It seems randomly pick a value from  `STACK_BATTLE`  or `STACK_INSTANCE` case (may be fetch from cache?) This problem occures in both comander and normal stack cases, and after I fix `STACK_BATTLE`  case, the result is right.