### PR TITLE
Fix crash when recruit hero carry a stale instance name

### DIFF
--- a/lib/gameState/GameStatePackVisitor.cpp
+++ b/lib/gameState/GameStatePackVisitor.cpp
@@ -629,9 +629,10 @@ void GameStatePackVisitor::visitHeroRecruited(HeroRecruited & pack)
 	h->pos = pack.tile;
 	h->updateAppearance();
 
-	// Generate unique instance name before adding to map
-	if (h->instanceName.empty())
-		gs.getMap().generateUniqueInstanceName(h.get());
+	// Heroes taken from the tavern pool may carry a stale instance name from an
+	// earlier lifetime or from an older save that reconstructed uidCounter from
+	// on-map objects only. Always assign a fresh map-unique name on recruitment.
+	gs.getMap().generateUniqueInstanceName(h.get());
 
 	gs.getMap().addNewObject(h);
 	assert(h->id.hasValue());

--- a/lib/mapping/CMap.cpp
+++ b/lib/mapping/CMap.cpp
@@ -1010,14 +1010,15 @@ ObjectInstanceID CMap::allocateUniqueInstanceID()
 void CMap::parseUidCounter()
 {
 	int max_index = -1;
-	for (const auto& entry : instanceNames) {
-		const std::string& key = entry.first;
+
+	auto updateMaxIndex = [&](const std::string & key)
+	{
 		const size_t pos = key.find_last_of('_');
 
 		// Validate underscore position
 		if (pos == std::string::npos || pos + 1 >= key.size()) {
 			logGlobal->error("Instance name '%s' is not valid.", key);
-			continue;
+			return;
 		}
 
 		const std::string index_part = key.substr(pos + 1);
@@ -1030,6 +1031,16 @@ void CMap::parseUidCounter()
 		}
 		catch (const std::out_of_range&) {
 			logGlobal->error("Instance name %s index part is overflow.", key);
+		}
+	};
+
+	for (const auto & entry : instanceNames) {
+		updateMaxIndex(entry.first);
+	}
+
+	for (const auto & hero : heroesPool) {
+		if (hero && !hero->instanceName.empty()) {
+			updateMaxIndex(hero->instanceName);
 		}
 	}
 

--- a/test/game/HeroRecruitmentTest.cpp
+++ b/test/game/HeroRecruitmentTest.cpp
@@ -137,3 +137,47 @@ TEST_F(HeroRecruitmentTest, DISABLED_recruitedHeroWithoutTownGetsId)
 	EXPECT_EQ(recruitedHero->getOwner(), playerColor);
 	EXPECT_EQ(recruitedHero->getHeroTypeID(), heroType);
 }
+
+TEST_F(HeroRecruitmentTest, recruitedHeroGetsFreshInstanceNameWhenPoolEntryConflicts)
+{
+	startTestGame();
+
+	PlayerColor playerColor = PlayerColor::NEUTRAL;
+
+	for (int playerIndex = 0; playerIndex < PlayerColor::PLAYER_LIMIT_I; ++playerIndex)
+	{
+		const auto currentPlayer = PlayerColor(playerIndex);
+		if (gameState->getPlayerState(currentPlayer))
+		{
+			playerColor = currentPlayer;
+			break;
+		}
+	}
+
+	ASSERT_TRUE(playerColor.isValidPlayer()) << "Test map must provide a recruitable hero";
+	auto * playerState = gameState->getPlayerState(playerColor);
+	ASSERT_NE(playerState, nullptr);
+
+	const auto heroesInPool = map->getHeroesInPool();
+	ASSERT_FALSE(heroesInPool.empty()) << "Test map must provide a hero in the recruitment pool";
+	auto * pooledHero = map->tryGetFromHeroPool(heroesInPool.front());
+	ASSERT_NE(pooledHero, nullptr);
+
+	auto objects = map->getObjects();
+	ASSERT_FALSE(objects.empty()) << "Test map must contain at least one object";
+	const std::string staleInstanceName = objects.front()->instanceName;
+	pooledHero->instanceName = staleInstanceName;
+
+	HeroRecruited pack;
+	pack.tid = ObjectInstanceID();
+	pack.hid = pooledHero->getHeroTypeID();
+	pack.player = playerColor;
+	pack.tile = int3(5, 5, 0);
+
+	ASSERT_NO_THROW(gameEventCallback->sendAndApply(pack));
+
+	auto * recruitedHero = dynamic_cast<CGHeroInstance *>(map->getObject(pooledHero->id));
+	ASSERT_NE(recruitedHero, nullptr);
+	EXPECT_NE(recruitedHero->instanceName, staleInstanceName);
+	EXPECT_EQ(map->instanceNames.count(recruitedHero->instanceName), 1);
+}


### PR DESCRIPTION
fix issues: https://github.com/vcmi/vcmi/issues/7083

13HeroRecruited
-> GameStatePackVisitor::visitHeroRecruited(HeroRecruited&)
-> CMap::addNewObject(...)
-> Reason: Object instance name duplicated: obj_2773

The new hero was assigned obj_2773, but that object name already existed, so CMap::addNewObject threw and the process aborted.