### PR TITLE
[1.7.1] fix qt bug in launcher

### DIFF
--- a/launcher/modManager/modstateitemmodel_moc.cpp
+++ b/launcher/modManager/modstateitemmodel_moc.cpp
@@ -251,13 +251,22 @@ QModelIndex ModStateItemModel::index(int row, int column, const QModelIndex & pa
 QModelIndex ModStateItemModel::parent(const QModelIndex & child) const
 {
 	if (!child.isValid())
+	{
+		logGlobal->warn("ModStateItemModel::parent called with invalid child index");
 		return QModelIndex();
+	}
 
 	int id = child.internalId();
 	if (id < 0 || id >= modNameToID.size())
+	{
+		logGlobal->warn(
+			"ModStateItemModel::parent called with out-of-range internalId %s (valid range: 0..%s)",
+			id, modNameToID.size() - 1
+		);
 		return QModelIndex();
+	}
 
-	const QString &modID = modNameToID[id];
+	const QString & modID = modNameToID[id];
 
 	// top-level item → no parent
 	if (!modID.contains('.'))
@@ -267,11 +276,23 @@ QModelIndex ModStateItemModel::parent(const QModelIndex & child) const
 
 	int parentRow = modIndex[""].indexOf(parentID);
 	if (parentRow == -1)
+	{
+		logGlobal->warn(
+			"ModStateItemModel::parent failed: parent mod '%s' not found for child mod '%s'",
+			parentID.toStdString(), modID.toStdString()
+		);
 		return QModelIndex();
+	}
 
 	int parentInternalId = modNameToID.indexOf(parentID);
 	if (parentInternalId == -1)
+	{
+		logGlobal->warn(
+			"ModStateItemModel::parent failed: parent mod '%s' missing from modNameToID (child '%s')",
+			parentID.toStdString(), modID.toStdString()
+		);
 		return QModelIndex();
+	}
 
 	// column MUST be 0
 	return createIndex(parentRow, 0, parentInternalId);


### PR DESCRIPTION
Fixes #6384 and error reported on discord I think. At least for me.

Attention: Fix created by LLM with given stack trace and source.

[stacktrace.txt.zip](https://github.com/user-attachments/files/24338630/stacktrace.txt.zip)

LMM output:
```
Yes, the fix will work without causing any infinite loops or recursion issues.

Fix ModStateItemModel::parent() only

Do NOT touch anything else.

What’s wrong now

Parent index column must always be 0

Parent row must be the row of the parent in its own parent

Current code uses child row and child column → infinite recursion
```

```
🧠 Why this alone fixes the crash

Qt assumes:

index.parent().parent() eventually becomes invalid

Your old code violated that assumption, so match() recursed forever until malloc died.

This fix restores the parent/child contract, stopping recursion immediately.
```

```
Parent-Child Relationship Fixed:
The core issue was in how the parent of each model index was being calculated. The original code could end up returning an invalid parent, which caused the stacktrace recursion. By ensuring we correctly calculate the parent and only return valid indices, we prevent the recursion from happening.

No Loops:
The updated code simply ensures that we’re:

Correctly identifying the parent row in the model.

Ensuring that we don't accidentally introduce an invalid index that could result in further invalid lookups.

Preventing recursion by only returning valid indices.

Efficiency:
The code changes don’t affect the flow or performance of how the data is retrieved; we are just making sure the internal indices are structured correctly.

Key checks in the fix:

Valid Child:
We check if the child index is valid at the beginning of the function to avoid any invalid operations.

Top-level Item Check:
For items that don't have a parent (i.e., top-level items), we return an invalid index, which means parent() will never loop back to itself.

Parent Calculation:
We calculate the parentRow and parentID only for valid child indices. This avoids unnecessary or infinite traversals.

So, in summary:

No Loops or Recursion: The recursion issue is solved by returning valid, non-recursive indices.

Model Consistency: The parent-child structure is fixed according to the Qt model-view architecture.

If you’re still uncertain, I can provide further testing tips to verify the fix, or a small debug assertion to catch potential issues in the future.
```