### PR TITLE
Fix for Cornucopia not giving its intended bonus after assembling

### DIFF
--- a/config/artifacts.json
+++ b/config/artifacts.json
@@ -2232,7 +2232,7 @@
 	},
 	"cornucopia":
 	{
-		"instanceBonuses" : {
+		"bonuses" : {
 			"crystal" : {
 				"subtype" : "resource.crystal",
 				"type" : "GENERATE_RESOURCE",


### PR DESCRIPTION
In current version, Cornucopia, when assembled from it's components, does not grant any resource boost at all and only the component effects work.

This PR fixes it by changing Cornucopia's `instanceBonuses` to regular `bonuses` which fixes the behavior. 

Fixes #6893 