### PR TITLE
[1.6.6] Clicking on blocked tile of a visitable object now builds a path to it

### DIFF
--- a/client/adventureMap/AdventureMapInterface.h
+++ b/client/adventureMap/AdventureMapInterface.h
@@ -75,9 +75,6 @@ private:
 	/// updates active state of game window whenever game state changes
 	void adjustActiveness();
 
-	/// checks if obj is our ashipyard and cursor is 0,0 -> returns shipyard or nullptr else
-	const IShipyard * ourInaccessibleShipyard(const CGObjectInstance *obj) const;
-
 	/// check and if necessary reacts on scrolling by moving cursor to screen edge
 	void handleMapScrollingUpdate(uint32_t msPassed);
 

--- a/config/schemas/settings.json
+++ b/config/schemas/settings.json
@@ -761,7 +761,10 @@
 				},
 				"simpleObjectSelection" : {
 					"type": "boolean",
-					"default": true
+					"default": true,
+					"defaultIOS": true,
+					"defaultAndroid": true,
+					"defaultDesktop" : false
 				},
 				"skipAdventureMapAnimations": {
 					"type": "boolean",

--- a/config/schemas/settings.json
+++ b/config/schemas/settings.json
@@ -719,6 +719,7 @@
 				"skipBattleIntroMusic",
 				"infoBarCreatureManagement",
 				"enableLargeSpellbook",
+				"simpleObjectSelection",
 				"skipAdventureMapAnimations"
 			],
 			"properties" : {
@@ -755,6 +756,10 @@
 					"default" : true
 				},
 				"enableLargeSpellbook" : {
+					"type": "boolean",
+					"default": true
+				},
+				"simpleObjectSelection" : {
 					"type": "boolean",
 					"default": true
 				},


### PR DESCRIPTION
Suggestion from Discord.

If player has hero selected, clicking on a blocked tile of a visitable, reachable object will now build a path to its visitable position (or move hero to it, in case of second click / tap).

Objects that have interaction on left click (allied town and shipyards) are excluded from this change and work as before