### PR TITLE
[1.6.1] correct align of thiefguild text an add popup

### DIFF
--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -1398,15 +1398,17 @@ CThievesGuildWindow::CThievesGuildWindow(const CGObjectInstance * _owner):
 			bestHeroes.push_back(std::make_shared<CAnimImage>(AnimationPath::builtin("PortraitsSmall"), iter.second.getIconIndex(), 0, 260 + 66 * counter, 360));
 			//TODO: r-click info:
 			// - r-click on hero
-			// - r-click on primary skill label
 			if(iter.second.details)
 			{
-				primSkillHeaders.push_back(std::make_shared<CTextBox>(CGI->generaltexth->allTexts[184], Rect(260 + 66*counter, 396, 52, 64),
-					0, FONT_TINY, ETextAlignment::TOPLEFT, Colors::WHITE));
-
-				for(int i=0; i<iter.second.details->primskills.size(); ++i)
+				std::vector<std::string> lines;
+				boost::split(lines, CGI->generaltexth->allTexts[184], boost::is_any_of("\n"));
+				for(int i=0; i<GameConstants::PRIMARY_SKILLS; ++i)
 				{
-					primSkillValues.push_back(std::make_shared<CLabel>(310 + 66 * counter, 407 + 11*i, FONT_TINY, ETextAlignment::BOTTOMRIGHT, Colors::WHITE,
+					primSkillHeaders.push_back(std::make_shared<CLabel>(260 + 66 * counter, 407 + 11 * i, FONT_TINY, ETextAlignment::BOTTOMLEFT, Colors::WHITE, lines[i]));
+					primSkillHeadersArea.push_back(std::make_shared<LRClickableArea>(Rect(primSkillHeaders.back()->pos.x - pos.x, primSkillHeaders.back()->pos.y - pos.y - 11, 50, 11), nullptr, [i]{
+						CRClickPopup::createAndPush(CGI->generaltexth->arraytxt[2 + i]);
+					}));
+					primSkillValues.push_back(std::make_shared<CLabel>(310 + 66 * counter, 407 + 11 * i, FONT_TINY, ETextAlignment::BOTTOMRIGHT, Colors::WHITE,
 							   std::to_string(iter.second.details->primskills[i])));
 				}
 			}

--- a/client/windows/GUIClasses.h
+++ b/client/windows/GUIClasses.h
@@ -502,7 +502,8 @@ class CThievesGuildWindow : public CStatusbarWindow
 
 	std::vector<std::shared_ptr<CPicture>> banners;
 	std::vector<std::shared_ptr<CAnimImage>> bestHeroes;
-	std::vector<std::shared_ptr<CTextBox>> primSkillHeaders;
+	std::vector<std::shared_ptr<CLabel>> primSkillHeaders;
+	std::vector<std::shared_ptr<LRClickableArea>> primSkillHeadersArea;
 	std::vector<std::shared_ptr<CLabel>> primSkillValues;
 	std::vector<std::shared_ptr<CAnimImage>> bestCreatures;
 	std::vector<std::shared_ptr<CLabel>> personalities;


### PR DESCRIPTION
From:
![grafik](https://github.com/user-attachments/assets/1252259e-5455-44cb-9286-8253d1f7e451)

To:
![grafik](https://github.com/user-attachments/assets/56f10451-0460-4975-9e1b-15dac9f229a6)

Also add popup for texts like in OH3.