### PR TITLE
fix android url encoding

### DIFF
--- a/launcher/helper.cpp
+++ b/launcher/helper.cpp
@@ -93,11 +93,13 @@ void performNativeCopy(QString src, QString dst)
 		QByteArray utf8 = input.toUtf8();
 		QByteArray encoded;
 
-		for (char c : utf8) {
+		for (char c : utf8)
+		{
 			// If ASCII (0x00 to 0x7F), keep as is
-			if (static_cast<unsigned char>(c) < 0x80) {
+			if (static_cast<unsigned char>(c) < 0x80)
 				encoded.append(c);
-			} else {
+			else
+			{
 				// Non-ASCII: encode as %HH
 				encoded.append('%');
 				encoded.append(QByteArray::number(static_cast<unsigned char>(c), 16).toUpper().rightJustified(2, '0'));

--- a/launcher/helper.cpp
+++ b/launcher/helper.cpp
@@ -89,20 +89,21 @@ QString getRealPath(QString path)
 void performNativeCopy(QString src, QString dst)
 {
 #ifdef VCMI_ANDROID
-	auto percentEncodeNonAscii = [](const QString &input) {
+	auto percentEncodeNonAscii = [](const QString &input) -> QString
+	{
 		QByteArray utf8 = input.toUtf8();
 		QByteArray encoded;
 
-		for (char c : utf8)
+		for(unsigned char c : utf8)
 		{
 			// If ASCII (0x00 to 0x7F), keep as is
-			if (static_cast<unsigned char>(c) < 0x80)
+			if(c < 0x80)
 				encoded.append(c);
 			else
 			{
 				// Non-ASCII: encode as %HH
 				encoded.append('%');
-				encoded.append(QByteArray::number(static_cast<unsigned char>(c), 16).toUpper().rightJustified(2, '0'));
+				encoded.append(QByteArray::number(static_cast<uint>(c), 16).toUpper().rightJustified(2, '0'));
 			}
 		}
 
@@ -111,7 +112,7 @@ void performNativeCopy(QString src, QString dst)
 
 	auto safeEncode = [&](QString uri) -> QString
 	{
-		if (!uri.startsWith("content://", Qt::CaseInsensitive))
+		if(!uri.startsWith("content://", Qt::CaseInsensitive))
 			return uri;
 		uri.replace(" ", "%20");
 		return percentEncodeNonAscii(uri);

--- a/launcher/helper.cpp
+++ b/launcher/helper.cpp
@@ -110,6 +110,9 @@ void performNativeCopy(QString src, QString dst)
 		return QString::fromUtf8(encoded);
 	};
 
+	// %-encode unencoded parts of string.
+	// This is needed because QT returns a mixed content url with %-encoded and unencoded parts. If Android > 13 this causes problems reading this files. E.g. when using spaces and unicode characters in folder or filename.
+	// Related, but seems not completly fixed (at least in our setup): https://bugreports.qt.io/browse/QTBUG-114435
 	auto safeEncode = [&](QString uri) -> QString
 	{
 		if(!uri.startsWith("content://", Qt::CaseInsensitive))

--- a/launcher/helper.cpp
+++ b/launcher/helper.cpp
@@ -90,8 +90,8 @@ void performNativeCopy(QString src, QString dst)
 {
 #ifdef VCMI_ANDROID
 	// %-encode unencoded parts of string.
-	// This is needed because QT returns a mixed content url with %-encoded and unencoded parts. If Android >= 13 this causes problems reading this files, when using spaces and unicode characters in folder or filename.
-	// Only these should encoded (other typically %-encoded chars should not encoded because this leads to errors).
+	// This is needed because Qt returns a mixed content url with %-encoded and unencoded parts. On Android >= 13 this causes problems reading these files, when using spaces and unicode characters in folder or filename.
+	// Only these should be encoded (other typically %-encoded chars should not be encoded because this leads to errors).
 	// Related, but seems not completly fixed (at least in our setup): https://bugreports.qt.io/browse/QTBUG-114435
 	auto safeEncode = [&](QString uri) -> QString
 	{


### PR DESCRIPTION
fixes #5945

Tested with space and german umlauts.

Not sure why https://github.com/qt/qtbase/commit/d5e03ad4e48c6e3229c88686cfc071ce57956dea doesn't work. We're using 5.15.16 which should have the fix.

Related: https://bugreports.qt.io/browse/QTBUG-114435