### PR TITLE
[1.6.7] Better fix for lobby room crash

### DIFF
--- a/client/CServerHandler.cpp
+++ b/client/CServerHandler.cpp
@@ -194,7 +194,6 @@ void CServerHandler::startLocalServerAndConnect(bool connectToLobby)
 
 void CServerHandler::connectToServer(const std::string & addr, const ui16 port)
 {
-	logNetwork->info("Establishing connection to %s:%d...", addr, port);
 	setState(EClientState::CONNECTING);
 	serverHostname = addr;
 	serverPort = port;

--- a/client/ServerRunner.cpp
+++ b/client/ServerRunner.cpp
@@ -40,6 +40,7 @@ void ServerThreadRunner::start(bool listenForConnections, bool connectToLobby, s
 	// cfgport may be 0 -- the real port is returned after calling prepare()
 	uint16_t port = settings["server"]["localPort"].Integer();
 	server = std::make_unique<CVCMIServer>(port, true);
+	lobbyMode = connectToLobby;
 
 	if (startingInfo)
 	{
@@ -77,7 +78,18 @@ int ServerThreadRunner::exitCode()
 
 void ServerThreadRunner::connect(INetworkHandler & network, INetworkClientListener & listener)
 {
-	network.createInternalConnection(listener, server->getNetworkServer());
+	if (lobbyMode)
+	{
+		std::string host = settings["server"]["localHostname"].String();
+		uint16_t port = settings["server"]["localPort"].Integer();
+		logNetwork->info("Establishing connection to %s:%d...", host, port);
+
+		network.connectToRemote(listener, host, port);
+	}
+	else
+	{
+		network.createInternalConnection(listener, server->getNetworkServer());
+	}
 }
 
 #ifdef ENABLE_SERVER_PROCESS
@@ -122,6 +134,7 @@ void ServerProcessRunner::connect(INetworkHandler & network, INetworkClientListe
 {
 	std::string host = settings["server"]["localHostname"].String();
 	uint16_t port = settings["server"]["localPort"].Integer();
+	logNetwork->info("Establishing connection to %s:%d...", host, port);
 
 	network.connectToRemote(listener, host, port);
 }

--- a/client/ServerRunner.h
+++ b/client/ServerRunner.h
@@ -38,6 +38,7 @@ class ServerThreadRunner final : public IServerRunner, boost::noncopyable
 	std::unique_ptr<CVCMIServer> server;
 	boost::thread threadRunLocalServer;
 	uint16_t serverPort = 0;
+	bool lobbyMode = false;
 
 public:
 	void start(bool listenForConnections, bool connectToLobby, std::shared_ptr<StartInfo> startingInfo) override;

--- a/server/CVCMIServer.cpp
+++ b/server/CVCMIServer.cpp
@@ -80,25 +80,27 @@ CVCMIServer::CVCMIServer(uint16_t port, bool runByClient)
 
 CVCMIServer::~CVCMIServer() = default;
 
-uint16_t CVCMIServer::prepare(bool connectToLobby, bool listenForConnections)
-{
-	if(connectToLobby)
+uint16_t CVCMIServer::prepare(bool connectToLobby, bool listenForConnections) {
+	if(connectToLobby) {
 		lobbyProcessor = std::make_unique<GlobalLobbyProcessor>(*this);
-
-	return startAcceptingIncomingConnections(listenForConnections);
+		return 0;
+	} else {
+		return startAcceptingIncomingConnections(listenForConnections);
+	}
 }
 
 uint16_t CVCMIServer::startAcceptingIncomingConnections(bool listenForConnections)
 {
 	networkServer = networkHandler->createServerTCP(*this);
 
+	port
+		? logNetwork->info("Port %d will be used", port)
+		: logNetwork->info("Randomly assigned port will be used");
+
+	// config port may be 0 => srvport will contain the OS-assigned port value
+
 	if (listenForConnections)
 	{
-		// config port may be 0 => srvport will contain the OS-assigned port value
-		port
-			? logNetwork->info("Port %d will be used", port)
-			: logNetwork->info("Randomly assigned port will be used");
-
 		auto srvport = networkServer->start(port);
 		logNetwork->info("Listening for connections at port %d", srvport);
 		return srvport;

--- a/server/GlobalLobbyProcessor.cpp
+++ b/server/GlobalLobbyProcessor.cpp
@@ -99,6 +99,7 @@ void GlobalLobbyProcessor::receiveServerLoginSuccess(const JsonNode & json)
 {
 	// no-op, wait just for any new commands from lobby
 	logGlobal->info("Lobby: Successfully connected to lobby server");
+	owner.startAcceptingIncomingConnections(true);
 }
 
 void GlobalLobbyProcessor::receiveAccountJoinsRoom(const JsonNode & json)


### PR DESCRIPTION
- Reverts changes from #5465

Always use TCP connection when connecting to self-hosted lobby room.
Effectively reverts 1.6.6 change for lobby connections. Single-player connections still use intra-process pseudo connection

Main problem is various side effects caused by changing order of operations. For example, client may inform lobby about joining the room before server finishes startup, which was not possible before, leading to (much rarer but existing) crashes, or lobby room not showing up correctly in lobby.