### PR TITLE
Fixes battle stack queue for high morale and not-skipping spellcasts

### DIFF
--- a/lib/battle/CUnitState.cpp
+++ b/lib/battle/CUnitState.cpp
@@ -931,6 +931,7 @@ void CUnitState::afterGetsTurn(BattleUnitTurnReason reason)
 	{
 		hadMorale = true;
 		castSpellThisTurn = false;
+		movedThisRound = false;
 	}
 }
 

--- a/lib/gameState/GameStatePackVisitor.cpp
+++ b/lib/gameState/GameStatePackVisitor.cpp
@@ -31,6 +31,8 @@
 #include "../mapping/CMap.h"
 #include "../networkPacks/StackLocation.h"
 
+#include "../../lib/spells/CSpellHandler.h"
+
 VCMI_LIB_NAMESPACE_BEGIN
 
 void GameStatePackVisitor::visitSetResources(SetResources & pack)
@@ -1328,13 +1330,25 @@ void GameStatePackVisitor::visitStartAction(StartAction & pack)
 				st->waiting = true;
 				st->waitedThisTurn = true;
 				break;
+			case EActionType::MONSTER_SPELL:
+			{
+				auto * spell = pack.ba.spell.toSpell();
+				if (spell && spell->canCastWithoutSkip()) {}	//state does not change
+				else
+				{
+					st->waiting = false;
+					st->defendingAnim = false;
+					st->movedThisRound = true;
+				}
+				st->castSpellThisTurn = true;
+				break;
+			}
 			case EActionType::HERO_SPELL: //no change in current stack state
 				break;
 			default: //any active stack action - attack, catapult, heal, spell...
 				st->waiting = false;
 				st->defendingAnim = false;
 				st->movedThisRound = true;
-				st->castSpellThisTurn = pack.ba.actionType == EActionType::MONSTER_SPELL;
 				break;
 		}
 	}


### PR DESCRIPTION
As in the description.
Fixes #6763 and a similar bug with morale bonus.
...maybe I should change the "movedThisRound" to "movedThisTurn", since a unit that receives morale bonus has already moved this round, but it received a second turn. I think? Just to avoid confusion.

