### PR TITLE
Detection of potential conflicts between mods

### DIFF
--- a/config/schemas/settings.json
+++ b/config/schemas/settings.json
@@ -3,7 +3,7 @@
 {
 	"type" : "object",
 	"$schema" : "http://json-schema.org/draft-04/schema",
-	"required" : [ "general", "video", "adventure", "battle", "input", "server", "logging", "launcher", "lobby", "gameTweaks" ],
+	"required" : [ "general", "video", "adventure", "battle", "input", "server", "logging", "launcher", "lobby", "gameTweaks", "mods" ],
 	"definitions" : {
 		"logLevelEnum" : {
 			"type" : "string",
@@ -149,6 +149,23 @@
 				}
 			}
 		},
+		
+		"mods" : {
+			"type" : "object",
+			"additionalProperties" : false,
+			"default" : {},
+			"required" : [ 
+				"validation"
+			],
+			"properties" : {
+				"validation" : {
+					"type" : "string",
+					"enum" : [ "off", "basic", "full" ],
+					"default" : "basic"
+				}
+			}
+		},
+		
 		"video" : {
 			"type" : "object",
 			"additionalProperties" : false,

--- a/launcher/settingsView/csettingsview_moc.cpp
+++ b/launcher/settingsView/csettingsview_moc.cpp
@@ -182,6 +182,13 @@ void CSettingsView::loadSettings()
 	else
 		ui->buttonFontScalable->setChecked(true);
 
+	if (settings["mods"]["validation"].String() == "off")
+		ui->buttonValidationOff->setChecked(true);
+	else if (settings["mods"]["validation"].String() == "basic")
+		ui->buttonValidationBasic->setChecked(true);
+	else
+		ui->buttonValidationFull->setChecked(true);
+
 	loadToggleButtonSettings();
 }
 
@@ -790,4 +797,22 @@ void CSettingsView::on_buttonFontOriginal_clicked(bool checked)
 {
 	Settings node = settings.write["video"]["fontsType"];
 	node->String() = "original";
+}
+
+void CSettingsView::on_buttonValidationOff_clicked(bool checked)
+{
+	Settings node = settings.write["mods"]["validation"];
+	node->String() = "off";
+}
+
+void CSettingsView::on_buttonValidationBasic_clicked(bool checked)
+{
+	Settings node = settings.write["mods"]["validation"];
+	node->String() = "basic";
+}
+
+void CSettingsView::on_buttonValidationFull_clicked(bool checked)
+{
+	Settings node = settings.write["mods"]["validation"];
+	node->String() = "full";
 }

--- a/launcher/settingsView/csettingsview_moc.h
+++ b/launcher/settingsView/csettingsview_moc.h
@@ -83,18 +83,19 @@ private slots:
 	void on_sliderToleranceDistanceController_valueChanged(int value);
 	void on_lineEditGameLobbyHost_textChanged(const QString &arg1);
 	void on_spinBoxNetworkPortLobby_valueChanged(int arg1);
-
 	void on_sliderControllerSticksAcceleration_valueChanged(int value);
-
 	void on_sliderControllerSticksSensitivity_valueChanged(int value);
-
-	//void on_buttonTtfFont_toggled(bool value);
-
 	void on_sliderScalingFont_valueChanged(int value);
-
 	void on_buttonFontAuto_clicked(bool checked);
 	void on_buttonFontScalable_clicked(bool checked);
 	void on_buttonFontOriginal_clicked(bool checked);
+
+
+	void on_buttonValidationOff_clicked(bool checked);
+
+	void on_buttonValidationBasic_clicked(bool checked);
+
+	void on_buttonValidationFull_clicked(bool checked);
 
 private:
 	Ui::CSettingsView * ui;

--- a/launcher/settingsView/csettingsview_moc.ui
+++ b/launcher/settingsView/csettingsview_moc.ui
@@ -47,87 +47,18 @@
       <property name="geometry">
        <rect>
         <x>0</x>
-        <y>0</y>
+        <y>-800</y>
         <width>729</width>
-        <height>1449</height>
+        <height>1506</height>
        </rect>
       </property>
       <layout class="QGridLayout" name="gridLayout" columnstretch="20,3,7,10,10">
-       <item row="47" column="1" colspan="4">
-        <widget class="QComboBox" name="comboBoxFriendlyAI">
-         <property name="editable">
-          <bool>false</bool>
-         </property>
-         <property name="currentText">
-          <string notr="true">BattleAI</string>
-         </property>
-         <item>
-          <property name="text">
-           <string notr="true">BattleAI</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string notr="true">StupidAI</string>
-          </property>
-         </item>
-        </widget>
-       </item>
-       <item row="35" column="1" colspan="4">
-        <widget class="QToolButton" name="buttonHapticFeedback">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
+       <item row="4" column="1" colspan="3">
+        <widget class="QLabel" name="labelTranslationStatus">
          <property name="text">
           <string/>
          </property>
-         <property name="checkable">
-          <bool>true</bool>
-         </property>
         </widget>
-       </item>
-       <item row="33" column="0">
-        <widget class="QLabel" name="labelRelativeCursorMode">
-         <property name="text">
-          <string>Use Relative Pointer Mode</string>
-         </property>
-        </widget>
-       </item>
-       <item row="12" column="1" colspan="4">
-        <widget class="QSlider" name="sliderReservedArea">
-         <property name="maximum">
-          <number>25</number>
-         </property>
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="tickPosition">
-          <enum>QSlider::TicksAbove</enum>
-         </property>
-         <property name="tickInterval">
-          <number>5</number>
-         </property>
-        </widget>
-       </item>
-       <item row="53" column="0">
-        <widget class="QLabel" name="labelRepositoryExtra">
-         <property name="text">
-          <string>Additional repository</string>
-         </property>
-        </widget>
-       </item>
-       <item row="27" column="0">
-        <widget class="QLabel" name="labelMusicVolume">
-         <property name="text">
-          <string>Music Volume</string>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="1" colspan="4">
-        <widget class="QComboBox" name="comboBoxLanguage"/>
        </item>
        <item row="42" column="1" colspan="4">
         <widget class="QSlider" name="sliderToleranceDistanceController">
@@ -157,492 +88,10 @@
          </property>
         </widget>
        </item>
-       <item row="36" column="0">
-        <widget class="QLabel" name="labelLongTouchDuration">
-         <property name="text">
-          <string>Long Touch Duration</string>
-         </property>
-        </widget>
-       </item>
-       <item row="48" column="1" colspan="4">
-        <widget class="QComboBox" name="comboBoxEnemyAI">
-         <property name="editable">
-          <bool>false</bool>
-         </property>
-         <property name="currentText">
-          <string notr="true">BattleAI</string>
-         </property>
-         <item>
-          <property name="text">
-           <string notr="true">BattleAI</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string notr="true">StupidAI</string>
-          </property>
-         </item>
-        </widget>
-       </item>
-       <item row="9" column="0">
-        <widget class="QLabel" name="labelVideo">
-         <property name="font">
-          <font>
-           <bold>true</bold>
-          </font>
-         </property>
-         <property name="text">
-          <string>Video</string>
-         </property>
-         <property name="margin">
-          <number>5</number>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="0">
-        <widget class="QLabel" name="labelGeneral">
-         <property name="font">
-          <font>
-           <bold>true</bold>
-          </font>
-         </property>
-         <property name="text">
-          <string>General</string>
-         </property>
-         <property name="margin">
-          <number>5</number>
-         </property>
-        </widget>
-       </item>
-       <item row="4" column="0">
-        <widget class="QLabel" name="labelTranslation">
-         <property name="text">
-          <string>Heroes III Translation</string>
-         </property>
-        </widget>
-       </item>
-       <item row="32" column="0">
-        <widget class="QLabel" name="labelResetTutorialTouchscreen">
-         <property name="text">
-          <string>Show Tutorial again</string>
-         </property>
-        </widget>
-       </item>
-       <item row="55" column="0">
-        <widget class="QLabel" name="labelNetworkPortLobby">
-         <property name="text">
-          <string>Online Lobby port</string>
-         </property>
-        </widget>
-       </item>
-       <item row="34" column="0">
-        <widget class="QLabel" name="labelRelativeCursorSpeed">
-         <property name="text">
-          <string>Relative Pointer Speed</string>
-         </property>
-        </widget>
-       </item>
-       <item row="38" column="0">
-        <widget class="QLabel" name="labelToleranceDistanceTouch">
-         <property name="text">
-          <string>Touch Tap Tolerance</string>
-         </property>
-        </widget>
-       </item>
-       <item row="11" column="1" colspan="4">
-        <widget class="QComboBox" name="comboBoxFullScreen">
-         <property name="toolTip">
-          <string>Select display mode for game
-
-Windowed - game will run inside a window that covers part of your screen
-
-Borderless Windowed Mode - game will run in a window that covers entirely of your screen, using same resolution as your screen.
-
-Fullscreen Exclusive Mode - game will cover entirety of your screen and will use selected resolution.</string>
-         </property>
-         <property name="currentIndex">
-          <number>0</number>
-         </property>
-         <item>
-          <property name="text">
-           <string>Windowed</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Borderless fullscreen</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Exclusive fullscreen</string>
-          </property>
-         </item>
-        </widget>
-       </item>
-       <item row="36" column="1" colspan="4">
-        <widget class="QSlider" name="sliderLongTouchDuration">
-         <property name="minimum">
-          <number>500</number>
-         </property>
-         <property name="maximum">
-          <number>2000</number>
-         </property>
-         <property name="singleStep">
-          <number>250</number>
-         </property>
-         <property name="pageStep">
-          <number>250</number>
-         </property>
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="tickPosition">
-          <enum>QSlider::TicksAbove</enum>
-         </property>
-         <property name="tickInterval">
-          <number>250</number>
-         </property>
-        </widget>
-       </item>
-       <item row="46" column="0">
-        <widget class="QLabel" name="labelNeutralAI">
-         <property name="text">
-          <string>Neutral AI in battles</string>
-         </property>
-        </widget>
-       </item>
-       <item row="29" column="0">
-        <widget class="QLabel" name="labelInputMouse">
-         <property name="font">
-          <font>
-           <bold>true</bold>
-          </font>
-         </property>
-         <property name="text">
-          <string>Input - Mouse</string>
-         </property>
-         <property name="margin">
-          <number>5</number>
-         </property>
-        </widget>
-       </item>
-       <item row="24" column="1" colspan="2">
-        <widget class="QToolButton" name="buttonFontAuto">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="text">
-          <string>Automatic</string>
-         </property>
-         <property name="checkable">
-          <bool>true</bool>
-         </property>
-         <property name="autoExclusive">
-          <bool>true</bool>
-         </property>
-         <attribute name="buttonGroup">
-          <string notr="true">buttonGroup</string>
-         </attribute>
-        </widget>
-       </item>
-       <item row="44" column="0">
-        <widget class="QLabel" name="labelEnemyPlayerAI">
-         <property name="text">
-          <string>Adventure Map Enemies</string>
-         </property>
-        </widget>
-       </item>
-       <item row="45" column="1" colspan="4">
-        <widget class="QComboBox" name="comboBoxAlliedPlayerAI">
-         <property name="currentText">
-          <string notr="true">VCAI</string>
-         </property>
-         <item>
-          <property name="text">
-           <string notr="true">VCAI</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string notr="true">Nullkiller</string>
-          </property>
-         </item>
-        </widget>
-       </item>
-       <item row="30" column="1" colspan="4">
-        <widget class="QSlider" name="slideToleranceDistanceMouse">
-         <property name="minimum">
-          <number>0</number>
-         </property>
-         <property name="maximum">
-          <number>50</number>
-         </property>
-         <property name="singleStep">
-          <number>1</number>
-         </property>
-         <property name="pageStep">
-          <number>10</number>
-         </property>
-         <property name="value">
-          <number>0</number>
-         </property>
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="tickPosition">
-          <enum>QSlider::TicksAbove</enum>
-         </property>
-         <property name="tickInterval">
-          <number>10</number>
-         </property>
-        </widget>
-       </item>
-       <item row="6" column="0">
-        <widget class="QLabel" name="labelAutoSave">
-         <property name="text">
-          <string>Autosave</string>
-         </property>
-        </widget>
-       </item>
-       <item row="20" column="0">
-        <widget class="QLabel" name="labelRendererType">
-         <property name="text">
-          <string>Renderer</string>
-         </property>
-        </widget>
-       </item>
-       <item row="7" column="0">
-        <widget class="QLabel" name="labelAutoSaveLimit">
-         <property name="text">
-          <string>Autosave limit (0 = off)</string>
-         </property>
-        </widget>
-       </item>
-       <item row="52" column="0">
-        <widget class="QLabel" name="labelRepositoryDefault">
-         <property name="text">
-          <string>Default repository</string>
-         </property>
-        </widget>
-       </item>
-       <item row="27" column="1" colspan="4">
-        <widget class="QSlider" name="sliderMusicVolume">
-         <property name="maximum">
-          <number>100</number>
-         </property>
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="tickPosition">
-          <enum>QSlider::TicksAbove</enum>
-         </property>
-         <property name="tickInterval">
-          <number>10</number>
-         </property>
-        </widget>
-       </item>
-       <item row="40" column="0">
-        <widget class="QLabel" name="labelControllerSticksSensitivity">
-         <property name="text">
-          <string>Sticks Sensitivity</string>
-         </property>
-        </widget>
-       </item>
-       <item row="26" column="0">
-        <widget class="QLabel" name="labelAudio">
-         <property name="font">
-          <font>
-           <bold>true</bold>
-          </font>
-         </property>
-         <property name="text">
-          <string>Audio</string>
-         </property>
-         <property name="margin">
-          <number>5</number>
-         </property>
-        </widget>
-       </item>
-       <item row="10" column="1" colspan="4">
-        <widget class="QComboBox" name="comboBoxResolution"/>
-       </item>
-       <item row="23" column="0">
-        <widget class="QLabel" name="labelDownscalingFilter">
-         <property name="text">
-          <string>Downscaling Filter</string>
-         </property>
-        </widget>
-       </item>
-       <item row="5" column="1" colspan="4">
-        <widget class="QSpinBox" name="spinBoxNetworkPort">
-         <property name="minimum">
-          <number>1024</number>
-         </property>
-         <property name="maximum">
-          <number>65535</number>
-         </property>
-         <property name="value">
-          <number>3030</number>
-         </property>
-        </widget>
-       </item>
-       <item row="38" column="1" colspan="4">
-        <widget class="QSlider" name="sliderToleranceDistanceTouch">
-         <property name="minimum">
-          <number>0</number>
-         </property>
-         <property name="maximum">
-          <number>50</number>
-         </property>
-         <property name="singleStep">
-          <number>1</number>
-         </property>
-         <property name="pageStep">
-          <number>10</number>
-         </property>
-         <property name="value">
-          <number>0</number>
-         </property>
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="tickPosition">
-          <enum>QSlider::TicksAbove</enum>
-         </property>
-         <property name="tickInterval">
-          <number>10</number>
-         </property>
-        </widget>
-       </item>
-       <item row="50" column="0">
-        <widget class="QLabel" name="labelIgnoreSslErrors">
-         <property name="text">
-          <string>Ignore SSL errors</string>
-         </property>
-        </widget>
-       </item>
        <item row="22" column="0">
         <widget class="QLabel" name="labelUpscalingFilter">
          <property name="text">
           <string>Upscaling Filter</string>
-         </property>
-        </widget>
-       </item>
-       <item row="51" column="2" colspan="3">
-        <widget class="QPushButton" name="refreshRepositoriesButton">
-         <property name="text">
-          <string>Refresh now</string>
-         </property>
-        </widget>
-       </item>
-       <item row="51" column="1">
-        <widget class="QToolButton" name="buttonAutoCheck">
-         <property name="enabled">
-          <bool>true</bool>
-         </property>
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="text">
-          <string/>
-         </property>
-         <property name="checkable">
-          <bool>true</bool>
-         </property>
-         <property name="checked">
-          <bool>false</bool>
-         </property>
-        </widget>
-       </item>
-       <item row="16" column="0">
-        <widget class="QLabel" name="labelVSync">
-         <property name="text">
-          <string>VSync</string>
-         </property>
-        </widget>
-       </item>
-       <item row="10" column="0">
-        <widget class="QLabel" name="labelResolution">
-         <property name="text">
-          <string>Resolution</string>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="0">
-        <widget class="QLabel" name="labelLanguage">
-         <property name="text">
-          <string>VCMI Language</string>
-         </property>
-        </widget>
-       </item>
-       <item row="13" column="0">
-        <widget class="QLabel" name="labelInterfaceScaling">
-         <property name="text">
-          <string>Interface Scaling</string>
-         </property>
-        </widget>
-       </item>
-       <item row="7" column="1" colspan="4">
-        <widget class="QSpinBox" name="spinBoxAutoSaveLimit"/>
-       </item>
-       <item row="4" column="4">
-        <widget class="QPushButton" name="pushButtonTranslation">
-         <property name="text">
-          <string/>
-         </property>
-        </widget>
-       </item>
-       <item row="54" column="0">
-        <widget class="QLabel" name="labelGameLobbyHost">
-         <property name="text">
-          <string>Online Lobby address</string>
-         </property>
-        </widget>
-       </item>
-       <item row="44" column="1" colspan="4">
-        <widget class="QComboBox" name="comboBoxEnemyPlayerAI">
-         <property name="currentText">
-          <string notr="true">VCAI</string>
-         </property>
-         <item>
-          <property name="text">
-           <string notr="true">VCAI</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string notr="true">Nullkiller</string>
-          </property>
-         </item>
-        </widget>
-       </item>
-       <item row="21" column="1" colspan="4">
-        <widget class="QToolButton" name="buttonCursorType">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="text">
-          <string/>
-         </property>
-         <property name="checkable">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item row="54" column="1" colspan="4">
-        <widget class="QLineEdit" name="lineEditGameLobbyHost">
-         <property name="text">
-          <string notr="true"/>
          </property>
         </widget>
        </item>
@@ -674,38 +123,37 @@ Fullscreen Exclusive Mode - game will cover entirety of your screen and will use
          </property>
         </widget>
        </item>
-       <item row="8" column="0">
-        <widget class="QLabel" name="labelAutoSavePrefix">
+       <item row="47" column="1" colspan="4">
+        <widget class="QComboBox" name="comboBoxFriendlyAI">
+         <property name="editable">
+          <bool>false</bool>
+         </property>
+         <property name="currentText">
+          <string notr="true">BattleAI</string>
+         </property>
+         <item>
+          <property name="text">
+           <string notr="true">BattleAI</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string notr="true">StupidAI</string>
+          </property>
+         </item>
+        </widget>
+       </item>
+       <item row="53" column="0">
+        <widget class="QLabel" name="labelRepositoryExtra">
          <property name="text">
-          <string>Autosave prefix</string>
+          <string>Additional repository</string>
          </property>
         </widget>
        </item>
-       <item row="12" column="0">
-        <widget class="QLabel" name="labelReservedArea">
+       <item row="50" column="0">
+        <widget class="QLabel" name="labelIgnoreSslErrors">
          <property name="text">
-          <string>Reserved screen area</string>
-         </property>
-        </widget>
-       </item>
-       <item row="28" column="0">
-        <widget class="QLabel" name="labelSoundVolume">
-         <property name="text">
-          <string>Sound Volume</string>
-         </property>
-        </widget>
-       </item>
-       <item row="25" column="0">
-        <widget class="QLabel" name="labelScalingFont">
-         <property name="text">
-          <string>Font Scaling (experimental)</string>
-         </property>
-        </widget>
-       </item>
-       <item row="15" column="0">
-        <widget class="QLabel" name="labelFramerateLimit">
-         <property name="text">
-          <string>Framerate Limit</string>
+          <string>Ignore SSL errors</string>
          </property>
         </widget>
        </item>
@@ -728,8 +176,130 @@ Fullscreen Exclusive Mode - game will cover entirety of your screen and will use
          </item>
         </widget>
        </item>
-       <item row="28" column="1" colspan="4">
-        <widget class="QSlider" name="sliderSoundVolume">
+       <item row="1" column="0">
+        <widget class="QLabel" name="labelLanguage">
+         <property name="text">
+          <string>VCMI Language</string>
+         </property>
+        </widget>
+       </item>
+       <item row="24" column="1" colspan="2">
+        <widget class="QToolButton" name="buttonFontAuto">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Automatic</string>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+         <property name="autoExclusive">
+          <bool>true</bool>
+         </property>
+         <attribute name="buttonGroup">
+          <string notr="true">buttonGroupFonts</string>
+         </attribute>
+        </widget>
+       </item>
+       <item row="9" column="0">
+        <widget class="QLabel" name="labelVideo">
+         <property name="font">
+          <font>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>Video</string>
+         </property>
+         <property name="margin">
+          <number>5</number>
+         </property>
+        </widget>
+       </item>
+       <item row="18" column="0">
+        <widget class="QLabel" name="labelShowIntro">
+         <property name="text">
+          <string>Show intro</string>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="0">
+        <widget class="QLabel" name="labelTranslation">
+         <property name="text">
+          <string>Heroes III Translation</string>
+         </property>
+        </widget>
+       </item>
+       <item row="30" column="1" colspan="4">
+        <widget class="QSlider" name="slideToleranceDistanceMouse">
+         <property name="minimum">
+          <number>0</number>
+         </property>
+         <property name="maximum">
+          <number>50</number>
+         </property>
+         <property name="singleStep">
+          <number>1</number>
+         </property>
+         <property name="pageStep">
+          <number>10</number>
+         </property>
+         <property name="value">
+          <number>0</number>
+         </property>
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="tickPosition">
+          <enum>QSlider::TicksAbove</enum>
+         </property>
+         <property name="tickInterval">
+          <number>10</number>
+         </property>
+        </widget>
+       </item>
+       <item row="24" column="3">
+        <widget class="QToolButton" name="buttonFontScalable">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Scalable</string>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+         <property name="autoExclusive">
+          <bool>true</bool>
+         </property>
+         <attribute name="buttonGroup">
+          <string notr="true">buttonGroupFonts</string>
+         </attribute>
+        </widget>
+       </item>
+       <item row="38" column="0">
+        <widget class="QLabel" name="labelToleranceDistanceTouch">
+         <property name="text">
+          <string>Touch Tap Tolerance</string>
+         </property>
+        </widget>
+       </item>
+       <item row="53" column="2" colspan="3">
+        <widget class="QLineEdit" name="lineEditRepositoryExtra">
+         <property name="text">
+          <string notr="true"/>
+         </property>
+        </widget>
+       </item>
+       <item row="27" column="1" colspan="4">
+        <widget class="QSlider" name="sliderMusicVolume">
          <property name="maximum">
           <number>100</number>
          </property>
@@ -744,56 +314,13 @@ Fullscreen Exclusive Mode - game will cover entirety of your screen and will use
          </property>
         </widget>
        </item>
-       <item row="22" column="1" colspan="4">
-        <widget class="QComboBox" name="comboBoxUpscalingFilter">
-         <item>
-          <property name="text">
-           <string>Automatic</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>None</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>xBRZ x2</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>xBRZ x3</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>xBRZ x4</string>
-          </property>
-         </item>
-        </widget>
+       <item row="7" column="1" colspan="4">
+        <widget class="QSpinBox" name="spinBoxAutoSaveLimit"/>
        </item>
-       <item row="47" column="0">
-        <widget class="QLabel" name="labelFriendlyAI">
+       <item row="20" column="0">
+        <widget class="QLabel" name="labelRendererType">
          <property name="text">
-          <string>Autocombat AI in battles</string>
-         </property>
-        </widget>
-       </item>
-       <item row="24" column="0">
-        <widget class="QLabel" name="labelFonts">
-         <property name="text">
-          <string>Use scalable fonts</string>
-         </property>
-        </widget>
-       </item>
-       <item row="52" column="2" colspan="3">
-        <widget class="QLineEdit" name="lineEditRepositoryDefault">
-         <property name="text">
-          <string notr="true"/>
-         </property>
-         <property name="readOnly">
-          <bool>true</bool>
+          <string>Renderer</string>
          </property>
         </widget>
        </item>
@@ -812,87 +339,24 @@ Fullscreen Exclusive Mode - game will cover entirety of your screen and will use
          </property>
         </widget>
        </item>
-       <item row="11" column="0">
-        <widget class="QLabel" name="labelFullScreen">
+       <item row="46" column="0">
+        <widget class="QLabel" name="labelNeutralAI">
          <property name="text">
-          <string>Fullscreen</string>
+          <string>Neutral AI in battles</string>
          </property>
         </widget>
        </item>
-       <item row="40" column="1" colspan="4">
-        <widget class="QSlider" name="sliderControllerSticksSensitivity">
-         <property name="minimum">
-          <number>500</number>
-         </property>
-         <property name="maximum">
-          <number>2500</number>
-         </property>
-         <property name="singleStep">
-          <number>25</number>
-         </property>
-         <property name="pageStep">
-          <number>250</number>
-         </property>
-         <property name="value">
-          <number>500</number>
-         </property>
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="tickPosition">
-          <enum>QSlider::TicksAbove</enum>
-         </property>
-         <property name="tickInterval">
-          <number>250</number>
-         </property>
-        </widget>
-       </item>
-       <item row="48" column="0">
-        <widget class="QLabel" name="labelEnemyAI">
+       <item row="16" column="0">
+        <widget class="QLabel" name="labelVSync">
          <property name="text">
-          <string>Enemy AI in battles</string>
+          <string>VSync</string>
          </property>
         </widget>
        </item>
-       <item row="41" column="0">
-        <widget class="QLabel" name="labelControllerSticksAcceleration">
+       <item row="15" column="0">
+        <widget class="QLabel" name="labelFramerateLimit">
          <property name="text">
-          <string>Sticks Acceleration</string>
-         </property>
-        </widget>
-       </item>
-       <item row="34" column="1" colspan="4">
-        <widget class="QSlider" name="sliderRelativeCursorSpeed">
-         <property name="minimum">
-          <number>100</number>
-         </property>
-         <property name="maximum">
-          <number>300</number>
-         </property>
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="tickPosition">
-          <enum>QSlider::TicksAbove</enum>
-         </property>
-         <property name="tickInterval">
-          <number>25</number>
-         </property>
-        </widget>
-       </item>
-       <item row="8" column="1">
-        <widget class="QToolButton" name="buttonAutoSavePrefix">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="text">
-          <string/>
-         </property>
-         <property name="checkable">
-          <bool>true</bool>
+          <string>Framerate Limit</string>
          </property>
         </widget>
        </item>
@@ -903,8 +367,61 @@ Fullscreen Exclusive Mode - game will cover entirety of your screen and will use
          </property>
         </widget>
        </item>
-       <item row="52" column="1">
-        <widget class="QToolButton" name="buttonRepositoryDefault">
+       <item row="31" column="0">
+        <widget class="QLabel" name="labelInputMouse_2">
+         <property name="font">
+          <font>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>Input - Touchscreen</string>
+         </property>
+         <property name="margin">
+          <number>5</number>
+         </property>
+        </widget>
+       </item>
+       <item row="38" column="1" colspan="4">
+        <widget class="QSlider" name="sliderToleranceDistanceTouch">
+         <property name="minimum">
+          <number>0</number>
+         </property>
+         <property name="maximum">
+          <number>50</number>
+         </property>
+         <property name="singleStep">
+          <number>1</number>
+         </property>
+         <property name="pageStep">
+          <number>10</number>
+         </property>
+         <property name="value">
+          <number>0</number>
+         </property>
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="tickPosition">
+          <enum>QSlider::TicksAbove</enum>
+         </property>
+         <property name="tickInterval">
+          <number>10</number>
+         </property>
+        </widget>
+       </item>
+       <item row="34" column="0">
+        <widget class="QLabel" name="labelRelativeCursorSpeed">
+         <property name="text">
+          <string>Relative Pointer Speed</string>
+         </property>
+        </widget>
+       </item>
+       <item row="10" column="1" colspan="4">
+        <widget class="QComboBox" name="comboBoxResolution"/>
+       </item>
+       <item row="51" column="1">
+        <widget class="QToolButton" name="buttonAutoCheck">
          <property name="enabled">
           <bool>true</bool>
          </property>
@@ -925,29 +442,6 @@ Fullscreen Exclusive Mode - game will cover entirety of your screen and will use
          </property>
         </widget>
        </item>
-       <item row="6" column="1" colspan="4">
-        <widget class="QToolButton" name="buttonAutoSave">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="text">
-          <string/>
-         </property>
-         <property name="checkable">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item row="4" column="1" colspan="3">
-        <widget class="QLabel" name="labelTranslationStatus">
-         <property name="text">
-          <string/>
-         </property>
-        </widget>
-       </item>
        <item row="18" column="1" colspan="4">
         <widget class="QToolButton" name="buttonShowIntro">
          <property name="sizePolicy">
@@ -964,33 +458,20 @@ Fullscreen Exclusive Mode - game will cover entirety of your screen and will use
          </property>
         </widget>
        </item>
-       <item row="45" column="0">
-        <widget class="QLabel" name="labelAlliedPlayerAI">
+       <item row="36" column="0">
+        <widget class="QLabel" name="labelLongTouchDuration">
          <property name="text">
-          <string>Adventure Map Allies</string>
+          <string>Long Touch Duration</string>
          </property>
         </widget>
        </item>
-       <item row="35" column="0">
-        <widget class="QLabel" name="labelHapticFeedback">
-         <property name="text">
-          <string>Haptic Feedback</string>
-         </property>
-        </widget>
+       <item row="19" column="1" colspan="4">
+        <widget class="QComboBox" name="comboBoxDisplayIndex"/>
        </item>
-       <item row="13" column="1" colspan="4">
-        <widget class="QSpinBox" name="spinBoxInterfaceScaling">
-         <property name="suffix">
-          <string>%</string>
-         </property>
-         <property name="minimum">
-          <number>50</number>
-         </property>
-         <property name="maximum">
-          <number>400</number>
-         </property>
-         <property name="singleStep">
-          <number>10</number>
+       <item row="51" column="0">
+        <widget class="QLabel" name="labelAutoCheck">
+         <property name="text">
+          <string>Check on startup</string>
          </property>
         </widget>
        </item>
@@ -1013,72 +494,6 @@ Fullscreen Exclusive Mode - game will cover entirety of your screen and will use
          </property>
         </widget>
        </item>
-       <item row="30" column="0">
-        <widget class="QLabel" name="labelToleranceDistanceMouse">
-         <property name="text">
-          <string>Mouse Click Tolerance</string>
-         </property>
-        </widget>
-       </item>
-       <item row="46" column="1" colspan="4">
-        <widget class="QComboBox" name="comboBoxNeutralAI">
-         <property name="currentText">
-          <string notr="true">BattleAI</string>
-         </property>
-         <item>
-          <property name="text">
-           <string notr="true">BattleAI</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string notr="true">StupidAI</string>
-          </property>
-         </item>
-        </widget>
-       </item>
-       <item row="50" column="1" colspan="4">
-        <widget class="QToolButton" name="buttonIgnoreSslErrors">
-         <property name="enabled">
-          <bool>true</bool>
-         </property>
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="text">
-          <string/>
-         </property>
-         <property name="checkable">
-          <bool>true</bool>
-         </property>
-         <property name="checked">
-          <bool>false</bool>
-         </property>
-        </widget>
-       </item>
-       <item row="32" column="1" colspan="4">
-        <widget class="QPushButton" name="pushButtonResetTutorialTouchscreen">
-         <property name="text">
-          <string>Reset</string>
-         </property>
-        </widget>
-       </item>
-       <item row="19" column="1" colspan="4">
-        <widget class="QComboBox" name="comboBoxDisplayIndex"/>
-       </item>
-       <item row="5" column="0">
-        <widget class="QLabel" name="labelNetworkPort">
-         <property name="text">
-          <string>Network port</string>
-         </property>
-        </widget>
-       </item>
-       <item row="20" column="1" colspan="4">
-        <widget class="QComboBox" name="comboBoxRendererType"/>
-       </item>
        <item row="39" column="0">
         <widget class="QLabel" name="labelInputMouse_3">
          <property name="font">
@@ -1094,15 +509,8 @@ Fullscreen Exclusive Mode - game will cover entirety of your screen and will use
          </property>
         </widget>
        </item>
-       <item row="19" column="0">
-        <widget class="QLabel" name="labelDisplayIndex">
-         <property name="text">
-          <string>Display index</string>
-         </property>
-        </widget>
-       </item>
-       <item row="33" column="1" colspan="4">
-        <widget class="QToolButton" name="buttonRelativeCursorMode">
+       <item row="8" column="1">
+        <widget class="QToolButton" name="buttonAutoSavePrefix">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
            <horstretch>0</horstretch>
@@ -1114,128 +522,6 @@ Fullscreen Exclusive Mode - game will cover entirety of your screen and will use
          </property>
          <property name="checkable">
           <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item row="49" column="0">
-        <widget class="QLabel" name="labelNetwork">
-         <property name="font">
-          <font>
-           <bold>true</bold>
-          </font>
-         </property>
-         <property name="text">
-          <string>Network</string>
-         </property>
-         <property name="margin">
-          <number>5</number>
-         </property>
-        </widget>
-       </item>
-       <item row="24" column="4">
-        <widget class="QToolButton" name="buttonFontOriginal">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="text">
-          <string>Original</string>
-         </property>
-         <property name="checkable">
-          <bool>true</bool>
-         </property>
-         <property name="autoExclusive">
-          <bool>true</bool>
-         </property>
-         <attribute name="buttonGroup">
-          <string notr="true">buttonGroup</string>
-         </attribute>
-        </widget>
-       </item>
-       <item row="53" column="2" colspan="3">
-        <widget class="QLineEdit" name="lineEditRepositoryExtra">
-         <property name="text">
-          <string notr="true"/>
-         </property>
-        </widget>
-       </item>
-       <item row="18" column="0">
-        <widget class="QLabel" name="labelShowIntro">
-         <property name="text">
-          <string>Show intro</string>
-         </property>
-        </widget>
-       </item>
-       <item row="16" column="1" colspan="4">
-        <widget class="QToolButton" name="buttonVSync">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="text">
-          <string/>
-         </property>
-         <property name="checkable">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item row="55" column="1" colspan="4">
-        <widget class="QSpinBox" name="spinBoxNetworkPortLobby">
-         <property name="minimum">
-          <number>1024</number>
-         </property>
-         <property name="maximum">
-          <number>65535</number>
-         </property>
-         <property name="value">
-          <number>3030</number>
-         </property>
-        </widget>
-       </item>
-       <item row="31" column="0">
-        <widget class="QLabel" name="labelInputMouse_2">
-         <property name="font">
-          <font>
-           <bold>true</bold>
-          </font>
-         </property>
-         <property name="text">
-          <string>Input - Touchscreen</string>
-         </property>
-         <property name="margin">
-          <number>5</number>
-         </property>
-        </widget>
-       </item>
-       <item row="15" column="1" colspan="4">
-        <widget class="QSpinBox" name="spinBoxFramerateLimit">
-         <property name="minimum">
-          <number>20</number>
-         </property>
-         <property name="maximum">
-          <number>1000</number>
-         </property>
-         <property name="singleStep">
-          <number>10</number>
-         </property>
-        </widget>
-       </item>
-       <item row="42" column="0">
-        <widget class="QLabel" name="labelToleranceDistanceController">
-         <property name="text">
-          <string>Controller Click Tolerance</string>
-         </property>
-        </widget>
-       </item>
-       <item row="51" column="0">
-        <widget class="QLabel" name="labelAutoCheck">
-         <property name="text">
-          <string>Check on startup</string>
          </property>
         </widget>
        </item>
@@ -1270,15 +556,53 @@ Fullscreen Exclusive Mode - game will cover entirety of your screen and will use
          </property>
         </widget>
        </item>
-       <item row="21" column="0">
-        <widget class="QLabel" name="labelCursorType">
+       <item row="23" column="0">
+        <widget class="QLabel" name="labelDownscalingFilter">
          <property name="text">
-          <string>Software Cursor</string>
+          <string>Downscaling Filter</string>
          </property>
         </widget>
        </item>
-       <item row="24" column="3">
-        <widget class="QToolButton" name="buttonFontScalable">
+       <item row="11" column="1" colspan="4">
+        <widget class="QComboBox" name="comboBoxFullScreen">
+         <property name="toolTip">
+          <string>Select display mode for game
+
+Windowed - game will run inside a window that covers part of your screen
+
+Borderless Windowed Mode - game will run in a window that covers entirely of your screen, using same resolution as your screen.
+
+Fullscreen Exclusive Mode - game will cover entirety of your screen and will use selected resolution.</string>
+         </property>
+         <property name="currentIndex">
+          <number>0</number>
+         </property>
+         <item>
+          <property name="text">
+           <string>Windowed</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Borderless fullscreen</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Exclusive fullscreen</string>
+          </property>
+         </item>
+        </widget>
+       </item>
+       <item row="24" column="0">
+        <widget class="QLabel" name="labelFonts">
+         <property name="text">
+          <string>Use scalable fonts</string>
+         </property>
+        </widget>
+       </item>
+       <item row="24" column="4">
+        <widget class="QToolButton" name="buttonFontOriginal">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
            <horstretch>0</horstretch>
@@ -1286,7 +610,7 @@ Fullscreen Exclusive Mode - game will cover entirety of your screen and will use
           </sizepolicy>
          </property>
          <property name="text">
-          <string>Scalable</string>
+          <string>Original</string>
          </property>
          <property name="checkable">
           <bool>true</bool>
@@ -1295,12 +619,785 @@ Fullscreen Exclusive Mode - game will cover entirety of your screen and will use
           <bool>true</bool>
          </property>
          <attribute name="buttonGroup">
-          <string notr="true">buttonGroup</string>
+          <string notr="true">buttonGroupFonts</string>
          </attribute>
+        </widget>
+       </item>
+       <item row="20" column="1" colspan="4">
+        <widget class="QComboBox" name="comboBoxRendererType"/>
+       </item>
+       <item row="22" column="1" colspan="4">
+        <widget class="QComboBox" name="comboBoxUpscalingFilter">
+         <item>
+          <property name="text">
+           <string>Automatic</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>None</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>xBRZ x2</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>xBRZ x3</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>xBRZ x4</string>
+          </property>
+         </item>
+        </widget>
+       </item>
+       <item row="55" column="0">
+        <widget class="QLabel" name="labelNetworkPortLobby">
+         <property name="text">
+          <string>Online Lobby port</string>
+         </property>
+        </widget>
+       </item>
+       <item row="35" column="1" colspan="4">
+        <widget class="QToolButton" name="buttonHapticFeedback">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="45" column="1" colspan="4">
+        <widget class="QComboBox" name="comboBoxAlliedPlayerAI">
+         <property name="currentText">
+          <string notr="true">VCAI</string>
+         </property>
+         <item>
+          <property name="text">
+           <string notr="true">VCAI</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string notr="true">Nullkiller</string>
+          </property>
+         </item>
+        </widget>
+       </item>
+       <item row="49" column="0">
+        <widget class="QLabel" name="labelNetwork">
+         <property name="font">
+          <font>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>Network</string>
+         </property>
+         <property name="margin">
+          <number>5</number>
+         </property>
+        </widget>
+       </item>
+       <item row="51" column="2" colspan="3">
+        <widget class="QPushButton" name="refreshRepositoriesButton">
+         <property name="text">
+          <string>Refresh now</string>
+         </property>
+        </widget>
+       </item>
+       <item row="40" column="1" colspan="4">
+        <widget class="QSlider" name="sliderControllerSticksSensitivity">
+         <property name="minimum">
+          <number>500</number>
+         </property>
+         <property name="maximum">
+          <number>2500</number>
+         </property>
+         <property name="singleStep">
+          <number>25</number>
+         </property>
+         <property name="pageStep">
+          <number>250</number>
+         </property>
+         <property name="value">
+          <number>500</number>
+         </property>
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="tickPosition">
+          <enum>QSlider::TicksAbove</enum>
+         </property>
+         <property name="tickInterval">
+          <number>250</number>
+         </property>
+        </widget>
+       </item>
+       <item row="19" column="0">
+        <widget class="QLabel" name="labelDisplayIndex">
+         <property name="text">
+          <string>Display index</string>
+         </property>
+        </widget>
+       </item>
+       <item row="36" column="1" colspan="4">
+        <widget class="QSlider" name="sliderLongTouchDuration">
+         <property name="minimum">
+          <number>500</number>
+         </property>
+         <property name="maximum">
+          <number>2000</number>
+         </property>
+         <property name="singleStep">
+          <number>250</number>
+         </property>
+         <property name="pageStep">
+          <number>250</number>
+         </property>
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="tickPosition">
+          <enum>QSlider::TicksAbove</enum>
+         </property>
+         <property name="tickInterval">
+          <number>250</number>
+         </property>
+        </widget>
+       </item>
+       <item row="48" column="1" colspan="4">
+        <widget class="QComboBox" name="comboBoxEnemyAI">
+         <property name="editable">
+          <bool>false</bool>
+         </property>
+         <property name="currentText">
+          <string notr="true">BattleAI</string>
+         </property>
+         <item>
+          <property name="text">
+           <string notr="true">BattleAI</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string notr="true">StupidAI</string>
+          </property>
+         </item>
+        </widget>
+       </item>
+       <item row="44" column="0">
+        <widget class="QLabel" name="labelEnemyPlayerAI">
+         <property name="text">
+          <string>Adventure Map Enemies</string>
+         </property>
+        </widget>
+       </item>
+       <item row="52" column="2" colspan="3">
+        <widget class="QLineEdit" name="lineEditRepositoryDefault">
+         <property name="text">
+          <string notr="true"/>
+         </property>
+         <property name="readOnly">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="32" column="1" colspan="4">
+        <widget class="QPushButton" name="pushButtonResetTutorialTouchscreen">
+         <property name="text">
+          <string>Reset</string>
+         </property>
+        </widget>
+       </item>
+       <item row="32" column="0">
+        <widget class="QLabel" name="labelResetTutorialTouchscreen">
+         <property name="text">
+          <string>Show Tutorial again</string>
+         </property>
+        </widget>
+       </item>
+       <item row="11" column="0">
+        <widget class="QLabel" name="labelFullScreen">
+         <property name="text">
+          <string>Fullscreen</string>
+         </property>
+        </widget>
+       </item>
+       <item row="33" column="0">
+        <widget class="QLabel" name="labelRelativeCursorMode">
+         <property name="text">
+          <string>Use Relative Pointer Mode</string>
+         </property>
+        </widget>
+       </item>
+       <item row="54" column="1" colspan="4">
+        <widget class="QLineEdit" name="lineEditGameLobbyHost">
+         <property name="text">
+          <string notr="true"/>
+         </property>
+        </widget>
+       </item>
+       <item row="41" column="0">
+        <widget class="QLabel" name="labelControllerSticksAcceleration">
+         <property name="text">
+          <string>Sticks Acceleration</string>
+         </property>
+        </widget>
+       </item>
+       <item row="7" column="0">
+        <widget class="QLabel" name="labelAutoSaveLimit">
+         <property name="text">
+          <string>Autosave limit (0 = off)</string>
+         </property>
+        </widget>
+       </item>
+       <item row="30" column="0">
+        <widget class="QLabel" name="labelToleranceDistanceMouse">
+         <property name="text">
+          <string>Mouse Click Tolerance</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="0">
+        <widget class="QLabel" name="labelGeneral">
+         <property name="font">
+          <font>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>General</string>
+         </property>
+         <property name="margin">
+          <number>5</number>
+         </property>
+        </widget>
+       </item>
+       <item row="54" column="0">
+        <widget class="QLabel" name="labelGameLobbyHost">
+         <property name="text">
+          <string>Online Lobby address</string>
+         </property>
+        </widget>
+       </item>
+       <item row="6" column="1" colspan="4">
+        <widget class="QToolButton" name="buttonAutoSave">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="13" column="0">
+        <widget class="QLabel" name="labelInterfaceScaling">
+         <property name="text">
+          <string>Interface Scaling</string>
+         </property>
+        </widget>
+       </item>
+       <item row="52" column="0">
+        <widget class="QLabel" name="labelRepositoryDefault">
+         <property name="text">
+          <string>Default repository</string>
+         </property>
+        </widget>
+       </item>
+       <item row="21" column="1" colspan="4">
+        <widget class="QToolButton" name="buttonCursorType">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="35" column="0">
+        <widget class="QLabel" name="labelHapticFeedback">
+         <property name="text">
+          <string>Haptic Feedback</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1" colspan="4">
+        <widget class="QComboBox" name="comboBoxLanguage"/>
+       </item>
+       <item row="8" column="0">
+        <widget class="QLabel" name="labelAutoSavePrefix">
+         <property name="text">
+          <string>Autosave prefix</string>
+         </property>
+        </widget>
+       </item>
+       <item row="29" column="0">
+        <widget class="QLabel" name="labelInputMouse">
+         <property name="font">
+          <font>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>Input - Mouse</string>
+         </property>
+         <property name="margin">
+          <number>5</number>
+         </property>
+        </widget>
+       </item>
+       <item row="12" column="1" colspan="4">
+        <widget class="QSlider" name="sliderReservedArea">
+         <property name="maximum">
+          <number>25</number>
+         </property>
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="tickPosition">
+          <enum>QSlider::TicksAbove</enum>
+         </property>
+         <property name="tickInterval">
+          <number>5</number>
+         </property>
+        </widget>
+       </item>
+       <item row="15" column="1" colspan="4">
+        <widget class="QSpinBox" name="spinBoxFramerateLimit">
+         <property name="minimum">
+          <number>20</number>
+         </property>
+         <property name="maximum">
+          <number>1000</number>
+         </property>
+         <property name="singleStep">
+          <number>10</number>
+         </property>
+        </widget>
+       </item>
+       <item row="55" column="1" colspan="4">
+        <widget class="QSpinBox" name="spinBoxNetworkPortLobby">
+         <property name="minimum">
+          <number>1024</number>
+         </property>
+         <property name="maximum">
+          <number>65535</number>
+         </property>
+         <property name="value">
+          <number>3030</number>
+         </property>
+        </widget>
+       </item>
+       <item row="34" column="1" colspan="4">
+        <widget class="QSlider" name="sliderRelativeCursorSpeed">
+         <property name="minimum">
+          <number>100</number>
+         </property>
+         <property name="maximum">
+          <number>300</number>
+         </property>
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="tickPosition">
+          <enum>QSlider::TicksAbove</enum>
+         </property>
+         <property name="tickInterval">
+          <number>25</number>
+         </property>
+        </widget>
+       </item>
+       <item row="48" column="0">
+        <widget class="QLabel" name="labelEnemyAI">
+         <property name="text">
+          <string>Enemy AI in battles</string>
+         </property>
+        </widget>
+       </item>
+       <item row="12" column="0">
+        <widget class="QLabel" name="labelReservedArea">
+         <property name="text">
+          <string>Reserved screen area</string>
+         </property>
+        </widget>
+       </item>
+       <item row="13" column="1" colspan="4">
+        <widget class="QSpinBox" name="spinBoxInterfaceScaling">
+         <property name="suffix">
+          <string>%</string>
+         </property>
+         <property name="minimum">
+          <number>50</number>
+         </property>
+         <property name="maximum">
+          <number>400</number>
+         </property>
+         <property name="singleStep">
+          <number>10</number>
+         </property>
+        </widget>
+       </item>
+       <item row="27" column="0">
+        <widget class="QLabel" name="labelMusicVolume">
+         <property name="text">
+          <string>Music Volume</string>
+         </property>
+        </widget>
+       </item>
+       <item row="46" column="1" colspan="4">
+        <widget class="QComboBox" name="comboBoxNeutralAI">
+         <property name="currentText">
+          <string notr="true">BattleAI</string>
+         </property>
+         <item>
+          <property name="text">
+           <string notr="true">BattleAI</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string notr="true">StupidAI</string>
+          </property>
+         </item>
+        </widget>
+       </item>
+       <item row="6" column="0">
+        <widget class="QLabel" name="labelAutoSave">
+         <property name="text">
+          <string>Autosave</string>
+         </property>
+        </widget>
+       </item>
+       <item row="28" column="1" colspan="4">
+        <widget class="QSlider" name="sliderSoundVolume">
+         <property name="maximum">
+          <number>100</number>
+         </property>
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="tickPosition">
+          <enum>QSlider::TicksAbove</enum>
+         </property>
+         <property name="tickInterval">
+          <number>10</number>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="0">
+        <widget class="QLabel" name="labelNetworkPort">
+         <property name="text">
+          <string>Network port</string>
+         </property>
+        </widget>
+       </item>
+       <item row="52" column="1">
+        <widget class="QToolButton" name="buttonRepositoryDefault">
+         <property name="enabled">
+          <bool>true</bool>
+         </property>
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+         <property name="checked">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="10" column="0">
+        <widget class="QLabel" name="labelResolution">
+         <property name="text">
+          <string>Resolution</string>
+         </property>
+        </widget>
+       </item>
+       <item row="33" column="1" colspan="4">
+        <widget class="QToolButton" name="buttonRelativeCursorMode">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="28" column="0">
+        <widget class="QLabel" name="labelSoundVolume">
+         <property name="text">
+          <string>Sound Volume</string>
+         </property>
+        </widget>
+       </item>
+       <item row="42" column="0">
+        <widget class="QLabel" name="labelToleranceDistanceController">
+         <property name="text">
+          <string>Controller Click Tolerance</string>
+         </property>
+        </widget>
+       </item>
+       <item row="45" column="0">
+        <widget class="QLabel" name="labelAlliedPlayerAI">
+         <property name="text">
+          <string>Adventure Map Allies</string>
+         </property>
+        </widget>
+       </item>
+       <item row="56" column="0">
+        <widget class="QLabel" name="labelMiscellaneous">
+         <property name="font">
+          <font>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>Miscellaneous</string>
+         </property>
+         <property name="margin">
+          <number>5</number>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="1" colspan="4">
+        <widget class="QSpinBox" name="spinBoxNetworkPort">
+         <property name="minimum">
+          <number>1024</number>
+         </property>
+         <property name="maximum">
+          <number>65535</number>
+         </property>
+         <property name="value">
+          <number>3030</number>
+         </property>
+        </widget>
+       </item>
+       <item row="44" column="1" colspan="4">
+        <widget class="QComboBox" name="comboBoxEnemyPlayerAI">
+         <property name="currentText">
+          <string notr="true">VCAI</string>
+         </property>
+         <item>
+          <property name="text">
+           <string notr="true">VCAI</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string notr="true">Nullkiller</string>
+          </property>
+         </item>
+        </widget>
+       </item>
+       <item row="26" column="0">
+        <widget class="QLabel" name="labelAudio">
+         <property name="font">
+          <font>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>Audio</string>
+         </property>
+         <property name="margin">
+          <number>5</number>
+         </property>
+        </widget>
+       </item>
+       <item row="16" column="1" colspan="4">
+        <widget class="QToolButton" name="buttonVSync">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="21" column="0">
+        <widget class="QLabel" name="labelCursorType">
+         <property name="text">
+          <string>Software Cursor</string>
+         </property>
+        </widget>
+       </item>
+       <item row="47" column="0">
+        <widget class="QLabel" name="labelFriendlyAI">
+         <property name="text">
+          <string>Autocombat AI in battles</string>
+         </property>
         </widget>
        </item>
        <item row="25" column="1">
         <widget class="QLabel" name="labelScalingFontValue"/>
+       </item>
+       <item row="4" column="4">
+        <widget class="QPushButton" name="pushButtonTranslation">
+         <property name="text">
+          <string/>
+         </property>
+        </widget>
+       </item>
+       <item row="50" column="1" colspan="4">
+        <widget class="QToolButton" name="buttonIgnoreSslErrors">
+         <property name="enabled">
+          <bool>true</bool>
+         </property>
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+         <property name="checked">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="25" column="0">
+        <widget class="QLabel" name="labelScalingFont">
+         <property name="text">
+          <string>Font Scaling (experimental)</string>
+         </property>
+        </widget>
+       </item>
+       <item row="40" column="0">
+        <widget class="QLabel" name="labelControllerSticksSensitivity">
+         <property name="text">
+          <string>Sticks Sensitivity</string>
+         </property>
+        </widget>
+       </item>
+       <item row="57" column="0">
+        <widget class="QLabel" name="labelModsValidation">
+         <property name="text">
+          <string>Mods Validation</string>
+         </property>
+        </widget>
+       </item>
+       <item row="57" column="1" colspan="2">
+        <widget class="QToolButton" name="buttonValidationOff">
+         <property name="enabled">
+          <bool>true</bool>
+         </property>
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Off</string>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+         <property name="checked">
+          <bool>false</bool>
+         </property>
+         <attribute name="buttonGroup">
+          <string notr="true">buttonGroupValidation</string>
+         </attribute>
+        </widget>
+       </item>
+       <item row="57" column="3">
+        <widget class="QToolButton" name="buttonValidationBasic">
+         <property name="enabled">
+          <bool>true</bool>
+         </property>
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Basic</string>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+         <property name="checked">
+          <bool>false</bool>
+         </property>
+         <attribute name="buttonGroup">
+          <string notr="true">buttonGroupValidation</string>
+         </attribute>
+        </widget>
+       </item>
+       <item row="57" column="4">
+        <widget class="QToolButton" name="buttonValidationFull">
+         <property name="enabled">
+          <bool>true</bool>
+         </property>
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Full</string>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+         <property name="checked">
+          <bool>false</bool>
+         </property>
+         <attribute name="buttonGroup">
+          <string notr="true">buttonGroupValidation</string>
+         </attribute>
+        </widget>
        </item>
       </layout>
      </widget>
@@ -1311,6 +1408,7 @@ Fullscreen Exclusive Mode - game will cover entirety of your screen and will use
  <resources/>
  <connections/>
  <buttongroups>
-  <buttongroup name="buttonGroup"/>
+  <buttongroup name="buttonGroupFonts"/>
+  <buttongroup name="buttonGroupValidation"/>
  </buttongroups>
 </ui>

--- a/lib/json/JsonUtils.cpp
+++ b/lib/json/JsonUtils.cpp
@@ -275,11 +275,8 @@ JsonNode JsonUtils::assembleFromFiles(const std::string & filename)
 	return result;
 }
 
-void JsonUtils::detectConflicts(const JsonNode & left, const JsonNode & right, const std::string & entityName, const std::string & keyName)
+void JsonUtils::detectConflicts(JsonNode & result, const JsonNode & left, const JsonNode & right, const std::string & keyName)
 {
-	if (left == right)
-		return;
-
 	switch (left.getType())
 	{
 		case JsonNode::JsonType::DATA_NULL:
@@ -289,16 +286,15 @@ void JsonUtils::detectConflicts(const JsonNode & left, const JsonNode & right, c
 		case JsonNode::JsonType::DATA_STRING:
 		case JsonNode::JsonType::DATA_VECTOR: // NOTE: comparing vectors as whole - since merge will overwrite it in its entirety
 		{
-			logMod->warn("Potential confict detected between '%s' and '%s' in object '%s'", left.getModScope(), right.getModScope(), entityName);
-			logMod->warn("Mod '%s' - value %s set to '%s'", left.getModScope(), keyName, left.toCompactString());
-			logMod->warn("Mod '%s' - value %s set to '%s'", right.getModScope(), keyName, right.toCompactString());
+			result[keyName][left.getModScope()] = left;
+			result[keyName][right.getModScope()] = right;
 			return;
 		}
 		case JsonNode::JsonType::DATA_STRUCT:
 		{
-			for(auto & node : left.Struct())
+			for(const auto & node : left.Struct())
 				if (!right[node.first].isNull())
-					detectConflicts(node.second, right[node.first], entityName, keyName + "/" + node.first);
+					detectConflicts(result, node.second, right[node.first], keyName + "/" + node.first);
 		}
 	}
 }

--- a/lib/json/JsonUtils.h
+++ b/lib/json/JsonUtils.h
@@ -74,8 +74,10 @@ namespace JsonUtils
 	DLL_LINKAGE const JsonNode & getSchema(const std::string & URI);
 
 	/// detects potential conflicts - json entries present in both nodes
-	/// any error messages will be printed to error log
-	DLL_LINKAGE void detectConflicts(const JsonNode & left, const JsonNode & right, const std::string & entityName, const std::string & keyName);
+	/// returns JsonNode that contains list of conflicting keys
+	/// For each conflict - list of conflicting mods and list of conflicting json values
+	/// result[pathToKey][modID] -> node that was conflicting
+	DLL_LINKAGE void detectConflicts(JsonNode & result, const JsonNode & left, const JsonNode & right, const std::string & keyName);
 }
 
 VCMI_LIB_NAMESPACE_END

--- a/lib/json/JsonUtils.h
+++ b/lib/json/JsonUtils.h
@@ -72,6 +72,10 @@ namespace JsonUtils
 	/// get schema by json URI: vcmi:<name of file in schemas directory>#<entry in file, optional>
 	/// example: schema "vcmi:settings" is used to check user settings
 	DLL_LINKAGE const JsonNode & getSchema(const std::string & URI);
+
+	/// detects potential conflicts - json entries present in both nodes
+	/// any error messages will be printed to error log
+	DLL_LINKAGE void detectConflicts(const JsonNode & left, const JsonNode & right, const std::string & entityName, const std::string & keyName);
 }
 
 VCMI_LIB_NAMESPACE_END

--- a/lib/mapObjectConstructors/CRewardableConstructor.cpp
+++ b/lib/mapObjectConstructors/CRewardableConstructor.cpp
@@ -14,6 +14,7 @@
 #include "../mapObjects/CRewardableObject.h"
 #include "../texts/CGeneralTextHandler.h"
 #include "../IGameCallback.h"
+#include "../CConfigHandler.h"
 
 VCMI_LIB_NAMESPACE_BEGIN
 
@@ -25,7 +26,8 @@ void CRewardableConstructor::initTypeData(const JsonNode & config)
 	if (!config["name"].isNull())
 		VLC->generaltexth->registerString( config.getModScope(), getNameTextID(), config["name"].String());
 
-	JsonUtils::validate(config, "vcmi:rewardable", getJsonKey());
+	if (settings["mods"]["validation"].String() != "off")
+		JsonUtils::validate(config, "vcmi:rewardable", getJsonKey());
 	
 }
 

--- a/lib/modding/CModHandler.cpp
+++ b/lib/modding/CModHandler.cpp
@@ -392,6 +392,12 @@ std::string CModHandler::getModLanguage(const TModID& modId) const
 	return allMods.at(modId).baseLanguage;
 }
 
+std::set<TModID> CModHandler::getModDependencies(const TModID & modId) const
+{
+	bool isModFound;
+	return getModDependencies(modId, isModFound);
+}
+
 std::set<TModID> CModHandler::getModDependencies(const TModID & modId, bool & isModFound) const
 {
 	auto it = allMods.find(modId);
@@ -499,8 +505,8 @@ void CModHandler::load()
 
 	content->loadCustom();
 
-	for(const TModID & modName : activeMods)
-		loadTranslation(modName);
+//	for(const TModID & modName : activeMods)
+//		loadTranslation(modName);
 
 #if 0
 	for(const TModID & modName : activeMods)

--- a/lib/modding/CModHandler.cpp
+++ b/lib/modding/CModHandler.cpp
@@ -346,6 +346,9 @@ void CModHandler::loadModFilesystems()
 			if (leftModName == rightModName)
 				continue;
 
+			if (getModDependencies(leftModName).count(rightModName) || getModDependencies(rightModName).count(leftModName))
+				continue;
+
 			const auto & filter = [](const ResourcePath &path){return path.getType() != EResType::DIRECTORY;};
 
 			std::unordered_set<ResourcePath> leftResources = modFilesystems[leftModName]->getFilteredFiles(filter);

--- a/lib/modding/CModHandler.h
+++ b/lib/modding/CModHandler.h
@@ -66,6 +66,7 @@ public:
 
 	std::string getModLanguage(const TModID & modId) const;
 
+	std::set<TModID> getModDependencies(const TModID & modId) const;
 	std::set<TModID> getModDependencies(const TModID & modId, bool & isModFound) const;
 
 	/// returns list of all (active) mods

--- a/lib/modding/ContentTypeHandler.cpp
+++ b/lib/modding/ContentTypeHandler.cpp
@@ -79,6 +79,9 @@ bool ContentTypeHandler::preloadModData(const std::string & modName, const std::
 			logMod->trace("Patching object %s (%s) from %s", objectName, remoteName, modName);
 			JsonNode & remoteConf = modData[remoteName].patches[objectName];
 
+			if (!remoteConf.isNull())
+				JsonUtils::detectConflicts(remoteConf, entry.second, objectName, "<root>");
+
 			JsonUtils::merge(remoteConf, entry.second);
 		}
 	}

--- a/lib/modding/ContentTypeHandler.cpp
+++ b/lib/modding/ContentTypeHandler.cpp
@@ -17,6 +17,7 @@
 #include "../BattleFieldHandler.h"
 #include "../CArtHandler.h"
 #include "../CCreatureHandler.h"
+#include "../CConfigHandler.h"
 #include "../entities/faction/CTownHandler.h"
 #include "../texts/CGeneralTextHandler.h"
 #include "../CHeroHandler.h"
@@ -79,7 +80,7 @@ bool ContentTypeHandler::preloadModData(const std::string & modName, const std::
 			logMod->trace("Patching object %s (%s) from %s", objectName, remoteName, modName);
 			JsonNode & remoteConf = modData[remoteName].patches[objectName];
 
-			if (!remoteConf.isNull())
+			if (!remoteConf.isNull() && settings["mods"]["validation"].String() != "off")
 				JsonUtils::detectConflicts(conflictList, remoteConf, entry.second, objectName);
 
 			JsonUtils::merge(remoteConf, entry.second);
@@ -162,67 +163,70 @@ void ContentTypeHandler::loadCustom()
 
 void ContentTypeHandler::afterLoadFinalization()
 {
-	for (auto const & data : modData)
+	if (settings["mods"]["validation"].String() != "off")
 	{
-		if (data.second.modData.isNull())
+		for (auto const & data : modData)
 		{
-			for (auto node : data.second.patches.Struct())
-				logMod->warn("Mod '%s' have added patch for object '%s' from mod '%s', but this mod was not loaded or has no new objects.", node.second.getModScope(), node.first, data.first);
-		}
-
-		for(auto & otherMod : modData)
-		{
-			if (otherMod.first == data.first)
-				continue;
-
-			if (otherMod.second.modData.isNull())
-				continue;
-
-			for(auto & otherObject : otherMod.second.modData.Struct())
+			if (data.second.modData.isNull())
 			{
-				if (data.second.modData.Struct().count(otherObject.first))
+				for (auto node : data.second.patches.Struct())
+					logMod->warn("Mod '%s' have added patch for object '%s' from mod '%s', but this mod was not loaded or has no new objects.", node.second.getModScope(), node.first, data.first);
+			}
+
+			for(auto & otherMod : modData)
+			{
+				if (otherMod.first == data.first)
+					continue;
+
+				if (otherMod.second.modData.isNull())
+					continue;
+
+				for(auto & otherObject : otherMod.second.modData.Struct())
 				{
-					logMod->warn("Mod '%s' have added object with name '%s' that is also available in mod '%s'", data.first, otherObject.first, otherMod.first);
-					logMod->warn("Two objects with same name were loaded. Please use form '%s:%s' if mod '%s' needs to modify this object instead", otherMod.first, otherObject.first, data.first);
+					if (data.second.modData.Struct().count(otherObject.first))
+					{
+						logMod->warn("Mod '%s' have added object with name '%s' that is also available in mod '%s'", data.first, otherObject.first, otherMod.first);
+						logMod->warn("Two objects with same name were loaded. Please use form '%s:%s' if mod '%s' needs to modify this object instead", otherMod.first, otherObject.first, data.first);
+					}
 				}
 			}
 		}
-	}
 
-	for (const auto& [conflictPath, conflictModData] : conflictList.Struct())
-	{
-		std::set<std::string> conflictingMods;
-		std::set<std::string> resolvedConflicts;
-
-		for (auto const & conflictModData : conflictModData.Struct())
-			conflictingMods.insert(conflictModData.first);
-
-		for (auto const & modID : conflictingMods)
-			resolvedConflicts.merge(VLC->modh->getModDependencies(modID));
-
-		vstd::erase_if(conflictingMods, [&resolvedConflicts](const std::string & entry){ return resolvedConflicts.count(entry);});
-
-		if (conflictingMods.size() < 2)
-			continue; // all conflicts were resolved - either via compatibility patch (mod that depends on 2 conflicting mods) or simple mod that depends on another one
-
-		bool allEqual = true;
-
-		for (auto const & modID : conflictingMods)
+		for (const auto& [conflictPath, conflictModData] : conflictList.Struct())
 		{
-			if (conflictModData[modID] != conflictModData[*conflictingMods.begin()])
+			std::set<std::string> conflictingMods;
+			std::set<std::string> resolvedConflicts;
+
+			for (auto const & conflictModData : conflictModData.Struct())
+				conflictingMods.insert(conflictModData.first);
+
+			for (auto const & modID : conflictingMods)
+				resolvedConflicts.merge(VLC->modh->getModDependencies(modID));
+
+			vstd::erase_if(conflictingMods, [&resolvedConflicts](const std::string & entry){ return resolvedConflicts.count(entry);});
+
+			if (conflictingMods.size() < 2)
+				continue; // all conflicts were resolved - either via compatibility patch (mod that depends on 2 conflicting mods) or simple mod that depends on another one
+
+			bool allEqual = true;
+
+			for (auto const & modID : conflictingMods)
 			{
-				allEqual = false;
-				break;
+				if (conflictModData[modID] != conflictModData[*conflictingMods.begin()])
+				{
+					allEqual = false;
+					break;
+				}
 			}
+
+			if (allEqual)
+				continue; // conflict still present, but all mods use the same value for conflicting entry - permit it
+
+			logMod->warn("Potential confict in '%s'", conflictPath);
+
+			for (auto const & modID : conflictingMods)
+				logMod->warn("Mod '%s' - value set to %s", modID, conflictModData[modID].toCompactString());
 		}
-
-		if (allEqual)
-			continue; // conflict still present, but all mods use the same value for conflicting entry - permit it
-
-		logMod->warn("Potential confict in '%s'", conflictPath);
-
-		for (auto const & modID : conflictingMods)
-			logMod->warn("Mod '%s' - value set to %s", modID, conflictModData[modID].toCompactString());
 	}
 
 	handler->afterLoadFinalization();
@@ -288,7 +292,7 @@ void CContentHandler::afterLoadFinalization()
 
 void CContentHandler::preloadData(CModInfo & mod)
 {
-	bool validate = (mod.validation != CModInfo::PASSED);
+	bool validate = validateMod(mod);
 
 	// print message in format [<8-symbols checksum>] <modname>
 	auto & info = mod.getVerificationInfo();
@@ -305,7 +309,7 @@ void CContentHandler::preloadData(CModInfo & mod)
 
 void CContentHandler::load(CModInfo & mod)
 {
-	bool validate = (mod.validation != CModInfo::PASSED);
+	bool validate = validateMod(mod);
 
 	if (!loadMod(mod.identifier, validate))
 		mod.validation = CModInfo::FAILED;
@@ -324,6 +328,20 @@ void CContentHandler::load(CModInfo & mod)
 const ContentTypeHandler & CContentHandler::operator[](const std::string & name) const
 {
 	return handlers.at(name);
+}
+
+bool CContentHandler::validateMod(const CModInfo & mod) const
+{
+	if (settings["mods"]["validation"].String() == "full")
+		return true;
+
+	if (mod.validation == CModInfo::PASSED)
+		return false;
+
+	if (settings["mods"]["validation"].String() == "off")
+		return false;
+
+	return true;
 }
 
 VCMI_LIB_NAMESPACE_END

--- a/lib/modding/ContentTypeHandler.h
+++ b/lib/modding/ContentTypeHandler.h
@@ -19,6 +19,8 @@ class CModInfo;
 /// internal type to handle loading of one data type (e.g. artifacts, creatures)
 class DLL_LINKAGE ContentTypeHandler
 {
+	JsonNode conflictList;
+
 public:
 	struct ModInfo
 	{
@@ -29,7 +31,7 @@ public:
 	};
 	/// handler to which all data will be loaded
 	IHandlerBase * handler;
-	std::string objectName;
+	std::string entityName;
 
 	/// contains all loaded H3 data
 	std::vector<JsonNode> originalData;

--- a/lib/modding/ContentTypeHandler.h
+++ b/lib/modding/ContentTypeHandler.h
@@ -58,6 +58,7 @@ class DLL_LINKAGE CContentHandler
 
 	std::map<std::string, ContentTypeHandler> handlers;
 
+	bool validateMod(const CModInfo & mod) const;
 public:
 	void init();
 


### PR DESCRIPTION
Attempt to automatically detect mod conflicts.
Currently it handles two cases:
- Two mods add file with same name, e.g.
  - mod A has file `config/creatures.json`
  - mod B also has file `config/creatures.json`
- Two mods modify same object in a different way, e.g.
  - mod A has `"core:imp" : { "health" : 5 }` 
  - mod B has `"core:imp" : { "health" : 6 }`

This should detect typical bugs that I've heard about, such as mods having files with same names or mods adding map object / object templates with same name (since those don't have proper conflict prevention)

TODO:
- [x] Try to add some detection for existing compatibility patches and silence corresponding warnings
- [x] Disable conflict detection by default and add config option to enable it (conflict detection may be slow)
- [x] (filesystem) Detect false positive - conflicts with dependent mods should not be viewed as conflict - it is likely already handled, and the reason for dependency
- [x] (json data) Detect false positive - conflicts with dependent mods should not be viewed as conflict - it is likely already handled, and the reason for dependency