### PR TITLE
[MMAI] Siege-only models

### DIFF
--- a/AI/MMAI/BAI/factory.cpp
+++ b/AI/MMAI/BAI/factory.cpp
@@ -87,7 +87,7 @@ namespace
 		auto metadata = session->GetModelMetadata();
 		auto allocator = Ort::AllocatorWithDefaultOptions();
 		auto version = readVersion(session.get(), allocator, metadata);
-		return std::make_shared<NNContainer>(std::move(session), std::move(meminfo), std::move(metadata), std::move(allocator), version);
+		return std::make_shared<NNContainer>(path, std::move(session), std::move(meminfo), std::move(metadata), std::move(allocator), version);
 	}
 
 }

--- a/AI/MMAI/BAI/factory.h
+++ b/AI/MMAI/BAI/factory.h
@@ -21,14 +21,22 @@ namespace MMAI::BAI
 
 struct NNContainer
 {
+	std::string path;
 	std::unique_ptr<Ort::Session> session = nullptr;
 	Ort::MemoryInfo meminfo;
 	Ort::ModelMetadata metadata;
 	OrtAllocator * allocator;
 	int version;
 
-	NNContainer(std::unique_ptr<Ort::Session> session, Ort::MemoryInfo meminfo, Ort::ModelMetadata metadata, OrtAllocator * allocator, int version)
-		: session(std::move(session)), meminfo(std::move(meminfo)), metadata(std::move(metadata)), allocator(allocator), version(version)
+	NNContainer(
+		const std::string & path,
+		std::unique_ptr<Ort::Session> session,
+		Ort::MemoryInfo meminfo,
+		Ort::ModelMetadata metadata,
+		OrtAllocator * allocator,
+		int version
+	)
+		: path(path), session(std::move(session)), meminfo(std::move(meminfo)), metadata(std::move(metadata)), allocator(allocator), version(version)
 	{
 	}
 };

--- a/AI/MMAI/BAI/fallback/scripted_model.cpp
+++ b/AI/MMAI/BAI/fallback/scripted_model.cpp
@@ -46,13 +46,12 @@ Schema::Side ScriptedModel::getSide()
 // When MMAI fails to load an ML model, it loads a SCRIPTED model instead
 // as per MMAI mod's "fallback" setting in order to prevent a game crash.
 
-// The below methods should never be called on this object:
 int ScriptedModel::getVersion()
 {
-	warn("getVersion", -666);
-	return -666;
+	return -1;
 };
 
+// The below methods should never be called on this object:
 int ScriptedModel::getAction(const MMAI::Schema::IState * s)
 {
 	warn("getAction", -666);

--- a/AI/MMAI/BAI/router.cpp
+++ b/AI/MMAI/BAI/router.cpp
@@ -116,7 +116,7 @@ namespace
 					for(const auto & k : keysToAdd)
 					{
 						logAi->debug("MMAI: cache write: %s (%s)", k, path);
-						repo->models.try_emplace(k, std::pair(model, path));
+						repo->models.try_emplace(k, model, path);
 					}
 					break;
 				}

--- a/AI/MMAI/BAI/router.cpp
+++ b/AI/MMAI/BAI/router.cpp
@@ -24,57 +24,49 @@
 
 namespace MMAI::BAI
 {
-using ModelStorage = std::map<std::string, std::shared_ptr<MMAI::Schema::IModel>>;
+// key => {model, path}
+using ModelStorage = std::map<std::string, std::pair<std::shared_ptr<MMAI::Schema::IModel>, std::string>>;
 
 namespace
 {
 	struct ModelRepository
 	{
-		ModelStorage models;
+		mutable std::mutex mutex;
+		mutable ModelStorage models;
 		float temperature = 1.0;
 		uint64_t seed = 0;
-		std::unique_ptr<ScriptedModel> fallbackModel;
+		std::map<std::string, std::string> paths;
+		std::shared_ptr<ScriptedModel> fallbackModel;
 		std::string fallbackName;
 	};
 
-	std::unique_ptr<ModelRepository> InitModelRepository()
+	std::shared_ptr<ModelRepository> InitModelRepository()
 	{
 		auto repo = std::make_unique<ModelRepository>();
 		auto json = JsonUtils::assembleFromFiles("MMAI/CONFIG/mmai-settings.json");
-		if(!json.isStruct())
+		std::string fallback;
+
+		if(json.isStruct())
+		{
+			JsonUtils::validate(json, "vcmi:mmaiSettings", "mmai");
+			repo->temperature = static_cast<float>(json["temperature"].Float());
+
+			repo->seed = json["seed"].Integer();
+			if(repo->seed == 0)
+				repo->seed = CRandomGenerator::getDefault().nextInt();
+
+			for(const auto & [key, node] : json["models"].Struct())
+				repo->paths.try_emplace(key, "MMAI/models/" + node.String());
+
+			fallback = json["fallback"].isNull() ? "BattleAI" : json["fallback"].String();
+		}
+		else
 		{
 			logAi->error("Could not load MMAI config. Is MMAI mod enabled?");
-			std::string fallback = "BattleAI";
-			logAi->debug("MMAI: preparing fallback model: %s", fallback);
-			repo->fallbackModel = std::make_unique<ScriptedModel>(fallback);
-			repo->fallbackName = fallback;
-			return repo;
+			fallback = "BattleAI";
 		}
 
-		JsonUtils::validate(json, "vcmi:mmaiSettings", "mmai");
-		repo->temperature = static_cast<float>(json["temperature"].Float());
-
-		repo->seed = json["seed"].Integer();
-		if(repo->seed == 0)
-			repo->seed = CRandomGenerator::getDefault().nextInt();
-
-		for(const std::string key : {"attacker", "defender"})
-		{
-			std::string path = "MMAI/models/" + json["models"][key].String();
-
-			logAi->debug("MMAI: Loading NN %s model from: %s", key, path);
-			try
-			{
-				repo->models.try_emplace(key, CreateNNModel(path, repo->temperature, repo->seed));
-			}
-			catch(std::exception & e)
-			{
-				logAi->error("MMAI: error loading " + key + ": " + std::string(e.what()));
-			}
-		}
-
-		auto fallback = json["fallback"].isNull() ? "BattleAI" : json["fallback"].String();
-		logAi->debug("MMAI: preparing fallback model: %s", fallback);
+		logAi->debug("MMAI: repo initialized with fallback: %s", fallback);
 		repo->fallbackModel = std::make_unique<ScriptedModel>(fallback);
 		repo->fallbackName = fallback;
 
@@ -89,16 +81,71 @@ namespace
 
 	Schema::IModel * GetModel(const std::string & key)
 	{
-		const auto * config = GetModelRepository();
-		auto it = config->models.find(key);
-		if(it == config->models.end())
+		const auto * repo = GetModelRepository();
+		auto lock = std::lock_guard<std::mutex>(repo->mutex);
+
+		std::shared_ptr<Schema::IModel> model = nullptr;
+
+		// Search for "foo.bar.baz" -> "foo.bar" -> "foo"
+		auto currentKey = key;
+		auto keysToAdd = std::vector<std::string>{};
+
+		while(true)
 		{
-			logAi->error("MMAI: no %s model loaded, trying fallback: %s", key, config->fallbackName);
-			ASSERT(config->fallbackModel, "fallback failed: model is null");
-			return config->fallbackModel.get();
+			logAi->debug("MMAI: trying %s", currentKey);
+			auto it = repo->models.find(currentKey);
+
+			if(it != repo->models.end())
+			{
+				model = it->second.first;
+				logAi->debug("MMAI: cache hit: %s (%s)", currentKey, it->second.second);
+				break;
+			}
+
+			logAi->debug("MMAI: cache miss: %s", currentKey);
+			keysToAdd.push_back(currentKey);
+
+			auto itPath = repo->paths.find(currentKey);
+			if(itPath != repo->paths.end())
+			{
+				const auto & path = itPath->second;
+				logAi->debug("MMAI: Loading %s model from: %s", currentKey, path);
+				try
+				{
+					model = CreateNNModel(path, repo->temperature, repo->seed);
+					for(const auto & k : keysToAdd)
+					{
+						logAi->debug("MMAI: cache write: %s (%s)", k, path);
+						repo->models.try_emplace(k, std::pair(model, path));
+					}
+					break;
+				}
+				catch(std::exception & e)
+				{
+					logAi->error("MMAI: load error: %s: %s", currentKey, std::string(e.what()));
+				}
+			}
+			else
+			{
+				logAi->warn("MMAI: load error: %s: no path configured", currentKey);
+			}
+
+			// Try next key (if any)
+			auto pos = currentKey.rfind('.');
+			if(pos == std::string::npos)
+				break;
+
+			currentKey = currentKey.substr(0, pos);
 		}
 
-		return it->second.get();
+		if(!model)
+		{
+			logAi->error("MMAI: %s: falling back to %s", key, repo->fallbackName);
+			ASSERT(repo->fallbackModel, "fallback error: model is null");
+			model = repo->fallbackModel;
+		}
+
+		return model.get();
 	}
 
 	// Convert a memory address for logging purposes
@@ -245,7 +292,12 @@ void Router::battleStart(
 {
 	MMAI_LOG_TAG;
 	Schema::IModel * model;
-	const std::string modelkey = side == BattleSide::ATTACKER ? "attacker" : "defender";
+
+	std::string modelkey = side == BattleSide::ATTACKER ? "attacker" : "defender";
+
+	if(cb->getBattle(bid)->battleGetWallState(EWallPart::GATE) != EWallState::NONE)
+		modelkey += ".siege";
+
 	model = GetModel(modelkey);
 
 	logtag += ".v" + std::to_string(model->getVersion());

--- a/AI/MMAI/BAI/v13/BAI.cpp
+++ b/AI/MMAI/BAI/v13/BAI.cpp
@@ -40,7 +40,6 @@ Schema::Action BAI::getNonRenderAction()
 {
 	NestedLogTag _("NN");
 
-	// logger.info("getNonRenderAciton called with result type: " + std::to_string(result->type));
 	const auto * s = state.get();
 	auto action = model->getAction(s);
 	while(action == Schema::ACTION_RENDER_ANSI)

--- a/AI/MMAI/BAI/v13/battlefield.cpp
+++ b/AI/MMAI/BAI/v13/battlefield.cpp
@@ -12,6 +12,7 @@
 #include "battle/BattleHex.h"
 #include "battle/IBattleInfoCallback.h"
 #include "battle/ReachabilityInfo.h"
+#include "entities/building/TownFortifications.h"
 
 #include "BAI/v13/battlefield.h"
 #include "BAI/v13/hex.h"
@@ -52,6 +53,122 @@ namespace
 
 		return res;
 	}
+
+	/*
+	 * Attacks from a moat hex are only allowed when the attacker already
+	 * stands in the moat.
+	 * E.g. in this scenario:
+	 *
+	 *  . . . . ~ . .            Legend:
+	 * . . . . ~ . .              o o   active stack (wide)
+	 *  . . x ~ . . .             x     enemy stack
+	 * . . . ~ . . .              ~     moat
+	 *  . . . . o o .             .     empty hex
+	 * . . . ~ . . .
+	 *  . . . ~ . . .
+	 * . . . . ~ . .
+	 *
+	 * The active stack can attack from the below positions only:
+	 *
+	 *  . . . . ~ .  |  . . . . ~ .  |  . . . . ~ .  |  . . . . ~ .  |
+	 * . . o o ~ . . | . o o . ~ . . | . . . . ~ . . | . . . . ~ . . |
+	 *  . . x ~ . .  |  . . x ~ . .  |  o o x ~ . .  |  . . x ~ . .  |
+	 * . . . ~ . . . | . . . ~ . . . | . . . ~ . . . | . o o ~ . . . |
+	 *  . . . . . .  |  . . . . . .  |  . . . . . .  |  . . . . . .  |
+	 * . . . ~ . . . | . . . ~ . . . | . . . ~ . . . | . . . ~ . . . |
+	 *  . . . ~ . .  |  . . . ~ . .  |  . . . ~ . .  |  . . . ~ . .  |
+	 *
+	 * However, in this scenario:
+	 *
+	 *  . . . . ~ . .
+	 * . . . o õ . .
+	 *  . . x ~ . . .
+	 * . . . ~ . . .
+	 *
+	 * An attack from the same position is also possible.
+	 *
+	 * NOTE: the above example uses moat, but in practice any STOPPING hex
+	 * 		 (i.e. quicksand) uses the same logic.
+	 *
+	 *
+	 * NOTE:
+	 * Currently, in VCMI this logic applies to both flyers and non-flyers.
+	 * However, in vanilla H3 flyers CAN move-and-attack onto a moat hex:
+	 * https://discord.com/channels/298106089885401090/298106089885401090/1485333577049833532
+	 * If VCMI gets updated to match H3 logic, fix this function accordingly.
+	 *
+	 *
+	 * Unfortunately, this can't be handled in the Hex() constructor, as it
+	 * requires knowledge of other hexes => set it here, after all hexes
+	 * are constructed.
+	 *
+	 */
+	void FixMoatMasks(const CPlayerBattleCallback * battle, const Hexes * hexes, const Stack * astack)
+	{
+		// e.g. at battle start there is no active stack
+		if(!astack)
+			return;
+
+		// Mask out AMOVE actions (i.e. all actions except MOVE / SHOOT)
+		static_assert(EI(HexAction::MOVE) == 12);
+		static_assert(EI(HexAction::SHOOT) == 13);
+		static_assert(EI(HexAction::_count) == 14);
+		auto noAmove = HexActionMask(0b11000000000000); // leftmost bit = SHOOT
+		assert(noAmove.test(EI(HexAction::MOVE)));
+		assert(noAmove.test(EI(HexAction::SHOOT)));
+
+		for(int row = 0; row < 11; ++row)
+		{
+			for(int col = 0; col < 15; ++col)
+			{
+				const auto & hex = hexes->at(row).at(col);
+
+				// Stacks already standing on a STOPPING hex can attack from it
+				if(astack->cstack->getPosition() == hex->bhex)
+					continue;
+
+				// Flyers are not affected by STOPPING hexes
+				// XXX: in VCMI, flyers are also affected. If this changes in
+				// a future version, an if+continue check for flyers here is needed.
+
+				// Convenience for disallowing AMOVE actions
+				auto applyMask = [&noAmove, &hex]
+				{
+					hex->actmask &= noAmove;
+					hex->finalize();
+				};
+
+				// Moving onto a stopping hex aborts the attack => disallow
+				if(hex->statemask.test(EI(HexState::STOPPING)))
+				{
+					applyMask();
+					continue;
+				}
+
+				// Cases below are for wide creatures only
+				if(!astack->cstack->doubleWide())
+					continue;
+
+				bool isAttacker = astack->cstack->unitSide() == BattleSide::ATTACKER;
+
+				// When moving wide stacks, we must check if their tail
+				// will land on a STOPPING hex, as it will also abort the attack
+				// => disallow
+				if(isAttacker && col > 0)
+				{
+					const auto & nbh = hexes->at(row).at(col - 1);
+					if(nbh->statemask.test(EI(HexState::STOPPING)))
+						applyMask();
+				}
+				else if(!isAttacker && col < 14)
+				{
+					const auto & nbh = hexes->at(row).at(col + 1);
+					if(nbh->statemask.test(EI(HexState::STOPPING)))
+						applyMask();
+				}
+			}
+		}
+	}
 }
 
 Battlefield::Battlefield(const std::shared_ptr<Hexes> & hexes_, const Stacks & stacks_, const AllLinks & allLinks_, const Stack * astack_)
@@ -69,6 +186,9 @@ std::shared_ptr<const Battlefield> Battlefield::Create(
 {
 	auto [stacks, queue] = InitStacks(battle, acstack, oldgstats, gstats, stacksStats, isMorale);
 	auto [hexes, astack] = InitHexes(battle, acstack, stacks);
+
+	FixMoatMasks(battle, hexes.get(), astack);
+
 	auto links = InitAllLinks(battle, stacks, queue, hexes);
 
 	return std::make_shared<const Battlefield>(hexes, stacks, links, astack);

--- a/AI/MMAI/BAI/v13/hex.cpp
+++ b/AI/MMAI/BAI/v13/hex.cpp
@@ -356,6 +356,10 @@ void Hex::setActionMask(const std::shared_ptr<ActiveStackInfo> & astackinfo, con
 		if(n_cstack->unitSide() == a_cstack->unitSide())
 			continue;
 
+		// XXX: There is an edge case related to STOPPING hexes (moat/quicksand)
+		// where AMOVE should not be allowed.
+		// It cannot be handled here; see note FixMoatMasks() in battlefield.cpp
+
 		if(hexaction <= HexAction::AMOVE_TL)
 		{
 			ASSERT(CStack::isMeleeAttackPossible(a_cstack, n_cstack, bhex), "vcmi says melee attack is IMPOSSIBLE [1]");

--- a/AI/MMAI/BAI/v13/hex.h
+++ b/AI/MMAI/BAI/v13/hex.h
@@ -75,10 +75,10 @@ public:
 
 	std::string name() const;
 	int attr(HexAttribute a) const;
+	void finalize();
 
 private:
 	void setattr(HexAttribute a, int value);
-	void finalize();
 
 	void setStateMask(EAccessibility accessibility, const std::vector<std::shared_ptr<const CObstacleInstance>> & obstacles, BattleSide side);
 

--- a/config/schemas/mmaiSettings.json
+++ b/config/schemas/mmaiSettings.json
@@ -16,10 +16,12 @@
         "models" : {
             "type" : "object",
             "additionalProperties" : false,
-            "required" : [ "attacker", "defender" ],
+            "required" : [ "attacker", "attacker.siege", "defender", "defender.siege" ],
             "properties" : {
                 "attacker" : { "type" : "string" },
-                "defender" : { "type" : "string" }
+                "defender" : { "type" : "string" },
+                "attacker.siege" : { "type" : "string" },
+                "defender.siege" : { "type" : "string" }
             }
         },
         "fallback" : {


### PR DESCRIPTION
This PR makes it possible to load separate models for siege battles.

### Rationale

MMAI was being too aggressive during siege defense. Based on feedback from the Discord channels, I decided to train a separate model for siege defense which has a different playstyle. The code needs to be changed to load it only for in siege battles.

### Summary of changes
- **New model config keys**: `attacker.siege` and `defender.siege`, example:
    ```json
    // mmai-settings.json
    "models": {
      "attacker": "attacker-nkjrmrsq-202509291846.onnx",
      "defender": "defender-tukbajrv-1770544743.onnx",
      "defender.siege": "defender-fqcbvmti-best10.onnx"    // <-- new key for siege model
    }
    ```
    This can easily be extended for other "specific" models if needed in the future.
- **Improved fallback**
    If a model fails to load (e.g. not present in config, or file not found on disk, etc.), then a "less specific" model will be loaded. Example: `attacker.siege` fails to load => `attacker` will be loaded instead.
    The old fallback logic still applies: if `attacker` model fails to load, then BattleAI will be used.
- **Lazy instead of eager loading**
    Each model will be loaded only when first needed (instead of all models getting loaded when MMAI lib is loaded).
    Given the increased number of models, this avoids an unpleasant CPU spike at the start of the first battle in the game.
- **Fix for moats (and quicksand)**
    Changes in https://github.com/vcmi/vcmi/pull/7136 which are closely related to siege battles and have been included in this PR as well.
