### PR TITLE
Remove old boost includes and defines

### DIFF
--- a/Global.h
+++ b/Global.h
@@ -162,15 +162,34 @@ static_assert(sizeof(bool) == 1, "Bool needs to be 1 byte in size.");
 #include <boost/algorithm/string.hpp>
 #include <boost/container/small_vector.hpp>
 #include <boost/container/static_vector.hpp>
-#include <boost/filesystem.hpp>
-#include <boost/filesystem/fstream.hpp>
+// C++ 20 -> std::source_location::function_name
+#include <boost/current_function.hpp>
+// C++ 17 -> std::filesystem
+#include <boost/filesystem/directory.hpp>
+#include <boost/filesystem/exception.hpp>
+#include <boost/filesystem/file_status.hpp>
+#include <boost/filesystem/operations.hpp>
 #include <boost/filesystem/path.hpp>
 #include <boost/format.hpp>
 #include <boost/logic/tribool.hpp>
 #include <boost/multi_array.hpp>
+// C++ 20 -> std::range
 #include <boost/range/adaptor/filtered.hpp>
 #include <boost/range/adaptor/reversed.hpp>
-#include <boost/range/algorithm.hpp>
+#include <boost/range/algorithm/copy.hpp>
+#include <boost/range/algorithm/count.hpp>
+#include <boost/range/algorithm/count_if.hpp>
+#include <boost/range/algorithm/fill.hpp>
+#include <boost/range/algorithm/find.hpp>
+#include <boost/range/algorithm/find_if.hpp>
+#include <boost/range/algorithm/max_element.hpp>
+#include <boost/range/algorithm/min_element.hpp>
+#include <boost/range/algorithm/remove.hpp>
+#include <boost/range/algorithm/remove_if.hpp>
+#include <boost/range/algorithm/replace.hpp>
+#include <boost/range/algorithm/sort.hpp>
+#include <boost/range/algorithm/unique.hpp>
+#include <boost/range/algorithm/upper_bound.hpp>
 
 #ifndef M_PI
 #  define M_PI 3.14159265358979323846
@@ -180,7 +199,6 @@ static_assert(sizeof(bool) == 1, "Bool needs to be 1 byte in size.");
 /* Usings */
 /* ---------------------------------------------------------------------------- */
 using namespace std::placeholders;
-namespace range = boost::range;
 
 /* ---------------------------------------------------------------------------- */
 /* Typedefs */
@@ -319,7 +337,7 @@ namespace vstd
 	template <typename Container, typename Func>
 	int find_pos_if(const Container & c, const Func &f)
 	{
-		auto ret = boost::range::find_if(c, f);
+		auto ret = std::find_if(c.begin(), c.end(), f);
 		if(ret != std::end(c))
 			return std::distance(std::begin(c), ret);
 
@@ -470,13 +488,13 @@ namespace vstd
 	template <typename Container, typename Item>
 	void erase(Container &c, const Item &item)
 	{
-		c.erase(boost::remove(c, item), c.end());
+		c.erase(std::remove(c.begin(), c.end(), item), c.end());
 	}
 
 	template<typename Range, typename Predicate>
 	void erase_if(Range &vec, Predicate pred)
 	{
-		vec.erase(boost::remove_if(vec, pred),vec.end());
+		vec.erase(std::remove_if(vec.begin(), vec.end(), pred), vec.end());
 	}
 
 	template<typename Elem, typename Predicate>
@@ -563,7 +581,7 @@ namespace vstd
 		 * Current bugfix is to don't use a typedef for decltype(*std::begin(rng)) and to use decltype
 		 * directly for both function parameters.
 		 */
-		return boost::min_element(rng, [&] (decltype(*std::begin(rng)) lhs, decltype(*std::begin(rng)) rhs) -> bool
+		return std::min_element(rng.begin(), rng.end(), [&] (decltype(*std::begin(rng)) lhs, decltype(*std::begin(rng)) rhs) -> bool
 		{
 			return vf(lhs) < vf(rhs);
 		});
@@ -578,7 +596,7 @@ namespace vstd
 		 * Current bugfix is to don't use a typedef for decltype(*std::begin(rng)) and to use decltype
 		 * directly for both function parameters.
 		 */
-		return boost::max_element(rng, [&] (decltype(*std::begin(rng)) lhs, decltype(*std::begin(rng)) rhs) -> bool
+		return std::max_element(rng.begin(), rng.end(), [&] (decltype(*std::begin(rng)) lhs, decltype(*std::begin(rng)) rhs) -> bool
 		{
 			return vf(lhs) < vf(rhs);
 		});

--- a/Global.h
+++ b/Global.h
@@ -150,43 +150,22 @@ static_assert(sizeof(bool) == 1, "Bool needs to be 1 byte in size.");
 // For versions TBB 2021.7 and later this define is not required
 #define TBB_PREVIEW_TASK_GROUP_EXTENSIONS 1
 
-//The only available version is 3, as of Boost 1.50
 #include <boost/version.hpp>
 
+// As of Boost 1.50+, the only available version is 3,
+// Version 4 has been added in Boost 1.77
 #define BOOST_FILESYSTEM_VERSION 3
-#if BOOST_VERSION > 105000
-#  define BOOST_THREAD_VERSION 3
-#endif
 #if BOOST_VERSION == 107400
 #  define BOOST_ALLOW_DEPRECATED_HEADERS
 #endif
-#define BOOST_THREAD_DONT_PROVIDE_THREAD_DESTRUCTOR_CALLS_TERMINATE_IF_JOINABLE 1
-//need to link boost thread dynamically to avoid https://stackoverflow.com/questions/35978572/boost-thread-interupt-does-not-work-when-crossing-a-dll-boundary
-//for example VCAI::finish() may freeze on thread join after interrupt when linking this statically
-#ifndef BOOST_THREAD_USE_DLL
-#  define BOOST_THREAD_USE_DLL
-#endif
-#define BOOST_BIND_NO_PLACEHOLDERS
 
-#if BOOST_VERSION >= 106600
-#define BOOST_ASIO_ENABLE_OLD_SERVICES
-#endif
-
-#include <boost/algorithm/hex.hpp>
 #include <boost/algorithm/string.hpp>
-#include <boost/crc.hpp>
-#include <boost/current_function.hpp>
 #include <boost/container/small_vector.hpp>
 #include <boost/container/static_vector.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/filesystem/fstream.hpp>
 #include <boost/filesystem/path.hpp>
 #include <boost/format.hpp>
-#include <boost/functional/hash.hpp>
-#include <boost/lexical_cast.hpp>
-#ifdef VCMI_WINDOWS
-#include <boost/locale/generator.hpp>
-#endif
 #include <boost/logic/tribool.hpp>
 #include <boost/multi_array.hpp>
 #include <boost/range/adaptor/filtered.hpp>

--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -108,6 +108,8 @@
 
 #include "../lib/texts/TextOperations.h"
 
+#include <boost/lexical_cast.hpp>
+
 // The macro below is used to mark functions that are called by client when game state changes.
 // They all assume that interface mutex is locked.
 #define EVENT_HANDLER_CALLED_BY_CLIENT

--- a/client/CServerHandler.cpp
+++ b/client/CServerHandler.cpp
@@ -58,6 +58,8 @@
 
 #include <vcmi/events/EventBus.h>
 
+#include <boost/lexical_cast.hpp>
+
 CServerHandler::~CServerHandler()
 {
 	if (serverRunner)

--- a/client/adventureMap/AdventureMapShortcuts.cpp
+++ b/client/adventureMap/AdventureMapShortcuts.cpp
@@ -308,7 +308,7 @@ void AdventureMapShortcuts::endTurn()
 void AdventureMapShortcuts::showThievesGuild()
 {
 	//find first town with tavern
-	auto itr = range::find_if(GAME->interface()->localState->getOwnedTowns(), [](const CGTownInstance * town)
+	auto itr = boost::range::find_if(GAME->interface()->localState->getOwnedTowns(), [](const CGTownInstance * town)
 	{
 		return town->hasBuilt(BuildingID::TAVERN);
 	});

--- a/client/mainmenu/CMainMenu.cpp
+++ b/client/mainmenu/CMainMenu.cpp
@@ -62,6 +62,8 @@
 #include "../../lib/GameLibrary.h"
 #include "../../lib/json/JsonUtils.h"
 
+#include <boost/lexical_cast.hpp>
+
 ISelectionScreenInfo * SEL = nullptr;
 
 CMenuScreen::CMenuScreen(const JsonNode & configNode)

--- a/client/render/Colors.cpp
+++ b/client/render/Colors.cpp
@@ -13,6 +13,8 @@
 
 #include "../../lib/json/JsonNode.h"
 
+#include <boost/algorithm/hex.hpp>
+
 const ColorRGBA Colors::YELLOW = { 229, 215, 123, ColorRGBA::ALPHA_OPAQUE };
 const ColorRGBA Colors::WHITE = { 255, 243, 222, ColorRGBA::ALPHA_OPAQUE };
 const ColorRGBA Colors::WHITE_TRUE = { 255, 255, 255, ColorRGBA::ALPHA_OPAQUE };

--- a/client/widgets/CTextInput.cpp
+++ b/client/widgets/CTextInput.cpp
@@ -22,6 +22,8 @@
 
 #include "../../lib/texts/TextOperations.h"
 
+#include <boost/lexical_cast.hpp>
+
 std::list<CFocusable *> CFocusable::focusables;
 CFocusable * CFocusable::inputWithFocus;
 

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -64,6 +64,8 @@
 #include "../lib/CSkillHandler.h"
 #include "../lib/CSoundBase.h"
 
+#include <boost/lexical_cast.hpp>
+
 CRecruitmentWindow::CCreatureCard::CCreatureCard(CRecruitmentWindow * window, const CCreature * crea, int totalAmount)
 	: CIntObject(LCLICK | SHOW_POPUP),
 	parent(window),

--- a/lib/CRandomGenerator.cpp
+++ b/lib/CRandomGenerator.cpp
@@ -34,8 +34,8 @@ void CRandomGenerator::setSeed(int seed)
 void CRandomGenerator::resetSeed()
 {
 	logRng->trace("CRandomGenerator::resetSeed");
-	boost::hash<std::string> stringHash;
-	auto threadIdHash = stringHash(boost::lexical_cast<std::string>(std::this_thread::get_id()));
+	std::hash<std::thread::id> hasher;
+	auto threadIdHash = hasher(std::this_thread::get_id());
 	setSeed(static_cast<int>(threadIdHash * std::time(nullptr)));
 }
 

--- a/lib/CThreadHelper.cpp
+++ b/lib/CThreadHelper.cpp
@@ -20,6 +20,7 @@
 #endif
 
 #include <tbb/task_arena.h>
+#include <boost/lexical_cast.hpp>
 
 VCMI_LIB_NAMESPACE_BEGIN
 

--- a/lib/VCMIDirs.cpp
+++ b/lib/VCMIDirs.cpp
@@ -132,7 +132,7 @@ bool StartBatchCopyDataProgram(
 		(boost::format("start \"\" /D %1% %2%") % currentPath % (to / exeName));	// Start game in 'currentPath"
 
 	const bfs::path bathFilename = to / "_temp.bat";
-	bfs::ofstream bathFile(bathFilename, bfs::ofstream::trunc | bfs::ofstream::out);
+	std::ofstream bathFile(bathFilename.c_str(), std::ofstream::trunc | std::ofstream::out);
 	if (!bathFile.is_open())
 		return false;
 	bathFile << (boost::format(base) % exeName % from % (from / "*.*") % to % startGameString.str()).str();

--- a/lib/campaign/CampaignState.cpp
+++ b/lib/campaign/CampaignState.cpp
@@ -372,7 +372,7 @@ const JsonNode & CampaignState::getHeroByType(HeroTypeID heroID) const
 
 void CampaignState::setCurrentMapAsConquered(std::vector<CGHeroInstance *> heroes)
 {
-	range::sort(heroes, [](const CGHeroInstance * a, const CGHeroInstance * b)
+	boost::range::sort(heroes, [](const CGHeroInstance * a, const CGHeroInstance * b)
 	{
 		return a->getValueForCampaign() > b->getValueForCampaign();
 	});

--- a/lib/filesystem/CInputStream.h
+++ b/lib/filesystem/CInputStream.h
@@ -11,6 +11,8 @@
 
 #include "CStream.h"
 
+#include <boost/crc.hpp>
+
 VCMI_LIB_NAMESPACE_BEGIN
 
 /**

--- a/lib/json/JsonNode.cpp
+++ b/lib/json/JsonNode.cpp
@@ -15,6 +15,8 @@
 #include "JsonWriter.h"
 #include "filesystem/Filesystem.h"
 
+#include <boost/lexical_cast.hpp>
+
 // to avoid duplicating const and non-const code
 template<typename Node>
 Node & resolvePointer(Node & in, const std::string & pointer)

--- a/lib/mapObjects/ObjectTemplate.cpp
+++ b/lib/mapObjects/ObjectTemplate.cpp
@@ -21,6 +21,8 @@
 #include "../mapObjectConstructors/CRewardableConstructor.h"
 #include "../modding/IdentifierStorage.h"
 
+#include <boost/lexical_cast.hpp>
+
 VCMI_LIB_NAMESPACE_BEGIN
 
 static bool isOnVisitableFromTopList(Obj identifier, int type)

--- a/lib/mapping/MapEditUtils.cpp
+++ b/lib/mapping/MapEditUtils.cpp
@@ -17,6 +17,8 @@
 #include "CMap.h"
 #include "CMapOperation.h"
 
+#include <boost/lexical_cast.hpp>
+
 VCMI_LIB_NAMESPACE_BEGIN
 
 MapRect::MapRect() : x(0), y(0), z(0), width(0), height(0)

--- a/lib/network/NetworkDefines.h
+++ b/lib/network/NetworkDefines.h
@@ -15,7 +15,7 @@
 
 VCMI_LIB_NAMESPACE_BEGIN
 
-#if BOOST_VERSION >= 108700
+#if BOOST_VERSION >= 106600
 using NetworkContext = boost::asio::io_context;
 #else
 using NetworkContext = boost::asio::io_service;

--- a/lib/rmg/CRmgTemplate.cpp
+++ b/lib/rmg/CRmgTemplate.cpp
@@ -21,6 +21,9 @@
 #include "../modding/ModScope.h"
 #include "../serializer/JsonSerializeFormat.h"
 
+#include <boost/lexical_cast.hpp>
+
+
 VCMI_LIB_NAMESPACE_BEGIN
 
 namespace

--- a/lib/texts/TextOperations.cpp
+++ b/lib/texts/TextOperations.cpp
@@ -317,10 +317,11 @@ DLL_LINKAGE bool TextOperations::compareLocalizedStrings(std::string_view str1, 
 
 std::optional<int> TextOperations::textSearchSimilarityScore(const std::string & s, const std::string & t)
 {
-	static const std::locale loc = boost::locale::generator().generate(getLocaleName());
+	static const std::locale loc(getLocaleName());
+	static const std::collate<char> & col = std::use_facet<std::collate<char>>(loc);
 
-	auto haystack = boost::locale::to_lower(t, loc);
-	auto needle = boost::locale::to_lower(s, loc);
+	auto haystack = col.transform(t.data(), t.data() + t.size());
+	auto needle = col.transform(s.data(), s.data() + s.size());
 
 	// 0 - Best possible match: text starts with the search string
 	if(haystack.rfind(needle, 0) == 0)

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -88,6 +88,8 @@
 #include <vcmi/events/GenericEvents.h>
 #include <vcmi/events/AdventureEvents.h>
 
+#include <boost/lexical_cast.hpp>
+
 #define COMPLAIN_RET_IF(cond, txt) do {if (cond){complain(txt); return;}} while(0)
 #define COMPLAIN_RET_FALSE_IF(cond, txt) do {if (cond){complain(txt); return false;}} while(0)
 #define COMPLAIN_RET(txt) {complain(txt); return false;}

--- a/server/battles/BattleResultProcessor.cpp
+++ b/server/battles/BattleResultProcessor.cpp
@@ -31,6 +31,8 @@
 
 #include <vstd/RNG.h>
 
+#include <boost/lexical_cast.hpp>
+
 BattleResultProcessor::BattleResultProcessor(BattleProcessor * owner, CGameHandler * newGameHandler)
 //	: owner(owner)
 	: gameHandler(newGameHandler)


### PR DESCRIPTION
Remove no longer relevant references to boost from Global.h:
- Remove boost::thread leftover defines
- Remove no longer used boost headers
- Move some rarely used boost headers to .cpp's that use them

Should have no effect on supported libboost versions