### PR TITLE
Fix shutdown

### DIFF
--- a/AI/Nullkiller/AIGateway.h
+++ b/AI/Nullkiller/AIGateway.h
@@ -22,8 +22,9 @@
 #include "Pathfinding/AIPathfinder.h"
 #include "Engine/Nullkiller.h"
 
-#include <tbb/task_group.h>
-#include <tbb/task_arena.h>
+VCMI_LIB_NAMESPACE_BEGIN
+class AsyncRunner;
+VCMI_LIB_NAMESPACE_END
 
 namespace NKAI
 {
@@ -74,7 +75,7 @@ public:
 	AIStatus status;
 	std::string battlename;
 	std::shared_ptr<CCallback> myCb;
-	std::unique_ptr<tbb::task_group> asyncTasks;
+	std::unique_ptr<AsyncRunner> asyncTasks;
 
 public:
 	ObjectInstanceID selectedObject;

--- a/AI/VCAI/VCAI.h
+++ b/AI/VCAI/VCAI.h
@@ -23,13 +23,11 @@
 #include "../../lib/spells/CSpellHandler.h"
 #include "Pathfinding/AIPathfinder.h"
 
-#include <tbb/task_group.h>
-#include <tbb/task_arena.h>
-
 VCMI_LIB_NAMESPACE_BEGIN
 
 struct QuestInfo;
 class PathfinderCache;
+class AsyncRunner;
 
 VCMI_LIB_NAMESPACE_END
 
@@ -108,7 +106,7 @@ public:
 
 	std::shared_ptr<CCallback> myCb;
 
-	std::unique_ptr<tbb::task_group> asyncTasks;
+	std::unique_ptr<AsyncRunner> asyncTasks;
 	ThreadInterruption makingTurnInterrupption;
 
 public:

--- a/client/CMT.h
+++ b/client/CMT.h
@@ -16,4 +16,3 @@ extern SDL_Renderer * mainRenderer;
 /// Defined in clientapp EntryPoint
 /// TODO: decide on better location for this method
 [[noreturn]] void handleFatalError(const std::string & message, bool terminate);
-[[noreturn]] void quitApplication();

--- a/client/CMT.h
+++ b/client/CMT.h
@@ -16,4 +16,4 @@ extern SDL_Renderer * mainRenderer;
 /// Defined in clientapp EntryPoint
 /// TODO: decide on better location for this method
 [[noreturn]] void handleFatalError(const std::string & message, bool terminate);
-void handleQuit(bool ask = true);
+[[noreturn]] void quitApplication();

--- a/client/CServerHandler.cpp
+++ b/client/CServerHandler.cpp
@@ -703,8 +703,6 @@ void CServerHandler::startCampaignScenario(HighScoreParameter param, std::shared
 			entry->Bool() = true;
 		}
 
-		GAME->mainmenu()->makeActiveInterface();
-
 		if(!ourCampaign->isCampaignFinished())
 			GAME->mainmenu()->openCampaignLobby(ourCampaign);
 		else

--- a/client/GameEngine.cpp
+++ b/client/GameEngine.cpp
@@ -36,6 +36,7 @@
 #include "GameEngineUser.h"
 #include "battle/BattleInterface.h"
 
+#include "../lib/AsyncRunner.h"
 #include "../lib/CThreadHelper.h"
 #include "../lib/CConfigHandler.h"
 
@@ -86,6 +87,8 @@ GameEngine::GameEngine()
 	sound().setVolume((ui32)settings["general"]["sound"].Float());
 	music().setVolume((ui32)settings["general"]["music"].Float());
 	cursorHandlerInstance = std::make_unique<CursorHandler>();
+
+	asyncTasks = std::make_unique<AsyncRunner>();
 }
 
 void GameEngine::handleEvents()

--- a/client/GameEngine.cpp
+++ b/client/GameEngine.cpp
@@ -58,7 +58,9 @@ ObjectConstruction::~ObjectConstruction()
 	ENGINE->captureChildren = !ENGINE->createdObj.empty();
 }
 
-void GameEngine::init()
+GameEngine::GameEngine()
+	: captureChildren(false)
+	, fakeStatusBar(std::make_shared<EmptyStatusBar>())
 {
 	inGuiThread = true;
 
@@ -131,12 +133,6 @@ void GameEngine::updateFrame()
 
 	windows().onFrameRendered();
 	ENGINE->cursor().update();
-}
-
-GameEngine::GameEngine()
-	: captureChildren(false)
-	, fakeStatusBar(std::make_shared<EmptyStatusBar>())
-{
 }
 
 GameEngine::~GameEngine()

--- a/client/GameEngine.cpp
+++ b/client/GameEngine.cpp
@@ -23,21 +23,17 @@
 #include "media/CVideoHandler.h"
 #include "media/CEmptyVideoPlayer.h"
 
-#include "CPlayerInterface.h"
 #include "adventureMap/AdventureMapInterface.h"
 #include "render/Canvas.h"
 #include "render/Colors.h"
-#include "render/Graphics.h"
 #include "render/IFont.h"
 #include "render/EFont.h"
 #include "renderSDL/ScreenHandler.h"
 #include "renderSDL/RenderHandler.h"
-#include "CMT.h"
 #include "GameEngineUser.h"
 #include "battle/BattleInterface.h"
 
 #include "../lib/AsyncRunner.h"
-#include "../lib/CThreadHelper.h"
 #include "../lib/CConfigHandler.h"
 
 #include <SDL_render.h>
@@ -84,8 +80,8 @@ GameEngine::GameEngine()
 
 	soundPlayerInstance = std::make_unique<CSoundHandler>();
 	musicPlayerInstance = std::make_unique<CMusicHandler>();
-	sound().setVolume((ui32)settings["general"]["sound"].Float());
-	music().setVolume((ui32)settings["general"]["music"].Float());
+	sound().setVolume(settings["general"]["sound"].Integer());
+	music().setVolume(settings["general"]["music"].Integer());
 	cursorHandlerInstance = std::make_unique<CursorHandler>();
 
 	asyncTasks = std::make_unique<AsyncRunner>();
@@ -244,7 +240,7 @@ std::shared_ptr<IStatusBar> GameEngine::statusbar()
 	return locked;
 }
 
-void GameEngine::setStatusbar(std::shared_ptr<IStatusBar> newStatusBar)
+void GameEngine::setStatusbar(const std::shared_ptr<IStatusBar> & newStatusBar)
 {
 	currentStatusBar = newStatusBar;
 }

--- a/client/GameEngine.cpp
+++ b/client/GameEngine.cpp
@@ -104,27 +104,33 @@ void GameEngine::fakeMouseMove()
 	});
 }
 
-void GameEngine::renderFrame()
+[[noreturn]] void GameEngine::mainLoop()
 {
+	for (;;)
 	{
-		std::scoped_lock interfaceLock(ENGINE->interfaceMutex);
-
-		engineUser->onUpdate();
-
-		handleEvents();
-		windows().simpleRedraw();
-
-		if (settings["video"]["showfps"].Bool())
-			drawFPSCounter();
-
-		screenHandlerInstance->updateScreenTexture();
-
-		windows().onFrameRendered();
-		ENGINE->cursor().update();
+		input().fetchEvents();
+		updateFrame();
+		screenHandlerInstance->presentScreenTexture();
+		framerate().framerateDelay(); // holds a constant FPS
 	}
+}
 
-	screenHandlerInstance->presentScreenTexture();
-	framerate().framerateDelay(); // holds a constant FPS
+void GameEngine::updateFrame()
+{
+	std::scoped_lock interfaceLock(ENGINE->interfaceMutex);
+
+	engineUser->onUpdate();
+
+	handleEvents();
+	windows().simpleRedraw();
+
+	if (settings["video"]["showfps"].Bool())
+		drawFPSCounter();
+
+	screenHandlerInstance->updateScreenTexture();
+
+	windows().onFrameRendered();
+	ENGINE->cursor().update();
 }
 
 GameEngine::GameEngine()

--- a/client/GameEngine.h
+++ b/client/GameEngine.h
@@ -58,6 +58,8 @@ private:
 	IGameEngineUser *engineUser = nullptr;
 
 	void updateFrame();
+	void handleEvents(); //takes events from queue and calls interested objects
+	void drawFPSCounter(); // draws the FPS to the upper left corner of the screen
 
 public:
 	std::mutex interfaceMutex;
@@ -102,7 +104,9 @@ public:
 	std::shared_ptr<IStatusBar> statusbar();
 
 	/// Set currently active status bar
-	void setStatusbar(std::shared_ptr<IStatusBar>);
+	void setStatusbar(const std::shared_ptr<IStatusBar> &);
+
+	/// Sets engine user that is used as target of callback for events received by engine
 	void setEngineUser(IGameEngineUser * user);
 
 	bool captureChildren; //all newly created objects will get their parents from stack and will be added to parents children list
@@ -111,15 +115,17 @@ public:
 	GameEngine();
 	~GameEngine();
 
+	/// Performs main game loop till game shutdown
+	/// This method never returns, to abort main loop throw GameShutdownException
 	[[noreturn]] void mainLoop();
 
 	/// called whenever SDL_WINDOWEVENT_RESTORED is reported or the user selects a different resolution, requiring to center/resize all windows
 	void onScreenResize(bool resolutionChanged);
 
-	void handleEvents(); //takes events from queue and calls interested objects
+	/// Simulate mouse movement to force refresh UI state that updates on mouse move
 	void fakeMouseMove();
-	void drawFPSCounter(); // draws the FPS to the upper left corner of the screen
 
+	/// Returns true for calls made from main (GUI) thread, false othervice
 	bool amIGuiThread();
 
 	/// Calls provided functor in main thread on next execution frame

--- a/client/GameEngine.h
+++ b/client/GameEngine.h
@@ -108,7 +108,6 @@ public:
 	GameEngine();
 	~GameEngine();
 
-	void init();
 	[[noreturn]] void mainLoop();
 
 	/// called whenever SDL_WINDOWEVENT_RESTORED is reported or the user selects a different resolution, requiring to center/resize all windows

--- a/client/GameEngine.h
+++ b/client/GameEngine.h
@@ -11,6 +11,7 @@
 
 VCMI_LIB_NAMESPACE_BEGIN
 class Point;
+class AsyncRunner;
 class Rect;
 VCMI_LIB_NAMESPACE_END
 
@@ -52,6 +53,7 @@ private:
 	std::unique_ptr<IMusicPlayer> musicPlayerInstance;
 	std::unique_ptr<CursorHandler> cursorHandlerInstance;
 	std::unique_ptr<IVideoPlayer> videoPlayerInstance;
+	std::unique_ptr<AsyncRunner> asyncTasks;
 
 	IGameEngineUser *engineUser = nullptr;
 
@@ -68,6 +70,7 @@ public:
 	EventDispatcher & events();
 	InputHandler & input();
 
+	AsyncRunner & async() { return *asyncTasks; }
 	IGameEngineUser & user() { return *engineUser; }
 	ISoundPlayer & sound() { return *soundPlayerInstance; }
 	IMusicPlayer & music() { return *musicPlayerInstance; }

--- a/client/GameEngine.h
+++ b/client/GameEngine.h
@@ -55,6 +55,8 @@ private:
 
 	IGameEngineUser *engineUser = nullptr;
 
+	void updateFrame();
+
 public:
 	std::mutex interfaceMutex;
 
@@ -107,7 +109,7 @@ public:
 	~GameEngine();
 
 	void init();
-	void renderFrame();
+	[[noreturn]] void mainLoop();
 
 	/// called whenever SDL_WINDOWEVENT_RESTORED is reported or the user selects a different resolution, requiring to center/resize all windows
 	void onScreenResize(bool resolutionChanged);

--- a/client/GameEngineUser.h
+++ b/client/GameEngineUser.h
@@ -20,6 +20,9 @@ public:
 	/// Called on every game tick for game to update its state
 	virtual void onUpdate() = 0;
 
+	/// Called when app shutdown has been requested in any way - exit button, Alt-F4, etc
+	virtual void onShutdownRequested(bool askForConfirmation) = 0;
+
 	/// Returns true if all input events should be captured and ignored
 	virtual bool capturedAllEvents() = 0;
 };

--- a/client/GameInstance.cpp
+++ b/client/GameInstance.cpp
@@ -100,13 +100,15 @@ bool GameInstance::capturedAllEvents()
 
 void GameInstance::onShutdownRequested(bool ask)
 {
+	auto doQuit = [](){ throw GameShutdownException(); };
+
 	if(!ask)
-		quitApplication();
+		doQuit();
 	else
 	{
 		if (interface())
-			interface()->showYesNoDialog(LIBRARY->generaltexth->allTexts[69], quitApplication, nullptr);
+			interface()->showYesNoDialog(LIBRARY->generaltexth->allTexts[69], doQuit, nullptr);
 		else
-			CInfoWindow::showYesNoDialog(LIBRARY->generaltexth->allTexts[69], {}, quitApplication, {}, PlayerColor(1));
+			CInfoWindow::showYesNoDialog(LIBRARY->generaltexth->allTexts[69], {}, doQuit, {}, PlayerColor(1));
 	}
 }

--- a/client/GameInstance.cpp
+++ b/client/GameInstance.cpp
@@ -11,12 +11,16 @@
 #include "GameInstance.h"
 
 #include "CPlayerInterface.h"
+#include "CMT.h"
 #include "CServerHandler.h"
 #include "mapView/mapHandler.h"
 #include "globalLobby/GlobalLobbyClient.h"
 #include "mainmenu/CMainMenu.h"
+#include "windows/InfoWindows.h"
 
 #include "../lib/CConfigHandler.h"
+#include "../lib/GameLibrary.h"
+#include "../lib/texts/CGeneralTextHandler.h"
 
 std::unique_ptr<GameInstance> GAME = nullptr;
 
@@ -92,4 +96,17 @@ bool GameInstance::capturedAllEvents()
 		return interfaceInstance->capturedAllEvents();
 	else
 		return false;
+}
+
+void GameInstance::onShutdownRequested(bool ask)
+{
+	if(!ask)
+		quitApplication();
+	else
+	{
+		if (interface())
+			interface()->showYesNoDialog(LIBRARY->generaltexth->allTexts[69], quitApplication, nullptr);
+		else
+			CInfoWindow::showYesNoDialog(LIBRARY->generaltexth->allTexts[69], {}, quitApplication, {}, PlayerColor(1));
+	}
 }

--- a/client/GameInstance.h
+++ b/client/GameInstance.h
@@ -45,6 +45,7 @@ public:
 	void onGlobalLobbyInterfaceActivated() final;
 	void onUpdate() final;
 	bool capturedAllEvents() final;
+	void onShutdownRequested(bool askForConfirmation) final;
 };
 
 extern std::unique_ptr<GameInstance> GAME;

--- a/client/GameInstance.h
+++ b/client/GameInstance.h
@@ -21,6 +21,15 @@ VCMI_LIB_NAMESPACE_BEGIN
 class INetworkHandler;
 VCMI_LIB_NAMESPACE_END
 
+class GameShutdownException final : public std::exception
+{
+public:
+	const char* what() const noexcept final
+	{
+		return "Game shutdown has been requested";
+	}
+};
+
 class GameInstance final : boost::noncopyable, public IGameEngineUser
 {
 	std::unique_ptr<CServerHandler> serverInstance;

--- a/client/NetPacksClient.cpp
+++ b/client/NetPacksClient.cpp
@@ -418,7 +418,7 @@ void ApplyClientNetPackVisitor::visitPlayerEndsGame(PlayerEndsGame & pack)
 	{
 		logAi->info("Red player %s. Ending game.", pack.victoryLossCheckResult.victory() ? "won" : "lost");
 
-		handleQuit(settings["session"]["spectate"].Bool()); // if spectator is active ask to close client or not
+		GAME->onShutdownRequested(settings["session"]["spectate"].Bool()); // if spectator is active ask to close client or not
 	}
 }
 

--- a/client/adventureMap/AdventureMapShortcuts.cpp
+++ b/client/adventureMap/AdventureMapShortcuts.cpp
@@ -354,14 +354,8 @@ void AdventureMapShortcuts::quitGame()
 {
 	GAME->interface()->showYesNoDialog(
 		LIBRARY->generaltexth->allTexts[578],
-		[]()
-		{
-			ENGINE->dispatchMainThread( []()
-			{
-				handleQuit(false);
-			});
-		},
-		0
+		[](){ GAME->onShutdownRequested(false);},
+		nullptr
 		);
 }
 

--- a/client/eventsSDL/InputHandler.cpp
+++ b/client/eventsSDL/InputHandler.cpp
@@ -19,6 +19,7 @@
 #include "InputSourceGameController.h"
 
 #include "../GameEngine.h"
+#include "../GameEngineUser.h"
 #include "../gui/CursorHandler.h"
 #include "../gui/EventDispatcher.h"
 #include "../gui/MouseButton.h"
@@ -194,9 +195,9 @@ void InputHandler::preprocessEvent(const SDL_Event & ev)
 	{
 		std::scoped_lock interfaceLock(ENGINE->interfaceMutex);
 #ifdef VCMI_ANDROID
-		handleQuit(false);
+		ENGINE->user().onShutdownRequested(false);
 #else
-		handleQuit(true);
+		ENGINE->user().onShutdownRequested(true);
 #endif
 		return;
 	}
@@ -206,14 +207,14 @@ void InputHandler::preprocessEvent(const SDL_Event & ev)
 		{
 			// FIXME: dead code? Looks like intercepted by OS/SDL and delivered as SDL_Quit instead?
 			std::scoped_lock interfaceLock(ENGINE->interfaceMutex);
-			handleQuit(true);
+			ENGINE->user().onShutdownRequested(true);
 			return;
 		}
 
 		if(ev.key.keysym.scancode == SDL_SCANCODE_AC_BACK && !settings["input"]["handleBackRightMouseButton"].Bool())
 		{
 			std::scoped_lock interfaceLock(ENGINE->interfaceMutex);
-			handleQuit(true);
+			ENGINE->user().onShutdownRequested(true);
 			return;
 		}
 	}

--- a/client/mainmenu/CMainMenu.cpp
+++ b/client/mainmenu/CMainMenu.cpp
@@ -64,14 +64,6 @@
 
 ISelectionScreenInfo * SEL = nullptr;
 
-static void do_quit()
-{
-	ENGINE->dispatchMainThread([]()
-	{
-		handleQuit(false);
-	});
-}
-
 CMenuScreen::CMenuScreen(const JsonNode & configNode)
 	: CWindowObject(BORDERED), config(configNode)
 {
@@ -210,7 +202,7 @@ static std::function<void()> genCommand(CMenuScreen * menu, std::vector<std::str
 			break;
 			case 4: //exit
 			{
-				return []() { CInfoWindow::showYesNoDialog(LIBRARY->generaltexth->allTexts[69], std::vector<std::shared_ptr<CComponent>>(), do_quit, 0, PlayerColor(1)); };
+				return []() { CInfoWindow::showYesNoDialog(LIBRARY->generaltexth->allTexts[69], std::vector<std::shared_ptr<CComponent>>(), [](){GAME->onShutdownRequested(false);}, 0, PlayerColor(1)); };
 			}
 			break;
 			case 5: //highscores

--- a/client/media/CAudioBase.cpp
+++ b/client/media/CAudioBase.cpp
@@ -37,7 +37,8 @@ CAudioBase::~CAudioBase()
 	--initializationCounter;
 
 	if(initializationCounter == 0 && initializeSuccess)
+	{
 		Mix_CloseAudio();
-
-	initializeSuccess = false;
+		initializeSuccess = false;
+	}
 }

--- a/client/media/CMusicHandler.cpp
+++ b/client/media/CMusicHandler.cpp
@@ -91,7 +91,6 @@ CMusicHandler::~CMusicHandler()
 		std::scoped_lock guard(mutex);
 
 		Mix_HookMusicFinished(nullptr);
-		current->stop();
 
 		current.reset();
 		next.reset();

--- a/client/media/CMusicHandler.cpp
+++ b/client/media/CMusicHandler.cpp
@@ -232,8 +232,7 @@ MusicEntry::~MusicEntry()
 
 	if(loop == 0 && Mix_FadingMusic() != MIX_NO_FADING)
 	{
-		assert(0);
-		logGlobal->error("Attempt to delete music while fading out!");
+		logGlobal->trace("Halting playback of music file %s", currentName.getOriginalName());
 		Mix_HaltMusic();
 	}
 

--- a/client/media/CSoundHandler.cpp
+++ b/client/media/CSoundHandler.cpp
@@ -64,6 +64,12 @@ CSoundHandler::~CSoundHandler()
 			if(chunk.second.first)
 				Mix_FreeChunk(chunk.second.first);
 		}
+
+		for(auto & chunk : soundChunksRaw)
+		{
+			if(chunk.second.first)
+				Mix_FreeChunk(chunk.second.first);
+		}
 	}
 }
 

--- a/client/media/CSoundHandler.cpp
+++ b/client/media/CSoundHandler.cpp
@@ -56,6 +56,7 @@ CSoundHandler::~CSoundHandler()
 {
 	if(isInitialized())
 	{
+		Mix_ChannelFinished(nullptr);
 		Mix_HaltChannel(-1);
 
 		for(auto & chunk : soundChunks)

--- a/client/render/IScreenHandler.h
+++ b/client/render/IScreenHandler.h
@@ -25,9 +25,6 @@ public:
 	/// Updates window state after fullscreen state has been changed in settings
 	virtual void onScreenResize() = 0;
 
-	/// De-initializes window state
-	virtual void close() = 0;
-
 	/// Fills screen with black color, erasing any existing content
 	virtual void clearScreen() = 0;
 

--- a/client/renderSDL/SDLImage.cpp
+++ b/client/renderSDL/SDLImage.cpp
@@ -24,7 +24,6 @@
 #include "../../lib/CConfigHandler.h"
 
 #include <tbb/parallel_for.h>
-#include <tbb/task_arena.h>
 
 #include <SDL_image.h>
 #include <SDL_surface.h>
@@ -400,6 +399,9 @@ std::shared_ptr<const ISharedImage> SDLImageShared::horizontalFlip() const
 	ret->margins.y = fullSize.y - surf->h - margins.y;
 	ret->fullSize = fullSize;
 
+	// erase our own reference
+	SDL_FreeSurface(flipped);
+
 	return ret;
 }
 
@@ -417,6 +419,9 @@ std::shared_ptr<const ISharedImage> SDLImageShared::verticalFlip() const
 	ret->margins.x = fullSize.x - surf->w - margins.x;
 	ret->margins.y = margins.y;
 	ret->fullSize = fullSize;
+
+	// erase our own reference
+	SDL_FreeSurface(flipped);
 
 	return ret;
 }

--- a/client/renderSDL/SDLImage.cpp
+++ b/client/renderSDL/SDLImage.cpp
@@ -20,6 +20,7 @@
 #include "../GameEngine.h"
 #include "../render/IScreenHandler.h"
 
+#include "../../lib/AsyncRunner.h"
 #include "../../lib/CConfigHandler.h"
 
 #include <tbb/parallel_for.h>
@@ -256,8 +257,6 @@ std::shared_ptr<const ISharedImage> SDLImageShared::scaleInteger(int factor, SDL
 
 SDLImageShared::SDLImageShared(const SDLImageShared * from, int integerScaleFactor, EScalingAlgorithm algorithm)
 {
-	static tbb::task_arena upscalingArena;
-
 	upscalingInProgress = true;
 
 	auto scaler = std::make_shared<SDLImageScaler>(from->surf, Rect(from->margins, from->fullSize), true);
@@ -273,7 +272,7 @@ SDLImageShared::SDLImageShared(const SDLImageShared * from, int integerScaleFact
 	};
 
 	if(settings["video"]["asyncUpscaling"].Bool())
-		upscalingArena.enqueue(scalingTask);
+		ENGINE->async().run(scalingTask);
 	else
 		scalingTask();
 }

--- a/client/renderSDL/ScreenHandler.cpp
+++ b/client/renderSDL/ScreenHandler.cpp
@@ -595,7 +595,7 @@ void ScreenHandler::destroyWindow()
 	}
 }
 
-void ScreenHandler::close()
+ScreenHandler::~ScreenHandler()
 {
 	if(settings["general"]["notifications"].Bool())
 		NotificationHandler::destroy();

--- a/client/renderSDL/ScreenHandler.h
+++ b/client/renderSDL/ScreenHandler.h
@@ -96,12 +96,10 @@ public:
 
 	/// Creates and initializes screen, window and SDL state
 	ScreenHandler();
+	~ScreenHandler();
 
 	/// Updates and potentially recreates target screen to match selected fullscreen status
 	void onScreenResize() final;
-
-	/// De-initializes and destroys screen, window and SDL state
-	void close() final;
 
 	/// Fills screen with black color, erasing any existing content
 	void clearScreen() final;

--- a/client/windows/settings/SettingsMainWindow.cpp
+++ b/client/windows/settings/SettingsMainWindow.cpp
@@ -125,12 +125,9 @@ void SettingsMainWindow::quitGameButtonCallback()
 		[this]()
 		{
 			close();
-			ENGINE->dispatchMainThread( []()
-			{
-				handleQuit(false);
-			});
+			ENGINE->user().onShutdownRequested(false);
 		},
-		0
+		nullptr
 	);
 }
 

--- a/clientapp/EntryPoint.cpp
+++ b/clientapp/EntryPoint.cpp
@@ -399,6 +399,8 @@ int main(int argc, char * argv[])
 	{
 		quitApplication();
 	}
+
+	return 0;
 }
 
 [[noreturn]] static void quitApplication()

--- a/clientapp/EntryPoint.cpp
+++ b/clientapp/EntryPoint.cpp
@@ -235,14 +235,14 @@ int main(int argc, char * argv[])
 	}
 
 	Settings session = settings.write["session"];
-	auto setSettingBool = [&](std::string key, std::string arg) {
+	auto setSettingBool = [&](const std::string & key, const std::string & arg) {
 		Settings s = settings.write(vstd::split(key, "/"));
 		if(vm.count(arg))
 			s->Bool() = true;
 		else if(s->isNull())
 			s->Bool() = false;
 	};
-	auto setSettingInteger = [&](std::string key, std::string arg, si64 defaultValue) {
+	auto setSettingInteger = [&](const std::string & key, const std::string & arg, si64 defaultValue) {
 		Settings s = settings.write(vstd::split(key, "/"));
 		if(vm.count(arg))
 			s->Integer() = vm[arg].as<si64>();
@@ -280,7 +280,7 @@ int main(int argc, char * argv[])
 	logGlobal->debug("settings = %s", settings.toJsonNode().toString());
 
 	// Some basic data validation to produce better error messages in cases of incorrect install
-	auto testFile = [](std::string filename, std::string message)
+	auto testFile = [](const std::string & filename, const std::string & message)
 	{
 		if (!CResourceHandler::get()->existsResource(ResourcePath(filename)))
 			handleFatalError(message, false);

--- a/clientapp/EntryPoint.cpp
+++ b/clientapp/EntryPoint.cpp
@@ -68,11 +68,7 @@ namespace po_style = boost::program_options::command_line_style;
 static std::atomic<bool> headlessQuit = false;
 static std::optional<std::string> criticalInitializationError;
 
-#ifndef VCMI_IOS
-void processCommand(const std::string &message);
-#endif
 [[noreturn]] static void quitApplication();
-static void mainLoop();
 
 static CBasicLogConfigurator *logConfig;
 
@@ -387,12 +383,15 @@ int main(int argc, char * argv[])
 			GAME->mainmenu()->playMusic();
 	}
 	
-	std::vector<std::string> names;
+#ifndef VCMI_UNIX
+	// on Linux, name of main thread is also name of our process. Which we don't want to change
+	setThreadName("MainGUI");
+#endif
 
 	if(!settings["session"]["headless"].Bool())
 	{
 		checkForModLoadingFailure();
-		mainLoop();
+		ENGINE->mainLoop();
 	}
 	else
 	{
@@ -403,23 +402,6 @@ int main(int argc, char * argv[])
 
 		quitApplication();
 	}
-
-	return 0;
-}
-
-static void mainLoop()
-{
-#ifndef VCMI_UNIX
-	// on Linux, name of main thread is also name of our process. Which we don't want to change
-	setThreadName("MainGUI");
-#endif
-
-	while(1) //main SDL events loop
-	{
-		ENGINE->input().fetchEvents();
-		ENGINE->renderFrame();
-	}
-}
 
 [[noreturn]] static void quitApplicationImmediately(int error_code)
 {

--- a/clientapp/EntryPoint.cpp
+++ b/clientapp/EntryPoint.cpp
@@ -27,6 +27,7 @@
 #include "../client/windows/CMessage.h"
 #include "../client/windows/InfoWindows.h"
 
+#include "../lib/AsyncRunner.h"
 #include "../lib/CConsoleHandler.h"
 #include "../lib/CConfigHandler.h"
 #include "../lib/CThreadHelper.h"
@@ -416,6 +417,9 @@ int main(int argc, char * argv[])
 		CMessage::dispose();
 		vstd::clear_pointer(graphics);
 	}
+
+	// must be executed before reset - since unique_ptr resets pointer to null before calling destructor
+	ENGINE->async().wait();
 
 	ENGINE.reset();
 

--- a/clientapp/EntryPoint.cpp
+++ b/clientapp/EntryPoint.cpp
@@ -62,8 +62,6 @@ namespace po_style = boost::program_options::command_line_style;
 static std::atomic<bool> headlessQuit = false;
 static std::optional<std::string> criticalInitializationError;
 
-[[noreturn]] static void quitApplication();
-
 static void init()
 {
 	try
@@ -397,14 +395,9 @@ int main(int argc, char * argv[])
 	}
 	catch (const GameShutdownException & )
 	{
-		quitApplication();
+		// no-op - just break out of main loop
 	}
 
-	return 0;
-}
-
-[[noreturn]] static void quitApplication()
-{
 	GAME->server().endNetwork();
 
 	if(!settings["session"]["headless"].Bool())
@@ -420,29 +413,16 @@ int main(int argc, char * argv[])
 	if(!settings["session"]["headless"].Bool())
 	{
 		CMessage::dispose();
-
 		vstd::clear_pointer(graphics);
 	}
 
+	ENGINE.reset();
+
 	vstd::clear_pointer(LIBRARY);
-
-	// sometimes leads to a hang. TODO: investigate
-	//vstd::clear_pointer(console);// should be removed after everything else since used by logging
-
-	if(!settings["session"]["headless"].Bool())
-		ENGINE->screenHandler().close();
-
-	//if(logConfig != nullptr)
-	//{
-	//	logConfig->deconfigure();
-	//	delete logConfig;
-	//	logConfig = nullptr;
-	//}
-
-	//ENGINE.reset();
+	logConfigurator.deconfigure();
 
 	std::cout << "Ending...\n";
-	::exit(0);
+	return 0;
 }
 
 /// Notify user about encountered fatal error and terminate the game

--- a/clientapp/EntryPoint.cpp
+++ b/clientapp/EntryPoint.cpp
@@ -78,18 +78,17 @@ static CBasicLogConfigurator *logConfig;
 
 static void init()
 {
-	CStopWatch tmh;
 	try
 	{
-		loadDLLClasses();
+		CStopWatch tmh;
+		LIBRARY->initializeLibrary();
+		logGlobal->info("Initializing VCMI_Lib: %d ms", tmh.getDiff());
 	}
 	catch (const DataLoadingException & e)
 	{
 		criticalInitializationError = e.what();
 		return;
 	}
-
-	logGlobal->info("Initializing VCMI_Lib: %d ms", tmh.getDiff());
 
 	// Debug code to load all maps on start
 	//ClientCommandManager commandController;
@@ -241,7 +240,8 @@ int main(int argc, char * argv[])
 	// Init filesystem and settings
 	try
 	{
-		preinitDLL(false);
+		LIBRARY = new GameLibrary;
+		LIBRARY->initializeFilesystem(false);
 	}
 	catch (const DataLoadingException & e)
 	{

--- a/lib/AsyncRunner.h
+++ b/lib/AsyncRunner.h
@@ -1,0 +1,40 @@
+/*
+ * AsyncRunner.h, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
+#pragma once
+
+#include <tbb/task_group.h>
+#include <tbb/task_arena.h>
+
+VCMI_LIB_NAMESPACE_BEGIN
+
+class AsyncRunner : boost::noncopyable
+{
+	tbb::task_arena arena;
+	tbb::task_group taskGroup;
+
+public:
+	template <typename Functor>
+	void run(Functor && f)
+	{
+		arena.enqueue(taskGroup.defer(std::forward<Functor>(f)));
+	}
+
+	void wait()
+	{
+		taskGroup.wait();
+	}
+
+	~AsyncRunner()
+	{
+		wait();
+	}
+};
+
+VCMI_LIB_NAMESPACE_END

--- a/lib/AsyncRunner.h
+++ b/lib/AsyncRunner.h
@@ -9,23 +9,27 @@
  */
 #pragma once
 
-#include <tbb/task_group.h>
 #include <tbb/task_arena.h>
+#include <tbb/task_group.h>
 
 VCMI_LIB_NAMESPACE_BEGIN
 
+/// Helper class for running asynchronous tasks using TBB thread pool
 class AsyncRunner : boost::noncopyable
 {
 	tbb::task_arena arena;
 	tbb::task_group taskGroup;
 
 public:
-	template <typename Functor>
+	/// Runs the provided functor asynchronously on a thread from the TBB worker pool.
+	template<typename Functor>
 	void run(Functor && f)
 	{
 		arena.enqueue(taskGroup.defer(std::forward<Functor>(f)));
 	}
 
+	/// Waits for all previously enqueued task.
+	/// Re-entrable - waiting for tasks does not prevent submitting new tasks
 	void wait()
 	{
 		taskGroup.wait();

--- a/lib/CConsoleHandler.cpp
+++ b/lib/CConsoleHandler.cpp
@@ -251,8 +251,9 @@ int CConsoleHandler::run()
 				if ( cb )
 					cb(buffer, false);
 		}
-		else
-			std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+		std::unique_lock guard(shutdownMutex);
+		shutdownVariable.wait_for(guard, std::chrono::seconds(1));
 
 		if (shutdownPending)
 			return -1;
@@ -308,6 +309,7 @@ void CConsoleHandler::end()
 	{
 #ifndef _MSC_VER
 		shutdownPending = true;
+		shutdownVariable.notify_all();
 #else
 		TerminateThread(thread.native_handle(),0);
 #endif

--- a/lib/CConsoleHandler.h
+++ b/lib/CConsoleHandler.h
@@ -94,6 +94,8 @@ private:
 	//function to be called when message is received - string: message, bool: whether call was made from in-game console
 	std::function<void(const std::string &, bool)> cb;
 
+	std::condition_variable shutdownVariable;
+	std::mutex shutdownMutex;
 	std::atomic<bool> shutdownPending = false;
 
 	std::mutex smx;

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -693,6 +693,7 @@ set(lib_MAIN_HEADERS
 
 	AI_Base.h
 	ArtifactUtils.h
+	AsyncRunner.h
 	BattleFieldHandler.h
 	CAndroidVMHelper.h
 	CArtHandler.h

--- a/lib/GameLibrary.h
+++ b/lib/GameLibrary.h
@@ -51,10 +51,6 @@ namespace scripting
 /// Loads and constructs several handlers
 class DLL_LINKAGE GameLibrary final : public Services
 {
-
-	std::shared_ptr<CContentHandler> getContent() const;
-	void setContent(std::shared_ptr<CContentHandler> content);
-
 public:
 	const ArtifactService * artifacts() const override;
 	const CreatureService * creatures() const override;
@@ -76,38 +72,44 @@ public:
 	const IBonusTypeHandler * getBth() const; //deprecated
 	const CIdentifierStorage * identifiers() const;
 
-	std::shared_ptr<CArtHandler> arth;
-	std::shared_ptr<CBonusTypeHandler> bth;
-	std::shared_ptr<CHeroHandler> heroh;
-	std::shared_ptr<CHeroClassHandler> heroclassesh;
-	std::shared_ptr<CCreatureHandler> creh;
-	std::shared_ptr<CSpellHandler> spellh;
-	std::shared_ptr<CSkillHandler> skillh;
+	std::unique_ptr<CArtHandler> arth;
+	std::unique_ptr<CBonusTypeHandler> bth;
+	std::unique_ptr<CHeroHandler> heroh;
+	std::unique_ptr<CHeroClassHandler> heroclassesh;
+	std::unique_ptr<CCreatureHandler> creh;
+	std::unique_ptr<CSpellHandler> spellh;
+	std::unique_ptr<CSkillHandler> skillh;
 	// TODO: Remove ObjectHandler altogether?
-	std::shared_ptr<CObjectHandler> objh;
-	std::shared_ptr<CObjectClassesHandler> objtypeh;
-	std::shared_ptr<CTownHandler> townh;
-	std::shared_ptr<CGeneralTextHandler> generaltexth;
-	std::shared_ptr<CModHandler> modh;
-	std::shared_ptr<TerrainTypeHandler> terrainTypeHandler;
-	std::shared_ptr<RoadTypeHandler> roadTypeHandler;
-	std::shared_ptr<RiverTypeHandler> riverTypeHandler;
-	std::shared_ptr<CIdentifierStorage> identifiersHandler;
-	std::shared_ptr<CTerrainViewPatternConfig> terviewh;
-	std::shared_ptr<CRmgTemplateStorage> tplh;
-	std::shared_ptr<BattleFieldHandler> battlefieldsHandler;
-	std::shared_ptr<ObstacleHandler> obstacleHandler;
-	std::shared_ptr<GameSettings> settingsHandler;
-	std::shared_ptr<ObstacleSetHandler> biomeHandler;
+	std::unique_ptr<CObjectHandler> objh;
+	std::unique_ptr<CObjectClassesHandler> objtypeh;
+	std::unique_ptr<CTownHandler> townh;
+	std::unique_ptr<CGeneralTextHandler> generaltexth;
+	std::unique_ptr<CModHandler> modh;
+	std::unique_ptr<TerrainTypeHandler> terrainTypeHandler;
+	std::unique_ptr<RoadTypeHandler> roadTypeHandler;
+	std::unique_ptr<RiverTypeHandler> riverTypeHandler;
+	std::unique_ptr<CIdentifierStorage> identifiersHandler;
+	std::unique_ptr<CTerrainViewPatternConfig> terviewh;
+	std::unique_ptr<CRmgTemplateStorage> tplh;
+	std::unique_ptr<BattleFieldHandler> battlefieldsHandler;
+	std::unique_ptr<ObstacleHandler> obstacleHandler;
+	std::unique_ptr<GameSettings> settingsHandler;
+	std::unique_ptr<ObstacleSetHandler> biomeHandler;
 
 #if SCRIPTING_ENABLED
-	std::shared_ptr<scripting::ScriptHandler> scriptHandler;
+	std::unique_ptr<scripting::ScriptHandler> scriptHandler;
 #endif
 
-	GameLibrary(); //c-tor, loads .lods and NULLs handlers
+	GameLibrary();
 	~GameLibrary();
-	void init(bool onlyEssential); //uses standard config file
 
+	/// initializes settings and filesystem
+	void initializeFilesystem(bool extractArchives);
+
+	/// Loads all game entities
+	void initializeLibrary();
+
+private:
 	// basic initialization. should be called before init(). Can also extract original H3 archives
 	void loadFilesystem(bool extractArchives);
 	void loadModFilesystem();
@@ -118,9 +120,5 @@ public:
 };
 
 extern DLL_LINKAGE GameLibrary * LIBRARY;
-
-DLL_LINKAGE void preinitDLL(bool extractArchives);
-DLL_LINKAGE void loadDLLClasses(bool onlyEssential = false);
-
 
 VCMI_LIB_NAMESPACE_END

--- a/lib/mapObjects/CGCreature.h
+++ b/lib/mapObjects/CGCreature.h
@@ -27,7 +27,7 @@ public:
 		COMPLIANT = 0, FRIENDLY = 1, AGGRESSIVE = 2, HOSTILE = 3, SAVAGE = 4
 	};
 
-	ui32 identifier; //unique code for this monster (used in missions)
+	ui32 identifier = -1; //unique code for this monster (used in missions)
 	si8 character = 0; //character of this set of creatures (0 - the most friendly, 4 - the most hostile) => on init changed to -4 (compliant) ... 10 value (savage)
 	MetaString message; //message printed for attacking hero
 	TResources resources; // resources given to hero that has won with monsters

--- a/lib/modding/CModHandler.cpp
+++ b/lib/modding/CModHandler.cpp
@@ -309,7 +309,7 @@ void CModHandler::load()
 	logMod->info("\tAll game content loaded");
 }
 
-void CModHandler::afterLoad(bool onlyEssential)
+void CModHandler::afterLoad()
 {
 	JsonNode modSettings;
 	for (const auto & modEntry : getActiveMods())

--- a/lib/modding/CModHandler.h
+++ b/lib/modding/CModHandler.h
@@ -62,7 +62,7 @@ public:
 
 	/// load content from all available mods
 	void load();
-	void afterLoad(bool onlyEssential);
+	void afterLoad();
 
 	CModHandler();
 	~CModHandler();

--- a/mapeditor/mainwindow.cpp
+++ b/mapeditor/mainwindow.cpp
@@ -69,16 +69,6 @@ QPixmap pixmapFromJson(const QJsonValue &val)
   return p;
 }
 
-void init()
-{
-	loadDLLClasses();
-
-	Settings config = settings.write["session"]["editor"];
-	config->Bool() = true;
-
-	logGlobal->info("Initializing VCMI_Lib");
-}
-
 void MainWindow::loadUserSettings()
 {
 	//load window settings
@@ -190,7 +180,8 @@ MainWindow::MainWindow(QWidget* parent) :
 	logGlobal->info("The log file will be saved to %s", logPath);
 
 	//init
-	preinitDLL(extractionOptions.extractArchives);
+	LIBRARY = new GameLibrary();
+	LIBRARY->initializeFilesystem(extractionOptions.extractArchives);
 
 	// Initialize logging based on settings
 	logConfig->configure();
@@ -250,7 +241,12 @@ MainWindow::MainWindow(QWidget* parent) :
 	loadUserSettings(); //For example window size
 	setTitle();
 
-	init();
+	LIBRARY->initializeLibrary();
+
+	Settings config = settings.write["session"]["editor"];
+	config->Bool() = true;
+
+	logGlobal->info("Initializing VCMI_Lib");
 
 	graphics = new Graphics(); // should be before curh->init()
 	graphics->load();//must be after Content loading but should be in main thread

--- a/serverapp/EntryPoint.cpp
+++ b/serverapp/EntryPoint.cpp
@@ -78,10 +78,11 @@ int main(int argc, const char * argv[])
 
 	boost::program_options::variables_map opts;
 	handleCommandOptions(argc, argv, opts);
-	preinitDLL(false);
+	LIBRARY = new GameLibrary;
+	LIBRARY->initializeFilesystem(false);
 	logConfigurator.configure();
 
-	loadDLLClasses();
+	LIBRARY->initializeLibrary();
 	std::srand(static_cast<uint32_t>(time(nullptr)));
 
 	{

--- a/test/CVcmiTestConfig.cpp
+++ b/test/CVcmiTestConfig.cpp
@@ -22,8 +22,9 @@
 
 void CVcmiTestConfig::SetUp()
 {
-	preinitDLL(true);
-	loadDLLClasses(true);
+	LIBRARY = new GameLibrary;
+	LIBRARY->initializeFilesystem(false);
+	LIBRARY->initializeLibrary();
 
 	/* TEST_DATA_DIR may be wrong, if yes below test don't run,
 	find your test data folder in your build and change TEST_DATA_DIR for it*/


### PR DESCRIPTION
- Fixes #5536 
- Fixes #5539

This PR reworks shutdown procedure and fixes multiple potential crashes that sometimes happen on app shutdown.

Engine shutdown is now performed by throwing an exception while in main thread instead of calling special function that ultimately calls `exit()`. This means that all local variables are correctly destroyed as part of stack unwinding, or in case of `main` method - destroyed as part of returning from function.

All workarounds for shutdown crashes, such deliberately not shut down subsystems are now removed.

Fixes multiple crashes on shutdown that had various reproducibility:
- Fixes crash on shutdown if there is ongoing images upscaling using xbrz (however may result in small delay on shutdown since game now waits for them to be finished)
- Fixes crash on shutdown during music fade out
- Fixes crash on shutdown during sound playback
- Fixes SDL_Mixer not being shut down correctly on engine destruction

Fixed several memory leaks (mostly some memory not being released on app shutdown)

Also as part of general code cleanup:
- Library handlers are now `unique_ptr`'s and not `shared_ptr` since they can only be owned by library
- Main loop is now method of game engine, and not implemented directly in `main` method