### PR TITLE
Add MORE_DAMAGE_FROM_SPELL

### DIFF
--- a/config/bonuses.json
+++ b/config/bonuses.json
@@ -338,7 +338,11 @@
 	{
 		"blockDescriptionPropagation": true
 	},
-	
+
+	"MORE_DAMAGE_FROM_SPELL":
+	{
+	},
+
 	"MOVEMENT":
 	{
 		"blockDescriptionPropagation": true


### PR DESCRIPTION
Fix for VCMI Extras touch

_Mod 'vcmi-extras.bonusicons.bonus icons' attempts to edit object 'MORE_DAMAGE_FROM_SPELL' of type 'bonus' from mod 'core' but no such object exist!_