### PR TITLE
Mines configurable

### DIFF
--- a/client/lobby/OptionsTab.cpp
+++ b/client/lobby/OptionsTab.cpp
@@ -820,6 +820,7 @@ OptionsTab::HandicapWindow::HandicapWindow()
 		INCOME = 1000,
 		GROWTH = 2000,
 	};
+	// TODO: configurable resources
 	auto columns = std::vector<int>{EGameResID::GOLD, EGameResID::WOOD, EGameResID::MERCURY, EGameResID::ORE, EGameResID::SULFUR, EGameResID::CRYSTAL, EGameResID::GEMS, Columns::INCOME, Columns::GROWTH};
 
 	int i = 0;

--- a/client/widgets/MiscWidgets.cpp
+++ b/client/widgets/MiscWidgets.cpp
@@ -227,7 +227,7 @@ void CMinorResDataBar::showAll(Canvas & to)
 {
 	CIntObject::showAll(to);
 
-	for (GameResID i=EGameResID::WOOD; i<=EGameResID::GOLD; ++i) //todo: configurable resource support
+	for (GameResID i=EGameResID::WOOD; i<=EGameResID::GOLD; ++i)
 	{
 		std::string text = std::to_string(GAME->interface()->cb->getResourceAmount(i));
 

--- a/client/windows/CKingdomInterface.cpp
+++ b/client/windows/CKingdomInterface.cpp
@@ -619,7 +619,7 @@ void CKingdomInterface::generateMinesList(const std::vector<const CGObjectInstan
 	totalIncome += GAME->interface()->cb->getPlayerState(GAME->interface()->playerID)->valOfBonuses(BonusType::RESOURCES_CONSTANT_BOOST, BonusSubtypeID(GameResID(EGameResID::GOLD))) * playerSettings->handicap.percentIncome / 100;
 	totalIncome += GAME->interface()->cb->getPlayerState(GAME->interface()->playerID)->valOfBonuses(BonusType::RESOURCES_TOWN_MULTIPLYING_BOOST, BonusSubtypeID(GameResID(EGameResID::GOLD))) * towns.size() * playerSettings->handicap.percentIncome / 100;
 
-	for(int i=0; i<7; i++)
+	for(int i=0; i<GameConstants::RESOURCE_QUANTITY; i++) // TODO: configurable resources - show up more mines
 	{
 		std::string value = std::to_string(minesCount[i]);
 		auto data = std::make_shared<InfoBoxCustom>(value, "", AnimationPath::builtin("OVMINES"), i, LIBRARY->generaltexth->translate("core.minename", i));

--- a/config/objects/moddables.json
+++ b/config/objects/moddables.json
@@ -286,7 +286,8 @@
 				},
 				"sounds" : {
 					"ambient" : ["LOOPLUMB"]
-				}
+				},
+				"resource" : "wood"
 			},
 			"alchemistLab" : {
 				"index" : 1,
@@ -296,7 +297,8 @@
 				},
 				"sounds" : {
 					"ambient" : ["LOOPSTAR"]
-				}
+				},
+				"resource" : "mercury"
 			},
 			"orePit" : {
 				"index" : 2,
@@ -306,7 +308,8 @@
 				},
 				"sounds" : {
 					"ambient" : ["LOOPSULF"]
-				}
+				},
+				"resource" : "ore"
 			},
 			"sulfurDune" : {
 				"index" : 3,
@@ -316,7 +319,8 @@
 				},
 				"sounds" : {
 					"ambient" : ["LOOPSULF"]
-				}
+				},
+				"resource" : "sulfur"
 			},
 			"crystalCavern" : {
 				"index" : 4,
@@ -327,7 +331,8 @@
 				"sounds" : {
 					"ambient" : ["LOOPCRYS"]
 				},
-				"battleground": "subterranean"
+				"battleground": "subterranean",
+				"resource" : "crystal"
 			},
 			"gemPond" : {
 				"index" : 5,
@@ -337,7 +342,8 @@
 				},
 				"sounds" : {
 					"ambient" : ["LOOPGEMP"]
-				}
+				},
+				"resource" : "gems"
 			},
 			"goldMine" : {
 				"index" : 6,
@@ -348,7 +354,8 @@
 				"sounds" : {
 					"ambient" : ["LOOPMINE"]
 				},
-				"battleground": "subterranean"
+				"battleground": "subterranean",
+				"resource" : "gold"
 			},
 			"abandoned" :	{
 				"index" : 7,

--- a/config/objects/moddables.json
+++ b/config/objects/moddables.json
@@ -287,7 +287,8 @@
 				"sounds" : {
 					"ambient" : ["LOOPLUMB"]
 				},
-				"resource" : "wood"
+				"resource" : "wood",
+				"defaultQuantity": 2
 			},
 			"alchemistLab" : {
 				"index" : 1,
@@ -298,7 +299,8 @@
 				"sounds" : {
 					"ambient" : ["LOOPSTAR"]
 				},
-				"resource" : "mercury"
+				"resource" : "mercury",
+				"defaultQuantity": 1
 			},
 			"orePit" : {
 				"index" : 2,
@@ -309,7 +311,8 @@
 				"sounds" : {
 					"ambient" : ["LOOPSULF"]
 				},
-				"resource" : "ore"
+				"resource" : "ore",
+				"defaultQuantity": 2
 			},
 			"sulfurDune" : {
 				"index" : 3,
@@ -320,7 +323,8 @@
 				"sounds" : {
 					"ambient" : ["LOOPSULF"]
 				},
-				"resource" : "sulfur"
+				"resource" : "sulfur",
+				"defaultQuantity": 1
 			},
 			"crystalCavern" : {
 				"index" : 4,
@@ -332,7 +336,8 @@
 					"ambient" : ["LOOPCRYS"]
 				},
 				"battleground": "subterranean",
-				"resource" : "crystal"
+				"resource" : "crystal",
+				"defaultQuantity": 1
 			},
 			"gemPond" : {
 				"index" : 5,
@@ -343,7 +348,8 @@
 				"sounds" : {
 					"ambient" : ["LOOPGEMP"]
 				},
-				"resource" : "gems"
+				"resource" : "gems",
+				"defaultQuantity": 1
 			},
 			"goldMine" : {
 				"index" : 6,
@@ -355,7 +361,8 @@
 					"ambient" : ["LOOPMINE"]
 				},
 				"battleground": "subterranean",
-				"resource" : "gold"
+				"resource" : "gold",
+				"defaultQuantity": 1000
 			},
 			"abandoned" :	{
 				"index" : 7,

--- a/lib/entities/faction/CTownHandler.cpp
+++ b/lib/entities/faction/CTownHandler.cpp
@@ -282,7 +282,31 @@ void CTownHandler::loadBuilding(CTown * town, const std::string & stringID, cons
 
 	ret->subId = vstd::find_or(MappedKeys::SPECIAL_BUILDINGS, source["type"].String(), BuildingSubID::NONE);
 	ret->resources.resolveFromJson(source["cost"]);
-	ret->produce.resolveFromJson(source["produce"]);
+
+	//MODS COMPATIBILITY FOR pre-1.6
+	bool produceEmpty = true;
+	for(auto & res : source["produce"].Struct())
+		if(res.second.Integer() != 0)
+			produceEmpty = false;
+	if(!produceEmpty)
+		ret->produce.resolveFromJson(source["produce"]); // non legacy
+	else if(ret->bid == BuildingID::RESOURCE_SILO)
+	{
+		logGlobal->warn("Resource silo in town '%s' does not produce any resources!", ret->town->faction->getJsonKey());
+		switch (ret->town->primaryRes.toEnum())
+		{
+			case EGameResID::GOLD:
+				ret->produce[ret->town->primaryRes] = 500;
+				break;
+			case EGameResID::WOOD_AND_ORE:
+				ret->produce[EGameResID::WOOD] = 1;
+				ret->produce[EGameResID::ORE] = 1;
+				break;
+			default:
+				ret->produce[ret->town->primaryRes] = 1;
+				break;
+		}
+	}
 
 	ret->manualHeroVisit = source["manualHeroVisit"].Bool();
 	ret->upgradeReplacesBonuses = source["upgradeReplacesBonuses"].Bool();
@@ -325,24 +349,6 @@ void CTownHandler::loadBuilding(CTown * town, const std::string & stringID, cons
 	if(!source["configuration"].isNull())
 		ret->rewardableObjectInfo.init(source["configuration"], ret->getBaseTextID());
 
-	//MODS COMPATIBILITY FOR pre-1.6
-	if(ret->produce.empty() && ret->bid == BuildingID::RESOURCE_SILO)
-	{
-		logGlobal->warn("Resource silo in town '%s' does not produce any resources!", ret->town->faction->getJsonKey());
-		switch (ret->town->primaryRes.toEnum())
-		{
-			case EGameResID::GOLD:
-				ret->produce[ret->town->primaryRes] = 500;
-				break;
-			case EGameResID::WOOD_AND_ORE:
-				ret->produce[EGameResID::WOOD] = 1;
-				ret->produce[EGameResID::ORE] = 1;
-				break;
-			default:
-				ret->produce[ret->town->primaryRes] = 1;
-				break;
-		}
-	}
 	loadBuildingRequirements(ret, source["requires"], requirementsToLoad);
 
 	if (!source["warMachine"].isNull())

--- a/lib/gameState/GameStatistics.cpp
+++ b/lib/gameState/GameStatistics.cpp
@@ -159,7 +159,7 @@ std::string StatisticDataSet::toCsv(std::string sep) const
 {
 	std::stringstream ss;
 
-	auto resources = std::vector<EGameResID>{EGameResID::GOLD, EGameResID::WOOD, EGameResID::MERCURY, EGameResID::ORE, EGameResID::SULFUR, EGameResID::CRYSTAL, EGameResID::GEMS}; //todo: configurable resource support
+	auto resources = LIBRARY->resourceTypeHandler->getAllObjects();
 
 	ss << "Map" << sep;
 	ss << "Timestamp" << sep;

--- a/lib/json/JsonRandom.cpp
+++ b/lib/json/JsonRandom.cpp
@@ -308,17 +308,9 @@ JsonRandom::JsonRandom(IGameInfoCallback * cb, IGameRandomizer & gameRandomizer)
 
 	TResources JsonRandom::loadResource(const JsonNode & value, const Variables & variables)
 	{
-		std::set<GameResID> defaultResources{
-			GameResID::WOOD,
-			GameResID::MERCURY,
-			GameResID::ORE,
-			GameResID::SULFUR,
-			GameResID::CRYSTAL,
-			GameResID::GEMS,
-			GameResID::GOLD
-		}; //todo: configurable resource support
+		auto defaultResources = LIBRARY->resourceTypeHandler->getAllObjects();
 
-		std::set<GameResID> potentialPicks = filterKeys(value, defaultResources, variables);
+		std::set<GameResID> potentialPicks = filterKeys(value, std::set<GameResID>(defaultResources.begin(), defaultResources.end()), variables);
 		GameResID resourceID = *RandomGeneratorUtil::nextItem(potentialPicks, rng);
 		si32 resourceAmount = loadValue(value, variables, 0);
 

--- a/lib/mapObjectConstructors/CObjectClassesHandler.cpp
+++ b/lib/mapObjectConstructors/CObjectClassesHandler.cpp
@@ -67,6 +67,7 @@ CObjectClassesHandler::CObjectClassesHandler()
 	SET_HANDLER_CLASS("shipyard", ShipyardInstanceConstructor);
 	SET_HANDLER_CLASS("monster", CreatureInstanceConstructor);
 	SET_HANDLER_CLASS("resource", ResourceInstanceConstructor);
+	SET_HANDLER_CLASS("mine", MineInstanceConstructor);
 
 	SET_HANDLER_CLASS("static", CObstacleConstructor);
 	SET_HANDLER_CLASS("", CObstacleConstructor);
@@ -88,7 +89,6 @@ CObjectClassesHandler::CObjectClassesHandler()
 	SET_HANDLER("heroPlaceholder", CGHeroPlaceholder);
 	SET_HANDLER("keymaster", CGKeymasterTent);
 	SET_HANDLER("magi", CGMagi);
-	SET_HANDLER("mine", CGMine);
 	SET_HANDLER("obelisk", CGObelisk);
 	SET_HANDLER("pandora", CGPandoraBox);
 	SET_HANDLER("prison", CGHeroInstance);

--- a/lib/mapObjectConstructors/CommonConstructors.cpp
+++ b/lib/mapObjectConstructors/CommonConstructors.cpp
@@ -90,6 +90,22 @@ void ResourceInstanceConstructor::randomizeObject(CGResource * object, IGameRand
 		object->amount = 5 * getAmountMultiplier();
 }
 
+void MineInstanceConstructor::initTypeData(const JsonNode & input)
+{
+	config = input;
+
+	resourceType = GameResID::NONE; //set up fallback
+	LIBRARY->identifiers()->requestIdentifierIfNotNull("resource", input["resource"], [&](si32 index)
+	{
+		resourceType = GameResID(index);
+	});
+}
+
+GameResID MineInstanceConstructor::getResourceType() const
+{
+	return resourceType;
+}
+
 void CTownInstanceConstructor::initTypeData(const JsonNode & input)
 {
 	LIBRARY->identifiers()->requestIdentifier("faction", input["faction"], [&](si32 index)

--- a/lib/mapObjectConstructors/CommonConstructors.cpp
+++ b/lib/mapObjectConstructors/CommonConstructors.cpp
@@ -25,6 +25,7 @@
 #include "../mapping/TerrainTile.h"
 #include "../modding/IdentifierStorage.h"
 #include "../texts/TextIdentifier.h"
+#include "../texts/CGeneralTextHandler.h"
 
 VCMI_LIB_NAMESPACE_BEGIN
 
@@ -99,11 +100,27 @@ void MineInstanceConstructor::initTypeData(const JsonNode & input)
 	{
 		resourceType = GameResID(index);
 	});
+
+	if (!config["name"].isNull())
+		LIBRARY->generaltexth->registerString(config.getModScope(), getNameTextID(), config["name"]);
+
+	if (!config["description"].isNull())
+		LIBRARY->generaltexth->registerString(config.getModScope(), getDescriptionTextID(), config["description"]);
 }
 
 GameResID MineInstanceConstructor::getResourceType() const
 {
 	return resourceType;
+}
+
+std::string MineInstanceConstructor::getDescriptionTextID() const
+{
+	return TextIdentifier(getBaseTextID(), "description").get();
+}
+
+std::string MineInstanceConstructor::getDescriptionTranslated() const
+{
+	return LIBRARY->generaltexth->translate(getDescriptionTextID());
 }
 
 void CTownInstanceConstructor::initTypeData(const JsonNode & input)

--- a/lib/mapObjectConstructors/CommonConstructors.cpp
+++ b/lib/mapObjectConstructors/CommonConstructors.cpp
@@ -100,6 +100,7 @@ void MineInstanceConstructor::initTypeData(const JsonNode & input)
 	{
 		resourceType = GameResID(index);
 	});
+	defaultQuantity = !config["defaultQuantity"].isNull() ? config["defaultQuantity"].Integer() : 1;
 
 	if (!config["name"].isNull())
 		LIBRARY->generaltexth->registerString(config.getModScope(), getNameTextID(), config["name"]);
@@ -111,6 +112,11 @@ void MineInstanceConstructor::initTypeData(const JsonNode & input)
 GameResID MineInstanceConstructor::getResourceType() const
 {
 	return resourceType;
+}
+
+ui32 MineInstanceConstructor::getDefaultQuantity() const
+{
+	return defaultQuantity;
 }
 
 std::string MineInstanceConstructor::getDescriptionTextID() const

--- a/lib/mapObjectConstructors/CommonConstructors.h
+++ b/lib/mapObjectConstructors/CommonConstructors.h
@@ -62,6 +62,16 @@ public:
 	void randomizeObject(CGResource * object, IGameRandomizer & gameRandomizer) const override;
 };
 
+class DLL_LINKAGE MineInstanceConstructor : public CDefaultObjectTypeHandler<CGMine>
+{
+	JsonNode config;
+	GameResID resourceType;
+public:
+	void initTypeData(const JsonNode & input) override;
+
+	GameResID getResourceType() const;
+};
+
 class CTownInstanceConstructor : public CDefaultObjectTypeHandler<CGTownInstance>
 {
 	JsonNode filtersJson;

--- a/lib/mapObjectConstructors/CommonConstructors.h
+++ b/lib/mapObjectConstructors/CommonConstructors.h
@@ -70,6 +70,8 @@ public:
 	void initTypeData(const JsonNode & input) override;
 
 	GameResID getResourceType() const;
+	std::string getDescriptionTextID() const;
+	std::string getDescriptionTranslated() const;
 };
 
 class CTownInstanceConstructor : public CDefaultObjectTypeHandler<CGTownInstance>

--- a/lib/mapObjectConstructors/CommonConstructors.h
+++ b/lib/mapObjectConstructors/CommonConstructors.h
@@ -66,10 +66,12 @@ class DLL_LINKAGE MineInstanceConstructor : public CDefaultObjectTypeHandler<CGM
 {
 	JsonNode config;
 	GameResID resourceType;
+	ui32 defaultQuantity;
 public:
 	void initTypeData(const JsonNode & input) override;
 
 	GameResID getResourceType() const;
+	ui32 getDefaultQuantity() const;
 	std::string getDescriptionTextID() const;
 	std::string getDescriptionTranslated() const;
 };

--- a/lib/mapObjects/CGResource.cpp
+++ b/lib/mapObjects/CGResource.cpp
@@ -61,7 +61,7 @@ void CGResource::pickRandomObject(IGameRandomizer & gameRandomizer)
 	if (ID == Obj::RANDOM_RESOURCE)
 	{
 		ID = Obj::RESOURCE;
-		subID = gameRandomizer.getDefault().nextInt(EGameResID::WOOD, EGameResID::GOLD); //todo: configurable resource support
+		subID = gameRandomizer.getDefault().nextInt(EGameResID::WOOD, LIBRARY->resourceTypeHandler->getAllObjects().size() - 1);
 		setType(ID, subID);
 
 		amount *= getAmountMultiplier();

--- a/lib/mapObjects/CGResource.h
+++ b/lib/mapObjects/CGResource.h
@@ -26,13 +26,14 @@ class DLL_LINKAGE CGResource : public CArmedInstance
 	static constexpr uint32_t RANDOM_AMOUNT = 0;
 	uint32_t amount = RANDOM_AMOUNT; //0 if random
 
-	std::shared_ptr<ResourceInstanceConstructor> getResourceHandler() const;
 	int getAmountMultiplier() const;
 	void collectRes(IGameEventCallback & gameEvents, const PlayerColor & player) const;
 	void serializeJsonOptions(JsonSerializeFormat & handler) override;
 
 public:
 	using CArmedInstance::CArmedInstance;
+	
+	std::shared_ptr<ResourceInstanceConstructor> getResourceHandler() const;
 
 	void onHeroVisit(IGameEventCallback & gameEvents, const CGHeroInstance * h) const override;
 	void initObj(IGameRandomizer & gameRandomizer) override;

--- a/lib/mapObjects/MiscObjects.cpp
+++ b/lib/mapObjects/MiscObjects.cpp
@@ -171,7 +171,7 @@ std::string CGMine::getObjectName() const
 	if(getResourceHandler()->getResourceType() == GameResID::NONE || getObjTypeIndex() < GameConstants::RESOURCE_QUANTITY)
 		return LIBRARY->generaltexth->translate("core.minename", getObjTypeIndex());
 	else
-		return getResourceHandler()->getResourceType().toResource()->getNameTranslated() + " " + LIBRARY->generaltexth->translate("core.genrltxt.617"); // TODO: new strings for new mines
+		return getResourceHandler()->getNameTranslated();
 }
 
 std::string CGMine::getHoverText(PlayerColor player) const
@@ -201,7 +201,7 @@ void CGMine::flagMine(IGameEventCallback & gameEvents, const PlayerColor & playe
 	if(getResourceHandler()->getResourceType() == GameResID::NONE || getObjTypeIndex() < GameConstants::RESOURCE_QUANTITY)
 		iw.text.appendTextID(TextIdentifier("core.mineevnt", producedResource.getNum()).get()); //not use subID, abandoned mines uses default mine texts
 	else
-		iw.text.appendRawString(getObjectName()); // TODO: new strings for new mines
+		iw.text.appendRawString(getResourceHandler()->getDescriptionTranslated());
 	iw.player = player;
 	iw.components.emplace_back(ComponentType::RESOURCE_PER_DAY, producedResource, getProducedQuantity());
 	gameEvents.showInfoDialog(&iw);

--- a/lib/mapObjects/MiscObjects.cpp
+++ b/lib/mapObjects/MiscObjects.cpp
@@ -209,16 +209,7 @@ void CGMine::flagMine(IGameEventCallback & gameEvents, const PlayerColor & playe
 
 ui32 CGMine::defaultResProduction() const
 {
-	switch(producedResource.toEnum())
-	{
-	case EGameResID::WOOD:
-	case EGameResID::ORE:
-		return 2;
-	case EGameResID::GOLD:
-		return 1000;
-	default:
-		return 1;
-	}
+	return getResourceHandler()->getDefaultQuantity();
 }
 
 ui32 CGMine::getProducedQuantity() const

--- a/lib/mapObjects/MiscObjects.cpp
+++ b/lib/mapObjects/MiscObjects.cpp
@@ -209,6 +209,19 @@ void CGMine::flagMine(IGameEventCallback & gameEvents, const PlayerColor & playe
 
 ui32 CGMine::defaultResProduction() const
 {
+	if(isAbandoned())
+	{
+		switch(producedResource.toEnum())
+		{
+		case EGameResID::WOOD:
+		case EGameResID::ORE:
+			return 2;
+		case EGameResID::GOLD:
+			return 1000;
+		default:
+			return 1;
+		}
+	}
 	return getResourceHandler()->getDefaultQuantity();
 }
 

--- a/lib/mapObjects/MiscObjects.cpp
+++ b/lib/mapObjects/MiscObjects.cpp
@@ -30,6 +30,7 @@
 #include "../serializer/JsonSerializeFormat.h"
 #include "../mapObjectConstructors/AObjectTypeHandler.h"
 #include "../mapObjectConstructors/CObjectClassesHandler.h"
+#include "../mapObjectConstructors/CommonConstructors.h"
 #include "../mapObjects/CGHeroInstance.h"
 #include "../networkPacks/PacksForClient.h"
 #include "../networkPacks/PacksForClientBattle.h"
@@ -74,6 +75,13 @@ bool CTeamVisited::wasVisited(const TeamID & team) const
 }
 
 //CGMine
+std::shared_ptr<MineInstanceConstructor> CGMine::getResourceHandler() const
+{
+	const auto & baseHandler = getObjectHandler();
+	const auto & ourHandler = std::dynamic_pointer_cast<MineInstanceConstructor>(baseHandler);
+	return ourHandler;
+}
+
 void CGMine::onHeroVisit(IGameEventCallback & gameEvents, const CGHeroInstance * h) const
 {
 	auto relations = cb->getPlayerRelations(h->tempOwner, tempOwner);
@@ -120,14 +128,17 @@ void CGMine::initObj(IGameRandomizer & gameRandomizer)
 	}
 	else
 	{
-		producedResource = GameResID(getObjTypeIndex().getNum());
+		if(getResourceHandler()->getResourceType() == GameResID::NONE) // fallback
+			producedResource = GameResID(getObjTypeIndex().getNum());
+		else
+			producedResource = getResourceHandler()->getResourceType();
 	}
 	producedQuantity = defaultResProduction();
 }
 
 bool CGMine::isAbandoned() const
 {
-	return subID.getNum() >= 7;
+	return subID.getNum() >= 7 && getResourceHandler()->getResourceType() == GameResID::NONE;
 }
 
 const IOwnableObject * CGMine::asOwnable() const
@@ -157,7 +168,10 @@ ResourceSet CGMine::dailyIncome() const
 
 std::string CGMine::getObjectName() const
 {
-	return LIBRARY->generaltexth->translate("core.minename", getObjTypeIndex());
+	if(getResourceHandler()->getResourceType() == GameResID::NONE || getObjTypeIndex() < GameConstants::RESOURCE_QUANTITY)
+		return LIBRARY->generaltexth->translate("core.minename", getObjTypeIndex());
+	else
+		return getResourceHandler()->getResourceType().toResource()->getNameTranslated() + " " + LIBRARY->generaltexth->translate("core.genrltxt.617"); // TODO: new strings for new mines
 }
 
 std::string CGMine::getHoverText(PlayerColor player) const
@@ -184,7 +198,10 @@ void CGMine::flagMine(IGameEventCallback & gameEvents, const PlayerColor & playe
 
 	InfoWindow iw;
 	iw.type = EInfoWindowMode::AUTO;
-	iw.text.appendTextID(TextIdentifier("core.mineevnt", producedResource.getNum()).get()); //not use subID, abandoned mines uses default mine texts
+	if(getResourceHandler()->getResourceType() == GameResID::NONE || getObjTypeIndex() < GameConstants::RESOURCE_QUANTITY)
+		iw.text.appendTextID(TextIdentifier("core.mineevnt", producedResource.getNum()).get()); //not use subID, abandoned mines uses default mine texts
+	else
+		iw.text.appendRawString(getObjectName()); // TODO: new strings for new mines
 	iw.player = player;
 	iw.components.emplace_back(ComponentType::RESOURCE_PER_DAY, producedResource, getProducedQuantity());
 	gameEvents.showInfoDialog(&iw);

--- a/lib/mapObjects/MiscObjects.cpp
+++ b/lib/mapObjects/MiscObjects.cpp
@@ -251,35 +251,7 @@ void CGMine::serializeJsonOptions(JsonSerializeFormat & handler)
 	CArmedInstance::serializeJsonOptions(handler);
 	serializeJsonOwner(handler);
 	if(isAbandoned())
-	{
-		if(handler.saving)
-		{
-			JsonNode node;
-			for(const auto & resID : abandonedMineResources)
-				node.Vector().emplace_back(resID.toResource()->getJsonKey());
-
-			handler.serializeRaw("possibleResources", node, std::nullopt);
-		}
-		else
-		{
-			auto guard = handler.enterArray("possibleResources");
-			const JsonNode & node = handler.getCurrent();
-
-			auto names = node.convertTo<std::vector<std::string>>();
-
-			for(const std::string & s : names)
-			{
-				std::vector<std::string> resNames;
-				for(auto & res : LIBRARY->resourceTypeHandler->getAllObjects())
-					resNames.push_back(res.toResource()->getJsonKey());
-				int raw_res = vstd::find_pos(resNames, s);
-				if(raw_res < 0)
-					logGlobal->error("Invalid resource name: %s", s);
-				else
-					abandonedMineResources.emplace(raw_res);
-			}
-		}
-	}
+		handler.serializeIdArray<GameResID>("possibleResources", abandonedMineResources);
 }
 
 bool CGTeleport::isEntrance() const

--- a/lib/mapObjects/MiscObjects.h
+++ b/lib/mapObjects/MiscObjects.h
@@ -18,6 +18,7 @@ VCMI_LIB_NAMESPACE_BEGIN
 
 class CMap;
 class UpgradeInfo;
+class MineInstanceConstructor;
 
 // This one teleport-specific, but has to be available everywhere in callbacks and netpacks
 // For now it's will be there till teleports code refactored and moved into own file
@@ -144,6 +145,8 @@ public:
 	ui32 producedQuantity;
 	std::set<GameResID> abandonedMineResources;
 	bool isAbandoned() const;
+	
+	std::shared_ptr<MineInstanceConstructor> getResourceHandler() const;
 private:
 	using CArmedInstance::CArmedInstance;
 

--- a/lib/rmg/modificators/MinePlacer.cpp
+++ b/lib/rmg/modificators/MinePlacer.cpp
@@ -23,6 +23,7 @@
 #include "RoadPlacer.h"
 #include "WaterAdopter.h"
 #include "../TileInfo.h"
+#include "../../entities/ResourceTypeHandler.h"
 
 #include <vstd/RNG.h>
 
@@ -65,6 +66,12 @@ bool MinePlacer::placeMines(ObjectManager & manager)
 				auto handler = std::dynamic_pointer_cast<MineInstanceConstructor>(LIBRARY->objtypeh->getHandlerFor(Obj::MINE, subObjID));
 				if(handler->getResourceType() == res)
 					mineHandler = handler;
+			}
+
+			if(!mineHandler)
+			{
+				logGlobal->error("No mine for resource %s found!", res.toResource()->getJsonKey());
+				continue;
 			}
 
 			const auto & rmginfo = mineHandler->getRMGInfo();

--- a/lib/rmg/modificators/MinePlacer.cpp
+++ b/lib/rmg/modificators/MinePlacer.cpp
@@ -12,6 +12,7 @@
 #include "../RmgMap.h"
 #include "../../mapObjectConstructors/AObjectTypeHandler.h"
 #include "../../mapObjectConstructors/CObjectClassesHandler.h"
+#include "../../mapObjectConstructors/CommonConstructors.h"
 #include "../../mapObjects/CGResource.h"
 #include "../../mapObjects/MiscObjects.h"
 #include "../../mapping/CMapEditManager.h"
@@ -58,7 +59,14 @@ bool MinePlacer::placeMines(ObjectManager & manager)
 		const auto res = GameResID(mineInfo.first);
 		for(int i = 0; i < mineInfo.second; ++i)
 		{
-			auto mineHandler = LIBRARY->objtypeh->getHandlerFor(Obj::MINE, res);
+			TObjectTypeHandler mineHandler;
+			for(auto & subObjID : LIBRARY->objtypeh->knownSubObjects(Obj::MINE))
+			{
+				auto handler = std::dynamic_pointer_cast<MineInstanceConstructor>(LIBRARY->objtypeh->getHandlerFor(Obj::MINE, subObjID));
+				if(handler->getResourceType() == res)
+					mineHandler = handler;
+			}
+
 			const auto & rmginfo = mineHandler->getRMGInfo();
 			auto mine = std::dynamic_pointer_cast<CGMine>(mineHandler->create(map.mapInstance->cb, nullptr));
 			mine->producedResource = res;

--- a/lib/serializer/JsonSerializeFormat.h
+++ b/lib/serializer/JsonSerializeFormat.h
@@ -346,7 +346,8 @@ public:
 		}
 		else
 		{
-			for (const auto & [keyStr, jsonVal] : getCurrent()[fieldName].Struct())
+			const auto & node = getCurrent()[fieldName].Struct();
+			for (const auto & [keyStr, jsonVal] : node)
 			{
 				LIBRARY->identifiers()->requestIdentifier(jsonVal.getModScope(), Key::entityType(), keyStr, [&value, jsonVal](int32_t index) {
 					value[Key(index)] = jsonVal.Integer(); // TODO: only int supported yet

--- a/lib/serializer/JsonSerializeFormat.h
+++ b/lib/serializer/JsonSerializeFormat.h
@@ -346,13 +346,10 @@ public:
 		}
 		else
 		{
-			const JsonNode & node = getCurrent()[fieldName];
-			for (const auto & [keyStr, jsonVal] : node.Struct())
+			for (const auto & [keyStr, jsonVal] : getCurrent()[fieldName].Struct())
 			{
-				Key key = Key::decode(keyStr);
-
-				LIBRARY->identifiers()->requestIdentifier(jsonVal.getModScope(), Key::entityType(), keyStr, [&value, key](int32_t index) {
-					value[key] = T(index);
+				LIBRARY->identifiers()->requestIdentifier(jsonVal.getModScope(), Key::entityType(), keyStr, [&value, jsonVal](int32_t index) {
+					value[Key(index)] = jsonVal.Integer(); // TODO: only int supported yet
 				});
 			}
 		}

--- a/lib/serializer/JsonSerializeFormat.h
+++ b/lib/serializer/JsonSerializeFormat.h
@@ -347,10 +347,10 @@ public:
 		else
 		{
 			const auto & node = getCurrent()[fieldName].Struct();
-			for (const auto & [keyStr, jsonVal] : node)
+			for (const auto & n : node)
 			{
-				LIBRARY->identifiers()->requestIdentifier(jsonVal.getModScope(), Key::entityType(), keyStr, [&value, jsonVal](int32_t index) {
-					value[Key(index)] = jsonVal.Integer(); // TODO: only int supported yet
+				LIBRARY->identifiers()->requestIdentifier(n.second.getModScope(), Key::entityType(), n.first, [&value, n](int32_t index) {
+					value[Key(index)] = n.second.Integer(); // TODO: only int supported yet
 				});
 			}
 		}

--- a/lib/serializer/JsonSerializeFormat.h
+++ b/lib/serializer/JsonSerializeFormat.h
@@ -351,7 +351,7 @@ public:
 			{
 				Key key = Key::decode(keyStr);
 
-				LIBRARY->identifiers()->requestIdentifier(node.getModScope(), Key::entityType(), keyStr, [&value, key](int32_t index) {
+				LIBRARY->identifiers()->requestIdentifier(jsonVal.getModScope(), Key::entityType(), keyStr, [&value, key](int32_t index) {
 					value[key] = T(index);
 				});
 			}

--- a/mapeditor/inspector/inspector.cpp
+++ b/mapeditor/inspector/inspector.cpp
@@ -402,7 +402,8 @@ void Inspector::updateProperties(CGMine * o)
 	if(!o) return;
 	
 	addProperty(QObject::tr("Owner"), o->tempOwner, new OwnerDelegate(controller), false);
-	addProperty(QObject::tr("Resource"), o->producedResource);
+	if(o->producedResource != GameResID::NONE)
+		addProperty(QObject::tr("Resource"), o->producedResource);
 	addProperty(QObject::tr("Productivity"), o->producedQuantity);
 }
 

--- a/mapeditor/inspector/inspector.cpp
+++ b/mapeditor/inspector/inspector.cpp
@@ -15,6 +15,7 @@
 #include "../lib/CRandomGenerator.h"
 #include "../lib/mapObjectConstructors/AObjectTypeHandler.h"
 #include "../lib/mapObjectConstructors/CObjectClassesHandler.h"
+#include "../lib/mapObjectConstructors/CommonConstructors.h"
 #include "../lib/mapObjects/ObjectTemplate.h"
 #include "../lib/mapping/CMap.h"
 #include "../lib/constants/StringConstants.h"
@@ -228,7 +229,10 @@ void Initializer::initialize(CGMine * o)
 	}
 	else
 	{
-		o->producedResource = GameResID(o->subID);
+		if(o->getResourceHandler()->getResourceType() == GameResID::NONE) // fallback
+			o->producedResource = GameResID(o->subID);
+		else
+			o->producedResource = o->getResourceHandler()->getResourceType();
 		o->producedQuantity = o->defaultResProduction();
 	}
 }

--- a/mapeditor/mapcontroller.cpp
+++ b/mapeditor/mapcontroller.cpp
@@ -17,6 +17,7 @@
 #include "../lib/entities/hero/CHeroHandler.h"
 #include "../lib/mapObjectConstructors/AObjectTypeHandler.h"
 #include "../lib/mapObjectConstructors/CObjectClassesHandler.h"
+#include "../lib/mapObjectConstructors/CommonConstructors.h"
 #include "../lib/mapObjects/ObjectTemplate.h"
 #include "../lib/mapping/CMapService.h"
 #include "../lib/mapping/CMap.h"
@@ -208,7 +209,10 @@ void MapController::repairMap(CMap * map)
 		{
 			if(!mine->isAbandoned())
 			{
-				mine->producedResource = GameResID(mine->subID);
+				if(mine->getResourceHandler()->getResourceType() == GameResID::NONE) // fallback
+					mine->producedResource = GameResID(mine->subID);
+				else
+					mine->producedResource = mine->getResourceHandler()->getResourceType();
 				mine->producedQuantity = mine->defaultResProduction();
 			}
 		}


### PR DESCRIPTION
Make mines configurable

<img width="267" height="256" alt="grafik" src="https://github.com/user-attachments/assets/6d564cd0-1d6c-4f61-b1e9-ee519da46649" />

```
{
	"core:mine" : {
		"types" : {
			"mithrilMine" : {
				"name" : "Mithrilmine",
				"description" : "{Mithrilmine}\n\nYou gain control of a Mithrilmine. It will provide you with 2 mithril per day.",
				"aiValue" : 1500,
				"rmg" : {
					"value" : 1500
				},
				"sounds" : {
					"ambient" : ["LOOPLUMB"]
				},
				"resource" : "mithril",
				"defaultQuantity": 2,
				"templates" : {
					"avwrhsmt" : {
						"animation" : "mithril/AVMGOSW1",
						"visitableFrom" : [
							"---",
							"-++",
							"+++"
						],
						"mask" : [
							"VVV",
							"VVV",
							"VBA"
						]
					}
				}
			}
		}
	}
}
```

Missing: Kingdom overview icon (for a later PR), similar to #6099

Hint: RMG Template needs to support the resource to show up on random map.