### PR TITLE
Bug fix Wyvern Monarch Poison chance

### DIFF
--- a/config/creatures/fortress.json
+++ b/config/creatures/fortress.json
@@ -343,7 +343,7 @@
 			{
 				"type" : "SPELL_AFTER_ATTACK",
 				"subtype" : "spell.poison",
-				"val" : 50
+				"val" : 30
 			}
 		},
 		"graphics" :


### PR DESCRIPTION
> The chance of poisoning the target is 30%.

https://heroes.thelazy.net/index.php/Poisonous

Was set to 50%.