### PR TITLE
Beta crashfixes

### DIFF
--- a/AI/CMakeLists.txt
+++ b/AI/CMakeLists.txt
@@ -30,14 +30,9 @@ if(NOT fuzzylite_FOUND)
 	if(ANDROID)
 		set(FL_BACKTRACE OFF CACHE BOOL "" FORCE)
 	endif()
-	#It is for compiling FuzzyLite, it will not compile without it on GCC
-	if("x${CMAKE_CXX_COMPILER_FRONTEND_VARIANT}" STREQUAL "xGNU" OR ${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU")
-		add_compile_options(-Wno-error=deprecated-declarations)
-	endif()
-	add_subdirectory(FuzzyLite/fuzzylite EXCLUDE_FROM_ALL)
-	set_property(TARGET fl-static PROPERTY CXX_STANDARD 14) # doesn't compile under 17 due to using removed symbol(s)
-	add_library(fuzzylite::fuzzylite ALIAS fl-static)
-	target_include_directories(fl-static PUBLIC ${CMAKE_HOME_DIRECTORY}/AI/FuzzyLite/fuzzylite)
+
+	add_subdirectory(FuzzyLite EXCLUDE_FROM_ALL)
+	add_library(fuzzylite::fuzzylite ALIAS staticTarget)
 endif()
 
 #######################################

--- a/client/lobby/OptionsTab.cpp
+++ b/client/lobby/OptionsTab.cpp
@@ -68,13 +68,14 @@ void OptionsTab::recreate()
 	entries.clear();
 	humanPlayers = 0;
 
+	for (auto tooltipWindow : GH.windows().findWindows<CPlayerOptionTooltipBox>())
+		tooltipWindow->close();
+
 	for (auto heroOverview : GH.windows().findWindows<CHeroOverview>())
 		heroOverview->close();
 
 	for (auto selectionWindow : GH.windows().findWindows<SelectionWindow>())
-	{
 		selectionWindow->reopen();
-	}
 
 	OBJECT_CONSTRUCTION;
 	for(auto & pInfo : SEL->getStartInfo()->playerInfos)

--- a/client/renderSDL/CTrueTypeFont.cpp
+++ b/client/renderSDL/CTrueTypeFont.cpp
@@ -147,7 +147,8 @@ void CTrueTypeFont::renderTextImpl(SDL_Surface * surface, const std::string & da
 	else
 		rendered = TTF_RenderUTF8_Solid(font.get(), data.c_str(), CSDL_Ext::toSDL(color));
 
-	assert(rendered);
+	if (!rendered)
+		throw std::runtime_error("Failed to render text '" + data + "'. Reason: '" + TTF_GetError() + "'");
 
 	CSDL_Ext::blitSurface(rendered, surface, pos);
 	SDL_FreeSurface(rendered);

--- a/client/renderSDL/ScreenHandler.cpp
+++ b/client/renderSDL/ScreenHandler.cpp
@@ -368,16 +368,12 @@ EUpscalingFilter ScreenHandler::loadUpscalingFilter() const
 	float scaleY = static_cast<float>(outputResolution.x) / logicalResolution.x;
 	float scaling = std::min(scaleX, scaleY);
 	int systemMemoryMb = SDL_GetSystemRAM();
-	bool is32Bit = sizeof(void*) == 4;
 
 	if (scaling <= 1.001f)
 		return EUpscalingFilter::NONE; // running at original resolution or even lower than that - no need for xbrz
 
-	if (systemMemoryMb < 2048)
+	if (systemMemoryMb <= 4096)
 		return EUpscalingFilter::NONE; // xbrz2 may use ~1.0 - 1.5 Gb of RAM and has notable CPU cost - avoid on low-spec hardware
-
-	if (is32Bit)
-		return EUpscalingFilter::NONE; // to be safe, avoid large numbers of memory (re)allocations when address space is small
 
 	// Only using xbrz2 for autoselection.
 	// Higher options may have high system requirements and should be only selected explicitly by player

--- a/clientapp/EntryPoint.cpp
+++ b/clientapp/EntryPoint.cpp
@@ -297,9 +297,10 @@ int main(int argc, char * argv[])
 
 	testFile("DATA/HELP.TXT", "VCMI requires Heroes III: Shadow of Death or Heroes III: Complete data files to run!");
 	testFile("DATA/TENTCOLR.TXT", "Heroes III: Restoration of Erathia (including HD Edition) data files are not supported!");
-	testFile("MODS/VCMI/MOD.JSON", "VCMI installation is corrupted! Built-in mod was not found!");
-	testFile("DATA/PLAYERS.PAL", "Heroes III data files (Data/H3Bitmap.lod) are incomplete or corruped! Please reinstall them.");
-	testFile("SPRITES/DEFAULT.DEF", "Heroes III data files (Data/H3Sprite.lod) are incomplete or corruped! Please reinstall them.");
+	testFile("MODS/VCMI/MOD.JSON", "VCMI installation is corrupted!\nBuilt-in mod was not found!");
+	testFile("DATA/NOTOSERIF-MEDIUM.TTF", "VCMI installation is corrupted!\nBuilt-in font was not found!\nManually deleting '" + VCMIDirs::get().userDataPath().string() + "/Mods/VCMI' directory (if it exists)\nor clearing app data and reimporting Heroes III files may fix this problem.");
+	testFile("DATA/PLAYERS.PAL", "Heroes III data files (Data/H3Bitmap.lod) are incomplete or corruped!\n Please reinstall them.");
+	testFile("SPRITES/DEFAULT.DEF", "Heroes III data files (Data/H3Sprite.lod) are incomplete or corruped!\n Please reinstall them.");
 
 	srand ( (unsigned int)time(nullptr) );
 

--- a/lib/networkPacks/NetPacksLib.cpp
+++ b/lib/networkPacks/NetPacksLib.cpp
@@ -1639,13 +1639,19 @@ void RebalanceStacks::applyGs(CGameState *gs)
 			{
 				if(auto dstArt = dstStack->getArt(ArtifactPosition::CREATURE_SLOT))
 				{
-					auto dstSlot = ArtifactUtils::getArtBackpackPosition(srcHero, dstArt->getTypeId());
-					if(srcHero && dstSlot != ArtifactPosition::PRE_FIRST)
+					bool artifactIsLost = true;
+
+					if(srcHero)
 					{
-						gs->map->moveArtifactInstance(*dstStack, ArtifactPosition::CREATURE_SLOT, *srcHero, dstSlot);
+						auto dstSlot = ArtifactUtils::getArtBackpackPosition(srcHero, dstArt->getTypeId());
+						if (dstSlot != ArtifactPosition::PRE_FIRST)
+						{
+							gs->map->moveArtifactInstance(*dstStack, ArtifactPosition::CREATURE_SLOT, *srcHero, dstSlot);
+							artifactIsLost = false;
+						}
 					}
-					//else - artifact can be lost :/
-					else
+
+					if (artifactIsLost)
 					{
 						BulkEraseArtifacts ea;
 						ea.artHolder = dstHero->id;

--- a/server/NetPacksServer.cpp
+++ b/server/NetPacksServer.cpp
@@ -70,6 +70,15 @@ void ApplyGhNetPackVisitor::visitMoveHero(MoveHero & pack)
 			result = false;
 			return;
 		}
+
+		// player got some query he has to reply to first for example, from triggered event
+		// ignore remaining path (if any), but handle this as success - since at least part of path was legal & was applied
+		auto query = gh.queries->topQuery(pack.player);
+		if (query && query->blocksPack(&pack))
+		{
+			result = true;
+			return;
+		}
 	}
 
 	result = true;


### PR DESCRIPTION
Another batch of fixes for 1.6.7 crashes discovered on Google Play & Discord:

- Fix crash if player uses maximum/instant movement speed and moves hero across event that grants enough XP to level up the hero
- Fix rare crash if player changes starting hero in MP map setup while another player has town/starting bonus right-click popup open at this very moment
- Fix rare crash on merging two units located in town garrison if both units have stack artifacts equipped
- Check for presence of builtin ttf fonts on game start and if missing - report this to player to avoid unclear to player crashes on font loading a bit later
- Increase system RAM for xbrz2 auto-activation to 4Gb due to crashes on Android (VCMI usage is way lower than 4Gb, but this is total memory that is shared with other apps)

Also backported fuzzylite submodule bump for CI to pass