### PR TITLE
fix ASAN detected leaks and heap-use-after-free error

### DIFF
--- a/launcher/aboutProject/aboutproject_moc.cpp
+++ b/launcher/aboutProject/aboutproject_moc.cpp
@@ -33,7 +33,7 @@ void AboutProjectView::hideAndStretchWidget(QGridLayout * layout, QWidget * toHi
 
 AboutProjectView::AboutProjectView(QWidget * parent)
 	: QWidget(parent)
-	, ui(new Ui::AboutProjectView)
+	, ui(std::make_unique<Ui::AboutProjectView>())
 {
 	ui->setupUi(this);
 
@@ -55,6 +55,8 @@ AboutProjectView::AboutProjectView(QWidget * parent)
 #endif
 #endif
 }
+
+AboutProjectView::~AboutProjectView() = default;
 
 void AboutProjectView::changeEvent(QEvent *event)
 {

--- a/launcher/aboutProject/aboutproject_moc.h
+++ b/launcher/aboutProject/aboutproject_moc.h
@@ -28,6 +28,7 @@ class AboutProjectView : public QWidget
 
 public:
 	explicit AboutProjectView(QWidget * parent = nullptr);
+	~AboutProjectView() override;
 
 private slots:
 	void on_updatesButton_clicked();
@@ -49,5 +50,5 @@ private slots:
 	void on_openConfigDir_clicked();
 
 private:
-	Ui::AboutProjectView * ui;
+	std::unique_ptr<Ui::AboutProjectView> ui;
 };

--- a/launcher/firstLaunch/firstlaunch_moc.cpp
+++ b/launcher/firstLaunch/firstlaunch_moc.cpp
@@ -41,7 +41,7 @@ extern "C" JNIEXPORT void JNICALL Java_eu_vcmi_vcmi_NativeMethods_heroesDataUpda
 
 FirstLaunchView::FirstLaunchView(QWidget * parent)
 	: QWidget(parent)
-	, ui(new Ui::FirstLaunchView)
+	, ui(std::make_unique<Ui::FirstLaunchView>())
 {
 	ui->setupUi(this);
 
@@ -64,6 +64,8 @@ FirstLaunchView::FirstLaunchView(QWidget * parent)
 	ui->labelDataGogDescr->hide();
 #endif
 }
+
+FirstLaunchView::~FirstLaunchView() = default;
 
 void FirstLaunchView::on_buttonTabLanguage_clicked()
 {

--- a/launcher/firstLaunch/firstlaunch_moc.h
+++ b/launcher/firstLaunch/firstlaunch_moc.h
@@ -58,6 +58,7 @@ class FirstLaunchView : public QWidget
 
 public:
 	explicit FirstLaunchView(QWidget * parent = nullptr);
+	~FirstLaunchView() override;
 
 	// Tab Heroes III Data
 	bool heroesDataUpdate();
@@ -89,5 +90,5 @@ private slots:
 	void on_pushButtonGithub_clicked();
 
 private:
-	Ui::FirstLaunchView * ui;
+	std::unique_ptr<Ui::FirstLaunchView> ui;
 };

--- a/launcher/firstLaunch/firstlaunch_moc.h
+++ b/launcher/firstLaunch/firstlaunch_moc.h
@@ -21,7 +21,7 @@ class FirstLaunchView : public QWidget
 {
 	Q_OBJECT
 
-	void changeEvent(QEvent *event);
+	void changeEvent(QEvent *event) override;
 	CModListView * getModView();
 
 	void setSetupProgress(int progress);

--- a/launcher/modManager/cdownloadmanager_moc.cpp
+++ b/launcher/modManager/cdownloadmanager_moc.cpp
@@ -73,17 +73,19 @@ void CDownloadManager::downloadFinished(QNetworkReply * reply)
 	if(possibleRedirectUrl.isValid())
 	{
 		QString filename;
+		qint64 totalSize = 0;
 
 		for(int i = 0; i< currentDownloads.size(); ++i)
 		{
 			if(currentDownloads[i].file == file.file)
 			{
 				filename = currentDownloads[i].filename;
+				totalSize = currentDownloads[i].totalSize;
 				currentDownloads.removeAt(i);
 				break;
 			}
 		}
-		downloadFile(qurl, filename, file.totalSize);
+		downloadFile(qurl, filename, totalSize);
 		return;
 	}
 


### PR DESCRIPTION
I have ASAN active all the time when working on Nullkiller2, therefore I saw that VCMI launcher has some issues when being ran with ASAN.
This small PR is fixing 2 leaks and one heap-use-after-free error, so you can open the editor or download a mod without ASAN being unhappy.