### PR TITLE
[1.7.2] Relax mod compatibility strictness when loading saves

### DIFF
--- a/lib/mapping/CMap.cpp
+++ b/lib/mapping/CMap.cpp
@@ -1088,7 +1088,7 @@ bool CMap::compareObjectBlitOrder(const CGObjectInstance * a, const CGObjectInst
 
 void CMap::deserializeHeroPool(const std::vector<std::shared_ptr<CGHeroInstance> > & poolFromSave)
 {
-	heroesPool.resize(poolFromSave.size());
+	heroesPool.resize(LIBRARY->heroh->size());
 	for (const auto & hero : poolFromSave)
 		if (hero)
 			heroesPool.at(hero->getHeroTypeID().getNum()) = hero;

--- a/lib/modding/ActiveModsInSaveList.cpp
+++ b/lib/modding/ActiveModsInSaveList.cpp
@@ -40,6 +40,9 @@ void ActiveModsInSaveList::verifyActiveMods(const std::map<TModID, ModVerificati
 
 	for (auto const & compared : comparison)
 	{
+		if (compared.first.find('.') != std::string::npos)
+			continue; // ignore changes in submods since they change a lot between mod updates
+
 		if (compared.second == ModVerificationStatus::NOT_INSTALLED)
 			missingMods.push_back(modList.at(compared.first).name);
 

--- a/lib/modding/ModVerificationInfo.cpp
+++ b/lib/modding/ModVerificationInfo.cpp
@@ -69,6 +69,15 @@ ModListVerificationStatus ModVerificationInfo::verifyListAgainstLocalMods(const 
 		if(modList.count(m))
 			continue;
 
+		// FIXME: for some reason parent mod (e.g. hota) is not present in save mod list even if its submods are
+		// workaround for this and exclude such mods from comparison list if submods are found
+		bool hasSubmod = false;
+		for (const auto & mod : modList)
+			hasSubmod = hasSubmod || boost::starts_with(mod.first, m + '.');
+
+		if (hasSubmod)
+			continue;
+
 		if (m == ModScope::scopeBuiltin())
 			continue;
 


### PR DESCRIPTION
It is now possible to load saves made with different configuration of submods, for example after mod update.

This is mostly to prevent save breakage for like half of our players when 1.7.2 & hota update with Bulwark is out

Same list of "main" mods is still required, however submods can now be rearranged if desired. In theory we can relax this requirement further, but for now it is better to play it safe and see how this version will work out.

Disabling submod that adds new game entities will break save as before, and in case of disabling towns/heroes will hide these saves from save list. Othervice, attempt to load such save will result in error mid- load. Submods that are graphical-only or balance-only should be possible to disable.

Enabling submods with new objects should now be possible, but in general new objects will be considered to be banned since list of (for example) allowed heroes is generated on map start, so heroes added mid-game will be considered as banned and won't appear in taverns