### PR TITLE
Enable AI to use all Hill Fort upgrades, including alternative ones

### DIFF
--- a/AI/Nullkiller/AIGateway.cpp
+++ b/AI/Nullkiller/AIGateway.cpp
@@ -19,6 +19,7 @@
 #include "../../lib/CConfigHandler.h"
 #include "../../lib/IGameSettings.h"
 #include "../../lib/gameState/CGameState.h"
+#include "../../lib/gameState/UpgradeInfo.h"
 #include "../../lib/serializer/CTypeList.h"
 #include "../../lib/networkPacks/PacksForClient.h"
 #include "../../lib/networkPacks/PacksForClientBattle.h"
@@ -805,7 +806,7 @@ bool AIGateway::makePossibleUpgrades(const CArmedInstance * obj)
 						myCb->upgradeCreature(obj, SlotID(i), upgID);
 						upgraded = true;
 						logAi->debug("Upgraded %d %s to %s", s->count, upgradeInfo.oldID.toCreature()->getNamePluralTranslated(), 
-							upgradeInfo.getNextUpgrade().toCreature()->getNamePluralTranslated());
+							upgradeInfo.getUpgrade().toCreature()->getNamePluralTranslated());
 					}
 					else
 						break;

--- a/AI/Nullkiller/AIGateway.cpp
+++ b/AI/Nullkiller/AIGateway.cpp
@@ -788,29 +788,30 @@ bool AIGateway::makePossibleUpgrades(const CArmedInstance * obj)
 	{
 		if(const CStackInstance * s = obj->getStackPtr(SlotID(i)))
 		{
-			UpgradeInfo ui(s->getId());
+			UpgradeInfo upgradeInfo(s->getId());
 			do
 			{
-				myCb->fillUpgradeInfo(obj, SlotID(i), ui);
+				myCb->fillUpgradeInfo(obj, SlotID(i), upgradeInfo);
 
-				if(ui.hasUpgrades())
+				if(upgradeInfo.hasUpgrades())
 				{
 					// creature at given slot might have alternative upgrades, pick best one
-					CreatureID upgID = *vstd::maxElementByFun(ui.getAvailableUpgrades(), [](const CreatureID & id)
+					CreatureID upgID = *vstd::maxElementByFun(upgradeInfo.getAvailableUpgrades(), [](const CreatureID & id)
 						{
 							return id.toCreature()->getAIValue();
 						});
-					if(nullkiller->getFreeResources().canAfford(ui.getUpgradeCostsFor(upgID) * s->count))
+					if(nullkiller->getFreeResources().canAfford(upgradeInfo.getUpgradeCostsFor(upgID) * s->count))
 					{
 						myCb->upgradeCreature(obj, SlotID(i), upgID);
 						upgraded = true;
-						logAi->debug("Upgraded %d %s to %s", s->count, ui.oldID.toCreature()->getNamePluralTranslated(), ui.getNextUpgrade().toCreature()->getNamePluralTranslated());
+						logAi->debug("Upgraded %d %s to %s", s->count, upgradeInfo.oldID.toCreature()->getNamePluralTranslated(), 
+							upgradeInfo.getNextUpgrade().toCreature()->getNamePluralTranslated());
 					}
 					else
 						break;
 				}
 			}
-			while(ui.hasUpgrades());
+			while(upgradeInfo.hasUpgrades());
 		}
 	}
 

--- a/AI/VCAI/VCAI.cpp
+++ b/AI/VCAI/VCAI.cpp
@@ -22,6 +22,7 @@
 #include "../../lib/CConfigHandler.h"
 #include "../../lib/IGameSettings.h"
 #include "../../lib/gameState/CGameState.h"
+#include "../../lib/gameState/UpgradeInfo.h"
 #include "../../lib/bonuses/Limiters.h"
 #include "../../lib/bonuses/Updaters.h"
 #include "../../lib/bonuses/Propagators.h"
@@ -770,7 +771,7 @@ void makePossibleUpgrades(const CArmedInstance * obj)
 					{
 						cb->upgradeCreature(obj, SlotID(i), upgID);
 						logAi->debug("Upgraded %d %s to %s", s->count, upgradeInfo.oldID.toCreature()->getNamePluralTranslated(), 
-							upgradeInfo.getNextUpgrade().toCreature()->getNamePluralTranslated());
+							upgradeInfo.getUpgrade().toCreature()->getNamePluralTranslated());
 					}
 					else
 						break;

--- a/AI/VCAI/VCAI.cpp
+++ b/AI/VCAI/VCAI.cpp
@@ -754,28 +754,29 @@ void makePossibleUpgrades(const CArmedInstance * obj)
 	{
 		if(const CStackInstance * s = obj->getStackPtr(SlotID(i)))
 		{
-			UpgradeInfo ui(s->getId());
+			UpgradeInfo upgradeInfo(s->getId());
 			do
 			{
-				cb->fillUpgradeInfo(obj, SlotID(i), ui);
+				cb->fillUpgradeInfo(obj, SlotID(i), upgradeInfo);
 
-				if(ui.hasUpgrades())
+				if(upgradeInfo.hasUpgrades())
 				{
 					// creature at given slot might have alternative upgrades, pick best one
-					CreatureID upgID = *vstd::maxElementByFun(ui.getAvailableUpgrades(), [](const CreatureID & id)
+					CreatureID upgID = *vstd::maxElementByFun(upgradeInfo.getAvailableUpgrades(), [](const CreatureID & id)
 						{
 							return id.toCreature()->getAIValue();
 						});
-					if(cb->getResourceAmount().canAfford(ui.getUpgradeCostsFor(upgID) * s->count))
+					if(cb->getResourceAmount().canAfford(upgradeInfo.getUpgradeCostsFor(upgID) * s->count))
 					{
 						cb->upgradeCreature(obj, SlotID(i), upgID);
-						logAi->debug("Upgraded %d %s to %s", s->count, ui.oldID.toCreature()->getNamePluralTranslated(), ui.getNextUpgrade().toCreature()->getNamePluralTranslated());
+						logAi->debug("Upgraded %d %s to %s", s->count, upgradeInfo.oldID.toCreature()->getNamePluralTranslated(), 
+							upgradeInfo.getNextUpgrade().toCreature()->getNamePluralTranslated());
 					}
 					else
 						break;
 				}
 			}
-			while(ui.hasUpgrades());
+			while(upgradeInfo.hasUpgrades());
 		}
 	}
 }

--- a/client/CPlayerInterface.h
+++ b/client/CPlayerInterface.h
@@ -24,7 +24,7 @@ class CCreature;
 struct CGPath;
 class CCreatureSet;
 class CGObjectInstance;
-struct UpgradeInfo;
+class UpgradeInfo;
 class ConditionalWait;
 struct CPathsInfo;
 

--- a/client/widgets/CGarrisonInt.cpp
+++ b/client/widgets/CGarrisonInt.cpp
@@ -33,6 +33,7 @@
 #include "../../lib/mapObjects/CGHeroInstance.h"
 #include "../../lib/networkPacks/ArtifactLocation.h"
 #include "../../lib/gameState/CGameState.h"
+#include "../../lib/gameState/UpgradeInfo.h"
 
 void CGarrisonSlot::setHighlight(bool on)
 {

--- a/client/widgets/CGarrisonInt.cpp
+++ b/client/widgets/CGarrisonInt.cpp
@@ -162,10 +162,10 @@ std::function<void()> CGarrisonSlot::getDismiss() const
 /// @return Whether the view should be refreshed
 bool CGarrisonSlot::viewInfo()
 {
-	UpgradeInfo pom;
+	UpgradeInfo pom(ID.getNum());
 	LOCPLINT->cb->fillUpgradeInfo(getObj(), ID, pom);
 
-	bool canUpgrade = getObj()->tempOwner == LOCPLINT->playerID && pom.oldID != CreatureID::NONE; //upgrade is possible
+	bool canUpgrade = getObj()->tempOwner == LOCPLINT->playerID && pom.canUpgrade(); //upgrade is possible
 	std::function<void(CreatureID)> upgr = nullptr;
 	auto dism = getDismiss();
 	if(canUpgrade) upgr = [=] (CreatureID newID) { LOCPLINT->cb->upgradeCreature(getObj(), ID, newID); };
@@ -177,7 +177,7 @@ bool CGarrisonSlot::viewInfo()
 		elem->block(true);
 
 	redraw();
-	GH.windows().createAndPushWindow<CStackWindow>(myStack, dism, pom, upgr);
+	GH.windows().createAndPushWindow<CStackWindow>(myStack, dism, std::move(pom), upgr);
 	return true;
 }
 

--- a/client/widgets/CGarrisonInt.cpp
+++ b/client/widgets/CGarrisonInt.cpp
@@ -177,7 +177,7 @@ bool CGarrisonSlot::viewInfo()
 		elem->block(true);
 
 	redraw();
-	GH.windows().createAndPushWindow<CStackWindow>(myStack, dism, std::move(pom), upgr);
+	GH.windows().createAndPushWindow<CStackWindow>(myStack, dism, pom, upgr);
 	return true;
 }
 

--- a/client/windows/CCreatureWindow.cpp
+++ b/client/windows/CCreatureWindow.cpp
@@ -35,6 +35,7 @@
 #include "../../lib/IGameSettings.h"
 #include "../../lib/entities/hero/CHeroHandler.h"
 #include "../../lib/gameState/CGameState.h"
+#include "../../lib/gameState/UpgradeInfo.h"
 #include "../../lib/networkPacks/ArtifactLocation.h"
 #include "../../lib/texts/CGeneralTextHandler.h"
 #include "../../lib/texts/TextOperations.h"
@@ -363,7 +364,7 @@ CStackWindow::ButtonsSection::ButtonsSection(CStackWindow * owner, int yOffset)
 
 		for(size_t buttonIndex = 0; buttonIndex < buttonsToCreate; buttonIndex++)
 		{
-			TResources totalCost = upgradeInfo.info.getUpgradeCosts().at(buttonIndex) * parent->info->creatureCount;
+			TResources totalCost = upgradeInfo.info.getAvailableUpgradeCosts().at(buttonIndex) * parent->info->creatureCount;
 
 			auto onUpgrade = [=]()
 			{

--- a/client/windows/CCreatureWindow.cpp
+++ b/client/windows/CCreatureWindow.cpp
@@ -58,8 +58,8 @@ public:
 	struct StackUpgradeInfo
 	{
 		StackUpgradeInfo() = delete;
-		StackUpgradeInfo(UpgradeInfo && upgradeInfo)
-			: info(std::move(upgradeInfo))
+		StackUpgradeInfo(const UpgradeInfo & upgradeInfo)
+			: info(upgradeInfo)
 		{ }
 		UpgradeInfo info;
 		std::function<void(CreatureID)> callback;
@@ -759,7 +759,7 @@ CStackWindow::CStackWindow(const CStackInstance * stack, bool popup)
 	init();
 }
 
-CStackWindow::CStackWindow(const CStackInstance * stack, std::function<void()> dismiss, UpgradeInfo && upgradeInfo, std::function<void(CreatureID)> callback)
+CStackWindow::CStackWindow(const CStackInstance * stack, std::function<void()> dismiss, const UpgradeInfo & upgradeInfo, std::function<void(CreatureID)> callback)
 	: CWindowObject(BORDERED),
 	info(new UnitView())
 {
@@ -767,7 +767,7 @@ CStackWindow::CStackWindow(const CStackInstance * stack, std::function<void()> d
 	info->creature = stack->getCreature();
 	info->creatureCount = stack->count;
 
-	info->upgradeInfo = std::make_optional(UnitView::StackUpgradeInfo(std::move(upgradeInfo)));
+	info->upgradeInfo = std::make_optional(UnitView::StackUpgradeInfo(upgradeInfo));
 	info->dismissInfo = std::make_optional(UnitView::StackDismissInfo());
 	info->upgradeInfo->callback = callback;
 	info->dismissInfo->callback = dismiss;

--- a/client/windows/CCreatureWindow.h
+++ b/client/windows/CCreatureWindow.h
@@ -19,7 +19,7 @@ VCMI_LIB_NAMESPACE_BEGIN
 class CCommanderInstance;
 class CStackInstance;
 class CStack;
-struct UpgradeInfo;
+class UpgradeInfo;
 
 VCMI_LIB_NAMESPACE_END
 
@@ -204,7 +204,7 @@ public:
 
 	// for normal stacks in armies
 	CStackWindow(const CStackInstance * stack, bool popup);
-	CStackWindow(const CStackInstance * stack, std::function<void()> dismiss, const UpgradeInfo & info, std::function<void(CreatureID)> callback);
+	CStackWindow(const CStackInstance * stack, std::function<void()> dismiss, UpgradeInfo && info, std::function<void(CreatureID)> callback);
 
 	// for commanders & commander level-up dialog
 	CStackWindow(const CCommanderInstance * commander, bool popup);

--- a/client/windows/CCreatureWindow.h
+++ b/client/windows/CCreatureWindow.h
@@ -204,7 +204,7 @@ public:
 
 	// for normal stacks in armies
 	CStackWindow(const CStackInstance * stack, bool popup);
-	CStackWindow(const CStackInstance * stack, std::function<void()> dismiss, UpgradeInfo && info, std::function<void(CreatureID)> callback);
+	CStackWindow(const CStackInstance * stack, std::function<void()> dismiss, const UpgradeInfo & info, std::function<void(CreatureID)> callback);
 
 	// for commanders & commander level-up dialog
 	CStackWindow(const CCommanderInstance * commander, bool popup);

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -1153,12 +1153,15 @@ void CHillFortWindow::updateGarrisons()
 		State newState = getState(SlotID(i));
 		if(newState != State::EMPTY)
 		{
-			UpgradeInfo info;
-			LOCPLINT->cb->fillUpgradeInfo(hero, SlotID(i), info);
-			if(info.newID.size())//we have upgrades here - update costs
+			if(const CStackInstance * s = hero->getStackPtr(SlotID(i)))
 			{
-				costs[i] = info.cost.back() * hero->getStackCount(SlotID(i));
-				totalSum += costs[i];
+				UpgradeInfo info(s->getCreature()->getId());
+				LOCPLINT->cb->fillUpgradeInfo(hero, SlotID(i), info);
+				if(info.canUpgrade())	//we have upgrades here - update costs
+				{
+					costs[i] = info.getNextUpgradeCosts() * hero->getStackCount(SlotID(i));
+					totalSum += costs[i];
+				}
 			}
 		}
 
@@ -1264,9 +1267,12 @@ void CHillFortWindow::makeDeal(SlotID slot)
 			{
 				if(slot.getNum() == i || ( slot.getNum() == slotsCount && currState[i] == State::MAKE_UPGRADE ))//this is activated slot or "upgrade all"
 				{
-					UpgradeInfo info;
-					LOCPLINT->cb->fillUpgradeInfo(hero, SlotID(i), info);
-					LOCPLINT->cb->upgradeCreature(hero, SlotID(i), info.newID.back());
+					if(const CStackInstance * s = hero->getStackPtr(SlotID(i)))
+					{
+						UpgradeInfo info(s->getCreatureID());
+						LOCPLINT->cb->fillUpgradeInfo(hero, SlotID(i), info);
+						LOCPLINT->cb->upgradeCreature(hero, SlotID(i), info.getNextUpgrade());
+					}
 				}
 			}
 			break;
@@ -1295,18 +1301,15 @@ CHillFortWindow::State CHillFortWindow::getState(SlotID slot)
 	if(hero->slotEmpty(slot))
 		return State::EMPTY;
 
-	UpgradeInfo info;
+	UpgradeInfo info(hero->getStackPtr(slot)->getCreatureID());
 	LOCPLINT->cb->fillUpgradeInfo(hero, slot, info);
-	if (info.newID.empty())
-	{
-		// Hill Fort may limit level of upgradeable creatures, e.g. mini Hill Fort from HOTA
-		if (hero->getCreature(slot)->hasUpgrades())
-			return State::UNAVAILABLE;
+	if(info.hasUpgrades() && !info.canUpgrade())
+		return State::UNAVAILABLE;  // Hill Fort may limit level of upgradeable creatures, e.g. mini Hill Fort from HOTA
 
+	if(!info.hasUpgrades())
 		return State::ALREADY_UPGRADED;
-	}
 
-	if(!(info.cost.back() * hero->getStackCount(slot)).canBeAfforded(myRes))
+	if(!(info.getNextUpgradeCosts() * hero->getStackCount(slot)).canBeAfforded(myRes))
 		return State::UNAFFORDABLE;
 
 	return State::MAKE_UPGRADE;

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -53,6 +53,7 @@
 #include "../lib/gameState/CGameState.h"
 #include "../lib/gameState/SThievesGuildInfo.h"
 #include "../lib/gameState/TavernHeroesPool.h"
+#include "../lib/gameState/UpgradeInfo.h"
 #include "../lib/texts/CGeneralTextHandler.h"
 #include "../lib/IGameSettings.h"
 #include "ConditionalWait.h"
@@ -1159,7 +1160,7 @@ void CHillFortWindow::updateGarrisons()
 				LOCPLINT->cb->fillUpgradeInfo(hero, SlotID(i), info);
 				if(info.canUpgrade())	//we have upgrades here - update costs
 				{
-					costs[i] = info.getNextUpgradeCosts() * hero->getStackCount(SlotID(i));
+					costs[i] = info.getUpgradeCosts() * hero->getStackCount(SlotID(i));
 					totalSum += costs[i];
 				}
 			}
@@ -1271,7 +1272,7 @@ void CHillFortWindow::makeDeal(SlotID slot)
 					{
 						UpgradeInfo info(s->getCreatureID());
 						LOCPLINT->cb->fillUpgradeInfo(hero, SlotID(i), info);
-						LOCPLINT->cb->upgradeCreature(hero, SlotID(i), info.getNextUpgrade());
+						LOCPLINT->cb->upgradeCreature(hero, SlotID(i), info.getUpgrade());
 					}
 				}
 			}
@@ -1309,7 +1310,7 @@ CHillFortWindow::State CHillFortWindow::getState(SlotID slot)
 	if(!info.hasUpgrades())
 		return State::ALREADY_UPGRADED;
 
-	if(!(info.getNextUpgradeCosts() * hero->getStackCount(slot)).canBeAfforded(myRes))
+	if(!(info.getUpgradeCosts() * hero->getStackCount(slot)).canBeAfforded(myRes))
 		return State::UNAFFORDABLE;
 
 	return State::MAKE_UPGRADE;

--- a/lib/CGameInfoCallback.cpp
+++ b/lib/CGameInfoCallback.cpp
@@ -183,7 +183,7 @@ const IMarket * CGameInfoCallback::getMarket(ObjectInstanceID objid) const
 		return nullptr;
 }
 
-void CGameInfoCallback::fillUpgradeInfo(const CArmedInstance *obj, SlotID stackPos, UpgradeInfo &out) const
+void CGameInfoCallback::fillUpgradeInfo(const CArmedInstance *obj, SlotID stackPos, UpgradeInfo & out) const
 {
 	//boost::shared_lock<boost::shared_mutex> lock(*gs->mx);
 	ERROR_RET_IF(!canGetFullInfo(obj), "Cannot get info about not owned object!");

--- a/lib/CGameInfoCallback.h
+++ b/lib/CGameInfoCallback.h
@@ -33,7 +33,7 @@ struct CPathsInfo;
 struct InfoAboutHero;
 struct InfoAboutTown;
 
-struct UpgradeInfo;
+class UpgradeInfo;
 struct SThievesGuildInfo;
 class CMapHeader;
 struct TeamState;
@@ -172,7 +172,7 @@ public:
 
 
 	//armed object
-	virtual void fillUpgradeInfo(const CArmedInstance *obj, SlotID stackPos, UpgradeInfo &out)const;
+	virtual void fillUpgradeInfo(const CArmedInstance *obj, SlotID stackPos, UpgradeInfo &out) const;
 
 	//hero
 	const CGHeroInstance * getHero(ObjectInstanceID objid) const override;

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -109,6 +109,7 @@ set(lib_MAIN_SRCS
 	gameState/RumorState.cpp
 	gameState/TavernHeroesPool.cpp
 	gameState/GameStatistics.cpp
+	gameState/UpgradeInfo.cpp
 
 	mapObjectConstructors/AObjectTypeHandler.cpp
 	mapObjectConstructors/CBankInstanceConstructor.cpp

--- a/lib/gameState/CGameState.cpp
+++ b/lib/gameState/CGameState.cpp
@@ -1779,11 +1779,12 @@ ArtifactID CGameState::pickRandomArtifact(vstd::RNG & rand, int flags)
 	return pickRandomArtifact(rand, flags, [](const ArtifactID &) { return true; });
 }
 
-void UpgradeInfo::addUpgrade(const CreatureID & upgradeID, ResourceSet && upgradeCost, bool available)
+void UpgradeInfo::addUpgrade(const CreatureID & upgradeID, const Creature * creature, int costModifier)
 {
-	isAvailable = available;
+	isAvailable = costModifier >= 0;
 	upgradesIDs.push_back(upgradeID);
 	
+	ResourceSet upgradeCost = (upgradeID.toCreature()->getFullRecruitCost() - creature->getFullRecruitCost()) * costModifier / 100;
 	upgradeCost.positive(); //upgrade cost can't be negative, ignore missing resources
 	upgradesCosts.push_back(std::move(upgradeCost));
 

--- a/lib/gameState/CGameState.cpp
+++ b/lib/gameState/CGameState.cpp
@@ -52,6 +52,7 @@
 #include "../rmg/CMapGenerator.h"
 #include "../serializer/CMemorySerializer.h"
 #include "../spells/CSpellHandler.h"
+#include "UpgradeInfo.h"
 
 #include <vstd/RNG.h>
 
@@ -1777,25 +1778,6 @@ ArtifactID CGameState::pickRandomArtifact(vstd::RNG & rand, std::function<bool(A
 ArtifactID CGameState::pickRandomArtifact(vstd::RNG & rand, int flags)
 {
 	return pickRandomArtifact(rand, flags, [](const ArtifactID &) { return true; });
-}
-
-void UpgradeInfo::addUpgrade(const CreatureID & upgradeID, const Creature * creature, int costModifier)
-{
-	isAvailable = costModifier >= 0;
-	upgradesIDs.push_back(upgradeID);
-	
-	ResourceSet upgradeCost = (upgradeID.toCreature()->getFullRecruitCost() - creature->getFullRecruitCost()) * costModifier / 100;
-	upgradeCost.positive(); //upgrade cost can't be negative, ignore missing resources
-	upgradesCosts.push_back(std::move(upgradeCost));
-
-	// sort from highest ID to smallest
-	size_t pos = upgradesIDs.size() - 1;
-	while(pos > 0 && upgradesIDs[pos] > upgradesIDs[pos - 1])
-	{
-		std::swap(upgradesIDs[pos], upgradesIDs[pos - 1]);
-		std::swap(upgradesCosts[pos], upgradesCosts[pos - 1]);
-		--pos;
-	}
 }
 
 VCMI_LIB_NAMESPACE_END

--- a/lib/gameState/CGameState.h
+++ b/lib/gameState/CGameState.h
@@ -39,12 +39,67 @@ struct SThievesGuildInfo;
 class CRandomGenerator;
 class GameSettings;
 
-struct UpgradeInfo
+class UpgradeInfo
 {
+public:
+	UpgradeInfo() = delete;
+	UpgradeInfo(CreatureID base)
+		: oldID(base), isAvailable(true)
+	{ }
+
 	CreatureID oldID; //creature to be upgraded
-	std::vector<CreatureID> newID; //possible upgrades
-	std::vector<ResourceSet> cost; // cost[upgrade_serial] -> set of pairs<resource_ID,resource_amount>; cost is for single unit (not entire stack)
-	UpgradeInfo(){oldID = CreatureID::NONE;};
+
+	const auto & getAvailableUpgrades() const
+	{
+		return upgradesIDs;
+	}
+
+	const CreatureID & getNextUpgrade() const
+	{
+		return upgradesIDs.back();
+	}
+
+	const auto & getUpgradeCostsFor(CreatureID id) const
+	{
+		auto idIt = std::find(upgradesIDs.begin(), upgradesIDs.end(), id);
+
+		assert(idIt != upgradesIDs.end());
+
+		return upgradesCosts[std::distance(upgradesIDs.begin(), idIt)];
+	}
+
+	const auto & getUpgradeCosts() const
+	{
+		return upgradesCosts;
+	}
+
+	const auto & getNextUpgradeCosts() const
+	{
+		return upgradesCosts.back();
+	}
+
+	bool canUpgrade() const
+	{
+		return !upgradesIDs.empty() && isAvailable;
+	}
+
+	bool hasUpgrades() const
+	{
+		return !upgradesIDs.empty();
+	}
+
+	// Adds a new upgrade and ensures alignment and sorted order
+	void addUpgrade(const CreatureID & upgradeID, ResourceSet && upgradeCost, bool available = true);
+
+	auto size() const
+	{
+		return upgradesIDs.size();
+	}
+
+private:
+	std::vector<CreatureID> upgradesIDs; //possible upgrades
+	std::vector<ResourceSet> upgradesCosts; // cost[upgrade_serial] -> set of pairs<resource_ID,resource_amount>; cost is for single unit (not entire stack)
+	bool isAvailable;		// flag for unavailableUpgrades like in miniHillFort from HoTA
 };
 
 class BattleInfo;

--- a/lib/gameState/CGameState.h
+++ b/lib/gameState/CGameState.h
@@ -38,71 +38,8 @@ class TavernHeroesPool;
 struct SThievesGuildInfo;
 class CRandomGenerator;
 class GameSettings;
-
-class UpgradeInfo
-{
-public:
-	UpgradeInfo() = delete;
-	UpgradeInfo(CreatureID base)
-		: oldID(base), isAvailable(true)
-	{ }
-
-	CreatureID oldID; //creature to be upgraded
-
-	const std::vector<CreatureID> & getAvailableUpgrades() const
-	{
-		return upgradesIDs;
-	}
-
-	const CreatureID & getNextUpgrade() const
-	{
-		return upgradesIDs.back();
-	}
-
-	const ResourceSet & getUpgradeCostsFor(CreatureID id) const
-	{
-		auto idIt = std::find(upgradesIDs.begin(), upgradesIDs.end(), id);
-
-		assert(idIt != upgradesIDs.end());
-
-		return upgradesCosts[std::distance(upgradesIDs.begin(), idIt)];
-	}
-
-	const std::vector<ResourceSet> & getUpgradeCosts() const
-	{
-		return upgradesCosts;
-	}
-
-	const ResourceSet & getNextUpgradeCosts() const
-	{
-		return upgradesCosts.back();
-	}
-
-	bool canUpgrade() const
-	{
-		return !upgradesIDs.empty() && isAvailable;
-	}
-
-	bool hasUpgrades() const
-	{
-		return !upgradesIDs.empty();
-	}
-
-	// Adds a new upgrade and ensures alignment and sorted order
-	void addUpgrade(const CreatureID & upgradeID, const Creature * creature, int costModifier = 100);
-
-	auto size() const
-	{
-		return upgradesIDs.size();
-	}
-
-private:
-	std::vector<CreatureID> upgradesIDs; //possible upgrades
-	std::vector<ResourceSet> upgradesCosts; // cost[upgrade_serial] -> set of pairs<resource_ID,resource_amount>; cost is for single unit (not entire stack)
-	bool isAvailable;		// flag for unavailableUpgrades like in miniHillFort from HoTA
-};
-
 class BattleInfo;
+class UpgradeInfo;
 
 DLL_LINKAGE std::ostream & operator<<(std::ostream & os, const EVictoryLossCheckResult & victoryLossCheckResult);
 

--- a/lib/gameState/CGameState.h
+++ b/lib/gameState/CGameState.h
@@ -49,7 +49,7 @@ public:
 
 	CreatureID oldID; //creature to be upgraded
 
-	const auto & getAvailableUpgrades() const
+	const std::vector<CreatureID> & getAvailableUpgrades() const
 	{
 		return upgradesIDs;
 	}
@@ -59,7 +59,7 @@ public:
 		return upgradesIDs.back();
 	}
 
-	const auto & getUpgradeCostsFor(CreatureID id) const
+	const ResourceSet & getUpgradeCostsFor(CreatureID id) const
 	{
 		auto idIt = std::find(upgradesIDs.begin(), upgradesIDs.end(), id);
 
@@ -68,12 +68,12 @@ public:
 		return upgradesCosts[std::distance(upgradesIDs.begin(), idIt)];
 	}
 
-	const auto & getUpgradeCosts() const
+	const std::vector<ResourceSet> & getUpgradeCosts() const
 	{
 		return upgradesCosts;
 	}
 
-	const auto & getNextUpgradeCosts() const
+	const ResourceSet & getNextUpgradeCosts() const
 	{
 		return upgradesCosts.back();
 	}
@@ -89,7 +89,7 @@ public:
 	}
 
 	// Adds a new upgrade and ensures alignment and sorted order
-	void addUpgrade(const CreatureID & upgradeID, ResourceSet && upgradeCost, bool available = true);
+	void addUpgrade(const CreatureID & upgradeID, const Creature * creature, int costModifier = 100);
 
 	auto size() const
 	{

--- a/lib/gameState/UpgradeInfo.cpp
+++ b/lib/gameState/UpgradeInfo.cpp
@@ -1,0 +1,36 @@
+/*
+ * UpgradeInfo.cpp, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
+#include "StdInc.h"
+#include "UpgradeInfo.h"
+#include "CCreatureHandler.h"
+
+VCMI_LIB_NAMESPACE_BEGIN
+
+void UpgradeInfo::addUpgrade(const CreatureID & upgradeID, const Creature * creature, int costPercentageModifier)
+{
+	isAvailable = costPercentageModifier >= 0;
+
+	upgradesIDs.push_back(upgradeID);
+
+	ResourceSet upgradeCost = (upgradeID.toCreature()->getFullRecruitCost() - creature->getFullRecruitCost()) * costPercentageModifier / 100;
+	upgradeCost.positive(); //upgrade cost can't be negative, ignore missing resources
+	upgradesCosts.push_back(std::move(upgradeCost));
+
+	// sort from highest ID to smallest
+	size_t pos = upgradesIDs.size() - 1;
+	while(pos > 0 && upgradesIDs[pos] > upgradesIDs[pos - 1])
+	{
+		std::swap(upgradesIDs[pos], upgradesIDs[pos - 1]);
+		std::swap(upgradesCosts[pos], upgradesCosts[pos - 1]);
+		--pos;
+	}
+}
+
+VCMI_LIB_NAMESPACE_END

--- a/lib/gameState/UpgradeInfo.h
+++ b/lib/gameState/UpgradeInfo.h
@@ -1,0 +1,82 @@
+/*
+ * UpgradeInfo.h, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
+#pragma once
+
+#include "../lib/constants/EntityIdentifiers.h"
+#include "../lib/ResourceSet.h"
+
+VCMI_LIB_NAMESPACE_BEGIN
+
+class DLL_LINKAGE UpgradeInfo
+{
+public:
+	UpgradeInfo() = delete;
+	UpgradeInfo(CreatureID base)
+		: oldID(base), isAvailable(true)
+	{
+	}
+
+	CreatureID oldID; //creature to be upgraded
+
+	const std::vector<CreatureID> & getAvailableUpgrades() const
+	{
+		return upgradesIDs;
+	}
+
+	const CreatureID & getUpgrade() const
+	{
+		return upgradesIDs.back();
+	}
+
+	const ResourceSet & getUpgradeCostsFor(CreatureID id) const
+	{
+		auto idIt = std::find(upgradesIDs.begin(), upgradesIDs.end(), id);
+
+		assert(idIt != upgradesIDs.end());
+
+		return upgradesCosts[std::distance(upgradesIDs.begin(), idIt)];
+	}
+
+	const std::vector<ResourceSet> & getAvailableUpgradeCosts() const
+	{
+		return upgradesCosts;
+	}
+
+	const ResourceSet & getUpgradeCosts() const
+	{
+		return upgradesCosts.back();
+	}
+
+	bool canUpgrade() const
+	{
+		return !upgradesIDs.empty() && isAvailable;
+	}
+
+	bool hasUpgrades() const
+	{
+		return !upgradesIDs.empty();
+	}
+
+	// Adds a new upgrade and ensures alignment and sorted order
+	void addUpgrade(const CreatureID & upgradeID, const Creature * creature, int costPercentageModifier = 100);
+
+	auto size() const
+	{
+		return upgradesIDs.size();
+	}
+
+private:
+	std::vector<CreatureID> upgradesIDs; //possible upgrades
+	std::vector<ResourceSet> upgradesCosts; // cost[upgrade_serial] -> set of pairs<resource_ID,resource_amount>; cost is for single unit (not entire stack)
+	bool isAvailable;		// flag for unavailableUpgrades like in miniHillFort from HoTA
+};
+
+VCMI_LIB_NAMESPACE_END
+

--- a/lib/mapObjects/CGHeroInstance.cpp
+++ b/lib/mapObjects/CGHeroInstance.cpp
@@ -1847,7 +1847,7 @@ bool CGHeroInstance::isMissionCritical() const
 	return false;
 }
 
-void CGHeroInstance::fillUpgradeInfo(UpgradeInfo & info, const CStackInstance &stack) const
+void CGHeroInstance::fillUpgradeInfo(UpgradeInfo & info, const CStackInstance & stack) const
 {
 	TConstBonusListPtr lista = getBonuses(Selector::typeSubtype(BonusType::SPECIAL_UPGRADE, BonusSubtypeID(stack.getId())));
 	for(const auto & it : *lista)
@@ -1855,7 +1855,7 @@ void CGHeroInstance::fillUpgradeInfo(UpgradeInfo & info, const CStackInstance &s
 		auto nid = CreatureID(it->additionalInfo[0]);
 		if (nid != stack.getId()) //in very specific case the upgrade is available by default (?)
 		{
-			info.addUpgrade(std::move(nid), nid.toCreature()->getFullRecruitCost() - stack.getType()->getFullRecruitCost());
+			info.addUpgrade(nid, stack.getType());
 		}
 	}
 }

--- a/lib/mapObjects/CGHeroInstance.cpp
+++ b/lib/mapObjects/CGHeroInstance.cpp
@@ -25,6 +25,7 @@
 #include "../CSkillHandler.h"
 #include "../IGameCallback.h"
 #include "../gameState/CGameState.h"
+#include "../gameState/UpgradeInfo.h"
 #include "../CCreatureHandler.h"
 #include "../mapping/CMap.h"
 #include "../StartInfo.h"

--- a/lib/mapObjects/CGHeroInstance.cpp
+++ b/lib/mapObjects/CGHeroInstance.cpp
@@ -1855,8 +1855,7 @@ void CGHeroInstance::fillUpgradeInfo(UpgradeInfo & info, const CStackInstance &s
 		auto nid = CreatureID(it->additionalInfo[0]);
 		if (nid != stack.getId()) //in very specific case the upgrade is available by default (?)
 		{
-			info.newID.push_back(nid);
-			info.cost.push_back(nid.toCreature()->getFullRecruitCost() - stack.getType()->getFullRecruitCost());
+			info.addUpgrade(std::move(nid), nid.toCreature()->getFullRecruitCost() - stack.getType()->getFullRecruitCost());
 		}
 	}
 }

--- a/lib/mapObjects/CGHeroInstance.h
+++ b/lib/mapObjects/CGHeroInstance.h
@@ -23,6 +23,7 @@ class CHero;
 class CGBoat;
 class CGTownInstance;
 class CMap;
+class UpgradeInfo;
 struct TerrainTile;
 struct TurnInfo;
 

--- a/lib/mapObjects/CGTownInstance.cpp
+++ b/lib/mapObjects/CGTownInstance.cpp
@@ -20,6 +20,7 @@
 #include "../texts/CGeneralTextHandler.h"
 #include "../IGameCallback.h"
 #include "../gameState/CGameState.h"
+#include "../gameState/UpgradeInfo.h"
 #include "../mapping/CMap.h"
 #include "../CPlayerState.h"
 #include "../StartInfo.h"

--- a/lib/mapObjects/CGTownInstance.cpp
+++ b/lib/mapObjects/CGTownInstance.cpp
@@ -1234,7 +1234,7 @@ void CGTownInstance::fillUpgradeInfo(UpgradeInfo & info, const CStackInstance &s
 			{
 				if(vstd::contains(stack.getCreature()->upgrades, upgrID)) //possible upgrade
 				{
-					info.addUpgrade(upgrID, upgrID.toCreature()->getFullRecruitCost() - stack.getType()->getFullRecruitCost());
+					info.addUpgrade(upgrID, stack.getType());
 				}
 			}
 		}

--- a/lib/mapObjects/CGTownInstance.cpp
+++ b/lib/mapObjects/CGTownInstance.cpp
@@ -1234,8 +1234,7 @@ void CGTownInstance::fillUpgradeInfo(UpgradeInfo & info, const CStackInstance &s
 			{
 				if(vstd::contains(stack.getCreature()->upgrades, upgrID)) //possible upgrade
 				{
-					info.newID.push_back(upgrID);
-					info.cost.push_back(upgrID.toCreature()->getFullRecruitCost() - stack.getType()->getFullRecruitCost());
+					info.addUpgrade(upgrID, upgrID.toCreature()->getFullRecruitCost() - stack.getType()->getFullRecruitCost());
 				}
 			}
 		}

--- a/lib/mapObjects/IObjectInterface.h
+++ b/lib/mapObjects/IObjectInterface.h
@@ -23,7 +23,7 @@ class RNG;
 }
 
 struct BattleResult;
-struct UpgradeInfo;
+class UpgradeInfo;
 class BoatId;
 class CGObjectInstance;
 class CStackInstance;

--- a/lib/mapObjects/MiscObjects.cpp
+++ b/lib/mapObjects/MiscObjects.cpp
@@ -1323,13 +1323,12 @@ void HillFort::fillUpgradeInfo(UpgradeInfo & info, const CStackInstance &stack) 
 
 	int costModifier = upgradeCostPercentage[index];
 
-	if (costModifier < 0)
-		return; // upgrade not allowed
+	if(costModifier < 0)
+		return;
 
 	for(const auto & nid : stack.getCreature()->upgrades)
 	{
-		info.newID.push_back(nid);
-		info.cost.push_back((nid.toCreature()->getFullRecruitCost() - stack.getType()->getFullRecruitCost()) * costModifier / 100);
+		info.addUpgrade(nid, (nid, (nid.toCreature()->getFullRecruitCost() - stack.getType()->getFullRecruitCost()) * costModifier / 100), costModifier >= 0);
 	}
 }
 

--- a/lib/mapObjects/MiscObjects.cpp
+++ b/lib/mapObjects/MiscObjects.cpp
@@ -1323,14 +1323,12 @@ void HillFort::fillUpgradeInfo(UpgradeInfo & info, const CStackInstance &stack) 
 
 	int costModifier = upgradeCostPercentage[index];
 
-	if(costModifier < 0)
+	if(costModifier < 0) // upgrade not allowed
 		return;
 
 	for(const auto & nid : stack.getCreature()->upgrades)
 	{
-		info.addUpgrade(nid, 
-						(nid.toCreature()->getFullRecruitCost() - stack.getType()->getFullRecruitCost() * costModifier / 100), 
-						costModifier >= 0);
+		info.addUpgrade(nid, stack.getType(), costModifier / 100);
 	}
 }
 

--- a/lib/mapObjects/MiscObjects.cpp
+++ b/lib/mapObjects/MiscObjects.cpp
@@ -32,6 +32,7 @@
 #include "../networkPacks/PacksForClient.h"
 #include "../networkPacks/PacksForClientBattle.h"
 #include "../networkPacks/StackLocation.h"
+#include "../lib/gameState/UpgradeInfo.h"
 
 #include <vstd/RNG.h>
 
@@ -1323,12 +1324,9 @@ void HillFort::fillUpgradeInfo(UpgradeInfo & info, const CStackInstance &stack) 
 
 	int costModifier = upgradeCostPercentage[index];
 
-	if(costModifier < 0) // upgrade not allowed
-		return;
-
 	for(const auto & nid : stack.getCreature()->upgrades)
 	{
-		info.addUpgrade(nid, stack.getType(), costModifier / 100);
+		info.addUpgrade(nid, stack.getType(), costModifier);
 	}
 }
 

--- a/lib/mapObjects/MiscObjects.cpp
+++ b/lib/mapObjects/MiscObjects.cpp
@@ -1328,7 +1328,9 @@ void HillFort::fillUpgradeInfo(UpgradeInfo & info, const CStackInstance &stack) 
 
 	for(const auto & nid : stack.getCreature()->upgrades)
 	{
-		info.addUpgrade(nid, (nid, (nid.toCreature()->getFullRecruitCost() - stack.getType()->getFullRecruitCost()) * costModifier / 100), costModifier >= 0);
+		info.addUpgrade(nid, 
+						(nid.toCreature()->getFullRecruitCost() - stack.getType()->getFullRecruitCost() * costModifier / 100), 
+						costModifier >= 0);
 	}
 }
 

--- a/lib/mapObjects/MiscObjects.h
+++ b/lib/mapObjects/MiscObjects.h
@@ -16,6 +16,7 @@
 VCMI_LIB_NAMESPACE_BEGIN
 
 class CMap;
+class UpgradeInfo;
 
 // This one teleport-specific, but has to be available everywhere in callbacks and netpacks
 // For now it's will be there till teleports code refactored and moved into own file

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -2414,18 +2414,18 @@ bool CGameHandler::upgradeCreature(ObjectInstanceID objid, SlotID pos, CreatureI
 	{
 		COMPLAIN_RET("Cannot upgrade, no stack at slot " + std::to_string(pos));
 	}
-	UpgradeInfo ui(obj->getStackPtr(pos)->getId());
-	fillUpgradeInfo(obj, pos, ui);
+	UpgradeInfo upgradeInfo(obj->getStackPtr(pos)->getId());
+	fillUpgradeInfo(obj, pos, upgradeInfo);
 	PlayerColor player = obj->tempOwner;
 	const PlayerState *p = getPlayerState(player);
 	int crQuantity = obj->stacks.at(pos)->count;
 
 	//check if upgrade is possible
-	if (!ui.hasUpgrades() && complain("That upgrade is not possible!"))
+	if (!upgradeInfo.hasUpgrades() && complain("That upgrade is not possible!"))
 	{
 		return false;
 	}
-	TResources totalCost = ui.getUpgradeCostsFor(upgID) * crQuantity;
+	TResources totalCost = upgradeInfo.getUpgradeCostsFor(upgID) * crQuantity;
 
 	//check if player has enough resources
 	if (!p->resources.canAfford(totalCost))

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -2419,7 +2419,6 @@ bool CGameHandler::upgradeCreature(ObjectInstanceID objid, SlotID pos, CreatureI
 	PlayerColor player = obj->tempOwner;
 	const PlayerState *p = getPlayerState(player);
 	int crQuantity = obj->stacks.at(pos)->count;
-	int newIDpos= vstd::find_pos(ui.getAvailableUpgrades(), upgID);//get position of new id in UpgradeInfo
 
 	//check if upgrade is possible
 	if (!ui.hasUpgrades() && complain("That upgrade is not possible!"))

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -2414,19 +2414,19 @@ bool CGameHandler::upgradeCreature(ObjectInstanceID objid, SlotID pos, CreatureI
 	{
 		COMPLAIN_RET("Cannot upgrade, no stack at slot " + std::to_string(pos));
 	}
-	UpgradeInfo ui;
+	UpgradeInfo ui(obj->getStackPtr(pos)->getId());
 	fillUpgradeInfo(obj, pos, ui);
 	PlayerColor player = obj->tempOwner;
 	const PlayerState *p = getPlayerState(player);
 	int crQuantity = obj->stacks.at(pos)->count;
-	int newIDpos= vstd::find_pos(ui.newID, upgID);//get position of new id in UpgradeInfo
+	int newIDpos= vstd::find_pos(ui.getAvailableUpgrades(), upgID);//get position of new id in UpgradeInfo
 
 	//check if upgrade is possible
-	if ((ui.oldID == CreatureID::NONE || newIDpos == -1) && complain("That upgrade is not possible!"))
+	if (!ui.hasUpgrades() && complain("That upgrade is not possible!"))
 	{
 		return false;
 	}
-	TResources totalCost = ui.cost.at(newIDpos) * crQuantity;
+	TResources totalCost = ui.getUpgradeCostsFor(upgID) * crQuantity;
 
 	//check if player has enough resources
 	if (!p->resources.canAfford(totalCost))

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -53,6 +53,7 @@
 #include "../lib/filesystem/Filesystem.h"
 
 #include "../lib/gameState/CGameState.h"
+#include "../lib/gameState/UpgradeInfo.h"
 
 #include "../lib/mapping/CMap.h"
 #include "../lib/mapping/CMapService.h"


### PR DESCRIPTION
This PR fixes #4749 issue.

AI will pick now the most valuable upgrade if creature has alternative ones.
