### PR TITLE
Fix crash on AI double-visiting a town with new hero

### DIFF
--- a/AI/Nullkiller/Goals/RecruitHero.cpp
+++ b/AI/Nullkiller/Goals/RecruitHero.cpp
@@ -74,9 +74,6 @@ void RecruitHero::accept(AIGateway * ai)
 
 		ai->nullkiller->heroManager->update();
 	}
-
-	if(t->visitingHero)
-		ai->moveHeroToTile(t->visitablePos(), t->visitingHero.get());
 }
 
 }

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -456,26 +456,28 @@ void CGameHandler::handleReceivedPack(CPackForServer * pack)
 	{
 		sendPackageResponse(false);
 	}
-
-	bool result;
-	try
-	{
-		ApplyGhNetPackVisitor applier(*this);
-		pack->visit(applier);
-		result = applier.getResult();
-	}
-	catch(ExceptionNotAllowedAction &)
-	{
-		result = false;
-	}
-
-	if(result)
-		logGlobal->trace("Message %s successfully applied!", typeid(*pack).name());
 	else
-		complain((boost::format("Got false in applying %s... that request must have been fishy!")
-			% typeid(*pack).name()).str());
+	{
+		bool result;
+		try
+		{
+			ApplyGhNetPackVisitor applier(*this);
+			pack->visit(applier);
+			result = applier.getResult();
+		}
+		catch(ExceptionNotAllowedAction &)
+		{
+			result = false;
+		}
 
-	sendPackageResponse(true);
+		if(result)
+			logGlobal->trace("Message %s successfully applied!", typeid(*pack).name());
+		else
+			complain((boost::format("Got false in applying %s... that request must have been fishy!")
+				% typeid(*pack).name()).str());
+
+		sendPackageResponse(true);
+	}
 	vstd::clear_pointer(pack);
 }
 


### PR DESCRIPTION
- Fixes #4598
- Removes AI attempt to visit town with newly recruited hero - redundant since visit already happens on recruit
- Fixes server processing network pack from client even if this network pack was blocked by a query