### PR TITLE
onetbb options in conanfile

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -19,7 +19,7 @@ class VCMI(ConanFile):
         "sdl_image/[~2.0.5]",
         "sdl_mixer/[~2.0.4]",
         "sdl_ttf/[~2.0.18]",
-        "onetbb/[^2021.3]",
+        "onetbb/2021.10.0",
         "xz_utils/[>=5.2.5]", # Required for innoextract
     ]
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -19,7 +19,7 @@ class VCMI(ConanFile):
         "sdl_image/[~2.0.5]",
         "sdl_mixer/[~2.0.4]",
         "sdl_ttf/[~2.0.18]",
-        "onetbb/[^2021.12]",
+        "onetbb/[^2021.3]",
         "xz_utils/[>=5.2.5]", # Required for innoextract
     ]
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -19,7 +19,7 @@ class VCMI(ConanFile):
         "sdl_image/[~2.0.5]",
         "sdl_mixer/[~2.0.4]",
         "sdl_ttf/[~2.0.18]",
-        "onetbb/2021.10.0",
+        "onetbb/[>=2021.12.0]",
         "xz_utils/[>=5.2.5]", # Required for innoextract
     ]
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -19,7 +19,7 @@ class VCMI(ConanFile):
         "sdl_image/[~2.0.5]",
         "sdl_mixer/[~2.0.4]",
         "sdl_ttf/[~2.0.18]",
-        "onetbb/[^2021.3]",
+        "onetbb/[^2021.12]",
         "xz_utils/[>=5.2.5]", # Required for innoextract
     ]
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -19,7 +19,7 @@ class VCMI(ConanFile):
         "sdl_image/[~2.0.5]",
         "sdl_mixer/[~2.0.4]",
         "sdl_ttf/[~2.0.18]",
-        "onetbb/[^2021.7 <2021.10]",  # 2021.10+ breaks mobile builds due to added hwloc dependency
+        "onetbb/[^2021.3]",
         "xz_utils/[>=5.2.5]", # Required for innoextract
     ]
 
@@ -145,6 +145,10 @@ class VCMI(ConanFile):
         #    self.options["ffmpeg"].avfilter = True
         #    self.options["ffmpeg"].with_sdl = True
         #    self.options["ffmpeg"].enable_filters = "aresample,scale"
+
+        self.options["onetbb"].tbbmalloc = False
+        self.options["onetbb"].tbbproxy = False
+        self.options["onetbb"].tbbbind = False
 
         self.options["sdl"].sdl2main = self.settings.os != "iOS"
         self.options["sdl"].vulkan = False


### PR DESCRIPTION
Follow-up PR from https://github.com/vcmi/vcmi/pull/4602 

Reverts upper-version limit for onetbb and adds appropriate options to prevent the `hwloc` dependency to prevent errors during ios builds.
