### PR TITLE
fixes blit order

### DIFF
--- a/client/mapView/mapHandler.cpp
+++ b/client/mapView/mapHandler.cpp
@@ -105,14 +105,14 @@ bool CMapHandler::compareObjectBlitOrder(const CGObjectInstance * a, const CGObj
 	for(const auto & aOffset : a->getBlockedOffsets())
 	{
 		int3 testTarget = a->anchorPos() + aOffset + int3(0, 1, 0);
-		if(b->blockingAt(testTarget))
+		if(!a->blockingAt(testTarget) && b->blockingAt(testTarget))
 			bBlocksA += 1;
 	}
 
 	for(const auto & bOffset : b->getBlockedOffsets())
 	{
 		int3 testTarget = b->anchorPos() + bOffset + int3(0, 1, 0);
-		if(a->blockingAt(testTarget))
+		if(!b->blockingAt(testTarget) && a->blockingAt(testTarget))
 			aBlocksB += 1;
 	}
 


### PR DESCRIPTION
When testing object rendering between OG and vcmi I found discrepancies (town is always constructed first, so the objectInstanceId comparison result is always the same):
<img width="1156" height="892" alt="Screenshot from 2025-12-21 10-05-34" src="https://github.com/user-attachments/assets/248c71ac-b7f2-4d2a-834d-56a9f5e9c22e" />
<img width="1156" height="936" alt="Screenshot from 2025-12-21 10-05-52" src="https://github.com/user-attachments/assets/ca58eba5-9508-4325-9e2f-941e00a5c01c" />
I think the sorting algorithm is a little bit off. When considering "blocked" tiles it takes all of them into consideration, when IMO it makes more sense to take only the most southern ones.
After the change those discrepancies disappeared as well as the problem with map "The Newcomers" mentioned in #1974. 
<img width="945" height="756" alt="Screenshot from 2025-12-21 10-10-41" src="https://github.com/user-attachments/assets/48ee18ac-7aad-4762-9f56-0a80944bbcdb" />
Problems with map "Tale of two lands" are already not an issue on dev.
I've noticed no new rendering bugs, though some further testing is warranted.