### PR TITLE
fix commander artifacts inactive when loading game

### DIFF
--- a/lib/mapObjects/CGHeroInstance.cpp
+++ b/lib/mapObjects/CGHeroInstance.cpp
@@ -1337,6 +1337,7 @@ void CGHeroInstance::restoreBonusSystem(CGameState & gs)
 {
 	CArmedInstance::restoreBonusSystem(gs);
 	artDeserializationFix(gs, this);
+	this->commander->artDeserializationFix(gs, this->commander.get());
 	if (boardedBoat.hasValue())
 	{
 		auto boat = gs.getObjInstance(boardedBoat);


### PR DESCRIPTION
Fixed #5682
`CArmedInstance::restoreBonusSystem` only considers stacks in slots, seemingly neglecting the commander.