### PR TITLE
Random map gen com only player count fix

### DIFF
--- a/client/lobby/RandomMapTab.cpp
+++ b/client/lobby/RandomMapTab.cpp
@@ -263,7 +263,7 @@ void RandomMapTab::setMapGenOptions(std::shared_ptr<CMapGenOptions> opts)
 		humanCountAllowed = tmpl->getHumanPlayers().getNumbers(); // Unused now?
 	}
 	
-	si8 playerLimit = opts->getMaxPlayersCount();
+	si8 playerLimit = opts->getPlayerLimit();
 	si8 humanOrCpuPlayerCount = opts->getHumanOrCpuPlayerCount();
 	si8 compOnlyPlayersCount = opts->getCompOnlyPlayerCount();
 

--- a/lib/rmg/CMapGenOptions.cpp
+++ b/lib/rmg/CMapGenOptions.cpp
@@ -124,7 +124,17 @@ si8 CMapGenOptions::getMinPlayersCount(bool withTemplateLimit) const
 si8 CMapGenOptions::getMaxPlayersCount(bool withTemplateLimit) const
 {
 	// Max number of players possible with current settings
-	auto totalPlayers = PlayerColor::PLAYER_LIMIT_I;
+	auto totalPlayers = 0;
+	si8 humans = getHumanOrCpuPlayerCount();
+	si8 cpus = getCompOnlyPlayerCount();
+	if (humans == RANDOM_SIZE || cpus == RANDOM_SIZE)
+	{
+		totalPlayers = PlayerColor::PLAYER_LIMIT_I;
+	}
+	else
+	{
+		totalPlayers = humans + cpus;
+	}
 
 	if (withTemplateLimit && mapTemplate)
 	{

--- a/lib/rmg/CMapGenOptions.cpp
+++ b/lib/rmg/CMapGenOptions.cpp
@@ -124,17 +124,7 @@ si8 CMapGenOptions::getMinPlayersCount(bool withTemplateLimit) const
 si8 CMapGenOptions::getMaxPlayersCount(bool withTemplateLimit) const
 {
 	// Max number of players possible with current settings
-	auto totalPlayers = 0;
-	si8 humans = getHumanOrCpuPlayerCount();
-	si8 cpus = getCompOnlyPlayerCount();
-	if (humans == RANDOM_SIZE || cpus == RANDOM_SIZE)
-	{
-		totalPlayers = PlayerColor::PLAYER_LIMIT_I;
-	}
-	else
-	{
-		totalPlayers = humans + cpus;
-	}
+	auto totalPlayers = PlayerColor::PLAYER_LIMIT_I;
 
 	if (withTemplateLimit && mapTemplate)
 	{


### PR DESCRIPTION
This should fix the issue #4881 

Current code sets player limit using the sum of "human or com player" and "com only player" atm, which causes higher com player count buttons to be disabled later. Change that to actual player limit - either 8 or whatever is set in the current template. 