### PR TITLE
[1.7] SDL access cleanup and encapsulation

### DIFF
--- a/client/CMT.h
+++ b/client/CMT.h
@@ -16,9 +16,7 @@ struct SDL_Surface;
 extern SDL_Texture * screenTexture;
 extern SDL_Renderer * mainRenderer;
 
-extern SDL_Surface *screen;      // main screen surface
-extern SDL_Surface *screen2;     // and hlp surface (used to store not-active interfaces layer)
-extern SDL_Surface *screenBuf; // points to screen (if only advmapint is present) or screen2 (else) - should be used when updating controls which are not regularly redrawed
+extern SDL_Surface *screen;
 
 /// Notify user about encountered fatal error and terminate the game
 /// Defined in clientapp EntryPoint

--- a/client/CMT.h
+++ b/client/CMT.h
@@ -9,11 +9,7 @@
  */
 #pragma once
 
-struct SDL_Texture;
 struct SDL_Renderer;
-struct SDL_Surface;
-
-extern SDL_Texture * screenTexture;
 extern SDL_Renderer * mainRenderer;
 
 /// Notify user about encountered fatal error and terminate the game

--- a/client/CMT.h
+++ b/client/CMT.h
@@ -16,8 +16,6 @@ struct SDL_Surface;
 extern SDL_Texture * screenTexture;
 extern SDL_Renderer * mainRenderer;
 
-extern SDL_Surface *screen;
-
 /// Notify user about encountered fatal error and terminate the game
 /// Defined in clientapp EntryPoint
 /// TODO: decide on better location for this method

--- a/client/adventureMap/AdventureMapInterface.cpp
+++ b/client/adventureMap/AdventureMapInterface.cpp
@@ -131,8 +131,6 @@ void AdventureMapInterface::activate()
 
 	adjustActiveness();
 
-	screenBuf = screen;
-	
 	if(LOCPLINT)
 	{
 		LOCPLINT->cingconsole->activate();
@@ -453,8 +451,7 @@ void AdventureMapInterface::onPlayerTurnStarted(PlayerColor playerID)
 		widget->getInfoBar()->showDate();
 
 	onHeroChanged(nullptr);
-	Canvas canvas = Canvas::createFromSurface(screen, CanvasScalingPolicy::AUTO);
-	showAll(canvas);
+	GH.windows().totalRedraw();
 	mapAudio->onPlayerTurnStarted();
 
 	if(settings["session"]["autoSkip"].Bool() && !GH.isKeyboardShiftDown())

--- a/client/adventureMap/AdventureMapInterface.cpp
+++ b/client/adventureMap/AdventureMapInterface.cpp
@@ -34,7 +34,6 @@
 #include "../render/IImage.h"
 #include "../render/IRenderHandler.h"
 #include "../render/IScreenHandler.h"
-#include "../CMT.h"
 #include "../PlayerLocalState.h"
 #include "../CPlayerInterface.h"
 

--- a/client/gui/CGuiHandler.cpp
+++ b/client/gui/CGuiHandler.cpp
@@ -27,7 +27,6 @@
 #include "../render/EFont.h"
 #include "../renderSDL/ScreenHandler.h"
 #include "../renderSDL/RenderHandler.h"
-#include "../CMT.h"
 #include "../CPlayerInterface.h"
 #include "../battle/BattleInterface.h"
 

--- a/client/gui/CGuiHandler.cpp
+++ b/client/gui/CGuiHandler.cpp
@@ -111,7 +111,7 @@ void CGuiHandler::renderFrame()
 		CCS->curh->update();
 	}
 
-	screenHandlerInstance->presetScreenTexture();
+	screenHandlerInstance->presentScreenTexture();
 	framerate().framerateDelay(); // holds a constant FPS
 }
 

--- a/client/gui/CIntObject.cpp
+++ b/client/gui/CIntObject.cpp
@@ -17,7 +17,6 @@
 #include "../render/Canvas.h"
 #include "../render/IScreenHandler.h"
 #include "../windows/CMessage.h"
-#include "../CMT.h"
 
 CIntObject::CIntObject(int used_, Point pos_):
 	parent_m(nullptr),

--- a/client/gui/CIntObject.cpp
+++ b/client/gui/CIntObject.cpp
@@ -15,6 +15,7 @@
 #include "EventDispatcher.h"
 #include "Shortcut.h"
 #include "../render/Canvas.h"
+#include "../render/IScreenHandler.h"
 #include "../windows/CMessage.h"
 #include "../CMT.h"
 
@@ -238,7 +239,7 @@ void CIntObject::redraw()
 		}
 		else
 		{
-			Canvas buffer = Canvas::createFromSurface(screen, CanvasScalingPolicy::AUTO);
+			Canvas buffer = GH.screenHandler().getScreenCanvas();
 			showAll(buffer);
 		}
 	}

--- a/client/gui/CIntObject.cpp
+++ b/client/gui/CIntObject.cpp
@@ -238,15 +238,8 @@ void CIntObject::redraw()
 		}
 		else
 		{
-			Canvas buffer = Canvas::createFromSurface(screenBuf, CanvasScalingPolicy::AUTO);
-
+			Canvas buffer = Canvas::createFromSurface(screen, CanvasScalingPolicy::AUTO);
 			showAll(buffer);
-			if(screenBuf != screen)
-			{
-				Canvas screenBuffer = Canvas::createFromSurface(screen, CanvasScalingPolicy::AUTO);
-
-				showAll(screenBuffer);
-			}
 		}
 	}
 }

--- a/client/gui/CursorHandler.cpp
+++ b/client/gui/CursorHandler.cpp
@@ -261,13 +261,18 @@ void CursorHandler::updateSpellcastCursor()
 
 void CursorHandler::render()
 {
+	cursor->render();
+}
+
+void CursorHandler::update()
+{
 	if(!showing)
 		return;
 
 	if (type == Cursor::Type::SPELLBOOK)
 		updateSpellcastCursor();
 
-	cursor->render();
+	cursor->update();
 }
 
 void CursorHandler::hide()

--- a/client/gui/CursorHandler.h
+++ b/client/gui/CursorHandler.h
@@ -179,6 +179,7 @@ public:
 	Point getPivotOffsetCombat(size_t index);
 
 	void render();
+	void update();
 
 	void hide();
 	void show();

--- a/client/gui/WindowHandler.cpp
+++ b/client/gui/WindowHandler.cpp
@@ -14,12 +14,10 @@
 #include "CIntObject.h"
 #include "CursorHandler.h"
 
-#include "../CMT.h"
 #include "../CGameInfo.h"
 #include "../render/Canvas.h"
 #include "../render/IScreenHandler.h"
 #include "../render/Colors.h"
-#include "../renderSDL/SDL_Extensions.h"
 
 void WindowHandler::popWindow(std::shared_ptr<IShowActivatable> top)
 {

--- a/client/gui/WindowHandler.cpp
+++ b/client/gui/WindowHandler.cpp
@@ -42,9 +42,6 @@ void WindowHandler::pushWindow(std::shared_ptr<IShowActivatable> newInt)
 	if (vstd::contains(windowsStack, newInt))
 		throw std::runtime_error("Attempt to add already existing window to stack!");
 
-	//a new interface will be present, we'll need to use buffer surface (unless it's advmapint that will alter screenBuf on activate anyway)
-	screenBuf = screen2;
-
 	if(!windowsStack.empty())
 		windowsStack.back()->deactivate();
 	windowsStack.push_back(newInt);
@@ -111,11 +108,10 @@ void WindowHandler::totalRedrawImpl()
 {
 	logGlobal->debug("totalRedraw requested!");
 
-	Canvas target = Canvas::createFromSurface(screen2, CanvasScalingPolicy::AUTO);
+	Canvas target = Canvas::createFromSurface(screen, CanvasScalingPolicy::AUTO);
 
 	for(auto & elem : windowsStack)
 		elem->showAll(target);
-	CSDL_Ext::blitAt(screen2, 0, 0, screen);
 }
 
 void WindowHandler::simpleRedraw()
@@ -130,10 +126,6 @@ void WindowHandler::simpleRedraw()
 
 void WindowHandler::simpleRedrawImpl()
 {
-	//update only top interface and draw background
-	if(windowsStack.size() > 1)
-		CSDL_Ext::blitAt(screen2, 0, 0, screen); //blit background
-
 	Canvas target = Canvas::createFromSurface(screen, CanvasScalingPolicy::AUTO);
 
 	if(!windowsStack.empty())

--- a/client/gui/WindowHandler.cpp
+++ b/client/gui/WindowHandler.cpp
@@ -17,6 +17,7 @@
 #include "../CMT.h"
 #include "../CGameInfo.h"
 #include "../render/Canvas.h"
+#include "../render/IScreenHandler.h"
 #include "../render/Colors.h"
 #include "../renderSDL/SDL_Extensions.h"
 
@@ -108,7 +109,7 @@ void WindowHandler::totalRedrawImpl()
 {
 	logGlobal->debug("totalRedraw requested!");
 
-	Canvas target = Canvas::createFromSurface(screen, CanvasScalingPolicy::AUTO);
+	Canvas target = GH.screenHandler().getScreenCanvas();
 
 	for(auto & elem : windowsStack)
 		elem->showAll(target);
@@ -126,7 +127,7 @@ void WindowHandler::simpleRedraw()
 
 void WindowHandler::simpleRedrawImpl()
 {
-	Canvas target = Canvas::createFromSurface(screen, CanvasScalingPolicy::AUTO);
+	Canvas target = GH.screenHandler().getScreenCanvas();
 
 	if(!windowsStack.empty())
 		windowsStack.back()->show(target); //blit active interface/window

--- a/client/render/ICursor.h
+++ b/client/render/ICursor.h
@@ -23,6 +23,7 @@ public:
 	virtual void setImage(std::shared_ptr<IImage> image, const Point & pivotOffset) = 0;
 	virtual void setCursorPosition( const Point & newPos ) = 0;
 	virtual void render() = 0;
+	virtual void update() = 0;
 	virtual void setVisible( bool on) = 0;
 };
 

--- a/client/render/IScreenHandler.h
+++ b/client/render/IScreenHandler.h
@@ -15,6 +15,8 @@ class Point;
 class Rect;
 VCMI_LIB_NAMESPACE_END
 
+class Canvas;
+
 class IScreenHandler
 {
 public:
@@ -28,6 +30,15 @@ public:
 
 	/// Fills screen with black color, erasing any existing content
 	virtual void clearScreen() = 0;
+
+	/// Returns canvas that can be used to display objects on screen
+	virtual Canvas getScreenCanvas() const = 0;
+
+	/// Synchronizes internal screen texture. Screen canvas may not be modified during this call
+	virtual void updateScreenTexture() = 0;
+
+	/// Presents screen texture on the screen
+	virtual void presetScreenTexture() = 0;
 
 	/// Returns list of resolutions supported by current screen
 	virtual std::vector<Point> getSupportedResolutions() const = 0;

--- a/client/render/IScreenHandler.h
+++ b/client/render/IScreenHandler.h
@@ -38,7 +38,7 @@ public:
 	virtual void updateScreenTexture() = 0;
 
 	/// Presents screen texture on the screen
-	virtual void presetScreenTexture() = 0;
+	virtual void presentScreenTexture() = 0;
 
 	/// Returns list of resolutions supported by current screen
 	virtual std::vector<Point> getSupportedResolutions() const = 0;

--- a/client/renderSDL/CursorHardware.cpp
+++ b/client/renderSDL/CursorHardware.cpp
@@ -92,3 +92,8 @@ void CursorHardware::render()
 {
 	//no-op
 }
+
+void CursorHardware::update()
+{
+	//no-op
+}

--- a/client/renderSDL/CursorHardware.h
+++ b/client/renderSDL/CursorHardware.h
@@ -30,6 +30,7 @@ public:
 	void setImage(std::shared_ptr<IImage> image, const Point & pivotOffset) override;
 	void setCursorPosition( const Point & newPos ) override;
 	void render() override;
+	void update() override;
 	void setVisible( bool on) override;
 };
 

--- a/client/renderSDL/CursorSoftware.cpp
+++ b/client/renderSDL/CursorSoftware.cpp
@@ -21,12 +21,15 @@
 #include <SDL_render.h>
 #include <SDL_events.h>
 
-void CursorSoftware::render()
+void CursorSoftware::update()
 {
 	//texture must be updated in the main (renderer) thread, but changes to cursor type may come from other threads
 	if (needUpdate)
 		updateTexture();
+}
 
+void CursorSoftware::render()
+{
 	Point renderPos = pos - pivot;
 
 	SDL_Rect destRect;

--- a/client/renderSDL/CursorSoftware.h
+++ b/client/renderSDL/CursorSoftware.h
@@ -38,6 +38,7 @@ public:
 	void setImage(std::shared_ptr<IImage> image, const Point & pivotOffset) override;
 	void setCursorPosition( const Point & newPos ) override;
 	void render() override;
+	void update() override;
 	void setVisible( bool on) override;
 };
 

--- a/client/renderSDL/SDLImage.cpp
+++ b/client/renderSDL/SDLImage.cpp
@@ -324,10 +324,21 @@ void SDLImageShared::exportBitmap(const boost::filesystem::path& path, SDL_Palet
 bool SDLImageShared::isTransparent(const Point & coords) const
 {
 	assert(upscalingInProgress == false);
-	if (surf)
-		return CSDL_Ext::isTransparent(surf, coords.x - margins.x, coords.y	- margins.y);
-	else
+	if (!surf)
 		return true;
+
+	Point test = coords - margins;
+
+	if (test.x < 0 || test.y < 0 || test.x >= surf->w || test.y >= surf->h)
+		return true;
+
+	SDL_Color color;
+	SDL_GetRGBA(CSDL_Ext::getPixel(surf, test.x, test.y), surf->format, &color.r, &color.g, &color.b, &color.a);
+
+	bool pixelTransparent = color.a < 128;
+	bool pixelCyan = (color.r == 0 && color.g == 255 && color.b == 255);
+
+	return pixelTransparent || pixelCyan;
 }
 
 Rect SDLImageShared::contentRect() const

--- a/client/renderSDL/SDLImageScaler.cpp
+++ b/client/renderSDL/SDLImageScaler.cpp
@@ -12,7 +12,6 @@
 
 #include "SDL_Extensions.h"
 
-#include "../CMT.h"
 #include "../xBRZ/xbrz.h"
 
 #include <tbb/parallel_for.h>

--- a/client/renderSDL/SDLImageScaler.cpp
+++ b/client/renderSDL/SDLImageScaler.cpp
@@ -211,7 +211,7 @@ SDLImageScaler::SDLImageScaler(SDL_Surface * surf, const Rect & virtualDimension
 	if (optimizeImage)
 	{
 		SDLImageOptimizer optimizer(surf, virtualDimensions);
-		optimizer.optimizeSurface(screen);
+		optimizer.optimizeSurface(nullptr);
 		intermediate = optimizer.acquireResultSurface();
 		virtualDimensionsInput = optimizer.getResultDimensions();
 	}

--- a/client/renderSDL/SDL_Extensions.cpp
+++ b/client/renderSDL/SDL_Extensions.cpp
@@ -59,16 +59,6 @@ SDL_Color CSDL_Ext::toSDL(const ColorRGBA & color)
 	return result;
 }
 
-void CSDL_Ext::setColors(SDL_Surface *surface, SDL_Color *colors, int firstcolor, int ncolors)
-{
-	SDL_SetPaletteColors(surface->format->palette,colors,firstcolor,ncolors);
-}
-
-void CSDL_Ext::setAlpha(SDL_Surface * bg, int value)
-{
-	SDL_SetSurfaceAlphaMod(bg, value);
-}
-
 SDL_Surface * CSDL_Ext::newSurface(const Point & dimensions)
 {
 	return newSurface(dimensions, nullptr);
@@ -100,25 +90,6 @@ SDL_Surface * CSDL_Ext::newSurface(const Point & dimensions, SDL_Surface * mod) 
 		memcpy(ret->format->palette->colors, mod->format->palette->colors, mod->format->palette->ncolors * sizeof(SDL_Color));
 	}
 	return ret;
-}
-
-SDL_Surface * CSDL_Ext::copySurface(SDL_Surface * mod) //returns copy of given surface
-{
-	//return SDL_DisplayFormat(mod);
-	return SDL_ConvertSurface(mod, mod->format, mod->flags);
-}
-
-template<int bpp>
-SDL_Surface * CSDL_Ext::createSurfaceWithBpp(int width, int height)
-{
-	uint32_t rMask = 0, gMask = 0, bMask = 0, aMask = 0;
-
-	Channels::px<bpp>::r.set((uint8_t*)&rMask, 255);
-	Channels::px<bpp>::g.set((uint8_t*)&gMask, 255);
-	Channels::px<bpp>::b.set((uint8_t*)&bMask, 255);
-	Channels::px<bpp>::a.set((uint8_t*)&aMask, 255);
-
-	return SDL_CreateRGBSurface(0, width, height, bpp * 8, rMask, gMask, bMask, aMask);
 }
 
 void CSDL_Ext::blitAt(SDL_Surface * src, int x, int y, SDL_Surface * dst)
@@ -542,54 +513,23 @@ void CSDL_Ext::drawBorder( SDL_Surface * sur, const Rect &r, const SDL_Color &co
 	drawBorder(sur, r.x, r.y, r.w, r.h, color, depth);
 }
 
-CSDL_Ext::TColorPutter CSDL_Ext::getPutterFor(SDL_Surface * const &dest)
-{
-	switch(dest->format->BytesPerPixel)
-	{
-		case 3:
-			return ColorPutter<3>::PutColor;
-		case 4:
-			return ColorPutter<4>::PutColor;
-	default:
-		logGlobal->error("%d bpp is not supported!", (int)dest->format->BitsPerPixel);
-		return nullptr;
-	}
-}
-
 uint8_t * CSDL_Ext::getPxPtr(const SDL_Surface * const &srf, const int x, const int y)
 {
 	return (uint8_t *)srf->pixels + y * srf->pitch + x * srf->format->BytesPerPixel;
 }
 
-bool CSDL_Ext::isTransparent( SDL_Surface * srf, const Point & position )
-{
-	return isTransparent(srf, position.x, position.y);
-}
-
-bool CSDL_Ext::isTransparent( SDL_Surface * srf, int x, int y )
-{
-	if (x < 0 || y < 0 || x >= srf->w || y >= srf->h)
-		return true;
-
-	SDL_Color color;
-
-	SDL_GetRGBA(CSDL_Ext::getPixel(srf, x, y), srf->format, &color.r, &color.g, &color.b, &color.a);
-
-	bool pixelTransparent = color.a < 128;
-	bool pixelCyan = (color.r == 0 && color.g == 255 && color.b == 255);
-
-	return pixelTransparent || pixelCyan;
-}
-
 void CSDL_Ext::putPixelWithoutRefresh(SDL_Surface *ekran, const int & x, const int & y, const uint8_t & R, const uint8_t & G, const uint8_t & B, uint8_t A)
 {
 	uint8_t *p = getPxPtr(ekran, x, y);
-	getPutterFor(ekran)(p, R, G, B);
 
 	switch(ekran->format->BytesPerPixel)
 	{
-	case 3: Channels::px<3>::a.set(p, A); break;
-	case 4: Channels::px<4>::a.set(p, A); break;
+	case 3:
+		ColorPutter<3>::PutColor(p, R, G, B);
+		Channels::px<3>::a.set(p, A); break;
+	case 4:
+		ColorPutter<4>::PutColor(p, R, G, B);
+		Channels::px<4>::a.set(p, A); break;
 	}
 }
 
@@ -724,6 +664,3 @@ void CSDL_Ext::getClipRect(SDL_Surface * src, Rect & other)
 
 	other = CSDL_Ext::fromSDL(rect);
 }
-
-template SDL_Surface * CSDL_Ext::createSurfaceWithBpp<3>(int, int);
-template SDL_Surface * CSDL_Ext::createSurfaceWithBpp<4>(int, int);

--- a/client/renderSDL/SDL_Extensions.cpp
+++ b/client/renderSDL/SDL_Extensions.cpp
@@ -71,24 +71,29 @@ void CSDL_Ext::setAlpha(SDL_Surface * bg, int value)
 
 SDL_Surface * CSDL_Ext::newSurface(const Point & dimensions)
 {
-	return newSurface(dimensions, screen);
+	return newSurface(dimensions, nullptr);
 }
 
 SDL_Surface * CSDL_Ext::newSurface(const Point & dimensions, SDL_Surface * mod) //creates new surface, with flags/format same as in surface given
 {
-	SDL_Surface * ret = SDL_CreateRGBSurface(0,dimensions.x,dimensions.y,mod->format->BitsPerPixel,mod->format->Rmask,mod->format->Gmask,mod->format->Bmask,mod->format->Amask);
+	SDL_Surface * ret = nullptr;
+
+	if (mod != nullptr)
+		ret = SDL_CreateRGBSurface(0,dimensions.x,dimensions.y,mod->format->BitsPerPixel,mod->format->Rmask,mod->format->Gmask,mod->format->Bmask,mod->format->Amask);
+	else
+		ret = SDL_CreateRGBSurfaceWithFormat(0,dimensions.x,dimensions.y,32,SDL_PixelFormatEnum::SDL_PIXELFORMAT_ARGB8888);
 
 	if(ret == nullptr)
 	{
 		const char * error = SDL_GetError();
 
-		std::string messagePattern = "Failed to create SDL Surface of size %d x %d, %d bpp. Reason: %s";
-		std::string message = boost::str(boost::format(messagePattern) % dimensions.x % dimensions.y % mod->format->BitsPerPixel % error);
+		std::string messagePattern = "Failed to create SDL Surface of size %d x %d. Reason: %s";
+		std::string message = boost::str(boost::format(messagePattern) % dimensions.x % dimensions.y % error);
 
 		handleFatalError(message, true);
 	}
 
-	if (mod->format->palette)
+	if (mod && mod->format->palette)
 	{
 		assert(ret->format->palette);
 		assert(ret->format->palette->ncolors >= mod->format->palette->ncolors);

--- a/client/renderSDL/SDL_Extensions.h
+++ b/client/renderSDL/SDL_Extensions.h
@@ -13,19 +13,8 @@
 #include "../../lib/Color.h"
 
 struct SDL_Rect;
-struct SDL_Window;
-struct SDL_Renderer;
-struct SDL_Texture;
 struct SDL_Surface;
 struct SDL_Color;
-
-VCMI_LIB_NAMESPACE_BEGIN
-
-class PlayerColor;
-class Rect;
-class Point;
-
-VCMI_LIB_NAMESPACE_END
 
 namespace CSDL_Ext
 {
@@ -41,12 +30,6 @@ ColorRGBA fromSDL(const SDL_Color & color);
 
 /// creates SDL_Color using provided Color
 SDL_Color toSDL(const ColorRGBA & color);
-
-void setColors(SDL_Surface *surface, SDL_Color *colors, int firstcolor, int ncolors);
-void setAlpha(SDL_Surface * bg, int value);
-
-using TColorPutter = void (*)(uint8_t *&, const uint8_t &, const uint8_t &, const uint8_t &);
-using TColorPutterAlpha = void (*)(uint8_t *&, const uint8_t &, const uint8_t &, const uint8_t &, const uint8_t &);
 
 	void blitAt(SDL_Surface * src, int x, int y, SDL_Surface * dst);
 	void blitAt(SDL_Surface * src, const Rect & pos, SDL_Surface * dst);
@@ -67,11 +50,8 @@ using TColorPutterAlpha = void (*)(uint8_t *&, const uint8_t &, const uint8_t &,
 	SDL_Surface * verticalFlip(SDL_Surface * toRot); //vertical flip
 	SDL_Surface * horizontalFlip(SDL_Surface * toRot); //horizontal flip
 	uint32_t getPixel(SDL_Surface * surface, const int & x, const int & y, bool colorByte = false);
-	bool isTransparent(SDL_Surface * srf, int x, int y); //checks if surface is transparent at given position
-	bool isTransparent(SDL_Surface * srf, const Point & position); //checks if surface is transparent at given position
 
 	uint8_t * getPxPtr(const SDL_Surface * const & srf, const int x, const int y);
-	TColorPutter getPutterFor(SDL_Surface * const & dest);
 
 	template<int bpp, bool useAlpha>
 	int blit8bppAlphaTo24bppT(const SDL_Surface * src, const Rect & srcRect, SDL_Surface * dst, const Point & dstPoint, uint8_t alpha); //blits 8 bpp surface with alpha channel to 24 bpp surface
@@ -86,9 +66,6 @@ using TColorPutterAlpha = void (*)(uint8_t *&, const uint8_t &, const uint8_t &,
 
 	SDL_Surface * newSurface(const Point & dimensions, SDL_Surface * mod); //creates new surface, with flags/format same as in surface given
 	SDL_Surface * newSurface(const Point & dimensions); //creates new surface, with flags/format same as in screen surface
-	SDL_Surface * copySurface(SDL_Surface * mod); //returns copy of given surface
-	template<int bpp>
-	SDL_Surface * createSurfaceWithBpp(int width, int height); //create surface with give bits per pixels value
 
 	template<int bpp>
 	void convertToGrayscaleBpp(SDL_Surface * surf, const Rect & rect);
@@ -100,25 +77,4 @@ using TColorPutterAlpha = void (*)(uint8_t *&, const uint8_t &, const uint8_t &,
 	void setDefaultColorKey(SDL_Surface * surface);
 	///set key-color to 0,255,255 only if it exactly mapped
 	void setDefaultColorKeyPresize(SDL_Surface * surface);
-
-	/// helper that will safely set and un-set ClipRect for SDL_Surface
-	class CClipRectGuard: boost::noncopyable
-	{
-		SDL_Surface * surf;
-		Rect oldRect;
-
-		int getScalingFactor() const;
-
-	public:
-		CClipRectGuard(SDL_Surface * surface, const Rect & rect): surf(surface)
-		{
-			CSDL_Ext::getClipRect(surf, oldRect);
-			CSDL_Ext::setClipRect(surf, rect * getScalingFactor());
-		}
-
-		~CClipRectGuard()
-		{
-			CSDL_Ext::setClipRect(surf, oldRect);
-		}
-	};
 }

--- a/client/renderSDL/ScreenHandler.cpp
+++ b/client/renderSDL/ScreenHandler.cpp
@@ -34,9 +34,7 @@
 #include <SDL.h>
 
 // TODO: should be made into a private members of ScreenHandler
-static SDL_Window * mainWindow = nullptr;
 SDL_Renderer * mainRenderer = nullptr;
-SDL_Texture * screenTexture = nullptr;
 
 static const std::string NAME = GameConstants::VCMI_VERSION; //application name
 static constexpr Point heroes3Resolution = Point(800, 600);
@@ -633,7 +631,7 @@ void ScreenHandler::updateScreenTexture()
 	SDL_UpdateTexture(screenTexture, nullptr, screen->pixels, screen->pitch);
 }
 
-void ScreenHandler::presetScreenTexture()
+void ScreenHandler::presentScreenTexture()
 {
 	SDL_RenderClear(mainRenderer);
 	SDL_RenderCopy(mainRenderer, screenTexture, nullptr, nullptr);

--- a/client/renderSDL/ScreenHandler.cpp
+++ b/client/renderSDL/ScreenHandler.cpp
@@ -11,11 +11,14 @@
 #include "StdInc.h"
 #include "ScreenHandler.h"
 
+#include "../CGameInfo.h"
+#include "../CMT.h"
 #include "../eventsSDL/NotificationHandler.h"
 #include "../gui/CGuiHandler.h"
+#include "../gui/CursorHandler.h"
 #include "../gui/WindowHandler.h"
+#include "../render/Canvas.h"
 #include "../renderSDL/SDL_Extensions.h"
-#include "CMT.h"
 
 #include "../../lib/CConfigHandler.h"
 #include "../../lib/constants/StringConstants.h"
@@ -34,7 +37,6 @@
 static SDL_Window * mainWindow = nullptr;
 SDL_Renderer * mainRenderer = nullptr;
 SDL_Texture * screenTexture = nullptr;
-SDL_Surface * screen = nullptr; //main screen surface
 
 static const std::string NAME = GameConstants::VCMI_VERSION; //application name
 static constexpr Point heroes3Resolution = Point(800, 600);
@@ -618,6 +620,24 @@ void ScreenHandler::clearScreen()
 {
 	SDL_SetRenderDrawColor(mainRenderer, 0, 0, 0, 255);
 	SDL_RenderClear(mainRenderer);
+	SDL_RenderPresent(mainRenderer);
+}
+
+Canvas ScreenHandler::getScreenCanvas() const
+{
+	return Canvas::createFromSurface(screen, CanvasScalingPolicy::AUTO);
+}
+
+void ScreenHandler::updateScreenTexture()
+{
+	SDL_UpdateTexture(screenTexture, nullptr, screen->pixels, screen->pitch);
+}
+
+void ScreenHandler::presetScreenTexture()
+{
+	SDL_RenderClear(mainRenderer);
+	SDL_RenderCopy(mainRenderer, screenTexture, nullptr, nullptr);
+	CCS->curh->render();
 	SDL_RenderPresent(mainRenderer);
 }
 

--- a/client/renderSDL/ScreenHandler.cpp
+++ b/client/renderSDL/ScreenHandler.cpp
@@ -18,7 +18,6 @@
 #include "../gui/CursorHandler.h"
 #include "../gui/WindowHandler.h"
 #include "../render/Canvas.h"
-#include "../renderSDL/SDL_Extensions.h"
 
 #include "../../lib/CConfigHandler.h"
 #include "../../lib/constants/StringConstants.h"

--- a/client/renderSDL/ScreenHandler.cpp
+++ b/client/renderSDL/ScreenHandler.cpp
@@ -35,8 +35,6 @@ static SDL_Window * mainWindow = nullptr;
 SDL_Renderer * mainRenderer = nullptr;
 SDL_Texture * screenTexture = nullptr;
 SDL_Surface * screen = nullptr; //main screen surface
-SDL_Surface * screen2 = nullptr; //and hlp surface (used to store not-active interfaces layer)
-SDL_Surface * screenBuf = screen; //points to screen (if only advmapint is present) or screen2 (else) - should be used when updating controls which are not regularly redrawed
 
 static const std::string NAME = GameConstants::VCMI_VERSION; //application name
 static constexpr Point heroes3Resolution = Point(800, 600);
@@ -434,18 +432,6 @@ void ScreenHandler::initializeScreenBuffers()
 		throw std::runtime_error("Unable to create screen texture");
 	}
 
-	screen2 = CSDL_Ext::copySurface(screen);
-
-	if(nullptr == screen2)
-	{
-		throw std::runtime_error("Unable to copy surface\n");
-	}
-
-	if (GH.windows().count() > 1)
-		screenBuf = screen2;
-	else
-		screenBuf = screen;
-
 	clearScreen();
 }
 
@@ -590,15 +576,6 @@ int ScreenHandler::getPreferredRenderingDriver() const
 
 void ScreenHandler::destroyScreenBuffers()
 {
-	// screenBuf is not a separate surface, but points to either screen or screen2 - just set to null
-	screenBuf = nullptr;
-
-	if(nullptr != screen2)
-	{
-		SDL_FreeSurface(screen2);
-		screen2 = nullptr;
-	}
-
 	if(nullptr != screen)
 	{
 		SDL_FreeSurface(screen);

--- a/client/renderSDL/ScreenHandler.h
+++ b/client/renderSDL/ScreenHandler.h
@@ -44,7 +44,9 @@ enum class EUpscalingFilter
 /// This class is responsible for management of game window and its main rendering surface
 class ScreenHandler final : public IScreenHandler
 {
-	SDL_Surface * screen = nullptr; //main screen surface
+	SDL_Window * mainWindow = nullptr;
+	SDL_Texture * screenTexture = nullptr;
+	SDL_Surface * screen = nullptr;
 
 	EUpscalingFilter upscalingFilter = EUpscalingFilter::AUTO;
 
@@ -118,7 +120,7 @@ public:
 
 	Canvas getScreenCanvas() const final;
 	void updateScreenTexture() final;
-	void presetScreenTexture() final;
+	void presentScreenTexture() final;
 
 	std::vector<Point> getSupportedResolutions() const final;
 	std::vector<Point> getSupportedResolutions(int displayIndex) const;

--- a/client/renderSDL/ScreenHandler.h
+++ b/client/renderSDL/ScreenHandler.h
@@ -10,13 +10,13 @@
 
 #pragma once
 
+#include "../../lib/Point.h"
+#include "../render/IScreenHandler.h"
+
 struct SDL_Texture;
 struct SDL_Window;
 struct SDL_Renderer;
 struct SDL_Surface;
-
-#include "../../lib/Point.h"
-#include "../render/IScreenHandler.h"
 
 enum class EWindowMode
 {
@@ -44,6 +44,8 @@ enum class EUpscalingFilter
 /// This class is responsible for management of game window and its main rendering surface
 class ScreenHandler final : public IScreenHandler
 {
+	SDL_Surface * screen = nullptr; //main screen surface
+
 	EUpscalingFilter upscalingFilter = EUpscalingFilter::AUTO;
 
 	/// Dimensions of target surfaces/textures, this value is what game logic views as screen size
@@ -113,6 +115,10 @@ public:
 	int getScalingFactor() const final;
 
 	int getInterfaceScalingPercentage() const final;
+
+	Canvas getScreenCanvas() const final;
+	void updateScreenTexture() final;
+	void presetScreenTexture() final;
 
 	std::vector<Point> getSupportedResolutions() const final;
 	std::vector<Point> getSupportedResolutions(int displayIndex) const;


### PR DESCRIPTION
Set of small changes to make work on hardware acceleration easier:
- `screen` surface is no longer a global variable, but instead private member of screen handler
- remove separate `screen2` and `screenBuf` globals, now `screen` is always used instead
- removed old and no longer used code from SDL_Extensions
- separated update & render methods in cursor - since update needs to be done while UI lock is being held, while render can be done at any point