### PR TITLE
Fixed golems' level

### DIFF
--- a/config/creatures/neutral.json
+++ b/config/creatures/neutral.json
@@ -3,7 +3,7 @@
 	"goldGolem" :
 	{
 		"index": 116,
-		"level": 4,
+		"level": 5,
 		"faction": "neutral",
 		"abilities":
 		{
@@ -36,7 +36,7 @@
 	"diamondGolem" :
 	{
 		"index": 117,
-		"level": 5,
+		"level": 6,
 		"faction": "neutral",
 		"abilities":
 		{


### PR DESCRIPTION
Gold and Diamond golems' level changed from 4 and 5 to 5 and 6. https://heroes.thelazy.net/index.php/Diamond_Golem and some other source I found state that the ones from that PR are correct.