### PR TITLE
Use buildin Garrison background

### DIFF
--- a/client/widgets/MiscWidgets.cpp
+++ b/client/widgets/MiscWidgets.cpp
@@ -279,9 +279,9 @@ void BuildArmyStacksUI(const InfoAboutArmy& army, const std::vector<Point>& slot
 		else
 		{
 			//if =0 - we have no information about stack size at all
-			if (slot.second.getCount())
+			if(slot.second.getCount())
 			{
-				if (settings["gameTweaks"]["numericCreaturesQuantities"].Bool())
+				if(settings["gameTweaks"]["numericCreaturesQuantities"].Bool())
 				{
 					subtitle = CCreature::getQuantityRangeStringForId((CCreature::CreatureQuantityId)slot.second.getCount());
 				}

--- a/client/widgets/MiscWidgets.cpp
+++ b/client/widgets/MiscWidgets.cpp
@@ -257,6 +257,45 @@ CMinorResDataBar::CMinorResDataBar()
 
 CMinorResDataBar::~CMinorResDataBar() = default;
 
+void BuildArmyStacksUI(const InfoAboutArmy& army, const std::vector<Point>& slotsPos, std::vector<std::shared_ptr<CAnimImage>>& icons, std::vector<std::shared_ptr<CLabel>>& subtitles)
+{
+	for(const auto& slot : army.army)
+	{
+		if(slot.first.getNum() >= GameConstants::ARMY_SIZE)
+		{
+			logGlobal->warn("%s has stack in slot %d", army.name, slot.first.getNum());
+			continue;
+		}
+
+		// Creature icon
+		icons.push_back(std::make_shared<CAnimImage>(AnimationPath::builtin("CPRSMALL"), slot.second.getType()->getIconIndex(), 0, slotsPos[slot.first.getNum()].x, slotsPos[slot.first.getNum()].y));
+
+		// Subtitle
+		std::string subtitle;
+		if(army.army.isDetailed)
+		{
+			subtitle = TextOperations::formatMetric(slot.second.getCount(), 4);
+		}
+		else
+		{
+			//if =0 - we have no information about stack size at all
+			if (slot.second.getCount())
+			{
+				if (settings["gameTweaks"]["numericCreaturesQuantities"].Bool())
+				{
+					subtitle = CCreature::getQuantityRangeStringForId((CCreature::CreatureQuantityId)slot.second.getCount());
+				}
+				else
+				{
+					subtitle = LIBRARY->generaltexth->arraytxt[171 + 3 * (slot.second.getCount())];
+				}
+			}
+		}
+
+		subtitles.push_back(std::make_shared<CLabel>(slotsPos[slot.first.getNum()].x + 17, slotsPos[slot.first.getNum()].y + 39, FONT_TINY, ETextAlignment::CENTER, Colors::WHITE, subtitle));
+	}
+}
+
 void CArmyTooltip::init(const InfoAboutArmy &army)
 {
 	OBJECT_CONSTRUCTION;
@@ -272,44 +311,35 @@ void CArmyTooltip::init(const InfoAboutArmy &army)
 	slotsPos.push_back(Point(90, 122));
 	slotsPos.push_back(Point(126, 122));
 
-	for(auto & slot : army.army)
-	{
-		if(slot.first.getNum() >= GameConstants::ARMY_SIZE)
-		{
-			logGlobal->warn("%s has stack in slot %d", army.name, slot.first.getNum());
-			continue;
-		}
+	BuildArmyStacksUI(army, slotsPos, icons, subtitles);
+}
 
-		icons.push_back(std::make_shared<CAnimImage>(AnimationPath::builtin("CPRSMALL"), slot.second.getType()->getIconIndex(), 0, slotsPos[slot.first.getNum()].x, slotsPos[slot.first.getNum()].y));
+void CGarrisonTooltip::init(const InfoAboutArmy& army)
+{
+	OBJECT_CONSTRUCTION;
 
-		std::string subtitle;
-		if(army.army.isDetailed)
-		{
-			subtitle = TextOperations::formatMetric(slot.second.getCount(), 4);
-		}
-		else
-		{
-			//if =0 - we have no information about stack size at all
-			if(slot.second.getCount())
-			{
-				if(settings["gameTweaks"]["numericCreaturesQuantities"].Bool())
-				{
-					subtitle = CCreature::getQuantityRangeStringForId((CCreature::CreatureQuantityId)slot.second.getCount());
-				}
-				else
-				{
-					subtitle = LIBRARY->generaltexth->arraytxt[171 + 3*(slot.second.getCount())];
-				}
-			}
-		}
+	title = std::make_shared<CLabel>(142, 26, FONT_SMALL, ETextAlignment::CENTER, Colors::WHITE, army.name);
 
-		subtitles.push_back(std::make_shared<CLabel>(slotsPos[slot.first.getNum()].x + 17, slotsPos[slot.first.getNum()].y + 39, FONT_TINY, ETextAlignment::CENTER, Colors::WHITE, subtitle));
-	}
+	std::vector<Point> slotsPos;
+	slotsPos.push_back(Point(14, 48));
+	slotsPos.push_back(Point(50, 48));
+	slotsPos.push_back(Point(86, 48));
+	slotsPos.push_back(Point(122, 48));
+	slotsPos.push_back(Point(158, 48));
+	slotsPos.push_back(Point(194, 48));
+	slotsPos.push_back(Point(230, 48));
 
+	BuildArmyStacksUI(army, slotsPos, icons, subtitles);
 }
 
 CArmyTooltip::CArmyTooltip(Point pos, const InfoAboutArmy & army):
 	CIntObject(0, pos)
+{
+	init(army);
+}
+
+CGarrisonTooltip::CGarrisonTooltip(Point pos, const InfoAboutArmy & army)
+	: CIntObject(0, pos)
 {
 	init(army);
 }

--- a/client/widgets/MiscWidgets.h
+++ b/client/widgets/MiscWidgets.h
@@ -62,7 +62,7 @@ public:
 	void showPopupWindow(const Point & cursorPosition) override;
 };
 
-/// base class for hero/town/garrison tooltips
+/// base class for hero/town tooltips
 class CArmyTooltip : public CIntObject
 {
 	std::shared_ptr<CLabel> title;
@@ -72,6 +72,17 @@ class CArmyTooltip : public CIntObject
 public:
 	CArmyTooltip(Point pos, const InfoAboutArmy & army);
 	CArmyTooltip(Point pos, const CArmedInstance * army);
+};
+
+/// base class garrison tooltips
+class CGarrisonTooltip : public CIntObject
+{
+	std::shared_ptr<CLabel> title;
+	std::vector<std::shared_ptr<CAnimImage>> icons;
+	std::vector<std::shared_ptr<CLabel>> subtitles;
+	void init(const InfoAboutArmy& army);
+public:
+	CGarrisonTooltip(Point pos, const InfoAboutArmy& army);
 };
 
 /// Class for hero tooltip. Does not have any background!

--- a/client/windows/InfoWindows.cpp
+++ b/client/windows/InfoWindows.cpp
@@ -316,13 +316,13 @@ CInfoBoxPopup::CInfoBoxPopup(Point position, const CGHeroInstance * hero)
 }
 
 CInfoBoxPopup::CInfoBoxPopup(Point position, const CGGarrison * garr)
-	: AdventureMapPopup(RCLICK_POPUP | PLAYER_COLORED, ImagePath::builtin("TOWNQVBK"), position)
+	: AdventureMapPopup(RCLICK_POPUP | PLAYER_COLORED, ImagePath::builtin("GARRIPOP"), position)
 {
 	InfoAboutTown iah;
 	GAME->interface()->cb->getTownInfo(garr, iah);
 
 	OBJECT_CONSTRUCTION;
-	tooltip = std::make_shared<CArmyTooltip>(Point(9, 10), iah);
+	tooltip = std::make_shared<CGarrisonTooltip>(Point(9, 10), iah);
 	
 	addUsedEvents(DRAG_POPUP);
 


### PR DESCRIPTION
Original game data have special Garrison background - GARRIPOP.bmp which seems was never used. Now it's used correctly for Garrisons tooltip

Before:
<img width="478" height="437" alt="image" src="https://github.com/user-attachments/assets/c9865488-fb22-46a1-affd-e3af671d7ea6" />

After:
<img width="494" height="444" alt="image" src="https://github.com/user-attachments/assets/c219c241-2c91-4a04-aa38-3432160dc739" />


Fixes: https://github.com/vcmi/vcmi/issues/6102