### PR TITLE
[1.7.2] fixed invalid color before first turn

### DIFF
--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -169,6 +169,7 @@ void CPlayerInterface::initGameInterface(std::shared_ptr<Environment> ENV, std::
 	initializeHeroTownList();
 
 	adventureInt.reset(new AdventureMapInterface());
+	adventureInt->onCurrentPlayerChanged(playerID);
 }
 
 std::shared_ptr<const CPathsInfo> CPlayerInterface::getPathsInfo(const CGHeroInstance * h)


### PR DESCRIPTION
In multiplayer:
- resource bar before first turn is always red (even as blue player)
- resizing window in this state results to gray background with broken graphics

This PR fixes this