### PR TITLE
prism attack fix

### DIFF
--- a/lib/battle/CBattleInfoCallback.cpp
+++ b/lib/battle/CBattleInfoCallback.cpp
@@ -1424,7 +1424,7 @@ AttackableTiles CBattleInfoCallback::getPotentiallyAttackableHexes(
 				{
 					//friendly stacks can also be damaged by Dragon Breath
 					const auto * st = battleGetUnitByPos(nextHex, true);
-					if(st != nullptr)
+					if(st != nullptr && st != attacker) //but not unit itself (doublewide + prism attack)
 						at.friendlyCreaturePositions.insert(nextHex);
 				}
 			}


### PR DESCRIPTION
Now doublewide doesn't damage itself.

Requested by @by003