### PR TITLE
Map editor fix event regressions

### DIFF
--- a/mapeditor/inspector/towneventdialog.cpp
+++ b/mapeditor/inspector/towneventdialog.cpp
@@ -13,6 +13,7 @@
 #include "towneventdialog.h"
 #include "ui_towneventdialog.h"
 #include "mapeditorroles.h"
+#include "../mapsettings/eventsettings.h"
 #include "../../lib/entities/building/CBuilding.h"
 #include "../../lib/entities/faction/CTownHandler.h"
 #include "../../lib/constants/NumericConstants.h"
@@ -66,7 +67,7 @@ void TownEventDialog::initPlayers()
 	auto playerList = params.value("players").toList();
 	for (int i = 0; i < PlayerColor::PLAYER_LIMIT_I; ++i)
 	{
-		bool isAffected = playerList.contains(QString::fromStdString(PlayerColor(i).toString()));
+		bool isAffected = playerList.contains(toQString(PlayerColor(i)));
 		auto * item = new QListWidgetItem(QString::fromStdString(GameConstants::PLAYER_COLOR_NAMES[i]));
 		item->setData(MapEditorRoles::PlayerIDRole, QVariant::fromValue(i));
 		item->setCheckState(isAffected ? Qt::Checked : Qt::Unchecked);
@@ -219,7 +220,7 @@ QVariant TownEventDialog::playersToVariant()
 	{
 		auto * item = ui->playersAffected->item(i);
 		if (item->checkState() == Qt::Checked)
-			players.push_back(QString::fromStdString(PlayerColor(i).toString()));
+			players.push_back(toQString(PlayerColor(i)));
 	}
 	return QVariant::fromValue(players);
 }

--- a/mapeditor/inspector/towneventdialog.cpp
+++ b/mapeditor/inspector/towneventdialog.cpp
@@ -63,9 +63,10 @@ TownEventDialog::~TownEventDialog()
 
 void TownEventDialog::initPlayers()
 {
+	auto playerList = params.value("players").toList();
 	for (int i = 0; i < PlayerColor::PLAYER_LIMIT_I; ++i)
 	{
-		bool isAffected = (1 << i) & params.value("players").toInt();
+		bool isAffected = playerList.contains(QString::fromStdString(PlayerColor(i).toString()));
 		auto * item = new QListWidgetItem(QString::fromStdString(GameConstants::PLAYER_COLOR_NAMES[i]));
 		item->setData(MapEditorRoles::PlayerIDRole, QVariant::fromValue(i));
 		item->setCheckState(isAffected ? Qt::Checked : Qt::Unchecked);
@@ -213,12 +214,12 @@ void TownEventDialog::on_TownEventDialog_finished(int result)
 
 QVariant TownEventDialog::playersToVariant()
 {
-	int players = 0;
+	QVariantList players;
 	for (int i = 0; i < ui->playersAffected->count(); ++i)
 	{
 		auto * item = ui->playersAffected->item(i);
 		if (item->checkState() == Qt::Checked)
-			players |= 1 << i;
+			players.push_back(QString::fromStdString(PlayerColor(i).toString()));
 	}
 	return QVariant::fromValue(players);
 }

--- a/mapeditor/inspector/towneventdialog.cpp
+++ b/mapeditor/inspector/towneventdialog.cpp
@@ -155,7 +155,12 @@ void TownEventDialog::initCreatures()
 {
 	auto creatures = params.value("creatures").toList();
 	auto * ctown = town.town;
-	for (int i = 0; i < GameConstants::CREATURES_PER_TOWN; ++i)
+	if (!ctown)
+		ui->creaturesTable->setRowCount(GameConstants::CREATURES_PER_TOWN);
+	else 
+		ui->creaturesTable->setRowCount(ctown->creatures.size());
+
+	for (int i = 0; i < ui->creaturesTable->rowCount(); ++i)
 	{
 		QString creatureNames;
 		if (!ctown)
@@ -239,7 +244,7 @@ QVariantList TownEventDialog::buildingsToVariant()
 QVariantList TownEventDialog::creaturesToVariant()
 {
 	QVariantList creaturesList;
-	for (int i = 0; i < GameConstants::CREATURES_PER_TOWN; ++i)
+	for (int i = 0; i < ui->creaturesTable->rowCount(); ++i)
 	{
 		auto * item = static_cast<QSpinBox *>(ui->creaturesTable->cellWidget(i, 1));
 		creaturesList.push_back(item->value());

--- a/mapeditor/mapsettings/eventsettings.cpp
+++ b/mapeditor/mapsettings/eventsettings.cpp
@@ -16,11 +16,16 @@
 #include "../../lib/constants/NumericConstants.h"
 #include "../../lib/constants/StringConstants.h"
 
+QString toQString(const PlayerColor & player)
+{
+	return QString::fromStdString(player.toString());
+}
+
 QVariant toVariant(const std::set<PlayerColor> & players)
 {
 	QVariantList result;
 	for(auto const id : players)
-		result.push_back(QString::fromStdString(id.toString()));
+		result.push_back(toQString(id));
 	return result;
 }
 

--- a/mapeditor/mapsettings/eventsettings.h
+++ b/mapeditor/mapsettings/eventsettings.h
@@ -15,6 +15,7 @@ namespace Ui {
 class EventSettings;
 }
 
+QString toQString(const PlayerColor & player);
 QVariant toVariant(const TResources & resources);
 QVariant toVariant(const std::set<PlayerColor> & players);
 

--- a/mapeditor/mapsettings/timedevent.cpp
+++ b/mapeditor/mapsettings/timedevent.cpp
@@ -30,9 +30,10 @@ TimedEvent::TimedEvent(QListWidgetItem * t, QWidget *parent) :
 	ui->eventFirstOccurrence->setValue(params.value("firstOccurrence").toInt());
 	ui->eventRepeatAfter->setValue(params.value("nextOccurrence").toInt());
 
+	auto playerList = params.value("players").toList();
 	for(int i = 0; i < PlayerColor::PLAYER_LIMIT_I; ++i)
 	{
-		bool isAffected = (1 << i) & params.value("players").toInt();
+		bool isAffected = playerList.contains(QString::fromStdString(PlayerColor(i).toString()));
 		auto * item = new QListWidgetItem(QString::fromStdString(GameConstants::PLAYER_COLOR_NAMES[i]));
 		item->setData(Qt::UserRole, QVariant::fromValue(i));
 		item->setCheckState(isAffected ? Qt::Checked : Qt::Unchecked);
@@ -69,12 +70,12 @@ void TimedEvent::on_TimedEvent_finished(int result)
 	descriptor["firstOccurrence"] = QVariant::fromValue(ui->eventFirstOccurrence->value());
 	descriptor["nextOccurrence"] = QVariant::fromValue(ui->eventRepeatAfter->value());
 
-	int players = 0;
+	QVariantList players;
 	for(int i = 0; i < ui->playersAffected->count(); ++i)
 	{
 		auto * item = ui->playersAffected->item(i);
 		if(item->checkState() == Qt::Checked)
-			players |= 1 << i;
+			players.push_back(QString::fromStdString(PlayerColor(i).toString()));
 	}
 	descriptor["players"] = QVariant::fromValue(players);
 

--- a/mapeditor/mapsettings/timedevent.cpp
+++ b/mapeditor/mapsettings/timedevent.cpp
@@ -10,6 +10,7 @@
 #include "StdInc.h"
 #include "timedevent.h"
 #include "ui_timedevent.h"
+#include "eventsettings.h"
 #include "../../lib/constants/EntityIdentifiers.h"
 #include "../../lib/constants/StringConstants.h"
 
@@ -33,7 +34,7 @@ TimedEvent::TimedEvent(QListWidgetItem * t, QWidget *parent) :
 	auto playerList = params.value("players").toList();
 	for(int i = 0; i < PlayerColor::PLAYER_LIMIT_I; ++i)
 	{
-		bool isAffected = playerList.contains(QString::fromStdString(PlayerColor(i).toString()));
+		bool isAffected = playerList.contains(toQString(PlayerColor(i)));
 		auto * item = new QListWidgetItem(QString::fromStdString(GameConstants::PLAYER_COLOR_NAMES[i]));
 		item->setData(Qt::UserRole, QVariant::fromValue(i));
 		item->setCheckState(isAffected ? Qt::Checked : Qt::Unchecked);
@@ -75,7 +76,7 @@ void TimedEvent::on_TimedEvent_finished(int result)
 	{
 		auto * item = ui->playersAffected->item(i);
 		if(item->checkState() == Qt::Checked)
-			players.push_back(QString::fromStdString(PlayerColor(i).toString()));
+			players.push_back(toQString(PlayerColor(i)));
 	}
 	descriptor["players"] = QVariant::fromValue(players);
 

--- a/server/processors/NewTurnProcessor.cpp
+++ b/server/processors/NewTurnProcessor.cpp
@@ -110,7 +110,7 @@ void NewTurnProcessor::handleTownEvents(const CGTownInstance * town)
 
 			for (si32 i=0;i<event.creatures.size();i++) //creature growths
 			{
-				if (!town->creatures.at(i).second.empty() && event.creatures.at(i) > 0)//there is dwelling
+				if (i < town->creatures.size() && !town->creatures.at(i).second.empty() && event.creatures.at(i) > 0)//there is dwelling
 				{
 					sac.creatures[i].first += event.creatures.at(i);
 					iw.components.emplace_back(ComponentType::CREATURE, town->creatures.at(i).second.back(), event.creatures.at(i));


### PR DESCRIPTION
Fixed two regressions from recent PRs:
 - map editor event from didn't supported 8th creature in town (resulted in crash of editor)
 - events didn't appeared because of broken saving of affected players (was recently changed to std::set)

There is still problem that creatures from town event are not added to town... works in 1.5.7