### PR TITLE
map editor: fix resource reward in events

### DIFF
--- a/mapeditor/inspector/towneventdialog.cpp
+++ b/mapeditor/inspector/towneventdialog.cpp
@@ -230,10 +230,10 @@ QVariantMap TownEventDialog::resourcesToVariant()
 	auto res = params.value("resources").toMap();
 	for (int i = 0; i < GameConstants::RESOURCE_QUANTITY; ++i)
 	{
-		auto * itemType = ui->resourcesTable->item(i, 0);
+		auto itemType = QString::fromStdString(GameConstants::RESOURCE_NAMES[i]);
 		auto * itemQty = static_cast<QSpinBox *> (ui->resourcesTable->cellWidget(i, 1));
 
-		res[itemType->text()] = QVariant::fromValue(itemQty->value());
+		res[itemType] = QVariant::fromValue(itemQty->value());
 	}
 	return res;
 }

--- a/mapeditor/mapsettings/timedevent.cpp
+++ b/mapeditor/mapsettings/timedevent.cpp
@@ -96,9 +96,9 @@ void TimedEvent::on_TimedEvent_finished(int result)
 	auto res = target->data(Qt::UserRole).toMap().value("resources").toMap();
 	for(int i = 0; i < GameConstants::RESOURCE_QUANTITY; ++i)
 	{
-		auto * itemType = ui->resources->item(i, 0);
+		auto itemType = QString::fromStdString(GameConstants::RESOURCE_NAMES[i]);
 		auto * itemQty = ui->resources->item(i, 1);
-		res[itemType->text()] = QVariant::fromValue(itemQty->text().toInt());
+		res[itemType] = QVariant::fromValue(itemQty->text().toInt());
 	}
 	descriptor["resources"] = res;
 


### PR DESCRIPTION
Regression from 1.6.3, table now contains translated resource names so it cannot be used