### PR TITLE
fix third dragon slayer mission

### DIFF
--- a/lib/gameState/CGameStateCampaign.cpp
+++ b/lib/gameState/CGameStateCampaign.cpp
@@ -72,8 +72,9 @@ std::optional<CampaignScenarioID> CGameStateCampaign::getHeroesSourceScenario() 
 	return campaignState->lastScenario();
 }
 
-void CGameStateCampaign::trimCrossoverHeroesParameters(vstd::RNG & randomGenerator, const CampaignTravel & travelOptions)
+void CGameStateCampaign::trimCrossoverHeroesParameters(vstd::RNG & randomGenerator, const CampaignState & campaignState)
 {
+	const CampaignTravel travelOptions = campaignState.scenario(*campaignState.currentScenario()).travelOptions;
 	// TODO this logic (what should be kept) should be part of CScenarioTravel and be exposed via some clean set of methods
 	if(!travelOptions.whatHeroKeeps.experience)
 	{
@@ -180,10 +181,11 @@ void CGameStateCampaign::trimCrossoverHeroesParameters(vstd::RNG & randomGenerat
 	//trimming creatures
 	for(auto & hero : campaignHeroReplacements)
 	{
-		auto shouldSlotBeErased = [&](CStackInstance & j) -> bool
+		// a special case: only the second mission should allow transfering stacks, but the player can choose two alternative missions after the first
+		bool isThirdDragonSlayerMission = boost::starts_with(campaignState.getFilename(), "DATA/SLAYER") && campaignState.conqueredScenarios().size() == 2;
+		auto shouldSlotBeErased = [&](CStackInstance & j) -> bool		//here slots are erased
 		{
-			CreatureID crid = j.getCreatureID();
-			return !travelOptions.monstersKeptByHero.count(crid);
+			return isThirdDragonSlayerMission || !travelOptions.monstersKeptByHero.count(j.getCreatureID());
 		};
 
 		//generate list of slots without removing anything first to avoid iterator invalidation
@@ -243,7 +245,8 @@ void CGameStateCampaign::placeCampaignHeroes(vstd::RNG & randomGenerator)
 	generateCampaignHeroesToReplace();
 
 	logGlobal->debug("\tPrepare crossover heroes");
-	trimCrossoverHeroesParameters(randomGenerator, campaignState->scenario(*campaignState->currentScenario()).travelOptions);
+	trimCrossoverHeroesParameters(randomGenerator, *campaignState);
+
 
 	// remove same heroes on the map which will be added through crossover heroes
 	// INFO: we will remove heroes because later it may be possible that the API doesn't allow having heroes

--- a/lib/gameState/CGameStateCampaign.h
+++ b/lib/gameState/CGameStateCampaign.h
@@ -17,6 +17,7 @@ VCMI_LIB_NAMESPACE_BEGIN
 
 class CampaignBonus;
 struct CampaignTravel;
+class CampaignState;
 class CGHeroInstance;
 class CGameState;
 class CMap;
@@ -51,7 +52,7 @@ class CGameStateCampaign : public Serializeable
 	std::optional<CampaignBonus> currentBonus() const;
 
 	/// Trims hero parameters that should not transfer between scenarios according to travelOptions flags
-	void trimCrossoverHeroesParameters(vstd::RNG & randomGenerator, const CampaignTravel & travelOptions);
+	void trimCrossoverHeroesParameters(vstd::RNG & randomGenerator, const CampaignState & campaignState);
 
 	void replaceHeroesPlaceholders();
 	void transferMissingArtifacts(const CampaignTravel & travelOptions);


### PR DESCRIPTION
Fixes #6858
Since both missions that can be chosen as the second one of the campaign are explicitly configured to allow transferring all stacks, and I did not find any mechanism that would limit it I assume that it was also hardcoded in OG. At least I did not find any smarter way to do it. 