### PR TITLE
[1.8.0] Center scenario selection

### DIFF
--- a/client/lobby/CLobbyScreen.cpp
+++ b/client/lobby/CLobbyScreen.cpp
@@ -24,6 +24,7 @@
 #include "../gui/Shortcut.h"
 #include "../widgets/Buttons.h"
 #include "../widgets/GraphicalPrimitiveCanvas.h"
+#include "../widgets/Images.h"
 #include "../windows/InfoWindows.h"
 #include "../render/Colors.h"
 #include "../globalLobby/GlobalLobbyClient.h"

--- a/client/lobby/CLobbyScreen.cpp
+++ b/client/lobby/CLobbyScreen.cpp
@@ -125,15 +125,18 @@ CLobbyScreen::CLobbyScreen(ESelectionScreen screenType, bool hideScreen)
 	}, EShortcut::GLOBAL_CANCEL);
 
 	// Make sure scenario selection is centered
-	if(screenType == ESelectionScreen::newGame || screenType == ESelectionScreen::loadGame)
+	if(settings["general"]["enableUiEnhancements"].Bool())
 	{
-		const Point contentOffset(19, 0);
-		for(CIntObject * child : children)
+		if(screenType == ESelectionScreen::newGame || screenType == ESelectionScreen::loadGame)
 		{
-			if(!child || child == background.get())
-				continue;
-
-			child->moveBy(contentOffset);
+			const Point contentOffset(19, 0);
+			for(CIntObject * child : children)
+			{
+				if(!child || child == background.get())
+					continue;
+	
+				child->moveBy(contentOffset);
+			}
 		}
 	}
 
@@ -289,8 +292,11 @@ void CLobbyScreen::updateAfterStateChange()
 		tabBattleOnlyMode->setEnabled(false);
 
 		// Make sure scenario selection is centered
-		if(screenType == ESelectionScreen::newGame || screenType == ESelectionScreen::loadGame)
-			tabBattleOnlyMode->moveBy(Point(19, 0));
+		if(settings["general"]["enableUiEnhancements"].Bool())
+		{
+			if(screenType == ESelectionScreen::newGame || screenType == ESelectionScreen::loadGame)
+				tabBattleOnlyMode->moveBy(Point(19, 0));
+		}
 
 		if(GAME->server().battleMode)
 			toggleTab(tabBattleOnlyMode);

--- a/client/lobby/CLobbyScreen.cpp
+++ b/client/lobby/CLobbyScreen.cpp
@@ -123,6 +123,19 @@ CLobbyScreen::CLobbyScreen(ESelectionScreen screenType, bool hideScreen)
 			GAME->server().getGlobalLobby().activateInterface();
 	}, EShortcut::GLOBAL_CANCEL);
 
+	// Make sure scenario selection is centered
+	if(screenType == ESelectionScreen::newGame || screenType == ESelectionScreen::loadGame)
+	{
+		const Point contentOffset(19, 0);
+		for(CIntObject * child : children)
+		{
+			if(!child || child == background.get())
+				continue;
+
+			child->moveBy(contentOffset);
+		}
+	}
+
 	if(hideScreen) // workaround to avoid confusing players by custom campaign list displaying for a few ms -> instead of this draw a black screen while "loading"
 	{
 		blackScreen = std::make_shared<GraphicalPrimitiveCanvas>(Rect(Point(0, 0), pos.dimensions()));
@@ -273,6 +286,10 @@ void CLobbyScreen::updateAfterStateChange()
 	{
 		tabBattleOnlyMode = std::make_shared<BattleOnlyModeTab>();
 		tabBattleOnlyMode->setEnabled(false);
+
+		// Make sure scenario selection is centered
+		if(screenType == ESelectionScreen::newGame || screenType == ESelectionScreen::loadGame)
+			tabBattleOnlyMode->moveBy(Point(19, 0));
 
 		if(GAME->server().battleMode)
 			toggleTab(tabBattleOnlyMode);


### PR DESCRIPTION
Now it's possible to center Scenario selection screen

<img width="877" height="665" alt="image" src="https://github.com/user-attachments/assets/650964b3-df4e-4d35-98a2-3e06d767d892" />

<img width="848" height="656" alt="image" src="https://github.com/user-attachments/assets/bbc53fca-b7ab-49b3-906b-761d03f0d3af" />


HotA backgrounds gaps are already solved in: https://github.com/vcmi-mods/horn-of-the-abyss/pull/613
So HotA mod version bump is enough after release.

<img width="834" height="639" alt="image" src="https://github.com/user-attachments/assets/87747559-2357-4ac1-8d7d-374ecd43f8bf" />
