### PR TITLE
[1.7.2] fix SubterraneanGate

### DIFF
--- a/lib/mapObjects/MiscObjects.cpp
+++ b/lib/mapObjects/MiscObjects.cpp
@@ -485,18 +485,12 @@ void CGSubterraneanGate::initObj(IGameRandomizer & gameRandomizer)
 
 void CGSubterraneanGate::postInit(IGameInfoCallback * cb) //matches subterranean gates into pairs
 {
-	//split on underground and surface gates
-	std::vector<std::vector<CGSubterraneanGate *>> gatesSplit(2); //surface and underground gates
-	for(auto gate : cb->gameState().getMap().getObjects<CGSubterraneanGate>())
-	{
-		if (gate->visitablePos().z > 1)
-			continue; // TODO: multilevel support for Subterranean Gates
+	// for > 2 layers it's still choosing the nearest in x/y axis independent from level
+	// collect all gates
+	auto allGates = cb->gameState().getMap().getObjects<CGSubterraneanGate>();
 
-		gatesSplit[gate->visitablePos().z].push_back(gate);
-	}
-
-	//sort by position
-	std::sort(gatesSplit[0].begin(), gatesSplit[0].end(), [](const CGObjectInstance * a, const CGObjectInstance * b)
+	// sort by position for deterministic behavior
+	std::sort(allGates.begin(), allGates.end(), [](const CGObjectInstance * a, const CGObjectInstance * b)
 	{
 		return a->visitablePos() < b->visitablePos();
 	});
@@ -510,21 +504,36 @@ void CGSubterraneanGate::postInit(IGameInfoCallback * cb) //matches subterranean
 		}
 	};
 
-	for(size_t i = 0; i < gatesSplit[0].size(); i++)
+	for(size_t i = 0; i < allGates.size(); i++)
 	{
-		CGSubterraneanGate * objCurrent = gatesSplit[0][i];
+		CGSubterraneanGate * objCurrent = allGates[i];
 
-		//find nearest underground exit
+		if(objCurrent->channel != TeleportChannelID())
+			continue;
+
+		// find nearest gate on any other layer
 		std::pair<int, si32> best(-1, std::numeric_limits<si32>::max()); //pair<pos_in_vector, distance^2>
-		for(int j = 0; j < gatesSplit[1].size(); j++)
+		for(size_t j = 0; j < allGates.size(); j++)
 		{
-			CGSubterraneanGate *checked = gatesSplit[1][j];
+			if(i == j)
+				continue;
+
+			CGSubterraneanGate * checked = allGates[j];
+
 			if(checked->channel != TeleportChannelID())
 				continue;
+
+			// Prefer pairing surface → underground
+			if(objCurrent->visitablePos().z > checked->visitablePos().z)
+				continue;
+
+			if(checked->visitablePos().z == objCurrent->visitablePos().z)
+				continue;
+
 			si32 hlp = checked->visitablePos().dist2dSQ(objCurrent->visitablePos());
 			if(hlp < best.second)
 			{
-				best.first = j;
+				best.first = static_cast<int>(j);
 				best.second = hlp;
 			}
 		}
@@ -532,15 +541,14 @@ void CGSubterraneanGate::postInit(IGameInfoCallback * cb) //matches subterranean
 		assignToChannel(objCurrent);
 		if(best.first >= 0) //found pair
 		{
-			gatesSplit[1][best.first]->channel = objCurrent->channel;
-			addToChannel(cb->gameState().getMap().teleportChannels, gatesSplit[1][best.first]);
+			allGates[best.first]->channel = objCurrent->channel;
+			addToChannel(cb->gameState().getMap().teleportChannels, allGates[best.first]);
 		}
 	}
 
-	// we should assign empty channels to underground gates if they don't have matching overground gates
-	if(gatesSplit.size() > 1)
-		for(auto & i : gatesSplit[1])
-			assignToChannel(i);
+	// assign empty channels to any remaining unpaired gates
+	for(auto & i : allGates)
+		assignToChannel(i);
 }
 
 void CGWhirlpool::onHeroVisit(IGameEventCallback & gameEvents, const CGHeroInstance * h) const


### PR DESCRIPTION
- for 1 and 2 layers it should behave like before (tested with 2 layers and edge case #6478)
  - prefer pairing surface → underground to matches also in some edge cases old behaviors
- for 2+ layers it connects always based on nearest x/y, independent from layer
  - this allows direct connection from deepest to highest layer directly if wanted by map creator
  - anyway we can also place a surface layer above a sky layer -> we don't have the concept that one layer is above the other: #6619)