### PR TITLE
Fix handling of creatures in configurable town buildings

### DIFF
--- a/docs/modders/Map_Objects/Rewardable.md
+++ b/docs/modders/Map_Objects/Rewardable.md
@@ -635,7 +635,8 @@ List of supported slots names:
 
 - Can be used as limiter
 - Can be used as reward, to give new creatures to a hero
-- If hero does not have enough free slots, game will show selection dialog to pick troops to keep
+- For map objects, if hero does not have enough free slots, game will show selection dialog to pick troops to keep
+- For town buildings, hero must either have free slot(s) to take them, or have creatures of this type. Othervice reward would fail to give any creatures
 - It is possible to specify probability to receive upgraded creature
 
 ```json

--- a/lib/callback/IGameEventCallback.h
+++ b/lib/callback/IGameEventCallback.h
@@ -76,6 +76,7 @@ public:
 	virtual void giveResource(PlayerColor player, GameResID which, int val)=0;
 	virtual void giveResources(PlayerColor player, ResourceSet resources)=0;
 
+	virtual void giveCreatures(const CGHeroInstance * h, const CCreatureSet &creatures) =0;
 	virtual void giveCreatures(const CArmedInstance *objid, const CGHeroInstance * h, const CCreatureSet &creatures, bool remove) =0;
 	virtual void takeCreatures(ObjectInstanceID objid, const std::vector<CStackBasicDescriptor> &creatures, bool forceRemoval = false) =0;
 	virtual bool changeStackCount(const StackLocation &sl, TQuantity count, ChangeValueMode mode) =0;

--- a/lib/rewardable/Interface.cpp
+++ b/lib/rewardable/Interface.cpp
@@ -254,8 +254,11 @@ void Rewardable::Interface::grantRewardAfterLevelup(IGameEventCallback & gameEve
 		for(const auto & crea : info.reward.creatures)
 			creatures.addToSlot(creatures.getFreeSlot(), std::make_unique<CStackInstance>(cb, crea.getId(), crea.getCount()));
 
-		if(auto * army = dynamic_cast<const CArmedInstance*>(this)) //TODO: to fix that, CArmedInstance must be split on map instance part and interface part
+		auto * army = dynamic_cast<const CArmedInstance*>(this);
+		if (army)
 			gameEvents.giveCreatures(army, hero, creatures, false);
+		else
+			gameEvents.giveCreatures(hero, creatures);
 	}
 	
 	if(info.reward.spellCast.first != SpellID::NONE)

--- a/server/CGameHandler.h
+++ b/server/CGameHandler.h
@@ -125,6 +125,7 @@ public:
 	void giveResource(PlayerColor player, GameResID which, int val) override;
 	void giveResources(PlayerColor player, TResources resources) override;
 
+	void giveCreatures(const CGHeroInstance * h, const CCreatureSet &creatures) override;
 	void giveCreatures(const CArmedInstance *objid, const CGHeroInstance * h, const CCreatureSet &creatures, bool remove) override;
 	void takeCreatures(ObjectInstanceID objid, const std::vector<CStackBasicDescriptor> &creatures, bool forceRemoval) override;
 	bool changeStackType(const StackLocation &sl, const CCreature *c) override;

--- a/test/mock/mock_IGameCallback.h
+++ b/test/mock/mock_IGameCallback.h
@@ -60,6 +60,7 @@ public:
 	void giveResource(PlayerColor player, GameResID which, int val) override {}
 	void giveResources(PlayerColor player, ResourceSet resources) override {}
 
+	void giveCreatures(const CGHeroInstance * h, const CCreatureSet &creatures) override{}
 	void giveCreatures(const CArmedInstance *objid, const CGHeroInstance * h, const CCreatureSet &creatures, bool remove) override {}
 	void takeCreatures(ObjectInstanceID objid, const std::vector<CStackBasicDescriptor> &creatures, bool forceRemoval) override {}
 	bool changeStackCount(const StackLocation &sl, TQuantity count, ChangeValueMode mode) override {return false;}


### PR DESCRIPTION
- Fixed removal of partial stacks of creatures
- It is now possible to give units via town building, but only if visitor has slots to take them