### PR TITLE
[1.7.3] Fix mod description and changelog position

### DIFF
--- a/launcher/modManager/cmodlistview_moc.cpp
+++ b/launcher/modManager/cmodlistview_moc.cpp
@@ -577,6 +577,15 @@ void CModListView::dataChanged(const QModelIndex & topleft, const QModelIndex & 
 	selectMod(ui->allModsView->currentIndex());
 }
 
+static void scrollTextBrowserToTop(QTextBrowser* browser)
+{
+	QTimer::singleShot(0, browser, [browser]()
+	{
+		browser->moveCursor(QTextCursor::Start);
+		browser->verticalScrollBar()->setValue(0);
+	});
+}
+
 void CModListView::selectMod(const QModelIndex & index)
 {
 	ui->tabWidget->setCurrentIndex(0);
@@ -598,6 +607,9 @@ void CModListView::selectMod(const QModelIndex & index)
 
 		Helper::enableScrollBySwiping(ui->modInfoBrowser);
 		Helper::enableScrollBySwiping(ui->changelogBrowser);
+
+		scrollTextBrowserToTop(ui->modInfoBrowser);
+		scrollTextBrowserToTop(ui->changelogBrowser);
 
 		auto state = buttonEnabledState(modName, mod);
 


### PR DESCRIPTION
Make sure to be always on top in mod description and changelog

1.7.2
![Screenshot_20260216_135908](https://github.com/user-attachments/assets/c31a8e0b-aa0a-42ee-a742-e3e8e4e4230b)

After this tweak:
![Screenshot_20260216_135924](https://github.com/user-attachments/assets/4bb8dd13-ba52-45ba-ad05-3309a290d16e)
