### PR TITLE
Reduce size of junction zones on Coldshadow Fantasy template

### DIFF
--- a/Mods/vcmi/Content/config/rmg/hdmod/coldshadowsFantasy.json
+++ b/Mods/vcmi/Content/config/rmg/hdmod/coldshadowsFantasy.json
@@ -159,7 +159,7 @@
 			},
 			"17":
 			{
-				"type" : "junction", "size" : 30,
+				"type" : "junction", "size" : 15,
 				"terrainTypeLikeZone" : 9,
 				"allowedTowns" : ["neutral"],
 				"monsters" : "strong",
@@ -172,7 +172,7 @@
 			},
 			"18":
 			{
-				"type" : "junction", "size" : 30,
+				"type" : "junction", "size" : 15,
 				"terrainTypeLikeZone" : 9,
 				"allowedTowns" : ["neutral"],
 				"monsters" : "strong",
@@ -181,7 +181,7 @@
 			},
 			"19":
 			{
-				"type" : "junction", "size" : 30,
+				"type" : "junction", "size" : 15,
 				"terrainTypeLikeZone" : 9,
 				"allowedTowns" : ["neutral"],
 				"monsters" : "strong",
@@ -190,7 +190,7 @@
 			},
 			"20":
 			{
-				"type" : "junction", "size" : 30,
+				"type" : "junction", "size" : 15,
 				"terrainTypeLikeZone" : 9,
 				"allowedTowns" : ["neutral"],
 				"monsters" : "strong",


### PR DESCRIPTION
This should reduce amount of huge blocked chunks of map without greatly changing template gameplay.

Junction zones are used on one more template (Gimlis revenge), however that template is limited to L-sized maps, so there are no massive chunks of blocked terrain