### PR TITLE
Fix dwellings recruitment text

### DIFF
--- a/lib/mapObjects/CGDwelling.cpp
+++ b/lib/mapObjects/CGDwelling.cpp
@@ -252,7 +252,7 @@ void CGDwelling::onHeroVisit( const CGHeroInstance * h ) const
 	bd.player = h->tempOwner;
 	if(ID == Obj::CREATURE_GENERATOR1 || ID == Obj::CREATURE_GENERATOR4)
 	{
-		bd.text.appendLocalString(EMetaText::ADVOB_TXT, ID == Obj::CREATURE_GENERATOR1 ? 35 : 36); //{%s} Would you like to recruit %s? / {%s} Would you like to recruit %s, %s, %s, or %s?
+		bd.text.appendLocalString(EMetaText::ADVOB_TXT, ID == Obj::CREATURE_GENERATOR1 || creatures.size() == 1 ? 35 : 36); //{%s} Would you like to recruit %s? / {%s} Would you like to recruit %s, %s, %s, or %s?
 		bd.text.replaceTextID(getObjectHandler()->getNameTextID());
 		for(const auto & elem : creatures)
 			bd.text.replaceNamePlural(elem.second[0]);

--- a/lib/mapObjects/CGDwelling.cpp
+++ b/lib/mapObjects/CGDwelling.cpp
@@ -252,7 +252,7 @@ void CGDwelling::onHeroVisit( const CGHeroInstance * h ) const
 	bd.player = h->tempOwner;
 	if(ID == Obj::CREATURE_GENERATOR1 || ID == Obj::CREATURE_GENERATOR4)
 	{
-		bd.text.appendLocalString(EMetaText::ADVOB_TXT, ID == Obj::CREATURE_GENERATOR1 || creatures.size() == 1 ? 35 : 36); //{%s} Would you like to recruit %s? / {%s} Would you like to recruit %s, %s, %s, or %s?
+		bd.text.appendLocalString(EMetaText::ADVOB_TXT, creatures.size() == 1 ? 35 : 36); //{%s} Would you like to recruit %s? / {%s} Would you like to recruit %s, %s, %s, or %s?
 		bd.text.replaceTextID(getObjectHandler()->getNameTextID());
 		for(const auto & elem : creatures)
 			bd.text.replaceNamePlural(elem.second[0]);


### PR DESCRIPTION
There is an issue where if you go into a dwelling with a single creature you can recruit, you will run into

![1743163555_grim](https://github.com/user-attachments/assets/40f02f92-30aa-4487-8093-6ea61a19b255)

This pr fixes this issue to make it look like

![1743287040_grim](https://github.com/user-attachments/assets/3ff7889a-2d15-43a6-9b36-7bb07e4b086a)
