### PR TITLE
Qt UI fixes

### DIFF
--- a/launcher/firstLaunch/firstlaunch_moc.cpp
+++ b/launcher/firstLaunch/firstlaunch_moc.cpp
@@ -349,6 +349,7 @@ void FirstLaunchView::extractGogData()
 		ui->progressBarGog->setVisible(false);
 		ui->pushButtonGogInstall->setVisible(true);
 		setEnabled(true);
+		heroesDataUpdate();
 	});
 #endif
 }

--- a/mapeditor/campaigneditor/campaigneditor.cpp
+++ b/mapeditor/campaigneditor/campaigneditor.cpp
@@ -249,7 +249,7 @@ void CampaignEditor::on_actionScenarioProperties_triggered()
 void CampaignEditor::closeEvent(QCloseEvent *event)
 {
 	if(getAnswerAboutUnsavedChanges())
-		QDialog::closeEvent(event);
+		QWidget::closeEvent(event);
 	else
 		event->ignore();
 }

--- a/mapeditor/campaigneditor/campaigneditor.h
+++ b/mapeditor/campaigneditor/campaigneditor.h
@@ -8,7 +8,7 @@
  *
  */
 #pragma once
-#include <QDialog>
+#include <QWidget>
 
 #include "campaignview.h"
 
@@ -21,7 +21,7 @@ namespace Ui {
 class CampaignEditor;
 }
 
-class CampaignEditor : public QDialog
+class CampaignEditor : public QWidget
 {
 	Q_OBJECT
 

--- a/mapeditor/campaigneditor/campaigneditor.ui
+++ b/mapeditor/campaigneditor/campaigneditor.ui
@@ -26,7 +26,7 @@
    <property name="bottomMargin">
     <number>0</number>
    </property>
-   <property name="Spacing" stdset="0">
+   <property name="spacing">
     <number>0</number>
    </property>
    <item>

--- a/mapeditor/campaigneditor/campaigneditor.ui
+++ b/mapeditor/campaigneditor/campaigneditor.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
  <class>CampaignEditor</class>
- <widget class="QDialog" name="CampaignEditor">
+ <widget class="QWidget" name="CampaignEditor">
   <property name="geometry">
    <rect>
     <x>0</x>


### PR DESCRIPTION
- fix gog install button remove after finish (in develop the button is currently not removed after successful install)
- normal window instead of dialog for campaigneditor
- fix spacing of buttons in toolbar in campaign editor