### PR TITLE
[1.8.0] Fix Level-up flickering

### DIFF
--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -520,15 +520,29 @@ void CPlayerInterface::receivedResource()
 void CPlayerInterface::heroGotLevel(const CGHeroInstance *hero, PrimarySkill pskill, std::vector<SecondarySkill>& skills, QueryID queryID)
 {
 	EVENT_HANDLER_CALLED_BY_CLIENT;
+	if(auto levelWindow = ENGINE->windows().topWindow<CLevelWindow>())
+	{
+		levelWindow->updateLevelUpData(hero, pskill, skills, [this, queryID](ui32 selection)
+		{
+			if(queryID < 0)
+				return;
+
+			cb->selectionMade(selection, queryID);
+		});
+		return;
+	}
+
 	waitWhileDialog();
 	ENGINE->sound().playSound(soundBase::heroNewLevel);
-	ENGINE->windows().createAndPushWindow<CLevelWindow>(hero, pskill, skills, [this, queryID](ui32 selection)
+	auto callback = [this, queryID](ui32 selection)
 	{
 		if(queryID < 0)
 			return;
 
 		cb->selectionMade(selection, queryID);
-	});
+	};
+
+	ENGINE->windows().createAndPushWindow<CLevelWindow>(hero, pskill, skills, callback);
 }
 
 void CPlayerInterface::commanderGotLevel (const CCommanderInstance * commander, std::vector<ui32> skills, QueryID queryID)
@@ -536,13 +550,15 @@ void CPlayerInterface::commanderGotLevel (const CCommanderInstance * commander, 
 	EVENT_HANDLER_CALLED_BY_CLIENT;
 	waitWhileDialog();
 	ENGINE->sound().playSound(soundBase::heroNewLevel);
-	ENGINE->windows().createAndPushWindow<CStackWindow>(commander, skills, [this, queryID](ui32 selection)
+	auto callback = [this, queryID](ui32 selection)
 	{
 		if(queryID < 0)
 			return;
 
 		cb->selectionMade(selection, queryID);
-	});
+	};
+
+	ENGINE->windows().createAndPushWindow<CStackWindow>(commander, skills, callback);
 }
 
 void CPlayerInterface::heroInGarrisonChange(const CGTownInstance *town)

--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -548,6 +548,18 @@ void CPlayerInterface::heroGotLevel(const CGHeroInstance *hero, PrimarySkill psk
 void CPlayerInterface::commanderGotLevel (const CCommanderInstance * commander, std::vector<ui32> skills, QueryID queryID)
 {
 	EVENT_HANDLER_CALLED_BY_CLIENT;
+	if(auto stackWindow = ENGINE->windows().topWindow<CStackWindow>(); stackWindow && stackWindow->isCommanderLevelUpDialog())
+	{
+		stackWindow->updateCommanderLevelUpData(commander, skills, [this, queryID](ui32 selection)
+		{
+			if(queryID < 0)
+				return;
+
+			cb->selectionMade(selection, queryID);
+		});
+		return;
+	}
+
 	waitWhileDialog();
 	ENGINE->sound().playSound(soundBase::heroNewLevel);
 	auto callback = [this, queryID](ui32 selection)

--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -130,7 +130,6 @@ namespace
 {
 	constexpr int LEVEL_UP_REQUEST_NONE = -1;
 	constexpr int LEVEL_UP_REQUEST_WAITING_FOR_REPLY = -2;
-	constexpr int LEVEL_UP_REQUEST_AUTO_RESOLVED = -3;
 }
 
 std::shared_ptr<BattleInterface> CPlayerInterface::battleInt;
@@ -532,7 +531,9 @@ void CPlayerInterface::heroGotLevel(const CGHeroInstance *hero, PrimarySkill psk
 
 	closePendingLevelUpDialog();
 
-	pendingLevelUpRequestID = queryID < 0 ? LEVEL_UP_REQUEST_AUTO_RESOLVED : LEVEL_UP_REQUEST_WAITING_FOR_REPLY;
+	const bool closeImmediately = queryID < 0;
+	pendingLevelUpRequestID = closeImmediately ? LEVEL_UP_REQUEST_NONE : LEVEL_UP_REQUEST_WAITING_FOR_REPLY;
+
 	auto levelWindow = std::make_shared<CLevelWindow>(hero, pskill, skills, [this, queryID](ui32 selection)
 	{
 		if(queryID < 0)
@@ -540,8 +541,11 @@ void CPlayerInterface::heroGotLevel(const CGHeroInstance *hero, PrimarySkill psk
 
 		pendingLevelUpRequestID = cb->selectionMade(selection, queryID);
 	});
-	levelWindow->setCloseOnSelection(false);
-	pendingLevelUpDialog = levelWindow;
+
+	levelWindow->setCloseOnSelection(closeImmediately);
+	if(!closeImmediately)
+		pendingLevelUpDialog = levelWindow;
+
 	ENGINE->windows().pushWindow(levelWindow);
 }
 
@@ -1319,12 +1323,6 @@ void CPlayerInterface::requestRealized( PackageApplied *pa )
 		if(pendingLevelUpRequestID == static_cast<int>(pa->requestID))
 			closePendingLevelUpDialog();
 		movementController->onQueryReplyApplied();
-	}
-	else if(pendingLevelUpDialog && pendingLevelUpRequestID == LEVEL_UP_REQUEST_AUTO_RESOLVED)
-	{
-		// Auto-resolved levelups (queryID < 0) have no QueryReply from client,
-		// so close pending window once current server request is fully applied.
-		closePendingLevelUpDialog();
 	}
 }
 

--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -126,6 +126,13 @@
 
 #define BATTLE_EVENT_POSSIBLE_RETURN	if (GAME->interface() != this) return; if (isAutoFightOn && !battleInt) return
 
+namespace
+{
+	constexpr int LEVEL_UP_REQUEST_NONE = -1;
+	constexpr int LEVEL_UP_REQUEST_WAITING_FOR_REPLY = -2;
+	constexpr int LEVEL_UP_REQUEST_AUTO_RESOLVED = -3;
+}
+
 std::shared_ptr<BattleInterface> CPlayerInterface::battleInt;
 
 CPlayerInterface::CPlayerInterface(PlayerColor Player):
@@ -520,57 +527,45 @@ void CPlayerInterface::receivedResource()
 void CPlayerInterface::heroGotLevel(const CGHeroInstance *hero, PrimarySkill pskill, std::vector<SecondarySkill>& skills, QueryID queryID)
 {
 	EVENT_HANDLER_CALLED_BY_CLIENT;
-	if(auto levelWindow = ENGINE->windows().topWindow<CLevelWindow>())
-	{
-		levelWindow->updateLevelUpData(hero, pskill, skills, [this, queryID](ui32 selection)
-		{
-			if(queryID < 0)
-				return;
-
-			cb->selectionMade(selection, queryID);
-		});
-		return;
-	}
-
 	waitWhileDialog();
 	ENGINE->sound().playSound(soundBase::heroNewLevel);
-	auto callback = [this, queryID](ui32 selection)
+
+	closePendingLevelUpDialog();
+
+	pendingLevelUpRequestID = queryID < 0 ? LEVEL_UP_REQUEST_AUTO_RESOLVED : LEVEL_UP_REQUEST_WAITING_FOR_REPLY;
+	auto levelWindow = std::make_shared<CLevelWindow>(hero, pskill, skills, [this, queryID](ui32 selection)
 	{
 		if(queryID < 0)
 			return;
 
-		cb->selectionMade(selection, queryID);
-	};
-
-	ENGINE->windows().createAndPushWindow<CLevelWindow>(hero, pskill, skills, callback);
+		pendingLevelUpRequestID = cb->selectionMade(selection, queryID);
+	});
+	levelWindow->setCloseOnSelection(false);
+	pendingLevelUpDialog = levelWindow;
+	ENGINE->windows().pushWindow(levelWindow);
 }
 
-void CPlayerInterface::commanderGotLevel (const CCommanderInstance * commander, std::vector<ui32> skills, QueryID queryID)
+void CPlayerInterface::commanderGotLevel(const CCommanderInstance * commander, std::vector<ui32> skills, QueryID queryID)
 {
 	EVENT_HANDLER_CALLED_BY_CLIENT;
-	if(auto stackWindow = ENGINE->windows().topWindow<CStackWindow>(); stackWindow && stackWindow->isCommanderLevelUpDialog())
-	{
-		stackWindow->updateCommanderLevelUpData(commander, skills, [this, queryID](ui32 selection)
-		{
-			if(queryID < 0)
-				return;
-
-			cb->selectionMade(selection, queryID);
-		});
-		return;
-	}
-
 	waitWhileDialog();
 	ENGINE->sound().playSound(soundBase::heroNewLevel);
-	auto callback = [this, queryID](ui32 selection)
+
+	closePendingLevelUpDialog();
+
+	const bool closeImmediately = queryID < 0;
+	pendingLevelUpRequestID = closeImmediately ? LEVEL_UP_REQUEST_NONE : LEVEL_UP_REQUEST_WAITING_FOR_REPLY;
+	auto levelWindow = std::make_shared<CStackWindow>(commander, skills, [this, queryID](ui32 selection)
 	{
 		if(queryID < 0)
 			return;
 
-		cb->selectionMade(selection, queryID);
-	};
-
-	ENGINE->windows().createAndPushWindow<CStackWindow>(commander, skills, callback);
+		pendingLevelUpRequestID = cb->selectionMade(selection, queryID);
+	});
+	levelWindow->setCloseOnSelection(closeImmediately);
+	if(!closeImmediately)
+		pendingLevelUpDialog = levelWindow;
+	ENGINE->windows().pushWindow(levelWindow);
 }
 
 void CPlayerInterface::heroInGarrisonChange(const CGTownInstance *town)
@@ -1320,7 +1315,30 @@ void CPlayerInterface::requestRealized( PackageApplied *pa )
 		movementController->onMoveHeroApplied();
 
 	if(pa->packType == CTypeList::getInstance().getTypeID<QueryReply>(nullptr))
+	{
+		if(pendingLevelUpRequestID == static_cast<int>(pa->requestID))
+			closePendingLevelUpDialog();
 		movementController->onQueryReplyApplied();
+	}
+	else if(pendingLevelUpDialog && pendingLevelUpRequestID == LEVEL_UP_REQUEST_AUTO_RESOLVED)
+	{
+		// Auto-resolved levelups (queryID < 0) have no QueryReply from client,
+		// so close pending window once current server request is fully applied.
+		closePendingLevelUpDialog();
+	}
+}
+
+void CPlayerInterface::closePendingLevelUpDialog()
+{
+	if(!pendingLevelUpDialog)
+	{
+		pendingLevelUpRequestID = LEVEL_UP_REQUEST_NONE;
+		return;
+	}
+
+	pendingLevelUpDialog->close();
+	pendingLevelUpDialog.reset();
+	pendingLevelUpRequestID = LEVEL_UP_REQUEST_NONE;
 }
 
 void CPlayerInterface::showHeroExchange(ObjectInstanceID hero1, ObjectInstanceID hero2)

--- a/client/CPlayerInterface.h
+++ b/client/CPlayerInterface.h
@@ -67,6 +67,8 @@ class CPlayerInterface : public CGameInterface
 	const std::string QUICKSAVE_PATH = "Saves/Quicksave";
 
 	std::list<std::shared_ptr<CInfoWindow>> dialogs; //queue of dialogs awaiting to be shown (not currently shown!)
+	std::shared_ptr<WindowBase> pendingLevelUpDialog;
+	int pendingLevelUpRequestID = -1;
 
 	std::unique_ptr<HeroMovementController> movementController;
 	std::unique_ptr<PathfinderCache> pathfinderCache;
@@ -241,6 +243,7 @@ private:
 	};
 
 	void heroKilled(const CGHeroInstance* hero);
+	void closePendingLevelUpDialog();
 	void townRemoved(const CGTownInstance* town);
 	void garrisonsChanged(std::vector<const CArmedInstance *> objs);
 	void requestReturningToMainMenu(bool won);

--- a/client/windows/CCreatureWindow.cpp
+++ b/client/windows/CCreatureWindow.cpp
@@ -142,6 +142,12 @@ void CCommanderSkillIcon::deselect()
 	redraw();
 }
 
+void CCommanderSkillIcon::select()
+{
+	isSelected = true;
+	redraw();
+}
+
 bool CCommanderSkillIcon::getIsMasterAbility()
 {
 	return isMasterAbility;
@@ -431,11 +437,15 @@ CStackWindow::ButtonsSection::ButtonsSection(CStackWindow * owner, int yOffset)
 			std::string tooltipText = "vcmi.creatureWindow." + btnIDs[buttonIndex];
 			parent->switchButtons[buttonIndex] = std::make_shared<CButton>(Point(342, 5), AnimationPath::builtin("stackWindow/upgradeButton"), CButton::tooltipLocalized(tooltipText), onSwitch);
 			parent->switchButtons[buttonIndex]->setOverlay(std::make_shared<CAnimImage>(AnimationPath::builtin("stackWindow/switchModeIcons"), buttonIndex));
+			parent->switchButtons[buttonIndex]->setHoverable(true);
+			parent->switchButtons[buttonIndex]->setImageOrder(0, 1, 2, 0); // no hover visual, keep pressed feedback
 		}
 		parent->switchButtons[parent->activeTab]->disable();
 	}
 
 	exit = std::make_shared<CButton>(Point(382, 5), AnimationPath::builtin("hsbtns.def"), LIBRARY->generaltexth->zelp[447], [this](){ parent->close(); }, EShortcut::GLOBAL_RETURN);
+	exit->setHoverable(true);
+	exit->setImageOrder(0, 1, 2, 0); // no hover visual, keep pressed feedback
 }
 
 CStackWindow::CommanderMainSection::CommanderMainSection(CStackWindow * owner, int yOffset)
@@ -541,6 +551,11 @@ CStackWindow::CommanderMainSection::CommanderMainSection(CStackWindow * owner, i
 
 			icon->hoverText = abilityDescription;
 			icon->text = abilityDescription;
+			if(parent->selectedSkill == skillID)
+			{
+				parent->selectedIcon = icon;
+				parent->setSelection(skillID, icon);
+			}
 
 			return icon;
 		};
@@ -836,6 +851,7 @@ CStackWindow::CStackWindow(const CCommanderInstance * commander, std::vector<ui3
 void CStackWindow::updateCommanderLevelUpData(const CCommanderInstance * commander, std::vector<ui32> & skills, std::function<void(ui32)> callback)
 {
 	OBJECT_CONSTRUCTION;
+	waitingForNextUpdate = false;
 
 	info->stackNode = commander;
 	info->creature = commander->getCreature();
@@ -848,23 +864,9 @@ void CStackWindow::updateCommanderLevelUpData(const CCommanderInstance * command
 
 	fakeNode.reset();
 	activeBonuses.clear();
-
-	if(mainSection)
-		removeChild(mainSection.get());
-	if(activeSpellsSection)
-		removeChild(activeSpellsSection.get());
-	if(commanderMainSection)
-		removeChild(commanderMainSection.get());
-	if(commanderBonusesSection)
-		removeChild(commanderBonusesSection.get());
-	if(bonusesSection)
-		removeChild(bonusesSection.get());
-	if(buttonsSection)
-		removeChild(buttonsSection.get());
-	if(commanderTab)
-		removeChild(commanderTab.get());
-
 	switchButtons.clear();
+	while(!children.empty())
+		removeChild(children.back());
 
 	mainSection.reset();
 	activeSpellsSection.reset();
@@ -873,15 +875,12 @@ void CStackWindow::updateCommanderLevelUpData(const CCommanderInstance * command
 	bonusesSection.reset();
 	buttonsSection.reset();
 	commanderTab.reset();
+	stackArtifact.reset();
+	stackArtifactButton.reset();
+	background.reset();
 
-	selectedIcon = nullptr;
-	selectedSkill = skills.empty() ? -1 : skills.front();
-	activeTab = 0;
-
-	pos = Rect();
-	initBonusesList();
-	initSections();
-	background->pos = pos;
+	pos = Rect(pos.x, pos.y, 0, 0);
+	init();
 
 	setRedrawParent(true);
 	redraw();
@@ -897,14 +896,32 @@ CStackWindow::~CStackWindow() = default;
 void CStackWindow::tick(uint32_t msPassed)
 {
 	CWindowObject::tick(msPassed);
+
+	if(waitingForNextUpdate && std::chrono::steady_clock::now() >= closeDeadline)
+	{
+		waitingForNextUpdate = false;
+		CWindowObject::close();
+	}
 }
 
 void CStackWindow::close()
 {
+	if(waitingForNextUpdate)
+		return;
+
 	if(info->levelupInfo && !info->levelupInfo->skills.empty())
 		info->levelupInfo->callback(vstd::find_pos(info->levelupInfo->skills, selectedSkill));
 
-	CWindowObject::close();
+	const bool expectAnotherCommanderLevelUp = info->commander && info->commander->gainsLevel();
+	if(expectAnotherCommanderLevelUp)
+	{
+		waitingForNextUpdate = true;
+		closeDeadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(200);
+	}
+	else
+	{
+		CWindowObject::close();
+	}
 }
 
 void CStackWindow::init()
@@ -1194,6 +1211,8 @@ void CStackWindow::setSelection(si32 newSkill, std::shared_ptr<CCommanderSkillIc
 	}
 
 	selectedIcon = newIcon; // update new selection
+	if(selectedIcon)
+		selectedIcon->select();
 	if(newSkill < 100)
 	{
 		newIcon->setObject(std::make_shared<CPicture>(getSkillImage(newSkill)));

--- a/client/windows/CCreatureWindow.cpp
+++ b/client/windows/CCreatureWindow.cpp
@@ -132,6 +132,11 @@ void CCommanderSkillIcon::setObject(std::shared_ptr<CIntObject> newObject)
 void CCommanderSkillIcon::clickPressed(const Point & cursorPosition)
 {
 	callback();
+	select();
+}
+
+void CCommanderSkillIcon::select()
+{
 	isSelected = true;
 	redraw();
 }
@@ -139,12 +144,6 @@ void CCommanderSkillIcon::clickPressed(const Point & cursorPosition)
 void CCommanderSkillIcon::deselect()
 {
 	isSelected = false;
-	redraw();
-}
-
-void CCommanderSkillIcon::select()
-{
-	isSelected = true;
 	redraw();
 }
 
@@ -547,11 +546,9 @@ CStackWindow::CommanderMainSection::CommanderMainSection(CStackWindow * owner, i
 
 			icon->hoverText = abilityDescription;
 			icon->text = abilityDescription;
-			if(parent->selectedSkill == skillID)
-			{
-				parent->selectedIcon = icon;
+
+			if(parent->selectedSkill == static_cast<si32>(skillID))
 				parent->setSelection(skillID, icon);
-			}
 
 			return icon;
 		};
@@ -844,80 +841,30 @@ CStackWindow::CStackWindow(const CCommanderInstance * commander, std::vector<ui3
 	init();
 }
 
-void CStackWindow::updateCommanderLevelUpData(const CCommanderInstance * commander, std::vector<ui32> & skills, std::function<void(ui32)> callback)
-{
-	OBJECT_CONSTRUCTION;
-	waitingForNextUpdate = false;
-
-	info->stackNode = commander;
-	info->creature = commander->getCreature();
-	info->commander = commander;
-	info->creatureCount = 1;
-	info->owner = dynamic_cast<const CGHeroInstance *> (commander->getArmy());
-	info->levelupInfo = std::make_optional(UnitView::CommanderLevelInfo());
-	info->levelupInfo->skills = skills;
-	info->levelupInfo->callback = callback;
-
-	fakeNode.reset();
-	activeBonuses.clear();
-	switchButtons.clear();
-	while(!children.empty())
-		removeChild(children.back());
-
-	mainSection.reset();
-	activeSpellsSection.reset();
-	commanderMainSection.reset();
-	commanderBonusesSection.reset();
-	bonusesSection.reset();
-	buttonsSection.reset();
-	commanderTab.reset();
-	stackArtifact.reset();
-	stackArtifactButton.reset();
-	background.reset();
-
-	pos = Rect(pos.x, pos.y, 0, 0);
-	init();
-
-	setRedrawParent(true);
-	redraw();
-}
-
-bool CStackWindow::isCommanderLevelUpDialog() const
-{
-	return info && info->levelupInfo.has_value();
-}
-
 CStackWindow::~CStackWindow() = default;
 
-void CStackWindow::tick(uint32_t msPassed)
+void CStackWindow::setCloseOnSelection(bool value)
 {
-	CWindowObject::tick(msPassed);
-
-	if(waitingForNextUpdate && std::chrono::steady_clock::now() >= closeDeadline)
-	{
-		waitingForNextUpdate = false;
-		CWindowObject::close();
-	}
+	closeOnSelection = value;
 }
 
 void CStackWindow::close()
 {
-	if(waitingForNextUpdate)
-		return;
-
-	if(info->levelupInfo && !info->levelupInfo->skills.empty())
-		info->levelupInfo->callback(vstd::find_pos(info->levelupInfo->skills, selectedSkill));
-
-	const bool expectAnotherCommanderLevelUp = info->commander && info->commander->gainsLevel();
-	if(expectAnotherCommanderLevelUp)
+	if(!selectionSubmitted)
 	{
-		waitingForNextUpdate = true;
-		closeDeadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(200);
+		if(info->levelupInfo && !info->levelupInfo->skills.empty())
+			info->levelupInfo->callback(vstd::find_pos(info->levelupInfo->skills, selectedSkill));
+
+		selectionSubmitted = true;
+
+		if(!closeOnSelection)
+		{
+			deactivate();
+			return;
+		}
 	}
-	else
-	{
-		CWindowObject::close();
-	}
+
+	CWindowObject::close();
 }
 
 void CStackWindow::init()
@@ -1207,8 +1154,6 @@ void CStackWindow::setSelection(si32 newSkill, std::shared_ptr<CCommanderSkillIc
 	}
 
 	selectedIcon = newIcon; // update new selection
-	if(selectedIcon)
-		selectedIcon->select();
 	if(newSkill < 100)
 	{
 		newIcon->setObject(std::make_shared<CPicture>(getSkillImage(newSkill)));
@@ -1217,6 +1162,7 @@ void CStackWindow::setSelection(si32 newSkill, std::shared_ptr<CCommanderSkillIc
 			newIcon->text = getSkillDescription(newSkill, true); //update currently selected icon's message to show upgrade description
 		}
 	}
+	newIcon->select();
 }
 
 std::shared_ptr<CIntObject> CStackWindow::switchTab(size_t index)

--- a/client/windows/CCreatureWindow.cpp
+++ b/client/windows/CCreatureWindow.cpp
@@ -437,15 +437,11 @@ CStackWindow::ButtonsSection::ButtonsSection(CStackWindow * owner, int yOffset)
 			std::string tooltipText = "vcmi.creatureWindow." + btnIDs[buttonIndex];
 			parent->switchButtons[buttonIndex] = std::make_shared<CButton>(Point(342, 5), AnimationPath::builtin("stackWindow/upgradeButton"), CButton::tooltipLocalized(tooltipText), onSwitch);
 			parent->switchButtons[buttonIndex]->setOverlay(std::make_shared<CAnimImage>(AnimationPath::builtin("stackWindow/switchModeIcons"), buttonIndex));
-			parent->switchButtons[buttonIndex]->setHoverable(true);
-			parent->switchButtons[buttonIndex]->setImageOrder(0, 1, 2, 0); // no hover visual, keep pressed feedback
 		}
 		parent->switchButtons[parent->activeTab]->disable();
 	}
 
 	exit = std::make_shared<CButton>(Point(382, 5), AnimationPath::builtin("hsbtns.def"), LIBRARY->generaltexth->zelp[447], [this](){ parent->close(); }, EShortcut::GLOBAL_RETURN);
-	exit->setHoverable(true);
-	exit->setImageOrder(0, 1, 2, 0); // no hover visual, keep pressed feedback
 }
 
 CStackWindow::CommanderMainSection::CommanderMainSection(CStackWindow * owner, int yOffset)

--- a/client/windows/CCreatureWindow.cpp
+++ b/client/windows/CCreatureWindow.cpp
@@ -440,7 +440,7 @@ CStackWindow::ButtonsSection::ButtonsSection(CStackWindow * owner, int yOffset)
 		parent->switchButtons[parent->activeTab]->disable();
 	}
 
-	exit = std::make_shared<CButton>(Point(382, 5), AnimationPath::builtin("hsbtns.def"), LIBRARY->generaltexth->zelp[447], [this](){ parent->close(); }, EShortcut::GLOBAL_RETURN);
+	exit = std::make_shared<CButton>(Point(382, 5), AnimationPath::builtin("hsbtns.def"), LIBRARY->generaltexth->zelp[447], [this](){ parent->submitSelection(); }, EShortcut::GLOBAL_RETURN);
 }
 
 CStackWindow::CommanderMainSection::CommanderMainSection(CStackWindow * owner, int yOffset)
@@ -848,7 +848,7 @@ void CStackWindow::setCloseOnSelection(bool value)
 	closeOnSelection = value;
 }
 
-void CStackWindow::close()
+void CStackWindow::submitSelection()
 {
 	if(!selectionSubmitted)
 	{
@@ -863,6 +863,14 @@ void CStackWindow::close()
 			return;
 		}
 	}
+
+	close();
+}
+
+void CStackWindow::close()
+{
+	if(!selectionSubmitted && info->levelupInfo && !info->levelupInfo->skills.empty())
+		return;
 
 	CWindowObject::close();
 }

--- a/client/windows/CCreatureWindow.cpp
+++ b/client/windows/CCreatureWindow.cpp
@@ -833,7 +833,71 @@ CStackWindow::CStackWindow(const CCommanderInstance * commander, std::vector<ui3
 	init();
 }
 
+void CStackWindow::updateCommanderLevelUpData(const CCommanderInstance * commander, std::vector<ui32> & skills, std::function<void(ui32)> callback)
+{
+	OBJECT_CONSTRUCTION;
+
+	info->stackNode = commander;
+	info->creature = commander->getCreature();
+	info->commander = commander;
+	info->creatureCount = 1;
+	info->owner = dynamic_cast<const CGHeroInstance *> (commander->getArmy());
+	info->levelupInfo = std::make_optional(UnitView::CommanderLevelInfo());
+	info->levelupInfo->skills = skills;
+	info->levelupInfo->callback = callback;
+
+	fakeNode.reset();
+	activeBonuses.clear();
+
+	if(mainSection)
+		removeChild(mainSection.get());
+	if(activeSpellsSection)
+		removeChild(activeSpellsSection.get());
+	if(commanderMainSection)
+		removeChild(commanderMainSection.get());
+	if(commanderBonusesSection)
+		removeChild(commanderBonusesSection.get());
+	if(bonusesSection)
+		removeChild(bonusesSection.get());
+	if(buttonsSection)
+		removeChild(buttonsSection.get());
+	if(commanderTab)
+		removeChild(commanderTab.get());
+
+	switchButtons.clear();
+
+	mainSection.reset();
+	activeSpellsSection.reset();
+	commanderMainSection.reset();
+	commanderBonusesSection.reset();
+	bonusesSection.reset();
+	buttonsSection.reset();
+	commanderTab.reset();
+
+	selectedIcon = nullptr;
+	selectedSkill = skills.empty() ? -1 : skills.front();
+	activeTab = 0;
+
+	pos = Rect();
+	initBonusesList();
+	initSections();
+	background->pos = pos;
+
+	setRedrawParent(true);
+	redraw();
+}
+
+bool CStackWindow::isCommanderLevelUpDialog() const
+{
+	return info && info->levelupInfo.has_value();
+}
+
 CStackWindow::~CStackWindow() = default;
+
+void CStackWindow::tick(uint32_t msPassed)
+{
+	CWindowObject::tick(msPassed);
+}
 
 void CStackWindow::close()
 {

--- a/client/windows/CCreatureWindow.h
+++ b/client/windows/CCreatureWindow.h
@@ -193,6 +193,7 @@ class CStackWindow : public CWindowObject
 	void initBonusesList();
 
 	void init();
+	void tick(uint32_t msPassed) override;
 	void close() override;
 
 	std::string generateStackExpDescription();
@@ -212,6 +213,8 @@ public:
 	// for commanders & commander level-up dialog
 	CStackWindow(const CCommanderInstance * commander, bool popup);
 	CStackWindow(const CCommanderInstance * commander, std::vector<ui32> &skills, std::function<void(ui32)> callback);
+	void updateCommanderLevelUpData(const CCommanderInstance * commander, std::vector<ui32> & skills, std::function<void(ui32)> callback);
+	bool isCommanderLevelUpDialog() const;
 
 	~CStackWindow();
 };

--- a/client/windows/CCreatureWindow.h
+++ b/client/windows/CCreatureWindow.h
@@ -13,6 +13,7 @@
 #include "../../lib/filesystem/ResourcePath.h"
 #include "../widgets/MiscWidgets.h"
 #include "CWindowObject.h"
+#include <chrono>
 
 VCMI_LIB_NAMESPACE_BEGIN
 
@@ -47,6 +48,7 @@ public:
 	void clickPressed(const Point & cursorPosition) override;
 
 	void setObject(std::shared_ptr<CIntObject> object);
+	void select();
 	void deselect(); //TODO: consider using observer pattern instead?
 	bool getIsMasterAbility();
 
@@ -183,6 +185,8 @@ class CStackWindow : public CWindowObject
 
 	std::shared_ptr<CCommanderSkillIcon> selectedIcon;
 	si32 selectedSkill;
+	bool waitingForNextUpdate = false;
+	std::chrono::steady_clock::time_point closeDeadline;
 
 	void setSelection(si32 newSkill, std::shared_ptr<CCommanderSkillIcon> newIcon);
 	std::shared_ptr<CIntObject> switchTab(size_t index);

--- a/client/windows/CCreatureWindow.h
+++ b/client/windows/CCreatureWindow.h
@@ -13,7 +13,6 @@
 #include "../../lib/filesystem/ResourcePath.h"
 #include "../widgets/MiscWidgets.h"
 #include "CWindowObject.h"
-#include <chrono>
 
 VCMI_LIB_NAMESPACE_BEGIN
 
@@ -185,8 +184,6 @@ class CStackWindow : public CWindowObject
 
 	std::shared_ptr<CCommanderSkillIcon> selectedIcon;
 	si32 selectedSkill;
-	bool waitingForNextUpdate = false;
-	std::chrono::steady_clock::time_point closeDeadline;
 
 	void setSelection(si32 newSkill, std::shared_ptr<CCommanderSkillIcon> newIcon);
 	std::shared_ptr<CIntObject> switchTab(size_t index);
@@ -197,7 +194,6 @@ class CStackWindow : public CWindowObject
 	void initBonusesList();
 
 	void init();
-	void tick(uint32_t msPassed) override;
 	void close() override;
 
 	std::string generateStackExpDescription();
@@ -217,8 +213,11 @@ public:
 	// for commanders & commander level-up dialog
 	CStackWindow(const CCommanderInstance * commander, bool popup);
 	CStackWindow(const CCommanderInstance * commander, std::vector<ui32> &skills, std::function<void(ui32)> callback);
-	void updateCommanderLevelUpData(const CCommanderInstance * commander, std::vector<ui32> & skills, std::function<void(ui32)> callback);
-	bool isCommanderLevelUpDialog() const;
+	void setCloseOnSelection(bool value);
 
 	~CStackWindow();
+
+private:
+	bool closeOnSelection = true;
+	bool selectionSubmitted = false;
 };

--- a/client/windows/CCreatureWindow.h
+++ b/client/windows/CCreatureWindow.h
@@ -192,6 +192,7 @@ class CStackWindow : public CWindowObject
 
 	void initSections();
 	void initBonusesList();
+	void submitSelection();
 
 	void init();
 	void close() override;

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -1154,13 +1154,7 @@ CGarrisonWindow::CGarrisonWindow(const CArmedInstance * up, const CGHeroInstance
 	std::string titleText;
 	if(down->tempOwner == up->tempOwner)
 	{
-		const auto * town = dynamic_cast<const CGTownInstance *>(up);
-		const bool isReinforcementsDialog = town != nullptr && down->getVisitedTown() != town;
-
-		if(isReinforcementsDialog)
-			titleText = LIBRARY->generaltexth->translate("vcmi.spells.reinforcements.garrison.title");
-		else
-			titleText = LIBRARY->generaltexth->allTexts[709];
+		titleText = LIBRARY->generaltexth->allTexts[709];
 	}
 	else
 	{

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -410,14 +410,63 @@ void CSplitWindow::sliderMoved(int to)
 
 CLevelWindow::CLevelWindow(const CGHeroInstance * hero, PrimarySkill pskill, std::vector<SecondarySkill> & skills, std::function<void(ui32)> callback)
 	: CWindowObject(PLAYER_COLORED, ImagePath::builtin("LVLUPBKG")),
-	cb(callback),
-	skills(skills),
-	hero(hero),
 	skillViewOffset(0)
 {
 	OBJECT_CONSTRUCTION;
 
 	GAME->interface()->showingDialog->setBusy();
+	updateLevelUpData(hero, pskill, skills, callback);
+}
+
+std::vector<SecondarySkill> getSkillsToShow(const std::vector<SecondarySkill>& skills, int offset, int count)
+{
+	std::vector<SecondarySkill> result;
+
+	int size = skills.size();
+	if (size == 0 || count <= 0) return result;
+
+	offset = offset % size; // ensure offset is within bounds
+	for (int i = 0; i < std::min(count, size); ++i)
+	{
+		int index = (offset + i) % size; // ring buffer like
+		result.push_back(skills[index]);
+	}
+
+	return result;
+}
+
+void CLevelWindow::createSkillBox()
+{
+	OBJECT_CONSTRUCTION;
+	box.reset();
+
+	std::vector<SecondarySkill> skillsToShow = skills.size() > 3 ? getSkillsToShow(sortedSkills, skillViewOffset, 3) : sortedSkills;
+	if(!skillsToShow.empty())
+	{
+		std::vector<std::shared_ptr<CSelectableComponent>> comps;
+		for(auto & skill : skillsToShow)
+		{
+			auto comp = std::make_shared<CSelectableComponent>(ComponentType::SEC_SKILL, skill, hero->getSecSkillLevel(SecondarySkill(skill))+1, CComponent::medium);
+			comp->onChoose = std::bind(&CLevelWindow::close, this);
+			comps.push_back(comp);
+		}
+
+		box = std::make_shared<CComponentBox>(comps, Rect(75, 300, pos.w - 150, 100));
+	}
+
+	setRedrawParent(true);
+	redraw();
+}
+
+void CLevelWindow::updateLevelUpData(const CGHeroInstance * hero, PrimarySkill pskill, std::vector<SecondarySkill> & skills, std::function<void(ui32)> callback)
+{
+	OBJECT_CONSTRUCTION;
+	waitingForNextUpdate = false;
+
+	this->hero = hero;
+	cb = callback;
+	this->skills = skills;
+	skillViewOffset = 0;
 
 	sortedSkills = skills;
 	std::sort(sortedSkills.begin(), sortedSkills.end(), [hero](auto a, auto b) {
@@ -427,17 +476,26 @@ CLevelWindow::CLevelWindow(const CGHeroInstance * hero, PrimarySkill pskill, std
 	});
 
 	createSkillBox();
+	buttonLeft.reset();
+	buttonRight.reset();
+	portrait.reset();
+	ok.reset();
+	mainTitle.reset();
+	levelTitle.reset();
+	skillIcon.reset();
+	skillValue.reset();
+
 	if(skills.size() > 3)
 	{
-		buttonLeft = std::make_shared<CButton>(Point(23, 309), AnimationPath::builtin("HSBTNS3"), CButton::tooltip(), [this, skills](){
+		buttonLeft = std::make_shared<CButton>(Point(23, 309), AnimationPath::builtin("HSBTNS3"), CButton::tooltip(), [this](){
 			if(skillViewOffset > 0)
 				skillViewOffset--;
 			else
-				skillViewOffset = skills.size() - 1;
+				skillViewOffset = this->skills.size() - 1;
 			createSkillBox();
 		}, EShortcut::MOVE_LEFT);
-		buttonRight = std::make_shared<CButton>(Point(pos.w - 45, 309), AnimationPath::builtin("HSBTNS5"), CButton::tooltip(), [this, skills](){
-			if(skillViewOffset < skills.size() - 1)
+		buttonRight = std::make_shared<CButton>(Point(pos.w - 45, 309), AnimationPath::builtin("HSBTNS5"), CButton::tooltip(), [this](){
+			if(skillViewOffset < this->skills.size() - 1)
 				skillViewOffset++;
 			else
 				skillViewOffset = 0;
@@ -462,51 +520,29 @@ CLevelWindow::CLevelWindow(const CGHeroInstance * hero, PrimarySkill pskill, std
 	levelTitle = std::make_shared<CLabel>(192, 162, FONT_MEDIUM, ETextAlignment::CENTER, Colors::WHITE, levelTitleText);
 
 	skillIcon = std::make_shared<CAnimImage>(AnimationPath::builtin("PSKIL42"), pskill.getNum(), 0, 174, 190);
-
 	skillValue = std::make_shared<CLabel>(192, 253, FONT_MEDIUM, ETextAlignment::CENTER, Colors::WHITE, LIBRARY->generaltexth->primarySkillNames[pskill.getNum()] + " +1");
-}
-
-std::vector<SecondarySkill> getSkillsToShow(const std::vector<SecondarySkill>& skills, int offset, int count)
-{
-	std::vector<SecondarySkill> result;
-
-	int size = skills.size();
-	if (size == 0 || count <= 0) return result;
-
-	offset = offset % size; // ensure offset is within bounds
-	for (int i = 0; i < std::min(count, size); ++i)
-	{
-		int index = (offset + i) % size; // ring buffer like
-		result.push_back(skills[index]);
-	}
-
-	return result;
-}
-
-void CLevelWindow::createSkillBox()
-{
-	OBJECT_CONSTRUCTION;
-
-	std::vector<SecondarySkill> skillsToShow = skills.size() > 3 ? getSkillsToShow(sortedSkills, skillViewOffset, 3) : sortedSkills;
-	if(!skillsToShow.empty())
-	{
-		std::vector<std::shared_ptr<CSelectableComponent>> comps;
-		for(auto & skill : skillsToShow)
-		{
-			auto comp = std::make_shared<CSelectableComponent>(ComponentType::SEC_SKILL, skill, hero->getSecSkillLevel(SecondarySkill(skill))+1, CComponent::medium);
-			comp->onChoose = std::bind(&CLevelWindow::close, this);
-			comps.push_back(comp);
-		}
-
-		box = std::make_shared<CComponentBox>(comps, Rect(75, 300, pos.w - 150, 100));
-	}
 
 	setRedrawParent(true);
 	redraw();
 }
 
+void CLevelWindow::tick(uint32_t msPassed)
+{
+	CWindowObject::tick(msPassed);
+
+	if(waitingForNextUpdate && std::chrono::steady_clock::now() >= closeDeadline)
+	{
+		waitingForNextUpdate = false;
+		GAME->interface()->showingDialog->setFree();
+		CWindowObject::close();
+	}
+}
+
 void CLevelWindow::close()
 {
+	if(waitingForNextUpdate)
+		return;
+
 	int idx = -1;
 
 	if(box)
@@ -527,12 +563,20 @@ void CLevelWindow::close()
 		const auto & chosen = sortedSkills[(idx + skillViewOffset) % skills.size()];
 		auto it = std::find(skills.begin(), skills.end(), chosen);
 
-		cb(std::distance(skills.begin(), it));
+				cb(std::distance(skills.begin(), it));
 	}
 
-	GAME->interface()->showingDialog->setFree();
-
-	CWindowObject::close();
+	const bool expectAnotherHeroLevelUp = hero && hero->gainsLevel();
+	if(expectAnotherHeroLevelUp)
+	{
+		waitingForNextUpdate = true;
+		closeDeadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(200);
+	}
+	else
+	{
+		GAME->interface()->showingDialog->setFree();
+		CWindowObject::close();
+	}
 }
 
 CTavernWindow::CTavernWindow(const CGObjectInstance * TavernObj, const std::function<void()> & onWindowClosed)
@@ -1139,7 +1183,13 @@ CGarrisonWindow::CGarrisonWindow(const CArmedInstance * up, const CGHeroInstance
 	std::string titleText;
 	if(down->tempOwner == up->tempOwner)
 	{
-		titleText = LIBRARY->generaltexth->allTexts[709];
+		const auto * town = dynamic_cast<const CGTownInstance *>(up);
+		const bool isReinforcementsDialog = town != nullptr && down->getVisitedTown() != town;
+
+		if(isReinforcementsDialog)
+			titleText = LIBRARY->generaltexth->translate("vcmi.spells.reinforcements.garrison.title");
+		else
+			titleText = LIBRARY->generaltexth->allTexts[709];
 	}
 	else
 	{

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -507,6 +507,8 @@ void CLevelWindow::updateLevelUpData(const CGHeroInstance * hero, PrimarySkill p
 	portrait->addClickCallback(nullptr);
 	portrait->addRClickCallback([hero](){ ENGINE->windows().createAndPushWindow<CRClickPopupInt>(std::make_shared<CHeroWindow>(hero)); });
 	ok = std::make_shared<CButton>(Point(297, 413), AnimationPath::builtin("IOKAY"), CButton::tooltip(), std::bind(&CLevelWindow::close, this), EShortcut::GLOBAL_ACCEPT);
+	ok->setHoverable(true);
+	ok->setImageOrder(0, 1, 2, 0); // keep hover visually neutral, preserve pressed frame
 
 	//%s has gained a level.
 	mainTitle = std::make_shared<CLabel>(192, 33, FONT_MEDIUM, ETextAlignment::CENTER, Colors::WHITE, boost::str(boost::format(LIBRARY->generaltexth->allTexts[444]) % hero->getNameTranslated()));

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -410,63 +410,14 @@ void CSplitWindow::sliderMoved(int to)
 
 CLevelWindow::CLevelWindow(const CGHeroInstance * hero, PrimarySkill pskill, std::vector<SecondarySkill> & skills, std::function<void(ui32)> callback)
 	: CWindowObject(PLAYER_COLORED, ImagePath::builtin("LVLUPBKG")),
+	cb(callback),
+	skills(skills),
+	hero(hero),
 	skillViewOffset(0)
 {
 	OBJECT_CONSTRUCTION;
 
 	GAME->interface()->showingDialog->setBusy();
-	updateLevelUpData(hero, pskill, skills, callback);
-}
-
-std::vector<SecondarySkill> getSkillsToShow(const std::vector<SecondarySkill>& skills, int offset, int count)
-{
-	std::vector<SecondarySkill> result;
-
-	int size = skills.size();
-	if (size == 0 || count <= 0) return result;
-
-	offset = offset % size; // ensure offset is within bounds
-	for (int i = 0; i < std::min(count, size); ++i)
-	{
-		int index = (offset + i) % size; // ring buffer like
-		result.push_back(skills[index]);
-	}
-
-	return result;
-}
-
-void CLevelWindow::createSkillBox()
-{
-	OBJECT_CONSTRUCTION;
-	box.reset();
-
-	std::vector<SecondarySkill> skillsToShow = skills.size() > 3 ? getSkillsToShow(sortedSkills, skillViewOffset, 3) : sortedSkills;
-	if(!skillsToShow.empty())
-	{
-		std::vector<std::shared_ptr<CSelectableComponent>> comps;
-		for(auto & skill : skillsToShow)
-		{
-			auto comp = std::make_shared<CSelectableComponent>(ComponentType::SEC_SKILL, skill, hero->getSecSkillLevel(SecondarySkill(skill))+1, CComponent::medium);
-			comp->onChoose = std::bind(&CLevelWindow::close, this);
-			comps.push_back(comp);
-		}
-
-		box = std::make_shared<CComponentBox>(comps, Rect(75, 300, pos.w - 150, 100));
-	}
-
-	setRedrawParent(true);
-	redraw();
-}
-
-void CLevelWindow::updateLevelUpData(const CGHeroInstance * hero, PrimarySkill pskill, std::vector<SecondarySkill> & skills, std::function<void(ui32)> callback)
-{
-	OBJECT_CONSTRUCTION;
-	waitingForNextUpdate = false;
-
-	this->hero = hero;
-	cb = callback;
-	this->skills = skills;
-	skillViewOffset = 0;
 
 	sortedSkills = skills;
 	std::sort(sortedSkills.begin(), sortedSkills.end(), [hero](auto a, auto b) {
@@ -476,26 +427,17 @@ void CLevelWindow::updateLevelUpData(const CGHeroInstance * hero, PrimarySkill p
 	});
 
 	createSkillBox();
-	buttonLeft.reset();
-	buttonRight.reset();
-	portrait.reset();
-	ok.reset();
-	mainTitle.reset();
-	levelTitle.reset();
-	skillIcon.reset();
-	skillValue.reset();
-
 	if(skills.size() > 3)
 	{
-		buttonLeft = std::make_shared<CButton>(Point(23, 309), AnimationPath::builtin("HSBTNS3"), CButton::tooltip(), [this](){
+		buttonLeft = std::make_shared<CButton>(Point(23, 309), AnimationPath::builtin("HSBTNS3"), CButton::tooltip(), [this, skills](){
 			if(skillViewOffset > 0)
 				skillViewOffset--;
 			else
-				skillViewOffset = this->skills.size() - 1;
+				skillViewOffset = skills.size() - 1;
 			createSkillBox();
 		}, EShortcut::MOVE_LEFT);
-		buttonRight = std::make_shared<CButton>(Point(pos.w - 45, 309), AnimationPath::builtin("HSBTNS5"), CButton::tooltip(), [this](){
-			if(skillViewOffset < this->skills.size() - 1)
+		buttonRight = std::make_shared<CButton>(Point(pos.w - 45, 309), AnimationPath::builtin("HSBTNS5"), CButton::tooltip(), [this, skills](){
+			if(skillViewOffset < skills.size() - 1)
 				skillViewOffset++;
 			else
 				skillViewOffset = 0;
@@ -520,63 +462,92 @@ void CLevelWindow::updateLevelUpData(const CGHeroInstance * hero, PrimarySkill p
 	levelTitle = std::make_shared<CLabel>(192, 162, FONT_MEDIUM, ETextAlignment::CENTER, Colors::WHITE, levelTitleText);
 
 	skillIcon = std::make_shared<CAnimImage>(AnimationPath::builtin("PSKIL42"), pskill.getNum(), 0, 174, 190);
+
 	skillValue = std::make_shared<CLabel>(192, 253, FONT_MEDIUM, ETextAlignment::CENTER, Colors::WHITE, LIBRARY->generaltexth->primarySkillNames[pskill.getNum()] + " +1");
+}
+
+std::vector<SecondarySkill> getSkillsToShow(const std::vector<SecondarySkill>& skills, int offset, int count)
+{
+	std::vector<SecondarySkill> result;
+
+	int size = skills.size();
+	if (size == 0 || count <= 0) return result;
+
+	offset = offset % size; // ensure offset is within bounds
+	for (int i = 0; i < std::min(count, size); ++i)
+	{
+		int index = (offset + i) % size; // ring buffer like
+		result.push_back(skills[index]);
+	}
+
+	return result;
+}
+
+void CLevelWindow::createSkillBox()
+{
+	OBJECT_CONSTRUCTION;
+
+	std::vector<SecondarySkill> skillsToShow = skills.size() > 3 ? getSkillsToShow(sortedSkills, skillViewOffset, 3) : sortedSkills;
+	if(!skillsToShow.empty())
+	{
+		std::vector<std::shared_ptr<CSelectableComponent>> comps;
+		for(auto & skill : skillsToShow)
+		{
+			auto comp = std::make_shared<CSelectableComponent>(ComponentType::SEC_SKILL, skill, hero->getSecSkillLevel(SecondarySkill(skill))+1, CComponent::medium);
+			comp->onChoose = std::bind(&CLevelWindow::close, this);
+			comps.push_back(comp);
+		}
+
+		box = std::make_shared<CComponentBox>(comps, Rect(75, 300, pos.w - 150, 100));
+	}
 
 	setRedrawParent(true);
 	redraw();
 }
 
-void CLevelWindow::tick(uint32_t msPassed)
+void CLevelWindow::setCloseOnSelection(bool value)
 {
-	CWindowObject::tick(msPassed);
-
-	if(waitingForNextUpdate && std::chrono::steady_clock::now() >= closeDeadline)
-	{
-		waitingForNextUpdate = false;
-		GAME->interface()->showingDialog->setFree();
-		CWindowObject::close();
-	}
+	closeOnSelection = value;
 }
 
 void CLevelWindow::close()
 {
-	if(waitingForNextUpdate)
-		return;
-
-	int idx = -1;
-
-	if(box)
-		idx = box->selectedIndex();
-
-	// If there are skills available, we must not close without producing a valid choice
-	// For a single available option, auto-pick it
-	if(!skills.empty())
+	if(!selectionSubmitted)
 	{
-		if(idx == -1)
+		int idx = -1;
+
+		if(box)
+			idx = box->selectedIndex();
+
+		// If there are skills available, we must not close without producing a valid choice
+		// For a single available option, auto-pick it
+		if(!skills.empty())
 		{
-			if(skills.size() == 1)
-				idx = 0;
-			else
-				return; // require explicit selection
+			if(idx == -1)
+			{
+				if(skills.size() == 1)
+					idx = 0;
+				else
+					return; // require explicit selection
+			}
+
+			const auto & chosen = sortedSkills[(idx + skillViewOffset) % skills.size()];
+			auto it = std::find(skills.begin(), skills.end(), chosen);
+
+			cb(std::distance(skills.begin(), it));
 		}
 
-		const auto & chosen = sortedSkills[(idx + skillViewOffset) % skills.size()];
-		auto it = std::find(skills.begin(), skills.end(), chosen);
-
-				cb(std::distance(skills.begin(), it));
-	}
-
-	const bool expectAnotherHeroLevelUp = hero && hero->gainsLevel();
-	if(expectAnotherHeroLevelUp)
-	{
-		waitingForNextUpdate = true;
-		closeDeadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(200);
-	}
-	else
-	{
+		selectionSubmitted = true;
 		GAME->interface()->showingDialog->setFree();
-		CWindowObject::close();
+
+		if(!closeOnSelection)
+		{
+			deactivate();
+			return;
+		}
 	}
+
+	CWindowObject::close();
 }
 
 CTavernWindow::CTavernWindow(const CGObjectInstance * TavernObj, const std::function<void()> & onWindowClosed)

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -448,7 +448,7 @@ CLevelWindow::CLevelWindow(const CGHeroInstance * hero, PrimarySkill pskill, std
 	portrait = std::make_shared<CHeroArea>(170, 66, hero);
 	portrait->addClickCallback(nullptr);
 	portrait->addRClickCallback([hero](){ ENGINE->windows().createAndPushWindow<CRClickPopupInt>(std::make_shared<CHeroWindow>(hero)); });
-	ok = std::make_shared<CButton>(Point(297, 413), AnimationPath::builtin("IOKAY"), CButton::tooltip(), std::bind(&CLevelWindow::close, this), EShortcut::GLOBAL_ACCEPT);
+	ok = std::make_shared<CButton>(Point(297, 413), AnimationPath::builtin("IOKAY"), CButton::tooltip(), std::bind(&CLevelWindow::submitSelection, this), EShortcut::GLOBAL_ACCEPT);
 
 	//%s has gained a level.
 	mainTitle = std::make_shared<CLabel>(192, 33, FONT_MEDIUM, ETextAlignment::CENTER, Colors::WHITE, boost::str(boost::format(LIBRARY->generaltexth->allTexts[444]) % hero->getNameTranslated()));
@@ -494,7 +494,7 @@ void CLevelWindow::createSkillBox()
 		for(auto & skill : skillsToShow)
 		{
 			auto comp = std::make_shared<CSelectableComponent>(ComponentType::SEC_SKILL, skill, hero->getSecSkillLevel(SecondarySkill(skill))+1, CComponent::medium);
-			comp->onChoose = std::bind(&CLevelWindow::close, this);
+			comp->onChoose = std::bind(&CLevelWindow::submitSelection, this);
 			comps.push_back(comp);
 		}
 
@@ -510,7 +510,7 @@ void CLevelWindow::setCloseOnSelection(bool value)
 	closeOnSelection = value;
 }
 
-void CLevelWindow::close()
+void CLevelWindow::submitSelection()
 {
 	if(!selectionSubmitted)
 	{
@@ -546,6 +546,14 @@ void CLevelWindow::close()
 			return;
 		}
 	}
+
+	close();
+}
+
+void CLevelWindow::close()
+{
+	if(!selectionSubmitted && !skills.empty())
+		return;
 
 	CWindowObject::close();
 }

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -507,8 +507,6 @@ void CLevelWindow::updateLevelUpData(const CGHeroInstance * hero, PrimarySkill p
 	portrait->addClickCallback(nullptr);
 	portrait->addRClickCallback([hero](){ ENGINE->windows().createAndPushWindow<CRClickPopupInt>(std::make_shared<CHeroWindow>(hero)); });
 	ok = std::make_shared<CButton>(Point(297, 413), AnimationPath::builtin("IOKAY"), CButton::tooltip(), std::bind(&CLevelWindow::close, this), EShortcut::GLOBAL_ACCEPT);
-	ok->setHoverable(true);
-	ok->setImageOrder(0, 1, 2, 0); // keep hover visually neutral, preserve pressed frame
 
 	//%s has gained a level.
 	mainTitle = std::make_shared<CLabel>(192, 33, FONT_MEDIUM, ETextAlignment::CENTER, Colors::WHITE, boost::str(boost::format(LIBRARY->generaltexth->allTexts[444]) % hero->getNameTranslated()));

--- a/client/windows/GUIClasses.h
+++ b/client/windows/GUIClasses.h
@@ -13,6 +13,7 @@
 #include "../lib/ResourceSet.h"
 #include "../widgets/Images.h"
 #include "../widgets/IVideoHolder.h"
+#include <chrono>
 
 VCMI_LIB_NAMESPACE_BEGIN
 
@@ -159,12 +160,16 @@ class CLevelWindow : public CWindowObject
 	std::vector<SecondarySkill> skills;
 	std::vector<SecondarySkill> sortedSkills;
 	const CGHeroInstance * hero;
+	bool waitingForNextUpdate = false;
+	std::chrono::steady_clock::time_point closeDeadline;
 
 	void selectionChanged(unsigned to);
 	void createSkillBox();
 
 public:
 	CLevelWindow(const CGHeroInstance *hero, PrimarySkill pskill, std::vector<SecondarySkill> &skills, std::function<void(ui32)> callback);
+	void updateLevelUpData(const CGHeroInstance * hero, PrimarySkill pskill, std::vector<SecondarySkill> & skills, std::function<void(ui32)> callback);
+	void tick(uint32_t msPassed) override;
 
 	void close() override;
 };

--- a/client/windows/GUIClasses.h
+++ b/client/windows/GUIClasses.h
@@ -162,6 +162,7 @@ class CLevelWindow : public CWindowObject
 
 	void selectionChanged(unsigned to);
 	void createSkillBox();
+	void submitSelection();
 
 public:
 	CLevelWindow(const CGHeroInstance *hero, PrimarySkill pskill, std::vector<SecondarySkill> &skills, std::function<void(ui32)> callback);

--- a/client/windows/GUIClasses.h
+++ b/client/windows/GUIClasses.h
@@ -13,7 +13,6 @@
 #include "../lib/ResourceSet.h"
 #include "../widgets/Images.h"
 #include "../widgets/IVideoHolder.h"
-#include <chrono>
 
 VCMI_LIB_NAMESPACE_BEGIN
 
@@ -160,18 +159,19 @@ class CLevelWindow : public CWindowObject
 	std::vector<SecondarySkill> skills;
 	std::vector<SecondarySkill> sortedSkills;
 	const CGHeroInstance * hero;
-	bool waitingForNextUpdate = false;
-	std::chrono::steady_clock::time_point closeDeadline;
 
 	void selectionChanged(unsigned to);
 	void createSkillBox();
 
 public:
 	CLevelWindow(const CGHeroInstance *hero, PrimarySkill pskill, std::vector<SecondarySkill> &skills, std::function<void(ui32)> callback);
-	void updateLevelUpData(const CGHeroInstance * hero, PrimarySkill pskill, std::vector<SecondarySkill> & skills, std::function<void(ui32)> callback);
-	void tick(uint32_t msPassed) override;
+	void setCloseOnSelection(bool value);
 
 	void close() override;
+
+private:
+	bool closeOnSelection = true;
+	bool selectionSubmitted = false;
 };
 
 /// Town portal, castle gate window

--- a/server/queries/MapQueries.cpp
+++ b/server/queries/MapQueries.cpp
@@ -254,14 +254,14 @@ void CHeroLevelUpDialogQuery::onAdded(PlayerColor color)
 
 void CHeroLevelUpDialogQuery::onExposure(QueryPtr topQuery)
 {
-	if(prompted)
-		return;
-
 	if(answer)
 	{
 		owner->popIfTop(*this);
 		return;
 	}
+
+	if(prompted)
+		return;
 
 	for(auto color : players)
 	{


### PR DESCRIPTION
Currently was both Hero / Commander level-up always generated again. This leads into visible flickering when perform multiple levelups at once. This PR fixes it and dialog is reused for next levels. 
I have also added fix for selecting Commader bonus - when all skills are grabbed and none of them left, mark first bonus with yellow frame - if you don't click on it, it's still used. This just fixes visual, functionality is same.