### PR TITLE
[develop] fix rightButtonDrag edge case

### DIFF
--- a/client/mapView/MapViewActions.cpp
+++ b/client/mapView/MapViewActions.cpp
@@ -108,6 +108,9 @@ void MapViewActions::mouseDragged(const Point & cursorPosition, const Point & la
 
 void MapViewActions::mouseDraggedPopup(const Point & cursorPosition, const Point & lastUpdateDistance)
 {
+	if(!settings["adventure"]["rightButtonDrag"].Bool())
+		return;
+
 	dragActive = true;
 	owner.onMapSwiped(lastUpdateDistance);
 }


### PR DESCRIPTION
Avoid right button drag when dragging started on place without popup and disabled.