### PR TITLE
fix NodeStorage::initialize for removed player

### DIFF
--- a/lib/pathfinder/NodeStorage.cpp
+++ b/lib/pathfinder/NodeStorage.cpp
@@ -28,7 +28,14 @@ void NodeStorage::initialize(const PathfinderOptions & options, const IGameInfoC
 	int3 pos;
 	const PlayerColor player = out.hero->tempOwner;
 	const int3 sizes = gameInfo.getMapSize();
-	const auto & fow = gameInfo.getPlayerTeam(player)->fogOfWarMap;
+	const TeamState * team = gameInfo.getPlayerTeam(player);
+	if (!team)
+	{
+		logGlobal->warn("Hero's owner %s has no valid team", player.toString());
+		return;
+	}
+
+	const auto & fow = team->fogOfWarMap;
 
 	//make 200% sure that these are loop invariants (also a bit shorter code), let compiler do the rest(loop unswitching)
 	const bool useFlying = options.useFlying;


### PR DESCRIPTION
Fixes #1962.

What happend: on victory / loss the server starts a shutdown, but object removal code is still executed leading to reinitialization of NodeStorage.

With the proposed fix the situation in the underlying issue is resolved as expected (one message for red loss, one message for blue win, end game screen).

I added a warning to global log, if the changed code would silence an otherwise illegal call to `NodeStorage::initialize` in a different setting.