### PR TITLE
Fixes for multiple reported issues

### DIFF
--- a/AI/BattleAI/BattleEvaluator.cpp
+++ b/AI/BattleAI/BattleEvaluator.cpp
@@ -568,7 +568,7 @@ bool BattleEvaluator::attemptCastingSpell(const CStack * activeStack)
 					ourTurnSpan++;
 				}
 
-				state->nextTurn(unit->unitId());
+				state->nextTurn(unit->unitId(), BattleUnitTurnReason::TURN_QUEUE);
 
 				PotentialTargets potentialTargets(unit, damageCache, state);
 

--- a/AI/BattleAI/StackWithBonuses.cpp
+++ b/AI/BattleAI/StackWithBonuses.cpp
@@ -342,14 +342,14 @@ void HypotheticBattle::nextRound()
 	}
 }
 
-void HypotheticBattle::nextTurn(uint32_t unitId)
+void HypotheticBattle::nextTurn(uint32_t unitId, BattleUnitTurnReason reason)
 {
 	activeUnitId = unitId;
 	auto unit = getForUpdate(unitId);
 
 	unit->removeUnitBonus(Bonus::UntilGetsTurn);
 
-	unit->afterGetsTurn();
+	unit->afterGetsTurn(reason);
 }
 
 void HypotheticBattle::addUnit(uint32_t id, const JsonNode & data)

--- a/AI/BattleAI/StackWithBonuses.h
+++ b/AI/BattleAI/StackWithBonuses.h
@@ -137,7 +137,7 @@ public:
 	battle::Units getUnitsIf(const battle::UnitFilter & predicate) const override;
 
 	void nextRound() override;
-	void nextTurn(uint32_t unitId) override;
+	void nextTurn(uint32_t unitId, BattleUnitTurnReason reason) override;
 
 	void addUnit(uint32_t id, const JsonNode & data) override;
 	void setUnitState(uint32_t id, const JsonNode & data, int64_t healthDelta) override;

--- a/AI/Nullkiller/AIGateway.cpp
+++ b/AI/Nullkiller/AIGateway.cpp
@@ -67,6 +67,7 @@ struct SetGlobalState
 #define MAKING_TURN SET_GLOBAL_STATE(this)
 
 AIGateway::AIGateway()
+	:status(this)
 {
 	LOG_TRACE(logAi);
 	destinationTeleport = ObjectInstanceID();
@@ -1676,7 +1677,8 @@ void AIGateway::validateObject(ObjectIdRef obj)
 	}
 }
 
-AIStatus::AIStatus()
+AIStatus::AIStatus(AIGateway * gateway)
+	: gateway(gateway)
 {
 	battle = NO_BATTLE;
 	havingTurn = false;
@@ -1758,7 +1760,10 @@ void AIStatus::waitTillFree()
 {
 	std::unique_lock<std::mutex> lock(mx);
 	while(battle != NO_BATTLE || !remainingQueries.empty() || !objectsBeingVisited.empty() || ongoingHeroMovement)
+	{
 		cv.wait_for(lock, std::chrono::milliseconds(10));
+		gateway->nullkiller->makingTurnInterrupption.interruptionPoint();
+	}
 }
 
 bool AIStatus::haveTurn()

--- a/AI/Nullkiller/AIGateway.h
+++ b/AI/Nullkiller/AIGateway.h
@@ -31,6 +31,7 @@ namespace NKAI
 
 class AIStatus
 {
+	AIGateway * gateway;
 	std::mutex mx;
 	std::condition_variable cv;
 
@@ -44,7 +45,7 @@ class AIStatus
 	bool havingTurn;
 
 public:
-	AIStatus();
+	AIStatus(AIGateway * gateway);
 	~AIStatus();
 	void setBattle(BattleState BS);
 	void setMove(bool ongoing);

--- a/client/NetPacksClient.cpp
+++ b/client/NetPacksClient.cpp
@@ -769,7 +769,7 @@ void ApplyClientNetPackVisitor::visitBattleNextRound(BattleNextRound & pack)
 
 void ApplyClientNetPackVisitor::visitBattleSetActiveStack(BattleSetActiveStack & pack)
 {
-	if(!pack.askPlayerInterface)
+	if(pack.reason == BattleUnitTurnReason::AUTOMATIC_ACTION)
 		return;
 
 	const CStack *activated = gs.getBattle(pack.battleID)->battleGetStackByID(pack.stack);

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -418,6 +418,7 @@ set(lib_MAIN_HEADERS
 	battle/BattleSide.h
 	battle/BattleStateInfoForRetreat.h
 	battle/BattleProxy.h
+	battle/BattleUnitTurnReason.h
 	battle/CBattleInfoCallback.h
 	battle/CBattleInfoEssentials.h
 	battle/CObstacleInstance.h

--- a/lib/battle/BattleInfo.cpp
+++ b/lib/battle/BattleInfo.cpp
@@ -666,7 +666,7 @@ void BattleInfo::nextRound()
 		obst->battleTurnPassed();
 }
 
-void BattleInfo::nextTurn(uint32_t unitId)
+void BattleInfo::nextTurn(uint32_t unitId, BattleUnitTurnReason reason)
 {
 	activeStack = unitId;
 
@@ -675,7 +675,7 @@ void BattleInfo::nextTurn(uint32_t unitId)
 	//remove bonuses that last until when stack gets new turn
 	st->removeBonusesRecursive(Bonus::UntilGetsTurn);
 
-	st->afterGetsTurn();
+	st->afterGetsTurn(reason);
 }
 
 void BattleInfo::addUnit(uint32_t id, const JsonNode & data)

--- a/lib/battle/BattleInfo.h
+++ b/lib/battle/BattleInfo.h
@@ -128,7 +128,7 @@ public:
 	// IBattleState
 
 	void nextRound() override;
-	void nextTurn(uint32_t unitId) override;
+	void nextTurn(uint32_t unitId, BattleUnitTurnReason reason) override;
 
 	void addUnit(uint32_t id, const JsonNode & data) override;
 	void moveUnit(uint32_t id, const BattleHex & destination) override;

--- a/lib/battle/BattleUnitTurnReason.h
+++ b/lib/battle/BattleUnitTurnReason.h
@@ -1,0 +1,28 @@
+/*
+ * BattleUnitTurnReason.h, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
+#pragma once
+
+VCMI_LIB_NAMESPACE_BEGIN
+
+enum class BattleUnitTurnReason : int8_t
+{
+	/// Unit gained turn due to becoming first unit in turn queue
+	TURN_QUEUE,
+	/// Unit gained turn due to morale triggering
+	MORALE,
+	/// Unit (re)gained	turn due to hero casting a spell while this unit is active
+	HERO_SPELLCAST,
+	/// Unit gained turn due to casting a spell while having ability to cast spells without spending turn
+	UNIT_SPELLCAST,
+	/// Unit gained turn for automatic action, player can not select action for this unit
+	AUTOMATIC_ACTION
+};
+
+VCMI_LIB_NAMESPACE_END

--- a/lib/battle/CUnitState.cpp
+++ b/lib/battle/CUnitState.cpp
@@ -920,11 +920,13 @@ void CUnitState::afterNewRound()
 		makeGhost();
 }
 
-void CUnitState::afterGetsTurn()
+void CUnitState::afterGetsTurn(BattleUnitTurnReason reason)
 {
-	//if moving second time this round it must be high morale bonus
-	if(movedThisRound)
+	if(reason == BattleUnitTurnReason::MORALE)
+	{
 		hadMorale = true;
+		castSpellThisTurn = false;
+	}
 }
 
 void CUnitState::makeGhost()

--- a/lib/battle/CUnitState.h
+++ b/lib/battle/CUnitState.h
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include "BattleUnitTurnReason.h"
 #include "Unit.h"
 #include "../bonuses/BonusCache.h"
 
@@ -254,7 +255,7 @@ public:
 
 	void afterNewRound();
 
-	void afterGetsTurn();
+	void afterGetsTurn(BattleUnitTurnReason reason);
 
 	void makeGhost();
 

--- a/lib/battle/IBattleState.h
+++ b/lib/battle/IBattleState.h
@@ -10,6 +10,7 @@
 
 #pragma once
 #include "CBattleInfoEssentials.h"
+#include "BattleUnitTurnReason.h"
 
 VCMI_LIB_NAMESPACE_BEGIN
 
@@ -80,7 +81,7 @@ class DLL_LINKAGE IBattleState : public IBattleInfo
 {
 public:
 	virtual void nextRound() = 0;
-	virtual void nextTurn(uint32_t unitId) = 0;
+	virtual void nextTurn(uint32_t unitId, BattleUnitTurnReason reason) = 0;
 
 	virtual void addUnit(uint32_t id, const JsonNode & data) = 0;
 	virtual void setUnitState(uint32_t id, const JsonNode & data, int64_t healthDelta) = 0;

--- a/lib/gameState/CGameStateCampaign.cpp
+++ b/lib/gameState/CGameStateCampaign.cpp
@@ -495,7 +495,17 @@ void CGameStateCampaign::generateCampaignHeroesToReplace()
 			if (nodeListIter == nodeList.end())
 				break;
 
-			auto hero = campaignState->crossoverDeserialize(*nodeListIter, gameState->map.get());
+			if (!gameState->players.count(placeholder->getOwner()))
+				continue; // illegal?
+
+			// It looks like heroes placeholder by power can only be replaced for human player
+			// Example where this is important: Spoils of War -> Greed
+			// Meanwhile, placeholders by hero ID can be replaced for AI as well
+			// Example: Armageddon's Blade -> To Kill A Hero
+			if (!gameState->players.at(placeholder->getOwner()).isHuman())
+				continue;
+
+			CGHeroInstance * hero = campaignState->crossoverDeserialize(*nodeListIter, gameState->map.get());
 			nodeListIter++;
 
 			logGlobal->info("Hero crossover: Loading placeholder as %d (%s)", hero->getHeroType(), hero->getNameTranslated());

--- a/lib/gameState/CGameStateCampaign.cpp
+++ b/lib/gameState/CGameStateCampaign.cpp
@@ -505,7 +505,7 @@ void CGameStateCampaign::generateCampaignHeroesToReplace()
 			if (!gameState->players.at(placeholder->getOwner()).isHuman())
 				continue;
 
-			CGHeroInstance * hero = campaignState->crossoverDeserialize(*nodeListIter, gameState->map.get());
+			auto hero = campaignState->crossoverDeserialize(*nodeListIter, gameState->map.get());
 			nodeListIter++;
 
 			logGlobal->info("Hero crossover: Loading placeholder as %d (%s)", hero->getHeroType(), hero->getNameTranslated());

--- a/lib/gameState/TavernHeroesPool.cpp
+++ b/lib/gameState/TavernHeroesPool.cpp
@@ -101,7 +101,7 @@ std::vector<const CGHeroInstance *> TavernHeroesPool::getHeroesFor(PlayerColor c
 
 	for(const auto & slot : currentTavern)
 	{
-		assert(slot.hero != nullptr);
+		assert(slot.hero.hasValue());
 		if (slot.player == color)
 			result.push_back(owner->getMap().tryGetFromHeroPool(slot.hero));
 	}

--- a/lib/gameState/TavernHeroesPool.cpp
+++ b/lib/gameState/TavernHeroesPool.cpp
@@ -59,11 +59,12 @@ void TavernHeroesPool::setHeroForPlayer(PlayerColor player, TavernHeroSlot slot,
 		return;
 
 	auto h = owner->getMap().tryGetFromHeroPool(hero);
+	assert(h != nullptr);
 
-	if (h && army)
+	if (army)
 		h->setToArmy(army);
 
-	if (h && replenishPoints)
+	if (replenishPoints)
 	{
 		h->setMovementPoints(h->movementPointsLimit(true));
 		h->mana = h->manaLimit();
@@ -100,6 +101,7 @@ std::vector<const CGHeroInstance *> TavernHeroesPool::getHeroesFor(PlayerColor c
 
 	for(const auto & slot : currentTavern)
 	{
+		assert(slot.hero != nullptr);
 		if (slot.player == color)
 			result.push_back(owner->getMap().tryGetFromHeroPool(slot.hero));
 	}

--- a/lib/mapObjectConstructors/CObjectClassesHandler.cpp
+++ b/lib/mapObjectConstructors/CObjectClassesHandler.cpp
@@ -217,16 +217,6 @@ TObjectTypeHandler CObjectClassesHandler::loadSubObjectFromJson(const std::strin
 		assert(handlerConstructors.count(handler) != 0);
 	}
 
-	// Compatibility with 1.5 mods for 1.6. To be removed in 1.7
-	// Detect banks that use old format and load them using old bank hander
-	if (baseObject->id == Obj::CREATURE_BANK)
-	{
-		if (entry.Struct().count("levels") && !entry.Struct().count("rewards"))
-			handler = "bank";
-		else
-			handler = "configurable";
-	}
-
 	auto createdObject = handlerConstructors.at(handler)();
 
 	createdObject->modScope = scope;

--- a/lib/networkPacks/NetPacksLib.cpp
+++ b/lib/networkPacks/NetPacksLib.cpp
@@ -2007,7 +2007,7 @@ void BattleNextRound::applyGs(CGameState *gs)
 
 void BattleSetActiveStack::applyGs(CGameState *gs)
 {
-	gs->getBattle(battleID)->nextTurn(stack);
+	gs->getBattle(battleID)->nextTurn(stack, reason);
 }
 
 void BattleTriggerEffect::applyGs(CGameState *gs)

--- a/lib/networkPacks/PacksForClientBattle.h
+++ b/lib/networkPacks/PacksForClientBattle.h
@@ -12,9 +12,10 @@
 #include "NetPacksBase.h"
 #include "BattleChanges.h"
 #include "PacksForClient.h"
-#include "../battle/BattleHexArray.h"
 #include "../battle/BattleAction.h"
 #include "../battle/BattleInfo.h"
+#include "../battle/BattleHexArray.h"
+#include "../battle/BattleUnitTurnReason.h"
 #include "../texts/MetaString.h"
 
 class CClient;
@@ -63,8 +64,8 @@ struct DLL_LINKAGE BattleSetActiveStack : public CPackForClient
 	void applyGs(CGameState * gs) override;
 
 	BattleID battleID = BattleID::NONE;
-	ui32 stack = 0;
-	ui8 askPlayerInterface = true;
+	uint32_t stack = 0;
+	BattleUnitTurnReason reason;
 
 	void visitTyped(ICPackVisitor & visitor) override;
 
@@ -72,7 +73,7 @@ struct DLL_LINKAGE BattleSetActiveStack : public CPackForClient
 	{
 		h & battleID;
 		h & stack;
-		h & askPlayerInterface;
+		h & reason;
 		assert(battleID != BattleID::NONE);
 	}
 };

--- a/server/CVCMIServer.cpp
+++ b/server/CVCMIServer.cpp
@@ -835,7 +835,7 @@ void CVCMIServer::setCampaignBonus(int bonusId)
 
 	const CampaignScenario & scenario = si->campState->scenario(campaignMap);
 	const std::vector<CampaignBonus> & bonDescs = scenario.travelOptions.bonusesToChoose;
-	if(bonDescs[bonusId].type == CampaignBonusType::HERO)
+	if(bonDescs[bonusId].type == CampaignBonusType::HERO || bonDescs[bonusId].type == CampaignBonusType::HEROES_FROM_PREVIOUS_SCENARIO)
 	{
 		for(auto & elem : si->playerInfos)
 		{

--- a/server/battles/BattleFlowProcessor.h
+++ b/server/battles/BattleFlowProcessor.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "../lib/battle/BattleSide.h"
+#include "../lib/battle/BattleUnitTurnReason.h"
 
 VCMI_LIB_NAMESPACE_BEGIN
 class CStack;
@@ -48,7 +49,7 @@ class BattleFlowProcessor : boost::noncopyable
 	void stackEnchantedTrigger(const CBattleInfoCallback & battle, const CStack * stack);
 	void removeObstacle(const CBattleInfoCallback & battle, const CObstacleInstance & obstacle);
 	void stackTurnTrigger(const CBattleInfoCallback & battle, const CStack * stack);
-	void setActiveStack(const CBattleInfoCallback & battle, const battle::Unit * stack);
+	void setActiveStack(const CBattleInfoCallback & battle, const battle::Unit * stack, BattleUnitTurnReason reason);
 
 	void makeStackDoNothing(const CBattleInfoCallback & battle, const CStack * next);
 	bool makeAutomaticAction(const CBattleInfoCallback & battle, const CStack * stack, BattleAction & ba); //used when action is taken by stack without volition of player (eg. unguided catapult attack)

--- a/server/battles/BattleResultProcessor.cpp
+++ b/server/battles/BattleResultProcessor.cpp
@@ -497,18 +497,6 @@ void BattleResultProcessor::battleFinalize(const BattleID & battleID, const Batt
 	//handle victory/loss of engaged players
 	gameHandler->checkVictoryLossConditions({finishingBattle->loser, finishingBattle->victor});
 
-	if (result.result == EBattleResult::SURRENDER)
-	{
-		gameHandler->gameState().statistic.accumulatedValues[finishingBattle->loser].numHeroSurrendered++;
-		gameHandler->heroPool->onHeroSurrendered(finishingBattle->loser, loserHero);
-	}
-
-	if (result.result == EBattleResult::ESCAPE)
-	{
-		gameHandler->gameState().statistic.accumulatedValues[finishingBattle->loser].numHeroEscaped++;
-		gameHandler->heroPool->onHeroEscaped(finishingBattle->loser, loserHero);
-	}
-
 	// Remove beaten hero
 	if(loserHero)
 	{
@@ -522,6 +510,18 @@ void BattleResultProcessor::battleFinalize(const BattleID & battleID, const Batt
 		gameHandler->sendAndApply(ro);
 		if(gameHandler->getSettings().getBoolean(EGameSettings::HEROES_RETREAT_ON_WIN_WITHOUT_TROOPS))
 			gameHandler->heroPool->onHeroEscaped(finishingBattle->victor, winnerHero);
+	}
+
+	if (result.result == EBattleResult::SURRENDER)
+	{
+		gameHandler->gameState().statistic.accumulatedValues[finishingBattle->loser].numHeroSurrendered++;
+		gameHandler->heroPool->onHeroSurrendered(finishingBattle->loser, loserHero);
+	}
+
+	if (result.result == EBattleResult::ESCAPE)
+	{
+		gameHandler->gameState().statistic.accumulatedValues[finishingBattle->loser].numHeroEscaped++;
+		gameHandler->heroPool->onHeroEscaped(finishingBattle->loser, loserHero);
 	}
 
 	finishingBattles.erase(battleID);

--- a/test/mock/mock_battle_IBattleState.h
+++ b/test/mock/mock_battle_IBattleState.h
@@ -42,7 +42,7 @@ public:
 	MOCK_CONST_METHOD1(getUsedSpells, std::vector<SpellID>(BattleSide));
 
 	MOCK_METHOD0(nextRound, void());
-	MOCK_METHOD1(nextTurn, void(uint32_t));
+	MOCK_METHOD2(nextTurn, void(uint32_t, BattleUnitTurnReason));
 	MOCK_METHOD2(addUnit, void(uint32_t, const JsonNode &));
 	MOCK_METHOD3(setUnitState, void(uint32_t, const JsonNode &, int64_t));
 	MOCK_METHOD2(moveUnit, void(uint32_t, const BattleHex &));


### PR DESCRIPTION
- Remove leftover part of compatibility code for loading old banks that was causing crashes if player has old mods
  - Fixes #5598
- Fix crash on AI evaluating hero pool after retreating from combat
  - Supersedes workaround from #5651
- Fix handling of campaign bonus where player can select color to play (e.g. third scenario in Spoils of War)
  - Fixes #5580
- Fix deadlock in AI on attempt to exit to main menu while in combat
  - Fixes #5636
- Fix inability of unit to cast spell after receiving morale. 
  - Also fixes bug where unit could not receive morale if player have casted spell during turn if this unit.
  - Fixes #5288