### PR TITLE
fix crash in map loading

### DIFF
--- a/lib/gameState/CGameState.cpp
+++ b/lib/gameState/CGameState.cpp
@@ -624,6 +624,7 @@ void CGameState::initHeroes()
 
 			boat->setAnchorPos(hero->anchorPos());
 			boat->appearance = handler->getTemplates().front();
+			map->generateUniqueInstanceName(boat.get());
 			map->addNewObject(boat);
 			hero->setBoat(boat.get());
 		}

--- a/lib/gameState/CGameState.h
+++ b/lib/gameState/CGameState.h
@@ -48,6 +48,7 @@ DLL_LINKAGE std::ostream & operator<<(std::ostream & os, const EVictoryLossCheck
 class DLL_LINKAGE CGameState : public CNonConstInfoCallback, public Serializeable, public GameCallbackHolder
 {
 	friend class CGameStateCampaign;
+	friend class CMapLoaderH3M;
 
 	std::shared_ptr<StartInfo> initialOpts; //copy of settings received from pregame (not randomized)
 	std::shared_ptr<StartInfo> scenarioOps;

--- a/lib/mapping/MapFormatH3M.cpp
+++ b/lib/mapping/MapFormatH3M.cpp
@@ -24,6 +24,7 @@
 #include "../RoadHandler.h"
 #include "../TerrainHandler.h"
 #include "../GameLibrary.h"
+#include "../gameState/CGameState.h"
 #include "../constants/StringConstants.h"
 #include "../entities/artifact/CArtHandler.h"
 #include "../entities/hero/CHeroHandler.h"
@@ -77,7 +78,18 @@ std::unique_ptr<CMap> CMapLoaderH3M::loadMap(IGameCallback * cb)
 	// Init map object by parsing the input buffer
 	map = new CMap(cb);
 	mapHeader = std::unique_ptr<CMapHeader>(dynamic_cast<CMapHeader *>(map));
-	init();
+
+	//FIXME:  The init function may put artifacts to hero, which triggers a call to cb->gameState().getMap(), will return nullptr, leading to a crash. This code needs to be refactored.
+	if (cb)
+	{
+		cb->gameState().map = std::unique_ptr<CMap>(map);
+		init();
+		cb->gameState().map.release();
+	}
+	else // FIXME: in mapeditor cb is nullptr, which causes some issues during init.
+	{
+		init();
+	}
 
 	return std::unique_ptr<CMap>(dynamic_cast<CMap *>(mapHeader.release()));
 }


### PR DESCRIPTION
Some maps require placing artifacts during initialization, which involves accessing the map field in gameState. However, this field is still being constructed during init and hasn't been assigned yet, which leads to a crash. I’ve written a temporary fix for now, but ideally, the code should be refactored if time permits. Additionally, these bugs are catastrophic in the map editor—cb is completely unavailable, making it impossible to use gameState. This part might have to be scrapped altogether.