### PR TITLE
Fix GCC15 uninitialized warning in ForEachVisitor

### DIFF
--- a/lib/LogicalExpression.h
+++ b/lib/LogicalExpression.h
@@ -297,11 +297,12 @@ namespace LogicalExpressionDetail
 		}
 
 		template <typename Type>
-		typename Base::Variant operator()(Type element) const
+		typename Base::Variant operator()(const Type & element) const
 		{
-			for (auto & entry : element.expressions)
+			Type result = element;
+			for (auto & entry : result.expressions)
 				entry = std::visit(*this, entry);
-			return element;
+			return result;
 		}
 	};
 


### PR DESCRIPTION
Fixes a compilation warning reported from:
lib/LogicalExpression.h:43:23

The warning was:
- `-Wuninitialized`
- synthetic temporaries 'SR.8386' and 'SR.8526' reported as used uninitialized
- triggered while std::visit instantiated copy paths for `ExpressionBase<EventCondition>::Element<ANY_OF>` and `Element<ALL_OF>`

The toolchain is GCC 15.2.0.

Root cause / trigger:
ForEachVisitor had a templated overload that accepted operator nodes by value:
```cpp
typename Base::Variant operator()(Type element) const
```

That forces a copy at the `std::visit` call boundary. With GCC 15.2.0 this instantiation path produced the uninitialized warning in variant/invoke frames for `Element<>` copies.

Fix approach:
- change overload to take const reference: `typename Base::Variant operator()(const Type & element) const`
- make an explicit local copy inside the function: `Type result = element;`
- recurse/mutate result.expressions
- return result

Why this is safe:
- behavior is preserved (the visitor still mutates and returns a copy, never the original input object)
- only copy timing/location changed (moved out of visit argument passing)
- this avoids the warning-producing copy site while keeping semantics intact