### PR TITLE
[1.6.1?] Mod preset import/export

### DIFF
--- a/launcher/modManager/cmodlistview_moc.cpp
+++ b/launcher/modManager/cmodlistview_moc.cpp
@@ -1143,3 +1143,14 @@ QString CModListView::getActivePreset() const
 {
 	return modStateModel->getActivePreset();
 }
+
+JsonNode CModListView::exportCurrentPreset() const
+{
+	return modStateModel->exportCurrentPreset();
+}
+
+void CModListView::importPreset(const JsonNode & data)
+{
+	modStateModel->importPreset(data);
+	modStateModel->reloadLocalState();
+}

--- a/launcher/modManager/cmodlistview_moc.cpp
+++ b/launcher/modManager/cmodlistview_moc.cpp
@@ -857,6 +857,12 @@ void CModListView::installMods(QStringList archives)
 		modNames.push_back(modName);
 	}
 
+	if (!activatingPreset.isEmpty())
+	{
+		modStateModel->activatePreset(activatingPreset);
+		activatingPreset.clear();
+	}
+
 	// uninstall old version of mod, if installed
 	for(QString mod : modNames)
 	{
@@ -1151,6 +1157,17 @@ JsonNode CModListView::exportCurrentPreset() const
 
 void CModListView::importPreset(const JsonNode & data)
 {
-	modStateModel->importPreset(data);
-	modStateModel->reloadLocalState();
+	const auto & [presetName, modList] = modStateModel->importPreset(data);
+
+	if (modList.empty())
+	{
+		modStateModel->activatePreset(presetName);
+		modStateModel->reloadLocalState();
+	}
+	else
+	{
+		activatingPreset = presetName;
+		for (const auto & modID : modList)
+			doInstallMod(modID);
+	}
 }

--- a/launcher/modManager/cmodlistview_moc.h
+++ b/launcher/modManager/cmodlistview_moc.h
@@ -37,6 +37,7 @@ class CModListView : public QWidget
 	CModFilterModel * filterModel;
 	CDownloadManager * dlManager;
 	JsonNode accumulatedRepositoryData;
+	QString activatingPreset;
 
 	QStringList enqueuedModDownloads;
 

--- a/launcher/modManager/cmodlistview_moc.h
+++ b/launcher/modManager/cmodlistview_moc.h
@@ -97,16 +97,15 @@ public:
 	QStringList getUpdateableMods();
 
 	void createNewPreset(const QString & presetName);
-
 	void deletePreset(const QString & presetName);
-
 	void activatePreset(const QString & presetName);
-
 	void renamePreset(const QString & oldPresetName, const QString & newPresetName);
 
 	QStringList getAllPresets() const;
-
 	QString getActivePreset() const;
+
+	JsonNode exportCurrentPreset() const;
+	void importPreset(const JsonNode & data);
 
 	/// returns true if mod is currently enabled
 	bool isModEnabled(const QString & modName);

--- a/launcher/modManager/modstatemodel.cpp
+++ b/launcher/modManager/modstatemodel.cpp
@@ -157,3 +157,13 @@ QString ModStateModel::getActivePreset() const
 {
 	return QString::fromStdString(modManager->getActivePreset());
 }
+
+JsonNode ModStateModel::exportCurrentPreset() const
+{
+	return modManager->exportCurrentPreset();
+}
+
+void ModStateModel::importPreset(const JsonNode & data)
+{
+	modManager->importPreset(data);
+}

--- a/launcher/modManager/modstatemodel.cpp
+++ b/launcher/modManager/modstatemodel.cpp
@@ -163,7 +163,10 @@ JsonNode ModStateModel::exportCurrentPreset() const
 	return modManager->exportCurrentPreset();
 }
 
-void ModStateModel::importPreset(const JsonNode & data)
+std::tuple<QString, QStringList> ModStateModel::importPreset(const JsonNode & data)
 {
-	modManager->importPreset(data);
+	std::tuple<QString, QStringList> result;
+	const auto & [presetName, modList] = modManager->importPreset(data);
+
+	return {QString::fromStdString(presetName), stringListStdToQt(modList)};
 }

--- a/launcher/modManager/modstatemodel.h
+++ b/launcher/modManager/modstatemodel.h
@@ -59,5 +59,5 @@ public:
 	QString getActivePreset() const;
 
 	JsonNode exportCurrentPreset() const;
-	void importPreset(const JsonNode & data);
+	std::tuple<QString, QStringList> importPreset(const JsonNode & data);
 };

--- a/launcher/modManager/modstatemodel.h
+++ b/launcher/modManager/modstatemodel.h
@@ -57,4 +57,7 @@ public:
 
 	QStringList getAllPresets() const;
 	QString getActivePreset() const;
+
+	JsonNode exportCurrentPreset() const;
+	void importPreset(const JsonNode & data);
 };

--- a/launcher/startGame/StartGameTab.cpp
+++ b/launcher/startGame/StartGameTab.cpp
@@ -44,8 +44,6 @@ StartGameTab::StartGameTab(QWidget * parent)
 	refreshState();
 
 	ui->buttonGameResume->setVisible(false); // TODO: implement
-	ui->buttonPresetExport->setVisible(false); // TODO: implement
-	ui->buttonPresetImport->setVisible(false); // TODO: implement
 
 #ifndef ENABLE_EDITOR
 	ui->buttonGameEditor->hide();
@@ -360,12 +358,20 @@ void StartGameTab::on_buttonMissingCampaignsHelp_clicked()
 
 void StartGameTab::on_buttonPresetExport_clicked()
 {
-	// TODO
+	JsonNode presetJson = getMainWindow()->getModView()->exportCurrentPreset();
+	QString presetString = QString::fromStdString(presetJson.toCompactString());
+	QGuiApplication::clipboard()->setText(presetString);
 }
 
 void StartGameTab::on_buttonPresetImport_clicked()
 {
-	// TODO
+	QString presetString = QGuiApplication::clipboard()->text();
+	QByteArray presetBytes(presetString.toUtf8());
+	JsonNode presetJson(reinterpret_cast<const std::byte*>(presetBytes.data()), presetBytes.size(), "imported preset");
+
+	getMainWindow()->getModView()->importPreset(presetJson);
+	getMainWindow()->switchToModsTab();
+	refreshPresets();
 }
 
 void StartGameTab::on_buttonPresetNew_clicked()

--- a/launcher/startGame/StartGameTab.h
+++ b/launcher/startGame/StartGameTab.h
@@ -65,19 +65,14 @@ private slots:
 	void on_buttonMissingVideoHelp_clicked();
 	void on_buttonMissingFilesHelp_clicked();
 	void on_buttonMissingCampaignsHelp_clicked();
-
 	void on_buttonPresetExport_clicked();
-
 	void on_buttonPresetImport_clicked();
-
 	void on_buttonPresetNew_clicked();
-
 	void on_buttonPresetDelete_clicked();
-
 	void on_comboBoxModPresets_currentTextChanged(const QString &arg1);
-
 	void on_buttonPresetRename_clicked();
 
+	void clipboardDataChanged();
 private:
 	Ui::StartGameTab * ui;
 };

--- a/lib/modding/ModManager.h
+++ b/lib/modding/ModManager.h
@@ -58,6 +58,9 @@ public:
 	std::vector<std::string> getAllPresets() const;
 	std::string getActivePreset() const;
 
+	JsonNode exportCurrentPreset() const;
+	void importPreset(const JsonNode & data);
+
 	void setModActive(const TModID & modName, bool isActive);
 
 	void addRootMod(const TModID & modName);
@@ -155,6 +158,9 @@ public:
 
 	std::vector<std::string> getAllPresets() const;
 	std::string getActivePreset() const;
+
+	JsonNode exportCurrentPreset() const;
+	void importPreset(const JsonNode & data);
 };
 
 VCMI_LIB_NAMESPACE_END

--- a/lib/modding/ModManager.h
+++ b/lib/modding/ModManager.h
@@ -59,7 +59,10 @@ public:
 	std::string getActivePreset() const;
 
 	JsonNode exportCurrentPreset() const;
-	void importPreset(const JsonNode & data);
+
+	/// Imports preset from provided json
+	/// Returns name of imported preset on success
+	std::string importPreset(const JsonNode & data);
 
 	void setModActive(const TModID & modName, bool isActive);
 
@@ -75,6 +78,8 @@ public:
 
 	/// Returns list of currently active root mods (non-submod)
 	TModList getActiveRootMods() const;
+	/// Returns list of root mods present in specified preset
+	TModList getRootMods(const std::string & presetName) const;
 
 	/// Returns list of all known settings (submods) for a specified mod
 	std::map<TModID, bool> getModSettings(const TModID & modID) const;
@@ -160,7 +165,10 @@ public:
 	std::string getActivePreset() const;
 
 	JsonNode exportCurrentPreset() const;
-	void importPreset(const JsonNode & data);
+
+	/// Imports preset from provided json
+	/// Returns name of imported preset and list of mods that must be installed to activate preset
+	std::tuple<std::string, TModList> importPreset(const JsonNode & data);
 };
 
 VCMI_LIB_NAMESPACE_END


### PR DESCRIPTION
It is now possible to import or export mod preset via clipboard.

Game start tab now has (previously hidden) import from clipboard / export to clipboard buttons. Presets are imported or exported using Json format. Any missing mods will be downloaded from mod repository.

- On using preset export, checkmark icon will be added to button to indicate that preset was exported.
- Import preset button is blocked unless clipboard data contains json with expected format

Example of preset that only includes Tides of War:
```json
{
	"mods" : [ "vcmi", "core", "tides-of-war" ],
	"name" : "Tides of War only",
	"settings" : {
		"tides-of-war" : {
			"alternative-creatures" : true,
			"artifacts" : true,
			"banks" : true,
			"heroes" : true,
			"hota-balance-compatibility-patch" : false,
			"lessrandomstart" : false,
			"neutral-creatures" : true,
			"objects" : true,
			"skills" : true,
			"spells" : true,
			"tow-main-menu" : false,
			"transformationaltar" : false
		}
	}
}
```