### PR TITLE
Fix Orrin as starting hero on some maps

### DIFF
--- a/lib/gameState/CGameState.cpp
+++ b/lib/gameState/CGameState.cpp
@@ -62,7 +62,7 @@ boost::shared_mutex CGameState::mutex;
 HeroTypeID CGameState::pickNextHeroType(const PlayerColor & owner)
 {
 	const PlayerSettings &ps = scenarioOps->getIthPlayersSettings(owner);
-	if(ps.hero >= HeroTypeID(0) && !isUsedHero(HeroTypeID(ps.hero))) //we haven't used selected hero
+	if(ps.hero.isValid() && !isUsedHero(HeroTypeID(ps.hero))) //we haven't used selected hero
 	{
 		return HeroTypeID(ps.hero);
 	}

--- a/lib/mapObjects/CGHeroInstance.cpp
+++ b/lib/mapObjects/CGHeroInstance.cpp
@@ -661,8 +661,10 @@ void CGHeroInstance::pickRandomObject(vstd::RNG & rand)
 
 	if (ID == Obj::RANDOM_HERO)
 	{
+		auto selectedHero = cb->gameState()->pickNextHeroType(getOwner());
+
 		ID = Obj::HERO;
-		subID = cb->gameState()->pickNextHeroType(getOwner());
+		subID = selectedHero;
 		randomizeArmy(getHeroClass()->faction);
 	}
 


### PR DESCRIPTION
Fixes a bug that led to Orrin being replaced with a different randomly selected hero on maps where starting hero is not generated in town, but pre-placed on map

- Fixes #4886