### PR TITLE
[1.7.4] Remove translation flag from navigation buttons

### DIFF
--- a/launcher/modManager/imageviewer_moc.ui
+++ b/launcher/modManager/imageviewer_moc.ui
@@ -40,17 +40,17 @@
    </property>
    <item row="0" column="1" rowspan="3">
     <widget class="QLabel" name="imageLabel">
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>0</height>
-      </size>
-     </property>
      <property name="sizePolicy">
       <sizepolicy hsizetype="Ignored" vsizetype="Ignored">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>0</height>
+      </size>
      </property>
      <property name="text">
       <string/>
@@ -97,7 +97,7 @@ QPushButton:pressed {
 }</string>
      </property>
      <property name="text">
-      <string>&lt;</string>
+      <string notr="true">&lt;</string>
      </property>
     </widget>
    </item>
@@ -135,7 +135,7 @@ QPushButton:pressed {
 }</string>
      </property>
      <property name="text">
-      <string>&gt;</string>
+      <string notr="true">&gt;</string>
      </property>
     </widget>
    </item>
@@ -173,7 +173,7 @@ QPushButton:pressed {
 }</string>
      </property>
      <property name="text">
-      <string>X</string>
+      <string notr="true">X</string>
      </property>
     </widget>
    </item>

--- a/launcher/modManager/imageviewer_moc.ui
+++ b/launcher/modManager/imageviewer_moc.ui
@@ -40,17 +40,17 @@
    </property>
    <item row="0" column="1" rowspan="3">
     <widget class="QLabel" name="imageLabel">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Ignored" vsizetype="Ignored">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
      <property name="minimumSize">
       <size>
        <width>0</width>
        <height>0</height>
       </size>
+     </property>
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Ignored" vsizetype="Ignored">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
      </property>
      <property name="text">
       <string/>


### PR DESCRIPTION
Do not require translation for **< > X** in Image viewer.