### PR TITLE
Aquire interfaceMutex before shutdown

### DIFF
--- a/client/CServerHandler.cpp
+++ b/client/CServerHandler.cpp
@@ -78,6 +78,7 @@ CServerHandler::~CServerHandler()
 	serverRunner.reset();
 	if (threadNetwork.joinable())
 	{
+		//ENGINE->interfaceMutex must have been locked by the current thread, otherwise an unlock will cause undefined behavior
 		auto unlockInterface = vstd::makeUnlockGuard(ENGINE->interfaceMutex);
 		threadNetwork.join();
 	}
@@ -91,6 +92,7 @@ void CServerHandler::endNetwork()
 
 	if (threadNetwork.joinable())
 	{
+		//ENGINE->interfaceMutex must have been locked by the current thread, otherwise an unlock will cause undefined behavior
 		auto unlockInterface = vstd::makeUnlockGuard(ENGINE->interfaceMutex);
 		threadNetwork.join();
 	}

--- a/clientapp/EntryPoint.cpp
+++ b/clientapp/EntryPoint.cpp
@@ -398,7 +398,11 @@ int main(int argc, char * argv[])
 		logGlobal->info("Main loop termination requested");
 	}
 
-	GAME->server().endNetwork();
+	{
+		//aquire interfaceMutex to prevent undefined behavior on vstd::makeUnlockGuard(ENGINE->interfaceMutex)
+		std::scoped_lock interfaceLock(ENGINE->interfaceMutex);
+		GAME->server().endNetwork();
+	}
 
 	if(!settings["session"]["headless"].Bool())
 	{


### PR DESCRIPTION
Fixes #6336 in the specific instance of regular shutdown.
Possibly related to #5803.