### PR TITLE
Fix several 404 links in documentation

### DIFF
--- a/docs/developers/Building_Android.md
+++ b/docs/developers/Building_Android.md
@@ -28,7 +28,7 @@ git clone --recurse-submodules https://github.com/vcmi/vcmi.git
 
 ## Obtaining dependencies
 
-We use Conan package manager to build/consume dependencies, find detailed usage instructions [here](./Conan.md). Note that the link points to the state of the current branch, for the latest release check the same document in the [master branch](https://github.com/vcmi/vcmi/blob/master/docs/developers/Сonan.md).
+We use Conan package manager to build/consume dependencies, find detailed usage instructions [here](./Conan.md). Note that the link points to the state of the current branch, for the latest release check the same document in the [master branch](https://github.com/vcmi/vcmi/blob/master/docs/developers/Conan.md).
 
 On the step where you need to replace **PROFILE**, choose:
 

--- a/docs/developers/Building_iOS.md
+++ b/docs/developers/Building_iOS.md
@@ -20,7 +20,7 @@ git clone --recurse-submodules https://github.com/vcmi/vcmi.git
 
 There are 2 ways to get prebuilt dependencies:
 
-- [Conan package manager](./Conan.md) - recommended. Note that the link points to the state of the current branch, for the latest release check the same document in the [master branch](https://github.com/vcmi/vcmi/blob/master/docs/developers/Сonan.md).
+- [Conan package manager](./Conan.md) - recommended. Note that the link points to the state of the current branch, for the latest release check the same document in the [master branch](https://github.com/vcmi/vcmi/blob/master/docs/developers/Conan.md).
 - [legacy manually built libraries](https://github.com/vcmi/vcmi-ios-deps) - can be used if you have Xcode 11/12 or to build for simulator / armv7 device
 
 ## Configuring project

--- a/docs/developers/Building_macOS.md
+++ b/docs/developers/Building_macOS.md
@@ -25,7 +25,7 @@ There're 2 ways to get dependencies automatically.
 
 ### Conan package manager
 
-Please find detailed instructions [here](./Conan.md). Note that the link points to the state of the current branch, for the latest release check the same document in the [master branch](https://github.com/vcmi/vcmi/blob/master/docs/developers/Сonan.md).
+Please find detailed instructions [here](./Conan.md). Note that the link points to the state of the current branch, for the latest release check the same document in the [master branch](https://github.com/vcmi/vcmi/blob/master/docs/developers/Conan.md).
 
 On the step where you need to replace **PROFILE**, choose:
 
@@ -76,7 +76,7 @@ Note that if you wish to use Qt Creator IDE, you should skip this step and confi
 
 ## Building project
 
-You must also install game files to be able to run the built version, see [Installation on macOS](players/Installation_macOS.md).
+You must also install game files to be able to run the built version, see [Installation on macOS](../players/Installation_macOS.md).
 
 ### From Xcode IDE
 

--- a/docs/developers/Networking.md
+++ b/docs/developers/Networking.md
@@ -82,7 +82,7 @@ Notes:
 
 #### Joining a game room
 
-See [#Proxy mode](proxy-mode)
+See [#Proxy mode](#proxy-mode)
 
 #### Leaving a game room
 

--- a/docs/developers/Serialization.md
+++ b/docs/developers/Serialization.md
@@ -33,7 +33,7 @@ It's not "really" portable, yet it works properly across all platforms we curren
 
 #### Pointers
 
-Storing pointers mechanics can be and almost always is customized. See [#Additional features](additional-features).
+Storing pointers mechanics can be and almost always is customized. See [#Additional features](#additional-features).
 
 In the most basic form storing pointer simply sends the object state and loading pointer allocates an object (using "new" operator) and fills its state with the stored data.
 

--- a/docs/modders/Difficulty.md
+++ b/docs/modders/Difficulty.md
@@ -3,7 +3,7 @@
 Since VCMI 1.4.0 there are more capabilities to configure difficulty parameters.
 It means, that modders can give different bonuses to AI or human players depending on selected difficulty
 
-Difficulty configuration is located in [config/difficulty.json](../config/difficulty.json) file and can be overridden by mods.
+Difficulty configuration is located in [config/difficulty.json](../../config/difficulty.json) file and can be overridden by mods.
 
 ## Format summary
 

--- a/docs/modders/Map_Objects/Flaggable.md
+++ b/docs/modders/Map_Objects/Flaggable.md
@@ -4,7 +4,7 @@ Flaggable object are those that can be captured by a visiting hero. H3 examples 
 
 Currently, it is possible to make flaggable objects that provide player with:
 
-- Any [Bonus](Bonus_Format.md) supported by bonus system
+- Any [Bonus](../Bonus_Format.md) supported by bonus system
 - Daily resources income (wood, ore, gold, etc)
 
 ## Format description

--- a/docs/modders/Mod_File_Format.md
+++ b/docs/modders/Mod_File_Format.md
@@ -193,7 +193,7 @@ These are fields that are present only in local mod.json file
 ## Translation fields
 
 In addition to field listed above, it is possible to add following block for any language supported by VCMI. If such block is present, Launcher will use this information for displaying translated mod information and game will use provided json files to translate mod to specified language.
-See [Translations](Translations.md) for more information
+See [Translations](../translators/Translations.md) for more information
 
 ```json
 	"<language>" : {
@@ -228,4 +228,4 @@ These are fields that are present only in remote repository and are generally no
 For mod description it is possible to use certain subset of HTML as
 described here:
 
-<http://qt-project.org/doc/qt-5.0/qtgui/richtext-html-subset.html>
+<https://doc.qt.io/qt-6/richtext-html-subset.html>

--- a/docs/modders/Readme.md
+++ b/docs/modders/Readme.md
@@ -74,7 +74,7 @@ Map objects:
 - - [Rewardable](Map_Objects/Rewardable.md)
 - - [Creature Bank](Map_Objects/Creature_Bank.md)
 - - [Dwelling](Map_Objects/Dwelling.md)
-- - [Market](Map_Objects/Markets.md)
+- - [Market](Map_Objects/Market.md)
 - - [Boat](Map_Objects/Boat.md)
 
 Other:

--- a/docs/players/Game_Mechanics.md
+++ b/docs/players/Game_Mechanics.md
@@ -23,7 +23,7 @@ Some of game features have already been extended in comparison to Shadow of Deat
 - Heroes can have primary stats up to 2^16.
 - Unlimited backpack (by default). This can be toggled off to restore original 64-slot backpack limit.
 
-The list of implemented cheat codes and console commands is [here](Cheat_codes.md).
+The list of implemented cheat codes and console commands is [here](Cheat_Codes.md).
 
 ## New mechanics (Optional)
 

--- a/docs/players/Installation_Linux.md
+++ b/docs/players/Installation_Linux.md
@@ -63,7 +63,7 @@ Stable VCMI version is available in RPM Fusion repository. Learn how to enable i
 
 Latest public release build can be installed via Flatpak.
 
-Depending on your distribution, you may need to install flatpak itself. You can find guide for your distribution here: <https://www.flatpak.org/setup/>
+Depending on your distribution, you may need to install flatpak itself. You can find guide for your distribution here: <https://flatpak.org/setup/>
 Once you have flatpak, you can install VCMI package which can be found here: <https://flathub.org/apps/details/eu.vcmi.VCMI>
 
 ### Other distributions


### PR DESCRIPTION
A broken link was reported on Discord, run automated check and found a bunch of other similar cases.
Unfortunately that tool produces multiple false positives for external links for some reasons so not including it into CI