### PR TITLE
Follow up to #6778: fix remaining turn-start hero level-up flow issues with multiple Dungeon towns

### DIFF
--- a/AI/Nullkiller2/AIGateway.cpp
+++ b/AI/Nullkiller2/AIGateway.cpp
@@ -630,9 +630,8 @@ void AIGateway::showBlockingDialog(const std::string & text, const std::vector<C
 	{
 		int sel = 0;
 
-		if(selection) //select from multiple components -> take the last one (they'bool executeTask(Goals::TTask task);re indexed [1-size])
+		if(selection) // select the last component; they are indexed in range [1, size]
 			sel = components.size();
-
 		{
 				std::unique_lock mxLock(nullkiller->aiStateMutex);
 

--- a/AI/Nullkiller2/Goals/ExecuteHeroChain.cpp
+++ b/AI/Nullkiller2/Goals/ExecuteHeroChain.cpp
@@ -145,9 +145,9 @@ void ExecuteHeroChain::accept(AIGateway * aiGw)
 					{
 						throw cannotFulfillGoalException("Path is nondeterministic.");
 					}
-					
+
 					node->specialAction->execute(aiGw, hero);
-					
+
 					if(!heroPtr.isVerified())
 					{
 						logAi->error("Hero %s was lost trying to execute special action. Exit hero chain.", heroPtr.nameOrDefault());
@@ -226,7 +226,7 @@ void ExecuteHeroChain::accept(AIGateway * aiGw)
 
 				auto sourceWhirlpool = findWhirlpool(hero->visitablePos());
 				auto targetWhirlpool = findWhirlpool(node->coord);
-				
+
 				if(i != chainPath.nodes.size() - 1 && sourceWhirlpool.hasValue() && sourceWhirlpool == targetWhirlpool)
 				{
 					logAi->trace("AI exited whirlpool at %s but expected at %s", hero->visitablePos().toString(), node->coord.toString());

--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -226,8 +226,8 @@ void CPlayerInterface::playerEndsTurn(PlayerColor player)
 		closeAllDialogs();
 
 		// remove all pending dialogs that do not expect query answer
-		vstd::erase_if(dialogs, [](const std::shared_ptr<CInfoWindow> & window){
-						   return window->ID == QueryID::NONE;
+		vstd::erase_if(dialogs, [](const PendingDialog & dialog){
+						   return dialog.dropOnTurnEnd;
 					   });
 	}
 }
@@ -527,50 +527,75 @@ void CPlayerInterface::receivedResource()
 void CPlayerInterface::heroGotLevel(const CGHeroInstance *hero, PrimarySkill pskill, std::vector<SecondarySkill>& skills, QueryID queryID)
 {
 	EVENT_HANDLER_CALLED_BY_CLIENT;
-	waitWhileDialog();
-	ENGINE->sound().playSound(soundBase::heroNewLevel);
+	auto availableSkills = skills;
 
-	closePendingLevelUpDialog();
-
-	const bool closeImmediately = queryID < 0;
-	pendingLevelUpRequestID = closeImmediately ? LEVEL_UP_REQUEST_NONE : LEVEL_UP_REQUEST_WAITING_FOR_REPLY;
-
-	auto levelWindow = std::make_shared<CLevelWindow>(hero, pskill, skills, [this, queryID](ui32 selection)
+	auto showLevelUpDialog = [this, hero, pskill, availableSkills = std::move(availableSkills), queryID]() mutable
 	{
-		if(queryID < 0)
-			return;
+		closePendingLevelUpDialog();
 
-		pendingLevelUpRequestID = cb->selectionMade(selection, queryID);
-	});
+		const bool closeImmediately = queryID < 0;
+		pendingLevelUpRequestID = closeImmediately ? LEVEL_UP_REQUEST_NONE : LEVEL_UP_REQUEST_WAITING_FOR_REPLY;
 
-	levelWindow->setCloseOnSelection(closeImmediately);
-	if(!closeImmediately)
-		pendingLevelUpDialog = levelWindow;
+		ENGINE->sound().playSound(soundBase::heroNewLevel);
+		auto levelWindow = std::make_shared<CLevelWindow>(hero, pskill, availableSkills, [this, queryID](ui32 selection)
+		{
+			if(queryID < 0)
+				return;
 
-	ENGINE->windows().pushWindow(levelWindow);
+			pendingLevelUpRequestID = cb->selectionMade(selection, queryID);
+		});
+
+		levelWindow->setCloseOnSelection(closeImmediately);
+		if(!closeImmediately)
+			pendingLevelUpDialog = levelWindow;
+
+		ENGINE->windows().pushWindow(levelWindow);
+	};
+
+	if(showingDialog->isBusy() || !dialogs.empty())
+	{
+		dialogs.push_back({false, std::move(showLevelUpDialog)});
+		return;
+	}
+
+	waitWhileDialog();
+	showLevelUpDialog();
 }
 
 void CPlayerInterface::commanderGotLevel(const CCommanderInstance * commander, std::vector<ui32> skills, QueryID queryID)
 {
 	EVENT_HANDLER_CALLED_BY_CLIENT;
-	waitWhileDialog();
-	ENGINE->sound().playSound(soundBase::heroNewLevel);
-
-	closePendingLevelUpDialog();
-
-	const bool closeImmediately = queryID < 0;
-	pendingLevelUpRequestID = closeImmediately ? LEVEL_UP_REQUEST_NONE : LEVEL_UP_REQUEST_WAITING_FOR_REPLY;
-	auto levelWindow = std::make_shared<CStackWindow>(commander, skills, [this, queryID](ui32 selection)
+	auto showLevelUpDialog = [this, commander, skills = std::move(skills), queryID]() mutable
 	{
-		if(queryID < 0)
-			return;
+		closePendingLevelUpDialog();
 
-		pendingLevelUpRequestID = cb->selectionMade(selection, queryID);
-	});
-	levelWindow->setCloseOnSelection(closeImmediately);
-	if(!closeImmediately)
-		pendingLevelUpDialog = levelWindow;
-	ENGINE->windows().pushWindow(levelWindow);
+		const bool closeImmediately = queryID < 0;
+		pendingLevelUpRequestID = closeImmediately ? LEVEL_UP_REQUEST_NONE : LEVEL_UP_REQUEST_WAITING_FOR_REPLY;
+
+		ENGINE->sound().playSound(soundBase::heroNewLevel);
+		auto levelWindow = std::make_shared<CStackWindow>(commander, skills, [this, queryID](ui32 selection)
+		{
+			if(queryID < 0)
+				return;
+
+			pendingLevelUpRequestID = cb->selectionMade(selection, queryID);
+		});
+
+		levelWindow->setCloseOnSelection(closeImmediately);
+		if(!closeImmediately)
+			pendingLevelUpDialog = levelWindow;
+
+		ENGINE->windows().pushWindow(levelWindow);
+	};
+
+	if(showingDialog->isBusy() || !dialogs.empty())
+	{
+		dialogs.push_back({false, std::move(showLevelUpDialog)});
+		return;
+	}
+
+	waitWhileDialog();
+	showLevelUpDialog();
 }
 
 void CPlayerInterface::heroInGarrisonChange(const CGTownInstance *town)
@@ -1083,7 +1108,13 @@ void CPlayerInterface::showInfoDialog(const std::string &text, const std::vector
 	}
 	else
 	{
-		dialogs.push_back(temp);
+		dialogs.push_back({true, [this, temp, soundID]()
+		{
+			ENGINE->sound().playSound(static_cast<soundBase::soundID>(soundID));
+			showingDialog->setBusy();
+			movementController->requestMovementAbort(); // interrupt movement to show dialog
+			ENGINE->windows().pushWindow(temp);
+		}});
 	}
 }
 
@@ -1556,8 +1587,7 @@ void CPlayerInterface::update()
 	//if there are any waiting dialogs, show them
 	if (makingTurn && !dialogs.empty() && !showingDialog->isBusy())
 	{
-		showingDialog->setBusy();
-		ENGINE->windows().pushWindow(dialogs.front());
+		dialogs.front().show();
 		dialogs.pop_front();
 	}
 }

--- a/client/CPlayerInterface.h
+++ b/client/CPlayerInterface.h
@@ -66,7 +66,13 @@ class CPlayerInterface : public CGameInterface
 
 	const std::string QUICKSAVE_PATH = "Saves/Quicksave";
 
-	std::list<std::shared_ptr<CInfoWindow>> dialogs; //queue of dialogs awaiting to be shown (not currently shown!)
+	struct PendingDialog
+	{
+		bool dropOnTurnEnd = false;
+		std::function<void()> show;
+	};
+
+	std::list<PendingDialog> dialogs; //queue of dialogs awaiting to be shown (not currently shown!)
 	std::shared_ptr<WindowBase> pendingLevelUpDialog;
 	int pendingLevelUpRequestID = -1;
 

--- a/lib/callback/CGameInfoCallback.cpp
+++ b/lib/callback/CGameInfoCallback.cpp
@@ -97,13 +97,13 @@ TurnTimerInfo CGameInfoCallback::getPlayerTurnTime(PlayerColor color) const
 	{
 		return TurnTimerInfo{};
 	}
-	
+
 	auto player = gameState().players.find(color);
 	if(player != gameState().players.end())
 	{
 		return player->second.turnTimer;
 	}
-	
+
 	return TurnTimerInfo{};
 }
 
@@ -622,7 +622,7 @@ std::string CGameInfoCallback::getTavernRumor(const CGObjectInstance * townOrTav
 {
 	MetaString text;
 	text.appendLocalString(EMetaText::GENERAL_TXT, 216);
-	
+
 	std::string extraText;
 	if(gameState().currentRumor.type == RumorState::TYPE_NONE)
 		return text.toString();

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -3513,20 +3513,18 @@ bool CGameHandler::isAllowedExchange(ObjectInstanceID id1, ObjectInstanceID id2)
 				return true;
 		}
 
-		//Ongoing garrison exchange - usually picking from top garison (from o1 to o2), but who knows
-		auto dialog = std::dynamic_pointer_cast<CGarrisonDialogQuery>(queries->topQuery(o1->tempOwner));
-		if (!dialog)
-		{
-			dialog = std::dynamic_pointer_cast<CGarrisonDialogQuery>(queries->topQuery(o2->tempOwner));
-		}
-		if (dialog)
-		{
-			const auto * topArmy = dialog->exchangingArmies.at(0);
-			const auto * bottomArmy = dialog->exchangingArmies.at(1);
+		// Ongoing garrison exchange
+		const auto * dialog = queries->findQuery<CGarrisonDialogQuery>(
+			[o1, o2](const CGarrisonDialogQuery & query)
+			{
+				const auto * topArmy = query.exchangingArmies.at(0);
+				const auto * bottomArmy = query.exchangingArmies.at(1);
 
-			if ((topArmy == o1 && bottomArmy == o2) || (bottomArmy == o1 && topArmy == o2))
-				return true;
-		}
+				return (topArmy == o1 && bottomArmy == o2) || (topArmy == o2 && bottomArmy == o1);
+			});
+
+		if(dialog)
+			return true;
 	}
 
 	return false;
@@ -4234,13 +4232,15 @@ void CGameHandler::removeAfterVisit(const ObjectInstanceID & id)
 	//If the object is being visited, there must be a matching query
 	for (const auto &query : queries->allQueries())
 	{
-		if (auto someVistQuery = std::dynamic_pointer_cast<MapObjectVisitQuery>(query))
+		auto * someVisitQuery = queries->queryAs<MapObjectVisitQuery>(query);
+
+		if(!someVisitQuery)
+			continue;
+
+		if(someVisitQuery->visitedObject == id)
 		{
-			if (someVistQuery->visitedObject == id)
-			{
-				someVistQuery->removeObjectAfterVisit = true;
-				return;
-			}
+			someVisitQuery->removeObjectAfterVisit = true;
+			return;
 		}
 	}
 
@@ -4295,8 +4295,11 @@ const CGHeroInstance * CGameHandler::getVisitingHero(const CGObjectInstance *obj
 
 	for(const auto & query : queries->allQueries())
 	{
-		auto visit = std::dynamic_pointer_cast<const VisitQuery>(query);
-		if (visit && visit->visitedObject == obj->id)
+		const auto * visit = dynamic_cast<VisitQuery *>(query.get());
+		if(!visit)
+			continue;
+
+		if(visit->visitedObject == obj->id)
 			return gameInfo().getHero(visit->visitingHero);
 	}
 	return nullptr;
@@ -4308,8 +4311,11 @@ const CGObjectInstance * CGameHandler::getVisitingObject(const CGHeroInstance *h
 
 	for(const auto & query : queries->allQueries())
 	{
-		auto visit = std::dynamic_pointer_cast<const VisitQuery>(query);
-		if (visit && visit->visitingHero == hero->id)
+		const auto * visit = dynamic_cast<VisitQuery *>(query.get());
+		if(!visit)
+			continue;
+
+		if(visit->visitingHero == hero->id)
 			return gameInfo().getObjInstance(visit->visitedObject);
 	}
 	return nullptr;
@@ -4324,8 +4330,8 @@ bool CGameHandler::isVisitCoveredByAnotherQuery(const CGObjectInstance *obj, con
 	// If top query is NOT visit to targeted object then we assume that
 	// visitation query is covered by other query that must be answered first
 
-	if (auto topQuery = queries->topQuery(hero->getOwner()))
-		if (auto visit = std::dynamic_pointer_cast<const VisitQuery>(topQuery))
+	if(const auto & topQuery = queries->topQuery(hero->getOwner()))
+		if(const auto * visit =  dynamic_cast<VisitQuery *>(topQuery.get()))
 			return !(visit->visitedObject == obj->id && visit->visitingHero == hero->id);
 
 	return true;

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -14,6 +14,7 @@
 #include "TurnTimerHandler.h"
 #include "ServerNetPackVisitors.h"
 #include "ServerSpellCastEnvironment.h"
+#include "TurnStartVisitScheduler.h"
 #include "battles/BattleProcessor.h"
 #include "processors/HeroPoolProcessor.h"
 #include "processors/NewTurnProcessor.h"
@@ -542,6 +543,7 @@ CGameHandler::CGameHandler(IGameServer & server)
 	, heroPool(std::make_unique<HeroPoolProcessor>(this))
 	, battles(std::make_unique<BattleProcessor>(this))
 	, queries(std::make_unique<QueriesProcessor>())
+	, turnStartVisitScheduler(std::make_unique<TurnStartVisitScheduler>(*this, *queries))
 	, turnOrder(std::make_unique<TurnOrderProcessor>(this))
 	, turnTimerHandler(std::make_unique<TurnTimerHandler>(*this))
 	, newTurnProcessor(std::make_unique<NewTurnProcessor>(this))
@@ -553,6 +555,7 @@ CGameHandler::CGameHandler(IGameServer & server)
 	, complainNotEnoughCreatures("Cannot split that stack, not enough creatures!")
 	, complainInvalidSlot("Invalid slot accessed!")
 {
+	queries->setListener(turnStartVisitScheduler.get());
 }
 
 CGameHandler::~CGameHandler() = default;
@@ -4214,6 +4217,9 @@ bool CGameHandler::isBlockedByQueries(const CPackForServer *pack, PlayerColor pl
 		return false;
 
 	if (dynamic_cast<const SaveLocalState *>(pack) != nullptr)
+		return false;
+
+	if(dynamic_cast<const AdvInterfaceReady *>(pack) != nullptr)
 		return false;
 
 	auto query = queries->topQuery(player);

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -4207,6 +4207,9 @@ void CGameHandler::spawnWanderingMonsters(CreatureID creatureID)
 
 bool CGameHandler::isBlockedByQueries(const CPackForServer *pack, PlayerColor player)
 {
+	if(!player.isValidPlayer())
+		return false;
+
 	if (dynamic_cast<const PlayerMessage *>(pack) != nullptr)
 		return false;
 

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -836,7 +836,7 @@ bool CGameHandler::moveHero(ObjectInstanceID hid, int3 dst, EMovementMode moveme
 	{
 		if(h && gameInfo().getStartInfo()->turnTimerInfo.isEnabled() && gameState().players.at(h->getOwner()).turnTimer.turnTimer == 0)
 			return true; //timer expired, no error
-		
+
 		logGlobal->error("Illegal call to move hero!");
 		return false;
 	}
@@ -1019,13 +1019,13 @@ bool CGameHandler::moveHero(ObjectInstanceID hid, int3 dst, EMovementMode moveme
 
 			if(h->inBoat() && !object->isBlockedVisitable() && !h->getBoat()->onboardVisitAllowed)
 				return doMove(TryMoveHero::SUCCESS, this->IGNORE_GUARDS, DONT_VISIT_DEST, REMAINING_ON_TILE);
-			
+
 			if (object != h && object->isBlockedVisitable() && !object->passableFor(h->tempOwner))
 			{
 				EVisitDest visitDest = VISIT_DEST;
 				if(h->inBoat() && !h->getBoat()->onboardVisitAllowed)
 					visitDest = DONT_VISIT_DEST;
-				
+
 				return doMove(TryMoveHero::BLOCKING_VISIT, this->IGNORE_GUARDS, visitDest, REMAINING_ON_TILE);
 			}
 		}
@@ -1093,7 +1093,7 @@ bool CGameHandler::moveHero(ObjectInstanceID hid, int3 dst, EMovementMode moveme
 		}
 		else if (blockingVisit())
 			return true;
-		
+
 		if(h->getBoat() && !h->getBoat()->onboardAssaultAllowed)
 			lookForGuards = IGNORE_GUARDS;
 
@@ -2350,12 +2350,12 @@ bool CGameHandler::spellResearch(ObjectInstanceID tid, SpellID spellAtSlot, bool
 	for(int i = 0; i < t->spells.size(); i++)
 		if(vstd::find_pos(t->spells[i], spellAtSlot) != -1)
 			level = i;
-	
+
 	if(level == -1 && complain("Spell for replacement not found!"))
 		return false;
 
 	auto spells = t->spells.at(level);
-	
+
 	bool researchLimitExceeded = t->spellResearchCounterDay >= gameInfo().getSettings().getValue(EGameSettings::TOWNS_SPELL_RESEARCH_PER_DAY).Vector()[level].Float();
 	if(researchLimitExceeded && complain("Already researched today!"))
 		return false;
@@ -2673,11 +2673,11 @@ bool CGameHandler::moveArtifact(const PlayerColor & player, const ArtifactLocati
 
 	if(src.slot == dstSlot && src.artHolder == dst.artHolder)
 		COMPLAIN_RET("Won't move artifact: Dest same as source!");
-	
+
 	BulkMoveArtifacts ma(player, src.artHolder, dst.artHolder, false);
 	ma.srcCreature = src.creature;
 	ma.dstCreature = dst.creature;
-	
+
 	// Check if dst slot is occupied
 	if(!isDstSlotBackpack && isDstSlotOccupied)
 	{
@@ -2876,19 +2876,19 @@ bool CGameHandler::manageBackpackArtifacts(const PlayerColor & player, const Obj
 		makeSortBackpackRequest([](const ArtSlotInfo & inf) -> int32_t
 			{
 				auto possibleSlots = inf.getArt()->getType()->getPossibleSlots();
-				if (possibleSlots.find(ArtBearer::CREATURE) != possibleSlots.end() && !possibleSlots.at(ArtBearer::CREATURE).empty()) 
+				if (possibleSlots.find(ArtBearer::CREATURE) != possibleSlots.end() && !possibleSlots.at(ArtBearer::CREATURE).empty())
 				{
 					return -2;
 				}
-				else if (possibleSlots.find(ArtBearer::COMMANDER) != possibleSlots.end() && !possibleSlots.at(ArtBearer::COMMANDER).empty()) 
+				else if (possibleSlots.find(ArtBearer::COMMANDER) != possibleSlots.end() && !possibleSlots.at(ArtBearer::COMMANDER).empty())
 				{
 					return -1;
 				}
-				else if (possibleSlots.find(ArtBearer::HERO) != possibleSlots.end() && !possibleSlots.at(ArtBearer::HERO).empty()) 
+				else if (possibleSlots.find(ArtBearer::HERO) != possibleSlots.end() && !possibleSlots.at(ArtBearer::HERO).empty())
 				{
 					return inf.getArt()->getType()->getPossibleSlots().at(ArtBearer::HERO).front().num;
 				}
-				else 
+				else
 				{
 					// for grail
 					return -3;
@@ -2964,7 +2964,7 @@ bool CGameHandler::switchArtifactsCostume(const PlayerColor & player, const Obje
 					artFittingSet.removeArtifact(slot);
 				}
 		}
-		
+
 		// Second, find the necessary artifacts for the costume
 		for(const auto & artPos : costumeArtMap)
 		{
@@ -2984,7 +2984,7 @@ bool CGameHandler::switchArtifactsCostume(const PlayerColor & player, const Obje
 				bma.artsPack0.emplace_back(slot, ArtifactPosition::BACKPACK_START);
 				estimateBackpackSize++;
 			}
-		
+
 		const auto backpackCap = gameInfo().getSettings().getInteger(EGameSettings::HEROES_BACKPACK_CAP);
 		if((backpackCap < 0 || estimateBackpackSize <= backpackCap) && !bma.artsPack0.empty())
 			sendAndApply(bma);
@@ -3023,7 +3023,7 @@ bool CGameHandler::assembleArtifacts(ObjectInstanceID heroID, ArtifactPosition a
 		{
 			COMPLAIN_RET("assembleArtifacts: It's impossible to give the artholder requested artifact!");
 		}
-		
+
 		if(ArtifactUtils::checkSpellbookIsNeeded(hero, assembleTo, artifactSlot))
 			giveHeroNewArtifact(hero, ArtifactID::SPELLBOOK, ArtifactPosition::SPELLBOOK);
 

--- a/server/CGameHandler.h
+++ b/server/CGameHandler.h
@@ -51,6 +51,7 @@ class QueriesProcessor;
 class CObjectVisitQuery;
 class NewTurnProcessor;
 class IGameServer;
+class TurnStartVisitScheduler;
 
 class CGameHandler : public Environment, public IGameEventCallback
 {
@@ -60,6 +61,7 @@ public:
 	std::unique_ptr<HeroPoolProcessor> heroPool;
 	std::unique_ptr<BattleProcessor> battles;
 	std::unique_ptr<QueriesProcessor> queries;
+	std::unique_ptr<TurnStartVisitScheduler> turnStartVisitScheduler;
 	std::unique_ptr<TurnOrderProcessor> turnOrder;
 	std::unique_ptr<TurnTimerHandler> turnTimerHandler;
 	std::unique_ptr<NewTurnProcessor> newTurnProcessor;

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -24,6 +24,7 @@ set(vcmiservercommon_SRCS
 		NetPacksServer.cpp
 		NetPacksLobbyServer.cpp
 		TurnTimerHandler.cpp
+		TurnStartVisitScheduler.cpp
 )
 
 set(vcmiservercommon_HEADERS
@@ -39,6 +40,7 @@ set(vcmiservercommon_HEADERS
 		queries/MapQueries.h
 		queries/VisitQueries.h
 		queries/QueriesProcessor.h
+		queries/IQueryStackListener.h
 
 		processors/HeroPoolProcessor.h
 		processors/NewTurnProcessor.h
@@ -53,6 +55,7 @@ set(vcmiservercommon_HEADERS
 		LobbyNetPackVisitors.h
 		ServerNetPackVisitors.h
 		TurnTimerHandler.h
+		TurnStartVisitScheduler.h
 )
 
 assign_source_group(${vcmiservercommon_SRCS} ${vcmiservercommon_HEADERS})

--- a/server/TurnStartVisitScheduler.cpp
+++ b/server/TurnStartVisitScheduler.cpp
@@ -1,0 +1,60 @@
+/*
+ * TurnStartVisitScheduler.cpp, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
+
+#include "StdInc.h"
+#include "TurnStartVisitScheduler.h"
+
+#include "CGameHandler.h"
+#include "lib/gameState/CGameState.h"
+#include "queries/QueriesProcessor.h"
+
+TurnStartVisitScheduler::TurnStartVisitScheduler(CGameHandler & gameHandler, QueriesProcessor & queries)
+	: gameHandler(gameHandler)
+	, queries(queries)
+{
+}
+
+void TurnStartVisitScheduler::enqueue(PlayerColor player, std::deque<PendingTurnStartVisit> visits)
+{
+	sessions[player] = std::move(visits);
+}
+
+void TurnStartVisitScheduler::processNext(PlayerColor player)
+{
+	auto & session = sessions[player];
+
+	if(session.empty())
+		return;
+
+	if(queries.topQuery(player))
+		return;
+
+	if(!session.empty())
+	{
+		const auto next = session.front();
+		session.pop_front();
+
+		const auto * object = gameHandler.gameState().getObjInstance(next.objectId);
+		const auto * hero = gameHandler.gameState().getHero(next.heroId);
+
+		gameHandler.objectVisited(object, hero);
+	}
+}
+
+void TurnStartVisitScheduler::onQueryStackChanged(PlayerColor player)
+{
+	processNext(player);
+}
+
+void TurnStartVisitScheduler::clear(PlayerColor player)
+{
+	sessions[player].clear();
+}
+

--- a/server/TurnStartVisitScheduler.h
+++ b/server/TurnStartVisitScheduler.h
@@ -1,0 +1,41 @@
+/*
+ * TurnStartVisitScheduler.h, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
+#pragma once
+
+#include "queries/IQueryStackListener.h"
+
+class CGameHandler;
+class QueriesProcessor;
+
+struct PendingTurnStartVisit
+{
+	PlayerColor player;
+	ObjectInstanceID objectId;
+	ObjectInstanceID heroId;
+};
+
+// Schedules deferred turn-start object visits and runs them one at a time
+// per player, resuming only after the previous visit's query chain finishes.
+class TurnStartVisitScheduler final : public IQueryStackListener
+{
+public:
+	TurnStartVisitScheduler(CGameHandler & gameHandler, QueriesProcessor & queries);
+
+	void enqueue(PlayerColor player, std::deque<PendingTurnStartVisit> visits);
+	void processNext(PlayerColor player);
+	void onQueryStackChanged(PlayerColor player) override;
+	void clear(PlayerColor player);
+
+private:
+	CGameHandler & gameHandler;
+	QueriesProcessor & queries;
+	std::array<std::deque<PendingTurnStartVisit>, PlayerColor::PLAYER_LIMIT_I> sessions;
+};
+

--- a/server/battles/BattleProcessor.cpp
+++ b/server/battles/BattleProcessor.cpp
@@ -60,14 +60,18 @@ void BattleProcessor::restartBattle(const BattleID & battleID, const CArmedInsta
 {
 	auto battle = gameHandler->gameState().getBattle(battleID);
 
-	auto lastBattleQuery = std::dynamic_pointer_cast<CBattleQuery>(gameHandler->queries->topQuery(battle->getSide(BattleSide::ATTACKER).color));
-	if(!lastBattleQuery)
-		lastBattleQuery = std::dynamic_pointer_cast<CBattleQuery>(gameHandler->queries->topQuery(battle->getSide(BattleSide::DEFENDER).color));
+	auto attackerQuery = gameHandler->queries->topQuery(battle->getSide(BattleSide::ATTACKER).color);
+	auto * topBattleQuery = gameHandler->queries->queryAs<CBattleQuery>(attackerQuery);
+	if(!topBattleQuery)
+	{
+		auto defenderQuery = gameHandler->queries->topQuery(battle->getSide(BattleSide::DEFENDER).color);
+		topBattleQuery = gameHandler->queries->queryAs<CBattleQuery>(defenderQuery);
+	}
 
-	assert(lastBattleQuery);
+	assert(topBattleQuery);
 
 	//existing battle query for retying auto-combat
-	if(lastBattleQuery)
+	if(topBattleQuery)
 	{
 		BattleSideArray<const CGHeroInstance*> heroes{hero1, hero2};
 
@@ -83,10 +87,10 @@ void BattleProcessor::restartBattle(const BattleID & battleID, const CArmedInsta
 			}
 		}
 
-		lastBattleQuery->result = std::nullopt;
+		topBattleQuery->result = std::nullopt;
 
-		assert(lastBattleQuery->belligerents[BattleSide::ATTACKER] == battle->getSideArmy(BattleSide::ATTACKER));
-		assert(lastBattleQuery->belligerents[BattleSide::DEFENDER] == battle->getSideArmy(BattleSide::DEFENDER));
+		assert(topBattleQuery->belligerents[BattleSide::ATTACKER] == battle->getSideArmy(BattleSide::ATTACKER));
+		assert(topBattleQuery->belligerents[BattleSide::DEFENDER] == battle->getSideArmy(BattleSide::DEFENDER));
 	}
 
 	BattleCancelled bc;
@@ -109,7 +113,7 @@ void BattleProcessor::startBattle(const CArmedInstance *army1, const CArmedInsta
 
 	const auto * battle = gameHandler->gameState().getBattle(battleID);
 	assert(battle);
-	
+
 	//add battle bonuses based from player state only when attacks neutral creatures
 	const auto * attackerInfo = gameHandler->gameInfo().getPlayerState(army1->getOwner(), false);
 	if(attackerInfo && !army2->getOwner().isValidPlayer())
@@ -123,13 +127,16 @@ void BattleProcessor::startBattle(const CArmedInstance *army1, const CArmedInsta
 		}
 	}
 
-	auto lastBattleQuery = std::dynamic_pointer_cast<CBattleQuery>(gameHandler->queries->topQuery(battle->getSide(BattleSide::ATTACKER).color));
-	if(!lastBattleQuery)
-		lastBattleQuery = std::dynamic_pointer_cast<CBattleQuery>(gameHandler->queries->topQuery(battle->getSide(BattleSide::DEFENDER).color));
-
-	if (lastBattleQuery)
+	auto attackerQuery = gameHandler->queries->topQuery(battle->getSide(BattleSide::ATTACKER).color);
+	auto * topBattleQuery = gameHandler->queries->queryAs<CBattleQuery>(attackerQuery);
+	if(!topBattleQuery)
 	{
-		lastBattleQuery->battleID = battleID;
+		auto defenderQuery = gameHandler->queries->topQuery(battle->getSide(BattleSide::DEFENDER).color);
+		topBattleQuery = gameHandler->queries->queryAs<CBattleQuery>(defenderQuery);
+	}
+	if (topBattleQuery)
+	{
+		topBattleQuery->battleID = battleID;
 	}
 	else
 	{
@@ -176,14 +183,19 @@ BattleID BattleProcessor::setupBattle(int3 tile, BattleSideArray<const CArmedIns
 	engageIntoBattle(bs.info->getSide(BattleSide::ATTACKER).color);
 	engageIntoBattle(bs.info->getSide(BattleSide::DEFENDER).color);
 
-	auto lastBattleQuery = std::dynamic_pointer_cast<CBattleQuery>(gameHandler->queries->topQuery(bs.info->getSide(BattleSide::ATTACKER).color));
-	if(!lastBattleQuery)
-		lastBattleQuery = std::dynamic_pointer_cast<CBattleQuery>(gameHandler->queries->topQuery(bs.info->getSide(BattleSide::DEFENDER).color));
+	auto attackerQuery = gameHandler->queries->topQuery(bs.info->getSide(BattleSide::ATTACKER).color);
+	auto * topBattleQuery = gameHandler->queries->queryAs<CBattleQuery>(attackerQuery);
+	if(!topBattleQuery)
+	{
+		auto defenderQuery = gameHandler->queries->topQuery(bs.info->getSide(BattleSide::DEFENDER).color);
+		topBattleQuery = gameHandler->queries->queryAs<CBattleQuery>(defenderQuery);
+	}
+
 	bool isDefenderHuman = bs.info->getSide(BattleSide::DEFENDER).color.isValidPlayer() && gameHandler->gameInfo().getPlayerState(bs.info->getSide(BattleSide::DEFENDER).color)->isHuman();
 	bool isAttackerHuman = gameHandler->gameInfo().getPlayerState(bs.info->getSide(BattleSide::ATTACKER).color)->isHuman();
 
 	bool onlyOnePlayerHuman = isDefenderHuman != isAttackerHuman;
-	bs.info->replayAllowed = lastBattleQuery == nullptr && onlyOnePlayerHuman;
+	bs.info->replayAllowed = topBattleQuery == nullptr && onlyOnePlayerHuman;
 
 	gameHandler->sendAndApply(bs);
 

--- a/server/battles/BattleProcessor.cpp
+++ b/server/battles/BattleProcessor.cpp
@@ -61,17 +61,21 @@ void BattleProcessor::restartBattle(const BattleID & battleID, const CArmedInsta
 	auto battle = gameHandler->gameState().getBattle(battleID);
 
 	auto attackerQuery = gameHandler->queries->topQuery(battle->getSide(BattleSide::ATTACKER).color);
-	auto * topBattleQuery = gameHandler->queries->queryAs<CBattleQuery>(attackerQuery);
-	if(!topBattleQuery)
+	auto * lastBattleQuery = gameHandler->queries->queryAs<CBattleQuery>(attackerQuery);
+	if(!lastBattleQuery)
 	{
-		auto defenderQuery = gameHandler->queries->topQuery(battle->getSide(BattleSide::DEFENDER).color);
-		topBattleQuery = gameHandler->queries->queryAs<CBattleQuery>(defenderQuery);
+		auto defenderPlayer = battle->getSide(BattleSide::DEFENDER).color;
+		if(defenderPlayer.isValidPlayer())
+		{
+			auto defenderQuery = gameHandler->queries->topQuery(defenderPlayer);
+			lastBattleQuery = gameHandler->queries->queryAs<CBattleQuery>(defenderQuery);
+		}
 	}
 
-	assert(topBattleQuery);
+	assert(lastBattleQuery);
 
 	//existing battle query for retying auto-combat
-	if(topBattleQuery)
+	if(lastBattleQuery)
 	{
 		BattleSideArray<const CGHeroInstance*> heroes{hero1, hero2};
 
@@ -87,10 +91,10 @@ void BattleProcessor::restartBattle(const BattleID & battleID, const CArmedInsta
 			}
 		}
 
-		topBattleQuery->result = std::nullopt;
+		lastBattleQuery->result = std::nullopt;
 
-		assert(topBattleQuery->belligerents[BattleSide::ATTACKER] == battle->getSideArmy(BattleSide::ATTACKER));
-		assert(topBattleQuery->belligerents[BattleSide::DEFENDER] == battle->getSideArmy(BattleSide::DEFENDER));
+		assert(lastBattleQuery->belligerents[BattleSide::ATTACKER] == battle->getSideArmy(BattleSide::ATTACKER));
+		assert(lastBattleQuery->belligerents[BattleSide::DEFENDER] == battle->getSideArmy(BattleSide::DEFENDER));
 	}
 
 	BattleCancelled bc;
@@ -129,7 +133,7 @@ void BattleProcessor::startBattle(const CArmedInstance *army1, const CArmedInsta
 
 	auto attackerQuery = gameHandler->queries->topQuery(battle->getSide(BattleSide::ATTACKER).color);
 	auto * topBattleQuery = gameHandler->queries->queryAs<CBattleQuery>(attackerQuery);
-	if(!topBattleQuery)
+	if(!topBattleQuery && army2->getOwner().isValidPlayer())
 	{
 		auto defenderQuery = gameHandler->queries->topQuery(battle->getSide(BattleSide::DEFENDER).color);
 		topBattleQuery = gameHandler->queries->queryAs<CBattleQuery>(defenderQuery);
@@ -185,13 +189,13 @@ BattleID BattleProcessor::setupBattle(int3 tile, BattleSideArray<const CArmedIns
 
 	auto attackerQuery = gameHandler->queries->topQuery(bs.info->getSide(BattleSide::ATTACKER).color);
 	auto * topBattleQuery = gameHandler->queries->queryAs<CBattleQuery>(attackerQuery);
-	if(!topBattleQuery)
+	bool isDefenderHuman = bs.info->getSide(BattleSide::DEFENDER).color.isValidPlayer() && gameHandler->gameInfo().getPlayerState(bs.info->getSide(BattleSide::DEFENDER).color)->isHuman();
+	if(!topBattleQuery && isDefenderHuman)
 	{
 		auto defenderQuery = gameHandler->queries->topQuery(bs.info->getSide(BattleSide::DEFENDER).color);
 		topBattleQuery = gameHandler->queries->queryAs<CBattleQuery>(defenderQuery);
 	}
 
-	bool isDefenderHuman = bs.info->getSide(BattleSide::DEFENDER).color.isValidPlayer() && gameHandler->gameInfo().getPlayerState(bs.info->getSide(BattleSide::DEFENDER).color)->isHuman();
 	bool isAttackerHuman = gameHandler->gameInfo().getPlayerState(bs.info->getSide(BattleSide::ATTACKER).color)->isHuman();
 
 	bool onlyOnePlayerHuman = isDefenderHuman != isAttackerHuman;

--- a/server/battles/BattleResultProcessor.cpp
+++ b/server/battles/BattleResultProcessor.cpp
@@ -252,13 +252,17 @@ void BattleResultProcessor::endBattle(const CBattleInfoCallback & battle)
 		battleResult->exp[BattleSide::DEFENDER] = heroDefender->calculateXp(battleResult->exp[BattleSide::DEFENDER]);
 
 	auto attackerQuery = gameHandler->queries->topQuery(battle.sideToPlayer(BattleSide::ATTACKER));
+
 	QueryPtr battleQuery;
+	const auto * defenderPlayer = gameHandler->gameInfo().getPlayerState(battle.getBattle()->getSidePlayer(BattleSide::DEFENDER));
+	bool isDefenderHuman = defenderPlayer && defenderPlayer->isHuman();
 	if(gameHandler->queries->queryAs<CBattleQuery>(attackerQuery))
 		battleQuery = attackerQuery;
-	else
+	else if(isDefenderHuman)
 	{
 		auto defenderQuery = gameHandler->queries->topQuery(battle.sideToPlayer(BattleSide::DEFENDER));
-		battleQuery = defenderQuery;
+		if(gameHandler->queries->queryAs<CBattleQuery>(defenderQuery))
+			battleQuery = defenderQuery;
 	}
 
 	if (!battleQuery)
@@ -279,9 +283,7 @@ void BattleResultProcessor::endBattle(const CBattleInfoCallback & battle)
 
 	// in battles against neutrals, 1st player can ask to replay battle manually
 	const auto * attackerPlayer = gameHandler->gameInfo().getPlayerState(battle.getBattle()->getSidePlayer(BattleSide::ATTACKER));
-	const auto * defenderPlayer = gameHandler->gameInfo().getPlayerState(battle.getBattle()->getSidePlayer(BattleSide::DEFENDER));
 	bool isAttackerHuman = attackerPlayer && attackerPlayer->isHuman();
-	bool isDefenderHuman = defenderPlayer && defenderPlayer->isHuman();
 	bool onlyOnePlayerHuman = isAttackerHuman != isDefenderHuman;
 	// in battles against neutrals attacker can ask to replay battle manually, additionally in battles against AI player human side can also ask for replay
 	if(onlyOnePlayerHuman)
@@ -294,7 +296,7 @@ void BattleResultProcessor::endBattle(const CBattleInfoCallback & battle)
 		battleResult->queryID = QueryID::NONE;
 
 	//set same battle result for all gameHandler->queries
-	for(auto & q : gameHandler->queries->allQueries())
+	for(const auto & q : gameHandler->queries->allQueries())
 	{
 		auto * otherBattleQuery = gameHandler->queries->queryAs<CBattleQuery>(q);
 		if(otherBattleQuery && otherBattleQuery->battleID == battle.getBattle()->getBattleID())
@@ -313,18 +315,18 @@ void BattleResultProcessor::endBattleConfirm(const CBattleInfoCallback & battle)
 	auto attackerQuery = gameHandler->queries->topQuery(battle.sideToPlayer(BattleSide::ATTACKER));
 
 	QueryPtr battleQueryPtr;
-	auto * battleQuery = gameHandler->queries->queryAs<CBattleQuery>(attackerQuery);
-	if(battleQuery)
+	auto defenderPlayer = battle.sideToPlayer(BattleSide::DEFENDER);
+	if(gameHandler->queries->queryAs<CBattleQuery>(attackerQuery))
 		battleQueryPtr = attackerQuery;
-	else
+	else if(defenderPlayer.isValidPlayer())
 	{
 		auto defenderQuery = gameHandler->queries->topQuery(battle.sideToPlayer(BattleSide::DEFENDER));
-		battleQuery = gameHandler->queries->queryAs<CBattleQuery>(defenderQuery);
-		if(battleQuery)
-			battleQueryPtr = attackerQuery;
+		if(gameHandler->queries->queryAs<CBattleQuery>(defenderQuery))
+			battleQueryPtr = defenderQuery;
 	}
 
-	if(!battleQuery)
+	auto * typedBattleQuery = gameHandler->queries->queryAs<CBattleQuery>(battleQueryPtr);
+	if(!typedBattleQuery)
 	{
 		logGlobal->trace("No battle query, battle end was confirmed by another player");
 		return;
@@ -371,7 +373,6 @@ void BattleResultProcessor::endBattleConfirm(const CBattleInfoCallback & battle)
 	}
 
 	auto attackerPlayer = battle.sideToPlayer(BattleSide::ATTACKER);
-	auto defenderPlayer = battle.sideToPlayer(BattleSide::DEFENDER);
 	auto isAttackerNeutral = attackerPlayer == PlayerColor::NEUTRAL;
 	auto isDefenderNeutral = defenderPlayer == PlayerColor::NEUTRAL;
 

--- a/server/battles/BattleResultProcessor.cpp
+++ b/server/battles/BattleResultProcessor.cpp
@@ -251,9 +251,16 @@ void BattleResultProcessor::endBattle(const CBattleInfoCallback & battle)
 	if(heroDefender)
 		battleResult->exp[BattleSide::DEFENDER] = heroDefender->calculateXp(battleResult->exp[BattleSide::DEFENDER]);
 
-	auto battleQuery = std::dynamic_pointer_cast<CBattleQuery>(gameHandler->queries->topQuery(battle.sideToPlayer(BattleSide::ATTACKER)));
-	if(!battleQuery)
-		battleQuery = std::dynamic_pointer_cast<CBattleQuery>(gameHandler->queries->topQuery(battle.sideToPlayer(BattleSide::DEFENDER)));
+	auto attackerQuery = gameHandler->queries->topQuery(battle.sideToPlayer(BattleSide::ATTACKER));
+	QueryPtr battleQuery;
+	if(gameHandler->queries->queryAs<CBattleQuery>(attackerQuery))
+		battleQuery = attackerQuery;
+	else
+	{
+		auto defenderQuery = gameHandler->queries->topQuery(battle.sideToPlayer(BattleSide::DEFENDER));
+		battleQuery = defenderQuery;
+	}
+
 	if (!battleQuery)
 	{
 		logGlobal->error("Cannot find battle query!");
@@ -261,18 +268,11 @@ void BattleResultProcessor::endBattle(const CBattleInfoCallback & battle)
 		return;
 	}
 
-	battleQuery->result = std::make_optional(*battleResult);
+	auto * typedBattleQuery = gameHandler->queries->queryAs<CBattleQuery>(battleQuery);
+	typedBattleQuery->result = std::make_optional(*battleResult);
 
 	//Check how many battle gameHandler->queries were created (number of players blocked by battle)
-	int queriedPlayers = 0;
-	if(battleQuery)
-	{
-		for(const auto & query : gameHandler->queries->allQueries())
-		{
-			if(query == battleQuery)
-				++queriedPlayers;
-		}
-	}
+	const int queriedPlayers = gameHandler->queries->countQuery(battleQuery);
 
 	assert(finishingBattles.count(battle.getBattle()->getBattleID()) == 0);
 	finishingBattles[battle.getBattle()->getBattleID()] = std::make_unique<FinishingBattleHelper>(battle, *battleResult, queriedPlayers);
@@ -286,7 +286,7 @@ void BattleResultProcessor::endBattle(const CBattleInfoCallback & battle)
 	// in battles against neutrals attacker can ask to replay battle manually, additionally in battles against AI player human side can also ask for replay
 	if(onlyOnePlayerHuman)
 	{
-		auto battleDialogQuery = std::make_shared<CBattleDialogQuery>(gameHandler, battle.getBattle(), battleQuery->result);
+		auto battleDialogQuery = std::make_shared<CBattleDialogQuery>(gameHandler, battle.getBattle(), typedBattleQuery->result);
 		battleResult->queryID = battleDialogQuery->queryID;
 		gameHandler->queries->addQuery(battleDialogQuery);
 	}
@@ -296,9 +296,9 @@ void BattleResultProcessor::endBattle(const CBattleInfoCallback & battle)
 	//set same battle result for all gameHandler->queries
 	for(auto & q : gameHandler->queries->allQueries())
 	{
-		auto otherBattleQuery = std::dynamic_pointer_cast<CBattleQuery>(q);
+		auto * otherBattleQuery = gameHandler->queries->queryAs<CBattleQuery>(q);
 		if(otherBattleQuery && otherBattleQuery->battleID == battle.getBattle()->getBattleID())
-			otherBattleQuery->result = battleQuery->result;
+			otherBattleQuery->result = typedBattleQuery->result;
 	}
 
 	gameHandler->turnTimerHandler->onBattleEnd(battle.getBattle()->getBattleID());
@@ -310,9 +310,20 @@ void BattleResultProcessor::endBattle(const CBattleInfoCallback & battle)
 
 void BattleResultProcessor::endBattleConfirm(const CBattleInfoCallback & battle)
 {
-	auto battleQuery = std::dynamic_pointer_cast<CBattleQuery>(gameHandler->queries->topQuery(battle.sideToPlayer(BattleSide::ATTACKER)));
-	if(!battleQuery)
-		battleQuery = std::dynamic_pointer_cast<CBattleQuery>(gameHandler->queries->topQuery(battle.sideToPlayer(BattleSide::DEFENDER)));
+	auto attackerQuery = gameHandler->queries->topQuery(battle.sideToPlayer(BattleSide::ATTACKER));
+
+	QueryPtr battleQueryPtr;
+	auto * battleQuery = gameHandler->queries->queryAs<CBattleQuery>(attackerQuery);
+	if(battleQuery)
+		battleQueryPtr = attackerQuery;
+	else
+	{
+		auto defenderQuery = gameHandler->queries->topQuery(battle.sideToPlayer(BattleSide::DEFENDER));
+		battleQuery = gameHandler->queries->queryAs<CBattleQuery>(defenderQuery);
+		if(battleQuery)
+			battleQueryPtr = attackerQuery;
+	}
+
 	if(!battleQuery)
 	{
 		logGlobal->trace("No battle query, battle end was confirmed by another player");
@@ -400,7 +411,7 @@ void BattleResultProcessor::endBattleConfirm(const CBattleInfoCallback & battle)
 	raccepted.winnerSide = finishingBattle->winnerSide;
 	gameHandler->sendAndApply(raccepted);
 
-	gameHandler->queries->popIfTop(battleQuery); // Workaround to remove battle query for AI case. TODO Think of a cleaner solution.
+	gameHandler->queries->popIfTop(battleQueryPtr); // Workaround to remove battle query for AI case. TODO Think of a cleaner solution.
 	//--> continuation (battleFinalize) occurs after level-up gameHandler->queries are handled or on removing query
 }
 

--- a/server/battles/BattleResultProcessor.cpp
+++ b/server/battles/BattleResultProcessor.cpp
@@ -264,7 +264,15 @@ void BattleResultProcessor::endBattle(const CBattleInfoCallback & battle)
 	battleQuery->result = std::make_optional(*battleResult);
 
 	//Check how many battle gameHandler->queries were created (number of players blocked by battle)
-	const int queriedPlayers = battleQuery ? boost::count(gameHandler->queries->allQueries(), battleQuery) : 0;
+	int queriedPlayers = 0;
+	if(battleQuery)
+	{
+		for(const auto & query : gameHandler->queries->allQueries())
+		{
+			if(query == battleQuery)
+				++queriedPlayers;
+		}
+	}
 
 	assert(finishingBattles.count(battle.getBattle()->getBattleID()) == 0);
 	finishingBattles[battle.getBattle()->getBattleID()] = std::make_unique<FinishingBattleHelper>(battle, *battleResult, queriedPlayers);
@@ -286,7 +294,7 @@ void BattleResultProcessor::endBattle(const CBattleInfoCallback & battle)
 		battleResult->queryID = QueryID::NONE;
 
 	//set same battle result for all gameHandler->queries
-	for(auto q : gameHandler->queries->allQueries())
+	for(auto & q : gameHandler->queries->allQueries())
 	{
 		auto otherBattleQuery = std::dynamic_pointer_cast<CBattleQuery>(q);
 		if(otherBattleQuery && otherBattleQuery->battleID == battle.getBattle()->getBattleID())

--- a/server/processors/NewTurnProcessor.cpp
+++ b/server/processors/NewTurnProcessor.cpp
@@ -34,6 +34,7 @@
 #include "../../lib/networkPacks/StackLocation.h"
 #include "../../lib/pathfinder/TurnInfo.h"
 #include "../../lib/texts/CGeneralTextHandler.h"
+#include "../TurnStartVisitScheduler.h"
 
 #include <vstd/RNG.h>
 
@@ -149,15 +150,20 @@ void NewTurnProcessor::onPlayerTurnStarted(PlayerColor which)
 	for (const auto * t : playerState->getTowns())
 		handleTownEvents(t);
 
+	std::deque<PendingTurnStartVisit> visits;
+
 	for (const auto * t : playerState->getTowns())
 	{
 		//garrison hero first - consistent with original H3 Mana Vortex and Battle Scholar Academy levelup windows order
-		if (t->getGarrisonHero() != nullptr)
-			gameHandler->objectVisited(t, t->getGarrisonHero());
+		if(t->getGarrisonHero() != nullptr)
+			visits.push_back({which, t->id, t->getGarrisonHero()->id});
 
-		if (t->getVisitingHero() != nullptr)
-			gameHandler->objectVisited(t, t->getVisitingHero());
+		if(t->getVisitingHero() != nullptr)
+			visits.push_back({which, t->id, t->getVisitingHero()->id});
 	}
+
+	gameHandler->turnStartVisitScheduler->enqueue(which, std::move(visits));
+	gameHandler->turnStartVisitScheduler->processNext(which);
 }
 
 void NewTurnProcessor::onPlayerTurnEnded(PlayerColor which)

--- a/server/queries/BattleQueries.cpp
+++ b/server/queries/BattleQueries.cpp
@@ -31,7 +31,7 @@ void CBattleQuery::notifyObjectAboutRemoval(const CGObjectInstance * visitedObje
 }
 
 CBattleQuery::CBattleQuery(CGameHandler * owner, const IBattleInfo * bi):
-	CQuery(owner),
+	CQuery(owner, TYPE),
 	battleID(bi->getBattleID())
 {
 	belligerents[BattleSide::ATTACKER] = bi->getSideArmy(BattleSide::ATTACKER);
@@ -42,7 +42,7 @@ CBattleQuery::CBattleQuery(CGameHandler * owner, const IBattleInfo * bi):
 }
 
 CBattleQuery::CBattleQuery(CGameHandler * owner):
-	CQuery(owner)
+	CQuery(owner, TYPE)
 {
 	belligerents[BattleSide::ATTACKER] = nullptr;
 	belligerents[BattleSide::DEFENDER] = nullptr;
@@ -77,7 +77,7 @@ void CBattleQuery::onExposure(QueryPtr topQuery)
 }
 
 CBattleDialogQuery::CBattleDialogQuery(CGameHandler * owner, const IBattleInfo * bi, const std::optional<BattleResult> & Br):
-	CDialogQuery(owner),
+	CDialogQuery(owner, TYPE),
 	bi(bi),
 	result(Br)
 {

--- a/server/queries/BattleQueries.cpp
+++ b/server/queries/BattleQueries.cpp
@@ -37,8 +37,13 @@ CBattleQuery::CBattleQuery(CGameHandler * owner, const IBattleInfo * bi):
 	belligerents[BattleSide::ATTACKER] = bi->getSideArmy(BattleSide::ATTACKER);
 	belligerents[BattleSide::DEFENDER] = bi->getSideArmy(BattleSide::DEFENDER);
 
-	addPlayer(bi->getSidePlayer(BattleSide::ATTACKER));
-	addPlayer(bi->getSidePlayer(BattleSide::DEFENDER));
+	auto attacker = bi->getSidePlayer(BattleSide::ATTACKER);
+	if(attacker.isValidPlayer())
+		addPlayer(attacker);
+
+	auto defender = bi->getSidePlayer(BattleSide::DEFENDER);
+	if(defender.isValidPlayer())
+		addPlayer(defender);
 }
 
 CBattleQuery::CBattleQuery(CGameHandler * owner):
@@ -81,8 +86,13 @@ CBattleDialogQuery::CBattleDialogQuery(CGameHandler * owner, const IBattleInfo *
 	bi(bi),
 	result(Br)
 {
-	addPlayer(bi->getSidePlayer(BattleSide::ATTACKER));
-	addPlayer(bi->getSidePlayer(BattleSide::DEFENDER));
+	auto attacker = bi->getSidePlayer(BattleSide::ATTACKER);
+	if(attacker.isValidPlayer())
+		addPlayer(attacker);
+
+	auto defender = bi->getSidePlayer(BattleSide::DEFENDER);
+	if(defender.isValidPlayer())
+		addPlayer(defender);
 }
 
 void CBattleDialogQuery::onRemoval(PlayerColor color)

--- a/server/queries/BattleQueries.h
+++ b/server/queries/BattleQueries.h
@@ -21,6 +21,8 @@ VCMI_LIB_NAMESPACE_END
 class CBattleQuery : public CQuery
 {
 public:
+	static constexpr QueryType TYPE = QueryType::Battle;
+
 	BattleSideArray<const CArmedInstance *> belligerents;
 
 	BattleID battleID;
@@ -41,6 +43,7 @@ class CBattleDialogQuery : public CDialogQuery
 	std::optional<BattleResult> result;
 
 public:
+	static constexpr QueryType TYPE = QueryType::BattleDialog;
 	CBattleDialogQuery(CGameHandler * owner, const IBattleInfo * Bi, const std::optional<BattleResult> & Br);
 	void onRemoval(PlayerColor color) override;
 };

--- a/server/queries/CQuery.cpp
+++ b/server/queries/CQuery.cpp
@@ -97,8 +97,7 @@ void CQuery::notifyObjectAboutRemoval(const CGObjectInstance * visitedObject, co
 
 void CQuery::onExposure(QueryPtr topQuery)
 {
-	logGlobal->trace("Exposed query with id %d", queryID);
-	owner->popQuery(*this);
+
 }
 
 void CQuery::onAdding(PlayerColor color)

--- a/server/queries/CQuery.cpp
+++ b/server/queries/CQuery.cpp
@@ -26,9 +26,10 @@ std::ostream & operator<<(std::ostream & out, QueryPtr query)
 	return out << "[" << query.get() << "] " << query->toString();
 }
 
-CQuery::CQuery(CGameHandler * gameHandler)
+CQuery::CQuery(CGameHandler * gameHandler, QueryType type)
 	: owner(gameHandler->queries.get())
 	, gh(gameHandler)
+	, type(type)
 {
 	queryID = ++gameHandler->QID;
 	logGlobal->trace("Created a new query with id %d", queryID);
@@ -119,8 +120,8 @@ bool CQuery::blockAllButReply(const CPackForServer * pack) const
 	return true;
 }
 
-CDialogQuery::CDialogQuery(CGameHandler * owner):
-	CQuery(owner)
+CDialogQuery::CDialogQuery(CGameHandler * owner, QueryType type):
+	CQuery(owner, type)
 {
 
 }
@@ -142,7 +143,7 @@ void CDialogQuery::setReply(std::optional<int32_t> reply)
 }
 
 CGenericQuery::CGenericQuery(CGameHandler * gh, PlayerColor color, const std::function<void(std::optional<int32_t>)> & callback):
-	CQuery(gh), callback(callback)
+	CQuery(gh, QueryType::Generic), callback(callback)
 {
 	addPlayer(color);
 }

--- a/server/queries/CQuery.cpp
+++ b/server/queries/CQuery.cpp
@@ -42,9 +42,9 @@ CQuery::~CQuery()
 
 void CQuery::addPlayer(PlayerColor color)
 {
-	if(!color.isValidPlayer())
-		return;
+	assert(color.isValidPlayer());
 
+	// prevent duplicates
 	if(vstd::contains(players, color))
 		return;
 

--- a/server/queries/CQuery.cpp
+++ b/server/queries/CQuery.cpp
@@ -42,8 +42,13 @@ CQuery::~CQuery()
 
 void CQuery::addPlayer(PlayerColor color)
 {
-	if(color.isValidPlayer())
-		players.push_back(color);
+	if(!color.isValidPlayer())
+		return;
+
+	if(vstd::contains(players, color))
+		return;
+
+	players.push_back(color);
 }
 
 std::string CQuery::toString() const

--- a/server/queries/CQuery.h
+++ b/server/queries/CQuery.h
@@ -10,7 +10,7 @@
 #pragma once
 
 #include "../../lib/constants/EntityIdentifiers.h"
-#include <cstdint>
+#include <boost/container/small_vector.hpp>
 
 VCMI_LIB_NAMESPACE_BEGIN
 

--- a/server/queries/CQuery.h
+++ b/server/queries/CQuery.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "../../lib/constants/EntityIdentifiers.h"
+#include <cstdint>
 
 VCMI_LIB_NAMESPACE_BEGIN
 
@@ -26,6 +27,24 @@ class CGameHandler;
 
 using QueryPtr = std::shared_ptr<CQuery>;
 
+enum class QueryType : uint8_t
+{
+	BlockingDialog,
+	GarrisonDialog,
+	TeleportDialog,
+	HeroLevelUpDialog,
+	CommanderLevelUpDialog,
+	OpenWindow,
+	MapObjectVisit,
+	TownBuildingVisit,
+	Battle,
+	BattleDialog,
+	HeroMovement,
+	TimerPause,
+	Generic,
+	Unknown
+};
+
 // This class represents any kind of prolonged interaction that may need to do something special after it is over.
 // It does not necessarily has to be "query" requiring player action, it can be also used internally within server.
 // Examples:
@@ -40,7 +59,10 @@ public:
 	std::vector<PlayerColor> players; //players that are affected (often "blocked") by query
 	QueryID queryID;
 
-	CQuery(CGameHandler * gh);
+	QueryType getType() const
+	{
+		return type;
+	}
 
 	/// query can block attempting actions by player. Eg. he can't move hero during the battle.
 	virtual bool blocksPack(const CPackForServer *pack) const;
@@ -68,10 +90,15 @@ public:
 
 	virtual ~CQuery();
 protected:
+	explicit CQuery(CGameHandler * gh, QueryType type);
+
 	QueriesProcessor * owner;
 	CGameHandler * gh;
 	void addPlayer(PlayerColor color);
 	bool blockAllButReply(const CPackForServer * pack) const;
+
+private:
+	QueryType type = QueryType::Unknown;
 };
 
 std::ostream &operator<<(std::ostream &out, const CQuery &query);
@@ -80,7 +107,7 @@ std::ostream &operator<<(std::ostream &out, QueryPtr query);
 class CDialogQuery : public CQuery
 {
 public:
-	explicit CDialogQuery(CGameHandler * owner);
+	explicit CDialogQuery(CGameHandler * owner, QueryType type);
 	bool endsByPlayerAnswer() const override;
 	bool blocksPack(const CPackForServer *pack) const override;
 	void setReply(std::optional<int32_t> reply) override;

--- a/server/queries/CQuery.h
+++ b/server/queries/CQuery.h
@@ -56,7 +56,7 @@ enum class QueryType : uint8_t
 class CQuery : boost::noncopyable
 {
 public:
-	std::vector<PlayerColor> players; //players that are affected (often "blocked") by query
+	boost::container::small_vector<PlayerColor, PlayerColor::PLAYER_LIMIT_I> players; //players that are affected (often "blocked") by query
 	QueryID queryID;
 
 	QueryType getType() const

--- a/server/queries/IQueryStackListener.h
+++ b/server/queries/IQueryStackListener.h
@@ -1,0 +1,22 @@
+/*
+ * IQueryStackListener.h, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
+#pragma once
+
+#include "../../lib/constants/EntityIdentifiers.h"
+
+class IQueryStackListener
+{
+public:
+	virtual ~IQueryStackListener() = default;
+
+	// Called after a player's query stack changes and local query lifecycle
+	// handling for that operation is complete.
+	virtual void onQueryStackChanged(PlayerColor player) = 0;
+};

--- a/server/queries/MapQueries.cpp
+++ b/server/queries/MapQueries.cpp
@@ -19,7 +19,7 @@
 #include "../../lib/networkPacks/PacksForServer.h"
 
 TimerPauseQuery::TimerPauseQuery(CGameHandler * owner, PlayerColor player):
-	CQuery(owner)
+	CQuery(owner, TYPE)
 {
 	addPlayer(player);
 }
@@ -62,7 +62,7 @@ void CGarrisonDialogQuery::notifyObjectAboutRemoval(const CGObjectInstance * vis
 }
 
 CGarrisonDialogQuery::CGarrisonDialogQuery(CGameHandler * owner, const CArmedInstance * up, const CArmedInstance * down):
-	CDialogQuery(owner)
+	CDialogQuery(owner, TYPE)
 {
 	exchangingArmies[0] = up;
 	exchangingArmies[1] = down;
@@ -142,14 +142,15 @@ void CBlockingDialogQuery::notifyObjectAboutRemoval(const CGObjectInstance * vis
 }
 
 CBlockingDialogQuery::CBlockingDialogQuery(CGameHandler * owner, const IObjectInterface * caller, const BlockingDialog & bd):
-	CDialogQuery(owner),
+	CDialogQuery(owner, TYPE),
 	caller(caller)
 {
 	this->bd = bd;
 	addPlayer(bd.player);
 }
 
-OpenWindowQuery::OpenWindowQuery(CGameHandler * owner, const CGHeroInstance * hero, EOpenWindowMode mode) : CDialogQuery(owner), mode(mode)
+OpenWindowQuery::OpenWindowQuery(CGameHandler * owner, const CGHeroInstance * hero, EOpenWindowMode mode)
+	: CDialogQuery(owner, TYPE), mode(mode)
 {
 	addPlayer(hero->getOwner());
 }
@@ -216,14 +217,15 @@ void CTeleportDialogQuery::notifyObjectAboutRemoval(const CGObjectInstance * vis
 		logGlobal->error("Invalid instance in teleport query");
 }
 
-CTeleportDialogQuery::CTeleportDialogQuery(CGameHandler * owner, const TeleportDialog & td) : CDialogQuery(owner)
+CTeleportDialogQuery::CTeleportDialogQuery(CGameHandler * owner, const TeleportDialog & td) :
+	CDialogQuery(owner, TYPE)
 {
 	this->td = td;
 	addPlayer(gh->gameInfo().getHero(td.hero)->getOwner());
 }
 
 CHeroLevelUpDialogQuery::CHeroLevelUpDialogQuery(CGameHandler * owner, const HeroLevelUp & Hlu, const CGHeroInstance * Hero):
-	CDialogQuery(owner), hero(Hero)
+	CDialogQuery(owner, TYPE), hero(Hero)
 {
 	hlu = Hlu;
 	addPlayer(hero->tempOwner);
@@ -283,8 +285,8 @@ void CHeroLevelUpDialogQuery::notifyObjectAboutRemoval(const CGObjectInstance * 
 	visitedObject->heroLevelUpDone(*gh, visitingHero);
 }
 
-CCommanderLevelUpDialogQuery::CCommanderLevelUpDialogQuery(CGameHandler * owner, const CommanderLevelUp & Clu, const CGHeroInstance * Hero):
-	CDialogQuery(owner), hero(Hero)
+CCommanderLevelUpDialogQuery::CCommanderLevelUpDialogQuery(CGameHandler * owner, const CommanderLevelUp & Clu, const CGHeroInstance * Hero)
+	: CDialogQuery(owner, TYPE), hero(Hero)
 {
 	clu = Clu;
 	addPlayer(hero->tempOwner);
@@ -339,7 +341,7 @@ void CCommanderLevelUpDialogQuery::notifyObjectAboutRemoval(const CGObjectInstan
 }
 
 CHeroMovementQuery::CHeroMovementQuery(CGameHandler * owner, const TryMoveHero & Tmh, const CGHeroInstance * Hero, bool VisitDestAfterVictory):
-	CQuery(owner), tmh(Tmh), visitDestAfterVictory(VisitDestAfterVictory), hero(Hero)
+	CQuery(owner, TYPE), tmh(Tmh), visitDestAfterVictory(VisitDestAfterVictory), hero(Hero)
 {
 	players.push_back(hero->tempOwner);
 }

--- a/server/queries/MapQueries.h
+++ b/server/queries/MapQueries.h
@@ -23,9 +23,11 @@ VCMI_LIB_NAMESPACE_END
 //Removed when player accepts a turn or continur play
 class TimerPauseQuery : public CQuery
 {
-public:	
+public:
+	static constexpr QueryType TYPE = QueryType::TimerPause;
+
 	TimerPauseQuery(CGameHandler * owner, PlayerColor player);
-	
+
 	bool blocksPack(const CPackForServer *pack) const override;
 	void onExposure(QueryPtr topQuery) override;
 	void onAdding(PlayerColor color) override;
@@ -38,6 +40,8 @@ public:
 class CHeroMovementQuery : public CQuery
 {
 public:
+	static constexpr QueryType TYPE = QueryType::HeroMovement;
+
 	TryMoveHero tmh;
 	bool visitDestAfterVictory; //if hero moved to guarded tile and it should be visited once guard is defeated
 	const CGHeroInstance *hero;
@@ -52,6 +56,8 @@ public:
 class CGarrisonDialogQuery : public CDialogQuery //used also for hero exchange dialogs
 {
 public:
+	static constexpr QueryType TYPE = QueryType::GarrisonDialog;
+
 	std::array<const CArmedInstance *,2> exchangingArmies;
 
 	CGarrisonDialogQuery(CGameHandler * owner, const CArmedInstance *up, const CArmedInstance *down);
@@ -63,6 +69,8 @@ public:
 class CBlockingDialogQuery : public CDialogQuery
 {
 public:
+	static constexpr QueryType TYPE = QueryType::BlockingDialog;
+
 	const IObjectInterface * caller;
 	BlockingDialog bd; //copy of pack... debug purposes
 
@@ -75,6 +83,8 @@ class OpenWindowQuery : public CDialogQuery
 {
 	EOpenWindowMode mode;
 public:
+	static constexpr QueryType TYPE = QueryType::OpenWindow;
+
 	OpenWindowQuery(CGameHandler * owner, const CGHeroInstance *hero, EOpenWindowMode mode);
 
 	bool blocksPack(const CPackForServer *pack) const override;
@@ -84,6 +94,8 @@ public:
 class CTeleportDialogQuery : public CDialogQuery
 {
 public:
+	static constexpr QueryType TYPE = QueryType::TeleportDialog;
+
 	TeleportDialog td; //copy of pack... debug purposes
 
 	CTeleportDialogQuery(CGameHandler * owner, const TeleportDialog &td);
@@ -94,6 +106,8 @@ public:
 class CHeroLevelUpDialogQuery : public CDialogQuery
 {
 public:
+	static constexpr QueryType TYPE = QueryType::HeroLevelUpDialog;
+
 	CHeroLevelUpDialogQuery(CGameHandler * owner, const HeroLevelUp &Hlu, const CGHeroInstance * Hero);
 
 	void onRemoval(PlayerColor color) override;
@@ -109,6 +123,8 @@ public:
 class CCommanderLevelUpDialogQuery : public CDialogQuery
 {
 public:
+	static constexpr QueryType TYPE = QueryType::CommanderLevelUpDialog;
+
 	CCommanderLevelUpDialogQuery(CGameHandler * owner, const CommanderLevelUp &Clu, const CGHeroInstance * Hero);
 
 	void onRemoval(PlayerColor color) override;

--- a/server/queries/QueriesProcessor.cpp
+++ b/server/queries/QueriesProcessor.cpp
@@ -88,6 +88,9 @@ void QueriesProcessor::addQuery(PlayerColor player, QueryPtr query)
 
 QueryPtr QueriesProcessor::topQuery(PlayerColor player)
 {
+	if(!player.isValidPlayer())
+		return nullptr;
+
 	return vstd::backOrNull(queries[player]);
 }
 
@@ -124,5 +127,19 @@ QueryPtr QueriesProcessor::getQuery(QueryID queryID)
 			if(query->queryID == queryID)
 				return query;
 	return nullptr;
+}
+
+int QueriesProcessor::countQuery(const QueryPtr & query) const
+{
+	if(!query)
+		return 0;
+
+	int result = 0;
+	for(const auto & currentQuery : allQueries())
+	{
+		if(currentQuery == query)
+			++result;
+	}
+	return result;
 }
 

--- a/server/queries/QueriesProcessor.cpp
+++ b/server/queries/QueriesProcessor.cpp
@@ -33,6 +33,9 @@ void QueriesProcessor::popQuery(PlayerColor player, QueryPtr query)
 	//Exposure on query below happens only if removal didn't trigger any new query
 	if(nextQuery && nextQuery == topQuery(player))
 		nextQuery->onExposure(query);
+
+	if(queriesStackListener)
+		queriesStackListener->onQueryStackChanged(player);
 }
 
 void QueriesProcessor::popQuery(const CQuery &query)
@@ -82,6 +85,9 @@ void QueriesProcessor::addQuery(PlayerColor player, QueryPtr query)
 	query->onAdding(player);
 	queries[player].push_back(query);
 	query->onAdded(player);
+
+	if(queriesStackListener)
+		queriesStackListener->onQueryStackChanged(player);
 }
 
 QueryPtr QueriesProcessor::topQuery(PlayerColor player)
@@ -143,5 +149,10 @@ int QueriesProcessor::countQuery(const QueryPtr & query) const
 			++result;
 	}
 	return result;
+}
+
+void QueriesProcessor::setListener(IQueryStackListener * listener)
+{
+	queriesStackListener = listener;
 }
 

--- a/server/queries/QueriesProcessor.cpp
+++ b/server/queries/QueriesProcessor.cpp
@@ -21,10 +21,10 @@ void QueriesProcessor::popQuery(PlayerColor player, QueryPtr query)
 		return;
 	}
 
-	const int idx = player.getNum();
-	assert(query && idx >= 0 && idx < PlayerColor::PLAYER_LIMIT_I);
+	const auto idx = static_cast<size_t>(player.getNum());
+	assert(query);
 
-	auto & stack = queries[static_cast<size_t>(idx)];
+	auto & stack = queries.at(idx);
 	stack.pop_back();
 	auto nextQuery = topQuery(player);
 
@@ -76,14 +76,14 @@ void QueriesProcessor::addQuery(PlayerColor player, QueryPtr query)
 {
 	LOG_TRACE_PARAMS(logGlobal, "player='%d', query='%s'", player.getNum() % query);
 
-	const int idx = player.getNum();
-	assert(query && idx >= 0 && idx < PlayerColor::PLAYER_LIMIT_I);
-	auto & stack = queries[static_cast<size_t>(idx)];
+	const auto idx = static_cast<size_t>(player.getNum());
+	assert(query);
+	auto & stack = queries.at(idx);
 	// Prevent adding the same query twice in a row
 	if(!stack.empty() && stack.back() == query)
 		return;
 	query->onAdding(player);
-	queries[player].push_back(query);
+	queries.at(idx).push_back(query);
 	query->onAdded(player);
 
 	if(queriesStackListener)

--- a/server/queries/QueriesProcessor.cpp
+++ b/server/queries/QueriesProcessor.cpp
@@ -88,6 +88,7 @@ void QueriesProcessor::addQuery(PlayerColor player, QueryPtr query)
 
 QueryPtr QueriesProcessor::topQuery(PlayerColor player)
 {
+	assert(player.isValidPlayer());
 	if(!player.isValidPlayer())
 		return nullptr;
 

--- a/server/queries/QueriesProcessor.cpp
+++ b/server/queries/QueriesProcessor.cpp
@@ -50,11 +50,16 @@ void QueriesProcessor::popQuery(const CQuery &query)
 			popQuery(top);
 		else
 		{
-			logGlobal->trace("Cannot remove query %s", query.toString());
-			logGlobal->trace("Queries found:");
-			for(auto q : queries[player])
+			if(logGlobal->isTraceEnabled())
 			{
-				logGlobal->trace(q->toString());
+				const auto idx = static_cast<size_t>(player.getNum());
+
+				logGlobal->trace("Cannot remove query %s", query.toString());
+				logGlobal->trace("Queries found:");
+				for(const auto & q : queries.at(idx))
+				{
+					logGlobal->trace(q->toString());
+				}
 			}
 		}
 	}

--- a/server/queries/QueriesProcessor.cpp
+++ b/server/queries/QueriesProcessor.cpp
@@ -21,7 +21,11 @@ void QueriesProcessor::popQuery(PlayerColor player, QueryPtr query)
 		return;
 	}
 
-	queries[player] -= query;
+	const int idx = player.getNum();
+	assert(query && idx >= 0 && idx < PlayerColor::PLAYER_LIMIT_I);
+
+	auto & stack = queries[static_cast<size_t>(idx)];
+	stack.pop_back();
 	auto nextQuery = topQuery(player);
 
 	query->onRemoval(player);
@@ -71,6 +75,13 @@ void QueriesProcessor::addQuery(QueryPtr query)
 void QueriesProcessor::addQuery(PlayerColor player, QueryPtr query)
 {
 	LOG_TRACE_PARAMS(logGlobal, "player='%d', query='%s'", player.getNum() % query);
+
+	const int idx = player.getNum();
+	assert(query && idx >= 0 && idx < PlayerColor::PLAYER_LIMIT_I);
+	auto & stack = queries[static_cast<size_t>(idx)];
+	// Prevent adding the same query twice in a row
+	if(!stack.empty() && stack.back() == query)
+		return;
 	query->onAdding(player);
 	queries[player].push_back(query);
 }

--- a/server/queries/QueriesProcessor.cpp
+++ b/server/queries/QueriesProcessor.cpp
@@ -67,9 +67,6 @@ void QueriesProcessor::addQuery(QueryPtr query)
 {
 	for(auto player : query->players)
 		addQuery(player, query);
-
-	for(auto player : query->players)
-		query->onAdded(player);
 }
 
 void QueriesProcessor::addQuery(PlayerColor player, QueryPtr query)
@@ -84,6 +81,7 @@ void QueriesProcessor::addQuery(PlayerColor player, QueryPtr query)
 		return;
 	query->onAdding(player);
 	queries[player].push_back(query);
+	query->onAdded(player);
 }
 
 QueryPtr QueriesProcessor::topQuery(PlayerColor player)

--- a/server/queries/QueriesProcessor.cpp
+++ b/server/queries/QueriesProcessor.cpp
@@ -107,32 +107,22 @@ void QueriesProcessor::popIfTop(const CQuery & query)
 			popQuery(color, topQuery(color));
 }
 
-std::vector<std::shared_ptr<const CQuery>> QueriesProcessor::allQueries() const
+QueriesProcessor::AllQueriesViewConst QueriesProcessor::allQueries() const
 {
-	std::vector<std::shared_ptr<const CQuery>> ret;
-	for(const auto & playerQueries : queries)
-		for(const auto & query : playerQueries.second)
-			ret.push_back(query);
-
-	return ret;
+	return AllQueriesViewConst(queries);
 }
 
-std::vector<QueryPtr> QueriesProcessor::allQueries()
+QueriesProcessor::AllQueriesView QueriesProcessor::allQueries()
 {
-	//TODO code duplication with const function :(
-	std::vector<QueryPtr> ret;
-	for(const auto & playerQueries : queries)
-		for(const auto & query : playerQueries.second)
-			ret.push_back(query);
-
-	return ret;
+	return AllQueriesView(queries);
 }
 
 QueryPtr QueriesProcessor::getQuery(QueryID queryID)
 {
 	for(auto & playerQueries : queries)
-		for(auto & query : playerQueries.second)
+		for(auto & query : playerQueries)
 			if(query->queryID == queryID)
 				return query;
 	return nullptr;
 }
+

--- a/server/queries/QueriesProcessor.cpp
+++ b/server/queries/QueriesProcessor.cpp
@@ -99,7 +99,10 @@ void QueriesProcessor::popIfTop(QueryPtr query)
 {
 	LOG_TRACE_PARAMS(logGlobal, "query='%d'", query);
 	if(!query)
+	{
 		logGlobal->error("The query is nullptr! Ignoring.");
+		return;
+	}
 
 	popIfTop(*query);
 }

--- a/server/queries/QueriesProcessor.h
+++ b/server/queries/QueriesProcessor.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "../../lib/GameConstants.h"
+#include "constants/EntityIdentifiers.h"
 
 class CQuery;
 using QueryPtr = std::shared_ptr<CQuery>;
@@ -20,7 +21,7 @@ private:
 	void addQuery(PlayerColor player, QueryPtr query);
 	void popQuery(PlayerColor player, QueryPtr query);
 
-	std::map<PlayerColor, std::vector<QueryPtr>> queries; //player => stack of queries
+	std::array<std::vector<QueryPtr>, PlayerColor::PLAYER_LIMIT_I> queries; //player => stack of queries
 
 public:
 	void addQuery(QueryPtr query);

--- a/server/queries/QueriesProcessor.h
+++ b/server/queries/QueriesProcessor.h
@@ -107,6 +107,7 @@ public:
 
 	AllQueriesView allQueries();
 	AllQueriesViewConst allQueries() const;
+	int countQuery(const QueryPtr & query) const;
 
 	template<typename T, typename QueryPtrT>
 	using QueryAsResult = std::conditional_t<
@@ -129,17 +130,20 @@ public:
 		return static_cast<ResultT*>(query.get());
 	}
 
-	template<typename T>
-	T * topQueryAs(PlayerColor player)
+	template<typename T, typename Predicate>
+	T * findQuery(Predicate predicate) const
 	{
-		auto query = topQuery(player);
-		if(!query)
-			return nullptr;
+		for(const auto & playerQueries : queries)
+		{
+			for(auto it = playerQueries.rbegin(); it != playerQueries.rend(); ++it)
+			{
+				auto * query = dynamic_cast<T *>(it->get());
+				if(query && predicate(*query))
+					return query;
+			}
+		}
 
-		if(query->getType() != T::TYPE)
-			return nullptr;
-
-		assert(dynamic_cast<T*>(query.get()) != nullptr);
-		return static_cast<T*>(query.get());
+		return nullptr;
 	}
+
 };

--- a/server/queries/QueriesProcessor.h
+++ b/server/queries/QueriesProcessor.h
@@ -11,19 +11,91 @@
 
 #include "../../lib/GameConstants.h"
 #include "constants/EntityIdentifiers.h"
+#include "queries/CQuery.h"
 
 class CQuery;
 using QueryPtr = std::shared_ptr<CQuery>;
 
 class QueriesProcessor
 {
+public:
+	using QueriesStack = std::vector<QueryPtr>;
+	using QueriesPerPlayer = std::array<QueriesStack, PlayerColor::PLAYER_LIMIT_I>;
+
 private:
 	void addQuery(PlayerColor player, QueryPtr query);
 	void popQuery(PlayerColor player, QueryPtr query);
 
-	std::array<std::vector<QueryPtr>, PlayerColor::PLAYER_LIMIT_I> queries; //player => stack of queries
+	QueriesPerPlayer queries;
+
+	template<typename StorageT>
+	class AllQueriesViewT
+	{
+	public:
+		explicit AllQueriesViewT(StorageT & s) : storage(&s) {}
+
+		struct iterator
+		{
+			StorageT * storage = nullptr;
+			size_t outer = 0;
+			size_t inner = 0;
+
+			void advance()
+			{
+				while(outer < storage->size())
+				{
+					auto & v = (*storage)[outer];
+					if(inner < v.size())
+						return;
+
+					outer++;
+					inner = 0;
+				}
+			}
+
+			decltype(auto) operator*() const
+			{
+				return (*storage)[outer][inner]; // QueryPtr& albo const QueryPtr&
+			}
+
+			iterator & operator++()
+			{
+				inner++;
+				advance();
+				return *this;
+			}
+
+			bool operator==(const iterator & other) const
+			{
+				return storage == other.storage && outer == other.outer && inner == other.inner;
+			}
+
+			bool operator!=(const iterator & other) const
+			{
+				return !(*this == other);
+			}
+		};
+
+		iterator begin() const
+		{
+			iterator it{ storage, 0, 0 };
+			it.advance();
+			return it;
+		}
+
+		iterator end() const
+		{
+			return iterator{ storage, storage->size(), 0 };
+		}
+
+	private:
+		StorageT * storage;
+	};
 
 public:
+	using AllQueriesView = AllQueriesViewT<QueriesPerPlayer>;
+	using AllQueriesViewConst = AllQueriesViewT<const QueriesPerPlayer>;
+
 	void addQuery(QueryPtr query);
 	void popQuery(const CQuery &query);
 	void popQuery(QueryPtr query);
@@ -31,9 +103,43 @@ public:
 	void popIfTop(QueryPtr query); //removes this query if it is at the top (otherwise, do nothing)
 
 	QueryPtr topQuery(PlayerColor player);
-
-	std::vector<std::shared_ptr<const CQuery>> allQueries() const;
-	std::vector<QueryPtr> allQueries();
 	QueryPtr getQuery(QueryID queryID);
-	//void removeQuery
+
+	AllQueriesView allQueries();
+	AllQueriesViewConst allQueries() const;
+
+	template<typename T, typename QueryPtrT>
+	using QueryAsResult = std::conditional_t<
+		std::is_const_v<std::remove_pointer_t<decltype(std::declval<const QueryPtrT &>().get())>>,
+		const T *,
+		T *>;
+
+	template<typename T, typename QueryPtrT>
+	QueryAsResult<T, QueryPtrT> queryAs(const QueryPtrT & query)
+	{
+		using ResultT = std::remove_pointer_t<QueryAsResult<T, QueryPtrT>>;
+
+		if(!query)
+			return nullptr;
+
+		if(query->getType() != T::TYPE)
+			return nullptr;
+
+		assert(dynamic_cast<ResultT*>(query.get()) != nullptr);
+		return static_cast<ResultT*>(query.get());
+	}
+
+	template<typename T>
+	T * topQueryAs(PlayerColor player)
+	{
+		auto query = topQuery(player);
+		if(!query)
+			return nullptr;
+
+		if(query->getType() != T::TYPE)
+			return nullptr;
+
+		assert(dynamic_cast<T*>(query.get()) != nullptr);
+		return static_cast<T*>(query.get());
+	}
 };

--- a/server/queries/QueriesProcessor.h
+++ b/server/queries/QueriesProcessor.h
@@ -12,6 +12,7 @@
 #include "../../lib/GameConstants.h"
 #include "constants/EntityIdentifiers.h"
 #include "queries/CQuery.h"
+#include "IQueryStackListener.h"
 
 class CQuery;
 using QueryPtr = std::shared_ptr<CQuery>;
@@ -22,11 +23,15 @@ public:
 	using QueriesStack = std::vector<QueryPtr>;
 	using QueriesPerPlayer = std::array<QueriesStack, PlayerColor::PLAYER_LIMIT_I>;
 
+	// Sets an optional listener notified when a player's query stack changes.
+	void setListener(IQueryStackListener * listener);
+
 private:
 	void addQuery(PlayerColor player, QueryPtr query);
 	void popQuery(PlayerColor player, QueryPtr query);
 
 	QueriesPerPlayer queries;
+	IQueryStackListener * queriesStackListener = nullptr;
 
 	template<typename StorageT>
 	class AllQueriesViewT
@@ -55,7 +60,7 @@ private:
 
 			decltype(auto) operator*() const
 			{
-				return (*storage)[outer][inner]; // QueryPtr& albo const QueryPtr&
+				return (*storage)[outer][inner]; // QueryPtr& or const QueryPtr&
 			}
 
 			iterator & operator++()

--- a/server/queries/VisitQueries.cpp
+++ b/server/queries/VisitQueries.cpp
@@ -17,8 +17,8 @@
 #include "../CGameHandler.h"
 #include "QueriesProcessor.h"
 
-VisitQuery::VisitQuery(CGameHandler * owner, const CGObjectInstance * Obj, const CGHeroInstance * Hero)
-	: CQuery(owner)
+VisitQuery::VisitQuery(CGameHandler * owner, const CGObjectInstance * Obj, const CGHeroInstance * Hero, QueryType type)
+	: CQuery(owner, type)
 	, visitedObject(Obj->id)
 	, visitingHero(Hero->id)
 {
@@ -45,7 +45,7 @@ void MapObjectVisitQuery::onExposure(QueryPtr topQuery)
 }
 
 MapObjectVisitQuery::MapObjectVisitQuery(CGameHandler * owner, const CGObjectInstance * Obj, const CGHeroInstance * Hero)
-	: VisitQuery(owner, Obj, Hero)
+	: VisitQuery(owner, Obj, Hero, TYPE)
 	, removeObjectAfterVisit(false)
 {
 }
@@ -62,7 +62,7 @@ void MapObjectVisitQuery::onRemoval(PlayerColor color)
 }
 
 TownBuildingVisitQuery::TownBuildingVisitQuery(CGameHandler * owner, const CGTownInstance * Obj, std::vector<const CGHeroInstance *> heroes, std::vector<BuildingID> buildingToVisit)
-	: VisitQuery(owner, Obj, heroes.front())
+	: VisitQuery(owner, Obj, heroes.front(), TYPE)
 	, visitedTown(Obj)
 {
 	// generate in reverse order - first building-hero pair to handle must be in the end of vector

--- a/server/queries/VisitQueries.h
+++ b/server/queries/VisitQueries.h
@@ -20,7 +20,7 @@ VCMI_LIB_NAMESPACE_END
 class VisitQuery : public CQuery
 {
 protected:
-	VisitQuery(CGameHandler * owner, const CGObjectInstance * Obj, const CGHeroInstance * Hero);
+	VisitQuery(CGameHandler * owner, const CGObjectInstance * Obj, const CGHeroInstance * Hero, QueryType type);
 
 public:
 	ObjectInstanceID visitedObject;
@@ -32,6 +32,8 @@ public:
 class MapObjectVisitQuery final : public VisitQuery
 {
 public:
+	static constexpr QueryType TYPE = QueryType::MapObjectVisit;
+
 	bool removeObjectAfterVisit;
 
 	MapObjectVisitQuery(CGameHandler * owner, const CGObjectInstance * Obj, const CGHeroInstance * Hero);
@@ -52,6 +54,8 @@ class TownBuildingVisitQuery final : public VisitQuery
 	std::vector<BuildingVisit> visitedBuilding;
 
 public:
+	static constexpr QueryType TYPE = QueryType::TownBuildingVisit;
+
 	TownBuildingVisitQuery(CGameHandler * owner, const CGTownInstance * Obj, std::vector<const CGHeroInstance *> heroes, std::vector<BuildingID> buildingToVisit);
 
 	void onAdded(PlayerColor color) final;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -80,6 +80,8 @@ set(test_SRCS
  		spells/targetConditions/SpellEffectConditionTest.cpp
  		spells/targetConditions/TargetConditionItemFixture.cpp
 
+		server/queries/QueriesProcessorTest.cpp
+
 		mock/BattleFake.cpp
 		mock/mock_IGameEventCallback.cpp
  		mock/mock_MapService.cpp
@@ -157,7 +159,7 @@ endif()
 add_subdirectory_with_folder("3rdparty" googletest EXCLUDE_FROM_ALL)
 
 add_executable(vcmitest ${test_SRCS} ${test_HEADERS} ${mock_HEADERS})
-target_link_libraries(vcmitest PRIVATE gtest gmock vcmi ${SYSTEM_LIBS})
+target_link_libraries(vcmitest PRIVATE gtest gmock vcmi vcmiservercommon ${SYSTEM_LIBS})
 target_link_libraries(vcmitest PRIVATE vcmiLua)
 if(ENABLE_NULLKILLER2_AI)
 	target_link_libraries(vcmitest PUBLIC Nullkiller2)

--- a/test/server/queries/QueriesProcessorTest.cpp
+++ b/test/server/queries/QueriesProcessorTest.cpp
@@ -1,0 +1,541 @@
+#include "StdInc.h"
+
+#include <gtest/gtest.h>
+
+#include "../../../server/queries/CQuery.h"
+#include "../../../server/IGameServer.h"
+#include "../../../server/queries/QueriesProcessor.h"
+#include "CGameHandler.h"
+
+namespace
+{
+
+class DummyGameServer : public IGameServer
+{
+public:
+	void setState(EServerState value) override
+	{
+		state = value;
+	}
+
+	EServerState getState() const override
+	{
+		return state;
+	}
+
+	bool isPlayerHost(const PlayerColor & color) const override
+	{
+		return false;
+	}
+
+	bool hasPlayerAt(PlayerColor player, GameConnectionID connectionID) const override
+	{
+		return false;
+	}
+
+	bool hasBothPlayersAtSameConnection(PlayerColor left, PlayerColor right) const override
+	{
+		return false;
+	}
+
+	void applyPack(CPackForClient & pack) override
+	{
+	}
+
+	void sendPack(CPackForClient & pack, GameConnectionID connectionID) override
+	{
+	}
+
+private:
+	EServerState state{};
+};
+
+enum class QueryEvent
+{
+	OnAdding,
+	OnAdded,
+	OnRemoval,
+	OnExposure
+};
+
+class TestQuery;
+
+struct RecordedEvent
+{
+	TestQuery * query;
+	QueryEvent event;
+};
+
+class TestQuery : public CQuery
+{
+public:
+	TestQuery(CGameHandler * gh, std::initializer_list<PlayerColor> affectedPlayers, QueryType type)
+		: CQuery(gh, type)
+	{
+		for(auto player : affectedPlayers)
+			players.push_back(player);
+	}
+
+	TestQuery(CGameHandler * gh, PlayerColor player, QueryType type)
+		: CQuery(gh, type)
+	{
+		players.push_back(player);
+	}
+
+	std::vector<RecordedEvent> * sharedEventLog = nullptr;
+	std::vector<QueryEvent> events;
+	std::vector<PlayerColor> onAddingCalls;
+	std::vector<PlayerColor> onAddedCalls;
+	std::vector<PlayerColor> onRemovalCalls;
+	std::vector<QueryPtr> exposureArgs;
+	bool popOnExposure = false;
+	bool addReplacementOnRemoval = false;
+	QueryPtr replacementQuery;
+
+	void onAdding(PlayerColor color) override
+	{
+		events.push_back(QueryEvent::OnAdding);
+		onAddingCalls.push_back(color);
+		if(sharedEventLog)
+			sharedEventLog->push_back({this, QueryEvent::OnAdding});
+	}
+
+	void onAdded(PlayerColor color) override
+	{
+		events.push_back(QueryEvent::OnAdded);
+		onAddedCalls.push_back(color);
+		if(sharedEventLog)
+			sharedEventLog->push_back({this, QueryEvent::OnAdded});
+	}
+
+	void onRemoval(PlayerColor color) override
+	{
+		events.push_back(QueryEvent::OnRemoval);
+		onRemovalCalls.push_back(color);
+
+		if(addReplacementOnRemoval && replacementQuery)
+			owner->addQuery(replacementQuery);
+
+		if(sharedEventLog)
+			sharedEventLog->push_back({this, QueryEvent::OnRemoval});
+	}
+
+	void onExposure(QueryPtr topQuery) override
+	{
+		events.push_back(QueryEvent::OnExposure);
+		exposureArgs.push_back(topQuery);
+
+		if(sharedEventLog)
+			sharedEventLog->push_back({this, QueryEvent::OnExposure});
+
+		if(popOnExposure)
+			owner->popIfTop(*this);
+	}
+};
+
+class QueriesProcessorTest : public ::testing::Test
+{
+protected:
+	DummyGameServer server;
+	CGameHandler gh{server};
+	QueriesProcessor & queries = *gh.queries;
+};
+
+}
+
+TEST_F(QueriesProcessorTest, topQuery_returnsNullWhenPlayerHasNoQueries)
+{
+	EXPECT_EQ(queries.topQuery(PlayerColor(1)), nullptr);
+}
+
+TEST_F(QueriesProcessorTest, popIfTop_removesTopQuery)
+{
+	auto query = std::make_shared<TestQuery>(&gh, PlayerColor(1), QueryType::HeroMovement);
+
+	queries.addQuery(query);
+
+	EXPECT_EQ(queries.topQuery(PlayerColor(1)), query);
+	EXPECT_EQ(queries.countQuery(query), 1);
+
+	queries.popIfTop(query);
+
+	EXPECT_EQ(queries.topQuery(PlayerColor(1)), nullptr);
+	EXPECT_EQ(queries.countQuery(query), 0);
+}
+
+TEST_F(QueriesProcessorTest, popIfTop_doesNothingWhenQueryIsNotPresent)
+{
+	auto addedQuery = std::make_shared<TestQuery>(&gh, PlayerColor(1), QueryType::HeroMovement);
+	auto missingQuery = std::make_shared<TestQuery>(&gh, PlayerColor(1), QueryType::MapObjectVisit);
+
+	queries.addQuery(addedQuery);
+
+	EXPECT_EQ(queries.topQuery(PlayerColor(1)), addedQuery);
+	EXPECT_EQ(queries.countQuery(addedQuery), 1);
+	EXPECT_EQ(queries.countQuery(missingQuery), 0);
+
+	queries.popIfTop(missingQuery);
+
+	EXPECT_EQ(queries.topQuery(PlayerColor(1)), addedQuery);
+	EXPECT_EQ(queries.countQuery(addedQuery), 1);
+	EXPECT_EQ(queries.countQuery(missingQuery), 0);
+}
+
+TEST_F(QueriesProcessorTest, popIfTop_skipsWhenNestedQueryIsAbove_andLaterSucceedsAfterUnwind)
+{
+	auto movementQuery = std::make_shared<TestQuery>(&gh, PlayerColor(1), QueryType::HeroMovement);
+	auto visitQuery = std::make_shared<TestQuery>(&gh, PlayerColor(1), QueryType::MapObjectVisit);
+
+	queries.addQuery(movementQuery);
+	queries.addQuery(visitQuery);
+
+	EXPECT_EQ(queries.topQuery(PlayerColor(1)), visitQuery);
+	EXPECT_EQ(queries.countQuery(movementQuery), 1);
+	EXPECT_EQ(queries.countQuery(visitQuery), 1);
+
+	queries.popIfTop(movementQuery);
+
+	EXPECT_EQ(queries.topQuery(PlayerColor(1)), visitQuery);
+	EXPECT_EQ(queries.countQuery(movementQuery), 1);
+	EXPECT_EQ(queries.countQuery(visitQuery), 1);
+
+	queries.popIfTop(visitQuery);
+
+	EXPECT_EQ(queries.topQuery(PlayerColor(1)), movementQuery);
+	EXPECT_EQ(queries.countQuery(movementQuery), 1);
+	EXPECT_EQ(queries.countQuery(visitQuery), 0);
+
+	queries.popIfTop(movementQuery);
+
+	EXPECT_EQ(queries.topQuery(PlayerColor(1)), nullptr);
+	EXPECT_EQ(queries.countQuery(movementQuery), 0);
+	EXPECT_EQ(queries.countQuery(visitQuery), 0);
+}
+
+TEST_F(QueriesProcessorTest, popIfTop_exposesQueryBelowWithRemovedQueryAsArgument)
+{
+	auto bottomQuery = std::make_shared<TestQuery>(&gh, PlayerColor(1), QueryType::HeroMovement);
+	auto topQuery = std::make_shared<TestQuery>(&gh, PlayerColor(1), QueryType::MapObjectVisit);
+
+	queries.addQuery(bottomQuery);
+	queries.addQuery(topQuery);
+
+	queries.popIfTop(topQuery);
+
+	EXPECT_EQ(queries.topQuery(PlayerColor(1)), bottomQuery);
+
+	EXPECT_EQ(bottomQuery->events, std::vector<QueryEvent>({
+		QueryEvent::OnAdding,
+		QueryEvent::OnAdded,
+		QueryEvent::OnExposure
+	}));
+
+	EXPECT_EQ(bottomQuery->onAddingCalls, std::vector<PlayerColor>({PlayerColor(1)}));
+	EXPECT_EQ(bottomQuery->onAddedCalls, std::vector<PlayerColor>({PlayerColor(1)}));
+	EXPECT_TRUE(bottomQuery->onRemovalCalls.empty());
+
+	ASSERT_EQ(bottomQuery->exposureArgs.size(), 1);
+	EXPECT_EQ(bottomQuery->exposureArgs[0], topQuery);
+
+	EXPECT_EQ(topQuery->events, std::vector<QueryEvent>({
+		QueryEvent::OnAdding,
+		QueryEvent::OnAdded,
+		QueryEvent::OnRemoval
+	}));
+}
+
+TEST_F(QueriesProcessorTest, popIfTop_allowsExposedQueryToPopItself)
+{
+	auto bottomQuery = std::make_shared<TestQuery>(&gh, PlayerColor(1), QueryType::HeroMovement);
+	auto topQuery = std::make_shared<TestQuery>(&gh, PlayerColor(1), QueryType::MapObjectVisit);
+
+	bottomQuery->popOnExposure = true;
+
+	queries.addQuery(bottomQuery);
+	queries.addQuery(topQuery);
+
+	queries.popIfTop(topQuery);
+
+	EXPECT_EQ(queries.topQuery(PlayerColor(1)), nullptr);
+	EXPECT_EQ(queries.countQuery(bottomQuery), 0);
+	EXPECT_EQ(queries.countQuery(topQuery), 0);
+
+	EXPECT_EQ(bottomQuery->events, std::vector<QueryEvent>({
+		QueryEvent::OnAdding,
+		QueryEvent::OnAdded,
+		QueryEvent::OnExposure,
+		QueryEvent::OnRemoval
+	}));
+
+	ASSERT_EQ(bottomQuery->exposureArgs.size(), 1);
+	EXPECT_EQ(bottomQuery->exposureArgs[0], topQuery);
+
+	EXPECT_EQ(bottomQuery->onRemovalCalls, std::vector<PlayerColor>({PlayerColor(1)}));
+
+	EXPECT_EQ(topQuery->events, std::vector<QueryEvent>({
+		QueryEvent::OnAdding,
+		QueryEvent::OnAdded,
+		QueryEvent::OnRemoval
+	}));
+}
+
+TEST_F(QueriesProcessorTest, popIfTop_removesMultiPlayerQueryOnlyWhereItIsTop)
+{
+	auto sharedQuery = std::make_shared<TestQuery>(
+		&gh,
+		std::initializer_list<PlayerColor>{PlayerColor(0), PlayerColor(1)},
+		QueryType::Generic);
+
+	auto blueTopQuery = std::make_shared<TestQuery>(&gh, PlayerColor(1), QueryType::MapObjectVisit);
+
+	queries.addQuery(sharedQuery);
+	queries.addQuery(blueTopQuery);
+
+	queries.popIfTop(sharedQuery);
+
+	EXPECT_EQ(queries.topQuery(PlayerColor(0)), nullptr);
+	EXPECT_EQ(queries.topQuery(PlayerColor(1)), blueTopQuery);
+	EXPECT_EQ(queries.countQuery(sharedQuery), 1);
+	EXPECT_EQ(queries.countQuery(blueTopQuery), 1);
+
+	EXPECT_EQ(sharedQuery->onRemovalCalls, std::vector<PlayerColor>({PlayerColor(0)}));
+}
+
+TEST_F(QueriesProcessorTest, popIfTop_removesMultiPlayerQueryAfterItBecomesTopAgain)
+{
+	auto sharedQuery = std::make_shared<TestQuery>(
+		&gh,
+		std::initializer_list<PlayerColor>{PlayerColor(0), PlayerColor(1)},
+		QueryType::Generic);
+
+	auto blueTopQuery = std::make_shared<TestQuery>(&gh, PlayerColor(1), QueryType::MapObjectVisit);
+
+	queries.addQuery(sharedQuery);
+	queries.addQuery(blueTopQuery);
+
+	queries.popIfTop(sharedQuery);
+
+	EXPECT_EQ(queries.topQuery(PlayerColor(0)), nullptr);
+	EXPECT_EQ(queries.topQuery(PlayerColor(1)), blueTopQuery);
+	EXPECT_EQ(queries.countQuery(sharedQuery), 1);
+
+	queries.popIfTop(blueTopQuery);
+
+	ASSERT_EQ(sharedQuery->exposureArgs.size(), 1);
+	EXPECT_EQ(sharedQuery->exposureArgs[0], blueTopQuery);
+
+	EXPECT_EQ(queries.topQuery(PlayerColor(1)), sharedQuery);
+	EXPECT_EQ(queries.countQuery(blueTopQuery), 0);
+	EXPECT_EQ(queries.countQuery(sharedQuery), 1);
+
+	queries.popIfTop(sharedQuery);
+
+	EXPECT_EQ(queries.topQuery(PlayerColor(0)), nullptr);
+	EXPECT_EQ(queries.topQuery(PlayerColor(1)), nullptr);
+	EXPECT_EQ(queries.countQuery(sharedQuery), 0);
+
+	EXPECT_EQ(sharedQuery->onRemovalCalls, std::vector<PlayerColor>({
+		PlayerColor(0),
+		PlayerColor(1)
+	}));
+}
+
+TEST_F(QueriesProcessorTest, popQuery_removesMultiPlayerQueryOnlyWhereItIsTop)
+{
+	auto sharedQuery = std::make_shared<TestQuery>(
+		&gh,
+		std::initializer_list<PlayerColor>{PlayerColor(0), PlayerColor(1)},
+		QueryType::Generic);
+
+	auto blueTopQuery = std::make_shared<TestQuery>(&gh, PlayerColor(1), QueryType::MapObjectVisit);
+
+	queries.addQuery(sharedQuery);
+	queries.addQuery(blueTopQuery);
+
+	queries.popQuery(*sharedQuery);
+
+	EXPECT_EQ(queries.topQuery(PlayerColor(0)), nullptr);
+	EXPECT_EQ(queries.topQuery(PlayerColor(1)), blueTopQuery);
+	EXPECT_EQ(queries.countQuery(sharedQuery), 1);
+	EXPECT_EQ(sharedQuery->onRemovalCalls, std::vector<PlayerColor>({PlayerColor(0)}));
+}
+
+TEST_F(QueriesProcessorTest, popQuery_removesRemainingMultiPlayerQueryAfterItBecomesTop)
+{
+	auto sharedQuery = std::make_shared<TestQuery>(
+		&gh,
+		std::initializer_list<PlayerColor>{PlayerColor(0), PlayerColor(1)},
+		QueryType::Generic);
+
+	auto blueTopQuery = std::make_shared<TestQuery>(&gh, PlayerColor(1), QueryType::MapObjectVisit);
+
+	queries.addQuery(sharedQuery);
+	queries.addQuery(blueTopQuery);
+
+	queries.popQuery(*sharedQuery);
+	queries.popIfTop(blueTopQuery);
+	queries.popQuery(*sharedQuery);
+
+	EXPECT_EQ(queries.topQuery(PlayerColor(0)), nullptr);
+	EXPECT_EQ(queries.topQuery(PlayerColor(1)), nullptr);
+	EXPECT_EQ(queries.countQuery(sharedQuery), 0);
+	EXPECT_EQ(sharedQuery->onRemovalCalls, std::vector<PlayerColor>({
+		PlayerColor(0),
+		PlayerColor(1)
+	}));
+}
+
+TEST_F(QueriesProcessorTest, popIfTop_callsRemovalBeforeExposure)
+{
+	std::vector<RecordedEvent> eventLog;
+
+	auto bottomQuery = std::make_shared<TestQuery>(&gh, PlayerColor(1), QueryType::HeroMovement);
+	auto topQuery = std::make_shared<TestQuery>(&gh, PlayerColor(1), QueryType::MapObjectVisit);
+
+	bottomQuery->sharedEventLog = &eventLog;
+	topQuery->sharedEventLog = &eventLog;
+
+	queries.addQuery(bottomQuery);
+	queries.addQuery(topQuery);
+
+	eventLog.clear();
+
+	queries.popIfTop(topQuery);
+
+	ASSERT_EQ(eventLog.size(), 2);
+	EXPECT_EQ(eventLog[0].query, topQuery.get());
+	EXPECT_EQ(eventLog[0].event, QueryEvent::OnRemoval);
+	EXPECT_EQ(eventLog[1].query, bottomQuery.get());
+	EXPECT_EQ(eventLog[1].event, QueryEvent::OnExposure);
+}
+
+TEST_F(QueriesProcessorTest, popQuery_callsRemovalBeforeExposure)
+{
+	std::vector<RecordedEvent> eventLog;
+
+	auto bottomQuery = std::make_shared<TestQuery>(&gh, PlayerColor(1), QueryType::HeroMovement);
+	auto topQuery = std::make_shared<TestQuery>(&gh, PlayerColor(1), QueryType::MapObjectVisit);
+
+	bottomQuery->sharedEventLog = &eventLog;
+	topQuery->sharedEventLog = &eventLog;
+
+	queries.addQuery(bottomQuery);
+	queries.addQuery(topQuery);
+
+	eventLog.clear();
+
+	queries.popQuery(*topQuery);
+
+	ASSERT_EQ(eventLog.size(), 2);
+	EXPECT_EQ(eventLog[0].query, topQuery.get());
+	EXPECT_EQ(eventLog[0].event, QueryEvent::OnRemoval);
+	EXPECT_EQ(eventLog[1].query, bottomQuery.get());
+	EXPECT_EQ(eventLog[1].event, QueryEvent::OnExposure);
+}
+
+TEST_F(QueriesProcessorTest, popIfTop_skipsExposureWhenRemovalAddsNewTopQuery)
+{
+	auto bottomQuery = std::make_shared<TestQuery>(&gh, PlayerColor(1), QueryType::HeroMovement);
+	auto topQuery = std::make_shared<TestQuery>(&gh, PlayerColor(1), QueryType::MapObjectVisit);
+	auto replacementQuery = std::make_shared<TestQuery>(&gh, PlayerColor(1), QueryType::Generic);
+
+	topQuery->addReplacementOnRemoval = true;
+	topQuery->replacementQuery = replacementQuery;
+
+	queries.addQuery(bottomQuery);
+	queries.addQuery(topQuery);
+
+	queries.popIfTop(topQuery);
+
+	EXPECT_EQ(queries.topQuery(PlayerColor(1)), replacementQuery);
+	EXPECT_EQ(queries.countQuery(bottomQuery), 1);
+	EXPECT_EQ(queries.countQuery(topQuery), 0);
+	EXPECT_EQ(queries.countQuery(replacementQuery), 1);
+
+	EXPECT_EQ(bottomQuery->events, std::vector<QueryEvent>({
+		QueryEvent::OnAdding,
+		QueryEvent::OnAdded
+	}));
+	EXPECT_TRUE(bottomQuery->exposureArgs.empty());
+
+	EXPECT_EQ(topQuery->events, std::vector<QueryEvent>({
+		QueryEvent::OnAdding,
+		QueryEvent::OnAdded,
+		QueryEvent::OnRemoval
+	}));
+
+	EXPECT_EQ(replacementQuery->events, std::vector<QueryEvent>({
+		QueryEvent::OnAdding,
+		QueryEvent::OnAdded
+	}));
+}
+
+TEST_F(QueriesProcessorTest, addQuery_addsSameQueryForAllAffectedPlayers)
+{
+	auto query = std::make_shared<TestQuery>(&gh, std::initializer_list<PlayerColor>{PlayerColor(0), PlayerColor(1)}, QueryType::Generic);
+
+	queries.addQuery(query);
+
+	EXPECT_EQ(queries.topQuery(PlayerColor(0)), query);
+	EXPECT_EQ(queries.topQuery(PlayerColor(1)), query);
+	EXPECT_EQ(queries.countQuery(query), 2);
+
+	EXPECT_EQ(query->events, std::vector<QueryEvent>({
+	QueryEvent::OnAdding,
+	QueryEvent::OnAdded,
+	QueryEvent::OnAdding,
+	QueryEvent::OnAdded
+	}));
+
+	EXPECT_EQ(query->onAddingCalls, std::vector<PlayerColor>({PlayerColor(0), PlayerColor(1)}));
+	EXPECT_EQ(query->onAddedCalls, std::vector<PlayerColor>({PlayerColor(0), PlayerColor(1)}));
+	EXPECT_TRUE(query->onRemovalCalls.empty());
+	EXPECT_TRUE(query->exposureArgs.empty());
+}
+
+TEST_F(QueriesProcessorTest, addQuery_skipsDuplicateBackWithoutRepeatingOnAdded)
+{
+	auto query = std::make_shared<TestQuery>(&gh, PlayerColor(1), QueryType::HeroMovement);
+
+	queries.addQuery(query);
+	queries.addQuery(query);
+
+	EXPECT_EQ(queries.topQuery(PlayerColor(1)), query);
+	EXPECT_EQ(queries.countQuery(query), 1);
+
+	EXPECT_EQ(query->events, std::vector<QueryEvent>({
+		QueryEvent::OnAdding,
+		QueryEvent::OnAdded
+	}));
+
+	EXPECT_EQ(query->onAddingCalls, std::vector<PlayerColor>({PlayerColor(1)}));
+	EXPECT_EQ(query->onAddedCalls, std::vector<PlayerColor>({PlayerColor(1)}));
+}
+
+TEST_F(QueriesProcessorTest, getQuery_returnsNullForUnknownQueryId)
+{
+	auto query = std::make_shared<TestQuery>(&gh, PlayerColor(1), QueryType::HeroMovement);
+
+	queries.addQuery(query);
+
+	EXPECT_EQ(queries.getQuery(QueryID(query->queryID.getNum() + 1)), nullptr);
+}
+
+TEST_F(QueriesProcessorTest, getQuery_returnsAddedQueryAndNullAfterRemoval)
+{
+	auto query = std::make_shared<TestQuery>(&gh, PlayerColor(1), QueryType::HeroMovement);
+
+	queries.addQuery(query);
+
+	EXPECT_EQ(queries.getQuery(query->queryID), query);
+
+	queries.popIfTop(query);
+
+	EXPECT_EQ(queries.getQuery(query->queryID), nullptr);
+}
+
+TEST_F(QueriesProcessorTest, countQuery_returnsZeroForNullptr)
+{
+	EXPECT_EQ(queries.countQuery(nullptr), 0);
+}
+


### PR DESCRIPTION
This PR is a follow-up to:
- #6778

It fixes the remaining turn-start case where a player owns multiple towns with Battle Scholar Academy built and has garrisoned heroes that receive experience at map start. In that situation, the previous flow could still break when several turn-start visits and level-up queries were triggered together.

This PR prevents:
  - for AI: freeze during turn-start processing
  - for human players: getting complain message `Player X has to answer queries before attempting any further actions` because a level-up query remained active without being resolved

when player starts map with aforementioned setup.

Added also query-stack tests and a few small query-handling cleanups and robustness improvements.

Fixes #7326
- #7326  