### PR TITLE
Fixes draw in a battle

### DIFF
--- a/lib/mapObjects/CGCreature.cpp
+++ b/lib/mapObjects/CGCreature.cpp
@@ -522,7 +522,7 @@ void CGCreature::battleFinished(IGameEventCallback & gameEvents, const CGHeroIns
 	else if(result.winner == BattleSide::NONE) // draw
 	{
 		// guarded reward is lost forever on draw
-		gameEvents.removeObject(this, hero->getOwner());
+		gameEvents.removeObject(this, result.attacker);
 	}
 	else
 	{

--- a/lib/mapObjects/CGPandoraBox.cpp
+++ b/lib/mapObjects/CGPandoraBox.cpp
@@ -294,6 +294,18 @@ void CGEvent::init()
 	}
 }
 
+void CGEvent::battleFinished(IGameEventCallback & gameEvents, const CGHeroInstance *hero, const BattleResult &result) const
+{
+	if(result.winner == BattleSide::ATTACKER)
+	{
+		CRewardableObject::onHeroVisit(gameEvents, hero);
+	}
+	if(result.winner == BattleSide::NONE && removeAfterVisit)	//rewards are lost if therer is a draw and an event is not repeatable
+	{
+		gameEvents.removeObject(this, result.attacker);
+	}
+}
+
 void CGEvent::grantRewardWithMessage(IGameEventCallback & gameEvents, const CGHeroInstance * contextHero, int rewardIndex, bool markAsVisit) const
 {
 	CRewardableObject::grantRewardWithMessage(gameEvents, contextHero, rewardIndex, markAsVisit);

--- a/lib/mapObjects/CGPandoraBox.h
+++ b/lib/mapObjects/CGPandoraBox.h
@@ -65,6 +65,7 @@ public:
 	}
 
 	void onHeroVisit(IGameEventCallback & gameEvents, const CGHeroInstance * h) const override;
+	void battleFinished(IGameEventCallback & gameEvents, const CGHeroInstance *hero, const BattleResult &result) const override;
 protected:
 	void grantRewardWithMessage(IGameEventCallback & gameEvents, const CGHeroInstance * contextHero, int rewardIndex, bool markAsVisit) const override;
 	

--- a/lib/networkPacks/PacksForClientBattle.h
+++ b/lib/networkPacks/PacksForClientBattle.h
@@ -121,7 +121,8 @@ struct DLL_LINKAGE BattleResult : public Query
 {
 	BattleID battleID = BattleID::NONE;
 	EBattleResult result = EBattleResult::NORMAL;
-	BattleSide winner = BattleSide::NONE; //0 - attacker, 1 - defender, [2 - draw (should be possible?)]
+	BattleSide winner = BattleSide::NONE; //0 - attacker, 1 - defender, 2 - draw
+	PlayerColor attacker; //used in case of a draw
 	BattleSideArray<std::map<CreatureID, si32>> casualties; //first => casualties of attackers - map crid => number
 	BattleSideArray<TExpType> exp{0,0}; //exp for attacker and defender
 

--- a/server/battles/BattleResultProcessor.cpp
+++ b/server/battles/BattleResultProcessor.cpp
@@ -409,13 +409,13 @@ void BattleResultProcessor::battleFinalize(const BattleID & battleID, const Batt
 	const auto defenderHero = (*battle)->battleGetFightingHero(BattleSide::DEFENDER);
 	const auto attackerSide = (*battle)->getSidePlayer(BattleSide::ATTACKER);
 	const auto defenderSide = (*battle)->getSidePlayer(BattleSide::DEFENDER);
-	bool winnerHasUnitsLeft = false;
+	bool winnerHasUnitsLeft = true;
 
 	if (!finishingBattle->isDraw())
 	{
 		winnerHero = (*battle)->battleGetFightingHero(finishingBattle->winnerSide);
 		loserHero = (*battle)->battleGetFightingHero(CBattleInfoEssentials::otherSide(finishingBattle->winnerSide));
-		winnerHasUnitsLeft = !winnerHero->getCreatureMap().empty();
+		winnerHasUnitsLeft = winnerHero ? winnerHero->stacksCount() > 0 : true;
 	}
 
 	BattleResultsApplied resultsApplied;


### PR DESCRIPTION
First I fixed crash on a draw, but it did not work properly at all so I've reworked it.

Tested scenarios:

Enemy hero: both attacker and defender are destroyed. 
If retreatOnWinWithoutTroops is set to true both players can rehire their respective hero with artifacts the very same turn. No experience is received from the battle.
It stays true for all other cases.

Enemy town battle: town is not flagged.
Neutral town battle: town is not flagged. Another hero can flag the empty town.
Neutral creatures: Disappear from the map.
Pandora box: Disappears. Rewards are wasted (even if rehired in a tavern, hero does not have artifacts/army/experience).
Artifact with guards: Artifact stays. Another hero can pick it up without fighting guards. The before-fight message is displayed.
Imp cache:  Player does not receive a reward. The next visiting hero will receive it without a fight.
Abandoned mine: Player does not flag the mine. The next visiting hero will do so without a fight. 

Necromancy skill: makes no difference.
Existence of summoned creature: makes no difference.

Fixes #2989.
Fixes #3853.


 