### PR TITLE
Fix VCMP campaign detection for buttons

### DIFF
--- a/client/mainmenu/CMainMenu.cpp
+++ b/client/mainmenu/CMainMenu.cpp
@@ -278,7 +278,7 @@ CMenuEntry::CMenuEntry(CMenuScreen * parent, const JsonNode & config)
 			for (const auto& item : campaign["items"].Vector()) {
 				std::string filename = item["file"].String();
 
-				if (CResourceHandler::get()->existsResource(ResourcePath(filename + ".h3c"))) {
+				if (CResourceHandler::get()->existsResource(ResourcePath(filename, EResType::CAMPAIGN))) {
 					fileExists = true;
 					break; 
 				}


### PR DESCRIPTION
Current logic was locked directly to H3C files. Now it should work fine for both H3C and VCMP.