### PR TITLE
[1.6.7] make lobby 4:3 aspect ratio & fixes

### DIFF
--- a/Mods/vcmi/Content/config/chinese.json
+++ b/Mods/vcmi/Content/config/chinese.json
@@ -175,7 +175,7 @@
 	"vcmi.lobby.match.solo" : "单人游戏",
 	"vcmi.lobby.match.duel" : "与 %s 的游戏", // %s -> nickname of another player
 	"vcmi.lobby.match.multi" : "%d 个玩家",
-	"vcmi.lobby.room.create" : "创建房间",
+	"vcmi.lobby.room.create.hover" : "创建房间",
 	"vcmi.lobby.room.players.limit" : "玩家限制",
 	"vcmi.lobby.room.description.public" : "任何玩家都可以加入公开房间。",
 	"vcmi.lobby.room.description.private" : "只有被邀请的玩家能加入私有房间。",

--- a/Mods/vcmi/Content/config/czech.json
+++ b/Mods/vcmi/Content/config/czech.json
@@ -178,7 +178,7 @@
 	"vcmi.lobby.match.solo" : "Hra jednoho hráče",
 	"vcmi.lobby.match.duel" : "Hra s %s", // %s -> nickname of another player
 	"vcmi.lobby.match.multi" : "%d hráčů",
-	"vcmi.lobby.room.create" : "Vytvořit novou místnost",
+	"vcmi.lobby.room.create.hover" : "Vytvořit novou místnost",
 	"vcmi.lobby.room.players.limit" : "Omezení počtu hráčů",
 	"vcmi.lobby.room.description.public" : "Jakýkoliv hráč se může připojit do veřejné místnosti.",
 	"vcmi.lobby.room.description.private" : "Pouze pozvaní hráči se mohou připojit do soukromé místnosti.",

--- a/Mods/vcmi/Content/config/english.json
+++ b/Mods/vcmi/Content/config/english.json
@@ -179,6 +179,7 @@
 	"vcmi.lobby.match.duel" : "Game with %s", // %s -> nickname of another player
 	"vcmi.lobby.match.multi" : "%d players",
 	"vcmi.lobby.room.create" : "Create New Room",
+	"vcmi.lobby.room.create.help" : "Create a new room in the online lobby that other players can join.",
 	"vcmi.lobby.room.players.limit" : "Players Limit",
 	"vcmi.lobby.room.description.public" : "Any player can join public room.",
 	"vcmi.lobby.room.description.private" : "Only invited players can join private room.",

--- a/Mods/vcmi/Content/config/english.json
+++ b/Mods/vcmi/Content/config/english.json
@@ -178,7 +178,7 @@
 	"vcmi.lobby.match.solo" : "Singleplayer Game",
 	"vcmi.lobby.match.duel" : "Game with %s", // %s -> nickname of another player
 	"vcmi.lobby.match.multi" : "%d players",
-	"vcmi.lobby.room.create" : "Create New Room",
+	"vcmi.lobby.room.create.hover" : "Create New Room",
 	"vcmi.lobby.room.create.help" : "Create a new room in the online lobby that other players can join.",
 	"vcmi.lobby.room.players.limit" : "Players Limit",
 	"vcmi.lobby.room.description.public" : "Any player can join public room.",
@@ -202,6 +202,8 @@
 	"vcmi.lobby.preview.error.mods" : "You are using different set of mods.",
 	"vcmi.lobby.preview.error.version" : "You are using different version of VCMI.",
 	"vcmi.lobby.channel.add" : "Add Channel",
+	"vcmi.lobby.channel.sendMessage.hover" : "Send message",
+	"vcmi.lobby.channel.sendMessage.help" : "Send message",
 	"vcmi.lobby.room.new" : "New Game",
 	"vcmi.lobby.room.load" : "Load Game",
 	"vcmi.lobby.room.type" : "Room Type",

--- a/Mods/vcmi/Content/config/german.json
+++ b/Mods/vcmi/Content/config/german.json
@@ -179,6 +179,7 @@
 	"vcmi.lobby.match.duel" : "Spiel mit %s", // %s -> nickname of another player
 	"vcmi.lobby.match.multi" : "%d Spieler",
 	"vcmi.lobby.room.create" : "Neuen Spiel-Raum erstellen",
+	"vcmi.lobby.room.create.help" : "Erstelle einen neuen Raum in der Online-Lobby, dem andere Spieler beitreten können.",
 	"vcmi.lobby.room.players.limit" : "Spieler Limit",
 	"vcmi.lobby.room.description.public" : "Jeder Spieler kann dem öffentlichen Raum beitreten.",
 	"vcmi.lobby.room.description.private" : "Nur eingeladene Spieler können den privaten Raum betreten.",

--- a/Mods/vcmi/Content/config/german.json
+++ b/Mods/vcmi/Content/config/german.json
@@ -178,7 +178,7 @@
 	"vcmi.lobby.match.solo" : "Einzelspieler-Spiel",
 	"vcmi.lobby.match.duel" : "Spiel mit %s", // %s -> nickname of another player
 	"vcmi.lobby.match.multi" : "%d Spieler",
-	"vcmi.lobby.room.create" : "Neuen Spiel-Raum erstellen",
+	"vcmi.lobby.room.create.hover" : "Neuen Spiel-Raum erstellen",
 	"vcmi.lobby.room.create.help" : "Erstelle einen neuen Raum in der Online-Lobby, dem andere Spieler beitreten können.",
 	"vcmi.lobby.room.players.limit" : "Spieler Limit",
 	"vcmi.lobby.room.description.public" : "Jeder Spieler kann dem öffentlichen Raum beitreten.",
@@ -202,6 +202,8 @@
 	"vcmi.lobby.preview.error.mods" : "Ihr verwendet andere Mods.",
 	"vcmi.lobby.preview.error.version" : "Ihr verwendet eine andere Version von VCMI.",
 	"vcmi.lobby.channel.add" : "Kanal hinzufügen",
+	"vcmi.lobby.channel.sendMessage.hover" : "Nachricht senden",
+	"vcmi.lobby.channel.sendMessage.help" : "Nachricht senden",
 	"vcmi.lobby.room.new" : "Neues Spiel",
 	"vcmi.lobby.room.load" : "Spiel laden",
 	"vcmi.lobby.room.type" : "Raumtyp",

--- a/Mods/vcmi/Content/config/hungarian.json
+++ b/Mods/vcmi/Content/config/hungarian.json
@@ -175,7 +175,7 @@
 	"vcmi.lobby.match.solo" : "Egyszemélyes játék",
 	"vcmi.lobby.match.duel" : "Játék %s-szel", // %s -> nickname of another player
 	"vcmi.lobby.match.multi" : "%d játékos",
-	"vcmi.lobby.room.create" : "Új szoba létrehozása",
+	"vcmi.lobby.room.create.hover" : "Új szoba létrehozása",
 	"vcmi.lobby.room.players.limit" : "Játékosok száma",
 	"vcmi.lobby.room.description.public" : "Bárki csatlakozhat a nyilvános szobához.",
 	"vcmi.lobby.room.description.private" : "Csak meghívott játékosok csatlakozhatnak a privát szobához.",

--- a/Mods/vcmi/Content/config/italian.json
+++ b/Mods/vcmi/Content/config/italian.json
@@ -177,7 +177,7 @@
 	"vcmi.lobby.match.solo" : "Partita in singolo",
 	"vcmi.lobby.match.duel" : "Partita con %s", // %s -> nickname of another player
 	"vcmi.lobby.match.multi" : "%d giocatori",
-	"vcmi.lobby.room.create" : "Crea nuova stanza",
+	"vcmi.lobby.room.create.hover" : "Crea nuova stanza",
 	"vcmi.lobby.room.players.limit" : "Limite giocatori",
 	"vcmi.lobby.room.description.public" : "Qualsiasi giocatore può entrare in una stanza pubblica.",
 	"vcmi.lobby.room.description.private" : "Solo i giocatori invitati possono entrare in una stanza privata.",

--- a/Mods/vcmi/Content/config/polish.json
+++ b/Mods/vcmi/Content/config/polish.json
@@ -171,7 +171,7 @@
 	"vcmi.lobby.match.solo" : "Gra jednoosobowa",
 	"vcmi.lobby.match.duel" : "vs. %s", // %s -> nickname of another player
 	"vcmi.lobby.match.multi" : "%d graczy",
-	"vcmi.lobby.room.create" : "Stwórz nowy pokój",
+	"vcmi.lobby.room.create.hover" : "Stwórz nowy pokój",
 	"vcmi.lobby.room.players.limit" : "Limit graczy",
 	"vcmi.lobby.room.description.public" : "Każdy może dołączyć do pokoju.",
 	"vcmi.lobby.room.description.private" : "Tylko zaproszeni gracze mogą dołączyć do pokoju.",

--- a/Mods/vcmi/Content/config/portuguese.json
+++ b/Mods/vcmi/Content/config/portuguese.json
@@ -175,7 +175,7 @@
 	"vcmi.lobby.match.solo" : "Jogo para um Jogador",
 	"vcmi.lobby.match.duel" : "Jogo com %s", // %s -> apelido de outro jogador
 	"vcmi.lobby.match.multi" : "%d jogadores",
-	"vcmi.lobby.room.create" : "Criar Nova Sala",
+	"vcmi.lobby.room.create.hover" : "Criar Nova Sala",
 	"vcmi.lobby.room.players.limit" : "Limite de Jogadores",
 	"vcmi.lobby.room.description.public" : "Qualquer jogador pode entrar na sala pública.",
 	"vcmi.lobby.room.description.private" : "Apenas jogadores convidados podem entrar na sala privada.",

--- a/Mods/vcmi/Content/config/swedish.json
+++ b/Mods/vcmi/Content/config/swedish.json
@@ -178,7 +178,7 @@
 	"vcmi.lobby.match.solo"              : "Spel för en spelare",
 	"vcmi.lobby.match.duel"              : "Spel med %s", // %s -> smeknamn på en annan spelare
 	"vcmi.lobby.match.multi"             : "%d spelare",
-	"vcmi.lobby.room.create"             : "Skapa nytt rum",
+	"vcmi.lobby.room.create.hover"             : "Skapa nytt rum",
 	"vcmi.lobby.room.players.limit"      : "Begränsning av spelare",
 	"vcmi.lobby.room.description.public" : "Alla spelare kan gå med i det offentliga rummet.",
 	"vcmi.lobby.room.description.private": "Endast inbjudna spelare kan gå med i ett privat rum.",

--- a/Mods/vcmi/Content/config/ukrainian.json
+++ b/Mods/vcmi/Content/config/ukrainian.json
@@ -178,7 +178,7 @@
 	"vcmi.lobby.match.solo" : "Одиночна гра",
 	"vcmi.lobby.match.duel" : "Гра з %s", // %s -> nickname of another player
 	"vcmi.lobby.match.multi" : "%d гравців",
-	"vcmi.lobby.room.create" : "Створити нову кімнату",
+	"vcmi.lobby.room.create.hover" : "Створити нову кімнату",
 	"vcmi.lobby.room.players.limit" : "Максимум гравців",
 	"vcmi.lobby.room.description.public" : "Будь-хто з гравців може приєднатися до публічної кімнати.",
 	"vcmi.lobby.room.description.private" : "Тільки запрошені гравці можуть приєднатися до приватної кімнати.",

--- a/Mods/vcmi/Content/config/vietnamese.json
+++ b/Mods/vcmi/Content/config/vietnamese.json
@@ -175,7 +175,7 @@
 	"vcmi.lobby.match.solo" : "Chơi Đơn",
 	"vcmi.lobby.match.duel" : "Chơi với %s", // %s -> nickname of another player
 	"vcmi.lobby.match.multi" : "người chơi %d",
-	"vcmi.lobby.room.create" : "Tạo Phòng Mới",
+	"vcmi.lobby.room.create.hover" : "Tạo Phòng Mới",
 	"vcmi.lobby.room.players.limit" : "Số Người Chơi",
 	"vcmi.lobby.room.description.public" : "Người chơi có thể vào phòng công khai.",
 	"vcmi.lobby.room.description.private" : "Người chơi được mời mới có thể vào phòng riêng tư.",

--- a/client/globalLobby/GlobalLobbyClient.cpp
+++ b/client/globalLobby/GlobalLobbyClient.cpp
@@ -477,7 +477,7 @@ std::shared_ptr<GlobalLobbyLoginWindow> GlobalLobbyClient::createLoginWindow()
 std::shared_ptr<GlobalLobbyWindow> GlobalLobbyClient::createLobbyWindow()
 {
 	auto lobbyWindowPtr = lobbyWindow.lock();
-	if(lobbyWindowPtr)
+	if(lobbyWindowPtr && GH.screenDimensions().x >= lobbyWindowPtr->pos.w) // if wide window doesn't fit anymore after ingame screen resolution change
 		return lobbyWindowPtr;
 
 	lobbyWindowPtr = std::make_shared<GlobalLobbyWindow>();

--- a/client/globalLobby/GlobalLobbyInviteWindow.cpp
+++ b/client/globalLobby/GlobalLobbyInviteWindow.cpp
@@ -95,6 +95,7 @@ GlobalLobbyInviteWindow::GlobalLobbyInviteWindow()
 
 	listBackground = std::make_shared<TransparentFilledRectangle>(Rect(8, 48, 220, 324), ColorRGBA(0, 0, 0, 64), ColorRGBA(64, 80, 128, 255), 1);
 	accountList = std::make_shared<CListBox>(createAccountCardCallback, Point(10, 50), Point(0, 40), 8, CSH->getGlobalLobby().getActiveAccounts().size(), 0, 1 | 4, Rect(200, 0, 320, 320));
+	accountList->setRedrawParent(true);
 
 	buttonClose = std::make_shared<CButton>(Point(86, 384), AnimationPath::builtin("MuBchck"), CButton::tooltip(), [this]() { close(); }, EShortcut::GLOBAL_RETURN );
 

--- a/client/globalLobby/GlobalLobbyServerSetup.cpp
+++ b/client/globalLobby/GlobalLobbyServerSetup.cpp
@@ -35,7 +35,7 @@ GlobalLobbyServerSetup::GlobalLobbyServerSetup()
 	pos.h = 340;
 
 	filledBackground = std::make_shared<FilledTexturePlayerColored>(Rect(0, 0, pos.w, pos.h));
-	labelTitle = std::make_shared<CLabel>( pos.w / 2, 20, FONT_BIG, ETextAlignment::CENTER, Colors::YELLOW, CGI->generaltexth->translate("vcmi.lobby.room.create"));
+	labelTitle = std::make_shared<CLabel>( pos.w / 2, 20, FONT_BIG, ETextAlignment::CENTER, Colors::YELLOW, CGI->generaltexth->translate("vcmi.lobby.room.create.hover"));
 	labelPlayerLimit = std::make_shared<CLabel>( pos.w / 2, 48, FONT_MEDIUM, ETextAlignment::CENTER, Colors::YELLOW, CGI->generaltexth->translate("vcmi.lobby.room.players.limit"));
 	labelRoomType = std::make_shared<CLabel>( pos.w / 2, 108, FONT_MEDIUM, ETextAlignment::CENTER, Colors::YELLOW, CGI->generaltexth->translate("vcmi.lobby.room.type"));
 	labelGameMode = std::make_shared<CLabel>( pos.w / 2, 158, FONT_MEDIUM, ETextAlignment::CENTER, Colors::YELLOW, CGI->generaltexth->translate("vcmi.lobby.room.mode"));

--- a/client/globalLobby/GlobalLobbyWidget.cpp
+++ b/client/globalLobby/GlobalLobbyWidget.cpp
@@ -44,7 +44,7 @@ GlobalLobbyWidget::GlobalLobbyWidget(GlobalLobbyWindow * window)
 
 	REGISTER_BUILDER("lobbyItemList", &GlobalLobbyWidget::buildItemList);
 
-	const JsonNode config(JsonPath::builtin("config/widgets/lobbyWindow.json"));
+	const JsonNode config(JsonPath::builtin(GH.screenDimensions().x >= 1024 ? "config/widgets/lobbyWindowWide.json" : "config/widgets/lobbyWindow.json"));
 	build(config);
 }
 

--- a/client/widgets/Buttons.cpp
+++ b/client/widgets/Buttons.cpp
@@ -206,6 +206,11 @@ bool CButton::isHighlighted()
 	return getState() == EButtonState::HIGHLIGHTED;
 }
 
+bool CButton::isPressed()
+{
+	return getState() == EButtonState::PRESSED;
+}
+
 void CButton::setHoverable(bool on)
 {
 	hoverable = on;

--- a/client/widgets/Buttons.h
+++ b/client/widgets/Buttons.h
@@ -105,6 +105,7 @@ public:
 	/// State modifiers
 	bool isBlocked();
 	bool isHighlighted();
+	bool isPressed();
 
 	/// Constructor
 	CButton(Point position, const AnimationPath & defName, const std::pair<std::string, std::string> & help,

--- a/client/widgets/Slider.cpp
+++ b/client/widgets/Slider.cpp
@@ -21,6 +21,13 @@
 
 void CSlider::mouseDragged(const Point & cursorPosition, const Point & lastUpdateDistance)
 {
+	bool onControl = pos.isInside(cursorPosition) && !left->pos.isInside(cursorPosition) && !right->pos.isInside(cursorPosition);
+	if(!onControl && !slider->isPressed())
+		return;
+
+	if(onControl && !slider->isPressed())
+		slider->clickPressed(cursorPosition);
+
 	double newPosition = 0;
 	if(getOrientation() == Orientation::HORIZONTAL)
 	{
@@ -129,44 +136,57 @@ void CSlider::scrollTo(int to, bool callCallbacks)
 		moved(getValue());
 }
 
+double CSlider::getClickPos(const Point & cursorPosition)
+{
+	double pw = 0;
+	double rw = 0;
+	if(getOrientation() == Orientation::HORIZONTAL)
+	{
+		pw = cursorPosition.x-pos.x-25;
+		rw = pw / static_cast<double>(pos.w - 48);
+	}
+	else
+	{
+		pw = cursorPosition.y-pos.y-24;
+		rw = pw / (pos.h-48);
+	}
+
+	return rw;
+}
+
 void CSlider::clickPressed(const Point & cursorPosition)
 {
-	if(!slider->isBlocked())
-	{
-		double pw = 0;
-		double rw = 0;
-		if(getOrientation() == Orientation::HORIZONTAL)
-		{
-			pw = cursorPosition.x-pos.x-25;
-			rw = pw / static_cast<double>(pos.w - 48);
-		}
-		else
-		{
-			pw = cursorPosition.y-pos.y-24;
-			rw = pw / (pos.h-48);
-		}
-
-		// click on area covered by buttons -> ignore, will be handled by left/right buttons
-		if (!vstd::iswithin(rw, 0, 1))
-			return;
-
-		slider->clickPressed(cursorPosition);
-		scrollTo((int)(rw * positions  +  0.5));
+	bool onControl = pos.isInside(cursorPosition) && !left->pos.isInside(cursorPosition) && !right->pos.isInside(cursorPosition);
+	if(!onControl)
 		return;
-	}
+
+	if(slider->isBlocked())
+		return;
+
+	// click on area covered by buttons -> ignore, will be handled by left/right buttons
+	auto rw = getClickPos(cursorPosition);
+	if (!vstd::iswithin(rw, 0, 1))
+		return;
+
+	slider->clickPressed(cursorPosition);
+	scrollTo((int)(rw * positions + 0.5));
+}
+
+void CSlider::clickReleased(const Point & cursorPosition)
+{
+	if(slider->isBlocked())
+		return;
+
+	slider->clickReleased(cursorPosition);
 }
 
 bool CSlider::receiveEvent(const Point &position, int eventType) const
 {
 	if (eventType == LCLICK)
-	{
-		return pos.isInside(position) && !left->pos.isInside(position) && !right->pos.isInside(position);
-	}
+		return true; //capture "clickReleased" also outside of control
 
 	if(eventType != WHEEL && eventType != GESTURE)
-	{
 		return CIntObject::receiveEvent(position, eventType);
-	}
 
 	if (!scrollBounds)
 		return true;

--- a/client/widgets/Slider.h
+++ b/client/widgets/Slider.h
@@ -38,6 +38,8 @@ class CSlider : public Scrollable
 
 	void updateSliderPos();
 
+	double getClickPos(const Point & cursorPosition);
+
 public:
 	enum EStyle
 	{
@@ -71,6 +73,7 @@ public:
 	bool receiveEvent(const Point & position, int eventType) const override;
 	void keyPressed(EShortcut key) override;
 	void clickPressed(const Point & cursorPosition) override;
+	void clickReleased(const Point & cursorPosition) override;
 	void mouseDragged(const Point & cursorPosition, const Point & lastUpdateDistance) override;
 	void gesturePanning(const Point & initialPosition, const Point & currentPosition, const Point & lastUpdateDistance) override;
 	void showAll(Canvas & to) override;

--- a/config/widgets/lobbyWindow.json
+++ b/config/widgets/lobbyWindow.json
@@ -112,7 +112,8 @@
 		{
 			"name" : "headerGameChat",
 			"type": "labelTitle",
-			"position": {"x": 421, "y": 53}
+			"position": {"x": 421, "y": 53},
+			"maxWidth": 210
 		},
 		{
 			"type": "textBox",

--- a/config/widgets/lobbyWindow.json
+++ b/config/widgets/lobbyWindow.json
@@ -26,14 +26,14 @@
 	},
 	
 	
-	"width": 1024,
+	"width": 800,
 	"height": 600,
 	
 	"items":
 	[
 		{
 			"type": "backgroundTexture",
-			"rect": {"w": 1024, "h": 600}
+			"rect": {"w": 800, "h": 600}
 		},
 		
 		{
@@ -69,36 +69,36 @@
 		
 		{
 			"type": "areaFilled",
-			"rect": {"x": 270, "y": 50, "w": 150, "h": 180}
+			"rect": {"x": 258, "y": 50, "w": 150, "h": 180}
 		},
 		{
 			"name" : "headerChannelList",
 			"type": "labelTitle",
-			"position": {"x": 280, "y": 53}
+			"position": {"x": 268, "y": 53}
 		},
 		{
 			"type" : "lobbyItemList",
 			"name" : "channelList",
 			"itemType" : "channel",
-			"position" : { "x" : 272, "y" : 68 },
+			"position" : { "x" : 260, "y" : 68 },
 			"itemOffset" : { "x" : 0, "y" : 40 },
 			"visibleAmount" : 4
 		},
 		
 		{
 			"type": "areaFilled",
-			"rect": {"x": 270, "y": 250, "w": 150, "h": 340}
+			"rect": {"x": 258, "y": 250, "w": 150, "h": 340}
 		},
 		{
 			"name" : "headerMatchList",
 			"type": "labelTitle",
-			"position": {"x": 280, "y": 253}
+			"position": {"x": 268, "y": 253}
 		},
 		{
 			"type" : "lobbyItemList",
 			"name" : "matchList",
 			"itemType" : "match",
-			"position" : { "x" : 272, "y" : 268 },
+			"position" : { "x" : 260, "y" : 268 },
 			"itemOffset" : { "x" : 0, "y" : 40 },
 			"sliderPosition" : { "x" : 130, "y" : 0 },
 			"sliderSize" : { "x" : 320, "y" : 320 },
@@ -107,12 +107,12 @@
 
 		{
 			"type": "areaFilled",
-			"rect": {"x": 430, "y": 50, "w": 430, "h": 515}
+			"rect": {"x": 411, "y": 50, "w": 232, "h": 515}
 		},
 		{
 			"name" : "headerGameChat",
 			"type": "labelTitle",
-			"position": {"x": 440, "y": 53}
+			"position": {"x": 421, "y": 53}
 		},
 		{
 			"type": "textBox",
@@ -121,33 +121,33 @@
 			"alignment": "left",
 			"color": "white",
 			"blueTheme" : true,
-			"rect": {"x": 440, "y": 68, "w": 418, "h": 495}
+			"rect": {"x": 421, "y": 68, "w": 210, "h": 495}
 		},
 		
 		{
 			"type": "areaFilled",
-			"rect": {"x": 430, "y": 565, "w": 397, "h": 25}
+			"rect": {"x": 411, "y": 565, "w": 196, "h": 25}
 		},
 		{
 			"name" : "messageInput",
 			"type": "textInput",
-			"rect": {"x": 440, "y": 568, "w": 377, "h": 20}
+			"rect": {"x": 421, "y": 568, "w": 176, "h": 20}
 		},
 		
 		{
 			"type": "areaFilled",
-			"rect": {"x": 870, "y": 50, "w": 150, "h": 540}
+			"rect": {"x": 646, "y": 50, "w": 150, "h": 540}
 		},
 		{
 			"name": "headerAccountList",
 			"type": "labelTitle",
-			"position": {"x": 880, "y": 53}
+			"position": {"x": 656, "y": 53}
 		},
 		{
 			"type" : "lobbyItemList",
 			"name" : "accountList",
 			"itemType" : "account",
-			"position" : { "x" : 872, "y" : 68 },
+			"position" : { "x" : 648, "y" : 68 },
 			"itemOffset" : { "x" : 0, "y" : 40 },
 			"sliderPosition" : { "x" : 130, "y" : 0 },
 			"sliderSize" : { "x" : 520, "y" : 520 },
@@ -156,7 +156,7 @@
 
 		{
 			"type": "button",
-			"position": {"x": 870, "y": 10},
+			"position": {"x": 646, "y": 10},
 			"image": "lobbyHideWindow",
 			"help": "core.help.288",
 			"callback": "closeWindow",
@@ -175,7 +175,7 @@
 		
 		{
 			"type": "button",
-			"position": {"x": 828, "y": 565},
+			"position": {"x": 610, "y": 565},
 			"image": "lobbySendMessage",
 			"help": "core.help.288",
 			"callback": "sendMessage",
@@ -191,7 +191,7 @@
 		
 		{
 			"type": "button",
-			"position": {"x": 10, "y": 555},
+			"position": {"x": 5, "y": 556},
 			"image": "lobbyCreateRoom",
 			"help": "core.help.288",
 			"callback": "createGameRoom",

--- a/config/widgets/lobbyWindow.json
+++ b/config/widgets/lobbyWindow.json
@@ -194,7 +194,7 @@
 			"type": "button",
 			"position": {"x": 5, "y": 556},
 			"image": "lobbyCreateRoom",
-			"help": "core.help.288",
+			"help": "vcmi.lobby.room.create",
 			"callback": "createGameRoom",
 			"items":
 			[

--- a/config/widgets/lobbyWindow.json
+++ b/config/widgets/lobbyWindow.json
@@ -178,7 +178,7 @@
 			"type": "button",
 			"position": {"x": 610, "y": 565},
 			"image": "lobbySendMessage",
-			"help": "core.help.288",
+			"help": "vcmi.lobby.channel.sendMessage",
 			"callback": "sendMessage",
 			"hotkey": "globalAccept",
 			"items":
@@ -203,7 +203,7 @@
 					"font": "medium",
 					"alignment": "center",
 					"color": "yellow",
-					"text": "vcmi.lobby.room.create"
+					"text": "vcmi.lobby.room.create.hover"
 				}
 			]
 		},

--- a/config/widgets/lobbyWindowWide.json
+++ b/config/widgets/lobbyWindowWide.json
@@ -1,0 +1,212 @@
+{
+	"customTypes" : {
+		"labelTitleMain" : {
+			"type": "label",
+			"font": "big",
+			"alignment": "left",
+			"color": "yellow"
+		},
+		"labelTitle" : {
+			"type": "label",
+			"font": "small",
+			"alignment": "left",
+			"color": "yellow"
+		},
+		"backgroundTexture" : {
+			"type": "texture",
+			"font": "tiny",
+			"color" : "blue",
+			"image": "DIBOXBCK"
+		},
+		"areaFilled":{
+			"type": "transparentFilledRectangle",
+			"color": [0, 0, 0, 75],
+			"colorLine": [64, 80, 128, 255]
+		}
+	},
+	
+	
+	"width": 1024,
+	"height": 600,
+	
+	"items":
+	[
+		{
+			"type": "backgroundTexture",
+			"rect": {"w": 1024, "h": 600}
+		},
+		
+		{
+			"type": "areaFilled",
+			"rect": {"x": 5, "y": 5, "w": 250, "h": 40}
+		},
+		{
+			"name" : "accountNameLabel",
+			"type": "labelTitleMain",
+			"position": {"x": 15, "y": 10},
+			"maxWidth": 230
+		},
+
+		{
+			"type": "areaFilled",
+			"rect": {"x": 5, "y": 50, "w": 250, "h": 500}
+		},
+		{
+			"name" : "headerRoomList",
+			"type": "labelTitle",
+			"position": {"x": 15, "y": 53}
+		},
+		{
+			"type" : "lobbyItemList",
+			"name" : "roomList",
+			"itemType" : "room",
+			"position" : { "x" : 7, "y" : 68 },
+			"itemOffset" : { "x" : 0, "y" : 40 },
+			"sliderPosition" : { "x" : 230, "y" : 0 },
+			"sliderSize" : { "x" : 480, "y" : 480 },
+			"visibleAmount" : 12
+		},
+		
+		{
+			"type": "areaFilled",
+			"rect": {"x": 270, "y": 50, "w": 150, "h": 180}
+		},
+		{
+			"name" : "headerChannelList",
+			"type": "labelTitle",
+			"position": {"x": 280, "y": 53}
+		},
+		{
+			"type" : "lobbyItemList",
+			"name" : "channelList",
+			"itemType" : "channel",
+			"position" : { "x" : 272, "y" : 68 },
+			"itemOffset" : { "x" : 0, "y" : 40 },
+			"visibleAmount" : 4
+		},
+		
+		{
+			"type": "areaFilled",
+			"rect": {"x": 270, "y": 250, "w": 150, "h": 340}
+		},
+		{
+			"name" : "headerMatchList",
+			"type": "labelTitle",
+			"position": {"x": 280, "y": 253}
+		},
+		{
+			"type" : "lobbyItemList",
+			"name" : "matchList",
+			"itemType" : "match",
+			"position" : { "x" : 272, "y" : 268 },
+			"itemOffset" : { "x" : 0, "y" : 40 },
+			"sliderPosition" : { "x" : 130, "y" : 0 },
+			"sliderSize" : { "x" : 320, "y" : 320 },
+			"visibleAmount" : 8
+		},
+
+		{
+			"type": "areaFilled",
+			"rect": {"x": 430, "y": 50, "w": 430, "h": 515}
+		},
+		{
+			"name" : "headerGameChat",
+			"type": "labelTitle",
+			"position": {"x": 440, "y": 53},
+			"maxWidth": 418
+		},
+		{
+			"type": "textBox",
+			"name": "gameChat",
+			"font": "small",
+			"alignment": "left",
+			"color": "white",
+			"blueTheme" : true,
+			"rect": {"x": 440, "y": 68, "w": 418, "h": 495}
+		},
+		
+		{
+			"type": "areaFilled",
+			"rect": {"x": 430, "y": 565, "w": 397, "h": 25}
+		},
+		{
+			"name" : "messageInput",
+			"type": "textInput",
+			"rect": {"x": 440, "y": 568, "w": 377, "h": 20}
+		},
+		
+		{
+			"type": "areaFilled",
+			"rect": {"x": 870, "y": 50, "w": 150, "h": 540}
+		},
+		{
+			"name": "headerAccountList",
+			"type": "labelTitle",
+			"position": {"x": 880, "y": 53}
+		},
+		{
+			"type" : "lobbyItemList",
+			"name" : "accountList",
+			"itemType" : "account",
+			"position" : { "x" : 872, "y" : 68 },
+			"itemOffset" : { "x" : 0, "y" : 40 },
+			"sliderPosition" : { "x" : 130, "y" : 0 },
+			"sliderSize" : { "x" : 520, "y" : 520 },
+			"visibleAmount" : 13
+		},
+
+		{
+			"type": "button",
+			"position": {"x": 870, "y": 10},
+			"image": "lobbyHideWindow",
+			"help": "core.help.288",
+			"callback": "closeWindow",
+			"hotkey": "globalCancel",
+			"items":
+			[
+				{
+					"type": "label",
+					"font": "medium",
+					"alignment": "center",
+					"color": "yellow",
+					"text": "core.help.561.hover" // Back
+				}
+			]
+		},
+		
+		{
+			"type": "button",
+			"position": {"x": 827, "y": 565},
+			"image": "lobbySendMessage",
+			"help": "vcmi.lobby.channel.sendMessage",
+			"callback": "sendMessage",
+			"hotkey": "globalAccept",
+			"items":
+			[
+				{
+					"type": "picture",
+					"image": "lobby/iconSend"
+				}
+			]
+		},
+		
+		{
+			"type": "button",
+			"position": {"x": 5, "y": 555},
+			"image": "lobbyCreateRoom",
+			"help": "vcmi.lobby.room.create",
+			"callback": "createGameRoom",
+			"items":
+			[
+				{
+					"type": "label",
+					"font": "medium",
+					"alignment": "center",
+					"color": "yellow",
+					"text": "vcmi.lobby.room.create.hover"
+				}
+			]
+		},
+
+	]
+}


### PR DESCRIPTION
Change aspect ratio of lobby to 4:3 to avoid broken window on 4:3 game.
After change it's in line with other big windows (800x600) in H3/VCMI.
If necessary it could extended with mod to 16:9...

Other fixes:
- fix graphical glitch when scrolling user (invite) list
- fix long text for (dynamic) label
- fix incorrect help for lobby create button
- fix incorrect help for lobby send message button
- fix stuck (pressed) slider when clicking on empty slider area

![grafik](https://github.com/user-attachments/assets/e41d947f-fe07-4736-991f-ad4a0dec809a)