### PR TITLE
Add movement points limiter to rewardable objects

### DIFF
--- a/config/schemas/rewardable.json
+++ b/config/schemas/rewardable.json
@@ -110,6 +110,7 @@
 				"heroLevel" : { "$ref" : "#/definitions/value" },
 				"movePercentage" : { "$ref" : "#/definitions/value" },
 				"movePoints" : { "$ref" : "#/definitions/value" },
+				"moveOverflowFactor" : { "$ref" : "#/definitions/value" },
 				"manaPercentage" : { "$ref" : "#/definitions/value" },
 				"manaPoints" : { "$ref" : "#/definitions/value" },
 				"manaOverflowFactor" : { "$ref" : "#/definitions/value" },
@@ -180,6 +181,8 @@
 				"heroLevel" : { "$ref" : "#/definitions/value" },
 				"manaPercentage" : { "$ref" : "#/definitions/value" },
 				"manaPoints" : { "$ref" : "#/definitions/value" },
+				"movePercentage" : { "$ref" : "#/definitions/value" },
+				"movePoints" : { "$ref" : "#/definitions/value" },
 
 				"canLearnSkills" : { "type" : "boolean" },
 				"commanderAlive" : { "type" : "boolean" },

--- a/docs/modders/Map_Objects/Rewardable.md
+++ b/docs/modders/Map_Objects/Rewardable.md
@@ -358,16 +358,22 @@ Keep in mind, that all randomization is performed on map load and on object rese
 
 ### Movement Points
 
-- Can NOT be used as limiter
+- Can be used as limiter. Hero must have at least specific movement points amount
 - Can be used as reward, to give movement points to hero. Movement points may go above mana pool limit.
 
 ```json
 "movePoints": 200,
 ```
 
+- If giving move points puts hero above daily movement limit, any overflow will be multiplied by specified percentage. If set to 0, movement will not go above movement limit.
+
+```json
+"moveOverflowFactor" : 50,
+```
+
 ### Movement Percentage
 
-- Can NOT be used as limiter
+- Can NOT be used as limiter. Hero must have at least specific movement points percentage
 - Can be used to set hero movement points level to specified percentage value. Value of 0 will take away any remaining movement points
 
 ```json

--- a/lib/mapObjects/CGHeroInstance.cpp
+++ b/lib/mapObjects/CGHeroInstance.cpp
@@ -205,6 +205,11 @@ void CGHeroInstance::setMovementPoints(int points)
 		movement = std::max(0, points);
 }
 
+int CGHeroInstance::movementPointsLimit() const
+{
+	return movementPointsLimit(!inBoat());
+}
+
 int CGHeroInstance::movementPointsLimit(bool onLand) const
 {
 	auto ti = getTurnInfo(0);

--- a/lib/mapObjects/CGHeroInstance.h
+++ b/lib/mapObjects/CGHeroInstance.h
@@ -201,6 +201,7 @@ public:
 
 	void setMovementPoints(int points);
 	int movementPointsRemaining() const;
+	int movementPointsLimit() const;
 	int movementPointsLimit(bool onLand) const;
 	//cached version is much faster, TurnInfo construction is costly
 	int movementPointsLimitCached(bool onLand, const TurnInfo * ti) const;

--- a/lib/mapping/MapFormatH3M.cpp
+++ b/lib/mapping/MapFormatH3M.cpp
@@ -1845,6 +1845,7 @@ void CMapLoaderH3M::readBoxHotaContent(CGPandoraBox * object, const int3 & mapPo
 		{
 			case 0: // Give
 				boxReward.reward.movePoints = movementAmount;
+				boxReward.reward.moveOverflowFactor = 100;
 				break;
 			case 1: // Take
 				boxReward.reward.movePoints = -movementAmount;
@@ -1853,10 +1854,13 @@ void CMapLoaderH3M::readBoxHotaContent(CGPandoraBox * object, const int3 & mapPo
 				boxReward.reward.movePercentage = 0;
 				break;
 			case 3: // Set
-			case 4: // Replenish
-				// TODO: what's the difference?
 				boxReward.reward.movePercentage = 0;
 				boxReward.reward.movePoints = movementAmount;
+				boxReward.reward.moveOverflowFactor = 100;
+				break;
+			case 4: // Replenish
+				boxReward.reward.movePoints = movementAmount;
+				boxReward.reward.moveOverflowFactor = 0;
 				break;
 		}
 	}

--- a/lib/rewardable/Info.cpp
+++ b/lib/rewardable/Info.cpp
@@ -141,6 +141,8 @@ void Rewardable::Info::configureLimiter(Rewardable::Configuration & object, IGam
 
 	limiter.manaPercentage = randomizer.loadValue(source["manaPercentage"], variables);
 	limiter.manaPoints = randomizer.loadValue(source["manaPoints"], variables);
+	limiter.movePercentage = randomizer.loadValue(source["movePercentage"], variables);
+	limiter.movePoints = randomizer.loadValue(source["movePoints"], variables);
 
 	limiter.resources = randomizer.loadResources(source["resources"], variables);
 
@@ -179,6 +181,7 @@ void Rewardable::Info::configureReward(Rewardable::Configuration & object, IGame
 
 	reward.movePoints = randomizer.loadValue(source["movePoints"], variables);
 	reward.movePercentage = randomizer.loadValue(source["movePercentage"], variables, -1);
+	reward.moveOverflowFactor = source["moveOverflowFactor"].isNull() ? 100 : randomizer.loadValue(source["moveOverflowFactor"], variables);
 
 	reward.removeObject = source["removeObject"].Bool();
 	reward.heroBonuses = randomizer.loadBonuses(source["bonuses"]);

--- a/lib/rewardable/Interface.cpp
+++ b/lib/rewardable/Interface.cpp
@@ -140,18 +140,8 @@ void Rewardable::Interface::grantRewardAfterLevelup(IGameEventCallback & gameEve
 	if(info.reward.manaDiff || info.reward.manaPercentage >= 0)
 		gameEvents.setManaPoints(hero->id, info.reward.calculateManaPoints(hero));
 
-	if(info.reward.movePoints || info.reward.movePercentage >= 0)
-	{
-		SetMovePoints smp;
-		smp.hid = hero->id;
-		smp.val = hero->movementPointsRemaining();
-
-		if (info.reward.movePercentage >= 0) // percent from max
-			smp.val = hero->movementPointsLimit(hero->inBoat() && hero->getBoat()->layer == EPathfindingLayer::SAIL) * info.reward.movePercentage / 100;
-		smp.val = std::max<si32>(0, smp.val + info.reward.movePoints);
-
-		gameEvents.setMovePoints(&smp);
-	}
+	if(info.reward.movePoints != 0 || info.reward.movePercentage >= 0)
+		gameEvents.setMovePoints(hero->id, info.reward.calculateMovePoints(hero));
 
 	for(const auto & bonus : info.reward.heroBonuses)
 	{

--- a/lib/rewardable/Limiter.cpp
+++ b/lib/rewardable/Limiter.cpp
@@ -29,6 +29,8 @@ Rewardable::Limiter::Limiter()
 	, heroLevel(-1)
 	, manaPercentage(0)
 	, manaPoints(0)
+	, movePercentage(0)
+	, movePoints(0)
 	, canLearnSkills(false)
 	, commanderAlive(false)
 	, hasExtraCreatures(false)
@@ -46,6 +48,8 @@ bool operator==(const Rewardable::Limiter & l, const Rewardable::Limiter & r)
 	&& l.heroLevel == r.heroLevel
 	&& l.manaPoints == r.manaPoints
 	&& l.manaPercentage == r.manaPercentage
+	&& l.movePoints == r.manaPoints
+	&& l.movePercentage == r.manaPercentage
 	&& l.canLearnSkills == r.canLearnSkills
 	&& l.commanderAlive == r.commanderAlive
 	&& l.hasExtraCreatures == r.hasExtraCreatures
@@ -119,10 +123,16 @@ bool Rewardable::Limiter::heroAllowed(const CGHeroInstance * hero) const
 	if(manaPoints > hero->mana)
 		return false;
 
+	if(movePoints > hero->movementPointsRemaining())
+		return false;
+
 	if (canLearnSkills && !hero->canLearnSkill())
 		return false;
 
 	if (hero->manaLimit() != 0 && manaPercentage > 100 * hero->mana / hero->manaLimit())
+		return false;
+
+	if (hero->movementPointsLimit() != 0 && movePercentage > 100 * hero->movementPointsRemaining()/ hero->movementPointsLimit())
 		return false;
 
 	for(size_t i=0; i<primary.size(); i++)
@@ -281,13 +291,15 @@ void Rewardable::Limiter::serializeJson(JsonSerializeFormat & handler)
 	handler.serializeInt("dayOfWeek", dayOfWeek);
 	handler.serializeInt("daysPassed", daysPassed);
 	resources.serializeJson(handler, "resources");
-	handler.serializeInt("manaPercentage", manaPercentage);
 	handler.serializeInt("heroExperience", heroExperience);
 	handler.serializeInt("heroLevel", heroLevel);
 	handler.serializeIdArray("heroes", heroes);
 	handler.serializeIdArray("heroClasses", heroClasses);
 	handler.serializeIdArray("colors", players);
 	handler.serializeInt("manaPoints", manaPoints);
+	handler.serializeInt("manaPercentage", manaPercentage);
+	handler.serializeInt("movePoints", movePoints);
+	handler.serializeInt("movePercentage", movePercentage);
 	handler.serializeIdArray("artifacts", artifacts);
 	handler.serializeIdArray("spells", spells);
 	handler.enterArray("creatures").serializeStruct(creatures);

--- a/lib/rewardable/Limiter.h
+++ b/lib/rewardable/Limiter.h
@@ -46,6 +46,12 @@ struct DLL_LINKAGE Limiter final : public Serializeable
 	/// percentage of mana points that hero needs to have
 	si32 manaPercentage;
 
+	/// movement points that hero needs to have
+	si32 movePoints;
+
+	/// percentage of movement points that hero needs to have
+	si32 movePercentage;
+
 	/// Number of free secondary slots that hero needs to have
 	bool canLearnSkills;
 
@@ -118,6 +124,11 @@ struct DLL_LINKAGE Limiter final : public Serializeable
 		h & heroLevel;
 		h & manaPoints;
 		h & manaPercentage;
+		if (h.version >= Handler::Version::REWARDABLE_EXTENSIONS_2)
+		{
+			h & movePoints;
+			h & movePercentage;
+		}
 		h & canLearnSkills;
 		if (h.version >= Handler::Version::REWARDABLE_EXTENSIONS)
 		{

--- a/lib/rewardable/Reward.cpp
+++ b/lib/rewardable/Reward.cpp
@@ -36,6 +36,7 @@ Rewardable::Reward::Reward()
 	, manaOverflowFactor(0)
 	, movePoints(0)
 	, movePercentage(-1)
+	, moveOverflowFactor(100)
 	, primary(4, 0)
 	, removeObject(false)
 	, spellCast(SpellID::NONE, MasteryLevel::NONE)
@@ -57,6 +58,23 @@ si32 Rewardable::Reward::calculateManaPoints(const CGHeroInstance * hero) const
 	si32 manaOutput    = manaScaled + manaGranted + manaOverLimit;
 
 	return manaOutput;
+}
+
+si32 Rewardable::Reward::calculateMovePoints(const CGHeroInstance * hero) const
+{
+	si32 moveScaled = hero->movementPointsRemaining();
+	si32 moveLimit = hero->movementPointsLimit();
+
+	if (movePercentage >= 0)
+		moveScaled = moveLimit * movePercentage / 100;
+
+	si32 moveMissing   = std::max(0, moveLimit - moveScaled);
+	si32 moveGranted   = std::min(moveMissing, movePoints);
+	si32 moveOverflow  = movePoints - moveGranted;
+	si32 moveOverLimit = moveOverflow * moveOverflowFactor / 100;
+	si32 moveOutput    = moveScaled + moveGranted + moveOverLimit;
+
+	return std::max(0, moveOutput);
 }
 
 Component Rewardable::Reward::getDisplayedComponent(const CGHeroInstance * h) const
@@ -163,6 +181,7 @@ void Rewardable::Reward::serializeJson(JsonSerializeFormat & handler)
 	handler.serializeInt("manaDiff", manaDiff);
 	handler.serializeInt("manaOverflowFactor", manaOverflowFactor);
 	handler.serializeInt("movePoints", movePoints);
+	handler.serializeInt("moveOverflowFactor", manaOverflowFactor);
 	handler.serializeIdArray("artifacts", grantedArtifacts);
 	handler.serializeIdArray("takenArtifacts", takenArtifacts);
 	handler.serializeIdArray("takenArtifactSlots", takenArtifactSlots);

--- a/lib/rewardable/Reward.h
+++ b/lib/rewardable/Reward.h
@@ -81,6 +81,9 @@ struct DLL_LINKAGE Reward final
 	/// fixed value, in form of percentage from max
 	si32 movePercentage;
 
+	/// if giving movement points puts hero above movement points limit, any overflow will be multiplied by specified percentage
+	si32 moveOverflowFactor;
+
 	/// Guards that must be defeated in order to access this reward, empty if not guarded
 	std::vector<CStackBasicDescriptor> guards;
 
@@ -124,6 +127,7 @@ struct DLL_LINKAGE Reward final
 	Component getDisplayedComponent(const CGHeroInstance * h) const;
 
 	si32 calculateManaPoints(const CGHeroInstance * h) const;
+	si32 calculateMovePoints(const CGHeroInstance * h) const;
 
 	Reward();
 	~Reward();
@@ -141,6 +145,9 @@ struct DLL_LINKAGE Reward final
 		h & manaDiff;
 		h & manaOverflowFactor;
 		h & movePoints;
+		if (h.version >= Handler::Version::REWARDABLE_EXTENSIONS_2)
+			h & moveOverflowFactor;
+
 		h & primary;
 		h & secondary;
 		if (h.version >= Handler::Version::REWARDABLE_EXTENSIONS)

--- a/lib/serializer/ESerializationVersion.h
+++ b/lib/serializer/ESerializationVersion.h
@@ -60,9 +60,10 @@ enum class ESerializationVersion : int32_t
 	HOTA_MAP_FORMAT_EXTENSIONS_2, // more Hota 1.7 map format features
 	TIMER_MOVEMENT_POINTS, // movement points for timer
 	DISABLE_TACTICS, // disable tactics
+	REWARDABLE_EXTENSIONS_2, // movement points limiter for rewardables
 
 	RELEASE_170 = HOTA_MAP_STACK_COUNT,
-	CURRENT = DISABLE_TACTICS
+	CURRENT = REWARDABLE_EXTENSIONS_2,
 };
 
 static_assert(ESerializationVersion::MINIMAL <= ESerializationVersion::CURRENT, "Invalid serialization version definition!");


### PR DESCRIPTION
Now movement points in rewardable objects have same level of functionality/checks as mana points:

- support for test for movement points in limiter (hero has X points)
- support for test for movement points percentage in limiter (hero has X% of total points)
- support to block granted movement points to go above hero limit (e.g. give 1000 points, but cap/don't cap at daily limit)

Also fixed "replenish" mode for hota Pandora's using new functionality