### PR TITLE
fix puzzle map never be revealed

### DIFF
--- a/client/mapView/MapView.cpp
+++ b/client/mapView/MapView.cpp
@@ -51,6 +51,7 @@ BasicMapView::BasicMapView(const Point & offset, const Point & dimensions)
 	: model(createModel(dimensions))
 	, tilesCache(new MapViewCache(model))
 	, controller(new MapViewController(model, tilesCache))
+	, needFullUpdate(false)
 {
 	OBJECT_CONSTRUCTION;
 	pos += offset;
@@ -76,7 +77,7 @@ void BasicMapView::tick(uint32_t msPassed)
 void BasicMapView::show(Canvas & to)
 {
 	CanvasClipRectGuard guard(to, pos);
-	render(to, false);
+	render(to, needFullUpdate);
 
 	controller->afterRender();
 }

--- a/client/mapView/MapView.h
+++ b/client/mapView/MapView.h
@@ -35,6 +35,8 @@ protected:
 	void render(Canvas & target, bool fullUpdate);
 
 public:
+	bool needFullUpdate;
+
 	BasicMapView(const Point & offset, const Point & dimensions);
 	~BasicMapView() override;
 

--- a/client/windows/CPuzzleWindow.cpp
+++ b/client/windows/CPuzzleWindow.cpp
@@ -43,6 +43,7 @@ CPuzzleWindow::CPuzzleWindow(const int3 & GrailPos, double discoveredRatio)
 	quitb->setBorderColor(Colors::METALLIC_GOLD);
 
 	mapView = std::make_shared<PuzzleMapView>(Point(8,9), Point(591, 544), grailPos);
+	mapView->needFullUpdate = true;
 
 	logo = std::make_shared<CPicture>(ImagePath::builtin("PUZZLOGO"), 607, 3);
 	title = std::make_shared<CLabel>(700, 95, FONT_BIG, ETextAlignment::CENTER, Colors::YELLOW, LIBRARY->generaltexth->allTexts[463]);
@@ -93,4 +94,7 @@ void CPuzzleWindow::show(Canvas & to)
 		currentAlpha -= animSpeed;
 	}
 	CWindowObject::show(to);
+
+	if(mapView->needFullUpdate && piecesToRemove.empty())
+		mapView->needFullUpdate = false;
 }


### PR DESCRIPTION
Fixed #5649

The rendering process for the puzzle map includes two steps:
1. Rendering the puzzle map view
2. Rendering the puzzle piece

The problem lies in the current draw method of the puzzle map view. When fullUpdate is set to false, and no changes have occurred in the map content (i.e., no new overlays), a lazy update is triggered. As a result, the puzzle map view is not refreshed.

However, the puzzle piece is still rendered on each frame with gradually increasing alpha values—for example, one frame might use alpha 255, the next 253, and so on. This causes the pieces to stack and eventually become fully opaque, even though they were intended to remain semi-transparent.

I added a switch to BasicMapView. This switch is enabled during the puzzle animation period to force a refresh of the puzzle map view before blending the semi-transparent puzzle piece. Once piecesToRemove is cleared—indicating the animation has finished—this switch is disabled again, as forced refresh is no longer necessary.