### PR TITLE
editor: reject zero custom RMG seed

### DIFF
--- a/mapeditor/windownewmap.ui
+++ b/mapeditor/windownewmap.ui
@@ -1020,8 +1020,14 @@
           <height>22</height>
          </size>
         </property>
+        <property name="minimum">
+         <number>1</number>
+        </property>
         <property name="maximum">
          <number>999</number>
+        </property>
+        <property name="value">
+         <number>1</number>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
## Summary
This PR makes custom-seed behavior in New Map explicit and reproducible by rejecting zero as a custom seed value.

## Problem
When custom seed was enabled and set to 0, generation fell back to time-based seeding. That silently broke reproducibility and made it look like the entered custom seed was accepted even though deterministic behavior was not used.

## What changed
- Set custom seed defaults to value 1.
- Enforced a minimum value of 1 in the seed control.
- Preserved existing time-based behavior when custom seed mode is disabled.

## Why this approach
The goal is to remove silent fallback in deterministic workflows while keeping current behavior unchanged for non-custom generation. Users now get immediate feedback instead of a surprising non-reproducible map.

## Testing
- Verified that custom seed values >= 1 generate maps normally.
- Verified that disabling custom seed still uses time-based generation.
