### PR TITLE
[1.7.4] small fixes and improvements for 1.7.4

### DIFF
--- a/client/adventureMap/AdventureOptions.cpp
+++ b/client/adventureMap/AdventureOptions.cpp
@@ -124,6 +124,7 @@ AdventureOptions::AdventureOptions()
 
 		scrollBar->setScrollBounds(Rect(-228, 0, 228 + 16, MAX_VISIBLE * BUTTON_STEP));
 		scrollBar->setPanningStep(BUTTON_STEP);
+		scrollBar->setInertiaEnabled(true);
 	}
 
 	exit = std::make_shared<CButton>(Point(203, 313), AnimationPath::builtin("IOK6432.DEF"), CButton::tooltip(), std::bind(&AdventureOptions::close, this), EShortcut::GLOBAL_RETURN);

--- a/client/lobby/CBonusSelection.cpp
+++ b/client/lobby/CBonusSelection.cpp
@@ -158,9 +158,11 @@ CBonusSelection::CBonusSelection()
 void CBonusSelection::createBonusesIcons()
 {
 	OBJECT_CONSTRUCTION;
+	groupBonusesLabels.clear();
 	const CampaignScenario & scenario = getCampaign()->scenario(GAME->server().campaignMap);
 	const std::vector<CampaignBonus> & bonDescs = scenario.travelOptions.bonusesToChoose;
 	groupBonuses = std::make_shared<CToggleGroup>(std::bind(&IServerAPI::setCampaignBonus, &GAME->server(), _1));
+	groupBonuses->setRedrawParent(true);
 
 	auto getBuildingID = [this](const CampaignBonusBuilding & bonusValue) -> std::pair<FactionID, BuildingID> {
 		FactionID faction;
@@ -393,6 +395,7 @@ void CBonusSelection::createBonusesIcons()
 			if(buttonStart->isActive() && !buttonStart->isBlocked())	
 				CBonusSelection::startMap();
 		});
+		bonusButton->setRedrawParent(true);
 
 		if(picNumber != -1)
 			bonusButton->setOverlay(std::make_shared<CAnimImage>(AnimationPath::builtin(picName), picNumber));

--- a/client/lobby/CSelectionBase.cpp
+++ b/client/lobby/CSelectionBase.cpp
@@ -280,7 +280,6 @@ void InfoCard::changeSelection()
 	labelLossConditionText->setText(header->defeatMessage.toString());
 	flagbox->recreate();
 	labelDifficulty->setText(LIBRARY->generaltexth->arraytxt[142 + vstd::to_underlying(mapInfo->mapHeader->difficulty)]);
-	iconDifficulty->activate();
 	iconDifficulty->setSelected(SEL->getCurrentDifficulty());
 	if(SEL->screenType == ESelectionScreen::loadGame || SEL->screenType == ESelectionScreen::saveGame)
 		for(auto & button : iconDifficulty->buttons)

--- a/client/widgets/TextControls.cpp
+++ b/client/widgets/TextControls.cpp
@@ -456,6 +456,7 @@ void CTextBox::setText(const std::string & text)
 			label->pos.h, label->textSize.y, 0, Orientation::VERTICAL, CSlider::EStyle(sliderStyle));
 		slider->setScrollStep(fontPtr->getLineHeight());
 		slider->setPanningStep(1);
+		slider->setInertiaEnabled(true);
 		slider->setScrollBounds(pos - slider->pos.topLeft());
 		// The redraw triggered by label->setText() above fired before the slider
 		// was created, so the slider would not appear until the next interaction.

--- a/client/windows/wiki/WikiWindow.cpp
+++ b/client/windows/wiki/WikiWindow.cpp
@@ -1629,6 +1629,10 @@ void WikiWindow::navigateTo(const WikiEntryKey & key) // NOSONAR
 
 	activeCategoryIndex = catIdx;
 	activeElementIndex = -1; // reset before rebuild to prevent stale pre-selection
+	if(searchBox)
+		searchBox->setText("");
+	if(searchBoxHint)
+		searchBoxHint->setEnabled(true);
 	buildElementList(activeCategoryIndex);
 
 	// Select the category item visually


### PR DESCRIPTION
- fixes difficulty icons click when in chat (-> you was able to click these buttons even if they're not visible)
- more places for inertia scroll (multiline label + adventure options dialog)
- fix flickering number when changing campaign bonus selection
- reset filter when navigate in wiki (avoids to navigate to non visible entry)