### PR TITLE
Fix crash on mapobjects with description popup window

### DIFF
--- a/lib/mapObjects/CGMarket.cpp
+++ b/lib/mapObjects/CGMarket.cpp
@@ -45,7 +45,7 @@ std::string CGMarket::getPopupText(PlayerColor player) const
 		return getHoverText(player);
 
 	MetaString message = MetaString::createFromRawString("{%s}\r\n\r\n%s");
-	message.replaceName(ID);
+	message.replaceTextID(TextIdentifier("object", getObjectHandler()->getModScope(), getObjectHandler()->getTypeName(), "name").get());
 	message.replaceTextID(TextIdentifier(getObjectHandler()->getBaseTextID(), "description").get());
 	return message.toString();
 }

--- a/lib/mapObjects/MiscObjects.cpp
+++ b/lib/mapObjects/MiscObjects.cpp
@@ -1334,7 +1334,7 @@ std::string HillFort::getPopupText(PlayerColor player) const
 {
 	MetaString message = MetaString::createFromRawString("{%s}\r\n\r\n%s");
 
-	message.replaceName(ID);
+	message.replaceTextID(TextIdentifier("object", getObjectHandler()->getModScope(), getObjectHandler()->getTypeName(), "name").get());
 	message.replaceTextID(getDescriptionToolTip());
 
 	return message.toString();

--- a/lib/mapObjects/MiscObjects.cpp
+++ b/lib/mapObjects/MiscObjects.cpp
@@ -1334,7 +1334,7 @@ std::string HillFort::getPopupText(PlayerColor player) const
 {
 	MetaString message = MetaString::createFromRawString("{%s}\r\n\r\n%s");
 
-	message.replaceName(ID, subID);
+	message.replaceName(ID);
 	message.replaceTextID(getDescriptionToolTip());
 
 	return message.toString();

--- a/lib/texts/MetaString.cpp
+++ b/lib/texts/MetaString.cpp
@@ -393,14 +393,9 @@ void MetaString::replaceName(const FactionID & id)
 	replaceTextID(id.toEntity(VLC)->getNameTextID());
 }
 
-void MetaString::replaceName(const MapObjectID & id)
+void MetaString::replaceName(const MapObjectID& id)
 {
 	replaceTextID(VLC->objtypeh->getObjectName(id, 0));
-}
-
-void MetaString::replaceName(const MapObjectID & id, const MapObjectSubID & subId)
-{
-	replaceTextID(VLC->objtypeh->getObjectName(id, subId));
 }
 
 void MetaString::replaceName(const PlayerColor & id)

--- a/lib/texts/MetaString.h
+++ b/lib/texts/MetaString.h
@@ -99,8 +99,7 @@ public:
 
 	void replaceName(const ArtifactID & id);
 	void replaceName(const FactionID& id);
-	void replaceName(const MapObjectID & id);
-	void replaceName(const MapObjectID & id, const MapObjectSubID & subId);
+	void replaceName(const MapObjectID& id);
 	void replaceName(const PlayerColor& id);
 	void replaceName(const SecondarySkill& id);
 	void replaceName(const SpellID& id);


### PR DESCRIPTION
This PR fixes crashes for non-core mapobjects with descriptions when popup window is being indicated.

I started to investigate when Junkman popup window crashed recently the game for me (and also it was reported on Discord today).

Non-core mapobjects don't use `json["lastReservedIndex"]` so after 
[newObject->objectTypeHandlers.resize(json["lastReservedIndex"].Float() + 1);](https://github.com/vcmi/vcmi/blob/367e1f192599e9788e60be5ce8af0095d8682541/lib/mapObjectConstructors/CObjectClassesHandler.cpp#L292) and then [push_back](https://github.com/vcmi/vcmi/blob/367e1f192599e9788e60be5ce8af0095d8682541/lib/mapObjectConstructors/CObjectClassesHandler.cpp#L176) there is valid handler at second index whereas the first one is empty.
After that, when popup window is called, code tries to get handler at [index = 0](https://github.com/vcmi/vcmi/blob/367e1f192599e9788e60be5ce8af0095d8682541/lib/texts/MetaString.cpp#L398) and this function [CObjectClassesHandler::getHandlerFor](https://github.com/vcmi/vcmi/blob/367e1f192599e9788e60be5ce8af0095d8682541/lib/mapObjectConstructors/CObjectClassesHandler.cpp#L357) crashes.

@IvanSavenko maybe you can figure out where this should be fixed during the loading stage or perhaps we leave it as it is.

That way or another: the fix is neutral in its core.

The similar crash was with miniHillFort popup window a while ago. I reverted the commit I made back then. It generated unnecessary log message and additional logic for MetaString is unneeded.