### PR TITLE
optimize skip video keys

### DIFF
--- a/client/mainmenu/CPrologEpilogVideo.cpp
+++ b/client/mainmenu/CPrologEpilogVideo.cpp
@@ -14,6 +14,7 @@
 #include "../media/IMusicPlayer.h"
 #include "../media/ISoundPlayer.h"
 #include "../GameEngine.h"
+#include "../gui/Shortcut.h"
 #include "../widgets/TextControls.h"
 #include "../widgets/VideoWidget.h"
 #include "../widgets/Images.h"
@@ -92,7 +93,7 @@ void CPrologEpilogVideo::show(Canvas & to)
 		text->showAll(to); // blit text over video, if needed
 }
 
-void CPrologEpilogVideo::clickPressed(const Point & cursorPosition)
+void CPrologEpilogVideo::exit()
 {
 	ENGINE->music().setVolume(ENGINE->music().getVolume() * 2); // restore background volume
 	close();
@@ -101,4 +102,15 @@ void CPrologEpilogVideo::clickPressed(const Point & cursorPosition)
 	ENGINE->sound().stopSound(videoSoundHandle);
 	if(exitCb)
 		exitCb();
+}
+
+void CPrologEpilogVideo::clickPressed(const Point & cursorPosition)
+{
+	exit();
+}
+
+void CPrologEpilogVideo::keyPressed(EShortcut key)
+{
+	if(key == EShortcut::GLOBAL_RETURN)
+		exit();
 }

--- a/client/mainmenu/CPrologEpilogVideo.h
+++ b/client/mainmenu/CPrologEpilogVideo.h
@@ -30,6 +30,8 @@ class CPrologEpilogVideo : public CWindowObject
 	std::shared_ptr<VideoWidget> videoPlayer;
 	std::shared_ptr<CFilledTexture> backgroundAroundMenu;
 
+	void exit();
+
 	bool voiceStopped = false;
 
 public:
@@ -37,5 +39,6 @@ public:
 
 	void tick(uint32_t msPassed) override;
 	void clickPressed(const Point & cursorPosition) override;
+	void keyPressed(EShortcut key) override;
 	void show(Canvas & to) override;
 };

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -1734,7 +1734,8 @@ void VideoWindow::clickPressed(const Point & cursorPosition)
 
 void VideoWindow::keyPressed(EShortcut key)
 {
-	exit(true);
+	if(key == EShortcut::GLOBAL_RETURN)
+		exit(true);
 }
 
 void VideoWindow::notFocusedClick()


### PR DESCRIPTION
Campaign videos and main menu videos can skipped with ESC and ENTER now (mouse click still working).

Fixes #5528