### PR TITLE
Bonus limiters refactoring

### DIFF
--- a/config/artifacts.json
+++ b/config/artifacts.json
@@ -913,14 +913,10 @@
 				"limiters" : [
 					{
 						"type" : "HAS_ANOTHER_BONUS_LIMITER",
-						"parameters" : [
-							"PERCENTAGE_DAMAGE_BOOST",
-							"damageTypeRanged",
-							{
-								"type" : "SECONDARY_SKILL",
-								"id" : "secondarySkill.archery"
-							}
-						]
+						"bonusType" : "PERCENTAGE_DAMAGE_BOOST",
+						"bonusSubtype" : "damageTypeRanged",
+						"bonusSourceType" : "SECONDARY_SKILL",
+						"bonusSourceID" : "secondarySkill.archery"
 					}
 				]
 			}
@@ -939,14 +935,10 @@
 				"limiters" : [
 					{
 						"type" : "HAS_ANOTHER_BONUS_LIMITER",
-						"parameters" : [
-							"PERCENTAGE_DAMAGE_BOOST",
-							"damageTypeRanged",
-							{
-								"type" : "SECONDARY_SKILL",
-								"id" : "secondarySkill.archery"
-							}
-						]
+						"bonusType" : "PERCENTAGE_DAMAGE_BOOST",
+						"bonusSubtype" : "damageTypeRanged",
+						"bonusSourceType" : "SECONDARY_SKILL",
+						"bonusSourceID" : "secondarySkill.archery"
 					}
 				]
 			}
@@ -965,14 +957,10 @@
 				"limiters" : [
 					{
 						"type" : "HAS_ANOTHER_BONUS_LIMITER",
-						"parameters" : [
-							"PERCENTAGE_DAMAGE_BOOST",
-							"damageTypeRanged",
-							{
-								"type" : "SECONDARY_SKILL",
-								"id" : "secondarySkill.archery"
-							}
-						]
+						"bonusType" : "PERCENTAGE_DAMAGE_BOOST",
+						"bonusSubtype" : "damageTypeRanged",
+						"bonusSourceType" : "SECONDARY_SKILL",
+						"bonusSourceID" : "secondarySkill.archery"
 					}
 				]
 			}
@@ -1993,19 +1981,19 @@
 					"IS_UNDEAD",
 					{
 						"type" : "HAS_ANOTHER_BONUS_LIMITER",
-						"parameters" : [ "NON_LIVING" ]
+						"bonusType" : "NON_LIVING"
 					},
 					{
 						"type" : "HAS_ANOTHER_BONUS_LIMITER",
-						"parameters" : [ "MECHANICAL" ]
+						"bonusType" : "MECHANICAL"
 					},
 					{
 						"type" : "HAS_ANOTHER_BONUS_LIMITER",
-						"parameters" : [ "GARGOYLE" ]
+						"bonusType" : "GARGOYLE"
 					},
 					{
 						"type" : "HAS_ANOTHER_BONUS_LIMITER",
-						"parameters" : [ "SIEGE_WEAPON" ]
+						"bonusType" : "SIEGE_WEAPON"
 					}
 				]
 			},
@@ -2018,15 +2006,15 @@
 					"IS_UNDEAD",
 					{
 						"type" : "HAS_ANOTHER_BONUS_LIMITER",
-						"parameters" : [ "NON_LIVING" ]
+						"bonusType" : "NON_LIVING"
 					},
 					{
 						"type" : "HAS_ANOTHER_BONUS_LIMITER",
-						"parameters" : [ "MECHANICAL" ]
+						"bonusType" : "MECHANICAL"
 					},
 					{
 						"type" : "HAS_ANOTHER_BONUS_LIMITER",
-						"parameters" : [ "GARGOYLE" ]
+						"bonusType" : "GARGOYLE"
 					}
 				]
 			}

--- a/config/battlefields.json
+++ b/config/battlefields.json
@@ -80,14 +80,14 @@
 				"val" : 1,
 				"valueType" : "BASE_NUMBER",
 				"description" : "@core.arraytxt.123",
-				"limiters": [{ "type" : "CREATURE_ALIGNMENT_LIMITER", "parameters" : ["good"] }]
+				"limiters": [{ "type" : "CREATURE_ALIGNMENT_LIMITER", "alignment" : "good" }]
 			},
 			{
 				"type" : "MORALE",
 				"val" : -1,
 				"valueType" : "BASE_NUMBER",
 				"description" : "@core.arraytxt.124",
-				"limiters": [{ "type" : "CREATURE_ALIGNMENT_LIMITER", "parameters" : ["evil"] }]
+				"limiters": [{ "type" : "CREATURE_ALIGNMENT_LIMITER", "alignment" : "evil" }]
 			}
 		]
 	},
@@ -100,7 +100,7 @@
 				"val" : 2,
 				"valueType" : "BASE_NUMBER",
 				"description" : "@core.arraytxt.83",
-				"limiters": [{ "type" : "CREATURE_ALIGNMENT_LIMITER", "parameters" : ["neutral"] }]
+				"limiters": [{ "type" : "CREATURE_ALIGNMENT_LIMITER", "alignment" : "neutral" }]
 			}
 		]
 	},
@@ -113,14 +113,14 @@
 				"val" : -1,
 				"valueType" : "BASE_NUMBER",
 				"description" : "@core.arraytxt.126",
-				"limiters": [{ "type" : "CREATURE_ALIGNMENT_LIMITER", "parameters" : ["good"] }]
+				"limiters": [{ "type" : "CREATURE_ALIGNMENT_LIMITER", "alignment" : "good" }]
 			},
 			{
 				"type" : "MORALE",
 				"val" : 1,
 				"valueType" : "BASE_NUMBER",
 				"description" : "@core.arraytxt.125",
-				"limiters": [{ "type" : "CREATURE_ALIGNMENT_LIMITER", "parameters" : ["evil"] }]
+				"limiters": [{ "type" : "CREATURE_ALIGNMENT_LIMITER", "alignment" : "evil" }]
 			}
 		]
 	},

--- a/config/creatures/neutral.json
+++ b/config/creatures/neutral.json
@@ -103,7 +103,7 @@
 					"OPPOSITE_SIDE", 
 					{
 						"type" : "HAS_ANOTHER_BONUS_LIMITER",
-						"parameters" : [ "LIVING" ]
+						"bonusType" : "LIVING"
 					}
 				]
 			},

--- a/config/heroes/castle.json
+++ b/config/heroes/castle.json
@@ -145,14 +145,8 @@
 					"limiters" : [
 						{
 							"type" : "HAS_ANOTHER_BONUS_LIMITER",
-							"parameters" : [
-								null,
-								null,
-								{
-									"type" : "SPELL_EFFECT",
-									"id" : "spell.bless"
-								}
-							]
+							"bonusSourceType" : "SPELL_EFFECT",
+							"bonusSourceID" : "spell.bless"
 						}
 					],
 					"updater" : "TIMES_HERO_LEVEL_DIVIDE_STACK_LEVEL",

--- a/config/heroes/conflux.json
+++ b/config/heroes/conflux.json
@@ -13,8 +13,9 @@
 			"base" : {
 				"limiters" : [
 					{
-						"parameters" : [ "psychicElemental", true ],
-						"type" : "CREATURE_TYPE_LIMITER"
+						"type" : "CREATURE_TYPE_LIMITER",
+						"creature" : "psychicElemental",
+						"includeUpgrades" : true
 					}
 				],
 				"type" : "PRIMARY_SKILL",
@@ -40,8 +41,9 @@
 			"base" : {
 				"limiters" : [
 					{
-						"parameters" : [ "earthElemental", true ],
-						"type" : "CREATURE_TYPE_LIMITER"
+						"type" : "CREATURE_TYPE_LIMITER",
+						"creature" : "earthElemental",
+						"includeUpgrades" : true
 					}
 				]
 			},
@@ -78,8 +80,9 @@
 			"base" : {
 				"limiters" : [
 					{
-						"parameters" : [ "fireElemental", true ],
-						"type" : "CREATURE_TYPE_LIMITER"
+						"type" : "CREATURE_TYPE_LIMITER",
+						"creature" : "fireElemental",
+						"includeUpgrades" : true
 					}
 				]
 			},
@@ -116,8 +119,9 @@
 				"attack" : {
 					"limiters" : [
 						{
-							"parameters" : [ "waterElemental", true ],
-							"type" : "CREATURE_TYPE_LIMITER"
+							"type" : "CREATURE_TYPE_LIMITER",
+							"creature" : "waterElemental",
+							"includeUpgrades" : true
 						}
 					],
 					"subtype" : "primarySkill.attack",
@@ -141,8 +145,9 @@
 			"base" : {
 				"limiters" : [
 					{
-						"parameters" : [ "psychicElemental", true ],
-						"type" : "CREATURE_TYPE_LIMITER"
+						"type" : "CREATURE_TYPE_LIMITER",
+						"creature" : "psychicElemental",
+						"includeUpgrades" : true
 					}
 				],
 				"type" : "PRIMARY_SKILL",
@@ -168,8 +173,9 @@
 			"base" : {
 				"limiters" : [
 					{
-						"parameters" : [ "earthElemental", true ],
-						"type" : "CREATURE_TYPE_LIMITER"
+						"type" : "CREATURE_TYPE_LIMITER",
+						"creature" : "earthElemental",
+						"includeUpgrades" : true
 					}
 				]
 			},
@@ -205,8 +211,9 @@
 			"base" : {
 				"limiters" : [
 					{
-						"parameters" : [ "fireElemental", true ],
-						"type" : "CREATURE_TYPE_LIMITER"
+						"type" : "CREATURE_TYPE_LIMITER",
+						"creature" : "fireElemental",
+						"includeUpgrades" : true
 					}
 				]
 			},
@@ -244,8 +251,9 @@
 				"attack" : {
 					"limiters" : [
 						{
-							"parameters" : [ "waterElemental", true ],
-							"type" : "CREATURE_TYPE_LIMITER"
+							"type" : "CREATURE_TYPE_LIMITER",
+							"creature" : "waterElemental",
+							"includeUpgrades" : true
 						}
 					],
 					"subtype" : "primarySkill.attack",

--- a/config/heroes/special.json
+++ b/config/heroes/special.json
@@ -110,8 +110,9 @@
 			"base" : {
 				"limiters" : [
 					{
-						"parameters" : [ "behemoth", true ],
-						"type" : "CREATURE_TYPE_LIMITER"
+						"type" : "CREATURE_TYPE_LIMITER",
+						"creature" : "behemoth",
+						"includeUpgrades" : true
 					}
 				]
 			},
@@ -149,8 +150,9 @@
 			"base" : {
 				"limiters" : [
 					{
-						"parameters" : [ "blackKnight", true ],
-						"type" : "CREATURE_TYPE_LIMITER"
+						"type" : "CREATURE_TYPE_LIMITER",
+						"creature" : "blackKnight",
+						"includeUpgrades" : true
 					}
 				]
 			},
@@ -189,8 +191,8 @@
 			"base" : {
 				"limiters" : [
 					{
-						"parameters" : [ "DRAGON_NATURE" ],
-						"type" : "HAS_ANOTHER_BONUS_LIMITER"
+						"type" : "HAS_ANOTHER_BONUS_LIMITER",
+						"bonusType" : "DRAGON_NATURE"
 					}
 				],
 				"type" : "PRIMARY_SKILL",
@@ -233,8 +235,8 @@
 			"base" : {
 				"limiters" : [
 					{
-						"parameters" : [ "DRAGON_NATURE" ],
-						"type" : "HAS_ANOTHER_BONUS_LIMITER"
+						"type" : "HAS_ANOTHER_BONUS_LIMITER",
+						"bonusType" : "DRAGON_NATURE"
 					}
 				],
 				"type" : "PRIMARY_SKILL",
@@ -306,8 +308,9 @@
 			"base" : {
 				"limiters" : [
 					{
-						"parameters" : [ "devil", true ],
-						"type" : "CREATURE_TYPE_LIMITER"
+						"type" : "CREATURE_TYPE_LIMITER",
+						"creature" : "devil",
+						"includeUpgrades" : true
 					}
 				]
 			},

--- a/config/schemas/artifact.json
+++ b/config/schemas/artifact.json
@@ -43,7 +43,7 @@
 				{
 					"type" : "array",
 					"minItems" : 1,
-					"additionalItems" : { "type" : "string" }
+					"items" : { "type" : "string" }
 				}
 			]
 		},

--- a/config/schemas/bonusInstance.json
+++ b/config/schemas/bonusInstance.json
@@ -7,33 +7,166 @@
 	"definitions" :
 	{
 		"nestedLimiter" : {
-			"anyOf" : [
+			"allOf" : [
 				{ 
-					"type" : "string",
-					"enum" : [ "SHOOTER_ONLY", "DRAGON_NATURE", "IS_UNDEAD", "CREATURE_NATIVE_TERRAIN", "CREATURE_FACTION", "SAME_FACTION", "CREATURES_ONLY", "OPPOSITE_SIDE" ],
-					"description" : "parameterless limiter or boolean operator at start of array"
+					"if" : {
+						"type" : "string"
+					},
+					"then" : {
+						"enum" : [ "allOf", "anyOf", "noneOf", "SHOOTER_ONLY", "DRAGON_NATURE", "IS_UNDEAD", "CREATURE_NATIVE_TERRAIN", "CREATURES_ONLY", "OPPOSITE_SIDE" ],
+						"description" : "parameterless limiter or boolean operator at start of array"
+					}
 				},
 				{
-					"type" : "object",
-					"additionalProperties" : false,
-					"properties" : {
-						"type" : {
-							"type" : "string",
-							"enum" : [ "CREATURE_TYPE_LIMITER", "HAS_ANOTHER_BONUS_LIMITER", "CREATURE_ALIGNMENT_LIMITER", "FACTION_LIMITER", "CREATURE_LEVEL_LIMITER", "CREATURE_TERRAIN_LIMITER", "UNIT_ON_HEXES" ],
-							"description" : "type"
-						},
-						"parameters" : {
-							"type" : "array",
-							"description" : "parameters",
-							"additionalItems" : true
+					"if" : {
+						"type" : "object",
+						"required" : [ "type" ],
+						"properties" : {
+							"type" : { "type" : "string", "const" : "CREATURE_TYPE_LIMITER" }
+						}
+					},
+					"then" : {
+						"additionalProperties" : false,
+						"required" : [ "type", "creature" ],
+						"properties" : {
+							"type" : { "type" : "string", "const" : "CREATURE_TYPE_LIMITER" },
+							"parameters" : { "type" : "array", "description" : "parameters", "additionalItems" : true },
+							"creature" : { "type" : "string" },
+							"includeUpgrades" : { "type" : "boolean" }
 						}
 					}
 				},
 				{
-					"type" : "array",
-					"additionalItems" : {
-						"$ref" : "#/definitions/nestedLimiter",
-						"description" : "nested limiters optionally prefixed with boolean operator"
+					"if" : {
+						"type" : "object",
+						"required" : [ "type" ],
+						"properties" : {
+							"type" : { "type" : "string", "const" : "HAS_ANOTHER_BONUS_LIMITER" }
+						}
+					},
+					"then" : {
+						"additionalProperties" : false,
+						"properties" : {
+							"type" : { "type" : "string", "const" : "HAS_ANOTHER_BONUS_LIMITER" },
+							"parameters" : { "type" : "array", "description" : "parameters", "additionalItems" : true },
+							"bonusType" : { "type" : "string" },
+							"bonusSubtype" : { "type" : "string" },
+							"bonusSourceType" : { "type" : "string" },
+							"bonusSourceID" : { "type" : "string" }
+						}
+					}
+				},
+				{
+					"if" : {
+						"type" : "object",
+						"properties" : {
+							"type" : { "type" : "string", "const" : "CREATURE_ALIGNMENT_LIMITER" }
+						}
+					},
+					"then" : {
+						"additionalProperties" : false,
+						"properties" : {
+							"type" : { "type" : "string", "const" : "CREATURE_ALIGNMENT_LIMITER" },
+							"parameters" : { "type" : "array", "description" : "parameters", "additionalItems" : true },
+							"alignment" : { "type" : "string", "enum" : [ "good", "evil", "neutral" ] }
+						}
+					}
+				},
+				{
+					"if" : {
+						"type" : "object",
+						"required" : [ "type" ],
+						"properties" : {
+							"type" : { "type" : "string", "enum" : [ "CREATURE_FACTION_LIMITER", "FACTION_LIMITER" ] }
+						}
+					},
+					"then" : {
+						"additionalProperties" : false,
+						"properties" : {
+							"type" : { "type" : "string", "enum" : [ "CREATURE_FACTION_LIMITER", "FACTION_LIMITER" ] },
+							"parameters" : { "type" : "array", "description" : "parameters", "additionalItems" : true },
+							"faction" : { "type" : "string" }
+						}
+					}
+				},
+				{
+					"if" : {
+						"type" : "object",
+						"required" : [ "type" ],
+						"properties" : {
+							"type" : { "type" : "string", "const" : "CREATURE_LEVEL_LIMITER" }
+						}
+					},
+					"then" : {
+						"additionalProperties" : false,
+						"properties" : {
+							"type" : { "type" : "string", "const" : "CREATURE_LEVEL_LIMITER" },
+							"parameters" : { "type" : "array", "description" : "parameters", "additionalItems" : true },
+							"minLevel" : { "type" : "number" },
+							"maxlevel" : { "type" : "number" }
+						}
+					}
+				},
+				{
+					"if" : {
+						"type" : "object",
+						"required" : [ "type" ],
+						"properties" : {
+							"type" : { "type" : "string", "const" : "CREATURE_TERRAIN_LIMITER" }
+						}
+					},
+					"then" : {
+						"additionalProperties" : false,
+						"properties" : {
+							"type" : { "type" : "string", "const" : "CREATURE_TERRAIN_LIMITER" },
+							"parameters" : { "type" : "array", "description" : "parameters", "additionalItems" : true },
+							"terrain" : { "type" : "string" }
+						}
+					}
+				},
+				{
+					"if" : {
+						"type" : "object",
+						"required" : [ "type" ],
+						"properties" : {
+							"type" : { "type" : "string", "const" : "UNIT_ON_HEXES" }
+						}
+					},
+					"then" : {
+						"additionalProperties" : false,
+						"properties" : {
+							"type" : { "type" : "string", "const" : "UNIT_ON_HEXES" },
+							"parameters" : { "type" : "array", "description" : "parameters", "additionalItems" : true },
+							"hexes" : { "type" : "array", "items" : { "type" : "number" } }
+						}
+					}
+				},
+				{
+					"if" : {
+						"type" : "object",
+						"required" : [ "type" ],
+						"properties" : {
+							"type" : { "type" : "string", "const" : "HAS_CHARGES_LIMITER" }
+						}
+					},
+					"then" : {
+						"additionalProperties" : false,
+						"properties" : {
+							"type" : { "type" : "string", "const" : "HAS_CHARGES_LIMITER" },
+							"parameters" : { "type" : "array", "description" : "parameters", "additionalItems" : true },
+							"cost" : { "type" : "number" }
+						}
+					}
+				},
+				{
+					"if" : {
+						"type" : "array"
+					},
+					"then" : {
+						"items" : {
+							"$ref" : "#/definitions/nestedLimiter",
+							"description" : "nested limiters optionally prefixed with boolean operator"
+						}
 					}
 				}
 			]

--- a/docs/modders/Bonus/Bonus_Limiters.md
+++ b/docs/modders/Bonus/Bonus_Limiters.md
@@ -2,22 +2,37 @@
 
 ## Predefined Limiters
 
-The limiters take no parameters:
-
-- SHOOTER_ONLY
-- DRAGON_NATURE
-- IS_UNDEAD
-- CREATURE_NATIVE_TERRAIN
-- CREATURE_FACTION
-- SAME_FACTION
-- CREATURES_ONLY
-- OPPOSITE_SIDE
+Simple limiters that take no parameters.
 
 Example:
 
 ```json
 "limiters" : [ "SHOOTER_ONLY" ]
 ```
+
+### SHOOTER_ONLY
+
+Bonus is active if affected unit is a shooter (has SHOOTER bonus)
+
+### DRAGON_NATURE
+
+Bonus is active if affected unit is a dragon (has DRAGON_NATURE bonus)
+
+### IS_UNDEAD
+
+Bonus is active if affected unit is an undead (has UNDEAD bonus)
+
+### CREATURE_NATIVE_TERRAIN
+
+Bonus is active if affected unit is on native terrain
+
+### CREATURES_ONLY
+
+Bonus is active only on units
+
+### OPPOSITE_SIDE
+
+Bonus is active only for opposite side for a battle-wide bonus. Requires `BONUS_OWNER_UPDATER` to be present on bonus
 
 ## Customizable Limiters
 
@@ -27,11 +42,12 @@ Bonus is only active if affected entity has another bonus that meets conditions
 
 Parameters:
 
-- Bonus type
-- Bonus subtype (only used if bonus type is set)
-- Bonus source type and bonus source ID
+- `bonusType` - type of bonus to check against
+- `bonusSubtype` - subtype of bonus to check against (only used if bonus type is set)
+- `bonusSourceType` - source type of bonus to check against
+- `bonusSourceID` -source ID of bonus to check against (only used if bonus type is set)
 
-All parameters are optional. Values that don't need checking can be replaces with `null`
+All parameters are optional.
 
 Examples:
 
@@ -41,14 +57,8 @@ Examples:
 	"limiters" : [
 		{
 			"type" : "HAS_ANOTHER_BONUS_LIMITER",
-			"parameters" : [
-				null, // bonus type is ignored
-				null, // bonus subtype is also ignored
-				{
-					"type" : "SPELL_EFFECT", // look for bonus of type SPELL_EFFECT
-					"id" : "spell.bless"     // ... from spell "Bless"
-				}
-				]
+			"bonusSourceType" : "SPELL_EFFECT", // look for bonus of type SPELL_EFFECT
+			"bonusSourceID" : "spell.bless"     // ... from spell "Bless"
 		}
 	],
 ```
@@ -58,8 +68,8 @@ Examples:
 ```json
 	"limiters" : [
 		{
-			"parameters" : [ "DRAGON_NATURE" ],
-			"type" : "HAS_ANOTHER_BONUS_LIMITER"
+			"type" : "HAS_ANOTHER_BONUS_LIMITER",
+			"bonusType" : "DRAGON_NATURE"
 		}
 	],
 ```
@@ -70,16 +80,19 @@ Bonus is only active on creatures of specified type
 
 Parameters:
 
-- Creature id (string)
-- (optional) include upgrades - default is false. If creature has multiple upgrades, or upgrades have their own upgrades, all such creatures will be affected. Special upgrades such as upgrades via specialties (Dragon, Gelu) are not affected
+- `creature` - ID of creature to check against
+- `includeUpgrades` - whether creature that is upgrade of `creature` should also pass this limiter. If creature has multiple upgrades, or upgrades have their own upgrades, all such creatures will be affected. Special upgrades such as upgrades via specialties (Dragon, Gelu) are not affected
 
 Example:
 
 ```json
-"limiters": [ {
-	"type":"CREATURE_TYPE_LIMITER",
-	"parameters": [ "angel", true ]
-} ],
+"limiters": [
+	{
+		"type" : "CREATURE_TYPE_LIMITER",
+		"creature" : "angel",
+		"includeUpgrades" : true
+	}
+],
 ```
 
 ### CREATURE_ALIGNMENT_LIMITER
@@ -88,45 +101,69 @@ Bonus is only active on creatures of factions of specified alignment
 
 Parameters:
 
-- Alignment identifier, `good`, `evil`, or `neutral`
+- `alignment` - ID of alignment that creature must have, `good`, `evil`, or `neutral`
+
+```json
+"limiters": [
+	{
+		"type" : "CREATURE_ALIGNMENT_LIMITER",
+		"alignment" : "evil"
+	}
+],
+```
 
 ### CREATURE_LEVEL_LIMITER
 
-If parameters is empty, level limiter works as CREATURES_ONLY limiter
+If parameters is empty, any creature will pass this limiter
 
 Parameters:
 
-- Minimal level
-- Maximal level
+- `minLevel` - minimal level that creature must have to pass limiter
+- `maxlevel` - maximal level that creature must have to pass limiter
+
+```json
+"limiters": [
+	{
+		"type" : "CREATURE_LEVEL_LIMITER",
+		"minLevel" : 1,
+		"maxlevel" : 5
+	}
+],
+```
 
 ### FACTION_LIMITER
 
+Also available as `CREATURE_FACTION_LIMITER`
+
 Parameters:
 
-- Faction identifier
+- `faction` - faction that creature or hero must belong to
+
+```json
+"limiters": [
+	{
+		"type" : "FACTION_LIMITER",
+		"faction" : "castle"
+	}
+],
+```
 
 ### CREATURE_TERRAIN_LIMITER
 
 Parameters:
 
-- Terrain identifier
+- `terrain` - identifier of terrain on which this creature must be to pass this limiter. If not set, creature will pass this limiter if it is on native terrain
 
 Example:
 
 ```json
-"limiters" : [ {
-	"type" : "CREATURE_TERRAIN_LIMITER",
-	"parameters" : ["sand"]
-} ]
+"limiters" : [
+	{
+		"type" : "CREATURE_TERRAIN_LIMITER",
+		"terrain" : "sand"
+	}
+]
 ```
-
-### UNIT_ON_HEXES
-
-Parameters:
-
-- List of affected battlefield hexes
-
-For reference on tiles indexes see image below:
 
 ### HAS_CHARGES_LIMITER
 
@@ -134,25 +171,43 @@ Currently works only with spells. Sets the cost of use in charges
 
 Parameters:
 
-- use cost (charges)
+- `cost` - use cost (charges)
 
 ```json
-"limiters" : [ {
-  "type" : "HAS_CHARGES_LIMITER",
-  "parameters" : [2]
-} ]
+"limiters" : [
+	{
+		"type" : "HAS_CHARGES_LIMITER",
+		"cost" : 2
+	}
+]
 ```
+
+### UNIT_ON_HEXES
+
+Parameters:
+
+- `hexes` - List of affected battlefield hexes
+
+```json
+"limiters" : [
+	{
+		"type" : "UNIT_ON_HEXES",
+		"hexes" : [ 25, 50, 75 ]
+	}
+]
+```
+
+For reference on tiles indexes see image below:
 
 ![Battlefield Hexes Layout](../../images/Battle_Field_Hexes.svg)
 
 ## Aggregate Limiters
 
-The following limiters must be specified as the first element of a list,
-and operate on the remaining limiters in that list:
+The following limiters must be specified as the first element of a list, and operate on the remaining limiters in that list:
 
-- allOf (default when no aggregate limiter is specified)
-- anyOf
-- noneOf
+- `allOf` (default when no aggregate limiter is specified)
+- `anyOf`
+- `noneOf`
 
 Example:
 

--- a/lib/bonuses/Limiters.cpp
+++ b/lib/bonuses/Limiters.cpp
@@ -30,8 +30,6 @@ const std::map<std::string, TLimiterPtr> bonusLimiterMap =
 	{"DRAGON_NATURE", std::make_shared<HasAnotherBonusLimiter>(BonusType::DRAGON_NATURE)},
 	{"IS_UNDEAD", std::make_shared<HasAnotherBonusLimiter>(BonusType::UNDEAD)},
 	{"CREATURE_NATIVE_TERRAIN", std::make_shared<CreatureTerrainLimiter>()},
-	{"CREATURE_FACTION", std::make_shared<AllOfLimiter>(std::initializer_list<TLimiterPtr>{std::make_shared<CreatureLevelLimiter>(), std::make_shared<FactionLimiter>()})},
-	{"SAME_FACTION", std::make_shared<FactionLimiter>()},
 	{"CREATURES_ONLY", std::make_shared<CreatureLevelLimiter>()},
 	{"OPPOSITE_SIDE", std::make_shared<OppositeSideLimiter>()},
 };

--- a/lib/json/JsonNode.cpp
+++ b/lib/json/JsonNode.cpp
@@ -306,28 +306,6 @@ bool JsonNode::isCompact() const
 	}
 }
 
-bool JsonNode::TryBoolFromString(bool & success) const
-{
-	success = true;
-	if(getType() == JsonNode::JsonType::DATA_BOOL)
-		return Bool();
-
-	success = getType() == JsonNode::JsonType::DATA_STRING;
-	if(success)
-	{
-		auto boolParamStr = String();
-		boost::algorithm::trim(boolParamStr);
-		boost::algorithm::to_lower(boolParamStr);
-		success = boolParamStr == "true";
-
-		if(success)
-			return true;
-
-		success = boolParamStr == "false";
-	}
-	return false;
-}
-
 void JsonNode::clear()
 {
 	setType(JsonType::DATA_NULL);

--- a/lib/json/JsonNode.h
+++ b/lib/json/JsonNode.h
@@ -109,9 +109,6 @@ public:
 	/// removes all data from node and sets type to null
 	void clear();
 
-	/// returns bool or bool equivalent of string value if 'success' is true, or false otherwise
-	bool TryBoolFromString(bool & success) const;
-
 	/// non-const accessors, node will change type on type mismatch
 	bool & Bool();
 	double & Float();


### PR DESCRIPTION
- Split massive `parseLimiter` method in smaller chunks
- Added alternative format for limiters with named parameters instead of unclear `parameters` entry that often leads to bugs in mods. Old format is still available and not reported by validation.
- Limiter parameters in new format are now validated.
- Converted vcmi json's to use new format
- Removed parameter-less `CREATURE_FACTION` and `SAME_FACTION` limiter. They are not used in mods and have unclear use-case that can be replaced by other limiters
- Expanded documentation on limiter types

All mods that were supported before should still be supported

Example - Adela specialty.
Before:
```json
"type" : "HAS_ANOTHER_BONUS_LIMITER",
"parameters" : [
	null,
	null,
	{
		"type" : "SPELL_EFFECT",
		"id" : "spell.bless"
	}
]
```

After:
```json
"type" : "HAS_ANOTHER_BONUS_LIMITER",
"bonusSourceType" : "SPELL_EFFECT",
"bonusSourceID" : "spell.bless"
```