### PR TITLE
[AI/NK2] Fix hero-chain path reconstruction and exchange semantics

### DIFF
--- a/AI/Nullkiller2/Analyzers/ArmyManager.cpp
+++ b/AI/Nullkiller2/Analyzers/ArmyManager.cpp
@@ -195,6 +195,10 @@ std::vector<SlotInfo> ArmyManager::getBestArmy(const IBonusBearer * armyCarrier,
 	uint64_t armyValue = 0;
 	TemporaryArmy newArmyInstance;
 
+	const auto & badMoraleChance = cpsic->getSettings().getVector(EGameSettings::COMBAT_BAD_MORALE_CHANCE);
+	const auto & highMoraleChance = cpsic->getSettings().getVector(EGameSettings::COMBAT_GOOD_MORALE_CHANCE);
+	int moraleDiceSize = cpsic->getSettings().getInteger(EGameSettings::COMBAT_MORALE_DICE_SIZE);
+
 	while(allowedFactions.size() < alignmentMap.size())
 	{
 		auto strongestAlignment = vstd::maxElementByFun(alignmentMap, [&](std::pair<FactionID, uint64_t> pair) -> uint64_t
@@ -228,10 +232,6 @@ std::vector<SlotInfo> ArmyManager::getBestArmy(const IBonusBearer * armyCarrier,
 		{
 			auto morale = slot.second->moraleVal();
 			auto multiplier = 1.0f;
-
-			const auto & badMoraleChance = cpsic->getSettings().getVector(EGameSettings::COMBAT_BAD_MORALE_CHANCE);
-			const auto & highMoraleChance = cpsic->getSettings().getVector(EGameSettings::COMBAT_GOOD_MORALE_CHANCE);
-			int moraleDiceSize = cpsic->getSettings().getInteger(EGameSettings::COMBAT_MORALE_DICE_SIZE);
 
 			if(morale < 0 && !badMoraleChance.empty())
 			{

--- a/AI/Nullkiller2/Analyzers/ObjectClusterizer.cpp
+++ b/AI/Nullkiller2/Analyzers/ObjectClusterizer.cpp
@@ -221,7 +221,7 @@ void ObjectClusterizer::onObjectRemoved(ObjectInstanceID id)
 	vstd::erase_if_present(invalidated, id);
 
 	NK2AI::ClusterMap::accessor cluster;
-	
+
 	if(blockedObjects.find(cluster, id))
 	{
 		for(auto & unlocked : cluster->second->objects)
@@ -299,13 +299,13 @@ void ObjectClusterizer::clusterize()
 
 	if(isUpToDate && invalidated.empty())
 		return;
-		
+
 	auto start = std::chrono::high_resolution_clock::now();
 
 	logAi->debug("Begin object clusterization");
 
 	std::vector<const CGObjectInstance *> objs;
-	
+
 	if(isUpToDate)
 	{
 		for(auto id : invalidated)

--- a/AI/Nullkiller2/Goals/ExecuteHeroChain.cpp
+++ b/AI/Nullkiller2/Goals/ExecuteHeroChain.cpp
@@ -190,13 +190,24 @@ void ExecuteHeroChain::accept(AIGateway * aiGw)
 
 					if(targetNode->accessible == EPathAccessibility::NOT_SET
 						|| targetNode->accessible == EPathAccessibility::BLOCKED
-						|| targetNode->accessible == EPathAccessibility::FLYABLE
-						|| targetNode->turns != 0)
+						|| targetNode->accessible == EPathAccessibility::FLYABLE)
 					{
 						logAi->error(
 							"Unable to complete chain. Expected hero %s to arrive to %s in 0 turns but he cannot do this",
 							hero->getNameTranslated(),
 							node->coord.toString());
+
+						return;
+					}
+
+					if(targetNode->turns != 0)
+					{
+						logAi->debug(
+							"Stopping stale hero chain for %s: expected immediate move to %s, but live path now takes %d turns with %d MP left",
+							hero->getNameTranslated(),
+							node->coord.toString(),
+							static_cast<int>(targetNode->turns),
+							hero->movementPointsRemaining());
 
 						return;
 					}

--- a/AI/Nullkiller2/Goals/ExecuteHeroChain.cpp
+++ b/AI/Nullkiller2/Goals/ExecuteHeroChain.cpp
@@ -245,7 +245,7 @@ void ExecuteHeroChain::accept(AIGateway * aiGw)
 							CGPath path;
 							bool isOk = aiGw->nullkiller->getPathsInfo(hero)->getPath(path, node->coord);
 
-							if(isOk && path.nodes.back().turns > 0)
+							if(isOk && path.nodes.front().turns > 0)
 							{
 								logAi->warn("Hero %s has %d mp which is not enough to continue his way towards %s.", hero->getNameTranslated(), hero->movementPointsRemaining(), node->coord.toString());
 

--- a/AI/Nullkiller2/Goals/ExecuteHeroChain.cpp
+++ b/AI/Nullkiller2/Goals/ExecuteHeroChain.cpp
@@ -154,6 +154,10 @@ void ExecuteHeroChain::accept(AIGateway * aiGw)
 
 						return;
 					}
+
+					// hero can be already on the target tile after move in specialAction->execute()
+					if(node->coord == heroPtr->visitablePos())
+						continue;
 				}
 				else if(i > 0 && aiGw->nullkiller->isObjectGraphAllowed())
 				{

--- a/AI/Nullkiller2/Markers/HeroExchange.cpp
+++ b/AI/Nullkiller2/Markers/HeroExchange.cpp
@@ -13,6 +13,7 @@
 #include "../Engine/Nullkiller.h"
 #include "../AIUtility.h"
 #include "../Analyzers/ArmyManager.h"
+#include "../../../lib/mapping/TerrainTile.h"
 
 namespace NK2AI
 {
@@ -31,8 +32,13 @@ std::string HeroExchange::toString() const
 
 uint64_t HeroExchange::getReinforcementArmyStrength(const Nullkiller * aiNk) const
 {
-	uint64_t armyValue = aiNk->armyManager->howManyReinforcementsCanGet(hero, exchangePath.heroArmy);
-	return armyValue;
+	assert(exchangePath.targetHero && exchangePath.heroArmy);
+
+	return aiNk->armyManager->howManyReinforcementsCanGet(
+		hero,
+		hero,
+		exchangePath.heroArmy,
+		aiNk->cc->getTile(exchangePath.targetTile())->getTerrainID());
 }
 
 }

--- a/AI/Nullkiller2/Pathfinding/AINodeStorage.cpp
+++ b/AI/Nullkiller2/Pathfinding/AINodeStorage.cpp
@@ -762,39 +762,26 @@ void HeroChainCalculationTask::calculateHeroChain(
 			}
 		}
 
-		// Retry with timeout to prevent livelock using exponential backoff
-		constexpr auto maxDelay = std::chrono::milliseconds(16);
-		auto currentDelay = std::chrono::milliseconds(1);
-		constexpr int maxRetries = 7;
-
-		for(int attempt = 0; attempt < maxRetries; ++attempt)
+		const auto exchangeResult = carrier->actor->tryExchangeNoLock(other->actor);
+		if(exchangeResult.lockAcquired)
 		{
-			const auto exchangeResult = carrier->actor->tryExchangeNoLock(other->actor);
-			if(exchangeResult.lockAcquired)
+			if (exchangeResult.actor)
 			{
-				if (exchangeResult.actor)
+				if(exchangeResult.actor->hero != carrier->actor->hero)
 				{
-					if(exchangeResult.actor->hero != carrier->actor->hero)
-					{
 #if NK2AI_PATHFINDER_TRACE_LEVEL >= 1
-						logAi->trace(
-			"HeroChainCalculationTask::calculateHeroChain exchange direction mismatch: result=%s, carrier=%s, other=%s",
+					logAi->trace(
+		"HeroChainCalculationTask::calculateHeroChain exchange direction mismatch: result=%s, carrier=%s, other=%s",
 						exchangeResult.actor->toString(),
-							carrier->actor->toString(),
-							other->actor->toString());
+					carrier->actor->toString(),
+					other->actor->toString());
 #endif
-						return;
-					}
-					result.push_back(calculateExchange(exchangeResult.actor, carrier, other));
+					return;
 				}
-				return;
+				result.push_back(calculateExchange(exchangeResult.actor, carrier, other));
 			}
-
-			std::this_thread::sleep_for(currentDelay);
-			currentDelay = std::min(currentDelay * 2, maxDelay);
+			return;
 		}
-
-		logAi->warn("HeroChainCalculationTask::calculateHeroChain failed to lock actors");
 	}
 }
 

--- a/AI/Nullkiller2/Pathfinding/AINodeStorage.cpp
+++ b/AI/Nullkiller2/Pathfinding/AINodeStorage.cpp
@@ -1442,8 +1442,18 @@ void AINodeStorage::calculateChainInfo(std::vector<AIPath> & paths, const int3 &
 		path.targetHero = node.actor->hero;
 		path.heroArmy = node.actor->creatureSet;
 		path.armyLoss = node.armyLoss;
+		path.chainMask = node.actor->chainMask;
 
-		fillChainInfo(&node, path, -1);
+		RealMoveMasksByHero realMoveMasks;
+		int parentIndex = -1;
+		if(!tryReconstructChainInfo(&node, path, parentIndex, realMoveMasks))
+		{
+#if NK2AI_PATHFINDER_TRACE_LEVEL >= 2
+			logAi->trace("AINodeStorage::calculateChainInfo Skip conflicting reconstructed chain path %s", path.toString());
+#endif
+			paths.pop_back();
+			continue;
+		}
 		path.targetObjectDanger = aiNk->dangerEvaluator->evaluateDanger(pos, path.targetHero, !node.actor->allowBattle);
 		for(const auto & pathNode : path.nodes)
 		{
@@ -1487,46 +1497,83 @@ void AINodeStorage::calculateChainInfo(std::vector<AIPath> & paths, const int3 &
 			path.targetHero,
 			getHeroArmyStrengthWithCommander(path.targetHero, path.heroArmy, fortLevel),
 			path.targetObjectDanger);
-
-		path.chainMask = node.actor->chainMask;
 		path.exchangeCount = node.actor->actorExchangeCount;
 	}
 }
 
-void AINodeStorage::fillChainInfo(const AIPathNode * node, AIPath & path, int parentIndex) const
+bool AINodeStorage::tryReconstructChainInfo(const AIPathNode * node, AIPath & path,	int & parentIndex, RealMoveMasksByHero & realMoveMasks) const
 {
 	while(node != nullptr)
 	{
 		if(!node->actor->hero)
-			return;
+			return true;
+
+		const auto tryAppendCurrentNode = [this, &node](AIPath & candidatePath, int candidateParentIndex,
+																										RealMoveMasksByHero & candidateMasks) -> std::optional<int>
+		{
+			if(isRealMovementNode(node))
+			{
+				auto existingMask = candidateMasks.find(node->actor->hero);
+				if(existingMask != candidateMasks.end() && existingMask->second != node->actor->chainMask)
+					return std::nullopt;
+			}
+
+			AIPathNodeInfo pathNode;
+			pathNode.cost = node->getCost();
+			pathNode.targetHero = node->actor->hero;
+			pathNode.chainMask = node->actor->chainMask;
+			pathNode.specialAction = node->specialAction;
+			pathNode.turns = node->turns;
+			pathNode.danger = node->danger;
+			pathNode.coord = node->coord;
+			pathNode.parentIndex = candidateParentIndex;
+			pathNode.actionIsBlocked = false;
+			pathNode.layer = node->layer;
+
+			if(pathNode.specialAction)
+			{
+				auto targetNode = node->theNodeBefore ? getAINode(node->theNodeBefore) : node;
+				pathNode.actionIsBlocked = !pathNode.specialAction->canAct(aiNk, targetNode);
+			}
+
+			const int nextParentIndex = static_cast<int>(candidatePath.nodes.size());
+
+			candidatePath.nodes.push_back(pathNode);
+			if(isRealMovementNode(node))
+				candidateMasks[node->actor->hero] = node->actor->chainMask;
+
+			return nextParentIndex;
+		};
 
 		if(node->chainOther)
-			fillChainInfo(node->chainOther, path, parentIndex);
-
-		AIPathNodeInfo pathNode;
-
-		pathNode.cost = node->getCost();
-		pathNode.targetHero = node->actor->hero;
-		pathNode.chainMask = node->actor->chainMask;
-		pathNode.specialAction = node->specialAction;
-		pathNode.turns = node->turns;
-		pathNode.danger = node->danger;
-		pathNode.coord = node->coord;
-		pathNode.parentIndex = parentIndex;
-		pathNode.actionIsBlocked = false;
-		pathNode.layer = node->layer;
-
-		if(pathNode.specialAction)
 		{
-			auto targetNode =node->theNodeBefore ?  getAINode(node->theNodeBefore) : node;
+			AIPath pathWithBranch = path;
+			auto masksWithBranch = realMoveMasks;
+			int parentIndexWithBranch = parentIndex;
 
-			pathNode.actionIsBlocked = !pathNode.specialAction->canAct(aiNk, targetNode);
+			if(!tryReconstructChainInfo(node->chainOther, pathWithBranch, parentIndexWithBranch, masksWithBranch))
+				return false; // Reject path because chainOther branch is conflicting for hero
+
+			auto nextParentIndex = tryAppendCurrentNode(pathWithBranch, parentIndexWithBranch, masksWithBranch);
+			if(!nextParentIndex)
+				return false; // Reject path because current node conflicts after chainOther for hero
+
+			path = std::move(pathWithBranch);
+			realMoveMasks = std::move(masksWithBranch);
+			parentIndex = *nextParentIndex;
+			node = getAINode(node->theNodeBefore);
+			continue;
 		}
 
-		parentIndex = path.nodes.size();
-		path.nodes.push_back(pathNode);
+		auto nextParentIndex = tryAppendCurrentNode(path, parentIndex, realMoveMasks);
+		if(!nextParentIndex)
+			return false;
+
+		parentIndex = *nextParentIndex;
 		node = getAINode(node->theNodeBefore);
 	}
+
+	return true;
 }
 
 AIPath::AIPath()

--- a/AI/Nullkiller2/Pathfinding/AINodeStorage.cpp
+++ b/AI/Nullkiller2/Pathfinding/AINodeStorage.cpp
@@ -762,13 +762,6 @@ void HeroChainCalculationTask::calculateHeroChain(
 			}
 		}
 
-		// Always acquire locks in consistent order to prevent deadlock
-		// Order by memory address to ensure consistent acquisition order
-		const ChainActor * firstActor = carrier->actor;
-		const ChainActor * secondActor = other->actor;
-		if(firstActor > secondActor)
-			std::swap(firstActor, secondActor);
-
 		// Retry with timeout to prevent livelock using exponential backoff
 		constexpr auto maxDelay = std::chrono::milliseconds(16);
 		auto currentDelay = std::chrono::milliseconds(1);
@@ -776,11 +769,24 @@ void HeroChainCalculationTask::calculateHeroChain(
 
 		for(int attempt = 0; attempt < maxRetries; ++attempt)
 		{
-			const auto exchangeResult = firstActor->tryExchangeNoLock(secondActor);
+			const auto exchangeResult = carrier->actor->tryExchangeNoLock(other->actor);
 			if(exchangeResult.lockAcquired)
 			{
 				if (exchangeResult.actor)
+				{
+					if(exchangeResult.actor->hero != carrier->actor->hero)
+					{
+#if NK2AI_PATHFINDER_TRACE_LEVEL >= 1
+						logAi->trace(
+			"HeroChainCalculationTask::calculateHeroChain exchange direction mismatch: result=%s, carrier=%s, other=%s",
+						exchangeResult.actor->toString(),
+							carrier->actor->toString(),
+							other->actor->toString());
+#endif
+						return;
+					}
 					result.push_back(calculateExchange(exchangeResult.actor, carrier, other));
+				}
 				return;
 			}
 

--- a/AI/Nullkiller2/Pathfinding/AINodeStorage.h
+++ b/AI/Nullkiller2/Pathfinding/AINodeStorage.h
@@ -49,7 +49,7 @@ struct AIPathNode : public CGPathNode
 
 	void addSpecialAction(std::shared_ptr<const SpecialAction> action);
 
-	inline void reset(EPathfindingLayer layer, EPathAccessibility accessibility)
+	STRONG_INLINE void reset(EPathfindingLayer layer, EPathAccessibility accessibility)
 	{
 		CGPathNode::reset();
 
@@ -213,26 +213,26 @@ public:
 		float cost,
 		bool saveToCommitted = true) const;
 
-	inline const AIPathNode * getAINode(const CGPathNode * node) const
+	STRONG_INLINE const AIPathNode * getAINode(const CGPathNode * node) const
 	{
 		return static_cast<const AIPathNode *>(node);
 	}
 
-	inline void updateAINode(CGPathNode * node, std::function<void (AIPathNode *)> updater)
+	STRONG_INLINE void updateAINode(CGPathNode * node, std::function<void (AIPathNode *)> updater)
 	{
 		auto * aiNode = static_cast<AIPathNode *>(node);
 
 		updater(aiNode);
 	}
 
-	inline const CGHeroInstance * getHero(const CGPathNode * node) const
+	STRONG_INLINE const CGHeroInstance * getHero(const CGPathNode * node) const
 	{
 		const auto * aiNode = getAINode(node);
 
 		return aiNode->actor->hero;
 	}
 
-	inline bool blocked(const int3 & tile, EPathfindingLayer layer) const
+	STRONG_INLINE bool blocked(const int3 & tile, EPathfindingLayer layer) const
 	{
 		EPathAccessibility accessible = getAccessibility(tile, layer);
 
@@ -277,12 +277,12 @@ public:
 
 	uint64_t evaluateArmyLoss(const CGHeroInstance * hero, uint64_t armyValue, uint64_t danger) const;
 
-	inline EPathAccessibility getAccessibility(const int3 & tile, EPathfindingLayer layer) const
+	STRONG_INLINE EPathAccessibility getAccessibility(const int3 & tile, EPathfindingLayer layer) const
 	{
 		return (*this->accessibility)[tile.z][tile.x][tile.y][layer.getNum()];
 	}
 
-	inline void resetTile(const int3 & tile, EPathfindingLayer layer, EPathAccessibility tileAccessibility)
+	STRONG_INLINE void resetTile(const int3 & tile, EPathfindingLayer layer, EPathAccessibility tileAccessibility)
 	{
 		(*this->accessibility)[tile.z][tile.x][tile.y][layer.getNum()] = tileAccessibility;
 	}

--- a/AI/Nullkiller2/Pathfinding/AINodeStorage.h
+++ b/AI/Nullkiller2/Pathfinding/AINodeStorage.h
@@ -175,7 +175,7 @@ private:
 	uint8_t turnDistanceLimit[2];
 
 public:
-	/// more than 1 chain layer for each hero allows us to have more than 1 path to each tile so we can chose more optimal one.	
+	/// more than 1 chain layer for each hero allows us to have more than 1 path to each tile so we can chose more optimal one.
 	AINodeStorage(Nullkiller * aiNk, const int3 & sizes);
 	~AINodeStorage() override;
 
@@ -245,7 +245,7 @@ public:
 
 	template<class NodeRange>
 	bool hasBetterChain(
-		const CGPathNode * source, 
+		const CGPathNode * source,
 		const AIPathNode & destinationNode,
 		const NodeRange & chains) const;
 

--- a/AI/Nullkiller2/Pathfinding/AINodeStorage.h
+++ b/AI/Nullkiller2/Pathfinding/AINodeStorage.h
@@ -288,7 +288,17 @@ public:
 	}
 
 	void calculateTownPortalTeleportations(std::vector<CGPathNode *> & neighbours);
-	void fillChainInfo(const AIPathNode * node, AIPath & path, int parentIndex) const;
+
+	using RealMoveMasksByHero = std::map<const CGHeroInstance *, uint64_t>;
+
+	STRONG_INLINE bool isRealMovementNode(const AIPathNode * node) const
+	{
+		return node && node->actor && node->actor->hero && node->coord != node->actor->hero->visitablePos();
+	}
+
+	// Reconstructs an AIPath by walking theNodeBefore / chainOther, appending branch nodes first and linking them via parentIndex
+	// Returns false when reconstruction would assign conflicting real-move chainMasks to the same hero
+	bool tryReconstructChainInfo(const AIPathNode * node, AIPath & path, int & parentIndex, RealMoveMasksByHero & realMoveMasks) const;
 
 	template<typename Fn>
 	void iterateValidNodes(const int3 & pos, EPathfindingLayer layer, Fn fn)

--- a/AI/Nullkiller2/Pathfinding/Actors.cpp
+++ b/AI/Nullkiller2/Pathfinding/Actors.cpp
@@ -215,14 +215,7 @@ ExchangeResult HeroExchangeMap::tryExchangeNoLock(const ChainActor * other)
 	ExchangeResult result;
 
 	{
-		std::shared_lock lock(sync, std::try_to_lock);
-
-		if(!lock.owns_lock())
-		{
-			result.lockAcquired = false;
-
-			return result;
-		}
+		std::shared_lock lock(sync);
 
 		auto position = exchangeMap.find(other);
 
@@ -235,13 +228,14 @@ ExchangeResult HeroExchangeMap::tryExchangeNoLock(const ChainActor * other)
 	}
 
 	{
-		std::unique_lock uniqueLock(sync, std::try_to_lock);
+		std::unique_lock uniqueLock(sync);
 
-		if(!uniqueLock.owns_lock())
+		auto position = exchangeMap.find(other);
+		if(position != exchangeMap.end())
 		{
-			result.lockAcquired = false;
+			result.actor = position->second;
 
-			return result;
+			return result; // inserted while waiting for unique lock
 		}
 
 		auto inserted = exchangeMap.insert(std::pair<const ChainActor *, HeroActor *>(other, nullptr));

--- a/AI/Nullkiller2/Pathfinding/Rules/AIMovementAfterDestinationRule.cpp
+++ b/AI/Nullkiller2/Pathfinding/Rules/AIMovementAfterDestinationRule.cpp
@@ -331,6 +331,8 @@ namespace AIPathfinding
 
 		if(loss < actualArmyValue)
 		{
+			battleNode->specialAction = nullptr;
+
 			if(destNode->specialAction)
 			{
 				battleNode->specialAction = destNode->specialAction;


### PR DESCRIPTION
This PR fixes Nullkiller AI hero-chain exchanges.

The main bug was in hero-chain path reconstruction. Branched chains could be rebuilt incorrectly, with unstable branch ordering and invalid `parentIndex` links. That produced invalid transfer plans and could send reinforcements through the wrong handoff sequence.

While playing, I observed a case where Jenova, who was carrying reinforcements, left Celestine behind on her route and continued directly toward the main hero, Agar. The correct behavior was to pass the reinforcements to Celestine and let her continue toward Agar.

During debugging, it turned out that the planner did create the intended chain, but the chain was reconstructed incorrectly and then executed in the wrong sequence. Further investigation pointed to `fillChainInfo()` as the source of the broken chain paths.

Repro save:
[how_about_passing_army.zip](https://github.com/user-attachments/files/27445110/how_about_passing_army.zip)

  ## What changed

  ### Main fix:
  - reconstruct branched hero chains with stable branch ordering and correct `parentIndex` links
 
### Additional fixes:
  - preserve carrier/receiver roles when calculating exchanges, to keep exchange direction consistent in hero-chain transfers
  - handle the case where a hero is already on the target tile after executing a special action
  - check the path target rather than the path start when deciding whether movement can continue this turn
  - clear stale `specialAction` state before reusing battle path nodes
  - evaluate reinforcement gain using destination-tile terrain when scoring hero exchanges
