### PR TITLE
[1.6.6] Fix visiting of Stables in Castle after visiting adventure map stables on the same week

### DIFF
--- a/config/factions/castle.json
+++ b/config/factions/castle.json
@@ -185,6 +185,7 @@
 				"ship":           { "id" : 20, "upgrades" : "shipyard" },
 				"special2":       {
 					"requires" : [ "dwellingLvl4" ],
+					"mapObjectLikeBonuses" : "stables",
 					"configuration" : {
 						"visitMode" : "bonus",
 						"rewards" : [

--- a/config/schemas/townBuilding.json
+++ b/config/schemas/townBuilding.json
@@ -65,6 +65,10 @@
 			"description" : "If set to true, this building will not automatically activate on new day or on entering town and needs to be activated manually on click",
 			"type" : "boolean"
 		},
+		"mapObjectLikeBonuses" : {
+			"description" : "Optional, all bonuses granted by configurable buildings will have source set to specified map object",
+			"type" : "string"
+		},
 		"configuration" : {
 			"description" : "Optional, configuration of building that can be activated by visiting hero",
 			"$ref" : "rewardable.json"

--- a/lib/entities/building/CBuilding.h
+++ b/lib/entities/building/CBuilding.h
@@ -46,6 +46,7 @@ public:
 	bool upgradeReplacesBonuses = false;
 	bool manualHeroVisit = false;
 	BonusList buildingBonuses;
+	MapObjectID mapObjectLikeBonuses;
 
 	Rewardable::Info rewardableObjectInfo; ///configurable rewards for special buildings
 

--- a/lib/entities/faction/CTownHandler.cpp
+++ b/lib/entities/faction/CTownHandler.cpp
@@ -329,6 +329,14 @@ void CTownHandler::loadBuilding(CTown * town, const std::string & stringID, cons
 
 	loadBuildingBonuses(source["bonuses"], ret->buildingBonuses, ret);
 
+	if(!source["mapObjectLikeBonuses"].isNull())
+	{
+		VLC->identifiers()->requestIdentifierOptional("object", source["mapObjectLikeBonuses"], [=](si32 identifier)
+		{
+			ret->mapObjectLikeBonuses = MapObjectID(identifier);
+		});
+	}
+
 	if(!source["configuration"].isNull())
 		ret->rewardableObjectInfo.init(source["configuration"], ret->getBaseTextID());
 

--- a/lib/mapObjects/TownBuildingInstance.cpp
+++ b/lib/mapObjects/TownBuildingInstance.cpp
@@ -82,8 +82,16 @@ Rewardable::Configuration TownRewardableBuildingInstance::generateConfiguration(
 	{
 		for (auto & bonus : rewardInfo.reward.bonuses)
 		{
-			bonus.source = BonusSource::TOWN_STRUCTURE;
-			bonus.sid = BonusSourceID(building->getUniqueTypeID());
+			if (building->mapObjectLikeBonuses.hasValue())
+			{
+				bonus.source = BonusSource::OBJECT_TYPE;
+				bonus.sid = BonusSourceID(building->mapObjectLikeBonuses);
+			}
+			else
+			{
+				bonus.source = BonusSource::TOWN_STRUCTURE;
+				bonus.sid = BonusSourceID(building->getUniqueTypeID());
+			}
 		}
 	}
 	return result;
@@ -158,7 +166,10 @@ bool TownRewardableBuildingInstance::wasVisitedBefore(const CGHeroInstance * con
 		case Rewardable::VISIT_BONUS:
 		{
 			const auto building = town->getTown()->buildings.at(getBuildingType());
-			return contextHero->hasBonusFrom(BonusSource::TOWN_STRUCTURE, BonusSourceID(building->getUniqueTypeID()));
+			if (building->mapObjectLikeBonuses.hasValue())
+				return contextHero->hasBonusFrom(BonusSource::OBJECT_TYPE, BonusSourceID(building->mapObjectLikeBonuses));
+			else
+				return contextHero->hasBonusFrom(BonusSource::TOWN_STRUCTURE, BonusSourceID(building->getUniqueTypeID()));
 		}
 		case Rewardable::VISIT_HERO:
 			return visitors.find(contextHero->id) != visitors.end();


### PR DESCRIPTION
Stables in Castle will now check for and give same bonuses as map stable, which should fix these bugs for good.