### PR TITLE
Ability to use random main menu background

### DIFF
--- a/client/mainmenu/CMainMenu.cpp
+++ b/client/mainmenu/CMainMenu.cpp
@@ -76,7 +76,13 @@ CMenuScreen::CMenuScreen(const JsonNode & configNode)
 {
 	OBJECT_CONSTRUCTION;
 
-	background = std::make_shared<CPicture>(ImagePath::fromJson(config["background"]));
+	const auto& bgConfig = config["background"];
+	if (bgConfig.isVector() && !bgConfig.Vector().empty())
+		background = std::make_shared<CPicture>(ImagePath::fromJson(*RandomGeneratorUtil::nextItem(bgConfig.Vector(), CRandomGenerator::getDefault())));
+
+	if (bgConfig.isString())
+		background = std::make_shared<CPicture>(ImagePath::fromJson(bgConfig));
+
 	if(config["scalable"].Bool())
 		background->scaleTo(GH.screenDimensions());
 


### PR DESCRIPTION
Adds ability to use random main menu background image in same logic as is for scenario selection or loading screen.

Single backgound in mainmenu.json as is
```
	"window":
	{
		"background" : "gamselbk0",
	}
```

Multiple random backgrounds
```
	"window":
	{
		"background" : ["gamselbk0", "gamselbk1"],
	}
```