### PR TITLE
mapedit - fix undo and redo operations for drawing terrain

### DIFF
--- a/lib/mapping/CMapOperation.h
+++ b/lib/mapping/CMapOperation.h
@@ -94,10 +94,11 @@ private:
 		InvalidTiles() : centerPosValid(false) { }
 	};
 
-	void drawTerrain(TerrainId terrain, CTerrainSelection selection);
-	void updateTerrainTypes(CTerrainSelection selection);
-	void invalidateTerrainViews(const int3 & centerPos);
+	void changeTerrainType(CTerrainSelection selection, TerrainId terrainType);
+	void expandSelection(CTerrainSelection selection);
+	void expandInvalidatedTileList(const int3 & centerPos);
 	InvalidTiles getInvalidTiles(const int3 & centerPos) const;
+	void saveTileState(int3 tile);
 
 	void updateTerrainViews();
 	/// Validates the terrain view of the given position and with the given pattern. The first method wraps the
@@ -106,6 +107,7 @@ private:
 	ValidationResult validateTerrainViewInner(const int3 & pos, const TerrainViewPattern & pattern, int recDepth = 0) const;
 
 	CTerrainSelection terrainSel;
+	CTerrainSelection extendedSel;	//includes tiles added to the explicit selection automatically to fit in on the map
 	TerrainId terType;
 	std::map<TerrainId, CTerrainSelection> formerState;
 	int decorationsPercentage;


### PR DESCRIPTION
https://github.com/user-attachments/assets/5fa4b4c6-a474-4377-afd0-77a0a65c5be3

(Imagine dramatic background music)

I fixed my implementation of undo and redo operations of CDrawTerrainOperation. It was badly thought out and bugged.
CDrawTerrainOperation can expand the list of changed tiles (since the exact shape is not always possible to achieve). The former implementation did not take this into consideration, what resulted in a bug in case of more complicated selections. Repeatitly calculating invalidated tiles (tiles that need to be redrawn) during each undo and redo also was unnecessary.   
Currently CDrawTerrainOperation does all the calculation involving changed and invalidated tiles only once during execute method and saves the results to apply them during redo and undo methods. 
 