### PR TITLE
Combination artifacts value

### DIFF
--- a/config/artifacts.json
+++ b/config/artifacts.json
@@ -1938,7 +1938,8 @@
 			"lionsShieldOfCourage",
 			"swordOfJudgement",
 			"helmOfHeavenlyEnlightenment"
-		]
+		],
+		"value" : 84000
 	},
 	"cloakOfTheUndeadKing":
 	{
@@ -1971,7 +1972,8 @@
 			"amuletOfTheUndertaker",
 			"vampiresCowl",
 			"deadMansBoots"
-		]
+		],
+		"value" : 12000
 	},
 	"elixirOfLife":
 	{
@@ -2006,7 +2008,8 @@
 			"ringOfVitality",
 			"ringOfLife",
 			"vialOfLifeblood"
-		]
+		],
+		"value" : 20000
 	},
 	"armorOfTheDamned":
 	{
@@ -2044,7 +2047,8 @@
 			"shieldOfTheYawningDead",
 			"skullHelmet",
 			"ribCage"
-		]
+		],
+		"value" : 12000
 	},
 	"statueOfLegion":
 	{
@@ -2064,7 +2068,8 @@
 				"val" : 50,
 				"propagator": "PLAYER"
 			}
-		}
+		},
+		"value" : 25000
 	},
 	"powerOfTheDragonFather":
 	{
@@ -2112,7 +2117,8 @@
 			"necklaceOfDragonteeth",
 			"crownOfDragontooth",
 			"stillEyeOfTheDragon"
-		]
+		],
+		"value" : 42000
 	},
 	"titansThunder":
 	{
@@ -2132,7 +2138,8 @@
 			"sentinelsShield",
 			"thunderHelmet",
 			"titansCuirass"
-		]
+		],
+		"value" : 40000
 	},
 	"admiralsHat":
 	{
@@ -2150,7 +2157,8 @@
 		[
 			"necklaceOfOceanGuidance",
 			"seaCaptainsHat"
-		]
+		],
+		"value" : 25000
 	},
 	"bowOfTheSharpshooter":
 	{
@@ -2181,7 +2189,8 @@
 			"bowOfElvenCherrywood",
 			"bowstringOfTheUnicornsMane",
 			"angelFeatherArrows"
-		]
+		],
+		"value" : 12000
 	},
 	"wizardsWell":
 	{
@@ -2199,7 +2208,8 @@
 			"charmOfMana",
 			"talismanOfMana",
 			"mysticOrbOfMana"
-		]
+		],
+		"value" : 3000
 	},
 	"ringOfTheMagi":
 	{
@@ -2217,7 +2227,8 @@
 			"collarOfConjuring",
 			"ringOfConjuring",
 			"capeOfConjuring"
-		]
+		],
+		"value" : 3000
 	},
 	"cornucopia":
 	{
@@ -2255,7 +2266,8 @@
 			"ringOfInfiniteGems",
 			"everpouringVialOfMercury",
 			"eversmokingRingOfSulfur"
-		]
+		],
+		"value" : 20000
 	},
 	// Misiokles: not having these 3 artifacts could lead to crashes. RMG will try to place them in some randoms maps (and crash the game)
 	"unusedArtifact1":


### PR DESCRIPTION
This PR changes the value of the combination artifacts to the sum of their components to ensure accurate selling prices at artifact merchants. Formerly they would all sell for just 1 gold.

Tested all sell prices against a fresh HoMM 3 Complete install.