### PR TITLE
[1.6.7] Fix crash on attempting to connect newly created lobby room

### DIFF
--- a/server/CVCMIServer.cpp
+++ b/server/CVCMIServer.cpp
@@ -80,27 +80,25 @@ CVCMIServer::CVCMIServer(uint16_t port, bool runByClient)
 
 CVCMIServer::~CVCMIServer() = default;
 
-uint16_t CVCMIServer::prepare(bool connectToLobby, bool listenForConnections) {
-	if(connectToLobby) {
+uint16_t CVCMIServer::prepare(bool connectToLobby, bool listenForConnections)
+{
+	if(connectToLobby)
 		lobbyProcessor = std::make_unique<GlobalLobbyProcessor>(*this);
-		return 0;
-	} else {
-		return startAcceptingIncomingConnections(listenForConnections);
-	}
+
+	return startAcceptingIncomingConnections(listenForConnections);
 }
 
 uint16_t CVCMIServer::startAcceptingIncomingConnections(bool listenForConnections)
 {
 	networkServer = networkHandler->createServerTCP(*this);
 
-	port
-		? logNetwork->info("Port %d will be used", port)
-		: logNetwork->info("Randomly assigned port will be used");
-
-	// config port may be 0 => srvport will contain the OS-assigned port value
-
 	if (listenForConnections)
 	{
+		// config port may be 0 => srvport will contain the OS-assigned port value
+		port
+			? logNetwork->info("Port %d will be used", port)
+			: logNetwork->info("Randomly assigned port will be used");
+
 		auto srvport = networkServer->start(port);
 		logNetwork->info("Listening for connections at port %d", srvport);
 		return srvport;

--- a/server/GlobalLobbyProcessor.cpp
+++ b/server/GlobalLobbyProcessor.cpp
@@ -99,7 +99,6 @@ void GlobalLobbyProcessor::receiveServerLoginSuccess(const JsonNode & json)
 {
 	// no-op, wait just for any new commands from lobby
 	logGlobal->info("Lobby: Successfully connected to lobby server");
-	owner.startAcceptingIncomingConnections(true);
 }
 
 void GlobalLobbyProcessor::receiveAccountJoinsRoom(const JsonNode & json)


### PR DESCRIPTION
Due to client no longer establishing TCP connection to local server, client was connecting to server too fast, before server was set up properly

- Fixes #5462