### PR TITLE
[1.6.7?] Statistic window fixes

### DIFF
--- a/client/mainmenu/CStatisticScreen.cpp
+++ b/client/mainmenu/CStatisticScreen.cpp
@@ -521,7 +521,9 @@ LineChart::LineChart(Rect position, std::string title, TData data, TIcons icons,
 			for(auto & icon : icons)
 				if(std::get<0>(icon) == line.first && std::get<1>(icon) == i + 1) // color && day
 				{
-					pictures.emplace_back(std::make_shared<CPicture>(std::get<2>(icon), Point(p.x - (std::get<2>(icon)->width() / 2), p.y - (std::get<2>(icon)->height() / 2))));
+					auto img = std::get<2>(icon);
+					Point imgPos(p.x - (img->contentRect().w / 2) - img->contentRect().x, p.y - (img->contentRect().h / 2) - img->contentRect().y);
+					pictures.emplace_back(std::make_shared<CPicture>(img, imgPos));
 					pictures.back()->addRClickCallback([icon](){ CRClickPopup::createAndPush(std::get<3>(icon)); });
 				}
 

--- a/client/mainmenu/CStatisticScreen.cpp
+++ b/client/mainmenu/CStatisticScreen.cpp
@@ -483,12 +483,15 @@ LineChart::LineChart(Rect position, std::string title, TData data, TIcons icons,
 
 	// draw grid (vertical lines)
 	int dayGridInterval = maxDay < 700 ? 7 : 28;
-	for(const auto & line : data)
+	if(maxDay > 1)
 	{
-		for(int i = 0; i < line.second.size(); i += dayGridInterval)
+		for(const auto & line : data)
 		{
-			Point p = getPoint(i, line.second) + chartArea.topLeft();
-			canvas->addLine(Point(p.x, chartArea.topLeft().y), Point(p.x, chartArea.topLeft().y + chartArea.h), ColorRGBA(70, 70, 70));
+			for(int i = 0; i < line.second.size(); i += dayGridInterval)
+			{
+				Point p = getPoint(i, line.second) + chartArea.topLeft();
+				canvas->addLine(Point(p.x, chartArea.topLeft().y), Point(p.x, chartArea.topLeft().y + chartArea.h), ColorRGBA(70, 70, 70));
+			}
 		}
 	}
 

--- a/client/mainmenu/CStatisticScreen.h
+++ b/client/mainmenu/CStatisticScreen.h
@@ -20,6 +20,7 @@ class ComboBox;
 class CSlider;
 class IImage;
 class CPicture;
+class TransparentFilledRectangle;
 
 using TData = std::vector<std::pair<ColorRGBA, std::vector<float>>>;
 using TIcons = std::vector<std::tuple<ColorRGBA, int, std::shared_ptr<IImage>, std::string>>; // Color, Day, Image, Helptext
@@ -118,13 +119,18 @@ class LineChart : public CIntObject
 	std::vector<std::shared_ptr<CIntObject>> layout;
 	std::shared_ptr<CGStatusBar> statusBar;
 	std::vector<std::shared_ptr<CPicture>> pictures;
+	std::shared_ptr<TransparentFilledRectangle> hoverMarker;
 
 	Rect chartArea;
 	float maxVal;
 	int niceMaxVal;
 	int maxDay;
 
+	TData data;
+
 	void updateStatusBar(const Point & cursorPosition);
+	// calculate points in chart
+	Point getPoint(int i, std::vector<float> data);
 public:
 	LineChart(Rect position, std::string title, TData data, TIcons icons, float maxY);
 


### PR DESCRIPTION
- remove weird line when winning in the first round
- correctly center icons with some transparent space around
- add snap in marker if mouse near data point (make it easier to get exact values)