### PR TITLE
[1.6.5] In-memory assets generation

### DIFF
--- a/client/ClientCommandManager.cpp
+++ b/client/ClientCommandManager.cpp
@@ -18,7 +18,6 @@
 #include "gui/CGuiHandler.h"
 #include "gui/WindowHandler.h"
 #include "render/IRenderHandler.h"
-#include "render/AssetGenerator.h"
 #include "ClientNetPackVisitors.h"
 #include "../lib/CConfigHandler.h"
 #include "../lib/gameState/CGameState.h"
@@ -510,7 +509,7 @@ void ClientCommandManager::handleVsLog(std::istringstream & singleWordBuffer)
 
 void ClientCommandManager::handleGenerateAssets()
 {
-	AssetGenerator::generateAll();
+	GH.renderHandler().exportGeneratedAssets();
 	printCommandMessage("All assets generated");
 }
 

--- a/client/adventureMap/AdventureMapInterface.cpp
+++ b/client/adventureMap/AdventureMapInterface.cpp
@@ -34,7 +34,6 @@
 #include "../render/IImage.h"
 #include "../render/IRenderHandler.h"
 #include "../render/IScreenHandler.h"
-#include "../render/AssetGenerator.h"
 #include "../CMT.h"
 #include "../PlayerLocalState.h"
 #include "../CPlayerInterface.h"
@@ -64,8 +63,6 @@ AdventureMapInterface::AdventureMapInterface():
 	pos.x = pos.y = 0;
 	pos.w = GH.screenDimensions().x;
 	pos.h = GH.screenDimensions().y;
-
-	AssetGenerator::createPaletteShiftedSprites();
 
 	shortcuts = std::make_shared<AdventureMapShortcuts>(*this);
 

--- a/client/battle/BattleStacksController.cpp
+++ b/client/battle/BattleStacksController.cpp
@@ -27,7 +27,6 @@
 #include "../gui/CGuiHandler.h"
 #include "../gui/WindowHandler.h"
 #include "../media/ISoundPlayer.h"
-#include "../render/AssetGenerator.h"
 #include "../render/Colors.h"
 #include "../render/Canvas.h"
 #include "../render/IRenderHandler.h"
@@ -80,7 +79,6 @@ BattleStacksController::BattleStacksController(BattleInterface & owner):
 	stackToActivate(nullptr),
 	animIDhelper(0)
 {
-	AssetGenerator::createCombatUnitNumberWindow();
 	//preparing graphics for displaying amounts of creatures
 	amountNormal     = GH.renderHandler().loadImage(ImagePath::builtin("combatUnitNumberWindowDefault"), EImageBlitMode::COLORKEY);
 	amountPositive   = GH.renderHandler().loadImage(ImagePath::builtin("combatUnitNumberWindowPositive"), EImageBlitMode::COLORKEY);

--- a/client/lobby/OptionsTabBase.cpp
+++ b/client/lobby/OptionsTabBase.cpp
@@ -18,7 +18,6 @@
 #include "../widgets/TextControls.h"
 #include "../CServerHandler.h"
 #include "../CGameInfo.h"
-#include "../render/AssetGenerator.h"
 
 #include "../../lib/StartInfo.h"
 #include "../../lib/texts/CGeneralTextHandler.h"
@@ -69,8 +68,6 @@ std::vector<SimturnsInfo> OptionsTabBase::getSimturnsPresets() const
 
 OptionsTabBase::OptionsTabBase(const JsonPath & configPath)
 {
-	AssetGenerator::createAdventureOptionsCleanBackground();
-
 	recActions = 0;
 
 	auto setTimerPresetCallback = [this](int index){

--- a/client/mainmenu/CMainMenu.cpp
+++ b/client/mainmenu/CMainMenu.cpp
@@ -38,7 +38,6 @@
 #include "../widgets/VideoWidget.h"
 #include "../windows/InfoWindows.h"
 #include "../CServerHandler.h"
-#include "../render/AssetGenerator.h"
 
 #include "../CGameInfo.h"
 #include "../CPlayerInterface.h"
@@ -427,9 +426,6 @@ void CMainMenu::openCampaignLobby(std::shared_ptr<CampaignState> campaign)
 void CMainMenu::openCampaignScreen(std::string name)
 {
 	auto const & config = CMainMenuConfig::get().getCampaigns();
-
-	AssetGenerator::createCampaignBackground();
-	AssetGenerator::createChroniclesCampaignImages();
 
 	if(!vstd::contains(config.Struct(), name))
 	{

--- a/client/render/AssetGenerator.h
+++ b/client/render/AssetGenerator.h
@@ -9,20 +9,53 @@
  */
 #pragma once
 
+#include "ImageLocator.h"
+
 VCMI_LIB_NAMESPACE_BEGIN
 class PlayerColor;
 VCMI_LIB_NAMESPACE_END
 
+class ISharedImage;
+class CanvasImage;
+
 class AssetGenerator
 {
 public:
-	static void clear();
-	static void generateAll();
-	static void createAdventureOptionsCleanBackground();
-	static void createBigSpellBook();
-	static void createPlayerColoredBackground(const PlayerColor & player);
-	static void createCombatUnitNumberWindow();
-	static void createCampaignBackground();
-	static void createChroniclesCampaignImages();
-	static void createPaletteShiftedSprites();
+	using AnimationLayoutMap = std::map<size_t, std::vector<ImageLocator>>;
+	using CanvasPtr = std::shared_ptr<CanvasImage>;
+
+	AssetGenerator();
+
+	void initialize();
+
+	std::shared_ptr<ISharedImage> generateImage(const ImagePath & image);
+
+	std::map<ImagePath, std::shared_ptr<ISharedImage>> generateAllImages();
+	std::map<AnimationPath, AnimationLayoutMap> generateAllAnimations();
+
+private:
+	using ImageGenerationFunctor = std::function<CanvasPtr()>;
+
+	struct PaletteAnimation
+	{
+		/// index of first color to cycle
+		int32_t start;
+		/// total numbers of colors to cycle
+		int32_t length;
+	};
+
+	std::map<ImagePath, ImageGenerationFunctor> imageFiles;
+	std::map<AnimationPath, AnimationLayoutMap> animationFiles;
+
+	CanvasPtr createAdventureOptionsCleanBackground();
+	CanvasPtr createBigSpellBook();
+	CanvasPtr createPlayerColoredBackground(const PlayerColor & player);
+	CanvasPtr createCombatUnitNumberWindow(float multR, float multG, float multB);
+	CanvasPtr createCampaignBackground();
+	CanvasPtr createChroniclesCampaignImages(int chronicle);
+	CanvasPtr createPaletteShiftedImage(const AnimationPath & source, const std::vector<PaletteAnimation> & animation, int frameIndex, int paletteShiftCounter);
+
+	void createPaletteShiftedSprites();
+	void generatePaletteShiftedAnimation(const AnimationPath & source, const std::vector<PaletteAnimation> & animation);
+
 };

--- a/client/render/CanvasImage.cpp
+++ b/client/render/CanvasImage.cpp
@@ -14,6 +14,7 @@
 #include "../render/IScreenHandler.h"
 #include "../renderSDL/SDL_Extensions.h"
 #include "../renderSDL/SDLImageScaler.h"
+#include "../renderSDL/SDLImage.h"
 
 #include <SDL_image.h>
 #include <SDL_surface.h>
@@ -60,4 +61,9 @@ Rect CanvasImage::contentRect() const
 Point CanvasImage::dimensions() const
 {
 	return {surface->w, surface->h};
+}
+
+std::shared_ptr<ISharedImage> CanvasImage::toSharedImage()
+{
+	return std::make_shared<SDLImageShared>(surface);
 }

--- a/client/render/CanvasImage.h
+++ b/client/render/CanvasImage.h
@@ -34,6 +34,8 @@ public:
 	void shiftPalette(uint32_t firstColorID, uint32_t colorsToMove, uint32_t distanceToMove) override{};
 	void adjustPalette(const ColorFilter & shifter, uint32_t colorsToSkipMask) override{};
 
+	std::shared_ptr<ISharedImage> toSharedImage();
+
 private:
 	SDL_Surface * surface;
 	CanvasScalingPolicy scalingPolicy;

--- a/client/render/IRenderHandler.h
+++ b/client/render/IRenderHandler.h
@@ -50,4 +50,6 @@ public:
 
 	/// Returns font with specified identifer
 	virtual std::shared_ptr<const IFont> loadFont(EFonts font) = 0;
+
+	virtual void exportGeneratedAssets() = 0;
 };

--- a/client/renderSDL/RenderHandler.cpp
+++ b/client/renderSDL/RenderHandler.cpp
@@ -16,6 +16,7 @@
 
 #include "../gui/CGuiHandler.h"
 
+#include "../render/AssetGenerator.h"
 #include "../render/CAnimation.h"
 #include "../render/CanvasImage.h"
 #include "../render/CDefFile.h"
@@ -42,6 +43,13 @@
 #include <vcmi/Services.h>
 #include <vcmi/SkillService.h>
 #include <vcmi/spells/Service.h>
+
+RenderHandler::RenderHandler()
+	:assetGenerator(std::make_unique<AssetGenerator>())
+{
+}
+
+RenderHandler::~RenderHandler() = default;
 
 std::shared_ptr<CDefFile> RenderHandler::getAnimationFile(const AnimationPath & path)
 {
@@ -201,12 +209,28 @@ std::shared_ptr<ScalableImageShared> RenderHandler::loadImageImpl(const ImageLoc
 	return scaledImage;
 }
 
-std::shared_ptr<SDLImageShared> RenderHandler::loadImageFromFileUncached(const ImageLocator & locator)
+std::shared_ptr<ISharedImage> RenderHandler::loadImageFromFileUncached(const ImageLocator & locator)
 {
 	if(locator.image)
 	{
-		// TODO: create EmptySharedImage class that will be instantiated if image does not exists or fails to load
-		return std::make_shared<SDLImageShared>(*locator.image);
+		auto imagePath = *locator.image;
+		auto imagePathSprites = imagePath.addPrefix("SPRITES/");
+		auto imagePathData = imagePath.addPrefix("DATA/");
+
+		if(CResourceHandler::get()->existsResource(imagePathSprites))
+			return std::make_shared<SDLImageShared>(imagePathSprites);
+
+		if(CResourceHandler::get()->existsResource(imagePathData))
+			return std::make_shared<SDLImageShared>(imagePathData);
+
+		if(CResourceHandler::get()->existsResource(imagePath))
+			return std::make_shared<SDLImageShared>(imagePath);
+
+		auto generated = assetGenerator->generateImage(imagePath);
+		if (generated)
+			return generated;
+
+		return std::make_shared<SDLImageShared>(ImagePath::builtin("DEFAULT"));
 	}
 
 	if(locator.defFile)
@@ -423,6 +447,10 @@ static void detectOverlappingBuildings(RenderHandler * renderHandler, const Fact
 
 void RenderHandler::onLibraryLoadingFinished(const Services * services)
 {
+	assert(animationLayouts.empty());
+	assetGenerator->initialize();
+	animationLayouts = assetGenerator->generateAllAnimations();
+
 	addImageListEntries(services->creatures());
 	addImageListEntries(services->heroTypes());
 	addImageListEntries(services->artifacts());
@@ -468,4 +496,10 @@ std::shared_ptr<const IFont> RenderHandler::loadFont(EFonts font)
 
 	fonts[font] = loadedFont;
 	return loadedFont;
+}
+
+void RenderHandler::exportGeneratedAssets()
+{
+	for (const auto & entry : assetGenerator->generateAllImages())
+		entry.second->exportBitmap(VCMIDirs::get().userDataPath() / "Generated" / (entry.first.getOriginalName() + ".png"), nullptr);
 }

--- a/client/renderSDL/RenderHandler.h
+++ b/client/renderSDL/RenderHandler.h
@@ -18,8 +18,9 @@ VCMI_LIB_NAMESPACE_END
 class CDefFile;
 class SDLImageShared;
 class ScalableImageShared;
+class AssetGenerator;
 
-class RenderHandler : public IRenderHandler
+class RenderHandler final : public IRenderHandler
 {
 	using AnimationLayoutMap = std::map<size_t, std::vector<ImageLocator>>;
 
@@ -27,6 +28,7 @@ class RenderHandler : public IRenderHandler
 	std::map<AnimationPath, AnimationLayoutMap> animationLayouts;
 	std::map<SharedImageLocator, std::shared_ptr<ScalableImageShared>> imageFiles;
 	std::map<EFonts, std::shared_ptr<const IFont>> fonts;
+	std::unique_ptr<AssetGenerator> assetGenerator;
 
 	std::shared_ptr<CDefFile> getAnimationFile(const AnimationPath & path);
 	AnimationLayoutMap & getAnimationLayout(const AnimationPath & path, int scalingFactor, EImageBlitMode mode);
@@ -38,13 +40,15 @@ class RenderHandler : public IRenderHandler
 
 	std::shared_ptr<ScalableImageShared> loadImageImpl(const ImageLocator & config);
 
-	std::shared_ptr<SDLImageShared> loadImageFromFileUncached(const ImageLocator & locator);
+	std::shared_ptr<ISharedImage> loadImageFromFileUncached(const ImageLocator & locator);
 
 	ImageLocator getLocatorForAnimationFrame(const AnimationPath & path, int frame, int group, int scaling, EImageBlitMode mode);
 
 	int getScalingFactor() const;
 
 public:
+	RenderHandler();
+	~RenderHandler();
 
 	// IRenderHandler implementation
 	void onLibraryLoadingFinished(const Services * services) override;
@@ -61,4 +65,6 @@ public:
 
 	/// Returns font with specified identifer
 	std::shared_ptr<const IFont> loadFont(EFonts font) override;
+
+	void exportGeneratedAssets() override;
 };

--- a/client/renderSDL/SDLImage.cpp
+++ b/client/renderSDL/SDLImage.cpp
@@ -306,6 +306,10 @@ std::shared_ptr<const ISharedImage> SDLImageShared::scaleTo(const Point & size, 
 
 void SDLImageShared::exportBitmap(const boost::filesystem::path& path, SDL_Palette * palette) const
 {
+	auto directory = path;
+	directory.remove_filename();
+	boost::filesystem::create_directories(directory);
+
 	assert(upscalingInProgress == false);
 	if (!surf)
 		return;

--- a/client/widgets/Images.cpp
+++ b/client/widgets/Images.cpp
@@ -13,7 +13,6 @@
 #include "MiscWidgets.h"
 
 #include "../gui/CGuiHandler.h"
-#include "../render/AssetGenerator.h"
 #include "../render/IImage.h"
 #include "../render/IRenderHandler.h"
 #include "../render/CAnimation.h"
@@ -184,8 +183,6 @@ FilledTexturePlayerColored::FilledTexturePlayerColored(Rect position)
 
 void FilledTexturePlayerColored::setPlayerColor(PlayerColor player)
 {
-	AssetGenerator::createPlayerColoredBackground(player);
-
 	ImagePath imagePath = ImagePath::builtin("DialogBoxBackground_" + player.toString() + ".bmp");
 
 	texture = GH.renderHandler().loadImage(imagePath, EImageBlitMode::COLORKEY);

--- a/client/windows/CSpellWindow.cpp
+++ b/client/windows/CSpellWindow.cpp
@@ -32,7 +32,6 @@
 #include "../widgets/Buttons.h"
 #include "../widgets/VideoWidget.h"
 #include "../adventureMap/AdventureMapInterface.h"
-#include "../render/AssetGenerator.h"
 
 #include "../../CCallback.h"
 
@@ -118,7 +117,6 @@ CSpellWindow::CSpellWindow(const CGHeroInstance * _myHero, CPlayerInterface * _m
 
 	if(isBigSpellbook)
 	{
-		AssetGenerator::createBigSpellBook();
 		background = std::make_shared<CPicture>(ImagePath::builtin("SpellBookLarge"), 0, 0);
 		updateShadow();
 	}

--- a/clientapp/EntryPoint.cpp
+++ b/clientapp/EntryPoint.cpp
@@ -27,7 +27,6 @@
 #include "../client/media/CMusicHandler.h"
 #include "../client/media/CSoundHandler.h"
 #include "../client/media/CVideoHandler.h"
-#include "../client/render/AssetGenerator.h"
 #include "../client/render/Graphics.h"
 #include "../client/render/IRenderHandler.h"
 #include "../client/render/IScreenHandler.h"
@@ -234,8 +233,6 @@ int main(int argc, char * argv[])
 	logGlobal->info("Starting client of '%s'", GameConstants::VCMI_VERSION);
 	logGlobal->info("Creating console and configuring logger: %d ms", pomtime.getDiff());
 	logGlobal->info("The log file will be saved to %s", logPath);
-
-	AssetGenerator::clear();
 
 	// Init filesystem and settings
 	try


### PR DESCRIPTION
All assets generation (large spellbook, terrain animations, etc) are now done in memory and used as it, without saving to disk.

This should slightly improve load times since there is no encode png / decode png, and should help with avoiding strange bug when vcmi fails to load recently saved assets.

If needed, such assets can be force-dumped on disk using already existing console command