### PR TITLE
Handle invalid map data and out-of-bounds objects more gracefully

### DIFF
--- a/lib/CPlayerState.cpp
+++ b/lib/CPlayerState.cpp
@@ -157,11 +157,23 @@ void PlayerState::addOwnedObject(CGObjectInstance * object)
 {
 	assert(object->asOwnable() != nullptr);
 	ownedObjects.push_back(object->id);
+	markObjectControlled(object->id);
 }
 
 void PlayerState::removeOwnedObject(CGObjectInstance * object)
 {
 	vstd::erase(ownedObjects, object->id);
+}
+
+void PlayerState::markObjectControlled(ObjectInstanceID objectID)
+{
+	if(objectID != ObjectInstanceID::NONE)
+		everControlledObjects.insert(objectID);
+}
+
+bool PlayerState::hasEverControlled(ObjectInstanceID objectID) const
+{
+	return everControlledObjects.count(objectID) != 0;
 }
 
 VCMI_LIB_NAMESPACE_END

--- a/lib/CPlayerState.h
+++ b/lib/CPlayerState.h
@@ -104,6 +104,8 @@ public:
 
 	void addOwnedObject(CGObjectInstance * object);
 	void removeOwnedObject(CGObjectInstance * object);
+	void markObjectControlled(ObjectInstanceID objectID);
+	bool hasEverControlled(ObjectInstanceID objectID) const;
 
 	bool checkVanquished() const
 	{
@@ -141,7 +143,12 @@ public:
 		h & enteredWinningCheatCode;
 		h & static_cast<CBonusSystemNode&>(*this);
 		h & destroyedObjects;
+		if(h.hasFeature(Handler::Version::CONTROL_LOSS_TRACKING))
+			h & everControlledObjects;
 	}
+
+	private:
+		std::set<ObjectInstanceID> everControlledObjects;
 };
 
 struct DLL_LINKAGE TeamState : public CBonusSystemNode

--- a/lib/filesystem/CBinaryReader.cpp
+++ b/lib/filesystem/CBinaryReader.cpp
@@ -88,8 +88,10 @@ INSTANTIATE(si64, readInt64)
 std::string CBinaryReader::readBaseString()
 {
 	unsigned int len = readUInt32();
-	assert(len <= 500000); //not too long
-	if (len > 0)
+	if(len > 500000)
+		throw std::runtime_error("Invalid or corrupt map file");
+
+	if(len > 0)
 	{
 		std::string ret;
 		ret.resize(len);

--- a/lib/gameState/CGameState.cpp
+++ b/lib/gameState/CGameState.cpp
@@ -216,6 +216,7 @@ void CGameState::init(const IMapService * mapService, StartInfo * si, IGameRando
 	placeStartingHeroes(randomGenerator);
 	initOwnedObjects();
 	initDifficulty();
+	adjustObjectsToMapBounds();
 	initHeroes(gameRandomizer);
 	initStartingBonus(gameRandomizer);
 	initTowns(randomGenerator);
@@ -621,6 +622,24 @@ void CGameState::removeHeroPlaceholders()
 	for(auto obj : map->getObjects<CGHeroPlaceholder>())
 	{
 		map->eraseObject(obj->id);
+	}
+}
+
+void CGameState::adjustObjectsToMapBounds()
+{
+	for(auto & obj : map->getObjects())
+	{
+		if(!obj->isVisitable())
+			continue;
+
+		const auto oldVisitablePos = obj->visitablePos();
+		if(!map->adjustToMapBounds(obj))
+			continue;
+
+		const auto newVisitablePos = obj->visitablePos();
+		logGlobal->warn(
+			"Object %s has out of map bounds visitable position %s. Shifted to %s.",
+			obj->getObjectName(), oldVisitablePos.toString(), newVisitablePos.toString());
 	}
 }
 

--- a/lib/gameState/CGameState.cpp
+++ b/lib/gameState/CGameState.cpp
@@ -626,7 +626,16 @@ void CGameState::initHeroes(IGameRandomizer & gameRandomizer)
 	for (auto heroID : map->getHeroesOnMap())
 	{
 		auto hero = getHero(heroID);
-		assert(map->isInTheMap(hero->visitablePos()));
+		const auto pos = hero->visitablePos();
+
+		if(!map->isInTheMap(pos))
+		{
+			logGlobal->warn(
+				"initHeroes: hero %s has invalid visitablePos %s (outside map) – skipping boat generation",
+				hero->getNameTranslated(), pos.toString());
+			continue;
+		}
+
 		const auto & tile = map->getTile(hero->visitablePos());
 
 		if (hero->ID == Obj::PRISON)

--- a/lib/gameState/CGameState.cpp
+++ b/lib/gameState/CGameState.cpp
@@ -234,7 +234,7 @@ void CGameState::init(const IMapService * mapService, StartInfo * si, IGameRando
 
 	logGlobal->debug("\tChecking objectives");
 	map->checkForObjectives(); //needs to be run when all objects are properly placed
-	initializeTrackedControlLossObjects();
+	rebuildObjectControlHistory();
 }
 
 void CGameState::updateEntity(Metatype metatype, int32_t index, const JsonNode & data)
@@ -524,22 +524,18 @@ void CGameState::randomizeMapObjects(IGameRandomizer & gameRandomizer)
 			map->eraseObject(obj->id);
 }
 
-void CGameState::initializeTrackedControlLossObjects()
+void CGameState::rebuildObjectControlHistory()
 {
-	for(const TriggeredEvent & event : map->triggeredEvents)
+	for(const auto & object : map->getObjects())
 	{
-		if(event.effect.type != EventEffect::DEFEAT)
+		if(!object)
 			continue;
 
-		const auto controlCondition = findSimpleControlLossCondition(event.trigger);
-		if(!controlCondition || controlCondition->objectID == ObjectInstanceID::NONE)
+		const auto owner = object->getOwner();
+		if(!owner.isValidPlayer())
 			continue;
 
-		for(const auto & [playerColor, _] : players)
-		{
-			if(checkForVictory(playerColor, *controlCondition))
-				markObjectControlled(playerColor, controlCondition->objectID);
-		}
+		markObjectControlled(owner, object->id);
 	}
 }
 
@@ -1489,6 +1485,37 @@ bool CGameState::checkForStandardLoss(const PlayerColor & player) const
 	return pState.checkVanquished();
 }
 
+void CGameState::markObjectControlled(PlayerColor player, ObjectInstanceID id)
+{
+	if(auto * playerState = getPlayerState(player))
+		playerState->markObjectControlled(id);
+}
+
+bool CGameState::hasEverControlled(PlayerColor player, ObjectInstanceID id) const
+{
+	const auto * playerState = getPlayerState(player);
+	return playerState && playerState->hasEverControlled(id);
+}
+
+bool CGameState::isControlLossTriggered(const PlayerColor & player, const EventCondition & cond) const
+{
+	if(cond.objectID == ObjectInstanceID::NONE)
+		return false;
+
+	const auto * team = CGameInfoCallback::getPlayerTeam(player);
+	if(!team)
+		return false;
+
+	const auto * object = getObjInstance(cond.objectID);
+	if(!object)
+		return hasEverControlled(player, cond.objectID);
+
+	if(team->players.count(object->getOwner()) != 0)
+		return false;
+
+	return hasEverControlled(player, cond.objectID);
+}
+
 void CGameState::obtainPlayersStats(SThievesGuildInfo & tgi, int level) const
 {
 	auto playerInactive = [&](const PlayerColor & color)
@@ -1642,7 +1669,7 @@ void CGameState::restoreBonusSystemTree()
 	if (campaign)
 		campaign->setGamestate(this);
 
-	initializeTrackedControlLossObjects();
+	rebuildObjectControlHistory();
 
 	// WORKAROUND FOR 1.6 SAVES
 	static_assert(ESerializationVersion::RELEASE_160 == ESerializationVersion::MINIMAL, "Please remove this code after dropping 1.6 save compat");

--- a/lib/gameState/CGameState.cpp
+++ b/lib/gameState/CGameState.cpp
@@ -1267,7 +1267,7 @@ EVictoryLossCheckResult CGameState::checkForVictoryAndLoss(const PlayerColor & p
 bool CGameState::checkForVictory(const PlayerColor & player, const EventCondition & condition) const
 {
 	const PlayerState *p = CGameInfoCallback::getPlayerState(player);
-	switch (condition.condition)
+	switch(condition.condition)
 	{
 		case EventCondition::STANDARD_WIN:
 		{
@@ -1286,12 +1286,12 @@ bool CGameState::checkForVictory(const PlayerColor & player, const EventConditio
 			// NOTE: only heroes & towns are checked, in line with H3.
 			// Garrisons, mines, and guards of owned dwellings(!) are excluded
 			int totalCreatures = 0;
-			for (const auto & hero : p->getHeroes())
+			for(const auto & hero : p->getHeroes())
 				for(const auto & elem : hero->Slots()) //iterate through army
 					if(elem.second->getId() == condition.objectType.as<CreatureID>()) //it's searched creature
 						totalCreatures += elem.second->getCount();
 
-			for (const auto & town : p->getTowns())
+			for(const auto & town : p->getTowns())
 				for(const auto & elem : town->Slots()) //iterate through army
 					if(elem.second->getId() == condition.objectType.as<CreatureID>()) //it's searched creature
 						totalCreatures += elem.second->getCount();
@@ -1304,16 +1304,16 @@ bool CGameState::checkForVictory(const PlayerColor & player, const EventConditio
 		}
 		case EventCondition::HAVE_BUILDING:
 		{
-			if (condition.objectID != ObjectInstanceID::NONE) // specific town
+			if(condition.objectID != ObjectInstanceID::NONE) // specific town
 			{
 				const auto * t = getTown(condition.objectID);
 				return (t->tempOwner == player && t->hasBuilt(condition.objectType.as<BuildingID>()));
 			}
 			else // any town
 			{
-				for (const CGTownInstance * t : p->getTowns())
+				for(const CGTownInstance * t : p->getTowns())
 				{
-					if (t->hasBuilt(condition.objectType.as<BuildingID>()))
+					if(t->hasBuilt(condition.objectType.as<BuildingID>()))
 						return true;
 				}
 				return false;
@@ -1321,9 +1321,9 @@ bool CGameState::checkForVictory(const PlayerColor & player, const EventConditio
 		}
 		case EventCondition::DESTROY:
 		{
-			if (condition.objectID != ObjectInstanceID::NONE) // mode A - destroy specific object of this type
+			if(condition.objectID != ObjectInstanceID::NONE) // mode A - destroy specific object of this type
 			{
-				return p->destroyedObjects.count(condition.objectID);
+				return p->destroyedObjects.contains(condition.objectID);
 			}
 			else
 			{
@@ -1396,7 +1396,7 @@ bool CGameState::checkForVictory(const PlayerColor & player, const EventConditio
 		}
 		case EventCondition::DAYS_WITHOUT_TOWN:
 		{
-			if (p->daysWithoutCastle)
+			if(p->daysWithoutCastle)
 				return p->daysWithoutCastle >= condition.value;
 			else
 				return false;

--- a/lib/gameState/CGameState.cpp
+++ b/lib/gameState/CGameState.cpp
@@ -208,6 +208,7 @@ void CGameState::init(const IMapService * mapService, StartInfo * si, IGameRando
 	initPlayerStates();
 	if (campaign)
 		campaign->placeCampaignHeroes(randomGenerator);
+	map->resolveHeroPlaceholderObjectives();
 	removeHeroPlaceholders();
 	initGrailPosition(randomGenerator);
 	initRandomFactionsForPlayers(randomGenerator);
@@ -1321,6 +1322,10 @@ bool CGameState::checkForVictory(const PlayerColor & player, const EventConditio
 		}
 		case EventCondition::DESTROY:
 		{
+			// Preserve hero-placeholder objectives as in HotA / OH3 so the map remains playable.
+			if(condition.objectType.as<MapObjectID>() == Obj::HERO_PLACEHOLDER)
+				return false;
+
 			if(condition.objectID != ObjectInstanceID::NONE) // mode A - destroy specific object of this type
 			{
 				return p->destroyedObjects.contains(condition.objectID);
@@ -1338,6 +1343,10 @@ bool CGameState::checkForVictory(const PlayerColor & player, const EventConditio
 		case EventCondition::CONTROL:
 		{
 			const auto * team = CGameInfoCallback::getPlayerTeam(player);
+
+			// Preserve hero-placeholder objectives as in HotA / OH3 so the map remains playable.
+			if(condition.objectType.as<MapObjectID>() == Obj::HERO_PLACEHOLDER)
+				return true;
 
 			if(condition.objectID != ObjectInstanceID::NONE)
 			{
@@ -1363,6 +1372,10 @@ bool CGameState::checkForVictory(const PlayerColor & player, const EventConditio
 		case EventCondition::CONTROL_CURRENT:
 		{
 			const auto * team = CGameInfoCallback::getPlayerTeam(player);
+
+			// Preserve hero-placeholder objectives as in HotA / OH3 so the map remains playable.
+			if(condition.objectType.as<MapObjectID>() == Obj::HERO_PLACEHOLDER)
+				return true;
 
 			if(condition.objectID != ObjectInstanceID::NONE)
 			{

--- a/lib/gameState/CGameState.cpp
+++ b/lib/gameState/CGameState.cpp
@@ -77,6 +77,8 @@ VCMI_LIB_NAMESPACE_BEGIN
 
 std::shared_mutex CGameState::mutex;
 
+static std::optional<EventCondition> findSimpleControlLossCondition(const EventExpression & expr);
+
 const Services * GameStateEnvironment::services() const
 {
 	return LIBRARY;
@@ -232,6 +234,7 @@ void CGameState::init(const IMapService * mapService, StartInfo * si, IGameRando
 
 	logGlobal->debug("\tChecking objectives");
 	map->checkForObjectives(); //needs to be run when all objects are properly placed
+	initializeTrackedControlLossObjects();
 }
 
 void CGameState::updateEntity(Metatype metatype, int32_t index, const JsonNode & data)
@@ -397,10 +400,10 @@ void CGameState::initDifficulty()
 	logGlobal->debug("\tLoading difficulty settings");
 	JsonNode config = JsonUtils::assembleFromFiles("config/difficulty.json");
 	config.setModScope(ModScope::scopeGame()); // FIXME: should be set to actual mod
-	
+
 	const JsonNode & difficultyAI(config["ai"][GameConstants::DIFFICULTY_NAMES[scenarioOps->difficulty]]);
 	const JsonNode & difficultyHuman(config["human"][GameConstants::DIFFICULTY_NAMES[scenarioOps->difficulty]]);
-	
+
 	auto setDifficulty = [this](PlayerState & state, const JsonNode & json)
 	{
 		//set starting resources
@@ -409,17 +412,17 @@ void CGameState::initDifficulty()
 		//handicap
 		const PlayerSettings &ps = scenarioOps->getIthPlayersSettings(state.color);
 		state.resources += ps.handicap.startBonus;
-		
+
 		//set global bonuses
 		for(auto & jsonBonus : json["globalBonuses"].Vector())
 			if(auto bonus = JsonUtils::parseBonus(jsonBonus))
 				state.addNewBonus(bonus);
-		
+
 		//set battle bonuses
 		for(auto & jsonBonus : json["battleBonuses"].Vector())
 			if(auto bonus = JsonUtils::parseBonus(jsonBonus))
 				state.battleBonuses.push_back(*bonus);
-		
+
 	};
 
 	for (auto & elem : players)
@@ -519,6 +522,25 @@ void CGameState::randomizeMapObjects(IGameRandomizer & gameRandomizer)
 	for(auto & obj : map->getObjects<CGPandoraBox>())
 		if (!obj->presentOnDifficulties.contains(getStartInfo()->getDifficulty()))
 			map->eraseObject(obj->id);
+}
+
+void CGameState::initializeTrackedControlLossObjects()
+{
+	for(const TriggeredEvent & event : map->triggeredEvents)
+	{
+		if(event.effect.type != EventEffect::DEFEAT)
+			continue;
+
+		const auto controlCondition = findSimpleControlLossCondition(event.trigger);
+		if(!controlCondition || controlCondition->objectID == ObjectInstanceID::NONE)
+			continue;
+
+		for(const auto & [playerColor, _] : players)
+		{
+			if(checkForVictory(playerColor, *controlCondition))
+				markObjectControlled(playerColor, controlCondition->objectID);
+		}
+	}
 }
 
 void CGameState::initOwnedObjects()
@@ -1076,7 +1098,7 @@ BattleField CGameState::battleGetBattlefieldType(int3 tile, vstd::RNG & randomGe
 
 	if(map->isCoastalTile(tile)) //coastal tile is always ground
 		return BattleField(*LIBRARY->identifiers()->getIdentifier("core", "battlefield.sand_shore"));
-	
+
 	auto currentLayer = map->mapLayers.at(tile.z);
 	const auto & terrainBattlefields = t.getTerrain()->battleFields;
 
@@ -1206,6 +1228,47 @@ bool CGameState::isVisibleFor(const CGObjectInstance * obj, PlayerColor player) 
 	);
 }
 
+static std::optional<EventCondition> findSimpleControlLossCondition(const EventExpression & expr)
+{
+	using Expr    = EventExpression;
+	using Value   = Expr::Value;
+	using All     = Expr::OperatorAll;
+	using None    = Expr::OperatorNone;
+	using Variant = Expr::Variant;
+
+	std::function<std::optional<EventCondition>(const Variant &)> impl;
+	impl = [&](const Variant & var) -> std::optional<EventCondition>
+	{
+		if(const auto * none = std::get_if<None>(&var))
+		{
+			if(none->expressions.size() != 1)
+				return std::nullopt;
+
+			const auto * cond = std::get_if<Value>(&none->expressions.front());
+			if(!cond || cond->condition != EventCondition::CONTROL)
+				return std::nullopt;
+
+			return *cond;
+		}
+
+		if(const auto * all = std::get_if<All>(&var))
+		{
+			if(all->expressions.size() != 2)
+				return std::nullopt;
+
+			const auto * first = std::get_if<Value>(&all->expressions.front());
+			if(!first || first->condition != EventCondition::IS_HUMAN)
+				return std::nullopt;
+
+			return impl(all->expressions[1]);
+		}
+
+		return std::nullopt;
+	};
+
+	return impl(expr.get());
+}
+
 EVictoryLossCheckResult CGameState::checkForVictoryAndLoss(const PlayerColor & player) const
 {
 	const MetaString messageWonSelf = MetaString::createFromTextID("core.genrltxt.659");
@@ -1227,14 +1290,28 @@ EVictoryLossCheckResult CGameState::checkForVictoryAndLoss(const PlayerColor & p
 	if (p->enteredLosingCheatCode)
 		return EVictoryLossCheckResult::defeat(messageLostSelf, messageLostOther);
 
-	for (const TriggeredEvent & event : map->triggeredEvents)
+	for(const TriggeredEvent & event : map->triggeredEvents)
 	{
-		if (event.trigger.test(evaluateEvent))
+		if(event.effect.type == EventEffect::VICTORY)
 		{
-			if (event.effect.type == EventEffect::VICTORY)
+			if(event.trigger.test(evaluateEvent))
 				return EVictoryLossCheckResult::victory(event.onFulfill, event.effect.toOtherMessage);
+		}
+		else if(event.effect.type == EventEffect::DEFEAT)
+		{
+			// Special handling for "lose town/hero" style conditions:
+			// triggers built as NONE(CONTROL(...)), optionally wrapped into ALL(IS_HUMAN, ...).
+			if(auto ctrlOpt = findSimpleControlLossCondition(event.trigger))
+			{
+				if(isControlLossTriggered(player, *ctrlOpt))
+					return EVictoryLossCheckResult::defeat(event.onFulfill, event.effect.toOtherMessage);
 
-			if (event.effect.type == EventEffect::DEFEAT)
+				// If our custom logic says "no loss yet", do NOT fall through to generic .test()
+				continue;
+			}
+
+			// All other defeat events: generic evaluation
+			if(event.trigger.test(evaluateEvent))
 				return EVictoryLossCheckResult::defeat(event.onFulfill, event.effect.toOtherMessage);
 		}
 	}
@@ -1414,7 +1491,7 @@ bool CGameState::checkForStandardLoss(const PlayerColor & player) const
 
 void CGameState::obtainPlayersStats(SThievesGuildInfo & tgi, int level) const
 {
-	auto playerInactive = [&](const PlayerColor & color) 
+	auto playerInactive = [&](const PlayerColor & color)
 	{
 		 return color == PlayerColor::NEUTRAL || players.at(color).status != EPlayerStatus::INGAME;
 	};
@@ -1564,6 +1641,8 @@ void CGameState::restoreBonusSystemTree()
 
 	if (campaign)
 		campaign->setGamestate(this);
+
+	initializeTrackedControlLossObjects();
 
 	// WORKAROUND FOR 1.6 SAVES
 	static_assert(ESerializationVersion::RELEASE_160 == ESerializationVersion::MINIMAL, "Please remove this code after dropping 1.6 save compat");

--- a/lib/gameState/CGameState.cpp
+++ b/lib/gameState/CGameState.cpp
@@ -77,8 +77,6 @@ VCMI_LIB_NAMESPACE_BEGIN
 
 std::shared_mutex CGameState::mutex;
 
-static std::optional<EventCondition> findSimpleControlLossCondition(const EventExpression & expr);
-
 const Services * GameStateEnvironment::services() const
 {
 	return LIBRARY;
@@ -1224,47 +1222,6 @@ bool CGameState::isVisibleFor(const CGObjectInstance * obj, PlayerColor player) 
 	);
 }
 
-static std::optional<EventCondition> findSimpleControlLossCondition(const EventExpression & expr)
-{
-	using Expr    = EventExpression;
-	using Value   = Expr::Value;
-	using All     = Expr::OperatorAll;
-	using None    = Expr::OperatorNone;
-	using Variant = Expr::Variant;
-
-	std::function<std::optional<EventCondition>(const Variant &)> impl;
-	impl = [&](const Variant & var) -> std::optional<EventCondition>
-	{
-		if(const auto * none = std::get_if<None>(&var))
-		{
-			if(none->expressions.size() != 1)
-				return std::nullopt;
-
-			const auto * cond = std::get_if<Value>(&none->expressions.front());
-			if(!cond || cond->condition != EventCondition::CONTROL)
-				return std::nullopt;
-
-			return *cond;
-		}
-
-		if(const auto * all = std::get_if<All>(&var))
-		{
-			if(all->expressions.size() != 2)
-				return std::nullopt;
-
-			const auto * first = std::get_if<Value>(&all->expressions.front());
-			if(!first || first->condition != EventCondition::IS_HUMAN)
-				return std::nullopt;
-
-			return impl(all->expressions[1]);
-		}
-
-		return std::nullopt;
-	};
-
-	return impl(expr.get());
-}
-
 EVictoryLossCheckResult CGameState::checkForVictoryAndLoss(const PlayerColor & player) const
 {
 	const MetaString messageWonSelf = MetaString::createFromTextID("core.genrltxt.659");
@@ -1295,18 +1252,6 @@ EVictoryLossCheckResult CGameState::checkForVictoryAndLoss(const PlayerColor & p
 		}
 		else if(event.effect.type == EventEffect::DEFEAT)
 		{
-			// Special handling for "lose town/hero" style conditions:
-			// triggers built as NONE(CONTROL(...)), optionally wrapped into ALL(IS_HUMAN, ...).
-			if(auto ctrlOpt = findSimpleControlLossCondition(event.trigger))
-			{
-				if(isControlLossTriggered(player, *ctrlOpt))
-					return EVictoryLossCheckResult::defeat(event.onFulfill, event.effect.toOtherMessage);
-
-				// If our custom logic says "no loss yet", do NOT fall through to generic .test()
-				continue;
-			}
-
-			// All other defeat events: generic evaluation
 			if(event.trigger.test(evaluateEvent))
 				return EVictoryLossCheckResult::defeat(event.onFulfill, event.effect.toOtherMessage);
 		}
@@ -1392,28 +1337,46 @@ bool CGameState::checkForVictory(const PlayerColor & player, const EventConditio
 		}
 		case EventCondition::CONTROL:
 		{
-			// list of players that need to control object to fulfull condition
-			// NOTE: CGameInfoCallback specified explicitly in order to get const version
 			const auto * team = CGameInfoCallback::getPlayerTeam(player);
 
-			if (condition.objectID != ObjectInstanceID::NONE) // mode A - flag one specific object, like town
+			if(condition.objectID != ObjectInstanceID::NONE)
 			{
 				const auto * object = getObjInstance(condition.objectID);
 
-				if (!object)
-					return false;
-				return team->players.count(object->getOwner()) != 0;
+				if(!object)
+					return !hasEverControlled(player, condition.objectID);
+
+				if(team->players.contains(object->getOwner()))
+					return true;
+
+				return !hasEverControlled(player, condition.objectID);
 			}
-			else
+
+			for(const auto & elem : map->getObjects())
 			{
-				for(const auto & elem : map->getObjects()) // mode B - flag all objects of this type
-				{
-					 //check not flagged objs
-					if ( elem && elem->ID == condition.objectType.as<MapObjectID>() && team->players.count(elem->getOwner()) == 0 )
-						return false;
-				}
+				if(elem && elem->ID == condition.objectType.as<MapObjectID>() && !team->players.contains(elem->getOwner()))
+					return false;
+			}
+
 				return true;
 			}
+		case EventCondition::CONTROL_CURRENT:
+		{
+			const auto * team = CGameInfoCallback::getPlayerTeam(player);
+
+			if(condition.objectID != ObjectInstanceID::NONE)
+			{
+				const auto * object = getObjInstance(condition.objectID);
+				return object && team->players.contains(object->getOwner());
+			}
+
+			for(const auto & elem : map->getObjects())
+			{
+				if(elem && elem->ID == condition.objectType.as<MapObjectID>() && !team->players.contains(elem->getOwner()))
+					return false;
+			}
+
+			return true;
 		}
 		case EventCondition::TRANSPORT:
 		{
@@ -1495,25 +1458,6 @@ bool CGameState::hasEverControlled(PlayerColor player, ObjectInstanceID id) cons
 {
 	const auto * playerState = getPlayerState(player);
 	return playerState && playerState->hasEverControlled(id);
-}
-
-bool CGameState::isControlLossTriggered(const PlayerColor & player, const EventCondition & cond) const
-{
-	if(cond.objectID == ObjectInstanceID::NONE)
-		return false;
-
-	const auto * team = CGameInfoCallback::getPlayerTeam(player);
-	if(!team)
-		return false;
-
-	const auto * object = getObjInstance(cond.objectID);
-	if(!object)
-		return hasEverControlled(player, cond.objectID);
-
-	if(team->players.count(object->getOwner()) != 0)
-		return false;
-
-	return hasEverControlled(player, cond.objectID);
 }
 
 void CGameState::obtainPlayersStats(SThievesGuildInfo & tgi, int level) const

--- a/lib/gameState/CGameState.h
+++ b/lib/gameState/CGameState.h
@@ -212,10 +212,6 @@ public:
 		h & globalEffects;
 		h & currentRumor;
 		h & campaign;
-		if(h.hasFeature(Handler::Version::CONTROL_LOSS_TRACKING))
-			h & everControlledObjects;
-		else if(!h.saving)
-			everControlledObjects = {};
 		if (!h.hasFeature(Handler::Version::RANDOMIZATION_REWORK))
 		{
 			std::map<ArtifactID, int> allocatedArtifactsUnused;
@@ -239,7 +235,7 @@ private:
 	void initRandomFactionsForPlayers(vstd::RNG & randomGenerator);
 	void initOwnedObjects();
 	void randomizeMapObjects(IGameRandomizer & gameRandomizer);
-	void initializeTrackedControlLossObjects();
+	void rebuildObjectControlHistory();
 	void initPlayerStates();
 	void placeStartingHeroes(vstd::RNG & randomGenerator);
 	void placeStartingHero(const PlayerColor & playerColor, const HeroTypeID & heroTypeId, int3 townPos);
@@ -271,8 +267,6 @@ private:
 
 	// ---- data -----
 	Services * services;
-
-	std::array<std::set<ObjectInstanceID>, PlayerColor::PLAYER_LIMIT_I> everControlledObjects;
 
 	/// Pointer to campaign state manager. Nullptr for single scenarios
 	std::unique_ptr<CGameStateCampaign> campaign;

--- a/lib/gameState/CGameState.h
+++ b/lib/gameState/CGameState.h
@@ -142,7 +142,6 @@ public:
 
 	void markObjectControlled(PlayerColor player, ObjectInstanceID id);
 	bool hasEverControlled(PlayerColor player, ObjectInstanceID id) const;
-	bool isControlLossTriggered(const PlayerColor & player, const EventCondition & cond) const;
 
 	//fills tgi with info about other players that is available at given level of thieves' guild
 	void obtainPlayersStats(SThievesGuildInfo & tgi, int level) const;

--- a/lib/gameState/CGameState.h
+++ b/lib/gameState/CGameState.h
@@ -140,6 +140,10 @@ public:
 	PlayerColor checkForStandardWin() const; //returns color of player that accomplished standard victory conditions or 255 (NEUTRAL) if no winner
 	bool checkForStandardLoss(const PlayerColor & player) const; //checks if given player lost the game
 
+	void markObjectControlled(PlayerColor player, ObjectInstanceID id);
+	bool hasEverControlled(PlayerColor player, ObjectInstanceID id) const;
+	bool isControlLossTriggered(const PlayerColor & player, const EventCondition & cond) const;
+
 	//fills tgi with info about other players that is available at given level of thieves' guild
 	void obtainPlayersStats(SThievesGuildInfo & tgi, int level) const;
 	const IGameSettings & getSettings() const override;
@@ -208,6 +212,10 @@ public:
 		h & globalEffects;
 		h & currentRumor;
 		h & campaign;
+		if(h.hasFeature(Handler::Version::CONTROL_LOSS_TRACKING))
+			h & everControlledObjects;
+		else if(!h.saving)
+			everControlledObjects = {};
 		if (!h.hasFeature(Handler::Version::RANDOMIZATION_REWORK))
 		{
 			std::map<ArtifactID, int> allocatedArtifactsUnused;
@@ -231,6 +239,7 @@ private:
 	void initRandomFactionsForPlayers(vstd::RNG & randomGenerator);
 	void initOwnedObjects();
 	void randomizeMapObjects(IGameRandomizer & gameRandomizer);
+	void initializeTrackedControlLossObjects();
 	void initPlayerStates();
 	void placeStartingHeroes(vstd::RNG & randomGenerator);
 	void placeStartingHero(const PlayerColor & playerColor, const HeroTypeID & heroTypeId, int3 townPos);
@@ -262,6 +271,8 @@ private:
 
 	// ---- data -----
 	Services * services;
+
+	std::array<std::set<ObjectInstanceID>, PlayerColor::PLAYER_LIMIT_I> everControlledObjects;
 
 	/// Pointer to campaign state manager. Nullptr for single scenarios
 	std::unique_ptr<CGameStateCampaign> campaign;

--- a/lib/gameState/CGameState.h
+++ b/lib/gameState/CGameState.h
@@ -240,6 +240,7 @@ private:
 	void placeStartingHero(const PlayerColor & playerColor, const HeroTypeID & heroTypeId, int3 townPos);
 	void removeHeroPlaceholders();
 	void initDifficulty();
+	void adjustObjectsToMapBounds();
 	void initHeroes(IGameRandomizer & gameRandomizer);
 	void placeHeroesInTowns();
 	void initFogOfWar();

--- a/lib/mapObjects/CGHeroInstance.cpp
+++ b/lib/mapObjects/CGHeroInstance.cpp
@@ -1710,8 +1710,8 @@ bool CGHeroInstance::isMissionCritical() const
 
 		auto const & testFunctor = [&](const EventCondition & condition)
 		{
-			if ((condition.condition == EventCondition::CONTROL) && condition.objectID != ObjectInstanceID::NONE)
-				return (id != condition.objectID);
+				if ((condition.condition == EventCondition::CONTROL || condition.condition == EventCondition::CONTROL_CURRENT) && condition.objectID != ObjectInstanceID::NONE)
+					return (id != condition.objectID);
 
 			if (condition.condition == EventCondition::HAVE_ARTIFACT)
 			{

--- a/lib/mapObjects/CGObjectInstance.cpp
+++ b/lib/mapObjects/CGObjectInstance.cpp
@@ -124,12 +124,46 @@ const std::set<int3> & CGObjectInstance::getBlockedOffsets() const
 void CGObjectInstance::setType(MapObjectID newID, MapObjectSubID newSubID)
 {
 	auto position = visitablePos();
-	auto oldOffset = appearance->getCornerOffset();
 	const auto * tile = cb->getTile(position);
+
+	if(!tile)
+	{
+		logGlobal->warn(
+			"CGObjectInstance::setType: object %s at %s has invalid visitablePos (null tile). "
+			"Skipping appearance update.",
+			LIBRARY->objtypeh->getObjectName(ID, newSubID), position.toString());
+		return;
+		// skip visual/type update here which would fail; object is already on map with bad coords.
+	}
 
 	//recalculate blockvis tiles - new appearance might have different blockmap than before
 	cb->gameState().getMap().hideObject(this);
 	auto handler = LIBRARY->objtypeh->getHandlerFor(newID, newSubID);
+
+	bool needToAdjustOffset = false;
+
+	// Current prison-release flow does not use setType(PRISON, HERO):
+	// GameStatePackVisitor::visitGiveHero updates appearance and anchor directly.
+	// Keep this branch as fallback in case another code path converts prisons via setType.
+	needToAdjustOffset |= this->ID == Obj::PRISON && newID == Obj::HERO;
+	needToAdjustOffset |= newID == Obj::MONSTER;
+	needToAdjustOffset |= newID == Obj::CREATURE_GENERATOR1 || newID == Obj::CREATURE_GENERATOR2 || newID == Obj::CREATURE_GENERATOR3 || newID == Obj::CREATURE_GENERATOR4;
+
+	int3 oldOffset;
+	if(needToAdjustOffset)
+	{
+		if(appearance->isVisitable())
+		{
+			oldOffset = appearance->getCornerOffset();
+		}
+		else
+		{
+			logGlobal->warn(
+				"CGObjectInstance::setType: object %s at %s has non-visitable template '%s'; "
+				"skipping old corner offset adjustment",
+				getObjectName(), pos.toString(), appearance->stringID);
+		}
+	}
 
 	if(!handler->getTemplates(tile->getTerrainID()).empty())
 	{
@@ -137,17 +171,12 @@ void CGObjectInstance::setType(MapObjectID newID, MapObjectSubID newSubID)
 	}
 	else
 	{
-		logGlobal->warn("Object %d:%d at %s has no templates suitable for terrain %s", newID, newSubID, visitablePos().toString(), tile->getTerrain()->getNameTranslated());
+		logGlobal->warn(
+			"Object %s at %s has no templates suitable for terrain %s",
+			LIBRARY->objtypeh->getObjectName(ID, newSubID), visitablePos().toString(),
+			tile->getTerrain()->getNameTranslated());
 		appearance = handler->getTemplates()[0]; // get at least some appearance since alternative is crash
 	}
-
-	bool needToAdjustOffset = false;
-
-	// FIXME: potentially unused code - setType is NOT called when releasing hero from prison
-	// instead, appearance update & pos adjustment occurs in GiveHero::applyGs
-	needToAdjustOffset |= this->ID == Obj::PRISON && newID == Obj::HERO;
-	needToAdjustOffset |= newID == Obj::MONSTER;
-	needToAdjustOffset |= newID == Obj::CREATURE_GENERATOR1 || newID == Obj::CREATURE_GENERATOR2 || newID == Obj::CREATURE_GENERATOR3 || newID == Obj::CREATURE_GENERATOR4;
 
 	if(needToAdjustOffset)
 	{

--- a/lib/mapping/CMap.cpp
+++ b/lib/mapping/CMap.cpp
@@ -39,6 +39,51 @@
 
 VCMI_LIB_NAMESPACE_BEGIN
 
+const CGHeroPlaceholder * CMap::findHeroPlaceholder(const int3 & position) const
+{
+	for(const auto * placeholder : getObjects<CGHeroPlaceholder>())
+	{
+		if(placeholder->coveringAt(position))
+			return placeholder;
+	}
+
+	return nullptr;
+}
+
+const CGHeroPlaceholder * CMap::isHeroPlaceholderObjective(const EventCondition & condition) const
+{
+	if((condition.condition != EventCondition::CONTROL &&
+		condition.condition != EventCondition::CONTROL_CURRENT &&
+		condition.condition != EventCondition::DESTROY) ||
+		condition.objectType.as<MapObjectID>() != Obj::HERO)
+		return nullptr;
+
+	return findHeroPlaceholder(condition.position);
+}
+
+void CMap::resolveHeroPlaceholderObjectives()
+{
+	for(TriggeredEvent & event : triggeredEvents)
+	{
+		auto patcher = [this, &event](EventCondition cond) -> EventExpression::Variant
+		{
+			if(const auto * placeholder = isHeroPlaceholderObjective(cond))
+			{
+				const std::string placeholderName = placeholder->heroType.has_value() ?
+					placeholder->heroType->toHeroType()->getNameTranslated() :
+					placeholder->instanceName;
+				cond.objectType = MapObjectID(Obj::HERO_PLACEHOLDER);
+				logGlobal->warn("Objective '%s': hero objective at %s points to hero placeholder '%s'; condition will remain unresolved until placeholder replacement is supported for normal maps",
+					event.identifier, cond.position.toString(), placeholderName);
+			}
+
+			return cond;
+		};
+
+		event.trigger = event.trigger.morph(patcher);
+	}
+}
+
 void Rumor::serializeJson(JsonSerializeFormat & handler)
 {
 	handler.serializeString("name", name);

--- a/lib/mapping/CMap.cpp
+++ b/lib/mapping/CMap.cpp
@@ -416,16 +416,6 @@ const CGObjectInstance * CMap::getObjectiveObjectFrom(const int3 & pos, Obj type
 	}
 
 	logGlobal->error("Failed to find object of type %d at %s", type.getNum(), pos.toString());
-
-	// Hero special case: this often means a placeholder hero used.
-	// OH3 treats such conditions as inactive if the hero doesn't actually exist on the map,
-	// so don't try to substitute some random other hero as it will trigger insta-loss.
-	if(type == Obj::HERO)
-	{
-		logGlobal->warn("Hero objective at %s has no actual hero instance; treating as placeholder / inactive.", pos.toString());
-		return nullptr;
-	}
-
 	logGlobal->error("Will try to find closest matching object");
 
 	CGObjectInstance * bestMatch = nullptr;
@@ -477,11 +467,21 @@ void CMap::checkForObjectives()
 					break;
 
 				case EventCondition::CONTROL:
-					if (isInTheMap(cond.position))
+					if(event.effect.type == EventEffect::VICTORY)
+						cond.condition = EventCondition::CONTROL_CURRENT;
+					[[fallthrough]];
+				case EventCondition::CONTROL_CURRENT:
+					if(isInTheMap(cond.position))
 					{
-						const auto * objective = getObjectiveObjectFrom(cond.position, cond.objectType.as<MapObjectID>());
-						if(objective)
-							cond.objectID = objective->id; // otherwise leave as NONE (placeholder / missing)
+						for(const auto & objID : getTile(cond.position).visitableObjects)
+						{
+							const auto * object = getObject(objID);
+							if(object->ID == cond.objectType.as<MapObjectID>())
+							{
+								cond.objectID = object->id;
+								break;
+							}
+						}
 					}
 
 					if (cond.objectID != ObjectInstanceID::NONE)

--- a/lib/mapping/CMap.cpp
+++ b/lib/mapping/CMap.cpp
@@ -441,11 +441,11 @@ const CGObjectInstance * CMap::getObjectiveObjectFrom(const int3 & pos, Obj type
 void CMap::checkForObjectives()
 {
 	// NOTE: probably should be moved to MapFormatH3M.cpp
-	for (TriggeredEvent & event : triggeredEvents)
+	for(TriggeredEvent & event : triggeredEvents)
 	{
 		auto patcher = [&](EventCondition cond) -> EventExpression::Variant
 		{
-			switch (cond.condition)
+			switch(cond.condition)
 			{
 				case EventCondition::HAVE_ARTIFACT:
 					event.onFulfill.replaceTextID(cond.objectType.as<ArtifactID>().toEntity(LIBRARY)->getNameTextID());
@@ -484,25 +484,25 @@ void CMap::checkForObjectives()
 						}
 					}
 
-					if (cond.objectID != ObjectInstanceID::NONE)
+					if(cond.objectID != ObjectInstanceID::NONE)
 					{
 						const auto * town = dynamic_cast<const CGTownInstance *>(objects[cond.objectID].get());
-						if (town)
+						if(town)
 							event.onFulfill.replaceRawString(town->getNameTranslated());
 						const auto * hero = dynamic_cast<const CGHeroInstance *>(objects[cond.objectID].get());
-						if (hero)
+						if(hero)
 							event.onFulfill.replaceRawString(hero->getNameTranslated());
 					}
 					break;
 
 				case EventCondition::DESTROY:
-					if (isInTheMap(cond.position))
+					if(isInTheMap(cond.position))
 						cond.objectID = getObjectiveObjectFrom(cond.position, cond.objectType.as<MapObjectID>())->id;
 
-					if (cond.objectID != ObjectInstanceID::NONE)
+					if(cond.objectID != ObjectInstanceID::NONE)
 					{
 						const auto * hero = dynamic_cast<const CGHeroInstance *>(objects[cond.objectID].get());
-						if (hero)
+						if(hero)
 							event.onFulfill.replaceRawString(hero->getNameTranslated());
 					}
 					break;

--- a/lib/mapping/CMap.cpp
+++ b/lib/mapping/CMap.cpp
@@ -648,6 +648,32 @@ void CMap::moveObject(ObjectInstanceID target, const int3 & dst)
 	showObject(obj);
 }
 
+bool CMap::adjustToMapBounds(CGObjectInstance * obj)
+{
+	if(!obj || !obj->isVisitable())
+		return false;
+
+	const auto oldVisitablePos = obj->visitablePos();
+	if(isInTheMap(oldVisitablePos))
+		return false;
+
+	int3 newVisitablePos = oldVisitablePos;
+	newVisitablePos.x = std::clamp(newVisitablePos.x, 0, width - 1);
+	newVisitablePos.y = std::clamp(newVisitablePos.y, 0, height - 1);
+
+	if(!isInTheMap(newVisitablePos))
+		return false;
+
+	// Keep object shape unchanged by translating anchor with the clamped visitable tile delta.
+	const int3 newAnchorPos = obj->anchorPos() + (newVisitablePos - oldVisitablePos);
+	if(obj->id.hasValue() && obj->id.getNum() < objects.size() && objects.at(obj->id.getNum()).get() == obj)
+		moveObject(obj->id, newAnchorPos);
+	else
+		obj->setAnchorPos(newAnchorPos);
+
+	return true;
+}
+
 std::shared_ptr<CGObjectInstance> CMap::removeObject(ObjectInstanceID oldObject)
 {
 	auto obj = objects.at(oldObject);

--- a/lib/mapping/CMap.cpp
+++ b/lib/mapping/CMap.cpp
@@ -414,10 +414,18 @@ const CGObjectInstance * CMap::getObjectiveObjectFrom(const int3 & pos, Obj type
 		if (object->ID == type)
 			return object;
 	}
-	// There is weird bug because of which sometimes heroes will not be found properly despite having correct position
-	// Try to workaround that and find closest object that we can use
 
 	logGlobal->error("Failed to find object of type %d at %s", type.getNum(), pos.toString());
+
+	// Hero special case: this often means a placeholder hero used.
+	// OH3 treats such conditions as inactive if the hero doesn't actually exist on the map,
+	// so don't try to substitute some random other hero as it will trigger insta-loss.
+	if(type == Obj::HERO)
+	{
+		logGlobal->warn("Hero objective at %s has no actual hero instance; treating as placeholder / inactive.", pos.toString());
+		return nullptr;
+	}
+
 	logGlobal->error("Will try to find closest matching object");
 
 	CGObjectInstance * bestMatch = nullptr;
@@ -470,7 +478,11 @@ void CMap::checkForObjectives()
 
 				case EventCondition::CONTROL:
 					if (isInTheMap(cond.position))
-						cond.objectID = getObjectiveObjectFrom(cond.position, cond.objectType.as<MapObjectID>())->id;
+					{
+						const auto * objective = getObjectiveObjectFrom(cond.position, cond.objectType.as<MapObjectID>());
+						if(objective)
+							cond.objectID = objective->id; // otherwise leave as NONE (placeholder / missing)
+					}
 
 					if (cond.objectID != ObjectInstanceID::NONE)
 					{

--- a/lib/mapping/CMap.cpp
+++ b/lib/mapping/CMap.cpp
@@ -416,26 +416,7 @@ const CGObjectInstance * CMap::getObjectiveObjectFrom(const int3 & pos, Obj type
 	}
 
 	logGlobal->error("Failed to find object of type %d at %s", type.getNum(), pos.toString());
-	logGlobal->error("Will try to find closest matching object");
-
-	CGObjectInstance * bestMatch = nullptr;
-	for (const auto & object : objects)
-	{
-		if (object && object->ID == type)
-		{
-			if (bestMatch == nullptr)
-				bestMatch = object.get();
-			else
-			{
-				if (object->anchorPos().dist2dSQ(pos) < bestMatch->anchorPos().dist2dSQ(pos))
-					bestMatch = object.get();// closer than one we already found
-			}
-		}
-	}
-	assert(bestMatch != nullptr); // if this happens - victory conditions or map itself is very, very broken
-
-	logGlobal->error("Will use %s from %s", bestMatch->getObjectName(), bestMatch->anchorPos().toString());
-	return bestMatch;
+	return nullptr;
 }
 
 void CMap::checkForObjectives()
@@ -463,7 +444,12 @@ void CMap::checkForObjectives()
 
 				case EventCondition::HAVE_BUILDING:
 					if (isInTheMap(cond.position))
-						cond.objectID = getObjectiveObjectFrom(cond.position, Obj::TOWN)->id;
+					{
+						if(const auto * object = getObjectiveObjectFrom(cond.position, Obj::TOWN))
+							cond.objectID = object->id;
+						else
+							logGlobal->warn("Objective '%s': failed to resolve town target for building objective at %s", event.identifier, cond.position.toString());
+					}
 					break;
 
 				case EventCondition::CONTROL:
@@ -496,8 +482,20 @@ void CMap::checkForObjectives()
 					break;
 
 				case EventCondition::DESTROY:
+					// Placeholder-targeted "defeat hero" objectives stay unresolved until normal-map placeholder replacement is supported.
+					if(cond.objectType.as<MapObjectID>() == Obj::HERO_PLACEHOLDER)
+						break;
+
 					if(isInTheMap(cond.position))
-						cond.objectID = getObjectiveObjectFrom(cond.position, cond.objectType.as<MapObjectID>())->id;
+					{
+						if(const auto * object = getObjectiveObjectFrom(cond.position, cond.objectType.as<MapObjectID>()))
+							cond.objectID = object->id;
+						else
+							logGlobal->warn("Objective '%s': failed to resolve destroy target of type %d at %s",
+								event.identifier,
+								cond.objectType.as<MapObjectID>().getNum(),
+								cond.position.toString());
+					}
 
 					if(cond.objectID != ObjectInstanceID::NONE)
 					{
@@ -507,7 +505,10 @@ void CMap::checkForObjectives()
 					}
 					break;
 				case EventCondition::TRANSPORT:
-					cond.objectID = getObjectiveObjectFrom(cond.position, Obj::TOWN)->id;
+					if(const auto * object = getObjectiveObjectFrom(cond.position, Obj::TOWN))
+						cond.objectID = object->id;
+					else
+						logGlobal->warn("Objective '%s': failed to resolve town target for transport objective at %s", event.identifier, cond.position.toString());
 					break;
 				//break; case EventCondition::DAYS_PASSED:
 				//break; case EventCondition::IS_HUMAN:

--- a/lib/mapping/CMap.h
+++ b/lib/mapping/CMap.h
@@ -25,6 +25,7 @@ class CArtifactInstance;
 class CArtifactSet;
 class CGObjectInstance;
 class CGHeroInstance;
+class CGHeroPlaceholder;
 class CCommanderInstance;
 class CGameState;
 class CGCreature;
@@ -235,6 +236,8 @@ public:
 
 	/// Gets object of specified type on requested position
 	const CGObjectInstance * getObjectiveObjectFrom(const int3 & pos, Obj type);
+	const CGHeroPlaceholder * findHeroPlaceholder(const int3 & position) const;
+	const CGHeroPlaceholder * isHeroPlaceholderObjective(const EventCondition & condition) const;
 
 	/// Returns pointer to hero of specified type if hero is present on map
 	CGHeroInstance * getHero(HeroTypeID heroId);
@@ -248,6 +251,7 @@ public:
 	const std::vector<ObjectInstanceID> & getAllTowns() const;
 
 	/// Sets the victory/loss condition objectives ??
+	void resolveHeroPlaceholderObjectives();
 	void checkForObjectives();
 
 	void resolveQuestIdentifiers();

--- a/lib/mapping/CMap.h
+++ b/lib/mapping/CMap.h
@@ -143,6 +143,10 @@ public:
 	/// Throws in invalid object instance ID
 	void moveObject(ObjectInstanceID target, const int3 & dst);
 
+	/// Clamps visitable x/y into the map and shifts anchor by the same delta.
+	/// Returns true if object position was changed.
+	bool adjustToMapBounds(CGObjectInstance * obj);
+
 	/// Hides object from map without actually removing it from object list
 	void hideObject(CGObjectInstance * obj);
 

--- a/lib/mapping/CMapHeader.h
+++ b/lib/mapping/CMapHeader.h
@@ -108,7 +108,7 @@ struct DLL_LINKAGE EventCondition
 		HAVE_CREATURES,    // type - creatures to collect, value - amount to collect
 		HAVE_RESOURCES,    // type - resource ID, value - amount to collect
 		HAVE_BUILDING,     // position - town, optional, type - building to build
-		CONTROL,           // position - position of object, optional, type - type of object
+		CONTROL,           // specific object: true until first capture, then only while currently controlled; generic type check: same as CONTROL_CURRENT
 		DESTROY,           // position - position of object, optional, type - type of object
 		TRANSPORT,         // position - where artifact should be transported, type - type of artifact
 
@@ -116,8 +116,9 @@ struct DLL_LINKAGE EventCondition
 		IS_HUMAN,          // value - 0 = player is AI, 1 = player is human
 		DAYS_WITHOUT_TOWN, // value - how long player can live without town, 0=instakill
 		STANDARD_WIN,      // normal defeat all enemies condition
-		CONST_VALUE,        // condition that always evaluates to "value" (0 = false, 1 = true)
-	};
+		CONST_VALUE,       // condition that always evaluates to "value" (0 = false, 1 = true)
+		CONTROL_CURRENT    // current ownership check, for specific object or all objects of given type
+		};
 
 	using TargetTypeID = VariantIdentifier<ArtifactID, CreatureID, GameResID, BuildingID, MapObjectID>;
 

--- a/lib/mapping/MapFormatH3M.cpp
+++ b/lib/mapping/MapFormatH3M.cpp
@@ -1829,7 +1829,7 @@ void CMapLoaderH3M::readBoxContent(CGPandoraBox * object, const int3 & mapPositi
 	size_t gcre = reader->readUInt8(); //number of gained creatures
 	for(size_t oo = 0; oo < gcre; ++oo)
 	{
-		auto rId = reader->readCreature();
+		auto rId = reader->readCreature("reward at " + mapPosition.toString());
 		auto rVal = reader->readUInt16();
 
 		reward.creatures.emplace_back(rId, rVal);
@@ -2078,7 +2078,7 @@ std::shared_ptr<CGObjectInstance> CMapLoaderH3M::readGarrison(const int3 & mapPo
 	auto object = std::make_shared<CGGarrison>(map->cb);
 
 	setOwnerAndValidate(mapPosition, object.get(), reader->readPlayer32());
-	readCreatureSet(object.get(), idToBeGiven);
+	readCreatureSet(object.get(), idToBeGiven, mapPosition);
 	if(features.levelAB)
 		object->removableUnits = reader->readBool();
 	else
@@ -2164,7 +2164,7 @@ std::shared_ptr<CGObjectInstance> CMapLoaderH3M::readAbandonedMine(const int3 & 
 		bool hasCustomGuards = reader->readBool();
 		if (hasCustomGuards)
 		{
-			object->abandonedMineGuards.creature = reader->readCreature32();
+			object->abandonedMineGuards.creature = reader->readCreature32("abandoned mine at " + mapPosition.toString());
 			object->abandonedMineGuards.minAmount = reader->readInt32();
 			object->abandonedMineGuards.maxAmount = reader->readInt32();
 		}
@@ -2935,14 +2935,15 @@ void CMapLoaderH3M::readObjects()
 	}
 }
 
-void CMapLoaderH3M::readCreatureSet(CArmedInstance * out, const ObjectInstanceID & idToBeGiven)
+void CMapLoaderH3M::readCreatureSet(CArmedInstance * out, const ObjectInstanceID & idToBeGiven, const int3 & position)
 {
 	constexpr int unitsToRead = 7;
 	out->id = idToBeGiven;
+	const std::string creatureContext = "army at " + position.toString();
 
 	for(int index = 0; index < unitsToRead; ++index)
 	{
-		CreatureID creatureID = reader->readCreature();
+		CreatureID creatureID = reader->readCreature(creatureContext);
 		int count = reader->readUInt16();
 
 		// Empty slot
@@ -3081,7 +3082,7 @@ std::shared_ptr<CGObjectInstance> CMapLoaderH3M::readHero(const int3 & mapPositi
 
 	bool hasGarison = reader->readBool();
 	if(hasGarison)
-		readCreatureSet(object.get(), objectInstanceID);
+		readCreatureSet(object.get(), objectInstanceID, mapPosition);
 
 	object->formation = static_cast<EArmyFormation>(reader->readInt8Checked(0, 1));
 	assert(object->formation == EArmyFormation::LOOSE || object->formation == EArmyFormation::TIGHT);
@@ -3329,7 +3330,7 @@ void CMapLoaderH3M::readSeerHutQuest(CGSeerHut * hut, const int3 & position, con
 			}
 			case ESeerHutRewardType::CREATURE:
 			{
-				auto rId = reader->readCreature();
+				auto rId = reader->readCreature("seer hut at " + position.toString());
 				auto rVal = reader->readUInt16();
 
 				reward.creatures.emplace_back(rId, rVal);
@@ -3408,7 +3409,7 @@ EQuestMission CMapLoaderH3M::readQuest(IQuestObject * guard, const int3 & positi
 			guard->getQuest().mission.creatures.resize(typeNumber);
 			for(size_t hh = 0; hh < typeNumber; ++hh)
 			{
-				guard->getQuest().mission.creatures[hh].setType(reader->readCreature().toCreature());
+				guard->getQuest().mission.creatures[hh].setType(reader->readCreature("quest at " + position.toString()).toCreature());
 				guard->getQuest().mission.creatures[hh].setCount(reader->readUInt16());
 			}
 			break;
@@ -3505,7 +3506,7 @@ std::shared_ptr<CGObjectInstance> CMapLoaderH3M::readTown(const int3 & position,
 
 	bool hasGarrison = reader->readBool();
 	if(hasGarrison)
-		readCreatureSet(object.get(), idToBeGiven);
+		readCreatureSet(object.get(), idToBeGiven, position);
 
 	object->formation = static_cast<EArmyFormation>(reader->readInt8Checked(0, 1));
 	assert(object->formation == EArmyFormation::LOOSE || object->formation == EArmyFormation::TIGHT);
@@ -3710,7 +3711,7 @@ void CMapLoaderH3M::readMessageAndGuards(MetaString & message, CArmedInstance * 
 		message.appendTextID(readLocalizedString(TextIdentifier("guards", position.x, position.y, position.z, "message")));
 		bool hasGuards = reader->readBool();
 		if(hasGuards)
-			readCreatureSet(guards, idToBeGiven);
+			readCreatureSet(guards, idToBeGiven, position);
 
 		reader->skipZero(4);
 	}

--- a/lib/mapping/MapFormatH3M.cpp
+++ b/lib/mapping/MapFormatH3M.cpp
@@ -451,7 +451,7 @@ void CMapLoaderH3M::readVictoryLossConditions()
 			}
 			case EVictoryConditionType::CAPTURECITY:
 			{
-				EventCondition cond(EventCondition::CONTROL);
+				EventCondition cond(EventCondition::CONTROL_CURRENT);
 				cond.objectType = MapObjectID(MapObjectID::TOWN);
 				cond.position = reader->readInt3();
 
@@ -479,8 +479,8 @@ void CMapLoaderH3M::readVictoryLossConditions()
 			case EVictoryConditionType::TAKEDWELLINGS:
 			{
 				EventExpression::OperatorAll oper;
-				oper.expressions.emplace_back(EventCondition(EventCondition::CONTROL, 0, Obj(Obj::CREATURE_GENERATOR1)));
-				oper.expressions.emplace_back(EventCondition(EventCondition::CONTROL, 0, Obj(Obj::CREATURE_GENERATOR4)));
+				oper.expressions.emplace_back(EventCondition(EventCondition::CONTROL_CURRENT, 0, Obj(Obj::CREATURE_GENERATOR1)));
+				oper.expressions.emplace_back(EventCondition(EventCondition::CONTROL_CURRENT, 0, Obj(Obj::CREATURE_GENERATOR4)));
 
 				specialVictory.effect.toOtherMessage.appendTextID("core.genrltxt.289");
 				specialVictory.onFulfill.appendTextID("core.genrltxt.288");
@@ -491,7 +491,7 @@ void CMapLoaderH3M::readVictoryLossConditions()
 			}
 			case EVictoryConditionType::TAKEMINES:
 			{
-				EventCondition cond(EventCondition::CONTROL);
+				EventCondition cond(EventCondition::CONTROL_CURRENT);
 				cond.objectType = MapObjectID(MapObjectID::MINE);
 
 				specialVictory.effect.toOtherMessage.appendTextID("core.genrltxt.291");

--- a/lib/mapping/MapFormatH3M.h
+++ b/lib/mapping/MapFormatH3M.h
@@ -243,7 +243,7 @@ private:
 	 * @param out the loaded creature set
 	 * @param number the count of creatures to read
 	 */
-	void readCreatureSet(CArmedInstance * out, const ObjectInstanceID & idToBeGiven);
+	void readCreatureSet(CArmedInstance * out, const ObjectInstanceID & idToBeGiven, const int3 & position);
 
 	void readBoxContent(CGPandoraBox * object, const int3 & position, const ObjectInstanceID & idToBeGiven);
 	void readBoxHotaContent(CGPandoraBox * object, const int3 & position, const ObjectInstanceID & idToBeGiven);

--- a/lib/mapping/MapFormatJson.cpp
+++ b/lib/mapping/MapFormatJson.cpp
@@ -123,12 +123,13 @@ namespace HeaderDetail
 
 namespace TriggeredEventsDetail
 {
-	static const std::array conditionNames =
-	{
-		"haveArtifact", "haveCreatures",   "haveResources",   "haveBuilding",
-		"control",      "destroy",         "transport",       "daysPassed",
-		"isHuman",      "daysWithoutTown", "standardWin",     "constValue"
-	};
+		static const std::array conditionNames =
+		{
+			"haveArtifact", "haveCreatures",   "haveResources",   "haveBuilding",
+			"control",      "destroy",         "transport",       "daysPassed",
+			"isHuman",      "daysWithoutTown", "standardWin",     "constValue",
+			"controlCurrent"
+		};
 
 	static const std::array typeNames = { "victory", "defeat" };
 
@@ -177,6 +178,7 @@ namespace TriggeredEventsDetail
 						event.objectType = BuildingID(BuildingID::decode(data["type"].String()));
 					break;
 				case EventCondition::CONTROL:
+					case EventCondition::CONTROL_CURRENT:
 				case EventCondition::DESTROY:
 					if (data["type"].isNumber()) // compatibility
 						event.objectType = MapObjectID(data["type"].Integer());

--- a/lib/mapping/MapFormatJson.cpp
+++ b/lib/mapping/MapFormatJson.cpp
@@ -773,7 +773,7 @@ void CMapFormatJson::serializePredefinedHeroes(JsonSerializeFormat & handler)
 void CMapFormatJson::serializeOptions(JsonSerializeFormat & handler)
 {
 	serializeRumors(handler);
-	
+
 	serializeTimedEvents(handler);
 
 	serializePredefinedHeroes(handler);
@@ -922,7 +922,7 @@ void CMapLoaderJson::readHeader(const bool complete)
 	}
 
 	mapHeader->version = EMapFormat::VCMI;//todo: new version field
-	
+
 	//loading mods
 	mapHeader->mods = ModVerificationInfo::jsonDeserializeList(header["mods"]);
 
@@ -1284,15 +1284,15 @@ void CMapLoaderJson::readTranslations()
 		if(isExistArchive(language.identifier + ".json"))
 			translationsFromFile.Struct()[language.identifier] = getFromArchive(language.identifier + ".json");
 	}
-	
+
 	// Register translations with map name prefix
 	if(!translationsFromFile.Struct().empty())
 	{
 		std::string actualMapName = TextOperations::convertMapName(mapName);
-		
+
 		std::string preferredLanguage = CGeneralTextHandler::getPreferredLanguage();
 		std::string baseLanguage = Languages::getLanguageOptions(Languages::ELanguages::ENGLISH).identifier;
-		
+
 		// Determine base language from translations with most strings
 		int maxStrings = 0;
 		for(auto & translation : translationsFromFile.Struct())
@@ -1303,14 +1303,14 @@ void CMapLoaderJson::readTranslations()
 				baseLanguage = translation.first;
 			}
 		}
-		
+
 		// Load base language translations
 		if(translationsFromFile.Struct().count(baseLanguage))
 		{
 			for(auto & str : translationsFromFile[baseLanguage].Struct())
 			{
 				// Keys in JSON don't have map name (e.g. "header.name"), add map name when registering: map.<mapName>.<identifier>
-				TextIdentifier fullIdentifier = runningInMapEditor 
+				TextIdentifier fullIdentifier = runningInMapEditor
 					? TextIdentifier(str.first)
 					: TextIdentifier("map", actualMapName, str.first);
 				mapRegisterLocalizedString("map", *mapHeader, fullIdentifier, str.second.String(), baseLanguage);
@@ -1323,7 +1323,7 @@ void CMapLoaderJson::readTranslations()
 			JsonNode translationOverrides;
 			for(auto & str : translationsFromFile[preferredLanguage].Struct())
 			{
-				TextIdentifier fullIdentifier = runningInMapEditor 
+				TextIdentifier fullIdentifier = runningInMapEditor
 					? TextIdentifier(str.first)
 					: TextIdentifier("map", actualMapName, str.first);
 				translationOverrides.Struct()[fullIdentifier.get()].String() = str.second.String();

--- a/lib/mapping/MapReaderH3M.cpp
+++ b/lib/mapping/MapReaderH3M.cpp
@@ -520,10 +520,17 @@ void MapReaderH3M::readResources(TResources & resources)
 
 bool MapReaderH3M::readBool()
 {
-	uint8_t result = readUInt8();
-	assert(result == 0 || result == 1);
+	const uint8_t raw = readUInt8();
 
-	return result != 0;
+	if(raw != 0 && raw != 1)
+	{
+		logGlobal->warn(
+			"MapReaderH3M: invalid bool value %u in H3M data, using LSB (%u) as value",
+			static_cast<unsigned>(raw),
+			static_cast<unsigned>(raw & 1));
+	}
+
+	return (raw & 1) != 0;
 }
 
 int8_t MapReaderH3M::readInt8Checked(int8_t lowerLimit, int8_t upperLimit)

--- a/lib/mapping/MapReaderH3M.cpp
+++ b/lib/mapping/MapReaderH3M.cpp
@@ -200,24 +200,65 @@ FactionID MapReaderH3M::readFaction32()
 
 TerrainId MapReaderH3M::readTerrain()
 {
-	TerrainId result(readUInt8());
-	assert(result.getNum() < features.terrainsCount);
+	uint8_t raw = readUInt8();
+
+	if(raw >= features.terrainsCount)
+	{
+		// Map uses terrain index we don't support (e.g. extended terrain from other editor/mod)
+		// Fallback: clamp to last known terrain
+		logGlobal->warn(
+			"MapReaderH3M::readTerrain: map uses terrain %u but only %u types are supported. "
+			"Clamping to %u.",
+			raw, features.terrainsCount, features.terrainsCount ? features.terrainsCount - 1 : 0);
+
+		raw = features.terrainsCount ? features.terrainsCount - 1 : 0;
+	}
+
+	TerrainId result(raw);
 	return remapIdentifier(result);
 }
 
 RoadId MapReaderH3M::readRoad()
 {
-	RoadId result(readInt8());
-	assert(result.getNum() <= features.roadsCount);
-	return result;
+	const uint8_t raw = readInt8();
+	// Keep low 3 bits as road type; discard high-bit flags set by some editors (HotA?)
+	uint8_t type = raw & 0x07;
+
+	if(type > features.roadsCount)
+	{
+		// Map uses extended road type not supported by current config.
+		// Fallback: use the last supported road type (usually cobblestone).
+		logGlobal->warn(
+			"MapReaderH3M::readRoad: map uses road type %u but only %u types are supported. "
+			"Clamping to %u.",
+			type, features.roadsCount, features.roadsCount);
+
+		type = features.roadsCount;
+	}
+
+	return RoadId(type);
 }
 
 RiverId MapReaderH3M::readRiver()
 {
 	const uint8_t raw = readInt8();
-	// Keep low 3 bits as river type (0..4); discard high-bit flags set by some editors (HotA ?)
-	const uint8_t type = raw & 0x07;
-	assert(type <= features.riversCount);
+	// Keep low 3 bits as river type (0..7); discard high-bit flags set by some editors (HotA?)
+	uint8_t type = raw & 0x07;
+
+	if(type > features.riversCount)
+	{
+		// Map uses extended river type not supported by our config
+		// Fallback: clamp to last supported river type
+		const uint8_t fallback = features.riversCount ? features.riversCount : 0;
+
+		logGlobal->warn(
+			"MapReaderH3M::readRiver: map uses river type %u but only %u types are supported. "
+			"Clamping to %u.",
+			type, features.riversCount, fallback);
+
+		type = fallback;
+	}
+
 	return RiverId(type);
 }
 

--- a/lib/mapping/MapReaderH3M.cpp
+++ b/lib/mapping/MapReaderH3M.cpp
@@ -144,7 +144,7 @@ HeroTypeID MapReaderH3M::readHeroPortrait()
 	return remapper.remapPortrait(result);
 }
 
-CreatureID MapReaderH3M::readCreature32()
+CreatureID MapReaderH3M::readCreature32(const std::string & context)
 {
 	CreatureID result(reader->readUInt32());
 
@@ -161,11 +161,14 @@ CreatureID MapReaderH3M::readCreature32()
 	if (randomIndex.getNum() > -16)
 		return randomIndex;
 
-	logGlobal->warn("Map contains invalid creature %d. Will be removed!", result.getNum());
+	if(context.empty())
+		logGlobal->warn("Map contains invalid creature %d. Will be removed!", result.getNum());
+	else
+		logGlobal->warn("Map contains invalid creature %d in %s. Will be removed!", result.getNum(), context);
 	return CreatureID::NONE;
 }
 
-CreatureID MapReaderH3M::readCreature()
+CreatureID MapReaderH3M::readCreature(const std::string & context)
 {
 	CreatureID result;
 
@@ -187,7 +190,10 @@ CreatureID MapReaderH3M::readCreature()
 	if (randomIndex.getNum() > -16)
 		return randomIndex;
 
-	logGlobal->warn("Map contains invalid creature %d. Will be removed!", result.getNum());
+	if(context.empty())
+		logGlobal->warn("Map contains invalid creature %d. Will be removed!", result.getNum());
+	else
+		logGlobal->warn("Map contains invalid creature %d in %s. Will be removed!", result.getNum(), context);
 	return CreatureID::NONE;
 }
 

--- a/lib/mapping/MapReaderH3M.h
+++ b/lib/mapping/MapReaderH3M.h
@@ -35,8 +35,8 @@ public:
 	ArtifactID readArtifact8();
 	ArtifactID readArtifact32();
 	BuildingID readBuilding32(std::optional<FactionID> faction);
-	CreatureID readCreature32();
-	CreatureID readCreature();
+	CreatureID readCreature32(const std::string & context = {});
+	CreatureID readCreature(const std::string & context = {});
 	HeroTypeID readHero();
 	HeroTypeID readHero32();
 	HeroTypeID readHeroPortrait();

--- a/lib/serializer/ESerializationVersion.h
+++ b/lib/serializer/ESerializationVersion.h
@@ -65,10 +65,12 @@ enum class ESerializationVersion : int32_t
 	CUSTOM_GARRISON_TITLE, // GarrisonDialog pack now has custom title parameter
 	LUA_SCRIPTS,
 	REWARDABLE_RESET_CALENDAR, // rewardable reset period split into days/weeks/months
+	CONTROL_LOSS_TRACKING, // track when players ever controlled special defeat-condition objects
 
 	RELEASE_170 = HOTA_MAP_STACK_COUNT,
 	RELEASE_174 = CUSTOM_GARRISON_TITLE,
-	CURRENT = REWARDABLE_RESET_CALENDAR,
+
+	CURRENT = CONTROL_LOSS_TRACKING,
 };
 
 static_assert(ESerializationVersion::MINIMAL <= ESerializationVersion::CURRENT, "Invalid serialization version definition!");

--- a/mapeditor/mapsettings/abstractsettings.cpp
+++ b/mapeditor/mapsettings/abstractsettings.cpp
@@ -11,6 +11,7 @@
 #include "StdInc.h"
 #include "abstractsettings.h"
 #include "../mapcontroller.h"
+#include "../../lib/entities/hero/CHero.h"
 #include "../../lib/mapObjects/CGHeroInstance.h"
 #include "../../lib/mapObjects/CGCreature.h"
 #include "../../lib/mapObjects/CGCreature.h"
@@ -106,6 +107,16 @@ std::string AbstractSettings::getHeroName(const CMap & map, int objectIdx)
 	{
 		name = hero->getNameTranslated();
 	}
+	else if(auto placeholder = dynamic_cast<const CGHeroPlaceholder*>(map.objects.at(objectIdx).get()))
+	{
+		if(placeholder->heroType.has_value())
+			name = placeholder->heroType->toHeroType()->getNameTranslated();
+		else if(placeholder->powerRank.has_value())
+			name = boost::str(boost::format(QObject::tr("Hero placeholder (power rank %1)").toStdString()) % placeholder->powerRank.value());
+		else
+			// Hero placeholders are expected to be initialized with either heroType or powerRank.
+			assert(0);
+	}
 	return name;
 }
 
@@ -117,6 +128,47 @@ std::string AbstractSettings::getMonsterName(const CMap & map, int objectIdx)
 		name = boost::str(boost::format("%1% at %2%") % monster->getObjectName() % monster->anchorPos().toString());
 	}
 	return name;
+}
+
+std::vector<int> AbstractSettings::getHeroTargetObjectIndexes(const CMap & map)
+{
+	std::vector<int> result = getObjectIndexes<const CGHeroInstance>(map);
+	for(const auto * placeholder : map.getObjects<CGHeroPlaceholder>())
+		result.push_back(placeholder->id.getNum());
+
+	return result;
+}
+
+int AbstractSettings::getHeroTargetObjectByPos(const CMap & map, const int3 & pos)
+{
+	for(const auto * hero : map.getObjects<CGHeroInstance>())
+	{
+		const bool matchesPosition =
+			hero->anchorPos() == pos ||
+			(hero->isVisitable() && hero->visitableAt(pos)) ||
+			hero->coveringAt(pos);
+
+		if(matchesPosition)
+			return hero->id.getNum();
+	}
+
+	for(const auto * placeholder : map.getObjects<CGHeroPlaceholder>())
+	{
+		const bool matchesPosition =
+			placeholder->anchorPos() == pos ||
+			(placeholder->isVisitable() && placeholder->visitableAt(pos)) ||
+			placeholder->coveringAt(pos);
+
+		if(matchesPosition)
+			return placeholder->id.getNum();
+	}
+
+	return -1;
+}
+
+bool AbstractSettings::isHeroTargetObject(const CGObjectInstance * obj)
+{
+	return dynamic_cast<const CGHeroInstance *>(obj) || dynamic_cast<const CGHeroPlaceholder *>(obj);
 }
 
 JsonNode AbstractSettings::conditionToJson(const EventCondition & event)

--- a/mapeditor/mapsettings/abstractsettings.h
+++ b/mapeditor/mapsettings/abstractsettings.h
@@ -39,6 +39,9 @@ public:
 	static std::string getTownName(const CMap & map, int objectIdx);
 	static std::string getHeroName(const CMap & map, int objectIdx);
 	static std::string getMonsterName(const CMap & map, int objectIdx);
+	static std::vector<int> getHeroTargetObjectIndexes(const CMap & map);
+	static int getHeroTargetObjectByPos(const CMap & map, const int3 & pos);
+	static bool isHeroTargetObject(const CGObjectInstance * obj);
 
 	static JsonNode conditionToJson(const EventCondition & event);
 

--- a/mapeditor/mapsettings/loseconditions.cpp
+++ b/mapeditor/mapsettings/loseconditions.cpp
@@ -76,11 +76,11 @@ void LoseConditions::initialize(MapController & c)
 									loseTypeWidget->setCurrentIndex(idx);
 								}
 							}
-							if(objectType == Obj::HERO)
+							if(objectType == Obj::HERO || objectType == Obj::HERO_PLACEHOLDER)
 							{
 								ui->loseComboBox->setCurrentIndex(2);
 								assert(loseTypeWidget);
-								int heroIdx = getObjectByPos<const CGHeroInstance>(*controller->map(), posFromJson(json["position"]));
+								int heroIdx = getHeroTargetObjectByPos(*controller->map(), posFromJson(json["position"]));
 								if(heroIdx >= 0)
 								{
 									auto idx = loseTypeWidget->findData(heroIdx);
@@ -263,7 +263,7 @@ void LoseConditions::on_loseComboBox_currentIndexChanged(int index)
 		case 1: { //EventCondition::CONTROL (Obj::HERO)
 			loseTypeWidget = new QComboBox;
 			ui->loseParamsLayout->addWidget(loseTypeWidget);
-			for(int i : getObjectIndexes<const CGHeroInstance>(*controller->map()))
+			for(int i : getHeroTargetObjectIndexes(*controller->map()))
 				loseTypeWidget->addItem(QString::fromStdString(getHeroName(*controller->map(), i).c_str()), QVariant::fromValue(i));
 			pickObjectButton = new QToolButton;
 			connect(pickObjectButton, &QToolButton::clicked, this, &LoseConditions::onObjectSelect);
@@ -301,7 +301,7 @@ void LoseConditions::onObjectSelect()
 			}
 				
 			case 1: { //EventCondition::CONTROL (Obj::HERO)
-				l.highlight<const CGHeroInstance>();
+				l.highlight([](const CGObjectInstance * obj){ return AbstractSettings::isHeroTargetObject(obj); });
 				break;
 			}
 			default:

--- a/mapeditor/mapsettings/victoryconditions.cpp
+++ b/mapeditor/mapsettings/victoryconditions.cpp
@@ -312,7 +312,7 @@ void VictoryConditions::update()
 				specialVictory.trigger = EventExpression(cond);
 				break;
 			}
-				
+
 			case 7: {
 				EventCondition cond(EventCondition::DESTROY);
 				assert(victoryTypeWidget);
@@ -348,7 +348,7 @@ void VictoryConditions::update()
 		}
 		controller->map()->triggeredEvents.push_back(specialVictory);
 	}
-	
+
 	if(customMessage)
 	{
 		controller->map()->victoryMessage = MetaString::createFromTextID(mapRegisterLocalizedString("map", *controller->map(), TextIdentifier("header", "victoryMessage"), ui->victoryMessageEdit->text().toStdString()));
@@ -436,7 +436,7 @@ void VictoryConditions::on_victoryComboBox_currentIndexChanged(int index)
 			victorySelectWidget->addItem(tr("Any town"), QVariant::fromValue(-1));
 			for(int i : getObjectIndexes<const CGTownInstance>(*controller->map()))
 				victorySelectWidget->addItem(getTownName(*controller->map(), i).c_str(), QVariant::fromValue(i));
-			
+
 			pickObjectButton = new QToolButton;
 			connect(pickObjectButton, &QToolButton::clicked, this, &VictoryConditions::onObjectSelect);
 			ui->victoryParamsLayout->addWidget(pickObjectButton);
@@ -470,7 +470,7 @@ void VictoryConditions::on_victoryComboBox_currentIndexChanged(int index)
 			ui->victoryParamsLayout->addWidget(victoryTypeWidget);
 			for(int i = 0; i < controller->map()->allowedArtifact.size(); ++i)
 				victoryTypeWidget->addItem(QString::fromStdString(LIBRARY->arth->objects[i]->getNameTranslated()), QVariant::fromValue(i));
-			
+
 			victorySelectWidget = new QComboBox;
 			ui->victoryParamsLayout->addWidget(victorySelectWidget);
 			for(int i : getObjectIndexes<const CGTownInstance>(*controller->map()))
@@ -480,7 +480,7 @@ void VictoryConditions::on_victoryComboBox_currentIndexChanged(int index)
 			ui->victoryParamsLayout->addWidget(pickObjectButton);
 			break;
 		}
-			
+
 		case 7: { //EventCondition::DESTROY (Obj::MONSTER)
 			victoryTypeWidget = new QComboBox;
 			ui->victoryParamsLayout->addWidget(victoryTypeWidget);
@@ -508,22 +508,22 @@ void VictoryConditions::onObjectSelect()
 				l.highlight<const CGTownInstance>();
 				break;
 			}
-				
+
 			case 4: { //EventCondition::CONTROL (Obj::TOWN)
 				l.highlight<const CGTownInstance>();
 				break;
 			}
-				
+
 			case 5: { //EventCondition::DESTROY (Obj::HERO)
 				l.highlight<const CGHeroInstance>();
 				break;
 			}
-				
+
 			case 6: { //EventCondition::TRANSPORT (Obj::ARTEFACT)
 				l.highlight<const CGTownInstance>();
 				break;
 			}
-				
+
 			case 7: { //EventCondition::DESTROY (Obj::MONSTER)
 				l.highlight<const CGCreature>();
 				break;
@@ -534,14 +534,14 @@ void VictoryConditions::onObjectSelect()
 		l.update();
 		QObject::connect(&l, &ObjectPickerLayer::selectionMade, this, &VictoryConditions::onObjectPicked);
 	}
-	
+
 	controller->settingsDialog->hide();
 }
 
 void VictoryConditions::onObjectPicked(const CGObjectInstance * obj)
 {
 	controller->settingsDialog->show();
-	
+
 	for(MapScene * level : controller->getScenes())
 	{
 		auto & l = level->objectPickerView;
@@ -549,20 +549,20 @@ void VictoryConditions::onObjectPicked(const CGObjectInstance * obj)
 		l.update();
 		QObject::disconnect(&l, &ObjectPickerLayer::selectionMade, this, &VictoryConditions::onObjectPicked);
 	}
-	
+
 	if(!obj) //discarded
 		return;
-	
+
 	int vicConditions = ui->victoryComboBox->currentIndex() - 1;
 	QComboBox * w = victoryTypeWidget;
 	if(vicConditions == 3 || vicConditions == 6)
 		w = victorySelectWidget;
-	
+
 	for(int i = 0; i < w->count(); ++i)
 	{
 		if(w->itemData(i).toInt() < 0)
 			continue;
-		
+
 		auto data = controller->map()->objects.at(w->itemData(i).toInt());
 		if(data.get() == obj)
 		{

--- a/mapeditor/mapsettings/victoryconditions.cpp
+++ b/mapeditor/mapsettings/victoryconditions.cpp
@@ -139,11 +139,11 @@ void VictoryConditions::initialize(MapController & c)
 
 						case EventCondition::DESTROY: {
 							auto objectType = MapObjectID::decode(json["objectType"].String());
-							if(objectType == Obj::HERO)
+							if(objectType == Obj::HERO || objectType == Obj::HERO_PLACEHOLDER)
 							{
 								ui->victoryComboBox->setCurrentIndex(6);
 								assert(victoryTypeWidget);
-								int heroIdx = getObjectByPos<const CGHeroInstance>(*controller->map(), posFromJson(json["position"]));
+								int heroIdx = getHeroTargetObjectByPos(*controller->map(), posFromJson(json["position"]));
 								if(heroIdx >= 0)
 								{
 									auto idx = victoryTypeWidget->findData(heroIdx);
@@ -457,7 +457,7 @@ void VictoryConditions::on_victoryComboBox_currentIndexChanged(int index)
 		case 5: { //EventCondition::DESTROY (Obj::HERO)
 			victoryTypeWidget = new QComboBox;
 			ui->victoryParamsLayout->addWidget(victoryTypeWidget);
-			for(int i : getObjectIndexes<const CGHeroInstance>(*controller->map()))
+			for(int i : getHeroTargetObjectIndexes(*controller->map()))
 				victoryTypeWidget->addItem(tr(getHeroName(*controller->map(), i).c_str()), QVariant::fromValue(i));
 			pickObjectButton = new QToolButton;
 			connect(pickObjectButton, &QToolButton::clicked, this, &VictoryConditions::onObjectSelect);
@@ -515,7 +515,7 @@ void VictoryConditions::onObjectSelect()
 			}
 
 			case 5: { //EventCondition::DESTROY (Obj::HERO)
-				l.highlight<const CGHeroInstance>();
+				l.highlight([](const CGObjectInstance * obj){ return AbstractSettings::isHeroTargetObject(obj); });
 				break;
 			}
 

--- a/mapeditor/mapsettings/victoryconditions.cpp
+++ b/mapeditor/mapsettings/victoryconditions.cpp
@@ -119,7 +119,8 @@ void VictoryConditions::initialize(MapController & c)
 							break;
 						}
 
-						case EventCondition::CONTROL: {
+							case EventCondition::CONTROL:
+							case EventCondition::CONTROL_CURRENT: {
 							ui->victoryComboBox->setCurrentIndex(5);
 							assert(victoryTypeWidget);
 							auto mapObject = MapObjectID::decode(json["objectType"].String());
@@ -276,7 +277,7 @@ void VictoryConditions::update()
 			}
 
 			case 4: {
-				EventCondition cond(EventCondition::CONTROL);
+					EventCondition cond(EventCondition::CONTROL_CURRENT);
 				assert(victoryTypeWidget);
 				cond.objectType = Obj(Obj::TOWN);
 				int townIdx = victoryTypeWidget->currentData().toInt();

--- a/mapeditor/validator.cpp
+++ b/mapeditor/validator.cpp
@@ -85,6 +85,12 @@ std::set<Validator::Issue> Validator::validate(const CMap * map)
 		{
 			if(!o)
 				continue;
+
+			if(o->isVisitable() && !map->isInTheMap(o->visitablePos()))
+				issues.insert({ tr("Object's %1 visitable position %2 is outside of the map bounds")
+					.arg(o->instanceName.c_str())
+					.arg(QString::fromStdString(o->visitablePos().toString())), false });
+
 			//owners for objects
 			if(o->getOwner() == PlayerColor::UNFLAGGABLE)
 			{

--- a/mapeditor/validator.cpp
+++ b/mapeditor/validator.cpp
@@ -197,6 +197,32 @@ std::set<Validator::Issue> Validator::validate(const CMap * map)
 			if(!map->mods.count(mod.first))
 				issues.insert({ MapController::modMissingMessage(mod.second), true });
 		}
+
+		for(const auto & event : map->triggeredEvents)
+		{
+			auto conditionValidator = [map, &issues, &event](const EventCondition & condition) -> EventExpression::Variant
+			{
+				if(const auto * placeholder = map->isHeroPlaceholderObjective(condition))
+				{
+					const auto conditionName =
+						event.effect.type == EventEffect::VICTORY ?
+							Validator::tr("defeat a specific hero") :
+							Validator::tr("lose a specific hero");
+					const QString placeholderName = placeholder->heroType.has_value() ?
+						QString::fromStdString(placeholder->heroType->toHeroType()->getNameTranslated()) :
+						Validator::tr("hero placeholder");
+					issues.insert({
+						Validator::tr("Triggered event '%1' uses %2 condition targeting %3 at %4. This setup is unusual and should be avoided; map will stay playable, but the condition remains unresolved unless placeholder replacement is supported.")
+							.arg(event.identifier.c_str(), conditionName, placeholderName, QString::fromStdString(condition.position.toString())),
+						false
+					});
+				}
+
+				return condition;
+			};
+
+			event.trigger.morph(conditionValidator);
+		}
 	}
 	catch(const std::exception & e)
 	{

--- a/mapeditor/validator.cpp
+++ b/mapeditor/validator.cpp
@@ -30,9 +30,9 @@ Validator::Validator(const CMap * map, QWidget *parent) :
 	ui->setupUi(this);
 
 	screenGeometry = QApplication::primaryScreen()->availableGeometry();
-	
+
 	Helper::decorateDialog(this);
-	
+
 	showValidationResults(map);
 }
 
@@ -44,13 +44,13 @@ Validator::~Validator()
 std::set<Validator::Issue> Validator::validate(const CMap * map)
 {
 	std::set<Validator::Issue> issues;
-	
+
 	if(!map)
 	{
 		issues.insert({ tr("Map is not loaded"), true });
 		return issues;
 	}
-	
+
 	try
 	{
 		//check player settings
@@ -79,7 +79,7 @@ std::set<Validator::Issue> Validator::validate(const CMap * map)
 			issues.insert({ tr("No human players allowed to play this map"), true });
 
 		std::set<const CHero * > allHeroesOnMap; //used to find hero duplicated
-		
+
 		//checking all objects in the map
 		for(auto o : map->objects)
 		{
@@ -122,14 +122,14 @@ std::set<Validator::Issue> Validator::validate(const CMap * map)
 				{
 					if(map->allowedHeroes.count(ins->getHeroTypeID()) == 0)
 						issues.insert({ tr("Hero %1 is prohibited by map settings").arg(ins->getHeroType()->getNameTranslated().c_str()), false });
-					
+
 					if(!allHeroesOnMap.insert(ins->getHeroType()).second)
 						issues.insert({ tr("Hero %1 has duplicate on map").arg(ins->getHeroType()->getNameTranslated().c_str()), false });
 				}
 				else if(ins->ID != Obj::RANDOM_HERO)
 					issues.insert({ tr("Hero %1 has an empty type and must be removed").arg(ins->instanceName.c_str()), true });
 			}
-			
+
 			//checking for arts
 			if(auto * ins = dynamic_cast<CGArtifact *>(o.get()))
 			{
@@ -190,7 +190,7 @@ std::set<Validator::Issue> Validator::validate(const CMap * map)
 			issues.insert({ tr("Map name is not specified"), false });
 		if(map->description.empty())
 			issues.insert({ tr("Map description is not specified"), false });
-		
+
 		//verification for mods
 		for(auto & mod : MapController::modAssessmentMap(*map))
 		{
@@ -206,7 +206,7 @@ std::set<Validator::Issue> Validator::validate(const CMap * map)
 	{
 		issues.insert({ tr("Unknown exception occurs during validation"), true });
 	}
-	
+
 	return issues;
 }
 

--- a/server/CVCMIServer.cpp
+++ b/server/CVCMIServer.cpp
@@ -335,9 +335,9 @@ bool CVCMIServer::prepareToStartGame()
 	catch(const std::exception & e)
 	{
 		logGlobal->error("Failed to launch game: %s", e.what());
-		auto str = MetaString::createFromTextID("vcmi.broadcast.failedLoadGame");
+		auto str = MetaString::createFromTextID("vcmi.client.errors.invalidMap");
 		str.appendRawString(":\n");
-		str.appendRawString(e.what());
+		str.replaceRawString(e.what());
 		announceMessage(str);
 	}
 	current.finish();


### PR DESCRIPTION
Fixes: 
- #2166

<html><head></head><body><h3>Summary</h3><p>This PR hardens VCMI against invalid or extended H3M map data and avoids several crashes that occurred on community / HotA-style maps.</p><hr><h3>Key changes</h3><ul><li><p><strong>Map parsing robustness</strong></p><ul><li><p><code inline="">CBinaryReader::readBaseString()</code> now throws <code inline="">std::runtime_error()</code> when encountering an absurd string length instead of tripping a debug assert and crashing.</p></li><li><p>Callers can report a clean “Invalid or corrupt map” error to the user (similar to HotA) instead of failing with a crash</p></li></ul></li><li><p><strong>Safer object type changes</strong></p><ul><li><p><code inline="">CGObjectInstance::setType()</code>:</p><ul><li><p>Only calls <code inline="">getCornerOffset()</code> when an offset adjustment is actually needed (prisons → hero, monsters, creature generators), avoiding asserts on non-visitable templates (e.g. resource piles).</p></li><li><p>Skips appearance updates when <code inline="">cb-&gt;getTile(visitablePos())</code> returns <code inline="">nullptr</code>, logging a warning instead of dereferencing a null tile. Edit: should not happen now with the approach "push visitablePos into map bounds").</p></li></ul></li></ul></li><li><p><strong>Out-of-bounds visitable positions</strong></p><ul><li><p>Update: Objects that are visitable and placed outside of map's bounds are now <i>pushed</i> into map's boundaries before initialisation step.</p></li></ul></li><li><p><strong>Special loss conditions with placeholder heroes</strong></p><ul><li><p>Maps where “losing &lt;hero&gt;” is marked as a special loss condition but that hero is only used as a <strong>placeholder</strong> (uninitialized / unflagged owner) <s>will still cause instant loss on day 1 but not crash - those cases need to be handled still. HOTA allows such map to be played though.</s> are now handled and playable. The placeholder hero is discarded, in-line with OH3 behavior.</p></li></ul></li></ul><hr><h3>Testing</h3><p>Maps were tested one by one from the below list, top to bottom and some of them became playable due to fixes done along the way; they are still listed here for completeness.</p>

<h4>Map status after this PR</h4>

<table>
  <thead>
    <tr>
      <th>Map name</th>
      <th>Status / notes</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td>AB_Angor_s_Wrath.h3m</td>
      <td>Losing Sir Mullich is marked as a special loss condition but he is only a hero placeholder. OH3 accepts this; VCMI <s>triggers insta-loss.</s> now also allows this as well.</td>
    </tr>
    <tr>
      <td>AB_Attainment INCORRECT DATA CHECK.h3m</td>
      <td>Reported as “Invalid or corrupt map” instead of crashing. OH3 - same behavior in this case.</td>
    </tr>
    <tr>
      <td>AB_A_War INCORRECT DATA CHECK.h3m</td>
      <td>Playable (already fixed by an earlier PR).</td>
    </tr>
    <tr>
      <td>AB_Theophobia TAKE RESOURSES OR VISIT STAR AXES.h3m</td>
      <td>Playable with current <code>develop</code>.</td>
    </tr>
    <tr>
      <td>Baker Street (CHI).h3m</td>
      <td>Playable with current <code>develop</code>.</td>
    </tr>
    <tr>
      <td>Brave Heart (CHI).h3m</td>
      <td>Playable with current <code>develop</code>.</td>
    </tr>
    <tr>
      <td>Brave People-BT (CHI).h3m</td>
      <td>Playable with current <code>develop</code>.</td>
    </tr>
    <tr>
      <td>C-_Shadows_of_the_Forest ENG.h3m</td>
      <td>Previously crashed due to a resource pile placed at (108, 0) out of map bounds (invalid visitable pos). Now logs a warning and <s>skips that object.</s> moves that object visitablePos into the map bounds.</td>
    </tr>
    <tr>
      <td>Defend Taierzhuang (CHI).h3m</td>
      <td>Previously crashed due to multiple objects with out-of-bounds visitable positions. Now logs and <s>skips</s> moves those problematic objects; map is playable.</td>
    </tr>
    <tr>
      <td>Disappearing Planning Room (CHI).h3m</td>
      <td>Previously crashed; now playable.</td>
    </tr>
    <tr>
      <td>Doomsday Battle-BT (CHI).h3m</td>
      <td>Playable (not tested in current develop)</td>
    </tr>
    <tr>
      <td>Dragon's Nest (CHI).h3m</td>
      <td>Playable (not tested in current develop)</td>
    </tr>
    <tr>
      <td>Jedi Strikes Back (CHI).h3m</td>
      <td>Playable (not tested in current develop)</td>
    </tr>
    <tr>
      <td>Jedi Strikes Back-BT (CHI).h3m</td>
      <td>Playable (not tested in current develop)</td>
    </tr>
    <tr>
      <td>Jennifer's Dream Journey (CHI) ПОРАЖЕНИЕ LOSE.h3m</td>
      <td><s>Results in insta-loss.</s> Update: playable but with lots of objects not reachable for AI.</td>
    </tr>
    <tr>
      <td>Liu Bang’s Story (CHI).h3m</td>
      <td>Playable (not tested in current develop)</td>
    </tr>
    <tr>
      <td>Matrix (CHI).h3m</td>
      <td>Playable (not tested in current develop)</td>
    </tr>
    <tr>
      <td>Niklots Testament.h3m</td>
      <td>Playable (not tested in current develop)</td>
    </tr>
    <tr>
      <td>_Rise of the Sun King_ v26.0f (E) - UNABLE TO SELECT RANDOM ITEM FROM EMPTY CONTAINER.h3m</td>
      <td>Playable (not tested in current develop)</td>
    </tr>
    <tr>
      <td>Saint Seiya the Goddess of Wisdom-BT (CHI).h3m</td>
      <td>Playable (not tested in current develop)</td>
    </tr>
    <tr>
      <td>SoD_Dart_NeoEdik__часть_2.h3m</td>
      <td>Playable (not tested in current develop)</td>
    </tr>
    <tr>
      <td>Where the beauty.h3m</td>
      <td>Playable (not tested in current develop)</td>
    </tr>
  </tbody>
</table>


<blockquote><p>Note: this PR primarily ensures the above community maps no longer crash due to invalid data and that VCMI reports invalid maps clearly instead of crashing.</p></blockquote></body></html>