### PR TITLE
[1.6.7] Fixes for reported issues

### DIFF
--- a/client/lobby/SelectionTab.cpp
+++ b/client/lobby/SelectionTab.cpp
@@ -961,31 +961,38 @@ void SelectionTab::parseCampaigns(const std::unordered_set<ResourcePath> & files
 	allItems.reserve(files.size());
 	for(auto & file : files)
 	{
-		auto info = std::make_shared<ElementInfo>();
-		info->fileURI = file.getOriginalName();
-		info->campaignInit();
-		info->name = info->getNameForList();
-				
-		if(info->campaign)
+		try
 		{
-			// skip campaigns organized in sets
-			std::string foundInSet = "";
-			for (auto const & set : campaignSets.Struct())
-				for (auto const & item : set.second["items"].Vector())
-					if(file.getName() == ResourcePath(item["file"].String()).getName())
-						foundInSet = set.first;
-			
-			// set has to be used in main menu
-			bool setInMainmenu = false;
-			if(!foundInSet.empty())
-				for (auto const & item : mainmenu["window"]["items"].Vector())
-					if(item["name"].String() == "campaign")
-						for (auto const & button : item["buttons"].Vector())
-							if(boost::algorithm::ends_with(boost::algorithm::to_lower_copy(button["command"].String()), boost::algorithm::to_lower_copy(foundInSet)))
-								setInMainmenu = true;
+			auto info = std::make_shared<ElementInfo>();
+			info->fileURI = file.getOriginalName();
+			info->campaignInit();
+			info->name = info->getNameForList();
 
-			if(!setInMainmenu)
-				allItems.push_back(info);
+			if(info->campaign)
+			{
+				// skip campaigns organized in sets
+				std::string foundInSet = "";
+				for (auto const & set : campaignSets.Struct())
+					for (auto const & item : set.second["items"].Vector())
+						if(file.getName() == ResourcePath(item["file"].String()).getName())
+							foundInSet = set.first;
+
+				// set has to be used in main menu
+				bool setInMainmenu = false;
+				if(!foundInSet.empty())
+					for (auto const & item : mainmenu["window"]["items"].Vector())
+						if(item["name"].String() == "campaign")
+							for (auto const & button : item["buttons"].Vector())
+								if(boost::algorithm::ends_with(boost::algorithm::to_lower_copy(button["command"].String()), boost::algorithm::to_lower_copy(foundInSet)))
+									setInMainmenu = true;
+
+				if(!setInMainmenu)
+					allItems.push_back(info);
+			}
+		}
+		catch(const std::exception & e)
+		{
+			logGlobal->error("Error: Failed to process campaign %s: %s", file.getName(), e.what());
 		}
 	}
 }

--- a/client/widgets/Images.cpp
+++ b/client/widgets/Images.cpp
@@ -442,7 +442,8 @@ void CShowableAnim::blitImage(size_t frame, size_t group, Canvas & to)
 	if(img)
 	{
 		img->setAlpha(alpha);
-		img->setOverlayColor(Colors::TRANSPARENCY);
+		if (getModeForFlags(flags) == EImageBlitMode::WITH_SHADOW_AND_SELECTION)
+			img->setOverlayColor(Colors::TRANSPARENCY);
 		to.draw(img, pos.topLeft(), src);
 	}
 }

--- a/lib/filesystem/CZipLoader.cpp
+++ b/lib/filesystem/CZipLoader.cpp
@@ -226,7 +226,7 @@ bool ZipArchive::extract(const boost::filesystem::path & where, const std::strin
 	if (!destFile.good())
 	{
 #ifdef VCMI_WINDOWS
-		if (fullName.size() < MAX_PATH)
+		if (fullName.size() < 260)
 			logGlobal->error("Failed to open file '%s'", fullName.c_str());
 		else
 			logGlobal->error("Failed to open file with long path '%s' (%d characters)", fullName.c_str(), fullName.size());

--- a/lib/filesystem/CZipLoader.cpp
+++ b/lib/filesystem/CZipLoader.cpp
@@ -224,7 +224,18 @@ bool ZipArchive::extract(const boost::filesystem::path & where, const std::strin
 
 	std::fstream destFile(fullName.c_str(), std::ios::out | std::ios::binary);
 	if (!destFile.good())
+	{
+#ifdef VCMI_WINDOWS
+		if (fullName.size() < MAX_PATH)
+			logGlobal->error("Failed to open file '%s'", fullName.c_str());
+		else
+			logGlobal->error("Failed to open file with long path '%s' (%d characters)", fullName.c_str(), fullName.size());
+#else
+		logGlobal->error("Failed to open file '%s'", fullName.c_str());
+#endif
+
 		return false;
+	}
 
 	if (!extractCurrent(archive, destFile))
 		return false;

--- a/lib/mapObjectConstructors/CObjectClassesHandler.cpp
+++ b/lib/mapObjectConstructors/CObjectClassesHandler.cpp
@@ -177,7 +177,12 @@ void CObjectClassesHandler::loadSubObject(const std::string & scope, const std::
 
 	registerObject(scope, baseObject->getJsonKey(), subObject->getSubTypeName(), subObject->subtype);
 	for(const auto & compatID : entry["compatibilityIdentifiers"].Vector())
-		registerObject(scope, baseObject->getJsonKey(), compatID.String(), subObject->subtype);
+	{
+		if (identifier != compatID.String())
+			registerObject(scope, baseObject->getJsonKey(), compatID.String(), subObject->subtype);
+		else
+			logMod->warn("Mod '%s' map object '%s': compatibility identifier has same name as object itself!");
+	}
 }
 
 void CObjectClassesHandler::loadSubObject(const std::string & scope, const std::string & identifier, const JsonNode & entry, ObjectClass * baseObject, size_t index)
@@ -192,7 +197,12 @@ void CObjectClassesHandler::loadSubObject(const std::string & scope, const std::
 
 	registerObject(scope, baseObject->getJsonKey(), subObject->getSubTypeName(), subObject->subtype);
 	for(const auto & compatID : entry["compatibilityIdentifiers"].Vector())
-		registerObject(scope, baseObject->getJsonKey(), compatID.String(), subObject->subtype);
+	{
+		if (identifier != compatID.String())
+			registerObject(scope, baseObject->getJsonKey(), compatID.String(), subObject->subtype);
+		else
+			logMod->warn("Mod '%s' map object '%s': compatibility identifier has same name as object itself!");
+	}
 }
 
 TObjectTypeHandler CObjectClassesHandler::loadSubObjectFromJson(const std::string & scope, const std::string & identifier, const JsonNode & entry, ObjectClass * baseObject, size_t index)

--- a/lib/modding/ModManager.cpp
+++ b/lib/modding/ModManager.cpp
@@ -763,6 +763,9 @@ void ModDependenciesResolver::tryAddMods(TModList modsToResolve, const ModsStora
 		if (mod.isTranslation() && CGeneralTextHandler::getPreferredLanguage() != mod.getBaseLanguage())
 			return false;
 
+		if(!mod.isCompatible())
+			return false;
+
 		if(mod.getDependencies().size() > resolvedModIDs.size())
 			return false;
 


### PR DESCRIPTION
- Avoid crash on having unsupported campaigns in map list
- Fix corrupted pixels on town building animations in mods
  - Fixes #5463
- Add logging for failure to extract file from .zip, with check for Windows 260 path length limit
- Fix crash if map object has the same name as one of names provided in compatiblity identifiers field and instead log it as warning.
- Add missing check for mod compatibility