### PR TITLE
[1.7.2] [MMAI] Fix model UB

### DIFF
--- a/AI/MMAI/BAI/model/NNModel.cpp
+++ b/AI/MMAI/BAI/model/NNModel.cpp
@@ -426,7 +426,7 @@ NNModel::NNModel(const std::string & path, float _temperature, uint64_t seed)
 	opts.DisableMemPattern();
 	opts.SetGraphOptimizationLevel(GraphOptimizationLevel::ORT_DISABLE_ALL);
 	opts.SetExecutionMode(ORT_SEQUENTIAL); // ORT_SEQUENTIAL = no inter-op parallelism
-	opts.SetIntraOpNumThreads(1); // Inter-op threads matter in ORT_PARALLEL
+	opts.SetInterOpNumThreads(1); // Inter-op threads matter in ORT_PARALLEL
 	opts.SetIntraOpNumThreads(4); // Parallelism inside kernels/operators
 
 	model = loadModel(path, opts);


### PR DESCRIPTION
There seems to be an issue with ONNX / onnxruntime which occasionally causes wrong outputs when MemPattern reuse is enabled or when graph optimisation is enabled.
This is very likely the cause for https://github.com/vcmi/vcmi/issues/6613 as well as a few other reported issues on the Discord channel related to invalid action errors emitted by MMAI. Locally, I observed similar issues until I tweaked the ONNX session options.
