### PR TITLE
Add cache cleanup workflow for closed PRs

### DIFF
--- a/.github/workflows/cache_cleanup.yml
+++ b/.github/workflows/cache_cleanup.yml
@@ -1,0 +1,34 @@
+name: Cleanup GitHub runner caches on closed pull requests
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: Install cache extension
+        run: gh extension install actions/gh-actions-cache
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Delete caches for this PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          # List caches whose key contains "-PR-<number>"
+          ids=$(gh cache list --limit 2000 --json id,key --jq ".[] | select(.key | contains(\"-PR-${PR_NUMBER}\")) | .id")
+
+          # Delete them (best effort)
+          set +e
+          for id in $ids; do
+            gh cache delete "$id"
+          done
+          set -e
+
+          echo "Done."

--- a/.github/workflows/cache_cleanup.yml
+++ b/.github/workflows/cache_cleanup.yml
@@ -10,12 +10,7 @@ jobs:
     permissions:
       actions: write
     steps:
-      - name: Install cache extension
-        run: gh extension install actions/gh-actions-cache
-        env:
-          GH_TOKEN: ${{ github.token }}
-
-      - name: Delete caches for this PR
+      - name: Delete caches for closed PR
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}


### PR DESCRIPTION
Regarding to cache size I have added PR cache cleanup workflow for closed PRs, based on https://docs.github.com/en/actions/how-tos/manage-workflow-runs/manage-caches

It should automatically remove closed PRs cache on PR's close action, for example.
<img width="528" height="163" alt="image" src="https://github.com/user-attachments/assets/1422065f-bd28-4cf8-90f6-16cff085cda7" />
