### PR TITLE
add workflow to notify other repos about new release

### DIFF
--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -1,0 +1,16 @@
+name: Notify other repos of release
+on:
+  release:
+    types: [published]
+jobs:
+  notify_repos:
+    if: ${{ !github.event.release.prerelease }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Repository Dispatch only for releases
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.HOMEBREW_TOKEN_SECRET }}
+          repository: vcmi/homebrew-vcmi
+          event-type: on-release
+          client-payload: '{"release": ${{ toJson(github.event.release) }}}'


### PR DESCRIPTION
cherry-pick of #5319 to beta. Apparently, workflow must exist in the branch which release is made from.