### PR TITLE
[Weblate] small correction in wording (German)

### DIFF
--- a/Mods/vcmi/Content/config/translations/german.json
+++ b/Mods/vcmi/Content/config/translations/german.json
@@ -873,7 +873,7 @@
 	"vcmi.optionsTab.accumulate": "Akkumulieren",
 	"vcmi.optionsTab.cheatAllowed.help": "{Cheats erlauben}\nErlaubt die Eingabe von Cheats während des Spiels.",
 	"vcmi.optionsTab.cheatAllowed.hover": "Cheats erlauben",
-	"vcmi.optionsTab.chessFieldBase.help": "Wird verwendet, wenn {Spielzug-Timer} 0 erreicht. Wird einmal zu Beginn des Spiels gesetzt. Bei Erreichen von Null wird der aktuelle Zug beendet. Jeder laufende Kampf endet mit einem Verlust.",
+	"vcmi.optionsTab.chessFieldBase.help": "Wird verwendet, wenn {Spielzug-Timer} 0 erreicht. Wird einmal zu Beginn des Spiels gesetzt. Bei Erreichen von Null wird der aktuelle Zug beendet. Jeder laufende Kampf endet in einer Niederlage.",
 	"vcmi.optionsTab.chessFieldBase.hover": "Basis-Timer",
 	"vcmi.optionsTab.chessFieldBattle.help": "Wird in Kämpfen mit der KI oder im PvP-Kampf verwendet, wenn der {Einheiten-Timer} abläuft. Wird zu Beginn eines jeden Kampfes zurückgesetzt.",
 	"vcmi.optionsTab.chessFieldBattle.hover": "Kampf-Timer",


### PR DESCRIPTION
vcmi.optionsTab.chessFieldBase.help: "endet mit einem Verlust" -> "endet in einer Niederlage"

As discussed in #7048