### PR TITLE
[1.7.4] Add support for S - G + C random map buttons

### DIFF
--- a/client/lobby/CBonusSelection.cpp
+++ b/client/lobby/CBonusSelection.cpp
@@ -94,7 +94,8 @@ CBonusSelection::CBonusSelection()
 
 	campaignName = std::make_shared<CLabel>(481, 28, FONT_BIG, ETextAlignment::TOPLEFT, Colors::YELLOW, GAME->server().si->getCampaignName(), 250);
 
-	iconsMapSizes = std::make_shared<CAnimImage>(AnimationPath::builtin("SCNRMPSZ"), 4, 0, 735, 26);
+	iconsMapSizes = std::make_shared<CAnimImage>(AnimationPath::builtin("SCNRMPSZ"), 0, 0, 735, 26);
+	iconsMapSizes->setFrame(iconsMapSizes->size() - 1); // use last available frame as "custom" icon
 
 	labelCampaignDescription = std::make_shared<CLabel>(481, 63, FONT_SMALL, ETextAlignment::TOPLEFT, Colors::YELLOW, LIBRARY->generaltexth->allTexts[38]);
 	campaignDescription = std::make_shared<CTextBox>(getCampaign()->getDescriptionTranslated(), Rect(480, 86, 286, 117), 1);
@@ -562,7 +563,7 @@ void CBonusSelection::updateAfterStateChange()
 
 	if(!GAME->server().mi)
 		return;
-	iconsMapSizes->setFrame(GAME->server().mi->getMapSizeIconId());
+	iconsMapSizes->setFrame(std::min<size_t>(GAME->server().mi->getMapSizeIconId(), iconsMapSizes->size() - 1));
 	mapName->setText(GAME->server().mi->getNameTranslated());
 	mapDescription->setText(GAME->server().mi->getDescriptionTranslated());
 	for(size_t i = 0; i < difficultyIcons.size(); i++)

--- a/client/lobby/CSelectionBase.cpp
+++ b/client/lobby/CSelectionBase.cpp
@@ -183,7 +183,8 @@ InfoCard::InfoCard()
 		parent->children.pop_back();
 		pos.w = background->pos.w;
 		pos.h = background->pos.h;
-		iconsMapSizes = std::make_shared<CAnimImage>(AnimationPath::builtin("SCNRMPSZ"), 4, 0, 313, 25); //let it be custom size (frame 4) by default
+		iconsMapSizes = std::make_shared<CAnimImage>(AnimationPath::builtin("SCNRMPSZ"), 0, 0, 313, 25);
+		iconsMapSizes->setFrame(iconsMapSizes->size() - 1); // use last available frame as "custom" icon
 
 		iconDifficulty = std::make_shared<CToggleGroup>(0);
 		{
@@ -255,8 +256,15 @@ void InfoCard::changeSelection()
 
 	const CMapHeader * header = mapInfo->mapHeader.get();
 
-	labelMapSize->setText(std::to_string(header->width) + "x" + std::to_string(header->height) + "x" + std::to_string(header->levels()));
-	iconsMapSizes->setFrame(mapInfo->getMapSizeIconId());
+	std::string mapSizeText = std::to_string(header->width) + "x" + std::to_string(header->height);
+	if(header->levels() > 1)
+		mapSizeText += "x" + std::to_string(header->levels());
+	labelMapSize->setText(mapSizeText);
+	size_t mapSizeIconFrame = mapInfo->getMapSizeIconId();
+	if(const auto * selectionScreen = dynamic_cast<const CSelectionBase *>(SEL);
+	   mapInfo->isRandomMap && selectionScreen && selectionScreen->tabRand && selectionScreen->tabRand->isCustomMapSizeMode())
+		mapSizeIconFrame = selectionScreen->tabRand->getCustomMapSizeIconFrame();
+	iconsMapSizes->setFrame(std::min<size_t>(mapSizeIconFrame, iconsMapSizes->size() - 1));
 
 	iconsVictoryCondition->setFrame(header->victoryIconIndex);
 	labelVictoryConditionText->setText(header->victoryMessage.toString());

--- a/client/lobby/RandomMapTab.cpp
+++ b/client/lobby/RandomMapTab.cpp
@@ -45,6 +45,37 @@
 #include "../../lib/serializer/JsonSerializer.h"
 #include "../../lib/serializer/JsonDeserializer.h"
 
+namespace
+{
+std::optional<int> mapSizeFromStringId(const std::string & id)
+{
+	const std::string upper = boost::to_upper_copy(id);
+
+	if(boost::ends_with(upper, ".C") || boost::ends_with(upper, "C"))
+		return std::nullopt; // custom map size
+	if(boost::ends_with(upper, ".XH") || boost::ends_with(upper, "XH"))
+		return CMapHeader::MAP_SIZE_XHUGE;
+	if(boost::ends_with(upper, ".XL") || boost::ends_with(upper, "XL"))
+		return CMapHeader::MAP_SIZE_XLARGE;
+	if(boost::ends_with(upper, ".HG") || boost::ends_with(upper, "HG"))
+		return CMapHeader::MAP_SIZE_HUGE;
+	if(boost::ends_with(upper, ".G") || boost::ends_with(upper, "G"))
+		return CMapHeader::MAP_SIZE_GIANT;
+	if(boost::ends_with(upper, ".H") || boost::ends_with(upper, "H"))
+		return CMapHeader::MAP_SIZE_HUGE;
+	if(boost::ends_with(upper, ".X") || boost::ends_with(upper, "X"))
+		return CMapHeader::MAP_SIZE_XLARGE;
+	if(boost::ends_with(upper, ".L") || boost::ends_with(upper, "L"))
+		return CMapHeader::MAP_SIZE_LARGE;
+	if(boost::ends_with(upper, ".M") || boost::ends_with(upper, "M"))
+		return CMapHeader::MAP_SIZE_MIDDLE;
+	if(boost::ends_with(upper, ".S") || boost::ends_with(upper, "S"))
+		return CMapHeader::MAP_SIZE_SMALL;
+
+	return std::nullopt;
+}
+}
+
 RandomMapTab::RandomMapTab():
 	InterfaceObjectConfigurable(),
 	templateIndex(0)
@@ -123,6 +154,7 @@ RandomMapTab::RandomMapTab():
 	}
 	
 	const JsonNode config(JsonPath::builtin("config/widgets/randomMapTab.json"));
+	initializeMapSizeButtons(config);
 	build(config);
 	
 	if(auto w = widget<CButton>("buttonShowRandomMaps"))
@@ -203,12 +235,63 @@ RandomMapTab::RandomMapTab():
 	loadOptions();
 }
 
+void RandomMapTab::initializeMapSizeButtons(const JsonNode & config)
+{
+	mapSizeButtons.clear();
+	customSizeButtons.clear();
+
+	const auto & mapSizeItems = config["items"].Vector();
+	for(const auto & item : mapSizeItems)
+	{
+		if(item["name"].String() != "groupMapSize" || item["items"].isNull())
+			continue;
+
+		int itemIdx = -1;
+		for(const auto & mapSizeButton : item["items"].Vector())
+		{
+			itemIdx = mapSizeButton["index"].isNull() ? itemIdx + 1 : mapSizeButton["index"].Integer();
+
+			if(!mapSizeButton["help"].isNull())
+			{
+				const auto sizeFromHelp = mapSizeFromStringId(mapSizeButton["help"].String());
+				if(sizeFromHelp.has_value())
+				{
+					mapSizeButtons[itemIdx] = *sizeFromHelp;
+					continue;
+				}
+				if(boost::ends_with(boost::to_upper_copy(mapSizeButton["help"].String()), ".C"))
+				{
+					customSizeButtons.insert(itemIdx);
+					continue;
+				}
+			}
+
+			if(!mapSizeButton["image"].isNull())
+			{
+				const auto sizeFromImage = mapSizeFromStringId(mapSizeButton["image"].String());
+				if(sizeFromImage.has_value())
+					mapSizeButtons[itemIdx] = *sizeFromImage;
+				else if(boost::ends_with(boost::to_upper_copy(mapSizeButton["image"].String()), "C"))
+					customSizeButtons.insert(itemIdx);
+			}
+		}
+		break;
+	}
+
+	if(mapSizeButtons.empty())
+	{
+		// Fallback for legacy configs that don't provide recognizable map-size IDs yet.
+		// TODO: remove once all maintained randomMapTab configs declare explicit IDs (including custom size button).
+		const auto defaultMapSizes = getStandardMapSizes();
+		for(size_t i = 0; i < defaultMapSizes.size(); ++i)
+			mapSizeButtons[static_cast<int>(i)] = defaultMapSizes[i];
+	}
+}
+
 void RandomMapTab::onToggleMapSize(int btnId)
 {
 	if(btnId == -1)
 		return;
-
-	auto mapSizeVal = getStandardMapSizes();
 
 	auto setTemplateForSize = [this](){
 		if(mapGenOptions->getMapTemplate())
@@ -217,7 +300,7 @@ void RandomMapTab::onToggleMapSize(int btnId)
 		updateMapInfoByHost();
 	};
 
-	if(btnId == mapSizeVal.size() - 1)
+	if(isCustomSizeButtonId(btnId))
 	{
 		ENGINE->windows().createAndPushWindow<SetSizeWindow>(int3(mapGenOptions->getWidth(), mapGenOptions->getHeight(), mapGenOptions->getLevels()), mapGenOptions->getMapTemplate(), [this, setTemplateForSize](int3 ret){
 			if(ret.z > 2)
@@ -233,8 +316,12 @@ void RandomMapTab::onToggleMapSize(int btnId)
 		return;
 	}
 
-	mapGenOptions->setWidth(mapSizeVal[btnId]);
-	mapGenOptions->setHeight(mapSizeVal[btnId]);
+	const auto mapSize = getMapSizeForButtonId(btnId);
+	if(!mapSize.has_value())
+		return;
+
+	mapGenOptions->setWidth(*mapSize);
+	mapGenOptions->setHeight(*mapSize);
 	setTemplateForSize();
 }
 
@@ -397,19 +484,34 @@ void RandomMapTab::setMapGenOptions(std::shared_ptr<CMapGenOptions> opts)
 	
 	if(auto w = widget<CToggleGroup>("groupMapSize"))
 	{
-		const auto & mapSizes = getStandardMapSizes();
 		for(auto toggle : w->buttons)
 		{
 			if(auto button = std::dynamic_pointer_cast<CToggleButton>(toggle.second))
 			{
-				int3 size( mapSizes[toggle.first], mapSizes[toggle.first], mapGenOptions->getLevels());
+				const auto mapSize = getMapSizeForButtonId(toggle.first);
+				if(!mapSize.has_value())
+				{
+					button->block(false); // custom/unknown button should stay usable
+					continue;
+				}
+
+				int3 size(*mapSize, *mapSize, mapGenOptions->getLevels());
 
 				bool sizeAllowed = !mapGenOptions->getMapTemplate() || mapGenOptions->getMapTemplate()->matchesSize(size);
-				button->block(!sizeAllowed && !(toggle.first == mapSizes.size() - 1));
+				button->block(!sizeAllowed);
 			}
 		}
-		auto position = vstd::find_pos(getStandardMapSizes(), opts->getWidth());
-		w->setSelected(position == mapSizes.size() - 1 || opts->getWidth() != opts->getHeight() ? -1 : position);
+
+		if(opts->getWidth() != opts->getHeight())
+		{
+			w->setSelected(customSizeButtons.empty() ? -1 : *customSizeButtons.begin());
+		}
+		else
+		{
+			bool found = false;
+			auto selectedButton = vstd::findKey(mapSizeButtons, opts->getWidth(), &found);
+			w->setSelected(found ? selectedButton : -1);
+		}
 	}
 	if(auto w = widget<CToggleButton>("buttonTwoLevels"))
 	{
@@ -519,9 +621,28 @@ void RandomMapTab::deactivateButtonsFrom(CToggleGroup & group, const std::set<in
 	}
 }
 
-std::vector<int> RandomMapTab::getStandardMapSizes()
+std::vector<int> RandomMapTab::getStandardMapSizes() const
 {
 	return {CMapHeader::MAP_SIZE_SMALL, CMapHeader::MAP_SIZE_MIDDLE, CMapHeader::MAP_SIZE_LARGE, CMapHeader::MAP_SIZE_XLARGE, CMapHeader::MAP_SIZE_HUGE, CMapHeader::MAP_SIZE_XHUGE, CMapHeader::MAP_SIZE_GIANT};
+}
+
+std::optional<int> RandomMapTab::getMapSizeForButtonId(int btnId) const
+{
+	if(auto mapSizeIt = mapSizeButtons.find(btnId); mapSizeIt != mapSizeButtons.end())
+		return mapSizeIt->second;
+
+	const auto defaultMapSizes = getStandardMapSizes();
+	// Fallback for old mods that still rely on historical button ordering.
+	// TODO: remove after legacy randomMapTab layouts are no longer supported.
+	if(btnId >= 0 && btnId < static_cast<int>(defaultMapSizes.size()))
+		return defaultMapSizes[btnId];
+
+	return std::nullopt;
+}
+
+bool RandomMapTab::isCustomSizeButtonId(int btnId) const
+{
+	return customSizeButtons.count(btnId) > 0;
 }
 
 void TeamAlignmentsWidget::checkTeamCount()

--- a/client/lobby/RandomMapTab.cpp
+++ b/client/lobby/RandomMapTab.cpp
@@ -45,37 +45,6 @@
 #include "../../lib/serializer/JsonSerializer.h"
 #include "../../lib/serializer/JsonDeserializer.h"
 
-namespace
-{
-std::optional<int> mapSizeFromStringId(const std::string & id)
-{
-	const std::string upper = boost::to_upper_copy(id);
-
-	if(boost::ends_with(upper, ".C") || boost::ends_with(upper, "C"))
-		return std::nullopt; // custom map size
-	if(boost::ends_with(upper, ".XH") || boost::ends_with(upper, "XH"))
-		return CMapHeader::MAP_SIZE_XHUGE;
-	if(boost::ends_with(upper, ".XL") || boost::ends_with(upper, "XL"))
-		return CMapHeader::MAP_SIZE_XLARGE;
-	if(boost::ends_with(upper, ".HG") || boost::ends_with(upper, "HG"))
-		return CMapHeader::MAP_SIZE_HUGE;
-	if(boost::ends_with(upper, ".G") || boost::ends_with(upper, "G"))
-		return CMapHeader::MAP_SIZE_GIANT;
-	if(boost::ends_with(upper, ".H") || boost::ends_with(upper, "H"))
-		return CMapHeader::MAP_SIZE_HUGE;
-	if(boost::ends_with(upper, ".X") || boost::ends_with(upper, "X"))
-		return CMapHeader::MAP_SIZE_XLARGE;
-	if(boost::ends_with(upper, ".L") || boost::ends_with(upper, "L"))
-		return CMapHeader::MAP_SIZE_LARGE;
-	if(boost::ends_with(upper, ".M") || boost::ends_with(upper, "M"))
-		return CMapHeader::MAP_SIZE_MIDDLE;
-	if(boost::ends_with(upper, ".S") || boost::ends_with(upper, "S"))
-		return CMapHeader::MAP_SIZE_SMALL;
-
-	return std::nullopt;
-}
-}
-
 RandomMapTab::RandomMapTab():
 	InterfaceObjectConfigurable(),
 	templateIndex(0)
@@ -158,7 +127,6 @@ RandomMapTab::RandomMapTab():
 	}
 	
 	const JsonNode config(JsonPath::builtin("config/widgets/randomMapTab.json"));
-	initializeMapSizeButtons(config);
 	build(config);
 	
 	if(auto w = widget<CButton>("buttonShowRandomMaps"))
@@ -237,59 +205,6 @@ RandomMapTab::RandomMapTab():
 	}
 	
 	loadOptions();
-}
-
-void RandomMapTab::initializeMapSizeButtons(const JsonNode & config)
-{
-	mapSizeButtons.clear();
-	customSizeButtons.clear();
-
-	const auto & mapSizeItems = config["items"].Vector();
-	for(const auto & item : mapSizeItems)
-	{
-		if(item["name"].String() != "groupMapSize" || item["items"].isNull())
-			continue;
-
-		int itemIdx = -1;
-		for(const auto & mapSizeButton : item["items"].Vector())
-		{
-			itemIdx = mapSizeButton["index"].isNull() ? itemIdx + 1 : mapSizeButton["index"].Integer();
-
-			if(!mapSizeButton["help"].isNull())
-			{
-				const auto sizeFromHelp = mapSizeFromStringId(mapSizeButton["help"].String());
-				if(sizeFromHelp.has_value())
-				{
-					mapSizeButtons[itemIdx] = *sizeFromHelp;
-					continue;
-				}
-				if(boost::ends_with(boost::to_upper_copy(mapSizeButton["help"].String()), ".C"))
-				{
-					customSizeButtons.insert(itemIdx);
-					continue;
-				}
-			}
-
-			if(!mapSizeButton["image"].isNull())
-			{
-				const auto sizeFromImage = mapSizeFromStringId(mapSizeButton["image"].String());
-				if(sizeFromImage.has_value())
-					mapSizeButtons[itemIdx] = *sizeFromImage;
-				else if(boost::ends_with(boost::to_upper_copy(mapSizeButton["image"].String()), "C"))
-					customSizeButtons.insert(itemIdx);
-			}
-		}
-		break;
-	}
-
-	if(mapSizeButtons.empty())
-	{
-		// Fallback for legacy configs that don't provide recognizable map-size IDs yet.
-		// TODO: remove once all maintained randomMapTab configs declare explicit IDs (including custom size button).
-		const auto defaultMapSizes = getStandardMapSizes();
-		for(size_t i = 0; i < defaultMapSizes.size(); ++i)
-			mapSizeButtons[static_cast<int>(i)] = defaultMapSizes[i];
-	}
 }
 
 void RandomMapTab::onToggleMapSize(int btnId)
@@ -496,6 +411,9 @@ void RandomMapTab::setMapGenOptions(std::shared_ptr<CMapGenOptions> opts)
 	
 	if(auto w = widget<CToggleGroup>("groupMapSize"))
 	{
+		const int customButtonId = static_cast<int>(getStandardMapSizes().size());
+		const bool hasCustomButton = w->buttons.count(customButtonId) > 0;
+
 		for(auto toggle : w->buttons)
 		{
 			if(auto button = std::dynamic_pointer_cast<CToggleButton>(toggle.second))
@@ -514,22 +432,22 @@ void RandomMapTab::setMapGenOptions(std::shared_ptr<CMapGenOptions> opts)
 			}
 		}
 
-		if(customMapSizeMode && customSizeButtons.count(w->getSelected()) > 0)
+		if(customMapSizeMode && hasCustomButton && isCustomSizeButtonId(w->getSelected()))
 		{
 			// Keep current custom button selection. Do not switch to preset button based on dimensions.
 		}
 		else if(opts->getWidth() != opts->getHeight())
 		{
 			customMapSizeMode = true;
-			w->setSelected(customSizeButtons.empty() ? -1 : *customSizeButtons.begin());
+			w->setSelected(hasCustomButton ? customButtonId : -1);
 		}
 		else
 		{
-			bool found = false;
-			auto selectedButton = vstd::findKey(mapSizeButtons, opts->getWidth(), &found);
-			if(!found && !customSizeButtons.empty())
-				customMapSizeMode = true;
-			w->setSelected(found ? selectedButton : -1);
+			auto position = vstd::find_pos(getStandardMapSizes(), opts->getWidth());
+			if(customMapSizeMode && hasCustomButton && position >= 0 && position < static_cast<int>(getStandardMapSizes().size()))
+				w->setSelected(customButtonId);
+			else
+				w->setSelected(position);
 		}
 	}
 	if(auto w = widget<CToggleButton>("buttonTwoLevels"))
@@ -648,12 +566,7 @@ std::vector<int> RandomMapTab::getStandardMapSizes() const
 
 std::optional<int> RandomMapTab::getMapSizeForButtonId(int btnId) const
 {
-	if(auto mapSizeIt = mapSizeButtons.find(btnId); mapSizeIt != mapSizeButtons.end())
-		return mapSizeIt->second;
-
 	const auto defaultMapSizes = getStandardMapSizes();
-	// Fallback for old mods that still rely on historical button ordering.
-	// TODO: remove after legacy randomMapTab layouts are no longer supported.
 	if(btnId >= 0 && btnId < static_cast<int>(defaultMapSizes.size()))
 		return defaultMapSizes[btnId];
 
@@ -662,14 +575,12 @@ std::optional<int> RandomMapTab::getMapSizeForButtonId(int btnId) const
 
 bool RandomMapTab::isCustomSizeButtonId(int btnId) const
 {
-	return customSizeButtons.count(btnId) > 0;
+	return btnId == static_cast<int>(getStandardMapSizes().size());
 }
 
 size_t RandomMapTab::getCustomMapSizeIconFrame() const
 {
-	// SCNRMPSZ convention: standard size icons first, then custom icon.
-	// Number of recognized standard map-size buttons gives custom icon frame index.
-	return mapSizeButtons.size();
+	return getStandardMapSizes().size();
 }
 
 void TeamAlignmentsWidget::checkTeamCount()

--- a/client/lobby/RandomMapTab.cpp
+++ b/client/lobby/RandomMapTab.cpp
@@ -89,10 +89,14 @@ RandomMapTab::RandomMapTab():
 	});
 	addCallback("toggleTwoLevels", [&](bool on)
 	{
-		mapGenOptions->setLevels(on ? 2 : 1);
+		if(mapGenOptions->getLevels() > 2)
+			mapGenOptions->setLevels(2); // standard setup supports at most 2 levels
+		else
+			mapGenOptions->setLevels(on ? 2 : 1);
 		if(mapGenOptions->getMapTemplate())
 			if(!mapGenOptions->getMapTemplate()->matchesSize(int3{mapGenOptions->getWidth(), mapGenOptions->getHeight(), mapGenOptions->getLevels()}))
 				setTemplate(nullptr);
+		customMapSizeMode = mapGenOptions->getWidth() != mapGenOptions->getHeight();
 		updateMapInfoByHost();
 	});
 	
@@ -311,6 +315,9 @@ void RandomMapTab::onToggleMapSize(int btnId)
 			mapGenOptions->setWidth(ret.x);
 			mapGenOptions->setHeight(ret.y);
 			mapGenOptions->setLevels(ret.z);
+			customMapSizeMode = true;
+			if(auto twoLevelsButton = widget<CToggleButton>("buttonTwoLevels"))
+				twoLevelsButton->setSelectedSilent(ret.z == 2);
 			setTemplateForSize();
 		});
 		return;
@@ -322,6 +329,11 @@ void RandomMapTab::onToggleMapSize(int btnId)
 
 	mapGenOptions->setWidth(*mapSize);
 	mapGenOptions->setHeight(*mapSize);
+	customMapSizeMode = false;
+	const int targetLevelCount = mapGenOptions->getLevels() > 1 ? 2 : 1;
+	mapGenOptions->setLevels(targetLevelCount);
+	if(auto twoLevelsButton = widget<CToggleButton>("buttonTwoLevels"))
+		twoLevelsButton->setSelectedSilent(targetLevelCount == 2);
 	setTemplateForSize();
 }
 
@@ -502,14 +514,21 @@ void RandomMapTab::setMapGenOptions(std::shared_ptr<CMapGenOptions> opts)
 			}
 		}
 
-		if(opts->getWidth() != opts->getHeight())
+		if(customMapSizeMode && customSizeButtons.count(w->getSelected()) > 0)
 		{
+			// Keep current custom button selection. Do not switch to preset button based on dimensions.
+		}
+		else if(opts->getWidth() != opts->getHeight())
+		{
+			customMapSizeMode = true;
 			w->setSelected(customSizeButtons.empty() ? -1 : *customSizeButtons.begin());
 		}
 		else
 		{
 			bool found = false;
 			auto selectedButton = vstd::findKey(mapSizeButtons, opts->getWidth(), &found);
+			if(!found && !customSizeButtons.empty())
+				customMapSizeMode = true;
 			w->setSelected(found ? selectedButton : -1);
 		}
 	}
@@ -580,6 +599,7 @@ void RandomMapTab::setMapGenOptions(std::shared_ptr<CMapGenOptions> opts)
 void RandomMapTab::setTemplate(const CRmgTemplate * tmpl)
 {
 	mapGenOptions->setMapTemplate(tmpl);
+	customMapSizeMode = false;
 	setMapGenOptions(mapGenOptions);
 	if(auto w = widget<CButton>("templateButton"))
 	{
@@ -643,6 +663,13 @@ std::optional<int> RandomMapTab::getMapSizeForButtonId(int btnId) const
 bool RandomMapTab::isCustomSizeButtonId(int btnId) const
 {
 	return customSizeButtons.count(btnId) > 0;
+}
+
+size_t RandomMapTab::getCustomMapSizeIconFrame() const
+{
+	// SCNRMPSZ convention: standard size icons first, then custom icon.
+	// Number of recognized standard map-size buttons gives custom icon frame index.
+	return mapSizeButtons.size();
 }
 
 void TeamAlignmentsWidget::checkTeamCount()

--- a/client/lobby/RandomMapTab.h
+++ b/client/lobby/RandomMapTab.h
@@ -50,7 +50,6 @@ public:
 	CFunctionList<void(std::shared_ptr<CMapInfo>, std::shared_ptr<CMapGenOptions>)> mapInfoChanged;
 
 private:
-	void initializeMapSizeButtons(const JsonNode & config);
 	void deactivateButtonsFrom(CToggleGroup & group, const std::set<int> & allowed);
 	std::vector<int> getStandardMapSizes() const;
 	std::optional<int> getMapSizeForButtonId(int btnId) const;
@@ -65,8 +64,6 @@ private:
 	std::set<int> playerTeamsAllowed;
 	std::set<int> compCountAllowed;
 	std::set<int> compTeamsAllowed;
-	std::map<int, int> mapSizeButtons;
-	std::set<int> customSizeButtons;
 	bool customMapSizeMode = false;
 
 	int templateIndex;

--- a/client/lobby/RandomMapTab.h
+++ b/client/lobby/RandomMapTab.h
@@ -16,6 +16,8 @@
 #include "../../lib/rmg/CRmgTemplate.h"
 #include "../gui/InterfaceObjectConfigurable.h"
 
+#include <optional>
+
 VCMI_LIB_NAMESPACE_BEGIN
 
 class CMapGenOptions;
@@ -46,8 +48,11 @@ public:
 	CFunctionList<void(std::shared_ptr<CMapInfo>, std::shared_ptr<CMapGenOptions>)> mapInfoChanged;
 
 private:
+	void initializeMapSizeButtons(const JsonNode & config);
 	void deactivateButtonsFrom(CToggleGroup & group, const std::set<int> & allowed);
-	std::vector<int> getStandardMapSizes();
+	std::vector<int> getStandardMapSizes() const;
+	std::optional<int> getMapSizeForButtonId(int btnId) const;
+	bool isCustomSizeButtonId(int btnId) const;
 	void onToggleMapSize(int btnId);
 
 	std::shared_ptr<CMapInfo> mapInfo;
@@ -58,6 +63,8 @@ private:
 	std::set<int> playerTeamsAllowed;
 	std::set<int> compCountAllowed;
 	std::set<int> compTeamsAllowed;
+	std::map<int, int> mapSizeButtons;
+	std::set<int> customSizeButtons;
 
 	int templateIndex;
 };

--- a/client/lobby/RandomMapTab.h
+++ b/client/lobby/RandomMapTab.h
@@ -44,6 +44,8 @@ public:
 	void saveOptions(const CMapGenOptions & options);
 	void loadOptions();
 	CMapGenOptions & obtainMapGenOptions() {return *mapGenOptions;}
+	bool isCustomMapSizeMode() const { return customMapSizeMode; }
+	size_t getCustomMapSizeIconFrame() const;
 
 	CFunctionList<void(std::shared_ptr<CMapInfo>, std::shared_ptr<CMapGenOptions>)> mapInfoChanged;
 
@@ -65,6 +67,7 @@ private:
 	std::set<int> compTeamsAllowed;
 	std::map<int, int> mapSizeButtons;
 	std::set<int> customSizeButtons;
+	bool customMapSizeMode = false;
 
 	int templateIndex;
 };


### PR DESCRIPTION
Adds support for https://github.com/vcmi-mods/vcmi-extras/pull/90

Should not break anything, at least existing configs works. Same without extras. Also works with new config. It will require some cleanup in 1.8+, so there is TODO.

<img width="769" height="586" alt="image" src="https://github.com/user-attachments/assets/463e7195-3b70-48ce-b892-22f82cbceb35" />

Extras needs to be updated after 1.7.4 release

This PR add also support for badly displayed size in right corner after selection.

Fixes: https://github.com/vcmi/vcmi/issues/4767