### PR TITLE
[CI] use `ccache` for iOS from Homebrew again

### DIFF
--- a/.github/workflows/github.yml
+++ b/.github/workflows/github.yml
@@ -267,14 +267,6 @@ jobs:
         ccache --set-config=hash_dir=true
         ccache --set-config=sloppiness=time_macros
 
-    # TODO: remove once v4.13 is available in Homebrew
-    - name: Install ccache v4.13
-      if: ${{ matrix.platform == 'ios' }}
-      run: |
-        curl -L https://github.com/ccache/ccache/releases/download/v4.13/ccache-4.13-darwin.tar.gz \
-          | tar -xf -
-        echo "$(pwd)/ccache-4.13-darwin" >> $GITHUB_PATH
-
     - name: Install Conan profile
       if: "${{ matrix.conan_profile != '' }}"
       run: |

--- a/CI/before_install/macos.sh
+++ b/CI/before_install/macos.sh
@@ -1,3 +1,5 @@
 #!/usr/bin/env bash
 
 echo DEVELOPER_DIR=/Applications/Xcode_26.2.app >> $GITHUB_ENV
+
+brew update


### PR DESCRIPTION
v4.13 is available in Homebrew now