### PR TITLE
Unify rewardable map object and town building code

### DIFF
--- a/lib/mapObjects/CRewardableObject.cpp
+++ b/lib/mapObjects/CRewardableObject.cpp
@@ -12,87 +12,30 @@
 #include "CRewardableObject.h"
 
 #include "../CPlayerState.h"
-#include "../GameSettings.h"
 #include "../IGameCallback.h"
+#include "../IGameSettings.h"
 #include "../battle/BattleLayout.h"
 #include "../gameState/CGameState.h"
 #include "../mapObjectConstructors/AObjectTypeHandler.h"
-#include "../mapObjectConstructors/CObjectClassesHandler.h"
 #include "../mapObjectConstructors/CRewardableConstructor.h"
 #include "../mapObjects/CGHeroInstance.h"
 #include "../networkPacks/PacksForClient.h"
 #include "../networkPacks/PacksForClientBattle.h"
 #include "../serializer/JsonSerializeFormat.h"
-#include "../texts/CGeneralTextHandler.h"
 
 #include <vstd/RNG.h>
 
 VCMI_LIB_NAMESPACE_BEGIN
 
-void CRewardableObject::grantRewardWithMessage(const CGHeroInstance * contextHero, int index, bool markAsVisit) const
+const IObjectInterface * CRewardableObject::getObject() const
 {
-	auto vi = configuration.info.at(index);
-	logGlobal->debug("Granting reward %d. Message says: %s", index, vi.message.toString());
-	// show message only if it is not empty or in infobox
-	if (configuration.infoWindowType != EInfoWindowMode::MODAL || !vi.message.toString().empty())
-	{
-		InfoWindow iw;
-		iw.player = contextHero->tempOwner;
-		iw.text = vi.message;
-		vi.reward.loadComponents(iw.components, contextHero);
-		iw.type = configuration.infoWindowType;
-		if(!iw.components.empty() || !iw.text.toString().empty())
-			cb->showInfoDialog(&iw);
-	}
-	// grant reward afterwards. Note that it may remove object
-	if(markAsVisit)
-		markAsVisited(contextHero);
-	grantReward(index, contextHero);
+	return this;
 }
 
-void CRewardableObject::selectRewardWithMessage(const CGHeroInstance * contextHero, const std::vector<ui32> & rewardIndices, const MetaString & dialog) const
+void CRewardableObject::markAsScouted(const CGHeroInstance * hero) const
 {
-	BlockingDialog sd(configuration.canRefuse, rewardIndices.size() > 1);
-	sd.player = contextHero->tempOwner;
-	sd.text = dialog;
-	sd.components = loadComponents(contextHero, rewardIndices);
-	cb->showBlockingDialog(this, &sd);
-
-}
-
-void CRewardableObject::grantAllRewardsWithMessage(const CGHeroInstance * contextHero, const std::vector<ui32> & rewardIndices, bool markAsVisit) const
-{
-	if (rewardIndices.empty())
-		return;
-		
-	for (auto index : rewardIndices)
-	{
-		// TODO: Merge all rewards of same type, with single message?
-		grantRewardWithMessage(contextHero, index, false);
-	}
-	// Mark visited only after all rewards were processed
-	if(markAsVisit)
-		markAsVisited(contextHero);
-}
-
-std::vector<Component> CRewardableObject::loadComponents(const CGHeroInstance * contextHero, const std::vector<ui32> & rewardIndices) const
-{
-	std::vector<Component> result;
-
-	if (rewardIndices.empty())
-		return result;
-
-	if (configuration.selectMode != Rewardable::SELECT_FIRST && rewardIndices.size() > 1)
-	{
-		for (auto index : rewardIndices)
-			result.push_back(configuration.info.at(index).reward.getDisplayedComponent(contextHero));
-	}
-	else
-	{
-		configuration.info.at(rewardIndices.front()).reward.loadComponents(result, contextHero);
-	}
-
-	return result;
+	ChangeObjectVisitors cov(ChangeObjectVisitors::VISITOR_ADD_PLAYER, id, hero->id);
+	cb->sendAndApply(&cov);
 }
 
 bool CRewardableObject::isGuarded() const
@@ -127,94 +70,9 @@ void CRewardableObject::onHeroVisit(const CGHeroInstance *hero) const
 	}
 }
 
-void CRewardableObject::doHeroVisit(const CGHeroInstance *h) const
-{
-	if(!wasVisitedBefore(h))
-	{
-		auto rewards = getAvailableRewards(h, Rewardable::EEventType::EVENT_FIRST_VISIT);
-		bool objectRemovalPossible = false;
-		for(auto index : rewards)
-		{
-			if(configuration.info.at(index).reward.removeObject)
-				objectRemovalPossible = true;
-		}
-
-		logGlobal->debug("Visiting object with %d possible rewards", rewards.size());
-		switch (rewards.size())
-		{
-			case 0: // no available rewards, e.g. visiting School of War without gold
-			{
-				auto emptyRewards = getAvailableRewards(h, Rewardable::EEventType::EVENT_NOT_AVAILABLE);
-				if (!emptyRewards.empty())
-					grantRewardWithMessage(h, emptyRewards[0], false);
-				else
-					logMod->warn("No applicable message for visiting empty object!");
-				break;
-			}
-			case 1: // one reward. Just give it with message
-			{
-				if (configuration.canRefuse)
-					selectRewardWithMessage(h, rewards, configuration.info.at(rewards.front()).message);
-				else
-					grantRewardWithMessage(h, rewards.front(), true);
-				break;
-			}
-			default: // multiple rewards. Act according to select mode
-			{
-				switch (configuration.selectMode) {
-					case Rewardable::SELECT_PLAYER: // player must select
-						selectRewardWithMessage(h, rewards, configuration.onSelect);
-						break;
-					case Rewardable::SELECT_FIRST: // give first available
-						if (configuration.canRefuse)
-							selectRewardWithMessage(h, { rewards.front() }, configuration.info.at(rewards.front()).message);
-						else
-							grantRewardWithMessage(h, rewards.front(), true);
-						break;
-					case Rewardable::SELECT_RANDOM: // give random
-					{
-						ui32 rewardIndex = *RandomGeneratorUtil::nextItem(rewards, cb->gameState()->getRandomGenerator());
-						if (configuration.canRefuse)
-							selectRewardWithMessage(h, { rewardIndex }, configuration.info.at(rewardIndex).message);
-						else
-							grantRewardWithMessage(h, rewardIndex, true);
-						break;
-					}
-					case Rewardable::SELECT_ALL: // grant all possible
-						grantAllRewardsWithMessage(h, rewards, true);
-						break;
-				}
-				break;
-			}
-		}
-
-		if(!objectRemovalPossible && getAvailableRewards(h, Rewardable::EEventType::EVENT_FIRST_VISIT).empty())
-		{
-			ChangeObjectVisitors cov(ChangeObjectVisitors::VISITOR_ADD_PLAYER, id, h->id);
-			cb->sendAndApply(&cov);
-		}
-	}
-	else
-	{
-		logGlobal->debug("Revisiting already visited object");
-
-		if (!wasVisited(h->getOwner()))
-		{
-			ChangeObjectVisitors cov(ChangeObjectVisitors::VISITOR_ADD_PLAYER, id, h->id);
-			cb->sendAndApply(&cov);
-		}
-
-		auto visitedRewards = getAvailableRewards(h, Rewardable::EEventType::EVENT_ALREADY_VISITED);
-		if (!visitedRewards.empty())
-			grantRewardWithMessage(h, visitedRewards[0], false);
-		else
-			logMod->warn("No applicable message for visiting already visited object!");
-	}
-}
-
 void CRewardableObject::heroLevelUpDone(const CGHeroInstance *hero) const
 {
-	grantRewardAfterLevelup(cb, configuration.info.at(selectedReward), this, hero);
+	grantRewardAfterLevelup(configuration.info.at(selectedReward), this, hero);
 }
 
 void CRewardableObject::battleFinished(const CGHeroInstance *hero, const BattleResult &result) const
@@ -264,12 +122,12 @@ void CRewardableObject::markAsVisited(const CGHeroInstance * hero) const
 void CRewardableObject::grantReward(ui32 rewardID, const CGHeroInstance * hero) const
 {
 	cb->setObjPropertyValue(id, ObjProperty::REWARD_SELECT, rewardID);
-	grantRewardBeforeLevelup(cb, configuration.info.at(rewardID), hero);
+	grantRewardBeforeLevelup(configuration.info.at(rewardID), hero);
 	
 	// hero is not blocked by levelup dialog - grant remainder immediately
 	if(!cb->isVisitCoveredByAnotherQuery(this, hero))
 	{
-		grantRewardAfterLevelup(cb, configuration.info.at(rewardID), this, hero);
+		grantRewardAfterLevelup(configuration.info.at(rewardID), this, hero);
 	}
 }
 

--- a/lib/mapObjects/CRewardableObject.cpp
+++ b/lib/mapObjects/CRewardableObject.cpp
@@ -95,16 +95,7 @@ std::vector<Component> CRewardableObject::loadComponents(const CGHeroInstance * 
 	return result;
 }
 
-bool CRewardableObject::guardedPotentially() const
-{
-	for (auto const & visitInfo : configuration.info)
-		if (!visitInfo.reward.guards.empty())
-			return true;
-
-	return false;
-}
-
-bool CRewardableObject::guardedPresently() const
+bool CRewardableObject::isGuarded() const
 {
 	return stacksCount() > 0;
 }
@@ -117,7 +108,7 @@ void CRewardableObject::onHeroVisit(const CGHeroInstance *hero) const
 		cb->sendAndApply(&cov);
 	}
 
-	if (guardedPresently())
+	if (isGuarded())
 	{
 		auto guardedIndexes = getAvailableRewards(hero, Rewardable::EEventType::EVENT_GUARDED);
 		auto guardedReward = configuration.info.at(guardedIndexes.at(0));
@@ -236,7 +227,7 @@ void CRewardableObject::battleFinished(const CGHeroInstance *hero, const BattleR
 
 void CRewardableObject::blockingDialogAnswered(const CGHeroInstance * hero, int32_t answer) const
 {
-	if(guardedPresently())
+	if(isGuarded())
 	{
 		if (answer)
 		{
@@ -410,7 +401,7 @@ std::vector<Component> CRewardableObject::getPopupComponentsImpl(PlayerColor pla
 	if (!wasScouted(player))
 		return {};
 
-	if (guardedPresently())
+	if (isGuarded())
 	{
 		if (!cb->getSettings().getBoolean(EGameSettings::BANKS_SHOW_GUARDS_COMPOSITION))
 			return {};

--- a/lib/mapObjects/CRewardableObject.h
+++ b/lib/mapObjects/CRewardableObject.h
@@ -47,10 +47,8 @@ protected:
 
 	void doHeroVisit(const CGHeroInstance *h) const;
 
-	/// Returns true if this object might have guards present, whether they were cleared or not
-	bool guardedPotentially() const;
 	/// Returns true if this object is currently guarded
-	bool guardedPresently() const;
+	bool isGuarded() const;
 public:
 
 	/// Visitability checks. Note that hero check includes check for hero owner (returns true if object was visited by player)

--- a/lib/mapObjects/CRewardableObject.h
+++ b/lib/mapObjects/CRewardableObject.h
@@ -25,27 +25,21 @@ protected:
 	/// reward selected by player, no serialize
 	ui16 selectedReward = 0;
 	
-	void grantReward(ui32 rewardID, const CGHeroInstance * hero) const;
-	void markAsVisited(const CGHeroInstance * hero) const;
+	void grantReward(ui32 rewardID, const CGHeroInstance * hero) const override;
+	void markAsVisited(const CGHeroInstance * hero) const override;
+
+	const IObjectInterface * getObject() const override;
+	void markAsScouted(const CGHeroInstance * hero) const override;
 	
 	/// return true if this object was "cleared" before and no longer has rewards applicable to selected hero
 	/// unlike wasVisited, this method uses information not available to player owner, for example, if object was cleared by another player before
-	bool wasVisitedBefore(const CGHeroInstance * contextHero) const;
+	bool wasVisitedBefore(const CGHeroInstance * contextHero) const override;
 	
 	void serializeJsonOptions(JsonSerializeFormat & handler) override;
 	
-	virtual void grantRewardWithMessage(const CGHeroInstance * contextHero, int rewardIndex, bool markAsVisit) const;
-	virtual void selectRewardWithMessage(const CGHeroInstance * contextHero, const std::vector<ui32> & rewardIndices, const MetaString & dialog) const;
-
-	virtual void grantAllRewardsWithMessage(const CGHeroInstance * contextHero, const std::vector<ui32>& rewardIndices, bool markAsVisit) const;
-
-	std::vector<Component> loadComponents(const CGHeroInstance * contextHero, const std::vector<ui32> & rewardIndices) const;
-
 	std::string getDisplayTextImpl(PlayerColor player, const CGHeroInstance * hero, bool includeDescription) const;
 	std::string getDescriptionMessage(PlayerColor player, const CGHeroInstance * hero) const;
 	std::vector<Component> getPopupComponentsImpl(PlayerColor player, const CGHeroInstance * hero) const;
-
-	void doHeroVisit(const CGHeroInstance *h) const;
 
 	/// Returns true if this object is currently guarded
 	bool isGuarded() const;

--- a/lib/mapObjects/TownBuildingInstance.h
+++ b/lib/mapObjects/TownBuildingInstance.h
@@ -63,10 +63,14 @@ class DLL_LINKAGE TownRewardableBuildingInstance : public TownBuildingInstance, 
 	ui16 selectedReward = 0;
 	std::set<ObjectInstanceID> visitors;
 
-	bool wasVisitedBefore(const CGHeroInstance * contextHero) const;
-	void grantReward(ui32 rewardID, const CGHeroInstance * hero) const;
+	bool wasVisitedBefore(const CGHeroInstance * contextHero) const override;
+	void grantReward(ui32 rewardID, const CGHeroInstance * hero) const override;
 	Rewardable::Configuration generateConfiguration(vstd::RNG & rand) const;
 
+	const IObjectInterface * getObject() const override;
+	bool wasVisited(PlayerColor player) const override;
+	void markAsVisited(const CGHeroInstance * hero) const override;
+	void markAsScouted(const CGHeroInstance * hero) const override;
 public:
 	void setProperty(ObjProperty what, ObjPropertyID identifier) override;
 	void onHeroVisit(const CGHeroInstance * h) const override;

--- a/lib/rewardable/Interface.h
+++ b/lib/rewardable/Interface.h
@@ -15,7 +15,7 @@
 
 VCMI_LIB_NAMESPACE_BEGIN
 
-class IGameCallback;
+class IObjectInterface;
 
 namespace Rewardable
 {
@@ -30,11 +30,24 @@ private:
 protected:
 	
 	/// function that must be called if hero got level-up during grantReward call
-	virtual void grantRewardAfterLevelup(IGameCallback * cb, const Rewardable::VisitInfo & reward, const CArmedInstance * army, const CGHeroInstance * hero) const;
+	void grantRewardAfterLevelup(const Rewardable::VisitInfo & reward, const CArmedInstance * army, const CGHeroInstance * hero) const;
 
 	/// grants reward to hero
-	virtual void grantRewardBeforeLevelup(IGameCallback * cb, const Rewardable::VisitInfo & reward, const CGHeroInstance * hero) const;
+	void grantRewardBeforeLevelup(const Rewardable::VisitInfo & reward, const CGHeroInstance * hero) const;
 	
+	virtual void grantRewardWithMessage(const CGHeroInstance * contextHero, int rewardIndex, bool markAsVisit) const;
+	void selectRewardWithMessage(const CGHeroInstance * contextHero, const std::vector<ui32> & rewardIndices, const MetaString & dialog) const;
+	void grantAllRewardsWithMessage(const CGHeroInstance * contextHero, const std::vector<ui32>& rewardIndices, bool markAsVisit) const;
+	std::vector<Component> loadComponents(const CGHeroInstance * contextHero, const std::vector<ui32> & rewardIndices) const;
+
+	void doHeroVisit(const CGHeroInstance *h) const;
+
+	virtual const IObjectInterface * getObject() const = 0;
+	virtual bool wasVisitedBefore(const CGHeroInstance * hero) const = 0;
+	virtual bool wasVisited(PlayerColor player) const = 0;
+	virtual void markAsVisited(const CGHeroInstance * hero) const = 0;
+	virtual void markAsScouted(const CGHeroInstance * hero) const = 0;
+	virtual void grantReward(ui32 rewardID, const CGHeroInstance * hero) const = 0;
 public:
 
 	/// filters list of visit info and returns rewards that can be granted to current hero

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -1194,7 +1194,7 @@ void CGameHandler::visitCastleObjects(const CGTownInstance * t, std::vector<cons
 
 	for (auto & building : t->rewardableBuildings)
 	{
-		if (!t->town->buildings.at(building.first)->manualHeroVisit)
+		if (!t->town->buildings.at(building.first)->manualHeroVisit && t->hasBuilt(building.first))
 			buildingsToVisit.push_back(building.first);
 	}
 


### PR DESCRIPTION
A lot of rewardable town buildings code was apparently made by copy-pasting town buildings code, which over time have diverged from original code since most of changes were only made for rewardable map objects.

This PR removes (some of) copy-pasted code and moves it to a shared class.

As a side effect, this fixes some of bugs with rewardable town buildings, such as visiting mana vortex when hero already has 200% of mana.