### PR TITLE
crash fix: dismiss hero when pick artifact

### DIFF
--- a/client/widgets/CArtifactsOfHeroBase.cpp
+++ b/client/widgets/CArtifactsOfHeroBase.cpp
@@ -140,6 +140,8 @@ void CArtifactsOfHeroBase::gestureArtPlace(CComponentHolder & artPlace, const Po
 void CArtifactsOfHeroBase::setHero(const CGHeroInstance * hero)
 {
 	curHero = hero;
+	if (!hero)
+		return;
 
 	for(auto slot : artWorn)
 	{

--- a/client/widgets/CArtifactsOfHeroMain.cpp
+++ b/client/widgets/CArtifactsOfHeroMain.cpp
@@ -28,7 +28,8 @@ CArtifactsOfHeroMain::CArtifactsOfHeroMain(const Point & position)
 
 CArtifactsOfHeroMain::~CArtifactsOfHeroMain()
 {
-	CArtifactsOfHeroBase::putBackPickedArtifact();
+	if(curHero)
+		CArtifactsOfHeroBase::putBackPickedArtifact();
 }
 
 void CArtifactsOfHeroMain::keyPressed(EShortcut key)

--- a/client/windows/CHeroWindow.cpp
+++ b/client/windows/CHeroWindow.cpp
@@ -312,6 +312,7 @@ void CHeroWindow::dismissCurrent()
 			arts->putBackPickedArtifact();
 			close();
 			LOCPLINT->cb->dismissHero(curHero);
+			arts->setHero(nullptr);
 		}, nullptr);
 }
 


### PR DESCRIPTION
when an artifacts is picked, client send ExchangeArtifacts twice: one is in showYesNoDialog function, the other is in ~CArtifactsOfHeroMain(). this change make sure that ~CArtifactsOfHeroMain() not send it when hero is dismissed.