### PR TITLE
Fix being stuck in blocked tiles while flying towards hero

### DIFF
--- a/lib/pathfinder/PathfindingRules.cpp
+++ b/lib/pathfinder/PathfindingRules.cpp
@@ -394,7 +394,7 @@ void LayerTransitionRule::process(
 		{
 			if(source.node->accessible != EPathAccessibility::ACCESSIBLE && source.node->accessible != EPathAccessibility::VISITABLE)
 			{
-				if (destination.node->accessible == EPathAccessibility::BLOCKVIS)
+				if (destination.node->accessible == EPathAccessibility::BLOCKVIS || (destination.node->accessible == EPathAccessibility::VISITABLE && destination.nodeHero != nullptr))
 				{
 					// Can't visit 'blockvisit' objects on coast if hero will end up on water terrain
 					if (source.tile->blocked || !destination.tile->entrableTerrain(source.tile))


### PR DESCRIPTION
Treat visitable tiles as if promoted to blockvis while occupied by ally / enemy hero so pathfinder does not suggest wrong path in such cases while flying with original rules