### PR TITLE
Fix issues with object customization in rmg

### DIFF
--- a/config/schemas/template.json
+++ b/config/schemas/template.json
@@ -86,9 +86,20 @@
 							}
 						},
 						"bannedObjects": {
-							"type": "array",
-							"items": {
-								"type": "string"
+							"type": "object",
+							"additionalProperties": {
+								"anyOf" : [
+									{
+										"type": "boolean"
+									},
+									{
+										"type": "object",
+										"additionalProperties": {
+											"type": "boolean"
+										}
+									}
+								]
+								
 							}
 						},
 						"commonObjects": {
@@ -96,7 +107,10 @@
 							"items": {
 								"type": "object",
 								"properties": {
-									"id": {
+									"type": {
+										"type": "string"
+									},
+									"subtype": {
 										"type": "string"
 									},
 									"rmg": {
@@ -115,7 +129,7 @@
 										"required": ["value", "rarity"]
 									}
 								},
-								"required": ["id", "rmg"]
+								"required": ["type", "rmg"]
 							}
 						}
 					}

--- a/docs/modders/Random_Map_Template.md
+++ b/docs/modders/Random_Map_Template.md
@@ -210,16 +210,51 @@
 		// All of objects of this kind will be removed from zone
 		// Possible values: "all", "none", "creatureBank", "bonus", "dwelling", "resource", "resourceGenerator", "spellScroll", "randomArtifact", "pandorasBox", "questArtifact", "seerHut", "other
 		"bannedCategories" : ["all", "dwelling", "creatureBank", "other"],
+
 		// Specify object types and subtypes
-		"bannedObjects" :["core:object.randomArtifactRelic"],
-		// Configure individual common objects - overrides banned objects
+		"bannedObjects" : {
+			// ban a specific object from base game or from any dependent mod. Object with such ID must exist
+			"randomArtifactRelic" : true,
+			
+			// ban object named townGate from mod 'hota.mapobjects'. Mod can be used without explicit dependency
+			// If mod with such name is not loaded, this entry will be ignored and will have no effect
+			"hota.mapobjects:townGate" : true,
+			
+			// ban only land version of Cartographer. Other versions, such as water and subterra cartographers may still appear on map
+			"cartographer" : {
+				"cartographerLand" : true
+			}
+		},
+
+		// Configure individual common objects. 
+		// Any object in this list will be excluded from regular placement rules, similarly to bannedObjects
 		"commonObjects":
 		[
 			{
-				"id" : "core:object.creatureBank.dragonFlyHive",
+				// configure water cartographer properties
+				"type" : "cartographer",
+				"subtype" : "cartographerWater",
 				"rmg" : {
 					"value"		: 9000,
 					"rarity"	: 500,
+					"zoneLimit" : 2
+				}
+			},
+			{
+				// configure scholar properties. Behavior unspecified if there are multiple 'scholar' objects
+				"type" : "scholar",
+				"rmg" : {
+					"value"		: 900,
+					"rarity"	: 50,
+					"zoneLimit" : 2
+				}
+			},
+			{
+				// configure town gate (hota) properties. This entry will have no effect if mod is not enabled
+				"type" : "hota.mapobjects:townGate",
+				"rmg" : {
+					"value"		: 2000,
+					"rarity"	: 100,
 					"zoneLimit" : 2
 				}
 			}

--- a/lib/mapObjectConstructors/CObjectClassesHandler.cpp
+++ b/lib/mapObjectConstructors/CObjectClassesHandler.cpp
@@ -433,7 +433,7 @@ CompoundMapObjectID CObjectClassesHandler::getCompoundIdentifier(const std::stri
 	if(id)
 	{
 		if (subtype.empty())
-			return CompoundMapObjectID(id.value(), 0);
+			return CompoundMapObjectID(id.value(), -1);
 
 		const auto & object = mapObjectTypes.at(id.value());
 		std::optional<si32> subID = LIBRARY->identifiers()->getIdentifier(scope, object->getJsonKey(), subtype);
@@ -449,7 +449,7 @@ CompoundMapObjectID CObjectClassesHandler::getCompoundIdentifier(const std::stri
 
 CompoundMapObjectID CObjectClassesHandler::getCompoundIdentifier(const std::string & objectName) const
 {
-	std::string subtype = "object"; //Default for objects with no subIds
+	std::string subtype;
 	std::string type;
 
 	auto scopeAndFullName = vstd::splitStringToPair(objectName, ':');

--- a/lib/rmg/ObjectConfig.h
+++ b/lib/rmg/ObjectConfig.h
@@ -40,7 +40,7 @@ public:
 	};
 
 	void addBannedObject(const CompoundMapObjectID & objid);
-	void addCustomObject(const ObjectInfo & object, const CompoundMapObjectID & objid);
+	void addCustomObject(const ObjectInfo & object);
 	void clearBannedObjects();
 	void clearCustomObjects();
 	const std::vector<CompoundMapObjectID> & getBannedObjects() const;

--- a/lib/rmg/ObjectInfo.h
+++ b/lib/rmg/ObjectInfo.h
@@ -20,6 +20,7 @@ class CGObjectInstance;
 
 struct DLL_LINKAGE ObjectInfo
 {
+	ObjectInfo() = default;
 	ObjectInfo(si32 ID, si32 subID);
 	ObjectInfo(CompoundMapObjectID id);
 	ObjectInfo(const ObjectInfo & other);

--- a/lib/rmg/modificators/TreasurePlacer.cpp
+++ b/lib/rmg/modificators/TreasurePlacer.cpp
@@ -1159,7 +1159,8 @@ void TreasurePlacer::ObjectPool::patchWithZoneConfig(const Zone & zone, Treasure
 			for (const auto & templ : object.templates)
 			{
 				CompoundMapObjectID key = object.getCompoundID();
-				if (bannedObjectsSet.count(key))
+				CompoundMapObjectID keyGroup( key.primaryID, -1);
+				if (bannedObjectsSet.count(key) || bannedObjectsSet.count(keyGroup))
 				{
 					// FIXME: Stopped working, nothing is banned
 					logGlobal->info("Banning object %s from possible objects", templ->stringID);


### PR DESCRIPTION
Fixed several issues with resolving identifiers of map objects when banning or overriding rmg properties of map objects.

Syntax should now be way simple and more readable, e.g:
```json
"bannedObjects" : {
	"randomArtifactRelic" : true,
	"hota.mapobjects:townGate" : true,
	"cartographer" : {
		"cartographerLand" : true
	}
}
```

Objects with customized rmg properties are now implicitly banned - to prevent default rmg properties from having an effect.

In addition, it is now possible to ban or customize objects even without explicit mod dependency, similar to how object bans work in 1.7. If corresponding mod is not active, object ban/customization will be ignored.

See changes in docs in this PR for docs.

Resolved issues:

- Fixes #5554
- Fixes #5556
- Fixes #6354

NOTE: old (1.6) rmg templates will work as before, however changed format will be reported by validation - please update mods either before or after 1.7 release