### PR TITLE
Remove MetaString method that can't be used with modded objects

### DIFF
--- a/lib/mapObjects/CGDwelling.cpp
+++ b/lib/mapObjects/CGDwelling.cpp
@@ -217,7 +217,7 @@ void CGDwelling::onHeroVisit( const CGHeroInstance * h ) const
 		iw.type = EInfoWindowMode::AUTO;
 		iw.player = h->tempOwner;
 		iw.text.appendLocalString(EMetaText::ADVOB_TXT, 44); //{%s} \n\n The camp is deserted.  Perhaps you should try next week.
-		iw.text.replaceName(ID);
+		iw.text.replaceName(ID, subID);
 		cb->sendAndApply(iw);
 		return;
 	}
@@ -260,7 +260,7 @@ void CGDwelling::onHeroVisit( const CGHeroInstance * h ) const
 	else if(ID == Obj::REFUGEE_CAMP)
 	{
 		bd.text.appendLocalString(EMetaText::ADVOB_TXT, 35); //{%s} Would you like to recruit %s?
-		bd.text.replaceName(ID);
+		bd.text.replaceName(ID, subID);
 		for(const auto & elem : creatures)
 			bd.text.replaceNamePlural(elem.second[0]);
 	}

--- a/lib/mapObjects/CGMarket.cpp
+++ b/lib/mapObjects/CGMarket.cpp
@@ -45,7 +45,7 @@ std::string CGMarket::getPopupText(PlayerColor player) const
 		return getHoverText(player);
 
 	MetaString message = MetaString::createFromRawString("{%s}\r\n\r\n%s");
-	message.replaceName(ID);
+	message.replaceName(ID, subID);
 	message.replaceTextID(TextIdentifier(getObjectHandler()->getBaseTextID(), "description").get());
 	return message.toString();
 }

--- a/lib/texts/MetaString.cpp
+++ b/lib/texts/MetaString.cpp
@@ -393,11 +393,6 @@ void MetaString::replaceName(const FactionID & id)
 	replaceTextID(id.toEntity(VLC)->getNameTextID());
 }
 
-void MetaString::replaceName(const MapObjectID & id)
-{
-	replaceTextID(VLC->objtypeh->getObjectName(id, 0));
-}
-
 void MetaString::replaceName(const MapObjectID & id, const MapObjectSubID & subId)
 {
 	replaceTextID(VLC->objtypeh->getObjectName(id, subId));

--- a/lib/texts/MetaString.h
+++ b/lib/texts/MetaString.h
@@ -99,7 +99,6 @@ public:
 
 	void replaceName(const ArtifactID & id);
 	void replaceName(const FactionID& id);
-	void replaceName(const MapObjectID & id);
 	void replaceName(const MapObjectID & id, const MapObjectSubID & subId);
 	void replaceName(const PlayerColor& id);
 	void replaceName(const SecondarySkill& id);


### PR DESCRIPTION
- Fixes crash on right-click on Junkman (and likely other modded markets)
- Supersedes #5139