### PR TITLE
Prevent AI from repeatedly swapping the same artifacts

### DIFF
--- a/AI/Nullkiller/AIGateway.cpp
+++ b/AI/Nullkiller/AIGateway.cpp
@@ -1039,6 +1039,8 @@ void AIGateway::pickBestArtifacts(const CGHeroInstance * h, const CGHeroInstance
 	auto equipBest = [](const CGHeroInstance * h, const CGHeroInstance * otherh, bool giveStuffToFirstHero) -> void
 	{
 		bool changeMade = false;
+		int swapCount = 0;
+		const int maxSwapCount = 100;
 		do
 		{
 			changeMade = false;
@@ -1100,6 +1102,7 @@ void AIGateway::pickBestArtifacts(const CGHeroInstance * h, const CGHeroInstance
 						cb->swapArtifacts(location, destLocation); //just put into empty slot
 						emptySlotFound = true;
 						changeMade = true;
+						swapCount++;
 						break;
 					}
 				}
@@ -1138,6 +1141,7 @@ void AIGateway::pickBestArtifacts(const CGHeroInstance * h, const CGHeroInstance
 								}
 
 								changeMade = true;
+								swapCount++;
 								break;
 							}
 						}
@@ -1147,7 +1151,9 @@ void AIGateway::pickBestArtifacts(const CGHeroInstance * h, const CGHeroInstance
 					break; //start evaluating artifacts from scratch
 			}
 		}
-		while(changeMade);
+		while(changeMade && swapCount < maxSwapCount);
+		if (swapCount >= maxSwapCount)
+			logAi->warn("Maximum artifact swap count exceeded!");
 	};
 
 	equipBest(h, other, true);


### PR DESCRIPTION
This is the most basic solution to prevent the issue described in #5652, but it does not fully fix it. The root cause of the problem lies in how artifact scores are calculated. For example, two ring artifacts—one granting +1 Knowledge and +1 Mana regeneration, and the other granting +10 Mana regeneration—can cause the AI to loop endlessly exchanging them.

Moreover, even if we fix the current scoring logic, there is no guarantee that similar issues won't arise again in the future. Therefore, adding a safeguard is a more reliable approach.

