### PR TITLE
Fixes regression causing a crash on getting current terrain of stackInstance

### DIFF
--- a/lib/mapObjects/army/CStackInstance.cpp
+++ b/lib/mapObjects/army/CStackInstance.cpp
@@ -259,8 +259,10 @@ TerrainId CStackInstance::getNativeTerrain() const
 
 TerrainId CStackInstance::getCurrentTerrain() const
 {
-	assert(getArmy() != nullptr);
-	return getArmy()->getCurrentTerrain();
+	if (armyInstance)
+		return armyInstance->getCurrentTerrain();
+	else
+		return TerrainId::NONE;		//for example a stackInstance created in order to display unit's statistics on a town screen
 }
 
 CreatureID CStackInstance::getCreatureID() const

--- a/lib/mapObjects/army/CStackInstance.h
+++ b/lib/mapObjects/army/CStackInstance.h
@@ -32,7 +32,7 @@ class DLL_LINKAGE CStackInstance : public CBonusSystemNode, public CStackBasicDe
 	BonusValueCache nativeTerrain;
 	BonusValueCache initiative;
 
-	CArmedInstance * armyInstance = nullptr; //stack must be part of some army, army must be part of some object
+	CArmedInstance * armyInstance = nullptr;
 
 	IGameInfoCallback * getCallback() const final
 	{


### PR DESCRIPTION
Fixes #6176.
I moved the check to CStackInstance.
CStackWindow when not provided with a stack instance will create a fake, army-less one - like in the case of a recruitment screen.
<img width="945" height="240" alt="Screenshot from 2025-12-11 16-44-14" src="https://github.com/user-attachments/assets/c2fc0a38-e00d-4d22-9501-281680208bbd" />
It was most probably a bad design choice but now we are kinda stuck with it until the entire class will get reworked.
Since such situation exists IMO it made the most sense to make StackInstance deal with it.

