### PR TITLE
Refactor batte move / attack logic

### DIFF
--- a/client/battle/BattleActionsController.h
+++ b/client/battle/BattleActionsController.h
@@ -45,7 +45,6 @@ class BattleActionsController
 	const CStack * selectedStack;
 
 	bool isCastingPossibleHere (const CSpell * spell, const CStack *shere, const BattleHex & myNumber);
-	bool canStackMoveHere (const CStack *sactive, const BattleHex & MyNumber) const; //TODO: move to BattleState / callback
 	std::vector<PossiblePlayerBattleAction> getPossibleActionsForStack (const CStack *stack) const; //called when stack gets its turn
 	void reorderPossibleActionsPriority(const CStack * stack, const CStack * targetStack);
 

--- a/client/battle/BattleFieldController.cpp
+++ b/client/battle/BattleFieldController.cpp
@@ -263,9 +263,10 @@ void BattleFieldController::showBackgroundImageWithHexes(Canvas & canvas)
 void BattleFieldController::redrawBackgroundWithHexes()
 {
 	const CStack *activeStack = owner.stacksController->getActiveStack();
-	BattleHexArray attackableHexes;
 	if(activeStack)
-		occupiableHexes = owner.getBattle()->battleGetAvailableHexes(activeStack, false, true, &attackableHexes);
+		availableHexes = owner.getBattle()->battleGetAvailableHexes(activeStack, false);
+	else
+		availableHexes.clear();
 
 	// prepare background graphic with hexes and shaded hexes
 	backgroundWithHexes->draw(background, Point(0,0));
@@ -274,13 +275,16 @@ void BattleFieldController::redrawBackgroundWithHexes()
 		owner.siegeController->showAbsoluteObstacles(*backgroundWithHexes);
 
 	// show shaded hexes for active's stack valid movement and the hexes that it can attack
-	if(settings["battle"]["stackRange"].Bool())
+	if(activeStack && settings["battle"]["stackRange"].Bool())
 	{
-		BattleHexArray hexesToShade = occupiableHexes;
-		hexesToShade.insert(attackableHexes);
-		for(const BattleHex & hex : hexesToShade)
+		auto occupiableHexes = owner.getBattle()->battleGetOccupiableHexes(availableHexes, activeStack);
+		for(si16 hex = 0; hex < GameConstants::BFIELD_SIZE; hex++)
 		{
-			showHighlightedHex(*backgroundWithHexes, cellShade, hex, false);
+			//shade occupiable and attackable hexes
+			if (occupiableHexes.contains(hex) ||
+				(owner.getBattle()->battleCanAttackUnit(activeStack, owner.getBattle()->battleGetStackByPos(hex, true)) &&
+					owner.getBattle()->battleCanAttackHex(availableHexes, activeStack, hex)))
+				showHighlightedHex(*backgroundWithHexes, cellShade, hex, false);
 		}
 	}
 
@@ -330,10 +334,7 @@ BattleHexArray BattleFieldController::getMovementRangeForHoveredStack()
 		return BattleHexArray();
 
 	auto hoveredStack = getHoveredStack();
-	if(hoveredStack)
-		return owner.getBattle()->battleGetAvailableHexes(hoveredStack, true, true, nullptr);
-	else
-		return BattleHexArray();
+	return hoveredStack ? owner.getBattle()->battleGetOccupiableHexes(hoveredStack, true) : BattleHexArray();
 }
 
 BattleHexArray BattleFieldController::getHighlightedHexesForSpellRange()
@@ -371,45 +372,26 @@ BattleHexArray BattleFieldController::getHighlightedHexesForMovementTarget()
 	if(!stack)
 		return {};
 
-	BattleHexArray availableHexes = owner.getBattle()->battleGetAvailableHexes(stack, false, false, nullptr);
-
 	auto hoveredStack = owner.getBattle()->battleGetStackByPos(hoveredHex, true);
 
-	if(owner.getBattle()->battleCanAttack(stack, hoveredStack, hoveredHex) && isTileAttackable(hoveredHex))
+	if(owner.getBattle()->battleCanAttackUnit(stack, hoveredStack) && owner.getBattle()->battleCanAttackHex(availableHexes, stack, hoveredHex))
 	{
-		BattleHex attackFromHex = fromWhichHexAttack(hoveredHex);
-		if(owner.getBattle()->battleCanAttack(stack, hoveredStack, attackFromHex))
-		{
-			if(stack->doubleWide())
-				return {attackFromHex, stack->occupiedHex(attackFromHex)};
+		BattleHex fromHex = owner.getBattle()->fromWhichHexAttack(stack, hoveredHex, selectAttackDirection(hoveredHex));
+		assert(fromHex.isValid());
+		if(stack->doubleWide())
+			return {fromHex, stack->occupiedHex(fromHex)};
 
-			return {attackFromHex};
-		}
+		return {fromHex};
 	}
 
-	if (stack->doubleWide())
-	{
-		const bool canMoveHeadHere = hoveredHex.isAvailable() && availableHexes.contains(hoveredHex);
-		const bool canMoveTailHere = hoveredHex.isAvailable() && availableHexes.contains(hoveredHex.cloneInDirection(stack->destShiftDir()));
-		const bool backwardsMove = stack->unitSide() == BattleSide::ATTACKER ?
-									   hoveredHex.getX() < stack->getPosition().getX():
-									   hoveredHex.getX() > stack->getPosition().getX();
-
-		if(canMoveTailHere && (backwardsMove || !canMoveHeadHere))
-			return {hoveredHex, hoveredHex.cloneInDirection(stack->destShiftDir())};
-
-		if (canMoveHeadHere)
-			return {hoveredHex, stack->occupiedHex(hoveredHex)};
-
+	auto toHex = owner.getBattle()->toWhichHexMove(availableHexes, stack, hoveredHex);
+	if (!toHex.isValid())
 		return {};
-	}
+	
+	if (stack->doubleWide())
+		return {toHex, stack->occupiedHex(toHex)};
 	else
-	{
-		if (availableHexes.contains(hoveredHex))
-			return {hoveredHex};
-		else
-			return {};
-	}
+		return {toHex};
 }
 
 // Range limit highlight helpers
@@ -667,162 +649,45 @@ BattleHex BattleFieldController::getHexAtPosition(Point hoverPos)
 
 BattleHex::EDir BattleFieldController::selectAttackDirection(const BattleHex & myNumber) const
 {
-	const bool doubleWide = owner.stacksController->getActiveStack()->doubleWide();
+	auto attacker = owner.stacksController->getActiveStack();
+	assert(attacker);
 	const BattleHexArray & neighbours = myNumber.getAllNeighbouringTiles();
-	//   0 1
-	//  5 x 2
-	//   4 3
-
-	// if true - our current stack can move into this hex (and attack)
-	std::array<bool, 8> attackAvailability;
-
-	if (doubleWide)
-	{
-		// For double-hexes we need to ensure that both hexes needed for this direction are occupyable:
-		// |    -0-   |   -1-    |    -2-   |   -3-    |    -4-   |   -5-    |    -6-   |   -7-
-		// |  o o -   |   - o o  |    - -   |   - -    |    - -   |   - -    |    o o   |   - -
-		// |   - x -  |  - x -   |   - x o o|  - x -   |   - x -  |o o x -   |   - x -  |  - x -
-		// |    - -   |   - -    |    - -   |   - o o  |  o o -   |   - -    |    - -   |   o o
-
-		for (size_t i : { 1, 2, 3})
-		{
-			BattleHex target = neighbours[i].cloneInDirection(BattleHex::RIGHT, false);
-			attackAvailability[i] = neighbours[i].isValid() && occupiableHexes.contains(neighbours[i]) && target.isValid() && occupiableHexes.contains(target);
-		}
-
-		for (size_t i : { 4, 5, 0})
-		{
-			BattleHex target = neighbours[i].cloneInDirection(BattleHex::LEFT, false);
-			attackAvailability[i] = neighbours[i].isValid() && occupiableHexes.contains(neighbours[i]) && target.isValid() && occupiableHexes.contains(target);
-		}
-
-		attackAvailability[6] = neighbours[0].isValid() && neighbours[1].isValid() && occupiableHexes.contains(neighbours[0]) && occupiableHexes.contains(neighbours[1]);
-		attackAvailability[7] = neighbours[3].isValid() && neighbours[4].isValid() && occupiableHexes.contains(neighbours[3]) && occupiableHexes.contains(neighbours[4]);
-	}
-	else
-	{
-		for (size_t i = 0; i < 6; ++i)
-			attackAvailability[i] = neighbours[i].isValid() && occupiableHexes.contains(neighbours[i]);
-
-		attackAvailability[6] = false;
-		attackAvailability[7] = false;
-	}
-
-	// Zero available tiles to attack from
-	if ( vstd::find(attackAvailability, true) == attackAvailability.end())
-	{
-		logGlobal->error("Error: cannot find a hex to attack hex %d from!", myNumber);
-		return BattleHex::NONE;
-	}
-
 	// For each valid direction, select position to test against
 	std::array<Point, 8> testPoint;
+	testPoint.fill(Point::makeInvalid());
 
 	for (size_t i = 0; i < 6; ++i)
-		if (attackAvailability[i])
+		if (owner.getBattle()->battleCanAttackHex(availableHexes, attacker, myNumber, BattleHex::EDir(i)))
 			testPoint[i] = hexPositionAbsolute(neighbours[i]).center();
 
 	// For bottom/top directions select central point, but move it a bit away from true center to reduce zones allocated to them
-	if (attackAvailability[6])
+	if (owner.getBattle()->battleCanAttackHex(availableHexes, attacker, myNumber, BattleHex::EDir(6)))
 		testPoint[6] = (hexPositionAbsolute(neighbours[0]).center() + hexPositionAbsolute(neighbours[1]).center()) / 2 + Point(0, -5);
 
-	if (attackAvailability[7])
+	if (owner.getBattle()->battleCanAttackHex(availableHexes, attacker, myNumber, BattleHex::EDir(7)))
 		testPoint[7] = (hexPositionAbsolute(neighbours[3]).center() + hexPositionAbsolute(neighbours[4]).center()) / 2 + Point(0,  5);
 
 	// Compute distance between tested position & cursor position and pick nearest
-	std::array<int, 8> distance2;
-
-	for (size_t i = 0; i < 8; ++i)
-		if (attackAvailability[i])
-			distance2[i] = (testPoint[i].y - currentAttackOriginPoint.y)*(testPoint[i].y - currentAttackOriginPoint.y) + (testPoint[i].x - currentAttackOriginPoint.x)*(testPoint[i].x - currentAttackOriginPoint.x);
-
+	int nearestDistance = std::numeric_limits<int>::max();
 	size_t nearest = -1;
+
 	for (size_t i = 0; i < 8; ++i)
-		if (attackAvailability[i] && (nearest == -1 || distance2[i] < distance2[nearest]) )
-			nearest = i;
+	{
+		if (testPoint[i].isValid())
+		{
+			int distance = (testPoint[i].y - currentAttackOriginPoint.y)*(testPoint[i].y - currentAttackOriginPoint.y) + (testPoint[i].x - currentAttackOriginPoint.x)*(testPoint[i].x - currentAttackOriginPoint.x);
+			if (nearest == -1 || distance < nearestDistance)
+			{
+				nearestDistance = distance;
+				nearest = i;
+			}
+		}
+	}
 
-	assert(nearest != -1);
+	if (nearest == -1)
+		// Zero available tiles to attack from
+		logGlobal->error("Error: cannot find a hex to attack hex %d from!", myNumber);
 	return BattleHex::EDir(nearest);
-}
-
-BattleHex BattleFieldController::fromWhichHexAttack(const BattleHex & attackTarget)
-{
-	BattleHex::EDir direction = selectAttackDirection(attackTarget);
-
-	const CStack * attacker = owner.stacksController->getActiveStack();
-
-	assert(direction != BattleHex::NONE);
-	assert(attacker);
-
-	if (!attacker->doubleWide())
-	{
-		assert(direction != BattleHex::BOTTOM);
-		assert(direction != BattleHex::TOP);
-		return attackTarget.cloneInDirection(direction);
-	}
-	else
-	{
-		// We need to find position of right hex of double-hex creature (or left for defending side)
-		// | TOP_LEFT |TOP_RIGHT |   RIGHT  |BOTTOM_RIGHT|BOTTOM_LEFT|  LEFT    |    TOP   |BOTTOM
-		// |  o o -   |   - o o  |    - -   |   - -      |    - -    |   - -    |    o o   |   - -
-		// |   - x -  |  - x -   |   - x o o|  - x -     |   - x -   |o o x -   |   - x -  |  - x -
-		// |    - -   |   - -    |    - -   |   - o o    |  o o -    |   - -    |    - -   |   o o
-
-		switch (direction)
-		{
-		case BattleHex::TOP_LEFT:
-		case BattleHex::LEFT:
-		case BattleHex::BOTTOM_LEFT:
-		{
-			if ( attacker->unitSide() == BattleSide::ATTACKER )
-				return attackTarget.cloneInDirection(direction);
-			else
-				return attackTarget.cloneInDirection(direction).cloneInDirection(BattleHex::LEFT);
-		}
-
-		case BattleHex::TOP_RIGHT:
-		case BattleHex::RIGHT:
-		case BattleHex::BOTTOM_RIGHT:
-		{
-			if ( attacker->unitSide() == BattleSide::ATTACKER )
-				return attackTarget.cloneInDirection(direction).cloneInDirection(BattleHex::RIGHT);
-			else
-				return attackTarget.cloneInDirection(direction);
-		}
-
-		case BattleHex::TOP:
-		{
-			if ( attacker->unitSide() == BattleSide::ATTACKER )
-				return attackTarget.cloneInDirection(BattleHex::TOP_RIGHT);
-			else
-				return attackTarget.cloneInDirection(BattleHex::TOP_LEFT);
-		}
-
-		case BattleHex::BOTTOM:
-		{
-			if ( attacker->unitSide() == BattleSide::ATTACKER )
-				return attackTarget.cloneInDirection(BattleHex::BOTTOM_RIGHT);
-			else
-				return attackTarget.cloneInDirection(BattleHex::BOTTOM_LEFT);
-		}
-		default:
-			assert(0);
-			return BattleHex::INVALID;
-		}
-	}
-}
-
-bool BattleFieldController::isTileAttackable(const BattleHex & number) const
-{
-	if(!number.isValid())
-		return false;
-
-	for (auto & elem : occupiableHexes)
-	{
-		if (BattleHex::mutualPosition(elem, number) != BattleHex::EDir::NONE)
-			return true;
-	}
-	return false;
 }
 
 void BattleFieldController::updateAccessibleHexes()

--- a/client/battle/BattleFieldController.h
+++ b/client/battle/BattleFieldController.h
@@ -46,8 +46,8 @@ class BattleFieldController : public CIntObject
 	/// hex currently under mouse hover
 	BattleHex hoveredHex;
 
-	/// hexes to which currently active stack can move
-	BattleHexArray occupiableHexes;
+	/// hexes to which the currently active stack can move (for double-wide units only the head is considered)
+	BattleHexArray availableHexes;
 
 	/// hexes that when in front of a unit cause it's amount box to move back
 	std::array<bool, GameConstants::BFIELD_SIZE> stackCountOutsideHexes;
@@ -126,13 +126,8 @@ public:
 	/// Returns the currently hovered stack
 	const CStack* getHoveredStack();
 
-	/// returns true if selected tile can be attacked in melee by current stack
-	bool isTileAttackable(const BattleHex & number) const;
-
 	/// returns true if stack should render its stack count image in default position - outside own hex
 	bool stackCountOutsideHex(const BattleHex & number) const;
 
 	BattleHex::EDir selectAttackDirection(const BattleHex & myNumber) const;
-
-	BattleHex fromWhichHexAttack(const BattleHex & myNumber);
 };

--- a/lib/CStack.cpp
+++ b/lib/CStack.cpp
@@ -107,21 +107,6 @@ si32 CStack::magicResistance() const
 	return static_cast<si32>(100 - castChance);
 }
 
-BattleHex::EDir CStack::destShiftDir() const
-{
-	if(doubleWide())
-	{
-		if(side == BattleSide::ATTACKER)
-			return BattleHex::EDir::RIGHT;
-		else
-			return BattleHex::EDir::LEFT;
-	}
-	else
-	{
-		return BattleHex::EDir::NONE;
-	}
-}
-
 std::vector<SpellID> CStack::activeSpells() const
 {
 	std::vector<SpellID> ret;

--- a/lib/CStack.h
+++ b/lib/CStack.h
@@ -66,8 +66,6 @@ public:
 	static BattleHexArray meleeAttackHexes(const battle::Unit * attacker, const battle::Unit * defender, BattleHex attackerPos = BattleHex::INVALID, BattleHex defenderPos = BattleHex::INVALID);
 	static bool isMeleeAttackPossible(const battle::Unit * attacker, const battle::Unit * defender, BattleHex attackerPos = BattleHex::INVALID, BattleHex defenderPos = BattleHex::INVALID);
 
-	BattleHex::EDir destShiftDir() const;
-
 	void prepareAttacked(BattleStackAttacked & bsa, vstd::RNG & rand) const; //requires bsa.damageAmount filled
 	static void prepareAttacked(BattleStackAttacked & bsa,
 								vstd::RNG & rand,

--- a/lib/battle/CBattleInfoCallback.h
+++ b/lib/battle/CBattleInfoCallback.h
@@ -79,13 +79,25 @@ public:
 
 	void battleGetTurnOrder(std::vector<battle::Units> & out, const size_t maxUnits, const int maxTurns, const int turn = 0, BattleSide lastMoved = BattleSide::NONE) const;
 
-	///returns reachable hexes (valid movement destinations), DOES contain stack current position
-	BattleHexArray battleGetAvailableHexes(const battle::Unit * unit, bool obtainMovementRange, bool addOccupiable, BattleHexArray * attackable) const;
-
 	///returns reachable hexes (valid movement destinations), DOES contain stack current position (lite version)
 	BattleHexArray battleGetAvailableHexes(const battle::Unit * unit, bool obtainMovementRange) const;
-
 	BattleHexArray battleGetAvailableHexes(const ReachabilityInfo & cache, const battle::Unit * unit, bool obtainMovementRange) const;
+
+	//returns hexes the unit can occupy, obtainMovementRange ignores tactics mode (for double-wide units includes both head and tail)
+	BattleHexArray battleGetOccupiableHexes(const battle::Unit * unit, bool obtainMovementRange) const;
+	BattleHexArray battleGetOccupiableHexes(const BattleHexArray & availableHexes, const battle::Unit * unit) const;
+	//returns from which hex the attacker would attack the target from given direction; INVALID if not possible; the hex may be inccessible
+	BattleHex fromWhichHexAttack(const battle::Unit * attacker, const BattleHex & target, const BattleHex::EDir & direction) const;
+
+	//returns to which hex the (head of) unit would move to occupy position (possibly by tail)
+	BattleHex toWhichHexMove(const battle::Unit * unit, const BattleHex & position) const;
+	BattleHex toWhichHexMove(const BattleHexArray & availableHexes, const battle::Unit * unit, const BattleHex & position) const;
+
+	//return true iff attacker move towards and attack position from direction (spatial reasoning only)
+	bool battleCanAttackHex(const battle::Unit * attacker, const BattleHex & position, const BattleHex::EDir & direction) const;
+	bool battleCanAttackHex(const BattleHexArray & availableHexes, const battle::Unit * attacker, const BattleHex & position, const BattleHex::EDir & direction) const; //reuse availableHexes on multiple calls
+	bool battleCanAttackHex(const battle::Unit * attacker, const BattleHex & position) const; //check all directions
+	bool battleCanAttackHex(const BattleHexArray & availableHexes, const battle::Unit * attacker, const BattleHex & position) const; //reuse availableHexes on multiple calls
 
 	int battleGetSurrenderCost(const PlayerColor & Player) const; //returns cost of surrendering battle, -1 if surrendering is not possible
 	ReachabilityInfo::TDistances battleGetDistances(const battle::Unit * unit, const BattleHex & assumedPosition) const;
@@ -96,7 +108,7 @@ public:
 	std::pair< BattleHexArray, int > getPath(const BattleHex & start, const BattleHex & dest, const battle::Unit * stack) const;
 
 	bool battleCanTargetEmptyHex(const battle::Unit * attacker) const; //determines of stack with given ID can target empty hex to attack - currently used only for SPELL_LIKE_ATTACK shooting
-	bool battleCanAttack(const battle::Unit * stack, const battle::Unit * target, const BattleHex & dest) const; //determines if stack with given ID can attack target at the selected destination
+	bool battleCanAttackUnit(const battle::Unit * attacker, const battle::Unit * target) const; //determines if attacker can attack target (no spatial reasoning)
 	bool battleCanShoot(const battle::Unit * attacker, const BattleHex & dest) const; //determines if stack with given ID shoot at the selected destination
 	bool battleCanShoot(const battle::Unit * attacker) const; //determines if stack with given ID shoot in principle
 	bool battleIsUnitBlocked(const battle::Unit * unit) const; //returns true if there is neighboring enemy stack

--- a/lib/battle/Unit.cpp
+++ b/lib/battle/Unit.cpp
@@ -91,9 +91,7 @@ BattleHexArray Unit::getAttackableHexes(const Unit * attacker) const
 			if (!coversPos(attacker->occupiedHex(attackOrigin)) && attackOrigin.isAvailable())
 				result.insert(attackOrigin);
 
-			bool isAttacker = attacker->unitSide() == BattleSide::ATTACKER;
-			BattleHex::EDir headDirection = isAttacker ? BattleHex::RIGHT : BattleHex::LEFT;
-			BattleHex headHex = attackOrigin.cloneInDirection(headDirection);
+			BattleHex headHex = attackOrigin.cloneInDirection(attacker->headDirection());
 
 			if (!coversPos(headHex) && headHex.isAvailable())
 				result.insert(headHex);
@@ -105,6 +103,21 @@ BattleHexArray Unit::getAttackableHexes(const Unit * attacker) const
 bool Unit::coversPos(const BattleHex & pos) const
 {
 	return getPosition() == pos || (doubleWide() && (occupiedHex() == pos));
+}
+
+BattleHex::EDir Unit::headDirection() const
+{
+	if(doubleWide())
+	{
+		if(unitSide() == BattleSide::ATTACKER)
+			return BattleHex::EDir::RIGHT;
+		else
+			return BattleHex::EDir::LEFT;
+	}
+	else
+	{
+		return BattleHex::EDir::NONE;
+	}
 }
 
 const BattleHexArray & Unit::getHexes() const

--- a/lib/battle/Unit.h
+++ b/lib/battle/Unit.h
@@ -140,6 +140,9 @@ public:
 
 	bool coversPos(const BattleHex & position) const; //checks also if unit is double-wide
 
+	/// Returns the direction the double-wide unit is facing; returns NONE for single-hex units
+	BattleHex::EDir headDirection() const;
+
 	const BattleHexArray & getHexes() const; //up to two occupied hexes, starting from front
 	const BattleHexArray & getHexes(const BattleHex & assumedPos) const; //up to two occupied hexes, starting from front
 	static const BattleHexArray & getHexes(const BattleHex & assumedPos, bool twoHex, BattleSide side);

--- a/server/battles/BattleActionProcessor.cpp
+++ b/server/battles/BattleActionProcessor.cpp
@@ -649,7 +649,7 @@ BattleActionProcessor::MovementResult BattleActionProcessor::moveStack(const CBa
 	//shifting destination (if we have double wide stack and we can occupy dest but not be exactly there)
 	if(!stackAtEnd && curStack->doubleWide() && !accessibility.accessible(dest, curStack))
 	{
-		BattleHex shifted = dest.cloneInDirection(curStack->destShiftDir(), false);
+		BattleHex shifted = dest.cloneInDirection(curStack->headDirection(), false);
 
 		if(accessibility.accessible(shifted, curStack))
 			dest = shifted;

--- a/server/battles/BattleFlowProcessor.cpp
+++ b/server/battles/BattleFlowProcessor.cpp
@@ -473,9 +473,19 @@ bool BattleFlowProcessor::tryMakeAutomaticActionOfBallistaOrTowers(const CBattle
 			if (battle.battleCanShoot(unit))
 				return true;
 
-			BattleHexArray attackableHexes;
-			battle.battleGetAvailableHexes(unit, true, false, &attackableHexes);
-			return !attackableHexes.empty();
+			auto units = battle.battleAliveUnits();
+			auto availableHexes = battle.battleGetAvailableHexes(unit, true);
+
+			for (auto otherUnit : units)
+			{
+				if (battle.battleCanAttackUnit(unit, otherUnit))
+					for (auto position : otherUnit->getHexes())
+					{
+						if (battle.battleCanAttackHex(availableHexes, unit, position))
+							return true;
+					}
+			}
+			return false;
 		};
 
 		const auto & getTowerAttackValue = [&battle, &next] (const battle::Unit * unit)


### PR DESCRIPTION
There are two goals.
1. Improve separation of game logic (CBattleInfoCallback) from UI logic (BattleFieldController, BattleActionsController).
2. Deduplicate logic code (written ad-hoc across several files, sometimes slightly differently).

Hopefully, this improves maintainability and removes / prevents bugs.
Some changes are prior to #6296 (to be updated after merge).
Comments are welcome.

List of changes:
- move fromWhichHexAttack to CBattleInfoCallback
- add toWhichHexMove (unifying incoherent duplicates)
- add battleGetOccupiableHexes
- add battleCanAttackHex for spatial attack check
- add battleCanAttackUnit for non-spatial attack check
- add headDirection to Unit (removing destShiftDir from CStack)
- remove redundant game logic from selectAttackDirection
- remove redundant game logic from BattleFieldController and BattleActionsController
- fix no consideration for double-wide tail attack in BattleFlowProcessor
- fix #6302 wrong moat stopping condition