### PR TITLE
text fixes

### DIFF
--- a/client/renderSDL/CTrueTypeFont.cpp
+++ b/client/renderSDL/CTrueTypeFont.cpp
@@ -118,6 +118,12 @@ size_t CTrueTypeFont::getStringWidthScaled(const std::string & text) const
 {
 	int width;
 	TTF_SizeUTF8(font.get(), text.c_str(), &width, nullptr);
+
+	if (outline)
+		width += getScalingFactor();
+	if (dropShadow || outline)
+		width += getScalingFactor();
+		
 	return width;
 }
 

--- a/client/windows/CCreatureWindow.cpp
+++ b/client/windows/CCreatureWindow.cpp
@@ -279,7 +279,7 @@ CStackWindow::BonusLineSection::BonusLineSection(CStackWindow * owner, size_t li
 		std::string t = bonusNames.count(bi.bonusSource) ? bonusNames[bi.bonusSource] : CGI->generaltexth->translate("vcmi.bonusSource.other");
 		int maxLen = 50;
 		EFonts f = FONT_TINY;
-		Point pText = p + Point(3, 40);
+		Point pText = p + Point(4, 38);
 
 		// 1px Black border
 		bonusSource[leftRight].push_back(std::make_shared<CLabel>(pText.x - 1, pText.y, f, ETextAlignment::TOPLEFT, Colors::BLACK, t, maxLen));

--- a/client/windows/CMessage.cpp
+++ b/client/windows/CMessage.cpp
@@ -117,7 +117,13 @@ std::vector<std::string> CMessage::breakText(std::string text, size_t maxLineWid
 				color = "";
 			}
 			else
-				printableString.append(text.data() + currPos, symbolSize);
+			{
+				std::string character = "";
+				character.append(text.data() + currPos, symbolSize);
+				if(fontPtr->getStringWidth(printableString + character) > maxLineWidth)
+					break;
+				printableString += character;
+			}
 
 			currPos += symbolSize;
 		}


### PR DESCRIPTION
- fixes incorrect width calculation for ttf fonts with shadow or outline
- fine adjusts text overlay for recent CreatureWindow changes
- fixes incorrect linebreak for multiline (fixes 2. from #4985)