### PR TITLE
Remove '-Og' from MINGW debug builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -355,13 +355,6 @@ if(MINGW OR MSVC)
 		if(ICONV_FOUND)
 			set(SYSTEM_LIBS ${SYSTEM_LIBS} iconv)
 		endif()
-
-		# Prevent compiler issues when building Debug
-		# Assembler might fail with "too many sections"
-		# With big-obj or 64-bit build will take hours
-		if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-			set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Og")
-		endif()
 	endif(MINGW)
 endif(MINGW OR MSVC)
 


### PR DESCRIPTION
Remove `-Og` from MINGW debug builds. It interferes with debugging. See https://stackoverflow.com/a/63386263/2323908. Instead, the default O0 is used.

This change makes it possible to use whatever optimization levels you want debug builds, which was previously impossible due to the passing of `-Og` in CMakeLists.txt.

Without this PR, breakpoints won't trigger on exact lines, several variables get optimized out, and generally makes it very difficult to debug with mingw builds.

The comments that motivates the addition of `-Og`
```cmake
# Prevent compiler issues when building Debug
# Assembler might fail with "too many sections"
# With big-obj or 64-bit build will take hours
```
does not hold any longer.
* It is possible to compile, without issues, without -Og
* I do not observe "too many sections" problems when compiling
* Compilation does not take hours