### PR TITLE
[1.7.2] fix bug: singel spell target can not be changed during a battle

### DIFF
--- a/client/battle/BattleActionsController.cpp
+++ b/client/battle/BattleActionsController.cpp
@@ -197,10 +197,10 @@ void BattleActionsController::endCastingSpell()
 
 	if(monsterCaster)
 	{
-		monsterSpellTargets.clear();
 		monsterCaster = nullptr;
 		owner.stacksController->activateStack();
 	}
+	monsterSpellTargets.clear();
 
 	if(owner.stacksController->getActiveStack())
 	{


### PR DESCRIPTION
monsterSpellTargets should be cleared each time; otherwise, if a creature casts a spell that is not teleport or sacrifice, the previous target will remain.