### PR TITLE
editor: fix crash on new map with missing scope

### DIFF
--- a/mapeditor/windownewmap.cpp
+++ b/mapeditor/windownewmap.cpp
@@ -16,6 +16,7 @@
 #include "../lib/GameLibrary.h"
 #include "../lib/mapping/CMapEditManager.h"
 #include "../lib/mapping/MapFormat.h"
+#include "../lib/modding/ModScope.h"
 #include "../lib/texts/CGeneralTextHandler.h"
 #include "../lib/CRandomGenerator.h"
 #include "../lib/serializer/JsonSerializer.h"
@@ -107,6 +108,7 @@ bool WindowNewMap::loadUserSettings()
 	if (settings.isValid())
 	{
 		auto node = JsonUtils::toJson(settings);
+		node.setModScope(ModScope::scopeMap());
 		JsonDeserializer handler(nullptr, node);
 		handler.serializeStruct("lastSettings", mapGenOptions);
 		templ = mapGenOptions.getMapTemplate(); // Remember for later
@@ -189,6 +191,7 @@ void WindowNewMap::saveUserSettings()
 	JsonSerializer ser(nullptr, data);
 
 	ser.serializeStruct("lastSettings", mapGenOptions);
+	data.setModScope(ModScope::scopeMap());
 
 	auto variant = JsonUtils::toVariant(data);
 	s.setValue(newMapWindow, variant);


### PR DESCRIPTION
Map editor could crash in debug builds when opening File -> New with assertion `!scope.empty()` from IdentifierStorage:

> vcmieditor: vcmi/lib/modding/IdentifierStorage.cpp:138: static
> CIdentifierStorage::ObjectCallback CIdentifierStorage::ObjectCallback::
> fromNameAndType(const std::string&, const std::string&, const std::string&,
> const std::function<void(int)>&, bool, bool, bool):
> Assertion `!scope.empty()' failed.
>   Aborted

Root cause: map settings loaded from QSettings lose JsonNode modScope metadata. During CMapGenOptions deserialization, identifier arrays (roads) were resolved via JsonNode-based helpers that expected non-empty scope and hit the assert.

QSettings stores QVariant, which drops JsonNode metadata. Restore map scope after QVariant->Json conversion before deserialization, and set map scope on serialized settings before writing to QSettings.