### PR TITLE
Fixes for crashes

### DIFF
--- a/AI/Nullkiller/AIGateway.cpp
+++ b/AI/Nullkiller/AIGateway.cpp
@@ -593,12 +593,11 @@ void AIGateway::yourTurn(QueryID queryID)
 
 	nullkiller->makingTurnInterrupption.reset();
 
-	asyncTasks->run([this]()
+	executeActionAsyncArena.enqueue(asyncTasks->defer([this]()
 	{
 		ScopedThreadName guard("NKAI::makingTurn");
 		makeTurn();
-	});
-	executeActionAsyncArena.enqueue([this](){asyncTasks->wait();});
+	}));
 }
 
 void AIGateway::heroGotLevel(const CGHeroInstance * hero, PrimarySkill pskill, std::vector<SecondarySkill> & skills, QueryID queryID)
@@ -1609,14 +1608,13 @@ void AIGateway::executeActionAsync(const std::string & description, const std::f
 	if (!asyncTasks)
 		throw std::runtime_error("Attempt to execute task on shut down AI state!");
 
-	asyncTasks->run([this, description, whatToDo]()
+	executeActionAsyncArena.enqueue(asyncTasks->defer([this, description, whatToDo]()
 	{
 		ScopedThreadName guard("NKAI::" + description);
 		SET_GLOBAL_STATE(this);
 		std::shared_lock gsLock(CGameState::mutex);
 		whatToDo();
-	});
-	executeActionAsyncArena.enqueue([this](){asyncTasks->wait();});
+	}));
 }
 
 void AIGateway::lostHero(HeroPtr h)

--- a/Global.h
+++ b/Global.h
@@ -145,6 +145,11 @@ static_assert(sizeof(bool) == 1, "Bool needs to be 1 byte in size.");
 #include <variant>
 #include <vector>
 
+// VCMI requires features that were added to TBB 2021.4
+// However, until TBB 2021.7 they were only available with this define
+// For versions TBB 2021.7 and later this define is not required
+#define TBB_PREVIEW_TASK_GROUP_EXTENSIONS 1
+
 //The only available version is 3, as of Boost 1.50
 #include <boost/version.hpp>
 

--- a/launcher/firstLaunch/firstlaunch_moc.h
+++ b/launcher/firstLaunch/firstlaunch_moc.h
@@ -42,6 +42,7 @@ class FirstLaunchView : public QWidget
 
 	QString getHeroesInstallDir();
 	void extractGogData();
+	void extractGogDataAsync(QString filePathBin, QString filePathExe);
 	void copyHeroesData(const QString & path = {}, bool move = false);
 
 	// Tab Mod Preset

--- a/lib/mapObjects/CGDwelling.cpp
+++ b/lib/mapObjects/CGDwelling.cpp
@@ -474,9 +474,17 @@ void CGDwelling::heroAcceptsCreatures( const CGHeroInstance *h) const
 			SetAvailableCreatures sac;
 			sac.tid = id;
 			sac.creatures = creatures;
-			sac.creatures[0].first = !h->getArt(ArtifactPosition::MACH1); //ballista
-			sac.creatures[1].first = !h->getArt(ArtifactPosition::MACH3); //first aid tent
-			sac.creatures[2].first = !h->getArt(ArtifactPosition::MACH2); //ammo cart
+
+			for (auto & entry : sac.creatures)
+			{
+				CreatureID creature = entry.second.at(0);
+				ArtifactID warMachine = creature.toCreature()->warMachine;
+
+				if (h->hasArt(warMachine, true, false))
+					entry.first = 0;
+				else
+					entry.first = 1;
+			}
 			cb->sendAndApply(sac);
 		}
 

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -2398,7 +2398,18 @@ bool CGameHandler::recruitCreatures(ObjectInstanceID objid, ObjectInstanceID dst
 		COMPLAIN_RET_FALSE_IF(!hero, "Only hero can buy war machines");
 		COMPLAIN_RET_FALSE_IF(artId == ArtifactID::CATAPULT, "Catapult cannot be recruited!");
 		COMPLAIN_RET_FALSE_IF(nullptr == art, "Invalid war machine artifact");
+		COMPLAIN_RET_FALSE_IF(hero->hasArt(artId),"Hero already has this machine!");
 
+		bool hasFreeSlot = false;
+		for(auto slot : art->getPossibleSlots().at(ArtBearer::HERO))
+			if (hero->getArt(slot) == nullptr)
+				hasFreeSlot = true;
+
+		if (!hasFreeSlot)
+		{
+			auto slot = art->getPossibleSlots().at(ArtBearer::HERO).front();
+			removeArtifact(ArtifactLocation(hero->id, slot));
+		}
 		return giveHeroNewArtifact(hero, artId, ArtifactPosition::FIRST_AVAILABLE);
 	}
 	else


### PR DESCRIPTION
- Fixes for crash on visiting Cannon Yard in HotA
- Fix possible crash if AI initiates large number of async requests on same turn (regression in 1.7)
- Try to fix remaining crashes with innoextract on Android

Will cherry-pick fixes for crashes to beta. Not sure if 1.6.8 is needed, but would like to have beta build in which such crashes are fixed