### PR TITLE
[1.7.2] Next town hotkey now centers on town if 1 and selected

### DIFF
--- a/client/PlayerLocalState.cpp
+++ b/client/PlayerLocalState.cpp
@@ -37,7 +37,7 @@ void PlayerLocalState::setSpellbookSettings(const PlayerSpellbookSetting & newSe
 void PlayerLocalState::setPath(const CGHeroInstance * h, const CGPath & path)
 {
 	paths[h] = path;
-	syncronizeState();
+	synchronizeState();
 }
 
 const CGPath & PlayerLocalState::getPath(const CGHeroInstance * h) const
@@ -57,7 +57,7 @@ bool PlayerLocalState::setPath(const CGHeroInstance * h, const int3 & destinatio
 	if(!owner.getPathsInfo(h)->getPath(path, destination))
 	{
 		paths.erase(h); //invalidate previously possible path if selected (before other hero blocked only path / fly spell expired)
-		syncronizeState();
+		synchronizeState();
 		return false;
 	}
 
@@ -81,7 +81,7 @@ void PlayerLocalState::erasePath(const CGHeroInstance * h)
 {
 	paths.erase(h);
 	adventureInt->onHeroChanged(h);
-	syncronizeState();
+	synchronizeState();
 }
 
 void PlayerLocalState::verifyPath(const CGHeroInstance * h)
@@ -162,14 +162,19 @@ const CArmedInstance * PlayerLocalState::getCurrentArmy() const
 
 void PlayerLocalState::setSelection(const CArmedInstance * selection)
 {
-	if (currentSelection == selection)
+	setSelection(selection, false);
+}
+
+void PlayerLocalState::setSelection(const CArmedInstance * selection, bool force)
+{
+	if (!force && currentSelection == selection)
 		return;
 
 	currentSelection = selection;
 
 	if (adventureInt && selection)
 		adventureInt->onSelectionChanged(selection);
-	syncronizeState();
+	synchronizeState();
 }
 
 bool PlayerLocalState::isHeroSleeping(const CGHeroInstance * hero) const
@@ -184,7 +189,7 @@ void PlayerLocalState::setHeroAsleep(const CGHeroInstance * hero)
 	assert(!vstd::contains(sleepingHeroes, hero));
 
 	sleepingHeroes.push_back(hero);
-	syncronizeState();
+	synchronizeState();
 }
 
 void PlayerLocalState::setHeroAwaken(const CGHeroInstance * hero)
@@ -194,7 +199,7 @@ void PlayerLocalState::setHeroAwaken(const CGHeroInstance * hero)
 	assert(vstd::contains(sleepingHeroes, hero));
 
 	vstd::erase(sleepingHeroes, hero);
-	syncronizeState();
+	synchronizeState();
 }
 
 const std::vector<const CGHeroInstance *> & PlayerLocalState::getWanderingHeroes()
@@ -218,7 +223,7 @@ void PlayerLocalState::addWanderingHero(const CGHeroInstance * hero)
 	if (currentSelection == nullptr)
 		setSelection(hero);
 
-	syncronizeState();
+	synchronizeState();
 }
 
 void PlayerLocalState::removeWanderingHero(const CGHeroInstance * hero)
@@ -246,7 +251,7 @@ void PlayerLocalState::removeWanderingHero(const CGHeroInstance * hero)
 	if (currentSelection == nullptr && !ownedTowns.empty())
 		setSelection(ownedTowns.front());
 
-	syncronizeState();
+	synchronizeState();
 }
 
 void PlayerLocalState::swapWanderingHero(size_t pos1, size_t pos2)
@@ -256,7 +261,7 @@ void PlayerLocalState::swapWanderingHero(size_t pos1, size_t pos2)
 
 	adventureInt->onHeroOrderChanged();
 
-	syncronizeState();
+	synchronizeState();
 }
 
 const std::vector<const CGTownInstance *> & PlayerLocalState::getOwnedTowns()
@@ -280,7 +285,7 @@ void PlayerLocalState::addOwnedTown(const CGTownInstance * town)
 	if (currentSelection == nullptr)
 		setSelection(town);
 
-	syncronizeState();
+	synchronizeState();
 }
 
 void PlayerLocalState::removeOwnedTown(const CGTownInstance * town)
@@ -298,7 +303,7 @@ void PlayerLocalState::removeOwnedTown(const CGTownInstance * town)
 	if (currentSelection == nullptr && !ownedTowns.empty())
 		setSelection(ownedTowns.front());
 
-	syncronizeState();
+	synchronizeState();
 }
 
 void PlayerLocalState::swapOwnedTowns(size_t pos1, size_t pos2)
@@ -306,12 +311,12 @@ void PlayerLocalState::swapOwnedTowns(size_t pos1, size_t pos2)
 	assert(ownedTowns[pos1] && ownedTowns[pos2]);
 	std::swap(ownedTowns.at(pos1), ownedTowns.at(pos2));
 
-	syncronizeState();
+	synchronizeState();
 
 	adventureInt->onTownOrderChanged();
 }
 
-void PlayerLocalState::syncronizeState()
+void PlayerLocalState::synchronizeState()
 {
 	JsonNode data;
 	serialize(data);

--- a/client/PlayerLocalState.h
+++ b/client/PlayerLocalState.h
@@ -51,7 +51,7 @@ class PlayerLocalState
 
 	SpellID currentSpell;
 
-	void syncronizeState();
+	void synchronizeState();
 public:
 
 	explicit PlayerLocalState(CPlayerInterface & owner);
@@ -101,4 +101,5 @@ public:
 
 	/// Changes currently selected object
 	void setSelection(const CArmedInstance *sel);
+	void setSelection(const CArmedInstance *sel, bool force);
 };

--- a/client/adventureMap/AdventureMapInterface.cpp
+++ b/client/adventureMap/AdventureMapInterface.cpp
@@ -883,7 +883,11 @@ void AdventureMapInterface::openWorldView(const std::vector<ObjectPosInfo>& obje
 
 void AdventureMapInterface::hotkeyNextTown()
 {
+	int selectedIndex = widget->getTownList()->getSelectedIndex();
 	widget->getTownList()->selectNext();
+
+	if(selectedIndex == widget->getTownList()->getSelectedIndex())
+		widget->getTownList()->refreshSelected();
 }
 
 void AdventureMapInterface::hotkeySwitchMapLevel()

--- a/client/adventureMap/CList.cpp
+++ b/client/adventureMap/CList.cpp
@@ -443,6 +443,11 @@ void CTownList::CTownItem::select(bool on)
 		GAME->interface()->localState->setSelection(town);
 }
 
+void CTownList::CTownItem::forceSelect()
+{
+	GAME->interface()->localState->setSelection(town, true);
+}
+
 void CTownList::CTownItem::open()
 {
 	GAME->interface()->openTownWindow(town);
@@ -593,4 +598,10 @@ void CTownList::updateWidget()
 		select(GAME->interface()->localState->getCurrentTown());
 
 	CList::update();
+}
+
+void CTownList::refreshSelected()
+{
+	if(getSelectedIndex() != -1)
+		dynamic_cast<CTownItem*>(this->listBox->getItem(getSelectedIndex()).get())->forceSelect();
 }

--- a/client/adventureMap/CList.h
+++ b/client/adventureMap/CList.h
@@ -161,6 +161,7 @@ class CTownList	: public CList
 		std::shared_ptr<CIntObject> genSelection() override;
 		void update();
 		void select(bool on) override;
+		void forceSelect();
 		void open() override;
 		void showTooltip() override;
 		void gesture(bool on, const Point & initialPosition, const Point & finalPosition) override;
@@ -180,5 +181,8 @@ public:
 
 	/// Update all towns
 	void updateWidget();
+
+	/// Refresh currently selected town if any selected
+	void refreshSelected();
 };
 


### PR DESCRIPTION
Missing H3 feature: If player has only 1 town and a town is currently selected, then next town hotkey should center adventure map on current town. Additionally one typo is fixed.