### PR TITLE
Correct shortcuts for beta / develop branches in Windows installer

### DIFF
--- a/CI/wininstaller/installer.iss
+++ b/CI/wininstaller/installer.iss
@@ -166,12 +166,12 @@ Source: "{#UCRTFilesPath}\{#InstallerArch}\*"; DestDir: "{app}"; Flags: ignoreve
 
 
 [Icons]
-Name: "{group}\{cm:ShortcutLauncher}"; Filename: "{app}\VCMI_launcher.exe"; Comment: "{cm:ShortcutLauncherComment}";  Tasks: startmenu
-Name: "{group}\{cm:ShortcutMapEditor}"; Filename: "{app}\VCMI_mapeditor.exe"; Comment: "{cm:ShortcutMapEditorComment}";  Tasks: startmenu
+Name: "{group}\{cm:ShortcutLauncher}{code:GetBranchSuffix}"; Filename: "{app}\VCMI_launcher.exe"; Comment: "{cm:ShortcutLauncherComment}{code:GetBranchSuffix}";  Tasks: startmenu
+Name: "{group}\{cm:ShortcutMapEditor}{code:GetBranchSuffix}"; Filename: "{app}\VCMI_mapeditor.exe"; Comment: "{cm:ShortcutMapEditorComment}{code:GetBranchSuffix}";  Tasks: startmenu
 Name: "{group}\{cm:ShortcutWebPage}"; Filename: "{#VCMIHome}"; Comment: "{cm:ShortcutWebPageComment}";  Tasks: startmenu
 Name: "{group}\{cm:ShortcutDiscord}"; Filename: "{#VCMIContact}"; Comment: "{cm:ShortcutDiscordComment}";  Tasks: startmenu
 
-Name: "{code:GetUserDesktopFolder}\{cm:ShortcutLauncher}"; Filename: "{app}\VCMI_launcher.exe"; Comment: "{cm:ShortcutLauncherComment}"; Tasks: desktop
+Name: "{code:GetUserDesktopFolder}\{cm:ShortcutLauncher}{code:GetBranchSuffix}"; Filename: "{app}\VCMI_launcher.exe"; Comment: "{cm:ShortcutLauncherComment}{code:GetBranchSuffix}"; Tasks: desktop
 
 
 [Tasks]
@@ -368,6 +368,22 @@ begin
     WTSFreeMemory(Buffer);
   end;
 
+end;
+
+
+function GetBranchSuffix(Param: string): string;
+var
+  Branch: string;
+begin
+  Branch := UpperCase(ExpandConstant('{#VCMIFolder}'));
+
+  if Pos('(BRANCH BETA)', Branch) > 0 then
+    Result := ' (Beta)'
+  else
+  if Pos('(BRANCH DEVELOP)', Branch) > 0 then
+    Result := ' (Develop)'
+  else
+    Result := '';
 end;
 
 


### PR DESCRIPTION
This change will correct desktop and start menu shortcuts for Beta / Develop branches.

Currently were shortcuts always overwritten. Branches are always installed to separate folders, so it make sense to split correctly shortcuts.
Now user can have Stable as "VCMI Launcher", beta as "VCMI Launcher (Beta)" and develop as "VCMI Launcher (Develop)".
