### PR TITLE
[1.7.3] Fix window resize

### DIFF
--- a/client/renderSDL/ScreenHandler.cpp
+++ b/client/renderSDL/ScreenHandler.cpp
@@ -493,21 +493,31 @@ SDL_Window * ScreenHandler::createWindow()
 
 bool ScreenHandler::onScreenResize(bool keepWindowResolution)
 {
-	if(getPreferredWindowMode() == EWindowMode::WINDOWED && keepWindowResolution)
+	if (keepWindowResolution)
 	{
+		// Only allowed in windowed mode
+		if (getPreferredWindowMode() != EWindowMode::WINDOWED)
+			return false;
+
 		auto res = getRenderResolution();
 
-		if(res.x < heroes3Resolution.x || res.y < heroes3Resolution.y)
+		if (res.x < heroes3Resolution.x || res.y < heroes3Resolution.y)
 			return false;
 
 		Settings video = settings.write["video"];
 		video["resolution"]["width"].Integer() = res.x;
 		video["resolution"]["height"].Integer() = res.y;
-	}
-	else if(keepWindowResolution)
-		return false;
 
-	recreateWindowAndScreenBuffers();
+		// Only recreate buffers (no window changes!)
+		destroyScreenBuffers();
+		initializeScreenBuffers();
+	}
+	else
+	{
+		// Apply settings change (may resize window / change fullscreen)
+		recreateWindowAndScreenBuffers();
+	}
+
 	return true;
 }
 


### PR DESCRIPTION
Fix resize of window. Especially visible in Ubuntu 22.04.

Solution (when screen is resized by user):
```
		destroyScreenBuffers();
		initializeScreenBuffers();
```
instead of:
```
		recreateWindowAndScreenBuffers();
```
because `recreateWindowAndScreenBuffers` also calls `updateWindowState` which calls `SDL_SetWindowSize` (even is resized by user) which is the root cause of this error here.

With older SDL this bug seems also to create a infinite loop, causing screen flicker forever.

Also done a small refactoring of function to make it easier to read.