### PR TITLE
Fix buffered stream growth & decode river type from low 3 bits (compat for “A War” AB map)

### DIFF
--- a/lib/filesystem/CCompressedStream.cpp
+++ b/lib/filesystem/CCompressedStream.cpp
@@ -65,10 +65,10 @@ void CBufferedStream::ensureSize(si64 size)
 	while(static_cast<si64>(buffer.size()) < size && !endOfFileReached)
 	{
 		si64 initialSize = buffer.size();
-		si64 currentStep = std::min<si64>(size, buffer.size());
+		si64 need = size - buffer.size();
 		// to avoid large number of calls at start
 		// this is often used to load h3m map headers, most of which are ~300 bytes in size
-		vstd::amax(currentStep, 512);
+		si64 currentStep = std::min<si64>(need, std::max<si64>(initialSize, si64{512}));
 
 		buffer.resize(initialSize + currentStep);
 

--- a/lib/mapping/MapReaderH3M.cpp
+++ b/lib/mapping/MapReaderH3M.cpp
@@ -199,9 +199,11 @@ RoadId MapReaderH3M::readRoad()
 
 RiverId MapReaderH3M::readRiver()
 {
-	RiverId result(readInt8());
-	assert(result.getNum() <= features.riversCount);
-	return result;
+	const uint8_t raw = readInt8();
+	// Keep low 3 bits as river type (0..4); discard high-bit flags set by some editors (HotA ?)
+	const uint8_t type = raw & 0x07;
+	assert(type <= features.riversCount);
+	return RiverId(type);
 }
 
 PrimarySkill MapReaderH3M::readPrimary()


### PR DESCRIPTION
- CBufferedStream::ensureSize: grow by the needed bytes (need = target - size), min step still 512, but no overshoot; avoids huge reallocs when only 1 byte is required.

- H3M reader (rivers): interpret river type as the low 3 bits (raw & 0x07; valid 0..4). Upper bits are editor flags (e.g., HotA).

- Prevents misreads/over-allocation and stops invalid river index crashes; with these changes the community map “A War” now opens and runs.

