### PR TITLE
Fix excessive paths updates when using Fly/Water Walk

### DIFF
--- a/client/adventureMap/AdventureMapInterface.cpp
+++ b/client/adventureMap/AdventureMapInterface.cpp
@@ -107,9 +107,6 @@ void AdventureMapInterface::onHeroMovementStarted(const CGHeroInstance * hero)
 
 void AdventureMapInterface::onHeroChanged(const CGHeroInstance *h)
 {
-	if (h)
-		LOCPLINT->localState->verifyPath(h);
-
 	widget->getHeroList()->updateElement(h);
 
 	if (h && h == LOCPLINT->localState->getCurrentHero() && !widget->getInfoBar()->showingComponents())


### PR DESCRIPTION
- Fixes hero stuck on water when water walk / fly is used
- Fixes hero stopping on top of enemy hero when attacking enemy town with hero while moving from top using fly