### PR TITLE
fix crash when loading game in battle

### DIFF
--- a/client/Client.cpp
+++ b/client/Client.cpp
@@ -191,7 +191,6 @@ void CClient::endGame()
 	removeGUI();
 
 	GAME->setMapInstance(nullptr);
-	gamestate.reset();
 
 	logNetwork->info("Deleted mapHandler and gameState.");
 
@@ -200,6 +199,11 @@ void CClient::endGame()
 	battleints.clear();
 	battleCallbacks.clear();
 	playerEnvironments.clear();
+
+	//FIXME: gamestate->currentBattles.clear() will use gamestate. So it shoule be callded before gamestate.reset()
+	gamestate->currentBattles.clear();
+	gamestate.reset();
+
 	logNetwork->info("Deleted playerInts.");
 	logNetwork->info("Client stopped.");
 }


### PR DESCRIPTION
fixed #5689

my friend [nickhuang99](https://github.com/vcmi/vcmi/issues?q=is%3Apr+is%3Aopen+author%3Anickhuang99) fix this problem. He ask me to make a pr. Maybe some code of `gamestate` need to be refactoring. `gamestate.reset()` set gamestate to nullptr, but it is used in some other objects' destruction, even `gamestate->currentBattles`.
