### PR TITLE
Fix bug when no casualties but 1 skeleton is raised

### DIFF
--- a/lib/mapObjects/CGHeroInstance.cpp
+++ b/lib/mapObjects/CGHeroInstance.cpp
@@ -969,11 +969,13 @@ CStackBasicDescriptor CGHeroInstance::calculateNecromancy (const BattleResult &b
 		const ui8 necromancyLevel = valOfBonuses(BonusType::IMPROVED_NECROMANCY);
 		vstd::amin(necromancySkill, 1.0); //it's impossible to raise more creatures than all...
 		const std::map<CreatureID,si32> &casualties = battleResult.casualties[CBattleInfoEssentials::otherSide(battleResult.winner)];
+        if(casualties.empty())
+            return CStackBasicDescriptor();
 		// figure out what to raise - pick strongest creature meeting requirements
 		CreatureID creatureTypeRaised = CreatureID::NONE; //now we always have IMPROVED_NECROMANCY, no need for hardcode
 		int requiredCasualtyLevel = 1;
 		TConstBonusListPtr improvedNecromancy = getBonusesOfType(BonusType::IMPROVED_NECROMANCY);
-		if(!improvedNecromancy->empty())
+        if(!improvedNecromancy->empty())
 		{
 			int maxCasualtyLevel = 1;
 			for(const auto & casualty : casualties)


### PR DESCRIPTION
This PR aims to fix issue as in the title. 
Example reproduction steps:

1. A hero with Necromancy attacks another one.
2. The defending hero acts first, casts a damaging spell that kills no units, then flees.
3. The attacker incorrectly gains 1 skeleton.