### PR TITLE
Seerhut typo fix

### DIFF
--- a/lib/mapObjects/CQuest.cpp
+++ b/lib/mapObjects/CQuest.cpp
@@ -459,7 +459,7 @@ void CGSeerHut::initObj(IGameRandomizer & gameRandomizer)
 	
 	if(getQuest().questName == getQuest().missionName(EQuestMission::NONE))
 	{
-		getQuest().firstVisitText.appendTextID(TextIdentifier("core", "seehut", "empty", getQuest().completedOption).get());
+		getQuest().firstVisitText.appendTextID(TextIdentifier("core", "seerhut", "empty", getQuest().completedOption).get());
 	}
 	else
 	{


### PR DESCRIPTION
Probably more fixes will be needed.
Tried to play map **[HotA] Bay of Broken Ships.h3m** and near town is Seer hut, so noticed this string typo. But seems this object have different behavior in HotA on this map.

EDIT: In HotA seeks for Ring of Life. In VCMI it shows this empty string and give scroll. So looks like a bug somewhere else.