### PR TITLE
Allow mods to provide save and map compatibilty

### DIFF
--- a/config/creatures/castle.json
+++ b/config/creatures/castle.json
@@ -58,7 +58,7 @@
 	{
 		"index": 2,
 		"level": 2,
-		"extraNames": [ "lightCrossbowman" ],
+		"compatibilityIdentifiers": [ "lightCrossbowman" ],
 		"faction": "castle",
 		"upgrades": ["marksman"],
 		"shots" : 12,

--- a/config/creatures/conflux.json
+++ b/config/creatures/conflux.json
@@ -3,7 +3,7 @@
 	{
 		"index": 118,
 		"level": 1,
-		"extraNames": [ "pixies" ],
+		"compatibilityIdentifiers": [ "pixies" ],
 		"faction": "conflux",
 		"upgrades": ["sprite"],
 		"abilities" :
@@ -63,7 +63,7 @@
 	{
 		"index": 112,
 		"level": 2,
-		"extraNames": [ "airElementals" ],
+		"compatibilityIdentifiers": [ "airElementals" ],
 		"faction": "conflux",
 		"abilities":
 		{
@@ -224,7 +224,7 @@
 	{
 		"index": 115,
 		"level": 3,
-		"extraNames": [ "waterElementals" ],
+		"compatibilityIdentifiers": [ "waterElementals" ],
 		"faction": "conflux",
 		"doubleWide" : true,
 		"abilities":

--- a/config/creatures/fortress.json
+++ b/config/creatures/fortress.json
@@ -44,7 +44,7 @@
 	{
 		"index": 100,
 		"level": 2,
-		"extraNames": [ "primitiveLizardman" ],
+		"compatibilityIdentifiers": [ "primitiveLizardman" ],
 		"faction": "fortress",
 		"upgrades": ["lizardWarrior"],
 		"hasDoubleWeek": true,
@@ -113,7 +113,7 @@
 	{
 		"index": 104,
 		"level": 3,
-		"extraNames": [ "dragonFly" ],
+		"compatibilityIdentifiers": [ "dragonFly" ],
 		"faction": "fortress",
 		"abilities":
 		{

--- a/config/creatures/necropolis.json
+++ b/config/creatures/necropolis.json
@@ -58,7 +58,7 @@
 	{
 		"index": 58,
 		"level": 2,
-		"extraNames": [ "zombie" ], //FIXME: zombie is a name of upgrade but not in HOTRAITS
+		"compatibilityIdentifiers": [ "zombie" ], //FIXME: zombie is a name of upgrade but not in HOTRAITS
 		"faction" : "necropolis",
 		"upgrades": ["zombieLord"],
 		"abilities" :

--- a/config/creatures/neutral.json
+++ b/config/creatures/neutral.json
@@ -367,7 +367,7 @@
 	{
 		"index": 136,
 		"level": 6,
-		"extraNames": [ "enchanters" ],
+		"compatibilityIdentifiers": [ "enchanters" ],
 		"faction": "neutral",
 		"excludeFromRandomization" : true,
 		"shots" : 32,
@@ -457,7 +457,7 @@
 	{
 		"index": 137,
 		"level": 4,
-		"extraNames": [ "sharpshooters" ],
+		"compatibilityIdentifiers": [ "sharpshooters" ],
 		"faction": "neutral",
 		"excludeFromRandomization" : true,
 		"shots" : 32,

--- a/config/creatures/stronghold.json
+++ b/config/creatures/stronghold.json
@@ -3,7 +3,7 @@
 	{
 		"index": 84,
 		"level": 1,
-		"extraNames": [ "goblins" ],
+		"compatibilityIdentifiers": [ "goblins" ],
 		"faction": "stronghold",
 		"upgrades": ["hobgoblin"],
 		"graphics" :

--- a/config/creatures/tower.json
+++ b/config/creatures/tower.json
@@ -3,7 +3,7 @@
 	{
 		"index": 28,
 		"level": 1,
-		"extraNames": [ "apprenticeGremlin" ],
+		"compatibilityIdentifiers": [ "apprenticeGremlin" ],
 		"faction": "tower",
 		"upgrades": ["masterGremlin"],
 		"hasDoubleWeek": true,

--- a/config/schemas/artifact.json
+++ b/config/schemas/artifact.json
@@ -21,6 +21,13 @@
 	},
 	"additionalProperties" : false,
 	"properties" : {
+		"compatibilityIdentifiers" : {
+			"type" : "array",
+			"items" : {
+				"type" : "string"
+			},
+			"description" : "Additional identifiers that may refer to this object, to provide compatibility after object has been renamed"
+		},
 		"warMachine" :
 		{
 			"type" : "string",

--- a/config/schemas/battlefield.json
+++ b/config/schemas/battlefield.json
@@ -6,6 +6,13 @@
 	"required" : [ "graphics" ],
 	"additionalProperties" : false,
 	"properties" : {
+		"compatibilityIdentifiers" : {
+			"type" : "array",
+			"items" : {
+				"type" : "string"
+			},
+			"description" : "Additional identifiers that may refer to this object, to provide compatibility after object has been renamed"
+		},
 		"name" : {
 			"type" : "string",
 			"description" : "Human-readable name of the battlefield"

--- a/config/schemas/bonus.json
+++ b/config/schemas/bonus.json
@@ -6,6 +6,14 @@
 	"required" : [],
 	"additionalProperties" : false,
 	"properties" : {
+		"compatibilityIdentifiers" : {
+			"type" : "array",
+			"items" : {
+				"type" : "string"
+			},
+			"description" : "Additional identifiers that may refer to this object, to provide compatibility after object has been renamed"
+		},
+
 		"hidden" : {
 			"type" : "boolean",
 			"description" : "If set to true, all instances of this bonus will be hidden in UI"

--- a/config/schemas/creature.json
+++ b/config/schemas/creature.json
@@ -49,6 +49,13 @@
 	],
 	"additionalProperties" : false,
 	"properties" : {
+		"compatibilityIdentifiers" : {
+			"type" : "array",
+			"items" : {
+				"type" : "string"
+			},
+			"description" : "Additional identifiers that may refer to this object, to provide compatibility after object has been renamed"
+		},
 		"special" : {
 			"type" : "boolean",
 			"description" : "Marks this object as special and not available by default"

--- a/config/schemas/faction.json
+++ b/config/schemas/faction.json
@@ -36,6 +36,13 @@
 	},
 	"additionalProperties" : false,
 	"properties" : {
+		"compatibilityIdentifiers" : {
+			"type" : "array",
+			"items" : {
+				"type" : "string"
+			},
+			"description" : "Additional identifiers that may refer to this object, to provide compatibility after object has been renamed"
+		},
 		"name" : {
 			"type" : "string",
 			"description" : "Localizable faction name, e.g. Rampart"

--- a/config/schemas/hero.json
+++ b/config/schemas/hero.json
@@ -14,6 +14,13 @@
 	],
 	"additionalProperties" : false,
 	"properties" : {
+		"compatibilityIdentifiers" : {
+			"type" : "array",
+			"items" : {
+				"type" : "string"
+			},
+			"description" : "Additional identifiers that may refer to this object, to provide compatibility after object has been renamed"
+		},
 		"special" : {
 			"type" : "boolean",
 			"description" : "If set to true hero will be unavailable on start and won't appear in taverns (campaign heroes)"

--- a/config/schemas/heroClass.json
+++ b/config/schemas/heroClass.json
@@ -10,6 +10,13 @@
 	],
 	"additionalProperties" : false,
 	"properties" : {
+		"compatibilityIdentifiers" : {
+			"type" : "array",
+			"items" : {
+				"type" : "string"
+			},
+			"description" : "Additional identifiers that may refer to this object, to provide compatibility after object has been renamed"
+		},
 		"name" : {
 			"type" : "string",
 			"description" : "Translatable name of hero class"

--- a/config/schemas/object.json
+++ b/config/schemas/object.json
@@ -7,6 +7,13 @@
 	"additionalProperties" : false,
 
 	"properties" : {
+		"compatibilityIdentifiers" : {
+			"type" : "array",
+			"items" : {
+				"type" : "string"
+			},
+			"description" : "Additional identifiers that may refer to this object, to provide compatibility after object has been renamed"
+		},
 		"name" : {
 			"type" : "string"
 		},

--- a/config/schemas/objectType.json
+++ b/config/schemas/objectType.json
@@ -6,6 +6,13 @@
 	"required" : [ ],
 	"additionalProperties" : true, // may have type-dependant properties
 	"properties" : {
+		"compatibilityIdentifiers" : {
+			"type" : "array",
+			"items" : {
+				"type" : "string"
+			},
+			"description" : "Additional identifiers that may refer to this object, to provide compatibility after object has been renamed"
+		},
 		"index" : {
 			"type" : "number"
 		},

--- a/config/schemas/resources.json
+++ b/config/schemas/resources.json
@@ -6,6 +6,13 @@
 	"required" : [ "name", "price" ],
 	"additionalProperties" : false,
 	"properties" : {
+		"compatibilityIdentifiers" : {
+			"type" : "array",
+			"items" : {
+				"type" : "string"
+			},
+			"description" : "Additional identifiers that may refer to this object, to provide compatibility after object has been renamed"
+		},
 		"index" : {
 			"type" : "number",
 			"description" : "numeric id of h3 resource, prohibited for new resources"

--- a/config/schemas/river.json
+++ b/config/schemas/river.json
@@ -6,6 +6,13 @@
 	"required" : [ "shortIdentifier", "text", "tilesFilename", "delta" ],
 	"additionalProperties" : false,
 	"properties" : {
+		"compatibilityIdentifiers" : {
+			"type" : "array",
+			"items" : {
+				"type" : "string"
+			},
+			"description" : "Additional identifiers that may refer to this object, to provide compatibility after object has been renamed"
+		},
 		"shortIdentifier" :
 		{
 			"type" : "string",

--- a/config/schemas/road.json
+++ b/config/schemas/road.json
@@ -6,6 +6,13 @@
 	"required" : [ "shortIdentifier", "text", "tilesFilename", "moveCost" ],
 	"additionalProperties" : false,
 	"properties" : {
+		"compatibilityIdentifiers" : {
+			"type" : "array",
+			"items" : {
+				"type" : "string"
+			},
+			"description" : "Additional identifiers that may refer to this object, to provide compatibility after object has been renamed"
+		},
 		"shortIdentifier" :
 		{
 			"type" : "string",

--- a/config/schemas/skill.json
+++ b/config/schemas/skill.json
@@ -51,6 +51,13 @@
 	},
 	"required" : ["name", "basic", "advanced", "expert", "specialty", "gainChance" ],
 	"properties" : {
+		"compatibilityIdentifiers" : {
+			"type" : "array",
+			"items" : {
+				"type" : "string"
+			},
+			"description" : "Additional identifiers that may refer to this object, to provide compatibility after object has been renamed"
+		},
 		"name" : {
 			"type" : "string",
 			"description" : "Mandatory, localizable skill name"

--- a/config/schemas/spell.json
+++ b/config/schemas/spell.json
@@ -513,6 +513,13 @@
 	],
 	
 	"properties" : {
+		"compatibilityIdentifiers" : {
+			"type" : "array",
+			"items" : {
+				"type" : "string"
+			},
+			"description" : "Additional identifiers that may refer to this object, to provide compatibility after object has been renamed"
+		},
 		"index" : {
 			"type" : "number",
 			"description" : "numeric id of spell required only for original spells, prohibited for new spells"

--- a/config/schemas/spellSchool.json
+++ b/config/schemas/spellSchool.json
@@ -6,6 +6,13 @@
 	"required" : [ "schoolBorders", "name" ],
 	"additionalProperties" : false,
 	"properties" : {
+		"compatibilityIdentifiers" : {
+			"type" : "array",
+			"items" : {
+				"type" : "string"
+			},
+			"description" : "Additional identifiers that may refer to this object, to provide compatibility after object has been renamed"
+		},
 		"index" : {
 			"type" : "number",
 			"description" : "numeric id of h3 spell school, prohibited for new schools"

--- a/config/schemas/terrain.json
+++ b/config/schemas/terrain.json
@@ -6,6 +6,13 @@
 	"required" : [ "text", "moveCost", "minimapUnblocked", "minimapBlocked", "music", "tiles", "type", "allowedLayers", "horseSound", "horseSoundPenalty", "shortIdentifier", "battleFields" ],
 	"additionalProperties" : false,
 	"properties" : {
+		"compatibilityIdentifiers" : {
+			"type" : "array",
+			"items" : {
+				"type" : "string"
+			},
+			"description" : "Additional identifiers that may refer to this object, to provide compatibility after object has been renamed"
+		},
 		"text" :
 		{
 			"type" : "string",

--- a/docs/modders/Updating_Mods.md
+++ b/docs/modders/Updating_Mods.md
@@ -1,0 +1,50 @@
+# Updating Mods
+
+## Hints to preserve save and map compatibility
+
+While in some cases save-breaking changes are unavoidable, in many cases it is possible to avoid save breakage.
+
+Things that are safe to change:
+
+- Generally, properties of various game entities such as heroes, creatures, or artifacts, are safe to change, and in many cases - will apply immediately to the ongoing games. Some properties such as heroes armies or adventure map object configuration is only loaded on map start. Such change will only apply on starting a new game or restarting scenario in case of campaign.
+- Mod updates that add new objects to existing mod are safe. New objects will be considered banned and will not appear in ongoing save, but save can still be loaded after such change.
+
+Things that need caution when changing:
+
+- Moving game entity into a different submod is safe on its own, however should be restricted to new submods, or to mods that player is likely to have enabled. Game can load save after moving entity to another submod, but only if submod to which this entity was moved to is also enabled
+- Renaming a game entity can only be done while providing hint for the game on how to replace it. See [Compatibility identifiers field](#compatibility-identifiers-field) for details.
+- Removing a game entity should be avoided if possible. Instead consider marking it as "special" to ban it from random selection in new saves to give players time to finish ungoing games, and after some period - remove it with some replacement using [Compatibility identifiers field](#compatibility-identifiers-field)
+
+Things that are guaranteed to break the save:
+
+- Removing or renaming an object without providing `compatibilityIdentifiers` field
+- Moving a game entity to another mod (and not a submod within same main mod)
+- Making you mod depend on another mod will break save since list of main mods from a save can't be changed right now
+
+### Compatibility identifiers field
+
+All game entities support field named `compatibilityIdentifiers`. This field allows VCMI to locate renamed entities or to provide fallback for removed objects. For example, if your mod has hero named `archibald` and at some point you've decided to rename it to `roland`, you can add following code:
+
+```json
+"roland" : {
+	"compatibilityIdentifiers" : [ "archibald`" ],
+	...
+}
+```
+
+With this code, when VCMI locates hero named `archibald` when loading old save or old map, it will automatically replace `archibald` with `roland`. Same approach should be used for small changes, for example to fix a typo in entity name. Renaming an object without providing this field **will break saves and maps for all players using your mod**.
+
+Similarly, when you need to remove an object, please provide some reasonable fallback for game to auto-replace your entity using this field. It can be used not only for renames, but also to completely replace an entity, including to existing one, so if you're removing it without replacement, this field can be used to replace entity with some other object that existed before and is not removed.
+
+### Updating map after mod update
+
+If one of mods on which your map depends made a map-breaking change and map can no longer be loaded in game, best option is to try to contact original mod author and ask it to provide save compability support as described on this page.
+
+If contacting author is not possible or you wish to fix your map on your own, you can instead:
+
+1. Alternatively, you can add map compability to the mod on your own using instructions from this page.
+2. If changes are too major and can't be fixed via map compability tools, rename your map from `xxx.vmap` to `xxx.zip`, extract map as zip archive.
+3. Open contained files using text editor such as Notepad++ and try to fix map manually, for example by removing broken objects or by renaming them to some other existing entity.
+4. After you've made the changes, recreate .zip archive and rename it back to `xxx.vmap` and test loading of map in game
+5. Once your map can be loaded, re-save map in map editor using fixed version of the mod
+6. If possible, update mod with changes that you've made, if any.

--- a/lib/CBonusTypeHandler.cpp
+++ b/lib/CBonusTypeHandler.cpp
@@ -40,8 +40,8 @@ CBonusTypeHandler::CBonusTypeHandler()
 	//register predefined bonus types
 
 	// MOD COMPATIBILITY FOR 1.6
-	registerObject(ModScope::scopeBuiltin(), "bonus", "FEAR", 0);
-	registerObject(ModScope::scopeBuiltin(), "bonus", "FEARLESS", 0);
+	registerObject(ModScope::scopeBuiltin(), "bonus", "FEAR", JsonNode(), 0);
+	registerObject(ModScope::scopeBuiltin(), "bonus", "FEARLESS", JsonNode(), 0);
 
 #define BONUS_NAME(x) { #x },
 	builtinBonusNames = {
@@ -53,7 +53,7 @@ CBonusTypeHandler::CBonusTypeHandler()
 		bonusTypes.push_back(std::make_shared<CBonusType>());
 
 	for (int i = 0; i < builtinBonusNames.size(); ++i)
-		registerObject(ModScope::scopeBuiltin(), "bonus", builtinBonusNames[i], i);
+		registerObject(ModScope::scopeBuiltin(), "bonus", builtinBonusNames[i], JsonNode(), i);
 }
 
 CBonusTypeHandler::~CBonusTypeHandler() = default;
@@ -129,7 +129,7 @@ void CBonusTypeHandler::loadObject(std::string scope, std::string name, const Js
 	else
 	{
 		// new bonus
-		registerObject(scope, "bonus", name, bonusTypes.size());
+		registerObject(scope, "bonus", name, data, bonusTypes.size());
 		bonusTypes.push_back(std::make_shared<CBonusType>());
 		loadItem(data, *bonusTypes.back(), name);
 		logBonus->trace("New bonus type %s", name);

--- a/lib/CCreatureHandler.cpp
+++ b/lib/CCreatureHandler.cpp
@@ -656,12 +656,6 @@ std::shared_ptr<CCreature> CCreatureHandler::loadFromJson(const std::string & sc
 	loadJsonAnimation(cre.get(), node["graphics"]);
 	loadCreatureJson(cre.get(), node);
 
-	for(const auto & extraName : node["extraNames"].Vector())
-	{
-		for(const auto & type_name : getTypeNames())
-			registerObject(scope, type_name, extraName.String(), cre->getIndex());
-	}
-
 	if (!cre->special &&
 		!CResourceHandler::get()->existsResource(cre->animDefName) &&
 		!CResourceHandler::get()->existsResource(cre->animDefName.toType<EResType::JSON>()) &&

--- a/lib/IHandlerBase.h
+++ b/lib/IHandlerBase.h
@@ -21,7 +21,8 @@ protected:
 	static std::string getScopeBuiltin();
 
 	/// Calls modhandler. Mostly needed to avoid large number of includes in headers
-	static void registerObject(const std::string & scope, const std::string & type_name, const std::string & name, si32 index);
+	void registerObject(const std::string & scope, const std::string & typeName, const std::string & name, const JsonNode & data, si32 index);
+	void registerObject(const std::string & scope, const std::vector<std::string> & typeNames, const std::string & name, const JsonNode & data, si32 index);
 
 public:
 	/// loads all original game data in vector of json nodes
@@ -91,18 +92,14 @@ public:
 	void loadObject(std::string scope, std::string name, const JsonNode & data) override
 	{
 		objects.push_back(loadFromJson(scope, data, name, objects.size()));
-
-		for(const auto & type_name : getTypeNames())
-			registerObject(scope, type_name, name, objects.back()->getIndex());
+		registerObject(scope, getTypeNames(), name, data, objects.back()->getIndex());
 	}
 
 	void loadObject(std::string scope, std::string name, const JsonNode & data, size_t index) override
 	{
 		assert(objects[index] == nullptr); // ensure that this id was not loaded before
 		objects[index] = loadFromJson(scope, data, name, index);
-
-		for(const auto & type_name : getTypeNames())
-			registerObject(scope, type_name, name, objects[index]->getIndex());
+		registerObject(scope, getTypeNames(), name, data, index);
 	}
 
 	const _Object * operator[] (const _ObjectID id) const

--- a/lib/campaign/CampaignRegionsHandler.cpp
+++ b/lib/campaign/CampaignRegionsHandler.cpp
@@ -22,7 +22,7 @@ std::vector<JsonNode> CampaignRegionsHandler::loadLegacyData()
 void CampaignRegionsHandler::loadObject(std::string scope, std::string name, const JsonNode & data)
 {
 	auto object = std::make_shared<CampaignRegions>(data);
-	registerObject(scope, "campaignRegion", name, objects.size());
+	registerObject(scope, "campaignRegion", name, data, objects.size());
 	objects.push_back(object);
 }
 

--- a/lib/entities/artifact/CArtHandler.cpp
+++ b/lib/entities/artifact/CArtHandler.cpp
@@ -112,7 +112,7 @@ void CArtHandler::loadObject(std::string scope, std::string name, const JsonNode
 
 	objects.emplace_back(object);
 
-	registerObject(scope, "artifact", name, object->id.getNum());
+	registerObject(scope, "artifact", name, data, object->id.getNum());
 }
 
 void CArtHandler::loadObject(std::string scope, std::string name, const JsonNode & data, size_t index)
@@ -124,7 +124,7 @@ void CArtHandler::loadObject(std::string scope, std::string name, const JsonNode
 	assert(objects[index] == nullptr); // ensure that this id was not loaded before
 	objects[index] = object;
 
-	registerObject(scope, "artifact", name, object->id.getNum());
+	registerObject(scope, "artifact", name, data, object->id.getNum());
 }
 
 const std::vector<std::string> & CArtHandler::getTypeNames() const

--- a/lib/entities/faction/CTownHandler.cpp
+++ b/lib/entities/faction/CTownHandler.cpp
@@ -406,7 +406,7 @@ void CTownHandler::loadBuilding(CTown * town, const std::string & stringID, cons
 		}
 	}
 
-	registerObject(source.getModScope(), ret->town->getBuildingScope(), ret->identifier, ret->bid.getNum());
+	registerObject(source.getModScope(), ret->town->getBuildingScope(), ret->identifier, source, ret->bid.getNum());
 }
 
 void CTownHandler::loadBuildings(CTown * town, const JsonNode & source)
@@ -854,7 +854,7 @@ void CTownHandler::loadObject(std::string scope, std::string name, const JsonNod
 		});
 	}
 
-	registerObject(scope, "faction", name, object->index.getNum());
+	registerObject(scope, "faction", name, data, object->index.getNum());
 }
 
 void CTownHandler::loadObject(std::string scope, std::string name, const JsonNode & data, size_t index)
@@ -885,7 +885,7 @@ void CTownHandler::loadObject(std::string scope, std::string name, const JsonNod
 		});
 	}
 
-	registerObject(scope, "faction", name, object->index.getNum());
+	registerObject(scope, "faction", name, data, object->index.getNum());
 }
 
 void CTownHandler::loadRandomFaction()

--- a/lib/entities/hero/CHeroHandler.cpp
+++ b/lib/entities/hero/CHeroHandler.cpp
@@ -370,10 +370,7 @@ void CHeroHandler::loadObject(std::string scope, std::string name, const JsonNod
 
 	objects.emplace_back(object);
 
-	registerObject(scope, "hero", name, object->getIndex());
-
-	for(const auto & compatID : data["compatibilityIdentifiers"].Vector())
-		registerObject(scope, "hero", compatID.String(), object->getIndex());
+	registerObject(scope, "hero", name, data, object->getIndex());
 }
 
 void CHeroHandler::loadObject(std::string scope, std::string name, const JsonNode & data, size_t index)
@@ -384,9 +381,7 @@ void CHeroHandler::loadObject(std::string scope, std::string name, const JsonNod
 	assert(objects[index] == nullptr); // ensure that this id was not loaded before
 	objects[index] = object;
 
-	registerObject(scope, "hero", name, object->getIndex());
-	for(const auto & compatID : data["compatibilityIdentifiers"].Vector())
-		registerObject(scope, "hero", compatID.String(), object->getIndex());
+	registerObject(scope, "hero", name, data, object->getIndex());
 }
 
 ui32 CHeroHandler::level (TExpType experience) const

--- a/lib/mapObjectConstructors/CObjectClassesHandler.cpp
+++ b/lib/mapObjectConstructors/CObjectClassesHandler.cpp
@@ -175,14 +175,7 @@ void CObjectClassesHandler::loadSubObject(const std::string & scope, const std::
 	assert(subObject);
 	baseObject->objectTypeHandlers.push_back(subObject);
 
-	registerObject(scope, baseObject->getJsonKey(), subObject->getSubTypeName(), subObject->subtype);
-	for(const auto & compatID : entry["compatibilityIdentifiers"].Vector())
-	{
-		if (identifier != compatID.String())
-			registerObject(scope, baseObject->getJsonKey(), compatID.String(), subObject->subtype);
-		else
-			logMod->warn("Mod '%s' map object '%s': compatibility identifier has same name as object itself!", scope, identifier);
-	}
+	registerObject(scope, baseObject->getJsonKey(), subObject->getSubTypeName(), entry, subObject->subtype);
 }
 
 void CObjectClassesHandler::loadSubObject(const std::string & scope, const std::string & identifier, const JsonNode & entry, ObjectClass * baseObject, size_t index)
@@ -195,14 +188,7 @@ void CObjectClassesHandler::loadSubObject(const std::string & scope, const std::
 
 	baseObject->objectTypeHandlers.at(index) = subObject;
 
-	registerObject(scope, baseObject->getJsonKey(), subObject->getSubTypeName(), subObject->subtype);
-	for(const auto & compatID : entry["compatibilityIdentifiers"].Vector())
-	{
-		if (identifier != compatID.String())
-			registerObject(scope, baseObject->getJsonKey(), compatID.String(), subObject->subtype);
-		else
-			logMod->warn("Mod '%s' map object '%s': compatibility identifier has same name as object itself!");
-	}
+	registerObject(scope, baseObject->getJsonKey(), subObject->getSubTypeName(), entry, subObject->subtype);
 }
 
 TObjectTypeHandler CObjectClassesHandler::loadSubObjectFromJson(const std::string & scope, const std::string & identifier, const JsonNode & entry, ObjectClass * baseObject, size_t index)
@@ -597,7 +583,7 @@ void CObjectClassesHandler::generateExtraMonolithsForRMG(ObjectClass * container
 
 		portalVec.push_back(newPortal);
 
-		registerObject(newPortal->modScope, container->getJsonKey(), newPortal->subTypeName, newPortal->subtype);
+		registerObject(newPortal->modScope, container->getJsonKey(), newPortal->subTypeName, JsonNode(), newPortal->subtype);
 	}
 }
 

--- a/lib/spells/SpellSchoolHandler.cpp
+++ b/lib/spells/SpellSchoolHandler.cpp
@@ -55,14 +55,14 @@ std::shared_ptr<spells::SpellSchoolType> SpellSchoolHandler::loadObjectImpl(std:
 void SpellSchoolHandler::loadObject(std::string scope, std::string name, const JsonNode & data)
 {
 	objects.push_back(loadObjectImpl(scope, name, data, objects.size()));
-	registerObject(scope, "spellSchool", name, objects.back()->getIndex());
+	registerObject(scope, "spellSchool", name, data, objects.back()->getIndex());
 }
 
 void SpellSchoolHandler::loadObject(std::string scope, std::string name, const JsonNode & data, size_t index)
 {
 	assert(objects[index] == nullptr); // ensure that this id was not loaded before
 	objects[index] = loadObjectImpl(scope, name, data, index);
-	registerObject(scope, "spellSchool", name, objects[index]->getIndex());
+	registerObject(scope, "spellSchool", name, data, objects[index]->getIndex());
 }
 
 std::vector<SpellSchool> SpellSchoolHandler::getAllObjects() const


### PR DESCRIPTION
Now `compatibilityIdentifers` field is supported for all game entities. As result it is now possible for mods to provide compatibility support for loading mods and saves made with older version of the mod.

Also, added docs to specify what exactly breaks saves with mods updates and ways to avoid that