### PR TITLE
Fix networkHandler is destroyed before networkServer

### DIFF
--- a/server/CVCMIServer.h
+++ b/server/CVCMIServer.h
@@ -36,14 +36,14 @@ class GlobalLobbyProcessor;
 
 class CVCMIServer : public LobbyInfo, public INetworkServerListener, public INetworkTimerListener, public IGameServer
 {
-	/// Network server instance that receives and processes incoming connections on active socket
-	std::unique_ptr<INetworkServer> networkServer;
 	std::unique_ptr<GlobalLobbyProcessor> lobbyProcessor;
 
 	std::chrono::steady_clock::time_point gameplayStartTime;
 	std::chrono::steady_clock::time_point lastTimerUpdateTime;
 
 	std::unique_ptr<INetworkHandler> networkHandler;
+	/// Network server instance that receives and processes incoming connections on active socket
+	std::unique_ptr<INetworkServer> networkServer;
 
 	EServerState state = EServerState::LOBBY;
 


### PR DESCRIPTION
fixes #6266

The underlying issue is that `NetworkServer` does not own the `context`, which is owned by `NetworkHandler`.
If `NetworkHandler` is destroyed before `NetworkServer`, then any interaction with `NetworkAcceptor` (such as destruction) crashes.

While this PR fixes the reported issue, it would be cleaner in the long run to have proper lifetime management of the context and objects that interact with it.