### PR TITLE
move commander start position to 94 to avoid overlap

### DIFF
--- a/config/gameConfig.json
+++ b/config/gameConfig.json
@@ -655,7 +655,7 @@
 				"creatureBankNarrow" : {
 					"tacticsAllowed" : false,
 					"obstaclesAllowed" : false,
-					"attackerCommander" : 95,
+					"attackerCommander" : 94,
 					"defenderCommander" : 8,
 					"attackerUnits": [ 57, 61, 90, 93, 96, 125, 129 ],
 					"defenderUnits": [ 15, 185, 172, 2, 100, 87, 8 ]
@@ -664,7 +664,7 @@
 				"creatureBankWide" : {
 					"tacticsAllowed" : false,
 					"obstaclesAllowed" : false,
-					"attackerCommander" : 95,
+					"attackerCommander" : 94,
 					"defenderCommander" : 8,
 					"attackerUnits": [ 57, 61, 90, 93, 96, 125, 129 ],
 					"defenderUnits": [ 15, 185, 171, 1, 100, 86, 8 ]


### PR DESCRIPTION
fixed #6039

Placing the commander on hex 95 will cause it to overlap with a double-hex creature on hex 96, leading to a series of bugs. Moving it to hex 94 can avoid this issue.