### PR TITLE
[beta] Backport of fixes for crashes

### DIFF
--- a/client/lobby/SelectionTab.cpp
+++ b/client/lobby/SelectionTab.cpp
@@ -617,7 +617,13 @@ void SelectionTab::sort()
 	if(!sortModeAscending)
 	{
 		if(firstMapIndex)
-			std::reverse(std::next(curItems.begin(), boost::starts_with(curItems[0]->folderName, "..") ? 1 : 0), std::next(curItems.begin(), firstMapIndex - 1));
+		{
+			auto startIt = std::next(curItems.begin(), boost::starts_with(curItems[0]->folderName, "..") ? 1 : 0);
+			auto endIt = std::next(curItems.begin(), firstMapIndex - 1);
+			if(startIt > endIt)
+				std::swap(startIt, endIt);
+			std::reverse(startIt, endIt);
+		}
 		std::reverse(std::next(curItems.begin(), firstMapIndex), curItems.end());
 	}
 

--- a/client/windows/CCastleInterface.cpp
+++ b/client/windows/CCastleInterface.cpp
@@ -398,7 +398,7 @@ void CHeroGSlot::gesture(bool on, const Point & initialPosition, const Point & f
 		std::vector<std::shared_ptr<CComponent>> resComps;
 		for(TResources::nziterator i(upgradableSlots.totalCosts); i.valid(); i++)
 			resComps.push_back(std::make_shared<CComponent>(ComponentType::RESOURCE, i->resType, i->resVal));
-		if(!resComps.size())
+		if(resComps.empty())
 			resComps.push_back(std::make_shared<CComponent>(ComponentType::RESOURCE, static_cast<GameResID>(GameResID::GOLD), 0)); // add at least gold, when there are no costs
 		resComps.back()->newLine = true;
 		for(auto & upgradeInfo : upgradableSlots.upgradeInfos)

--- a/client/windows/CCastleInterface.cpp
+++ b/client/windows/CCastleInterface.cpp
@@ -398,6 +398,8 @@ void CHeroGSlot::gesture(bool on, const Point & initialPosition, const Point & f
 		std::vector<std::shared_ptr<CComponent>> resComps;
 		for(TResources::nziterator i(upgradableSlots.totalCosts); i.valid(); i++)
 			resComps.push_back(std::make_shared<CComponent>(ComponentType::RESOURCE, i->resType, i->resVal));
+		if(!resComps.size())
+			resComps.push_back(std::make_shared<CComponent>(ComponentType::RESOURCE, static_cast<GameResID>(GameResID::GOLD), 0)); // add at least gold, when there are no costs
 		resComps.back()->newLine = true;
 		for(auto & upgradeInfo : upgradableSlots.upgradeInfos)
 			resComps.push_back(std::make_shared<CComponent>(ComponentType::CREATURE, upgradeInfo.second.getUpgrade(), obj->Slots().at(upgradeInfo.first)->count));

--- a/launcher/firstLaunch/firstlaunch_moc.h
+++ b/launcher/firstLaunch/firstlaunch_moc.h
@@ -42,6 +42,7 @@ class FirstLaunchView : public QWidget
 
 	QString getHeroesInstallDir();
 	void extractGogData();
+	void extractGogDataAsync(QString filePathBin, QString filePathExe);
 	void copyHeroesData(const QString & path = {}, bool move = false);
 
 	// Tab Mod Preset

--- a/lib/mapObjects/CGDwelling.cpp
+++ b/lib/mapObjects/CGDwelling.cpp
@@ -474,9 +474,17 @@ void CGDwelling::heroAcceptsCreatures( const CGHeroInstance *h) const
 			SetAvailableCreatures sac;
 			sac.tid = id;
 			sac.creatures = creatures;
-			sac.creatures[0].first = !h->getArt(ArtifactPosition::MACH1); //ballista
-			sac.creatures[1].first = !h->getArt(ArtifactPosition::MACH3); //first aid tent
-			sac.creatures[2].first = !h->getArt(ArtifactPosition::MACH2); //ammo cart
+
+			for (auto & entry : sac.creatures)
+			{
+				CreatureID creature = entry.second.at(0);
+				ArtifactID warMachine = creature.toCreature()->warMachine;
+
+				if (h->hasArt(warMachine, true, false))
+					entry.first = 0;
+				else
+					entry.first = 1;
+			}
 			cb->sendAndApply(sac);
 		}
 

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -2397,7 +2397,18 @@ bool CGameHandler::recruitCreatures(ObjectInstanceID objid, ObjectInstanceID dst
 		COMPLAIN_RET_FALSE_IF(!hero, "Only hero can buy war machines");
 		COMPLAIN_RET_FALSE_IF(artId == ArtifactID::CATAPULT, "Catapult cannot be recruited!");
 		COMPLAIN_RET_FALSE_IF(nullptr == art, "Invalid war machine artifact");
+		COMPLAIN_RET_FALSE_IF(hero->hasArt(artId),"Hero already has this machine!");
 
+		bool hasFreeSlot = false;
+		for(auto slot : art->getPossibleSlots().at(ArtBearer::HERO))
+			if (hero->getArt(slot) == nullptr)
+				hasFreeSlot = true;
+
+		if (!hasFreeSlot)
+		{
+			auto slot = art->getPossibleSlots().at(ArtBearer::HERO).front();
+			removeArtifact(ArtifactLocation(hero->id, slot));
+		}
 		return giveHeroNewArtifact(hero, artId, ArtifactPosition::FIRST_AVAILABLE);
 	}
 	else


### PR DESCRIPTION
Backports of crashes that were present in 1.6.7 from develop to beta

Potentially may be released in future as 1.6.8, but for now it is mostly to give players who run into them a more stable version.

Will upload to Google Play a bit later, to confirm that these crashes are indeed fixed.