### PR TITLE
Extends creature terrain limiter to hero and towns nodes

### DIFF
--- a/config/schemas/bonusInstance.json
+++ b/config/schemas/bonusInstance.json
@@ -112,13 +112,13 @@
 						"type" : "object",
 						"required" : [ "type" ],
 						"properties" : {
-							"type" : { "type" : "string", "const" : "CREATURE_TERRAIN_LIMITER" }
+							"type" : { "type" : "string", "enum" : [ "CREATURE_TERRAIN_LIMITER", "TERRAIN_LIMITER" ] }
 						}
 					},
 					"then" : {
 						"additionalProperties" : false,
 						"properties" : {
-							"type" : { "type" : "string", "const" : "CREATURE_TERRAIN_LIMITER" },
+							"type" : { "type" : "string", "enum" : [ "CREATURE_TERRAIN_LIMITER", "TERRAIN_LIMITER" ] },
 							"parameters" : { "type" : "array", "description" : "parameters", "additionalItems" : true },
 							"terrain" : { "type" : "string" }
 						}

--- a/docs/modders/Bonus/Bonus_Limiters.md
+++ b/docs/modders/Bonus/Bonus_Limiters.md
@@ -148,18 +148,22 @@ Parameters:
 ],
 ```
 
-### CREATURE_TERRAIN_LIMITER
+### TERRAIN_LIMITER
+
+Also available as `CREATURE_TERRAIN_LIMITER`
 
 Parameters:
 
-- `terrain` - identifier of terrain on which this creature must be to pass this limiter. If not set, creature will pass this limiter if it is on native terrain
+- `terrain` - identifier of terrain on which this creature, hero or town must be to pass this limiter. If not set, creature will pass this limiter if it is on native terrain
+
+The native terrain of a town or a hero depends on their factions (e.g for a castle and a knight it is grass). The terrain type occupied by a town depends on its entrance tile (the tile with flags that is taken by visiting heros).
 
 Example:
 
 ```json
 "limiters" : [
 	{
-		"type" : "CREATURE_TERRAIN_LIMITER",
+		"type" : "TERRAIN_LIMITER",
 		"terrain" : "sand"
 	}
 ]
@@ -221,3 +225,7 @@ Example:
     }
 ]
 ```
+
+## Propagating Limiters
+
+When bonuses with limiters are propagated limiters are applied independently on each node. E.g. a bonus with "HAS_ANOTHER_BONUS_LIMITER" propagated to a hero from a stack will apply to the hero only if the hero has the required bonus, independently of the stack bonuses.

--- a/lib/BasicTypes.cpp
+++ b/lib/BasicTypes.cpp
@@ -32,7 +32,7 @@ bool INativeTerrainProvider::isNativeTerrain(TerrainId terrain) const
 
 TerrainId AFactionMember::getNativeTerrain() const
 {
-	//this code is used in the CreatureTerrainLimiter::limit to setup battle bonuses
+	//this code is used in the TerrainLimiter::limit to setup battle bonuses
 	//and in the CGHeroInstance::getNativeTerrain() to setup movement bonuses or/and penalties.
 	return getBonusBearer()->hasBonusOfType(BonusType::TERRAIN_NATIVE)
 			 ? TerrainId::ANY_TERRAIN : getFactionID().toEntity(LIBRARY)->getNativeTerrain();

--- a/lib/battle/BattleInfo.cpp
+++ b/lib/battle/BattleInfo.cpp
@@ -384,7 +384,7 @@ std::unique_ptr<BattleInfo> BattleInfo::setupBattle(IGameInfoCallback *cb, const
 	}
 
 	//native terrain bonuses
-	auto nativeTerrain = std::make_shared<CreatureTerrainLimiter>();
+	auto nativeTerrain = std::make_shared<TerrainLimiter>();
 	
 	currentBattle->addNewBonus(std::make_shared<Bonus>(BonusDuration::ONE_BATTLE, BonusType::STACKS_SPEED, BonusSource::TERRAIN_NATIVE, 1,  BonusSourceID())->addLimiter(nativeTerrain));
 	currentBattle->addNewBonus(std::make_shared<Bonus>(BonusDuration::ONE_BATTLE, BonusType::PRIMARY_SKILL, BonusSource::TERRAIN_NATIVE, 1, BonusSourceID(), BonusSubtypeID(PrimarySkill::ATTACK))->addLimiter(nativeTerrain));

--- a/lib/bonuses/Limiters.h
+++ b/lib/bonuses/Limiters.h
@@ -158,12 +158,12 @@ public:
 	}
 };
 
-class DLL_LINKAGE CreatureTerrainLimiter : public ILimiter //applies only to creatures that are on specified terrain, default native terrain
+class DLL_LINKAGE TerrainLimiter : public ILimiter //applies only to creatures that are on specified terrain, default native terrain
 {
 public:
 	TerrainId terrainType;
-	CreatureTerrainLimiter();
-	CreatureTerrainLimiter(TerrainId terrain);
+	TerrainLimiter();
+	TerrainLimiter(TerrainId terrain);
 
 	EDecision limit(const BonusLimitationContext &context) const override;
 	std::string toString() const override;

--- a/lib/bonuses/Updaters.h
+++ b/lib/bonuses/Updaters.h
@@ -17,7 +17,7 @@ VCMI_LIB_NAMESPACE_BEGIN
 class AggregateLimiter;
 class CCreatureTypeLimiter;
 class HasAnotherBonusLimiter;
-class CreatureTerrainLimiter;
+class TerrainLimiter;
 class CreatureLevelLimiter;
 class FactionLimiter;
 class CreatureAlignmentLimiter;

--- a/lib/json/JsonBonus.cpp
+++ b/lib/json/JsonBonus.cpp
@@ -647,12 +647,12 @@ static std::shared_ptr<const ILimiter> parseCreatureLevelLimiter(const JsonNode 
 	return levelLimiter;
 }
 
-static std::shared_ptr<const ILimiter> parseCreatureTerrainLimiter(const JsonNode & limiter)
+static std::shared_ptr<const ILimiter> parseTerrainLimiter(const JsonNode & limiter)
 {
 	const JsonNode & parameters = limiter["parameters"];
 	const JsonNode & terrainNode = limiter.Struct().count("terrain") ? limiter["terrain"] : parameters[0];
 
-	auto terrainLimiter = std::make_shared<CreatureTerrainLimiter>();
+	auto terrainLimiter = std::make_shared<TerrainLimiter>();
 	if(!terrainNode.isNull())
 	{
 		LIBRARY->identifiers()->requestIdentifier("terrain", terrainNode, [terrainLimiter](si32 terrain)
@@ -697,7 +697,8 @@ std::shared_ptr<const ILimiter> JsonUtils::parseLimiter(const JsonNode & limiter
 		{"FACTION_LIMITER",            parseFactionLimiter          },
 		{"CREATURE_FACTION_LIMITER",   parseFactionLimiter          },
 		{"CREATURE_LEVEL_LIMITER",     parseCreatureLevelLimiter    },
-		{"CREATURE_TERRAIN_LIMITER",   parseCreatureTerrainLimiter  },
+		{"TERRAIN_LIMITER",            parseTerrainLimiter          },
+		{"CREATURE_TERRAIN_LIMITER",   parseTerrainLimiter          },
 		{"UNIT_ON_HEXES",              parseUnitOnHexLimiter        },
 		{"HAS_CHARGES_LIMITER",        parseHasChargesLimiter       },
 	};

--- a/lib/serializer/RegisterTypes.h
+++ b/lib/serializer/RegisterTypes.h
@@ -110,7 +110,7 @@ void registerTypes(Serializer &s)
 	s.template registerType<AllOfLimiter>(61);
 	s.template registerType<CCreatureTypeLimiter>(62);
 	s.template registerType<HasAnotherBonusLimiter>(63);
-	s.template registerType<CreatureTerrainLimiter>(64);
+	s.template registerType<TerrainLimiter>(64);
 	s.template registerType<FactionLimiter>(65);
 	s.template registerType<CreatureLevelLimiter>(66);
 	s.template registerType<CreatureAlignmentLimiter>(67);


### PR DESCRIPTION
As in title.
Currently bonuses that are limited by terrain and propagated to hero/town do not work (e.g. Desert Warrior bonus from new Pavilion mod).
PS: if somebody is curious (I was) native terrain for a hero depends on the class (e.g. grass for a knight, snow for an alchemist) and current terrain for a town depends on the "entrance to town" tile.   