### PR TITLE
Use json instead of json5 for syntax highlight in docs

### DIFF
--- a/docs/developers/Bonus_System.md
+++ b/docs/developers/Bonus_System.md
@@ -55,7 +55,7 @@ Updaters are objects attached to bonuses. They can modify a bonus (typically by 
 
 The following example shows an artifact providing a bonus based on the level of the hero that wears it:
 
-```json5
+```json
    "core:greaterGnollsFlail":
    {
        "text" : { "description" : "This mighty flail increases the attack of all gnolls under the hero's command by twice the hero's level." },

--- a/docs/developers/Conan.md
+++ b/docs/developers/Conan.md
@@ -172,7 +172,7 @@ cmake --preset ios-conan
 
 `CMakeUserPresets.json` file:
 
-```json5
+```json
 {
     "version": 3,
     "cmakeMinimumRequired": {

--- a/docs/developers/Logging_API.md
+++ b/docs/developers/Logging_API.md
@@ -24,7 +24,7 @@ Some notes:
 
 ### Setup settings.json
 
-```json5
+```json
 {
     "logging" : {
         "console" : {

--- a/docs/developers/Lua_Scripting_System.md
+++ b/docs/developers/Lua_Scripting_System.md
@@ -2,7 +2,7 @@
 
 ## Configuration
 
-```json5
+```json
 {
  	//general purpose script, Lua or ERM, runs on server
  	"myScript":

--- a/docs/modders/Animation_Format.md
+++ b/docs/modders/Animation_Format.md
@@ -8,7 +8,7 @@ VCMI allows overriding HoMM3 .def files with .json replacement. Compared to .def
 
 ## Format description
 
-```json5
+```json
 {
     // Base path of all images in animation. Optional.
     // Can be used to avoid using long path to images 
@@ -64,7 +64,7 @@ This json file will allow replacing .def file for a button with png images. Butt
 3. Blocked state. Button is blocked and can not be interacted with. Note that some buttons are never blocked and can be used without this image
 4. Highlighted state. This state is used by only some buttons and only in some cases. For example, in main menu buttons will appear highlighted when mouse cursor is on top of the image. Another example is buttons that can be selected, such as settings that can be toggled on or off
 
-```json5
+```json
 {
 	"basepath" : "interface/MyButton", // all images are located in this directory
 
@@ -82,7 +82,7 @@ This json file will allow replacing .def file for a button with png images. Butt
 
 This json file allows defining one animation sequence, for example for adventure map objects or for town buildings.
 
-```json5
+```json
 {
 	"basepath" : "myTown/myBuilding", // all images are located in this directory
 

--- a/docs/modders/Bonus/Bonus_Limiters.md
+++ b/docs/modders/Bonus/Bonus_Limiters.md
@@ -15,7 +15,7 @@ The limiters take no parameters:
 
 Example:
 
-```json5
+```json
 "limiters" : [ "SHOOTER_ONLY" ]
 ```
 
@@ -30,7 +30,7 @@ Parameters:
 - (optional) bonus sourceType and sourceId in struct
 - example: (from Adele's bless):
 
-```json5
+```json
 	"limiters" : [
 		{
 			"type" : "HAS_ANOTHER_BONUS_LIMITER",
@@ -82,14 +82,14 @@ Parameters:
 
 Example:
 
-```json5
+```json
 "limiters": [ {
 	"type":"CREATURE_TYPE_LIMITER",
 	"parameters": [ "angel", true ]
 } ],
 ```
 
-```json5
+```json
 "limiters" : [ {
 	"type" : "CREATURE_TERRAIN_LIMITER",
 	"parameters" : ["sand"]
@@ -113,7 +113,7 @@ and operate on the remaining limiters in that list:
 
 Example:
 
-```json5
+```json
 "limiters" : [
     "noneOf",
     "IS_UNDEAD",

--- a/docs/modders/Bonus/Bonus_Types.md
+++ b/docs/modders/Bonus/Bonus_Types.md
@@ -128,7 +128,7 @@ Allows to raise different creatures than Skeletons after battle.
 - addInfo: Level of Necromancy secondary skill (1 - Basic, 3 - Expert)
 - Example (from Cloak Of The Undead King):
 
-```json5
+```json
 {
     "type" : "IMPROVED_NECROMANCY",
     "subtype" : "creature.walkingDead",
@@ -256,7 +256,7 @@ Gives creature under effect of this spell additional bonus, which is hardcoded a
 
 Modifies 'val' parameter of spell effects that give bonuses by specified value. For example, Aenain makes Disrupting Ray decrease target's defense by additional 2 points:
 
-```json5
+```json
 "disruptingRay" : {
     "addInfo" : -2,
     "subtype" : "spell.disruptingRay",
@@ -271,7 +271,7 @@ Modifies 'val' parameter of spell effects that give bonuses by specified value. 
 
 Changes 'val' parameter of spell effects that give bonuses to a specified value. For example, Fortune cast by Melody always modifies luck by +3:
 
-```json5
+```json
 "fortune" : {
     "addInfo" : 3,
     "subtype" : "spell.fortune",

--- a/docs/modders/Bonus/Bonus_Updaters.md
+++ b/docs/modders/Bonus/Bonus_Updaters.md
@@ -17,7 +17,7 @@ Check the files in *config/heroes/* for additional usage examples.
 Example: The following updater will cause a bonus to grow by 6 for every
 40 levels. At first level, rounding will cause the bonus to be 0.
 
-```json5
+```json
 "updater" : {
     "parameters" : [ 6, 2 ],
     "type" : "GROWS_WITH_LEVEL"
@@ -27,7 +27,7 @@ Example: The following updater will cause a bonus to grow by 6 for every
 Example: The following updater will cause a bonus to grow by 3 for every
 20 levels. At first level, rounding will cause the bonus to be 1.
 
-```json5
+```json
 "updater" : {
     "parameters" : [ 3 ],
     "type" : "GROWS_WITH_LEVEL"
@@ -71,7 +71,7 @@ Remark: The stack level for war machines is 0.
 - Remark: this updater is designed for MOVEMENT bonus to match H3 army movement rules (in the example - actual movement updater, which produces values same as in default movement.txt).
 - Example:
 
-```json5
+```json
 "updater" : {
     "parameters" : [ 20, 3, 10, 700 ],
     "type" : "ARMY_MOVEMENT"

--- a/docs/modders/Bonus_Format.md
+++ b/docs/modders/Bonus_Format.md
@@ -4,7 +4,7 @@
 
 All parameters but type are optional.
 
-```json5
+```json
 {
 	// Type of the bonus. See Bonus Types for full list
 	"type":         "BONUS_TYPE",
@@ -81,7 +81,7 @@ See [Game Identifiers](Game_Identifiers.md) for full list of available identifie
 
 ### Example
 
-```json5
+```json
 "bonus" :
 {
 	"type" : "HATE",

--- a/docs/modders/Building_Bonuses.md
+++ b/docs/modders/Building_Bonuses.md
@@ -22,7 +22,7 @@ Includes:
 
 Function of all of these objects can be enabled by this:
 
-```json5
+```json
  "function" : "castleGates" 
 ```
 
@@ -58,31 +58,31 @@ CBuilding class.
 
 #### unlock guild level
 
-```json5
+```json
  "guildLevels" : 1 
 ```
 
 #### unlock hero recruitment
 
-```json5
+```json
  "allowsHeroPurchase" : true 
 ```
 
 #### unlock ship purchase
 
-```json5
+```json
  "allowsShipPurchase" : true 
 ```
 
 #### unlock building purchase
 
-```json5
+```json
  "allowsBuildingPurchase" : true 
 ```
 
 #### unlocks creatures
 
-```json5
+```json
  "dwelling" : { "level" : 1, "creature" : "archer" } 
 ```
 
@@ -92,31 +92,31 @@ Turn into town bonus? What about creature-specific bonuses from hordes?
 
 #### gives resources
 
-```json5
+```json
  "provides" : { "gold" : 500 } 
 ```
 
 #### gives guild spells
 
-```json5
+```json
  "guildSpells" : [5, 0, 0, 0, 0] 
 ```
 
 #### gives thieves guild
 
-```json5
+```json
  "thievesGuildLevels" : 1 
 ```
 
 #### gives fortifications
 
-```json5
+```json
  "fortificationLevels" : 1 
 ```
 
 #### gives war machine
 
-```json5
+```json
  "warMachine" : "ballista" 
 ```
 
@@ -134,7 +134,7 @@ Includes:
 - bonus to scouting range
 - bonus to player
 
-```json5
+```json
 "bonuses" :
 {
 	"moraleToDefenders" :
@@ -162,12 +162,12 @@ Possible issue - with removing of fixed ID's buildings in different town
 may no longer share same ID. However Capitol must be unique across all
 town. Should be fixed somehow.
 
-```json5
+```json
  "onePerPlayer" : true 
 ```
 
 #### chance to be built on start
 
-```json5
+```json
  "prebuiltChance" : 75 
 ```

--- a/docs/modders/Campaign_Format.md
+++ b/docs/modders/Campaign_Format.md
@@ -9,7 +9,7 @@ To start making campaign, create file named `header.json`. See also [Packing cam
 
 Basic structure of this file is here, each section is described in details below
 
-```json5
+```json
 {
     "version" : 1,
 
@@ -34,7 +34,7 @@ Basic structure of this file is here, each section is described in details below
 
 In header are parameters describing campaign properties
 
-```json5
+```json
     ...
     "regions": {...},
     "name": "Campaign name",
@@ -63,7 +63,7 @@ In header are parameters describing campaign properties
 
 Scenario description looks like follow:
 
-```json5
+```json
 {
     "map": "maps/SomeMap",
     "preconditions": [],
@@ -100,7 +100,7 @@ Scenario description looks like follow:
 
 Prolog and epilog properties are optional
 
-```json5
+```json
 {
     "video": "NEUTRALA.smk", //video to show
     "music": "musicFile.ogg", //music to play, should be located in music directory
@@ -119,7 +119,7 @@ If `startOptions` is `none`, `bonuses` field will be ignored
 
 If `startOptions` is `bonus`, bonus format may vary depending on its type.
 
-```json5
+```json
 {
     "what": "",
 
@@ -162,7 +162,7 @@ If `startOptions` is `bonus`, bonus format may vary depending on its type.
 
 If `startOptions` is `crossover`, heroes from specific scenario will be moved to this scenario. Bonus format is following
 
-```json5
+```json
 {
     "playerColor": 0,
     "scenario": 0
@@ -176,7 +176,7 @@ If `startOptions` is `crossover`, heroes from specific scenario will be moved to
 
 If `startOptions` is `hero`, hero can be chosen as a starting bonus. Bonus format is following
 
-```json5
+```json
 {
     "playerColor": 0,
     "hero": "random"
@@ -190,7 +190,7 @@ If `startOptions` is `hero`, hero can be chosen as a starting bonus. Bonus forma
 
 Predefined campaign regions are located in file `campaign_regions.json`
 
-```json5
+```json
 {
     "background": "ownRegionBackground.png",
 		"suffix": ["Enabled", "Selected", "Conquered"],

--- a/docs/modders/Configurable_Widgets.md
+++ b/docs/modders/Configurable_Widgets.md
@@ -33,7 +33,7 @@ extendedLobby/
 
 File `mod.json` is generic and could look like this:
 
-```json5
+```json
 {
 	"name" : "Configurable UI tutorial mod",
 	"description" : "See tutorial here https://github.com/vcmi/vcmi/wiki/Configurable-UI-widgets",
@@ -67,7 +67,7 @@ Open `optionsTab.json` and scroll it until you see comment `timer`. Three elemen
 
 Let's find first element, which is label
 
-```json5
+```json
 {
 	"items"
 	[
@@ -89,7 +89,7 @@ Let's find first element, which is label
 
 And modify it a bit
 
-```json5
+```json
 {
 	"name": "labelTimer", //add name, only for convenience
 	"type": "label",
@@ -103,7 +103,7 @@ And modify it a bit
 
 But we also need proper background image for this label. Add image widget BEFORE labelTimer widget:
 
-```json5
+```json
 {
 	"type": "picture",
 	"image": "RmgTTBk",
@@ -127,7 +127,7 @@ Copy image `DrDoCoBk.bmp` to `content/sprites/`. Button objects use animated ima
 For normal, pressed, blocked and highlighted. Our combo box inherits this behavior, so let's convert image to animation.
 In order to do it, we need to create file `DrDoCoBk.json` in same folder `content/sprites/` with following content:
 
-```json5
+```json
 {
     "sequences" :
     [
@@ -146,7 +146,7 @@ Thus we created file with animation, containing single frame which can be used f
 
 Let's add one more element after `//timer` comment:
 
-```json5
+```json
 ...
 //timer
 {
@@ -163,7 +163,7 @@ Let's add one more element after `//timer` comment:
 
 We also want to have label on the top of this combo box showing which element is selected. You need to add `items` array, where additional elements can be specified, label in our case:
 
-```json5
+```json
 ...
 //timer
 {
@@ -195,7 +195,7 @@ First of all, add images to `content/sprites/` folder: `List2Bk.bmp` for drop-do
 
 Now specify items inside `dropDown` field
 
-```json5
+```json
 "dropDown":
 {
 	"items":
@@ -279,7 +279,7 @@ Let's hide elements, related to classic timer when chess timer is selected and s
 
 To do that, find `"variables"` part inside `optionsTab.json` and add there `"timers"` array, containing 2 elements:
 
-```json5
+```json
 "variables":
 {
 	"timers":
@@ -310,7 +310,7 @@ Now we show and hide elements, but visually you still can some "artifacts":
 It's because options tab background image we use has those elements drawn. Let's hide them with overlay image `timchebk.bmp`.
 It should be drawn before all other timer elements:
 
-```json5
+```json
 ...
 // timer
 {
@@ -338,7 +338,7 @@ We should add text input fields, to specify different timers. We will use backgr
 There are 4 different timers: base, turn, battle and creature. Read about them here: <https://github.com/vcmi/vcmi/issues/1364>
 We can add editors for them into items list, their format will be following:
 
-```json5
+```json
 {
 	"name": "chessFieldBase",
 	"type": "textInput",
@@ -440,7 +440,7 @@ One of predefined values:
 
 Configurable object has following structure:
 
-```json5
+```json
 {
 	"items": [],
 	"variables": {}, //optional
@@ -837,7 +837,7 @@ std::shared_ptr<MyYesNoDialog::Item> MyYesNoDialog::buildMyItem(const JsonNode &
 
 After that, if your JSON file has items with type "MyItem", the new Item element will be constructed.
 
-```json5
+```json
 {
 	"items":
 	[

--- a/docs/modders/Difficulty.md
+++ b/docs/modders/Difficulty.md
@@ -7,7 +7,7 @@ Difficulty configuration is located in [config/difficulty.json](../config/diffic
 
 ## Format summary
 
-```json5
+```json
 {
 	"human": //parameters impacting human players only
 	{
@@ -50,7 +50,7 @@ For both types of bonuses, `source` should be specified as `OTHER`.
 
 ## Example
 
-```json5
+```json
 { //will give 150% extra health to all players' creatures if specified in "battleBonuses" array
 	"type" : "STACK_HEALTH",
 	"val" : 150,

--- a/docs/modders/Entities_Format/Artifact_Format.md
+++ b/docs/modders/Entities_Format/Artifact_Format.md
@@ -12,7 +12,7 @@ In order to make functional artifact you also need:
 
 ## Format
 
-```json5
+```json
 {
 	// Type of this artifact - creature, hero or commander
 	"type": ["HERO", "CREATURE", "COMMANDER"] 

--- a/docs/modders/Entities_Format/Battle_Obstacle_Format.md
+++ b/docs/modders/Entities_Format/Battle_Obstacle_Format.md
@@ -1,6 +1,6 @@
 # Battle Obstacle Format
 
-```json5
+```json
 	// List of terrains on which this obstacle can be used
 	"allowedTerrains" : []
 	

--- a/docs/modders/Entities_Format/Battlefield_Format.md
+++ b/docs/modders/Entities_Format/Battlefield_Format.md
@@ -1,6 +1,6 @@
 # Battlefield Format
 
-```json5
+```json
 	// Human-readable name of the battlefield
 	"name" : "",
 	

--- a/docs/modders/Entities_Format/Biome_Format.md
+++ b/docs/modders/Entities_Format/Biome_Format.md
@@ -8,7 +8,7 @@ The purpose is to create visually attractive and consistent maps, which will als
 
 If not enough biomes are defined for [terrain type](Terrain_Format.md), map generator will fall back to using all available templates that match this terrain, which was original behavior before 1.5.0.
 
-```json5
+```json
 "obstacleSetId" : {
 	"biome" : {
 		"terrain" : "grass", // Id or vector of Ids this obstacle set can spawn at

--- a/docs/modders/Entities_Format/Creature_Format.md
+++ b/docs/modders/Entities_Format/Creature_Format.md
@@ -23,7 +23,7 @@ In order to make functional creature you also need:
 
 ## Format
 
-```json5
+```json
 // camelCase unique creature identifier
 "creatureName" : 
 {

--- a/docs/modders/Entities_Format/Faction_Format.md
+++ b/docs/modders/Entities_Format/Faction_Format.md
@@ -47,7 +47,7 @@ Each town requires a set of buildings (Around 30-45 buildings)
 
 ## Faction node (root entry for town configuration)
 
-```json5
+```json
 // Unique faction identifier.
 "myFaction" :
 {
@@ -108,7 +108,7 @@ Each town requires a set of buildings (Around 30-45 buildings)
 
 ## Town node
 
-```json5
+```json
 {
 	// Field that describes behavior of map object part of town. Town-specific part of object format
 	"mapObject" : 
@@ -256,7 +256,7 @@ Each town requires a set of buildings (Around 30-45 buildings)
 
 ## Siege node
 
-```json5
+```json
 // Describes town siege screen
 // Comments in the end of each graphic position indicate specify required suffix for image
 // Note: one not included image is battlefield background with suffix "BACK"

--- a/docs/modders/Entities_Format/Hero_Class_Format.md
+++ b/docs/modders/Entities_Format/Hero_Class_Format.md
@@ -9,7 +9,7 @@ In order to make functional hero class you also need:
 
 ## Format
 
-```json5
+```json
 // Unique identifier of hero class, camelCase
 "myClassName" :
 {

--- a/docs/modders/Entities_Format/Hero_Type_Format.md
+++ b/docs/modders/Entities_Format/Hero_Type_Format.md
@@ -9,7 +9,7 @@ In order to make functional hero you also need:
 
 ## Format
 
-```json5
+```json
 "myHeroName" :
 {
 	// Identifier of class this hero belongs to. Such as knight or battleMage

--- a/docs/modders/Entities_Format/River_Format.md
+++ b/docs/modders/Entities_Format/River_Format.md
@@ -2,7 +2,7 @@
 
 ## Format
 
-```json5
+```json
 "newRiver" :
 {
 	// Two-letters unique identifier for this river. Used in map format

--- a/docs/modders/Entities_Format/Road_Format.md
+++ b/docs/modders/Entities_Format/Road_Format.md
@@ -2,7 +2,7 @@
 
 ## Format
 
-```json5
+```json
 "newRoad" :
 {
 	// Two-letters unique identifier for this road. Used in map format

--- a/docs/modders/Entities_Format/Secondary_Skill_Format.md
+++ b/docs/modders/Entities_Format/Secondary_Skill_Format.md
@@ -2,7 +2,7 @@
 
 ## Main format
 
-```json5
+```json
 {
 	// Skill be only be available on maps with water
 	"onlyOnWaterMap" : false,
@@ -11,7 +11,7 @@
 }
 ```
 
-```json5
+```json
 {
 	"skillName":
 	{
@@ -55,7 +55,7 @@ level fields become optional if they equal "base" configuration.
 
 ## Skill level format
 
-```json5
+```json
 {
 	// Localizable description
 	// Use {xxx} for formatting
@@ -87,7 +87,7 @@ level fields become optional if they equal "base" configuration.
 The following modifies the tactics skill to grant an additional speed
 boost at advanced and expert levels.
 
-```json5
+```json
 "core:tactics" : {
 	"base" : {
 		"effects" : {

--- a/docs/modders/Entities_Format/Spell_Format.md
+++ b/docs/modders/Entities_Format/Spell_Format.md
@@ -2,7 +2,7 @@
 
 ## Main format
 
-```json5
+```json
 {
 	"spellName":
 	{	
@@ -156,7 +156,7 @@
 
 TODO
 
-```json5
+```json
 {
 	"projectile": [
 		{"minimumAngle": 0 ,"defName":"C20SPX4"},
@@ -179,7 +179,7 @@ Json object with data common for all levels can be put here. These configuration
 
 This will make spell affect single target on all levels except expert, where it is massive spell.
 
-```json5
+```json
 "base":{
 	"range": 0
 },
@@ -192,7 +192,7 @@ This will make spell affect single target on all levels except expert, where it 
 
 TODO
 
-```json5
+```json
 
 {
 	//Mandatory, localizable description. Use {xxx} for formatting
@@ -262,7 +262,7 @@ Configurable spells ignore *offensive* flag, *effects* and *cumulativeEffects*. 
 
 TODO
 
-```json5
+```json
 
 "mod:effectId":{
 
@@ -283,7 +283,7 @@ TODO
 
 TODO
 
-```json5
+```json
 
 "mod:effectId":{
 
@@ -304,7 +304,7 @@ TODO
 
 Configurable version of Clone spell.
 
-```json5
+```json
 
 "mod:effectId":{
 
@@ -320,7 +320,7 @@ TODO
 
 If effect is automatic, spell behave like offensive spell (uses power, levelPower etc)
 
-```json5
+```json
 
 "mod:effectId":{
 
@@ -368,7 +368,7 @@ TODO
 If effect is automatic, spell behave like \[de\]buff spell (effect and
 cumulativeEffects ignored)
 
-```json5
+```json
 
 "mod:effectId":{
 

--- a/docs/modders/Entities_Format/Terrain_Format.md
+++ b/docs/modders/Entities_Format/Terrain_Format.md
@@ -2,7 +2,7 @@
 
 ## Format
 
-```json5
+```json
 "newTerrain" :
 {
 	// Two-letters unique identifier for this terrain. Used in map format

--- a/docs/modders/Entities_Format/Town_Building_Format.md
+++ b/docs/modders/Entities_Format/Town_Building_Format.md
@@ -17,7 +17,7 @@ These are just a couple of examples of what can be done in VCMI. See vcmi config
 
 ##### Order of Fire from Inferno
 
-```json5
+```json
 "special4": {
 	"requires" : [ "mageGuild1" ],
 	"name" : "Order of Fire",
@@ -41,7 +41,7 @@ These are just a couple of examples of what can be done in VCMI. See vcmi config
 
 ##### Mana Vortex from Dungeon
 
-```json5
+```json
 "special2": {
 	"requires" : [ "mageGuild1" ],
 	"name" : "Mana Vortex",
@@ -70,7 +70,7 @@ These are just a couple of examples of what can be done in VCMI. See vcmi config
 
 #### Resource Silo with custom production
 
-```json5
+```json
 "resourceSilo": {
 	"name" : "Wood Resource Silo",
 	"description" : "Produces 2 wood every day",
@@ -86,7 +86,7 @@ These are just a couple of examples of what can be done in VCMI. See vcmi config
 
 #### Brotherhood of Sword - bonuses in siege
 
-```json5
+```json
 "special3": {
 	// replaces +1 Morale bonus from Tavern
 	"upgradeReplacesBonuses" : true, 
@@ -103,7 +103,7 @@ These are just a couple of examples of what can be done in VCMI. See vcmi config
 
 #### Lighthouse - bonus to all heroes under player control
 
-```json5
+```json
 "special1":       { 
 	"bonuses": [
 		{
@@ -119,7 +119,7 @@ These are just a couple of examples of what can be done in VCMI. See vcmi config
 
 ## Town Building node
 
-```json5
+```json
 {
 	// Numeric identifier of this building
 	"id" : 0,
@@ -218,7 +218,7 @@ These are just a couple of examples of what can be done in VCMI. See vcmi config
 
 Building requirements can be described using logical expressions:
 
-```json5
+```json
 "requires" :
 [
 	"allOf", // Normal H3 "build all" mode
@@ -265,7 +265,7 @@ In addition to above, it is possible to use same format as [Rewardable](../Map_O
 
 ### Town Structure node
 
-```json5
+```json
 {
 	// Main animation file for this building
 	"animation" : "", 
@@ -299,12 +299,12 @@ Market buildings require list of available [modes](../Map_Objects/Market.md)
 
 ##### Marketplace
 
-```json5
+```json
 	"marketplace":    { "marketModes" : ["resource-resource", "resource-player"] },
 ```
 
 ##### Artifact merchant
 
-```json5
+```json
 	"special1":       { "type" : "artifactMerchant", "requires" : [ "marketplace" ], "marketModes" : ["resource-artifact", "artifact-resource"] },
 ```

--- a/docs/modders/Map_Object_Format.md
+++ b/docs/modders/Map_Object_Format.md
@@ -16,7 +16,7 @@ Full object consists from 3 parts:
 
 ## Object group format
 
-```json5
+```json
 
 {
 	"myCoolObjectGroup":
@@ -99,7 +99,7 @@ These are internal types that are generally not available for modding and are ha
 
 ## Object type format
 
-```json5
+```json
 {
 	"myCoolObject":
 	{
@@ -153,7 +153,7 @@ These are internal types that are generally not available for modding and are ha
 
 ## Object template format
 
-```json5
+```json
 {
 	"myCoolObjectTemplate" : 
 	{

--- a/docs/modders/Map_Objects/Boat.md
+++ b/docs/modders/Map_Objects/Boat.md
@@ -1,6 +1,6 @@
 # Boat
 
-```json5
+```json
 {
 	// Layer on which this boat moves. Possible values:
 	// "land" - same rules as movement of hero on land

--- a/docs/modders/Map_Objects/Creature_Bank.md
+++ b/docs/modders/Map_Objects/Creature_Bank.md
@@ -10,7 +10,7 @@ Deprecated in 1.6. Please use [Rewardable Objects](Rewardable.md) instead. See C
 This example defines a rewardable object with functionality similar of H3 creature bank.
 See [Rewardable Objects](Rewardable.md) for detailed documentation of these properties.
 
-```json5
+```json
 {
 	"name" : "Cyclops Stockpile",
 
@@ -115,7 +115,7 @@ This is a list of changes that needs to be done to bank config to migrate it to 
 
 ### Old format (1.5 or earlier)
 
-```json5
+```json
 {
 	/// If true, battle setup will be like normal - Attacking player on the left, enemy on the right
 	"regularUnitPlacement" : true,

--- a/docs/modders/Map_Objects/Dwelling.md
+++ b/docs/modders/Map_Objects/Dwelling.md
@@ -1,6 +1,6 @@
 # Dwelling
 
-```json5
+```json
 {
 	/// List of creatures in this bank. Each list represents one "level" of bank
 	/// Creatures on the same level will have shared growth and available number (similar to towns)

--- a/docs/modders/Map_Objects/Flaggable.md
+++ b/docs/modders/Map_Objects/Flaggable.md
@@ -9,7 +9,7 @@ Currently, it is possible to make flaggable objects that provide player with:
 
 ## Format description
 
-```json5
+```json
 {
   "baseObjectName" : {
     "name" : "Object name",

--- a/docs/modders/Map_Objects/Market.md
+++ b/docs/modders/Map_Objects/Market.md
@@ -7,7 +7,7 @@ Markets can be added as any other object with special handler called "market".
 
 Here is schema describing such object
 
-```json5
+```json
 "seafaringAcademy" : //object name
 {
 	"handler" : "market", //market handler
@@ -51,19 +51,19 @@ Following options are supported:
 
 Trading post allows to exchange resources and send resources to another player, so it shall be configured this way:
 
-```json5
+```json
 "modes" : ["resource-resource", "resource-player"]
 ```
 
 ### Black market
 
-```json5
+```json
 "modes" : ["resource-artifact"]
 ```
 
 ### Freelance guild
 
-```json5
+```json
 "modes" : ["creature-resource"]
 ```
 
@@ -73,7 +73,7 @@ Altar of sacrifice allows exchange creatures for experience for evil factions an
 So both modes shall be available in the market.
 Game logic prohibits using modes unavailable for faction
 
-```json5
+```json
 "modes" : ["creature-experience", "artifact-experience"]
 ```
 
@@ -85,14 +85,14 @@ See [Secondary skills](Rewardable.md#secondary-skills) description for more deta
 
 ### Example for University of magic (e.g conflux building)
 
-```json5
+```json
 "modes" : ["resource-skill"],
 "offer" : ["airMagic", "waterMagic", "earthMagic", "fireMagic"]
 ```
 
 ### Example for regular University
 
-```json5
+```json
 "modes" : ["resource-skill"],
 "offer" : [ //4 random skills except necromancy
     { "noneOf" : ["necromancy"] },

--- a/docs/modders/Map_Objects/Rewardable.md
+++ b/docs/modders/Map_Objects/Rewardable.md
@@ -4,7 +4,7 @@
 
 Rewardable object is defined similarly to other objects, with key difference being `handler`. This field must be set to `"handler" : "configurable"` in order for vcmi to use this mode.
 
-```json5
+```json
 {
   "baseObjectName" : {
     "name" : "Object name",
@@ -37,7 +37,7 @@ Rewardable object is defined similarly to other objects, with key difference bei
 
 ## Configurable object definition
 
-```json5
+```json
 // List of potential rewards
 "rewards" : [
   {
@@ -177,7 +177,7 @@ Variables are randomized only once, so you can use them multiple times for examp
 
 Example of creation of a variable named "gainedSkill" of type "secondarySkill":
 
-```json5
+```json
 "variables" : {
 	"secondarySkill" : {
 		"gainedSkill" : {
@@ -200,7 +200,7 @@ Possible variable types:
 
 To reference variable in limiter prepend variable name with '@' symbol:
 
-```json5
+```json
 "secondary" : {
     "@gainedSkill" : 1
 },
@@ -214,7 +214,7 @@ This property describes how object state should be reset. Objects without this f
 - If `visitors` is set to true, game will reset list of visitors (heroes and players) on start of new period, allowing revisits of objects with `visitMode` set to `once`, `hero`, or `player`. Objects with visit mode set to `bonus` are not affected. In order to allow revisit such objects use appropriate bonus duration (e.g. `ONE_DAY` or `ONE_WEEK`) instead.
 - If `rewards` is set to true, object will re-randomize its provided rewards, similar to such H3 objects as "Fountain of Fortune" or "Windmill"
 
-```json5
+```json
 "resetParameters" : {
     "period" : 7,
     "visitors" : true,
@@ -233,7 +233,7 @@ Note that object that uses appearChance MUST have continuous range for every val
 - `"min" : 66, "max" : 100`
 In other words, min chance of second reward must be equal to max chance of previous reward
 
-```json5
+```json
     "appearChance": 
     {
       // (Advanced) rewards with different dice number will get different dice number
@@ -253,7 +253,7 @@ In other words, min chance of second reward must be equal to max chance of previ
 
 Unless stated othervice, all numbers in this section can be replaced with random values, e.g.
 
-```json5
+```json
 "minLevel" : { "min" : 5, "max" : 10 } // select random number between 5-10, including both 5 & 10
 "minLevel" : [ 2, 4, 6, 8, 10] // (VCMI 1.2) select random number out of provided list, with equal chance for each
 ```
@@ -265,13 +265,13 @@ Keep in mind, that all randomization is performed on map load and on object rese
 
 - Can only be used as limiter. To pass, current day of week should be equal to this value. 1 = first day of the week, 7 = last day
 
-```json5
+```json
 "dayOfWeek" : 0 
 ```
 
 - Can only be used as limiter. To pass, number of days since game started must be at equal or greater than this value
 
-```json5
+```json
 "daysPassed" : 8
 ```
 
@@ -281,7 +281,7 @@ Keep in mind, that all randomization is performed on map load and on object rese
 - Can be used as reward to grant resources to player
 - If negative value is used as reward, it will be used as cost and take resources from player
 
-```json5
+```json
 "resources": {
     "crystal" : 6,
     "gold" : -1000,
@@ -290,7 +290,7 @@ Keep in mind, that all randomization is performed on map load and on object rese
 
 - Alternative format that allows random selection of a resource type
 
-```json5
+```json
 "resources": [
     {
         "anyOf" : [ "wood", "ore" ],
@@ -308,7 +308,7 @@ Keep in mind, that all randomization is performed on map load and on object rese
 - Can be used as limiter
 - Can be used as reward to grant experience to hero
 
-```json5
+```json
 "heroExperience" : 1000, 
 ```
 
@@ -317,7 +317,7 @@ Keep in mind, that all randomization is performed on map load and on object rese
 - Can be used as limiter. Hero requires to have at least specified level
 - Can be used as reward, will grant hero experience amount equal to the difference between the hero's next level and current level (Tree of Knowledge)
 
-```json5
+```json
 "heroLevel" : 1,
 ```
 
@@ -327,13 +327,13 @@ Keep in mind, that all randomization is performed on map load and on object rese
 - Can be used as reward, to give mana points to hero. Mana points may go above mana pool limit.
 - If negative value is used as reward, it will be used as cost and take mana from player
 
-```json5
+```json
 "manaPoints": -10, 
 ```
 
 - If giving mana points puts hero above mana pool limit, any overflow will be multiplied by specified percentage. If set to 0, mana will not go above mana pool limit.
 
-```json5
+```json
 "manaOverflowFactor" : 50,
 ```
 
@@ -342,7 +342,7 @@ Keep in mind, that all randomization is performed on map load and on object rese
 - Can be used as limiter. Hero must have at least specific mana percentage
 - Can be used to set hero mana level to specified percentage value, not restricted to mana pool limit (Magic Well, Mana Spring)
 
-```json5
+```json
 "manaPercentage": 200, 
 ```
 
@@ -351,7 +351,7 @@ Keep in mind, that all randomization is performed on map load and on object rese
 - Can NOT be used as limiter
 - Can be used as reward, to give movement points to hero. Movement points may go above mana pool limit.
 
-```json5
+```json
 "movePoints": 200,
 ```
 
@@ -360,7 +360,7 @@ Keep in mind, that all randomization is performed on map load and on object rese
 - Can NOT be used as limiter
 - Can be used to set hero movement points level to specified percentage value. Value of 0 will take away any remaining movement points
 
-```json5
+```json
 "movePercentage": 50,
 ```
 
@@ -372,7 +372,7 @@ Keep in mind, that all randomization is performed on map load and on object rese
 - Each primary skill can be explicitly specified or randomly selected
 - Possible values: `"attack", "defence", "spellpower", "knowledge"`
 
-```json5
+```json
 "primary": [
     {
         // Specific primary skill
@@ -406,7 +406,7 @@ Keep in mind, that all randomization is performed on map load and on object rese
 - Possible values: 1 (basic), 2 (advanced), 3 (expert)
 - Each secondary skill can be explicitly specified or randomly selected
 
-```json5
+```json
 "secondary": [
     {
         // Specific skill
@@ -435,7 +435,7 @@ Keep in mind, that all randomization is performed on map load and on object rese
 
 - Can be used as limiter. Hero must have free skill slot to pass limiter
 
-```json5
+```json
     "canLearnSkills" : true
 ```
 
@@ -446,7 +446,7 @@ Keep in mind, that all randomization is performed on map load and on object rese
 - Note that unlike most values, parameter of bonuses can NOT be randomized
 - Description can be string or number of corresponding string from `arraytxt.txt`
 
-```json5
+```json
 "bonuses" : [
     {
         "type" : "MORALE", 
@@ -463,7 +463,7 @@ Keep in mind, that all randomization is performed on map load and on object rese
 - Can be used as reward, to give new artifact to a hero
 - Artifacts added as reward will be used for text substitution. First `%s` in text string will be replaced with name of an artifact
 
-```json5
+```json
 "artifacts": [
     "ribCage"
 ],
@@ -473,7 +473,7 @@ Keep in mind, that all randomization is performed on map load and on object rese
 - For artifact class possible values are "TREASURE", "MINOR", "MAJOR", "RELIC"
 - Artifact value range can be specified with min value and max value
 
-```json5
+```json
 "artifacts": [
     {
         "class" : "TREASURE",
@@ -489,7 +489,7 @@ Keep in mind, that all randomization is performed on map load and on object rese
 - Can be used as reward, to give new spell to a hero
 - Spells added as reward will be used for text substitution. First `%s` in text string will be replaced with spell name
 
-```json5
+```json
 "spells": [
     "magicArrow"
 ],
@@ -498,7 +498,7 @@ Keep in mind, that all randomization is performed on map load and on object rese
 - Alternative format, random spell selection
 - Spell can be selected from specifically selected school
 
-```json5
+```json
 "spells": [
     {
         "level" : 1,
@@ -515,7 +515,7 @@ Keep in mind, that all randomization is performed on map load and on object rese
 - - he does not have a spellbook
 - - he does not have sufficient Wisdom level for this spell
 
-```json5
+```json
     "canLearnSpells" : [
         "magicArrow"
 ],
@@ -528,7 +528,7 @@ Keep in mind, that all randomization is performed on map load and on object rese
 - If hero does not have enough free slots, game will show selection dialog to pick troops to keep
 - It is possible to specify probability to receive upgraded creature
 
-```json5
+```json
 "creatures" : [
     {
         "type" : "archer",
@@ -547,7 +547,7 @@ Keep in mind, that all randomization is performed on map load and on object rese
 - It is possible to add up to 7 slots of creatures
 - Guards of the same creature type will never merge or rearrange their stacks
 
-```json5
+```json
 "guards" : [
     { "type" : "archer", "amount" : 20 },
     { "type" : "archer", "amount" : 20, "upgradeChance" : 30 },
@@ -561,7 +561,7 @@ Keep in mind, that all randomization is performed on map load and on object rese
 - Can be used as reward, to replace creatures in hero army. It is possible to use this parameter both for upgrades of creatures as well as for changing them into completely unrelated creature, e.g. similar to Skeleton Transformer
 - This parameter will not change creatures given by `creatures` parameter on the same visit
 
-```json5
+```json
 "changeCreatures" : {
     "cavalier" : "champion"
 }
@@ -573,7 +573,7 @@ Keep in mind, that all randomization is performed on map load and on object rese
 - As reward, instantly casts adventure map spell for visiting hero. All checks for spell book, wisdom or presence of mana will be ignored. It's possible to specify school level at which spell will be casted. If it's necessary to reduce player's mana or do some checks, they shall be introduced as limiters and other rewards
 - School level possible values: 1 (basic), 2 (advanced), 3 (expert)
 
-```json5
+```json
 "spellCast" : {
     "spell" : "townPortal",
     "schoolLevel": 3
@@ -588,7 +588,7 @@ Keep in mind, that all randomization is performed on map load and on object rese
 - It is possible to specify which terrain classes should be affected. Tile will be affected if sum of values its classes is positive. For example, `"water" : 1` will affect all water tiles, while `"surface" : 1, "subterra" : -1` will include terrains that have "surface" flag but do not have "subterra" flag
 - If 'hide' is set to true, then instead of revealing terrain, game will hide affected tiles for all other players
 
-```json5
+```json
 "revealTiles" : {
 	"radius" : 20,
 	"surface" : 1,
@@ -605,7 +605,7 @@ Keep in mind, that all randomization is performed on map load and on object rese
 - Can NOT be used as reward
 - Only players with specific color can pass the limiter
 
-```json5
+```json
 "colors" : [ "red", "blue", "tan", "green", "orange", "purple", "teal", "pink" ]
 ```
 
@@ -615,7 +615,7 @@ Keep in mind, that all randomization is performed on map load and on object rese
 - Can NOT be used as reward
 - Only specific heroes can pass the limiter
 
-```json5
+```json
 "heroes" : [ "orrin" ]
 ```
 
@@ -625,6 +625,6 @@ Keep in mind, that all randomization is performed on map load and on object rese
 - Can NOT be used as reward
 - Only heroes belonging to specific classes can pass the limiter
 
-```json5
+```json
 "heroClasses" : [ "battlemage" ]
 ```

--- a/docs/modders/Mod_File_Format.md
+++ b/docs/modders/Mod_File_Format.md
@@ -2,7 +2,7 @@
 
 ## Fields with description of mod
 
-```json5
+```json
 {
 	// Name of your mod. While it does not have hard length limit
 	// it should not be longer than ~30 symbols to fit into allowed space
@@ -91,7 +91,7 @@
 
 These are fields that are present only in local mod.json file
 
-```json5
+```json
  
 {
 	// Following section describes configuration files with content added by mod
@@ -210,7 +210,7 @@ See [Translations](Translations.md) for more information
 
 These are fields that are present only in remote repository and are generally not used in mod.json
 
-```json5
+```json
 {
 	// URL to mod.json that describes this mod
 	"mod" : "https://raw.githubusercontent.com/vcmi-mods/vcmi-extras/vcmi-1.4/mod.json",

--- a/docs/modders/Random_Map_Template.md
+++ b/docs/modders/Random_Map_Template.md
@@ -2,7 +2,7 @@
 
 ## Template format
 
-```json5
+```json
 /// Unique template name
 "Triangle" : 
 {
@@ -57,7 +57,7 @@
 
 ## Zone format
 
-```json5
+```json
 {
 	// Type of this zone. Possible values are:
 	// "playerStart" - Starting zone for a "human or CPU" players

--- a/docs/modders/Readme.md
+++ b/docs/modders/Readme.md
@@ -30,7 +30,7 @@ All VCMI configuration files use [JSON format](http://en.wikipedia.org/wiki/Json
 Mod.json is main file in your mod and must be present in any mod. This file contains basic description of your mod, dependencies or conflicting mods (if present), list of new content and so on.
 Minimalistic version of this file:
 
-```json5
+```json
 {
     "name" : "My test mod",
     "description" : "My test mod that add a lot of useless stuff into the game",
@@ -102,7 +102,7 @@ VCMI uses strings to reference objects. Examples:
 
 Alternatively to creating new objects, you can edit existing objects. Normally, when creating new objects you specify object name as:
 
-```json5
+```json
 "newCreature" : {
     // creature parameters
 }
@@ -110,7 +110,7 @@ Alternatively to creating new objects, you can edit existing objects. Normally, 
 
 In order to access and modify existing object you need to specify mod that you wish to edit:
 
-```json5
+```json
 /// "core" specifier refers to objects that exist in H3
 "core:archer" : {
 	/// This will set health of Archer to 10
@@ -159,7 +159,7 @@ These files can be replaced by another def file but in some cases original forma
 In VCMI these animation files can also be replaced by json description of their content. See [Animation Format](Animation_Format.md) for full description of this format.
 Example: replacing single icon
 
-```json5
+```json
 {
 	// List of replaced images
 	"images" :

--- a/docs/translators/Translations.md
+++ b/docs/translators/Translations.md
@@ -62,7 +62,7 @@ To export maps and campaigns, use '/translate maps' command instead.
 
 It's possible to add video subtitles. Create a JSON file in `video` folder of translation mod with the name of the video (e.g. `H3Intro.json`):
 
-```json5
+```json
 [
     {
         "timeStart" : 5.640, // start time, seconds
@@ -164,7 +164,7 @@ If you want to update existing translation, you can use '/translate missing' com
 
 In order to display information in Launcher in language selected by user add following block into your `mod.json`:
 
-```json5
+```json
 	"<language>" : {
 		"name" : "<translated name>",
 		"description" : "<translated description>",


### PR DESCRIPTION
Looks like website only recognizes javascript & json, and is not aware of jsonc or json5.

Will result in small regression on Github web view - comments will show up as red (since comments are not part of json format), but syntax highlight would work both on website and on Github.

Alternative is using javascript for syntax highlight, however syntax highlighter for json looks better on both website and Github (since it uses separate highlighting for json keys, separate from strings in values)