### PR TITLE
[1.8] Fix touch screen button handling

### DIFF
--- a/client/eventsSDL/InputSourceTouch.cpp
+++ b/client/eventsSDL/InputSourceTouch.cpp
@@ -32,6 +32,11 @@
 #include <SDL_hints.h>
 #include <SDL_timer.h>
 
+namespace
+{
+	const Point TOUCH_CANCEL_POSITION(-1, -1);
+}
+
 InputSourceTouch::InputSourceTouch()
 	: lastTapTimeTicks(0), lastLeftClickTimeTicks(0), numTouchFingers(0)
 {
@@ -98,6 +103,7 @@ void InputSourceTouch::handleEventFingerMotion(const SDL_TouchFingerEvent & tfin
 			Point distance = convertTouchToMouse(tfinger) - lastTapPosition;
 			if ( std::abs(distance.x) > params.panningSensitivityThreshold || std::abs(distance.y) > params.panningSensitivityThreshold)
 			{
+				ENGINE->events().dispatchMouseLeftButtonReleased(convertTouchToMouse(tfinger), params.touchToleranceDistance);
 				state = state == TouchState::TAP_DOWN_SHORT ? TouchState::TAP_DOWN_PANNING : TouchState::TAP_DOWN_PANNING_POPUP;
 				ENGINE->events().dispatchGesturePanningStarted(lastTapPosition);
 			}
@@ -162,12 +168,14 @@ void InputSourceTouch::handleEventFingerDown(const SDL_TouchFingerEvent & tfinge
 		{
 			lastTapPosition = convertTouchToMouse(tfinger);
 			ENGINE->input().setCursorPosition(lastTapPosition);
+			ENGINE->events().dispatchMouseLeftButtonPressed(lastTapPosition, params.touchToleranceDistance);
 			state = TouchState::TAP_DOWN_SHORT;
 			break;
 		}
 		case TouchState::TAP_DOWN_SHORT:
 		{
 			ENGINE->input().setCursorPosition(convertTouchToMouse(tfinger));
+			ENGINE->events().dispatchMouseLeftButtonReleased(TOUCH_CANCEL_POSITION, params.touchToleranceDistance);
 			ENGINE->events().dispatchGesturePanningStarted(lastTapPosition);
 			state = TouchState::TAP_DOWN_DOUBLE;
 			break;
@@ -227,7 +235,6 @@ void InputSourceTouch::handleEventFingerUp(const SDL_TouchFingerEvent & tfinger)
 			}
 			else
 			{
-				ENGINE->events().dispatchMouseLeftButtonPressed(convertTouchToMouse(tfinger), params.touchToleranceDistance);
 				ENGINE->events().dispatchMouseLeftButtonReleased(convertTouchToMouse(tfinger), params.touchToleranceDistance);
 				lastLeftClickTimeTicks = tfinger.timestamp;
 				lastLeftClickPosition = convertTouchToMouse(tfinger);
@@ -281,6 +288,7 @@ void InputSourceTouch::handleUpdate()
 		uint32_t currentTime = SDL_GetTicks();
 		if (currentTime > lastTapTimeTicks + params.longTouchTimeMilliseconds)
 		{
+			ENGINE->events().dispatchMouseLeftButtonReleased(TOUCH_CANCEL_POSITION, params.touchToleranceDistance);
 			ENGINE->events().dispatchShowPopup(ENGINE->getCursorPosition(), params.touchToleranceDistance);
 
 			if (ENGINE->windows().isTopWindowPopup())


### PR DESCRIPTION
Now all buttons respect their states on touch screen. PR also fixes double click behavior, which I was not able to identify before, caused by Press and Release convert event together.

Replaces: https://github.com/vcmi/vcmi/pull/7225