### PR TITLE
Fix abilities propagation

### DIFF
--- a/Mods/vcmi/Content/config/english.json
+++ b/Mods/vcmi/Content/config/english.json
@@ -952,6 +952,11 @@
 	"creatures.core.marksman.bonus.extraAttack" : "{Shoots twice}\nThis unit can shoot twice",
 	"creatures.core.azureDragon.bonus.fearful" : "{Fear}\nEnemy units have a 10% chance of freezing in fear",
 	"creatures.core.azureDragon.bonus.fearless" : "{Fearless}\nImmune to Fear ability",
+	"creatures.core.halfling.bonus.lucky" : "{Lucky}\nHalfling's luck cannot be decreased below +1",
+	"creatures.core.nomad.bonus.sandWalker" : "{Sand walker}\nHero ignores terrain penalty on sand",
+	"creatures.core.rogue.bonus.visionsMonsters" : "{Visions Monsters}\nHero can see detailed informations about neutral monsters",
+	"creatures.core.rogue.bonus.visionsHeroes" : "{Visions Heroes}\nHero can see detailed informations about enemy heroes",
+	"creatures.core.rogue.bonus.visionsTowns" : "{Visions Towns}\nHero can see detailed informations about enemy towns",
 
 	"core.bonus.ADDITIONAL_ATTACK.description" : "{Additional attacks}\nUnit can attack an additional {$val} times", // TODO: alternative descriptions for melee/ranged effect range
 	"core.bonus.ADDITIONAL_RETALIATION.description" : "{Additional retaliations}\nUnit can retaliate ${val} extra times",

--- a/client/windows/CCreatureWindow.cpp
+++ b/client/windows/CCreatureWindow.cpp
@@ -868,10 +868,10 @@ void CStackWindow::initBonusesList()
 			return  info->stackNode->bonusToString(v1) < info->stackNode->bonusToString(v2);
 	};
 
-	// these bonuses require special handling. For example they come with own descriptions, for use in morale/luck description
-	// also, this information is already available in creature window
-	receivedBonuses.remove_if(Selector::type()(BonusType::MORALE));
-	receivedBonuses.remove_if(Selector::type()(BonusType::LUCK));
+	receivedBonuses.remove_if([](const Bonus* b)
+	{
+		return !LIBRARY->bth->shouldPropagateDescription(b->type);
+	});
 
 	std::vector<BonusList> groupedBonuses;
 	while (!receivedBonuses.empty())

--- a/config/bonuses.json
+++ b/config/bonuses.json
@@ -1,4 +1,14 @@
 {
+	"ARTIFACT_GROWING":
+	{
+		"propagateDescription": false
+	},
+	
+	"ARTIFACT_CHARGE":
+	{
+		"propagateDescription": false
+	},
+	
 	"ADDITIONAL_ATTACK":
 	{
 	},
@@ -9,6 +19,31 @@
 
 	"ATTACKS_ALL_ADJACENT":
 	{
+	},
+	
+	"BASE_TILE_MOVEMENT_COST":
+	{
+		"propagateDescription": false
+	},
+
+	"BATTLE_NO_FLEEING":
+	{
+		"propagateDescription": false
+	},
+
+	"BEFORE_BATTLE_REPOSITION":
+	{
+		"propagateDescription": false
+	},
+
+	"BEFORE_BATTLE_REPOSITION_BLOCK":
+	{
+		"propagateDescription": false
+	},
+
+	"BIND_EFFECT":
+	{
+		"propagateDescription": false
 	},
 
 	"BLOCKS_RANGED_RETALIATION":
@@ -39,10 +74,31 @@
 	"CHARGE_IMMUNITY":
 	{
 	},
+	
+	"COMBAT_MANA_BONUS":
+	{
+		"propagateDescription": false
+	},
+
+	"CREATURE_GROWTH":
+	{
+		"propagateDescription": false
+	},
+
+	"CREATURE_GROWTH_PERCENT":
+	{
+		"propagateDescription": false
+	},
 
 	"DARKNESS":
 	{
 		"hidden": true
+	},
+	
+	"DISGUISED":
+	{
+		"hidden": true,
+		"propagateDescription": false
 	},
 
 	"DEATH_STARE":
@@ -63,11 +119,6 @@
 
 	"DRAGON_NATURE":
 	{
-	},
-
-	"DISGUISED":
-	{
-		"hidden": true
 	},
 
 	"ENCHANTER":
@@ -112,6 +163,17 @@
 			"bonusSubtype.movementTeleporting" : null,
 		}
 	},
+	
+	"FLYING_MOVEMENT":
+	{
+		"propagateDescription": false
+	},
+
+	"FREE_SHIP_BOARDING":
+	{
+		"propagateDescription": false
+	},
+	
 
 	"FREE_SHOOTING":
 	{
@@ -119,10 +181,12 @@
 	
 	"FULL_MAP_DARKNESS":
 	{
+		"propagateDescription": false
 	},
-	
+
 	"FULL_MAP_SCOUTING":
 	{
+		"propagateDescription": false
 	},
 
 	"GARGOYLE":
@@ -137,6 +201,11 @@
 			"bonusSubtype.damageTypeMelee" : null,
 		}
 	},
+	
+	"GENERATE_RESOURCE":
+	{
+		"propagateDescription": false
+	},
 
 	"HATE":
 	{
@@ -148,6 +217,21 @@
 
 	"HP_REGENERATION":
 	{
+	},
+	
+	"HERO_EXPERIENCE_GAIN_PERCENT":
+	{
+		"propagateDescription": false
+	},
+
+	"HERO_SPELL_CASTS_PER_COMBAT_TURN":
+	{
+		"propagateDescription": false
+	},
+	
+	"IMPROVED_NECROMANCY":
+	{
+		"propagateDescription": false
 	},
 	
 	"JOUSTING":
@@ -164,12 +248,19 @@
 
 	"LEARN_BATTLE_SPELL_CHANCE":
 	{
-		"hidden": true
+		"hidden": true,
+		"propagateDescription": false
 	},
 
 	"LEARN_BATTLE_SPELL_LEVEL_LIMIT":
 	{
-		"hidden": true
+		"hidden": true,
+		"propagateDescription": false
+	},
+	
+	"LEARN_MEETING_SPELL_LIMIT":
+	{
+		"propagateDescription": false
 	},
 
 	"LEVEL_SPELL_IMMUNITY":
@@ -188,6 +279,11 @@
 	{
 		"creatureNature" : true
 	},
+	
+	"LUCK":
+	{
+		"propagateDescription": false
+	},
 
 	"MANA_CHANNELING":
 	{
@@ -205,6 +301,26 @@
 	{
 	},
 	
+	"MAGIC_SCHOOL_SKILL":
+	{
+		"propagateDescription": false
+	},
+
+	"MANA_PERCENTAGE_REGENERATION":
+	{
+		"propagateDescription": false
+	},
+
+	"MANA_PER_KNOWLEDGE_PERCENTAGE":
+	{
+		"propagateDescription": false
+	},
+
+	"MAX_LEARNABLE_SPELL_LEVEL":
+	{
+		"propagateDescription": false
+	},
+	
 	"MECHANICAL":
 	{
 		"creatureNature" : true
@@ -212,6 +328,16 @@
 
 	"MIND_IMMUNITY":
 	{
+	},
+	
+	"MORALE":
+	{
+		"propagateDescription": false
+	},
+	
+	"MOVEMENT":
+	{
+		"propagateDescription": false
 	},
 	
 	"NEGATIVE_EFFECTS_IMMUNITY" :
@@ -241,7 +367,8 @@
 
 	"NO_TERRAIN_PENALTY":
 	{
-		"hidden": true
+		"hidden": true,
+		"propagateDescription": false
 	},
 
 	"NON_LIVING":
@@ -270,8 +397,23 @@
 	{
 	},
 	
+	"PRIMARY_SKILL":
+	{
+		"propagateDescription": false
+	},
+	
 	"REBIRTH":
 	{
+	},
+	
+	"RESOURCES_CONSTANT_BOOST":
+	{
+		"propagateDescription": false
+	},
+
+	"RESOURCES_TOWN_MULTIPLYING_BOOST":
+	{
+		"propagateDescription": false
 	},
 
 	"RETURN_AFTER_STRIKE":
@@ -282,6 +424,11 @@
 	{
 	},
 	
+	"ROUGH_TERRAIN_DISCOUNT":
+	{
+		"propagateDescription": false
+	},
+
 	"SIEGE_WEAPON":
 	{
 		"creatureNature" : true
@@ -297,6 +444,11 @@
 
 	"SHOOTS_ALL_ADJACENT":
 	{
+	},
+	
+	"SIGHT_RADIUS":
+	{
+		"propagateDescription": false
 	},
 	
 	"SOUL_STEAL":
@@ -350,6 +502,11 @@
 	"SUMMON_GUARDIANS":
 	{
 	},
+	
+	"SURRENDER_DISCOUNT":
+	{
+		"propagateDescription": false
+	},
 
 	"TWO_HEX_ATTACK_BREATH":
 	{
@@ -370,10 +527,20 @@
 	"TRANSMUTATION_IMMUNITY":
 	{
 	},
+	
+	"THIEVES_GUILD_ACCESS":
+	{
+		"propagateDescription": false
+	},
 
 	"UNDEAD":
 	{
 		"creatureNature" : true,
+	},
+	
+	"UNDEAD_RAISE_PERCENTAGE":
+	{
+		"propagateDescription": false
 	},
 	
 	"UNLIMITED_RETALIATIONS":
@@ -382,11 +549,22 @@
 
 	"VISIONS":
 	{
-		"hidden": true
+		"hidden": true,
+		"propagateDescription": false
 	},
 	
 	"VULNERABLE_FROM_BACK":
 	{
+	},
+	
+	"WANDERING_CREATURES_JOIN_BONUS":
+	{
+		"propagateDescription": false
+	},
+	
+	"WATER_WALKING":
+	{
+		"propagateDescription": false
 	},
 	
 	"WIDE_BREATH":

--- a/config/bonuses.json
+++ b/config/bonuses.json
@@ -1,12 +1,12 @@
 {
 	"ARTIFACT_GROWING":
 	{
-		"propagateDescription": false
+		"blockDescriptionPropagation": true
 	},
 	
 	"ARTIFACT_CHARGE":
 	{
-		"propagateDescription": false
+		"blockDescriptionPropagation": true
 	},
 	
 	"ADDITIONAL_ATTACK":
@@ -23,27 +23,27 @@
 	
 	"BASE_TILE_MOVEMENT_COST":
 	{
-		"propagateDescription": false
+		"blockDescriptionPropagation": true
 	},
 
 	"BATTLE_NO_FLEEING":
 	{
-		"propagateDescription": false
+		"blockDescriptionPropagation": true
 	},
 
 	"BEFORE_BATTLE_REPOSITION":
 	{
-		"propagateDescription": false
+		"blockDescriptionPropagation": true
 	},
 
 	"BEFORE_BATTLE_REPOSITION_BLOCK":
 	{
-		"propagateDescription": false
+		"blockDescriptionPropagation": true
 	},
 
 	"BIND_EFFECT":
 	{
-		"propagateDescription": false
+		"blockDescriptionPropagation": true
 	},
 
 	"BLOCKS_RANGED_RETALIATION":
@@ -77,17 +77,17 @@
 	
 	"COMBAT_MANA_BONUS":
 	{
-		"propagateDescription": false
+		"blockDescriptionPropagation": true
 	},
 
 	"CREATURE_GROWTH":
 	{
-		"propagateDescription": false
+		"blockDescriptionPropagation": true
 	},
 
 	"CREATURE_GROWTH_PERCENT":
 	{
-		"propagateDescription": false
+		"blockDescriptionPropagation": true
 	},
 
 	"DARKNESS":
@@ -98,7 +98,7 @@
 	"DISGUISED":
 	{
 		"hidden": true,
-		"propagateDescription": false
+		"blockDescriptionPropagation": true
 	},
 
 	"DEATH_STARE":
@@ -166,12 +166,12 @@
 	
 	"FLYING_MOVEMENT":
 	{
-		"propagateDescription": false
+		"blockDescriptionPropagation": true
 	},
 
 	"FREE_SHIP_BOARDING":
 	{
-		"propagateDescription": false
+		"blockDescriptionPropagation": true
 	},
 	
 
@@ -181,12 +181,12 @@
 	
 	"FULL_MAP_DARKNESS":
 	{
-		"propagateDescription": false
+		"blockDescriptionPropagation": true
 	},
 
 	"FULL_MAP_SCOUTING":
 	{
-		"propagateDescription": false
+		"blockDescriptionPropagation": true
 	},
 
 	"GARGOYLE":
@@ -204,7 +204,7 @@
 	
 	"GENERATE_RESOURCE":
 	{
-		"propagateDescription": false
+		"blockDescriptionPropagation": true
 	},
 
 	"HATE":
@@ -221,17 +221,17 @@
 	
 	"HERO_EXPERIENCE_GAIN_PERCENT":
 	{
-		"propagateDescription": false
+		"blockDescriptionPropagation": true
 	},
 
 	"HERO_SPELL_CASTS_PER_COMBAT_TURN":
 	{
-		"propagateDescription": false
+		"blockDescriptionPropagation": true
 	},
 	
 	"IMPROVED_NECROMANCY":
 	{
-		"propagateDescription": false
+		"blockDescriptionPropagation": true
 	},
 	
 	"JOUSTING":
@@ -249,18 +249,18 @@
 	"LEARN_BATTLE_SPELL_CHANCE":
 	{
 		"hidden": true,
-		"propagateDescription": false
+		"blockDescriptionPropagation": true
 	},
 
 	"LEARN_BATTLE_SPELL_LEVEL_LIMIT":
 	{
 		"hidden": true,
-		"propagateDescription": false
+		"blockDescriptionPropagation": true
 	},
 	
 	"LEARN_MEETING_SPELL_LIMIT":
 	{
-		"propagateDescription": false
+		"blockDescriptionPropagation": true
 	},
 
 	"LEVEL_SPELL_IMMUNITY":
@@ -282,7 +282,7 @@
 	
 	"LUCK":
 	{
-		"propagateDescription": false
+		"blockDescriptionPropagation": true
 	},
 
 	"MANA_CHANNELING":
@@ -303,22 +303,22 @@
 	
 	"MAGIC_SCHOOL_SKILL":
 	{
-		"propagateDescription": false
+		"blockDescriptionPropagation": true
 	},
 
 	"MANA_PERCENTAGE_REGENERATION":
 	{
-		"propagateDescription": false
+		"blockDescriptionPropagation": true
 	},
 
 	"MANA_PER_KNOWLEDGE_PERCENTAGE":
 	{
-		"propagateDescription": false
+		"blockDescriptionPropagation": true
 	},
 
 	"MAX_LEARNABLE_SPELL_LEVEL":
 	{
-		"propagateDescription": false
+		"blockDescriptionPropagation": true
 	},
 	
 	"MECHANICAL":
@@ -332,12 +332,12 @@
 	
 	"MORALE":
 	{
-		"propagateDescription": false
+		"blockDescriptionPropagation": true
 	},
 	
 	"MOVEMENT":
 	{
-		"propagateDescription": false
+		"blockDescriptionPropagation": true
 	},
 	
 	"NEGATIVE_EFFECTS_IMMUNITY" :
@@ -368,7 +368,7 @@
 	"NO_TERRAIN_PENALTY":
 	{
 		"hidden": true,
-		"propagateDescription": false
+		"blockDescriptionPropagation": true
 	},
 
 	"NON_LIVING":
@@ -399,7 +399,7 @@
 	
 	"PRIMARY_SKILL":
 	{
-		"propagateDescription": false
+		"blockDescriptionPropagation": true
 	},
 	
 	"REBIRTH":
@@ -408,12 +408,12 @@
 	
 	"RESOURCES_CONSTANT_BOOST":
 	{
-		"propagateDescription": false
+		"blockDescriptionPropagation": true
 	},
 
 	"RESOURCES_TOWN_MULTIPLYING_BOOST":
 	{
-		"propagateDescription": false
+		"blockDescriptionPropagation": true
 	},
 
 	"RETURN_AFTER_STRIKE":
@@ -426,7 +426,7 @@
 	
 	"ROUGH_TERRAIN_DISCOUNT":
 	{
-		"propagateDescription": false
+		"blockDescriptionPropagation": true
 	},
 
 	"SIEGE_WEAPON":
@@ -448,7 +448,7 @@
 	
 	"SIGHT_RADIUS":
 	{
-		"propagateDescription": false
+		"blockDescriptionPropagation": true
 	},
 	
 	"SOUL_STEAL":
@@ -505,7 +505,7 @@
 	
 	"SURRENDER_DISCOUNT":
 	{
-		"propagateDescription": false
+		"blockDescriptionPropagation": true
 	},
 
 	"TWO_HEX_ATTACK_BREATH":
@@ -530,7 +530,7 @@
 	
 	"THIEVES_GUILD_ACCESS":
 	{
-		"propagateDescription": false
+		"blockDescriptionPropagation": true
 	},
 
 	"UNDEAD":
@@ -540,7 +540,7 @@
 	
 	"UNDEAD_RAISE_PERCENTAGE":
 	{
-		"propagateDescription": false
+		"blockDescriptionPropagation": true
 	},
 	
 	"UNLIMITED_RETALIATIONS":
@@ -550,7 +550,7 @@
 	"VISIONS":
 	{
 		"hidden": true,
-		"propagateDescription": false
+		"blockDescriptionPropagation": true
 	},
 	
 	"VULNERABLE_FROM_BACK":
@@ -559,12 +559,12 @@
 	
 	"WANDERING_CREATURES_JOIN_BONUS":
 	{
-		"propagateDescription": false
+		"blockDescriptionPropagation": true
 	},
 	
 	"WATER_WALKING":
 	{
-		"propagateDescription": false
+		"blockDescriptionPropagation": true
 	},
 	
 	"WIDE_BREATH":

--- a/config/creatures/neutral.json
+++ b/config/creatures/neutral.json
@@ -512,7 +512,8 @@
 			{
 				"type" : "LUCK",
 				"val" : 1,
-				"valueType" : "INDEPENDENT_MAX"
+				"valueType" : "INDEPENDENT_MAX",
+				"description" : "PLACEHOLDER"
 			}
 		 },
 		"graphics" :
@@ -621,7 +622,8 @@
 			{
 				"type" : "NO_TERRAIN_PENALTY",
 				"subtype" : "terrain.sand",
-				"propagator" : "HERO"
+				"propagator" : "HERO",
+				"description" : "PLACEHOLDER"
 			}
 		},
 		"graphics" :
@@ -652,7 +654,8 @@
 				"subtype" : "visionsMonsters",
 				"val" : 3,
 				"valueType" : "INDEPENDENT_MAX",
-				"propagator" : "HERO"
+				"propagator" : "HERO",
+				"description" : "PLACEHOLDER"
 			},
 			"visionsHeroes" :
 			{
@@ -660,7 +663,8 @@
 				"subtype" : "visionsHeroes",
 				"val" : 3,
 				"valueType" : "INDEPENDENT_MAX",
-				"propagator" : "HERO"
+				"propagator" : "HERO",
+				"description" : "PLACEHOLDER"
 			},
 			"visionsTowns" :
 			{
@@ -668,7 +672,8 @@
 				"subtype" : "visionsTowns",
 				"val" : 3,
 				"valueType" : "INDEPENDENT_MAX",
-				"propagator" : "HERO"
+				"propagator" : "HERO",
+				"description" : "PLACEHOLDER"
 			}
 		},
 		"graphics" :

--- a/config/schemas/bonus.json
+++ b/config/schemas/bonus.json
@@ -15,6 +15,11 @@
 			"type" : "boolean",
 			"description" : "If set to true, this bonus will be considered 'creature nature' bonus, and such creature won't be automatically granted LIVING bonus"
 		},
+		
+		"propagateDescription" : {
+			"type" : "boolean",
+			"description" : "If set to false, this ability description will not be displayed if a creature receives it by propagation"
+		},
 
 		"description" : {
 			"type" : "string"

--- a/config/schemas/bonus.json
+++ b/config/schemas/bonus.json
@@ -16,9 +16,9 @@
 			"description" : "If set to true, this bonus will be considered 'creature nature' bonus, and such creature won't be automatically granted LIVING bonus"
 		},
 		
-		"propagateDescription" : {
+		"blockDescriptionPropagation" : {
 			"type" : "boolean",
-			"description" : "If set to false, this ability description will not be displayed if a creature receives it by propagation"
+			"description" : "If set to true, this ability description will not be displayed if a creature receives it by propagation"
 		},
 
 		"description" : {

--- a/lib/CBonusTypeHandler.cpp
+++ b/lib/CBonusTypeHandler.cpp
@@ -142,7 +142,7 @@ void CBonusTypeHandler::loadItem(const JsonNode & source, CBonusType & dest, con
 	dest.identifier = name;
 	dest.hidden = source["hidden"].Bool(); //Null -> false
 	dest.creatureNature = source["creatureNature"].Bool(); //Null -> false
-	dest.propagateDescription = source["propagateDescription"].isNull() ? true : source["propagateDescription"].Bool(); //Null -> true
+	dest.blockDescriptionPropagation = source["blockDescriptionPropagation"].Bool(); //Null -> false
 
 	if (!dest.hidden)
 		LIBRARY->generaltexth->registerString( "vcmi", dest.getDescriptionTextID(), source["description"]);
@@ -199,7 +199,7 @@ bool CBonusTypeHandler::isCreatureNatureBonus(BonusType bonus) const
 
 bool CBonusTypeHandler::shouldPropagateDescription(BonusType bonus) const
 {
-	return bonusTypes.at(static_cast<int>(bonus))->propagateDescription;
+	return !bonusTypes.at(static_cast<int>(bonus))->blockDescriptionPropagation;
 }
 
 

--- a/lib/CBonusTypeHandler.cpp
+++ b/lib/CBonusTypeHandler.cpp
@@ -142,6 +142,7 @@ void CBonusTypeHandler::loadItem(const JsonNode & source, CBonusType & dest, con
 	dest.identifier = name;
 	dest.hidden = source["hidden"].Bool(); //Null -> false
 	dest.creatureNature = source["creatureNature"].Bool(); //Null -> false
+	dest.propagateDescription = source["propagateDescription"].isNull() ? true : source["propagateDescription"].Bool(); //Null -> true
 
 	if (!dest.hidden)
 		LIBRARY->generaltexth->registerString( "vcmi", dest.getDescriptionTextID(), source["description"]);
@@ -195,6 +196,12 @@ bool CBonusTypeHandler::isCreatureNatureBonus(BonusType bonus) const
 {
 	return bonusTypes.at(static_cast<int>(bonus))->creatureNature;
 }
+
+bool CBonusTypeHandler::shouldPropagateDescription(BonusType bonus) const
+{
+	return bonusTypes.at(static_cast<int>(bonus))->propagateDescription;
+}
+
 
 std::vector<BonusType> CBonusTypeHandler::getAllObjets() const
 {

--- a/lib/CBonusTypeHandler.h
+++ b/lib/CBonusTypeHandler.h
@@ -38,7 +38,7 @@ private:
 
 	bool creatureNature = false;
 	bool hidden = true;
-	bool propagateDescription = true;
+	bool blockDescriptionPropagation = false;
 };
 
 class DLL_LINKAGE CBonusTypeHandler : public IBonusTypeHandler

--- a/lib/CBonusTypeHandler.h
+++ b/lib/CBonusTypeHandler.h
@@ -38,6 +38,7 @@ private:
 
 	bool creatureNature = false;
 	bool hidden = true;
+	bool propagateDescription = true;
 };
 
 class DLL_LINKAGE CBonusTypeHandler : public IBonusTypeHandler
@@ -57,6 +58,7 @@ public:
 	const std::string & bonusToString(BonusType bonus) const;
 
 	bool isCreatureNatureBonus(BonusType bonus) const;
+	bool shouldPropagateDescription(BonusType bonus) const;
 
 	std::vector<BonusType> getAllObjets() const;
 private:


### PR DESCRIPTION
Solves an issue mentioned in #5993 with descriptions to unit-given hero abilities being propagated to all other units within an army.
It is the best solution I came up with, since, unless I am mistaken, there is no programmatic way to check what a bonus affects (hero, campaign or units). Also, I think an access to a list like this can be quite useful (though the list is arbitrary, unfortunately).
Don't bother checking if the list is correct, if the solution will be accepted I will do it more thoroughly.
PS: I found after I wrote this PR that the same effect can be achieved on develop with a JSON like this:
"sandWalker" :
{
    "type" : "NO_TERRAIN_PENALTY",
    "subtype" : "terrain.sand",
    "propagator" : "HERO",
},
"sandWalkerDescription" :
{
    "type" : "NONE",
    "description" : "Hero ignores terrain penalty on sand"
},
So maybe the PR is not needed at all?