### PR TITLE
Ensure the commander has no melee penalty when gaining the SHOOT ability

### DIFF
--- a/client/windows/CCreatureWindow.cpp
+++ b/client/windows/CCreatureWindow.cpp
@@ -498,15 +498,18 @@ CStackWindow::CommanderMainSection::CommanderMainSection(CStackWindow * owner, i
 			{
 				if(index == 0 && skillID >= 100)
 				{
-					const auto bonus = CGI->creh->skillRequirements[skillID-100].first;
+					const auto bonuses = CGI->creh->skillRequirements[skillID-100].first;
 					const CStackInstance * stack = parent->info->commander;
-					auto icon = std::make_shared<CCommanderSkillIcon>(std::make_shared<CPicture>(stack->bonusToGraphics(bonus)), true,  [](){});
+					auto icon = std::make_shared<CCommanderSkillIcon>(std::make_shared<CPicture>(stack->bonusToGraphics(bonuses[0])), true, [](){});
 					icon->callback = [=]()
 					{
 						parent->setSelection(skillID, icon);
 					};
-					icon->text = stack->bonusToString(bonus, true);
-					icon->hoverText = stack->bonusToString(bonus, false);
+					for(int i = 0; i < bonuses.size(); i++) 
+					{
+						icon->text += stack->bonusToString(bonuses[i], true) + "\n";
+						icon->hoverText += stack->bonusToString(bonuses[i], false) + "\n";
+					}
 
 					return icon;
 				}

--- a/config/commanders.json
+++ b/config/commanders.json
@@ -25,7 +25,7 @@
 		{"ability": ["ENEMY_DEFENCE_REDUCTION", 50, null, 0 ], "skills": [0, 1]},
 		{"ability": ["FEAR", 0, null, 0 ], "skills": [0, 2]},
 		{"ability": ["ALWAYS_MAXIMUM_DAMAGE", 0, null, 0 ], "skills": [0, 3]},
-		{"ability": ["SHOOTER", 0, null, 0 ], "skills": [0, 4]},
+		{"ability": [["SHOOTER", 0, null, 0 ], ["NO_MELEE_PENALTY", 0, null, 0 ]], "skills": [0, 4]},
 		{"ability": ["BLOCKS_RETALIATION", 0, null, 0 ], "skills": [0,5]},
 		{"ability": ["UNLIMITED_RETALIATIONS", 0, null, 0 ], "skills": [1, 2]},
 		{"ability": ["ATTACKS_ALL_ADJACENT", 0, null, 0 ], "skills": [1, 3]},

--- a/lib/CCreatureHandler.cpp
+++ b/lib/CCreatureHandler.cpp
@@ -454,8 +454,14 @@ void CCreatureHandler::loadCommanders()
 
 	for (auto ability : config["abilityRequirements"].Vector())
 	{
-		std::pair <std::shared_ptr<Bonus>, std::pair <ui8, ui8> > a;
-		a.first = JsonUtils::parseBonus (ability["ability"].Vector());
+		std::pair <std::vector<std::shared_ptr<Bonus> >, std::pair <ui8, ui8> > a;
+		JsonVector & abilities = ability["ability"].Vector();
+		a.first = std::vector<std::shared_ptr<Bonus> >();
+		if (abilities[0].isVector()) 
+			for (int i = 0; i < abilities.size(); i++) 
+				a.first.push_back(JsonUtils::parseBonus(abilities[i].Vector()));
+		else 
+			a.first.push_back(JsonUtils::parseBonus(ability["ability"].Vector()));
 		a.second.first =  static_cast<ui8>(ability["skills"].Vector()[0].Float());
 		a.second.second = static_cast<ui8>(ability["skills"].Vector()[1].Float());
 		skillRequirements.push_back (a);
@@ -1312,7 +1318,7 @@ int CCreatureHandler::stringToNumber(std::string & s) const
 CCreatureHandler::~CCreatureHandler()
 {
 	for(auto & p : skillRequirements)
-		p.first = nullptr;
+		p.first.clear();
 }
 
 CreatureID CCreatureHandler::pickRandomMonster(vstd::RNG & rand, int tier) const

--- a/lib/CCreatureHandler.h
+++ b/lib/CCreatureHandler.h
@@ -224,7 +224,7 @@ public:
 	//Commanders
 	BonusList commanderLevelPremy; //bonus values added with each level-up
 	std::vector< std::vector <ui8> > skillLevels; //how much of a bonus will be given to commander with every level. SPELL_POWER also gives CASTS and RESISTANCE
-	std::vector <std::pair <std::shared_ptr<Bonus>, std::pair <ui8, ui8> > > skillRequirements; // first - Bonus, second - which two skills are needed to use it
+	std::vector <std::pair <std::vector<std::shared_ptr<Bonus> >, std::pair <ui8, ui8> > > skillRequirements; // first - Bonus, second - which two skills are needed to use it
 
 	CreatureID pickRandomMonster(vstd::RNG & rand, int tier = -1) const; //tier <1 - CREATURES_PER_TOWN> or -1 for any
 

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -259,10 +259,13 @@ void CGameHandler::levelUpCommander (const CCommanderInstance * c, int skill)
 	}
 	else if (skill >= 100)
 	{
-		scp.which = SetCommanderProperty::SPECIAL_SKILL;
-		scp.accumulatedBonus = *VLC->creh->skillRequirements.at(skill-100).first;
-		scp.additionalInfo = skill; //unnormalized
-		sendAndApply(scp);
+		for(auto & bonus : VLC->creh->skillRequirements.at(skill - 100).first) 
+		{
+			scp.which = SetCommanderProperty::SPECIAL_SKILL;
+			scp.accumulatedBonus = *bonus;
+			scp.additionalInfo = skill; //unnormalized
+			sendAndApply(scp);
+		}
 	}
 	expGiven(hero);
 }


### PR DESCRIPTION
Now, while the commander gains the SHOOT bonus, it also incurs a melee penalty. This discourages players from choosing this bonus and does not align with the WoG setting (in WoG, commanders have no melee penalty). To address this, I modified commander.json to allow more bonuses in special skills and added the NO_MELEE_PENALTY bonus to attack+speed.