### PR TITLE
Building dependence of Unicorn Glide in Rampart should include Dendro…

### DIFF
--- a/config/factions/rampart.json
+++ b/config/factions/rampart.json
@@ -199,7 +199,7 @@
 				"dwellingLvl3":   { "id" : 32, "requires" : [ "dwellingLvl1" ] },
 				"dwellingLvl4":   { "id" : 33, "requires" : [ "dwellingLvl3" ] },
 				"dwellingLvl5":   { "id" : 34, "requires" : [ "dwellingLvl3" ] },
-				"dwellingLvl6":   { "id" : 35, "requires" : [ "allOf", [ "dwellingLvl3" ], [ "dwellingLvl4" ] ] },
+				"dwellingLvl6":   { "id" : 35, "requires" : [ "allOf", [ "dwellingLvl4" ], [ "dwellingLvl5" ] ] },
 				"dwellingLvl7":   { "id" : 36, "requires" : [ "allOf", [ "dwellingLvl6" ], [ "mageGuild2" ] ] },
 
 				"dwellingUpLvl1": { "id" : 37, "upgrades" : "dwellingLvl1" },


### PR DESCRIPTION
…id Arches
This is bug fix for [building dependency of unicorn glide](https://github.com/vcmi/vcmi/issues/4791#issue-2595021409)