### PR TITLE
map editor: fix crash when copying monster

### DIFF
--- a/lib/CCreatureSet.h
+++ b/lib/CCreatureSet.h
@@ -59,7 +59,8 @@ public:
 		{
 			CreatureID creatureID;
 			h & creatureID;
-			setType(creatureID.toCreature());
+			if(creatureID != CreatureID::NONE)
+				setType(creatureID.toCreature());
 		}
 
 		h & count;


### PR DESCRIPTION
I was able to track introduction of this crash to this commit https://github.com/vcmi/vcmi/commit/d3af9f1c675997f7f0768be25e025bde836d5cec and change in CCreatureSet serialization, so I tried with not setting type for CreatureID::NONE, as it was before, and it fixes the issue. 
I don't see any immediate problem with that, tested few maps both in game and editor.
Targeted beta, but not sure if such change is safe enough

