### PR TITLE
Use SDL scancodes instead of keycodes for keybindings

### DIFF
--- a/client/eventsSDL/InputSourceKeyboard.cpp
+++ b/client/eventsSDL/InputSourceKeyboard.cpp
@@ -56,7 +56,7 @@ std::string InputSourceKeyboard::getKeyNameWithModifiers(const std::string & key
 
 void InputSourceKeyboard::handleEventKeyDown(const SDL_KeyboardEvent & key)
 {
-	std::string keyName = getKeyNameWithModifiers(SDL_GetKeyName(key.keysym.sym), false);
+	std::string keyName = getKeyNameWithModifiers(SDL_GetScancodeName(key.keysym.scancode), false);
 	logGlobal->trace("keyboard: key '%s' pressed", keyName);
 	assert(key.state == SDL_PRESSED);
 
@@ -130,7 +130,7 @@ void InputSourceKeyboard::handleEventKeyUp(const SDL_KeyboardEvent & key)
 		return;
 	}
 
-	std::string keyName = getKeyNameWithModifiers(SDL_GetKeyName(key.keysym.sym), true);
+	std::string keyName = getKeyNameWithModifiers(SDL_GetScancodeName(key.keysym.scancode), true);
 	logGlobal->trace("keyboard: key '%s' released", keyName);
 
 	if (SDL_IsTextInputActive() == SDL_TRUE)


### PR DESCRIPTION
- Fixes #794

Way smaller change than I expected. Looks like all / almost all keys have same string ID for both scancode & keycodes in SDL. Now keybindings work for me on any keyboard layout.

In theory might (somewhat) break non-QWERTY keyboards since scancodes in SDL are supposed to represent position of key on keyboard

Text input works as expected and respects keyboard layout, as before.