### PR TITLE
Fix win32 clang64 compilation

### DIFF
--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -76,6 +76,10 @@ if(WIN32)
 			OUTPUT_NAME "VCMI_vcmiservercommon"
 			PROJECT_LABEL "VCMI_vcmiservercommon"
 	)
+	if (MINGW)
+		# Link Windows system libs: WinSock2 (ws2_32)
+		target_link_libraries(vcmiservercommon PRIVATE ws2_32)
+	endif()
 endif()
 
 vcmi_set_output_dir(vcmiservercommon "")

--- a/win/WindowsFileInfo.rc.in
+++ b/win/WindowsFileInfo.rc.in
@@ -21,12 +21,12 @@ BEGIN
         BEGIN
             VALUE "CompanyName", "VCMI Team"
             VALUE "FileDescription", "@VCMI_FILE_DESCRIPTION@"
-            VALUE "FileVersion", VCMI_VERSION_STRING
+            VALUE "FileVersion", "@VCMI_VERSION_STRING@"
             VALUE "InternalName", "@VCMI_ORIGINAL_FILENAME@"
             VALUE "LegalCopyright", "Copyright \xA9 VCMI Team. All rights reserved."
             VALUE "OriginalFilename", "@VCMI_ORIGINAL_FILENAME@"
             VALUE "ProductName", "VCMI"
-            VALUE "ProductVersion", VCMI_VERSION_STRING
+            VALUE "ProductVersion", "@VCMI_VERSION_STRING@"
         END
     END
     BLOCK "VarFileInfo"


### PR DESCRIPTION
Fixes #7230
Also fixes `boost::asio` by linking `ws2_32`. 
```
undefined symbol: __declspec(dllimport) WSAStartup
>>> referenced by C:/msys64/clang64/include/boost/asio/detail/impl/winsock_init.ipp:39
>>>               serverapp/CMakeFiles/vcmiserver.dir/EntryPoint.cpp.obj:(boost::asio::detail::winsock_init_base::startup(boost::asio::detail::winsock_init_base::data&, unsigned char, unsigned char))
>>> referenced by libVCMI_vcmiservercommon.a(CVCMIServer.cpp.obj)
>>> referenced by libVCMI_vcmiservercommon.a(GlobalLobbyProcessor.cpp.obj)
```

Should this also go into `develop`?