### PR TITLE
Fix crash on selecting different language during initial setup

### DIFF
--- a/launcher/startGame/StartGameTab.ui
+++ b/launcher/startGame/StartGameTab.ui
@@ -545,11 +545,6 @@
            <height>30</height>
           </size>
          </property>
-         <item>
-          <property name="text">
-           <string>Current Preset</string>
-          </property>
-         </item>
         </widget>
        </item>
        <item row="7" column="0">


### PR DESCRIPTION
Remove placeholder item from mod preset combobox - it should be filled using mod preset list from user config file, and should not be translated.