### PR TITLE
Map editor add disposed heroes selector

### DIFF
--- a/lib/gameState/CGameState.cpp
+++ b/lib/gameState/CGameState.cpp
@@ -96,9 +96,9 @@ HeroTypeID CGameState::pickUnusedHeroTypeRandomly(vstd::RNG & randomGenerator, c
 	const PlayerSettings &ps = scenarioOps->getIthPlayersSettings(owner);
 	for(const HeroTypeID & hid : getUnusedAllowedHeroes())
 	{
-		if(hid.toHeroType()->heroClass->faction == ps.castle)
+		if(hid.toHeroType()->heroClass->faction == ps.castle && isHeroAllowedForPlayer(hid, owner))
 			factionHeroes.push_back(hid);
-		else
+		else if (isHeroAllowedForPlayer(hid, owner))
 			otherHeroes.push_back(hid);
 	}
 
@@ -121,6 +121,16 @@ HeroTypeID CGameState::pickUnusedHeroTypeRandomly(vstd::RNG & randomGenerator, c
 
 	logGlobal->error("No free heroes at all!");
 	throw std::runtime_error("Can not allocate hero. All heroes are already used.");
+}
+
+bool CGameState::isHeroAllowedForPlayer(const HeroTypeID & hid, const PlayerColor & owner)
+{
+	for(const auto & disposedHero : map->disposedHeroes)
+	{
+		if(disposedHero.heroId == hid)
+            return disposedHero.players.count(owner);
+	}
+	return true;
 }
 
 int CGameState::getDate(int d, Date mode)

--- a/lib/gameState/CGameState.h
+++ b/lib/gameState/CGameState.h
@@ -243,6 +243,7 @@ private:
 	bool isUsedHero(const HeroTypeID & hid) const; //looks in heroes and prisons
 	std::set<HeroTypeID> getUnusedAllowedHeroes(bool alsoIncludeNotAllowed = false) const;
 	HeroTypeID pickUnusedHeroTypeRandomly(vstd::RNG & randomGenerator, const PlayerColor & owner); // picks a unused hero type randomly
+	bool isHeroAllowedForPlayer(const HeroTypeID & hid, const PlayerColor & owner);
 
 	// ---- data -----
 	Services * services;

--- a/lib/mapping/MapFormatJson.cpp
+++ b/lib/mapping/MapFormatJson.cpp
@@ -764,40 +764,8 @@ void CMapFormatJson::serializeTimedEvents(JsonSerializeFormat & handler)
 
 void CMapFormatJson::serializePredefinedHeroes(JsonSerializeFormat & handler)
 {
-	if(handler.saving)
-	{
-		auto heroPool = map->getHeroesInPool();
-		if(!heroPool.empty())
-		{
-			auto predefinedHeroes = handler.enterStruct("predefinedHeroes");
-
-			for(auto & heroID : heroPool)
-			{
-				auto heroPtr = map->tryGetFromHeroPool(heroID);
-				auto predefinedHero = handler.enterStruct(heroPtr->getHeroTypeName());
-
-				heroPtr->serializeJsonDefinition(handler);
-			}
-		}
-	}
-	else
-	{
-		auto predefinedHeroes = handler.enterStruct("predefinedHeroes");
-
-		const JsonNode & data = handler.getCurrent();
-
-		for(const auto & p : data.Struct())
-		{
-			auto predefinedHero = handler.enterStruct(p.first);
-
-			auto hero = std::make_shared<CGHeroInstance>(map->cb);
-			hero->ID = Obj::HERO;
-			hero->setHeroTypeName(p.first);
-			hero->serializeJsonDefinition(handler);
-
-			map->addToHeroPool(hero);
-		}
-	}
+    // An option to create custom map heroes like in SoD - currently not ready in the editor.
+    // There was an implementation that caused bugs, look at file history if you need it.
 }
 
 void CMapFormatJson::serializeOptions(JsonSerializeFormat & handler)
@@ -819,7 +787,6 @@ void CMapFormatJson::serializeOptions(JsonSerializeFormat & handler)
 
 void CMapFormatJson::readOptions(JsonDeserializer & handler)
 {
-	readDisposedHeroes(handler);
 	serializeOptions(handler);
 }
 
@@ -1016,6 +983,8 @@ void CMapLoaderJson::readHeader(const bool complete)
 	//TODO: check mods
 
 	mapHeader->battleOnly = header["battleOnly"].Bool();
+
+	readDisposedHeroes(handler);
 
 	if(complete)
 		readOptions(handler);

--- a/mapeditor/CMakeLists.txt
+++ b/mapeditor/CMakeLists.txt
@@ -11,6 +11,7 @@ set(editor_SRCS
 		mapview.cpp
 		objectbrowser.cpp
 		mapsettings/abstractsettings.cpp
+		mapsettings/heroessettings.cpp
 		mapsettings/mapsettings.cpp
 		mapsettings/generalsettings.cpp
 		mapsettings/modsettings.cpp
@@ -80,6 +81,7 @@ set(editor_HEADERS
 		mapsettings/abstractsettings.h
 		mapsettings/mapsettings.h
 		mapsettings/generalsettings.h
+		mapsettings/heroessettings.h
 		mapsettings/modsettings.h
 		mapsettings/timedevent.h
 		mapsettings/victoryconditions.h
@@ -141,6 +143,7 @@ set(editor_FORMS
 		generatorprogress.ui
 		mapsettings/mapsettings.ui
 		mapsettings/generalsettings.ui
+		mapsettings/heroessettings.ui
 		mapsettings/modsettings.ui
 		mapsettings/timedevent.ui
 		mapsettings/victoryconditions.ui

--- a/mapeditor/mapsettings/heroessettings.cpp
+++ b/mapeditor/mapsettings/heroessettings.cpp
@@ -1,0 +1,227 @@
+/*
+ * heroessettings.cpp, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
+#include "StdInc.h"
+#include "../../lib/mapping/CMapService.h"
+#include "../../lib/modding/CModHandler.h"
+#include "../../lib/modding/ModDescription.h"
+#include "../mapcontroller.h"
+#include "heroessettings.h"
+#include "ui_heroessettings.h"
+
+#include <entities/hero/CHeroHandler.h>
+
+HeroesSettings::HeroesSettings(QWidget * parent) : AbstractSettings(parent), ui(new Ui::HeroesSettings)
+{
+	ui->setupUi(this);
+}
+
+HeroesSettings::~HeroesSettings()
+{
+	delete ui;
+}
+
+void HeroesSettings::initialize(MapController & c)
+{
+	AbstractSettings::initialize(c);
+
+	for(const auto & objectPtr : LIBRARY->heroh->objects)
+	{
+		auto * item = new QListWidgetItem(QString::fromStdString(objectPtr->getNameTranslated()));
+		item->setData(Qt::UserRole, QVariant::fromValue(objectPtr->getIndex()));
+		item->setFlags(item->flags() | Qt::ItemIsUserCheckable);
+		item->setCheckState(controller->map()->allowedHeroes.count(objectPtr->getId()) ? Qt::Checked : Qt::Unchecked);
+		ui->heroList->addItem(item);
+	}
+
+	for(auto color = PlayerColor(0); color < PlayerColor::PLAYER_LIMIT; ++color)
+	{
+		MetaString str;
+		str.appendName(color);
+		auto * item = new QListWidgetItem(QString::fromStdString(str.toString()));
+		item->setData(Qt::UserRole, QVariant::fromValue(color.getNum()));
+		ui->playerList->addItem(item);
+	}
+
+	for(auto & f : filters)
+	{
+		ui->filterModeCombo->addItem(tr(f.description.c_str()));
+	}
+
+	disposedHeroesCopy = controller->map()->disposedHeroes;
+}
+
+void HeroesSettings::update()
+{
+	controller->map()->allowedHeroes.clear();
+	for(int i = 0; i < ui->heroList->count(); ++i)
+	{
+		auto * item = ui->heroList->item(i);
+		if(item->checkState() == Qt::Checked)
+			controller->map()->allowedHeroes.emplace(i);
+	}
+
+	controller->map()->disposedHeroes = disposedHeroesCopy;
+}
+
+void HeroesSettings::on_textSearch_textChanged(const QString & keyword)
+{
+	filterHeroes();
+}
+
+void HeroesSettings::on_filterModeCombo_currentIndexChanged(int index)
+{
+	filterHeroes();
+}
+
+void HeroesSettings::on_heroList_itemSelectionChanged()
+{
+	updatePlayersSelection();
+}
+
+void HeroesSettings::on_heroList_itemChanged(QListWidgetItem * item)
+{
+	updatePlayersSelection();
+	if(item->checkState() == Qt::Unchecked)
+		removeDisposedHero(item->data(Qt::UserRole).toInt());
+}
+
+void HeroesSettings::on_playerList_itemChanged(QListWidgetItem * item)
+{
+	if(allPlayersSelected())
+		removeDisposedHero(getSelectedHeroId());
+	else
+		setDisposedHero(getSelectedHeroId(), getSelectedPlayers());
+}
+
+void HeroesSettings::updatePlayersSelection()
+{
+	ui->playerList->blockSignals(true);
+
+	auto * currentItem = ui->heroList->currentItem();
+	if(!currentItem || currentItem->checkState() == Qt::Unchecked)
+	{
+		showPlayerSelection(false);
+		return;
+	}
+
+	showPlayerSelection(true);
+
+	auto disposedHero = getDisposedHero(getSelectedHeroId());
+	for(auto color = PlayerColor(0); color < PlayerColor::PLAYER_LIMIT; ++color)
+	{
+		auto * item = ui->playerList->item(color.num);
+		bool isAllowedPlayer = controller->map()->players[color.num].canAnyonePlay();
+		if(isAllowedPlayer)
+		{
+			item->setFlags(item->flags() | Qt::ItemIsUserCheckable);
+			item->setCheckState((!disposedHero || disposedHero->players.contains(color)) ? Qt::Checked : Qt::Unchecked);
+		}
+		else
+		{
+			item->setFlags(Qt::NoItemFlags);
+			item->setCheckState(Qt::Checked);
+		}
+	}
+
+	ui->playerList->blockSignals(false);
+}
+
+void HeroesSettings::showPlayerSelection(bool show)
+{
+	ui->playerList->setHidden(!show);
+}
+
+void HeroesSettings::filterHeroes()
+{
+	for(int i = 0; i < ui->heroList->count(); ++i)
+	{
+		QListWidgetItem * item = ui->heroList->item(i);
+
+		auto textToMatch = ui->textSearch->text();
+		bool modeCheck = filters[ui->filterModeCombo->currentIndex()].isVisible(item);
+		bool textMatchCheck = item->text().contains(textToMatch, Qt::CaseInsensitive);
+		item->setHidden(!modeCheck || !textMatchCheck);
+	}
+
+	if(!ui->heroList->currentItem() || ui->heroList->currentItem()->isHidden()) //clear player list if the selected hero has been hidden
+	{
+		ui->heroList->clearSelection();
+		ui->heroList->setCurrentIndex(QModelIndex());
+		updatePlayersSelection();
+	}
+}
+
+void HeroesSettings::setDisposedHero(int heroId, std::set<PlayerColor> players)
+{
+	for(auto & disposedHero : disposedHeroesCopy)
+	{
+		if(disposedHero.heroId == heroId)
+		{
+			disposedHero.players = std::move(players);
+			return;
+		}
+	}
+
+	DisposedHero newHero; // portrait and name is used only in h3m; in vcmi format you can change those by adding custom heroes
+	newHero.heroId = HeroTypeID(heroId);
+	newHero.players = std::move(players);
+	disposedHeroesCopy.push_back(newHero);
+}
+
+void HeroesSettings::removeDisposedHero(int heroId)
+{
+	auto position = std::find_if(
+		disposedHeroesCopy.begin(),
+		disposedHeroesCopy.end(),
+		[&heroId](const DisposedHero & dh) -> bool
+		{
+			return dh.heroId == heroId;
+		}
+	);
+	if(position != disposedHeroesCopy.end())
+		disposedHeroesCopy.erase(position);
+}
+
+std::optional<const DisposedHero> HeroesSettings::getDisposedHero(int heroId)
+{
+	for(auto & disposedHero : disposedHeroesCopy)
+	{
+		if(disposedHero.heroId == heroId)
+			return disposedHero;
+	}
+	return std::nullopt;
+}
+
+std::set<PlayerColor> HeroesSettings::getSelectedPlayers()
+{
+	std::set<PlayerColor> result;
+	for(int i = 0; i < ui->playerList->count(); ++i)
+	{
+		QListWidgetItem * item = ui->playerList->item(i);
+		if(item->checkState() == Qt::Checked)
+			result.insert(PlayerColor(i));
+	}
+	return result;
+}
+
+int HeroesSettings::getSelectedHeroId()
+{
+	return ui->heroList->currentItem()->data(Qt::UserRole).toInt();
+}
+
+bool HeroesSettings::allPlayersSelected()
+{
+	return getSelectedPlayers().size() == PlayerColor::PLAYER_LIMIT;
+}
+
+bool HeroesSettings::isHeroBanned(int heroId)
+{
+	return ui->heroList->item(heroId)->checkState() == Qt::Unchecked;
+}

--- a/mapeditor/mapsettings/heroessettings.h
+++ b/mapeditor/mapsettings/heroessettings.h
@@ -1,0 +1,62 @@
+/*
+ * heroessettings.h, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
+#pragma once
+
+#include "abstractsettings.h"
+
+namespace Ui
+{
+class HeroesSettings;
+}
+
+class HeroesSettings : public AbstractSettings
+{
+	Q_OBJECT
+
+public:
+	explicit HeroesSettings(QWidget * parent = nullptr);
+	~HeroesSettings() override;
+
+	void initialize(MapController & map) override;
+	void update() override;
+
+private slots:
+	void on_textSearch_textChanged(const QString & keyword);
+	void on_filterModeCombo_currentIndexChanged(int index);
+	void on_heroList_itemSelectionChanged();
+	void on_heroList_itemChanged(QListWidgetItem * item);
+	void on_playerList_itemChanged(QListWidgetItem * item);
+
+private:
+	struct Filter
+	{
+		std::string description;
+		std::function<bool(const QListWidgetItem *)> isVisible;
+	};
+
+	Ui::HeroesSettings * ui;
+	std::vector<DisposedHero> disposedHeroesCopy;
+	const std::vector<Filter> filters = {
+		{QT_TR_NOOP("All heroes"), [](const QListWidgetItem * heroItem) -> bool { return true; }},
+		{QT_TR_NOOP("Exclusive heroes"), [this](const QListWidgetItem * item) -> bool { return getDisposedHero(item->data(Qt::UserRole).toInt()).has_value(); }},
+		{QT_TR_NOOP("Banned Heroes"), [](const QListWidgetItem * item) -> bool { return item->checkState() == Qt::Unchecked; }}
+	};
+
+	void updatePlayersSelection();
+	void showPlayerSelection(bool show);
+	void filterHeroes();
+	void setDisposedHero(int heroId, std::set<PlayerColor> players);
+	void removeDisposedHero(int heroId);
+	std::optional<const DisposedHero> getDisposedHero(int heroId);
+	std::set<PlayerColor> getSelectedPlayers();
+	int getSelectedHeroId();
+	bool allPlayersSelected();
+	bool isHeroBanned(int heroId);
+};

--- a/mapeditor/mapsettings/heroessettings.ui
+++ b/mapeditor/mapsettings/heroessettings.ui
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>HeroesSettings</class>
+ <widget class="QWidget" name="HeroesSettings">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>493</width>
+    <height>428</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <widget class="QListWidget" name="playerList">
+   <property name="geometry">
+    <rect>
+     <x>320</x>
+     <y>181</y>
+     <width>151</width>
+     <height>231</height>
+    </rect>
+   </property>
+  </widget>
+  <widget class="QListWidget" name="heroList">
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>50</y>
+     <width>301</width>
+     <height>361</height>
+    </rect>
+   </property>
+   <property name="editTriggers">
+    <set>QAbstractItemView::EditTrigger::NoEditTriggers</set>
+   </property>
+   <property name="horizontalScrollMode">
+    <enum>QAbstractItemView::ScrollMode::ScrollPerItem</enum>
+   </property>
+   <property name="isWrapping" stdset="0">
+    <bool>true</bool>
+   </property>
+   <property name="layoutMode">
+    <enum>QListView::LayoutMode::SinglePass</enum>
+   </property>
+   <property name="batchSize">
+    <number>30</number>
+   </property>
+  </widget>
+  <widget class="QLineEdit" name="textSearch">
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>10</y>
+     <width>251</width>
+     <height>25</height>
+    </rect>
+   </property>
+  </widget>
+  <widget class="QComboBox" name="filterModeCombo">
+   <property name="geometry">
+    <rect>
+     <x>280</x>
+     <y>10</y>
+     <width>191</width>
+     <height>25</height>
+    </rect>
+   </property>
+  </widget>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/mapeditor/mapsettings/mapsettings.cpp
+++ b/mapeditor/mapsettings/mapsettings.cpp
@@ -56,14 +56,6 @@ MapSettings::MapSettings(MapController & ctrl, QWidget *parent) :
 		item->setCheckState(controller.map()->allowedArtifact.count(objectPtr->getId()) ? Qt::Checked : Qt::Unchecked);
 		ui->listArts->addItem(item);
 	}
-	for(auto const & objectPtr : LIBRARY->heroh->objects)
-	{
-		auto * item = new QListWidgetItem(QString::fromStdString(objectPtr->getNameTranslated()));
-		item->setData(Qt::UserRole, QVariant::fromValue(objectPtr->getIndex()));
-		item->setFlags(item->flags() | Qt::ItemIsUserCheckable);
-		item->setCheckState(controller.map()->allowedHeroes.count(objectPtr->getId()) ? Qt::Checked : Qt::Unchecked);
-		ui->listHeroes->addItem(item);
-	}
 
 	ui->general->initialize(controller);
 	ui->mods->initialize(controller);
@@ -71,6 +63,7 @@ MapSettings::MapSettings(MapController & ctrl, QWidget *parent) :
 	ui->lose->initialize(controller);
 	ui->events->initialize(controller);
 	ui->rumors->initialize(controller);
+	ui->heroes->initialize(controller);
 }
 
 MapSettings::~MapSettings()
@@ -100,7 +93,6 @@ void MapSettings::on_pushButton_clicked()
 	updateMapArray(ui->listAbilities, controller.map()->allowedAbilities);
 	updateMapArray(ui->listSpells, controller.map()->allowedSpells);
 	updateMapArray(ui->listArts, controller.map()->allowedArtifact);
-	updateMapArray(ui->listHeroes, controller.map()->allowedHeroes);
 
 	controller.map()->triggeredEvents.clear();
 
@@ -110,6 +102,7 @@ void MapSettings::on_pushButton_clicked()
 	ui->lose->update();
 	ui->events->update();
 	ui->rumors->update();
+	ui->heroes->update();
 
 	controller.commitChangeWithoutRedraw();
 

--- a/mapeditor/mapsettings/mapsettings.ui
+++ b/mapeditor/mapsettings/mapsettings.ui
@@ -3,7 +3,7 @@
  <class>MapSettings</class>
  <widget class="QDialog" name="MapSettings">
   <property name="windowModality">
-   <enum>Qt::ApplicationModal</enum>
+   <enum>Qt::WindowModality::ApplicationModal</enum>
   </property>
   <property name="geometry">
    <rect>
@@ -35,7 +35,7 @@
    <item>
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
-      <number>0</number>
+      <number>6</number>
      </property>
      <widget class="QWidget" name="tab">
       <attribute name="title">
@@ -191,16 +191,16 @@
        <item>
         <widget class="QListWidget" name="listAbilities">
          <property name="horizontalScrollMode">
-          <enum>QAbstractItemView::ScrollPerItem</enum>
+          <enum>QAbstractItemView::ScrollMode::ScrollPerItem</enum>
          </property>
          <property name="isWrapping" stdset="0">
           <bool>true</bool>
          </property>
          <property name="resizeMode">
-          <enum>QListView::Adjust</enum>
+          <enum>QListView::ResizeMode::Adjust</enum>
          </property>
          <property name="layoutMode">
-          <enum>QListView::Batched</enum>
+          <enum>QListView::LayoutMode::Batched</enum>
          </property>
          <property name="batchSize">
           <number>30</number>
@@ -226,16 +226,16 @@
        <item>
         <widget class="QListWidget" name="listSpells">
          <property name="editTriggers">
-          <set>QAbstractItemView::NoEditTriggers</set>
+          <set>QAbstractItemView::EditTrigger::NoEditTriggers</set>
          </property>
          <property name="horizontalScrollMode">
-          <enum>QAbstractItemView::ScrollPerItem</enum>
+          <enum>QAbstractItemView::ScrollMode::ScrollPerItem</enum>
          </property>
          <property name="isWrapping" stdset="0">
           <bool>true</bool>
          </property>
          <property name="layoutMode">
-          <enum>QListView::Batched</enum>
+          <enum>QListView::LayoutMode::Batched</enum>
          </property>
          <property name="batchSize">
           <number>30</number>
@@ -261,16 +261,16 @@
        <item>
         <widget class="QListWidget" name="listArts">
          <property name="editTriggers">
-          <set>QAbstractItemView::NoEditTriggers</set>
+          <set>QAbstractItemView::EditTrigger::NoEditTriggers</set>
          </property>
          <property name="horizontalScrollMode">
-          <enum>QAbstractItemView::ScrollPerItem</enum>
+          <enum>QAbstractItemView::ScrollMode::ScrollPerItem</enum>
          </property>
          <property name="isWrapping" stdset="0">
           <bool>true</bool>
          </property>
          <property name="layoutMode">
-          <enum>QListView::Batched</enum>
+          <enum>QListView::LayoutMode::Batched</enum>
          </property>
          <property name="batchSize">
           <number>30</number>
@@ -294,23 +294,7 @@
         <number>12</number>
        </property>
        <item>
-        <widget class="QListWidget" name="listHeroes">
-         <property name="editTriggers">
-          <set>QAbstractItemView::NoEditTriggers</set>
-         </property>
-         <property name="horizontalScrollMode">
-          <enum>QAbstractItemView::ScrollPerItem</enum>
-         </property>
-         <property name="isWrapping" stdset="0">
-          <bool>true</bool>
-         </property>
-         <property name="layoutMode">
-          <enum>QListView::Batched</enum>
-         </property>
-         <property name="batchSize">
-          <number>30</number>
-         </property>
-        </widget>
+        <widget class="HeroesSettings" name="heroes" native="true"/>
        </item>
       </layout>
      </widget>
@@ -330,6 +314,12 @@
    <class>GeneralSettings</class>
    <extends>QWidget</extends>
    <header>mapsettings/generalsettings.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>HeroesSettings</class>
+   <extends>QWidget</extends>
+   <header>mapsettings/heroessettings.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>


### PR DESCRIPTION
Reworks hero tab in map setting in the editor to allow limiting some heroes to specific players.
Also, fixes a bug when an exclusive hero could be chosen as the random starting hero for a player that theoretically shouldn't be able to get them.

Snags and problems:
HeroesSettings keeping a deep copy of disposed heroes is necessary to implement behaviour of map settings, where exiting options with x button preserves the state of all the option windows, but do not propagate changes to map. Now, it is a little bit confusing (and least it confused me for some time) and IMO some warning for the user would be in order, but it is not the point of this pr so I just adapted.

There are some heroes without a name?
<img width="478" height="567" alt="Screenshot from 2026-04-25 22-17-05" src="https://github.com/user-attachments/assets/b3240d49-d2ec-41ed-b037-3ca3ba3f2901" />
Not sure what's up with it, but they were there before my pr. I may take a look at it later.

When I changed mapsettings.ui with Qt Widget Designer it also went and changed names of some unrelated elements. I guess the QWD was updated since that widget was created. I left it in the pr.

Important stuff: changes to MapFormatJson.
a) Reading disposed heroes needed to be moved up in readHeader method so Lobby, which reads header with bool complete set to false, could access disposedHeroes and remove them from option tab after loading a map header.

b) DisposedHeroes clashed with predefinedHeroes, creating a default-initialized hero with name of a core heroes when a disposedHeroe was set for this core hero.
Now, I may be wrong about it, but I think that predefinedHeroes is a dangling code from an unfinished feature. It is supposed to get heroes from heroPool to create map-specific heroes. The problem is, I could not find any code in map editor that would do anything with heroPool, rendering the code serializing predefinedHeroes effectively dead (unless somebody modifies vcmi file manually). If I am right, it should just be removed (what I did).

Edit: I fixed sonarqube warnings that IMO were fixable. The rest is a result of implementing qt interface.
