### PR TITLE
Try to fix non-functioning ccache in some CI runs

### DIFF
--- a/.github/workflows/github.yml
+++ b/.github/workflows/github.yml
@@ -283,7 +283,7 @@ jobs:
         elif [[ (${{matrix.preset}} == android-conan-ninja-release) && (${{github.ref}} != 'refs/heads/master') ]]
         then
             cmake -DENABLE_CCACHE:BOOL=ON -DANDROID_GRADLE_PROPERTIES="applicationIdSuffix=.daily;signingConfig=dailySigning;applicationLabel=VCMI daily;applicationVariant=daily" --preset ${{ matrix.preset }}
-        elif [[ ${{startsWith(matrix.platform, 'msvc') }} ]]
+        elif ${{startsWith(matrix.platform, 'msvc') }}
         then
             cmake --preset ${{ matrix.preset }}
         else

--- a/.github/workflows/github.yml
+++ b/.github/workflows/github.yml
@@ -25,13 +25,13 @@ jobs:
             before_install: linux_qt6.sh
             preset: linux-clang-test
 
-          - platform: linux
+          - platform: linux-qt5
             os: ubuntu-24.04
             test: 1
             before_install: linux_qt5.sh
             preset: linux-gcc-test
 
-          - platform: linux
+          - platform: linux-debug
             os: ubuntu-22.04
             test: 0
             before_install: linux_qt5.sh
@@ -189,21 +189,21 @@ jobs:
       uses: hendrikmuhs/ccache-action@v1.2
       if: ${{ github.event.number != '' && !startsWith(matrix.platform, 'msvc') }}
       with:
-        key: ${{ matrix.preset }}-PR-${{ github.event.number }}
+        key: ${{ matrix.platform }}-PR-${{ github.event.number }}
         restore-keys: |
-          ${{ matrix.preset }}-PR-${{ github.event.number }}
-          ${{ matrix.preset }}-no-PR
+          ${{ matrix.platform }}-PR-${{ github.event.number }}
+          ${{ matrix.platform }}-branch-${{ github.base_ref }}
         # actual cache takes up less space, at most ~1 GB
         max-size: "5G"
         verbose: 2
 
-    - name: ccache for everything but PRs
+    - name: ccache for branch builds
       uses: hendrikmuhs/ccache-action@v1.2
-      if: ${{ (!startsWith(matrix.platform, 'msvc')) && (github.repository == 'vcmi/vcmi' && github.event.number == '' && (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/beta' || github.ref == 'refs/heads/master')) || github.repository != 'vcmi/vcmi' }}
+      if: ${{ github.event.number == '' && !startsWith(matrix.platform, 'msvc')}}
       with:
-        key: ${{ matrix.preset }}-no-PR
+        key: ${{ matrix.platform }}-${{ github.ref_name }}
         restore-keys: |
-          ${{ matrix.preset }}-no-PR
+          ${{ matrix.platform }}-branch-${{ github.ref_name }}
         # actual cache takes up less space, at most ~1 GB
         max-size: "5G"
         verbose: 2

--- a/CI/before_install/macos.sh
+++ b/CI/before_install/macos.sh
@@ -1,5 +1,3 @@
 #!/usr/bin/env bash
 
 echo DEVELOPER_DIR=/Applications/Xcode_14.2.app >> $GITHUB_ENV
-
-brew install ninja


### PR DESCRIPTION
- [x] Apparently some CI runs run without ccache at all, due to bug in bash script syntax 
- [x] When we have multiple active branches (beta/develop/master) ccache basically dies since cache between beta/develop branches is shared and is constantly invalidated
- [ ] Ccache *should* support MSVC, but we have it disabled, initially - here: #4132, and remaining bits - here: #5932. Would be great to figure out why that happens to get CI speedup, especially since we now have 3 msvc runs and not 1.
- [ ] For unknown reason, on Android platforms ccache runs with 100% misses

Fixed issues:
- Partial #5195