### PR TITLE
Lua fallback fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -551,11 +551,11 @@ if(ENABLE_LUA)
 		message(STATUS "Cannot find LuaJIT! Fallback to using usual Lua.")
 		find_package(Lua REQUIRED)
 		if(Lua_FOUND)
-			add_library(luajit::luajit UNKNOWN IMPORTED)
+			add_library(luajit::luajit INTERFACE IMPORTED)
 			set_target_properties(luajit::luajit PROPERTIES
-				INTERFACE_INCLUDE_DIRECTORIES "${LUA_INCLUDE_DIR}")
-			set_target_properties(luajit::luajit PROPERTIES
-				IMPORTED_LOCATION "${LUA_LIBRARIES}")
+				INTERFACE_INCLUDE_DIRECTORIES "${LUA_INCLUDE_DIR}"
+				INTERFACE_LINK_LIBRARIES "${LUA_LIBRARIES}"
+			)
 		endif()
 	endif()
 endif()

--- a/scripting/lua/LuaScriptingContext.cpp
+++ b/scripting/lua/LuaScriptingContext.cpp
@@ -26,6 +26,12 @@
 #include "../../lib/battle/IBattleInfoCallback.h"
 #include "../../lib/modding/ModScope.h"
 
+// Compatibility for standard Lua 5.1 with lua-bitop (non-LuaJIT builds)
+#ifndef LUAJIT_VERSION
+constexpr const char* LUA_BITLIBNAME = "bit";
+extern "C" int luaopen_bit(lua_State *L);
+#endif
+
 VCMI_LIB_NAMESPACE_BEGIN
 
 namespace scripting


### PR DESCRIPTION
Fix Lua 5.1 fallback for architectures without LuaJIT

On architectures where LuaJIT is unavailable (e.g. ppc64le), VCMI can
fall back to standard Lua 5.1. This PR fixes two issues with that path:

1. CMakeLists.txt: IMPORTED_LOCATION expects a single library path, but
   LUA_LIBRARIES can be a list (e.g. liblua + libm), causing the semicolon
   to be passed literally to the linker. Switch to INTERFACE IMPORTED
   library which handles this correctly.

2. LuaScriptingContext.cpp: LUA_BITLIBNAME and luaopen_bit are LuaJIT-
   specific. Add compatibility defines for standard Lua 5.1 builds using
   lua-bitop.

Tested on Fedora 43 (x86_64, aarch64, ppc64le).

Assisted-by: Claude (Anthropic) <https://claude.ai>