### PR TITLE
Fix game not awarding stack experience after combat

### DIFF
--- a/lib/networkPacks/NetPacksLib.cpp
+++ b/lib/networkPacks/NetPacksLib.cpp
@@ -36,6 +36,7 @@ void CPack::visitBasic(ICPackVisitor & visitor)
 
 void CPack::visitTyped(ICPackVisitor & visitor)
 {
+	throw std::runtime_error(std::string("CPack::visitTyped called for class ") + typeid(*this).name());
 }
 
 void CPackForClient::visitBasic(ICPackVisitor & visitor)
@@ -810,6 +811,21 @@ void LobbyDelete::visitTyped(ICPackVisitor & visitor)
 void CatapultAttack::visitTyped(ICPackVisitor & visitor)
 {
 	visitor.visitCatapultAttack(*this);
+}
+
+void BattleResultAccepted::visitTyped(ICPackVisitor & visitor)
+{
+	visitor.visitBattleResultAccepted(*this);
+}
+
+void BattleCancelled::visitTyped(ICPackVisitor & visitor)
+{
+	visitor.visitBattleCancelled(*this);
+}
+
+void TurnTimeUpdate::visitTyped(ICPackVisitor & visitor)
+{
+	visitor.visitTurnTimeUpdate(*this);
 }
 
 VCMI_LIB_NAMESPACE_END

--- a/lib/networkPacks/PacksForClient.h
+++ b/lib/networkPacks/PacksForClient.h
@@ -129,6 +129,8 @@ struct DLL_LINKAGE TurnTimeUpdate : public CPackForClient
 {
 	PlayerColor player;
 	TurnTimerInfo turnTimer;
+
+	void visitTyped(ICPackVisitor & visitor) override;
 		
 	template <typename Handler> void serialize(Handler & h)
 	{

--- a/lib/networkPacks/PacksForClientBattle.h
+++ b/lib/networkPacks/PacksForClientBattle.h
@@ -76,6 +76,8 @@ struct DLL_LINKAGE BattleCancelled: public CPackForClient
 {
 	BattleID battleID = BattleID::NONE;
 
+	void visitTyped(ICPackVisitor & visitor) override;
+
 	template <typename Handler> void serialize(Handler & h)
 	{
 		h & battleID;
@@ -103,6 +105,8 @@ struct DLL_LINKAGE BattleResultAccepted : public CPackForClient
 	BattleSideArray<HeroBattleResults> heroResult;
 	BattleSide winnerSide;
 	std::vector<BulkMoveArtifacts> artifacts;
+
+	void visitTyped(ICPackVisitor & visitor) override;
 
 	template <typename Handler> void serialize(Handler & h)
 	{


### PR DESCRIPTION
- Added missing `visitTyped` overloads.
- Throw runtime error if `visitTyped` is called on raw CPack, to avoid such silent errors in future