### PR TITLE
Fix highscore screen freeze when entering player name

### DIFF
--- a/client/CServerHandler.cpp
+++ b/client/CServerHandler.cpp
@@ -978,7 +978,12 @@ void CServerHandler::waitForServerShutdown()
 	if (!serverRunner)
 		return; // may not exist for guest in MP
 
-	serverRunner->wait();
+	{
+		// Release interfaceMutex while waiting for server thread to finish
+		// to avoid blocking the GUI thread (same pattern as endNetwork())
+		auto unlockInterface = vstd::makeUnlockGuard(ENGINE->interfaceMutex);
+		serverRunner->wait();
+	}
 	int exitCode = serverRunner->exitCode();
 	serverRunner.reset();
 

--- a/client/mainmenu/CHighScoreScreen.cpp
+++ b/client/mainmenu/CHighScoreScreen.cpp
@@ -332,7 +332,7 @@ void CHighScoreInputScreen::clickPressed(const Point & cursorPosition)
 	if(!input)
 	{
 		input = std::make_shared<CHighScoreInput>(calc.parameters[0].playerName,
-		[&] (std::string text)
+		[this] (std::string text)
 		{
 			if(!text.empty())
 			{


### PR DESCRIPTION
## Problem
After winning a game, the highscore name entry screen freezes when typing the player name. The GUI thread stops processing events and rendering frames, requiring a force-quit.

## Root Cause
`waitForServerShutdown()` in `CServerHandler.cpp` blocks on `serverRunner->wait()` (a thread join) while holding `interfaceMutex`. The GUI thread cannot acquire the mutex in `updateFrame()`, so no events are processed and no frames render.

The call chain on the network thread:
```
onPacketReceived [acquires interfaceMutex]
  → visitPlayerEndsGame
    → showHighScoresAndEndGameplay
      → endGameplay
        → sendClientDisconnecting
          → waitForServerShutdown
            → serverRunner->wait()  ← blocks while holding mutex
```

The existing `endNetwork()` already handles this correctly using `makeUnlockGuard` before joining the thread, but `waitForServerShutdown()` did not.

## Fix
1. Release `interfaceMutex` during `serverRunner->wait()` in `waitForServerShutdown()`, matching the existing pattern in `endNetwork()`
2. Change `[&]` lambda capture to `[this]` in the highscore input ready callback to avoid a dangling reference to a stack variable (`cursorPosition` from `clickPressed`)

## Testing
- Built and launched VCMI successfully
- Played a game to victory, entered name on highscore screen — completes without freezing