### PR TITLE
Do not add non-existing buildings to H3 towns

### DIFF
--- a/lib/entities/faction/CTownHandler.cpp
+++ b/lib/entities/faction/CTownHandler.cpp
@@ -389,13 +389,10 @@ void CTownHandler::loadBuilding(CTown * town, const std::string & stringID, cons
 
 void CTownHandler::loadBuildings(CTown * town, const JsonNode & source)
 {
-	if(source.isStruct())
+	for(const auto & node : source.Struct())
 	{
-		for(const auto & node : source.Struct())
-		{
-			if (!node.second.isNull())
-				loadBuilding(town, node.first, node.second);
-		}
+		if (!node.second.isNull())
+			loadBuilding(town, node.first, node.second);
 	}
 }
 
@@ -874,6 +871,9 @@ void CTownHandler::beforeValidate(JsonNode & object)
 
 	for (auto & building : object["town"]["buildings"].Struct())
 	{
+		if (building.second.isNull())
+			continue;
+
 		inheritBuilding(building.first, building.second);
 		if (building.second.Struct().count("type"))
 			inheritBuilding(building.second["type"].String(), building.second);


### PR DESCRIPTION
Such as Mages Guild 4-5 to Fortress, or all 4 special buildings to towns without them

Fixes attempts by AI to build such invalid buildings