### PR TITLE
display attack type(melee/ranged) in popup window

### DIFF
--- a/Mods/vcmi/config/vcmi/chinese.json
+++ b/Mods/vcmi/config/vcmi/chinese.json
@@ -12,7 +12,9 @@
 	"vcmi.adventureMap.monsterThreat.levels.9"  : "压倒性的",
 	"vcmi.adventureMap.monsterThreat.levels.10" : "致命的",
 	"vcmi.adventureMap.monsterThreat.levels.11" : "无法取胜",
-	"vcmi.adventureMap.monsterLevel"            : "\n\n%TOWN%LEVEL级生物",
+	"vcmi.adventureMap.monsterLevel"            : "\n\n%TOWN%LEVEL级%ATTACK_TYPE生物",
+	"vcmi.adventureMap.monsterMeleeType"        : "近战",
+	"vcmi.adventureMap.monsterRangedType"       : "远程",
 
 	"vcmi.adventureMap.confirmRestartGame"     : "你想要重新开始游戏吗？",
 	"vcmi.adventureMap.noTownWithMarket"       : "没有足够的市场。",

--- a/Mods/vcmi/config/vcmi/english.json
+++ b/Mods/vcmi/config/vcmi/english.json
@@ -12,7 +12,9 @@
 	"vcmi.adventureMap.monsterThreat.levels.9"  : "Overpowering",
 	"vcmi.adventureMap.monsterThreat.levels.10" : "Deadly",
 	"vcmi.adventureMap.monsterThreat.levels.11" : "Impossible",
-	"vcmi.adventureMap.monsterLevel"            : "\n\nLevel %LEVEL %TOWN unit",
+	"vcmi.adventureMap.monsterLevel"            : "\n\nLevel %LEVEL %TOWN %ATTACK_TYPE unit",
+	"vcmi.adventureMap.monsterMeleeType"        : "melee",
+	"vcmi.adventureMap.monsterRangedType"       : "ranged",
 
 	"vcmi.adventureMap.confirmRestartGame"               : "Are you sure you want to restart the game?",
 	"vcmi.adventureMap.noTownWithMarket"                 : "There are no available marketplaces!",

--- a/Mods/vcmi/config/vcmi/german.json
+++ b/Mods/vcmi/config/vcmi/german.json
@@ -12,7 +12,9 @@
 	"vcmi.adventureMap.monsterThreat.levels.9"  : "Überwältigend",
 	"vcmi.adventureMap.monsterThreat.levels.10" : "Tödlich",
 	"vcmi.adventureMap.monsterThreat.levels.11" : "Unmöglich",
-	"vcmi.adventureMap.monsterLevel"            : "\n\nStufe %LEVEL %TOWN-Einheit",
+	"vcmi.adventureMap.monsterLevel"            : "\n\nStufe %LEVEL %TOWN-Einheit (%ATTACK_TYPE)",
+	"vcmi.adventureMap.monsterMeleeType"        : "Nahkampf",
+	"vcmi.adventureMap.monsterRangedType"       : "Fernkampf",
 
 	"vcmi.adventureMap.confirmRestartGame"               : "Seid Ihr sicher, dass Ihr das Spiel neu starten wollt?",
 	"vcmi.adventureMap.noTownWithMarket"                 : "Kein Marktplatz verfügbar!",

--- a/lib/mapObjects/CGCreature.cpp
+++ b/lib/mapObjects/CGCreature.cpp
@@ -66,6 +66,18 @@ std::string CGCreature::getHoverText(const CGHeroInstance * hero) const
 	}
 }
 
+std::string CGCreature::getMonsterLevelText() const
+{
+	std::string monsterLevel = VLC->generaltexth->translate("vcmi.adventureMap.monsterLevel");
+	bool isRanged = VLC->creatures()->getById(getCreature())->getBonusBearer()->hasBonusOfType(BonusType::SHOOTER);
+	std::string attackTypeKey = isRanged ? "vcmi.adventureMap.monsterRangedType" : "vcmi.adventureMap.monsterMeleeType";
+	std::string attackType = VLC->generaltexth->translate(attackTypeKey);
+	boost::replace_first(monsterLevel, "%TOWN", (*VLC->townh)[VLC->creatures()->getById(getCreature())->getFaction()]->getNameTranslated());
+	boost::replace_first(monsterLevel, "%LEVEL", std::to_string(VLC->creatures()->getById(getCreature())->getLevel()));
+	boost::replace_first(monsterLevel, "%ATTACK_TYPE", attackType);
+	return monsterLevel;
+}
+
 std::string CGCreature::getPopupText(const CGHeroInstance * hero) const
 {
 	std::string hoverName;
@@ -102,11 +114,7 @@ std::string CGCreature::getPopupText(const CGHeroInstance * hero) const
 
 	if (settings["general"]["enableUiEnhancements"].Bool())
 	{
-		std::string monsterLevel = VLC->generaltexth->translate("vcmi.adventureMap.monsterLevel");
-		boost::replace_first(monsterLevel, "%TOWN", (*VLC->townh)[VLC->creatures()->getById(getCreature())->getFaction()]->getNameTranslated());
-		boost::replace_first(monsterLevel, "%LEVEL", std::to_string(VLC->creatures()->getById(getCreature())->getLevel()));
-		hoverName += monsterLevel;
-
+		hoverName += getMonsterLevelText();
 		hoverName += VLC->generaltexth->translate("vcmi.adventureMap.monsterThreat.title");
 
 		int choice;
@@ -131,7 +139,12 @@ std::string CGCreature::getPopupText(const CGHeroInstance * hero) const
 
 std::string CGCreature::getPopupText(PlayerColor player) const
 {
-	return getHoverText(player);
+	std::string hoverName = getHoverText(player);
+	if (settings["general"]["enableUiEnhancements"].Bool())
+	{
+		hoverName += getMonsterLevelText();
+	}
+	return hoverName;
 }
 
 std::vector<Component> CGCreature::getPopupComponents(PlayerColor player) const

--- a/lib/mapObjects/CGCreature.cpp
+++ b/lib/mapObjects/CGCreature.cpp
@@ -141,9 +141,7 @@ std::string CGCreature::getPopupText(PlayerColor player) const
 {
 	std::string hoverName = getHoverText(player);
 	if (settings["general"]["enableUiEnhancements"].Bool())
-	{
 		hoverName += getMonsterLevelText();
-	}
 	return hoverName;
 }
 

--- a/lib/mapObjects/CGCreature.h
+++ b/lib/mapObjects/CGCreature.h
@@ -81,7 +81,7 @@ private:
 
 	int takenAction(const CGHeroInstance *h, bool allowJoin=true) const; //action on confrontation: -2 - fight, -1 - flee, >=0 - will join for given value of gold (may be 0)
 	void giveReward(const CGHeroInstance * h) const;
-
+	std::string getMonsterLevelText() const;
 };
 
 VCMI_LIB_NAMESPACE_END


### PR DESCRIPTION
 melee/ranged infomation is important for players to determined whether attack or not, so I think it should be displayed in master level message.

if no hero selected, the master level message should be displayed too.

![屏幕截图 2024-10-02 190504](https://github.com/user-attachments/assets/58846df3-6c52-406d-96be-5d1bb30ac46b)

![屏幕截图 2024-10-02 190543](https://github.com/user-attachments/assets/d278c423-3e99-457c-b043-fa59e693b1af)
