### PR TITLE
Fix linker error in EntryPoint if ffmpeg is missing due to missing DISABLE_VIDEO in vcmiclient target

### DIFF
--- a/clientapp/CMakeLists.txt
+++ b/clientapp/CMakeLists.txt
@@ -56,6 +56,11 @@ if(WIN32)
 	endif()
 	target_compile_definitions(vcmiclient PRIVATE WINDOWS_IGNORE_PACKING_MISMATCH)
 
+	if(NOT ffmpeg_LIBRARIES)
+		target_compile_definitions(vcmiclient PRIVATE DISABLE_VIDEO)
+	endif()
+
+
 	# TODO: very hacky, find proper solution to copy AI dlls into bin dir
 	if(MSVC)
 		add_custom_command(TARGET vcmiclient POST_BUILD


### PR DESCRIPTION
Fix linker error:
```
EntryPoint.cpp.obj:EntryPoint.cpp:(.rdata$.refptr._ZTV12CVideoPlayer[.refptr._ZTV12CVideoPlayer]+0x0): undefined reference to `vtable for CVideoPlayer'"
```

Happens when ffmpeg is not installed (in `windows-mingw-release`, but I recon this happens for any GCC-based build where ffmpeg is missing from host?).

Before this PR, DISABLE_VIDEO is *not* added to vcmiclient-target. `EntryPoint.cpp` is compiled by vcmiclient-target, so the wrong code-path is chosen in snippet below:

EntryPoint.cpp:289
```c++
	// Initialize video
#ifdef DISABLE_VIDEO <-- this PR makes it so that this is TRUE if ffmpeg is missing
	CCS->videoh = new CEmptyVideoPlayer(); <-- We should be here...
#else
	if (!settings["session"]["headless"].Bool() && !vm.count("disable-video"))
		CCS->videoh = new CVideoPlayer(); <-- ... but we wind up here since DISABLE_VIDEO is not properly set if ffmpeg is missing
	else
		CCS->videoh = new CEmptyVideoPlayer();
#endif
```

Virtual function definitions of CVideoPlayer *are* correctly left out since they belong to another target vcmiclientcommon where DISABLE_VIDEO is already set, but `CVideoPlayer` is instantiated in unintended code-path, hence linker errors.