### PR TITLE
Replace random hero info in scenario info window with generated hero data

### DIFF
--- a/lib/gameState/CGameState.cpp
+++ b/lib/gameState/CGameState.cpp
@@ -566,7 +566,7 @@ void CGameState::placeStartingHeroes()
 				continue;
 
 			HeroTypeID heroTypeId = pickNextHeroType(playerColor);
-			if(playerSettingPair.second.hero == HeroTypeID::NONE)
+			if(playerSettingPair.second.hero == HeroTypeID::NONE || playerSettingPair.second.hero == HeroTypeID::RANDOM)
 				playerSettingPair.second.hero = heroTypeId;
 
 			placeStartingHero(playerColor, HeroTypeID(heroTypeId), playerInfo.posOfMainTown);


### PR DESCRIPTION
Random heroes in scenario info get properly replaced with their identities after map starts
![image](https://github.com/user-attachments/assets/6bec0e37-dd31-42f7-93ac-b20d4c571281)
