### PR TITLE
Miscellaneous fixes

### DIFF
--- a/client/battle/BattleInterface.cpp
+++ b/client/battle/BattleInterface.cpp
@@ -231,7 +231,7 @@ void BattleInterface::stacksAreAttacked(std::vector<StackAttackedInfo> attackedI
 {
 	stacksController->stacksAreAttacked(attackedInfos);
 
-	BattleSideArray<int> killedBySide;
+	BattleSideArray<int> killedBySide{0,0};
 
 	for(const StackAttackedInfo & attackedInfo : attackedInfos)
 	{

--- a/client/windows/CCreatureWindow.cpp
+++ b/client/windows/CCreatureWindow.cpp
@@ -851,6 +851,10 @@ void CStackWindow::initBonusesList()
 	BonusList receivedBonuses = *info->stackNode->getBonuses(CSelector(Bonus::Permanent), Selector::all);
 	BonusList abilities = info->creature->getExportedBonusList();
 
+	// remove all bonuses that are not propagated away
+	// such bonuses should be present in received bonuses, and if not - this means that they are behind inactive limiter, such as inactive stack experience bonuses
+	abilities.remove_if([](const Bonus* b){ return b->propagator == nullptr;});
+
 	const auto & bonusSortingPredicate = [this](const std::shared_ptr<Bonus> & v1, const std::shared_ptr<Bonus> & v2){
 		if (v1->source != v2->source)
 		{

--- a/config/creatures/special.json
+++ b/config/creatures/special.json
@@ -179,6 +179,7 @@
 			"noDistancePenalty" : { "type" : "NO_DISTANCE_PENALTY" },
 			"noRetalitation" : { "type" : "BLOCKS_RANGED_RETALIATION" },
 			"noLuck" : { "type" : "NO_LUCK" }
+			"attackAlwaysZero" : { "type" : "PRIMARY_SKILL", "subtype" : "attack", "val" : 0, "valueType" : "INDEPENDENT_MIN" },
 		},
 		"graphics" :
 		{

--- a/docs/modders/Entities_Format/Faction_Format.md
+++ b/docs/modders/Entities_Format/Faction_Format.md
@@ -66,6 +66,9 @@ Each town requires a set of buildings (Around 30-45 buildings)
 
 	// Faction alignment. Can be good, neutral (default) or evil.
 	"alignment" : "",
+	
+	// If set to true, RMG will prefer placing towns of this faction on subterranean level of the map
+	"preferUndergroundPlacement" : true,
 
 	// Backgrounds for creature screen, two versions: 120px-height and 130-px height
 	"creatureBackground"

--- a/lib/mapObjects/CGTownInstance.cpp
+++ b/lib/mapObjects/CGTownInstance.cpp
@@ -201,7 +201,7 @@ int CGTownInstance::getDwellingBonus(const std::vector<CreatureID>& creatureIds,
 		const auto & dwellingCreatures = dwelling->asOwnable()->providedCreatures();
 		bool hasMatch = false;
 		for (const auto& creature : dwellingCreatures)
-			hasMatch = vstd::contains(creatureIds, creature);
+			hasMatch |= vstd::contains(creatureIds, creature);
 
 		if (hasMatch)
 			totalBonus += 1;

--- a/lib/mapObjects/IObjectInterface.cpp
+++ b/lib/mapObjects/IObjectInterface.cpp
@@ -95,9 +95,12 @@ int3 IBoatGenerator::bestLocation() const
 			continue;
 
 		if (tile->blocked())
+			continue;
+
+		if (tile->visitable())
 		{
 			bool hasBoat = false;
-			for (auto const & objectID : tile->blockingObjects)
+			for (auto const & objectID : tile->visitableObjects)
 			{
 				const auto * object = getObject()->cb->getObj(objectID);
 				if (object->ID == Obj::BOAT || object->ID == Obj::HERO)


### PR DESCRIPTION
- When summoning or building a boat, check for visitable objects when looking for objects that might block boat, and not for blocked (since hero & boat are visitable, not blocked). 
  - Fixes #5671 
- Fix multi-creature dwelling only giving town growth bonus to last unit available in this dwelling
- Add missing docs for `preferUndergroundPlacement` field
- Bring Arrow Tower damage in line with H3. 
  - Fixes #5546
- Fix uninitialized value on playback of hero batte animation
  - Fixes #5530
- Do not show inactive stack experience bonuses in creature window
