### PR TITLE
Update daily builds server configuration and maintenance docs

### DIFF
--- a/.github/workflows/github.yml
+++ b/.github/workflows/github.yml
@@ -457,14 +457,14 @@ jobs:
             ${{ env.IOS_APPSTORE_SYMBOLS_DIR }}
 
     - name: Upload build to download.vcmi.eu
-      if: ${{ matrix.upload == 1 && github.event.number == '' && env.DEPLOY_RSA != '' }}
+      if: ${{ matrix.upload == 1 && github.event.number == '' && env.BUILDS_UPLOADER_PRIVATE_KEY != '' }}
       run: |
         if [ -z '${{ env.ANDROID_APK_PATH }}' ] ; then
           cd '${{github.workspace}}/out/build/${{matrix.preset}}'
         fi
         source '${{github.workspace}}/CI/upload_package.sh'
       env:
-        DEPLOY_RSA: ${{ secrets.DEPLOY_RSA }}
+        BUILDS_UPLOADER_PRIVATE_KEY: ${{ secrets.BUILDS_UPLOADER_PRIVATE_KEY }}
         PACKAGE_EXTENSION: ${{ matrix.extension }}
 
     - name: Prepare partial JSON with build informations

--- a/CI/upload_package.sh
+++ b/CI/upload_package.sh
@@ -1,15 +1,15 @@
 #!/bin/sh
-if [ -z "$DEPLOY_RSA" ];
+if [ -z "$BUILDS_UPLOADER_PRIVATE_KEY" ];
 then
 	# Due to security measures travis not expose encryption keys for PR from forks
 	echo "Build generation is skipped for forks"
 	exit 0
 fi
 
-echo "$DEPLOY_RSA" > /tmp/deploy_rsa
+echo "$BUILDS_UPLOADER_PRIVATE_KEY" > /tmp/deploy_rsa
 chmod 600 /tmp/deploy_rsa
 
 eval "$(ssh-agent -s)"
 ssh-add /tmp/deploy_rsa
 
-sftp -r -o StrictHostKeyChecking=no travis@beholder.vcmi.eu <<< "put $VCMI_PACKAGE_FILE_NAME.$PACKAGE_EXTENSION /incoming/$VCMI_PACKAGE_FILE_NAME.$PACKAGE_EXTENSION"
+sftp -r -o StrictHostKeyChecking=no uploader@upload.vcmi.eu <<< "put $VCMI_PACKAGE_FILE_NAME.$PACKAGE_EXTENSION /uploads/$VCMI_PACKAGE_FILE_NAME.$PACKAGE_EXTENSION"

--- a/docs/maintainers/Daily_Builds.md
+++ b/docs/maintainers/Daily_Builds.md
@@ -1,0 +1,16 @@
+# Builds downloads server
+
+RAM requirements: non-existing
+CPU requirements: non-existing
+SSD requirements: 100 GB, ideally - 200 GB. Can be located on a separate volume
+
+## Setup
+
+- Copy scripts from `scripts` directory to `/root/scripts`
+- Execute script `setup_uploader.sh`
+- If needed, attach volume for builds storage via fstab: `/dev/disk/by-id/scsi-0DO_Volume_vcmi-second-builds /home/downloader ext4 defaults,nofail,discard 0 0`
+- Ensure that `/home/downloader` and `/home/downloader/www` are owned by root, while all `/home/downloader/www` content is owned by `downloader` user
+- Copy sites definitions from `scripts/sites` to `/etc/nginx/sites-available` and symlink them to `/etc/nginx/sites-enabled`
+- Add certificates to nginx
+- Install `fancy_index` nginx module: `apt install libnginx-mod-http-fancyindex`
+- Restart nginx

--- a/docs/maintainers/Discourse.md
+++ b/docs/maintainers/Discourse.md
@@ -1,0 +1,92 @@
+# Discourse
+
+- RAM requirements: ~1.5 GB.
+- CPU requirements: 1 core
+- SSD requirements: ~20 GB. May be more over time
+
+Accessible as [forum.vcmi.eu](https://forum.vcmi.eu/)
+
+Admin access:
+
+- Ivan Savenko
+- AVS
+- SXX
+- Warmonger
+
+Additional accounts can be given admin rights via admin panel. Or, if none are available - directly via server console (requires root access to server)
+
+## Configuration
+
+- Located at `/var/discourse`.
+- Configuration file is at `/var/discourse/containers/app.yml`
+- For administration typical approach is `cd /var/discourse; ./launcher enter app`. However most commands are also available in web UI
+- To apply configuration changes, `cd /var/discourse; ./launcher rebuild app`. WARNING: this will also perform update of Discourse itself!
+
+## Setup
+
+References:
+
+- [official docs](https://github.com/discourse/discourse/blob/main/docs/INSTALL-cloud.md):
+- [nginx multi-server configuration](https://meta.discourse.org/t/run-other-websites-on-the-same-machine-as-discourse/17247)
+
+```sh
+wget -qO- https://raw.githubusercontent.com/discourse/discourse_docker/main/install-discourse | sudo bash
+```
+
+Configure Discourse to run through nginx outside of container, to allow multiple sites to be hosted on same server.
+
+1. Install nginx
+2. Edit configuration at `/var/discourse/containers/app.yml`:
+3. Configure nginx server
+4. Rebuild app and restart nginx
+
+Modified configuration file:
+
+```text
+  - "templates/postgres.template.yml"
+  - "templates/redis.template.yml"
+  - "templates/web.template.yml"
+  - "templates/web.ratelimited.template.yml"
+  - "templates/web.socketed.template.yml"  # <-- Added
+#   - "templates/web.ssl.template.yml" # remove - https will be handled by outer nginx
+#   - "templates/web.letsencrypt.ssl.template.yml" # remove -- https will be handled by outer nginx
+# expose: # comment out entire section by putting a # in front of each line
+# - "80:80"   # http
+# - "443:443" # https  
+```
+
+Approximate order of commands:
+
+```sh
+cd /var/discourse
+apt install nginx
+nano containers/app.yml
+
+cd /etc/nginx/sites-available
+cp default forum.vcmi.eu
+cd ../sites-enabled
+ln -s ../sites-available/forum.vcmi.eu
+
+./launcher rebuild app
+sudo service nginx reload
+```
+
+## Upgrade
+
+```sh
+cd /var/discourse
+./launcher rebuild app
+```
+
+Alternatively can be done in UI, but untested
+
+## Migration
+
+When setting up Discourse, it needs to be already located on target domain name, so it might be a good idea to do operations in following order:
+
+- create backup on old server (or pick latest weekly backup)
+- switch domain name to new IP & wait for DNS to propagate
+- ensure that ports 80 and 443 are open on new server
+- setup Discourse on new server
+- restore backup either in web interface or in console on new server
+- adjust or migrate configuration file from old server to new one

--- a/docs/maintainers/Multiplayer_Lobby.md
+++ b/docs/maintainers/Multiplayer_Lobby.md
@@ -1,0 +1,48 @@
+# Multiplayer lobby
+
+- RAM requirements: ~1 GB (can be potentially reduced if we were to track down all un-indexed sqlite queries)
+- CPU requirements: 1 core (preferrably dedicated to ensure low latency)
+- SSD requirements: up to 4 Gb (depending on log and database size over time)
+
+Exposed to public as `beholder.vcmi.eu:3031` or `lobby.vcmi.eu:3031`
+
+- Start: `cd /home/vcmilobby/build/bin && ./vcmilobby &`
+- Stop: `killall -9 vcmilobby`
+- Examine database (can be done live): `sqlite3 ~/.local/share/vcmi/vcmiLobby.db`
+- Examine log file: `nano ~/.cache/vcmi/VCMI_Lobby_log.txt`
+
+## TODO
+
+- Update lobby setup to allow running it as non-root
+- Set up PPA with lobby builds and install lobby from PPA instead of building from sources
+- Migrate lobby to new domain name (`lobby.vcmi.eu:3031`). Needs adjustment to automatically move existing login information
+- (long term) expand lobby functionality, including vcmiserver hosting for cheat-proof MP
+
+## Setup
+
+```sh
+git clone https://github.com/vcmi/vcmi.git
+mkdir build
+cmake -DENABLE_EDITOR=OFF -DENABLE_CLIENT=OFF -DENABLE_SERVER=OFF -DENABLE_LAUNCHER=OFF -DENABLE_TEST=OFF -DENABLE_LOBBY=ON -DENABLE_MINIMAL_LIB=ON -DENABLE_PCH=OFF -DENABLE_STATIC_LIBS=ON ../vcmi`
+make
+```
+
+Note: rebuild may take up to 15 minutes. During updates you might want to rebuild first, without shutting down server and then - quickly restart server
+Note: server has configured swap file specifically to allow building vcmilobby locally. System memory usage was slightly over 1 Gb during build.
+
+### Upgrade
+
+```sh
+cd /home/vcmilobby/vcmi && git pull --ff-only
+cd /home/vcmilobby/build && make
+killall -9 vcmilobby
+cd /home/vcmilobby/build/bin && ./vcmilobby &
+```
+
+#### Migration
+
+- setup binary on new server
+- stop old server
+- transfer database at `~/.local/share/vcmi/vcmiLobby.db` to new server
+- adjust domain name to point to new server. WARNING: clients store login information based on DNS name. If new server has new DNS name, some code adjustments will be needed
+- start new server

--- a/docs/maintainers/Project_Infrastructure.md
+++ b/docs/maintainers/Project_Infrastructure.md
@@ -1,98 +1,64 @@
 # Project Infrastructure
 
-This section hold important information about project infrastructure for current and future contributors. At moment it's all maintained by me (SXX), but following information will be useful if someone going to replace me in future.
-
-## Services and accounts
-
-So far we using following services:
-
-### Most important
-
-- VCMI.eu domain paid until July of 2019.
-  - Owner: Tow
-  - Our main domain used by services.
-- VCMI.download paid until November of 2026.
-  - Owner: SXX
-  - Intended to be used for all assets downloads.
-  - Domain registered on GANDI and **can be renewed by anyone without access to account**.
-- [DigitalOcean](https://cloud.digitalocean.com/) team.
-  - Our hosting sponsor.
-  - Administrator access: SXX, Warmonger.
-  - User access: AVS, Tow.
-- [CloudFlare](https://www.cloudflare.com/a/overview) account.
-  - Access through shared login / password.
-  - All of our infrastructure is behind CloudFlare and all our web. We manage our DNS there.
-- [Google Apps (G Suite)](https://admin.google.com/) account.
-  - It's only for vcmi.eu domain and limited to 5 users. Each account has limit of 500 emails / day.
-  - One administrative email used for other services registration.
-  - "noreply" email used for outgoing mail on Wiki and Bug Tracker.
-  - "forum" email used for outgoing mail on Forums. Since we authenticate everyone through forum it's should be separate email.
-  - Administrator access: Tow, SXX.
-- [Google Play Console](https://play.google.com/apps/publish/) account.
-  - Hold ownership over VCMI Android App.
-  - Owner: SXX
-  - Administrator access: Warmonger, AVS, Ivan.
-  - Release manager access: Fay.
-
-Not all services let us safely share login credentials, but at least when possible at least two of core developers must have access to them in case of emergency.
-
-### Public relations
-
-We want to notify players about updates on as many social services as possible.
-
-- Facebook page: <https://www.facebook.com/VCMIOfficial>
-  - Administrator access: SXX, Warmonger
-- Twitter account: <https://twitter.com/VCMIOfficial>
-  - Administrator access: SXX.
-- User access via TweetDeck:
-  - VK / VKontakte page: <https://vk.com/VCMIOfficial>
-- Owner: SXX
-  - Administrator access: AVS
-- Steam group: <https://steamcommunity.com/groups/VCMI>
-  - Administrator access: SXX
-- Moderator access: Dydzio
-  - Reddit: <https://reddit.com/r/vcmi/>
-- Administrator access: SXX
-  - ModDB entry: <http://www.moddb.com/engines/vcmi>
-- Administrator access: SXX
-
-### Communication channels
-
-- Slack team: <https://h3vcmi.slack.com/>
-  - Owner: vmarkovtsev
-  - Administrator access: SXX, Warmonger, AVS...
-- Trello team: <https://trello.com/vcmi/>
-  - Administrator access: SXX
-- Discord:
-  - Owner: dydzio
-  - Administrator access: SXX, Warmonger, Ivan...
-
-### Other services
-
-- Launchpad PPA: <https://launchpad.net/~vcmi>
-  - Member access: AVS
-  - Administrator access: Ivan, SXX
-- Snapcraft Dashboard: <https://dashboard.snapcraft.io/>
-  - Administrator access: SXX
-- Coverity Scan page: <https://scan.coverity.com/projects/vcmi>
-  - Administrator access: SXX, Warmonger, AVS
-- OpenHub page: <https://www.openhub.net/p/VCMI>
-  - Administrator access: Tow
-- Docker Hub organization: <https://hub.docker.com/u/vcmi/>
-  - Administrator access: SXX
-
-Reserve accounts for other code hosting services:
-
-- GitLab organization: <https://gitlab.com/vcmi/>
-  - Administrator access: SXX
-- BitBucket organization: <https://bitbucket.org/vcmi/>
-  - Administrator access: SXX
-
 ## What's to improve
 
 1. Encourage Tow to transfer VCMI.eu to GANDI so it's can be also renewed without access.
-2. Use 2FA on CloudFlare and just ask everyone to get FreeOTP and then use shared secret.
-3. Centralized way to post news about game updates to all social media.
+2. Centralized way to post news about game updates to all social media.
+3. Verify VCMI.eu domain name expiration date with Tow
+4. Verify VCMI.download domain name expiration date with SXX
+5. Verify Google Apps (G Suite) status with Tow
+6. Restore firewall which for some reason is disabled on DO
+7. Migrate remaining services from `vcmi-second` droplet
+
+## Services and accounts
+
+### Infrastructure
+
+| Service | Details | Owner | Administrators | Notes |
+| ------- | ------- | ----- | -------------- | ----- |
+| [GitHub](https://github.com/vcmi/) | Code hosting, bug tracker, pull requests, website hosting | - | Tow, AVS, Ivan, Warmonger, SXX | - |
+| [VCMI.eu domain name](https://vcmi.eu) | Main domain for services | Tow | - | Renewal date **unknown** |
+| [VCMI.download domain name](https://vcmi.download) | Secondary domain name for downloads | SXX | - | Paid until **November 2026**. Registered on GANDI; **can be renewed by anyone without account access** |
+| [DigitalOcean](https://cloud.digitalocean.com/) | Hosting sponsor for all our self-hosted services | - | SXX, Warmonger, Ivan, AVS, Tow | - |
+| [CloudFlare](https://www.cloudflare.com/a/overview) | DNS & CDN for our web services | - | SXX, Ivan | All our web services are behind CloudFlare and use Cloudflare SSL certificates |
+| [Weblate](https://hosted.weblate.org/projects/vcmi/) | Game translations | - | Ivan | Hosts translations for VCMI itself (not including mods & website). Uses free "Gratis" plan |
+| [Google Play Console](https://play.google.com/apps/publish/) | VCMI Android App | SXX | Warmonger, AVS, Ivan, Fay | - |
+| [Google Apps (G Suite)](https://admin.google.com/) | Email for vcmi.eu domain | - | Tow, SXX | Limited to 5 users; 500 emails/day limit per account. Includes: admin email (service registration), "noreply" (Wiki/Bug Tracker), "forum" (Forums authentication). **Likely dead. Verify with Tow** |
+| [Launchpad PPA](https://launchpad.net/~vcmi) | Ubuntu package repository | Mantas Kriaučiūnas | Ivan, SXX, AVS | Contains daily builds and latest releases PPA's for Ubuntu |
+| [Sonar Cloud](https://sonarcloud.io/project/overview?id=vcmi_vcmi) | Code analysis | - | Shares credentials with Github | Integrated into Github pull requests |
+| [Discord Team](https://discord.com/developers/teams/1467529815450976543/information/) | Discord app holder | Ivan | Laserlicht, dydzio, Warmonger | Holds ownership of [Discord VCMI app](https://discord.com/developers/applications/1416538363254669455/information) that is used to display rich presence when people are playing VCMI |
+| [Snapcraft Dashboard](https://dashboard.snapcraft.io/) | Snap package distribution | - | SXX | Abandoned in favor of Flatpaks and PPA |
+| [Coverity Scan](https://scan.coverity.com/projects/vcmi) | Code analysis | - | SXX, Warmonger, AVS | Abandoned in favor of Sonar Cloud |
+| [OpenHub](https://www.openhub.net/p/VCMI) | Code statistics | - | Tow | - |
+| [Docker Hub](https://hub.docker.com/u/vcmi/) | Container registry | - | SXX | Abandoned and never used? |
+| [GitLab](https://gitlab.com/vcmi/) | Code repository | - | SXX | Reserve account, not used |
+| [BitBucket](https://bitbucket.org/vcmi/) | Code repository | - | SXX | Reserve account, not used |
+
+Note: "Owner" refers to services that require one (and only one) account to have special superuser-like status, potentially - with legal and/or biling information. If service has no such requirement, this field is left blanc.
+
+When possible at least two of active core developers must have access to them in case of emergency.
+
+#### Communities with page managed by VCMI Team
+
+| Service Name | Owner | Administrators | Notes |
+| ------------ | ----- | -------------- | ----- |
+| [Discord](https://discord.com/) | dydzio | SXX, Warmonger, Ivan... | Main communication platform |
+| [Facebook page](https://www.facebook.com/VCMIOfficial) | — | SXX, Warmonger | Active |
+| [Reddit](https://reddit.com/r/vcmi/) | — | SXX | Abandoned in favor of general H3 subreddits |
+| [Twitter account](https://twitter.com/VCMIOfficial) | — | SXX | Abandoned, User access via TweetDeck |
+| [VK / VKontakte page](https://vk.com/VCMIOfficial) | SXX | AVS | Abandoned |
+| [Steam group](https://steamcommunity.com/groups/VCMI) | SXX | Dydzio | Abandoned |
+| [ModDB entry](http://www.moddb.com/engines/vcmi) | — | SXX | Abandoned |
+| [Slack team](https://h3vcmi.slack.com/) | vmarkovtsev | SXX, Warmonger, AVS... | Abandoned in favor of Discord |
+| [Trello team](https://trello.com/vcmi/) | — | SXX | Abandoned |
+
+#### Heroes 3 communities with VCMI Team presence
+
+| Service Name | Active team members | Notes |
+| ------------ | ------------------- | ----- |
+| [VCMI thread on Heroes Community](http://heroescommunity.com/viewthread.php3?TID=30659&pagenumber=1) | Warmonger, Ivan, dydzio... | Very low player activity |
+| [Heroes 3 subreddit](https://www.reddit.com/r/heroes3/) | Ivan, dydzio... | VCMI-related questions are rather common |
+| [HoMM subreddit](https://www.reddit.com/r/HoMM/) | Ivan, dydzio... | Way less active than Heroes 3 subreddit, but sometimes posts about VCMI do appear |
 
 ## Project Servers Configuration
 
@@ -100,18 +66,27 @@ This section dedicated to explain specific configurations of our servers for any
 
 ### Droplet configuration
 
-Currently we using two droplets:
+All droplets can only be accessed using ssh login with public key. Currently access to all droplets is granted to:
 
-- First one serve all of our web services:
-  - [Forum](https://forum.vcmi.eu/)
-  - [Bug tracker](https://bugs.vcmi.eu/)
-  - [Wiki](https://wiki.vcmi.eu/)
-  - [Slack invite page](https://slack.vcmi.eu/)
-- Second serve downloads:
-  - [Legacy download page](http://download.vcmi.eu/)
-  - [Build download page](https://builds.vcmi.download/)
+- Ivan Savenko
+- Alexvins
+- Warmonger
+- Tow
+- SXX
+- kambala (`vcmi-artifactory` droplet)
 
-To keep everything secure we should always keep binary downloads separate from any web services.
+| Droplet | Specifications | Services |
+| ------- | -------------- | -------- |
+| `vcmi-artifactory` | 4 Gb / 2 CPU / 80 Gb / $24 | [Conan Artifactory server](https://artifactory.vcmi.eu/) (WIP) |
+| `vcmi-forum` | 2 Gb / 1 CPU / 25 Gb / $12 (+20%) | [Discourse forum](https://forum.vcmi.eu/) |
+| `vcmi-second` | 1 Gb / 1 CPU / 20 Gb + 100 Gb / $6 + $10 | Multiplayer lobby (lobby.vcmi.eu or beholder.vcmi.eu - deprecated). Floating IP: 67.207.75.182, Builds uploading from Github, [Build download page](http://download.vcmi.eu/), [Legacy download page](https://builds.vcmi.download/) |
+| `vcmi-web` | 512 Mb / 1 CPU / 10 Gb / $4 (+20%) | Contains nginx server for redirecting [old bug tracker](https://bugs.vcmi.eu/), [old wiki](https://wiki.vcmi.eu/), and [old slack invite page](https://slack.vcmi.eu/) |
+
+Notes:
+
+- Droplets with deployed services have backups enabled (+20% costs)
+- In addition to droplets, we have separate 100 Gb volume for builds ($10 / month), currently attached to `vcmi-second`
+- There is snapshot for old `vcmi-main` droplet, preserved in case if we need to retrieve some data from it - old bugtracker, forum, and wiki ($1.5 / month)
 
 ### Rules to stick to
 
@@ -124,9 +99,51 @@ To keep everything secure we should always keep binary downloads separate from a
 
 ### Our publicly-facing server
 
-We only expose floating IP that can be detached from droplet in case of emergency using [DO control panel](https://cloud.digitalocean.com/networking/floating_ips). This also allow us to easily move public services to dedicated droplet in future.
+We only expose reserve IP that can be detached from droplet in case of emergency using DO control panel. This also allow us to easily move public services to dedicated droplet in future.
 
 - Address: beholder.vcmi.eu (67.207.75.182)
 - Port 22 serve SFTP for file uploads as well as CI artifacts uploads.
 
 If new services added firewall rules can be adjusted in [DO control panel](https://cloud.digitalocean.com/networking/firewalls).
+
+## Domain names
+
+| Domain | Content | Hosted on | Notes |
+| ------ | ------- | --------- | ----- |
+| [vcmi.eu](https://vcmi.eu) | Main page redirect | CNAME | No content, redirects to [real main page](https://vcmi.github.io/) |
+| [download.vcmi.eu](https://download.vcmi.eu) | Public downloads & daily builds | `vcmi-second` | - |
+| [beholder.vcmi.eu](https://beholder.vcmi.eu) | Multiplayer lobby | `vcmi-second` | No http services. Used for VCMI 1.7 lobby and older. Also handles build uploads from Github. Deprecated in favor of lobby and uploads |
+| [lobby.vcmi.eu](https://lobby.vcmi.eu) | Multiplayer lobby | `vcmi-second` | No http services |
+| [forum.vcmi.eu](https://forum.vcmi.eu) | Discourse forum | `vcmi-forum` | - |
+| [bugs.vcmi.eu](https://bugs.vcmi.eu) | Bug tracker | `vcmi-web` | Redirects to [Github Issues](https://github.com/vcmi/vcmi/issues) |
+| [slack.vcmi.eu](https://slack.vcmi.eu) | Slack invite page | `vcmi-web` | Redirects to [main page](https://vcmi.eu/) |
+| [wiki.vcmi.eu](https://wiki.vcmi.eu) | Wiki | `vcmi-web` | Redirects to [main page](https://vcmi.eu/) |
+| [vcmi.download](https://vcmi.download) | Main page redirect | CNAME | No content, redirects to [main page](https://vcmi.eu/) |
+| [builds.vcmi.download](https://builds.vcmi.download) | Public downloads | `vcmi-second` | Same content as main download server. Known bug: excessive caching. Potentially deprecated in favor of main domain |
+| [dependencies.vcmi.download](https://dependencies.vcmi.download) | — | — | Not configured |
+| [mods.vcmi.download](https://mods.vcmi.download) | — | — | Not configured |
+
+## Self-hosted services
+
+Currenly we have following services deployed:
+
+- [Discourse](Discourse.md)
+- [Multiplayer lobby](Multiplayer_Lobby.md)
+- [Downloads & daily builds](Daily_Builds.md)
+
+Potential addition for the future:
+
+- Conan Artifactory
+- Self-hosted Weblate, to bypass Libre tier restrictions on our Weblate hosted by upstream team and allow translation of Heroes 3, mods, and VCMI website
+- Crash reporter tool, such as [GlitchTip](https://glitchtip.com/)
+- (long-term) Expanded multiplayer lobby with cheat-proof game hosting
+
+### Web Hosting
+
+For all web services we use Nginx, including websites that run on standalone servers. This allows to easily migrate more services onto another server that already has some services, and use nginx reverse proxy to host all such services on same 443 port.
+
+For certificates all services use Cloudflare Origin certificates. These certificates are issued for free in Cloudflare web UI, have expiration period of 10 years (oldest VCMI certificate will expire in 2032), but can only be used by services that are located behind Cloudflare, which all VCMI services do. Client-facing certificates are managed and automatically updated by Cloudflare.
+
+### Configuration files
+
+See scripts directory that contains most of customized configuration files used on our servers. For obvious reasons, sensitive parts that include password and other non-public data are excluded for it

--- a/docs/maintainers/scripts/download/FOOTER.html
+++ b/docs/maintainers/scripts/download/FOOTER.html
@@ -1,0 +1,13 @@
+<h4>
+<a href="http://forum.vcmi.eu/portal.php">Site</a>
+ | 
+<a href="https://discord.gg/chBT42V">Discord</a>
+ |
+<a href="http://forum.vcmi.eu/">Forums</a>
+ | 
+<a href="https://github.com/vcmi/vcmi">GitHub</a>
+</h4>
+<h5>
+Hosting provided by <a href="https://www.digitalocean.com/" target="_blank" rel="noopener">DigitalOcean</a>
+</h5>
+</body></html>

--- a/docs/maintainers/scripts/download/HEADER.html
+++ b/docs/maintainers/scripts/download/HEADER.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta name="viewport" content="width=device-width"/>
+<meta http-equiv="content-type" content="text/html; charset=utf-8"/>
+<style type="text/css">
+body,html {background:#fff;font-family:"Bitstream Vera Sans","Lucida Grande","Lucida Sans Unicode",Lucidux,Verdana,Lucida,sans-serif;}
+tr:nth-child(even) {background:#f4f4f4;}th,td {padding:0.1em 0.5em;}th {text-align:left;font-weight:bold;background:#eee;border-bottom:1px solid #aaa;}
+#list {border:1px solid #aaa;width:100%;}a {color:#a33;}a:hover {color:#e33;}
+h4,h5{margin-top:0.5em;margin-bottom:0.5em;}
+h1{margin-top:0.3em;margin-bottom:0.3em;}
+</style>
+
+<title>VCMI Project Builds</title>
+</head><body>
+<h1>VCMI Project builds<H1>
+<h4>
+<a href="http://forum.vcmi.eu/portal.php">Site</a>
+ |
+<a href="https://discord.gg/chBT42V">Discord</a>
+ |
+<a href="http://forum.vcmi.eu/">Forums</a>
+ |
+<a href="https://github.com/vcmi/vcmi">GitHub</a>
+</h4>
+<h5>
+Follow us: <a href="https://www.facebook.com/VCMIOfficial">Facebook</a>
+ | 
+<a href="https://twitter.com/VCMIOfficial">Twitter</a>
+ | 
+<a href="https://reddit.com/r/vcmi/">Reddit</a>
+</h5>
+<h1>Index of 

--- a/docs/maintainers/scripts/ensure_free_space.sh
+++ b/docs/maintainers/scripts/ensure_free_space.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# Ensures that used space on drive that contains this directory stays below 90%
+# Oldest builds will be automatically removed to make space for new uploads
+
+# Base directory that needs free space
+TARGET_DIR="/home/downloader/www/branch"
+# Exlude master builds (releases) from auto-removal
+EXCLUDE_DIR="/home/downloader/www/branch/master"
+# Arbitrary threshold, can be adjusted
+USAGE_THRESHOLD=90
+
+while true; do
+    # Calculate disk usage percentage
+    USAGE=$(df "$TARGET_DIR" | awk 'NR==2 {print int($5)}')
+    echo "Current disk usage of $TARGET_DIR is: $USAGE%"
+
+    # Check if usage is above threshold
+    if [[ $USAGE -gt $USAGE_THRESHOLD ]]; then
+        # Find the modification time of oldest file across all subdirectories
+        OLDEST_MTIME=$(find "$TARGET_DIR" -type f -path "$EXCLUDE_DIR" -prune -o -type f -exec stat -c %Y {} \; | sort -n | head -1)
+
+        if [[ -z "$OLDEST_MTIME" ]]; then
+            echo "No files found to delete"
+            break
+        fi
+
+        # Calculate age in days
+        CURRENT_TIME=$(date +%s)
+        AGE_DAYS=$(( (CURRENT_TIME - OLDEST_MTIME) / 86400 ))
+        echo "Oldest file: $OLDEST_FILE (Age: $AGE_DAYS days)"
+
+        # Delete all files with the same age in all subdirectories using mtime
+        find "${SUBDIRS[@]/#/$TARGET_DIR/}" -type f -mtime "$AGE_DAYS" -delete
+        echo "Deleted files with age $AGE_DAYS days"
+    else
+        echo "Disk usage is below threshold ($USAGE% < $USAGE_THRESHOLD%)"
+        break
+    fi
+done

--- a/docs/maintainers/scripts/nginx/bugs.vcmi.eu
+++ b/docs/maintainers/scripts/nginx/bugs.vcmi.eu
@@ -1,0 +1,12 @@
+server {
+	listen 443 ssl;
+	listen [::]:443 ssl;
+
+        ssl_certificate /etc/nginx/certs/dot.vcmi.eu.pem;
+        ssl_certificate_key /etc/nginx/certs/dot.vcmi.eu.key;
+        ssl_client_certificate /etc/nginx/certs/cloudflare-client.crt;
+        ssl_verify_client on;
+
+        server_name bugs.vcmi.eu;
+        return 301 https://github.com/vcmi/vcmi/issues;
+}

--- a/docs/maintainers/scripts/nginx/builds.vcmi.download
+++ b/docs/maintainers/scripts/nginx/builds.vcmi.download
@@ -1,0 +1,14 @@
+server {
+        listen 443 ssl;
+        listen [::]:443 ssl;
+      
+        server_name builds.vcmi.download;
+    
+        ssl on;
+        ssl_certificate /etc/nginx/certs/builds.vcmi.download.pem;
+        ssl_certificate_key /etc/nginx/certs/builds.vcmi.download.key;
+        ssl_client_certificate /etc/nginx/certs/cloudflare-client.crt;
+        ssl_verify_client on;
+    
+        return 301 https://builds.vcmi.eu$request_uri;
+}

--- a/docs/maintainers/scripts/nginx/download.vcmi.eu
+++ b/docs/maintainers/scripts/nginx/download.vcmi.eu
@@ -1,0 +1,42 @@
+server {
+        listen 443 ssl;
+        listen [::]:443 ssl;
+
+        root /home/downloader/www;
+        access_log /var/log/nginx/builds.access.log;
+        error_log /var/log/nginx/builds.error.log;
+        index index.html index.htm;
+
+        server_name download.vcmi.eu;
+
+        ssl on;
+        ssl_certificate /etc/nginx/certs/dot.vcmi.eu.pem;
+        ssl_certificate_key /etc/nginx/certs/dot.vcmi.eu.key;
+        ssl_client_certificate /etc/nginx/certs/cloudflare-client.crt;
+        ssl_verify_client on;
+
+        location / {
+                fancyindex on;
+                fancyindex_ignore HEADER.html FOOTER.html;
+                fancyindex_header /HEADER.html;
+                fancyindex_footer /FOOTER.html;
+                fancyindex_exact_size on;
+                fancyindex_default_sort name;
+                error_page 404 =  @toindex;
+        }
+
+# e.g. /branch/<branch name>/<platform>/ - sort by date
+        location ~ ^/[^/]+/[^/]+/[^/]+/ {
+                fancyindex on;
+                fancyindex_ignore HEADER.html FOOTER.html;
+                fancyindex_header /HEADER.html;
+                fancyindex_footer /FOOTER.html;
+                fancyindex_exact_size on;
+                fancyindex_default_sort date_desc;
+                error_page 404 =  @toindex;
+        }
+
+        location @toindex {
+            rewrite  .*  / redirect;
+        }
+}

--- a/docs/maintainers/scripts/nginx/forum.vcmi.eu
+++ b/docs/maintainers/scripts/nginx/forum.vcmi.eu
@@ -1,0 +1,20 @@
+server {
+	listen 443 ssl;
+	listen [::]:443 ssl;
+
+	server_name forum.vcmi.eu;
+
+	ssl_certificate /etc/nginx/certs/forum.vcmi.eu.pem;
+	ssl_certificate_key /etc/nginx/certs/forum.vcmi.eu.key;
+	ssl_client_certificate /etc/nginx/certs/cloudflare-client.crt;
+	ssl_verify_client on;
+
+	location / {
+		proxy_pass http://unix:/var/discourse/shared/standalone/nginx.http.sock:;
+		proxy_set_header Host $http_host;
+		proxy_http_version 1.1;
+		proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+		proxy_set_header X-Forwarded-Proto $scheme;
+		proxy_set_header X-Real-IP $remote_addr;
+	}
+}

--- a/docs/maintainers/scripts/nginx/slack.vcmi.eu
+++ b/docs/maintainers/scripts/nginx/slack.vcmi.eu
@@ -1,0 +1,12 @@
+server {
+	listen 443 ssl default_server;
+	listen [::]:443 ssl default_server;
+
+        ssl_certificate /etc/nginx/certs/dot.vcmi.eu.pem;
+        ssl_certificate_key /etc/nginx/certs/dot.vcmi.eu.key;
+        ssl_client_certificate /etc/nginx/certs/cloudflare-client.crt;
+        ssl_verify_client on;
+
+        server_name slack.vcmi.eu;
+        return 301 https://vcmi.eu/;
+}

--- a/docs/maintainers/scripts/nginx/wiki.vcmi.eu
+++ b/docs/maintainers/scripts/nginx/wiki.vcmi.eu
@@ -1,0 +1,12 @@
+server {
+	listen 443 ssl;
+	listen [::]:443 ssl;
+
+        ssl_certificate /etc/nginx/certs/dot.vcmi.eu.pem;
+        ssl_certificate_key /etc/nginx/certs/dot.vcmi.eu.key;
+        ssl_client_certificate /etc/nginx/certs/cloudflare-client.crt;
+        ssl_verify_client on;
+
+        server_name wiki.vcmi.eu;
+        return 301 https://vcmi.eu/;
+}

--- a/docs/maintainers/scripts/on_cron_update.sh
+++ b/docs/maintainers/scripts/on_cron_update.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+find /home/uploader/uploads -type f -mmin +2 -exec chmod 644 {} \; -exec chown downloader:downloader {} \; -print0 | xargs -0 -I {} mv {} /home/downloader/tmp
+
+sudo -u downloader ensure_free_space.sh
+sudo -u downloader sort_builds.sh

--- a/docs/maintainers/scripts/setup_uploader.sh
+++ b/docs/maintainers/scripts/setup_uploader.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+useradd -m -s /usr/sbin/nologin uploader
+mkdir -p /home/uploader/uploads
+mkdir -p /home/uploader/.ssh
+
+# Install key stored as Github secret in vcmi/vcmi repository
+echo "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGfZ1TNzHf7ECsC32/9dSHViMoJMMq/e1kB4NV9i6SDY root@vcmi-web" >/home/uploader/.ssh/authorized_keys
+
+chown root:root /home/uploader
+chown uploader:uploader /home/uploader/uploads
+chown -R uploader:uploader /home/uploader/.ssh
+
+chmod 755 /home/uploader
+chmod 333 /home/uploader/uploads
+chmod 700 /home/uploader/.ssh
+chmod 600 /home/uploader/.ssh/authorized_keys
+
+echo "Copy uploader-uses-sftp.conf to /etc/ssh/sshd_config.d/"
+
+useradd -m -s /bin/false downloader
+
+(crontab -l 2>/dev/null; echo "* * * * * /opt/vcmiscripts/on_cron_update.sh") | crontab -

--- a/docs/maintainers/scripts/sftp/uploader-uses-sftp.conf
+++ b/docs/maintainers/scripts/sftp/uploader-uses-sftp.conf
@@ -1,0 +1,11 @@
+Subsystem sftp internal-sftp
+
+# uploader: only sftp access
+Match User uploader
+    ForceCommand internal-sftp
+    ChrootDirectory /home/uploader
+    PermitTTY no
+    AllowAgentForwarding no
+    AllowTcpForwarding no
+    X11Forwarding no
+    PermitUserRC no

--- a/docs/maintainers/scripts/sort_builds.sh
+++ b/docs/maintainers/scripts/sort_builds.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+# Sorts and renames builds that were uploaded via sftp to make them available for download
+
+# Examples of currently uploaded build file names
+# 16379399612-vcmi-branch-develop-7fcb024-intel.dmg
+# 16379399612-vcmi-branch-develop-7fcb024-arm.dmg
+# 16379399612-vcmi-branch-develop-7fcb024.ipa
+# 16379399612-vcmi-branch-develop-7fcb024.exe
+# 16379399612-vcmi-branch-develop-7fcb024-armeabi-v7a.apk
+# 16379399612-vcmi-branch-develop-7fcb024-arm64-v8a.apk
+
+SOURCE_BASE_DIRECTORY="/home/downloader/tmp"
+TARGET_BASE_DIRECTORY="/home/downloader/www"
+
+for fullpath in "${SOURCE_BASE_DIRECTORY}"/*.*
+do
+	echo "Full path: ${fullpath}"
+	filename=${fullpath##*/}
+	echo "Filename: ${filename}"
+
+	if [[ $filename =~ ^([0-9^\-]+)\-vcmi\-(branch|PR)\-([^-]+)\-([a-f0-9]+)(-[^.]+)? ]]
+	then
+		jobidentifier=${BASH_REMATCH[1]} # unique Github job identifier, unused
+		category=${BASH_REMATCH[2]}      # branch or PR. Only branches are uploaded right now
+		branchname=${BASH_REMATCH[3]}    # name of branch or PR number
+		commitsha=${BASH_REMATCH[4]}     # commit sha1
+
+		architecture=${BASH_REMATCH[5]}  # optional, name of system architecture (x86/x64/arm/etc)
+		architecture=${architecture:1}   # remove leading dash
+
+		extension=${filename##*.}
+
+		echo "Github Job Id: ${jobidentifier}"
+		echo "Category: ${category}"
+		echo "Branch name or PR number: ${branchname}"
+		echo "Commit SHA1:  ${commitsha}"
+		echo "Architecture: ${architecture}"
+		echo "Extension: ${extension}"
+
+		if [[ "$category" != "branch" && "$category" != "PR" ]]
+		then
+			echo "Unknown category :-("
+			continue
+		fi
+
+		if [[ "$extension" == "exe" ]]
+		then
+			system="windows"
+		elif [[ "$extension" == "dmg" ]]
+		then
+			system="macos"
+		elif [[ "$extension" == "ipa" ]]
+		then
+			system="ios"
+		elif [[ "$extension" == "apk" ]]
+		then
+			system="android"
+		elif [[ "$extension" == "AppImage" ]]
+		then
+			system="linux"
+		else
+			echo "Unknown extension :-("
+			continue
+		fi
+
+		echo "System: ${system}"
+
+		if [[ "$architecture" ]]
+		then
+			targetdirectory="${TARGET_BASE_DIRECTORY}/${category}/${branchname}/${system}-${architecture}"
+		else
+			targetdirectory="${TARGET_BASE_DIRECTORY}/${category}/${branchname}/${system}"
+		fi
+
+		targetname="VCMI-${category}-${branchname}-${commitsha:0:7}.${extension}"
+		echo "Target Directory: $targetdirectory"
+		echo "Target Name: $targetname"
+
+		mkdir -p "$targetdirectory"
+		mv -n "${fullpath}" "$targetdirectory/$targetname"
+	fi
+done


### PR DESCRIPTION
- Updated documentation on server maintenance. Most of outdated information is now gone, added information I collected during server updates
- Added various bits of our custom server configuration to docs
- Daily builds hosting is now handled by new droplet that runs on cheapest configuration, and uses latest Ubuntu LTS (unlike old droplet)
- Builds uploading is now handled by dedicated `upload.vcmi.eu` domain name (huh, looks like need to disable / redirect it on nginx), and not by beholder.vcmi.eu (which is shared by multiple services)

NOTE: after merge server needs some maintenance - to move existing daily builds to new server (volume reattachment, so hopefully easy) & update docs based on what I'll have to change for that.