### PR TITLE
[1.7.4] Enable search in default mod name

### DIFF
--- a/launcher/modManager/modstate.cpp
+++ b/launcher/modManager/modstate.cpp
@@ -25,6 +25,11 @@ QString ModState::getName() const
 	return QString::fromStdString(impl.getName());
 }
 
+QString ModState::getNameEnglish() const
+{
+	return QString::fromStdString(impl.getValue("name").String());
+}
+
 QString ModState::getType() const
 {
 	return QString::fromStdString(impl.getValue("modType").String());

--- a/launcher/modManager/modstate.h
+++ b/launcher/modManager/modstate.h
@@ -23,6 +23,7 @@ public:
 	explicit ModState(const ModDescription & impl);
 
 	QString getName() const;
+	QString getNameEnglish() const;
 	QString getType() const;
 	QString getDescription() const;
 

--- a/launcher/modManager/modstateitemmodel_moc.cpp
+++ b/launcher/modManager/modstateitemmodel_moc.cpp
@@ -163,6 +163,8 @@ QVariant ModStateItemModel::data(const QModelIndex & index, int role) const
 			return getValue(mod, index.column());
 		case ModRoles::ModNameRole:
 			return mod.getID();
+		case ModRoles::ModNameRoleEnglish:
+			return mod.getNameEnglish();
 		}
 	}
 	return QVariant();
@@ -301,7 +303,19 @@ bool CModFilterModel::filterMatchesCategory(const QModelIndex & source) const
 
 bool CModFilterModel::filterMatchesThis(const QModelIndex & source) const
 {
-	return filterMatchesCategory(source) && QSortFilterProxyModel::filterAcceptsRow(source.row(), source.parent());
+	if(!filterMatchesCategory(source))
+		return false;
+
+	const QRegularExpression filter = filterRegularExpression();
+	if(filter.pattern().isEmpty())
+		return true;
+
+	if(QSortFilterProxyModel::filterAcceptsRow(source.row(), source.parent()))
+		return true;
+
+	const QString localizedName = source.data(Qt::DisplayRole).toString();
+	const QString englishName = source.data(ModRoles::ModNameRoleEnglish).toString();
+	return localizedName.contains(filter) || englishName.contains(filter);
 }
 
 bool CModFilterModel::filterAcceptsRow(int source_row, const QModelIndex & source_parent) const

--- a/launcher/modManager/modstateitemmodel_moc.h
+++ b/launcher/modManager/modstateitemmodel_moc.h
@@ -43,7 +43,8 @@ namespace ModRoles
 enum EModRoles
 {
 	ValueRole = Qt::UserRole,
-	ModNameRole
+	ModNameRole,
+	ModNameRoleEnglish
 };
 }
 


### PR DESCRIPTION
Enable search in mod list in default mod name. This means, we can filter now mods in localized VCMI by their default name too. 