### PR TITLE
[1.7.2] Improvements for HotA h3m support

### DIFF
--- a/config/objects/creatureBanks.json
+++ b/config/objects/creatureBanks.json
@@ -29,6 +29,7 @@
 				"rewards" : [
 					{
 						"message" : 34,
+						"mapDice" : 0,
 						"appearChance" : { "min" : 0, "max" : 30 },
 						"guards" : [
 							{ "amount" : 4, "type" : "cyclop" },
@@ -51,6 +52,7 @@
 
 					{
 						"message" : 34,
+						"mapDice" : 1,
 						"appearChance" : { "min" : 30, "max" : 60 },
 						"guards" : [
 							{ "amount" : 6, "type" : "cyclop" },
@@ -71,6 +73,7 @@
 					},
 					{
 						"message" : 34,
+						"mapDice" : 2,
 						"appearChance" : { "min" : 60, "max" : 90 },
 						"guards" : [
 							{ "amount" : 8, "type" : "cyclop" },
@@ -91,6 +94,7 @@
 					},
 					{
 						"message" : 34,
+						"mapDice" : 3,
 						"appearChance" : { "min" : 90, "max" : 100 },
 						"guards" : [
 							{ "amount" : 10, "type" : "cyclop" },
@@ -130,6 +134,7 @@
 				"rewards" : [
 					{
 						"message" : 34,
+						"mapDice" : 0,
 						"appearChance" : { "min" : 0, "max" : 30 },
 						"guards" : [
 							{ "amount" : 10, "type" : "dwarf" },
@@ -146,6 +151,7 @@
 					},
 					{
 						"message" : 34,
+						"mapDice" : 1,
 						"appearChance" : { "min" : 30, "max" : 60 },
 						"guards" : [
 							{ "amount" : 15, "type" : "dwarf" },
@@ -162,6 +168,7 @@
 					},
 					{
 						"message" : 34,
+						"mapDice" : 2,
 						"appearChance" : { "min" : 60, "max" : 90 },
 						"guards" : [
 							{ "amount" : 20, "type" : "dwarf" },
@@ -178,6 +185,7 @@
 					},
 					{
 						"message" : 34,
+						"mapDice" : 3,
 						"appearChance" : { "min" : 90, "max" : 100 },
 						"guards" : [
 							{ "amount" : 30, "type" : "dwarf" },
@@ -213,6 +221,7 @@
 				"rewards" : [
 					{
 						"message" : 34,
+						"mapDice" : 0,
 						"appearChance" : { "min" : 0, "max" : 30 },
 						"guards" : [
 							{ "amount" : 10, "type" : "griffin" },
@@ -225,6 +234,7 @@
 					},
 					{
 						"message" : 34,
+						"mapDice" : 1,
 						"appearChance" : { "min" : 30, "max" : 60 },
 						"guards" : [
 							{ "amount" : 20, "type" : "griffin" },
@@ -237,6 +247,7 @@
 					},
 					{
 						"message" : 34,
+						"mapDice" : 2,
 						"appearChance" : { "min" : 60, "max" : 90 },
 						"guards" : [
 							{ "amount" : 30, "type" : "griffin" },
@@ -249,6 +260,7 @@
 					},
 					{
 						"message" : 34,
+						"mapDice" : 3,
 						"appearChance" : { "min" : 90, "max" : 100 },
 						"guards" : [
 							{ "amount" : 40, "type" : "griffin" },
@@ -281,6 +293,7 @@
 				"rewards" : [
 					{
 						"message" : 34,
+						"mapDice" : 0,
 						"appearChance" : { "min" : 0, "max" : 30 },
 						"guards" : [
 							{ "amount" : 20, "type" : "imp" },
@@ -296,6 +309,7 @@
 					},
 					{
 						"message" : 34,
+						"mapDice" : 1,
 						"appearChance" : { "min" : 30, "max" : 60 },
 						"guards" : [
 							{ "amount" : 30, "type" : "imp" },
@@ -312,6 +326,7 @@
 					},
 					{
 						"message" : 34,
+						"mapDice" : 2,
 						"appearChance" : { "min" : 60, "max" : 90 },
 						"guards" : [
 							{ "amount" : 40, "type" : "imp" },
@@ -328,6 +343,7 @@
 					},
 					{
 						"message" : 34,
+						"mapDice" : 3,
 						"appearChance" : { "min" : 90, "max" : 100 },
 						"guards" : [
 							{ "amount" : 60, "type" : "imp" },
@@ -363,6 +379,7 @@
 				"rewards" : [
 					{
 						"message" : 34,
+						"mapDice" : 0,
 						"appearChance" : { "min" : 0, "max" : 30 },
 						"guards" : [
 							{ "amount" : 4, "type" : "medusa" },
@@ -379,6 +396,7 @@
 					},
 					{
 						"message" : 34,
+						"mapDice" : 1,
 						"appearChance" : { "min" : 30, "max" : 60 },
 						"guards" : [
 							{ "amount" : 6, "type" : "medusa" },
@@ -395,6 +413,7 @@
 					},
 					{
 						"message" : 34,
+						"mapDice" : 2,
 						"appearChance" : { "min" : 60, "max" : 90 },
 						"guards" : [
 							{ "amount" : 8, "type" : "medusa" },
@@ -411,6 +430,7 @@
 					},
 					{
 						"message" : 34,
+						"mapDice" : 3,
 						"appearChance" : { "min" : 90, "max" : 100 },
 						"guards" : [
 							{ "amount" : 10, "type" : "medusa" },
@@ -446,6 +466,7 @@
 				"rewards" : [
 					{
 						"message" : 34,
+						"mapDice" : 0,
 						"appearChance" : { "min" : 0, "max" : 30 },
 						"guards" : [
 							{ "amount" : 2, "type" : "naga" },
@@ -462,6 +483,7 @@
 					},
 					{
 						"message" : 34,
+						"mapDice" : 1,
 						"appearChance" : { "min" : 30, "max" : 60 },
 						"guards" : [
 							{ "amount" : 3, "type" : "naga" },
@@ -478,6 +500,7 @@
 					},
 					{
 						"message" : 34,
+						"mapDice" : 2,
 						"appearChance" : { "min" : 60, "max" : 90 },
 						"guards" : [
 							{ "amount" : 4, "type" : "naga" },
@@ -494,6 +517,7 @@
 					},
 					{
 						"message" : 34,
+						"mapDice" : 3,
 						"appearChance" : { "min" : 90, "max" : 100 },
 						"guards" : [
 							{ "amount" : 6, "type" : "naga" },
@@ -529,6 +553,7 @@
 				"rewards" : [
 					{
 						"message" : 34,
+						"mapDice" : 0,
 						"appearChance" : { "min" : 0, "max" : 30 },
 						"guards" : [
 							{ "amount" : 6, "type" : "fireDragonFly" },
@@ -541,6 +566,7 @@
 					},
 					{
 						"message" : 34,
+						"mapDice" : 1,
 						"appearChance" : { "min" : 30, "max" : 60 },
 						"guards" : [
 							{ "amount" : 9, "type" : "fireDragonFly" },
@@ -553,6 +579,7 @@
 					},
 					{
 						"message" : 34,
+						"mapDice" : 2,
 						"appearChance" : { "min" : 60, "max" : 90 },
 						"guards" : [
 							{ "amount" : 12, "type" : "fireDragonFly" },
@@ -565,6 +592,7 @@
 					},
 					{
 						"message" : 34,
+						"mapDice" : 3,
 						"appearChance" : { "min" : 90, "max" : 100 },
 						"guards" : [
 							{ "amount" : 18, "type" : "fireDragonFly" },
@@ -612,6 +640,7 @@
 				"rewards" : [
 					{
 						"message" : 34,
+						"mapDice" : 0,
 						"appearChance" : { "min" : 0, "max" : 30 },
 						"guards" : [
 							{ "amount" : 2, "type" : "wight" },
@@ -627,6 +656,7 @@
 					},
 					{
 						"message" : 34,
+						"mapDice" : 1,
 						"appearChance" : { "min" : 30, "max" : 60 },
 						"guards" : [
 							{ "amount" : 3, "type" : "wight" },
@@ -642,6 +672,7 @@
 					},
 					{
 						"message" : 34,
+						"mapDice" : 2,
 						"appearChance" : { "min" : 60, "max" : 90 },
 						"guards" : [
 							{ "amount" : 5, "type" : "wight" },
@@ -658,6 +689,7 @@
 					},
 					{
 						"message" : 34,
+						"mapDice" : 3,
 						"appearChance" : { "min" : 90, "max" : 100 },
 						"guards" : [
 							{ "amount" : 10, "type" : "wight" },
@@ -708,6 +740,7 @@
 				"rewards" : [
 					{
 						"message" : 43,
+						"mapDice" : 0,
 						"appearChance" : { "min" : 0, "max" : 30 },
 						"guards" : [
 							{ "amount" : 4, "type" : "waterElemental" },
@@ -723,6 +756,7 @@
 					},
 					{
 						"message" : 43,
+						"mapDice" : 1,
 						"appearChance" : { "min" : 30, "max" : 60 },
 						"guards" : [
 							{ "amount" : 6, "type" : "waterElemental" },
@@ -738,6 +772,7 @@
 					},
 					{
 						"message" : 43,
+						"mapDice" : 2,
 						"appearChance" : { "min" : 60, "max" : 90 },
 						"guards" : [
 							{ "amount" : 8, "type" : "waterElemental" },
@@ -753,6 +788,7 @@
 					},
 					{
 						"message" : 43,
+						"mapDice" : 3,
 						"appearChance" : { "min" : 90, "max" : 100 },
 						"guards" : [
 							{ "amount" : 12, "type" : "waterElemental" },
@@ -803,6 +839,7 @@
 				"rewards" : [
 					{
 						"appearChance" : { "min" : 0, "max" : 30 },
+						"mapDice" : 0,
 						"guards" : [
 							{ "amount" : 10, "type" : "skeleton" },
 							{ "amount" : 10, "type" : "walkingDead" },
@@ -818,6 +855,7 @@
 					},
 					{
 						"appearChance" : { "min" : 30, "max" : 60 },
+						"mapDice" : 1,
 						"guards" : [
 							{ "amount" : 13, "type" : "skeleton" },
 							{ "amount" : 10, "type" : "walkingDead" },
@@ -833,6 +871,7 @@
 					},
 					{
 						"appearChance" : { "min" : 60, "max" : 90 },
+						"mapDice" : 2,
 						"guards" : [
 							{ "amount" : 20, "type" : "skeleton" },
 							{ "amount" : 20, "type" : "walkingDead" },
@@ -848,6 +887,7 @@
 					},
 					{
 						"appearChance" : { "min" : 90, "max" : 100 },
+						"mapDice" : 3,
 						"guards" : [
 							{ "amount" : 20, "type" : "skeleton" },
 							{ "amount" : 20, "type" : "walkingDead" },
@@ -893,6 +933,7 @@
 				"rewards" : [
 					{
 						"message" : 34,
+						"mapDice" : 0,
 						"appearChance" : { "min" : 0, "max" : 30 },
 						"guards" : [
 							{ "amount" : 8, "type" : "greenDragon" },
@@ -913,6 +954,7 @@
 					},
 					{
 						"message" : 34,
+						"mapDice" : 1,
 						"appearChance" : { "min" : 30, "max" : 60 },
 						"guards" : [
 							{ "amount" : 8, "type" : "greenDragon" },
@@ -933,6 +975,7 @@
 					},
 					{
 						"message" : 34,
+						"mapDice" : 2,
 						"appearChance" : { "min" : 60, "max" : 90 },
 						"guards" : [
 							{ "amount" : 8, "type" : "greenDragon" },
@@ -953,6 +996,7 @@
 					},
 					{
 						"message" : 34,
+						"mapDice" : 3,
 						"appearChance" : { "min" : 90, "max" : 100 },
 						"guards" : [
 							{ "amount" : 8, "type" : "greenDragon" },

--- a/config/objects/pyramid.json
+++ b/config/objects/pyramid.json
@@ -20,7 +20,7 @@
 				
 				"variables" : {
 					"spell" : {
-						"gainedSpell" : {
+						"gainedSpell" : { // Note: this variable name is used by engine for H3M loading
 							"level": 5
 						}
 					}

--- a/config/objects/rewardableOncePerHero.json
+++ b/config/objects/rewardableOncePerHero.json
@@ -248,12 +248,14 @@
 					{
 						"description" : "@core.arraytxt.202",
 						"message" : 148,
+						"mapDice" : 0,
 						"appearChance" : { "max" : 34 },
 						"heroLevel" : 1
 					},
 					{
 						"description" : "@core.arraytxt.203",
 						"message" : 149,
+						"mapDice" : 1,
 						"appearChance" : { "min" : 34, "max" : 67 },
 						"limiter" : { "resources" : { "gold" : 2000 } },
 						"resources" : { "gold" : -2000 },
@@ -262,6 +264,7 @@
 					{
 						"description" : "@core.arraytxt.204",
 						"message" : 151,
+						"mapDice" : 2,
 						"appearChance" : { "min" : 67 },
 						"limiter" : { "resources" : { "gems" : 10 } },
 						"resources" : { "gems" : -10 },

--- a/config/objects/rewardableOnceVisitable.json
+++ b/config/objects/rewardableOnceVisitable.json
@@ -58,20 +58,32 @@
 				"onVisitedMessage" : 38,
 				"visitMode" : "once",
 				"selectMode" : "selectFirst",
+				
+				"variables" : {
+					"artifact" : {
+						"gainedArtifact" : { // Note: this variable name is used by engine for H3M loading
+							"class" : "TREASURE"
+						}
+					}
+				},
+				
 				"rewards" : [
 					{
 						"appearChance" : { "max" : 10 },
 						"message" : 37,
-						"artifacts" : [ { "class" : "TREASURE" } ]
+						"mapDice" : 1,
+						"artifacts" : [ "@gainedArtifact" ]
 					},
 					{
 						"appearChance" : { "min" : 10, "max" : 20 },
 						"message" : 37,
+						"mapDice" : 2,
 						"artifacts" : [ { "class" : "MINOR" } ]
 					},
 					{
 						"appearChance" : { "min" : 20, "max" : 100 },
 						"message" : 38,
+						"mapDice" : 0
 					}
 				]
 			}
@@ -156,27 +168,38 @@
 						"bonuses" : [ { "type" : "MORALE", "val" : -3, "duration" : "ONE_BATTLE", "description" : 104 } ]
 					}
 				],
+				"variables" : {
+					"artifact" : {
+						"gainedArtifact" : { // Note: this variable name is used by engine for H3M loading
+							"class" : "TREASURE"
+						}
+					}
+				},
 				"rewards" : [
 					{
 						"appearChance" : { "max" : 30 },
 						"message" : 162,
-						"artifacts" : [ { "class" : "TREASURE" } ],
+						"mapDice" : 0,
+						"artifacts" : [ "@gainedArtifact" ],
 						"bonuses" : [ { "type" : "MORALE", "val" : -3, "duration" : "ONE_BATTLE", "description" : 104 } ]
 					},
 					{
 						"appearChance" : { "min" : 30, "max" : 80 },
+						"mapDice" : 1,
 						"message" : 162,
 						"artifacts" : [ { "class" : "MINOR" } ],
 						"bonuses" : [ { "type" : "MORALE", "val" : -3, "duration" : "ONE_BATTLE", "description" : 104 } ]
 					},
 					{
 						"appearChance" : { "min" : 80, "max" : 95 },
+						"mapDice" : 2,
 						"message" : 162,
 						"artifacts" : [ { "class" : "MAJOR" } ],
 						"bonuses" : [ { "type" : "MORALE", "val" : -3, "duration" : "ONE_BATTLE", "description" : 104 } ]
 					},
 					{
 						"appearChance" : { "min" : 95 },
+						"mapDice" : 3,
 						"message" : 162,
 						"artifacts" : [ { "class" : "RELIC" } ],
 						"bonuses" : [ { "type" : "MORALE", "val" : -3, "duration" : "ONE_BATTLE", "description" : 104 } ]

--- a/config/objects/rewardablePickable.json
+++ b/config/objects/rewardablePickable.json
@@ -99,11 +99,13 @@
 				"rewards" : [
 					{
 						"message" : 51,
+						"mapDice" : 0,
 						"appearChance" : { "max" : 25 },
 						"removeObject" : true
 					},
 					{
 						"message" : 52,
+						"mapDice" : 1,
 						"appearChance" : { "min" : 25, "max" : 50 },
 						"removeObject" : true,
 						"resources" : {
@@ -112,6 +114,7 @@
 					},
 					{
 						"message" : 53,
+						"mapDice" : 2,
 						"appearChance" : { "min" : 50, "max" : 75 },
 						"removeObject" : true,
 						"resources" : {
@@ -121,6 +124,7 @@
 					},
 					{
 						"message" : 54,
+						"mapDice" : 3,
 						"appearChance" : { "min" : 75 },
 						"removeObject" : true,
 						"resources" : {
@@ -154,25 +158,35 @@
 				"compatibilityIdentifiers" : [ "object" ],
 				"visitMode" : "unlimited",
 				"selectMode" : "selectFirst",
+				
+				"variables" : {
+					"artifact" : {
+						"gainedArtifact" : { // Note: this variable name is used by engine for H3M loading
+							"class" : "TREASURE"
+						}
+					}
+				},
+				
 				"rewards" : [
 					{
 						"appearChance" : { "max" : 20 },
 						"message" : 116,
+						"mapDice" : 0,
 						"removeObject" : true,
 					},
 					{
 						"appearChance" : { "min" : 20, "max" : 30 },
 						"message" : 117,
+						"mapDice" : 2,
 						"removeObject" : true,
-						"artifacts" : [
-							{ "class" : "TREASURE" }
-						],
+						"artifacts" : [ "@gainedArtifact" ],
 						"resources" : {
 							"gold" : 1000
 						}
 					},
 					{
 						"appearChance" : { "min" : 30 },
+						"mapDice" : 1,
 						"message" : 118,
 						"removeObject" : true,
 						"resources" : {
@@ -205,27 +219,40 @@
 				"compatibilityIdentifiers" : [ "object" ],
 				"visitMode" : "unlimited",
 				"selectMode" : "selectFirst",
+
+				"variables" : {
+					"artifact" : {
+						"gainedArtifact" : { // Note: this variable name is used by engine for H3M loading
+							"class" : "TREASURE"
+						}
+					}
+				},
+
 				"rewards" : [
 					{
 						"appearChance" : { "max" : 55 },
 						"message" : 125,
+						"mapDice" : 0,
 						"removeObject" : true,
-						"artifacts" : [ { "class" : "TREASURE" } ]
+						"artifacts" : [ "@gainedArtifact" ]
 					},
 					{
 						"appearChance" : { "min" : 55, "max" : 75 },
+						"mapDice" : 1,
 						"message" : 125,
 						"removeObject" : true,
 						"artifacts" : [ { "class" : "MINOR" } ]
 					},
 					{
 						"appearChance" : { "min" : 75, "max" : 95 },
+						"mapDice" : 2,
 						"message" : 125,
 						"removeObject" : true,
 						"artifacts" : [ { "class" : "MAJOR" } ]
 					},
 					{
 						"appearChance" : { "min" : 95 },
+						"mapDice" : 3,
 						"message" : 125,
 						"removeObject" : true,
 						"artifacts" : [ { "class" : "RELIC" } ]
@@ -258,42 +285,58 @@
 				"onSelectMessage" : 146,
 				"visitMode" : "unlimited",
 				"selectMode" : "selectPlayer",
+				
+				"variables" : {
+					"artifact" : {
+						"gainedArtifact" : { // Note: this variable name is used by engine for H3M loading
+							"class" : "TREASURE"
+						}
+					}
+				},
+				
 				"rewards" : [
 					{
 						"appearChance" : { "max" : 33 },
+						"mapDice" : 0,
 						"resources" : { "gold" : 2000 },
 						"removeObject" : true,
 					},
 					{
 						"appearChance" : { "max" : 33 },
+						"mapDice" : 0,
 						"heroExperience" : 1500,
 						"removeObject" : true,
 					},
 					{
 						"appearChance" : { "min" : 33, "max" : 65 },
+						"mapDice" : 1,
 						"resources" : { "gold" : 1500 },
 						"removeObject" : true,
 					},
 					{
 						"appearChance" : { "min" : 33, "max" : 65 },
+						"mapDice" : 1,
 						"heroExperience" : 1000,
 						"removeObject" : true,
 					},
 					{
 						"appearChance" : { "min" : 65, "max" : 95 },
+						"mapDice" : 2,
 						"resources" : { "gold" : 1000 },
 						"removeObject" : true,
 					},
 					{
 						"appearChance" : { "min" : 65, "max" : 95 },
+						"mapDice" : 2,
 						"heroExperience" : 500,
 						"removeObject" : true,
 					},
 					{
 						"appearChance" : { "min" : 95 },
+						"mapDice" : 3,
 						"message" : 145,
 						"removeObject" : true,
-						"artifacts" : [ { "class" : "TREASURE" } ]
+						"artifacts" : [ "@gainedArtifact" ]
 					}
 				]
 			}

--- a/config/objects/scholar.json
+++ b/config/objects/scholar.json
@@ -39,6 +39,7 @@
 				"rewards" : [
 					{
 						"appearChance" : { "min" : 0, "max" : 33 },
+						"mapDice" : 0,
 						"message" : 115,
 						"limiter" : {
 							"canLearnSpells" : [
@@ -52,6 +53,7 @@
 					},
 					{
 						"appearChance" : { "min" : 33, "max" : 66 },
+						"mapDice" : 1,
 						"message" : 115,
 						"limiter" : {
 							// Hero does not have this skill at expert

--- a/config/schemas/rewardable.json
+++ b/config/schemas/rewardable.json
@@ -89,6 +89,7 @@
 			"type" : "object",
 			"additionalProperties" : false,
 			"properties" : {
+				"mapDice" : { "type" : "number" },
 				"appearChance" : {
 					"type" : "object", 
 					"additionalProperties" : false,

--- a/docs/modders/Map_Objects/Rewardable.md
+++ b/docs/modders/Map_Objects/Rewardable.md
@@ -44,6 +44,10 @@ Rewardable object is defined similarly to other objects, with key difference bei
     // see Appear Chance definition section
     "appearChance" : {
     },
+    
+    // If specified, then when loading from h3m map object may load preconfigured set of reward instead of randomizing them via appearChance
+    // Only supported for some objects, such as Scholar (SoD), and several other added in hota map format
+    "mapDice" : 0,
 
     // Conditions to receive reward. Hero can only see this reward if he fulfills limiter
     "limiter" : {

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -612,6 +612,7 @@ set(lib_MAIN_HEADERS
 	mapping/CMapInfo.h
 	mapping/CMapOperation.h
 	mapping/CMapService.h
+	mapping/MapDifficulty.h
 	mapping/MapEditUtils.h
 	mapping/MapIdentifiersH3M.h
 	mapping/MapFeaturesH3M.h

--- a/lib/StartInfo.cpp
+++ b/lib/StartInfo.cpp
@@ -96,6 +96,11 @@ bool StartInfo::restrictedGarrisonsForAI() const
 	return campState && campState->restrictedGarrisonsForAI();
 }
 
+EMapDifficulty StartInfo::getDifficulty() const
+{
+	return static_cast<EMapDifficulty>(difficulty);
+}
+
 void LobbyInfo::verifyStateBeforeStart(bool ignoreNoHuman) const
 {
 	if(!mi || !mi->mapHeader)

--- a/lib/StartInfo.h
+++ b/lib/StartInfo.h
@@ -15,6 +15,7 @@
 #include "TurnTimerInfo.h"
 #include "ExtraOptionsInfo.h"
 #include "campaign/CampaignConstants.h"
+#include "mapping/MapDifficulty.h"
 #include "serializer/GameConnectionID.h"
 #include "serializer/Serializeable.h"
 #include "serializer/PlayerConnectionID.h"
@@ -156,6 +157,8 @@ struct DLL_LINKAGE StartInfo : public Serializeable
 
 	/// Controls check for handling of garrisons by AI in Restoration of Erathia campaigns to match H3 behavior
 	bool restrictedGarrisonsForAI() const;
+
+	EMapDifficulty getDifficulty() const;
 
 	template <typename Handler>
 	void serialize(Handler &h)

--- a/lib/gameState/CGameState.cpp
+++ b/lib/gameState/CGameState.cpp
@@ -66,6 +66,7 @@
 #include "../serializer/CSaveFile.h"
 #include "../spells/CSpellHandler.h"
 #include "UpgradeInfo.h"
+#include "mapObjects/CGPandoraBox.h"
 
 #include <vstd/RNG.h>
 
@@ -922,6 +923,10 @@ void CGameState::initTowns(vstd::RNG & randomGenerator)
 void CGameState::initMapObjects(IGameRandomizer & gameRandomizer)
 {
 	logGlobal->debug("\tObject initialization");
+
+	for(auto & obj : map->getObjects<CGPandoraBox>())
+		if (!obj->presentOnDifficulties.contains(getStartInfo()->getDifficulty()))
+			map->eraseObject(obj->id);
 
 	for(auto & obj : map->getObjects())
 		obj->initObj(gameRandomizer);

--- a/lib/mapObjects/CGCreature.cpp
+++ b/lib/mapObjects/CGCreature.cpp
@@ -387,7 +387,7 @@ int CGCreature::takenAction(const CGHeroInstance *h, bool allowJoin) const
 
 	if (allowJoin && cb->getSettings().getInteger(EGameSettings::CREATURES_JOINING_PERCENTAGE) > 0)
 	{
-		if((cb->getSettings().getBoolean(EGameSettings::CREATURES_ALLOW_JOINING_FOR_FREE) || character == Character::COMPLIANT) && diplomacy + sympathy + 1 >= character)
+		if((cb->getSettings().getBoolean(EGameSettings::CREATURES_ALLOW_JOINING_FOR_FREE) || character == Character::COMPLIANT) && diplomacy + sympathy + 1 >= character && !joinOnlyForMoney)
 			return JOIN_FOR_FREE;
 
 		if(diplomacy * 2 + sympathy + 1 >= character)
@@ -573,13 +573,23 @@ bool CGCreature::containsUpgradedStack() const
 {
 	//source http://heroescommunity.com/viewthread.php3?TID=27539&PID=830557#focus
 
-	float a = 2992.911117f;
-	float b = 14174.264968f;
-	float c = 5325.181015f;
-	float d = 32788.727920f;
+	static constexpr float a = 2992.911117f;
+	static constexpr float b = 14174.264968f;
+	static constexpr float c = 5325.181015f;
+	static constexpr float d = 32788.727920f;
 
-	int val = static_cast<int>(std::floor(a * visitablePos().x + b * visitablePos().y + c * visitablePos().z + d));
-	return ((val % 32768) % 100) < 50;
+	switch (upgradedStackPresence)
+	{
+		case UpgradedStackPresence::ALWAYS:
+			return true;
+		case UpgradedStackPresence::NEVER:
+			return false;
+		default:
+		{
+			int val = static_cast<int>(std::floor(a * visitablePos().x + b * visitablePos().y + c * visitablePos().z + d));
+			return ((val % 32768) % 100) < 50;
+		}
+	}
 }
 
 int CGCreature::getNumberOfStacks(const CGHeroInstance * hero) const

--- a/lib/mapObjects/CGCreature.h
+++ b/lib/mapObjects/CGCreature.h
@@ -27,6 +27,12 @@ public:
 		COMPLIANT = 0, FRIENDLY = 1, AGGRESSIVE = 2, HOSTILE = 3, SAVAGE = 4
 	};
 
+	enum class UpgradedStackPresence : int8_t {
+		RANDOM = -1,
+		NEVER = 0,
+		ALWAYS = 1
+	};
+
 	ui32 identifier = -1; //unique code for this monster (used in missions)
 	si8 character = 0; //character of this set of creatures (0 - the most friendly, 4 - the most hostile) => on init changed to -4 (compliant) ... 10 value (savage)
 	MetaString message; //message printed for attacking hero
@@ -36,6 +42,8 @@ public:
 	bool notGrowingTeam = false; //if true, number of units won't grow
 	int64_t temppower = 0; //used to handle fractional stack growth for tiny stacks
 	int64_t stacksCount = -1; // the split stack count specified in a HotA 1.7 map (0 - one more, -1 - default, -2 one less, -3 average)
+	UpgradedStackPresence upgradedStackPresence = UpgradedStackPresence::RANDOM;
+	bool joinOnlyForMoney = false;
 
 	bool refusedJoining = false;
 
@@ -73,6 +81,11 @@ public:
 		h & formation;
 		if(h.version >= Handler::Version::HOTA_MAP_STACK_COUNT)
 			h & stacksCount;
+		if(h.version >= Handler::Version::HOTA_MAP_FORMAT_EXTENSIONS)
+		{
+			h & upgradedStackPresence;
+			h & joinOnlyForMoney;
+		}
 	}
 protected:
 	void setPropertyDer(ObjProperty what, ObjPropertyID identifier) override;

--- a/lib/mapObjects/CGPandoraBox.h
+++ b/lib/mapObjects/CGPandoraBox.h
@@ -11,6 +11,7 @@
 
 #include "CRewardableObject.h"
 #include "../ResourceSet.h"
+#include "../mapping/MapDifficulty.h"
 
 VCMI_LIB_NAMESPACE_BEGIN
 
@@ -19,6 +20,8 @@ struct InfoWindow;
 class DLL_LINKAGE CGPandoraBox : public CRewardableObject
 {
 public:
+	MapDifficultySet presentOnDifficulties;
+
 	using CRewardableObject::CRewardableObject;
 
 	MetaString message;
@@ -32,6 +35,8 @@ public:
 	{
 		h & static_cast<CRewardableObject&>(*this);
 		h & message;
+		if(h.version >= Handler::Version::HOTA_MAP_FORMAT_EXTENSIONS)
+			h & presentOnDifficulties;
 	}
 protected:
 	void grantRewardWithMessage(IGameEventCallback & gameEvents, const CGHeroInstance * contextHero, int rewardIndex, bool markAsVisit) const override;

--- a/lib/mapping/CMap.cpp
+++ b/lib/mapping/CMap.cpp
@@ -68,6 +68,11 @@ bool CMapEvent::occursToday(int currentDay) const
 	return (currentDay - firstOccurrence - 1) % nextOccurrence == 0;
 }
 
+bool CMapEvent::affectsDifficulty(EMapDifficulty difficulty) const
+{
+	return affectedDifficulties.contains(difficulty);
+}
+
 bool CMapEvent::affectsPlayer(PlayerColor color, bool isHuman) const
 {
 	if (players.count(color) == 0)

--- a/lib/mapping/CMapEvent.h
+++ b/lib/mapping/CMapEvent.h
@@ -13,6 +13,8 @@
 #include "../ResourceSet.h"
 #include "../texts/MetaString.h"
 
+#include "MapDifficulty.h"
+
 VCMI_LIB_NAMESPACE_BEGIN
 
 class JsonSerializeFormat;
@@ -26,12 +28,14 @@ public:
 	virtual ~CMapEvent() = default;
 
 	bool occursToday(int currentDay) const;
+	bool affectsDifficulty(EMapDifficulty difficulty) const;
 	bool affectsPlayer(PlayerColor player, bool isHuman) const;
 
 	std::string name;
 	MetaString message;
 	TResources resources;
 	std::set<PlayerColor> players;
+	MapDifficultySet affectedDifficulties;
 	bool humanAffected;
 	bool computerAffected;
 	ui32 firstOccurrence;
@@ -46,6 +50,8 @@ public:
 		h & message;
 		h & resources;
 		h & players;
+		if(h.version >= Handler::Version::HOTA_MAP_FORMAT_EXTENSIONS)
+			h & affectedDifficulties;
 		h & humanAffected;
 		h & computerAffected;
 		h & firstOccurrence;

--- a/lib/mapping/CMapHeader.h
+++ b/lib/mapping/CMapHeader.h
@@ -20,6 +20,8 @@
 #include "../texts/MetaString.h"
 #include "../texts/TextLocalizationContainer.h"
 
+#include "MapDifficulty.h"
+
 VCMI_LIB_NAMESPACE_BEGIN
 
 class CGObjectInstance;
@@ -191,15 +193,6 @@ struct DLL_LINKAGE TriggeredEvent
 		h & onFulfill;
 		h & effect;
 	}
-};
-
-enum class EMapDifficulty : uint8_t
-{
-	EASY = 0,
-	NORMAL = 1,
-	HARD = 2,
-	EXPERT = 3,
-	IMPOSSIBLE = 4
 };
 
 /// The disposed hero struct describes which hero can be hired from which player.

--- a/lib/mapping/MapDifficulty.h
+++ b/lib/mapping/MapDifficulty.h
@@ -1,0 +1,48 @@
+/*
+ * MapDifficulty.h, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
+
+#pragma once
+
+VCMI_LIB_NAMESPACE_BEGIN
+
+enum class EMapDifficulty : uint8_t
+{
+	EASY = 0,
+	NORMAL = 1,
+	HARD = 2,
+	EXPERT = 3,
+	IMPOSSIBLE = 4,
+	COUNT = 5
+};
+
+class MapDifficultySet
+{
+	static constexpr uint8_t allDifficultiesMask = (1 << static_cast<uint8_t>(EMapDifficulty::COUNT)) - 1;
+
+	uint8_t mask = allDifficultiesMask;
+public:
+	MapDifficultySet() = default;
+	explicit MapDifficultySet(uint8_t mask)
+		:mask(mask)
+	{}
+
+	bool contains(const	EMapDifficulty & difficulty) const
+	{
+		return (1 << static_cast<uint8_t>(difficulty)) & mask;
+	}
+
+	template <typename Handler>
+	void serialize(Handler & h)
+	{
+		h & mask;
+	}
+};
+
+VCMI_LIB_NAMESPACE_END

--- a/lib/mapping/MapFormatH3M.h
+++ b/lib/mapping/MapFormatH3M.h
@@ -215,7 +215,9 @@ private:
 	std::shared_ptr<CGObjectInstance> readLighthouse(const int3 & mapPosition, std::shared_ptr<const ObjectTemplate> objectTemplate);
 	std::shared_ptr<CGObjectInstance> readGeneric(const int3 & position, std::shared_ptr<const ObjectTemplate> objectTemplate);
 	std::shared_ptr<CGObjectInstance> readBank(const int3 & position, std::shared_ptr<const ObjectTemplate> objectTemplate);
-	std::shared_ptr<CGObjectInstance> readRewardWithArtifact(const int3 & position, std::shared_ptr<const ObjectTemplate> objectTemplate);
+	std::shared_ptr<CGObjectInstance> readRewardWithArtifact(const int3 & position, std::shared_ptr<const ObjectTemplate> objectTemplate, int artifactRewardIndex);
+	std::shared_ptr<CGObjectInstance> readRewardWithSpell(const int3 & position, std::shared_ptr<const ObjectTemplate> objectTemplate);
+	std::shared_ptr<CGObjectInstance> readRewardWithGarbage(const int3 & position, std::shared_ptr<const ObjectTemplate> objectTemplate);
 	std::shared_ptr<CGObjectInstance> readRewardWithArtifactAndResources(const int3 & position, std::shared_ptr<const ObjectTemplate> objectTemplate);
 	std::shared_ptr<CGObjectInstance> readBlackMarket(const int3 & position, std::shared_ptr<const ObjectTemplate> objectTemplate);
 	std::shared_ptr<CGObjectInstance> readUniversity(const int3 & position, std::shared_ptr<const ObjectTemplate> objectTemplate);

--- a/lib/rewardable/Info.cpp
+++ b/lib/rewardable/Info.cpp
@@ -363,36 +363,40 @@ void Rewardable::Info::configureRewards(
 	{
 		const JsonNode & reward = source.Vector().at(i);
 
-		if (!reward["appearChance"].isNull())
+		auto diceValue = object.getPresetVariable("dice", "map");
+
+		if (!diceValue.isNull())
 		{
-			const JsonNode & chance = reward["appearChance"];
-			std::string diceID = std::to_string(chance["dice"].Integer());
-
-			auto diceValue = object.getVariable("dice", diceID);
-
-			if (!diceValue.has_value())
+			if (!reward["mapDice"].isNull() && reward["mapDice"] != diceValue)
+				continue;
+		}
+		else
+		{
+			if (!reward["appearChance"].isNull())
 			{
-				const JsonNode & preset = object.getPresetVariable("dice", diceID);
-				if (preset.isNull())
+				const JsonNode & chance = reward["appearChance"];
+				std::string diceID = std::to_string(chance["dice"].Integer());
+
+				auto diceValue = object.getVariable("dice", diceID);
+				if (!diceValue.has_value())
+				{
 					object.initVariable("dice", diceID, gameRandomizer.getDefault().nextInt(0, 99));
-				else
-					object.initVariable("dice", diceID, preset.Integer());
+					diceValue = object.getVariable("dice", diceID);
+				}
+				assert(diceValue.has_value());
 
-				diceValue = object.getVariable("dice", diceID);
-			}
-			assert(diceValue.has_value());
-
-			if (!chance["min"].isNull())
-			{
-				int min = static_cast<int>(chance["min"].Float());
-				if (min > *diceValue)
-					continue;
-			}
-			if (!chance["max"].isNull())
-			{
-				int max = static_cast<int>(chance["max"].Float());
-				if (max <= *diceValue)
-					continue;
+				if (!chance["min"].isNull())
+				{
+					int min = static_cast<int>(chance["min"].Float());
+					if (min > *diceValue)
+						continue;
+				}
+				if (!chance["max"].isNull())
+				{
+					int max = static_cast<int>(chance["max"].Float());
+					if (max <= *diceValue)
+						continue;
+				}
 			}
 		}
 

--- a/lib/serializer/ESerializationVersion.h
+++ b/lib/serializer/ESerializationVersion.h
@@ -54,8 +54,9 @@ enum class ESerializationVersion : int32_t
 	BATTLE_ONLY, // battle only mode
 	CAMPAIGN_VIDEO, // second video for prolog/epilog in campaigns
 	HOTA_MAP_STACK_COUNT, // support Hota 1.7 stack count feature
+	HOTA_MAP_FORMAT_EXTENSIONS, // support multiple Hota 1.7 map format features
 
-	CURRENT = HOTA_MAP_STACK_COUNT,
+	CURRENT = HOTA_MAP_FORMAT_EXTENSIONS,
 };
 
 static_assert(ESerializationVersion::MINIMAL <= ESerializationVersion::CURRENT, "Invalid serialization version definition!");

--- a/server/processors/NewTurnProcessor.cpp
+++ b/server/processors/NewTurnProcessor.cpp
@@ -48,6 +48,9 @@ void NewTurnProcessor::handleTimeEvents(PlayerColor color)
 		if (!event.occursToday(gameHandler->gameState().day))
 			continue;
 
+		if (!event.affectsDifficulty(gameHandler->gameInfo().getStartInfo()->getDifficulty()))
+			continue;
+
 		if (!event.affectsPlayer(color, gameHandler->gameInfo().getPlayerState(color)->isHuman()))
 			continue;
 
@@ -80,6 +83,9 @@ void NewTurnProcessor::handleTownEvents(const CGTownInstance * town)
 	for (auto const & event : town->events)
 	{
 		if (!event.occursToday(gameHandler->gameState().day))
+			continue;
+
+		if (!event.affectsDifficulty(gameHandler->gameInfo().getStartInfo()->getDifficulty()))
 			continue;
 
 		PlayerColor player = town->getOwner();


### PR DESCRIPTION
Mostly based on the mysterious island map test results

Added support for following functionality from hota 1.7.X h3m format:
- Pandoras or map events can now grant movement points
- Pandoras or map events can now specify map difficulties on which these objects are present
- Timed events and town events can now specify map difficulties on which these objects are present
- Creature banks now support selection of difficulty preset (number of guards/reward) instead of random-selection
- Wandering monsters "joins only for money" flag is now supported
- Wandering monsters presence of upgraded stack can now be configured in map
- Pyramid can now grant specific spell configured in map
- Treasure Chest, Corpse, Sea Chest, Flotsam, Tree of Knowledge can now grant specific reward instead of randomly selected one
- Treasure Chest, Corpse, Warrior's Tomb, Shipwreck Survivor and Sea Chest can now grant specific artifact configured in map

With these changes,  mysterious island goes from 2600 objects with unsupported functionality to 500