### PR TITLE
Support system onnxruntime on Arch

### DIFF
--- a/AI/MMAI/CMakeLists.txt
+++ b/AI/MMAI/CMakeLists.txt
@@ -82,8 +82,11 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
   message(STATUS "Looking for a system onnxruntime")
   find_path(ONNXRUNTIME_INCLUDE_DIR
     NAMES onnxruntime_cxx_api.h
-    PATH_SUFFIXES onnxruntime include
-  )
+    PATH_SUFFIXES
+        onnxruntime
+        include
+        include/onnxruntime
+)
 
   find_library(ONNXRUNTIME_LIBRARY NAMES onnxruntime libonnxruntime)
 


### PR DESCRIPTION
This PR broadens the ONNX Runtime include search paths on Linux so that the `onnxruntime-cpu` package installed from Arch/CachyOS (header in `/usr/include/onnxruntime/onnxruntime_cxx_api.h`) is correctly detected. This allows MMAI to link against a system-installed onnxruntime without requiring a custom `/opt/onnxruntime` layout.