### PR TITLE
Fixes for recently reported issues

### DIFF
--- a/client/NetPacksClient.cpp
+++ b/client/NetPacksClient.cpp
@@ -828,7 +828,7 @@ void ApplyClientNetPackVisitor::visitBattleResultsApplied(BattleResultsApplied &
 {
 	if(!pack.learnedSpells.spells.empty())
 	{
-		const auto hero = GAME->interface()->cb->getHero(pack.learnedSpells.hid);
+		const auto * hero = cl.gameInfo().getHero(pack.learnedSpells.hid);
 		assert(hero);
 		callInterfaceIfPresent(cl, pack.victor, &CGameInterface::showInfoDialog, EInfoWindowMode::MODAL,
 			UIHelper::getEagleEyeInfoWindowText(*hero, pack.learnedSpells.spells), UIHelper::getSpellsComponents(pack.learnedSpells.spells), soundBase::soundID(0));
@@ -836,7 +836,7 @@ void ApplyClientNetPackVisitor::visitBattleResultsApplied(BattleResultsApplied &
 
 	if(!pack.movingArtifacts.empty())
 	{
-		const auto artSet = GAME->interface()->cb->getArtSet(ArtifactLocation(pack.movingArtifacts.front().dstArtHolder));
+		const auto * artSet = cl.gameState().getArtSet(ArtifactLocation(pack.movingArtifacts.front().dstArtHolder));
 		assert(artSet);
 		std::vector<Component> artComponents;
 		for(const auto & artPack : pack.movingArtifacts)

--- a/client/windows/QuickRecruitmentWindow.cpp
+++ b/client/windows/QuickRecruitmentWindow.cpp
@@ -103,26 +103,35 @@ void QuickRecruitmentWindow::maxAllCards(std::vector<std::shared_ptr<CreaturePur
 
 void QuickRecruitmentWindow::purchaseUnits()
 {
+	int freeSlotsLeft = town->getUpperArmy()->getFreeSlots().size();
+
 	for(auto selected : boost::adaptors::reverse(cards))
 	{
-		if(selected->slider->getValue())
+		if(selected->slider->getValue() == 0)
+			continue;
+
+		int level = 0;
+		int i = 0;
+		for(auto c : town->getTown()->creatures)
 		{
-			int level = 0;
-			int i = 0;
-			for(auto c : town->getTown()->creatures)
-			{
-				for(auto c2 : c)
-					if(c2 == selected->creatureOnTheCard->getId())
-						level = i;
-				i++;
-			}
-			auto onRecruit = [this, level](CreatureID id, int count){ GAME->interface()->cb->recruitCreatures(town, town->getUpperArmy(), id, count, level); };
-			CreatureID crid =  selected->creatureOnTheCard->getId();
-			SlotID dstslot = town -> getSlotFor(crid);
-			if(!dstslot.validSlot())
-				continue;
-			onRecruit(crid, selected->slider->getValue());
+			for(auto c2 : c)
+				if(c2 == selected->creatureOnTheCard->getId())
+					level = i;
+			i++;
 		}
+
+		CreatureID crid = selected->creatureOnTheCard->getId();
+		SlotID dstslot = town->getUpperArmy()->getSlotFor(crid);
+
+		if(town->getUpperArmy()->slotEmpty(dstslot))
+		{
+			if(freeSlotsLeft == 0)
+				continue;
+			freeSlotsLeft -= 1;
+		}
+
+		if(dstslot.validSlot())
+			GAME->interface()->cb->recruitCreatures(town, town->getUpperArmy(), crid, selected->slider->getValue(), level);
 	}
 	close();
 }

--- a/lib/campaign/CampaignState.cpp
+++ b/lib/campaign/CampaignState.cpp
@@ -316,6 +316,8 @@ JsonNode CampaignState::crossoverSerialize(CGHeroInstance * hero) const
 	JsonNode node;
 	JsonSerializer handler(nullptr, node);
 	hero->serializeJsonOptions(handler);
+	node.setModScope(ModScope::scopeGame());
+	logGlobal->info(node.toString());
 	return node;
 }
 

--- a/lib/constants/EntityIdentifiers.cpp
+++ b/lib/constants/EntityIdentifiers.cpp
@@ -158,6 +158,16 @@ int32_t IdentifierBase::resolveIdentifier(const std::string & entityType, const 
 
 	if (rawId)
 		return rawId.value();
+
+	size_t semicolon = identifier.find(':');
+
+	if (semicolon != std::string::npos)
+	{
+		auto rawId2 = LIBRARY->identifiers()->getIdentifier(ModScope::scopeGame(), entityType, identifier.substr(semicolon + 1));
+		if (rawId2)
+			return rawId2.value();
+	}
+
 	throw IdentifierResolutionException(identifier);
 }
 

--- a/lib/entities/faction/CTownHandler.cpp
+++ b/lib/entities/faction/CTownHandler.cpp
@@ -373,6 +373,9 @@ void CTownHandler::loadBuilding(CTown * town, const std::string & stringID, cons
 	else
 		ret->upgrade = BuildingID::NONE;
 
+	if (ret->town->buildings[ret->bid] != nullptr)
+		logMod->error("Mod %s, faction %s: detected multiple town buildings with ID %d", source.getModScope(), stringID, ret->bid.getNum());
+
 	ret->town->buildings[ret->bid].reset(ret);
 	for(const auto & element : source["marketModes"].Vector())
 	{

--- a/lib/gameState/CGameStateCampaign.cpp
+++ b/lib/gameState/CGameStateCampaign.cpp
@@ -197,6 +197,10 @@ void CGameStateCampaign::trimCrossoverHeroesParameters(vstd::RNG & randomGenerat
 			hero.hero->eraseStack(slotID);
 	}
 
+	// Add spell flag to ensure that hero without spellbook won't receive one as part of initHero call
+	for(auto & hero : campaignHeroReplacements)
+		hero.hero->addSpellToSpellbook(SpellID::SPELLBOOK_PRESET);
+
 	// Removing short-term bonuses
 	for(auto & hero : campaignHeroReplacements)
 	{

--- a/lib/mapping/MapFormatH3M.cpp
+++ b/lib/mapping/MapFormatH3M.cpp
@@ -2474,7 +2474,10 @@ std::shared_ptr<CGObjectInstance> CMapLoaderH3M::readTown(const int3 & position,
 
 	std::optional<FactionID> faction;
 	if (objectTemplate->id == Obj::TOWN)
+	{
 		faction = FactionID(objectTemplate->subid);
+		object->subID = objectTemplate->subid;
+	}
 
 	bool hasName = reader->readBool();
 	if(hasName)

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -2947,6 +2947,8 @@ bool CGameHandler::assembleArtifacts(ObjectInstanceID heroID, ArtifactPosition a
 		sendAndApply(da);
 	}
 
+	checkVictoryLossConditionsForPlayer(hero->getOwner());
+
 	return true;
 }
 

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -1606,8 +1606,8 @@ void CGameHandler::save(const std::string & filename)
 
 void CGameHandler::load(const StartInfo &info)
 {
-	logGlobal->info("Loading from %s", info.fileURI);
-	const auto stem	= FileInfo::GetPathStem(info.fileURI);
+	logGlobal->info("Loading from %s", info.mapname);
+	const auto stem	= FileInfo::GetPathStem(info.mapname);
 
 	reinitScripting();
 


### PR DESCRIPTION
Changes:

- Add debug logging for mods with invalid town building config
- Add check for victory condition on assembling artifact
- Fix crash on loading town with unit that has ability propagated to army
- Fix regression - crash on attempt to load saved game
- Fix Solmyr/Yog receiving spellbook on transferring to next scenario
- Add workaround for loading save when entity was moved to another mod
- Fix regresssion - crash on transferring hero to next scenario
- Fix quick recruitment failing when there are no free slots in army
- Fix crash on AI capturing artifacts in battle while covered by FoW

Fixed issues:

- #5872
- #5918
- #5906
- #5917
- #5928
- #5912
- #5719