### PR TITLE
Hotfix for 1.6.4

### DIFF
--- a/android/vcmi-app/build.gradle
+++ b/android/vcmi-app/build.gradle
@@ -26,7 +26,7 @@ android {
 		minSdk = qtMinSdkVersion as Integer
 		targetSdk = qtTargetSdkVersion as Integer // ANDROID_TARGET_SDK_VERSION in the CMake project
 
-		versionCode 1640
+		versionCode 1642
 		versionName "1.6.4"
 
 		setProperty("archivesBaseName", "vcmi")

--- a/lib/battle/BattleHexArray.cpp
+++ b/lib/battle/BattleHexArray.cpp
@@ -32,9 +32,7 @@ void BattleHexArray::insert(const BattleHexArray & other) noexcept
 
 void BattleHexArray::clear() noexcept
 {
-	for(const auto & hex : internalStorage)
-		presenceFlags[hex.toInt()] = false;
-
+	presenceFlags = {};
 	internalStorage.clear();
 }
 

--- a/lib/battle/BattleHexArray.h
+++ b/lib/battle/BattleHexArray.h
@@ -126,7 +126,7 @@ public:
 		// reinit presence flags
 		presenceFlags = {};
 		for(const auto & hex : internalStorage)
-			presenceFlags.set(hex.toInt()) = true;
+			presenceFlags.set(hex.toInt());
 	}
 
 	void shuffle(vstd::RNG & rand)
@@ -239,7 +239,7 @@ public:
 		if(!s.saving)
 		{
 			for(const auto & hex : internalStorage)
-				presenceFlags.set(hex.toInt()) = true;
+				presenceFlags.set(hex.toInt());
 		}
 	}
 


### PR DESCRIPTION
Apparently this is legal code:
```cpp
presenceFlags.set(hex.toInt()) = true;
```
... and will result in bitset that has only 1st bit set to true due to multiple implicit conversions. Thank you, ISO.

And thanks to Manfred for noticing it. 