### PR TITLE
[1.6.6] Show total movement cost for multi-turn paths

### DIFF
--- a/Mods/vcmi/Content/config/chinese.json
+++ b/Mods/vcmi/Content/config/chinese.json
@@ -23,8 +23,6 @@
 	"vcmi.adventureMap.noTownWithTavern"       : "没有酒馆可供查看。",
 	"vcmi.adventureMap.spellUnknownProblem"    : "无此魔法的信息。",
 	"vcmi.adventureMap.playerAttacked"         : "玩家遭受攻击: %s",
-	"vcmi.adventureMap.moveCostDetails"        : "移动点数 - 花费: %TURNS 轮 + %POINTS 点移动力, 剩余移动力: %REMAINING",
-	"vcmi.adventureMap.moveCostDetailsNoTurns" : "移动点数 - 花费: %POINTS 点移动力, 剩余移动力: %REMAINING",
 	"vcmi.adventureMap.movementPointsHeroInfo" 			 : "(移动点数: %REMAINING / %POINTS)",
 	"vcmi.adventureMap.replayOpponentTurnNotImplemented" : "抱歉，重放对手行动功能目前暂未实现！",
 

--- a/Mods/vcmi/Content/config/czech.json
+++ b/Mods/vcmi/Content/config/czech.json
@@ -23,8 +23,6 @@
 	"vcmi.adventureMap.noTownWithTavern"       : "Nejsou dostupná žádná města s putykou!",
 	"vcmi.adventureMap.spellUnknownProblem"    : "Neznámý problém s tímto kouzlem! Další informace nejsou k dispozici.",
 	"vcmi.adventureMap.playerAttacked"         : "Hráč byl napaden: %s",
-	"vcmi.adventureMap.moveCostDetails"        : "Body pohybu - Cena: %TURNS tahů + %POINTS bodů, zbylé body: %REMAINING",
-	"vcmi.adventureMap.moveCostDetailsNoTurns" : "Body pohybu - Cena: %POINTS bodů, zbylé body: %REMAINING",
 	"vcmi.adventureMap.movementPointsHeroInfo" 			 : "(Body pohybu: %REMAINING / %POINTS)",
 	"vcmi.adventureMap.replayOpponentTurnNotImplemented" : "Omlouváme se, přehrání tahu soupeře ještě není implementováno!",
 

--- a/Mods/vcmi/Content/config/english.json
+++ b/Mods/vcmi/Content/config/english.json
@@ -23,9 +23,9 @@
 	"vcmi.adventureMap.noTownWithTavern"                 : "There are no available towns with taverns!",
 	"vcmi.adventureMap.spellUnknownProblem"              : "There is an unknown problem with this spell! No more information is available.",
 	"vcmi.adventureMap.playerAttacked"                   : "Player has been attacked: %s",
-	"vcmi.adventureMap.moveCostDetails"                  : "Movement points - Cost: %TURNS turns + %POINTS points, Remaining points: %REMAINING",
-	"vcmi.adventureMap.moveCostDetailsNoTurns"           : "Movement points - Cost: %POINTS points, Remaining points: %REMAINING",
-	"vcmi.adventureMap.movementPointsHeroInfo" 			 : "(Movement points: %REMAINING / %POINTS)",
+	"vcmi.adventureMap.moveCostDetails"                  : "Moving here will cost {%TOTAL} points in total ({%TURNS} turns and {%POINTS} points). {%REMAINING} points will remain after moving.",
+	"vcmi.adventureMap.moveCostDetailsNoTurns"           : "Moving here will cost {%POINTS} points. {%REMAINING} points will remain after moving.",
+	"vcmi.adventureMap.movementPointsHeroInfo"           : "(Movement points: %REMAINING / %POINTS)",
 	"vcmi.adventureMap.replayOpponentTurnNotImplemented" : "Sorry, replay opponent turn is not implemented yet!",
 
 	"vcmi.bonusSource.artifact" : "Artifact",

--- a/Mods/vcmi/Content/config/french.json
+++ b/Mods/vcmi/Content/config/french.json
@@ -18,8 +18,6 @@
 	"vcmi.adventureMap.noTownWithTavern"       : "Il n'y a pas de villes disponibles avec des tavernes !",
 	"vcmi.adventureMap.spellUnknownProblem"    : "Il y a un problème inconnu avec ce sort ! Pas plus d'informations sont disponibles.",
 	"vcmi.adventureMap.playerAttacked"         : "Le joueur a été attaqué : %s",
-	"vcmi.adventureMap.moveCostDetails"        : "Points de mouvement - Coût : %TURNS tours + %POINTS points, Points restants : %REMAINING",
-	"vcmi.adventureMap.moveCostDetailsNoTurns" : "Points de mouvement - Coût : %POINTS points, Points restants : %REMAINING",
 
 	"vcmi.capitalColors.0" : "Rouge",
 	"vcmi.capitalColors.1" : "Bleu",

--- a/Mods/vcmi/Content/config/german.json
+++ b/Mods/vcmi/Content/config/german.json
@@ -23,8 +23,6 @@
 	"vcmi.adventureMap.noTownWithTavern"                 : "Keine Stadt mit Taverne verfügbar!",
 	"vcmi.adventureMap.spellUnknownProblem"              : "Unbekanntes Problem mit diesem Zauberspruch, keine weiteren Informationen verfügbar.",
 	"vcmi.adventureMap.playerAttacked"                   : "Spieler wurde attackiert: %s",
-	"vcmi.adventureMap.moveCostDetails"                  : "Bewegungspunkte - Kosten: %TURNS Runden + %POINTS Punkte, Verbleibende Punkte: %REMAINING",
-	"vcmi.adventureMap.moveCostDetailsNoTurns"           : "Bewegungspunkte - Kosten: %POINTS Punkte, Verbleibende Punkte: %REMAINING",
 	"vcmi.adventureMap.movementPointsHeroInfo" 			 : "(Bewegungspunkte: %REMAINING / %POINTS)",
 	"vcmi.adventureMap.replayOpponentTurnNotImplemented" : "Das Wiederholen des gegnerischen Zuges ist aktuell noch nicht implementiert!",
 

--- a/Mods/vcmi/Content/config/hungarian.json
+++ b/Mods/vcmi/Content/config/hungarian.json
@@ -23,8 +23,6 @@
 	"vcmi.adventureMap.noTownWithTavern"                 : "Nincsenek elérhető kocsmával rendelkező városok!",
 	"vcmi.adventureMap.spellUnknownProblem"              : "Ismeretlen probléma van ezzel a varázslattal! További információ nem érhető el.",
 	"vcmi.adventureMap.playerAttacked"                   : "A játékost megtámadták: %s",
-	"vcmi.adventureMap.moveCostDetails"                  : "Mozgáspontok - Költség: %TURNS kör + %POINTS pont, Hátralévő pontok: %REMAINING",
-	"vcmi.adventureMap.moveCostDetailsNoTurns"           : "Mozgáspontok - Költség: %POINTS pont, Hátralévő pontok: %REMAINING",
 	"vcmi.adventureMap.movementPointsHeroInfo" 			 : "(Mozgáspontok: %REMAINING / %POINTS)",
 	"vcmi.adventureMap.replayOpponentTurnNotImplemented" : "Sajnáljuk, az ellenfél körének visszajátszása még nincs megvalósítva!",
 

--- a/Mods/vcmi/Content/config/polish.json
+++ b/Mods/vcmi/Content/config/polish.json
@@ -23,8 +23,6 @@
 	"vcmi.adventureMap.noTownWithTavern"       : "Brak dostępnego miasta z karczmą!",
 	"vcmi.adventureMap.spellUnknownProblem"    : "Nieznany problem z zaklęciem, brak dodatkowych informacji.",
 	"vcmi.adventureMap.playerAttacked"         : "Gracz został zaatakowany: %s",
-	"vcmi.adventureMap.moveCostDetails"        : "Punkty ruchu - Koszt: %TURNS tury + %POINTS punktów, Pozostanie: %REMAINING punktów",
-	"vcmi.adventureMap.moveCostDetailsNoTurns" : "Punkty ruchu - Koszt: %POINTS punktów, Pozostanie: %REMAINING punktów",
 	"vcmi.adventureMap.movementPointsHeroInfo" : "(Punkty ruchu: %REMAINING / %POINTS)",
 	"vcmi.adventureMap.replayOpponentTurnNotImplemented" : "Wybacz, powtórka ruchu wroga nie została jeszcze zaimplementowana!",
 

--- a/Mods/vcmi/Content/config/portuguese.json
+++ b/Mods/vcmi/Content/config/portuguese.json
@@ -23,8 +23,6 @@
 	"vcmi.adventureMap.noTownWithTavern"                 : "Não há cidades disponíveis com tavernas!",
 	"vcmi.adventureMap.spellUnknownProblem"              : "Há um problema desconhecido com este feitiço! Não há mais informações disponíveis.",
 	"vcmi.adventureMap.playerAttacked"                   : "O jogador foi atacado: %s",
-	"vcmi.adventureMap.moveCostDetails"                  : "Pontos de movimento - Custo: %TURNS turnos + %POINTS pontos, Pontos restantes: %REMAINING",
-	"vcmi.adventureMap.moveCostDetailsNoTurns"           : "Pontos de movimento - Custo: %POINTS pontos, Pontos restantes: %REMAINING",
 	"vcmi.adventureMap.movementPointsHeroInfo" 			 : "(Pontos de movimento: %REMAINING / %POINTS)",
 	"vcmi.adventureMap.replayOpponentTurnNotImplemented" : "Desculpe, a repetição do turno do oponente ainda não está implementada!",
 

--- a/Mods/vcmi/Content/config/russian.json
+++ b/Mods/vcmi/Content/config/russian.json
@@ -18,8 +18,6 @@
 	"vcmi.adventureMap.noTownWithTavern"       : "Нет союзных городов с тавернами!",
 	"vcmi.adventureMap.spellUnknownProblem"    : "Неизвестная проблема с заклинанием, дополнительная информация недоступна.",
 	"vcmi.adventureMap.playerAttacked"         : "Игрок атакован: %s",
-	"vcmi.adventureMap.moveCostDetails"        : "Очки движения - Стоимость: %TURNS ходов + %POINTS очков, Останется: %REMAINING очков",
-	"vcmi.adventureMap.moveCostDetailsNoTurns" : "Очки движения - Стоимость: %POINTS очков, Останется: %REMAINING очков",
 
 	"vcmi.capitalColors.0" : "Красный",
 	"vcmi.capitalColors.1" : "Синий",

--- a/Mods/vcmi/Content/config/spanish.json
+++ b/Mods/vcmi/Content/config/spanish.json
@@ -18,8 +18,6 @@
 	"vcmi.adventureMap.noTownWithTavern"       : "¡No hay pueblo disponible con taberna!",
 	"vcmi.adventureMap.spellUnknownProblem"    : "Problema desconocido con este hechizo, no hay más información disponible.",
 	"vcmi.adventureMap.playerAttacked"         : "El jugador ha sido atacado: %s",
-	"vcmi.adventureMap.moveCostDetails"        : "Puntos de movimiento - Coste: %TURNS turnos + %POINTS puntos, Puntos restantes: %REMAINING",
-	"vcmi.adventureMap.moveCostDetailsNoTurns" : "Puntos de movimiento - Coste: %POINTS puntos, Puntos restantes: %REMAINING",
 	"vcmi.adventureMap.replayOpponentTurnNotImplemented" : "Disculpe, la repetición del turno del oponente aún no está implementada.",
 
 	"vcmi.capitalColors.0" : "Rojo",

--- a/Mods/vcmi/Content/config/swedish.json
+++ b/Mods/vcmi/Content/config/swedish.json
@@ -23,8 +23,6 @@
 	"vcmi.adventureMap.noTownWithTavern"                 : "Det finns inga tillgängliga städer med värdshus!",
 	"vcmi.adventureMap.spellUnknownProblem"              : "Det finns ett okänt problem med den här trollformeln! Ingen mer information är tillgänglig.",
 	"vcmi.adventureMap.playerAttacked"                   : "Spelare har blivit attackerad: %s",
-	"vcmi.adventureMap.moveCostDetails"                  : "Förflyttningspoängs-kostnad: %TURNS tur(er) + %POINTS poäng - Återstående poäng: %REMAINING",
-	"vcmi.adventureMap.moveCostDetailsNoTurns"           : "Förflyttningspoängs-kostnad: %POINTS poäng - Återstående poäng: %REMAINING",
 	"vcmi.adventureMap.movementPointsHeroInfo"           : "(Förflyttningspoäng: %REMAINING / %POINTS)",
 	"vcmi.adventureMap.replayOpponentTurnNotImplemented" : "Tyvärr, att spela om motståndarens tur är inte implementerat ännu!",
 

--- a/Mods/vcmi/Content/config/ukrainian.json
+++ b/Mods/vcmi/Content/config/ukrainian.json
@@ -23,8 +23,8 @@
 	"vcmi.adventureMap.noTownWithTavern"    : "Немає доступного міста з таверною!",
 	"vcmi.adventureMap.spellUnknownProblem" : "Невідома проблема з цим заклинанням, більше інформації немає.",
 	"vcmi.adventureMap.playerAttacked"      : "Гравця атаковано: %s",
-	"vcmi.adventureMap.moveCostDetails" : "Очки руху - Вартість: %TURNS ходів + %POINTS очок. Залишок очок: %REMAINING",
-	"vcmi.adventureMap.moveCostDetailsNoTurns" : "Очки руху - Вартість: %POINTS очок, Залишок очок: %REMAINING",
+	"vcmi.adventureMap.moveCostDetails"     : "Переміщення сюди коштуватиме {%TOTAL} очок загалом ({%TURNS} ходів і {%POINTS} очок). Після переміщення залишиться {%REMAINING} очок.",
+	"vcmi.adventureMap.moveCostDetailsNoTurns" : "Переміщення сюди коштуватиме {%TOTAL} очок. Після переміщення залишиться {%REMAINING} очок.",
 	"vcmi.adventureMap.movementPointsHeroInfo" : "(Очки руху: %REMAINING / %POINTS)",
 	"vcmi.adventureMap.replayOpponentTurnNotImplemented" : "Вибачте, функція повтору ходу суперника ще не реалізована!",
 

--- a/Mods/vcmi/Content/config/vietnamese.json
+++ b/Mods/vcmi/Content/config/vietnamese.json
@@ -23,8 +23,6 @@
 	"vcmi.adventureMap.noTownWithTavern": "Thành không có sẵn quán rượu!",
 	"vcmi.adventureMap.spellUnknownProblem": "Phép này có lỗi! Không có thông tin nào khác.",
 	"vcmi.adventureMap.playerAttacked": "Người chơi bị tấn công: %s",
-	"vcmi.adventureMap.moveCostDetails": "Điểm di chuyển - Cần: %TURNS lượt + %POINTS điểm, Còn lại: %REMAINING",
-	"vcmi.adventureMap.moveCostDetailsNoTurns": "Điểm di chuyển - Cần: %POINTS điểm, Còn lại: %REMAINING",
 	"vcmi.adventureMap.movementPointsHeroInfo": "(Điểm di chuyển: %REMAINING / %POINTS)",
 	"vcmi.adventureMap.replayOpponentTurnNotImplemented": "Xin lỗi, lượt chơi lại của đối thủ vẫn chưa được triển khai!",
 


### PR DESCRIPTION
Game will now show both total cost in movement point as well as expected time to arrive in turns when hovering over reachable location.

Also changed string phrasing to more natural and added formatting for numbers.