### PR TITLE
Fix crash on attempting to install mod when nothing is selected

### DIFF
--- a/launcher/modManager/cmodlistview_moc.cpp
+++ b/launcher/modManager/cmodlistview_moc.cpp
@@ -932,7 +932,7 @@ void CModListView::on_pushButton_clicked()
 
 void CModListView::modelReset()
 {
-	selectMod(filterModel->rowCount() > 0 ? filterModel->index(0, 0) : QModelIndex());
+	ui->allModsView->setCurrentIndex(filterModel->rowCount() > 0 ? filterModel->index(0, 0) : QModelIndex());
 }
 
 void CModListView::checkManagerErrors()


### PR DESCRIPTION
Fixes situation in which it was possible to have mod description and mod actions visible (usually for 1st mod in list) without actually having this mod selected in the list, leading to crash on pressing "Install" button.

Now selection should be updated correctly in both mod description view and in mod list

- Fixes #5120