### PR TITLE
[1.7.4] Hide useless buttons on scenario information

### DIFF
--- a/client/lobby/OptionsTabBase.cpp
+++ b/client/lobby/OptionsTabBase.cpp
@@ -445,6 +445,18 @@ void OptionsTabBase::recreate(bool campaign)
 		buttonTurnOptions->block(GAME->server().isGuest() || campaign);
 	}
 
+	if(SEL->screenType == ESelectionScreen::scenarioInfo)
+	{
+		if(auto timerPresetSelector = widget<CIntObject>("timerPresetSelector"))
+			timerPresetSelector->setEnabled(false);
+
+		if(auto simturnsPresetSelector = widget<CIntObject>("simturnsPresetSelector"))
+			simturnsPresetSelector->setEnabled(false);
+
+		if(auto buttonTurnOptions = widget<CIntObject>("buttonTurnOptions"))
+			buttonTurnOptions->setEnabled(false);
+	}
+
 	if(auto textureCampaignOverdraw = widget<CFilledTexture>("textureCampaignOverdraw"))
 		textureCampaignOverdraw->setEnabled(campaign);
 }


### PR DESCRIPTION
Fixes: https://github.com/vcmi/vcmi/issues/6765

When player open scenario information from adventure map it, these not working buttons are now correctly hidden.