### PR TITLE
Fix movement point cost of Advanced Town Portal

### DIFF
--- a/config/spells/adventure.json
+++ b/config/spells/adventure.json
@@ -420,9 +420,7 @@
 			},
 			"advanced":{
 				"adventureEffect" : {
-					"allowTownSelection" : true,
-					"movementPointsRequired" : 200,
-					"movementPointsTaken" : 200
+					"allowTownSelection" : true
 				}
 			},
 			"expert":{


### PR DESCRIPTION
This PR addresses the wrong movement point cost when casting Town Portal with Advanced Earth Magic. I tested against SoD with only HD mod active to see movement points and this is the result:

before casting
<img width="436" height="94" alt="beforeadvtp" src="https://github.com/user-attachments/assets/df624dad-7806-4091-8729-d05e47dfbea7" />

after casting
<img width="390" height="76" alt="afteradvtp" src="https://github.com/user-attachments/assets/1b1da67f-aaf7-4e13-a88f-7a826e56424f" />


--> cost should be 300 and only reduce to 200 on Expert.