### PR TITLE
[1.7.2] VMAP translation

### DIFF
--- a/lib/mapping/CMapService.cpp
+++ b/lib/mapping/CMapService.cpp
@@ -141,7 +141,7 @@ std::unique_ptr<IMapLoader> CMapService::getMapLoader(std::unique_ptr<CInputStre
 	case 0x06054b50:
 	case 0x04034b50:
 	case 0x02014b50:
-		return std::unique_ptr<IMapLoader>(new CMapLoaderJson(stream.get()));
+		return std::unique_ptr<IMapLoader>(new CMapLoaderJson(stream.get(), mapName));
 		break;
 	default:
 		// Check which map format is used

--- a/lib/mapping/MapFormatJson.cpp
+++ b/lib/mapping/MapFormatJson.cpp
@@ -13,6 +13,7 @@
 
 #include "../filesystem/CInputStream.h"
 #include "../filesystem/COutputStream.h"
+#include "../filesystem/Filesystem.h"
 #include "../json/JsonWriter.h"
 #include "CMap.h"
 #include "MapFormat.h"
@@ -36,7 +37,10 @@
 #include "../constants/StringConstants.h"
 #include "../serializer/JsonDeserializer.h"
 #include "../serializer/JsonSerializer.h"
+#include "../json/JsonUtils.h"
 #include "../texts/Languages.h"
+#include "../texts/CGeneralTextHandler.h"
+#include "../texts/TextOperations.h"
 
 VCMI_LIB_NAMESPACE_BEGIN
 
@@ -254,7 +258,7 @@ std::string getTerrainFilename(int i)
 CMapFormatJson::CMapFormatJson():
 	fileVersionMajor(0), fileVersionMinor(0),
 	mapObjectResolver(std::make_unique<MapObjectResolver>(this)),
-	map(nullptr), mapHeader(nullptr)
+	map(nullptr), mapHeader(nullptr), mapName("")
 {
 
 }
@@ -289,6 +293,20 @@ RoadId CMapFormatJson::getRoadByCode(const std::string & code)
 	return RoadId::NO_ROAD;
 }
 
+std::string CMapFormatJson::removeMapNamePrefix(const std::string & fullIdentifier)
+{
+	// Remove "map.<mapname>." prefix from translation keys
+	// Example: "map.testmap.header.name" -> "header.name"
+	size_t mapPrefixPos = fullIdentifier.find("map.");
+	if(mapPrefixPos == 0)
+	{
+		size_t secondDotPos = fullIdentifier.find('.', 4); // 4 = strlen("map.")
+		if(secondDotPos != std::string::npos)
+			return fullIdentifier.substr(secondDotPos + 1);
+	}
+	return fullIdentifier;
+}
+
 void CMapFormatJson::serializeAllowedFactions(JsonSerializeFormat & handler, std::set<FactionID> & value) const
 {
 	std::set<FactionID> temp;
@@ -306,10 +324,53 @@ void CMapFormatJson::serializeAllowedFactions(JsonSerializeFormat & handler, std
 		value = temp;
 }
 
+void CMapFormatJson::fixStringsTextIDInJson(JsonNode & node, const std::string & mapPrefix) const
+{
+	if(!node.isStruct())
+		return;
+	
+	// Check if stringsTextID exists without creating it
+	auto & nodeStruct = node.Struct();
+	auto it = nodeStruct.find("stringsTextID");
+	
+	// Process stringsTextID array if present (MetaString structure)
+	if(it != nodeStruct.end() && it->second.isVector())
+	{
+		for(auto & textID : it->second.Vector())
+		{
+			if(textID.isString() && !textID.String().empty() 
+				&& textID.String().find("map.") != 0 
+				&& textID.String().find("core.") != 0
+				&& textID.String().find("vcmi.") != 0)
+			{
+				textID.String() = mapPrefix + textID.String();
+			}
+		}
+	}
+	
+	// Recursively search for more stringsTextID arrays in child Struct nodes only
+	for(auto & child : nodeStruct)
+	{
+		if(child.second.isStruct())
+			fixStringsTextIDInJson(child.second, mapPrefix);
+	}
+}
+
 void CMapFormatJson::serializeHeader(JsonSerializeFormat & handler)
 {
+	if(!handler.saving)
+	{
+		// When loading: Fix TextIDs in JSON to include map name prefix before deserialization
+		std::string actualMapName = TextOperations::convertMapName(mapName);
+		std::string mapPrefix = "map." + actualMapName + ".";
+		
+		JsonNode & headerData = const_cast<JsonNode &>(handler.getCurrent());
+		fixStringsTextIDInJson(headerData, mapPrefix);
+	}
+	
 	handler.serializeStruct("name", mapHeader->name);
 	handler.serializeStruct("description", mapHeader->description);
+	
 	handler.serializeStruct("author", mapHeader->author);
 	handler.serializeStruct("authorContact", mapHeader->authorContact);
 	handler.serializeStruct("mapVersion", mapHeader->mapVersion);
@@ -769,11 +830,12 @@ void CMapPatcher::readPatchData()
 }
 
 ///CMapLoaderJson
-CMapLoaderJson::CMapLoaderJson(CInputStream * stream)
+CMapLoaderJson::CMapLoaderJson(CInputStream * stream, const std::string & mapName)
 	: buffer(stream)
 	, ioApi(new CProxyROIOApi(buffer))
 	, loader("", "_", ioApi)
 {
+	this->mapName = mapName;
 }
 
 std::unique_ptr<CMap> CMapLoaderJson::loadMap(IGameInfoCallback * cb)
@@ -863,6 +925,9 @@ void CMapLoaderJson::readHeader(const bool complete)
 		mapHeader->mapLevels = levels->getCurrent().Struct().size();
 	}
 
+	// Load translations BEFORE deserializing header so that header.name etc. can be translated
+	readTranslations();
+
 	serializeHeader(handler);
 
 	readTriggeredEvents(handler);
@@ -875,7 +940,6 @@ void CMapLoaderJson::readHeader(const bool complete)
 	if(complete)
 		readOptions(handler);
 	
-	readTranslations();
 }
 
 void CMapLoaderJson::readTerrainTile(const std::string & src, TerrainTile & tile)
@@ -1154,13 +1218,56 @@ void CMapLoaderJson::readObjects()
 
 void CMapLoaderJson::readTranslations()
 {
-	std::list<Languages::Options> languages{Languages::getLanguageList().begin(), Languages::getLanguageList().end()};
+	// Load translations from ZIP archive - keys in JSON are WITHOUT map name (e.g. "header.name")
+	JsonNode translationsFromFile;
 	for(auto & language : Languages::getLanguageList())
 	{
 		if(isExistArchive(language.identifier + ".json"))
-			mapHeader->translations.Struct()[language.identifier] = getFromArchive(language.identifier + ".json");
+			translationsFromFile.Struct()[language.identifier] = getFromArchive(language.identifier + ".json");
 	}
-	mapHeader->registerMapStrings();
+	
+	// Register translations with map name prefix
+	if(!translationsFromFile.Struct().empty())
+	{
+		std::string actualMapName = TextOperations::convertMapName(mapName);
+		
+		std::string preferredLanguage = CGeneralTextHandler::getPreferredLanguage();
+		std::string baseLanguage = Languages::getLanguageOptions(Languages::ELanguages::ENGLISH).identifier;
+		
+		// Determine base language from translations with most strings
+		int maxStrings = 0;
+		for(auto & translation : translationsFromFile.Struct())
+		{
+			if(translation.second.isStruct() && translation.second.Struct().size() > maxStrings)
+			{
+				maxStrings = translation.second.Struct().size();
+				baseLanguage = translation.first;
+			}
+		}
+		
+		// Load base language translations
+		if(translationsFromFile.Struct().count(baseLanguage))
+		{
+			for(auto & str : translationsFromFile[baseLanguage].Struct())
+			{
+				// Keys in JSON don't have map name (e.g. "header.name"), add map name when registering: map.<mapName>.<identifier>
+				TextIdentifier fullIdentifier("map", actualMapName, str.first);
+				mapRegisterLocalizedString("map", *mapHeader, fullIdentifier, str.second.String(), baseLanguage);
+			}
+		}
+
+		// Load preferred language (if different)
+		if(preferredLanguage != baseLanguage && translationsFromFile.Struct().count(preferredLanguage))
+		{
+			JsonNode translationOverrides;
+			for(auto & str : translationsFromFile[preferredLanguage].Struct())
+			{
+				TextIdentifier fullIdentifier("map", actualMapName, str.first);
+				translationOverrides.Struct()[fullIdentifier.get()].String() = str.second.String();
+			}
+			mapHeader->texts.loadTranslationOverrides("map", preferredLanguage, translationOverrides);
+		}
+	}
 }
 
 
@@ -1354,7 +1461,18 @@ void CMapSaverJson::writeTranslations()
 			continue;
 		}
 		logGlobal->trace("Saving translations, language: %s", language);
-		addToArchive(s.second, language + ".json");
+		
+		// Remove map name prefix from keys when saving to JSON
+		// Keys are stored as "map.<mapName>.<identifier>" but should be saved as just "<identifier>"
+		JsonNode translationsToSave;
+		
+		for(auto & translation : s.second.Struct())
+		{
+			std::string key = removeMapNamePrefix(translation.first);
+			translationsToSave[key] = translation.second;
+		}
+		
+		addToArchive(translationsToSave, language + ".json");
 	}
 }
 

--- a/lib/mapping/MapFormatJson.h
+++ b/lib/mapping/MapFormatJson.h
@@ -43,6 +43,9 @@ public:
 	static const std::string OBJECTS_FILE_NAME;
 	static const std::string TERRAIN_FILE_NAMES[2];
 
+	/// Removes "map.<mapName>." prefix from translation keys
+	static std::string removeMapNamePrefix(const std::string & fullIdentifier);
+
 	int fileVersionMajor;
 	int fileVersionMinor;
 protected:
@@ -57,12 +60,16 @@ protected:
 	 * (when loading map and mapHeader point to the same object)
 	 */
 	CMapHeader * mapHeader;
+	
+	std::string mapName; ///< name of the map file (for translations, same as H3M)
 
 	CMapFormatJson();
 
 	static TerrainId getTerrainByCode(const std::string & code);
 	static RiverId getRiverByCode(const std::string & code);
 	static RoadId getRoadByCode(const std::string & code);
+
+	void fixStringsTextIDInJson(JsonNode & node, const std::string & mapPrefix) const;
 
 	void serializeAllowedFactions(JsonSerializeFormat & handler, std::set<FactionID> & value) const;
 
@@ -159,8 +166,9 @@ public:
 	 * Constructor.
 	 *
 	 * @param stream a stream containing the map data
+	 * @param mapName name of the map file (for external translations)
 	 */
-	CMapLoaderJson(CInputStream * stream);
+	CMapLoaderJson(CInputStream * stream, const std::string & mapName = "");
 
 	/**
 	 * Loads the VCMI/Json map file.

--- a/mapeditor/mapsettings/translations.cpp
+++ b/mapeditor/mapsettings/translations.cpp
@@ -15,6 +15,7 @@
 #include "../../lib/texts/CGeneralTextHandler.h"
 #include "../../lib/mapObjects/CGObjectInstance.h"
 #include "../../lib/GameLibrary.h"
+#include "../../lib/mapping/MapFormatJson.h"
 
 void Translations::cleanupRemovedItems(CMap & map)
 {
@@ -67,6 +68,19 @@ Translations::Translations(CMapHeader & mh, QWidget *parent) :
 	
 	setWindowFlags(Qt::Dialog | Qt::WindowTitleHint | Qt::WindowCloseButtonHint);
 	
+	// Remove "map.<mapname>." prefix from all translation keys for editor display
+	// Internal VMAP translations are saved WITHOUT this prefix
+	for(auto & langPair : mapHeader.translations.Struct())
+	{
+		JsonNode cleanedTranslations;
+		for(auto & entry : langPair.second.Struct())
+		{
+			std::string key = CMapFormatJson::removeMapNamePrefix(entry.first);
+			cleanedTranslations.Struct()[key] = entry.second;
+		}
+		langPair.second = cleanedTranslations;
+	}
+	
 	//fill languages list
 	std::set<int> indexFoundLang;
 	int foundLang = -1;
@@ -108,6 +122,7 @@ void Translations::fillTranslationsTable(const std::string & language)
 	ui->translationsTable->blockSignals(true);
 	ui->translationsTable->setRowCount(0);
 	ui->translationsTable->setRowCount(translation.Struct().size());
+	
 	int i = 0;
 	for(auto & s : translation.Struct())
 	{


### PR DESCRIPTION
fixes: #5810

Works like this:
- Prefer external translation
- If not exists use internal

Fixes:
- asserts and bugs because string ids are multiple registered -> now approach is the same as H3M maps

@GeorgeK1ng 
As it's also requested by you:
Can you test it? But please both. Internal VMAP translation (use map editor) as well as external translation. And also included in vcmp.