### PR TITLE
[1.7.2] Add support for external description file for mods

### DIFF
--- a/CI/example.markdownlint-cli2.jsonc
+++ b/CI/example.markdownlint-cli2.jsonc
@@ -184,7 +184,7 @@
 		// MD040/fenced-code-language : Fenced code blocks should have a language specified : https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md040.md
 		"MD040": {
 		// List of languages
-			"allowed_languages": [ "cpp", "json", "sh", "text", "nix", "powershell", "lua", "batchfile" ],
+			"allowed_languages": [ "cpp", "json", "sh", "text", "nix", "powershell", "lua", "batchfile", "md" ],
 		// Require language only
 			"language_only": true
 		},

--- a/config/schemas/mod.json
+++ b/config/schemas/mod.json
@@ -3,7 +3,7 @@
 	"$schema" : "http://json-schema.org/draft-04/schema",
 	"title" : "VCMI mod file format",
 	"description" : "Format used to define main mod file (mod.json) in VCMI",
-	"required" : [ "name", "description", "modType", "version", "author", "contact" ],
+	"required" : [ "name", "modType", "version", "author" ],
 	"definitions" : {
 		"fileListOrObject" : {
 			"oneOf" : [
@@ -19,7 +19,7 @@
 		"localizable" : {
 			"type" : "object",
 			"additionalProperties" : false,
-			"required" : [ "name", "description" ],
+			"required" : [ "name" ],
 			"properties" : {
 				"name" : {
 					"type" : "string",
@@ -62,6 +62,10 @@
 		"description" : {
 			"type" : "string",
 			"description" : "More lengthy description of mod. No hard limit"
+		},
+		"descriptionURL" : {
+			"type" : "string",
+			"description" : "URL to location of external description of mod. No hard limit"
 		},
 		"modType" : {
 			"type" : "string",

--- a/docs/modders/Mod_File_Format.md
+++ b/docs/modders/Mod_File_Format.md
@@ -9,7 +9,8 @@
 	"name" : "My test mod",
 
 	// More lengthy description of mod. No hard limit. This text will be visible in launcher.
-	// This field can use small subset of HTML, see link at the bottom of this page.
+	// This field uses .md (Markdown) formatting
+	// For main mods, prefer to use external description in form of description.md file, see below for details
 	"description" : "My test mod that add a lot of useless stuff into the game",
 
 	// Author of mod. Can be nickname, real name or name of team
@@ -197,10 +198,10 @@ These are fields that are present only in local mod.json file
 	],
 	
 	// Optional, primaly used by translation mods
-	// Defines strings that are translated by mod into base language specified in "language" field
+	// Defines strings that are translated by mod into base language specified in 'language' field
 	"translations" :
 	[
-		"config/englishStrings.json
+	    "config/englishStrings.json"
 	]
 }
 ```
@@ -238,9 +239,6 @@ These are fields that are present only in remote repository and are generally no
 }
 ```
 
-## Notes
+## Mod description
 
-For mod description it is possible to use certain subset of HTML as
-described here:
-
-<https://doc.qt.io/qt-6/richtext-html-subset.html>
+For mod description it is recommended to provide file named `description.mod`. See [Readme](Readme.md#creating-mod-description) for more details

--- a/docs/modders/Readme.md
+++ b/docs/modders/Readme.md
@@ -33,7 +33,6 @@ Minimalistic version of this file:
 ```json
 {
     "name" : "My test mod",
-    "description" : "My test mod that add a lot of useless stuff into the game",
     "version" : "1.00",
 	"modType" : "Graphical",	
 	"contact" : "http://www.contact.example.com"
@@ -41,6 +40,38 @@ Minimalistic version of this file:
 ```
 
 See [Mod file Format](Mod_File_Format.md) for its full description.
+
+## Creating mod description
+
+For convenience, mod descriptions are located in separate file named `description.md`. This file uses Markdown formatting and allows modder to add mod description of arbitrary length as well as to provide translations.
+
+If mod provides description in both `mod.json` and in `description.md`, Markdown version will take priority and will be used instead of version in `mod.json` for languages that are present in `description.md`
+
+Please do NOT include mod name as title of `description.md`. Mod name will be added automatically on top of your mod description in Launcher
+
+Majority of markdown format is allowed in description.md. Exceptions are:
+
+- top-level headings are reserved for translations and must use form `#(one space)(language ID)`, for example `# english`. Language ID is lower-case name of language in English.
+- embedded images are currently not supported.
+
+Note that due to technical details, if you have added `description.md` for mod that previously did not have one, it will only show up in Launcher for players without your mod on next automatic daily update, and not immediately.
+
+Expected format of `description.md` is:
+
+```md
+# english
+
+(description in English)
+
+# polish
+
+(description in Polish)
+
+# czech
+
+(description in Czech)
+
+```
 
 ## Creation of new objects
 

--- a/lib/filesystem/ResourcePath.cpp
+++ b/lib/filesystem/ResourcePath.cpp
@@ -93,6 +93,7 @@ EResType EResTypeHelper::getTypeFromExtension(std::string extension)
 	static const std::map<std::string, EResType> stringToRes =
 	{
 		{".TXT",   EResType::TEXT},
+		{".MD",   EResType::TEXT},
 		{".JSON",  EResType::JSON},
 		{".DEF",   EResType::ANIMATION},
 		{".MSK",   EResType::MASK},

--- a/lib/modding/ModDescription.cpp
+++ b/lib/modding/ModDescription.cpp
@@ -15,8 +15,41 @@
 
 #include "../json/JsonNode.h"
 #include "../texts/CGeneralTextHandler.h"
+#include "../texts/Languages.h"
 
 VCMI_LIB_NAMESPACE_BEGIN
+
+void ModDescription::mergeModDescriptions(JsonNode & modConfig, const std::string & fullDescription)
+{
+	std::vector<std::string> sections;
+	boost::algorithm::iter_split(sections, fullDescription, boost::algorithm::first_finder("\n# "));
+
+	for (const auto & section : sections)
+	{
+		size_t endOfFirstLine = section.find('\n', 1);
+		if (endOfFirstLine == std::string::npos)
+			continue;
+
+		std::string firstLine = section.substr(0, endOfFirstLine);
+
+		for (const auto & language : Languages::getLanguageList())
+		{
+			if (firstLine.find(language.identifier) == std::string::npos)
+			   continue;
+
+			bool baseLanguageDescription = language.identifier == "english";
+			if (modConfig.Struct().count("language"))
+				baseLanguageDescription = language.identifier == modConfig["language"].String();
+
+			if (baseLanguageDescription)
+				modConfig["description"].String() = section.substr(endOfFirstLine+1);
+			else
+				modConfig[language.identifier]["description"].String() = section.substr(endOfFirstLine+1);
+
+			break;
+		}
+	}
+}
 
 ModDescription::ModDescription(const TModID & fullID, const JsonNode & localConfig, const JsonNode & repositoryConfig)
 	: identifier(fullID)

--- a/lib/modding/ModDescription.h
+++ b/lib/modding/ModDescription.h
@@ -65,6 +65,8 @@ public:
 	bool isTranslation() const;
 	bool keepDisabled() const;
 	bool isInstalled() const;
+
+	static void mergeModDescriptions(JsonNode & config, const std::string & fullDescription);
 };
 
 VCMI_LIB_NAMESPACE_END


### PR DESCRIPTION
VCMI will now load mod descriptions from `description.md` file located next to `mod.json`. Old form is still supported, but probably deprecated in long-term, at least for main mods while submods can keep existing short ~1 paragraph descriptions in mod.json (at least until it is decided what to do with submods)

Related PR's:
- https://github.com/vcmi/vcmi-mods-repository/pull/103
- https://github.com/vcmi-mods/horn-of-the-abyss/pull/400

TODO:
- [x] update docs on mod.json format
- [x] add documentation for new description format
- [x] update mod.json schema, mark description as no longer required
- [x] Test loading of mod descriptions from repository in Launcher