### PR TITLE
editor: prevent line tool assert after level switches

### DIFF
--- a/mapeditor/mainwindow.cpp
+++ b/mapeditor/mainwindow.cpp
@@ -305,6 +305,7 @@ MainWindow::MainWindow(QWidget* parent) :
 			
 			mapLevel = combo->currentIndex();
 			ui->mapView->setScene(controller.scene(mapLevel));
+			ui->mapView->resetInteractionState();
 			ui->mapView->setViewports();
 			ui->minimapView->setScene(controller.miniScene(mapLevel));
 		});
@@ -346,6 +347,7 @@ MainWindow::MainWindow(QWidget* parent) :
 	
 	ui->mapView->setScene(controller.scene(0));
 	ui->mapView->setController(&controller);
+	ui->mapView->resetInteractionState();
 	ui->mapView->setOptimizationFlags(QGraphicsView::DontSavePainterState | QGraphicsView::DontAdjustForAntialiasing);
 	connect(ui->mapView, &MapView::openObjectProperties, this, &MainWindow::loadInspector);
 	connect(ui->mapView, &MapView::currentCoordinates, this, &MainWindow::currentCoordinatesChanged);
@@ -431,6 +433,7 @@ void MainWindow::initializeMap(bool isNew)
 
 	mapLevel = 0;
 	ui->mapView->setScene(controller.scene(mapLevel));
+	ui->mapView->resetInteractionState();
 	ui->minimapView->setScene(controller.miniScene(mapLevel));
 	ui->minimapView->dimensions();
 	if(initialScale.isValid())

--- a/mapeditor/mapview.cpp
+++ b/mapeditor/mapview.cpp
@@ -57,7 +57,10 @@ void MinimapView::mousePressEvent(QMouseEvent* event)
 
 MapView::MapView(QWidget * parent):
 	QGraphicsView(parent),
-	selectionTool(MapView::SelectionTool::None)
+	selectionTool(MapView::SelectionTool::None),
+	tileStart(int3{}),
+	tilePrev(int3{}),
+	pressedOnSelected(false)
 {
 	connect(horizontalScrollBar(), &QScrollBar::valueChanged, this, &MapView::setViewports);
 	connect(verticalScrollBar(), &QScrollBar::valueChanged, this, &MapView::setViewports);
@@ -71,6 +74,17 @@ void MapView::cameraChanged(const QPointF & pos)
 void MapView::setController(MapController * ctrl)
 {
 	controller = ctrl;
+}
+
+void MapView::resetInteractionState()
+{
+	if(rubberBand)
+		rubberBand->hide();
+
+	tileStart = int3{};
+	tilePrev = int3{};
+	pressedOnSelected = false;
+	temporaryTiles.clear();
 }
 
 void MapView::resizeEvent(QResizeEvent * event)
@@ -163,7 +177,16 @@ void MapView::mouseMoveEvent(QMouseEvent *mouseEvent)
 	case MapView::SelectionTool::Line:
 	{
 		{
-			assert(tile.z == tileStart.z);
+			if(!(mouseEvent->buttons() & (Qt::LeftButton | Qt::RightButton)))
+				break;
+
+			if(tile.z != tileStart.z)
+			{
+				temporaryTiles.clear();
+				tileStart = tilePrev = tile;
+				break;
+			}
+
 			const auto diff = tile - tileStart;
 			if(diff == int3{})
 				break;

--- a/mapeditor/mapview.h
+++ b/mapeditor/mapview.h
@@ -95,6 +95,7 @@ public:
 public:
 	MapView(QWidget * parent);
 	void setController(MapController *);
+	void resetInteractionState();
 
 	SelectionTool selectionTool;
 


### PR DESCRIPTION
The map editor could abort in Line mode with `assert(tile.z == tileStart.z)` while handling mouse move events. `tileStart` is captured when a drag begins, but `tile.z` follows the current scene level. Switching surface/underground (or moving in Line mode before a fresh press) could leave them out of sync.

Limit Line processing to active drags and replace the z-level assert with a runtime guard. When levels differ, clear temporary line state and re-anchor the drag at the current tile. Also reset transient interaction state whenever MapView switches scenes so stale drag state does not leak between levels.