### PR TITLE
Fix the problem that launcher doesn't close after starting game

### DIFF
--- a/launcher/main.cpp
+++ b/launcher/main.cpp
@@ -111,7 +111,7 @@ void startExecutable(QString name, const QStringList & args)
 	// Start vcmiclient and vcmieditor with QProcess::start() instead of QProcess::startDetached()
 	// since startDetached() results in a missing terminal prompt after quitting vcmiclient.
 	// QProcess::start() causes the launcher window to freeze while the child process is running. By changing
-	// the "process" to pointer, the launcher will be detached on MacOS while sticking with QProcess::start().
+	// the "process" to pointer, the "process" exist after startExecutable return.
 	auto process = std::make_unique<QProcess> ();
 	process->setProcessChannelMode(QProcess::ForwardedChannels);
 	process->start(name, args);


### PR DESCRIPTION
Fixes #5129

The window of launcher will freeze after the game start becausethe "process" destoried after function startExecutable() return so it have to contain waitForFinished(-1) to ensure it exist before the game end.

By changing the "process" to unique pointer, I can use QObject::connect to make the lifetime of "process" long enough (destory when recieved &QProcess::finished), so there's no need for waitForFinished(-1). The window won't freeze in that case. (ChatGPT helped me in how to use QObject::connect to keep the lifetime long enough. The majority of the code is from myself)