### PR TITLE
Lower movement priority for INVINCIBLE targets in stupidAI

### DIFF
--- a/AI/StupidAI/StupidAI.h
+++ b/AI/StupidAI/StupidAI.h
@@ -51,5 +51,6 @@ public:
 
 private:
 	BattleAction goTowards(const BattleID & battleID, const CStack * stack, BattleHexArray hexes) const;
+	bool moveStackToClosestEnemy(const BattleID & battleID, const CStack * stack, const ReachabilityInfo & dists, const std::vector<EnemyInfo> & enemyInfos);
 };
 


### PR DESCRIPTION
Fixes a case where stupidAI could get stuck moving around an INVINCIBLE war machine and stay around it. INVINCIBLE stacks are now separated into their own list and only considered as a last-priority movement target. If the AI has any enemy it can actually damage, it will ignore invincible ones.


https://github.com/user-attachments/assets/1f2acd32-ddaa-4068-ba56-10504ac62bcf



