### PR TITLE
[1.6.6] Fix stacking of bonuses from buildings like Tavern

### DIFF
--- a/config/factions/castle.json
+++ b/config/factions/castle.json
@@ -202,6 +202,11 @@
 						{
 							"type": "MORALE",
 							"val": 2
+						},
+						{
+							"propagator": "PLAYER_PROPAGATOR",
+							"type": "THIEVES_GUILD_ACCESS",
+							"val": 1
 						}
 					],
 					"upgrades" : "tavern"

--- a/lib/mapObjects/CGTownInstance.cpp
+++ b/lib/mapObjects/CGTownInstance.cpp
@@ -754,8 +754,6 @@ void CGTownInstance::recreateBuildingsBonuses()
 	for(const auto & b : bl)
 		removeBonus(b);
 
-
-
 	for(const auto & bid : builtBuildings)
 	{
 		bool bonusesReplacedByUpgrade = false;
@@ -777,7 +775,12 @@ void CGTownInstance::recreateBuildingsBonuses()
 			continue;
 
 		for(auto & bonus : building->buildingBonuses)
-			addNewBonus(bonus);
+		{
+			// Add copy of bonus to bonus system
+			// Othervice, bonuses with player or global propagator will not stack if player has multiple towns of same faction
+			auto bonusCopy = std::make_shared<Bonus>(*bonus);
+			addNewBonus(bonusCopy);
+		}
 	}
 }
 


### PR DESCRIPTION
- Same buildings in different towns of the same faction that provide bonuses with propagators will now correctly stack their bonuses. This fixes Tavern and possibly other such buildings
- Brotherhood of Sword now correctly adds bonus to thieves guild access