### PR TITLE
[1.6.6] Fixes for issues in 1.6.5

### DIFF
--- a/client/battle/BattleFieldController.cpp
+++ b/client/battle/BattleFieldController.cpp
@@ -533,7 +533,7 @@ void BattleFieldController::showHighlightedHexes(Canvas & canvas)
 	BattleHexArray hoveredMoveHexes  = getHighlightedHexesForMovementTarget();
 
 	BattleHex hoveredHex = getHoveredHex();
-	BattleHexArray hoveredMouseHex = hoveredHex.isValid() ? BattleHexArray({ hoveredHex }) : BattleHexArray();
+	BattleHexArray hoveredMouseHex = hoveredHex.isAvailable() ? BattleHexArray({ hoveredHex }) : BattleHexArray();
 
 	const CStack * hoveredStack = getHoveredStack();
 	if(!hoveredStack && hoveredHex == BattleHex::INVALID)

--- a/client/battle/BattleInterfaceClasses.cpp
+++ b/client/battle/BattleInterfaceClasses.cpp
@@ -691,7 +691,7 @@ void StackInfoBasicPanel::initializeData(const CStack * stack)
 			if (spellBonuses->empty())
 				throw std::runtime_error("Failed to find effects for spell " + effect.toSpell()->getJsonKey());
 
-			int duration = spellBonuses->front()->duration;
+			int duration = spellBonuses->front()->turnsRemain;
 
 			icons.push_back(std::make_shared<CAnimImage>(AnimationPath::builtin("SpellInt"), effect + 1, 0, firstPos.x + offset.x * printed, firstPos.y + offset.y * printed));
 			if(settings["general"]["enableUiEnhancements"].Bool())

--- a/client/globalLobby/GlobalLobbyWidget.cpp
+++ b/client/globalLobby/GlobalLobbyWidget.cpp
@@ -28,6 +28,7 @@
 #include "../widgets/Images.h"
 #include "../widgets/MiscWidgets.h"
 #include "../widgets/ObjectLists.h"
+#include "../widgets/Slider.h"
 #include "../widgets/TextControls.h"
 
 #include "../../lib/CConfigHandler.h"
@@ -125,6 +126,15 @@ std::shared_ptr<CIntObject> GlobalLobbyWidget::buildItemList(const JsonNode & co
 	int initialPos = 0;
 
 	auto result = std::make_shared<CListBox>(callback, position, itemOffset, visibleAmount, totalAmount, initialPos, sliderMode, Rect(sliderPosition, sliderSize));
+
+	if (result->getSlider())
+	{
+		Point scrollBoundsDimensions(sliderPosition.x + result->getSlider()->pos.w, result->getSlider()->pos.h);
+		Point scrollBoundsOffset = -sliderPosition;
+
+		result->getSlider()->setScrollBounds(Rect(scrollBoundsOffset, scrollBoundsDimensions));
+		result->getSlider()->setPanningStep(itemOffset.length());
+	}
 
 	result->setRedrawParent(true);
 	return result;

--- a/client/render/AssetGenerator.cpp
+++ b/client/render/AssetGenerator.cpp
@@ -247,7 +247,7 @@ AssetGenerator::CanvasPtr AssetGenerator::createCampaignBackground()
 
 AssetGenerator::CanvasPtr AssetGenerator::createChroniclesCampaignImages(int chronicle)
 {
-	auto imgPathBg = ImagePath::builtin("data/chronicles_" + std::to_string(chronicle) + "/GamSelBk");
+	auto imgPathBg = ImagePath::builtin("chronicles_" + std::to_string(chronicle) + "/GamSelBk");
 	auto locator = ImageLocator(imgPathBg, EImageBlitMode::OPAQUE);
 
 	std::shared_ptr<IImage> img = GH.renderHandler().loadImage(locator);

--- a/client/render/CanvasImage.cpp
+++ b/client/render/CanvasImage.cpp
@@ -25,6 +25,11 @@ CanvasImage::CanvasImage(const Point & size, CanvasScalingPolicy scalingPolicy)
 {
 }
 
+CanvasImage::~CanvasImage()
+{
+	SDL_FreeSurface(surface);
+}
+
 void CanvasImage::draw(SDL_Surface * where, const Point & pos, const Rect * src, int scalingFactor) const
 {
 	if(src)

--- a/client/render/CanvasImage.h
+++ b/client/render/CanvasImage.h
@@ -16,6 +16,7 @@ class CanvasImage : public IImage
 {
 public:
 	CanvasImage(const Point & size, CanvasScalingPolicy scalingPolicy);
+	~CanvasImage();
 
 	Canvas getCanvas();
 

--- a/client/renderSDL/RenderHandler.cpp
+++ b/client/renderSDL/RenderHandler.cpp
@@ -379,7 +379,7 @@ void RenderHandler::addImageListEntries(const EntityService * service)
 			if (imageName.empty())
 				return;
 
-			auto & layout = getAnimationLayout(AnimationPath::builtin("SPRITES/" + listName), 1, EImageBlitMode::SIMPLE);
+			auto & layout = getAnimationLayout(AnimationPath::builtin("SPRITES/" + listName), 1, EImageBlitMode::COLORKEY);
 
 			JsonNode entry;
 			entry["file"].String() = imageName;
@@ -417,8 +417,8 @@ static void detectOverlappingBuildings(RenderHandler * renderHandler, const Fact
 			if (left->pos.z != right->pos.z)
 				continue; // buildings already have different z-index and have well-defined overlap logic
 
-			auto leftImage = renderHandler->loadImage(left->defName, 0, 0, EImageBlitMode::SIMPLE);
-			auto rightImage = renderHandler->loadImage(right->defName, 0, 0, EImageBlitMode::SIMPLE);
+			auto leftImage = renderHandler->loadImage(left->defName, 0, 0, EImageBlitMode::COLORKEY);
+			auto rightImage = renderHandler->loadImage(right->defName, 0, 0, EImageBlitMode::COLORKEY);
 
 			Rect leftRect( left->pos.x, left->pos.y, leftImage->width(), leftImage->height());
 			Rect rightRect( right->pos.x, right->pos.y, rightImage->width(), rightImage->height());

--- a/client/widgets/ObjectLists.cpp
+++ b/client/widgets/ObjectLists.cpp
@@ -168,6 +168,11 @@ std::shared_ptr<CIntObject> CListBox::getItem(size_t which)
 	return std::shared_ptr<CIntObject>();
 }
 
+std::shared_ptr<CSlider> CListBox::getSlider()
+{
+	return slider;
+}
+
 size_t CListBox::getIndexOf(std::shared_ptr<CIntObject> item)
 {
 	size_t i=first;

--- a/client/widgets/ObjectLists.h
+++ b/client/widgets/ObjectLists.h
@@ -91,6 +91,8 @@ public:
 	//return item with index which or null if not present
 	std::shared_ptr<CIntObject> getItem(size_t which);
 
+	std::shared_ptr<CSlider> getSlider();
+
 	//return currently active items
 	const std::list<std::shared_ptr<CIntObject>> & getItems();
 

--- a/client/windows/CCreatureWindow.cpp
+++ b/client/windows/CCreatureWindow.cpp
@@ -238,7 +238,7 @@ CStackWindow::ActiveSpellsSection::ActiveSpellsSection(CStackWindow * owner, int
 			if (spellBonuses->empty())
 				throw std::runtime_error("Failed to find effects for spell " + effect.toSpell()->getJsonKey());
 
-			int duration = spellBonuses->front()->duration;
+			int duration = spellBonuses->front()->turnsRemain;
 			boost::replace_first(spellText, "%d", std::to_string(duration));
 
 			spellIcons.push_back(std::make_shared<CAnimImage>(AnimationPath::builtin("SpellInt"), effect + 1, 0, firstPos.x + offset.x * printed, firstPos.y + offset.y * printed));

--- a/config/campaignSets.json
+++ b/config/campaignSets.json
@@ -50,7 +50,7 @@
 	},
 	"chr":
 	{
-		"images" : [ {"x": 0, "y": 0, "name":"data/CampaignBackground8"} ],
+		"images" : [ {"x": 0, "y": 0, "name":"CampaignBackground8"} ],
 		"exitbutton" : {"x": 658, "y": 482, "name":"CMPSCAN" },
 		"items":
 		[

--- a/config/mapOverrides.json
+++ b/config/mapOverrides.json
@@ -2370,5 +2370,120 @@
 		},
 		"victoryIconIndex" : 11,
 		"victoryString" : "core.vcdesc.0"
+	},
+	
+	"data/gelu:1" : { // Cutthroats
+		"defeatIconIndex" : 1,
+		"defeatString" : "core.lcdesc.2",
+		"triggeredEvents" : {
+			"heroesMustSurvive" : {
+				"condition" : [
+					"allOf",
+					[ "isHuman", { "value" : 1 } ],
+					[ "noneOf",
+						[ "control", { "position" : [ 11, 8, 0 ], "type" : "hero" } ] // Gelu
+					]
+				],
+				"effect" : {
+					"messageToSend" : "core.genrltxt.5",
+					"type" : "defeat"
+				},
+				"message" : "core.genrltxt.253"
+			},
+			"specialVictory" : {
+				"condition" : [ "haveArtifact", { "type" : "artifact.ringOfVitality" } ],
+				"effect" : {
+					"messageToSend" : "core.genrltxt.281",
+					"type" : "victory"
+				},
+				"message" : "core.genrltxt.280"
+			},
+			"standardDefeat" : {
+				"condition" : [ "daysWithoutTown", { "value" : 7 } ],
+				"effect" : {
+					"messageToSend" : "core.genrltxt.8",
+					"type" : "defeat"
+				},
+				"message" : "core.genrltxt.7"
+			}
+		},
+		"victoryIconIndex" : 0,
+		"victoryString" : "core.vcdesc.1"
+	},
+	"data/gelu:2" : { // Valley of the Dragon Lords
+		"defeatIconIndex" : 1,
+		"defeatString" : "core.lcdesc.2",
+		"triggeredEvents" : {
+			"heroesMustSurvive" : {
+				"condition" : [
+					"allOf",
+					[ "isHuman", { "value" : 1 } ],
+					[ "noneOf",
+						[ "control", { "position" : [ 62, 12, 0 ], "type" : "hero" } ] // Gelu
+					]
+				],
+				"effect" : {
+					"messageToSend" : "core.genrltxt.5",
+					"type" : "defeat"
+				},
+				"message" : "core.genrltxt.253"
+			},
+			"specialVictory" : {
+				"condition" : [ "haveArtifact", { "type" : "artifact.ringOfLife" } ],
+				"effect" : {
+					"messageToSend" : "core.genrltxt.281",
+					"type" : "victory"
+				},
+				"message" : "core.genrltxt.280"
+			},
+			"standardDefeat" : {
+				"condition" : [ "daysWithoutTown", { "value" : 7 } ],
+				"effect" : {
+					"messageToSend" : "core.genrltxt.8",
+					"type" : "defeat"
+				},
+				"message" : "core.genrltxt.7"
+			}
+		},
+		"victoryIconIndex" : 0,
+		"victoryString" : "core.vcdesc.1"
+	},
+	"data/gelu:3" : { // A Thief in the Night
+		"defeatIconIndex" : 1,
+		"defeatString" : "core.lcdesc.2",
+		"triggeredEvents" : {
+			"heroesMustSurvive" : {
+				"condition" : [
+					"allOf",
+					[ "isHuman", { "value" : 1 } ],
+					[ "noneOf",
+						[ "control", { "position" : [ 50, 9, 0 ], "type" : "hero" } ] // Gelu
+					]
+				],
+				"effect" : {
+					"messageToSend" : "core.genrltxt.5",
+					"type" : "defeat"
+				},
+				"message" : "core.genrltxt.253"
+			},
+			"specialVictory" : {
+				"condition" : [ "haveArtifact", { "type" : "artifact.vialOfLifeblood" } ],
+				"effect" : {
+					"messageToSend" : "core.genrltxt.281",
+					"type" : "victory"
+				},
+				"message" : "core.genrltxt.280"
+			},
+			"standardDefeat" : {
+				"condition" : [ "daysWithoutTown", { "value" : 7 } ],
+				"effect" : {
+					"messageToSend" : "core.genrltxt.8",
+					"type" : "defeat"
+				},
+				"message" : "core.genrltxt.7"
+			}
+		},
+		"victoryIconIndex" : 0,
+		"victoryString" : "core.vcdesc.1"
 	}
 }

--- a/lib/bonuses/CBonusSystemNode.cpp
+++ b/lib/bonuses/CBonusSystemNode.cpp
@@ -188,6 +188,7 @@ std::shared_ptr<Bonus> CBonusSystemNode::getUpdatedBonus(const std::shared_ptr<B
 CBonusSystemNode::CBonusSystemNode(bool isHypotetic):
 	nodeType(UNKNOWN),
 	cachedLast(0),
+	nodeChanged(0),
 	isHypotheticNode(isHypotetic)
 {
 }
@@ -195,6 +196,7 @@ CBonusSystemNode::CBonusSystemNode(bool isHypotetic):
 CBonusSystemNode::CBonusSystemNode(ENodeTypes NodeType):
 	nodeType(NodeType),
 	cachedLast(0),
+	nodeChanged(0),
 	isHypotheticNode(false)
 {
 }

--- a/lib/filesystem/Filesystem.cpp
+++ b/lib/filesystem/Filesystem.cpp
@@ -183,14 +183,9 @@ void CResourceHandler::initialize()
 	knownLoaders["saves"] = new CFilesystemLoader("SAVES/", VCMIDirs::get().userSavePath());
 	knownLoaders["config"] = new CFilesystemLoader("CONFIG/", VCMIDirs::get().userConfigPath());
 
-	knownLoaders["gen_data"] = new CFilesystemLoader("DATA/", VCMIDirs::get().userDataPath() / "Generated" / "Data");
-	knownLoaders["gen_sprites"] = new CFilesystemLoader("SPRITES/", VCMIDirs::get().userDataPath() / "Generated" / "Sprites");
-
 	auto * localFS = new CFilesystemList();
 	localFS->addLoader(knownLoaders["saves"], true);
 	localFS->addLoader(knownLoaders["config"], true);
-	localFS->addLoader(knownLoaders["gen_data"], true);
-	localFS->addLoader(knownLoaders["gen_sprites"], true);
 
 	addFilesystem("root", "initial", createInitial());
 	addFilesystem("root", "data", new CFilesystemList());

--- a/lib/mapping/CMapHeader.cpp
+++ b/lib/mapping/CMapHeader.cpp
@@ -117,8 +117,17 @@ void CMapHeader::setupEvents()
 	defeatMessage.appendTextID("core.lcdesc.0");
 }
 
-CMapHeader::CMapHeader() : version(EMapFormat::VCMI), height(72), width(72),
-	twoLevel(true), difficulty(EMapDifficulty::NORMAL), levelLimit(0), howManyTeams(0), areAnyPlayers(false)
+CMapHeader::CMapHeader()
+	: version(EMapFormat::VCMI)
+	, height(72)
+	, width(72)
+	, twoLevel(true)
+	, difficulty(EMapDifficulty::NORMAL)
+	, levelLimit(0)
+	, howManyTeams(0)
+	, areAnyPlayers(false)
+	, victoryIconIndex(0)
+	, defeatIconIndex(0)
 {
 	setupEvents();
 	allowedHeroes = VLC->heroh->getDefaultAllowed();

--- a/lib/network/NetworkConnection.h
+++ b/lib/network/NetworkConnection.h
@@ -51,6 +51,7 @@ class InternalConnection final : public IInternalConnection, public std::enable_
 	std::weak_ptr<IInternalConnection> otherSideWeak;
 	std::shared_ptr<NetworkContext> io;
 	INetworkConnectionListener & listener;
+	bool connectionActive = false;
 public:
 	InternalConnection(INetworkConnectionListener & listener, const std::shared_ptr<NetworkContext> & context);
 

--- a/lib/pathfinder/PathfinderUtil.h
+++ b/lib/pathfinder/PathfinderUtil.h
@@ -40,15 +40,23 @@ namespace PathfinderUtil
 				}
 				else
 				{
+					bool hasBlockedVisitable = false;
+					bool hasVisitable = false;
+
 					for(const CGObjectInstance * obj : tinfo.visitableObjects)
 					{
 						if(obj->isBlockedVisitable())
-							return EPathAccessibility::BLOCKVIS;
-						else if(obj->passableFor(player))
-							return EPathAccessibility::ACCESSIBLE;
-						else if(obj->ID != Obj::EVENT)
-							return EPathAccessibility::VISITABLE;
+							hasBlockedVisitable = true;
+						else if(!obj->passableFor(player) && obj->ID != Obj::EVENT)
+							hasVisitable = true;
 					}
+
+					if(hasBlockedVisitable)
+						return EPathAccessibility::BLOCKVIS;
+					if(hasVisitable)
+						return EPathAccessibility::VISITABLE;
+
+					return EPathAccessibility::ACCESSIBLE;
 				}
 			}
 			else if(tinfo.blocked())

--- a/lib/serializer/Connection.cpp
+++ b/lib/serializer/Connection.cpp
@@ -102,7 +102,8 @@ std::unique_ptr<CPack> CConnection::retrievePack(const std::vector<std::byte> & 
 	if (packReader->position != data.size())
 		throw std::runtime_error("Failed to retrieve pack! Not all data has been read!");
 
-	logNetwork->trace("Received CPack of type %s", typeid(result.get()).name());
+	auto packRawPtr = result.get();
+	logNetwork->trace("Received CPack of type %s", typeid(*packRawPtr).name());
 	deserializer->loadedPointers.clear();
 	deserializer->loadedSharedPointers.clear();
 	return result;

--- a/server/processors/TurnOrderProcessor.cpp
+++ b/server/processors/TurnOrderProcessor.cpp
@@ -249,6 +249,8 @@ void TurnOrderProcessor::doStartNewDay()
 	assert(awaitingPlayers.empty());
 	assert(actingPlayers.empty());
 
+	gameHandler->onNewTurn();
+
 	bool activePlayer = false;
 	for (auto player : actedPlayers)
 	{
@@ -264,7 +266,6 @@ void TurnOrderProcessor::doStartNewDay()
 
 	std::swap(actedPlayers, awaitingPlayers);
 
-	gameHandler->onNewTurn();
 	updateAndNotifyContactStatus();
 	tryStartTurnsForPlayers();
 }


### PR DESCRIPTION
- Fixed crash on winning the game due to AI losing all towns and not capturing any in 7 days
- Added custom victory conditions to Elixir of Life campaign since 2-4 scenarios don't allow standard victory, despite it being enabled in h3m
- Pathfinder will now correctly handle visitable object with hero standing on top of it as blocked-visitable. This fixes attacking heroes from blocked tiles or from water when hero uses Fly
- Fixed highlighting of unavailable combat hexes via mouse
- Fix duration of spell effects in creature window always displaying 16
- Scrolling in lobby UI is now restricted to corresponding element, to avoid scrolling every visible list at once
- Fix broken path to generated chronicles campaign background image
- Fixes broken transparency of some heroes portraits from mods.
- Fixes for memory leak and undefined behavior detected by valgrind
- Fix possible crash on returning to main menu / advancing to next scenario due to internal connection sending queued packages after closing

Fixes following issues:
- Fixes #5382
- Fixes #5381
- Fixes #5170
- Fixes #4501
- Fixes #4470
- Fixes #4468