### PR TITLE
PROPOSAL: Add Patch Category for Mods

### DIFF
--- a/config/schemas/mod.json
+++ b/config/schemas/mod.json
@@ -65,7 +65,7 @@
 		},
 		"modType" : {
 			"type" : "string",
-			"enum" : [ "Translation", "Town", "Test", "Templates", "Spells", "Music", "Maps", "Sounds", "Skills", "Other", "Objects", "Mechanics", "Interface", "Heroes", "Graphical", "Expansion", "Creatures", "Compatibility", "Campaigns", "Artifacts", "AI", "Resources" ],
+			"enum" : [ "Translation", "Town", "Test", "Templates", "Spells", "Music", "Maps", "Sounds", "Skills", "Other", "Objects", "Mechanics", "Interface", "Heroes", "Graphical", "Expansion", "Creatures", "Compatibility", "Campaigns", "Artifacts", "AI", "Resources", "Patch" ],
 			"description" : "Type of mod, e.g. Town, Artifacts, Graphical."
 		},
 		"author" : {

--- a/docs/modders/Mod_File_Format.md
+++ b/docs/modders/Mod_File_Format.md
@@ -31,7 +31,7 @@
 
 	// Type of mod, list of all possible values:
 	// "Translation", "Town", "Test", "Templates", "Spells", "Music", "Maps", "Sounds", "Skills", "Other", "Objects", 
-	// "Mechanics", "Interface", "Heroes", "Graphical", "Expansion", "Creatures", "Compatibility", "Campaigns", "Artifacts", "AI", "Resources"
+	// "Mechanics", "Interface", "Heroes", "Graphical", "Expansion", "Creatures", "Compatibility", "Campaigns", "Artifacts", "AI", "Resources", "Patch"
 	//
 	// Some mod types have additional effects on your mod:
 	// Translation: mod of this type is only active if player uses base language of this mod. See "language" property. 

--- a/launcher/modManager/modstateitemmodel_moc.cpp
+++ b/launcher/modManager/modstateitemmodel_moc.cpp
@@ -55,6 +55,7 @@ QString ModStateItemModel::modTypeName(QString modTypeID) const
 		QT_TR_NOOP("Artifacts"),
 		QT_TR_NOOP("AI"),
 		QT_TR_NOOP("Resources"),
+		QT_TR_NOOP("Patch"),
 	};
 
 	if (modTypes.contains(modTypeID))


### PR DESCRIPTION
I would like to suggest adding "Patch" as a category for modType. This would differ from "Compatibility" in that it would not be hidden by the UI. This would be for optional feature patches between mods. For example, typically Fused Upgrades converts combination artifacts into fused artifacts. Some mods add Combination artifacts such as Third Upgrades Mod adding the Magic Compendium. For balance reasons, players may not want the combination artifacts from certain mods to become fused artifacts. By using the category "Compatibility", this choice is taken away from players and it is forcibly applied under the hood if Fused Artifacts adds a compatibility mod for Third Upgrades. This proposal allows patches that can be added either as submods or completely independently that can be toggled and managed by the user in the mod manager, while still allowing other critical compatibility fixes to remain transparent to the player.