### PR TITLE
[conan] move comment to a separate line

### DIFF
--- a/CI/conan/base/android
+++ b/CI/conan/base/android
@@ -6,4 +6,5 @@ compiler.version=14
 os=Android
 
 [buildenv]
-LD=ld # fixes shared libiconv build
+# fixes shared libiconv build
+LD=ld


### PR DESCRIPTION
looks like inline comments are not allowed, [example](https://gitlab.com/fdroid/fdroiddata/-/issues/3324#note_2396083863) from FFmpeg `configure` command:
```
'--ld=ld # fixes shared libiconv build'
```