### PR TITLE
Compatibility hack for mods with old banks format

### DIFF
--- a/lib/mapObjectConstructors/CObjectClassesHandler.cpp
+++ b/lib/mapObjectConstructors/CObjectClassesHandler.cpp
@@ -203,6 +203,11 @@ TObjectTypeHandler CObjectClassesHandler::loadSubObjectFromJson(const std::strin
 		assert(handlerConstructors.count(handler) != 0);
 	}
 
+	// Compatibility with 1.5 mods for 1.6. To be removed in 1.7
+	// Detect banks that use old format and load them using old bank hander
+	if (baseObject->id == Obj::CREATURE_BANK && entry.Struct().count("levels") && !entry.Struct().count("rewards"))
+		handler = "bank";
+
 	auto createdObject = handlerConstructors.at(handler)();
 
 	createdObject->modScope = scope;


### PR DESCRIPTION
Should fix mod objects that were added to `core:creatureBank` object that is now a rewardable object and not a bank