### PR TITLE
Loading separate audio file in place of audio stream embedded in video

### DIFF
--- a/client/media/CVideoHandler.cpp
+++ b/client/media/CVideoHandler.cpp
@@ -608,9 +608,8 @@ std::pair<std::unique_ptr<ui8 []>, si64> CAudioInstance::extractAudio(const Vide
 bool CVideoPlayer::openAndPlayVideoImpl(const VideoPath & name, const Point & position, bool useOverlay, bool stopOnKey)
 {
 	CVideoInstance instance;
-	CAudioInstance audio;
 
-	auto extractedAudio = audio.extractAudio(name);
+	auto extractedAudio = getAudio(name);
 	int audioHandle = CCS->soundh->playSound(extractedAudio);
 
 	if (!instance.openInput(name))
@@ -684,6 +683,15 @@ std::unique_ptr<IVideoInstance> CVideoPlayer::open(const VideoPath & name, float
 
 std::pair<std::unique_ptr<ui8[]>, si64> CVideoPlayer::getAudio(const VideoPath & videoToOpen)
 {
+	AudioPath audioPath = videoToOpen.toType<EResType::SOUND>();
+	AudioPath audioPathVideoDir = audioPath.addPrefix("VIDEO/");
+
+	if(CResourceHandler::get()->existsResource(audioPath))
+		return CResourceHandler::get()->load(audioPath)->readAll();
+
+	if(CResourceHandler::get()->existsResource(audioPathVideoDir))
+		return CResourceHandler::get()->load(audioPathVideoDir)->readAll();
+
 	CAudioInstance audio;
 	return audio.extractAudio(videoToOpen);
 }


### PR DESCRIPTION
Turned out to be even easier than I expected.

With this change, when loading video, VCMI will look up audio file with the same name as video (but different extension), and if such file is present - use it in place of audio embedded into video file.

So, for example, `Video/H3Intro.ogg` will be used as audio track for `Video/H3Intro.bik`

This allows translation mods to only provide audio track for voice videos (e.g. h3 intro), avoiding lossy video re-encoding and large translation mod sizes.

Tested with ogg/vorbis, but mp3's and wav's should work as well. Support for ogg/opus may be added in the future.