### PR TITLE
Fix handling of upgrades of upgrades for necromancy

### DIFF
--- a/lib/mapObjects/CGHeroInstance.cpp
+++ b/lib/mapObjects/CGHeroInstance.cpp
@@ -990,13 +990,13 @@ CStackBasicDescriptor CGHeroInstance::calculateNecromancy (const BattleResult &b
 		const ui8 necromancyLevel = valOfBonuses(BonusType::IMPROVED_NECROMANCY);
 		vstd::amin(necromancySkill, 1.0); //it's impossible to raise more creatures than all...
 		const std::map<CreatureID,si32> &casualties = battleResult.casualties[CBattleInfoEssentials::otherSide(battleResult.winner)];
-        if(casualties.empty())
-            return CStackBasicDescriptor();
+		if(casualties.empty())
+			return CStackBasicDescriptor();
 		// figure out what to raise - pick strongest creature meeting requirements
 		CreatureID creatureTypeRaised = CreatureID::NONE; //now we always have IMPROVED_NECROMANCY, no need for hardcode
 		int requiredCasualtyLevel = 1;
 		TConstBonusListPtr improvedNecromancy = getBonusesOfType(BonusType::IMPROVED_NECROMANCY);
-        if(!improvedNecromancy->empty())
+		if(!improvedNecromancy->empty())
 		{
 			int maxCasualtyLevel = 1;
 			for(const auto & casualty : casualties)
@@ -1033,11 +1033,11 @@ CStackBasicDescriptor CGHeroInstance::calculateNecromancy (const BattleResult &b
 		// raise upgraded creature (at 2/3 rate) if no space available otherwise
 		if(getSlotFor(creatureTypeRaised) == SlotID())
 		{
-			for(const CreatureID & upgraded : creatureTypeRaised.toCreature()->upgrades)
+			for (const auto & slot : Slots())
 			{
-				if(getSlotFor(upgraded) != SlotID())
+				if (creatureTypeRaised.toCreature()->isMyDirectOrIndirectUpgrade(slot.second->getCreature()))
 				{
-					creatureTypeRaised = upgraded;
+					creatureTypeRaised = slot.second->getCreatureID();
 					necromancySkill *= 2/3.0;
 					break;
 				}
@@ -1059,12 +1059,6 @@ CStackBasicDescriptor CGHeroInstance::calculateNecromancy (const BattleResult &b
 
 	return CStackBasicDescriptor();
 }
-
-/*
-int3 CGHeroInstance::getSightCenter() const
-{
-	return getPosition(false);
-}*/
 
 int CGHeroInstance::getSightRadius() const
 {


### PR DESCRIPTION
Game will now recognize upgrades of upgrades for Necromancy purposes - if hero has such units in his army, Necromancy can target them with same 2/3 efficiency like direct upgrades