### PR TITLE
allows resizing window in windowed mode

### DIFF
--- a/client/GameEngine.cpp
+++ b/client/GameEngine.cpp
@@ -281,10 +281,11 @@ void GameEngine::setStatusbar(const std::shared_ptr<IStatusBar> & newStatusBar)
 	currentStatusBar = newStatusBar;
 }
 
-void GameEngine::onScreenResize(bool resolutionChanged)
+void GameEngine::onScreenResize(bool resolutionChanged, bool windowResized)
 {
 	if(resolutionChanged)
-		screenHandler().onScreenResize();
+		if(!screenHandler().onScreenResize(windowResized))
+			return;
 
 	windows().onScreenResize();
 	ENGINE->cursor().onScreenResize();

--- a/client/GameEngine.h
+++ b/client/GameEngine.h
@@ -122,7 +122,7 @@ public:
 	[[noreturn]] void mainLoop();
 
 	/// called whenever SDL_WINDOWEVENT_RESTORED is reported or the user selects a different resolution, requiring to center/resize all windows
-	void onScreenResize(bool resolutionChanged);
+	void onScreenResize(bool resolutionChanged, bool windowResized);
 
 	/// Simulate mouse movement to force refresh UI state that updates on mouse move
 	void fakeMouseMove();

--- a/client/eventsSDL/InputHandler.cpp
+++ b/client/eventsSDL/InputHandler.cpp
@@ -248,17 +248,15 @@ void InputHandler::preprocessEvent(const SDL_Event & ev)
 #ifndef VCMI_IOS
 			{
 				std::scoped_lock interfaceLock(ENGINE->interfaceMutex);
-				ENGINE->onScreenResize(false);
+				ENGINE->onScreenResize(false, false);
 			}
 #endif
 				break;
 			case SDL_WINDOWEVENT_SIZE_CHANGED:
-#ifdef VCMI_MOBILE
 			{
 				std::scoped_lock interfaceLock(ENGINE->interfaceMutex);
-				ENGINE->onScreenResize(true);
+				ENGINE->onScreenResize(true, true);
 			}
-#endif
 				break;
 			case SDL_WINDOWEVENT_FOCUS_GAINED:
 			{

--- a/client/eventsSDL/InputSourceKeyboard.cpp
+++ b/client/eventsSDL/InputSourceKeyboard.cpp
@@ -97,7 +97,7 @@ void InputSourceKeyboard::handleEventKeyDown(const SDL_KeyboardEvent & key)
 	{
 		Settings full = settings.write["video"]["fullscreen"];
 		full->Bool() = !full->Bool();
-		ENGINE->onScreenResize(true);
+		ENGINE->onScreenResize(true, false);
 	}
 
 	if (vstd::contains(shortcutsVector, EShortcut::SPECTATE_TRACK_HERO))

--- a/client/render/IScreenHandler.h
+++ b/client/render/IScreenHandler.h
@@ -25,7 +25,7 @@ public:
 	virtual ~IScreenHandler() = default;
 
 	/// Updates window state after fullscreen state has been changed in settings
-	virtual void onScreenResize() = 0;
+	virtual bool onScreenResize(bool keepWindowResolution) = 0;
 
 	/// Fills screen with black color, erasing any existing content
 	virtual void clearScreen() = 0;

--- a/client/renderSDL/ScreenHandler.cpp
+++ b/client/renderSDL/ScreenHandler.cpp
@@ -298,7 +298,6 @@ void ScreenHandler::updateWindowState()
 			Point resolution = getPreferredWindowResolution();
 			SDL_SetWindowFullscreen(mainWindow, 0);
 			SDL_SetWindowSize(mainWindow, resolution.x, resolution.y);
-			SDL_SetWindowPosition(mainWindow, SDL_WINDOWPOS_CENTERED_DISPLAY(displayIndex), SDL_WINDOWPOS_CENTERED_DISPLAY(displayIndex));
 			return;
 		}
 	}
@@ -480,9 +479,24 @@ SDL_Window * ScreenHandler::createWindow()
 #endif
 }
 
-void ScreenHandler::onScreenResize()
+bool ScreenHandler::onScreenResize(bool keepWindowResolution)
 {
+	if(getPreferredWindowMode() == EWindowMode::WINDOWED && keepWindowResolution)
+	{
+		auto res = getRenderResolution();
+
+		if(res.x < heroes3Resolution.x || res.y < heroes3Resolution.y)
+			return false;
+
+		Settings video = settings.write["video"];
+		video["resolution"]["width"].Integer() = res.x;
+		video["resolution"]["height"].Integer() = res.y;
+	}
+	else if(keepWindowResolution)
+		return false;
+
 	recreateWindowAndScreenBuffers();
+	return true;
 }
 
 void ScreenHandler::validateSettings()

--- a/client/renderSDL/ScreenHandler.h
+++ b/client/renderSDL/ScreenHandler.h
@@ -100,7 +100,7 @@ public:
 	~ScreenHandler();
 
 	/// Updates and potentially recreates target screen to match selected fullscreen status
-	void onScreenResize() final;
+	bool onScreenResize(bool keepWindowResolution) final;
 
 	/// Fills screen with black color, erasing any existing content
 	void clearScreen() final;

--- a/client/windows/settings/GeneralOptionsTab.cpp
+++ b/client/windows/settings/GeneralOptionsTab.cpp
@@ -336,7 +336,7 @@ void GeneralOptionsTab::setGameResolution(int index)
 	widget<CLabel>("resolutionLabel")->setText(resolutionToLabelString(resolution.x, resolution.y));
 
 	ENGINE->dispatchMainThread([](){
-		ENGINE->onScreenResize(true);
+		ENGINE->onScreenResize(true, false);
 	});
 }
 
@@ -360,7 +360,7 @@ void GeneralOptionsTab::setFullscreenMode(bool on, bool exclusive)
 	updateResolutionSelector();
 
 	ENGINE->dispatchMainThread([](){
-		ENGINE->onScreenResize(true);
+		ENGINE->onScreenResize(true, false);
 	});
 }
 
@@ -419,7 +419,7 @@ void GeneralOptionsTab::setGameScaling(int index)
 	widget<CLabel>("scalingLabel")->setText(scalingToLabelString(scaling));
 
 	ENGINE->dispatchMainThread([](){
-		ENGINE->onScreenResize(true);
+		ENGINE->onScreenResize(true, false);
 	});
 }
 


### PR DESCRIPTION
Allows to resize window in windowed mode.

Avoid strange, unwanted (SDL, not VCMI) scaling, when resizing or maximize window (if window size is higher than OH3 resolution).