### PR TITLE
[1.6.6] Handle flag color overlay and creature selection overlay separately

### DIFF
--- a/client/battle/CreatureAnimation.cpp
+++ b/client/battle/CreatureAnimation.cpp
@@ -200,8 +200,8 @@ CreatureAnimation::CreatureAnimation(const AnimationPath & name_, TSpeedControll
 	  speedController(controller),
 	  once(false)
 {
-	forward = GH.renderHandler().loadAnimation(name_, EImageBlitMode::WITH_SHADOW_AND_OVERLAY);
-	reverse = GH.renderHandler().loadAnimation(name_, EImageBlitMode::WITH_SHADOW_AND_OVERLAY);
+	forward = GH.renderHandler().loadAnimation(name_, EImageBlitMode::WITH_SHADOW_AND_SELECTION);
+	reverse = GH.renderHandler().loadAnimation(name_, EImageBlitMode::WITH_SHADOW_AND_SELECTION);
 
 	// if necessary, add one frame into vcmi-only group DEAD
 	if(forward->size(size_t(ECreatureAnimType::DEAD)) == 0)

--- a/client/mapView/MapRenderer.cpp
+++ b/client/mapView/MapRenderer.cpp
@@ -407,7 +407,7 @@ std::shared_ptr<CAnimation> MapRendererObjects::getAnimation(const AnimationPath
 	if(it != animations.end())
 		return it->second;
 
-	auto ret = GH.renderHandler().loadAnimation(filename, enableOverlay ? EImageBlitMode::WITH_SHADOW_AND_OVERLAY : EImageBlitMode::WITH_SHADOW);
+	auto ret = GH.renderHandler().loadAnimation(filename, enableOverlay ? EImageBlitMode::WITH_SHADOW_AND_FLAG_COLOR: EImageBlitMode::WITH_SHADOW);
 	animations[filename] = ret;
 
 	if(generateMovementGroups)

--- a/client/render/IImage.h
+++ b/client/render/IImage.h
@@ -47,19 +47,23 @@ enum class EImageBlitMode : uint8_t
 	WITH_SHADOW,
 
 	/// RGBA, may consist from 3 separate parts: base, shadow, and overlay
-	WITH_SHADOW_AND_OVERLAY,
+	WITH_SHADOW_AND_SELECTION,
+	WITH_SHADOW_AND_FLAG_COLOR,
 
 	/// RGBA, contains only body, with shadow and overlay disabled
-	ONLY_BODY,
+	ONLY_BODY_HIDE_SELECTION,
+	ONLY_BODY_HIDE_FLAG_COLOR,
 
 	/// RGBA, contains only body, with shadow disabled and overlay treated as part of body
 	ONLY_BODY_IGNORE_OVERLAY,
 
 	/// RGBA, contains only shadow
-	ONLY_SHADOW,
+	ONLY_SHADOW_HIDE_SELECTION,
+	ONLY_SHADOW_HIDE_FLAG_COLOR,
 
 	/// RGBA, contains only overlay
-	ONLY_OVERLAY,
+	ONLY_SELECTION,
+	ONLY_FLAG_COLOR,
 };
 
 enum class EScalingAlgorithm : int8_t

--- a/client/renderSDL/RenderHandler.cpp
+++ b/client/renderSDL/RenderHandler.cpp
@@ -230,6 +230,7 @@ std::shared_ptr<ISharedImage> RenderHandler::loadImageFromFileUncached(const Ima
 		if (generated)
 			return generated;
 
+		logGlobal->error("Failed to load image %s", locator.image->getOriginalName());
 		return std::make_shared<SDLImageShared>(ImagePath::builtin("DEFAULT"));
 	}
 
@@ -292,9 +293,9 @@ std::shared_ptr<SDLImageShared> RenderHandler::loadScaledImage(const ImageLocato
 
 	std::string imagePathString = pathToLoad.getName();
 
-	if(locator.layer == EImageBlitMode::ONLY_OVERLAY)
+	if(locator.layer == EImageBlitMode::ONLY_FLAG_COLOR || locator.layer == EImageBlitMode::ONLY_SELECTION)
 		imagePathString += "-OVERLAY";
-	if(locator.layer == EImageBlitMode::ONLY_SHADOW)
+	if(locator.layer == EImageBlitMode::ONLY_SHADOW_HIDE_SELECTION || locator.layer == EImageBlitMode::ONLY_SHADOW_HIDE_FLAG_COLOR)
 		imagePathString += "-SHADOW";
 	if(locator.playerColored.isValidPlayer())
 		imagePathString += "-" + boost::to_upper_copy(GameConstants::PLAYER_COLOR_NAMES[locator.playerColored.getNum()]);
@@ -347,7 +348,10 @@ std::shared_ptr<IImage> RenderHandler::loadImage(const AnimationPath & path, int
 	if (!locator.empty())
 		return loadImage(locator);
 	else
+	{
+		logGlobal->error("Failed to load non-existing image");
 		return loadImage(ImageLocator(ImagePath::builtin("DEFAULT"), mode));
+	}
 }
 
 std::shared_ptr<IImage> RenderHandler::loadImage(const ImagePath & path, EImageBlitMode mode)

--- a/client/renderSDL/ScalableImage.h
+++ b/client/renderSDL/ScalableImage.h
@@ -39,7 +39,7 @@ struct ScalableImageParameters : boost::noncopyable
 	void setShadowTransparency(const SDL_Palette * originalPalette, float factor);
 	void shiftPalette(const SDL_Palette * originalPalette, uint32_t firstColorID, uint32_t colorsToMove, uint32_t distanceToMove);
 	void playerColored(PlayerColor player);
-	void setOverlayColor(const SDL_Palette * originalPalette, const ColorRGBA & color);
+	void setOverlayColor(const SDL_Palette * originalPalette, const ColorRGBA & color, bool includeShadow);
 	void preparePalette(const SDL_Palette * originalPalette, EImageBlitMode blitMode);
 	void adjustPalette(const SDL_Palette * originalPalette, EImageBlitMode blitMode, const ColorFilter & shifter, uint32_t colorsToSkipMask);
 };

--- a/client/widgets/Images.cpp
+++ b/client/widgets/Images.cpp
@@ -195,12 +195,12 @@ CAnimImage::CAnimImage(const AnimationPath & name, size_t Frame, size_t Group, i
 {
 	pos.x += x;
 	pos.y += y;
-	anim = GH.renderHandler().loadAnimation(name, (Flags & CCreatureAnim::CREATURE_MODE) ? EImageBlitMode::WITH_SHADOW_AND_OVERLAY : EImageBlitMode::COLORKEY);
+	anim = GH.renderHandler().loadAnimation(name, (Flags & CCreatureAnim::CREATURE_MODE) ? EImageBlitMode::WITH_SHADOW_AND_SELECTION: EImageBlitMode::COLORKEY);
 	init();
 }
 
 CAnimImage::CAnimImage(const AnimationPath & name, size_t Frame, Rect targetPos, size_t Group, ui8 Flags):
-	anim(GH.renderHandler().loadAnimation(name, (Flags & CCreatureAnim::CREATURE_MODE) ? EImageBlitMode::WITH_SHADOW_AND_OVERLAY : EImageBlitMode::COLORKEY)),
+	anim(GH.renderHandler().loadAnimation(name, (Flags & CCreatureAnim::CREATURE_MODE) ? EImageBlitMode::WITH_SHADOW_AND_SELECTION : EImageBlitMode::COLORKEY)),
 	frame(Frame),
 	group(Group),
 	flags(Flags),
@@ -318,7 +318,7 @@ bool CAnimImage::isPlayerColored() const
 }
 
 CShowableAnim::CShowableAnim(int x, int y, const AnimationPath & name, ui8 Flags, ui32 frameTime, size_t Group, uint8_t alpha):
-	anim(GH.renderHandler().loadAnimation(name, (Flags & CREATURE_MODE) ? EImageBlitMode::WITH_SHADOW_AND_OVERLAY : EImageBlitMode::COLORKEY)),
+	anim(GH.renderHandler().loadAnimation(name, (Flags & CREATURE_MODE) ? EImageBlitMode::WITH_SHADOW_AND_SELECTION : EImageBlitMode::COLORKEY)),
 	group(Group),
 	frame(0),
 	first(0),


### PR DESCRIPTION
Fixes handling of Iron Golem animation from HotA

TODO: review names of EImageBlitMode enumeration for clarity