### PR TITLE
Fixes a bug that changes rives directions when terrain type is change…

### DIFF
--- a/lib/mapping/CMapOperation.cpp
+++ b/lib/mapping/CMapOperation.cpp
@@ -311,7 +311,7 @@ void CDrawTerrainOperation::updateTerrainViews()
 		if(!pattern.diffImages)
 		{
 			tile.terView = gen->nextInt(mapping.first, mapping.second);
-			tile.extTileFlags = valRslt.flip;
+			tile.extTileFlags = (tile.extTileFlags & 0b11111100) | valRslt.flip;
 		}
 		else
 		{


### PR DESCRIPTION
Fixes a bug that changes rives/roads directions together with terrain type.
<img width="647" height="631" alt="Screenshot from 2025-10-06 22-11-47" src="https://github.com/user-attachments/assets/0cdb4bf5-7dfc-4f52-9920-bd30425649eb" />
<img width="647" height="631" alt="Screenshot from 2025-10-06 22-12-01" src="https://github.com/user-attachments/assets/d3cc63f4-4dec-43ee-96e4-10d1e6ab8d6d" />

It was caused by updateTerrainView overwriting those information when setting a terrain direction.
