### PR TITLE
Fixes pathfinding via subterranean gates located on right edge of map

### DIFF
--- a/lib/CGameInfoCallback.cpp
+++ b/lib/CGameInfoCallback.cpp
@@ -964,7 +964,7 @@ std::vector<ObjectInstanceID> CGameInfoCallback::getVisibleTeleportObjects(std::
 	vstd::erase_if(ids, [&](const ObjectInstanceID & id) -> bool
 	{
 		const auto * obj = getObj(id, false);
-		return player != PlayerColor::UNFLAGGABLE && (!obj || !isVisible(obj->pos, player));
+		return player != PlayerColor::UNFLAGGABLE && (!obj || !isVisible(obj->visitablePos(), player));
 	});
 	return ids;
 }


### PR DESCRIPTION
In this case, 'pos' is actually outside of map borders, so never visible to a player