### PR TITLE
Allow moving double-wide unit 1 tile backwards

### DIFF
--- a/client/battle/BattleActionsController.cpp
+++ b/client/battle/BattleActionsController.cpp
@@ -723,14 +723,19 @@ void BattleActionsController::actionRealize(PossiblePlayerBattleAction action, c
 		case PossiblePlayerBattleAction::MOVE_TACTICS:
 		case PossiblePlayerBattleAction::MOVE_STACK:
 		{
-			if(owner.stacksController->getActiveStack()->doubleWide())
+			const auto * activeStack = owner.stacksController->getActiveStack();
+			const bool backwardsMove = activeStack->unitSide() == BattleSide::ATTACKER ?
+				targetHex.getX() < activeStack->getPosition().getX():
+				targetHex.getX() > activeStack->getPosition().getX();
+
+			if(activeStack->doubleWide() && backwardsMove)
 			{
-				BattleHexArray acc = owner.getBattle()->battleGetAvailableHexes(owner.stacksController->getActiveStack(), false);
-				BattleHex shiftedDest = targetHex.cloneInDirection(owner.stacksController->getActiveStack()->destShiftDir(), false);
-				if(acc.contains(targetHex))
-					owner.giveCommand(EActionType::WALK, targetHex);
-				else if(acc.contains(shiftedDest))
+				BattleHexArray acc = owner.getBattle()->battleGetAvailableHexes(activeStack, false);
+				BattleHex shiftedDest = targetHex.cloneInDirection(activeStack->destShiftDir(), false);
+				if(acc.contains(shiftedDest))
 					owner.giveCommand(EActionType::WALK, shiftedDest);
+				else
+					owner.giveCommand(EActionType::WALK, targetHex);
 			}
 			else
 			{

--- a/client/battle/BattleFieldController.cpp
+++ b/client/battle/BattleFieldController.cpp
@@ -390,24 +390,27 @@ BattleHexArray BattleFieldController::getHighlightedHexesForMovementTarget()
 		}
 	}
 
-	if(availableHexes.contains(hoveredHex))
+	if (stack->doubleWide())
 	{
-		if(stack->doubleWide())
+		const bool backwardsMove = stack->unitSide() == BattleSide::ATTACKER ?
+			hoveredHex.getX() < stack->getPosition().getX():
+			hoveredHex.getX() > stack->getPosition().getX();
+
+		if (backwardsMove && availableHexes.contains(hoveredHex.cloneInDirection(stack->destShiftDir())))
+			return {hoveredHex, hoveredHex.cloneInDirection(stack->destShiftDir())};
+
+		if (availableHexes.contains(hoveredHex))
 			return {hoveredHex, stack->occupiedHex(hoveredHex)};
-		else
-			return {hoveredHex};
-	}
 
-	if(stack->doubleWide())
+		return {};
+	}
+	else
 	{
-		for(const auto & hex : availableHexes)
-		{
-			if(stack->occupiedHex(hex) == hoveredHex)
-				return {hoveredHex, hex};
-		}
+		if (availableHexes.contains(hoveredHex))
+			return {hoveredHex};
+		else
+			return {};
 	}
-
-	return {};
 }
 
 // Range limit highlight helpers


### PR DESCRIPTION
When moving double-wide unit backwards, game was always selecting "head" hex, as result it was impossible to move unit 1 hex backwards - since in this scenario, you need to hover tail hex of the creature, which triggers unit info instead of movement.

Now moving backwards is always done by selecting "tail" hex, eliminating this problem