### PR TITLE
optimize videowindow (black bg)

### DIFF
--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -1628,10 +1628,10 @@ VideoWindow::VideoWindow(VideoPath video, ImagePath rim, bool showBackground, fl
 	}
 	else
 	{
-		blackBackground = std::make_shared<GraphicalPrimitiveCanvas>(Rect(0, 0, pos.w, pos.h));
-		blackBackground->addBox(Point(0, 0), Point(pos.w, pos.h), Colors::BLACK);
+		blackBackground = std::make_shared<GraphicalPrimitiveCanvas>(Rect(0, 0, GH.screenDimensions().x, GH.screenDimensions().y));
 		videoPlayer = std::make_shared<VideoWidgetOnce>(Point(0, 0), video, true, scaleFactor, [this](){ exit(false); });
 		pos = center(Rect(0, 0, videoPlayer->pos.w, videoPlayer->pos.h));
+		blackBackground->addBox(Point(0, 0), Point(pos.x, pos.y), Colors::BLACK);
 	}
 
 	if(backgroundAroundWindow)

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -1617,6 +1617,9 @@ VideoWindow::VideoWindow(VideoPath video, ImagePath rim, bool showBackground, fl
 
 	addUsedEvents(LCLICK | KEYBOARD);
 
+	if(showBackground)
+		backgroundAroundWindow = std::make_shared<CFilledTexture>(ImagePath::builtin("DIBOXBCK"), Rect(0, 0, GH.screenDimensions().x, GH.screenDimensions().y));
+	
 	if(!rim.empty())
 	{
 		setBackground(rim);
@@ -1625,18 +1628,15 @@ VideoWindow::VideoWindow(VideoPath video, ImagePath rim, bool showBackground, fl
 	}
 	else
 	{
+		blackBackground = std::make_shared<GraphicalPrimitiveCanvas>(Rect(0, 0, pos.w, pos.h));
+		blackBackground->addBox(Point(0, 0), Point(pos.w, pos.h), Colors::BLACK);
 		videoPlayer = std::make_shared<VideoWidgetOnce>(Point(0, 0), video, true, scaleFactor, [this](){ exit(false); });
 		pos = center(Rect(0, 0, videoPlayer->pos.w, videoPlayer->pos.h));
 	}
 
-	if(showBackground)
-		backgroundAroundWindow = std::make_shared<CFilledTexture>(ImagePath::builtin("DIBOXBCK"), Rect(-pos.x, -pos.y, GH.screenDimensions().x, GH.screenDimensions().y));
+	if(backgroundAroundWindow)
+		backgroundAroundWindow->pos.moveTo(Point(0, 0));
 
-	if(rim.empty())
-	{
-		blackBackground = std::make_shared<GraphicalPrimitiveCanvas>(Rect(0, 0, pos.w, pos.h));
-		blackBackground->addBox(Point(0, 0), Point(pos.w, pos.h), Colors::BLACK);
-	}
 }
 
 void VideoWindow::exit(bool skipped)

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -34,6 +34,7 @@
 #include "../widgets/TextControls.h"
 #include "../widgets/ObjectLists.h"
 #include "../widgets/VideoWidget.h"
+#include "../widgets/GraphicalPrimitiveCanvas.h"
 
 #include "../render/Canvas.h"
 #include "../render/IRenderHandler.h"
@@ -1618,6 +1619,7 @@ VideoWindow::VideoWindow(VideoPath video, ImagePath rim, bool showBackground, fl
 
 	if(!rim.empty())
 	{
+		setBackground(rim);
 		videoPlayer = std::make_shared<VideoWidgetOnce>(Point(80, 186), video, true, [this](){ exit(false); });
 		pos = center(Rect(0, 0, 800, 600));
 	}
@@ -1630,8 +1632,11 @@ VideoWindow::VideoWindow(VideoPath video, ImagePath rim, bool showBackground, fl
 	if(showBackground)
 		backgroundAroundWindow = std::make_shared<CFilledTexture>(ImagePath::builtin("DIBOXBCK"), Rect(-pos.x, -pos.y, GH.screenDimensions().x, GH.screenDimensions().y));
 
-	if(!rim.empty())
-		setBackground(rim);
+	if(rim.empty())
+	{
+		blackBackground = std::make_shared<GraphicalPrimitiveCanvas>(Rect(0, 0, pos.w, pos.h));
+		blackBackground->addBox(Point(0, 0), Point(pos.w, pos.h), Colors::BLACK);
+	}
 }
 
 void VideoWindow::exit(bool skipped)

--- a/client/windows/GUIClasses.h
+++ b/client/windows/GUIClasses.h
@@ -44,6 +44,7 @@ class CFilledTexture;
 class IImage;
 class VideoWidget;
 class VideoWidgetOnce;
+class GraphicalPrimitiveCanvas;
 
 enum class EUserEvent;
 
@@ -506,6 +507,7 @@ class VideoWindow : public CWindowObject
 {
 	std::shared_ptr<VideoWidgetOnce> videoPlayer;
 	std::shared_ptr<CFilledTexture> backgroundAroundWindow;
+	std::shared_ptr<GraphicalPrimitiveCanvas> blackBackground;
 
 	std::function<void(bool)> closeCb;
 


### PR DESCRIPTION
Show black bg while loading video (avoid flicker a few ms).
Also shows black bg, when mod incompatibility window is open (looks better).