### PR TITLE
[1.7.4] small fixes related to scrolling

### DIFF
--- a/client/widgets/CViewport.cpp
+++ b/client/widgets/CViewport.cpp
@@ -78,6 +78,10 @@ void CViewport::remakeVSlider(int length)
 	}
 	vSlider->setScrollStep(20);
 	vSlider->setPanningStep(1);
+	// This slider's GESTURE events are handled exclusively by CViewport::gesturePanning.
+	// Without this, both the slider (via Scrollable::gesturePanning) and the viewport
+	// would scroll on every touch-panning event, causing double (over-)scroll speed.
+	vSlider->removeUsedEvents(GESTURE);
 }
 
 void CViewport::remakeHSlider(int length)
@@ -98,6 +102,8 @@ void CViewport::remakeHSlider(int length)
 	}
 	hSlider->setScrollStep(20);
 	hSlider->setPanningStep(1);
+	// Same reason as vSlider: gesture events are handled by CViewport, not the slider.
+	hSlider->removeUsedEvents(GESTURE);
 }
 
 void CViewport::updateSliders()
@@ -306,8 +312,8 @@ void CViewport::gesture(bool on, const Point & initialPosition, const Point & fi
 void CViewport::gesturePanning(const Point & initialPosition, const Point & currentPosition, const Point & lastUpdateDistance)
 {
 	const uint32_t ts = ENGINE->input().getTicks();
-	const int deltaX = -lastUpdateDistance.x;
-	const int deltaY =  lastUpdateDistance.y;
+	const int deltaX = lastUpdateDistance.x;
+	const int deltaY = lastUpdateDistance.y;
 
 	smoothH.addStep(deltaX, ts);
 	smoothV.addStep(deltaY, ts);

--- a/client/widgets/Slider.cpp
+++ b/client/widgets/Slider.cpp
@@ -30,18 +30,33 @@ void CSlider::mouseDragged(const Point & cursorPosition, const Point & lastUpdat
 		return;
 
 	if(onControl && !slider->isPressed())
+	{
 		slider->clickPressed(cursorPosition);
+		// Cursor landed on the thumb for the first time – initialise offset so the
+		// thumb doesn't jump to centre the thumb under the cursor.
+		if(slider->pos.isInside(cursorPosition))
+		{
+			if(getOrientation() == Orientation::HORIZONTAL)
+				dragOffset = cursorPosition.x - (slider->pos.x + barLength / 2);
+			else
+				dragOffset = cursorPosition.y - (slider->pos.y + barLength / 2);
+		}
+		else
+		{
+			dragOffset = 0;
+		}
+	}
 
 	double newPosition = 0;
 	if(getOrientation() == Orientation::HORIZONTAL)
 	{
-		newPosition = cursorPosition.x - pos.x - 16 - (barLength / 2);
+		newPosition = (cursorPosition.x - dragOffset) - pos.x - 16 - (barLength / 2);
 		newPosition *= positions;
 		newPosition /= (pos.w - 32 - barLength);
 	}
 	else
 	{
-		newPosition = cursorPosition.y - pos.y - 16 - (barLength / 2);
+		newPosition = (cursorPosition.y - dragOffset) - pos.y - 16 - (barLength / 2);
 		newPosition *= positions;
 		newPosition /= (pos.h - 32 - barLength);
 	}
@@ -176,8 +191,25 @@ void CSlider::clickPressed(const Point & cursorPosition)
 	if (!vstd::iswithin(rw, 0, 1))
 		return;
 
+	// If the cursor lands directly on the thumb, remember the offset so that
+	// subsequent mouseDragged calls don't jump the thumb to centre under cursor.
+	if(slider->pos.isInside(cursorPosition))
+	{
+		if(getOrientation() == Orientation::HORIZONTAL)
+			dragOffset = cursorPosition.x - (slider->pos.x + barLength / 2);
+		else
+			dragOffset = cursorPosition.y - (slider->pos.y + barLength / 2);
+	}
+	else
+	{
+		// Click on track: jump to clicked position, no offset.
+		dragOffset = 0;
+		slider->clickPressed(cursorPosition);
+		scrollTo((int)(rw * positions + 0.5));
+		return;
+	}
+
 	slider->clickPressed(cursorPosition);
-	scrollTo((int)(rw * positions + 0.5));
 }
 
 void CSlider::clickReleased(const Point & cursorPosition)
@@ -185,6 +217,7 @@ void CSlider::clickReleased(const Point & cursorPosition)
 	if(slider->isBlocked())
 		return;
 
+	dragOffset = 0;
 	slider->clickReleased(cursorPosition);
 }
 
@@ -211,7 +244,8 @@ CSlider::CSlider(Point position, int totalw, const SliderMovingFunctor & Moved, 
 	value(Value),
 	moved(Moved),
 	length(totalw),
-	style(Style)
+	style(Style),
+	dragOffset(0)
 {
 	OBJECT_CONSTRUCTION;
 	setAmount(amount);

--- a/client/widgets/Slider.h
+++ b/client/widgets/Slider.h
@@ -50,6 +50,10 @@ private:
 
 	CFunctionList<void(int)> moved;
 
+	/// Pixel offset from cursor to thumb centre recorded at drag start.
+	/// Keeps the thumb from jumping when the user clicks off-centre.
+	int dragOffset;
+
 	void updateSliderPos();
 	void updateSlider();
 


### PR DESCRIPTION
- panning in wiki is now correct (no too fast panning anymore)
- scrollbar thumbs now respect click position (no auto center around mouse cursor anymore when clicking on thumb, only when clicking on track)