### PR TITLE
Fix unit invalid move target

### DIFF
--- a/AI/BattleAI/BattleExchangeVariant.cpp
+++ b/AI/BattleAI/BattleExchangeVariant.cpp
@@ -392,6 +392,8 @@ MoveTarget BattleExchangeEvaluator::findMoveTowardsUnreachable(
 
 		for(auto & hex : hexes)
 		{
+			if (!dists.isReachable(hex))
+				continue;
 			// FIXME: provide distance info for Jousting bonus
 			auto bai = BattleAttackInfo(activeStack, enemy, 0, cb->battleCanShoot(activeStack));
 			auto attack = AttackPossibility::evaluate(bai, hex, damageCache, hb);

--- a/lib/battle/Unit.cpp
+++ b/lib/battle/Unit.cpp
@@ -88,11 +88,11 @@ BattleHexArray Unit::getAttackableHexes(const Unit * attacker) const
 
 		for (const auto & attackOrigin : getSurroundingHexes())
 		{
-			if (!coversPos(attacker->occupiedHex(attackOrigin)) && attackOrigin.isAvailable())
+			BattleHex occupiedHex = attacker->occupiedHex(attackOrigin); 
+			if (!coversPos(occupiedHex) && occupiedHex.isAvailable())
 				result.insert(attackOrigin);
 
 			BattleHex headHex = attackOrigin.cloneInDirection(attacker->headDirection());
-
 			if (!coversPos(headHex) && headHex.isAvailable())
 				result.insert(headHex);
 		}

--- a/lib/battle/Unit.h
+++ b/lib/battle/Unit.h
@@ -134,7 +134,7 @@ public:
 
 	const BattleHexArray & getSurroundingHexes(const BattleHex & assumedPosition = BattleHex::INVALID) const; // get six or 8 surrounding hexes depending on creature size
 
-	/// Returns list of hexes from which attacker can attack this unit
+	/// Returns list of hexes (head positions for double-wide units) from which attacker can attack this unit
 	BattleHexArray getAttackableHexes(const Unit * attacker) const;
 	static const BattleHexArray & getSurroundingHexes(const BattleHex & position, bool twoHex, BattleSide side);
 


### PR DESCRIPTION
Fixes #6371, #6425.

When choosing a move target, only the head position of a double-wide unit was considered.
This induced invalid choices and turn skip, while a more distant, valid move target was available.