### PR TITLE
mapeditor fix changing neutral armies character

### DIFF
--- a/mapeditor/inspector/inspector.cpp
+++ b/mapeditor/inspector/inspector.cpp
@@ -430,7 +430,7 @@ void Inspector::updateProperties(CGCreature * o)
 	{ //Character
 		auto * delegate = new InspectorDelegate;
 		delegate->options = characterIdentifiers;
-		addProperty<CGCreature::Character>("Character", (CGCreature::Character)o->character, delegate, false);
+		addProperty<CGCreature::Character>(QObject::tr("Character"), (CGCreature::Character)o->character, delegate, false);
 	}
 	addProperty(QObject::tr("Never flees"), o->neverFlees, false);
 	addProperty(QObject::tr("Not growing"), o->notGrowingTeam, false);


### PR DESCRIPTION
As in the title.
Fixes #6465 