### PR TITLE
[1.7.2] Hotfix for BattleStacksAttacked with invalid stackAttacked

### DIFF
--- a/AI/MMAI/BAI/v13/state.cpp
+++ b/AI/MMAI/BAI/v13/state.cpp
@@ -465,7 +465,11 @@ void State::onBattleStacksAttacked(const std::vector<BattleStackAttacked> & bsa)
 		const auto * cdefender = battle->battleGetStackByID(elem.stackAttacked, false);
 		const auto * cattacker = battle->battleGetStackByID(elem.attackerID, false);
 
-		ASSERT(cdefender, "defender cannot be NULL");
+		if(!cdefender)
+		{
+			logAi->error("MMAI: received BattleStackAttacked with invalid stackAttacked: " + std::to_string(elem.stackAttacked));
+			continue;
+		}
 
 		const auto defender = std::ranges::find_if(
 			stacks,


### PR DESCRIPTION
Issue reported on [discord](https://discord.com/channels/298106089885401090/298106089885401090/1464350669858275455)

For some reason, the  `CBattleGameInterface::battleStacksAttacked` gets called with a `BattleStackAttacked` containing a stack id which does not exist.

This PR implements a workaround and such `BattleStackAttacked` objects will be ignored. 

However, MMAI is just the messenger here - the real issue is somewhere else. `BattleStackAttacked` must contain a valid stack attacked (unless the naming is really off). Here is the related code path on the mmai side:
1. begins [here](https://github.com/vcmi/vcmi/blob/develop/AI/MMAI/BAI/v13/BAI.cpp#L130-L134)
1. the [base](https://github.com/vcmi/vcmi/blob/develop/AI/MMAI/BAI/base.cpp#L199) implementation is a no-op
1. then it goes [here](https://github.com/vcmi/vcmi/blob/develop/AI/MMAI/BAI/v13/state.cpp#L465-L468) 
i.e. 
```
// this is called by the game engine/client
void BAI::battleStacksAttacked(const BattleID & bid, const std::vector<BattleStackAttacked> & bsa, bool ranged)
  for(const auto & elem : bsa)
    {
        const auto * cdefender = battle->battleGetStackByID(elem.stackAttacked, false);
        const auto * cattacker = battle->battleGetStackByID(elem.attackerID, false);

        ASSERT(cdefender, "defender cannot be NULL");  // <--- this line throws
```

