### PR TITLE
[1.8.0] Mines improvements 

### DIFF
--- a/config/objects/moddables.json
+++ b/config/objects/moddables.json
@@ -273,6 +273,7 @@
 		"handler": "mine",
 		"lastReservedIndex" : 7,
 		"base" : {
+			"ownedGuardedMessage" : 187,
 			"sounds" : {
 				"visit" : ["FLAGMINE"]
 			}
@@ -280,6 +281,7 @@
 		"types" : {
 			"sawmill" : {
 				"index" : 0,
+				"description" : "@core.mineevnt.0",
 				"aiValue" : 1500,
 				"rmg" : {
 					"value" : 1500
@@ -292,6 +294,7 @@
 			},
 			"alchemistLab" : {
 				"index" : 1,
+				"description" : "@core.mineevnt.1",
 				"aiValue" : 3500,
 				"rmg" : {
 					"value" : 3500
@@ -304,6 +307,7 @@
 			},
 			"orePit" : {
 				"index" : 2,
+				"description" : "@core.mineevnt.2",
 				"aiValue" : 1500,
 				"rmg" : {
 					"value" : 1500
@@ -316,6 +320,7 @@
 			},
 			"sulfurDune" : {
 				"index" : 3,
+				"description" : "@core.mineevnt.3",
 				"aiValue" : 3500,
 				"rmg" : {
 					"value" : 3500
@@ -328,6 +333,7 @@
 			},
 			"crystalCavern" : {
 				"index" : 4,
+				"description" : "@core.mineevnt.4",
 				"aiValue" : 3500,
 				"rmg" : {
 					"value" : 3500
@@ -341,6 +347,7 @@
 			},
 			"gemPond" : {
 				"index" : 5,
+				"description" : "@core.mineevnt.5",
 				"aiValue" : 3500,
 				"rmg" : {
 					"value" : 3500
@@ -353,6 +360,7 @@
 			},
 			"goldMine" : {
 				"index" : 6,
+				"description" : "@core.mineevnt.6",
 				"aiValue" : 7000,
 				"rmg" : {
 					"value" : 7000
@@ -366,6 +374,15 @@
 			},
 			"abandoned" :	{
 				"index" : 7,
+				"description" : "@core.mineevnt.7",
+					"guards" : [{
+						"type" : "troglodyte",
+						"min" : 100,
+						"max" : 249
+					}],
+				"onGuardedMessage" : 84,
+				"ownedGuardedMessage" : 187,
+				"message" : 85,
 				"aiValue" : 3500,
 				"sounds" : {
 					"ambient" : ["LOOPCAVE"],
@@ -386,7 +403,19 @@
 			}
 		},
 		"types" : {
-			"mine" : { "index" : 7, "battleground": "subterranean" }
+			"mine" : {
+				"index" : 7,
+				"description" : "@core.mineevnt.7",
+				"battleground": "subterranean",
+				"guards" : [{
+					"type" : "troglodyte",
+					"min" : 100,
+					"max" : 249
+				}],
+				"onGuardedMessage" : 84,
+				"ownedGuardedMessage" : 187,
+				"message" : 85
+			}
 		}
 	},
 

--- a/config/objects/moddables.json
+++ b/config/objects/moddables.json
@@ -382,7 +382,7 @@
 					}],
 				"onGuardedMessage" : 84,
 				"ownedGuardedMessage" : 187,
-				"message" : 85,
+				"onCaptureMessage" : 85,
 				"aiValue" : 3500,
 				"sounds" : {
 					"ambient" : ["LOOPCAVE"],
@@ -414,7 +414,7 @@
 				}],
 				"onGuardedMessage" : 84,
 				"ownedGuardedMessage" : 187,
-				"message" : 85
+				"onCaptureMessage" : 85
 			}
 		}
 	},

--- a/docs/modders/Map_Objects/Mine.md
+++ b/docs/modders/Map_Objects/Mine.md
@@ -20,12 +20,20 @@ Beside the common parameters from [Map Object Format](../Map_Object_Format.md) t
 
 	/// Optional guards, uses the same stack format as other configurable guard lists.
 	"guards" : [
-		{ "type" : "core:marksman", "amount" : 40, "upgradeChance" : 50 }
+		{ "type" : "marksman", "amount" : 40, "upgradeChance" : 50 }
 	],
 
-	/// Optional message shown when hero attempts to visit guarded non-abandoned mine.
-	/// Falls back to default abandoned messages when not set.
+	/// Optional message shown when hero attempts to visit guarded mine.
+	/// Can be a raw string, @textID, or adventure text index.
 	"onGuardedMessage" : "This mine is guarded.\n\nDo you wish to fight the guards?",
+
+	/// Optional message shown when hero attempts to visit guarded owned mine.
+	/// Can be a raw string, @textID, or adventure text index.
+	"ownedGuardedMessage" : "This mine belongs to an enemy, and is guarded.\n\nDo you wish to fight the guards?",
+
+	/// Optional message shown after hero captures abandoned mine.
+	/// Can be a raw string, @textID, or adventure text index.
+	"onCaptureMessage" : "The mine has fallen into your hands.",
 
 	/// Optional image showed on kingdom overview (animation; only frame 0 displayed)
 	"kingdomOverviewImage" : "image.def"

--- a/docs/modders/Map_Objects/Mine.md
+++ b/docs/modders/Map_Objects/Mine.md
@@ -1,6 +1,6 @@
 # Mine
 
-Currently only one mine per resource allowed.
+Multiple mines per resource are allowed.
 
 Beside the common parameters from [Map Object Format](../Map_Object_Format.md) there are some additional parameters:
 

--- a/docs/modders/Map_Objects/Mine.md
+++ b/docs/modders/Map_Objects/Mine.md
@@ -18,7 +18,16 @@ Beside the common parameters from [Map Object Format](../Map_Object_Format.md) t
 	/// displayed description of mine (for popup)
 	"description" : "description text",
 
-	/// Image showed on kingdom overview (animation; only frame 0 displayed)
+	/// Optional guards, uses the same stack format as other configurable guard lists.
+	"guards" : [
+		{ "type" : "core:marksman", "amount" : 40, "upgradeChance" : 50 }
+	],
+
+	/// Optional message shown when hero attempts to visit guarded non-abandoned mine.
+	/// Falls back to default abandoned messages when not set.
+	"onGuardedMessage" : "This mine is guarded.\n\nDo you wish to fight the guards?",
+
+	/// Optional image showed on kingdom overview (animation; only frame 0 displayed)
 	"kingdomOverviewImage" : "image.def"
 }
 ```

--- a/lib/mapObjectConstructors/CommonConstructors.cpp
+++ b/lib/mapObjectConstructors/CommonConstructors.cpp
@@ -108,6 +108,12 @@ void MineInstanceConstructor::initTypeData(const JsonNode & input)
 	if (!config["description"].isNull())
 		LIBRARY->generaltexth->registerString(config.getModScope(), getDescriptionTextID(), config["description"]);
 
+	if (!config["guards"].isNull())
+		guards = config["guards"];
+
+	if (!config["onGuardedMessage"].isNull())
+		LIBRARY->generaltexth->registerString(config.getModScope(), getOnGuardedMessageTextID(), config["onGuardedMessage"]);
+	
 	kingdomOverviewImage = AnimationPath::fromJson(config["kingdomOverviewImage"]);
 }
 
@@ -131,9 +137,26 @@ std::string MineInstanceConstructor::getDescriptionTranslated() const
 	return LIBRARY->generaltexth->translate(getDescriptionTextID());
 }
 
+std::string MineInstanceConstructor::getOnGuardedMessageTextID() const
+{
+	return TextIdentifier(getBaseTextID(), "onGuardedMessage").get();
+}
+
+std::string MineInstanceConstructor::getOnGuardedMessageTranslated() const
+{
+	return LIBRARY->generaltexth->translate(getOnGuardedMessageTextID());
+}
+
 AnimationPath MineInstanceConstructor::getKingdomOverviewImage() const
 {
 	return kingdomOverviewImage;
+}
+
+std::vector<CStackBasicDescriptor> MineInstanceConstructor::getGuards(IGameInfoCallback * cb, IGameRandomizer & gameRandomizer) const
+{
+	JsonRandom randomizer(cb, gameRandomizer);
+	JsonRandom::Variables emptyVariables;
+	return randomizer.loadCreatures(guards, emptyVariables);
 }
 
 void CTownInstanceConstructor::initTypeData(const JsonNode & input)

--- a/lib/mapObjectConstructors/CommonConstructors.cpp
+++ b/lib/mapObjectConstructors/CommonConstructors.cpp
@@ -111,9 +111,27 @@ void MineInstanceConstructor::initTypeData(const JsonNode & input)
 	if (!config["guards"].isNull())
 		guards = config["guards"];
 
-	if (!config["onGuardedMessage"].isNull())
-		LIBRARY->generaltexth->registerString(config.getModScope(), getOnGuardedMessageTextID(), config["onGuardedMessage"]);
-	
+	auto registerAdventureMessage = [&](const JsonNode & inputNode, const std::string & textID)
+	{
+		if(inputNode.isNull())
+			return;
+
+		if(inputNode.isNumber())
+		{
+			JsonNode asString;
+			asString.String() = "@" + TextIdentifier("core.advevent", inputNode.Integer()).get();
+			LIBRARY->generaltexth->registerString(config.getModScope(), textID, asString);
+		}
+		else
+		{
+			LIBRARY->generaltexth->registerString(config.getModScope(), textID, inputNode);
+		}
+	};
+
+	registerAdventureMessage(config["onGuardedMessage"], getOnGuardedMessageTextID());
+	registerAdventureMessage(config["ownedGuardedMessage"], getOwnedGuardedMessageTextID());
+	registerAdventureMessage(config["message"], getMessageTextID());
+
 	kingdomOverviewImage = AnimationPath::fromJson(config["kingdomOverviewImage"]);
 }
 
@@ -145,6 +163,26 @@ std::string MineInstanceConstructor::getOnGuardedMessageTextID() const
 std::string MineInstanceConstructor::getOnGuardedMessageTranslated() const
 {
 	return LIBRARY->generaltexth->translate(getOnGuardedMessageTextID());
+}
+
+std::string MineInstanceConstructor::getOwnedGuardedMessageTextID() const
+{
+	return TextIdentifier(getBaseTextID(), "ownedGuardedMessage").get();
+}
+
+std::string MineInstanceConstructor::getOwnedGuardedMessageTranslated() const
+{
+	return LIBRARY->generaltexth->translate(getOwnedGuardedMessageTextID());
+}
+
+std::string MineInstanceConstructor::getMessageTextID() const
+{
+	return TextIdentifier(getBaseTextID(), "message").get();
+}
+
+std::string MineInstanceConstructor::getMessageTranslated() const
+{
+	return LIBRARY->generaltexth->translate(getMessageTextID());
 }
 
 AnimationPath MineInstanceConstructor::getKingdomOverviewImage() const

--- a/lib/mapObjectConstructors/CommonConstructors.cpp
+++ b/lib/mapObjectConstructors/CommonConstructors.cpp
@@ -117,8 +117,7 @@ void MineInstanceConstructor::initTypeData(const JsonNode & input)
 		}
 	}
 
-	if(!config["guards"].isNull())
-		guards = config["guards"];
+	guards = config["guards"];
 
 	auto loadAdventureMessageTextID = [&](const JsonNode & inputNode, const std::string & key) -> std::string
 	{

--- a/lib/mapObjectConstructors/CommonConstructors.cpp
+++ b/lib/mapObjectConstructors/CommonConstructors.cpp
@@ -102,35 +102,44 @@ void MineInstanceConstructor::initTypeData(const JsonNode & input)
 	});
 	defaultQuantity = !config["defaultQuantity"].isNull() ? config["defaultQuantity"].Integer() : 1;
 
-	if (!config["name"].isNull())
+	if(!config["name"].isNull())
 		LIBRARY->generaltexth->registerString(config.getModScope(), getNameTextID(), config["name"]);
 
-	if (!config["description"].isNull())
-		LIBRARY->generaltexth->registerString(config.getModScope(), getDescriptionTextID(), config["description"]);
-
-	if (!config["guards"].isNull())
-		guards = config["guards"];
-
-	auto registerAdventureMessage = [&](const JsonNode & inputNode, const std::string & textID)
+	if(!config["description"].isNull())
 	{
-		if(inputNode.isNull())
-			return;
-
-		if(inputNode.isNumber())
-		{
-			JsonNode asString;
-			asString.String() = "@" + TextIdentifier("core.advevent", inputNode.Integer()).get();
-			LIBRARY->generaltexth->registerString(config.getModScope(), textID, asString);
-		}
+		const std::string description = config["description"].String();
+		if(!description.empty() && description.front() == '@')
+			descriptionTextID = description.substr(1);
 		else
 		{
-			LIBRARY->generaltexth->registerString(config.getModScope(), textID, inputNode);
+			descriptionTextID = TextIdentifier(getBaseTextID(), "description").get();
+			LIBRARY->generaltexth->registerString(config.getModScope(), descriptionTextID, config["description"]);
 		}
+	}
+
+	if(!config["guards"].isNull())
+		guards = config["guards"];
+
+	auto loadAdventureMessageTextID = [&](const JsonNode & inputNode, const std::string & key) -> std::string
+	{
+		if(inputNode.isNull())
+			return {};
+
+		if(inputNode.isNumber())
+			return TextIdentifier("core.advevent", inputNode.Integer()).get();
+
+		const std::string message = inputNode.String();
+		if(!message.empty() && message.front() == '@')
+			return message.substr(1);
+
+		const std::string textID = TextIdentifier(getBaseTextID(), key).get();
+		LIBRARY->generaltexth->registerString(config.getModScope(), textID, inputNode);
+		return textID;
 	};
 
-	registerAdventureMessage(config["onGuardedMessage"], getOnGuardedMessageTextID());
-	registerAdventureMessage(config["ownedGuardedMessage"], getOwnedGuardedMessageTextID());
-	registerAdventureMessage(config["message"], getMessageTextID());
+	onGuardedMessageTextID = loadAdventureMessageTextID(config["onGuardedMessage"], "onGuardedMessage");
+	ownedGuardedMessageTextID = loadAdventureMessageTextID(config["ownedGuardedMessage"], "ownedGuardedMessage");
+	onCaptureMessageTextID = loadAdventureMessageTextID(config["onCaptureMessage"], "onCaptureMessage");
 
 	kingdomOverviewImage = AnimationPath::fromJson(config["kingdomOverviewImage"]);
 }
@@ -147,42 +156,22 @@ ui32 MineInstanceConstructor::getDefaultQuantity() const
 
 std::string MineInstanceConstructor::getDescriptionTextID() const
 {
-	return TextIdentifier(getBaseTextID(), "description").get();
-}
-
-std::string MineInstanceConstructor::getDescriptionTranslated() const
-{
-	return LIBRARY->generaltexth->translate(getDescriptionTextID());
+	return descriptionTextID;
 }
 
 std::string MineInstanceConstructor::getOnGuardedMessageTextID() const
 {
-	return TextIdentifier(getBaseTextID(), "onGuardedMessage").get();
-}
-
-std::string MineInstanceConstructor::getOnGuardedMessageTranslated() const
-{
-	return LIBRARY->generaltexth->translate(getOnGuardedMessageTextID());
+	return onGuardedMessageTextID;
 }
 
 std::string MineInstanceConstructor::getOwnedGuardedMessageTextID() const
 {
-	return TextIdentifier(getBaseTextID(), "ownedGuardedMessage").get();
+	return ownedGuardedMessageTextID;
 }
 
-std::string MineInstanceConstructor::getOwnedGuardedMessageTranslated() const
+std::string MineInstanceConstructor::getOnCaptureMessageTextID() const
 {
-	return LIBRARY->generaltexth->translate(getOwnedGuardedMessageTextID());
-}
-
-std::string MineInstanceConstructor::getMessageTextID() const
-{
-	return TextIdentifier(getBaseTextID(), "message").get();
-}
-
-std::string MineInstanceConstructor::getMessageTranslated() const
-{
-	return LIBRARY->generaltexth->translate(getMessageTextID());
+	return onCaptureMessageTextID;
 }
 
 AnimationPath MineInstanceConstructor::getKingdomOverviewImage() const

--- a/lib/mapObjectConstructors/CommonConstructors.h
+++ b/lib/mapObjectConstructors/CommonConstructors.h
@@ -80,6 +80,10 @@ public:
 	std::string getDescriptionTranslated() const;
 	std::string getOnGuardedMessageTextID() const;
 	std::string getOnGuardedMessageTranslated() const;
+	std::string getOwnedGuardedMessageTextID() const;
+	std::string getOwnedGuardedMessageTranslated() const;
+	std::string getMessageTextID() const;
+	std::string getMessageTranslated() const;
 	AnimationPath getKingdomOverviewImage() const;
 	std::vector<CStackBasicDescriptor> getGuards(IGameInfoCallback * cb, IGameRandomizer & gameRandomizer) const;
 };

--- a/lib/mapObjectConstructors/CommonConstructors.h
+++ b/lib/mapObjectConstructors/CommonConstructors.h
@@ -30,6 +30,8 @@ class CGCreature;
 class CGBoat;
 class CFaction;
 class CStackBasicDescriptor;
+class IGameInfoCallback;
+class IGameRandomizer;
 
 class CObstacleConstructor : public CDefaultObjectTypeHandler<CGObjectInstance>
 {
@@ -68,6 +70,7 @@ class DLL_LINKAGE MineInstanceConstructor : public CDefaultObjectTypeHandler<CGM
 	GameResID resourceType;
 	ui32 defaultQuantity;
 	AnimationPath kingdomOverviewImage;
+	JsonNode guards;
 public:
 	void initTypeData(const JsonNode & input) override;
 
@@ -75,7 +78,10 @@ public:
 	ui32 getDefaultQuantity() const;
 	std::string getDescriptionTextID() const;
 	std::string getDescriptionTranslated() const;
+	std::string getOnGuardedMessageTextID() const;
+	std::string getOnGuardedMessageTranslated() const;
 	AnimationPath getKingdomOverviewImage() const;
+	std::vector<CStackBasicDescriptor> getGuards(IGameInfoCallback * cb, IGameRandomizer & gameRandomizer) const;
 };
 
 class CTownInstanceConstructor : public CDefaultObjectTypeHandler<CGTownInstance>

--- a/lib/mapObjectConstructors/CommonConstructors.h
+++ b/lib/mapObjectConstructors/CommonConstructors.h
@@ -71,19 +71,19 @@ class DLL_LINKAGE MineInstanceConstructor : public CDefaultObjectTypeHandler<CGM
 	ui32 defaultQuantity;
 	AnimationPath kingdomOverviewImage;
 	JsonNode guards;
+	std::string descriptionTextID;
+	std::string onGuardedMessageTextID;
+	std::string ownedGuardedMessageTextID;
+	std::string onCaptureMessageTextID;
 public:
 	void initTypeData(const JsonNode & input) override;
 
 	GameResID getResourceType() const;
 	ui32 getDefaultQuantity() const;
 	std::string getDescriptionTextID() const;
-	std::string getDescriptionTranslated() const;
 	std::string getOnGuardedMessageTextID() const;
-	std::string getOnGuardedMessageTranslated() const;
 	std::string getOwnedGuardedMessageTextID() const;
-	std::string getOwnedGuardedMessageTranslated() const;
-	std::string getMessageTextID() const;
-	std::string getMessageTranslated() const;
+	std::string getOnCaptureMessageTextID() const;
 	AnimationPath getKingdomOverviewImage() const;
 	std::vector<CStackBasicDescriptor> getGuards(IGameInfoCallback * cb, IGameRandomizer & gameRandomizer) const;
 };

--- a/lib/mapObjects/MiscObjects.cpp
+++ b/lib/mapObjects/MiscObjects.cpp
@@ -98,7 +98,11 @@ void CGMine::onHeroVisit(IGameEventCallback & gameEvents, const CGHeroInstance *
 	{
 		BlockingDialog ynd(true,false);
 		ynd.player = h->tempOwner;
-		ynd.text.appendLocalString(EMetaText::ADVOB_TXT, isAbandoned() ? 84 : 187); //TODO: alternative text for custom guards
+		const auto guardedMessageTranslated = getResourceHandler()->getOnGuardedMessageTranslated();
+		if(!isAbandoned() && !guardedMessageTranslated.empty())
+			ynd.text.appendRawString(guardedMessageTranslated);
+		else
+			ynd.text.appendLocalString(EMetaText::ADVOB_TXT, isAbandoned() ? 84 : 187);
 		gameEvents.showBlockingDialog(this, &ynd);
 		return;
 	}
@@ -110,7 +114,7 @@ void CGMine::initObj(IGameRandomizer & gameRandomizer)
 {
 	if(isAbandoned())
 	{
-		//set guardians
+		//set default abandoned mine guardians
 		int howManyGuards = gameRandomizer.getDefault().nextInt(abandonedMineGuards.minAmount, abandonedMineGuards.maxAmount);
 		auto guards = std::make_unique<CStackInstance>(cb, abandonedMineGuards.creature, howManyGuards);
 		putStack(SlotID(0), std::move(guards));
@@ -128,6 +132,16 @@ void CGMine::initObj(IGameRandomizer & gameRandomizer)
 	}
 	else
 	{
+		const auto configuredGuards = getResourceHandler()->getGuards(cb, gameRandomizer);
+		if(!configuredGuards.empty())
+		{
+			for(const auto & stack : configuredGuards)
+			{
+				auto guards = std::make_unique<CStackInstance>(cb, stack.getId(), stack.getCount());
+				putStack(SlotID(stacksCount()), std::move(guards));
+			}
+		}
+
 		if(getResourceHandler()->getResourceType() == GameResID::NONE) // fallback
 			producedResource = GameResID(getObjTypeIndex().getNum());
 		else

--- a/lib/mapObjects/MiscObjects.cpp
+++ b/lib/mapObjects/MiscObjects.cpp
@@ -99,10 +99,16 @@ void CGMine::onHeroVisit(IGameEventCallback & gameEvents, const CGHeroInstance *
 		BlockingDialog ynd(true,false);
 		ynd.player = h->tempOwner;
 		const auto guardedMessageTranslated = getResourceHandler()->getOnGuardedMessageTranslated();
-		if(!isAbandoned() && !guardedMessageTranslated.empty())
+
+		if(isAbandoned())
+			ynd.text.appendLocalString(EMetaText::ADVOB_TXT, 84);
+		else if(tempOwner != PlayerColor::NEUTRAL)
+			ynd.text.appendLocalString(EMetaText::ADVOB_TXT, 187);
+		else if(!guardedMessageTranslated.empty())
 			ynd.text.appendRawString(guardedMessageTranslated);
 		else
-			ynd.text.appendLocalString(EMetaText::ADVOB_TXT, isAbandoned() ? 84 : 187);
+			ynd.text.appendLocalString(EMetaText::ADVOB_TXT, 187);
+
 		gameEvents.showBlockingDialog(this, &ynd);
 		return;
 	}

--- a/lib/mapObjects/MiscObjects.cpp
+++ b/lib/mapObjects/MiscObjects.cpp
@@ -100,17 +100,9 @@ void CGMine::onHeroVisit(IGameEventCallback & gameEvents, const CGHeroInstance *
 		ynd.player = h->tempOwner;
 		// ownedGuardedMessage applies to any owned mine with guards.
 		const bool useOwnedGuardedMessage = tempOwner != PlayerColor::NEUTRAL;
-		auto guardedMessageTranslated = useOwnedGuardedMessage ? getResourceHandler()->getOwnedGuardedMessageTranslated() : getResourceHandler()->getOnGuardedMessageTranslated();
-
-		const bool missingConfiguredGuardedMessage = guardedMessageTranslated.empty() || guardedMessageTranslated == (useOwnedGuardedMessage ? getResourceHandler()->getOwnedGuardedMessageTextID() : getResourceHandler()->getOnGuardedMessageTextID());
-
-		if(!missingConfiguredGuardedMessage)
-		{
-			if(!guardedMessageTranslated.empty() && guardedMessageTranslated.front() == '@')
-				ynd.text.appendTextID(guardedMessageTranslated.substr(1));
-			else
-				ynd.text.appendRawString(guardedMessageTranslated);
-		}
+		const std::string guardedMessageTextID = useOwnedGuardedMessage ? getResourceHandler()->getOwnedGuardedMessageTextID() : getResourceHandler()->getOnGuardedMessageTextID();
+		if(!guardedMessageTextID.empty())
+			ynd.text.appendTextID(guardedMessageTextID);
 		else
 			ynd.text.appendLocalString(EMetaText::ADVOB_TXT, 187);
 
@@ -123,6 +115,13 @@ void CGMine::onHeroVisit(IGameEventCallback & gameEvents, const CGHeroInstance *
 
 void CGMine::initObj(IGameRandomizer & gameRandomizer)
 {
+	const auto configuredGuards = getResourceHandler()->getGuards(cb, gameRandomizer);
+	for(const auto & stack : configuredGuards)
+	{
+		auto guards = std::make_unique<CStackInstance>(cb, stack.getId(), stack.getCount());
+		putStack(SlotID(stacksCount()), std::move(guards));
+	}
+
 	if(isAbandoned())
 	{
 		assert(!abandonedMineResources.empty());
@@ -138,16 +137,6 @@ void CGMine::initObj(IGameRandomizer & gameRandomizer)
 	}
 	else
 	{
-		const auto configuredGuards = getResourceHandler()->getGuards(cb, gameRandomizer);
-		if(!configuredGuards.empty())
-		{
-			for(const auto & stack : configuredGuards)
-			{
-				auto guards = std::make_unique<CStackInstance>(cb, stack.getId(), stack.getCount());
-				putStack(SlotID(stacksCount()), std::move(guards));
-			}
-		}
-
 		if(getResourceHandler()->getResourceType() == GameResID::NONE) // fallback
 			producedResource = GameResID(getObjTypeIndex().getNum());
 		else
@@ -218,11 +207,9 @@ void CGMine::flagMine(IGameEventCallback & gameEvents, const PlayerColor & playe
 
 	InfoWindow iw;
 	iw.type = EInfoWindowMode::AUTO;
-	const auto descriptionText = getResourceHandler()->getDescriptionTranslated();
-	if(!descriptionText.empty() && descriptionText.front() == '@')
-		iw.text.appendTextID(descriptionText.substr(1));
-	else if(!descriptionText.empty() && descriptionText != getResourceHandler()->getDescriptionTextID())
-		iw.text.appendRawString(descriptionText);
+	const auto descriptionTextID = getResourceHandler()->getDescriptionTextID();
+	if(!descriptionTextID.empty())
+		iw.text.appendTextID(descriptionTextID);
 	else
 		iw.text.appendTextID(TextIdentifier("core.mineevnt", producedResource.getNum()).get());
 	iw.player = player;
@@ -261,16 +248,13 @@ void CGMine::battleFinished(IGameEventCallback & gameEvents, const CGHeroInstanc
 	{
 		if(isAbandoned())
 		{
-			auto message = getResourceHandler()->getMessageTranslated();
-			if(!message.empty() && message != getResourceHandler()->getMessageTextID())
+			const auto onCaptureMessageTextID = getResourceHandler()->getOnCaptureMessageTextID();
+			if(!onCaptureMessageTextID.empty())
 			{
 				InfoWindow iw;
 				iw.type = EInfoWindowMode::AUTO;
 				iw.player = hero->tempOwner;
-				if(message.front() == '@')
-					iw.text.appendTextID(message.substr(1));
-				else
-					iw.text.appendRawString(message);
+				iw.text.appendTextID(onCaptureMessageTextID);
 				gameEvents.showInfoDialog(&iw);
 			}
 		}

--- a/lib/mapObjects/MiscObjects.cpp
+++ b/lib/mapObjects/MiscObjects.cpp
@@ -98,14 +98,19 @@ void CGMine::onHeroVisit(IGameEventCallback & gameEvents, const CGHeroInstance *
 	{
 		BlockingDialog ynd(true,false);
 		ynd.player = h->tempOwner;
-		const auto guardedMessageTranslated = getResourceHandler()->getOnGuardedMessageTranslated();
+		// ownedGuardedMessage applies to any owned mine with guards.
+		const bool useOwnedGuardedMessage = tempOwner != PlayerColor::NEUTRAL;
+		auto guardedMessageTranslated = useOwnedGuardedMessage ? getResourceHandler()->getOwnedGuardedMessageTranslated() : getResourceHandler()->getOnGuardedMessageTranslated();
 
-		if(isAbandoned())
-			ynd.text.appendLocalString(EMetaText::ADVOB_TXT, 84);
-		else if(tempOwner != PlayerColor::NEUTRAL)
-			ynd.text.appendLocalString(EMetaText::ADVOB_TXT, 187);
-		else if(!guardedMessageTranslated.empty())
-			ynd.text.appendRawString(guardedMessageTranslated);
+		const bool missingConfiguredGuardedMessage = guardedMessageTranslated.empty() || guardedMessageTranslated == (useOwnedGuardedMessage ? getResourceHandler()->getOwnedGuardedMessageTextID() : getResourceHandler()->getOnGuardedMessageTextID());
+
+		if(!missingConfiguredGuardedMessage)
+		{
+			if(!guardedMessageTranslated.empty() && guardedMessageTranslated.front() == '@')
+				ynd.text.appendTextID(guardedMessageTranslated.substr(1));
+			else
+				ynd.text.appendRawString(guardedMessageTranslated);
+		}
 		else
 			ynd.text.appendLocalString(EMetaText::ADVOB_TXT, 187);
 
@@ -120,11 +125,6 @@ void CGMine::initObj(IGameRandomizer & gameRandomizer)
 {
 	if(isAbandoned())
 	{
-		//set default abandoned mine guardians
-		int howManyGuards = gameRandomizer.getDefault().nextInt(abandonedMineGuards.minAmount, abandonedMineGuards.maxAmount);
-		auto guards = std::make_unique<CStackInstance>(cb, abandonedMineGuards.creature, howManyGuards);
-		putStack(SlotID(0), std::move(guards));
-
 		assert(!abandonedMineResources.empty());
 		if (!abandonedMineResources.empty())
 		{
@@ -218,10 +218,13 @@ void CGMine::flagMine(IGameEventCallback & gameEvents, const PlayerColor & playe
 
 	InfoWindow iw;
 	iw.type = EInfoWindowMode::AUTO;
-	if(getResourceHandler()->getResourceType() == GameResID::NONE || getObjTypeIndex() < GameConstants::RESOURCE_QUANTITY)
-		iw.text.appendTextID(TextIdentifier("core.mineevnt", producedResource.getNum()).get()); //not use subID, abandoned mines uses default mine texts
+	const auto descriptionText = getResourceHandler()->getDescriptionTranslated();
+	if(!descriptionText.empty() && descriptionText.front() == '@')
+		iw.text.appendTextID(descriptionText.substr(1));
+	else if(!descriptionText.empty() && descriptionText != getResourceHandler()->getDescriptionTextID())
+		iw.text.appendRawString(descriptionText);
 	else
-		iw.text.appendRawString(getResourceHandler()->getDescriptionTranslated());
+		iw.text.appendTextID(TextIdentifier("core.mineevnt", producedResource.getNum()).get());
 	iw.player = player;
 	iw.components.emplace_back(ComponentType::RESOURCE_PER_DAY, producedResource, getProducedQuantity());
 	gameEvents.showInfoDialog(&iw);
@@ -258,7 +261,18 @@ void CGMine::battleFinished(IGameEventCallback & gameEvents, const CGHeroInstanc
 	{
 		if(isAbandoned())
 		{
-			hero->showInfoDialog(gameEvents, 85); //TODO: alternative text for custom guards
+			auto message = getResourceHandler()->getMessageTranslated();
+			if(!message.empty() && message != getResourceHandler()->getMessageTextID())
+			{
+				InfoWindow iw;
+				iw.type = EInfoWindowMode::AUTO;
+				iw.player = hero->tempOwner;
+				if(message.front() == '@')
+					iw.text.appendTextID(message.substr(1));
+				else
+					iw.text.appendRawString(message);
+				gameEvents.showInfoDialog(&iw);
+			}
 		}
 		flagMine(gameEvents, hero->tempOwner);
 	}

--- a/lib/mapObjects/MiscObjects.cpp
+++ b/lib/mapObjects/MiscObjects.cpp
@@ -116,10 +116,13 @@ void CGMine::onHeroVisit(IGameEventCallback & gameEvents, const CGHeroInstance *
 void CGMine::initObj(IGameRandomizer & gameRandomizer)
 {
 	const auto configuredGuards = getResourceHandler()->getGuards(cb, gameRandomizer);
-	for(const auto & stack : configuredGuards)
+	if(!configuredGuards.empty())
 	{
-		auto guards = std::make_unique<CStackInstance>(cb, stack.getId(), stack.getCount());
-		putStack(SlotID(stacksCount()), std::move(guards));
+		for(const auto & stack : configuredGuards)
+		{
+			auto guards = std::make_unique<CStackInstance>(cb, stack.getId(), stack.getCount());
+			putStack(SlotID(stacksCount()), std::move(guards));
+		}
 	}
 
 	if(isAbandoned())

--- a/lib/mapObjects/MiscObjects.cpp
+++ b/lib/mapObjects/MiscObjects.cpp
@@ -99,7 +99,7 @@ void CGMine::onHeroVisit(IGameEventCallback & gameEvents, const CGHeroInstance *
 		BlockingDialog ynd(true,false);
 		ynd.player = h->tempOwner;
 		// ownedGuardedMessage applies to any owned mine with guards.
-		const bool useOwnedGuardedMessage = tempOwner != PlayerColor::NEUTRAL;
+		const bool useOwnedGuardedMessage = getOwner().isValid();
 		const std::string guardedMessageTextID = useOwnedGuardedMessage ? getResourceHandler()->getOwnedGuardedMessageTextID() : getResourceHandler()->getOnGuardedMessageTextID();
 		if(!guardedMessageTextID.empty())
 			ynd.text.appendTextID(guardedMessageTextID);

--- a/lib/mapObjects/MiscObjects.cpp
+++ b/lib/mapObjects/MiscObjects.cpp
@@ -99,7 +99,7 @@ void CGMine::onHeroVisit(IGameEventCallback & gameEvents, const CGHeroInstance *
 		BlockingDialog ynd(true,false);
 		ynd.player = h->tempOwner;
 		// ownedGuardedMessage applies to any owned mine with guards.
-		const bool useOwnedGuardedMessage = getOwner().isValid();
+		const bool useOwnedGuardedMessage = tempOwner != PlayerColor::NEUTRAL;
 		const std::string guardedMessageTextID = useOwnedGuardedMessage ? getResourceHandler()->getOwnedGuardedMessageTextID() : getResourceHandler()->getOnGuardedMessageTextID();
 		if(!guardedMessageTextID.empty())
 			ynd.text.appendTextID(guardedMessageTextID);

--- a/lib/rmg/modificators/MinePlacer.cpp
+++ b/lib/rmg/modificators/MinePlacer.cpp
@@ -60,19 +60,21 @@ bool MinePlacer::placeMines(ObjectManager & manager)
 		const auto res = GameResID(mineInfo.first);
 		for(int i = 0; i < mineInfo.second; ++i)
 		{
-			TObjectTypeHandler mineHandler;
+			std::vector<TObjectTypeHandler> compatibleMineHandlers;
 			for(auto & subObjID : LIBRARY->objtypeh->knownSubObjects(Obj::MINE))
 			{
 				auto handler = std::dynamic_pointer_cast<MineInstanceConstructor>(LIBRARY->objtypeh->getHandlerFor(Obj::MINE, subObjID));
 				if(handler->getResourceType() == res)
-					mineHandler = handler;
+					compatibleMineHandlers.push_back(handler);
 			}
 
-			if(!mineHandler)
+			if(compatibleMineHandlers.empty())
 			{
 				logGlobal->error("No mine for resource %s found!", res.toResource()->getJsonKey());
 				continue;
 			}
+
+			auto mineHandler = *RandomGeneratorUtil::nextItem(compatibleMineHandlers, zone.getRand());
 
 			const auto & rmginfo = mineHandler->getRMGInfo();
 			auto mine = std::dynamic_pointer_cast<CGMine>(mineHandler->create(map.mapInstance->cb, nullptr));


### PR DESCRIPTION
1) It's now possible to define multiple mines per resource - for example mines with different daily amount
2) Added support for custom mine guards
3) It's possible to set custom guards message, otherwise default abandon mine message is used

This PR is required to finish "Big Crystal Cavern" object in Pavilion mod which should work as Crystal Cavern with 2pcs per day and guards needs to be defeated first. After this PR It's possible to configure it.