### PR TITLE
Fixes TIMES_STACK_SIZE updater

### DIFF
--- a/config/schemas/bonusInstance.json
+++ b/config/schemas/bonusInstance.json
@@ -254,6 +254,11 @@
 							"minimum" : 1,
 							"description" : "Size of each step, in levels"
 						},
+						"stepValue" : {
+							"type" : "integer",
+							"minimum" : 1,
+							"description" : "Bonus value per each step"
+						},
 						"minimum" : {
 							"type" : "integer",
 							"description" : "Minimal bonus value"

--- a/docs/modders/Bonus/Bonus_Updaters.md
+++ b/docs/modders/Bonus/Bonus_Updaters.md
@@ -82,7 +82,7 @@ Usage:
 
 ## TIMES_STACK_SIZE
 
-Effect: Updates val to `val = clamp(val * floor(stackSize / stepSize), minimum, maximum)`, where stackSize is total number of creatures in current unit stack
+Effect: Updates val to `val = stepValue * clamp(val * floor(stackSize / stepSize), minimum, maximum)`, where stackSize is total number of creatures in current unit stack.
 
 Example of short form with default parameters:
 
@@ -104,6 +104,8 @@ Example of long form with custom parameters:
     
     // Optional, by default - 1
     "stepSize" : 2
+    // Optional, by default - 1
+    "stepValue" : 2
 }
 ```
 

--- a/lib/battle/BattleInfo.cpp
+++ b/lib/battle/BattleInfo.cpp
@@ -744,6 +744,11 @@ void BattleInfo::setUnitState(uint32_t id, const JsonNode & data, int64_t health
 		changedStack->removeBonusesRecursive(Bonus::UntilBeingAttacked);
 	}
 
+	if(healthDelta < 0)
+	{
+		changedStack->nodeHasChanged();	//bonuses with TIMES_STACK_SIZE updater may change
+	}
+
 	resurrected = resurrected || (killed && changedStack->alive());
 
 	if(killed)

--- a/lib/bonuses/Updaters.cpp
+++ b/lib/bonuses/Updaters.cpp
@@ -121,7 +121,7 @@ JsonNode TimesHeroLevelDivideStackLevelUpdater::toJsonNode() const
 std::shared_ptr<Bonus> TimesStackSizeUpdater::apply(const std::shared_ptr<Bonus> & b, int count) const
 {
 	auto newBonus = std::make_shared<Bonus>(*b);
-	newBonus->val *= std::clamp(count / stepSize, minimum, maximum);
+	newBonus->val = stepValue * std::clamp(count / stepSize, minimum, maximum);
 	return newBonus;
 }
 

--- a/lib/bonuses/Updaters.h
+++ b/lib/bonuses/Updaters.h
@@ -92,12 +92,14 @@ class DLL_LINKAGE TimesStackSizeUpdater : public IUpdater
 	int minimum = std::numeric_limits<int>::min();
 	int maximum = std::numeric_limits<int>::max();
 	int stepSize = 1;
+	int stepValue = 1;
 public:
 	TimesStackSizeUpdater() = default;
-	TimesStackSizeUpdater(int minimum, int maximum, int stepSize)
+	TimesStackSizeUpdater(int minimum, int maximum, int stepSize, int stepValue)
 		: minimum(minimum)
 		, maximum(maximum)
 		, stepSize(stepSize)
+		, stepValue(stepValue)
 	{}
 
 	std::shared_ptr<Bonus> createUpdatedBonus(const std::shared_ptr<Bonus> & b, const CBonusSystemNode & context) const override;

--- a/lib/json/JsonBonus.cpp
+++ b/lib/json/JsonBonus.cpp
@@ -444,12 +444,13 @@ static TUpdaterPtr parseUpdater(const JsonNode & updaterJson)
 			int minimum = updaterJson["minimum"].isNull() ? std::numeric_limits<int>::min() : updaterJson["minimum"].Integer();
 			int maximum = updaterJson["maximum"].isNull() ? std::numeric_limits<int>::max() : updaterJson["maximum"].Integer();
 			int stepSize = updaterJson["stepSize"].Integer();
+			int stepValue = updaterJson["stepValue"].Integer();
 			if (minimum > maximum)
 			{
 				logMod->warn("TIMES_STACK_SIZE updater: minimum value (%d) is above maximum value(%d)!", minimum, maximum);
-				return std::make_shared<TimesStackSizeUpdater>(maximum, minimum, std::max(1, stepSize));
+				return std::make_shared<TimesStackSizeUpdater>(maximum, minimum, std::max(1, stepSize), std::max(1, stepValue));
 			}
-			return std::make_shared<TimesStackSizeUpdater>(minimum, maximum, std::max(1, stepSize));
+			return std::make_shared<TimesStackSizeUpdater>(minimum, maximum, std::max(1, stepSize), std::max(1, stepValue));
 		}
 		if(updaterJson["type"].String() == "TIMES_ARMY_SIZE")
 		{


### PR DESCRIPTION
It fixes #6804.
The problem lies in the fact that CStack inherits this bonus from CCreature, and both of them apply this bonus independently.
Adding a separate parameter so the updater won't overwrite the value it uses for calculation is IMO the best solution, even if it changes the JSON scheme. Backward compatibility is doable, but I am not sure if it is needed. A search through Vcmi-mods repository shows no instance of this updater being used yet.

PS: the if statement in BattleInfo was added separately from a similar statement above to not create conflicts with pr #6810.