### PR TITLE
Use local mod information to decide on mod compatibility

### DIFF
--- a/launcher/modManager/modstate.cpp
+++ b/launcher/modManager/modstate.cpp
@@ -172,7 +172,7 @@ QString ModState::getDownloadUrl() const
 
 QPair<QString, QString> ModState::getCompatibleVersionRange() const
 {
-	const JsonNode & compatibility = impl.getValue("compatibility");
+	const JsonNode & compatibility = impl.getLocalValue("compatibility");
 
 	if (compatibility.isNull())
 		return {};

--- a/lib/modding/ModDescription.cpp
+++ b/lib/modding/ModDescription.cpp
@@ -191,7 +191,7 @@ ModVerificationInfo ModDescription::getVerificationInfo() const
 
 bool ModDescription::isCompatible() const
 {
-	const JsonNode & compatibility = getValue("compatibility");
+	const JsonNode & compatibility = getLocalValue("compatibility");
 
 	if (compatibility.isNull())
 		return true;


### PR DESCRIPTION
This fixes inability to enable already installed mod if there is updated version of mod in repository that is not compatible with installed VCMI version