### PR TITLE
Fix crash when losing battle vs neutral creatures (null winnerHero commander)

### DIFF
--- a/server/battles/BattleResultProcessor.cpp
+++ b/server/battles/BattleResultProcessor.cpp
@@ -416,8 +416,7 @@ void BattleResultProcessor::battleFinalize(const BattleID & battleID, const Batt
 	{
 		winnerHero = (*battle)->battleGetFightingHero(finishingBattle->winnerSide);
 		loserHero = (*battle)->battleGetFightingHero(CBattleInfoEssentials::otherSide(finishingBattle->winnerSide));
-		auto commander = winnerHero->getCommander();
-		winnerHasUnitsLeft = winnerHero ? winnerHero->stacksCount() > 0 || (commander && commander->alive) : true;
+		winnerHasUnitsLeft = winnerHero ? winnerHero->stacksCount() > 0 || (winnerHero->getCommander() && winnerHero->getCommander()->alive) : true;
 	}
 
 	BattleResultsApplied resultsApplied;


### PR DESCRIPTION
Yesterday I introduced a bug by dereferencing `winnerHero->getCommander(`) without checking if `winnerHero` is null. In battles where the winner has no hero (e.g. losing to neutral creatures), this could cause a crash when finishing the battle. The new code only checks commander state when `winnerHero` is valid, preventing the null dereference and the crash.