### PR TITLE
Add status bar movement points info for own hero on adventure map or hero list

### DIFF
--- a/Mods/vcmi/config/vcmi/english.json
+++ b/Mods/vcmi/config/vcmi/english.json
@@ -20,6 +20,7 @@
 	"vcmi.adventureMap.playerAttacked"                   : "Player has been attacked: %s",
 	"vcmi.adventureMap.moveCostDetails"                  : "Movement points - Cost: %TURNS turns + %POINTS points, Remaining points: %REMAINING",
 	"vcmi.adventureMap.moveCostDetailsNoTurns"           : "Movement points - Cost: %POINTS points, Remaining points: %REMAINING",
+	"vcmi.adventureMap.movementPointsHeroInfo" 			 : "(Movement points: %REMAINING / %POINTS)",
 	"vcmi.adventureMap.replayOpponentTurnNotImplemented" : "Sorry, replay opponent turn is not implemented yet!",
 
 	"vcmi.capitalColors.0" : "Red",

--- a/Mods/vcmi/config/vcmi/polish.json
+++ b/Mods/vcmi/config/vcmi/polish.json
@@ -20,6 +20,7 @@
 	"vcmi.adventureMap.playerAttacked"         : "Gracz został zaatakowany: %s",
 	"vcmi.adventureMap.moveCostDetails"        : "Punkty ruchu - Koszt: %TURNS tury + %POINTS punkty, Pozostałe punkty: %REMAINING",
 	"vcmi.adventureMap.moveCostDetailsNoTurns" : "Punkty ruchu - Koszt: %POINTS punkty, Pozostałe punkty: %REMAINING",
+	"vcmi.adventureMap.movementPointsHeroInfo" : "(Punkty ruchu: %REMAINING / %POINTS)",
 	"vcmi.adventureMap.replayOpponentTurnNotImplemented" : "Wybacz, powtórka ruchu wroga nie została jeszcze zaimplementowana!",
 
 	"vcmi.capitalColors.0" : "Czerwony",

--- a/client/adventureMap/CList.cpp
+++ b/client/adventureMap/CList.cpp
@@ -263,7 +263,7 @@ void CHeroList::CHeroItem::showTooltip()
 
 std::string CHeroList::CHeroItem::getHoverText()
 {
-	return boost::str(boost::format(CGI->generaltexth->allTexts[15]) % hero->getNameTranslated() % hero->getClassNameTranslated());
+	return boost::str(boost::format(CGI->generaltexth->allTexts[15]) % hero->getNameTranslated() % hero->getClassNameTranslated()) + hero->getMovementPointsTextIfOwner(hero->getOwner());
 }
 
 void CHeroList::CHeroItem::gesture(bool on, const Point & initialPosition, const Point & finalPosition)

--- a/lib/mapObjects/CGHeroInstance.cpp
+++ b/lib/mapObjects/CGHeroInstance.cpp
@@ -566,6 +566,25 @@ std::string CGHeroInstance::getObjectName() const
 		return VLC->objtypeh->getObjectName(ID, 0);
 }
 
+std::string CGHeroInstance::getHoverText(PlayerColor player) const
+{
+	std::string hoverText = CArmedInstance::getHoverText(player) + getMovementPointsTextIfOwner(player);
+	return hoverText;
+}
+
+std::string CGHeroInstance::getMovementPointsTextIfOwner(PlayerColor player) const
+{
+	std::string output = "";
+	if(player == getOwner())
+	{
+		output += " " + VLC->generaltexth->translate("vcmi.adventureMap.movementPointsHeroInfo");
+		boost::replace_first(output, "%POINTS", std::to_string(movementPointsLimit(!boat)));
+		boost::replace_first(output, "%REMAINING", std::to_string(movementPointsRemaining()));
+	}
+
+	return output;
+}
+
 ui8 CGHeroInstance::maxlevelsToMagicSchool() const
 {
 	return type->heroClass->isMagicHero() ? 3 : 4;

--- a/lib/mapObjects/CGHeroInstance.h
+++ b/lib/mapObjects/CGHeroInstance.h
@@ -297,6 +297,8 @@ public:
 	void pickRandomObject(CRandomGenerator & rand) override;
 	void onHeroVisit(const CGHeroInstance * h) const override;
 	std::string getObjectName() const override;
+	std::string getHoverText(PlayerColor player) const override;
+	std::string getMovementPointsTextIfOwner(PlayerColor player) const;
 
 	void afterAddToMap(CMap * map) override;
 	void afterRemoveFromMap(CMap * map) override;


### PR DESCRIPTION
As in title - ability to check movement points of hero that is not currently selected is decent QoL improvement from HD mod / hota and people are used to it