### PR TITLE
not report warning in factory-town

### DIFF
--- a/config/schemas/faction.json
+++ b/config/schemas/faction.json
@@ -96,7 +96,7 @@
 				"creatures" : {
 					"type" : "array",
 					"minItems" : 7,
-					"maxItems" : 7,
+					"maxItems" : 8,
 					"description" : "List of creatures available for recruitment on each level",
 					"items" : {
 						"type" : "array",


### PR DESCRIPTION
disable warning when creature length is 8.