### PR TITLE
fix crash when opening available artifacts popup for a slot

### DIFF
--- a/lib/entities/artifact/CArtifact.cpp
+++ b/lib/entities/artifact/CArtifact.cpp
@@ -207,6 +207,8 @@ bool CArtifact::canBePutAt(const CArtifactSet * artSet, ArtifactPosition slot, b
 				auto possibleSlot = ArtifactUtils::getArtAnyPosition(&fittingSet, art->getId());
 				if(ArtifactUtils::isSlotEquipment(possibleSlot))
 				{
+					if (fittingSet.getSlot(possibleSlot) == nullptr)
+						fittingSet.artifactsWorn.insert(std::make_pair(possibleSlot, ArtSlotInfo(fittingSet.cb)));
 					fittingSet.lockSlot(possibleSlot);
 				}
 				else


### PR DESCRIPTION
Currently, determining whether a combo artifact can be shown in the popup window may cause a crash. The issue occurs because the function removes the artifact in the current slot from the fittingSet, but still tries to lock that slot in fittingSet when checking whether a combo artifact piece can be placed. This leads to access of a non-existent element in the artifactsWorn map, resulting in a crash.

My solution is to first check whether the slot exists in artifactsWorn. If it doesn't, I insert an empty artifact node and lock it. Since this function only checks whether an artifact can be placed and does not actually place it, this approach is appropriate. Locking the slot is also necessary—for example, the Bow of the Sharpshooter locks three misc slots, which would otherwise prevent Wizard's Well and Statue of Legion from being equipped.