### PR TITLE
[1.7.4] fixes multiple bugs²

### DIFF
--- a/client/CServerHandler.cpp
+++ b/client/CServerHandler.cpp
@@ -400,8 +400,11 @@ void CServerHandler::sendClientDisconnecting()
 	{
 		logNetwork->info("Sent leaving signal to the server");
 	}
-	sendLobbyPack(lcd);
-	networkConnection->close();
+	if(networkConnection)
+	{
+		sendLobbyPack(lcd);
+		networkConnection->close();
+	}
 	networkConnection.reset();
 	logicConnection.reset();
 	waitForServerShutdown();

--- a/client/adventureMap/AdventureMapInterface.cpp
+++ b/client/adventureMap/AdventureMapInterface.cpp
@@ -442,7 +442,7 @@ void AdventureMapInterface::onPlayerTurnStarted(PlayerColor playerID)
 	{
 		GAME->interface()->localState->setSelection(GAME->interface()->localState->getOwnedTown(0));
 	}
-	else
+	else if(!GAME->interface()->localState->getWanderingHeroes().empty())
 	{
 		GAME->interface()->localState->setSelection(GAME->interface()->localState->getWanderingHero(0));
 	}

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -2239,7 +2239,8 @@ bool CGameHandler::buildStructure(ObjectInstanceID tid, BuildingID requestedID, 
 	if(!force)
 	{
 		giveResources(t->tempOwner, -requestedBuilding->resources);
-		statistics->getPlayerAccumulator(t->tempOwner).spentResourcesForBuildings += requestedBuilding->resources;
+		if(t->tempOwner.isValidPlayer())
+			statistics->getPlayerAccumulator(t->tempOwner).spentResourcesForBuildings += requestedBuilding->resources;
 	}
 
 	//We know what has been built, apply changes. Do this as final step to properly update town window


### PR DESCRIPTION
More fixes:
- #7010
- #6999
- #6942 (even it makes no sense to play a map without hero or town)

And summary for other issues.

----------------------------------

# VCMI iOS Crash Analysis Report

## Overview

| # | Issue | Title | Signal | Thread | Root Cause | Fix Status |
|---|-------|-------|--------|--------|-----------|------------|
| 1 | [#7011](https://github.com/vcmi/vcmi/issues/7011) | crash in `ModManager::collectDependenciesRecursive()` | SIGABRT | 0 | Uninstalled dependency throws in mod enable | ❌ Unfixed |
| 2 | [#7010](https://github.com/vcmi/vcmi/issues/7010) | crash when sending lobby disconnection packet | SIGABRT | 0 | Connection already closed when sending disconnect | ✅ Fixed |
| 3 | [#6999](https://github.com/vcmi/vcmi/issues/6999) | crash in `StatisticDataSet::getPlayerAccumulator()` | SIGABRT | 10 | Invalid player color in building statistics | ✅ Fixed |
| 4 | [#6953](https://github.com/vcmi/vcmi/issues/6953) | crash on installing a downloaded mod | SIGABRT | 0 | Unknown mod ID in `ModsStorage::getMod()` during disable | ❌ Unfixed |
| 5 | [#6952](https://github.com/vcmi/vcmi/issues/6952) | crash on pressing shortcut | SIGABRT | 0 | `WindowBase::close()` throws when window not on top | ❌ Unfixed |
| 6 | [#6951](https://github.com/vcmi/vcmi/issues/6951) | mod manager file reading crash | SIGABRT | 0 | `CFileInputStream` file not found during mod init | ❌ Unfixed |
| 7 | [#6942](https://github.com/vcmi/vcmi/issues/6942) | crash in `PlayerLocalState::getWanderingHero()` | SIGABRT | 8 | Empty hero list at turn start, out-of-range index | ✅ Fixed |
| 8 | [#6885](https://github.com/vcmi/vcmi/issues/6885) | crash in `CMapInfo::campaignInit()` | SIGSEGV | 10 | NULL pointer from `getResourceName()` dereference | ❌ Unfixed |
| 9 | [#6812](https://github.com/vcmi/vcmi/issues/6812) | crash on casting a spell (serialization) | SIGABRT | 18 | Invalid `SecondarySkill` index during serialization | ⚠️ Deep issue |
| 10 | [#6750](https://github.com/vcmi/vcmi/issues/6750) | `CFilesystemLoader::listFiles` crash | SIGABRT | 7 | Filesystem race condition in `updateFilteredFiles()` | ❌ Unfixed |

---

## Crash 1: `ModManager::collectDependenciesRecursive()` ([#7011](https://github.com/vcmi/vcmi/issues/7011))

| Field | Value |
|-------|-------|
| **Device** | iPhone17,2 (iPhone 16 Pro Max) |
| **OS** | iOS 26.2 |
| **App Version** | 1.7.3 RC (315a90f) |
| **Exception** | EXC_CRASH (SIGABRT) |
| **Crashed Thread** | 0 (Main) |

### Stack Trace (Key Frames)
```
9  vcmi    ModManager::collectDependenciesRecursive()    ModManager.cpp:643
10 vcmi    ModManager::tryEnableMods()                   ModManager.cpp:662
11 vcmiclient  ModStateModel::doEnableMods()             modstatemodel.cpp:108
12 vcmiclient  ModStateController::enableMods()          modstatecontroller.cpp:109
13 vcmiclient  CModListView::installMods()               cmodlistview_moc.cpp:1156
```

### Root Cause
After downloading and installing a mod, the launcher calls `tryEnableMods()` which recursively resolves dependencies via `collectDependenciesRecursive()`. If a dependency is not installed, the function throws `std::runtime_error`. This uncaught exception propagates up and terminates the app.

### Fix Status: ❌ Unfixed
The symptom-only fix (try-catch around `tryEnableMods()` in `modstatemodel.cpp`) would prevent the crash but hide the logic error. The root cause fix requires checking whether all dependencies are actually installed before calling `collectDependenciesRecursive()` — either in `tryEnableMods()` itself or in `canEnableMod()` in `modstatecontroller.cpp`.

---

## Crash 2: Lobby Disconnection Packet ([#7010](https://github.com/vcmi/vcmi/issues/7010))

| Field | Value |
|-------|-------|
| **Device** | iPad8,3 (iPad Pro 11") |
| **OS** | iOS 26.3 |
| **App Version** | 1.7.3 RC (315a90f) |
| **Exception** | EXC_CRASH (SIGABRT) |
| **Crashed Thread** | 0 (Main) |

### Stack Trace (Key Frames)
```
9  vcmi        GameConnection::sendPack()                GameConnection.cpp:77
10 vcmiclient  CServerHandler::sendLobbyPack()           CServerHandler.cpp:403
11 vcmiclient  CServerHandler::sendClientDisconnecting() CServerHandler.cpp:403
12 vcmiclient  CLobbyScreen::CLobbyScreen()::$_2         (back button lambda)
13 vcmiclient  CButton::onButtonClicked()                Buttons.cpp:258
```

### Root Cause
When the user taps the back button in the lobby, `sendClientDisconnecting()` tries to send a `LobbyClientDisconnected` packet. Inside `GameConnection::sendPack()`, the underlying `networkConnection` weak_ptr can't be locked because the connection is already closed, causing a `std::runtime_error("Attempt to send packet on a closed connection!")` to be thrown.

### Fix Applied
**File: `client/CServerHandler.cpp`**
- Added `if(networkConnection)` guard before `sendLobbyPack(lcd)` and `networkConnection->close()`
- If the connection is already gone, the disconnect packet is simply skipped and the connection is cleaned up without crashing
- Root cause: `sendClientDisconnecting()` did not verify that the connection was still live before attempting to use it

---

## Crash 3: `StatisticDataSet::getPlayerAccumulator()` ([#6999](https://github.com/vcmi/vcmi/issues/6999))

| Field | Value |
|-------|-------|
| **Device** | iPad12,1 (iPad 9th gen) |
| **OS** | iOS 18.5 |
| **App Version** | 1.7.4 (41207f4) |
| **Exception** | EXC_CRASH (SIGABRT) |
| **Crashed Thread** | 10 (Server) |

### Stack Trace (Key Frames)
```
9  vcmi        StatisticDataSet::getPlayerAccumulator()   GameStatistics.cpp:40
10 vcmiclient  CGameHandler::buildStructure()             CGameHandler.cpp:2242
11 vcmiclient  ApplyGhNetPackVisitor::visitBuildStructure() NetPacksServer.cpp:146
12 vcmiclient  CGameHandler::handleReceivedPack()         CGameHandler.cpp:505
```

### Root Cause
In `CGameHandler::buildStructure()`, the code calls `statistics->getPlayerAccumulator(t->tempOwner)` where `t->tempOwner` is an invalid player color (not a valid player index 0-7). `getPlayerAccumulator()` validates this and throws `std::runtime_error`. This can happen when a building is built by a non-player entity (e.g., scripted events, neutral towns).

The issue was reported as "still crashing" after two previous fix attempts (#7000, #7019) indicating the validation in `getPlayerAccumulator` catches some cases but not the invalid player color from `tempOwner`.

### Fix Applied
**File: `server/CGameHandler.cpp`**
- Added `t->tempOwner.isValidPlayer()` guard before `getPlayerAccumulator()`
- Neutral towns (`PlayerColor::NEUTRAL`) and spectators are legitimately allowed to build structures; they simply have no statistics to accumulate
- Root cause: the statistics code was never designed to handle non-player building events, but `giveResources` (called on the same `tempOwner` right above) already supports non-players silently

---

## Crash 4: Mod Install/Update ([#6953](https://github.com/vcmi/vcmi/issues/6953))

| Field | Value |
|-------|-------|
| **Device** | iPad16,1 (iPad Air M3) |
| **OS** | iOS 26.3.1 |
| **App Version** | 1.7.3 (20d4101) |
| **Exception** | EXC_CRASH (SIGABRT) |
| **Crashed Thread** | 0 (Main) |

### Stack Trace (Key Frames)
```
9  vcmi        ModsStorage::getMod()                     ModManager.cpp:487
10 vcmi        ModManager::updatePreset()                ModManager.cpp:748
11 vcmi        ModManager::tryDisableMod()               ModManager.cpp:716
12 vcmiclient  ModStateModel::doDisableMod()             modstatemodel.cpp:113
13 vcmiclient  ModStateController::disableMod()          modstatecontroller.cpp:117
14 vcmiclient  CModListView::doUninstallMod()            cmodlistview_moc.cpp:1449
15 vcmiclient  CModListView::installMods()               cmodlistview_moc.cpp:1125
```

### Root Cause
During mod installation, the launcher first uninstalls the old version via `doUninstallMod()` → `tryDisableMod()`. Inside `updatePreset()`, a loop iterates over mod settings and calls `modsStorage->getMod(fullModID)`. If the mod ID doesn't exist in the storage (removed during the uninstall process), `getMod()` throws `std::out_of_range`.

### Fix Status: ❌ Unfixed — symptom-only fix available (try-catch), root cause in `ModManager::updatePreset()` calling `getMod()` on IDs that have been removed from storage

---

## Crash 5: Shortcut/Button Press ([#6952](https://github.com/vcmi/vcmi/issues/6952))

| Field | Value |
|-------|-------|
| **Device** | iPad13,16 (iPad Air 5th gen) |
| **OS** | iOS 26.2.1 |
| **App Version** | 1.7.2 (c09996f) |
| **Exception** | EXC_CRASH (SIGABRT) |
| **Crashed Thread** | 0 (Main) |

### Stack Trace (Key Frames)
```
9  vcmiclient  WindowBase::close()                       CIntObject.cpp:355
10 vcmiclient  CFunctionList<void()>::operator()()        FunctionList.h:62
13 vcmiclient  CButton::onButtonClicked()                Buttons.cpp:258
14 vcmiclient  EventDispatcher::dispatchShortcutReleased() EventDispatcher.cpp:130
15 vcmiclient  InputSourceKeyboard::handleEventKeyUp()    InputSourceKeyboard.cpp:154
```

### Root Cause
`WindowBase::close()` throws a `std::runtime_error` when the window being closed is not the topmost window. This can happen when a keyboard shortcut triggers a button callback that tries to close a window while another window (e.g., a dialog) has been pushed on top in the meantime. The exception is uncaught and terminates the app.

### Fix Status: ❌ Unfixed
`WindowBase::close()` intentionally throws when a non-top window tries to close itself, to enforce the window stack invariant. The correct fix is to prevent the shortcut/button callback from firing when the window is no longer on top — i.e., guard button callbacks in `CButton::onButtonClicked()` or `EventDispatcher::dispatchShortcutReleased()` against the case where the owning window has been covered by another.

---

## Crash 6: Mod Manager File Reading ([#6951](https://github.com/vcmi/vcmi/issues/6951))

| Field | Value |
|-------|-------|
| **Device** | iPad8,11 (iPad Air 3rd gen) |
| **OS** | iOS 26.2.1 |
| **App Version** | 1.7.2 (c09996f) |
| **Exception** | EXC_CRASH (SIGABRT) |
| **Crashed Thread** | 0 (Main) |

### Stack Trace (Key Frames)
```
9  vcmi        CFileInputStream::CFileInputStream()      CFileInputStream.cpp:23
10 vcmi        CFilesystemLoader::load()                 CFilesystemLoader.cpp:42
12 vcmi        JsonNode::JsonNode()                      JsonNode.cpp:125
15 vcmi        ModsPresetState::ModsPresetState()        ModManager.cpp:163
17 vcmi        ModManager::ModManager()                  ModManager.cpp:507
19 vcmiclient  ModStateModel::setRepositoryData()        modstatemodel.cpp:27
21 vcmiclient  CModListView::installFiles()              cmodlistview_moc.cpp:1029
```

### Root Cause
After downloading mod files, `CModListView::installFiles()` calls `setRepositoryData()` which recreates the `ModManager`. During `ModManager` initialization, `ModsPresetState` tries to read `config/modSettings.json`. If the file doesn't exist on disk (e.g., corrupted install, file being written by another operation), `CFileInputStream` throws an exception that propagates uncaught.

### Fix Status: ❌ Unfixed — symptom-only fix available (try-catch in `setRepositoryData`), root cause is a race condition between the `existsResource` check and actual file open inside `JsonNode`/`CFileInputStream`

---

## Crash 7: `PlayerLocalState::getWanderingHero()` ([#6942](https://github.com/vcmi/vcmi/issues/6942))

| Field | Value |
|-------|-------|
| **Device** | iPad15,5 (iPad Air M2) |
| **OS** | iOS 18.6.2 |
| **App Version** | 1.7.2 |
| **Exception** | EXC_CRASH (SIGABRT) |
| **Crashed Thread** | 8 (Network) |

### Stack Trace (Key Frames)
```
9  vcmiclient  PlayerLocalState::getWanderingHero()      PlayerLocalState.cpp:214
10 vcmiclient  AdventureMapInterface::onPlayerTurnStarted() AdventureMapInterface.cpp:447
11 vcmiclient  CPlayerInterface::yourTurn()              CPlayerInterface.cpp:341
13 vcmiclient  ApplyClientNetPackVisitor::visitPlayerStartsTurn() NetPacksClient.cpp:929
14 vcmiclient  CClient::handlePack()                    Client.cpp:359
```

### Root Cause
In `AdventureMapInterface::onPlayerTurnStarted()`, the code selects an initial entity for the player:
1. First tries to find a non-sleeping hero
2. If no hero found, selects the first owned town
3. If no town, calls `getWanderingHero(0)` — but if the player has NO wandering heroes either, this throws `std::runtime_error("No hero with index 0")`

As noted by IvanSavenko: "Player has loaded on map without any owned heroes or towns, effectively - instant defeat." This can happen due to RMG failure, corrupted maps, or loading a multiplayer game after player defeat.

### Fix Applied
**File: `client/adventureMap/AdventureMapInterface.cpp`**
- Changed the final `else` branch to `else if(!localState->getWanderingHeroes().empty())`, so `getWanderingHero(0)` is only called when the list is non-empty
- Root cause: the selection logic assumed that if the player has no sleeping heroes and no towns, they must have at least one wandering hero — an invariant that does not hold when a player loads into a map without any owned entities (defeat scenario, RMG failure, corrupted save)

---

## Crash 8: `CMapInfo::campaignInit()` ([#6885](https://github.com/vcmi/vcmi/issues/6885))

| Field | Value |
|-------|-------|
| **Device** | iPhone18,1 (iPhone 16e) |
| **OS** | iOS 26.3 |
| **App Version** | 1.7.2 (c09996f) |
| **Exception** | EXC_BAD_ACCESS (SIGSEGV) |
| **Crashed Thread** | 10 (Network) |
| **Exception Subtype** | KERN_INVALID_ADDRESS at 0x0000000000000000 |

### Stack Trace (Key Frames)
```
0  libsystem_platform  _platform_memmove                (NULL deref)
4  vcmi                boost::filesystem::last_write_time() CMapInfo.cpp:85
5  vcmi                CMapInfo::campaignInit()
6  vcmiclient          SelectionTab::parseCampaigns()    SelectionTab.cpp:1023
7  vcmiclient          SelectionTab::toggleMode()        SelectionTab.cpp:352
8  vcmiclient          CLobbyScreen::toggleMode()        CLobbyScreen.cpp:223
```

### Root Cause
In `CMapInfo::campaignInit()`, the code calls:
```cpp
lastWrite = boost::filesystem::last_write_time(*CResourceHandler::get()->getResourceName(resource));
```
`getResourceName(resource)` returns an `std::optional<boost::filesystem::path>`. If the resource doesn't exist (file deleted by another thread, race condition in the shared filesystem), the optional is empty and `*` dereferences a null pointer → SIGSEGV.

As IvanSavenko noted: "Our filesystem is global - shared by client threads, server thread, and any tasks threads. But when opening map list, game will automatically update filesystem, without any mutex or other concurrency protection."

### Fix Status: ❌ Unfixed
`getResourceName()` only tells whether the resource is known to the virtual filesystem — not whether the file still exists on disk. Adding a null-check prevents the immediate dereference crash but doesn't fix the real problem: the shared filesystem has no mutex, so the resource can be removed between the `getResourceName()` call and `last_write_time()`. The correct fix requires adding concurrency protection (e.g. `std::shared_mutex`) to `CResourceHandler`.

---

## Crash 9: Serialization / Spell Casting ([#6812](https://github.com/vcmi/vcmi/issues/6812))

| Field | Value |
|-------|-------|
| **Device** | iPhone17,1 (iPhone 16 Pro) |
| **OS** | iOS 18.7.1 |
| **App Version** | 1.7.2 (429820a) |
| **Exception** | EXC_CRASH (SIGABRT) |
| **Crashed Thread** | 18 (Server) |

### Stack Trace (Key Frames)
```
9  vcmi        CHandlerBase<SecondarySkill,...>::getObjectImpl() IHandlerBase.h:59
10 vcmi        SecondarySkill::encode()                  EntityIdentifiers.cpp:340
11 vcmi        BinarySerializer::save<SecondarySkill>()  BinarySerializer.h
16 vcmi        CMap::serialize()                         CMap.h:303
26 vcmi        GameConnection::sendPack()                GameConnection.cpp:80
30 vcmiclient  CVCMIServer::announcePack()               CVCMIServer.cpp:385
```

### Root Cause
During game start (pressing "BEGIN"), the server serializes the game state including the map data. During serialization of `CMap`, a `SecondarySkill` identifier has an invalid index that is out of range for `CHandlerBase<SecondarySkill>::getObjectImpl()`. This causes a thrown exception.

The issue reporter noted this may be a mix of two separate issues: one about spell casting (user reported "crashes when trying to cast a spell on a titan") and one about the serialize/save calls. Xcode grouped them together.

This is likely caused by a corrupted map or mod-related issue where a secondary skill ID doesn't exist in the handler registry.

### Fix Status: ❌ Unfixed — root cause requires finding where invalid `SecondarySkill` IDs enter the game state (corrupted map, missing mod, or a skills set that was never validated at load time)

---

## Crash 10: `CFilesystemLoader::listFiles` ([#6750](https://github.com/vcmi/vcmi/issues/6750))

| Field | Value |
|-------|-------|
| **Device** | iPad13,4 (iPad Pro 11" M1) |
| **OS** | iOS 26.1 |
| **App Version** | 1.7.2 (5a9631e) |
| **Exception** | EXC_CRASH (SIGABRT) |
| **Crashed Thread** | 7 (Network) |

### Stack Trace (Key Frames)
```
9  boost_filesystem  (unsymbolized)
10 vcmi        boost::filesystem::directory_entry::status() directory.hpp:186
11 vcmi        CFilesystemLoader::listFiles()            CFilesystemLoader.cpp:149
12 vcmi        CFilesystemLoader::updateFilteredFiles()  CFilesystemLoader.cpp:64
13 vcmi        CFilesystemList::updateFilteredFiles()    AdapterLoaders.cpp:127
14 vcmiclient  SelectionTab::getFiles()                  SelectionTab.cpp:1049
15 vcmiclient  SelectionTab::toggleMode()                SelectionTab.cpp:339
```

**Concurrent Thread Context:**
Thread 18 was simultaneously calling `boost::filesystem::remove()` → `unlink` from `ApplyOnServerNetPackVisitor::visitLobbyDelete()` (NetPacksLobbyServer.cpp:440)

### Root Cause
Classic filesystem race condition: Thread 7 (network/client) calls `updateFilteredFiles()` which iterates over directory entries via `boost::filesystem::directory_iterator`. Simultaneously, Thread 18 (server) is deleting a file. When the iterator encounters the now-deleted file and calls `directory_entry::status()`, `boost::filesystem` throws an exception because the file no longer exists.

### Fix Status: ❌ Unfixed — root cause requires adding a mutex to the shared `CResourceHandler` filesystem layer or making `updateFilteredFiles()` atomic; a try-catch in `getFiles()` only hides the race

---

## Summary of Changes

### Files Modified (3 files)

| File | Crash | Fix |
|------|-------|-----|
| `server/CGameHandler.cpp` | #6999 | `isValidPlayer()` guard — skip stats for non-player entities |
| `client/CServerHandler.cpp` | #7010 | Guard send+close behind `if(networkConnection)` |
| `client/adventureMap/AdventureMapInterface.cpp` | #6942 | Guard `getWanderingHero(0)` behind `!getWanderingHeroes().empty()` |

### Unfixed (symptom-only or needs deeper work)

| Crash | Reason |
|-------|--------|
| #7011 | Root cause: mod enable proceeds without checking if dependency is installed. Fix needs guard in `collectDependenciesRecursive` or the calling flow. |
| #6953 | Root cause: `updatePreset()` calls `getMod()` on IDs already removed from storage. Fix needs existence check in `updatePreset()`. |
| #6952 | Root cause: shortcut/button event dispatched to a window that is no longer on top. Fix needs guard in `EventDispatcher` or `CButton`. |
| #6951 | Root cause: race between `existsResource` check and actual file open. Fix needs atomic file access or retry logic. |
| #6885 | Root cause: `CResourceHandler` has no mutex — `getResourceName()` only reflects the virtual filesystem, not actual disk state. Fix needs `std::shared_mutex` in `CResourceHandler`. |
| #6750 | Root cause: `CResourceHandler` has no mutex for concurrent filesystem access. Fix needs `std::shared_mutex` on the global filesystem layer. |
| #6812 | Root cause: unknown — invalid `SecondarySkill` IDs in game state need tracing to their origin. |
