### PR TITLE
[1.7.2] fix mapeditor crash when mod is in zip format

### DIFF
--- a/mapeditor/BitmapHandler.cpp
+++ b/mapeditor/BitmapHandler.cpp
@@ -123,16 +123,8 @@ namespace BitmapHandler
 		else
 		{ //loading via QImage
 			QImage image;
-			if(fullpath)
-			{
-				image = QImage(QString::fromStdString(fullpath->make_preferred().string()));
-			}
-			else
-			{
-				QByteArray byteArray(reinterpret_cast<const char *>(readFile.first.get()), readFile.second);
-				image.loadFromData(byteArray);
-			}
-
+			QByteArray byteArray(reinterpret_cast<const char *>(readFile.first.get()), readFile.second);
+			image.loadFromData(byteArray);
 			if(!image.isNull())
 			{
 				if(image.bitPlaneCount() == 1)


### PR DESCRIPTION
In the ZIP format, fullpath is nullopt, so QImage cannot be constructed from a file path and must be created from raw bytes instead.
<img width="3340" height="655" alt="image" src="https://github.com/user-attachments/assets/49ec03fc-d958-409e-95e6-87405a91037d" />
