### PR TITLE
[1.6.2] Crashfixes for bugs discovered via Google Play

### DIFF
--- a/Mods/vcmi/Content/config/english.json
+++ b/Mods/vcmi/Content/config/english.json
@@ -222,6 +222,7 @@
 
 	"vcmi.client.errors.invalidMap" : "{Invalid map or campaign}\n\nFailed to start game! Selected map or campaign might be invalid or corrupted. Reason:\n%s",
 	"vcmi.client.errors.missingCampaigns" : "{Missing data files}\n\nCampaigns data files were not found! You may be using incomplete or corrupted Heroes 3 data files. Please reinstall game data.",
+	"vcmi.client.errors.modLoadingFailure" : "{Mod loading failure}\n\nCritical issues found when loading mods! Game may not work correctly or crash! Please update or disable following mods:\n\n",
 	"vcmi.server.errors.disconnected" : "{Network Error}\n\nConnection to game server has been lost!",
 	"vcmi.server.errors.playerLeft" : "{Player Left}\n\n%s player have disconnected from the game!", //%s -> player color
 	"vcmi.server.errors.existingProcess" : "Another VCMI server process is running. Please terminate it before starting a new game.",

--- a/client/adventureMap/CList.cpp
+++ b/client/adventureMap/CList.cpp
@@ -471,8 +471,11 @@ void CTownList::CTownItem::gesture(bool on, const Point & initialPosition, const
 	int townLowerPos = (townIndex > towns.size() - 2) ? -1 : townIndex + 1;
 
 	auto updateList = [](){
-		for (auto ki : GH.windows().findWindows<CCastleInterface>())
-			ki->townChange(); //update list
+		for (auto ci : GH.windows().findWindows<CCastleInterface>())
+		{
+			ci->townlist->updateWidget();
+			ci->townlist->select(ci->town);
+		}
 	};
 
 	std::vector<RadialMenuConfig> menuElements = {

--- a/client/lobby/CSelectionBase.cpp
+++ b/client/lobby/CSelectionBase.cpp
@@ -74,7 +74,14 @@ int ISelectionScreenInfo::getCurrentDifficulty()
 
 PlayerInfo ISelectionScreenInfo::getPlayerInfo(PlayerColor color)
 {
-	return getMapInfo()->mapHeader->players.at(color.getNum());
+	auto mapInfo = getMapInfo();
+	if (!mapInfo)
+		throw std::runtime_error("Attempt to get player info for invalid map!");
+
+	if (!mapInfo->mapHeader)
+		throw std::runtime_error("Attempt to get player info for invalid map header!");
+
+	return mapInfo->mapHeader->players.at(color.getNum());
 }
 
 CSelectionBase::CSelectionBase(ESelectionScreen type)

--- a/client/lobby/OptionsTab.cpp
+++ b/client/lobby/OptionsTab.cpp
@@ -933,6 +933,9 @@ void OptionsTab::SelectedBox::showPopupWindow(const Point & cursorPosition)
 
 void OptionsTab::SelectedBox::clickReleased(const Point & cursorPosition)
 {
+	if (!SEL)
+		return;
+
 	if(SEL->screenType != ESelectionScreen::newGame)
 		return;
 	

--- a/client/renderSDL/SDLImage.cpp
+++ b/client/renderSDL/SDLImage.cpp
@@ -404,6 +404,9 @@ std::shared_ptr<IImage> SDLImageShared::createImageReference(EImageBlitMode mode
 
 std::shared_ptr<const ISharedImage> SDLImageShared::horizontalFlip() const
 {
+	if (!surf)
+		return shared_from_this();
+
 	SDL_Surface * flipped = CSDL_Ext::horizontalFlip(surf);
 	auto ret = std::make_shared<SDLImageShared>(flipped, preScaleFactor);
 	ret->fullSize = fullSize;
@@ -416,6 +419,9 @@ std::shared_ptr<const ISharedImage> SDLImageShared::horizontalFlip() const
 
 std::shared_ptr<const ISharedImage> SDLImageShared::verticalFlip() const
 {
+	if (!surf)
+		return shared_from_this();
+
 	SDL_Surface * flipped = CSDL_Ext::verticalFlip(surf);
 	auto ret = std::make_shared<SDLImageShared>(flipped, preScaleFactor);
 	ret->fullSize = fullSize;

--- a/launcher/modManager/cmodlistview_moc.cpp
+++ b/launcher/modManager/cmodlistview_moc.cpp
@@ -1053,7 +1053,13 @@ QStringList CModListView::getUpdateableMods()
 	for(const auto & modName : modStateModel->getAllMods())
 	{
 		auto mod = modStateModel->getMod(modName);
-		if (mod.isUpdateAvailable())
+		if (!mod.isUpdateAvailable())
+			continue;
+
+		QStringList notInstalledDependencies = getModsToInstall(mod.getID());
+		QStringList unavailableDependencies = findUnavailableMods(notInstalledDependencies);
+
+		if (unavailableDependencies.empty())
 			result.push_back(modName);
 	}
 

--- a/lib/modding/IdentifierStorage.cpp
+++ b/lib/modding/IdentifierStorage.cpp
@@ -442,6 +442,7 @@ bool CIdentifierStorage::resolveIdentifier(const ObjectCallback & request) const
 	}
 
 	// error found. Try to generate some debug info
+	failedRequests.push_back(request);
 	showIdentifierResolutionErrorDetails(request);
 	return false;
 }
@@ -492,6 +493,17 @@ void CIdentifierStorage::debugDumpIdentifiers()
 		for(const auto & entry : category.second)
 			logMod->trace("- " + entry);
 	}
+}
+
+std::vector<std::string> CIdentifierStorage::getModsWithFailedRequests() const
+{
+	std::vector<std::string> result;
+
+	for (const auto & request : failedRequests)
+		if (!vstd::contains(result, request.localScope))
+			result.push_back(request.localScope);
+
+	return result;
 }
 
 VCMI_LIB_NAMESPACE_END

--- a/lib/modding/IdentifierStorage.h
+++ b/lib/modding/IdentifierStorage.h
@@ -58,6 +58,9 @@ class DLL_LINKAGE CIdentifierStorage
 	std::multimap<std::string, ObjectData> registeredObjects;
 	mutable std::vector<ObjectCallback> scheduledRequests;
 
+	/// All non-optional requests that have failed to resolve, for debug & error reporting
+	mutable std::vector<ObjectCallback> failedRequests;
+
 	ELoadingState state = ELoadingState::LOADING;
 
 	/// Helper method that dumps all registered identifier into log file
@@ -101,6 +104,9 @@ public:
 
 	/// called at the very end of loading to check for any missing ID's
 	void finalize();
+
+	/// Returns list of all mods, from which at least one identifier has failed to resolve
+	std::vector<std::string> getModsWithFailedRequests() const;
 };
 
 VCMI_LIB_NAMESPACE_END

--- a/lib/modding/ModManager.h
+++ b/lib/modding/ModManager.h
@@ -132,6 +132,7 @@ class DLL_LINKAGE ModManager : boost::noncopyable
 	void addNewModsToPreset();
 	void updatePreset(const ModDependenciesResolver & newData);
 
+	TModList getInstalledValidMods() const;
 	TModList collectDependenciesRecursive(const TModID & modID) const;
 
 	void tryEnableMod(const TModID & modList);


### PR DESCRIPTION
-  Correctly remove unsupported (e.g. era) mods from active preset
- Fix crash on attempt to update mod that depends on unknown mod
-  Fix crash on attempt to flip empty image
- Try to handle crash on map selection screen
- Added information on mod loading failure to inform player on broken mods. Does not fixes crash, but helps player figure out what's wrong.
-  More robust checks for old saves removal