### PR TITLE
Implemented optional descriptions for market map objects

### DIFF
--- a/lib/mapObjectConstructors/CommonConstructors.cpp
+++ b/lib/mapObjectConstructors/CommonConstructors.cpp
@@ -205,6 +205,12 @@ AnimationPath BoatInstanceConstructor::getBoatAnimationName() const
 
 void MarketInstanceConstructor::initTypeData(const JsonNode & input)
 {
+	if (!input["description"].isNull())
+	{
+		description = input["description"].String();
+		VLC->generaltexth->registerString(input.getModScope(), TextIdentifier(getBaseTextID(), "description"), description);
+	}
+
 	for(auto & element : input["modes"].Vector())
 	{
 		if(MappedKeys::MARKET_NAMES_TO_TYPES.count(element.String()))
@@ -216,6 +222,11 @@ void MarketInstanceConstructor::initTypeData(const JsonNode & input)
 	
 	title = input["title"].String();
 	speech = input["speech"].String();
+}
+
+bool MarketInstanceConstructor::hasDescription() const
+{
+	return !description.empty();
 }
 
 CGMarket * MarketInstanceConstructor::createObject(IGameCallback * cb) const

--- a/lib/mapObjectConstructors/CommonConstructors.h
+++ b/lib/mapObjectConstructors/CommonConstructors.h
@@ -118,6 +118,7 @@ protected:
 	JsonNode predefinedOffer;
 	int marketEfficiency;
 	
+	std::string description;
 	std::string title;
 	std::string speech;
 	
@@ -127,6 +128,7 @@ public:
 	void randomizeObject(CGMarket * object, vstd::RNG & rng) const override;
 
 	const std::set<EMarketMode> & availableModes() const;
+	bool hasDescription() const;
 
 };
 

--- a/lib/mapObjects/CGMarket.cpp
+++ b/lib/mapObjects/CGMarket.cpp
@@ -39,6 +39,22 @@ void CGMarket::onHeroVisit(const CGHeroInstance * h) const
 	cb->showObjectWindow(this, EOpenWindowMode::MARKET_WINDOW, h, true);
 }
 
+std::string CGMarket::getPopupText(PlayerColor player) const
+{
+	if (!getMarketHandler()->hasDescription())
+		return getHoverText(player);
+
+	MetaString message = MetaString::createFromRawString("{%s}\r\n\r\n%s");
+	message.replaceName(ID);
+	message.replaceTextID(TextIdentifier(getObjectHandler()->getBaseTextID(), "description").get());
+	return message.toString();
+}
+
+std::string CGMarket::getPopupText(const CGHeroInstance * hero) const
+{
+	return getPopupText(hero->getOwner());
+}
+
 int CGMarket::getMarketEfficiency() const
 {
 	return marketEfficiency;
@@ -49,12 +65,16 @@ int CGMarket::availableUnits(EMarketMode mode, int marketItemSerial) const
 	return -1;
 }
 
-std::set<EMarketMode> CGMarket::availableModes() const
+std::shared_ptr<MarketInstanceConstructor> CGMarket::getMarketHandler() const
 {
 	const auto & baseHandler = getObjectHandler();
 	const auto & ourHandler = std::dynamic_pointer_cast<MarketInstanceConstructor>(baseHandler);
+	return ourHandler;
+}
 
-	return ourHandler->availableModes();
+std::set<EMarketMode> CGMarket::availableModes() const
+{
+	return getMarketHandler()->availableModes();
 }
 
 CGMarket::CGMarket(IGameCallback *cb):

--- a/lib/mapObjects/CGMarket.h
+++ b/lib/mapObjects/CGMarket.h
@@ -15,8 +15,12 @@
 
 VCMI_LIB_NAMESPACE_BEGIN
 
+class MarketInstanceConstructor;
+
 class DLL_LINKAGE CGMarket : public CGObjectInstance, public IMarket
 {
+	std::shared_ptr<MarketInstanceConstructor> getMarketHandler() const;
+
 public:
 	int marketEfficiency;
 	
@@ -24,6 +28,9 @@ public:
 	///IObjectInterface
 	void onHeroVisit(const CGHeroInstance * h) const override; //open trading window
 	void initObj(vstd::RNG & rand) override;//set skills for trade
+
+	std::string getPopupText(PlayerColor player) const override;
+	std::string getPopupText(const CGHeroInstance * hero) const override;
 
 	///IMarket
 	ObjectInstanceID getObjInstanceID() const override;

--- a/lib/mapObjects/MiscObjects.cpp
+++ b/lib/mapObjects/MiscObjects.cpp
@@ -1333,6 +1333,22 @@ void HillFort::fillUpgradeInfo(UpgradeInfo & info, const CStackInstance &stack) 
 	}
 }
 
+std::string HillFort::getPopupText(PlayerColor player) const
+{
+	MetaString message = MetaString::createFromRawString("{%s}\r\n\r\n%s");
+
+	message.replaceName(ID);
+	message.replaceTextID(getDescriptionToolTip());
+
+	return message.toString();
+}
+
+std::string HillFort::getPopupText(const CGHeroInstance * hero) const
+{
+	return getPopupText(hero->getOwner());
+}
+
+
 std::string HillFort::getDescriptionToolTip() const
 {
 	return TextIdentifier(getObjectHandler()->getBaseTextID(), "description").get();

--- a/lib/mapObjects/MiscObjects.h
+++ b/lib/mapObjects/MiscObjects.h
@@ -437,6 +437,9 @@ protected:
 public:
 	using CGObjectInstance::CGObjectInstance;
 
+	std::string getPopupText(PlayerColor player) const override;
+	std::string getPopupText(const CGHeroInstance * hero) const override;
+
 	std::string getDescriptionToolTip() const;
 	std::string getUnavailableUpgradeMessage() const;
 


### PR DESCRIPTION
It is now possible to define description of an object with 'market' handler that will be shown on right-clicking the object.

Similarly, added description to right-click popup to Hill Fort.