### PR TITLE
Restructure unpropagation logic

### DIFF
--- a/lib/bonuses/CBonusSystemNode.cpp
+++ b/lib/bonuses/CBonusSystemNode.cpp
@@ -366,7 +366,7 @@ void CBonusSystemNode::propagateBonus(const std::shared_ptr<Bonus> & b, const CB
 			? source.getUpdatedBonus(b, b->propagationUpdater)
 			: b;
 		bonuses.push_back(propagated);
-		logBonus->trace("#$# %s #propagated to# %s",  propagated->Description(nullptr), nodeName());
+		logBonus->trace("#$# %s #propagated to# %s", propagated->Description(nullptr), nodeName());
 		invalidateChildrenNodes(globalCounter);
 	}
 
@@ -380,20 +380,20 @@ void CBonusSystemNode::unpropagateBonus(const std::shared_ptr<Bonus> & b)
 {
 	if(b->propagator->shouldBeAttached(this))
 	{
-		if (bonuses -= b)
-			logBonus->trace("#$# %s #is no longer propagated to# %s",  b->Description(nullptr), nodeName());
-		else
-			logBonus->warn("Attempt to remove #$# %s, which is not propagated to %s", b->Description(nullptr), nodeName());
-
-		bonuses.remove_if([b](const auto & bonus)
+		if (b->propagationUpdater)
 		{
-			if (bonus->propagationUpdater && bonus->propagationUpdater == b->propagationUpdater)
+			bonuses.remove_if([b](const auto & bonus)
 			{
-
-				return true;
-			}
-			return false;
-		});
+				return bonus->propagationUpdater && bonus->propagationUpdater == b->propagationUpdater;
+			});
+		}
+		else
+		{
+			if (bonuses -= b)
+				logBonus->trace("#$# %s #is no longer propagated to# %s", b->Description(nullptr), nodeName());
+			else
+				logBonus->warn("Attempt to remove #$# %s, which is not propagated to %s", b->Description(nullptr), nodeName());
+		}
 
 		invalidateChildrenNodes(globalCounter);
 	}


### PR DESCRIPTION
During gameplay I get many `Attempt to remove #$# [...], which is not propagated to [...].`.
This is because in `CBonusSystemNode::propagateBonus` new Bonus instances are created (according to updaters) and added to `bonuses`.
Therefore, in `CBonusSystemNode::unpropagateBonus` the original bonus object is not in `bonuses` and `if (bonuses -= b)` fails.

The fix is that `if (bonuses -= b)` is not executed (and would be redundant anyway) if `b->propagationUpdater` is set. In this case `bonuses.remove_if` will remove the bonus.