### PR TITLE
Fix JSON schemas

### DIFF
--- a/config/creatures/inferno.json
+++ b/config/creatures/inferno.json
@@ -481,7 +481,6 @@
 		},
 		"graphics" :
 		{
-			"missile" : null,
 			"mapAttackFromRight": "AvWattak.def:0:110",
 			"mapAttackFromLeft": "AvWattak.def:0:111",
 			"animation": "CADEVL.DEF"

--- a/config/creatures/rampart.json
+++ b/config/creatures/rampart.json
@@ -9,7 +9,6 @@
 		"hasDoubleWeek": true,
 		"graphics" :
 		{
-			"missile" : null,
 			"mapAttackFromRight": "AvWattak.def:0:28",
 			"mapAttackFromLeft": "AvWattak.def:0:29",
 			"animation": "CCENTR.DEF"
@@ -32,7 +31,6 @@
 		"doubleWide" : true,
 		"graphics" :
 		{
-			"missile" : null,
 			"mapAttackFromRight": "AvWattak.def:0:30",
 			"mapAttackFromLeft": "AvWattak.def:0:31",
 			"animation": "CECENT.DEF"

--- a/config/creatures/special.json
+++ b/config/creatures/special.json
@@ -5,28 +5,24 @@
 	{
 		"faction": "neutral",
 		"disabled" : true,
-		"graphics" : null,
 		"index" : 122
 	},
 	"unused124" :
 	{
 		"faction": "neutral",
 		"disabled" : true,
-		"graphics" : null,
 		"index" : 124
 	},
 	"unused126" :
 	{
 		"faction": "neutral",
 		"disabled" : true,
-		"graphics" : null,
 		"index" : 126
 	},
 	"unused128" :
 	{
 		"faction": "neutral",
 		"disabled" : true,
-		"graphics" : null,
 		"index" : 128
 	},
 

--- a/config/schemas/artifact.json
+++ b/config/schemas/artifact.json
@@ -146,10 +146,10 @@
 			"properties" : {
 				"usageType": {
 					"type" : "string",
-					"enum" : ["SPELLCAST", "BATTLE", "BUILDING"],
+					"enum" : ["SPELLCAST", "BATTLE", "BUILDING"]
 				},
 				"removeOnDepletion" : {
-					"type" : "boolean",
+					"type" : "boolean"
 				},
 				"startingCharges" : {
 					"type" : "number",

--- a/config/schemas/bonusInstance.json
+++ b/config/schemas/bonusInstance.json
@@ -249,7 +249,7 @@
 					"properties" : {
 						"type" : {
 							"type" : "string",
-							"const" : "TIMES_ARMY_SIZE",
+							"const" : "TIMES_ARMY_SIZE"
 						},
 						"stepSize" : {
 							"type" : "integer",

--- a/config/schemas/bonusInstance.json
+++ b/config/schemas/bonusInstance.json
@@ -186,7 +186,7 @@
 					"properties" : {
 						"type" : {
 							"type" : "string",
-							"const" : "GROWS_WITH_LEVEL",
+							"const" : "GROWS_WITH_LEVEL"
 						},
 						"valPer20" : {
 							"type" : "integer",
@@ -207,7 +207,7 @@
 					"properties" : {
 						"type" : {
 							"type" : "string",
-							"const" : "TIMES_HERO_LEVEL",
+							"const" : "TIMES_HERO_LEVEL"
 						},
 						"stepSize" : {
 							"type" : "integer",
@@ -224,7 +224,7 @@
 					"properties" : {
 						"type" : {
 							"type" : "string",
-							"const" : "TIMES_STACK_SIZE",
+							"const" : "TIMES_STACK_SIZE"
 						},
 						"stepSize" : {
 							"type" : "integer",
@@ -297,12 +297,12 @@
 		},
 		"sourceType" : {
 			"type" : "string",
-			"enum" : [ "ARTIFACT", "ARTIFACT_INSTANCE", "OBJECT_TYPE", "OBJECT_INSTANCE", "CREATURE_ABILITY", "TERRAIN_NATIVE", "TERRAIN_OVERLAY", "SPELL_EFFECT", "TOWN_STRUCTURE", "HERO_BASE_SKILL", "SECONDARY_SKILL", "HERO_SPECIAL", "ARMY", "CAMPAIGN_BONUS", "STACK_EXPERIENCE", "COMMANDER", "GLOBAL", "OTHER", ],
+			"enum" : [ "ARTIFACT", "ARTIFACT_INSTANCE", "OBJECT_TYPE", "OBJECT_INSTANCE", "CREATURE_ABILITY", "TERRAIN_NATIVE", "TERRAIN_OVERLAY", "SPELL_EFFECT", "TOWN_STRUCTURE", "HERO_BASE_SKILL", "SECONDARY_SKILL", "HERO_SPECIAL", "ARMY", "CAMPAIGN_BONUS", "STACK_EXPERIENCE", "COMMANDER", "GLOBAL", "OTHER" ],
 			"description" : "sourceType"
 		},
 		"targetSourceType" : {
 			"type" : "string",
-			"enum" : [ "ARTIFACT", "ARTIFACT_INSTANCE", "OBJECT_TYPE", "OBJECT_INSTANCE", "CREATURE_ABILITY", "TERRAIN_NATIVE", "TERRAIN_OVERLAY", "SPELL_EFFECT", "TOWN_STRUCTURE", "HERO_BASE_SKILL", "SECONDARY_SKILL", "HERO_SPECIAL", "ARMY", "CAMPAIGN_BONUS", "STACK_EXPERIENCE", "COMMANDER", "GLOBAL", "OTHER", ],
+			"enum" : [ "ARTIFACT", "ARTIFACT_INSTANCE", "OBJECT_TYPE", "OBJECT_INSTANCE", "CREATURE_ABILITY", "TERRAIN_NATIVE", "TERRAIN_OVERLAY", "SPELL_EFFECT", "TOWN_STRUCTURE", "HERO_BASE_SKILL", "SECONDARY_SKILL", "HERO_SPECIAL", "ARMY", "CAMPAIGN_BONUS", "STACK_EXPERIENCE", "COMMANDER", "GLOBAL", "OTHER" ],
 			"description" : "targetSourceType"
 		},
 		"propagator" : {

--- a/config/schemas/flaggable.json
+++ b/config/schemas/flaggable.json
@@ -25,10 +25,10 @@
 			"description" : "Message that will be shown to player on capturing this object",
 			"anyOf" : [
 				{
-					"type" : "string",
+					"type" : "string"
 				},
 				{
-					"type" : "number",
+					"type" : "number"
 				}
 			]
 		},

--- a/config/schemas/hero.json
+++ b/config/schemas/hero.json
@@ -34,7 +34,7 @@
 		"compatibilityIdentifiers" : {
 			"type" : "array",
 			"items" : {
-				"type" : "string",
+				"type" : "string"
 			},
 			"description" : "Additional identifiers that may refer to this object, to provide compatibility after object has been renamed"
 		},

--- a/config/schemas/highscoreCreatures.json
+++ b/config/schemas/highscoreCreatures.json
@@ -1,0 +1,33 @@
+{
+	"type": "object",
+	"$schema": "http://json-schema.org/draft-04/schema",
+	"title": "Highscore Creature format",
+	"description" : "Json format for defining highscore for creatures in VCMI",
+	"properties": {
+		"creatures": {
+			"type": "array",
+			"items": {
+				"type": "object",
+				"required": [
+					"creature"
+				],
+				"properties": {
+					"min": {
+						"type": "integer"
+					},
+					"max": {
+						"type": "integer"
+					},
+					"creature": {
+						"type": "string"
+					}
+				},
+				"additionalProperties": false
+			}
+		}
+	},
+	"required": [
+		"creatures"
+	],
+	"additionalProperties": false
+}

--- a/config/schemas/mod.json
+++ b/config/schemas/mod.json
@@ -147,7 +147,7 @@
 				{
 					"type" : "array",
 					"items" : { "type" : "string", "format" : "textFile" }
-				},
+				}
 			]
 		},
 		"filesystem" : {

--- a/config/schemas/rewardable.json
+++ b/config/schemas/rewardable.json
@@ -82,8 +82,8 @@
 					"additionalProperties" : {
 						"$ref" : "#/definitions/value"
 					}
-				},
-			],
+				}
+			]
 		},
 		"reward" : {
 			"type" : "object",
@@ -210,7 +210,7 @@
 				"noneOf" : {
 					"type" : "array",
 					"items" : { "$ref" : "#/definitions/limiter" }
-				},
+				}
 			}
 		},
 		"message" : {
@@ -275,8 +275,8 @@
 				},
 				"secondarySkill" : {
 					"$ref" : "#/definitions/variableList"
-				},
-			},
+				}
+			}
 		},
 
 		"onGuardedMessage" : {

--- a/config/schemas/settings.json
+++ b/config/schemas/settings.json
@@ -695,19 +695,19 @@
 			"properties" : {
 				"defaultRepositoryEnabled" : {
 					"type" : "boolean",
-					"default" : true,
+					"default" : true
 				},
 				"defaultRepositoryURL" : {
 					"type" : "string",
-					"default" : "https://raw.githubusercontent.com/vcmi/vcmi-mods-repository/develop/vcmi-1.7.json",
+					"default" : "https://raw.githubusercontent.com/vcmi/vcmi-mods-repository/develop/vcmi-1.7.json"
 				},
 				"extraRepositoryEnabled" : {
 					"type" : "boolean",
-					"default" : false,
+					"default" : false
 				},
 				"extraRepositoryURL" : {
 					"type" : "string",
-					"default" : "",
+					"default" : ""
 				},
 				"setupCompleted" : {
 					"type" : "boolean",
@@ -736,7 +736,7 @@
 					"defaultAndroid": false,
 					"defaultDesktop" : true
 
-				},
+				}
 			}
 		},
 		"lobby" : {

--- a/config/schemas/spell.json
+++ b/config/schemas/spell.json
@@ -466,8 +466,8 @@
 				},
 				"properties": {
 					"type": {
-						"enum" : ["adventure", "combat"],
-					},
+						"enum" : ["adventure", "combat"]
+					}
 					
 				}
 			},
@@ -479,7 +479,7 @@
 					},
 					"graphics" : {
 						"required" : ["iconBook", "iconScroll", "iconEffect", "iconImmune", "iconScenarioBonus"]
-					},
+					}
 				}
 			}
 		},
@@ -506,7 +506,7 @@
 					},
 					"graphics" : {
 						"required" : ["iconEffect", "iconImmune"]
-					},
+					}
 				}
 			}
 		}

--- a/config/schemas/townBuilding.json
+++ b/config/schemas/townBuilding.json
@@ -125,7 +125,7 @@
 			"type" : "array",
 			"items" : {
 				"type" : "string",
-				"enum" : [ "resource-resource", "resource-player", "creature-resource", "resource-artifact", "artifact-resource", "artifact-experience", "creature-experience", "creature-undead", "resource-skill"],
+				"enum" : [ "resource-resource", "resource-player", "creature-resource", "resource-artifact", "artifact-resource", "artifact-experience", "creature-experience", "creature-undead", "resource-skill"]
 			},
 			"description" : "List of modes available in this market"
 		},


### PR DESCRIPTION
Minor fixes to JSON schemas to make them compatible with the `jsonschema` Python module, that I use in the new mod validation script. Also added a schema for `highscoreCreatures` (whoever might want to change these values).