### PR TITLE
Allow un-banning normally banned objects in RMG template

### DIFF
--- a/client/lobby/RandomMapTab.cpp
+++ b/client/lobby/RandomMapTab.cpp
@@ -266,6 +266,9 @@ void RandomMapTab::updateMapInfoByHost()
 
 		for (const auto & hero : temp->getBannedHeroes())
 			mapInfo->mapHeader->allowedHeroes.erase(hero);
+
+		for (const auto & hero : temp->getEnabledHeroes())
+			mapInfo->mapHeader->allowedHeroes.insert(hero);
 	}
 
 	mapInfo->mapHeader->difficulty = EMapDifficulty::NORMAL;

--- a/config/schemas/template.json
+++ b/config/schemas/template.json
@@ -237,6 +237,26 @@
 			"$ref" : "#/definitions/stringArray"
 		},
 		
+		"enabledHeroes": {
+			"description" : "List of normally banned heroes that are enabled on this template",
+			"$ref" : "#/definitions/stringArray"
+		},
+		
+		"enabledSpells": {
+			"description" : "List of normally banned spells that are enabled on this template",
+			"$ref" : "#/definitions/stringArray"
+		},
+		
+		"enabledArtifacts": {
+			"description" : "List of normally banned artifacts that are enabled on this template",
+			"$ref" : "#/definitions/stringArray"
+		},
+		
+		"enabledSkills": {
+			"description" : "List of normally banned skills that are enabled on this template",
+			"$ref" : "#/definitions/stringArray"
+		},
+		
 		"bannedHeroes": {
 			"description" : "List of heroes that are banned on this template",
 			"$ref" : "#/definitions/stringArray"

--- a/docs/modders/Random_Map_Template.md
+++ b/docs/modders/Random_Map_Template.md
@@ -43,6 +43,9 @@
 		"townPortal",
 		"modID:spellFromMod"
 	],
+	
+	// Similar to bannedSpells, list of normally banned spells that are enabled on this map
+	"enabledSpells" : [ ],
 
 	/// List of artifacts that are banned on this map. 
 	/// Identifier without modID specifier MUST exist in base game or in one of dependencies
@@ -51,6 +54,9 @@
 		"armageddonsBlade",
 		"modID:artifactFromMod"
 	],
+	
+	// Similar to bannedArtifacts, list of normally banned artifacts that are enabled on this map
+	"enabledArtifacts" : [ ],
 
 	/// List of secondary skills that are banned on this map. 
 	/// Identifier without modID specifier MUST exist in base game or in one of dependencies
@@ -60,13 +66,19 @@
 		"modID:secondarySkillFromMod"
 	],
 
+	// Similar to bannedSkills, list of normally banned skills that are enabled on this map
+	"enabledSkills" : [ ],
+
 	/// List of heroes that are banned on this map. 
 	/// Identifier without modID specifier MUST exist in base game or in one of dependencies
 	/// Identifier with explicit modID specifier will be silently skipped if corresponding mod is not loaded
 	"bannedHeroes": [
 		"lordHaart",
 		"modID:heroFromMod"
-	]
+	],
+	
+	// Similar to bannedHeroes, list of normally banned heroes that are enabled on this map
+	"enabledHeroes" : [ ],
 
 	/// List of named zones, see below for format description
 	"zones" :

--- a/lib/modding/IdentifierStorage.cpp
+++ b/lib/modding/IdentifierStorage.cpp
@@ -143,8 +143,8 @@ CIdentifierStorage::ObjectCallback CIdentifierStorage::ObjectCallback::fromNameA
 		logMod->debug("Target scope for identifier '%s' is redundant! Identifier already defined in mod '%s'", fullName, scope);
 
 	ObjectCallback result;
-	result.localScope = scope;
-	result.remoteScope = scopeAndFullName.first;
+	result.localScope = boost::to_lower_copy(scope);
+	result.remoteScope = boost::to_lower_copy(scopeAndFullName.first);
 	result.type = type;
 	result.name = typeAndName.second;
 	result.callback = callback;
@@ -298,6 +298,8 @@ void CIdentifierStorage::showIdentifierResolutionErrorDetails(const ObjectCallba
 				{
 					logMod->error("Identifier '%s' exists in mod %s", options.name, testOption.scope);
 					logMod->error("Please add mod '%s' as dependency of mod '%s' to access this identifier", testOption.scope, options.localScope);
+					if (options.bypassDependenciesCheck)
+						logMod->error("Or, to avoid this dependency, request this object as %s:%s", testOption.scope, options.name);
 					continue;
 				}
 
@@ -453,11 +455,11 @@ bool CIdentifierStorage::resolveIdentifier(const ObjectCallback & request) const
 		return true;
 	}
 
-	if (request.bypassDependenciesCheck)
+	if (request.bypassDependenciesCheck && !request.remoteScope.empty())
 	{
 		if (!vstd::contains(LIBRARY->modh->getActiveMods(), request.remoteScope))
 		{
-			logMod->debug("Mod '%s' requested identifier '%s' from not loaded mod '%s'. Ignoring.", request.localScope, request.remoteScope, request.name);
+			logMod->debug("Mod '%s' requested identifier '%s' from not loaded mod '%s'. Ignoring.", request.localScope, request.name, request.remoteScope);
 			return true; // mod was not loaded - ignore
 		}
 	}

--- a/lib/rmg/CMapGenerator.cpp
+++ b/lib/rmg/CMapGenerator.cpp
@@ -485,6 +485,18 @@ void CMapGenerator::addHeaderInfo()
 
 	for (const auto & hero : mapGenOptions.getMapTemplate()->getBannedHeroes())
 		m.allowedHeroes.erase(hero);
+
+	for (const auto & spell : mapGenOptions.getMapTemplate()->getEnabledSpells())
+		m.allowedSpells.insert(spell);
+
+	for (const auto & artifact : mapGenOptions.getMapTemplate()->getEnabledArtifacts())
+		m.allowedArtifact.insert(artifact);
+
+	for (const auto & skill : mapGenOptions.getMapTemplate()->getEnabledSkills())
+		m.allowedAbilities.insert(skill);
+
+	for (const auto & hero : mapGenOptions.getMapTemplate()->getEnabledHeroes())
+		m.allowedHeroes.insert(hero);
 }
 
 int CMapGenerator::getNextMonlithIndex()

--- a/lib/rmg/CRmgTemplate.cpp
+++ b/lib/rmg/CRmgTemplate.cpp
@@ -892,6 +892,11 @@ void CRmgTemplate::serializeJson(JsonSerializeFormat & handler)
 	handler.serializeIdArray("bannedSkills", bannedSkills);
 	handler.serializeIdArray("bannedHeroes", bannedHeroes);
 
+	handler.serializeIdArray("enabledSpells", enabledSpells);
+	handler.serializeIdArray("enabledArtifacts", enabledArtifacts);
+	handler.serializeIdArray("enabledSkills", enabledSkills);
+	handler.serializeIdArray("enabledHeroes", enabledHeroes);
+
 	*mapSettings = handler.getCurrent()["settings"];
 
 	{

--- a/lib/rmg/CRmgTemplate.h
+++ b/lib/rmg/CRmgTemplate.h
@@ -359,6 +359,10 @@ public:
 	const std::set<ArtifactID> & getBannedArtifacts() const { return bannedArtifacts; }
 	const std::set<SecondarySkill> & getBannedSkills() const { return bannedSkills; }
 	const std::set<HeroTypeID> & getBannedHeroes() const { return bannedHeroes; }
+	const std::set<SpellID> & getEnabledSpells() const { return enabledSpells; }
+	const std::set<ArtifactID> & getEnabledArtifacts() const { return enabledArtifacts; }
+	const std::set<SecondarySkill> & getEnabledSkills() const { return enabledSkills; }
+	const std::set<HeroTypeID> & getEnabledHeroes() const { return enabledHeroes; }
 
 	void validate() const; /// Tests template on validity and throws exception on failure
 
@@ -382,6 +386,11 @@ private:
 	std::set<ArtifactID> bannedArtifacts;
 	std::set<SecondarySkill> bannedSkills;
 	std::set<HeroTypeID> bannedHeroes;
+
+	std::set<SpellID> enabledSpells;
+	std::set<ArtifactID> enabledArtifacts;
+	std::set<SecondarySkill> enabledSkills;
+	std::set<HeroTypeID> enabledHeroes;
 
 	std::set<TerrainId> inheritTerrainType(std::shared_ptr<rmg::ZoneOptions> zone, uint32_t iteration = 0);
 	std::map<GameResID, ui16> inheritMineTypes(std::shared_ptr<rmg::ZoneOptions> zone, uint32_t iteration = 0);


### PR DESCRIPTION
It is now possible to enabled heroes, spells, artifacts and skills that are normally banned on a RMG template, using format similar to recently added `bannedXXX : [ ... ]`

Also:
- made minor fixes to generate more clear error messages when identifier resolution fails due to not specified mod ID for optional requests
- mod ID is now case-insensitive when requesting identifiers