### PR TITLE
mapeditor - fixes crashes at picking victory conditions

### DIFF
--- a/mapeditor/mapsettings/victoryconditions.cpp
+++ b/mapeditor/mapsettings/victoryconditions.cpp
@@ -497,7 +497,11 @@ void VictoryConditions::on_victoryComboBox_currentIndexChanged(int index)
 void VictoryConditions::onObjectSelect()
 {
 	int vicConditions = ui->victoryComboBox->currentIndex() - 1;
-	for(int lvl : {0, 1})
+
+	std::vector<int>levels(controller->map()->levels());
+	std::iota (std::begin(levels), std::end(levels), 0);
+
+	for(int lvl : levels)
 	{
 		auto & l = controller->scene(lvl)->objectPickerView;
 		switch(vicConditions)
@@ -539,8 +543,11 @@ void VictoryConditions::onObjectSelect()
 void VictoryConditions::onObjectPicked(const CGObjectInstance * obj)
 {
 	controller->settingsDialog->show();
+
+	std::vector<int>levels(controller->map()->levels());
+	std::iota (std::begin(levels), std::end(levels), 0);
 	
-	for(int lvl : {0, 1})
+	for(int lvl : levels)
 	{
 		auto & l = controller->scene(lvl)->objectPickerView;
 		l.clear();


### PR DESCRIPTION
Fixes crashes when choosing object picker for victory condition on a single-level map.
I also made it possible on multi-level maps.

PS: I think that the entire thing can be improved, controller should not generate mapViews for layers that do not exist (currently it does so) and victoryconditions should not be forced to figure out which levels exist and which don't, but maybe not so little before the release.