### PR TITLE
Fix preserveCountSuffix if no parentheses are present

### DIFF
--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -1676,9 +1676,12 @@ void CObjectListWindow::trimTextIfTooWide(std::string & text, bool preserveCount
 	{
 		auto posBrace = text.find_last_of("(");
 		auto posClosing = text.find_last_of(")");
-		std::string objCount = text.substr(posBrace, posClosing - posBrace) + ')';
-		suffix += " ";
-		suffix += objCount;
+		if (posBrace != std::string::npos && posClosing != std::string::npos && posClosing > posBrace)
+		{
+			std::string objCount = text.substr(posBrace, posClosing - posBrace) + ')';
+			suffix += " ";
+			suffix += objCount;
+		}
 	}
 
 	const auto & font = ENGINE->renderHandler().loadFont(FONT_SMALL);


### PR DESCRIPTION
This PR fixes list of resolution scaling options display (before it just crashed when trying to show the options).
Basically, `GeneralOptionsTab.cpp` calls `ENGINE->windows().createAndPushWindow<CObjectListWindow>` with entries like `50%`, `60%`, ...
When those are passed to `trimTextIfTooWide` with the option `preserveCountSuffix`, then one searches for parentheses (which are missing) and crashes upon using `std::string::npos` as bounds.