### PR TITLE
generate file hashes if innoextract fails

### DIFF
--- a/launcher/firstLaunch/firstlaunch_moc.cpp
+++ b/launcher/firstLaunch/firstlaunch_moc.cpp
@@ -391,7 +391,7 @@ void FirstLaunchView::extractGogData()
 		
 		QString hashError;
 		if(!errorText.isEmpty())
-			hashError = Innoextract::getHashError(tmpFileExe, tmpFileBin);
+			hashError = Innoextract::getHashError(tmpFileExe, tmpFileBin, fileExe, fileBin);
 
 		ui->progressBarGog->setVisible(false);
 		ui->pushButtonGogInstall->setVisible(true);

--- a/launcher/firstLaunch/firstlaunch_moc.cpp
+++ b/launcher/firstLaunch/firstlaunch_moc.cpp
@@ -359,8 +359,9 @@ void FirstLaunchView::extractGogData()
 			return; // should not happen - but avoid deleting wrong folder in any case
 
 		QString tmpFileExe = tempDir.filePath("h3_gog.exe");
+		QString tmpFileBin = tempDir.filePath("h3_gog-1.bin");
 		QFile(fileExe).copy(tmpFileExe);
-		QFile(fileBin).copy(tempDir.filePath("h3_gog-1.bin"));
+		QFile(fileBin).copy(tmpFileBin);
 
 		QString errorText{};
 
@@ -387,6 +388,10 @@ void FirstLaunchView::extractGogData()
 				ui->progressBarGog->setValue(progress * 100);
 				qApp->processEvents();
 			});
+		
+		QString hashError;
+		if(!errorText.isEmpty())
+			hashError = Innoextract::getHashError(tmpFileExe, tmpFileBin);
 
 		ui->progressBarGog->setVisible(false);
 		ui->pushButtonGogInstall->setVisible(true);
@@ -395,8 +400,12 @@ void FirstLaunchView::extractGogData()
 		QStringList dirData = tempDir.entryList({"data"}, QDir::Filter::Dirs);
 		if(!errorText.isEmpty() || dirData.empty() || QDir(tempDir.filePath(dirData.front())).entryList({"*.lod"}, QDir::Filter::Files).empty())
 		{
-			if(!errorText.isEmpty()) //
+			if(!errorText.isEmpty())
+			{
 				QMessageBox::critical(this, tr("Extracting error!"), errorText, QMessageBox::Ok, QMessageBox::Ok);
+				if(!hashError.isEmpty())
+					QMessageBox::critical(this, tr("Hash error!"), hashError, QMessageBox::Ok, QMessageBox::Ok);
+			}
 			else
 				QMessageBox::critical(this, tr("No Heroes III data!"), tr("Selected files do not contain Heroes III data!"), QMessageBox::Ok, QMessageBox::Ok);
 			tempDir.removeRecursively();

--- a/launcher/firstLaunch/firstlaunch_moc.cpp
+++ b/launcher/firstLaunch/firstlaunch_moc.cpp
@@ -395,7 +395,7 @@ void FirstLaunchView::extractGogData()
 		QStringList dirData = tempDir.entryList({"data"}, QDir::Filter::Dirs);
 		if(!errorText.isEmpty() || dirData.empty() || QDir(tempDir.filePath(dirData.front())).entryList({"*.lod"}, QDir::Filter::Files).empty())
 		{
-			if(!errorText.isEmpty())
+			if(!errorText.isEmpty()) //
 				QMessageBox::critical(this, tr("Extracting error!"), errorText, QMessageBox::Ok, QMessageBox::Ok);
 			else
 				QMessageBox::critical(this, tr("No Heroes III data!"), tr("Selected files do not contain Heroes III data!"), QMessageBox::Ok, QMessageBox::Ok);

--- a/launcher/innoextract.cpp
+++ b/launcher/innoextract.cpp
@@ -123,9 +123,9 @@ QString Innoextract::getHashError(QString exeFile, QString binFile)
 			return QString{}; // reading problem
 	}
 	
-	QString hashOutput = tr("SHA1-Hash of provided files:\n") + tr("Exe") + ":\n" + QString::fromStdString(exeHash) + "\n(" + QString::number(exeSize) + " " + tr("bytes") + ")";
+	QString hashOutput = tr("SHA1-Hash of provided files:\n") + tr("Exe") + " (" + QString::number(exeSize) + " " + tr("bytes") + ")" + ":\n" + QString::fromStdString(exeHash);
 	if(!binHash.empty())
-		hashOutput += "\n" + tr("Bin") + ":\n" + QString::fromStdString(binHash) + "\n(" + QString::number(binSize) + " " + tr("bytes") + ")";
+		hashOutput += "\n" + tr("Bin") + " (" + QString::number(binSize) + " " + tr("bytes") + ")" + ":\n" + QString::fromStdString(binHash);
 	
 	QString foundKnown;
 	QString exeLang;

--- a/launcher/innoextract.cpp
+++ b/launcher/innoextract.cpp
@@ -123,9 +123,9 @@ QString Innoextract::getHashError(QString exeFile, QString binFile)
 			return QString{}; // reading problem
 	}
 	
-	QString hashOutput = tr("Hash:\n") + tr("Exe") + ": " + QString::fromStdString(exeHash) + " (" + QString::number(exeSize) + " " + tr("bytes") + ")";
+	QString hashOutput = tr("SHA1-Hash of provided files:\n") + tr("Exe") + ":\n" + QString::fromStdString(exeHash) + "\n(" + QString::number(exeSize) + " " + tr("bytes") + ")";
 	if(!binHash.empty())
-		hashOutput += "\n" + tr("Bin") + ": " + QString::fromStdString(binHash) + " (" + QString::number(binSize) + " " + tr("bytes") + ")";
+		hashOutput += "\n" + tr("Bin") + ":\n" + QString::fromStdString(binHash) + "\n(" + QString::number(binSize) + " " + tr("bytes") + ")";
 	
 	QString foundKnown;
 	QString exeLang;
@@ -144,7 +144,7 @@ QString Innoextract::getHashError(QString exeFile, QString binFile)
 	if(!exeLang.isEmpty() && !binLang.isEmpty() && exeLang != binLang && !binFile.isEmpty())
 		return tr("Language mismatch.\n\n") + foundKnown + "\n\n" + hashOutput;
 	else if((!exeLang.isEmpty() || !binLang.isEmpty()) && !binFile.isEmpty())
-		return tr("Only one file known.\n\n") + foundKnown + "\n\n" + hashOutput;
+		return tr("Only one file known. Maybe files are corrupted? Please download again.\n\n") + foundKnown + "\n\n" + hashOutput;
 	else if(!exeLang.isEmpty() && binFile.isEmpty())
 		return QString{};
 	else if(!exeLang.isEmpty() && !binFile.isEmpty() && exeLang == binLang)

--- a/launcher/innoextract.cpp
+++ b/launcher/innoextract.cpp
@@ -106,6 +106,8 @@ QString Innoextract::getHashError(QString exeFile, QString binFile)
 		QCryptographicHash hash(QCryptographicHash::Algorithm::Sha1);
 		if(hash.addData(&exe))
 			exeHash = hash.result().toHex().toLower().toStdString();
+		else
+			return QString{}; // error with hashing
 		exeSize = exe.size();
 	}
 	else
@@ -117,6 +119,8 @@ QString Innoextract::getHashError(QString exeFile, QString binFile)
 			QCryptographicHash hash(QCryptographicHash::Algorithm::Sha1);
 			if(hash.addData(&bin))
 				binHash = hash.result().toHex().toLower().toStdString();
+			else
+				return QString{}; // error with hashing
 			binSize = bin.size();
 		}
 		else

--- a/launcher/innoextract.cpp
+++ b/launcher/innoextract.cpp
@@ -60,3 +60,76 @@ QString Innoextract::extract(QString installer, QString outDir, std::function<vo
 
 	return errorText;
 }
+
+QString Innoextract::getHashError(QFile exe, std::optional<QFile> bin)
+{
+	enum filetype
+	{
+		H3_COMPLETE,
+		CHR1,
+		CHR2,
+		CHR3,
+		CHR4,
+		CHR5,
+		CHR6,
+		CHR7,
+		CHR8
+	};
+	struct data
+	{
+		filetype type;
+		std::string language;
+		int exeSize;
+		int binSize;
+		std::string exe;
+		std::string bin;
+	};
+	
+	std::vector<data> knownHashes = {
+		{ H3_COMPLETE, "english",    822520, 1005040617, "66646a353b06417fa12c6384405688c84a315cc1", "c624e2071f4e35386765ab044ad5860ac245b7f4" }, // setup_heroes_of_might_and_magic_3_complete_4.0_(28740).exe
+		{ H3_COMPLETE, "french",     824960,  997305870, "072f1d4466ff16444d8c7949c6530448a9c53cfa", "9b6b451d2bd2f8b4be159e62fa6d32e87ee10455" }, // setup_heroes_of_might_and_magic_3_complete_4.0_(french)_(28740).exe
+		{ H3_COMPLETE, "polish",     822288,  849286313, "74ffde00156dd5a8e237668f87213387f0dd9c7c", "2523cf9943043ae100186f89e4ebf7c28be09804" }, // setup_heroes_of_might_and_magic_3_complete_4.0_(polish)_(28740).exe
+		{ H3_COMPLETE, "russian",    821608,  980398466, "88ccae41e66da58ba4ad62024d97dfe69084f825", "58f1b3c813a1953992bba1f9855c47d01c897db8" }, // setup_heroes_of_might_and_magic_3_complete_4.0_(russian)_(28740).exe
+		{ H3_COMPLETE, "english",    820288, 1006275333, "ca68adb8c2d8c6b3afa17a595ad70c2cec062b5a", "2715e10e91919d05377d39fd879d43f9f0cb9f87" }, // setup_heroes_of_might_and_magic_3_complete_4.0_(3.2)_gog_0.1_(77075).exe
+		{ H3_COMPLETE, "french",     822688,  998540653, "fbb300eeef52f5d81a571a178723b19313e3856d", "4f4d90ff2f60968616766237664744bc54754500" }, // setup_heroes_of_might_and_magic_3_complete_4.0_(3.2)_gog_0.1_(french)_(77075).exe
+		{ H3_COMPLETE, "polish",     819904,  851750601, "a413b0b9f3d5ca3e1a57e84a42de28c67d77b1a7", "fd9fe58bcbb8b442e8cfc299d90f1d503f281d40" }, // setup_heroes_of_might_and_magic_3_complete_4.0_(3.2)_gog_0.1_(polish)_(77075).exe
+		{ H3_COMPLETE, "russian",    819416,  981633128, "e84eedf62fe2e5f9171a7e1ce6e99315a09ce41f", "49cc683395c0cf80830bfa66e42bb5dfdb7aa124" }, // setup_heroes_of_might_and_magic_3_complete_4.0_(3.2)_gog_0.1_(russian)_(77075).exe
+		{ CHR1,        "english", 485694752,          0, "44e4fc2c38261a1c2a57d5198f44493210e8fc1a", ""                                         }, // setup_heroes_chronicles_chapter1_2.1.0.42.exe
+		{ CHR2,        "english", 493102840,          0, "b479a3272cf4b57a6b7fc499df5eafb624dcd6de", ""                                         }, // setup_heroes_chronicles_chapter2_2.1.0.43.exe
+		{ CHR3,        "english", 470364128,          0, "5ad36d822e1700c9ecf93b78652900a52518146b", ""                                         }, // setup_heroes_chronicles_chapter3_2.1.0.41.exe
+		{ CHR4,        "english", 469211296,          0, "5deb374a2e188ed14e8f74ad1284c45e46adf760", ""                                         }, // setup_heroes_chronicles_chapter4_2.1.0.42.exe
+		{ CHR5,        "english", 447497560,          0, "a6daa6ed56c840f3be7ad6ad920a2f9f2439acc8", ""                                         }, // setup_heroes_chronicles_chapter5_2.1.0.42.exe
+		{ CHR6,        "english", 447430456,          0, "93a42dd24453f36e7020afc61bca05b8461a3f04", ""                                         }, // setup_heroes_chronicles_chapter6_2.1.0.42.exe
+		{ CHR7,        "english", 481583720,          0, "d74b042015f3c5b667821c5d721ac3d2fdbf43fc", ""                                         }, // setup_heroes_chronicles_chapter7_2.1.0.42.exe
+		{ CHR8,        "english", 462976008,          0, "9039050e88b9dabcdb3ffa74b33e6aa86a20b7d9", ""                                         }, // setup_heroes_chronicles_chapter8_2.1.0.42.exe
+	};
+
+	std::string exeHash;
+	std::string binHash;
+
+	if(exe.open(QFile::ReadOnly)) {
+        QCryptographicHash hash(QCryptographicHash::Algorithm::Sha1);
+        if(hash.addData(&exe)) {
+            exeHash = hash.result().toHex().toLower().toStdString();
+        }
+    }
+	else
+		return QString{}; // reading problem
+	if(bin)
+	{
+		if((*bin).open(QFile::ReadOnly)) {
+			QCryptographicHash hash(QCryptographicHash::Algorithm::Sha1);
+			if(hash.addData(&(*bin))) {
+				binHash = hash.result().toHex().toLower().toStdString();
+			}
+		}
+		else
+			return QString{}; // reading problem
+	}
+	
+	QString hashOutput = tr("Hash:\n") + tr("Exe: ") + QString::fromStdString(exeHash);
+	if(!binHash.empty())
+		hashOutput += "\n" + tr("Bin: ") + QString::fromStdString(binHash);
+
+	return tr("Unknown files:\n\n") + hashOutput;
+}

--- a/launcher/innoextract.cpp
+++ b/launcher/innoextract.cpp
@@ -123,7 +123,7 @@ QString Innoextract::getHashError(QString exeFile, QString binFile)
 			return QString{}; // reading problem
 	}
 	
-	QString hashOutput = tr("SHA1-Hash of provided files:\n") + tr("Exe") + " (" + QString::number(exeSize) + " " + tr("bytes") + ")" + ":\n" + QString::fromStdString(exeHash);
+	QString hashOutput = tr("SHA1 hash of provided files:\n") + tr("Exe") + " (" + QString::number(exeSize) + " " + tr("bytes") + ")" + ":\n" + QString::fromStdString(exeHash);
 	if(!binHash.empty())
 		hashOutput += "\n" + tr("Bin") + " (" + QString::number(binSize) + " " + tr("bytes") + ")" + ":\n" + QString::fromStdString(binHash);
 	
@@ -142,13 +142,13 @@ QString Innoextract::getHashError(QString exeFile, QString binFile)
 		it = std::find_if(++it, knownHashes.end(), find);
 	}
 	if(!exeLang.isEmpty() && !binLang.isEmpty() && exeLang != binLang && !binFile.isEmpty())
-		return tr("Language mismatch.\n\n") + foundKnown + "\n\n" + hashOutput;
+		return tr("Language mismatch!\n\n") + foundKnown + "\n\n" + hashOutput;
 	else if((!exeLang.isEmpty() || !binLang.isEmpty()) && !binFile.isEmpty())
-		return tr("Only one file known. Maybe files are corrupted? Please download again.\n\n") + foundKnown + "\n\n" + hashOutput;
+		return tr("Only one file known! Maybe files are corrupted? Please download again.\n\n") + foundKnown + "\n\n" + hashOutput;
 	else if(!exeLang.isEmpty() && binFile.isEmpty())
 		return QString{};
 	else if(!exeLang.isEmpty() && !binFile.isEmpty() && exeLang == binLang)
 		return QString{};
 
-	return tr("Unknown files. Maybe files are corrupted? Please download again.\n\n") + hashOutput;
+	return tr("Unknown files! Maybe files are corrupted? Please download again.\n\n") + hashOutput;
 }

--- a/launcher/innoextract.cpp
+++ b/launcher/innoextract.cpp
@@ -65,15 +65,7 @@ QString Innoextract::getHashError(QFile exe, std::optional<QFile> bin)
 {
 	enum filetype
 	{
-		H3_COMPLETE,
-		CHR1,
-		CHR2,
-		CHR3,
-		CHR4,
-		CHR5,
-		CHR6,
-		CHR7,
-		CHR8
+		H3_COMPLETE, CHR
 	};
 	struct data
 	{
@@ -94,42 +86,67 @@ QString Innoextract::getHashError(QFile exe, std::optional<QFile> bin)
 		{ H3_COMPLETE, "french",     822688,  998540653, "fbb300eeef52f5d81a571a178723b19313e3856d", "4f4d90ff2f60968616766237664744bc54754500" }, // setup_heroes_of_might_and_magic_3_complete_4.0_(3.2)_gog_0.1_(french)_(77075).exe
 		{ H3_COMPLETE, "polish",     819904,  851750601, "a413b0b9f3d5ca3e1a57e84a42de28c67d77b1a7", "fd9fe58bcbb8b442e8cfc299d90f1d503f281d40" }, // setup_heroes_of_might_and_magic_3_complete_4.0_(3.2)_gog_0.1_(polish)_(77075).exe
 		{ H3_COMPLETE, "russian",    819416,  981633128, "e84eedf62fe2e5f9171a7e1ce6e99315a09ce41f", "49cc683395c0cf80830bfa66e42bb5dfdb7aa124" }, // setup_heroes_of_might_and_magic_3_complete_4.0_(3.2)_gog_0.1_(russian)_(77075).exe
-		{ CHR1,        "english", 485694752,          0, "44e4fc2c38261a1c2a57d5198f44493210e8fc1a", ""                                         }, // setup_heroes_chronicles_chapter1_2.1.0.42.exe
-		{ CHR2,        "english", 493102840,          0, "b479a3272cf4b57a6b7fc499df5eafb624dcd6de", ""                                         }, // setup_heroes_chronicles_chapter2_2.1.0.43.exe
-		{ CHR3,        "english", 470364128,          0, "5ad36d822e1700c9ecf93b78652900a52518146b", ""                                         }, // setup_heroes_chronicles_chapter3_2.1.0.41.exe
-		{ CHR4,        "english", 469211296,          0, "5deb374a2e188ed14e8f74ad1284c45e46adf760", ""                                         }, // setup_heroes_chronicles_chapter4_2.1.0.42.exe
-		{ CHR5,        "english", 447497560,          0, "a6daa6ed56c840f3be7ad6ad920a2f9f2439acc8", ""                                         }, // setup_heroes_chronicles_chapter5_2.1.0.42.exe
-		{ CHR6,        "english", 447430456,          0, "93a42dd24453f36e7020afc61bca05b8461a3f04", ""                                         }, // setup_heroes_chronicles_chapter6_2.1.0.42.exe
-		{ CHR7,        "english", 481583720,          0, "d74b042015f3c5b667821c5d721ac3d2fdbf43fc", ""                                         }, // setup_heroes_chronicles_chapter7_2.1.0.42.exe
-		{ CHR8,        "english", 462976008,          0, "9039050e88b9dabcdb3ffa74b33e6aa86a20b7d9", ""                                         }, // setup_heroes_chronicles_chapter8_2.1.0.42.exe
+		{ CHR,         "english", 485694752,          0, "44e4fc2c38261a1c2a57d5198f44493210e8fc1a", ""                                         }, // setup_heroes_chronicles_chapter1_2.1.0.42.exe
+		{ CHR,         "english", 493102840,          0, "b479a3272cf4b57a6b7fc499df5eafb624dcd6de", ""                                         }, // setup_heroes_chronicles_chapter2_2.1.0.43.exe
+		{ CHR,         "english", 470364128,          0, "5ad36d822e1700c9ecf93b78652900a52518146b", ""                                         }, // setup_heroes_chronicles_chapter3_2.1.0.41.exe
+		{ CHR,         "english", 469211296,          0, "5deb374a2e188ed14e8f74ad1284c45e46adf760", ""                                         }, // setup_heroes_chronicles_chapter4_2.1.0.42.exe
+		{ CHR,         "english", 447497560,          0, "a6daa6ed56c840f3be7ad6ad920a2f9f2439acc8", ""                                         }, // setup_heroes_chronicles_chapter5_2.1.0.42.exe
+		{ CHR,         "english", 447430456,          0, "93a42dd24453f36e7020afc61bca05b8461a3f04", ""                                         }, // setup_heroes_chronicles_chapter6_2.1.0.42.exe
+		{ CHR,         "english", 481583720,          0, "d74b042015f3c5b667821c5d721ac3d2fdbf43fc", ""                                         }, // setup_heroes_chronicles_chapter7_2.1.0.42.exe
+		{ CHR,         "english", 462976008,          0, "9039050e88b9dabcdb3ffa74b33e6aa86a20b7d9", ""                                         }, // setup_heroes_chronicles_chapter8_2.1.0.42.exe
 	};
 
 	std::string exeHash;
 	std::string binHash;
+	int exeSize = 0;
+	int binSize = 0;
 
 	if(exe.open(QFile::ReadOnly)) {
-        QCryptographicHash hash(QCryptographicHash::Algorithm::Sha1);
-        if(hash.addData(&exe)) {
-            exeHash = hash.result().toHex().toLower().toStdString();
-        }
-    }
+		QCryptographicHash hash(QCryptographicHash::Algorithm::Sha1);
+		if(hash.addData(&exe))
+			exeHash = hash.result().toHex().toLower().toStdString();
+		exeSize = exe.size();
+	}
 	else
 		return QString{}; // reading problem
 	if(bin)
 	{
 		if((*bin).open(QFile::ReadOnly)) {
 			QCryptographicHash hash(QCryptographicHash::Algorithm::Sha1);
-			if(hash.addData(&(*bin))) {
+			if(hash.addData(&(*bin)))
 				binHash = hash.result().toHex().toLower().toStdString();
-			}
+			binSize = (*bin).size();
 		}
 		else
 			return QString{}; // reading problem
 	}
 	
-	QString hashOutput = tr("Hash:\n") + tr("Exe: ") + QString::fromStdString(exeHash);
+	QString hashOutput = tr("Hash:\n") + tr("Exe") + ": " + QString::fromStdString(exeHash) + " (" + QString::number(1) + " " + tr("bytes") + ")";
 	if(!binHash.empty())
-		hashOutput += "\n" + tr("Bin: ") + QString::fromStdString(binHash);
+		hashOutput += "\n" + tr("Bin") + ": " + QString::fromStdString(binHash) + " (" + QString::number(1) + " " + tr("bytes") + ")";
+	
+	QString foundKnown;
+	QString exeLang;
+	QString binLang;
+	auto find = [exeHash, binHash](const data & d) { return (!d.exe.empty() && d.exe == exeHash) || (!d.bin.empty() && d.bin == binHash);};
+	auto it = std::find_if(knownHashes.begin(), knownHashes.end(), find);
+	while(it != knownHashes.end()){
+		auto lang = QString::fromStdString((*it).language);
+		foundKnown += (exeHash == (*it).exe ? tr("Exe") : tr("Bin")) + " - " + lang + "\n";
+		if(exeHash == (*it).exe)
+			exeLang = lang;
+		else
+			binLang = lang;
+		it = std::find_if(++it, knownHashes.end(), find);
+	}
+	if(!exeLang.isEmpty() && !binLang.isEmpty() && exeLang != binLang && bin)
+		return tr("Language mismatch.\n\n") + foundKnown + "\n\n" + hashOutput;
+	else if((!exeLang.isEmpty() || !binLang.isEmpty()) && bin)
+		return tr("Only one file known.\n\n") + foundKnown + "\n\n" + hashOutput;
+	else if(!exeLang.isEmpty() && !bin)
+		return QString{};
+	else if(!exeLang.isEmpty() && bin && exeLang == binLang)
+		return QString{};
 
-	return tr("Unknown files:\n\n") + hashOutput;
+	return tr("Unknown files. Maybe files are corrupted? Please download again.\n\n") + hashOutput;
 }

--- a/launcher/innoextract.h
+++ b/launcher/innoextract.h
@@ -13,5 +13,5 @@ class Innoextract : public QObject
 {
 public:
 	static QString extract(QString installer, QString outDir, std::function<void (float percent)> cb = nullptr);
-	QString getHashError(QFile exe, std::optional<QFile> bin);
+	static QString getHashError(QString exeFile, QString binFile);
 };

--- a/launcher/innoextract.h
+++ b/launcher/innoextract.h
@@ -13,4 +13,5 @@ class Innoextract : public QObject
 {
 public:
 	static QString extract(QString installer, QString outDir, std::function<void (float percent)> cb = nullptr);
+	QString getHashError(QFile exe, std::optional<QFile> bin);
 };

--- a/launcher/innoextract.h
+++ b/launcher/innoextract.h
@@ -13,5 +13,5 @@ class Innoextract : public QObject
 {
 public:
 	static QString extract(QString installer, QString outDir, std::function<void (float percent)> cb = nullptr);
-	static QString getHashError(QString exeFile, QString binFile);
+	static QString getHashError(QString exeFile, QString binFile, QString exeFileOriginal, QString binFileOriginal);
 };

--- a/launcher/modManager/chroniclesextractor.cpp
+++ b/launcher/modManager/chroniclesextractor.cpp
@@ -84,7 +84,10 @@ bool ChroniclesExtractor::extractGogInstaller(QString file)
 
 	if(!errorText.isEmpty())
 	{
+		QString hashError = Innoextract::getHashError(file, {});
 		QMessageBox::critical(parent, tr("Extracting error!"), errorText);
+		if(!hashError.isEmpty())
+			QMessageBox::critical(parent, tr("Hash error!"), hashError, QMessageBox::Ok, QMessageBox::Ok);
 		return false;
 	}
 

--- a/launcher/modManager/chroniclesextractor.cpp
+++ b/launcher/modManager/chroniclesextractor.cpp
@@ -84,7 +84,7 @@ bool ChroniclesExtractor::extractGogInstaller(QString file)
 
 	if(!errorText.isEmpty())
 	{
-		QString hashError = Innoextract::getHashError(file, {});
+		QString hashError = Innoextract::getHashError(file, {}, {}, {});
 		QMessageBox::critical(parent, tr("Extracting error!"), errorText);
 		if(!hashError.isEmpty())
 			QMessageBox::critical(parent, tr("Hash error!"), hashError, QMessageBox::Ok, QMessageBox::Ok);


### PR DESCRIPTION
Second error window after (already existing) innoextract error:
![grafik](https://github.com/user-attachments/assets/f4df63b0-74fc-4f3b-bce0-fb56f2976fcb)
![grafik](https://github.com/user-attachments/assets/71d49c74-1f37-4634-a4f4-500fdbcaf7a9)
![grafik](https://github.com/user-attachments/assets/e9be96cd-d9ad-4c03-a2e2-b8b163f01377)
![grafik](https://github.com/user-attachments/assets/fbebb2a9-9e8d-48a8-8dc6-b1ec1c431b40)

fixes #4879
