### PR TITLE
Fixes for commanders logic

### DIFF
--- a/client/windows/CCreatureWindow.cpp
+++ b/client/windows/CCreatureWindow.cpp
@@ -132,11 +132,13 @@ void CCommanderSkillIcon::clickPressed(const Point & cursorPosition)
 {
 	callback();
 	isSelected = true;
+	redraw();
 }
 
 void CCommanderSkillIcon::deselect()
 {
 	isSelected = false;
+	redraw();
 }
 
 bool CCommanderSkillIcon::getIsMasterAbility()

--- a/lib/json/JsonBonus.cpp
+++ b/lib/json/JsonBonus.cpp
@@ -552,12 +552,11 @@ static std::shared_ptr<const ILimiter> parseHasAnotherBonusLimiter(const JsonNod
 {
 	auto bonusLimiter = std::make_shared<HasAnotherBonusLimiter>();
 
-	static const JsonNode nullNode;
 	const JsonNode & parameters = limiter["parameters"];
-	const JsonNode & jsonType    = limiter.Struct().count("bonusType") ? limiter["bonusType"] : parameters[0];
-	const JsonNode & jsonSubtype = limiter.Struct().count("bonusSubtype") ? limiter["bonusSubtype"] : (parameters.Vector().size() > 2 ? parameters[1] : nullNode);
-	const JsonNode & jsonSourceType  = limiter.Struct().count("bonusSourceType") ? limiter["bonusSourceType"] : (parameters.Vector().size() > 2 ? parameters[2]["type"] : parameters[1]["type"]);
-	const JsonNode & jsonSourceID  = limiter.Struct().count("bonusSourceID") ? limiter["bonusSourceID"] : (parameters.Vector().size() > 2 ? parameters[2]["id"] : parameters[1]["id"]);
+	const JsonNode & jsonType = limiter.Struct().count("bonusType") ? limiter["bonusType"] : parameters[0];
+	const JsonNode & jsonSubtype = limiter.Struct().count("bonusSubtype") ? limiter["bonusSubtype"] : parameters[1];
+	const JsonNode & jsonSourceType = limiter.Struct().count("bonusSourceType") ? limiter["bonusSourceType"] : parameters[2]["type"];
+	const JsonNode & jsonSourceID = limiter.Struct().count("bonusSourceID") ? limiter["bonusSourceID"] : parameters[2]["id"];
 
 	if (!jsonType.isNull())
 	{
@@ -565,7 +564,10 @@ static std::shared_ptr<const ILimiter> parseHasAnotherBonusLimiter(const JsonNod
 		{
 			bonusLimiter->type = static_cast<BonusType>(bonusID);
 			if (!jsonSubtype.isNull())
+			{
 				loadBonusSubtype(bonusLimiter->subtype, bonusLimiter->type, jsonSubtype);
+				bonusLimiter->isSubtypeRelevant = true;
+			}
 		});
 	}
 

--- a/lib/json/JsonBonus.cpp
+++ b/lib/json/JsonBonus.cpp
@@ -537,6 +537,14 @@ static std::shared_ptr<const ILimiter> parseCreatureTypeLimiter(const JsonNode &
 	});
 
 	creatureLimiter->includeUpgrades = upgradesNode.Bool();
+
+	if (upgradesNode.isString())
+	{
+		logGlobal->warn("CREATURE_TYPE_LIMITER: parameter 'includeUpgrades' is invalid! expected boolean, but string '%s' found!", upgradesNode.String());
+		if (upgradesNode.String() == "true") // MOD COMPATIBILITY - broken mod, compensating
+			creatureLimiter->includeUpgrades = true;
+	}
+
 	return creatureLimiter;
 }
 


### PR DESCRIPTION
- Fix commander skill icon not updating on deselection when selecting skill on levelup
- Add workaround for mods that use `"true"` (string) instead of real bool in json config for `CREATURE_TYPE_LIMITER`
- Fix loading of subtype property for `HAS_ANOTHER_BONUS` limiter
- Limit commander experience level to map limit in line with heroes