### PR TITLE
[1.6.6] Update status window on receiving secondary skill

### DIFF
--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -491,6 +491,7 @@ void CPlayerInterface::heroSecondarySkillChanged(const CGHeroInstance * hero, in
 		cuw->updateSecondarySkills();
 
 	localState->verifyPath(hero);
+	adventureInt->onHeroChanged(hero);// secondary skill can change primary skill / mana limit
 }
 
 void CPlayerInterface::heroManaPointsChanged(const CGHeroInstance * hero)


### PR DESCRIPTION
Fixes hero information not updating if for example hero receives secondary skill that modifies his primary stats