### PR TITLE
fix: use sdl mixer to get audio duration

### DIFF
--- a/client/media/CSoundHandler.cpp
+++ b/client/media/CSoundHandler.cpp
@@ -153,14 +153,15 @@ uint32_t CSoundHandler::getSoundDurationMilliseconds(const AudioPath & sound)
 
 	int freq = 0;
 	Uint16 fmt = 0;
-	int chans = 0;
-	if(!Mix_QuerySpec(&freq, &fmt, &chans))
+	int channels = 0;
+	if(!Mix_QuerySpec(&freq, &fmt, &channels))
 		return 0;
 
 	if(chunk != nullptr)
 	{
-		Uint32 points = (chunk->alen / ((fmt & 0xFF) / 8));
-		Uint32 frames = (points / chans);
+		Uint32 sampleSizeBytes = (fmt & 0xFF) / 8;
+		Uint32 samples = (chunk->alen / sampleSizeBytes);
+		Uint32 frames = (samples / channels);
 		milliseconds = ((frames * 1000) / freq);
 
 		Mix_FreeChunk(chunk);

--- a/client/media/CSoundHandler.cpp
+++ b/client/media/CSoundHandler.cpp
@@ -147,18 +147,23 @@ uint32_t CSoundHandler::getSoundDurationMilliseconds(const AudioPath & sound)
 
 	auto data = CResourceHandler::get()->load(resourcePath)->readAll();
 
-	SDL_AudioSpec spec;
-	uint32_t audioLen;
-	uint8_t * audioBuf;
 	uint32_t milliseconds = 0;
 
-	if(SDL_LoadWAV_RW(SDL_RWFromMem(data.first.get(), data.second), 1, &spec, &audioBuf, &audioLen) != nullptr)
+	Mix_Chunk * chunk = Mix_LoadWAV_RW(SDL_RWFromMem(data.first.get(), data.second), 1);
+
+	int freq = 0;
+	Uint16 fmt = 0;
+	int chans = 0;
+	if(!Mix_QuerySpec(&freq, &fmt, &chans))
+		return 0;
+
+	if(chunk != nullptr)
 	{
-		SDL_FreeWAV(audioBuf);
-		uint32_t sampleSize = SDL_AUDIO_BITSIZE(spec.format) / 8;
-		uint32_t sampleCount = audioLen / sampleSize;
-		uint32_t sampleLen = sampleCount / spec.channels;
-		milliseconds = 1000 * sampleLen / spec.freq;
+		Uint32 points = (chunk->alen / ((fmt & 0xFF) / 8));
+		Uint32 frames = (points / chans);
+		milliseconds = ((frames * 1000) / freq);
+
+		Mix_FreeChunk(chunk);
 	}
 
 	return milliseconds;


### PR DESCRIPTION
Support getting audio length for other audio formats by using sdl_mixer.

Fixes error getting audio length when using .ogg as in @heroesiiifan new audio translation for german and @Fabrice-TIERCELIN for french.

Notable at incorrect scrolling speed of text.

Used this logic: https://discourse.libsdl.org/t/time-length-of-sdl-mixer-chunks/12852/2