### PR TITLE
left mouse drag on advmap improvement

### DIFF
--- a/client/mapView/MapViewActions.cpp
+++ b/client/mapView/MapViewActions.cpp
@@ -18,6 +18,7 @@
 #include "../GameEngine.h"
 #include "../gui/CursorHandler.h"
 #include "../gui/MouseButton.h"
+#include "../render/IScreenHandler.h"
 
 #include "../CPlayerInterface.h"
 #include "../adventureMap/CInGameConsole.h"
@@ -99,7 +100,7 @@ void MapViewActions::mouseDragged(const Point & cursorPosition, const Point & la
 {
 	dragDistance += lastUpdateDistance;
 
-	if (dragDistance.length() > 16)
+	if ((dragDistance.length() * ENGINE->screenHandler().getInterfaceScalingPercentage() / 100) > 12)
 		dragActive = true;
 
 	if (dragActive && settings["adventure"]["leftButtonDrag"].Bool())


### PR DESCRIPTION
- use `getInterfaceScalingPercentage` to avoid the need of more mouse distance on higher scaling percents
- reduce threshold to 12 (should be enough - is more fluid)