### PR TITLE
add missing text in kindom overview

### DIFF
--- a/client/widgets/TextControls.cpp
+++ b/client/widgets/TextControls.cpp
@@ -344,6 +344,7 @@ Rect CMultiLineLabel::getTextLocation()
 	case ETextAlignment::TOPLEFT:     return Rect(pos.topLeft(), textSizeComputed);
 	case ETextAlignment::TOPCENTER:   return Rect(pos.topLeft(), textSizeComputed);
 	case ETextAlignment::CENTER:      return Rect(pos.topLeft() + textOffset / 2, textSizeComputed);
+	case ETextAlignment::CENTERLEFT:  return Rect(pos.topLeft() + Point(0, textOffset.y / 2), textSizeComputed);
 	case ETextAlignment::CENTERRIGHT: return Rect(pos.topLeft() + Point(textOffset.x, textOffset.y / 2), textSizeComputed);
 	case ETextAlignment::BOTTOMRIGHT: return Rect(pos.topLeft() + textOffset, textSizeComputed);
 	}

--- a/client/windows/CKingdomInterface.cpp
+++ b/client/windows/CKingdomInterface.cpp
@@ -831,6 +831,9 @@ CTownItem::CTownItem(const CGTownInstance * Town)
 	{
 		ENGINE->windows().createAndPushWindow<CCastleInterface>(town);
 	});
+
+	labelCreatureGrowth = std::make_shared<CMultiLineLabel>(Rect(4, 76, 50, 35), EFonts::FONT_SMALL, ETextAlignment::CENTERLEFT, Colors::YELLOW, LIBRARY->generaltexth->translate("core.genrltxt.265"));
+	labelCreatureAvailable = std::make_shared<CMultiLineLabel>(Rect(349, 76, 57, 35), EFonts::FONT_SMALL, ETextAlignment::CENTERLEFT, Colors::YELLOW, LIBRARY->generaltexth->translate("core.genrltxt.266"));
 }
 
 void CTownItem::updateGarrisons()

--- a/client/windows/CKingdomInterface.h
+++ b/client/windows/CKingdomInterface.h
@@ -31,6 +31,7 @@ class CListBox;
 class CTabbedInt;
 class CGStatusBar;
 class CGarrisonInt;
+class CMultiLineLabel;
 
 class CKingdHeroList;
 class CKingdTownList;
@@ -271,6 +272,9 @@ class CTownItem : public CIntObject, public IGarrisonHolder
 
 	std::vector<std::shared_ptr<CCreaInfo>> available;
 	std::vector<std::shared_ptr<CCreaInfo>> growth;
+
+	std::shared_ptr<CMultiLineLabel> labelCreatureAvailable;
+	std::shared_ptr<CMultiLineLabel> labelCreatureGrowth;
 
 	std::shared_ptr<LRClickableAreaOpenTown> openTown;
 


### PR DESCRIPTION
Add missing strings in kingdom overview.
- `core.genrltxt.265`
- `core.genrltxt.266`