### PR TITLE
Fix placeholder typo in additional attack descriptions.

### DIFF
--- a/Mods/vcmi/Content/config/english.json
+++ b/Mods/vcmi/Content/config/english.json
@@ -958,7 +958,7 @@
 	"creatures.core.rogue.bonus.visionsHeroes" : "{Visions Heroes}\nHero can see detailed informations about enemy heroes",
 	"creatures.core.rogue.bonus.visionsTowns" : "{Visions Towns}\nHero can see detailed informations about enemy towns",
 
-	"core.bonus.ADDITIONAL_ATTACK.description" : "{Additional attacks}\nUnit can attack an additional {$val} times", // TODO: alternative descriptions for melee/ranged effect range
+	"core.bonus.ADDITIONAL_ATTACK.description" : "{Additional attacks}\nUnit can attack an additional ${val} times", // TODO: alternative descriptions for melee/ranged effect range
 	"core.bonus.ADDITIONAL_RETALIATION.description" : "{Additional retaliations}\nUnit can retaliate ${val} extra times",
 	"core.bonus.ATTACKS_ALL_ADJACENT.description" : "{Attack all around}\nAttacks all adjacent enemies in addition to the primary target",
 	"core.bonus.BLOCKS_RANGED_RETALIATION.description" : "{No ranged retaliation}\nThe enemy cannot retaliate when shot by this unit",

--- a/Mods/vcmi/Content/config/portuguese.json
+++ b/Mods/vcmi/Content/config/portuguese.json
@@ -645,7 +645,7 @@
 	"creatures.core.azureDragon.bonus.fearful" : "{Medo}\nUnidades inimigas têm 10% de chance de congelar de medo",
 	"creatures.core.azureDragon.bonus.fearless" : "{Destemido}\nImune à habilidade Medo",
 
-	"core.bonus.ADDITIONAL_ATTACK.description" : "{Ataques Adicionais}\nA unidade pode atacar {$val} vezes adicionais",
+	"core.bonus.ADDITIONAL_ATTACK.description" : "{Ataques Adicionais}\nA unidade pode atacar ${val} vezes adicionais",
 	"core.bonus.ADDITIONAL_RETALIATION.description" : "{Contra-ataques Adicionais}\nA unidade pode contra-atacar ${val} vezes extras",
 	"core.bonus.ATTACKS_ALL_ADJACENT.description" : "{Ataque em Área}\nAtaca todos os inimigos adjacentes além do alvo principal",
 	"core.bonus.BLOCKS_RANGED_RETALIATION.description" : "{Evita Contra-ataques à Distância}\nO inimigo não pode contra-atacar usando um ataque à distância",

--- a/Mods/vcmi/Content/config/swedish.json
+++ b/Mods/vcmi/Content/config/swedish.json
@@ -953,7 +953,7 @@
 	"creatures.core.azureDragon.bonus.fearful"           : "{Skräckinjagande}\nInjagar skräck/rädsla hos fiendetrupper.",
 	"creatures.core.azureDragon.bonus.fearless"          : "{Orädd}\nImmun mot rädsla/skräck.",
 
-	"core.bonus.ADDITIONAL_ATTACK.description" : "{Ytterligare attacker}\nEnheten kan attackera ytterligare {$val} gång(er).",
+	"core.bonus.ADDITIONAL_ATTACK.description" : "{Ytterligare attacker}\nEnheten kan attackera ytterligare ${val} gång(er).",
 	"core.bonus.ADDITIONAL_RETALIATION.description" : "{Ytterligare motattacker}\nKan slå tillbaka ${val} extra gång(er).",
 	"core.bonus.ATTACKS_ALL_ADJACENT.description" : "{Attackera runtomkring}\nAttackerar alla angränsande fiender.",
 	"core.bonus.BLOCKS_RANGED_RETALIATION.description" : "{Stoppa avståndsretaliering}\nFienden kan inte retaliera på avstånd.",


### PR DESCRIPTION
Fixes typo in additional attack description value. Should fix https://github.com/vcmi/vcmi/issues/6067