### PR TITLE
Add DLL_LINKAGE and out-of-line destructors to all exception classes

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -16,6 +16,7 @@ set(lib_SRCS
 	filesystem/MinizipExtensions.cpp
 	filesystem/ResourcePath.cpp
 
+	json/JsonFormatException.cpp
 	json/JsonNode.cpp
 	json/JsonParser.cpp
 	json/JsonUtils.cpp
@@ -97,6 +98,7 @@ set(lib_MAIN_SRCS
 	campaign/CampaignRegionsHandler.cpp
 
 	constants/EntityIdentifiers.cpp
+	constants/IdentifierBase.cpp
 
 	entities/artifact/ArtifactUtils.cpp
 	entities/artifact/ArtSlotInfo.cpp
@@ -192,6 +194,7 @@ set(lib_MAIN_SRCS
 	modding/ContentTypeHandler.cpp
 	modding/IdentifierStorage.cpp
 	modding/ModDescription.cpp
+	modding/ModIncompatibility.cpp
 	modding/ModManager.cpp
 	modding/ModUtility.cpp
 	modding/ModVerificationInfo.cpp
@@ -316,6 +319,7 @@ set(lib_MAIN_SRCS
 	CScriptingModule.cpp
 	CSkillHandler.cpp
 	CStack.cpp
+	ExceptionsCommon.cpp
 	GameSettings.cpp
 	IHandlerBase.cpp
 	LoadProgress.cpp

--- a/lib/ExceptionsCommon.cpp
+++ b/lib/ExceptionsCommon.cpp
@@ -1,0 +1,14 @@
+/*
+ * ExceptionsCommon.cpp, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
+#include "StdInc.h"
+#include "ExceptionsCommon.h"
+
+DataLoadingException::~DataLoadingException() = default;
+ModLoadingException::~ModLoadingException() = default;

--- a/lib/ExceptionsCommon.h
+++ b/lib/ExceptionsCommon.h
@@ -13,6 +13,7 @@ class DLL_LINKAGE DataLoadingException: public std::runtime_error
 {
 public:
     using std::runtime_error::runtime_error;
+	~DataLoadingException() override;
 };
 
 class DLL_LINKAGE ModLoadingException: public DataLoadingException
@@ -21,4 +22,5 @@ public:
 	ModLoadingException(const std::string & modName, const std::string & reason)
 		: DataLoadingException("Mod " + modName + " is corrupted! Please disable or reinstall this mod. Reason: " + reason)
 	{}
+	~ModLoadingException() override;
 };

--- a/lib/constants/IdentifierBase.cpp
+++ b/lib/constants/IdentifierBase.cpp
@@ -1,5 +1,5 @@
 /*
- * JsonFormatException.h, part of VCMI engine
+ * IdentifierBase.cpp, part of VCMI engine
  *
  * Authors: listed in file AUTHORS in main folder
  *
@@ -7,15 +7,11 @@
  * Full text of license available in license.txt file, in main folder
  *
  */
-#pragma once
+#include "StdInc.h"
+#include "IdentifierBase.h"
 
 VCMI_LIB_NAMESPACE_BEGIN
 
-class DLL_LINKAGE JsonFormatException : public std::runtime_error
-{
-public:
-	using runtime_error::runtime_error;
-	~JsonFormatException() override;
-};
+IdentifierResolutionException::~IdentifierResolutionException() = default;
 
 VCMI_LIB_NAMESPACE_END

--- a/lib/constants/IdentifierBase.h
+++ b/lib/constants/IdentifierBase.h
@@ -11,7 +11,7 @@
 
 VCMI_LIB_NAMESPACE_BEGIN
 
-class IdentifierResolutionException : public std::runtime_error
+class DLL_LINKAGE IdentifierResolutionException : public std::runtime_error
 {
 public:
 	const std::string identifierName;
@@ -20,6 +20,7 @@ public:
 		: std::runtime_error("Failed to resolve identifier " + identifierName)
 		, identifierName(identifierName)
 	{}
+	~IdentifierResolutionException() override;
 };
 
 class IdentifierBase

--- a/lib/filesystem/CCompressedStream.cpp
+++ b/lib/filesystem/CCompressedStream.cpp
@@ -14,6 +14,8 @@
 
 VCMI_LIB_NAMESPACE_BEGIN
 
+DecompressionException::~DecompressionException() = default;
+
 static const int inflateBlockSize = 10000;
 
 CBufferedStream::CBufferedStream():

--- a/lib/filesystem/CCompressedStream.h
+++ b/lib/filesystem/CCompressedStream.h
@@ -15,10 +15,11 @@ struct z_stream_s;
 
 VCMI_LIB_NAMESPACE_BEGIN
 
-class DecompressionException : public std::runtime_error
+class DLL_LINKAGE DecompressionException : public std::runtime_error
 {
 public:
 	using runtime_error::runtime_error;
+	~DecompressionException() override;
 };
 
 /// Abstract class that provides buffer for one-directional input streams (e.g. compressed data)

--- a/lib/json/JsonFormatException.cpp
+++ b/lib/json/JsonFormatException.cpp
@@ -1,5 +1,5 @@
 /*
- * JsonFormatException.h, part of VCMI engine
+ * JsonFormatException.cpp, part of VCMI engine
  *
  * Authors: listed in file AUTHORS in main folder
  *
@@ -7,15 +7,11 @@
  * Full text of license available in license.txt file, in main folder
  *
  */
-#pragma once
+#include "StdInc.h"
+#include "JsonFormatException.h"
 
 VCMI_LIB_NAMESPACE_BEGIN
 
-class DLL_LINKAGE JsonFormatException : public std::runtime_error
-{
-public:
-	using runtime_error::runtime_error;
-	~JsonFormatException() override;
-};
+JsonFormatException::~JsonFormatException() = default;
 
 VCMI_LIB_NAMESPACE_END

--- a/lib/json/JsonRandom.h
+++ b/lib/json/JsonRandom.h
@@ -28,7 +28,7 @@ struct Component;
 class CStackBasicDescriptor;
 class IGameRandomizer;
 
-class JsonRandomizationException : public std::runtime_error
+class DLL_LINKAGE JsonRandomizationException : public std::runtime_error
 {
 	std::string cleanupJson(const JsonNode & value);
 public:

--- a/lib/modding/ModIncompatibility.cpp
+++ b/lib/modding/ModIncompatibility.cpp
@@ -1,5 +1,5 @@
 /*
- * JsonFormatException.h, part of VCMI engine
+ * ModIncompatibility.cpp, part of VCMI engine
  *
  * Authors: listed in file AUTHORS in main folder
  *
@@ -7,15 +7,11 @@
  * Full text of license available in license.txt file, in main folder
  *
  */
-#pragma once
+#include "StdInc.h"
+#include "ModIncompatibility.h"
 
 VCMI_LIB_NAMESPACE_BEGIN
 
-class DLL_LINKAGE JsonFormatException : public std::runtime_error
-{
-public:
-	using runtime_error::runtime_error;
-	~JsonFormatException() override;
-};
+ModIncompatibility::~ModIncompatibility() = default;
 
 VCMI_LIB_NAMESPACE_END

--- a/lib/modding/ModIncompatibility.h
+++ b/lib/modding/ModIncompatibility.h
@@ -17,6 +17,7 @@ VCMI_LIB_NAMESPACE_BEGIN
 class DLL_LINKAGE ModIncompatibility: public std::exception
 {
 public:
+	~ModIncompatibility() override;
 	using ModList = std::vector<std::string>;
 
 	ModIncompatibility(const ModList & _missingMods)


### PR DESCRIPTION
**Problem**

  Exception classes defined in `lib/` headers without a key function (all methods inline) get their typeinfo emitted independently in each dylib that includes the header. On macOS, `catch` by type may fail to match when the exception is thrown in
  one dylib and caught in another, because the runtime compares typeinfo pointers that differ between dylibs.

  This was already confirmed as the root cause of a std::terminate() crash in Nullkiller2 AI (fixed in #7125 for `InterruptionRequestedException` / `TerminationRequestedException`). This PR applies the same fix to all remaining exception classes
  that cross library boundaries.

**Changes**

  Affected exception classes:
  - `DataLoadingException` / `ModLoadingException` (`lib/ExceptionsCommon.h`) — thrown in lib, caught in client/launcher
  - `JsonFormatException` (`lib/json/JsonFormatException.h`) — thrown in lib, caught in launcher/lobby
  - `ModIncompatibility` (`lib/modding/ModIncompatibility.h`) — thrown in lib, caught in client/server/mapeditor
  - `IdentifierResolutionException` (`lib/constants/IdentifierBase.h`) — thrown in lib, caught in client/server/mapeditor
  - `DecompressionException` (`lib/filesystem/CCompressedStream.h`) — thrown in lib, defined in public header
  - `JsonRandomizationException` (`lib/json/JsonRandom.h`) — already had out-of-line constructor (key function), only needed `DLL_LINKAGE`