### PR TITLE
ResourcePath ctor chopoff extension of originalName when filename has…

### DIFF
--- a/lib/filesystem/ResourcePath.cpp
+++ b/lib/filesystem/ResourcePath.cpp
@@ -51,19 +51,19 @@ static inline std::string readName(std::string name, bool uppercase)
 ResourcePath::ResourcePath(const std::string & name_):
 	type(readType(name_)),
 	name(readName(name_, true)),
-	originalName(readName(name_, false))
+	originalName(name_)
 {}
 
 ResourcePath::ResourcePath(const std::string & name_, EResType type_):
 	type(type_),
 	name(readName(name_, true)),
-	originalName(readName(name_, false))
+	originalName(name_)
 {}
 
 ResourcePath::ResourcePath(const JsonNode & name, EResType type):
 	type(type),
 	name(readName(name.String(), true)),
-	originalName(readName(name.String(), false))
+	originalName(name.String())
 {
 }
 
@@ -76,7 +76,7 @@ void ResourcePath::serializeJson(JsonSerializeFormat & handler)
 		if (node.isString())
 		{
 			name = readName(node.String(), true);
-			originalName = readName(node.String(), false);
+			originalName = node.String();
 			return;
 		}
 	}


### PR DESCRIPTION
… multiple dots.
This is to fix [bug](https://github.com/vcmi/vcmi/issues/4833) when map file name has multiple dots which causes **ResourcePath** ctor modify **originalName**. As **ResourcePath** is used whenever necessary to reconstruct from "**originalName**", this would lead to "file not found".

Keeping **originalName** unchanged seems to be original design because it allows reconstruction of **ResourcePath** from it without issue. This is the rational of this fix.

 