### PR TITLE
Add automated Qt translation workflow

### DIFF
--- a/.github/workflows/qt_translation_update.yml
+++ b/.github/workflows/qt_translation_update.yml
@@ -28,12 +28,12 @@ jobs:
       - name: Update TS files (Launcher)
         working-directory: launcher
         run: |
-          lupdate -no-obsolete . -ts translation/*.ts
+          lupdate . -ts translation/*.ts
 
       - name: Update TS files (Map Editor)
         working-directory: mapeditor
         run: |
-          lupdate -no-obsolete . -ts translation/*.ts
+          lupdate . -ts translation/*.ts
 
       - name: Commit and push translation updates
         uses: EndBug/add-and-commit@v9


### PR DESCRIPTION
This PR adds worflow to automatically update Qt *.ts files for Launcher and Map editor. There will be no need to do it manually as repo will do it automatically every Sunday 00:00 UTC.