### PR TITLE
Fix negative morale on Cursed Ground

### DIFF
--- a/config/battlefields.json
+++ b/config/battlefields.json
@@ -129,7 +129,7 @@
 		"isSpecial" : true,
 		"bonuses": [
 			{
-				"type" : "NO_MORALE",
+				"type" : "MORALE",
 				"val" : 0,
 				"valueType" : "INDEPENDENT_MIN",
 				"description" : "@core.arraytxt.112"
@@ -148,7 +148,7 @@
 		]
 	},
 	"rough": { "graphics" : "CMBKRGH.BMP" },
-	"ship_to_ship": 
+	"ship_to_ship":
 	{
 		"graphics" : "CMBKBOAT.BMP",
 		"impassableHexes" : [


### PR DESCRIPTION
This PR addresses the issue of Cursed Ground blocking all morale procs (positive and negative) when fighting on Cursed Ground. The way it's supposed to work is that it only blocks positive morale procs, just like Spirit of Oppression.