### PR TITLE
Overload canBeCastAt method

### DIFF
--- a/client/battle/BattleActionsController.cpp
+++ b/client/battle/BattleActionsController.cpp
@@ -257,9 +257,7 @@ void BattleActionsController::enterCreatureCastingMode()
 		spells::BattleCast cast(owner.getBattle().get(), caster, spells::Mode::CREATURE_ACTIVE, spell);
 
 		auto m = spell->battleMechanics(&cast);
-		spells::detail::ProblemImpl ignored;
-
-		const bool isCastingPossible = m->canBeCastAt(target, ignored);
+		const bool isCastingPossible = m->canBeCastAt(target);
 
 		if (isCastingPossible)
 		{

--- a/client/battle/BattleFieldController.cpp
+++ b/client/battle/BattleFieldController.cpp
@@ -393,8 +393,7 @@ BattleHexArray BattleFieldController::getHighlightedHexesForMovementTarget()
 			target.emplace_back(hoveredHex);
 
 			spells::BattleCast event(owner.getBattle().get(), caster, mode, spell);
-			spells::detail::ProblemImpl problem;
-			canCastAdjacentSpell = spell->battleMechanics(&event)->canBeCastAt(target, problem);
+			canCastAdjacentSpell = spell->battleMechanics(&event)->canBeCastAt(target);
 		}
 	}
 

--- a/lib/battle/CBattleInfoCallback.cpp
+++ b/lib/battle/CBattleInfoCallback.cpp
@@ -2072,9 +2072,7 @@ SpellID CBattleInfoCallback::getRandomBeneficialSpell(vstd::RNG & rand, const ba
 		spells::BattleCast cast(this, caster, spells::Mode::CREATURE_ACTIVE, spellPtr);
 
 		auto m = spellPtr->battleMechanics(&cast);
-		spells::detail::ProblemImpl problem;
-
-		if (!m->canBeCastAt(target, problem))
+		if (!m->canBeCastAt(target))
 			continue;
 
 		switch (spellID.toEnum())

--- a/lib/spells/BattleSpellMechanics.cpp
+++ b/lib/spells/BattleSpellMechanics.cpp
@@ -264,6 +264,12 @@ bool BattleSpellMechanics::canCastAtTarget(const battle::Unit * target) const
 	return true;
 }
 
+bool BattleSpellMechanics::canBeCastAt(const Target & target) const
+{
+	spells::detail::ProblemImpl ignore;
+	return canBeCastAt(target, ignore);
+}
+
 bool BattleSpellMechanics::canBeCastAt(const Target & target, Problem & problem) const
 {
 	if(!canBeCast(problem))
@@ -697,9 +703,7 @@ std::vector<Destination> BattleSpellMechanics::getPossibleDestinations(size_t in
 			Target tmp = current;
 			tmp.emplace_back(stack->getPosition());
 
-			detail::ProblemImpl ignored;
-
-			if(canBeCastAt(tmp, ignored))
+			if(canBeCastAt(tmp))
 				ret.emplace_back(stack->getPosition());
 		}
 
@@ -725,9 +729,7 @@ std::vector<Destination> BattleSpellMechanics::getPossibleDestinations(size_t in
 					Target tmp = current;
 					tmp.emplace_back(hex);
 
-					detail::ProblemImpl ignored;
-
-					if(canBeCastAt(tmp, ignored))
+					if(canBeCastAt(tmp))
 						ret.emplace_back(hex);
 				}
 			}
@@ -742,9 +744,7 @@ std::vector<Destination> BattleSpellMechanics::getPossibleDestinations(size_t in
 					Target tmp = current;
 					tmp.emplace_back(dest);
 
-					detail::ProblemImpl ignored;
-
-					if(canBeCastAt(tmp, ignored))
+					if(canBeCastAt(tmp))
 						ret.emplace_back(dest);
 				}
 			}

--- a/lib/spells/BattleSpellMechanics.h
+++ b/lib/spells/BattleSpellMechanics.h
@@ -41,6 +41,7 @@ public:
 	bool canBeCast(Problem & problem) const override;
 
 	/// Returns false if spell can not be cast at specified target
+	bool canBeCastAt(const Target & target) const override;
 	bool canBeCastAt(const Target & target, Problem & problem) const override;
 
 	// TODO: ??? (what's the difference compared to applyEffects?)

--- a/lib/spells/ISpellMechanics.h
+++ b/lib/spells/ISpellMechanics.h
@@ -210,6 +210,7 @@ public:
 	virtual std::vector<const CStack *> getAffectedStacks(const Target & target) const = 0;
 
 	virtual bool canBeCast(Problem & problem) const = 0;
+	virtual bool canBeCastAt(const Target & target) const = 0;
 	virtual bool canBeCastAt(const Target & target, Problem & problem) const = 0;
 
 	virtual void applyEffects(ServerCallback * server, const Target & targets, bool indirect, bool ignoreImmunity) const = 0;

--- a/server/battles/BattleActionProcessor.cpp
+++ b/server/battles/BattleActionProcessor.cpp
@@ -1226,9 +1226,7 @@ void BattleActionProcessor::attackCasting(const CBattleInfoCallback & battle, bo
 
 			auto m = spell->battleMechanics(&parameters);
 
-			spells::detail::ProblemImpl ignored;
-
-			if(!m->canBeCastAt(target, ignored))
+			if(!m->canBeCastAt(target))
 				continue;
 
 			//check if spell should be cast (probability handling)

--- a/test/mock/mock_spells_Mechanics.h
+++ b/test/mock/mock_spells_Mechanics.h
@@ -26,6 +26,7 @@ public:
 	MOCK_CONST_METHOD1(getAffectedStacks, std::vector<const CStack *>(const Target &));
 
 	MOCK_CONST_METHOD1(canBeCast, bool(Problem &));
+	MOCK_CONST_METHOD1(canBeCastAt, bool(const Target &));
 	MOCK_CONST_METHOD2(canBeCastAt, bool(const Target &, Problem &));
 
 	MOCK_CONST_METHOD4(applyEffects, void(ServerCallback *, const Target &, bool, bool));


### PR DESCRIPTION
Just an overload of that method in order to clean code up a little  by getting rid of this confusing parameter.
Ideally it would be nice to also avoid running the logic for it when all that we want is knowing if a spell can be cast on a field, but that will require a major refactoring.