### PR TITLE
Refactor logging in doHeroVisit function (Rewardable::Interface): reduce excessive logs and improve clarity

### DIFF
--- a/AI/Nullkiller/Engine/PriorityEvaluator.cpp
+++ b/AI/Nullkiller/Engine/PriorityEvaluator.cpp
@@ -692,6 +692,8 @@ float RewardEvaluator::getSkillReward(const CGObjectInstance * target, const CGH
 	case Obj::SHRINE_OF_MAGIC_GESTURE:
 		return 1.0f;
 	case Obj::SHRINE_OF_MAGIC_THOUGHT:
+	case Obj::PYRAMID:
+	case Obj::SEER_HUT:
 		return 2.0f;
 	case Obj::LIBRARY_OF_ENLIGHTENMENT:
 		return 8;
@@ -726,7 +728,6 @@ float RewardEvaluator::getSkillReward(const CGObjectInstance * target, const CGH
 				for(auto spellID : info.reward.spells)
 				{
 					const spells::Spell * spell = VLC->spells()->getById(spellID);
-						
 					if(hero->canLearnSpell(spell) && !hero->spellbookContainsSpell(spellID))
 					{
 						rewardValue += std::sqrt(spell->getLevel()) / 4.0f;

--- a/lib/battle/CBattleInfoEssentials.cpp
+++ b/lib/battle/CBattleInfoEssentials.cpp
@@ -56,8 +56,11 @@ std::vector<std::shared_ptr<const CObstacleInstance>> CBattleInfoEssentials::bat
 	}
 	else
 	{
-		if(!!getPlayerID() && *perspective != battleGetMySide())
-			logGlobal->warn("Unauthorized obstacles access attempt, assuming massive spell");
+		if(*perspective != BattleSide::ALL_KNOWING)
+		{
+			if(getPlayerID() && *perspective != battleGetMySide())
+				logGlobal->warn("Unauthorized obstacles access attempt, assuming massive spell");
+		}
 	}
 
 	for(const auto & obstacle : getBattle()->getAllObstacles())

--- a/lib/rewardable/Interface.cpp
+++ b/lib/rewardable/Interface.cpp
@@ -287,6 +287,15 @@ void Rewardable::Interface::grantAllRewardsWithMessage(const CGHeroInstance * co
 
 void Rewardable::Interface::doHeroVisit(const CGHeroInstance *h) const
 {
+	auto instance = dynamic_cast<const CGObjectInstance *>(this);
+	if(!instance)
+	{
+		logGlobal->error("MapObject at tile %s is not a valid CObjectInstance", 
+			getObject()->visitablePos().toString());
+		// throw ?
+		return;
+	}
+
 	if(!wasVisitedBefore(h))
 	{
 		auto rewards = getAvailableRewards(h, Rewardable::EEventType::EVENT_FIRST_VISIT);
@@ -297,7 +306,11 @@ void Rewardable::Interface::doHeroVisit(const CGHeroInstance *h) const
 				objectRemovalPossible = true;
 		}
 
-		logGlobal->debug("Visiting object with %d possible rewards", rewards.size());
+		logGlobal->debug("Visiting object %s with %d possible rewards at tile %s", 
+			instance->getObjectName(),
+			rewards.size(), 
+			getObject()->visitablePos().toString());
+
 		switch (rewards.size())
 		{
 			case 0: // no available rewards, e.g. visiting School of War without gold
@@ -306,7 +319,9 @@ void Rewardable::Interface::doHeroVisit(const CGHeroInstance *h) const
 				if (!emptyRewards.empty())
 					grantRewardWithMessage(h, emptyRewards[0], false);
 				else
-					logMod->warn("No applicable message for visiting empty object!");
+					logMod->warn("No applicable message for visiting object %s at tile %s that has no rewards",
+						instance->getObjectName(),
+						getObject()->visitablePos().toString());
 				break;
 			}
 			case 1: // one reward. Just give it with message
@@ -351,7 +366,9 @@ void Rewardable::Interface::doHeroVisit(const CGHeroInstance *h) const
 	}
 	else
 	{
-		logGlobal->debug("Revisiting already visited object");
+		logGlobal->debug("Revisiting already visited object %s at tile %s", 
+			instance->getObjectName(),
+			getObject()->visitablePos().toString());
 
 		if (!wasVisited(h->getOwner()))
 			markAsScouted(h);
@@ -360,7 +377,9 @@ void Rewardable::Interface::doHeroVisit(const CGHeroInstance *h) const
 		if (!visitedRewards.empty())
 			grantRewardWithMessage(h, visitedRewards[0], false);
 		else
-			logMod->warn("No applicable message for visiting already visited object!");
+			logMod->warn("No applicable message for visiting already visited object %s at tile %s", 
+				instance->getObjectName(),
+				getObject()->visitablePos().toString());
 	}
 }
 


### PR DESCRIPTION
This PR aims to:

- Fix excessive logging caused by repeated messages:

> "Unauthorized obstacles access attempt, assuming massive spell"

during AI battles,

- Fix log flooding by correctly setting reward values for Seer Huts and Pyramids, preventing repeated unnecessary log entries like these:

![image2](https://github.com/user-attachments/assets/2ba7d35c-78bc-4e15-900f-93174c1ad4c7)

when AI is probing those objects for reward values.

- Improve log message clarity when making hero visit events on rewardable objects more descriptive. 
Example:

![image](https://github.com/user-attachments/assets/3b05b0fb-47d5-4e26-8e1b-621838ec993e)
