### PR TITLE
[beta] Wait for inactive player in hotseat to answer dialog before starting battle

### DIFF
--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -1489,6 +1489,7 @@ void CPlayerInterface::playerBlocked(int reason, bool start)
 			cmp.push_back(std::make_shared<CComponent>(ComponentType::FLAG, playerID));
 			makingTurn = true; //workaround for stiff showInfoDialog implementation
 			showInfoDialog(msg, cmp);
+			waitWhileDialog();
 			makingTurn = false;
 		}
 	}


### PR DESCRIPTION
Quick workaround for #4582

Will review this code and try to make more robust solution for 1.6 later