### PR TITLE
Changed Commander Resistance type from Dwarf to Golem

### DIFF
--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -235,7 +235,8 @@ void CGameHandler::levelUpCommander (const CCommanderInstance * c, int skill)
 				scp.accumulatedBonus.type = BonusType::STACKS_SPEED;
 				break;
 			case ECommander::SPELL_POWER:
-				scp.accumulatedBonus.type = BonusType::MAGIC_RESISTANCE;
+				scp.accumulatedBonus.type = BonusType::SPELL_DAMAGE_REDUCTION;
+				scp.accumulatedBonus.subtype = BonusSubtypeID(SpellSchool::ANY);
 				scp.accumulatedBonus.val = difference (VLC->creh->skillLevels, c->secondarySkills, ECommander::RESISTANCE);
 				sendAndApply(scp); //additional pack
 				scp.accumulatedBonus.type = BonusType::CREATURE_SPELL_POWER;


### PR DESCRIPTION
Only changed the bonus on level-ups
The starting bonus on level 1 needs to be changed in mods
Checked in game. Before this change commanders took full damage from spells or resisted them. After this change they took reduced damage.
Should fix https://github.com/vcmi/vcmi/issues/4634
Didn't include "test/googletest" in commit. Git says something changed there but I didn't touch any files there. So I don't know if I should add it or not.