### PR TITLE
[iOS] add setting to honor mute switch

### DIFF
--- a/client/renderSDL/ScreenHandler.cpp
+++ b/client/renderSDL/ScreenHandler.cpp
@@ -212,6 +212,11 @@ ScreenHandler::ScreenHandler()
 	else
 		SDL_SetHint(SDL_HINT_ORIENTATIONS, "LandscapeLeft LandscapeRight");
 
+#ifdef VCMI_IOS
+	if(!settings["general"]["ignoreMuteSwitch"].Bool())
+		SDL_SetHint(SDL_HINT_AUDIO_CATEGORY, "AVAudioSessionCategoryAmbient");
+#endif
+
 	if(SDL_Init(SDL_INIT_VIDEO | SDL_INIT_TIMER | SDL_INIT_AUDIO | SDL_INIT_GAMECONTROLLER))
 	{
 		logGlobal->error("Something was wrong: %s", SDL_GetError());

--- a/config/schemas/settings.json
+++ b/config/schemas/settings.json
@@ -45,7 +45,8 @@
 				"audioMuteFocus",
 				"enableOverlay",
 				"lastKindomInterface",
-				"enableSubtitle"
+				"enableSubtitle",
+				"ignoreMuteSwitch"
 			],
 			"properties" : {
 				"playerName" : {
@@ -159,6 +160,10 @@
 					"default" : 0
 				},
 				"enableSubtitle" : {
+					"type": "boolean",
+					"default": true
+				},
+				"ignoreMuteSwitch" : {
 					"type": "boolean",
 					"default": true
 				}

--- a/launcher/settingsView/csettingsview_moc.cpp
+++ b/launcher/settingsView/csettingsview_moc.cpp
@@ -131,6 +131,10 @@ void CSettingsView::loadSettings()
 	ui->buttonAllowPortrait->hide();
 	ui->labelAllowPortrait->hide();
 #endif
+#ifndef VCMI_IOS
+	ui->labelIgnoreMuteSwitch->hide();
+	ui->buttonIgnoreMuteSwitch->hide();
+#endif
 	fillValidScalingRange();
 
 	ui->buttonScalingAuto->setChecked(settings["video"]["resolution"]["scaling"].Integer() == 0);
@@ -223,6 +227,8 @@ void CSettingsView::loadToggleButtonSettings()
 	setCheckbuttonState(ui->buttonHapticFeedback, settings["general"]["hapticFeedback"].Bool());
 
 	setCheckbuttonState(ui->buttonHandleBackRightMouseButton, settings["input"]["handleBackRightMouseButton"].Bool());
+
+	setCheckbuttonState(ui->buttonIgnoreMuteSwitch, settings["general"]["ignoreMuteSwitch"].Bool());
 
 	std::string cursorType = settings["video"]["cursor"].String();
 	int cursorTypeIndex = vstd::find_pos(cursorTypesList, cursorType);
@@ -866,3 +872,9 @@ void CSettingsView::on_buttonHandleBackRightMouseButton_toggled(bool checked)
 	updateCheckbuttonText(ui->buttonHandleBackRightMouseButton);
 }
 
+void CSettingsView::on_buttonIgnoreMuteSwitch_toggled(bool checked)
+{
+	Settings node = settings.write["general"]["ignoreMuteSwitch"];
+	node->Bool() = checked;
+	updateCheckbuttonText(ui->buttonIgnoreMuteSwitch);
+}

--- a/launcher/settingsView/csettingsview_moc.h
+++ b/launcher/settingsView/csettingsview_moc.h
@@ -91,18 +91,13 @@ private slots:
 	void on_buttonFontScalable_clicked(bool checked);
 	void on_buttonFontOriginal_clicked(bool checked);
 
-
 	void on_buttonValidationOff_clicked(bool checked);
-
 	void on_buttonValidationBasic_clicked(bool checked);
-
 	void on_buttonValidationFull_clicked(bool checked);
-
 	void on_sliderScalingCursor_valueChanged(int value);
-
 	void on_buttonScalingAuto_toggled(bool checked);
-
 	void on_buttonHandleBackRightMouseButton_toggled(bool checked);
+	void on_buttonIgnoreMuteSwitch_toggled(bool checked);
 
 private:
 	Ui::CSettingsView * ui;

--- a/launcher/settingsView/csettingsview_moc.ui
+++ b/launcher/settingsView/csettingsview_moc.ui
@@ -69,7 +69,7 @@
          </property>
         </widget>
        </item>
-       <item row="62" column="0">
+       <item row="63" column="0">
         <widget class="QLabel" name="labelModsValidation">
          <property name="text">
           <string>Mods Validation</string>
@@ -105,7 +105,7 @@
          </item>
         </widget>
        </item>
-       <item row="45" column="1" colspan="5">
+       <item row="46" column="1" colspan="5">
         <widget class="QSlider" name="sliderControllerSticksSensitivity">
          <property name="minimum">
           <number>500</number>
@@ -133,7 +133,7 @@
          </property>
         </widget>
        </item>
-       <item row="37" column="1" colspan="5">
+       <item row="38" column="1" colspan="5">
         <widget class="QPushButton" name="pushButtonResetTutorialTouchscreen">
          <property name="text">
           <string>Reset</string>
@@ -147,7 +147,7 @@
          </property>
         </widget>
        </item>
-       <item row="41" column="1" colspan="5">
+       <item row="42" column="1" colspan="5">
         <widget class="QSlider" name="sliderLongTouchDuration">
          <property name="minimum">
           <number>500</number>
@@ -172,7 +172,7 @@
          </property>
         </widget>
        </item>
-       <item row="56" column="1">
+       <item row="57" column="1">
         <widget class="QToolButton" name="buttonAutoCheck">
          <property name="enabled">
           <bool>true</bool>
@@ -239,7 +239,7 @@
          </property>
         </widget>
        </item>
-       <item row="57" column="1">
+       <item row="58" column="1">
         <widget class="QToolButton" name="buttonRepositoryDefault">
          <property name="enabled">
           <bool>true</bool>
@@ -268,14 +268,14 @@
          </property>
         </widget>
        </item>
-       <item row="40" column="0">
+       <item row="41" column="0">
         <widget class="QLabel" name="labelHapticFeedback">
          <property name="text">
           <string>Haptic Feedback</string>
          </property>
         </widget>
        </item>
-       <item row="43" column="0">
+       <item row="44" column="0">
         <widget class="QLabel" name="labelToleranceDistanceTouch">
          <property name="text">
           <string>Touch Tap Tolerance</string>
@@ -288,7 +288,7 @@
        <item row="1" column="1" colspan="5">
         <widget class="QComboBox" name="comboBoxLanguage"/>
        </item>
-       <item row="60" column="1" colspan="5">
+       <item row="61" column="1" colspan="5">
         <widget class="QSpinBox" name="spinBoxNetworkPortLobby">
          <property name="minimum">
           <number>1024</number>
@@ -301,7 +301,7 @@
          </property>
         </widget>
        </item>
-       <item row="62" column="5">
+       <item row="63" column="5">
         <widget class="QToolButton" name="buttonValidationFull">
          <property name="enabled">
           <bool>true</bool>
@@ -326,7 +326,7 @@
          </attribute>
         </widget>
        </item>
-       <item row="44" column="0">
+       <item row="45" column="0">
         <widget class="QLabel" name="labelInputMouse_3">
          <property name="font">
           <font>
@@ -379,7 +379,7 @@
          </property>
         </widget>
        </item>
-       <item row="49" column="1" colspan="5">
+       <item row="50" column="1" colspan="5">
         <widget class="QComboBox" name="comboBoxEnemyPlayerAI">
          <property name="currentText">
           <string notr="true">VCAI</string>
@@ -396,7 +396,7 @@
          </item>
         </widget>
        </item>
-       <item row="57" column="2" colspan="4">
+       <item row="58" column="2" colspan="4">
         <widget class="QLineEdit" name="lineEditRepositoryDefault">
          <property name="text">
           <string notr="true"/>
@@ -406,7 +406,7 @@
          </property>
         </widget>
        </item>
-       <item row="50" column="1" colspan="5">
+       <item row="51" column="1" colspan="5">
         <widget class="QComboBox" name="comboBoxAlliedPlayerAI">
          <property name="currentText">
           <string notr="true">VCAI</string>
@@ -430,7 +430,7 @@
          </property>
         </widget>
        </item>
-       <item row="48" column="0">
+       <item row="49" column="0">
         <widget class="QLabel" name="labelArtificialIntelligence">
          <property name="font">
           <font>
@@ -445,7 +445,7 @@
          </property>
         </widget>
        </item>
-       <item row="57" column="0">
+       <item row="58" column="0">
         <widget class="QLabel" name="labelRepositoryDefault">
          <property name="text">
           <string>Default repository</string>
@@ -471,7 +471,7 @@
          </property>
         </widget>
        </item>
-       <item row="39" column="0">
+       <item row="40" column="0">
         <widget class="QLabel" name="labelRelativeCursorSpeed">
          <property name="text">
           <string>Relative Pointer Speed</string>
@@ -485,7 +485,7 @@
          </property>
         </widget>
        </item>
-       <item row="55" column="1" colspan="5">
+       <item row="56" column="1" colspan="5">
         <widget class="QToolButton" name="buttonIgnoreSslErrors">
          <property name="enabled">
           <bool>true</bool>
@@ -588,7 +588,7 @@
          </property>
         </widget>
        </item>
-       <item row="58" column="1">
+       <item row="59" column="1">
         <widget class="QToolButton" name="buttonRepositoryExtra">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
@@ -607,21 +607,21 @@
          </property>
         </widget>
        </item>
-       <item row="56" column="2" colspan="4">
+       <item row="57" column="2" colspan="4">
         <widget class="QPushButton" name="refreshRepositoriesButton">
          <property name="text">
           <string>Refresh now</string>
          </property>
         </widget>
        </item>
-       <item row="50" column="0">
+       <item row="51" column="0">
         <widget class="QLabel" name="labelAlliedPlayerAI">
          <property name="text">
           <string>Adventure Map Allies</string>
          </property>
         </widget>
        </item>
-       <item row="51" column="0">
+       <item row="52" column="0">
         <widget class="QLabel" name="labelNeutralAI">
          <property name="text">
           <string>Neutral AI in battles</string>
@@ -659,7 +659,7 @@
          </property>
         </widget>
        </item>
-       <item row="59" column="1" colspan="5">
+       <item row="60" column="1" colspan="5">
         <widget class="QLineEdit" name="lineEditGameLobbyHost">
          <property name="text">
           <string notr="true"/>
@@ -673,7 +673,7 @@
          </property>
         </widget>
        </item>
-       <item row="38" column="0">
+       <item row="39" column="0">
         <widget class="QLabel" name="labelRelativeCursorMode">
          <property name="text">
           <string>Use Relative Pointer Mode</string>
@@ -683,14 +683,14 @@
        <item row="7" column="1" colspan="5">
         <widget class="QSpinBox" name="spinBoxAutoSaveLimit"/>
        </item>
-       <item row="52" column="0">
+       <item row="53" column="0">
         <widget class="QLabel" name="labelFriendlyAI">
          <property name="text">
           <string>Autocombat AI in battles</string>
          </property>
         </widget>
        </item>
-       <item row="62" column="1" colspan="2">
+       <item row="63" column="1" colspan="2">
         <widget class="QToolButton" name="buttonValidationOff">
          <property name="enabled">
           <bool>true</bool>
@@ -715,7 +715,7 @@
          </attribute>
         </widget>
        </item>
-       <item row="33" column="0">
+       <item row="34" column="0">
         <widget class="QLabel" name="labelInputMouse">
          <property name="font">
           <font>
@@ -737,7 +737,7 @@
          </property>
         </widget>
        </item>
-       <item row="40" column="1" colspan="5">
+       <item row="41" column="1" colspan="5">
         <widget class="QToolButton" name="buttonHapticFeedback">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
@@ -768,7 +768,7 @@
          </property>
         </widget>
        </item>
-       <item row="58" column="0">
+       <item row="59" column="0">
         <widget class="QLabel" name="labelRepositoryExtra">
          <property name="text">
           <string>Additional repository</string>
@@ -791,7 +791,7 @@
          </property>
         </widget>
        </item>
-       <item row="49" column="0">
+       <item row="50" column="0">
         <widget class="QLabel" name="labelEnemyPlayerAI">
          <property name="text">
           <string>Adventure Map Enemies</string>
@@ -819,7 +819,7 @@
          </property>
         </widget>
        </item>
-       <item row="36" column="0">
+       <item row="37" column="0">
         <widget class="QLabel" name="labelInputMouse_2">
          <property name="font">
           <font>
@@ -853,7 +853,7 @@
        <item row="24" column="1">
         <widget class="QLabel" name="labelScalingCursorValue"/>
        </item>
-       <item row="38" column="1" colspan="5">
+       <item row="39" column="1" colspan="5">
         <widget class="QToolButton" name="buttonRelativeCursorMode">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
@@ -876,28 +876,28 @@
          </property>
         </widget>
        </item>
-       <item row="59" column="0">
+       <item row="60" column="0">
         <widget class="QLabel" name="labelGameLobbyHost">
          <property name="text">
           <string>Online Lobby address</string>
          </property>
         </widget>
        </item>
-       <item row="60" column="0">
+       <item row="61" column="0">
         <widget class="QLabel" name="labelNetworkPortLobby">
          <property name="text">
           <string>Online Lobby port</string>
          </property>
         </widget>
        </item>
-       <item row="47" column="0">
+       <item row="48" column="0">
         <widget class="QLabel" name="labelToleranceDistanceController">
          <property name="text">
           <string>Controller Click Tolerance</string>
          </property>
         </widget>
        </item>
-       <item row="51" column="1" colspan="5">
+       <item row="52" column="1" colspan="5">
         <widget class="QComboBox" name="comboBoxNeutralAI">
          <property name="currentText">
           <string notr="true">BattleAI</string>
@@ -933,7 +933,7 @@
          </item>
         </widget>
        </item>
-       <item row="55" column="0">
+       <item row="56" column="0">
         <widget class="QLabel" name="labelIgnoreSslErrors">
          <property name="text">
           <string>Ignore SSL errors</string>
@@ -943,14 +943,14 @@
        <item row="21" column="1" colspan="5">
         <widget class="QComboBox" name="comboBoxDisplayIndex"/>
        </item>
-       <item row="37" column="0">
+       <item row="38" column="0">
         <widget class="QLabel" name="labelResetTutorialTouchscreen">
          <property name="text">
           <string>Show Tutorial again</string>
          </property>
         </widget>
        </item>
-       <item row="46" column="0">
+       <item row="47" column="0">
         <widget class="QLabel" name="labelControllerSticksAcceleration">
          <property name="text">
           <string>Sticks Acceleration</string>
@@ -972,7 +972,7 @@
          </property>
         </widget>
        </item>
-       <item row="53" column="1" colspan="5">
+       <item row="54" column="1" colspan="5">
         <widget class="QComboBox" name="comboBoxEnemyAI">
          <property name="editable">
           <bool>false</bool>
@@ -1006,21 +1006,21 @@
          </property>
         </widget>
        </item>
-       <item row="34" column="0">
+       <item row="35" column="0">
         <widget class="QLabel" name="labelToleranceDistanceMouse">
          <property name="text">
           <string>Mouse Click Tolerance</string>
          </property>
         </widget>
        </item>
-       <item row="35" column="0">
+       <item row="36" column="0">
         <widget class="QLabel" name="labelHandleBackRightMouseButton">
          <property name="text">
           <string>Handle back as right mouse button</string>
          </property>
         </widget>
        </item>
-       <item row="35" column="1" colspan="5">
+       <item row="36" column="1" colspan="5">
         <widget class="QToolButton" name="buttonHandleBackRightMouseButton">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
@@ -1036,7 +1036,7 @@
          </property>
         </widget>
        </item>
-       <item row="53" column="0">
+       <item row="54" column="0">
         <widget class="QLabel" name="labelEnemyAI">
          <property name="text">
           <string>Enemy AI in battles</string>
@@ -1050,7 +1050,7 @@
          </property>
         </widget>
        </item>
-       <item row="43" column="1" colspan="5">
+       <item row="44" column="1" colspan="5">
         <widget class="QSlider" name="sliderToleranceDistanceTouch">
          <property name="minimum">
           <number>0</number>
@@ -1092,7 +1092,7 @@
          </property>
         </widget>
        </item>
-       <item row="52" column="1" colspan="5">
+       <item row="53" column="1" colspan="5">
         <widget class="QComboBox" name="comboBoxFriendlyAI">
          <property name="editable">
           <bool>false</bool>
@@ -1112,7 +1112,7 @@
          </item>
         </widget>
        </item>
-       <item row="58" column="2" colspan="4">
+       <item row="59" column="2" colspan="4">
         <widget class="QLineEdit" name="lineEditRepositoryExtra">
          <property name="text">
           <string notr="true"/>
@@ -1164,7 +1164,7 @@
          </attribute>
         </widget>
        </item>
-       <item row="54" column="0">
+       <item row="55" column="0">
         <widget class="QLabel" name="labelNetwork">
          <property name="font">
           <font>
@@ -1179,7 +1179,7 @@
          </property>
         </widget>
        </item>
-       <item row="61" column="0">
+       <item row="62" column="0">
         <widget class="QLabel" name="labelMiscellaneous">
          <property name="font">
           <font>
@@ -1194,7 +1194,7 @@
          </property>
         </widget>
        </item>
-       <item row="46" column="1" colspan="5">
+       <item row="47" column="1" colspan="5">
         <widget class="QSlider" name="sliderControllerSticksAcceleration">
          <property name="minimum">
           <number>100</number>
@@ -1266,21 +1266,21 @@ Fullscreen Exclusive Mode - the game will cover the entirety of your screen and 
          </property>
         </widget>
        </item>
-       <item row="41" column="0">
+       <item row="42" column="0">
         <widget class="QLabel" name="labelLongTouchDuration">
          <property name="text">
           <string>Long Touch Duration</string>
          </property>
         </widget>
        </item>
-       <item row="56" column="0">
+       <item row="57" column="0">
         <widget class="QLabel" name="labelAutoCheck">
          <property name="text">
           <string>Check on startup</string>
          </property>
         </widget>
        </item>
-       <item row="47" column="1" colspan="5">
+       <item row="48" column="1" colspan="5">
         <widget class="QSlider" name="sliderToleranceDistanceController">
          <property name="minimum">
           <number>0</number>
@@ -1324,7 +1324,7 @@ Fullscreen Exclusive Mode - the game will cover the entirety of your screen and 
          </property>
         </widget>
        </item>
-       <item row="39" column="1" colspan="5">
+       <item row="40" column="1" colspan="5">
         <widget class="QSlider" name="sliderRelativeCursorSpeed">
          <property name="minimum">
           <number>100</number>
@@ -1366,7 +1366,7 @@ Fullscreen Exclusive Mode - the game will cover the entirety of your screen and 
          </property>
         </widget>
        </item>
-       <item row="34" column="1" colspan="5">
+       <item row="35" column="1" colspan="5">
         <widget class="QSlider" name="slideToleranceDistanceMouse">
          <property name="minimum">
           <number>0</number>
@@ -1439,7 +1439,7 @@ Fullscreen Exclusive Mode - the game will cover the entirety of your screen and 
          </property>
         </widget>
        </item>
-       <item row="45" column="0">
+       <item row="46" column="0">
         <widget class="QLabel" name="labelControllerSticksSensitivity">
          <property name="text">
           <string>Sticks Sensitivity</string>
@@ -1470,7 +1470,7 @@ Fullscreen Exclusive Mode - the game will cover the entirety of your screen and 
        <item row="12" column="1" colspan="5">
         <widget class="QComboBox" name="comboBoxResolution"/>
        </item>
-       <item row="62" column="3" colspan="2">
+       <item row="63" column="3" colspan="2">
         <widget class="QToolButton" name="buttonValidationBasic">
          <property name="enabled">
           <bool>true</bool>
@@ -1493,6 +1493,26 @@ Fullscreen Exclusive Mode - the game will cover the entirety of your screen and 
          <attribute name="buttonGroup">
           <string notr="true">buttonGroupValidation</string>
          </attribute>
+        </widget>
+       </item>
+       <item row="33" column="0">
+        <widget class="QLabel" name="labelIgnoreMuteSwitch">
+         <property name="text">
+          <string>Ignore mute switch</string>
+         </property>
+        </widget>
+       </item>
+       <item row="33" column="1" colspan="5">
+        <widget class="QToolButton" name="buttonIgnoreMuteSwitch">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
         </widget>
        </item>
       </layout>


### PR DESCRIPTION
adds new entry to the Audio settings section, visible only on iOS. The SDL hint must be set before `SDL_Init()` call. Default setting is compatible with existing behavior - ignore the silent switch, always play sounds/music.

fixes #5312