### PR TITLE
Fix magic_mirror spell

### DIFF
--- a/config/spells/timed.json
+++ b/config/spells/timed.json
@@ -1311,7 +1311,8 @@
 				"bonus.MIND_IMMUNITY":"normal",
 				"bonus.UNDEAD":"normal",
 				"bonus.NON_LIVING":"normal",
-				"bonus.MECHANICAL":"normal"
+				"bonus.MECHANICAL":"normal",
+				"spell.magicMirror":"normal"
 			}
 		},
 		"flags" : {

--- a/lib/spells/BattleSpellMechanics.cpp
+++ b/lib/spells/BattleSpellMechanics.cpp
@@ -19,7 +19,6 @@
 #include "../networkPacks/PacksForClientBattle.h"
 #include "../networkPacks/SetStackEffect.h"
 #include "../CStack.h"
-#include <boost/assign.hpp>
 
 #include <vstd/RNG.h>
 

--- a/lib/spells/BattleSpellMechanics.cpp
+++ b/lib/spells/BattleSpellMechanics.cpp
@@ -437,7 +437,7 @@ void BattleSpellMechanics::beforeCast(BattleSpellCast & sc, vstd::RNG & rng, con
 bool BattleSpellMechanics::isReflected(const battle::Unit * unit, vstd::RNG & rng)
 {
 	auto range = owner -> getLevelInfo(getRangeLevel()).range;
-	const auto directSpellRange = boost::assign::list_of(0);
+	const std::vector<int> directSpellRange = { 0 };
 	const std::string magicMirrorCacheStr = "type_MAGIC_MIRROR";
 	static const auto magicMirrorSelector = Selector::type()(BonusType::MAGIC_MIRROR);
 

--- a/lib/spells/BattleSpellMechanics.cpp
+++ b/lib/spells/BattleSpellMechanics.cpp
@@ -444,7 +444,7 @@ bool BattleSpellMechanics::isReflected(const battle::Unit * unit, vstd::RNG & rn
 	bool spellIsDirect = !isMassive() && owner -> getLevelInfo(getRangeLevel()).range == directSpellRange;
 	bool spellIsReflectable = spellIsDirect && (mode == Mode::HERO || mode == Mode::MAGIC_MIRROR) && isNegativeSpell();
 	bool targetCanReflectSpell = spellIsReflectable && unit->getAllBonuses(Selector::type()(BonusType::MAGIC_MIRROR))->size()>0;
-	return targetCanReflectSpell && rng.nextInt(0, 99) < unit->valOfBonuses(magicMirrorSelector, magicMirrorCacheStr);
+	return targetCanReflectSpell && rng.nextInt(0, 99) < unit->valOfBonuses(BonusType::MAGIC_MIRROR);
 }
 
 void BattleSpellMechanics::reflect(BattleSpellCast & sc, vstd::RNG & rng, const battle::Unit * unit)

--- a/lib/spells/BattleSpellMechanics.cpp
+++ b/lib/spells/BattleSpellMechanics.cpp
@@ -413,9 +413,7 @@ void BattleSpellMechanics::beforeCast(BattleSpellCast & sc, vstd::RNG & rng, con
 	std::set<const battle::Unit *> unitTargets = collectTargets();
 
 	if (unitTargets.size()==1 && isReflected(*(unitTargets.begin()), rng))
-	{
 		return reflect(sc, rng, *(unitTargets.begin()));
-	}
 
 	//process them
 	for(const auto * unit : unitTargets)
@@ -449,7 +447,7 @@ bool BattleSpellMechanics::isReflected(const battle::Unit * unit, vstd::RNG & rn
 	return targetCanReflectSpell && rng.nextInt(0, 99) < unit->valOfBonuses(magicMirrorSelector, magicMirrorCacheStr);
 }
 
-void BattleSpellMechanics::reflect(BattleSpellCast & sc, vstd::RNG & rng, const battle::Unit* unit)
+void BattleSpellMechanics::reflect(BattleSpellCast & sc, vstd::RNG & rng, const battle::Unit * unit)
 {
 	auto otherSide = battle()->otherSide(unit->unitSide());
 	auto newTarget = getRandomUnit(rng, otherSide);
@@ -460,15 +458,13 @@ void BattleSpellMechanics::reflect(BattleSpellCast & sc, vstd::RNG & rng, const 
 	sc.tile = reflectedTo;
 
 	if (!isReceptive(newTarget))
-	{
 		sc.resistedCres.insert(newTarget->unitId());    //A spell can be reflected to then resisted by an immune unit. Consistent with the original game.
-	}
 
 	beforeCast(sc, rng,
 		boost::assign::list_of(reflectedTo));
 }
 
-const battle::Unit* BattleSpellMechanics::getRandomUnit(vstd::RNG & rng, BattleSide & side)
+const battle::Unit * BattleSpellMechanics::getRandomUnit(vstd::RNG & rng, BattleSide & side)
 {
 	auto targets = battle()->getBattle()->getUnitsIf([this, & side](const battle::Unit * unit)
 	{

--- a/lib/spells/BattleSpellMechanics.cpp
+++ b/lib/spells/BattleSpellMechanics.cpp
@@ -466,7 +466,7 @@ void BattleSpellMechanics::reflect(BattleSpellCast & sc, vstd::RNG & rng, const 
 
 const battle::Unit * BattleSpellMechanics::getRandomUnit(vstd::RNG & rng, BattleSide & side)
 {
-	auto targets = battle()->getBattle()->getUnitsIf([this, & side](const battle::Unit * unit)
+	auto targets = battle()->getBattle()->getUnitsIf([&side](const battle::Unit * unit)
 	{
 		return unit->unitSide() == side && unit->isValidTarget(false) &&
 			!unit->hasBonusOfType(BonusType::SIEGE_WEAPON);

--- a/lib/spells/BattleSpellMechanics.cpp
+++ b/lib/spells/BattleSpellMechanics.cpp
@@ -463,7 +463,7 @@ void BattleSpellMechanics::reflect(BattleSpellCast & sc, vstd::RNG & rng, const 
 	beforeCast(sc, rng, { reflectedTo });
 }
 
-const battle::Unit * BattleSpellMechanics::getRandomUnit(vstd::RNG & rng, BattleSide & side)
+const battle::Unit * BattleSpellMechanics::getRandomUnit(vstd::RNG & rng, const BattleSide & side)
 {
 	auto targets = battle()->getBattle()->getUnitsIf([&side](const battle::Unit * unit)
 	{

--- a/lib/spells/BattleSpellMechanics.cpp
+++ b/lib/spells/BattleSpellMechanics.cpp
@@ -460,8 +460,7 @@ void BattleSpellMechanics::reflect(BattleSpellCast & sc, vstd::RNG & rng, const 
 	if (!isReceptive(newTarget))
 		sc.resistedCres.insert(newTarget->unitId());    //A spell can be reflected to then resisted by an immune unit. Consistent with the original game.
 
-	beforeCast(sc, rng,
-		boost::assign::list_of(reflectedTo));
+	beforeCast(sc, rng, { reflectedTo });
 }
 
 const battle::Unit * BattleSpellMechanics::getRandomUnit(vstd::RNG & rng, BattleSide & side)

--- a/lib/spells/BattleSpellMechanics.h
+++ b/lib/spells/BattleSpellMechanics.h
@@ -59,6 +59,7 @@ public:
 
 	/// Returns true if spell can be cast on unit
 	bool isReceptive(const battle::Unit * target) const override;
+	bool isSmart() const override;
 
 	/// Returns list of hexes that are affected by spell assuming cast at centralHex
 	BattleHexArray rangeInHexes(const BattleHex & centralHex) const override;
@@ -75,6 +76,9 @@ private:
 	effects::Effects::EffectsToApply effectsToApply;
 
 	void beforeCast(BattleSpellCast & sc, vstd::RNG & rng, const Target & target);
+	bool isReflected(const battle::Unit * unit, vstd::RNG & rng);
+	void reflect(BattleSpellCast & sc, vstd::RNG & rng, const battle::Unit* unit);
+	const battle::Unit* getRandomUnit(vstd::RNG & rng, BattleSide & side);
 
 	std::set<const battle::Unit *> collectTargets() const;
 

--- a/lib/spells/BattleSpellMechanics.h
+++ b/lib/spells/BattleSpellMechanics.h
@@ -78,7 +78,7 @@ private:
 	void beforeCast(BattleSpellCast & sc, vstd::RNG & rng, const Target & target);
 	bool isReflected(const battle::Unit * unit, vstd::RNG & rng);
 	void reflect(BattleSpellCast & sc, vstd::RNG & rng, const battle::Unit * unit);
-	const battle::Unit * getRandomUnit(vstd::RNG & rng, BattleSide & side);
+	const battle::Unit * getRandomUnit(vstd::RNG & rng, const BattleSide & side);
 
 	std::set<const battle::Unit *> collectTargets() const;
 

--- a/lib/spells/BattleSpellMechanics.h
+++ b/lib/spells/BattleSpellMechanics.h
@@ -77,8 +77,8 @@ private:
 
 	void beforeCast(BattleSpellCast & sc, vstd::RNG & rng, const Target & target);
 	bool isReflected(const battle::Unit * unit, vstd::RNG & rng);
-	void reflect(BattleSpellCast & sc, vstd::RNG & rng, const battle::Unit* unit);
-	const battle::Unit* getRandomUnit(vstd::RNG & rng, BattleSide & side);
+	void reflect(BattleSpellCast & sc, vstd::RNG & rng, const battle::Unit * unit);
+	const battle::Unit * getRandomUnit(vstd::RNG & rng, BattleSide & side);
 
 	std::set<const battle::Unit *> collectTargets() const;
 

--- a/lib/spells/ISpellMechanics.h
+++ b/lib/spells/ISpellMechanics.h
@@ -102,9 +102,6 @@ public:
 	//normal constructor
 	BattleCast(const CBattleInfoCallback * cb_, const Caster * caster_, const Mode mode_, const CSpell * spell_);
 
-	//magic mirror constructor
-	BattleCast(const BattleCast & orig, const Caster * caster_);
-
 	virtual ~BattleCast();
 
 	///IBattleCast


### PR DESCRIPTION
Fixes most issues related to magic mirror spell mentioned in the issue 5786.

Bug 1 Magic Mirror don't defend affected unit against spells when trigger.
Fixed.

Bug 2 Redirected spell have fraction of his spell power
Fixed.

Bug 3 Magic Mirror and Hypnotize - In H3 Magic Mirror has feature that unit protected by Magic Mirror was immune to Hypnotize.
Fixed. Currently on dev there seems to be game-breaking bug when Hypnotize is used in a hot-seat battle with two players, though. I cleaned and rebuilded from dev to be sure that it is not caused by my changes.  

Bug 4 No information when redirected spell failed
Fixed.

Bug 5 Area of effect spells.
After the changes a magic mirror counters only direct spells, aoe and mass spells are ignored. This behavior is consistent with the original.

Bug 6 Two Magic Mirror.
Fixed. I could not reproduce a chain of magic mirrors in the original (maybe I was unlucky and/or not stubborn enough), but it seems to be logical behavior, so I implemented it.

Bug 7 Magic Mirror and Blind/Berserk Spell
Not fixed (yet).

Current differences from the original:

Animation: In a case when a missile-type spell (for example magic arrow) is reflected to a caster's stack, the animation looks identical to an attack perform on an enemy stack.
In the original the missile starting position is moved a little above the casting hero. I am not sure if it was intentional and if it should be imitated.

Animation: in a case when a missile-type spell is reflected to a caster's stack that is immune to magic (for example black dragons or a stack with Anti-Magic spell) four animation play out: hero casts spells, the first unit reflects, the second resist and the missile strikes the resisting unit. In the original missile animation was omitted.
It is a result of current logic for resisting spells so I consider it outside the scope of pr.

Logic: Bug 7: I plan to fix it, but I would like to do it in a different pr for clarity sake.

PS: I like how each time a caster deals damage to his/her own units a facepalm animation is triggered.
PS2: I am kinda new to C++. I was trying to be careful, but I hope I didn't do anything silly with memory allocation.


