### PR TITLE
Reduce number of global variables

### DIFF
--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -398,6 +398,7 @@ set(vcmiclientcommon_HEADERS
 	CMT.h
 	CPlayerInterface.h
 	GameEngine.h
+	GameEngineUser.h
 	GameInstance.h
 	PlayerLocalState.h
 	CServerHandler.h

--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -1801,7 +1801,7 @@ void CPlayerInterface::proposeLoadingGame()
 		[]()
 		{
 			GAME->server().endGameplay();
-			CMM->menu->switchToTab("load");
+			GAME->mainmenu()->menu->switchToTab("load");
 		},
 		nullptr
 	);

--- a/client/CPlayerInterface.h
+++ b/client/CPlayerInterface.h
@@ -57,7 +57,7 @@ namespace boost
 }
 
 /// Central class for managing user interface logic
-class CPlayerInterface : public CGameInterface, public IUpdateable
+class CPlayerInterface : public CGameInterface
 {
 	bool ignoreEvents;
 	int autosaveCount;
@@ -90,7 +90,6 @@ public: // TODO: make private
 
 protected: // Call-ins from server, should not be called directly, but only via GameInterface
 
-	void update() override;
 	void initGameInterface(std::shared_ptr<Environment> ENV, std::shared_ptr<CCallback> CB) override;
 
 	void garrisonsChanged(ObjectInstanceID id1, ObjectInstanceID id2) override;
@@ -173,6 +172,7 @@ protected: // Call-ins from server, should not be called directly, but only via 
 public: // public interface for use by client via GAME->interface() access
 
 	// part of GameInterface that is also used by client code
+	void update();
 	void showPuzzleMap() override;
 	void viewWorldMap() override;
 	void showQuestLog() override;

--- a/client/CServerHandler.cpp
+++ b/client/CServerHandler.cpp
@@ -666,15 +666,15 @@ void CServerHandler::endGameplay()
 
 	if(CMM)
 	{
-		ENGINE->curInt = CMM.get();
 		CMM->enable();
 		CMM->playMusic();
+		CMM->makeActiveInterface();
 	}
 	else
 	{
 		auto mainMenu = CMainMenu::create();
-		ENGINE->curInt = mainMenu.get();
 		mainMenu->playMusic();
+		mainMenu->makeActiveInterface();
 	}
 }
 

--- a/client/CServerHandler.cpp
+++ b/client/CServerHandler.cpp
@@ -15,6 +15,7 @@
 #include "GameChatHandler.h"
 #include "CPlayerInterface.h"
 #include "GameEngine.h"
+#include "GameInstance.h"
 #include "gui/WindowHandler.h"
 
 #include "globalLobby/GlobalLobbyClient.h"
@@ -610,8 +611,8 @@ void CServerHandler::startMapAfterConnection(std::shared_ptr<CMapInfo> to)
 
 void CServerHandler::startGameplay(VCMI_LIB_WRAP_NAMESPACE(CGameState) * gameState)
 {
-	if(CMM)
-		CMM->disable();
+	if(GAME->mainmenu())
+		GAME->mainmenu()->disable();
 
 	switch(si->mode)
 	{
@@ -649,7 +650,7 @@ void CServerHandler::showHighScoresAndEndGameplay(PlayerColor player, bool victo
 		scenarioHighScores.isCampaign = false;
 
 		endGameplay();
-		CMM->menu->switchToTab("main");
+		GAME->mainmenu()->menu->switchToTab("main");
 		ENGINE->windows().createAndPushWindow<CHighScoreInputScreen>(victory, scenarioHighScores, statistic);
 	}
 }
@@ -664,17 +665,11 @@ void CServerHandler::endGameplay()
 	client->endGame();
 	client.reset();
 
-	if(CMM)
+	if (GAME->mainmenu())
 	{
-		CMM->enable();
-		CMM->playMusic();
-		CMM->makeActiveInterface();
-	}
-	else
-	{
-		auto mainMenu = CMainMenu::create();
-		mainMenu->playMusic();
-		mainMenu->makeActiveInterface();
+		GAME->mainmenu()->enable();
+		GAME->mainmenu()->playMusic();
+		GAME->mainmenu()->makeActiveInterface();
 	}
 }
 
@@ -710,14 +705,13 @@ void CServerHandler::startCampaignScenario(HighScoreParameter param, std::shared
 			entry->Bool() = true;
 		}
 
-		ENGINE->windows().pushWindow(CMM);
-		ENGINE->windows().pushWindow(CMM->menu);
+		GAME->mainmenu()->makeActiveInterface();
 
 		if(!ourCampaign->isCampaignFinished())
-			CMM->openCampaignLobby(ourCampaign);
+			GAME->mainmenu()->openCampaignLobby(ourCampaign);
 		else
 		{
-			CMM->openCampaignScreen(ourCampaign->campaignSet);
+			GAME->mainmenu()->openCampaignScreen(ourCampaign->campaignSet);
 			if(!ourCampaign->getOutroVideo().empty() && ENGINE->video().open(ourCampaign->getOutroVideo(), 1))
 			{
 				ENGINE->music().stopMusic();
@@ -890,7 +884,7 @@ void CServerHandler::onDisconnected(const std::shared_ptr<INetworkConnection> & 
 	if(client)
 	{
 		endGameplay();
-		CMM->menu->switchToTab("main");
+		GAME->mainmenu()->menu->switchToTab("main");
 		showServerError(LIBRARY->generaltexth->translate("vcmi.server.errors.disconnected"));
 	}
 	else

--- a/client/Client.cpp
+++ b/client/Client.cpp
@@ -191,7 +191,6 @@ void CClient::endGame()
 	for(auto & i : playerint)
 		i.second->finish();
 
-	ENGINE->curInt = nullptr;
 	{
 		logNetwork->info("Ending current game!");
 		removeGUI();
@@ -518,7 +517,6 @@ void CClient::reinitScripting()
 void CClient::removeGUI() const
 {
 	// CClient::endGame
-	ENGINE->curInt = nullptr;
 	ENGINE->windows().clear();
 	adventureInt.reset();
 	logGlobal->info("Removed GUI.");

--- a/client/GameEngine.cpp
+++ b/client/GameEngine.cpp
@@ -33,7 +33,7 @@
 #include "renderSDL/ScreenHandler.h"
 #include "renderSDL/RenderHandler.h"
 #include "CMT.h"
-#include "GameInstance.h"
+#include "GameEngineUser.h"
 #include "battle/BattleInterface.h"
 
 #include "../lib/CThreadHelper.h"
@@ -91,7 +91,7 @@ void GameEngine::handleEvents()
 	events().dispatchTimer(framerate().getElapsedMilliseconds());
 
 	//player interface may want special event handling
-	if(GAME->interface() && GAME->interface()->capturedAllEvents())
+	if(engineUser->capturedAllEvents())
 		return;
 
 	input().processEvents();
@@ -109,8 +109,10 @@ void GameEngine::renderFrame()
 	{
 		std::scoped_lock interfaceLock(ENGINE->interfaceMutex);
 
-		if (nullptr != curInt)
-			curInt->update();
+		engineUser->onUpdate();
+
+		handleEvents();
+		windows().simpleRedraw();
 
 		if (settings["video"]["showfps"].Bool())
 			drawFPSCounter();
@@ -127,7 +129,6 @@ void GameEngine::renderFrame()
 
 GameEngine::GameEngine()
 	: captureChildren(false)
-	, curInt(nullptr)
 	, fakeStatusBar(std::make_shared<EmptyStatusBar>())
 {
 }
@@ -250,4 +251,9 @@ void GameEngine::onScreenResize(bool resolutionChanged)
 
 	windows().onScreenResize();
 	ENGINE->cursor().onScreenResize();
+}
+
+void GameEngine::setEngineUser(IGameEngineUser * user)
+{
+	engineUser = user;
 }

--- a/client/GameEngine.h
+++ b/client/GameEngine.h
@@ -19,8 +19,7 @@ class ShortcutHandler;
 class FramerateManager;
 class IStatusBar;
 class CIntObject;
-class IUpdateable;
-class IShowActivatable;
+class IGameEngineUser;
 class IRenderHandler;
 class IScreenHandler;
 class WindowHandler;
@@ -54,6 +53,8 @@ private:
 	std::unique_ptr<CursorHandler> cursorHandlerInstance;
 	std::unique_ptr<IVideoPlayer> videoPlayerInstance;
 
+	IGameEngineUser *engineUser = nullptr;
+
 public:
 	std::mutex interfaceMutex;
 
@@ -65,6 +66,7 @@ public:
 	EventDispatcher & events();
 	InputHandler & input();
 
+	IGameEngineUser & user() { return *engineUser; }
 	ISoundPlayer & sound() { return *soundPlayerInstance; }
 	IMusicPlayer & music() { return *musicPlayerInstance; }
 	CursorHandler & cursor() { return *cursorHandlerInstance; }
@@ -96,8 +98,7 @@ public:
 
 	/// Set currently active status bar
 	void setStatusbar(std::shared_ptr<IStatusBar>);
-
-	IUpdateable *curInt;
+	void setEngineUser(IGameEngineUser * user);
 
 	bool captureChildren; //all newly created objects will get their parents from stack and will be added to parents children list
 	std::list<CIntObject *> createdObj; //stack of objs being created

--- a/client/GameEngineUser.h
+++ b/client/GameEngineUser.h
@@ -1,0 +1,25 @@
+/*
+ * GameEngineUser.h, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
+#pragma once
+
+class IGameEngineUser
+{
+public:
+	~IGameEngineUser() = default;
+
+	/// Called when user presses hotkey that activates global lobby
+	virtual void onGlobalLobbyInterfaceActivated() = 0;
+
+	/// Called on every game tick for game to update its state
+	virtual void onUpdate() = 0;
+
+	/// Returns true if all input events should be captured and ignored
+	virtual bool capturedAllEvents() = 0;
+};

--- a/client/GameInstance.cpp
+++ b/client/GameInstance.cpp
@@ -14,6 +14,9 @@
 #include "CServerHandler.h"
 #include "mapView/mapHandler.h"
 #include "globalLobby/GlobalLobbyClient.h"
+#include "mainmenu/CMainMenu.h"
+
+#include "../lib/CConfigHandler.h"
 
 std::unique_ptr<GameInstance> GAME = nullptr;
 
@@ -41,6 +44,17 @@ CMapHandler & GameInstance::map()
 	return *mapInstance;
 }
 
+std::shared_ptr<CMainMenu> GameInstance::mainmenu()
+{
+	if(settings["session"]["headless"].Bool())
+		return nullptr;
+
+	if (!mainMenuInstance)
+		mainMenuInstance = std::shared_ptr<CMainMenu>(new CMainMenu());
+
+	return mainMenuInstance;
+}
+
 CPlayerInterface * GameInstance::interface()
 {
 	return interfaceInstance;
@@ -58,7 +72,7 @@ void GameInstance::setMapInstance(std::unique_ptr<CMapHandler> ptr)
 
 void GameInstance::setInterfaceInstance(CPlayerInterface * ptr)
 {
-	interfaceInstance = std::move(ptr);
+	interfaceInstance = ptr;
 }
 
 void GameInstance::onGlobalLobbyInterfaceActivated()

--- a/client/GameInstance.cpp
+++ b/client/GameInstance.cpp
@@ -10,8 +10,10 @@
 #include "StdInc.h"
 #include "GameInstance.h"
 
+#include "CPlayerInterface.h"
 #include "CServerHandler.h"
 #include "mapView/mapHandler.h"
+#include "globalLobby/GlobalLobbyClient.h"
 
 std::unique_ptr<GameInstance> GAME = nullptr;
 
@@ -57,4 +59,23 @@ void GameInstance::setMapInstance(std::unique_ptr<CMapHandler> ptr)
 void GameInstance::setInterfaceInstance(CPlayerInterface * ptr)
 {
 	interfaceInstance = std::move(ptr);
+}
+
+void GameInstance::onGlobalLobbyInterfaceActivated()
+{
+	server().getGlobalLobby().activateInterface();
+}
+
+void GameInstance::onUpdate()
+{
+	if (interfaceInstance)
+		interfaceInstance->update();
+}
+
+bool GameInstance::capturedAllEvents()
+{
+	if (interfaceInstance)
+		return interfaceInstance->capturedAllEvents();
+	else
+		return false;
 }

--- a/client/GameInstance.cpp
+++ b/client/GameInstance.cpp
@@ -50,7 +50,7 @@ std::shared_ptr<CMainMenu> GameInstance::mainmenu()
 		return nullptr;
 
 	if (!mainMenuInstance)
-		mainMenuInstance = std::shared_ptr<CMainMenu>(new CMainMenu());
+		mainMenuInstance = std::make_shared<CMainMenu>();
 
 	return mainMenuInstance;
 }

--- a/client/GameInstance.h
+++ b/client/GameInstance.h
@@ -15,6 +15,7 @@ class CServerHandler;
 class GlobalLobbyClient;
 class CPlayerInterface;
 class CMapHandler;
+class CMainMenu;
 
 VCMI_LIB_NAMESPACE_BEGIN
 class INetworkHandler;
@@ -24,6 +25,7 @@ class GameInstance final : boost::noncopyable, public IGameEngineUser
 {
 	std::unique_ptr<CServerHandler> serverInstance;
 	std::unique_ptr<CMapHandler> mapInstance;
+	std::shared_ptr<CMainMenu> mainMenuInstance;
 	CPlayerInterface * interfaceInstance;
 
 public:
@@ -33,6 +35,7 @@ public:
 	CServerHandler & server();
 	CMapHandler & map();
 
+	std::shared_ptr<CMainMenu> mainmenu();
 	CPlayerInterface * interface();
 
 	void setServerInstance(std::unique_ptr<CServerHandler> ptr);

--- a/client/GameInstance.h
+++ b/client/GameInstance.h
@@ -9,6 +9,8 @@
  */
 #pragma once
 
+#include "GameEngineUser.h"
+
 class CServerHandler;
 class GlobalLobbyClient;
 class CPlayerInterface;
@@ -18,7 +20,7 @@ VCMI_LIB_NAMESPACE_BEGIN
 class INetworkHandler;
 VCMI_LIB_NAMESPACE_END
 
-class GameInstance : boost::noncopyable
+class GameInstance final : boost::noncopyable, public IGameEngineUser
 {
 	std::unique_ptr<CServerHandler> serverInstance;
 	std::unique_ptr<CMapHandler> mapInstance;
@@ -36,6 +38,10 @@ public:
 	void setServerInstance(std::unique_ptr<CServerHandler> ptr);
 	void setMapInstance(std::unique_ptr<CMapHandler> ptr);
 	void setInterfaceInstance(CPlayerInterface * ptr);
+
+	void onGlobalLobbyInterfaceActivated() final;
+	void onUpdate() final;
+	bool capturedAllEvents() final;
 };
 
 extern std::unique_ptr<GameInstance> GAME;

--- a/client/adventureMap/AdventureMapShortcuts.cpp
+++ b/client/adventureMap/AdventureMapShortcuts.cpp
@@ -331,7 +331,7 @@ void AdventureMapShortcuts::toMainMenu()
 		[]()
 		{
 			GAME->server().endGameplay();
-			CMM->menu->switchToTab("main");
+			GAME->mainmenu()->menu->switchToTab("main");
 		},
 		0
 		);
@@ -344,7 +344,7 @@ void AdventureMapShortcuts::newGame()
 		[]()
 		{
 			GAME->server().endGameplay();
-			CMM->menu->switchToTab("new");
+			GAME->mainmenu()->menu->switchToTab("new");
 		},
 		nullptr
 		);

--- a/client/eventsSDL/InputSourceKeyboard.cpp
+++ b/client/eventsSDL/InputSourceKeyboard.cpp
@@ -12,14 +12,11 @@
 #include "InputSourceKeyboard.h"
 
 #include "../../lib/CConfigHandler.h"
-#include "../CPlayerInterface.h"
 #include "../GameEngine.h"
-#include "../GameInstance.h"
+#include "../GameEngineUser.h"
 #include "../gui/EventDispatcher.h"
 #include "../gui/Shortcut.h"
 #include "../gui/ShortcutHandler.h"
-#include "../CServerHandler.h"
-#include "../globalLobby/GlobalLobbyClient.h"
 
 #include <SDL_clipboard.h>
 #include <SDL_events.h>
@@ -92,7 +89,7 @@ void InputSourceKeyboard::handleEventKeyDown(const SDL_KeyboardEvent & key)
 	auto shortcutsVector = ENGINE->shortcuts().translateKeycode(keyName);
 
 	if (vstd::contains(shortcutsVector, EShortcut::MAIN_MENU_LOBBY))
-		GAME->server().getGlobalLobby().activateInterface();
+		ENGINE->user().onGlobalLobbyInterfaceActivated();
 
 	if (vstd::contains(shortcutsVector, EShortcut::GLOBAL_FULLSCREEN))
 	{

--- a/client/eventsSDL/InputSourceTouch.cpp
+++ b/client/eventsSDL/InputSourceTouch.cpp
@@ -16,13 +16,11 @@
 #include "../../lib/CConfigHandler.h"
 #include "../gui/CursorHandler.h"
 #include "../GameEngine.h"
-#include "../GameInstance.h"
+#include "../GameEngineUser.h"
 #include "../gui/EventDispatcher.h"
 #include "../gui/MouseButton.h"
 #include "../gui/WindowHandler.h"
 #include "../render/IScreenHandler.h"
-#include "../CServerHandler.h"
-#include "../globalLobby/GlobalLobbyClient.h"
 
 #if defined(VCMI_ANDROID)
 #include "../../lib/CAndroidVMHelper.h"
@@ -170,7 +168,7 @@ void InputSourceTouch::handleEventFingerDown(const SDL_TouchFingerEvent & tfinge
 		}
 		case TouchState::TAP_DOWN_DOUBLE:
 		{
-			GAME->server().getGlobalLobby().activateInterface();
+			ENGINE->user().onGlobalLobbyInterfaceActivated();
 			break;
 		}
 		case TouchState::TAP_DOWN_LONG_AWAIT:

--- a/client/gui/CIntObject.h
+++ b/client/gui/CIntObject.h
@@ -23,13 +23,6 @@ VCMI_LIB_NAMESPACE_BEGIN
 class CArmedInstance;
 VCMI_LIB_NAMESPACE_END
 
-class IUpdateable
-{
-public:
-	virtual void update()=0;
-	virtual ~IUpdateable() = default;
-};
-
 class IShowActivatable
 {
 public:

--- a/client/lobby/CBonusSelection.cpp
+++ b/client/lobby/CBonusSelection.cpp
@@ -398,7 +398,7 @@ void CBonusSelection::goBack()
 	if(GAME->server().getState() != EClientState::GAMEPLAY)
 	{
 		ENGINE->windows().popWindows(2);
-		CMM->playMusic();
+		GAME->mainmenu()->playMusic();
 	}
 	else
 	{

--- a/client/mainmenu/CHighScoreScreen.cpp
+++ b/client/mainmenu/CHighScoreScreen.cpp
@@ -14,6 +14,7 @@
 #include "CStatisticScreen.h"
 #include "CMainMenu.h"
 #include "../GameEngine.h"
+#include "../GameInstance.h"
 #include "../gui/WindowHandler.h"
 #include "../gui/Shortcut.h"
 #include "../media/IMusicPlayer.h"
@@ -169,7 +170,7 @@ void CHighScoreScreen::buttonResetClick()
 void CHighScoreScreen::buttonExitClick()
 {
 	close();
-	CMM->playMusic();
+	GAME->mainmenu()->playMusic();
 }
 
 void CHighScoreScreen::showAll(Canvas & to)
@@ -221,7 +222,7 @@ CHighScoreInputScreen::CHighScoreInputScreen(bool won, HighScoreCalculation calc
 
 void CHighScoreInputScreen::stopMusicAndClose()
 {
-	CMM->playMusic();
+	GAME->mainmenu()->playMusic();
 	close();
 }
 

--- a/client/mainmenu/CMainMenu.cpp
+++ b/client/mainmenu/CMainMenu.cpp
@@ -61,7 +61,6 @@
 #include "../../lib/CRandomGenerator.h"
 #include "../../lib/GameLibrary.h"
 
-std::shared_ptr<CMainMenu> CMM;
 ISelectionScreenInfo * SEL = nullptr;
 
 static void do_quit()
@@ -171,7 +170,7 @@ static std::function<void()> genCommand(CMenuScreen * menu, std::vector<std::str
 			}
 			case 1: //open campaign selection window
 			{
-				return std::bind(&CMainMenu::openCampaignScreen, CMM, commands.front());
+				return std::bind(&CMainMenu::openCampaignScreen, GAME->mainmenu(), commands.front());
 				break;
 			}
 			case 2: //start
@@ -384,7 +383,7 @@ void CMainMenu::onScreenResize()
 
 void CMainMenu::makeActiveInterface()
 {
-	ENGINE->windows().pushWindow(CMM);
+	ENGINE->windows().pushWindow(GAME->mainmenu());
 	ENGINE->windows().pushWindow(menu);
 	menu->switchToTab(menu->getActiveTab());
 }
@@ -459,14 +458,6 @@ void CMainMenu::openHighScoreScreen()
 {
 	ENGINE->windows().createAndPushWindow<CHighScoreScreen>(CHighScoreScreen::HighScorePage::SCENARIO);
 	return;
-}
-
-std::shared_ptr<CMainMenu> CMainMenu::create()
-{
-	if(!CMM)
-		CMM = std::shared_ptr<CMainMenu>(new CMainMenu());
-
-	return CMM;
 }
 
 std::shared_ptr<CPicture> CMainMenu::createPicture(const JsonNode & config)

--- a/client/mainmenu/CMainMenu.cpp
+++ b/client/mainmenu/CMainMenu.cpp
@@ -331,11 +331,7 @@ CMainMenu::CMainMenu()
 	backgroundAroundMenu = std::make_shared<CFilledTexture>(ImagePath::builtin("DIBOXBCK"), pos);
 }
 
-CMainMenu::~CMainMenu()
-{
-	if(ENGINE->curInt == this)
-		ENGINE->curInt = nullptr;
-}
+CMainMenu::~CMainMenu() = default;
 
 void CMainMenu::playIntroVideos()
 {
@@ -386,21 +382,11 @@ void CMainMenu::onScreenResize()
 	backgroundAroundMenu->pos = pos;
 }
 
-void CMainMenu::update()
+void CMainMenu::makeActiveInterface()
 {
-	if(CMM != this->shared_from_this()) //don't update if you are not a main interface
-		return;
-
-	if(ENGINE->windows().count() == 0)
-	{
-		ENGINE->windows().pushWindow(CMM);
-		ENGINE->windows().pushWindow(menu);
-		menu->switchToTab(menu->getActiveTab());
-	}
-
-	// Handles mouse and key input
-	ENGINE->handleEvents();
-	ENGINE->windows().simpleRedraw();
+	ENGINE->windows().pushWindow(CMM);
+	ENGINE->windows().pushWindow(menu);
+	menu->switchToTab(menu->getActiveTab());
 }
 
 void CMainMenu::openLobby(ESelectionScreen screenType, bool host, const std::vector<std::string> & names, ELoadMode loadMode)

--- a/client/mainmenu/CMainMenu.h
+++ b/client/mainmenu/CMainMenu.h
@@ -139,7 +139,7 @@ private:
 };
 
 /// Handles background screen, loads graphics for victory/loss condition and random town or hero selection
-class CMainMenu : public CIntObject, public IUpdateable, public std::enable_shared_from_this<CMainMenu>
+class CMainMenu : public CIntObject, public std::enable_shared_from_this<CMainMenu>
 {
 	std::shared_ptr<CFilledTexture> backgroundAroundMenu;
 
@@ -153,7 +153,7 @@ public:
 	~CMainMenu();
 	void activate() override;
 	void onScreenResize() override;
-	void update() override;
+	void makeActiveInterface();
 	static void openLobby(ESelectionScreen screenType, bool host, const std::vector<std::string> & names, ELoadMode loadMode);
 	static void openCampaignLobby(const std::string & campaignFileName, std::string campaignSet = "");
 	static void openCampaignLobby(std::shared_ptr<CampaignState> campaign);

--- a/client/mainmenu/CMainMenu.h
+++ b/client/mainmenu/CMainMenu.h
@@ -139,15 +139,15 @@ private:
 };
 
 /// Handles background screen, loads graphics for victory/loss condition and random town or hero selection
-class CMainMenu : public CIntObject, public std::enable_shared_from_this<CMainMenu>
+class CMainMenu final : public CIntObject, public std::enable_shared_from_this<CMainMenu>
 {
 	std::shared_ptr<CFilledTexture> backgroundAroundMenu;
 
 	std::vector<VideoPath> videoPlayList;
 
-	CMainMenu(); //Use CMainMenu::create
-
 public:
+	CMainMenu();
+
 	std::shared_ptr<CMenuScreen> menu;
 
 	~CMainMenu();
@@ -160,8 +160,6 @@ public:
 	static void startTutorial();
 	static void openHighScoreScreen();
 	void openCampaignScreen(std::string name);
-
-	static std::shared_ptr<CMainMenu> create();
 
 	static std::shared_ptr<CPicture> createPicture(const JsonNode & config);
 
@@ -203,4 +201,4 @@ public:
 	void tick(uint32_t msPassed) override;
 };
 
-extern std::shared_ptr<CMainMenu> CMM;
+

--- a/client/windows/settings/SettingsMainWindow.cpp
+++ b/client/windows/settings/SettingsMainWindow.cpp
@@ -147,7 +147,7 @@ void SettingsMainWindow::mainMenuButtonCallback()
 		{
 			close();
 			GAME->server().endGameplay();
-			CMM->menu->switchToTab("main");
+			GAME->mainmenu()->menu->switchToTab("main");
 		},
 		0
 	);

--- a/clientapp/EntryPoint.cpp
+++ b/clientapp/EntryPoint.cpp
@@ -309,6 +309,7 @@ int main(int argc, char * argv[])
 		ENGINE->init();
 
 	GAME = std::make_unique<GameInstance>();
+	ENGINE->setEngineUser(GAME.get());
 	
 #ifndef VCMI_NO_THREADED_LOAD
 	//we can properly play intro only in the main thread, so we have to move loading to the separate thread
@@ -373,7 +374,7 @@ int main(int argc, char * argv[])
 	else
 	{
 		auto mmenu = CMainMenu::create();
-		ENGINE->curInt = mmenu.get();
+		mmenu->makeActiveInterface();
 
 		bool playIntroVideo = !settings["session"]["headless"].Bool() && !vm.count("battle") && !vm.count("nointro") && settings["video"]["showIntro"].Bool();
 		if(playIntroVideo)

--- a/clientapp/EntryPoint.cpp
+++ b/clientapp/EntryPoint.cpp
@@ -34,6 +34,7 @@
 #include "../client/windows/CMessage.h"
 #include "../client/windows/InfoWindows.h"
 
+#include "../lib/CConsoleHandler.h"
 #include "../lib/CThreadHelper.h"
 #include "../lib/ExceptionsCommon.h"
 #include "../lib/filesystem/Filesystem.h"
@@ -227,12 +228,12 @@ int main(int argc, char * argv[])
 	CConsoleHandler console(callbackFunction);
 	console.start();
 
-	CBasicLogConfigurator logConfig(logPath, &console);
+	CBasicLogConfigurator logConfigurator(logPath, &console);
 #else
-	CBasicLogConfigurator logConfig(logPath, nullptr);
+	CBasicLogConfigurator logConfigurator(logPath, nullptr);
 #endif
 
-	logConfig.configureDefault();
+	logConfigurator.configureDefault();
 	logGlobal->info("Starting client of '%s'", GameConstants::VCMI_VERSION);
 	logGlobal->info("Creating console and configuring logger: %d ms", pomtime.getDiff());
 	logGlobal->info("The log file will be saved to %s", logPath);
@@ -289,7 +290,7 @@ int main(int argc, char * argv[])
 	setSettingInteger("general/saveFrequency", "savefrequency", 1);
 
 	// Initialize logging based on settings
-	logConfig.configure();
+	logConfigurator.configure();
 	logGlobal->debug("settings = %s", settings.toJsonNode().toString());
 
 	// Some basic data validation to produce better error messages in cases of incorrect install

--- a/clientapp/EntryPoint.cpp
+++ b/clientapp/EntryPoint.cpp
@@ -371,16 +371,15 @@ int main(int argc, char * argv[])
 		session["onlyai"].Bool() = true;
 		boost::thread(&CServerHandler::debugStartTest, &GAME->server(), session["testsave"].String(), true);
 	}
-	else
+	else if (!settings["session"]["headless"].Bool())
 	{
-		auto mmenu = CMainMenu::create();
-		mmenu->makeActiveInterface();
+		GAME->mainmenu()->makeActiveInterface();
 
-		bool playIntroVideo = !settings["session"]["headless"].Bool() && !vm.count("battle") && !vm.count("nointro") && settings["video"]["showIntro"].Bool();
+		bool playIntroVideo = !vm.count("battle") && !vm.count("nointro") && settings["video"]["showIntro"].Bool();
 		if(playIntroVideo)
-			mmenu->playIntroVideos();
+			GAME->mainmenu()->playIntroVideos();
 		else
-			mmenu->playMusic();
+			GAME->mainmenu()->playMusic();
 	}
 	
 	std::vector<std::string> names;
@@ -444,7 +443,7 @@ static void mainLoop()
 	}
 
 	GAME.reset();
-	CMM.reset();
+	GAME->mainmenu().reset();
 
 	if(!settings["session"]["headless"].Bool())
 	{

--- a/clientapp/EntryPoint.cpp
+++ b/clientapp/EntryPoint.cpp
@@ -227,12 +227,12 @@ int main(int argc, char * argv[])
 	CConsoleHandler console(callbackFunction);
 	console.start();
 
-	logConfig = new CBasicLogConfigurator(logPath, &console);
+	CBasicLogConfigurator logConfig(logPath, &console);
 #else
-	logConfig = new CBasicLogConfigurator(logPath, nullptr);
+	CBasicLogConfigurator logConfig(logPath, nullptr);
 #endif
 
-	logConfig->configureDefault();
+	logConfig.configureDefault();
 	logGlobal->info("Starting client of '%s'", GameConstants::VCMI_VERSION);
 	logGlobal->info("Creating console and configuring logger: %d ms", pomtime.getDiff());
 	logGlobal->info("The log file will be saved to %s", logPath);
@@ -289,7 +289,7 @@ int main(int argc, char * argv[])
 	setSettingInteger("general/saveFrequency", "savefrequency", 1);
 
 	// Initialize logging based on settings
-	logConfig->configure();
+	logConfig.configure();
 	logGlobal->debug("settings = %s", settings.toJsonNode().toString());
 
 	// Some basic data validation to produce better error messages in cases of incorrect install

--- a/launcher/mainwindow_moc.cpp
+++ b/launcher/mainwindow_moc.cpp
@@ -31,9 +31,12 @@ void MainWindow::load()
 	QDir::setCurrent(QApplication::applicationDirPath());
 
 #ifndef VCMI_MOBILE
-	console = new CConsoleHandler();
+	console = std::make_unique<CConsoleHandler>();
+	CBasicLogConfigurator logConfig(VCMIDirs::get().userLogsPath() / "VCMI_Launcher_log.txt", console.get());
+#else
+	CBasicLogConfigurator logConfig(VCMIDirs::get().userLogsPath() / "VCMI_Launcher_log.txt", nullptr);
 #endif
-	CBasicLogConfigurator logConfig(VCMIDirs::get().userLogsPath() / "VCMI_Launcher_log.txt", console);
+
 	logConfig.configureDefault();
 
 	try

--- a/launcher/mainwindow_moc.cpp
+++ b/launcher/mainwindow_moc.cpp
@@ -14,6 +14,7 @@
 #include <QDir>
 
 #include "../lib/CConfigHandler.h"
+#include "../lib/CConsoleHandler.h"
 #include "../lib/VCMIDirs.h"
 #include "../lib/filesystem/Filesystem.h"
 #include "../lib/logging/CBasicLogConfigurator.h"
@@ -32,12 +33,12 @@ void MainWindow::load()
 
 #ifndef VCMI_MOBILE
 	console = std::make_unique<CConsoleHandler>();
-	CBasicLogConfigurator logConfig(VCMIDirs::get().userLogsPath() / "VCMI_Launcher_log.txt", console.get());
+	CBasicLogConfigurator logConfigurator(VCMIDirs::get().userLogsPath() / "VCMI_Launcher_log.txt", console.get());
 #else
-	CBasicLogConfigurator logConfig(VCMIDirs::get().userLogsPath() / "VCMI_Launcher_log.txt", nullptr);
+	CBasicLogConfigurator logConfigurator(VCMIDirs::get().userLogsPath() / "VCMI_Launcher_log.txt", nullptr);
 #endif
 
-	logConfig.configureDefault();
+	logConfigurator.configureDefault();
 
 	try
 	{

--- a/launcher/mainwindow_moc.h
+++ b/launcher/mainwindow_moc.h
@@ -12,6 +12,10 @@
 #include <QStringList>
 #include <QTranslator>
 
+VCMI_LIB_NAMESPACE_BEGIN
+class CConsoleHandler;
+VCMI_LIB_NAMESPACE_END
+
 namespace Ui
 {
 class MainWindow;
@@ -39,6 +43,10 @@ class MainWindow : public QMainWindow
 	QTranslator translator;
 #endif
 	Ui::MainWindow * ui;
+
+#ifndef VCMI_MOBILE
+	std::unique_ptr<CConsoleHandler> console;
+#endif
 
 	void load();
 

--- a/lib/CConsoleHandler.cpp
+++ b/lib/CConsoleHandler.cpp
@@ -27,7 +27,6 @@ VCMI_LIB_NAMESPACE_END
 #endif
 
 #ifndef VCMI_WINDOWS
-	using TColor = std::string;
 	#define CONSOLE_GREEN "\x1b[1;32m"
 	#define CONSOLE_RED "\x1b[1;31m"
 	#define CONSOLE_MAGENTA "\x1b[1;35m"
@@ -41,7 +40,6 @@ VCMI_LIB_NAMESPACE_END
 #ifndef __MINGW32__
 	#pragma comment(lib, "dbghelp.lib")
 #endif
-	typedef WORD TColor;
 	HANDLE handleIn;
 	HANDLE handleOut;
 	HANDLE handleErr;
@@ -52,11 +50,7 @@ VCMI_LIB_NAMESPACE_END
 	#define CONSOLE_WHITE FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE | FOREGROUND_INTENSITY
 	#define CONSOLE_GRAY FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE
 	#define CONSOLE_TEAL FOREGROUND_GREEN | FOREGROUND_BLUE | FOREGROUND_INTENSITY
-
-	static TColor defErrColor;
 #endif
-
-static TColor defColor;
 
 VCMI_LIB_NAMESPACE_BEGIN
 

--- a/lib/CConsoleHandler.cpp
+++ b/lib/CConsoleHandler.cpp
@@ -15,8 +15,6 @@
 
 #include <boost/stacktrace.hpp>
 
-VCMI_LIB_NAMESPACE_END
-
 #if defined(NDEBUG) && !defined(VCMI_ANDROID)
 #define USE_ON_TERMINATE
 #endif
@@ -27,29 +25,29 @@ VCMI_LIB_NAMESPACE_END
 #endif
 
 #ifndef VCMI_WINDOWS
-	#define CONSOLE_GREEN "\x1b[1;32m"
-	#define CONSOLE_RED "\x1b[1;31m"
-	#define CONSOLE_MAGENTA "\x1b[1;35m"
-	#define CONSOLE_YELLOW "\x1b[1;33m"
-	#define CONSOLE_WHITE "\x1b[1;37m"
-	#define CONSOLE_GRAY "\x1b[1;30m"
-	#define CONSOLE_TEAL "\x1b[1;36m"
+constexpr const char * CONSOLE_GREEN = "\x1b[1;32m";
+constexpr const char * CONSOLE_RED = "\x1b[1;31m";
+constexpr const char * CONSOLE_MAGENTA = "\x1b[1;35m";
+constexpr const char * CONSOLE_YELLOW = "\x1b[1;33m";
+constexpr const char * CONSOLE_WHITE = "\x1b[1;37m";
+constexpr const char * CONSOLE_GRAY = "\x1b[1;30m";
+constexpr const char * CONSOLE_TEAL = "\x1b[1;36m";
 #else
-	#include <windows.h>
-	#include <dbghelp.h>
+#include <windows.h>
+#include <dbghelp.h>
 #ifndef __MINGW32__
 	#pragma comment(lib, "dbghelp.lib")
 #endif
-	HANDLE handleIn;
-	HANDLE handleOut;
-	HANDLE handleErr;
-	#define CONSOLE_GREEN FOREGROUND_GREEN | FOREGROUND_INTENSITY
-	#define CONSOLE_RED FOREGROUND_RED | FOREGROUND_INTENSITY
-	#define CONSOLE_MAGENTA FOREGROUND_RED | FOREGROUND_BLUE | FOREGROUND_INTENSITY
-	#define CONSOLE_YELLOW FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_INTENSITY
-	#define CONSOLE_WHITE FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE | FOREGROUND_INTENSITY
-	#define CONSOLE_GRAY FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE
-	#define CONSOLE_TEAL FOREGROUND_GREEN | FOREGROUND_BLUE | FOREGROUND_INTENSITY
+HANDLE handleIn;
+HANDLE handleOut;
+HANDLE handleErr;
+constexpr int32_t CONSOLE_GREEN = FOREGROUND_GREEN | FOREGROUND_INTENSITY;
+constexpr int32_t CONSOLE_RED = FOREGROUND_RED | FOREGROUND_INTENSITY;
+constexpr int32_t CONSOLE_MAGENTA = FOREGROUND_RED | FOREGROUND_BLUE | FOREGROUND_INTENSITY;
+constexpr int32_t CONSOLE_YELLOW = FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_INTENSITY;
+constexpr int32_t CONSOLE_WHITE = FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE | FOREGROUND_INTENSITY;
+constexpr int32_t CONSOLE_GRAY = FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE;
+constexpr int32_t CONSOLE_TEAL = FOREGROUND_GREEN | FOREGROUND_BLUE | FOREGROUND_INTENSITY;
 #endif
 
 VCMI_LIB_NAMESPACE_BEGIN
@@ -190,7 +188,7 @@ LONG WINAPI onUnhandledException(EXCEPTION_POINTERS* exception)
 }
 #endif
 
-void CConsoleHandler::setColor(EConsoleTextColor::EConsoleTextColor color)
+void CConsoleHandler::setColor(EConsoleTextColor color)
 {
 	TColor colorCode;
 	switch(color)
@@ -259,8 +257,8 @@ int CConsoleHandler::run()
 		boost::this_thread::interruption_point();
 #else
 		std::getline(std::cin, buffer);
-		if ( cb && *cb )
-			(*cb)(buffer, false);
+		if ( cb )
+			cb(buffer, false);
 #endif
 	}
 	return -1;
@@ -270,7 +268,7 @@ CConsoleHandler::CConsoleHandler()
 	:CConsoleHandler(std::function<void(const std::string &, bool)>{})
 {}
 
-CConsoleHandler::CConsoleHandler(std::function<void(const std::string &, bool)> callback)
+CConsoleHandler::CConsoleHandler(const std::function<void(const std::string &, bool)> & callback)
 	:cb(callback)
 {
 #ifdef VCMI_WINDOWS
@@ -310,7 +308,7 @@ void CConsoleHandler::end()
 #ifndef VCMI_WINDOWS
 		thread.interrupt();
 #else
-		TerminateThread(thread->native_handle(),0);
+		TerminateThread(thread.native_handle(),0);
 #endif
 		thread.join();
 	}

--- a/lib/CConsoleHandler.h
+++ b/lib/CConsoleHandler.h
@@ -11,10 +11,8 @@
 
 VCMI_LIB_NAMESPACE_BEGIN
 
-namespace EConsoleTextColor
-{
 /** The color enum is used for colored text console output. */
-enum EConsoleTextColor
+enum class EConsoleTextColor : int8_t
 {
 	DEFAULT = -1,
 	GREEN,
@@ -25,19 +23,18 @@ enum EConsoleTextColor
 	GRAY,
 	TEAL = -2
 };
-}
 
 /// Class which wraps the native console. It can print text based on
 /// the chosen color
 class DLL_LINKAGE CConsoleHandler
 {
 public:
-	CConsoleHandler(std::function<void(const std::string &, bool)> callback);
+	CConsoleHandler(const std::function<void(const std::string &, bool)> & callback);
 	CConsoleHandler();
 	~CConsoleHandler();
 	void start(); //starts listening thread
 
-	template<typename T> void print(const T &data, bool addNewLine = false, EConsoleTextColor::EConsoleTextColor color = EConsoleTextColor::DEFAULT, bool printToStdErr = false)
+	template<typename T> void print(const T &data, bool addNewLine = false, EConsoleTextColor color = EConsoleTextColor::DEFAULT, bool printToStdErr = false)
 	{
 		TLockGuard _(smx);
 #ifndef VCMI_WINDOWS
@@ -82,17 +79,17 @@ private:
 #ifndef VCMI_WINDOWS
 	using TColor = std::string;
 #else
-	typedef WORD TColor;
+	using TColor = int32_t;
 #endif
 
 	int run();
 
 	void end(); //kills listening thread
 
-	void setColor(EConsoleTextColor::EConsoleTextColor color); //sets color of text appropriate for given logging level
+	void setColor(EConsoleTextColor color); //sets color of text appropriate for given logging level
 
-	static TColor defColor;
-	static TColor defErrColor;
+	TColor defColor;
+	TColor defErrColor;
 
 	//function to be called when message is received - string: message, bool: whether call was made from in-game console
 	std::function<void(const std::string &, bool)> cb;

--- a/lib/CConsoleHandler.h
+++ b/lib/CConsoleHandler.h
@@ -78,11 +78,21 @@ public:
 	}
 
 private:
+
+#ifndef VCMI_WINDOWS
+	using TColor = std::string;
+#else
+	typedef WORD TColor;
+#endif
+
 	int run();
 
 	void end(); //kills listening thread
 
 	void setColor(EConsoleTextColor::EConsoleTextColor color); //sets color of text appropriate for given logging level
+
+	static TColor defColor;
+	static TColor defErrColor;
 
 	//function to be called when message is received - string: message, bool: whether call was made from in-game console
 	std::function<void(const std::string &, bool)> cb;

--- a/lib/CConsoleHandler.h
+++ b/lib/CConsoleHandler.h
@@ -16,14 +16,14 @@ namespace EConsoleTextColor
 /** The color enum is used for colored text console output. */
 enum EConsoleTextColor
 {
-    DEFAULT = -1,
-    GREEN,
-    RED,
-    MAGENTA,
-    YELLOW,
-    WHITE,
-    GRAY,
-    TEAL = -2
+	DEFAULT = -1,
+	GREEN,
+	RED,
+	MAGENTA,
+	YELLOW,
+	WHITE,
+	GRAY,
+	TEAL = -2
 };
 }
 
@@ -32,67 +32,64 @@ enum EConsoleTextColor
 class DLL_LINKAGE CConsoleHandler
 {
 public:
-    CConsoleHandler();
-    ~CConsoleHandler();
-    void start(); //starts listening thread
+	CConsoleHandler(std::function<void(const std::string &, bool)> callback);
+	CConsoleHandler();
+	~CConsoleHandler();
+	void start(); //starts listening thread
 
-    template<typename T> void print(const T &data, bool addNewLine = false, EConsoleTextColor::EConsoleTextColor color = EConsoleTextColor::DEFAULT, bool printToStdErr = false)
+	template<typename T> void print(const T &data, bool addNewLine = false, EConsoleTextColor::EConsoleTextColor color = EConsoleTextColor::DEFAULT, bool printToStdErr = false)
 	{
-        TLockGuard _(smx);
+		TLockGuard _(smx);
 #ifndef VCMI_WINDOWS
 		// with love from ffmpeg - library is trying to print some warnings from separate thread
 		// this results in broken console on Linux. Lock stdout to print all our data at once
 		flockfile(stdout);
 #endif
-        if(color != EConsoleTextColor::DEFAULT) setColor(color);
-        if(printToStdErr)
-        {
-            std::cerr << data;
-            if(addNewLine)
-            {
-                std::cerr << std::endl;
-            }
-            else
-            {
-                std::cerr << std::flush;
-            }
-        }
-        else
-        {
-            std::cout << data;
-            if(addNewLine)
-            {
-                std::cout << std::endl;
-            }
-            else
-            {
-                std::cout << std::flush;
-            }
-        }
+		if(color != EConsoleTextColor::DEFAULT) setColor(color);
+		if(printToStdErr)
+		{
+			std::cerr << data;
+			if(addNewLine)
+			{
+				std::cerr << std::endl;
+			}
+			else
+			{
+				std::cerr << std::flush;
+			}
+		}
+		else
+		{
+			std::cout << data;
+			if(addNewLine)
+			{
+				std::cout << std::endl;
+			}
+			else
+			{
+				std::cout << std::flush;
+			}
+		}
 
-        if(color != EConsoleTextColor::DEFAULT) setColor(EConsoleTextColor::DEFAULT);
+		if(color != EConsoleTextColor::DEFAULT) setColor(EConsoleTextColor::DEFAULT);
 #ifndef VCMI_WINDOWS
 		funlockfile(stdout);
 #endif
 	}
-	//function to be called when message is received - string: message, bool: whether call was made from in-game console
-	std::function<void(const std::string &, bool)> *cb;
 
 private:
-	int run() const;
+	int run();
 
 	void end(); //kills listening thread
 
-	static void setColor(EConsoleTextColor::EConsoleTextColor color); //sets color of text appropriate for given logging level
+	void setColor(EConsoleTextColor::EConsoleTextColor color); //sets color of text appropriate for given logging level
 
-	/// FIXME: Implement CConsoleHandler as singleton, move some logic into CLogConsoleTarget, etc... needs to be discussed:)
-	/// Without static, application will crash complaining about mutex deleted. In short: CConsoleHandler gets deleted before
-	/// the logging system.
-	static std::mutex smx;
+	//function to be called when message is received - string: message, bool: whether call was made from in-game console
+	std::function<void(const std::string &, bool)> cb;
 
-	boost::thread * thread;
+	std::mutex smx;
+
+	boost::thread thread;
 };
-
-extern DLL_LINKAGE CConsoleHandler * console;
 
 VCMI_LIB_NAMESPACE_END

--- a/lib/GameLibrary.cpp
+++ b/lib/GameLibrary.cpp
@@ -32,7 +32,6 @@
 #include "CStopWatch.h"
 #include "VCMIDirs.h"
 #include "filesystem/Filesystem.h"
-#include "CConsoleHandler.h"
 #include "rmg/CRmgTemplateStorage.h"
 #include "mapObjectConstructors/CObjectClassesHandler.h"
 #include "mapObjects/CObjectHandler.h"
@@ -47,9 +46,8 @@ VCMI_LIB_NAMESPACE_BEGIN
 
 GameLibrary * LIBRARY = nullptr;
 
-DLL_LINKAGE void preinitDLL(CConsoleHandler * Console, bool extractArchives)
+DLL_LINKAGE void preinitDLL(bool extractArchives)
 {
-	console = Console;
 	LIBRARY = new GameLibrary();
 	LIBRARY->loadFilesystem(extractArchives);
 	settings.init("config/settings.json", "vcmi:settings");

--- a/lib/GameLibrary.h
+++ b/lib/GameLibrary.h
@@ -119,7 +119,7 @@ public:
 
 extern DLL_LINKAGE GameLibrary * LIBRARY;
 
-DLL_LINKAGE void preinitDLL(CConsoleHandler * Console, bool extractArchives);
+DLL_LINKAGE void preinitDLL(bool extractArchives);
 DLL_LINKAGE void loadDLLClasses(bool onlyEssential = false);
 
 

--- a/lib/logging/CBasicLogConfigurator.cpp
+++ b/lib/logging/CBasicLogConfigurator.cpp
@@ -12,6 +12,7 @@
 #include "CLogger.h"
 
 #include "../CConfigHandler.h"
+#include "../CConsoleHandler.h"
 
 VCMI_LIB_NAMESPACE_BEGIN
 
@@ -122,9 +123,9 @@ ELogLevel::ELogLevel CBasicLogConfigurator::getLogLevel(const std::string & leve
 		throw std::runtime_error("Log level " + level + " unknown.");
 }
 
-EConsoleTextColor::EConsoleTextColor CBasicLogConfigurator::getConsoleColor(const std::string & colorName)
+EConsoleTextColor CBasicLogConfigurator::getConsoleColor(const std::string & colorName)
 {
-	static const std::map<std::string, EConsoleTextColor::EConsoleTextColor> colorMap =
+	static const std::map<std::string, EConsoleTextColor> colorMap =
 	{
 		{"default", EConsoleTextColor::DEFAULT},
 		{"green", EConsoleTextColor::GREEN},

--- a/lib/logging/CBasicLogConfigurator.h
+++ b/lib/logging/CBasicLogConfigurator.h
@@ -10,12 +10,11 @@
 
 #pragma once
 
-#include "../CConsoleHandler.h"
-
 VCMI_LIB_NAMESPACE_BEGIN
 
 class CConsoleHandler;
 class JsonNode;
+enum class EConsoleTextColor : int8_t;
 
 /// The class CBasicLogConfigurator reads log properties from settings.json and
 /// sets up the logging system. Make sure that you use the same configurator object to
@@ -42,7 +41,7 @@ private:
 	static ELogLevel::ELogLevel getLogLevel(const std::string & level);
 	// Gets EConsoleTextColor enum from strings. (Should be moved to CLogger as a separate function?)
 	// Throws: std::runtime_error
-	static EConsoleTextColor::EConsoleTextColor getConsoleColor(const std::string & colorName);
+	static EConsoleTextColor getConsoleColor(const std::string & colorName);
 
 	boost::filesystem::path filePath;
 	CConsoleHandler * console;

--- a/lib/logging/CLogger.cpp
+++ b/lib/logging/CLogger.cpp
@@ -10,6 +10,7 @@
 #include "StdInc.h"
 #include "CLogger.h"
 #include "../CThreadHelper.h"
+#include "../CConsoleHandler.h"
 
 #ifdef VCMI_ANDROID
 #include <android/log.h>
@@ -313,13 +314,13 @@ CColorMapping::CColorMapping()
 	levelMap[ELogLevel::ERROR] = EConsoleTextColor::RED;
 }
 
-void CColorMapping::setColorFor(const CLoggerDomain & domain, ELogLevel::ELogLevel level, EConsoleTextColor::EConsoleTextColor color)
+void CColorMapping::setColorFor(const CLoggerDomain & domain, ELogLevel::ELogLevel level, EConsoleTextColor color)
 {
 	assert(level != ELogLevel::NOT_SET);
 	map[domain.getName()][level] = color;
 }
 
-EConsoleTextColor::EConsoleTextColor CColorMapping::getColorFor(const CLoggerDomain & domain, ELogLevel::ELogLevel level) const
+EConsoleTextColor CColorMapping::getColorFor(const CLoggerDomain & domain, ELogLevel::ELogLevel level) const
 {
 	CLoggerDomain currentDomain = domain;
 	while(true)
@@ -400,7 +401,7 @@ void CLogConsoleTarget::write(const LogRecord & record)
 	const bool printToStdErr = record.level >= ELogLevel::WARN;
 	if(console)
 	{
-		const EConsoleTextColor::EConsoleTextColor textColor =
+		const EConsoleTextColor textColor =
 			coloredOutputEnabled ? colorMapping.getColorFor(record.domain, record.level) : EConsoleTextColor::DEFAULT;
 
 		console->print(message, true, textColor, printToStdErr);

--- a/lib/logging/CLogger.h
+++ b/lib/logging/CLogger.h
@@ -9,14 +9,14 @@
  */
 #pragma once
 
-#include "../CConsoleHandler.h"
 
 VCMI_LIB_NAMESPACE_BEGIN
 
 class CLogger;
+class CConsoleHandler;
 struct LogRecord;
 class ILogTarget;
-
+enum class EConsoleTextColor : int8_t;
 
 namespace ELogLevel
 {
@@ -157,11 +157,11 @@ class DLL_LINKAGE CColorMapping
 public:
 	CColorMapping();
 
-	void setColorFor(const CLoggerDomain & domain, ELogLevel::ELogLevel level, EConsoleTextColor::EConsoleTextColor color);
-	EConsoleTextColor::EConsoleTextColor getColorFor(const CLoggerDomain & domain, ELogLevel::ELogLevel level) const;
+	void setColorFor(const CLoggerDomain & domain, ELogLevel::ELogLevel level, EConsoleTextColor color);
+	EConsoleTextColor getColorFor(const CLoggerDomain & domain, ELogLevel::ELogLevel level) const;
 
 private:
-	std::map<std::string, std::map<ELogLevel::ELogLevel, EConsoleTextColor::EConsoleTextColor> > map;
+	std::map<std::string, std::map<ELogLevel::ELogLevel, EConsoleTextColor> > map;
 };
 
 /// This target is a logging target which writes message to the console.

--- a/lobby/EntryPoint.cpp
+++ b/lobby/EntryPoint.cpp
@@ -24,9 +24,9 @@ int main(int argc, const char * argv[])
 	CResourceHandler::load("config/filesystem.json"); // FIXME: we actually need only config directory for schemas, can be reduced
 
 #ifndef VCMI_IOS
-	console = new CConsoleHandler();
+	CConsoleHandler console;
 #endif
-	CBasicLogConfigurator logConfig(VCMIDirs::get().userLogsPath() / "VCMI_Lobby_log.txt", console);
+	CBasicLogConfigurator logConfig(VCMIDirs::get().userLogsPath() / "VCMI_Lobby_log.txt", &console);
 	logConfig.configureDefault();
 
 	auto databasePath = VCMIDirs::get().userDataPath() / "vcmiLobby.db";

--- a/lobby/EntryPoint.cpp
+++ b/lobby/EntryPoint.cpp
@@ -11,6 +11,7 @@
 
 #include "LobbyServer.h"
 
+#include "../lib/CConsoleHandler.h"
 #include "../lib/logging/CBasicLogConfigurator.h"
 #include "../lib/filesystem/CFilesystemLoader.h"
 #include "../lib/filesystem/Filesystem.h"
@@ -26,8 +27,8 @@ int main(int argc, const char * argv[])
 #ifndef VCMI_IOS
 	CConsoleHandler console;
 #endif
-	CBasicLogConfigurator logConfig(VCMIDirs::get().userLogsPath() / "VCMI_Lobby_log.txt", &console);
-	logConfig.configureDefault();
+	CBasicLogConfigurator logConfigurator(VCMIDirs::get().userLogsPath() / "VCMI_Lobby_log.txt", &console);
+	logConfigurator.configureDefault();
 
 	auto databasePath = VCMIDirs::get().userDataPath() / "vcmiLobby.db";
 	logGlobal->info("Opening database %s", databasePath.string());

--- a/mapeditor/inspector/heroskillswidget.cpp
+++ b/mapeditor/inspector/heroskillswidget.cpp
@@ -15,7 +15,7 @@
 #include "../../lib/CSkillHandler.h"
 #include "inspector.h"
 
-static QList<std::pair<QString, QVariant>> LevelIdentifiers
+static const QList<std::pair<QString, QVariant>> LevelIdentifiers
 {
 	{QObject::tr("Beginner"), QVariant::fromValue(1)},
 	{QObject::tr("Advanced"), QVariant::fromValue(2)},

--- a/mapeditor/mainwindow.cpp
+++ b/mapeditor/mainwindow.cpp
@@ -184,14 +184,14 @@ MainWindow::MainWindow(QWidget* parent) :
 
 	//configure logging
 	const boost::filesystem::path logPath = VCMIDirs::get().userLogsPath() / "VCMI_Editor_log.txt";
-	console = new CConsoleHandler();
-	logConfig = new CBasicLogConfigurator(logPath, console);
+	console = std::make_unique<CConsoleHandler>();
+	logConfig = new CBasicLogConfigurator(logPath, console.get());
 	logConfig->configureDefault();
 	logGlobal->info("Starting map editor of '%s'", GameConstants::VCMI_VERSION);
 	logGlobal->info("The log file will be saved to %s", logPath);
 
 	//init
-	preinitDLL(::console, extractionOptions.extractArchives);
+	preinitDLL(extractionOptions.extractArchives);
 
 	// Initialize logging based on settings
 	logConfig->configure();

--- a/mapeditor/mainwindow.cpp
+++ b/mapeditor/mainwindow.cpp
@@ -51,8 +51,6 @@
 #include "playersettings.h"
 #include "validator.h"
 
-static CBasicLogConfigurator * logConfig;
-
 QJsonValue jsonFromPixmap(const QPixmap &p)
 {
   QBuffer buffer;
@@ -185,7 +183,7 @@ MainWindow::MainWindow(QWidget* parent) :
 	//configure logging
 	const boost::filesystem::path logPath = VCMIDirs::get().userLogsPath() / "VCMI_Editor_log.txt";
 	console = std::make_unique<CConsoleHandler>();
-	logConfig = new CBasicLogConfigurator(logPath, console.get());
+	logConfig = std::make_unique<CBasicLogConfigurator>(logPath, console.get());
 	logConfig->configureDefault();
 	logGlobal->info("Starting map editor of '%s'", GameConstants::VCMI_VERSION);
 	logGlobal->info("The log file will be saved to %s", logPath);

--- a/mapeditor/mainwindow.cpp
+++ b/mapeditor/mainwindow.cpp
@@ -23,6 +23,7 @@
 #include "../lib/GameLibrary.h"
 #include "../lib/logging/CBasicLogConfigurator.h"
 #include "../lib/CConfigHandler.h"
+#include "../lib/CConsoleHandler.h"
 #include "../lib/filesystem/Filesystem.h"
 #include "../lib/filesystem/CMemoryBuffer.h"
 #include "../lib/GameConstants.h"

--- a/mapeditor/mainwindow.h
+++ b/mapeditor/mainwindow.h
@@ -12,6 +12,7 @@ class ObjectBrowserProxyModel;
 VCMI_LIB_NAMESPACE_BEGIN
 class CMap;
 class CampaignState;
+class CConsoleHandler;
 class CGObjectInstance;
 VCMI_LIB_NAMESPACE_END
 
@@ -34,7 +35,11 @@ class MainWindow : public QMainWindow
 #ifdef ENABLE_QT_TRANSLATIONS
 	QTranslator translator;
 #endif
-	
+
+#ifndef VCMI_MOBILE
+	std::unique_ptr<CConsoleHandler> console;
+#endif
+
 	std::unique_ptr<CMap> openMapInternal(const QString &);
 	std::shared_ptr<CampaignState> openCampaignInternal(const QString &);
 

--- a/mapeditor/mainwindow.h
+++ b/mapeditor/mainwindow.h
@@ -13,6 +13,7 @@ VCMI_LIB_NAMESPACE_BEGIN
 class CMap;
 class CampaignState;
 class CConsoleHandler;
+class CBasicLogConfigurator;
 class CGObjectInstance;
 VCMI_LIB_NAMESPACE_END
 
@@ -39,6 +40,7 @@ class MainWindow : public QMainWindow
 #ifndef VCMI_MOBILE
 	std::unique_ptr<CConsoleHandler> console;
 #endif
+	std::unique_ptr<CBasicLogConfigurator> logConfig;
 
 	std::unique_ptr<CMap> openMapInternal(const QString &);
 	std::shared_ptr<CampaignState> openCampaignInternal(const QString &);

--- a/serverapp/EntryPoint.cpp
+++ b/serverapp/EntryPoint.cpp
@@ -72,14 +72,14 @@ int main(int argc, const char * argv[])
 	boost::filesystem::current_path(boost::filesystem::system_complete(argv[0]).parent_path());
 
 	CConsoleHandler console;
-	CBasicLogConfigurator logConfig(VCMIDirs::get().userLogsPath() / "VCMI_Server_log.txt", &console);
-	logConfig.configureDefault();
+	CBasicLogConfigurator logConfigurator(VCMIDirs::get().userLogsPath() / "VCMI_Server_log.txt", &console);
+	logConfigurator.configureDefault();
 	logGlobal->info(SERVER_NAME);
 
 	boost::program_options::variables_map opts;
 	handleCommandOptions(argc, argv, opts);
 	preinitDLL(false);
-	logConfig.configure();
+	logConfigurator.configure();
 
 	loadDLLClasses();
 	std::srand(static_cast<uint32_t>(time(nullptr)));
@@ -98,7 +98,7 @@ int main(int argc, const char * argv[])
 		// CVCMIServer destructor must be called here - before LIBRARY cleanup
 	}
 
-	logConfig.deconfigure();
+	logConfigurator.deconfigure();
 	vstd::clear_pointer(LIBRARY);
 
 	return 0;

--- a/serverapp/EntryPoint.cpp
+++ b/serverapp/EntryPoint.cpp
@@ -71,14 +71,14 @@ int main(int argc, const char * argv[])
 	// Correct working dir executable folder (not bundle folder) so we can use executable relative paths
 	boost::filesystem::current_path(boost::filesystem::system_complete(argv[0]).parent_path());
 
-	console = new CConsoleHandler();
-	CBasicLogConfigurator logConfig(VCMIDirs::get().userLogsPath() / "VCMI_Server_log.txt", console);
+	CConsoleHandler console;
+	CBasicLogConfigurator logConfig(VCMIDirs::get().userLogsPath() / "VCMI_Server_log.txt", &console);
 	logConfig.configureDefault();
 	logGlobal->info(SERVER_NAME);
 
 	boost::program_options::variables_map opts;
 	handleCommandOptions(argc, argv, opts);
-	preinitDLL(console, false);
+	preinitDLL(false);
 	logConfig.configure();
 
 	loadDLLClasses();

--- a/test/CVcmiTestConfig.cpp
+++ b/test/CVcmiTestConfig.cpp
@@ -11,7 +11,6 @@
 #include "StdInc.h"
 #include "CVcmiTestConfig.h"
 
-#include "../lib/CConsoleHandler.h"
 #include "../lib/logging/CBasicLogConfigurator.h"
 #include "../lib/VCMIDirs.h"
 #include "../lib/GameLibrary.h"
@@ -23,8 +22,7 @@
 
 void CVcmiTestConfig::SetUp()
 {
-	console = new CConsoleHandler();
-	preinitDLL(console, true);
+	preinitDLL(true);
 	loadDLLClasses(true);
 
 	/* TEST_DATA_DIR may be wrong, if yes below test don't run,


### PR DESCRIPTION
Another part of startup refactoring:
- Removed `ENGINE->curInt` that was mostly duplicating LOCPLINT. Event processing is now initiated by GameEngine directly instead of having a weird chain engine -> player interface -> engine.
- Added GameEngineUser interface (implemented by GameInstance) to remove mutual strong dependency between GameEngine and GameInstance (some technically still remains for now, in form of free functions)
- Removed `console` global. Cleaned up `CConsoleHandler` class. Apparently this global is only needed to initialize logging, which is usually done immediately after in the same method. Now `console` is local variable in `main()` and similar methods
- Removed `CMM` (CMainMenu) global. Main menu is no longer a singleton. It is now managed by GameInstance and can be accessed via `GAME->mainmenu()`