### PR TITLE
[1.7.4] Fixes for lobby regressions

### DIFF
--- a/client/globalLobby/GlobalLobbyClient.cpp
+++ b/client/globalLobby/GlobalLobbyClient.cpp
@@ -157,6 +157,7 @@ void GlobalLobbyClient::receiveOperationFailed(const JsonNode & json)
 void GlobalLobbyClient::receiveClientLoginSuccess(const JsonNode & json)
 {
 	accountLoggedIn = true;
+	setAccountID(getAccountID());
 	setAccountDisplayName(json["displayName"].String());
 	setAccountCookie(json["accountCookie"].String());
 
@@ -282,15 +283,20 @@ GlobalLobbyRoom::GlobalLobbyRoom(const JsonNode & jsonEntry)
 void GlobalLobbyClient::receiveUpdateGameRoom(const JsonNode & json)
 {
 	GlobalLobbyRoom updatedRoom(json["room"]);
+	bool roomExists = false;
 
 	for(auto & room : activeRooms)
 	{
 		if (room.gameRoomID == updatedRoom.gameRoomID)
 		{
 			room = std::move(updatedRoom);
+			roomExists = true;
 			break;
 		}
 	}
+
+	if (!roomExists)
+		activeRooms.push_back(updatedRoom);
 
 	auto lobbyWindowPtr = lobbyWindow.lock();
 	if(lobbyWindowPtr)

--- a/lobby/LobbyServer.cpp
+++ b/lobby/LobbyServer.cpp
@@ -648,7 +648,6 @@ void LobbyServer::receiveServerLogin(const NetworkConnectionPtr & connection, co
 
 		activeGameRooms[connection] = gameRoomID;
 		sendServerLoginSuccess(connection, accountCookie);
-		broadcastActiveGameRooms();
 	}
 }
 
@@ -742,7 +741,7 @@ void LobbyServer::receiveActivateGameRoom(const NetworkConnectionPtr & connectio
 
 	database->updateRoomPlayerLimit(gameRoomID, playerLimit);
 	database->insertPlayerIntoGameRoom(accountID, gameRoomID);
-	broadcastGameRoomDescription(gameRoomID);
+	broadcastActiveGameRooms(); //FIXME: use broadcastGameRoomDescription when there are no 1.7.3 clients
 	sendJoinRoomSuccess(connection, gameRoomID, false);
 }
 
@@ -777,7 +776,7 @@ void LobbyServer::receiveJoinGameRoom(const NetworkConnectionPtr & connection, c
 	sendAccountJoinsRoom(targetRoom, accountID);
 	//No reply to client - will be sent once match server establishes proxy connection with lobby
 
-	broadcastGameRoomDescription(gameRoomID);
+	broadcastActiveGameRooms(); //FIXME: use broadcastGameRoomDescription when there are no 1.7.3 clients
 }
 
 void LobbyServer::receiveChangeRoomDescription(const NetworkConnectionPtr & connection, const JsonNode & json)
@@ -807,7 +806,7 @@ void LobbyServer::receiveLeaveGameRoom(const NetworkConnectionPtr & connection, 
 
 	database->deletePlayerFromGameRoom(accountID, gameRoomID);
 
-	broadcastGameRoomDescription(gameRoomID);
+	broadcastActiveGameRooms(); //FIXME: use broadcastGameRoomDescription when there are no 1.7.3 clients
 }
 
 void LobbyServer::receiveSendInvite(const NetworkConnectionPtr & connection, const JsonNode & json)
@@ -832,7 +831,7 @@ void LobbyServer::receiveSendInvite(const NetworkConnectionPtr & connection, con
 
 	database->insertGameRoomInvite(accountID, gameRoomID);
 	sendInviteReceived(targetAccountConnection, senderName, gameRoomID);
-	broadcastGameRoomDescription(gameRoomID);
+	broadcastActiveGameRooms(); //FIXME: use broadcastGameRoomDescription when there are no 1.7.3 clients
 }
 
 LobbyServer::~LobbyServer() = default;


### PR DESCRIPTION
- Fixed client not handling updateGameRoom message for new rooms
- Fixed account ID not updating correctly when using account details from beholder for lobby domain name
- Removed unnecessary sending of all game rooms when server starts connection. Now list is only send once connection is done
- Reverted some changes for 1.7.3 compatibility