### PR TITLE
Ensure fallback to BattleAI triggers on any MMAI error

### DIFF
--- a/AI/MMAI/BAI/model/util/bucketing.cpp
+++ b/AI/MMAI/BAI/model/util/bucketing.cpp
@@ -79,11 +79,21 @@ bool BucketBuilder::bucket_satisfies(const std::vector<std::vector<int32_t>> & s
 
 void BucketBuilder::log_bucket_choice(int chosen, const Requirements & req) const
 {
-	logAi->debug("Size: %d", chosen);
+	if(chosen < 0)
+		logAi->warn("Failed to find suitable bucket size.");
+
+	static const std::vector<int32_t> nullBucket = {-1, -1};
+	std::string msg;
+	msg.reserve(40 * LT_COUNT);
+	msg += (boost::format("Size: %1%") % chosen).str();
+
 	for(int i = 0; i < LT_COUNT; ++i)
 	{
-		logAi->debug("  %d: [%ld, %ld] -> [%lld, %lld]", i, req.e_req[i], req.k_req[i], all_sizes_[chosen][i][0], all_sizes_[chosen][i][1]);
+		auto bucket = chosen >= 0 ? all_sizes_[chosen][i] : nullBucket;
+		msg += (boost::format("\n  %1%: [%2%, %3%] -> [%4%, %5%]") % i % req.e_req[i] % req.k_req[i] % bucket[0] % bucket[1]).str();
 	}
+
+	logAi->debug(msg);
 }
 
 BucketChoice BucketBuilder::choose_bucket(const Requirements & req) const
@@ -105,8 +115,7 @@ BucketChoice BucketBuilder::choose_bucket(const Requirements & req) const
 		break;
 	}
 
-	if(choice.index >= 0)
-		log_bucket_choice(choice.index, req);
+	log_bucket_choice(choice.index, req);
 
 	return choice;
 }

--- a/AI/MMAI/BAI/v13/BAI.cpp
+++ b/AI/MMAI/BAI/v13/BAI.cpp
@@ -171,17 +171,6 @@ bool BAI::maybeCastSpell(const CStack * astack, const BattleID & bid)
 
 std::shared_ptr<BattleAction> BAI::maybeBuildAutoAction(const CStack * astack, const BattleID & bid) const
 {
-	// Guard against infinite battles
-	// (print warning once, make only fallback actions from there on)
-	if(getActionTotalCalls == 100)
-		warn("Reached 100 predictions, will fall back to BattleAI until this combat ends");
-
-	if(getActionTotalCalls >= 100)
-	{
-		auto evaluator = BattleEvaluator(env, cb, astack, *cb->getPlayerID(), bid, battle->battleGetMySide(), 1.0f, 2);
-		return std::make_shared<BattleAction>(evaluator.selectStackAction(astack));
-	}
-
 	if(astack->creatureId() == CreatureID::FIRST_AID_TENT)
 	{
 		const CStack * target = nullptr;
@@ -296,12 +285,42 @@ void BAI::activeStack(const BattleID & bid, const CStack * astack)
 {
 	Base::activeStack(bid, astack);
 
+	try
+	{
+		_activeStack(bid, astack);
+	}
+	catch(const std::exception & e)
+	{
+		error("Falling back to BattleAI due to MMAI error: " + std::string(e.what()));
+		auto evaluator = BattleEvaluator(env, cb, astack, *cb->getPlayerID(), bid, battle->battleGetMySide(), 1.0f, 2);
+		cb->battleMakeUnitAction(bid, evaluator.selectStackAction(astack));
+		return;
+	}
+}
+
+void BAI::_activeStack(const BattleID & bid, const CStack * astack)
+{
 	auto ba = maybeBuildAutoAction(astack, bid);
 
 	if(ba)
 	{
 		info("Making automatic action with %s", astack->getDescription());
 		cb->battleMakeUnitAction(bid, *ba);
+		return;
+	}
+
+	// Guard against infinite battles
+	// (print warning once, make only fallback actions from there on)
+	if(!inFallback && getActionTotalCalls >= 100)
+	{
+		warn("Reached 100 predictions, will fall back to BattleAI until this combat ends");
+		inFallback = true;
+	}
+
+	if(inFallback)
+	{
+		auto evaluator = BattleEvaluator(env, cb, astack, *cb->getPlayerID(), bid, battle->battleGetMySide(), 1.0f, 2);
+		cb->battleMakeUnitAction(bid, evaluator.selectStackAction(astack));
 		return;
 	}
 
@@ -353,33 +372,27 @@ void BAI::activeStack(const BattleID & bid, const CStack * astack)
 		state->action = std::make_unique<Action>(a, state->battlefield.get(), colorname);
 		debug("(%lld ms) Got action: %d: %s ", dt, a, state->action->name());
 
-		try
-		{
-			ba = buildBattleAction();
+		ba = buildBattleAction();
 
-			if(ba)
+		if(ba)
+		{
+			debug("Action is VALID: " + state->action->name());
+			errcounter = 0;
+			cb->battleMakeUnitAction(bid, *ba);
+			break;
+		}
+		else
+		{
+			++errcounter;
+			error("Action is INVALID: " + state->action->name());
+			if(errcounter > 10)
 			{
-				debug("Action is VALID: " + state->action->name());
-				errcounter = 0;
-				cb->battleMakeUnitAction(bid, *ba);
+				warn("Got 10 consecutive errors, will fall back to BattleAI until this combat ends");
+				auto evaluator = BattleEvaluator(env, cb, astack, *cb->getPlayerID(), bid, battle->battleGetMySide(), 1.0f, 2);
+				cb->battleMakeUnitAction(bid, evaluator.selectStackAction(astack));
+				inFallback = true;
 				break;
 			}
-			else
-			{
-				std::cout << Render(state.get(), state->action.get()) << "\n";
-				++errcounter;
-				if(errcounter > 10)
-				{
-					throw std::runtime_error("Received 10 consecutive invalid actions");
-				}
-				error("Action is INVALID: " + state->action->name());
-			}
-		}
-		catch(const std::exception & e)
-		{
-			std::cout << Render(state.get(), state->action.get()) << "\n";
-			std::cout << "FATAL ERROR: " << e.what() << "\n";
-			throw;
 		}
 	}
 }

--- a/AI/MMAI/BAI/v13/BAI.h
+++ b/AI/MMAI/BAI/v13/BAI.h
@@ -61,6 +61,7 @@ public:
 
 	// consecutive invalid actions counter
 	int errcounter = 0;
+	bool inFallback = false;
 
 	int getActionTotalMs;
 	int getActionTotalCalls;
@@ -75,6 +76,7 @@ public:
 	std::shared_ptr<BattleAction> buildBattleAction();
 	std::shared_ptr<BattleAction> maybeBuildAutoAction(const CStack * stack, const BattleID & bid) const;
 	bool maybeCastSpell(const CStack * stack, const BattleID & bid);
+	void _activeStack(const BattleID & bid, const CStack * stack);
 
 	std::optional<BattleAction> maybeFleeOrSurrender(const BattleID & bid);
 };

--- a/AI/MMAI/BAI/v13/render.cpp
+++ b/AI/MMAI/BAI/v13/render.cpp
@@ -98,7 +98,7 @@ namespace
 
 	std::array<const CStack *, 7> getAllStacksForSide(const Context & ctx, bool side)
 	{
-		return side ? ctx.l_CStacks : ctx.r_CStacks;
+		return side ? ctx.r_CStacks : ctx.l_CStacks;
 	}
 
 	// Return (attr == N/A), but after performing some checks

--- a/AI/MMAI/schema/schema.h
+++ b/AI/MMAI/schema/schema.h
@@ -10,13 +10,6 @@
 
 #pragma once
 
-/*
- * THIS FILE LIVES IN:
- *
- * vcmi/AI/MMAI/export/export.h
- *
- */
-
 #include "schema/base.h"
 
 #include "schema/v13/schema.h"


### PR DESCRIPTION
Fixes an issue where fallback to BattleAI was not correctly triggered.
Wrapped entire activeStack logic in try/catch with fallback, to prevent game crashes. 

