### PR TITLE
fixes crash when entering a shipyard

### DIFF
--- a/lib/callback/CGameInfoCallback.cpp
+++ b/lib/callback/CGameInfoCallback.cpp
@@ -394,7 +394,7 @@ bool CGameInfoCallback::isVisibleFor(int3 pos, PlayerColor player) const
 bool CGameInfoCallback::isVisible(int3 pos) const
 {
 	if (!getPlayerID().has_value())
-		return true; // weird, but we do have such calls
+		return gameState().getMap().isInTheMap(pos); // weird, but we do have such calls
 	return gameState().isVisibleFor(pos, *getPlayerID());
 }
 


### PR DESCRIPTION
A fix to a bug I've noticed.
If you put a shipyard next to the left border of a map like this:
<img width="186" height="186" alt="Screenshot from 2025-09-12 16-00-10" src="https://github.com/user-attachments/assets/cdaf17bf-f37d-494c-aadf-94253f88f7f5" />
the game will crash once you attempt to enter it.
It happens because neutral objects can see all tiles (even those not-existing) and attempt to access them.
