### PR TITLE
Improved "Create new map" dialog for map editor

### DIFF
--- a/mapeditor/generatorprogress.cpp
+++ b/mapeditor/generatorprogress.cpp
@@ -19,10 +19,10 @@ GeneratorProgress::GeneratorProgress(Load::Progress & source, QWidget *parent) :
 	source(source)
 {
 	ui->setupUi(this);
+	
+	setWindowFlags(Qt::Dialog | Qt::WindowTitleHint | Qt::CustomizeWindowHint);
 
 	setAttribute(Qt::WA_DeleteOnClose);
-
-	setWindowFlags(Qt::Window);
 
 	show();
 }

--- a/mapeditor/mapsettings/mapsettings.cpp
+++ b/mapeditor/mapsettings/mapsettings.cpp
@@ -25,7 +25,9 @@ MapSettings::MapSettings(MapController & ctrl, QWidget *parent) :
 	controller(ctrl)
 {
 	ui->setupUi(this);
-
+	
+	setWindowFlags(Qt::Dialog | Qt::WindowTitleHint | Qt::WindowCloseButtonHint);
+	
 	assert(controller.map());
 	
 	show();

--- a/mapeditor/mapsettings/translations.cpp
+++ b/mapeditor/mapsettings/translations.cpp
@@ -62,6 +62,8 @@ Translations::Translations(CMapHeader & mh, QWidget *parent) :
 	setAttribute(Qt::WA_DeleteOnClose, true);
 	ui->setupUi(this);
 	
+	setWindowFlags(Qt::Dialog | Qt::WindowTitleHint | Qt::WindowCloseButtonHint);
+	
 	//fill languages list
 	std::set<int> indexFoundLang;
 	int foundLang = -1;

--- a/mapeditor/playersettings.cpp
+++ b/mapeditor/playersettings.cpp
@@ -22,6 +22,9 @@ PlayerSettings::PlayerSettings(MapController & ctrl, QWidget *parent) :
 	controller(ctrl)
 {
 	ui->setupUi(this);
+	
+	setWindowFlags(Qt::Dialog | Qt::WindowTitleHint | Qt::WindowCloseButtonHint);
+	
 	show();
 
 	int players = 0;

--- a/mapeditor/validator.cpp
+++ b/mapeditor/validator.cpp
@@ -24,7 +24,9 @@ Validator::Validator(const CMap * map, QWidget *parent) :
 	ui(new Ui::Validator)
 {
 	ui->setupUi(this);
-
+	
+	setWindowFlags(Qt::Dialog | Qt::WindowTitleHint | Qt::WindowCloseButtonHint);
+	
 	show();
 	
 	setAttribute(Qt::WA_DeleteOnClose);

--- a/mapeditor/windownewmap.cpp
+++ b/mapeditor/windownewmap.cpp
@@ -367,7 +367,7 @@ void WindowNewMap::on_cpuCombo_activated(int index)
 void WindowNewMap::on_randomMapCheck_stateChanged(int arg1)
 {
 	randomMap = ui->randomMapCheck->isChecked();
-	ui->templateCombo->setEnabled(randomMap);
+	ui->randomOptions->setEnabled(randomMap);
 	updateTemplateList();
 }
 

--- a/mapeditor/windownewmap.cpp
+++ b/mapeditor/windownewmap.cpp
@@ -63,7 +63,8 @@ WindowNewMap::WindowNewMap(QWidget *parent) :
 	connect(ui->mapOpt2, &QRadioButton::toggled, this, &WindowNewMap::on_mapOpt2_toggled);
 
 	on_mapOpt1_toggled(true);
-	
+	on_checkSeed_toggled(false);
+
 	// size combo
 	connect(ui->sizeCombo, QOverload<int>::of(&QComboBox::activated), this, &WindowNewMap::on_sizeCombo_activated);
 	

--- a/mapeditor/windownewmap.cpp
+++ b/mapeditor/windownewmap.cpp
@@ -295,6 +295,8 @@ void WindowNewMap::on_okButton_clicked()
 			return;
 		}
 		
+		hide();
+
 		int seed = std::time(nullptr);
 		if(ui->checkSeed->isChecked() && ui->lineSeed->value() != 0)
 			seed = ui->lineSeed->value();

--- a/mapeditor/windownewmap.cpp
+++ b/mapeditor/windownewmap.cpp
@@ -221,16 +221,15 @@ std::unique_ptr<CMap> generateEmptyMap(CMapGenOptions & options)
 	return map;
 }
 
-int getSelectedMapSize(QComboBox* comboBox, int dimension) {
-	QString selectedText = comboBox->currentText();
-	QRegularExpression regex(R"(\((\d+)x(\d+)\))"); // Regex for format (width x height)
-	QRegularExpressionMatch match = regex.match(selectedText);
+std::pair<int, int> getSelectedMapSize(QComboBox* comboBox, const std::map<int, std::pair<int, int>>& mapSizes) {
+	int selectedIndex = comboBox->currentIndex();
 
-	if (match.hasMatch() && (dimension == 1 || dimension == 2)) {
-		return match.captured(dimension).toInt(); // Return width (1) or height (2)
+	auto it = mapSizes.find(selectedIndex);
+	if (it != mapSizes.end()) {
+		return it->second; // Return the width and height pair
 	}
 
-	return -1; // Return -1 if no match or invalid dimension
+	return { 0, 0 };
 }
 
 void WindowNewMap::on_okButton_clicked()
@@ -263,8 +262,9 @@ void WindowNewMap::on_okButton_clicked()
 	
 	if(ui->sizeStandardRadio->isChecked())
 	{
-		mapGenOptions.setWidth(getSelectedMapSize(ui->sizeCombo, 1));
-		mapGenOptions.setHeight(getSelectedMapSize(ui->sizeCombo, 2));
+		auto size = getSelectedMapSize(ui->sizeCombo, mapSizes);
+		mapGenOptions.setWidth(size.first);
+		mapGenOptions.setHeight(size.second);
 	}
 	else
 	{
@@ -319,8 +319,9 @@ void WindowNewMap::on_okButton_clicked()
 
 void WindowNewMap::on_sizeCombo_activated(int index)
 {
-	mapGenOptions.setWidth(getSelectedMapSize(ui->sizeCombo, 1));
-	mapGenOptions.setHeight(getSelectedMapSize(ui->sizeCombo, 2));
+	auto size = getSelectedMapSize(ui->sizeCombo, mapSizes);
+	mapGenOptions.setWidth(size.first);
+	mapGenOptions.setHeight(size.second);
 	updateTemplateList();
 }
 

--- a/mapeditor/windownewmap.cpp
+++ b/mapeditor/windownewmap.cpp
@@ -57,20 +57,9 @@ WindowNewMap::WindowNewMap(QWidget *parent) :
 		ui->cpuTeamsCombo->addItem(!i ? randomString : QString::number(cpuPlayers.at(i)));
 		ui->cpuTeamsCombo->setItemData(i, QVariant(cpuPlayers.at(i)));
 	}
-	
-	// map option radios
-	connect(ui->mapOpt1, &QRadioButton::toggled, this, &WindowNewMap::on_mapOpt1_toggled);
-	connect(ui->mapOpt2, &QRadioButton::toggled, this, &WindowNewMap::on_mapOpt2_toggled);
 
-	on_mapOpt1_toggled(true);
+	on_sizeStandardRadio_toggled(true);
 	on_checkSeed_toggled(false);
-
-	// size combo
-	connect(ui->sizeCombo, QOverload<int>::of(&QComboBox::activated), this, &WindowNewMap::on_sizeCombo_activated);
-	
-	// spin boxes
-	connect(ui->widthTxt, QOverload<int>::of(&QSpinBox::valueChanged), this, &WindowNewMap::on_widthTxt_valueChanged);
-	connect(ui->heightTxt, QOverload<int>::of(&QSpinBox::valueChanged), this, &WindowNewMap::on_heightTxt_valueChanged);
 
 	bool useLoaded = loadUserSettings();
 	if (!useLoaded)
@@ -272,7 +261,7 @@ void WindowNewMap::on_okButton_clicked()
 	mapGenOptions.setRoadEnabled(Road::GRAVEL_ROAD, ui->roadGravel->isChecked());
 	mapGenOptions.setRoadEnabled(Road::COBBLESTONE_ROAD, ui->roadCobblestone->isChecked());
 	
-	if(ui->mapOpt1->isChecked())
+	if(ui->sizeStandardRadio->isChecked())
 	{
 		mapGenOptions.setWidth(getSelectedMapSize(ui->sizeCombo, 1));
 		mapGenOptions.setHeight(getSelectedMapSize(ui->sizeCombo, 2));
@@ -505,7 +494,7 @@ void WindowNewMap::on_cpuTeamsCombo_activated(int index)
 
 
 
-void WindowNewMap::on_mapOpt1_toggled(bool checked) 
+void WindowNewMap::on_sizeStandardRadio_toggled(bool checked) 
 {
 	if (checked) {
 		ui->sizeGroup1->setEnabled(true);
@@ -515,7 +504,7 @@ void WindowNewMap::on_mapOpt1_toggled(bool checked)
 }
 
 
-void WindowNewMap::on_mapOpt2_toggled(bool checked) 
+void WindowNewMap::on_sizeCustomRadio_toggled(bool checked) 
 {
 	if (checked) {
 		ui->sizeGroup1->setEnabled(false);

--- a/mapeditor/windownewmap.cpp
+++ b/mapeditor/windownewmap.cpp
@@ -295,7 +295,7 @@ void WindowNewMap::on_okButton_clicked()
 		}
 		
 		int seed = std::time(nullptr);
-		if(ui->checkSeed->isChecked() && !ui->lineSeed->value().isEmpty())
+		if(ui->checkSeed->isChecked() && !ui->lineSeed->value() != 0)
 			seed = ui->lineSeed->value();
 			
 		CMapGenerator generator(mapGenOptions, nullptr, seed);

--- a/mapeditor/windownewmap.cpp
+++ b/mapeditor/windownewmap.cpp
@@ -33,6 +33,8 @@ WindowNewMap::WindowNewMap(QWidget *parent) :
 {
 	ui->setupUi(this);
 
+	setWindowFlags(Qt::Dialog | Qt::WindowTitleHint | Qt::WindowCloseButtonHint);
+
 	setAttribute(Qt::WA_DeleteOnClose);
 
 	setWindowModality(Qt::ApplicationModal);

--- a/mapeditor/windownewmap.cpp
+++ b/mapeditor/windownewmap.cpp
@@ -328,6 +328,13 @@ void WindowNewMap::on_okButton_clicked()
 	close();
 }
 
+void WindowNewMap::on_sizeCombo_activated(int index)
+{
+	mapGenOptions.setWidth(getSelectedMapSize(ui->sizeCombo, 1));
+	mapGenOptions.setHeight(getSelectedMapSize(ui->sizeCombo, 2));
+	updateTemplateList();
+}
+
 
 void WindowNewMap::on_twoLevelCheck_stateChanged(int arg1)
 {
@@ -345,8 +352,6 @@ void WindowNewMap::on_humanCombo_activated(int index)
 		humans = PlayerColor::PLAYER_LIMIT_I;
 		ui->humanCombo->setCurrentIndex(humans);
 	}
-
-	mapGenOptions.setHumanOrCpuPlayerCount(humans);
 
 	int teams = mapGenOptions.getTeamCount();
 	if(teams > humans - 1)
@@ -369,6 +374,8 @@ void WindowNewMap::on_humanCombo_activated(int index)
 		ui->cpuTeamsCombo->setCurrentIndex(cpuTeams + 1); //skip one element because first is random
 	}
 
+	mapGenOptions.setHumanOrCpuPlayerCount(humans);
+
 	updateTemplateList();
 }
 
@@ -384,15 +391,15 @@ void WindowNewMap::on_cpuCombo_activated(int index)
 		cpu = PlayerColor::PLAYER_LIMIT_I - humans;
 		ui->cpuCombo->setCurrentIndex(cpu + 1); //skip one element because first is random
 	}
-	
-	mapGenOptions.setCompOnlyPlayerCount(cpu);
-	
+
 	int cpuTeams = mapGenOptions.getCompOnlyTeamCount(); //comp only players - 1
 	if(cpuTeams > cpu - 1)
 	{
 		cpuTeams = cpu > 0 ? cpu - 1 : CMapGenOptions::RANDOM_SIZE;
 		ui->cpuTeamsCombo->setCurrentIndex(cpuTeams + 1); //skip one element because first is random
 	}
+
+	mapGenOptions.setCompOnlyPlayerCount(cpu);
 
 	updateTemplateList();
 }
@@ -496,13 +503,6 @@ void WindowNewMap::on_cpuTeamsCombo_activated(int index)
 	updateTemplateList();
 }
 
-
-void WindowNewMap::on_sizeCombo_activated(int index) 
-{
-	mapGenOptions.setWidth(getSelectedMapSize(ui->sizeCombo, 1));
-	mapGenOptions.setHeight(getSelectedMapSize(ui->sizeCombo, 2));
-	updateTemplateList();
-}
 
 
 void WindowNewMap::on_mapOpt1_toggled(bool checked) 

--- a/mapeditor/windownewmap.cpp
+++ b/mapeditor/windownewmap.cpp
@@ -296,7 +296,7 @@ void WindowNewMap::on_okButton_clicked()
 		}
 		
 		int seed = std::time(nullptr);
-		if(ui->checkSeed->isChecked() && !ui->lineSeed->value() != 0)
+		if(ui->checkSeed->isChecked() && ui->lineSeed->value() != 0)
 			seed = ui->lineSeed->value();
 			
 		CMapGenerator generator(mapGenOptions, nullptr, seed);

--- a/mapeditor/windownewmap.cpp
+++ b/mapeditor/windownewmap.cpp
@@ -222,7 +222,7 @@ std::unique_ptr<CMap> generateEmptyMap(CMapGenOptions & options)
 }
 
 int getSelectedMapSize(QComboBox* comboBox, int dimension) {
-	QString selectedText = comboBox->currentText(); // Get the selected text
+	QString selectedText = comboBox->currentText();
 	QRegularExpression regex(R"(\((\d+)x(\d+)\))"); // Regex for format (width x height)
 	QRegularExpressionMatch match = regex.match(selectedText);
 

--- a/mapeditor/windownewmap.h
+++ b/mapeditor/windownewmap.h
@@ -108,9 +108,9 @@ private slots:
 
 	void on_cpuTeamsCombo_activated(int index);
 
-	void on_mapOpt1_toggled(bool checked);
+	void on_sizeStandardRadio_toggled(bool checked);
 	
-	void on_mapOpt2_toggled(bool checked);
+	void on_sizeCustomRadio_toggled(bool checked);
 
 private:
 

--- a/mapeditor/windownewmap.h
+++ b/mapeditor/windownewmap.h
@@ -67,13 +67,13 @@ class WindowNewMap : public QDialog
 
 	const std::map<int, std::pair<int, int>> mapSizes
 	{
-		{0, {CMapHeader::MAP_SIZE_SMALL, 	CMapHeader::MAP_SIZE_SMALL}},
-		{1, {CMapHeader::MAP_SIZE_MIDDLE,	CMapHeader::MAP_SIZE_MIDDLE}},
-		{2, {CMapHeader::MAP_SIZE_LARGE,	CMapHeader::MAP_SIZE_LARGE}},
-		{3, {CMapHeader::MAP_SIZE_XLARGE,	CMapHeader::MAP_SIZE_XLARGE}},
-		{4, {CMapHeader::MAP_SIZE_HUGE,		CMapHeader::MAP_SIZE_HUGE}},
-		{5, {CMapHeader::MAP_SIZE_XHUGE,	CMapHeader::MAP_SIZE_XHUGE}},
-		{6, {CMapHeader::MAP_SIZE_GIANT,	CMapHeader::MAP_SIZE_GIANT}}
+		{0, {CMapHeader::MAP_SIZE_SMALL, CMapHeader::MAP_SIZE_SMALL}},
+		{1, {CMapHeader::MAP_SIZE_MIDDLE, CMapHeader::MAP_SIZE_MIDDLE}},
+		{2, {CMapHeader::MAP_SIZE_LARGE, CMapHeader::MAP_SIZE_LARGE}},
+		{3, {CMapHeader::MAP_SIZE_XLARGE, CMapHeader::MAP_SIZE_XLARGE}},
+		{4, {CMapHeader::MAP_SIZE_HUGE, CMapHeader::MAP_SIZE_HUGE}},
+		{5, {CMapHeader::MAP_SIZE_XHUGE, CMapHeader::MAP_SIZE_XHUGE}},
+		{6, {CMapHeader::MAP_SIZE_GIANT, CMapHeader::MAP_SIZE_GIANT}},
 	};
 
 public:

--- a/mapeditor/windownewmap.h
+++ b/mapeditor/windownewmap.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include <QDialog>
+#include <QRegularExpression>
 
 #include "../lib/mapping/CMapHeader.h"
 #include "../lib/rmg/CMapGenOptions.h"
@@ -73,7 +74,7 @@ class WindowNewMap : public QDialog
 		{3, {CMapHeader::MAP_SIZE_XLARGE,	CMapHeader::MAP_SIZE_XLARGE}},
 		{4, {CMapHeader::MAP_SIZE_HUGE,		CMapHeader::MAP_SIZE_HUGE}},
 		{5, {CMapHeader::MAP_SIZE_XHUGE,	CMapHeader::MAP_SIZE_XHUGE}},
-		{6, {CMapHeader::MAP_SIZE_GIANT,	CMapHeader::MAP_SIZE_GIANT}},
+		{6, {CMapHeader::MAP_SIZE_GIANT,	CMapHeader::MAP_SIZE_GIANT}}
 	};
 
 public:
@@ -85,8 +86,6 @@ private slots:
 
 	void on_okButton_clicked();
 
-	void on_sizeCombo_activated(int index);
-
 	void on_twoLevelCheck_stateChanged(int arg1);
 
 	void on_humanCombo_activated(int index);
@@ -97,15 +96,21 @@ private slots:
 
 	void on_templateCombo_activated(int index);
 
-	void on_widthTxt_textChanged(const QString &arg1);
+	void on_widthTxt_valueChanged(int value);
 
-	void on_heightTxt_textChanged(const QString &arg1);
+	void on_heightTxt_valueChanged(int value);
 
 	void on_checkSeed_toggled(bool checked);
 
 	void on_humanTeamsCombo_activated(int index);
 
 	void on_cpuTeamsCombo_activated(int index);
+
+    void on_mapOpt1_toggled(bool checked);
+	
+    void on_mapOpt2_toggled(bool checked);
+	
+	void on_sizeCombo_activated(int index);
 
 private:
 

--- a/mapeditor/windownewmap.h
+++ b/mapeditor/windownewmap.h
@@ -11,7 +11,6 @@
 #pragma once
 
 #include <QDialog>
-#include <QRegularExpression>
 
 #include "../lib/mapping/CMapHeader.h"
 #include "../lib/rmg/CMapGenOptions.h"

--- a/mapeditor/windownewmap.h
+++ b/mapeditor/windownewmap.h
@@ -86,6 +86,8 @@ private slots:
 
 	void on_okButton_clicked();
 
+	void on_sizeCombo_activated(int index);
+
 	void on_twoLevelCheck_stateChanged(int arg1);
 
 	void on_humanCombo_activated(int index);
@@ -109,8 +111,6 @@ private slots:
 	void on_mapOpt1_toggled(bool checked);
 	
 	void on_mapOpt2_toggled(bool checked);
-	
-	void on_sizeCombo_activated(int index);
 
 private:
 

--- a/mapeditor/windownewmap.h
+++ b/mapeditor/windownewmap.h
@@ -106,9 +106,9 @@ private slots:
 
 	void on_cpuTeamsCombo_activated(int index);
 
-    void on_mapOpt1_toggled(bool checked);
+	void on_mapOpt1_toggled(bool checked);
 	
-    void on_mapOpt2_toggled(bool checked);
+	void on_mapOpt2_toggled(bool checked);
 	
 	void on_sizeCombo_activated(int index);
 

--- a/mapeditor/windownewmap.ui
+++ b/mapeditor/windownewmap.ui
@@ -39,7 +39,7 @@
     <rect>
      <x>10</x>
      <y>10</y>
-     <width>291</width>
+     <width>301</width>
      <height>101</height>
     </rect>
    </property>
@@ -51,7 +51,7 @@
      <rect>
       <x>0</x>
       <y>20</y>
-      <width>281</width>
+      <width>301</width>
       <height>73</height>
      </rect>
     </property>
@@ -941,7 +941,7 @@
     <rect>
      <x>10</x>
      <y>120</y>
-     <width>291</width>
+     <width>421</width>
      <height>20</height>
     </rect>
    </property>
@@ -953,9 +953,9 @@
    <property name="geometry">
     <rect>
      <x>320</x>
-     <y>20</y>
+     <y>30</y>
      <width>111</width>
-     <height>91</height>
+     <height>71</height>
     </rect>
    </property>
    <layout class="QVBoxLayout" name="verticalLayout">
@@ -967,12 +967,6 @@
         <verstretch>0</verstretch>
        </sizepolicy>
       </property>
-      <property name="minimumSize">
-       <size>
-        <width>0</width>
-        <height>36</height>
-       </size>
-      </property>
       <property name="maximumSize">
        <size>
         <width>16777215</width>
@@ -980,7 +974,7 @@
        </size>
       </property>
       <property name="text">
-       <string>Ok</string>
+       <string>OK</string>
       </property>
      </widget>
     </item>

--- a/mapeditor/windownewmap.ui
+++ b/mapeditor/windownewmap.ui
@@ -55,7 +55,39 @@
       <height>73</height>
      </rect>
     </property>
-    <layout class="QGridLayout" name="gridLayout_2" columnstretch="3,0,1">
+    <layout class="QGridLayout" name="gridLayout_2" columnstretch="3,0,1,0">
+     <item row="0" column="1">
+      <widget class="QLabel" name="label">
+       <property name="minimumSize">
+        <size>
+         <width>48</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>96</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>Width</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QLabel" name="label_2">
+       <property name="text">
+        <string>Height</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
      <item row="0" column="2">
       <widget class="QLineEdit" name="widthTxt">
        <property name="maximumSize">
@@ -75,13 +107,6 @@
        </property>
       </widget>
      </item>
-     <item row="1" column="1">
-      <widget class="QLabel" name="label_2">
-       <property name="text">
-        <string>Height</string>
-       </property>
-      </widget>
-     </item>
      <item row="1" column="2">
       <widget class="QLineEdit" name="heightTxt">
        <property name="maximumSize">
@@ -98,25 +123,6 @@
        </property>
        <property name="maxLength">
         <number>3</number>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="1">
-      <widget class="QLabel" name="label">
-       <property name="minimumSize">
-        <size>
-         <width>48</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>96</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <property name="text">
-        <string>Width</string>
        </property>
       </widget>
      </item>
@@ -217,6 +223,38 @@
         </widget>
        </item>
       </layout>
+     </item>
+     <item row="1" column="3">
+      <spacer name="horizontalSpacer_11">
+       <property name="orientation">
+        <enum>Qt::Orientation::Horizontal</enum>
+       </property>
+       <property name="sizeType">
+        <enum>QSizePolicy::Policy::Fixed</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>8</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item row="0" column="3">
+      <spacer name="horizontalSpacer_12">
+       <property name="orientation">
+        <enum>Qt::Orientation::Horizontal</enum>
+       </property>
+       <property name="sizeType">
+        <enum>QSizePolicy::Policy::Fixed</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>8</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
      </item>
     </layout>
    </widget>
@@ -923,7 +961,7 @@
      <item>
       <widget class="QComboBox" name="templateCombo">
        <property name="enabled">
-        <bool>false</bool>
+        <bool>true</bool>
        </property>
        <property name="currentText">
         <string notr="true"/>

--- a/mapeditor/windownewmap.ui
+++ b/mapeditor/windownewmap.ui
@@ -368,7 +368,7 @@
        <widget class="QComboBox" name="humanCombo">
         <property name="minimumSize">
          <size>
-          <width>96</width>
+          <width>90</width>
           <height>0</height>
          </size>
         </property>
@@ -429,7 +429,7 @@
        <widget class="QLabel" name="label_3">
         <property name="minimumSize">
          <size>
-          <width>96</width>
+          <width>90</width>
           <height>0</height>
          </size>
         </property>
@@ -448,7 +448,7 @@
        <widget class="QComboBox" name="humanTeamsCombo">
         <property name="minimumSize">
          <size>
-          <width>0</width>
+          <width>90</width>
           <height>0</height>
          </size>
         </property>
@@ -470,6 +470,12 @@
       </item>
       <item row="0" column="2">
        <widget class="QLabel" name="label_6">
+        <property name="minimumSize">
+         <size>
+          <width>90</width>
+          <height>0</height>
+         </size>
+        </property>
         <property name="text">
          <string>Human teams</string>
         </property>
@@ -518,32 +524,7 @@
        <height>26</height>
       </rect>
      </property>
-     <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,1,1,1,1,1">
-      <item>
-       <spacer name="horizontalSpacer_9">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>16777215</width>
-          <height>16777215</height>
-         </size>
-        </property>
-        <property name="orientation">
-         <enum>Qt::Orientation::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>40</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
+     <layout class="QHBoxLayout" name="horizontalLayout" stretch="1,1,1,1">
       <item>
        <widget class="QRadioButton" name="monsterOpt1">
         <property name="sizePolicy">
@@ -551,6 +532,12 @@
           <horstretch>0</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>90</width>
+          <height>0</height>
+         </size>
         </property>
         <property name="maximumSize">
          <size>
@@ -574,6 +561,12 @@
           <verstretch>0</verstretch>
          </sizepolicy>
         </property>
+        <property name="minimumSize">
+         <size>
+          <width>90</width>
+          <height>0</height>
+         </size>
+        </property>
         <property name="maximumSize">
          <size>
           <width>120</width>
@@ -592,6 +585,12 @@
           <horstretch>0</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>90</width>
+          <height>0</height>
+         </size>
         </property>
         <property name="maximumSize">
          <size>
@@ -612,6 +611,12 @@
           <verstretch>0</verstretch>
          </sizepolicy>
         </property>
+        <property name="minimumSize">
+         <size>
+          <width>90</width>
+          <height>0</height>
+         </size>
+        </property>
         <property name="maximumSize">
          <size>
           <width>120</width>
@@ -622,31 +627,6 @@
          <string>Strong</string>
         </property>
        </widget>
-      </item>
-      <item>
-       <spacer name="horizontalSpacer_2">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>16777215</width>
-          <height>16777215</height>
-         </size>
-        </property>
-        <property name="orientation">
-         <enum>Qt::Orientation::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>40</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
       </item>
      </layout>
     </widget>
@@ -684,20 +664,7 @@
        <height>26</height>
       </rect>
      </property>
-     <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="0,1,1,1,1,1">
-      <item>
-       <spacer name="horizontalSpacer_8">
-        <property name="orientation">
-         <enum>Qt::Orientation::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>40</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
+     <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="1,1,1,1">
       <item>
        <widget class="QRadioButton" name="waterOpt1">
         <property name="sizePolicy">
@@ -705,6 +672,12 @@
           <horstretch>0</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>90</width>
+          <height>0</height>
+         </size>
         </property>
         <property name="maximumSize">
          <size>
@@ -728,6 +701,12 @@
           <verstretch>0</verstretch>
          </sizepolicy>
         </property>
+        <property name="minimumSize">
+         <size>
+          <width>90</width>
+          <height>0</height>
+         </size>
+        </property>
         <property name="maximumSize">
          <size>
           <width>144</width>
@@ -746,6 +725,12 @@
           <horstretch>0</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>90</width>
+          <height>0</height>
+         </size>
         </property>
         <property name="maximumSize">
          <size>
@@ -766,6 +751,12 @@
           <verstretch>0</verstretch>
          </sizepolicy>
         </property>
+        <property name="minimumSize">
+         <size>
+          <width>90</width>
+          <height>0</height>
+         </size>
+        </property>
         <property name="maximumSize">
          <size>
           <width>144</width>
@@ -776,19 +767,6 @@
          <string>Islands</string>
         </property>
        </widget>
-      </item>
-      <item>
-       <spacer name="horizontalSpacer">
-        <property name="orientation">
-         <enum>Qt::Orientation::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>40</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
       </item>
      </layout>
     </widget>
@@ -826,75 +804,57 @@
        <height>26</height>
       </rect>
      </property>
-     <layout class="QHBoxLayout" name="horizontalLayout_5" stretch="0,0,0,0,0,0,1">
-      <item>
-       <spacer name="horizontalSpacer_10">
-        <property name="orientation">
-         <enum>Qt::Orientation::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>40</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
+     <layout class="QHBoxLayout" name="horizontalLayout_5" stretch="0,0,0,0">
       <item>
        <widget class="QCheckBox" name="roadDirt">
+        <property name="minimumSize">
+         <size>
+          <width>90</width>
+          <height>0</height>
+         </size>
+        </property>
         <property name="text">
          <string>Dirt</string>
         </property>
        </widget>
       </item>
       <item>
-       <spacer name="horizontalSpacer_4">
-        <property name="orientation">
-         <enum>Qt::Orientation::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
+       <widget class="QCheckBox" name="roadGravel">
+        <property name="minimumSize">
          <size>
-          <width>40</width>
-          <height>20</height>
+          <width>90</width>
+          <height>0</height>
          </size>
         </property>
-       </spacer>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="roadGravel">
         <property name="text">
          <string>Gravel</string>
         </property>
        </widget>
       </item>
       <item>
-       <spacer name="horizontalSpacer_6">
-        <property name="orientation">
-         <enum>Qt::Orientation::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
+       <widget class="QCheckBox" name="roadCobblestone">
+        <property name="minimumSize">
          <size>
-          <width>40</width>
-          <height>20</height>
+          <width>90</width>
+          <height>0</height>
          </size>
         </property>
-       </spacer>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="roadCobblestone">
         <property name="text">
          <string>Cobblestone</string>
         </property>
        </widget>
       </item>
       <item>
-       <spacer name="horizontalSpacer_3">
+       <spacer name="horizontalSpacer">
         <property name="orientation">
          <enum>Qt::Orientation::Horizontal</enum>
         </property>
+        <property name="sizeType">
+         <enum>QSizePolicy::Policy::Fixed</enum>
+        </property>
         <property name="sizeHint" stdset="0">
          <size>
-          <width>40</width>
+          <width>100</width>
           <height>20</height>
          </size>
         </property>
@@ -935,7 +895,7 @@
         </property>
         <property name="minimumSize">
          <size>
-          <width>96</width>
+          <width>90</width>
           <height>0</height>
          </size>
         </property>
@@ -971,6 +931,12 @@
       </item>
       <item row="1" column="0">
        <widget class="QCheckBox" name="checkSeed">
+        <property name="minimumSize">
+         <size>
+          <width>90</width>
+          <height>0</height>
+         </size>
+        </property>
         <property name="text">
          <string>Custom seed</string>
         </property>

--- a/mapeditor/windownewmap.ui
+++ b/mapeditor/windownewmap.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>444</width>
-    <height>506</height>
+    <width>460</width>
+    <height>573</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -39,230 +39,255 @@
     <rect>
      <x>10</x>
      <y>10</y>
-     <width>301</width>
-     <height>91</height>
+     <width>441</width>
+     <height>121</height>
     </rect>
    </property>
    <property name="title">
     <string>Map size</string>
    </property>
-   <widget class="QWidget" name="layoutWidget1">
+   <widget class="QGroupBox" name="sizeGroup1">
     <property name="geometry">
      <rect>
-      <x>0</x>
-      <y>10</y>
-      <width>301</width>
-      <height>73</height>
+      <x>10</x>
+      <y>40</y>
+      <width>211</width>
+      <height>40</height>
      </rect>
     </property>
-    <layout class="QGridLayout" name="gridLayout_2" columnstretch="3,0,1,0">
-     <item row="0" column="1">
-      <widget class="QLabel" name="label">
-       <property name="minimumSize">
-        <size>
-         <width>48</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>96</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <property name="text">
-        <string>Width</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="1">
-      <widget class="QLabel" name="label_2">
-       <property name="text">
-        <string>Height</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="2">
-      <widget class="QLineEdit" name="widthTxt">
-       <property name="maximumSize">
-        <size>
-         <width>64</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <property name="inputMethodHints">
-        <set>Qt::InputMethodHint::ImhDigitsOnly</set>
-       </property>
-       <property name="text">
-        <string notr="true">36</string>
-       </property>
-       <property name="maxLength">
-        <number>3</number>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="2">
-      <widget class="QLineEdit" name="heightTxt">
-       <property name="maximumSize">
-        <size>
-         <width>64</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <property name="inputMethodHints">
-        <set>Qt::InputMethodHint::ImhDigitsOnly</set>
-       </property>
-       <property name="text">
-        <string notr="true">36</string>
-       </property>
-       <property name="maxLength">
-        <number>3</number>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="0">
-      <layout class="QHBoxLayout" name="horizontalLayout_4">
-       <item>
-        <spacer name="horizontalSpacer_5">
-         <property name="orientation">
-          <enum>Qt::Orientation::Horizontal</enum>
-         </property>
-         <property name="sizeType">
-          <enum>QSizePolicy::Policy::Fixed</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>8</width>
-           <height>20</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item>
-        <widget class="QComboBox" name="sizeCombo">
-         <property name="minimumSize">
-          <size>
-           <width>96</width>
-           <height>0</height>
-          </size>
-         </property>
-         <property name="maximumSize">
-          <size>
-           <width>144</width>
-           <height>16777215</height>
-          </size>
-         </property>
-         <item>
-          <property name="text">
-           <string>S  (36x36)</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>M  (72x72)</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>L  (108x108)</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>XL (144x144)</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>H  (180x180)</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>XH (216x216)</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>G  (252x252)</string>
-          </property>
-         </item>
-        </widget>
-       </item>
-      </layout>
-     </item>
-     <item row="1" column="0">
-      <layout class="QHBoxLayout" name="horizontalLayout_7">
-       <item>
-        <spacer name="horizontalSpacer_7">
-         <property name="orientation">
-          <enum>Qt::Orientation::Horizontal</enum>
-         </property>
-         <property name="sizeType">
-          <enum>QSizePolicy::Policy::Fixed</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>8</width>
-           <height>20</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item>
-        <widget class="QCheckBox" name="twoLevelCheck">
-         <property name="minimumSize">
-          <size>
-           <width>96</width>
-           <height>0</height>
-          </size>
-         </property>
+    <property name="title">
+     <string/>
+    </property>
+    <property name="flat">
+     <bool>false</bool>
+    </property>
+    <property name="checkable">
+     <bool>false</bool>
+    </property>
+    <widget class="QWidget" name="layoutWidget">
+     <property name="geometry">
+      <rect>
+       <x>10</x>
+       <y>10</y>
+       <width>191</width>
+       <height>24</height>
+      </rect>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout_6">
+      <item>
+       <widget class="QComboBox" name="sizeCombo">
+        <property name="minimumSize">
+         <size>
+          <width>120</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>200</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <item>
          <property name="text">
-          <string>Two level map</string>
+          <string>S  (36x36)</string>
          </property>
-        </widget>
-       </item>
-      </layout>
-     </item>
-     <item row="1" column="3">
-      <spacer name="horizontalSpacer_11">
-       <property name="orientation">
-        <enum>Qt::Orientation::Horizontal</enum>
-       </property>
-       <property name="sizeType">
-        <enum>QSizePolicy::Policy::Fixed</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
+        </item>
+        <item>
+         <property name="text">
+          <string>M  (72x72)</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>L  (108x108)</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>XL (144x144)</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>H  (180x180)</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>XH (216x216)</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>G  (252x252)</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </widget>
+   <widget class="QGroupBox" name="sizeGroup2">
+    <property name="geometry">
+     <rect>
+      <x>220</x>
+      <y>40</y>
+      <width>211</width>
+      <height>40</height>
+     </rect>
+    </property>
+    <property name="title">
+     <string/>
+    </property>
+    <property name="flat">
+     <bool>false</bool>
+    </property>
+    <property name="checkable">
+     <bool>false</bool>
+    </property>
+    <widget class="QWidget" name="layoutWidget_2">
+     <property name="geometry">
+      <rect>
+       <x>10</x>
+       <y>10</y>
+       <width>194</width>
+       <height>24</height>
+      </rect>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout_7">
+      <item>
+       <widget class="QLabel" name="label">
+        <property name="minimumSize">
+         <size>
+          <width>48</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>96</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>Width</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QSpinBox" name="widthTxt">
+        <property name="maximum">
+         <number>999</number>
+        </property>
+        <property name="value">
+         <number>0</number>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="label_2">
+        <property name="minimumSize">
+         <size>
+          <width>48</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>Height</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QSpinBox" name="heightTxt">
+        <property name="maximum">
+         <number>999</number>
+        </property>
+        <property name="value">
+         <number>0</number>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </widget>
+   <widget class="QWidget" name="horizontalLayoutWidget">
+    <property name="geometry">
+     <rect>
+      <x>10</x>
+      <y>20</y>
+      <width>211</width>
+      <height>22</height>
+     </rect>
+    </property>
+    <layout class="QHBoxLayout" name="horizontalLayout_11">
+     <item>
+      <widget class="QRadioButton" name="mapOpt1">
+       <property name="maximumSize">
         <size>
-         <width>8</width>
-         <height>20</height>
+         <width>16777215</width>
+         <height>16777215</height>
         </size>
        </property>
-      </spacer>
-     </item>
-     <item row="0" column="3">
-      <spacer name="horizontalSpacer_12">
-       <property name="orientation">
-        <enum>Qt::Orientation::Horizontal</enum>
+       <property name="text">
+        <string>Standard size</string>
        </property>
-       <property name="sizeType">
-        <enum>QSizePolicy::Policy::Fixed</enum>
+       <property name="checked">
+        <bool>true</bool>
        </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>8</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
+       <attribute name="buttonGroup">
+        <string notr="true">buttonGroup</string>
+       </attribute>
+      </widget>
      </item>
     </layout>
+   </widget>
+   <widget class="QWidget" name="horizontalLayoutWidget_2">
+    <property name="geometry">
+     <rect>
+      <x>220</x>
+      <y>20</y>
+      <width>211</width>
+      <height>22</height>
+     </rect>
+    </property>
+    <layout class="QHBoxLayout" name="horizontalLayout_12">
+     <item>
+      <widget class="QRadioButton" name="mapOpt2">
+       <property name="text">
+        <string>Custom size</string>
+       </property>
+       <attribute name="buttonGroup">
+        <string notr="true">buttonGroup</string>
+       </attribute>
+      </widget>
+     </item>
+    </layout>
+   </widget>
+   <widget class="QCheckBox" name="twoLevelCheck">
+    <property name="geometry">
+     <rect>
+      <x>10</x>
+      <y>90</y>
+      <width>277</width>
+      <height>20</height>
+     </rect>
+    </property>
+    <property name="minimumSize">
+     <size>
+      <width>96</width>
+      <height>0</height>
+     </size>
+    </property>
+    <property name="text">
+     <string>Underground</string>
+    </property>
    </widget>
   </widget>
   <widget class="QGroupBox" name="randomOptions">
@@ -272,8 +297,8 @@
    <property name="geometry">
     <rect>
      <x>10</x>
-     <y>140</y>
-     <width>431</width>
+     <y>170</y>
+     <width>441</width>
      <height>361</height>
     </rect>
    </property>
@@ -291,7 +316,7 @@
      <rect>
       <x>10</x>
       <y>110</y>
-      <width>411</width>
+      <width>421</width>
       <height>91</height>
      </rect>
     </property>
@@ -303,67 +328,11 @@
       <rect>
        <x>10</x>
        <y>20</y>
-       <width>391</width>
+       <width>401</width>
        <height>61</height>
       </rect>
      </property>
      <layout class="QGridLayout" name="gridLayout" columnstretch="0,0,0,0">
-      <item row="1" column="1">
-       <widget class="QComboBox" name="cpuCombo">
-        <item>
-         <property name="text">
-          <string>Random</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string notr="true">0</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string notr="true">1</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string notr="true">2</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string notr="true">3</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string notr="true">4</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string notr="true">5</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string notr="true">6</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string notr="true">7</string>
-         </property>
-        </item>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_4">
-        <property name="text">
-         <string>Computer only</string>
-        </property>
-       </widget>
-      </item>
       <item row="0" column="1">
        <widget class="QComboBox" name="humanCombo">
         <property name="minimumSize">
@@ -444,7 +413,39 @@
         </property>
        </widget>
       </item>
-      <item row="0" column="3">
+      <item row="1" column="3">
+       <widget class="QComboBox" name="cpuTeamsCombo">
+        <property name="currentText">
+         <string notr="true">0</string>
+        </property>
+        <item>
+         <property name="text">
+          <string notr="true">0</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+      <item row="1" column="2">
+       <widget class="QLabel" name="label_7">
+        <property name="text">
+         <string>Computer teams</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_6">
+        <property name="minimumSize">
+         <size>
+          <width>90</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>Human teams</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
        <widget class="QComboBox" name="humanTeamsCombo">
         <property name="minimumSize">
          <size>
@@ -469,35 +470,59 @@
        </widget>
       </item>
       <item row="0" column="2">
-       <widget class="QLabel" name="label_6">
-        <property name="minimumSize">
-         <size>
-          <width>90</width>
-          <height>0</height>
-         </size>
-        </property>
+       <widget class="QLabel" name="label_4">
         <property name="text">
-         <string>Human teams</string>
+         <string>Computer only</string>
         </property>
        </widget>
       </item>
-      <item row="1" column="3">
-       <widget class="QComboBox" name="cpuTeamsCombo">
-        <property name="currentText">
-         <string notr="true">0</string>
-        </property>
+      <item row="0" column="3">
+       <widget class="QComboBox" name="cpuCombo">
+        <item>
+         <property name="text">
+          <string>Random</string>
+         </property>
+        </item>
         <item>
          <property name="text">
           <string notr="true">0</string>
          </property>
         </item>
-       </widget>
-      </item>
-      <item row="1" column="2">
-       <widget class="QLabel" name="label_7">
-        <property name="text">
-         <string>Computer teams</string>
-        </property>
+        <item>
+         <property name="text">
+          <string notr="true">1</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string notr="true">2</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string notr="true">3</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string notr="true">4</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string notr="true">5</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string notr="true">6</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string notr="true">7</string>
+         </property>
+        </item>
        </widget>
       </item>
      </layout>
@@ -508,7 +533,7 @@
      <rect>
       <x>10</x>
       <y>250</y>
-      <width>411</width>
+      <width>421</width>
       <height>51</height>
      </rect>
     </property>
@@ -520,7 +545,7 @@
       <rect>
        <x>10</x>
        <y>20</y>
-       <width>391</width>
+       <width>401</width>
        <height>26</height>
       </rect>
      </property>
@@ -636,7 +661,7 @@
      <rect>
       <x>10</x>
       <y>200</y>
-      <width>411</width>
+      <width>421</width>
       <height>51</height>
      </rect>
     </property>
@@ -660,7 +685,7 @@
       <rect>
        <x>10</x>
        <y>20</y>
-       <width>391</width>
+       <width>401</width>
        <height>26</height>
       </rect>
      </property>
@@ -776,7 +801,7 @@
      <rect>
       <x>10</x>
       <y>300</y>
-      <width>411</width>
+      <width>421</width>
       <height>51</height>
      </rect>
     </property>
@@ -800,7 +825,7 @@
       <rect>
        <x>10</x>
        <y>20</y>
-       <width>391</width>
+       <width>401</width>
        <height>26</height>
       </rect>
      </property>
@@ -868,7 +893,7 @@
      <rect>
       <x>10</x>
       <y>20</y>
-      <width>411</width>
+      <width>421</width>
       <height>91</height>
      </rect>
     </property>
@@ -880,22 +905,16 @@
       <rect>
        <x>10</x>
        <y>20</y>
-       <width>391</width>
+       <width>401</width>
        <height>61</height>
       </rect>
      </property>
      <layout class="QGridLayout" name="gridLayout_3" columnstretch="0,0">
       <item row="0" column="0">
        <widget class="QLabel" name="label_5">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
         <property name="minimumSize">
          <size>
-          <width>90</width>
+          <width>100</width>
           <height>0</height>
          </size>
         </property>
@@ -937,33 +956,27 @@
           <height>0</height>
          </size>
         </property>
+        <property name="maximumSize">
+         <size>
+          <width>120</width>
+          <height>16777215</height>
+         </size>
+        </property>
         <property name="text">
          <string>Custom seed</string>
         </property>
        </widget>
       </item>
       <item row="1" column="1">
-       <widget class="QLineEdit" name="lineSeed">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
+       <widget class="QSpinBox" name="lineSeed">
         <property name="maximumSize">
          <size>
-          <width>64</width>
-          <height>16777215</height>
+          <width>39</width>
+          <height>22</height>
          </size>
         </property>
-        <property name="inputMethodHints">
-         <set>Qt::InputMethodHint::ImhDigitsOnly</set>
-        </property>
-        <property name="text">
-         <string>0</string>
+        <property name="maximum">
+         <number>999</number>
         </property>
        </widget>
       </item>
@@ -975,8 +988,8 @@
    <property name="geometry">
     <rect>
      <x>10</x>
-     <y>110</y>
-     <width>421</width>
+     <y>140</y>
+     <width>441</width>
      <height>20</height>
     </rect>
    </property>
@@ -987,13 +1000,13 @@
   <widget class="QWidget" name="layoutWidget6">
    <property name="geometry">
     <rect>
-     <x>320</x>
-     <y>20</y>
-     <width>111</width>
-     <height>71</height>
+     <x>250</x>
+     <y>540</y>
+     <width>201</width>
+     <height>26</height>
     </rect>
    </property>
-   <layout class="QVBoxLayout" name="verticalLayout">
+   <layout class="QHBoxLayout" name="horizontalLayout_3">
     <item>
      <widget class="QPushButton" name="okButton">
       <property name="sizePolicy">
@@ -1037,4 +1050,7 @@
  </widget>
  <resources/>
  <connections/>
+ <buttongroups>
+  <buttongroup name="buttonGroup"/>
+ </buttongroups>
 </ui>

--- a/mapeditor/windownewmap.ui
+++ b/mapeditor/windownewmap.ui
@@ -40,7 +40,7 @@
      <x>10</x>
      <y>10</y>
      <width>301</width>
-     <height>101</height>
+     <height>91</height>
     </rect>
    </property>
    <property name="title">
@@ -50,7 +50,7 @@
     <property name="geometry">
      <rect>
       <x>0</x>
-      <y>20</y>
+      <y>10</y>
       <width>301</width>
       <height>73</height>
      </rect>
@@ -217,6 +217,12 @@
        </item>
        <item>
         <widget class="QCheckBox" name="twoLevelCheck">
+         <property name="minimumSize">
+          <size>
+           <width>96</width>
+           <height>0</height>
+          </size>
+         </property>
          <property name="text">
           <string>Two level map</string>
          </property>
@@ -266,9 +272,9 @@
    <property name="geometry">
     <rect>
      <x>10</x>
-     <y>150</y>
+     <y>140</y>
      <width>431</width>
-     <height>351</height>
+     <height>361</height>
     </rect>
    </property>
    <property name="sizePolicy">
@@ -284,7 +290,7 @@
     <property name="geometry">
      <rect>
       <x>10</x>
-      <y>60</y>
+      <y>110</y>
       <width>411</width>
       <height>91</height>
      </rect>
@@ -298,7 +304,7 @@
        <x>10</x>
        <y>20</y>
        <width>391</width>
-       <height>72</height>
+       <height>61</height>
       </rect>
      </property>
      <layout class="QGridLayout" name="gridLayout" columnstretch="0,0,0,0">
@@ -495,7 +501,7 @@
     <property name="geometry">
      <rect>
       <x>10</x>
-      <y>210</y>
+      <y>250</y>
       <width>411</width>
       <height>51</height>
      </rect>
@@ -506,9 +512,9 @@
     <widget class="QWidget" name="layoutWidget3">
      <property name="geometry">
       <rect>
-       <x>0</x>
+       <x>10</x>
        <y>20</y>
-       <width>411</width>
+       <width>391</width>
        <height>26</height>
       </rect>
      </property>
@@ -649,7 +655,7 @@
     <property name="geometry">
      <rect>
       <x>10</x>
-      <y>160</y>
+      <y>200</y>
       <width>411</width>
       <height>51</height>
      </rect>
@@ -672,9 +678,9 @@
     <widget class="QWidget" name="layoutWidget4">
      <property name="geometry">
       <rect>
-       <x>0</x>
+       <x>10</x>
        <y>20</y>
-       <width>411</width>
+       <width>391</width>
        <height>26</height>
       </rect>
      </property>
@@ -791,7 +797,7 @@
     <property name="geometry">
      <rect>
       <x>10</x>
-      <y>260</y>
+      <y>300</y>
       <width>411</width>
       <height>51</height>
      </rect>
@@ -814,9 +820,9 @@
     <widget class="QWidget" name="layoutWidget4_2">
      <property name="geometry">
       <rect>
-       <x>0</x>
+       <x>10</x>
        <y>20</y>
-       <width>411</width>
+       <width>391</width>
        <height>26</height>
       </rect>
      </property>
@@ -897,88 +903,113 @@
      </layout>
     </widget>
    </widget>
-   <widget class="QWidget" name="layoutWidget">
-    <property name="geometry">
-     <rect>
-      <x>10</x>
-      <y>310</y>
-      <width>171</width>
-      <height>31</height>
-     </rect>
-    </property>
-    <layout class="QHBoxLayout" name="horizontalLayout_6">
-     <item>
-      <widget class="QCheckBox" name="checkSeed">
-       <property name="text">
-        <string>Custom seed</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLineEdit" name="lineSeed">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="inputMethodHints">
-        <set>Qt::InputMethodHint::ImhDigitsOnly</set>
-       </property>
-       <property name="text">
-        <string>0</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </widget>
-   <widget class="QWidget" name="layoutWidget5">
+   <widget class="QGroupBox" name="groupBox_5">
     <property name="geometry">
      <rect>
       <x>10</x>
       <y>20</y>
       <width>411</width>
-      <height>34</height>
+      <height>91</height>
      </rect>
     </property>
-    <layout class="QHBoxLayout" name="horizontalLayout_3">
-     <item>
-      <widget class="QLabel" name="label_5">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>120</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <property name="text">
-        <string>Template</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QComboBox" name="templateCombo">
-       <property name="enabled">
-        <bool>true</bool>
-       </property>
-       <property name="currentText">
-        <string notr="true"/>
-       </property>
-       <property name="currentIndex">
-        <number>-1</number>
-       </property>
-      </widget>
-     </item>
-    </layout>
+    <property name="title">
+     <string>Template</string>
+    </property>
+    <widget class="QWidget" name="layoutWidget2_2">
+     <property name="geometry">
+      <rect>
+       <x>10</x>
+       <y>20</y>
+       <width>391</width>
+       <height>61</height>
+      </rect>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_3" columnstretch="0,0">
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_5">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>96</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>120</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>Template</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QComboBox" name="templateCombo">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="currentText">
+         <string notr="true"/>
+        </property>
+        <property name="currentIndex">
+         <number>-1</number>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QCheckBox" name="checkSeed">
+        <property name="text">
+         <string>Custom seed</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QLineEdit" name="lineSeed">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>64</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="inputMethodHints">
+         <set>Qt::InputMethodHint::ImhDigitsOnly</set>
+        </property>
+        <property name="text">
+         <string>0</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
    </widget>
   </widget>
   <widget class="QCheckBox" name="randomMapCheck">
    <property name="geometry">
     <rect>
      <x>10</x>
-     <y>120</y>
+     <y>110</y>
      <width>421</width>
      <height>20</height>
     </rect>
@@ -991,7 +1022,7 @@
    <property name="geometry">
     <rect>
      <x>320</x>
-     <y>30</y>
+     <y>20</y>
      <width>111</width>
      <height>71</height>
     </rect>

--- a/mapeditor/windownewmap.ui
+++ b/mapeditor/windownewmap.ui
@@ -38,9 +38,9 @@
    <property name="geometry">
     <rect>
      <x>10</x>
-     <y>20</y>
+     <y>10</y>
      <width>291</width>
-     <height>91</height>
+     <height>101</height>
     </rect>
    </property>
    <property name="title">
@@ -56,13 +56,6 @@
      </rect>
     </property>
     <layout class="QGridLayout" name="gridLayout_2" columnstretch="3,0,1">
-     <item row="1" column="0">
-      <widget class="QCheckBox" name="twoLevelCheck">
-       <property name="text">
-        <string>Two level map</string>
-       </property>
-      </widget>
-     </item>
      <item row="0" column="2">
       <widget class="QLineEdit" name="widthTxt">
        <property name="maximumSize">
@@ -198,16 +191,46 @@
        </item>
       </layout>
      </item>
+     <item row="1" column="0">
+      <layout class="QHBoxLayout" name="horizontalLayout_7">
+       <item>
+        <spacer name="horizontalSpacer_7">
+         <property name="orientation">
+          <enum>Qt::Orientation::Horizontal</enum>
+         </property>
+         <property name="sizeType">
+          <enum>QSizePolicy::Policy::Fixed</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>8</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="twoLevelCheck">
+         <property name="text">
+          <string>Two level map</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
     </layout>
    </widget>
   </widget>
-  <widget class="QGroupBox" name="groupBox_5">
+  <widget class="QGroupBox" name="randomOptions">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
    <property name="geometry">
     <rect>
      <x>10</x>
-     <y>140</y>
+     <y>150</y>
      <width>431</width>
-     <height>361</height>
+     <height>351</height>
     </rect>
    </property>
    <property name="sizePolicy">
@@ -223,7 +246,7 @@
     <property name="geometry">
      <rect>
       <x>10</x>
-      <y>20</y>
+      <y>60</y>
       <width>411</width>
       <height>91</height>
      </rect>
@@ -434,7 +457,7 @@
     <property name="geometry">
      <rect>
       <x>10</x>
-      <y>170</y>
+      <y>210</y>
       <width>411</width>
       <height>51</height>
      </rect>
@@ -451,7 +474,32 @@
        <height>26</height>
       </rect>
      </property>
-     <layout class="QHBoxLayout" name="horizontalLayout" stretch="1,1,1,1,1">
+     <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,1,1,1,1,1">
+      <item>
+       <spacer name="horizontalSpacer_9">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>16777215</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="orientation">
+         <enum>Qt::Orientation::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
       <item>
        <widget class="QRadioButton" name="monsterOpt1">
         <property name="sizePolicy">
@@ -563,7 +611,7 @@
     <property name="geometry">
      <rect>
       <x>10</x>
-      <y>120</y>
+      <y>160</y>
       <width>411</width>
       <height>51</height>
      </rect>
@@ -592,7 +640,20 @@
        <height>26</height>
       </rect>
      </property>
-     <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="1,1,1,1,1">
+     <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="0,1,1,1,1,1">
+      <item>
+       <spacer name="horizontalSpacer_8">
+        <property name="orientation">
+         <enum>Qt::Orientation::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
       <item>
        <widget class="QRadioButton" name="waterOpt1">
         <property name="sizePolicy">
@@ -692,7 +753,7 @@
     <property name="geometry">
      <rect>
       <x>10</x>
-      <y>230</y>
+      <y>260</y>
       <width>411</width>
       <height>51</height>
      </rect>
@@ -721,7 +782,20 @@
        <height>26</height>
       </rect>
      </property>
-     <layout class="QHBoxLayout" name="horizontalLayout_5" stretch="0,0,0,0,0,1">
+     <layout class="QHBoxLayout" name="horizontalLayout_5" stretch="0,0,0,0,0,0,1">
+      <item>
+       <spacer name="horizontalSpacer_10">
+        <property name="orientation">
+         <enum>Qt::Orientation::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
       <item>
        <widget class="QCheckBox" name="roadDirt">
         <property name="text">
@@ -785,11 +859,43 @@
      </layout>
     </widget>
    </widget>
+   <widget class="QWidget" name="layoutWidget">
+    <property name="geometry">
+     <rect>
+      <x>10</x>
+      <y>310</y>
+      <width>171</width>
+      <height>31</height>
+     </rect>
+    </property>
+    <layout class="QHBoxLayout" name="horizontalLayout_6">
+     <item>
+      <widget class="QCheckBox" name="checkSeed">
+       <property name="text">
+        <string>Custom seed</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="lineSeed">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="inputMethodHints">
+        <set>Qt::InputMethodHint::ImhDigitsOnly</set>
+       </property>
+       <property name="text">
+        <string>0</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </widget>
    <widget class="QWidget" name="layoutWidget5">
     <property name="geometry">
      <rect>
       <x>10</x>
-      <y>280</y>
+      <y>20</y>
       <width>411</width>
       <height>34</height>
      </rect>
@@ -829,38 +935,6 @@
      </item>
     </layout>
    </widget>
-   <widget class="QWidget" name="layoutWidget">
-    <property name="geometry">
-     <rect>
-      <x>80</x>
-      <y>320</y>
-      <width>283</width>
-      <height>33</height>
-     </rect>
-    </property>
-    <layout class="QHBoxLayout" name="horizontalLayout_6">
-     <item>
-      <widget class="QCheckBox" name="checkSeed">
-       <property name="text">
-        <string>Custom seed</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLineEdit" name="lineSeed">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="inputMethodHints">
-        <set>Qt::InputMethodHint::ImhDigitsOnly</set>
-       </property>
-       <property name="text">
-        <string>0</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </widget>
   </widget>
   <widget class="QCheckBox" name="randomMapCheck">
    <property name="geometry">
@@ -878,10 +952,10 @@
   <widget class="QWidget" name="layoutWidget6">
    <property name="geometry">
     <rect>
-     <x>310</x>
+     <x>320</x>
      <y>20</y>
      <width>111</width>
-     <height>101</height>
+     <height>91</height>
     </rect>
    </property>
    <layout class="QVBoxLayout" name="verticalLayout">

--- a/mapeditor/windownewmap.ui
+++ b/mapeditor/windownewmap.ui
@@ -228,7 +228,7 @@
     </property>
     <layout class="QHBoxLayout" name="horizontalLayout_11">
      <item>
-      <widget class="QRadioButton" name="mapOpt1">
+      <widget class="QRadioButton" name="sizeStandardRadio">
        <property name="maximumSize">
         <size>
          <width>16777215</width>
@@ -259,7 +259,7 @@
     </property>
     <layout class="QHBoxLayout" name="horizontalLayout_12">
      <item>
-      <widget class="QRadioButton" name="mapOpt2">
+      <widget class="QRadioButton" name="sizeCustomRadio">
        <property name="text">
         <string>Custom size</string>
        </property>

--- a/mapeditor/windownewmap.ui
+++ b/mapeditor/windownewmap.ui
@@ -409,7 +409,7 @@
          </size>
         </property>
         <property name="text">
-         <string>Human/Computer</string>
+         <string>Humans</string>
         </property>
        </widget>
       </item>
@@ -472,7 +472,7 @@
       <item row="0" column="2">
        <widget class="QLabel" name="label_4">
         <property name="text">
-         <string>Computer only</string>
+         <string>Computers</string>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
This PR was for just rearrange, but it involved into review of whole dialog.

1) Redesigned
2) Added ability to choose between Standard size vs Custom size
3) Replaced lineEdits with spinBoxes
4) Fixed disabling of whole Random map group instead of checkbox only
5) Fixed Humans vs Computer dropdown selection. Now selecting 8 Humans correctly set 0 Computers when more than 0 Computer were selected before changing Humans to 8
6) Removed help button in all dialogs accross map editor
7) Hide "Create new map" dialog when generating map using template starts
8) Changed texts to make it clear
     "Two level map"        -> "Underground"
     "Human/Computer"  -> "Humans"
     "Computer only"       -> "Computers"

From this
![image](https://github.com/user-attachments/assets/59bd0333-4a69-4fa8-8f43-168549c294a7)

To this:
![image](https://github.com/user-attachments/assets/1f7175bd-4137-4cee-b8f7-d3d6c95b510b)
![image](https://github.com/user-attachments/assets/af757d3d-29cd-4dab-967a-93026032da67)






