### PR TITLE
Block attempt to select invalid custom size of random map

### DIFF
--- a/Mods/vcmi/Content/config/english.json
+++ b/Mods/vcmi/Content/config/english.json
@@ -845,6 +845,8 @@
 	"vcmi.randomMapTab.widgets.teamAlignmentsButton" : "Setup...",
 	"vcmi.randomMapTab.widgets.teamAlignmentsLabel"  : "Team Alignments",
 	"vcmi.randomMapTab.widgets.roadTypesLabel"       : "Road Types",
+	"vcmi.randomMapTab.template.minimalSize" : "Minimal size: %dx%d, layers: %d",
+	"vcmi.randomMapTab.template.maximalSize" : "Maximal size: %dx%d, layers: %d",
 
 	"vcmi.optionsTab.turnOptions.hover" : "Turn Options",
 	"vcmi.optionsTab.turnOptions.help" : "Select turn timer and simultaneous turns options",

--- a/Mods/vcmi/Content/config/ukrainian.json
+++ b/Mods/vcmi/Content/config/ukrainian.json
@@ -568,6 +568,8 @@
 	"vcmi.randomMapTab.widgets.teamAlignmentsButton" : "Налаштувати...",
 	"vcmi.randomMapTab.widgets.teamAlignmentsLabel"  : "Розподіл команд",
 	"vcmi.randomMapTab.widgets.roadTypesLabel"       : "Види доріг",
+	"vcmi.randomMapTab.template.minimalSize" : "Мінімальний розмір: %dx%d, рівнів: %d",
+	"vcmi.randomMapTab.template.maximalSize" : "Максимальний розмір: %dx%d, рівнів: %d",
 
 	"vcmi.optionsTab.turnOptions.hover" : "Параметри ходів",
 	"vcmi.optionsTab.turnOptions.help" : "Виберіть опції таймера ходів та одночасних ходів",

--- a/client/lobby/RandomMapTab.cpp
+++ b/client/lobby/RandomMapTab.cpp
@@ -219,7 +219,7 @@ void RandomMapTab::onToggleMapSize(int btnId)
 
 	if(btnId == mapSizeVal.size() - 1)
 	{
-		ENGINE->windows().createAndPushWindow<SetSizeWindow>(int3(mapGenOptions->getWidth(), mapGenOptions->getHeight(), mapGenOptions->getLevels()), [this, setTemplateForSize](int3 ret){
+		ENGINE->windows().createAndPushWindow<SetSizeWindow>(int3(mapGenOptions->getWidth(), mapGenOptions->getHeight(), mapGenOptions->getLevels()), mapGenOptions->getMapTemplate(), [this, setTemplateForSize](int3 ret){
 			if(ret.z > 2)
 			{
 				std::shared_ptr<CInfoWindow> temp = CInfoWindow::create(LIBRARY->generaltexth->translate("vcmi.lobby.customRmgSize.experimental"), PlayerColor(0), {}); //TODO: multilevel support
@@ -474,6 +474,15 @@ void RandomMapTab::setTemplate(const CRmgTemplate * tmpl)
 		else
 			w->setTextOverlay(readText(variables["randomTemplate"]), EFonts::FONT_SMALL, Colors::WHITE);
 	}
+
+	if(auto w = widget<ComboBox>("templateList"))
+	{
+		if(tmpl)
+			w->setTextOverlay(tmpl->getName(), EFonts::FONT_SMALL, Colors::WHITE);
+		else
+			w->setTextOverlay(readText(variables["randomTemplate"]), EFonts::FONT_SMALL, Colors::WHITE);
+	}
+
 	updateMapInfoByHost();
 }
 
@@ -695,34 +704,82 @@ void RandomMapTab::loadOptions()
 	// TODO: Save & load difficulty?
 }
 
-SetSizeWindow::SetSizeWindow(int3 initSize, std::function<void(int3)> cb)
+SetSizeWindow::SetSizeWindow(int3 initSize, const CRmgTemplate * mapTemplate, std::function<void(int3)> cb)
 	: CWindowObject(BORDERED)
 {
 	OBJECT_CONSTRUCTION;
 
-	pos.w = 200;
-	pos.h = 122;
+	pos.w = 300;
+	pos.h = 180;
 
 	updateShadow();
 	center();
 
 	background = std::make_shared<FilledTexturePlayerColored>(Rect(0, 0, pos.w, pos.h));
 	background->setPlayerColor(PlayerColor(1));
-	buttonOk = std::make_shared<CButton>(Point(68, 80), AnimationPath::builtin("MuBchck"), CButton::tooltip(), [this, cb](){
+	buttonCancel = std::make_shared<CButton>(Point(160, 140), AnimationPath::builtin("MuBcanc"), CButton::tooltip(), [this, cb](){ close();}, EShortcut::GLOBAL_CANCEL);
+	buttonOk = std::make_shared<CButton>(Point(70, 140), AnimationPath::builtin("MuBchck"), CButton::tooltip(), [this, cb](){
 		close();
 		if(cb)
 			cb(int3(std::max(1, std::stoi(numInputs[0]->getText())), std::max(1, std::stoi(numInputs[1]->getText())), std::max(1, std::stoi(numInputs[2]->getText()))));
 	}, EShortcut::GLOBAL_ACCEPT);
 
-	titles.push_back(std::make_shared<CLabel>(100, 15, FONT_BIG, ETextAlignment::CENTER, Colors::WHITE, LIBRARY->generaltexth->translate("vcmi.lobby.customRmgSize.title")));
+	int3 minSize = mapTemplate ? mapTemplate->getMapSizes().first : int3{36,36,1};
+	int3 maxSize = mapTemplate ? mapTemplate->getMapSizes().second : int3{999,999,9};
+
+	MetaString minSizeString;
+	MetaString maxSizeString;
+	minSizeString.appendTextID("vcmi.randomMapTab.template.minimalSize");
+	maxSizeString.appendTextID("vcmi.randomMapTab.template.maximalSize");
+
+	minSizeString.replaceNumber(minSize.x);
+	minSizeString.replaceNumber(minSize.y);
+	minSizeString.replaceNumber(minSize.z);
+	maxSizeString.replaceNumber(maxSize.x);
+	maxSizeString.replaceNumber(maxSize.y);
+	maxSizeString.replaceNumber(maxSize.z);
+
+	if (mapTemplate)
+	{
+		MetaString templateTitle;
+		templateTitle.appendRawString("%s: %s");
+		templateTitle.replaceTextID("vcmi.randomMapTab.widgets.templateLabel");
+		templateTitle.replaceRawString(mapTemplate->getName());
+
+		titles.push_back(std::make_shared<CLabel>(10, 40, FONT_SMALL, ETextAlignment::CENTERLEFT, Colors::WHITE, templateTitle.toString()));
+	}
+
+	sizeLabels.push_back(std::make_shared<CLabel>(10, 60, FONT_SMALL, ETextAlignment::CENTERLEFT, Colors::WHITE, minSizeString.toString()));
+	sizeLabels.push_back(std::make_shared<CLabel>(10, 80, FONT_SMALL, ETextAlignment::CENTERLEFT, Colors::WHITE, maxSizeString.toString()));
+
+	const auto checkTemplateSize = [this, mapTemplate](const std::string &){
+		int3 mapSize {
+			std::stoi(numInputs[0]->getText()),
+			std::stoi(numInputs[1]->getText()),
+			std::stoi(numInputs[2]->getText())
+		};
+
+		bool isSizeLegal = mapTemplate ? mapTemplate->matchesSize(mapSize) : (mapSize.x * mapSize.y >= 36*36);
+
+		buttonOk->block(!isSizeLegal);
+
+		auto labelColors = isSizeLegal ? Colors::WHITE : Colors::RED;
+
+		for (const auto & label : sizeLabels)
+			label->setColor(labelColors);
+	};
+
+	titles.push_back(std::make_shared<CLabel>(150, 15, FONT_BIG, ETextAlignment::CENTER, Colors::WHITE, LIBRARY->generaltexth->translate("vcmi.lobby.customRmgSize.title")));
 
 	for(int i = 0; i < 3; i++)
 	{
-		Rect r(30 + i * 50, 50, 40, 20);
+		Rect r(10 + i * 100, 110, 80, 20);
+		rectangles.push_back(std::make_shared<TransparentFilledRectangle>(Rect(r.topLeft() - Point(0,18), r.dimensions()), ColorRGBA(0, 0, 0, 64), ColorRGBA(64, 64, 64, 64), 1));
 		rectangles.push_back(std::make_shared<TransparentFilledRectangle>(r, ColorRGBA(0, 0, 0, 128), ColorRGBA(64, 64, 64, 64), 1));
-		titles.push_back(std::make_shared<CLabel>(50 + i * 50, 40, FONT_SMALL, ETextAlignment::CENTER, Colors::WHITE, LIBRARY->generaltexth->translate("vcmi.lobby.customRmgSize." + std::to_string(i))));
+		titles.push_back(std::make_shared<CLabel>(50 + i * 100, 100, FONT_SMALL, ETextAlignment::CENTER, Colors::WHITE, LIBRARY->generaltexth->translate("vcmi.lobby.customRmgSize." + std::to_string(i))));
 		numInputs.push_back(std::make_shared<CTextInput>(r, EFonts::FONT_SMALL, ETextAlignment::CENTER, false));
 		numInputs.back()->setFilterNumber(0, i < 2 ? 999 : 9);
+		numInputs.back()->setCallback(checkTemplateSize);
 	}
 	numInputs[0]->setText(std::to_string(initSize.x));
 	numInputs[1]->setText(std::to_string(initSize.y));

--- a/client/lobby/RandomMapTab.h
+++ b/client/lobby/RandomMapTab.h
@@ -90,9 +90,11 @@ class SetSizeWindow: public CWindowObject
 	std::shared_ptr<FilledTexturePlayerColored> background;
 	std::vector<std::shared_ptr<CLabel>> titles;
 	std::shared_ptr<CButton> buttonOk;
+	std::shared_ptr<CButton> buttonCancel;
+	std::vector<std::shared_ptr<CLabel>> sizeLabels;
 
 	std::vector<std::shared_ptr<CTextInput>> numInputs;
 	std::vector<std::shared_ptr<TransparentFilledRectangle>> rectangles;
 public:
-	SetSizeWindow(int3 initSize, std::function<void(int3)> cb);
+	SetSizeWindow(int3 initSize, const CRmgTemplate * mapTemplate, std::function<void(int3)> cb);
 };


### PR DESCRIPTION
- It is no longer possible to select invalid (too big or too small) map size via custom size dialog when configuring random map
- Fixed bug where template name won't reset to default if template parameters are no longer valid
- Custom map size dialog now displays supported map sizes for random map template
- Fixes #6487

<img width="768" height="510" alt="зображення" src="https://github.com/user-attachments/assets/7139cf0d-a896-4aec-aa26-c593b640cf74" />
