### PR TITLE
VCMIDirs: fix vcmieditor dev-mode data lookup

### DIFF
--- a/lib/VCMIDirs.cpp
+++ b/lib/VCMIDirs.cpp
@@ -224,7 +224,7 @@ bool IVCMIDirsUNIX::developmentMode() const
 {
 	// We want to be able to run VCMI from single directory. E.g to run from build output directory
 	const bool hasConfigs = bfs::exists("config") && bfs::exists("Mods");
-	const bool hasBinaries = bfs::exists("vcmiclient") || bfs::exists("vcmiserver") || bfs::exists("vcmilobby");
+	const bool hasBinaries = bfs::exists("vcmiclient") || bfs::exists("vcmiserver") || bfs::exists("vcmilobby") || bfs::exists("vcmieditor");
 	return hasConfigs && hasBinaries;
 }
 


### PR DESCRIPTION
On Unix, development mode only activated when the working directory contained config and Mods plus one of the game binaries. A build that only produced `vcmieditor` failed that check, so the editor looked for installed data paths and aborted on `config/filesystem.json`.

Treat `vcmieditor` as a valid development binary so editor-only builds use the local build tree data layout and start correctly.

Fix the following crash:

```
$ ./out/build/linux-gcc-release/bin/vcmieditor
Starting map editor of 'VCMI 1.8.0.'
...
Disaster happened.
Reason: Resource with name CONFIG/FILESYSTEM and type JSON wasn't found.
```