### PR TITLE
Show "No Creatures Available" for empty dwellings

### DIFF
--- a/Mods/vcmi/Content/config/translations/english.json
+++ b/Mods/vcmi/Content/config/translations/english.json
@@ -435,6 +435,7 @@
 	"vcmi.credits.vcmi": "VCMI",
 	"vcmi.credits.website": "Website",
 	"vcmi.dimensionDoor.seaToLandError": "It's not possible to teleport from sea to land or vice versa with a Dimension Door.",
+	"vcmi.dwelling.noCreaturesAvailable": "No Creatures Available",
 	"vcmi.heroOverview.secondarySkills": "Secondary Skills",
 	"vcmi.heroOverview.spells": "Spells",
 	"vcmi.heroOverview.startingArmy": "Starting Units",

--- a/client/widgets/CComponent.cpp
+++ b/client/widgets/CComponent.cpp
@@ -306,10 +306,11 @@ std::string CComponent::getSubtitle() const
 		case ComponentType::CREATURE:
 		{
 			auto creature = LIBRARY->creh->getById(data.subType.as<CreatureID>());
-			if(data.value)
-				return std::to_string(*data.value) + " " + (*data.value > 1 ? creature->getNamePluralTranslated() : creature->getNameSingularTranslated());
-			else
+			if(!data.value)
 				return creature->getNamePluralTranslated();
+			if(*data.value == 0)
+				return creature->getNamePluralTranslated() + " - " + LIBRARY->generaltexth->translate("vcmi.dwelling.noCreaturesAvailable");
+			return std::to_string(*data.value) + " " + (*data.value > 1 ? creature->getNamePluralTranslated() : creature->getNameSingularTranslated());
 		}
 		case ComponentType::ARTIFACT:
 			return LIBRARY->artifacts()->getById(data.subType.as<ArtifactID>())->getNameTranslated();


### PR DESCRIPTION
## Summary
- Replaces `0 <creature name>` subtitle in creature dwelling popups (adventure map, when owner right-clicks their own empty dwelling) with a translated `No Creatures Available` string when the available count is zero.
- Adds new translation key `vcmi.dwelling.noCreaturesAvailable`.

Fixes #7173

## Test plan
- [ ] Right-click an owned creature dwelling after recruiting all its creatures — popup shows "No Creatures Available" instead of "0 <name>".
- [ ] Right-click a dwelling with creatures available — popup still shows "<count> <name>" (singular/plural correct).
- [ ] Right-click a non-owned dwelling — still shows creature name(s) without count, unchanged.