### PR TITLE
[mapeditor] Map validation results window changes

### DIFF
--- a/lib/constants/EntityIdentifiers.h
+++ b/lib/constants/EntityIdentifiers.h
@@ -9,6 +9,7 @@
  */
 #pragma once
 
+#include "Global.h"
 #include "NumericConstants.h"
 #include "IdentifierBase.h"
 

--- a/mapeditor/Animation.h
+++ b/mapeditor/Animation.h
@@ -13,6 +13,7 @@
 #include "../lib/GameConstants.h"
 #include <QRgb>
 #include <QImage>
+#include <QDir>
 
 VCMI_LIB_NAMESPACE_BEGIN
 class JsonNode;

--- a/mapeditor/CMakeLists.txt
+++ b/mapeditor/CMakeLists.txt
@@ -20,6 +20,7 @@ set(editor_SRCS
 		mapsettings/eventsettings.cpp
 		mapsettings/rumorsettings.cpp
 		mapsettings/translations.cpp
+		PlayerSelectionDialog.cpp
 		playersettings.cpp
 		playerparams.cpp
 		scenelayer.cpp
@@ -70,6 +71,7 @@ set(editor_HEADERS
 		mapsettings/eventsettings.h
 		mapsettings/rumorsettings.h
 		mapsettings/translations.h
+		PlayerSelectionDialog.h
 		playersettings.h
 		playerparams.h
 		scenelayer.h

--- a/mapeditor/PlayerSelectionDialog.cpp
+++ b/mapeditor/PlayerSelectionDialog.cpp
@@ -9,8 +9,14 @@
  */
 
 #include "PlayerSelectionDialog.h"
-#include "mainwindow.h"
 #include "../lib/mapping/CMap.h"
+#include "mainwindow.h"
+
+#include <QCheckBox>
+#include <QDialogButtonBox>
+#include <QAction>
+#include <QLabel>
+
 
 PlayerSelectionDialog::PlayerSelectionDialog(MainWindow * mainWindow)
 	: QDialog(mainWindow), selectedPlayer(PlayerColor::NEUTRAL)

--- a/mapeditor/PlayerSelectionDialog.cpp
+++ b/mapeditor/PlayerSelectionDialog.cpp
@@ -72,24 +72,21 @@ PlayerColor PlayerSelectionDialog::getSelectedPlayer() const
 void PlayerSelectionDialog::setupDialogComponents()
 {
 	setWindowTitle(tr("Select Player"));
-	setFixedSize(sizeHint());
+	setFixedWidth(dialogWidth);
 	setWindowFlags(Qt::Dialog | Qt::MSWindowsFixedSizeDialogHint);
 	font.setPointSize(10);
 	setFont(font);
 
-	mainLayout.setSpacing(10);
-	mainLayout.setContentsMargins(20, 20, 80, 20);
-	checkboxLayout.setContentsMargins(0, 10, 0, 20);
-	mainLayout.addSpacing(4);
-
 	QLabel * errorLabel = new QLabel(tr("Hero cannot be created as NEUTRAL"), this);
 	font.setBold(true);
 	errorLabel->setFont(font);
+	errorLabel->setWordWrap(true);
 	mainLayout.addWidget(errorLabel);
 
 	QLabel * instructionLabel = new QLabel(tr("Switch to one of the available players:"), this);
 	font.setBold(false);
 	instructionLabel->setFont(font);
+	instructionLabel->setWordWrap(true);
 	mainLayout.addWidget(instructionLabel);
 
 	QWidget * checkboxContainer = new QWidget(this);

--- a/mapeditor/PlayerSelectionDialog.cpp
+++ b/mapeditor/PlayerSelectionDialog.cpp
@@ -1,0 +1,156 @@
+/*
+ * PlayerSelectionDialog.cpp, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
+
+#include "PlayerSelectionDialog.h"
+#include "mainwindow.h"
+#include "../lib/mapping/CMap.h"
+
+PlayerSelectionDialog::PlayerSelectionDialog(QWidget * parent)
+	: QDialog(parent), selectedPlayer(PlayerColor::NEUTRAL)
+{
+	auto main = qobject_cast<MainWindow *>(parent);
+	assert(main);
+
+	setupDialogComponents();
+
+	int maxPlayers = 0;
+	if(main && main->controller.map())
+		maxPlayers = main->controller.map()->players.size();
+	
+	bool defaultIsChecked = false;
+
+	for(int i = 0; i < maxPlayers; ++i)
+	{
+		PlayerColor player(i);
+		QAction * action = main->getActionPlayer(player);
+
+		addCheckbox(action, player, main->controller.map()->players.at(i).canAnyonePlay(), & defaultIsChecked);
+	}
+}
+
+void PlayerSelectionDialog::onCheckboxToggled(bool checked)
+{
+	if(!checked)
+		return;
+
+	QCheckBox * senderCheckBox = qobject_cast<QCheckBox *>(sender());
+	if(!senderCheckBox)
+		return;
+
+	for(int i = 0; i < checkboxes.size(); ++i)
+	{
+		QCheckBox * cb = checkboxes[i];
+		if(cb == senderCheckBox)
+		{
+			selectedPlayer = PlayerColor(i);
+		}
+		else
+		{
+			cb->blockSignals(true);
+			cb->setChecked(false);
+			cb->blockSignals(false);
+		}
+	}
+}
+
+
+PlayerColor PlayerSelectionDialog::getSelectedPlayer() const
+{
+	return selectedPlayer;
+}
+
+void PlayerSelectionDialog::setupDialogComponents()
+{
+	setWindowTitle(tr("Select Player"));
+	setFixedSize(sizeHint());
+	setWindowFlags(Qt::Dialog | Qt::MSWindowsFixedSizeDialogHint);
+	font.setPointSize(10);
+	setFont(font);
+
+	mainLayout.setSpacing(10);
+	mainLayout.setContentsMargins(20, 20, 80, 20);
+	checkboxLayout.setContentsMargins(0, 10, 0, 20);
+	mainLayout.addSpacing(4);
+
+	QLabel * errorLabel = new QLabel(tr("Hero cannot be created as NEUTRAL"), this);
+	font.setBold(true);
+	errorLabel->setFont(font);
+	mainLayout.addWidget(errorLabel);
+
+	QLabel * instructionLabel = new QLabel(tr("Switch to one of the available players:"), this);
+	font.setBold(false);
+	instructionLabel->setFont(font);
+	mainLayout.addWidget(instructionLabel);
+
+	QWidget * checkboxContainer = new QWidget(this);
+	checkboxContainer->setLayout(& checkboxLayout);
+	mainLayout.addWidget(checkboxContainer);
+
+	QDialogButtonBox * box = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, this);
+	connect(box, &QDialogButtonBox::accepted, this, &QDialog::accept);
+	connect(box, &QDialogButtonBox::rejected, this, &QDialog::reject);
+	mainLayout.addWidget(box);
+
+	setLayout(& mainLayout);
+}
+
+void PlayerSelectionDialog::addCheckbox(QAction * checkboxAction, PlayerColor player, bool isEnabled, bool * isDefault)
+{
+	QHBoxLayout * rowLayout = new QHBoxLayout();
+	auto * checkbox = new QCheckBox(checkboxAction->text(), this);
+	
+	QLabel * shortcutLabel = new QLabel(checkboxAction->shortcut().toString(), this);
+	QFont shortcutFont = font;
+	shortcutFont.setPointSize(9);
+	shortcutFont.setItalic(true);
+	shortcutLabel->setFont(shortcutFont);
+	shortcutLabel->setAlignment(Qt::AlignCenter | Qt::AlignVCenter);
+
+	QWidget * checkboxContainer = new QWidget(this);
+	QHBoxLayout * cbLayout = new QHBoxLayout(checkboxContainer);
+	cbLayout->setContentsMargins(0, 0, 0, 0);
+	cbLayout->addWidget(checkbox, 0, Qt::AlignCenter);
+
+	rowLayout->addWidget(checkboxContainer, 1);
+	rowLayout->addWidget(shortcutLabel, 1);
+
+	checkbox->setEnabled(isEnabled);
+	if(checkbox->isEnabled() && !*isDefault)
+	{
+		checkbox->setChecked(true);
+		selectedPlayer = player;
+		*isDefault = true;
+	}
+
+	checkboxLayout.addLayout(rowLayout);
+
+	connect(checkbox, &QCheckBox::clicked, this, [=]()
+		{
+			selectedPlayer = player;
+
+			// Radio-style logic: uncheck other boxes
+			for(auto * box : findChildren<QCheckBox *>())
+			{
+				if(box != checkbox)
+					box->setChecked(false);
+			}
+		});
+
+
+	// Add action to the dialog for shortcut support
+	addAction(checkboxAction);
+
+	// Connect action trigger to simulate checkbox click
+	connect(checkboxAction, &QAction::triggered, this, [=]()
+		{
+			if(checkbox->isEnabled())
+				checkbox->click();
+		});
+}

--- a/mapeditor/PlayerSelectionDialog.cpp
+++ b/mapeditor/PlayerSelectionDialog.cpp
@@ -22,8 +22,6 @@
 PlayerSelectionDialog::PlayerSelectionDialog(MainWindow * mainWindow)
 	: QDialog(mainWindow), selectedPlayer(PlayerColor::NEUTRAL)
 {
-	assert(mainWindow);
-
 	setupDialogComponents();
 
 	int maxPlayers = 0;
@@ -88,22 +86,9 @@ void PlayerSelectionDialog::addRadioButton(QAction * action, PlayerColor player)
 		selectedPlayer = player;
 	}
 
+	radioButton->setToolTip(tr("Shortcut: %1").arg(action->shortcut().toString()));
 	buttonGroup->addButton(radioButton, player.getNum());
-
-	auto * shortcutLabel = new QLabel(action->shortcut().toString(), this);
-	QFont shortcutFont = font;
-	shortcutFont.setPointSize(9);
-	shortcutFont.setItalic(true);
-	shortcutLabel->setFont(shortcutFont);
-	shortcutLabel->setAlignment(Qt::AlignCenter | Qt::AlignVCenter);
-	shortcutLabel->setContentsMargins(0, 0, 6, 0); // Italic text was trimmed at the end
-
-	auto * rowWidget = new QWidget(this);
-	auto * rowLayout = new QGridLayout(rowWidget);
-	rowLayout->setContentsMargins(0, 0, 0, 0);
-	rowLayout->addWidget(radioButton, 0, 0, Qt::AlignCenter | Qt::AlignVCenter);
-	rowLayout->addWidget(shortcutLabel, 0, 1, Qt::AlignCenter | Qt::AlignVCenter);
-	radioButtonsLayout.addWidget(rowWidget);
+	radioButtonsLayout.addWidget(radioButton);
 
 	connect(radioButton, &QRadioButton::clicked, this, [this, player]()
 		{

--- a/mapeditor/PlayerSelectionDialog.h
+++ b/mapeditor/PlayerSelectionDialog.h
@@ -32,6 +32,8 @@ private slots:
 	void onCheckboxToggled(bool checked);
 
 private:
+	const int dialogWidth = 320;
+
 	std::vector<QCheckBox *> checkboxes;
 	PlayerColor selectedPlayer;
 

--- a/mapeditor/PlayerSelectionDialog.h
+++ b/mapeditor/PlayerSelectionDialog.h
@@ -14,7 +14,8 @@
 #include <QVBoxLayout>
 #include "../lib/constants/EntityIdentifiers.h"
 
-class QCheckBox;
+class QRadioButton;
+class QButtonGroup;
 class MainWindow;
 
 /// Dialog shown when a hero cannot be placed as NEUTRAL.
@@ -28,22 +29,17 @@ public:
 	explicit PlayerSelectionDialog(MainWindow * mainWindow = nullptr);
 	PlayerColor getSelectedPlayer() const;
 
-private slots:
-	void onCheckboxToggled(bool checked);
-
 private:
 	const int dialogWidth = 320;
 
-	std::vector<QCheckBox *> checkboxes;
+	QButtonGroup * buttonGroup = nullptr;
 	PlayerColor selectedPlayer;
 
 	QFont font;
 	QVBoxLayout mainLayout;
-	QVBoxLayout checkboxLayout;
-
-	bool defaultCheckedSet = false;
+	QVBoxLayout radioButtonsLayout;
 
 	void setupDialogComponents();
-	void addCheckbox(QAction * checkboxAction, PlayerColor player, bool isEnabled);
+	void addRadioButton(QAction * action, PlayerColor player);
 
 };

--- a/mapeditor/PlayerSelectionDialog.h
+++ b/mapeditor/PlayerSelectionDialog.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include <QDialog>
+#include <QVBoxLayout>
 #include "../lib/constants/EntityIdentifiers.h"
 
 class QCheckBox;

--- a/mapeditor/PlayerSelectionDialog.h
+++ b/mapeditor/PlayerSelectionDialog.h
@@ -11,10 +11,10 @@
 #pragma once
 
 #include <QDialog>
-#include <QComboBox>
-#include <QCheckBox>
-#include <QDialogButtonBox>
-#include "../source/lib/constants/EntityIdentifiers.h"
+#include "../lib/constants/EntityIdentifiers.h"
+
+class QCheckBox;
+class MainWindow;
 
 /// Dialog shown when a hero cannot be placed as NEUTRAL.
 /// Allows the user to select a valid player via checkboxes,
@@ -24,7 +24,7 @@ class PlayerSelectionDialog : public QDialog
 	Q_OBJECT
 
 public:
-	explicit PlayerSelectionDialog(QWidget * parent = nullptr);
+	explicit PlayerSelectionDialog(MainWindow * mainWindow = nullptr);
 	PlayerColor getSelectedPlayer() const;
 
 private slots:
@@ -38,7 +38,9 @@ private:
 	QVBoxLayout mainLayout;
 	QVBoxLayout checkboxLayout;
 
+	bool defaultCheckedSet = false;
+
 	void setupDialogComponents();
-	void addCheckbox(QAction * checkboxAction, PlayerColor player, bool isEnabled, bool * isDefault);
+	void addCheckbox(QAction * checkboxAction, PlayerColor player, bool isEnabled);
 
 };

--- a/mapeditor/PlayerSelectionDialog.h
+++ b/mapeditor/PlayerSelectionDialog.h
@@ -26,13 +26,13 @@ class PlayerSelectionDialog : public QDialog
 	Q_OBJECT
 
 public:
-	explicit PlayerSelectionDialog(MainWindow * mainWindow = nullptr);
+	explicit PlayerSelectionDialog(MainWindow * mainWindow);
 	PlayerColor getSelectedPlayer() const;
 
 private:
 	const int dialogWidth = 320;
 
-	QButtonGroup * buttonGroup = nullptr;
+	QButtonGroup * buttonGroup;
 	PlayerColor selectedPlayer;
 
 	QFont font;

--- a/mapeditor/PlayerSelectionDialog.h
+++ b/mapeditor/PlayerSelectionDialog.h
@@ -1,0 +1,44 @@
+/*
+ * PlayerSelectionDialog.h, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
+
+#pragma once
+
+#include <QDialog>
+#include <QComboBox>
+#include <QCheckBox>
+#include <QDialogButtonBox>
+#include "../source/lib/constants/EntityIdentifiers.h"
+
+/// Dialog shown when a hero cannot be placed as NEUTRAL.
+/// Allows the user to select a valid player via checkboxes,
+/// or using the existing keyboard shortcuts from MainWindow's player QActions.
+class PlayerSelectionDialog : public QDialog
+{
+	Q_OBJECT
+
+public:
+	explicit PlayerSelectionDialog(QWidget * parent = nullptr);
+	PlayerColor getSelectedPlayer() const;
+
+private slots:
+	void onCheckboxToggled(bool checked);
+
+private:
+	std::vector<QCheckBox *> checkboxes;
+	PlayerColor selectedPlayer;
+
+	QFont font;
+	QVBoxLayout mainLayout;
+	QVBoxLayout checkboxLayout;
+
+	void setupDialogComponents();
+	void addCheckbox(QAction * checkboxAction, PlayerColor player, bool isEnabled, bool * isDefault);
+
+};

--- a/mapeditor/mainwindow.cpp
+++ b/mapeditor/mainwindow.cpp
@@ -609,14 +609,7 @@ void MainWindow::on_actionCampaignEditor_triggered()
 void MainWindow::on_actionNew_triggered()
 {
 	if(getAnswerAboutUnsavedChanges())
-	{
 		new WindowNewMap(this);
-		//mapSettings = new MapSettings(controller, this);
-		//connect(&controller, &MapController::requestModsUpdate,
-		//	mapSettings->getModSettings(), &ModSettings::updateModWidgetBasedOnMods);
-
-		//controller.requestModsUpdate({}, true);
-	}
 }
 
 void MainWindow::on_actionSave_triggered()
@@ -1136,9 +1129,6 @@ void MainWindow::on_inspectorWidget_itemChanged(QTableWidgetItem *item)
 
 void MainWindow::on_actionMapSettings_triggered()
 {
-	if(!mapSettings)
-		return;
-
 	if(mapSettings->isVisible())
 	{
 		mapSettings->raise();
@@ -1146,8 +1136,6 @@ void MainWindow::on_actionMapSettings_triggered()
 	}
 	else
 	{
-		mapSettings->setWindowModality(Qt::WindowModal);
-		mapSettings->setModal(true);
 		mapSettings->show();
 	}
 }
@@ -1178,15 +1166,15 @@ void MainWindow::switchDefaultPlayer(const PlayerColor & player)
 {
 	if(controller.defaultPlayer == player)
 		return;
-	
-	ui->actionNeutral->blockSignals(true);
+
+	QSignalBlocker blockerNeutral(ui->actionNeutral);
 	ui->actionNeutral->setChecked(PlayerColor::NEUTRAL == player);
-	ui->actionNeutral->blockSignals(false);
+
 	for(int i = 0; i < PlayerColor::PLAYER_LIMIT.getNum(); ++i)
 	{
-		getActionPlayer(PlayerColor(i))->blockSignals(true);
-		getActionPlayer(PlayerColor(i))->setChecked(PlayerColor(i) == player);
-		getActionPlayer(PlayerColor(i))->blockSignals(false);
+		QAction * playerEntry = getActionPlayer(PlayerColor(i));
+		QSignalBlocker blocker(playerEntry); 
+		playerEntry->setChecked(PlayerColor(i) == player);
 	}
 	controller.defaultPlayer = player;
 }

--- a/mapeditor/mainwindow.cpp
+++ b/mapeditor/mainwindow.cpp
@@ -45,6 +45,7 @@
 #include "inspector/inspector.h"
 #include "mapsettings/mapsettings.h"
 #include "mapsettings/translations.h"
+#include "mapsettings/modsettings.h"
 #include "playersettings.h"
 #include "validator.h"
 #include "helper.h"
@@ -371,6 +372,10 @@ void MainWindow::initializeMap(bool isNew)
 	initialScale = ui->mapView->mapToScene(ui->mapView->viewport()->geometry()).boundingRect();
 	
 	//enable settings
+	mapSettings = new MapSettings(controller, this);
+	connect(&controller, &MapController::requestModsUpdate,
+		mapSettings->getModSettings(), &ModSettings::updateModWidgetBasedOnMods);
+
 	ui->actionMapSettings->setEnabled(true);
 	ui->actionPlayers_settings->setEnabled(true);
 	ui->actionTranslations->setEnabled(true);
@@ -604,7 +609,14 @@ void MainWindow::on_actionCampaignEditor_triggered()
 void MainWindow::on_actionNew_triggered()
 {
 	if(getAnswerAboutUnsavedChanges())
+	{
 		new WindowNewMap(this);
+		//mapSettings = new MapSettings(controller, this);
+		//connect(&controller, &MapController::requestModsUpdate,
+		//	mapSettings->getModSettings(), &ModSettings::updateModWidgetBasedOnMods);
+
+		//controller.requestModsUpdate({}, true);
+	}
 }
 
 void MainWindow::on_actionSave_triggered()
@@ -1124,9 +1136,20 @@ void MainWindow::on_inspectorWidget_itemChanged(QTableWidgetItem *item)
 
 void MainWindow::on_actionMapSettings_triggered()
 {
-	auto settingsDialog = new MapSettings(controller, this);
-	settingsDialog->setWindowModality(Qt::WindowModal);
-	settingsDialog->setModal(true);
+	if(!mapSettings)
+		return;
+
+	if(mapSettings->isVisible())
+	{
+		mapSettings->raise();
+		mapSettings->activateWindow();
+	}
+	else
+	{
+		mapSettings->setWindowModality(Qt::WindowModal);
+		mapSettings->setModal(true);
+		mapSettings->show();
+	}
 }
 
 

--- a/mapeditor/mainwindow.h
+++ b/mapeditor/mainwindow.h
@@ -3,6 +3,8 @@
 #include <QMainWindow>
 #include <QGraphicsScene>
 #include <QStandardItemModel>
+#include <QTranslator>
+#include <QTableWidgetItem>
 #include "mapcontroller.h"
 #include "resourceExtractor/ResourceConverter.h"
 

--- a/mapeditor/mainwindow.h
+++ b/mapeditor/mainwindow.h
@@ -25,7 +25,7 @@ namespace Ui
 
 class MainWindow : public QMainWindow
 {
-    Q_OBJECT
+	Q_OBJECT
 
 	const QString mainWindowSizeSetting = "MainWindow/Size";
 	const QString mainWindowPositionSetting = "MainWindow/Position";
@@ -42,8 +42,8 @@ class MainWindow : public QMainWindow
 	std::unique_ptr<CBasicLogConfigurator> logConfig;
 
 public:
-    explicit MainWindow(QWidget *parent = nullptr);
-    ~MainWindow();
+	explicit MainWindow(QWidget *parent = nullptr);
+	~MainWindow();
 
 	void initializeMap(bool isNew);
 
@@ -61,6 +61,11 @@ public:
 	MapController controller;
 
 	void loadTranslation();
+
+	QAction * getActionPlayer(const PlayerColor &);
+
+public slots:
+	void switchDefaultPlayer(const PlayerColor &);
 
 private slots:
 	void on_actionOpen_triggered();
@@ -110,8 +115,6 @@ private slots:
 	void on_actionUpdate_appearance_triggered();
 
 	void on_actionRecreate_obstacles_triggered();
-	
-	void switchDefaultPlayer(const PlayerColor &);
 
 	void on_actionCut_triggered();
 
@@ -169,8 +172,6 @@ private:
 	void preparePreview(const QModelIndex & index);
 	void addGroupIntoCatalog(const QString & groupName, bool staticOnly);
 	void addGroupIntoCatalog(const QString & groupName, bool useCustomName, bool staticOnly, int ID);
-	
-	QAction * getActionPlayer(const PlayerColor &);
 
 	void changeBrushState(int idx);
 	void setTitle();
@@ -187,7 +188,7 @@ private:
 	void updateRecentMenu(const QString & filenameSelect);
 
 private:
-    Ui::MainWindow * ui;
+	Ui::MainWindow * ui;
 	ObjectBrowserProxyModel * objectBrowser = nullptr;
 	QGraphicsScene * scenePreview;
 	MapSettings * mapSettings = nullptr;

--- a/mapeditor/mainwindow.h
+++ b/mapeditor/mainwindow.h
@@ -8,6 +8,7 @@
 
 class ObjectBrowser;
 class ObjectBrowserProxyModel;
+class MapSettings;
 
 VCMI_LIB_NAMESPACE_BEGIN
 class CConsoleHandler;
@@ -189,6 +190,7 @@ private:
     Ui::MainWindow * ui;
 	ObjectBrowserProxyModel * objectBrowser = nullptr;
 	QGraphicsScene * scenePreview;
+	MapSettings * mapSettings = nullptr;
 	
 	QString filename;
 	QString lastSavingDir;

--- a/mapeditor/mapcontroller.cpp
+++ b/mapeditor/mapcontroller.cpp
@@ -683,23 +683,7 @@ void MapController::modAssessmentObject(const CGObjectInstance * obj, ModCompati
 
 		for(const auto & spellID : town->obligatorySpells)
 		{
-			auto hero = dynamic_cast<CGHeroInstance *>(obj.get());
-			for(const auto & spellID : hero->getSpellsInSpellbook())
-			{
-				if(spellID == SpellID::PRESET || spellID == SpellID::SPELLBOOK_PRESET)
-					continue;
-				extractEntityMod(spellID.toEntity(LIBRARY));
-			}
-
-			for(const auto & [_, slotInfo] : hero->artifactsWorn)
-			{
-				extractEntityMod(slotInfo.getArt()->getTypeId().toEntity(LIBRARY));
-			}
-
-			for(const auto & art : hero->artifactsInBackpack)
-			{
-				extractEntityMod(art.getArt()->getTypeId().toEntity(LIBRARY));
-			}
+			extractEntityMod(spellID.toEntity(LIBRARY));
 		}
 	}
 
@@ -715,12 +699,12 @@ void MapController::modAssessmentObject(const CGObjectInstance * obj, ModCompati
 
 		for(const auto & [_, slotInfo] : hero->artifactsWorn)
 		{
-			extractEntityMod(slotInfo.artifact->getTypeId().toEntity(LIBRARY));
+			extractEntityMod(slotInfo.getArt()->getTypeId().toEntity(LIBRARY));
 		}
 
 		for(const auto & art : hero->artifactsInBackpack)
 		{
-			extractEntityMod(art.artifact->getTypeId().toEntity(LIBRARY));
+			extractEntityMod(art.getArt()->getTypeId().toEntity(LIBRARY));
 		}
 	}
 

--- a/mapeditor/mapcontroller.cpp
+++ b/mapeditor/mapcontroller.cpp
@@ -601,20 +601,15 @@ bool MapController::checkRequiredMods(const CGObjectInstance * obj, QString & er
 	{
 		if(!_map->mods.count(mod.first))
 		{
-			QString submod;
-			if(!mod.second.parent.empty())
-				submod = tr(" (submod of %1)").arg(QString::fromStdString(mod.second.parent));
-
 			auto reply = QMessageBox::question(main,
-				tr("Missing Required Mod"),
-				tr("This object is from the mod '%1'%2.\n\n"
-					"The mod is currently not in the map's required modifications list.\n\n"
-					"Do you want to add this mod to the required modifications?\n")
-				.arg(QString::fromStdString(LIBRARY->modh->getModInfo(mod.first).getVerificationInfo().name), submod),
+				tr("Missing Required Mod"), modMissingMessage(mod.second) + tr("\n\nDo you want to do that now ?"),
 				QMessageBox::Yes | QMessageBox::No);
 
 			if(reply == QMessageBox::Yes)
+			{
+				_map->mods[mod.first] = LIBRARY->modh->getModInfo(mod.first).getVerificationInfo();
 				Q_EMIT requestModsUpdate(modsInfo, true); // signal for MapSettings
+			}
 			else
 			{
 				error = tr("This object's mod is mandatory for map to remain valid.");
@@ -623,6 +618,19 @@ bool MapController::checkRequiredMods(const CGObjectInstance * obj, QString & er
 		}
 	}
 	return true;
+}
+
+QString MapController::modMissingMessage(const ModVerificationInfo & info)
+{
+	QString modName = QString::fromStdString(info.name);
+	QString submod;
+	if(!info.parent.empty())
+		submod = QObject::tr(" (submod of %1)").arg(QString::fromStdString(info.parent));
+
+	return QObject::tr("The mod '%1'%2, is required by an object on the map.\n"
+		"Add it to the map's required mods in Map->General settings.",
+		"should be consistent with Map->General menu entry translation")
+		.arg(modName, submod);
 }
 
 void MapController::undo()

--- a/mapeditor/mapcontroller.cpp
+++ b/mapeditor/mapcontroller.cpp
@@ -588,7 +588,7 @@ bool MapController::canPlaceHero(const CGObjectInstance * heroObj, QString & err
 		return true;
 	}
 	
-	error = QObject::tr("Hero %1 cannot be created as NEUTRAL.").arg(QString::fromStdString(heroObj->instanceName));
+	error = tr("Hero %1 cannot be created as NEUTRAL.").arg(QString::fromStdString(heroObj->instanceName));
 	return false;
 }
 
@@ -603,18 +603,18 @@ bool MapController::checkRequiredMods(const CGObjectInstance * obj, QString & er
 		{
 			QString submod;
 			if(!mod.second.parent.empty())
-				submod = " (" + tr("submod of") + " " + QString::fromStdString(mod.second.parent) + ")";
+				submod = tr(" (submod of %1)").arg(QString::fromStdString(mod.second.parent));
 
 			auto reply = QMessageBox::question(main,
 				tr("Missing Required Mod"),
 				tr("This object is from the mod '%1'%2.\n\n"
 					"The mod is currently not in the map's required modifications list.\n\n"
-					"Do you want to add this mod to the required modifications ?\n")
+					"Do you want to add this mod to the required modifications?\n")
 				.arg(QString::fromStdString(LIBRARY->modh->getModInfo(mod.first).getVerificationInfo().name), submod),
 				QMessageBox::Yes | QMessageBox::No);
 
 			if(reply == QMessageBox::Yes)
-				/* emit */ requestModsUpdate(modsInfo, true); // signal for MapSettings
+				Q_EMIT requestModsUpdate(modsInfo, true); // signal for MapSettings
 			else
 			{
 				error = tr("This object's mod is mandatory for map to remain valid.");

--- a/mapeditor/mapcontroller.cpp
+++ b/mapeditor/mapcontroller.cpp
@@ -537,21 +537,24 @@ void MapController::commitObjectCreate(int level)
 }
 
 bool MapController::canPlaceObject(int level, CGObjectInstance * newObj, QString & error) const
-{
-	//find all objects of such type
-	int objCounter = 0;
-	for(auto o : _map->objects)
+{	
+	if(newObj->ID == Obj::GRAIL) //special case for grail
 	{
-		if(o->ID == newObj->ID && o->subID == newObj->subID)
+		//find all objects of such type
+		int objCounter = 0;
+		for(auto o : _map->objects)
 		{
-			++objCounter;
+			if(o->ID == newObj->ID && o->subID == newObj->subID)
+			{
+				++objCounter;
+			}
 		}
-	}
-	
-	if(newObj->ID == Obj::GRAIL && objCounter >= 1) //special case for grail
-	{
-		error = QObject::tr("There can only be one grail object on the map.");
-		return false; //maplimit reached
+
+		if(objCounter >= 1)
+		{
+			error = QObject::tr("There can only be one grail object on the map.");
+			return false; //maplimit reached
+		}
 	}
 	
 	if(defaultPlayer == PlayerColor::NEUTRAL && (newObj->ID == Obj::HERO || newObj->ID == Obj::RANDOM_HERO))

--- a/mapeditor/mapcontroller.h
+++ b/mapeditor/mapcontroller.h
@@ -20,9 +20,12 @@ class EditorObstaclePlacer;
 VCMI_LIB_NAMESPACE_END
 
 class MainWindow;
-class MapController
+class MapController : public QObject
 {
+	Q_OBJECT
+
 public:
+	explicit MapController(QObject * parent = nullptr);
 	MapController(MainWindow *);
 	MapController(const MapController &) = delete;
 	MapController(const MapController &&) = delete;
@@ -62,6 +65,7 @@ public:
 	void createObject(int level, std::shared_ptr<CGObjectInstance> obj) const;
 	bool canPlaceObject(int level, CGObjectInstance * obj, QString & error) const;
 	
+	static void modAssessmentObject(CGObjectInstance * obj, ModCompatibilityInfo & result);
 	static ModCompatibilityInfo modAssessmentAll();
 	static ModCompatibilityInfo modAssessmentMap(const CMap & map);
 
@@ -70,6 +74,9 @@ public:
 	
 	PlayerColor defaultPlayer;
 	QDialog * settingsDialog = nullptr;
+
+signals:
+	void requestModsUpdate(const ModCompatibilityInfo & mods, bool leaveCheckedUnchanged) const;
 	
 private:
 	std::unique_ptr<CMap> _map;

--- a/mapeditor/mapcontroller.h
+++ b/mapeditor/mapcontroller.h
@@ -71,7 +71,10 @@ public:
 	/// If the mod is missing, prompts the user to add it. Returns false if the user declines,
 	/// making the object invalid for placement.
 	bool checkRequiredMods(const CGObjectInstance * obj, QString & error) const;
-	
+
+	/// These functions collect mod verification data for gameplay objects by scanning map objects
+	/// and their nested elements (like spells and artifacts). The gathered information
+	/// is used to assess compatibility and integrity of mods used in a given map or game state
 	static void modAssessmentObject(const CGObjectInstance * obj, ModCompatibilityInfo & result);
 	static ModCompatibilityInfo modAssessmentAll();
 	static ModCompatibilityInfo modAssessmentMap(const CMap & map);

--- a/mapeditor/mapcontroller.h
+++ b/mapeditor/mapcontroller.h
@@ -12,9 +12,9 @@
 
 #include "maphandler.h"
 #include "mapview.h"
+#include "lib/modding/ModVerificationInfo.h"
 
 VCMI_LIB_NAMESPACE_BEGIN
-struct ModVerificationInfo;
 using ModCompatibilityInfo = std::map<std::string, ModVerificationInfo>;
 class EditorObstaclePlacer;
 VCMI_LIB_NAMESPACE_END

--- a/mapeditor/mapcontroller.h
+++ b/mapeditor/mapcontroller.h
@@ -79,6 +79,10 @@ public:
 	static ModCompatibilityInfo modAssessmentAll();
 	static ModCompatibilityInfo modAssessmentMap(const CMap & map);
 
+	/// Returns formatted message string describing a missing mod requirement for the map.
+	/// Used in both warnings and confirmations related to required mod dependencies.
+	static QString modMissingMessage(const ModVerificationInfo & info);
+
 	void undo();
 	void redo();
 	

--- a/mapeditor/mapcontroller.h
+++ b/mapeditor/mapcontroller.h
@@ -63,9 +63,16 @@ public:
 	
 	bool discardObject(int level) const;
 	void createObject(int level, std::shared_ptr<CGObjectInstance> obj) const;
-	bool canPlaceObject(int level, CGObjectInstance * obj, QString & error) const;
+	bool canPlaceObject(const CGObjectInstance * obj, QString & error) const;
+	bool canPlaceGrail(const CGObjectInstance * grailObj, QString & error) const;
+	bool canPlaceHero(const CGObjectInstance * heroObj, QString & error) const;
 	
-	static void modAssessmentObject(CGObjectInstance * obj, ModCompatibilityInfo & result);
+	/// Ensures that the object's mod is listed in the map's required mods.
+	/// If the mod is missing, prompts the user to add it. Returns false if the user declines,
+	/// making the object invalid for placement.
+	bool checkRequiredMods(const CGObjectInstance * obj, QString & error) const;
+	
+	static void modAssessmentObject(const CGObjectInstance * obj, ModCompatibilityInfo & result);
 	static ModCompatibilityInfo modAssessmentAll();
 	static ModCompatibilityInfo modAssessmentMap(const CMap & map);
 

--- a/mapeditor/mapsettings/mapsettings.cpp
+++ b/mapeditor/mapsettings/mapsettings.cpp
@@ -25,7 +25,8 @@ MapSettings::MapSettings(MapController & ctrl, QWidget *parent) :
 	controller(ctrl)
 {
 	ui->setupUi(this);
-	
+
+	setWindowModality(Qt::WindowModal);
 	setWindowFlags(Qt::Dialog | Qt::WindowTitleHint | Qt::WindowCloseButtonHint);
 	
 	assert(controller.map());

--- a/mapeditor/mapsettings/mapsettings.cpp
+++ b/mapeditor/mapsettings/mapsettings.cpp
@@ -30,7 +30,6 @@ MapSettings::MapSettings(MapController & ctrl, QWidget *parent) :
 	
 	assert(controller.map());
 	controller.settingsDialog = this;
-	show();
 
 	for(auto const & objectPtr : LIBRARY->skillh->objects)
 	{
@@ -77,6 +76,11 @@ MapSettings::~MapSettings()
 {
 	controller.settingsDialog = nullptr;
 	delete ui;
+}
+
+ModSettings * MapSettings::getModSettings()
+{
+	return ui->mods;
 }
 
 void MapSettings::on_pushButton_clicked()

--- a/mapeditor/mapsettings/mapsettings.h
+++ b/mapeditor/mapsettings/mapsettings.h
@@ -18,6 +18,8 @@ namespace Ui {
 class MapSettings;
 }
 
+class ModSettings;
+
 class MapSettings : public QDialog
 {
 	Q_OBJECT
@@ -25,6 +27,8 @@ class MapSettings : public QDialog
 public:
 	explicit MapSettings(MapController & controller, QWidget *parent = nullptr);
 	~MapSettings();
+
+	ModSettings * getModSettings();
 
 private slots:
 	void on_pushButton_clicked();

--- a/mapeditor/mapsettings/modsettings.cpp
+++ b/mapeditor/mapsettings/modsettings.cpp
@@ -44,6 +44,8 @@ void ModSettings::initialize(MapController & c)
 	QMap<QString, QTreeWidgetItem*> addedMods;
 	QSet<QString> modsToProcess;
 	ui->treeMods->blockSignals(true);
+	ui->treeMods->header()->setSectionResizeMode(0, QHeaderView::ResizeToContents);
+	ui->treeMods->header()->setSectionResizeMode(1, QHeaderView::ResizeToContents);
 
 	auto createModTreeWidgetItem = [&](QTreeWidgetItem * parent, const ModDescription & modInfo)
 	{
@@ -59,6 +61,8 @@ void ModSettings::initialize(MapController & c)
 
 	for(const auto & modName : LIBRARY->modh->getActiveMods())
 	{
+		if(modName == "core")
+			continue;
 		QString qmodName = QString::fromStdString(modName);
 		if(qmodName.split(".").size() == 1)
 		{
@@ -115,13 +119,21 @@ void ModSettings::update()
 	}
 }
 
-void ModSettings::updateModWidgetBasedOnMods(const ModCompatibilityInfo & mods)
+void ModSettings::updateModWidgetBasedOnMods(const ModCompatibilityInfo & mods, bool leaveCheckedUnchanged)
 {
 	//Mod management
 	auto widgetAction = [&](QTreeWidgetItem * item)
 	{
 		auto modName = item->data(0, Qt::UserRole).toString().toStdString();
-		item->setCheckState(0, mods.count(modName) ? Qt::Checked : Qt::Unchecked);
+		if(leaveCheckedUnchanged)
+		{
+			if(mods.count(modName))
+				item->setCheckState(0, Qt::Checked);
+		}
+		else
+		{
+			item->setCheckState(0, mods.count(modName) ? Qt::Checked : Qt::Unchecked);
+		}
 	};
 
 	for (int i = 0; i < ui->treeMods->topLevelItemCount(); ++i)

--- a/mapeditor/mapsettings/modsettings.h
+++ b/mapeditor/mapsettings/modsettings.h
@@ -26,15 +26,14 @@ public:
 	void initialize(MapController & map) override;
 	void update() override;
 
+	void updateModWidgetBasedOnMods(const ModCompatibilityInfo & mods, bool leaveCheckedUnchanged = false);
+
 private slots:
 	void on_modResolution_map_clicked();
 
 	void on_modResolution_full_clicked();
 
 	void on_treeMods_itemChanged(QTreeWidgetItem *item, int column);
-
-private:
-	void updateModWidgetBasedOnMods(const ModCompatibilityInfo & mods);
 
 private:
 	Ui::ModSettings *ui;

--- a/mapeditor/mapview.cpp
+++ b/mapeditor/mapview.cpp
@@ -614,7 +614,7 @@ void MapView::dropEvent(QDropEvent * event)
 	if(sc->selectionObjectsView.newObject)
 	{
 		QString errorMsg;
-		if(controller->canPlaceObject(sc->level, sc->selectionObjectsView.newObject.get(), errorMsg))
+		if(controller->canPlaceObject(sc->selectionObjectsView.newObject, errorMsg))
 		{
 			auto obj = sc->selectionObjectsView.newObject;
 			controller->commitObjectCreate(sc->level);

--- a/mapeditor/mapview.cpp
+++ b/mapeditor/mapview.cpp
@@ -614,7 +614,7 @@ void MapView::dropEvent(QDropEvent * event)
 	if(sc->selectionObjectsView.newObject)
 	{
 		QString errorMsg;
-		if(controller->canPlaceObject(sc->selectionObjectsView.newObject, errorMsg))
+		if(controller->canPlaceObject(sc->selectionObjectsView.newObject.get(), errorMsg))
 		{
 			auto obj = sc->selectionObjectsView.newObject;
 			controller->commitObjectCreate(sc->level);

--- a/mapeditor/mapview.h
+++ b/mapeditor/mapview.h
@@ -12,6 +12,7 @@
 
 #include <QGraphicsScene>
 #include <QGraphicsView>
+#include <QRubberBand>
 #include "scenelayer.h"
 #include "../lib/int3.h"
 

--- a/mapeditor/validator.cpp
+++ b/mapeditor/validator.cpp
@@ -174,7 +174,7 @@ std::set<Validator::Issue> Validator::validate(const CMap * map)
 			{
 				QString submod;
 				if(!mod.second.parent.empty())
-					submod = " ("+ tr("submod of") +" "+ QString::fromStdString(mod.second.parent) + ")";
+					submod = tr(" (submod of %1").arg(QString::fromStdString(mod.second.parent));
 				
 				issues.insert({
 						tr("Map contains object(s) from mod '%1'%2, but the mod is missing from the map's required mods list."
@@ -195,30 +195,6 @@ std::set<Validator::Issue> Validator::validate(const CMap * map)
 	return issues;
 }
 
-QPixmap Validator::createGreenTickIcon()
-{
-	QPixmap pixmap(24, 24);
-	pixmap.fill(Qt::transparent);
-
-	QPainter painter(&pixmap);
-	painter.setRenderHint(QPainter::Antialiasing);
-
-	QBrush brush(QColor(50, 205, 50));
-	painter.setBrush(brush);
-	painter.setPen(Qt::NoPen);
-	painter.drawEllipse(0, 0, 24, 24);
-
-	QPen pen(Qt::white);
-	pen.setWidth(3);
-	painter.setPen(pen);
-
-	painter.drawLine(7, 12, 10, 17);  // Tick part 1
-	painter.drawLine(10, 17, 17, 7);  // Tick part 2
-
-	painter.end();
-	return pixmap;
-}
-
 void Validator::showValidationResults(const CMap * map)
 {
 	show();
@@ -235,7 +211,7 @@ void Validator::showValidationResults(const CMap * map)
 
 	if(ui->listWidget->count() == 0)
 	{
-		QPixmap greenTick = createGreenTickIcon();
+		QPixmap greenTick = QPixmap(":/icons/mod-enabled.png");
 		QString validMessage = tr("The map is valid and has no issues.");
 		auto * item = new QListWidgetItem(QIcon(greenTick), validMessage, ui->listWidget);
 		ui->listWidget->addItem(item);
@@ -276,13 +252,11 @@ void Validator::adjustWindowSize()
 	int finalWidth = qMin(contentWidth + padding, screenWidth - screenMarginHorizontal);
 	int finalHeight = qMin(contentHeight + padding, screenHeight - screenMarginVertical);
 
-	logGlobal->warn("adjustWindowSize(): %d x %d", finalWidth, finalHeight);
-
 	QWidget * parentWidget = ui->listWidget->parentWidget();
 	if(parentWidget)
 	{
-		parentWidget->setFixedWidth(finalWidth + padding);
-		parentWidget->setFixedHeight(finalHeight + padding);
+		parentWidget->setMinimumWidth(finalWidth + padding);
+		parentWidget->setMinimumHeight(finalHeight + padding);
 	}
 
 	ui->listWidget->resize(finalWidth, finalHeight);

--- a/mapeditor/validator.cpp
+++ b/mapeditor/validator.cpp
@@ -174,14 +174,12 @@ std::set<Validator::Issue> Validator::validate(const CMap * map)
 			{
 				QString submod;
 				if(!mod.second.parent.empty())
-					submod = " (submod of '"+ QString::fromStdString(mod.second.parent) +"')";
+					submod = " ("+ tr("submod of") +" "+ QString::fromStdString(mod.second.parent) + ")";
 				
 				issues.insert({
 						tr("Map contains object(s) from mod '%1'%2, but the mod is missing from the map's required mods list."
-						" Add it to the map's required mods in Map->General settings.", "be consistent with Map->General menu entry translation")
-						.arg(QString::fromStdString(LIBRARY->modh->getModInfo(mod.first).getVerificationInfo().name)), submod),
-						true
-					});
+						" Add it to the map's required mods in Map->General settings.", "should be consistent with Map->General menu entry translation")
+						.arg(QString::fromStdString(LIBRARY->modh->getModInfo(mod.first).getVerificationInfo().name), submod), true });
 			}
 		}
 	}

--- a/mapeditor/validator.cpp
+++ b/mapeditor/validator.cpp
@@ -201,11 +201,11 @@ void Validator::showValidationResults(const CMap * map)
 	setAttribute(Qt::WA_DeleteOnClose);
 	ui->listWidget->setItemDelegate(new ValidatorItemDelegate(ui->listWidget));
 
-	const std::array<QString, 2> icons{ ":/icons/mod-update.png", ":/icons/mod-delete.png" };
-
 	for(auto const & issue : Validator::validate(map))
 	{
-		auto * item = new QListWidgetItem(QIcon(icons[issue.critical ? 1 : 0]), issue.message, ui->listWidget);
+		auto * item = new QListWidgetItem(QIcon(issue.critical ? ":/icons/mod-delete.png" : ":/icons/mod-update.png"),
+			issue.message, ui->listWidget);
+
 		ui->listWidget->addItem(item);
 	}
 

--- a/mapeditor/validator.cpp
+++ b/mapeditor/validator.cpp
@@ -171,16 +171,7 @@ std::set<Validator::Issue> Validator::validate(const CMap * map)
 		for(auto & mod : MapController::modAssessmentMap(*map))
 		{
 			if(!map->mods.count(mod.first))
-			{
-				QString submod;
-				if(!mod.second.parent.empty())
-					submod = tr(" (submod of %1").arg(QString::fromStdString(mod.second.parent));
-				
-				issues.insert({
-						tr("Map contains object(s) from mod '%1'%2, but the mod is missing from the map's required mods list."
-						" Add it to the map's required mods in Map->General settings.", "should be consistent with Map->General menu entry translation")
-						.arg(QString::fromStdString(LIBRARY->modh->getModInfo(mod.first).getVerificationInfo().name), submod), true });
-			}
+				issues.insert({ MapController::modMissingMessage(mod.second), true });
 		}
 	}
 	catch(const std::exception & e)
@@ -211,7 +202,7 @@ void Validator::showValidationResults(const CMap * map)
 
 	if(ui->listWidget->count() == 0)
 	{
-		QPixmap greenTick = QPixmap(":/icons/mod-enabled.png");
+		QPixmap greenTick(":/icons/mod-enabled.png");
 		QString validMessage = tr("The map is valid and has no issues.");
 		auto * item = new QListWidgetItem(QIcon(greenTick), validMessage, ui->listWidget);
 		ui->listWidget->addItem(item);

--- a/mapeditor/validator.h
+++ b/mapeditor/validator.h
@@ -47,32 +47,32 @@ public:
 private:
 	Ui::Validator *ui;
 
-    QRect screenGeometry;
+	QRect screenGeometry;
 
 	void showValidationResults(const CMap * map);
-    void adjustWindowSize();
+	void adjustWindowSize();
 };
 
 class ValidatorItemDelegate : public QStyledItemDelegate
 {
 public:
-    explicit ValidatorItemDelegate(QObject * parent = nullptr) : QStyledItemDelegate(parent) 
-    {
-        screenGeometry = QApplication::primaryScreen()->availableGeometry();
-    }
+	explicit ValidatorItemDelegate(QObject * parent = nullptr) : QStyledItemDelegate(parent) 
+	{
+		screenGeometry = QApplication::primaryScreen()->availableGeometry();
+	}
 
-    int itemPaddingBottom = 14;
-    int iconPadding = 4;
-    int textOffsetForIcon = 30;
+	int itemPaddingBottom = 14;
+	int iconPadding = 4;
+	int textOffsetForIcon = 30;
 	int textPaddingRight = 10;
-    int minItemWidth = 350;
-    int screenMargin = 350;     // some reserved space from screenWidth; used if text.width > screenWidth - screenMargin 
+	int minItemWidth = 350;
+	int screenMargin = 350;     // some reserved space from screenWidth; used if text.width > screenWidth - screenMargin 
 	
 	const int offsetForIcon = iconPadding + textOffsetForIcon;
 
-    void paint(QPainter * painter, const QStyleOptionViewItem & option, const QModelIndex & index) const override;
+	void paint(QPainter * painter, const QStyleOptionViewItem & option, const QModelIndex & index) const override;
 	QSize sizeHint(const QStyleOptionViewItem & option, const QModelIndex & index) const override;
 
 private:
-    QRect screenGeometry;
+	QRect screenGeometry;
 };

--- a/mapeditor/validator.h
+++ b/mapeditor/validator.h
@@ -46,4 +46,34 @@ public:
 
 private:
 	Ui::Validator *ui;
+
+    QRect screenGeometry;
+
+	QPixmap createGreenTickIcon();
+	void showValidationResults(const CMap * map);
+    void adjustWindowSize();
+};
+
+class ValidatorItemDelegate : public QStyledItemDelegate
+{
+public:
+    explicit ValidatorItemDelegate(QObject * parent = nullptr) : QStyledItemDelegate(parent) 
+    {
+        screenGeometry = QApplication::primaryScreen()->availableGeometry();
+    }
+
+    int itemPaddingBottom = 14;
+    int iconPadding = 4;
+    int textOffsetForIcon = 30;
+	int textPaddingRight = 10;
+    int minItemWidth = 350;
+    int screenMargin = 350;     // some reserved space from screenWidth; used if text.width > screenWidth - screenMargin 
+	
+	const int offsetForIcon = iconPadding + textOffsetForIcon;
+
+    void paint(QPainter * painter, const QStyleOptionViewItem & option, const QModelIndex & index) const override;
+	QSize sizeHint(const QStyleOptionViewItem & option, const QModelIndex & index) const override;
+
+private:
+    QRect screenGeometry;
 };

--- a/mapeditor/validator.h
+++ b/mapeditor/validator.h
@@ -49,7 +49,6 @@ private:
 
     QRect screenGeometry;
 
-	QPixmap createGreenTickIcon();
 	void showValidationResults(const CMap * map);
     void adjustWindowSize();
 };

--- a/mapeditor/windownewmap.cpp
+++ b/mapeditor/windownewmap.cpp
@@ -311,7 +311,7 @@ void WindowNewMap::on_okButton_clicked()
 		nmap = f.get();
 	}
 	
-	nmap->mods = MapController::modAssessmentAll();
+	nmap->mods = MapController::modAssessmentMap(*nmap);
 	static_cast<MainWindow*>(parent())->controller.setMap(std::move(nmap));
 	static_cast<MainWindow*>(parent())->initializeMap(true);
 	close();


### PR DESCRIPTION
This PR introduces the following changes:
- the results window now dynamically adjusts its size based on message lengths
- a valid map will now properly display an appropriate message in the validation results
- word wrap for item text activates only when the window reaches a defined width limit

Additionally, one of the issue messages has been updated to make the error clearer.

If this PR gets accepted, I’ll also regenerate and commit the updated .ts files.

Old validation results window with multiple issues:
![old1](https://github.com/user-attachments/assets/bfb71b1b-8a9b-4205-8f24-330a7ce9ffae)

After manual resize:
![old2](https://github.com/user-attachments/assets/6c0aba30-6149-4156-914f-d69827d34842)

Empty issue list (valid map):
![old3](https://github.com/user-attachments/assets/0eacc7d2-24fc-4671-89b6-a82f16874b50)

New validation results window with multiple issues:
![new1](https://github.com/user-attachments/assets/414d6b27-92cd-42cd-aed5-ce362f2da79d)
![new2](https://github.com/user-attachments/assets/f7cb0f11-3e03-49cd-8b2d-aa9e8a4080db)

Empty issue list (valid map):
![new3](https://github.com/user-attachments/assets/31c06cfb-903f-46dc-9db7-3322f2bbbc86)
