### PR TITLE
Fix walk and spellcast targeting

### DIFF
--- a/client/battle/BattleActionsController.cpp
+++ b/client/battle/BattleActionsController.cpp
@@ -343,16 +343,16 @@ void BattleActionsController::reorderPossibleActionsPriority(const CStack * stac
 			case PossiblePlayerBattleAction::WALK_AND_ATTACK:
 				return 7;
 				break;
-			case PossiblePlayerBattleAction::MOVE_STACK:
+			case PossiblePlayerBattleAction::WALK_AND_SPELLCAST:
 				return 8;
 				break;
-			case PossiblePlayerBattleAction::CATAPULT:
+			case PossiblePlayerBattleAction::MOVE_STACK:
 				return 9;
 				break;
-			case PossiblePlayerBattleAction::HEAL:
+			case PossiblePlayerBattleAction::CATAPULT:
 				return 10;
 				break;
-			case PossiblePlayerBattleAction::WALK_AND_SPELLCAST:
+			case PossiblePlayerBattleAction::HEAL:
 				return 11;
 				break;
 			case PossiblePlayerBattleAction::CREATURE_INFO:
@@ -768,7 +768,7 @@ bool BattleActionsController::actionIsLegal(PossiblePlayerBattleAction action, c
 		case PossiblePlayerBattleAction::WALK_AND_SPELLCAST:
 			{
 				const CStack * currentStack = owner.stacksController->getActiveStack();
-				if (!currentStack || !targetStack || !targetStack->alive())
+				if (!currentStack || !targetStack)
 					return false;
 
 				if (targetStack == currentStack)

--- a/lib/battle/CBattleInfoCallback.cpp
+++ b/lib/battle/CBattleInfoCallback.cpp
@@ -763,6 +763,9 @@ bool CBattleInfoCallback::battleCanAttackHex(const BattleHexArray & availableHex
 			if (attacker->doubleWide() && obstacle->getStoppingTile().contains(attacker->occupiedHex(fromHex)))
 				return false;
 		}
+		const battle::Unit * defender = battleGetUnitByPos(position, false); //Do not allow to target corpses when standing on them (a WALK_AND_SPELLCAST action)
+		if (defender && defender->isDead() && defender->coversPos(fromHex))
+			return false;
 	}
 
 	return true;

--- a/server/battles/BattleActionProcessor.cpp
+++ b/server/battles/BattleActionProcessor.cpp
@@ -551,7 +551,7 @@ bool BattleActionProcessor::doWalkAndSpellcastAction(const CBattleInfoCallback &
 
 	BattleHex movementDestinationTile = target.at(0).hexValue;
 	BattleHex targetUnitTile = target.at(1).hexValue;
-	const CStack * destinationStack = battle.battleGetStackByPos(targetUnitTile, true);
+	const CStack * destinationStack = battle.battleGetStackByPos(targetUnitTile, false);
 
 	if(!destinationStack)
 	{


### PR DESCRIPTION
Fixes corpse targeting from issue 6757.
I will take a look at the visual problem as well. 
I also changed the action priority, so the default action will be casting a spell on a corpse, not walking on him (just like for an archangel.)

Edit: visual problems solved, fixed #6757.
What has been tested:
Spell can be casted on living units.
Spell can be casted on corpses (resurrection).
Cannot resurrect dead allied units standing on them (both if you want to move there or started a turn on a corpse).
Cannot resurrect dead allied units when an enemy or ally stands on them.
In case of an action not being selected the default action on a corpse it to cast the spell.
In case of a negative spell the default action on enemy it to attack them (spell can be casted when explicitly selected). I think this is desired.