### PR TITLE
Fixes crash on uncheck customize spell

### DIFF
--- a/lib/mapObjects/CGHeroInstance.cpp
+++ b/lib/mapObjects/CGHeroInstance.cpp
@@ -1273,6 +1273,11 @@ void CGHeroInstance::removeSpellbook()
 	}
 }
 
+void CGHeroInstance::removeAllSpells()
+{
+	spells.clear();
+}
+
 const std::set<SpellID> & CGHeroInstance::getSpellsInSpellbook() const
 {
 	return spells;

--- a/lib/mapObjects/CGHeroInstance.h
+++ b/lib/mapObjects/CGHeroInstance.h
@@ -157,6 +157,7 @@ public:
 	bool spellbookContainsSpell(const SpellID & spell) const;
 	std::vector<BonusSourceID> getSourcesForSpell(const SpellID & spell) const;
 	void removeSpellbook();
+	void removeAllSpells();
 	const std::set<SpellID> & getSpellsInSpellbook() const;
 	EAlignment getAlignment() const;
 	bool needsLastStack()const override;

--- a/mapeditor/inspector/herospellwidget.cpp
+++ b/mapeditor/inspector/herospellwidget.cpp
@@ -96,8 +96,7 @@ void HeroSpellWidget::on_customizeSpells_toggled(bool checked)
 	}
 	else
 	{
-		hero.removeSpellFromSpellbook(SpellID::PRESET);
-		hero.removeSpellbook();
+		hero.removeAllSpells();
 	}
 	ui->tabWidget->setEnabled(checked);
 	initSpellLists();


### PR DESCRIPTION
hero.removeSpellbook() had two problems: first, it made a call to a method unsupported by editor, causing a crash, second, it also removed spellbook the artifact. 