### PR TITLE
[1.7.4] Fix crash on accessing VCMI campaign inside .zip archive

### DIFF
--- a/client/windows/CMapOverview.cpp
+++ b/client/windows/CMapOverview.cpp
@@ -221,7 +221,8 @@ CMapOverviewWidget::CMapOverviewWidget(CMapOverview& parent):
 	{
 		if(p.date.empty())
 		{
-			std::time_t time = boost::filesystem::last_write_time(*CResourceHandler::get()->getResourceName(ResourcePath(p.resource.getName(), p.tabType == ESelectionScreen::campaignList ? EResType::CAMPAIGN : EResType::MAP)));
+			ResourcePath path(p.resource.getName(), p.tabType == ESelectionScreen::campaignList ? EResType::CAMPAIGN : EResType::MAP);
+			std::time_t time = CResourceHandler::get()->getLastWriteTime(path);
 			w->setText(TextOperations::getFormattedDateTimeLocal(time));
 		}
 		else

--- a/lib/mapping/CMapInfo.cpp
+++ b/lib/mapping/CMapInfo.cpp
@@ -82,7 +82,7 @@ void CMapInfo::campaignInit()
 	originalFileURI = resource.getOriginalName();
 	fullFileURI = CResourceHandler::get()->getFullFileURI(resource);
 	campaign = CampaignHandler::getHeader(fileURI);
-	lastWrite = boost::filesystem::last_write_time(*CResourceHandler::get()->getResourceName(resource));
+	lastWrite = CResourceHandler::get()->getLastWriteTime(resource);
 	date = TextOperations::getFormattedDateTimeLocal(lastWrite);
 }
 


### PR DESCRIPTION
Fixes cases where game would try to access file on real filesystem for VCMI campaigns files that are actually located inside .zip archive.

Made search for other usages of last_write_time access, don't see any other similar cases left

- Fixes #6885