### PR TITLE
Prevent crash when opening stack's info window in current Haven town fort window

### DIFF
--- a/lib/bonuses/Limiters.cpp
+++ b/lib/bonuses/Limiters.cpp
@@ -287,16 +287,9 @@ ILimiter::EDecision CreatureTerrainLimiter::limit(const BonusLimitationContext &
 	}
 	else
 	{
-		if (context.node.getNodeType() == BonusNodeType::STACK_BATTLE)
+		if(const auto * unit = retrieveStackInstance(&context.node))
 		{
-			const auto * unit = dynamic_cast<const CStack *>(&context.node);
-			if (unit->getCurrentTerrain() == terrainType)
-				return ILimiter::EDecision::ACCEPT;
-		}
-		else
-		{
-			const auto * unit = dynamic_cast<const CStackInstance*>(&context.node);
-			if (unit->getCurrentTerrain() == terrainType)
+			if (unit->getArmy() && unit->getCurrentTerrain() == terrainType)
 				return ILimiter::EDecision::ACCEPT;
 		}
 	}


### PR DESCRIPTION
In the issue below the assert is triggered when stack's info window is opened in fort.

```cpp
TerrainId CStackInstance::getCurrentTerrain() const
{
	assert(getArmy() != nullptr);
	return getArmy()->getCurrentTerrain();
}
```

- fixes: #6176

In truth this fix is rather preventing the crash. The real problem might be elsewhere. 