### PR TITLE
fixes deathcloud and fireball's abilities area targeting problems

### DIFF
--- a/config/creatures/inferno.json
+++ b/config/creatures/inferno.json
@@ -98,7 +98,7 @@
 			"fireball" :
 			{
 				"type" : "SPELL_LIKE_ATTACK",
-				"subtype" : "spell.fireball"
+				"subtype" : "spell.fireballAbility"
 			}
 		},
 		"graphics" :

--- a/config/spells/ability.json
+++ b/config/spells/ability.json
@@ -277,7 +277,9 @@
 			}
 		},
 		"flags" : {
-			"negative": true
+			"damage": true,
+			"negative": true,
+			"nonMagical": true
 		},
 		"targetCondition" : {
 			"noneOf" : {
@@ -441,5 +443,32 @@
 		},
 		"targetCondition" : {
 		}
-	}
+	},
+	"fireballAbility" : {
+		"type": "ability",
+		"targetType": "LOCATION",
+
+		"animation":{
+			"hit":["C13SPF"] //C13SPF0 ???
+		},
+		"sounds": {
+			"cast": "SPONTCOMB"
+		},
+		"level": 0,
+		"levels" : {
+			"none": {
+				"range" : "0-1",
+				"battleEffects":{
+					"damage":{
+						"type":"core:damage"
+					}
+				}
+			}
+		},
+		"flags" : {
+			"damage": true,
+			"negative": true,
+			"nonMagical": true
+		}
+	},
 }


### PR DESCRIPTION
The pr resolves following issues:
- Death Cloud does not damage units with SPELL_DAMAGE_REDUCTION set to 100%.
- Magog's fireball does not damage units with SPELL_DAMAGE_REDUCTION set to 100%.
- Magog's fireball does not damage units with LEVEL_SPELL_IMMUNITY above 3

For the test diamond's golem magic immunity has been increased to 100% and death cloud has been allowed to target mechanical and unliving units.

https://github.com/user-attachments/assets/e7ab0d8c-fbe2-4e92-9b63-125369fffd58

Though SPELL_DAMAGE_REDUCTION below 100% does not decrease damage of death cloud or magog's fireball, if it is set above 100% it makes a unit invulnerable to it completely. It happens because check for it being over 100% comes first and does not take into consideration spell's configuration.
As both Magog's fireball and Death Cloud are not supposed to interact in any ways with magic immunities, abilities or bonuses giving them "nonMagical" flag seems to me the most natural solution.
It is easy in the case of deathCloud, but a little bit more complicated in the case of fireball. Magog's fireball is not configured as a separate unit ability in SPTRAITS.TXT in the original game, so Magog's SPELL_LIKE_ATTACK was linked to the fireball hero spell. It does not really work well in vcmi, spoiling some interaction (for example it does not work on Black Dragons, since Black Dragon have LEVEL_SPELL_IMMUNITY and hero's fireball, unlike Death Cloud, has a level to be immune to). I think the best solution is to add a separate ability to the core game (without index, since it is not loaded from the original game). 

    