### PR TITLE
add workflow to notify other repos about new release

### DIFF
--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -1,0 +1,16 @@
+name: Notify other repos of release
+on:
+  release:
+    types: [published]
+jobs:
+  notify_repos:
+    if: ${{ !github.event.release.prerelease }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Repository Dispatch only for releases
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.HOMEBREW_TOKEN_SECRET }}
+          repository: vcmi/homebrew-vcmi
+          event-type: on-release
+          client-payload: '{"release": ${{ toJson(github.event.release) }}}'


### PR DESCRIPTION
only Homebrew repo for now

This workflow would trigger whenever a new VCMI release is published on GitHub notifying interested repos about it.

I've tested this approach on 2 test repos of my own:
- upstream repo / release publisher: https://github.com/kambala-decapitator/workflow-test/blob/main/.github/workflows/on-release.yml
- downstream repo / release event listener: https://github.com/kambala-decapitator/repository_dispatch_test/blob/main/.github/workflows/blank.yml

The workflow has already been added to the Homebrew repo: https://github.com/vcmi/homebrew-vcmi/blob/main/.github/workflows/vcmi-release.yml