### PR TITLE
[1.6.6] portmaster support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,6 +109,8 @@ include(CMakeDependentOption)
 cmake_dependent_option(ENABLE_INNOEXTRACT "Enable innoextract for GOG file extraction in launcher" ON "ENABLE_LAUNCHER" OFF)
 cmake_dependent_option(ENABLE_GITVERSION "Enable Version.cpp with Git commit hash" ON "NOT ENABLE_GOLDMASTER" OFF)
 
+option(VCMI_PORTMASTER "PortMaster build" OFF)
+
 ############################################
 #        Miscellaneous options             #
 ############################################

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -319,6 +319,25 @@
             "cacheVariables": {
                 "ANDROID_GRADLE_PROPERTIES": "applicationIdSuffix=.daily;signingConfig=dailySigning;applicationLabel=VCMI daily;applicationVariant=daily"
             }
+        },
+        {
+            "name": "portmaster-release",
+            "displayName": "PortMaster",
+            "description": "VCMI PortMaster",
+            "inherits": "default-release",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Release",
+                "CMAKE_INSTALL_PREFIX": ".",
+                "ENABLE_DEBUG_CONSOLE": "OFF",
+                "ENABLE_EDITOR": "OFF",
+                "ENABLE_GITVERSION": "OFF",
+                "ENABLE_LAUNCHER": "OFF",
+                "ENABLE_SERVER": "OFF",
+                "ENABLE_TRANSLATIONS": "OFF",
+                "FORCE_BUNDLED_FL": "ON",
+                "ENABLE_GOLDMASTER": "ON",
+                "VCMI_PORTMASTER": "ON"
+            }
         }
     ],
     "buildPresets": [
@@ -447,6 +466,12 @@
             "name": "android-daily-release",
             "configurePreset": "android-daily-release",
             "inherits": "android-conan-ninja-release"
+        },
+        {
+            "name": "portmaster-release",
+            "configurePreset": "portmaster-release",
+            "inherits": "default-release",
+            "configuration": "Release"
         }
     ],
     "testPresets": [

--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -493,5 +493,9 @@ if (ffmpeg_INCLUDE_DIRS)
 	)
 endif()
 
+if(VCMI_PORTMASTER)
+	target_compile_definitions(vcmiclientcommon PRIVATE VCMI_PORTMASTER)
+endif()
+
 vcmi_set_output_dir(vcmiclientcommon "")
 enable_pch(vcmiclientcommon)

--- a/client/gui/CursorHandler.cpp
+++ b/client/gui/CursorHandler.cpp
@@ -24,7 +24,7 @@
 
 std::unique_ptr<ICursor> CursorHandler::createCursor()
 {
-#if defined(VCMI_MOBILE)
+#if defined(VCMI_MOBILE) || defined(VCMI_PORTMASTER)
 	if (settings["general"]["userRelativePointer"].Bool())
 		return std::make_unique<CursorSoftware>();
 #endif

--- a/docker/BuildPortmaster-aarch64.dockerfile
+++ b/docker/BuildPortmaster-aarch64.dockerfile
@@ -1,0 +1,28 @@
+FROM monkeyx/retro_builder:arm64
+WORKDIR /usr/local/app
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# from VCMI build docs
+RUN apt-get update && apt-get install -y cmake g++ clang libsdl2-dev libsdl2-image-dev libsdl2-ttf-dev libsdl2-mixer-dev zlib1g-dev libavformat-dev libswscale-dev libboost-dev libboost-filesystem-dev libboost-system-dev libboost-thread-dev libboost-program-options-dev libboost-locale-dev libboost-iostreams-dev qtbase5-dev libtbb-dev libluajit-5.1-dev liblzma-dev libsqlite3-dev qttools5-dev ninja-build ccache
+
+# newer cmake version to support presets
+RUN apt-get remove -y cmake
+RUN apt-get install -y libssl-dev
+RUN wget https://github.com/Kitware/CMake/releases/download/v3.31.5/cmake-3.31.5.tar.gz ; tar zxvf cmake-3.31.5.tar.gz ; cd cmake-3.31.5 ; ./bootstrap ; make ; make install ; cd .. ; rm -rf cmake-3.31.5
+
+CMD ["sh", "-c", " \
+    # switch to mounted dir
+    cd /vcmi ; \
+    # fix for wrong path of base image
+    ln -s /usr/lib/libSDL2.so /usr/lib/aarch64-linux-gnu/libSDL2.so ; \
+    # build
+    cmake --preset portmaster-release ; \
+    cmake --build --preset portmaster-release ; \
+    # export missing libraries
+    ldd /vcmi/out/build/portmaster-release/bin/vcmiclient | grep -e libboost -e libtbb -e libicu | awk 'NF == 4 { system(\"cp \" $3 \" /vcmi/out/build/portmaster-release/bin/\") }' \
+"]
+
+# Build on ARM64 processor or ARM64 chroot with:
+#      docker build -f docker/BuildPortmaster-aarch64.dockerfile -t vcmi-portmaster-build .
+#      docker run -it --rm -v $PWD/:/vcmi vcmi-portmaster-build

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -872,3 +872,7 @@ if(APPLE_IOS AND NOT USING_CONAN)
 		install(${INSTALL_TYPE} ${LINKED_LIB_REAL} LIBRARY DESTINATION ${LIB_DIR})
 	endforeach()
 endif()
+
+if(VCMI_PORTMASTER)
+	target_compile_definitions(vcmi PRIVATE VCMI_PORTMASTER)
+endif()


### PR DESCRIPTION
@IvanSavenko Do you think we should merge this one?

It make it easier to build VCMI for portmaster. As portmaster builds are quite complicated...

With this we would avoid patching VCMI files and provide a docker file that could run on ARM64 (or [ARM64 qemu](https://portmaster.games/docker.html)) which makes this easier.

Even if we would not merge it's for documenting how it can build.

Video is working (related https://github.com/PortsMaster/PortMaster-New/issues/497).

@ddrsoul