### PR TITLE
AI/MMAI: improve onnxruntime detection on Linux

### DIFF
--- a/AI/MMAI/CMakeLists.txt
+++ b/AI/MMAI/CMakeLists.txt
@@ -77,30 +77,38 @@ endif()
 target_link_libraries(MMAI PRIVATE vcmi)
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-  set(ONNXRUNTIME_ROOT "/opt/onnxruntime" CACHE PATH "Path to onnxruntime containing lib/onnxruntime.so and include/onnxruntime_cxx_api.h")
-
-  message(STATUS "Looking for a system onnxruntime")
-  find_path(ONNXRUNTIME_INCLUDE_DIR
-    NAMES onnxruntime_cxx_api.h
-    PATH_SUFFIXES
-        onnxruntime
-        include
-        include/onnxruntime
-)
-
-  find_library(ONNXRUNTIME_LIBRARY NAMES onnxruntime libonnxruntime)
-
-  if(ONNXRUNTIME_INCLUDE_DIR AND ONNXRUNTIME_LIBRARY)
-    message(STATUS "Using system onnxruntime:")
-    message(STATUS "  include: ${ONNXRUNTIME_INCLUDE_DIR}")
-    message(STATUS "  library: ${ONNXRUNTIME_LIBRARY}")
-
-    target_include_directories(MMAI PRIVATE "${ONNXRUNTIME_INCLUDE_DIR}")
-    target_link_libraries(MMAI PRIVATE "${ONNXRUNTIME_LIBRARY}")
+  # First try CMake config (works on Fedora, Debian, Ubuntu, Arch)
+  find_package(onnxruntime CONFIG QUIET)
+  if(onnxruntime_FOUND)
+    message(STATUS "Found onnxruntime via CMake config")
+    target_link_libraries(MMAI PRIVATE onnxruntime::onnxruntime)
   else()
-    message(STATUS "System onnxruntime not found, falling back to ${ONNXRUNTIME_ROOT}")
-    target_include_directories(MMAI PRIVATE "${ONNXRUNTIME_ROOT}/include")
-    target_link_libraries(MMAI PRIVATE "${ONNXRUNTIME_ROOT}/lib/libonnxruntime.so")
+    # Fallback to manual search for custom installs
+    message(STATUS "onnxruntime CMake config not found, trying system installation")
+    set(ONNXRUNTIME_ROOT "/opt/onnxruntime" CACHE PATH "Path to onnxruntime containing lib/onnxruntime.so and include/onnxruntime_cxx_api.h")
+    message(STATUS "Looking for onnxruntime via find_path/find_library (hint: ${ONNXRUNTIME_ROOT})")
+    find_path(ONNXRUNTIME_INCLUDE_DIR
+      NAMES onnxruntime_cxx_api.h
+      HINTS "${ONNXRUNTIME_ROOT}/include"
+      PATH_SUFFIXES
+          onnxruntime
+          include
+          include/onnxruntime
+    )
+
+    find_library(ONNXRUNTIME_LIBRARY NAMES onnxruntime libonnxruntime
+      HINTS "${ONNXRUNTIME_ROOT}/lib"
+    )
+
+    if(ONNXRUNTIME_INCLUDE_DIR AND ONNXRUNTIME_LIBRARY)
+      message(STATUS "Using onnxruntime:")
+      message(STATUS "  include: ${ONNXRUNTIME_INCLUDE_DIR}")
+      message(STATUS "  library: ${ONNXRUNTIME_LIBRARY}")
+      target_include_directories(MMAI PRIVATE "${ONNXRUNTIME_INCLUDE_DIR}")
+      target_link_libraries(MMAI PRIVATE "${ONNXRUNTIME_LIBRARY}")
+    else()
+      message(FATAL_ERROR "onnxruntime not found. Install onnxruntime-devel or set ONNXRUNTIME_ROOT to a custom installation path, or disable MMAI with -DENABLE_MMAI=OFF")
+    endif()
   endif()
 else()
   find_package(onnxruntime CONFIG REQUIRED)


### PR DESCRIPTION
Currently, the MMAI build on Linux falls back to hardcoded /opt/onnxruntime paths without checking if they exist, resulting in confusing compile-time errors about missing headers instead of a clear CMake configuration error.

This change:
- Tries find_package(onnxruntime CONFIG) first, which works on Fedora, Debian, Ubuntu, Arch, and other distros shipping CMake config files
- Falls back to manual find_path/find_library with ONNXRUNTIME_ROOT as a hint for custom installations
- Emits FATAL_ERROR with actionable guidance if onnxruntime cannot be found

Users with custom onnxruntime builds can still use:
  cmake -DONNXRUNTIME_ROOT=/path/to/onnxruntime ...

Tested on Fedora 43.


Assisted-by: Claude (Anthropic) <https://claude.ai>