### PR TITLE
mapeditor: handle nodiscard in CardItem ctor

### DIFF
--- a/mapeditor/templateeditor/graphicelements/CardItem.cpp
+++ b/mapeditor/templateeditor/graphicelements/CardItem.cpp
@@ -57,10 +57,27 @@ CardItem::CardItem():
 	useBlackText(false),
 	mousePressed(false)
 {
-	QFile file(":/icons/templateSquare.svg");
-	file.open(QIODevice::ReadOnly);
-	QByteArray data = file.readAll();
-	doc.setContent(data);
+	static const QString templateSquarePath = ":/icons/templateSquare.svg";
+	QFile file(templateSquarePath);
+	if(!file.open(QIODevice::ReadOnly))
+	{
+		logGlobal->error("Failed to open template editor card SVG %s: %s", templateSquarePath.toStdString(), file.errorString().toStdString());
+	}
+	else
+	{
+		QByteArray data = file.readAll();
+#if QT_VERSION >= QT_VERSION_CHECK(6, 8, 0)
+		const auto parseResult = doc.setContent(data);
+		if(!parseResult)
+			logGlobal->error("Failed to parse template editor card SVG %s at %d:%d: %s", templateSquarePath.toStdString(), parseResult.errorLine, parseResult.errorColumn, parseResult.errorMessage.toStdString());
+#else
+		QString errorMessage;
+		int errorLine = 0;
+		int errorColumn = 0;
+		if(!doc.setContent(data, &errorMessage, &errorLine, &errorColumn))
+			logGlobal->error("Failed to parse template editor card SVG %s at %d:%d: %s", templateSquarePath.toStdString(), errorLine, errorColumn, errorMessage.toStdString());
+#endif
+	}
 
 	updateContent();
 }


### PR DESCRIPTION
This fixes a vcmieditor build failure in nix dev shell.

Reproducer:
```
nix develop ./nix/ -c cmake --preset linux-gcc-debug --fresh
nix develop ./nix/ -c cmake --build --preset linux-gcc-debug \ --target vcmieditor -j"$(nproc)"
```

With `CMAKE_CXX_COMPILER_VERSION=14.3.0` and `-Werror`, step 2 failed in `mapeditor/templateeditor/graphicelements/CardItem.cpp` with:

```
error: ignoring return value of 'virtual bool QFile::open(...)', declared with attribute 'nodiscard' [-Werror=unused-result]
```

Qt 6 marks `QFile::open(...)` as `[[nodiscard]]`. Guard the read with `if(file.open(QIODevice::ReadOnly))` before reading/parsing SVG data.

The constructor now logs when :/icons/templateSquare.svg cannot be opened, and it also logs SVG parse failures with line/column details instead of silently ignoring them.
    
Qt 6.10 deprecated old setContent method overload. New overload was added in Qt 6.8. I used conditional compilation (macros) to use the right overload.