### PR TITLE
Fix crash when ATTACK_AND_RETURN unit is slowed by retaliation and can’t return to origin

### DIFF
--- a/server/battles/BattleActionProcessor.cpp
+++ b/server/battles/BattleActionProcessor.cpp
@@ -229,7 +229,7 @@ bool BattleActionProcessor::doAttackAction(const CBattleInfoCallback & battle, c
 	}
 
 	BattleHex startingPos = stack->getPosition();
-	int overrideCreSpeed = stack->getMovementRange(0);
+	int beforeAttackSpeed = stack->getMovementRange(0);
 	const auto movementResult = moveStack(battle, ba.stackNumber, attackPos);
 
 	logGlobal->trace("%s will attack %s", stack->nodeName(), destinationStack->nodeName());
@@ -329,7 +329,11 @@ bool BattleActionProcessor::doAttackAction(const CBattleInfoCallback & battle, c
 		&& stack->alive())
 	{
 		assert(stack->unitId() == ba.stackNumber);
-		moveStack(battle, ba.stackNumber, startingPos, overrideCreSpeed);
+		int afterAttackSpeed = stack->getMovementRange(0);
+		std::pair<BattleHexArray, int> path = battle.getPath(stack->getPosition(), startingPos, stack);
+		size_t maxReachbleIndex = std::max(0, beforeAttackSpeed - afterAttackSpeed);
+		if(maxReachbleIndex < path.first.size())
+			moveStack(battle, ba.stackNumber, path.first[maxReachbleIndex]);
 	}
 	return true;
 }
@@ -624,7 +628,7 @@ bool BattleActionProcessor::makeBattleActionImpl(const CBattleInfoCallback & bat
 	return result;
 }
 
-BattleActionProcessor::MovementResult BattleActionProcessor::moveStack(const CBattleInfoCallback & battle, int stack, BattleHex dest, int overrideCreSpeed)
+BattleActionProcessor::MovementResult BattleActionProcessor::moveStack(const CBattleInfoCallback & battle, int stack, BattleHex dest)
 {
 	const CStack *curStack = battle.battleGetStackByID(stack);
 	const CStack *stackAtEnd = battle.battleGetStackByPos(dest);
@@ -677,7 +681,7 @@ BattleActionProcessor::MovementResult BattleActionProcessor::moveStack(const CBa
 	int8_t passedHexes = path.second;
 	bool movementSuccess = true;
 
-	int creSpeed = overrideCreSpeed == -1 ? curStack->getMovementRange(0) : overrideCreSpeed;
+	int creSpeed = curStack->getMovementRange(0);
 
 	if (battle.battleGetTacticDist() > 0 && creSpeed > 0)
 		creSpeed = GameConstants::BFIELD_SIZE;

--- a/server/battles/BattleActionProcessor.h
+++ b/server/battles/BattleActionProcessor.h
@@ -51,7 +51,7 @@ class BattleActionProcessor : boost::noncopyable
 	BattleProcessor * owner;
 	CGameHandler * gameHandler;
 
-	MovementResult moveStack(const CBattleInfoCallback & battle, int stack, BattleHex dest, int overrideCurSpeed=-1); //returned value - travelled distance
+	MovementResult moveStack(const CBattleInfoCallback & battle, int stack, BattleHex dest); //returned value - travelled distance
 	void makeAttack(const CBattleInfoCallback & battle, const CStack * attacker, const CStack * defender, int distance, const BattleHex & targetHex, bool first, bool ranged, bool counter);
 
 	void handleAttackBeforeCasting(const CBattleInfoCallback & battle, bool ranged, const CStack * attacker, const CStack * defender);


### PR DESCRIPTION
Fixes a crash where creatures with the ATTACK_AND_RETURN bonus may crash after being slowed by enemy retaliation and failing to return to their original hex.

The fix records the creature’s speed before the attack and uses that value for the return movement instead of the current (modified) speed, ensuring the return step always succeeds.