### PR TITLE
[1.8.0] Center scenario selection

### DIFF
--- a/client/lobby/CLobbyScreen.cpp
+++ b/client/lobby/CLobbyScreen.cpp
@@ -24,6 +24,7 @@
 #include "../gui/Shortcut.h"
 #include "../widgets/Buttons.h"
 #include "../widgets/GraphicalPrimitiveCanvas.h"
+#include "../widgets/Images.h"
 #include "../windows/InfoWindows.h"
 #include "../render/Colors.h"
 #include "../globalLobby/GlobalLobbyClient.h"
@@ -130,6 +131,18 @@ CLobbyScreen::CLobbyScreen(ESelectionScreen screenType, bool hideScreen)
 		if (wasInLobbyRoom)
 			GAME->server().getGlobalLobby().activateInterface();
 	}, EShortcut::GLOBAL_CANCEL);
+
+	if(screenType == ESelectionScreen::newGame || screenType == ESelectionScreen::loadGame)
+	{
+		const Point contentOffset(19, 0);
+		for(CIntObject * child : children)
+		{
+			if(!child || child == background.get())
+				continue;
+
+			child->moveBy(contentOffset);
+		}
+	}
 
 	if(hideScreen) // workaround to avoid confusing players by custom campaign list displaying for a few ms -> instead of this draw a black screen while "loading"
 	{
@@ -281,6 +294,9 @@ void CLobbyScreen::updateAfterStateChange()
 	{
 		tabBattleOnlyMode = std::make_shared<BattleOnlyModeTab>();
 		tabBattleOnlyMode->setEnabled(false);
+
+		if(screenType == ESelectionScreen::newGame || screenType == ESelectionScreen::loadGame)
+			tabBattleOnlyMode->moveBy(Point(19, 0));
 
 		if(GAME->server().battleMode)
 			toggleTab(tabBattleOnlyMode);

--- a/client/lobby/CLobbyScreen.cpp
+++ b/client/lobby/CLobbyScreen.cpp
@@ -132,7 +132,7 @@ CLobbyScreen::CLobbyScreen(ESelectionScreen screenType, bool hideScreen)
 			GAME->server().getGlobalLobby().activateInterface();
 	}, EShortcut::GLOBAL_CANCEL);
 
-	if(screenType == ESelectionScreen::newGame || screenType == ESelectionScreen::loadGame)
+	if((screenType == ESelectionScreen::newGame || screenType == ESelectionScreen::loadGame) && !ENGINE->isDemoData())
 	{
 		const Point contentOffset(19, 0);
 		for(CIntObject * child : children)
@@ -295,7 +295,7 @@ void CLobbyScreen::updateAfterStateChange()
 		tabBattleOnlyMode = std::make_shared<BattleOnlyModeTab>();
 		tabBattleOnlyMode->setEnabled(false);
 
-		if(screenType == ESelectionScreen::newGame || screenType == ESelectionScreen::loadGame)
+		if((screenType == ESelectionScreen::newGame || screenType == ESelectionScreen::loadGame) && !ENGINE->isDemoData())
 			tabBattleOnlyMode->moveBy(Point(19, 0));
 
 		if(GAME->server().battleMode)

--- a/client/lobby/CLobbyScreen.cpp
+++ b/client/lobby/CLobbyScreen.cpp
@@ -132,6 +132,7 @@ CLobbyScreen::CLobbyScreen(ESelectionScreen screenType, bool hideScreen)
 			GAME->server().getGlobalLobby().activateInterface();
 	}, EShortcut::GLOBAL_CANCEL);
 
+	// Make sure scenario selection is centered
 	if((screenType == ESelectionScreen::newGame || screenType == ESelectionScreen::loadGame) && !ENGINE->isDemoData())
 	{
 		const Point contentOffset(19, 0);
@@ -295,6 +296,7 @@ void CLobbyScreen::updateAfterStateChange()
 		tabBattleOnlyMode = std::make_shared<BattleOnlyModeTab>();
 		tabBattleOnlyMode->setEnabled(false);
 
+		// Make sure scenario selection is centered
 		if((screenType == ESelectionScreen::newGame || screenType == ESelectionScreen::loadGame) && !ENGINE->isDemoData())
 			tabBattleOnlyMode->moveBy(Point(19, 0));
 


### PR DESCRIPTION
We can easily "center" scenario options. but there are side effects for mods, when game selection background have black square in image.. OH3 images are fine and they are full images.

<img width="1355" height="847" alt="image" src="https://github.com/user-attachments/assets/a9e1b85c-c323-47bd-817c-2c115bf74cca" />

<img width="1355" height="847" alt="image" src="https://github.com/user-attachments/assets/d1dbfda9-a113-467b-9254-996538e4281e" />

HotA images are not full images and will create 19px black line: https://github.com/vcmi-mods/horn-of-the-abyss/blob/vcmi-1.7/mods/mainMenu/content/data/gamselb7.png

HotA main menu backgrounds can be now easily fixed by adding missing 19px. All images were fullfilled using Gemini. So all required assets for future use are prepared and can be easily updated.

[hota-gameselbk-AI-fill.zip](https://github.com/user-attachments/files/27416768/hota-gameselbk-AI-fill.zip)
