### PR TITLE
[1.6.6?] Remove network connection from local games

### DIFF
--- a/client/CServerHandler.cpp
+++ b/client/CServerHandler.cpp
@@ -186,7 +186,7 @@ void CServerHandler::startLocalServerAndConnect(bool connectToLobby)
 	si->difficulty = lastDifficulty.Integer();
 
 	logNetwork->trace("\tStarting local server");
-	uint16_t srvport = serverRunner->start(getLocalPort(), connectToLobby, si);
+	uint16_t srvport = serverRunner->start(getLocalPort(), loadMode == ELoadMode::MULTI, connectToLobby, si);
 	logNetwork->trace("\tConnecting to local server");
 	connectToServer(getLocalHostname(), srvport);
 	logNetwork->trace("\tWaiting for connection");

--- a/client/CServerHandler.cpp
+++ b/client/CServerHandler.cpp
@@ -186,9 +186,9 @@ void CServerHandler::startLocalServerAndConnect(bool connectToLobby)
 	si->difficulty = lastDifficulty.Integer();
 
 	logNetwork->trace("\tStarting local server");
-	uint16_t srvport = serverRunner->start(getLocalPort(), loadMode == ELoadMode::MULTI, connectToLobby, si);
+	serverRunner->start(loadMode == ELoadMode::MULTI, connectToLobby, si);
 	logNetwork->trace("\tConnecting to local server");
-	connectToServer(getLocalHostname(), srvport);
+	connectToServer(getLocalHostname(), getLocalPort());
 	logNetwork->trace("\tWaiting for connection");
 }
 
@@ -211,7 +211,7 @@ void CServerHandler::connectToServer(const std::string & addr, const ui16 port)
 	}
 	else
 	{
-		serverRunner->connect(*networkHandler, *this, addr, port);
+		serverRunner->connect(*networkHandler, *this);
 	}
 }
 
@@ -249,7 +249,7 @@ void CServerHandler::onTimer()
 	}
 
 	assert(isServerLocal());
-	serverRunner->connect(*networkHandler, *this, getLocalHostname(), getLocalPort());
+	serverRunner->connect(*networkHandler, *this);
 }
 
 void CServerHandler::onConnectionEstablished(const NetworkConnectionPtr & netConnection)

--- a/client/CServerHandler.cpp
+++ b/client/CServerHandler.cpp
@@ -206,9 +206,13 @@ void CServerHandler::connectToServer(const std::string & addr, const ui16 port)
 
 		Settings remotePort = settings.write["server"]["remotePort"];
 		remotePort->Integer() = port;
-	}
 
-	networkHandler->connectToRemote(*this, addr, port);
+		networkHandler->connectToRemote(*this, addr, port);
+	}
+	else
+	{
+		serverRunner->connect(*networkHandler, *this, addr, port);
+	}
 }
 
 void CServerHandler::onConnectionFailed(const std::string & errorMessage)
@@ -245,7 +249,7 @@ void CServerHandler::onTimer()
 	}
 
 	assert(isServerLocal());
-	networkHandler->connectToRemote(*this, getLocalHostname(), getLocalPort());
+	serverRunner->connect(*networkHandler, *this, getLocalHostname(), getLocalPort());
 }
 
 void CServerHandler::onConnectionEstablished(const NetworkConnectionPtr & netConnection)

--- a/client/ServerRunner.cpp
+++ b/client/ServerRunner.cpp
@@ -34,7 +34,7 @@
 ServerThreadRunner::ServerThreadRunner() = default;
 ServerThreadRunner::~ServerThreadRunner() = default;
 
-uint16_t ServerThreadRunner::start(uint16_t cfgport, bool connectToLobby, std::shared_ptr<StartInfo> startingInfo)
+uint16_t ServerThreadRunner::start(uint16_t cfgport, bool listenForConnections, bool connectToLobby, std::shared_ptr<StartInfo> startingInfo)
 {
 	// cfgport may be 0 -- the real port is returned after calling prepare()
 	server = std::make_unique<CVCMIServer>(cfgport, true);
@@ -46,9 +46,9 @@ uint16_t ServerThreadRunner::start(uint16_t cfgport, bool connectToLobby, std::s
 
 	std::promise<uint16_t> promise;
 
-	threadRunLocalServer = boost::thread([this, connectToLobby, &promise]{
+	threadRunLocalServer = boost::thread([this, connectToLobby, listenForConnections, &promise]{
 		setThreadName("runServer");
-		uint16_t port = server->prepare(connectToLobby);
+		uint16_t port = server->prepare(connectToLobby, listenForConnections);
 		promise.set_value(port);
 		server->run();
 	});
@@ -100,7 +100,7 @@ int ServerProcessRunner::exitCode()
 	return child->exit_code();
 }
 
-uint16_t ServerProcessRunner::start(uint16_t port, bool connectToLobby, std::shared_ptr<StartInfo> startingInfo)
+uint16_t ServerProcessRunner::start(uint16_t port, bool listenForConnections, bool connectToLobby, std::shared_ptr<StartInfo> startingInfo)
 {
 	boost::filesystem::path serverPath = VCMIDirs::get().serverPath();
 	boost::filesystem::path logPath = VCMIDirs::get().userLogsPath() / "server_log.txt";

--- a/client/ServerRunner.cpp
+++ b/client/ServerRunner.cpp
@@ -13,6 +13,7 @@
 
 #include "../lib/VCMIDirs.h"
 #include "../lib/CThreadHelper.h"
+#include "../lib/network/NetworkInterface.h"
 #include "../server/CVCMIServer.h"
 
 #ifdef ENABLE_SERVER_PROCESS
@@ -74,6 +75,11 @@ int ServerThreadRunner::exitCode()
 	return 0;
 }
 
+void ServerThreadRunner::connect(INetworkHandler & network, INetworkClientListener & listener, const std::string & host, uint16_t port)
+{
+	network.createInternalConnection(listener, server->getNetworkServer());
+}
+
 #ifdef ENABLE_SERVER_PROCESS
 
 ServerProcessRunner::ServerProcessRunner() = default;
@@ -111,6 +117,11 @@ uint16_t ServerProcessRunner::start(uint16_t port, bool connectToLobby, std::sha
 		throw std::runtime_error("Failed to start server! Reason: " + ec.message());
 
 	return port;
+}
+
+void ServerProcessRunner::connect(INetworkHandler & network, INetworkClientListener & listener, const std::string & host, uint16_t port)
+{
+	network.connectToRemote(listener, host, port);
 }
 
 #endif

--- a/client/ServerRunner.h
+++ b/client/ServerRunner.h
@@ -22,12 +22,12 @@ class CVCMIServer;
 class IServerRunner
 {
 public:
-	virtual uint16_t start(uint16_t port, bool listenForConnections, bool connectToLobby, std::shared_ptr<StartInfo> startingInfo) = 0;
+	virtual void start(bool listenForConnections, bool connectToLobby, std::shared_ptr<StartInfo> startingInfo) = 0;
 	virtual void shutdown() = 0;
 	virtual void wait() = 0;
 	virtual int exitCode() = 0;
 
-	virtual void connect(INetworkHandler & network, INetworkClientListener & listener, const std::string & host, uint16_t port) = 0;
+	virtual void connect(INetworkHandler & network, INetworkClientListener & listener) = 0;
 
 	virtual ~IServerRunner() = default;
 };
@@ -37,13 +37,15 @@ class ServerThreadRunner final : public IServerRunner, boost::noncopyable
 {
 	std::unique_ptr<CVCMIServer> server;
 	boost::thread threadRunLocalServer;
+	uint16_t serverPort = 0;
+
 public:
-	uint16_t start(uint16_t port, bool listenForConnections, bool connectToLobby, std::shared_ptr<StartInfo> startingInfo) override;
+	void start(bool listenForConnections, bool connectToLobby, std::shared_ptr<StartInfo> startingInfo) override;
 	void shutdown() override;
 	void wait() override;
 	int exitCode() override;
 
-	void connect(INetworkHandler & network, INetworkClientListener & listener, const std::string & host, uint16_t port) override;
+	void connect(INetworkHandler & network, INetworkClientListener & listener) override;
 
 	ServerThreadRunner();
 	~ServerThreadRunner();
@@ -75,12 +77,12 @@ class ServerProcessRunner final : public IServerRunner, boost::noncopyable
 	std::unique_ptr<boost::process::child> child;
 
 public:
-	uint16_t start(uint16_t port, bool listenForConnections, bool connectToLobby, std::shared_ptr<StartInfo> startingInfo) override;
+	void start(bool listenForConnections, bool connectToLobby, std::shared_ptr<StartInfo> startingInfo) override;
 	void shutdown() override;
 	void wait() override;
 	int exitCode() override;
 
-	void connect(INetworkHandler & network, INetworkClientListener & listener, const std::string & host, uint16_t port) override;
+	void connect(INetworkHandler & network, INetworkClientListener & listener) override;
 
 	ServerProcessRunner();
 	~ServerProcessRunner();

--- a/client/ServerRunner.h
+++ b/client/ServerRunner.h
@@ -22,7 +22,7 @@ class CVCMIServer;
 class IServerRunner
 {
 public:
-	virtual uint16_t start(uint16_t port, bool connectToLobby, std::shared_ptr<StartInfo> startingInfo) = 0;
+	virtual uint16_t start(uint16_t port, bool listenForConnections, bool connectToLobby, std::shared_ptr<StartInfo> startingInfo) = 0;
 	virtual void shutdown() = 0;
 	virtual void wait() = 0;
 	virtual int exitCode() = 0;
@@ -38,7 +38,7 @@ class ServerThreadRunner final : public IServerRunner, boost::noncopyable
 	std::unique_ptr<CVCMIServer> server;
 	boost::thread threadRunLocalServer;
 public:
-	uint16_t start(uint16_t port, bool connectToLobby, std::shared_ptr<StartInfo> startingInfo) override;
+	uint16_t start(uint16_t port, bool listenForConnections, bool connectToLobby, std::shared_ptr<StartInfo> startingInfo) override;
 	void shutdown() override;
 	void wait() override;
 	int exitCode() override;
@@ -75,7 +75,7 @@ class ServerProcessRunner final : public IServerRunner, boost::noncopyable
 	std::unique_ptr<boost::process::child> child;
 
 public:
-	uint16_t start(uint16_t port, bool connectToLobby, std::shared_ptr<StartInfo> startingInfo) override;
+	uint16_t start(uint16_t port, bool listenForConnections, bool connectToLobby, std::shared_ptr<StartInfo> startingInfo) override;
 	void shutdown() override;
 	void wait() override;
 	int exitCode() override;

--- a/client/ServerRunner.h
+++ b/client/ServerRunner.h
@@ -12,6 +12,8 @@
 VCMI_LIB_NAMESPACE_BEGIN
 
 struct StartInfo;
+class INetworkHandler;
+class INetworkClientListener;
 
 VCMI_LIB_NAMESPACE_END
 
@@ -25,11 +27,13 @@ public:
 	virtual void wait() = 0;
 	virtual int exitCode() = 0;
 
+	virtual void connect(INetworkHandler & network, INetworkClientListener & listener, const std::string & host, uint16_t port) = 0;
+
 	virtual ~IServerRunner() = default;
 };
 
 /// Class that runs server instance as a thread of client process
-class ServerThreadRunner : public IServerRunner, boost::noncopyable
+class ServerThreadRunner final : public IServerRunner, boost::noncopyable
 {
 	std::unique_ptr<CVCMIServer> server;
 	boost::thread threadRunLocalServer;
@@ -38,6 +42,8 @@ public:
 	void shutdown() override;
 	void wait() override;
 	int exitCode() override;
+
+	void connect(INetworkHandler & network, INetworkClientListener & listener, const std::string & host, uint16_t port) override;
 
 	ServerThreadRunner();
 	~ServerThreadRunner();
@@ -64,7 +70,7 @@ class child;
 
 /// Class that runs server instance as a child process
 /// Available only on desktop systems where process management is allowed
-class ServerProcessRunner : public IServerRunner, boost::noncopyable
+class ServerProcessRunner final : public IServerRunner, boost::noncopyable
 {
 	std::unique_ptr<boost::process::child> child;
 
@@ -73,6 +79,8 @@ public:
 	void shutdown() override;
 	void wait() override;
 	int exitCode() override;
+
+	void connect(INetworkHandler & network, INetworkClientListener & listener, const std::string & host, uint16_t port) override;
 
 	ServerProcessRunner();
 	~ServerProcessRunner();

--- a/lib/network/NetworkConnection.h
+++ b/lib/network/NetworkConnection.h
@@ -46,4 +46,20 @@ public:
 	void setAsyncWritesEnabled(bool on) override;
 };
 
+class InternalConnection final : public IInternalConnection, public std::enable_shared_from_this<InternalConnection>
+{
+	std::weak_ptr<IInternalConnection> otherSideWeak;
+	std::shared_ptr<NetworkContext> io;
+	INetworkConnectionListener & listener;
+public:
+	InternalConnection(INetworkConnectionListener & listener, const std::shared_ptr<NetworkContext> & context);
+
+	void receivePacket(const std::vector<std::byte> & message) override;
+	void disconnect() override;
+	void connectTo(std::shared_ptr<IInternalConnection> connection) override;
+	void sendPacket(const std::vector<std::byte> & message) override;
+	void setAsyncWritesEnabled(bool on) override;
+	void close() override;
+};
+
 VCMI_LIB_NAMESPACE_END

--- a/lib/network/NetworkHandler.cpp
+++ b/lib/network/NetworkHandler.cpp
@@ -73,6 +73,17 @@ void NetworkHandler::createTimer(INetworkTimerListener & listener, std::chrono::
 	});
 }
 
+void NetworkHandler::createInternalConnection(INetworkClientListener & listener, INetworkServer & server)
+{
+	auto localConnection = std::make_shared<InternalConnection>(listener, io);
+
+	server.receiveInternalConnection(localConnection);
+
+	io->post([&listener, localConnection](){
+		listener.onConnectionEstablished(localConnection);
+	});
+}
+
 void NetworkHandler::stop()
 {
 	io->stop();

--- a/lib/network/NetworkHandler.h
+++ b/lib/network/NetworkHandler.h
@@ -22,6 +22,7 @@ public:
 
 	std::unique_ptr<INetworkServer> createServerTCP(INetworkServerListener & listener) override;
 	void connectToRemote(INetworkClientListener & listener, const std::string & host, uint16_t port) override;
+	void createInternalConnection(INetworkClientListener & listener, INetworkServer & server) override;
 	void createTimer(INetworkTimerListener & listener, std::chrono::milliseconds duration) override;
 
 	void run() override;

--- a/lib/network/NetworkServer.cpp
+++ b/lib/network/NetworkServer.cpp
@@ -57,6 +57,18 @@ void NetworkServer::onDisconnected(const std::shared_ptr<INetworkConnection> & c
 	}
 }
 
+void NetworkServer::receiveInternalConnection(std::shared_ptr<IInternalConnection> remoteConnection)
+{
+	auto localConnection = std::make_shared<InternalConnection>(*this, io);
+
+	connections.insert(localConnection);
+
+	localConnection->connectTo(remoteConnection);
+	remoteConnection->connectTo(localConnection);
+
+	listener.onNewConnection(localConnection);
+}
+
 void NetworkServer::onPacketReceived(const std::shared_ptr<INetworkConnection> & connection, const std::vector<std::byte> & message)
 {
 	listener.onPacketReceived(connection, message);

--- a/lib/network/NetworkServer.h
+++ b/lib/network/NetworkServer.h
@@ -29,6 +29,8 @@ class NetworkServer : public INetworkConnectionListener, public INetworkServer
 public:
 	NetworkServer(INetworkServerListener & listener, const std::shared_ptr<NetworkContext> & context);
 
+	void receiveInternalConnection(std::shared_ptr<IInternalConnection> remoteConnection) override;
+
 	uint16_t start(uint16_t port) override;
 };
 

--- a/server/CVCMIServer.cpp
+++ b/server/CVCMIServer.cpp
@@ -1077,3 +1077,8 @@ INetworkHandler & CVCMIServer::getNetworkHandler()
 {
 	return *networkHandler;
 }
+
+INetworkServer & CVCMIServer::getNetworkServer()
+{
+	return *networkServer;
+}

--- a/server/CVCMIServer.h
+++ b/server/CVCMIServer.h
@@ -63,7 +63,7 @@ public:
 	/// List of all active connections
 	std::vector<std::shared_ptr<CConnection>> activeConnections;
 
-	uint16_t prepare(bool connectToLobby);
+	uint16_t prepare(bool connectToLobby, bool listenForConnections);
 
 	// INetworkListener impl
 	void onDisconnected(const std::shared_ptr<INetworkConnection> & connection, const std::string & errorMessage) override;
@@ -82,7 +82,7 @@ public:
 	bool prepareToStartGame();
 	void prepareToRestart();
 	void startGameImmediately();
-	uint16_t startAcceptingIncomingConnections();
+	uint16_t startAcceptingIncomingConnections(bool listenForConnections);
 
 	void threadHandleClient(std::shared_ptr<CConnection> c);
 

--- a/server/CVCMIServer.h
+++ b/server/CVCMIServer.h
@@ -107,6 +107,7 @@ public:
 	void updateAndPropagateLobbyState();
 
 	INetworkHandler & getNetworkHandler();
+	INetworkServer & getNetworkServer();
 
 	void setState(EServerState value);
 	EServerState getState() const;

--- a/server/GlobalLobbyProcessor.cpp
+++ b/server/GlobalLobbyProcessor.cpp
@@ -99,7 +99,7 @@ void GlobalLobbyProcessor::receiveServerLoginSuccess(const JsonNode & json)
 {
 	// no-op, wait just for any new commands from lobby
 	logGlobal->info("Lobby: Successfully connected to lobby server");
-	owner.startAcceptingIncomingConnections();
+	owner.startAcceptingIncomingConnections(true);
 }
 
 void GlobalLobbyProcessor::receiveAccountJoinsRoom(const JsonNode & json)

--- a/serverapp/EntryPoint.cpp
+++ b/serverapp/EntryPoint.cpp
@@ -92,7 +92,7 @@ int main(int argc, const char * argv[])
 			port = opts["port"].as<uint16_t>();
 
 		CVCMIServer server(port, runByClient);
-		server.prepare(connectToLobby);
+		server.prepare(connectToLobby, true);
 		server.run();
 
 		// CVCMIServer destructor must be called here - before VLC cleanup


### PR DESCRIPTION
This removes need for TCP network connection in single-player games.

Instead, game will now create internal pseudo-connection that performs client<->server communication by posting sent messages to client/server asio::io_service's directly.

This should fix gameplay aborting on switching to another app on iOS (and apparently, on Android in some cases)