### PR TITLE
Add CBattleInfoEssentials::nextObstacleId

### DIFF
--- a/lib/battle/CBattleInfoEssentials.cpp
+++ b/lib/battle/CBattleInfoEssentials.cpp
@@ -44,6 +44,17 @@ int32_t CBattleInfoEssentials::battleGetEnchanterCounter(BattleSide side) const
 	return getBattle()->getEnchanterCounter(side);
 }
 
+int32_t CBattleInfoEssentials::nextObstacleId() const
+{
+	int32_t maxId = -1;
+	for (const auto & obstacle : getBattle()->getAllObstacles())
+	{
+		if (obstacle->uniqueID > maxId)
+			maxId = obstacle->uniqueID;
+	}
+	return maxId + 1;
+}
+
 std::vector<std::shared_ptr<const CObstacleInstance>> CBattleInfoEssentials::battleGetAllObstacles(std::optional<BattleSide> perspective) const
 {
 	std::vector<std::shared_ptr<const CObstacleInstance> > ret;

--- a/lib/battle/CBattleInfoEssentials.h
+++ b/lib/battle/CBattleInfoEssentials.h
@@ -43,6 +43,7 @@ public:
 	BattleField battleGetBattlefieldType() const override;
 	int32_t battleGetEnchanterCounter(BattleSide side) const;
 
+	int32_t nextObstacleId() const; //returns next available obstacle ID
 	std::vector<std::shared_ptr<const CObstacleInstance>> battleGetAllObstacles(std::optional<BattleSide> perspective = std::nullopt) const; //returns all obstacles on the battlefield
 
 	std::shared_ptr<const CObstacleInstance> battleGetObstacleByID(uint32_t ID) const;

--- a/lib/spells/effects/Moat.cpp
+++ b/lib/spells/effects/Moat.cpp
@@ -139,12 +139,7 @@ void Moat::placeObstacles(ServerCallback * server, const Mechanics * m, const Ef
 	BattleObstaclesChanged pack;
 	pack.battleID = m->battle()->getBattle()->getBattleID();
 
-	auto all = m->battle()->battleGetAllObstacles(BattleSide::ALL_KNOWING);
-
-	int obstacleIdToGive = 1;
-	for(auto & one : all)
-		if(one->uniqueID >= obstacleIdToGive)
-			obstacleIdToGive = one->uniqueID + 1;
+	int obstacleIdToGive = m->battle()->nextObstacleId();
 
 	for(const auto & destination : moatHexes)  //Moat hexes can be different obstacles
 	{

--- a/lib/spells/effects/Obstacle.cpp
+++ b/lib/spells/effects/Obstacle.cpp
@@ -275,12 +275,7 @@ void Obstacle::placeObstacles(ServerCallback * server, const Mechanics * m, cons
 	BattleObstaclesChanged pack;
 	pack.battleID = m->battle()->getBattle()->getBattleID();
 
-	auto all = m->battle()->battleGetAllObstacles(BattleSide::ALL_KNOWING);
-
-	int obstacleIdToGive = 1;
-	for(auto & one : all)
-		if(one->uniqueID >= obstacleIdToGive)
-			obstacleIdToGive = one->uniqueID + 1;
+	int obstacleIdToGive = m->battle()->nextObstacleId();
 
 	for(const Destination & destination : target)
 	{


### PR DESCRIPTION
Prevents client code from ALL_KNOWING access to obstacles just to compute new id.

Fixes many `Unauthorized obstacles access attempt, assuming massive spell` warnings.

For example, if the enemy has the Quicksand spell, it floods the battle log with such messages while computing new obstacle ids for the individual quicksand patches.