### PR TITLE
Fix for #5885

### DIFF
--- a/lib/CStack.cpp
+++ b/lib/CStack.cpp
@@ -246,7 +246,6 @@ void CStack::prepareAttacked(BattleStackAttacked & bsa, vstd::RNG & rand, const 
 
 BattleHexArray CStack::meleeAttackHexes(const battle::Unit * attacker, const battle::Unit * defender, BattleHex attackerPos, BattleHex defenderPos)
 {
-	int mask = 0;
 	BattleHexArray res;
 
 	if (!attackerPos.isValid())
@@ -254,43 +253,15 @@ BattleHexArray CStack::meleeAttackHexes(const battle::Unit * attacker, const bat
 	if (!defenderPos.isValid())
 		defenderPos = defender->getPosition();
 
-	BattleHex otherAttackerPos = attackerPos.toInt() + (attacker->unitSide() == BattleSide::ATTACKER ? -1 : 1);
-	BattleHex otherDefenderPos = defenderPos.toInt() + (defender->unitSide() == BattleSide::ATTACKER ? -1 : 1);
+	BattleHexArray attackableHxs = attacker->doubleWide() ? attackerPos.getNeighbouringTilesDoubleWide(attacker->unitSide()) : attackerPos.getNeighbouringTiles();
 
-	if(BattleHex::mutualPosition(attackerPos, defenderPos) >= 0) //front <=> front
+	if (std::find(attackableHxs.begin(), attackableHxs.end(), defenderPos) != attackableHxs.end())
+		res.insert(defenderPos);
+	if (defender->doubleWide())
 	{
-		if((mask & 1) == 0)
-		{
-			mask |= 1;
-			res.insert(defenderPos);
-		}
-	}
-	if (attacker->doubleWide() //back <=> front
-		&& BattleHex::mutualPosition(otherAttackerPos, defenderPos) >= 0)
-	{
-		if((mask & 1) == 0)
-		{
-			mask |= 1;
-			res.insert(defenderPos);
-		}
-	}
-	if (defender->doubleWide()//front <=> back
-		&& BattleHex::mutualPosition(attackerPos, otherDefenderPos) >= 0)
-	{
-		if((mask & 2) == 0)
-		{
-			mask |= 2;
+		BattleHex otherDefenderPos = defenderPos.toInt() + (defender->unitSide() == BattleSide::ATTACKER ? -1 : 1);
+		if (std::find(attackableHxs.begin(), attackableHxs.end(), otherDefenderPos) != attackableHxs.end())
 			res.insert(otherDefenderPos);
-		}
-	}
-	if (defender->doubleWide() && attacker->doubleWide()//back <=> back
-		&& BattleHex::mutualPosition(otherAttackerPos, otherDefenderPos) >= 0)
-	{
-		if((mask & 2) == 0)
-		{
-			mask |= 2;
-			res.insert(otherDefenderPos);
-		}
 	}
 
 	return res;

--- a/lib/CStack.cpp
+++ b/lib/CStack.cpp
@@ -253,15 +253,24 @@ BattleHexArray CStack::meleeAttackHexes(const battle::Unit * attacker, const bat
 	if (!defenderPos.isValid())
 		defenderPos = defender->getPosition();
 
-	BattleHexArray attackableHxs = attacker->doubleWide() ? attackerPos.getNeighbouringTilesDoubleWide(attacker->unitSide()) : attackerPos.getNeighbouringTiles();
+	BattleHexArray defenderHexes = defender->getHexes(defenderPos);
+	BattleHexArray attackerHexes = attacker->getHexes(attackerPos);
 
-	if (std::find(attackableHxs.begin(), attackableHxs.end(), defenderPos) != attackableHxs.end())
-		res.insert(defenderPos);
-	if (defender->doubleWide())
+	for (BattleHex defenderHex : defenderHexes)
 	{
-		BattleHex otherDefenderPos = defenderPos.toInt() + (defender->unitSide() == BattleSide::ATTACKER ? -1 : 1);
-		if (std::find(attackableHxs.begin(), attackableHxs.end(), otherDefenderPos) != attackableHxs.end())
-			res.insert(otherDefenderPos);
+		if (attackerHexes.contains(defenderHex))
+		{
+			logGlobal->debug("CStack::meleeAttackHexes: defender and attacker positions overlap");
+			return res;
+		}
+	}
+
+	const BattleHexArray attackableHxs = attacker->getSurroundingHexes(attackerPos);
+
+	for (BattleHex defenderHex : defenderHexes)
+	{
+		if (attackableHxs.contains(defenderHex))
+			res.insert(defenderHex);
 	}
 
 	return res;


### PR DESCRIPTION
Fixes #5885
The crashes were caused by the behaviour of method meleeAttackHexes when receiving two double-wide units stacked one on another. 
<img width="306" height="266" alt="position" src="https://github.com/user-attachments/assets/9c17245a-f5a7-44c0-88d1-ac03ed27a80f" />
One represents the position of helldoggos, two the position of an enemy double-wide unit.
The old method would consider it a viable melee position.

Now, why BattleAI tries to check for such a situation is a completely different can of worms. I think it has to do with how reachability for flying units is calculated but I am not sure yet how to fix it or even if it should be fixed. 