### PR TITLE
Uniform Quickload and Restart logic

### DIFF
--- a/client/CServerHandler.cpp
+++ b/client/CServerHandler.cpp
@@ -724,13 +724,6 @@ std::optional<std::string> CServerHandler::canQuickLoadGame(const std::string & 
 
 void CServerHandler::quickLoadGame(const std::string & path)
 {
-	if(!settings["session"]["headless"].Bool())
-	{
-		if(si->campState && !si->campState->getLoadingBackground().empty())
-			ENGINE->windows().createAndPushWindow<CLoadingScreen>(si->campState->getLoadingBackground());
-		else
-			ENGINE->windows().createAndPushWindow<CLoadingScreen>();
-	}
 	LobbyQuickLoadGame pack;
 	pack.saveFilePath = path;
 	sendLobbyPack(pack);

--- a/client/NetPacksLobbyClient.cpp
+++ b/client/NetPacksLobbyClient.cpp
@@ -44,6 +44,9 @@
 void ApplyOnLobbyHandlerNetPackVisitor::visitLobbyQuickLoadGame(LobbyQuickLoadGame & pack)
 {
 	assert(handler.getState() == EClientState::GAMEPLAY);
+
+	handler.restartGameplay();
+	handler.sendStartGame();
 }
 
 void ApplyOnLobbyHandlerNetPackVisitor::visitLobbyClientConnected(LobbyClientConnected & pack)
@@ -160,13 +163,6 @@ void ApplyOnLobbyHandlerNetPackVisitor::visitLobbyPrepareStartGame(LobbyPrepareS
 
 void ApplyOnLobbyHandlerNetPackVisitor::visitLobbyStartGame(LobbyStartGame & pack)
 {
-	// Handle mid-game reload
-	if (handler.getState() == EClientState::GAMEPLAY) {
-			handler.client->finishGameplay();
-			handler.client->endGame();
-			handler.client.reset();
-	}
-
 	handler.setState(EClientState::STARTING);
 	if(handler.si->mode != EStartMode::LOAD_GAME)
 	{


### PR DESCRIPTION
Fixes #6389.

Made quick load logic follow restart logic more closely.
This eliminates double cleanup potential and makes handing of mid-game reloads by quickload unnecessary.
Quickload loading screen now follows the same path as restart.

Tested (quick load from map / quick load from battle / restart) on single player, hotseat, and campaign mode.