### PR TITLE
[1.7.4] Fixes for reported issues

### DIFF
--- a/Mods/vcmi/Content/config/rmg/hdmod/coldshadowsFantasy.json
+++ b/Mods/vcmi/Content/config/rmg/hdmod/coldshadowsFantasy.json
@@ -2,7 +2,7 @@
 	"Coldshadow's Fantasy":
 	{
 		"minSize" : "xl+u", "maxSize" : "g+u",
-		"players" : "2-8"
+		"players" : "2-8", "humans" : "2",
 		"zones":
 		{
 			"1":

--- a/Mods/vcmi/Content/config/rmg/hdmod/coldshadowsFantasy.json
+++ b/Mods/vcmi/Content/config/rmg/hdmod/coldshadowsFantasy.json
@@ -2,7 +2,7 @@
 	"Coldshadow's Fantasy":
 	{
 		"minSize" : "xl+u", "maxSize" : "g+u",
-		"players" : "4-8", "humans" : "3-6",
+		"players" : "2-8"
 		"zones":
 		{
 			"1":

--- a/Mods/vcmi/Content/config/translations/english.json
+++ b/Mods/vcmi/Content/config/translations/english.json
@@ -1090,6 +1090,7 @@
 	"vcmi.townStructure.bank.payBack": "You enter the bank. A banker sees you and says: \"You have already got your loan. Pay it back before taking a new one.\"",
 	"vcmi.townWindow.upgradeAll.notAllUpgradable": "Not enough resources to upgrade all creatures. Do you want to upgrade following creatures?",
 	"vcmi.townWindow.upgradeAll.notUpgradable": "Not enough resources to upgrade any creature.",
+	"vcmi.townWindow.blacksmith.replaceWarMachine" : "Your hero already owns a similar war machine, %s. Are you sure that you wish to replace it with %s?",
 	"vcmi.tutorialWindow.decription.AbortSpell": "Touch and hold to cancel a spell.",
 	"vcmi.tutorialWindow.decription.BattleDirection": "To attack from a particular direction, swipe in the direction from which the attack is to be made.",
 	"vcmi.tutorialWindow.decription.BattleDirectionAbort": "The attack direction gesture can be cancelled if the finger is far enough away.",

--- a/client/widgets/CComponent.cpp
+++ b/client/widgets/CComponent.cpp
@@ -136,7 +136,7 @@ std::vector<AnimationPath> CComponent::getFileName() const
 	static const std::array<std::string, 4>  resourceArr =   {"SMALRES",        "RESOURCE",       "RESOURCE",       "RESOUR82"};
 	static const std::array<std::string, 4>  creatureArr =   {"CPRSMALL",       "CPRSMALL",       "TWCRPORT",       "TWCRPORT"};
 	static const std::array<std::string, 4>  artifactArr =   {"Artifact",       "Artifact",       "Artifact",       "Artifact"};
-	static const std::array<std::string, 4>  spellsArr =     {"SpellInt",       "SpellInt",       "SpellInt",       "SPELLSCR"};
+	static const std::array<std::string, 4>  spellsArr =     {"SpellInt",       "SpellInt",       "SPELLSCR",       "SPELLSCR"};
 	static const std::array<std::string, 4>  moraleArr =     {"IMRL22",         "IMRL30",         "IMRL42",         "imrl82"};
 	static const std::array<std::string, 4>  luckArr =       {"ILCK22",         "ILCK30",         "ILCK42",         "ilck82"};
 	static const std::array<std::string, 4>  heroArr =       {"PortraitsSmall", "PortraitsSmall", "PortraitsSmall", "PortraitsLarge"};
@@ -207,7 +207,7 @@ size_t CComponent::getIndex() const
 			return LIBRARY->artifacts()->getById(data.subType.as<ArtifactID>())->getIconIndex();
 		case ComponentType::SPELL_SCROLL:
 		case ComponentType::SPELL:
-			return (size < large) ? data.subType.getNum() + 1 : data.subType.getNum();
+			return (size < medium) ? data.subType.getNum() + 1 : data.subType.getNum();
 		case ComponentType::MORALE:
 			return std::clamp(data.value.value_or(0) + 3, 0, 6);
 		case ComponentType::LUCK:

--- a/client/widgets/markets/CAltarArtifacts.cpp
+++ b/client/widgets/markets/CAltarArtifacts.cpp
@@ -36,7 +36,7 @@ CAltarArtifacts::CAltarArtifacts(const IMarket * market, const CGHeroInstance * 
 	altarArtifactsStorage = market->getArtifactsStorage();
 
 	deal = std::make_shared<CButton>(Point(269, 520), AnimationPath::builtin("ALTSACR.DEF"),
-		LIBRARY->generaltexth->zelp[585], [this]() {CAltarArtifacts::makeDeal(); }, EShortcut::MARKET_DEAL);
+		LIBRARY->generaltexth->zelp[584], [this]() {CAltarArtifacts::makeDeal(); }, EShortcut::MARKET_DEAL);
 	labels.emplace_back(std::make_shared<CLabel>(450, 32, FONT_SMALL, ETextAlignment::CENTER, Colors::YELLOW, LIBRARY->generaltexth->allTexts[477]));
 	labels.emplace_back(std::make_shared<CLabel>(302, 424, FONT_SMALL, ETextAlignment::CENTER, Colors::YELLOW, LIBRARY->generaltexth->allTexts[478]));
 

--- a/client/widgets/markets/CAltarCreatures.cpp
+++ b/client/widgets/markets/CAltarCreatures.cpp
@@ -33,7 +33,7 @@ CAltarCreatures::CAltarCreatures(const IMarket * market, const CGHeroInstance * 
 	OBJECT_CONSTRUCTION;
 
 	deal = std::make_shared<CButton>(dealButtonPosWithSlider, AnimationPath::builtin("ALTSACR.DEF"),
-		LIBRARY->generaltexth->zelp[584], [this]() {CAltarCreatures::makeDeal();}, EShortcut::MARKET_DEAL);
+		LIBRARY->generaltexth->zelp[585], [this]() {CAltarCreatures::makeDeal();}, EShortcut::MARKET_DEAL);
 	labels.emplace_back(std::make_shared<CLabel>(155, 30, FONT_SMALL, ETextAlignment::CENTER, Colors::YELLOW,
 		boost::str(boost::format(LIBRARY->generaltexth->allTexts[272]) % hero->getNameTranslated())));
 	labels.emplace_back(std::make_shared<CLabel>(450, 30, FONT_SMALL, ETextAlignment::CENTER, Colors::YELLOW, LIBRARY->generaltexth->allTexts[479]));

--- a/client/windows/CCastleInterface.cpp
+++ b/client/windows/CCastleInterface.cpp
@@ -1026,12 +1026,21 @@ void CCastleBuildings::enterBlacksmith(BuildingID building, ArtifactID artifactI
 
 	int price = art->getPrice();
 	bool possible = GAME->interface()->cb->getResourceAmount(EGameResID::GOLD) >= price;
+	ArtifactID existingArtifact;
 	if(possible)
 	{
 		for(auto slot : art->getPossibleSlots().at(ArtBearer::HERO))
 		{
-			if(hero->getArt(slot) == nullptr || hero->getArt(slot)->getTypeId() != artifactID)
+			const auto * currentArtifact = hero->getArt(slot);
+
+			if(currentArtifact == nullptr)
 			{
+				possible = true;
+				break;
+			}
+			else if (currentArtifact->getTypeId() != artifactID)
+			{
+				existingArtifact = currentArtifact->getTypeId();
 				possible = true;
 				break;
 			}
@@ -1042,8 +1051,7 @@ void CCastleBuildings::enterBlacksmith(BuildingID building, ArtifactID artifactI
 		}
 	}
 
-	CreatureID creatureID = artifactID.toArtifact()->getWarMachine();
-	ENGINE->windows().createAndPushWindow<CBlacksmithDialog>(possible, creatureID, artifactID, hero->id);
+	ENGINE->windows().createAndPushWindow<CBlacksmithDialog>(possible, artifactID, existingArtifact, hero->id);
 }
 
 void CCastleBuildings::enterBuilding(BuildingID building)
@@ -2346,7 +2354,7 @@ void CMageGuildScreen::Scroll::hover(bool on)
 
 }
 
-CBlacksmithDialog::CBlacksmithDialog(bool possible, CreatureID creMachineID, ArtifactID aid, ObjectInstanceID hid):
+CBlacksmithDialog::CBlacksmithDialog(bool possible, ArtifactID aid, ArtifactID existingArtifact, ObjectInstanceID hid):
 	CWindowObject(PLAYER_COLORED, ImagePath::builtin("TPSMITH"))
 {
 	OBJECT_CONSTRUCTION;
@@ -2359,7 +2367,7 @@ CBlacksmithDialog::CBlacksmithDialog(bool possible, CreatureID creMachineID, Art
 	animBG = std::make_shared<CPicture>(ImagePath::builtin("TPSMITBK"), 64, 50);
 	animBG->needRefresh = true;
 
-	const CCreature * creature = creMachineID.toCreature();
+	const CCreature * creature = aid.toArtifact()->getWarMachine().toCreature();
 	anim = std::make_shared<CCreatureAnim>(64, 50, creature->animDefName);
 	anim->clipRect(113,125,200,150);
 
@@ -2384,7 +2392,25 @@ CBlacksmithDialog::CBlacksmithDialog(bool possible, CreatureID creMachineID, Art
 	cancel = std::make_shared<CButton>(Point(224, 312), AnimationPath::builtin("ICANCEL.DEF"), CButton::tooltip(cancelText.toString()), [&](){ close(); }, EShortcut::GLOBAL_CANCEL);
 
 	if(possible)
-		buy->addCallback([=](){ GAME->interface()->cb->buyArtifact(GAME->interface()->cb->getHero(hid),aid); });
+	{
+		if (existingArtifact.hasValue())
+		{
+			MetaString message;
+			message.appendTextID("vcmi.townWindow.blacksmith.replaceWarMachine");
+			message.replaceName(existingArtifact);
+			message.replaceName(aid);
+
+			buy->addCallback([=](){
+				GAME->interface()->showYesNoDialog(
+					message.toString(),
+					[&](){ GAME->interface()->cb->buyArtifact(GAME->interface()->cb->getHero(hid),aid); },
+					nullptr);
+			});
+
+		}
+		else
+			buy->addCallback([=](){ GAME->interface()->cb->buyArtifact(GAME->interface()->cb->getHero(hid),aid); });
+	}
 	else
 		buy->block(true);
 

--- a/client/windows/CCastleInterface.cpp
+++ b/client/windows/CCastleInterface.cpp
@@ -1025,31 +1025,11 @@ void CCastleBuildings::enterBlacksmith(BuildingID building, ArtifactID artifactI
 	auto art = artifactID.toArtifact();
 
 	int price = art->getPrice();
-	bool possible = GAME->interface()->cb->getResourceAmount(EGameResID::GOLD) >= price;
-	ArtifactID existingArtifact;
-	if(possible)
-	{
-		for(auto slot : art->getPossibleSlots().at(ArtBearer::HERO))
-		{
-			const auto * currentArtifact = hero->getArt(slot);
+	ArtifactID existingArtifact = hero->getReplacedWarMachine(artifactID);
 
-			if(currentArtifact == nullptr)
-			{
-				possible = true;
-				break;
-			}
-			else if (currentArtifact->getTypeId() != artifactID)
-			{
-				existingArtifact = currentArtifact->getTypeId();
-				possible = true;
-				break;
-			}
-			else
-			{
-				possible = false;
-			}
-		}
-	}
+	bool canAfford = GAME->interface()->cb->getResourceAmount(EGameResID::GOLD) >= price;
+	bool hasSameMachine = existingArtifact == artifactID;
+	bool possible = canAfford && !hasSameMachine;
 
 	ENGINE->windows().createAndPushWindow<CBlacksmithDialog>(possible, artifactID, existingArtifact, hero->id);
 }
@@ -2403,13 +2383,13 @@ CBlacksmithDialog::CBlacksmithDialog(bool possible, ArtifactID aid, ArtifactID e
 			buy->addCallback([=](){
 				GAME->interface()->showYesNoDialog(
 					message.toString(),
-					[&](){ GAME->interface()->cb->buyArtifact(GAME->interface()->cb->getHero(hid),aid); },
+					[hid, aid](){ GAME->interface()->cb->buyArtifact(GAME->interface()->cb->getHero(hid),aid); },
 					nullptr);
 			});
 
 		}
 		else
-			buy->addCallback([=](){ GAME->interface()->cb->buyArtifact(GAME->interface()->cb->getHero(hid),aid); });
+			buy->addCallback([hid, aid](){ GAME->interface()->cb->buyArtifact(GAME->interface()->cb->getHero(hid),aid); });
 	}
 	else
 		buy->block(true);

--- a/client/windows/CCastleInterface.h
+++ b/client/windows/CCastleInterface.h
@@ -433,5 +433,5 @@ class CBlacksmithDialog : public CStatusbarWindow
 	std::shared_ptr<CLabel> costValue;
 
 public:
-	CBlacksmithDialog(bool possible, CreatureID creMachineID, ArtifactID aid, ObjectInstanceID hid);
+	CBlacksmithDialog(bool possible, ArtifactID newArtifact, ArtifactID existingArtifact, ObjectInstanceID hid);
 };

--- a/client/windows/CCreatureWindow.cpp
+++ b/client/windows/CCreatureWindow.cpp
@@ -101,8 +101,12 @@ public:
 	{
 		if(commander)
 			return commander->getType()->getNameSingularTranslated();
-		else
-			return creature->getNamePluralTranslated();
+		if (stackNode)
+			return stackNode->getName();
+		if (stack)
+			return stack->getName();
+
+		return creature->getNamePluralTranslated();
 	}
 private:
 

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -165,6 +165,27 @@ void CRecruitmentWindow::buy()
 {
 	CreatureID crid =  selected->creature->getId();
 	SlotID dstslot = dst->getSlotFor(crid);
+	const CGHeroInstance * hero = dynamic_cast<const CGHeroInstance *>(dst);
+
+	if (selected->creature->warMachine.hasValue() && hero)
+	{
+		ArtifactID newWarMachine = selected->creature->warMachine;
+		ArtifactID currentWarMachine = hero->getReplacedWarMachine(newWarMachine);
+		if (newWarMachine != currentWarMachine)
+		{
+			MetaString message;
+			message.appendTextID("vcmi.townWindow.blacksmith.replaceWarMachine");
+			message.replaceName(currentWarMachine);
+			message.replaceName(newWarMachine);
+
+			GAME->interface()->showYesNoDialog(
+				message.toString(),
+				[this, crid](){ onRecruit(crid, slider->getValue()); if(level >= 0) close();},
+				nullptr
+			);
+			return;
+		}
+	}
 
 	if(!dstslot.validSlot() && (selected->creature->warMachine == ArtifactID::NONE)) //no available slot
 	{

--- a/launcher/mainwindow_moc.cpp
+++ b/launcher/mainwindow_moc.cpp
@@ -331,6 +331,8 @@ void MainWindow::updateTranslation()
 
 	logGlobal->info("Loading translation %s", translationFile);
 
+	qApp->removeTranslator(&translator);
+
 	if(!QFile::exists(translationFileResourcePath))
 	{
 		logGlobal->debug("Translation file %s does not exist", translationFileResourcePath.toStdString());

--- a/launcher/settingsView/csettingsview_moc.cpp
+++ b/launcher/settingsView/csettingsview_moc.cpp
@@ -231,7 +231,7 @@ void CSettingsView::loadSettings()
 	ui->spinBoxFramerateLimit->setDisabled(settings["video"]["vsync"].Bool());
 	ui->sliderReservedArea->setValue(std::round(settings["video"]["reservedWidth"].Float() * 100));
 
-	ui->spinBoxNetworkPort->setValue(settings["server"]["localPort"].Integer());
+	ui->spinBoxNetworkPort->setValue(settings["server"]["port"].Integer());
 
 	ui->lineEditRepositoryDefault->setText(QString::fromStdString(settings["launcher"]["defaultRepositoryURL"].String()));
 	ui->lineEditRepositoryExtra->setText(QString::fromStdString(settings["launcher"]["extraRepositoryURL"].String()));

--- a/lib/battle/CBattleInfoCallback.cpp
+++ b/lib/battle/CBattleInfoCallback.cpp
@@ -277,7 +277,7 @@ std::vector<PossiblePlayerBattleAction> CBattleInfoCallback::getClientActionsFor
 			if(stack->hasBonusOfType(BonusType::RANDOM_SPELLCASTER))
 				allowedActionList.push_back(PossiblePlayerBattleAction::RANDOM_GENIE_SPELL);
 		}
-		if(stack->canShoot())
+		if(battleCanShoot(stack))
 			allowedActionList.push_back(PossiblePlayerBattleAction::SHOOT);
 		if(stack->hasBonusOfType(BonusType::RETURN_AFTER_STRIKE))
 			allowedActionList.push_back(PossiblePlayerBattleAction::ATTACK_AND_RETURN);

--- a/lib/mapObjects/CGHeroInstance.cpp
+++ b/lib/mapObjects/CGHeroInstance.cpp
@@ -1790,4 +1790,22 @@ int CGHeroInstance::getBasePrimarySkillValue(PrimarySkill which) const
 	return std::max(valOfBonuses(selector, cachingStr), minSkillValue);
 }
 
+ArtifactID CGHeroInstance::getReplacedWarMachine(ArtifactID artifactID) const
+{
+	ArtifactID replacedArtifact;
+	auto art = artifactID.toArtifact();
+
+	for(auto slot : art->getPossibleSlots().at(ArtBearer::HERO))
+	{
+		const auto * currentArtifact = getArt(slot);
+
+		if(currentArtifact == nullptr)
+			return ArtifactID();
+		else
+			replacedArtifact = currentArtifact->getTypeId();
+	}
+	return replacedArtifact;
+}
+
+
 VCMI_LIB_NAMESPACE_END

--- a/lib/mapObjects/CGHeroInstance.h
+++ b/lib/mapObjects/CGHeroInstance.h
@@ -150,6 +150,9 @@ public:
 	const CGBoat * getBoat() const;
 	void setBoat(CGBoat * getBoat);
 
+	/// Returns ID of existing war machine that will be replaced if hero were to purchase new war machine
+	/// If there is no replaced war machine (for example slot is empty), method will return empty ArtifactID
+	ArtifactID getReplacedWarMachine(ArtifactID newWarMachine) const;
 	bool hasSpellbook() const;
 	int maxSpellLevel() const;
 	void addSpellToSpellbook(const SpellID & spell);

--- a/lib/mapObjects/CRewardableObject.cpp
+++ b/lib/mapObjects/CRewardableObject.cpp
@@ -208,8 +208,17 @@ std::string CRewardableObject::getDisplayTextImpl(PlayerColor player, const CGHe
 {
 	std::string result = getObjectName();
 
-	if (includeDescription && !getDescriptionMessage(player, hero).empty())
-		result += "\n" + getDescriptionMessage(player, hero);
+	if (includeDescription)
+	{
+		if (!getDescriptionMessage(player, hero).empty())
+			result += "\n" + getDescriptionMessage(player, hero);
+	}
+	else
+	{
+		// scouted version is included unconditionally into hover text (e.g. Shrines - "learn X spell")
+		if (!getScoutedDescriptionMessage(hero).empty())
+			result += "\n" + getDescriptionMessage(player, hero);
+	}
 
 	if (hero)
 	{
@@ -254,11 +263,8 @@ std::string CRewardableObject::getPopupText(const CGHeroInstance * hero) const
 	return getDisplayTextImpl(hero->getOwner(), hero, true);
 }
 
-std::string CRewardableObject::getDescriptionMessage(PlayerColor player, const CGHeroInstance * hero) const
+std::string CRewardableObject::getScoutedDescriptionMessage(const CGHeroInstance * hero) const
 {
-	if (!wasScouted(player) || configuration.info.empty())
-		return configuration.description.toString();
-
 	auto rewardIndices = getAvailableRewards(hero, Rewardable::EEventType::EVENT_FIRST_VISIT);
 	if (rewardIndices.empty() || !configuration.info[0].description.empty())
 		return configuration.info[0].description.toString();
@@ -266,7 +272,24 @@ std::string CRewardableObject::getDescriptionMessage(PlayerColor player, const C
 	if (!configuration.info[rewardIndices.front()].description.empty())
 		return configuration.info[rewardIndices.front()].description.toString();
 
+	return {};
+}
+
+std::string CRewardableObject::getGenericDescriptionMessage() const
+{
 	return configuration.description.toString();
+}
+
+std::string CRewardableObject::getDescriptionMessage(PlayerColor player, const CGHeroInstance * hero) const
+{
+	if (!wasScouted(player) || configuration.info.empty())
+		return getGenericDescriptionMessage();
+
+	auto scoutedMessage	= getScoutedDescriptionMessage(hero);
+	if (!scoutedMessage.empty())
+		return scoutedMessage;
+
+	return getGenericDescriptionMessage();
 }
 
 std::vector<Component> CRewardableObject::getPopupComponentsImpl(PlayerColor player, const CGHeroInstance * hero) const

--- a/lib/mapObjects/CRewardableObject.cpp
+++ b/lib/mapObjects/CRewardableObject.cpp
@@ -285,7 +285,7 @@ std::string CRewardableObject::getDescriptionMessage(PlayerColor player, const C
 	if (!wasScouted(player) || configuration.info.empty())
 		return getGenericDescriptionMessage();
 
-	auto scoutedMessage	= getScoutedDescriptionMessage(hero);
+	auto scoutedMessage = getScoutedDescriptionMessage(hero);
 	if (!scoutedMessage.empty())
 		return scoutedMessage;
 

--- a/lib/mapObjects/CRewardableObject.h
+++ b/lib/mapObjects/CRewardableObject.h
@@ -41,6 +41,8 @@ protected:
 	void serializeJsonOptions(JsonSerializeFormat & handler) override;
 	
 	std::string getDisplayTextImpl(PlayerColor player, const CGHeroInstance * hero, bool includeDescription) const;
+	std::string getScoutedDescriptionMessage(const CGHeroInstance * hero) const;
+	std::string getGenericDescriptionMessage() const;
 	std::string getDescriptionMessage(PlayerColor player, const CGHeroInstance * hero) const;
 	std::vector<Component> getPopupComponentsImpl(PlayerColor player, const CGHeroInstance * hero) const;
 

--- a/lib/mapping/CMap.cpp
+++ b/lib/mapping/CMap.cpp
@@ -862,12 +862,15 @@ CArtifactInstance * CMap::createScroll(const SpellID & spellId)
 
 CArtifactInstance * CMap::createArtifactComponent(const ArtifactID & artId)
 {
-	auto newArtifact = artId.hasValue() ?
-		std::make_shared<CArtifactInstance>(cb, artId.toArtifact()):
-		std::make_shared<CArtifactInstance>(cb);
+	auto art = artId.toArtifact();
+	auto newArtifact = std::make_shared<CArtifactInstance>(cb, art);
 
 	newArtifact->setId(ArtifactInstanceID(artInstances.size()));
 	artInstances.push_back(newArtifact);
+
+	for (const auto & bonus : art->instanceBonuses)
+		newArtifact->addNewBonus(std::make_shared<Bonus>(*bonus, newArtifact->getId()));
+
 	return newArtifact.get();
 }
 
@@ -905,9 +908,6 @@ CArtifactInstance * CMap::createArtifact(const ArtifactID & artID, const SpellID
 		artInst->addNewBonus(bonus);
 		artInst->addCharges(art->getDefaultStartCharges());
 	}
-
-	for (const auto & bonus : art->instanceBonuses)
-		artInst->addNewBonus(std::make_shared<Bonus>(*bonus, artInst->getId()));
 
 	return artInst;
 }

--- a/mapeditor/mainwindow.cpp
+++ b/mapeditor/mainwindow.cpp
@@ -137,6 +137,8 @@ void MainWindow::loadTranslation()
 
 	logGlobal->info("Loading translation %s", translationFile);
 
+	qApp->removeTranslator(&translator);
+
 	if(!QFile::exists(translationFileResourcePath))
 	{
 		logGlobal->debug("Translation file %s does not exist", translationFileResourcePath.toStdString());

--- a/server/processors/PlayerMessageProcessor.cpp
+++ b/server/processors/PlayerMessageProcessor.cpp
@@ -486,9 +486,9 @@ void PlayerMessageProcessor::cheatGiveArtifacts(PlayerColor player, const CGHero
 	}
 	else
 	{
-		for(int g = 7; g < LIBRARY->arth->objects.size(); ++g) //including artifacts from mods
+		for(int g = 3; g < LIBRARY->arth->objects.size(); ++g)
 		{
-			if(LIBRARY->arth->objects[g]->canBePutAt(hero))
+			if(LIBRARY->arth->objects[g]->canBePutAt(hero) && !LIBRARY->arth->objects[g]->getWarMachine().hasValue())
 				gameHandler->giveHeroNewArtifact(hero, ArtifactID(g), ArtifactPosition::FIRST_AVAILABLE);
 		}
 	}


### PR DESCRIPTION
- Fix swapped messages in Altar (#7099)
- Fix spell icon size & Shrine hover text to match H3 (#7202)
- Correctly reset translation to English when requested (#7141)
- Fix loading of vcmiserver port in Launcher settings (#7107)
- Do not show option to shoot for blocked units (#7161)
- Use correct singular / plural form in creature window (#7240)
- Added warning on attempt to replace war machine in Blacksmith (#7210)
- Exclude war machines from mods from vcmiartifacts cheat (#7210)
- Attach instance bonuses to newly assembled combined arts (#6893)