### PR TITLE
Fix freeze on closing server before starting the game

### DIFF
--- a/server/CVCMIServer.cpp
+++ b/server/CVCMIServer.cpp
@@ -300,7 +300,7 @@ void CVCMIServer::onDisconnected(const std::shared_ptr<INetworkConnection> & con
 	std::shared_ptr<CConnection> c = findConnection(connection);
 
 	// player may have already disconnected via clientDisconnected call
-	if (c && gh && getState() == EServerState::GAMEPLAY)
+	if (c)
 	{
 		LobbyClientDisconnected lcd;
 		lcd.c = c;


### PR DESCRIPTION
Fixes possible freeze that seems to be caused by client shutting down socket before sending its final LobbyClientDisconnected packet, leading to server not processing disconnection of host correctly, which in turn causes client to wait server shutdown forever.

Looks like regression from #4722

- Fixes #4912 and its duplicates