### PR TITLE
Tweaks for scalable / true type fonts

### DIFF
--- a/client/lobby/OptionsTab.cpp
+++ b/client/lobby/OptionsTab.cpp
@@ -1037,11 +1037,11 @@ OptionsTab::PlayerOptionsEntry::PlayerOptionsEntry(const PlayerSettings & S, con
 	}
 	const auto & font = GH.renderHandler().loadFont(FONT_SMALL);
 
-	labelWhoCanPlay = std::make_shared<CMultiLineLabel>(Rect(6, 23, 45, font->getLineHeight()*2), EFonts::FONT_TINY, ETextAlignment::CENTER, Colors::WHITE, CGI->generaltexth->arraytxt[206 + whoCanPlay]);
+	labelWhoCanPlay = std::make_shared<CMultiLineLabel>(Rect(6, 23, 45, font->getLineHeight()*2), EFonts::FONT_TINY, ETextAlignment::TOPCENTER, Colors::WHITE, CGI->generaltexth->arraytxt[206 + whoCanPlay]);
 
 	auto hasHandicap = [this](){ return s->handicap.startBonus.empty() && s->handicap.percentIncome == 100 && s->handicap.percentGrowth == 100; };
 	std::string labelHandicapText = hasHandicap() ? CGI->generaltexth->arraytxt[210] : MetaString::createFromTextID("vcmi.lobby.handicap").toString();
-	labelHandicap = std::make_shared<CMultiLineLabel>(Rect(57, 24, 47, font->getLineHeight()*2), EFonts::FONT_TINY, ETextAlignment::CENTER, Colors::WHITE, labelHandicapText);
+	labelHandicap = std::make_shared<CMultiLineLabel>(Rect(57, 24, 47, font->getLineHeight()*2), EFonts::FONT_TINY, ETextAlignment::TOPCENTER, Colors::WHITE, labelHandicapText);
 	handicap = std::make_shared<LRClickableArea>(Rect(56, 24, 49, font->getLineHeight()*2), [](){
 		if(!CSH->isHost())
 			return;

--- a/client/renderSDL/CBitmapFont.cpp
+++ b/client/renderSDL/CBitmapFont.cpp
@@ -212,6 +212,12 @@ CBitmapFont::CBitmapFont(const std::string & filename):
 		SDL_FreeSurface(atlasImage);
 		atlasImage = scaledSurface;
 	}
+
+	logGlobal->debug("Loaded BMP font: '%s', height %d, ascent %d",
+					 filename,
+					 getLineHeightScaled(),
+					 getFontAscentScaled()
+					 );
 }
 
 CBitmapFont::~CBitmapFont()

--- a/client/renderSDL/CTrueTypeFont.cpp
+++ b/client/renderSDL/CTrueTypeFont.cpp
@@ -73,6 +73,14 @@ CTrueTypeFont::CTrueTypeFont(const JsonNode & fontConfig):
 	TTF_SetFontStyle(font.get(), getFontStyle(fontConfig));
 	TTF_SetFontHinting(font.get(),TTF_HINTING_MONO);
 
+	logGlobal->debug("Loaded TTF font: '%s', point size %d, height %d, ascent %d, descent %d, line skip %d",
+					 fontConfig["file"].String(),
+					 getPointSize(fontConfig["size"]),
+					 TTF_FontHeight(font.get()),
+					 TTF_FontAscent(font.get()),
+					 TTF_FontDescent(font.get()),
+					 TTF_FontLineSkip(font.get())
+	);
 }
 
 CTrueTypeFont::~CTrueTypeFont() = default;

--- a/client/renderSDL/FontChain.cpp
+++ b/client/renderSDL/FontChain.cpp
@@ -13,8 +13,13 @@
 #include "CTrueTypeFont.h"
 #include "CBitmapFont.h"
 
+#include "../CGameInfo.h"
+
 #include "../../lib/CConfigHandler.h"
+#include "../../lib/modding/CModHandler.h"
 #include "../../lib/texts/TextOperations.h"
+#include "../../lib/texts/CGeneralTextHandler.h"
+#include "../../lib/texts/Languages.h"
 
 void FontChain::renderText(SDL_Surface * surface, const std::string & data, const ColorRGBA & color, const Point & pos) const
 {
@@ -39,7 +44,7 @@ size_t FontChain::getFontAscentScaled() const
 	return maxHeight;
 }
 
-bool FontChain::bitmapFontsPrioritized() const
+bool FontChain::bitmapFontsPrioritized(const std::string & bitmapFontName) const
 {
 	const std::string & fontType = settings["video"]["fontsType"].String();
 	if (fontType == "original")
@@ -55,6 +60,19 @@ bool FontChain::bitmapFontsPrioritized() const
 	if (!vstd::isAlmostEqual(1.0, settings["video"]["fontScalingFactor"].Float()))
 		return false; // If player requested non-100% scaling - use scalable fonts
 
+	std::string modName = CGI->modh->findResourceOrigin(ResourcePath("data/" + bitmapFontName, EResType::BMP_FONT));
+	std::string fontLanguage = CGI->modh->getModLanguage(modName);
+	std::string gameLanguage = CGI->generaltexth->getPreferredLanguage();
+	std::string fontEncoding = Languages::getLanguageOptions(fontLanguage).encoding;
+	std::string gameEncoding = Languages::getLanguageOptions(gameLanguage).encoding;
+
+	// player uses language with different encoding than his bitmap fonts
+	// for example, Polish language with English fonts or Chinese language which can't use H3 fonts at all
+	// this may result in unintended mixing of ttf and bitmap fonts, which may have a bit different look
+	// so in this case prefer ttf fonts that are likely to cover target language better than H3 fonts
+	if (fontEncoding != gameEncoding)
+		return false;
+
 	return true; // else - use original bitmap fonts
 }
 
@@ -65,7 +83,7 @@ void FontChain::addTrueTypeFont(const JsonNode & trueTypeConfig)
 
 void FontChain::addBitmapFont(const std::string & bitmapFilename)
 {
-	if (bitmapFontsPrioritized())
+	if (bitmapFontsPrioritized(bitmapFilename))
 		chain.insert(chain.begin(), std::make_unique<CBitmapFont>(bitmapFilename));
 	else
 		chain.push_back(std::make_unique<CBitmapFont>(bitmapFilename));

--- a/client/renderSDL/FontChain.h
+++ b/client/renderSDL/FontChain.h
@@ -29,7 +29,7 @@ class FontChain final : public IFont
 
 	void renderText(SDL_Surface * surface, const std::string & data, const ColorRGBA & color, const Point & pos) const override;
 	size_t getFontAscentScaled() const override;
-	bool bitmapFontsPrioritized() const;
+	bool bitmapFontsPrioritized(const std::string & bitmapFontName) const;
 public:
 	FontChain() = default;
 

--- a/client/renderSDL/RenderHandler.cpp
+++ b/client/renderSDL/RenderHandler.cpp
@@ -342,6 +342,8 @@ std::shared_ptr<const IFont> RenderHandler::loadFont(EFonts font)
 		return fonts.at(font);
 
 	const int8_t index = static_cast<int8_t>(font);
+	logGlobal->debug("Loading font %d", static_cast<int>(index));
+
 	auto configList = CResourceHandler::get()->getResourcesWithName(JsonPath::builtin("config/fonts.json"));
 	std::shared_ptr<FontChain> loadedFont = std::make_shared<FontChain>();
 	std::string bitmapPath;

--- a/config/fonts.json
+++ b/config/fonts.json
@@ -29,14 +29,14 @@
 	// "noShadow" - if set, this font will not drop any shadow
 	"trueType":
 	{
-		"BIGFONT"  : { "file" : "NotoSerif-Bold.ttf",   "size" : [ 19, 39, 58, 78] },
+		"BIGFONT"  : { "file" : "NotoSerif-Bold.ttf",   "size" : [ 18, 38, 57, 76] },
 		"CALLI10R" : { "file" : "NotoSerif-Bold.ttf",   "size" : [ 12, 24, 36, 48] }, // TODO: find better matching font? This is likely non-free 'Callisto MT' font
 		"CREDITS"  : { "file" : "NotoSerif-Black.ttf",  "size" : [ 22, 44, 66, 88], "outline" : true },
 		"HISCORE"  : { "file" : "NotoSerif-Black.ttf",  "size" : [ 18, 36, 54, 72], "outline" : true },
-		"MEDFONT"  : { "file" : "NotoSerif-Bold.ttf",   "size" : [ 15, 31, 46, 62] },
-		"SMALFONT" : { "file" : "NotoSerif-Medium.ttf", "size" : [ 12, 24, 36, 48] },
+		"MEDFONT"  : { "file" : "NotoSerif-Bold.ttf",   "size" : [ 13, 26, 39, 52] },
+		"SMALFONT" : { "file" : "NotoSerif-Medium.ttf", "size" : [ 11, 22, 33, 44] },
 		"TIMES08R" : { "file" : "NotoSerif-Medium.ttf", "size" : [  8, 16, 24, 32] },
-		"TINY"     : { "file" : "NotoSans-Medium.ttf",  "size" : [  9, 19, 28, 38], "noShadow" : true }, // The only H3 font without shadow
+		"TINY"     : { "file" : "NotoSans-Medium.ttf",  "size" : [  9, 18, 28, 38], "noShadow" : true }, // The only H3 font without shadow
 		"VERD10B"  : { "file" : "NotoSans-Medium.ttf",  "size" : [ 13, 26, 39, 52] }
 	}
 }


### PR DESCRIPTION
- Reduced point size of some fonts to better match H3 (including localized versions). I originally use upper case symbols as reference to match, but upper/lower case size ratio is different in H3 & Noto, so some fonts ended up a little too big.
- Likely fixed #4681. Can confirm that cases described in there are now fine, but haven't made detailed comparison vs before or vs H3
- Tweaked autoselection of ttf/h3 fonts. Now, if player uses languages without H3 fonts (e.g. Chinese) game will always prefer ttf fonts - to avoid excessive mixing of ttf/h3 fonts. Specifically - if font type is set to default (autoselection), game will now prefer ttf fonts if encoding of H3 fonts is different from encoding used by language selected by player.