### PR TITLE
[1.7.4?] Better translation exporting for mods

### DIFF
--- a/client/ClientCommandManager.cpp
+++ b/client/ClientCommandManager.cpp
@@ -190,7 +190,7 @@ void ClientCommandManager::handleRedrawCommand()
 
 void ClientCommandManager::handleTranslateGameCommand(bool onlyMissing)
 {
-	std::map<std::string, std::map<std::string, std::string>> textsByMod;
+	std::map<std::string, ExportedStrings> textsByMod;
 	LIBRARY->generaltexth->exportAllTexts(textsByMod, onlyMissing);
 
 	const boost::filesystem::path outPath = VCMIDirs::get().userExtractedPath() / ( onlyMissing ? "translationMissing" : "translation");
@@ -200,7 +200,7 @@ void ClientCommandManager::handleTranslateGameCommand(bool onlyMissing)
 	{
 		JsonNode output;
 
-		for(const auto & stringEntry : modEntry.second)
+		for(const auto & stringEntry : modEntry.second.strings)
 		{
 			if(boost::algorithm::starts_with(stringEntry.first, "map."))
 				continue;
@@ -212,7 +212,9 @@ void ClientCommandManager::handleTranslateGameCommand(bool onlyMissing)
 
 		if (!output.isNull())
 		{
-			const boost::filesystem::path filePath = outPath / (modEntry.first + ".json");
+			std::string filename = modEntry.first;
+			boost::range::replace(filename, '.', '_');
+			const boost::filesystem::path filePath = outPath / (filename + ".json");
 			std::ofstream file(filePath.c_str());
 			file << output.toString();
 		}
@@ -274,7 +276,7 @@ void ClientCommandManager::handleTranslateMapsCommand()
 		}
 	}
 
-	std::map<std::string, std::map<std::string, std::string>> textsByMod;
+	std::map<std::string, ExportedStrings> textsByMod;
 	LIBRARY->generaltexth->exportAllTexts(textsByMod, false);
 
 	const boost::filesystem::path outPath = VCMIDirs::get().userExtractedPath() / "translation";
@@ -284,7 +286,7 @@ void ClientCommandManager::handleTranslateMapsCommand()
 	{
 		JsonNode output;
 
-		for(const auto & stringEntry : modEntry.second)
+		for(const auto & stringEntry : modEntry.second.strings)
 		{
 			if(boost::algorithm::starts_with(stringEntry.first, "map."))
 				output[stringEntry.first].String() = stringEntry.second;

--- a/docs/maintainers/Project_Infrastructure.md
+++ b/docs/maintainers/Project_Infrastructure.md
@@ -77,9 +77,8 @@ At the moment, all our services are hosted by Digital Ocean. Current approach is
 | Droplet | Specifications | Services |
 | ------- | -------------- | -------- |
 | `vcmi-artifactory` | 4 Gb / 2 CPU / 80 Gb / $24 | [Conan Artifactory server](https://artifactory.vcmi.eu/) (removed, snapshot available) |
-| `vcmi-forum` | 2 Gb / 1 CPU / 25 Gb / $12 (+20%) | [Discourse forum](https://forum.vcmi.eu/) |
-| `vcmi-second` | 1 Gb / 1 CPU / 20 Gb / $6 | Old multiplayer lobby server that runs on Ubuntu 20.04. Soon to be removed |
-| `vcmi-lobby` | 1 Gb / 1 CPU / 20 Gb / $6 | Multiplayer lobby (lobby.vcmi.eu or beholder.vcmi.eu - deprecated) |
+| `vcmi-forum` | 2 Gb / 1 CPU / 25 Gb / $12 (+20%) | [Discourse forum](https://forum.vcmi.eu/). Note: 25 Gb droplet - ssd can be expanded, or we can downscale entire droplet to 1 Gb config |
+| `vcmi-weblate` | 2 Gb / 1 CPU / 50 Gb / $12 | [Weblate](https://weblate.vcmi.eu/) |
 | `vcmi-web` | 512 Mb / 1 CPU / 10 Gb + 100 Gb / $4 (+20%) + $10 | Builds uploading from Github, [Build download page](http://download.vcmi.eu/), [Legacy download page](https://builds.vcmi.download/). Also contains nginx server for redirecting [old bug tracker](https://bugs.vcmi.eu/), [old wiki](https://wiki.vcmi.eu/), and [old slack invite page](https://slack.vcmi.eu/) |
 
 Notes:
@@ -111,6 +110,7 @@ Notes:
 | [forum.vcmi.eu](https://forum.vcmi.eu) | Discourse forum | `vcmi-forum` | - |
 | [bugs.vcmi.eu](https://bugs.vcmi.eu) | Bug tracker | `vcmi-web` | Redirects to [Github Issues](https://github.com/vcmi/vcmi/issues) |
 | [slack.vcmi.eu](https://slack.vcmi.eu) | Slack invite page | `vcmi-web` | Redirects to [main page](https://vcmi.eu/) |
+| [weblate.vcmi.eu](https://weblate.vcmi.eu) | Weblate translation service | `vcmi-weblate` | - |
 | [wiki.vcmi.eu](https://wiki.vcmi.eu) | Wiki | `vcmi-web` | Redirects to [main page](https://vcmi.eu/) |
 | [vcmi.download](https://vcmi.download) | Main page redirect | CNAME | No content, redirects to [main page](https://vcmi.eu/) |
 | [builds.vcmi.download](https://builds.vcmi.download) | Public downloads | `vcmi-second` | Redirects to [download.vcmi.eu](https://download.vcmi.eu) |
@@ -122,11 +122,11 @@ Currenly we have following services deployed:
 - [Discourse](Discourse.md)
 - [Multiplayer lobby](Multiplayer_Lobby.md)
 - [Downloads & daily builds](Daily_Builds.md)
+- [Weblate](Weblate.md)
 
 Potential addition for the future:
 
 - Conan Artifactory
-- Self-hosted Weblate, to bypass Libre tier restrictions on our Weblate hosted by upstream team and allow translation of Heroes 3, mods, and VCMI website
 - Crash reporter tool, such as [GlitchTip](https://glitchtip.com/)
 - (long-term) Expanded multiplayer lobby with cheat-proof game hosting
 

--- a/docs/maintainers/Project_Infrastructure.md
+++ b/docs/maintainers/Project_Infrastructure.md
@@ -63,9 +63,9 @@ When possible at least two of active core developers must have access to them in
 
 This section dedicated to explain specific configurations of our servers for anyone who might need to improve it in future.
 
-### Droplet configuration
+### VPS configuration
 
-At the moment, all our services are hosted by Digital Ocean. Current approach is to keep services on separate VPS (called "droplets" by Digital Ocean) for better isolation & to allow independent restarts / upgrades. This also allows us to measure performance & system load of each service independently. All droplets can only be accessed using ssh login with public key. Currently access to all droplets is granted to:
+At the moment, most our services are hosted by Digital Ocean. Current approach is to keep services on separate VPS (called "droplets" by Digital Ocean) for better isolation & to allow independent restarts / upgrades. This also allows us to measure performance & system load of each service independently. All droplets can only be accessed using ssh login with public key. Currently access to all droplets is granted to:
 
 - Ivan Savenko
 - Alexvins
@@ -74,19 +74,25 @@ At the moment, all our services are hosted by Digital Ocean. Current approach is
 - SXX
 - kambala (`vcmi-artifactory` droplet)
 
-| Droplet | Specifications | Services |
-| ------- | -------------- | -------- |
-| `vcmi-artifactory` | 4 Gb / 2 CPU / 80 Gb / $24 | [Conan Artifactory server](https://artifactory.vcmi.eu/) (removed, snapshot available) |
-| `vcmi-forum` | 2 Gb / 1 CPU / 25 Gb / $12 (+20%) | [Discourse forum](https://forum.vcmi.eu/). Note: 25 Gb droplet - ssd can be expanded, or we can downscale entire droplet to 1 Gb config |
-| `vcmi-weblate` | 2 Gb / 1 CPU / 50 Gb / $12 | [Weblate](https://weblate.vcmi.eu/) |
-| `vcmi-web` | 512 Mb / 1 CPU / 10 Gb + 100 Gb / $4 (+20%) + $10 | Builds uploading from Github, [Build download page](http://download.vcmi.eu/), [Legacy download page](https://builds.vcmi.download/). Also contains nginx server for redirecting [old bug tracker](https://bugs.vcmi.eu/), [old wiki](https://wiki.vcmi.eu/), and [old slack invite page](https://slack.vcmi.eu/) |
+Lobby is currently hosted on Hetzner, with migration of other services to Hetzner in plans. Login is via public key, currently granted to:
+
+- Ivan Savenko
+
+| VPS | Location | Specifications | Services |
+| --- | -------- | -------------- | -------- |
+| `vcmi-forum` | DO Droplet | 2 Gb / 1 CPU / 25 Gb / $12 (+20%) | [Discourse forum](https://forum.vcmi.eu/). Note: 25 Gb droplet - ssd can be expanded, or we can downscale entire droplet to 1 Gb config |
+| `vcmi-weblate` | DO Droplet | 2 Gb / 1 CPU / 50 Gb / $12 | [Weblate](https://weblate.vcmi.eu/) |
+| `vcmi-web` | DO Droplet | 512 Mb / 1 CPU / 10 Gb + 100 Gb / $4 (+20%) + $10 | Builds uploading from Github, [Build download page](http://download.vcmi.eu/), [Legacy download page](https://builds.vcmi.download/). Also contains nginx server for redirecting [old bug tracker](https://bugs.vcmi.eu/), [old wiki](https://wiki.vcmi.eu/), and [old slack invite page](https://slack.vcmi.eu/) |
+| `vcmi-lobby` | Hetzner Server | 4 Gb / 2 CPU / 40 Gb / €4 (+20%) | Multiplayer lobby (lobby.vcmi.eu or beholder.vcmi.eu - deprecated) as we ll as [API endpoint](https://api.vcmi.eu/) |
+| `vcmi-artifactory` | DO Snapshot | 4 Gb / 2 CPU / 80 Gb / $24 | [Conan Artifactory server](https://artifactory.vcmi.eu/) |
+| `vcmi-main` | DO Snapshot | ??? / $1 | Contains old bugtracker, forum, and wiki |
+| `vcmi-second` | DO Snapshot | ??? / $1 | Contains old MP lobby and builds uploader |
 
 Notes:
 
-- All droplets other than `vcmi-second` run Ubuntu 24.04
-- Droplets with deployed services have backups enabled (+20% costs)
-- In addition to droplets, we have separate 100 Gb volume for builds ($10 / month), currently attached to `vcmi-web`
-- There is snapshot for old `vcmi-main` droplet, preserved in case if we need to retrieve some data from it - old bugtracker, forum, and wiki ($1.5 / month)
+- All active VPS run Ubuntu 24.04
+- VPS with deployed and tested services have backups enabled (+20% costs)
+- In addition, we have separate 100 Gb volume for builds ($10 / month), currently attached to `vcmi-web`
 
 ### Rules to stick to
 

--- a/docs/maintainers/Weblate.md
+++ b/docs/maintainers/Weblate.md
@@ -83,31 +83,10 @@ services:
     - "127.0.0.1:8080:8080"
 ```
 
-
 ## Upgrade
 
-```sh
-cd /var/discourse
-./launcher rebuild app
-```
-
-Alternatively can be done in UI, but untested
+(not investigated)
 
 ## Migration
 
-When setting up Discourse, it needs to be already located on target domain name, so it might be a good idea to do operations in following order:
-
-- create backup on old server (or pick latest weekly backup)
-- switch domain name to new IP & wait for DNS to propagate
-- ensure that ports 80 and 443 are open on new server
-- setup Discourse on new server
-- restore backup either in web interface or in console on new server
-- adjust or migrate configuration file from old server to new one
-
-
-
-
-
-
-
-
+(not investigated)

--- a/docs/maintainers/Weblate.md
+++ b/docs/maintainers/Weblate.md
@@ -1,0 +1,113 @@
+# Discourse
+
+- RAM requirements: 2 GB + swap, official docs recommend 3 Gb
+- CPU requirements: 1 core, official docs recommend 2 cores.
+- SSD requirements: over 10 GB. Will grow over time with more translations
+
+Accessible as [weblate.vcmi.eu](https://weblate.vcmi.eu/)
+
+Admin access:
+
+- Ivan Savenko
+
+Additional accounts can be given admin rights via admin panel.
+
+## Configuration
+
+- Located at `/var/weblate-docker`.
+- Configuration file is at `/var/weblate-docker/docker-compose.override.yml`
+- Administration primarily via web interface
+- To apply configuration changes and update weblate:
+  ```sh
+  # Fetch latest versions of the images
+  docker-compose pull
+  # Stop and destroy the containers
+  docker-compose down
+  # Spawn new containers in the background
+  docker-compose up -d
+  # Follow the logs during upgrade
+  docker-compose logs -f
+  ```
+
+## Setup
+
+See [Official docs](https://docs.weblate.org/en/latest/admin/install/docker.html):
+
+Approximate order of commands:
+
+```sh
+# Install git and docker
+apt install docker.io git docker-compose nginx
+
+# Setup nginx
+cd /etc/nginx/sites-available/
+nano weblate.vcmi.eu
+cd ../sites-enabled/
+ln -s ../sites-available/weblate.vcmi.eu 
+service nginx restart 
+
+# Setup Weblate
+cd /var
+git clone https://github.com/WeblateOrg/docker-compose.git weblate-docker
+cd weblate-docker/
+nano docker-compose.override.yml
+docker compose up -d
+
+# Optionally, create swap
+fallocate -l 2G /swapfile
+chmod 600 /swapfile
+mkswap /swapfile
+swapon /swapfile
+nano /etc/fstab # append `/swapfile swap swap defaults 0 0` to the end, on new line
+```
+
+Modified configuration file. Check existing instance or other services (e.g. Discourse) for private fields:
+
+```text
+services:
+  weblate:
+    image: weblate/weblate:latest
+    environment:
+      WEBLATE_EMAIL_HOST: ***
+      WEBLATE_EMAIL_HOST_USER: ***
+      WEBLATE_EMAIL_HOST_PASSWORD: ***
+      WEBLATE_SERVER_EMAIL: weblate@vcmi.eu
+      WEBLATE_DEFAULT_FROM_EMAIL: weblate@vcmi.eu
+      WEBLATE_SITE_DOMAIN: weblate.vcmi.eu
+      WEBLATE_ADMIN_EMAIL: ***
+      CELERY_SINGLE_PROCESS: 1
+      WEBLATE_ENABLE_HTTPS: 1
+      WEBLATE_IP_PROXY_HEADER: HTTP_X_FORWARDED_FOR
+      WEBLATE_SECURE_PROXY_SSL_HEADER: HTTP_X_FORWARDED_PROTO,https
+    ports:
+    - "127.0.0.1:8080:8080"
+```
+
+
+## Upgrade
+
+```sh
+cd /var/discourse
+./launcher rebuild app
+```
+
+Alternatively can be done in UI, but untested
+
+## Migration
+
+When setting up Discourse, it needs to be already located on target domain name, so it might be a good idea to do operations in following order:
+
+- create backup on old server (or pick latest weekly backup)
+- switch domain name to new IP & wait for DNS to propagate
+- ensure that ports 80 and 443 are open on new server
+- setup Discourse on new server
+- restore backup either in web interface or in console on new server
+- adjust or migrate configuration file from old server to new one
+
+
+
+
+
+
+
+

--- a/docs/maintainers/scripts/nginx/weblate.vcmi.eu
+++ b/docs/maintainers/scripts/nginx/weblate.vcmi.eu
@@ -1,0 +1,25 @@
+server {
+    listen 443 ssl http2;
+    server_name weblate.vcmi.eu;
+
+    ssl_certificate /etc/nginx/certs/dot.vcmi.eu.pem;
+    ssl_certificate_key /etc/nginx/certs/dot.vcmi.eu.key;
+    ssl_client_certificate /etc/nginx/certs/cloudflare-client.crt;
+    ssl_verify_client on;
+
+    access_log /var/log/nginx/weblate.access.log;
+    error_log /var/log/nginx/weblate.error.log;
+
+    client_max_body_size 1000m;
+
+    location / {
+        proxy_pass http://127.0.0.1:8080;
+        proxy_read_timeout 3600s;
+        proxy_connect_timeout 3600s;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Host $server_name;
+    }
+}

--- a/docs/translators/Translations.md
+++ b/docs/translators/Translations.md
@@ -93,8 +93,6 @@ VCMI contains several new strings, to cover functionality not existing in Heroes
 - Linux specific
 - Android Launcher
 
-### Translation of in-game data
-
 Most of game data is translated using [Weblate](https://hosted.weblate.org/projects/vcmi/)
 
 For usage of Weblate, please refer to [Weblate documentation](https://docs.weblate.org/en/latest/user/translating.html)
@@ -102,6 +100,27 @@ For usage of Weblate, please refer to [Weblate documentation](https://docs.webla
 If something is not clear - feel free to ask us on Discord or forum. Translation made via Weblate will be automatically integrated into VCMI for next release
 
 ## Translating mods
+
+### Weblate translations
+
+Translation for some mods is being migrated to our self-hosted [Weblate](https://weblate.vcmi.eu/projects/). If mod that you wish to translate is already there and it already has your language, then all you need to do is register and start translating.
+
+If you wish to add a new mod on our Weblate, please contact VCMI Team for initial setup via Discord or Github.
+
+Mod management on weblate:
+
+- If translation to a new language needs to be added to Weblate, please add empty dummy files for required language to mod repository on Github. This should automatically generate translation on Weblate once changes are merged
+- If there is a new submods that needs translating, add required files (english.json and any required dummy translations) to mod repository on Github. After that, on Weblate add new component and configure it as follows. If you have not set any of these fields, they can be edited later in Component -> Settings -> Files tab.
+  - Source code repository: `weblate://mod-name/mod-name`
+  - File format: `Json nested structure file` (should be auto-selected)
+  - File mask: `Mods/XXX/Content/translation/*.json` for submods, or `Mods/XXX/Mods/YYY/Content/translation/*.json` for submods of submods. Weblate will offer to auto-detect this option
+  - Json indentation: `1`
+  - Json indentation style: `Tabs`
+  - Monolingual base language file: `Mods/XXX/Content/translation/english.json` for submods, or `Mods/XXX/Mods/YYY/Content/translation/english.json` for submods of submods.
+  - Edit base file: `off`
+  - Adding new translation: `Disable adding new translations`
+
+WARNING: Do not edit or move translation files other than through Weblate. If you have to, for example due to submod reorganization, make sure to flush any changes from Weblate using Component -> Repo
 
 ### Exporting translation
 
@@ -141,7 +160,7 @@ In order to display information in Launcher in language selected by user add fol
 		"description" : "<translated description>",
 		"author" : "<translated author>",
 		"translations" : [
-			"config/<modName>/<language>.json"
+			"translation/<language>.json"
 		]
 	},
 ```
@@ -150,7 +169,7 @@ However, normally you don't need to use block for English. Instead, English text
 
 ### Translating in-game strings
 
-After you have exported translation and added mod information for your language, copy exported file to `<mod directory>/Content/config/<mod name>/<language>.json`.
+After you have exported translation and added mod information for your language, copy exported file to `<mod directory>/Content/translation/<language>.json`.
 
 Use any text editor (Notepad++ is recommended for Windows) and translate all strings from this file to your language
 

--- a/docs/translators/Translations.md
+++ b/docs/translators/Translations.md
@@ -107,6 +107,18 @@ If something is not clear - feel free to ask us on Discord or forum. Translation
 
 If you want to start new translation for a mod or to update existing one you may need to export it first. To do that:
 
+- Optionally, backup your mod preset - game may modify active submods of mod being translated
+- Set game language in Launcher to one that you want to target
+- launch VCMI server in translation export mode:
+  - (Windows) Create shortcut for VCMI_Server.exe and append `--translate-mod=XXX` to "Target" field in shortcut properties, where XXX is identifier of mod that you want to translate
+  - (command-line) Open command line and run `vcmiserver --translate-mod=XXX`, where XXX is identifier of mod that you want to translate
+
+After that, start Launcher, switch to Help tab and open "log files directory". You can find exported json's in `extracted/translation` directory.
+
+### Exporting translation (alternative)
+
+Alternatively, you can use vcmi client to do similar actions:
+
 - Enable mod(s) that you want to export and set game language in Launcher to one that you want to target
 - Launch VCMI and start any map to get in game
 - Press Tab to activate chat and enter '/translate'
@@ -116,6 +128,8 @@ After that, start Launcher, switch to Help tab and open "log files directory". Y
 If your mod also contains maps or campaigns that you want to translate, then use `/translate maps` command instead.
 
 If you want to update existing translation, you can use `/translate missing` command that will export only strings that were not translated
+
+NOTE: when translating with this method, some strings may not export correctly, for example strings that were modified in multiple mods. To avoid this, you'll need to disable mods that overrride other strings and do a second re-run of this command
 
 ### Translating mod information
 

--- a/docs/translators/Translations.md
+++ b/docs/translators/Translations.md
@@ -85,42 +85,72 @@ It's possible to add video subtitles. Create a JSON file in `video` folder of tr
 
 ## Translating VCMI data
 
-VCMI contains several new strings, to cover functionality not existing in Heroes III. It can be roughly split into following parts:
-
-- In-game texts, most noticeably - in-game settings menu.
-- Game Launcher
-- Map Editor
-- Linux specific
-- Android Launcher
-
-Most of game data is translated using [Weblate](https://hosted.weblate.org/projects/vcmi/)
+VCMI game data is translated via [Weblate](https://hosted.weblate.org/projects/vcmi/).
 
 For usage of Weblate, please refer to [Weblate documentation](https://docs.weblate.org/en/latest/user/translating.html)
 
 If something is not clear - feel free to ask us on Discord or forum. Translation made via Weblate will be automatically integrated into VCMI for next release
 
-## Translating mods
-
-### Weblate translations
+## Translating mods via Weblate
 
 Translation for some mods is being migrated to our self-hosted [Weblate](https://weblate.vcmi.eu/projects/). If mod that you wish to translate is already there and it already has your language, then all you need to do is register and start translating.
 
 If you wish to add a new mod on our Weblate, please contact VCMI Team for initial setup via Discord or Github.
 
-Mod management on weblate:
+### Initial setup
 
-- If translation to a new language needs to be added to Weblate, please add empty dummy files for required language to mod repository on Github. This should automatically generate translation on Weblate once changes are merged
-- If there is a new submods that needs translating, add required files (english.json and any required dummy translations) to mod repository on Github. After that, on Weblate add new component and configure it as follows. If you have not set any of these fields, they can be edited later in Component -> Settings -> Files tab.
-  - Source code repository: `weblate://mod-name/mod-name`
-  - File format: `Json nested structure file` (should be auto-selected)
-  - File mask: `Mods/XXX/Content/translation/*.json` for submods, or `Mods/XXX/Mods/YYY/Content/translation/*.json` for submods of submods. Weblate will offer to auto-detect this option
-  - Json indentation: `1`
-  - Json indentation style: `Tabs`
-  - Monolingual base language file: `Mods/XXX/Content/translation/english.json` for submods, or `Mods/XXX/Mods/YYY/Content/translation/english.json` for submods of submods.
-  - Edit base file: `off`
-  - Adding new translation: `Disable adding new translations`
+Before starting, go through this checklist to ensure that mod is ready for Weblate:
 
-WARNING: Do not edit or move translation files other than through Weblate. If you have to, for example due to submod reorganization, make sure to flush any changes from Weblate using Component -> Repo
+- mod must be hosted by vcmi-mods Github organization
+- mod must contain mod.json in top-level directory, and not in a subdirectory
+- preferrably, mod should use centralized workflow from <https://github.com/vcmi-mods/workflow>
+- export English strings by running `vcmiserver --translate-mod=mod-name` and moving all generated `english.json` files to your mod
+- create dummy .json for each language to which you wish to translate in every submod that has translatable strings
+
+This operation can only be done by VCMI Team. Only mods hosted by vcmi-mods org can be translated this way.
+
+- Create new project on Weblate:
+  - Project name: name of the mod
+  - Project slug: mod ID
+  - Project website: mod page in vcmi-mods org
+- Create new component:
+  - Version control system: `Git`
+  - Source code repository: `https://github.com/vcmi-mods/mod-name.git`
+  - Repository branch: `vcmi-1.x`. This is branch from which Weblate will take translations
+  - On next page, select `Json nested structure file` with path pattern `content/translation/*.json`
+  - Repository push URL: `https://github_pat_***@github.com/vcmi-mods/horn-of-the-abyss.git` (replace *** with token from existing project)
+  - Push branch: `vcmi-1.x`. This is branch to which Weblate will upload translations
+  - Rest of options are the same as with addition of new submods
+
+### Addition of new languages
+
+This operation can be done by anyone with write access to mod repository. You can also create new pull request and ask for someone with write access to accept it.
+
+If translation to a new language needs to be added to Weblate, please add empty dummy files for required language to mod repository on Github. This should automatically generate translation on Weblate once changes are merged.
+
+Note that while Weblate supports basically any language, VCMI only supports limited set of languages listed in this document
+
+### Addition of new submods
+
+This operation can only be done by VCMI Team
+
+If there is a new submods that needs translating, add required files (english.json and any required dummy translations) to mod repository on Github. Please use the same list of translations as for the rest of the mod.
+
+After that, on Weblate add new component and configure it as follows. If you have not set any of these fields, they can be edited later in Component -> Settings -> Files tab.
+
+- Source code repository: `weblate://mod-name/mod-name`
+- On next page, select `Json nested structure file` with path pattern:
+  - File mask: `Mods/XXX/Content/translation/*.json` for submods.
+  - File mask: `Mods/XXX/Mods/YYY/Content/translation/*.json` for submods of submods
+- Json indentation: `1`
+- Json indentation style: `Tabs`
+- Monolingual base language file: `Mods/XXX/Content/translation/english.json` for submods, or `Mods/XXX/Mods/YYY/Content/translation/english.json` for submods of submods.
+- Edit base file: `off`
+- Adding new translation: `Disable adding new translations`
+
+WARNING: Do not edit or move translation files other than through Weblate. If you have to, for example due to submod reorganization, please contact VCMI Team.
+
+## Translating mods manually
 
 ### Exporting translation
 

--- a/lib/GameLibrary.h
+++ b/lib/GameLibrary.h
@@ -117,9 +117,10 @@ public:
 	/// Loads all game entities
 	void initializeLibrary();
 
-private:
 	// basic initialization. should be called before init(). Can also extract original H3 archives
 	void loadFilesystem(bool extractArchives);
+
+	// loads filesystems of all mods
 	void loadModFilesystem();
 
 #if SCRIPTING_ENABLED

--- a/lib/json/JsonNode.cpp
+++ b/lib/json/JsonNode.cpp
@@ -136,11 +136,11 @@ JsonNode::JsonNode(const JsonPath & fileURI, const std::string & modName)
 	*this = parser.parse(fileURI.getName());
 }
 
-JsonNode::JsonNode(const JsonPath & fileURI, const std::string & modName, bool & isValidSyntax)
+JsonNode::JsonNode(const JsonPath & fileURI, const JsonParsingSettings & parserSettings, const std::string & modName, bool & isValidSyntax)
 {
 	auto file = CResourceHandler::get(modName)->load(fileURI)->readAll();
 
-	JsonParser parser(reinterpret_cast<std::byte *>(file.first.get()), file.second, JsonParsingSettings());
+	JsonParser parser(reinterpret_cast<std::byte *>(file.first.get()), file.second, parserSettings);
 	*this = parser.parse(fileURI.getName());
 	isValidSyntax = parser.isValid();
 }

--- a/lib/json/JsonNode.h
+++ b/lib/json/JsonNode.h
@@ -85,7 +85,7 @@ public:
 	explicit JsonNode(const JsonPath & fileURI);
 	explicit JsonNode(const JsonPath & fileURI, const JsonParsingSettings & parserSettings);
 	explicit JsonNode(const JsonPath & fileURI, const std::string & modName);
-	explicit JsonNode(const JsonPath & fileURI, const std::string & modName, bool & isValidSyntax);
+	explicit JsonNode(const JsonPath & fileURI, const JsonParsingSettings & parserSettings, const std::string & modName, bool & isValidSyntax);
 
 	bool operator==(const JsonNode & other) const;
 	bool operator!=(const JsonNode & other) const;

--- a/lib/json/JsonUtils.cpp
+++ b/lib/json/JsonUtils.cpp
@@ -286,13 +286,19 @@ void JsonUtils::inherit(JsonNode & descendant, const JsonNode & base)
 	std::swap(descendant, inheritedNode);
 }
 
-JsonNode JsonUtils::assembleFromFiles(const JsonNode & files, bool & isValid)
+JsonNode JsonUtils::assembleFromFiles(const JsonNode & files, const JsonParsingSettings & settings)
+{
+	bool isValid = false;
+	return assembleFromFiles(files, settings, isValid);
+}
+
+JsonNode JsonUtils::assembleFromFiles(const JsonNode & files, const JsonParsingSettings & settings, bool & isValid)
 {
 	if (files.isVector())
 	{
 		assert(!files.getModScope().empty());
 		auto configList = files.convertTo<std::vector<std::string> >();
-		JsonNode result = JsonUtils::assembleFromFiles(configList, files.getModScope(), isValid);
+		JsonNode result = JsonUtils::assembleFromFiles(configList, files.getModScope(), {}, isValid);
 
 		return result;
 	}
@@ -306,16 +312,16 @@ JsonNode JsonUtils::assembleFromFiles(const JsonNode & files, bool & isValid)
 JsonNode JsonUtils::assembleFromFiles(const JsonNode & files)
 {
 	bool isValid = false;
-	return assembleFromFiles(files, isValid);
+	return assembleFromFiles(files, {}, isValid);
 }
 
 JsonNode JsonUtils::assembleFromFiles(const std::vector<std::string> & files)
 {
 	bool isValid = false;
-	return assembleFromFiles(files, "", isValid);
+	return assembleFromFiles(files, "", {}, isValid);
 }
 
-JsonNode JsonUtils::assembleFromFiles(const std::vector<std::string> & files, std::string modName, bool & isValid)
+JsonNode JsonUtils::assembleFromFiles(const std::vector<std::string> & files, std::string modName, const JsonParsingSettings & settings, bool & isValid)
 {
 	isValid = true;
 	JsonNode result;
@@ -327,7 +333,7 @@ JsonNode JsonUtils::assembleFromFiles(const std::vector<std::string> & files, st
 		if (CResourceHandler::get(modName)->existsResource(path))
 		{
 			bool isValidFile = false;
-			JsonNode section(JsonPath::builtinTODO(file), modName, isValidFile);
+			JsonNode section(JsonPath::builtinTODO(file), settings, modName, isValidFile);
 			merge(result, section);
 			isValid |= isValidFile;
 		}

--- a/lib/json/JsonUtils.h
+++ b/lib/json/JsonUtils.h
@@ -45,9 +45,10 @@ namespace JsonUtils
 	 * @param files - list of filenames with parts of json structure
 	 */
 	DLL_LINKAGE JsonNode assembleFromFiles(const JsonNode & files);
-	DLL_LINKAGE JsonNode assembleFromFiles(const JsonNode & files, bool & isValid);
+	DLL_LINKAGE JsonNode assembleFromFiles(const JsonNode & files, const JsonParsingSettings & settings);
+	DLL_LINKAGE JsonNode assembleFromFiles(const JsonNode & files, const JsonParsingSettings & settings, bool & isValid);
 	DLL_LINKAGE JsonNode assembleFromFiles(const std::vector<std::string> & files);
-	DLL_LINKAGE JsonNode assembleFromFiles(const std::vector<std::string> & files, std::string modName, bool & isValid);
+	DLL_LINKAGE JsonNode assembleFromFiles(const std::vector<std::string> & files, std::string modName, const JsonParsingSettings & settings, bool & isValid);
 
 	/// This version loads all files with same name (overridden by mods)
 	DLL_LINKAGE JsonNode assembleFromFiles(const std::string & filename);

--- a/lib/modding/CModHandler.cpp
+++ b/lib/modding/CModHandler.cpp
@@ -237,12 +237,14 @@ void CModHandler::initializeConfig()
 void CModHandler::loadTranslation(const TModID & modName)
 {
 	const auto & mod = getModInfo(modName);
+	JsonParsingSettings settings;
+	settings.strict	= true; // weblate requirement
 
 	std::string preferredLanguage = LIBRARY->generaltexth->getPreferredLanguage();
 	std::string modBaseLanguage = getModInfo(modName).getBaseLanguage();
 
-	JsonNode baseTranslation = JsonUtils::assembleFromFiles(mod.getLocalConfig()["translations"]);
-	JsonNode extraTranslation = JsonUtils::assembleFromFiles(mod.getLocalConfig()[preferredLanguage]["translations"]);
+	JsonNode baseTranslation = JsonUtils::assembleFromFiles(mod.getLocalConfig()["translations"], settings);
+	JsonNode extraTranslation = JsonUtils::assembleFromFiles(mod.getLocalConfig()[preferredLanguage]["translations"], settings);
 
 	LIBRARY->generaltexth->loadTranslationOverrides(modName, modBaseLanguage, baseTranslation);
 	LIBRARY->generaltexth->loadTranslationOverrides(modName, preferredLanguage, extraTranslation);

--- a/lib/modding/ContentTypeHandler.cpp
+++ b/lib/modding/ContentTypeHandler.cpp
@@ -61,7 +61,7 @@ ContentTypeHandler::ContentTypeHandler(IHandlerBase * handler, const std::string
 bool ContentTypeHandler::preloadModData(const std::string & modName, const JsonNode & fileList, bool validate)
 {
 	bool result = true;
-	JsonNode data = JsonUtils::assembleFromFiles(fileList, result);
+	JsonNode data = JsonUtils::assembleFromFiles(fileList, {}, result);
 	data.setModScope(modName);
 
 	ModInfo & modInfo = modData[modName];

--- a/lib/texts/TextLocalizationContainer.cpp
+++ b/lib/texts/TextLocalizationContainer.cpp
@@ -161,11 +161,19 @@ void TextLocalizationContainer::exportAllTexts(std::map<std::string, ExportedStr
 		std::string modName = entry.second.baseStringModContext;
 		std::string originalMod = entry.second.identifierModContext;
 
-		if (modName == originalMod && modName.find('.') != std::string::npos)
-			modName = modName.substr(0, modName.find('.'));
-		else
+		if (modName != originalMod)
+		{
+			// this is string patching - one mod modified string from another mod
 			if (!vstd::contains(storage[modName].overridenMods, originalMod))
 				storage[modName].overridenMods.push_back(originalMod);
+		}
+		else
+		{
+			// move string to translation of base mod, for more convenient translation of scattered strings
+			// except for maps / compaigns - those are usually kept in separate submod, so keep translations separate to group maps and game translations separate
+			if (modName.find('.') != std::string::npos && !entry.first.starts_with("map.") && !entry.first.starts_with("campaign."))
+				modName = modName.substr(0, modName.find('.'));
+		}
 
 		if (!textToWrite.empty())
 			storage[modName].strings[entry.first] = textToWrite;

--- a/lib/texts/TextLocalizationContainer.cpp
+++ b/lib/texts/TextLocalizationContainer.cpp
@@ -145,7 +145,7 @@ bool TextLocalizationContainer::identifierExists(const TextIdentifier & UID) con
 	return stringsLocalizations.count(UID.get());
 }
 
-void TextLocalizationContainer::exportAllTexts(std::map<std::string, std::map<std::string, std::string>> & storage, bool onlyMissing) const
+void TextLocalizationContainer::exportAllTexts(std::map<std::string, ExportedStrings> & storage, bool onlyMissing) const
 {
 	std::lock_guard globalLock(globalTextMutex);
 
@@ -157,18 +157,18 @@ void TextLocalizationContainer::exportAllTexts(std::map<std::string, std::map<st
 		if (onlyMissing && entry.second.overriden)
 			continue;
 
-		std::string textToWrite;
+		std::string textToWrite = entry.second.translatedText;
 		std::string modName = entry.second.baseStringModContext;
+		std::string originalMod = entry.second.identifierModContext;
 
-		if (entry.second.baseStringModContext == entry.second.identifierModContext && modName.find('.') != std::string::npos)
+		if (modName == originalMod && modName.find('.') != std::string::npos)
 			modName = modName.substr(0, modName.find('.'));
-
-		boost::range::replace(modName, '.', '_');
-
-		textToWrite = entry.second.translatedText;
+		else
+			if (!vstd::contains(storage[modName].overridenMods, originalMod))
+				storage[modName].overridenMods.push_back(originalMod);
 
 		if (!textToWrite.empty())
-			storage[modName][entry.first] = textToWrite;
+			storage[modName].strings[entry.first] = textToWrite;
 	}
 }
 

--- a/lib/texts/TextLocalizationContainer.h
+++ b/lib/texts/TextLocalizationContainer.h
@@ -15,6 +15,15 @@ VCMI_LIB_NAMESPACE_BEGIN
 
 class JsonNode;
 
+struct ExportedStrings
+{
+	/// Strings (string ID -> translation) that were added by this mod
+	std::map<std::string, std::string> strings;
+
+	/// mods that had one or more of their strings overriden by this mod
+	std::vector<std::string> overridenMods;
+};
+
 class DLL_LINKAGE TextLocalizationContainer
 {
 protected:
@@ -79,7 +88,7 @@ public:
 
 	/// Debug method, returns all currently stored texts
 	/// Format: [mod ID][string ID] -> human-readable text
-	void exportAllTexts(std::map<std::string, std::map<std::string, std::string>> & storage, bool onlyMissing) const;
+	void exportAllTexts(std::map<std::string, ExportedStrings> & storage, bool onlyMissing) const;
 
 	/// Add or override subcontainer which can store identifiers
 	void addSubContainer(const TextLocalizationContainer & container);

--- a/serverapp/EntryPoint.cpp
+++ b/serverapp/EntryPoint.cpp
@@ -19,6 +19,10 @@
 #include "../lib/filesystem/Filesystem.h"
 #include "../lib/modding/CModHandler.h"
 #include "../lib/modding/ModManager.h"
+#include "callback/EditorCallback.h"
+#include "campaign/CampaignHandler.h"
+#include "mapping/CMap.h"
+#include "mapping/CMapService.h"
 #include "modding/ModDescription.h"
 #include "texts/CGeneralTextHandler.h"
 
@@ -62,7 +66,68 @@ static void generateTranslations(const std::string & modID)
 	LIBRARY = new GameLibrary;
 	LIBRARY->initializeFilesystem(false);
 	LIBRARY->initializeLibrary();
-	LIBRARY->generaltexth->exportAllTexts(textsByMod, false);
+
+	{
+		CMapService mapService;
+
+		logGlobal->info("Searching for available maps");
+		std::unordered_set<ResourcePath> mapList = CResourceHandler::get()->getFilteredFiles([&](const ResourcePath & ident)
+		{
+			return ident.getType() == EResType::MAP;
+		});
+
+		std::vector<std::unique_ptr<CMap>> loadedMaps;
+		std::vector<std::shared_ptr<CampaignState>> loadedCampaigns;
+
+		logGlobal->info("Loading maps for export");
+		for (auto const & mapName : mapList)
+		{
+			try
+			{
+				std::string mapModName = LIBRARY->modh->findResourceOrigin(mapName);
+				if (mapModName != modID && !mapModName.starts_with(modID + '.'))
+					continue;
+
+				EditorCallback cb(nullptr);
+				// load and drop loaded map - we only need loader to run over all maps
+				loadedMaps.push_back(mapService.loadMap(mapName, &cb));
+			}
+			catch(std::exception & e)
+			{
+				logGlobal->warn("Map %s is invalid. Message: %s", mapName.getName(), e.what());
+			}
+		}
+
+		logGlobal->info("Searching for available campaigns");
+		std::unordered_set<ResourcePath> campaignList = CResourceHandler::get()->getFilteredFiles([&](const ResourcePath & ident)
+		{
+			return ident.getType() == EResType::CAMPAIGN;
+		});
+
+		logGlobal->info("Loading campaigns for export");
+		for (auto const & campaignName : campaignList)
+		{
+			try
+			{
+				std::string campaignModName = LIBRARY->modh->findResourceOrigin(campaignName);
+				if (campaignModName != modID && !campaignModName.starts_with(modID + '.'))
+					continue;
+
+				loadedCampaigns.push_back(CampaignHandler::getCampaign(campaignName.getName()));
+				for (auto const & part : loadedCampaigns.back()->allScenarios())
+				{
+					EditorCallback cb(nullptr);
+					loadedCampaigns.back()->getMap(part, &cb);
+				}
+			}
+			catch(std::exception & e)
+			{
+				logGlobal->warn("Campaign %s is invalid. Message: %s", campaignName.getName(), e.what());
+			}
+		}
+
+		LIBRARY->generaltexth->exportAllTexts(textsByMod, false);
+	}
 
 	for(const auto & modEntry : textsByMod)
 	{
@@ -106,7 +171,7 @@ static void generateTranslations(const std::string & modID)
 		{
 			std::string preferredLanguage = LIBRARY->generaltexth->getPreferredLanguage();
 			std::string filename = boost::replace_all_copy(modEntry.first, ".", "/Mods/");
-			const boost::filesystem::path dirPath = outPath / filename / "Content/config/translation/";
+			const boost::filesystem::path dirPath = outPath / filename / "Content/translation/";
 			boost::filesystem::create_directories(dirPath);
 			const boost::filesystem::path filePath = dirPath / (preferredLanguage + ".json");
 			std::ofstream file(filePath.c_str());

--- a/serverapp/EntryPoint.cpp
+++ b/serverapp/EntryPoint.cpp
@@ -16,11 +16,108 @@
 #include "../lib/VCMIDirs.h"
 #include "../lib/GameLibrary.h"
 #include "../lib/CConfigHandler.h"
+#include "../lib/filesystem/Filesystem.h"
+#include "../lib/modding/CModHandler.h"
+#include "../lib/modding/ModManager.h"
+#include "modding/ModDescription.h"
+#include "texts/CGeneralTextHandler.h"
 
 #include <boost/program_options.hpp>
 
 static const std::string SERVER_NAME_AFFIX = "server";
 static const std::string SERVER_NAME = GameConstants::VCMI_VERSION + std::string(" (") + SERVER_NAME_AFFIX + ')';
+
+static void generateTranslations(const std::string & modID)
+{
+	LIBRARY = new GameLibrary;
+	LIBRARY->loadFilesystem(false);
+	settings.init("config/settings.json", "vcmi:settings");
+
+	ModManager mods;
+
+	if (!mods.isModActive(modID))
+		mods.tryEnableMods({modID});
+
+	for (const auto & submod : mods.getModSettings(modID))
+	{
+		try
+		{
+			if (!submod.second)
+				mods.tryEnableMods({modID + '.' + submod.first});
+		}
+		catch (const std::exception &)
+		{
+			// failed to enable mod - ignore, will be logged later
+		}
+	}
+
+	for (const auto & submod : mods.getModSettings(modID))
+		if (!submod.second)
+			logGlobal->warn("Failed to enable submod %s", submod.first);
+
+	std::map<std::string, ExportedStrings> textsByMod;
+	std::vector<std::string> modsWithOverrides;
+
+	delete LIBRARY;
+	LIBRARY = new GameLibrary;
+	LIBRARY->initializeFilesystem(false);
+	LIBRARY->initializeLibrary();
+	LIBRARY->generaltexth->exportAllTexts(textsByMod, false);
+
+	for(const auto & modEntry : textsByMod)
+	{
+		if (modEntry.first.find('.') != std::string::npos)
+		{
+			for (const auto & otherModID : modEntry.second.overridenMods)
+			{
+				if (otherModID == modID || otherModID.starts_with(modID + '.'))
+				{
+					modsWithOverrides.push_back(modEntry.first);
+					break;
+				}
+			}
+		}
+	}
+
+	const boost::filesystem::path outPath = VCMIDirs::get().userExtractedPath() / "translationFull";
+	boost::filesystem::create_directories(outPath);
+
+	for (const auto & modWithOverrides : modsWithOverrides)
+		mods.tryDisableMod(modWithOverrides);
+
+	CResourceHandler::destroy();
+	delete LIBRARY;
+	LIBRARY = new GameLibrary;
+	LIBRARY->initializeFilesystem(false);
+	LIBRARY->initializeLibrary();
+	LIBRARY->generaltexth->exportAllTexts(textsByMod, false);
+
+	for(const auto & modEntry : textsByMod)
+	{
+		JsonNode output;
+
+		if (modEntry.first != modID && !modEntry.first.starts_with(modID + '.'))
+			continue;
+
+		for(const auto & stringEntry : modEntry.second.strings)
+			output[stringEntry.first].String() = stringEntry.second;
+
+		if (!output.isNull())
+		{
+			std::string preferredLanguage = LIBRARY->generaltexth->getPreferredLanguage();
+			std::string filename = boost::replace_all_copy(modEntry.first, ".", "/Mods/");
+			const boost::filesystem::path dirPath = outPath / filename / "Content/config/translation/";
+			boost::filesystem::create_directories(dirPath);
+			const boost::filesystem::path filePath = dirPath / (preferredLanguage + ".json");
+			std::ofstream file(filePath.c_str());
+			file << output.toString();
+		}
+	}
+
+	logGlobal->info("Translation export complete");
+	logGlobal->info("Extracted files can be found in " + outPath.string() + " directory\n");
+
+}
 
 static void handleCommandOptions(int argc, const char * argv[], boost::program_options::variables_map & options)
 {
@@ -30,6 +127,7 @@ static void handleCommandOptions(int argc, const char * argv[], boost::program_o
 	("version,v", "display version information and exit")
 	("run-by-client", "indicate that server launched by client on same machine")
 	("dummy-run", "Shutdown immediately after loading was sucessful")
+	("translate-mod", boost::program_options::value<std::string>(), "Export translations for specified mod")
 	("port", boost::program_options::value<ui16>(), "port at which server will listen to connections from client")
 	("lobby", "start server in lobby mode in which server connects to a global lobby");
 
@@ -56,6 +154,13 @@ static void handleCommandOptions(int argc, const char * argv[], boost::program_o
 		printf("warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.\n");
 		printf("\n");
 		std::cout << opts;
+		exit(0);
+	}
+
+	if(options.count("translate-mod"))
+	{
+		std::string modID = options["translate-mod"].as<std::string>();
+		generateTranslations(modID);
 		exit(0);
 	}
 


### PR DESCRIPTION
Better version of translation exporting logic. Compared to existiing version it:
- places generated json's in same directory structure as recommended for mods (`modname/Content/translation/language.json`). Files are placed in the same directory as before (`exported`) to reduce chance of information loss on overwrite
- (mostly) correctly handled mods that overwrite strings from another submod of the same mod. For now only simple cases are handled (within same mod, and without long overwrite chains), which seems to be sufficient for existing mods

New translation is done by server (vcmiserver / VCMI_Server.exe) and not by client command - this is due to reloading of library in runtime which at the moment can't be done on client, especially during ongoing game

Targeting beta - should be safe, worst-case scenario is broken modder-only feature, and I'd like to have it in beta branch since this is what we're using for mods CI runs