### PR TITLE
Prelauncher

### DIFF
--- a/config/schemas/settings.json
+++ b/config/schemas/settings.json
@@ -624,7 +624,8 @@
 				"autoCheckRepositories", 
 				"ignoreSslErrors",
 				"updateOnStartup", 
-				"updateConfigUrl"
+				"updateConfigUrl", 
+				"preLauncher"
 			],
 			"properties" : {
 				"defaultRepositoryEnabled" : {
@@ -666,6 +667,10 @@
 				"updateConfigUrl" : {
 					"type" : "string",
 					"default" : "https://raw.githubusercontent.com/vcmi/vcmi-updates/master/vcmi-updates.json"
+				},
+				"preLauncher" : {
+					"type" : "boolean",
+					"default" : false
 				}
 			}
 		},

--- a/config/schemas/settings.json
+++ b/config/schemas/settings.json
@@ -625,7 +625,7 @@
 				"ignoreSslErrors",
 				"updateOnStartup", 
 				"updateConfigUrl", 
-				"preLauncher"
+				"skipLauncher"
 			],
 			"properties" : {
 				"defaultRepositoryEnabled" : {
@@ -668,7 +668,7 @@
 					"type" : "string",
 					"default" : "https://raw.githubusercontent.com/vcmi/vcmi-updates/master/vcmi-updates.json"
 				},
-				"preLauncher" : {
+				"skipLauncher" : {
 					"type" : "boolean",
 					"default" : false
 				}

--- a/launcher/CMakeLists.txt
+++ b/launcher/CMakeLists.txt
@@ -166,6 +166,8 @@ if(ANDROID)
 	list(APPEND launcher_RESOURCES "${CMAKE_CURRENT_BINARY_DIR}/config.qrc")
 	generate_binary_resource("Mods" "${CMAKE_SOURCE_DIR}/Mods")
 	list(APPEND launcher_RESOURCES "${CMAKE_CURRENT_BINARY_DIR}/Mods.qrc")
+
+	add_definitions(-DENABLE_SKIP_LAUNCHER)
 endif()
 
 target_sources(vcmilauncher PRIVATE

--- a/launcher/mainwindow_moc.cpp
+++ b/launcher/mainwindow_moc.cpp
@@ -125,6 +125,7 @@ MainWindow::MainWindow(QWidget * parent)
 
 void MainWindow::skipLauncher()
 {
+#ifdef ENABLE_SKIP_LAUNCHER
 	QMessageBox msgBox;
 	int secondsRemaining = 10;
 	auto getText = [&] { return tr("How to start?\n\nVCMI starts automatically in %n second(s)", nullptr, secondsRemaining); };
@@ -154,6 +155,7 @@ void MainWindow::skipLauncher()
 		hide();
 		startGame({});
 	}
+#endif
 }
 
 void MainWindow::detectPreferredLanguage()

--- a/launcher/mainwindow_moc.cpp
+++ b/launcher/mainwindow_moc.cpp
@@ -127,14 +127,14 @@ void MainWindow::preLauncher()
 {
 	QMessageBox msgBox;
 	int secondsRemaining = 10;
-	auto setText = [&](){ msgBox.setText(tr("How to start?\n\nVCMI starts automatically in %n second(s)", "", secondsRemaining)); };
-	setText();
+	auto getText = [&] { return tr("How to start?\n\nVCMI starts automatically in %n second(s)", nullptr, secondsRemaining); };
+	msgBox.setText(getText());
 	msgBox.setWindowTitle("VCMI");
 	msgBox.setIcon(QMessageBox::Question);
 	msgBox.addButton(tr("Start Launcher"), QMessageBox::YesRole);
-	QPushButton * startClient = msgBox.addButton(tr("Start VCMI"), QMessageBox::NoRole);
-	QTimer *timer = new QTimer(this);
-	connect(timer, &QTimer::timeout, this, [&, this](){
+	auto startClient = msgBox.addButton(tr("Start VCMI"), QMessageBox::NoRole);
+	auto timer = new QTimer(this);
+	connect(timer, &QTimer::timeout, this, [&, this, timer](){
 		if(secondsRemaining == 0)
 		{
 			timer->stop();
@@ -143,7 +143,7 @@ void MainWindow::preLauncher()
 			startGame({});
 			return;
 		}
-		setText();
+		msgBox.setText(getText());
 		secondsRemaining--;
 	});
 	timer->start(1000);

--- a/launcher/mainwindow_moc.cpp
+++ b/launcher/mainwindow_moc.cpp
@@ -116,8 +116,40 @@ MainWindow::MainWindow(QWidget * parent)
 
 	ui->settingsView->setDisplayList();
 	
+	if(settings["launcher"]["preLauncher"].Bool())
+		preLauncher();
+
 	if(settings["launcher"]["updateOnStartup"].Bool())
 		UpdateDialog::showUpdateDialog(false);
+}
+
+void MainWindow::preLauncher()
+{
+	QMessageBox msgBox;
+	int secondsRemaining = 10;
+	QString text = tr("How to start?\n\nVCMI starts automatically in ");
+	msgBox.setText(text + QString::number(secondsRemaining) + tr(" Seconds"));
+	msgBox.setWindowTitle(tr("VCMI"));
+	msgBox.setIcon(QMessageBox::Information);
+	msgBox.addButton(tr("Start Launcher"), QMessageBox::YesRole);
+	QPushButton * startClient = msgBox.addButton(tr("Start VCMI"), QMessageBox::NoRole);
+	QTimer *timer = new QTimer(this);
+    connect(timer, &QTimer::timeout, this, [this, &timer, &text, &msgBox, &secondsRemaining](){
+		if(secondsRemaining == 0)
+		{
+			timer->stop();
+			msgBox.close();
+			ui->startGameButton->click();
+			return;
+		}
+		msgBox.setText(text + QString::number(secondsRemaining) + tr(" Seconds"));
+		secondsRemaining--;
+	});
+    timer->start(1000);
+	msgBox.exec();
+	timer->stop();
+	if(msgBox.clickedButton() == startClient && secondsRemaining)
+		ui->startGameButton->click();
 }
 
 void MainWindow::detectPreferredLanguage()

--- a/launcher/mainwindow_moc.cpp
+++ b/launcher/mainwindow_moc.cpp
@@ -116,7 +116,7 @@ MainWindow::MainWindow(QWidget * parent)
 
 	ui->settingsView->setDisplayList();
 	
-	if(settings["launcher"]["preLauncher"].Bool())
+	if(settings["launcher"]["preLauncher"].Bool()) // MessageBox before launcher asking how to start (automatically starts client after 10 seconds)
 		preLauncher();
 
 	if(settings["launcher"]["updateOnStartup"].Bool())
@@ -128,13 +128,14 @@ void MainWindow::preLauncher()
 	QMessageBox msgBox;
 	int secondsRemaining = 10;
 	QString text = tr("How to start?\n\nVCMI starts automatically in ");
-	msgBox.setText(text + QString::number(secondsRemaining) + tr(" Seconds"));
+	QString textSeconds = tr(" Seconds");
+	msgBox.setText(text + QString::number(secondsRemaining) + textSeconds);
 	msgBox.setWindowTitle(tr("VCMI"));
 	msgBox.setIcon(QMessageBox::Information);
 	msgBox.addButton(tr("Start Launcher"), QMessageBox::YesRole);
 	QPushButton * startClient = msgBox.addButton(tr("Start VCMI"), QMessageBox::NoRole);
 	QTimer *timer = new QTimer(this);
-    connect(timer, &QTimer::timeout, this, [this, &timer, &text, &msgBox, &secondsRemaining](){
+	connect(timer, &QTimer::timeout, this, [this, &timer, &text, &textSeconds, &msgBox, &secondsRemaining](){
 		if(secondsRemaining == 0)
 		{
 			timer->stop();
@@ -142,10 +143,10 @@ void MainWindow::preLauncher()
 			ui->startGameButton->click();
 			return;
 		}
-		msgBox.setText(text + QString::number(secondsRemaining) + tr(" Seconds"));
+		msgBox.setText(text + QString::number(secondsRemaining) + textSeconds);
 		secondsRemaining--;
 	});
-    timer->start(1000);
+	timer->start(1000);
 	msgBox.exec();
 	timer->stop();
 	if(msgBox.clickedButton() == startClient && secondsRemaining)

--- a/launcher/mainwindow_moc.cpp
+++ b/launcher/mainwindow_moc.cpp
@@ -127,29 +127,33 @@ void MainWindow::preLauncher()
 {
 	QMessageBox msgBox;
 	int secondsRemaining = 10;
-	auto text = "How to start?\n\nVCMI starts automatically in %n second(s)";
-	msgBox.setText(tr(text, "", secondsRemaining));
-	msgBox.setWindowTitle(tr("VCMI"));
-	msgBox.setIcon(QMessageBox::Information);
+	auto setText = [&](){ msgBox.setText(tr("How to start?\n\nVCMI starts automatically in %n second(s)", "", secondsRemaining)); };
+	setText();
+	msgBox.setWindowTitle("VCMI");
+	msgBox.setIcon(QMessageBox::Question);
 	msgBox.addButton(tr("Start Launcher"), QMessageBox::YesRole);
 	QPushButton * startClient = msgBox.addButton(tr("Start VCMI"), QMessageBox::NoRole);
 	QTimer *timer = new QTimer(this);
-	connect(timer, &QTimer::timeout, this, [this, &timer, &text, &msgBox, &secondsRemaining](){
+	connect(timer, &QTimer::timeout, this, [&, this](){
 		if(secondsRemaining == 0)
 		{
 			timer->stop();
 			msgBox.close();
-			ui->startGameButton->click();
+			hide();
+			startGame({});
 			return;
 		}
-		msgBox.setText(tr(text, "", secondsRemaining));
+		setText();
 		secondsRemaining--;
 	});
 	timer->start(1000);
 	msgBox.exec();
 	timer->stop();
 	if(msgBox.clickedButton() == startClient && secondsRemaining)
-		ui->startGameButton->click();
+	{
+		hide();
+		startGame({});
+	}
 }
 
 void MainWindow::detectPreferredLanguage()

--- a/launcher/mainwindow_moc.cpp
+++ b/launcher/mainwindow_moc.cpp
@@ -116,14 +116,14 @@ MainWindow::MainWindow(QWidget * parent)
 
 	ui->settingsView->setDisplayList();
 	
-	if(settings["launcher"]["preLauncher"].Bool()) // MessageBox before launcher asking how to start (automatically starts client after 10 seconds)
-		preLauncher();
+	if(settings["launcher"]["skipLauncher"].Bool()) // MessageBox before launcher asking how to start (automatically starts client after 10 seconds)
+		skipLauncher();
 
 	if(settings["launcher"]["updateOnStartup"].Bool())
 		UpdateDialog::showUpdateDialog(false);
 }
 
-void MainWindow::preLauncher()
+void MainWindow::skipLauncher()
 {
 	QMessageBox msgBox;
 	int secondsRemaining = 10;
@@ -132,7 +132,7 @@ void MainWindow::preLauncher()
 	msgBox.setWindowTitle("VCMI");
 	msgBox.setIcon(QMessageBox::Question);
 	msgBox.addButton(tr("Start Launcher"), QMessageBox::YesRole);
-	auto startClient = msgBox.addButton(tr("Start VCMI"), QMessageBox::NoRole);
+	auto startClientButton = msgBox.addButton(tr("Start VCMI"), QMessageBox::NoRole);
 	auto timer = new QTimer(this);
 	connect(timer, &QTimer::timeout, this, [&, this, timer](){
 		if(secondsRemaining == 0)
@@ -149,7 +149,7 @@ void MainWindow::preLauncher()
 	timer->start(1000);
 	msgBox.exec();
 	timer->stop();
-	if(msgBox.clickedButton() == startClient && secondsRemaining)
+	if(msgBox.clickedButton() == startClientButton && secondsRemaining)
 	{
 		hide();
 		startGame({});

--- a/launcher/mainwindow_moc.cpp
+++ b/launcher/mainwindow_moc.cpp
@@ -127,15 +127,14 @@ void MainWindow::preLauncher()
 {
 	QMessageBox msgBox;
 	int secondsRemaining = 10;
-	QString text = tr("How to start?\n\nVCMI starts automatically in ");
-	QString textSeconds = tr(" Seconds");
-	msgBox.setText(text + QString::number(secondsRemaining) + textSeconds);
+	auto text = "How to start?\n\nVCMI starts automatically in %n second(s)";
+	msgBox.setText(tr(text, "", secondsRemaining));
 	msgBox.setWindowTitle(tr("VCMI"));
 	msgBox.setIcon(QMessageBox::Information);
 	msgBox.addButton(tr("Start Launcher"), QMessageBox::YesRole);
 	QPushButton * startClient = msgBox.addButton(tr("Start VCMI"), QMessageBox::NoRole);
 	QTimer *timer = new QTimer(this);
-	connect(timer, &QTimer::timeout, this, [this, &timer, &text, &textSeconds, &msgBox, &secondsRemaining](){
+	connect(timer, &QTimer::timeout, this, [this, &timer, &text, &msgBox, &secondsRemaining](){
 		if(secondsRemaining == 0)
 		{
 			timer->stop();
@@ -143,7 +142,7 @@ void MainWindow::preLauncher()
 			ui->startGameButton->click();
 			return;
 		}
-		msgBox.setText(text + QString::number(secondsRemaining) + textSeconds);
+		msgBox.setText(tr(text, "", secondsRemaining));
 		secondsRemaining--;
 	});
 	timer->start(1000);

--- a/launcher/mainwindow_moc.h
+++ b/launcher/mainwindow_moc.h
@@ -33,6 +33,7 @@ class MainWindow : public QMainWindow
 	Ui::MainWindow * ui;
 
 	void load();
+	void preLauncher();
 
 	enum TabRows
 	{

--- a/launcher/mainwindow_moc.h
+++ b/launcher/mainwindow_moc.h
@@ -33,7 +33,7 @@ class MainWindow : public QMainWindow
 	Ui::MainWindow * ui;
 
 	void load();
-	void preLauncher();
+	void skipLauncher();
 
 	enum TabRows
 	{

--- a/launcher/settingsView/csettingsview_moc.cpp
+++ b/launcher/settingsView/csettingsview_moc.cpp
@@ -214,7 +214,12 @@ void CSettingsView::loadToggleButtonSettings()
 	setCheckbuttonState(ui->buttonRelativeCursorMode, settings["general"]["userRelativePointer"].Bool());
 	setCheckbuttonState(ui->buttonHapticFeedback, settings["general"]["hapticFeedback"].Bool());
 
+#ifdef ENABLE_SKIP_LAUNCHER
 	setCheckbuttonState(ui->buttonSkipLauncher, settings["launcher"]["skipLauncher"].Bool());
+#else
+	ui->buttonSkipLauncher->setVisible(false);
+	ui->labelSkipLauncher->setVisible(false);
+#endif
 
 	std::string cursorType = settings["video"]["cursor"].String();
 	int cursorTypeIndex = vstd::find_pos(cursorTypesList, cursorType);

--- a/launcher/settingsView/csettingsview_moc.cpp
+++ b/launcher/settingsView/csettingsview_moc.cpp
@@ -214,7 +214,7 @@ void CSettingsView::loadToggleButtonSettings()
 	setCheckbuttonState(ui->buttonRelativeCursorMode, settings["general"]["userRelativePointer"].Bool());
 	setCheckbuttonState(ui->buttonHapticFeedback, settings["general"]["hapticFeedback"].Bool());
 
-	setCheckbuttonState(ui->buttonPreLauncher, settings["launcher"]["preLauncher"].Bool());
+	setCheckbuttonState(ui->buttonSkipLauncher, settings["launcher"]["skipLauncher"].Bool());
 
 	std::string cursorType = settings["video"]["cursor"].String();
 	int cursorTypeIndex = vstd::find_pos(cursorTypesList, cursorType);
@@ -854,10 +854,10 @@ void CSettingsView::on_buttonScalingAuto_toggled(bool checked)
 	node->Integer() = checked ? 0 : 100;
 }
 
-void CSettingsView::on_buttonPreLauncher_clicked(bool checked)
+void CSettingsView::on_buttonSkipLauncher_clicked(bool checked)
 {
-	Settings node = settings.write["launcher"]["preLauncher"];
+	Settings node = settings.write["launcher"]["skipLauncher"];
 	node->Bool() = checked;
-	updateCheckbuttonText(ui->buttonPreLauncher);
+	updateCheckbuttonText(ui->buttonSkipLauncher);
 }
 

--- a/launcher/settingsView/csettingsview_moc.cpp
+++ b/launcher/settingsView/csettingsview_moc.cpp
@@ -214,6 +214,8 @@ void CSettingsView::loadToggleButtonSettings()
 	setCheckbuttonState(ui->buttonRelativeCursorMode, settings["general"]["userRelativePointer"].Bool());
 	setCheckbuttonState(ui->buttonHapticFeedback, settings["general"]["hapticFeedback"].Bool());
 
+	setCheckbuttonState(ui->buttonPreLauncher, settings["launcher"]["preLauncher"].Bool());
+
 	std::string cursorType = settings["video"]["cursor"].String();
 	int cursorTypeIndex = vstd::find_pos(cursorTypesList, cursorType);
 	setCheckbuttonState(ui->buttonCursorType, cursorTypeIndex);
@@ -850,5 +852,12 @@ void CSettingsView::on_buttonScalingAuto_toggled(bool checked)
 	
 	Settings node = settings.write["video"]["resolution"]["scaling"];
 	node->Integer() = checked ? 0 : 100;
+}
+
+void CSettingsView::on_buttonPreLauncher_clicked(bool checked)
+{
+	Settings node = settings.write["launcher"]["preLauncher"];
+	node->Bool() = checked;
+	updateCheckbuttonText(ui->buttonPreLauncher);
 }
 

--- a/launcher/settingsView/csettingsview_moc.h
+++ b/launcher/settingsView/csettingsview_moc.h
@@ -89,7 +89,7 @@ private slots:
 	void on_buttonFontAuto_clicked(bool checked);
 	void on_buttonFontScalable_clicked(bool checked);
 	void on_buttonFontOriginal_clicked(bool checked);
-	void on_buttonPreLauncher_clicked(bool checked);
+	void on_buttonSkipLauncher_clicked(bool checked);
 
 
 	void on_buttonValidationOff_clicked(bool checked);

--- a/launcher/settingsView/csettingsview_moc.h
+++ b/launcher/settingsView/csettingsview_moc.h
@@ -89,6 +89,7 @@ private slots:
 	void on_buttonFontAuto_clicked(bool checked);
 	void on_buttonFontScalable_clicked(bool checked);
 	void on_buttonFontOriginal_clicked(bool checked);
+	void on_buttonPreLauncher_clicked(bool checked);
 
 
 	void on_buttonValidationOff_clicked(bool checked);

--- a/launcher/settingsView/csettingsview_moc.ui
+++ b/launcher/settingsView/csettingsview_moc.ui
@@ -1449,6 +1449,35 @@ Fullscreen Exclusive Mode - game will cover entirety of your screen and will use
          </attribute>
         </widget>
        </item>
+       <item row="61" column="0">
+        <widget class="QLabel" name="labelPreLauncher">
+         <property name="text">
+          <string>Prelauncher</string>
+         </property>
+        </widget>
+       </item>
+       <item row="61" column="1" colspan="5">
+        <widget class="QToolButton" name="buttonPreLauncher">
+         <property name="enabled">
+          <bool>true</bool>
+         </property>
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+         <property name="checked">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
       </layout>
      </widget>
     </widget>

--- a/launcher/settingsView/csettingsview_moc.ui
+++ b/launcher/settingsView/csettingsview_moc.ui
@@ -1450,14 +1450,14 @@ Fullscreen Exclusive Mode - game will cover entirety of your screen and will use
         </widget>
        </item>
        <item row="61" column="0">
-        <widget class="QLabel" name="labelPreLauncher">
+        <widget class="QLabel" name="labelSkipLauncher">
          <property name="text">
           <string>Skip Launcher on start</string>
          </property>
         </widget>
        </item>
        <item row="61" column="1" colspan="5">
-        <widget class="QToolButton" name="buttonPreLauncher">
+        <widget class="QToolButton" name="buttonSkipLauncher">
          <property name="enabled">
           <bool>true</bool>
          </property>

--- a/launcher/settingsView/csettingsview_moc.ui
+++ b/launcher/settingsView/csettingsview_moc.ui
@@ -1452,7 +1452,7 @@ Fullscreen Exclusive Mode - game will cover entirety of your screen and will use
        <item row="61" column="0">
         <widget class="QLabel" name="labelPreLauncher">
          <property name="text">
-          <string>Prelauncher</string>
+          <string>Skip Launcher on start</string>
          </property>
         </widget>
        </item>


### PR DESCRIPTION
- Optional (enable setting in launcher options)
- Mainly to fix issue that android gamepad user needs to use mouse just for launching VCMI every time
  - now mouse is only needed for first launch and settings/mod-managment, but not for starting (if prelauncher is enabled)

Related: #4111 

![grafik](https://github.com/user-attachments/assets/5165582a-3007-460d-befd-7dfad6c24ff4)
