### PR TITLE
Set CMAKE_C_COMPILER and CMAKE_CXX_COMPILER to gcc and g++ for windows-mingw-release

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -134,7 +134,9 @@
             "description": "VCMI Windows Ninja using MinGW",
             "inherits": "default-release",
             "cacheVariables": {
-                "CMAKE_BUILD_TYPE": "Release"
+                "CMAKE_BUILD_TYPE": "Release",
+                "CMAKE_C_COMPILER": "gcc",
+                "CMAKE_CXX_COMPILER": "g++"
             }
         },
         {


### PR DESCRIPTION
Prevents various situations where clang is chosen over gcc, which is unintended when using windows-mingw-release preset.