### PR TITLE
keep screen on in launcher while downloading

### DIFF
--- a/android/vcmi-app/src/main/java/eu/vcmi/vcmi/ActivityLauncher.java
+++ b/android/vcmi-app/src/main/java/eu/vcmi/vcmi/ActivityLauncher.java
@@ -6,6 +6,8 @@ import android.net.Uri;
 import android.os.Bundle;
 import android.os.Environment;
 import android.provider.DocumentsContract;
+import android.view.Window;
+import android.view.WindowManager;
 
 import androidx.annotation.Nullable;
 
@@ -53,6 +55,14 @@ public class ActivityLauncher extends org.qtproject.qt5.android.bindings.QtActiv
             Uri.fromFile(new File(Environment.getExternalStorageDirectory(), "vcmi-data"))
         );
         startActivityForResult(intent, PICK_EXTERNAL_VCMI_DATA_TO_COPY);
+    }
+
+    public void setScreensaverEnabled(boolean on)
+    {
+        if(on)
+            getWindow().clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+        else
+            getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
     }
 
     public void onLaunchGameBtnPressed()

--- a/android/vcmi-app/src/main/java/eu/vcmi/vcmi/ActivityLauncher.java
+++ b/android/vcmi-app/src/main/java/eu/vcmi/vcmi/ActivityLauncher.java
@@ -57,12 +57,12 @@ public class ActivityLauncher extends org.qtproject.qt5.android.bindings.QtActiv
         startActivityForResult(intent, PICK_EXTERNAL_VCMI_DATA_TO_COPY);
     }
 
-    public void setScreensaverEnabled(boolean on)
+    public void keepScreenOn(boolean isEnabled)
     {
-        if(on)
-            getWindow().clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
-        else
+        if(isEnabled)
             getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+        else
+            getWindow().clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
     }
 
     public void onLaunchGameBtnPressed()

--- a/ios/CMakeLists.txt
+++ b/ios/CMakeLists.txt
@@ -4,6 +4,7 @@ add_library(iOS_utils SHARED
 )
 target_link_libraries(iOS_utils PRIVATE
 	"-framework Foundation"
+	"-framework UIKit"
 )
 target_include_directories(iOS_utils PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 

--- a/ios/iOS_utils.h
+++ b/ios/iOS_utils.h
@@ -27,6 +27,6 @@ const char *frameworksPath();
 const char *bundleIdentifier();
 
 bool isOsVersionAtLeast(unsigned int osMajorVersion);
-void setScreensaverEnabled(bool isEnabled);
+void keepScreenOn(bool isEnabled);
 }
 #pragma GCC visibility pop

--- a/ios/iOS_utils.h
+++ b/ios/iOS_utils.h
@@ -27,5 +27,6 @@ const char *frameworksPath();
 const char *bundleIdentifier();
 
 bool isOsVersionAtLeast(unsigned int osMajorVersion);
+void setScreensaverEnabled(bool isEnabled);
 }
 #pragma GCC visibility pop

--- a/ios/iOS_utils.mm
+++ b/ios/iOS_utils.mm
@@ -53,8 +53,8 @@ bool isOsVersionAtLeast(unsigned int osMajorVersion)
 	return NSProcessInfo.processInfo.operatingSystemVersion.majorVersion >= osMajorVersion;
 }
 
-void setScreensaverEnabled(bool isEnabled)
+void keepScreenOn(bool isEnabled)
 {
-	UIApplication.sharedApplication.idleTimerDisabled = isEnabled ? NO : YES;
+	UIApplication.sharedApplication.idleTimerDisabled = isEnabled ? YES : NO;
 }
 }

--- a/ios/iOS_utils.mm
+++ b/ios/iOS_utils.mm
@@ -11,6 +11,7 @@
 #include "iOS_utils.h"
 
 #import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
 namespace
 {
@@ -50,5 +51,10 @@ const char *bundleIdentifier() { return NSBundle.mainBundle.bundleIdentifier.UTF
 bool isOsVersionAtLeast(unsigned int osMajorVersion)
 {
 	return NSProcessInfo.processInfo.operatingSystemVersion.majorVersion >= osMajorVersion;
+}
+
+void setScreensaverEnabled(bool isEnabled)
+{
+	UIApplication.sharedApplication.idleTimerDisabled = isEnabled ? NO : YES;
 }
 }

--- a/launcher/firstLaunch/firstlaunch_moc.cpp
+++ b/launcher/firstLaunch/firstlaunch_moc.cpp
@@ -443,10 +443,12 @@ void FirstLaunchView::extractGogDataAsync(QString filePathBin, QString filePathE
 	if(errorText.isEmpty())
 	{
 		logGlobal->info("Performing extraction using innoextract...");
+		Helper::keepScreenOn(true);
 		errorText = Innoextract::extract(tmpFileExe, tempDir.path(), [this](float progress) {
 			ui->progressBarGog->setValue(progress * 100);
 			qApp->processEvents();
 		});
+		Helper::keepScreenOn(false);
 		logGlobal->info("Extraction done!");
 	}
 

--- a/launcher/helper.cpp
+++ b/launcher/helper.cpp
@@ -22,6 +22,7 @@
 #ifdef VCMI_ANDROID
 #include <QAndroidJniObject>
 #include <QtAndroid>
+#include <QAndroidJniEnvironment>
 #endif
 
 #ifdef VCMI_IOS
@@ -113,5 +114,33 @@ MainWindow * getMainWindow()
 		if(auto mainWin = qobject_cast<MainWindow*>(w))
 			return mainWin;
 	return nullptr;
+}
+
+
+void keepScreenOn(bool on)
+{
+#if defined(VCMI_ANDROID)
+	// based on https://stackoverflow.com/a/38846485
+	QtAndroid::runOnAndroidThread([on]
+	{
+		QAndroidJniObject activity = QtAndroid::androidActivity();
+		if(activity.isValid())
+		{
+			QAndroidJniObject window = activity.callObjectMethod("getWindow", "()Landroid/view/Window;");
+
+			if(window.isValid())
+			{
+				const int FLAG_KEEP_SCREEN_ON = 128;
+				if(on)
+					window.callMethod<void>("addFlags", "(I)V", FLAG_KEEP_SCREEN_ON);
+				else
+					window.callMethod<void>("clearFlags", "(I)V", FLAG_KEEP_SCREEN_ON);
+			}
+		}
+		QAndroidJniEnvironment env;
+		if (env->ExceptionCheck())
+			env->ExceptionClear();
+	});
+#endif
 }
 }

--- a/launcher/helper.cpp
+++ b/launcher/helper.cpp
@@ -22,11 +22,11 @@
 #ifdef VCMI_ANDROID
 #include <QAndroidJniObject>
 #include <QtAndroid>
-#include <QAndroidJniEnvironment>
 #endif
 
 #ifdef VCMI_IOS
 #include "ios/revealdirectoryinfiles.h"
+#include "iOS_utils.h"
 #endif
 
 #ifdef VCMI_MOBILE
@@ -120,27 +120,12 @@ MainWindow * getMainWindow()
 void keepScreenOn(bool on)
 {
 #if defined(VCMI_ANDROID)
-	// based on https://stackoverflow.com/a/38846485
 	QtAndroid::runOnAndroidThread([on]
 	{
-		QAndroidJniObject activity = QtAndroid::androidActivity();
-		if(activity.isValid())
-		{
-			QAndroidJniObject window = activity.callObjectMethod("getWindow", "()Landroid/view/Window;");
-
-			if(window.isValid())
-			{
-				const int FLAG_KEEP_SCREEN_ON = 128;
-				if(on)
-					window.callMethod<void>("addFlags", "(I)V", FLAG_KEEP_SCREEN_ON);
-				else
-					window.callMethod<void>("clearFlags", "(I)V", FLAG_KEEP_SCREEN_ON);
-			}
-		}
-		QAndroidJniEnvironment env;
-		if (env->ExceptionCheck())
-			env->ExceptionClear();
+		QtAndroid::androidActivity().callMethod<void>("setScreensaverEnabled", "(Z)V", !on);
 	});
+#elif defined(VCMI_IOS)
+	iOS_utils::setScreensaverEnabled(!on);
 #endif
 }
 }

--- a/launcher/helper.cpp
+++ b/launcher/helper.cpp
@@ -117,15 +117,15 @@ MainWindow * getMainWindow()
 }
 
 
-void keepScreenOn(bool on)
+void keepScreenOn(bool isEnabled)
 {
 #if defined(VCMI_ANDROID)
-	QtAndroid::runOnAndroidThread([on]
+	QtAndroid::runOnAndroidThread([isEnabled]
 	{
-		QtAndroid::androidActivity().callMethod<void>("setScreensaverEnabled", "(Z)V", !on);
+		QtAndroid::androidActivity().callMethod<void>("keepScreenOn", "(Z)V", isEnabled);
 	});
 #elif defined(VCMI_IOS)
-	iOS_utils::setScreensaverEnabled(!on);
+	iOS_utils::keepScreenOn(isEnabled);
 #endif
 }
 }

--- a/launcher/helper.h
+++ b/launcher/helper.h
@@ -23,4 +23,5 @@ QString getRealPath(QString path);
 void performNativeCopy(QString src, QString dst);
 void revealDirectoryInFileBrowser(QString path);
 MainWindow * getMainWindow();
+void keepScreenOn(bool on);
 }

--- a/launcher/helper.h
+++ b/launcher/helper.h
@@ -23,5 +23,5 @@ QString getRealPath(QString path);
 void performNativeCopy(QString src, QString dst);
 void revealDirectoryInFileBrowser(QString path);
 MainWindow * getMainWindow();
-void keepScreenOn(bool on);
+void keepScreenOn(bool isEnabled);
 }

--- a/launcher/modManager/cmodlistview_moc.cpp
+++ b/launcher/modManager/cmodlistview_moc.cpp
@@ -798,6 +798,7 @@ void CModListView::downloadFile(QString file, QUrl url, QString description, qin
 
 void CModListView::downloadProgress(qint64 current, qint64 max)
 {
+	Helper::keepScreenOn(true);
 	// display progress, in megabytes
 	ui->progressBar->setVisible(true);
 	ui->progressBar->setMaximum(max / (1024 * 1024));
@@ -806,6 +807,7 @@ void CModListView::downloadProgress(qint64 current, qint64 max)
 
 void CModListView::extractionProgress(qint64 current, qint64 max)
 {
+	Helper::keepScreenOn(true);
 	// display progress, in extracted files
 	ui->progressBar->setVisible(true);
 	ui->progressBar->setMaximum(max);
@@ -857,6 +859,7 @@ void CModListView::downloadFinished(QStringList savedFiles, QStringList failedFi
 
 void CModListView::hideProgressBar()
 {
+	Helper::keepScreenOn(false);
 	if(dlManager == nullptr) // it was not recreated meanwhile
 	{
 		ui->progressWidget->setVisible(false);

--- a/launcher/modManager/cmodlistview_moc.cpp
+++ b/launcher/modManager/cmodlistview_moc.cpp
@@ -807,7 +807,6 @@ void CModListView::downloadProgress(qint64 current, qint64 max)
 
 void CModListView::extractionProgress(qint64 current, qint64 max)
 {
-	Helper::keepScreenOn(true);
 	// display progress, in extracted files
 	ui->progressBar->setVisible(true);
 	ui->progressBar->setMaximum(max);
@@ -854,12 +853,12 @@ void CModListView::downloadFinished(QStringList savedFiles, QStringList failedFi
 	if(doInstallFiles)
 		installFiles(savedFiles);
 
+	Helper::keepScreenOn(false);
 	hideProgressBar();
 }
 
 void CModListView::hideProgressBar()
 {
-	Helper::keepScreenOn(false);
 	if(dlManager == nullptr) // it was not recreated meanwhile
 	{
 		ui->progressWidget->setVisible(false);
@@ -983,6 +982,8 @@ void CModListView::installFiles(QStringList files)
 
 		float prog = 0.0;
 
+		Helper::keepScreenOn(true);
+
 		auto futureExtract = std::async(std::launch::async, [this, exe, &prog]()
 		{
 			ChroniclesExtractor ce(this, [&prog](float progress) { prog = progress; });
@@ -998,6 +999,7 @@ void CModListView::installFiles(QStringList files)
 
 		if(futureExtract.get())
 		{
+			Helper::keepScreenOn(false);
 			hideProgressBar();
 			ui->abortButton->setEnabled(true);
 			ui->progressWidget->setVisible(false);
@@ -1236,6 +1238,7 @@ void CModListView::on_abortButton_clicked()
 {
 	delete dlManager;
 	dlManager = nullptr;
+	Helper::keepScreenOn(false);
 	hideProgressBar();
 }
 

--- a/launcher/modManager/cmodlistview_moc.cpp
+++ b/launcher/modManager/cmodlistview_moc.cpp
@@ -793,12 +793,12 @@ void CModListView::downloadFile(QString file, QUrl url, QString description, qin
 		ui->progressBar->setFormat(progressBarFormat);
 	}
 
+	Helper::keepScreenOn(true);
 	dlManager->downloadFile(url, file, sizeBytes);
 }
 
 void CModListView::downloadProgress(qint64 current, qint64 max)
 {
-	Helper::keepScreenOn(true);
 	// display progress, in megabytes
 	ui->progressBar->setVisible(true);
 	ui->progressBar->setMaximum(max / (1024 * 1024));


### PR DESCRIPTION
Fixes #5995

Replacement for #6022

Only keep screen on while downloading/extracting.

iOS can be added in separate PR later.

Sadly there is no native function in QT for this.