### PR TITLE
Fixes for crashes discovered via Google Play

### DIFF
--- a/launcher/mainwindow_moc.cpp
+++ b/launcher/mainwindow_moc.cpp
@@ -18,6 +18,7 @@
 #include "../lib/filesystem/Filesystem.h"
 #include "../lib/logging/CBasicLogConfigurator.h"
 #include "../lib/texts/Languages.h"
+#include "../lib/ExceptionsCommon.h"
 
 #include "updatedialog_moc.h"
 #include "main.h"
@@ -35,8 +36,15 @@ void MainWindow::load()
 	CBasicLogConfigurator logConfig(VCMIDirs::get().userLogsPath() / "VCMI_Launcher_log.txt", console);
 	logConfig.configureDefault();
 
-	CResourceHandler::initialize();
-	CResourceHandler::load("config/filesystem.json");
+	try
+	{
+		CResourceHandler::initialize();
+		CResourceHandler::load("config/filesystem.json");
+	}
+	catch (const DataLoadingException & e)
+	{
+		QMessageBox::critical(this, tr("Error starting executable"), QString::fromStdString(e.what()));
+	}
 
 	Helper::loadSettings();
 }

--- a/launcher/modManager/cmodlistview_moc.cpp
+++ b/launcher/modManager/cmodlistview_moc.cpp
@@ -561,7 +561,7 @@ QStringList CModListView::getModsToInstall(QString mod)
 				potentialToInstall = modStateModel->getTopParent(potentialToInstall);
 		}
 
-		if (modStateModel->isModExists(potentialToInstall) && !modStateModel->isModInstalled(potentialToInstall))
+		if (!modStateModel->isModInstalled(potentialToInstall))
 			result.push_back(potentialToInstall);
 
 		if (modStateModel->isModExists(potentialToInstall))
@@ -818,7 +818,8 @@ void CModListView::installFiles(QStringList files)
 			ChroniclesExtractor ce(this, [&prog](float progress) { prog = progress; });
 			ce.installChronicles(exe);
 			reload();
-			enableModByName("chronicles");
+			if (modStateModel->isModExists("chronicles"))
+				enableModByName("chronicles");
 			return true;
 		});
 		

--- a/launcher/modManager/modstatemodel.cpp
+++ b/launcher/modManager/modstatemodel.cpp
@@ -65,7 +65,7 @@ bool ModStateModel::isModExists(QString modName) const
 
 bool ModStateModel::isModInstalled(QString modName) const
 {
-	return getMod(modName).isInstalled();
+	return isModExists(modName) && getMod(modName).isInstalled();
 }
 
 bool ModStateModel::isModSettingEnabled(QString rootModName, QString modSettingName) const

--- a/lib/mapObjects/CQuest.cpp
+++ b/lib/mapObjects/CQuest.cpp
@@ -149,12 +149,14 @@ void CQuest::completeQuest(IGameCallback * cb, const CGHeroInstance *h) const
 		if(h->hasArt(elem))
 		{
 			cb->removeArtifact(ArtifactLocation(h->id, h->getArtPos(elem, false)));
+			continue;
 		}
-		else
+
+		// perhaps artifact is part of a combined artifact?
+		const auto * assembly = h->getCombinedArtWithPart(elem);
+		if (assembly)
 		{
-			const auto * assembly = h->getCombinedArtWithPart(elem);
-			assert(assembly);
-			auto parts = assembly->getPartsInfo();
+			auto parts = assembly->getPartsInfo(); // FIXME: causes crashes on Google Play
 
 			// Remove the assembly
 			cb->removeArtifact(ArtifactLocation(h->id, h->getArtPos(assembly)));
@@ -165,7 +167,11 @@ void CQuest::completeQuest(IGameCallback * cb, const CGHeroInstance *h) const
 				if(ci.art->getTypeId() != elem)
 					cb->giveHeroNewArtifact(h, ci.art->getTypeId(), ArtifactPosition::BACKPACK_START);
 			}
+
+			continue;
 		}
+
+		logGlobal->error("Failed to find artifact %s in inventory of hero %s", elem.toEntity(VLC)->getJsonKey(), h->getHeroTypeID());
 	}
 
 	cb->takeCreatures(h->id, mission.creatures);

--- a/server/NetPacksLobbyServer.cpp
+++ b/server/NetPacksLobbyServer.cpp
@@ -445,7 +445,14 @@ void ApplyOnServerNetPackVisitor::visitLobbyDelete(LobbyDelete & pack)
 	if(pack.type == LobbyDelete::EType::SAVEGAME || pack.type == LobbyDelete::EType::RANDOMMAP)
 	{
 		auto res = ResourcePath(pack.name, pack.type == LobbyDelete::EType::SAVEGAME ? EResType::SAVEGAME : EResType::MAP);
-		auto file = boost::filesystem::canonical(*CResourceHandler::get()->getResourceName(res));
+		auto name = CResourceHandler::get()->getResourceName(res);
+		if (!name)
+		{
+			logGlobal->error("Failed to find resource with name '%s'", res.getOriginalName());
+			return;
+		}
+
+		auto file = boost::filesystem::canonical(*name);
 		boost::filesystem::remove(file);
 		if(boost::filesystem::is_empty(file.parent_path()))
 			boost::filesystem::remove(file.parent_path());
@@ -453,7 +460,13 @@ void ApplyOnServerNetPackVisitor::visitLobbyDelete(LobbyDelete & pack)
 	else if(pack.type == LobbyDelete::EType::SAVEGAME_FOLDER)
 	{
 		auto res = ResourcePath("Saves/" + pack.name, EResType::DIRECTORY);
-		auto folder = boost::filesystem::canonical(*CResourceHandler::get()->getResourceName(res));
+		auto name = CResourceHandler::get()->getResourceName(res);
+		if (!name)
+		{
+			logGlobal->error("Failed to find folder with name '%s'", res.getOriginalName());
+			return;
+		}
+		auto folder = boost::filesystem::canonical(*name);
 		boost::filesystem::remove_all(folder);
 	}
 


### PR DESCRIPTION
- Fix crash on attempt to enable mod with recursive dependencies
- Fix crash on attempt to enable Chronicles after failed install
- Fixed crash on attempt to access non-installed mod when repository checkout is off
- Show error message on failure to load filesystem instead of crash in launcher
- Added workaround for crash on attempt to delete nonexisting save/map
- Added logging of mod settings to log file to simplify debugging