### PR TITLE
[1.6.x] clear generated assets only on client

### DIFF
--- a/client/render/AssetGenerator.cpp
+++ b/client/render/AssetGenerator.cpp
@@ -22,10 +22,18 @@
 #include "../lib/GameSettings.h"
 #include "../lib/IGameSettings.h"
 #include "../lib/json/JsonNode.h"
+#include "../lib/VCMIDirs.h"
 #include "../lib/VCMI_Lib.h"
 #include "../lib/RiverHandler.h"
 #include "../lib/RoadHandler.h"
 #include "../lib/TerrainHandler.h"
+
+void AssetGenerator::clear()
+{
+	// clear to avoid non updated sprites after mod change (if base imnages are used)
+	if(boost::filesystem::is_directory(VCMIDirs::get().userDataPath() / "Generated"))
+		boost::filesystem::remove_all(VCMIDirs::get().userDataPath() / "Generated");
+}
 
 void AssetGenerator::generateAll()
 {

--- a/client/render/AssetGenerator.h
+++ b/client/render/AssetGenerator.h
@@ -16,6 +16,7 @@ VCMI_LIB_NAMESPACE_END
 class AssetGenerator
 {
 public:
+	static void clear();
 	static void generateAll();
 	static void createAdventureOptionsCleanBackground();
 	static void createBigSpellBook();

--- a/clientapp/EntryPoint.cpp
+++ b/clientapp/EntryPoint.cpp
@@ -27,6 +27,7 @@
 #include "../client/media/CMusicHandler.h"
 #include "../client/media/CSoundHandler.h"
 #include "../client/media/CVideoHandler.h"
+#include "../client/render/AssetGenerator.h"
 #include "../client/render/Graphics.h"
 #include "../client/render/IRenderHandler.h"
 #include "../client/render/IScreenHandler.h"
@@ -230,6 +231,8 @@ int main(int argc, char * argv[])
 	logGlobal->info("Starting client of '%s'", GameConstants::VCMI_VERSION);
 	logGlobal->info("Creating console and configuring logger: %d ms", pomtime.getDiff());
 	logGlobal->info("The log file will be saved to %s", logPath);
+
+	AssetGenerator::clear();
 
 	// Init filesystem and settings
 	try

--- a/lib/filesystem/Filesystem.cpp
+++ b/lib/filesystem/Filesystem.cpp
@@ -183,8 +183,6 @@ void CResourceHandler::initialize()
 	knownLoaders["saves"] = new CFilesystemLoader("SAVES/", VCMIDirs::get().userSavePath());
 	knownLoaders["config"] = new CFilesystemLoader("CONFIG/", VCMIDirs::get().userConfigPath());
 
-	if(boost::filesystem::is_directory(VCMIDirs::get().userDataPath() / "Generated"))
-		boost::filesystem::remove_all(VCMIDirs::get().userDataPath() / "Generated");
 	knownLoaders["gen_data"] = new CFilesystemLoader("DATA/", VCMIDirs::get().userDataPath() / "Generated" / "Data");
 	knownLoaders["gen_sprites"] = new CFilesystemLoader("SPRITES/", VCMIDirs::get().userDataPath() / "Generated" / "Sprites");
 


### PR DESCRIPTION
avoids deleting by starting launcher or mapeditor

related #5233