### PR TITLE
fix Chinese encoding problem in GBK

### DIFF
--- a/lib/filesystem/CFilesystemLoader.cpp
+++ b/lib/filesystem/CFilesystemLoader.cpp
@@ -14,6 +14,8 @@
 
 #include "../ExceptionsCommon.h"
 
+#include <boost/locale/encoding_utf.hpp>
+
 VCMI_LIB_NAMESPACE_BEGIN
 
 CFilesystemLoader::CFilesystemLoader(std::string _mountPoint, boost::filesystem::path baseDirectory, size_t depth, bool initial):
@@ -91,20 +93,21 @@ bool CFilesystemLoader::createResource(const std::string & requestedFilename, bo
 	}
 
 	filename = filename.substr(mountPoint.size());
+	std::wstring filePath = boost::locale::conv::utf_to_utf<wchar_t>(filename);
 
 	if (!update)
 	{
 		// create folders if not exists
-		boost::filesystem::path p((baseDirectory / filename).c_str());
+		boost::filesystem::path p((baseDirectory / filePath).c_str());
 		boost::filesystem::create_directories(p.parent_path());
 
 		// create file, if not exists
-		std::ofstream file((baseDirectory / filename).c_str(), std::ofstream::binary);
+		std::ofstream file((baseDirectory / filePath).c_str(), std::ofstream::binary);
 
 		if (!file.is_open())
 			return false;
 	}
-	fileList[resID] = filename;
+	fileList[resID] = filePath;
 	return true;
 }
 
@@ -173,19 +176,26 @@ std::unordered_map<ResourcePath, boost::filesystem::path> CFilesystemLoader::lis
 				filename = it->path().filename();
 
 			std::string resName;
+
+#ifdef VCMI_WINDOWS
+			std::string filenameUtf8 = boost::locale::conv::utf_to_utf<char>(filename.native());
+#else
+			std::string filenameUtf8 = filename.string();
+#endif
+
 			if (boost::filesystem::path::preferred_separator != '/')
 			{
 				// resource names are using UNIX slashes (/)
 				resName.reserve(resName.size() + filename.native().size());
 				resName = mountPoint;
-				for (const char c : filename.string())
+				for (const char c : filenameUtf8)
 					if (c != boost::filesystem::path::preferred_separator)
 						resName.push_back(c);
 					else
 						resName.push_back('/');
 			}
 			else
-				resName = mountPoint + filename.string();
+				resName = mountPoint + filenameUtf8;
 
 			fileList[ResourcePath(resName, type)] = std::move(filename);
 		}

--- a/lib/filesystem/CFilesystemLoader.cpp
+++ b/lib/filesystem/CFilesystemLoader.cpp
@@ -13,8 +13,7 @@
 #include "CFileInputStream.h"
 
 #include "../ExceptionsCommon.h"
-
-#include <boost/locale/encoding_utf.hpp>
+#include "../texts/TextOperations.h"
 
 VCMI_LIB_NAMESPACE_BEGIN
 
@@ -93,11 +92,7 @@ bool CFilesystemLoader::createResource(const std::string & requestedFilename, bo
 	}
 
 	filename = filename.substr(mountPoint.size());
-#ifdef VCMI_WINDOWS
-			boost::filesystem::path filePath(boost::locale::conv::utf_to_utf<wchar_t>(filename));
-#else
-			boost::filesystem::path filePath(filename.string());
-#endif
+	boost::filesystem::path filePath = TextOperations::Utf8TofilesystemPath(filename);
 
 	if (!update)
 	{
@@ -180,12 +175,7 @@ std::unordered_map<ResourcePath, boost::filesystem::path> CFilesystemLoader::lis
 				filename = it->path().filename();
 
 			std::string resName;
-
-#ifdef VCMI_WINDOWS
-			std::string filenameUtf8 = boost::locale::conv::utf_to_utf<char>(filename.native());
-#else
-			std::string filenameUtf8 = filename.string();
-#endif
+			std::string filenameUtf8 = TextOperations::filesystemPathToUtf8(filename);
 
 			if (boost::filesystem::path::preferred_separator != '/')
 			{

--- a/lib/filesystem/CFilesystemLoader.cpp
+++ b/lib/filesystem/CFilesystemLoader.cpp
@@ -93,7 +93,11 @@ bool CFilesystemLoader::createResource(const std::string & requestedFilename, bo
 	}
 
 	filename = filename.substr(mountPoint.size());
-	std::wstring filePath = boost::locale::conv::utf_to_utf<wchar_t>(filename);
+#ifdef VCMI_WINDOWS
+			boost::filesystem::path filePath(boost::locale::conv::utf_to_utf<wchar_t>(filename));
+#else
+			boost::filesystem::path filePath(filename.string());
+#endif
 
 	if (!update)
 	{

--- a/lib/mapping/CMapInfo.cpp
+++ b/lib/mapping/CMapInfo.cpp
@@ -27,8 +27,6 @@
 #include "../IGameSettings.h"
 #include "../CConfigHandler.h"
 
- #include <boost/locale/encoding_utf.hpp>
-
 VCMI_LIB_NAMESPACE_BEGIN
 
 CMapInfo::CMapInfo()
@@ -45,11 +43,7 @@ CMapInfo::~CMapInfo()
 std::string CMapInfo::getFullFileURI(const ResourcePath & file) const
 {
 	auto path = boost::filesystem::canonical(*CResourceHandler::get()->getResourceName(file));
-#ifdef VCMI_WINDOWS
-	return boost::locale::conv::utf_to_utf<char>(path.native());
-#else
-	return path.string();
-#endif
+	return TextOperations::filesystemPathToUtf8(path);
 }
 
 void CMapInfo::mapInit(const std::string & fname)

--- a/lib/mapping/CMapInfo.h
+++ b/lib/mapping/CMapInfo.h
@@ -48,7 +48,7 @@ public:
 	CMapInfo &operator=(CMapInfo &&other) = delete;
 	CMapInfo &operator=(const CMapInfo &other) = delete;
 
-	std::string CMapInfo::getFullFileURI(const ResourcePath& file) const;
+	std::string getFullFileURI(const ResourcePath& file) const;
 	void mapInit(const std::string & fname);
 	void saveInit(const ResourcePath & file);
 	void campaignInit();

--- a/lib/mapping/CMapInfo.h
+++ b/lib/mapping/CMapInfo.h
@@ -48,6 +48,7 @@ public:
 	CMapInfo &operator=(CMapInfo &&other) = delete;
 	CMapInfo &operator=(const CMapInfo &other) = delete;
 
+	std::string CMapInfo::getFullFileURI(const ResourcePath& file) const;
 	void mapInit(const std::string & fname);
 	void saveInit(const ResourcePath & file);
 	void campaignInit();

--- a/lib/texts/TextOperations.cpp
+++ b/lib/texts/TextOperations.cpp
@@ -419,7 +419,7 @@ boost::filesystem::path TextOperations::Utf8TofilesystemPath(const std::string& 
 #ifdef VCMI_WINDOWS
 	return boost::filesystem::path(boost::locale::conv::utf_to_utf<wchar_t>(path));
 #else
-	return boost::filesystem::path(path.string());
+	return boost::filesystem::path(path);
 #endif
 }
 

--- a/lib/texts/TextOperations.cpp
+++ b/lib/texts/TextOperations.cpp
@@ -405,4 +405,22 @@ std::optional<int> TextOperations::textSearchSimilarityScore(const std::string &
 	return (minDist > maxAllowedDistance) ? std::nullopt : std::optional<int>{ minDist };
 }
 
+std::string TextOperations::filesystemPathToUtf8(const boost::filesystem::path& path)
+{
+#ifdef VCMI_WINDOWS
+	return boost::locale::conv::utf_to_utf<char>(path.native());
+#else
+	return path.string();
+#endif
+}
+
+boost::filesystem::path TextOperations::Utf8TofilesystemPath(const std::string& path)
+{
+#ifdef VCMI_WINDOWS
+	return boost::filesystem::path(boost::locale::conv::utf_to_utf<wchar_t>(path));
+#else
+	return boost::filesystem::path(path.string());
+#endif
+}
+
 VCMI_LIB_NAMESPACE_END

--- a/lib/texts/TextOperations.h
+++ b/lib/texts/TextOperations.h
@@ -84,6 +84,13 @@ namespace TextOperations
 	/// other values = Levenshtein distance, returns std::nullopt for unrelated word (bad match).
 	DLL_LINKAGE std::optional<int> textSearchSimilarityScore(const std::string & s, const std::string & t);
 
+	/// This function is mainly used to avoid garbled text when reading or writing files
+	/// with non-ASCII (e.g. Chinese) characters in the path, especially on Windows.
+	/// Call this before passing the path to file I/O functions that take std::string.
+	DLL_LINKAGE std::string filesystemPathToUtf8(const boost::filesystem::path& path);
+
+	// Used for handling paths with non-ASCII characters.
+	DLL_LINKAGE boost::filesystem::path Utf8TofilesystemPath(const std::string& path);
 };
 
 template<typename Arithmetic>


### PR DESCRIPTION
As mentioned in #5634, Chinese characters may display as garbled text in certain situations.
This commit addresses the issue following the approach suggested by @IvanSavenko , and the fix has been tested under both GBK and Unicode environments. No garbled output or read/write failures were observed.

Fixes #5634