### PR TITLE
Another batch of fixes for recent bugs & regressions

### DIFF
--- a/client/NetPacksClient.cpp
+++ b/client/NetPacksClient.cpp
@@ -517,6 +517,7 @@ void ApplyFirstClientNetPackVisitor::visitTryMoveHero(TryMoveHero & pack)
 	{
 		case TryMoveHero::EMBARK:
 			GAME->map().onBeforeHeroEmbark(h, pack.start, pack.end);
+			GAME->map().waitForOngoingAnimations(); // required - hero must play fade-out animation on his pre-embark position
 			break;
 		case TryMoveHero::TELEPORTATION:
 			GAME->map().onBeforeHeroTeleported(h, pack.start, pack.end);

--- a/client/adventureMap/CMinimap.cpp
+++ b/client/adventureMap/CMinimap.cpp
@@ -49,6 +49,12 @@ ColorRGBA CMinimapInstance::getTileColor(const int3 & pos) const
 		if(player == PlayerColor::NEUTRAL)
 			return graphics->neutralColor;
 
+		if (settings["adventure"]["minimapShowHeroes"].Bool())
+		{
+			if (obj->ID == MapObjectID::HERO)
+				continue;
+		}
+
 		if (player.isValidPlayer())
 			return graphics->playerColors[player.getNum()];
 	}
@@ -134,8 +140,8 @@ Point CMinimap::tileToPixels(const int3 &tile) const
 	double stepX = static_cast<double>(pos.w) / mapSizes.x;
 	double stepY = static_cast<double>(pos.h) / mapSizes.y;
 
-	int x = static_cast<int>(stepX * tile.x);
-	int y = static_cast<int>(stepY * tile.y);
+	int x = static_cast<int>(stepX * (tile.x + 0.5));
+	int y = static_cast<int>(stepY * (tile.y + 0.5));
 
 	return Point(x,y);
 }

--- a/lib/campaign/CampaignHandler.cpp
+++ b/lib/campaign/CampaignHandler.cpp
@@ -356,9 +356,12 @@ void CampaignHandler::readHeaderFromMemory( CampaignHeader & ret, CBinaryReader 
 	const auto & mapping = LIBRARY->mapFormat->getMapping(ret.version);
 
 	CampaignRegionID campaignMapId(reader.readUInt8());
-	ret.campaignRegions = *LIBRARY->campaignRegions->getByIndex(mapping.remap(campaignMapId));
-	if(ret.version != CampaignVersion::HotA)
-		ret.numberOfScenarios = ret.campaignRegions.regionsCount();
+	if(ret.version != CampaignVersion::Chr)
+	{
+		ret.campaignRegions = *LIBRARY->campaignRegions->getByIndex(mapping.remap(campaignMapId));
+		if(ret.version != CampaignVersion::HotA)
+			ret.numberOfScenarios = ret.campaignRegions.regionsCount();
+	}
 	ret.name.appendTextID(readLocalizedString(ret, reader, filename, modName, encoding, "name"));
 	ret.description.appendTextID(readLocalizedString(ret, reader, filename, modName, encoding, "description"));
 	ret.author.appendRawString("");

--- a/lib/campaign/CampaignHandler.cpp
+++ b/lib/campaign/CampaignHandler.cpp
@@ -295,7 +295,16 @@ CampaignTravel CampaignHandler::readScenarioTravelFromJson(JsonNode & reader)
 		ret.playerColor = PlayerColor(PlayerColor::decode(reader["playerColor"].String()));
 
 	for(auto & bjson : reader["bonuses"].Vector())
-		ret.bonusesToChoose.emplace_back(bjson, ret.startOptions);
+	{
+		try {
+			ret.bonusesToChoose.emplace_back(bjson, ret.startOptions);
+		}
+		catch (const std::exception & e)
+		{
+			logGlobal->error("Failed to parse campaign bonus: %s", bjson.toCompactString());
+			throw e;
+		}
+	}
 
 	return ret;
 }

--- a/mapeditor/helper.cpp
+++ b/mapeditor/helper.cpp
@@ -85,7 +85,9 @@ void Helper::saveCampaign(std::shared_ptr<CampaignState> campaignState, const QS
 	auto saver = std::make_shared<CZipSaver>(io, filename.toStdString());
 	for(auto & scenario : campaignState->allScenarios())
 	{
-		auto map = campaignState->getMap(scenario, nullptr);
+		EditorCallback cb(nullptr);
+		auto map = campaignState->getMap(scenario, &cb);
+		cb.setMap(map.get());
 		MapController::repairMap(map.get());
 		CMemoryBuffer serializeBuffer;
 		{

--- a/mapeditor/mapcontroller.cpp
+++ b/mapeditor/mapcontroller.cpp
@@ -139,6 +139,9 @@ void MapController::repairMap(CMap * map)
 
 	for(auto obj : allImpactedObjects)
 	{
+		if(obj == nullptr)
+			continue;
+
 		//fix flags
 		if(obj->asOwnable() != nullptr && obj->getOwner() == PlayerColor::UNFLAGGABLE)
 		{


### PR DESCRIPTION
- Fix crash on (some?) h3c -> vcmp conversion attempt in editor 
- Fixed parsing of Chronicles campaign format
- Fixed broken boat embarking animation
- If hero minimap icons are in use, game will no longer show dot at hero location, but only icon - since dot was visible on small map sizes. Also, on such small maps, icon will be centered on tile, not on its top-left corner
- Added logging on parsing failure of campaign starting bonus in vcmp's 