### PR TITLE
[1.6.1] Fixes for 1.6.0 issues reported on Discord

### DIFF
--- a/client/renderSDL/ScreenHandler.cpp
+++ b/client/renderSDL/ScreenHandler.cpp
@@ -356,6 +356,10 @@ EUpscalingFilter ScreenHandler::loadUpscalingFilter() const
 		return filter;
 
 	// else - autoselect
+#ifdef VCMI_MOBILE
+	// to help with performance - only if player explicitly enabled xbrz
+	return EUpscalingFilter::NONE;
+#else
 	Point outputResolution = getRenderResolution();
 	Point logicalResolution = getPreferredLogicalResolution();
 
@@ -371,6 +375,7 @@ EUpscalingFilter ScreenHandler::loadUpscalingFilter() const
 		return EUpscalingFilter::XBRZ_3; // resolutions below 2400p (including 1440p and 2160p / 4K)
 
 	return EUpscalingFilter::XBRZ_4; // Only for massive displays, e.g. 8K
+#endif
 }
 
 void ScreenHandler::selectUpscalingFilter()

--- a/client/renderSDL/ScreenHandler.cpp
+++ b/client/renderSDL/ScreenHandler.cpp
@@ -369,6 +369,14 @@ EUpscalingFilter ScreenHandler::loadUpscalingFilter() const
 
 	if (scaling <= 1.001f)
 		return EUpscalingFilter::NONE; // running at original resolution or even lower than that - no need for xbrz
+	else
+		return EUpscalingFilter::XBRZ_2;
+#endif
+
+#if 0
+// Old version, most optimal, but rather performance-heavy
+	if (scaling <= 1.001f)
+		return EUpscalingFilter::NONE; // running at original resolution or even lower than that - no need for xbrz
 	if (scaling <= 2.001f)
 		return EUpscalingFilter::XBRZ_2; // resolutions below 1200p (including 1080p / FullHD)
 	if (scaling <= 3.001f)

--- a/launcher/firstLaunch/firstlaunch_moc.cpp
+++ b/launcher/firstLaunch/firstlaunch_moc.cpp
@@ -19,6 +19,7 @@
 #include "../../lib/texts/Languages.h"
 #include "../../lib/VCMIDirs.h"
 #include "../../lib/filesystem/Filesystem.h"
+#include "../../vcmiqt/MessageBox.h"
 #include "../helper.h"
 #include "../languages.h"
 #include "../innoextract.h"
@@ -122,7 +123,7 @@ void FirstLaunchView::on_pushButtonDataCopy_clicked()
 #else
 	// iOS can't display modal dialogs when called directly on button press
 	// https://bugreports.qt.io/browse/QTBUG-98651
-	QTimer::singleShot(0, this, [this]{ copyHeroesData(); });
+	MessageBoxCustom::showDialog(this, [this]{ copyHeroesData(); });
 #endif
 }
 
@@ -130,7 +131,7 @@ void FirstLaunchView::on_pushButtonGogInstall_clicked()
 {
 	// iOS can't display modal dialogs when called directly on button press
 	// https://bugreports.qt.io/browse/QTBUG-98651
-	QTimer::singleShot(0, this, &FirstLaunchView::extractGogData);
+	MessageBoxCustom::showDialog(this, [this]{extractGogData();});
 }
 
 void FirstLaunchView::enterSetup()

--- a/launcher/startGame/StartGameTab.cpp
+++ b/launcher/startGame/StartGameTab.cpp
@@ -19,6 +19,7 @@
 
 #include "../../lib/filesystem/Filesystem.h"
 #include "../../lib/VCMIDirs.h"
+#include "../../vcmiqt/MessageBox.h"
 
 void StartGameTab::changeEvent(QEvent *event)
 {
@@ -269,7 +270,7 @@ void StartGameTab::on_buttonHelpImportFiles_clicked()
 		" - VCMI configuration files (.json)\n"
 	);
 
-	QMessageBox::information(this, ui->buttonImportFiles->text(), message);
+	MessageBox::information(this, ui->buttonImportFiles->text(), message);
 }
 
 void StartGameTab::on_buttonInstallTranslationHelp_clicked()
@@ -279,7 +280,7 @@ void StartGameTab::on_buttonInstallTranslationHelp_clicked()
 		"VCMI provides translations of the game into various languages that you can use. "
 		"Use this option to automatically install such translation to your language."
 	);
-	QMessageBox::information(this, ui->buttonInstallTranslation->text(), message);
+	MessageBox::information(this, ui->buttonInstallTranslation->text(), message);
 }
 
 void StartGameTab::on_buttonActivateTranslationHelp_clicked()
@@ -289,7 +290,7 @@ void StartGameTab::on_buttonActivateTranslationHelp_clicked()
 		"Use this option to enable it."
 	);
 
-	QMessageBox::information(this, ui->buttonActivateTranslation->text(), message);
+	MessageBox::information(this, ui->buttonActivateTranslation->text(), message);
 }
 
 void StartGameTab::on_buttonUpdateModsHelp_clicked()
@@ -301,7 +302,7 @@ void StartGameTab::on_buttonUpdateModsHelp_clicked()
 		"You many want to postpone mod update until you finish any of your ongoing games."
 		);
 
-	QMessageBox::information(this, ui->buttonUpdateMods->text(), message);
+	MessageBox::information(this, ui->buttonUpdateMods->text(), message);
 }
 
 void StartGameTab::on_buttonChroniclesHelp_clicked()
@@ -314,7 +315,7 @@ void StartGameTab::on_buttonChroniclesHelp_clicked()
 		"This will generate and install mod for VCMI that contains imported chronicles"
 	);
 
-	QMessageBox::information(this, ui->labelChronicles->text(), message);
+	MessageBox::information(this, ui->labelChronicles->text(), message);
 }
 
 void StartGameTab::on_buttonMissingSoundtrackHelp_clicked()
@@ -325,7 +326,7 @@ void StartGameTab::on_buttonMissingSoundtrackHelp_clicked()
 		"To resolve this problem, please copy missing mp3 files from Heroes III to VCMI data files directory manually "
 		"or reinstall VCMI and re-import Heroes III data files"
 	);
-	QMessageBox::information(this, ui->labelMissingSoundtrack->text(), message);
+	MessageBox::information(this, ui->labelMissingSoundtrack->text(), message);
 }
 
 void StartGameTab::on_buttonMissingVideoHelp_clicked()
@@ -336,7 +337,7 @@ void StartGameTab::on_buttonMissingVideoHelp_clicked()
 		"To resolve this problem, please copy VIDEO.VID file from Heroes III to VCMI data files directory manually "
 		"or reinstall VCMI and re-import Heroes III data files"
 		);
-	QMessageBox::information(this, ui->labelMissingVideo->text(), message);
+	MessageBox::information(this, ui->labelMissingVideo->text(), message);
 }
 
 void StartGameTab::on_buttonMissingFilesHelp_clicked()
@@ -347,7 +348,7 @@ void StartGameTab::on_buttonMissingFilesHelp_clicked()
 		"To resolve this problem, please reinstall game and reimport data files using supported version of Heroes III. "
 		"VCMI requires Heroes III: Shadow of Death or Complete Edition to run, which you can get (for example) from gog.com"
 	);
-	QMessageBox::information(this, ui->labelMissingFiles->text(), message);
+	MessageBox::information(this, ui->labelMissingFiles->text(), message);
 }
 
 void StartGameTab::on_buttonMissingCampaignsHelp_clicked()
@@ -358,7 +359,7 @@ void StartGameTab::on_buttonMissingCampaignsHelp_clicked()
 		"To resolve this problem, please copy missing data files from Heroes III to VCMI data files directory manually "
 		"or reinstall VCMI and re-import Heroes III data files"
 	);
-	QMessageBox::information(this, ui->labelMissingCampaigns->text(), message);
+	MessageBox::information(this, ui->labelMissingCampaigns->text(), message);
 }
 
 void StartGameTab::on_buttonPresetExport_clicked()
@@ -373,21 +374,24 @@ void StartGameTab::on_buttonPresetImport_clicked()
 
 void StartGameTab::on_buttonPresetNew_clicked()
 {
-	bool ok;
-	QString presetName = QInputDialog::getText(
-		this,
-		ui->buttonPresetNew->text(),
-		tr("Enter preset name:"),
-		QLineEdit::Normal,
-		QString(),
-		&ok);
+	const auto & functor = [this](){
+		bool ok;
+		QString presetName = QInputDialog::getText(
+			this,
+			ui->buttonPresetNew->text(),
+			tr("Enter preset name:"),
+			QLineEdit::Normal,
+			QString(),
+			&ok);
 
-	if (ok && !presetName.isEmpty())
-	{
-		getMainWindow()->getModView()->createNewPreset(presetName);
-		getMainWindow()->getModView()->activatePreset(presetName);
-		refreshPresets();
-	}
+		if (ok && !presetName.isEmpty())
+		{
+			getMainWindow()->getModView()->createNewPreset(presetName);
+			getMainWindow()->getModView()->activatePreset(presetName);
+			refreshPresets();
+		}
+	};
+	MessageBox::showDialog(functor);
 }
 
 void StartGameTab::on_buttonPresetDelete_clicked()
@@ -411,21 +415,23 @@ void StartGameTab::on_comboBoxModPresets_currentTextChanged(const QString &prese
 
 void StartGameTab::on_buttonPresetRename_clicked()
 {
-	QString currentName = getMainWindow()->getModView()->getActivePreset();
+	const auto & functor = [this](){
+		QString currentName = getMainWindow()->getModView()->getActivePreset();
 
-	bool ok;
-	QString newName = QInputDialog::getText(
-		this,
-		ui->buttonPresetNew->text(),
-		tr("Rename preset '%1' to:").arg(currentName),
-		QLineEdit::Normal,
-		currentName,
-		&ok);
+		bool ok;
+		QString newName = QInputDialog::getText(
+			this,
+			ui->buttonPresetNew->text(),
+			tr("Rename preset '%1' to:").arg(currentName),
+			QLineEdit::Normal,
+			currentName,
+			&ok);
 
-	if (ok && !newName.isEmpty())
-	{
-		getMainWindow()->getModView()->renamePreset(currentName, newName);
-		refreshPresets();
-	}
+		if (ok && !newName.isEmpty())
+		{
+			getMainWindow()->getModView()->renamePreset(currentName, newName);
+			refreshPresets();
+		}
+	};
+	MessageBox::showDialog(functor);
 }
-

--- a/launcher/startGame/StartGameTab.cpp
+++ b/launcher/startGame/StartGameTab.cpp
@@ -228,7 +228,7 @@ void StartGameTab::on_buttonImportFiles_clicked()
 
 	// iOS can't display modal dialogs when called directly on button press
 	// https://bugreports.qt.io/browse/QTBUG-98651
-	QTimer::singleShot(0, this, importFunctor);
+	MessageBoxCustom::showDialog(this, importFunctor);
 }
 
 void StartGameTab::on_buttonInstallTranslation_clicked()
@@ -270,7 +270,7 @@ void StartGameTab::on_buttonHelpImportFiles_clicked()
 		" - VCMI configuration files (.json)\n"
 	);
 
-	MessageBox::information(this, ui->buttonImportFiles->text(), message);
+	MessageBoxCustom::information(this, ui->buttonImportFiles->text(), message);
 }
 
 void StartGameTab::on_buttonInstallTranslationHelp_clicked()
@@ -280,7 +280,7 @@ void StartGameTab::on_buttonInstallTranslationHelp_clicked()
 		"VCMI provides translations of the game into various languages that you can use. "
 		"Use this option to automatically install such translation to your language."
 	);
-	MessageBox::information(this, ui->buttonInstallTranslation->text(), message);
+	MessageBoxCustom::information(this, ui->buttonInstallTranslation->text(), message);
 }
 
 void StartGameTab::on_buttonActivateTranslationHelp_clicked()
@@ -290,7 +290,7 @@ void StartGameTab::on_buttonActivateTranslationHelp_clicked()
 		"Use this option to enable it."
 	);
 
-	MessageBox::information(this, ui->buttonActivateTranslation->text(), message);
+	MessageBoxCustom::information(this, ui->buttonActivateTranslation->text(), message);
 }
 
 void StartGameTab::on_buttonUpdateModsHelp_clicked()
@@ -302,7 +302,7 @@ void StartGameTab::on_buttonUpdateModsHelp_clicked()
 		"You many want to postpone mod update until you finish any of your ongoing games."
 		);
 
-	MessageBox::information(this, ui->buttonUpdateMods->text(), message);
+	MessageBoxCustom::information(this, ui->buttonUpdateMods->text(), message);
 }
 
 void StartGameTab::on_buttonChroniclesHelp_clicked()
@@ -315,7 +315,7 @@ void StartGameTab::on_buttonChroniclesHelp_clicked()
 		"This will generate and install mod for VCMI that contains imported chronicles"
 	);
 
-	MessageBox::information(this, ui->labelChronicles->text(), message);
+	MessageBoxCustom::information(this, ui->labelChronicles->text(), message);
 }
 
 void StartGameTab::on_buttonMissingSoundtrackHelp_clicked()
@@ -326,7 +326,7 @@ void StartGameTab::on_buttonMissingSoundtrackHelp_clicked()
 		"To resolve this problem, please copy missing mp3 files from Heroes III to VCMI data files directory manually "
 		"or reinstall VCMI and re-import Heroes III data files"
 	);
-	MessageBox::information(this, ui->labelMissingSoundtrack->text(), message);
+	MessageBoxCustom::information(this, ui->labelMissingSoundtrack->text(), message);
 }
 
 void StartGameTab::on_buttonMissingVideoHelp_clicked()
@@ -337,7 +337,7 @@ void StartGameTab::on_buttonMissingVideoHelp_clicked()
 		"To resolve this problem, please copy VIDEO.VID file from Heroes III to VCMI data files directory manually "
 		"or reinstall VCMI and re-import Heroes III data files"
 		);
-	MessageBox::information(this, ui->labelMissingVideo->text(), message);
+	MessageBoxCustom::information(this, ui->labelMissingVideo->text(), message);
 }
 
 void StartGameTab::on_buttonMissingFilesHelp_clicked()
@@ -348,7 +348,7 @@ void StartGameTab::on_buttonMissingFilesHelp_clicked()
 		"To resolve this problem, please reinstall game and reimport data files using supported version of Heroes III. "
 		"VCMI requires Heroes III: Shadow of Death or Complete Edition to run, which you can get (for example) from gog.com"
 	);
-	MessageBox::information(this, ui->labelMissingFiles->text(), message);
+	MessageBoxCustom::information(this, ui->labelMissingFiles->text(), message);
 }
 
 void StartGameTab::on_buttonMissingCampaignsHelp_clicked()
@@ -359,7 +359,7 @@ void StartGameTab::on_buttonMissingCampaignsHelp_clicked()
 		"To resolve this problem, please copy missing data files from Heroes III to VCMI data files directory manually "
 		"or reinstall VCMI and re-import Heroes III data files"
 	);
-	MessageBox::information(this, ui->labelMissingCampaigns->text(), message);
+	MessageBoxCustom::information(this, ui->labelMissingCampaigns->text(), message);
 }
 
 void StartGameTab::on_buttonPresetExport_clicked()
@@ -391,7 +391,7 @@ void StartGameTab::on_buttonPresetNew_clicked()
 			refreshPresets();
 		}
 	};
-	MessageBox::showDialog(functor);
+	MessageBoxCustom::showDialog(this, functor);
 }
 
 void StartGameTab::on_buttonPresetDelete_clicked()
@@ -433,5 +433,5 @@ void StartGameTab::on_buttonPresetRename_clicked()
 			refreshPresets();
 		}
 	};
-	MessageBox::showDialog(functor);
+	MessageBoxCustom::showDialog(this, functor);
 }

--- a/lib/CConsoleHandler.cpp
+++ b/lib/CConsoleHandler.cpp
@@ -299,7 +299,9 @@ CConsoleHandler::CConsoleHandler():
 	GetConsoleScreenBufferInfo(handleErr, &csbi);
 	defErrColor = csbi.wAttributes;
 #ifdef NDEBUG
+#ifndef VCMI_ANDROID
 	SetUnhandledExceptionFilter(onUnhandledException);
+#endif
 #endif
 #else
 	defColor = "\x1b[0m";

--- a/vcmiqt/CMakeLists.txt
+++ b/vcmiqt/CMakeLists.txt
@@ -8,6 +8,7 @@ set(vcmiqt_SRCS
 set(vcmiqt_HEADERS
 		StdInc.h
 
+		MessageBox.h
 		jsonutils.h
 		launcherdirs.h
 		convpathqstring.h
@@ -32,7 +33,7 @@ if(WIN32)
 	)
 endif()
 
-target_link_libraries(vcmiqt vcmi Qt${QT_VERSION_MAJOR}::Core)
+target_link_libraries(vcmiqt vcmi Qt${QT_VERSION_MAJOR}::Core Qt${QT_VERSION_MAJOR}::Widgets)
 
 target_include_directories(vcmiqt PUBLIC
 	${CMAKE_CURRENT_SOURCE_DIR}

--- a/vcmiqt/MessageBox.h
+++ b/vcmiqt/MessageBox.h
@@ -1,0 +1,50 @@
+/*
+ * MessageBox.h, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
+
+#pragma once
+
+#include "vcmiqt.h"
+
+#include <QMessageBox>
+#include <QTimer>
+
+namespace MessageBox
+{
+#ifdef VCMI_IOS
+	// iOS can't display modal dialogs when called directly on button press
+	// https://bugreports.qt.io/browse/QTBUG-98651
+
+	template<typename Functor>
+	void showDialog(const Functor & f)
+	{
+		QTimer::singleShot(0, this, f);
+	}
+
+	void information(QWidget *parent, const QString &title, const QString& text, QMessageBox::StandardButtons buttons = QMessageBox::Ok, QMessageBox::StandardButton defaultButton = QMessageBox::NoButton)
+	{
+		QTimer::singleShot(0, this, [=](){
+			QMessageBox::information(parent, title, text, buttons, defaultButton);
+		});
+	}
+
+#else
+
+	template<typename Functor>
+	void showDialog(const Functor & f)
+	{
+		f();
+	}
+
+	void information(QWidget *parent, const QString &title, const QString& text, QMessageBox::StandardButtons buttons = QMessageBox::Ok, QMessageBox::StandardButton defaultButton = QMessageBox::NoButton)
+	{
+		QMessageBox::information(parent, title, text, buttons, defaultButton);
+	}
+#endif
+}

--- a/vcmiqt/MessageBox.h
+++ b/vcmiqt/MessageBox.h
@@ -15,21 +15,21 @@
 #include <QMessageBox>
 #include <QTimer>
 
-namespace MessageBox
+namespace MessageBoxCustom
 {
 #ifdef VCMI_IOS
 	// iOS can't display modal dialogs when called directly on button press
 	// https://bugreports.qt.io/browse/QTBUG-98651
 
 	template<typename Functor>
-	void showDialog(const Functor & f)
+	inline void showDialog(QWidget *parent, const Functor & f)
 	{
-		QTimer::singleShot(0, this, f);
+		QTimer::singleShot(0, parent, f);
 	}
 
-	void information(QWidget *parent, const QString &title, const QString& text, QMessageBox::StandardButtons buttons = QMessageBox::Ok, QMessageBox::StandardButton defaultButton = QMessageBox::NoButton)
+	inline void information(QWidget *parent, const QString &title, const QString& text, QMessageBox::StandardButtons buttons = QMessageBox::Ok, QMessageBox::StandardButton defaultButton = QMessageBox::NoButton)
 	{
-		QTimer::singleShot(0, this, [=](){
+		QTimer::singleShot(0, parent, [=](){
 			QMessageBox::information(parent, title, text, buttons, defaultButton);
 		});
 	}
@@ -37,12 +37,12 @@ namespace MessageBox
 #else
 
 	template<typename Functor>
-	void showDialog(const Functor & f)
+	inline void showDialog(QWidget *parent, const Functor & f)
 	{
 		f();
 	}
 
-	void information(QWidget *parent, const QString &title, const QString& text, QMessageBox::StandardButtons buttons = QMessageBox::Ok, QMessageBox::StandardButton defaultButton = QMessageBox::NoButton)
+	inline void information(QWidget *parent, const QString &title, const QString& text, QMessageBox::StandardButtons buttons = QMessageBox::Ok, QMessageBox::StandardButton defaultButton = QMessageBox::NoButton)
 	{
 		QMessageBox::information(parent, title, text, buttons, defaultButton);
 	}


### PR DESCRIPTION
- Disable autoselection of xbrz on mobiles to fix performance. Can still be selected manually.
- Disable terminate handler on Android since it interferes with Google Play crash reporter
- Add workaround for inability to display dialogs on button click on iOS