### PR TITLE
[1.7.0] handle non loadable maps in campaign editor

### DIFF
--- a/mapeditor/campaigneditor/campaigneditor.h
+++ b/mapeditor/campaigneditor/campaigneditor.h
@@ -16,6 +16,7 @@
 #include "../../lib/constants/EntityIdentifiers.h"
 
 class CampaignState;
+class CMap;
 
 namespace Ui {
 class CampaignEditor;
@@ -32,6 +33,7 @@ public:
 	void redraw();
 
 	static void showCampaignEditor(QWidget *parent);
+	static std::unique_ptr<CMap> tryToOpenMap(QWidget* parent, std::shared_ptr<CampaignState> state, CampaignScenarioID scenario);
 
 private slots:
 	void on_actionOpen_triggered();

--- a/mapeditor/campaigneditor/scenarioproperties.cpp
+++ b/mapeditor/campaigneditor/scenarioproperties.cpp
@@ -11,6 +11,7 @@
 #include "scenarioproperties.h"
 #include "ui_scenarioproperties.h"
 #include "startingbonus.h"
+#include "campaigneditor.h"
 
 #include "../../lib/GameLibrary.h"
 #include "../../lib/CCreatureHandler.h"
@@ -403,6 +404,13 @@ void ScenarioProperties::on_pushButtonImport_clicked()
 	QFileInfo fileInfo(filename);
 	QString baseName = fileInfo.fileName();
 	campaignState->scenarios.at(scenario).mapName = baseName.toStdString();
+
+	if(!CampaignEditor::tryToOpenMap(this, campaignState, scenario))
+	{
+		campaignState->mapPieces.erase(scenario);
+		campaignState->scenarios.at(scenario) = CampaignScenario();
+		return;
+	}
 
 	reloadMapRelatedUi();
 }


### PR DESCRIPTION
... to avoid crashes and show the problem to user...