### PR TITLE
Add BattleEnded pack

### DIFF
--- a/AI/Nullkiller/AIGateway.cpp
+++ b/AI/Nullkiller/AIGateway.cpp
@@ -485,6 +485,13 @@ void AIGateway::battleResultsApplied()
 	LOG_TRACE(logAi);
 	NET_EVENT_HANDLER;
 	assert(status.getBattle() == ENDING_BATTLE);
+}
+
+void AIGateway::battleEnded()
+{
+	LOG_TRACE(logAi);
+	NET_EVENT_HANDLER;
+	assert(status.getBattle() == ENDING_BATTLE);
 	status.setBattle(NO_BATTLE);
 }
 

--- a/AI/Nullkiller/AIGateway.h
+++ b/AI/Nullkiller/AIGateway.h
@@ -141,6 +141,7 @@ public:
 	void heroManaPointsChanged(const CGHeroInstance * hero) override;
 	void heroSecondarySkillChanged(const CGHeroInstance * hero, int which, int val) override;
 	void battleResultsApplied() override;
+	void battleEnded() override;
 	void beforeObjectPropertyChanged(const SetObjectProperty * sop) override;
 	void objectPropertyChanged(const SetObjectProperty * sop) override;
 	void buildChanged(const CGTownInstance * town, BuildingID buildingID, int what) override;

--- a/AI/VCAI/VCAI.cpp
+++ b/AI/VCAI/VCAI.cpp
@@ -552,6 +552,13 @@ void VCAI::battleResultsApplied()
 	LOG_TRACE(logAi);
 	NET_EVENT_HANDLER;
 	assert(status.getBattle() == ENDING_BATTLE);
+}
+
+void VCAI::battleEnded()
+{
+	LOG_TRACE(logAi);
+	NET_EVENT_HANDLER;
+	assert(status.getBattle() == ENDING_BATTLE);
 	status.setBattle(NO_BATTLE);
 }
 

--- a/AI/VCAI/VCAI.h
+++ b/AI/VCAI/VCAI.h
@@ -182,6 +182,7 @@ public:
 	void heroManaPointsChanged(const CGHeroInstance * hero) override;
 	void heroSecondarySkillChanged(const CGHeroInstance * hero, int which, int val) override;
 	void battleResultsApplied() override;
+	void battleEnded() override;
 	void beforeObjectPropertyChanged(const SetObjectProperty * sop) override;
 	void objectPropertyChanged(const SetObjectProperty * sop) override;
 	void buildChanged(const CGTownInstance * town, BuildingID buildingID, int what) override;

--- a/client/ClientNetPackVisitors.h
+++ b/client/ClientNetPackVisitors.h
@@ -86,6 +86,7 @@ public:
 	void visitSetStackEffect(SetStackEffect & pack) override;
 	void visitStacksInjured(StacksInjured & pack) override;
 	void visitBattleResultsApplied(BattleResultsApplied & pack) override;
+	void visitBattleEnded(BattleEnded & pack) override;
 	void visitBattleUnitsChanged(BattleUnitsChanged & pack) override;
 	void visitBattleObstaclesChanged(BattleObstaclesChanged & pack) override;
 	void visitCatapultAttack(CatapultAttack & pack) override;

--- a/client/NetPacksClient.cpp
+++ b/client/NetPacksClient.cpp
@@ -868,6 +868,13 @@ void ApplyClientNetPackVisitor::visitBattleResultsApplied(BattleResultsApplied &
 	callInterfaceIfPresent(cl, PlayerColor::SPECTATOR, &IGameEventsReceiver::battleResultsApplied);
 }
 
+void ApplyClientNetPackVisitor::visitBattleEnded(BattleEnded & pack)
+{
+	callInterfaceIfPresent(cl, pack.victor, &IGameEventsReceiver::battleEnded);
+	callInterfaceIfPresent(cl, pack.loser, &IGameEventsReceiver::battleEnded);
+	callInterfaceIfPresent(cl, PlayerColor::SPECTATOR, &IGameEventsReceiver::battleEnded);
+}
+
 void ApplyClientNetPackVisitor::visitBattleUnitsChanged(BattleUnitsChanged & pack)
 {
 	callBattleInterfaceIfPresentForBothSides(cl, pack.battleID, &IBattleEventsReceiver::battleUnitsChanged, pack.battleID, pack.changedStacks);

--- a/lib/callback/IGameEventsReceiver.h
+++ b/lib/callback/IGameEventsReceiver.h
@@ -41,6 +41,7 @@ public:
 	virtual void buildChanged(const CGTownInstance *town, BuildingID buildingID, int what){}; //what: 1 - built, 2 - demolished
 
 	virtual void battleResultsApplied(){}; //called when all effects of last battle are applied
+	virtual void battleEnded(){}; //called when a battle has ended
 
 	virtual void garrisonsChanged(ObjectInstanceID id1, ObjectInstanceID id2){};
 

--- a/lib/gameState/GameStatePackVisitor.cpp
+++ b/lib/gameState/GameStatePackVisitor.cpp
@@ -1427,7 +1427,14 @@ void GameStatePackVisitor::visitBattleResultsApplied(BattleResultsApplied & pack
 			hero->mana = std::min(hero->mana, currentBattle.getSide(i).initialMana);
 		}
 	}
+}
 
+void GameStatePackVisitor::visitBattleEnded(BattleEnded & pack)
+{
+	auto battleIter = boost::range::find_if(gs.currentBattles, [&](const auto & battle)
+	{
+		return battle->battleID == pack.battleID;
+	});
 	assert(battleIter != gs.currentBattles.end());
 	gs.currentBattles.erase(battleIter);
 }

--- a/lib/gameState/GameStatePackVisitor.h
+++ b/lib/gameState/GameStatePackVisitor.h
@@ -102,6 +102,7 @@ public:
 	void visitBattleNextRound(BattleNextRound & pack) override;
 	void visitBattleCancelled(BattleCancelled & pack) override;
 	void visitBattleResultsApplied(BattleResultsApplied & pack) override;
+	void visitBattleEnded(BattleEnded & pack) override;
 	void visitBattleResultAccepted(BattleResultAccepted & pack) override;
 	void visitTurnTimeUpdate(TurnTimeUpdate & pack) override;
 };

--- a/lib/networkPacks/NetPackVisitor.h
+++ b/lib/networkPacks/NetPackVisitor.h
@@ -113,6 +113,7 @@ public:
 	virtual void visitSetStackEffect(SetStackEffect & pack) {}
 	virtual void visitStacksInjured(StacksInjured & pack) {}
 	virtual void visitBattleResultsApplied(BattleResultsApplied & pack) {}
+	virtual void visitBattleEnded(BattleEnded & pack) {}
 	virtual void visitBattleObstaclesChanged(BattleObstaclesChanged & pack) {}
 	virtual void visitBattleSetStackProperty(BattleSetStackProperty & pack) {}
 	virtual void visitBattleTriggerEffect(BattleTriggerEffect & pack) {}

--- a/lib/networkPacks/NetPacksLib.cpp
+++ b/lib/networkPacks/NetPacksLib.cpp
@@ -483,6 +483,11 @@ void BattleResultsApplied::visitTyped(ICPackVisitor & visitor)
 	visitor.visitBattleResultsApplied(*this);
 }
 
+void BattleEnded::visitTyped(ICPackVisitor & visitor)
+{
+	visitor.visitBattleEnded(*this);
+}
+
 void BattleObstaclesChanged::visitTyped(ICPackVisitor & visitor)
 {
 	visitor.visitBattleObstaclesChanged(*this);

--- a/lib/networkPacks/PacksForClientBattle.h
+++ b/lib/networkPacks/PacksForClientBattle.h
@@ -415,6 +415,22 @@ struct DLL_LINKAGE BattleResultsApplied : public CPackForClient
 	}
 };
 
+struct DLL_LINKAGE BattleEnded : public CPackForClient
+{
+	BattleID battleID = BattleID::NONE;
+	PlayerColor victor;
+	PlayerColor loser;
+	void visitTyped(ICPackVisitor & visitor) override;
+
+	template <typename Handler> void serialize(Handler & h)
+	{
+		h & battleID;
+		h & victor;
+		h & loser;
+		assert(battleID != BattleID::NONE);
+	}
+};
+
 struct DLL_LINKAGE BattleObstaclesChanged : public CPackForClient
 {
 	BattleID battleID = BattleID::NONE;

--- a/lib/serializer/RegisterTypes.h
+++ b/lib/serializer/RegisterTypes.h
@@ -294,6 +294,7 @@ void registerTypes(Serializer &s)
 	s.template registerType<ChangeTownName>(252);
 	s.template registerType<SetTownName>(253);
 	s.template registerType<LobbySetBattleOnlyModeStartInfo>(254);
+	s.template registerType<BattleEnded>(255);
 }
 
 VCMI_LIB_NAMESPACE_END

--- a/server/battles/BattleResultProcessor.cpp
+++ b/server/battles/BattleResultProcessor.cpp
@@ -558,6 +558,7 @@ void BattleResultProcessor::battleFinalize(const BattleID & battleID, const Batt
 	resultsApplied.battleID = battleID;
 	resultsApplied.victor = finishingBattle->victor;
 	resultsApplied.loser = finishingBattle->loser;
+	//BattleResultsApplied does not end the battle, it only applies most of its consequences
 	gameHandler->sendAndApply(resultsApplied);
 
 	// Remove beaten hero
@@ -611,6 +612,13 @@ void BattleResultProcessor::battleFinalize(const BattleID & battleID, const Batt
 		gameHandler->statistics->accumulatedValues[finishingBattle->loser].numHeroEscaped++;
 		gameHandler->heroPool->onHeroEscaped(finishingBattle->loser, loserHero);
 	}
+
+	//notify all players that battle has ended after all consequences are applied
+	BattleEnded ended;
+	ended.battleID = battleID;
+	ended.victor = finishingBattle->victor;
+	ended.loser = finishingBattle->loser;
+	gameHandler->sendAndApply(ended);
 
 	//handle victory/loss of engaged players
 	gameHandler->checkVictoryLossConditions({finishingBattle->loser, finishingBattle->victor});

--- a/test/vcai/mock_VCAI.h
+++ b/test/vcai/mock_VCAI.h
@@ -78,6 +78,7 @@ public:
 	MOCK_METHOD1(heroManaPointsChanged, void(const CGHeroInstance * hero));
 	MOCK_METHOD3(heroSecondarySkillChanged, void(const CGHeroInstance * hero, int which, int val));
 	MOCK_METHOD0(battleResultsApplied, void());
+	MOCK_METHOD0(battleEnded, void());
 	MOCK_METHOD1(objectPropertyChanged, void(const SetObjectProperty * sop));
 	MOCK_METHOD3(buildChanged, void(const CGTownInstance * town, BuildingID buildingID, int what));
 	MOCK_METHOD3(heroBonusChanged, void(const CGHeroInstance * hero, const Bonus & bonus, bool gain));


### PR DESCRIPTION
Proposed fix for #6309 (up for discussion).

What currently happens when nullkiller ai defeats a garrisoned hero in a town:
1. BattleResultProcessor sends the signal that the battle has ended
https://github.com/vcmi/vcmi/blob/81db5c7cf4746dc61cc2d38f03f99fcd3916939d/server/battles/BattleResultProcessor.cpp#L561
2. the ai sets `NO_BATTLE`
https://github.com/vcmi/vcmi/blob/81db5c7cf4746dc61cc2d38f03f99fcd3916939d/AI/Nullkiller/AIGateway.cpp#L488
3. the ai understand that it can continue (there is no ongoing battle, movement, or other tasks)
https://github.com/vcmi/vcmi/blob/81db5c7cf4746dc61cc2d38f03f99fcd3916939d/AI/Nullkiller/AIGateway.cpp#L1770
4. the ai obtains a incoherent gamestate, because the losing hero is not yet removed from the town
https://github.com/vcmi/vcmi/blob/81db5c7cf4746dc61cc2d38f03f99fcd3916939d/AI/Nullkiller/Analyzers/ArmyManager.cpp#L482
5. at a later point, losing hero removal is initiated in BattleResultProcessor (which is too late!)
https://github.com/vcmi/vcmi/blob/81db5c7cf4746dc61cc2d38f03f99fcd3916939d/server/battles/BattleResultProcessor.cpp#L567

The resulting behavior due to 4. is arbitrary. Mostly it is fine if the ai does not interact with the foreign dead player in town. Sometimes there are invalid instructions and sometimes a segfault. This also happens with no mods.

The proposed fix delays the signal which truly ends the battle until all battle effects (including hero removal) are processed.