### PR TITLE
fix error during ios build

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -19,7 +19,7 @@ class VCMI(ConanFile):
         "sdl_image/[~2.0.5]",
         "sdl_mixer/[~2.0.4]",
         "sdl_ttf/[~2.0.18]",
-        "onetbb/[^2021.3]",
+        "onetbb/[^2021.7 <2021.10]",  # 2021.10+ breaks mobile builds due to added hwloc dependency
         "xz_utils/[>=5.2.5]", # Required for innoextract
     ]
 
@@ -39,7 +39,6 @@ class VCMI(ConanFile):
 
         "boost/*:shared": True,
         "minizip/*:shared": True,
-        "onetbb/*:shared": True,
     }
 
     def configure(self):


### PR DESCRIPTION
`onetbb/2021.10.0` adds a transitive dependency for `hwloc/2.9.1`

The problem is that `hwloc` does not support mobile OS.

```
checking which OS support to include... Unsupported! (aarch64-apple-ios)
configure: WARNING: ***********************************************************
configure: WARNING: *** hwloc does not support this system.
configure: WARNING: *** hwloc will *attempt* to build (but it may not work).
configure: WARNING: *** hwloc run-time results may be reduced to showing just one processor,
configure: WARNING: *** and binding will not be supported.
configure: WARNING: *** You have been warned.
configure: WARNING: *** Pausing to give you time to read this message...
configure: WARNING: ***********************************************************
checking which CPU support to include... unknown
```

...which eventually leads to:

```
ninja: error: '/Users/simo/.conan/data/hwloc/2.9.3/_/_/package/81c684be1f19b5b5aefe294dd826377be1235f07/lib/libhwloc.so', needed by 'appleclang_15.0_cxx17_64_release/libtbbbind_2_5.3.12.dylib', missing and no known rule to make it
onetbb/2021.12.0:
onetbb/2021.12.0: ERROR: Package '9fcc0a90f088a5fd6ea9bf93b3534713b5635296' build failed
```

Additionally, hwloc recipe apparently has dropped support for the `shared` option at some point, so it was removed from conanfile as well.

```
ERROR: onetbb/2021.7.0: option 'shared' doesn't exist
Possible options are ['tbbmalloc', 'tbbproxy', 'tbbbind', 'interprocedural_optimization']
```

