### PR TITLE
Add clang-tidy and clang-format configuration

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,190 @@
+---
+Language:        Cpp
+# BasedOnStyle:  Mozilla
+AccessModifierOffset: -4
+AlignAfterOpenBracket: BlockIndent
+AlignArrayOfStructures: Left
+AlignConsecutiveMacros: false 
+AlignConsecutiveAssignments: false 
+AlignConsecutiveBitFields: false 
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Left
+AlignOperands:   AlignAfterOperator
+AlignTrailingComments: false
+AllowAllArgumentsOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortEnumsOnASingleLine: false
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Empty
+AllowShortLambdasOnASingleLine: None
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: Yes
+AttributeMacros:
+  - __capability
+BinPackArguments: false
+BinPackParameters: false
+BraceWrapping:
+  AfterCaseLabel:  false
+  AfterClass:      true
+  AfterControlStatement: Never
+  AfterEnum:       true
+  AfterFunction:   true
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     true
+  AfterUnion:      true
+  AfterExternBlock: true
+  BeforeCatch:     false
+  BeforeElse:      false
+  BeforeLambdaBody: false
+  BeforeWhile:     false
+  IndentBraces:    false
+  SplitEmptyFunction: false
+  SplitEmptyRecord: false
+  SplitEmptyNamespace: false
+BreakBeforeBinaryOperators: None
+BreakBeforeConceptDeclarations: true
+BreakBeforeBraces: Allman
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeComma
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeComma
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     160
+CommentPragmas:  '^ IWYU pragma:'
+QualifierAlignment: Left
+CompactNamespaces: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DeriveLineEnding: true
+DerivePointerAlignment: false
+DisableFormat:   false
+EmptyLineAfterAccessModifier: Never
+EmptyLineBeforeAccessModifier: LogicalBlock
+ExperimentalAutoDetectBinPacking: false
+PackConstructorInitializers: BinPack
+BasedOnStyle:    ''
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+AllowAllConstructorInitializersOnNextLine: true
+FixNamespaceComments: false
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IfMacros:
+  - KJ_IF_MAYBE
+IncludeBlocks: Preserve
+IncludeCategories:
+  # Precompiled header
+  - Regex:           '"StdInc\.h"'
+    Priority:        0
+    SortPriority:    -1
+IncludeIsMainRegex: '(Test)?$'
+IncludeIsMainSourceRegex: ''
+IndentAccessModifiers: false
+IndentCaseLabels: true
+IndentCaseBlocks: false
+IndentGotoLabels: true
+IndentPPDirectives: AfterHash
+IndentExternBlock: AfterExternBlock
+IndentRequires:  false
+IndentWidth:     4
+IndentWrappedFunctionNames: false
+InsertTrailingCommas: None
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: true
+LambdaBodyIndentation: Signature
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Auto
+ObjCBlockIndentWidth: 4
+ObjCBreakBeforeNestedBlockParam: true
+ObjCSpaceAfterProperty: true
+ObjCSpaceBeforeProtocolList: false
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakOpenParenthesis: 0
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
+PenaltyIndentedWhitespace: 0
+PointerAlignment: Middle
+PPIndentWidth:   -1
+ReferenceAlignment: Pointer
+ReflowComments:  false
+RemoveBracesLLVM: false
+SeparateDefinitionBlocks: Leave
+ShortNamespaceLines: 1
+SortIncludes:    CaseSensitive
+SortJavaStaticImport: Before
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: Never
+SpaceBeforeParensOptions:
+  AfterControlStatements: true
+  AfterForeachMacros: true
+  AfterFunctionDefinitionName: false
+  AfterFunctionDeclarationName: false
+  AfterIfMacros:   true
+  AfterOverloadedOperator: false
+  BeforeNonEmptyParentheses: false
+SpaceAroundPointerQualifiers: Default
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  Never
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInLineCommentPrefix:
+  Minimum:         0
+  Maximum:         -1
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpaceBeforeSquareBrackets: false
+BitFieldColonSpacing: Both
+Standard:        Latest
+StatementAttributeLikeMacros:
+  - FALLTHROUGH
+  - STRONG_INLINE
+  - DLL_EXPORT
+  - DLL_IMPORT
+  - ELF_VISIBILITY
+  - Q_EMIT
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TabWidth:        4
+UseCRLF:         false
+UseTab:          ForContinuationAndIndentation 
+WhitespaceSensitiveMacros:
+  - STRINGIZE
+  - PP_STRINGIZE
+  - BOOST_PP_STRINGIZE
+  - NS_SWIFT_NAME
+  - CF_SWIFT_NAME
+...
+
+

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,83 @@
+# Enabled, but situational - a lot of triggers in old code:
+#  -bugprone-narrowing-conversions,                      # might be too noisy
+#  -cppcoreguidelines-narrowing-conversions,             # might be too noisy
+#  -cppcoreguidelines-pro-bounds-pointer-arithmetic,     # pointer arithmetic should be avoided, with possible exception for low-level reader classes
+#  -misc-private-member-variables-in-classes,            # good for classes, should be disabled/ignored for structs
+#  -readability-function-cognitive-complexity,           # can show candidates for refactoring
+#
+# Currently disabled options:
+#  -misc-unused-parameters,                              # a lot of intended cases, e.g. interfaces & their implementations
+#  -misc-include-cleaner,                                # a lot of false-positives, mostly due to StdInc.h
+#  -cppcoreguidelines-init-variables,                    # better to rely on "maybe initialized" compiler warnings
+#  -cppcoreguidelines-owning-memory,                     # requires 'gsl' library presence
+#  -cppcoreguidelines-avoid-magic-numbers,               # too much noise
+#  -readability-identifier-length,                       # too much noise
+#  -readability-magic-numbers,                           # too much noise
+#  -bugprone-easily-swappable-parameters,                # improvement doubtful
+#  -cppcoreguidelines-avoid-const-or-ref-data-members    # improvement doubtful
+#  -cppcoreguidelines-special-member-functions,          # improvement doubtful
+#  -cppcoreguidelines-pro-bounds-constant-array-index,   # improvement doubtful
+#  -readability-static-accessed-through-instance,        # improvement doubtful
+#  -readability-else-after-return,                       # improvement doubtful
+#  -modernize-pass-by-value,                             # improvement doubtful
+#  -google-readability-braces-around-statements,         # not in our code style
+#  -google-readability-namespace-comments,               # not in our code style
+#  -google-readability-todo,                             # not in our code style
+#  -modernize-use-trailing-return-type,                  # not in our code style
+#  -modernize-return-braced-init-list,                   # not in our code style
+#  -modernize-use-nodiscard,                             # not in our code style
+#  -readability-braces-around-statements,                # not in our code style
+#  -readability-implicit-bool-conversion,                # not in our code style for pointers, and int-only detection seems to be broken?
+#  -readability-uppercase-literal-suffix                 # not in our code style
+#  -readability-convert-member-functions-to-static,      # candidate for re-enabling, to show poorly designed class methods
+
+Checks: >
+  -*,
+  boost-*,
+  bugprone-*,
+  clang-*,
+  cppcoreguidelines-*,
+  google-*,
+  misc-*,
+  modernize-*,
+  performance-*,
+  readability-*,
+  -bugprone-easily-swappable-parameters,
+  -cppcoreguidelines-avoid-const-or-ref-data-members,
+  -cppcoreguidelines-avoid-magic-numbers,
+  -cppcoreguidelines-init-variables,
+  -cppcoreguidelines-owning-memory,
+  -cppcoreguidelines-special-member-functions,
+  -cppcoreguidelines-pro-bounds-constant-array-index,
+  -google-readability-braces-around-statements,
+  -google-readability-namespace-comments,
+  -google-readability-todo,
+  -misc-include-cleaner,
+  -misc-unused-parameters,
+  -modernize-use-trailing-return-type,
+  -modernize-return-braced-init-list,
+  -modernize-pass-by-value,
+  -modernize-use-nodiscard,
+  -readability-braces-around-statements,
+  -readability-convert-member-functions-to-static,
+  -readability-else-after-return,
+  -readability-identifier-length,
+  -readability-implicit-bool-conversion,
+  -readability-magic-numbers,
+  -readability-static-accessed-through-instance,
+  -readability-uppercase-literal-suffix,
+  -readability-use-anyofallof
+
+CheckOptions:
+  - key:             misc-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic
+    value:           'true'
+  - key:             llvm-else-after-return.WarnOnConditionVariables
+    value:           'false'
+  - key:             misc-const-correctness.AnalyzeValues 
+    value:           'false'
+  - key:             misc-include-cleaner.IgnoreHeaders
+    value:           'StdInc.h'
+  - key:             readability-function-size.StatementThreshold
+    value:           '800'
+  - key:             misc-include-cleaner.IgnoreHeaders
+    value:           'StdInc.h'


### PR DESCRIPTION
- Fixes #938

I've been using these configurations for some time, and they work quite well for vcmi code. Providing them primary to help with setting up code formatting & linting for other developers. So if your IDE supports these tools - feel free to enable their use.

However I can't say that I am 100% satisfied with how they work, so some notes.

clang-format:
- I was unable to setup lambdas formatting when used as function parameters in a "nice" way. They often end up with some strange alignment. Not sure if this is due to misconfiguration or due to how the tool works
- Line length threshold is too strict. For example I'd like to configure it in a way "always break if line longer than 160 chars, always merge if line is shorter than 120 chars, keep as if it is 120-160 chars long.". But clang-format can't be configured this way.
- when near threshold, function parameters align in a strange way, like this:
  ```cpp
    function(
        parameter1, parameter2,
    );
  ```
  ... instead of more logical single-line or 1-parameter-per-line forms.

So clang-format is good in like 99% of cases, but not something that I would use for automatic use (e.g. pre-commit hook or CI check). I usually use it to process visible part of the code, and revert/adjust manually parts I don't agree with.

clang-tidy:
- Produces results quite close to what Sonar offers, in fact a lot of checks are clearly identical.
- Some enabled rules are not "must-fix", but rather a hint "make sure that this code is correct". For example it has enabled rule "no recursion", even though we use recursion and I don't see anything wrong with it. However it was handy a few times when I *accidentally* ended up with unintended recursion. Same goes to various narrowing conversions

So something that worth keeping an eye on, but not something that must be fixed before merging. In theory we could try to setup clang-tidy as CI step, but would largely duplicate existing Sonar.