### PR TITLE
Fixes segmentation fault when getting magic strength of a hero

### DIFF
--- a/AI/Nullkiller/Analyzers/HeroManager.cpp
+++ b/AI/Nullkiller/Analyzers/HeroManager.cpp
@@ -221,6 +221,10 @@ float HeroManager::getMagicStrength(const CGHeroInstance * hero) const
 	for(auto spellId : hero->getSpellsInSpellbook())
 	{
 		auto spell = spellId.toSpell();
+
+		if (!spell->isAdventure())
+			continue;
+
 		auto schoolLevel = hero->getSpellSchoolLevel(spell);
 		auto townPortalEffect = spell->getAdventureMechanics().getEffectAs<TownPortalEffect>(hero);
 


### PR DESCRIPTION
Fixes issue #5943.
The problem was caused by dereferencing nullptr when getting adventure mechanics of a battle spell.