### PR TITLE
Attempt to fix Chronicles installation on Android

### DIFF
--- a/launcher/firstLaunch/firstlaunch_moc.cpp
+++ b/launcher/firstLaunch/firstlaunch_moc.cpp
@@ -371,6 +371,9 @@ void FirstLaunchView::extractGogData()
 		QFile(fileExe).copy(tmpFileExe);
 		QFile(fileBin).copy(tmpFileBin);
 
+		logGlobal->info("Installing exe '%s' ('%s')", tmpFileExe.toStdString(), fileExe.toStdString());
+		logGlobal->info("Installing bin '%s' ('%s')", tmpFileBin.toStdString(), fileBin.toStdString());
+
 		QString errorText{};
 
 		auto isGogGalaxyExe = [](QString fileToTest) {

--- a/launcher/mainwindow_moc.cpp
+++ b/launcher/mainwindow_moc.cpp
@@ -258,12 +258,15 @@ void MainWindow::manualInstallFile(QString filePath)
 
 	QString fileName = QFileInfo{filePath}.fileName();
 	if(filePath.endsWith(".zip", Qt::CaseInsensitive))
-		getModView()->downloadFile(fileName.toLower()
-														// mod name currently comes from zip file -> remove suffixes from github zip download
-														.replace(QRegularExpression("-[0-9a-f]{40}"), "")
-														.replace(QRegularExpression("-vcmi-.+\\.zip"), ".zip")
-														.replace("-main.zip", ".zip")
-													, QUrl::fromLocalFile(filePath), "mods");
+	{
+		QString filenameClean = fileName.toLower()
+			// mod name currently comes from zip file -> remove suffixes from github zip download
+			.replace(QRegularExpression("-[0-9a-f]{40}"), "")
+			.replace(QRegularExpression("-vcmi-.+\\.zip"), ".zip")
+			.replace("-main.zip", ".zip");
+
+		getModView()->downloadFile(filenameClean, QUrl::fromLocalFile(filePath), "mods");
+	}
 	else if(filePath.endsWith(".json", Qt::CaseInsensitive))
 	{
 		QDir configDir(QString::fromStdString(VCMIDirs::get().userConfigPath().string()));

--- a/launcher/modManager/chroniclesextractor.cpp
+++ b/launcher/modManager/chroniclesextractor.cpp
@@ -43,19 +43,21 @@ void ChroniclesExtractor::removeTempDir()
 
 int ChroniclesExtractor::getChronicleNo()
 {
-	for (size_t i = 1; i < chronicles.size(); ++i)
-	{
-		QString chronicleName = chronicles.at(i);
+	QStringList appDirCandidates = tempDir.entryList({"app"}, QDir::Filter::Dirs);
 
-		QStringList appDirCandidates = tempDir.entryList({"app"}, QDir::Filter::Dirs);
+	if (!appDirCandidates.empty())
+	{
 		QDir appDir = tempDir.filePath(appDirCandidates.front());
 
-		QStringList chroniclesDirCandidates = appDir.entryList({chronicleName}, QDir::Filter::Dirs);
+		for (size_t i = 1; i < chronicles.size(); ++i)
+		{
+			QString chronicleName = chronicles.at(i);
+			QStringList chroniclesDirCandidates = appDir.entryList({chronicleName}, QDir::Filter::Dirs);
 
-		if (!chroniclesDirCandidates.empty())
-			return i;
+			if (!chroniclesDirCandidates.empty())
+				return i;
+		}
 	}
-
 	QMessageBox::critical(parent, tr("Invalid file selected"), tr("You have to select a Heroes Chronicles installer file!"));
 	return 0;
 }
@@ -138,8 +140,8 @@ void ChroniclesExtractor::createChronicleMod(int no)
 	QJsonObject mod
 	{
 		{ "modType", "Expansion" },
-		{ "name", QString::number(no) + " - " + tmpChronicles },
-		{ "description", tr("Heroes Chronicles") + " - " + QString::number(no) + " - " + tmpChronicles },
+		{ "name", QString("%1 - %2").arg(no).arg(tmpChronicles) },
+		{ "description", tr("Heroes Chronicles %1 - %2").arg(no).arg(tmpChronicles) },
 		{ "author", "3DO" },
 		{ "version", "1.0" },
 		{ "contact", "vcmi.eu" },

--- a/launcher/modManager/chroniclesextractor.h
+++ b/launcher/modManager/chroniclesextractor.h
@@ -31,7 +31,7 @@ class ChroniclesExtractor : public QObject
 	void extractFiles(int no) const;
 
 	const QStringList chronicles = {
-		"", // fake	0th "chronicle", to create 1-based list
+		{}, // fake	0th "chronicle", to create 1-based list
 		"Warlords of the Wasteland",
 		"Conquest of the Underworld",
 		"Masters of the Elements",

--- a/launcher/modManager/chroniclesextractor.h
+++ b/launcher/modManager/chroniclesextractor.h
@@ -24,21 +24,22 @@ class ChroniclesExtractor : public QObject
 
 	bool createTempDir();
 	void removeTempDir();
-	int getChronicleNo(QFile & file);
+	int getChronicleNo();
 	bool extractGogInstaller(QString filePath);
 	void createBaseMod() const;
 	void createChronicleMod(int no);
 	void extractFiles(int no) const;
 
-	const std::map<int, QByteArray> chronicles = {
-		{1, QByteArray{reinterpret_cast<const char*>(u"Warlords of the Wasteland"), 50}},
-		{2, QByteArray{reinterpret_cast<const char*>(u"Conquest of the Underworld"), 52}},
-		{3, QByteArray{reinterpret_cast<const char*>(u"Masters of the Elements"), 46}},
-		{4, QByteArray{reinterpret_cast<const char*>(u"Clash of the Dragons"), 40}},
-		{5, QByteArray{reinterpret_cast<const char*>(u"The World Tree"), 28}},
-		{6, QByteArray{reinterpret_cast<const char*>(u"The Fiery Moon"), 28}},
-		{7, QByteArray{reinterpret_cast<const char*>(u"Revolt of the Beastmasters"), 52}},
-		{8, QByteArray{reinterpret_cast<const char*>(u"The Sword of Frost"), 36}}
+	const QStringList chronicles = {
+		"", // fake	0th "chronicle", to create 1-based list
+		"Warlords of the Wasteland",
+		"Conquest of the Underworld",
+		"Masters of the Elements",
+		"Clash of the Dragons",
+		"The World Tree",
+		"The Fiery Moon",
+		"Revolt of the Beastmasters",
+		"The Sword of Frost",
 	};
 public:
 	void installChronicles(QStringList exe);

--- a/launcher/modManager/cmodlistview_moc.cpp
+++ b/launcher/modManager/cmodlistview_moc.cpp
@@ -817,6 +817,8 @@ void CModListView::installFiles(QStringList files)
 		{
 			ChroniclesExtractor ce(this, [&prog](float progress) { prog = progress; });
 			ce.installChronicles(exe);
+			modStateModel->reloadLocalState();
+			modModel->reloadRepositories();
 			enableModByName("chronicles");
 			return true;
 		});

--- a/launcher/startGame/StartGameTab.cpp
+++ b/launcher/startGame/StartGameTab.cpp
@@ -219,7 +219,10 @@ void StartGameTab::on_buttonImportFiles_clicked()
 		QStringList files = QFileDialog::getOpenFileNames(this, tr("Select files (configs, mods, maps, campaigns, gog files) to install..."), QDir::homePath(), filter);
 
 		for(const auto & file : files)
+		{
+			logGlobal->info("Importing file %s", file.toStdString());
 			getMainWindow()->manualInstallFile(file);
+		}
 	};
 
 	// iOS can't display modal dialogs when called directly on button press

--- a/launcher/translation/chinese.ts
+++ b/launcher/translation/chinese.ts
@@ -1086,6 +1086,11 @@ Fullscreen Exclusive Mode - game will cover entirety of your screen and will use
         <source>Heroes Chronicles</source>
         <translation>英雄无敌历代记</translation>
     </message>
+    <message>
+        <location filename="../modManager/chroniclesextractor.cpp" line="144"/>
+        <source>Heroes Chronicles %1 - %2</source>
+        <translation type="unfinished">英雄无敌历代记 %1 - %2</translation>
+    </message>
 </context>
 <context>
     <name>File size</name>

--- a/launcher/translation/czech.ts
+++ b/launcher/translation/czech.ts
@@ -832,6 +832,11 @@ Režim celé obrazovky - hra pokryje celou vaši obrazovku a použije vybrané r
         <source>Heroes Chronicles</source>
         <translation>Heroes Chronicles</translation>
     </message>
+    <message>
+        <location filename="../modManager/chroniclesextractor.cpp" line="144"/>
+        <source>Heroes Chronicles %1 - %2</source>
+        <translation type="unfinished">Heroes Chronicles %1 - %2</translation>
+    </message>
 </context>
 <context>
     <name>File size</name>

--- a/launcher/translation/french.ts
+++ b/launcher/translation/french.ts
@@ -1055,6 +1055,11 @@ Mode exclusif plein écran - le jeu couvrira l&quot;intégralité de votre écra
         <source>Heroes Chronicles</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../modManager/chroniclesextractor.cpp" line="144"/>
+        <source>Heroes Chronicles %1 - %2</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>File size</name>

--- a/launcher/translation/german.ts
+++ b/launcher/translation/german.ts
@@ -1080,6 +1080,11 @@ Exklusiver Vollbildmodus - das Spiel bedeckt den gesamten Bildschirm und verwend
         <source>Heroes Chronicles</source>
         <translation>Heroes Chronicles</translation>
     </message>
+    <message>
+        <location filename="../modManager/chroniclesextractor.cpp" line="144"/>
+        <source>Heroes Chronicles %1 - %2</source>
+        <translation type="unfinished">Heroes Chronicles %1 - %2</translation>
+    </message>
 </context>
 <context>
     <name>File size</name>

--- a/launcher/translation/polish.ts
+++ b/launcher/translation/polish.ts
@@ -1080,6 +1080,11 @@ Pełny ekran klasyczny - gra przysłoni cały ekran uruchamiając się w wybrane
         <source>Heroes Chronicles</source>
         <translation>Heroes Kroniki</translation>
     </message>
+    <message>
+        <location filename="../modManager/chroniclesextractor.cpp" line="144"/>
+        <source>Heroes Chronicles %1 - %2</source>
+        <translation type="unfinished">Heroes Kroniki %1 - %2</translation>
+    </message>
 </context>
 <context>
     <name>File size</name>

--- a/launcher/translation/portuguese.ts
+++ b/launcher/translation/portuguese.ts
@@ -898,6 +898,11 @@ Modo de tela cheia exclusivo - o jogo cobrirá toda a sua tela e usará a resolu
         <source>Heroes Chronicles</source>
         <translation>Heroes Chronicles</translation>
     </message>
+    <message>
+        <location filename="../modManager/chroniclesextractor.cpp" line="144"/>
+        <source>Heroes Chronicles %1 - %2</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>File size</name>

--- a/launcher/translation/russian.ts
+++ b/launcher/translation/russian.ts
@@ -918,6 +918,11 @@ Fullscreen Exclusive Mode - the game will cover the entirety of your screen and 
         <source>Heroes Chronicles</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../modManager/chroniclesextractor.cpp" line="144"/>
+        <source>Heroes Chronicles %1 - %2</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>File size</name>

--- a/launcher/translation/spanish.ts
+++ b/launcher/translation/spanish.ts
@@ -949,6 +949,11 @@ Pantalla completa - el juego cubrirá la totalidad de la pantalla y utilizará l
         <source>Heroes Chronicles</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../modManager/chroniclesextractor.cpp" line="144"/>
+        <source>Heroes Chronicles %1 - %2</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>File size</name>

--- a/launcher/translation/swedish.ts
+++ b/launcher/translation/swedish.ts
@@ -1074,6 +1074,11 @@ Exklusivt helskärmsläge - spelet kommer att täcka hela skärmen och använda 
         <source>Heroes Chronicles</source>
         <translation>Heroes Chronicles</translation>
     </message>
+    <message>
+        <location filename="../modManager/chroniclesextractor.cpp" line="144"/>
+        <source>Heroes Chronicles %1 - %2</source>
+        <translation type="unfinished">Heroes Chronicles %1 - %2</translation>
+    </message>
 </context>
 <context>
     <name>File size</name>

--- a/launcher/translation/ukrainian.ts
+++ b/launcher/translation/ukrainian.ts
@@ -1056,6 +1056,11 @@ Fullscreen Exclusive Mode - game will cover entirety of your screen and will use
         <source>Heroes Chronicles</source>
         <translation>Хроніки Героїв</translation>
     </message>
+    <message>
+        <location filename="../modManager/chroniclesextractor.cpp" line="144"/>
+        <source>Heroes Chronicles %1 - %2</source>
+        <translation type="unfinished">Хроніки Героїв %1 - %2</translation>
+    </message>
 </context>
 <context>
     <name>File size</name>

--- a/launcher/translation/vietnamese.ts
+++ b/launcher/translation/vietnamese.ts
@@ -934,6 +934,11 @@ Toàn màn hình riêng biệt - Trò chơi chạy toàn màn hình và dùng đ
         <source>Heroes Chronicles</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../modManager/chroniclesextractor.cpp" line="144"/>
+        <source>Heroes Chronicles %1 - %2</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>File size</name>


### PR DESCRIPTION
Seems to be working now, at least on my phone.

- Simplified detection of which Chronicles was provided by player (by examining extracted content instead of searching in binary file)
- Fixed enabling of 1st imported Chronicle (mod was enabled before mod manager reloaded its state)
- Added logging to help with tracking down similar issues in the future 