### PR TITLE
fixes to mapeditor

### DIFF
--- a/mapeditor/inspector/rewardswidget.cpp
+++ b/mapeditor/inspector/rewardswidget.cpp
@@ -459,7 +459,7 @@ void RewardsWidget::loadCurrentVisitInfo(int index)
 	for(auto i : vinfo.reward.grantedArtifacts)
 		ui->rArtifacts->item(LIBRARY->artifacts()->getById(i)->getIndex())->setCheckState(Qt::Checked);
 	for(auto i : vinfo.reward.spells)
-		ui->rArtifacts->item(LIBRARY->spells()->getById(i)->getIndex())->setCheckState(Qt::Checked);
+		ui->rSpells->item(LIBRARY->spells()->getById(i)->getIndex())->setCheckState(Qt::Checked);
 	for(auto & i : vinfo.reward.secondary)
 	{
 		int index = LIBRARY->skills()->getById(i.first)->getIndex();

--- a/mapeditor/mainwindow.cpp
+++ b/mapeditor/mainwindow.cpp
@@ -457,7 +457,7 @@ void MainWindow::initializeMap(bool isNew)
 		controller.map()->players[0].canComputerPlay = true;
 		controller.map()->players[0].canHumanPlay = true;
 	}
-	
+	ui->inspectorWidget->setRowCount(0);
 	onPlayersChanged();
 }
 

--- a/mapeditor/scenelayer.cpp
+++ b/mapeditor/scenelayer.cpp
@@ -327,7 +327,7 @@ QGraphicsItem * PassabilityLayer::draw(const QRectF & section)
 	if(isShown)
 	{
 		QPainter painter(&pixmap);
-		for(int j = 0; j <= pixmap.height(); j += tileSize)
+		for(int j = 0; j < pixmap.height(); j += tileSize)
 		{
 			for(int i = 0; i < pixmap.width(); i += tileSize)
 			{


### PR DESCRIPTION
Two quick fixes to bugs I've noticed when playing around with mapeditor.
1. Spells selected in Rewardbox change to artifacts on reopening.
https://github.com/user-attachments/assets/67b1cfe9-1c68-4c33-8099-12dfc2e12fef
2. Attempting to change inspectorTable instantly after reloading a map results in a crash. 
https://github.com/user-attachments/assets/faa81a90-0648-4abf-95db-810dd473d8e2

