### PR TITLE
[1.8.0] MapEditor - fixes crashes on undo delete object operation

### DIFF
--- a/lib/mapping/CMap.cpp
+++ b/lib/mapping/CMap.cpp
@@ -560,9 +560,6 @@ void CMap::addNewObject(std::shared_ptr<CGObjectInstance> obj)
 	if (!obj->id.hasValue())
 		obj->id = ObjectInstanceID(objects.size());
 
-	if(obj->id != ObjectInstanceID(objects.size()) && objects.at(obj->id.getNum()) != nullptr)
-		throw std::runtime_error("Invalid object instance id");
-
 	if(obj->instanceName.empty())
 		throw std::runtime_error("Object instance name missing");
 
@@ -572,7 +569,17 @@ void CMap::addNewObject(std::shared_ptr<CGObjectInstance> obj)
 	if (obj->id == ObjectInstanceID(objects.size()))
 		objects.emplace_back(obj);
 	else
-		objects[obj->id.getNum()] = obj;
+	{
+		if(objects.at(obj->id.getNum()) == nullptr)
+			objects[obj->id.getNum()] = obj;
+		else
+		{
+			int index = obj->id.getNum();
+			auto iter = objects.begin() + index;
+			objects.insert(iter, obj);
+			shiftObjectIndices(index, 1);
+		}
+	}
 
 	instanceNames[obj->instanceName] = obj;
 	showObject(obj.get());
@@ -603,32 +610,31 @@ std::shared_ptr<CGObjectInstance> CMap::removeObject(ObjectInstanceID oldObject)
 	auto iter = std::next(objects.begin(), obj->id.getNum());
 	iter = objects.erase(iter);
 
-	for(int i = obj->id.getNum(); iter != objects.end(); ++i, ++iter)
-		(*iter)->id = ObjectInstanceID(i);
-
-	for (auto & town : towns)
-		if (town.getNum() >= obj->id)
-			town = ObjectInstanceID(town.getNum()-1);
-
-	for (auto & hero : heroesOnMap)
-		if (hero.getNum() >= obj->id)
-			hero = ObjectInstanceID(hero.getNum()-1);
-
-	for(auto & tile : terrain)
-	{
-		for (auto & objectID : tile.blockingObjects)
-			if (objectID.getNum() >= obj->id)
-				objectID = ObjectInstanceID(objectID.getNum()-1);
-
-		for (auto & objectID : tile.visitableObjects)
-			if (objectID.getNum() >= obj->id)
-				objectID = ObjectInstanceID(objectID.getNum()-1);
-	}
-
+	shiftObjectIndices(obj->id.getNum(), -1);
 	//TODO: Clean artifact instances (mostly worn by hero?) and quests related to this object
-	//This causes crash with undo/redo in editor
 
 	return obj;
+}
+
+void CMap::shiftObjectIndices(int from, int shift)
+{
+	for(int i = from; i < objects.size(); i++)
+		objects[i]->id = ObjectInstanceID(i);
+
+	auto shiftUtilityContainer = [&from, &shift](std::vector<ObjectInstanceID> & indices) -> void
+	{
+		for(auto & index : indices)
+			if(index.getNum() >= from)
+				index = ObjectInstanceID(index.getNum() + shift);
+	};
+
+	shiftUtilityContainer(towns);
+	shiftUtilityContainer(heroesOnMap);
+	for(auto & tile : terrain)
+	{
+		shiftUtilityContainer(tile.blockingObjects);
+		shiftUtilityContainer(tile.visitableObjects);
+	}
 }
 
 std::shared_ptr<CGObjectInstance> CMap::replaceObject(ObjectInstanceID oldObjectID, const std::shared_ptr<CGObjectInstance> & newObject)

--- a/lib/mapping/CMap.cpp
+++ b/lib/mapping/CMap.cpp
@@ -605,21 +605,39 @@ std::shared_ptr<CGObjectInstance> CMap::removeObject(ObjectInstanceID oldObject)
 	instanceNames.erase(obj->instanceName);
 	obj->afterRemoveFromMap(this);
 
-	//update indices
+	for(int i = 0; i < objects.size(); i++)
+	{
+		if(auto questGiver = std::dynamic_pointer_cast<IQuestObject>(objects[i]))
+		{
+			ObjectInstanceID & questTarget = questGiver->getQuest().killTarget;
+			if(questTarget.getNum() == oldObject)
+				questTarget = ObjectInstanceID::NONE;
+		}
+	}
 
 	auto iter = std::next(objects.begin(), obj->id.getNum());
 	iter = objects.erase(iter);
 
 	shiftObjectIndices(obj->id.getNum(), -1);
-	//TODO: Clean artifact instances (mostly worn by hero?) and quests related to this object
+	//TODO: Clean artifact instances (mostly worn by hero?)
 
 	return obj;
 }
 
 void CMap::shiftObjectIndices(int from, int shift)
 {
-	for(int i = from; i < objects.size(); i++)
-		objects[i]->id = ObjectInstanceID(i);
+	for(int i = 0; i < objects.size(); i++)
+	{
+		if(i >= from)
+			objects[i]->id = ObjectInstanceID(i);
+
+		if(auto questGiver = std::dynamic_pointer_cast<IQuestObject>(objects[i]))
+		{
+			ObjectInstanceID & questTarget = questGiver->getQuest().killTarget;
+			if(questTarget != ObjectInstanceID::NONE && questTarget.getNum() >= from)
+				questTarget = ObjectInstanceID(questTarget.getNum() + shift);
+		}
+	}
 
 	auto shiftUtilityContainer = [&from, &shift](std::vector<ObjectInstanceID> & indices) -> void
 	{

--- a/lib/mapping/CMap.h
+++ b/lib/mapping/CMap.h
@@ -290,7 +290,9 @@ private:
 	/// a 3-dimensional array of terrain tiles
 	MapTilesStorage<TerrainTile> terrain;
 
-	si32 uidCounter; 
+	si32 uidCounter;
+
+	void shiftObjectIndices(int from, int shift);
 
 public:
 	template <typename Handler>


### PR DESCRIPTION
Allows inserting objects with instanceId smaller than number of already existing objects in CMap.
Fixes #7181.

Edit: I've added code to resolve the third issue from #7280 (seer hut/quest guard quest assigned monster change after adding/deleting unrelated objects).