### PR TITLE
fix overdrawn graphics in KindomOverview

### DIFF
--- a/client/windows/CKingdomInterface.cpp
+++ b/client/windows/CKingdomInterface.cpp
@@ -649,15 +649,15 @@ void CKingdomInterface::generateButtons()
 	btnExit->setImageOrder(3, 4, 5, 6);
 
 	//Object list control buttons
-	dwellTop = std::make_shared<CButton>(Point(733, 4), AnimationPath::builtin("OVBUTN4.DEF"), CButton::tooltip(), [&](){ dwellingsList->moveToPos(0);});
+	dwellTop = std::make_shared<CButton>(Point(733, 4), AnimationPath::builtin("OVBUTN4.DEF"), CButton::tooltip(), [&](){ dwellingsList->moveToPos(0); redraw(); });
 
-	dwellBottom = std::make_shared<CButton>(Point(733, footerPos+2), AnimationPath::builtin("OVBUTN4.DEF"), CButton::tooltip(), [&](){ dwellingsList->moveToPos(-1); });
+	dwellBottom = std::make_shared<CButton>(Point(733, footerPos+2), AnimationPath::builtin("OVBUTN4.DEF"), CButton::tooltip(), [&](){ dwellingsList->moveToPos(-1); redraw(); });
 	dwellBottom->setImageOrder(2, 3, 4, 5);
 
-	dwellUp = std::make_shared<CButton>(Point(733, 24), AnimationPath::builtin("OVBUTN4.DEF"), CButton::tooltip(), [&](){ dwellingsList->moveToPrev(); });
+	dwellUp = std::make_shared<CButton>(Point(733, 24), AnimationPath::builtin("OVBUTN4.DEF"), CButton::tooltip(), [&](){ dwellingsList->moveToPrev(); redraw(); });
 	dwellUp->setImageOrder(4, 5, 6, 7);
 
-	dwellDown = std::make_shared<CButton>(Point(733, footerPos-18), AnimationPath::builtin("OVBUTN4.DEF"), CButton::tooltip(), [&](){ dwellingsList->moveToNext(); });
+	dwellDown = std::make_shared<CButton>(Point(733, footerPos-18), AnimationPath::builtin("OVBUTN4.DEF"), CButton::tooltip(), [&](){ dwellingsList->moveToNext(); redraw(); });
 	dwellDown->setImageOrder(6, 7, 8, 9);
 }
 


### PR DESCRIPTION
Fixes overdrawn graphics in KindomOverview reported on discord.

<img width="130" height="430" alt="image" src="https://github.com/user-attachments/assets/426f8c70-b408-4438-9c50-328e60ee0ddd" />

@edeksumo 