### PR TITLE
Fix one caption in the source code

### DIFF
--- a/docs/Readme.md
+++ b/docs/Readme.md
@@ -52,12 +52,15 @@ Please see corresponding installation guide articles for details for your platfo
 - [Cheat codes](players/Cheat_Codes.md)
 - [Privacy Policy](players/Privacy_Policy.md)
 
+## Documentation and guidelines for translators
+
+- [Translations](translators/Translations.md)
+
 ## Documentation and guidelines for game modders
 
 - [Modding Guidelines](modders/Readme.md)
 - [Mod File Format](modders/Mod_File_Format.md)
 - [Bonus Format](modders/Bonus_Format.md)
-- [Translations](modders/Translations.md)
 - [Map Editor](modders/Map_Editor.md)
 - [Campaign Format](modders/Campaign_Format.md)
 - [Configurable Widgets](modders/Configurable_Widgets.md)

--- a/docs/translators/Translations.md
+++ b/docs/translators/Translations.md
@@ -33,6 +33,7 @@ The page will be automatically updated once a week.
 VCMI allows translating game data into languages other than English. In order to translate Heroes III in your language easiest approach is to:
 
 - Copy existing translation, such as English translation from here: https://github.com/vcmi-mods/h3-for-vcmi-englisation (delete sound and video folders)
+- Copy text-free images from here: https://github.com/vcmi-mods/empty-translation
 - Rename mod to indicate your language, preferred form is "(language)-translation"
 - Update mod.json to match your mod
 - Translate all texts strings from `game.json`, `campaigns.json` and `maps.json`

--- a/launcher/firstLaunch/firstlaunch_moc.cpp
+++ b/launcher/firstLaunch/firstlaunch_moc.cpp
@@ -323,7 +323,7 @@ void FirstLaunchView::extractGogData()
 		QFile tmpFile(file);
 		if(!tmpFile.open(QIODevice::ReadOnly))
 		{
-			QMessageBox::critical(this, tr("File cannot opened"), tmpFile.errorString());
+			QMessageBox::critical(this, tr("File cannot be opened"), tmpFile.errorString());
 			return QString{};
 		}
 		QByteArray magicFile = tmpFile.read(magic.length());

--- a/launcher/translation/chinese.ts
+++ b/launcher/translation/chinese.ts
@@ -1248,7 +1248,7 @@ Offline installer consists of two parts, .exe and .bin. Make sure you download b
     </message>
     <message>
         <location filename="../firstLaunch/firstlaunch_moc.cpp" line="330"/>
-        <source>File cannot opened</source>
+        <source>File cannot be opened</source>
         <translation>打开文件失败</translation>
     </message>
     <message>

--- a/launcher/translation/czech.ts
+++ b/launcher/translation/czech.ts
@@ -1241,7 +1241,7 @@ Offline instalátor obsahuje dvě části, .exe a .bin. Ujistěte se, že stahuj
     </message>
     <message>
         <location filename="../firstLaunch/firstlaunch_moc.cpp" line="330"/>
-        <source>File cannot opened</source>
+        <source>File cannot be opened</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/launcher/translation/english.ts
+++ b/launcher/translation/english.ts
@@ -1220,7 +1220,7 @@ Offline installer consists of two parts, .exe and .bin. Make sure you download b
     </message>
     <message>
         <location filename="../firstLaunch/firstlaunch_moc.cpp" line="330"/>
-        <source>File cannot opened</source>
+        <source>File cannot be opened</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/launcher/translation/french.ts
+++ b/launcher/translation/french.ts
@@ -1246,7 +1246,7 @@ Heroes® of Might and Magic® III HD n&quot;est actuellement pas pris en charge 
     </message>
     <message>
         <location filename="../firstLaunch/firstlaunch_moc.cpp" line="330"/>
-        <source>File cannot opened</source>
+        <source>File cannot be opened</source>
         <translation>Le fichier ne peut pas être ouvert</translation>
     </message>
     <message>

--- a/launcher/translation/german.ts
+++ b/launcher/translation/german.ts
@@ -1241,7 +1241,7 @@ Der Offline-Installer besteht aus zwei Teilen, .exe und .bin. Stellen Sie sicher
     </message>
     <message>
         <location filename="../firstLaunch/firstlaunch_moc.cpp" line="330"/>
-        <source>File cannot opened</source>
+        <source>File cannot be opened</source>
         <translation>Datei kann nicht geöffnet werden</translation>
     </message>
     <message>

--- a/launcher/translation/polish.ts
+++ b/launcher/translation/polish.ts
@@ -1241,7 +1241,7 @@ Instalator offline składa się z dwóch części, .exe i .bin. Upewnij się, ż
     </message>
     <message>
         <location filename="../firstLaunch/firstlaunch_moc.cpp" line="330"/>
-        <source>File cannot opened</source>
+        <source>File cannot be opened</source>
         <translation>Nieudane otwarcie pliku</translation>
     </message>
     <message>

--- a/launcher/translation/portuguese.ts
+++ b/launcher/translation/portuguese.ts
@@ -1241,7 +1241,7 @@ O instalador offline consiste em duas partes, .exe e .bin. Certifique-se de baix
     </message>
     <message>
         <location filename="../firstLaunch/firstlaunch_moc.cpp" line="330"/>
-        <source>File cannot opened</source>
+        <source>File cannot be opened</source>
         <translation>O arquivo não pode ser aberto</translation>
     </message>
     <message>

--- a/launcher/translation/russian.ts
+++ b/launcher/translation/russian.ts
@@ -1226,7 +1226,7 @@ Offline installer consists of two parts, .exe and .bin. Make sure you download b
     </message>
     <message>
         <location filename="../firstLaunch/firstlaunch_moc.cpp" line="330"/>
-        <source>File cannot opened</source>
+        <source>File cannot be opened</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/launcher/translation/spanish.ts
+++ b/launcher/translation/spanish.ts
@@ -1239,7 +1239,7 @@ Offline installer consists of two parts, .exe and .bin. Make sure you download b
     </message>
     <message>
         <location filename="../firstLaunch/firstlaunch_moc.cpp" line="330"/>
-        <source>File cannot opened</source>
+        <source>File cannot be opened</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/launcher/translation/swedish.ts
+++ b/launcher/translation/swedish.ts
@@ -6,32 +6,32 @@
     <message>
         <location filename="../aboutProject/aboutproject_moc.ui" line="22"/>
         <source>VCMI on Discord</source>
-        <translation type="unfinished">VCMI på Discord</translation>
+        <translation>VCMI på Discord</translation>
     </message>
     <message>
         <location filename="../aboutProject/aboutproject_moc.ui" line="29"/>
         <source>Have a question? Found a bug? Want to help? Join us!</source>
-        <translation type="unfinished">Har du en fråga? Hittat en bugg? Vill du hjälpa till? Anslut dig till oss!</translation>
+        <translation>Har du en fråga? Hittat en bugg? Vill du hjälpa till? Anslut dig till oss!</translation>
     </message>
     <message>
         <location filename="../aboutProject/aboutproject_moc.ui" line="36"/>
         <source>VCMI on Github</source>
-        <translation type="unfinished">VCMI på Github</translation>
+        <translation>VCMI på Github</translation>
     </message>
     <message>
         <location filename="../aboutProject/aboutproject_moc.ui" line="54"/>
         <source>Our Community</source>
-        <translation type="unfinished">Vår gemenskap</translation>
+        <translation>Vår gemenskap</translation>
     </message>
     <message>
         <location filename="../aboutProject/aboutproject_moc.ui" line="220"/>
         <source>Build Information</source>
-        <translation type="unfinished">Konstruktionsinformation</translation>
+        <translation>Konstruktionsinformation</translation>
     </message>
     <message>
         <location filename="../aboutProject/aboutproject_moc.ui" line="182"/>
         <source>User data directory</source>
-        <translation type="unfinished">Användardata-mapp</translation>
+        <translation>Användardata-mapp</translation>
     </message>
     <message>
         <location filename="../aboutProject/aboutproject_moc.ui" line="88"/>
@@ -39,52 +39,52 @@
         <location filename="../aboutProject/aboutproject_moc.ui" line="161"/>
         <location filename="../aboutProject/aboutproject_moc.ui" line="247"/>
         <source>Open</source>
-        <translation type="unfinished">Öppna</translation>
+        <translation>Öppna</translation>
     </message>
     <message>
         <location filename="../aboutProject/aboutproject_moc.ui" line="121"/>
         <source>Check for updates</source>
-        <translation type="unfinished">Sök efter uppdateringar</translation>
+        <translation>Sök efter uppdateringar</translation>
     </message>
     <message>
         <location filename="../aboutProject/aboutproject_moc.ui" line="189"/>
         <source>Game version</source>
-        <translation type="unfinished">Spelversion</translation>
+        <translation>Spelversion</translation>
     </message>
     <message>
         <location filename="../aboutProject/aboutproject_moc.ui" line="114"/>
         <source>Log files directory</source>
-        <translation type="unfinished">Loggfils-mapp</translation>
+        <translation>Loggfils-mapp</translation>
     </message>
     <message>
         <location filename="../aboutProject/aboutproject_moc.ui" line="107"/>
         <source>Data Directories</source>
-        <translation type="unfinished">Datafilsregister</translation>
+        <translation>Datafilsregister</translation>
     </message>
     <message>
         <location filename="../aboutProject/aboutproject_moc.ui" line="168"/>
         <source>Game data directory</source>
-        <translation type="unfinished">Speldata-mapp</translation>
+        <translation>Speldata-mapp</translation>
     </message>
     <message>
         <location filename="../aboutProject/aboutproject_moc.ui" line="175"/>
         <source>Operating System</source>
-        <translation type="unfinished">Operativsystem</translation>
+        <translation>Operativsystem</translation>
     </message>
     <message>
         <location filename="../aboutProject/aboutproject_moc.ui" line="227"/>
         <source>Configuration files directory</source>
-        <translation type="unfinished">Konfigurationsfils-mapp</translation>
+        <translation>Konfigurationsfils-mapp</translation>
     </message>
     <message>
         <location filename="../aboutProject/aboutproject_moc.ui" line="290"/>
         <source>Project homepage</source>
-        <translation type="unfinished">Projektets hemsida</translation>
+        <translation>Projektets hemsida</translation>
     </message>
     <message>
         <location filename="../aboutProject/aboutproject_moc.ui" line="303"/>
         <source>Report a bug</source>
-        <translation type="unfinished">Rapportera ett fel</translation>
+        <translation>Rapportera ett fel</translation>
     </message>
 </context>
 <context>
@@ -92,106 +92,106 @@
     <message>
         <location filename="../modManager/cmodlistmodel_moc.cpp" line="42"/>
         <source>Translation</source>
-        <translation type="unfinished">Översättning</translation>
+        <translation>Översättning</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistmodel_moc.cpp" line="43"/>
         <source>Town</source>
-        <translation type="unfinished">Stad</translation>
+        <translation>Stad</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistmodel_moc.cpp" line="44"/>
         <source>Test</source>
-        <translation type="unfinished">Testa</translation>
+        <translation>Testa</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistmodel_moc.cpp" line="45"/>
         <source>Templates</source>
-        <translation type="unfinished">Modeller</translation>
+        <translation>Modeller</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistmodel_moc.cpp" line="46"/>
         <source>Spells</source>
-        <translation type="unfinished">Trollformler</translation>
+        <translation>Trollformler</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistmodel_moc.cpp" line="47"/>
         <source>Music</source>
-        <translation type="unfinished">Musik</translation>
+        <translation>Musik</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistmodel_moc.cpp" line="48"/>
         <source>Maps</source>
-        <translation type="unfinished">Kartor</translation>
+        <translation>Kartor</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistmodel_moc.cpp" line="49"/>
         <source>Sounds</source>
-        <translation type="unfinished">Ljud</translation>
+        <translation>Ljud</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistmodel_moc.cpp" line="50"/>
         <source>Skills</source>
-        <translation type="unfinished">Färdigheter</translation>
+        <translation>Färdigheter</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistmodel_moc.cpp" line="51"/>
         <location filename="../modManager/cmodlistmodel_moc.cpp" line="69"/>
         <source>Other</source>
-        <translation type="unfinished">Övrigt</translation>
+        <translation>Övrigt</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistmodel_moc.cpp" line="52"/>
         <source>Objects</source>
-        <translation type="unfinished">Objekt</translation>
+        <translation>Objekt</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistmodel_moc.cpp" line="53"/>
         <location filename="../modManager/cmodlistmodel_moc.cpp" line="54"/>
         <source>Mechanics</source>
-        <translation type="unfinished">Mekanik</translation>
+        <translation>Mekanik</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistmodel_moc.cpp" line="55"/>
         <location filename="../modManager/cmodlistmodel_moc.cpp" line="56"/>
         <source>Interface</source>
-        <translation type="unfinished">Gränssnitt</translation>
+        <translation>Gränssnitt</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistmodel_moc.cpp" line="57"/>
         <source>Heroes</source>
-        <translation type="unfinished">Hjälte</translation>
+        <translation>Hjälte</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistmodel_moc.cpp" line="58"/>
         <location filename="../modManager/cmodlistmodel_moc.cpp" line="59"/>
         <source>Graphical</source>
-        <translation type="unfinished">Grafik</translation>
+        <translation>Grafik</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistmodel_moc.cpp" line="60"/>
         <source>Expansion</source>
-        <translation type="unfinished">Expansion/Tillägg</translation>
+        <translation>Expansion/Tillägg</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistmodel_moc.cpp" line="61"/>
         <source>Creatures</source>
-        <translation type="unfinished">Varelser</translation>
+        <translation>Varelser</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistmodel_moc.cpp" line="62"/>
         <source>Compatibility</source>
-        <translation type="unfinished">Kompatibilitet</translation>
+        <translation>Kompatibilitet</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistmodel_moc.cpp" line="63"/>
         <source>Artifacts</source>
-        <translation type="unfinished">Artefakter</translation>
+        <translation>Artefakter</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistmodel_moc.cpp" line="64"/>
         <source>AI</source>
-        <translation type="unfinished">AI</translation>
+        <translation>AI</translation>
     </message>
 </context>
 <context>
@@ -199,270 +199,270 @@
     <message>
         <location filename="../modManager/cmodlistview_moc.ui" line="43"/>
         <source>Filter</source>
-        <translation type="unfinished">Filter</translation>
+        <translation>Filter</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.ui" line="66"/>
         <source>All mods</source>
-        <translation type="unfinished">Alla moddar</translation>
+        <translation>Alla moddar</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.ui" line="71"/>
         <source>Downloadable</source>
-        <translation type="unfinished">Nedladdningsbar</translation>
+        <translation>Nedladdningsbar</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.ui" line="76"/>
         <source>Installed</source>
-        <translation type="unfinished">Installerad</translation>
+        <translation>Installerad</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.ui" line="81"/>
         <source>Updatable</source>
-        <translation type="unfinished">Uppdaterbar</translation>
+        <translation>Uppdaterbar</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.ui" line="86"/>
         <source>Active</source>
-        <translation type="unfinished">Tillgångar</translation>
+        <translation>Tillgångar</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.ui" line="91"/>
         <source>Inactive</source>
-        <translation type="unfinished">Inaktiv</translation>
+        <translation>Inaktiv</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.ui" line="105"/>
         <source>Reload repositories</source>
-        <translation type="unfinished">Ladda om repositorier</translation>
+        <translation>Ladda om repositorier</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.ui" line="163"/>
         <location filename="../modManager/cmodlistview_moc.cpp" line="350"/>
         <source>Description</source>
-        <translation type="unfinished">Beskrivning</translation>
+        <translation>Beskrivning</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.ui" line="209"/>
         <source>Changelog</source>
-        <translation type="unfinished">Förändringshistorik</translation>
+        <translation>Förändringshistorik</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.ui" line="231"/>
         <source>Screenshots</source>
-        <translation type="unfinished">Skärmbilder</translation>
+        <translation>Skärmbilder</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.ui" line="327"/>
         <source> %p% (%v KB out of %m KB)</source>
-        <translation type="unfinished"> %p% (%v KB av %m KB)</translation>
+        <translation> %p% (%v KB av %m KB)</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.ui" line="373"/>
         <source>Install from file</source>
-        <translation type="unfinished">Installera från fil</translation>
+        <translation>Installera från fil</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.ui" line="424"/>
         <source>Uninstall</source>
-        <translation type="unfinished">Avinstallera</translation>
+        <translation>Avinstallera</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.ui" line="455"/>
         <source>Enable</source>
-        <translation type="unfinished">Aktivera</translation>
+        <translation>Aktivera</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.ui" line="486"/>
         <source>Disable</source>
-        <translation type="unfinished">Inaktivera</translation>
+        <translation>Inaktivera</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.ui" line="517"/>
         <source>Update</source>
-        <translation type="unfinished">Uppdatera</translation>
+        <translation>Uppdatera</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.ui" line="548"/>
         <source>Install</source>
-        <translation type="unfinished">Installera</translation>
+        <translation>Installera</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.ui" line="340"/>
         <source>Abort</source>
-        <translation type="unfinished">Ge upp</translation>
+        <translation>Ge upp</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.cpp" line="285"/>
         <source>Mod name</source>
-        <translation type="unfinished">Modd-namn</translation>
+        <translation>Modd-namn</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.cpp" line="286"/>
         <source>Installed version</source>
-        <translation type="unfinished">Installerad version</translation>
+        <translation>Installerad version</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.cpp" line="287"/>
         <source>Latest version</source>
-        <translation type="unfinished">Senaste version</translation>
+        <translation>Senaste version</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.cpp" line="290"/>
         <source>Size</source>
-        <translation type="unfinished">Storlek</translation>
+        <translation>Storlek</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.cpp" line="292"/>
         <source>Download size</source>
-        <translation type="unfinished">Nedladdningsstorlek</translation>
+        <translation>Nedladdningsstorlek</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.cpp" line="294"/>
         <source>Authors</source>
-        <translation type="unfinished">Författare</translation>
+        <translation>Författare</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.cpp" line="297"/>
         <source>License</source>
-        <translation type="unfinished">Licens</translation>
+        <translation>Licens</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.cpp" line="300"/>
         <source>Contact</source>
-        <translation type="unfinished">Kontakt</translation>
+        <translation>Kontakt</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.cpp" line="309"/>
         <source>Compatibility</source>
-        <translation type="unfinished">Kompatibilitet</translation>
+        <translation>Kompatibilitet</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.cpp" line="311"/>
         <location filename="../modManager/cmodlistview_moc.cpp" line="319"/>
         <source>Required VCMI version</source>
-        <translation type="unfinished">VCMI-version som krävs</translation>
+        <translation>VCMI-version som krävs</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.cpp" line="317"/>
         <source>Supported VCMI version</source>
-        <translation type="unfinished">Stödd VCMI-version</translation>
+        <translation>Stödd VCMI-version</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.cpp" line="317"/>
-        <source>Please upgrade mod</source>
-        <translation type="unfinished">Vänligen uppdatera modd</translation>
+        <source>please upgrade mod</source>
+        <translation>vänligen uppdatera modd</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.cpp" line="189"/>
         <location filename="../modManager/cmodlistview_moc.cpp" line="809"/>
         <source>mods repository index</source>
-        <translation type="unfinished">Modd-repositorie index</translation>
+        <translation>Modd-repositorie index</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.cpp" line="319"/>
         <source>or newer</source>
-        <translation type="unfinished">eller nyare</translation>
+        <translation>eller nyare</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.cpp" line="322"/>
         <source>Supported VCMI versions</source>
-        <translation type="unfinished">VCMI-versioner som stöds</translation>
+        <translation>VCMI-versioner som stöds</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.cpp" line="346"/>
         <source>Languages</source>
-        <translation type="unfinished">Språk</translation>
+        <translation>Språk</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.cpp" line="348"/>
         <source>Required mods</source>
-        <translation type="unfinished">Moddar som krävs</translation>
+        <translation>Moddar som krävs</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.cpp" line="349"/>
         <source>Conflicting mods</source>
-        <translation type="unfinished">Modd-konflikter</translation>
+        <translation>Modd-konflikter</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.cpp" line="354"/>
         <source>This mod can not be installed or enabled because the following dependencies are not present</source>
-        <translation type="unfinished">Denna modd kan inte installeras eller aktiveras eftersom följande beroenden inte finns</translation>
+        <translation>Denna modd kan inte installeras eller aktiveras eftersom följande beroenden inte finns</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.cpp" line="355"/>
         <source>This mod can not be enabled because the following mods are incompatible with it</source>
-        <translation type="unfinished">Denna modd kan inte aktiveras eftersom följande beroenden är inkompatibla med den</translation>
+        <translation>Denna modd kan inte aktiveras eftersom följande beroenden är inkompatibla med den</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.cpp" line="356"/>
         <source>This mod cannot be disabled because it is required by the following mods</source>
-        <translation type="unfinished">Denna modd kan inte inaktiveras eftersom den krävs för följande beroenden</translation>
+        <translation>Denna modd kan inte inaktiveras eftersom den krävs för följande beroenden</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.cpp" line="357"/>
         <source>This mod cannot be uninstalled or updated because it is required by the following mods</source>
-        <translation type="unfinished">Denna modd kan inte avinstalleras eller uppdateras eftersom den krävs för följande beroenden</translation>
+        <translation>Denna modd kan inte avinstalleras eller uppdateras eftersom den krävs för följande beroenden</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.cpp" line="358"/>
         <source>This is a submod and it cannot be installed or uninstalled separately from its parent mod</source>
-        <translation type="unfinished">Denna undermodd/submodd kan inte installeras eller uppdateras separat från huvud-modden</translation>
+        <translation>Denna undermodd/submodd kan inte installeras eller uppdateras separat från huvud-modden</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.cpp" line="373"/>
         <source>Notes</source>
-        <translation type="unfinished">Anteckningar</translation>
+        <translation>Anteckningar</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.cpp" line="639"/>
         <source>All supported files</source>
-        <translation type="unfinished">Alla filer som stöds</translation>
+        <translation>Alla filer som stöds</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.cpp" line="639"/>
         <source>Maps</source>
-        <translation type="unfinished">Kartor</translation>
+        <translation>Kartor</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.cpp" line="639"/>
         <source>Campaigns</source>
-        <translation type="unfinished">Kampanjer</translation>
+        <translation>Kampanjer</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.cpp" line="639"/>
         <source>Configs</source>
-        <translation type="unfinished">Konfigurationer</translation>
+        <translation>Konfigurationer</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.cpp" line="639"/>
         <source>Mods</source>
-        <translation type="unfinished">Moddar</translation>
+        <translation>Moddar</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.cpp" line="640"/>
         <source>Select files (configs, mods, maps, campaigns) to install...</source>
-        <translation type="unfinished">Välj filer att installera (konfigurationer, moddar, kartor, kampanjer)...</translation>
+        <translation>Välj filer att installera (konfigurationer, moddar, kartor, kampanjer)...</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.cpp" line="665"/>
         <source>Replace config file?</source>
-        <translation type="unfinished">Byt ut konfigurationsfilen?</translation>
+        <translation>Byt ut konfigurationsfilen?</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.cpp" line="665"/>
         <source>Do you want to replace %1?</source>
-        <translation type="unfinished">Vill du ersätta %1?</translation>
+        <translation>Vill du ersätta %1?</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.cpp" line="708"/>
         <source>Downloading %1. %p% (%v MB out of %m MB) finished</source>
-        <translation type="unfinished">Ladda ner %1. %p% (%v MB av %m MB) slutfört</translation>
+        <translation>Ladda ner %1. %p% (%v MB av %m MB) slutfört</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.cpp" line="733"/>
         <source>Download failed</source>
-        <translation type="unfinished">Nedladdning misslyckades</translation>
+        <translation>Nedladdning misslyckades</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.cpp" line="734"/>
@@ -471,7 +471,7 @@
 Encountered errors:
 
 </source>
-        <translation type="unfinished">Det går inte att ladda ner alla filer.
+        <translation>Det går inte att ladda ner alla filer.
 
 Fel påträffat:
 
@@ -482,41 +482,41 @@ Fel påträffat:
         <source>
 
 Install successfully downloaded?</source>
-        <translation type="unfinished">
+        <translation>
 
 Installera lyckade nedladdningar?</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.cpp" line="881"/>
         <source>Installing mod %1</source>
-        <translation type="unfinished">Installera mod %1</translation>
+        <translation>Installera mod %1</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.cpp" line="950"/>
         <source>Operation failed</source>
-        <translation type="unfinished">Åtgärden misslyckades</translation>
+        <translation>Åtgärden misslyckades</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.cpp" line="951"/>
         <source>Encountered errors:
 </source>
-        <translation type="unfinished">Fel påträffades:
+        <translation>Fel påträffades:
 </translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.cpp" line="986"/>
         <source>screenshots</source>
-        <translation type="unfinished">skärmdumpar</translation>
+        <translation>skärmdumpar</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.cpp" line="992"/>
         <source>Screenshot %1</source>
-        <translation type="unfinished">Skriv ut skärm %1</translation>
+        <translation>Skriv ut skärm %1</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistview_moc.cpp" line="280"/>
         <source>Mod is incompatible</source>
-        <translation type="unfinished">Denna modd är inkompatibel</translation>
+        <translation>Denna modd är inkompatibel</translation>
     </message>
 </context>
 <context>
@@ -524,95 +524,95 @@ Installera lyckade nedladdningar?</translation>
     <message>
         <location filename="../modManager/cmodmanager.cpp" line="168"/>
         <source>Can not install submod</source>
-        <translation type="unfinished">Det går inte att installera undermodd/submodd</translation>
+        <translation>Det går inte att installera undermodd/submodd</translation>
     </message>
     <message>
         <location filename="../modManager/cmodmanager.cpp" line="171"/>
         <source>Mod is already installed</source>
-        <translation type="unfinished">Modden är redan installerad</translation>
+        <translation>Modden är redan installerad</translation>
     </message>
     <message>
         <location filename="../modManager/cmodmanager.cpp" line="180"/>
         <source>Can not uninstall submod</source>
-        <translation type="unfinished">Det går inte att avinstallera undermodd/submodd</translation>
+        <translation>Det går inte att avinstallera undermodd/submodd</translation>
     </message>
     <message>
         <location filename="../modManager/cmodmanager.cpp" line="183"/>
         <source>Mod is not installed</source>
-        <translation type="unfinished">Modden är inte installerad</translation>
+        <translation>Modden är inte installerad</translation>
     </message>
     <message>
         <location filename="../modManager/cmodmanager.cpp" line="193"/>
         <source>Mod is already enabled</source>
-        <translation type="unfinished">Modden är redan aktiverad</translation>
+        <translation>Modden är redan aktiverad</translation>
     </message>
     <message>
         <location filename="../modManager/cmodmanager.cpp" line="196"/>
         <location filename="../modManager/cmodmanager.cpp" line="239"/>
         <source>Mod must be installed first</source>
-        <translation type="unfinished">Modden måste installeras först</translation>
+        <translation>Modden måste installeras först</translation>
     </message>
     <message>
         <location filename="../modManager/cmodmanager.cpp" line="200"/>
         <source>Mod is not compatible, please update VCMI and checkout latest mod revisions</source>
-        <translation type="unfinished">Modden är inte kompatibel. Vänligen uppdatera VCMI och kontrollera att du har den senaste versionen av modden</translation>
+        <translation>Modden är inte kompatibel. Vänligen uppdatera VCMI och kontrollera att du har den senaste versionen av modden</translation>
     </message>
     <message>
         <location filename="../modManager/cmodmanager.cpp" line="205"/>
         <source>Required mod %1 is missing</source>
-        <translation type="unfinished">Den obligatorisk modden %1 saknas</translation>
+        <translation>Den obligatorisk modden %1 saknas</translation>
     </message>
     <message>
         <location filename="../modManager/cmodmanager.cpp" line="210"/>
         <source>Required mod %1 is not enabled</source>
-        <translation type="unfinished">Den obligatorisk modden %1 är inte aktiverad</translation>
+        <translation>Den obligatorisk modden %1 är inte aktiverad</translation>
     </message>
     <message>
         <location filename="../modManager/cmodmanager.cpp" line="219"/>
         <location filename="../modManager/cmodmanager.cpp" line="226"/>
         <source>This mod conflicts with %1</source>
-        <translation type="unfinished">Denna modd är i konflikt med %1</translation>
+        <translation>Denna modd är i konflikt med %1</translation>
     </message>
     <message>
         <location filename="../modManager/cmodmanager.cpp" line="236"/>
         <source>Mod is already disabled</source>
-        <translation type="unfinished">Modden är redan inaktiverad</translation>
+        <translation>Modden är redan inaktiverad</translation>
     </message>
     <message>
         <location filename="../modManager/cmodmanager.cpp" line="246"/>
         <source>This mod is needed to run %1</source>
-        <translation type="unfinished">Denna modden krävs för att köra %1</translation>
+        <translation>Denna modden krävs för att köra %1</translation>
     </message>
     <message>
         <location filename="../modManager/cmodmanager.cpp" line="288"/>
         <source>Mod archive is missing</source>
-        <translation type="unfinished">Modd-arkiv saknas</translation>
+        <translation>Modd-arkiv saknas</translation>
     </message>
     <message>
         <location filename="../modManager/cmodmanager.cpp" line="291"/>
         <source>Mod with such name is already installed</source>
-        <translation type="unfinished">En modd med samma namn är redan installerad</translation>
+        <translation>En modd med samma namn är redan installerad</translation>
     </message>
     <message>
         <location filename="../modManager/cmodmanager.cpp" line="296"/>
         <source>Mod archive is invalid or corrupted</source>
-        <translation type="unfinished">Modd-arkivet är ogiltigt eller korrupt</translation>
+        <translation>Modd-arkivet är ogiltigt eller korrupt</translation>
     </message>
     <message>
         <location filename="../modManager/cmodmanager.cpp" line="322"/>
         <source>Failed to extract mod data</source>
-        <translation type="unfinished">Det gick inte att extrahera data från modd</translation>
+        <translation>Det gick inte att extrahera data från modd</translation>
     </message>
     <message>
         <location filename="../modManager/cmodmanager.cpp" line="350"/>
         <source>Data with this mod was not found</source>
-        <translation type="unfinished">Modd-data för denna modd hittades inte</translation>
+        <translation>Modd-data för denna modd hittades inte</translation>
     </message>
     <message>
         <location filename="../modManager/cmodmanager.cpp" line="354"/>
         <source>Mod is located in protected directory, please remove it manually:
 </source>
-        <translation type="unfinished">Modden är placerad i en skyddad mapp. Vänligen radera den manuellt:
+        <translation>Modden är placerad i en skyddad mapp. Vänligen radera den manuellt:
 </translation>
     </message>
 </context>
@@ -621,192 +621,192 @@ Installera lyckade nedladdningar?</translation>
     <message>
         <location filename="../settingsView/csettingsview_moc.cpp" line="90"/>
         <source>Off</source>
-        <translation type="unfinished">Inaktiverad</translation>
+        <translation>Inaktiverad</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="307"/>
         <source>Artificial Intelligence</source>
-        <translation type="unfinished">Artificiell intelligens</translation>
+        <translation>Artificiell intelligens</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.cpp" line="88"/>
         <source>On</source>
-        <translation type="unfinished">Aktiverad</translation>
+        <translation>Aktiverad</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="738"/>
         <source>Enemy AI in battles</source>
-        <translation type="unfinished">Fiendens AI i strider</translation>
+        <translation>Fiendens AI i strider</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="249"/>
         <source>Default repository</source>
-        <translation type="unfinished">Standard-repositorie</translation>
+        <translation>Standard-repositorie</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="593"/>
         <source>VSync</source>
-        <translation type="unfinished">Vertikal synkronisering</translation>
+        <translation>Vertikal synkronisering</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="490"/>
         <source>Online Lobby port</source>
-        <translation type="unfinished">Port-numret till online-väntrummet</translation>
+        <translation>Port-numret till online-väntrummet</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="331"/>
         <source>Autocombat AI in battles</source>
-        <translation type="unfinished">Automatiska AI-strider</translation>
+        <translation>Automatiska AI-strider</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="352"/>
         <source>Sticks Sensitivity</source>
-        <translation type="unfinished">Spak-känslighet</translation>
+        <translation>Spak-känslighet</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="618"/>
         <source>Automatic (Linear)</source>
-        <translation type="unfinished">Automatisk (linjär)</translation>
+        <translation>Automatisk (linjär)</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="798"/>
         <source>Haptic Feedback</source>
-        <translation type="unfinished">Haptisk återkoppling (vibrationer i kontrollen)</translation>
+        <translation>Haptisk återkoppling (vibrationer i kontrollen)</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="835"/>
         <source>Software Cursor</source>
-        <translation type="unfinished">Programvarumarkör (muspekare)</translation>
+        <translation>Programvarumarkör (muspekare)</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="1166"/>
         <source>Automatic</source>
-        <translation type="unfinished">Automatisk</translation>
+        <translation>Automatisk</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="1171"/>
         <source>None</source>
-        <translation type="unfinished">Inget</translation>
+        <translation>Inget</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="1176"/>
         <source>xBRZ x2</source>
-        <translation type="unfinished">xBRZ x2</translation>
+        <translation>xBRZ x2</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="1181"/>
         <source>xBRZ x3</source>
-        <translation type="unfinished">xBRZ x3</translation>
+        <translation>xBRZ x3</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="1186"/>
         <source>xBRZ x4</source>
-        <translation type="unfinished">xBRZ x4</translation>
+        <translation>xBRZ x4</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="138"/>
         <source>Online Lobby address</source>
-        <translation type="unfinished">Adressen till online-väntrummet</translation>
+        <translation>Adressen till online-väntrummet</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="1158"/>
         <source>Upscaling Filter</source>
-        <translation type="unfinished">Förstoringsfilter</translation>
+        <translation>Förstoringsfilter</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="317"/>
         <source>Use Relative Pointer Mode</source>
-        <translation type="unfinished">Använd läge för relativ muspekare</translation>
+        <translation>Använd läge för relativ muspekare</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="608"/>
         <source>Nearest</source>
-        <translation type="unfinished">Närmast</translation>
+        <translation>Närmast</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="613"/>
         <source>Linear</source>
-        <translation type="unfinished">Linjär</translation>
+        <translation>Linjär</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="750"/>
         <source>Input - Touchscreen</source>
-        <translation type="unfinished">Ingång/indata - Pekskärm</translation>
+        <translation>Ingång/indata - Pekskärm</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="854"/>
         <source>Network</source>
-        <translation type="unfinished">Nätverk</translation>
+        <translation>Nätverk</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="893"/>
         <source>Downscaling Filter</source>
-        <translation type="unfinished">Nerskalnings-filter</translation>
+        <translation>Nerskalnings-filter</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="1144"/>
         <source>Show Tutorial again</source>
-        <translation type="unfinished">Visa övningsgenomgången igen</translation>
+        <translation>Visa övningsgenomgången igen</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="1151"/>
         <source>Reset</source>
-        <translation type="unfinished">Återställ</translation>
+        <translation>Återställ</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="536"/>
         <source>Audio</source>
-        <translation type="unfinished">Ljud</translation>
+        <translation>Ljud</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="842"/>
         <source>Relative Pointer Speed</source>
-        <translation type="unfinished">Relativ pekarhastighet</translation>
+        <translation>Relativ pekarhastighet</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="1137"/>
         <source>Music Volume</source>
-        <translation type="unfinished">Musikvolym</translation>
+        <translation>Musikvolym</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="767"/>
         <source>Ignore SSL errors</source>
-        <translation type="unfinished">Ignorera SSL-fel</translation>
+        <translation>Ignorera SSL-fel</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="943"/>
         <source>Input - Mouse</source>
-        <translation type="unfinished">Ingång/indata - Mus</translation>
+        <translation>Ingång/indata - Mus</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="345"/>
         <source>Long Touch Duration</source>
-        <translation type="unfinished">Utökad beröringslängd</translation>
+        <translation>Utökad beröringslängd</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="115"/>
         <source>%</source>
-        <translation type="unfinished">%</translation>
+        <translation>%</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="1037"/>
         <source>Controller Click Tolerance</source>
-        <translation type="unfinished">Tolerans för klick på styrenhet</translation>
+        <translation>Tolerans för klick på styrenhet</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="359"/>
         <source>Touch Tap Tolerance</source>
-        <translation type="unfinished">Tolerans för pektryck</translation>
+        <translation>Tolerans för pektryck</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="1020"/>
         <source>Input - Controller</source>
-        <translation type="unfinished">Ingång/indata - Kontroll</translation>
+        <translation>Ingång/indata - Kontroll</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="1086"/>
         <source>Sound Volume</source>
-        <translation type="unfinished">Ljudvolym</translation>
+        <translation>Ljudvolym</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="389"/>
@@ -817,7 +817,7 @@ Windowed - game will run inside a window that covers part of your screen
 Borderless Windowed Mode - game will run in a window that covers entirely of your screen, using same resolution as your screen.
 
 Fullscreen Exclusive Mode - game will cover entirety of your screen and will use selected resolution.</source>
-        <translation type="unfinished">Välj visningsläge för spelet
+        <translation>Välj visningsläge för spelet
 
 Fönsterläge - spelet kommer att köras i ett fönster som täcker en viss del av din skärm (kan även täcka hela skärmen).
 
@@ -828,167 +828,167 @@ Exklusivt helskärmsläge - spelet kommer att täcka hela skärmen och använda 
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="402"/>
         <source>Windowed</source>
-        <translation type="unfinished">Fönsterläge</translation>
+        <translation>Fönsterläge</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="407"/>
         <source>Borderless fullscreen</source>
-        <translation type="unfinished">Kantlöst fönsterläge</translation>
+        <translation>Kantlöst fönsterläge</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="412"/>
         <source>Exclusive fullscreen</source>
-        <translation type="unfinished">Exklusiv helskärm</translation>
+        <translation>Exklusiv helskärm</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="131"/>
         <source>Reserved screen area</source>
-        <translation type="unfinished">Reserverat skärmområde</translation>
+        <translation>Reserverat skärmområde</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="924"/>
         <source>Neutral AI in battles</source>
-        <translation type="unfinished">Neutralt AI i strider</translation>
+        <translation>Neutralt AI i strider</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="777"/>
         <source>Autosave limit (0 = off)</source>
-        <translation type="unfinished">Antal platser för automatisk-sparning (0 = inaktiverad)</translation>
+        <translation>Antal platser för automatisk-sparning (0 = inaktiverad)</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="900"/>
         <source>Adventure Map Enemies</source>
-        <translation type="unfinished">Fiender på äventyskartan</translation>
+        <translation>Fiender på äventyskartan</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="760"/>
         <source>Autosave prefix</source>
-        <translation type="unfinished">Prefix för automatisk-sparning</translation>
+        <translation>Prefix för automatisk-sparning</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="1008"/>
         <source>empty = map name prefix</source>
-        <translation type="unfinished">tomt = kartnamnsprefix</translation>
+        <translation>tomt = kartnamnsprefix</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="1072"/>
         <source>Interface Scaling</source>
-        <translation type="unfinished">Gränssnittsskalning</translation>
+        <translation>Gränssnittsskalning</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="1030"/>
         <source>Framerate Limit</source>
-        <translation type="unfinished">Gräns ​​för bildhastighet</translation>
+        <translation>Gräns ​​för bildhastighet</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="295"/>
         <source>Renderer</source>
-        <translation type="unfinished">Renderingsmotor</translation>
+        <translation>Renderingsmotor</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="269"/>
         <source>Heroes III Translation</source>
-        <translation type="unfinished">Heroes III - Översättning</translation>
+        <translation>Heroes III - Översättning</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="931"/>
         <source>Adventure Map Allies</source>
-        <translation type="unfinished">Allierade på äventyrskartan</translation>
+        <translation>Allierade på äventyrskartan</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="821"/>
         <source>Additional repository</source>
-        <translation type="unfinished">Ytterligare repositorier</translation>
+        <translation>Ytterligare repositorier</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="646"/>
         <source>Check on startup</source>
-        <translation type="unfinished">Kontrollera vid start</translation>
+        <translation>Kontrollera vid start</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="828"/>
         <source>Mouse Click Tolerance</source>
-        <translation type="unfinished">Musklickstolerans</translation>
+        <translation>Musklickstolerans</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="94"/>
         <source>Sticks Acceleration</source>
-        <translation type="unfinished">Styrspaks-acceleration</translation>
+        <translation>Styrspaks-acceleration</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="101"/>
         <source>Refresh now</source>
-        <translation type="unfinished">Uppdatera nu</translation>
+        <translation>Uppdatera nu</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="324"/>
         <source>Fullscreen</source>
-        <translation type="unfinished">Helskärm</translation>
+        <translation>Helskärm</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="64"/>
         <source>General</source>
-        <translation type="unfinished">Allmänt</translation>
+        <translation>Allmänt</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="210"/>
         <source>VCMI Language</source>
-        <translation type="unfinished">VCMI-språk</translation>
+        <translation>VCMI-språk</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="1079"/>
         <source>Resolution</source>
-        <translation type="unfinished">Upplösning</translation>
+        <translation>Upplösning</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="791"/>
         <source>Autosave</source>
-        <translation type="unfinished">Auto-spara</translation>
+        <translation>Auto-spara</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="338"/>
         <source>Display index</source>
-        <translation type="unfinished">Visa index</translation>
+        <translation>Visa index</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="864"/>
         <source>Network port</source>
-        <translation type="unfinished">Nätverksport</translation>
+        <translation>Nätverksport</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="521"/>
         <source>Video</source>
-        <translation type="unfinished">Video</translation>
+        <translation>Video</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="452"/>
         <source>Show intro</source>
-        <translation type="unfinished">Visa intro</translation>
+        <translation>Visa intro</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.cpp" line="503"/>
         <source>Active</source>
-        <translation type="unfinished">Aktiv</translation>
+        <translation>Aktiv</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.cpp" line="508"/>
         <source>Disabled</source>
-        <translation type="unfinished">Inaktiverad</translation>
+        <translation>Inaktiverad</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.cpp" line="509"/>
         <source>Enable</source>
-        <translation type="unfinished">Aktivera</translation>
+        <translation>Aktivera</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.cpp" line="514"/>
         <source>Not Installed</source>
-        <translation type="unfinished">Inte installerad</translation>
+        <translation>Inte installerad</translation>
     </message>
     <message>
         <location filename="../settingsView/csettingsview_moc.cpp" line="515"/>
         <source>Install</source>
-        <translation type="unfinished">Installera</translation>
+        <translation>Installera</translation>
     </message>
 </context>
 <context>
@@ -996,27 +996,27 @@ Exklusivt helskärmsläge - spelet kommer att täcka hela skärmen och använda 
     <message>
         <location filename="../modManager/cmodlist.cpp" line="21"/>
         <source>%1 B</source>
-        <translation type="unfinished">%1 B</translation>
+        <translation>%1 B</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlist.cpp" line="22"/>
         <source>%1 KiB</source>
-        <translation type="unfinished">%1 KiB</translation>
+        <translation>%1 KiB</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlist.cpp" line="23"/>
         <source>%1 MiB</source>
-        <translation type="unfinished">%1 MiB</translation>
+        <translation>%1 MiB</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlist.cpp" line="24"/>
         <source>%1 GiB</source>
-        <translation type="unfinished">%1 GiB</translation>
+        <translation>%1 GiB</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlist.cpp" line="25"/>
         <source>%1 TiB</source>
-        <translation type="unfinished">%1 TiB</translation>
+        <translation>%1 TiB</translation>
     </message>
 </context>
 <context>
@@ -1024,98 +1024,98 @@ Exklusivt helskärmsläge - spelet kommer att täcka hela skärmen och använda 
     <message>
         <location filename="../firstLaunch/firstlaunch_moc.ui" line="28"/>
         <source>Language</source>
-        <translation type="unfinished">Språk</translation>
+        <translation>Språk</translation>
     </message>
     <message>
         <location filename="../firstLaunch/firstlaunch_moc.ui" line="53"/>
         <source>Heroes III Data</source>
-        <translation type="unfinished">Heroes III-data</translation>
+        <translation>Heroes III-data</translation>
     </message>
     <message>
         <location filename="../firstLaunch/firstlaunch_moc.ui" line="78"/>
         <source>Mods Preset</source>
-        <translation type="unfinished">Modd-förinställningar</translation>
+        <translation>Modd-förinställningar</translation>
     </message>
     <message>
         <location filename="../firstLaunch/firstlaunch_moc.ui" line="126"/>
         <source>Select your language</source>
-        <translation type="unfinished">Välj ditt språk</translation>
+        <translation>Välj ditt språk</translation>
     </message>
     <message>
         <location filename="../firstLaunch/firstlaunch_moc.ui" line="169"/>
         <source>Have a question? Found a bug? Want to help? Join us!</source>
-        <translation type="unfinished">Har du en fråga? Hittat en bugg? Vill du hjälpa till? Anslut dig till oss!</translation>
+        <translation>Har du en fråga? Hittat en bugg? Vill du hjälpa till? Anslut dig till oss!</translation>
     </message>
     <message>
         <location filename="../firstLaunch/firstlaunch_moc.ui" line="248"/>
         <source>Locate Heroes III data files</source>
-        <translation type="unfinished">Hitta Heroes III-datafiler</translation>
+        <translation>Hitta Heroes III-datafiler</translation>
     </message>
     <message>
         <location filename="../firstLaunch/firstlaunch_moc.ui" line="297"/>
         <source>Use offline installer from gog.com</source>
-        <translation type="unfinished">Använd offline-installationsprogrammet från GOG.com</translation>
+        <translation>Använd offline-installationsprogrammet från GOG.com</translation>
     </message>
     <message>
         <location filename="../firstLaunch/firstlaunch_moc.ui" line="310"/>
         <source>You can manually copy directories Maps, Data and Mp3 from the original game directory to VCMI data directory that you can see on top of this page</source>
-        <translation type="unfinished">Du kan manuellt kopiera mapparna 'Maps', 'Data' och 'Mp3' från den ursprungliga spel-mappen till VCMI-datamappen som du kan se överst på den här sidan</translation>
+        <translation>Du kan manuellt kopiera mapparna 'Maps', 'Data' och 'Mp3' från den ursprungliga spel-mappen till VCMI-datamappen som du kan se överst på den här sidan</translation>
     </message>
     <message>
         <location filename="../firstLaunch/firstlaunch_moc.ui" line="329"/>
         <source>Install gog.com files</source>
-        <translation type="unfinished">Installera filer från GOG.com</translation>
+        <translation>Installera filer från GOG.com</translation>
     </message>
     <message>
         <location filename="../firstLaunch/firstlaunch_moc.ui" line="347"/>
         <source>Manual Installation</source>
-        <translation type="unfinished">Manuell installation</translation>
+        <translation>Manuell installation</translation>
     </message>
     <message>
         <location filename="../firstLaunch/firstlaunch_moc.ui" line="388"/>
         <source>Installing... %p%</source>
-        <translation type="unfinished">Installerar... %p%</translation>
+        <translation>Installerar... %p%</translation>
     </message>
     <message>
         <location filename="../firstLaunch/firstlaunch_moc.ui" line="417"/>
         <source>If you already have Heroes III files on your device, you can select this directory and VCMI will copy the existing data automatically.</source>
-        <translation type="unfinished">Om du redan har Heroes III-filerna på din enhet kan du välja den här mappen och VCMI kommer automatiskt att kopiera befintliga data.</translation>
+        <translation>Om du redan har Heroes III-filerna på din enhet kan du välja den här mappen och VCMI kommer automatiskt att kopiera befintliga data.</translation>
     </message>
     <message>
         <location filename="../firstLaunch/firstlaunch_moc.ui" line="459"/>
         <source>Copy existing files</source>
-        <translation type="unfinished">Kopiera befintliga filer</translation>
+        <translation>Kopiera befintliga filer</translation>
     </message>
     <message>
         <location filename="../firstLaunch/firstlaunch_moc.ui" line="488"/>
         <source>Your Heroes III data files have been successfully found.</source>
-        <translation type="unfinished">Dina Heroes III-datafiler har hittats.</translation>
+        <translation>Dina Heroes III-datafiler har hittats.</translation>
     </message>
     <message>
         <location filename="../firstLaunch/firstlaunch_moc.ui" line="504"/>
         <source>If you own Heroes III on gog.com you can download backup offline installer from gog.com, and VCMI will import Heroes III data using offline installer. 
 Offline installer consists of two parts, .exe and .bin. Make sure you download both of them.</source>
-        <translation type="unfinished">Om du äger Heroes III från GOG.com kan du ladda ner backup offline-installationsprogrammet från GOG.com - VCMI kommer att importera Heroes III-data med hjälp av offline-installationsprogrammet. Offline-installationsprogrammet består av två delar, en .exe och en .bin. Se till att ladda ner båda.</translation>
+        <translation>Om du äger Heroes III från GOG.com kan du ladda ner backup offline-installationsprogrammet från GOG.com - VCMI kommer att importera Heroes III-data med hjälp av offline-installationsprogrammet. Offline-installationsprogrammet består av två delar, en .exe och en .bin. Se till att ladda ner båda.</translation>
     </message>
     <message>
         <location filename="../firstLaunch/firstlaunch_moc.ui" line="622"/>
         <source>Install a translation of Heroes III in your preferred language</source>
-        <translation type="unfinished">Installera en översättning av Heroes III på ditt föredragna språk</translation>
+        <translation>Installera en översättning av Heroes III på ditt föredragna språk</translation>
     </message>
     <message>
         <location filename="../firstLaunch/firstlaunch_moc.ui" line="867"/>
         <source>Finish</source>
-        <translation type="unfinished">Slutför</translation>
+        <translation>Slutför</translation>
     </message>
     <message>
         <location filename="../firstLaunch/firstlaunch_moc.ui" line="155"/>
         <source>VCMI on Github</source>
-        <translation type="unfinished">VCMI på Github</translation>
+        <translation>VCMI på Github</translation>
     </message>
     <message>
         <location filename="../firstLaunch/firstlaunch_moc.ui" line="162"/>
         <source>VCMI on Discord</source>
-        <translation type="unfinished">VCMI på Discord</translation>
+        <translation>VCMI på Discord</translation>
     </message>
     <message>
         <location filename="../firstLaunch/firstlaunch_moc.ui" line="178"/>
@@ -1126,7 +1126,7 @@ Before you can start playing, there are a few more steps that need to be complet
 Please keep in mind that in order to use VCMI you must own the original data files for Heroes® of Might and Magic® III: Complete or The Shadow of Death.
 
 Heroes® of Might and Magic® III HD is currently not supported!</source>
-        <translation type="unfinished">Tack för att du installerade VCMI!
+        <translation>Tack för att du installerade VCMI!
 
 Innan du kan börja spela finns det några steg kvar att slutföra.
 
@@ -1138,135 +1138,135 @@ Heroes® of Might and Magic® III HD stöds för närvarande inte!</translation>
         <location filename="../firstLaunch/firstlaunch_moc.ui" line="212"/>
         <location filename="../firstLaunch/firstlaunch_moc.ui" line="564"/>
         <source>Next</source>
-        <translation type="unfinished">Nästa</translation>
+        <translation>Nästa</translation>
     </message>
     <message>
         <location filename="../firstLaunch/firstlaunch_moc.ui" line="360"/>
         <source>Search again</source>
-        <translation type="unfinished">Sök igen</translation>
+        <translation>Sök igen</translation>
     </message>
     <message>
         <location filename="../firstLaunch/firstlaunch_moc.ui" line="441"/>
         <source>Heroes III data files</source>
-        <translation type="unfinished">Heroes III-datafiler</translation>
+        <translation>Heroes III-datafiler</translation>
     </message>
     <message>
         <location filename="../firstLaunch/firstlaunch_moc.ui" line="279"/>
         <source>Copy existing data</source>
-        <translation type="unfinished">Kopiera befintliga data</translation>
+        <translation>Kopiera befintliga data</translation>
     </message>
     <message>
         <location filename="../firstLaunch/firstlaunch_moc.ui" line="557"/>
         <location filename="../firstLaunch/firstlaunch_moc.ui" line="860"/>
         <source>Back</source>
-        <translation type="unfinished">Tillbaka</translation>
+        <translation>Tillbaka</translation>
     </message>
     <message>
         <location filename="../firstLaunch/firstlaunch_moc.ui" line="594"/>
         <source>Install VCMI Mod Preset</source>
-        <translation type="unfinished">Installera VCMI Modd-förinställningar</translation>
+        <translation>Installera VCMI Modd-förinställningar</translation>
     </message>
     <message>
         <location filename="../firstLaunch/firstlaunch_moc.ui" line="710"/>
         <source>Horn of the Abyss</source>
-        <translation type="unfinished">Avgrundens horn (Horn of the Abyss)</translation>
+        <translation>Avgrundens horn (Horn of the Abyss)</translation>
     </message>
     <message>
         <location filename="../firstLaunch/firstlaunch_moc.ui" line="643"/>
         <source>Heroes III Translation</source>
-        <translation type="unfinished">Heroes III - Översättning</translation>
+        <translation>Heroes III - Översättning</translation>
     </message>
     <message>
         <location filename="../firstLaunch/firstlaunch_moc.ui" line="742"/>
         <source>Interface Improvements</source>
-        <translation type="unfinished">Gränssnitts-förbättringar</translation>
+        <translation>Gränssnitts-förbättringar</translation>
     </message>
     <message>
         <location filename="../firstLaunch/firstlaunch_moc.ui" line="809"/>
         <source>In The Wake of Gods</source>
-        <translation type="unfinished">I gudars kölvatten (In The Wake of Gods)</translation>
+        <translation>I gudars kölvatten (In The Wake of Gods)</translation>
     </message>
     <message>
         <location filename="../firstLaunch/firstlaunch_moc.ui" line="689"/>
         <source>Optionally, you can install additional mods either now, or at any point later, using the VCMI Launcher</source>
-        <translation type="unfinished">Valfritt kan du installera ytterligare moddar antingen nu eller när som helst senare med hjälp av 'VCMI Launcher'</translation>
+        <translation>Valfritt kan du installera ytterligare moddar antingen nu eller när som helst senare med hjälp av 'VCMI Launcher'</translation>
     </message>
     <message>
         <location filename="../firstLaunch/firstlaunch_moc.ui" line="788"/>
         <source>Install mod that provides various interface improvements, such as better interface for random maps and selectable actions in battles</source>
-        <translation type="unfinished">Installera en modd som förbättrar olika användargränssnitt i spelet, såsom ett bättre användargränssnitt för slumpmässiga kartor och valbara åtgärder i strider</translation>
+        <translation>Installera en modd som förbättrar olika användargränssnitt i spelet, såsom ett bättre användargränssnitt för slumpmässiga kartor och valbara åtgärder i strider</translation>
     </message>
     <message>
         <location filename="../firstLaunch/firstlaunch_moc.ui" line="673"/>
         <source>Install compatible version of &quot;Horn of the Abyss&quot;, a fan-made Heroes III expansion ported by the VCMI team</source>
-        <translation type="unfinished">Installera en kompatibel version av &quot;Horn of the Abyss&quot; (en fantillverkad Heroes III-expansion som blivit portad av VCMI-teamet)</translation>
+        <translation>Installera en kompatibel version av &quot;Horn of the Abyss&quot; (en fantillverkad Heroes III-expansion som blivit portad av VCMI-teamet)</translation>
     </message>
     <message>
         <location filename="../firstLaunch/firstlaunch_moc.ui" line="772"/>
         <source>Install compatible version of &quot;In The Wake of Gods&quot;, a fan-made Heroes III expansion</source>
-        <translation type="unfinished">Installera en kompatibel version av &quot;In The Wake of Gods&quot; (en fantillverkad Heroes III-expansion)</translation>
+        <translation>Installera en kompatibel version av &quot;In The Wake of Gods&quot; (en fantillverkad Heroes III-expansion)</translation>
     </message>
     <message>
         <location filename="../firstLaunch/firstlaunch_moc.cpp" line="178"/>
         <source>Heroes III installation found!</source>
-        <translation type="unfinished">Heroes III-installationen hittades!</translation>
+        <translation>Heroes III-installationen hittades!</translation>
     </message>
     <message>
         <location filename="../firstLaunch/firstlaunch_moc.cpp" line="178"/>
         <source>Copy data to VCMI folder?</source>
-        <translation type="unfinished">Kopiera data till VCMI-mappen?</translation>
+        <translation>Kopiera data till VCMI-mappen?</translation>
     </message>
     <message>
         <location filename="../firstLaunch/firstlaunch_moc.cpp" line="317"/>
         <source>Select %1 file...</source>
         <comment>param is file extension</comment>
-        <translation type="unfinished">Välj filen %1...</translation>
+        <translation>Välj filen %1...</translation>
     </message>
     <message>
         <location filename="../firstLaunch/firstlaunch_moc.cpp" line="318"/>
         <source>You have to select %1 file!</source>
         <comment>param is file extension</comment>
-        <translation type="unfinished">Du behöver välja filen %1!</translation>
+        <translation>Du behöver välja filen %1!</translation>
     </message>
     <message>
         <location filename="../firstLaunch/firstlaunch_moc.cpp" line="320"/>
         <source>GOG file (*.*)</source>
-        <translation type="unfinished">GOG-fil (*.*)</translation>
+        <translation>GOG-fil (*.*)</translation>
     </message>
     <message>
         <location filename="../firstLaunch/firstlaunch_moc.cpp" line="321"/>
         <source>File selection</source>
-        <translation type="unfinished">Filval</translation>
+        <translation>Filval</translation>
     </message>
     <message>
         <location filename="../firstLaunch/firstlaunch_moc.cpp" line="330"/>
         <source>File cannot be opened</source>
-        <translation type="unfinished">Filen kan inte öppnas</translation>
+        <translation>Filen kan inte öppnas</translation>
     </message>
     <message>
         <location filename="../firstLaunch/firstlaunch_moc.cpp" line="336"/>
         <source>Invalid file selected</source>
-        <translation type="unfinished">Ogiltig fil vald</translation>
+        <translation>Ogiltig fil vald</translation>
     </message>
     <message>
         <location filename="../firstLaunch/firstlaunch_moc.cpp" line="346"/>
         <source>GOG installer</source>
-        <translation type="unfinished">GOG installationsprogram</translation>
+        <translation>GOG installationsprogram</translation>
     </message>
     <message>
         <location filename="../firstLaunch/firstlaunch_moc.cpp" line="343"/>
         <source>GOG data</source>
-        <translation type="unfinished">GOG-data</translation>
+        <translation>GOG-data</translation>
     </message>
     <message>
         <location filename="../firstLaunch/firstlaunch_moc.cpp" line="438"/>
         <source>No Heroes III data!</source>
-        <translation type="unfinished">Inga Heroes III-data!</translation>
+        <translation>Inga Heroes III-data!</translation>
     </message>
     <message>
         <location filename="../firstLaunch/firstlaunch_moc.cpp" line="438"/>
         <source>Selected files do not contain Heroes III data!</source>
-        <translation type="unfinished">De valda filerna innehåller inte Heroes III-data!</translation>
+        <translation>De valda filerna innehåller inte Heroes III-data!</translation>
     </message>
     <message>
         <location filename="../firstLaunch/firstlaunch_moc.cpp" line="485"/>
@@ -1274,48 +1274,48 @@ Heroes® of Might and Magic® III HD stöds för närvarande inte!</translation>
         <location filename="../firstLaunch/firstlaunch_moc.cpp" line="506"/>
         <location filename="../firstLaunch/firstlaunch_moc.cpp" line="511"/>
         <source>Heroes III data not found!</source>
-        <translation type="unfinished">Heroes III-data hittades inte!</translation>
+        <translation>Heroes III-data hittades inte!</translation>
     </message>
     <message>
         <location filename="../firstLaunch/firstlaunch_moc.cpp" line="482"/>
         <source>Failed to detect valid Heroes III data in chosen directory.
 Please select directory with installed Heroes III data.</source>
-        <translation type="unfinished">Det går inte att upptäcka giltiga Heroes III-data i den valda katalogen. Välj en mapp där Heroes III-data finns.</translation>
+        <translation>Det går inte att upptäcka giltiga Heroes III-data i den valda katalogen. Välj en mapp där Heroes III-data finns.</translation>
     </message>
     <message>
         <location filename="../firstLaunch/firstlaunch_moc.cpp" line="387"/>
         <source>You&apos;ve provided GOG Galaxy installer! This file doesn&apos;t contain the game. Please download the offline backup game installer!</source>
-        <translation type="unfinished">Du har tillhandahållit installationsprogrammet för GOG Galaxy! Den här filen innehåller inte spelet. Ladda ner offline-installationsprogrammet för spelet!</translation>
+        <translation>Du har tillhandahållit installationsprogrammet för GOG Galaxy! Den här filen innehåller inte spelet. Ladda ner offline-installationsprogrammet för spelet!</translation>
     </message>
     <message>
         <location filename="../firstLaunch/firstlaunch_moc.cpp" line="412"/>
         <source>Stream error while extracting files!
 error reason: </source>
-        <translation type="unfinished">Strömningsfel vid extrahering av filer!
+        <translation>Strömningsfel vid extrahering av filer!
 Orsak till fel: </translation>
     </message>
     <message>
         <location filename="../firstLaunch/firstlaunch_moc.cpp" line="425"/>
         <source>Not a supported Inno Setup installer!</source>
-        <translation type="unfinished">Inno Setup-installationsprogrammet stöds inte!</translation>
+        <translation>Inno Setup-installationsprogrammet stöds inte!</translation>
     </message>
     <message>
         <location filename="../firstLaunch/firstlaunch_moc.cpp" line="436"/>
         <source>Extracting error!</source>
-        <translation type="unfinished">Extraktionsfel!</translation>
+        <translation>Extraktionsfel!</translation>
     </message>
     <message>
         <location filename="../firstLaunch/firstlaunch_moc.cpp" line="506"/>
         <source>Heroes III: HD Edition files are not supported by VCMI.
 Please select directory with Heroes III: Complete Edition or Heroes III: Shadow of Death.</source>
-        <translation type="unfinished">Heroes III HD Edition-filer stöds inte av VCMI.
+        <translation>Heroes III HD Edition-filer stöds inte av VCMI.
 Välj en mapp som innehåller data från Heroes III: Complete Edition eller Heroes III: Shadow of Death.</translation>
     </message>
     <message>
         <location filename="../firstLaunch/firstlaunch_moc.cpp" line="511"/>
         <source>Unknown or unsupported Heroes III version found.
 Please select directory with Heroes III: Complete Edition or Heroes III: Shadow of Death.</source>
-        <translation type="unfinished">Okänd eller ostödd version av Heroes III.
+        <translation>Okänd eller ostödd version av Heroes III.
 Vänligen välj en mapp som innehåller data från Heroes III: Complete Edition eller Heroes III: Shadow of Death.</translation>
     </message>
 </context>
@@ -1324,7 +1324,7 @@ Vänligen välj en mapp som innehåller data från Heroes III: Complete Edition 
     <message>
         <location filename="../modManager/imageviewer_moc.ui" line="20"/>
         <source>Image Viewer</source>
-        <translation type="unfinished">Bildvisare</translation>
+        <translation>Bildvisare</translation>
     </message>
 </context>
 <context>
@@ -1332,92 +1332,92 @@ Vänligen välj en mapp som innehåller data från Heroes III: Complete Edition 
     <message>
         <location filename="../languages.cpp" line="23"/>
         <source>Czech</source>
-        <translation type="unfinished">Tjeckiska</translation>
+        <translation>Tjeckiska</translation>
     </message>
     <message>
         <location filename="../languages.cpp" line="24"/>
         <source>Chinese</source>
-        <translation type="unfinished">Kinesiska</translation>
+        <translation>Kinesiska</translation>
     </message>
     <message>
         <location filename="../languages.cpp" line="25"/>
         <source>English</source>
-        <translation type="unfinished">Engelska</translation>
+        <translation>Engelska</translation>
     </message>
     <message>
         <location filename="../languages.cpp" line="26"/>
         <source>Finnish</source>
-        <translation type="unfinished">Finska</translation>
+        <translation>Finska</translation>
     </message>
     <message>
         <location filename="../languages.cpp" line="27"/>
         <source>French</source>
-        <translation type="unfinished">Franska</translation>
+        <translation>Franska</translation>
     </message>
     <message>
         <location filename="../languages.cpp" line="28"/>
         <source>German</source>
-        <translation type="unfinished">Tyska</translation>
+        <translation>Tyska</translation>
     </message>
     <message>
         <location filename="../languages.cpp" line="29"/>
         <source>Hungarian</source>
-        <translation type="unfinished">Ungerska</translation>
+        <translation>Ungerska</translation>
     </message>
     <message>
         <location filename="../languages.cpp" line="30"/>
         <source>Italian</source>
-        <translation type="unfinished">Italienska</translation>
+        <translation>Italienska</translation>
     </message>
     <message>
         <location filename="../languages.cpp" line="31"/>
         <source>Korean</source>
-        <translation type="unfinished">Koreanska</translation>
+        <translation>Koreanska</translation>
     </message>
     <message>
         <location filename="../languages.cpp" line="32"/>
         <source>Polish</source>
-        <translation type="unfinished">Polska</translation>
+        <translation>Polska</translation>
     </message>
     <message>
         <location filename="../languages.cpp" line="33"/>
         <source>Portuguese</source>
-        <translation type="unfinished">Portugisiska</translation>
+        <translation>Portugisiska</translation>
     </message>
     <message>
         <location filename="../languages.cpp" line="34"/>
         <source>Russian</source>
-        <translation type="unfinished">Ryska</translation>
+        <translation>Ryska</translation>
     </message>
     <message>
         <location filename="../languages.cpp" line="35"/>
         <source>Spanish</source>
-        <translation type="unfinished">Spanska</translation>
+        <translation>Spanska</translation>
     </message>
     <message>
         <location filename="../languages.cpp" line="36"/>
         <source>Swedish</source>
-        <translation type="unfinished">Svenska</translation>
+        <translation>Svenska</translation>
     </message>
     <message>
         <location filename="../languages.cpp" line="37"/>
         <source>Turkish</source>
-        <translation type="unfinished">Turkiska</translation>
+        <translation>Turkiska</translation>
     </message>
     <message>
         <location filename="../languages.cpp" line="38"/>
         <source>Ukrainian</source>
-        <translation type="unfinished">Ukrainska</translation>
+        <translation>Ukrainska</translation>
     </message>
     <message>
         <location filename="../languages.cpp" line="39"/>
         <source>Vietnamese</source>
-        <translation type="unfinished">Vietnamesiska</translation>
+        <translation>Vietnamesiska</translation>
     </message>
     <message>
         <location filename="../languages.cpp" line="61"/>
         <source>Auto (%1)</source>
-        <translation type="unfinished">Auto (%1)</translation>
+        <translation>Auto (%1)</translation>
     </message>
 </context>
 <context>
@@ -1425,32 +1425,32 @@ Vänligen välj en mapp som innehåller data från Heroes III: Complete Edition 
     <message>
         <location filename="../mainwindow_moc.ui" line="20"/>
         <source>VCMI Launcher</source>
-        <translation type="unfinished">VCMI Launcher</translation>
+        <translation>VCMI Launcher</translation>
     </message>
     <message>
         <location filename="../mainwindow_moc.ui" line="53"/>
         <source>Mods</source>
-        <translation type="unfinished">Moddar</translation>
+        <translation>Moddar</translation>
     </message>
     <message>
         <location filename="../mainwindow_moc.ui" line="99"/>
         <source>Settings</source>
-        <translation type="unfinished">Inställningar</translation>
+        <translation>Inställningar</translation>
     </message>
     <message>
         <location filename="../mainwindow_moc.ui" line="145"/>
         <source>Help</source>
-        <translation type="unfinished">Hjälp</translation>
+        <translation>Hjälp</translation>
     </message>
     <message>
         <location filename="../mainwindow_moc.ui" line="210"/>
         <source>Map Editor</source>
-        <translation type="unfinished">Kartredigerare</translation>
+        <translation>Kartredigerare</translation>
     </message>
     <message>
         <location filename="../mainwindow_moc.ui" line="259"/>
         <source>Start game</source>
-        <translation type="unfinished">Starta ett spel</translation>
+        <translation>Starta ett spel</translation>
     </message>
 </context>
 <context>
@@ -1458,12 +1458,12 @@ Vänligen välj en mapp som innehåller data från Heroes III: Complete Edition 
     <message>
         <location filename="../modManager/cmodlistmodel_moc.cpp" line="169"/>
         <source>Name</source>
-        <translation type="unfinished">Namn</translation>
+        <translation>Namn</translation>
     </message>
     <message>
         <location filename="../modManager/cmodlistmodel_moc.cpp" line="172"/>
         <source>Type</source>
-        <translation type="unfinished">Typ</translation>
+        <translation>Typ</translation>
     </message>
 </context>
 <context>
@@ -1471,13 +1471,13 @@ Vänligen välj en mapp som innehåller data från Heroes III: Complete Edition 
     <message>
         <location filename="../main.cpp" line="122"/>
         <source>Error starting executable</source>
-        <translation type="unfinished">Fel vid start av körbar fil</translation>
+        <translation>Fel vid start av körbar fil</translation>
     </message>
     <message>
         <location filename="../main.cpp" line="123"/>
         <source>Failed to start %1
 Reason: %2</source>
-        <translation type="unfinished">Startfel %1
+        <translation>Startfel %1
 Orsak: %2</translation>
     </message>
 </context>
@@ -1486,27 +1486,27 @@ Orsak: %2</translation>
     <message>
         <location filename="../updatedialog_moc.ui" line="71"/>
         <source>You have the latest version</source>
-        <translation type="unfinished">Du har den senaste versionen</translation>
+        <translation>Du har den senaste versionen</translation>
     </message>
     <message>
         <location filename="../updatedialog_moc.ui" line="94"/>
         <source>Close</source>
-        <translation type="unfinished">Stäng</translation>
+        <translation>Stäng</translation>
     </message>
     <message>
         <location filename="../updatedialog_moc.ui" line="101"/>
         <source>Check for updates on startup</source>
-        <translation type="unfinished">Sök efter uppdateringar vid uppstart</translation>
+        <translation>Sök efter uppdateringar vid uppstart</translation>
     </message>
     <message>
         <location filename="../updatedialog_moc.cpp" line="64"/>
         <source>Network error</source>
-        <translation type="unfinished">Nätverksfel</translation>
+        <translation>Nätverksfel</translation>
     </message>
     <message>
         <location filename="../updatedialog_moc.cpp" line="101"/>
         <source>Cannot read JSON from url or incorrect JSON data</source>
-        <translation type="unfinished">Det går inte att läsa JSON-data från URL:en eller fel JSON-data</translation>
+        <translation>Det går inte att läsa JSON-data från URL:en eller fel JSON-data</translation>
     </message>
 </context>
 </TS>

--- a/launcher/translation/ukrainian.ts
+++ b/launcher/translation/ukrainian.ts
@@ -1241,7 +1241,7 @@ Offline installer consists of two parts, .exe and .bin. Make sure you download b
     </message>
     <message>
         <location filename="../firstLaunch/firstlaunch_moc.cpp" line="330"/>
-        <source>File cannot opened</source>
+        <source>File cannot be opened</source>
         <translation>Не вдається відкрити файл</translation>
     </message>
     <message>

--- a/launcher/translation/vietnamese.ts
+++ b/launcher/translation/vietnamese.ts
@@ -1232,7 +1232,7 @@ Offline installer consists of two parts, .exe and .bin. Make sure you download b
     </message>
     <message>
         <location filename="../firstLaunch/firstlaunch_moc.cpp" line="330"/>
-        <source>File cannot opened</source>
+        <source>File cannot be opened</source>
         <translation type="unfinished"></translation>
     </message>
     <message>


### PR DESCRIPTION
Hi @IvanSavenko,

This PR:
- Fixes a caption in the source code and updates all the translations
- Fixes a translation in Swedish
- Split the modder and translator documentations (more documentation to come)
- Mention the `empty-translation` project for translators