### PR TITLE
 Add addInfo support for OPENING_BATTLE_SPELL to set spell level

### DIFF
--- a/docs/modders/Bonus/Bonus_Types.md
+++ b/docs/modders/Bonus/Bonus_Types.md
@@ -403,6 +403,7 @@ In battle, army affected by this bonus will cast spell at the very start of the 
 
 - subtype: spell identifier
 - val: duration of the spell, in rounds
+- addInfo - spell mastery level (1 - Basic, 3 - Expert)
 
 ### FREE_SHIP_BOARDING
 

--- a/lib/json/JsonBonus.cpp
+++ b/lib/json/JsonBonus.cpp
@@ -225,6 +225,7 @@ static void loadBonusAddInfo(CAddInfo & var, BonusType type, const JsonNode & va
 		case BonusType::DARKNESS:
 		case BonusType::FULL_MAP_SCOUTING:
 		case BonusType::FULL_MAP_DARKNESS:
+		case BonusType::OPENING_BATTLE_SPELL:
 			// 1 number
 			var = getFirstValue(value).Integer();
 			break;

--- a/server/battles/BattleFlowProcessor.cpp
+++ b/server/battles/BattleFlowProcessor.cpp
@@ -206,7 +206,8 @@ void BattleFlowProcessor::castOpeningSpells(const CBattleInfoCallback & battle)
 			const CSpell * spell = b->subtype.as<SpellID>().toSpell();
 
 			spells::BattleCast parameters(&battle, &caster, spells::Mode::PASSIVE, spell);
-			parameters.setSpellLevel(3);
+			int32_t spellLevel = b->additionalInfo != CAddInfo::NONE ? b->additionalInfo[0] : 3;
+			parameters.setSpellLevel(spellLevel);
 			parameters.setEffectDuration(b->val);
 			parameters.massive = true;
 			parameters.castIfPossible(gameHandler->spellcastEnvironment(), spells::Target());


### PR DESCRIPTION
I need to implement a skill that casts a spell at the start of combat — Basic, Advanced, or Expert — depending on the skill level.
To achieve this, I modified OPENING_BATTLE_SPELL to allow setting the spell level via addInfo.

With this change:

If addInfo is provided, the corresponding spell level will be cast.

If addInfo is not provided, the default behavior is to cast the Expert-level spell.

This ensures full backward compatibility with the previous implementation while avoiding the need to copy the same spell three times.