### PR TITLE
Reduce usage of pointers to CPack and derived classes

### DIFF
--- a/AI/BattleAI/StackWithBonuses.cpp
+++ b/AI/BattleAI/StackWithBonuses.cpp
@@ -531,44 +531,44 @@ vstd::RNG * HypotheticBattle::HypotheticServerCallback::getRNG()
 	return &rngStub;
 }
 
-void HypotheticBattle::HypotheticServerCallback::apply(CPackForClient * pack)
+void HypotheticBattle::HypotheticServerCallback::apply(CPackForClient & pack)
 {
 	logAi->error("Package of type %s is not allowed in battle evaluation", typeid(pack).name());
 }
 
-void HypotheticBattle::HypotheticServerCallback::apply(BattleLogMessage * pack)
+void HypotheticBattle::HypotheticServerCallback::apply(BattleLogMessage & pack)
 {
-	pack->applyBattle(owner);
+	pack.applyBattle(owner);
 }
 
-void HypotheticBattle::HypotheticServerCallback::apply(BattleStackMoved * pack)
+void HypotheticBattle::HypotheticServerCallback::apply(BattleStackMoved & pack)
 {
-	pack->applyBattle(owner);
+	pack.applyBattle(owner);
 }
 
-void HypotheticBattle::HypotheticServerCallback::apply(BattleUnitsChanged * pack)
+void HypotheticBattle::HypotheticServerCallback::apply(BattleUnitsChanged & pack)
 {
-	pack->applyBattle(owner);
+	pack.applyBattle(owner);
 }
 
-void HypotheticBattle::HypotheticServerCallback::apply(SetStackEffect * pack)
+void HypotheticBattle::HypotheticServerCallback::apply(SetStackEffect & pack)
 {
-	pack->applyBattle(owner);
+	pack.applyBattle(owner);
 }
 
-void HypotheticBattle::HypotheticServerCallback::apply(StacksInjured * pack)
+void HypotheticBattle::HypotheticServerCallback::apply(StacksInjured & pack)
 {
-	pack->applyBattle(owner);
+	pack.applyBattle(owner);
 }
 
-void HypotheticBattle::HypotheticServerCallback::apply(BattleObstaclesChanged * pack)
+void HypotheticBattle::HypotheticServerCallback::apply(BattleObstaclesChanged & pack)
 {
-	pack->applyBattle(owner);
+	pack.applyBattle(owner);
 }
 
-void HypotheticBattle::HypotheticServerCallback::apply(CatapultAttack * pack)
+void HypotheticBattle::HypotheticServerCallback::apply(CatapultAttack & pack)
 {
-	pack->applyBattle(owner);
+	pack.applyBattle(owner);
 }
 
 HypotheticBattle::HypotheticEnvironment::HypotheticEnvironment(HypotheticBattle * owner_, const Environment * upperEnvironment)

--- a/AI/BattleAI/StackWithBonuses.h
+++ b/AI/BattleAI/StackWithBonuses.h
@@ -189,15 +189,15 @@ private:
 
 		vstd::RNG * getRNG() override;
 
-		void apply(CPackForClient * pack) override;
+		void apply(CPackForClient & pack) override;
 
-		void apply(BattleLogMessage * pack) override;
-		void apply(BattleStackMoved * pack) override;
-		void apply(BattleUnitsChanged * pack) override;
-		void apply(SetStackEffect * pack) override;
-		void apply(StacksInjured * pack) override;
-		void apply(BattleObstaclesChanged * pack) override;
-		void apply(CatapultAttack * pack) override;
+		void apply(BattleLogMessage & pack) override;
+		void apply(BattleStackMoved & pack) override;
+		void apply(BattleUnitsChanged & pack) override;
+		void apply(SetStackEffect & pack) override;
+		void apply(StacksInjured & pack) override;
+		void apply(BattleObstaclesChanged & pack) override;
+		void apply(CatapultAttack & pack) override;
 	private:
 		HypotheticBattle * owner;
 		RNGStub rngStub;

--- a/CCallback.cpp
+++ b/CCallback.cpp
@@ -29,20 +29,20 @@
 bool CCallback::teleportHero(const CGHeroInstance *who, const CGTownInstance *where)
 {
 	CastleTeleportHero pack(who->id, where->id, 1);
-	sendRequest(&pack);
+	sendRequest(pack);
 	return true;
 }
 
 void CCallback::moveHero(const CGHeroInstance *h, const int3 & destination, bool transit)
 {
 	MoveHero pack({destination}, h->id, transit);
-	sendRequest(&pack);
+	sendRequest(pack);
 }
 
 void CCallback::moveHero(const CGHeroInstance *h, const std::vector<int3> & path, bool transit)
 {
 	MoveHero pack(path, h->id, transit);
-	sendRequest(&pack);
+	sendRequest(pack);
 }
 
 int CCallback::selectionMade(int selection, QueryID queryID)
@@ -61,7 +61,7 @@ int CCallback::sendQueryReply(std::optional<int32_t> reply, QueryID queryID)
 
 	QueryReply pack(queryID, reply);
 	pack.player = *player;
-	return sendRequest(&pack);
+	return sendRequest(pack);
 }
 
 void CCallback::recruitCreatures(const CGDwelling * obj, const CArmedInstance * dst, CreatureID ID, ui32 amount, si32 level)
@@ -71,7 +71,7 @@ void CCallback::recruitCreatures(const CGDwelling * obj, const CArmedInstance * 
 		return;
 
 	RecruitCreatures pack(obj->id, dst->id, ID, amount, level);
-	sendRequest(&pack);
+	sendRequest(pack);
 }
 
 bool CCallback::dismissCreature(const CArmedInstance *obj, SlotID stackPos)
@@ -80,14 +80,14 @@ bool CCallback::dismissCreature(const CArmedInstance *obj, SlotID stackPos)
 		return false;
 
 	DisbandCreature pack(stackPos,obj->id);
-	sendRequest(&pack);
+	sendRequest(pack);
 	return true;
 }
 
 bool CCallback::upgradeCreature(const CArmedInstance *obj, SlotID stackPos, CreatureID newID)
 {
 	UpgradeCreature pack(stackPos,obj->id,newID);
-	sendRequest(&pack);
+	sendRequest(pack);
 	return false;
 }
 
@@ -95,54 +95,54 @@ void CCallback::endTurn()
 {
 	logGlobal->trace("Player %d ended his turn.", player->getNum());
 	EndTurn pack;
-	sendRequest(&pack);
+	sendRequest(pack);
 }
 int CCallback::swapCreatures(const CArmedInstance *s1, const CArmedInstance *s2, SlotID p1, SlotID p2)
 {
 	ArrangeStacks pack(1,p1,p2,s1->id,s2->id,0);
-	sendRequest(&pack);
+	sendRequest(pack);
 	return 0;
 }
 
 int CCallback::mergeStacks(const CArmedInstance *s1, const CArmedInstance *s2, SlotID p1, SlotID p2)
 {
 	ArrangeStacks pack(2,p1,p2,s1->id,s2->id,0);
-	sendRequest(&pack);
+	sendRequest(pack);
 	return 0;
 }
 
 int CCallback::splitStack(const CArmedInstance *s1, const CArmedInstance *s2, SlotID p1, SlotID p2, int val)
 {
 	ArrangeStacks pack(3,p1,p2,s1->id,s2->id,val);
-	sendRequest(&pack);
+	sendRequest(pack);
 	return 0;
 }
 
 int CCallback::bulkMoveArmy(ObjectInstanceID srcArmy, ObjectInstanceID destArmy, SlotID srcSlot)
 {
 	BulkMoveArmy pack(srcArmy, destArmy, srcSlot);
-	sendRequest(&pack);
+	sendRequest(pack);
 	return 0;
 }
 
 int CCallback::bulkSplitStack(ObjectInstanceID armyId, SlotID srcSlot, int howMany)
 {
 	BulkSplitStack pack(armyId, srcSlot, howMany);
-	sendRequest(&pack);
+	sendRequest(pack);
 	return 0;
 }
 
 int CCallback::bulkSmartSplitStack(ObjectInstanceID armyId, SlotID srcSlot)
 {
 	BulkSmartSplitStack pack(armyId, srcSlot);
-	sendRequest(&pack);
+	sendRequest(pack);
 	return 0;
 }
 
 int CCallback::bulkMergeStacks(ObjectInstanceID armyId, SlotID srcSlot)
 {
 	BulkMergeStacks pack(armyId, srcSlot);
-	sendRequest(&pack);
+	sendRequest(pack);
 	return 0;
 }
 
@@ -151,7 +151,7 @@ bool CCallback::dismissHero(const CGHeroInstance *hero)
 	if(player!=hero->tempOwner) return false;
 
 	DismissHero pack(hero->id);
-	sendRequest(&pack);
+	sendRequest(pack);
 	return true;
 }
 
@@ -160,7 +160,7 @@ bool CCallback::swapArtifacts(const ArtifactLocation &l1, const ArtifactLocation
 	ExchangeArtifacts ea;
 	ea.src = l1;
 	ea.dst = l2;
-	sendRequest(&ea);
+	sendRequest(ea);
 	return true;
 }
 
@@ -175,13 +175,13 @@ bool CCallback::swapArtifacts(const ArtifactLocation &l1, const ArtifactLocation
 void CCallback::assembleArtifacts(const ObjectInstanceID & heroID, ArtifactPosition artifactSlot, bool assemble, ArtifactID assembleTo)
 {
 	AssembleArtifacts aa(heroID, artifactSlot, assemble, assembleTo);
-	sendRequest(&aa);
+	sendRequest(aa);
 }
 
 void CCallback::bulkMoveArtifacts(ObjectInstanceID srcHero, ObjectInstanceID dstHero, bool swap, bool equipped, bool backpack)
 {
 	BulkExchangeArtifacts bma(srcHero, dstHero, swap, equipped, backpack);
-	sendRequest(&bma);
+	sendRequest(bma);
 }
 
 void CCallback::scrollBackpackArtifacts(ObjectInstanceID hero, bool left)
@@ -189,7 +189,7 @@ void CCallback::scrollBackpackArtifacts(ObjectInstanceID hero, bool left)
 	ManageBackpackArtifacts mba(hero, ManageBackpackArtifacts::ManageCmd::SCROLL_RIGHT);
 	if(left)
 		mba.cmd = ManageBackpackArtifacts::ManageCmd::SCROLL_LEFT;
-	sendRequest(&mba);
+	sendRequest(mba);
 }
 
 void CCallback::sortBackpackArtifactsBySlot(const ObjectInstanceID hero)
@@ -213,13 +213,13 @@ void CCallback::sortBackpackArtifactsByClass(const ObjectInstanceID hero)
 void CCallback::manageHeroCostume(ObjectInstanceID hero, size_t costumeIndex, bool saveCostume)
 {
 	ManageEquippedArtifacts mea(hero, costumeIndex, saveCostume);
-	sendRequest(&mea);
+	sendRequest(mea);
 }
 
 void CCallback::eraseArtifactByClient(const ArtifactLocation & al)
 {
 	EraseArtifactByClient ea(al);
-	sendRequest(&ea);
+	sendRequest(ea);
 }
 
 bool CCallback::buildBuilding(const CGTownInstance *town, BuildingID buildingID)
@@ -231,7 +231,7 @@ bool CCallback::buildBuilding(const CGTownInstance *town, BuildingID buildingID)
 		return false;
 
 	BuildStructure pack(town->id,buildingID);
-	sendRequest(&pack);
+	sendRequest(pack);
 	return true;
 }
 
@@ -241,7 +241,7 @@ bool CCallback::visitTownBuilding(const CGTownInstance *town, BuildingID buildin
 		return false;
 
 	VisitTownBuilding pack(town->id, buildingID);
-	sendRequest(&pack);
+	sendRequest(pack);
 	return true;
 }
 
@@ -250,10 +250,10 @@ void CBattleCallback::battleMakeSpellAction(const BattleID & battleID, const Bat
 	assert(action.actionType == EActionType::HERO_SPELL);
 	MakeAction mca(action);
 	mca.battleID = battleID;
-	sendRequest(&mca);
+	sendRequest(mca);
 }
 
-int CBattleCallback::sendRequest(const CPackForServer * request)
+int CBattleCallback::sendRequest(const CPackForServer & request)
 {
 	int requestID = cl->sendRequest(request, *getPlayerID());
 	if(waitTillRealize)
@@ -278,7 +278,7 @@ void CCallback::swapGarrisonHero( const CGTownInstance *town )
 	if(town->tempOwner == *player || (town->garrisonHero && town->garrisonHero->tempOwner == *player ))
 	{
 		GarrisonHeroSwap pack(town->id);
-		sendRequest(&pack);
+		sendRequest(pack);
 	}
 }
 
@@ -287,7 +287,7 @@ void CCallback::buyArtifact(const CGHeroInstance *hero, ArtifactID aid)
 	if(hero->tempOwner != *player) return;
 
 	BuyArtifact pack(hero->id,aid);
-	sendRequest(&pack);
+	sendRequest(pack);
 }
 
 void CCallback::trade(const ObjectInstanceID marketId, EMarketMode mode, TradeItemSell id1, TradeItemBuy id2, ui32 val1, const CGHeroInstance * hero)
@@ -304,13 +304,13 @@ void CCallback::trade(const ObjectInstanceID marketId, EMarketMode mode, const s
 	pack.r1 = id1;
 	pack.r2 = id2;
 	pack.val = val1;
-	sendRequest(&pack);
+	sendRequest(pack);
 }
 
 void CCallback::setFormation(const CGHeroInstance * hero, EArmyFormation mode)
 {
 	SetFormation pack(hero->id, mode);
-	sendRequest(&pack);
+	sendRequest(pack);
 }
 
 void CCallback::recruitHero(const CGObjectInstance *townOrTavern, const CGHeroInstance *hero, const HeroTypeID & nextHero)
@@ -320,7 +320,7 @@ void CCallback::recruitHero(const CGObjectInstance *townOrTavern, const CGHeroIn
 
 	HireHero pack(hero->getHeroType(), townOrTavern->id, nextHero);
 	pack.player = *player;
-	sendRequest(&pack);
+	sendRequest(pack);
 }
 
 void CCallback::save( const std::string &fname )
@@ -334,7 +334,7 @@ void CCallback::gamePause(bool pause)
 	{
 		GamePause pack;
 		pack.player = *player;
-		sendRequest(&pack);
+		sendRequest(pack);
 	}
 	else
 	{
@@ -348,14 +348,14 @@ void CCallback::sendMessage(const std::string &mess, const CGObjectInstance * cu
 	PlayerMessage pm(mess, currentObject? currentObject->id : ObjectInstanceID(-1));
 	if(player)
 		pm.player = *player;
-	sendRequest(&pm);
+	sendRequest(pm);
 }
 
 void CCallback::buildBoat( const IShipyard *obj )
 {
 	BuildBoat bb;
 	bb.objid = dynamic_cast<const CGObjectInstance*>(obj)->id;
-	sendRequest(&bb);
+	sendRequest(bb);
 }
 
 CCallback::CCallback(CGameState * GS, std::optional<PlayerColor> Player, CClient * C)
@@ -397,7 +397,7 @@ void CCallback::dig( const CGObjectInstance *hero )
 {
 	DigWithHero dwh;
 	dwh.id = hero->id;
-	sendRequest(&dwh);
+	sendRequest(dwh);
 }
 
 void CCallback::castSpell(const CGHeroInstance *hero, SpellID spellID, const int3 &pos)
@@ -406,7 +406,7 @@ void CCallback::castSpell(const CGHeroInstance *hero, SpellID spellID, const int
 	cas.hid = hero->id;
 	cas.sid = spellID;
 	cas.pos = pos;
-	sendRequest(&cas);
+	sendRequest(cas);
 }
 
 int CCallback::mergeOrSwapStacks(const CArmedInstance *s1, const CArmedInstance *s2, SlotID p1, SlotID p2)
@@ -439,7 +439,7 @@ void CBattleCallback::battleMakeUnitAction(const BattleID & battleID, const Batt
 	MakeAction ma;
 	ma.ba = action;
 	ma.battleID = battleID;
-	sendRequest(&ma);
+	sendRequest(ma);
 }
 
 void CBattleCallback::battleMakeTacticAction(const BattleID & battleID, const BattleAction & action )
@@ -448,7 +448,7 @@ void CBattleCallback::battleMakeTacticAction(const BattleID & battleID, const Ba
 	MakeAction ma;
 	ma.ba = action;
 	ma.battleID = battleID;
-	sendRequest(&ma);
+	sendRequest(ma);
 }
 
 std::optional<BattleAction> CBattleCallback::makeSurrenderRetreatDecision(const BattleID & battleID, const BattleStateInfoForRetreat & battleState)

--- a/CCallback.cpp
+++ b/CCallback.cpp
@@ -195,19 +195,19 @@ void CCallback::scrollBackpackArtifacts(ObjectInstanceID hero, bool left)
 void CCallback::sortBackpackArtifactsBySlot(const ObjectInstanceID hero)
 {
 	ManageBackpackArtifacts mba(hero, ManageBackpackArtifacts::ManageCmd::SORT_BY_SLOT);
-	sendRequest(&mba);
+	sendRequest(mba);
 }
 
 void CCallback::sortBackpackArtifactsByCost(const ObjectInstanceID hero)
 {
 	ManageBackpackArtifacts mba(hero, ManageBackpackArtifacts::ManageCmd::SORT_BY_COST);
-	sendRequest(&mba);
+	sendRequest(mba);
 }
 
 void CCallback::sortBackpackArtifactsByClass(const ObjectInstanceID hero)
 {
 	ManageBackpackArtifacts mba(hero, ManageBackpackArtifacts::ManageCmd::SORT_BY_CLASS);
-	sendRequest(&mba);
+	sendRequest(mba);
 }
 
 void CCallback::manageHeroCostume(ObjectInstanceID hero, size_t costumeIndex, bool saveCostume)
@@ -270,7 +270,7 @@ int CBattleCallback::sendRequest(const CPackForServer & request)
 void CCallback::spellResearch( const CGTownInstance *town, SpellID spellAtSlot, bool accepted )
 {
 	SpellResearch pack(town->id, spellAtSlot, accepted);
-	sendRequest(&pack);
+	sendRequest(pack);
 }
 
 void CCallback::swapGarrisonHero( const CGTownInstance *town )

--- a/CCallback.h
+++ b/CCallback.h
@@ -127,7 +127,7 @@ class CBattleCallback : public IBattleCallback
 	std::optional<PlayerColor> player;
 
 protected:
-	int sendRequest(const CPackForServer * request); //returns requestID (that'll be matched to requestID in PackageApplied)
+	int sendRequest(const CPackForServer & request); //returns requestID (that'll be matched to requestID in PackageApplied)
 	CClient *cl;
 
 public:

--- a/client/CServerHandler.cpp
+++ b/client/CServerHandler.cpp
@@ -938,7 +938,7 @@ void CServerHandler::visitForLobby(CPackForLobby & lobbyPack)
 
 void CServerHandler::visitForClient(CPackForClient & clientPack)
 {
-	client->handlePack(&clientPack);
+	client->handlePack(clientPack);
 }
 
 

--- a/client/CServerHandler.cpp
+++ b/client/CServerHandler.cpp
@@ -853,7 +853,7 @@ void CServerHandler::onPacketReceived(const std::shared_ptr<INetworkConnection> 
 	if(getState() == EClientState::DISCONNECTING)
 		return;
 
-	CPack * pack = logicConnection->retrievePack(message);
+	auto pack = logicConnection->retrievePack(message);
 	ServerHandlerCPackVisitor visitor(*this);
 	pack->visit(visitor);
 }
@@ -945,7 +945,7 @@ void CServerHandler::visitForClient(CPackForClient & clientPack)
 void CServerHandler::sendLobbyPack(const CPackForLobby & pack) const
 {
 	if(getState() != EClientState::STARTING)
-		logicConnection->sendPack(&pack);
+		logicConnection->sendPack(pack);
 }
 
 bool CServerHandler::inLobbyRoom() const

--- a/client/CServerHandler.h
+++ b/client/CServerHandler.h
@@ -25,7 +25,6 @@ struct TurnTimerInfo;
 class CMapInfo;
 class CGameState;
 struct ClientPlayer;
-struct CPack;
 struct CPackForLobby;
 struct CPackForClient;
 

--- a/client/Client.cpp
+++ b/client/Client.cpp
@@ -362,8 +362,6 @@ void CClient::handlePack(CPackForClient * pack)
 	logNetwork->trace("\tApplied on gs: %s", typeid(*pack).name());
 	pack->visit(afterVisitor);
 	logNetwork->trace("\tMade second apply on cl: %s", typeid(*pack).name());
-
-	delete pack;
 }
 
 int CClient::sendRequest(const CPackForServer * request, PlayerColor player)
@@ -376,7 +374,7 @@ int CClient::sendRequest(const CPackForServer * request, PlayerColor player)
 	waitingRequest.pushBack(requestID);
 	request->requestID = requestID;
 	request->player = player;
-	CSH->logicConnection->sendPack(request);
+	CSH->logicConnection->sendPack(*request);
 	if(vstd::contains(playerint, player))
 		playerint[player]->requestSent(request, requestID);
 

--- a/client/Client.cpp
+++ b/client/Client.cpp
@@ -163,7 +163,7 @@ void CClient::save(const std::string & fname)
 	}
 
 	SaveGame save_game(fname);
-	sendRequest(&save_game, PlayerColor::NEUTRAL);
+	sendRequest(save_game, PlayerColor::NEUTRAL);
 }
 
 void CClient::endNetwork()
@@ -348,35 +348,35 @@ void CClient::installNewBattleInterface(std::shared_ptr<CBattleGameInterface> ba
 	}
 }
 
-void CClient::handlePack(CPackForClient * pack)
+void CClient::handlePack(CPackForClient & pack)
 {
 	ApplyClientNetPackVisitor afterVisitor(*this, *gameState());
 	ApplyFirstClientNetPackVisitor beforeVisitor(*this, *gameState());
 
-	pack->visit(beforeVisitor);
-	logNetwork->trace("\tMade first apply on cl: %s", typeid(*pack).name());
+	pack.visit(beforeVisitor);
+	logNetwork->trace("\tMade first apply on cl: %s", typeid(pack).name());
 	{
 		boost::unique_lock lock(CGameState::mutex);
 		gs->apply(pack);
 	}
-	logNetwork->trace("\tApplied on gs: %s", typeid(*pack).name());
-	pack->visit(afterVisitor);
-	logNetwork->trace("\tMade second apply on cl: %s", typeid(*pack).name());
+	logNetwork->trace("\tApplied on gs: %s", typeid(pack).name());
+	pack.visit(afterVisitor);
+	logNetwork->trace("\tMade second apply on cl: %s", typeid(pack).name());
 }
 
-int CClient::sendRequest(const CPackForServer * request, PlayerColor player)
+int CClient::sendRequest(const CPackForServer & request, PlayerColor player)
 {
 	static ui32 requestCounter = 1;
 
 	ui32 requestID = requestCounter++;
-	logNetwork->trace("Sending a request \"%s\". It'll have an ID=%d.", typeid(*request).name(), requestID);
+	logNetwork->trace("Sending a request \"%s\". It'll have an ID=%d.", typeid(request).name(), requestID);
 
 	waitingRequest.pushBack(requestID);
-	request->requestID = requestID;
-	request->player = player;
-	CSH->logicConnection->sendPack(*request);
+	request.requestID = requestID;
+	request.player = player;
+	CSH->logicConnection->sendPack(request);
 	if(vstd::contains(playerint, player))
-		playerint[player]->requestSent(request, requestID);
+		playerint[player]->requestSent(&request, requestID);
 
 	return requestID;
 }

--- a/client/Client.h
+++ b/client/Client.h
@@ -204,7 +204,7 @@ public:
 	void setManaPoints(ObjectInstanceID hid, int val) override {};
 	void giveHero(ObjectInstanceID id, PlayerColor player, ObjectInstanceID boatId = ObjectInstanceID()) override {};
 	void changeObjPos(ObjectInstanceID objid, int3 newPos, const PlayerColor & initiator) override {};
-	void sendAndApply(CPackForClient * pack) override {};
+	void sendAndApply(CPackForClient & pack) override {};
 	void heroExchange(ObjectInstanceID hero1, ObjectInstanceID hero2) override {};
 	void castSpell(const spells::Caster * caster, SpellID spellID, const int3 &pos) override {};
 

--- a/client/Client.h
+++ b/client/Client.h
@@ -16,7 +16,6 @@
 
 VCMI_LIB_NAMESPACE_BEGIN
 
-struct CPack;
 struct CPackForServer;
 class IBattleEventsReceiver;
 class CBattleGameInterface;

--- a/client/Client.h
+++ b/client/Client.h
@@ -142,8 +142,8 @@ public:
 
 	static ThreadSafeVector<int> waitingRequest; //FIXME: make this normal field (need to join all threads before client destruction)
 
-	void handlePack(CPackForClient * pack); //applies the given pack and deletes it
-	int sendRequest(const CPackForServer * request, PlayerColor player); //returns ID given to that request
+	void handlePack(CPackForClient & pack); //applies the given pack and deletes it
+	int sendRequest(const CPackForServer & request, PlayerColor player); //returns ID given to that request
 
 	void battleStarted(const BattleInfo * info);
 	void battleFinished(const BattleID & battleID);

--- a/include/vcmi/ServerCallback.h
+++ b/include/vcmi/ServerCallback.h
@@ -36,15 +36,15 @@ public:
 
 	virtual vstd::RNG * getRNG() = 0;
 
-	virtual void apply(CPackForClient * pack) = 0;
+	virtual void apply(CPackForClient & pack) = 0;
 
-	virtual void apply(BattleLogMessage * pack) = 0;
-	virtual void apply(BattleStackMoved * pack) = 0;
-	virtual void apply(BattleUnitsChanged * pack) = 0;
-	virtual void apply(SetStackEffect * pack) = 0;
-	virtual void apply(StacksInjured * pack) = 0;
-	virtual void apply(BattleObstaclesChanged * pack) = 0;
-	virtual void apply(CatapultAttack * pack) = 0;
+	virtual void apply(BattleLogMessage & pack) = 0;
+	virtual void apply(BattleStackMoved & pack) = 0;
+	virtual void apply(BattleUnitsChanged & pack) = 0;
+	virtual void apply(SetStackEffect & pack) = 0;
+	virtual void apply(StacksInjured & pack) = 0;
+	virtual void apply(BattleObstaclesChanged & pack) = 0;
+	virtual void apply(CatapultAttack & pack) = 0;
 };
 
 VCMI_LIB_NAMESPACE_END

--- a/lib/CStack.cpp
+++ b/lib/CStack.cpp
@@ -401,7 +401,7 @@ void CStack::spendMana(ServerCallback * server, const int spellCost) const
 	ssp.which = BattleSetStackProperty::CASTS;
 	ssp.val = -spellCost;
 	ssp.absolute = false;
-	server->apply(&ssp);
+	server->apply(ssp);
 }
 
 VCMI_LIB_NAMESPACE_END

--- a/lib/IGameCallback.h
+++ b/lib/IGameCallback.h
@@ -140,7 +140,7 @@ public:
 	virtual void setManaPoints(ObjectInstanceID hid, int val)=0;
 	virtual void giveHero(ObjectInstanceID id, PlayerColor player, ObjectInstanceID boatId = ObjectInstanceID()) = 0;
 	virtual void changeObjPos(ObjectInstanceID objid, int3 newPos, const PlayerColor & initiator)=0;
-	virtual void sendAndApply(CPackForClient * pack) = 0;
+	virtual void sendAndApply(CPackForClient & pack) = 0;
 	virtual void heroExchange(ObjectInstanceID hero1, ObjectInstanceID hero2)=0; //when two heroes meet on adventure map
 	virtual void changeFogOfWar(int3 center, ui32 radius, PlayerColor player, ETileVisibility mode) = 0;
 	virtual void changeFogOfWar(const std::unordered_set<int3> &tiles, PlayerColor player, ETileVisibility mode) = 0;

--- a/lib/battle/CBattleInfoCallback.cpp
+++ b/lib/battle/CBattleInfoCallback.cpp
@@ -927,7 +927,7 @@ bool CBattleInfoCallback::handleObstacleTriggersForUnit(SpellCastEnvironment & s
 				bocp.battleID = getBattle()->getBattleID();
 				bocp.changes.emplace_back(spellObstacle.uniqueID, operation);
 				changedObstacle.toInfo(bocp.changes.back(), operation);
-				spellEnv.apply(&bocp);
+				spellEnv.apply(bocp);
 			};
 			const auto side = unit.unitSide();
 			auto shouldReveal = !spellObstacle->hidden || !battleIsObstacleVisibleForSide(*obstacle, side);

--- a/lib/gameState/CGameState.cpp
+++ b/lib/gameState/CGameState.cpp
@@ -1143,9 +1143,9 @@ PlayerRelations CGameState::getPlayerRelations( PlayerColor color1, PlayerColor 
 	return PlayerRelations::ENEMIES;
 }
 
-void CGameState::apply(CPackForClient *pack)
+void CGameState::apply(CPackForClient & pack)
 {
-	pack->applyGs(this);
+	pack.applyGs(this);
 }
 
 void CGameState::calculatePaths(const CGHeroInstance *hero, CPathsInfo &out)

--- a/lib/gameState/CGameState.h
+++ b/lib/gameState/CGameState.h
@@ -98,7 +98,7 @@ public:
 	/// picks next free hero type of the H3 hero init sequence -> chosen starting hero, then unused hero type randomly
 	HeroTypeID pickNextHeroType(const PlayerColor & owner);
 
-	void apply(CPackForClient *pack);
+	void apply(CPackForClient & pack);
 	BattleField battleGetBattlefieldType(int3 tile, vstd::RNG & rand);
 
 	void fillUpgradeInfo(const CArmedInstance *obj, SlotID stackPos, UpgradeInfo &out) const override;

--- a/lib/mapObjects/CBank.cpp
+++ b/lib/mapObjects/CBank.cpp
@@ -138,7 +138,7 @@ bool CBank::wasVisited (PlayerColor player) const
 void CBank::onHeroVisit(const CGHeroInstance * h) const
 {
 	ChangeObjectVisitors cov(ChangeObjectVisitors::VISITOR_ADD_PLAYER, id, h->id);
-	cb->sendAndApply(&cov);
+	cb->sendAndApply(cov);
 
 	BlockingDialog bd(true, false);
 	bd.player = h->getOwner();

--- a/lib/mapObjects/CGDwelling.cpp
+++ b/lib/mapObjects/CGDwelling.cpp
@@ -224,7 +224,7 @@ void CGDwelling::onHeroVisit( const CGHeroInstance * h ) const
 		iw.player = h->tempOwner;
 		iw.text.appendLocalString(EMetaText::ADVOB_TXT, 44); //{%s} \n\n The camp is deserted.  Perhaps you should try next week.
 		iw.text.replaceName(ID);
-		cb->sendAndApply(&iw);
+		cb->sendAndApply(iw);
 		return;
 	}
 
@@ -324,7 +324,7 @@ void CGDwelling::newTurn(vstd::RNG & rand) const
 	}
 
 	if(change)
-		cb->sendAndApply(&sac);
+		cb->sendAndApply(sac);
 
 	updateGuards();
 }
@@ -392,7 +392,7 @@ void CGDwelling::updateGuards() const
 				csc.slot = slot;
 				csc.count = crea->getGrowth() * 3;
 				csc.absoluteValue = true;
-				cb->sendAndApply(&csc);
+				cb->sendAndApply(csc);
 			}
 			else //slot is empty, create whole new stack
 			{
@@ -401,7 +401,7 @@ void CGDwelling::updateGuards() const
 				ns.slot = slot;
 				ns.type = crea->getId();
 				ns.count = crea->getGrowth() * 3;
-				cb->sendAndApply(&ns);
+				cb->sendAndApply(ns);
 			}
 		}
 	}
@@ -458,7 +458,7 @@ void CGDwelling::heroAcceptsCreatures( const CGHeroInstance *h) const
 				iw.text.replaceNamePlural(crid);
 
 				cb->showInfoDialog(&iw);
-				cb->sendAndApply(&sac);
+				cb->sendAndApply(sac);
 				cb->addToSlot(StackLocation(h, slot), crs, count);
 			}
 		}
@@ -469,7 +469,7 @@ void CGDwelling::heroAcceptsCreatures( const CGHeroInstance *h) const
 			iw.text.appendLocalString(EMetaText::GENERAL_TXT, 422); //There are no %s here to recruit.
 			iw.text.replaceNamePlural(crid);
 			iw.player = h->tempOwner;
-			cb->sendAndApply(&iw);
+			cb->sendAndApply(iw);
 		}
 	}
 	else
@@ -483,7 +483,7 @@ void CGDwelling::heroAcceptsCreatures( const CGHeroInstance *h) const
 			sac.creatures[0].first = !h->getArt(ArtifactPosition::MACH1); //ballista
 			sac.creatures[1].first = !h->getArt(ArtifactPosition::MACH3); //first aid tent
 			sac.creatures[2].first = !h->getArt(ArtifactPosition::MACH2); //ammo cart
-			cb->sendAndApply(&sac);
+			cb->sendAndApply(sac);
 		}
 
 		auto windowMode = (ID == Obj::CREATURE_GENERATOR1 || ID == Obj::REFUGEE_CAMP) ? EOpenWindowMode::RECRUITMENT_FIRST : EOpenWindowMode::RECRUITMENT_ALL;

--- a/lib/mapObjects/CGHeroInstance.cpp
+++ b/lib/mapObjects/CGHeroInstance.cpp
@@ -804,7 +804,7 @@ void CGHeroInstance::spendMana(ServerCallback * server, const int spellCost) con
 		sm.hid = id;
 		sm.val = -spellCost;
 
-		server->apply(&sm);
+		server->apply(sm);
 	}
 }
 

--- a/lib/mapObjects/CGMarket.cpp
+++ b/lib/mapObjects/CGMarket.cpp
@@ -93,7 +93,7 @@ void CGBlackMarket::newTurn(vstd::RNG & rand) const
 	SetAvailableArtifacts saa;
 	saa.id = id;
 	cb->pickAllowedArtsSet(saa.arts, rand);
-	cb->sendAndApply(&saa);
+	cb->sendAndApply(saa);
 }
 
 std::vector<TradeItemBuy> CGUniversity::availableItemsIds(EMarketMode mode) const

--- a/lib/mapObjects/CGTownInstance.cpp
+++ b/lib/mapObjects/CGTownInstance.cpp
@@ -350,7 +350,7 @@ void CGTownInstance::onHeroVisit(const CGHeroInstance * h) const
 			scp.heroid = h->id;
 			scp.which = SetCommanderProperty::ALIVE;
 			scp.amount = 1;
-			cb->sendAndApply(&scp);
+			cb->sendAndApply(scp);
 		}
 		cb->heroVisitCastle(this, h);
 		// TODO(vmarkovtsev): implement payment for rising the commander
@@ -631,7 +631,7 @@ void CGTownInstance::removeCapitols(const PlayerColor & owner) const
 				rs.tid = id;
 				rs.bid.insert(BuildingID::CAPITOL);
 				rs.destroyed = destroyed;
-				cb->sendAndApply(&rs);
+				cb->sendAndApply(rs);
 				return;
 			}
 		}

--- a/lib/mapObjects/CQuest.cpp
+++ b/lib/mapObjects/CQuest.cpp
@@ -588,7 +588,7 @@ void CGSeerHut::onHeroVisit(const CGHeroInstance * h) const
 			AddQuest aq;
 			aq.quest = QuestInfo (quest, this, visitablePos());
 			aq.player = h->tempOwner;
-			cb->sendAndApply(&aq); //TODO: merge with setObjProperty?
+			cb->sendAndApply(aq); //TODO: merge with setObjProperty?
 		}
 
 		if(firstVisit || failRequirements)
@@ -811,7 +811,7 @@ void CGKeymasterTent::onHeroVisit( const CGHeroInstance * h ) const
 		cow.mode = ChangeObjectVisitors::VISITOR_GLOBAL;
 		cow.hero = h->id;
 		cow.object = id;
-		cb->sendAndApply(&cow);
+		cb->sendAndApply(cow);
 		txt_id=19;
 	}
 	else
@@ -860,7 +860,7 @@ void CGBorderGuard::onHeroVisit(const CGHeroInstance * h) const
 		AddQuest aq;
 		aq.quest = QuestInfo (quest, this, visitablePos());
 		aq.player = h->tempOwner;
-		cb->sendAndApply (&aq);
+		cb->sendAndApply(aq);
 		//TODO: add this quest only once OR check for multiple instances later
 	}
 }
@@ -885,7 +885,7 @@ void CGBorderGate::onHeroVisit(const CGHeroInstance * h) const //TODO: passabili
 		AddQuest aq;
 		aq.quest = QuestInfo (quest, this, visitablePos());
 		aq.player = h->tempOwner;
-		cb->sendAndApply (&aq);
+		cb->sendAndApply(aq);
 	}
 }
 

--- a/lib/mapObjects/CRewardableObject.cpp
+++ b/lib/mapObjects/CRewardableObject.cpp
@@ -35,7 +35,7 @@ const IObjectInterface * CRewardableObject::getObject() const
 void CRewardableObject::markAsScouted(const CGHeroInstance * hero) const
 {
 	ChangeObjectVisitors cov(ChangeObjectVisitors::VISITOR_ADD_PLAYER, id, hero->id);
-	cb->sendAndApply(&cov);
+	cb->sendAndApply(cov);
 }
 
 bool CRewardableObject::isGuarded() const
@@ -48,7 +48,7 @@ void CRewardableObject::onHeroVisit(const CGHeroInstance *hero) const
 	if(!wasScouted(hero->getOwner()))
 	{
 		ChangeObjectVisitors cov(ChangeObjectVisitors::VISITOR_SCOUTED, id, hero->id);
-		cb->sendAndApply(&cov);
+		cb->sendAndApply(cov);
 	}
 
 	if (isGuarded())
@@ -116,7 +116,7 @@ void CRewardableObject::markAsVisited(const CGHeroInstance * hero) const
 	cb->setObjPropertyValue(id, ObjProperty::REWARD_CLEARED, true);
 
 	ChangeObjectVisitors cov(ChangeObjectVisitors::VISITOR_ADD_HERO, id, hero->id);
-	cb->sendAndApply(&cov);
+	cb->sendAndApply(cov);
 }
 
 void CRewardableObject::grantReward(ui32 rewardID, const CGHeroInstance * hero) const
@@ -336,7 +336,7 @@ void CRewardableObject::newTurn(vstd::RNG & rand) const
 		{
 			cb->setObjPropertyValue(id, ObjProperty::REWARD_CLEARED, false);
 			ChangeObjectVisitors cov(ChangeObjectVisitors::VISITOR_CLEAR, id);
-			cb->sendAndApply(&cov);
+			cb->sendAndApply(cov);
 		}
 	}
 }

--- a/lib/mapObjects/IObjectInterface.cpp
+++ b/lib/mapObjects/IObjectInterface.cpp
@@ -28,7 +28,7 @@ void IObjectInterface::showInfoDialog(const ui32 txtID, const ui16 soundID, EInf
 	iw.player = getOwner();
 	iw.type = mode;
 	iw.text.appendLocalString(EMetaText::ADVOB_TXT,txtID);
-	cb->sendAndApply(&iw);
+	cb->sendAndApply(iw);
 }
 
 ///IObjectInterface

--- a/lib/mapObjects/MiscObjects.cpp
+++ b/lib/mapObjects/MiscObjects.cpp
@@ -1087,14 +1087,14 @@ void CGMagi::onHeroVisit(const CGHeroInstance * h) const
 			for(const auto & eye : eyes)
 			{
 				cb->getTilesInRange (fw.tiles, eye->pos, 10, ETileVisibility::HIDDEN, h->tempOwner);
-				cb->sendAndApply(&fw);
+				cb->sendAndApply(fw);
 				cv.pos = eye->pos;
 
-				cb->sendAndApply(&cv);
+				cb->sendAndApply(cv);
 			}
 			cv.pos = h->visitablePos();
 			cv.focusTime = 0;
-			cb->sendAndApply(&cv);
+			cb->sendAndApply(cv);
 		}
 	}
 	else if (ID == Obj::EYE_OF_MAGI)
@@ -1258,7 +1258,7 @@ void CGObelisk::onHeroVisit( const CGHeroInstance * h ) const
 	if(!wasVisited(team))
 	{
 		iw.text.appendLocalString(EMetaText::ADVOB_TXT, 96);
-		cb->sendAndApply(&iw);
+		cb->sendAndApply(iw);
 
 		// increment general visited obelisks counter
 		cb->setObjPropertyID(id, ObjProperty::OBELISK_VISITED, team);
@@ -1273,7 +1273,7 @@ void CGObelisk::onHeroVisit( const CGHeroInstance * h ) const
 	else
 	{
 		iw.text.appendLocalString(EMetaText::ADVOB_TXT, 97);
-		cb->sendAndApply(&iw);
+		cb->sendAndApply(iw);
 	}
 
 }
@@ -1341,7 +1341,7 @@ void CGLighthouse::onHeroVisit( const CGHeroInstance * h ) const
 			rb.whoID = oldOwner;
 			rb.source = BonusSource::OBJECT_INSTANCE;
 			rb.id = BonusSourceID(id);
-			cb->sendAndApply(&rb);
+			cb->sendAndApply(rb);
 		}
 	}
 }
@@ -1372,7 +1372,7 @@ void CGLighthouse::giveBonusTo(const PlayerColor & player, bool onInit) const
 	if(onInit)
 		gb.applyGs(cb->gameState());
 	else
-		cb->sendAndApply(&gb);
+		cb->sendAndApply(gb);
 }
 
 void CGLighthouse::serializeJsonOptions(JsonSerializeFormat& handler)

--- a/lib/serializer/Connection.h
+++ b/lib/serializer/Connection.h
@@ -51,8 +51,8 @@ public:
 	explicit CConnection(std::weak_ptr<INetworkConnection> networkConnection);
 	~CConnection();
 
-	void sendPack(const CPack * pack);
-	CPack * retrievePack(const std::vector<std::byte> & data);
+	void sendPack(const CPack & pack);
+	std::unique_ptr<CPack> retrievePack(const std::vector<std::byte> & data);
 
 	void enterLobbyConnectionMode();
 	void setCallback(IGameCallback * cb);

--- a/lib/spells/AdventureSpellMechanics.cpp
+++ b/lib/spells/AdventureSpellMechanics.cpp
@@ -105,7 +105,7 @@ ESpellCastResult AdventureSpellMechanics::applyAdventureEffects(SpellCastEnviron
 			GiveBonus gb;
 			gb.id = ObjectInstanceID(parameters.caster->getCasterUnitId());
 			gb.bonus = b;
-			env->apply(&gb);
+			env->apply(gb);
 		}
 
 		return ESpellCastResult::OK;
@@ -136,7 +136,7 @@ void AdventureSpellMechanics::performCast(SpellCastEnvironment * env, const Adve
 	AdvmapSpellCast asc;
 	asc.casterID = ObjectInstanceID(parameters.caster->getCasterUnitId());
 	asc.spellID = owner->id;
-	env->apply(&asc);
+	env->apply(asc);
 
 	ESpellCastResult result = applyAdventureEffects(env, parameters);
 
@@ -194,7 +194,7 @@ ESpellCastResult SummonBoatMechanics::applyAdventureEffects(SpellCastEnvironment
 		iw.player = parameters.caster->getCasterOwner();
 		iw.text.appendLocalString(EMetaText::GENERAL_TXT, 336); //%s tried to summon a boat, but failed.
 		parameters.caster->getCasterName(iw.text);
-		env->apply(&iw);
+		env->apply(iw);
 		return ESpellCastResult::OK;
 	}
 
@@ -226,14 +226,14 @@ ESpellCastResult SummonBoatMechanics::applyAdventureEffects(SpellCastEnvironment
 		cop.objid = nearest->id;
 		cop.nPos = summonPos;
 		cop.initiator = parameters.caster->getCasterOwner();
-		env->apply(&cop);
+		env->apply(cop);
 	}
 	else if(schoolLevel < 2) //none or basic level -> cannot create boat :(
 	{
 		InfoWindow iw;
 		iw.player = parameters.caster->getCasterOwner();
 		iw.text.appendLocalString(EMetaText::GENERAL_TXT, 335); //There are no boats to summon.
-		env->apply(&iw);
+		env->apply(iw);
 		return ESpellCastResult::ERROR;
 	}
 	else //create boat
@@ -282,7 +282,7 @@ ESpellCastResult ScuttleBoatMechanics::applyAdventureEffects(SpellCastEnvironmen
 		iw.player = parameters.caster->getCasterOwner();
 		iw.text.appendLocalString(EMetaText::GENERAL_TXT, 337); //%s tried to scuttle the boat, but failed
 		parameters.caster->getCasterName(iw.text);
-		env->apply(&iw);
+		env->apply(iw);
 		return ESpellCastResult::OK;
 	}
 
@@ -291,7 +291,7 @@ ESpellCastResult ScuttleBoatMechanics::applyAdventureEffects(SpellCastEnvironmen
 	RemoveObject ro;
 	ro.initiator = parameters.caster->getCasterOwner();
 	ro.objectID = t.visitableObjects.back()->id;
-	env->apply(&ro);
+	env->apply(ro);
 	return ESpellCastResult::OK;
 }
 
@@ -400,14 +400,14 @@ ESpellCastResult DimensionDoorMechanics::applyAdventureEffects(SpellCastEnvironm
 		{
 			// SOD: DD to such "wrong" terrain results in mana and move points spending, but fails to move hero
 			iw.text = MetaString::createFromTextID("core.genrltxt.70"); // Dimension Door failed!
-			env->apply(&iw);
+			env->apply(iw);
 			// no return - resources will be spent
 		}
 		else
 		{
 			// HotA: game will show error message without taking mana or move points, even when DD into terra incognita
 			iw.text = MetaString::createFromTextID("vcmi.dimensionDoor.seaToLandError");
-			env->apply(&iw);
+			env->apply(iw);
 			return ESpellCastResult::CANCEL;
 		}
 	}
@@ -415,7 +415,7 @@ ESpellCastResult DimensionDoorMechanics::applyAdventureEffects(SpellCastEnvironm
 	GiveBonus gb;
 	gb.id = ObjectInstanceID(parameters.caster->getCasterUnitId());
 	gb.bonus = Bonus(BonusDuration::ONE_DAY, BonusType::NONE, BonusSource::SPELL_EFFECT, 0, BonusSourceID(owner->id));
-	env->apply(&gb);
+	env->apply(gb);
 
 	SetMovePoints smp;
 	smp.hid = ObjectInstanceID(parameters.caster->getCasterUnitId());
@@ -423,7 +423,7 @@ ESpellCastResult DimensionDoorMechanics::applyAdventureEffects(SpellCastEnvironm
 		smp.val = parameters.caster->getHeroCaster()->movementPointsRemaining() - movementCost;
 	else
 		smp.val = 0;
-	env->apply(&smp);
+	env->apply(smp);
 
 	return ESpellCastResult::OK;
 }
@@ -471,7 +471,7 @@ ESpellCastResult TownPortalMechanics::applyAdventureEffects(SpellCastEnvironment
 			InfoWindow iw;
 			iw.player = parameters.caster->getCasterOwner();
 			iw.text.appendLocalString(EMetaText::GENERAL_TXT, 123);
-			env->apply(&iw);
+			env->apply(iw);
 			return ESpellCastResult::CANCEL;
 		}
 	}
@@ -539,7 +539,7 @@ ESpellCastResult TownPortalMechanics::applyAdventureEffects(SpellCastEnvironment
 		InfoWindow iw;
 		iw.player = parameters.caster->getCasterOwner();
 		iw.text.appendLocalString(EMetaText::GENERAL_TXT, 135);
-		env->apply(&iw);
+		env->apply(iw);
 		return ESpellCastResult::ERROR;
 	}
 
@@ -568,7 +568,7 @@ void TownPortalMechanics::endCast(SpellCastEnvironment * env, const AdventureSpe
 		SetMovePoints smp;
 		smp.hid = ObjectInstanceID(parameters.caster->getCasterUnitId());
 		smp.val = std::max<ui32>(0, parameters.caster->getHeroCaster()->movementPointsRemaining() - moveCost);
-		env->apply(&smp);
+		env->apply(smp);
 	}
 }
 
@@ -587,7 +587,7 @@ ESpellCastResult TownPortalMechanics::beginCast(SpellCastEnvironment * env, cons
 		InfoWindow iw;
 		iw.player = parameters.caster->getCasterOwner();
 		iw.text.appendLocalString(EMetaText::GENERAL_TXT, 124);
-		env->apply(&iw);
+		env->apply(iw);
 		return ESpellCastResult::CANCEL;
 	}
 
@@ -598,7 +598,7 @@ ESpellCastResult TownPortalMechanics::beginCast(SpellCastEnvironment * env, cons
 		InfoWindow iw;
 		iw.player = parameters.caster->getCasterOwner();
 		iw.text.appendLocalString(EMetaText::GENERAL_TXT, 125);
-		env->apply(&iw);
+		env->apply(iw);
 		return ESpellCastResult::CANCEL;
 	}
 
@@ -643,7 +643,7 @@ ESpellCastResult TownPortalMechanics::beginCast(SpellCastEnvironment * env, cons
 			InfoWindow iw;
 			iw.player = parameters.caster->getCasterOwner();
 			iw.text.appendLocalString(EMetaText::GENERAL_TXT, 124);
-			env->apply(&iw);
+			env->apply(iw);
 			return ESpellCastResult::CANCEL;
 		}
 
@@ -737,7 +737,7 @@ ESpellCastResult ViewMechanics::applyAdventureEffects(SpellCastEnvironment * env
 	}
 	pack.showTerrain = showTerrain(spellLevel);
 
-	env->apply(&pack);
+	env->apply(pack);
 
 	return ESpellCastResult::OK;
 }

--- a/lib/spells/BattleSpellMechanics.cpp
+++ b/lib/spells/BattleSpellMechanics.cpp
@@ -353,9 +353,9 @@ void BattleSpellMechanics::cast(ServerCallback * server, const Target & target)
 		sc.affectedCres.insert(unit->unitId());
 
 	if(!castDescription.lines.empty())
-		server->apply(&castDescription);
+		server->apply(castDescription);
 
-	server->apply(&sc);
+	server->apply(sc);
 
 	for(auto & p : effectsToApply)
 		p.first->apply(server, this, p.second);
@@ -375,7 +375,7 @@ void BattleSpellMechanics::cast(ServerCallback * server, const Target & target)
 	// temporary(?) workaround to force animations to trigger
 	StacksInjured fakeEvent;
 	fakeEvent.battleID = battle()->getBattle()->getBattleID();
-	server->apply(&fakeEvent);
+	server->apply(fakeEvent);
 }
 
 void BattleSpellMechanics::beforeCast(BattleSpellCast & sc, vstd::RNG & rng, const Target & target)
@@ -491,7 +491,7 @@ void BattleSpellMechanics::doRemoveEffects(ServerCallback * server, const std::v
 	}
 
 	if(!sse.toRemove.empty())
-		server->apply(&sse);
+		server->apply(sse);
 }
 
 bool BattleSpellMechanics::counteringSelector(const Bonus * bonus) const

--- a/lib/spells/effects/Catapult.cpp
+++ b/lib/spells/effects/Catapult.cpp
@@ -104,7 +104,7 @@ void Catapult::applyMassive(ServerCallback * server, const Mechanics * m) const
 			attackInfo->damageDealt += getRandomDamage(server);
 		}
 	}
-	server->apply(&ca);
+	server->apply(ca);
 
 	removeTowerShooters(server, m);
 }
@@ -144,7 +144,7 @@ void Catapult::applyTargeted(ServerCallback * server, const Mechanics * m, const
 		ca.battleID = m->battle()->getBattle()->getBattleID();
 		ca.attacker = m->caster->getHeroCaster() ? -1 : m->caster->getCasterUnitId();
 		ca.attackedParts.push_back(attack);
-		server->apply(&ca);
+		server->apply(ca);
 		removeTowerShooters(server, m);
 	}
 }
@@ -228,7 +228,7 @@ void Catapult::removeTowerShooters(ServerCallback * server, const Mechanics * m)
 	}
 
 	if(!removeUnits.changedStacks.empty())
-		server->apply(&removeUnits);
+		server->apply(removeUnits);
 }
 
 std::vector<EWallPart> Catapult::getPotentialTargets(const Mechanics * m, bool bypassGateCheck, bool bypassTowerCheck) const

--- a/lib/spells/effects/Clone.cpp
+++ b/lib/spells/effects/Clone.cpp
@@ -65,7 +65,7 @@ void Clone::apply(ServerCallback * server, const Mechanics * m, const EffectTarg
 		pack.battleID = m->battle()->getBattle()->getBattleID();
 		pack.changedStacks.emplace_back(info.id, UnitChanges::EOperation::ADD);
 		info.save(pack.changedStacks.back().data);
-		server->apply(&pack);
+		server->apply(pack);
 
 		//TODO: use BattleUnitsChanged with UPDATE operation
 
@@ -90,7 +90,7 @@ void Clone::apply(ServerCallback * server, const Mechanics * m, const EffectTarg
 		cloneFlags.changedStacks.emplace_back(originalState->unitId(), UnitChanges::EOperation::RESET_STATE);
 		originalState->save(cloneFlags.changedStacks.back().data);
 
-		server->apply(&cloneFlags);
+		server->apply(cloneFlags);
 
 		SetStackEffect sse;
 		sse.battleID = m->battle()->getBattle()->getBattleID();
@@ -100,7 +100,7 @@ void Clone::apply(ServerCallback * server, const Mechanics * m, const EffectTarg
 		std::vector<Bonus> buffer;
 		buffer.push_back(lifeTimeMarker);
 		sse.toAdd.emplace_back(unitId, buffer);
-		server->apply(&sse);
+		server->apply(sse);
 	}
 }
 

--- a/lib/spells/effects/Damage.cpp
+++ b/lib/spells/effects/Damage.cpp
@@ -80,10 +80,10 @@ void Damage::apply(ServerCallback * server, const Mechanics * m, const EffectTar
 	}
 
 	if(!stacksInjured.stacks.empty())
-		server->apply(&stacksInjured);
+		server->apply(stacksInjured);
 
 	if(!blm.lines.empty())
-		server->apply(&blm);
+		server->apply(blm);
 }
 
 bool Damage::isReceptive(const Mechanics * m, const battle::Unit * unit) const

--- a/lib/spells/effects/DemonSummon.cpp
+++ b/lib/spells/effects/DemonSummon.cpp
@@ -98,7 +98,7 @@ void DemonSummon::apply(ServerCallback * server, const Mechanics * m, const Effe
 	}
 
 	if(!pack.changedStacks.empty())
-		server->apply(&pack);
+		server->apply(pack);
 }
 
 bool DemonSummon::isValidTarget(const Mechanics * m, const battle::Unit * unit) const

--- a/lib/spells/effects/Dispel.cpp
+++ b/lib/spells/effects/Dispel.cpp
@@ -65,10 +65,10 @@ void Dispel::apply(ServerCallback * server, const Mechanics * m, const EffectTar
 	}
 
 	if(!sse.toRemove.empty())
-		server->apply(&sse);
+		server->apply(sse);
 
 	if(describe && !blm.lines.empty())
-		server->apply(&blm);
+		server->apply(blm);
 }
 
 bool Dispel::isValidTarget(const Mechanics * m, const battle::Unit * unit) const

--- a/lib/spells/effects/Heal.cpp
+++ b/lib/spells/effects/Heal.cpp
@@ -42,9 +42,9 @@ void Heal::apply(int64_t value, ServerCallback * server, const Mechanics * m, co
 
 	prepareHealEffect(value, pack, logMessage, *server->getRNG(), m, target);
 	if(!pack.changedStacks.empty())
-		server->apply(&pack);
+		server->apply(pack);
 	if(!logMessage.lines.empty())
-		server->apply(&logMessage);
+		server->apply(logMessage);
 }
 
 bool Heal::isValidTarget(const Mechanics * m, const battle::Unit * unit) const

--- a/lib/spells/effects/Moat.cpp
+++ b/lib/spells/effects/Moat.cpp
@@ -122,7 +122,7 @@ void Moat::apply(ServerCallback * server, const Mechanics * m, const EffectTarge
 			GiveBonus gb(GiveBonus::ETarget::BATTLE);
 			gb.id = m->battle()->getBattle()->getBattleID();
 			gb.bonus = b;
-			server->apply(&gb);
+			server->apply(gb);
 		}
 	}
 }
@@ -171,7 +171,7 @@ void Moat::placeObstacles(ServerCallback * server, const Mechanics * m, const Ef
 	}
 
 	if(!pack.changes.empty())
-		server->apply(&pack);
+		server->apply(pack);
 }
 
 }

--- a/lib/spells/effects/Obstacle.cpp
+++ b/lib/spells/effects/Obstacle.cpp
@@ -326,7 +326,7 @@ void Obstacle::placeObstacles(ServerCallback * server, const Mechanics * m, cons
 	}
 
 	if(!pack.changes.empty())
-		server->apply(&pack);
+		server->apply(pack);
 }
 
 }

--- a/lib/spells/effects/RemoveObstacle.cpp
+++ b/lib/spells/effects/RemoveObstacle.cpp
@@ -54,7 +54,7 @@ void RemoveObstacle::apply(ServerCallback * server, const Mechanics * m, const E
 	}
 
 	if(!pack.changes.empty())
-		server->apply(&pack);
+		server->apply(pack);
 }
 
 void RemoveObstacle::serializeJsonEffect(JsonSerializeFormat & handler)

--- a/lib/spells/effects/Sacrifice.cpp
+++ b/lib/spells/effects/Sacrifice.cpp
@@ -125,7 +125,7 @@ void Sacrifice::apply(ServerCallback * server, const Mechanics * m, const Effect
 	BattleUnitsChanged removeUnits;
 	removeUnits.battleID = m->battle()->getBattle()->getBattleID();
 	removeUnits.changedStacks.emplace_back(victim->unitId(), UnitChanges::EOperation::REMOVE);
-	server->apply(&removeUnits);
+	server->apply(removeUnits);
 }
 
 bool Sacrifice::isValidTarget(const Mechanics * m, const battle::Unit * unit) const

--- a/lib/spells/effects/Summon.cpp
+++ b/lib/spells/effects/Summon.cpp
@@ -159,7 +159,7 @@ void Summon::apply(ServerCallback * server, const Mechanics * m, const EffectTar
 	}
 
 	if(!pack.changedStacks.empty())
-		server->apply(&pack);
+		server->apply(pack);
 }
 
 EffectTarget Summon::filterTarget(const Mechanics * m, const EffectTarget & target) const

--- a/lib/spells/effects/Teleport.cpp
+++ b/lib/spells/effects/Teleport.cpp
@@ -85,7 +85,7 @@ void Teleport::apply(ServerCallback * server, const Mechanics * m, const EffectT
 	tiles.push_back(destination);
 	pack.tilesToMove = tiles;
 	pack.teleporting = true;
-	server->apply(&pack);
+	server->apply(pack);
 
 	if(triggerObstacles)
 	{

--- a/lib/spells/effects/Timed.cpp
+++ b/lib/spells/effects/Timed.cpp
@@ -205,10 +205,10 @@ void Timed::apply(ServerCallback * server, const Mechanics * m, const EffectTarg
 	}
 
 	if(!(sse.toAdd.empty() && sse.toUpdate.empty()))
-		server->apply(&sse);
+		server->apply(sse);
 
 	if(describe && !blm.lines.empty())
-		server->apply(&blm);
+		server->apply(blm);
 }
 
 void Timed::convertBonus(const Mechanics * m, int32_t & duration, std::vector<Bonus> & converted) const

--- a/scripting/lua/api/ServerCb.cpp
+++ b/scripting/lua/api/ServerCb.cpp
@@ -74,7 +74,7 @@ int ServerCbProxy::commitPackage(lua_State * L)
 
 	auto * pack = static_cast<CPackForClient *>(lua_touserdata(L, 1));
 
-	object->apply(pack);
+	object->apply(*pack);
 
 	return S.retVoid();
 }
@@ -96,7 +96,7 @@ int ServerCbProxy::apply(lua_State * L)
 	if(!S.tryGet(1, pack))
 		return S.retVoid();
 
-	object->apply(pack.get());
+	object->apply(*pack);
 
 	return S.retVoid();
 }

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -1444,8 +1444,8 @@ void CGameHandler::sendToAllClients(CPackForClient * pack)
 void CGameHandler::sendAndApply(CPackForClient * pack)
 {
 	sendToAllClients(pack);
-	gs->apply(pack);
-	logNetwork->trace("\tApplied on gs: %s", typeid(*pack).name());
+	gs->apply(*pack);
+	logNetwork->trace("\tApplied on gs: %s", typeid(pack).name());
 }
 
 void CGameHandler::sendAndApply(CGarrisonOperationPack * pack)

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -4008,7 +4008,7 @@ bool CGameHandler::isValidObject(const CGObjectInstance *obj) const
 	return vstd::contains(gs->map->objects, obj);
 }
 
-bool CGameHandler::isBlockedByQueries(const CPack *pack, PlayerColor player)
+bool CGameHandler::isBlockedByQueries(const CPackForServer *pack, PlayerColor player)
 {
 	if (dynamic_cast<const PlayerMessage *>(pack) != nullptr)
 		return false;

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -467,7 +467,7 @@ void CGameHandler::handleReceivedPack(CPackForServer * pack)
 		applied.result = successfullyApplied;
 		applied.packType = CTypeList::getInstance().getTypeID(pack);
 		applied.requestID = pack->requestID;
-		pack->c->sendPack(&applied);
+		pack->c->sendPack(applied);
 	};
 
 	if(isBlockedByQueries(pack, pack->player))
@@ -1438,7 +1438,7 @@ void CGameHandler::sendToAllClients(CPackForClient * pack)
 {
 	logNetwork->trace("\tSending to all clients: %s", typeid(*pack).name());
 	for (auto c : lobby->activeConnections)
-		c->sendPack(pack);
+		c->sendPack(*pack);
 }
 
 void CGameHandler::sendAndApply(CPackForClient * pack)

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -156,7 +156,7 @@ void CGameHandler::levelUpHero(const CGHeroInstance * hero)
 	sps.which = primarySkill;
 	sps.abs = false;
 	sps.val = 1;
-	sendAndApply(&sps);
+	sendAndApply(sps);
 
 	HeroLevelUp hlu;
 	hlu.player = hero->tempOwner;
@@ -166,12 +166,12 @@ void CGameHandler::levelUpHero(const CGHeroInstance * hero)
 
 	if (hlu.skills.size() == 0)
 	{
-		sendAndApply(&hlu);
+		sendAndApply(hlu);
 		levelUpHero(hero);
 	}
 	else if (hlu.skills.size() == 1 || !hero->getOwner().isValidPlayer())
 	{
-		sendAndApply(&hlu);
+		sendAndApply(hlu);
 		levelUpHero(hero, hlu.skills.front());
 	}
 	else if (hlu.skills.size() > 1)
@@ -179,7 +179,7 @@ void CGameHandler::levelUpHero(const CGHeroInstance * hero)
 		auto levelUpQuery = std::make_shared<CHeroLevelUpDialogQuery>(this, hlu, hero);
 		hlu.queryID = levelUpQuery->queryID;
 		queries->addQuery(levelUpQuery);
-		sendAndApply(&hlu);
+		sendAndApply(hlu);
 		//level up will be called on query reply
 	}
 }
@@ -237,31 +237,31 @@ void CGameHandler::levelUpCommander (const CCommanderInstance * c, int skill)
 			case ECommander::SPELL_POWER:
 				scp.accumulatedBonus.type = BonusType::MAGIC_RESISTANCE;
 				scp.accumulatedBonus.val = difference (VLC->creh->skillLevels, c->secondarySkills, ECommander::RESISTANCE);
-				sendAndApply (&scp); //additional pack
+				sendAndApply(scp); //additional pack
 				scp.accumulatedBonus.type = BonusType::CREATURE_SPELL_POWER;
 				scp.accumulatedBonus.val = difference (VLC->creh->skillLevels, c->secondarySkills, ECommander::SPELL_POWER) * 100; //like hero with spellpower = ability level
-				sendAndApply (&scp); //additional pack
+				sendAndApply(scp); //additional pack
 				scp.accumulatedBonus.type = BonusType::CASTS;
 				scp.accumulatedBonus.val = difference (VLC->creh->skillLevels, c->secondarySkills, ECommander::CASTS);
-				sendAndApply (&scp); //additional pack
+				sendAndApply(scp); //additional pack
 				scp.accumulatedBonus.type = BonusType::CREATURE_ENCHANT_POWER; //send normally
 				break;
 		}
 
 		scp.accumulatedBonus.val = difference (VLC->creh->skillLevels, c->secondarySkills, skill);
-		sendAndApply (&scp);
+		sendAndApply(scp);
 
 		scp.which = SetCommanderProperty::SECONDARY_SKILL;
 		scp.additionalInfo = skill;
 		scp.amount = c->secondarySkills.at(skill) + 1;
-		sendAndApply (&scp);
+		sendAndApply(scp);
 	}
 	else if (skill >= 100)
 	{
 		scp.which = SetCommanderProperty::SPECIAL_SKILL;
 		scp.accumulatedBonus = *VLC->creh->skillRequirements.at(skill-100).first;
 		scp.additionalInfo = skill; //unnormalized
-		sendAndApply (&scp);
+		sendAndApply(scp);
 	}
 	expGiven(hero);
 }
@@ -306,12 +306,12 @@ void CGameHandler::levelUpCommander(const CCommanderInstance * c)
 
 	if (!skillAmount)
 	{
-		sendAndApply(&clu);
+		sendAndApply(clu);
 		levelUpCommander(c);
 	}
 	else if (skillAmount == 1  ||  hero->tempOwner == PlayerColor::NEUTRAL) //choose skill automatically
 	{
-		sendAndApply(&clu);
+		sendAndApply(clu);
 		levelUpCommander(c, *RandomGeneratorUtil::nextItem(clu.skills, getRandomGenerator()));
 	}
 	else if (skillAmount > 1) //apply and ask for secondary skill
@@ -319,7 +319,7 @@ void CGameHandler::levelUpCommander(const CCommanderInstance * c)
 		auto commanderLevelUp = std::make_shared<CCommanderLevelUpDialogQuery>(this, clu, hero);
 		clu.queryID = commanderLevelUp->queryID;
 		queries->addQuery(commanderLevelUp);
-		sendAndApply(&clu);
+		sendAndApply(clu);
 	}
 }
 
@@ -357,7 +357,7 @@ void CGameHandler::giveExperience(const CGHeroInstance * hero, TExpType amountTo
 		iw.player = hero->tempOwner;
 		iw.text.appendLocalString(EMetaText::GENERAL_TXT, 1); //can gain no more XP
 		iw.text.replaceTextID(hero->getNameTextID());
-		sendAndApply(&iw);
+		sendAndApply(iw);
 	}
 
 	SetPrimSkill sps;
@@ -365,7 +365,7 @@ void CGameHandler::giveExperience(const CGHeroInstance * hero, TExpType amountTo
 	sps.which = PrimarySkill::EXPERIENCE;
 	sps.abs = false;
 	sps.val = amountToGain;
-	sendAndApply(&sps);
+	sendAndApply(sps);
 
 	//hero may level up
 	if (hero->commander && hero->commander->alive)
@@ -375,7 +375,7 @@ void CGameHandler::giveExperience(const CGHeroInstance * hero, TExpType amountTo
 		scp.heroid = hero->id;
 		scp.which = SetCommanderProperty::EXPERIENCE;
 		scp.amount = amountToGain;
-		sendAndApply (&scp);
+		sendAndApply(scp);
 		CBonusSystemNode::treeHasChanged();
 	}
 
@@ -389,7 +389,7 @@ void CGameHandler::changePrimSkill(const CGHeroInstance * hero, PrimarySkill whi
 	sps.which = which;
 	sps.abs = abs;
 	sps.val = val;
-	sendAndApply(&sps);
+	sendAndApply(sps);
 }
 
 void CGameHandler::changeSecSkill(const CGHeroInstance * hero, SecondarySkill which, int val, bool abs)
@@ -404,7 +404,7 @@ void CGameHandler::changeSecSkill(const CGHeroInstance * hero, SecondarySkill wh
 	sss.which = which;
 	sss.val = val;
 	sss.abs = abs;
-	sendAndApply(&sss);
+	sendAndApply(sss);
 
 	if (hero->visitedTown)
 		giveSpells(hero->visitedTown, hero);
@@ -596,7 +596,7 @@ void CGameHandler::setPortalDwelling(const CGTownInstance * town, bool forced=fa
 				ssi.creatures[town->town->creatures.size()].first = creatureId.toEntity(VLC)->getGrowth();
 			}
 			ssi.creatures[town->town->creatures.size()].second.push_back(creatureId);
-			sendAndApply(&ssi);
+			sendAndApply(ssi);
 		}
 }
 
@@ -683,7 +683,7 @@ void CGameHandler::onNewTurn()
 		SetAvailableArtifacts saa;
 		saa.id = ObjectInstanceID::NONE;
 		pickAllowedArtsSet(saa.arts, getRandomGenerator());
-		sendAndApply(&saa);
+		sendAndApply(saa);
 	}
 
 	newTurnProcessor->onNewTurn();
@@ -770,7 +770,7 @@ void CGameHandler::giveSpells(const CGTownInstance *t, const CGHeroInstance *h)
 		}
 	}
 	if (!cs.spells.empty())
-		sendAndApply(&cs);
+		sendAndApply(cs);
 }
 
 bool CGameHandler::removeObject(const CGObjectInstance * obj, const PlayerColor & initiator)
@@ -784,7 +784,7 @@ bool CGameHandler::removeObject(const CGObjectInstance * obj, const PlayerColor 
 	RemoveObject ro;
 	ro.objectID = obj->id;
 	ro.initiator = initiator;
-	sendAndApply(&ro);
+	sendAndApply(ro);
 
 	checkVictoryLossConditionsForAll(); //eg if monster escaped (removing objs after battle is done dircetly by endBattle, not this function)
 	return true;
@@ -857,7 +857,7 @@ bool CGameHandler::moveHero(ObjectInstanceID hid, int3 dst, EMovementMode moveme
 	{
 		//send info about movement failure
 		complain(message);
-		sendAndApply(&tmh);
+		sendAndApply(tmh);
 		return false;
 	};
 
@@ -924,7 +924,7 @@ bool CGameHandler::moveHero(ObjectInstanceID hid, int3 dst, EMovementMode moveme
 			tmh.attackedFrom = std::make_optional(guardPos);
 
 		tmh.result = result;
-		sendAndApply(&tmh);
+		sendAndApply(tmh);
 
 		if (visitDest == VISIT_DEST && objectToVisit && objectToVisit->id == h->id)
 		{ // Hero should be always able to visit any object he is staying on even if there are guards around
@@ -1101,7 +1101,7 @@ void CGameHandler::showBlockingDialog(const IObjectInterface * caller, BlockingD
 	auto dialogQuery = std::make_shared<CBlockingDialogQuery>(this, caller, *iw);
 	queries->addQuery(dialogQuery);
 	iw->queryID = dialogQuery->queryID;
-	sendToAllClients(iw);
+	sendToAllClients(*iw);
 }
 
 void CGameHandler::showTeleportDialog(TeleportDialog *iw)
@@ -1109,7 +1109,7 @@ void CGameHandler::showTeleportDialog(TeleportDialog *iw)
 	auto dialogQuery = std::make_shared<CTeleportDialogQuery>(this, *iw);
 	queries->addQuery(dialogQuery);
 	iw->queryID = dialogQuery->queryID;
-	sendToAllClients(iw);
+	sendToAllClients(*iw);
 }
 
 void CGameHandler::giveResource(PlayerColor player, GameResID which, int val) //TODO: cap according to Bersy's suggestion
@@ -1127,7 +1127,7 @@ void CGameHandler::giveResources(PlayerColor player, TResources resources)
 	sr.abs = false;
 	sr.player = player;
 	sr.res = resources;
-	sendAndApply(&sr);
+	sendAndApply(sr);
 }
 
 void CGameHandler::giveCreatures(const CArmedInstance *obj, const CGHeroInstance * h, const CCreatureSet &creatures, bool remove)
@@ -1187,7 +1187,7 @@ void CGameHandler::heroVisitCastle(const CGTownInstance * obj, const CGHeroInsta
 		vc.hid = hero->id;
 		vc.tid = obj->id;
 		vc.flags |= 1;
-		sendAndApply(&vc);
+		sendAndApply(vc);
 	}
 	visitCastleObjects(obj, hero);
 
@@ -1227,7 +1227,7 @@ void CGameHandler::stopHeroVisitCastle(const CGTownInstance * obj, const CGHeroI
 	HeroVisitCastle vc;
 	vc.hid = hero->id;
 	vc.tid = obj->id;
-	sendAndApply(&vc);
+	sendAndApply(vc);
 }
 
 void CGameHandler::removeArtifact(const ArtifactLocation & al)
@@ -1240,7 +1240,7 @@ void CGameHandler::removeArtifact(const ObjectInstanceID & srcId, const std::vec
 	BulkEraseArtifacts ea;
 	ea.artHolder = srcId;
 	ea.posPack.insert(ea.posPack.end(), slotsPack.begin(), slotsPack.end());
-	sendAndApply(&ea);
+	sendAndApply(ea);
 }
 
 void CGameHandler::changeSpells(const CGHeroInstance * hero, bool give, const std::set<SpellID> &spells)
@@ -1249,7 +1249,7 @@ void CGameHandler::changeSpells(const CGHeroInstance * hero, bool give, const st
 	cs.hid = hero->id;
 	cs.spells = spells;
 	cs.learn = give;
-	sendAndApply(&cs);
+	sendAndApply(cs);
 }
 
 void CGameHandler::setResearchedSpells(const CGTownInstance * town, int level, const std::vector<SpellID> spells, bool accepted)
@@ -1264,12 +1264,12 @@ void CGameHandler::setResearchedSpells(const CGTownInstance * town, int level, c
 
 void CGameHandler::giveHeroBonus(GiveBonus * bonus)
 {
-	sendAndApply(bonus);
+	sendAndApply(*bonus);
 }
 
 void CGameHandler::setMovePoints(SetMovePoints * smp)
 {
-	sendAndApply(smp);
+	sendAndApply(*smp);
 }
 
 void CGameHandler::setMovePoints(ObjectInstanceID hid, int val, bool absolute)
@@ -1278,7 +1278,7 @@ void CGameHandler::setMovePoints(ObjectInstanceID hid, int val, bool absolute)
 	smp.hid = hid;
 	smp.val = val;
 	smp.absolute = absolute;
-	sendAndApply(&smp);
+	sendAndApply(smp);
 }
 
 void CGameHandler::setManaPoints(ObjectInstanceID hid, int val)
@@ -1287,7 +1287,7 @@ void CGameHandler::setManaPoints(ObjectInstanceID hid, int val)
 	sm.hid = hid;
 	sm.val = val;
 	sm.absolute = true;
-	sendAndApply(&sm);
+	sendAndApply(sm);
 }
 
 void CGameHandler::giveHero(ObjectInstanceID id, PlayerColor player, ObjectInstanceID boatId)
@@ -1296,7 +1296,7 @@ void CGameHandler::giveHero(ObjectInstanceID id, PlayerColor player, ObjectInsta
 	gh.id = id;
 	gh.player = player;
 	gh.boatId = boatId;
-	sendAndApply(&gh);
+	sendAndApply(gh);
 
 	//Reveal fow around new hero, especially released from Prison
 	auto h = getHero(id);
@@ -1309,7 +1309,7 @@ void CGameHandler::changeObjPos(ObjectInstanceID objid, int3 newPos, const Playe
 	cop.objid = objid;
 	cop.nPos = newPos;
 	cop.initiator = initiator;
-	sendAndApply(&cop);
+	sendAndApply(cop);
 }
 
 void CGameHandler::useScholarSkill(ObjectInstanceID fromHero, ObjectInstanceID toHero)
@@ -1379,7 +1379,7 @@ void CGameHandler::useScholarSkill(ObjectInstanceID fromHero, ObjectInstanceID t
 			}
 			iw.text.appendLocalString(EMetaText::GENERAL_TXT, 142);//from %s
 			iw.text.replaceTextID(h2->getNameTextID());
-			sendAndApply(&cs2);
+			sendAndApply(cs2);
 		}
 
 		if (!cs1.spells.empty() && !cs2.spells.empty())
@@ -1407,9 +1407,9 @@ void CGameHandler::useScholarSkill(ObjectInstanceID fromHero, ObjectInstanceID t
 			}
 			iw.text.appendLocalString(EMetaText::GENERAL_TXT, 148);//from %s
 			iw.text.replaceTextID(h2->getNameTextID());
-			sendAndApply(&cs1);
+			sendAndApply(cs1);
 		}
-		sendAndApply(&iw);
+		sendAndApply(iw);
 	}
 }
 
@@ -1426,43 +1426,43 @@ void CGameHandler::heroExchange(ObjectInstanceID hero1, ObjectInstanceID hero2)
 		hex.player = h1->getOwner();
 		hex.hero1 = hero1;
 		hex.hero2 = hero2;
-		sendAndApply(&hex);
+		sendAndApply(hex);
 
 		useScholarSkill(hero1,hero2);
 		queries->addQuery(exchange);
 	}
 }
 
-void CGameHandler::sendToAllClients(CPackForClient * pack)
+void CGameHandler::sendToAllClients(CPackForClient & pack)
 {
-	logNetwork->trace("\tSending to all clients: %s", typeid(*pack).name());
+	logNetwork->trace("\tSending to all clients: %s", typeid(pack).name());
 	for (auto c : lobby->activeConnections)
-		c->sendPack(*pack);
+		c->sendPack(pack);
 }
 
-void CGameHandler::sendAndApply(CPackForClient * pack)
+void CGameHandler::sendAndApply(CPackForClient & pack)
 {
 	sendToAllClients(pack);
-	gs->apply(*pack);
+	gs->apply(pack);
 	logNetwork->trace("\tApplied on gs: %s", typeid(pack).name());
 }
 
-void CGameHandler::sendAndApply(CGarrisonOperationPack * pack)
+void CGameHandler::sendAndApply(CGarrisonOperationPack & pack)
 {
-	sendAndApply(static_cast<CPackForClient *>(pack));
+	sendAndApply(static_cast<CPackForClient &>(pack));
 	checkVictoryLossConditionsForAll();
 }
 
-void CGameHandler::sendAndApply(SetResources * pack)
+void CGameHandler::sendAndApply(SetResources & pack)
 {
-	sendAndApply(static_cast<CPackForClient *>(pack));
-	checkVictoryLossConditionsForPlayer(pack->player);
+	sendAndApply(static_cast<CPackForClient &>(pack));
+	checkVictoryLossConditionsForPlayer(pack.player);
 }
 
-void CGameHandler::sendAndApply(NewStructures * pack)
+void CGameHandler::sendAndApply(NewStructures & pack)
 {
-	sendAndApply(static_cast<CPackForClient *>(pack));
-	checkVictoryLossConditionsForPlayer(getTown(pack->tid)->tempOwner);
+	sendAndApply(static_cast<CPackForClient &>(pack));
+	checkVictoryLossConditionsForPlayer(getTown(pack.tid)->tempOwner);
 }
 
 bool CGameHandler::isPlayerOwns(CPackForServer * pack, ObjectInstanceID id)
@@ -1644,7 +1644,7 @@ bool CGameHandler::bulkSplitStack(SlotID slotSrc, ObjectInstanceID srcOwner, si3
 		if(actualAmount <= howMany)
 			break;
 	}
-	sendAndApply(&bulkRS);
+	sendAndApply(bulkRS);
 	return true;
 }
 
@@ -1686,7 +1686,7 @@ bool CGameHandler::bulkMergeStacks(SlotID slotSrc, ObjectInstanceID srcOwner)
 		rs.count = creatureSet.getStackCount(slot);
 		bulkRS.moves.push_back(rs);
 	}
-	sendAndApply(&bulkRS);
+	sendAndApply(bulkRS);
 	return true;
 }
 
@@ -1773,7 +1773,7 @@ bool CGameHandler::bulkMoveArmy(ObjectInstanceID srcArmy, ObjectInstanceID destA
 		rs.count = move.second.second;
 		bulkRS.moves.push_back(rs);
 	}
-	sendAndApply(&bulkRS);
+	sendAndApply(bulkRS);
 	return true;
 }
 
@@ -1855,7 +1855,7 @@ bool CGameHandler::bulkSmartSplitStack(SlotID slotSrc, ObjectInstanceID srcOwner
 		complain((boost::format("Failure: totalCreatures=%d but check=%d") % totalCreatures % check).str());
 		return false;
 	}
-	sendAndApply(&bulkSRS);
+	sendAndApply(bulkSRS);
 	return true;
 }
 
@@ -2096,7 +2096,7 @@ bool CGameHandler::buildStructure(ObjectInstanceID tid, BuildingID requestedID, 
 			if (ssi.creatures[level].second.empty()) // first creature in a dwelling
 				ssi.creatures[level].first = crea->getGrowth();
 			ssi.creatures[level].second.push_back(crea->getId());
-			sendAndApply(&ssi);
+			sendAndApply(ssi);
 		}
 		if(t->town->buildings.at(buildingID)->subId == BuildingSubID::PORTAL_OF_SUMMONING)
 		{
@@ -2178,7 +2178,7 @@ bool CGameHandler::buildStructure(ObjectInstanceID tid, BuildingID requestedID, 
 	}
 
 	//We know what has been built, apply changes. Do this as final step to properly update town window
-	sendAndApply(&ns);
+	sendAndApply(ns);
 
 	//Other post-built events. To some logic like giving spells to work gamestate changes for new building must be already in place!
 	for(auto builtID : ns.bid)
@@ -2247,7 +2247,7 @@ bool CGameHandler::razeStructure (ObjectInstanceID tid, BuildingID bid)
 	rs.tid = tid;
 	rs.bid.insert(bid);
 	rs.destroyed = t->destroyed + 1;
-	sendAndApply(&rs);
+	sendAndApply(rs);
 //TODO: Remove dwellers
 // 	if (t->subID == 4 && bid == 17) //Veil of Darkness
 // 	{
@@ -2255,7 +2255,7 @@ bool CGameHandler::razeStructure (ObjectInstanceID tid, BuildingID bid)
 // 		rb.whoID = t->id;
 // 		rb.source = BonusSource::TOWN_STRUCTURE;
 // 		rb.id = 17;
-// 		sendAndApply(&rb);
+// 		sendAndApply(rb);
 // 	}
 	return true;
 }
@@ -2380,7 +2380,7 @@ bool CGameHandler::recruitCreatures(ObjectInstanceID objid, ObjectInstanceID dst
 	sac.tid = objid;
 	sac.creatures = dwelling->creatures;
 	sac.creatures[level].first -= cram;
-	sendAndApply(&sac);
+	sendAndApply(sac);
 
 	if (warMachine)
 	{
@@ -2443,7 +2443,7 @@ bool CGameHandler::changeStackType(const StackLocation &sl, const CCreature *c)
 	sst.army = sl.army->id;
 	sst.slot = sl.slot;
 	sst.type = c->getId();
-	sendAndApply(&sst);
+	sendAndApply(sst);
 	return true;
 }
 
@@ -2502,7 +2502,7 @@ bool CGameHandler::swapGarrisonOnSiege(ObjectInstanceID tid)
 		intown.visiting = ObjectInstanceID();
 		intown.garrison = town->visitingHero->id;
 	}
-	sendAndApply(&intown);
+	sendAndApply(intown);
 	return true;
 }
 
@@ -2524,7 +2524,7 @@ bool CGameHandler::garrisonSwap(ObjectInstanceID tid)
 		intown.tid = tid;
 		intown.visiting = ObjectInstanceID();
 		intown.garrison = town->visitingHero->id;
-		sendAndApply(&intown);
+		sendAndApply(intown);
 		return true;
 	}
 	else if (town->garrisonHero && !town->visitingHero) //move hero out of the garrison
@@ -2541,7 +2541,7 @@ bool CGameHandler::garrisonSwap(ObjectInstanceID tid)
 		intown.tid = tid;
 		intown.garrison = ObjectInstanceID();
 		intown.visiting =  town->garrisonHero->id;
-		sendAndApply(&intown);
+		sendAndApply(intown);
 		return true;
 	}
 	else if (!!town->garrisonHero && town->visitingHero) //swap visiting and garrison hero
@@ -2550,7 +2550,7 @@ bool CGameHandler::garrisonSwap(ObjectInstanceID tid)
 		intown.tid = tid;
 		intown.garrison = town->visitingHero->id;
 		intown.visiting =  town->garrisonHero->id;
-		sendAndApply(&intown);
+		sendAndApply(intown);
 		return true;
 	}
 	else
@@ -2631,7 +2631,7 @@ bool CGameHandler::moveArtifact(const PlayerColor & player, const ArtifactLocati
 	ma.artsPack0.push_back(BulkMoveArtifacts::LinkedSlots(src.slot, dstSlot));
 	if(src.artHolder != dst.artHolder)
 		ma.artsPack0.back().askAssemble = true;
-	sendAndApply(&ma);
+	sendAndApply(ma);
 	return true;
 }
 
@@ -2732,7 +2732,7 @@ bool CGameHandler::bulkMoveArtifacts(const PlayerColor & player, ObjectInstanceI
 			}
 		}
 	}
-	sendAndApply(&ma);
+	sendAndApply(ma);
 	return true;
 }
 
@@ -2799,7 +2799,7 @@ bool CGameHandler::manageBackpackArtifacts(const PlayerColor & player, const Obj
 				bma.artsPack0.emplace_back(ArtifactPosition::BACKPACK_START, backpackEnd);
 		}
 	}
-	sendAndApply(&bma);
+	sendAndApply(bma);
 	return true;
 }
 
@@ -2815,7 +2815,7 @@ bool CGameHandler::saveArtifactsCostume(const PlayerColor & player, const Object
 			costume.costumeSet.emplace(slot, slotInfo->getArt()->getTypeId());
 	}
 
-	sendAndApply(&costume);
+	sendAndApply(costume);
 	return true;
 }
 
@@ -2870,7 +2870,7 @@ bool CGameHandler::switchArtifactsCostume(const PlayerColor & player, const Obje
 		
 		const auto backpackCap = getSettings().getInteger(EGameSettings::HEROES_BACKPACK_CAP);
 		if((backpackCap < 0 || estimateBackpackSize <= backpackCap) && !bma.artsPack0.empty())
-			sendAndApply(&bma);
+			sendAndApply(bma);
 	}
 	return true;
 }
@@ -2913,7 +2913,7 @@ bool CGameHandler::assembleArtifacts(ObjectInstanceID heroID, ArtifactPosition a
 		AssembledArtifact aa;
 		aa.al = dstLoc;
 		aa.builtArt = combinedArt;
-		sendAndApply(&aa);
+		sendAndApply(aa);
 	}
 	else
 	{
@@ -2926,7 +2926,7 @@ bool CGameHandler::assembleArtifacts(ObjectInstanceID heroID, ArtifactPosition a
 
 		DisassembledArtifact da;
 		da.al = dstLoc;
-		sendAndApply(&da);
+		sendAndApply(da);
 	}
 
 	return true;
@@ -3045,7 +3045,7 @@ bool CGameHandler::buyArtifact(const IMarket *m, const CGHeroInstance *h, GameRe
 	if (!found)
 		COMPLAIN_RET("Cannot find selected artifact on the list");
 
-	sendAndApply(&saa);
+	sendAndApply(saa);
 	giveHeroNewArtifact(h, aid, ArtifactPosition::FIRST_AVAILABLE);
 	return true;
 }
@@ -3209,7 +3209,7 @@ bool CGameHandler::setFormation(ObjectInstanceID hid, EArmyFormation formation)
 	ChangeFormation cf;
 	cf.hid = hid;
 	cf.formation = formation;
-	sendAndApply(&cf);
+	sendAndApply(cf);
 
 	return true;
 }
@@ -3266,7 +3266,7 @@ void CGameHandler::showGarrisonDialog(ObjectInstanceID upobj, ObjectInstanceID h
 	gd.objid = upobj;
 	gd.removableUnits = removableUnits;
 	gd.queryID = garrisonQuery->queryID;
-	sendAndApply(&gd);
+	sendAndApply(gd);
 }
 
 void CGameHandler::showObjectWindow(const CGObjectInstance * object, EOpenWindowMode window, const CGHeroInstance * visitor, bool addQuery)
@@ -3282,7 +3282,7 @@ void CGameHandler::showObjectWindow(const CGObjectInstance * object, EOpenWindow
 		pack.queryID = windowQuery->queryID;
 		queries->addQuery(windowQuery);
 	}
-	sendAndApply(&pack);
+	sendAndApply(pack);
 }
 
 bool CGameHandler::isAllowedExchange(ObjectInstanceID id1, ObjectInstanceID id2)
@@ -3384,7 +3384,7 @@ void CGameHandler::objectVisited(const CGObjectInstance * obj, const CGHeroInsta
 		hv.heroId = h->id;
 		hv.player = h->tempOwner;
 		hv.starting = true;
-		sendAndApply(&hv);
+		sendAndApply(hv);
 
 		obj->onHeroVisit(h);
 	};
@@ -3407,7 +3407,7 @@ void CGameHandler::objectVisitEnded(const CGHeroInstance *h, PlayerColor player)
 		hv.player = event.getPlayer();
 		hv.heroId = event.getHero();
 		hv.starting = false;
-		sendAndApply(&hv);
+		sendAndApply(hv);
 	};
 
 	//TODO: ObjectVisitEnded should also have id of visited object,
@@ -3478,14 +3478,14 @@ void CGameHandler::checkVictoryLossConditionsForPlayer(PlayerColor player)
 	{
 		InfoWindow iw;
 		getVictoryLossMessage(player, victoryLossCheckResult, iw);
-		sendAndApply(&iw);
+		sendAndApply(iw);
 
 		PlayerEndsGame peg;
 		peg.player = player;
 		peg.victoryLossCheckResult = victoryLossCheckResult;
 		peg.statistic = StatisticDataSet(gameState()->statistic);
 		addStatistics(peg.statistic); // add last turn befor win / loss
-		sendAndApply(&peg);
+		sendAndApply(peg);
 
 		turnOrder->onPlayerEndsGame(player);
 
@@ -3504,8 +3504,8 @@ void CGameHandler::checkVictoryLossConditionsForPlayer(PlayerColor player)
 					getVictoryLossMessage(player, peg.victoryLossCheckResult, iw);
 					iw.player = i->first;
 
-					sendAndApply(&iw);
-					sendAndApply(&peg);
+					sendAndApply(iw);
+					sendAndApply(peg);
 				}
 			}
 
@@ -3549,7 +3549,7 @@ void CGameHandler::checkVictoryLossConditionsForPlayer(PlayerColor player)
 					InfoWindow iw;
 					getVictoryLossMessage(player, victoryLossCheckResult.invert(), iw);
 					iw.player = pc;
-					sendAndApply(&iw);
+					sendAndApply(iw);
 				}
 			}
 			checkVictoryLossConditions(playerColors);
@@ -3576,7 +3576,7 @@ bool CGameHandler::dig(const CGHeroInstance *h)
 	SetMovePoints smp;
 	smp.hid = h->id;
 	smp.val = 0;
-	sendAndApply(&smp);
+	sendAndApply(smp);
 
 	InfoWindow iw;
 	iw.type = EInfoWindowMode::AUTO;
@@ -3589,19 +3589,19 @@ bool CGameHandler::dig(const CGHeroInstance *h)
 		iw.text.appendName(grail); // ... " The Grail"
 		iw.soundID = soundBase::ULTIMATEARTIFACT;
 		giveHeroNewArtifact(h, grail, ArtifactPosition::FIRST_AVAILABLE); //give grail
-		sendAndApply(&iw);
+		sendAndApply(iw);
 
 		iw.soundID = soundBase::invalid;
 		iw.components.emplace_back(ComponentType::ARTIFACT, grail);
 		iw.text.clear();
 		iw.text.appendTextID(grail.toArtifact()->getDescriptionTextID());
-		sendAndApply(&iw);
+		sendAndApply(iw);
 	}
 	else
 	{
 		iw.text.appendLocalString(EMetaText::GENERAL_TXT, 59); //"Nothing here. \n Where could it be?"
 		iw.soundID = soundBase::Dig;
-		sendAndApply(&iw);
+		sendAndApply(iw);
 	}
 
 	return true;
@@ -3721,7 +3721,7 @@ bool CGameHandler::insertNewStack(const StackLocation &sl, const CCreature *c, T
 	ins.slot = sl.slot;
 	ins.type = c->getId();
 	ins.count = count;
-	sendAndApply(&ins);
+	sendAndApply(ins);
 	return true;
 }
 
@@ -3740,7 +3740,7 @@ bool CGameHandler::eraseStack(const StackLocation &sl, bool forceRemoval)
 	EraseStack es;
 	es.army = sl.army->id;
 	es.slot = sl.slot;
-	sendAndApply(&es);
+	sendAndApply(es);
 	return true;
 }
 
@@ -3765,7 +3765,7 @@ bool CGameHandler::changeStackCount(const StackLocation &sl, TQuantity count, bo
 		csc.slot = sl.slot;
 		csc.count = count;
 		csc.absoluteValue = absoluteValue;
-		sendAndApply(&csc);
+		sendAndApply(csc);
 	}
 	return true;
 }
@@ -3847,7 +3847,7 @@ bool CGameHandler::moveStack(const StackLocation &src, const StackLocation &dst,
 	rs.srcSlot = src.slot;
 	rs.dstSlot = dst.slot;
 	rs.count = count;
-	sendAndApply(&rs);
+	sendAndApply(rs);
 	return true;
 }
 
@@ -3881,7 +3881,7 @@ bool CGameHandler::swapStacks(const StackLocation & sl1, const StackLocation & s
 		ss.dstArmy = sl2.army->id;
 		ss.srcSlot = sl1.slot;
 		ss.dstSlot = sl2.slot;
-		sendAndApply(&ss);
+		sendAndApply(ss);
 		return true;
 	}
 }
@@ -3919,7 +3919,7 @@ bool CGameHandler::putArtifact(const ArtifactLocation & al, const ArtifactInstan
 	if(artInst->canBePutAt(putTo, dst.slot))
 	{
 		PutArtifact pa(id, dst, askAssemble.value());
-		sendAndApply(&pa);
+		sendAndApply(pa);
 		return true;
 	}
 	else
@@ -3954,7 +3954,7 @@ bool CGameHandler::giveHeroNewArtifact(
 	{
 		COMPLAIN_RET_FALSE_IF(!artType->canBePutAt(h, pos, false), "Cannot put artifact in that slot!");
 	}
-	sendAndApply(&na);
+	sendAndApply(na);
 	return true;
 }
 
@@ -3999,7 +3999,7 @@ void CGameHandler::synchronizeArtifactHandlerLists()
 {
 	UpdateArtHandlerLists uahl;
 	uahl.allocatedArtifacts = gs->allocatedArtifacts;
-	sendAndApply(&uahl);
+	sendAndApply(uahl);
 }
 
 bool CGameHandler::isValidObject(const CGObjectInstance *obj) const
@@ -4086,7 +4086,7 @@ void CGameHandler::changeFogOfWar(const std::unordered_set<int3> &tiles, PlayerC
 			return;
 	}
 
-	sendAndApply(&fow);
+	sendAndApply(fow);
 }
 
 const CGHeroInstance * CGameHandler::getVisitingHero(const CGObjectInstance *obj)
@@ -4137,7 +4137,7 @@ void CGameHandler::setObjPropertyValue(ObjectInstanceID objid, ObjProperty prop,
 	sob.id = objid;
 	sob.what = prop;
 	sob.identifier = NumericID(value);
-	sendAndApply(&sob);
+	sendAndApply(sob);
 }
 
 void CGameHandler::setObjPropertyID(ObjectInstanceID objid, ObjProperty prop, ObjPropertyID identifier)
@@ -4146,7 +4146,7 @@ void CGameHandler::setObjPropertyID(ObjectInstanceID objid, ObjProperty prop, Ob
 	sob.id = objid;
 	sob.what = prop;
 	sob.identifier = identifier;
-	sendAndApply(&sob);
+	sendAndApply(sob);
 }
 
 void CGameHandler::setBankObjectConfiguration(ObjectInstanceID objid, const BankConfig & configuration)
@@ -4154,7 +4154,7 @@ void CGameHandler::setBankObjectConfiguration(ObjectInstanceID objid, const Bank
 	SetBankConfiguration srb;
 	srb.objectID = objid;
 	srb.configuration = configuration;
-	sendAndApply(&srb);
+	sendAndApply(srb);
 }
 
 void CGameHandler::setRewardableObjectConfiguration(ObjectInstanceID objid, const Rewardable::Configuration & configuration)
@@ -4162,7 +4162,7 @@ void CGameHandler::setRewardableObjectConfiguration(ObjectInstanceID objid, cons
 	SetRewardableConfiguration srb;
 	srb.objectID = objid;
 	srb.configuration = configuration;
-	sendAndApply(&srb);
+	sendAndApply(srb);
 }
 
 void CGameHandler::setRewardableObjectConfiguration(ObjectInstanceID townInstanceID, BuildingID buildingID, const Rewardable::Configuration & configuration)
@@ -4171,12 +4171,12 @@ void CGameHandler::setRewardableObjectConfiguration(ObjectInstanceID townInstanc
 	srb.objectID = townInstanceID;
 	srb.buildingID = buildingID;
 	srb.configuration = configuration;
-	sendAndApply(&srb);
+	sendAndApply(srb);
 }
 
 void CGameHandler::showInfoDialog(InfoWindow * iw)
 {
-	sendAndApply(iw);
+	sendAndApply(*iw);
 }
 
 vstd::RNG & CGameHandler::getRandomGenerator()
@@ -4261,7 +4261,7 @@ void CGameHandler::newObject(CGObjectInstance * object, PlayerColor initiator)
 	NewObject no;
 	no.newObject = object;
 	no.initiator = initiator;
-	sendAndApply(&no);
+	sendAndApply(no);
 }
 
 void CGameHandler::startBattle(const CArmedInstance *army1, const CArmedInstance *army2, int3 tile, const CGHeroInstance *hero1, const CGHeroInstance *hero2, const BattleLayout & layout, const CGTownInstance *town)

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -452,7 +452,7 @@ void CGameHandler::handleClientDisconnection(std::shared_ptr<CConnection> c)
 			out.text.appendTextID("vcmi.server.errors.playerLeft");
 			out.text.replaceName(playerId);
 			out.components.emplace_back(ComponentType::FLAG, playerId);
-			sendAndApply(&out);
+			sendAndApply(out);
 		}
 	}
 }
@@ -1259,7 +1259,7 @@ void CGameHandler::setResearchedSpells(const CGTownInstance * town, int level, c
 	cs.spells = spells;
 	cs.level = level;
 	cs.accepted = accepted;
-	sendAndApply(&cs);
+	sendAndApply(cs);
 }
 
 void CGameHandler::giveHeroBonus(GiveBonus * bonus)

--- a/server/CGameHandler.h
+++ b/server/CGameHandler.h
@@ -194,7 +194,7 @@ public:
 
 	void init(StartInfo *si, Load::ProgressAccumulator & progressTracking);
 	void handleClientDisconnection(std::shared_ptr<CConnection> c);
-	void handleReceivedPack(CPackForServer * pack);
+	void handleReceivedPack(CPackForServer & pack);
 	bool hasPlayerAt(PlayerColor player, std::shared_ptr<CConnection> c) const;
 	bool hasBothPlayersAtSameConnection(PlayerColor left, PlayerColor right) const;
 

--- a/server/CGameHandler.h
+++ b/server/CGameHandler.h
@@ -260,11 +260,11 @@ public:
 #endif
 	}
 
-	void sendToAllClients(CPackForClient * pack);
-	void sendAndApply(CPackForClient * pack) override;
-	void sendAndApply(CGarrisonOperationPack * pack);
-	void sendAndApply(SetResources * pack);
-	void sendAndApply(NewStructures * pack);
+	void sendToAllClients(CPackForClient & pack);
+	void sendAndApply(CPackForClient & pack) override;
+	void sendAndApply(CGarrisonOperationPack & pack);
+	void sendAndApply(SetResources & pack);
+	void sendAndApply(NewStructures & pack);
 
 	void wrongPlayerMessage(CPackForServer * pack, PlayerColor expectedplayer);
 	/// Unconditionally throws with "Action not allowed" message

--- a/server/CGameHandler.h
+++ b/server/CGameHandler.h
@@ -27,7 +27,6 @@ class CCommanderInstance;
 class EVictoryLossCheckResult;
 class CRandomGenerator;
 
-struct CPack;
 struct CPackForServer;
 struct NewTurn;
 struct CGarrisonOperationPack;
@@ -89,7 +88,7 @@ public:
 	CVCMIServer * gameLobby() const;
 
 	bool isValidObject(const CGObjectInstance *obj) const;
-	bool isBlockedByQueries(const CPack *pack, PlayerColor player);
+	bool isBlockedByQueries(const CPackForServer *pack, PlayerColor player);
 	bool isAllowedExchange(ObjectInstanceID id1, ObjectInstanceID id2);
 	void giveSpells(const CGTownInstance *t, const CGHeroInstance *h);
 

--- a/server/CVCMIServer.cpp
+++ b/server/CVCMIServer.cpp
@@ -55,7 +55,7 @@ public:
 	void visitForServer(CPackForServer & serverPack) override
 	{
 		if (gh)
-			gh->handleReceivedPack(&serverPack);
+			gh->handleReceivedPack(serverPack);
 		else
 			logNetwork->error("Received pack for game server while in lobby!");
 	}

--- a/server/CVCMIServer.cpp
+++ b/server/CVCMIServer.cpp
@@ -476,7 +476,7 @@ void CVCMIServer::clientDisconnected(std::shared_ptr<CConnection> connection)
 //	}
 //
 //	if(!startAiPack.players.empty())
-//		gh->sendAndApply(&startAiPack);
+//		gh->sendAndApply(startAiPack);
 }
 
 void CVCMIServer::reconnectPlayer(int connId)
@@ -503,7 +503,7 @@ void CVCMIServer::reconnectPlayer(int connId)
 		}
 
 		if(!startAiPack.players.empty())
-			gh->sendAndApply(&startAiPack);
+			gh->sendAndApply(startAiPack);
 	}
 }
 

--- a/server/CVCMIServer.h
+++ b/server/CVCMIServer.h
@@ -86,7 +86,7 @@ public:
 
 	void threadHandleClient(std::shared_ptr<CConnection> c);
 
-	void announcePack(std::unique_ptr<CPackForLobby> pack);
+	void announcePack(CPackForLobby & pack);
 	bool passHost(int toConnectionId);
 
 	void announceTxt(const MetaString & txt, const std::string & playerName = "system");
@@ -102,7 +102,7 @@ public:
 	void announceMessage(const MetaString & txt);
 	void announceMessage(const std::string & txt);
 
-	void handleReceivedPack(std::unique_ptr<CPackForLobby> pack);
+	void handleReceivedPack(CPackForLobby & pack);
 
 	void updateAndPropagateLobbyState();
 

--- a/server/NetPacksLobbyServer.cpp
+++ b/server/NetPacksLobbyServer.cpp
@@ -128,10 +128,10 @@ void ApplyOnServerAfterAnnounceNetPackVisitor::visitLobbyClientDisconnected(Lobb
 	}
 	else if(pack.c->connectionID == srv.hostClientId)
 	{
-		auto ph = std::make_unique<LobbyChangeHost>();
+		LobbyChangeHost ph;
 		auto newHost = srv.activeConnections.front();
-		ph->newHostConnectionId = newHost->connectionID;
-		srv.announcePack(std::move(ph));
+		ph.newHostConnectionId = newHost->connectionID;
+		srv.announcePack(ph);
 	}
 	srv.updateAndPropagateLobbyState();
 	

--- a/server/ServerSpellCastEnvironment.cpp
+++ b/server/ServerSpellCastEnvironment.cpp
@@ -39,42 +39,42 @@ vstd::RNG * ServerSpellCastEnvironment::getRNG()
 	return &gh->getRandomGenerator();
 }
 
-void ServerSpellCastEnvironment::apply(CPackForClient * pack)
+void ServerSpellCastEnvironment::apply(CPackForClient & pack)
 {
 	gh->sendAndApply(pack);
 }
 
-void ServerSpellCastEnvironment::apply(BattleLogMessage * pack)
+void ServerSpellCastEnvironment::apply(BattleLogMessage & pack)
 {
 	gh->sendAndApply(pack);
 }
 
-void ServerSpellCastEnvironment::apply(BattleStackMoved * pack)
+void ServerSpellCastEnvironment::apply(BattleStackMoved & pack)
 {
 	gh->sendAndApply(pack);
 }
 
-void ServerSpellCastEnvironment::apply(BattleUnitsChanged * pack)
+void ServerSpellCastEnvironment::apply(BattleUnitsChanged & pack)
 {
 	gh->sendAndApply(pack);
 }
 
-void ServerSpellCastEnvironment::apply(SetStackEffect * pack)
+void ServerSpellCastEnvironment::apply(SetStackEffect & pack)
 {
 	gh->sendAndApply(pack);
 }
 
-void ServerSpellCastEnvironment::apply(StacksInjured * pack)
+void ServerSpellCastEnvironment::apply(StacksInjured & pack)
 {
 	gh->sendAndApply(pack);
 }
 
-void ServerSpellCastEnvironment::apply(BattleObstaclesChanged * pack)
+void ServerSpellCastEnvironment::apply(BattleObstaclesChanged & pack)
 {
 	gh->sendAndApply(pack);
 }
 
-void ServerSpellCastEnvironment::apply(CatapultAttack * pack)
+void ServerSpellCastEnvironment::apply(CatapultAttack & pack)
 {
 	gh->sendAndApply(pack);
 }
@@ -104,5 +104,5 @@ void ServerSpellCastEnvironment::genericQuery(Query * request, PlayerColor color
 	auto query = std::make_shared<CGenericQuery>(gh, color, callback);
 	request->queryID = query->queryID;
 	gh->queries->addQuery(query);
-	gh->sendAndApply(request);
+	gh->sendAndApply(*request);
 }

--- a/server/ServerSpellCastEnvironment.h
+++ b/server/ServerSpellCastEnvironment.h
@@ -24,15 +24,15 @@ public:
 
 	vstd::RNG * getRNG() override;
 
-	void apply(CPackForClient * pack) override;
+	void apply(CPackForClient & pack) override;
 
-	void apply(BattleLogMessage * pack) override;
-	void apply(BattleStackMoved * pack) override;
-	void apply(BattleUnitsChanged * pack) override;
-	void apply(SetStackEffect * pack) override;
-	void apply(StacksInjured * pack) override;
-	void apply(BattleObstaclesChanged * pack) override;
-	void apply(CatapultAttack * pack) override;
+	void apply(BattleLogMessage & pack) override;
+	void apply(BattleStackMoved & pack) override;
+	void apply(BattleUnitsChanged & pack) override;
+	void apply(SetStackEffect & pack) override;
+	void apply(StacksInjured & pack) override;
+	void apply(BattleObstaclesChanged & pack) override;
+	void apply(CatapultAttack & pack) override;
 
 	const CMap * getMap() const override;
 	const CGameInfoCallback * getCb() const override;

--- a/server/TurnTimerHandler.cpp
+++ b/server/TurnTimerHandler.cpp
@@ -60,7 +60,7 @@ void TurnTimerHandler::sendTimerUpdate(PlayerColor player)
 	TurnTimeUpdate ttu;
 	ttu.player = player;
 	ttu.turnTimer = timers[player];
-	gameHandler.sendAndApply(&ttu);
+	gameHandler.sendAndApply(ttu);
 	lastUpdate[player] = 0;
 }
 

--- a/server/battles/BattleActionProcessor.cpp
+++ b/server/battles/BattleActionProcessor.cpp
@@ -187,7 +187,7 @@ bool BattleActionProcessor::doDefendAction(const CBattleInfoCallback & battle, c
 	buffer.push_back(bonus2);
 
 	sse.toUpdate.push_back(std::make_pair(ba.stackNumber, buffer));
-	gameHandler->sendAndApply(&sse);
+	gameHandler->sendAndApply(sse);
 
 	BattleLogMessage message;
 	message.battleID = battle.getBattle()->getBattleID();
@@ -199,7 +199,7 @@ bool BattleActionProcessor::doDefendAction(const CBattleInfoCallback & battle, c
 
 	message.lines.push_back(text);
 
-	gameHandler->sendAndApply(&message);
+	gameHandler->sendAndApply(message);
 	return true;
 }
 
@@ -596,7 +596,7 @@ bool BattleActionProcessor::makeBattleActionImpl(const CBattleInfoCallback & bat
 	{
 		StartAction startAction(ba);
 		startAction.battleID = battle.getBattle()->getBattleID();
-		gameHandler->sendAndApply(&startAction);
+		gameHandler->sendAndApply(startAction);
 	}
 
 	bool result = dispatchBattleAction(battle, ba);
@@ -605,7 +605,7 @@ bool BattleActionProcessor::makeBattleActionImpl(const CBattleInfoCallback & bat
 	{
 		EndAction endAction;
 		endAction.battleID = battle.getBattle()->getBattleID();
-		gameHandler->sendAndApply(&endAction);
+		gameHandler->sendAndApply(endAction);
 	}
 
 	if(ba.actionType == EActionType::WAIT || ba.actionType == EActionType::DEFEND || ba.actionType == EActionType::SHOOT || ba.actionType == EActionType::MONSTER_SPELL)
@@ -716,7 +716,7 @@ int BattleActionProcessor::moveStack(const CBattleInfoCallback & battle, int sta
 				BattleUpdateGateState db;
 				db.battleID = battle.getBattle()->getBattleID();
 				db.state = EGateState::OPENED;
-				gameHandler->sendAndApply(&db);
+				gameHandler->sendAndApply(db);
 			}
 
 			//inform clients about move
@@ -728,7 +728,7 @@ int BattleActionProcessor::moveStack(const CBattleInfoCallback & battle, int sta
 			sm.tilesToMove = tiles;
 			sm.distance = path.second;
 			sm.teleporting = false;
-			gameHandler->sendAndApply(&sm);
+			gameHandler->sendAndApply(sm);
 		}
 	}
 	else //for non-flying creatures
@@ -856,7 +856,7 @@ int BattleActionProcessor::moveStack(const CBattleInfoCallback & battle, int sta
 				sm.distance = path.second;
 				sm.teleporting = false;
 				sm.tilesToMove = tiles;
-				gameHandler->sendAndApply(&sm);
+				gameHandler->sendAndApply(sm);
 				tiles.clear();
 			}
 
@@ -881,7 +881,7 @@ int BattleActionProcessor::moveStack(const CBattleInfoCallback & battle, int sta
 							BattleUpdateGateState db;
 							db.battleID = battle.getBattle()->getBattleID();
 							db.state = EGateState::OPENED;
-							gameHandler->sendAndApply(&db);
+							gameHandler->sendAndApply(db);
 						}
 					}
 					else if (curStack->getPosition() == gateMayCloseAtHex)
@@ -1034,7 +1034,7 @@ void BattleActionProcessor::makeAttack(const CBattleInfoCallback & battle, const
 	for (BattleStackAttacked & bsa : bat.bsa)
 		bsa.battleID = battle.getBattle()->getBattleID();
 
-	gameHandler->sendAndApply(&bat);
+	gameHandler->sendAndApply(bat);
 
 	{
 		const bool multipleTargets = bat.bsa.size() > 1;
@@ -1101,7 +1101,7 @@ void BattleActionProcessor::makeAttack(const CBattleInfoCallback & battle, const
 			StacksInjured pack;
 			pack.battleID = battle.getBattle()->getBattleID();
 			pack.stacks.push_back(bsa);
-			gameHandler->sendAndApply(&pack);
+			gameHandler->sendAndApply(pack);
 
 			// TODO: this is already implemented in Damage::describeEffect()
 			{
@@ -1115,7 +1115,7 @@ void BattleActionProcessor::makeAttack(const CBattleInfoCallback & battle, const
 		}
 	}
 
-	gameHandler->sendAndApply(&blm);
+	gameHandler->sendAndApply(blm);
 
 	if(defender)
 		handleAfterAttackCasting(battle, ranged, attacker, defender);
@@ -1386,14 +1386,14 @@ void BattleActionProcessor::handleAfterAttackCasting(const CBattleInfoCallback &
 		BattleUnitsChanged removeUnits;
 		removeUnits.battleID = battle.getBattle()->getBattleID();
 		removeUnits.changedStacks.emplace_back(defender->unitId(), UnitChanges::EOperation::REMOVE);
-		gameHandler->sendAndApply(&removeUnits);
-		gameHandler->sendAndApply(&addUnits);
+		gameHandler->sendAndApply(removeUnits);
+		gameHandler->sendAndApply(addUnits);
 
 		// send empty event to client
 		// temporary(?) workaround to force animations to trigger
 		StacksInjured fakeEvent;
 		fakeEvent.battleID = battle.getBattle()->getBattleID();
-		gameHandler->sendAndApply(&fakeEvent);
+		gameHandler->sendAndApply(fakeEvent);
 	}
 
 	if(attacker->hasBonusOfType(BonusType::DESTRUCTION, BonusCustomSubtype::destructionKillPercentage) || attacker->hasBonusOfType(BonusType::DESTRUCTION, BonusCustomSubtype::destructionKillAmount))
@@ -1430,7 +1430,7 @@ void BattleActionProcessor::handleAfterAttackCasting(const CBattleInfoCallback &
 		si.battleID = battle.getBattle()->getBattleID();
 		si.stacks.push_back(bsa);
 
-		gameHandler->sendAndApply(&si);
+		gameHandler->sendAndApply(si);
 		sendGenericKilledLog(battle, defender, bsa.killedAmount, false);
 	}
 }
@@ -1504,7 +1504,7 @@ void BattleActionProcessor::sendGenericKilledLog(const CBattleInfoCallback & bat
 		BattleLogMessage blm;
 		blm.battleID = battle.getBattle()->getBattleID();
 		addGenericKilledLog(blm, defender, killed, multiple);
-		gameHandler->sendAndApply(&blm);
+		gameHandler->sendAndApply(blm);
 	}
 }
 

--- a/server/battles/BattleFlowProcessor.cpp
+++ b/server/battles/BattleFlowProcessor.cpp
@@ -179,7 +179,7 @@ void BattleFlowProcessor::trySummonGuardians(const CBattleInfoCallback & battle,
 			pack.battleID = battle.getBattle()->getBattleID();
 			pack.changedStacks.emplace_back(info.id, UnitChanges::EOperation::ADD);
 			info.save(pack.changedStacks.back().data);
-			gameHandler->sendAndApply(&pack);
+			gameHandler->sendAndApply(pack);
 		}
 	}
 
@@ -187,7 +187,7 @@ void BattleFlowProcessor::trySummonGuardians(const CBattleInfoCallback & battle,
 	// temporary(?) workaround to force animations to trigger
 	StacksInjured fakeEvent;
 	fakeEvent.battleID = battle.getBattle()->getBattleID();
-	gameHandler->sendAndApply(&fakeEvent);
+	gameHandler->sendAndApply(fakeEvent);
 }
 
 void BattleFlowProcessor::castOpeningSpells(const CBattleInfoCallback & battle)
@@ -241,7 +241,7 @@ void BattleFlowProcessor::startNextRound(const CBattleInfoCallback & battle, boo
 	BattleNextRound bnr;
 	bnr.battleID = battle.getBattle()->getBattleID();
 	logGlobal->debug("Next round starts");
-	gameHandler->sendAndApply(&bnr);
+	gameHandler->sendAndApply(bnr);
 
 	// operate on copy - removing obstacles will invalidate iterator on 'battle' container
 	auto obstacles = battle.battleGetAllObstacles();
@@ -287,7 +287,7 @@ const CStack * BattleFlowProcessor::getNextStack(const CBattleInfoCallback & bat
 			bte.val = std::min(lostHealth, stack->valOfBonuses(BonusType::HP_REGENERATION));
 
 		if(bte.val) // anything to heal
-			gameHandler->sendAndApply(&bte);
+			gameHandler->sendAndApply(bte);
 	}
 
 	if(!next || !next->willMove())
@@ -327,7 +327,7 @@ void BattleFlowProcessor::activateNextStack(const CBattleInfoCallback & battle)
 			removeGhosts.changedStacks.emplace_back(stack->unitId(), UnitChanges::EOperation::REMOVE);
 
 		if(!removeGhosts.changedStacks.empty())
-			gameHandler->sendAndApply(&removeGhosts);
+			gameHandler->sendAndApply(removeGhosts);
 
 		gameHandler->turnTimerHandler->onBattleNextStack(battle.getBattle()->getBattleID(), *next);
 
@@ -537,7 +537,7 @@ bool BattleFlowProcessor::rollGoodMorale(const CBattleInfoCallback & battle, con
 			bte.effect = vstd::to_underlying(BonusType::MORALE);
 			bte.val = 1;
 			bte.additionalInfo = 0;
-			gameHandler->sendAndApply(&bte); //play animation
+			gameHandler->sendAndApply(bte); //play animation
 			return true;
 		}
 	}
@@ -621,7 +621,7 @@ bool BattleFlowProcessor::makeAutomaticAction(const CBattleInfoCallback & battle
 	bsa.battleID = battle.getBattle()->getBattleID();
 	bsa.stack = stack->unitId();
 	bsa.askPlayerInterface = false;
-	gameHandler->sendAndApply(&bsa);
+	gameHandler->sendAndApply(bsa);
 
 	bool ret = owner->makeAutomaticBattleAction(battle, ba);
 	return ret;
@@ -664,7 +664,7 @@ void BattleFlowProcessor::removeObstacle(const CBattleInfoCallback & battle, con
 	BattleObstaclesChanged obsRem;
 	obsRem.battleID = battle.getBattle()->getBattleID();
 	obsRem.changes.emplace_back(obstacle.uniqueID, ObstacleChanges::EOperation::REMOVE);
-	gameHandler->sendAndApply(&obsRem);
+	gameHandler->sendAndApply(obsRem);
 }
 
 void BattleFlowProcessor::stackTurnTrigger(const CBattleInfoCallback & battle, const CStack *st)
@@ -706,7 +706,7 @@ void BattleFlowProcessor::stackTurnTrigger(const CBattleInfoCallback & battle, c
 				ssp.battleID = battle.getBattle()->getBattleID();
 				ssp.which = BattleSetStackProperty::UNBIND;
 				ssp.stackID = st->unitId();
-				gameHandler->sendAndApply(&ssp);
+				gameHandler->sendAndApply(ssp);
 			}
 		}
 
@@ -719,7 +719,7 @@ void BattleFlowProcessor::stackTurnTrigger(const CBattleInfoCallback & battle, c
 				if (bte.val < b->val) //(negative) poison effect increases - update it
 				{
 					bte.effect = vstd::to_underlying(BonusType::POISON);
-					gameHandler->sendAndApply(&bte);
+					gameHandler->sendAndApply(bte);
 				}
 			}
 		}
@@ -735,7 +735,7 @@ void BattleFlowProcessor::stackTurnTrigger(const CBattleInfoCallback & battle, c
 					bte.effect = vstd::to_underlying(BonusType::MANA_DRAIN);
 					bte.val = manaDrained;
 					bte.additionalInfo = opponentHero->id.getNum(); //for sanity
-					gameHandler->sendAndApply(&bte);
+					gameHandler->sendAndApply(bte);
 				}
 			}
 		}
@@ -755,7 +755,7 @@ void BattleFlowProcessor::stackTurnTrigger(const CBattleInfoCallback & battle, c
 				if (gameHandler->getRandomGenerator().nextInt(99) < 10) //fixed 10%
 				{
 					bte.effect = vstd::to_underlying(BonusType::FEAR);
-					gameHandler->sendAndApply(&bte);
+					gameHandler->sendAndApply(bte);
 				}
 			}
 		}
@@ -800,7 +800,7 @@ void BattleFlowProcessor::stackTurnTrigger(const CBattleInfoCallback & battle, c
 					ssp.absolute = false;
 					ssp.val = cooldown;
 					ssp.stackID = st->unitId();
-					gameHandler->sendAndApply(&ssp);
+					gameHandler->sendAndApply(ssp);
 				}
 			}
 		}
@@ -814,5 +814,5 @@ void BattleFlowProcessor::setActiveStack(const CBattleInfoCallback & battle, con
 	BattleSetActiveStack sas;
 	sas.battleID = battle.getBattle()->getBattleID();
 	sas.stack = stack->unitId();
-	gameHandler->sendAndApply(&sas);
+	gameHandler->sendAndApply(sas);
 }

--- a/server/battles/BattleProcessor.cpp
+++ b/server/battles/BattleProcessor.cpp
@@ -50,7 +50,7 @@ void BattleProcessor::engageIntoBattle(PlayerColor player)
 	pb.player = player;
 	pb.reason = PlayerBlocked::UPCOMING_BATTLE;
 	pb.startOrEnd = PlayerBlocked::BLOCKADE_STARTED;
-	gameHandler->sendAndApply(&pb);
+	gameHandler->sendAndApply(pb);
 }
 
 void BattleProcessor::restartBattle(const BattleID & battleID, const CArmedInstance *army1, const CArmedInstance *army2, int3 tile,
@@ -76,7 +76,7 @@ void BattleProcessor::restartBattle(const BattleID & battleID, const CArmedInsta
 				SetMana restoreInitialMana;
 				restoreInitialMana.val = lastBattleQuery->initialHeroMana[i];
 				restoreInitialMana.hid = heroes[i]->id;
-				gameHandler->sendAndApply(&restoreInitialMana);
+				gameHandler->sendAndApply(restoreInitialMana);
 			}
 		}
 
@@ -88,7 +88,7 @@ void BattleProcessor::restartBattle(const BattleID & battleID, const CArmedInsta
 
 	BattleCancelled bc;
 	bc.battleID = battleID;
-	gameHandler->sendAndApply(&bc);
+	gameHandler->sendAndApply(bc);
 
 	startBattle(army1, army2, tile, hero1, hero2, layout, town);
 }
@@ -116,7 +116,7 @@ void BattleProcessor::startBattle(const CArmedInstance *army1, const CArmedInsta
 			GiveBonus giveBonus(GiveBonus::ETarget::OBJECT);
 			giveBonus.id = hero1->id;
 			giveBonus.bonus = bonus;
-			gameHandler->sendAndApply(&giveBonus);
+			gameHandler->sendAndApply(giveBonus);
 		}
 	}
 
@@ -180,7 +180,7 @@ BattleID BattleProcessor::setupBattle(int3 tile, BattleSideArray<const CArmedIns
 	bool onlyOnePlayerHuman = isDefenderHuman != isAttackerHuman;
 	bs.info->replayAllowed = lastBattleQuery == nullptr && onlyOnePlayerHuman;
 
-	gameHandler->sendAndApply(&bs);
+	gameHandler->sendAndApply(bs);
 
 	return bs.battleID;
 }
@@ -258,7 +258,7 @@ void BattleProcessor::updateGateState(const CBattleInfoCallback & battle)
 	}
 
 	if (db.state != battle.battleGetGateState())
-		gameHandler->sendAndApply(&db);
+		gameHandler->sendAndApply(db);
 }
 
 bool BattleProcessor::makePlayerBattleAction(const BattleID & battleID, PlayerColor player, const BattleAction &ba)

--- a/server/battles/BattleResultProcessor.cpp
+++ b/server/battles/BattleResultProcessor.cpp
@@ -178,7 +178,7 @@ void CasualtiesAfterBattle::updateArmy(CGameHandler *gh)
 		scp.heroid = heroWithDeadCommander;
 		scp.which = SetCommanderProperty::ALIVE;
 		scp.amount = 0;
-		gh->sendAndApply(&scp);
+		gh->sendAndApply(scp);
 	}
 }
 
@@ -291,7 +291,7 @@ void BattleResultProcessor::endBattle(const CBattleInfoCallback & battle)
 	}
 
 	gameHandler->turnTimerHandler->onBattleEnd(battle.getBattle()->getBattleID());
-	gameHandler->sendAndApply(battleResult);
+	gameHandler->sendAndApply(*battleResult);
 
 	if (battleResult->queryID == QueryID::NONE)
 		endBattleConfirm(battle);
@@ -384,8 +384,8 @@ void BattleResultProcessor::endBattleConfirm(const CBattleInfoCallback & battle)
 					iw.text.replaceLocalString(EMetaText::GENERAL_TXT, 141); // " and "
 				iw.components.emplace_back(ComponentType::SPELL, *it);
 			}
-			gameHandler->sendAndApply(&iw);
-			gameHandler->sendAndApply(&spells);
+			gameHandler->sendAndApply(iw);
+			gameHandler->sendAndApply(spells);
 		}
 	}
 	// Artifacts handling
@@ -410,7 +410,7 @@ void BattleResultProcessor::endBattleConfirm(const CBattleInfoCallback & battle)
 		const auto sendArtifacts = [this](BulkMoveArtifacts & bma)
 		{
 			if(!bma.artsPack0.empty())
-				gameHandler->sendAndApply(&bma);
+				gameHandler->sendAndApply(bma);
 		};
 
 		BulkMoveArtifacts packHero(finishingBattle->winnerHero->getOwner(), ObjectInstanceID::NONE, finishingBattle->winnerHero->id, false);
@@ -466,11 +466,11 @@ void BattleResultProcessor::endBattleConfirm(const CBattleInfoCallback & battle)
 
 				if(iw.components.size() >= GameConstants::INFO_WINDOW_ARTIFACTS_MAX_ITEMS)
 				{
-					gameHandler->sendAndApply(&iw);
+					gameHandler->sendAndApply(iw);
 					iw.components.clear();
 				}
 			}
-			gameHandler->sendAndApply(&iw);
+			gameHandler->sendAndApply(iw);
 		}
 		if(!packHero.artsPack0.empty())
 			sendArtifacts(packHero);
@@ -491,13 +491,13 @@ void BattleResultProcessor::endBattleConfirm(const CBattleInfoCallback & battle)
 		}
 
 		RemoveObject ro(finishingBattle->loserHero->id, finishingBattle->victor);
-		gameHandler->sendAndApply(&ro);
+		gameHandler->sendAndApply(ro);
 	}
 	// For draw case both heroes should be removed
 	if(finishingBattle->isDraw() && finishingBattle->winnerHero)
 	{
 		RemoveObject ro(finishingBattle->winnerHero->id, finishingBattle->loser);
-		gameHandler->sendAndApply(&ro);
+		gameHandler->sendAndApply(ro);
 	}
 
 	// add statistic
@@ -525,7 +525,7 @@ void BattleResultProcessor::endBattleConfirm(const CBattleInfoCallback & battle)
 	raccepted.heroResult[BattleSide::ATTACKER].exp = battleResult->exp[BattleSide::ATTACKER];
 	raccepted.heroResult[BattleSide::DEFENDER].exp = battleResult->exp[BattleSide::DEFENDER];
 	raccepted.winnerSide = finishingBattle->winnerSide;
-	gameHandler->sendAndApply(&raccepted);
+	gameHandler->sendAndApply(raccepted);
 
 	gameHandler->queries->popIfTop(battleQuery);
 	//--> continuation (battleAfterLevelUp) occurs after level-up gameHandler->queries are handled or on removing query
@@ -568,7 +568,7 @@ void BattleResultProcessor::battleAfterLevelUp(const BattleID & battleID, const 
 	resultsApplied.battleID = battleID;
 	resultsApplied.player1 = finishingBattle->victor;
 	resultsApplied.player2 = finishingBattle->loser;
-	gameHandler->sendAndApply(&resultsApplied);
+	gameHandler->sendAndApply(resultsApplied);
 
 	//handle victory/loss of engaged players
 	std::set<PlayerColor> playerColors = {finishingBattle->loser, finishingBattle->victor};
@@ -590,7 +590,7 @@ void BattleResultProcessor::battleAfterLevelUp(const BattleID & battleID, const 
 		&& (!finishingBattle->winnerHero->commander || !finishingBattle->winnerHero->commander->alive))
 	{
 		RemoveObject ro(finishingBattle->winnerHero->id, finishingBattle->winnerHero->getOwner());
-		gameHandler->sendAndApply(&ro);
+		gameHandler->sendAndApply(ro);
 
 		if (gameHandler->getSettings().getBoolean(EGameSettings::HEROES_RETREAT_ON_WIN_WITHOUT_TROOPS))
 			gameHandler->heroPool->onHeroEscaped(finishingBattle->victor, finishingBattle->winnerHero);

--- a/server/processors/HeroPoolProcessor.cpp
+++ b/server/processors/HeroPoolProcessor.cpp
@@ -72,7 +72,7 @@ void HeroPoolProcessor::onHeroSurrendered(const PlayerColor & color, const CGHer
 	sah.player = color;
 	sah.hid = hero->getHeroType();
 	sah.replenishPoints = false;
-	gameHandler->sendAndApply(&sah);
+	gameHandler->sendAndApply(sah);
 }
 
 void HeroPoolProcessor::onHeroEscaped(const PlayerColor & color, const CGHeroInstance * hero)
@@ -87,7 +87,7 @@ void HeroPoolProcessor::onHeroEscaped(const PlayerColor & color, const CGHeroIns
 	sah.army.setCreature(SlotID(0), hero->type->initialArmy.at(0).creature, 1);
 	sah.replenishPoints = false;
 
-	gameHandler->sendAndApply(&sah);
+	gameHandler->sendAndApply(sah);
 }
 
 void HeroPoolProcessor::clearHeroFromSlot(const PlayerColor & color, TavernHeroSlot slot)
@@ -98,7 +98,7 @@ void HeroPoolProcessor::clearHeroFromSlot(const PlayerColor & color, TavernHeroS
 	sah.slotID = slot;
 	sah.hid = HeroTypeID::NONE;
 	sah.replenishPoints = false;
-	gameHandler->sendAndApply(&sah);
+	gameHandler->sendAndApply(sah);
 }
 
 void HeroPoolProcessor::selectNewHeroForSlot(const PlayerColor & color, TavernHeroSlot slot, bool needNativeHero, bool giveArmy, const HeroTypeID & nextHero)
@@ -131,7 +131,7 @@ void HeroPoolProcessor::selectNewHeroForSlot(const PlayerColor & color, TavernHe
 		sah.hid = HeroTypeID::NONE;
 	}
 
-	gameHandler->sendAndApply(&sah);
+	gameHandler->sendAndApply(sah);
 }
 
 void HeroPoolProcessor::onNewWeek(const PlayerColor & color)
@@ -232,7 +232,7 @@ bool HeroPoolProcessor::hireHero(const ObjectInstanceID & objectID, const HeroTy
 	}
 
 	// apply netpack -> this will remove hired hero from pool
-	gameHandler->sendAndApply(&hr);
+	gameHandler->sendAndApply(hr);
 
 	if(recruitableHeroes[0] == recruitedHero)
 		selectNewHeroForSlot(player, TavernHeroSlot::NATIVE, false, false, nextHero);

--- a/server/processors/NewTurnProcessor.cpp
+++ b/server/processors/NewTurnProcessor.cpp
@@ -60,7 +60,7 @@ void NewTurnProcessor::handleTimeEvents(PlayerColor color)
 				if (event.resources[i])
 					iw.components.emplace_back(ComponentType::RESOURCE, i, event.resources[i]);
 		}
-		gameHandler->sendAndApply(&iw); //show dialog
+		gameHandler->sendAndApply(iw); //show dialog
 	}
 }
 
@@ -117,7 +117,7 @@ void NewTurnProcessor::handleTownEvents(const CGTownInstance * town)
 				}
 			}
 		}
-		gameHandler->sendAndApply(&iw); //show dialog
+		gameHandler->sendAndApply(iw); //show dialog
 	}
 }
 
@@ -150,7 +150,7 @@ void NewTurnProcessor::onPlayerTurnEnded(PlayerColor which)
 		DaysWithoutTown pack;
 		pack.player = which;
 		pack.daysWithoutCastle = playerState->daysWithoutCastle.value_or(0) + 1;
-		gameHandler->sendAndApply(&pack);
+		gameHandler->sendAndApply(pack);
 	}
 	else
 	{
@@ -159,7 +159,7 @@ void NewTurnProcessor::onPlayerTurnEnded(PlayerColor which)
 			DaysWithoutTown pack;
 			pack.player = which;
 			pack.daysWithoutCastle = std::nullopt;
-			gameHandler->sendAndApply(&pack);
+			gameHandler->sendAndApply(pack);
 		}
 	}
 
@@ -321,7 +321,7 @@ void NewTurnProcessor::updateNeutralTownGarrison(const CGTownInstance * t, int c
 			sac.tid = t->id;
 			sac.creatures = t->creatures;
 			sac.creatures[tierToSubstract].first = creaturesLeft;
-			gameHandler->sendAndApply(&sac);
+			gameHandler->sendAndApply(sac);
 		}
 	};
 
@@ -657,7 +657,7 @@ void NewTurnProcessor::onNewTurn()
 	bool newWeek = gameHandler->getDate(Date::DAY_OF_WEEK) == 7; //day numbers are confusing, as day was not yet switched
 	bool newMonth = gameHandler->getDate(Date::DAY_OF_MONTH) == 28;
 
-	gameHandler->sendAndApply(&n);
+	gameHandler->sendAndApply(n);
 
 	if (newWeek)
 	{

--- a/server/processors/PlayerMessageProcessor.cpp
+++ b/server/processors/PlayerMessageProcessor.cpp
@@ -847,7 +847,7 @@ void PlayerMessageProcessor::sendSystemMessage(std::shared_ptr<CConnection> conn
 {
 	SystemMessage sm;
 	sm.text = message;
-	connection->sendPack(&sm);
+	connection->sendPack(sm);
 }
 
 void PlayerMessageProcessor::sendSystemMessage(std::shared_ptr<CConnection> connection, const std::string & message)

--- a/server/processors/PlayerMessageProcessor.cpp
+++ b/server/processors/PlayerMessageProcessor.cpp
@@ -100,7 +100,7 @@ void PlayerMessageProcessor::commandKick(PlayerColor player, const std::vector<s
 			PlayerCheated pc;
 			pc.player = playerToKick;
 			pc.losingCheatCode = true;
-			gameHandler->sendAndApply(&pc);
+			gameHandler->sendAndApply(pc);
 			gameHandler->checkVictoryLossConditionsForPlayer(playerToKick);
 		}
 	}
@@ -354,7 +354,7 @@ void PlayerMessageProcessor::cheatGiveSpells(PlayerColor player, const CGHeroIns
 	for (int level = 1; level <= GameConstants::SPELL_LEVELS; level++)
 	{
 		giveBonus.bonus.subtype = BonusCustomSubtype::spellLevel(level);
-		gameHandler->sendAndApply(&giveBonus);
+		gameHandler->sendAndApply(giveBonus);
 	}
 
 	///Give mana
@@ -362,7 +362,7 @@ void PlayerMessageProcessor::cheatGiveSpells(PlayerColor player, const CGHeroIns
 	sm.hid = hero->id;
 	sm.val = 999;
 	sm.absolute = true;
-	gameHandler->sendAndApply(&sm);
+	gameHandler->sendAndApply(sm);
 }
 
 void PlayerMessageProcessor::cheatBuildTown(PlayerColor player, const CGTownInstance * town)
@@ -520,7 +520,7 @@ void PlayerMessageProcessor::cheatMovement(PlayerColor player, const CGHeroInsta
 		unlimited = true;
 	}
 
-	gameHandler->sendAndApply(&smp);
+	gameHandler->sendAndApply(smp);
 
 	GiveBonus gb(GiveBonus::ETarget::OBJECT);
 	gb.bonus.type = BonusType::FREE_SHIP_BOARDING;
@@ -565,7 +565,7 @@ void PlayerMessageProcessor::cheatVictory(PlayerColor player)
 	PlayerCheated pc;
 	pc.player = player;
 	pc.winningCheatCode = true;
-	gameHandler->sendAndApply(&pc);
+	gameHandler->sendAndApply(pc);
 }
 
 void PlayerMessageProcessor::cheatDefeat(PlayerColor player)
@@ -573,7 +573,7 @@ void PlayerMessageProcessor::cheatDefeat(PlayerColor player)
 	PlayerCheated pc;
 	pc.player = player;
 	pc.losingCheatCode = true;
-	gameHandler->sendAndApply(&pc);
+	gameHandler->sendAndApply(pc);
 }
 
 void PlayerMessageProcessor::cheatMapReveal(PlayerColor player, bool reveal)
@@ -594,7 +594,7 @@ void PlayerMessageProcessor::cheatMapReveal(PlayerColor player, bool reveal)
 
 	fc.tiles.insert(hlp_tab, hlp_tab + lastUnc);
 	delete [] hlp_tab;
-	gameHandler->sendAndApply(&fc);
+	gameHandler->sendAndApply(fc);
 }
 
 void PlayerMessageProcessor::cheatPuzzleReveal(PlayerColor player)
@@ -612,7 +612,7 @@ void PlayerMessageProcessor::cheatPuzzleReveal(PlayerColor player)
 
 				PlayerCheated pc;
 				pc.player = color;
-				gameHandler->sendAndApply(&pc);
+				gameHandler->sendAndApply(pc);
 			}
 		}
 	}
@@ -715,7 +715,7 @@ bool PlayerMessageProcessor::handleCheatCode(const std::string & cheat, PlayerCo
 
 		PlayerCheated pc;
 		pc.player = i.first;
-		gameHandler->sendAndApply(&pc);
+		gameHandler->sendAndApply(pc);
 
 		playerTargetedCheat = true;
 		parameters.erase(parameters.begin());
@@ -734,7 +734,7 @@ bool PlayerMessageProcessor::handleCheatCode(const std::string & cheat, PlayerCo
 
 	PlayerCheated pc;
 	pc.player = player;
-	gameHandler->sendAndApply(&pc);
+	gameHandler->sendAndApply(pc);
 	
 	if (!playerTargetedCheat)
 		executeCheatCode(cheatName, player, currObj, words);
@@ -861,7 +861,7 @@ void PlayerMessageProcessor::broadcastSystemMessage(MetaString message)
 {
 	SystemMessage sm;
 	sm.text = message;
-	gameHandler->sendToAllClients(&sm);
+	gameHandler->sendToAllClients(sm);
 }
 
 void PlayerMessageProcessor::broadcastSystemMessage(const std::string & message)
@@ -874,5 +874,5 @@ void PlayerMessageProcessor::broadcastSystemMessage(const std::string & message)
 void PlayerMessageProcessor::broadcastMessage(PlayerColor playerSender, const std::string & message)
 {
 	PlayerMessageClient temp_message(playerSender, message);
-	gameHandler->sendAndApply(&temp_message);
+	gameHandler->sendAndApply(temp_message);
 }

--- a/server/processors/TurnOrderProcessor.cpp
+++ b/server/processors/TurnOrderProcessor.cpp
@@ -287,7 +287,7 @@ void TurnOrderProcessor::doStartPlayerTurn(PlayerColor which)
 	PlayerStartsTurn pst;
 	pst.player = which;
 	pst.queryID = turnQuery->queryID;
-	gameHandler->sendAndApply(&pst);
+	gameHandler->sendAndApply(pst);
 
 	assert(!actingPlayers.empty());
 }
@@ -302,7 +302,7 @@ void TurnOrderProcessor::doEndPlayerTurn(PlayerColor which)
 
 	PlayerEndsTurn pet;
 	pet.player = which;
-	gameHandler->sendAndApply(&pet);
+	gameHandler->sendAndApply(pet);
 
 	if (!awaitingPlayers.empty())
 		tryStartTurnsForPlayers();

--- a/server/queries/BattleQueries.cpp
+++ b/server/queries/BattleQueries.cpp
@@ -49,7 +49,7 @@ CBattleQuery::CBattleQuery(CGameHandler * owner):
 	belligerents[BattleSide::DEFENDER] = nullptr;
 }
 
-bool CBattleQuery::blocksPack(const CPack * pack) const
+bool CBattleQuery::blocksPack(const CPackForServer * pack) const
 {
 	if(dynamic_cast<const MakeAction*>(pack) != nullptr)
 		return false;

--- a/server/queries/BattleQueries.h
+++ b/server/queries/BattleQueries.h
@@ -30,7 +30,7 @@ public:
 	CBattleQuery(CGameHandler * owner);
 	CBattleQuery(CGameHandler * owner, const IBattleInfo * Bi); //TODO
 	void notifyObjectAboutRemoval(const CGObjectInstance * visitedObject, const CGHeroInstance * visitingHero) const override;
-	bool blocksPack(const CPack *pack) const override;
+	bool blocksPack(const CPackForServer *pack) const override;
 	void onRemoval(PlayerColor color) override;
 	void onExposure(QueryPtr topQuery) override;
 };

--- a/server/queries/CQuery.cpp
+++ b/server/queries/CQuery.cpp
@@ -81,7 +81,7 @@ void CQuery::onRemoval(PlayerColor color)
 
 }
 
-bool CQuery::blocksPack(const CPack * pack) const
+bool CQuery::blocksPack(const CPackForServer * pack) const
 {
 	return false;
 }
@@ -112,7 +112,7 @@ void CQuery::setReply(std::optional<int32_t> reply)
 
 }
 
-bool CQuery::blockAllButReply(const CPack * pack) const
+bool CQuery::blockAllButReply(const CPackForServer * pack) const
 {
 	//We accept only query replies from correct player
 	if(auto reply = dynamic_cast<const QueryReply*>(pack))
@@ -132,7 +132,7 @@ bool CDialogQuery::endsByPlayerAnswer() const
 	return true;
 }
 
-bool CDialogQuery::blocksPack(const CPack * pack) const
+bool CDialogQuery::blocksPack(const CPackForServer * pack) const
 {
 	return blockAllButReply(pack);
 }
@@ -149,7 +149,7 @@ CGenericQuery::CGenericQuery(CGameHandler * gh, PlayerColor color, std::function
 	addPlayer(color);
 }
 
-bool CGenericQuery::blocksPack(const CPack * pack) const
+bool CGenericQuery::blocksPack(const CPackForServer * pack) const
 {
 	return blockAllButReply(pack);
 }

--- a/server/queries/CQuery.h
+++ b/server/queries/CQuery.h
@@ -13,7 +13,7 @@
 
 VCMI_LIB_NAMESPACE_BEGIN
 
-struct CPack;
+struct CPackForServer;
 class CGObjectInstance;
 class CGHeroInstance;
 
@@ -43,7 +43,7 @@ public:
 	CQuery(CGameHandler * gh);
 
 	/// query can block attempting actions by player. Eg. he can't move hero during the battle.
-	virtual bool blocksPack(const CPack *pack) const;
+	virtual bool blocksPack(const CPackForServer *pack) const;
 
 	/// query is removed after player gives answer (like dialogs)
 	virtual bool endsByPlayerAnswer() const;
@@ -71,7 +71,7 @@ protected:
 	QueriesProcessor * owner;
 	CGameHandler * gh;
 	void addPlayer(PlayerColor color);
-	bool blockAllButReply(const CPack * pack) const;
+	bool blockAllButReply(const CPackForServer * pack) const;
 };
 
 std::ostream &operator<<(std::ostream &out, const CQuery &query);
@@ -82,7 +82,7 @@ class CDialogQuery : public CQuery
 public:
 	CDialogQuery(CGameHandler * owner);
 	bool endsByPlayerAnswer() const override;
-	bool blocksPack(const CPack *pack) const override;
+	bool blocksPack(const CPackForServer *pack) const override;
 	void setReply(std::optional<int32_t> reply) override;
 protected:
 	std::optional<ui32> answer;
@@ -93,7 +93,7 @@ class CGenericQuery : public CQuery
 public:
 	CGenericQuery(CGameHandler * gh, PlayerColor color, std::function<void(std::optional<int32_t>)> Callback);
 
-	bool blocksPack(const CPack * pack) const override;
+	bool blocksPack(const CPackForServer * pack) const override;
 	bool endsByPlayerAnswer() const override;
 	void onExposure(QueryPtr topQuery) override;
 	void setReply(std::optional<int32_t> reply) override;

--- a/server/queries/MapQueries.cpp
+++ b/server/queries/MapQueries.cpp
@@ -23,7 +23,7 @@ TimerPauseQuery::TimerPauseQuery(CGameHandler * owner, PlayerColor player):
 	addPlayer(player);
 }
 
-bool TimerPauseQuery::blocksPack(const CPack *pack) const
+bool TimerPauseQuery::blocksPack(const CPackForServer *pack) const
 {
 	return blockAllButReply(pack);
 }
@@ -58,7 +58,7 @@ CGarrisonDialogQuery::CGarrisonDialogQuery(CGameHandler * owner, const CArmedIns
 	addPlayer(down->tempOwner);
 }
 
-bool CGarrisonDialogQuery::blocksPack(const CPack * pack) const
+bool CGarrisonDialogQuery::blocksPack(const CPackForServer * pack) const
 {
 	std::set<ObjectInstanceID> ourIds;
 	ourIds.insert(this->exchangingArmies[0]->id);
@@ -143,7 +143,7 @@ void OpenWindowQuery::onExposure(QueryPtr topQuery)
 	//do nothing - wait for reply
 }
 
-bool OpenWindowQuery::blocksPack(const CPack *pack) const
+bool OpenWindowQuery::blocksPack(const CPackForServer *pack) const
 {
 	if (mode == EOpenWindowMode::RECRUITMENT_FIRST || mode == EOpenWindowMode::RECRUITMENT_ALL)
 	{

--- a/server/queries/MapQueries.cpp
+++ b/server/queries/MapQueries.cpp
@@ -273,7 +273,7 @@ void CHeroMovementQuery::onRemoval(PlayerColor color)
 	pb.player = color;
 	pb.reason = PlayerBlocked::ONGOING_MOVEMENT;
 	pb.startOrEnd = PlayerBlocked::BLOCKADE_ENDED;
-	gh->sendAndApply(&pb);
+	gh->sendAndApply(pb);
 }
 
 void CHeroMovementQuery::onAdding(PlayerColor color)
@@ -282,5 +282,5 @@ void CHeroMovementQuery::onAdding(PlayerColor color)
 	pb.player = color;
 	pb.reason = PlayerBlocked::ONGOING_MOVEMENT;
 	pb.startOrEnd = PlayerBlocked::BLOCKADE_STARTED;
-	gh->sendAndApply(&pb);
+	gh->sendAndApply(pb);
 }

--- a/server/queries/MapQueries.h
+++ b/server/queries/MapQueries.h
@@ -25,7 +25,7 @@ class TimerPauseQuery : public CQuery
 public:	
 	TimerPauseQuery(CGameHandler * owner, PlayerColor player);
 	
-	bool blocksPack(const CPack *pack) const override;
+	bool blocksPack(const CPackForServer *pack) const override;
 	void onAdding(PlayerColor color) override;
 	void onRemoval(PlayerColor color) override;
 	bool endsByPlayerAnswer() const override;
@@ -54,7 +54,7 @@ public:
 
 	CGarrisonDialogQuery(CGameHandler * owner, const CArmedInstance *up, const CArmedInstance *down);
 	void notifyObjectAboutRemoval(const CGObjectInstance * visitedObject, const CGHeroInstance * visitingHero) const override;
-	bool blocksPack(const CPack *pack) const override;
+	bool blocksPack(const CPackForServer *pack) const override;
 };
 
 //yes/no and component selection dialogs
@@ -75,7 +75,7 @@ class OpenWindowQuery : public CDialogQuery
 public:
 	OpenWindowQuery(CGameHandler * owner, const CGHeroInstance *hero, EOpenWindowMode mode);
 
-	bool blocksPack(const CPack *pack) const override;
+	bool blocksPack(const CPackForServer *pack) const override;
 	void onExposure(QueryPtr topQuery) override;
 };
 

--- a/server/queries/VisitQueries.cpp
+++ b/server/queries/VisitQueries.cpp
@@ -24,7 +24,7 @@ VisitQuery::VisitQuery(CGameHandler * owner, const CGObjectInstance * Obj, const
 	addPlayer(Hero->tempOwner);
 }
 
-bool VisitQuery::blocksPack(const CPack * pack) const
+bool VisitQuery::blocksPack(const CPackForServer * pack) const
 {
 	//During the visit itself ALL actions are blocked.
 	//(However, the visit may trigger a query above that'll pass some.)

--- a/server/queries/VisitQueries.h
+++ b/server/queries/VisitQueries.h
@@ -26,7 +26,7 @@ public:
 	const CGObjectInstance * visitedObject;
 	const CGHeroInstance * visitingHero;
 
-	bool blocksPack(const CPack * pack) const final;
+	bool blocksPack(const CPackForServer * pack) const final;
 };
 
 class MapObjectVisitQuery final : public VisitQuery

--- a/test/game/CGameStateTest.cpp
+++ b/test/game/CGameStateTest.cpp
@@ -65,42 +65,42 @@ public:
 
 	void apply(CPackForClient * pack) override
 	{
-		gameState->apply(pack);
+		gameState->apply(*pack);
 	}
 
 	void apply(BattleLogMessage * pack) override
 	{
-		gameState->apply(pack);
+		gameState->apply(*pack);
 	}
 
 	void apply(BattleStackMoved * pack) override
 	{
-		gameState->apply(pack);
+		gameState->apply(*pack);
 	}
 
 	void apply(BattleUnitsChanged * pack) override
 	{
-		gameState->apply(pack);
+		gameState->apply(*pack);
 	}
 
 	void apply(SetStackEffect * pack) override
 	{
-		gameState->apply(pack);
+		gameState->apply(*pack);
 	}
 
 	void apply(StacksInjured * pack) override
 	{
-		gameState->apply(pack);
+		gameState->apply(*pack);
 	}
 
 	void apply(BattleObstaclesChanged * pack) override
 	{
-		gameState->apply(pack);
+		gameState->apply(*pack);
 	}
 
 	void apply(CatapultAttack * pack) override
 	{
-		gameState->apply(pack);
+		gameState->apply(*pack);
 	}
 
 	void complain(const std::string & problem) override

--- a/test/game/CGameStateTest.cpp
+++ b/test/game/CGameStateTest.cpp
@@ -63,44 +63,44 @@ public:
 		return true;
 	}
 
-	void apply(CPackForClient * pack) override
+	void apply(CPackForClient & pack) override
 	{
-		gameState->apply(*pack);
+		gameState->apply(pack);
 	}
 
-	void apply(BattleLogMessage * pack) override
+	void apply(BattleLogMessage & pack) override
 	{
-		gameState->apply(*pack);
+		gameState->apply(pack);
 	}
 
-	void apply(BattleStackMoved * pack) override
+	void apply(BattleStackMoved & pack) override
 	{
-		gameState->apply(*pack);
+		gameState->apply(pack);
 	}
 
-	void apply(BattleUnitsChanged * pack) override
+	void apply(BattleUnitsChanged & pack) override
 	{
-		gameState->apply(*pack);
+		gameState->apply(pack);
 	}
 
-	void apply(SetStackEffect * pack) override
+	void apply(SetStackEffect & pack) override
 	{
-		gameState->apply(*pack);
+		gameState->apply(pack);
 	}
 
-	void apply(StacksInjured * pack) override
+	void apply(StacksInjured & pack) override
 	{
-		gameState->apply(*pack);
+		gameState->apply(pack);
 	}
 
-	void apply(BattleObstaclesChanged * pack) override
+	void apply(BattleObstaclesChanged & pack) override
 	{
-		gameState->apply(*pack);
+		gameState->apply(pack);
 	}
 
-	void apply(CatapultAttack * pack) override
+	void apply(CatapultAttack & pack) override
 	{
-		gameState->apply(*pack);
+		gameState->apply(pack);
 	}
 
 	void complain(const std::string & problem) override
@@ -207,7 +207,7 @@ public:
 		BattleStart bs;
 		bs.info = battle;
 		ASSERT_EQ(gameState->currentBattles.size(), 0);
-		gameCallback->sendAndApply(&bs);
+		gameCallback->sendAndApply(bs);
 		ASSERT_EQ(gameState->currentBattles.size(), 1);
 	}
 
@@ -236,7 +236,7 @@ TEST_F(CGameStateTest, DISABLED_issue2765)
 		na.artHolder = defender->id;
 		na.artId = ArtifactID::BALLISTA;
 		na.pos = ArtifactPosition::MACH1;
-		gameCallback->sendAndApply(&na);
+		gameCallback->sendAndApply(na);
 	}
 
 	startTestBattle(attacker, defender);
@@ -253,7 +253,7 @@ TEST_F(CGameStateTest, DISABLED_issue2765)
 		BattleUnitsChanged pack;
 		pack.changedStacks.emplace_back(info.id, UnitChanges::EOperation::ADD);
 		info.save(pack.changedStacks.back().data);
-		gameCallback->sendAndApply(&pack);
+		gameCallback->sendAndApply(pack);
 	}
 
 	const CStack * att = nullptr;
@@ -324,7 +324,7 @@ TEST_F(CGameStateTest, DISABLED_battleResurrection)
 		na.artHolder = attacker->id;
 		na.artId = ArtifactID::SPELLBOOK;
 		na.pos = ArtifactPosition::SPELLBOOK;
-		gameCallback->sendAndApply(&na);
+		gameCallback->sendAndApply(na);
 	}
 
 	startTestBattle(attacker, defender);
@@ -343,7 +343,7 @@ TEST_F(CGameStateTest, DISABLED_battleResurrection)
 		BattleUnitsChanged pack;
 		pack.changedStacks.emplace_back(info.id, UnitChanges::EOperation::ADD);
 		info.save(pack.changedStacks.back().data);
-		gameCallback->sendAndApply(&pack);
+		gameCallback->sendAndApply(pack);
 	}
 
 	{
@@ -358,7 +358,7 @@ TEST_F(CGameStateTest, DISABLED_battleResurrection)
 		BattleUnitsChanged pack;
 		pack.changedStacks.emplace_back(info.id, UnitChanges::EOperation::ADD);
 		info.save(pack.changedStacks.back().data);
-		gameCallback->sendAndApply(&pack);
+		gameCallback->sendAndApply(pack);
 	}
 
 	CStack * unit = gameState->currentBattles.front()->getStack(unitId);

--- a/test/mock/BattleFake.h
+++ b/test/mock/BattleFake.h
@@ -81,9 +81,9 @@ public:
 #endif
 
 	template <typename T>
-	void accept(T * pack)
+	void accept(T & pack)
 	{
-		pack->applyBattle(this);
+		pack.applyBattle(this);
 	}
 
 	const IBattleInfo * getBattle() const override

--- a/test/mock/mock_IGameCallback.cpp
+++ b/test/mock/mock_IGameCallback.cpp
@@ -27,7 +27,7 @@ void GameCallbackMock::setGameState(CGameState * gameState)
 	gs = gameState;
 }
 
-void GameCallbackMock::sendAndApply(CPackForClient * pack)
+void GameCallbackMock::sendAndApply(CPackForClient & pack)
 {
 	upperCallback->apply(pack);
 }

--- a/test/mock/mock_IGameCallback.h
+++ b/test/mock/mock_IGameCallback.h
@@ -96,7 +96,7 @@ public:
 	void castSpell(const spells::Caster * caster, SpellID spellID, const int3 &pos) override {}
 
 	///useful callback methods
-	void sendAndApply(CPackForClient * pack) override;
+	void sendAndApply(CPackForClient & pack) override;
 
 	vstd::RNG & getRandomGenerator() override;
 

--- a/test/mock/mock_ServerCallback.h
+++ b/test/mock/mock_ServerCallback.h
@@ -20,13 +20,13 @@ public:
 	MOCK_METHOD1(complain, void(const std::string &));
 	MOCK_METHOD0(getRNG, vstd::RNG *());
 
-	MOCK_METHOD1(apply, void(CPackForClient *));
+	MOCK_METHOD1(apply, void(CPackForClient &));
 
-	MOCK_METHOD1(apply, void(BattleLogMessage *));
-	MOCK_METHOD1(apply, void(BattleStackMoved *));
-	MOCK_METHOD1(apply, void(BattleUnitsChanged *));
-	MOCK_METHOD1(apply, void(SetStackEffect *));
-	MOCK_METHOD1(apply, void(StacksInjured *));
-	MOCK_METHOD1(apply, void(BattleObstaclesChanged *));
-	MOCK_METHOD1(apply, void(CatapultAttack *));
+	MOCK_METHOD1(apply, void(BattleLogMessage &));
+	MOCK_METHOD1(apply, void(BattleStackMoved &));
+	MOCK_METHOD1(apply, void(BattleUnitsChanged &));
+	MOCK_METHOD1(apply, void(SetStackEffect &));
+	MOCK_METHOD1(apply, void(StacksInjured &));
+	MOCK_METHOD1(apply, void(BattleObstaclesChanged &));
+	MOCK_METHOD1(apply, void(CatapultAttack &));
 };

--- a/test/scripting/LuaSpellEffectAPITest.cpp
+++ b/test/scripting/LuaSpellEffectAPITest.cpp
@@ -157,18 +157,18 @@ TEST_F(LuaSpellEffectAPITest, DISABLED_ApplyMoveUnit)
 	BattleStackMoved expected;
 	BattleStackMoved actual;
 
-	auto checkMove = [&](BattleStackMoved * pack)
+	auto checkMove = [&](BattleStackMoved & pack)
 	{
-		EXPECT_EQ(pack->stack, 42);
-		EXPECT_EQ(pack->teleporting, true);
-		EXPECT_EQ(pack->distance, 0);
+		EXPECT_EQ(pack.stack, 42);
+		EXPECT_EQ(pack.teleporting, true);
+		EXPECT_EQ(pack.distance, 0);
 
 		std::vector<BattleHex> toMove(1, hex2);
 
-		EXPECT_EQ(pack->tilesToMove, toMove);
+		EXPECT_EQ(pack.tilesToMove, toMove);
 	};
 
-	EXPECT_CALL(serverMock, apply(Matcher<BattleStackMoved *>(_))).WillOnce(Invoke(checkMove));
+	EXPECT_CALL(serverMock, apply(Matcher<BattleStackMoved &>(_))).WillOnce(Invoke(checkMove));
 
 	context->callGlobal(&serverMock, "apply", params);
 }

--- a/test/spells/effects/CatapultTest.cpp
+++ b/test/spells/effects/CatapultTest.cpp
@@ -134,7 +134,7 @@ TEST_F(CatapultApplyTest, DISABLED_DamageToIntactPart)
 	EXPECT_CALL(*battleFake, getWallState(_)).WillRepeatedly(Return(EWallState::DESTROYED));
 	EXPECT_CALL(*battleFake, getWallState(Eq(targetPart))).WillRepeatedly(Return(EWallState::INTACT));
 	EXPECT_CALL(*battleFake, setWallState(Eq(targetPart), Eq(EWallState::DAMAGED))).Times(1);
-	EXPECT_CALL(serverMock, apply(Matcher<CatapultAttack *>(_))).Times(1);
+	EXPECT_CALL(serverMock, apply(Matcher<CatapultAttack &>(_))).Times(1);
 
     EffectTarget target;
     target.emplace_back();

--- a/test/spells/effects/CloneTest.cpp
+++ b/test/spells/effects/CloneTest.cpp
@@ -148,8 +148,8 @@ public:
 
 		battleFake->setupEmptyBattlefield();
 
-		EXPECT_CALL(serverMock, apply(Matcher<BattleUnitsChanged *>(_))).Times(2);
-		EXPECT_CALL(serverMock, apply(Matcher<SetStackEffect *>(_))).Times(1);
+		EXPECT_CALL(serverMock, apply(Matcher<BattleUnitsChanged &>(_))).Times(2);
+		EXPECT_CALL(serverMock, apply(Matcher<SetStackEffect &>(_))).Times(1);
 
 		EXPECT_CALL(mechanicsMock, getEffectDuration()).WillOnce(Return(effectDuration));
 		EXPECT_CALL(*battleFake, getUnitsIf(_)).Times(AtLeast(1));

--- a/test/spells/effects/DamageTest.cpp
+++ b/test/spells/effects/DamageTest.cpp
@@ -109,7 +109,7 @@ TEST_F(DamageApplyTest, DISABLED_DoesDamageToAliveUnit)
 	targetUnitState->localInit(&unitEnvironmentMock);
 	EXPECT_CALL(targetUnit, acquireState()).WillOnce(Return(targetUnitState));
 	EXPECT_CALL(*battleFake, setUnitState(Eq(unitId),_, Lt(0))).Times(1);
-	EXPECT_CALL(serverMock, apply(Matcher<StacksInjured *>(_))).Times(1);
+	EXPECT_CALL(serverMock, apply(Matcher<StacksInjured &>(_))).Times(1);
 	EXPECT_CALL(serverMock, describeChanges()).WillRepeatedly(Return(false));
 
 	setupDefaultRNG();
@@ -174,7 +174,7 @@ TEST_F(DamageApplyTest, DISABLED_DoesDamageByPercent)
 	EXPECT_CALL(targetUnit, acquireState()).WillOnce(Return(targetUnitState));
 
 	EXPECT_CALL(*battleFake, setUnitState(Eq(unitId),_, Lt(0))).Times(1);
-	EXPECT_CALL(serverMock, apply(Matcher<StacksInjured *>(_))).Times(1);
+	EXPECT_CALL(serverMock, apply(Matcher<StacksInjured &>(_))).Times(1);
 	EXPECT_CALL(serverMock, describeChanges()).WillRepeatedly(Return(false));
 
 	setupDefaultRNG();
@@ -218,7 +218,7 @@ TEST_F(DamageApplyTest, DISABLED_DoesDamageByCount)
 	EXPECT_CALL(targetUnit, acquireState()).WillOnce(Return(targetUnitState));
 
 	EXPECT_CALL(*battleFake, setUnitState(Eq(unitId), _, Lt(0))).Times(1);
-	EXPECT_CALL(serverMock, apply(Matcher<StacksInjured *>(_))).Times(1);
+	EXPECT_CALL(serverMock, apply(Matcher<StacksInjured &>(_))).Times(1);
 	EXPECT_CALL(serverMock, describeChanges()).WillRepeatedly(Return(false));
 
 	setupDefaultRNG();

--- a/test/spells/effects/DispelTest.cpp
+++ b/test/spells/effects/DispelTest.cpp
@@ -209,7 +209,7 @@ TEST_F(DispelApplyTest, DISABLED_RemovesEffects)
 
 	EXPECT_CALL(mechanicsMock, getSpellIndex()).Times(AtLeast(1)).WillRepeatedly(Return(neutralID.toEnum()));
 
-	EXPECT_CALL(serverMock, apply(Matcher<SetStackEffect *>(_))).Times(1);
+	EXPECT_CALL(serverMock, apply(Matcher<SetStackEffect &>(_))).Times(1);
 	EXPECT_CALL(serverMock, describeChanges()).WillRepeatedly(Return(false));
 
 	setDefaultExpectations();

--- a/test/spells/effects/EffectFixture.cpp
+++ b/test/spells/effects/EffectFixture.cpp
@@ -92,13 +92,13 @@ void EffectFixture::setUp()
 
 	ON_CALL(serverMock, getRNG()).WillByDefault(Return(&rngMock));
 
-	ON_CALL(serverMock, apply(Matcher<BattleLogMessage *>(_))).WillByDefault(Invoke(battleFake.get(),  &battle::BattleFake::accept<BattleLogMessage>));
-	ON_CALL(serverMock, apply(Matcher<BattleStackMoved *>(_))).WillByDefault(Invoke(battleFake.get(),  &battle::BattleFake::accept<BattleStackMoved>));
-	ON_CALL(serverMock, apply(Matcher<BattleUnitsChanged *>(_))).WillByDefault(Invoke(battleFake.get(),  &battle::BattleFake::accept<BattleUnitsChanged>));
-	ON_CALL(serverMock, apply(Matcher<SetStackEffect *>(_))).WillByDefault(Invoke(battleFake.get(),  &battle::BattleFake::accept<SetStackEffect>));
-	ON_CALL(serverMock, apply(Matcher<StacksInjured *>(_))).WillByDefault(Invoke(battleFake.get(),  &battle::BattleFake::accept<StacksInjured>));
-	ON_CALL(serverMock, apply(Matcher<BattleObstaclesChanged *>(_))).WillByDefault(Invoke(battleFake.get(),  &battle::BattleFake::accept<BattleObstaclesChanged>));
-	ON_CALL(serverMock, apply(Matcher<CatapultAttack *>(_))).WillByDefault(Invoke(battleFake.get(),  &battle::BattleFake::accept<CatapultAttack>));
+	ON_CALL(serverMock, apply(Matcher<BattleLogMessage &>(_))).WillByDefault(Invoke(battleFake.get(),  &battle::BattleFake::accept<BattleLogMessage>));
+	ON_CALL(serverMock, apply(Matcher<BattleStackMoved &>(_))).WillByDefault(Invoke(battleFake.get(),  &battle::BattleFake::accept<BattleStackMoved>));
+	ON_CALL(serverMock, apply(Matcher<BattleUnitsChanged &>(_))).WillByDefault(Invoke(battleFake.get(),  &battle::BattleFake::accept<BattleUnitsChanged>));
+	ON_CALL(serverMock, apply(Matcher<SetStackEffect &>(_))).WillByDefault(Invoke(battleFake.get(),  &battle::BattleFake::accept<SetStackEffect>));
+	ON_CALL(serverMock, apply(Matcher<StacksInjured &>(_))).WillByDefault(Invoke(battleFake.get(),  &battle::BattleFake::accept<StacksInjured>));
+	ON_CALL(serverMock, apply(Matcher<BattleObstaclesChanged &>(_))).WillByDefault(Invoke(battleFake.get(),  &battle::BattleFake::accept<BattleObstaclesChanged>));
+	ON_CALL(serverMock, apply(Matcher<CatapultAttack &>(_))).WillByDefault(Invoke(battleFake.get(),  &battle::BattleFake::accept<CatapultAttack>));
 }
 
 static int64_t getInt64Range(int64_t lower, int64_t upper)

--- a/test/spells/effects/HealTest.cpp
+++ b/test/spells/effects/HealTest.cpp
@@ -375,8 +375,8 @@ TEST_P(HealApplyTest, DISABLED_Heals)
 
 	EXPECT_CALL(actualCaster, getCasterUnitId()).WillRepeatedly(Return(-1));
 
-	EXPECT_CALL(serverMock, apply(Matcher<BattleUnitsChanged *>(_))).Times(1);
-	EXPECT_CALL(serverMock, apply(Matcher<BattleLogMessage *>(_))).Times(AtLeast(1));
+	EXPECT_CALL(serverMock, apply(Matcher<BattleUnitsChanged &>(_))).Times(1);
+	EXPECT_CALL(serverMock, apply(Matcher<BattleLogMessage &>(_))).Times(AtLeast(1));
 
 	setupDefaultRNG();
 

--- a/test/spells/effects/SacrificeTest.cpp
+++ b/test/spells/effects/SacrificeTest.cpp
@@ -203,8 +203,8 @@ TEST_F(SacrificeApplyTest, DISABLED_ResurrectsTarget)
 
 	EXPECT_CALL(targetUnit, acquire()).WillOnce(Return(targetUnitState));
 
-	EXPECT_CALL(serverMock, apply(Matcher<BattleUnitsChanged *>(_))).Times(AtLeast(1));
-	EXPECT_CALL(serverMock, apply(Matcher<BattleLogMessage *>(_))).Times(AtLeast(1));
+	EXPECT_CALL(serverMock, apply(Matcher<BattleUnitsChanged &>(_))).Times(AtLeast(1));
+	EXPECT_CALL(serverMock, apply(Matcher<BattleLogMessage &>(_))).Times(AtLeast(1));
 
 	setupDefaultRNG();
 

--- a/test/spells/effects/SummonTest.cpp
+++ b/test/spells/effects/SummonTest.cpp
@@ -225,7 +225,7 @@ TEST_P(SummonApplyTest, DISABLED_SpawnsNewUnit)
 
 	EXPECT_CALL(*battleFake, nextUnitId()).WillOnce(Return(unitId));
 	EXPECT_CALL(*battleFake, addUnit(Eq(unitId), _)).WillOnce(Invoke(this, &SummonApplyTest::onUnitAdded));
-	EXPECT_CALL(serverMock, apply(Matcher<BattleUnitsChanged *>(_))).Times(1);
+	EXPECT_CALL(serverMock, apply(Matcher<BattleUnitsChanged &>(_))).Times(1);
 
 	EffectTarget target;
 	target.emplace_back(unitPosition);
@@ -261,7 +261,7 @@ TEST_P(SummonApplyTest, DISABLED_UpdatesOldUnit)
 
 	EXPECT_CALL(unit, unitId()).WillOnce(Return(unitId));
 
-	EXPECT_CALL(serverMock, apply(Matcher<BattleUnitsChanged *>(_))).Times(1);
+	EXPECT_CALL(serverMock, apply(Matcher<BattleUnitsChanged &>(_))).Times(1);
 
 	unitsFake.setDefaultBonusExpectations();
 

--- a/test/spells/effects/TeleportTest.cpp
+++ b/test/spells/effects/TeleportTest.cpp
@@ -71,7 +71,7 @@ TEST_F(TeleportApplyTest, DISABLED_MovesUnit)
 
 	EXPECT_CALL(*battleFake, moveUnit(Eq(unitId), Eq(destination)));
 	EXPECT_CALL(mechanicsMock, getEffectLevel()).WillRepeatedly(Return(0));
-	EXPECT_CALL(serverMock, apply(Matcher<BattleStackMoved *>(_))).Times(1);
+	EXPECT_CALL(serverMock, apply(Matcher<BattleStackMoved &>(_))).Times(1);
 
 	Target target;
 	target.emplace_back(&unit, BattleHex());

--- a/test/spells/effects/TimedTest.cpp
+++ b/test/spells/effects/TimedTest.cpp
@@ -118,7 +118,7 @@ TEST_P(TimedApplyTest, DISABLED_ChangesBonuses)
 
 	setDefaultExpectations();
 
-	EXPECT_CALL(serverMock, apply(Matcher<SetStackEffect *>(_))).Times(1);
+	EXPECT_CALL(serverMock, apply(Matcher<SetStackEffect &>(_))).Times(1);
 
 	subject->apply(&serverMock, &mechanicsMock, target);
 


### PR DESCRIPTION
Removed most of manual memory management related to CPack and classes derived from it. Most of methods that accepted pointer to CPack / CPackForServer / CPackForClient now accept reference to it instead.

Removed usage of unique_ptr for CPackForLobby, replaced with allocation on stack - was completely unnecessary, both from performance point of view and from readability point of view. 

CPack's deletion is now managed by unique_ptr - Connection class returns unique_ptr with pointer instead of raw pointer.