### PR TITLE
Fix chain lightning wasting effect on creatures immune to magic

### DIFF
--- a/lib/spells/effects/UnitEffect.cpp
+++ b/lib/spells/effects/UnitEffect.cpp
@@ -197,7 +197,7 @@ EffectTarget UnitEffect::transformTargetByChain(const Mechanics * m, const Targe
 
 	auto possibleTargets = m->battle()->battleGetUnitsIf([&](const battle::Unit * unit) -> bool
 	{
-		return isValidTarget(m, unit);
+		return isReceptive(m, unit) && isValidTarget(m, unit);
 	});
 
 	for(const auto *unit : possibleTargets)


### PR DESCRIPTION
Creatures immune to magic should be removed from list of targets for chain spell, after fix targeting works properly as shown on following screenshot:
![obraz](https://github.com/user-attachments/assets/c3a22799-2665-4c63-80b5-f44c78183ffa)
