### PR TITLE
Enable autodetection of video scaling parameters

### DIFF
--- a/client/gui/CGuiHandler.cpp
+++ b/client/gui/CGuiHandler.cpp
@@ -250,8 +250,8 @@ void CGuiHandler::setStatusbar(std::shared_ptr<IStatusBar> newStatusBar)
 void CGuiHandler::onScreenResize(bool resolutionChanged)
 {
 	if(resolutionChanged)
-	{
 		screenHandler().onScreenResize();
-	}
+
 	windows().onScreenResize();
+	CCS->curh->onScreenResize();
 }

--- a/client/gui/CursorHandler.cpp
+++ b/client/gui/CursorHandler.cpp
@@ -312,3 +312,8 @@ void CursorHandler::changeCursor(Cursor::ShowType newShowType)
 			break;
 	}
 }
+
+void CursorHandler::onScreenResize()
+{
+	cursor->setImage(getCurrentImage(), getPivotOffset());
+}

--- a/client/gui/CursorHandler.h
+++ b/client/gui/CursorHandler.h
@@ -182,6 +182,7 @@ public:
 
 	void hide();
 	void show();
+	void onScreenResize();
 
 	/// change cursor's positions to (x, y)
 	void cursorMove(const int & x, const int & y);

--- a/client/render/IScreenHandler.h
+++ b/client/render/IScreenHandler.h
@@ -44,6 +44,8 @@ public:
 	/// Dimensions of logical output. Can be different if scaling is used
 	virtual Point getLogicalResolution() const = 0;
 
+	virtual int getInterfaceScalingPercentage() const = 0;
+
 	virtual int getScalingFactor() const = 0;
 
 	/// Window has focus

--- a/client/renderSDL/CursorHardware.cpp
+++ b/client/renderSDL/CursorHardware.cpp
@@ -11,11 +11,14 @@
 #include "StdInc.h"
 #include "CursorHardware.h"
 
+#include "SDL_Extensions.h"
+
 #include "../gui/CGuiHandler.h"
 #include "../render/IScreenHandler.h"
 #include "../render/Colors.h"
 #include "../render/IImage.h"
-#include "SDL_Extensions.h"
+
+#include "../../lib/CConfigHandler.h"
 
 #include <SDL_render.h>
 #include <SDL_events.h>
@@ -45,19 +48,26 @@ void CursorHardware::setVisible(bool on)
 
 void CursorHardware::setImage(std::shared_ptr<IImage> image, const Point & pivotOffset)
 {
-	auto cursorSurface = CSDL_Ext::newSurface(image->dimensions() * GH.screenHandler().getScalingFactor());
+	int cursorScalingPercent = settings["video"]["resolution"]["scaling"].Integer();
+	Point cursorDimensions = image->dimensions() * GH.screenHandler().getScalingFactor();
+	Point cursorDimensionsScaled = image->dimensions() * cursorScalingPercent / 100;
+	Point pivotOffsetScaled = pivotOffset * cursorScalingPercent / 100 / GH.screenHandler().getScalingFactor();
+
+	auto cursorSurface = CSDL_Ext::newSurface(cursorDimensions);
 
 	CSDL_Ext::fillSurface(cursorSurface, CSDL_Ext::toSDL(Colors::TRANSPARENCY));
 
 	image->draw(cursorSurface, Point(0,0));
+	auto cursorSurfaceScaled = CSDL_Ext::scaleSurface(cursorSurface, cursorDimensionsScaled.x, cursorDimensionsScaled.y );
 
 	auto oldCursor = cursor;
-	cursor = SDL_CreateColorCursor(cursorSurface, pivotOffset.x, pivotOffset.y);
+	cursor = SDL_CreateColorCursor(cursorSurfaceScaled, pivotOffsetScaled.x, pivotOffsetScaled.y);
 
 	if (!cursor)
 		logGlobal->error("Failed to set cursor! SDL says %s", SDL_GetError());
 
 	SDL_FreeSurface(cursorSurface);
+	SDL_FreeSurface(cursorSurfaceScaled);
 
 	GH.dispatchMainThread([this, oldCursor](){
 		SDL_SetCursor(cursor);

--- a/client/renderSDL/CursorHardware.cpp
+++ b/client/renderSDL/CursorHardware.cpp
@@ -48,7 +48,9 @@ void CursorHardware::setVisible(bool on)
 
 void CursorHardware::setImage(std::shared_ptr<IImage> image, const Point & pivotOffset)
 {
-	int cursorScalingPercent = settings["video"]["resolution"]["scaling"].Integer();
+	int videoScalingSettings = settings["video"]["resolution"]["scaling"].Integer();
+	float cursorScalingSettings = settings["video"]["cursorScalingFactor"].Float();
+	int cursorScalingPercent = videoScalingSettings * cursorScalingSettings;
 	Point cursorDimensions = image->dimensions() * GH.screenHandler().getScalingFactor();
 	Point cursorDimensionsScaled = image->dimensions() * cursorScalingPercent / 100;
 	Point pivotOffsetScaled = pivotOffset * cursorScalingPercent / 100 / GH.screenHandler().getScalingFactor();

--- a/client/renderSDL/CursorHardware.cpp
+++ b/client/renderSDL/CursorHardware.cpp
@@ -48,7 +48,7 @@ void CursorHardware::setVisible(bool on)
 
 void CursorHardware::setImage(std::shared_ptr<IImage> image, const Point & pivotOffset)
 {
-	int videoScalingSettings = settings["video"]["resolution"]["scaling"].Integer();
+	int videoScalingSettings = GH.screenHandler().getInterfaceScalingPercentage();
 	float cursorScalingSettings = settings["video"]["cursorScalingFactor"].Float();
 	int cursorScalingPercent = videoScalingSettings * cursorScalingSettings;
 	Point cursorDimensions = image->dimensions() * GH.screenHandler().getScalingFactor();

--- a/client/renderSDL/ScreenHandler.cpp
+++ b/client/renderSDL/ScreenHandler.cpp
@@ -335,25 +335,22 @@ EUpscalingFilter ScreenHandler::loadUpscalingFilter() const
 	if (filter != EUpscalingFilter::AUTO)
 		return filter;
 
-	// for now - always fallback to no filter
-	return EUpscalingFilter::NONE;
-
 	// else - autoselect
-//	Point outputResolution = getRenderResolution();
-//	Point logicalResolution = getPreferredLogicalResolution();
-//
-//	float scaleX = static_cast<float>(outputResolution.x) / logicalResolution.x;
-//	float scaleY = static_cast<float>(outputResolution.x) / logicalResolution.x;
-//	float scaling = std::min(scaleX, scaleY);
-//
-//	if (scaling <= 1.0f)
-//		return EUpscalingFilter::NONE;
-//	if (scaling <= 2.0f)
-//		return EUpscalingFilter::XBRZ_2;
-//	if (scaling <= 3.0f)
-//		return EUpscalingFilter::XBRZ_3;
-//
-//	return EUpscalingFilter::XBRZ_4;
+	Point outputResolution = getRenderResolution();
+	Point logicalResolution = getPreferredLogicalResolution();
+
+	float scaleX = static_cast<float>(outputResolution.x) / logicalResolution.x;
+	float scaleY = static_cast<float>(outputResolution.x) / logicalResolution.x;
+	float scaling = std::min(scaleX, scaleY);
+
+	if (scaling <= 1.001f)
+		return EUpscalingFilter::NONE; // running at original resolution or even lower than that - no need for xbrz
+	if (scaling <= 2.001f)
+		return EUpscalingFilter::XBRZ_2; // resolutions below 1200p (including 1080p / FullHD)
+	if (scaling <= 3.001f)
+		return EUpscalingFilter::XBRZ_3; // resolutions below 2400p (including 1440p and 2160p / 4K)
+
+	return EUpscalingFilter::XBRZ_4; // Only for massive displays, e.g. 8K
 }
 
 void ScreenHandler::selectUpscalingFilter()

--- a/client/renderSDL/ScreenHandler.cpp
+++ b/client/renderSDL/ScreenHandler.cpp
@@ -84,12 +84,8 @@ Rect ScreenHandler::convertLogicalPointsToWindow(const Rect & input) const
 	return result;
 }
 
-Point ScreenHandler::getPreferredLogicalResolution() const
+int ScreenHandler::getInterfaceScalingPercentage() const
 {
-	Point renderResolution = getRenderResolution();
-	double reservedAreaWidth = settings["video"]["reservedWidth"].Float();
-	Point availableResolution = Point(renderResolution.x * (1 - reservedAreaWidth), renderResolution.y);
-
 	auto [minimalScaling, maximalScaling] = getSupportedScalingRange();
 
 	int userScaling = settings["video"]["resolution"]["scaling"].Integer();
@@ -110,9 +106,17 @@ Point ScreenHandler::getPreferredLogicalResolution() const
 	}
 
 	int scaling = std::clamp(userScaling, minimalScaling, maximalScaling);
+	return scaling;
+}
 
+Point ScreenHandler::getPreferredLogicalResolution() const
+{
+	Point renderResolution = getRenderResolution();
+	double reservedAreaWidth = settings["video"]["reservedWidth"].Float();
+
+	int scaling = getInterfaceScalingPercentage();
+	Point availableResolution = Point(renderResolution.x * (1 - reservedAreaWidth), renderResolution.y);
 	Point logicalResolution = availableResolution * 100.0 / scaling;
-
 	return logicalResolution;
 }
 

--- a/client/renderSDL/ScreenHandler.cpp
+++ b/client/renderSDL/ScreenHandler.cpp
@@ -93,6 +93,22 @@ Point ScreenHandler::getPreferredLogicalResolution() const
 	auto [minimalScaling, maximalScaling] = getSupportedScalingRange();
 
 	int userScaling = settings["video"]["resolution"]["scaling"].Integer();
+
+	if (userScaling == 0) // autodetection
+	{
+#ifdef VCMI_MOBILE
+		// for mobiles - stay at maximum scaling unless we have large screen
+		// might be better to check screen DPI / physical dimensions, but way more complex, and may result in different edge cases, e.g. chromebooks / tv's
+		int preferredMinimalScaling = 200;
+#else
+		// for PC - avoid downscaling if possible
+		int preferredMinimalScaling = 100;
+#endif
+		// prefer a little below maximum - to give space for extended UI
+		int preferredMaximalScaling = maximalScaling * 10 / 12;
+		userScaling = std::max(std::min(maximalScaling, preferredMinimalScaling), preferredMaximalScaling);
+	}
+
 	int scaling = std::clamp(userScaling, minimalScaling, maximalScaling);
 
 	Point logicalResolution = availableResolution * 100.0 / scaling;

--- a/client/renderSDL/ScreenHandler.h
+++ b/client/renderSDL/ScreenHandler.h
@@ -112,6 +112,8 @@ public:
 
 	int getScalingFactor() const final;
 
+	int getInterfaceScalingPercentage() const final;
+
 	std::vector<Point> getSupportedResolutions() const final;
 	std::vector<Point> getSupportedResolutions(int displayIndex) const;
 	std::tuple<int, int> getSupportedScalingRange() const final;

--- a/client/windows/settings/GeneralOptionsTab.cpp
+++ b/client/windows/settings/GeneralOptionsTab.cpp
@@ -194,10 +194,8 @@ GeneralOptionsTab::GeneralOptionsTab()
 
 	build(config);
 
-	const auto & currentResolution = settings["video"]["resolution"];
-
 	std::shared_ptr<CLabel> scalingLabel = widget<CLabel>("scalingLabel");
-	scalingLabel->setText(scalingToLabelString(currentResolution["scaling"].Integer()));
+	scalingLabel->setText(scalingToLabelString(GH.screenHandler().getInterfaceScalingPercentage()));
 
 	std::shared_ptr<CLabel> longTouchLabel = widget<CLabel>("longTouchLabel");
 	if (longTouchLabel)

--- a/config/schemas/settings.json
+++ b/config/schemas/settings.json
@@ -195,9 +195,9 @@
 					"additionalProperties" : false,
 					"required" : [ "width", "height", "scaling" ],
 					"properties" : {
-						"width"  :  { "type" : "number", "default" : 800 },
-						"height" :  { "type" : "number", "default" : 600 },
-						"scaling" : { "type" : "number", "default" :   0 }
+						"width"  :  { "type" : "number", "default" : 1280 },
+						"height" :  { "type" : "number", "default" :  720 },
+						"scaling" : { "type" : "number", "default" :    0 }
 					}
 				},
 				"reservedWidth" : {

--- a/config/schemas/settings.json
+++ b/config/schemas/settings.json
@@ -195,17 +195,14 @@
 					"additionalProperties" : false,
 					"required" : [ "width", "height", "scaling" ],
 					"properties" : {
-						"width"  : { "type" : "number" },
-						"height" : { "type" : "number" },
-						"scaling" : { "type" : "number" }
-					},
-					"defaultIOS" : {"width" : 800, "height" : 600, "scaling" : 200 },
-					"defaultAndroid" : {"width" : 800, "height" : 600, "scaling" : 200 },
-					"default" : {"width" : 800, "height" : 600, "scaling" : 100 }
+						"width"  :  { "type" : "number", "default" : 800 },
+						"height" :  { "type" : "number", "default" : 600 },
+						"scaling" : { "type" : "number", "default" :   0 }
+					}
 				},
 				"reservedWidth" : {
 					"type" : "number",
-					"defaultIOS" : 0.1, // iOS camera cutout / notch is excluded from available area by SDL
+					"defaultIOS" : 0.1, // iOS camera cutout / notch is not excluded from available area by SDL, handle it this way
 					"default" : 0
 				},
 				"fullscreen" : {

--- a/config/schemas/settings.json
+++ b/config/schemas/settings.json
@@ -184,6 +184,7 @@
 				"targetfps",
 				"vsync",
 				"fontsType",
+				"cursorScalingFactor",
 				"fontScalingFactor",
 				"upscalingFilter",
 				"fontUpscalingFilter",
@@ -252,6 +253,10 @@
 					"type" : "string",
 					"enum" : [ "auto", "original", "scalable" ],
 					"default" : "auto"
+				},
+				"cursorScalingFactor" : {
+					"type" : "number",
+					"default" : 1
 				},
 				"fontScalingFactor" : {
 					"type" : "number",

--- a/config/schemas/settings.json
+++ b/config/schemas/settings.json
@@ -207,7 +207,7 @@
 				},
 				"fullscreen" : {
 					"type" : "boolean",
-					"default" : false
+					"default" : true
 				},
 				"realFullscreen" : {
 					"type" : "boolean",

--- a/launcher/settingsView/csettingsview_moc.cpp
+++ b/launcher/settingsView/csettingsview_moc.cpp
@@ -127,7 +127,12 @@ void CSettingsView::loadSettings()
 #endif
 	fillValidScalingRange();
 
-	ui->spinBoxInterfaceScaling->setValue(settings["video"]["resolution"]["scaling"].Float());
+	ui->buttonScalingAuto->setChecked(settings["video"]["resolution"]["scaling"].Integer() == 0);
+	if (settings["video"]["resolution"]["scaling"].Integer() == 0)
+		ui->spinBoxInterfaceScaling->setValue(100);
+	else
+		ui->spinBoxInterfaceScaling->setValue(settings["video"]["resolution"]["scaling"].Float());
+
 	ui->spinBoxFramerateLimit->setValue(settings["video"]["targetfps"].Float());
 	ui->spinBoxFramerateLimit->setDisabled(settings["video"]["vsync"].Bool());
 	ui->sliderReservedArea->setValue(std::round(settings["video"]["reservedWidth"].Float() * 100));
@@ -174,6 +179,7 @@ void CSettingsView::loadSettings()
 	ui->sliderControllerSticksAcceleration->setValue(settings["input"]["controllerAxisScale"].Float() * 100);
 	ui->lineEditGameLobbyHost->setText(QString::fromStdString(settings["lobby"]["hostname"].String()));
 	ui->spinBoxNetworkPortLobby->setValue(settings["lobby"]["port"].Integer());
+	ui->buttonVSync->setChecked(settings["video"]["vsync"].Bool());
 
 	if (settings["video"]["fontsType"].String() == "auto")
 		ui->buttonFontAuto->setChecked(true);
@@ -195,7 +201,6 @@ void CSettingsView::loadSettings()
 void CSettingsView::loadToggleButtonSettings()
 {
 	setCheckbuttonState(ui->buttonShowIntro, settings["video"]["showIntro"].Bool());
-	setCheckbuttonState(ui->buttonVSync, settings["video"]["vsync"].Bool());
 	setCheckbuttonState(ui->buttonAutoCheck, settings["launcher"]["autoCheckRepositories"].Bool());
 
 	setCheckbuttonState(ui->buttonRepositoryDefault, settings["launcher"]["defaultRepositoryEnabled"].Bool());
@@ -212,9 +217,14 @@ void CSettingsView::loadToggleButtonSettings()
 	std::string cursorType = settings["video"]["cursor"].String();
 	int cursorTypeIndex = vstd::find_pos(cursorTypesList, cursorType);
 	setCheckbuttonState(ui->buttonCursorType, cursorTypeIndex);
+	ui->sliderScalingCursor->setDisabled(cursorType == "software"); // Not supported
+	ui->labelScalingCursorValue->setDisabled(cursorType == "software"); // Not supported
 
 	int fontScalingPercentage = settings["video"]["fontScalingFactor"].Float() * 100;
 	ui->sliderScalingFont->setValue(fontScalingPercentage / 5);
+
+	int cursorScalingPercentage = settings["video"]["cursorScalingFactor"].Float() * 100;
+	ui->sliderScalingCursor->setValue(cursorScalingPercentage / 5);
 
 }
 
@@ -494,6 +504,8 @@ void CSettingsView::on_buttonCursorType_toggled(bool value)
 	Settings node = settings.write["video"]["cursor"];
 	node->String() = cursorTypesList[value ? 1 : 0];
 	updateCheckbuttonText(ui->buttonCursorType);
+	ui->sliderScalingCursor->setDisabled(value == 1); // Not supported
+	ui->labelScalingCursorValue->setDisabled(value == 1); // Not supported
 }
 
 void CSettingsView::loadTranslation()
@@ -627,7 +639,6 @@ void CSettingsView::on_buttonVSync_toggled(bool value)
 	Settings node = settings.write["video"]["vsync"];
 	node->Bool() = value;
 	ui->spinBoxFramerateLimit->setDisabled(settings["video"]["vsync"].Bool());
-	updateCheckbuttonText(ui->buttonVSync);
 }
 
 void CSettingsView::on_comboBoxEnemyPlayerAI_currentTextChanged(const QString &arg1)
@@ -816,3 +827,21 @@ void CSettingsView::on_buttonValidationFull_clicked(bool checked)
 	Settings node = settings.write["mods"]["validation"];
 	node->String() = "full";
 }
+
+void CSettingsView::on_sliderScalingCursor_valueChanged(int value)
+{
+	int actualValuePercentage = value * 5;
+	ui->labelScalingCursorValue->setText(QString("%1%").arg(actualValuePercentage));
+	Settings node = settings.write["video"]["cursorScalingFactor"];
+	node->Float() = actualValuePercentage / 100.0;
+}
+
+void CSettingsView::on_buttonScalingAuto_toggled(bool checked)
+{
+	ui->spinBoxInterfaceScaling->setDisabled(checked);
+	ui->spinBoxInterfaceScaling->setValue(100);
+
+	Settings node = settings.write["video"]["resolution"]["scaling"];
+	node->Integer() = checked ? 0 : 100;
+}
+

--- a/launcher/settingsView/csettingsview_moc.h
+++ b/launcher/settingsView/csettingsview_moc.h
@@ -97,6 +97,10 @@ private slots:
 
 	void on_buttonValidationFull_clicked(bool checked);
 
+	void on_sliderScalingCursor_valueChanged(int value);
+
+	void on_buttonScalingAuto_toggled(bool checked);
+
 private:
 	Ui::CSettingsView * ui;
 

--- a/launcher/settingsView/csettingsview_moc.ui
+++ b/launcher/settingsView/csettingsview_moc.ui
@@ -47,209 +47,119 @@
       <property name="geometry">
        <rect>
         <x>0</x>
-        <y>-800</y>
+        <y>-126</y>
         <width>729</width>
-        <height>1506</height>
+        <height>1503</height>
        </rect>
       </property>
-      <layout class="QGridLayout" name="gridLayout" columnstretch="20,3,7,10,10">
-       <item row="4" column="1" colspan="3">
+      <layout class="QGridLayout" name="gridLayout" columnstretch="20,5,5,5,5,10">
+       <item row="22" column="1" colspan="5">
+        <widget class="QToolButton" name="buttonCursorType">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="60" column="0">
+        <widget class="QLabel" name="labelModsValidation">
+         <property name="text">
+          <string>Mods Validation</string>
+         </property>
+        </widget>
+       </item>
+       <item row="24" column="1" colspan="5">
+        <widget class="QComboBox" name="comboBoxUpscalingFilter">
+         <item>
+          <property name="text">
+           <string>Automatic</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>None</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>xBRZ x2</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>xBRZ x3</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>xBRZ x4</string>
+          </property>
+         </item>
+        </widget>
+       </item>
+       <item row="43" column="1" colspan="5">
+        <widget class="QSlider" name="sliderControllerSticksSensitivity">
+         <property name="minimum">
+          <number>500</number>
+         </property>
+         <property name="maximum">
+          <number>2500</number>
+         </property>
+         <property name="singleStep">
+          <number>25</number>
+         </property>
+         <property name="pageStep">
+          <number>250</number>
+         </property>
+         <property name="value">
+          <number>500</number>
+         </property>
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="tickPosition">
+          <enum>QSlider::TicksAbove</enum>
+         </property>
+         <property name="tickInterval">
+          <number>250</number>
+         </property>
+        </widget>
+       </item>
+       <item row="35" column="1" colspan="5">
+        <widget class="QPushButton" name="pushButtonResetTutorialTouchscreen">
+         <property name="text">
+          <string>Reset</string>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="1" colspan="4">
         <widget class="QLabel" name="labelTranslationStatus">
          <property name="text">
           <string/>
          </property>
         </widget>
        </item>
-       <item row="42" column="1" colspan="4">
-        <widget class="QSlider" name="sliderToleranceDistanceController">
+       <item row="39" column="1" colspan="5">
+        <widget class="QSlider" name="sliderLongTouchDuration">
          <property name="minimum">
-          <number>0</number>
-         </property>
-         <property name="maximum">
-          <number>50</number>
-         </property>
-         <property name="singleStep">
-          <number>1</number>
-         </property>
-         <property name="pageStep">
-          <number>10</number>
-         </property>
-         <property name="value">
-          <number>0</number>
-         </property>
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="tickPosition">
-          <enum>QSlider::TicksAbove</enum>
-         </property>
-         <property name="tickInterval">
-          <number>10</number>
-         </property>
-        </widget>
-       </item>
-       <item row="22" column="0">
-        <widget class="QLabel" name="labelUpscalingFilter">
-         <property name="text">
-          <string>Upscaling Filter</string>
-         </property>
-        </widget>
-       </item>
-       <item row="41" column="1" colspan="4">
-        <widget class="QSlider" name="sliderControllerSticksAcceleration">
-         <property name="minimum">
-          <number>100</number>
-         </property>
-         <property name="maximum">
           <number>500</number>
          </property>
-         <property name="singleStep">
-          <number>10</number>
-         </property>
-         <property name="pageStep">
-          <number>100</number>
-         </property>
-         <property name="value">
-          <number>100</number>
-         </property>
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="tickPosition">
-          <enum>QSlider::TicksAbove</enum>
-         </property>
-         <property name="tickInterval">
-          <number>50</number>
-         </property>
-        </widget>
-       </item>
-       <item row="47" column="1" colspan="4">
-        <widget class="QComboBox" name="comboBoxFriendlyAI">
-         <property name="editable">
-          <bool>false</bool>
-         </property>
-         <property name="currentText">
-          <string notr="true">BattleAI</string>
-         </property>
-         <item>
-          <property name="text">
-           <string notr="true">BattleAI</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string notr="true">StupidAI</string>
-          </property>
-         </item>
-        </widget>
-       </item>
-       <item row="53" column="0">
-        <widget class="QLabel" name="labelRepositoryExtra">
-         <property name="text">
-          <string>Additional repository</string>
-         </property>
-        </widget>
-       </item>
-       <item row="50" column="0">
-        <widget class="QLabel" name="labelIgnoreSslErrors">
-         <property name="text">
-          <string>Ignore SSL errors</string>
-         </property>
-        </widget>
-       </item>
-       <item row="23" column="1" colspan="4">
-        <widget class="QComboBox" name="comboBoxDownscalingFilter">
-         <item>
-          <property name="text">
-           <string>Nearest</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Linear</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Automatic (Linear)</string>
-          </property>
-         </item>
-        </widget>
-       </item>
-       <item row="1" column="0">
-        <widget class="QLabel" name="labelLanguage">
-         <property name="text">
-          <string>VCMI Language</string>
-         </property>
-        </widget>
-       </item>
-       <item row="24" column="1" colspan="2">
-        <widget class="QToolButton" name="buttonFontAuto">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="text">
-          <string>Automatic</string>
-         </property>
-         <property name="checkable">
-          <bool>true</bool>
-         </property>
-         <property name="autoExclusive">
-          <bool>true</bool>
-         </property>
-         <attribute name="buttonGroup">
-          <string notr="true">buttonGroupFonts</string>
-         </attribute>
-        </widget>
-       </item>
-       <item row="9" column="0">
-        <widget class="QLabel" name="labelVideo">
-         <property name="font">
-          <font>
-           <bold>true</bold>
-          </font>
-         </property>
-         <property name="text">
-          <string>Video</string>
-         </property>
-         <property name="margin">
-          <number>5</number>
-         </property>
-        </widget>
-       </item>
-       <item row="18" column="0">
-        <widget class="QLabel" name="labelShowIntro">
-         <property name="text">
-          <string>Show intro</string>
-         </property>
-        </widget>
-       </item>
-       <item row="4" column="0">
-        <widget class="QLabel" name="labelTranslation">
-         <property name="text">
-          <string>Heroes III Translation</string>
-         </property>
-        </widget>
-       </item>
-       <item row="30" column="1" colspan="4">
-        <widget class="QSlider" name="slideToleranceDistanceMouse">
-         <property name="minimum">
-          <number>0</number>
-         </property>
          <property name="maximum">
-          <number>50</number>
+          <number>2000</number>
          </property>
          <property name="singleStep">
-          <number>1</number>
+          <number>250</number>
          </property>
          <property name="pageStep">
-          <number>10</number>
-         </property>
-         <property name="value">
-          <number>0</number>
+          <number>250</number>
          </property>
          <property name="orientation">
           <enum>Qt::Horizontal</enum>
@@ -258,169 +168,11 @@
           <enum>QSlider::TicksAbove</enum>
          </property>
          <property name="tickInterval">
-          <number>10</number>
+          <number>250</number>
          </property>
         </widget>
        </item>
-       <item row="24" column="3">
-        <widget class="QToolButton" name="buttonFontScalable">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="text">
-          <string>Scalable</string>
-         </property>
-         <property name="checkable">
-          <bool>true</bool>
-         </property>
-         <property name="autoExclusive">
-          <bool>true</bool>
-         </property>
-         <attribute name="buttonGroup">
-          <string notr="true">buttonGroupFonts</string>
-         </attribute>
-        </widget>
-       </item>
-       <item row="38" column="0">
-        <widget class="QLabel" name="labelToleranceDistanceTouch">
-         <property name="text">
-          <string>Touch Tap Tolerance</string>
-         </property>
-        </widget>
-       </item>
-       <item row="53" column="2" colspan="3">
-        <widget class="QLineEdit" name="lineEditRepositoryExtra">
-         <property name="text">
-          <string notr="true"/>
-         </property>
-        </widget>
-       </item>
-       <item row="27" column="1" colspan="4">
-        <widget class="QSlider" name="sliderMusicVolume">
-         <property name="maximum">
-          <number>100</number>
-         </property>
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="tickPosition">
-          <enum>QSlider::TicksAbove</enum>
-         </property>
-         <property name="tickInterval">
-          <number>10</number>
-         </property>
-        </widget>
-       </item>
-       <item row="7" column="1" colspan="4">
-        <widget class="QSpinBox" name="spinBoxAutoSaveLimit"/>
-       </item>
-       <item row="20" column="0">
-        <widget class="QLabel" name="labelRendererType">
-         <property name="text">
-          <string>Renderer</string>
-         </property>
-        </widget>
-       </item>
-       <item row="43" column="0">
-        <widget class="QLabel" name="labelArtificialIntelligence">
-         <property name="font">
-          <font>
-           <bold>true</bold>
-          </font>
-         </property>
-         <property name="text">
-          <string>Artificial Intelligence</string>
-         </property>
-         <property name="margin">
-          <number>5</number>
-         </property>
-        </widget>
-       </item>
-       <item row="46" column="0">
-        <widget class="QLabel" name="labelNeutralAI">
-         <property name="text">
-          <string>Neutral AI in battles</string>
-         </property>
-        </widget>
-       </item>
-       <item row="16" column="0">
-        <widget class="QLabel" name="labelVSync">
-         <property name="text">
-          <string>VSync</string>
-         </property>
-        </widget>
-       </item>
-       <item row="15" column="0">
-        <widget class="QLabel" name="labelFramerateLimit">
-         <property name="text">
-          <string>Framerate Limit</string>
-         </property>
-        </widget>
-       </item>
-       <item row="8" column="2" colspan="3">
-        <widget class="QLineEdit" name="lineEditAutoSavePrefix">
-         <property name="placeholderText">
-          <string>empty = map name prefix</string>
-         </property>
-        </widget>
-       </item>
-       <item row="31" column="0">
-        <widget class="QLabel" name="labelInputMouse_2">
-         <property name="font">
-          <font>
-           <bold>true</bold>
-          </font>
-         </property>
-         <property name="text">
-          <string>Input - Touchscreen</string>
-         </property>
-         <property name="margin">
-          <number>5</number>
-         </property>
-        </widget>
-       </item>
-       <item row="38" column="1" colspan="4">
-        <widget class="QSlider" name="sliderToleranceDistanceTouch">
-         <property name="minimum">
-          <number>0</number>
-         </property>
-         <property name="maximum">
-          <number>50</number>
-         </property>
-         <property name="singleStep">
-          <number>1</number>
-         </property>
-         <property name="pageStep">
-          <number>10</number>
-         </property>
-         <property name="value">
-          <number>0</number>
-         </property>
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="tickPosition">
-          <enum>QSlider::TicksAbove</enum>
-         </property>
-         <property name="tickInterval">
-          <number>10</number>
-         </property>
-        </widget>
-       </item>
-       <item row="34" column="0">
-        <widget class="QLabel" name="labelRelativeCursorSpeed">
-         <property name="text">
-          <string>Relative Pointer Speed</string>
-         </property>
-        </widget>
-       </item>
-       <item row="10" column="1" colspan="4">
-        <widget class="QComboBox" name="comboBoxResolution"/>
-       </item>
-       <item row="51" column="1">
+       <item row="54" column="1">
         <widget class="QToolButton" name="buttonAutoCheck">
          <property name="enabled">
           <bool>true</bool>
@@ -442,8 +194,56 @@
          </property>
         </widget>
        </item>
-       <item row="18" column="1" colspan="4">
-        <widget class="QToolButton" name="buttonShowIntro">
+       <item row="13" column="0">
+        <widget class="QLabel" name="labelReservedArea">
+         <property name="text">
+          <string>Reserved screen area</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="0">
+        <widget class="QLabel" name="labelGeneral">
+         <property name="font">
+          <font>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>General</string>
+         </property>
+         <property name="margin">
+          <number>5</number>
+         </property>
+        </widget>
+       </item>
+       <item row="6" column="0">
+        <widget class="QLabel" name="labelAutoSave">
+         <property name="text">
+          <string>Autosave</string>
+         </property>
+        </widget>
+       </item>
+       <item row="30" column="1" colspan="5">
+        <widget class="QSlider" name="sliderMusicVolume">
+         <property name="maximum">
+          <number>100</number>
+         </property>
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="tickPosition">
+          <enum>QSlider::TicksAbove</enum>
+         </property>
+         <property name="tickInterval">
+          <number>10</number>
+         </property>
+        </widget>
+       </item>
+       <item row="55" column="1">
+        <widget class="QToolButton" name="buttonRepositoryDefault">
+         <property name="enabled">
+          <bool>true</bool>
+         </property>
          <property name="sizePolicy">
           <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
            <horstretch>0</horstretch>
@@ -456,26 +256,341 @@
          <property name="checkable">
           <bool>true</bool>
          </property>
-        </widget>
-       </item>
-       <item row="36" column="0">
-        <widget class="QLabel" name="labelLongTouchDuration">
-         <property name="text">
-          <string>Long Touch Duration</string>
+         <property name="checked">
+          <bool>false</bool>
          </property>
         </widget>
        </item>
-       <item row="19" column="1" colspan="4">
-        <widget class="QComboBox" name="comboBoxDisplayIndex"/>
-       </item>
-       <item row="51" column="0">
-        <widget class="QLabel" name="labelAutoCheck">
+       <item row="60" column="4">
+        <widget class="QToolButton" name="buttonValidationBasic">
+         <property name="enabled">
+          <bool>true</bool>
+         </property>
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
          <property name="text">
-          <string>Check on startup</string>
+          <string>Basic</string>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+         <property name="checked">
+          <bool>false</bool>
+         </property>
+         <attribute name="buttonGroup">
+          <string notr="true">buttonGroupValidation</string>
+         </attribute>
+        </widget>
+       </item>
+       <item row="31" column="0">
+        <widget class="QLabel" name="labelSoundVolume">
+         <property name="text">
+          <string>Sound Volume</string>
          </property>
         </widget>
        </item>
-       <item row="53" column="1">
+       <item row="38" column="0">
+        <widget class="QLabel" name="labelHapticFeedback">
+         <property name="text">
+          <string>Haptic Feedback</string>
+         </property>
+        </widget>
+       </item>
+       <item row="41" column="0">
+        <widget class="QLabel" name="labelToleranceDistanceTouch">
+         <property name="text">
+          <string>Touch Tap Tolerance</string>
+         </property>
+        </widget>
+       </item>
+       <item row="21" column="1" colspan="5">
+        <widget class="QComboBox" name="comboBoxRendererType"/>
+       </item>
+       <item row="1" column="1" colspan="5">
+        <widget class="QComboBox" name="comboBoxLanguage"/>
+       </item>
+       <item row="58" column="1" colspan="5">
+        <widget class="QSpinBox" name="spinBoxNetworkPortLobby">
+         <property name="minimum">
+          <number>1024</number>
+         </property>
+         <property name="maximum">
+          <number>65535</number>
+         </property>
+         <property name="value">
+          <number>3030</number>
+         </property>
+        </widget>
+       </item>
+       <item row="60" column="5">
+        <widget class="QToolButton" name="buttonValidationFull">
+         <property name="enabled">
+          <bool>true</bool>
+         </property>
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Full</string>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+         <property name="checked">
+          <bool>false</bool>
+         </property>
+         <attribute name="buttonGroup">
+          <string notr="true">buttonGroupValidation</string>
+         </attribute>
+        </widget>
+       </item>
+       <item row="42" column="0">
+        <widget class="QLabel" name="labelInputMouse_3">
+         <property name="font">
+          <font>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>Input - Controller</string>
+         </property>
+         <property name="margin">
+          <number>5</number>
+         </property>
+        </widget>
+       </item>
+       <item row="23" column="2" colspan="4">
+        <widget class="QSlider" name="sliderScalingCursor">
+         <property name="minimum">
+          <number>10</number>
+         </property>
+         <property name="maximum">
+          <number>30</number>
+         </property>
+         <property name="singleStep">
+          <number>1</number>
+         </property>
+         <property name="pageStep">
+          <number>2</number>
+         </property>
+         <property name="value">
+          <number>20</number>
+         </property>
+         <property name="sliderPosition">
+          <number>20</number>
+         </property>
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="tickPosition">
+          <enum>QSlider::TicksAbove</enum>
+         </property>
+         <property name="tickInterval">
+          <number>2</number>
+         </property>
+        </widget>
+       </item>
+       <item row="22" column="0">
+        <widget class="QLabel" name="labelCursorType">
+         <property name="text">
+          <string>Software Cursor</string>
+         </property>
+        </widget>
+       </item>
+       <item row="47" column="1" colspan="5">
+        <widget class="QComboBox" name="comboBoxEnemyPlayerAI">
+         <property name="currentText">
+          <string notr="true">VCAI</string>
+         </property>
+         <item>
+          <property name="text">
+           <string notr="true">VCAI</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string notr="true">Nullkiller</string>
+          </property>
+         </item>
+        </widget>
+       </item>
+       <item row="55" column="2" colspan="4">
+        <widget class="QLineEdit" name="lineEditRepositoryDefault">
+         <property name="text">
+          <string notr="true"/>
+         </property>
+         <property name="readOnly">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="48" column="1" colspan="5">
+        <widget class="QComboBox" name="comboBoxAlliedPlayerAI">
+         <property name="currentText">
+          <string notr="true">VCAI</string>
+         </property>
+         <item>
+          <property name="text">
+           <string notr="true">VCAI</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string notr="true">Nullkiller</string>
+          </property>
+         </item>
+        </widget>
+       </item>
+       <item row="4" column="0">
+        <widget class="QLabel" name="labelTranslation">
+         <property name="text">
+          <string>Heroes III Translation</string>
+         </property>
+        </widget>
+       </item>
+       <item row="46" column="0">
+        <widget class="QLabel" name="labelArtificialIntelligence">
+         <property name="font">
+          <font>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>Artificial Intelligence</string>
+         </property>
+         <property name="margin">
+          <number>5</number>
+         </property>
+        </widget>
+       </item>
+       <item row="55" column="0">
+        <widget class="QLabel" name="labelRepositoryDefault">
+         <property name="text">
+          <string>Default repository</string>
+         </property>
+        </widget>
+       </item>
+       <item row="27" column="1">
+        <widget class="QLabel" name="labelScalingFontValue"/>
+       </item>
+       <item row="14" column="4" colspan="2">
+        <widget class="QSpinBox" name="spinBoxInterfaceScaling">
+         <property name="suffix">
+          <string>%</string>
+         </property>
+         <property name="minimum">
+          <number>50</number>
+         </property>
+         <property name="maximum">
+          <number>400</number>
+         </property>
+         <property name="singleStep">
+          <number>10</number>
+         </property>
+        </widget>
+       </item>
+       <item row="37" column="0">
+        <widget class="QLabel" name="labelRelativeCursorSpeed">
+         <property name="text">
+          <string>Relative Pointer Speed</string>
+         </property>
+        </widget>
+       </item>
+       <item row="25" column="0">
+        <widget class="QLabel" name="labelDownscalingFilter">
+         <property name="text">
+          <string>Downscaling Filter</string>
+         </property>
+        </widget>
+       </item>
+       <item row="53" column="1" colspan="5">
+        <widget class="QToolButton" name="buttonIgnoreSslErrors">
+         <property name="enabled">
+          <bool>true</bool>
+         </property>
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+         <property name="checked">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="1" colspan="5">
+        <widget class="QSpinBox" name="spinBoxNetworkPort">
+         <property name="minimum">
+          <number>1024</number>
+         </property>
+         <property name="maximum">
+          <number>65535</number>
+         </property>
+         <property name="value">
+          <number>3030</number>
+         </property>
+        </widget>
+       </item>
+       <item row="19" column="0">
+        <widget class="QLabel" name="labelShowIntro">
+         <property name="text">
+          <string>Show intro</string>
+         </property>
+        </widget>
+       </item>
+       <item row="26" column="1" colspan="2">
+        <widget class="QToolButton" name="buttonFontAuto">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Automatic</string>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+         <property name="autoExclusive">
+          <bool>true</bool>
+         </property>
+         <attribute name="buttonGroup">
+          <string notr="true">buttonGroupFonts</string>
+         </attribute>
+        </widget>
+       </item>
+       <item row="31" column="1" colspan="5">
+        <widget class="QSlider" name="sliderSoundVolume">
+         <property name="maximum">
+          <number>100</number>
+         </property>
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="tickPosition">
+          <enum>QSlider::TicksAbove</enum>
+         </property>
+         <property name="tickInterval">
+          <number>10</number>
+         </property>
+        </widget>
+       </item>
+       <item row="56" column="1">
         <widget class="QToolButton" name="buttonRepositoryExtra">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
@@ -494,38 +609,28 @@
          </property>
         </widget>
        </item>
-       <item row="39" column="0">
-        <widget class="QLabel" name="labelInputMouse_3">
-         <property name="font">
-          <font>
-           <bold>true</bold>
-          </font>
-         </property>
+       <item row="54" column="2" colspan="4">
+        <widget class="QPushButton" name="refreshRepositoriesButton">
          <property name="text">
-          <string>Input - Controller</string>
-         </property>
-         <property name="margin">
-          <number>5</number>
+          <string>Refresh now</string>
          </property>
         </widget>
        </item>
-       <item row="8" column="1">
-        <widget class="QToolButton" name="buttonAutoSavePrefix">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
+       <item row="48" column="0">
+        <widget class="QLabel" name="labelAlliedPlayerAI">
          <property name="text">
-          <string/>
-         </property>
-         <property name="checkable">
-          <bool>true</bool>
+          <string>Adventure Map Allies</string>
          </property>
         </widget>
        </item>
-       <item row="25" column="2" colspan="3">
+       <item row="49" column="0">
+        <widget class="QLabel" name="labelNeutralAI">
+         <property name="text">
+          <string>Neutral AI in battles</string>
+         </property>
+        </widget>
+       </item>
+       <item row="27" column="2" colspan="4">
         <widget class="QSlider" name="sliderScalingFont">
          <property name="minimum">
           <number>10</number>
@@ -556,14 +661,547 @@
          </property>
         </widget>
        </item>
-       <item row="23" column="0">
-        <widget class="QLabel" name="labelDownscalingFilter">
+       <item row="57" column="1" colspan="5">
+        <widget class="QLineEdit" name="lineEditGameLobbyHost">
          <property name="text">
-          <string>Downscaling Filter</string>
+          <string notr="true"/>
          </property>
         </widget>
        </item>
-       <item row="11" column="1" colspan="4">
+       <item row="20" column="0">
+        <widget class="QLabel" name="labelDisplayIndex">
+         <property name="text">
+          <string>Display index</string>
+         </property>
+        </widget>
+       </item>
+       <item row="36" column="0">
+        <widget class="QLabel" name="labelRelativeCursorMode">
+         <property name="text">
+          <string>Use Relative Pointer Mode</string>
+         </property>
+        </widget>
+       </item>
+       <item row="7" column="1" colspan="5">
+        <widget class="QSpinBox" name="spinBoxAutoSaveLimit"/>
+       </item>
+       <item row="50" column="0">
+        <widget class="QLabel" name="labelFriendlyAI">
+         <property name="text">
+          <string>Autocombat AI in battles</string>
+         </property>
+        </widget>
+       </item>
+       <item row="60" column="1" colspan="2">
+        <widget class="QToolButton" name="buttonValidationOff">
+         <property name="enabled">
+          <bool>true</bool>
+         </property>
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Off</string>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+         <property name="checked">
+          <bool>false</bool>
+         </property>
+         <attribute name="buttonGroup">
+          <string notr="true">buttonGroupValidation</string>
+         </attribute>
+        </widget>
+       </item>
+       <item row="32" column="0">
+        <widget class="QLabel" name="labelInputMouse">
+         <property name="font">
+          <font>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>Input - Mouse</string>
+         </property>
+         <property name="margin">
+          <number>5</number>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="0">
+        <widget class="QLabel" name="labelNetworkPort">
+         <property name="text">
+          <string>Network port</string>
+         </property>
+        </widget>
+       </item>
+       <item row="38" column="1" colspan="5">
+        <widget class="QToolButton" name="buttonHapticFeedback">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="29" column="0">
+        <widget class="QLabel" name="labelAudio">
+         <property name="font">
+          <font>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>Audio</string>
+         </property>
+         <property name="margin">
+          <number>5</number>
+         </property>
+        </widget>
+       </item>
+       <item row="56" column="0">
+        <widget class="QLabel" name="labelRepositoryExtra">
+         <property name="text">
+          <string>Additional repository</string>
+         </property>
+        </widget>
+       </item>
+       <item row="17" column="1" colspan="3">
+        <widget class="QToolButton" name="buttonVSync">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>VSync</string>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="47" column="0">
+        <widget class="QLabel" name="labelEnemyPlayerAI">
+         <property name="text">
+          <string>Adventure Map Enemies</string>
+         </property>
+        </widget>
+       </item>
+       <item row="17" column="0">
+        <widget class="QLabel" name="labelFramerateLimit">
+         <property name="text">
+          <string>Framerate Limit</string>
+         </property>
+        </widget>
+       </item>
+       <item row="26" column="0">
+        <widget class="QLabel" name="labelFonts">
+         <property name="text">
+          <string>Use scalable fonts</string>
+         </property>
+        </widget>
+       </item>
+       <item row="21" column="0">
+        <widget class="QLabel" name="labelRendererType">
+         <property name="text">
+          <string>Renderer</string>
+         </property>
+        </widget>
+       </item>
+       <item row="34" column="0">
+        <widget class="QLabel" name="labelInputMouse_2">
+         <property name="font">
+          <font>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>Input - Touchscreen</string>
+         </property>
+         <property name="margin">
+          <number>5</number>
+         </property>
+        </widget>
+       </item>
+       <item row="13" column="1" colspan="5">
+        <widget class="QSlider" name="sliderReservedArea">
+         <property name="maximum">
+          <number>25</number>
+         </property>
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="tickPosition">
+          <enum>QSlider::TicksAbove</enum>
+         </property>
+         <property name="tickInterval">
+          <number>5</number>
+         </property>
+        </widget>
+       </item>
+       <item row="23" column="1">
+        <widget class="QLabel" name="labelScalingCursorValue"/>
+       </item>
+       <item row="36" column="1" colspan="5">
+        <widget class="QToolButton" name="buttonRelativeCursorMode">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <widget class="QLabel" name="labelLanguage">
+         <property name="text">
+          <string>VCMI Language</string>
+         </property>
+        </widget>
+       </item>
+       <item row="57" column="0">
+        <widget class="QLabel" name="labelGameLobbyHost">
+         <property name="text">
+          <string>Online Lobby address</string>
+         </property>
+        </widget>
+       </item>
+       <item row="58" column="0">
+        <widget class="QLabel" name="labelNetworkPortLobby">
+         <property name="text">
+          <string>Online Lobby port</string>
+         </property>
+        </widget>
+       </item>
+       <item row="45" column="0">
+        <widget class="QLabel" name="labelToleranceDistanceController">
+         <property name="text">
+          <string>Controller Click Tolerance</string>
+         </property>
+        </widget>
+       </item>
+       <item row="49" column="1" colspan="5">
+        <widget class="QComboBox" name="comboBoxNeutralAI">
+         <property name="currentText">
+          <string notr="true">BattleAI</string>
+         </property>
+         <item>
+          <property name="text">
+           <string notr="true">BattleAI</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string notr="true">StupidAI</string>
+          </property>
+         </item>
+        </widget>
+       </item>
+       <item row="25" column="1" colspan="5">
+        <widget class="QComboBox" name="comboBoxDownscalingFilter">
+         <item>
+          <property name="text">
+           <string>Nearest</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Linear</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Automatic (Linear)</string>
+          </property>
+         </item>
+        </widget>
+       </item>
+       <item row="53" column="0">
+        <widget class="QLabel" name="labelIgnoreSslErrors">
+         <property name="text">
+          <string>Ignore SSL errors</string>
+         </property>
+        </widget>
+       </item>
+       <item row="20" column="1" colspan="5">
+        <widget class="QComboBox" name="comboBoxDisplayIndex"/>
+       </item>
+       <item row="35" column="0">
+        <widget class="QLabel" name="labelResetTutorialTouchscreen">
+         <property name="text">
+          <string>Show Tutorial again</string>
+         </property>
+        </widget>
+       </item>
+       <item row="44" column="0">
+        <widget class="QLabel" name="labelControllerSticksAcceleration">
+         <property name="text">
+          <string>Sticks Acceleration</string>
+         </property>
+        </widget>
+       </item>
+       <item row="9" column="0">
+        <widget class="QLabel" name="labelVideo">
+         <property name="font">
+          <font>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>Video</string>
+         </property>
+         <property name="margin">
+          <number>5</number>
+         </property>
+        </widget>
+       </item>
+       <item row="51" column="1" colspan="5">
+        <widget class="QComboBox" name="comboBoxEnemyAI">
+         <property name="editable">
+          <bool>false</bool>
+         </property>
+         <property name="currentText">
+          <string notr="true">BattleAI</string>
+         </property>
+         <item>
+          <property name="text">
+           <string notr="true">BattleAI</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string notr="true">StupidAI</string>
+          </property>
+         </item>
+        </widget>
+       </item>
+       <item row="4" column="5">
+        <widget class="QPushButton" name="pushButtonTranslation">
+         <property name="text">
+          <string/>
+         </property>
+        </widget>
+       </item>
+       <item row="11" column="0">
+        <widget class="QLabel" name="labelFullScreen">
+         <property name="text">
+          <string>Fullscreen</string>
+         </property>
+        </widget>
+       </item>
+       <item row="33" column="0">
+        <widget class="QLabel" name="labelToleranceDistanceMouse">
+         <property name="text">
+          <string>Mouse Click Tolerance</string>
+         </property>
+        </widget>
+       </item>
+       <item row="51" column="0">
+        <widget class="QLabel" name="labelEnemyAI">
+         <property name="text">
+          <string>Enemy AI in battles</string>
+         </property>
+        </widget>
+       </item>
+       <item row="7" column="0">
+        <widget class="QLabel" name="labelAutoSaveLimit">
+         <property name="text">
+          <string>Autosave limit (0 = off)</string>
+         </property>
+        </widget>
+       </item>
+       <item row="41" column="1" colspan="5">
+        <widget class="QSlider" name="sliderToleranceDistanceTouch">
+         <property name="minimum">
+          <number>0</number>
+         </property>
+         <property name="maximum">
+          <number>50</number>
+         </property>
+         <property name="singleStep">
+          <number>1</number>
+         </property>
+         <property name="pageStep">
+          <number>10</number>
+         </property>
+         <property name="value">
+          <number>0</number>
+         </property>
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="tickPosition">
+          <enum>QSlider::TicksAbove</enum>
+         </property>
+         <property name="tickInterval">
+          <number>10</number>
+         </property>
+        </widget>
+       </item>
+       <item row="14" column="0">
+        <widget class="QLabel" name="labelInterfaceScaling">
+         <property name="text">
+          <string>Interface Scaling</string>
+         </property>
+        </widget>
+       </item>
+       <item row="30" column="0">
+        <widget class="QLabel" name="labelMusicVolume">
+         <property name="text">
+          <string>Music Volume</string>
+         </property>
+        </widget>
+       </item>
+       <item row="50" column="1" colspan="5">
+        <widget class="QComboBox" name="comboBoxFriendlyAI">
+         <property name="editable">
+          <bool>false</bool>
+         </property>
+         <property name="currentText">
+          <string notr="true">BattleAI</string>
+         </property>
+         <item>
+          <property name="text">
+           <string notr="true">BattleAI</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string notr="true">StupidAI</string>
+          </property>
+         </item>
+        </widget>
+       </item>
+       <item row="56" column="2" colspan="4">
+        <widget class="QLineEdit" name="lineEditRepositoryExtra">
+         <property name="text">
+          <string notr="true"/>
+         </property>
+        </widget>
+       </item>
+       <item row="23" column="0">
+        <widget class="QLabel" name="labelScalingCursor">
+         <property name="text">
+          <string>Cursor Scaling</string>
+         </property>
+        </widget>
+       </item>
+       <item row="6" column="1" colspan="5">
+        <widget class="QToolButton" name="buttonAutoSave">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="26" column="3" colspan="2">
+        <widget class="QToolButton" name="buttonFontScalable">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Scalable</string>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+         <property name="autoExclusive">
+          <bool>true</bool>
+         </property>
+         <attribute name="buttonGroup">
+          <string notr="true">buttonGroupFonts</string>
+         </attribute>
+        </widget>
+       </item>
+       <item row="52" column="0">
+        <widget class="QLabel" name="labelNetwork">
+         <property name="font">
+          <font>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>Network</string>
+         </property>
+         <property name="margin">
+          <number>5</number>
+         </property>
+        </widget>
+       </item>
+       <item row="59" column="0">
+        <widget class="QLabel" name="labelMiscellaneous">
+         <property name="font">
+          <font>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>Miscellaneous</string>
+         </property>
+         <property name="margin">
+          <number>5</number>
+         </property>
+        </widget>
+       </item>
+       <item row="44" column="1" colspan="5">
+        <widget class="QSlider" name="sliderControllerSticksAcceleration">
+         <property name="minimum">
+          <number>100</number>
+         </property>
+         <property name="maximum">
+          <number>500</number>
+         </property>
+         <property name="singleStep">
+          <number>10</number>
+         </property>
+         <property name="pageStep">
+          <number>100</number>
+         </property>
+         <property name="value">
+          <number>100</number>
+         </property>
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="tickPosition">
+          <enum>QSlider::TicksAbove</enum>
+         </property>
+         <property name="tickInterval">
+          <number>50</number>
+         </property>
+        </widget>
+       </item>
+       <item row="11" column="1" colspan="5">
         <widget class="QComboBox" name="comboBoxFullScreen">
          <property name="toolTip">
           <string>Select display mode for game
@@ -594,14 +1232,155 @@ Fullscreen Exclusive Mode - game will cover entirety of your screen and will use
          </item>
         </widget>
        </item>
-       <item row="24" column="0">
-        <widget class="QLabel" name="labelFonts">
-         <property name="text">
-          <string>Use scalable fonts</string>
+       <item row="17" column="4" colspan="2">
+        <widget class="QSpinBox" name="spinBoxFramerateLimit">
+         <property name="minimum">
+          <number>20</number>
+         </property>
+         <property name="maximum">
+          <number>1000</number>
+         </property>
+         <property name="singleStep">
+          <number>10</number>
          </property>
         </widget>
        </item>
-       <item row="24" column="4">
+       <item row="39" column="0">
+        <widget class="QLabel" name="labelLongTouchDuration">
+         <property name="text">
+          <string>Long Touch Duration</string>
+         </property>
+        </widget>
+       </item>
+       <item row="54" column="0">
+        <widget class="QLabel" name="labelAutoCheck">
+         <property name="text">
+          <string>Check on startup</string>
+         </property>
+        </widget>
+       </item>
+       <item row="45" column="1" colspan="5">
+        <widget class="QSlider" name="sliderToleranceDistanceController">
+         <property name="minimum">
+          <number>0</number>
+         </property>
+         <property name="maximum">
+          <number>50</number>
+         </property>
+         <property name="singleStep">
+          <number>1</number>
+         </property>
+         <property name="pageStep">
+          <number>10</number>
+         </property>
+         <property name="value">
+          <number>0</number>
+         </property>
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="tickPosition">
+          <enum>QSlider::TicksAbove</enum>
+         </property>
+         <property name="tickInterval">
+          <number>10</number>
+         </property>
+        </widget>
+       </item>
+       <item row="8" column="1">
+        <widget class="QToolButton" name="buttonAutoSavePrefix">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="37" column="1" colspan="5">
+        <widget class="QSlider" name="sliderRelativeCursorSpeed">
+         <property name="minimum">
+          <number>100</number>
+         </property>
+         <property name="maximum">
+          <number>300</number>
+         </property>
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="tickPosition">
+          <enum>QSlider::TicksAbove</enum>
+         </property>
+         <property name="tickInterval">
+          <number>25</number>
+         </property>
+        </widget>
+       </item>
+       <item row="27" column="0">
+        <widget class="QLabel" name="labelScalingFont">
+         <property name="text">
+          <string>Font Scaling (experimental)</string>
+         </property>
+        </widget>
+       </item>
+       <item row="19" column="1" colspan="5">
+        <widget class="QToolButton" name="buttonShowIntro">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="33" column="1" colspan="5">
+        <widget class="QSlider" name="slideToleranceDistanceMouse">
+         <property name="minimum">
+          <number>0</number>
+         </property>
+         <property name="maximum">
+          <number>50</number>
+         </property>
+         <property name="singleStep">
+          <number>1</number>
+         </property>
+         <property name="pageStep">
+          <number>10</number>
+         </property>
+         <property name="value">
+          <number>0</number>
+         </property>
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="tickPosition">
+          <enum>QSlider::TicksAbove</enum>
+         </property>
+         <property name="tickInterval">
+          <number>10</number>
+         </property>
+        </widget>
+       </item>
+       <item row="8" column="2" colspan="4">
+        <widget class="QLineEdit" name="lineEditAutoSavePrefix">
+         <property name="placeholderText">
+          <string>empty = map name prefix</string>
+         </property>
+        </widget>
+       </item>
+       <item row="26" column="5">
         <widget class="QToolButton" name="buttonFontOriginal">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
@@ -623,47 +1402,8 @@ Fullscreen Exclusive Mode - game will cover entirety of your screen and will use
          </attribute>
         </widget>
        </item>
-       <item row="20" column="1" colspan="4">
-        <widget class="QComboBox" name="comboBoxRendererType"/>
-       </item>
-       <item row="22" column="1" colspan="4">
-        <widget class="QComboBox" name="comboBoxUpscalingFilter">
-         <item>
-          <property name="text">
-           <string>Automatic</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>None</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>xBRZ x2</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>xBRZ x3</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>xBRZ x4</string>
-          </property>
-         </item>
-        </widget>
-       </item>
-       <item row="55" column="0">
-        <widget class="QLabel" name="labelNetworkPortLobby">
-         <property name="text">
-          <string>Online Lobby port</string>
-         </property>
-        </widget>
-       </item>
-       <item row="35" column="1" colspan="4">
-        <widget class="QToolButton" name="buttonHapticFeedback">
+       <item row="14" column="1" colspan="3">
+        <widget class="QToolButton" name="buttonScalingAuto">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
            <horstretch>0</horstretch>
@@ -671,282 +1411,26 @@ Fullscreen Exclusive Mode - game will cover entirety of your screen and will use
           </sizepolicy>
          </property>
          <property name="text">
-          <string/>
+          <string>Automatic</string>
          </property>
          <property name="checkable">
           <bool>true</bool>
          </property>
         </widget>
        </item>
-       <item row="45" column="1" colspan="4">
-        <widget class="QComboBox" name="comboBoxAlliedPlayerAI">
-         <property name="currentText">
-          <string notr="true">VCAI</string>
-         </property>
-         <item>
-          <property name="text">
-           <string notr="true">VCAI</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string notr="true">Nullkiller</string>
-          </property>
-         </item>
-        </widget>
-       </item>
-       <item row="49" column="0">
-        <widget class="QLabel" name="labelNetwork">
-         <property name="font">
-          <font>
-           <bold>true</bold>
-          </font>
-         </property>
+       <item row="43" column="0">
+        <widget class="QLabel" name="labelControllerSticksSensitivity">
          <property name="text">
-          <string>Network</string>
-         </property>
-         <property name="margin">
-          <number>5</number>
+          <string>Sticks Sensitivity</string>
          </property>
         </widget>
        </item>
-       <item row="51" column="2" colspan="3">
-        <widget class="QPushButton" name="refreshRepositoriesButton">
+       <item row="24" column="0">
+        <widget class="QLabel" name="labelUpscalingFilter">
          <property name="text">
-          <string>Refresh now</string>
+          <string>Upscaling Filter</string>
          </property>
         </widget>
-       </item>
-       <item row="40" column="1" colspan="4">
-        <widget class="QSlider" name="sliderControllerSticksSensitivity">
-         <property name="minimum">
-          <number>500</number>
-         </property>
-         <property name="maximum">
-          <number>2500</number>
-         </property>
-         <property name="singleStep">
-          <number>25</number>
-         </property>
-         <property name="pageStep">
-          <number>250</number>
-         </property>
-         <property name="value">
-          <number>500</number>
-         </property>
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="tickPosition">
-          <enum>QSlider::TicksAbove</enum>
-         </property>
-         <property name="tickInterval">
-          <number>250</number>
-         </property>
-        </widget>
-       </item>
-       <item row="19" column="0">
-        <widget class="QLabel" name="labelDisplayIndex">
-         <property name="text">
-          <string>Display index</string>
-         </property>
-        </widget>
-       </item>
-       <item row="36" column="1" colspan="4">
-        <widget class="QSlider" name="sliderLongTouchDuration">
-         <property name="minimum">
-          <number>500</number>
-         </property>
-         <property name="maximum">
-          <number>2000</number>
-         </property>
-         <property name="singleStep">
-          <number>250</number>
-         </property>
-         <property name="pageStep">
-          <number>250</number>
-         </property>
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="tickPosition">
-          <enum>QSlider::TicksAbove</enum>
-         </property>
-         <property name="tickInterval">
-          <number>250</number>
-         </property>
-        </widget>
-       </item>
-       <item row="48" column="1" colspan="4">
-        <widget class="QComboBox" name="comboBoxEnemyAI">
-         <property name="editable">
-          <bool>false</bool>
-         </property>
-         <property name="currentText">
-          <string notr="true">BattleAI</string>
-         </property>
-         <item>
-          <property name="text">
-           <string notr="true">BattleAI</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string notr="true">StupidAI</string>
-          </property>
-         </item>
-        </widget>
-       </item>
-       <item row="44" column="0">
-        <widget class="QLabel" name="labelEnemyPlayerAI">
-         <property name="text">
-          <string>Adventure Map Enemies</string>
-         </property>
-        </widget>
-       </item>
-       <item row="52" column="2" colspan="3">
-        <widget class="QLineEdit" name="lineEditRepositoryDefault">
-         <property name="text">
-          <string notr="true"/>
-         </property>
-         <property name="readOnly">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item row="32" column="1" colspan="4">
-        <widget class="QPushButton" name="pushButtonResetTutorialTouchscreen">
-         <property name="text">
-          <string>Reset</string>
-         </property>
-        </widget>
-       </item>
-       <item row="32" column="0">
-        <widget class="QLabel" name="labelResetTutorialTouchscreen">
-         <property name="text">
-          <string>Show Tutorial again</string>
-         </property>
-        </widget>
-       </item>
-       <item row="11" column="0">
-        <widget class="QLabel" name="labelFullScreen">
-         <property name="text">
-          <string>Fullscreen</string>
-         </property>
-        </widget>
-       </item>
-       <item row="33" column="0">
-        <widget class="QLabel" name="labelRelativeCursorMode">
-         <property name="text">
-          <string>Use Relative Pointer Mode</string>
-         </property>
-        </widget>
-       </item>
-       <item row="54" column="1" colspan="4">
-        <widget class="QLineEdit" name="lineEditGameLobbyHost">
-         <property name="text">
-          <string notr="true"/>
-         </property>
-        </widget>
-       </item>
-       <item row="41" column="0">
-        <widget class="QLabel" name="labelControllerSticksAcceleration">
-         <property name="text">
-          <string>Sticks Acceleration</string>
-         </property>
-        </widget>
-       </item>
-       <item row="7" column="0">
-        <widget class="QLabel" name="labelAutoSaveLimit">
-         <property name="text">
-          <string>Autosave limit (0 = off)</string>
-         </property>
-        </widget>
-       </item>
-       <item row="30" column="0">
-        <widget class="QLabel" name="labelToleranceDistanceMouse">
-         <property name="text">
-          <string>Mouse Click Tolerance</string>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="0">
-        <widget class="QLabel" name="labelGeneral">
-         <property name="font">
-          <font>
-           <bold>true</bold>
-          </font>
-         </property>
-         <property name="text">
-          <string>General</string>
-         </property>
-         <property name="margin">
-          <number>5</number>
-         </property>
-        </widget>
-       </item>
-       <item row="54" column="0">
-        <widget class="QLabel" name="labelGameLobbyHost">
-         <property name="text">
-          <string>Online Lobby address</string>
-         </property>
-        </widget>
-       </item>
-       <item row="6" column="1" colspan="4">
-        <widget class="QToolButton" name="buttonAutoSave">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="text">
-          <string/>
-         </property>
-         <property name="checkable">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item row="13" column="0">
-        <widget class="QLabel" name="labelInterfaceScaling">
-         <property name="text">
-          <string>Interface Scaling</string>
-         </property>
-        </widget>
-       </item>
-       <item row="52" column="0">
-        <widget class="QLabel" name="labelRepositoryDefault">
-         <property name="text">
-          <string>Default repository</string>
-         </property>
-        </widget>
-       </item>
-       <item row="21" column="1" colspan="4">
-        <widget class="QToolButton" name="buttonCursorType">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="text">
-          <string/>
-         </property>
-         <property name="checkable">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item row="35" column="0">
-        <widget class="QLabel" name="labelHapticFeedback">
-         <property name="text">
-          <string>Haptic Feedback</string>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="1" colspan="4">
-        <widget class="QComboBox" name="comboBoxLanguage"/>
        </item>
        <item row="8" column="0">
         <widget class="QLabel" name="labelAutoSavePrefix">
@@ -955,449 +1439,15 @@ Fullscreen Exclusive Mode - game will cover entirety of your screen and will use
          </property>
         </widget>
        </item>
-       <item row="29" column="0">
-        <widget class="QLabel" name="labelInputMouse">
-         <property name="font">
-          <font>
-           <bold>true</bold>
-          </font>
-         </property>
-         <property name="text">
-          <string>Input - Mouse</string>
-         </property>
-         <property name="margin">
-          <number>5</number>
-         </property>
-        </widget>
-       </item>
-       <item row="12" column="1" colspan="4">
-        <widget class="QSlider" name="sliderReservedArea">
-         <property name="maximum">
-          <number>25</number>
-         </property>
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="tickPosition">
-          <enum>QSlider::TicksAbove</enum>
-         </property>
-         <property name="tickInterval">
-          <number>5</number>
-         </property>
-        </widget>
-       </item>
-       <item row="15" column="1" colspan="4">
-        <widget class="QSpinBox" name="spinBoxFramerateLimit">
-         <property name="minimum">
-          <number>20</number>
-         </property>
-         <property name="maximum">
-          <number>1000</number>
-         </property>
-         <property name="singleStep">
-          <number>10</number>
-         </property>
-        </widget>
-       </item>
-       <item row="55" column="1" colspan="4">
-        <widget class="QSpinBox" name="spinBoxNetworkPortLobby">
-         <property name="minimum">
-          <number>1024</number>
-         </property>
-         <property name="maximum">
-          <number>65535</number>
-         </property>
-         <property name="value">
-          <number>3030</number>
-         </property>
-        </widget>
-       </item>
-       <item row="34" column="1" colspan="4">
-        <widget class="QSlider" name="sliderRelativeCursorSpeed">
-         <property name="minimum">
-          <number>100</number>
-         </property>
-         <property name="maximum">
-          <number>300</number>
-         </property>
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="tickPosition">
-          <enum>QSlider::TicksAbove</enum>
-         </property>
-         <property name="tickInterval">
-          <number>25</number>
-         </property>
-        </widget>
-       </item>
-       <item row="48" column="0">
-        <widget class="QLabel" name="labelEnemyAI">
-         <property name="text">
-          <string>Enemy AI in battles</string>
-         </property>
-        </widget>
-       </item>
        <item row="12" column="0">
-        <widget class="QLabel" name="labelReservedArea">
-         <property name="text">
-          <string>Reserved screen area</string>
-         </property>
-        </widget>
-       </item>
-       <item row="13" column="1" colspan="4">
-        <widget class="QSpinBox" name="spinBoxInterfaceScaling">
-         <property name="suffix">
-          <string>%</string>
-         </property>
-         <property name="minimum">
-          <number>50</number>
-         </property>
-         <property name="maximum">
-          <number>400</number>
-         </property>
-         <property name="singleStep">
-          <number>10</number>
-         </property>
-        </widget>
-       </item>
-       <item row="27" column="0">
-        <widget class="QLabel" name="labelMusicVolume">
-         <property name="text">
-          <string>Music Volume</string>
-         </property>
-        </widget>
-       </item>
-       <item row="46" column="1" colspan="4">
-        <widget class="QComboBox" name="comboBoxNeutralAI">
-         <property name="currentText">
-          <string notr="true">BattleAI</string>
-         </property>
-         <item>
-          <property name="text">
-           <string notr="true">BattleAI</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string notr="true">StupidAI</string>
-          </property>
-         </item>
-        </widget>
-       </item>
-       <item row="6" column="0">
-        <widget class="QLabel" name="labelAutoSave">
-         <property name="text">
-          <string>Autosave</string>
-         </property>
-        </widget>
-       </item>
-       <item row="28" column="1" colspan="4">
-        <widget class="QSlider" name="sliderSoundVolume">
-         <property name="maximum">
-          <number>100</number>
-         </property>
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="tickPosition">
-          <enum>QSlider::TicksAbove</enum>
-         </property>
-         <property name="tickInterval">
-          <number>10</number>
-         </property>
-        </widget>
-       </item>
-       <item row="5" column="0">
-        <widget class="QLabel" name="labelNetworkPort">
-         <property name="text">
-          <string>Network port</string>
-         </property>
-        </widget>
-       </item>
-       <item row="52" column="1">
-        <widget class="QToolButton" name="buttonRepositoryDefault">
-         <property name="enabled">
-          <bool>true</bool>
-         </property>
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="text">
-          <string/>
-         </property>
-         <property name="checkable">
-          <bool>true</bool>
-         </property>
-         <property name="checked">
-          <bool>false</bool>
-         </property>
-        </widget>
-       </item>
-       <item row="10" column="0">
         <widget class="QLabel" name="labelResolution">
          <property name="text">
           <string>Resolution</string>
          </property>
         </widget>
        </item>
-       <item row="33" column="1" colspan="4">
-        <widget class="QToolButton" name="buttonRelativeCursorMode">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="text">
-          <string/>
-         </property>
-         <property name="checkable">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item row="28" column="0">
-        <widget class="QLabel" name="labelSoundVolume">
-         <property name="text">
-          <string>Sound Volume</string>
-         </property>
-        </widget>
-       </item>
-       <item row="42" column="0">
-        <widget class="QLabel" name="labelToleranceDistanceController">
-         <property name="text">
-          <string>Controller Click Tolerance</string>
-         </property>
-        </widget>
-       </item>
-       <item row="45" column="0">
-        <widget class="QLabel" name="labelAlliedPlayerAI">
-         <property name="text">
-          <string>Adventure Map Allies</string>
-         </property>
-        </widget>
-       </item>
-       <item row="56" column="0">
-        <widget class="QLabel" name="labelMiscellaneous">
-         <property name="font">
-          <font>
-           <bold>true</bold>
-          </font>
-         </property>
-         <property name="text">
-          <string>Miscellaneous</string>
-         </property>
-         <property name="margin">
-          <number>5</number>
-         </property>
-        </widget>
-       </item>
-       <item row="5" column="1" colspan="4">
-        <widget class="QSpinBox" name="spinBoxNetworkPort">
-         <property name="minimum">
-          <number>1024</number>
-         </property>
-         <property name="maximum">
-          <number>65535</number>
-         </property>
-         <property name="value">
-          <number>3030</number>
-         </property>
-        </widget>
-       </item>
-       <item row="44" column="1" colspan="4">
-        <widget class="QComboBox" name="comboBoxEnemyPlayerAI">
-         <property name="currentText">
-          <string notr="true">VCAI</string>
-         </property>
-         <item>
-          <property name="text">
-           <string notr="true">VCAI</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string notr="true">Nullkiller</string>
-          </property>
-         </item>
-        </widget>
-       </item>
-       <item row="26" column="0">
-        <widget class="QLabel" name="labelAudio">
-         <property name="font">
-          <font>
-           <bold>true</bold>
-          </font>
-         </property>
-         <property name="text">
-          <string>Audio</string>
-         </property>
-         <property name="margin">
-          <number>5</number>
-         </property>
-        </widget>
-       </item>
-       <item row="16" column="1" colspan="4">
-        <widget class="QToolButton" name="buttonVSync">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="text">
-          <string/>
-         </property>
-         <property name="checkable">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item row="21" column="0">
-        <widget class="QLabel" name="labelCursorType">
-         <property name="text">
-          <string>Software Cursor</string>
-         </property>
-        </widget>
-       </item>
-       <item row="47" column="0">
-        <widget class="QLabel" name="labelFriendlyAI">
-         <property name="text">
-          <string>Autocombat AI in battles</string>
-         </property>
-        </widget>
-       </item>
-       <item row="25" column="1">
-        <widget class="QLabel" name="labelScalingFontValue"/>
-       </item>
-       <item row="4" column="4">
-        <widget class="QPushButton" name="pushButtonTranslation">
-         <property name="text">
-          <string/>
-         </property>
-        </widget>
-       </item>
-       <item row="50" column="1" colspan="4">
-        <widget class="QToolButton" name="buttonIgnoreSslErrors">
-         <property name="enabled">
-          <bool>true</bool>
-         </property>
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="text">
-          <string/>
-         </property>
-         <property name="checkable">
-          <bool>true</bool>
-         </property>
-         <property name="checked">
-          <bool>false</bool>
-         </property>
-        </widget>
-       </item>
-       <item row="25" column="0">
-        <widget class="QLabel" name="labelScalingFont">
-         <property name="text">
-          <string>Font Scaling (experimental)</string>
-         </property>
-        </widget>
-       </item>
-       <item row="40" column="0">
-        <widget class="QLabel" name="labelControllerSticksSensitivity">
-         <property name="text">
-          <string>Sticks Sensitivity</string>
-         </property>
-        </widget>
-       </item>
-       <item row="57" column="0">
-        <widget class="QLabel" name="labelModsValidation">
-         <property name="text">
-          <string>Mods Validation</string>
-         </property>
-        </widget>
-       </item>
-       <item row="57" column="1" colspan="2">
-        <widget class="QToolButton" name="buttonValidationOff">
-         <property name="enabled">
-          <bool>true</bool>
-         </property>
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="text">
-          <string>Off</string>
-         </property>
-         <property name="checkable">
-          <bool>true</bool>
-         </property>
-         <property name="checked">
-          <bool>false</bool>
-         </property>
-         <attribute name="buttonGroup">
-          <string notr="true">buttonGroupValidation</string>
-         </attribute>
-        </widget>
-       </item>
-       <item row="57" column="3">
-        <widget class="QToolButton" name="buttonValidationBasic">
-         <property name="enabled">
-          <bool>true</bool>
-         </property>
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="text">
-          <string>Basic</string>
-         </property>
-         <property name="checkable">
-          <bool>true</bool>
-         </property>
-         <property name="checked">
-          <bool>false</bool>
-         </property>
-         <attribute name="buttonGroup">
-          <string notr="true">buttonGroupValidation</string>
-         </attribute>
-        </widget>
-       </item>
-       <item row="57" column="4">
-        <widget class="QToolButton" name="buttonValidationFull">
-         <property name="enabled">
-          <bool>true</bool>
-         </property>
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="text">
-          <string>Full</string>
-         </property>
-         <property name="checkable">
-          <bool>true</bool>
-         </property>
-         <property name="checked">
-          <bool>false</bool>
-         </property>
-         <attribute name="buttonGroup">
-          <string notr="true">buttonGroupValidation</string>
-         </attribute>
-        </widget>
+       <item row="12" column="1" colspan="5">
+        <widget class="QComboBox" name="comboBoxResolution"/>
        </item>
       </layout>
      </widget>


### PR DESCRIPTION
### Upscaling filter autodetect
If upscaling filter is set to Auto, game will now pick optimal filter based on resolution scaling:
  - unscaled only if game runs at resolution scaling of 100% or less (e.g. 800x600 resolution)
  - xbrz2 if game runs at 101%...200% (e.g. FullHD/1080p or 1440p)
  - xbrz3 if game runs at 201%...300% (e.g. 4K/2160p)
  - xbrz4 if game runs at over 300% resolution scaling (8K so basically never)

### Resolution scaling autodetect
If resolution scaling is not explicitly selected by player, game will set resolution scaling to:
  - 80% of maximum resolution scaling - this will put internal resolution to 720p, giving enough space for UI improvements, e.g. large battle queue, 8 hero slots on adventure map. 
  - on mobiles, if maximum resolution scaling is below 200%, it will be maxed-out - to compensate for small screens (similar logic to what we already have on mobiles). On PC this logic is only present for below 100% screens, so basically never.

### Other
- Hardware cursor size is now automatically scaled to by resolution scaling factor. This fixes massive cursor when xbrz is in use.

TODO:
- [x] Adapt launcher UI to account for resolution scaling autodetection
- [x] Adapt in-game UI to account for resolution scaling autodetection
- [x] Correctly handle automatic resolution scaling in game (e.g. cursor size)
- [x] Consider player-selectable cursor scaling in Launcher
- [x] Consider enabling fullscreen as default