### PR TITLE
map editor: show edited values in inspector

### DIFF
--- a/mapeditor/CMakeLists.txt
+++ b/mapeditor/CMakeLists.txt
@@ -84,6 +84,7 @@ set(editor_HEADERS
 		inspector/herospellwidget.h
 		inspector/PickObjectDelegate.h
 		inspector/portraitwidget.h
+		inspector/baseinspectoritemdelegate.h
 		resourceExtractor/ResourceConverter.h
 		mapeditorroles.h
 )

--- a/mapeditor/inspector/PickObjectDelegate.h
+++ b/mapeditor/inspector/PickObjectDelegate.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include <QItemDelegate>
+#include "baseinspectoritemdelegate.h"
 
 class MapController;
 
@@ -20,7 +21,7 @@ class CGObjectInstance;
 
 VCMI_LIB_NAMESPACE_END
 
-class PickObjectDelegate : public QItemDelegate
+class PickObjectDelegate : public BaseInspectorItemDelegate
 {
 	Q_OBJECT
 public:

--- a/mapeditor/inspector/armywidget.cpp
+++ b/mapeditor/inspector/armywidget.cpp
@@ -158,9 +158,5 @@ void ArmyDelegate::updateModelData(QAbstractItemModel * model, const QModelIndex
 			textList += QString("%1 %2").arg(stack->count).arg(QString::fromStdString(stack->getCreature()->getNamePluralTranslated()));
 	}
 
-	QString text = textList.join("\n");
-	model->setItemData(index, {
-		{Qt::DisplayRole, QVariant{text}},
-		{Qt::ToolTipRole, QVariant{text}}
-	});
+	setModelTextData(model, index, textList);
 }

--- a/mapeditor/inspector/armywidget.cpp
+++ b/mapeditor/inspector/armywidget.cpp
@@ -115,7 +115,7 @@ ArmyWidget::~ArmyWidget()
 
 
 
-ArmyDelegate::ArmyDelegate(CArmedInstance & t): army(t), QStyledItemDelegate()
+ArmyDelegate::ArmyDelegate(CArmedInstance & t): army(t), BaseInspectorItemDelegate()
 {
 }
 
@@ -141,9 +141,27 @@ void ArmyDelegate::setModelData(QWidget *editor, QAbstractItemModel *model, cons
 	if(auto * ed = qobject_cast<ArmyWidget *>(editor))
 	{
 		ed->commitChanges();
+		updateModelData(model, index);
 	}
 	else
 	{
 		QStyledItemDelegate::setModelData(editor, model, index);
 	}
+}
+
+void ArmyDelegate::updateModelData(QAbstractItemModel * model, const QModelIndex & index) const
+{
+	QStringList textList;
+	for(auto i = army.stacks.begin(); i != army.stacks.end(); i++)
+	{
+		auto stack = i->second;
+		if(stack->count != 0 && stack->getCreature() != nullptr)
+			textList += QString::number(stack->count) + " " + QString::fromStdString(stack->getCreature()->getNamePluralTranslated());
+	}
+
+	QString text = textList.join("\n");
+	QMap<int, QVariant> data;
+	data[Qt::DisplayRole] = QVariant(text);
+	data[Qt::ToolTipRole] = QVariant(text);
+	model->setItemData(index, data);
 }

--- a/mapeditor/inspector/armywidget.cpp
+++ b/mapeditor/inspector/armywidget.cpp
@@ -152,16 +152,15 @@ void ArmyDelegate::setModelData(QWidget *editor, QAbstractItemModel *model, cons
 void ArmyDelegate::updateModelData(QAbstractItemModel * model, const QModelIndex & index) const
 {
 	QStringList textList;
-	for(auto i = army.stacks.begin(); i != army.stacks.end(); i++)
+	for(const auto & [_, stack] : army.stacks)
 	{
-		auto stack = i->second;
 		if(stack->count != 0 && stack->getCreature() != nullptr)
-			textList += QString::number(stack->count) + " " + QString::fromStdString(stack->getCreature()->getNamePluralTranslated());
+			textList += QString("%1 %2").arg(stack->count).arg(QString::fromStdString(stack->getCreature()->getNamePluralTranslated()));
 	}
 
 	QString text = textList.join("\n");
-	QMap<int, QVariant> data;
-	data[Qt::DisplayRole] = QVariant(text);
-	data[Qt::ToolTipRole] = QVariant(text);
-	model->setItemData(index, data);
+	model->setItemData(index, {
+		{Qt::DisplayRole, QVariant{text}},
+		{Qt::ToolTipRole, QVariant{text}}
+	});
 }

--- a/mapeditor/inspector/armywidget.h
+++ b/mapeditor/inspector/armywidget.h
@@ -11,6 +11,7 @@
 
 #include "../StdInc.h"
 #include <QDialog>
+#include "baseinspectoritemdelegate.h"
 #include "../lib/mapObjects/CArmedInstance.h"
 
 const int TOTAL_SLOTS = 7;
@@ -39,17 +40,18 @@ private:
 	std::array<QComboBox*, TOTAL_SLOTS> uiSlots;
 };
 
-class ArmyDelegate : public QStyledItemDelegate
+class ArmyDelegate : public BaseInspectorItemDelegate
 {
 	Q_OBJECT
 public:
-	using QStyledItemDelegate::QStyledItemDelegate;
+	using BaseInspectorItemDelegate::BaseInspectorItemDelegate;
 	
 	ArmyDelegate(CArmedInstance &);
 	
 	QWidget * createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
 	void setEditorData(QWidget *editor, const QModelIndex &index) const override;
 	void setModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const override;
+	void updateModelData(QAbstractItemModel * model, const QModelIndex & index) const override;
 	
 private:
 	CArmedInstance & army;

--- a/mapeditor/inspector/baseinspectoritemdelegate.h
+++ b/mapeditor/inspector/baseinspectoritemdelegate.h
@@ -1,0 +1,22 @@
+/*
+ * baseinspectoritemdelegate.h, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
+#pragma once
+
+#include <QStyledItemDelegate>
+#include <QAbstractItemModel>
+
+class BaseInspectorItemDelegate : public QStyledItemDelegate
+{
+    Q_OBJECT
+public:
+    using QStyledItemDelegate::QStyledItemDelegate;
+
+    virtual void updateModelData(QAbstractItemModel * model, const QModelIndex & index) const {};
+};

--- a/mapeditor/inspector/baseinspectoritemdelegate.h
+++ b/mapeditor/inspector/baseinspectoritemdelegate.h
@@ -19,4 +19,12 @@ public:
     using QStyledItemDelegate::QStyledItemDelegate;
 
     virtual void updateModelData(QAbstractItemModel * model, const QModelIndex & index) const {};
+    void setModelTextData(QAbstractItemModel * model, const QModelIndex & index, const QStringList & list) const
+    {
+        QString text = list.join("\n");
+        model->setItemData(index, {
+            {Qt::DisplayRole, QVariant{text}},
+            {Qt::ToolTipRole, QVariant{text}}
+        });
+    };
 };

--- a/mapeditor/inspector/heroartifactswidget.cpp
+++ b/mapeditor/inspector/heroartifactswidget.cpp
@@ -150,16 +150,16 @@ void HeroArtifactsDelegate::updateModelData(QAbstractItemModel * model, const QM
 	for(const auto & [artPosition, artSlotInfo] : hero.artifactsWorn)
 	{
 		auto slotText = NArtifactPosition::namesHero[artPosition.num];
-		textList += QString::fromStdString(slotText) + ": " + QString::fromStdString(artSlotInfo.artifact->getType()->getNameTranslated());
+		textList += QString("%1: %2").arg(QString::fromStdString(slotText)).arg(QString::fromStdString(artSlotInfo.artifact->getType()->getNameTranslated()));
 	}
-	textList += QString::fromStdString(NArtifactPosition::backpack) + ":";
+	textList += QString("%1:").arg(QString::fromStdString(NArtifactPosition::backpack));
 	for(const auto & art : hero.artifactsInBackpack)
 	{
 		textList += QString::fromStdString(art.artifact->getType()->getNameTranslated());
 	}
 	QString text = textList.join("\n");
-	QMap<int, QVariant> data;
-	data[Qt::DisplayRole] = QVariant(text);
-	data[Qt::ToolTipRole] = QVariant(text);
-	model->setItemData(index, data);
+	model->setItemData(index, {
+		{Qt::DisplayRole, QVariant{text}},
+		{Qt::ToolTipRole, QVariant{text}}
+	});
 }

--- a/mapeditor/inspector/heroartifactswidget.cpp
+++ b/mapeditor/inspector/heroartifactswidget.cpp
@@ -157,9 +157,5 @@ void HeroArtifactsDelegate::updateModelData(QAbstractItemModel * model, const QM
 	{
 		textList += QString::fromStdString(art.artifact->getType()->getNameTranslated());
 	}
-	QString text = textList.join("\n");
-	model->setItemData(index, {
-		{Qt::DisplayRole, QVariant{text}},
-		{Qt::ToolTipRole, QVariant{text}}
-	});
+	setModelTextData(model, index, textList);
 }

--- a/mapeditor/inspector/heroartifactswidget.cpp
+++ b/mapeditor/inspector/heroartifactswidget.cpp
@@ -110,7 +110,7 @@ void HeroArtifactsWidget::commitChanges()
 	}
 }
 
-HeroArtifactsDelegate::HeroArtifactsDelegate(CGHeroInstance & h) : QStyledItemDelegate(), hero(h)
+HeroArtifactsDelegate::HeroArtifactsDelegate(CGHeroInstance & h) : BaseInspectorItemDelegate(), hero(h)
 {
 }
 
@@ -136,9 +136,30 @@ void HeroArtifactsDelegate::setModelData(QWidget * editor, QAbstractItemModel * 
 	if (auto * ed = qobject_cast<HeroArtifactsWidget *>(editor))
 	{
 		ed->commitChanges();
+		updateModelData(model, index);
 	}
 	else
 	{
 		QStyledItemDelegate::setModelData(editor, model, index);
 	}
+}
+
+void HeroArtifactsDelegate::updateModelData(QAbstractItemModel * model, const QModelIndex & index) const
+{
+	QStringList textList;
+	for(const auto & [artPosition, artSlotInfo] : hero.artifactsWorn)
+	{
+		auto slotText = NArtifactPosition::namesHero[artPosition.num];
+		textList += QString::fromStdString(slotText) + ": " + QString::fromStdString(artSlotInfo.artifact->getType()->getNameTranslated());
+	}
+	textList += QString::fromStdString(NArtifactPosition::backpack) + ":";
+	for(const auto & art : hero.artifactsInBackpack)
+	{
+		textList += QString::fromStdString(art.artifact->getType()->getNameTranslated());
+	}
+	QString text = textList.join("\n");
+	QMap<int, QVariant> data;
+	data[Qt::DisplayRole] = QVariant(text);
+	data[Qt::ToolTipRole] = QVariant(text);
+	model->setItemData(index, data);
 }

--- a/mapeditor/inspector/heroartifactswidget.h
+++ b/mapeditor/inspector/heroartifactswidget.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include <QDialog>
+#include "baseinspectoritemdelegate.h"
 #include "../../lib/mapObjects/CGHeroInstance.h"
 
 namespace Ui {
@@ -48,17 +49,18 @@ private:
 	
 };
 
-class HeroArtifactsDelegate : public QStyledItemDelegate
+class HeroArtifactsDelegate : public BaseInspectorItemDelegate
 {
 	Q_OBJECT
 public:
-	using QStyledItemDelegate::QStyledItemDelegate;
+	using BaseInspectorItemDelegate::BaseInspectorItemDelegate;
 	
 	HeroArtifactsDelegate(CGHeroInstance &);
 	
 	QWidget * createEditor(QWidget * parent, const QStyleOptionViewItem & option, const QModelIndex & index) const override;
 	void setEditorData(QWidget * editor, const QModelIndex & index) const override;
 	void setModelData(QWidget * editor, QAbstractItemModel * model, const QModelIndex & index) const override;
+	void updateModelData(QAbstractItemModel * model, const QModelIndex & index) const override;
 	
 private:
 	CGHeroInstance & hero;

--- a/mapeditor/inspector/heroskillswidget.cpp
+++ b/mapeditor/inspector/heroskillswidget.cpp
@@ -153,10 +153,10 @@ void HeroSkillsDelegate::setModelData(QWidget *editor, QAbstractItemModel *model
 void HeroSkillsDelegate::updateModelData(QAbstractItemModel * model, const QModelIndex & index) const
 {
 	QStringList textList;
-	textList += QString::fromStdString(VLC->generaltexth->primarySkillNames[PrimarySkill::ATTACK]) + ": " + QString::number(hero.getBasePrimarySkillValue(PrimarySkill::ATTACK));
-	textList += QString::fromStdString(VLC->generaltexth->primarySkillNames[PrimarySkill::DEFENSE]) + ": " + QString::number(hero.getBasePrimarySkillValue(PrimarySkill::DEFENSE));
-	textList += QString::fromStdString(VLC->generaltexth->primarySkillNames[PrimarySkill::SPELL_POWER]) + ": " + QString::number(hero.getBasePrimarySkillValue(PrimarySkill::SPELL_POWER));
-	textList += QString::fromStdString(VLC->generaltexth->primarySkillNames[PrimarySkill::KNOWLEDGE]) + ": " + QString::number(hero.getBasePrimarySkillValue(PrimarySkill::KNOWLEDGE));
+	textList += QString("%1: %2").arg(QString::fromStdString(VLC->generaltexth->primarySkillNames[PrimarySkill::ATTACK])).arg(hero.getBasePrimarySkillValue(PrimarySkill::ATTACK));
+	textList += QString("%1: %2").arg(QString::fromStdString(VLC->generaltexth->primarySkillNames[PrimarySkill::DEFENSE])).arg(hero.getBasePrimarySkillValue(PrimarySkill::DEFENSE));
+	textList += QString("%1: %2").arg(QString::fromStdString(VLC->generaltexth->primarySkillNames[PrimarySkill::SPELL_POWER])).arg(hero.getBasePrimarySkillValue(PrimarySkill::SPELL_POWER));
+	textList += QString("%1: %2").arg(QString::fromStdString(VLC->generaltexth->primarySkillNames[PrimarySkill::KNOWLEDGE])).arg(hero.getBasePrimarySkillValue(PrimarySkill::KNOWLEDGE));
 ;
 	auto heroSecondarySkills = hero.secSkills;
 	if(heroSecondarySkills.size() == 1 && heroSecondarySkills[0].first == SecondarySkill::NONE) 
@@ -169,11 +169,11 @@ void HeroSkillsDelegate::updateModelData(QAbstractItemModel * model, const QMode
 		textList += QObject::tr("Secondary skills:");
 	}
 	for(auto & [skill, skillLevel] : heroSecondarySkills)
-		textList += QString::fromStdString(VLC->skillh->getById(skill)->getNameTranslated()) + " " + LevelIdentifiers[skillLevel - 1].first;
+		textList += QString("%1 %2").arg(QString::fromStdString(VLC->skillh->getById(skill)->getNameTranslated())).arg(LevelIdentifiers[skillLevel - 1].first);
 
 	QString text = textList.join("\n");
-	QMap<int, QVariant> data;
-	data[Qt::DisplayRole] = QVariant(text);
-	data[Qt::ToolTipRole] = QVariant(text);
-	model->setItemData(index, data);
+	model->setItemData(index, {
+		{Qt::DisplayRole, QVariant{text}},
+		{Qt::ToolTipRole, QVariant{text}}
+	});
 }

--- a/mapeditor/inspector/heroskillswidget.cpp
+++ b/mapeditor/inspector/heroskillswidget.cpp
@@ -171,9 +171,5 @@ void HeroSkillsDelegate::updateModelData(QAbstractItemModel * model, const QMode
 	for(auto & [skill, skillLevel] : heroSecondarySkills)
 		textList += QString("%1 %2").arg(QString::fromStdString(VLC->skillh->getById(skill)->getNameTranslated())).arg(LevelIdentifiers[skillLevel - 1].first);
 
-	QString text = textList.join("\n");
-	model->setItemData(index, {
-		{Qt::DisplayRole, QVariant{text}},
-		{Qt::ToolTipRole, QVariant{text}}
-	});
+	setModelTextData(model, index, textList);
 }

--- a/mapeditor/inspector/heroskillswidget.cpp
+++ b/mapeditor/inspector/heroskillswidget.cpp
@@ -11,6 +11,7 @@
 #include "heroskillswidget.h"
 #include "ui_heroskillswidget.h"
 #include "../../lib/constants/StringConstants.h"
+#include "../../lib/entities/hero/CHeroHandler.h"
 #include "../../lib/CSkillHandler.h"
 #include "inspector.h"
 
@@ -115,7 +116,7 @@ void HeroSkillsWidget::commitChanges()
 	}
 }
 
-HeroSkillsDelegate::HeroSkillsDelegate(CGHeroInstance & h): hero(h), QStyledItemDelegate()
+HeroSkillsDelegate::HeroSkillsDelegate(CGHeroInstance & h): hero(h), BaseInspectorItemDelegate()
 {
 }
 
@@ -141,9 +142,38 @@ void HeroSkillsDelegate::setModelData(QWidget *editor, QAbstractItemModel *model
 	if(auto * ed = qobject_cast<HeroSkillsWidget *>(editor))
 	{
 		ed->commitChanges();
+		updateModelData(model, index);
 	}
 	else
 	{
 		QStyledItemDelegate::setModelData(editor, model, index);
 	}
+}
+
+void HeroSkillsDelegate::updateModelData(QAbstractItemModel * model, const QModelIndex & index) const
+{
+	QStringList textList;
+	textList += QString::fromStdString(VLC->generaltexth->primarySkillNames[PrimarySkill::ATTACK]) + ": " + QString::number(hero.getBasePrimarySkillValue(PrimarySkill::ATTACK));
+	textList += QString::fromStdString(VLC->generaltexth->primarySkillNames[PrimarySkill::DEFENSE]) + ": " + QString::number(hero.getBasePrimarySkillValue(PrimarySkill::DEFENSE));
+	textList += QString::fromStdString(VLC->generaltexth->primarySkillNames[PrimarySkill::SPELL_POWER]) + ": " + QString::number(hero.getBasePrimarySkillValue(PrimarySkill::SPELL_POWER));
+	textList += QString::fromStdString(VLC->generaltexth->primarySkillNames[PrimarySkill::KNOWLEDGE]) + ": " + QString::number(hero.getBasePrimarySkillValue(PrimarySkill::KNOWLEDGE));
+;
+	auto heroSecondarySkills = hero.secSkills;
+	if(heroSecondarySkills.size() == 1 && heroSecondarySkills[0].first == SecondarySkill::NONE) 
+	{
+		textList += QObject::tr("Default secondary skills:");
+		heroSecondarySkills = hero.getHeroType()->secSkillsInit;
+	}
+	else
+	{
+		textList += QObject::tr("Secondary skills:");
+	}
+	for(auto & [skill, skillLevel] : heroSecondarySkills)
+		textList += QString::fromStdString(VLC->skillh->getById(skill)->getNameTranslated()) + " " + LevelIdentifiers[skillLevel - 1].first;
+
+	QString text = textList.join("\n");
+	QMap<int, QVariant> data;
+	data[Qt::DisplayRole] = QVariant(text);
+	data[Qt::ToolTipRole] = QVariant(text);
+	model->setItemData(index, data);
 }

--- a/mapeditor/inspector/heroskillswidget.h
+++ b/mapeditor/inspector/heroskillswidget.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include <QDialog>
+#include "baseinspectoritemdelegate.h"
 #include "../../lib/mapObjects/CGHeroInstance.h"
 
 namespace Ui {
@@ -42,17 +43,18 @@ private:
 	std::set<int> occupiedSkills;
 };
 
-class HeroSkillsDelegate : public QStyledItemDelegate
+class HeroSkillsDelegate : public BaseInspectorItemDelegate
 {
 	Q_OBJECT
 public:
-	using QStyledItemDelegate::QStyledItemDelegate;
+	using BaseInspectorItemDelegate::BaseInspectorItemDelegate;
 	
 	HeroSkillsDelegate(CGHeroInstance &);
 	
 	QWidget * createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
 	void setEditorData(QWidget *editor, const QModelIndex &index) const override;
 	void setModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const override;
+	void updateModelData(QAbstractItemModel * model, const QModelIndex & index) const override;
 	
 private:
 	CGHeroInstance & hero;

--- a/mapeditor/inspector/herospellwidget.cpp
+++ b/mapeditor/inspector/herospellwidget.cpp
@@ -101,7 +101,7 @@ void HeroSpellWidget::on_customizeSpells_toggled(bool checked)
 	initSpellLists();
 }
 
-HeroSpellDelegate::HeroSpellDelegate(CGHeroInstance & h) : hero(h), QStyledItemDelegate()
+HeroSpellDelegate::HeroSpellDelegate(CGHeroInstance & h) : hero(h), BaseInspectorItemDelegate()
 {
 }
 
@@ -127,9 +127,34 @@ void HeroSpellDelegate::setModelData(QWidget * editor, QAbstractItemModel * mode
 	if (auto * ed = qobject_cast<HeroSpellWidget *>(editor))
 	{
 		ed->commitChanges();
+		updateModelData(model, index);
 	}
 	else
 	{
 		QStyledItemDelegate::setModelData(editor, model, index);
 	}
+}
+
+void HeroSpellDelegate::updateModelData(QAbstractItemModel * model, const QModelIndex & index) const
+{
+	QMap<int, QVariant> data;
+	if(hero.spellbookContainsSpell(SpellID::PRESET))
+	{
+		QStringList textList;
+		textList += QObject::tr("Custom Spells:");
+		for(auto const & spellID : hero.getSpellsInSpellbook())
+		{
+			if(spellID != SpellID::PRESET)
+				textList += QString::fromStdString(spellID.toSpell()->getNameTranslated());
+		}
+		QString text = textList.join("\n");
+		data[Qt::DisplayRole] = QVariant(text);
+		data[Qt::ToolTipRole] = QVariant(text);
+	}
+	else
+	{
+		data[Qt::DisplayRole] = QObject::tr("Default Spells");
+		data[Qt::ToolTipRole] = QObject::tr("Default Spells");
+	}
+	model->setItemData(index, data);
 }

--- a/mapeditor/inspector/herospellwidget.cpp
+++ b/mapeditor/inspector/herospellwidget.cpp
@@ -148,13 +148,11 @@ void HeroSpellDelegate::updateModelData(QAbstractItemModel * model, const QModel
 				textList += QString::fromStdString(spellID.toSpell()->getNameTranslated());
 		}
 		QString text = textList.join("\n");
-		data[Qt::DisplayRole] = QVariant(text);
-		data[Qt::ToolTipRole] = QVariant(text);
+		data[Qt::DisplayRole] = data[Qt::ToolTipRole] = QVariant(text);
 	}
 	else
 	{
-		data[Qt::DisplayRole] = QObject::tr("Default Spells");
-		data[Qt::ToolTipRole] = QObject::tr("Default Spells");
+		data[Qt::DisplayRole] = data[Qt::ToolTipRole] = QObject::tr("Default Spells");
 	}
 	model->setItemData(index, data);
 }

--- a/mapeditor/inspector/herospellwidget.cpp
+++ b/mapeditor/inspector/herospellwidget.cpp
@@ -137,22 +137,19 @@ void HeroSpellDelegate::setModelData(QWidget * editor, QAbstractItemModel * mode
 
 void HeroSpellDelegate::updateModelData(QAbstractItemModel * model, const QModelIndex & index) const
 {
-	QMap<int, QVariant> data;
+	QStringList textList;
 	if(hero.spellbookContainsSpell(SpellID::PRESET))
 	{
-		QStringList textList;
 		textList += QObject::tr("Custom Spells:");
 		for(auto const & spellID : hero.getSpellsInSpellbook())
 		{
 			if(spellID != SpellID::PRESET)
 				textList += QString::fromStdString(spellID.toSpell()->getNameTranslated());
 		}
-		QString text = textList.join("\n");
-		data[Qt::DisplayRole] = data[Qt::ToolTipRole] = QVariant(text);
 	}
 	else
 	{
-		data[Qt::DisplayRole] = data[Qt::ToolTipRole] = QObject::tr("Default Spells");
+		textList += QObject::tr("Default Spells");
 	}
-	model->setItemData(index, data);
+	setModelTextData(model, index, textList);
 }

--- a/mapeditor/inspector/herospellwidget.h
+++ b/mapeditor/inspector/herospellwidget.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include <QDialog>
+#include "baseinspectoritemdelegate.h"
 #include "../../lib/mapObjects/CGHeroInstance.h"
 
 namespace Ui {
@@ -39,17 +40,18 @@ private:
 	void initSpellLists();
 };
 
-class HeroSpellDelegate : public QStyledItemDelegate
+class HeroSpellDelegate : public BaseInspectorItemDelegate
 {
 	Q_OBJECT
 public:
-	using QStyledItemDelegate::QStyledItemDelegate;
+	using BaseInspectorItemDelegate::BaseInspectorItemDelegate;
 
 	HeroSpellDelegate(CGHeroInstance &);
 
 	QWidget * createEditor(QWidget * parent, const QStyleOptionViewItem & option, const QModelIndex& index) const override;
 	void setEditorData(QWidget * editor, const QModelIndex & index) const override;
 	void setModelData(QWidget * editor, QAbstractItemModel * model, const QModelIndex & index) const override;
+	void updateModelData(QAbstractItemModel * model, const QModelIndex & index) const override;
 
 private:
 	CGHeroInstance & hero;

--- a/mapeditor/inspector/inspector.cpp
+++ b/mapeditor/inspector/inspector.cpp
@@ -20,6 +20,7 @@
 #include "../lib/mapObjects/ObjectTemplate.h"
 #include "../lib/mapping/CMap.h"
 #include "../lib/constants/StringConstants.h"
+#include "../lib/CPlayerState.h"
 #include "../lib/texts/CGeneralTextHandler.h"
 
 #include "townbuildingswidget.h"
@@ -249,7 +250,7 @@ void Inspector::updateProperties(CGDwelling * o)
 	if (o->ID == Obj::RANDOM_DWELLING || o->ID == Obj::RANDOM_DWELLING_LVL)
 	{
 		auto * delegate = new PickObjectDelegate(controller, PickObjectDelegate::typedFilter<CGTownInstance>);
-		addProperty(QObject::tr("Same as town"), PropertyEditorPlaceholder(), delegate, false);
+		addProperty(QObject::tr("Same as town"), o->randomizationInfo, delegate, false);
 	}
 }
 
@@ -850,6 +851,7 @@ QTableWidgetItem * Inspector::addProperty(const QString & value)
 {
 	auto * item = new QTableWidgetItem(value);
 	item->setFlags(Qt::NoItemFlags);
+	item->setToolTip(value);
 	return item;
 }
 
@@ -902,6 +904,17 @@ QTableWidgetItem * Inspector::addProperty(CGCreature::Character value)
 		}
 	}
 	
+	return item;
+}
+
+QTableWidgetItem * Inspector::addProperty(const std::optional<CGDwellingRandomizationInfo> & value)
+{
+	QString text = QObject::tr("Select town");
+	if(value.has_value() && !value->instanceId.empty())
+		text = QString::fromStdString(value->instanceId);
+
+	auto * item = new QTableWidgetItem(text);
+	item->setFlags(Qt::NoItemFlags);
 	return item;
 }
 

--- a/mapeditor/inspector/inspector.h
+++ b/mapeditor/inspector/inspector.h
@@ -13,6 +13,7 @@
 #include <QTableWidget>
 #include <QTableWidgetItem>
 #include <QStyledItemDelegate>
+#include "baseinspectoritemdelegate.h"
 #include "../lib/int3.h"
 #include "../lib/GameConstants.h"
 #include "../lib/mapObjects/CGCreature.h"
@@ -101,6 +102,7 @@ protected:
 	QTableWidgetItem * addProperty(bool value);
 	QTableWidgetItem * addProperty(CGObjectInstance * value);
 	QTableWidgetItem * addProperty(CGCreature::Character value);
+	QTableWidgetItem * addProperty(const std::optional<CGDwellingRandomizationInfo> & value);
 	QTableWidgetItem * addProperty(PropertyEditorPlaceholder value);
 	
 //===============END OF DECLARATION=======================================
@@ -117,7 +119,7 @@ public:
 protected:
 
 	template<class T>
-	void addProperty(const QString & key, const T & value, QAbstractItemDelegate * delegate, bool restricted)
+	void addProperty(const QString & key, const T & value, BaseInspectorItemDelegate * delegate, bool restricted)
 	{
 		auto * itemValue = addProperty(value);
 		if(!restricted)
@@ -144,6 +146,11 @@ protected:
 			++row;
 		}
 		itemKey->setFlags(restricted ? Qt::NoItemFlags : Qt::ItemIsEnabled);
+		if(delegate != nullptr)
+		{
+			QModelIndex index = table->model()->index(itemValue->row(), itemValue->column());
+			delegate->updateModelData(table->model(), index);
+		}
 	}
 	
 	template<class T>
@@ -161,11 +168,11 @@ protected:
 };
 
 
-class InspectorDelegate : public QStyledItemDelegate
+class InspectorDelegate : public BaseInspectorItemDelegate
 {
 	Q_OBJECT
 public:
-	using QStyledItemDelegate::QStyledItemDelegate;
+	using BaseInspectorItemDelegate::BaseInspectorItemDelegate;
 
 	QWidget * createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
 	void setEditorData(QWidget *editor, const QModelIndex &index) const override;

--- a/mapeditor/inspector/messagewidget.h
+++ b/mapeditor/inspector/messagewidget.h
@@ -9,6 +9,7 @@
  */
 #pragma once
 #include "../StdInc.h"
+#include "baseinspectoritemdelegate.h"
 #include <QDialog>
 
 namespace Ui {
@@ -31,11 +32,11 @@ private:
 };
 
 
-class MessageDelegate : public QStyledItemDelegate
+class MessageDelegate : public BaseInspectorItemDelegate
 {
 	Q_OBJECT
 public:
-	using QStyledItemDelegate::QStyledItemDelegate;
+	using BaseInspectorItemDelegate::BaseInspectorItemDelegate;
 	
 	QWidget * createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
 	void setEditorData(QWidget *editor, const QModelIndex &index) const override;

--- a/mapeditor/inspector/portraitwidget.cpp
+++ b/mapeditor/inspector/portraitwidget.cpp
@@ -102,7 +102,7 @@ void PortraitWidget::on_buttonPrev_clicked()
 	drawPortrait();
 }
 
-PortraitDelegate::PortraitDelegate(CGHeroInstance & h): hero(h), QStyledItemDelegate()
+PortraitDelegate::PortraitDelegate(CGHeroInstance & h): hero(h), BaseInspectorItemDelegate()
 {
 }
 
@@ -128,9 +128,21 @@ void PortraitDelegate::setModelData(QWidget *editor, QAbstractItemModel *model, 
 	if(auto * ed = qobject_cast<PortraitWidget *>(editor))
 	{
 		ed->commitChanges();
+		updateModelData(model, index);
 	}
 	else
 	{
 		QStyledItemDelegate::setModelData(editor, model, index);
 	}
+}
+
+void PortraitDelegate::updateModelData(QAbstractItemModel * model, const QModelIndex & index) const
+{
+	QMap<int, QVariant> data;
+	if(hero.customPortraitSource == HeroTypeID::NONE)
+		data[Qt::DisplayRole] = QObject::tr("Default");
+	else
+		data[Qt::DisplayRole] = QString::fromStdString(hero.customPortraitSource.toHeroType()->getNameTranslated());
+	
+	model->setItemData(index, data);
 }

--- a/mapeditor/inspector/portraitwidget.h
+++ b/mapeditor/inspector/portraitwidget.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include <QDialog>
+#include "baseinspectoritemdelegate.h"
 #include "../../lib/mapObjects/CGHeroInstance.h"
 
 namespace Ui {
@@ -47,17 +48,18 @@ private:
 	int portraitIndex;
 };
 
-class PortraitDelegate : public QStyledItemDelegate
+class PortraitDelegate : public BaseInspectorItemDelegate
 {
 	Q_OBJECT
 public:
-	using QStyledItemDelegate::QStyledItemDelegate;
+	using BaseInspectorItemDelegate::BaseInspectorItemDelegate;
 
 	PortraitDelegate(CGHeroInstance &);
 
 	QWidget * createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
 	void setEditorData(QWidget *editor, const QModelIndex &index) const override;
 	void setModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const override;
+	void updateModelData(QAbstractItemModel * model, const QModelIndex & index) const override;
 
 private:
 	CGHeroInstance & hero;

--- a/mapeditor/inspector/questwidget.cpp
+++ b/mapeditor/inspector/questwidget.cpp
@@ -462,51 +462,51 @@ void QuestDelegate::updateModelData(QAbstractItemModel * model, const QModelInde
 			continue;
 		MetaString str;
 		str.appendName(resource);
-		resourcesList += QString::fromStdString(str.toString()) + ": " + QString::number(quest.mission.resources[resource]);
+		resourcesList += QString("%1: %2").arg(QString::fromStdString(str.toString())).arg(quest.mission.resources[resource]);
 	}
-	textList += QObject::tr("Resources: ") + resourcesList.join(", ");
+	textList += QObject::tr("Resources: %1").arg(resourcesList.join(", "));
 
 	QStringList artifactsList;
 	for(auto artifact : quest.mission.artifacts)
 	{
 		artifactsList += QString::fromStdString(VLC->artifacts()->getById(artifact)->getNameTranslated());
 	}
-	textList += QObject::tr("Artifacts: ") + artifactsList.join(", ");
+	textList += QObject::tr("Artifacts: %1").arg(artifactsList.join(", "));
 
 	QStringList spellsList;
 	for(auto spell : quest.mission.spells)
 	{
 		spellsList += QString::fromStdString(VLC->spells()->getById(spell)->getNameTranslated());
 	}
-	textList += QObject::tr("Spells: ") + spellsList.join(", ");
+	textList += QObject::tr("Spells: %1").arg(spellsList.join(", "));
 
 	QStringList secondarySkillsList;
 	for(auto & [skill, skillLevel] : quest.mission.secondary)
 	{
-		secondarySkillsList += QString::fromStdString(VLC->skills()->getById(skill)->getNameTranslated()) + " (" + QString::number(skillLevel) + ")";
+		secondarySkillsList += QString("%1 (%2)").arg(QString::fromStdString(VLC->skills()->getById(skill)->getNameTranslated())).arg(skillLevel);
 	}
-	textList += QObject::tr("Secondary Skills: ") + secondarySkillsList.join(", ");
+	textList += QObject::tr("Secondary Skills: %1").arg(secondarySkillsList.join(", "));
 
 	QStringList creaturesList;
 	for(auto & creature : quest.mission.creatures)
 	{
-		creaturesList += QString::number(creature.count) + " " + QString::fromStdString(creature.getType()->getNamePluralTranslated());
+		creaturesList += QString("%1 %2").arg(creature.count).arg(QString::fromStdString(creature.getType()->getNamePluralTranslated()));
 	}
-	textList += QObject::tr("Creatures: ") + creaturesList.join(", ");
+	textList += QObject::tr("Creatures: %1").arg(creaturesList.join(", "));
 
 	QStringList heroesList;
 	for(auto & hero : quest.mission.heroes)
 	{
 		heroesList += QString::fromStdString(VLC->heroTypes()->getById(hero)->getNameTranslated());
 	}
-	textList += QObject::tr("Heroes: ") + heroesList.join(", ");
+	textList += QObject::tr("Heroes: %1").arg(heroesList.join(", "));
 
 	QStringList heroClassesList;
 	for(auto & heroClass : quest.mission.heroClasses)
 	{
 		heroClassesList += QString::fromStdString(VLC->heroClasses()->getById(heroClass)->getNameTranslated());
 	}
-	textList += QObject::tr("Hero Classes: ") + heroClassesList.join(", ");
+	textList += QObject::tr("Hero Classes: %1").arg(heroClassesList.join(", "));
 
 	QStringList playersList;
 	for(auto & player : quest.mission.players)
@@ -515,11 +515,11 @@ void QuestDelegate::updateModelData(QAbstractItemModel * model, const QModelInde
 		str.appendName(player);
 		playersList += QString::fromStdString(str.toString());
 	}
-	textList += QObject::tr("Players: ") + playersList.join(", ");
+	textList += QObject::tr("Players: %1").arg(playersList.join(", "));
 
 	QString text = textList.join("\n");
-	QMap<int, QVariant> data;
-	data[Qt::DisplayRole] = QVariant(text);
-	data[Qt::ToolTipRole] = QVariant(text);
-	model->setItemData(index, data);
+	model->setItemData(index, {
+		{Qt::DisplayRole, QVariant{text}},
+		{Qt::ToolTipRole, QVariant{text}}
+	});
 }

--- a/mapeditor/inspector/questwidget.cpp
+++ b/mapeditor/inspector/questwidget.cpp
@@ -391,7 +391,7 @@ void QuestWidget::on_lCreatureRemove_clicked()
 		ui->lCreatures->removeRow(i);
 }
 
-QuestDelegate::QuestDelegate(MapController & c, CQuest & t): controller(c), quest(t), QStyledItemDelegate()
+QuestDelegate::QuestDelegate(MapController & c, CQuest & t): controller(c), quest(t), BaseInspectorItemDelegate()
 {
 }
 
@@ -417,6 +417,7 @@ void QuestDelegate::setModelData(QWidget * editor, QAbstractItemModel * model, c
 	if(auto *ed = qobject_cast<QuestWidget *>(editor))
 	{
 		ed->commitChanges();
+		updateModelData(model, index);
 	}
 	else
 	{
@@ -438,4 +439,87 @@ bool QuestDelegate::eventFilter(QObject * object, QEvent * event)
 		}
 	}
 	return QStyledItemDelegate::eventFilter(object, event);
+}
+
+void QuestDelegate::updateModelData(QAbstractItemModel * model, const QModelIndex & index) const
+{
+	QStringList textList;
+	textList += QObject::tr("Quest:");
+	textList += QObject::tr("Day of Week: %1").arg(quest.mission.dayOfWeek);
+	textList += QObject::tr("Days Passed: %1").arg(quest.mission.daysPassed);
+	textList += QObject::tr("Hero Level: %1").arg(quest.mission.heroLevel);
+	textList += QObject::tr("Hero Experience: %1").arg(quest.mission.heroExperience);
+	textList += QObject::tr("Mana Points: %1").arg(quest.mission.manaPoints);
+	textList += QObject::tr("Mana Percentage: %1").arg(quest.mission.manaPercentage);
+	textList += QObject::tr("Primary Skills: %1/%2/%3/%4").arg(quest.mission.primary[0]).arg(quest.mission.primary[1]).arg(quest.mission.primary[2]).arg(quest.mission.primary[3]);
+
+	QStringList resourcesList;
+	for(GameResID resource = GameResID::WOOD; resource < GameResID::COUNT ; resource++)
+	{
+		if(resource == GameResID::MITHRIL)
+			continue;
+		if(quest.mission.resources[resource] == 0)
+			continue;
+		MetaString str;
+		str.appendName(resource);
+		resourcesList += QString::fromStdString(str.toString()) + ": " + QString::number(quest.mission.resources[resource]);
+	}
+	textList += QObject::tr("Resources: ") + resourcesList.join(", ");
+
+	QStringList artifactsList;
+	for(auto artifact : quest.mission.artifacts)
+	{
+		artifactsList += QString::fromStdString(VLC->artifacts()->getById(artifact)->getNameTranslated());
+	}
+	textList += QObject::tr("Artifacts: ") + artifactsList.join(", ");
+
+	QStringList spellsList;
+	for(auto spell : quest.mission.spells)
+	{
+		spellsList += QString::fromStdString(VLC->spells()->getById(spell)->getNameTranslated());
+	}
+	textList += QObject::tr("Spells: ") + spellsList.join(", ");
+
+	QStringList secondarySkillsList;
+	for(auto & [skill, skillLevel] : quest.mission.secondary)
+	{
+		secondarySkillsList += QString::fromStdString(VLC->skills()->getById(skill)->getNameTranslated()) + " (" + QString::number(skillLevel) + ")";
+	}
+	textList += QObject::tr("Secondary Skills: ") + secondarySkillsList.join(", ");
+
+	QStringList creaturesList;
+	for(auto & creature : quest.mission.creatures)
+	{
+		creaturesList += QString::number(creature.count) + " " + QString::fromStdString(creature.getType()->getNamePluralTranslated());
+	}
+	textList += QObject::tr("Creatures: ") + creaturesList.join(", ");
+
+	QStringList heroesList;
+	for(auto & hero : quest.mission.heroes)
+	{
+		heroesList += QString::fromStdString(VLC->heroTypes()->getById(hero)->getNameTranslated());
+	}
+	textList += QObject::tr("Heroes: ") + heroesList.join(", ");
+
+	QStringList heroClassesList;
+	for(auto & heroClass : quest.mission.heroClasses)
+	{
+		heroClassesList += QString::fromStdString(VLC->heroClasses()->getById(heroClass)->getNameTranslated());
+	}
+	textList += QObject::tr("Hero Classes: ") + heroClassesList.join(", ");
+
+	QStringList playersList;
+	for(auto & player : quest.mission.players)
+	{
+		MetaString str;
+		str.appendName(player);
+		playersList += QString::fromStdString(str.toString());
+	}
+	textList += QObject::tr("Players: ") + playersList.join(", ");
+
+	QString text = textList.join("\n");
+	QMap<int, QVariant> data;
+	data[Qt::DisplayRole] = QVariant(text);
+	data[Qt::ToolTipRole] = QVariant(text);
+	model->setItemData(index, data);
 }

--- a/mapeditor/inspector/questwidget.cpp
+++ b/mapeditor/inspector/questwidget.cpp
@@ -443,8 +443,7 @@ bool QuestDelegate::eventFilter(QObject * object, QEvent * event)
 
 void QuestDelegate::updateModelData(QAbstractItemModel * model, const QModelIndex & index) const
 {
-	QStringList textList;
-	textList += QObject::tr("Quest:");
+	QStringList textList(QObject::tr("Quest:"));
 	textList += QObject::tr("Day of Week: %1").arg(quest.mission.dayOfWeek);
 	textList += QObject::tr("Days Passed: %1").arg(quest.mission.daysPassed);
 	textList += QObject::tr("Hero Level: %1").arg(quest.mission.heroLevel);
@@ -517,9 +516,5 @@ void QuestDelegate::updateModelData(QAbstractItemModel * model, const QModelInde
 	}
 	textList += QObject::tr("Players: %1").arg(playersList.join(", "));
 
-	QString text = textList.join("\n");
-	model->setItemData(index, {
-		{Qt::DisplayRole, QVariant{text}},
-		{Qt::ToolTipRole, QVariant{text}}
-	});
+	setModelTextData(model, index, textList);
 }

--- a/mapeditor/inspector/questwidget.h
+++ b/mapeditor/inspector/questwidget.h
@@ -10,6 +10,7 @@
 #pragma once
 #include "../StdInc.h"
 #include <QDialog>
+#include "baseinspectoritemdelegate.h"
 #include "../lib/mapObjects/CQuest.h"
 
 namespace Ui {
@@ -46,17 +47,18 @@ private:
 	Ui::QuestWidget *ui;
 };
 
-class QuestDelegate : public QStyledItemDelegate
+class QuestDelegate : public BaseInspectorItemDelegate
 {
 	Q_OBJECT
 public:
-	using QStyledItemDelegate::QStyledItemDelegate;
+	using BaseInspectorItemDelegate::BaseInspectorItemDelegate;
 	
 	QuestDelegate(MapController &, CQuest &);
 	
 	QWidget * createEditor(QWidget * parent, const QStyleOptionViewItem & option, const QModelIndex & index) const override;
 	void setEditorData(QWidget * editor, const QModelIndex & index) const override;
 	void setModelData(QWidget * editor, QAbstractItemModel * model, const QModelIndex & index) const override;
+	void updateModelData(QAbstractItemModel * model, const QModelIndex & index) const override;
 	
 protected:
 	bool eventFilter(QObject * object, QEvent * event) override;

--- a/mapeditor/inspector/rewardswidget.cpp
+++ b/mapeditor/inspector/rewardswidget.cpp
@@ -782,47 +782,47 @@ void RewardsDelegate::updateModelData(QAbstractItemModel * model, const QModelIn
 				continue;
 			MetaString str;
 			str.appendName(resource);
-			resourcesList += QString::fromStdString(str.toString()) + ": " + QString::number(vinfo.reward.resources[resource]);
+			resourcesList += QString("%1: %2").arg(QString::fromStdString(str.toString())).arg(vinfo.reward.resources[resource]);
 		}
-		textList += QObject::tr("Resources: ") + resourcesList.join(", ");
+		textList += QObject::tr("Resources: %1").arg(resourcesList.join(", "));
 		QStringList artifactsList;
 		for (auto artifact : vinfo.reward.artifacts)
 		{
 			artifactsList += QString::fromStdString(VLC->artifacts()->getById(artifact)->getNameTranslated());
 		}
-		textList += QObject::tr("Artifacts: ") + artifactsList.join(", ");
+		textList += QObject::tr("Artifacts: %1").arg(artifactsList.join(", "));
 		QStringList spellsList;
 		for (auto spell : vinfo.reward.spells)
 		{
 			spellsList += QString::fromStdString(VLC->spells()->getById(spell)->getNameTranslated());
 		}
-		textList += QObject::tr("Spells: ") + spellsList.join(", ");
+		textList += QObject::tr("Spells: %1").arg(spellsList.join(", "));
 		QStringList secondarySkillsList;
 		for(auto & [skill, skillLevel] : vinfo.reward.secondary)
 		{
-			secondarySkillsList += QString::fromStdString(VLC->skills()->getById(skill)->getNameTranslated()) + " (" + QString::number(skillLevel) + ")";
+			secondarySkillsList += QString("%1 (%2)").arg(QString::fromStdString(VLC->skills()->getById(skill)->getNameTranslated())).arg(skillLevel);
 		}
-		textList += QObject::tr("Secondary Skills: ") + secondarySkillsList.join(", ");
+		textList += QObject::tr("Secondary Skills: %1").arg(secondarySkillsList.join(", "));
 		QStringList creaturesList;
 		for (auto & creature : vinfo.reward.creatures)
 		{
-			creaturesList += QString::number(creature.count) + " " + QString::fromStdString(creature.getType()->getNamePluralTranslated());
+			creaturesList += QString("%1 %2").arg(creature.count).arg(QString::fromStdString(creature.getType()->getNamePluralTranslated()));
 		}
-		textList += QObject::tr("Creatures: ") + creaturesList.join(", ");
+		textList += QObject::tr("Creatures: %1").arg(creaturesList.join(", "));
 		if (vinfo.reward.spellCast.first != SpellID::NONE)
 		{
-			textList += QObject::tr("Spell Cast: ") + QString::fromStdString(VLC->spells()->getById(vinfo.reward.spellCast.first)->getNameTranslated()) + " (" + QString::number(vinfo.reward.spellCast.second) + ")";
+			textList += QObject::tr("Spell Cast: %1 (%2)").arg(QString::fromStdString(VLC->spells()->getById(vinfo.reward.spellCast.first)->getNameTranslated())).arg(vinfo.reward.spellCast.second);
 		}
 		QStringList bonusesList;
 		for (auto & bonus : vinfo.reward.bonuses)
 		{
-			bonusesList += QString::fromStdString(vstd::findKey(bonusDurationMap, bonus.duration)) + " " + QString::fromStdString(vstd::findKey(bonusNameMap, bonus.type)) + " (" + QString::number(bonus.val) + ")";
+			bonusesList += QString("%1 %2 (%3)").arg(QString::fromStdString(vstd::findKey(bonusDurationMap, bonus.duration))).arg(QString::fromStdString(vstd::findKey(bonusNameMap, bonus.type))).arg(bonus.val);
 		}
-		textList += QObject::tr("Bonuses: ") + bonusesList.join(", ");
+		textList += QObject::tr("Bonuses: %1").arg(bonusesList.join(", "));
 	}
 	QString text = textList.join("\n");
-	QMap<int, QVariant> data;
-	data[Qt::DisplayRole] = QVariant(text);
-	data[Qt::ToolTipRole] = QVariant(text);
-	model->setItemData(index, data);
+	model->setItemData(index, {
+		{Qt::DisplayRole, QVariant{text}},
+		{Qt::ToolTipRole, QVariant{text}}
+	});
 }

--- a/mapeditor/inspector/rewardswidget.cpp
+++ b/mapeditor/inspector/rewardswidget.cpp
@@ -761,8 +761,7 @@ QWidget * RewardsDelegate::createEditor(QWidget *parent, const QStyleOptionViewI
 
 void RewardsDelegate::updateModelData(QAbstractItemModel * model, const QModelIndex & index) const
 {
-	QStringList textList;
-	textList += QObject::tr("Rewards:");
+	QStringList textList(QObject::tr("Rewards:"));
 	for (const auto & vinfo : object.configuration.info)
 	{
 		textList += QObject::tr("Reward Message: %1").arg(QString::fromStdString(vinfo.message.toString()));
@@ -820,9 +819,5 @@ void RewardsDelegate::updateModelData(QAbstractItemModel * model, const QModelIn
 		}
 		textList += QObject::tr("Bonuses: %1").arg(bonusesList.join(", "));
 	}
-	QString text = textList.join("\n");
-	model->setItemData(index, {
-		{Qt::DisplayRole, QVariant{text}},
-		{Qt::ToolTipRole, QVariant{text}}
-	});
+	setModelTextData(model, index, textList);
 }

--- a/mapeditor/inspector/rewardswidget.cpp
+++ b/mapeditor/inspector/rewardswidget.cpp
@@ -742,6 +742,7 @@ void RewardsDelegate::setModelData(QWidget *editor, QAbstractItemModel *model, c
 	if(auto * ed = qobject_cast<RewardsWidget *>(editor))
 	{
 		ed->commitChanges();
+		updateModelData(model, index);
 	}
 	else
 	{
@@ -756,4 +757,72 @@ RewardsDelegate::RewardsDelegate(CMap & m, CRewardableObject & t): map(m), objec
 QWidget * RewardsDelegate::createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const
 {
 	return new RewardsWidget(map, object, parent);
+}
+
+void RewardsDelegate::updateModelData(QAbstractItemModel * model, const QModelIndex & index) const
+{
+	QStringList textList;
+	textList += QObject::tr("Rewards:");
+	for (const auto & vinfo : object.configuration.info)
+	{
+		textList += QObject::tr("Reward Message: %1").arg(QString::fromStdString(vinfo.message.toString()));
+		textList += QObject::tr("Hero Level: %1").arg(vinfo.reward.heroLevel);
+		textList += QObject::tr("Hero Experience: %1").arg(vinfo.reward.heroExperience);
+		textList += QObject::tr("Mana Diff: %1").arg(vinfo.reward.manaDiff);
+		textList += QObject::tr("Mana Percentage: %1").arg(vinfo.reward.manaPercentage);
+		textList += QObject::tr("Move Points: %1").arg(vinfo.reward.movePoints);
+		textList += QObject::tr("Move Percentage: %1").arg(vinfo.reward.movePercentage);
+		textList += QObject::tr("Primary Skills: %1/%2/%3/%4").arg(vinfo.reward.primary[0]).arg(vinfo.reward.primary[1]).arg(vinfo.reward.primary[2]).arg(vinfo.reward.primary[3]);
+		QStringList resourcesList;
+		for(GameResID resource = GameResID::WOOD; resource < GameResID::COUNT ; resource++)
+		{
+			if(resource == GameResID::MITHRIL)
+				continue; // translated as "Abandoned"?
+			if(vinfo.reward.resources[resource] == 0)
+				continue;
+			MetaString str;
+			str.appendName(resource);
+			resourcesList += QString::fromStdString(str.toString()) + ": " + QString::number(vinfo.reward.resources[resource]);
+		}
+		textList += QObject::tr("Resources: ") + resourcesList.join(", ");
+		QStringList artifactsList;
+		for (auto artifact : vinfo.reward.artifacts)
+		{
+			artifactsList += QString::fromStdString(VLC->artifacts()->getById(artifact)->getNameTranslated());
+		}
+		textList += QObject::tr("Artifacts: ") + artifactsList.join(", ");
+		QStringList spellsList;
+		for (auto spell : vinfo.reward.spells)
+		{
+			spellsList += QString::fromStdString(VLC->spells()->getById(spell)->getNameTranslated());
+		}
+		textList += QObject::tr("Spells: ") + spellsList.join(", ");
+		QStringList secondarySkillsList;
+		for(auto & [skill, skillLevel] : vinfo.reward.secondary)
+		{
+			secondarySkillsList += QString::fromStdString(VLC->skills()->getById(skill)->getNameTranslated()) + " (" + QString::number(skillLevel) + ")";
+		}
+		textList += QObject::tr("Secondary Skills: ") + secondarySkillsList.join(", ");
+		QStringList creaturesList;
+		for (auto & creature : vinfo.reward.creatures)
+		{
+			creaturesList += QString::number(creature.count) + " " + QString::fromStdString(creature.getType()->getNamePluralTranslated());
+		}
+		textList += QObject::tr("Creatures: ") + creaturesList.join(", ");
+		if (vinfo.reward.spellCast.first != SpellID::NONE)
+		{
+			textList += QObject::tr("Spell Cast: ") + QString::fromStdString(VLC->spells()->getById(vinfo.reward.spellCast.first)->getNameTranslated()) + " (" + QString::number(vinfo.reward.spellCast.second) + ")";
+		}
+		QStringList bonusesList;
+		for (auto & bonus : vinfo.reward.bonuses)
+		{
+			bonusesList += QString::fromStdString(vstd::findKey(bonusDurationMap, bonus.duration)) + " " + QString::fromStdString(vstd::findKey(bonusNameMap, bonus.type)) + " (" + QString::number(bonus.val) + ")";
+		}
+		textList += QObject::tr("Bonuses: ") + bonusesList.join(", ");
+	}
+	QString text = textList.join("\n");
+	QMap<int, QVariant> data;
+	data[Qt::DisplayRole] = QVariant(text);
+	data[Qt::ToolTipRole] = QVariant(text);
+	model->setItemData(index, data);
 }

--- a/mapeditor/inspector/rewardswidget.h
+++ b/mapeditor/inspector/rewardswidget.h
@@ -10,6 +10,7 @@
 #pragma once
 #include "../StdInc.h"
 #include <QDialog>
+#include "baseinspectoritemdelegate.h"
 #include "../lib/mapObjects/CRewardableObject.h"
 
 namespace Ui {
@@ -67,18 +68,19 @@ private:
 	CMap & map;
 };
 
-class RewardsDelegate : public QStyledItemDelegate
+class RewardsDelegate : public BaseInspectorItemDelegate
 {
 	Q_OBJECT
 public:
 	RewardsDelegate(CMap &, CRewardableObject &);
 
-	using QStyledItemDelegate::QStyledItemDelegate;
+	using BaseInspectorItemDelegate::BaseInspectorItemDelegate;
 	
 	void setEditorData(QWidget *editor, const QModelIndex &index) const override;
 	void setModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const override;
 
 	QWidget * createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
+	void updateModelData(QAbstractItemModel * model, const QModelIndex & index) const override;
 
 private:
 	CRewardableObject & object;

--- a/mapeditor/inspector/townbuildingswidget.cpp
+++ b/mapeditor/inspector/townbuildingswidget.cpp
@@ -332,11 +332,6 @@ void TownBuildingsDelegate::setEditorData(QWidget *editor, const QModelIndex &in
 	if(auto * ed = qobject_cast<TownBuildingsWidget *>(editor))
 	{
 		auto * ctown = town.getTown();
-		if(!ctown)
-			ctown = VLC->townh->randomTown;
-		if(!ctown)
-			throw std::runtime_error("No Town defined for type selected");
-		
 		ed->addBuildings(*ctown);
 	}
 	else
@@ -366,8 +361,6 @@ void TownBuildingsDelegate::updateModelData(QAbstractItemModel * model, const QM
 	QStringList textList;
 	textList += QObject::tr("Built buildings:");
 	auto * ctown = town.getTown();
-	if(!ctown)
-		ctown = VLC->townh->randomTown;
 	for(const auto & buildingID : town.getBuildings())
 	{
 		if(buildingID == BuildingID::DEFAULT)

--- a/mapeditor/inspector/townbuildingswidget.cpp
+++ b/mapeditor/inspector/townbuildingswidget.cpp
@@ -379,8 +379,8 @@ void TownBuildingsDelegate::updateModelData(QAbstractItemModel * model, const QM
 		textList += name;
 	}
 	QString text = textList.join("\n");
-	QMap<int, QVariant> data;
-	data[Qt::DisplayRole] = QVariant(text);
-	data[Qt::ToolTipRole] = QVariant(text);
-	model->setItemData(index, data);
+	model->setItemData(index, {
+		{Qt::DisplayRole, QVariant{text}},
+		{Qt::ToolTipRole, QVariant{text}}
+	});
 }

--- a/mapeditor/inspector/townbuildingswidget.cpp
+++ b/mapeditor/inspector/townbuildingswidget.cpp
@@ -358,8 +358,7 @@ void TownBuildingsDelegate::setModelData(QWidget *editor, QAbstractItemModel *mo
 
 void TownBuildingsDelegate::updateModelData(QAbstractItemModel * model, const QModelIndex & index) const
 {
-	QStringList textList;
-	textList += QObject::tr("Built buildings:");
+	QStringList textList(QObject::tr("Built buildings:"));
 	auto * ctown = town.getTown();
 	for(const auto & buildingID : town.getBuildings())
 	{
@@ -378,9 +377,5 @@ void TownBuildingsDelegate::updateModelData(QAbstractItemModel * model, const QM
 			name = QString::fromStdString(defaultBuildingIdConversion(buildingID));
 		textList += name;
 	}
-	QString text = textList.join("\n");
-	model->setItemData(index, {
-		{Qt::DisplayRole, QVariant{text}},
-		{Qt::ToolTipRole, QVariant{text}}
-	});
+	setModelTextData(model, index, textList);
 }

--- a/mapeditor/inspector/townbuildingswidget.h
+++ b/mapeditor/inspector/townbuildingswidget.h
@@ -11,6 +11,7 @@
 
 #include "../StdInc.h"
 #include <QDialog>
+#include "baseinspectoritemdelegate.h"
 #include "../lib/mapObjects/CGTownInstance.h"
 
 namespace Ui {
@@ -66,17 +67,18 @@ private:
 	mutable QStandardItemModel model;
 };
 
-class TownBuildingsDelegate : public QStyledItemDelegate
+class TownBuildingsDelegate : public BaseInspectorItemDelegate
 {
 	Q_OBJECT
 public:
-	using QStyledItemDelegate::QStyledItemDelegate;
+	using BaseInspectorItemDelegate::BaseInspectorItemDelegate;
 	
 	TownBuildingsDelegate(CGTownInstance &);
 	
 	QWidget * createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
 	void setEditorData(QWidget *editor, const QModelIndex &index) const override;
 	void setModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const override;
+	void updateModelData(QAbstractItemModel * model, const QModelIndex & index) const override;
 	
 private:
 	CGTownInstance & town;

--- a/mapeditor/inspector/towneventdialog.cpp
+++ b/mapeditor/inspector/towneventdialog.cpp
@@ -105,10 +105,6 @@ void TownEventDialog::initResources()
 void TownEventDialog::initBuildings()
 {
 	auto * ctown = town.getTown();
-	if (!ctown)
-		ctown = VLC->townh->randomTown;
-	if (!ctown)
-		throw std::runtime_error("No Town defined for type selected");
 	auto allBuildings = ctown->getAllBuildings();
 	while (!allBuildings.empty())
 	{

--- a/mapeditor/inspector/towneventswidget.cpp
+++ b/mapeditor/inspector/towneventswidget.cpp
@@ -179,16 +179,11 @@ void TownEventsDelegate::setModelData(QWidget * editor, QAbstractItemModel * mod
 
 void TownEventsDelegate::updateModelData(QAbstractItemModel * model, const QModelIndex & index) const
 {
-	QStringList eventList;
-	eventList += QObject::tr("Town Events:");
+	QStringList eventList(QObject::tr("Town Events:"));
 	for (const auto & event : town.events)
 	{
 		auto eventName = QString::fromStdString(event.name);
 		eventList += tr("Day %1 - %2").arg(event.firstOccurrence + 1).arg(eventName);
 	}
-	QString text = eventList.join("\n");
-	model->setItemData(index, {
-		{Qt::DisplayRole, QVariant{text}},
-		{Qt::ToolTipRole, QVariant{text}}
-	});
+	setModelTextData(model, index, eventList);
 }

--- a/mapeditor/inspector/towneventswidget.cpp
+++ b/mapeditor/inspector/towneventswidget.cpp
@@ -179,15 +179,16 @@ void TownEventsDelegate::setModelData(QWidget * editor, QAbstractItemModel * mod
 
 void TownEventsDelegate::updateModelData(QAbstractItemModel * model, const QModelIndex & index) const
 {
-	QStringList eventLists;
+	QStringList eventList;
+	eventList += QObject::tr("Town Events:");
 	for (const auto & event : town.events)
 	{
 		auto eventName = QString::fromStdString(event.name);
-		eventLists += tr("Day %1 - %2").arg(event.firstOccurrence + 1, 3).arg(eventName);
+		eventList += tr("Day %1 - %2").arg(event.firstOccurrence + 1).arg(eventName);
 	}
-	QString text = QObject::tr("Town Events:\n") + eventLists.join(",\n");
-	QMap<int, QVariant> data;
-	data[Qt::DisplayRole] = QVariant(text);
-	data[Qt::ToolTipRole] = QVariant(text);
-	model->setItemData(index, data);
+	QString text = eventList.join("\n");
+	model->setItemData(index, {
+		{Qt::DisplayRole, QVariant{text}},
+		{Qt::ToolTipRole, QVariant{text}}
+	});
 }

--- a/mapeditor/inspector/towneventswidget.cpp
+++ b/mapeditor/inspector/towneventswidget.cpp
@@ -143,7 +143,7 @@ void TownEventsWidget::on_eventsList_itemActivated(QListWidgetItem* item)
 }
 
 
-TownEventsDelegate::TownEventsDelegate(CGTownInstance & town, MapController & c) : QStyledItemDelegate(), town(town), controller(c)
+TownEventsDelegate::TownEventsDelegate(CGTownInstance & town, MapController & c) : BaseInspectorItemDelegate(), town(town), controller(c)
 {
 }
 
@@ -169,9 +169,25 @@ void TownEventsDelegate::setModelData(QWidget * editor, QAbstractItemModel * mod
 	if (auto * ed = qobject_cast<TownEventsWidget *>(editor))
 	{
 		ed->commitChanges(controller);
+		updateModelData(model, index);
 	}
 	else
 	{
 		QStyledItemDelegate::setModelData(editor, model, index);
 	}
+}
+
+void TownEventsDelegate::updateModelData(QAbstractItemModel * model, const QModelIndex & index) const
+{
+	QStringList eventLists;
+	for (const auto & event : town.events)
+	{
+		auto eventName = QString::fromStdString(event.name);
+		eventLists += tr("Day %1 - %2").arg(event.firstOccurrence + 1, 3).arg(eventName);
+	}
+	QString text = QObject::tr("Town Events:\n") + eventLists.join(",\n");
+	QMap<int, QVariant> data;
+	data[Qt::DisplayRole] = QVariant(text);
+	data[Qt::ToolTipRole] = QVariant(text);
+	model->setItemData(index, data);
 }

--- a/mapeditor/inspector/towneventswidget.h
+++ b/mapeditor/inspector/towneventswidget.h
@@ -11,6 +11,7 @@
 
 #include "../StdInc.h"
 #include <QDialog>
+#include "baseinspectoritemdelegate.h"
 #include "../lib/mapping/CMapDefines.h"
 #include "../lib/mapObjects/CGTownInstance.h"
 #include "../mapcontroller.h"
@@ -40,17 +41,18 @@ private:
 	CGTownInstance & town;
 };
 
-class TownEventsDelegate : public QStyledItemDelegate
+class TownEventsDelegate : public BaseInspectorItemDelegate
 {
 	Q_OBJECT
 public:
-	using QStyledItemDelegate::QStyledItemDelegate;
+	using BaseInspectorItemDelegate::BaseInspectorItemDelegate;
 
 	TownEventsDelegate(CGTownInstance &, MapController &);
 
 	QWidget* createEditor(QWidget * parent, const QStyleOptionViewItem & option, const QModelIndex & index) const override;
 	void setEditorData(QWidget * editor, const QModelIndex & index) const override;
 	void setModelData(QWidget * editor, QAbstractItemModel * model, const QModelIndex & index) const override;
+	void updateModelData(QAbstractItemModel * model, const QModelIndex & index) const override;
 
 private:
 	CGTownInstance & town;

--- a/mapeditor/inspector/townspellswidget.cpp
+++ b/mapeditor/inspector/townspellswidget.cpp
@@ -174,7 +174,6 @@ void TownSpellsDelegate::updateModelData(QAbstractItemModel * model, const QMode
 	if(vstd::contains(town.possibleSpells, SpellID::PRESET)) {
 		textList += QObject::tr("Custom Spells:");
 		textList += QObject::tr("Required:");
-		QStringList requiredSpellsList;
 		for(auto spellID : town.obligatorySpells)
 		{
 			auto spell = spellID.toEntity(VLC);
@@ -196,8 +195,8 @@ void TownSpellsDelegate::updateModelData(QAbstractItemModel * model, const QMode
 		textList += QObject::tr("Default Spells");
 	}
 	QString text = textList.join("\n");
-	QMap<int, QVariant> data;
-	data[Qt::DisplayRole] = QVariant(text);
-	data[Qt::ToolTipRole] = QVariant(text);
-	model->setItemData(index, data);
+	model->setItemData(index, {
+		{Qt::DisplayRole, QVariant{text}},
+		{Qt::ToolTipRole, QVariant{text}}
+	});
 }

--- a/mapeditor/inspector/townspellswidget.cpp
+++ b/mapeditor/inspector/townspellswidget.cpp
@@ -194,9 +194,5 @@ void TownSpellsDelegate::updateModelData(QAbstractItemModel * model, const QMode
 	{
 		textList += QObject::tr("Default Spells");
 	}
-	QString text = textList.join("\n");
-	model->setItemData(index, {
-		{Qt::DisplayRole, QVariant{text}},
-		{Qt::ToolTipRole, QVariant{text}}
-	});
+	setModelTextData(model, index, textList);
 }

--- a/mapeditor/inspector/townspellswidget.h
+++ b/mapeditor/inspector/townspellswidget.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include <QDialog>
+#include "baseinspectoritemdelegate.h"
 #include "../../lib/mapObjects/CGTownInstance.h"
 
 namespace Ui {
@@ -43,17 +44,18 @@ private:
 	void initSpellLists();
 };
 
-class TownSpellsDelegate : public QStyledItemDelegate
+class TownSpellsDelegate : public BaseInspectorItemDelegate
 {
 	Q_OBJECT
 public:
-	using QStyledItemDelegate::QStyledItemDelegate;
+	using BaseInspectorItemDelegate::BaseInspectorItemDelegate;
 
 	TownSpellsDelegate(CGTownInstance&);
 
 	QWidget * createEditor(QWidget * parent, const QStyleOptionViewItem & option, const QModelIndex& index) const override;
 	void setEditorData(QWidget * editor, const QModelIndex & index) const override;
 	void setModelData(QWidget * editor, QAbstractItemModel * model, const QModelIndex & index) const override;
+	void updateModelData(QAbstractItemModel * model, const QModelIndex & index) const override;
 
 private:
 	CGTownInstance& town;

--- a/mapeditor/playerparams.cpp
+++ b/mapeditor/playerparams.cpp
@@ -80,8 +80,6 @@ PlayerParams::PlayerParams(MapController & ctrl, int playerId, QWidget *parent) 
 		if(auto town = dynamic_cast<CGTownInstance*>(controller.map()->objects[i].get()))
 		{
 			auto * ctown = town->getTown();
-			if(!ctown)
-				ctown = VLC->townh->randomTown;
 
 			if(ctown && town->getOwner().getNum() == playerColor)
 			{


### PR DESCRIPTION
Improved inspector to show real values instead of `...`
As description of most values can get quite long I added also tooltip. Might be overkill for quests and rewards, but better than nothing

![image](https://github.com/user-attachments/assets/491b03a5-faaa-48a0-9b3e-55b35084c32c)
![image](https://github.com/user-attachments/assets/e64f15c0-1c61-4e3b-995c-265bfb733925)
![image](https://github.com/user-attachments/assets/4ddbbd45-e242-462a-9a5b-791d32c7829c)

