### PR TITLE
[1.6.6] portrait mode for android & grey bar fix

### DIFF
--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -81,7 +81,7 @@
             android:configChanges="orientation|uiMode|screenLayout|screenSize|smallestScreenSize|layoutDirection|locale|fontScale|keyboard|keyboardHidden|navigation|mcc|mnc|density"
             android:label="@string/app_name"
             android:launchMode="singleTop"
-            android:screenOrientation="sensorLandscape" />
+            android:screenOrientation="fullSensor" />
 
         <service
             android:name=".ServerService"

--- a/android/vcmi-app/src/main/java/eu/vcmi/vcmi/VcmiSDLActivity.java
+++ b/android/vcmi-app/src/main/java/eu/vcmi/vcmi/VcmiSDLActivity.java
@@ -107,6 +107,8 @@ public class VcmiSDLActivity extends SDLActivity
         mLayout = layout;
 
         setContentView(outerLayout);
+
+        VcmiSDLActivity.this.setWindowStyle(true); // set fullscreen
     }
 
     @Override

--- a/client/eventsSDL/InputHandler.cpp
+++ b/client/eventsSDL/InputHandler.cpp
@@ -236,6 +236,14 @@ void InputHandler::preprocessEvent(const SDL_Event & ev)
 			}
 #endif
 				break;
+			case SDL_WINDOWEVENT_SIZE_CHANGED:
+#ifdef VCMI_ANDROID
+			{
+				boost::mutex::scoped_lock interfaceLock(GH.interfaceMutex);
+				GH.onScreenResize(true);
+			}
+#endif
+				break;
 			case SDL_WINDOWEVENT_FOCUS_GAINED:
 			{
 				boost::mutex::scoped_lock interfaceLock(GH.interfaceMutex);

--- a/client/mainmenu/CHighScoreScreen.cpp
+++ b/client/mainmenu/CHighScoreScreen.cpp
@@ -45,8 +45,6 @@ CHighScoreScreen::CHighScoreScreen(HighScorePage highscorepage, int highlighted)
 	OBJECT_CONSTRUCTION;
 	pos = center(Rect(0, 0, 800, 600));
 
-	backgroundAroundMenu = std::make_shared<CFilledTexture>(ImagePath::builtin("DIBOXBCK"), Rect(-pos.x, -pos.y, GH.screenDimensions().x, GH.screenDimensions().y));
-
 	addHighScores();
 	addButtons();
 }
@@ -174,6 +172,12 @@ void CHighScoreScreen::buttonExitClick()
 	CMM->playMusic();
 }
 
+void CHighScoreScreen::showAll(Canvas & to)
+{
+	to.fillTexture(GH.renderHandler().loadImage(ImagePath::builtin("DiBoxBck"), EImageBlitMode::OPAQUE));
+	CWindowObject::showAll(to);
+}
+
 CHighScoreInputScreen::CHighScoreInputScreen(bool won, HighScoreCalculation calc, const StatisticDataSet & statistic)
 	: CWindowObject(BORDERED), won(won), calc(calc), stat(statistic)
 {
@@ -182,7 +186,6 @@ CHighScoreInputScreen::CHighScoreInputScreen(bool won, HighScoreCalculation calc
 	OBJECT_CONSTRUCTION;
 	pos = center(Rect(0, 0, 800, 600));
 
-	backgroundAroundMenu = std::make_shared<CFilledTexture>(ImagePath::builtin("DIBOXBCK"), Rect(-pos.x, -pos.y, GH.screenDimensions().x, GH.screenDimensions().y));
 	background = std::make_shared<TransparentFilledRectangle>(Rect(0, 0, pos.w, pos.h), Colors::BLACK);
 
 	if(won)
@@ -269,6 +272,12 @@ int CHighScoreInputScreen::addEntry(std::string text) {
 
 void CHighScoreInputScreen::show(Canvas & to)
 {
+	CWindowObject::showAll(to);
+}
+
+void CHighScoreInputScreen::showAll(Canvas & to)
+{
+	to.fillTexture(GH.renderHandler().loadImage(ImagePath::builtin("DiBoxBck"), EImageBlitMode::OPAQUE));
 	CWindowObject::showAll(to);
 }
 

--- a/client/mainmenu/CHighScoreScreen.h
+++ b/client/mainmenu/CHighScoreScreen.h
@@ -39,11 +39,11 @@ private:
 	void buttonExitClick();
 
 	void showPopupWindow(const Point & cursorPosition) override;
+	void showAll(Canvas & to) override;
 
 	HighScorePage highscorepage;
 
 	std::shared_ptr<CPicture> background;
-	std::shared_ptr<CFilledTexture> backgroundAroundMenu;
 	std::vector<std::shared_ptr<CButton>> buttons;
 	std::vector<std::shared_ptr<CLabel>> texts;
 	std::vector<std::shared_ptr<CAnimImage>> images;
@@ -77,7 +77,6 @@ class CHighScoreInputScreen : public CWindowObject, public IVideoHolder
 	std::shared_ptr<CHighScoreInput> input;
 	std::shared_ptr<TransparentFilledRectangle> background;
 	std::shared_ptr<VideoWidgetBase> videoPlayer;
-	std::shared_ptr<CFilledTexture> backgroundAroundMenu;
 
 	std::shared_ptr<CButton> statisticButton;
 
@@ -95,4 +94,5 @@ public:
 	void clickPressed(const Point & cursorPosition) override;
 	void keyPressed(EShortcut key) override;
 	void show(Canvas & to) override;
+	void showAll(Canvas & to) override;
 };

--- a/client/renderSDL/ScreenHandler.cpp
+++ b/client/renderSDL/ScreenHandler.cpp
@@ -211,6 +211,10 @@ ScreenHandler::ScreenHandler()
 	// NOTE: requires SDL 2.24.
 	SDL_SetHint(SDL_HINT_WINDOWS_DPI_AWARENESS, "permonitor");
 #endif
+	if(settings["video"]["allowPortrait"].Bool())
+		SDL_SetHint(SDL_HINT_ORIENTATIONS, "Portrait PortraitUpsideDown LandscapeLeft LandscapeRight");
+	else
+		SDL_SetHint(SDL_HINT_ORIENTATIONS, "LandscapeLeft LandscapeRight");
 
 	if(SDL_Init(SDL_INIT_VIDEO | SDL_INIT_TIMER | SDL_INIT_AUDIO | SDL_INIT_GAMECONTROLLER))
 	{
@@ -493,7 +497,7 @@ SDL_Window * ScreenHandler::createWindow()
 #endif
 
 #ifdef VCMI_ANDROID
-	return createWindowImpl(Point(), SDL_WINDOW_FULLSCREEN, false);
+	return createWindowImpl(Point(), SDL_WINDOW_RESIZABLE, false);
 #endif
 }
 

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -1685,15 +1685,12 @@ void CObjectListWindow::keyPressed(EShortcut key)
 }
 
 VideoWindow::VideoWindow(const VideoPath & video, const ImagePath & rim, bool showBackground, float scaleFactor, const std::function<void(bool skipped)> & closeCb)
-	: CWindowObject(BORDERED | SHADOW_DISABLED | NEEDS_ANIMATED_BACKGROUND), closeCb(closeCb)
+	: CWindowObject(BORDERED | SHADOW_DISABLED | NEEDS_ANIMATED_BACKGROUND), closeCb(closeCb), showBackground(showBackground)
 {
 	OBJECT_CONSTRUCTION;
 
 	addUsedEvents(LCLICK | KEYBOARD);
 
-	if(showBackground)
-		backgroundAroundWindow = std::make_shared<CFilledTexture>(ImagePath::builtin("DIBOXBCK"), Rect(0, 0, GH.screenDimensions().x, GH.screenDimensions().y));
-	
 	if(!rim.empty())
 	{
 		setBackground(rim);
@@ -1707,16 +1704,19 @@ VideoWindow::VideoWindow(const VideoPath & video, const ImagePath & rim, bool sh
 		pos = center(Rect(0, 0, videoPlayer->pos.w, videoPlayer->pos.h));
 		blackBackground->addBox(Point(0, 0), Point(videoPlayer->pos.w, videoPlayer->pos.h), Colors::BLACK);
 	}
+}
 
-	if(backgroundAroundWindow)
-		backgroundAroundWindow->pos.moveTo(Point(0, 0));
+void VideoWindow::showAll(Canvas & to)
+{
+	if(showBackground)
+		to.fillTexture(GH.renderHandler().loadImage(ImagePath::builtin("DiBoxBck"), EImageBlitMode::OPAQUE));
+	CWindowObject::showAll(to);
 }
 
 void VideoWindow::onVideoPlaybackFinished()
 {
 	exit(false);
 }
-
 
 void VideoWindow::exit(bool skipped)
 {

--- a/client/windows/GUIClasses.h
+++ b/client/windows/GUIClasses.h
@@ -517,6 +517,7 @@ class VideoWindow : public CWindowObject, public IVideoHolder
 	std::shared_ptr<VideoWidgetOnce> videoPlayer;
 	std::shared_ptr<CFilledTexture> backgroundAroundWindow;
 	std::shared_ptr<GraphicalPrimitiveCanvas> blackBackground;
+	bool showBackground;
 
 	std::function<void(bool)> closeCb;
 
@@ -528,4 +529,5 @@ public:
 	void clickPressed(const Point & cursorPosition) override;
 	void keyPressed(EShortcut key) override;
 	void notFocusedClick() override;
+	void showAll(Canvas & to) override;
 };

--- a/config/schemas/settings.json
+++ b/config/schemas/settings.json
@@ -188,7 +188,8 @@
 				"fontScalingFactor",
 				"upscalingFilter",
 				"fontUpscalingFilter",
-				"downscalingFilter"
+				"downscalingFilter",
+				"allowPortrait"
 			],
 			"properties" : {
 				"resolution" : {
@@ -276,6 +277,10 @@
 					"type" : "string",
 					"enum" : [ "nearest", "linear", "best" ],
 					"default" : "best"
+				},
+				"allowPortrait" : {
+					"type" : "boolean",
+					"default" : false
 				}
 			}
 		},

--- a/launcher/settingsView/csettingsview_moc.cpp
+++ b/launcher/settingsView/csettingsview_moc.cpp
@@ -128,6 +128,8 @@ void CSettingsView::loadSettings()
 #ifndef VCMI_ANDROID
 	ui->buttonHandleBackRightMouseButton->hide();
 	ui->labelHandleBackRightMouseButton->hide();
+	ui->buttonAllowPortrait->hide();
+	ui->labelAllowPortrait->hide();
 #endif
 	fillValidScalingRange();
 
@@ -206,6 +208,7 @@ void CSettingsView::loadSettings()
 void CSettingsView::loadToggleButtonSettings()
 {
 	setCheckbuttonState(ui->buttonShowIntro, settings["video"]["showIntro"].Bool());
+	setCheckbuttonState(ui->buttonAllowPortrait, settings["video"]["allowPortrait"].Bool());
 	setCheckbuttonState(ui->buttonAutoCheck, settings["launcher"]["autoCheckRepositories"].Bool());
 
 	setCheckbuttonState(ui->buttonRepositoryDefault, settings["launcher"]["defaultRepositoryEnabled"].Bool());
@@ -470,6 +473,13 @@ void CSettingsView::on_buttonShowIntro_toggled(bool value)
 	Settings node = settings.write["video"]["showIntro"];
 	node->Bool() = value;
 	updateCheckbuttonText(ui->buttonShowIntro);
+}
+
+void CSettingsView::on_buttonAllowPortrait_toggled(bool value)
+{
+	Settings node = settings.write["video"]["allowPortrait"];
+	node->Bool() = value;
+	updateCheckbuttonText(ui->buttonAllowPortrait);
 }
 
 void CSettingsView::on_buttonAutoSave_toggled(bool value)

--- a/launcher/settingsView/csettingsview_moc.h
+++ b/launcher/settingsView/csettingsview_moc.h
@@ -47,6 +47,7 @@ private slots:
 	void on_comboBoxEnemyAI_currentTextChanged(const QString & arg1);
 	void on_spinBoxNetworkPort_valueChanged(int arg1);
 	void on_buttonShowIntro_toggled(bool value);
+	void on_buttonAllowPortrait_toggled(bool value);
 	void on_buttonAutoCheck_toggled(bool value);
 	void on_comboBoxDisplayIndex_currentIndexChanged(int index);
 	void on_buttonAutoSave_toggled(bool value);

--- a/launcher/settingsView/csettingsview_moc.ui
+++ b/launcher/settingsView/csettingsview_moc.ui
@@ -53,7 +53,7 @@
        </rect>
       </property>
       <layout class="QGridLayout" name="gridLayout" columnstretch="20,5,5,5,5,10">
-       <item row="22" column="1" colspan="5">
+       <item row="23" column="1" colspan="5">
         <widget class="QToolButton" name="buttonCursorType">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
@@ -69,14 +69,14 @@
          </property>
         </widget>
        </item>
-       <item row="61" column="0">
+       <item row="62" column="0">
         <widget class="QLabel" name="labelModsValidation">
          <property name="text">
           <string>Mods Validation</string>
          </property>
         </widget>
        </item>
-       <item row="24" column="1" colspan="5">
+       <item row="25" column="1" colspan="5">
         <widget class="QComboBox" name="comboBoxUpscalingFilter">
          <item>
           <property name="text">
@@ -105,7 +105,7 @@
          </item>
         </widget>
        </item>
-       <item row="44" column="1" colspan="5">
+       <item row="45" column="1" colspan="5">
         <widget class="QSlider" name="sliderControllerSticksSensitivity">
          <property name="minimum">
           <number>500</number>
@@ -133,7 +133,7 @@
          </property>
         </widget>
        </item>
-       <item row="36" column="1" colspan="5">
+       <item row="37" column="1" colspan="5">
         <widget class="QPushButton" name="pushButtonResetTutorialTouchscreen">
          <property name="text">
           <string>Reset</string>
@@ -147,7 +147,7 @@
          </property>
         </widget>
        </item>
-       <item row="40" column="1" colspan="5">
+       <item row="41" column="1" colspan="5">
         <widget class="QSlider" name="sliderLongTouchDuration">
          <property name="minimum">
           <number>500</number>
@@ -172,7 +172,7 @@
          </property>
         </widget>
        </item>
-       <item row="55" column="1">
+       <item row="56" column="1">
         <widget class="QToolButton" name="buttonAutoCheck">
          <property name="enabled">
           <bool>true</bool>
@@ -223,7 +223,7 @@
          </property>
         </widget>
        </item>
-       <item row="30" column="1" colspan="5">
+       <item row="31" column="1" colspan="5">
         <widget class="QSlider" name="sliderMusicVolume">
          <property name="maximum">
           <number>100</number>
@@ -239,7 +239,7 @@
          </property>
         </widget>
        </item>
-       <item row="56" column="1">
+       <item row="57" column="1">
         <widget class="QToolButton" name="buttonRepositoryDefault">
          <property name="enabled">
           <bool>true</bool>
@@ -261,34 +261,34 @@
          </property>
         </widget>
        </item>
-       <item row="31" column="0">
+       <item row="32" column="0">
         <widget class="QLabel" name="labelSoundVolume">
          <property name="text">
           <string>Sound Volume</string>
          </property>
         </widget>
        </item>
-       <item row="39" column="0">
+       <item row="40" column="0">
         <widget class="QLabel" name="labelHapticFeedback">
          <property name="text">
           <string>Haptic Feedback</string>
          </property>
         </widget>
        </item>
-       <item row="42" column="0">
+       <item row="43" column="0">
         <widget class="QLabel" name="labelToleranceDistanceTouch">
          <property name="text">
           <string>Touch Tap Tolerance</string>
          </property>
         </widget>
        </item>
-       <item row="21" column="1" colspan="5">
+       <item row="22" column="1" colspan="5">
         <widget class="QComboBox" name="comboBoxRendererType"/>
        </item>
        <item row="1" column="1" colspan="5">
         <widget class="QComboBox" name="comboBoxLanguage"/>
        </item>
-       <item row="59" column="1" colspan="5">
+       <item row="60" column="1" colspan="5">
         <widget class="QSpinBox" name="spinBoxNetworkPortLobby">
          <property name="minimum">
           <number>1024</number>
@@ -301,7 +301,7 @@
          </property>
         </widget>
        </item>
-       <item row="61" column="5">
+       <item row="62" column="5">
         <widget class="QToolButton" name="buttonValidationFull">
          <property name="enabled">
           <bool>true</bool>
@@ -326,7 +326,7 @@
          </attribute>
         </widget>
        </item>
-       <item row="43" column="0">
+       <item row="44" column="0">
         <widget class="QLabel" name="labelInputMouse_3">
          <property name="font">
           <font>
@@ -341,7 +341,7 @@
          </property>
         </widget>
        </item>
-       <item row="23" column="2" colspan="4">
+       <item row="24" column="2" colspan="4">
         <widget class="QSlider" name="sliderScalingCursor">
          <property name="minimum">
           <number>10</number>
@@ -372,14 +372,14 @@
          </property>
         </widget>
        </item>
-       <item row="22" column="0">
+       <item row="23" column="0">
         <widget class="QLabel" name="labelCursorType">
          <property name="text">
           <string>Software Cursor</string>
          </property>
         </widget>
        </item>
-       <item row="48" column="1" colspan="5">
+       <item row="49" column="1" colspan="5">
         <widget class="QComboBox" name="comboBoxEnemyPlayerAI">
          <property name="currentText">
           <string notr="true">VCAI</string>
@@ -396,7 +396,7 @@
          </item>
         </widget>
        </item>
-       <item row="56" column="2" colspan="4">
+       <item row="57" column="2" colspan="4">
         <widget class="QLineEdit" name="lineEditRepositoryDefault">
          <property name="text">
           <string notr="true"/>
@@ -406,7 +406,7 @@
          </property>
         </widget>
        </item>
-       <item row="49" column="1" colspan="5">
+       <item row="50" column="1" colspan="5">
         <widget class="QComboBox" name="comboBoxAlliedPlayerAI">
          <property name="currentText">
           <string notr="true">VCAI</string>
@@ -430,7 +430,7 @@
          </property>
         </widget>
        </item>
-       <item row="47" column="0">
+       <item row="48" column="0">
         <widget class="QLabel" name="labelArtificialIntelligence">
          <property name="font">
           <font>
@@ -445,14 +445,14 @@
          </property>
         </widget>
        </item>
-       <item row="56" column="0">
+       <item row="57" column="0">
         <widget class="QLabel" name="labelRepositoryDefault">
          <property name="text">
           <string>Default repository</string>
          </property>
         </widget>
        </item>
-       <item row="27" column="1">
+       <item row="28" column="1">
         <widget class="QLabel" name="labelScalingFontValue"/>
        </item>
        <item row="14" column="4" colspan="2">
@@ -471,21 +471,21 @@
          </property>
         </widget>
        </item>
-       <item row="38" column="0">
+       <item row="39" column="0">
         <widget class="QLabel" name="labelRelativeCursorSpeed">
          <property name="text">
           <string>Relative Pointer Speed</string>
          </property>
         </widget>
        </item>
-       <item row="25" column="0">
+       <item row="26" column="0">
         <widget class="QLabel" name="labelDownscalingFilter">
          <property name="text">
           <string>Downscaling Filter</string>
          </property>
         </widget>
        </item>
-       <item row="54" column="1" colspan="5">
+       <item row="55" column="1" colspan="5">
         <widget class="QToolButton" name="buttonIgnoreSslErrors">
          <property name="enabled">
           <bool>true</bool>
@@ -527,7 +527,30 @@
          </property>
         </widget>
        </item>
-       <item row="26" column="1" colspan="2">
+       <item row="20" column="0">
+        <widget class="QLabel" name="labelAllowPortrait">
+         <property name="text">
+          <string>Allow portrait mode</string>
+         </property>
+        </widget>
+       </item>
+       <item row="20" column="1" colspan="5">
+        <widget class="QToolButton" name="buttonAllowPortrait">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="27" column="1" colspan="2">
         <widget class="QToolButton" name="buttonFontAuto">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
@@ -549,7 +572,7 @@
          </attribute>
         </widget>
        </item>
-       <item row="31" column="1" colspan="5">
+       <item row="32" column="1" colspan="5">
         <widget class="QSlider" name="sliderSoundVolume">
          <property name="maximum">
           <number>100</number>
@@ -565,7 +588,7 @@
          </property>
         </widget>
        </item>
-       <item row="57" column="1">
+       <item row="58" column="1">
         <widget class="QToolButton" name="buttonRepositoryExtra">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
@@ -584,28 +607,28 @@
          </property>
         </widget>
        </item>
-       <item row="55" column="2" colspan="4">
+       <item row="56" column="2" colspan="4">
         <widget class="QPushButton" name="refreshRepositoriesButton">
          <property name="text">
           <string>Refresh now</string>
          </property>
         </widget>
        </item>
-       <item row="49" column="0">
+       <item row="50" column="0">
         <widget class="QLabel" name="labelAlliedPlayerAI">
          <property name="text">
           <string>Adventure Map Allies</string>
          </property>
         </widget>
        </item>
-       <item row="50" column="0">
+       <item row="51" column="0">
         <widget class="QLabel" name="labelNeutralAI">
          <property name="text">
           <string>Neutral AI in battles</string>
          </property>
         </widget>
        </item>
-       <item row="27" column="2" colspan="4">
+       <item row="28" column="2" colspan="4">
         <widget class="QSlider" name="sliderScalingFont">
          <property name="minimum">
           <number>10</number>
@@ -636,21 +659,21 @@
          </property>
         </widget>
        </item>
-       <item row="58" column="1" colspan="5">
+       <item row="59" column="1" colspan="5">
         <widget class="QLineEdit" name="lineEditGameLobbyHost">
          <property name="text">
           <string notr="true"/>
          </property>
         </widget>
        </item>
-       <item row="20" column="0">
+       <item row="21" column="0">
         <widget class="QLabel" name="labelDisplayIndex">
          <property name="text">
           <string>Display index</string>
          </property>
         </widget>
        </item>
-       <item row="37" column="0">
+       <item row="38" column="0">
         <widget class="QLabel" name="labelRelativeCursorMode">
          <property name="text">
           <string>Use Relative Pointer Mode</string>
@@ -660,14 +683,14 @@
        <item row="7" column="1" colspan="5">
         <widget class="QSpinBox" name="spinBoxAutoSaveLimit"/>
        </item>
-       <item row="51" column="0">
+       <item row="52" column="0">
         <widget class="QLabel" name="labelFriendlyAI">
          <property name="text">
           <string>Autocombat AI in battles</string>
          </property>
         </widget>
        </item>
-       <item row="61" column="1" colspan="2">
+       <item row="62" column="1" colspan="2">
         <widget class="QToolButton" name="buttonValidationOff">
          <property name="enabled">
           <bool>true</bool>
@@ -692,7 +715,7 @@
          </attribute>
         </widget>
        </item>
-       <item row="32" column="0">
+       <item row="33" column="0">
         <widget class="QLabel" name="labelInputMouse">
          <property name="font">
           <font>
@@ -714,7 +737,7 @@
          </property>
         </widget>
        </item>
-       <item row="39" column="1" colspan="5">
+       <item row="40" column="1" colspan="5">
         <widget class="QToolButton" name="buttonHapticFeedback">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
@@ -730,7 +753,7 @@
          </property>
         </widget>
        </item>
-       <item row="29" column="0">
+       <item row="30" column="0">
         <widget class="QLabel" name="labelAudio">
          <property name="font">
           <font>
@@ -745,7 +768,7 @@
          </property>
         </widget>
        </item>
-       <item row="57" column="0">
+       <item row="58" column="0">
         <widget class="QLabel" name="labelRepositoryExtra">
          <property name="text">
           <string>Additional repository</string>
@@ -768,7 +791,7 @@
          </property>
         </widget>
        </item>
-       <item row="48" column="0">
+       <item row="49" column="0">
         <widget class="QLabel" name="labelEnemyPlayerAI">
          <property name="text">
           <string>Adventure Map Enemies</string>
@@ -782,21 +805,21 @@
          </property>
         </widget>
        </item>
-       <item row="26" column="0">
+       <item row="27" column="0">
         <widget class="QLabel" name="labelFonts">
          <property name="text">
           <string>Use scalable fonts</string>
          </property>
         </widget>
        </item>
-       <item row="21" column="0">
+       <item row="22" column="0">
         <widget class="QLabel" name="labelRendererType">
          <property name="text">
           <string>Renderer</string>
          </property>
         </widget>
        </item>
-       <item row="35" column="0">
+       <item row="36" column="0">
         <widget class="QLabel" name="labelInputMouse_2">
          <property name="font">
           <font>
@@ -827,10 +850,10 @@
          </property>
         </widget>
        </item>
-       <item row="23" column="1">
+       <item row="24" column="1">
         <widget class="QLabel" name="labelScalingCursorValue"/>
        </item>
-       <item row="37" column="1" colspan="5">
+       <item row="38" column="1" colspan="5">
         <widget class="QToolButton" name="buttonRelativeCursorMode">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
@@ -853,28 +876,28 @@
          </property>
         </widget>
        </item>
-       <item row="58" column="0">
+       <item row="59" column="0">
         <widget class="QLabel" name="labelGameLobbyHost">
          <property name="text">
           <string>Online Lobby address</string>
          </property>
         </widget>
        </item>
-       <item row="59" column="0">
+       <item row="60" column="0">
         <widget class="QLabel" name="labelNetworkPortLobby">
          <property name="text">
           <string>Online Lobby port</string>
          </property>
         </widget>
        </item>
-       <item row="46" column="0">
+       <item row="47" column="0">
         <widget class="QLabel" name="labelToleranceDistanceController">
          <property name="text">
           <string>Controller Click Tolerance</string>
          </property>
         </widget>
        </item>
-       <item row="50" column="1" colspan="5">
+       <item row="51" column="1" colspan="5">
         <widget class="QComboBox" name="comboBoxNeutralAI">
          <property name="currentText">
           <string notr="true">BattleAI</string>
@@ -891,7 +914,7 @@
          </item>
         </widget>
        </item>
-       <item row="25" column="1" colspan="5">
+       <item row="26" column="1" colspan="5">
         <widget class="QComboBox" name="comboBoxDownscalingFilter">
          <item>
           <property name="text">
@@ -910,24 +933,24 @@
          </item>
         </widget>
        </item>
-       <item row="54" column="0">
+       <item row="55" column="0">
         <widget class="QLabel" name="labelIgnoreSslErrors">
          <property name="text">
           <string>Ignore SSL errors</string>
          </property>
         </widget>
        </item>
-       <item row="20" column="1" colspan="5">
+       <item row="21" column="1" colspan="5">
         <widget class="QComboBox" name="comboBoxDisplayIndex"/>
        </item>
-       <item row="36" column="0">
+       <item row="37" column="0">
         <widget class="QLabel" name="labelResetTutorialTouchscreen">
          <property name="text">
           <string>Show Tutorial again</string>
          </property>
         </widget>
        </item>
-       <item row="45" column="0">
+       <item row="46" column="0">
         <widget class="QLabel" name="labelControllerSticksAcceleration">
          <property name="text">
           <string>Sticks Acceleration</string>
@@ -949,7 +972,7 @@
          </property>
         </widget>
        </item>
-       <item row="52" column="1" colspan="5">
+       <item row="53" column="1" colspan="5">
         <widget class="QComboBox" name="comboBoxEnemyAI">
          <property name="editable">
           <bool>false</bool>
@@ -983,21 +1006,21 @@
          </property>
         </widget>
        </item>
-       <item row="33" column="0">
+       <item row="34" column="0">
         <widget class="QLabel" name="labelToleranceDistanceMouse">
          <property name="text">
           <string>Mouse Click Tolerance</string>
          </property>
         </widget>
        </item>
-       <item row="34" column="0">
+       <item row="35" column="0">
         <widget class="QLabel" name="labelHandleBackRightMouseButton">
          <property name="text">
           <string>Handle back as right mouse button</string>
          </property>
         </widget>
        </item>
-       <item row="34" column="1" colspan="5">
+       <item row="35" column="1" colspan="5">
         <widget class="QToolButton" name="buttonHandleBackRightMouseButton">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
@@ -1013,7 +1036,7 @@
          </property>
         </widget>
        </item>
-       <item row="52" column="0">
+       <item row="53" column="0">
         <widget class="QLabel" name="labelEnemyAI">
          <property name="text">
           <string>Enemy AI in battles</string>
@@ -1027,7 +1050,7 @@
          </property>
         </widget>
        </item>
-       <item row="42" column="1" colspan="5">
+       <item row="43" column="1" colspan="5">
         <widget class="QSlider" name="sliderToleranceDistanceTouch">
          <property name="minimum">
           <number>0</number>
@@ -1062,14 +1085,14 @@
          </property>
         </widget>
        </item>
-       <item row="30" column="0">
+       <item row="31" column="0">
         <widget class="QLabel" name="labelMusicVolume">
          <property name="text">
           <string>Music Volume</string>
          </property>
         </widget>
        </item>
-       <item row="51" column="1" colspan="5">
+       <item row="52" column="1" colspan="5">
         <widget class="QComboBox" name="comboBoxFriendlyAI">
          <property name="editable">
           <bool>false</bool>
@@ -1089,14 +1112,14 @@
          </item>
         </widget>
        </item>
-       <item row="57" column="2" colspan="4">
+       <item row="58" column="2" colspan="4">
         <widget class="QLineEdit" name="lineEditRepositoryExtra">
          <property name="text">
           <string notr="true"/>
          </property>
         </widget>
        </item>
-       <item row="23" column="0">
+       <item row="24" column="0">
         <widget class="QLabel" name="labelScalingCursor">
          <property name="text">
           <string>Cursor Scaling</string>
@@ -1119,7 +1142,7 @@
          </property>
         </widget>
        </item>
-       <item row="26" column="3" colspan="2">
+       <item row="27" column="3" colspan="2">
         <widget class="QToolButton" name="buttonFontScalable">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
@@ -1141,7 +1164,7 @@
          </attribute>
         </widget>
        </item>
-       <item row="53" column="0">
+       <item row="54" column="0">
         <widget class="QLabel" name="labelNetwork">
          <property name="font">
           <font>
@@ -1156,7 +1179,7 @@
          </property>
         </widget>
        </item>
-       <item row="60" column="0">
+       <item row="61" column="0">
         <widget class="QLabel" name="labelMiscellaneous">
          <property name="font">
           <font>
@@ -1171,7 +1194,7 @@
          </property>
         </widget>
        </item>
-       <item row="45" column="1" colspan="5">
+       <item row="46" column="1" colspan="5">
         <widget class="QSlider" name="sliderControllerSticksAcceleration">
          <property name="minimum">
           <number>100</number>
@@ -1243,21 +1266,21 @@ Fullscreen Exclusive Mode - the game will cover the entirety of your screen and 
          </property>
         </widget>
        </item>
-       <item row="40" column="0">
+       <item row="41" column="0">
         <widget class="QLabel" name="labelLongTouchDuration">
          <property name="text">
           <string>Long Touch Duration</string>
          </property>
         </widget>
        </item>
-       <item row="55" column="0">
+       <item row="56" column="0">
         <widget class="QLabel" name="labelAutoCheck">
          <property name="text">
           <string>Check on startup</string>
          </property>
         </widget>
        </item>
-       <item row="46" column="1" colspan="5">
+       <item row="47" column="1" colspan="5">
         <widget class="QSlider" name="sliderToleranceDistanceController">
          <property name="minimum">
           <number>0</number>
@@ -1301,7 +1324,7 @@ Fullscreen Exclusive Mode - the game will cover the entirety of your screen and 
          </property>
         </widget>
        </item>
-       <item row="38" column="1" colspan="5">
+       <item row="39" column="1" colspan="5">
         <widget class="QSlider" name="sliderRelativeCursorSpeed">
          <property name="minimum">
           <number>100</number>
@@ -1320,7 +1343,7 @@ Fullscreen Exclusive Mode - the game will cover the entirety of your screen and 
          </property>
         </widget>
        </item>
-       <item row="27" column="0">
+       <item row="28" column="0">
         <widget class="QLabel" name="labelScalingFont">
          <property name="text">
           <string>Font Scaling (experimental)</string>
@@ -1343,7 +1366,7 @@ Fullscreen Exclusive Mode - the game will cover the entirety of your screen and 
          </property>
         </widget>
        </item>
-       <item row="33" column="1" colspan="5">
+       <item row="34" column="1" colspan="5">
         <widget class="QSlider" name="slideToleranceDistanceMouse">
          <property name="minimum">
           <number>0</number>
@@ -1378,7 +1401,7 @@ Fullscreen Exclusive Mode - the game will cover the entirety of your screen and 
          </property>
         </widget>
        </item>
-       <item row="26" column="5">
+       <item row="27" column="5">
         <widget class="QToolButton" name="buttonFontOriginal">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
@@ -1416,14 +1439,14 @@ Fullscreen Exclusive Mode - the game will cover the entirety of your screen and 
          </property>
         </widget>
        </item>
-       <item row="44" column="0">
+       <item row="45" column="0">
         <widget class="QLabel" name="labelControllerSticksSensitivity">
          <property name="text">
           <string>Sticks Sensitivity</string>
          </property>
         </widget>
        </item>
-       <item row="24" column="0">
+       <item row="25" column="0">
         <widget class="QLabel" name="labelUpscalingFilter">
          <property name="text">
           <string>Upscaling Filter</string>
@@ -1447,7 +1470,7 @@ Fullscreen Exclusive Mode - the game will cover the entirety of your screen and 
        <item row="12" column="1" colspan="5">
         <widget class="QComboBox" name="comboBoxResolution"/>
        </item>
-       <item row="61" column="3" colspan="2">
+       <item row="62" column="3" colspan="2">
         <widget class="QToolButton" name="buttonValidationBasic">
          <property name="enabled">
           <bool>true</bool>


### PR DESCRIPTION
Adds setting to allow portrait mode change by screen rotation on android. No layout changes yet (so: not optimal for smartphones, but good for tablets). Splitscreen is working nicely too.

Also fixes grey bar after switching app.

Portrait mode:
- Related #3765

Gray bar:
- Fixes #4141 
- Fixes #5362
- Related #4336

@kambala-decapitator Don't have an iOS device. If you interested you could also add iOS support afterwards.