### PR TITLE
Fix PlayerConnectionID regression

### DIFF
--- a/server/CVCMIServer.cpp
+++ b/server/CVCMIServer.cpp
@@ -599,7 +599,7 @@ void CVCMIServer::setPlayer(PlayerColor clickedColor)
 	{
 		PlayerColor color;
 		PlayerConnectionID id;
-		void reset() { id = PlayerConnectionID::PLAYER_AI; color = PlayerColor::CANNOT_DETERMINE; }
+		void reset() { id = PlayerConnectionID::INVALID; color = PlayerColor::CANNOT_DETERMINE; }
 		PlayerToRestore(){ reset(); }
 	};
 


### PR DESCRIPTION
@IvanSavenko, this should fix regression from [commit 52da332](https://github.com/vcmi/vcmi/commit/52da332640ed1ce0c70353739cf42d973038ec3b) that you mentioned on discord and - hopefully - also the issue with non-working hotseat reported by @edeksumo 

Other than that I don't see any more problems in code there.   