### PR TITLE
Automatically make save before visiting objects

### DIFF
--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -1001,6 +1001,8 @@ bool CGameHandler::moveHero(ObjectInstanceID hid, int3 dst, EMovementMode moveme
 		return false;
 	};
 
+	if (gameInfo().getPlayerState(h->getOwner())->human && (guardian || objectToVisit) && movementMode == EMovementMode::STANDARD)
+		save("Saves/BeforeVisitSave");
 
 	if (!transit && embarking)
 	{


### PR DESCRIPTION
Server will now automatically make save before visit of a map object by human-controlled hero.

Save is made immediately before visit, so if hero walks alongside some path that ends with combat, save will be made only before the very last step, and not at the start of the movement.

This should cover all possible cases where battle might start - enemy heroes, objects like creature banks, events, zone-of-control of wandering monsters, etc.

- Fixes #4816