### PR TITLE
Fixes for bugs for 1.6.4

### DIFF
--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -164,10 +164,10 @@ void CPlayerInterface::initGameInterface(std::shared_ptr<Environment> ENV, std::
 	cb = CB;
 	env = ENV;
 
+	pathfinderCache = std::make_unique<PathfinderCache>(cb.get(), PathfinderOptions(cb.get()));
 	CCS->musich->loadTerrainMusicThemes();
 	initializeHeroTownList();
 
-	pathfinderCache = std::make_unique<PathfinderCache>(cb.get(), PathfinderOptions(cb.get()));
 	adventureInt.reset(new AdventureMapInterface());
 }
 

--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -628,7 +628,6 @@ void CPlayerInterface::buildChanged(const CGTownInstance *town, BuildingID build
 			switch(what)
 			{
 			case 1:
-				CCS->soundh->playSound(soundBase::newBuilding);
 				castleInt->addBuilding(buildingID);
 				break;
 			case 2:
@@ -1415,7 +1414,6 @@ void CPlayerInterface::newObject( const CGObjectInstance * obj )
 		&& LOCPLINT->castleInt
 		&&  obj->visitablePos() == LOCPLINT->castleInt->town->bestLocation())
 	{
-		CCS->soundh->playSound(soundBase::newBuilding);
 		LOCPLINT->castleInt->addBuilding(BuildingID::SHIP);
 	}
 }

--- a/client/globalLobby/GlobalLobbyClient.cpp
+++ b/client/globalLobby/GlobalLobbyClient.cpp
@@ -171,7 +171,7 @@ void GlobalLobbyClient::receiveChatMessage(const JsonNode & json)
 		lobbyWindowPtr->onGameChatMessage(message.displayName, message.messageText, message.timeFormatted, channelType, channelName);
 		lobbyWindowPtr->refreshChatText();
 
-		if(channelType == "player" || lobbyWindowPtr->isChannelOpen(channelType, channelName))
+		if(channelType == "player" || (lobbyWindowPtr->isChannelOpen(channelType, channelName) && lobbyWindowPtr->isActive()))
 			CCS->soundh->playSound(AudioPath::builtin("CHAT"));
 	}
 }

--- a/client/renderSDL/SDLImage.cpp
+++ b/client/renderSDL/SDLImage.cpp
@@ -252,7 +252,7 @@ SDLImageShared::SDLImageShared(const SDLImageShared * from, int integerScaleFact
 
 	upscalingInProgress = true;
 
-	auto scaler = std::make_shared<SDLImageScaler>(from->surf, Rect(from->margins, from->fullSize));
+	auto scaler = std::make_shared<SDLImageScaler>(from->surf, Rect(from->margins, from->fullSize), true);
 
 	const auto & scalingTask = [this, algorithm, scaler]()
 	{
@@ -278,7 +278,7 @@ std::shared_ptr<const ISharedImage> SDLImageShared::scaleTo(const Point & size, 
 	if (palette && surf->format->palette)
 		SDL_SetSurfacePalette(surf, palette);
 
-	SDLImageScaler scaler(surf, Rect(margins, fullSize));
+	SDLImageScaler scaler(surf, Rect(margins, fullSize), true);
 
 	scaler.scaleSurface(size, EScalingAlgorithm::XBRZ_ALPHA);
 

--- a/client/renderSDL/SDLImageScaler.cpp
+++ b/client/renderSDL/SDLImageScaler.cpp
@@ -196,16 +196,25 @@ void SDLImageScaler::scaleSurfaceIntegerFactor(int factor, EScalingAlgorithm alg
 }
 
 SDLImageScaler::SDLImageScaler(SDL_Surface * surf)
-	:SDLImageScaler(surf, Rect(0,0,surf->w, surf->h))
+	:SDLImageScaler(surf, Rect(0,0,surf->w, surf->h), false)
 {
 }
 
-SDLImageScaler::SDLImageScaler(SDL_Surface * surf, const Rect & virtualDimensions)
+SDLImageScaler::SDLImageScaler(SDL_Surface * surf, const Rect & virtualDimensions, bool optimizeImage)
 {
-	SDLImageOptimizer optimizer(surf, virtualDimensions);
-	optimizer.optimizeSurface(screen);
-	intermediate = optimizer.acquireResultSurface();
-	virtualDimensionsInput = optimizer.getResultDimensions();
+	if (optimizeImage)
+	{
+		SDLImageOptimizer optimizer(surf, virtualDimensions);
+		optimizer.optimizeSurface(screen);
+		intermediate = optimizer.acquireResultSurface();
+		virtualDimensionsInput = optimizer.getResultDimensions();
+	}
+	else
+	{
+		intermediate = surf;
+		intermediate->refcount += 1;
+		virtualDimensionsInput = virtualDimensions;
+	}
 
 	if (intermediate == surf)
 	{

--- a/client/renderSDL/SDLImageScaler.h
+++ b/client/renderSDL/SDLImageScaler.h
@@ -43,7 +43,7 @@ class SDLImageScaler : boost::noncopyable
 
 public:
 	SDLImageScaler(SDL_Surface * surf);
-	SDLImageScaler(SDL_Surface * surf, const Rect & virtualDimensions);
+	SDLImageScaler(SDL_Surface * surf, const Rect & virtualDimensions, bool optimizeImage);
 	~SDLImageScaler();
 
 	/// Performs upscaling or downscaling to a requested dimensions

--- a/client/windows/CCastleInterface.cpp
+++ b/client/windows/CCastleInterface.cpp
@@ -24,6 +24,7 @@
 #include "../gui/Shortcut.h"
 #include "../gui/WindowHandler.h"
 #include "../media/IMusicPlayer.h"
+#include "../media/ISoundPlayer.h"
 #include "../widgets/MiscWidgets.h"
 #include "../widgets/CComponent.h"
 #include "../widgets/CGarrisonInt.h"
@@ -1435,6 +1436,9 @@ void CCastleInterface::townChange()
 
 void CCastleInterface::addBuilding(BuildingID bid)
 {
+	if (town->getTown()->buildings.at(bid)->mode != CBuilding::BUILD_AUTO)
+		CCS->soundh->playSound(soundBase::newBuilding);
+
 	deactivate();
 	builds->addBuilding(bid);
 	recreateIcons();

--- a/config/creatures/special.json
+++ b/config/creatures/special.json
@@ -48,6 +48,10 @@
 			{
 				"type" : "SHOOTER"
 			},
+			"noDistancePenalty" :
+			{
+				"type" : "NO_DISTANCE_PENALTY" // hide shooting range visualization
+			},
 			"siegeMachine" :
 			{
 				"type" : "CATAPULT",

--- a/lib/battle/BattleHex.h
+++ b/lib/battle/BattleHex.h
@@ -267,6 +267,12 @@ public:
 		return hex < other.hex;
 	}
 
+	[[nodiscard]] bool operator <=(const BattleHex & other) const noexcept
+	{
+		return hex <= other.hex;
+	}
+
+
 	template <typename Handler>
 	void serialize(Handler & h)
 	{

--- a/lib/battle/CBattleInfoCallback.cpp
+++ b/lib/battle/CBattleInfoCallback.cpp
@@ -51,7 +51,7 @@ static bool sameSideOfWall(const BattleHex & pos1, const BattleHex & pos2)
 
 static bool isInsideWalls(const BattleHex & pos)
 {
-	return lineToWallHex(pos.getY()) < pos;
+	return lineToWallHex(pos.getY()) <= pos;
 }
 
 // parts of wall

--- a/lib/battle/CUnitState.cpp
+++ b/lib/battle/CUnitState.cpp
@@ -605,17 +605,18 @@ uint8_t CUnitState::getRangedFullDamageDistance() const
 	if(!isShooter())
 		return 0;
 
-	uint8_t rangedFullDamageDistance = GameConstants::BATTLE_SHOOTING_PENALTY_DISTANCE;
-
 	// overwrite full ranged damage distance with the value set in Additional info field of LIMITED_SHOOTING_RANGE bonus
 	if(hasBonusOfType(BonusType::LIMITED_SHOOTING_RANGE))
 	{
 		auto bonus = this->getBonus(Selector::type()(BonusType::LIMITED_SHOOTING_RANGE));
 		if(bonus != nullptr && bonus->additionalInfo != CAddInfo::NONE)
-			rangedFullDamageDistance = bonus->additionalInfo[0];
+			return bonus->additionalInfo[0];
 	}
 
-	return rangedFullDamageDistance;
+	if (hasBonusOfType(BonusType::NO_DISTANCE_PENALTY))
+		return GameConstants::BATTLE_SHOOTING_RANGE_DISTANCE;
+
+	return GameConstants::BATTLE_SHOOTING_PENALTY_DISTANCE;
 }
 
 uint8_t CUnitState::getShootingRangeDistance() const

--- a/lobby/LobbyServer.cpp
+++ b/lobby/LobbyServer.cpp
@@ -325,7 +325,7 @@ void LobbyServer::onDisconnected(const NetworkConnectionPtr & connection, const 
 
 	if(activeProxies.count(connection))
 	{
-		const auto & otherConnection = activeProxies.at(connection);
+		const auto otherConnection = activeProxies.at(connection);
 
 		if (otherConnection)
 			otherConnection->close();


### PR DESCRIPTION
- Fix crash on loading saved game - regression from pathfinding PR
- Fix potential use-after-free in global lobby server - already deployed on server
- Fix corrupted display of H3 bitmap fonts if xbrz is in use
- Do not play sound on new chat message in global chat unless lobby UI is open