### PR TITLE
Building fixes

### DIFF
--- a/client/windows/CCastleInterface.cpp
+++ b/client/windows/CCastleInterface.cpp
@@ -54,6 +54,7 @@
 #include "../../lib/entities/building/CBuilding.h"
 #include "../../lib/mapObjects/CGHeroInstance.h"
 #include "../../lib/mapObjects/CGTownInstance.h"
+#include "../../lib/mapObjects/TownBuildingInstance.h"
 
 
 static bool useCompactCreatureBox()
@@ -855,7 +856,10 @@ void CCastleBuildings::enterRewardable(BuildingID building)
 	}
 	else
 	{
-		LOCPLINT->cb->visitTownBuilding(town, building);
+		if (town->rewardableBuildings.at(building)->wasVisited(town->visitingHero))
+			enterBuilding(building);
+		else
+			LOCPLINT->cb->visitTownBuilding(town, building);
 	}
 }
 

--- a/client/windows/CCastleInterface.cpp
+++ b/client/windows/CCastleInterface.cpp
@@ -845,7 +845,18 @@ bool CCastleBuildings::buildingTryActivateCustomUI(BuildingID buildingToTest, Bu
 
 void CCastleBuildings::enterRewardable(BuildingID building)
 {
-	LOCPLINT->cb->visitTownBuilding(town, building);
+	if (town->visitingHero == nullptr)
+	{
+		MetaString message;
+		message.appendTextID("core.genrltxt.273"); // only visiting heroes may visit %s
+		message.replaceTextID(town->town->buildings.at(building)->getNameTextID());
+
+		LOCPLINT->showInfoDialog(message.toString());
+	}
+	else
+	{
+		LOCPLINT->cb->visitTownBuilding(town, building);
+	}
 }
 
 void CCastleBuildings::enterBlacksmith(BuildingID building, ArtifactID artifactID)

--- a/docs/modders/Entities_Format/Town_Building_Format.md
+++ b/docs/modders/Entities_Format/Town_Building_Format.md
@@ -197,6 +197,7 @@ These are just a couple of examples of what can be done in VCMI. See vcmi config
 	"bonuses" : [ BONUS_FORMAT ]
 	
 	// If set to true, this building will not automatically activate on new day or on entering town and needs to be activated manually on click
+	// Note that such building can only be activated by visiting hero, and not by garrisoned hero.
 	"manualHeroVisit" : false,
 	
 	// Bonuses provided by this special building if this building or any of its upgrades are constructed in town

--- a/lib/mapObjects/CRewardableObject.cpp
+++ b/lib/mapObjects/CRewardableObject.cpp
@@ -246,6 +246,9 @@ void CRewardableObject::blockingDialogAnswered(const CGHeroInstance * hero, int3
 	}
 	else
 	{
+		if (answer == 0)
+			return; //Player refused
+
 		if(answer > 0 && answer - 1 < configuration.info.size())
 		{
 			auto list = getAvailableRewards(hero, Rewardable::EEventType::EVENT_FIRST_VISIT);

--- a/lib/mapObjects/TownBuildingInstance.cpp
+++ b/lib/mapObjects/TownBuildingInstance.cpp
@@ -165,6 +165,11 @@ void TownRewardableBuildingInstance::grantReward(ui32 rewardID, const CGHeroInst
 	}
 }
 
+bool TownRewardableBuildingInstance::wasVisited(const CGHeroInstance * contextHero) const
+{
+	return wasVisitedBefore(contextHero);
+}
+
 bool TownRewardableBuildingInstance::wasVisitedBefore(const CGHeroInstance * contextHero) const
 {
 	switch (configuration.visitMode)

--- a/lib/mapObjects/TownBuildingInstance.h
+++ b/lib/mapObjects/TownBuildingInstance.h
@@ -70,6 +70,7 @@ class DLL_LINKAGE TownRewardableBuildingInstance : public TownBuildingInstance, 
 public:
 	void setProperty(ObjProperty what, ObjPropertyID identifier) override;
 	void onHeroVisit(const CGHeroInstance * h) const override;
+	bool wasVisited(const CGHeroInstance * contextHero) const override;
 	
 	void newTurn(vstd::RNG & rand) const override;
 	

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -2175,7 +2175,7 @@ bool CGameHandler::visitTownBuilding(ObjectInstanceID tid, BuildingID bid)
 
 	if (t->rewardableBuildings.count(bid))
 	{
-		auto & hero = t->garrisonHero ? t->garrisonHero : t->visitingHero;
+		auto & hero = t->visitingHero;
 		auto * building = t->rewardableBuildings.at(bid);
 
 		if (hero && t->town->buildings.at(bid)->manualHeroVisit)

--- a/server/CGameHandler.h
+++ b/server/CGameHandler.h
@@ -182,6 +182,7 @@ public:
 	void visitObjectOnTile(const TerrainTile &t, const CGHeroInstance * h);
 	bool teleportHero(ObjectInstanceID hid, ObjectInstanceID dstid, ui8 source, PlayerColor asker = PlayerColor::NEUTRAL);
 	void visitCastleObjects(const CGTownInstance * obj, const CGHeroInstance * hero) override;
+	void visitCastleObjects(const CGTownInstance * obj, std::vector<const CGHeroInstance * > visitors);
 	void levelUpHero(const CGHeroInstance * hero, SecondarySkill skill);//handle client respond and send one more request if needed
 	void levelUpHero(const CGHeroInstance * hero);//initial call - check if hero have remaining levelups & handle them
 	void levelUpCommander (const CCommanderInstance * c, int skill); //secondary skill 1 to 6, special skill : skill - 100

--- a/server/queries/VisitQueries.h
+++ b/server/queries/VisitQueries.h
@@ -11,19 +11,22 @@
 
 #include "CQuery.h"
 
+VCMI_LIB_NAMESPACE_BEGIN
+class CGTownInstance;
+VCMI_LIB_NAMESPACE_END
+
 //Created when hero visits object.
 //Removed when query above is resolved (or immediately after visit if no queries were created)
 class VisitQuery : public CQuery
 {
 protected:
-	VisitQuery(CGameHandler * owner, const CGObjectInstance *Obj, const CGHeroInstance *Hero);
+	VisitQuery(CGameHandler * owner, const CGObjectInstance * Obj, const CGHeroInstance * Hero);
 
 public:
-	const CGObjectInstance *visitedObject;
-	const CGHeroInstance *visitingHero;
+	const CGObjectInstance * visitedObject;
+	const CGHeroInstance * visitingHero;
 
-	bool blocksPack(const CPack *pack) const final;
-	void onExposure(QueryPtr topQuery) final;
+	bool blocksPack(const CPack * pack) const final;
 };
 
 class MapObjectVisitQuery final : public VisitQuery
@@ -31,17 +34,26 @@ class MapObjectVisitQuery final : public VisitQuery
 public:
 	bool removeObjectAfterVisit;
 
-	MapObjectVisitQuery(CGameHandler * owner, const CGObjectInstance *Obj, const CGHeroInstance *Hero);
+	MapObjectVisitQuery(CGameHandler * owner, const CGObjectInstance * Obj, const CGHeroInstance * Hero);
 
 	void onRemoval(PlayerColor color) final;
+	void onExposure(QueryPtr topQuery) final;
 };
 
 class TownBuildingVisitQuery final : public VisitQuery
 {
+	struct BuildingVisit
+	{
+		const CGHeroInstance * hero;
+		BuildingID building;
+	};
+
+	const CGTownInstance * visitedTown;
+	std::vector<BuildingVisit> visitedBuilding;
+
 public:
-	BuildingID visitedBuilding;
+	TownBuildingVisitQuery(CGameHandler * owner, const CGTownInstance * Obj, std::vector<const CGHeroInstance *> heroes, std::vector<BuildingID> buildingToVisit);
 
-	TownBuildingVisitQuery(CGameHandler * owner, const CGObjectInstance *Obj, const CGHeroInstance *Hero, BuildingID buildingToVisit);
-
-	void onRemoval(PlayerColor color) final;
+	void onAdded(PlayerColor color) final;
+	void onExposure(QueryPtr topQuery) final;
 };


### PR DESCRIPTION
Fixes for several issues related to town buildings that were reported recently:
- Fixed crash on refusing reward, e.g. from Tree of Knowledge
- It is now actually possible to visit multiple buildings at once, will well defined order even if building visit creates queries, e.g. building War Academy in town with 2 heroes ready to levelup - game will now create a query that keeps list of pending visits 
- Buildings with manual visit mode can now be only triggered by a visiting hero. If there is no visiting hero, game will show error message instead of doing nothing.