### PR TITLE
fix: placing a single hex unit during tactics into a hex which is blo…

### DIFF
--- a/client/battle/BattleFieldController.cpp
+++ b/client/battle/BattleFieldController.cpp
@@ -375,18 +375,15 @@ BattleHexArray BattleFieldController::getHighlightedHexesForMovementTarget()
 
 	auto hoveredStack = owner.getBattle()->battleGetStackByPos(hoveredHex, true);
 
-	if(owner.getBattle()->battleCanAttack(stack, hoveredStack, hoveredHex))
+	if(owner.getBattle()->battleCanAttack(stack, hoveredStack, hoveredHex) && isTileAttackable(hoveredHex))
 	{
-		if(isTileAttackable(hoveredHex))
+		BattleHex attackFromHex = fromWhichHexAttack(hoveredHex);
+		if(owner.getBattle()->battleCanAttack(stack, hoveredStack, attackFromHex))
 		{
-			BattleHex attackFromHex = fromWhichHexAttack(hoveredHex);
-			if(owner.getBattle()->battleCanAttack(stack, hoveredStack, attackFromHex))
-			{
-				if(stack->doubleWide())
-					return {attackFromHex, stack->occupiedHex(attackFromHex)};
+			if(stack->doubleWide())
+				return {attackFromHex, stack->occupiedHex(attackFromHex)};
 
-				return {attackFromHex};
-			}
+			return {attackFromHex};
 		}
 	}
 


### PR DESCRIPTION
…cked on all sides excepting the enemy side. Reusing ->battleCanAttack as it was before does the trick, as it contains a ton of smaller checks inside.

Hi, everyone! 
This is my first PR in VCMI and I would like to extend my deepest appreciation for all the people that worked on this.

I've been playing quite a bit on 1.6.8, then I moved on develop and I quickly discovered a bug when playing with tactics. Comparing the code with 1.6.8, I saw some changes in BattleFieldController, isTileAttackable becoming the first if condition into that piece of logic, leading to many smaller checks that used to happen when battleCanAttack was the first if condition in 1.6.8
I saw there's new behavior with attackFromHex, so I kept that, I only brought back the initial if condition as the main gate of this piece of logic.

Save game for testing: 
[game9 m01w02d06 red sulf mine tactics pikeman bug.vsgm1.zip](https://github.com/user-attachments/files/21721228/game9.m01w02d06.red.sulf.mine.tactics.pikeman.bug.vsgm1.zip)
Go and attack the guard of the sulf mine (2 movement units left from hero to that guard when opening the saved game)

See the 3 steps below of the Pikeman: (please ignore the monkey, my kid...)
I placed all other units together, leaving only 1 hex available for the Pikeman, without any other available hexes in the tactics mode, thus triggering the error.
<img width="2560" height="1440" alt="Screenshot at 2025-08-11 19-58-45" src="https://github.com/user-attachments/assets/3d929df6-38f0-4718-911e-6e3b9178f7ab" />
<img width="2560" height="1440" alt="Screenshot at 2025-08-11 19-59-01" src="https://github.com/user-attachments/assets/6619715e-a482-4084-a569-f3e9044e9424" />
<img width="2560" height="1440" alt="Screenshot at 2025-08-11 19-59-10" src="https://github.com/user-attachments/assets/10c1858b-b9f0-46bb-bddb-0cfa8545c4ec" />
