### PR TITLE
Bugfixing

### DIFF
--- a/AI/BattleAI/AttackPossibility.cpp
+++ b/AI/BattleAI/AttackPossibility.cpp
@@ -45,11 +45,12 @@ void DamageCache::buildObstacleDamageCache(std::shared_ptr<HypotheticBattle> hb,
 			continue;
 
 		std::unique_ptr<spells::BattleCast> cast = nullptr;
+		std::unique_ptr<spells::ObstacleCasterProxy> caster = nullptr;
 		if(spellObstacle->obstacleType == SpellCreatedObstacle::EObstacleType::SPELL_CREATED)
 		{
 			const auto * hero = hb->battleGetFightingHero(spellObstacle->casterSide);
-			auto caster = spells::ObstacleCasterProxy(hb->getSidePlayer(spellObstacle->casterSide), hero, *spellObstacle);
-			cast = std::make_unique<spells::BattleCast>(spells::BattleCast(hb.get(), &caster, spells::Mode::PASSIVE, obst->getTrigger().toSpell()));
+			caster = std::make_unique<spells::ObstacleCasterProxy>(hb->getSidePlayer(spellObstacle->casterSide), hero, *spellObstacle);
+			cast = std::make_unique<spells::BattleCast>(spells::BattleCast(hb.get(), caster.get(), spells::Mode::PASSIVE, obst->getTrigger().toSpell()));
 		}
 
 		auto affectedHexes = obst->getAffectedTiles();

--- a/client/eventsSDL/InputSourceMouse.cpp
+++ b/client/eventsSDL/InputSourceMouse.cpp
@@ -72,7 +72,9 @@ void InputSourceMouse::handleEventMouseButtonDown(const SDL_MouseButtonEvent & b
 
 void InputSourceMouse::handleEventMouseWheel(const SDL_MouseWheelEvent & wheel)
 {
-#if SDL_VERSION_ATLEAST(2,26,0)
+	//NOTE: while mouseX / mouseY properties are available since 2.26.0, they are not converted into logical coordinates so don't account for resolution scaling
+	// This SDL bug was fixed in 2.30.1: https://github.com/libsdl-org/SDL/issues/9097
+#if SDL_VERSION_ATLEAST(2,30,1)
 	GH.events().dispatchMouseScrolled(Point(wheel.x, wheel.y), Point(wheel.mouseX, wheel.mouseY) / GH.screenHandler().getScalingFactor());
 #else
 	GH.events().dispatchMouseScrolled(Point(wheel.x, wheel.y), GH.getCursorPosition());

--- a/client/windows/CMessage.cpp
+++ b/client/windows/CMessage.cpp
@@ -83,7 +83,7 @@ std::vector<std::string> CMessage::breakText(std::string text, size_t maxLineWid
 		std::string printableString;
 
 		// loops till line is full or end of text reached
-		while(currPos < text.length() && text[currPos] != 0x0a)
+		while(currPos < text.length() && text[currPos] != 0x0a && graphics->fonts[font]->getStringWidth(printableString) <= maxLineWidth)
 		{
 			symbolSize = TextOperations::getUnicodeCharacterSize(text[currPos]);
 
@@ -115,18 +115,13 @@ std::vector<std::string> CMessage::breakText(std::string text, size_t maxLineWid
 				color = "";
 			}
 			else
-			{
-				std::string newPrintableString = printableString;
-				newPrintableString.append(text.data() + currPos, symbolSize);
-				if (graphics->fonts[font]->getStringWidth(newPrintableString) < maxLineWidth)
-					printableString.append(text.data() + currPos, symbolSize);
-				else
-					break;
-			}
+				printableString.append(text.data() + currPos, symbolSize);
+
 			currPos += symbolSize;
 		}
 
-		// long line, create line break
+		// not all line has been processed - it turned out to be too long, so erase everything after last word break
+		// if string consists from a single word (or this is Chinese/Korean) - erase only last symbol to bring line back to allowed length
 		if(currPos < text.length() && (text[currPos] != 0x0a))
 		{
 			if(wordBreak != ui32(-1))

--- a/lib/rewardable/Info.cpp
+++ b/lib/rewardable/Info.cpp
@@ -105,6 +105,7 @@ void Rewardable::Info::init(const JsonNode & objectConfig, const std::string & o
 	loadString(parameters["visitedTooltip"], TextIdentifier(objectName, "visitedTooltip"));
 	loadString(parameters["onVisitedMessage"], TextIdentifier(objectName, "onVisited"));
 	loadString(parameters["onEmptyMessage"], TextIdentifier(objectName, "onEmpty"));
+	loadString(parameters["onGuardedMessage"], TextIdentifier(objectName, "onGuarded"));
 }
 
 Rewardable::LimitersList Rewardable::Info::configureSublimiters(Rewardable::Configuration & object, vstd::RNG & rng, IGameCallback * cb, const JsonNode & source) const

--- a/server/queries/VisitQueries.cpp
+++ b/server/queries/VisitQueries.cpp
@@ -68,6 +68,8 @@ TownBuildingVisitQuery::TownBuildingVisitQuery(CGameHandler * owner, const CGTow
 
 void TownBuildingVisitQuery::onExposure(QueryPtr topQuery)
 {
+	topQuery->notifyObjectAboutRemoval(visitedObject, visitingHero);
+
 	onAdded(players.front());
 }
 


### PR DESCRIPTION
- Fix line break position computation for text without spaces (Chinese)
  - should fix #4646
- Fix potential access to destroyed variable on stack
  - fixes #4632
- Fix crash on transfer of multiple artifacts in a backpack to another hero on starting next campaign scenario without hero that held these artifacts before
  - fixes #4635
- Fix missing registration of onGuardedMessage string for banks
  - fixes #4658
- Fix mouse wheel handling on SDL versions between 2.26..2.30.0 if resolution scaling is in use
  - fixes #4657
- Fixes blocking dialogs in rewardable town buildings not doing anything on selection