### PR TITLE
Add possibility to define custom main menu around image

### DIFF
--- a/client/mainmenu/CMainMenu.cpp
+++ b/client/mainmenu/CMainMenu.cpp
@@ -335,7 +335,13 @@ CMainMenu::CMainMenu()
 
 	menu = std::make_shared<CMenuScreen>(CMainMenuConfig::get().getConfig()["window"]);
 	OBJECT_CONSTRUCTION;
-	backgroundAroundMenu = std::make_shared<CFilledTexture>(ImagePath::builtin("DIBOXBCK"), pos);
+
+	const auto& bgConfig = CMainMenuConfig::get().getConfig()["backgroundAround"];
+
+	if (bgConfig.isString())
+		backgroundAroundMenu = std::make_shared<CFilledTexture>(ImagePath::fromJson(bgConfig), pos);
+	else
+		backgroundAroundMenu = std::make_shared<CFilledTexture>(ImagePath::builtin("DIBOXBCK"), pos);
 }
 
 CMainMenu::~CMainMenu() = default;

--- a/config/mainmenu.json
+++ b/config/mainmenu.json
@@ -1,5 +1,8 @@
 {
-	//images used in game selection screen
+	// Image around main menu
+	"backgroundAround" : "diboxbck",
+	
+	// Images used in game selection screen
 	"scenario-selection" :
 	{
 		"background" : ["gamselb0", "gamselb1"],
@@ -35,17 +38,17 @@
 		
 	},
 	
-	//Multiplayer selection image
+	// Multiplayer selection image
 	"multiplayer" : ["mumap"],
 
-	//Main menu window, consists of several sub-menus aka items
+	// Main menu window, consists of several sub-menus aka items
 	"window":
 	{
-		//"scalable" : true, //background will be scaled to screen size
+		//"scalable" : true, // Background will be scaled to screen size
 		
 		"background" : ["gamselbk"],
 
-		//"video" :    {"x": 8, "y": 105, "name":"CREDITS.SMK" },//Floating WoG logo. Disabled due to different position in various versions of H3.
+		//"video" :    {"x": 8, "y": 105, "name":"CREDITS.SMK" }, // Floating WoG logo. Disabled due to different position in various versions of H3.
 		
 		// Additional images
 		//"images": 


### PR DESCRIPTION
Add possibility to define custom image around main menu.

So now can be used custom colored one or single color image there instead of hardcoded DIBOXBCK.

<img width="1618" height="895" alt="image" src="https://github.com/user-attachments/assets/bec3ed38-891d-40a8-a67b-f10b24e9eba5" />
