### PR TITLE
Fix Sphere of Permanence Effect

### DIFF
--- a/config/artifacts.json
+++ b/config/artifacts.json
@@ -1344,8 +1344,12 @@
 			"noDispel" : {
 				"subtype" : "dispel",
 				"type" : "SPELL_IMMUNITY",
-				"val" : 0,
-				"valueType" : "BASE_NUMBER"
+				"addInfo" : 1
+			},
+			"noDispelHelpful" : {
+				"subtype" : "dispelHelpful",
+				"type" : "SPELL_IMMUNITY",
+				"addInfo" : 1
 			}
 		},
 		"index" : 92,


### PR DESCRIPTION
Sphere of Permanence is supposed to make the hero's army completely immune to the effects of any Dispel, however the current artifact did not quite work. It only worked against targeted Dispel and not against Mass Dispel and it also didn't provide immunity to Serpent/Dragonfly's type of Dispel. This PR fixes the following issues:

+ Now also grants immunity to Expert level Dispel to the hero's army
+ Now also grants immunity to dispel effect from creatures (e.g. Dragonfly)