### PR TITLE
[1.6.1] add shortcut for android

### DIFF
--- a/.github/workflows/github.yml
+++ b/.github/workflows/github.yml
@@ -248,7 +248,7 @@ jobs:
             cmake -DENABLE_CCACHE:BOOL=ON -DCMAKE_C_COMPILER=gcc-14 -DCMAKE_CXX_COMPILER=g++-14 --preset ${{ matrix.preset }}
         elif [[ (${{matrix.preset}} == android-conan-ninja-release) && (${{github.ref}} != 'refs/heads/master') ]]
         then
-            cmake -DENABLE_CCACHE:BOOL=ON -DANDROID_GRADLE_PROPERTIES="applicationIdSuffix=.daily;signingConfig=dailySigning;applicationLabel=VCMI daily" --preset ${{ matrix.preset }}
+            cmake -DENABLE_CCACHE:BOOL=ON -DANDROID_GRADLE_PROPERTIES="applicationIdSuffix=.daily;signingConfig=dailySigning;applicationLabel=VCMI daily;applicationVariant=daily" --preset ${{ matrix.preset }}
         elif [[ ${{startsWith(matrix.platform, 'msvc') }} ]]
         then
             cmake --preset ${{ matrix.preset }}

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -317,7 +317,7 @@
             "description": "VCMI Android daily build",
             "inherits": "android-conan-ninja-release",
             "cacheVariables": {
-                "ANDROID_GRADLE_PROPERTIES": "applicationIdSuffix=.daily;signingConfig=dailySigning;applicationLabel=VCMI daily"
+                "ANDROID_GRADLE_PROPERTIES": "applicationIdSuffix=.daily;signingConfig=dailySigning;applicationLabel=VCMI daily;applicationVariant=daily"
             }
         }
     ],

--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -30,6 +30,8 @@
 				<category android:name="android.intent.category.LAUNCHER"/>
 			</intent-filter>
 
+			<meta-data android:name="android.app.shortcuts" android:resource="@xml/shortcuts${applicationVariant}" /> 
+
 			<meta-data android:name="android.app.lib_name" android:value="-- %%INSERT_APP_LIB_NAME%% --"/>
 			<meta-data android:name="android.app.qt_sources_resource_id" android:resource="@array/qt_sources"/>
 			<meta-data android:name="android.app.repository" android:value="default"/>

--- a/android/vcmi-app/build.gradle
+++ b/android/vcmi-app/build.gradle
@@ -57,6 +57,7 @@ android {
 			applicationIdSuffix '.debug'
 			manifestPlaceholders = [
 				applicationLabel: 'VCMI debug',
+				applicationVariant: 'debug',
 			]
 			ndk {
 				debugSymbolLevel 'full'
@@ -70,6 +71,7 @@ android {
 			proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
 			manifestPlaceholders = [
 				applicationLabel: project.findProperty('applicationLabel') ?: 'VCMI',
+				applicationVariant: project.findProperty('applicationVariant') ?: '',
 			]
 			ndk {
 				debugSymbolLevel 'full'

--- a/android/vcmi-app/src/main/res/values-de/strings.xml
+++ b/android/vcmi-app/src/main/res/values-de/strings.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="server_name">VCMI-Server</string>
+    <string name="shortcut_play">VCMI spielen</string>
 </resources>

--- a/android/vcmi-app/src/main/res/values/strings.xml
+++ b/android/vcmi-app/src/main/res/values/strings.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="server_name">VCMI Server</string>
+    <string name="shortcut_play">Play VCMI</string>
 </resources>

--- a/android/vcmi-app/src/main/res/xml/shortcuts.xml
+++ b/android/vcmi-app/src/main/res/xml/shortcuts.xml
@@ -1,0 +1,13 @@
+<shortcuts xmlns:android="http://schemas.android.com/apk/res/android">
+	<shortcut
+		android:shortcutId="play"
+		android:enabled="true"
+		android:icon="@mipmap/ic_launcher"
+		android:shortcutShortLabel="@string/shortcut_play"
+		android:shortcutLongLabel="@string/shortcut_play">
+		<intent
+			android:action="android.intent.action.VIEW"
+			android:targetPackage="is.xyz.vcmi"
+			android:targetClass="eu.vcmi.vcmi.VcmiSDLActivity" />
+	</shortcut>
+</shortcuts>

--- a/android/vcmi-app/src/main/res/xml/shortcutsdaily.xml
+++ b/android/vcmi-app/src/main/res/xml/shortcutsdaily.xml
@@ -1,0 +1,13 @@
+<shortcuts xmlns:android="http://schemas.android.com/apk/res/android">
+	<shortcut
+		android:shortcutId="play"
+		android:enabled="true"
+		android:icon="@mipmap/ic_launcher"
+		android:shortcutShortLabel="@string/shortcut_play"
+		android:shortcutLongLabel="@string/shortcut_play">
+		<intent
+			android:action="android.intent.action.VIEW"
+			android:targetPackage="is.xyz.vcmi.daily"
+			android:targetClass="eu.vcmi.vcmi.VcmiSDLActivity" />
+	</shortcut>
+</shortcuts>

--- a/android/vcmi-app/src/main/res/xml/shortcutsdebug.xml
+++ b/android/vcmi-app/src/main/res/xml/shortcutsdebug.xml
@@ -1,0 +1,13 @@
+<shortcuts xmlns:android="http://schemas.android.com/apk/res/android">
+	<shortcut
+		android:shortcutId="play"
+		android:enabled="true"
+		android:icon="@mipmap/ic_launcher"
+		android:shortcutShortLabel="@string/shortcut_play"
+		android:shortcutLongLabel="@string/shortcut_play">
+		<intent
+			android:action="android.intent.action.VIEW"
+			android:targetPackage="is.xyz.vcmi.debug"
+			android:targetClass="eu.vcmi.vcmi.VcmiSDLActivity" />
+	</shortcut>
+</shortcuts>


### PR DESCRIPTION
Start shortcut for skipping launcher.

Shortcut:
![grafik](https://github.com/user-attachments/assets/9a2809ee-541b-4089-934a-0acc31ef7fef)

Also possible to manually add to homescreen by user:
![grafik](https://github.com/user-attachments/assets/a926a08c-f452-4459-ba95-40e9563e7244)

Also accessable via gamepad (hold A for opening shortcut menu, then arrow down and A again).

Sadly I had to add `shortcuts.xml` three times. That's a workaround as there are no variables allowed (we need different appids for release/debug/daily) in it. After searching for possible solutions it seems that this is the best solution here.

replacement for: #5128

