### PR TITLE
Exchange full army by holding alt while pressing VCMI extras creature arrow button

### DIFF
--- a/client/widgets/CExchangeController.cpp
+++ b/client/widgets/CExchangeController.cpp
@@ -79,6 +79,10 @@ void CExchangeController::moveArmy(bool leftToRight, std::optional<SlotID> heldS
 			});
 		heldSlot = weakestSlot->first;
 	}
+	
+	if (source->getCreature(heldSlot.value()) == nullptr)
+		return;
+
 	LOCPLINT->cb->bulkMoveArmy(source->id, target->id, heldSlot.value());
 }
 

--- a/client/windows/CExchangeWindow.cpp
+++ b/client/windows/CExchangeWindow.cpp
@@ -248,7 +248,7 @@ CExchangeWindow::CExchangeWindow(ObjectInstanceID hero1, ObjectInstanceID hero2,
 					Point(484 + 35 * i, 154),
 					AnimationPath::builtin("quick-exchange/unitLeft.DEF"),
 					CButton::tooltip(CGI->generaltexth->translate("vcmi.quickExchange.moveUnit")),
-					std::bind(&CExchangeController::moveStack, &controller, false, SlotID(i))));
+					[this, i]() { creatureArrowButtonCallback(false, SlotID(i)); }));
 			moveUnitFromRightToLeftButtons.back()->block(leftHeroBlock);
 
 			moveUnitFromLeftToRightButtons.push_back(
@@ -256,12 +256,20 @@ CExchangeWindow::CExchangeWindow(ObjectInstanceID hero1, ObjectInstanceID hero2,
 					Point(66 + 35 * i, 154),
 					AnimationPath::builtin("quick-exchange/unitRight.DEF"),
 					CButton::tooltip(CGI->generaltexth->translate("vcmi.quickExchange.moveUnit")),
-					std::bind(&CExchangeController::moveStack, &controller, true, SlotID(i))));
+					[this, i]() { creatureArrowButtonCallback(true, SlotID(i)); }));
 			moveUnitFromLeftToRightButtons.back()->block(rightHeroBlock);
 		}
 	}
 
 	CExchangeWindow::update();
+}
+
+void CExchangeWindow::creatureArrowButtonCallback(bool leftToRight, SlotID slotId)
+{
+	if (GH.isKeyboardAltDown())
+		controller.moveArmy(leftToRight, slotId);
+	else
+		controller.moveStack(leftToRight, slotId);
 }
 
 void CExchangeWindow::moveArtifactsCallback(bool leftToRight)

--- a/client/windows/CExchangeWindow.h
+++ b/client/windows/CExchangeWindow.h
@@ -54,6 +54,7 @@ class CExchangeWindow : public CStatusbarWindow, public IGarrisonHolder, public 
 	std::shared_ptr<CButton> backpackButtonRight;
 	CExchangeController controller;
 
+	void creatureArrowButtonCallback(bool leftToRight, SlotID slotID);
 	void moveArtifactsCallback(bool leftToRight);
 	void swapArtifactsCallback();
 	void moveUnitsShortcut(bool leftToRight);


### PR DESCRIPTION
During exchange screen there are buttons under unit slots for exchanging army - players are used to QoL that pressing them while holding alt exchanges whole army except 1 creature in that slot

Simple and not too good implementation UI-wise, but functional from player point of view