### PR TITLE
mapeditor: fix template editor selection crash

### DIFF
--- a/mapeditor/templateeditor/GeometryAlgorithm.cpp
+++ b/mapeditor/templateeditor/GeometryAlgorithm.cpp
@@ -39,6 +39,14 @@ bool GeometryAlgorithm::edgesIntersect(const Node& a, const Node& b, const Node&
 
 void GeometryAlgorithm::forceDirectedLayout(std::vector<Node> & nodes, const std::vector<Edge> & edges, int iterations, double width, double height)
 {
+	if (nodes.empty())
+		return;
+
+	const auto hasValidNodeIndex = [&nodes](int index)
+	{
+		return index >= 0 && static_cast<size_t>(index) < nodes.size();
+	};
+
 	const double area = width * height;
 	const double k = std::sqrt(area / nodes.size());
 
@@ -68,6 +76,9 @@ void GeometryAlgorithm::forceDirectedLayout(std::vector<Node> & nodes, const std
 		// Attractive forces
 		for (const auto& edge : edges)
 		{
+			if (!hasValidNodeIndex(edge.from) || !hasValidNodeIndex(edge.to))
+				continue;
+
 			Node& u = nodes[edge.from];
 			Node& v = nodes[edge.to];
 			double dx = u.x - v.x;
@@ -89,6 +100,10 @@ void GeometryAlgorithm::forceDirectedLayout(std::vector<Node> & nodes, const std
 			for (size_t j = i + 1; j < edges.size(); ++j) {
 				const Edge& e1 = edges[i];
 				const Edge& e2 = edges[j];
+
+				if (!hasValidNodeIndex(e1.from) || !hasValidNodeIndex(e1.to) ||
+					!hasValidNodeIndex(e2.from) || !hasValidNodeIndex(e2.to))
+					continue;
 
 				if (e1.from == e2.from || e1.from == e2.to ||
 				   e1.to == e2.from || e1.to == e2.to)

--- a/mapeditor/templateeditor/templateeditor.cpp
+++ b/mapeditor/templateeditor/templateeditor.cpp
@@ -131,6 +131,9 @@ void TemplateEditor::autoPositionZones()
 {
 	auto & zones = templates[selectedTemplate]->getZones();
 
+	if (zones.empty())
+		return;
+
 	std::vector<GeometryAlgorithm::Node> nodes;
 	std::default_random_engine rng(0);
 	std::uniform_real_distribution<double> distX(0.0, 500);
@@ -145,10 +148,13 @@ void TemplateEditor::autoPositionZones()
 	}
 	std::vector<GeometryAlgorithm::Edge> edges;
 	for(auto & item : templates[selectedTemplate]->getConnectedZoneIds())
-		edges.push_back({
-			vstd::find_pos_if(nodes, [item](auto & elem){ return elem.id == item.getZoneA(); }),
-			vstd::find_pos_if(nodes, [item](auto & elem){ return elem.id == item.getZoneB(); })
-		});
+	{
+		const auto from = vstd::find_pos_if(nodes, [item](auto & elem){ return elem.id == item.getZoneA(); });
+		const auto to = vstd::find_pos_if(nodes, [item](auto & elem){ return elem.id == item.getZoneB(); });
+		if (from >= nodes.size() || to >= nodes.size())
+			continue;
+		edges.push_back({from, to});
+	}
 		
 	GeometryAlgorithm::forceDirectedLayout(nodes, edges, 1000, 500, 500);
 
@@ -169,7 +175,7 @@ void TemplateEditor::loadContent(bool autoPosition)
 		return;
 
 	auto & zones = templates[selectedTemplate]->getZones();
-	if(autoPosition || std::all_of(zones.begin(), zones.end(), [](auto & item){ return item.second->getVisiblePosition().x == 0 && item.second->getVisiblePosition().y == 0; }))
+	if(!zones.empty() && (autoPosition || std::all_of(zones.begin(), zones.end(), [](auto & item){ return item.second->getVisiblePosition().x == 0 && item.second->getVisiblePosition().y == 0; })))
 		autoPositionZones();
 
 	for(auto & zone : zones)
@@ -1159,8 +1165,20 @@ void TemplateEditor::on_checkBoxAllowedWaterContentIslands_stateChanged(int stat
 
 void TemplateEditor::on_pushButtonConnectionAdd_clicked()
 {
+	const auto & zones = templates[selectedTemplate]->getZones();
+	if (zones.size() < 2)
+	{
+		QMessageBox::warning(this, tr("Too few zones"), tr("Create at least two zones before adding a connection."));
+		return;
+	}
+
 	auto & connections = templates[selectedTemplate]->connections;
-	connections.push_back(rmg::ZoneConnection());
+	rmg::ZoneConnection connection;
+	auto zoneIt = zones.begin();
+	connection.zoneA = zoneIt->first;
+	++zoneIt;
+	connection.zoneB = zoneIt->first;
+	connections.push_back(connection);
 	loadZoneConnectionMenuContent();
 }
 

--- a/mapeditor/templateeditor/templateeditor.cpp
+++ b/mapeditor/templateeditor/templateeditor.cpp
@@ -431,6 +431,8 @@ void TemplateEditor::loadZoneMenuContent(bool onlyPosition)
 
 void TemplateEditor::loadZoneConnectionMenuContent()
 {
+	updateConnectionAddButton();
+
 	auto widget = ui->tableWidgetConnections;
 	auto & connections = templates[selectedTemplate]->connections;
 
@@ -510,6 +512,12 @@ void TemplateEditor::loadZoneConnectionMenuContent()
 		widget->setCellWidget(i, 5, delButton);
 	};
 	widget->resizeColumnsToContents();
+}
+
+void TemplateEditor::updateConnectionAddButton()
+{
+	const bool canAddConnection = templates.count(selectedTemplate) && templates[selectedTemplate]->getZones().size() >= 2;
+	ui->pushButtonConnectionAdd->setEnabled(canAddConnection);
 }
 
 void TemplateEditor::saveZoneMenuContent()

--- a/mapeditor/templateeditor/templateeditor.h
+++ b/mapeditor/templateeditor/templateeditor.h
@@ -115,6 +115,7 @@ private:
 	void loadZoneMenuContent(bool onlyPosition = false);
 	void saveZoneMenuContent();
 	void loadZoneConnectionMenuContent();
+	void updateConnectionAddButton();
 	void updateConnectionLines(bool recreate = false);
 	void autoPositionZones();
 	void updateZonePositions();


### PR DESCRIPTION
Adding a connection before enough zones existed could leave the template with invalid endpoints. Re-selecting the template then ran auto-layout on an empty or incomplete graph and hit an out-of-bounds node index.

Require at least two zones before creating a connection, seed new connections with real zone ids, and ignore invalid edges in the layout code.

Previously, the following resulted in a crash:
1. Template editor
2. New
3. on the right tabs -> select zone -> Button "Add" below
4. On the left "Selected Template": open the scrollbox with a single item "TemplateEditor". Select "TemplateEditor" -> crash

```
include/c++/14.3.0/bits/stl_vector.h:1143: constexpr std::vector<_Tp, _Alloc>::reference std::vector<_Tp, _Alloc>::operator[](size_type) [with _Tp = GeometryAlgorithm::Node; _Alloc = std::allocator<GeometryAlgorithm::Node>; reference = GeometryAlgorithm::Node&; size_type = long unsigned int]: Assertion '__n < this->size()' failed.
Aborted
```

Now at step 3 it shows a warning box: "Create at least two zones before adding a connection".