### PR TITLE
Fix crash when only Commander survives after battle

### DIFF
--- a/server/battles/BattleResultProcessor.cpp
+++ b/server/battles/BattleResultProcessor.cpp
@@ -416,7 +416,8 @@ void BattleResultProcessor::battleFinalize(const BattleID & battleID, const Batt
 	{
 		winnerHero = (*battle)->battleGetFightingHero(finishingBattle->winnerSide);
 		loserHero = (*battle)->battleGetFightingHero(CBattleInfoEssentials::otherSide(finishingBattle->winnerSide));
-		winnerHasUnitsLeft = winnerHero ? winnerHero->stacksCount() > 0 : true;
+		auto commander = winnerHero->getCommander();
+		winnerHasUnitsLeft = winnerHero ? winnerHero->stacksCount() > 0 || (commander && commander->alive) : true;
 	}
 
 	BattleResultsApplied resultsApplied;


### PR DESCRIPTION
 fixed #6411

This PR fixes a crash that occurred when only the Commander unit remained alive after a battle.

The root cause was that the Commander was not treated as a remaining valid unit during post-battle victory processing, which caused invalid state handling and led to a crash.

Now, the Commander is correctly recognized as a surviving unit, and the battle ends normally without crashing.