### PR TITLE
save before each battle. The launcher UI adds 'Save before battle' by…

### DIFF
--- a/config/schemas/settings.json
+++ b/config/schemas/settings.json
@@ -42,7 +42,8 @@
 				"savePrefix",
 				"startTurnAutosave",
 				"enableUiEnhancements",
-				"audioMuteFocus"
+				"audioMuteFocus",
+				"saveBeforeBattle"
 			],
 			"properties" : {
 				"playerName" : {
@@ -144,6 +145,10 @@
 					"default": true
 				},
 				"audioMuteFocus" : {
+					"type": "boolean",
+					"default": false
+				},
+				"saveBeforeBattle" : {
 					"type": "boolean",
 					"default": false
 				}

--- a/launcher/settingsView/csettingsview_moc.cpp
+++ b/launcher/settingsView/csettingsview_moc.cpp
@@ -214,6 +214,8 @@ void CSettingsView::loadToggleButtonSettings()
 	setCheckbuttonState(ui->buttonRelativeCursorMode, settings["general"]["userRelativePointer"].Bool());
 	setCheckbuttonState(ui->buttonHapticFeedback, settings["general"]["hapticFeedback"].Bool());
 
+	setCheckbuttonState(ui->buttonSaveBeforeBattle, settings["general"]["saveBeforeBattle"].Bool());
+
 	std::string cursorType = settings["video"]["cursor"].String();
 	int cursorTypeIndex = vstd::find_pos(cursorTypesList, cursorType);
 	setCheckbuttonState(ui->buttonCursorType, cursorTypeIndex);
@@ -470,6 +472,13 @@ void CSettingsView::on_buttonAutoSave_toggled(bool value)
 	Settings node = settings.write["general"]["saveFrequency"];
 	node->Integer() = value ? 1 : 0;
 	updateCheckbuttonText(ui->buttonAutoSave);
+}
+
+void CSettingsView::on_buttonSaveBeforeBattle_toggled(bool value)
+{
+	Settings node = settings.write["general"]["saveBeforeBattle"];
+	node->Bool() = value;
+	updateCheckbuttonText(ui->buttonSaveBeforeBattle);
 }
 
 void CSettingsView::on_comboBoxLanguage_currentIndexChanged(int index)

--- a/launcher/settingsView/csettingsview_moc.h
+++ b/launcher/settingsView/csettingsview_moc.h
@@ -50,6 +50,7 @@ private slots:
 	void on_buttonAutoCheck_toggled(bool value);
 	void on_comboBoxDisplayIndex_currentIndexChanged(int index);
 	void on_buttonAutoSave_toggled(bool value);
+	void on_buttonSaveBeforeBattle_toggled(bool value);
 	void on_comboBoxLanguage_currentIndexChanged(int index);
 	void on_buttonCursorType_toggled(bool value);
 	void on_pushButtonTranslation_clicked();

--- a/launcher/settingsView/csettingsview_moc.ui
+++ b/launcher/settingsView/csettingsview_moc.ui
@@ -69,7 +69,7 @@
          </property>
         </widget>
        </item>
-       <item row="60" column="0">
+       <item row="61" column="0">
         <widget class="QLabel" name="labelModsValidation">
          <property name="text">
           <string>Mods Validation</string>
@@ -301,7 +301,7 @@
          </property>
         </widget>
        </item>
-       <item row="60" column="5">
+       <item row="61" column="5">
         <widget class="QToolButton" name="buttonValidationFull">
          <property name="enabled">
           <bool>true</bool>
@@ -507,7 +507,7 @@
          </property>
         </widget>
        </item>
-       <item row="5" column="1" colspan="5">
+       <item row="59" column="1" colspan="5">
         <widget class="QSpinBox" name="spinBoxNetworkPort">
          <property name="minimum">
           <number>1024</number>
@@ -667,7 +667,7 @@
          </property>
         </widget>
        </item>
-       <item row="60" column="1" colspan="2">
+       <item row="61" column="1" colspan="2">
         <widget class="QToolButton" name="buttonValidationOff">
          <property name="enabled">
           <bool>true</bool>
@@ -707,7 +707,7 @@
          </property>
         </widget>
        </item>
-       <item row="5" column="0">
+       <item row="59" column="0">
         <widget class="QLabel" name="labelNetworkPort">
          <property name="text">
           <string>Network port</string>
@@ -1133,7 +1133,7 @@
          </property>
         </widget>
        </item>
-       <item row="59" column="0">
+       <item row="60" column="0">
         <widget class="QLabel" name="labelMiscellaneous">
          <property name="font">
           <font>
@@ -1424,7 +1424,7 @@ Fullscreen Exclusive Mode - game will cover entirety of your screen and will use
        <item row="12" column="1" colspan="5">
         <widget class="QComboBox" name="comboBoxResolution"/>
        </item>
-       <item row="60" column="3" colspan="2">
+       <item row="61" column="3" colspan="2">
         <widget class="QToolButton" name="buttonValidationBasic">
          <property name="enabled">
           <bool>true</bool>
@@ -1447,6 +1447,29 @@ Fullscreen Exclusive Mode - game will cover entirety of your screen and will use
          <attribute name="buttonGroup">
           <string notr="true">buttonGroupValidation</string>
          </attribute>
+        </widget>
+       </item>
+       <item row="5" column="0">
+        <widget class="QLabel" name="labelSaveBeforeBattle">
+         <property name="text">
+          <string>Save before battle</string>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="1" colspan="5">
+        <widget class="QToolButton" name="buttonSaveBeforeBattle">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
         </widget>
        </item>
       </layout>

--- a/launcher/translation/chinese.ts
+++ b/launcher/translation/chinese.ts
@@ -1010,6 +1010,11 @@ Fullscreen Exclusive Mode - game will cover entirety of your screen and will use
         <translation>自动存档</translation>
     </message>
     <message>
+        <location filename="../settingsView/csettingsview_moc.ui" line="1455"/>
+        <source>Save before battle</source>
+        <translation>战斗前存档</translation>
+    </message>
+    <message>
         <location filename="../settingsView/csettingsview_moc.ui" line="764"/>
         <source>VSync</source>
         <translation>垂直同步</translation>

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -4276,10 +4276,21 @@ void CGameHandler::newObject(CGObjectInstance * object, PlayerColor initiator)
 
 void CGameHandler::startBattle(const CArmedInstance *army1, const CArmedInstance *army2, int3 tile, const CGHeroInstance *hero1, const CGHeroInstance *hero2, const BattleLayout & layout, const CGTownInstance *town)
 {
+	if (settings["general"]["saveBeforeBattle"].Bool())
+	{
+		logGlobal->debug("gameHandler save before battle.");
+		save("Saves/BATTLE");
+	}
 	battles->startBattle(army1, army2, tile, hero1, hero2, layout, town);
 }
 
 void CGameHandler::startBattle(const CArmedInstance *army1, const CArmedInstance *army2 )
 {
+	if (settings["general"]["saveBeforeBattle"].Bool())
+	{
+		logGlobal->debug("gameHandler save before battle.");
+		save("Saves/BATTLE");
+	}
+
 	battles->startBattle(army1, army2);
 }


### PR DESCRIPTION
… replacing original 'Network port' button because insertion new button meaning to move all row index by 1. Also 'network port' seems fitting to be category of 'Network' which is near end of all buttons and it saves a lot modifications.

This is a new feature for this [save before battle](https://github.com/vcmi/vcmi/issues/4816#issue-2607282983). 