### PR TITLE
Fix High Res Menu layout issue on Android in portrait mode

### DIFF
--- a/client/gui/WindowHandler.cpp
+++ b/client/gui/WindowHandler.cpp
@@ -48,6 +48,25 @@ void WindowHandler::pushWindow(std::shared_ptr<IShowActivatable> newInt)
 	totalRedraw();
 }
 
+bool WindowHandler::tryReplaceWindow(std::shared_ptr<IShowActivatable> oldInt, std::shared_ptr<IShowActivatable> newInt)
+{
+	int pos = vstd::find_pos(windowsStack, oldInt);
+	if(pos == -1)
+		return false;
+
+	if(newInt == nullptr)
+		throw std::runtime_error("Attempt to replace null window onto windows stack!");
+
+	if(vstd::contains(windowsStack, newInt))
+		throw std::runtime_error("Attempt to add already existing window to stack!");
+
+	windowsStack[pos] = newInt;
+	if(!windowsStack.empty())
+		windowsStack.back()->activate();
+	totalRedraw();
+	return true;
+}
+
 bool WindowHandler::isTopWindowPopup() const
 {
 	if (windowsStack.empty())

--- a/client/gui/WindowHandler.h
+++ b/client/gui/WindowHandler.h
@@ -57,6 +57,9 @@ public:
 	/// removes given windows from the top and activates next
 	void popWindow(std::shared_ptr<IShowActivatable> top);
 
+	/// Replace the existing window with a new window
+	bool tryReplaceWindow(std::shared_ptr<IShowActivatable> oldInt, std::shared_ptr<IShowActivatable> newInt);
+
 	/// returns true if selected interface is on top
 	bool isTopWindow(std::shared_ptr<IShowActivatable> window) const;
 	bool isTopWindow(IShowActivatable * window) const;

--- a/client/mainmenu/CMainMenu.cpp
+++ b/client/mainmenu/CMainMenu.cpp
@@ -384,8 +384,10 @@ void CMainMenu::onScreenResize()
 	pos.w = ENGINE->screenDimensions().x;
 	pos.h = ENGINE->screenDimensions().y;
 
+	auto oldMenu = menu;
 	menu = nullptr;
 	menu = std::make_shared<CMenuScreen>(CMainMenuConfig::get().getConfig()["window"]);
+	ENGINE->windows().tryReplaceWindow(oldMenu, menu);
 
 	backgroundAroundMenu->pos = pos;
 }


### PR DESCRIPTION
This PR fixes an issue where the High Res Menu mod could cause corrupted main menu layout on Android when entering the game in portrait mode and triggering onScreenResize.

A new window replacement method is added to WindowHandler, allowing the main menu to safely replace itself during screen resize and avoid invalid window stack states.