### PR TITLE
Fix duplicated Mystic Pond description on building click

### DIFF
--- a/client/windows/CCastleInterface.cpp
+++ b/client/windows/CCastleInterface.cpp
@@ -1131,7 +1131,7 @@ void CCastleBuildings::enterFountain(const BuildingID & building, BuildingSubID:
 		|| (upgrades != BuildingID::NONE
 			&& town->getTown()->buildings.find(BuildingID(upgrades))->second->subId == BuildingSubID::MYSTIC_POND);
 
-	if(upgrades != BuildingID::NONE)
+	if(upgrades != BuildingID::NONE && upgrades != building)
 		descr += "\n\n"+town->getTown()->buildings.find(BuildingID(upgrades))->second->getDescriptionTranslated();
 
 	if(isMysticPondOrItsUpgrade) //for vanila Rampart like towns


### PR DESCRIPTION
## Summary

Fixes #7142 — clicking Mystic Pond in a Rampart town shows the building's description twice.

## Cause

`CCastleBuildings::enterFountain()` (client/windows/CCastleInterface.cpp) builds the popup text as follows:

```cpp
std::string descr = town->getTown()->buildings.find(building)->second->getDescriptionTranslated();
...
if(upgrades != BuildingID::NONE)
    descr += "\n\n" + town->getTown()->buildings.find(BuildingID(upgrades))->second->getDescriptionTranslated();
```

The intent of the second block is to also append the description of a modded upgraded Mystic Pond when entering via the base building. But for vanilla Rampart, Mystic Pond has no upgrade chain, so `buildingClicked()` calls `buildingTryActivateCustomUI(mysticPond, mysticPond)` with the same `BuildingID` as both the current building and the target. That propagates to `enterFountain()` as `building == upgrades`, the `!= NONE` check passes, and the description gets appended to itself.

## Fix

Guard the append with an additional check so it runs only when `upgrades` actually refers to a different building than the one we're already describing:

```cpp
if(upgrades != BuildingID::NONE && upgrades != building)
```

Modded scenarios where Mystic Pond is genuinely upgraded into a separate building still go through the append path (`upgrades` and `building` differ), so the intended behavior is preserved.

## Test plan

- [ ] Load a map with a Rampart town, build Mystic Pond, left-click it — description shows once.
- [ ] (If available) load a mod that upgrades Mystic Pond into a distinct building and verify both descriptions still appear when clicking the base building.