### PR TITLE
[launcher] fix sorting mods by the Enabled column

### DIFF
--- a/launcher/modManager/modstateitemmodel_moc.cpp
+++ b/launcher/modManager/modstateitemmodel_moc.cpp
@@ -276,7 +276,7 @@ bool CModFilterModel::filterMatchesCategory(const QModelIndex & source) const
 			return !mod.isInstalled();
 		case ModFilterMask::INSTALLED:
 			return mod.isInstalled();
-		case ModFilterMask::UPDATEABLE:
+		case ModFilterMask::UPDATABLE:
 			return mod.isUpdateAvailable();
 		case ModFilterMask::ENABLED:
 			return mod.isInstalled() && base->model->isModEnabled(modID);

--- a/launcher/modManager/modstateitemmodel_moc.h
+++ b/launcher/modManager/modstateitemmodel_moc.h
@@ -32,7 +32,7 @@ enum class ModFilterMask : uint8_t
 	ALL,
 	AVAILABLE,
 	INSTALLED,
-	UPDATEABLE,
+	UPDATABLE,
 	ENABLED,
 	DISABLED
 };


### PR DESCRIPTION
If both mods have the same Enabled status, then Install status is compared in the same way and the last fallback is to name sorting.

This broken sorting has been bugging me for a very long time :)

<img width="360" height="234" alt="Screenshot 2025-10-30 at 00 36 38" src="https://github.com/user-attachments/assets/e11913d4-e2f0-4e92-a71c-d1b1d43ddb90" />
