### PR TITLE
fix zero level spell hint text

### DIFF
--- a/Mods/vcmi/Content/config/chinese.json
+++ b/Mods/vcmi/Content/config/chinese.json
@@ -103,6 +103,7 @@
 	"vcmi.spellBook.search" : "搜索中...",
 	"vcmi.spellBook.tab.hover" : "%s法术",
 	"vcmi.spellBook.tab.help" : "切换以查看%s法术",
+    "vcmi.spellBook.zero_level.hint" : "0级",
 
 	"vcmi.spellResearch.canNotAfford" : "你没有足够的资源来将{%SPELL1}替换为{%SPELL2}。但你依然可以弃掉此法术，继续法术研究。",
 	"vcmi.spellResearch.comeAgain" : "今日已研究过法术，请明日再来。",

--- a/Mods/vcmi/Content/config/english.json
+++ b/Mods/vcmi/Content/config/english.json
@@ -103,6 +103,7 @@
 	"vcmi.spellBook.search" : "search...",
 	"vcmi.spellBook.tab.hover" : "%s Spells",
 	"vcmi.spellBook.tab.help" : "Turn to view %s spells",
+    "vcmi.spellBook.zero_level.hint" : "0th lev",
 
 	"vcmi.spellResearch.canNotAfford" : "You can't afford to replace {%SPELL1} with {%SPELL2}. But you can still discard this spell and continue spell research.",
 	"vcmi.spellResearch.comeAgain" : "Research has already been done today. Come back tomorrow.",

--- a/client/windows/CSpellWindow.cpp
+++ b/client/windows/CSpellWindow.cpp
@@ -848,15 +848,18 @@ void CSpellWindow::SpellArea::setSpell(const CSpell * spell)
 		name->setText(mySpell->getNameTranslated());
 
 		level->color = secondLineColor;
+		std::string levelStr = mySpell->getLevel() > 0 ? LIBRARY->generaltexth->allTexts[171 + mySpell->getLevel()]
+												   : LIBRARY->generaltexth->translate("vcmi.spellBook.zero_level.hint");
+
 		if(schoolLevel > 0)
 		{
 			boost::format fmt("%s/%s");
-			fmt % LIBRARY->generaltexth->allTexts[171 + mySpell->getLevel()];
+			fmt % levelStr;
 			fmt % LIBRARY->generaltexth->levels[3+(schoolLevel-1)];//lines 4-6
 			level->setText(fmt.str());
 		}
 		else
-			level->setText(LIBRARY->generaltexth->allTexts[171 + mySpell->getLevel()]);
+			level->setText(levelStr);
 
 		cost->color = secondLineColor;
 		boost::format costfmt("%s: %d");


### PR DESCRIPTION
Fixed a bug where Level-0 spells could not display their level text correctly in the spellbook.