### PR TITLE
Fix multiplayer lobby issues when 2 and more players join

### DIFF
--- a/server/CVCMIServer.cpp
+++ b/server/CVCMIServer.cpp
@@ -437,7 +437,8 @@ void CVCMIServer::clientConnected(std::shared_ptr<GameConnection> c, std::vector
 {
 	assert(getState() == EServerState::LOBBY);
 
-	c->connectionID = vstd::next(currentClientId, 1);
+	c->connectionID = currentClientId;
+	currentClientId = vstd::next(currentClientId, 1);
 	c->uuid = uuid;
 
 	if(hostClientId == GameConnectionID::INVALID)
@@ -451,7 +452,8 @@ void CVCMIServer::clientConnected(std::shared_ptr<GameConnection> c, std::vector
 	for(auto & name : names)
 	{
 		logNetwork->info("Client %d player: %s", static_cast<int>(c->connectionID), name);
-		PlayerConnectionID id = vstd::next(currentPlayerId, 1);
+		PlayerConnectionID id = currentPlayerId;
+		currentPlayerId = vstd::next(currentPlayerId, 1);
 
 		ClientPlayer cp;
 		cp.connection = c->connectionID;


### PR DESCRIPTION
This PR provides the proper fix for the bug mentioned in the title.

Previously, in my PR 
- #6092 

the bug was only partially addressed. The real problem was how `vstd::next` works (vs previous code, e.g.: `ui8 id = currentPlayerId++;`). It takes const ref as argument so `currentClientId` and `currentPlayerId` were not incremented.

That being said, this PR should be the proper fix for:
- Fixes #5986
- Fixes #6069
- Fixes #6045

I suppose it would be best drop the commit from #6092 and the corresponding revert in this PR (or squash the history) to keep the tree clean.