### PR TITLE
[1.6.7] Invalidate pathfinder cache on dismissing a hero

### DIFF
--- a/AI/Nullkiller/AIGateway.cpp
+++ b/AI/Nullkiller/AIGateway.cpp
@@ -1608,6 +1608,7 @@ void AIGateway::requestActionASAP(std::function<void()> whatToDo)
 void AIGateway::lostHero(HeroPtr h)
 {
 	logAi->debug("I lost my hero %s. It's best to forget and move on.", h.name());
+	nullkiller->invalidatePathfinderData();
 }
 
 void AIGateway::answerQuery(QueryID queryID, int selection)


### PR DESCRIPTION
- Fixes #5479