### PR TITLE
[Docs] Enable rule to enforce specifying language for code blocks

### DIFF
--- a/CI/example.markdownlint-cli2.jsonc
+++ b/CI/example.markdownlint-cli2.jsonc
@@ -182,14 +182,12 @@
 		"MD039": true,
 
 		// MD040/fenced-code-language : Fenced code blocks should have a language specified : https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md040.md
-		"MD040": false,
-		// FIXME: enable and consider fixing
-		//{
-		//// List of languages
-		//	"allowed_languages": [ "cpp", "json5", "sh" ],
-		//// Require language only
-		//	"language_only": true
-		//},
+		"MD040": {
+		// List of languages
+			"allowed_languages": [ "cpp", "json", "sh", "text", "nix", "powershell", "lua" ],
+		// Require language only
+			"language_only": true
+		},
 
 		// MD041/first-line-heading/first-line-h1 : First line in a file should be a top-level heading : https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md041.md
 		"MD041": {

--- a/docs/developers/Building_Android.md
+++ b/docs/developers/Building_Android.md
@@ -22,7 +22,7 @@ The following instructions apply to **v1.2 and later**. For earlier versions the
 
 Clone <https://github.com/vcmi/vcmi> with submodules. Example for command line:
 
-```
+```sh
 git clone --recurse-submodules https://github.com/vcmi/vcmi.git
 ```
 
@@ -42,7 +42,7 @@ Conan must be aware of the NDK location when you execute `conan install`. There'
 - the easiest is to download NDK from Conan (option 1 in the docs), then all the magic happens automatically. On the step where you need to replace **PROFILE**, choose *android-**X**-ndk* where ***X*** is either `32` or `64`.
 - to use an already installed NDK, you can simply pass it on the command line to `conan install`: (note that this will work only when consuming the pre-built binaries)
 
-```
+```sh
 conan install -c tools.android:ndk_path=/path/to/ndk ...
 ```
 

--- a/docs/developers/Building_Linux.md
+++ b/docs/developers/Building_Linux.md
@@ -70,7 +70,7 @@ And put it into build directory. Then run `nix-shell` before running any build c
 
 We recommend the following directory structure:
 
-```
+```text
 .
 ├── vcmi -> contains sources and is under git control
 └── build -> contains build output, makefiles, object files,...
@@ -97,7 +97,7 @@ See [CMake](CMake.md) for a list of options
 
 ### Trigger build
 
-```
+```sh
 cmake --build . -j8
 ```
 

--- a/docs/developers/Building_iOS.md
+++ b/docs/developers/Building_iOS.md
@@ -12,7 +12,7 @@
 
 Clone <https://github.com/vcmi/vcmi> with submodules. Example for command line:
 
-```
+```sh
 git clone --recurse-submodules https://github.com/vcmi/vcmi.git
 ```
 
@@ -36,9 +36,8 @@ There're a few [CMake presets](https://cmake.org/cmake/help/latest/manual/cmake-
 
 Open terminal and `cd` to the directory with source code. Configuration example for device with Conan:
 
-```
-cmake --preset ios-device-conan \
-  -D BUNDLE_IDENTIFIER_PREFIX=com.MY-NAME
+```sh
+cmake --preset ios-device-conan -D BUNDLE_IDENTIFIER_PREFIX=com.MY-NAME
 ```
 
 By default build directory containing Xcode project will appear at `../build-ios-device-conan`, but you can change it with `-B` option.
@@ -61,7 +60,7 @@ You must also install game files, see [Installation on iOS](../players/Installat
 
 ### From command line
 
-```
+```sh
 cmake --build <path to build directory> --target vcmiclient -- -quiet
 ```
 

--- a/docs/developers/Building_macOS.md
+++ b/docs/developers/Building_macOS.md
@@ -15,7 +15,7 @@
 
 Clone <https://github.com/vcmi/vcmi> with submodules. Example for command line:
 
-```
+```sh
 git clone --recurse-submodules https://github.com/vcmi/vcmi.git
 ```
 

--- a/docs/developers/CMake.md
+++ b/docs/developers/CMake.md
@@ -4,12 +4,12 @@
   * Enables debug info and disables optimizations
 * `-D CMAKE_EXPORT_COMPILE_COMMANDS=ON`
   * Creates `compile_commands.json` for [clangd](https://clangd.llvm.org/) language server. For clangd to find the JSON, create a file named `.clangd` with this content
-     ```
+     ```text
     CompileFlags:
     CompilationDatabase: build
     ```
     and place it here:
-    ```
+    ```text
     .
     ├── vcmi -> contains sources and is under git control
     ├── build -> contains build output, makefiles, object files,...

--- a/docs/developers/Conan.md
+++ b/docs/developers/Conan.md
@@ -126,7 +126,7 @@ In these examples only the minimum required amount of options is passed to `cmak
 
 ### Use our prebuilt binaries to build for macOS x86_64 with Xcode
 
-```
+```sh
 conan install . \
   --install-folder=conan-generated \
   --no-imports \
@@ -143,7 +143,7 @@ cmake -S . -B build -G Xcode \
 
 If you also want to build the missing binaries from source, use `--build=missing` instead of `--build=never`.
 
-```
+```sh
 conan install . \
   --install-folder=~/my-dir \
   --no-imports \
@@ -158,7 +158,7 @@ cmake -S . -B build \
 
 ### Use our prebuilt binaries to build for iOS arm64 device with custom preset
 
-```
+```sh
 conan install . \
   --install-folder=~/my-dir \
   --no-imports \
@@ -205,7 +205,7 @@ ubuntu
 
 Next steps are identical both in WSL and in real Ubuntu 22.04
 
-```bash
+```sh
 sudo pip3 install conan
 sudo apt install cmake build-essential
 sed -i 's/x86_64-w64-mingw32/i686-w64-mingw32/g' CI/mingw-ubuntu/before-install.sh

--- a/docs/developers/Lua_Scripting_System.md
+++ b/docs/developers/Lua_Scripting_System.md
@@ -65,7 +65,7 @@ TODO **In near future Lua API may change drastically several times. Information 
 
 #### Low level events API
 
-``` Lua
+```lua
 
 -- Each event type must be loaded first
 local PlayerGotTurn = require("events.PlayerGotTurn")

--- a/docs/developers/Networking.md
+++ b/docs/developers/Networking.md
@@ -6,7 +6,7 @@ For implementation details see files located at `lib/network` directory.
 
 VCMI uses connection using TCP to communicate with server, even in single-player games. However, even though TCP is stream-based protocol, VCMI uses atomic messages for communication. Each message is a serialized stream of bytes, preceded by 4-byte message size:
 
-```
+```cpp
 int32_t messageSize;
 byte messagePayload[messageSize];
 ```
@@ -37,7 +37,7 @@ For implementation details see:
 
 In case of global lobby, message payload uses plaintext json format - utf-8 encoded string:
 
-```
+```cpp
 int32_t messageSize;
 char jsonString[messageSize];
 ```

--- a/docs/modders/Bonus/Bonus_Range_Types.md
+++ b/docs/modders/Bonus/Bonus_Range_Types.md
@@ -10,7 +10,7 @@ TODO: ONLY_MELEE_FIGHT / ONLY_DISTANCE_FIGHT range types work ONLY with creature
 
 For replacing ONLY_ENEMY_ARMY alias, you should use the following parameters of bonus:
 
-```
+```text
 	"propagator": "BATTLE_WIDE",
 	"propagationUpdater" : "BONUS_OWNER_UPDATER",
 	"limiters" : [ "OPPOSITE_SIDE" ]

--- a/docs/modders/Bonus/Bonus_Value_Types.md
+++ b/docs/modders/Bonus/Bonus_Value_Types.md
@@ -4,7 +4,7 @@ Total value of Bonus is calculated using the following:
 
 - For each bonus source type we calculate new source value (for all bonus value types except PERCENT_TO_SOURCE and PERCENT_TO_TARGET_TYPE) using the following:
 
-```
+```text
 newVal = (val * (100 + PERCENT_TO_SOURCE) / 100))
 ```
 
@@ -12,7 +12,7 @@ newVal = (val * (100 + PERCENT_TO_SOURCE) / 100))
 
 - All bonus value types summarized and then used as subject of the following formula:
 
-```
+```text
 clamp(((BASE_NUMBER * (100 + PERCENT_TO_BASE) / 100) + ADDITIVE_VALUE) * (100 + PERCENT_TO_ALL) / 100), INDEPENDENT_MAX, INDEPENDENT_MIN)
 ```
 

--- a/docs/modders/Configurable_Widgets.md
+++ b/docs/modders/Configurable_Widgets.md
@@ -22,7 +22,7 @@ In this tutorial we will recreate options tab to support chess timers UI.
 
 To start making mod, create following folders structure;
 
-```
+```text
 extendedLobby/
 |- content/
 |  |- sprites/
@@ -413,7 +413,7 @@ Predefined fonts:
 Hint text is a pair of strings, one is usually shown in status bar when cursor hovers element, another hint while right button pressed.
 Each of elements is a [Text](#text)
 
-```
+```json
 {
   "hover": "Text",
   "help": "Text

--- a/docs/modders/Mod_File_Format.md
+++ b/docs/modders/Mod_File_Format.md
@@ -195,7 +195,7 @@ These are fields that are present only in local mod.json file
 In addition to field listed above, it is possible to add following block for any language supported by VCMI. If such block is present, Launcher will use this information for displaying translated mod information and game will use provided json files to translate mod to specified language.
 See [Translations](Translations.md) for more information
 
-```
+```json
 	"<language>" : {
 		"name" : "<translated name>",
 		"description" : "<translated description>",

--- a/docs/modders/Readme.md
+++ b/docs/modders/Readme.md
@@ -8,7 +8,7 @@ All content of your mod should go into **Content** directory, e.g. **Mods/myMod/
 
 Example of how directory structure of your mod may look like:
 
-```
+```text
     Mods/
         myMod/
             mod.json
@@ -208,7 +208,7 @@ Link to our mod will looks like that: <https://github.com/vcmi-mods/adventure-ai
 
 For sanity reasons mod identifier must only contain lower-case English characters, numbers and hyphens.
 
-```
+```text
 my-mod-name
 2000-new-maps
 ```

--- a/docs/players/Installation_Linux.md
+++ b/docs/players/Installation_Linux.md
@@ -10,7 +10,7 @@ Up-to-date releases can be found in our PPA here: <https://launchpad.net/~vcmi/+
 
 To install VCMI from PPA use:
 
-```
+```sh
     sudo apt-add-repository ppa:vcmi/ppa
     sudo apt update
     sudo apt install vcmi
@@ -22,7 +22,7 @@ We also provide latest, unstable builds mostly suitable for testing here: <https
 
 In order to install from this PPA use:
 
-```
+```sh
     sudo add-apt-repository ppa:vcmi/vcmi-latest
     sudo apt update
     sudo apt install vcmi
@@ -33,7 +33,7 @@ In order to install from this PPA use:
 VCMI stable builds available in "multiverse" repository. Learn how to enable it in [Ubuntu wiki](https://help.ubuntu.com/community/Repositories/Ubuntu).
 Once enabled, you can install VCMI using Ubuntu Store or in terminal using following commands:
 
-```
+```sh
     sudo apt update
     sudo apt install vcmi
 ```
@@ -45,7 +45,7 @@ Note that version available in Ubuntu is outdated. Install via PPA is preferred.
 Stable VCMI version is available in "contrib" repository. Learn how to enable it in [Debian wiki](https://wiki.debian.org/SourcesList).
 To install VCMI from repository:
 
-```
+```sh
     sudo apt-get update
     sudo apt-get install vcmi
 ```
@@ -54,7 +54,7 @@ To install VCMI from repository:
 
 Stable VCMI version is available in RPM Fusion repository. Learn how to enable it in [wiki](https://docs.fedoraproject.org/en-US/quick-docs/rpmfusion-setup/). To install VCMI from repository:
 
-```
+```sh
     sudo dnf update
     sudo dnf install vcmi
 ```
@@ -95,7 +95,7 @@ To install Heroes 3 data using automated script you need any of:
 
 Run the script using options appropriate to your input files:
 
-```
+```sh
 vcmibuilder --cd1 /path/to/iso/or/cd --cd2 /path/to/second/cd
 vcmibuilder --gog /path/to/gog.com/installer.exe
 vcmibuilder --data /path/to/h3/data
@@ -105,7 +105,7 @@ You should use only one of these commands.
 
 On flatpak install, it's also possible to run the script, but any path seems to be interpreted from within the Flatpak sandbox:
 
-```
+```sh
 flatpak run --command=vcmibuilder eu.vcmi.VCMI --data /path/to/h3/data`
 ```
 
@@ -117,7 +117,7 @@ You can select both downloaded files in launcher to extract automatically.
 
 Alternatively you can use the classic way:
 
-```
+```sh
 innoextract --output-dir=~/Downloads/HoMM3 "setup_heroes_of_might_and_magic_3_complete_4.0_(28740).exe"
 ```
 

--- a/docs/players/Installation_iOS.md
+++ b/docs/players/Installation_iOS.md
@@ -53,7 +53,7 @@ The easiest way to install the ipa on your device is to do one of the following:
 
 Alternatively, to install the signed ipa on your device, you can use Xcode or Apple Configurator (available on the Mac App Store for free). The latter also allows installing ipa from the command line, here's an example that assumes you have only 1 device connected to your Mac and the signed ipa is on your desktop:
 
-```
+```sh
 /Applications/Apple\ Configurator.app/Contents/MacOS/cfgutil install-app ~/Desktop/vcmi.ipa
 ```
 


### PR DESCRIPTION
One of the rules from markdownlint that was not enabled initially.

We have some places where code block is used without specifying language, leading to no syntax highlight on website or in github web UI. This enforces requirement to have language specified to prevent this.

For cases where syntax highlight is not needed, it is now possible to use `text` language.