### PR TITLE
fix problems with death cloud targeting

### DIFF
--- a/client/battle/BattleActionsController.cpp
+++ b/client/battle/BattleActionsController.cpp
@@ -787,7 +787,7 @@ bool BattleActionsController::actionIsLegal(PossiblePlayerBattleAction action, c
 				if(!owner.getBattle()->battleCanShoot(currentStack, targetHex))
 					return false;
 
-				if(targetStack == nullptr && owner.getBattle()->battleCanTargetEmptyHex(currentStack))
+				if(owner.getBattle()->battleCanTargetEmptyHex(currentStack))
 				{
 					auto spellLikeAttackBonus = currentStack->getBonus(Selector::type()(BonusType::SPELL_LIKE_ATTACK));
 					const CSpell * spellDataToCheck = spellLikeAttackBonus->subtype.as<SpellID>().toSpell();

--- a/config/spells/ability.json
+++ b/config/spells/ability.json
@@ -277,7 +277,7 @@
 			}
 		},
 		"flags" : {
-			"indifferent": true
+			"negative": true
 		},
 		"targetCondition" : {
 			"noneOf" : {

--- a/docs/modders/Bonus/Bonus_Types.md
+++ b/docs/modders/Bonus/Bonus_Types.md
@@ -1246,7 +1246,7 @@ When a unit affected by this bonus dies, no corpse is left behind
 
 ### INVINCIBLE
 
-The unit affected by this bonus cannot be target of attacks or spells
+The unit affected by this bonus cannot be targeted by attacks or affected by negative spells.
 
 ### UNIT_DEFENDING
 

--- a/lib/spells/effects/UnitEffect.cpp
+++ b/lib/spells/effects/UnitEffect.cpp
@@ -19,6 +19,7 @@
 #include "../../battle/CBattleInfoCallback.h"
 #include "../../battle/Unit.h"
 #include "../../serializer/JsonSerializeFormat.h"
+#include <vcmi/spells/Spell.h>
 
 VCMI_LIB_NAMESPACE_BEGIN
 
@@ -265,6 +266,8 @@ bool UnitEffect::isValidTarget(const Mechanics * m, const battle::Unit * unit) c
 
 bool UnitEffect::isReceptive(const Mechanics * m, const battle::Unit * unit) const
 {
+	if (m->isNegativeSpell() && unit->isInvincible())
+		return false;
 	if(ignoreImmunity)
 	{
 		//ignore all immunities, except specific absolute immunity(VCMI addition)

--- a/server/battles/BattleActionProcessor.cpp
+++ b/server/battles/BattleActionProcessor.cpp
@@ -417,7 +417,9 @@ bool BattleActionProcessor::doShootAction(const CBattleInfoCallback & battle, co
 		makeAttack(battle, stack, destinationStack, 0, destination, true, true, false);
 
 	BonusList attackerBonusesToRemove = *stack->getAllBonuses(Bonus::untilAfterAttackSequence);	//they need to be gathered here since bonuses with this duration added during attack (like blind) should not be removed
-	BonusList defenderBonusesToRemove = *destinationStack->getAllBonuses(Bonus::untilAfterAttackSequence);
+	BonusList defenderBonusesToRemove;
+	if (destinationStack)
+		defenderBonusesToRemove = *destinationStack->getAllBonuses(Bonus::untilAfterAttackSequence);
 
 	//ranged counterattack
 	if (!emptyTileAreaAttack

--- a/test/spells/effects/SacrificeTest.cpp
+++ b/test/spells/effects/SacrificeTest.cpp
@@ -68,6 +68,7 @@ TEST_F(SacrificeTest, ApplicableForTwoTargets)
 
 	EXPECT_CALL(mechanicsMock, isSmart()).WillRepeatedly(Return(true));
 	EXPECT_CALL(mechanicsMock, isMassive()).WillRepeatedly(Return(false));
+	EXPECT_CALL(mechanicsMock, isNegativeSpell()).WillRepeatedly(Return(false));
 	EXPECT_CALL(mechanicsMock, alwaysHitFirstTarget()).WillRepeatedly(Return(false));
 
 	EXPECT_CALL(mechanicsMock, ownerMatches(Eq(&unit))).Times(AtLeast(1)).WillRepeatedly(Return(true));


### PR DESCRIPTION
Fixes #7046.
I work under the assumption that invincible units (i. e. Couatls under meditation) should not be targetable by anything (positive spells included).
The mentioned bug with magogs not being able to target stacks immune to magic is more complicated, and I haven't found a good solution yet. 