### PR TITLE
[1.7.0] fix mouse drag on higher scale factor

### DIFF
--- a/client/eventsSDL/InputSourceMouse.cpp
+++ b/client/eventsSDL/InputSourceMouse.cpp
@@ -27,6 +27,8 @@
 
 InputSourceMouse::InputSourceMouse()
 	:mouseToleranceDistance(settings["input"]["mouseToleranceDistance"].Integer())
+	,motionAccumulatedX(.0f)
+	,motionAccumulatedY(.0f)
 {
 	SDL_SetHint(SDL_HINT_MOUSE_FOCUS_CLICKTHROUGH, "1");
 }
@@ -34,7 +36,11 @@ InputSourceMouse::InputSourceMouse()
 void InputSourceMouse::handleEventMouseMotion(const SDL_MouseMotionEvent & motion)
 {
 	Point newPosition = Point(motion.x, motion.y) / ENGINE->screenHandler().getScalingFactor();
-	Point distance = Point(-motion.xrel, -motion.yrel) / ENGINE->screenHandler().getScalingFactor();
+	motionAccumulatedX += static_cast<float>(-motion.xrel) / ENGINE->screenHandler().getScalingFactor();
+	motionAccumulatedY += static_cast<float>(-motion.yrel) / ENGINE->screenHandler().getScalingFactor();
+	Point distance = Point(motionAccumulatedX, motionAccumulatedY);
+	motionAccumulatedX -= distance.x;
+	motionAccumulatedY -= distance.y;
 
 	mouseButtonsMask = motion.state;
 

--- a/client/eventsSDL/InputSourceMouse.h
+++ b/client/eventsSDL/InputSourceMouse.h
@@ -24,6 +24,9 @@ class InputSourceMouse
 	Point middleClickPosition;
 	int mouseButtonsMask = 0;
 	const int mouseToleranceDistance;
+
+	float motionAccumulatedX;
+	float motionAccumulatedY;
 public:
 	InputSourceMouse();
 


### PR DESCRIPTION
We need floats to apply `handleEventMouseMotion` correct if scaling factor > 1.

Otherwise movement is dropped if motion is to slow, leading in buggy slow movement.