### PR TITLE
MMAI: Temporarily disable temperature

### DIFF
--- a/AI/MMAI/BAI/model/NNModel.h
+++ b/AI/MMAI/BAI/model/NNModel.h
@@ -22,7 +22,7 @@ namespace MMAI::BAI
 class NNModel : public MMAI::Schema::IModel
 {
 public:
-	explicit NNModel(const std::string & path, float temperature, uint64_t seed);
+	explicit NNModel(const std::string & path, float _temperature, uint64_t seed);
 
 	Schema::ModelType getType() override;
 	std::string getName() override;


### PR DESCRIPTION
Force temperature=0 as a temporary workaround until the actual fix for an issue where a non-greedily sampled primary action leads to incorrect probabilities for sampling sub-actions.