### PR TITLE
Fix ESC to close hero backpack window

### DIFF
--- a/client/windows/CHeroBackpackWindow.cpp
+++ b/client/windows/CHeroBackpackWindow.cpp
@@ -31,6 +31,7 @@ CHeroBackpackWindow::CHeroBackpackWindow(const CGHeroInstance * hero, const std:
 	: CWindowWithArtifacts(&artsSets)
 {
 	OBJECT_CONSTRUCTION;
+	addUsedEvents(KEYBOARD);
 
 	stretchedBackground = std::make_shared<CFilledTexture>(ImagePath::builtin("DIBOXBCK"), Rect(0, 0, 0, 0));
 	arts = std::make_shared<CArtifactsOfHeroBackpack>();
@@ -82,6 +83,12 @@ CHeroBackpackWindow::CHeroBackpackWindow(const CGHeroInstance * hero, const std:
 void CHeroBackpackWindow::notFocusedClick()
 {
 	close();
+}
+
+void CHeroBackpackWindow::keyPressed(EShortcut key)
+{
+	if(key == EShortcut::GLOBAL_RETURN)
+		close();
 }
 
 void CHeroBackpackWindow::showAll(Canvas & to)

--- a/client/windows/CHeroBackpackWindow.h
+++ b/client/windows/CHeroBackpackWindow.h
@@ -18,6 +18,7 @@ class CHeroBackpackWindow : public CStatusbarWindow, public CWindowWithArtifacts
 public:
 	CHeroBackpackWindow(const CGHeroInstance * hero, const std::vector<CArtifactsOfHeroPtr> & artsSets);
 	void notFocusedClick() override;
+	void keyPressed(EShortcut key) override;
 	
 protected:
 	std::shared_ptr<CArtifactsOfHeroBackpack> arts;


### PR DESCRIPTION
## Summary
- enable keyboard events in `CHeroBackpackWindow`
- handle `GLOBAL_RETURN` (Escape/Enter) to close the backpack window

## Context
Pressing `Esc` did not close the hero backpack window (only clicking outside worked). This now matches other dialogs that close via `GLOBAL_RETURN`.

## Testing
- open hero screen → click backpack button → press `Esc` → backpack window closes
- click outside still closes the backpack window
