### PR TITLE
[1.7.4] Prevents Documents folder creation on VCMI_MOBILE

### DIFF
--- a/launcher/firstLaunch/firstlaunch_moc.cpp
+++ b/launcher/firstLaunch/firstlaunch_moc.cpp
@@ -312,7 +312,6 @@ static QString defaultStartDirForOpen()
 {
 #if defined(VCMI_MOBILE)
 	const QStandardPaths::StandardLocation mobilePrefs[] = {
-		QStandardPaths::DocumentsLocation,
 		QStandardPaths::HomeLocation
 	};
 	for(auto location : mobilePrefs)


### PR DESCRIPTION
Get rid of Documents folder creation on VCMI_MOBILE

<img width="471" height="93" alt="image" src="https://github.com/user-attachments/assets/d3e2c2f4-0a8d-42cb-9023-6d6753237880" />

Will check it after CI finish to confirm, but most likely it's source of this folder creation.