### PR TITLE
Luna Fire Wall tooltip damage display

### DIFF
--- a/config/heroes/conflux.json
+++ b/config/heroes/conflux.json
@@ -281,6 +281,12 @@
 					"type" : "SPECIFIC_SPELL_DAMAGE",
 					"val" : 100,
 					"valueType" : "BASE_NUMBER"
+				},
+				"fireWallTooltip" : {
+					"subtype" : "spell.fireWall",
+					"type" : "SPECIFIC_SPELL_DAMAGE",
+					"val" : 100,
+					"valueType" : "BASE_NUMBER"
 				}
 			}
 		}


### PR DESCRIPTION
This PR adds a bonus to Luna that increases the calculated damage tool top for Fire Wall according to her specialty.

Previously, it would display the damage without factoring in the increase from the specialty because Fire Wall spell has 2 parts and only the part that actually dealt damage was increased. There is no change in damage dealt, it is just displayed correctly when right-clicking in the spell book.