### PR TITLE
[1.7.4] Fix asset gen

### DIFF
--- a/client/render/AssetGenerator.cpp
+++ b/client/render/AssetGenerator.cpp
@@ -1207,8 +1207,14 @@ AssetGenerator::AnimationLayoutMap AssetGenerator::createAdventureOptionsButton(
 
                 for(int y = startY; y < startY + height; ++y)
                 {
-                    bool isScratchRow = ((y * 2147483647) % 13) > 8;
-                    int rowBaseBias = ((y * 1103515245) % 11) - 5;
+                    // 2147483647 is the Mersenne prime 2^31-1, used as a hash multiplier to scatter
+                    // the row index across the modulus 13, producing an irregular scratch pattern
+                    // instead of a visually obvious repeating stripe every 13 rows.
+                    bool isScratchRow = ((static_cast<unsigned>(y) * 2147483647u) % 13u) > 8u;
+                    // 1103515245 is the LCG multiplier from the glibc rand() implementation.
+                    // Multiplying by it before taking mod 11 distributes the per-row brightness
+                    // bias pseudo-randomly rather than cycling predictably every 11 rows.
+                    int rowBaseBias = static_cast<int>((static_cast<unsigned>(y) * 1103515245u) % 11u) - 5;
 
                     for(int x = startX; x < startX + width; ++x)
                     {


### PR DESCRIPTION
Hopefully fixes: #7286

@IvanSavenko Any way to test PPA for PR's? Was still not able to reproduce error - or just merge and re-check beta?

　
　
　
　
　
　
　

----------------------

# Root Cause: Potential Infinite Loop in `AssetGenerator::createAdventureOptionsButton`

## Summary
The potential infinite loop was caused by **signed integer overflow** in the row-mixing logic inside `AssetGenerator::createAdventureOptionsButton()`.

## What happened
The code used expressions like:

- `y * 2147483647`
- `y * 1103515245`

where `y` is an `int` loop variable.

For the values used in the loop, these multiplications overflow a signed 32-bit integer. In C++, **signed overflow is undefined behavior**.

## Why this can become an infinite loop
Optimizing compilers such as GCC and Clang may assume that signed overflow never happens. Under those assumptions, they can make aggressive loop optimizations that change the control flow in unexpected ways. On some systems and compiler settings, that can lead to the loop being miscompiled into behavior that looks like an infinite loop.

## Fix
The overflow was removed by switching the arithmetic to **unsigned** calculations:

- unsigned overflow is defined and wraps predictably
- the visual output remains effectively the same
- the compiler no longer has undefined behavior to exploit

## Notes
This problem was not caused by the image drawing logic itself, but by the arithmetic used to generate pseudo-random row variation.
