### PR TITLE
Postpone next turn logic after victory / loss status is settled

### DIFF
--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -3654,9 +3654,9 @@ void CGameHandler::checkVictoryLossConditionsForPlayer(PlayerColor player)
 			}
 			checkVictoryLossConditions(playerColors);
 			// give turn to next player(s)
-			// FIXME: this may cause multiple calls to onPlayerEndsGame if multiple players lose in chain reaction
+			// FIXME: this may cause multiple calls to resumeTurnOrder if multiple players lose in chain reaction
 			if(gameServer().getState() != EServerState::SHUTDOWN)
-				turnOrder->onPlayerEndsGame(player);
+				turnOrder->resumeTurnOrder();
 		}
 	}
 }

--- a/server/processors/TurnOrderProcessor.cpp
+++ b/server/processors/TurnOrderProcessor.cpp
@@ -307,11 +307,7 @@ void TurnOrderProcessor::doEndPlayerTurn(PlayerColor which)
 	pet.player = which;
 	gameHandler->sendAndApply(pet);
 
-	if (!awaitingPlayers.empty())
-		tryStartTurnsForPlayers();
-
-	if (actingPlayers.empty())
-		doStartNewDay();
+	resumeTurnOrder();
 
 	assert(!actingPlayers.empty());
 }
@@ -328,10 +324,8 @@ void TurnOrderProcessor::removePlayer(PlayerColor which)
 	actedPlayers.erase(which);
 }
 
-void TurnOrderProcessor::onPlayerEndsGame(PlayerColor which)
+void TurnOrderProcessor::resumeTurnOrder()
 {
-	removePlayer(which);
-
 	if (!awaitingPlayers.empty())
 		tryStartTurnsForPlayers();
 
@@ -362,7 +356,7 @@ bool TurnOrderProcessor::onPlayerEndsTurn(PlayerColor which)
 	gameHandler->onPlayerTurnEnded(which);
 
 	// it is possible that player have lost - e.g. spent 7 days without town
-	// in this case - don't call doEndPlayerTurn - turn transfer was already handled by onPlayerEndsGame
+	// in this case - don't call doEndPlayerTurn - turn transfer was already handled by resumeTurnOrder
 	if(gameHandler->gameInfo().getPlayerStatus(which) == EPlayerStatus::INGAME)
 		doEndPlayerTurn(which);
 

--- a/server/processors/TurnOrderProcessor.h
+++ b/server/processors/TurnOrderProcessor.h
@@ -91,8 +91,8 @@ public:
 	/// Ends player turn and removes this player from turn order
 	void removePlayer(PlayerColor which);
 
-	/// Ends player turn and removes this player from turn order, starting turns for next players if possible
-	void onPlayerEndsGame(PlayerColor which);
+	/// Start turns for next players if possible
+	void resumeTurnOrder();
 
 	/// Start game (or resume from save) and send PlayerStartsTurn pack to player(s)
 	void onGameStarted();


### PR DESCRIPTION
Fixes #6366.

Only run next turn code after victory / loss status is settled and the server is not shutting down.