### PR TITLE
Fix shooting being priority action for dead creature hexes with empty hex target enabled

### DIFF
--- a/client/battle/BattleActionsController.cpp
+++ b/client/battle/BattleActionsController.cpp
@@ -275,7 +275,7 @@ void BattleActionsController::reorderPossibleActionsPriority(const CStack * stac
 				return 2;
 				break;
 			case PossiblePlayerBattleAction::SHOOT:
-				if(targetStack == nullptr || targetStack->unitSide() == stack->unitSide())
+				if(targetStack == nullptr || targetStack->unitSide() == stack->unitSide() || !targetStack->alive())
 					return 100; //bottom priority
 
 				return 4;


### PR DESCRIPTION
As in title