### PR TITLE
fixes spell counter for adventure spells

### DIFF
--- a/docs/modders/Bonus/Bonus_Types.md
+++ b/docs/modders/Bonus/Bonus_Types.md
@@ -270,6 +270,10 @@ Grants affected hero additional mana for the duration of combat. Bonus may give 
 
 - val: amount of additional mana
 
+### SPELL_CAST_COUNTER
+
+Internal bonus, do not use
+
 ## Hero specialties
 
 ### SPECIAL_SPELL_LEV

--- a/lib/bonuses/BonusEnum.h
+++ b/lib/bonuses/BonusEnum.h
@@ -196,7 +196,8 @@ class JsonNode;
 	BONUS_NAME(SPECIFIC_SPELL_RANGE) /* value used for allowed spell range, subtype - spell id */\
 	BONUS_NAME(HATES_TRAIT) /* affected unit deals additional damage to units with specific bonus. subtype - bonus, val - damage bonus percent */ \
 	BONUS_NAME(DAMAGE_RECEIVED_CAP) /* limits the damage dealt to affected unit */ \
-	BONUS_NAME(FORCE_NEUTRAL_ENCOUNTER_STACK_COUNT) /* Forces the number of neutral stacks in hero–neutral encounters.*/
+	BONUS_NAME(FORCE_NEUTRAL_ENCOUNTER_STACK_COUNT) /* Forces the number of neutral stacks in hero–neutral encounters.*/ \
+	BONUS_NAME(SPELL_CAST_COUNTER)  /*used to keep count how many times a particular spells has been cast*/
 	/* end of list */
 
 

--- a/lib/spells/adventure/AdventureSpellMechanics.cpp
+++ b/lib/spells/adventure/AdventureSpellMechanics.cpp
@@ -116,7 +116,8 @@ bool AdventureSpellMechanics::canBeCast(spells::Problem & problem, const IGameIn
 
 		std::stringstream cachingStr;
 		cachingStr << "source_" << vstd::to_underlying(BonusSource::SPELL_EFFECT) << "id_" << owner->id.num;
-		int castsAlreadyPerformedThisTurn = caster->getHeroCaster()->getBonuses(Selector::source(BonusSource::SPELL_EFFECT, BonusSourceID(owner->id)), cachingStr.str())->size();
+		auto selectorForCastCounter = Selector::source(BonusSource::SPELL_EFFECT, BonusSourceID(owner->id)).And(Selector::type()(BonusType::SPELL_CAST_COUNTER));
+		int castsAlreadyPerformedThisTurn = caster->getHeroCaster()->valOfBonuses(selectorForCastCounter, cachingStr.str());
 		int3 mapSize = cb->getMapSize();
 		bool mapSizeIsAtLeastXL = mapSize.x * mapSize.y * mapSize.z >= GameConstants::TOURNAMENT_RULES_DD_MAP_TILES_THRESHOLD;
 		bool useAlternativeLimit = mapSizeIsAtLeastXL && getLevel(caster).castsPerDayXL != 0;
@@ -166,7 +167,7 @@ void AdventureSpellMechanics::giveBonuses(SpellCastEnvironment * env, const Adve
 
 	GiveBonus gb;
 	gb.id = ObjectInstanceID(parameters.caster->getCasterUnitId());
-	gb.bonus = Bonus(BonusDuration::ONE_DAY, BonusType::NONE, BonusSource::SPELL_EFFECT, 0, BonusSourceID(owner->id));
+	gb.bonus = Bonus(BonusDuration::ONE_DAY, BonusType::SPELL_CAST_COUNTER, BonusSource::SPELL_EFFECT, 1, BonusSourceID(owner->id));
 	env->apply(gb);
 }
 


### PR DESCRIPTION
Fixes #6659
The problem lied in the fact that a search by BonusSourceId alone found both the special bonus with type NONE left for the counter and the actual bonus with stats improvement.
A Thought: maybe we should add a explicit BonusType "COUNTER" in case something else uses NONE?

Edit: Done.