### PR TITLE
Fixes mapeditor crashing when user changes terrain beyond map

### DIFF
--- a/mapeditor/scenelayer.cpp
+++ b/mapeditor/scenelayer.cpp
@@ -170,7 +170,8 @@ void AbstractViewportLayer::redrawWithSurroundingTiles(const std::vector<int3> &
 
 void AbstractViewportLayer::redraw(const std::set<CGObjectInstance *> & objects)
 {
-	std::vector<QRectF> areas(objects.size());
+	std::vector<QRectF> areas;
+	areas.reserve(objects.size());
 	for (const CGObjectInstance * object : objects)
 	{
 		areas.push_back(getObjectArea(object));


### PR DESCRIPTION
As in title.

I also added fixes suggested by kambala-decapitor's post-merge code review of #6173.