### PR TITLE
fix limiter is invalid in SPELL_LIKE_ATTACK bonus

### DIFF
--- a/server/battles/BattleActionProcessor.cpp
+++ b/server/battles/BattleActionProcessor.cpp
@@ -976,7 +976,7 @@ void BattleActionProcessor::makeAttack(const CBattleInfoCallback & battle, const
 	if (useCustomAnimation)
 		bat.flags |= BattleAttack::CUSTOM_ANIMATION;
 
-	std::shared_ptr<const Bonus> bonus = attacker->getFirstBonus(Selector::type()(BonusType::SPELL_LIKE_ATTACK));
+	std::shared_ptr<const Bonus> bonus = attacker->getBonus(Selector::type()(BonusType::SPELL_LIKE_ATTACK));
 	if(bonus && ranged && bonus->subtype.hasValue()) //TODO: make it work in melee?
 	{
 		//this is need for displaying hit animation


### PR DESCRIPTION
getFirstBonus only reads bonuses and ignores limiters; use getBonus when limiter evaluation is required.

fixed #5037