### PR TITLE
fix crash during loading map

### DIFF
--- a/lib/mapObjects/CGHeroInstance.cpp
+++ b/lib/mapObjects/CGHeroInstance.cpp
@@ -1613,7 +1613,8 @@ void CGHeroInstance::levelUp(const std::vector<SecondarySkill> & skills)
 
 void CGHeroInstance::attachCommanderToArmy()
 {
-	commander->setArmy(this);
+	if (commander)
+		commander->setArmy(this);
 }
 
 void CGHeroInstance::levelUpAutomatically(vstd::RNG & rand)


### PR DESCRIPTION
When loading certain maps, such as Hota's dead man's tales, the commander pointer may be nullptr, which will lead to a crash.