### PR TITLE
Fixes targeting of undead units by power liches

### DIFF
--- a/client/battle/BattleActionsController.cpp
+++ b/client/battle/BattleActionsController.cpp
@@ -787,7 +787,7 @@ bool BattleActionsController::actionIsLegal(PossiblePlayerBattleAction action, c
 				if(!owner.getBattle()->battleCanShoot(currentStack, targetHex))
 					return false;
 
-				if(owner.getBattle()->battleCanTargetEmptyHex(currentStack))
+				if((targetStack == nullptr || targetStack->isInvincible()) && owner.getBattle()->battleCanTargetEmptyHex(currentStack))
 				{
 					auto spellLikeAttackBonus = currentStack->getBonus(Selector::type()(BonusType::SPELL_LIKE_ATTACK));
 					const CSpell * spellDataToCheck = spellLikeAttackBonus->subtype.as<SpellID>().toSpell();


### PR DESCRIPTION
It fixes problem with power liches attack targeting.
The problem lies in the fact that the code before rework of targeting to encompass possible INVULNERABLE bonus automatically assumed that if a SPELL_LIKE_ATTACK targets directly a unit, it can be made. Naturally, it was a bug. I've changed it to always check if the spell can be cast, but I did not consider that power lich area spell and direct attack behave differently (namely, the area spell does not affect undead creatures).

On this branch it work like this (pikeman had been made invincible for the test):

https://github.com/user-attachments/assets/eb4a8839-26e6-45ea-81dd-bc6fe25ab868