### PR TITLE
[1.7.3] Fix frozen UI on Android after unlocking device

### DIFF
--- a/android/vcmi-app/src/main/java/eu/vcmi/vcmi/VcmiSDLActivity.java
+++ b/android/vcmi-app/src/main/java/eu/vcmi/vcmi/VcmiSDLActivity.java
@@ -12,8 +12,11 @@ import android.os.Messenger;
 import android.os.RemoteException;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.WindowManager;
 
 import org.libsdl.app.SDLActivity;
+
+import java.lang.reflect.Method;
 
 import eu.vcmi.vcmi.util.LibsLoader;
 import eu.vcmi.vcmi.util.Log;
@@ -21,6 +24,9 @@ import eu.vcmi.vcmi.util.Log;
 public class VcmiSDLActivity extends SDLActivity
 {
     protected static final int COMMAND_USER = 0x8000;
+
+    private static final long INPUT_FOCUS_RETRY_DELAY_MS = 200;
+    private static final int INPUT_FOCUS_RETRY_COUNT = 4;
 
     final Messenger mClientMessenger = new Messenger(
             new IncomingServerMessageHandler(
@@ -120,6 +126,62 @@ public class VcmiSDLActivity extends SDLActivity
 
         finishAffinity();
         System.exit(0);
+    }
+
+
+    @Override
+    protected void onResume()
+    {
+        super.onResume();
+        scheduleInputFocusRestore();
+    }
+
+    @Override
+    public void onWindowFocusChanged(final boolean hasFocus)
+    {
+        super.onWindowFocusChanged(hasFocus);
+        if (hasFocus)
+            scheduleInputFocusRestore();
+    }
+
+    private void scheduleInputFocusRestore()
+    {
+        if (mSurface == null)
+            return;
+
+        // Some devices restore lockscreen / immersive state asynchronously.
+        // Retry a few times after resume/focus to make sure SDL input gets reattached.
+        for (int attempt = 0; attempt < INPUT_FOCUS_RETRY_COUNT; ++attempt)
+            mSurface.postDelayed(this::ensureInputFocusNow, INPUT_FOCUS_RETRY_DELAY_MS * attempt);
+    }
+
+    private void ensureInputFocusNow()
+    {
+        if (mSurface == null)
+            return;
+
+        VcmiSDLActivity.this.setWindowStyle(true);
+        getWindow().clearFlags(WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE);
+
+        mSurface.setFocusable(true);
+        mSurface.setFocusableInTouchMode(true);
+        mSurface.requestFocus();
+
+        notifySdlFocusChanged();
+    }
+
+    private void notifySdlFocusChanged()
+    {
+        try
+        {
+            final Method onNativeFocusChanged = SDLActivity.class.getDeclaredMethod("onNativeFocusChanged", boolean.class);
+            onNativeFocusChanged.setAccessible(true);
+            onNativeFocusChanged.invoke(null, true);
+        }
+        catch (ReflectiveOperationException ignored)
+        {
+            // Older/newer SDL Java wrappers may not expose onNativeFocusChanged.
+        }
     }
 
     private void initService()


### PR DESCRIPTION
This fixes UI freeze on Android which happends when you lock your device with VCMI on background. Until now was needed to switch apps and go back to VCMI to be able to click on anything. After this, it no longer exist and UI is reponsible immediately after unlocking device.

Tested on Galaxy Tab S9 FE with Android 16