### PR TITLE
[1.7.1] fix modlist

### DIFF
--- a/launcher/modManager/cmodlistview_moc.cpp
+++ b/launcher/modManager/cmodlistview_moc.cpp
@@ -161,10 +161,10 @@ void CModListView::reload(const QString & modToSelect)
 
 	if (!modToSelect.isEmpty())
 	{
-		QModelIndexList matches = filterModel->match(filterModel->index(0, 0), ModRoles::ModNameRole, modToSelect, 1, Qt::MatchExactly | Qt::MatchRecursive);
+		QModelIndexList matches = modModel->match(modModel->index(0, 0, QModelIndex()), ModRoles::ModNameRole, modToSelect, 1, Qt::MatchExactly | Qt::MatchRecursive);
 
 		if (!matches.isEmpty())
-			ui->allModsView->setCurrentIndex(matches.first());
+			ui->allModsView->setCurrentIndex(filterModel->mapFromSource(matches.first()));
 	}
 }
 


### PR DESCRIPTION
Fixes #6384

This time the real fix. At least to that what's the LLM is saying. 🤣

May a regression of:  #5959

Replaces: #6546

Flatpak is working without crash: https://github.com/flathub/eu.vcmi.VCMI/pull/227#issuecomment-3691945264


# LLM output:

## 🔥 Root cause (the crash)

### ❌ Infinite recursion in `CModListView::reload`

```cpp
QModelIndexList matches =
    filterModel->match(
        filterModel->index(0, 0),
        ModRoles::ModNameRole,
        modToSelect,
        1,
        Qt::MatchExactly | Qt::MatchRecursive);
```
        
Why this is fatal

- filterModel is a QSortFilterProxyModel

- QSortFilterProxyModel::match() internally calls QAbstractItemModel::match()

- That implementation walks the model by repeatedly calling:

  - rowCount()

  - index()

  - parent()

Because you call it on the proxy, it ends up calling back into the proxy again:

proxy → source → proxy → source → …

This is exactly the infinite loop shown in your stack trace.


# This stack trace crash seems to only affects newer qt versions is that possible?

Yes — **that is absolutely possible**, and in your case it’s very likely what you’re seeing.

Short answer:  
👉 **Your code has been invalid for a long time, but newer Qt versions trigger the bug much more reliably.**

---

## 1. Why it “worked” on older Qt

Older Qt (Qt 5.x, early Qt 6) had:

- Less aggressive recursion in `QAbstractItemModel::match()`
- Simpler proxy–source traversal
- Fewer internal consistency checks
- More accidental tolerance for:
  - broken `parent()` implementations
  - calling `match()` on proxy models
  - inconsistent `index()` / `rowCount()` behavior

So:
- The recursion still existed
- But it didn’t blow up the stack or heap
- Or it exited early enough to hide the problem

This is **undefined behavior that just happened not to explode**.

---

## 2. What changed in newer Qt

In newer Qt 6 releases (especially 6.5+):

### 🔁 `match()` is more aggressive
- Uses deeper recursive traversal
- Walks more indexes per call
- Relies more strictly on correct `parent()` / `index()` behavior

Your infinite proxy recursion now becomes:
proxy → source → proxy → source → ...


instead of stopping early.

---

### 🧠 Proxy models are stricter
Qt 6 tightened guarantees around:

- `internalId()` usage
- Parent/child consistency
- Model traversal logic

Incorrect parent rows or invalid internal IDs now:
- cause deeper traversal
- prevent recursion termination

---

### 🧨 Allocator behavior changed
Newer toolchains + Qt builds often use:

- stronger stack protection
- hardened allocators
- different inlining decisions

Result:
- runaway recursion hits `_int_malloc()` or stack guards
- crash appears “inside Qt” or libc

---

## 3. Why the crash *looks* random

The top frame:

_int_malloc()


is misleading.

What actually happened:

1. Infinite recursion from `match()`
2. Massive stack growth
3. Repeated container detach / allocations
4. Heap corruption or stack overflow
5. Crash during allocation

Different Qt versions:
- crash at different depths
- crash in different places
- or not crash at all

That’s textbook undefined behavior.

---

## 4. This is a common Qt upgrade trap

This exact pattern shows up frequently when moving:

- Qt 5 → Qt 6
- Qt 6.2 → 6.5+
- Older distro Qt → newer distro Qt

Especially in code that:

- uses `QSortFilterProxyModel`
- overrides tree models
- calls `match()`, `data()`, or `index()` during updates

---

## 5. Why your fix is correct *for all Qt versions*

Your change:

```cpp
modModel->match(...)
filterModel->mapFromSource(...)
```

Does three important things:

1. Eliminates proxy recursion

2. Uses model traversal the way Qt expects

3. Makes behavior deterministic across Qt versions

After this:

- Old Qt still works

- New Qt stops crashing

- Future Qt won’t regress

## 6. TL;DR

- ✅ Yes, newer Qt versions can expose this crash

- ❌ Qt is not “breaking” your code — it’s enforcing correctness

- 🧨 The bug was always there

- 🛠 Your fix is the right one

If you want, I can:

- point out other Qt-6-sensitive spots in your models

- or give you a short checklist for “Qt 5 code that breaks in Qt 6”

Just say the word.