### PR TITLE
[1.6.4] Workarounds for crashes from Google Play

### DIFF
--- a/lib/battle/BattleHex.h
+++ b/lib/battle/BattleHex.h
@@ -118,7 +118,7 @@ public:
 		if(hasToBeValid)
 		{
 			if(x < 0 || x >= GameConstants::BFIELD_WIDTH || y < 0 || y >= GameConstants::BFIELD_HEIGHT)
-				throw std::runtime_error("Valid hex required");
+				throw std::runtime_error("Hex at (" + std::to_string(x) + ", " + std::to_string(y) + ") is not valid!");
 		}
 
 		hex = x + y * GameConstants::BFIELD_WIDTH;


### PR DESCRIPTION
- Do not crash on failure to read recently created file from disk. Will look for more permanent solution for 1.6.5
- Add more debug information for crash on BattleHex access