### PR TITLE
Avoid crash when town has out-of-bounds visitablePos (null TerrainTile)

### DIFF
--- a/lib/mapObjects/CGTownInstance.cpp
+++ b/lib/mapObjects/CGTownInstance.cpp
@@ -698,7 +698,15 @@ ObjectInstanceID CGTownInstance::getObjInstanceID() const
 
 void CGTownInstance::updateAppearance()
 {
-	auto terrain = cb->getTile(visitablePos())->getTerrainID();
+	const auto tile = cb->getTile(visitablePos());
+	if(!tile)
+	{
+		logGlobal->warn("Town is misplaced at (%d, %d, %d)", visitablePos().x,
+				visitablePos().y, visitablePos().z);
+		return;
+	}
+
+	auto terrain = tile->getTerrainID();
 	//FIXME: not the best way to do this
 	auto app = getObjectHandler()->getOverride(terrain, this);
 	if (app)


### PR DESCRIPTION
- Add a guard in `CGTownInstance::updateAppearance()` to handle `cb->getTile(visitablePos()) == nullptr`
- When no tile is returned (e.g., position is outside map bounds), log a warning and return early.
- Fixes SIGSEGV during map load on some community maps, e.g. `Into The Depths of Hell`