### PR TITLE
Fixed crypt, derelict ship and shipwreck

### DIFF
--- a/config/objects/creatureBanks.json
+++ b/config/objects/creatureBanks.json
@@ -633,7 +633,7 @@
 				"onVisited" : [
 					{
 						"message" : 123, // Such a despicable act reduces your army's morale.
-						"bonuses" : [ { "type" : "MORALE", "val" : -1, "duration" : "ONE_BATTLE", "description" : 99 } ]
+						"bonuses" : [ { "type" : "MORALE", "val" : -1, "duration" : "ONE_BATTLE", "stacking" : "shipwreckVisited", "description" : 99 } ]
 					}
 				],
 				"guardsLayout" : "creatureBankNarrow",
@@ -720,7 +720,6 @@
 			"derelictShip" : {
 				"index" : 0,
 
-				"blockedVisitable" : true,
 				"name" : "Derelict Ship",
 				"aiValue" : 4000,
 				"rmg" : {
@@ -733,7 +732,7 @@
 				"onVisited" : [
 					{
 						"message" : 42, // Such a despicable act reduces your army's morale.
-						"bonuses" : [ { "type" : "MORALE", "val" : -1, "duration" : "ONE_BATTLE", "description" : 101 } ]
+						"bonuses" : [ { "type" : "MORALE", "val" : -1, "duration" : "ONE_BATTLE", "stacking" : "derelictShipVisited", "description" : 101 } ]
 					}
 				],
 				"guardsLayout" : "creatureBankWide",
@@ -832,7 +831,7 @@
 				"onVisited" : [
 					{
 						"message" : 120, // Such a despicable act reduces your army's morale.
-						"bonuses" : [ { "type" : "MORALE", "val" : -1, "duration" : "ONE_BATTLE" } ]
+						"bonuses" : [ { "type" : "MORALE", "val" : -1, "duration" : "ONE_BATTLE", "stacking" : "sepulcherVisited", "description" : 98 } ]
 					}
 				],
 				"guardsLayout" : "creatureBankNarrow",


### PR DESCRIPTION
Tested all changes in this PR against an unmodded HoMM3 Complete install:

+ Added individual `"stacking"` fields to Crypt, Derelict Ship and Shipwreck. They stack with each other but not with themselves
+ Added missing bonus description to Crypt ("-1 Sepulcher Visited", index 98 in arrayTxt)
+ Removed Derelict Ship's Activator not being visitable