### PR TITLE
Fix incorrect assertion in CArtPlace::setArtifact

### DIFF
--- a/client/widgets/CComponentHolder.cpp
+++ b/client/widgets/CComponentHolder.cpp
@@ -117,7 +117,7 @@ void CArtPlace::setArtifact(const ArtifactID & newArtId, const SpellID & newSpel
 	if(artId == ArtifactID::SPELL_SCROLL)
 	{
 		spellId = newSpellId;
-		assert(spellId.num > 0);
+		assert(spellId != SpellID::NONE);
 
 		if(settings["general"]["enableUiEnhancements"].Bool())
 		{


### PR DESCRIPTION
Hi! I have encountered a bug while playing vcmi. The commit message is self-explanatory:

This fixes a crash in debug builds when the player tries to access a hero's inventory and the hero has a "Summon Boat" spell scroll.