### PR TITLE
keep ext of originalName of ResourcePath so that it can safely recons…

### DIFF
--- a/client/render/AssetGenerator.cpp
+++ b/client/render/AssetGenerator.cpp
@@ -178,10 +178,10 @@ void AssetGenerator::createCombatUnitNumberWindow()
 	if(CResourceHandler::get()->existsResource(savePathDefault)) // overridden by mod, no generation
 		return;
 
-	if(!CResourceHandler::get("local")->createResource(savePathDefault.getOriginalName() + ".png") ||
-	   !CResourceHandler::get("local")->createResource(savePathNeutral.getOriginalName() + ".png") ||
-	   !CResourceHandler::get("local")->createResource(savePathPositive.getOriginalName() + ".png") ||
-	   !CResourceHandler::get("local")->createResource(savePathNegative.getOriginalName() + ".png"))
+	if(!CResourceHandler::get("local")->createResource(savePathDefault.getOriginalName()) ||
+	   !CResourceHandler::get("local")->createResource(savePathNeutral.getOriginalName()) ||
+	   !CResourceHandler::get("local")->createResource(savePathPositive.getOriginalName()) ||
+	   !CResourceHandler::get("local")->createResource(savePathNegative.getOriginalName()))
 		return;
 
 	auto locator = ImageLocator(ImagePath::builtin("CMNUMWIN"));

--- a/client/windows/CMapOverview.cpp
+++ b/client/windows/CMapOverview.cpp
@@ -155,11 +155,11 @@ CMapOverviewWidget::CMapOverviewWidget(CMapOverview& parent):
 
 	if(settings["lobby"]["mapPreview"].Bool() && p.tabType != ESelectionScreen::campaignList)
 	{
-		ResourcePath res = ResourcePath(p.resource.getName(), EResType::MAP);
+		ResourcePath res = ResourcePath(p.resource.getOriginalName(), EResType::MAP);
 		std::unique_ptr<CMap> campaignMap = nullptr;
 		if(p.tabType != ESelectionScreen::newGame && config["variables"]["mapPreviewForSaves"].Bool())
 		{
-			CLoadFile lf(*CResourceHandler::get()->getResourceName(ResourcePath(p.resource.getName(), EResType::SAVEGAME)), ESerializationVersion::MINIMAL);
+			CLoadFile lf(*CResourceHandler::get()->getResourceName(ResourcePath(p.resource.getOriginalName(), EResType::SAVEGAME)), ESerializationVersion::MINIMAL);
 			lf.checkMagicBytes(SAVEGAME_MAGIC);
 
 			auto mapHeader = std::make_unique<CMapHeader>();
@@ -196,7 +196,8 @@ CMapOverviewWidget::CMapOverviewWidget(CMapOverview& parent):
 	{
 		if(p.date.empty())
 		{
-			std::time_t time = boost::filesystem::last_write_time(*CResourceHandler::get()->getResourceName(ResourcePath(p.resource.getName(), p.tabType == ESelectionScreen::campaignList ? EResType::CAMPAIGN : EResType::MAP)));
+			std::time_t time = boost::filesystem::last_write_time(*CResourceHandler::get()->getResourceName(ResourcePath(p.resource.getOriginalName(),
+				p.tabType == ESelectionScreen::campaignList ? EResType::CAMPAIGN : EResType::MAP)));
 			w->setText(TextOperations::getFormattedDateTimeLocal(time));
 		}
 		else

--- a/lib/filesystem/ResourcePath.cpp
+++ b/lib/filesystem/ResourcePath.cpp
@@ -26,7 +26,8 @@ static inline EResType readType(const std::string& name)
 	return EResTypeHelper::getTypeFromExtension(FileInfo::GetExtension(name).to_string());
 }
 
-static inline std::string readName(std::string name, bool uppercase)
+static inline std::string readName(std::string name, bool uppercase, bool chopExt = true);
+static inline std::string readName(std::string name, bool uppercase, bool chopExt)
 {
 	const auto dotPos = name.find_last_of('.');
 
@@ -38,7 +39,7 @@ static inline std::string readName(std::string name, bool uppercase)
 	if((delimPos == std::string::npos || delimPos < dotPos) && dotPos != std::string::npos)
 	{
 		auto type = EResTypeHelper::getTypeFromExtension(name.substr(dotPos));
-		if(type != EResType::OTHER)
+		if(type != EResType::OTHER && chopExt)
 			name.resize(dotPos);
 	}
 
@@ -51,19 +52,19 @@ static inline std::string readName(std::string name, bool uppercase)
 ResourcePath::ResourcePath(const std::string & name_):
 	type(readType(name_)),
 	name(readName(name_, true)),
-	originalName(readName(name_, false))
+	originalName(readName(name_, false, false))
 {}
 
 ResourcePath::ResourcePath(const std::string & name_, EResType type_):
 	type(type_),
 	name(readName(name_, true)),
-	originalName(readName(name_, false))
+	originalName(readName(name_, false, false))
 {}
 
 ResourcePath::ResourcePath(const JsonNode & name, EResType type):
 	type(type),
 	name(readName(name.String(), true)),
-	originalName(readName(name.String(), false))
+	originalName(readName(name.String(), false, false))
 {
 }
 
@@ -76,7 +77,7 @@ void ResourcePath::serializeJson(JsonSerializeFormat & handler)
 		if (node.isString())
 		{
 			name = readName(node.String(), true);
-			originalName = readName(node.String(), false);
+			originalName =  readName(node.String(), false, false);
 			return;
 		}
 	}

--- a/lib/modding/CModHandler.cpp
+++ b/lib/modding/CModHandler.cpp
@@ -38,7 +38,7 @@ static JsonNode loadModSettings(const JsonPath & path)
 		return JsonNode(path);
 	}
 	// Probably new install. Create initial configuration
-	CResourceHandler::get("local")->createResource(path.getOriginalName() + ".json");
+	CResourceHandler::get("local")->createResource(path.getOriginalName());
 	return JsonNode();
 }
 

--- a/test/map/CMapEditManagerTest.cpp
+++ b/test/map/CMapEditManagerTest.cpp
@@ -111,7 +111,7 @@ TEST(MapManager, DrawTerrain_View)
 {
 	try
 	{
-		const ResourcePath testMap("test/TerrainViewTest", EResType::MAP);
+		const ResourcePath testMap("test/TerrainViewTest.h3m", EResType::MAP);
 		// Load maps and json config
 		CMapService mapService;
 		const auto originalMap = mapService.loadMap(testMap, nullptr);


### PR DESCRIPTION
…truct
This is second approach to fix this [bug](https://github.com/vcmi/vcmi/issues/4833#issue-2616967128).
**ResourcePath** ctor would chopoff ext of its member **name**. This would cause problem when reconstruct from its **name** again. So, the correct way is to reconstruct from its member **originalName** which should not be altered. 

