### PR TITLE
Editing hero primary skill in map editor should not be influenced by artifacts

### DIFF
--- a/lib/mapObjects/CGHeroInstance.cpp
+++ b/lib/mapObjects/CGHeroInstance.cpp
@@ -1923,7 +1923,8 @@ int CGHeroInstance::getBasePrimarySkillValue(PrimarySkill which) const
 {
 	std::string cachingStr = "type_PRIMARY_SKILL_base_" + std::to_string(static_cast<int>(which));
 	auto selector = Selector::typeSubtype(BonusType::PRIMARY_SKILL, BonusSubtypeID(which)).And(Selector::sourceType()(BonusSource::HERO_BASE_SKILL));
-	return valOfBonuses(selector, cachingStr);
+	auto minSkillValue = VLC->engineSettings()->getVector(EGameSettings::HEROES_MINIMAL_PRIMARY_SKILLS)[which.getNum()];
+	return std::max(valOfBonuses(selector, cachingStr), minSkillValue);
 }
 
 VCMI_LIB_NAMESPACE_END

--- a/mapeditor/inspector/heroskillswidget.cpp
+++ b/mapeditor/inspector/heroskillswidget.cpp
@@ -67,10 +67,10 @@ void HeroSkillsWidget::on_checkBox_toggled(bool checked)
 
 void HeroSkillsWidget::obtainData()
 {
-	ui->attack->setValue(hero.getPrimSkillLevel(PrimarySkill::ATTACK));
-	ui->defence->setValue(hero.getPrimSkillLevel(PrimarySkill::DEFENSE));
-	ui->power->setValue(hero.getPrimSkillLevel(PrimarySkill::SPELL_POWER));
-	ui->knowledge->setValue(hero.getPrimSkillLevel(PrimarySkill::KNOWLEDGE));
+	ui->attack->setValue(hero.getBasePrimarySkillValue(PrimarySkill::ATTACK));
+	ui->defence->setValue(hero.getBasePrimarySkillValue(PrimarySkill::DEFENSE));
+	ui->power->setValue(hero.getBasePrimarySkillValue(PrimarySkill::SPELL_POWER));
+	ui->knowledge->setValue(hero.getBasePrimarySkillValue(PrimarySkill::KNOWLEDGE));
 	
 	if(!hero.secSkills.empty() && hero.secSkills.front().first.getNum() == -1)
 		return;


### PR DESCRIPTION
Hero skill widget was initialized with value of primary skills with all bonuses, while it should only show hero base primary skills.
`getBasePrimarySkillValue` was used only in `HeroManager::evaluateFightingStrength` so I guess it won't hurt to take minimal hero skills into calculation