### PR TITLE
fix hangs after a siege battle

### DIFF
--- a/lib/mapObjects/CGTownInstance.cpp
+++ b/lib/mapObjects/CGTownInstance.cpp
@@ -644,7 +644,7 @@ void CGTownInstance::clearArmy() const
 {
 	while(!stacks.empty())
 	{
-		cb->eraseStack(StackLocation(id, stacks.begin()->first));
+		cb->eraseStack(StackLocation(id, stacks.begin()->first), true);
 	}
 }
 


### PR DESCRIPTION
If a hero is stationed outside the town with a full army of 7 stacks, and there is one army stack inside the town, a siege battle may occur. After the attacker wins, the 7 strongest stacks inside the town are removed, but the remaining last army stack cannot be cleared. This leads to repeated attempts to remove the army, all of which fail, eventually causing the game to freeze.

This commit enforces the removal of the remaining town army stack, effectively resolving the issue.