### PR TITLE
Add support for Win7 and 32-bit msvc+vcpkg builds

### DIFF
--- a/.github/workflows/github.yml
+++ b/.github/workflows/github.yml
@@ -285,6 +285,7 @@ jobs:
             sleep 3
             ((counter++))
         done
+        rm -rf _CPack_Packages
 
     - name: Artifacts
       if: ${{ matrix.pack == 1 }}

--- a/.github/workflows/github.yml
+++ b/.github/workflows/github.yml
@@ -69,7 +69,7 @@ jobs:
             conan_profile: ios-arm64
             conan_prebuilts: dependencies-ios
             conan_options: --options with_apple_system_libs=True
-          - platform: msvc
+          - platform: msvc-x64
             os: windows-latest
             test: 0
             pack: 1
@@ -77,6 +77,14 @@ jobs:
             extension: exe
             before_install: msvc.sh
             preset: windows-msvc-release
+          - platform: msvc-x86
+            os: windows-latest
+            test: 0
+            pack: 1
+            pack_type: RelWithDebInfo
+            extension: exe
+            before_install: msvc.sh
+            preset: windows-msvc-release-x86
           - platform: mingw_x86_64
             os: ubuntu-24.04
             test: 0
@@ -135,6 +143,10 @@ jobs:
     - name: Install Conan Dependencies
       if: "${{ matrix.conan_prebuilts != '' }}"
       run: source '${{github.workspace}}/CI/install_conan_dependencies.sh' '${{matrix.conan_prebuilts}}'
+
+    - name: Install vcpkg Dependencies
+      if: ${{ startsWith(matrix.platform, 'msvc') }}
+      run: source '${{github.workspace}}/CI/install_vcpkg_dependencies.sh' '${{matrix.platform}}'
 
     # ensure the ccache for each PR is separate so they don't interfere with each other
     # fall back to ccache of the vcmi/vcmi repo if no PR-specific ccache is found
@@ -232,7 +244,7 @@ jobs:
         elif [[ (${{matrix.preset}} == android-conan-ninja-release) && (${{github.ref}} != 'refs/heads/master') ]]
         then
             cmake -DENABLE_CCACHE:BOOL=ON -DANDROID_GRADLE_PROPERTIES="applicationIdSuffix=.daily;signingConfig=dailySigning;applicationLabel=VCMI daily" --preset ${{ matrix.preset }}
-        elif [[ ${{matrix.platform}} != msvc ]]
+        elif [[ (${{matrix.platform}} != msvc-x64) && (${{matrix.platform}} != msvc-x86) ]]
         then
             cmake -DENABLE_CCACHE:BOOL=ON --preset ${{ matrix.preset }}
         else
@@ -279,6 +291,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: ${{ env.VCMI_PACKAGE_FILE_NAME }} - ${{ matrix.platform }}
+        compression-level: 0
         path: |
           ${{github.workspace}}/out/build/${{matrix.preset}}/${{ env.VCMI_PACKAGE_FILE_NAME }}.${{ matrix.extension }}
 
@@ -299,6 +312,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: ${{ env.VCMI_PACKAGE_FILE_NAME }} - ${{ matrix.platform }}
+        compression-level: 0
         path: |
           ${{ env.ANDROID_APK_PATH }}
 
@@ -307,19 +321,21 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: ${{ env.VCMI_PACKAGE_FILE_NAME }} - ${{ matrix.platform }} - aab
+        compression-level: 0
         path: |
           ${{ env.ANDROID_AAB_PATH }}
 
     - name: Upload debug symbols
-      if: ${{ matrix.platform == 'msvc' }}
+      if: ${{ startsWith(matrix.platform, 'msvc') }}
       uses: actions/upload-artifact@v4
       with:
         name: ${{ env.VCMI_PACKAGE_FILE_NAME }} - ${{ matrix.platform }} - symbols
+        compression-level: 9
         path: |
             ${{github.workspace}}/**/*.pdb
 
     - name: Upload build
-      if: ${{ (matrix.pack == 1 || startsWith(matrix.platform, 'android')) && (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/beta' || github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/features/')) && matrix.platform != 'msvc' && matrix.platform != 'mingw-32' }}
+      if: ${{ (matrix.pack == 1 || startsWith(matrix.platform, 'android')) && (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/beta' || github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/features/')) && matrix.platform != 'msvc-x64' && matrix.platform != 'msvc-x86' && matrix.platform != 'mingw-32' }}
       continue-on-error: true
       run: |
         if [ -z '${{ env.ANDROID_APK_PATH }}' ] ; then

--- a/.github/workflows/github.yml
+++ b/.github/workflows/github.yml
@@ -38,6 +38,7 @@ jobs:
             os: macos-13
             test: 0
             pack: 1
+            upload: 1
             pack_type: Release
             extension: dmg
             before_install: macos.sh
@@ -50,6 +51,7 @@ jobs:
             os: macos-13
             test: 0
             pack: 1
+            upload: 1
             pack_type: Release
             extension: dmg
             before_install: macos.sh
@@ -62,6 +64,7 @@ jobs:
             os: macos-13
             test: 0
             pack: 1
+            upload: 1
             pack_type: Release
             extension: ipa
             before_install: macos.sh
@@ -89,6 +92,7 @@ jobs:
             os: ubuntu-24.04
             test: 0
             pack: 1
+            upload: 1
             pack_type: Release
             extension: exe
             cmake_args: -G Ninja
@@ -109,6 +113,7 @@ jobs:
             conan_prebuilts: dependencies-mingw-x86
           - platform: android-32
             os: ubuntu-24.04
+            upload: 1
             extension: apk
             preset: android-conan-ninja-release
             before_install: android.sh
@@ -117,6 +122,7 @@ jobs:
             artifact_platform: armeabi-v7a
           - platform: android-64
             os: ubuntu-24.04
+            upload: 1
             extension: apk
             preset: android-conan-ninja-release
             before_install: android.sh
@@ -244,11 +250,11 @@ jobs:
         elif [[ (${{matrix.preset}} == android-conan-ninja-release) && (${{github.ref}} != 'refs/heads/master') ]]
         then
             cmake -DENABLE_CCACHE:BOOL=ON -DANDROID_GRADLE_PROPERTIES="applicationIdSuffix=.daily;signingConfig=dailySigning;applicationLabel=VCMI daily" --preset ${{ matrix.preset }}
-        elif [[ (${{matrix.platform}} != msvc-x64) && (${{matrix.platform}} != msvc-x86) ]]
+        elif [[ ${{startsWith(matrix.platform, 'msvc') }} ]]
         then
-            cmake -DENABLE_CCACHE:BOOL=ON --preset ${{ matrix.preset }}
-        else
             cmake --preset ${{ matrix.preset }}
+        else
+            cmake -DENABLE_CCACHE:BOOL=ON --preset ${{ matrix.preset }}
         fi
 
     - name: Build
@@ -336,7 +342,7 @@ jobs:
             ${{github.workspace}}/**/*.pdb
 
     - name: Upload build
-      if: ${{ (matrix.pack == 1 || startsWith(matrix.platform, 'android')) && (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/beta' || github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/features/')) && matrix.platform != 'msvc-x64' && matrix.platform != 'msvc-x86' && matrix.platform != 'mingw-32' }}
+      if: ${{ (matrix.upload == 1) && (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/beta' || github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/features/')) }}
       continue-on-error: true
       run: |
         if [ -z '${{ env.ANDROID_APK_PATH }}' ] ; then

--- a/CI/before_install/msvc.sh
+++ b/CI/before_install/msvc.sh
@@ -3,14 +3,13 @@
 MSVC_INSTALL_PATH=$(vswhere -latest -property installationPath)
 echo "MSVC_INSTALL_PATH = $MSVC_INSTALL_PATH"
 echo "Installed toolset versions:"
-ls -vr "$MSVC_INSTALL_PATH"/VC/Tools/MSVC
+ls -vr "$MSVC_INSTALL_PATH/VC/Tools/MSVC"
 
-TOOLS_DIR=$(ls -vr "$MSVC_INSTALL_PATH"/VC/Tools/MSVC/ | head -1)
-DUMPBIN_PATH="$MSVC_INSTALL_PATH"/VC/Tools/MSVC/"$TOOLS_DIR"/bin/Hostx64/x64/dumpbin.exe
+TOOLS_DIR=$(ls -vr "$MSVC_INSTALL_PATH/VC/Tools/MSVC/" | head -1)
+DUMPBIN_PATH="$MSVC_INSTALL_PATH/VC/Tools/MSVC/$TOOLS_DIR/bin/Hostx64/x64/dumpbin.exe"
 
-# This script should also work, but for some reason is *extremely* slow on Github CI (~7 minutes)
+# This command should work as well, but for some reason it is *extremely* slow on the Github CI (~7 minutes)
 #DUMPBIN_PATH=$(vswhere -latest -find **/dumpbin.exe | head -n 1)
-#
 
 echo "TOOLS_DIR = $TOOLS_DIR"
 echo "DUMPBIN_PATH = $DUMPBIN_PATH"

--- a/CI/before_install/msvc.sh
+++ b/CI/before_install/msvc.sh
@@ -1,10 +1,4 @@
-curl -LfsS -o "vcpkg-export-${VCMI_BUILD_PLATFORM}-windows-v143.7z" \
-	"https://github.com/vcmi/vcmi-deps-windows/releases/download/v1.7/vcpkg-export-${VCMI_BUILD_PLATFORM}-windows-v143.7z"
-7z x "vcpkg-export-${VCMI_BUILD_PLATFORM}-windows-v143.7z"
-
-#rm -r -f vcpkg/installed/${VCMI_BUILD_PLATFORM}-windows/debug
-#mkdir -p vcpkg/installed/${VCMI_BUILD_PLATFORM}-windows/debug/bin
-#cp vcpkg/installed/${VCMI_BUILD_PLATFORM}-windows/bin/* vcpkg/installed/${VCMI_BUILD_PLATFORM}-windows/debug/bin
+#!/usr/bin/env bash
 
 DUMPBIN_DIR=$(vswhere -latest -find **/dumpbin.exe | head -n 1)
 dirname "$DUMPBIN_DIR" > $GITHUB_PATH

--- a/CI/before_install/msvc.sh
+++ b/CI/before_install/msvc.sh
@@ -1,4 +1,18 @@
 #!/usr/bin/env bash
 
-DUMPBIN_DIR=$(vswhere -latest -find **/dumpbin.exe | head -n 1)
-dirname "$DUMPBIN_DIR" > $GITHUB_PATH
+MSVC_INSTALL_PATH=$(vswhere -latest -property installationPath)
+echo "MSVC_INSTALL_PATH = $MSVC_INSTALL_PATH"
+echo "Installed toolset versions:"
+ls -vr "$MSVC_INSTALL_PATH"/VC/Tools/MSVC
+
+TOOLS_DIR=$(ls -vr "$MSVC_INSTALL_PATH"/VC/Tools/MSVC/ | head -1)
+DUMPBIN_PATH="$MSVC_INSTALL_PATH"/VC/Tools/MSVC/"$TOOLS_DIR"/bin/Hostx64/x64/dumpbin.exe
+
+# This script should also work, but for some reason is *extremely* slow on Github CI (~7 minutes)
+#DUMPBIN_PATH=$(vswhere -latest -find **/dumpbin.exe | head -n 1)
+#
+
+echo "TOOLS_DIR = $TOOLS_DIR"
+echo "DUMPBIN_PATH = $DUMPBIN_PATH"
+
+dirname "$DUMPBIN_PATH" > "$GITHUB_PATH"

--- a/CI/install_vcpkg_dependencies.sh
+++ b/CI/install_vcpkg_dependencies.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+RELEASE_TAG="v1.8"
+FILENAME="dependencies-$1"
+DOWNLOAD_URL="https://github.com/vcmi/vcmi-deps-windows/releases/download/$RELEASE_TAG/$FILENAME.txz"
+
+curl -L "$DOWNLOAD_URL" | tar -xf - --xz

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -155,6 +155,19 @@
             }
         },
         {
+            "name": "windows-msvc-release-x86",
+            "displayName": "Windows x86 RelWithDebInfo",
+            "description": "VCMI RelWithDebInfo build",
+            "inherits": "default-release",
+            "generator": "Visual Studio 17 2022",
+            "cacheVariables": {
+                "CMAKE_TOOLCHAIN_FILE": "${sourceDir}/vcpkg/scripts/buildsystems/vcpkg.cmake",
+                "CMAKE_POLICY_DEFAULT_CMP0091": "NEW",
+                "FORCE_BUNDLED_MINIZIP": "ON",
+                "CMAKE_GENERATOR_PLATFORM": "WIN32"
+            }
+        },
+        {
             "name": "windows-msvc-release-ccache",
             "displayName": "Windows x64 RelWithDebInfo with ccache",
             "description": "VCMI RelWithDebInfo build with ccache",
@@ -380,6 +393,11 @@
         {
             "name": "windows-msvc-release",
             "configurePreset": "windows-msvc-release",
+            "inherits": "default-release"
+        },
+        {
+            "name": "windows-msvc-release-x86",
+            "configurePreset": "windows-msvc-release-x86",
             "inherits": "default-release"
         },
         {

--- a/Global.h
+++ b/Global.h
@@ -154,7 +154,10 @@ static_assert(sizeof(bool) == 1, "Bool needs to be 1 byte in size.");
 #endif
 #define BOOST_THREAD_DONT_PROVIDE_THREAD_DESTRUCTOR_CALLS_TERMINATE_IF_JOINABLE 1
 //need to link boost thread dynamically to avoid https://stackoverflow.com/questions/35978572/boost-thread-interupt-does-not-work-when-crossing-a-dll-boundary
-#define BOOST_THREAD_USE_DLL //for example VCAI::finish() may freeze on thread join after interrupt when linking this statically
+//for example VCAI::finish() may freeze on thread join after interrupt when linking this statically
+#ifndef BOOST_THREAD_USE_DLL
+#  define BOOST_THREAD_USE_DLL
+#endif
 #define BOOST_BIND_NO_PLACEHOLDERS
 
 #if BOOST_VERSION >= 106600


### PR DESCRIPTION
- Prebuilts package for vcpkg is now generated from scratch using Github CI (see https://github.com/vcmi/vcmi-deps-windows/pull/5 )
- As a result, all libraries were updated to latest version available on vcpkg
- Now only boost components that are required for vcmi are included into the package instead of entire 'boost' package (due to issues with boost-python on Win7/32 bit)
- Package now archived as .txz instead of .7z (hopefully will improve extraction times - currently msvc CI spends 7+ minutes to extract package)
- Added / restored support for 32-bit builds. Tested on 64-bit system, but not on native 32 bit one.
- VCPKG now targets Windows 7, but untested.

With this changes we can now completely switch to vcpkg / msvc as default release package for Windows and drop 'alternate' builds. Should also make prebuilts package updates less of a pain since we no longer need to wait for developer with msvc setup to do everything on his PC.

In future this can be replaced by conan, but replacing vcpkg with conan for msvc looks to be non-trivial at the moment, while automating vcpkg is simple enough.

I've also checked possibility of windows-arm builds via vcpkg, but seems to not be possible - qt cross-compilation is broken on vcpkg for years (or never worked to begin with). So not possible until vcpkg fixes that or Github provides arm Windows runners.