### PR TITLE
fix load game crash

### DIFF
--- a/lib/gameState/CGameState.cpp
+++ b/lib/gameState/CGameState.cpp
@@ -1766,13 +1766,13 @@ void CGameState::loadGame(CLoadFile & file)
 	logGlobal->info("Loading game state...");
 
 	CMapHeader dummyHeader;
-	auto startInfo = std::make_shared<StartInfo>();
+	StartInfo dummyStartInfo;
 	ActiveModsInSaveList dummyActiveMods;
 
 	file.load(dummyHeader);
 	if (file.hasFeature(ESerializationVersion::NO_RAW_POINTERS_IN_SERIALIZER))
 	{
-		file.load(startInfo);
+		file.load(dummyStartInfo);
 		file.load(dummyActiveMods);
 		file.load(*this);
 	}
@@ -1781,7 +1781,7 @@ void CGameState::loadGame(CLoadFile & file)
 		bool dummyA = false;
 		uint32_t dummyB = 0;
 		uint16_t dummyC = 0;
-		file.load(startInfo);
+		file.load(dummyStartInfo);
 		file.load(dummyActiveMods);
 		file.load(dummyA);
 		file.load(dummyB);


### PR DESCRIPTION
Fixed #5679 

When saving the game, we serialize using a` StartInfo` object directly. However, when loading, we use a `shared_ptr<StartInfo>`. This causes the `BinaryDeserializer` to enter the code path for parsing shared_ptr, leading to incorrect format interpretation and ultimately a crash.