### PR TITLE
AI/MMAI/CMakeLists.txt: fix RPATH for unix

### DIFF
--- a/AI/MMAI/CMakeLists.txt
+++ b/AI/MMAI/CMakeLists.txt
@@ -70,7 +70,7 @@ else()
   if(APPLE)
     set_target_properties(MMAI PROPERTIES INSTALL_RPATH "@loader_path")
   elseif(UNIX)
-    set_target_properties(MMAI PROPERTIES INSTALL_RPATH "$ORIGIN")
+    set_target_properties(MMAI PROPERTIES INSTALL_RPATH "${CMAKE_INSTALL_RPATH}:${CMAKE_INSTALL_RPATH}/AI")
   endif()
 endif()
 


### PR DESCRIPTION
When building the RPM package, I get incorrect RPATH to the required libraries:

lib.req: ERROR: /usr/src/tmp/vcmi-buildroot/usr/lib64/vcmi/AI/libMMAI.so: library libvcmi.so not found