### PR TITLE
Fixed issues with object customization in RMG

### DIFF
--- a/lib/json/JsonNode.cpp
+++ b/lib/json/JsonNode.cpp
@@ -242,6 +242,11 @@ bool JsonNode::isNull() const
 	return getType() == JsonType::DATA_NULL;
 }
 
+bool JsonNode::isBool() const
+{
+	return getType() == JsonType::DATA_BOOL;
+}
+
 bool JsonNode::isNumber() const
 {
 	return getType() == JsonType::DATA_INTEGER || getType() == JsonType::DATA_FLOAT;

--- a/lib/json/JsonNode.h
+++ b/lib/json/JsonNode.h
@@ -98,6 +98,7 @@ public:
 	JsonType getType() const;
 
 	bool isNull() const;
+	bool isBool() const;
 	bool isNumber() const;
 	bool isString() const;
 	bool isVector() const;

--- a/lib/rmg/ObjectConfig.cpp
+++ b/lib/rmg/ObjectConfig.cpp
@@ -93,17 +93,22 @@ void ObjectConfig::serializeJson(JsonSerializeFormat & handler)
 		{
 			LIBRARY->identifiers()->requestIdentifierIfFound(node.second.getModScope(), "object", node.first, [this, node](int primaryID)
 			{
-				if (node.second.Bool())
-					addBannedObject(CompoundMapObjectID(primaryID, -1));
-
-				for (const auto & subNode : node.second.Struct())
+				if (node.second.isBool())
 				{
-					const std::string jsonKey = LIBRARY->objtypeh->getJsonKey(primaryID);
-
-					LIBRARY->identifiers()->requestIdentifierIfFound(node.second.getModScope(), jsonKey, subNode.first, [this, primaryID](int secondaryID)
+					if (node.second.Bool())
+						addBannedObject(CompoundMapObjectID(primaryID, -1));
+				}
+				else
+				{
+					for (const auto & subNode : node.second.Struct())
 					{
-						addBannedObject(CompoundMapObjectID(primaryID, secondaryID));
-					});
+						const std::string jsonKey = LIBRARY->objtypeh->getJsonKey(primaryID);
+
+						LIBRARY->identifiers()->requestIdentifierIfFound(node.second.getModScope(), jsonKey, subNode.first, [this, primaryID](int secondaryID)
+						{
+							addBannedObject(CompoundMapObjectID(primaryID, secondaryID));
+						});
+					}
 				}
 			});
 		}
@@ -133,7 +138,7 @@ void ObjectConfig::serializeJson(JsonSerializeFormat & handler)
 					auto objectWithID = object;
 					objectWithID.primaryID = primaryID;
 					objectWithID.secondaryID = 0;
-					addCustomObject(object);
+					addCustomObject(objectWithID);
 				}
 				else
 				{
@@ -144,7 +149,7 @@ void ObjectConfig::serializeJson(JsonSerializeFormat & handler)
 						auto objectWithID = object;
 						objectWithID.primaryID = primaryID;
 						objectWithID.secondaryID = secondaryID;
-						addCustomObject(object);
+						addCustomObject(objectWithID);
 					});
 				}
 			});


### PR DESCRIPTION
Fix for regression / incomplete code from my previous PR

Tested example:
- witch huts and prisons are banned from zone
- imp caches are banned, other creature banks permitted
- dragon utopias are limited to 1
```json
"customObjects" : {
	"bannedObjects" : {
		"witchHut" : true,
		"prison" : true,
		"creatureBank" : {
			"impCache" : true
		}
	},
	"commonObjects":
	[
		{
		"type" : "dragonUtopia",
		"subtype" : "dragonUtopia",
		"rmg" : {
			"value"     : 10000,
			"rarity"    : 100,
			"zoneLimit" : 1
			}
		}
	]
},
```