### PR TITLE
fix disconnection in globallobby

### DIFF
--- a/client/globalLobby/GlobalLobbyClient.cpp
+++ b/client/globalLobby/GlobalLobbyClient.cpp
@@ -421,6 +421,18 @@ void GlobalLobbyClient::onDisconnected(const std::shared_ptr<INetworkConnection>
 	networkConnection.reset();
 	accountLoggedIn = false;
 
+	// GlobalLobbyInviteWindow can be present on the window stack independently of
+	// GlobalLobbyWindow (it is opened via "Invite Players" in CSelectionBase, i.e.
+	// when the user is already in a pre-game room setup screen).
+	// If the connection drops while this window is open, networkConnection is already
+	// null -- but the window remains active and interactive, causing a null-pointer
+	// dereference crash when the user taps an invite card (issue #7071).
+	// Close it explicitly before handling GlobalLobbyWindow.
+	while (!ENGINE->windows().findWindows<GlobalLobbyInviteWindow>().empty())
+	{
+		ENGINE->windows().popWindows(1);
+	}
+
 	while (!ENGINE->windows().findWindows<GlobalLobbyWindow>().empty())
 	{
 		// if global lobby is open, pop all dialogs on top of it as well as lobby itself
@@ -432,6 +444,11 @@ void GlobalLobbyClient::onDisconnected(const std::shared_ptr<INetworkConnection>
 
 void GlobalLobbyClient::sendMessage(const JsonNode & data)
 {
+	if (!networkConnection)
+	{
+		logGlobal->warn("GlobalLobbyClient::sendMessage called without active connection, ignoring message of type '%s'", data["type"].String());
+		return;
+	}
 	assert(JsonUtils::validate(data, "vcmi:lobbyProtocol/" + data["type"].String(), data["type"].String() + " pack"));
 	networkConnection->sendPacket(data.toBytes());
 }


### PR DESCRIPTION
Model: Sonnet 4.6

Promt:
```
I want to fix this issue: https://github.com/vcmi/vcmi/issues/7071
download attached stacktrace

Please analyse this issue in depth. Analyse each possible fault code path for this issue in repository. I want to find the root cause, I don't want quick fixes.

Provide an detailed, correct analysis and a suggested fix for this issue.

Review your response for correctness.

write a md file with a detailed report (in english) at the end
```

------------------

# Issue #7071 – Root Cause Analysis & Fix: Crash in `GlobalLobbyClient::sendMessage()`

> **Status:** Open – fix proposed below  
> **Crash type:** `EXC_BAD_ACCESS (SIGSEGV)` – Null pointer dereference  
> **Platform:** iOS TestFlight (commit `20d4101b9`)  
> **Crash address:** `0x0000000000000000` (null pointer dereference)  
> **Crashed thread:** Thread 0 (main / UI thread)  
> **Triggered by:** Tap on invite button in Global Lobby Invite window  

---

## Table of Contents

1. [Crash Report Summary](#1-crash-report-summary)
2. [Stacktrace Analysis](#2-stacktrace-analysis)
3. [Code Architecture Background](#3-code-architecture-background)
4. [Complete Fault Path Walkthrough](#4-complete-fault-path-walkthrough)
5. [Why the Existing Workaround Is Insufficient](#5-why-the-existing-workaround-is-insufficient)
6. [All sendMessage() Callers Audit](#6-all-sendmessage-callers-audit)
7. [Root Cause Summary](#7-root-cause-summary)
8. [Proposed Fix](#8-proposed-fix)
9. [Why This Fix Is Correct](#9-why-this-fix-is-correct)
10. [Architectural Note / Future Hardening](#10-architectural-note--future-hardening)

---

## 1. Crash Report Summary

The crash was reported on iOS TestFlight, version `20d4101`. The crash report shows:

| Field | Value |
|---|---|
| Exception | `EXC_BAD_ACCESS (SIGSEGV)` |
| Crash address | `0x0000000000000000` (null pointer dereference) |
| Crashed thread | Thread 0 (main/UI thread) |
| User action | Tap on invite-player card in the Global Lobby Invite window |

---

## 2. Stacktrace Analysis

```
0  GlobalLobbyClient::sendMessage(VCMI::JsonNode const&)   GlobalLobbyClient.cpp:436
1  GlobalLobbyInviteAccountCard::clickPressed(VCMI::Point const&)  GlobalLobbyInviteWindow.cpp:71
2  EventDispatcher::handleLeftButtonClick(...)
3  InputSourceTouch::handleEventFingerUp(...)
```

Frame 0 is the crash site. Line 436 of `GlobalLobbyClient.cpp` is:

```cpp
networkConnection->sendPacket(data.toBytes());
```

`networkConnection` is a `std::shared_ptr<INetworkConnection>`. The dereference crashes because `networkConnection` is `nullptr` at this point.

Frame 1 (`GlobalLobbyInviteAccountCard::clickPressed`, line 71) calls `sendMessage` unconditionally:

```cpp
void GlobalLobbyInviteAccountCard::clickPressed(const Point & cursorPosition)
{
    JsonNode message;
    message["type"].String() = "sendInvite";
    message["accountID"].String() = accountID;

    GAME->server().getGlobalLobby().sendMessage(message);  // line 71 — no connection guard
}
```

---

## 3. Code Architecture Background

Understanding the bug requires understanding four interacting subsystems.

### 3.1 – `GlobalLobbyClient::networkConnection` lifecycle

`networkConnection` is a `std::shared_ptr<INetworkConnection>` inside `GlobalLobbyClient`. It has two state transitions:

| Event | Effect |
|---|---|
| `onConnectionEstablished(connection)` | Sets `networkConnection = connection` |
| `onDisconnected(connection, error)` | Calls `networkConnection.reset()` → null |

Both callbacks are called from the **network thread** and both acquire `ENGINE->interfaceMutex` before making any state changes.

### 3.2 – `GlobalLobbyClient::sendMessage()` – no null guard

```cpp
// GlobalLobbyClient.cpp:433–438
void GlobalLobbyClient::sendMessage(const JsonNode & data)
{
    assert(JsonUtils::validate(data, "vcmi:lobbyProtocol/" + data["type"].String(), ...));
    networkConnection->sendPacket(data.toBytes());   // UB if null
}
```

No null check. If `networkConnection` is null, calling `->sendPacket()` dereferences the null pointer and crashes.

### 3.3 – `GlobalLobbyClient::onDisconnected()` – incomplete window cleanup

```cpp
// GlobalLobbyClient.cpp (onDisconnected)
void GlobalLobbyClient::onDisconnected(const std::shared_ptr<INetworkConnection> & connection,
                                       const std::string & errorMessage)
{
    std::scoped_lock interfaceLock(ENGINE->interfaceMutex);

    assert(connection == networkConnection);
    networkConnection.reset();      // ← (A) null out connection FIRST
    accountLoggedIn = false;

    while (!ENGINE->windows().findWindows<GlobalLobbyWindow>().empty())
    {
        ENGINE->windows().popWindows(1);  // ← (B) close lobby-related windows SECOND
    }

    CInfoWindow::showInfoDialog("Connection to game lobby was lost!", {});
}
```

Critical design flaw: the loop at **(B)** only searches for `GlobalLobbyWindow` in the window stack. It closes the `GlobalLobbyWindow` itself and **every sub-window on top of it** (by popping one window at a time until `GlobalLobbyWindow` is gone). However, `GlobalLobbyInviteWindow` can be pushed to the window stack **independently of `GlobalLobbyWindow`** (see Section 3.4). When that happens, the loop finds no `GlobalLobbyWindow`, exits immediately, and `GlobalLobbyInviteWindow` remains open — with its buttons still registered in the event dispatcher — while `networkConnection` is already null.

### 3.4 – `GlobalLobbyInviteWindow` – can be opened from outside the Global Lobby

`GlobalLobbyClient::activateRoomInviteInterface()` **unconditionally** pushes `GlobalLobbyInviteWindow`:

```cpp
// GlobalLobbyClient.cpp:566
void GlobalLobbyClient::activateRoomInviteInterface()
{
    ENGINE->windows().createAndPushWindow<GlobalLobbyInviteWindow>();
}
```

This method is exposed via a button in `InfoCard` (part of `CSelectionBase`, the pre-game lobby selection screen):

```cpp
// CSelectionBase.cpp:167
buttonInvitePlayers = std::make_shared<CButton>(
    Point(20, 365),
    AnimationPath::builtin("pregameInvitePlayers"),
    ...,
    []() { GAME->server().getGlobalLobby().activateRoomInviteInterface(); },
    EShortcut::LOBBY_INVITE_PLAYERS
);
```

`CSelectionBase` is present during the **pre-game multiplayer room setup** (joining a room via global lobby), not inside `GlobalLobbyWindow`. When the user clicks "Invite Players" from here, the window stack looks like:

```
[..., CSelectionBase (or derived), GlobalLobbyInviteWindow]
```

There is **no** `GlobalLobbyWindow` in the stack.

### 3.5 – `WindowHandler::popWindows()` and the `disposed` list

```cpp
// WindowHandler.cpp:59–74
void WindowHandler::popWindows(int howMany)
{
    if(!howMany) return;

    windowsStack.back()->deactivate();    // (1) deactivate top window → removes from lclickable
    for(int i = 0; i < howMany; i++)
    {
        disposed.push_back(windowsStack.back());  // (2) defer destruction
        windowsStack.pop_back();
    }

    if(!windowsStack.empty())
        windowsStack.back()->activate();
    ENGINE->fakeMouseMove();              // (3) post a fake SDL user event
}
```

When a window is popped: its widgets are **deactivated** (removed from `EventDispatcher`'s event receiver lists such as `lclickable`). The window object itself is not immediately destroyed — it is kept alive in `disposed` until `WindowHandler::onFrameRendered()` clears it at the end of the next rendered frame.

**Key implication**: after `popWindows` is called, the button widget is removed from `lclickable`, so the click event dispatcher would not reach it in subsequent frames. The crash only occurs when the window is **NOT** popped — i.e., when `GlobalLobbyInviteWindow` is open outside the `GlobalLobbyWindow` stack.

### 3.6 – Touch event model on iOS (TAP_DOWN_SHORT)

`InputSourceTouch` implements iOS touch events with a deferred tap model: on `SDL_FINGERDOWN`, the state transitions to `TAP_DOWN_SHORT` but **no click event is dispatched yet**. On `SDL_FINGERUP` (with state `TAP_DOWN_SHORT`), **both** pressed and released events are dispatched in the same handler:

```cpp
// InputSourceTouch.cpp:221–235
case TouchState::TAP_DOWN_SHORT:
{
    ENGINE->input().setCursorPosition(convertTouchToMouse(tfinger));
    // ...
    ENGINE->events().dispatchMouseLeftButtonPressed(...);   // fires clickPressed()
    ENGINE->events().dispatchMouseLeftButtonReleased(...);  // fires clickReleased()
    state = TouchState::IDLE;
    break;
}
```

`GlobalLobbyInviteAccountCard` overrides `clickPressed`, so the action fires on the **pressed** event, before `clickReleased`.

All input event processing is guarded by `ENGINE->interfaceMutex` (acquired in `GameEngine::updateFrame()`). All network callbacks are also guarded by the same mutex (acquired in `onDisconnected`, `onPacketReceived`, etc.). This means there is **no data race** — the two cannot execute concurrently.

---

## 4. Complete Fault Path Walkthrough

### Step 1 — User enters pre-game room setup from Global Lobby

The user joins a game room via the Global Lobby. The Global Lobby's `receiveJoinRoomSuccess` handler calls:

```cpp
GAME->server().resetStateForLobby(...);
GAME->server().connectToServer(hostname, port);
```

The Global Lobby window is closed (or was never open), and the pre-game selection screen (`CSelectionBase`) becomes active. The window stack is approximately:

```
[CMainMenu, CSelectionBase widget hierarchy]
```

`GlobalLobbyWindow` is **not** on the stack; only the pre-game screen is present.

### Step 2 — User opens the Invite Players window

The user taps the "Invite Players" button in the pre-game screen:

```cpp
// CSelectionBase.cpp:167
[]() { GAME->server().getGlobalLobby().activateRoomInviteInterface(); }
```

→ `pushWindow<GlobalLobbyInviteWindow>()` adds the invite window on top:

```
[CMainMenu, CSelectionBase, GlobalLobbyInviteWindow]   ← no GlobalLobbyWindow
```

`GlobalLobbyInviteAccountCard` widgets register themselves in `EventDispatcher::lclickable`.

### Step 3 — Network connection drops

The global lobby server becomes unreachable (iOS network loss, server restart, app backgrounding, etc.). Boost.Asio detects the error and calls `GlobalLobbyClient::onDisconnected()` on the **network thread**:

```cpp
// network thread acquires interfaceMutex, waits for main thread to release it
std::scoped_lock interfaceLock(ENGINE->interfaceMutex);

networkConnection.reset();    // ← (A) networkConnection is now nullptr
accountLoggedIn = false;

// (B) loop: findWindows<GlobalLobbyWindow>() → EMPTY (no GlobalLobbyWindow in stack!)
while (!ENGINE->windows().findWindows<GlobalLobbyWindow>().empty())
{
    ENGINE->windows().popWindows(1);   // ← never executed
}

CInfoWindow::showInfoDialog("Connection to game lobby was lost!", {});
```

`GlobalLobbyInviteWindow` is **not closed**. Its button widgets remain in `lclickable`. Only `networkConnection` is null.

### Step 4 — "Connection lost" dialog is dismissed

The user taps "OK" on the info dialog. The dialog is popped. The window stack is now:

```
[CMainMenu, CSelectionBase, GlobalLobbyInviteWindow]   ← still open
```

### Step 5 — User taps invite card

The user taps (or was already mid-tap on) an invite account card:

```
SDL_FINGERDOWN → state = TAP_DOWN_SHORT (no click yet)
SDL_FINGERUP   → handleEventFingerUp → dispatchMouseLeftButtonPressed
              → EventDispatcher::handleLeftButtonClick(position, tolerance, isPressed=true)
              → GlobalLobbyInviteAccountCard::clickPressed(position)
              → GAME->server().getGlobalLobby().sendMessage(message)
              → networkConnection->sendPacket(...)   ← SIGSEGV: networkConnection == nullptr
```

### Visualized Timeline

```
   User flow (main thread)                  Network thread
   ─────────────────────────                ────────────────
   CSelectionBase open
   └─ pushWindow<GlobalLobbyInviteWindow>
      stack: [..., InviteWindow]

   updateFrame() (interfaceMutex held)      [waiting for mutex]
   └─ SDL events processed (no tap yet)

   updateFrame() releases interfaceMutex    onDisconnected() acquires interfaceMutex
                                            networkConnection.reset()  ← (null)
                                            findWindows<GlobalLobbyWindow>() → empty
                                            → loop body never runs
                                            InviteWindow still active in lclickable!
                                            showInfoDialog("lost!")
                                            releases interfaceMutex

   updateFrame() (interfaceMutex held)
   └─ user taps "OK" → info dialog popped
   └─ InviteWindow visible, active

   updateFrame() (interfaceMutex held)
   └─ SDL_FINGERUP → TAP_DOWN_SHORT
      dispatchMouseLeftButtonPressed
      → InviteAccountCard.clickPressed()
      → sendMessage()
      → networkConnection->sendPacket()
         SIGSEGV (networkConnection == nullptr)  ✗
```

---

## 5. Why the Existing Workaround Is Insufficient

PR #7089 proposed adding an early-return guard in `sendMessage()`:

```cpp
void GlobalLobbyClient::sendMessage(const JsonNode & data)
{
    if (!networkConnection)
    {
        logGlobal->warn("...");
        return;   // ← silently drops the message
    }
    assert(...);
    networkConnection->sendPacket(data.toBytes());
}
```

This prevents the **crash** but leaves the following problems unsolved:

1. **`GlobalLobbyInviteWindow` stays open after disconnect.** The user can still see and interact with an invite list that is no longer connected to anything. Every tap silently fails. No visual feedback is given.
2. **UI state inconsistency.** The button appears enabled and tappable, but performs no action. The "connection lost" dialog is dismissed and the user is left confused.
3. **Architectural fragility.** The root problem — that `onDisconnected` does not close all lobby-dependent windows — persists. Any future lobby window that can be opened outside the `GlobalLobbyWindow` stack will have the same vulnerability.

IvanSavenko's review comment on this PR explicitly noted: *"Crash 1 - workaround that likely would fail at next operation"*.

---

## 6. All `sendMessage()` Callers Audit

This table documents every call site of `sendMessage` (direct or via `getGlobalLobby().sendMessage`) and whether it is protected against a null `networkConnection`.

| Location | Method | Has null guard? | Risk |
|---|---|---|---|
| `GlobalLobbyClient.cpp:385` | `sendClientRegister` | No | Called only from login window; connection must be established |
| `GlobalLobbyClient.cpp:400` | `sendClientLogin` | No | Called only from login window; connection must be established |
| `GlobalLobbyClient.cpp:446` | `sendOpenRoom` | No | Called from lobby window; `onDisconnected` closes it |
| `GlobalLobbyClient.cpp:62` | `addChannel` | No | Called from lobby window/add-channel dialog; `onDisconnected` closes them |
| `GlobalLobbyClient.cpp:535` | `getChannelHistory` | No | Called from any window opening a non-global channel |
| `GlobalLobbyClient.cpp:651` | `sendMatchChatMessage` | **Yes** (`isLoggedIn()` check) | Safe |
| `GlobalLobbyWindow.cpp:91` | `doSendChatMessage` | No | Called only from lobby window; `onDisconnected` closes it |
| `GlobalLobbyWindow.cpp:107` | `doInviteAccount` | No | Called only from lobby window; `onDisconnected` closes it |
| `GlobalLobbyWindow.cpp:116` | `doJoinRoom` | No | Called only from lobby window; `onDisconnected` closes it |
| `GlobalLobbyInviteWindow.cpp:71` | `clickPressed` | No | **CRASH PATH** – window survives disconnect when opened from `CSelectionBase` |

`getChannelHistory` (line 535) also calls `sendMessage` without a connection check, but only for non-global channel types. If a player-channel invite window is somehow open after disconnect (possible if `GlobalLobbyWindow` was open), this path would also crash.

---

## 7. Root Cause Summary

| Contributing factor | Role |
|---|---|
| `GlobalLobbyInviteWindow` opened from `CSelectionBase` | Window is on the stack **without** `GlobalLobbyWindow` |
| `onDisconnected` only closes `GlobalLobbyWindow`-anchored windows | **Root cause** – incomplete cleanup leaves `GlobalLobbyInviteWindow` active |
| `networkConnection.reset()` called before window deactivation | Connection becomes null while UI is still interactive |
| `sendMessage()` has no null guard | Immediate crash site when null dereference occurs |
| iOS touch model (TAP_DOWN_SHORT) | Pressed event fires after finger-up, after potential disconnect |

The bug is a **design oversight**: `GlobalLobbyClient::onDisconnected()` assumes that all lobby-dependent interactive windows are children of (or on top of) `GlobalLobbyWindow`. This assumption is violated by `GlobalLobbyInviteWindow`, which can be created independently via `activateRoomInviteInterface()` from `CSelectionBase`.

---

## 8. Proposed Fix

Two complementary changes are required for a correct and complete fix.

### Fix A – `GlobalLobbyClient::sendMessage()` – defensive null guard

This is the minimal safety net. It prevents any current or future crash due to sending on a null connection, regardless of which UI path triggered it.

**File:** `client/globalLobby/GlobalLobbyClient.cpp`

```cpp
// BEFORE (line 433–438):
void GlobalLobbyClient::sendMessage(const JsonNode & data)
{
    assert(JsonUtils::validate(data, "vcmi:lobbyProtocol/" + data["type"].String(),
                               data["type"].String() + " pack"));
    networkConnection->sendPacket(data.toBytes());
}

// AFTER:
void GlobalLobbyClient::sendMessage(const JsonNode & data)
{
    if (!networkConnection)
    {
        logGlobal->warn("GlobalLobbyClient::sendMessage called without active connection"
                        ", ignoring message of type '%s'", data["type"].String());
        return;
    }
    assert(JsonUtils::validate(data, "vcmi:lobbyProtocol/" + data["type"].String(),
                               data["type"].String() + " pack"));
    networkConnection->sendPacket(data.toBytes());
}
```

### Fix B – `GlobalLobbyClient::onDisconnected()` – also close `GlobalLobbyInviteWindow`

This is the **structural** fix that addresses the root cause: ensuring the invite window is always closed when the connection drops, regardless of whether `GlobalLobbyWindow` is present.

**File:** `client/globalLobby/GlobalLobbyClient.cpp`

```cpp
// BEFORE:
void GlobalLobbyClient::onDisconnected(const std::shared_ptr<INetworkConnection> & connection,
                                       const std::string & errorMessage)
{
    std::scoped_lock interfaceLock(ENGINE->interfaceMutex);

    assert(connection == networkConnection);
    networkConnection.reset();
    accountLoggedIn = false;

    while (!ENGINE->windows().findWindows<GlobalLobbyWindow>().empty())
    {
        ENGINE->windows().popWindows(1);
    }

    CInfoWindow::showInfoDialog("Connection to game lobby was lost!", {});
}

// AFTER:
void GlobalLobbyClient::onDisconnected(const std::shared_ptr<INetworkConnection> & connection,
                                       const std::string & errorMessage)
{
    std::scoped_lock interfaceLock(ENGINE->interfaceMutex);

    assert(connection == networkConnection);
    networkConnection.reset();
    accountLoggedIn = false;

    // Close GlobalLobbyInviteWindow first. It can be present on the window stack
    // independently of GlobalLobbyWindow (e.g. opened via "Invite Players" in
    // CSelectionBase). Without this, the invite window remains interactive after
    // disconnect with a null networkConnection, causing a null-pointer dereference
    // crash when the user taps an invite card (issue #7071).
    while (!ENGINE->windows().findWindows<GlobalLobbyInviteWindow>().empty())
    {
        ENGINE->windows().popWindows(1);
    }

    // Close GlobalLobbyWindow (and any dialogs stacked on top of it). This handles
    // GlobalLobbyAddChannelWindow, GlobalLobbyRoomWindow, GlobalLobbyServerSetup, etc.
    while (!ENGINE->windows().findWindows<GlobalLobbyWindow>().empty())
    {
        ENGINE->windows().popWindows(1);
    }

    CInfoWindow::showInfoDialog("Connection to game lobby was lost!", {});
}
```

The `#include "GlobalLobbyInviteWindow.h"` is already present in `GlobalLobbyClient.cpp`, so no additional include is needed.

---

## 9. Why This Fix Is Correct

| Property | Verdict |
|---|---|
| Prevents the crash entirely | ✅ Fix B deactivates `GlobalLobbyInviteWindow` (removes from `lclickable`) before any FINGERUP event can reach it. Fix A closes the last gap. |
| No dangling-pointer risk from Fix B | ✅ `popWindows` moves windows into `disposed` list; they are destroyed at end of frame after deactivation. |
| Correct window-close order | ✅ Invite window is closed first; if `GlobalLobbyWindow` is also present (edge case), the second loop closes it and everything above it as before. |
| Correct UX behaviour | ✅ After a disconnect, the invite list vanishes (via Fix B) rather than staying open silently broken (PR #7089 behaviour). |
| No regressions for normal disconnect | ✅ Both `while` loops only execute if the respective window type is actually present. Normal flow (disconnect from global lobby main screen) closes `GlobalLobbyWindow` exactly as before. |
| Null guard also helps for `getChannelHistory` path | ✅ Fix A catches the secondary crash site (line 535, non-global channel history request on a disconnected client). |
| Compile errors | ✅ No new types introduced; existing include already present. |

---

## 10. Architectural Note / Future Hardening

The immediate two-part fix is correct and sufficient for the known crash path.

However, the underlying architectural pattern is fragile: lobby-dependent windows **bypass the lifecycle management** performed in `onDisconnected`. Any new lobby window that can be pushed outside `GlobalLobbyWindow` would re-introduce the same class of bug.

### Longer-term improvement options

**Option A – Common base class for all disconnection-sensitive lobby windows**

Introduce a base class (e.g., `GlobalLobbyWindowBase`) for every window that requires an active lobby connection. `onDisconnected` would then close all windows of this type:

```cpp
// onDisconnected:
while (!ENGINE->windows().findWindows<GlobalLobbyWindowBase>().empty())
    ENGINE->windows().popWindows(1);
```

This is the most extensible approach. `GlobalLobbyWindow`, `GlobalLobbyInviteWindow`, `GlobalLobbyAddChannelWindow`, `GlobalLobbyRoomWindow`, and `GlobalLobbyServerSetup` would all inherit from this base.

**Option B – `isConnected()` guard at every call site**

Every UI action that calls `sendMessage` could guard with `isConnected()`. This is verbose and error-prone (easy to forget in future additions), but provides per-site control.

**Option C – Disable buttons on disconnect**

`onDisconnected` could traverse all descendant widgets in lobby-related windows and call `CButton::block(true)` to disable them. This is the most user-visible fix (grayed-out buttons) but is complex to implement correctly.

Given the fix above closes every known exploitation path and `sendMessage`'s null guard catches unknown future paths, implementing Option A is the recommended follow-up refactor.

---

*Analysis performed on commit `20d4101b9` (VCMI v1.7.3, iOS TestFlight crash report attached to issue #7071).*  
*Fix verified against `master` / `beta` branch codebase at `/home/laserlicht/vcmi`.*
