### PR TITLE
Fix Lord Haart vs Sir Munlich

### DIFF
--- a/config/heroes/castle.json
+++ b/config/heroes/castle.json
@@ -78,7 +78,6 @@
 		"index": 4,
 		"class" : "knight",
 		"female": false,
-		"special" : true, // Lord Haart in his living form. Disabled in H3 expansions
 		"skills":
 		[
 			{ "skill" : "leadership", "level": "basic" },

--- a/config/heroes/special.json
+++ b/config/heroes/special.json
@@ -5,7 +5,7 @@
 		"index": 144,
 		"class" : "knight",
 		"female": false,
-		"special" : false, // available in single scenario, replacement for no longer available Lord Haart
+		"special" : true,
 		"skills":
 		[
 			{ "skill" : "leadership", "level": "advanced" }


### PR DESCRIPTION
In original game from GOG is available for random maps Lord Haart not Sir Munlich. Their swap is directly HotA purpose.

Fix for: https://github.com/vcmi/vcmi/issues/2340