### PR TITLE
[1.7.0] Fixes and workarounds for crashes from Google Play

### DIFF
--- a/launcher/modManager/cmodlistview_moc.cpp
+++ b/launcher/modManager/cmodlistview_moc.cpp
@@ -727,7 +727,20 @@ QStringList CModListView::getModsToInstall(QString mod)
 
 void CModListView::on_updateButton_clicked()
 {
-	QString modName = ui->allModsView->currentIndex().data(ModRoles::ModNameRole).toString();
+	QModelIndex selectedMod = ui->allModsView->currentIndex();
+	if (!selectedMod.isValid())
+	{
+		logGlobal->error("Update failed! Invalid index selected but update button is not locked!");
+		return;
+	}
+
+	QString modName = selectedMod.data(ModRoles::ModNameRole).toString();
+	if (modName.isEmpty())
+	{
+		logGlobal->error("Update failed! Model index is valid but mod name is empty!");
+		return;
+	}
+
 	doUpdateMod(modName);
 
 	ui->updateButton->setEnabled(false);

--- a/lib/json/JsonValidator.cpp
+++ b/lib/json/JsonValidator.cpp
@@ -480,9 +480,17 @@ static bool testFilePresence(const std::string & scope, const ResourcePath & res
 
 	for(const auto & entry : allowedScopes)
 	{
-		if (CResourceHandler::get(entry)->existsResource(resource))
-			return true;
+		try
+		{
+			if (CResourceHandler::get(entry)->existsResource(resource))
+				return true;
+		}
+		catch (const std::out_of_range & e)
+		{
+			throw std::out_of_range("Failed to find filesystem of mod '" + entry + "' when testing file '" + resource.getOriginalName() + "' for mod '" + scope + "'");
+		}
 	}
+
 #endif
 	return false;
 }

--- a/server/CVCMIServer.h
+++ b/server/CVCMIServer.h
@@ -36,14 +36,15 @@ class GlobalLobbyProcessor;
 
 class CVCMIServer : public LobbyInfo, public INetworkServerListener, public INetworkTimerListener, public IGameServer
 {
-	std::unique_ptr<GlobalLobbyProcessor> lobbyProcessor;
-
 	std::chrono::steady_clock::time_point gameplayStartTime;
 	std::chrono::steady_clock::time_point lastTimerUpdateTime;
 
 	std::unique_ptr<INetworkHandler> networkHandler;
 	/// Network server instance that receives and processes incoming connections on active socket
 	std::unique_ptr<INetworkServer> networkServer;
+
+	/// Handles connection with global lobby. Must be constructed and destroyed after network handler
+	std::unique_ptr<GlobalLobbyProcessor> lobbyProcessor;
 
 	EServerState state = EServerState::LOBBY;
 


### PR DESCRIPTION
- Added more detailed error message for crash due to potential load of mod with missing dependencies?
- Fix crash on shutting down server when playing through online lobby
- Log instead of crash when player (somehow) presses update button without mod selected