### PR TITLE
Add ingame guard to `onTileHovered`

### DIFF
--- a/client/adventureMap/AdventureMapInterface.cpp
+++ b/client/adventureMap/AdventureMapInterface.cpp
@@ -603,7 +603,9 @@ void AdventureMapInterface::onTileHovered(const int3 &targetPosition)
 {
 	if(!shortcuts->optionMapViewActive())
 		return;
-
+	//if the player is not ingame (loser, winner, wrong) we are in a shutdown process
+	if (!GAME->interface()->cb || GAME->interface()->cb->getPlayerStatus(GAME->interface()->playerID) != EPlayerStatus::INGAME)
+		return;
 	//may occur just at the start of game (fake move before full initialization)
 	if(!GAME->interface()->localState->getCurrentArmy())
 		return;


### PR DESCRIPTION
Fixes #1962.

If the current player is not ingame, then we are in a shutdown process, which results in crashes if we execute `onTileHovered` game logic (e.g. `NodeStorage` is reinitialized with incoherent data).

Now on hotseat win there is no crash, but message flow as expected (one message for red loss, one message for blue win, end game screen).

Tested in single player, hotseat, and multi player using the map from #1962.