### PR TITLE
fix crash when bonus limiter is empty in OwnerUpdater

### DIFF
--- a/lib/bonuses/Updaters.cpp
+++ b/lib/bonuses/Updaters.cpp
@@ -229,7 +229,8 @@ std::shared_ptr<Bonus> OwnerUpdater::createUpdatedBonus(const std::shared_ptr<Bo
 	std::shared_ptr<Bonus> updated =
 		std::make_shared<Bonus>(*b);
 	updated->limiter = b->limiter;
-	updated->limiter->acceptUpdater(*this);
+	if (updated->limiter)
+		updated->limiter->acceptUpdater(*this);
 	return updated;
 }
 


### PR DESCRIPTION
My previous code did not account for cases where b->limiter could be empty. This issue has now been resolved.