### PR TITLE
rmg: break quest zone ownership cycle

### DIFF
--- a/lib/rmg/modificators/QuestArtifactPlacer.cpp
+++ b/lib/rmg/modificators/QuestArtifactPlacer.cpp
@@ -38,7 +38,7 @@ void QuestArtifactPlacer::init()
 void QuestArtifactPlacer::addQuestArtZone(std::shared_ptr<Zone> otherZone)
 {
 	RecursiveLock lock(externalAccessMutex);
-	questArtZones.push_back(otherZone);
+	questArtZones.emplace_back(otherZone);
 }
 
 void QuestArtifactPlacer::addQuestArtifact(const ArtifactID& id, ui32 desiredValue)
@@ -132,10 +132,16 @@ void QuestArtifactPlacer::placeQuestArtifacts(vstd::RNG & rand)
 	for (const auto & questRequest : questArtifactsToPlace)
 	{
 		RandomGeneratorUtil::randomShuffle(questArtZones, rand);
-		for (auto zone : questArtZones)
+		for (const auto & zoneWeak : questArtZones)
 		{
-			auto* qap = zone->getModificator<QuestArtifactPlacer>();
-			
+			auto targetZone = zoneWeak.lock();
+			if (!targetZone)
+				throw rmgException("Quest artifact target zone expired unexpectedly");
+
+			auto* qap = targetZone->getModificator<QuestArtifactPlacer>();
+			if (!qap)
+				continue;
+
 			auto objectToReplace = qap->drawObjectToReplace(questRequest.desiredValue);
 			if (!objectToReplace)
 				continue;

--- a/lib/rmg/modificators/QuestArtifactPlacer.h
+++ b/lib/rmg/modificators/QuestArtifactPlacer.h
@@ -51,7 +51,7 @@ protected:
 		ui32 value;
 	};
 
-	std::vector<std::shared_ptr<Zone>> questArtZones; //artifacts required for Seer Huts will be placed here - or not if null
+	std::vector<std::weak_ptr<Zone>> questArtZones; //artifacts required for Seer Huts will be placed here - or not if null
 	std::vector<QuestArtifactRequest> questArtifactsToPlace;
 	std::vector<ReplacementCandidate> artifactsToReplace; //Common artifacts which may be replaced by quest artifacts from other zones
 


### PR DESCRIPTION
ASan/LSan fuzz runs were reporting large indirect leaks at exit. The stack traces touched many RMG modificators (TreasurePlacer, RiverPlacer, WaterAdopter, ObjectManager), which looked like unrelated leaks at first.

The common root cause is ownership: each Zone owns modificators, while QuestArtifactPlacer kept neighboring zones in `std::vector<std::shared_ptr<Zone>>`. That creates a strong reference cycle between zones and their modificators, so clearing map zones cannot release the whole graph and LeakSanitizer reports it as leaked memory.

This was verified by running the same fuzzer command with leak detection enabled before and after changing only this edge. Before the change, LSAN consistently reported multi-megabyte indirect leaks; after the change, the report disappears while fuzzing behavior stays the same.

Use weak_ptr for cross-zone references in QuestArtifactPlacer and lock the references when iterating. This keeps behavior intact while breaking the cycle so normal cleanup can reclaim zone state.