### PR TITLE
Fixes for recently reported issues

### DIFF
--- a/client/mapView/MapRendererContextState.cpp
+++ b/client/mapView/MapRendererContextState.cpp
@@ -54,9 +54,8 @@ void MapRendererContextState::addObject(const CGObjectInstance * obj)
 			if(LOCPLINT->cb->isInTheMap(currTile) && obj->coveringAt(currTile))
 			{
 				auto & container = objects[currTile.z][currTile.x][currTile.y];
-
-				container.push_back(obj->id);
-				boost::range::sort(container, compareObjectBlitOrder);
+				auto position = std::upper_bound(container.begin(), container.end(), obj->id, compareObjectBlitOrder);
+				container.insert(position, obj->id);
 			}
 		}
 	}

--- a/client/render/IImage.h
+++ b/client/render/IImage.h
@@ -78,7 +78,7 @@ public:
 	virtual void setShadowEnabled(bool on) = 0;
 	virtual void setBodyEnabled(bool on) = 0;
 	virtual void setOverlayEnabled(bool on) = 0;
-	virtual std::shared_ptr<ISharedImage> getSharedImage() const = 0;
+	virtual std::shared_ptr<const ISharedImage> getSharedImage() const = 0;
 
 	virtual ~IImage() = default;
 };
@@ -94,12 +94,12 @@ public:
 	virtual bool isTransparent(const Point & coords) const = 0;
 	virtual void draw(SDL_Surface * where, SDL_Palette * palette, const Point & dest, const Rect * src, const ColorRGBA & colorMultiplier, uint8_t alpha, EImageBlitMode mode) const = 0;
 
-	virtual std::shared_ptr<IImage> createImageReference(EImageBlitMode mode) = 0;
+	virtual std::shared_ptr<IImage> createImageReference(EImageBlitMode mode) const = 0;
 
-	virtual std::shared_ptr<ISharedImage> horizontalFlip() const = 0;
-	virtual std::shared_ptr<ISharedImage> verticalFlip() const = 0;
-	virtual std::shared_ptr<ISharedImage> scaleInteger(int factor, SDL_Palette * palette) const = 0;
-	virtual std::shared_ptr<ISharedImage> scaleTo(const Point & size, SDL_Palette * palette) const = 0;
+	virtual std::shared_ptr<const ISharedImage> horizontalFlip() const = 0;
+	virtual std::shared_ptr<const ISharedImage> verticalFlip() const = 0;
+	virtual std::shared_ptr<const ISharedImage> scaleInteger(int factor, SDL_Palette * palette) const = 0;
+	virtual std::shared_ptr<const ISharedImage> scaleTo(const Point & size, SDL_Palette * palette) const = 0;
 
 
 	virtual ~ISharedImage() = default;

--- a/client/renderSDL/ImageScaled.cpp
+++ b/client/renderSDL/ImageScaled.cpp
@@ -21,7 +21,7 @@
 
 #include <SDL_surface.h>
 
-ImageScaled::ImageScaled(const ImageLocator & inputLocator, const std::shared_ptr<ISharedImage> & source, EImageBlitMode mode)
+ImageScaled::ImageScaled(const ImageLocator & inputLocator, const std::shared_ptr<const ISharedImage> & source, EImageBlitMode mode)
 	: source(source)
 	, locator(inputLocator)
 	, colorMultiplier(Colors::WHITE_TRUE)
@@ -33,7 +33,7 @@ ImageScaled::ImageScaled(const ImageLocator & inputLocator, const std::shared_pt
 		setShadowEnabled(true);
 }
 
-std::shared_ptr<ISharedImage> ImageScaled::getSharedImage() const
+std::shared_ptr<const ISharedImage> ImageScaled::getSharedImage() const
 {
 	return body;
 }

--- a/client/renderSDL/ImageScaled.h
+++ b/client/renderSDL/ImageScaled.h
@@ -25,16 +25,16 @@ class ImageScaled final : public IImage
 private:
 
 	/// Original unscaled image
-	std::shared_ptr<ISharedImage> source;
+	std::shared_ptr<const ISharedImage> source;
 
 	/// Upscaled shadow of our image, may be null
-	std::shared_ptr<ISharedImage> shadow;
+	std::shared_ptr<const ISharedImage> shadow;
 
 	/// Upscaled main part of our image, may be null
-	std::shared_ptr<ISharedImage> body;
+	std::shared_ptr<const ISharedImage> body;
 
 	/// Upscaled overlay (player color, selection highlight) of our image, may be null
-	std::shared_ptr<ISharedImage> overlay;
+	std::shared_ptr<const ISharedImage> overlay;
 
 	ImageLocator locator;
 
@@ -45,7 +45,7 @@ private:
 	EImageBlitMode blitMode;
 
 public:
-	ImageScaled(const ImageLocator & locator, const std::shared_ptr<ISharedImage> & source, EImageBlitMode mode);
+	ImageScaled(const ImageLocator & locator, const std::shared_ptr<const ISharedImage> & source, EImageBlitMode mode);
 
 	void scaleInteger(int factor) override;
 	void scaleTo(const Point & size) override;
@@ -63,5 +63,5 @@ public:
 	void setShadowEnabled(bool on) override;
 	void setBodyEnabled(bool on) override;
 	void setOverlayEnabled(bool on) override;
-	std::shared_ptr<ISharedImage> getSharedImage() const override;
+	std::shared_ptr<const ISharedImage> getSharedImage() const override;
 };

--- a/client/renderSDL/RenderHandler.cpp
+++ b/client/renderSDL/RenderHandler.cpp
@@ -212,7 +212,7 @@ ImageLocator RenderHandler::getLocatorForAnimationFrame(const AnimationPath & pa
 	return ImageLocator(path, frame, group);
 }
 
-std::shared_ptr<ISharedImage> RenderHandler::loadImageImpl(const ImageLocator & locator)
+std::shared_ptr<const ISharedImage> RenderHandler::loadImageImpl(const ImageLocator & locator)
 {
 	auto it = imageFiles.find(locator);
 	if (it != imageFiles.end())
@@ -231,7 +231,7 @@ std::shared_ptr<ISharedImage> RenderHandler::loadImageImpl(const ImageLocator & 
 	return scaledImage;
 }
 
-std::shared_ptr<ISharedImage> RenderHandler::loadImageFromFileUncached(const ImageLocator & locator)
+std::shared_ptr<const ISharedImage> RenderHandler::loadImageFromFileUncached(const ImageLocator & locator)
 {
 	if (locator.image)
 	{
@@ -258,7 +258,7 @@ std::shared_ptr<ISharedImage> RenderHandler::loadImageFromFileUncached(const Ima
 	throw std::runtime_error("Invalid image locator received!");
 }
 
-void RenderHandler::storeCachedImage(const ImageLocator & locator, std::shared_ptr<ISharedImage> image)
+void RenderHandler::storeCachedImage(const ImageLocator & locator, std::shared_ptr<const ISharedImage> image)
 {
 	imageFiles[locator] = image;
 
@@ -271,7 +271,7 @@ void RenderHandler::storeCachedImage(const ImageLocator & locator, std::shared_p
 #endif
 }
 
-std::shared_ptr<ISharedImage> RenderHandler::loadImageFromFile(const ImageLocator & locator)
+std::shared_ptr<const ISharedImage> RenderHandler::loadImageFromFile(const ImageLocator & locator)
 {
 	if (imageFiles.count(locator))
 		return imageFiles.at(locator);
@@ -281,7 +281,7 @@ std::shared_ptr<ISharedImage> RenderHandler::loadImageFromFile(const ImageLocato
 	return result;
 }
 
-std::shared_ptr<ISharedImage> RenderHandler::transformImage(const ImageLocator & locator, std::shared_ptr<ISharedImage> image)
+std::shared_ptr<const ISharedImage> RenderHandler::transformImage(const ImageLocator & locator, std::shared_ptr<const ISharedImage> image)
 {
 	if (imageFiles.count(locator))
 		return imageFiles.at(locator);
@@ -298,7 +298,7 @@ std::shared_ptr<ISharedImage> RenderHandler::transformImage(const ImageLocator &
 	return result;
 }
 
-std::shared_ptr<ISharedImage> RenderHandler::scaleImage(const ImageLocator & locator, std::shared_ptr<ISharedImage> image)
+std::shared_ptr<const ISharedImage> RenderHandler::scaleImage(const ImageLocator & locator, std::shared_ptr<const ISharedImage> image)
 {
 	if (imageFiles.count(locator))
 		return imageFiles.at(locator);

--- a/client/renderSDL/RenderHandler.h
+++ b/client/renderSDL/RenderHandler.h
@@ -25,7 +25,7 @@ class RenderHandler : public IRenderHandler
 
 	std::map<AnimationPath, std::shared_ptr<CDefFile>> animationFiles;
 	std::map<AnimationPath, AnimationLayoutMap> animationLayouts;
-	std::map<ImageLocator, std::shared_ptr<ISharedImage>> imageFiles;
+	std::map<ImageLocator, std::shared_ptr<const ISharedImage>> imageFiles;
 	std::map<EFonts, std::shared_ptr<const IFont>> fonts;
 
 	std::shared_ptr<CDefFile> getAnimationFile(const AnimationPath & path);
@@ -36,15 +36,15 @@ class RenderHandler : public IRenderHandler
 
 	void addImageListEntry(size_t index, size_t group, const std::string & listName, const std::string & imageName);
 	void addImageListEntries(const EntityService * service);
-	void storeCachedImage(const ImageLocator & locator, std::shared_ptr<ISharedImage> image);
+	void storeCachedImage(const ImageLocator & locator, std::shared_ptr<const ISharedImage> image);
 
-	std::shared_ptr<ISharedImage> loadImageImpl(const ImageLocator & config);
+	std::shared_ptr<const ISharedImage> loadImageImpl(const ImageLocator & config);
 
-	std::shared_ptr<ISharedImage> loadImageFromFileUncached(const ImageLocator & locator);
-	std::shared_ptr<ISharedImage> loadImageFromFile(const ImageLocator & locator);
+	std::shared_ptr<const ISharedImage> loadImageFromFileUncached(const ImageLocator & locator);
+	std::shared_ptr<const ISharedImage> loadImageFromFile(const ImageLocator & locator);
 
-	std::shared_ptr<ISharedImage> transformImage(const ImageLocator & locator, std::shared_ptr<ISharedImage> image);
-	std::shared_ptr<ISharedImage> scaleImage(const ImageLocator & locator, std::shared_ptr<ISharedImage> image);
+	std::shared_ptr<const ISharedImage> transformImage(const ImageLocator & locator, std::shared_ptr<const ISharedImage> image);
+	std::shared_ptr<const ISharedImage> scaleImage(const ImageLocator & locator, std::shared_ptr<const ISharedImage> image);
 
 	ImageLocator getLocatorForAnimationFrame(const AnimationPath & path, int frame, int group);
 

--- a/client/renderSDL/SDLImage.cpp
+++ b/client/renderSDL/SDLImage.cpp
@@ -269,7 +269,7 @@ void SDLImageShared::optimizeSurface()
 	}
 }
 
-std::shared_ptr<ISharedImage> SDLImageShared::scaleInteger(int factor, SDL_Palette * palette) const
+std::shared_ptr<const ISharedImage> SDLImageShared::scaleInteger(int factor, SDL_Palette * palette) const
 {
 	if (factor <= 0)
 		throw std::runtime_error("Unable to scale by integer value of " + std::to_string(factor));
@@ -279,10 +279,7 @@ std::shared_ptr<ISharedImage> SDLImageShared::scaleInteger(int factor, SDL_Palet
 
 	SDL_Surface * scaled = nullptr;
 	if(preScaleFactor == factor)
-	{
-		scaled = CSDL_Ext::newSurface(Point(surf->w, surf->h), surf);
-		SDL_BlitSurface(surf, nullptr, scaled, nullptr);
-	}
+		return shared_from_this();
 	else if(preScaleFactor == 1)
 		scaled = CSDL_Ext::scaleSurfaceIntegerFactor(surf, factor, EScalingAlgorithm::XBRZ);
 	else
@@ -306,7 +303,7 @@ std::shared_ptr<ISharedImage> SDLImageShared::scaleInteger(int factor, SDL_Palet
 	return ret;
 }
 
-std::shared_ptr<ISharedImage> SDLImageShared::scaleTo(const Point & size, SDL_Palette * palette) const
+std::shared_ptr<const ISharedImage> SDLImageShared::scaleTo(const Point & size, SDL_Palette * palette) const
 {
 	float scaleX = float(size.x) / fullSize.x;
 	float scaleY = float(size.y) / fullSize.y;
@@ -370,7 +367,7 @@ Point SDLImageShared::dimensions() const
 	return fullSize / preScaleFactor;
 }
 
-std::shared_ptr<IImage> SDLImageShared::createImageReference(EImageBlitMode mode)
+std::shared_ptr<IImage> SDLImageShared::createImageReference(EImageBlitMode mode) const
 {
 	if (surf && surf->format->palette)
 		return std::make_shared<SDLImageIndexed>(shared_from_this(), originalPalette, mode);
@@ -378,7 +375,7 @@ std::shared_ptr<IImage> SDLImageShared::createImageReference(EImageBlitMode mode
 		return std::make_shared<SDLImageRGB>(shared_from_this(), mode);
 }
 
-std::shared_ptr<ISharedImage> SDLImageShared::horizontalFlip() const
+std::shared_ptr<const ISharedImage> SDLImageShared::horizontalFlip() const
 {
 	SDL_Surface * flipped = CSDL_Ext::horizontalFlip(surf);
 	auto ret = std::make_shared<SDLImageShared>(flipped, preScaleFactor);
@@ -390,7 +387,7 @@ std::shared_ptr<ISharedImage> SDLImageShared::horizontalFlip() const
 	return ret;
 }
 
-std::shared_ptr<ISharedImage> SDLImageShared::verticalFlip() const
+std::shared_ptr<const ISharedImage> SDLImageShared::verticalFlip() const
 {
 	SDL_Surface * flipped = CSDL_Ext::verticalFlip(surf);
 	auto ret = std::make_shared<SDLImageShared>(flipped, preScaleFactor);
@@ -444,7 +441,7 @@ void SDLImageIndexed::adjustPalette(const ColorFilter & shifter, uint32_t colors
 	}
 }
 
-SDLImageIndexed::SDLImageIndexed(const std::shared_ptr<ISharedImage> & image, SDL_Palette * originalPalette, EImageBlitMode mode)
+SDLImageIndexed::SDLImageIndexed(const std::shared_ptr<const ISharedImage> & image, SDL_Palette * originalPalette, EImageBlitMode mode)
 	:SDLImageBase::SDLImageBase(image, mode)
 	,originalPalette(originalPalette)
 {
@@ -541,13 +538,13 @@ SDLImageShared::~SDLImageShared()
 	SDL_FreePalette(originalPalette);
 }
 
-SDLImageBase::SDLImageBase(const std::shared_ptr<ISharedImage> & image, EImageBlitMode mode)
+SDLImageBase::SDLImageBase(const std::shared_ptr<const ISharedImage> & image, EImageBlitMode mode)
 	:image(image)
 	, alphaValue(SDL_ALPHA_OPAQUE)
 	, blitMode(mode)
 {}
 
-std::shared_ptr<ISharedImage> SDLImageBase::getSharedImage() const
+std::shared_ptr<const ISharedImage> SDLImageBase::getSharedImage() const
 {
 	return image;
 }

--- a/client/renderSDL/SDLImage.h
+++ b/client/renderSDL/SDLImage.h
@@ -57,11 +57,11 @@ public:
 	void exportBitmap(const boost::filesystem::path & path, SDL_Palette * palette) const override;
 	Point dimensions() const override;
 	bool isTransparent(const Point & coords) const override;
-	std::shared_ptr<IImage> createImageReference(EImageBlitMode mode) override;
-	std::shared_ptr<ISharedImage> horizontalFlip() const override;
-	std::shared_ptr<ISharedImage> verticalFlip() const override;
-	std::shared_ptr<ISharedImage> scaleInteger(int factor, SDL_Palette * palette) const override;
-	std::shared_ptr<ISharedImage> scaleTo(const Point & size, SDL_Palette * palette) const override;
+	std::shared_ptr<IImage> createImageReference(EImageBlitMode mode) const override;
+	std::shared_ptr<const ISharedImage> horizontalFlip() const override;
+	std::shared_ptr<const ISharedImage> verticalFlip() const override;
+	std::shared_ptr<const ISharedImage> scaleInteger(int factor, SDL_Palette * palette) const override;
+	std::shared_ptr<const ISharedImage> scaleTo(const Point & size, SDL_Palette * palette) const override;
 
 	friend class SDLImageLoader;
 };
@@ -69,19 +69,19 @@ public:
 class SDLImageBase : public IImage, boost::noncopyable
 {
 protected:
-	std::shared_ptr<ISharedImage> image;
+	std::shared_ptr<const ISharedImage> image;
 
 	uint8_t alphaValue;
 	EImageBlitMode blitMode;
 
 public:
-	SDLImageBase(const std::shared_ptr<ISharedImage> & image, EImageBlitMode mode);
+	SDLImageBase(const std::shared_ptr<const ISharedImage> & image, EImageBlitMode mode);
 
 	bool isTransparent(const Point & coords) const override;
 	Point dimensions() const override;
 	void setAlpha(uint8_t value) override;
 	void setBlitMode(EImageBlitMode mode) override;
-	std::shared_ptr<ISharedImage> getSharedImage() const override;
+	std::shared_ptr<const ISharedImage> getSharedImage() const override;
 };
 
 class SDLImageIndexed final : public SDLImageBase
@@ -95,7 +95,7 @@ class SDLImageIndexed final : public SDLImageBase
 
 	void setShadowTransparency(float factor);
 public:
-	SDLImageIndexed(const std::shared_ptr<ISharedImage> & image, SDL_Palette * palette, EImageBlitMode mode);
+	SDLImageIndexed(const std::shared_ptr<const ISharedImage> & image, SDL_Palette * palette, EImageBlitMode mode);
 	~SDLImageIndexed();
 
 	void draw(SDL_Surface * where, const Point & pos, const Rect * src) const override;

--- a/config/objects/generic.json
+++ b/config/objects/generic.json
@@ -223,6 +223,7 @@
 				"ambient" : ["LOOPFACT"],
 				"visit" : ["MILITARY"]
 			}
+			"creatures": [["ballista"], ["firstAidTent"], ["ammoCart"] ]
 		},
 		"types" : {
 			"object" : {

--- a/config/objects/generic.json
+++ b/config/objects/generic.json
@@ -222,8 +222,8 @@
 			"sounds" : {
 				"ambient" : ["LOOPFACT"],
 				"visit" : ["MILITARY"]
-			}
-			"creatures": [["ballista"], ["firstAidTent"], ["ammoCart"] ]
+			},
+			"creatures": [ ["ballista"], ["firstAidTent"], ["ammoCart"] ]
 		},
 		"types" : {
 			"object" : {

--- a/lib/mapObjects/CGDwelling.cpp
+++ b/lib/mapObjects/CGDwelling.cpp
@@ -180,6 +180,7 @@ void CGDwelling::initObj(vstd::RNG & rand)
 	{
 	case Obj::CREATURE_GENERATOR1:
 	case Obj::CREATURE_GENERATOR4:
+	case Obj::WAR_MACHINE_FACTORY:
 		{
 			getObjectHandler()->configureObject(this, rand);
 			assert(!creatures.empty());
@@ -188,13 +189,6 @@ void CGDwelling::initObj(vstd::RNG & rand)
 		}
 	case Obj::REFUGEE_CAMP:
 		//is handled within newturn func
-		break;
-
-	case Obj::WAR_MACHINE_FACTORY:
-		creatures.resize(3);
-		creatures[0].second.emplace_back(CreatureID::BALLISTA);
-		creatures[1].second.emplace_back(CreatureID::FIRST_AID_TENT);
-		creatures[2].second.emplace_back(CreatureID::AMMO_CART);
 		break;
 
 	default:

--- a/lib/mapObjects/CGHeroInstance.cpp
+++ b/lib/mapObjects/CGHeroInstance.cpp
@@ -1243,7 +1243,7 @@ void CGHeroInstance::removeSpellbook()
 
 	if(hasSpellbook())
 	{
-		cb->removeArtifact(ArtifactLocation(this->id, ArtifactPosition::SPELLBOOK));
+		cb->gameState()->map->removeArtifactInstance(*this, ArtifactPosition::SPELLBOOK);
 	}
 }
 

--- a/lib/rewardable/Reward.h
+++ b/lib/rewardable/Reward.h
@@ -129,6 +129,8 @@ struct DLL_LINKAGE Reward final
 		h & removeObject;
 		h & manaPercentage;
 		h & movePercentage;
+		if (h.version >= Handler::Version::REWARDABLE_GUARDS)
+			h & guards;
 		h & heroExperience;
 		h & heroLevel;
 		h & manaDiff;

--- a/lib/serializer/ESerializationVersion.h
+++ b/lib/serializer/ESerializationVersion.h
@@ -67,6 +67,7 @@ enum class ESerializationVersion : int32_t
 	REMOVE_OBJECT_TYPENAME, // 868 - remove typename from CGObjectInstance
 	REMOVE_VLC_POINTERS, // 869 removed remaining pointers to VLC entities
 	FOLDER_NAME_REWORK, // 870 - rework foldername
+	REWARDABLE_GUARDS, // 871 - fix missing serialization of guards in rewardable objects
 	
-	CURRENT = FOLDER_NAME_REWORK
+	CURRENT = REWARDABLE_GUARDS
 };


### PR DESCRIPTION
- Add missing field to serialization. Fixes #4911, supersedes #4918 (since this PR also adds save compat check)

- Fix crash on advancing to 3rd scenario of Birth of Barbarian campaign - spellbook removal was not working correctly when hero does not keeps his spells (which they normally do, except in this scenario for some reason). Fixes #4894

-  ISharedImage is now always const. Removed creation of image copy when upscaling to same factor as this image is already scaled to (leftover from HD assets support PR)

- List of items available for purchase in War Machines Factory is now moved to config and is no longer hardcoded. This means that objects like Cannon Yard can now define list of war machines from scratch - they no longer have 3 H3 machines unconditionally.

-  Use upper_bound instead of sort since std::sort requires predicate that can guarantee strict weak ordering. However our map object priority predicate can't provide it by design. Meanwhile, upper_bound does not have such requirement, so should be safe to use. As a side effect, this seems to fix some issues with object ordering. Some still remain, but way less than before.