### PR TITLE
Map Editor:Add filter to the herospell widget

### DIFF
--- a/mapeditor/inspector/herospellwidget.cpp
+++ b/mapeditor/inspector/herospellwidget.cpp
@@ -103,6 +103,70 @@ void HeroSpellWidget::on_customizeSpells_toggled(bool checked)
 	initSpellLists();
 }
 
+void HeroSpellWidget::on_filter_textChanged(const QString & keyword)
+{
+	if (keyword.toStdString().find_first_not_of(' ') == std::string::npos)
+	{
+		const auto exists = QString::fromStdString(".*");
+		showItemIfMatches(exists);
+	}
+	else
+	{
+		const auto doesNotContainKeyword = QString::fromStdString("^((?!") + keyword + QString::fromStdString(").)*$");
+		hideItemIfMatches(doesNotContainKeyword);
+
+		const auto containsKeyword = QString::fromStdString(".*") + keyword + QString::fromStdString(".*");
+		showItemIfMatches(containsKeyword);
+	}
+
+	hideEmptySpellLists();
+}
+
+void HeroSpellWidget::showItemIfMatches(const QString & match)
+{
+	toggleHiddenForItemIfMatches(match, false);
+}
+
+void HeroSpellWidget::hideItemIfMatches(const QString & match)
+{
+	toggleHiddenForItemIfMatches(match, true);
+}
+
+void HeroSpellWidget::toggleHiddenForItemIfMatches(const QString & match, bool hidden)
+{
+	QListWidget * spellLists[] = { ui->spellList1, ui->spellList2, ui->spellList3, ui->spellList4, ui->spellList5 };
+	for (const QListWidget * list : spellLists) {
+		const auto items = list->findItems(match, Qt::MatchRegularExpression);
+		for (QListWidgetItem * item : items) {
+			item->setHidden(hidden);
+		}
+	}
+}
+
+void HeroSpellWidget::hideEmptySpellLists()
+{
+
+	QListWidget * spellLists[] = { ui->spellList1, ui->spellList2, ui->spellList3, ui->spellList4, ui->spellList5 };
+	auto toggleSpellListVisibility = [&](const QListWidget * list, bool visible) {
+		auto * parent = list->parentWidget();
+		int index = ui->tabWidget->indexOf(parent);
+		ui->tabWidget->setTabVisible(index, visible);
+	};
+
+	for (const QListWidget * list : spellLists) {
+		const auto allItems = list->findItems("*", Qt::MatchWildcard);
+		bool isListEmpty = true;
+		for (QListWidgetItem * item : allItems) {
+			if (!item->isHidden())
+			{
+				isListEmpty = false;
+				break;
+			}
+		}
+		toggleSpellListVisibility(list, !isListEmpty);
+	}
+}
+
 HeroSpellDelegate::HeroSpellDelegate(CGHeroInstance & h)
 	: BaseInspectorItemDelegate()
 	, hero(h)

--- a/mapeditor/inspector/herospellwidget.cpp
+++ b/mapeditor/inspector/herospellwidget.cpp
@@ -135,9 +135,11 @@ void HeroSpellWidget::hideItemIfMatches(const QString & match)
 void HeroSpellWidget::toggleHiddenForItemIfMatches(const QString & match, bool hidden)
 {
 	QListWidget * spellLists[] = { ui->spellList1, ui->spellList2, ui->spellList3, ui->spellList4, ui->spellList5 };
-	for (const QListWidget * list : spellLists) {
+	for (const QListWidget * list : spellLists)
+	{
 		const auto items = list->findItems(match, Qt::MatchRegularExpression);
-		for (QListWidgetItem * item : items) {
+		for (QListWidgetItem * item : items)
+		{
 			item->setHidden(hidden);
 		}
 	}
@@ -147,16 +149,19 @@ void HeroSpellWidget::hideEmptySpellLists()
 {
 
 	QListWidget * spellLists[] = { ui->spellList1, ui->spellList2, ui->spellList3, ui->spellList4, ui->spellList5 };
-	auto toggleSpellListVisibility = [&](const QListWidget * list, bool visible) {
+	auto toggleSpellListVisibility = [&](const QListWidget * list, bool visible)
+	{
 		auto * parent = list->parentWidget();
 		int index = ui->tabWidget->indexOf(parent);
 		ui->tabWidget->setTabVisible(index, visible);
 	};
 
-	for (const QListWidget * list : spellLists) {
+	for (const QListWidget * list : spellLists)
+	{
 		const auto allItems = list->findItems("*", Qt::MatchWildcard);
 		bool isListEmpty = true;
-		for (QListWidgetItem * item : allItems) {
+		for (QListWidgetItem * item : allItems)
+		{
 			if (!item->isHidden())
 			{
 				isListEmpty = false;

--- a/mapeditor/inspector/herospellwidget.cpp
+++ b/mapeditor/inspector/herospellwidget.cpp
@@ -99,6 +99,8 @@ void HeroSpellWidget::on_customizeSpells_toggled(bool checked)
 		hero.removeSpellFromSpellbook(SpellID::PRESET);
 		hero.removeSpellbook();
 	}
+	ui->filter->clear();
+	ui->filter->setEnabled(checked);
 	ui->tabWidget->setEnabled(checked);
 	initSpellLists();
 }

--- a/mapeditor/inspector/herospellwidget.h
+++ b/mapeditor/inspector/herospellwidget.h
@@ -31,6 +31,7 @@ public:
 
 private slots:
 	void on_customizeSpells_toggled(bool checked);
+	void on_filter_textChanged(const QString & keyword);
 
 private:
 	Ui::HeroSpellWidget * ui;
@@ -38,6 +39,10 @@ private:
 	CGHeroInstance & hero;
 
 	void initSpellLists();
+	void showItemIfMatches(const QString & match);
+	void hideItemIfMatches(const QString & match);
+	void toggleHiddenForItemIfMatches(const QString & match, bool hidden);
+	void hideEmptySpellLists();
 };
 
 class HeroSpellDelegate : public BaseInspectorItemDelegate

--- a/mapeditor/inspector/herospellwidget.ui
+++ b/mapeditor/inspector/herospellwidget.ui
@@ -52,6 +52,9 @@
     </widget>
    </item>
    <item>
+    <widget class="QLineEdit" name="filter"/>
+   </item>
+   <item>
     <widget class="QTabWidget" name="tabWidget">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
@@ -99,6 +102,9 @@
          <property name="alternatingRowColors">
           <bool>true</bool>
          </property>
+         <property name="sortingEnabled">
+          <bool>true</bool>
+         </property>
         </widget>
        </item>
       </layout>
@@ -135,6 +141,9 @@
           <set>QAbstractItemView::NoEditTriggers</set>
          </property>
          <property name="alternatingRowColors">
+          <bool>true</bool>
+         </property>
+         <property name="sortingEnabled">
           <bool>true</bool>
          </property>
         </widget>
@@ -175,6 +184,9 @@
          <property name="alternatingRowColors">
           <bool>true</bool>
          </property>
+         <property name="sortingEnabled">
+          <bool>true</bool>
+         </property>
         </widget>
        </item>
       </layout>
@@ -213,6 +225,9 @@
          <property name="alternatingRowColors">
           <bool>true</bool>
          </property>
+         <property name="sortingEnabled">
+          <bool>true</bool>
+         </property>
         </widget>
        </item>
       </layout>
@@ -249,6 +264,9 @@
           <set>QAbstractItemView::NoEditTriggers</set>
          </property>
          <property name="alternatingRowColors">
+          <bool>true</bool>
+         </property>
+         <property name="sortingEnabled">
           <bool>true</bool>
          </property>
         </widget>


### PR DESCRIPTION
An improvement proposition.
I noticed that adding/removing spells is a little bit of a chore, so I've sorted the list and added a filter that hides all spells that do not contain the typed phrase (it also hides entire levels if they are empty).