### PR TITLE
MinGW debug compilation error fix 'too many sections'

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -797,7 +797,7 @@ if(MINGW AND CMAKE_BUILD_TYPE STREQUAL "Debug")
 		serializer/SerializerReflection.cpp
 		IGameCallback.cpp
 		PROPERTIES
-		COMPILE_OPTIONS "-Og")
+		COMPILE_OPTIONS "-Wa,-mbig-obj")
 endif()
 
 vcmi_set_output_dir(vcmi "")

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -790,7 +790,7 @@ if(WIN32)
 	)
 endif()
 
-# Use -Og for files that generate very large object files
+# Use '-Wa,-mbig-obj' for files that generate very large object files
 # when compiling with MinGW lest you get "too many sections" assembler errors
 if(MINGW AND CMAKE_BUILD_TYPE STREQUAL "Debug")
 	set_source_files_properties(

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -790,6 +790,16 @@ if(WIN32)
 	)
 endif()
 
+# Use -Og for files that generate very large object files
+# when compiling with MinGW lest you get "too many sections" assembler errors
+if(MINGW AND CMAKE_BUILD_TYPE STREQUAL "Debug")
+	set_source_files_properties(
+		serializer/SerializerReflection.cpp
+		IGameCallback.cpp
+		PROPERTIES
+		COMPILE_OPTIONS "-Og")
+endif()
+
 vcmi_set_output_dir(vcmi "")
 
 enable_pch(vcmi)


### PR DESCRIPTION
Use `-Wa,-mbig-obj` for a subset of `.cpp`-files that are too large on MinGW windows debug builds.

Issue introduced by https://github.com/vcmi/vcmi/pull/4919.