### PR TITLE
[1.7.2] [MMAI] Fix retreat action handling

### DIFF
--- a/AI/MMAI/BAI/v13/BAI.cpp
+++ b/AI/MMAI/BAI/v13/BAI.cpp
@@ -374,7 +374,7 @@ void BAI::_activeStack(const BattleID & bid, const CStack * astack)
 
 		ba = buildBattleAction();
 
-		if(ba)
+		if(ba && (a != Schema::ACTION_RETREAT || resetting))
 		{
 			debug("Action is VALID: " + state->action->name());
 			errcounter = 0;


### PR DESCRIPTION
When the NN model returns garbage output (e.g. due to UB fixed [here](https://github.com/vcmi/vcmi/pull/6664)) it may end up returning a RETREAT action which was considered valid, even for neutrals. As a result, the action was sent to the server and often caused many "fishy request" error messages printed in the UI.

With this fix, if the model falls into a corrupted state and starts returning RETREAT actions again, it will be handled on the client side and an error will be printed only in the logs, not the UI.