### PR TITLE
Fix MinGW date formatting error

### DIFF
--- a/lib/texts/Languages.h
+++ b/lib/texts/Languages.h
@@ -77,23 +77,23 @@ inline const auto & getLanguageList()
 {
 	static const std::array<Options, 17> languages
 	{ {
-		{ "czech",       "Czech",       "Čeština",    "CP1250", "cs", "cze", "%d.%m.%Y %T", EPluralForms::CZ_3 },
-		{ "chinese",     "Chinese",     "简体中文",       "GBK",    "zh", "chi", "%F %T", EPluralForms::VI_1 }, // Note: actually Simplified Chinese
-		{ "english",     "English",     "English",    "CP1252", "en", "eng", "%F %T", EPluralForms::EN_2 }, // English uses international date/time format here
-		{ "finnish",     "Finnish",     "Suomi",      "CP1252", "fi", "fin", "%d.%m.%Y %T", EPluralForms::EN_2, },
-		{ "french",      "French",      "Français",   "CP1252", "fr", "fre", "%d/%m/%Y %T", EPluralForms::FR_2, },
-		{ "german",      "German",      "Deutsch",    "CP1252", "de", "ger", "%d.%m.%Y %T", EPluralForms::EN_2, },
-		{ "hungarian",   "Hungarian",   "Magyar",     "CP1250", "hu", "hun", "%Y. %m. %d. %T", EPluralForms::EN_2 },
-		{ "italian",     "Italian",     "Italiano",   "CP1250", "it", "ita", "%d/%m/%Y %T", EPluralForms::EN_2 },
-		{ "korean",      "Korean",      "한국어",        "CP949",  "ko", "kor", "%F %T", EPluralForms::VI_1 },
-		{ "polish",      "Polish",      "Polski",     "CP1250", "pl", "pol", "%d.%m.%Y %T", EPluralForms::PL_3 },
-		{ "portuguese",  "Portuguese",  "Português",  "CP1252", "pt", "por", "%d/%m/%Y %T", EPluralForms::EN_2 }, // Note: actually Brazilian Portuguese
-		{ "russian",     "Russian",     "Русский",    "CP1251", "ru", "rus", "%d.%m.%Y %T", EPluralForms::UK_3 },
-		{ "spanish",     "Spanish",     "Español",    "CP1252", "es", "spa", "%d/%m/%Y %T", EPluralForms::EN_2 },
-		{ "swedish",     "Swedish",     "Svenska",    "CP1252", "sv", "swe", "%F %T", EPluralForms::EN_2 },
-		{ "turkish",     "Turkish",     "Türkçe",     "CP1254", "tr", "tur", "%d.%m.%Y %T", EPluralForms::EN_2 },
-		{ "ukrainian",   "Ukrainian",   "Українська", "CP1251", "uk", "ukr", "%d.%m.%Y %T", EPluralForms::UK_3 },
-		{ "vietnamese",  "Vietnamese",  "Tiếng Việt", "UTF-8",  "vi", "vie", "%d/%m/%Y %T", EPluralForms::VI_1 }, // Fan translation uses special encoding
+		{ "czech",       "Czech",       "Čeština",    "CP1250", "cs", "cze", "%d.%m.%Y %H:%M:%S", EPluralForms::CZ_3 },
+		{ "chinese",     "Chinese",     "简体中文",       "GBK",    "zh", "chi", "%Y-%m-%d %H:%M:%S", EPluralForms::VI_1 }, // Note: actually Simplified Chinese
+		{ "english",     "English",     "English",    "CP1252", "en", "eng", "%Y-%m-%d %H:%M:%S", EPluralForms::EN_2 }, // English uses international date/time format here
+		{ "finnish",     "Finnish",     "Suomi",      "CP1252", "fi", "fin", "%d.%m.%Y %H:%M:%S", EPluralForms::EN_2, },
+		{ "french",      "French",      "Français",   "CP1252", "fr", "fre", "%d/%m/%Y %H:%M:%S", EPluralForms::FR_2, },
+		{ "german",      "German",      "Deutsch",    "CP1252", "de", "ger", "%d.%m.%Y %H:%M:%S", EPluralForms::EN_2, },
+		{ "hungarian",   "Hungarian",   "Magyar",     "CP1250", "hu", "hun", "%Y. %m. %d. %H:%M:%S", EPluralForms::EN_2 },
+		{ "italian",     "Italian",     "Italiano",   "CP1250", "it", "ita", "%d/%m/%Y %H:%M:%S", EPluralForms::EN_2 },
+		{ "korean",      "Korean",      "한국어",        "CP949",  "ko", "kor", "%Y-%m-%d %H:%M:%S", EPluralForms::VI_1 },
+		{ "polish",      "Polish",      "Polski",     "CP1250", "pl", "pol", "%d.%m.%Y %H:%M:%S", EPluralForms::PL_3 },
+		{ "portuguese",  "Portuguese",  "Português",  "CP1252", "pt", "por", "%d/%m/%Y %H:%M:%S", EPluralForms::EN_2 }, // Note: actually Brazilian Portuguese
+		{ "russian",     "Russian",     "Русский",    "CP1251", "ru", "rus", "%d.%m.%Y %H:%M:%S", EPluralForms::UK_3 },
+		{ "spanish",     "Spanish",     "Español",    "CP1252", "es", "spa", "%d/%m/%Y %H:%M:%S", EPluralForms::EN_2 },
+		{ "swedish",     "Swedish",     "Svenska",    "CP1252", "sv", "swe", "%Y-%m-%d %H:%M:%S", EPluralForms::EN_2 },
+		{ "turkish",     "Turkish",     "Türkçe",     "CP1254", "tr", "tur", "%d.%m.%Y %H:%M:%S", EPluralForms::EN_2 },
+		{ "ukrainian",   "Ukrainian",   "Українська", "CP1251", "uk", "ukr", "%d.%m.%Y %H:%M:%S", EPluralForms::UK_3 },
+		{ "vietnamese",  "Vietnamese",  "Tiếng Việt", "UTF-8",  "vi", "vie", "%d/%m/%Y %H:%M:%S", EPluralForms::VI_1 }, // Fan translation uses special encoding
 	} };
 	static_assert(languages.size() == static_cast<size_t>(ELanguages::COUNT), "Languages array is missing a value!");
 


### PR DESCRIPTION
Fix MinGW date formatting error, see https://sourceforge.net/p/mingw-w64/bugs/793/. Workaround is to replace %F with %Y-%m-%d and %T with %H:%M:%S, should produce the same output as before per https://en.cppreference.com/w/cpp/io/manip/put_time

Solves https://github.com/vcmi/vcmi/issues/4903.