### PR TITLE
Rework drawing objects and fix drawing locked objects

### DIFF
--- a/mapeditor/maphandler.h
+++ b/mapeditor/maphandler.h
@@ -111,8 +111,8 @@ public:
 	std::set<int3> addObject(const CGObjectInstance * object);
 	
 	/// draws all objects on current tile (higher-level logic, unlike other draw*** methods)
-	void drawObjects(QPainter & painter, int x, int y, int z, QPointF offset, const std::set<const CGObjectInstance *> & locked);
-	void drawObjectAt(QPainter & painter, const CGObjectInstance * object, int x, int y, QPointF offset);
+	void drawObjects(QPainter & painter, const QRectF & section, int z, std::set<const CGObjectInstance *> & locked);
+	void drawObjectAt(QPainter & painter, const CGObjectInstance * object, int x, int y, QPointF offset, bool locked = false);
 	
 	void drawMinimapTile(QPainter & painter, int x, int y, int z);
 

--- a/mapeditor/scenelayer.cpp
+++ b/mapeditor/scenelayer.cpp
@@ -545,28 +545,13 @@ ObjectsLayer::ObjectsLayer(MapSceneBase * s): AbstractViewportLayer(s)
 
 QGraphicsItem * ObjectsLayer::draw(const QRectF & section)
 {
-	int left = toInt(section.left());
-	int right = toInt(section.right());
-	int top = toInt(section.top());
-	int bottom = toInt(section.bottom());
 	QPixmap pixmap(toInt(section.width()), toInt(section.height()));
 	pixmap.fill(Qt::transparent);
 
 	if (isShown)
 	{
 		QPainter painter(&pixmap);
-
-		QPointF offset = section.topLeft();
-
-		int margin = 2;		// margin is necessary to properly display flags on heroes on a border between two sections
-
-		for(int x = (left - margin)/tileSize; x < (right + margin)/tileSize; ++x)
-		{
-			for(int y = (top - margin)/tileSize; y < (bottom + margin)/tileSize; ++y)
-			{
-				handler->drawObjects(painter, x, y, scene->level, offset, lockedObjects);
-			}
-		}
+		handler->drawObjects(painter, section, scene->level, lockedObjects);
 	}
 
 	QGraphicsPixmapItem * result = scene->addPixmap(pixmap);
@@ -586,11 +571,14 @@ void ObjectsLayer::setLockObject(const CGObjectInstance * object, bool lock)
 		lockedObjects.insert(object);
 	else
 		lockedObjects.erase(object);
+	QRectF area = getObjectArea(object);
+	redraw({area});
 }
 
 void ObjectsLayer::unlockAll()
 {
 	lockedObjects.clear();
+	redraw();
 }
 
 SelectionObjectsLayer::SelectionObjectsLayer(MapSceneBase * s): AbstractViewportLayer(s), newObject(nullptr)


### PR DESCRIPTION
Pr fixes two bugs introduced in #6173:
- locked objects do not display as locked (with a checkered pattern put on the top of an object).
- flags of heroes are not displayed on borders between sectors (every 10 tiles).

Besides:
- Logic of drawing objects for ObjectLayer and SelectionObjectsLayer have been merged together, simplifying code and removing some duplicates.
- Performance for drawing objects for ObjectLayer has been improved. Before every object was drawn once for each tile it took (for example an object 3x3 was drawn 9 times). Now it only occurs once. I measured it and it saved ~2miliseconds when drawing a small map 36x36. Nothing spectacular, but those things add up. IMO code is easier to understand now, and that's more important.

PS: You may notice I completely removed "Qt::AutoColor | Qt::NoOpaqueDetection" flag from SelectionObjectsLayer. AutoColor is default behavior, NoOpaqueDetection is a performance hint for transparent objects. IMO it simply isn't worth creating separate methods for both layers/adding a boolean argument to the function. 