### PR TITLE
editor: fix "Export As" extension handling and "Save As" writes

### DIFF
--- a/mapeditor/mainwindow.cpp
+++ b/mapeditor/mainwindow.cpp
@@ -1469,26 +1469,55 @@ void MainWindow::on_actionPaste_triggered()
 
 void MainWindow::on_actionExport_triggered()
 {
-	QString fileName = QFileDialog::getSaveFileName(this, tr("Save to image"), lastSavingDir, "BMP (*.bmp);;JPEG (*.jpeg);;PNG (*.png)");
+	QString selectedFilter;
+	QString fileName = QFileDialog::getSaveFileName(
+		this,
+		tr("Save to image"),
+		lastSavingDir,
+		"BMP (*.bmp);;JPEG (*.jpeg);;PNG (*.png)",
+		&selectedFilter
+	);
 	if(!fileName.isNull())
 	{
+		QFileInfo fileInfo(fileName);
+		if(fileInfo.suffix().isEmpty())
+		{
+			QString extension;
+			if(selectedFilter.contains("*.bmp", Qt::CaseInsensitive))
+				extension = "bmp";
+			else if(selectedFilter.contains("*.jpeg", Qt::CaseInsensitive))
+				extension = "jpeg";
+			else if(selectedFilter.contains("*.png", Qt::CaseInsensitive))
+				extension = "png";
+
+			if(!extension.isEmpty())
+				fileName += "." + extension;
+		}
+		lastSavingDir = QFileInfo(fileName).dir().path();
+
 		auto * sc = static_cast<MapScene*>(ui->mapView->scene());
 		if(!sc)
 			return;
-		
+
 		QRectF sceneRect = sc->sceneRect();
-		
+
 		// Temporarily set viewport to full map for export
 		for (auto * layer : sc->getDynamicLayers())
 			layer->setViewport(sceneRect);
-		
+
 		QImage image(sceneRect.size().toSize(), QImage::Format_RGB888);
 		QPainter painter(&image);
 		sc->render(&painter, QRectF(), sceneRect);
-		image.save(fileName);
-		
+		const bool saved = image.save(fileName);
+
 		// Restore viewport to visible area
 		ui->mapView->setViewports();
+
+		if(!saved)
+		{
+			QMessageBox::critical(this, tr("Failed to save image"), tr("Cannot save image to %1.").arg(fileName));
+			return;
+		}
 	}
 }
 

--- a/mapeditor/mainwindow.cpp
+++ b/mapeditor/mainwindow.cpp
@@ -617,12 +617,12 @@ void MainWindow::on_menuOpenRecent_aboutToShow()
 	}
 }
 
-void MainWindow::saveMap()
+void MainWindow::saveMap(bool force)
 {
 	if(!controller.map())
 		return;
 
-	if(!unsaved)
+	if(!force && !unsaved)
 		return;
 	
 	//validate map
@@ -690,7 +690,7 @@ void MainWindow::on_actionSave_as_triggered()
 
 	filename = filenameSelect;
 
-	saveMap();
+	saveMap(true);
 }
 
 void MainWindow::on_actionCampaignEditor_triggered()

--- a/mapeditor/mainwindow.h
+++ b/mapeditor/mainwindow.h
@@ -49,7 +49,7 @@ public:
 
 	void initializeMap(bool isNew);
 
-	void saveMap();
+	void saveMap(bool force = false);
 	bool openMap(const QString &);
 	void openCampaign(const QString &);
 	


### PR DESCRIPTION
## Summary
This PR fixes two map editor file-save UX bugs that made actions look like they succeeded while no file was created or updated.

The first fix makes `Export As` work when the user types a filename without an extension (for example `1`). The second fix makes `Save As` always write to the selected file, even if the map is currently marked as unchanged.

## Problem
In `Export As`, saving silently failed when the target name had no extension. Qt chooses image format from the filename suffix, so `image.save("1")` returns `false`, and the editor previously did not surface that error.

In `Save As`, the action reused `saveMap()`, and `saveMap()` returned early when `unsaved == false`. After one successful save, subsequent `Save As` attempts could become no-ops with no warning and no written file.

## What changed
For `Export As`:
- Capture the selected file filter from `QFileDialog`.
- If the typed filename has no suffix, append the extension that matches the selected filter (`.bmp`, `.jpeg`, `.png`).
- Check the return value of `image.save(...)` and show a clear error dialog when saving fails.
- Update `lastSavingDir` based on the final resolved path.

For `Save As`:
- Extend `saveMap` with a `force` parameter (`saveMap(bool force = false)`).
- Preserve existing behavior for regular Save (`saveMap()` still skips writing when nothing changed).
- Call `saveMap(true)` from `Save As` so the chosen target is always written.

## Testing
Manual validation was done for:
- `Export As` with filename without extension (`1`) for each filter.
- `Export As` with explicit extension (existing behavior still works).
- `Save As` first save, then repeated `Save As` to new names without modifying the map in between.
- Existing map validation warning path remains shown after successful save.
