### PR TITLE
Add 'newBuilding' sound upon hero recruitment in towns

### DIFF
--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -427,6 +427,8 @@ void CPlayerInterface::heroCreated(const CGHeroInstance * hero)
 	EVENT_HANDLER_CALLED_BY_CLIENT;
 	localState->addWanderingHero(hero);
 	adventureInt->onHeroChanged(hero);
+	if(castleInt)
+		CCS->soundh->playSound(soundBase::newBuilding);
 }
 void CPlayerInterface::openTownWindow(const CGTownInstance * town)
 {


### PR DESCRIPTION
A 'newBuilding' sound is going to play when recruiting heroes in taverns present within town screens.