### PR TITLE
Gameplay improvements

### DIFF
--- a/client/battle/BattleWindow.cpp
+++ b/client/battle/BattleWindow.cpp
@@ -855,7 +855,7 @@ void BattleWindow::blockUI(bool on)
 	setShortcutBlocked(EShortcut::BATTLE_DEFEND, on || owner.tacticsMode);
 	setShortcutBlocked(EShortcut::BATTLE_SELECT_ACTION, on || owner.tacticsMode);
 	setShortcutBlocked(EShortcut::BATTLE_AUTOCOMBAT, (settings["battle"]["endWithAutocombat"].Bool() && onlyOnePlayerHuman) ? on || owner.tacticsMode || owner.actionsController->heroSpellcastingModeActive() : owner.actionsController->heroSpellcastingModeActive());
-	setShortcutBlocked(EShortcut::BATTLE_END_WITH_AUTOCOMBAT, on || owner.tacticsMode || !onlyOnePlayerHuman || owner.actionsController->heroSpellcastingModeActive());
+	setShortcutBlocked(EShortcut::BATTLE_END_WITH_AUTOCOMBAT, on || !onlyOnePlayerHuman || owner.actionsController->heroSpellcastingModeActive());
 	setShortcutBlocked(EShortcut::BATTLE_TACTICS_END, on || !owner.tacticsMode);
 	setShortcutBlocked(EShortcut::BATTLE_TACTICS_NEXT, on || !owner.tacticsMode);
 	setShortcutBlocked(EShortcut::BATTLE_CONSOLE_DOWN, on && !owner.tacticsMode);
@@ -891,7 +891,7 @@ std::optional<uint32_t> BattleWindow::getQueueHoveredUnitId()
 
 void BattleWindow::endWithAutocombat() 
 {
-	if(!owner.makingTurn() || owner.tacticsMode)
+	if(!owner.makingTurn())
 		return;
 
 	GAME->interface()->showYesNoDialog(

--- a/client/widgets/Scrollable.cpp
+++ b/client/widgets/Scrollable.cpp
@@ -27,10 +27,7 @@ void Scrollable::gesture(bool on, const Point & initialPosition, const Point & f
 
 void Scrollable::wheelScrolled(int distance)
 {
-	if (orientation == Orientation::HORIZONTAL)
-		scrollBy(distance * scrollStep);
-	else
-		scrollBy(-distance * scrollStep);
+	scrollBy(-distance * scrollStep);
 }
 
 void Scrollable::gesturePanning(const Point & initialPosition, const Point & currentPosition, const Point & lastUpdateDistance)

--- a/config/gameConfig.json
+++ b/config/gameConfig.json
@@ -295,7 +295,7 @@
 			// number of heroes that player can have active on map at the same time
 			"perPlayerOnMapCap" : 8,
 			// number of heroes that player can have in total, including garrisoned
-			"perPlayerTotalCap" : 16,
+			"perPlayerTotalCap" : 9999,
 			// if enabled, hero that wins a battle without any non-summoned troops left will retreat and become available in tavern instead of being lost
 			"retreatOnWinWithoutTroops" : true,
 			// Chances for a hero with default army to receive corresponding stack out of his predefined starting troops

--- a/lib/battle/CBattleInfoEssentials.cpp
+++ b/lib/battle/CBattleInfoEssentials.cpp
@@ -270,7 +270,7 @@ const IBonusBearer * CBattleInfoEssentials::getBonusBearer() const
 bool CBattleInfoEssentials::battleCanFlee(const PlayerColor & player) const
 {
 	RETURN_IF_NOT_BATTLE(false);
-	const auto side = playerToSide(player);
+	const BattleSide side = playerToSide(player);
 	if(side == BattleSide::NONE)
 		return false;
 
@@ -281,7 +281,7 @@ bool CBattleInfoEssentials::battleCanFlee(const PlayerColor & player) const
 		return false;
 
 	//eg. one of heroes is wearing shakles of war
-	if(myHero->hasBonusOfType(BonusType::BATTLE_NO_FLEEING))
+	if(myHero->hasBonusOfType(BonusType::BATTLE_NO_FLEEING) && battleHasHero(otherSide(side)))
 		return false;
 
 	//we are besieged defender

--- a/server/processors/HeroPoolProcessor.cpp
+++ b/server/processors/HeroPoolProcessor.cpp
@@ -164,7 +164,7 @@ bool HeroPoolProcessor::hireHero(const ObjectInstanceID & objectID, const HeroTy
 	if (gameHandler->getHeroCount(player, false) >= gameHandler->getSettings().getInteger(EGameSettings::HEROES_PER_PLAYER_ON_MAP_CAP) && gameHandler->complain("Cannot hire hero, too many wandering heroes already!"))
 		return false;
 
-	if (gameHandler->getHeroCount(player, true) >= gameHandler->getSettings().getInteger(EGameSettings::HEROES_PER_PLAYER_TOTAL_CAP) && gameHandler->complain("Cannot hire hero, too many heroes garrizoned and wandering already!"))
+	if (gameHandler->getHeroCount(player, true) >= gameHandler->getSettings().getInteger(EGameSettings::HEROES_PER_PLAYER_TOTAL_CAP) && gameHandler->complain("Cannot hire hero, too many heroes garrisoned and wandering heroes present!"))
 		return false;
 
 	if (nextHero != HeroTypeID::NONE) // player attempts to invite next hero


### PR DESCRIPTION
Some minor improvements for VCMI 1.7

1. Allow "finish battle with autocombat" during tactics phase
2. Remove default 16 total heroes limit (probably some old H3 version thing)
3. Change scroll direction for horizontal slider (matches HD mod) - IMO not just comptibility change but also minor ergonomic improvement - I find scrolling down a bit easier than scrolling up
4. Allow fleeing while having shackles of war when other side got no hero - change made by HotA that allows fleeing in battles where shackles of war are useless, so you do not have to keep putting it in backpack when opponent does not have hero anyway etc.