### PR TITLE
Charged artifacts

### DIFF
--- a/Mods/vcmi/Content/config/english.json
+++ b/Mods/vcmi/Content/config/english.json
@@ -28,6 +28,8 @@
 	"vcmi.adventureMap.movementPointsHeroInfo"           : "(Movement points: %REMAINING / %POINTS)",
 	"vcmi.adventureMap.replayOpponentTurnNotImplemented" : "Sorry, replay opponent turn is not implemented yet!",
 
+	"vcmi.artifact.charges" : "Charges",
+
 	"vcmi.bonusSource.artifact" : "Artifact",
 	"vcmi.bonusSource.creature" : "Ability",
 	"vcmi.bonusSource.spell" : "Spell",

--- a/client/NetPacksClient.cpp
+++ b/client/NetPacksClient.cpp
@@ -847,12 +847,12 @@ void ApplyClientNetPackVisitor::visitBattleResultsApplied(BattleResultsApplied &
 			UIHelper::getEagleEyeInfoWindowText(*hero, pack.learnedSpells.spells), UIHelper::getSpellsComponents(pack.learnedSpells.spells), soundBase::soundID(0));
 	}
 
-	if(!pack.artifacts.empty())
+	if(!pack.movingArtifacts.empty())
 	{
-		const auto artSet = GAME->interface()->cb->getArtSet(ArtifactLocation(pack.artifacts.front().dstArtHolder));
+		const auto artSet = GAME->interface()->cb->getArtSet(ArtifactLocation(pack.movingArtifacts.front().dstArtHolder));
 		assert(artSet);
 		std::vector<Component> artComponents;
-		for(const auto & artPack : pack.artifacts)
+		for(const auto & artPack : pack.movingArtifacts)
 		{
 			auto packComponents = UIHelper::getArtifactsComponents(*artSet, artPack.artsPack0);
 			artComponents.insert(artComponents.end(), std::make_move_iterator(packComponents.begin()), std::make_move_iterator(packComponents.end()));
@@ -861,7 +861,7 @@ void ApplyClientNetPackVisitor::visitBattleResultsApplied(BattleResultsApplied &
 			artComponents, soundBase::soundID(0));
 	}
 
-	for(auto & artPack : pack.artifacts)
+	for(auto & artPack : pack.movingArtifacts)
 		visitBulkMoveArtifacts(artPack);
 
 	if(pack.raisedStack.getCreature())

--- a/client/widgets/CArtifactsOfHeroBase.cpp
+++ b/client/widgets/CArtifactsOfHeroBase.cpp
@@ -276,7 +276,8 @@ void CArtifactsOfHeroBase::setSlotData(ArtPlacePtr artPlace, const ArtifactPosit
 
 		const auto curArt = slotInfo->getArt();
 		// If the artifact has charges, add charges information
-		artPlace->addChargesArtInfo(curArt->valOfBonuses(BonusType::ARTIFACT_CHARGE));
+		if(curArt->getType()->isCharged())
+			artPlace->addChargedArtInfo(curArt->getCharges());
 
 		if(curArt->isCombined())
 			return;

--- a/client/widgets/CArtifactsOfHeroBase.cpp
+++ b/client/widgets/CArtifactsOfHeroBase.cpp
@@ -271,7 +271,14 @@ void CArtifactsOfHeroBase::setSlotData(ArtPlacePtr artPlace, const ArtifactPosit
 	{
 		artPlace->lockSlot(slotInfo->locked);
 		artPlace->setArtifact(slotInfo->getArt()->getTypeId(), slotInfo->getArt()->getScrollSpellID());
-		if(slotInfo->locked || slotInfo->getArt()->isCombined())
+		if(slotInfo->locked)
+			return;
+
+		const auto curArt = slotInfo->getArt();
+		// If the artifact has charges, add charges information
+		artPlace->addChargesArtInfo(curArt->valOfBonuses(BonusType::ARTIFACT_CHARGE));
+
+		if(curArt->isCombined())
 			return;
 
 		// If the artifact is part of at least one combined artifact, add additional information

--- a/client/widgets/CComponentHolder.cpp
+++ b/client/widgets/CComponentHolder.cpp
@@ -263,16 +263,15 @@ void CArtPlace::addCombinedArtInfo(const std::map<const ArtifactID, std::vector<
 	}
 }
 
-void CArtPlace::addChargesArtInfo(const int charges)
+void CArtPlace::addChargedArtInfo(const uint16_t charges)
 {
-	if(charges > 0)
-	{
-		MetaString info;
-		info.appendTextID("vcmi.artifact.charges");
-		info.appendRawString(" %d");
-		info.replaceNumber(charges);
-		text += info.toString();
-	}
+	MetaString info;
+	info.appendEOL();
+	info.appendEOL();
+	info.appendTextID("vcmi.artifact.charges");
+	info.appendRawString(" %d");
+	info.replaceNumber(charges);
+	text += info.toString();
 }
 
 CSecSkillPlace::CSecSkillPlace(const Point & position, const ImageSize & imageSize, const SecondarySkill & newSkillId, const uint8_t level)

--- a/client/widgets/CComponentHolder.cpp
+++ b/client/widgets/CComponentHolder.cpp
@@ -263,6 +263,18 @@ void CArtPlace::addCombinedArtInfo(const std::map<const ArtifactID, std::vector<
 	}
 }
 
+void CArtPlace::addChargesArtInfo(const int charges)
+{
+	if(charges > 0)
+	{
+		MetaString info;
+		info.appendTextID("vcmi.artifact.charges");
+		info.appendRawString(" %d");
+		info.replaceNumber(charges);
+		text += info.toString();
+	}
+}
+
 CSecSkillPlace::CSecSkillPlace(const Point & position, const ImageSize & imageSize, const SecondarySkill & newSkillId, const uint8_t level)
 	: CComponentHolder(Rect(position, Point()), Point())
 {

--- a/client/widgets/CComponentHolder.h
+++ b/client/widgets/CComponentHolder.h
@@ -44,7 +44,7 @@ public:
 	void lockSlot(bool on);
 	bool isLocked() const;
 	void addCombinedArtInfo(const std::map<const ArtifactID, std::vector<ArtifactID>> & arts);
-	void addChargesArtInfo(const int charges);
+	void addChargedArtInfo(const uint16_t charges);
 
 private:
 	ArtifactID artId;

--- a/client/widgets/CComponentHolder.h
+++ b/client/widgets/CComponentHolder.h
@@ -44,6 +44,7 @@ public:
 	void lockSlot(bool on);
 	bool isLocked() const;
 	void addCombinedArtInfo(const std::map<const ArtifactID, std::vector<ArtifactID>> & arts);
+	void addChargesArtInfo(const int charges);
 
 private:
 	ArtifactID artId;

--- a/config/schemas/artifact.json
+++ b/config/schemas/artifact.json
@@ -142,7 +142,7 @@
 				"removeOnDepletion" : {
 					"type" : "boolean",
 				},
-				"val" : {
+				"startingCharges" : {
 					"type" : "number",
 					"description" : "Default starting charge amount"
 				}

--- a/config/schemas/artifact.json
+++ b/config/schemas/artifact.json
@@ -128,6 +128,25 @@
 		"onlyOnWaterMap" : {
 			"type" : "boolean",
 			"description" : "If set to true, artifact won't spawn on a map without water"
+		},
+		"charged": {
+			"type" : "object",
+			"additionalProperties" : false,
+			"description" : "Determines charged artifact behavior",
+			"required" : ["usageType"],
+			"properties" : {
+				"usageType": {
+					"type" : "string",
+					"enum" : ["SPELLCAST", "BATTLE", "BUILDING"],
+				},
+				"removeOnDepletion" : {
+					"type" : "boolean",
+				},
+				"val" : {
+					"type" : "number",
+					"description" : "Default number of charges"
+				}
+			}
 		}
 	}
 }

--- a/config/schemas/artifact.json
+++ b/config/schemas/artifact.json
@@ -144,7 +144,7 @@
 				},
 				"val" : {
 					"type" : "number",
-					"description" : "Default number of charges"
+					"description" : "Default starting charge amount"
 				}
 			}
 		}

--- a/docs/modders/Bonus/Bonus_Types.md
+++ b/docs/modders/Bonus/Bonus_Types.md
@@ -1031,9 +1031,15 @@ Increases amount of information available in affected thieves guild (in town or 
 
 - val: additional number of 'levels' of information to grant access to
 
-### LEVEL_COUNTER
+### ARTIFACT_GROWING
 
 Internal bonus, do not use
+
+### ARTIFACT_CHARGE
+
+Consumable bonus. Used to perform actions specified by a specific artifact.
+
+- val: number of charges
 
 ### DISINTEGRATE
 

--- a/docs/modders/Bonus/Bonus_Types.md
+++ b/docs/modders/Bonus/Bonus_Types.md
@@ -1037,7 +1037,7 @@ Internal bonus, do not use
 
 ### ARTIFACT_CHARGE
 
-Consumable bonus. Used to perform actions specified by a specific artifact.
+Consumable bonus. Used to perform actions specified by a charged artifact.
 
 - val: number of charges
 

--- a/docs/modders/Entities_Format/Artifact_Format.md
+++ b/docs/modders/Entities_Format/Artifact_Format.md
@@ -98,7 +98,7 @@ In order to make functional artifact you also need:
     // Optional, by default is false. Remove when fully discharged
     "removeOnDepletion" : true,
     // Optional, by default is 0. Default starting charge amount.
-    "val" : 2,
+    "startingCharges" : 2,
 	}
 }
 ```

--- a/docs/modders/Entities_Format/Artifact_Format.md
+++ b/docs/modders/Entities_Format/Artifact_Format.md
@@ -87,5 +87,18 @@ In order to make functional artifact you also need:
 		"bonusesPerLevel" : {},
 		"thresholdBonuses" : {},
 	}
+
+	// Optional, used for artifacts with charges.
+	"charged" : {
+    // Artifact discharging action
+    // SPELLCAST - Consumes a charge for each spellcast. Applies to every spell added through the "bonuses" section.
+    // BATTLE - Consumes one charge per battle.
+    // BUILDING (not implemented)
+    "usageType": "BATTLE",
+    // Optional, by default is false. Remove when fully discharged
+    "removeOnDepletion" : true,
+    // Optional, by default is 0. Default starting charge amount.
+    "val" : 2,
+	}
 }
 ```

--- a/lib/bonuses/BonusEnum.h
+++ b/lib/bonuses/BonusEnum.h
@@ -16,7 +16,7 @@ class JsonNode;
 
 #define BONUS_LIST										\
 	BONUS_NAME(NONE) 									\
-	BONUS_NAME(LEVEL_COUNTER) /* for commander artifacts*/ \
+	BONUS_NAME(ARTIFACT_GROWING) \
 	BONUS_NAME(MOVEMENT) /*Subtype is 1 - land, 0 - sea*/ \
 	BONUS_NAME(MORALE) \
 	BONUS_NAME(LUCK) \

--- a/lib/bonuses/BonusEnum.h
+++ b/lib/bonuses/BonusEnum.h
@@ -17,6 +17,7 @@ class JsonNode;
 #define BONUS_LIST										\
 	BONUS_NAME(NONE) 									\
 	BONUS_NAME(ARTIFACT_GROWING) \
+	BONUS_NAME(ARTIFACT_CHARGE) \
 	BONUS_NAME(MOVEMENT) /*Subtype is 1 - land, 0 - sea*/ \
 	BONUS_NAME(MORALE) \
 	BONUS_NAME(LUCK) \

--- a/lib/entities/artifact/CArtHandler.cpp
+++ b/lib/entities/artifact/CArtHandler.cpp
@@ -226,9 +226,9 @@ std::shared_ptr<CArtifact> CArtHandler::loadFromJson(const std::string & scope, 
 		art->setCondition(stringToDischargeCond(node["charged"]["usageType"].String()));
 		if(!node["charged"]["removeOnDepletion"].isNull())
 			art->setRemoveOnDepletion(node["charged"]["removeOnDepletion"].Bool());
-		if(!node["charged"]["val"].isNull())
+		if(!node["charged"]["startingCharges"].isNull())
 		{
-			const auto charges = node["charged"]["val"].Integer();
+			const auto charges = node["charged"]["startingCharges"].Integer();
 			if(charges < 0)
 				logMod->warn("Warning! Charged artifact %s number of charges cannot be less than zero %d!", art->getNameTranslated(), charges);
 			else
@@ -335,7 +335,7 @@ DischargeArtifactCondition CArtHandler::stringToDischargeCond(const std::string 
 	{
 		{"SPELLCAST", DischargeArtifactCondition::SPELLCAST},
 		{"BATTLE", DischargeArtifactCondition::BATTLE},
-		{"BUILDING", DischargeArtifactCondition::BUILDING},
+		//{"BUILDING", DischargeArtifactCondition::BUILDING},
 	};
 	return growingConditionsMap.at(cond);
 }

--- a/lib/entities/artifact/CArtHandler.cpp
+++ b/lib/entities/artifact/CArtHandler.cpp
@@ -152,20 +152,6 @@ std::shared_ptr<CArtifact> CArtHandler::loadFromJson(const std::string & scope, 
 			JsonUtils::parseBonus(bonus["bonus"], &art->thresholdBonuses.back().second);
 		}
 	}
-	if(!node["charged"].isNull())
-	{
-		art->setCondition(stringToDischargeCond(node["charged"]["usageType"].String()));
-		if(!node["charged"]["removeOnDepletion"].isNull())
-			art->setRemoveOnDepletion(node["charged"]["removeOnDepletion"].Bool());
-		if(!node["charged"]["val"].isNull())
-		{
-			const auto charges = node["charged"]["val"].Integer();
-			if(charges < 0)
-				logMod->warn("Warning! Charged artifact number of charges cannot be less than zero %d!", charges);
-			else
-				art->setDefaultStartCharges(charges);
-		}
-	}
 
 	art->id = ArtifactID(index);
 	art->identifier = identifier;
@@ -234,6 +220,23 @@ std::shared_ptr<CArtifact> CArtHandler::loadFromJson(const std::string & scope, 
 
 	if(art->isTradable())
 		art->possibleSlots.at(ArtBearer::ALTAR).push_back(ArtifactPosition::ALTAR);
+
+	if(!node["charged"].isNull())
+	{
+		art->setCondition(stringToDischargeCond(node["charged"]["usageType"].String()));
+		if(!node["charged"]["removeOnDepletion"].isNull())
+			art->setRemoveOnDepletion(node["charged"]["removeOnDepletion"].Bool());
+		if(!node["charged"]["val"].isNull())
+		{
+			const auto charges = node["charged"]["val"].Integer();
+			if(charges < 0)
+				logMod->warn("Warning! Charged artifact %s number of charges cannot be less than zero %d!", art->getNameTranslated(), charges);
+			else
+				art->setDefaultStartCharges(charges);
+		}
+		if(art->getDischargeCondition() == DischargeArtifactCondition::SPELLCAST && art->getBonusesOfType(BonusType::SPELL)->size() == 0)
+			logMod->warn("Warning! %s condition of discharge is \"SPELLCAST\", but there is not a single spell.", art->getNameTranslated());
+	}
 
 	return art;
 }
@@ -326,7 +329,7 @@ EArtifactClass CArtHandler::stringToClass(const std::string & className)
 	return EArtifactClass::ART_SPECIAL;
 }
 
-DischargeArtifactCondition CArtHandler::stringToDischargeCond(const std::string & cond)
+DischargeArtifactCondition CArtHandler::stringToDischargeCond(const std::string & cond) const
 {
 	const std::unordered_map<std::string, DischargeArtifactCondition> growingConditionsMap =
 	{

--- a/lib/entities/artifact/CArtHandler.h
+++ b/lib/entities/artifact/CArtHandler.h
@@ -24,7 +24,7 @@ public:
 	void addBonuses(CArtifact * art, const JsonNode & bonusList);
 
 	static EArtifactClass stringToClass(const std::string & className); //TODO: rework EartClass to make this a constructor
-	DischargeArtifactCondition stringToDischargeCond(const std::string & cond);
+	DischargeArtifactCondition stringToDischargeCond(const std::string & cond) const;
 
 	bool legalArtifact(const ArtifactID & id) const;
 	static void makeItCreatureArt(CArtifact * a, bool onlyCreature = true);

--- a/lib/entities/artifact/CArtHandler.h
+++ b/lib/entities/artifact/CArtHandler.h
@@ -24,6 +24,7 @@ public:
 	void addBonuses(CArtifact * art, const JsonNode & bonusList);
 
 	static EArtifactClass stringToClass(const std::string & className); //TODO: rework EartClass to make this a constructor
+	DischargeArtifactCondition stringToDischargeCond(const std::string & cond);
 
 	bool legalArtifact(const ArtifactID & id) const;
 	static void makeItCreatureArt(CArtifact * a, bool onlyCreature = true);

--- a/lib/entities/artifact/CArtifact.cpp
+++ b/lib/entities/artifact/CArtifact.cpp
@@ -282,6 +282,11 @@ std::optional<DischargeArtifactCondition> CChargedArtifact::getDischargeConditio
 	return condition;
 }
 
+bool CChargedArtifact::getRemoveOnDepletion() const
+{
+	return removeOnDepletion;
+}
+
 CArtifact::CArtifact()
 	: iconIndex(ArtifactID::NONE),
 	price(0)

--- a/lib/entities/artifact/CArtifact.cpp
+++ b/lib/entities/artifact/CArtifact.cpp
@@ -257,9 +257,9 @@ bool CChargedArtifact::isCharged() const
 	return condition.has_value();
 }
 
-void CChargedArtifact::setCondition(const DischargeArtifactCondition & condition)
+void CChargedArtifact::setCondition(const DischargeArtifactCondition & dischargeCondition)
 {
-	this->condition = condition;
+	condition = dischargeCondition;
 }
 
 void CChargedArtifact::setRemoveOnDepletion(const bool remove)

--- a/lib/entities/artifact/CArtifact.cpp
+++ b/lib/entities/artifact/CArtifact.cpp
@@ -247,14 +247,15 @@ bool CArtifact::canBePutAt(const CArtifactSet * artSet, ArtifactPosition slot, b
 }
 
 CChargedArtifact::CChargedArtifact()
-	: removeOnDepletion(false)
+	: condition(DischargeArtifactCondition::NONE)
+	,	removeOnDepletion(false)
 	, defaultStartCharges(0)
 {
 }
 
 bool CChargedArtifact::isCharged() const
 {
-	return condition.has_value();
+	return condition != DischargeArtifactCondition::NONE;
 }
 
 void CChargedArtifact::setCondition(const DischargeArtifactCondition & dischargeCondition)
@@ -277,7 +278,7 @@ uint16_t CChargedArtifact::getDefaultStartCharges() const
 	return defaultStartCharges;
 }
 
-std::optional<DischargeArtifactCondition> CChargedArtifact::getDischargeCondition() const
+DischargeArtifactCondition CChargedArtifact::getDischargeCondition() const
 {
 	return condition;
 }

--- a/lib/entities/artifact/CArtifact.cpp
+++ b/lib/entities/artifact/CArtifact.cpp
@@ -246,6 +246,42 @@ bool CArtifact::canBePutAt(const CArtifactSet * artSet, ArtifactPosition slot, b
 	}
 }
 
+CChargedArtifact::CChargedArtifact()
+	: removeOnDepletion(false)
+	, defaultStartCharges(0)
+{
+}
+
+bool CChargedArtifact::isCharged() const
+{
+	return condition.has_value();
+}
+
+void CChargedArtifact::setCondition(const DischargeArtifactCondition & condition)
+{
+	this->condition = condition;
+}
+
+void CChargedArtifact::setRemoveOnDepletion(const bool remove)
+{
+	removeOnDepletion = remove;
+}
+
+void CChargedArtifact::setDefaultStartCharges(const uint16_t charges)
+{
+	defaultStartCharges = charges;
+}
+
+uint16_t CChargedArtifact::getDefaultStartCharges() const
+{
+	return defaultStartCharges;
+}
+
+std::optional<DischargeArtifactCondition> CChargedArtifact::getDischargeCondition() const
+{
+	return condition;
+}
+
 CArtifact::CArtifact()
 	: iconIndex(ArtifactID::NONE),
 	price(0)

--- a/lib/entities/artifact/CArtifact.h
+++ b/lib/entities/artifact/CArtifact.h
@@ -9,10 +9,13 @@
  */
 #pragma once
 
+#include "StdInc.h"
+
 #include "ArtBearer.h"
 #include "EArtifactClass.h"
 
 #include "../../bonuses/CBonusSystemNode.h"
+#include "../../networkPacks/ArtifactLocation.h"
 
 #include <vcmi/Artifact.h>
 
@@ -64,8 +67,28 @@ public:
 	const std::vector<std::pair<ui16, Bonus>> & getThresholdBonuses() const;
 };
 
+class DLL_LINKAGE CChargedArtifact
+{
+	std::optional<DischargeArtifactCondition> condition;
+	bool removeOnDepletion;
+	uint16_t defaultStartCharges;
+
+protected:
+	CChargedArtifact();
+
+public:
+	bool isCharged() const;
+
+	void setCondition(const DischargeArtifactCondition & condition);
+	void setRemoveOnDepletion(const bool remove);
+	void setDefaultStartCharges(const uint16_t charges);
+	uint16_t getDefaultStartCharges() const;
+	std::optional<DischargeArtifactCondition> getDischargeCondition() const;
+};
+
 // Container for artifacts. Not for instances.
-class DLL_LINKAGE CArtifact final : public Artifact, public CBonusSystemNode, public CCombinedArtifact, public CScrollArtifact, public CGrowingArtifact
+class DLL_LINKAGE CArtifact final : public Artifact, public CBonusSystemNode,
+		public CCombinedArtifact, public CScrollArtifact, public CGrowingArtifact, public CChargedArtifact
 {
 	ArtifactID id;
 	std::string image;

--- a/lib/entities/artifact/CArtifact.h
+++ b/lib/entities/artifact/CArtifact.h
@@ -84,6 +84,7 @@ public:
 	void setDefaultStartCharges(const uint16_t charges);
 	uint16_t getDefaultStartCharges() const;
 	std::optional<DischargeArtifactCondition> getDischargeCondition() const;
+	bool getRemoveOnDepletion() const;
 };
 
 // Container for artifacts. Not for instances.

--- a/lib/entities/artifact/CArtifact.h
+++ b/lib/entities/artifact/CArtifact.h
@@ -79,7 +79,7 @@ protected:
 public:
 	bool isCharged() const;
 
-	void setCondition(const DischargeArtifactCondition & condition);
+	void setCondition(const DischargeArtifactCondition & dischargeCondition);
 	void setRemoveOnDepletion(const bool remove);
 	void setDefaultStartCharges(const uint16_t charges);
 	uint16_t getDefaultStartCharges() const;

--- a/lib/entities/artifact/CArtifact.h
+++ b/lib/entities/artifact/CArtifact.h
@@ -9,8 +9,6 @@
  */
 #pragma once
 
-#include "StdInc.h"
-
 #include "ArtBearer.h"
 #include "EArtifactClass.h"
 
@@ -69,7 +67,7 @@ public:
 
 class DLL_LINKAGE CChargedArtifact
 {
-	std::optional<DischargeArtifactCondition> condition;
+	DischargeArtifactCondition condition;
 	bool removeOnDepletion;
 	uint16_t defaultStartCharges;
 
@@ -83,7 +81,7 @@ public:
 	void setRemoveOnDepletion(const bool remove);
 	void setDefaultStartCharges(const uint16_t charges);
 	uint16_t getDefaultStartCharges() const;
-	std::optional<DischargeArtifactCondition> getDischargeCondition() const;
+	DischargeArtifactCondition getDischargeCondition() const;
 	bool getRemoveOnDepletion() const;
 };
 

--- a/lib/entities/artifact/CArtifactInstance.cpp
+++ b/lib/entities/artifact/CArtifactInstance.cpp
@@ -99,17 +99,16 @@ void CGrowingArtifactInstance::growingUp()
 	
 	if(artInst->getType()->isGrowing())
 	{
-
-		auto bonus = std::make_shared<Bonus>();
-		bonus->type = BonusType::LEVEL_COUNTER;
-		bonus->val = 1;
-		bonus->duration = BonusDuration::COMMANDER_KILLED;
-		artInst->accumulateBonus(bonus);
+		auto growingBonus = std::make_shared<Bonus>();
+		growingBonus->type = BonusType::ARTIFACT_GROWING;
+		growingBonus->val = 1;
+		growingBonus->duration = BonusDuration::PERMANENT;
+		artInst->accumulateBonus(growingBonus);
 
 		for(const auto & bonus : artInst->getType()->getBonusesPerLevel())
 		{
 			// Every n levels
-			if(artInst->valOfBonuses(BonusType::LEVEL_COUNTER) % bonus.first == 0)
+			if(artInst->valOfBonuses(BonusType::ARTIFACT_GROWING) % bonus.first == 0)
 			{
 				artInst->accumulateBonus(std::make_shared<Bonus>(bonus.second));
 			}
@@ -117,7 +116,7 @@ void CGrowingArtifactInstance::growingUp()
 		for(const auto & bonus : artInst->getType()->getThresholdBonuses())
 		{
 			// At n level
-			if(artInst->valOfBonuses(BonusType::LEVEL_COUNTER) == bonus.first)
+			if(artInst->valOfBonuses(BonusType::ARTIFACT_GROWING) == bonus.first)
 			{
 				artInst->addNewBonus(std::make_shared<Bonus>(bonus.second));
 			}

--- a/lib/entities/artifact/CArtifactInstance.cpp
+++ b/lib/entities/artifact/CArtifactInstance.cpp
@@ -96,16 +96,15 @@ SpellID CScrollArtifactInstance::getScrollSpellID() const
 void CGrowingArtifactInstance::growingUp()
 {
 	auto artInst = static_cast<CArtifactInstance*>(this);
+	const auto artType = artInst->getType();
 	
-	if(artInst->getType()->isGrowing())
+	if(artType->isGrowing())
 	{
-		auto growingBonus = std::make_shared<Bonus>();
-		growingBonus->type = BonusType::ARTIFACT_GROWING;
-		growingBonus->val = 1;
-		growingBonus->duration = BonusDuration::PERMANENT;
-		artInst->accumulateBonus(growingBonus);
+		const auto growingBonus = artInst->getBonusesOfType(BonusType::ARTIFACT_GROWING);
+		assert(!growingBonus.empty());
+		growingBonus->front()->val++;
 
-		for(const auto & bonus : artInst->getType()->getBonusesPerLevel())
+		for(const auto & bonus : artType->getBonusesPerLevel())
 		{
 			// Every n levels
 			if(artInst->valOfBonuses(BonusType::ARTIFACT_GROWING) % bonus.first == 0)
@@ -113,12 +112,47 @@ void CGrowingArtifactInstance::growingUp()
 				artInst->accumulateBonus(std::make_shared<Bonus>(bonus.second));
 			}
 		}
-		for(const auto & bonus : artInst->getType()->getThresholdBonuses())
+		for(const auto & bonus : artType->getThresholdBonuses())
 		{
 			// At n level
 			if(artInst->valOfBonuses(BonusType::ARTIFACT_GROWING) == bonus.first)
 			{
 				artInst->addNewBonus(std::make_shared<Bonus>(bonus.second));
+			}
+		}
+
+		if(artType->isCharged())
+			artInst->onChargesChanged();
+	}
+}
+
+void CChargedArtifactInstance::onChargesChanged()
+{
+	auto artInst = static_cast<CArtifactInstance*>(this);
+	const auto artType = artInst->getType();
+
+	const auto bonusSelector = artType->getDischargeCondition() == DischargeArtifactCondition::SPELLCAST ?
+		Selector::type()(BonusType::SPELL) : Selector::all;
+
+	auto instBonuses = artInst->getAllBonuses(bonusSelector, nullptr);
+
+	if(artInst->getCharges() == 0)
+	{
+		for(const auto & bonus : *instBonuses)
+			if(bonus->type != BonusType::ARTIFACT_GROWING && bonus->type != BonusType::ARTIFACT_CHARGE)
+				artInst->removeBonus(bonus);
+	}
+	else
+	{
+		for(const auto & refBonus : *artType->getAllBonuses(bonusSelector, nullptr))
+		{
+			if(const auto bonusFound = std::find_if(instBonuses->begin(), instBonuses->end(),
+				[refBonus](const auto & instBonus)
+				{
+					return refBonus->type == instBonus->type;
+				}); bonusFound == instBonuses->end())
+			{
+				artInst->accumulateBonus(refBonus);
 			}
 		}
 	}
@@ -128,12 +162,13 @@ void CChargedArtifactInstance::discharge(const uint16_t charges)
 {
 	auto artInst = static_cast<CArtifactInstance*>(this);
 
-	if(const auto chargeBonuses = artInst->getAllBonuses(Selector::type()(BonusType::ARTIFACT_CHARGE), nullptr))
+	if(const auto chargedBonus = artInst->getBonusesOfType(BonusType::ARTIFACT_CHARGE); !chargedBonus->empty())
 	{
-		if(chargeBonuses->front()->val > charges)
-			chargeBonuses->front()->val -= charges;
+		if(chargedBonus->front()->val > charges)
+			chargedBonus->front()->val -= charges;
 		else
-			chargeBonuses->front()->val = 0;
+			chargedBonus->front()->val = 0;
+		onChargesChanged();
 	}
 }
 
@@ -143,11 +178,10 @@ void CChargedArtifactInstance::addCharges(const uint16_t charges)
 
 	if(artInst->getType()->isCharged())
 	{
-		auto bonus = std::make_shared<Bonus>();
-		bonus->type = BonusType::ARTIFACT_CHARGE;
-		bonus->val = charges;
-		bonus->duration = BonusDuration::PERMANENT;
-		artInst->accumulateBonus(bonus);
+		const auto chargedBonus = artInst->getBonusesOfType(BonusType::ARTIFACT_CHARGE);
+		assert(!chargedBonus.empty());
+		chargedBonus->front()->val += charges;
+		onChargesChanged();
 	}
 }
 
@@ -158,23 +192,38 @@ uint16_t CChargedArtifactInstance::getCharges() const
 	return artInst->valOfBonuses(BonusType::ARTIFACT_CHARGE);
 }
 
+void CArtifactInstance::init()
+{
+	const auto art = artTypeID.toArtifact();
+	assert(art);
+
+	if(art->isCharged())
+	{
+		// Charged artifacts contain all bonuses inside instance bonus node
+		if(art->getDischargeCondition() == DischargeArtifactCondition::SPELLCAST)
+		{
+			for(const auto & bonus : *art->getAllBonuses(Selector::all, nullptr))
+				if(bonus->type != BonusType::SPELL)
+					accumulateBonus(bonus);
+		}
+	}
+	else
+	{
+		attachToSource(*art);
+	}
+}
+
 CArtifactInstance::CArtifactInstance(IGameInfoCallback *cb, const CArtifact * art)
 	:CArtifactInstance(cb)
 {
-	setType(art);
-	addCharges(getType()->getDefaultStartCharges());
+	artTypeID = art->getId();
+	init();
 }
 
 CArtifactInstance::CArtifactInstance(IGameInfoCallback *cb)
 	: CBonusSystemNode(ARTIFACT_INSTANCE)
 	, CCombinedArtifactInstance(cb)
 {
-}
-
-void CArtifactInstance::setType(const CArtifact * art)
-{
-	artTypeID = art->getId();
-	attachToSource(*art);
 }
 
 std::string CArtifactInstance::nodeName() const

--- a/lib/entities/artifact/CArtifactInstance.cpp
+++ b/lib/entities/artifact/CArtifactInstance.cpp
@@ -124,10 +124,45 @@ void CGrowingArtifactInstance::growingUp()
 	}
 }
 
+void CChargedArtifactInstance::discharge(const uint16_t charges)
+{
+	auto artInst = static_cast<CArtifactInstance*>(this);
+
+	if(const auto chargeBonuses = artInst->getAllBonuses(Selector::type()(BonusType::ARTIFACT_CHARGE), nullptr))
+	{
+		if(chargeBonuses->front()->val > charges)
+			chargeBonuses->front()->val -= charges;
+		else
+			chargeBonuses->front()->val = 0;
+	}
+}
+
+void CChargedArtifactInstance::addCharges(const uint16_t charges)
+{
+	auto artInst = static_cast<CArtifactInstance*>(this);
+
+	if(artInst->getType()->isCharged())
+	{
+		auto bonus = std::make_shared<Bonus>();
+		bonus->type = BonusType::ARTIFACT_CHARGE;
+		bonus->val = charges;
+		bonus->duration = BonusDuration::PERMANENT;
+		artInst->accumulateBonus(bonus);
+	}
+}
+
+uint16_t CChargedArtifactInstance::getCharges() const
+{
+	auto artInst = static_cast<const CArtifactInstance*>(this);
+
+	return artInst->valOfBonuses(BonusType::ARTIFACT_CHARGE);
+}
+
 CArtifactInstance::CArtifactInstance(IGameInfoCallback *cb, const CArtifact * art)
 	:CArtifactInstance(cb)
 {
 	setType(art);
+	addCharges(getType()->getDefaultStartCharges());
 }
 
 CArtifactInstance::CArtifactInstance(IGameInfoCallback *cb)

--- a/lib/entities/artifact/CArtifactInstance.cpp
+++ b/lib/entities/artifact/CArtifactInstance.cpp
@@ -101,7 +101,7 @@ void CGrowingArtifactInstance::growingUp()
 	if(artType->isGrowing())
 	{
 		const auto growingBonus = artInst->getBonusesOfType(BonusType::ARTIFACT_GROWING);
-		assert(!growingBonus.empty());
+		assert(!growingBonus->empty());
 		growingBonus->front()->val++;
 
 		for(const auto & bonus : artType->getBonusesPerLevel())
@@ -179,7 +179,7 @@ void CChargedArtifactInstance::addCharges(const uint16_t charges)
 	if(artInst->getType()->isCharged())
 	{
 		const auto chargedBonus = artInst->getBonusesOfType(BonusType::ARTIFACT_CHARGE);
-		assert(!chargedBonus.empty());
+		assert(!chargedBonus->empty());
 		chargedBonus->front()->val += charges;
 		onChargesChanged();
 	}

--- a/lib/entities/artifact/CArtifactInstance.h
+++ b/lib/entities/artifact/CArtifactInstance.h
@@ -75,8 +75,18 @@ public:
 	void growingUp();
 };
 
+class DLL_LINKAGE CChargedArtifactInstance
+{
+protected:
+	CChargedArtifactInstance() = default;
+public:
+	void discharge(const uint16_t charges);
+	void addCharges(const uint16_t charges);
+	uint16_t getCharges() const;
+};
+
 class DLL_LINKAGE CArtifactInstance final
-	: public CBonusSystemNode, public CCombinedArtifactInstance, public CScrollArtifactInstance, public CGrowingArtifactInstance
+	: public CBonusSystemNode, public CCombinedArtifactInstance, public CScrollArtifactInstance, public CGrowingArtifactInstance, public CChargedArtifactInstance
 {
 	ArtifactInstanceID id;
 	ArtifactID artTypeID;

--- a/lib/entities/artifact/CArtifactInstance.h
+++ b/lib/entities/artifact/CArtifactInstance.h
@@ -80,6 +80,7 @@ class DLL_LINKAGE CChargedArtifactInstance
 protected:
 	CChargedArtifactInstance() = default;
 public:
+	void onChargesChanged();
 	void discharge(const uint16_t charges);
 	void addCharges(const uint16_t charges);
 	uint16_t getCharges() const;
@@ -91,10 +92,11 @@ class DLL_LINKAGE CArtifactInstance final
 	ArtifactInstanceID id;
 	ArtifactID artTypeID;
 
+	void init();
+
 public:
 	CArtifactInstance(IGameInfoCallback *cb, const CArtifact * art);
 	CArtifactInstance(IGameInfoCallback *cb);
-	void setType(const CArtifact * art);
 	std::string nodeName() const override;
 	ArtifactID getTypeId() const;
 	const CArtifact * getType() const;
@@ -118,8 +120,10 @@ public:
 		h & id;
 
 		if(!h.saving && h.loadingGamestate)
-			setType(artTypeID.toArtifact());
-
+		{
+			init();
+			onChargesChanged();
+		}
 	}
 };
 

--- a/lib/gameState/GameStatePackVisitor.cpp
+++ b/lib/gameState/GameStatePackVisitor.cpp
@@ -820,6 +820,13 @@ void GameStatePackVisitor::visitBulkRebalanceStacks(BulkRebalanceStacks & pack)
 		move.visit(*this);
 }
 
+void GameStatePackVisitor::visitGrowUpArtifact(GrowUpArtifact & pack)
+{
+	auto artInst = gs.getArtInstance(pack.id);
+	assert(artInst);
+	artInst->growingUp();
+}
+
 void GameStatePackVisitor::visitPutArtifact(PutArtifact & pack)
 {
 	auto art = gs.getArtInstance(pack.id);
@@ -912,6 +919,13 @@ void GameStatePackVisitor::visitBulkMoveArtifacts(BulkMoveArtifacts & pack)
 		bulkArtsPut(pack.artsPack1, artInitialSetRight, *leftSet);
 	}
 	bulkArtsPut(pack.artsPack0, artInitialSetLeft, *rightSet);
+}
+
+void GameStatePackVisitor::visitDischargeArtifact(DischargeArtifact & pack)
+{
+	auto artInst = gs.getArtInstance(pack.id);
+	assert(artInst);
+	artInst->discharge(pack.charges);
 }
 
 void GameStatePackVisitor::visitAssembledArtifact(AssembledArtifact & pack)
@@ -1217,22 +1231,6 @@ void GameStatePackVisitor::visitBattleResultAccepted(BattleResultAccepted & pack
 	if(const auto defenderHero = gs.getHero(pack.heroResult[BattleSide::DEFENDER].heroID))
 		defenderHero->removeBonusesRecursive(Bonus::OneBattle);
 
-	if(pack.winnerSide != BattleSide::NONE)
-	{
-		// Grow up growing artifacts
-		if(const auto winnerHero = gs.getHero(pack.heroResult[pack.winnerSide].heroID))
-		{
-			if(winnerHero->getCommander() && winnerHero->getCommander()->alive)
-
-			{
-				for(auto & art : winnerHero->getCommander()->artifactsWorn)
-					gs.getArtInstance(art.second.getID())->growingUp();
-			}
-			for(auto & art : winnerHero->artifactsWorn)
-				gs.getArtInstance(art.second.getID())->growingUp();
-		}
-	}
-
 	if(gs.getSettings().getBoolean(EGameSettings::MODULE_STACK_EXPERIENCE))
 	{
 		if(const auto attackerArmy = gs.getArmyInstance(pack.heroResult[BattleSide::ATTACKER].armyID))
@@ -1343,8 +1341,14 @@ void GameStatePackVisitor::visitBattleResultsApplied(BattleResultsApplied & pack
 {
 	pack.learnedSpells.visit(*this);
 
-	for(auto & artPack : pack.artifacts)
-		artPack.visit(*this);
+	for(auto & movingPack : pack.movingArtifacts)
+		movingPack.visit(*this);
+
+	for(auto & growing : pack.growingArtifacts)
+		growing.visit(*this);
+
+	for(auto & discharging : pack.dischargingArtifacts)
+		discharging.visit(*this);
 
 	const auto currentBattle = std::find_if(gs.currentBattles.begin(), gs.currentBattles.end(),
 											[&](const auto & battle)

--- a/lib/gameState/GameStatePackVisitor.h
+++ b/lib/gameState/GameStatePackVisitor.h
@@ -41,11 +41,13 @@ public:
 	void visitInsertNewStack(InsertNewStack & pack) override;
 	void visitRebalanceStacks(RebalanceStacks & pack) override;
 	void visitBulkRebalanceStacks(BulkRebalanceStacks & pack) override;
+	void visitGrowUpArtifact(GrowUpArtifact & pack) override;
 	void visitPutArtifact(PutArtifact & pack) override;
 	void visitBulkEraseArtifacts(BulkEraseArtifacts & pack) override;
 	void visitBulkMoveArtifacts(BulkMoveArtifacts & pack) override;
 	void visitAssembledArtifact(AssembledArtifact & pack) override;
 	void visitDisassembledArtifact(DisassembledArtifact & pack) override;
+	void visitDischargeArtifact(DischargeArtifact & pack) override;
 	void visitHeroVisit(HeroVisit & pack) override;
 	void visitNewTurn(NewTurn & pack) override;
 	void visitGiveBonus(GiveBonus & pack) override;

--- a/lib/mapping/CMap.cpp
+++ b/lib/mapping/CMap.cpp
@@ -847,6 +847,14 @@ CArtifactInstance * CMap::createArtifact(const ArtifactID & artID, const SpellID
 		artInst->addNewBonus(std::make_shared<Bonus>(BonusDuration::PERMANENT, BonusType::SPELL,
 													 BonusSource::ARTIFACT_INSTANCE, -1, BonusSourceID(ArtifactID(ArtifactID::SPELL_SCROLL)), BonusSubtypeID(spellId)));
 	}
+	if(art->isCharged())
+	{
+		auto bonus = std::make_shared<Bonus>();
+		bonus->type = BonusType::ARTIFACT_CHARGE;
+		bonus->val = 0;
+		artInst->addNewBonus(bonus);
+		artInst->addCharges(art->getDefaultStartCharges());
+	}
 	return artInst;
 }
 

--- a/lib/mapping/CMap.cpp
+++ b/lib/mapping/CMap.cpp
@@ -838,7 +838,7 @@ CArtifactInstance * CMap::createArtifact(const ArtifactID & artID, const SpellID
 	if(art->isGrowing())
 	{
 		auto bonus = std::make_shared<Bonus>();
-		bonus->type = BonusType::LEVEL_COUNTER;
+		bonus->type = BonusType::ARTIFACT_GROWING;
 		bonus->val = 0;
 		artInst->addNewBonus(bonus);
 	}

--- a/lib/networkPacks/ArtifactLocation.h
+++ b/lib/networkPacks/ArtifactLocation.h
@@ -79,11 +79,12 @@ struct MoveArtifactInfo
 	}
 };
 
-enum class DischargeArtifactCondition
+enum class DischargeArtifactCondition : int8_t
 {
+	NONE,
 	SPELLCAST,
 	BATTLE,
-	BUILDING	// not implemented
+	//BUILDING	// not implemented
 };
 
 VCMI_LIB_NAMESPACE_END

--- a/lib/networkPacks/ArtifactLocation.h
+++ b/lib/networkPacks/ArtifactLocation.h
@@ -81,9 +81,9 @@ struct MoveArtifactInfo
 
 enum class DischargeArtifactCondition
 {
-		SPELLCAST,
-		BATTLE,
-		BUILDING
+	SPELLCAST,
+	BATTLE,
+	BUILDING	// not implemented
 };
 
 VCMI_LIB_NAMESPACE_END

--- a/lib/networkPacks/ArtifactLocation.h
+++ b/lib/networkPacks/ArtifactLocation.h
@@ -79,4 +79,11 @@ struct MoveArtifactInfo
 	}
 };
 
+enum class DischargeArtifactCondition
+{
+		SPELLCAST,
+		BATTLE,
+		BUILDING
+};
+
 VCMI_LIB_NAMESPACE_END

--- a/lib/networkPacks/NetPackVisitor.h
+++ b/lib/networkPacks/NetPackVisitor.h
@@ -77,9 +77,11 @@ public:
 	virtual void visitInsertNewStack(InsertNewStack & pack) {}
 	virtual void visitRebalanceStacks(RebalanceStacks & pack) {}
 	virtual void visitBulkRebalanceStacks(BulkRebalanceStacks & pack) {}
+	virtual void visitGrowUpArtifact(GrowUpArtifact & pack) {}
 	virtual void visitPutArtifact(PutArtifact & pack) {}
 	virtual void visitBulkEraseArtifacts(BulkEraseArtifacts & pack) {}
 	virtual void visitBulkMoveArtifacts(BulkMoveArtifacts & pack) {}
+	virtual void visitDischargeArtifact(DischargeArtifact & pack) {}
 	virtual void visitAssembledArtifact(AssembledArtifact & pack) {}
 	virtual void visitDisassembledArtifact(DisassembledArtifact & pack) {}
 	virtual void visitHeroVisit(HeroVisit & pack) {}

--- a/lib/networkPacks/NetPacksLib.cpp
+++ b/lib/networkPacks/NetPacksLib.cpp
@@ -302,6 +302,11 @@ void BulkRebalanceStacks::visitTyped(ICPackVisitor & visitor)
 	visitor.visitBulkRebalanceStacks(*this);
 }
 
+void GrowUpArtifact::visitTyped(ICPackVisitor & visitor)
+{
+	visitor.visitGrowUpArtifact(*this);
+}
+
 void PutArtifact::visitTyped(ICPackVisitor & visitor)
 {
 	visitor.visitPutArtifact(*this);
@@ -320,6 +325,11 @@ void BulkMoveArtifacts::visitTyped(ICPackVisitor & visitor)
 void AssembledArtifact::visitTyped(ICPackVisitor & visitor)
 {
 	visitor.visitAssembledArtifact(*this);
+}
+
+void DischargeArtifact::visitTyped(ICPackVisitor & visitor)
+{
+	visitor.visitDischargeArtifact(*this);
 }
 
 void DisassembledArtifact::visitTyped(ICPackVisitor & visitor)

--- a/lib/networkPacks/PacksForClient.h
+++ b/lib/networkPacks/PacksForClient.h
@@ -907,6 +907,23 @@ struct DLL_LINKAGE CArtifactOperationPack : CPackForClient
 {
 };
 
+struct DLL_LINKAGE GrowUpArtifact : CArtifactOperationPack
+{
+	ArtifactInstanceID id;
+
+	GrowUpArtifact() = default;
+	GrowUpArtifact(const ArtifactInstanceID & id)
+		: id(id)
+	{
+	}
+	void applyGs(CGameState * gs) override;
+
+	template <typename Handler> void serialize(Handler & h)
+	{
+		h & id;
+	}
+};
+
 struct DLL_LINKAGE PutArtifact : CArtifactOperationPack
 {
 	PutArtifact() = default;

--- a/lib/networkPacks/PacksForClient.h
+++ b/lib/networkPacks/PacksForClient.h
@@ -1027,6 +1027,7 @@ struct DLL_LINKAGE DischargeArtifact : CArtifactOperationPack
 {
 	ArtifactInstanceID id;
 	uint16_t charges;
+	std::optional<ArtifactLocation> artLoc;
 
 	DischargeArtifact() = default;
 	DischargeArtifact(const ArtifactInstanceID & id, const uint16_t charges)
@@ -1041,6 +1042,7 @@ struct DLL_LINKAGE DischargeArtifact : CArtifactOperationPack
 	{
 		h & id;
 		h & charges;
+		h & artLoc;
 	}
 };
 

--- a/lib/networkPacks/PacksForClient.h
+++ b/lib/networkPacks/PacksForClient.h
@@ -916,7 +916,8 @@ struct DLL_LINKAGE GrowUpArtifact : CArtifactOperationPack
 		: id(id)
 	{
 	}
-	void applyGs(CGameState * gs) override;
+
+	void visitTyped(ICPackVisitor & visitor) override;
 
 	template <typename Handler> void serialize(Handler & h)
 	{
@@ -1019,6 +1020,27 @@ struct DLL_LINKAGE BulkMoveArtifacts : CArtifactOperationPack
 		h & dstArtHolder;
 		h & srcCreature;
 		h & dstCreature;
+	}
+};
+
+struct DLL_LINKAGE DischargeArtifact : CArtifactOperationPack
+{
+	ArtifactInstanceID id;
+	uint16_t charges;
+
+	DischargeArtifact() = default;
+	DischargeArtifact(const ArtifactInstanceID & id, const uint16_t charges)
+		: id(id)
+		, charges(charges)
+	{
+	}
+
+	void visitTyped(ICPackVisitor & visitor) override;
+
+	template <typename Handler> void serialize(Handler & h)
+	{
+		h & id;
+		h & charges;
 	}
 };
 

--- a/lib/networkPacks/PacksForClientBattle.h
+++ b/lib/networkPacks/PacksForClientBattle.h
@@ -102,14 +102,12 @@ struct DLL_LINKAGE BattleResultAccepted : public CPackForClient
 	BattleID battleID = BattleID::NONE;
 	BattleSideArray<HeroBattleResults> heroResult;
 	BattleSide winnerSide;
-	std::vector<BulkMoveArtifacts> artifacts;
 
 	template <typename Handler> void serialize(Handler & h)
 	{
 		h & battleID;
 		h & heroResult;
 		h & winnerSide;
-		h & artifacts;
 		assert(battleID != BattleID::NONE);
 	}
 };
@@ -387,7 +385,8 @@ struct DLL_LINKAGE BattleResultsApplied : public CPackForClient
 	PlayerColor victor;
 	PlayerColor loser;
 	ChangeSpells learnedSpells;
-	std::vector<BulkMoveArtifacts> artifacts;
+	std::vector<BulkMoveArtifacts> movingArtifacts;
+	std::vector<GrowUpArtifact> growingArtifacts;
 	CStackBasicDescriptor raisedStack;
 	void visitTyped(ICPackVisitor & visitor) override;
 
@@ -397,7 +396,8 @@ struct DLL_LINKAGE BattleResultsApplied : public CPackForClient
 		h & victor;
 		h & loser;
 		h & learnedSpells;
-		h & artifacts;
+		h & movingArtifacts;
+		h & growingArtifacts;
 		h & raisedStack;
 		assert(battleID != BattleID::NONE);
 	}

--- a/lib/networkPacks/PacksForClientBattle.h
+++ b/lib/networkPacks/PacksForClientBattle.h
@@ -387,6 +387,7 @@ struct DLL_LINKAGE BattleResultsApplied : public CPackForClient
 	ChangeSpells learnedSpells;
 	std::vector<BulkMoveArtifacts> movingArtifacts;
 	std::vector<GrowUpArtifact> growingArtifacts;
+	std::vector<DischargeArtifact> dischargingArtifacts;
 	CStackBasicDescriptor raisedStack;
 	void visitTyped(ICPackVisitor & visitor) override;
 
@@ -398,6 +399,7 @@ struct DLL_LINKAGE BattleResultsApplied : public CPackForClient
 		h & learnedSpells;
 		h & movingArtifacts;
 		h & growingArtifacts;
+		h & dischargingArtifacts;
 		h & raisedStack;
 		assert(battleID != BattleID::NONE);
 	}

--- a/lib/serializer/RegisterTypes.h
+++ b/lib/serializer/RegisterTypes.h
@@ -219,6 +219,7 @@ void registerTypes(Serializer &s)
 	s.template registerType<SwapStacks>(165);
 	s.template registerType<InsertNewStack>(166);
 	s.template registerType<RebalanceStacks>(167);
+	s.template registerType<GrowUpArtifact>(168);
 	s.template registerType<PutArtifact>(169);
 	s.template registerType<BulkEraseArtifacts>(170);
 	s.template registerType<AssembledArtifact>(171);

--- a/lib/serializer/RegisterTypes.h
+++ b/lib/serializer/RegisterTypes.h
@@ -227,6 +227,7 @@ void registerTypes(Serializer &s)
 	s.template registerType<BulkMoveArtifacts>(173);
 	s.template registerType<PlayerMessageClient>(174);
 	s.template registerType<BulkRebalanceStacks>(175);
+	s.template registerType<DischargeArtifact>(176);
 	s.template registerType<SetRewardableConfiguration>(177);
 	s.template registerType<CPackForServer>(179);
 	s.template registerType<EndTurn>(180);

--- a/server/CGameHandler.h
+++ b/server/CGameHandler.h
@@ -169,6 +169,7 @@ public:
 	void changeFogOfWar(const std::unordered_set<int3> &tiles, PlayerColor player,ETileVisibility mode) override;
 	
 	void castSpell(const spells::Caster * caster, SpellID spellID, const int3 &pos) override;
+	void verifyChargedArtifactUsed(const ObjectInstanceID & heroObjectID, const SpellID & spellID);
 
 	/// Returns hero that is currently visiting this object, or nullptr if no visit is active
 	const CGHeroInstance * getVisitingHero(const CGObjectInstance *obj);

--- a/server/CGameHandler.h
+++ b/server/CGameHandler.h
@@ -169,7 +169,7 @@ public:
 	void changeFogOfWar(const std::unordered_set<int3> &tiles, PlayerColor player,ETileVisibility mode) override;
 	
 	void castSpell(const spells::Caster * caster, SpellID spellID, const int3 &pos) override;
-	void verifyChargedArtifactUsed(const ObjectInstanceID & heroObjectID, const SpellID & spellID);
+	void useChargedArtifactUsed(const ObjectInstanceID & heroObjectID, const SpellID & spellID);
 
 	/// Returns hero that is currently visiting this object, or nullptr if no visit is active
 	const CGHeroInstance * getVisitingHero(const CGObjectInstance *obj);

--- a/server/battles/BattleActionProcessor.cpp
+++ b/server/battles/BattleActionProcessor.cpp
@@ -124,7 +124,7 @@ bool BattleActionProcessor::doHeroSpellAction(const CBattleInfoCallback & battle
 	}
 
 	parameters.cast(gameHandler->spellEnv, ba.getTarget(&battle));
-	gameHandler->verifyChargedArtifactUsed(h->id, ba.spell);
+	gameHandler->useChargedArtifactUsed(h->id, ba.spell);
 
 	return true;
 }

--- a/server/battles/BattleActionProcessor.cpp
+++ b/server/battles/BattleActionProcessor.cpp
@@ -124,6 +124,7 @@ bool BattleActionProcessor::doHeroSpellAction(const CBattleInfoCallback & battle
 	}
 
 	parameters.cast(gameHandler->spellEnv, ba.getTarget(&battle));
+	gameHandler->verifyChargedArtifactUsed(h->id, ba.spell);
 
 	return true;
 }

--- a/server/battles/BattleResultProcessor.cpp
+++ b/server/battles/BattleResultProcessor.cpp
@@ -500,6 +500,30 @@ void BattleResultProcessor::battleFinalize(const BattleID & battleID, const Batt
 		addArtifactToGrowing(winnerHero->artifactsWorn);
 	}
 
+	// Charged artifacts handling
+	const auto addArtifactToDischarging = [&resultsApplied](const std::map<ArtifactPosition, ArtSlotInfo> & artMap)
+	{
+		for(const auto & [slot, slotInfo] : artMap)
+		{
+			auto artInst = slotInfo.getArt();
+			assert(artInst);
+			if(const auto condition = artInst->getType()->getDischargeCondition(); condition && condition.value() == DischargeArtifactCondition::BATTLE)
+				resultsApplied.dischargingArtifacts.emplace_back(artInst->getId(), 1);
+		}
+	};
+	if(winnerHero)
+	{
+		addArtifactToDischarging(winnerHero->artifactsWorn);
+		if(const auto commander = winnerHero->getCommander())
+			addArtifactToDischarging(commander->artifactsWorn);
+	}
+	if(loserHero)
+	{
+		addArtifactToDischarging(loserHero->artifactsWorn);
+		if(const auto commander = loserHero->getCommander())
+			addArtifactToDischarging(commander->artifactsWorn);
+	}
+
 	// Necromancy handling
 	// Give raised units to winner, if any were raised, units will be given after casualties are taken
 	if(winnerHero)

--- a/server/battles/BattleResultProcessor.cpp
+++ b/server/battles/BattleResultProcessor.cpp
@@ -508,7 +508,7 @@ void BattleResultProcessor::battleFinalize(const BattleID & battleID, const Batt
 		{
 			auto artInst = slotInfo.getArt();
 			assert(artInst);
-			if(const auto condition = artInst->getType()->getDischargeCondition(); condition && condition.value() == DischargeArtifactCondition::BATTLE)
+			if(const auto condition = artInst->getType()->getDischargeCondition(); condition == DischargeArtifactCondition::BATTLE)
 			{
 				auto & discharging = resultsApplied.dischargingArtifacts.emplace_back(artInst->getId(), 1);
 				discharging.artLoc.emplace(id, creature, slot);


### PR DESCRIPTION
- Removed hardcoded binding of growing artifacts to commanders. Now the hero can have a growing artifact.

- Charged artifacts have been implemented. Three actions are available to choose from for discharging BATTLE, BUILDING (not yet implemented), SPELLCAST.

- Added new bonus type ARTIFACT_CHARGE. 

[Fragile](https://github.com/vcmi/vcmi/issues/4932) artifacts can now be implemented through "charged" mechanic.
```
{
	"charged" : {
		"usageType" : "BATTLE",
		"startingCharges" : 1,
		"removeOnDepletion" : true
	},
}
```
The Grail can also be implemented as a charged artifact with one charge.
Another example of a charged artifact with replenishing charges.
```
{
    "bonuses" : [
        {
            "type" : "SPELL",
            "subtype" : "bless"
        }
    ],
    "charged" : {
        "usageType" : "SPELLCAST",
        "startingCharges" : 2,
    },
    "growing" : {
        "bonusesPerLevel" :
        [
            {
                "level" : 1,
                "bonus" : 
                {
                    "type" : "ARTIFACT_CHARGE",
                    "val" : 1
                }
            }
        ]
    }
}
```