### PR TITLE
[cmake] rename iOS and macOS variables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,12 +17,8 @@ project(VCMI)
 # It's used currently to make sure that 3rd-party dependencies in git submodules get proper FOLDER property
 # - Make FindFuzzyLite check for the right version and disable FORCE_BUNDLED_FL by default
 
-if(APPLE)
-	if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-		set(APPLE_MACOS 1)
-	else()
-		set(APPLE_IOS 1)
-	endif()
+if(APPLE AND NOT IOS)
+	set(MACOS 1)
 endif()
 
 if(POLICY CMP0142)
@@ -77,12 +73,12 @@ else()
 	option(ENABLE_LAUNCHER "Enable compilation of launcher" ON)
 endif()
 
-if(APPLE_IOS)
+if(IOS)
 	set(BUNDLE_IDENTIFIER_PREFIX "" CACHE STRING "Bundle identifier prefix")
 	set(APP_DISPLAY_NAME "VCMI" CACHE STRING "App name on the home screen")
 endif()
 
-if(APPLE_IOS OR ANDROID)
+if(IOS OR ANDROID)
 	set(ENABLE_MONOLITHIC_INSTALL OFF)
 	set(ENABLE_SINGLE_APP_BUILD ON)
 	set(ENABLE_EDITOR OFF)
@@ -155,7 +151,7 @@ if(ENABLE_CCACHE)
     endif()
 endif()
 
-if(ENABLE_CCACHE AND (CMAKE_GENERATOR STREQUAL "Xcode"))
+if(ENABLE_CCACHE AND XCODE)
 	# https://stackoverflow.com/a/36515503/2278742
 	# Set up wrapper scripts
 	configure_file(xcode/launch-c.in   xcode/launch-c)
@@ -287,7 +283,7 @@ if(ENABLE_GOLDMASTER)
 	add_definitions(-DENABLE_GOLDMASTER)
 endif()
 
-if(APPLE_IOS)
+if(IOS)
 	set(CMAKE_MACOSX_RPATH 1)
 	set(CMAKE_OSX_DEPLOYMENT_TARGET 12.0)
 
@@ -303,7 +299,7 @@ if(APPLE_IOS)
 	set(CMAKE_XCODE_ATTRIBUTE_TARGETED_DEVICE_FAMILY "1,2")
 endif()
 
-if(APPLE_MACOS)
+if(MACOS)
 	# Not supported by standard library of our current minimal target - macOS 10.14 or newer required
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-aligned-allocation")
 endif()
@@ -441,7 +437,7 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR NOT WIN32)
 endif()
 
 # Check if some platform-specific libraries are needed for linking
-if(NOT WIN32 AND NOT APPLE_IOS)
+if(NOT WIN32 AND NOT IOS)
 	include(CheckLibraryExists)
 
 	# Shared memory functions used by Boost.Interprocess
@@ -596,7 +592,7 @@ elseif(APPLE)
 		set(LIB_DIR "." CACHE STRING "Where to install main library")
 		set(DATA_DIR "." CACHE STRING "Where to install data files")
 	else()
-		if(APPLE_MACOS)
+		if(MACOS)
 			set(APP_BUNDLE_DIR "${CMAKE_PROJECT_NAME}.app")
 			set(APP_BUNDLE_CONTENTS_DIR "${APP_BUNDLE_DIR}/Contents")
 			set(APP_BUNDLE_BINARY_DIR "${APP_BUNDLE_CONTENTS_DIR}/MacOS")
@@ -657,7 +653,7 @@ else()
 endif()
 
 # iOS/Android have flat libs directory structure
-if(APPLE_IOS OR ANDROID)
+if(IOS OR ANDROID)
 	set(AI_LIB_DIR "${LIB_DIR}")
 	set(SCRIPTING_LIB_DIR "${LIB_DIR}")
 else()
@@ -676,7 +672,7 @@ endif()
 #        Add subdirectories           #
 #######################################
 
-if(APPLE_IOS)
+if(IOS)
 	add_subdirectory(ios)
 endif()
 
@@ -755,7 +751,7 @@ if(ENABLE_LUA)
 endif()
 
 # that script is useless for Windows / iOS / Android
-if(NOT WIN32 AND NOT APPLE_IOS AND NOT ANDROID)
+if(NOT WIN32 AND NOT IOS AND NOT ANDROID)
 	install(FILES vcmibuilder DESTINATION ${BIN_DIR} PERMISSIONS
 		OWNER_WRITE OWNER_READ OWNER_EXECUTE
 					GROUP_READ GROUP_EXECUTE
@@ -855,7 +851,7 @@ if(WIN32)
 	if(NOT (${CMAKE_CROSSCOMPILING}))
 		add_subdirectory(win)
 	endif()
-elseif(APPLE_MACOS AND NOT ENABLE_MONOLITHIC_INSTALL)
+elseif(MACOS AND NOT ENABLE_MONOLITHIC_INSTALL)
 	set(CPACK_MONOLITHIC_INSTALL 1)
 	set(CPACK_GENERATOR "DragNDrop")
 	set(CPACK_DMG_BACKGROUND_IMAGE "${CMAKE_SOURCE_DIR}/osx/dmg_background.png")
@@ -899,7 +895,7 @@ elseif(APPLE_MACOS AND NOT ENABLE_MONOLITHIC_INSTALL)
 
 	# Bundle fixing code must be in separate directory to be executed after all other install code
 	add_subdirectory(osx)
-elseif(APPLE_IOS)
+elseif(IOS)
 	set(CPACK_GENERATOR ZIP)
 	set(CPACK_ARCHIVE_FILE_EXTENSION ipa)
 	set(CPACK_INCLUDE_TOPLEVEL_DIRECTORY OFF)

--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -437,7 +437,7 @@ set(vcmiclientcommon_HEADERS
 	UIHelper.h
 )
 
-if(APPLE_IOS)
+if(IOS)
 	set(vcmiclientcommon_SRCS ${vcmiclientcommon_SRCS}
 		ios/utils.mm
 	)
@@ -460,7 +460,7 @@ if(NOT ENABLE_STATIC_LIBS)
 		add_dependencies(vcmiclientcommon Nullkiller)
 	endif()
 endif()
-if(APPLE_IOS)
+if(IOS)
 	if(ENABLE_ERM)
 		add_dependencies(vcmiclientcommon vcmiERM)
 	endif()
@@ -480,7 +480,7 @@ if(WIN32)
 		target_link_libraries(vcmiclientcommon SDL2::SDL2main)
 	endif()
 	target_compile_definitions(vcmiclientcommon PRIVATE WINDOWS_IGNORE_PACKING_MISMATCH)
-elseif(APPLE_IOS)
+elseif(IOS)
 	target_link_libraries(vcmiclientcommon PRIVATE
 		iOS_utils
 

--- a/clientapp/CMakeLists.txt
+++ b/clientapp/CMakeLists.txt
@@ -7,7 +7,7 @@ set(clientapp_HEADERS
 		StdInc.h
 )
 
-if(APPLE_IOS)
+if(IOS)
 	set(clientapp_SRCS ${clientapp_SRCS}
 		CFocusableHelper.cpp
 		ios/GameChatKeyboardHandler.m
@@ -56,7 +56,7 @@ if(WIN32)
 		target_link_libraries(vcmiclient SDL2::SDL2main)
 	endif()
 	target_compile_definitions(vcmiclient PRIVATE WINDOWS_IGNORE_PACKING_MISMATCH)
-elseif(APPLE_IOS)
+elseif(IOS)
 	set_target_properties(vcmiclient PROPERTIES
 		MACOSX_BUNDLE_INFO_PLIST "${CMAKE_CURRENT_LIST_DIR}/ios/Info.plist"
 		XCODE_ATTRIBUTE_LD_RUNPATH_SEARCH_PATHS "@executable_path/Frameworks"
@@ -81,7 +81,7 @@ endif()
 vcmi_set_output_dir(vcmiclient "")
 enable_pch(vcmiclient)
 
-if(APPLE_IOS)
+if(IOS)
 	add_custom_command(TARGET vcmiclient POST_BUILD
 		COMMAND ios/set_build_version.sh "$<TARGET_BUNDLE_CONTENT_DIR:vcmiclient>"
 		COMMAND ${CMAKE_COMMAND} --install "${CMAKE_BINARY_DIR}" --component "${CMAKE_INSTALL_DEFAULT_COMPONENT_NAME}" --config "$<CONFIG>" --prefix "$<TARGET_BUNDLE_CONTENT_DIR:vcmiclient>"

--- a/cmake_modules/FindSDL2.cmake
+++ b/cmake_modules/FindSDL2.cmake
@@ -273,7 +273,7 @@ if(SDL2_LIBRARY)
   # I think it has something to do with the CACHE STRING.
   # So I use a temporary variable until the end so I can set the
   # "real" variable in one-shot.
-  if(APPLE_MACOS)
+  if(MACOS)
     set(SDL2_LIBRARIES ${SDL2_LIBRARIES} -framework Cocoa)
   endif()
 
@@ -335,10 +335,10 @@ if(SDL2_FOUND)
     if(APPLE)
       # For OS X, SDL2 uses Cocoa as a backend so it must link to Cocoa.
       # For more details, please see above.
-      if (APPLE_MACOS)
+      if (MACOS)
         set_property(TARGET SDL2::SDL2 APPEND PROPERTY
                      INTERFACE_LINK_OPTIONS -framework Cocoa)
-      elseif (APPLE_IOS)
+      elseif (IOS)
         target_link_libraries(SDL2::SDL2 INTERFACE
           "-framework AudioToolbox"
           "-framework AVFoundation"

--- a/cmake_modules/FindSDL2_image.cmake
+++ b/cmake_modules/FindSDL2_image.cmake
@@ -227,7 +227,7 @@ if(SDL2_IMAGE_FOUND)
                           IMPORTED_LOCATION "${SDL2_IMAGE_LIBRARY}"
                           INTERFACE_INCLUDE_DIRECTORIES "${SDL2_IMAGE_INCLUDE_DIR}"
                           INTERFACE_LINK_LIBRARIES SDL2::SDL2)
-    if (APPLE_IOS)
+    if (IOS)
       target_link_libraries(SDL2::Image INTERFACE
         "-framework CoreGraphics"
         "-framework Foundation"

--- a/cmake_modules/FindSDL2_mixer.cmake
+++ b/cmake_modules/FindSDL2_mixer.cmake
@@ -216,7 +216,7 @@ if(SDL2_MIXER_FOUND)
                           IMPORTED_LOCATION "${SDL2_MIXER_LIBRARY}"
                           INTERFACE_INCLUDE_DIRECTORIES "${SDL2_MIXER_INCLUDE_DIR}"
                           INTERFACE_LINK_LIBRARIES SDL2::SDL2)
-    if (APPLE_IOS)
+    if (IOS)
       target_link_libraries(SDL2::Mixer INTERFACE
         "-framework AudioToolbox"
         "-framework CoreServices"

--- a/cmake_modules/Findminizip.cmake
+++ b/cmake_modules/Findminizip.cmake
@@ -33,7 +33,7 @@ else()
   set(VC_LIB_PATH_SUFFIX lib/x86)
 endif()
 
-if (NOT WIN32 AND NOT APPLE_IOS)
+if (NOT WIN32 AND NOT IOS)
     find_package(PkgConfig)
     if (PKG_CONFIG_FOUND)
         pkg_check_modules(_MINIZIP minizip)

--- a/launcher/CMakeLists.txt
+++ b/launcher/CMakeLists.txt
@@ -27,7 +27,7 @@ set(launcher_SRCS
 		updatedialog_moc.cpp
 		prepare.cpp
 )
-if(APPLE_IOS)
+if(IOS)
 	list(APPEND launcher_SRCS
 		ios/launchGame.m
 		ios/revealdirectoryinfiles.h
@@ -225,7 +225,7 @@ endif()
 
 if(ANDROID)
 	target_link_libraries(vcmilauncher Qt${QT_VERSION_MAJOR}::AndroidExtras)
-elseif(NOT APPLE_IOS)
+elseif(NOT IOS)
 	target_link_libraries(vcmilauncher SDL2::SDL2)
 endif()
 
@@ -245,7 +245,7 @@ if(ENABLE_INNOEXTRACT)
 	target_link_libraries(vcmilauncher innoextract)
 endif()
 
-if(APPLE_IOS)
+if(IOS)
 	target_link_libraries(vcmilauncher
 		iOS_utils
 		"-framework UniformTypeIdentifiers"

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -846,11 +846,11 @@ endif()
 
 # no longer necessary, but might be useful to keep in future
 # unfortunately at the moment tests do not support namespaced build, so enable only on some systems
-if(APPLE_IOS OR ANDROID)
+if(IOS OR ANDROID)
 	target_compile_definitions(vcmi PUBLIC VCMI_LIB_NAMESPACE=VCMI)
 endif()
 
-if(APPLE_IOS)
+if(IOS)
 	target_link_libraries(vcmi PUBLIC iOS_utils)
 endif()
 
@@ -901,7 +901,7 @@ if(NOT ENABLE_STATIC_LIBS)
 	install(TARGETS vcmi RUNTIME DESTINATION ${LIB_DIR} LIBRARY DESTINATION ${LIB_DIR})
 endif()
 
-if(APPLE_IOS AND NOT USING_CONAN)
+if(IOS AND NOT USING_CONAN)
 	install(IMPORTED_RUNTIME_ARTIFACTS TBB::tbb LIBRARY DESTINATION ${LIB_DIR}) # CMake 3.21+
 
 	get_target_property(LINKED_LIBS vcmi LINK_LIBRARIES)

--- a/osx/CMakeLists.txt
+++ b/osx/CMakeLists.txt
@@ -1,6 +1,6 @@
 # We need to keep this code into separate directory so CMake will execute it after all other subdirectories install code
 # Otherwise we can't fix Mac bundle dependencies since binaries wouldn't be there when this code executed
-if(APPLE_MACOS)
+if(MACOS)
 	set(bundleDir "\${CMAKE_INSTALL_PREFIX}/${APP_BUNDLE_DIR}")
 	set(bundleContentsDir "${bundleDir}/Contents")
 

--- a/scripting/erm/CMakeLists.txt
+++ b/scripting/erm/CMakeLists.txt
@@ -20,7 +20,7 @@ target_link_libraries(vcmiERM Boost::boost vcmi)
 vcmi_set_output_dir(vcmiERM "scripting")
 enable_pch(vcmiERM)
 
-if(APPLE_IOS)
+if(IOS)
 	install(TARGETS vcmiERM LIBRARY DESTINATION ${SCRIPTING_LIB_DIR})
 else()
 	install(TARGETS vcmiERM DESTINATION ${SCRIPTING_LIB_DIR})

--- a/scripting/lua/CMakeLists.txt
+++ b/scripting/lua/CMakeLists.txt
@@ -88,7 +88,7 @@ target_link_libraries(vcmiLua Boost::boost luajit::luajit vcmi)
 vcmi_set_output_dir(vcmiLua "scripting")
 enable_pch(vcmiLua)
 
-if(APPLE_IOS)
+if(IOS)
 	install(TARGETS vcmiLua LIBRARY DESTINATION ${SCRIPTING_LIB_DIR})
 else()
 	install(TARGETS vcmiLua DESTINATION ${SCRIPTING_LIB_DIR})


### PR DESCRIPTION
- CMake has standard `IOS` variable, let's use it
- renamed `APPLE_MACOS` to `MACOS` to be more in line with other OS names