### PR TITLE
[1.6.1] fix music

### DIFF
--- a/client/mainmenu/CHighScoreScreen.cpp
+++ b/client/mainmenu/CHighScoreScreen.cpp
@@ -216,9 +216,15 @@ CHighScoreInputScreen::CHighScoreInputScreen(bool won, HighScoreCalculation calc
 	}
 }
 
+void CHighScoreInputScreen::stopMusicAndClose()
+{
+	CMM->playMusic();
+	close();
+}
+
 void CHighScoreInputScreen::onVideoPlaybackFinished()
 {
-	close();
+	stopMusicAndClose();
 }
 
 int CHighScoreInputScreen::addEntry(std::string text) {
@@ -275,7 +281,7 @@ void CHighScoreInputScreen::clickPressed(const Point & cursorPosition)
 
 	if(!won)
 	{
-		close();
+		stopMusicAndClose();
 		return;
 	}
 
@@ -291,7 +297,7 @@ void CHighScoreInputScreen::clickPressed(const Point & cursorPosition)
 				GH.windows().createAndPushWindow<CHighScoreScreen>(calc.isCampaign ? CHighScoreScreen::HighScorePage::CAMPAIGN : CHighScoreScreen::HighScorePage::SCENARIO, pos);
 			}
 			else
-				close();
+				stopMusicAndClose();
 		});
 	}
 }

--- a/client/mainmenu/CHighScoreScreen.h
+++ b/client/mainmenu/CHighScoreScreen.h
@@ -85,6 +85,7 @@ class CHighScoreInputScreen : public CWindowObject, public IVideoHolder
 	HighScoreCalculation calc;
 	StatisticDataSet stat;
 
+	void stopMusicAndClose();
 	void onVideoPlaybackFinished() override;
 public:
 	CHighScoreInputScreen(bool won, HighScoreCalculation calc, const StatisticDataSet & statistic);


### PR DESCRIPTION
Reported on discord:

`minor bug in code probably related to your changes - on scenario lose the defeat music doesn't stop playing on skip and after that screen main menu music doesn't play no matter if you skip or wait till video end`