### PR TITLE
Fixes for beta bugs reported on Discord

### DIFF
--- a/launcher/modManager/cmodlistview_moc.cpp
+++ b/launcher/modManager/cmodlistview_moc.cpp
@@ -860,7 +860,7 @@ void CModListView::installMods(QStringList archives)
 	// uninstall old version of mod, if installed
 	for(QString mod : modNames)
 	{
-		if(modStateModel->getMod(mod).isInstalled())
+		if(modStateModel->isModExists(mod) && modStateModel->getMod(mod).isInstalled())
 		{
 			logGlobal->info("Uninstalling old version of mod '%s'", mod.toStdString());
 			if (modStateModel->isModEnabled(mod))

--- a/launcher/modManager/cmodlistview_moc.cpp
+++ b/launcher/modManager/cmodlistview_moc.cpp
@@ -779,25 +779,34 @@ void CModListView::installFiles(QStringList files)
 
 	if (!accumulatedRepositoryData.isNull() && !repositoryFilesEnqueued)
 	{
+		logGlobal->info("Installing repository: started");
 		manager->setRepositoryData(accumulatedRepositoryData);
 		modModel->reloadRepositories();
 
 		static const QString repositoryCachePath = CLauncherDirs::downloadsPath() + "/repositoryCache.json";
 		JsonUtils::jsonToFile(repositoryCachePath, modStateModel->getRepositoryData());
+		logGlobal->info("Installing repository: ended");
 	}
 
 	if(!mods.empty())
 	{
+		logGlobal->info("Installing mods: started");
 		installMods(mods);
 		modStateModel->reloadLocalState();
 		modModel->reloadRepositories();
+		logGlobal->info("Installing mods: ended");
 	}
 
 	if(!maps.empty())
+	{
+		logGlobal->info("Installing maps: started");
 		installMaps(maps);
+		logGlobal->info("Installing maps: ended");
+	}
 
 	if(!exe.empty())
 	{
+		logGlobal->info("Installing chronicles: started");
 		ui->progressBar->setFormat(tr("Installing Heroes Chronicles"));
 		ui->progressWidget->setVisible(true);
 		ui->pushButton->setEnabled(false);
@@ -827,6 +836,7 @@ void CModListView::installFiles(QStringList files)
 			modStateModel->reloadLocalState();
 			modModel->reloadRepositories();
 		}
+		logGlobal->info("Installing chronicles: ended");
 	}
 
 	if(!images.empty())
@@ -852,6 +862,7 @@ void CModListView::installMods(QStringList archives)
 	{
 		if(modStateModel->getMod(mod).isInstalled())
 		{
+			logGlobal->info("Uninstalling old version of mod '%s'", mod.toStdString());
 			if (modStateModel->isModEnabled(mod))
 				modsToEnable.push_back(mod);
 
@@ -866,17 +877,23 @@ void CModListView::installMods(QStringList archives)
 
 	for(int i = 0; i < modNames.size(); i++)
 	{
+		logGlobal->info("Installing mod '%s'", modNames[i].toStdString());
 		ui->progressBar->setFormat(tr("Installing mod %1").arg(modNames[i]));
 		manager->installMod(modNames[i], archives[i]);
 	}
 
 	if (!modsToEnable.empty())
+	{
 		manager->enableMods(modsToEnable);
+	}
 
 	checkManagerErrors();
 
 	for(QString archive : archives)
+	{
+		logGlobal->info("Erasing archive '%s'", archive.toStdString());
 		QFile::remove(archive);
+	}
 }
 
 void CModListView::installMaps(QStringList maps)
@@ -885,6 +902,7 @@ void CModListView::installMaps(QStringList maps)
 
 	for(QString map : maps)
 	{
+		logGlobal->info("Importing map '%s'", map.toStdString());
 		QFile(map).rename(destDir + map.section('/', -1, -1));
 	}
 }

--- a/launcher/modManager/cmodlistview_moc.cpp
+++ b/launcher/modManager/cmodlistview_moc.cpp
@@ -27,12 +27,13 @@
 #include "../vcmiqt/jsonutils.h"
 #include "../helper.h"
 
-#include "../../lib/VCMIDirs.h"
 #include "../../lib/CConfigHandler.h"
-#include "../../lib/texts/Languages.h"
-#include "../../lib/modding/CModVersion.h"
+#include "../../lib/VCMIDirs.h"
 #include "../../lib/filesystem/Filesystem.h"
+#include "../../lib/json/JsonUtils.h"
+#include "../../lib/modding/CModVersion.h"
 #include "../../lib/texts/CGeneralTextHandler.h"
+#include "../../lib/texts/Languages.h"
 
 #include <future>
 
@@ -747,7 +748,7 @@ void CModListView::installFiles(QStringList files)
 		else if(filename.endsWith(".json", Qt::CaseInsensitive))
 		{
 			//download and merge additional files
-			const auto &repoData = JsonUtils::jsonFromFile(filename);
+			JsonNode repoData = JsonUtils::jsonFromFile(filename);
 			if(repoData["name"].isNull())
 			{
 				// This is main repository index. Download all referenced mods
@@ -769,7 +770,7 @@ void CModListView::installFiles(QStringList files)
 				// This is json of a single mod. Extract name of mod and add it to repo
 				auto modName = QFileInfo(filename).baseName().toStdString();
 				auto modNameLower = boost::algorithm::to_lower_copy(modName);
-				accumulatedRepositoryData[modNameLower] = repoData;
+				JsonUtils::merge(accumulatedRepositoryData[modNameLower], repoData);
 			}
 		}
 		else if(filename.endsWith(".png", Qt::CaseInsensitive))

--- a/launcher/modManager/modstatecontroller.cpp
+++ b/launcher/modManager/modstatecontroller.cpp
@@ -120,6 +120,9 @@ bool ModStateController::disableMod(QString modname)
 
 bool ModStateController::canInstallMod(QString modname)
 {
+	if (!modList->isModExists(modname))
+		return true; // for installation of unknown mods, e.g. via "Install from file" option
+
 	auto mod = modList->getMod(modname);
 
 	if(mod.isSubmod())

--- a/launcher/startGame/StartGameTab.cpp
+++ b/launcher/startGame/StartGameTab.cpp
@@ -23,7 +23,10 @@
 void StartGameTab::changeEvent(QEvent *event)
 {
 	if(event->type() == QEvent::LanguageChange)
+	{
 		ui->retranslateUi(this);
+		refreshState();
+	}
 
 	QWidget::changeEvent(event);
 }

--- a/lib/modding/ModManager.cpp
+++ b/lib/modding/ModManager.cpp
@@ -163,7 +163,7 @@ ModsPresetState::ModsPresetState()
 		CResourceHandler::get("local")->createResource(settingsPath.getOriginalName() + ".json");
 	}
 
-	if(modConfig["presets"].isNull())
+	if(modConfig["presets"].isNull() || modConfig["presets"].Struct().empty())
 	{
 		modConfig["activePreset"] = JsonNode("default");
 		if(modConfig["activeMods"].isNull())
@@ -171,6 +171,10 @@ ModsPresetState::ModsPresetState()
 		else
 			importInitialPreset(); // 1.5 format import
 	}
+
+	auto allPresets = getAllPresets();
+	if (!vstd::contains(allPresets, modConfig["activePreset"].String()))
+		modConfig["activePreset"] = JsonNode(allPresets.front());
 }
 
 void ModsPresetState::createInitialPreset()


### PR DESCRIPTION
- Fix overwriting mod download URL during repo checkout leading to inability to install mods
- Fix crash on attempt to install mod not present in mod repository via "Install from file" option
- Reload start game tab state on language change. This should correctly retranslate all labels like "Update X mods" instead of having empty buttons.
- Added auto-recovery from cases when active preset specified in modSettings.json does not exists
