### PR TITLE
Use performNativeCopy instead of copy

### DIFF
--- a/launcher/helper.cpp
+++ b/launcher/helper.cpp
@@ -21,7 +21,6 @@
 
 #ifdef VCMI_ANDROID
 #include <QAndroidJniObject>
-#include <QAndroidJniEnvironment>
 #include <QtAndroid>
 #endif
 
@@ -102,19 +101,14 @@ bool performNativeCopy(QString src, QString dst)
 		return QString::fromUtf8(QUrl::toPercentEncoding(uri, "!#$&'()*+,/:;=?@[]<>{}\"`^~%"));
 	};
 
-	QAndroidJniEnvironment env;
 	auto srcStr = QAndroidJniObject::fromString(safeEncode(src));
 	auto dstStr = QAndroidJniObject::fromString(safeEncode(dst));
 	QAndroidJniObject::callStaticObjectMethod("eu/vcmi/vcmi/util/FileUtil", "copyFileFromUri", "(Ljava/lang/String;Ljava/lang/String;Landroid/content/Context;)V", srcStr.object<jstring>(), dstStr.object<jstring>(), QtAndroid::androidContext().object());
 
-	if(env->ExceptionCheck())
-	{
-		env->ExceptionDescribe();
-		env->ExceptionClear();
+	if(QFileInfo(dst).exists())
+		return true;
+	else
 		return false;
-	}
-
-	return QFileInfo(dst).exists();
 #else
 	return QFile::copy(src, dst);
 #endif

--- a/launcher/helper.cpp
+++ b/launcher/helper.cpp
@@ -102,6 +102,7 @@ bool performNativeCopy(QString src, QString dst)
 		return QString::fromUtf8(QUrl::toPercentEncoding(uri, "!#$&'()*+,/:;=?@[]<>{}\"`^~%"));
 	};
 
+	QAndroidJniEnvironment env;
 	auto srcStr = QAndroidJniObject::fromString(safeEncode(src));
 	auto dstStr = QAndroidJniObject::fromString(safeEncode(dst));
 	QAndroidJniObject::callStaticObjectMethod("eu/vcmi/vcmi/util/FileUtil", "copyFileFromUri", "(Ljava/lang/String;Ljava/lang/String;Landroid/content/Context;)V", srcStr.object<jstring>(), dstStr.object<jstring>(), QtAndroid::androidContext().object());

--- a/launcher/helper.cpp
+++ b/launcher/helper.cpp
@@ -115,7 +115,7 @@ bool performNativeCopy(QString src, QString dst)
 
 	return QFileInfo(dst).exists();
 #else
-	QFile::copy(src, dst);
+	return QFile::copy(src, dst);
 #endif
 }
 

--- a/launcher/helper.h
+++ b/launcher/helper.h
@@ -20,7 +20,7 @@ void loadSettings();
 void reLoadSettings();
 void enableScrollBySwiping(QObject * scrollTarget);
 QString getRealPath(QString path);
-void performNativeCopy(QString src, QString dst);
+bool performNativeCopy(QString src, QString dst);
 void revealDirectoryInFileBrowser(QString path);
 MainWindow * getMainWindow();
 void keepScreenOn(bool isEnabled);

--- a/launcher/mainwindow_moc.cpp
+++ b/launcher/mainwindow_moc.cpp
@@ -295,7 +295,7 @@ void MainWindow::manualInstallFile(QString filePath)
 			{
 				const auto configFilePath = configDir.filePath(configFile[0]);
 				QFile::remove(configFilePath);
-				QFile::copy(filePath, configFilePath);
+				Helper::performNativeCopy(filePath, configFilePath);
 
 				Helper::reLoadSettings();
 			}

--- a/launcher/modManager/chroniclesextractor.cpp
+++ b/launcher/modManager/chroniclesextractor.cpp
@@ -133,7 +133,7 @@ void ChroniclesExtractor::createBaseMod() const
 		{
 			QDir().mkpath(pathToQString(destFolder));
 			QFile::remove(destFile);
-			QFile::copy(file, destFile);
+			Helper::performNativeCopy(file, destFile);
 		}
 	}
 }
@@ -237,7 +237,7 @@ void ChroniclesExtractor::extractFiles(int no) const
 				continue;
 			auto srcName = vstd::reverseMap(mapping).at(no);
 			auto dstName = (no == 7 || no == 8) ? srcName : "Intro";
-			QFile::copy(tmpDir.filePath(QString::fromStdString(srcName + ending)), outDirVideo.filePath(QString::fromStdString(dstName + ending)));
+			Helper::performNativeCopy(tmpDir.filePath(QString::fromStdString(srcName + ending)), outDirVideo.filePath(QString::fromStdString(dstName + ending)));
 		}
 	}
 

--- a/launcher/modManager/cmodlistview_moc.cpp
+++ b/launcher/modManager/cmodlistview_moc.cpp
@@ -1212,7 +1212,7 @@ void CModListView::installMaps(QStringList maps)
 				QFile::remove(destFile);
 			}
 
-			if (QFile::copy(map, destFile))
+			if (Helper::performNativeCopy(map, destFile))
 				successCount++;
 			else
 			{

--- a/launcher/prepare_android.cpp
+++ b/launcher/prepare_android.cpp
@@ -10,6 +10,7 @@
 #include "StdInc.h"
 #include "prepare_p.h"
 #include "../lib/CAndroidVMHelper.h"
+#include "helper.h"
 
 #include <QDir>
 #include <QFile>
@@ -41,7 +42,7 @@ bool copyRecursively(const QString & srcFilePath, const QString & tgtFilePath)
 				return false;
 		}
 	} else {
-		if(!QFile::copy(srcFilePath, tgtFilePath))
+		if(!Helper::performNativeCopy(srcFilePath, tgtFilePath))
 			return false;
 	}
 	return true;

--- a/launcher/prepare_android.cpp
+++ b/launcher/prepare_android.cpp
@@ -10,7 +10,6 @@
 #include "StdInc.h"
 #include "prepare_p.h"
 #include "../lib/CAndroidVMHelper.h"
-#include "helper.h"
 
 #include <QDir>
 #include <QFile>
@@ -42,7 +41,7 @@ bool copyRecursively(const QString & srcFilePath, const QString & tgtFilePath)
 				return false;
 		}
 	} else {
-		if(!Helper::performNativeCopy(srcFilePath, tgtFilePath))
+		if(!QFile::copy(srcFilePath, tgtFilePath))
 			return false;
 	}
 	return true;


### PR DESCRIPTION
This should fix all issues with spaces in filenames on Android.

1) Changed performNativeCopy to bool
2) Narroved getRealPath to same logic with path encodig using safeEncode
3) Replaced QFile::copy with Helper::performNativeCopy where possible. Now remains only in prepare_android.cpp - when I tried to replace it here too, Launcher crashed on load without any error. So keeping this file as is.

Now EXE / ZIP with spaces can be safely imported on Android devices using Launcher.