### PR TITLE
Add all artifacts/spells/skills to quest widget lists and disable banned

### DIFF
--- a/lib/rewardable/Limiter.cpp
+++ b/lib/rewardable/Limiter.cpp
@@ -244,6 +244,7 @@ void Rewardable::Limiter::serializeJson(JsonSerializeFormat & handler)
 	handler.serializeIdArray("colors", players);
 	handler.serializeInt("manaPoints", manaPoints);
 	handler.serializeIdArray("artifacts", artifacts);
+	handler.serializeIdArray("spells", spells);
 	handler.enterArray("creatures").serializeStruct(creatures);
 	handler.enterArray("primary").serializeArray(primary);
 	{

--- a/mapeditor/inspector/questwidget.cpp
+++ b/mapeditor/inspector/questwidget.cpp
@@ -48,11 +48,10 @@ QuestWidget::QuestWidget(MapController & _controller, CQuest & _sh, QWidget *par
 	}
 	
 	//fill artifacts
-	for(auto const & artifactPtr : VLC->arth->objects)
+	for(const auto artifactPtr : VLC->arth->objects)
 	{
 		auto artifactIndex = artifactPtr->getIndex();
 		auto * item = new QListWidgetItem(QString::fromStdString(artifactPtr->getNameTranslated()));
-		item->setData(Qt::UserRole, QVariant::fromValue(artifactIndex));
 		item->setFlags(item->flags() | Qt::ItemIsUserCheckable);
 		item->setCheckState(Qt::Unchecked);
 		if(controller.map()->allowedArtifact.count(artifactIndex) == 0)
@@ -61,11 +60,10 @@ QuestWidget::QuestWidget(MapController & _controller, CQuest & _sh, QWidget *par
 	}
 	
 	//fill spells
-	for(auto const & spellPtr : VLC->spellh->objects)
+	for(const auto spellPtr : VLC->spellh->objects)
 	{
 		auto spellIndex = spellPtr->getIndex();
 		auto * item = new QListWidgetItem(QString::fromStdString(spellPtr->getNameTranslated()));
-		item->setData(Qt::UserRole, QVariant::fromValue(spellIndex));
 		item->setFlags(item->flags() | Qt::ItemIsUserCheckable);
 		item->setCheckState(Qt::Unchecked);
 		if(controller.map()->allowedSpells.count(spellIndex) == 0)
@@ -75,14 +73,13 @@ QuestWidget::QuestWidget(MapController & _controller, CQuest & _sh, QWidget *par
 	
 	//fill skills
 	ui->lSkills->setRowCount(VLC->skillh->objects.size());
-	for(auto const & skillPtr : VLC->skillh->objects)
+	for(const auto skillPtr : VLC->skillh->objects)
 	{
 		auto skillIndex = skillPtr->getIndex();
 		auto * item = new QTableWidgetItem(QString::fromStdString(skillPtr->getNameTranslated()));
-		item->setData(Qt::UserRole, QVariant::fromValue(skillIndex));
 		
 		auto * widget = new QComboBox;
-		for(auto & s : NSecondarySkill::levels)
+		for(const auto & s : NSecondarySkill::levels)
 			widget->addItem(QString::fromStdString(s));
 		
 		if(controller.map()->allowedAbilities.count(skillIndex) == 0)

--- a/mapeditor/inspector/questwidget.cpp
+++ b/mapeditor/inspector/questwidget.cpp
@@ -48,7 +48,7 @@ QuestWidget::QuestWidget(MapController & _controller, CQuest & _sh, QWidget *par
 	}
 	
 	//fill artifacts
-	for(const auto artifactPtr : VLC->arth->objects)
+	for(const auto & artifactPtr : VLC->arth->objects)
 	{
 		auto artifactIndex = artifactPtr->getIndex();
 		auto * item = new QListWidgetItem(QString::fromStdString(artifactPtr->getNameTranslated()));
@@ -60,7 +60,7 @@ QuestWidget::QuestWidget(MapController & _controller, CQuest & _sh, QWidget *par
 	}
 	
 	//fill spells
-	for(const auto spellPtr : VLC->spellh->objects)
+	for(const auto & spellPtr : VLC->spellh->objects)
 	{
 		auto spellIndex = spellPtr->getIndex();
 		auto * item = new QListWidgetItem(QString::fromStdString(spellPtr->getNameTranslated()));
@@ -73,7 +73,7 @@ QuestWidget::QuestWidget(MapController & _controller, CQuest & _sh, QWidget *par
 	
 	//fill skills
 	ui->lSkills->setRowCount(VLC->skillh->objects.size());
-	for(const auto skillPtr : VLC->skillh->objects)
+	for(const auto & skillPtr : VLC->skillh->objects)
 	{
 		auto skillIndex = skillPtr->getIndex();
 		auto * item = new QTableWidgetItem(QString::fromStdString(skillPtr->getNameTranslated()));

--- a/mapeditor/inspector/questwidget.cpp
+++ b/mapeditor/inspector/questwidget.cpp
@@ -48,48 +48,51 @@ QuestWidget::QuestWidget(MapController & _controller, CQuest & _sh, QWidget *par
 	}
 	
 	//fill artifacts
-	for(int i = 0; i < controller.map()->allowedArtifact.size(); ++i)
+	for(auto const & artifactPtr : VLC->arth->objects)
 	{
-		auto * item = new QListWidgetItem(QString::fromStdString(VLC->artifacts()->getByIndex(i)->getNameTranslated()));
-		item->setData(Qt::UserRole, QVariant::fromValue(i));
+		auto artifactIndex = artifactPtr->getIndex();
+		auto * item = new QListWidgetItem(QString::fromStdString(artifactPtr->getNameTranslated()));
+		item->setData(Qt::UserRole, QVariant::fromValue(artifactIndex));
 		item->setFlags(item->flags() | Qt::ItemIsUserCheckable);
 		item->setCheckState(Qt::Unchecked);
-		if(controller.map()->allowedArtifact.count(i) == 0)
+		if(controller.map()->allowedArtifact.count(artifactIndex) == 0)
 			item->setFlags(item->flags() & ~Qt::ItemIsEnabled);
 		ui->lArtifacts->addItem(item);
 	}
 	
 	//fill spells
-	for(int i = 0; i < controller.map()->allowedSpells.size(); ++i)
+	for(auto const & spellPtr : VLC->spellh->objects)
 	{
-		auto * item = new QListWidgetItem(QString::fromStdString(VLC->spells()->getByIndex(i)->getNameTranslated()));
-		item->setData(Qt::UserRole, QVariant::fromValue(i));
+		auto spellIndex = spellPtr->getIndex();
+		auto * item = new QListWidgetItem(QString::fromStdString(spellPtr->getNameTranslated()));
+		item->setData(Qt::UserRole, QVariant::fromValue(spellIndex));
 		item->setFlags(item->flags() | Qt::ItemIsUserCheckable);
 		item->setCheckState(Qt::Unchecked);
-		if(controller.map()->allowedSpells.count(i) == 0)
+		if(controller.map()->allowedSpells.count(spellIndex) == 0)
 			item->setFlags(item->flags() & ~Qt::ItemIsEnabled);
 		ui->lSpells->addItem(item);
 	}
 	
 	//fill skills
-	ui->lSkills->setRowCount(controller.map()->allowedAbilities.size());
-	for(int i = 0; i < controller.map()->allowedAbilities.size(); ++i)
+	ui->lSkills->setRowCount(VLC->skillh->objects.size());
+	for(auto const & skillPtr : VLC->skillh->objects)
 	{
-		auto * item = new QTableWidgetItem(QString::fromStdString(VLC->skills()->getByIndex(i)->getNameTranslated()));
-		item->setData(Qt::UserRole, QVariant::fromValue(i));
+		auto skillIndex = skillPtr->getIndex();
+		auto * item = new QTableWidgetItem(QString::fromStdString(skillPtr->getNameTranslated()));
+		item->setData(Qt::UserRole, QVariant::fromValue(skillIndex));
 		
 		auto * widget = new QComboBox;
 		for(auto & s : NSecondarySkill::levels)
 			widget->addItem(QString::fromStdString(s));
 		
-		if(controller.map()->allowedAbilities.count(i) == 0)
+		if(controller.map()->allowedAbilities.count(skillIndex) == 0)
 		{
 			item->setFlags(item->flags() & ~Qt::ItemIsEnabled);
 			widget->setEnabled(false);
 		}
 			
-		ui->lSkills->setItem(i, 0, item);
-		ui->lSkills->setCellWidget(i, 1, widget);
+		ui->lSkills->setItem(skillIndex, 0, item);
+		ui->lSkills->setCellWidget(skillIndex, 1, widget);
 	}
 	
 	//fill creatures
@@ -156,7 +159,7 @@ void QuestWidget::obtainData()
 	for(auto i : quest.mission.artifacts)
 		ui->lArtifacts->item(VLC->artifacts()->getById(i)->getIndex())->setCheckState(Qt::Checked);
 	for(auto i : quest.mission.spells)
-		ui->lArtifacts->item(VLC->spells()->getById(i)->getIndex())->setCheckState(Qt::Checked);
+		ui->lSpells->item(VLC->spells()->getById(i)->getIndex())->setCheckState(Qt::Checked);
 	for(auto & i : quest.mission.secondary)
 	{
 		int index = VLC->skills()->getById(i.first)->getIndex();


### PR DESCRIPTION
Previous code added at most as many items as were in allowed lists, which caused to skip last items if some were banned.