### PR TITLE
Enable backpack sorting in both ways

### DIFF
--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -2729,75 +2729,88 @@ bool CGameHandler::manageBackpackArtifacts(const PlayerColor & player, const Obj
 	const auto * artSet = gameState().getArtSet(heroID);
 	COMPLAIN_RET_FALSE_IF(artSet == nullptr, "manageBackpackArtifacts: wrong hero's ID");
 
-	auto isSortableCmd = [](const ManageBackpackArtifacts::ManageCmd & cmd)
-	{
-		using MC = ManageBackpackArtifacts::ManageCmd;
-		return cmd == MC::SORT_BY_SLOT || cmd == MC::SORT_BY_COST || cmd == MC::SORT_BY_CLASS;
-	};
-
-	static std::map<ObjectInstanceID, std::pair<ManageBackpackArtifacts::ManageCmd, bool>> lastSort;
-	bool descending = false;
-	if(isSortableCmd(sortType))
-	{
-		auto it = lastSort.find(heroID);
-		if(it != lastSort.end() && it->second.first == sortType)
-			descending = !it->second.second;
-		else
-			descending = false;
-
-		lastSort[heroID] = { sortType, descending };
-	}
-
 	BulkMoveArtifacts bma(player, heroID, heroID, false);
 
-	const auto makeSortBackpackRequest = [artSet, &bma, descending](const std::function<int32_t(const ArtSlotInfo&)> & getSortId)
+	const auto sortPack = [artSet](std::vector<MoveArtifactInfo> & pack)
+	{
+		// Each pack of artifacts is also sorted by ArtifactID. Scrolls by SpellID
+		std::sort(pack.begin(), pack.end(), [artSet](const auto & slots0, const auto & slots1) -> bool
+		{
+			const auto art0 = artSet->getArt(slots0.srcPos);
+			const auto art1 = artSet->getArt(slots1.srcPos);
+			if(art0->isScroll() && art1->isScroll())
+				return art0->getScrollSpellID() > art1->getScrollSpellID();
+			return art0->getTypeId().num > art1->getTypeId().num;
+		});
+	};
+
+	const auto buildAscendingOrder = [artSet, &sortPack](auto && getSortId)
 	{
 		std::map<int32_t, std::vector<MoveArtifactInfo>> packsSorted;
 		ArtifactPosition backpackSlot = ArtifactPosition::BACKPACK_START;
+
 		for(const auto & backpackSlotInfo : artSet->artifactsInBackpack)
 			packsSorted.try_emplace(getSortId(backpackSlotInfo)).first->second.emplace_back(backpackSlot++, ArtifactPosition::PRE_FIRST);
 
-		auto sortPack = [artSet](std::vector<MoveArtifactInfo> & pack)
+		std::vector<MoveArtifactInfo> orderAsc;
+		for(auto & entry : packsSorted)
 		{
-			std::sort(pack.begin(), pack.end(), [artSet](const auto & slots0, const auto & slots1)
-			{
-				const auto art0 = artSet->getArt(slots0.srcPos);
-				const auto art1 = artSet->getArt(slots1.srcPos);
-				if (art0->isScroll() && art1->isScroll())
-					return art0->getScrollSpellID() > art1->getScrollSpellID();
-				return art0->getTypeId().num > art1->getTypeId().num;
-			});
-		};
-
-		for(auto & [sortId, pack] : packsSorted)
-		{
-			(void)sortId;
-			sortPack(pack);
-			bma.artsPack0.insert(bma.artsPack0.end(), pack.begin(), pack.end());
+		    auto & pack = entry.second;
+		    sortPack(pack);
+		    orderAsc.insert(orderAsc.end(), pack.begin(), pack.end());
 		}
 
-		if(descending)
-			std::reverse(bma.artsPack0.begin(), bma.artsPack0.end());
+		return orderAsc;
+	};
 
-		backpackSlot = ArtifactPosition::BACKPACK_START;
+	const auto isAlreadyAscending = [artSet](const std::vector<MoveArtifactInfo> & orderAsc)
+	{
+		std::vector<ArtifactInstanceID> curIds;
+		curIds.reserve(artSet->artifactsInBackpack.size());
+		for(const auto & slotInfo : artSet->artifactsInBackpack)
+			curIds.push_back(slotInfo.getArt()->getId());
+
+		std::vector<ArtifactInstanceID> ascIds;
+		ascIds.reserve(orderAsc.size());
+		for(const auto & mi : orderAsc)
+			ascIds.push_back(artSet->getArt(mi.srcPos)->getId());
+
+		return curIds == ascIds;
+	};
+
+	const auto buildRequestFromOrder = [&bma](const std::vector<MoveArtifactInfo> & order, bool reverseAll)
+	{
+		if(!reverseAll)
+			bma.artsPack0.insert(bma.artsPack0.end(), order.begin(), order.end());
+		else
+			bma.artsPack0.insert(bma.artsPack0.end(), order.rbegin(), order.rend());
+
+		ArtifactPosition backpackSlot = ArtifactPosition::BACKPACK_START;
 		for(auto & slots : bma.artsPack0)
 			slots.dstPos = backpackSlot++;
 	};
-	
+
+	const auto makeSortBackpackRequest = [&](auto && getSortId)
+	{
+		auto orderAsc = buildAscendingOrder(getSortId);
+		const bool reverseAll = isAlreadyAscending(orderAsc);
+		buildRequestFromOrder(orderAsc, reverseAll);
+	};
+
 	if(sortType == ManageBackpackArtifacts::ManageCmd::SORT_BY_SLOT)
 	{
 		makeSortBackpackRequest([](const ArtSlotInfo & inf) -> int32_t
 			{
 				auto possibleSlots = inf.getArt()->getType()->getPossibleSlots();
-				if(possibleSlots.find(ArtBearer::CREATURE) != possibleSlots.end() && !possibleSlots.at(ArtBearer::CREATURE).empty()) 
+				if (possibleSlots.find(ArtBearer::CREATURE) != possibleSlots.end() && !possibleSlots.at(ArtBearer::CREATURE).empty()) 
 				{
 					return -2;
 				}
-				else if(possibleSlots.find(ArtBearer::COMMANDER) != possibleSlots.end() && !possibleSlots.at(ArtBearer::COMMANDER).empty()) 
+				else if (possibleSlots.find(ArtBearer::COMMANDER) != possibleSlots.end() && !possibleSlots.at(ArtBearer::COMMANDER).empty()) 
 				{
 					return -1;
 				}
-				else if(possibleSlots.find(ArtBearer::HERO) != possibleSlots.end() && !possibleSlots.at(ArtBearer::HERO).empty()) 
+				else if (possibleSlots.find(ArtBearer::HERO) != possibleSlots.end() && !possibleSlots.at(ArtBearer::HERO).empty()) 
 				{
 					return inf.getArt()->getType()->getPossibleSlots().at(ArtBearer::HERO).front().num;
 				}
@@ -2819,7 +2832,7 @@ bool CGameHandler::manageBackpackArtifacts(const PlayerColor & player, const Obj
 	{
 		makeSortBackpackRequest([](const ArtSlotInfo & inf) -> int32_t
 			{
-									return static_cast<int32_t>(inf.getArt()->getType()->aClass);
+				return static_cast<int32_t>(inf.getArt()->getType()->aClass);
 			});
 	}
 	else


### PR DESCRIPTION
It's now possible to sort in both orders in backpack. So you can now click on sort button to see artifacts in both directions.

Fixes https://github.com/vcmi/vcmi/issues/5607

Sadly scrolling using stylus doesn't work in this dialog. Unrelated to my change, but would be great to fix it too.