### PR TITLE
Count days from 1 instead of 0 in map editor timed event UI

### DIFF
--- a/mapeditor/mapsettings/timedevent.cpp
+++ b/mapeditor/mapsettings/timedevent.cpp
@@ -28,7 +28,7 @@ TimedEvent::TimedEvent(QListWidgetItem * t, QWidget *parent) :
 	ui->eventMessageText->setPlainText(params.value("message").toString());
 	ui->eventAffectsCpu->setChecked(params.value("computerAffected").toBool());
 	ui->eventAffectsHuman->setChecked(params.value("humanAffected").toBool());
-	ui->eventFirstOccurrence->setValue(params.value("firstOccurrence").toInt());
+	ui->eventFirstOccurrence->setValue(params.value("firstOccurrence").toInt() + 1);
 	ui->eventRepeatAfter->setValue(params.value("nextOccurrence").toInt());
 
 	auto playerList = params.value("players").toList();
@@ -68,7 +68,7 @@ void TimedEvent::on_TimedEvent_finished(int result)
 	descriptor["message"] = ui->eventMessageText->toPlainText();
 	descriptor["humanAffected"] = QVariant::fromValue(ui->eventAffectsHuman->isChecked());
 	descriptor["computerAffected"] = QVariant::fromValue(ui->eventAffectsCpu->isChecked());
-	descriptor["firstOccurrence"] = QVariant::fromValue(ui->eventFirstOccurrence->value());
+	descriptor["firstOccurrence"] = QVariant::fromValue(ui->eventFirstOccurrence->value() - 1);
 	descriptor["nextOccurrence"] = QVariant::fromValue(ui->eventRepeatAfter->value());
 
 	QVariantList players;

--- a/mapeditor/mapsettings/timedevent.ui
+++ b/mapeditor/mapsettings/timedevent.ui
@@ -72,7 +72,11 @@
           </widget>
          </item>
          <item>
-          <widget class="QSpinBox" name="eventFirstOccurrence"/>
+          <widget class="QSpinBox" name="eventFirstOccurrence">
+           <property name="minimum">
+            <number>1</number>
+           </property>
+          </widget>
          </item>
         </layout>
        </item>


### PR DESCRIPTION
Popup for adding/editing timed event will have days counter starting from 1 instead of 0