### PR TITLE
Fix undefined unlocks on unlocked mutex

### DIFF
--- a/lib/UnlockGuard.h
+++ b/lib/UnlockGuard.h
@@ -37,7 +37,7 @@ namespace vstd
 		protected:
 			void unlock(Mutex &m)
 			{
-				if (m.try_lock_shared())
+				if (m.try_lock())
 					logGlobal->error("Failed to unlock shared mutex - it was not locked");
 				m.unlock_shared();
 			}


### PR DESCRIPTION
`makeUnlockGuard` sometimes tried to unlock a mutex which is not locked, leading to unspecified behavior (can be different on different platforms).
Let's control the situation better and also protocol it for debugging.

Edit: currently this is for debugging (in my build there is also undefined behavior). A better solution is needed.

Possibly related to https://github.com/vcmi/vcmi/issues/5803