### PR TITLE
Launcher fix

### DIFF
--- a/launcher/innoextract.cpp
+++ b/launcher/innoextract.cpp
@@ -83,6 +83,8 @@ QString Innoextract::getHashError(QString exeFile, QString binFile, QString exeF
 	};
 	
 	std::vector<data> knownHashes = {
+	//	{ H3_COMPLETE, "english", 973162040,          0, "7cf1ecec73e8c2f2c2619415cd16749be5641942", ""                                         }, // setup_homm_3_complete_4.0_(10665).exe
+	//	{ H3_COMPLETE, "french",        ???,          0, "7e5a737c51530a1888033d188ab0635825ee622f", ""                                         }, // setup_homm_3_complete_french_4.0_(10665).exe
 		{ H3_COMPLETE, "english",    822520, 1005040617, "66646a353b06417fa12c6384405688c84a315cc1", "c624e2071f4e35386765ab044ad5860ac245b7f4" }, // setup_heroes_of_might_and_magic_3_complete_4.0_(28740).exe
 		{ H3_COMPLETE, "french",     824960,  997305870, "072f1d4466ff16444d8c7949c6530448a9c53cfa", "9b6b451d2bd2f8b4be159e62fa6d32e87ee10455" }, // setup_heroes_of_might_and_magic_3_complete_4.0_(french)_(28740).exe
 		{ H3_COMPLETE, "polish",     822288,  849286313, "74ffde00156dd5a8e237668f87213387f0dd9c7c", "2523cf9943043ae100186f89e4ebf7c28be09804" }, // setup_heroes_of_might_and_magic_3_complete_4.0_(polish)_(28740).exe

--- a/launcher/mainwindow_moc.cpp
+++ b/launcher/mainwindow_moc.cpp
@@ -77,6 +77,8 @@ MainWindow::MainWindow(QWidget * parent)
 
 	ui->setupUi(this);
 
+	setAcceptDrops(true);
+
 	setWindowIcon(QIcon{":/icons/menu-game.png"});
 	ui->modslistButton->setIcon(QIcon{":/icons/menu-mods.png"});
 	ui->settingsButton->setIcon(QIcon{":/icons/menu-settings.png"});

--- a/launcher/mainwindow_moc.cpp
+++ b/launcher/mainwindow_moc.cpp
@@ -164,6 +164,10 @@ void MainWindow::switchToStartTab()
 	ui->startGameButton->setEnabled(true);
 	ui->startGameButton->setChecked(true);
 	ui->tabListWidget->setCurrentIndex(TabRows::START);
+
+	auto* startGameTabWidget = qobject_cast<StartGameTab*>(ui->tabListWidget->widget(TabRows::START));
+	if(startGameTabWidget)
+		startGameTabWidget->refreshState();
 }
 
 void MainWindow::switchToModsTab()
@@ -247,6 +251,9 @@ void MainWindow::dropEvent(QDropEvent* event)
 
 void MainWindow::manualInstallFile(QString filePath)
 {
+	if(filePath.endsWith(".zip", Qt::CaseInsensitive) || filePath.endsWith(".exe", Qt::CaseInsensitive))
+		switchToModsTab();
+
 	QString fileName = QFileInfo{filePath}.fileName();
 	if(filePath.endsWith(".zip", Qt::CaseInsensitive))
 		getModView()->downloadFile(fileName.toLower()
@@ -279,7 +286,7 @@ void MainWindow::manualInstallFile(QString filePath)
 		}
 	}
 	else
-		getModView()->downloadFile(fileName, QUrl::fromLocalFile(filePath), fileName);
+		getModView()->installFiles(QStringList{filePath});
 }
 
 ETranslationStatus MainWindow::getTranslationStatus()

--- a/launcher/modManager/chroniclesextractor.cpp
+++ b/launcher/modManager/chroniclesextractor.cpp
@@ -129,16 +129,14 @@ void ChroniclesExtractor::createBaseMod() const
 
 	for(auto & dataPath : VCMIDirs::get().dataPaths())
 	{
-		auto file = dataPath / "config" / "heroes" / "portraitsChronicles.json";
+		auto file = pathToQString(dataPath / "config" / "heroes" / "portraitsChronicles.json");
 		auto destFolder = VCMIDirs::get().userDataPath() / "Mods" / "chronicles" / "content" / "config";
-		if(boost::filesystem::exists(file))
+		auto destFile = pathToQString(destFolder / "portraitsChronicles.json");
+		if(QFile::exists(file))
 		{
-			boost::filesystem::create_directories(destFolder);
-#if BOOST_VERSION >= 107400
-			boost::filesystem::copy_file(file, destFolder / "portraitsChronicles.json", boost::filesystem::copy_options::overwrite_existing);
-#else
-			boost::filesystem::copy_file(file, destFolder / "portraitsChronicles.json", boost::filesystem::copy_option::overwrite_if_exists);
-#endif
+			QDir().mkpath(pathToQString(destFolder));
+			QFile::remove(destFile);
+			QFile::copy(file, destFile);
 		}
 	}
 }

--- a/launcher/modManager/chroniclesextractor.cpp
+++ b/launcher/modManager/chroniclesextractor.cpp
@@ -235,16 +235,19 @@ void ChroniclesExtractor::installChronicles(QStringList exe)
 	for(QString f : exe)
 	{
 		extractionFile++;
-		QFile file(f);
+
+		if(!createTempDir())
+			continue;
+		
+		QString filepath = tempDir.filePath("chr.exe");
+		QFile(f).copy(filepath);
+		QFile file(filepath);
 
 		int chronicleNo = getChronicleNo(file);
 		if(!chronicleNo)
 			continue;
 
-		if(!createTempDir())
-			continue;
-
-		if(!extractGogInstaller(f))
+		if(!extractGogInstaller(filepath))
 			continue;
 		
 		createBaseMod();

--- a/launcher/modManager/cmodlistview_moc.cpp
+++ b/launcher/modManager/cmodlistview_moc.cpp
@@ -110,8 +110,6 @@ CModListView::CModListView(QWidget * parent)
 {
 	ui->setupUi(this);
 
-	setAcceptDrops(true);
-
 	ui->uninstallButton->setIcon(QIcon{":/icons/mod-delete.png"});
 	ui->enableButton->setIcon(QIcon{":/icons/mod-enabled.png"});
 	ui->disableButton->setIcon(QIcon{":/icons/mod-disabled.png"});

--- a/launcher/modManager/cmodlistview_moc.cpp
+++ b/launcher/modManager/cmodlistview_moc.cpp
@@ -788,6 +788,8 @@ void CModListView::installFiles(QStringList files)
 
 	if(!exe.empty())
 	{
+		ui->progressWidget->setVisible(true);
+		ui->pushButton->setEnabled(false);
 		ui->progressBar->setFormat(tr("Installing chronicles"));
 
 		float prog = 0.0;
@@ -807,6 +809,9 @@ void CModListView::installFiles(QStringList files)
 		
 		if(futureExtract.get())
 		{
+			hideProgressBar();
+			ui->pushButton->setEnabled(true);
+			ui->progressWidget->setVisible(false);
 			//update
 			modStateModel->reloadLocalState();
 			modModel->reloadRepositories();

--- a/launcher/modManager/cmodlistview_moc.h
+++ b/launcher/modManager/cmodlistview_moc.h
@@ -54,7 +54,6 @@ class CModListView : public QWidget
 
 	void installMods(QStringList archives);
 	void installMaps(QStringList maps);
-	void installFiles(QStringList mods);
 
 	QString genChangelogText(const ModState & mod);
 	QString genModInfoText(const ModState & mod);
@@ -113,6 +112,7 @@ public:
 	bool isModInstalled(const QString & modName);
 
 	void downloadFile(QString file, QUrl url, QString description, qint64 sizeBytes = 0);
+	void installFiles(QStringList mods);
 
 public slots:
 	void enableModByName(QString modName);

--- a/launcher/startGame/StartGameTab.h
+++ b/launcher/startGame/StartGameTab.h
@@ -33,8 +33,6 @@ class StartGameTab : public QWidget
 
 	MainWindow * getMainWindow();
 
-	void refreshState();
-
 	void refreshUpdateStatus(EGameUpdateStatus status);
 	void refreshTranslation(ETranslationStatus status);
 	void refreshMods();
@@ -44,6 +42,8 @@ class StartGameTab : public QWidget
 public:
 	explicit StartGameTab(QWidget * parent = nullptr);
 	~StartGameTab();
+
+	void refreshState();
 
 private slots:
 	void on_buttonGameStart_clicked();


### PR DESCRIPTION
Manual install handling:
- avoid download manager for exe (fix super long loading on android)
  - copy file first (like in H3Complete install) -> Needed because innoxtract cannot handle Urls (QT can do)
- fix crash with chronicles mod generation on android
- switch to mod manager for exe and zip after selecting files (loadingbar is displayed there)
- refresh state after new chronicles are installed
- fix drag & drop

Also:
- Add two hashes as comment (only for documentation)