### PR TITLE
fix crash:  spell before attack kill defender will lead to crash

### DIFF
--- a/server/battles/BattleActionProcessor.cpp
+++ b/server/battles/BattleActionProcessor.cpp
@@ -916,6 +916,10 @@ void BattleActionProcessor::makeAttack(const CBattleInfoCallback & battle, const
 	if(defender && first && !counter)
 		handleAttackBeforeCasting(battle, ranged, attacker, defender);
 
+	// If the attacker or defender is not alive before the attack action, the action should be skipped.
+	if((attacker && !attacker->alive()) || (defender && !defender->alive()))
+		return;
+
 	FireShieldInfo fireShield;
 	BattleAttack bat;
 	BattleLogMessage blm;


### PR DESCRIPTION
Defender is killed by spell before attack, but attacker still do attack action. So I add a check after this spell, to check both attack or defender are alive.