### PR TITLE
prescaled image support

### DIFF
--- a/client/render/ImageLocator.cpp
+++ b/client/render/ImageLocator.cpp
@@ -71,6 +71,7 @@ ImageLocator ImageLocator::copyFile() const
 {
 	ImageLocator result;
 	result.scalingFactor = 1;
+	result.preScaledFactor = preScaledFactor;
 	result.image = image;
 	result.defFile = defFile;
 	result.defFrame = defFrame;

--- a/client/render/ImageLocator.h
+++ b/client/render/ImageLocator.h
@@ -33,6 +33,7 @@ struct ImageLocator
 	bool verticalFlip = false;
 	bool horizontalFlip = false;
 	int8_t scalingFactor = 0; // 0 = auto / use default scaling
+	int8_t preScaledFactor = 1;
 	EImageLayer layer = EImageLayer::ALL;
 
 	ImageLocator() = default;

--- a/client/renderSDL/RenderHandler.cpp
+++ b/client/renderSDL/RenderHandler.cpp
@@ -246,9 +246,9 @@ std::shared_ptr<ISharedImage> RenderHandler::loadImageFromFileUncached(const Ima
 		if(!defFile) // no prescale for this frame
 		{
 			auto tmpPath = (*locator.defFile).getName();
-			boost::algorithm::replace_all(tmpPath, "2X/", "/");
-			boost::algorithm::replace_all(tmpPath, "3X/", "/");
-			boost::algorithm::replace_all(tmpPath, "4X/", "/");
+			boost::algorithm::replace_all(tmpPath, "SPRITES2X/", "SPRITES/");
+			boost::algorithm::replace_all(tmpPath, "SPRITES3X/", "SPRITES/");
+			boost::algorithm::replace_all(tmpPath, "SPRITES4X/", "SPRITES/");
 			preScaledFactor = 1;
 			defFile = getAnimationFile(AnimationPath::builtin(tmpPath));
 		}

--- a/client/renderSDL/RenderHandler.cpp
+++ b/client/renderSDL/RenderHandler.cpp
@@ -361,6 +361,18 @@ std::shared_ptr<IImage> RenderHandler::loadImage(const ImageLocator & locator, E
 	}
 	else
 	{
+		if(loc.image)
+		{
+			std::string imgPath = (*loc.image).getName();
+			if(loc.layer == EImageLayer::OVERLAY)
+				imgPath += "-overlay";
+			if(loc.layer == EImageLayer::SHADOW)
+				imgPath += "-shadow";
+
+			if(CResourceHandler::get()->existsResource(ImagePath::builtin(imgPath)))
+				loc.image = ImagePath::builtin(imgPath);
+		}
+
 		return loadImageImpl(loc)->createImageReference(mode);
 	}
 }

--- a/client/renderSDL/RenderHandler.cpp
+++ b/client/renderSDL/RenderHandler.cpp
@@ -55,17 +55,15 @@ std::shared_ptr<CDefFile> RenderHandler::getAnimationFile(const AnimationPath & 
 	return result;
 }
 
-std::optional<ResourcePath> RenderHandler::getPath(ResourcePath path, std::string factor)
+std::optional<ResourcePath> RenderHandler::getPathForScaleFactor(ResourcePath path, std::string factor)
 {
-	if(CResourceHandler::get()->existsResource(path))
-		return path;
 	if(path.getType() == EResType::IMAGE)
 	{
 		auto p = ImagePath::builtin(path.getName());
-		if(CResourceHandler::get()->existsResource(p.addPrefix("DATA" + factor + "X/")))
-			return std::optional<ResourcePath>(p.addPrefix("DATA" + factor + "X/"));
 		if(CResourceHandler::get()->existsResource(p.addPrefix("SPRITES" + factor + "X/")))
 			return std::optional<ResourcePath>(p.addPrefix("SPRITES" + factor + "X/"));
+		if(CResourceHandler::get()->existsResource(p.addPrefix("DATA" + factor + "X/")))
+			return std::optional<ResourcePath>(p.addPrefix("DATA" + factor + "X/"));
 	}
 	else
 	{
@@ -97,7 +95,7 @@ std::pair<ResourcePath, int> RenderHandler::getScalePath(ResourcePath p)
 			ResourcePath scaledPath = ImagePath::builtin(name);
 			if(p.getType() != EResType::IMAGE)
 				scaledPath = AnimationPath::builtin(name);
-			auto tmpPath = getPath(scaledPath, std::to_string(factorToCheck));
+			auto tmpPath = getPathForScaleFactor(scaledPath, std::to_string(factorToCheck));
 			if(tmpPath)
 			{
 				path = *tmpPath;

--- a/client/renderSDL/RenderHandler.cpp
+++ b/client/renderSDL/RenderHandler.cpp
@@ -327,13 +327,13 @@ std::shared_ptr<ISharedImage> RenderHandler::scaleImage(const ImageLocator & loc
 std::shared_ptr<IImage> RenderHandler::loadImage(const ImageLocator & locator, EImageBlitMode mode)
 {
 	ImageLocator loc = locator;
-	if(loc.defFile && loc.scalingFactor == 0 && loc.preScaledFactor == 1)
+	if(loc.defFile && loc.scalingFactor == 0)
 	{
 		auto tmp = getScalePath(*loc.defFile);
 		loc.defFile = AnimationPath::builtin(tmp.first.getName());
 		loc.preScaledFactor = tmp.second;
 	}
-	if(loc.image && loc.scalingFactor == 0 && loc.preScaledFactor == 1)
+	if(loc.image && loc.scalingFactor == 0)
 	{
 		auto tmp = getScalePath(*loc.image);
 		loc.image = ImagePath::builtin(tmp.first.getName());

--- a/client/renderSDL/RenderHandler.cpp
+++ b/client/renderSDL/RenderHandler.cpp
@@ -326,24 +326,24 @@ std::shared_ptr<ISharedImage> RenderHandler::scaleImage(const ImageLocator & loc
 
 std::shared_ptr<IImage> RenderHandler::loadImage(const ImageLocator & locator, EImageBlitMode mode)
 {
-	ImageLocator loc = locator;
-	if(loc.defFile && loc.scalingFactor == 0)
+	ImageLocator adjustedLocator = locator;
+	if(adjustedLocator.defFile && adjustedLocator.scalingFactor == 0)
 	{
-		auto tmp = getScalePath(*loc.defFile);
-		loc.defFile = AnimationPath::builtin(tmp.first.getName());
-		loc.preScaledFactor = tmp.second;
+		auto tmp = getScalePath(*adjustedLocator.defFile);
+		adjustedLocator.defFile = AnimationPath::builtin(tmp.first.getName());
+		adjustedLocator.preScaledFactor = tmp.second;
 	}
-	if(loc.image && loc.scalingFactor == 0)
+	if(adjustedLocator.image && adjustedLocator.scalingFactor == 0)
 	{
-		auto tmp = getScalePath(*loc.image);
-		loc.image = ImagePath::builtin(tmp.first.getName());
-		loc.preScaledFactor = tmp.second;
+		auto tmp = getScalePath(*adjustedLocator.image);
+		adjustedLocator.image = ImagePath::builtin(tmp.first.getName());
+		adjustedLocator.preScaledFactor = tmp.second;
 	}
 
-	if (loc.scalingFactor == 0 && getScalingFactor() != 1 )
+	if (adjustedLocator.scalingFactor == 0 && getScalingFactor() != 1 )
 	{
-		auto unscaledLocator = loc;
-		auto scaledLocator = loc;
+		auto unscaledLocator = adjustedLocator;
+		auto scaledLocator = adjustedLocator;
 
 		unscaledLocator.scalingFactor = 1;
 		scaledLocator.scalingFactor = getScalingFactor();
@@ -352,28 +352,28 @@ std::shared_ptr<IImage> RenderHandler::loadImage(const ImageLocator & locator, E
 		return std::make_shared<ImageScaled>(scaledLocator, unscaledImage, mode);
 	}
 
-	if (loc.scalingFactor == 0)
+	if (adjustedLocator.scalingFactor == 0)
 	{
-		auto scaledLocator = loc;
+		auto scaledLocator = adjustedLocator;
 		scaledLocator.scalingFactor = getScalingFactor();
 
 		return loadImageImpl(scaledLocator)->createImageReference(mode);
 	}
 	else
 	{
-		if(loc.image)
+		if(adjustedLocator.image)
 		{
-			std::string imgPath = (*loc.image).getName();
-			if(loc.layer == EImageLayer::OVERLAY)
+			std::string imgPath = (*adjustedLocator.image).getName();
+			if(adjustedLocator.layer == EImageLayer::OVERLAY)
 				imgPath += "-overlay";
-			if(loc.layer == EImageLayer::SHADOW)
+			if(adjustedLocator.layer == EImageLayer::SHADOW)
 				imgPath += "-shadow";
 
 			if(CResourceHandler::get()->existsResource(ImagePath::builtin(imgPath)))
-				loc.image = ImagePath::builtin(imgPath);
+				adjustedLocator.image = ImagePath::builtin(imgPath);
 		}
 
-		return loadImageImpl(loc)->createImageReference(mode);
+		return loadImageImpl(adjustedLocator)->createImageReference(mode);
 	}
 }
 

--- a/client/renderSDL/RenderHandler.h
+++ b/client/renderSDL/RenderHandler.h
@@ -29,7 +29,7 @@ class RenderHandler : public IRenderHandler
 	std::map<EFonts, std::shared_ptr<const IFont>> fonts;
 
 	std::shared_ptr<CDefFile> getAnimationFile(const AnimationPath & path);
-	std::optional<ResourcePath> getPath(ResourcePath path);
+	std::optional<ResourcePath> getPath(ResourcePath path, std::string factor);
 	std::pair<ResourcePath, int> getScalePath(ResourcePath p);
 	AnimationLayoutMap & getAnimationLayout(const AnimationPath & path);
 	void initFromJson(AnimationLayoutMap & layout, const JsonNode & config);

--- a/client/renderSDL/RenderHandler.h
+++ b/client/renderSDL/RenderHandler.h
@@ -29,7 +29,7 @@ class RenderHandler : public IRenderHandler
 	std::map<EFonts, std::shared_ptr<const IFont>> fonts;
 
 	std::shared_ptr<CDefFile> getAnimationFile(const AnimationPath & path);
-	std::optional<ResourcePath> getPath(ResourcePath path, std::string factor);
+	std::optional<ResourcePath> getPathForScaleFactor(ResourcePath path, std::string factor);
 	std::pair<ResourcePath, int> getScalePath(ResourcePath p);
 	AnimationLayoutMap & getAnimationLayout(const AnimationPath & path);
 	void initFromJson(AnimationLayoutMap & layout, const JsonNode & config);

--- a/client/renderSDL/RenderHandler.h
+++ b/client/renderSDL/RenderHandler.h
@@ -29,6 +29,8 @@ class RenderHandler : public IRenderHandler
 	std::map<EFonts, std::shared_ptr<const IFont>> fonts;
 
 	std::shared_ptr<CDefFile> getAnimationFile(const AnimationPath & path);
+	std::optional<ResourcePath> getPath(ResourcePath path);
+	std::pair<ResourcePath, int> getScalePath(ResourcePath p);
 	AnimationLayoutMap & getAnimationLayout(const AnimationPath & path);
 	void initFromJson(AnimationLayoutMap & layout, const JsonNode & config);
 

--- a/client/renderSDL/SDLImage.cpp
+++ b/client/renderSDL/SDLImage.cpp
@@ -89,12 +89,12 @@ int IImage::height() const
 	return dimensions().y;
 }
 
-SDLImageShared::SDLImageShared(const CDefFile * data, size_t frame, size_t group, int scaleFactor)
+SDLImageShared::SDLImageShared(const CDefFile * data, size_t frame, size_t group, int preScaleFactor)
 	: surf(nullptr),
 	margins(0, 0),
 	fullSize(0, 0),
 	originalPalette(nullptr),
-	scaleFactor(scaleFactor)
+	preScaleFactor(preScaleFactor)
 {
 	SDLImageLoader loader(this);
 	data->loadFrame(frame, group, loader);
@@ -107,7 +107,7 @@ SDLImageShared::SDLImageShared(SDL_Surface * from)
 	margins(0, 0),
 	fullSize(0, 0),
 	originalPalette(nullptr),
-	scaleFactor(1)
+	preScaleFactor(1)
 {
 	surf = from;
 	if (surf == nullptr)
@@ -120,12 +120,12 @@ SDLImageShared::SDLImageShared(SDL_Surface * from)
 	fullSize.y = surf->h;
 }
 
-SDLImageShared::SDLImageShared(const ImagePath & filename, int scaleFactor)
+SDLImageShared::SDLImageShared(const ImagePath & filename, int preScaleFactor)
 	: surf(nullptr),
 	margins(0, 0),
 	fullSize(0, 0),
 	originalPalette(nullptr),
-	scaleFactor(scaleFactor)
+	preScaleFactor(preScaleFactor)
 {
 	surf = BitmapHandler::loadBitmap(filename);
 
@@ -278,12 +278,12 @@ std::shared_ptr<ISharedImage> SDLImageShared::scaleInteger(int factor, SDL_Palet
 		SDL_SetSurfacePalette(surf, palette);
 
 	SDL_Surface * scaled = nullptr;
-	if(scaleFactor == factor)
+	if(preScaleFactor == factor)
 		scaled = CSDL_Ext::scaleSurfaceIntegerFactor(surf, 1, EScalingAlgorithm::NEAREST); // keep size
-	else if(scaleFactor == 1)
+	else if(preScaleFactor == 1)
 		scaled = CSDL_Ext::scaleSurfaceIntegerFactor(surf, factor, EScalingAlgorithm::XBRZ);
 	else
-		scaled = CSDL_Ext::scaleSurface(surf, (surf->w / scaleFactor) * factor, (surf->h / scaleFactor) * factor);
+		scaled = CSDL_Ext::scaleSurface(surf, (surf->w / preScaleFactor) * factor, (surf->h / preScaleFactor) * factor);
 
 	auto ret = std::make_shared<SDLImageShared>(scaled);
 
@@ -364,7 +364,7 @@ bool SDLImageShared::isTransparent(const Point & coords) const
 
 Point SDLImageShared::dimensions() const
 {
-	return fullSize / scaleFactor;
+	return fullSize / preScaleFactor;
 }
 
 std::shared_ptr<IImage> SDLImageShared::createImageReference(EImageBlitMode mode)

--- a/client/renderSDL/SDLImage.cpp
+++ b/client/renderSDL/SDLImage.cpp
@@ -102,12 +102,12 @@ SDLImageShared::SDLImageShared(const CDefFile * data, size_t frame, size_t group
 	savePalette();
 }
 
-SDLImageShared::SDLImageShared(SDL_Surface * from)
+SDLImageShared::SDLImageShared(SDL_Surface * from, int preScaleFactor)
 	: surf(nullptr),
 	margins(0, 0),
 	fullSize(0, 0),
 	originalPalette(nullptr),
-	preScaleFactor(1)
+	preScaleFactor(preScaleFactor)
 {
 	surf = from;
 	if (surf == nullptr)
@@ -285,7 +285,7 @@ std::shared_ptr<ISharedImage> SDLImageShared::scaleInteger(int factor, SDL_Palet
 	else
 		scaled = CSDL_Ext::scaleSurface(surf, (surf->w / preScaleFactor) * factor, (surf->h / preScaleFactor) * factor);
 
-	auto ret = std::make_shared<SDLImageShared>(scaled);
+	auto ret = std::make_shared<SDLImageShared>(scaled, preScaleFactor);
 
 	ret->fullSize.x = fullSize.x * factor;
 	ret->fullSize.y = fullSize.y * factor;
@@ -320,7 +320,7 @@ std::shared_ptr<ISharedImage> SDLImageShared::scaleTo(const Point & size, SDL_Pa
 	else
 		CSDL_Ext::setDefaultColorKey(scaled);//just in case
 
-	auto ret = std::make_shared<SDLImageShared>(scaled);
+	auto ret = std::make_shared<SDLImageShared>(scaled, preScaleFactor);
 
 	ret->fullSize.x = (int) round((float)fullSize.x * scaleX);
 	ret->fullSize.y = (int) round((float)fullSize.y * scaleY);
@@ -378,7 +378,7 @@ std::shared_ptr<IImage> SDLImageShared::createImageReference(EImageBlitMode mode
 std::shared_ptr<ISharedImage> SDLImageShared::horizontalFlip() const
 {
 	SDL_Surface * flipped = CSDL_Ext::horizontalFlip(surf);
-	auto ret = std::make_shared<SDLImageShared>(flipped);
+	auto ret = std::make_shared<SDLImageShared>(flipped, preScaleFactor);
 	ret->fullSize = fullSize;
 	ret->margins.x = margins.x;
 	ret->margins.y = fullSize.y - surf->h - margins.y;
@@ -390,7 +390,7 @@ std::shared_ptr<ISharedImage> SDLImageShared::horizontalFlip() const
 std::shared_ptr<ISharedImage> SDLImageShared::verticalFlip() const
 {
 	SDL_Surface * flipped = CSDL_Ext::verticalFlip(surf);
-	auto ret = std::make_shared<SDLImageShared>(flipped);
+	auto ret = std::make_shared<SDLImageShared>(flipped, preScaleFactor);
 	ret->fullSize = fullSize;
 	ret->margins.x = fullSize.x - surf->w - margins.x;
 	ret->margins.y = margins.y;

--- a/client/renderSDL/SDLImage.cpp
+++ b/client/renderSDL/SDLImage.cpp
@@ -279,7 +279,10 @@ std::shared_ptr<ISharedImage> SDLImageShared::scaleInteger(int factor, SDL_Palet
 
 	SDL_Surface * scaled = nullptr;
 	if(preScaleFactor == factor)
-		scaled = CSDL_Ext::scaleSurfaceIntegerFactor(surf, 1, EScalingAlgorithm::NEAREST); // keep size
+	{
+		scaled = CSDL_Ext::newSurface(Point(surf->w, surf->h), surf);
+		SDL_BlitSurface(surf, nullptr, scaled, nullptr);
+	}
 	else if(preScaleFactor == 1)
 		scaled = CSDL_Ext::scaleSurfaceIntegerFactor(surf, factor, EScalingAlgorithm::XBRZ);
 	else

--- a/client/renderSDL/SDLImage.h
+++ b/client/renderSDL/SDLImage.h
@@ -49,7 +49,7 @@ public:
 	//Load from bitmap file
 	SDLImageShared(const ImagePath & filename, int preScaleFactor=1);
 	//Create using existing surface, extraRef will increase refcount on SDL_Surface
-	SDLImageShared(SDL_Surface * from);
+	SDLImageShared(SDL_Surface * from, int preScaleFactor=1);
 	~SDLImageShared();
 
 	void draw(SDL_Surface * where, SDL_Palette * palette, const Point & dest, const Rect * src, const ColorRGBA & colorMultiplier, uint8_t alpha, EImageBlitMode mode) const override;

--- a/client/renderSDL/SDLImage.h
+++ b/client/renderSDL/SDLImage.h
@@ -35,6 +35,9 @@ class SDLImageShared final : public ISharedImage, public std::enable_shared_from
 	//total size including borders
 	Point fullSize;
 
+	//pre scaled image
+	int scaleFactor;
+
 	// Keep the original palette, in order to do color switching operation
 	void savePalette();
 
@@ -42,9 +45,9 @@ class SDLImageShared final : public ISharedImage, public std::enable_shared_from
 
 public:
 	//Load image from def file
-	SDLImageShared(const CDefFile *data, size_t frame, size_t group=0);
+	SDLImageShared(const CDefFile *data, size_t frame, size_t group=0, int scaleFactor=1);
 	//Load from bitmap file
-	SDLImageShared(const ImagePath & filename);
+	SDLImageShared(const ImagePath & filename, int scaleFactor=1);
 	//Create using existing surface, extraRef will increase refcount on SDL_Surface
 	SDLImageShared(SDL_Surface * from);
 	~SDLImageShared();

--- a/client/renderSDL/SDLImage.h
+++ b/client/renderSDL/SDLImage.h
@@ -36,7 +36,7 @@ class SDLImageShared final : public ISharedImage, public std::enable_shared_from
 	Point fullSize;
 
 	//pre scaled image
-	int scaleFactor;
+	int preScaleFactor;
 
 	// Keep the original palette, in order to do color switching operation
 	void savePalette();
@@ -45,9 +45,9 @@ class SDLImageShared final : public ISharedImage, public std::enable_shared_from
 
 public:
 	//Load image from def file
-	SDLImageShared(const CDefFile *data, size_t frame, size_t group=0, int scaleFactor=1);
+	SDLImageShared(const CDefFile *data, size_t frame, size_t group=0, int preScaleFactor=1);
 	//Load from bitmap file
-	SDLImageShared(const ImagePath & filename, int scaleFactor=1);
+	SDLImageShared(const ImagePath & filename, int preScaleFactor=1);
 	//Create using existing surface, extraRef will increase refcount on SDL_Surface
 	SDLImageShared(SDL_Surface * from);
 	~SDLImageShared();

--- a/docs/modders/HD_Graphics.md
+++ b/docs/modders/HD_Graphics.md
@@ -1,0 +1,29 @@
+# HD Graphics
+
+It's possible to provide alternative HD-Graphics within mods. They will be used if any upscaling filter is activated.
+
+## Preconditions
+
+It's still necessary to add 1x graphics as before. HD graphics are seperate from usual graphics. This allows to partitially use HD for a few graphics in mod. And avoid handling huge graphics if upscaling isn't enabled.
+
+Currently following scaling factors are possible to use: 2x, 3x, 4x. You can also provide multiple of them (increases size of mod, but improves loading performance for player). It's recommend to provide 2x and 3x images.
+
+If user for example selects 3x resolution and only 2x exists in mod then the 2x images are upscaled to 3x (same for other combinations > 1x).
+
+## Mod
+
+For upscaled images you have to use following folders (next to `sprites` and `data` folders):
+- `sprites2x`, `sprites3x`, `sprites4x` for sprites
+- `data2x`, `data3x`, `data4x` for images
+
+The sprites should have the same name and folder structure as in `sprites` and `data` folder. All images that are missing in the upscaled folders are scaled with the selected upscaling filter instead of using prescaled images.
+
+### Shadows / Overlays
+
+It's also possible (but not necessary) to add HD shadows: Just place a image next to the normal upscaled image with the suffix `-shadow`. E.g. `TestImage.png` and `TestImage-shadow.png`.
+
+Same for overlays with `-overlay`. But overlays are **necessary** for some animation graphics. They will be colorized by VCMI.
+
+Currently needed for:
+- flaggable adventure map objects (needs a transparent image with white flags on it)
+- creature battle animations (needs a transparent image with white outline of creature for highlighting on mouse hover)


### PR DESCRIPTION
Support for prescaled images. Allows hybrid usage of xbrz and prescaled.

Original size is still required. But additional hires can be loaded:
E.g. for `ADOPFLGB.bmp` -> `ADOPFLGB$3.png`. It searches images with the same name but `$SCALEFACTOR`-Suffix. If it is found it uses it instead doing xbrz. Multiple scale factors can be provided (2-4). It prefer the one with the current xbrz factor. If it's not found it uses the biggest found image and downscale it. Works also with def (but strongly suggest json for animations; def has some size limitations).

Can be used to provide HQ mods and maybe also for a conversion script converting official HD files.

Fixes #1070

Here's VCMI with some HD graphics from official HD version:
![grafik](https://github.com/user-attachments/assets/0d542d2c-3a4c-4d0d-83f3-c1abce6571d1)
