### PR TITLE
fix kingdom overview rendering

### DIFF
--- a/client/windows/CKingdomInterface.cpp
+++ b/client/windows/CKingdomInterface.cpp
@@ -877,9 +877,9 @@ public:
 	std::shared_ptr<CAnimImage> background;
 	std::vector<std::shared_ptr<CArtPlace>> arts;
 
-	ArtSlotsTab(CIntObject * parent)
+	ArtSlotsTab()
 	{
-		OBJECT_CONSTRUCTION_TARGETED(parent);
+		OBJECT_CONSTRUCTION;
 		background = std::make_shared<CAnimImage>(AnimationPath::builtin("OVSLOT"), 4);
 		pos = background->pos;
 		for(int i=0; i<9; i++)
@@ -895,9 +895,9 @@ public:
 	std::shared_ptr<CButton> btnLeft;
 	std::shared_ptr<CButton> btnRight;
 
-	BackpackTab(CIntObject * parent)
+	BackpackTab()
 	{
-		OBJECT_CONSTRUCTION_TARGETED(parent);
+		OBJECT_CONSTRUCTION;
 		background = std::make_shared<CAnimImage>(AnimationPath::builtin("OVSLOT"), 5);
 		pos = background->pos;
 		btnLeft = std::make_shared<CButton>(Point(269, 66), AnimationPath::builtin("HSBTNS3"), CButton::tooltip(), 0);
@@ -913,9 +913,9 @@ CHeroItem::CHeroItem(const CGHeroInstance * Hero)
 	OBJECT_CONSTRUCTION;
 
 	artTabs.resize(3);
-	auto arts1 = std::make_shared<ArtSlotsTab>(this);
-	auto arts2 = std::make_shared<ArtSlotsTab>(this);
-	auto backpack = std::make_shared<BackpackTab>(this);
+	auto arts1 = std::make_shared<ArtSlotsTab>();
+	auto arts2 = std::make_shared<ArtSlotsTab>();
+	auto backpack = std::make_shared<BackpackTab>();
 	artTabs[0] = arts1;
 	artTabs[1] = arts2;
 	artTabs[2] = backpack;
@@ -1020,6 +1020,8 @@ CHeroItem::CHeroItem(const CGHeroInstance * Hero)
 
 	morale->set(hero);
 	luck->set(hero);
+
+	redraw();
 }
 
 
@@ -1040,7 +1042,13 @@ std::shared_ptr<CIntObject> CHeroItem::onTabSelected(size_t index)
 
 void CHeroItem::onArtChange(int tabIndex)
 {
-	//redraw item after background change
 	if(isActive())
 		redraw();
+}
+
+void CHeroItem::redraw()
+{
+	for(int i = 0; i<3; i++)
+		artTabs.at(i)->setEnabled(artButtons->getSelected() == i);
+	CIntObject::redraw();
 }

--- a/client/windows/CKingdomInterface.h
+++ b/client/windows/CKingdomInterface.h
@@ -328,6 +328,8 @@ public:
 	void updateGarrisons() override;
 	bool holdsGarrison(const CArmedInstance * army) override;
 
+	void redraw() override;
+
 	CHeroItem(const CGHeroInstance * hero);
 };
 


### PR DESCRIPTION
partially address #5816

At least rendering is correct now. Artifact managment itself (and popup) is still broken. May need some adjustments in `CArtifactsOfHeroBase`.