### PR TITLE
Implement gamestate desync detection

### DIFF
--- a/client/ClientNetPackVisitors.h
+++ b/client/ClientNetPackVisitors.h
@@ -107,6 +107,7 @@ public:
 	void visitPlayerCheated(PlayerCheated & pack) override;
 	void visitChangeTownName(ChangeTownName & pack) override;
 	void visitResponseStatistic(ResponseStatistic & pack) override;
+	void visitVerifyGameState(VerifyGameState & pack) override;
 };
 
 class ApplyFirstClientNetPackVisitor : public VCMI_LIB_WRAP_NAMESPACE(ICPackVisitor)

--- a/client/NetPacksClient.cpp
+++ b/client/NetPacksClient.cpp
@@ -37,6 +37,7 @@
 #include "../lib/mapping/CMap.h"
 #include "../lib/VCMIDirs.h"
 #include "../lib/spells/CSpellHandler.h"
+#include "../lib/serializer/CSaveFile.h"
 #include "../lib/CSoundBase.h"
 #include "../lib/StartInfo.h"
 #include "../lib/CConfigHandler.h"
@@ -1105,4 +1106,10 @@ void ApplyClientNetPackVisitor::visitChangeTownName(ChangeTownName & pack)
 void ApplyClientNetPackVisitor::visitResponseStatistic(ResponseStatistic & pack)
 {
 	callInterfaceIfPresent(cl, pack.player, &IGameEventsReceiver::responseStatistic, pack.statistic);
+}
+
+void ApplyClientNetPackVisitor::visitVerifyGameState(VerifyGameState & pack)
+{
+	VerifyFile file(pack.data);
+	cl.gameState().saveGame(file);
 }

--- a/lib/gameState/CGameState.cpp
+++ b/lib/gameState/CGameState.cpp
@@ -1619,7 +1619,7 @@ CArtifactInstance * CGameState::createArtifact(const ArtifactID & artID, const S
 	return map->createArtifact(artID, spellId);
 }
 
-void CGameState::saveGame(CSaveFile & file) const
+void CGameState::saveGame(ISaveFile & file) const
 {
 	ActiveModsInSaveList activeModsDummy;
 	logGlobal->info("Saving game state");

--- a/lib/gameState/CGameState.h
+++ b/lib/gameState/CGameState.h
@@ -26,7 +26,7 @@ class Services;
 class IGameRandomizer;
 class IMapService;
 class CMap;
-class CSaveFile;
+class ISaveFile;
 class CLoadFile;
 struct CPackForClient;
 class CHeroClass;
@@ -172,7 +172,7 @@ public:
 	scripting::Pool * getGlobalContextPool() const override;
 #endif
 
-	void saveGame(CSaveFile & file) const;
+	void saveGame(ISaveFile & file) const;
 	void loadGame(CLoadFile & file);
 
 	template <typename Handler> void serialize(Handler &h)

--- a/lib/networkPacks/NetPackVisitor.h
+++ b/lib/networkPacks/NetPackVisitor.h
@@ -191,6 +191,7 @@ public:
 	virtual void visitBattleResultAccepted(BattleResultAccepted & pack) {}
 	virtual void visitBattleStackMoved(BattleLogMessage & pack) {}
 	virtual void visitResponseStatistic(ResponseStatistic & pack) {}
+	virtual void visitVerifyGameState(VerifyGameState & pack) {}
 };
 
 VCMI_LIB_NAMESPACE_END

--- a/lib/networkPacks/NetPacksLib.cpp
+++ b/lib/networkPacks/NetPacksLib.cpp
@@ -878,4 +878,9 @@ void ResponseStatistic::visitTyped(ICPackVisitor & visitor)
 	visitor.visitResponseStatistic(*this);
 }
 
+void VerifyGameState::visitTyped(ICPackVisitor & visitor)
+{
+	visitor.visitVerifyGameState(*this);
+}
+
 VCMI_LIB_NAMESPACE_END

--- a/lib/networkPacks/PacksForClient.h
+++ b/lib/networkPacks/PacksForClient.h
@@ -1537,4 +1537,16 @@ struct DLL_LINKAGE ResponseStatistic : public CPackForClient
 	}
 };
 
+struct DLL_LINKAGE VerifyGameState : public CPackForClient
+{
+	std::vector<std::byte> data;
+
+	void visitTyped(ICPackVisitor & visitor) override;
+
+	template <typename Handler> void serialize(Handler & h)
+	{
+		h & data;
+	}
+};
+
 VCMI_LIB_NAMESPACE_END

--- a/lib/serializer/CSaveFile.cpp
+++ b/lib/serializer/CSaveFile.cpp
@@ -12,18 +12,18 @@
 
 VCMI_LIB_NAMESPACE_BEGIN
 
-CSaveFile::CSaveFile()
-	: serializer(this)
+static const char * SAVE_HEADER = "VCMI";
+
+SaveFile::SaveFile()
 {
 	saveData.reserve(128*1024);
-	static const char * SAVE_HEADER = "VCMI";
 
 	write(reinterpret_cast<const std::byte*>(SAVE_HEADER), 4); //write magic identifier
 	serializer & ESerializationVersion::CURRENT; //write format version
 	write(reinterpret_cast<const std::byte*>(SAVEGAME_MAGIC.c_str()), SAVEGAME_MAGIC.length());
 }
 
-void CSaveFile::write(const boost::filesystem::path & fileName)
+void SaveFile::writeFile(const boost::filesystem::path & fileName)
 {
 	std::ofstream sfile(fileName.c_str(), std::ios::out | std::ios::binary);
 
@@ -35,10 +35,34 @@ void CSaveFile::write(const boost::filesystem::path & fileName)
 	sfile.write(reinterpret_cast<const char *>(saveData.data()), saveData.size());
 }
 
-int CSaveFile::write(const std::byte * data, unsigned size)
+int SaveFile::write(const std::byte * data, unsigned size)
 {
 	saveData.insert(saveData.end(), data, data + size);
 	return size;
 }
+
+int VerifyFile::write(const std::byte * data, unsigned size)
+{
+	if (std::equal(data, data + size, testSaveData.data() + testPosition))
+	{
+		testPosition += size;
+	}
+	else
+	{
+		logGlobal->error("GAMESTATE DESYNC FOUND! GAME WILL NOW TERMINATE");
+		throw std::runtime_error("GAMESTATE DESYNC FOUND! GAME WILL NOW TERMINATE");
+	}
+	return size;
+}
+
+VerifyFile::VerifyFile(const std::vector<std::byte> & saveData)
+	: testSaveData(saveData)
+	, testPosition(0)
+{
+	write(reinterpret_cast<const std::byte*>(SAVE_HEADER), 4); //write magic identifier
+	serializer & ESerializationVersion::CURRENT; //write format version
+	write(reinterpret_cast<const std::byte*>(SAVEGAME_MAGIC.c_str()), SAVEGAME_MAGIC.length());
+}
+
 
 VCMI_LIB_NAMESPACE_END

--- a/lib/serializer/CSaveFile.h
+++ b/lib/serializer/CSaveFile.h
@@ -14,15 +14,15 @@
 
 VCMI_LIB_NAMESPACE_BEGIN
 
-class DLL_LINKAGE CSaveFile final : public IBinaryWriter
+class DLL_LINKAGE ISaveFile : public IBinaryWriter
 {
+protected:
 	BinarySerializer serializer;
-	std::vector<std::byte> saveData;
-
-	int write(const std::byte * data, unsigned size) final;
 
 public:
-	CSaveFile();
+	ISaveFile()
+		: serializer(this)
+	{}
 
 	template<class T>
 	void save(const T & data)
@@ -31,12 +31,32 @@ public:
 		serializer & data;
 	}
 
-	void write(const boost::filesystem::path & fname);
+};
+
+class DLL_LINKAGE SaveFile final : public ISaveFile
+{
+	std::vector<std::byte> saveData;
+
+	int write(const std::byte * data, unsigned size) final;
+public:
+	SaveFile();
+
+	void writeFile(const boost::filesystem::path & fileName);
 
 	const std::vector<std::byte> & currentContent() const
 	{
 		return saveData;
 	}
+};
+
+class DLL_LINKAGE VerifyFile final : public ISaveFile
+{
+	std::vector<std::byte> testSaveData;
+	size_t testPosition;
+
+	int write(const std::byte * data, unsigned size) final;
+public:
+	VerifyFile(const std::vector<std::byte> & saveData);
 };
 
 VCMI_LIB_NAMESPACE_END

--- a/lib/serializer/RegisterTypes.h
+++ b/lib/serializer/RegisterTypes.h
@@ -298,6 +298,7 @@ void registerTypes(Serializer &s)
 	s.template registerType<RequestStatistic>(256);
 	s.template registerType<ResponseStatistic>(257);
 	s.template registerType<LobbyQuickLoadGame>(258);
+	s.template registerType<VerifyGameState>(259);
 }
 
 VCMI_LIB_NAMESPACE_END

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -1621,11 +1621,17 @@ void CGameHandler::save(const std::string & filename)
 
 	try
 	{
-		CSaveFile save;
+		SaveFile save;
 		gameState().saveGame(save);
+#if 0
+		VerifyGameState vgs;
+		vgs.data = save.currentContent();
+		sendAndApply(vgs);
+#endif
 		logGlobal->info("Saving server state");
 		save.save(*this);
-		save.write(*CResourceHandler::get("local")->getResourceName(savePath));
+		save.writeFile(*CResourceHandler::get("local")->getResourceName(savePath));
+
 	}
 	catch(std::exception &e)
 	{


### PR DESCRIPTION
WIP, not sure if/when I'll finish it unless more desyncs are found in game.

Server will now send serialized gamestate to client, and client will compare received gamestate with his own, and throw an exception on any mismatch.

TODO: make it working. There are some fields like translations, player local state (selected hero & such), and appearance of objects on map that for some reason don't match at the moment. Might be safe, or might need investigation.

Current approach is also very slow & only usable for debug. Might be good enough, but on the other hand would be great to have this enabled by default to detect such errors in the future. Some other approach like sending checksum might work for such purpose