### PR TITLE
Fix battleLogMessage translation and add singular/plural support

### DIFF
--- a/config/schemas/spell.json
+++ b/config/schemas/spell.json
@@ -372,7 +372,14 @@
 							"chainLength" : { "type" : "number" },
 							"chainFactor" : { "type" : "number" },
 							"cumulative" : { "type" : "boolean" },
-							"battleLogMessage" : { "type" : "string" },
+							"battleLogMessage" : {
+								"type" : "object",
+								"additionalProperties" : false,
+								"properties" : {
+									"singular" : { "type" : "string" },
+									"plural" : { "type" : "string" }
+								}
+							},
 							"bonus" : { "additionalProperties" : { "$ref" : "bonusInstance.json" } }
 						},
 						"additionalProperties" : false

--- a/config/spells/ability.json
+++ b/config/spells/ability.json
@@ -17,7 +17,7 @@
 				"battleEffects" : {
 					"petrification" : {
 						"type" : "core:timed",
-						"battleLogMessage" : "The %s are petrified.",
+						"battleLogMessage" : { "singular" : "@core.genrltxt.558", "plural" : "@core.genrltxt.559" },
 						"bonus" : {
 							"notActive" : {
 								"val" : 0,
@@ -75,7 +75,7 @@
 				"battleEffects" : {
 					"poisoning" : {
 						"type" : "core:timed",
-						"battleLogMessage" : "The %s are poisoned.",
+						"battleLogMessage" : { "singular" : "@core.genrltxt.561", "plural" : "@core.genrltxt.562" },
 						"bonus" : {
 							"poison" : {
 								"val" : 30,
@@ -123,7 +123,7 @@
 				"battleEffects" : {
 					"binding" : {
 						"type" : "core:timed",
-						"battleLogMessage" : "The %s are rooted to the ground.",
+						"battleLogMessage" : { "singular" : "@core.genrltxt.560", "plural" : "@core.genrltxt.560" },
 						"bonus" : {
 							"bindEffect" : {
 								"val" : 0,
@@ -158,7 +158,7 @@
 				"battleEffects" : {
 					"illness" : {
 						"type" : "core:timed",
-						"battleLogMessage" : "The %s become ill.",
+						"battleLogMessage" : { "singular" : "@core.genrltxt.553", "plural" : "@core.genrltxt.554" },
 						"bonus" : {
 							"attack" : {
 								"val" : -2,
@@ -206,7 +206,7 @@
 				"battleEffects" : {
 					"paralysis" : {
 						"type" : "core:timed",
-						"battleLogMessage" : "The %s are paralyzed.",
+						"battleLogMessage" : { "singular" : "@core.genrltxt.563", "plural" : "@core.genrltxt.564" },
 						"bonus" : {
 							"notActive" : {
 								"val" : 0,

--- a/docs/modders/Entities_Format/Spell_Format.md
+++ b/docs/modders/Entities_Format/Spell_Format.md
@@ -648,8 +648,14 @@ Value of all bonuses can be affected by following bonuses:
 
 	// Optional, localizable battle log message displayed when this effect is applied.
 	// The text should contain a %s placeholder which will be replaced with the affected creature's name.
-	// A text ID for translation is auto-generated as: spell.<modName>.<spellName>.<effectName>.battleLogMessage
-	"battleLogMessage" : "The %s are frozen solid.",
+	// Singular form is used for stacks with 1 creature, plural for stacks with multiple creatures.
+	// Text IDs for translation are auto-generated as:
+	//   spell.<modName>.<spellName>.<effectName>.battleLogMessage.singular
+	//   spell.<modName>.<spellName>.<effectName>.battleLogMessage.plural
+	// Values starting with @ reference an existing text ID instead of registering a new string.
+	"battleLogMessage" : { "singular" : "The %s is frozen solid.", "plural" : "The %s are frozen solid." },
+	// OR referencing existing text IDs:
+	// "battleLogMessage" : { "singular" : "@core.genrltxt.558", "plural" : "@core.genrltxt.559" },
 	
 	// List of bonuses granted by this spell
 	"bonus" : {

--- a/lib/spells/CSpellHandler.cpp
+++ b/lib/spells/CSpellHandler.cpp
@@ -1003,6 +1003,25 @@ std::shared_ptr<CSpell> CSpellHandler::loadFromJson(const std::string & scope, c
 		{
 			levelObject.battleEffects = levelNode["battleEffects"];
 
+			for(const auto & effectEntry : levelNode["battleEffects"].Struct())
+			{
+				const JsonNode & msgNode = effectEntry.second["battleLogMessage"];
+				if(msgNode.isStruct())
+				{
+					auto registerField = [&](const std::string & field)
+					{
+						const std::string & value = msgNode[field].String();
+						if(!value.empty() && value.at(0) != '@')
+						{
+							TextIdentifier textID("spell", scope, identifier, effectEntry.first, "battleLogMessage", field);
+							LIBRARY->generaltexth->registerString(scope, textID, msgNode[field]);
+						}
+					};
+					registerField("singular");
+					registerField("plural");
+				}
+			}
+
 			if(!levelObject.cumulativeEffects.empty() || !levelObject.effects.empty() || spell->isOffensive())
 				logGlobal->error("Mixing %s special effects with old format effects gives unpredictable result", spell->getNameTranslated());
 		}

--- a/lib/spells/effects/Timed.cpp
+++ b/lib/spells/effects/Timed.cpp
@@ -31,7 +31,7 @@ namespace spells
 namespace effects
 {
 
-static void describeEffect(std::vector<MetaString> & log, const Mechanics * m, const std::vector<Bonus> & bonuses, const battle::Unit * target, const std::string & battleLogMessage)
+static void describeEffect(std::vector<MetaString> & log, const Mechanics * m, const std::vector<Bonus> & bonuses, const battle::Unit * target, const std::string & battleLogMessageSingular, const std::string & battleLogMessagePlural)
 {
 	for(const auto & bonus : bonuses)
 	{
@@ -54,10 +54,13 @@ static void describeEffect(std::vector<MetaString> & log, const Mechanics * m, c
 		}
 	}
 
-	if(!battleLogMessage.empty())
+	if(!battleLogMessagePlural.empty())
 	{
 		MetaString line;
-		line.appendTextID(battleLogMessage);
+		if(!battleLogMessageSingular.empty() && target->getCount() == 1)
+			line.appendTextID(battleLogMessageSingular);
+		else
+			line.appendTextID(battleLogMessagePlural);
 		target->addNameReplacement(line, boost::logic::indeterminate);
 		log.push_back(std::move(line));
 	}
@@ -105,7 +108,7 @@ void Timed::apply(ServerCallback * server, const Mechanics * m, const EffectTarg
 			continue;
 
 		if(describe)
-			describeEffect(blm.lines, m, converted, affected, battleLogMessage);
+			describeEffect(blm.lines, m, converted, affected, battleLogMessageSingular, battleLogMessagePlural);
 
 
 		//Apply hero specials - peculiar enchants
@@ -213,11 +216,19 @@ void Timed::serializeJsonUnitEffect(JsonSerializeFormat & handler)
 	handler.serializeBool("cumulative", cumulative, false);
 	{
 		const JsonNode & messageNode = handler.getCurrent()["battleLogMessage"];
-		if(!messageNode.String().empty())
+		if(messageNode.isStruct())
 		{
-			TextIdentifier textID("spell", spellScope, spellIdentifier, name, "battleLogMessage");
-			LIBRARY->generaltexth->registerString(spellScope, textID, messageNode);
-			battleLogMessage = textID.get();
+			auto resolveField = [&](const std::string & field) -> std::string
+			{
+				const std::string & value = messageNode[field].String();
+				if(value.empty())
+					return {};
+				if(value.at(0) == '@')
+					return value.substr(1);
+				return TextIdentifier("spell", spellScope, spellIdentifier, name, "battleLogMessage", field).get();
+			};
+			battleLogMessageSingular = resolveField("singular");
+			battleLogMessagePlural = resolveField("plural");
 		}
 	}
 	{

--- a/lib/spells/effects/Timed.h
+++ b/lib/spells/effects/Timed.h
@@ -27,7 +27,8 @@ class Timed : public UnitEffect
 {
 public:
 	bool cumulative = false;
-	std::string battleLogMessage;
+	std::string battleLogMessageSingular;
+	std::string battleLogMessagePlural;
 	std::vector<std::shared_ptr<Bonus>> bonus;
 
 	void apply(ServerCallback * server, const Mechanics * m, const EffectTarget & target) const override;


### PR DESCRIPTION
Follow-up to #7188 addressing reported issues.

## Fixes

**1. Translation not working**

String registration was happening in `Timed::serializeJsonUnitEffect` which runs during `afterLoadFinalization` — after translation overrides are already loaded. Moved registration to `CSpellHandler::loadFromJson` so it happens before `loadTranslation`, matching the pattern used by spell name/description. The effect now only generates the text ID without registering.

**2. Singular/plural support**

`battleLogMessage` is now an object with `singular`/`plural` fields for grammatically correct messages. The correct form is selected at runtime based on the target stack's creature count.

**3. Reuse H3 translations via @textID syntax**

Values starting with `@` reference an existing text ID instead of registering a new string, following the same pattern as `MarketInstanceConstructor::initTypeData`. Core spells now use the original H3 translations directly, so players with localized game files automatically get the correct language without any additional translation work.

## How it works

There are two use cases with different behavior:

### Core H3 spells — reuse existing translations

Core spells reference text IDs from the H3 game files using the `@` prefix. Nothing is registered — the strings already exist in every localized H3 installation:

```json
"petrification" : {
    "type" : "core:timed",
    "battleLogMessage" : {
        "singular" : "@core.genrltxt.558",
        "plural" : "@core.genrltxt.559"
    },
    "bonus" : { ... }
}
```

The `@` is stripped at runtime and the rest is used as the text ID directly.

Core spells using this approach:

| Spell | Singular | Plural |
| - | - | - |
| Stone Gaze | `@core.genrltxt.558` | `@core.genrltxt.559` |
| Poison | `@core.genrltxt.561` | `@core.genrltxt.562` |
| Bind | `@core.genrltxt.560` | `@core.genrltxt.560` |
| Disease | `@core.genrltxt.553` | `@core.genrltxt.554` |
| Paralyze | `@core.genrltxt.563` | `@core.genrltxt.564` |

### Mod-defined spells — new translatable strings

Mods provide their own English text. These strings are registered with the translation system so translators can override them in language files.

For example, the Horn of the Abyss mod's Greater Shaman has a Freezing Shot ability (the original issue that motivated this feature — https://github.com/vcmi-mods/horn-of-the-abyss/issues/551):

```json
"frozen" : {
    "type" : "core:timed",
    "battleLogMessage" : {
        "singular" : "The %s is frozen.",
        "plural" : "The %s are frozen."
    },
    "bonus" : { ... }
}
```

This generates translatable text IDs:
- `spell.hota.bulwark.freezingShot.frozen.battleLogMessage.singular`
- `spell.hota.bulwark.freezingShot.frozen.battleLogMessage.plural`

Any mod adding custom creature abilities with timed effects can use the same approach — e.g. a custom entangle ability (`"The %s is entangled in vines."`) or a custom curse (`"The %s is hexed."`).

## Not included

The following H3 spells also have battle log text in GENRLTXT but still use the old `effects` format, which doesn't support `battleLogMessage`. Converting them to `battleEffects` format would be a separate change:

| Spell | Creature ability | GENRLTXT entry |
| - | - | - |
| Blind | Unicorns | core.genrltxt.556 |
| Curse | Black Knights | core.genrltxt.557 |
| Dispel Helpful | Dragonflies | core.genrltxt.555 |

## Test plan

- [ ] Verify battle log messages display correctly for stone gaze, paralyze, poison, disease, bind
- [ ] Verify singular form is used for stacks with 1 creature
- [ ] Verify plural form is used for stacks with multiple creatures
- [ ] Verify core spells show correct localized H3 text (not hardcoded English)
- [ ] Add a translation override for a mod spell's battleLogMessage text ID, verify it is used