### PR TITLE
Fix commander levelups

### DIFF
--- a/lib/CCreatureSet.cpp
+++ b/lib/CCreatureSet.cpp
@@ -781,12 +781,7 @@ void CStackInstance::giveTotalStackExperience(TExpType experienceToGive)
 	if (!canGainExperience())
 		return;
 
-	int level = std::clamp(getLevel(), 1, 7);
-	TExpType maxAmountPerUnit = LIBRARY->creh->expRanks[level].back();
-	TExpType maxExperience = maxAmountPerUnit * getCount();
-	TExpType maxExperienceToGain = maxExperience - totalExperience;
-	TExpType actualGainedExperience = std::min(maxExperienceToGain, experienceToGive);
-	totalExperience	+= actualGainedExperience;
+	totalExperience	+= experienceToGive;
 }
 
 TExpType CStackInstance::getTotalExperience() const
@@ -1064,7 +1059,7 @@ void CCommanderInstance::setAlive (bool Alive)
 
 bool CCommanderInstance::canGainExperience() const
 {
-	return alive && CStackInstance::canGainExperience();
+	return alive;
 }
 
 int CCommanderInstance::getExpRank() const

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -149,6 +149,8 @@ void CGameHandler::levelUpHero(const CGHeroInstance * hero)
 	// required exp for at least 1 lvl-up hasn't been reached
 	if (!hero->gainsLevel())
 	{
+		if (hero->getCommander() && hero->getCommander()->gainsLevel())
+			levelUpCommander(hero->getCommander());
 		return;
 	}
 
@@ -338,11 +340,6 @@ void CGameHandler::expGiven(const CGHeroInstance *hero)
 		levelUpHero(hero);
 	else if (hero->getCommander() && hero->getCommander()->gainsLevel())
 		levelUpCommander(hero->getCommander());
-
-	//if (hero->commander && hero->level > hero->commander->level && hero->commander->gainsLevel())
-// 		levelUpCommander(hero->commander);
-// 	else
-// 		levelUpHero(hero);
 }
 
 void CGameHandler::giveExperience(const CGHeroInstance * hero, TExpType amountToGain)


### PR DESCRIPTION
- Fixes commander not receiving experience if stack experience is off
- Fixes commander not leveling up when hero fill his secondary skills
- Fixes #5697