### PR TITLE
[1.7.4] Improve mod description handling

### DIFF
--- a/launcher/modManager/modstate.cpp
+++ b/launcher/modManager/modstate.cpp
@@ -37,7 +37,16 @@ QString ModState::getType() const
 
 QString ModState::getDescription() const
 {
-	return QString::fromStdString(impl.getLocalizedValue("description").String());
+	QString description = QString::fromStdString(impl.getLocalizedDescription().String());
+
+	if (Qt::mightBeRichText(description))
+	{
+		QTextDocument document;
+		document.setHtml(description);
+		description = document.toMarkdown();
+	}
+
+	return description;
 }
 
 QString ModState::getID() const

--- a/lib/modding/ModDescription.cpp
+++ b/lib/modding/ModDescription.cpp
@@ -37,14 +37,7 @@ void ModDescription::mergeModDescriptions(JsonNode & modConfig, const std::strin
 			if (firstLine.find(language.identifier) == std::string::npos)
 			   continue;
 
-			bool baseLanguageDescription = language.identifier == "english";
-			if (modConfig.Struct().count("language"))
-				baseLanguageDescription = language.identifier == modConfig["language"].String();
-
-			if (baseLanguageDescription)
-				modConfig["description"].String() = section.substr(endOfFirstLine+1);
-			else
-				modConfig[language.identifier]["description"].String() = section.substr(endOfFirstLine+1);
+			modConfig[language.identifier]["description"].String() = section.substr(endOfFirstLine + 1);
 
 			break;
 		}
@@ -153,6 +146,22 @@ const JsonNode & ModDescription::getLocalizedValue(const std::string & keyName) 
 		return baseValue;
 	else
 		return localizedValue;
+}
+
+const JsonNode & ModDescription::getLocalizedDescription() const
+{
+	const std::string language = CGeneralTextHandler::getPreferredLanguage();
+	const JsonNode & localizedValue = getValue(language)["description"];
+	const JsonNode & englishValue = getValue("english")["description"];
+	const JsonNode & baseValue = getValue("description");
+
+	if (!localizedValue.isNull())
+		return localizedValue;
+
+	if (!englishValue.isNull())
+		return englishValue;
+
+	return baseValue;
 }
 
 const JsonNode & ModDescription::getValue(const std::string & keyName) const

--- a/lib/modding/ModDescription.h
+++ b/lib/modding/ModDescription.h
@@ -51,6 +51,7 @@ public:
 	const JsonNode & getLocalConfig() const;
 	const JsonNode & getValue(const std::string & keyName) const;
 	const JsonNode & getLocalizedValue(const std::string & keyName) const;
+	const JsonNode & getLocalizedDescription() const;
 	const JsonNode & getLocalValue(const std::string & keyName) const;
 	const JsonNode & getRepositoryValue(const std::string & keyName) const;
 


### PR DESCRIPTION
Proper solution for loading new description.md with mod.json description combination. Many mods uses mod.json with basic html tags, this properly loads it and convert it to markdown.

Before:
<img width="577" height="373" alt="image" src="https://github.com/user-attachments/assets/0dc02c5c-d7a7-41c8-8f44-e27f72d898ab" />

After:
<img width="581" height="476" alt="image" src="https://github.com/user-attachments/assets/467563a8-3449-41ea-8aa2-47cd334d807b" />
