### PR TITLE
fix for defect mp3

### DIFF
--- a/client/media/CMusicHandler.cpp
+++ b/client/media/CMusicHandler.cpp
@@ -265,7 +265,12 @@ void MusicEntry::load(const AudioPath & musicURI)
 
 	try
 	{
-		auto * musicFile = MakeSDLRWops(CResourceHandler::get()->load(currentName));
+		std::unique_ptr<CInputStream> stream = CResourceHandler::get()->load(currentName);
+
+		if(musicURI.getName() == "BLADEFWCAMPAIGN") // handle defect MP3 file - ffprobe says: Skipping 52 bytes of junk at 0.
+			stream->seek(52);
+
+		auto * musicFile = MakeSDLRWops(std::move(stream));
 		music = Mix_LoadMUS_RW(musicFile, SDL_TRUE);
 	}
 	catch(std::exception & e)


### PR DESCRIPTION
fixes #4799

Output of `ffprobe BladeFWCampaign.mp3`:
`Skipping 52 bytes of junk at 0.`

Tested for CD and GOG Complete version.

Checked other files. Only this file have this error...