### PR TITLE
[1.8] Replace boost locale with iconv

### DIFF
--- a/.github/workflows/github.yml
+++ b/.github/workflows/github.yml
@@ -145,6 +145,7 @@ jobs:
             artifact_platform: arm64
 
     runs-on: ${{ matrix.os }}
+    continue-on-error: true
 
     defaults:
       run:

--- a/CI/before_install/linux_qt5.sh
+++ b/CI/before_install/linux_qt5.sh
@@ -16,8 +16,8 @@ sudo eatmydata apt -yq --no-install-recommends \
   -o APT::Keep-Downloaded-Packages=true \
   -o Acquire::Retries=3 -o Dpkg::Use-Pty=0 \
   install \
-  libboost-dev libboost-filesystem-dev libboost-system-dev libboost-thread-dev \
-  libboost-program-options-dev libboost-locale-dev libboost-iostreams-dev \
+  libboost-dev libboost-filesystem-dev libboost-date-time-dev \
+  libboost-program-options-dev libboost-iostreams-dev \
   libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev libsdl2-ttf-dev \
   qtbase5-dev qtbase5-dev-tools qttools5-dev qttools5-dev-tools \
   libqt5svg5-dev \

--- a/CI/before_install/linux_qt6.sh
+++ b/CI/before_install/linux_qt6.sh
@@ -16,8 +16,8 @@ sudo eatmydata apt -yq --no-install-recommends \
   -o APT::Keep-Downloaded-Packages=true \
   -o Acquire::Retries=3 -o Dpkg::Use-Pty=0 \
   install \
-  libboost-dev libboost-filesystem-dev libboost-system-dev libboost-thread-dev \
-  libboost-program-options-dev libboost-locale-dev libboost-iostreams-dev \
+  libboost-dev libboost-filesystem-dev libboost-date-time-dev \
+  libboost-program-options-dev libboost-iostreams-dev \
   libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev libsdl2-ttf-dev \
   qt6-base-dev qt6-base-dev-tools qt6-tools-dev qt6-tools-dev-tools \
   qt6-l10n-tools qt6-svg-dev \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -478,7 +478,7 @@ endif()
 #        Finding packages                  #
 ############################################
 
-set(BOOST_COMPONENTS date_time filesystem locale program_options)
+set(BOOST_COMPONENTS date_time filesystem program_options)
 if(ENABLE_INNOEXTRACT)
 	list(APPEND BOOST_COMPONENTS iostreams)
 endif()
@@ -487,6 +487,8 @@ if(Boost_MAJOR_VERSION EQUAL 1 AND Boost_MINOR_VERSION LESS 69)
 	list(APPEND BOOST_COMPONENTS system)
 	find_package(Boost 1.74.0 REQUIRED COMPONENTS ${BOOST_COMPONENTS})
 endif()
+
+find_package(Iconv REQUIRED)
 
 find_package(ZLIB REQUIRED)
 # Conan compatibility

--- a/client/renderSDL/CBitmapFont.cpp
+++ b/client/renderSDL/CBitmapFont.cpp
@@ -112,8 +112,6 @@ void CBitmapFont::loadFont(const ResourcePath & resource, std::unordered_map<Cod
 
 	for (uint32_t charIndex = 0; charIndex < symbolsInFile; ++charIndex)
 	{
-		CodePoint codepoint = TextOperations::getUnicodeCodepoint(static_cast<char>(charIndex), modEncoding);
-
 		EntryFNT symbol;
 
 		symbol.leftOffset =  read_le_u32(data.first.get() + baseIndex + charIndex * 12 + 0);
@@ -130,7 +128,15 @@ void CBitmapFont::loadFont(const ResourcePath & resource, std::unordered_map<Cod
 
 		std::copy_n(pixelData, pixelsCount, symbol.pixels.data() );
 
-		loadedChars[codepoint] = symbol;
+		try {
+			CodePoint codepoint = TextOperations::getUnicodeCodepoint(static_cast<char>(charIndex), modEncoding);
+			loadedChars[codepoint] = symbol;
+		}
+		catch (const EncodingConversionFailureException &)
+		{
+			// ignore - some encodings don't contain all 256 characters
+			logGlobal->trace("Character %d does not exists in encoding %s, ignoring", charIndex, modEncoding);
+		}
 	}
 
 	// Try to use symbol 'L' to detect font 'ascent' - number of pixels above text baseline

--- a/docs/developers/Building_Linux.md
+++ b/docs/developers/Building_Linux.md
@@ -15,13 +15,13 @@ To compile, the following packages (and their development counterparts) are need
 - SDL2 with devel packages: mixer, image, ttf
 - minizip or minizip-ng
 - zlib and zlib-devel
-- onnxruntime
-- Boost C++ libraries: program-options, filesystem, system, thread, locale
+- Boost C++ libraries: `date-time`, `iostreams`, `filesystem`, `program-options`
 - Recommended, if you want to build launcher or map editor: Qt (widget and network modules)
-- Recommended, FFmpeg libraries, if you want to watch in-game videos: libavformat and libswscale. Their name could be libavformat-devel and libswscale-devel, or ffmpeg-libs-devel or similar names.
+- Recommended, FFmpeg libraries, if you want to watch in-game videos: `libavformat` and `libswscale`. Their name could be `libavformat-devel` and `libswscale-devel`, or `ffmpeg-libs-devel` or similar names.
 - Optional:
-  - if you want to build scripting modules: LuaJIT
-  - to speed up recompilation: Ccache
+  - if you want to enable MMAI: `onnxruntime`
+  - if you want to build scripting modules: `LuaJIT`
+  - to speed up recompilation: `Ccache`
 
 ### On Debian-based systems (e.g. Ubuntu)
 
@@ -30,7 +30,7 @@ For Ubuntu and Debian you need to:
 1. Install this list of packages:
 
     ```sh
-    sudo apt-get install cmake g++ clang libsdl2-dev libsdl2-image-dev libsdl2-ttf-dev libsdl2-mixer-dev zlib1g-dev libavformat-dev libswscale-dev libboost-dev libboost-filesystem-dev libboost-system-dev libboost-thread-dev libboost-program-options-dev libboost-locale-dev libboost-iostreams-dev qt6-base-dev qt6-base-dev-tools qt6-tools-dev qt6-tools-dev-tools qt6-l10n-tools qt6-svg-dev libtbb-dev libluajit-5.1-dev liblzma-dev libsqlite3-dev libminizip-dev libsquish-dev libfmt-dev ninja-build ccache
+    sudo apt-get install cmake g++ clang libsdl2-dev libsdl2-image-dev libsdl2-ttf-dev libsdl2-mixer-dev zlib1g-dev libavformat-dev libswscale-dev libboost-dev libboost-filesystem-dev libboost-program-options-dev libboost-date-time-dev libboost-iostreams-dev qt6-base-dev qt6-base-dev-tools qt6-tools-dev qt6-tools-dev-tools qt6-l10n-tools qt6-svg-dev libtbb-dev libluajit-5.1-dev liblzma-dev libsqlite3-dev libminizip-dev libsquish-dev libfmt-dev ninja-build ccache
     ```
 
 2. Optionally, install `onnxruntime`:

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -839,8 +839,8 @@ endif()
 
 set_target_properties(vcmi PROPERTIES COMPILE_DEFINITIONS "VCMI_DLL=1")
 target_link_libraries(vcmi PUBLIC
-	minizip::minizip ZLIB::ZLIB TBB::tbb
-	${SYSTEM_LIBS} Boost::boost Boost::filesystem Boost::program_options Boost::locale Boost::date_time
+	minizip::minizip ZLIB::ZLIB TBB::tbb Iconv::Iconv
+	${SYSTEM_LIBS} Boost::boost Boost::filesystem Boost::program_options Boost::date_time
 )
 
 if(ENABLE_STATIC_LIBS AND ENABLE_CLIENT)

--- a/lib/texts/TextOperations.cpp
+++ b/lib/texts/TextOperations.cpp
@@ -17,9 +17,40 @@
 
 #include <vstd/DateUtils.h>
 
-#include <boost/locale/encoding.hpp>
+#include <iconv.h>
 
 VCMI_LIB_NAMESPACE_BEGIN
+
+template<typename FromString, typename DestString>
+FromString convertTextEncoding(const DestString & fromString, const std::string & fromEncoding, const std::string & destEncoding)
+{
+	constexpr auto fromCharSize = sizeof(typename DestString::value_type);
+	constexpr auto destCharSize = sizeof(typename FromString::value_type);
+
+	iconv_t cd = iconv_open(destEncoding.c_str(), fromEncoding.c_str());
+	if(cd == reinterpret_cast<iconv_t>(-1))
+		throw EncodingConversionFailureException("Encoding coversion failure. Invalid encoding " + fromEncoding + " -> " + destEncoding);
+
+	FromString destString;
+	// reserve large enough destination storage
+	// worst-case scenario: each input single-byte character is mapped to 4-byte long utf8 sequence
+	destString.resize(fromString.size() * 4);
+
+	// use const_cast to get char * - since iconv api for some reason requests non-const input
+	char * fromData = const_cast<char *>(reinterpret_cast<const char *>(fromString.data()));
+	char * destData = reinterpret_cast<char *>(destString.data());
+	size_t fromLeft = fromString.size() * fromCharSize;
+	size_t destLeft = destString.size() * destCharSize;
+
+	size_t ret = iconv(cd, &fromData, &fromLeft, &destData, &destLeft);
+	iconv_close(cd);
+
+	if(ret == static_cast<size_t>(-1))
+		throw EncodingConversionFailureException("Encoding coversion failure. Failed to convert text " + fromString);
+
+	destString.resize(destString.size() - destLeft / destCharSize);
+	return destString;
+}
 
 size_t TextOperations::getUnicodeCharacterSize(char firstByte)
 {
@@ -162,24 +193,7 @@ uint32_t TextOperations::getUnicodeCodepoint(char data, const std::string & enco
 
 std::string TextOperations::toUnicode(const std::string &text, const std::string &encoding)
 {
-	try {
-		return boost::locale::conv::to_utf<char>(text, encoding);
-	}
-	catch (const boost::locale::conv::conversion_error &)
-	{
-		throw std::runtime_error("Failed to convert text '" + text + "' from encoding " + encoding );
-	}
-}
-
-std::string TextOperations::fromUnicode(const std::string &text, const std::string &encoding)
-{
-	try {
-		return boost::locale::conv::from_utf<char>(text, encoding);
-	}
-	catch (const boost::locale::conv::conversion_error &)
-	{
-		throw std::runtime_error("Failed to convert text '" + text + "' to encoding " + encoding );
-	}
+	return convertTextEncoding<std::string>(text, encoding, "UTF-8");
 }
 
 void TextOperations::trimRightUnicode(std::string & text, const size_t amount)
@@ -408,7 +422,7 @@ std::optional<int> TextOperations::textSearchSimilarityScore(const std::string &
 std::string TextOperations::filesystemPathToUtf8(const boost::filesystem::path& path)
 {
 #ifdef VCMI_WINDOWS
-	return boost::locale::conv::utf_to_utf<char>(path.native());
+	return convertTextEncoding<std::string>(path.native(), "UTF-16LE", "UTF-8");
 #else
 	return path.string();
 #endif
@@ -417,7 +431,7 @@ std::string TextOperations::filesystemPathToUtf8(const boost::filesystem::path& 
 boost::filesystem::path TextOperations::Utf8TofilesystemPath(const std::string& path)
 {
 #ifdef VCMI_WINDOWS
-	return boost::filesystem::path(boost::locale::conv::utf_to_utf<wchar_t>(path));
+	return boost::filesystem::path(convertTextEncoding<std::wstring>(path, "UTF-8", "UTF-16LE"));
 #else
 	return boost::filesystem::path(path);
 #endif

--- a/lib/texts/TextOperations.h
+++ b/lib/texts/TextOperations.h
@@ -13,6 +13,13 @@
 
 VCMI_LIB_NAMESPACE_BEGIN
 
+class EncodingConversionFailureException : public std::runtime_error
+{
+public:
+	using runtime_error::runtime_error;
+};
+
+
 /// Namespace that provides utilities for unicode support (UTF-8)
 namespace TextOperations
 {
@@ -40,10 +47,6 @@ namespace TextOperations
 
 	/// converts text to UTF-8 from specified encoding or from one specified in settings
 	std::string DLL_LINKAGE toUnicode(const std::string & text, const std::string & encoding);
-
-	/// converts text from unicode to specified encoding or to one specified in settings
-	/// NOTE: usage of these functions should be avoided if possible
-	std::string DLL_LINKAGE fromUnicode(const std::string & text, const std::string & encoding);
 
 	///delete specified amount of UTF-8 characters from right
 	DLL_LINKAGE void trimRightUnicode(std::string & text, size_t amount = 1);

--- a/mapeditor/resourceExtractor/ResourceConverter.cpp
+++ b/mapeditor/resourceExtractor/ResourceConverter.cpp
@@ -19,7 +19,6 @@
 #include "Animation.h"
 
 #include <boost/filesystem/path.hpp>
-#include <boost/locale.hpp>
 
 void ResourceConverter::convertExtractedResourceFiles(ConversionOptions conversionOptions)
 {


### PR DESCRIPTION
Replaced remaining boost::locale usage with direct usage of iconv (which boost locale uses internally anyway).

May require new prebuilts, in that case - postponing merge till such new prebuilts are done