### PR TITLE
Campaigneditor: allow open campaign from set

### DIFF
--- a/mapeditor/campaigneditor/campaigneditor.h
+++ b/mapeditor/campaigneditor/campaigneditor.h
@@ -35,6 +35,7 @@ public:
 
 private slots:
 	void on_actionOpen_triggered();
+	void on_actionOpenSet_triggered();
 	void on_actionSave_as_triggered();
 	void on_actionNew_triggered();
 	void on_actionSave_triggered();

--- a/mapeditor/campaigneditor/campaigneditor.ui
+++ b/mapeditor/campaigneditor/campaigneditor.ui
@@ -37,6 +37,7 @@
       </property>
       <addaction name="actionNew"/>
       <addaction name="actionOpen"/>
+      <addaction name="actionOpenSet"/>
       <addaction name="actionSave"/>
       <addaction name="actionSave_as"/>
      </widget>
@@ -105,6 +106,14 @@
    </property>
    <property name="shortcut">
     <string notr="true">Ctrl+O</string>
+   </property>
+  </action>
+  <action name="actionOpenSet">
+   <property name="text">
+    <string>Open Campaignset</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true">Ctrl+G</string>
    </property>
   </action>
   <action name="actionSave">


### PR DESCRIPTION
New entry in menu for allowing open campaign from campaign set

Advantage over manual opening h3c:
- easier access of (native) campaigns (grouped by sets)
- standard campaigns embedded in lod files can directly opened
- [campaignOverrides](https://github.com/vcmi/vcmi/blob/develop/config/campaignOverrides.json) is correctly applied as they are in native path