### PR TITLE
Fix crash on playing spellbook pageflip video

### DIFF
--- a/client/media/CVideoHandler.cpp
+++ b/client/media/CVideoHandler.cpp
@@ -376,7 +376,7 @@ FFMpegStream::~FFMpegStream()
 
 	// for some reason, buffer is managed (e.g. reallocated) by FFmpeg
 	// however, it must still be freed manually by user
-	if (context->buffer)
+	if (context && context->buffer)
 		av_free(context->buffer);
 	av_free(context);
 }

--- a/client/windows/CSpellWindow.cpp
+++ b/client/windows/CSpellWindow.cpp
@@ -520,7 +520,7 @@ void CSpellWindow::turnPageRight()
 {
 	OBJECT_CONSTRUCTION;
 	if(settings["video"]["spellbookAnimation"].Bool() && !isBigSpellbook)
-		video = std::make_shared<VideoWidgetOnce>(Point(13, 14), VideoPath::builtin("PGTRNRENGINE->SMK"), false, this);
+		video = std::make_shared<VideoWidgetOnce>(Point(13, 14), VideoPath::builtin("PGTRNRGH.SMK"), false, this);
 }
 
 void CSpellWindow::onVideoPlaybackFinished()


### PR DESCRIPTION
Was reported on Discord.
- Fixes corrupted name of spellbook page flip video
- Fixes possible crash on deleting invalid video instance