### PR TITLE
mapeditor: fix random artifact inspect crash

### DIFF
--- a/lib/mapObjects/MiscObjects.cpp
+++ b/lib/mapObjects/MiscObjects.cpp
@@ -628,6 +628,9 @@ bool CGWhirlpool::isProtected(const CGHeroInstance * h)
 
 const CArtifactInstance * CGArtifact::getArtifactInstance() const
 {
+	if(!storedArtifact.hasValue())
+		return nullptr;
+
 	return cb->getArtInstance(storedArtifact);
 }
 

--- a/mapeditor/inspector/inspector.cpp
+++ b/mapeditor/inspector/inspector.cpp
@@ -380,9 +380,12 @@ void Inspector::updateProperties(CGArtifact * o)
 
 	addProperty(QObject::tr("Message"), o->message, false);
 
-	const CArtifactInstance * instance = o->getArtifactInstance();
-	if(instance && o->ID == Obj::SPELL_SCROLL)
+	if(o->ID == Obj::SPELL_SCROLL)
 	{
+		const CArtifactInstance * instance = o->getArtifactInstance();
+		if(!instance)
+			return;
+
 		SpellID spellId = instance->getScrollSpellID();
 		if(spellId != SpellID::NONE)
 		{

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -42,6 +42,7 @@ set(test_SRCS
 
 		map/CMapEditManagerTest.cpp
 		map/CMapFormatTest.cpp
+		map/CGArtifactRegressionTest.cpp
 		map/MapComparer.cpp
 
 		netpacks/NetPackFixture.cpp

--- a/test/map/CGArtifactRegressionTest.cpp
+++ b/test/map/CGArtifactRegressionTest.cpp
@@ -1,0 +1,27 @@
+/*
+ * CGArtifactRegressionTest.cpp, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
+#include "StdInc.h"
+
+#include "callback/EditorCallback.h"
+#include "mapping/CMap.h"
+#include "mapObjects/MiscObjects.h"
+
+TEST(CGArtifactRegression, RandomArtifactInstanceLookupIsSafe)
+{
+	EditorCallback cb(nullptr);
+	CMap map(&cb);
+	cb.setMap(&map);
+	CGArtifact randomArtifact(&cb);
+	randomArtifact.ID = Obj::RANDOM_ART;
+
+	const CArtifactInstance * instance = nullptr;
+	EXPECT_NO_THROW(instance = randomArtifact.getArtifactInstance());
+	EXPECT_EQ(instance, nullptr);
+}


### PR DESCRIPTION
Selecting certain objects in the editor could abort both on a freshly generated random map and after saving and reloading a map with random artifacts. The runtime error was `std::out_of_range` from `vector::_M_range_check`, with `__n` shown as 18446744073709551615, and the stack passed through `Inspector::updateProperties(CGArtifact*)`, `CGArtifact::getArtifactInstance`, and `CMap::getArtifactInstance`.

The immediate problem was an unset ArtifactInstanceID (-1) on artifact-like objects. Inspector asked for artifact instance unconditionally, and `CGArtifact::getArtifactInstance` forwarded the invalid id into map storage.

The change handles this at both levels involved in the crash path. Inspector now requests artifact instance only for spell scrolls, and CGArtifact now returns nullptr when the stored id is unset.

A regression test in vcmitest now constructs EditorCallback + CMap + CGArtifact with random artifact id and default stored instance, then checks that getArtifactInstance does not throw and returns nullptr. It fails before the fix with the same out_of_range path and passes after it.