### PR TITLE
Fixes abilities propagation the second (and better?) solution

### DIFF
--- a/Mods/vcmi/Content/config/english.json
+++ b/Mods/vcmi/Content/config/english.json
@@ -952,6 +952,12 @@
 	"creatures.core.marksman.bonus.extraAttack" : "{Shoots twice}\nThis unit can shoot twice",
 	"creatures.core.azureDragon.bonus.fearful" : "{Fear}\nEnemy units have a 10% chance of freezing in fear",
 	"creatures.core.azureDragon.bonus.fearless" : "{Fearless}\nImmune to Fear ability",
+	"creatures.core.azureDragon.bonus.fearful" : "{Fear}\nEnemy units have a 10% chance of freezing in fear",
+	"creatures.core.halfling.bonus.lucky" : "{Lucky}\nHalfling's luck cannot be decreased below +1",
+	"creatures.core.nomad.bonus.sandWalker" : "{Sand walker}\nHero ignores terrain penalty on sand",
+	"creatures.core.rogue.bonus.visionsMonsters" : "{Lucky}\nHero can see detailed informations about neutral monsters",
+	"creatures.core.rogue.bonus.visionsHeroes" : "{Lucky}\nHero can see detailed informations about enemy heroes.",
+	"creatures.core.rogue.bonus.visionsTowns" : "{Lucky}\nHero can see detailed informations about enemy towns.",
 
 	"core.bonus.ADDITIONAL_ATTACK.description" : "{Additional attacks}\nUnit can attack an additional {$val} times", // TODO: alternative descriptions for melee/ranged effect range
 	"core.bonus.ADDITIONAL_RETALIATION.description" : "{Additional retaliations}\nUnit can retaliate ${val} extra times",

--- a/client/windows/CCreatureWindow.cpp
+++ b/client/windows/CCreatureWindow.cpp
@@ -868,10 +868,8 @@ void CStackWindow::initBonusesList()
 			return  info->stackNode->bonusToString(v1) < info->stackNode->bonusToString(v2);
 	};
 
-	// these bonuses require special handling. For example they come with own descriptions, for use in morale/luck description
-	// also, this information is already available in creature window
-	receivedBonuses.remove_if(Selector::type()(BonusType::MORALE));
-	receivedBonuses.remove_if(Selector::type()(BonusType::LUCK));
+	receivedBonuses.remove_if(Selector::targetSourceType()(BonusSource::COMMANDER));
+	receivedBonuses.remove_if(Selector::targetSourceType()(BonusSource::GLOBAL));
 
 	std::vector<BonusList> groupedBonuses;
 	while (!receivedBonuses.empty())

--- a/config/creatures/castle.json
+++ b/config/creatures/castle.json
@@ -384,6 +384,7 @@
 				"type" : "MORALE",
 				"val" : 1,
 				"propagator" : "ARMY",
+				"targetSourceType" : "COMMANDER",
 				"description" : "PLACEHOLDER",
 				"stacking" : "Angels"
 			},
@@ -454,6 +455,7 @@
 				"type" : "MORALE",
 				"val" : 1,
 				"propagator" : "ARMY",
+				"targetSourceType" : "COMMANDER",
 				"description" : "@creatures.core.angel.bonus.raisesMorale",
 				"stacking" : "Angels"
 			},

--- a/config/creatures/inferno.json
+++ b/config/creatures/inferno.json
@@ -394,6 +394,7 @@
 				"val" : -1,
 				"stacking" : "Devils",
 				"propagator": "BATTLE_WIDE",
+				"targetSourceType" : "COMMANDER",
 				"propagationUpdater" : "BONUS_OWNER_UPDATER",
 				"description" : "PLACEHOLDER",
 				"limiters" : [ "OPPOSITE_SIDE" ]
@@ -457,6 +458,7 @@
 				"val" : -1,
 				"stacking" : "Devils",
 				"propagator": "BATTLE_WIDE",
+				"targetSourceType" : "COMMANDER",
 				"propagationUpdater" : "BONUS_OWNER_UPDATER",
 				"description" : "@creatures.core.devil.bonus.decreaseLuck",
 				"limiters" : [ "OPPOSITE_SIDE" ]

--- a/config/creatures/neutral.json
+++ b/config/creatures/neutral.json
@@ -512,7 +512,8 @@
 			{
 				"type" : "LUCK",
 				"val" : 1,
-				"valueType" : "INDEPENDENT_MAX"
+				"valueType" : "INDEPENDENT_MAX",
+				"description" : "PLACEHOLDER"
 			}
 		 },
 		"graphics" :
@@ -621,7 +622,9 @@
 			{
 				"type" : "NO_TERRAIN_PENALTY",
 				"subtype" : "terrain.sand",
-				"propagator" : "HERO"
+				"propagator" : "HERO",
+				"description" : "PLACEHOLDER",
+				"targetSourceType" : "COMMANDER"
 			}
 		},
 		"graphics" :
@@ -652,7 +655,9 @@
 				"subtype" : "visionsMonsters",
 				"val" : 3,
 				"valueType" : "INDEPENDENT_MAX",
-				"propagator" : "HERO"
+				"propagator" : "HERO",
+				"description" : "PLACEHOLDER",
+				"targetSourceType" : "COMMANDER"
 			},
 			"visionsHeroes" :
 			{
@@ -660,7 +665,9 @@
 				"subtype" : "visionsHeroes",
 				"val" : 3,
 				"valueType" : "INDEPENDENT_MAX",
-				"propagator" : "HERO"
+				"propagator" : "HERO",
+				"description" : "PLACEHOLDER",
+				"targetSourceType" : "COMMANDER"
 			},
 			"visionsTowns" :
 			{
@@ -668,7 +675,9 @@
 				"subtype" : "visionsTowns",
 				"val" : 3,
 				"valueType" : "INDEPENDENT_MAX",
-				"propagator" : "HERO"
+				"propagator" : "HERO",
+				"description" : "PLACEHOLDER",
+				"targetSourceType" : "COMMANDER"
 			}
 		},
 		"graphics" :

--- a/lib/mapObjects/army/CArmedInstance.cpp
+++ b/lib/mapObjects/army/CArmedInstance.cpp
@@ -112,6 +112,8 @@ void CArmedInstance::updateMoraleBonusFromArmy()
 
 	b->description = bonusDescription;
 
+	b->targetSourceType = BonusSource::COMMANDER;
+
 	nodeHasChanged();
 
 	//-1 modifier for any Undead unit in army


### PR DESCRIPTION
I know it is a second pr for the same issue, but I think I found a much better solution.
Instead of hardcoding everything I changed the code to remove description if it is propagated and targetSourceType was set to "COMMANDER" (e.g nomad's sandwalking) or "GLOBAL" (e.g whipper from new pavilion mod).
After that I deleted code that removes luck and morale bonuses and let json configuration take care of that. After that, bonuses like "lucky" of halfling and "positive luck" of mermaid from Haven mod display normally. 

With that two out of three problems mentioned in #5993 are resolved. There is still a problem with descriptions not displaying when limiters conditions are not fulfilled - for example the desertRider ability from new pavilion mod does not show unless hero stands on a desert tile. 
