### PR TITLE
[1.7.2?] mapeditor - allows picking objects for events on levels lower than 2. 

### DIFF
--- a/mapeditor/inspector/PickObjectDelegate.cpp
+++ b/mapeditor/inspector/PickObjectDelegate.cpp
@@ -28,9 +28,9 @@ PickObjectDelegate::PickObjectDelegate(MapController & c, std::function<bool(con
 
 void PickObjectDelegate::onObjectPicked(const CGObjectInstance * o)
 {
-	for(int lvl : {0, 1})
+	for(MapScene * level : controller.getScenes())
 	{
-		auto & l = controller.scene(lvl)->objectPickerView;
+		auto & l = level->objectPickerView;
 		l.clear();
 		l.update();
 		QObject::disconnect(&l, &ObjectPickerLayer::selectionMade, this, &PickObjectDelegate::onObjectPicked);
@@ -46,9 +46,9 @@ void PickObjectDelegate::onObjectPicked(const CGObjectInstance * o)
 
 QWidget * PickObjectDelegate::createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const
 {
-	for(int lvl : {0, 1})
+	for(MapScene * level : controller.getScenes())
 	{
-		auto & l = controller.scene(lvl)->objectPickerView;
+		auto & l = level->objectPickerView;
 		l.highlight(filter);
 		l.update();
 		QObject::connect(&l, &ObjectPickerLayer::selectionMade, this, &PickObjectDelegate::onObjectPicked);

--- a/mapeditor/inspector/questwidget.cpp
+++ b/mapeditor/inspector/questwidget.cpp
@@ -342,9 +342,9 @@ void QuestWidget::on_lKillTargetSelect_clicked()
 		return false;
 	};
 	
-	for(int lvl : {0, 1})
+	for(MapScene * level : controller.getScenes())
 	{
-		auto & l = controller.scene(lvl)->objectPickerView;
+		auto & l = level->objectPickerView;
 		l.highlight(pred);
 		l.update();
 		QObject::connect(&l, &ObjectPickerLayer::selectionMade, this, &QuestWidget::onTargetPicked);
@@ -357,9 +357,9 @@ void QuestWidget::onTargetPicked(const CGObjectInstance * obj)
 {
 	show();
 	
-	for(int lvl : {0, 1})
+	for(MapScene * level : controller.getScenes())
 	{
-		auto & l = controller.scene(lvl)->objectPickerView;
+		auto & l = level->objectPickerView;
 		l.clear();
 		l.update();
 		QObject::disconnect(&l, &ObjectPickerLayer::selectionMade, this, &QuestWidget::onTargetPicked);

--- a/mapeditor/mapcontroller.cpp
+++ b/mapeditor/mapcontroller.cpp
@@ -102,6 +102,16 @@ MapScene * MapController::scene(int level)
 	return _scenes[level].get();
 }
 
+std::set<MapScene *> MapController::getScenes()
+{
+	std::set<MapScene *>result;
+	if (!map())
+		return result;
+	for (int i=0; i<map()->levels(); i++)
+		result.insert(_scenes[i].get());
+	return result;
+}
+
 MinimapScene * MapController::miniScene(int level)
 {
 	return _miniscenes[level].get();

--- a/mapeditor/mapcontroller.h
+++ b/mapeditor/mapcontroller.h
@@ -44,6 +44,7 @@ public:
 	CMap * map();
 	MapHandler * mapHandler();
 	MapScene * scene(int level);
+	std::set<MapScene *> getScenes();
 	MinimapScene * miniScene(int level);
 	
 	void resetMapHandler();

--- a/mapeditor/mapsettings/loseconditions.cpp
+++ b/mapeditor/mapsettings/loseconditions.cpp
@@ -290,9 +290,9 @@ void LoseConditions::on_loseComboBox_currentIndexChanged(int index)
 void LoseConditions::onObjectSelect()
 {
 	int loseCondition = ui->loseComboBox->currentIndex() - 1;
-	for(int lvl : {0, 1})
+	for(MapScene * level : controller->getScenes())
 	{
-		auto & l = controller->scene(lvl)->objectPickerView;
+		auto & l = level->objectPickerView;
 		switch(loseCondition)
 		{
 			case 0: {  //EventCondition::CONTROL (Obj::TOWN)
@@ -318,9 +318,9 @@ void LoseConditions::onObjectPicked(const CGObjectInstance * obj)
 {
 	controller->settingsDialog->show();
 	
-	for(int lvl : {0, 1})
+	for(MapScene * level : controller->getScenes())
 	{
-		auto & l = controller->scene(lvl)->objectPickerView;
+		auto & l = level->objectPickerView;
 		l.clear();
 		l.update();
 		QObject::disconnect(&l, &ObjectPickerLayer::selectionMade, this, &LoseConditions::onObjectPicked);

--- a/mapeditor/mapsettings/timedevent.cpp
+++ b/mapeditor/mapsettings/timedevent.cpp
@@ -120,9 +120,9 @@ void TimedEvent::on_TimedEvent_finished(int result)
 
 void TimedEvent::on_addObjectToDelete_clicked()
 {
-	for(int lvl : {0, 1})
+	for(MapScene * level : controller.getScenes())
 	{
-		auto & l = controller.scene(lvl)->objectPickerView;
+		auto & l = level->objectPickerView;
 		l.highlight<const CGObjectInstance>();
 		l.update();
 		QObject::connect(&l, &ObjectPickerLayer::selectionMade, this, &TimedEvent::onObjectPicked);
@@ -141,9 +141,9 @@ void TimedEvent::onObjectPicked(const CGObjectInstance * obj)
 	show();
 	controller.settingsDialog->show();
 
-	for(int lvl : {0, 1})
+	for(MapScene * level : controller.getScenes())
 	{
-		auto & l = controller.scene(lvl)->objectPickerView;
+		auto & l = level->objectPickerView;
 		l.clear();
 		l.update();
 		QObject::disconnect(&l, &ObjectPickerLayer::selectionMade, this, &TimedEvent::onObjectPicked);

--- a/mapeditor/mapsettings/victoryconditions.cpp
+++ b/mapeditor/mapsettings/victoryconditions.cpp
@@ -498,12 +498,9 @@ void VictoryConditions::onObjectSelect()
 {
 	int vicConditions = ui->victoryComboBox->currentIndex() - 1;
 
-	std::vector<int>levels(controller->map()->levels());
-	std::iota (std::begin(levels), std::end(levels), 0);
-
-	for(int lvl : levels)
+	for(MapScene * level : controller->getScenes())
 	{
-		auto & l = controller->scene(lvl)->objectPickerView;
+		auto & l = level->objectPickerView;
 		switch(vicConditions)
 		{
 			case 3: { //EventCondition::HAVE_BUILDING
@@ -543,13 +540,10 @@ void VictoryConditions::onObjectSelect()
 void VictoryConditions::onObjectPicked(const CGObjectInstance * obj)
 {
 	controller->settingsDialog->show();
-
-	std::vector<int>levels(controller->map()->levels());
-	std::iota (std::begin(levels), std::end(levels), 0);
 	
-	for(int lvl : levels)
+	for(MapScene * level : controller->getScenes())
 	{
-		auto & l = controller->scene(lvl)->objectPickerView;
+		auto & l = level->objectPickerView;
 		l.clear();
 		l.update();
 		QObject::disconnect(&l, &ObjectPickerLayer::selectionMade, this, &VictoryConditions::onObjectPicked);

--- a/mapeditor/playerparams.cpp
+++ b/mapeditor/playerparams.cpp
@@ -194,9 +194,9 @@ void PlayerParams::on_townSelect_clicked()
 		return false;
 	};
 	
-	for(int lvl : {0, 1})
+	for(MapScene * level : controller.getScenes())
 	{
-		auto & l = controller.scene(lvl)->objectPickerView;
+		auto & l = level->objectPickerView;
 		l.highlight(pred);
 		l.update();
 		QObject::connect(&l, &ObjectPickerLayer::selectionMade, this, &PlayerParams::onTownPicked);
@@ -209,9 +209,9 @@ void PlayerParams::onTownPicked(const CGObjectInstance * obj)
 {
 	controller.settingsDialog->show();
 	
-	for(int lvl : {0, 1})
+	for(MapScene * level : controller.getScenes())
 	{
-		auto & l = controller.scene(lvl)->objectPickerView;
+		auto & l = level->objectPickerView;
 		l.clear();
 		l.update();
 		QObject::disconnect(&l, &ObjectPickerLayer::selectionMade, this, &PlayerParams::onTownPicked);


### PR DESCRIPTION
As in the title.
I also moved the logic for extracting the right MapScenes to MapController.