### PR TITLE
cmake-presets: use PATH tools for Linux presets

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -62,8 +62,8 @@
             "description": "VCMI Linux Clang",
             "inherits": "linux-release",
             "cacheVariables": {
-                "CMAKE_C_COMPILER": "/usr/bin/clang",
-                "CMAKE_CXX_COMPILER": "/usr/bin/clang++",
+                "CMAKE_C_COMPILER": "clang",
+                "CMAKE_CXX_COMPILER": "clang++",
                 "ENABLE_DISCORD": "OFF"
             }
         },
@@ -84,8 +84,8 @@
             "inherits": "linux-release",
             "cacheVariables": {
                 "ENABLE_LUA" : "ON",
-                "CMAKE_C_COMPILER": "/usr/bin/gcc",
-                "CMAKE_CXX_COMPILER": "/usr/bin/g++"
+                "CMAKE_C_COMPILER": "gcc",
+                "CMAKE_CXX_COMPILER": "g++"
             }
         },
         {
@@ -94,8 +94,8 @@
             "description": "VCMI Linux GCC",
             "inherits": "linux-release",
             "cacheVariables": {
-                "CMAKE_C_COMPILER": "/usr/bin/gcc",
-                "CMAKE_CXX_COMPILER": "/usr/bin/g++",
+                "CMAKE_C_COMPILER": "gcc",
+                "CMAKE_CXX_COMPILER": "g++",
                 "ENABLE_STATIC_LIBS": "ON"
             }
         },
@@ -105,8 +105,8 @@
             "description": "VCMI Linux GCC ARM64",
             "inherits": "linux-release",
             "cacheVariables": {
-                "CMAKE_C_COMPILER": "/usr/bin/gcc",
-                "CMAKE_CXX_COMPILER": "/usr/bin/g++",
+                "CMAKE_C_COMPILER": "gcc",
+                "CMAKE_CXX_COMPILER": "g++",
                 "ENABLE_STATIC_LIBS": "ON"
             }
         },
@@ -127,8 +127,8 @@
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "Debug",
                 "ENABLE_LUA" : "ON",
-                "CMAKE_C_COMPILER": "/usr/bin/gcc",
-                "CMAKE_CXX_COMPILER": "/usr/bin/g++"
+                "CMAKE_C_COMPILER": "gcc",
+                "CMAKE_CXX_COMPILER": "g++"
             }
         },
         {
@@ -139,8 +139,8 @@
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "Debug",
                 "ENABLE_LUA" : "ON",
-                "CMAKE_C_COMPILER": "/usr/bin/clang",
-                "CMAKE_CXX_COMPILER": "/usr/bin/clang++",
+                "CMAKE_C_COMPILER": "clang",
+                "CMAKE_CXX_COMPILER": "clang++",
                 "ENABLE_DISCORD": "OFF"
             }
         },
@@ -150,8 +150,8 @@
             "description": "VCMI Linux Clang",
             "inherits": "linux-test",
             "cacheVariables": {
-                "CMAKE_C_COMPILER": "/usr/bin/clang",
-                "CMAKE_CXX_COMPILER": "/usr/bin/clang++",
+                "CMAKE_C_COMPILER": "clang",
+                "CMAKE_CXX_COMPILER": "clang++",
                 "ENABLE_DISCORD": "OFF"
             }
         },
@@ -162,8 +162,8 @@
             "inherits": "linux-test",
             "cacheVariables": {
                 "ENABLE_LUA" : "OFF",
-                "CMAKE_C_COMPILER": "/usr/bin/gcc",
-                "CMAKE_CXX_COMPILER": "/usr/bin/g++"
+                "CMAKE_C_COMPILER": "gcc",
+                "CMAKE_CXX_COMPILER": "g++"
             }
         },
         {


### PR DESCRIPTION
Fix Linux presets in CMakePresets.json for nix dev shells.

Reproducer:
```
  nix develop ./nix/ -c cmake --preset linux-gcc-debug
```

Before this change, configure failed because presets hardcoded /usr/bin/gcc, /usr/bin/g++, /usr/bin/clang and /usr/bin/clang++, which do not exist in nix environments.

Use compiler names (gcc/g++, clang/clang++) so CMake resolves them from PATH. This keeps behavior on standard systems while making the same presets work in nix shells.