### PR TITLE
[1.6.2] Option to fix right mouse button on some android devices

### DIFF
--- a/client/eventsSDL/InputHandler.cpp
+++ b/client/eventsSDL/InputHandler.cpp
@@ -211,7 +211,7 @@ void InputHandler::preprocessEvent(const SDL_Event & ev)
 			return;
 		}
 
-		if(ev.key.keysym.scancode == SDL_SCANCODE_AC_BACK)
+		if(ev.key.keysym.scancode == SDL_SCANCODE_AC_BACK && !settings["input"]["handleBackRightMouseButton"].Bool())
 		{
 			boost::mutex::scoped_lock interfaceLock(GH.interfaceMutex);
 			handleQuit(true);

--- a/client/eventsSDL/InputSourceKeyboard.h
+++ b/client/eventsSDL/InputSourceKeyboard.h
@@ -19,6 +19,8 @@ class InputSourceKeyboard
 	bool wasKeyboardAltDown;
 	bool wasKeyboardShiftDown;
 
+	bool handleBackRightMouseButton; // on some android devices right mouse button is "back"
+
 	std::string getKeyNameWithModifiers(const std::string & keyName, bool keyUp);
 public:
 	InputSourceKeyboard();

--- a/config/schemas/settings.json
+++ b/config/schemas/settings.json
@@ -295,7 +295,8 @@
 				"controllerAxisDeadZone",
 				"controllerAxisFullZone",
 				"controllerAxisSpeed",
-				"controllerAxisScale"
+				"controllerAxisScale",
+				"handleBackRightMouseButton"
 			],
 			"properties" : {
 				"radialWheelGarrisonSwipe" : {
@@ -345,6 +346,10 @@
 				"controllerAxisScale" : {
 					"type" : "number",
 					"default" : 2
+				},
+				"handleBackRightMouseButton" : {
+					"type" : "boolean",
+					"default" : false
 				}
 			}
 		},

--- a/launcher/settingsView/csettingsview_moc.cpp
+++ b/launcher/settingsView/csettingsview_moc.cpp
@@ -125,6 +125,9 @@ void CSettingsView::loadSettings()
 	else
 		ui->comboBoxFullScreen->setCurrentIndex(settings["video"]["fullscreen"].Bool());
 #endif
+#ifndef VCMI_ANDROID
+	ui->buttonHandleBackRightMouseButton->hide();
+#endif
 	fillValidScalingRange();
 
 	ui->buttonScalingAuto->setChecked(settings["video"]["resolution"]["scaling"].Integer() == 0);
@@ -173,6 +176,7 @@ void CSettingsView::loadSettings()
 	ui->sliderRelativeCursorSpeed->setValue(settings["general"]["relativePointerSpeedMultiplier"].Integer());
 	ui->sliderLongTouchDuration->setValue(settings["general"]["longTouchTimeMilliseconds"].Integer());
 	ui->slideToleranceDistanceMouse->setValue(settings["input"]["mouseToleranceDistance"].Integer());
+	ui->buttonHandleBackRightMouseButton->setChecked(settings["input"]["handleBackRightMouseButton"].Bool());
 	ui->sliderToleranceDistanceTouch->setValue(settings["input"]["touchToleranceDistance"].Integer());
 	ui->sliderToleranceDistanceController->setValue(settings["input"]["shortcutToleranceDistance"].Integer());
 	ui->sliderControllerSticksSensitivity->setValue(settings["input"]["controllerAxisSpeed"].Integer());
@@ -840,5 +844,11 @@ void CSettingsView::on_buttonScalingAuto_toggled(bool checked)
 	
 	Settings node = settings.write["video"]["resolution"]["scaling"];
 	node->Integer() = checked ? 0 : 100;
+}
+
+void CSettingsView::on_buttonHandleBackRightMouseButton_toggled(bool checked)
+{
+	Settings node = settings.write["input"]["handleBackRightMouseButton"];
+	node->Bool() = checked;
 }
 

--- a/launcher/settingsView/csettingsview_moc.cpp
+++ b/launcher/settingsView/csettingsview_moc.cpp
@@ -127,6 +127,7 @@ void CSettingsView::loadSettings()
 #endif
 #ifndef VCMI_ANDROID
 	ui->buttonHandleBackRightMouseButton->hide();
+	ui->labelHandleBackRightMouseButton->hide();
 #endif
 	fillValidScalingRange();
 

--- a/launcher/settingsView/csettingsview_moc.cpp
+++ b/launcher/settingsView/csettingsview_moc.cpp
@@ -219,6 +219,8 @@ void CSettingsView::loadToggleButtonSettings()
 	setCheckbuttonState(ui->buttonRelativeCursorMode, settings["general"]["userRelativePointer"].Bool());
 	setCheckbuttonState(ui->buttonHapticFeedback, settings["general"]["hapticFeedback"].Bool());
 
+	setCheckbuttonState(ui->buttonHandleBackRightMouseButton, settings["input"]["handleBackRightMouseButton"].Bool());
+
 	std::string cursorType = settings["video"]["cursor"].String();
 	int cursorTypeIndex = vstd::find_pos(cursorTypesList, cursorType);
 	setCheckbuttonState(ui->buttonCursorType, cursorTypeIndex);
@@ -851,5 +853,6 @@ void CSettingsView::on_buttonHandleBackRightMouseButton_toggled(bool checked)
 {
 	Settings node = settings.write["input"]["handleBackRightMouseButton"];
 	node->Bool() = checked;
+	updateCheckbuttonText(ui->buttonHandleBackRightMouseButton);
 }
 

--- a/launcher/settingsView/csettingsview_moc.h
+++ b/launcher/settingsView/csettingsview_moc.h
@@ -101,6 +101,8 @@ private slots:
 
 	void on_buttonScalingAuto_toggled(bool checked);
 
+	void on_buttonHandleBackRightMouseButton_toggled(bool checked);
+
 private:
 	Ui::CSettingsView * ui;
 

--- a/launcher/settingsView/csettingsview_moc.ui
+++ b/launcher/settingsView/csettingsview_moc.ui
@@ -69,7 +69,7 @@
          </property>
         </widget>
        </item>
-       <item row="60" column="0">
+       <item row="61" column="0">
         <widget class="QLabel" name="labelModsValidation">
          <property name="text">
           <string>Mods Validation</string>
@@ -105,7 +105,7 @@
          </item>
         </widget>
        </item>
-       <item row="43" column="1" colspan="5">
+       <item row="44" column="1" colspan="5">
         <widget class="QSlider" name="sliderControllerSticksSensitivity">
          <property name="minimum">
           <number>500</number>
@@ -133,7 +133,7 @@
          </property>
         </widget>
        </item>
-       <item row="35" column="1" colspan="5">
+       <item row="36" column="1" colspan="5">
         <widget class="QPushButton" name="pushButtonResetTutorialTouchscreen">
          <property name="text">
           <string>Reset</string>
@@ -147,7 +147,7 @@
          </property>
         </widget>
        </item>
-       <item row="39" column="1" colspan="5">
+       <item row="40" column="1" colspan="5">
         <widget class="QSlider" name="sliderLongTouchDuration">
          <property name="minimum">
           <number>500</number>
@@ -172,7 +172,7 @@
          </property>
         </widget>
        </item>
-       <item row="54" column="1">
+       <item row="55" column="1">
         <widget class="QToolButton" name="buttonAutoCheck">
          <property name="enabled">
           <bool>true</bool>
@@ -239,7 +239,7 @@
          </property>
         </widget>
        </item>
-       <item row="55" column="1">
+       <item row="56" column="1">
         <widget class="QToolButton" name="buttonRepositoryDefault">
          <property name="enabled">
           <bool>true</bool>
@@ -268,14 +268,14 @@
          </property>
         </widget>
        </item>
-       <item row="38" column="0">
+       <item row="39" column="0">
         <widget class="QLabel" name="labelHapticFeedback">
          <property name="text">
           <string>Haptic Feedback</string>
          </property>
         </widget>
        </item>
-       <item row="41" column="0">
+       <item row="42" column="0">
         <widget class="QLabel" name="labelToleranceDistanceTouch">
          <property name="text">
           <string>Touch Tap Tolerance</string>
@@ -288,7 +288,7 @@
        <item row="1" column="1" colspan="5">
         <widget class="QComboBox" name="comboBoxLanguage"/>
        </item>
-       <item row="58" column="1" colspan="5">
+       <item row="59" column="1" colspan="5">
         <widget class="QSpinBox" name="spinBoxNetworkPortLobby">
          <property name="minimum">
           <number>1024</number>
@@ -301,7 +301,7 @@
          </property>
         </widget>
        </item>
-       <item row="60" column="5">
+       <item row="61" column="5">
         <widget class="QToolButton" name="buttonValidationFull">
          <property name="enabled">
           <bool>true</bool>
@@ -326,7 +326,7 @@
          </attribute>
         </widget>
        </item>
-       <item row="42" column="0">
+       <item row="43" column="0">
         <widget class="QLabel" name="labelInputMouse_3">
          <property name="font">
           <font>
@@ -379,7 +379,7 @@
          </property>
         </widget>
        </item>
-       <item row="47" column="1" colspan="5">
+       <item row="48" column="1" colspan="5">
         <widget class="QComboBox" name="comboBoxEnemyPlayerAI">
          <property name="currentText">
           <string notr="true">VCAI</string>
@@ -396,7 +396,7 @@
          </item>
         </widget>
        </item>
-       <item row="55" column="2" colspan="4">
+       <item row="56" column="2" colspan="4">
         <widget class="QLineEdit" name="lineEditRepositoryDefault">
          <property name="text">
           <string notr="true"/>
@@ -406,7 +406,7 @@
          </property>
         </widget>
        </item>
-       <item row="48" column="1" colspan="5">
+       <item row="49" column="1" colspan="5">
         <widget class="QComboBox" name="comboBoxAlliedPlayerAI">
          <property name="currentText">
           <string notr="true">VCAI</string>
@@ -430,7 +430,7 @@
          </property>
         </widget>
        </item>
-       <item row="46" column="0">
+       <item row="47" column="0">
         <widget class="QLabel" name="labelArtificialIntelligence">
          <property name="font">
           <font>
@@ -445,7 +445,7 @@
          </property>
         </widget>
        </item>
-       <item row="55" column="0">
+       <item row="56" column="0">
         <widget class="QLabel" name="labelRepositoryDefault">
          <property name="text">
           <string>Default repository</string>
@@ -471,7 +471,7 @@
          </property>
         </widget>
        </item>
-       <item row="37" column="0">
+       <item row="38" column="0">
         <widget class="QLabel" name="labelRelativeCursorSpeed">
          <property name="text">
           <string>Relative Pointer Speed</string>
@@ -485,7 +485,7 @@
          </property>
         </widget>
        </item>
-       <item row="53" column="1" colspan="5">
+       <item row="54" column="1" colspan="5">
         <widget class="QToolButton" name="buttonIgnoreSslErrors">
          <property name="enabled">
           <bool>true</bool>
@@ -565,7 +565,7 @@
          </property>
         </widget>
        </item>
-       <item row="56" column="1">
+       <item row="57" column="1">
         <widget class="QToolButton" name="buttonRepositoryExtra">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
@@ -584,21 +584,21 @@
          </property>
         </widget>
        </item>
-       <item row="54" column="2" colspan="4">
+       <item row="55" column="2" colspan="4">
         <widget class="QPushButton" name="refreshRepositoriesButton">
          <property name="text">
           <string>Refresh now</string>
          </property>
         </widget>
        </item>
-       <item row="48" column="0">
+       <item row="49" column="0">
         <widget class="QLabel" name="labelAlliedPlayerAI">
          <property name="text">
           <string>Adventure Map Allies</string>
          </property>
         </widget>
        </item>
-       <item row="49" column="0">
+       <item row="50" column="0">
         <widget class="QLabel" name="labelNeutralAI">
          <property name="text">
           <string>Neutral AI in battles</string>
@@ -636,7 +636,7 @@
          </property>
         </widget>
        </item>
-       <item row="57" column="1" colspan="5">
+       <item row="58" column="1" colspan="5">
         <widget class="QLineEdit" name="lineEditGameLobbyHost">
          <property name="text">
           <string notr="true"/>
@@ -650,7 +650,7 @@
          </property>
         </widget>
        </item>
-       <item row="36" column="0">
+       <item row="37" column="0">
         <widget class="QLabel" name="labelRelativeCursorMode">
          <property name="text">
           <string>Use Relative Pointer Mode</string>
@@ -660,14 +660,14 @@
        <item row="7" column="1" colspan="5">
         <widget class="QSpinBox" name="spinBoxAutoSaveLimit"/>
        </item>
-       <item row="50" column="0">
+       <item row="51" column="0">
         <widget class="QLabel" name="labelFriendlyAI">
          <property name="text">
           <string>Autocombat AI in battles</string>
          </property>
         </widget>
        </item>
-       <item row="60" column="1" colspan="2">
+       <item row="61" column="1" colspan="2">
         <widget class="QToolButton" name="buttonValidationOff">
          <property name="enabled">
           <bool>true</bool>
@@ -714,7 +714,7 @@
          </property>
         </widget>
        </item>
-       <item row="38" column="1" colspan="5">
+       <item row="39" column="1" colspan="5">
         <widget class="QToolButton" name="buttonHapticFeedback">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
@@ -745,7 +745,7 @@
          </property>
         </widget>
        </item>
-       <item row="56" column="0">
+       <item row="57" column="0">
         <widget class="QLabel" name="labelRepositoryExtra">
          <property name="text">
           <string>Additional repository</string>
@@ -768,7 +768,7 @@
          </property>
         </widget>
        </item>
-       <item row="47" column="0">
+       <item row="48" column="0">
         <widget class="QLabel" name="labelEnemyPlayerAI">
          <property name="text">
           <string>Adventure Map Enemies</string>
@@ -796,7 +796,7 @@
          </property>
         </widget>
        </item>
-       <item row="34" column="0">
+       <item row="35" column="0">
         <widget class="QLabel" name="labelInputMouse_2">
          <property name="font">
           <font>
@@ -830,7 +830,7 @@
        <item row="23" column="1">
         <widget class="QLabel" name="labelScalingCursorValue"/>
        </item>
-       <item row="36" column="1" colspan="5">
+       <item row="37" column="1" colspan="5">
         <widget class="QToolButton" name="buttonRelativeCursorMode">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
@@ -853,28 +853,28 @@
          </property>
         </widget>
        </item>
-       <item row="57" column="0">
+       <item row="58" column="0">
         <widget class="QLabel" name="labelGameLobbyHost">
          <property name="text">
           <string>Online Lobby address</string>
          </property>
         </widget>
        </item>
-       <item row="58" column="0">
+       <item row="59" column="0">
         <widget class="QLabel" name="labelNetworkPortLobby">
          <property name="text">
           <string>Online Lobby port</string>
          </property>
         </widget>
        </item>
-       <item row="45" column="0">
+       <item row="46" column="0">
         <widget class="QLabel" name="labelToleranceDistanceController">
          <property name="text">
           <string>Controller Click Tolerance</string>
          </property>
         </widget>
        </item>
-       <item row="49" column="1" colspan="5">
+       <item row="50" column="1" colspan="5">
         <widget class="QComboBox" name="comboBoxNeutralAI">
          <property name="currentText">
           <string notr="true">BattleAI</string>
@@ -910,7 +910,7 @@
          </item>
         </widget>
        </item>
-       <item row="53" column="0">
+       <item row="54" column="0">
         <widget class="QLabel" name="labelIgnoreSslErrors">
          <property name="text">
           <string>Ignore SSL errors</string>
@@ -920,14 +920,14 @@
        <item row="20" column="1" colspan="5">
         <widget class="QComboBox" name="comboBoxDisplayIndex"/>
        </item>
-       <item row="35" column="0">
+       <item row="36" column="0">
         <widget class="QLabel" name="labelResetTutorialTouchscreen">
          <property name="text">
           <string>Show Tutorial again</string>
          </property>
         </widget>
        </item>
-       <item row="44" column="0">
+       <item row="45" column="0">
         <widget class="QLabel" name="labelControllerSticksAcceleration">
          <property name="text">
           <string>Sticks Acceleration</string>
@@ -949,7 +949,7 @@
          </property>
         </widget>
        </item>
-       <item row="51" column="1" colspan="5">
+       <item row="52" column="1" colspan="5">
         <widget class="QComboBox" name="comboBoxEnemyAI">
          <property name="editable">
           <bool>false</bool>
@@ -990,7 +990,30 @@
          </property>
         </widget>
        </item>
-       <item row="51" column="0">
+       <item row="34" column="0">
+        <widget class="QLabel" name="labelHandleBackRightMouseButton">
+         <property name="text">
+          <string>Handle back as right mouse button</string>
+         </property>
+        </widget>
+       </item>
+       <item row="34" column="1" colspan="5">
+        <widget class="QToolButton" name="buttonHandleBackRightMouseButton">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="52" column="0">
         <widget class="QLabel" name="labelEnemyAI">
          <property name="text">
           <string>Enemy AI in battles</string>
@@ -1004,7 +1027,7 @@
          </property>
         </widget>
        </item>
-       <item row="41" column="1" colspan="5">
+       <item row="42" column="1" colspan="5">
         <widget class="QSlider" name="sliderToleranceDistanceTouch">
          <property name="minimum">
           <number>0</number>
@@ -1046,7 +1069,7 @@
          </property>
         </widget>
        </item>
-       <item row="50" column="1" colspan="5">
+       <item row="51" column="1" colspan="5">
         <widget class="QComboBox" name="comboBoxFriendlyAI">
          <property name="editable">
           <bool>false</bool>
@@ -1066,7 +1089,7 @@
          </item>
         </widget>
        </item>
-       <item row="56" column="2" colspan="4">
+       <item row="57" column="2" colspan="4">
         <widget class="QLineEdit" name="lineEditRepositoryExtra">
          <property name="text">
           <string notr="true"/>
@@ -1118,7 +1141,7 @@
          </attribute>
         </widget>
        </item>
-       <item row="52" column="0">
+       <item row="53" column="0">
         <widget class="QLabel" name="labelNetwork">
          <property name="font">
           <font>
@@ -1133,7 +1156,7 @@
          </property>
         </widget>
        </item>
-       <item row="59" column="0">
+       <item row="60" column="0">
         <widget class="QLabel" name="labelMiscellaneous">
          <property name="font">
           <font>
@@ -1148,7 +1171,7 @@
          </property>
         </widget>
        </item>
-       <item row="44" column="1" colspan="5">
+       <item row="45" column="1" colspan="5">
         <widget class="QSlider" name="sliderControllerSticksAcceleration">
          <property name="minimum">
           <number>100</number>
@@ -1220,21 +1243,21 @@ Fullscreen Exclusive Mode - the game will cover the entirety of your screen and 
          </property>
         </widget>
        </item>
-       <item row="39" column="0">
+       <item row="40" column="0">
         <widget class="QLabel" name="labelLongTouchDuration">
          <property name="text">
           <string>Long Touch Duration</string>
          </property>
         </widget>
        </item>
-       <item row="54" column="0">
+       <item row="55" column="0">
         <widget class="QLabel" name="labelAutoCheck">
          <property name="text">
           <string>Check on startup</string>
          </property>
         </widget>
        </item>
-       <item row="45" column="1" colspan="5">
+       <item row="46" column="1" colspan="5">
         <widget class="QSlider" name="sliderToleranceDistanceController">
          <property name="minimum">
           <number>0</number>
@@ -1278,7 +1301,7 @@ Fullscreen Exclusive Mode - the game will cover the entirety of your screen and 
          </property>
         </widget>
        </item>
-       <item row="37" column="1" colspan="5">
+       <item row="38" column="1" colspan="5">
         <widget class="QSlider" name="sliderRelativeCursorSpeed">
          <property name="minimum">
           <number>100</number>
@@ -1393,7 +1416,7 @@ Fullscreen Exclusive Mode - the game will cover the entirety of your screen and 
          </property>
         </widget>
        </item>
-       <item row="43" column="0">
+       <item row="44" column="0">
         <widget class="QLabel" name="labelControllerSticksSensitivity">
          <property name="text">
           <string>Sticks Sensitivity</string>
@@ -1424,7 +1447,7 @@ Fullscreen Exclusive Mode - the game will cover the entirety of your screen and 
        <item row="12" column="1" colspan="5">
         <widget class="QComboBox" name="comboBoxResolution"/>
        </item>
-       <item row="60" column="3" colspan="2">
+       <item row="61" column="3" colspan="2">
         <widget class="QToolButton" name="buttonValidationBasic">
          <property name="enabled">
           <bool>true</bool>


### PR DESCRIPTION
On some android devices right mouse button is "back" button.

SDL provides flag `SDL_HINT_ANDROID_TRAP_BACK_BUTTON` for this. This PR exposes this flag as setting on android devices and handle the button.