### PR TITLE
Fixes crashes caused by CREATURE_TERRAIN_LIMITER

### DIFF
--- a/lib/callback/EditorCallback.cpp
+++ b/lib/callback/EditorCallback.cpp
@@ -52,9 +52,9 @@ int EditorCallback::getDate(Date mode) const
 	THROW_EDITOR_UNSUPPORTED;
 }
 
-const TerrainTile * EditorCallback::getTile(int3, bool) const
+const TerrainTile * EditorCallback::getTile(int3 tile, bool) const
 {
-	THROW_EDITOR_UNSUPPORTED;
+	return &map->getTile(tile);
 }
 
 const TerrainTile * EditorCallback::getTileUnchecked(int3) const

--- a/lib/gameState/CGameState.cpp
+++ b/lib/gameState/CGameState.cpp
@@ -607,6 +607,7 @@ void CGameState::initHeroes(IGameRandomizer & gameRandomizer)
 			continue;
 		}
 		hero->initHero(gameRandomizer);
+		hero->armyChanged();
 	}
 
 	// generate boats for all heroes on water

--- a/lib/mapObjects/army/CCreatureSet.cpp
+++ b/lib/mapObjects/army/CCreatureSet.cpp
@@ -661,7 +661,9 @@ void CCreatureSet::serializeJson(JsonSerializeFormat & handler, const std::strin
 			{
 				auto newStack = std::make_unique<CStackInstance>(getArmy()->cb);
 				newStack->serializeJson(handler);
-				putStack(SlotID(static_cast<si32>(idx)), std::move(newStack));
+				SlotID slot(static_cast<si32>(idx));
+				stacks[slot] = std::move(newStack);
+				stacks[slot]->setArmy(getArmy());
 			}
 		}
 	}


### PR DESCRIPTION
Problem: 
1) if you try to add a unit with a bonus limited by terrain to a hero in the editor, the editor crashes (e.g. Desert Rider from New Pavilion mod)
2) If you try to start a game with a unit with a bonus limited by terrain in a hero's army, the game crashes.

Reason: Adding a unit to an army causes a check for UNDEAD bonus in order to calculate morale penalties. Whenever the game check if a unit has a specific bonus, it needs to check through all the bonuses and limiters. A terrain limiter want to check the tile on which the unit resides. It will cause a crash in editor because EditorCallback does not support that action and will cause a crash during loading a game because the map has not been properly initialized yet. 

Solution: For editor, implement the method getTile of EditorCallback. For the game, only add the creatures to the slots when deserializing and call armyChanged() on each hero later in code, once the map has been initialized.

I am a little wary of that deserialization change, but I think that editor does not care and CGameState is responsible for all the cases of client (starting a game, loading a game and starting a campaign). Calculating morale bonuses should not be deserialization concern, so it seems to make sense.

A simpler solution was to check undead status of the type of the creature instead of the stack, but I discarded it as it would introduce a bug into any mods where undead status can be granted (e.g by an artifact).

PS: abilities with CREATURE_TERRAIN_LIMITER seem to currently not work at all on develop, it is the next thing I want to take a look at.
  