### PR TITLE
Workaround for hero movement lag caused by network latency

### DIFF
--- a/client/HeroMovementController.cpp
+++ b/client/HeroMovementController.cpp
@@ -162,11 +162,6 @@ void HeroMovementController::onTryMoveHero(const CGHeroInstance * hero, const Tr
 		}
 	}
 
-	bool directlyAttackingCreature =
-		details.attackedFrom.has_value() &&
-		LOCPLINT->localState->hasPath(hero) &&
-		LOCPLINT->localState->getPath(hero).lastNode().coord == details.attackedFrom;
-
 	std::unordered_set<int3> changedTiles {
 		hero->convertToVisitablePos(details.start),
 		hero->convertToVisitablePos(details.end)
@@ -189,13 +184,6 @@ void HeroMovementController::onTryMoveHero(const CGHeroInstance * hero, const Tr
 
 	//move finished
 	adventureInt->onHeroChanged(hero);
-
-	// Hero attacked creature, set direction to face it.
-	if(directlyAttackingCreature)
-	{
-		//FIXME: better handling of this case without const_cast
-		const_cast<CGHeroInstance *>(hero)->moveDir = details.end.getDirection(*details.attackedFrom);
-	}
 }
 
 void HeroMovementController::onQueryReplyApplied()
@@ -374,6 +362,9 @@ void HeroMovementController::sendMovementRequest(const CGHeroInstance * h, const
 		int3 nextCoord = h->convertFromVisitablePos(nextNode.coord);
 
 		LOCPLINT->cb->moveHero(h, nextCoord, useTransit);
+
+		if (nextNode.action == EPathNodeAction::NORMAL || nextNode.action == EPathNodeAction::VISIT)
+			CGI->mh->onHeroMoved(h, h->pos, h->convertFromVisitablePos(nextNode.coord));
 		return;
 	}
 

--- a/client/HeroMovementController.cpp
+++ b/client/HeroMovementController.cpp
@@ -193,17 +193,8 @@ void HeroMovementController::onTryMoveHero(const CGHeroInstance * hero, const Tr
 	// Hero attacked creature, set direction to face it.
 	if(directlyAttackingCreature)
 	{
-		// Get direction to attacker.
-		int3 posOffset = *details.attackedFrom - details.end + int3(2, 1, 0);
-		static const ui8 dirLookup[3][3] =
-		{
-			{ 1, 2, 3 },
-			{ 8, 0, 4 },
-			{ 7, 6, 5 }
-		};
-
 		//FIXME: better handling of this case without const_cast
-		const_cast<CGHeroInstance *>(hero)->moveDir = dirLookup[posOffset.y][posOffset.x];
+		const_cast<CGHeroInstance *>(hero)->moveDir = details.end.getDirection(*details.attackedFrom);
 	}
 }
 

--- a/client/NetPacksClient.cpp
+++ b/client/NetPacksClient.cpp
@@ -554,12 +554,13 @@ void ApplyFirstClientNetPackVisitor::visitTryMoveHero(TryMoveHero & pack)
 				CGI->mh->onBeforeHeroDisembark(h, pack.start, pack.end);
 				break;
 		}
-		CGI->mh->waitForOngoingAnimations();
 	}
 }
 
 void ApplyClientNetPackVisitor::visitTryMoveHero(TryMoveHero & pack)
 {
+	CGI->mh->waitForOngoingAnimations();
+
 	const CGHeroInstance *h = cl.getHero(pack.id);
 	cl.invalidatePaths();
 
@@ -568,7 +569,8 @@ void ApplyClientNetPackVisitor::visitTryMoveHero(TryMoveHero & pack)
 		switch(pack.result)
 		{
 			case TryMoveHero::SUCCESS:
-				CGI->mh->onHeroMoved(h, pack.start, pack.end);
+				CGI->mh->onObjectInstantRemove(h, h->getOwner());
+				CGI->mh->onObjectInstantAdd(h, h->getOwner());
 				break;
 			case TryMoveHero::EMBARK:
 				CGI->mh->onAfterHeroEmbark(h, pack.start, pack.end);

--- a/client/mapView/IMapRendererContext.h
+++ b/client/mapView/IMapRendererContext.h
@@ -21,6 +21,32 @@ struct CGPath;
 
 VCMI_LIB_NAMESPACE_END
 
+// Hero / boat animation groups, as defined in H3 .def files
+enum class EHeroMapAnimationGroup : int8_t
+{
+	IDLE_NORTH,
+	IDLE_NORTHEAST,
+	IDLE_EAST,
+	IDLE_SOUTHEAST,
+	IDLE_SOUTH,
+
+	MOVE_NORTH,
+	MOVE_NORTHEAST,
+	MOVE_EAST,
+	MOVE_SOUTHEAST,
+	MOVE_SOUTH,
+
+	// End of H3 groups, start of groups generated in vcmi in runtime
+
+	MOVE_NORTHWEST,
+	MOVE_WEST,
+	MOVE_SOUTHWEST,
+
+	IDLE_NORTHWEST,
+	IDLE_WEST,
+	IDLE_SOUTHWEST,
+};
+
 class IMapRendererContext
 {
 public:

--- a/client/mapView/MapRenderer.cpp
+++ b/client/mapView/MapRenderer.cpp
@@ -405,13 +405,13 @@ std::shared_ptr<CAnimation> MapRendererObjects::getAnimation(const AnimationPath
 
 	if(generateMovementGroups)
 	{
-		ret->createFlippedGroup(1, 13);
-		ret->createFlippedGroup(2, 14);
-		ret->createFlippedGroup(3, 15);
+		ret->createFlippedGroup(static_cast<size_t>(EHeroMapAnimationGroup::IDLE_NORTHEAST), static_cast<size_t>(EHeroMapAnimationGroup::IDLE_NORTHWEST));
+		ret->createFlippedGroup(static_cast<size_t>(EHeroMapAnimationGroup::IDLE_EAST),      static_cast<size_t>(EHeroMapAnimationGroup::IDLE_WEST));
+		ret->createFlippedGroup(static_cast<size_t>(EHeroMapAnimationGroup::IDLE_SOUTHEAST), static_cast<size_t>(EHeroMapAnimationGroup::IDLE_SOUTHWEST));
 
-		ret->createFlippedGroup(6, 10);
-		ret->createFlippedGroup(7, 11);
-		ret->createFlippedGroup(8, 12);
+		ret->createFlippedGroup(static_cast<size_t>(EHeroMapAnimationGroup::MOVE_NORTHEAST), static_cast<size_t>(EHeroMapAnimationGroup::MOVE_NORTHWEST));
+		ret->createFlippedGroup(static_cast<size_t>(EHeroMapAnimationGroup::MOVE_EAST),      static_cast<size_t>(EHeroMapAnimationGroup::MOVE_WEST));
+		ret->createFlippedGroup(static_cast<size_t>(EHeroMapAnimationGroup::MOVE_SOUTHEAST), static_cast<size_t>(EHeroMapAnimationGroup::MOVE_SOUTHWEST));
 	}
 	return ret;
 }

--- a/client/mapView/MapRendererContext.cpp
+++ b/client/mapView/MapRendererContext.cpp
@@ -424,7 +424,9 @@ size_t MapRendererAdventureMovingContext::objectGroupIndex(ObjectInstanceID obje
 		EHeroMapAnimationGroup::MOVE_NORTHWEST, //NORTHWEST
 		EHeroMapAnimationGroup::MOVE_EAST       //CENTER
 	};
-	return static_cast<size_t>(moveGroups.at(static_cast<size_t>(getObjectRotation(objectID))));
+
+	auto direction = objectID == target ? tileFrom.getDirection(tileDest) : getObjectRotation(objectID);
+	return static_cast<size_t>(moveGroups.at(static_cast<int>(direction)));
 }
 
 bool MapRendererAdventureMovingContext::tileAnimated(const int3 & coordinates) const

--- a/client/mapView/MapRendererContext.cpp
+++ b/client/mapView/MapRendererContext.cpp
@@ -31,7 +31,7 @@ MapRendererBaseContext::MapRendererBaseContext(const MapRendererContextState & v
 {
 }
 
-uint32_t MapRendererBaseContext::getObjectRotation(ObjectInstanceID objectID) const
+ECardinalDirection MapRendererBaseContext::getObjectRotation(ObjectInstanceID objectID) const
 {
 	const CGObjectInstance * obj = getObject(objectID);
 
@@ -49,7 +49,7 @@ uint32_t MapRendererBaseContext::getObjectRotation(ObjectInstanceID objectID) co
 			return boat->hero->moveDir;
 		return boat->direction;
 	}
-	return 0;
+	return ECardinalDirection::INVALID;
 }
 
 int3 MapRendererBaseContext::getMapSize() const
@@ -113,8 +113,19 @@ const CGPath * MapRendererBaseContext::currentPath() const
 
 size_t MapRendererBaseContext::objectGroupIndex(ObjectInstanceID objectID) const
 {
-	static const std::array<size_t, 9> idleGroups = {0, 13, 0, 1, 2, 3, 4, 15, 14};
-	return idleGroups[getObjectRotation(objectID)];
+	static constexpr std::array idleGroups = {
+		EHeroMapAnimationGroup::IDLE_NORTH,     //INVALID
+		EHeroMapAnimationGroup::IDLE_NORTH,     //NORTH
+		EHeroMapAnimationGroup::IDLE_NORTHEAST, //NORTHEAST
+		EHeroMapAnimationGroup::IDLE_EAST,      //EAST
+		EHeroMapAnimationGroup::IDLE_SOUTHEAST, //SOUTHEAST
+		EHeroMapAnimationGroup::IDLE_SOUTH,     //SOUTH
+		EHeroMapAnimationGroup::IDLE_SOUTHWEST, //SOUTHWEST
+		EHeroMapAnimationGroup::IDLE_WEST,	    //WEST
+		EHeroMapAnimationGroup::IDLE_NORTHWEST, //NORTHWEST
+		EHeroMapAnimationGroup::IDLE_EAST       //CENTER
+	};
+	return static_cast<size_t>(idleGroups.at(static_cast<size_t>(getObjectRotation(objectID))));
 }
 
 Point MapRendererBaseContext::objectImageOffset(ObjectInstanceID objectID, const int3 & coordinates) const
@@ -401,12 +412,19 @@ MapRendererAdventureMovingContext::MapRendererAdventureMovingContext(const MapRe
 
 size_t MapRendererAdventureMovingContext::objectGroupIndex(ObjectInstanceID objectID) const
 {
-	if(target == objectID)
-	{
-		static const std::array<size_t, 9> moveGroups = {0, 10, 5, 6, 7, 8, 9, 12, 11};
-		return moveGroups[getObjectRotation(objectID)];
-	}
-	return MapRendererAdventureContext::objectGroupIndex(objectID);
+	static constexpr std::array moveGroups = {
+		EHeroMapAnimationGroup::IDLE_NORTH,     //INVALID
+		EHeroMapAnimationGroup::MOVE_NORTH,     //NORTH
+		EHeroMapAnimationGroup::MOVE_NORTHEAST, //NORTHEAST
+		EHeroMapAnimationGroup::MOVE_EAST,      //EAST
+		EHeroMapAnimationGroup::MOVE_SOUTHEAST, //SOUTHEAST
+		EHeroMapAnimationGroup::MOVE_SOUTH,     //SOUTH
+		EHeroMapAnimationGroup::MOVE_SOUTHWEST, //SOUTHWEST
+		EHeroMapAnimationGroup::MOVE_WEST,	    //WEST
+		EHeroMapAnimationGroup::MOVE_NORTHWEST, //NORTHWEST
+		EHeroMapAnimationGroup::MOVE_EAST       //CENTER
+	};
+	return static_cast<size_t>(moveGroups.at(static_cast<size_t>(getObjectRotation(objectID))));
 }
 
 bool MapRendererAdventureMovingContext::tileAnimated(const int3 & coordinates) const

--- a/client/mapView/MapRendererContext.h
+++ b/client/mapView/MapRendererContext.h
@@ -28,7 +28,7 @@ public:
 
 	explicit MapRendererBaseContext(const MapRendererContextState & viewState);
 
-	uint32_t getObjectRotation(ObjectInstanceID objectID) const;
+	ECardinalDirection getObjectRotation(ObjectInstanceID objectID) const;
 
 	int3 getMapSize() const override;
 	bool isInMap(const int3 & coordinates) const override;

--- a/client/mapView/MapViewController.cpp
+++ b/client/mapView/MapViewController.cpp
@@ -244,10 +244,10 @@ void MapViewController::afterRender()
 		if(movementContext->progress >= 0.999)
 		{
 			logGlobal->debug("Ending movement animation");
-			setViewCenter(hero->getSightCenter());
+			setViewCenter(hero->convertToVisitablePos(movementContext->tileDest));
 
-			removeObject(context->getObject(movementContext->target));
-			addObject(context->getObject(movementContext->target));
+			//removeObject(context->getObject(movementContext->target));
+			//addObject(context->getObject(movementContext->target));
 
 			activateAdventureContext(movementContext->animationTime);
 		}

--- a/client/mapView/mapHandler.cpp
+++ b/client/mapView/mapHandler.cpp
@@ -218,7 +218,7 @@ void CMapHandler::onBeforeHeroTeleported(const CGHeroInstance * obj, const int3 
 
 void CMapHandler::onHeroMoved(const CGHeroInstance * obj, const int3 & from, const int3 & dest)
 {
-	assert(obj->pos == dest);
+	assert(obj->pos == dest || obj->pos == from);
 	for(auto * observer : observers)
 		observer->onHeroMoved(obj, from, dest);
 }

--- a/lib/int3.h
+++ b/lib/int3.h
@@ -11,6 +11,21 @@
 
 VCMI_LIB_NAMESPACE_BEGIN
 
+enum class ECardinalDirection : int8_t
+{
+	INVALID = 0,
+
+	NORTH = 1,
+	NORTHEAST = 2,
+	EAST = 3,
+	SOUTHEAST = 4,
+	SOUTH = 5,
+	SOUTHWEST = 6,
+	WEST = 7,
+	NORTHWEST = 8,
+	CENTER = 9
+};
+
 /// Class which consists of three integer values. Represents position on adventure map.
 class int3
 {
@@ -46,6 +61,7 @@ public:
 	constexpr int3 operator*(const si32 i) const { return int3(x * i, y * i, z * i); }
 	//returns int3 with coordinates divided by given number
 	constexpr int3 operator/(const si32 i) const { return int3(x / i, y / i, z / i); }
+	constexpr int3 operator/(const int3 & i) const { return int3(x / i.x, y / i.y, z / i.z); }
 
 	constexpr int3 & operator+=(const int3 & i)
 	{
@@ -175,6 +191,22 @@ public:
 	{
 		return { { int3(0,1,0),int3(0,-1,0),int3(-1,0,0),int3(+1,0,0),
 			int3(1,1,0),int3(-1,1,0),int3(1,-1,0),int3(-1,-1,0) } };
+	}
+
+	/// returns cardinal direction in which to move in order to reach 'to'
+	/// returns INVALID if tiles are not adjancent
+	ECardinalDirection getDirection(int3 to) const
+	{
+		static std::array<std::array<ECardinalDirection, 3>, 3> dirLookup = {{
+			{ECardinalDirection::NORTHWEST, ECardinalDirection::NORTH,  ECardinalDirection::NORTHEAST},
+			{ECardinalDirection::WEST,      ECardinalDirection::CENTER, ECardinalDirection::EAST},
+			{ECardinalDirection::SOUTHWEST, ECardinalDirection::SOUTH,  ECardinalDirection::SOUTHEAST}
+		}};
+		int3 offset = to - *this + int3(1,1,0);
+		if (offset.x > 2 || offset.y > 2 || offset.x < 0 || offset.y < 0) // different z is legal, e.g. seer hut
+			return ECardinalDirection::INVALID;
+
+		return dirLookup.at(offset.y).at(offset.x);
 	}
 
 	// Solution by ChatGPT

--- a/lib/mapObjects/CGHeroInstance.cpp
+++ b/lib/mapObjects/CGHeroInstance.cpp
@@ -285,7 +285,7 @@ CGHeroInstance::CGHeroInstance(IGameCallback * cb)
 	type(nullptr),
 	tacticFormationEnabled(false),
 	inTownGarrison(false),
-	moveDir(4),
+	moveDir(ECardinalDirection::EAST),
 	mana(UNINITIALIZED_MANA),
 	movement(UNINITIALIZED_MOVEMENT),
 	level(1),

--- a/lib/mapObjects/CGHeroInstance.h
+++ b/lib/mapObjects/CGHeroInstance.h
@@ -63,14 +63,8 @@ private:
 
 public:
 
-	//////////////////////////////////////////////////////////////////////////
-	//format:   123
-	//          8 4
-	//          765
-	ui8 moveDir;
+	ECardinalDirection moveDir;
 	mutable ui8 tacticFormationEnabled;
-
-	//////////////////////////////////////////////////////////////////////////
 
 	const CHero * type;
 	TExpType exp; //experience points

--- a/lib/mapObjects/CQuest.h
+++ b/lib/mapObjects/CQuest.h
@@ -61,7 +61,7 @@ public:
 	ui8 textOption;
 	ui8 completedOption;
 	CreatureID stackToKill;
-	ui8 stackDirection;
+	ECardinalDirection stackDirection;
 	std::string heroName; //backup of hero name
 	HeroTypeID heroPortrait;
 
@@ -154,7 +154,7 @@ public:
 	void getVisitText (MetaString &text, std::vector<Component> &components, bool FirstVisit, const CGHeroInstance * h = nullptr) const override;
 
 	virtual void init(vstd::RNG & rand);
-	int checkDirection() const; //calculates the region of map where monster is placed
+	ECardinalDirection checkDirection() const; //calculates the region of map where monster is placed
 	void setObjToKill(); //remember creatures / heroes to kill after they are initialized
 	const CGHeroInstance *getHeroToKill(bool allowNull) const;
 	const CGCreature *getCreatureToKill(bool allowNull) const;

--- a/lib/mapObjects/MiscObjects.cpp
+++ b/lib/mapObjects/MiscObjects.cpp
@@ -1107,7 +1107,7 @@ CGBoat::CGBoat(IGameCallback * cb)
 	: CGObjectInstance(cb)
 {
 	hero = nullptr;
-	direction = 4;
+	direction = ECardinalDirection::EAST;
 	layer = EPathfindingLayer::SAIL;
 }
 

--- a/lib/mapObjects/MiscObjects.h
+++ b/lib/mapObjects/MiscObjects.h
@@ -317,7 +317,7 @@ class DLL_LINKAGE CGBoat : public CGObjectInstance, public CBonusSystemNode
 public:
 	using CGObjectInstance::CGObjectInstance;
 
-	ui8 direction;
+	ECardinalDirection direction;
 	const CGHeroInstance *hero;  //hero on board
 	bool onboardAssaultAllowed; //if true, hero can attack units from transport
 	bool onboardVisitAllowed; //if true, hero can visit objects from transport

--- a/lib/networkPacks/NetPacksLib.cpp
+++ b/lib/networkPacks/NetPacksLib.cpp
@@ -1262,6 +1262,9 @@ void TryMoveHero::applyGs(CGameState *gs)
 	if((result == SUCCESS || result == BLOCKING_VISIT || result == EMBARK || result == DISEMBARK) && start != end)
 	{
 		auto direction = start.getDirection(end);
+		if(attackedFrom) // Hero attacked creature, set direction to face it.
+			direction = end.getDirection(*attackedFrom);
+
 		if (direction != ECardinalDirection::INVALID)
 			h->moveDir = direction;
 		//else don`t change move direction - hero might have traversed the subterranean gate, direction should be kept

--- a/lib/networkPacks/NetPacksLib.cpp
+++ b/lib/networkPacks/NetPacksLib.cpp
@@ -1248,44 +1248,6 @@ void RemoveObject::applyGs(CGameState *gs)
 	gs->map->calculateGuardingGreaturePositions();//FIXME: excessive, update only affected tiles
 }
 
-static int getDir(const int3 & src, const int3 & dst)
-{
-	int ret = -1;
-	if(dst.x+1 == src.x && dst.y+1 == src.y) //tl
-	{
-		ret = 1;
-	}
-	else if(dst.x == src.x && dst.y+1 == src.y) //t
-	{
-		ret = 2;
-	}
-	else if(dst.x-1 == src.x && dst.y+1 == src.y) //tr
-	{
-		ret = 3;
-	}
-	else if(dst.x-1 == src.x && dst.y == src.y) //r
-	{
-		ret = 4;
-	}
-	else if(dst.x-1 == src.x && dst.y-1 == src.y) //br
-	{
-		ret = 5;
-	}
-	else if(dst.x == src.x && dst.y-1 == src.y) //b
-	{
-		ret = 6;
-	}
-	else if(dst.x+1 == src.x && dst.y-1 == src.y) //bl
-	{
-		ret = 7;
-	}
-	else if(dst.x+1 == src.x && dst.y == src.y) //l
-	{
-		ret = 8;
-	}
-	return ret;
-}
-
 void TryMoveHero::applyGs(CGameState *gs)
 {
 	CGHeroInstance *h = gs->getHero(id);
@@ -1299,9 +1261,9 @@ void TryMoveHero::applyGs(CGameState *gs)
 
 	if((result == SUCCESS || result == BLOCKING_VISIT || result == EMBARK || result == DISEMBARK) && start != end)
 	{
-		auto dir = getDir(start,end);
-		if(dir > 0  &&  dir <= 8)
-			h->moveDir = dir;
+		auto direction = start.getDirection(end);
+		if (direction != ECardinalDirection::INVALID)
+			h->moveDir = direction;
 		//else don`t change move direction - hero might have traversed the subterranean gate, direction should be kept
 	}
 

--- a/mapeditor/maphandler.cpp
+++ b/mapeditor/maphandler.cpp
@@ -313,7 +313,7 @@ std::shared_ptr<QImage> MapHandler::findFlagBitmap(const CGHeroInstance * hero, 
 	return findFlagBitmapInternal(graphics->heroFlagAnimations.at(color.getNum()), anim, group, hero->moveDir, true);
 }
 
-std::shared_ptr<QImage> MapHandler::findFlagBitmapInternal(std::shared_ptr<Animation> animation, int anim, int group, ui8 dir, bool moving) const
+std::shared_ptr<QImage> MapHandler::findFlagBitmapInternal(std::shared_ptr<Animation> animation, int anim, int group, ECardinalDirection dir, bool moving) const
 {
 	size_t groupSize = animation->size(group);
 	if(groupSize == 0)

--- a/mapeditor/maphandler.h
+++ b/mapeditor/maphandler.h
@@ -58,7 +58,7 @@ private:
 	int index(int x, int y, int z) const;
 	int index(const int3 &) const;
 		
-	std::shared_ptr<QImage> findFlagBitmapInternal(std::shared_ptr<Animation> animation, int anim, int group, ui8 dir, bool moving) const;
+	std::shared_ptr<QImage> findFlagBitmapInternal(std::shared_ptr<Animation> animation, int anim, int group, ECardinalDirection dir, bool moving) const;
 	std::shared_ptr<QImage> findFlagBitmap(const CGHeroInstance * obj, int anim, const PlayerColor color, int group) const;
 	BitmapHolder findObjectBitmap(const CGObjectInstance * obj, int anim, int group = 0) const;
 	


### PR DESCRIPTION
Heavy WIP.

With this PR, VCMI will start playing hero movement animation immediately, without waiting for server reply. This allows to hide network lag caused by network latency / ping (as long as latency is less than time it takes to animate hero movement)

Since only animation is emulated by client, there is no need to rollback gamestate in case of movement failure, so should be relatively easy to implement compared to alternative approaches.

Downsides of this approach:
- FOW reveal occurs only when client receives reply from server, so may be delayed a bit. Not a problem when hero moves in already revealed terrain
- If player ping/latency is higher than time it takes to animate movement, lag would still occur (but would be shorter than before)
- Right now only 'standard' movement uses this approach, embarking/disembarking or teleporting works as before (with lag)

TODO:
- [ ] check that animation of enemy heroes movement works as before
- [ ] handle rollback in case if movement was denied by server
- [ ] check event triggering - what happens if hero steps on tile with event?
- [ ] ensure that movement animation works as intended when batching is on and speed set to max
- [ ] ensure that movement animation works if water walk / fly is in use