### PR TITLE
Fix infinite loop when trimming lines starting with control character…

### DIFF
--- a/client/windows/CMessage.cpp
+++ b/client/windows/CMessage.cpp
@@ -164,7 +164,13 @@ std::vector<std::string> CMessage::breakText(std::string text, size_t maxLineWid
 		{
 			// trim only if line does not starts with LF
 			// FIXME: necessary? All lines will be trimmed before returning anyway
-			boost::algorithm::trim_left_if(text, boost::algorithm::is_any_of(std::string(" ")));
+			boost::algorithm::trim_left_if(
+				text,
+				[](char c)
+				{
+					return static_cast<unsigned char>(c) <= static_cast<unsigned char>(' ');
+				}
+			);
 		}
 
 		if(opened)


### PR DESCRIPTION
This PR fixes a potential infinite loop in CMessage::breakText when processing lines that start with control characters such as \t, especially in combination with long CJK text.

Previously, the code only trimmed plain spaces (' '), while wordBreak treated all characters with ASCII value ≤ ' ' (including \t, \r, etc.) as valid break points.
This could lead to a situation where:

The line is too long to fit,

currPos falls back to wordBreak == 0,

No characters are erased from the input,

And the outer loop repeats forever with unchanged text.

The fix makes the trimming logic consistent with the break logic by removing all characters with ASCII value ≤ ' ', which guarantees forward progress in all cases.

This eliminates the infinite loop without changing the intended text layout behavior.