### PR TITLE
Fix SPELLCASTER bonus regressions

### DIFF
--- a/AI/BattleAI/BattleEvaluator.cpp
+++ b/AI/BattleAI/BattleEvaluator.cpp
@@ -130,35 +130,55 @@ bool BattleEvaluator::hasWorkingTowers() const
 	return keepIntact || upperIntact || bottomIntact;
 }
 
-std::optional<PossibleSpellcast> BattleEvaluator::findBestCreatureSpell(const CStack *stack)
+std::optional<PossibleSpellcast> BattleEvaluator::findBestCreatureSpell(const CStack * stack)
 {
+	if(!stack->canCast())
+		return std::nullopt;
+
+	std::vector<SpellID> spellsToCast;
+	TConstBonusListPtr bl = stack->getBonusesOfType(BonusType::SPELLCASTER);
+
 	//TODO: faerie dragon type spell should be selected by server
-	SpellID creatureSpellToCast = cb->getBattle(battleID)->getRandomCastedSpell(CRandomGenerator::getDefault(), stack, true);
+	SpellID creatureSpellToCast = cb->getBattle(battleID)->getRandomCastedSpell(CRandomGenerator::getDefault(), stack);
 
-	if(stack->canCast() && creatureSpellToCast != SpellID::NONE)
+	for(const auto & bonus : *bl)
+		if(!bonus->parameters && bonus->subtype.as<SpellID>().hasValue())
+			spellsToCast.push_back(bonus->subtype.as<SpellID>());
+
+	if(creatureSpellToCast.hasValue())
+		spellsToCast.push_back(creatureSpellToCast);
+
+	std::vector<PossibleSpellcast> possibleCasts;
+
+	for(const auto spellID : spellsToCast)
 	{
-		const CSpell * spell = creatureSpellToCast.toSpell();
+		const CSpell * spell = spellID.toSpell();
 
-		if(spell->canBeCast(cb->getBattle(battleID).get(), spells::Mode::CREATURE_ACTIVE, stack))
+		if(!spell->canBeCast(cb->getBattle(battleID).get(), spells::Mode::CREATURE_ACTIVE, stack))
+			continue;
+
+		spells::BattleCast temp(cb->getBattle(battleID).get(), stack, spells::Mode::CREATURE_ACTIVE, spell);
+		for(auto & target : temp.findPotentialTargets())
 		{
-			std::vector<PossibleSpellcast> possibleCasts;
-			spells::BattleCast temp(cb->getBattle(battleID).get(), stack, spells::Mode::CREATURE_ACTIVE, spell);
-			for(auto & target : temp.findPotentialTargets())
-			{
-				PossibleSpellcast ps;
-				ps.dest = target;
-				ps.spell = spell;
-				evaluateCreatureSpellcast(stack, ps);
-				possibleCasts.push_back(ps);
-			}
-
-			std::sort(possibleCasts.begin(), possibleCasts.end(), [&](const PossibleSpellcast & lhs, const PossibleSpellcast & rhs) { return lhs.value > rhs.value; });
-			if(!possibleCasts.empty() && possibleCasts.front().value > 0)
-			{
-				return possibleCasts.front();
-			}
+			PossibleSpellcast ps;
+			ps.dest = target;
+			ps.spell = spell;
+			evaluateCreatureSpellcast(stack, ps);
+			possibleCasts.push_back(ps);
 		}
 	}
+
+	std::ranges::sort(
+		possibleCasts,
+		[&](const PossibleSpellcast & lhs, const PossibleSpellcast & rhs)
+		{
+			return lhs.value > rhs.value;
+		}
+	);
+
+	if(!possibleCasts.empty() && possibleCasts.front().value > 0)
+		return possibleCasts.front();
+
 	return std::nullopt;
 }
 

--- a/client/battle/BattleActionsController.cpp
+++ b/client/battle/BattleActionsController.cpp
@@ -1097,26 +1097,24 @@ void BattleActionsController::onHexLeftClicked(const BattleHex & clickedHex)
 	ENGINE->statusbar()->clear();
 }
 
-void BattleActionsController::tryActivateStackSpellcasting(const CStack *casterStack)
+void BattleActionsController::tryActivateStackSpellcasting(const CStack * casterStack)
 {
 	creatureSpells.clear();
+	TConstBonusListPtr bl = casterStack->getBonusesOfType(BonusType::SPELLCASTER);
 
-	bool spellcaster = casterStack->hasBonusOfType(BonusType::SPELLCASTER);
-	if(casterStack->canCast() && spellcaster)
+	if(casterStack->canCast() && !bl->empty())
 	{
 		// faerie dragon can cast only one, randomly selected spell until their next move
 		//TODO: faerie dragon type spell should be selected by server
 		const auto spellToCast = owner.getBattle()->getRandomCastedSpell(CRandomGenerator::getDefault(), casterStack);
 
-		if (spellToCast.hasValue())
+		if(spellToCast.hasValue())
 			creatureSpells.push_back(spellToCast.toSpell());
 	}
 
-	TConstBonusListPtr bl = casterStack->getBonusesOfType(BonusType::SPELLCASTER);
-
 	for(const auto & bonus : *bl)
 	{
-		if (!bonus->parameters && bonus->subtype.as<SpellID>().hasValue())
+		if(!bonus->parameters && bonus->subtype.as<SpellID>().hasValue())
 			creatureSpells.push_back(bonus->subtype.as<SpellID>().toSpell());
 	}
 }
@@ -1133,11 +1131,10 @@ const spells::Caster * BattleActionsController::getCurrentSpellcaster() const
 
 spells::Mode BattleActionsController::getCurrentCastMode() const
 {
-	if (heroSpellToCast)
+	if(heroSpellToCast)
 		return spells::Mode::HERO;
 	else
 		return spells::Mode::CREATURE_ACTIVE;
-
 }
 
 bool BattleActionsController::isCastingPossibleHere(const CSpell * currentSpell, const CStack *targetStack, const BattleHex & targetHex)

--- a/include/vstd/RNG.h
+++ b/include/vstd/RNG.h
@@ -70,16 +70,17 @@ namespace RandomGeneratorUtil
 	}
 
 	template<typename Container>
-	size_t nextItemWeighted(Container & container, vstd::RNG & rand)
+	int64_t nextItemWeighted(Container & container, vstd::RNG & rand)
 	{
 		assert(!container.empty());
 
 		int64_t totalWeight = std::accumulate(container.begin(), container.end(), 0);
-		assert(totalWeight > 0);
+		if(totalWeight == 0)
+			return -1;
 
 		int64_t roll = rand.nextInt64(0, totalWeight - 1);
 
-		for (size_t i = 0; i < container.size(); ++i)
+		for (int64_t i = 0; i < container.size(); ++i)
 		{
 			int chance = container[i];
 			if(roll < chance)

--- a/lib/battle/CBattleInfoCallback.cpp
+++ b/lib/battle/CBattleInfoCallback.cpp
@@ -2157,34 +2157,33 @@ SpellID CBattleInfoCallback::getRandomBeneficialSpell(vstd::RNG & rand, const ba
 	}
 }
 
-SpellID CBattleInfoCallback::getRandomCastedSpell(vstd::RNG & rand,const CStack * caster, bool includeAllowed) const
+SpellID CBattleInfoCallback::getRandomCastedSpell(vstd::RNG & rand, const CStack * caster) const
 {
 	RETURN_IF_NOT_BATTLE(SpellID::NONE);
 
 	TConstBonusListPtr bl = caster->getBonusesOfType(BonusType::SPELLCASTER);
-	if (!bl->size())
+
+	if(bl->empty())
 		return SpellID::NONE;
 
-	int totalWeight = 0;
+	std::vector<int> weights;
+
+	//spells with 0 weight are non-random, exclude them
 	for(const auto & b : *bl)
 	{
-		totalWeight += std::max(b->parameters ? b->parameters->toNumber() : 0, includeAllowed ? 1 : 0); //spells with 0 weight are non-random, exclude them
+		if(b->parameters && b->parameters->toNumber() > 0)
+			weights.push_back(b->parameters->toNumber());
+		else
+			weights.push_back(0);
 	}
 
-	if (totalWeight == 0)
+	int64_t itemIndex = RandomGeneratorUtil::nextItemWeighted(weights, rand);
+
+	if(itemIndex < 0)
 		return SpellID::NONE;
 
-	int randomPos = rand.nextInt(totalWeight - 1);
-	for(const auto & b : *bl)
-	{
-		randomPos -= std::max(b->parameters ? b->parameters->toNumber() : 0, includeAllowed ? 1 : 0);
-		if(randomPos < 0)
-		{
-			return b->subtype.as<SpellID>();
-		}
-	}
-
-	return SpellID::NONE;
+	auto result = *(bl->begin() + itemIndex);
+	return result->subtype.as<SpellID>();
 }
 
 int CBattleInfoCallback::battleGetSurrenderCost(const PlayerColor & Player) const

--- a/lib/battle/CBattleInfoCallback.h
+++ b/lib/battle/CBattleInfoCallback.h
@@ -158,7 +158,7 @@ public:
 	ESpellCastProblem battleCanCastSpell(const spells::Caster * caster, spells::Mode mode) const; //returns true if there are no general issues preventing from casting a spell
 
 	SpellID getRandomBeneficialSpell(vstd::RNG & rand, const battle::Unit * caster, const battle::Unit * target) const;
-	SpellID getRandomCastedSpell(vstd::RNG & rand, const CStack * caster, bool includeAllowed = false) const; //called at the beginning of turn for Faerie Dragon
+	SpellID getRandomCastedSpell(vstd::RNG & rand, const CStack * caster) const; //called at the beginning of turn for Faerie Dragon
 
 	std::vector<PossiblePlayerBattleAction> getClientActionsForStack(const CStack * stack, const BattleClientInterfaceData & data);
 	PossiblePlayerBattleAction getCasterAction(const CSpell * spell, const spells::Caster * caster, spells::Mode mode) const;


### PR DESCRIPTION
Fixed 1.7.2 regression of spellcaster logic when casting non-random spells.

Slight refactoring of AI code to simplify logic related to SPELLCASTER. As a side effect - AI should now be better at selecting spells if unit has multiple spells to cast.

- Fixes #6935