### PR TITLE
Fix std::terminate crash in Nullkiller2 AI on macOS when game ends during AI turn

### DIFF
--- a/AI/Nullkiller2/AIGateway.cpp
+++ b/AI/Nullkiller2/AIGateway.cpp
@@ -531,7 +531,7 @@ void AIGateway::yourTurn(QueryID queryID)
 
 	nullkiller->makingTurnInterruption.reset();
 
-	asyncTasks->run([this]() noexcept
+	asyncTasks->run([this]()
 	{
 		ScopedThreadName guard("NK2AI::AIGateway::makingTurn");
 		status.waitTillFree();
@@ -764,7 +764,7 @@ bool AIGateway::makePossibleUpgrades(const CArmedInstance * obj)
 	return upgraded;
 }
 
-void AIGateway::makeTurn() noexcept
+void AIGateway::makeTurn()
 {
 	try
 	{
@@ -795,11 +795,14 @@ void AIGateway::makeTurn() noexcept
 	catch (const InterruptionRequestedException &)
 	{
 		logAi->debug("Making turn thread has been interrupted. We'll end without calling endTurn.");
-		return;
 	}
 	catch (const TerminationRequestedException &)
 	{
 		logAi->debug("Making turn thread has been terminated. We'll end without calling endTurn");
+	}
+	catch (...)
+	{
+		logAi->error("Unknown exception in makeTurn. Ending turn without calling endTurn.");
 	}
 }
 

--- a/AI/Nullkiller2/AIGateway.h
+++ b/AI/Nullkiller2/AIGateway.h
@@ -155,7 +155,7 @@ public:
 
 	void invalidatePaths() override;
 
-	void makeTurn() noexcept;
+	void makeTurn();
 
 	void buildArmyIn(const CGTownInstance * t);
 	void endTurn();

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -310,6 +310,7 @@ set(lib_MAIN_SRCS
 	CAndroidVMHelper.cpp
 	CBonusTypeHandler.cpp
 	CCreatureHandler.cpp
+	ConditionalWait.cpp
 	CPlayerState.cpp
 	CRandomGenerator.cpp
 	CScriptingModule.cpp

--- a/lib/ConditionalWait.cpp
+++ b/lib/ConditionalWait.cpp
@@ -1,0 +1,18 @@
+/*
+ * ConditionalWait.cpp, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
+#include "StdInc.h"
+#include "ConditionalWait.h"
+
+VCMI_LIB_NAMESPACE_BEGIN
+
+TerminationRequestedException::~TerminationRequestedException() = default;
+InterruptionRequestedException::~InterruptionRequestedException() = default;
+
+VCMI_LIB_NAMESPACE_END

--- a/lib/ConditionalWait.h
+++ b/lib/ConditionalWait.h
@@ -13,10 +13,11 @@
 
 VCMI_LIB_NAMESPACE_BEGIN
 
-class TerminationRequestedException : public std::exception
+class DLL_LINKAGE TerminationRequestedException : public std::exception
 {
 public:
 	using exception::exception;
+	~TerminationRequestedException() override;
 
 	const char* what() const noexcept override
 	{
@@ -24,10 +25,11 @@ public:
 	}
 };
 
-class InterruptionRequestedException : public std::exception
+class DLL_LINKAGE InterruptionRequestedException : public std::exception
 {
 public:
 	using exception::exception;
+	~InterruptionRequestedException() override;
 
 	const char* what() const noexcept override
 	{


### PR DESCRIPTION
**Problem**                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                     
  When a game ends (victory/loss) while Nullkiller2 AI is making its turn, `gameOver()` sets the interruption flag from the network thread. The AI's `interruptionPoint()` then throws `InterruptionRequestedException` from `libvcmi.dylib`. On macOS, the  
  `catch (const InterruptionRequestedException &)` in `libNullkiller2.dylib` may fail to match due to duplicated typeinfo across dylibs. Since both `makeTurn()` and the TBB lambda were marked `noexcept`, the unmatched exception triggers                 
  `std::terminate()`.                                                                                                                                                                                                                                  
                  
**Fix**

Added `DLL_LINKAGE` to both exception classes and gave them out-of-line virtual destructors in a new `ConditionalWait.cpp`. The out-of-line destructor acts as a "key function" per the Itanium C++ ABI, anchoring the vtable and typeinfo to a single 
  translation unit in `libvcmi.dylib`. The dynamic linker then uses this single typeinfo copy, so catch matches correctly across all dylibs.