### PR TITLE
[1.8.0] mapeditor: adds a widget for editing witch hut preset abilities

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -127,6 +127,7 @@ set(lib_MAIN_SRCS
 
 	json/JsonBonus.cpp
 	json/JsonRandom.cpp
+	json/JsonKeyExtractor.cpp
 
 	gameState/CGameState.cpp
 	gameState/CGameStateCampaign.cpp
@@ -562,6 +563,7 @@ set(lib_MAIN_HEADERS
 
 	json/JsonBonus.h
 	json/JsonRandom.h
+	json/JsonKeyExtractor.h
 
 	gameState/CGameState.h
 	gameState/CGameStateCampaign.h

--- a/lib/json/JsonKeyExtractor.cpp
+++ b/lib/json/JsonKeyExtractor.cpp
@@ -1,0 +1,123 @@
+#include "StdInc.h"
+#include "JsonKeyExtractor.h"
+
+#include <entities/artifact/CArtHandler.h>
+
+#include <callback/IGameInfoCallback.h>
+
+#include <spells/CSpellHandler.h>
+
+VCMI_LIB_NAMESPACE_BEGIN
+
+JsonKeyExtractor::JsonKeyExtractor(IGameInfoCallback * cb) : cb(cb) {}
+
+si32 JsonKeyExtractor::loadVariable(const std::string & variableGroup, const std::string & value, const Variables & variables, si32 defaultValue)
+{
+	if(value.empty() || value[0] != '@')
+	{
+		logMod->warn("Invalid syntax in load value! Can not load value from '%s'", value);
+		return defaultValue;
+	}
+
+	std::string variableID = variableGroup + value;
+
+	if(variables.count(variableID) == 0)
+	{
+		logMod->warn("Invalid syntax in load value! Unknown variable '%s'", value);
+		return defaultValue;
+	}
+	return variables.at(variableID);
+}
+
+std::set<ArtifactID> JsonKeyExtractor::filterKeysTyped(const JsonNode & value, const std::set<ArtifactID> & valuesSet)
+{
+	assert(value.isStruct());
+
+	std::set<EArtifactClass> allowedClasses;
+	std::set<ArtifactPosition> allowedPositions;
+	ui32 minValue = 0;
+	ui32 maxValue = std::numeric_limits<ui32>::max();
+
+	if(value["class"].getType() == JsonNode::JsonType::DATA_STRING)
+		allowedClasses.insert(CArtHandler::stringToClass(value["class"].String()));
+	else
+		for(const auto & entry : value["class"].Vector())
+			allowedClasses.insert(CArtHandler::stringToClass(entry.String()));
+
+	if(value["slot"].getType() == JsonNode::JsonType::DATA_STRING)
+		allowedPositions.insert(ArtifactPosition::decode(value["class"].String()));
+	else
+		for(const auto & entry : value["slot"].Vector())
+			allowedPositions.insert(ArtifactPosition::decode(entry.String()));
+
+	if(!value["minValue"].isNull())
+		minValue = static_cast<ui32>(value["minValue"].Float());
+	if(!value["maxValue"].isNull())
+		maxValue = static_cast<ui32>(value["maxValue"].Float());
+
+	std::set<ArtifactID> result;
+
+	for(const auto & artID : valuesSet)
+	{
+		const CArtifact * art = artID.toArtifact();
+
+		if(!vstd::iswithin(art->getPrice(), minValue, maxValue))
+			continue;
+
+		if(!allowedClasses.empty() && !allowedClasses.count(art->aClass))
+			continue;
+
+		if(!cb->isAllowed(art->getId()))
+			continue;
+
+		if(!allowedPositions.empty())
+		{
+			bool positionAllowed = false;
+			for(const auto & pos : art->getPossibleSlots().at(ArtBearer::HERO))
+			{
+				if(allowedPositions.count(pos))
+					positionAllowed = true;
+			}
+
+			if(!positionAllowed)
+				continue;
+		}
+
+		result.insert(artID);
+	}
+	return result;
+}
+
+std::set<SpellID> JsonKeyExtractor::filterKeysTyped(const JsonNode & value, const std::set<SpellID> & valuesSet)
+{
+	std::set<SpellID> result = valuesSet;
+
+	if(!value["level"].isNull())
+	{
+		int32_t spellLevel = value["level"].Integer();
+
+		vstd::erase_if(
+			result,
+			[=](const SpellID & spell)
+			{
+				return LIBRARY->spellh->getById(spell)->getLevel() != spellLevel;
+			}
+		);
+	}
+
+	if(!value["school"].isNull())
+	{
+		int32_t schoolID = LIBRARY->identifiers()->getIdentifier("spellSchool", value["school"]).value();
+
+		vstd::erase_if(
+			result,
+			[=](const SpellID & spell)
+			{
+				return !LIBRARY->spellh->getById(spell)->hasSchool(SpellSchool(schoolID));
+			}
+		);
+	}
+	return result;
+}
+
+VCMI_LIB_NAMESPACE_END

--- a/lib/json/JsonKeyExtractor.h
+++ b/lib/json/JsonKeyExtractor.h
@@ -1,0 +1,142 @@
+#pragma once
+
+#include "../GameLibrary.h"
+#include "../modding/IdentifierStorage.h"
+#include "GameConstants.h"
+#include "JsonNode.h"
+
+VCMI_LIB_NAMESPACE_BEGIN
+
+class DLL_LINKAGE JsonKeyExtractor
+{
+
+public:
+	JsonKeyExtractor(IGameInfoCallback * cb);
+
+	using Variables = std::map<std::string, int>;
+
+	template<typename IdentifierType>
+	std::set<IdentifierType> filterKeys(const JsonNode & value, const std::set<IdentifierType> & valuesSet, const Variables & variables = {});
+
+	template<typename IdentifierType>
+	IdentifierType decodeKey(const std::string & modScope, const std::string & value, const Variables & variables);
+
+	si32 loadVariable(const std::string & variableGroup, const std::string & value, const Variables & variables, si32 defaultValue);
+
+private:
+	template<typename IdentifierType>
+	IdentifierType decodeKey(const JsonNode & value, const Variables & variables);
+
+	template<typename IdentifierType>
+	std::set<IdentifierType> filterKeysTyped(const JsonNode & value, const std::set<IdentifierType> & valuesSet);
+
+	std::set<ArtifactID> filterKeysTyped(const JsonNode & value, const std::set<ArtifactID> & valuesSet);
+
+	std::set<SpellID> filterKeysTyped(const JsonNode & value, const std::set<SpellID> & valuesSet);
+
+	IGameInfoCallback * cb;
+};
+
+template<typename IdentifierType>
+std::set<IdentifierType> JsonKeyExtractor::filterKeys(const JsonNode & value, const std::set<IdentifierType> & valuesSet, const Variables & variables)
+{
+	if(value.isString())
+		return {decodeKey<IdentifierType>(value, variables)};
+
+	assert(value.isStruct());
+
+	if(value.isStruct())
+	{
+		if(!value["type"].isNull())
+			return filterKeys(value["type"], valuesSet, variables);
+
+		std::set<IdentifierType> filteredTypes = filterKeysTyped(value, valuesSet);
+
+		if(!value["anyOf"].isNull())
+		{
+			std::set<IdentifierType> filteredAnyOf;
+			for(const auto & entry : value["anyOf"].Vector())
+			{
+				std::set<IdentifierType> subset = filterKeys(entry, valuesSet, variables);
+				filteredAnyOf.insert(subset.begin(), subset.end());
+			}
+
+			vstd::erase_if(
+				filteredTypes,
+				[&filteredAnyOf](const IdentifierType & filteredValue)
+				{
+					return filteredAnyOf.count(filteredValue) == 0;
+				}
+			);
+		}
+
+		if(!value["noneOf"].isNull())
+		{
+			for(const auto & entry : value["noneOf"].Vector())
+			{
+				std::set<IdentifierType> subset = filterKeys(entry, valuesSet, variables);
+				for(auto bannedEntry : subset)
+					filteredTypes.erase(bannedEntry);
+			}
+		}
+
+		return filteredTypes;
+	}
+	return valuesSet;
+}
+
+template<typename IdentifierType>
+IdentifierType JsonKeyExtractor::decodeKey(const std::string & modScope, const std::string & value, const Variables & variables)
+{
+	if(value.empty() || value[0] != '@')
+		return IdentifierType(LIBRARY->identifiers()->getIdentifier(modScope, IdentifierType::entityType(), value).value_or(-1));
+	else
+		return loadVariable(IdentifierType::entityType(), value, variables, IdentifierType::NONE);
+}
+
+template<>
+inline PrimarySkill JsonKeyExtractor::decodeKey(const std::string & modScope, const std::string & value, const Variables & variables)
+{
+	if(value.empty() || value[0] != '@')
+		return PrimarySkill(*LIBRARY->identifiers()->getIdentifier(modScope, "primarySkill", value));
+	else
+		return PrimarySkill(loadVariable("primarySkill", value, variables, PrimarySkill::NONE.getNum()));
+}
+
+template<typename IdentifierType>
+IdentifierType JsonKeyExtractor::decodeKey(const JsonNode & value, const Variables & variables)
+{
+	if(value.String().empty() || value.String()[0] != '@')
+		return IdentifierType(LIBRARY->identifiers()->getIdentifier(IdentifierType::entityType(), value).value_or(-1));
+	else
+		return loadVariable(IdentifierType::entityType(), value.String(), variables, IdentifierType::NONE);
+}
+
+template<>
+inline ArtifactPosition JsonKeyExtractor::decodeKey(const JsonNode & value, const Variables & variables)
+{
+	return ArtifactPosition::decode(value.String());
+}
+
+template<>
+inline PlayerColor JsonKeyExtractor::decodeKey(const JsonNode & value, const Variables & variables)
+{
+	return PlayerColor(*LIBRARY->identifiers()->getIdentifier("playerColor", value));
+}
+
+template<>
+inline PrimarySkill JsonKeyExtractor::decodeKey(const JsonNode & value, const Variables & variables)
+{
+	return PrimarySkill(*LIBRARY->identifiers()->getIdentifier("primarySkill", value));
+}
+
+
+/// Method that allows type-specific object filtering
+/// Default implementation is to accept all input objects
+template<typename IdentifierType>
+std::set<IdentifierType> JsonKeyExtractor::filterKeysTyped(const JsonNode & value, const std::set<IdentifierType> & valuesSet)
+{
+	return valuesSet;
+}
+
+VCMI_LIB_NAMESPACE_END

--- a/lib/json/JsonRandom.cpp
+++ b/lib/json/JsonRandom.cpp
@@ -11,37 +11,37 @@
 #include "StdInc.h"
 #include "JsonRandom.h"
 
-#include <vstd/StringUtils.h>
-#include <vstd/RNG.h>
 #include <vcmi/HeroClassService.h>
 #include <vcmi/HeroTypeService.h>
+#include <vstd/RNG.h>
+#include <vstd/StringUtils.h>
 
 #include "JsonBonus.h"
 
+#include "../CCreatureHandler.h"
+#include "../CSkillHandler.h"
+#include "../GameLibrary.h"
 #include "../callback/IGameInfoCallback.h"
 #include "../callback/IGameRandomizer.h"
 #include "../constants/StringConstants.h"
-#include "../GameLibrary.h"
-#include "../CCreatureHandler.h"
-#include "../spells/CSpellHandler.h"
-#include "../CSkillHandler.h"
+#include "../entities/ResourceTypeHandler.h"
 #include "../entities/artifact/CArtHandler.h"
 #include "../entities/hero/CHero.h"
 #include "../entities/hero/CHeroClass.h"
-#include "../entities/ResourceTypeHandler.h"
 #include "../gameState/CGameState.h"
-#include "../mapObjects/army/CStackBasicDescriptor.h"
 #include "../mapObjects/IObjectInterface.h"
+#include "../mapObjects/army/CStackBasicDescriptor.h"
 #include "../modding/IdentifierStorage.h"
 #include "../modding/ModScope.h"
+#include "../spells/CSpellHandler.h"
 
 VCMI_LIB_NAMESPACE_BEGIN
 
 std::string JsonRandomizationException::cleanupJson(const JsonNode & value)
 {
 	std::string result = value.toCompactString();
-	for (size_t i = 0; i < result.size(); ++i)
-		if (result[i] == '\n')
+	for(size_t i = 0; i < result.size(); ++i)
+		if(result[i] == '\n')
 			result[i] = ' ';
 
 	return result;
@@ -49,551 +49,337 @@ std::string JsonRandomizationException::cleanupJson(const JsonNode & value)
 
 JsonRandomizationException::JsonRandomizationException(const std::string & message, const JsonNode & input)
 	: std::runtime_error(message + " Input was: " + cleanupJson(input))
-{}
-
-JsonRandom::JsonRandom(IGameInfoCallback * cb, IGameRandomizer & gameRandomizer)
-	: GameCallbackHolder(cb)
-	, gameRandomizer(gameRandomizer)
-	, rng(gameRandomizer.getDefault())
 {
 }
 
-	si32 JsonRandom::loadVariable(const std::string & variableGroup, const std::string & value, const Variables & variables, si32 defaultValue)
-	{
-		if (value.empty() || value[0] != '@')
-		{
-			logMod->warn("Invalid syntax in load value! Can not load value from '%s'", value);
-			return defaultValue;
-		}
+JsonRandom::JsonRandom(IGameInfoCallback * cb, IGameRandomizer & gameRandomizer)
+	: GameCallbackHolder(cb), gameRandomizer(gameRandomizer), rng(gameRandomizer.getDefault()), jsonKeyExtractor(cb)
+{
+}
 
-		std::string variableID = variableGroup + value;
-
-		if (variables.count(variableID) == 0)
-		{
-			logMod->warn("Invalid syntax in load value! Unknown variable '%s'", value);
-			return defaultValue;
-		}
-		return variables.at(variableID);
-	}
-
-	si32 JsonRandom::loadValue(const JsonNode & value, const Variables & variables, si32 defaultValue)
-	{
-		if(value.isNull())
-			return defaultValue;
-		if(value.isNumber())
-			return value.Integer();
-		if (value.isString())
-			return loadVariable("number", value.String(), variables, defaultValue);
-
-		if(value.isVector())
-		{
-			const auto & vector = value.Vector();
-
-			size_t index= rng.nextInt64(0, vector.size()-1);
-			return loadValue(vector[index], variables, 0);
-		}
-		if(value.isStruct())
-		{
-			if (!value["amount"].isNull())
-				return loadValue(value["amount"], variables, defaultValue);
-			si32 min = loadValue(value["min"], variables, 0);
-			si32 max = loadValue(value["max"], variables, 0);
-			return rng.nextInt64(min, max);
-		}
+si32 JsonRandom::loadValue(const JsonNode & value, const Variables & variables, si32 defaultValue)
+{
+	if(value.isNull())
 		return defaultValue;
-	}
+	if(value.isNumber())
+		return value.Integer();
+	if(value.isString())
+		return jsonKeyExtractor.loadVariable("number", value.String(), variables, defaultValue);
 
-	template<typename IdentifierType>
-	IdentifierType JsonRandom::decodeKey(const std::string & modScope, const std::string & value, const Variables & variables)
+	if(value.isVector())
 	{
-		if (value.empty() || value[0] != '@')
-			return IdentifierType(LIBRARY->identifiers()->getIdentifier(modScope, IdentifierType::entityType(), value).value_or(-1));
-		else
-			return loadVariable(IdentifierType::entityType(), value, variables, IdentifierType::NONE);
+		const auto & vector = value.Vector();
+
+		size_t index = rng.nextInt64(0, vector.size() - 1);
+		return loadValue(vector[index], variables, 0);
 	}
-
-	template<typename IdentifierType>
-	IdentifierType JsonRandom::decodeKey(const JsonNode & value, const Variables & variables)
+	if(value.isStruct())
 	{
-		if (value.String().empty() || value.String()[0] != '@')
-			return IdentifierType(LIBRARY->identifiers()->getIdentifier(IdentifierType::entityType(), value).value_or(-1));
-		else
-			return loadVariable(IdentifierType::entityType(), value.String(), variables, IdentifierType::NONE);
+		if(!value["amount"].isNull())
+			return loadValue(value["amount"], variables, defaultValue);
+		si32 min = loadValue(value["min"], variables, 0);
+		si32 max = loadValue(value["max"], variables, 0);
+		return rng.nextInt64(min, max);
 	}
+	return defaultValue;
+}
 
-	template<>
-	ArtifactPosition JsonRandom::decodeKey(const JsonNode & value, const Variables & variables)
+TResources JsonRandom::loadResources(const JsonNode & value, const Variables & variables)
+{
+	TResources ret;
+
+	if(value.isVector())
 	{
-		return ArtifactPosition::decode(value.String());
-	}
-
-	template<>
-	PlayerColor JsonRandom::decodeKey(const JsonNode & value, const Variables & variables)
-	{
-		return PlayerColor(*LIBRARY->identifiers()->getIdentifier("playerColor", value));
-	}
-
-	template<>
-	PrimarySkill JsonRandom::decodeKey(const JsonNode & value, const Variables & variables)
-	{
-		return PrimarySkill(*LIBRARY->identifiers()->getIdentifier("primarySkill", value));
-	}
-
-	template<>
-	PrimarySkill JsonRandom::decodeKey(const std::string & modScope, const std::string & value, const Variables & variables)
-	{
-		if (value.empty() || value[0] != '@')
-			return PrimarySkill(*LIBRARY->identifiers()->getIdentifier(modScope, "primarySkill", value));
-		else
-			return PrimarySkill(loadVariable("primarySkill", value, variables, PrimarySkill::NONE.getNum()));
-	}
-
-	/// Method that allows type-specific object filtering
-	/// Default implementation is to accept all input objects
-	template<typename IdentifierType>
-	std::set<IdentifierType> JsonRandom::filterKeysTyped(const JsonNode & value, const std::set<IdentifierType> & valuesSet)
-	{
-		return valuesSet;
-	}
-
-	template<>
-	std::set<ArtifactID> JsonRandom::filterKeysTyped(const JsonNode & value, const std::set<ArtifactID> & valuesSet)
-	{
-		assert(value.isStruct());
-
-		std::set<EArtifactClass> allowedClasses;
-		std::set<ArtifactPosition> allowedPositions;
-		ui32 minValue = 0;
-		ui32 maxValue = std::numeric_limits<ui32>::max();
-
-		if (value["class"].getType() == JsonNode::JsonType::DATA_STRING)
-			allowedClasses.insert(CArtHandler::stringToClass(value["class"].String()));
-		else
-			for(const auto & entry : value["class"].Vector())
-				allowedClasses.insert(CArtHandler::stringToClass(entry.String()));
-
-		if (value["slot"].getType() == JsonNode::JsonType::DATA_STRING)
-			allowedPositions.insert(ArtifactPosition::decode(value["class"].String()));
-		else
-			for(const auto & entry : value["slot"].Vector())
-				allowedPositions.insert(ArtifactPosition::decode(entry.String()));
-
-		if (!value["minValue"].isNull())
-			minValue = static_cast<ui32>(value["minValue"].Float());
-		if (!value["maxValue"].isNull())
-			maxValue = static_cast<ui32>(value["maxValue"].Float());
-
-		std::set<ArtifactID> result;
-
-		for (auto const & artID : valuesSet)
-		{
-			const CArtifact * art = artID.toArtifact();
-
-			if(!vstd::iswithin(art->getPrice(), minValue, maxValue))
-				continue;
-
-			if(!allowedClasses.empty() && !allowedClasses.count(art->aClass))
-				continue;
-
-			if(!cb->isAllowed(art->getId()))
-				continue;
-
-			if(!allowedPositions.empty())
-			{
-				bool positionAllowed = false;
-				for(const auto & pos : art->getPossibleSlots().at(ArtBearer::HERO))
-				{
-					if(allowedPositions.count(pos))
-						positionAllowed = true;
-				}
-
-				if (!positionAllowed)
-					continue;
-			}
-
-			result.insert(artID);
-		}
-		return result;
-	}
-
-	template<>
-	std::set<SpellID> JsonRandom::filterKeysTyped(const JsonNode & value, const std::set<SpellID> & valuesSet)
-	{
-		std::set<SpellID> result = valuesSet;
-
-		if (!value["level"].isNull())
-		{
-			int32_t spellLevel = value["level"].Integer();
-
-			vstd::erase_if(result, [=](const SpellID & spell)
-			{
-				return LIBRARY->spellh->getById(spell)->getLevel() != spellLevel;
-			});
-		}
-
-		if (!value["school"].isNull())
-		{
-			int32_t schoolID = LIBRARY->identifiers()->getIdentifier("spellSchool", value["school"]).value();
-
-			vstd::erase_if(result, [=](const SpellID & spell)
-			{
-				return !LIBRARY->spellh->getById(spell)->hasSchool(SpellSchool(schoolID));
-			});
-		}
-		return result;
-	}
-
-	template<typename IdentifierType>
-	std::set<IdentifierType> JsonRandom::filterKeys(const JsonNode & value, const std::set<IdentifierType> & valuesSet, const Variables & variables)
-	{
-		if(value.isString())
-			return { decodeKey<IdentifierType>(value, variables) };
-
-		assert(value.isStruct());
-
-		if(value.isStruct())
-		{
-			if(!value["type"].isNull())
-				return filterKeys(value["type"], valuesSet, variables);
-
-			std::set<IdentifierType> filteredTypes = filterKeysTyped(value, valuesSet);
-
-			if(!value["anyOf"].isNull())
-			{
-				std::set<IdentifierType> filteredAnyOf;
-				for (auto const & entry : value["anyOf"].Vector())
-				{
-					std::set<IdentifierType> subset = filterKeys(entry, valuesSet, variables);
-					filteredAnyOf.insert(subset.begin(), subset.end());
-				}
-
-				vstd::erase_if(filteredTypes, [&filteredAnyOf](const IdentifierType & filteredValue)
-				{
-					return filteredAnyOf.count(filteredValue) == 0;
-				});
-			}
-
-			if(!value["noneOf"].isNull())
-			{
-				for (auto const & entry : value["noneOf"].Vector())
-				{
-					std::set<IdentifierType> subset = filterKeys(entry, valuesSet, variables);
-					for (auto bannedEntry : subset )
-						filteredTypes.erase(bannedEntry);
-				}
-			}
-
-			return filteredTypes;
-		}
-		return valuesSet;
-	}
-
-	TResources JsonRandom::loadResources(const JsonNode & value, const Variables & variables)
-	{
-		TResources ret;
-
-		if (value.isVector())
-		{
-			for (const auto & entry : value.Vector())
-				ret += loadResource(entry, variables);
-			return ret;
-		}
-
-		for(auto & i : LIBRARY->resourceTypeHandler->getAllObjects())
-		{
-			ret[i] = loadValue(value[i.toResource()->getJsonKey()], variables);
-		}
+		for(const auto & entry : value.Vector())
+			ret += loadResource(entry, variables);
 		return ret;
 	}
 
-	TResources JsonRandom::loadResource(const JsonNode & value, const Variables & variables)
+	for(auto & i : LIBRARY->resourceTypeHandler->getAllObjects())
 	{
-		GameResID resourceID = loadResourceType(value, variables);
-		si32 resourceAmount = loadValue(value, variables, 0);
-
-		TResources ret;
-		ret[resourceID] = resourceAmount;
-		return ret;
+		ret[i] = loadValue(value[i.toResource()->getJsonKey()], variables);
 	}
+	return ret;
+}
 
-	GameResID JsonRandom::loadResourceType(const JsonNode & value, const Variables & variables)
+TResources JsonRandom::loadResource(const JsonNode & value, const Variables & variables)
+{
+	GameResID resourceID = loadResourceType(value, variables);
+	si32 resourceAmount = loadValue(value, variables, 0);
+
+	TResources ret;
+	ret[resourceID] = resourceAmount;
+	return ret;
+}
+
+GameResID JsonRandom::loadResourceType(const JsonNode & value, const Variables & variables)
+{
+	auto defaultResources = LIBRARY->resourceTypeHandler->getAllObjects();
+
+	std::set<GameResID> potentialPicks = jsonKeyExtractor.filterKeys(value, std::set<GameResID>(defaultResources.begin(), defaultResources.end()), variables);
+	GameResID resourceID = *RandomGeneratorUtil::nextItem(potentialPicks, rng);
+	return resourceID;
+}
+
+PrimarySkill JsonRandom::loadPrimary(const JsonNode & value, const Variables & variables)
+{
+	std::set<PrimarySkill> defaultSkills{PrimarySkill::ATTACK, PrimarySkill::DEFENSE, PrimarySkill::SPELL_POWER, PrimarySkill::KNOWLEDGE};
+	std::set<PrimarySkill> potentialPicks = jsonKeyExtractor.filterKeys(value, defaultSkills, variables);
+	return *RandomGeneratorUtil::nextItem(potentialPicks, rng);
+}
+
+std::vector<si32> JsonRandom::loadPrimaries(const JsonNode & value, const Variables & variables)
+{
+	std::vector<si32> ret(GameConstants::PRIMARY_SKILLS, 0);
+	std::set<PrimarySkill> defaultSkills{PrimarySkill::ATTACK, PrimarySkill::DEFENSE, PrimarySkill::SPELL_POWER, PrimarySkill::KNOWLEDGE};
+
+	if(value.isStruct())
 	{
-		auto defaultResources = LIBRARY->resourceTypeHandler->getAllObjects();
-
-		std::set<GameResID> potentialPicks = filterKeys(value, std::set<GameResID>(defaultResources.begin(), defaultResources.end()), variables);
-		GameResID resourceID = *RandomGeneratorUtil::nextItem(potentialPicks, rng);
-		return resourceID;
-	}
-
-	PrimarySkill JsonRandom::loadPrimary(const JsonNode & value, const Variables & variables)
-	{
-		std::set<PrimarySkill> defaultSkills{
-			PrimarySkill::ATTACK,
-			PrimarySkill::DEFENSE,
-			PrimarySkill::SPELL_POWER,
-			PrimarySkill::KNOWLEDGE
-		};
-		std::set<PrimarySkill> potentialPicks = filterKeys(value, defaultSkills, variables);
-		return *RandomGeneratorUtil::nextItem(potentialPicks, rng);
-	}
-
-	std::vector<si32> JsonRandom::loadPrimaries(const JsonNode & value, const Variables & variables)
-	{
-		std::vector<si32> ret(GameConstants::PRIMARY_SKILLS, 0);
-		std::set<PrimarySkill> defaultSkills{
-			PrimarySkill::ATTACK,
-			PrimarySkill::DEFENSE,
-			PrimarySkill::SPELL_POWER,
-			PrimarySkill::KNOWLEDGE
-		};
-
-		if(value.isStruct())
+		for(const auto & pair : value.Struct())
 		{
-			for(const auto & pair : value.Struct())
-			{
-				PrimarySkill id = decodeKey<PrimarySkill>(pair.second.getModScope(), pair.first, variables);
-				ret[id.getNum()] += loadValue(pair.second, variables);
-			}
+			PrimarySkill id = jsonKeyExtractor.decodeKey<PrimarySkill>(pair.second.getModScope(), pair.first, variables);
+			ret[id.getNum()] += loadValue(pair.second, variables);
 		}
-		if(value.isVector())
-		{
-			for(const auto & element : value.Vector())
-			{
-				std::set<PrimarySkill> potentialPicks = filterKeys(element, defaultSkills, variables);
-				PrimarySkill skillID = *RandomGeneratorUtil::nextItem(potentialPicks, rng);
-
-				defaultSkills.erase(skillID);
-				ret[skillID.getNum()] += loadValue(element, variables);
-			}
-		}
-		return ret;
 	}
+	if(value.isVector())
+	{
+		for(const auto & element : value.Vector())
+		{
+			std::set<PrimarySkill> potentialPicks = jsonKeyExtractor.filterKeys(element, defaultSkills, variables);
+			PrimarySkill skillID = *RandomGeneratorUtil::nextItem(potentialPicks, rng);
 
-	SecondarySkill JsonRandom::loadSecondary(const JsonNode & value, const Variables & variables)
+			defaultSkills.erase(skillID);
+			ret[skillID.getNum()] += loadValue(element, variables);
+		}
+	}
+	return ret;
+}
+
+SecondarySkill JsonRandom::loadSecondary(const JsonNode & value, const Variables & variables)
+{
+	std::set<SecondarySkill> defaultSkills;
+	for(const auto & skill : LIBRARY->skillh->objects)
+		if(cb->isAllowed(skill->getId()) && !skill->special)
+			defaultSkills.insert(skill->getId());
+
+	std::set<SecondarySkill> potentialPicks = jsonKeyExtractor.filterKeys(value, defaultSkills, variables);
+	return *RandomGeneratorUtil::nextItem(potentialPicks, rng);
+}
+
+std::map<SecondarySkill, si32> JsonRandom::loadSecondaries(const JsonNode & value, const Variables & variables)
+{
+	std::map<SecondarySkill, si32> ret;
+	if(value.isStruct())
+	{
+		for(const auto & pair : value.Struct())
+		{
+			SecondarySkill id = jsonKeyExtractor.decodeKey<SecondarySkill>(pair.second.getModScope(), pair.first, variables);
+			ret[id] = loadValue(pair.second, variables);
+		}
+	}
+	if(value.isVector())
 	{
 		std::set<SecondarySkill> defaultSkills;
 		for(const auto & skill : LIBRARY->skillh->objects)
-			if (cb->isAllowed(skill->getId()) && !skill->special)
+			if(cb->isAllowed(skill->getId()) && !skill->special)
 				defaultSkills.insert(skill->getId());
 
-		std::set<SecondarySkill> potentialPicks = filterKeys(value, defaultSkills, variables);
-		return *RandomGeneratorUtil::nextItem(potentialPicks, rng);
-	}
-
-	std::map<SecondarySkill, si32> JsonRandom::loadSecondaries(const JsonNode & value, const Variables & variables)
-	{
-		std::map<SecondarySkill, si32> ret;
-		if(value.isStruct())
+		for(const auto & element : value.Vector())
 		{
-			for(const auto & pair : value.Struct())
-			{
-				SecondarySkill id = decodeKey<SecondarySkill>(pair.second.getModScope(), pair.first, variables);
-				ret[id] = loadValue(pair.second, variables);
-			}
+			std::set<SecondarySkill> potentialPicks = jsonKeyExtractor.filterKeys(element, defaultSkills, variables);
+			SecondarySkill skillID = *RandomGeneratorUtil::nextItem(potentialPicks, rng);
+
+			defaultSkills.erase(skillID); //avoid dupicates
+			ret[skillID] = loadValue(element, variables);
 		}
-		if(value.isVector())
+	}
+	return ret;
+}
+
+ArtifactID JsonRandom::loadArtifact(const JsonNode & value, const Variables & variables)
+{
+	std::set<ArtifactID> allowedArts;
+	for(const auto & artifact : LIBRARY->arth->objects)
+		if(cb->isAllowed(artifact->getId()) && LIBRARY->arth->legalArtifact(artifact->getId()))
+			allowedArts.insert(artifact->getId());
+
+	std::set<ArtifactID> potentialPicks = jsonKeyExtractor.filterKeys(value, allowedArts, variables);
+
+	return gameRandomizer.rollArtifact(potentialPicks);
+}
+
+std::vector<ArtifactID> JsonRandom::loadArtifacts(const JsonNode & value, const Variables & variables)
+{
+	std::vector<ArtifactID> ret;
+	for(const JsonNode & entry : value.Vector())
+	{
+		ret.push_back(loadArtifact(entry, variables));
+	}
+	return ret;
+}
+
+std::vector<ArtifactPosition> JsonRandom::loadArtifactSlots(const JsonNode & value, const Variables & variables)
+{
+	std::set<ArtifactPosition> allowedSlots;
+	for(ArtifactPosition pos(0); pos < ArtifactPosition::BACKPACK_START; ++pos)
+		allowedSlots.insert(pos);
+
+	std::vector<ArtifactPosition> ret;
+	for(const JsonNode & entry : value.Vector())
+	{
+		std::set<ArtifactPosition> potentialPicks = jsonKeyExtractor.filterKeys(entry, allowedSlots, variables);
+		ret.push_back(*RandomGeneratorUtil::nextItem(potentialPicks, rng));
+	}
+	return ret;
+}
+
+SpellID JsonRandom::loadSpell(const JsonNode & value, const Variables & variables)
+{
+	std::set<SpellID> defaultSpells;
+	for(const auto & spell : LIBRARY->spellh->objects)
+		if(cb->isAllowed(spell->getId()) && !spell->isSpecial())
+			defaultSpells.insert(spell->getId());
+
+	std::set<SpellID> potentialPicks = jsonKeyExtractor.filterKeys(value, defaultSpells, variables);
+
+	if(potentialPicks.empty())
+	{
+		logMod->warn("Failed to select suitable random spell!");
+		return SpellID::NONE;
+	}
+	return *RandomGeneratorUtil::nextItem(potentialPicks, rng);
+}
+
+std::vector<SpellID> JsonRandom::loadSpells(const JsonNode & value, const Variables & variables)
+{
+	std::vector<SpellID> ret;
+	for(const JsonNode & entry : value.Vector())
+	{
+		ret.push_back(loadSpell(entry, variables));
+	}
+	return ret;
+}
+
+std::vector<PlayerColor> JsonRandom::loadColors(const JsonNode & value, const Variables & variables)
+{
+	std::vector<PlayerColor> ret;
+	std::set<PlayerColor> defaultPlayers;
+	for(size_t i = 0; i < PlayerColor::PLAYER_LIMIT_I; ++i)
+		defaultPlayers.insert(PlayerColor(i));
+
+	for(auto & entry : value.Vector())
+	{
+		std::set<PlayerColor> potentialPicks = jsonKeyExtractor.filterKeys(entry, defaultPlayers, variables);
+		ret.push_back(*RandomGeneratorUtil::nextItem(potentialPicks, rng));
+	}
+
+	return ret;
+}
+
+std::vector<HeroTypeID> JsonRandom::loadHeroes(const JsonNode & value)
+{
+	std::vector<HeroTypeID> ret;
+	for(auto & entry : value.Vector())
+	{
+		ret.push_back(LIBRARY->heroTypes()->getByIndex(LIBRARY->identifiers()->getIdentifier("hero", entry).value())->getId());
+	}
+	return ret;
+}
+
+std::vector<HeroClassID> JsonRandom::loadHeroClasses(const JsonNode & value)
+{
+	std::vector<HeroClassID> ret;
+	for(auto & entry : value.Vector())
+	{
+		ret.push_back(LIBRARY->heroClasses()->getByIndex(LIBRARY->identifiers()->getIdentifier("heroClass", entry).value())->getId());
+	}
+	return ret;
+}
+
+CreatureID JsonRandom::loadCreatureType(const JsonNode & value, const Variables & variables)
+{
+	std::set<CreatureID> defaultCreatures;
+	for(const auto & creature : LIBRARY->creh->objects)
+		if(!creature->special)
+			defaultCreatures.insert(creature->getId());
+
+	std::set<CreatureID> potentialPicks = jsonKeyExtractor.filterKeys(value, defaultCreatures, variables);
+	CreatureID pickedCreature;
+
+	if(!potentialPicks.empty())
+		pickedCreature = *RandomGeneratorUtil::nextItem(potentialPicks, rng);
+	else
+		throw JsonRandomizationException("No potential creatures to pick!", value);
+
+	if(!pickedCreature.hasValue())
+		throw JsonRandomizationException("Invalid creature picked!", value);
+
+	return pickedCreature;
+}
+
+CStackBasicDescriptor JsonRandom::loadCreature(const JsonNode & value, const Variables & variables)
+{
+	CStackBasicDescriptor stack;
+
+	CreatureID pickedCreature = loadCreatureType(value, variables);
+	stack.setType(pickedCreature.toCreature());
+	stack.setCount(loadValue(value, variables));
+	if(!value["upgradeChance"].isNull() && !stack.getCreature()->upgrades.empty())
+	{
+		if(int(value["upgradeChance"].Float()) > rng.nextInt(99)) // select random upgrade
 		{
-			std::set<SecondarySkill> defaultSkills;
-			for(const auto & skill : LIBRARY->skillh->objects)
-				if (cb->isAllowed(skill->getId()) && !skill->special)
-					defaultSkills.insert(skill->getId());
-
-			for(const auto & element : value.Vector())
-			{
-				std::set<SecondarySkill> potentialPicks = filterKeys(element, defaultSkills, variables);
-				SecondarySkill skillID = *RandomGeneratorUtil::nextItem(potentialPicks, rng);
-
-				defaultSkills.erase(skillID); //avoid dupicates
-				ret[skillID] = loadValue(element, variables);
-			}
+			stack.setType(RandomGeneratorUtil::nextItem(stack.getCreature()->upgrades, rng)->toCreature());
 		}
-		return ret;
 	}
+	return stack;
+}
 
-	ArtifactID JsonRandom::loadArtifact(const JsonNode & value, const Variables & variables)
+std::vector<CStackBasicDescriptor> JsonRandom::loadCreatures(const JsonNode & value, const Variables & variables)
+{
+	std::vector<CStackBasicDescriptor> ret;
+	for(const JsonNode & node : value.Vector())
 	{
-		std::set<ArtifactID> allowedArts;
-		for(const auto & artifact : LIBRARY->arth->objects)
-			if (cb->isAllowed(artifact->getId()) && LIBRARY->arth->legalArtifact(artifact->getId()))
-				allowedArts.insert(artifact->getId());
-
-		std::set<ArtifactID> potentialPicks = filterKeys(value, allowedArts, variables);
-
-		return gameRandomizer.rollArtifact(potentialPicks);
+		ret.push_back(loadCreature(node, variables));
 	}
+	return ret;
+}
 
-	std::vector<ArtifactID> JsonRandom::loadArtifacts(const JsonNode & value, const Variables & variables)
+std::vector<JsonRandom::RandomStackInfo> JsonRandom::evaluateCreatures(const JsonNode & value, const Variables & variables)
+{
+	std::vector<RandomStackInfo> ret;
+	for(const JsonNode & node : value.Vector())
 	{
-		std::vector<ArtifactID> ret;
-		for (const JsonNode & entry : value.Vector())
-		{
-			ret.push_back(loadArtifact(entry, variables));
-		}
-		return ret;
-	}
+		RandomStackInfo info;
 
-	std::vector<ArtifactPosition> JsonRandom::loadArtifactSlots(const JsonNode & value, const Variables & variables)
-	{
-		std::set<ArtifactPosition> allowedSlots;
-		for(ArtifactPosition pos(0); pos < ArtifactPosition::BACKPACK_START; ++pos)
-			allowedSlots.insert(pos);
-
-		std::vector<ArtifactPosition> ret;
-		for (const JsonNode & entry : value.Vector())
-		{
-			std::set<ArtifactPosition> potentialPicks = filterKeys(entry, allowedSlots, variables);
-			ret.push_back(*RandomGeneratorUtil::nextItem(potentialPicks, rng));
-		}
-		return ret;
-	}
-
-	SpellID JsonRandom::loadSpell(const JsonNode & value, const Variables & variables)
-	{
-		std::set<SpellID> defaultSpells;
-		for(const auto & spell : LIBRARY->spellh->objects)
-			if (cb->isAllowed(spell->getId()) && !spell->isSpecial())
-				defaultSpells.insert(spell->getId());
-
-		std::set<SpellID> potentialPicks = filterKeys(value, defaultSpells, variables);
-
-		if (potentialPicks.empty())
-		{
-			logMod->warn("Failed to select suitable random spell!");
-			return SpellID::NONE;
-		}
-		return *RandomGeneratorUtil::nextItem(potentialPicks, rng);
-	}
-
-	std::vector<SpellID> JsonRandom::loadSpells(const JsonNode & value, const Variables & variables)
-	{
-		std::vector<SpellID> ret;
-		for (const JsonNode & entry : value.Vector())
-		{
-			ret.push_back(loadSpell(entry, variables));
-		}
-		return ret;
-	}
-
-	std::vector<PlayerColor> JsonRandom::loadColors(const JsonNode & value, const Variables & variables)
-	{
-		std::vector<PlayerColor> ret;
-		std::set<PlayerColor> defaultPlayers;
-		for(size_t i = 0; i < PlayerColor::PLAYER_LIMIT_I; ++i)
-			defaultPlayers.insert(PlayerColor(i));
-
-		for(auto & entry : value.Vector())
-		{
-			std::set<PlayerColor> potentialPicks = filterKeys(entry, defaultPlayers, variables);
-			ret.push_back(*RandomGeneratorUtil::nextItem(potentialPicks, rng));
-		}
-
-		return ret;
-	}
-
-	std::vector<HeroTypeID> JsonRandom::loadHeroes(const JsonNode & value)
-	{
-		std::vector<HeroTypeID> ret;
-		for(auto & entry : value.Vector())
-		{
-			ret.push_back(LIBRARY->heroTypes()->getByIndex(LIBRARY->identifiers()->getIdentifier("hero", entry).value())->getId());
-		}
-		return ret;
-	}
-
-	std::vector<HeroClassID> JsonRandom::loadHeroClasses(const JsonNode & value)
-	{
-		std::vector<HeroClassID> ret;
-		for(auto & entry : value.Vector())
-		{
-			ret.push_back(LIBRARY->heroClasses()->getByIndex(LIBRARY->identifiers()->getIdentifier("heroClass", entry).value())->getId());
-		}
-		return ret;
-	}
-
-	CreatureID JsonRandom::loadCreatureType(const JsonNode & value, const Variables & variables)
-	{
-		std::set<CreatureID> defaultCreatures;
-		for(const auto & creature : LIBRARY->creh->objects)
-			if (!creature->special)
-				defaultCreatures.insert(creature->getId());
-
-		std::set<CreatureID> potentialPicks = filterKeys(value, defaultCreatures, variables);
-		CreatureID pickedCreature;
-
-		if (!potentialPicks.empty())
-			pickedCreature = *RandomGeneratorUtil::nextItem(potentialPicks, rng);
+		if(!node["amount"].isNull())
+			info.minAmount = info.maxAmount = static_cast<si32>(node["amount"].Float());
 		else
-			throw JsonRandomizationException("No potential creatures to pick!", value);
-
-		if (!pickedCreature.hasValue())
-			throw JsonRandomizationException("Invalid creature picked!", value);
-
-		return pickedCreature;
-	}
-
-	CStackBasicDescriptor JsonRandom::loadCreature(const JsonNode & value, const Variables & variables)
-	{
-		CStackBasicDescriptor stack;
-
-		CreatureID pickedCreature = loadCreatureType(value, variables);
-		stack.setType(pickedCreature.toCreature());
-		stack.setCount(loadValue(value, variables));
-		if (!value["upgradeChance"].isNull() && !stack.getCreature()->upgrades.empty())
 		{
-			if (int(value["upgradeChance"].Float()) > rng.nextInt(99)) // select random upgrade
-			{
-				stack.setType(RandomGeneratorUtil::nextItem(stack.getCreature()->upgrades, rng)->toCreature());
-			}
+			info.minAmount = static_cast<si32>(node["min"].Float());
+			info.maxAmount = static_cast<si32>(node["max"].Float());
 		}
-		return stack;
-	}
-
-	std::vector<CStackBasicDescriptor> JsonRandom::loadCreatures(const JsonNode & value, const Variables & variables)
-	{
-		std::vector<CStackBasicDescriptor> ret;
-		for (const JsonNode & node : value.Vector())
+		CreatureID creatureID(LIBRARY->identifiers()->getIdentifier("creature", node["type"]).value());
+		const CCreature * crea = creatureID.toCreature();
+		info.allowedCreatures.push_back(crea);
+		if(node["upgradeChance"].Float() > 0)
 		{
-			ret.push_back(loadCreature(node, variables));
+			for(const auto & creaID : crea->upgrades)
+				info.allowedCreatures.push_back(creaID.toCreature());
 		}
-		return ret;
+		ret.push_back(info);
 	}
+	return ret;
+}
 
-	std::vector<JsonRandom::RandomStackInfo> JsonRandom::evaluateCreatures(const JsonNode & value, const Variables & variables)
+std::vector<std::shared_ptr<Bonus>> JsonRandom::loadBonuses(const JsonNode & value)
+{
+	std::vector<std::shared_ptr<Bonus>> ret;
+	for(const JsonNode & entry : value.Vector())
 	{
-		std::vector<RandomStackInfo> ret;
-		for (const JsonNode & node : value.Vector())
-		{
-			RandomStackInfo info;
-
-			if (!node["amount"].isNull())
-				info.minAmount = info.maxAmount = static_cast<si32>(node["amount"].Float());
-			else
-			{
-				info.minAmount = static_cast<si32>(node["min"].Float());
-				info.maxAmount = static_cast<si32>(node["max"].Float());
-			}
-			CreatureID creatureID(LIBRARY->identifiers()->getIdentifier("creature", node["type"]).value());
-			const CCreature * crea = creatureID.toCreature();
-			info.allowedCreatures.push_back(crea);
-			if (node["upgradeChance"].Float() > 0)
-			{
-				for(const auto & creaID : crea->upgrades)
-					info.allowedCreatures.push_back(creaID.toCreature());
-			}
-			ret.push_back(info);
-		}
-		return ret;
+		if(auto bonus = JsonUtils::parseBonus(entry))
+			ret.push_back(bonus);
 	}
-
-	std::vector<std::shared_ptr<Bonus>> JsonRandom::loadBonuses(const JsonNode & value)
-	{
-		std::vector<std::shared_ptr<Bonus>> ret;
-		for (const JsonNode & entry : value.Vector())
-		{
-			if(auto bonus = JsonUtils::parseBonus(entry))
-				ret.push_back(bonus);
-		}
-		return ret;
-	}
+	return ret;
+}
 
 VCMI_LIB_NAMESPACE_END

--- a/lib/json/JsonRandom.h
+++ b/lib/json/JsonRandom.h
@@ -9,9 +9,10 @@
  */
 #pragma once
 
-#include "callback/GameCallbackHolder.h"
 #include "GameConstants.h"
+#include "JsonKeyExtractor.h"
 #include "ResourceSet.h"
+#include "callback/GameCallbackHolder.h"
 
 VCMI_LIB_NAMESPACE_BEGIN
 
@@ -38,24 +39,10 @@ public:
 class JsonRandom : public GameCallbackHolder
 {
 	IGameRandomizer & gameRandomizer;
+	JsonKeyExtractor jsonKeyExtractor;
 	vstd::RNG & rng;
 public:
 	using Variables = std::map<std::string, int>;
-
-private:
-	template<typename IdentifierType>
-	std::set<IdentifierType> filterKeys(const JsonNode & value, const std::set<IdentifierType> & valuesSet, const Variables & variables);
-
-	template<typename IdentifierType>
-	std::set<IdentifierType> filterKeysTyped(const JsonNode & value, const std::set<IdentifierType> & valuesSet);
-
-	template<typename IdentifierType>
-	IdentifierType decodeKey(const std::string & modScope, const std::string & value, const Variables & variables);
-
-	template<typename IdentifierType>
-	IdentifierType decodeKey(const JsonNode & value, const Variables & variables);
-
-	si32 loadVariable(const std::string & variableGroup, const std::string & value, const Variables & variables, si32 defaultValue);
 
 public:
 	JsonRandom(IGameInfoCallback *cb, IGameRandomizer & gameRandomizer);

--- a/lib/mapObjectConstructors/AObjectTypeHandler.cpp
+++ b/lib/mapObjectConstructors/AObjectTypeHandler.cpp
@@ -282,7 +282,7 @@ void AObjectTypeHandler::afterLoadFinalization()
 {
 }
 
-std::unique_ptr<IObjectInfo> AObjectTypeHandler::getObjectInfo(std::shared_ptr<const ObjectTemplate> tmpl) const
+std::unique_ptr<IObjectInfo> AObjectTypeHandler::getObjectInfo() const
 {
 	return nullptr;
 }

--- a/lib/mapObjectConstructors/AObjectTypeHandler.h
+++ b/lib/mapObjectConstructors/AObjectTypeHandler.h
@@ -126,7 +126,7 @@ public:
 	virtual void configureObject(CGObjectInstance * object, IGameRandomizer & gameRandomizer) const = 0;
 
 	/// Returns object configuration, if available. Otherwise returns NULL
-	virtual std::unique_ptr<IObjectInfo> getObjectInfo(std::shared_ptr<const ObjectTemplate> tmpl) const;
+	virtual std::unique_ptr<IObjectInfo> getObjectInfo() const;
 };
 
 VCMI_LIB_NAMESPACE_END

--- a/lib/mapObjectConstructors/CRewardableConstructor.cpp
+++ b/lib/mapObjectConstructors/CRewardableConstructor.cpp
@@ -97,7 +97,7 @@ void CRewardableConstructor::configureObject(CGObjectInstance * object, IGameRan
 	}
 }
 
-std::unique_ptr<IObjectInfo> CRewardableConstructor::getObjectInfo(std::shared_ptr<const ObjectTemplate> tmpl) const
+std::unique_ptr<IObjectInfo> CRewardableConstructor::getObjectInfo() const
 {
 	return std::unique_ptr<IObjectInfo>(new Rewardable::Info(objectInfo));
 }

--- a/lib/mapObjectConstructors/CRewardableConstructor.h
+++ b/lib/mapObjectConstructors/CRewardableConstructor.h
@@ -32,7 +32,7 @@ public:
 
 	void configureObject(CGObjectInstance * object, IGameRandomizer & gameRandomizer) const override;
 
-	std::unique_ptr<IObjectInfo> getObjectInfo(std::shared_ptr<const ObjectTemplate> tmpl) const override;
+	std::unique_ptr<IObjectInfo> getObjectInfo() const override;
 
 	Rewardable::Configuration generateConfiguration(IGameInfoCallback * cb, IGameRandomizer & gameRandomizer, MapObjectID objectID, const std::map<std::string, JsonNode> & presetVariables) const;
 };

--- a/lib/rewardable/Configuration.cpp
+++ b/lib/rewardable/Configuration.cpp
@@ -106,6 +106,7 @@ void Rewardable::Configuration::serializeJson(JsonSerializeFormat & handler)
 	handler.serializeBool("forceCombat", forceCombat);
 	handler.serializeBool("coastVisitable", coastVisitable);
 	handler.serializeInt("infoWindowType", infoWindowType);
+	variables.serializeJson(handler);
 }
 
 VCMI_LIB_NAMESPACE_END

--- a/lib/rmg/modificators/TreasurePlacer.cpp
+++ b/lib/rmg/modificators/TreasurePlacer.cpp
@@ -1252,8 +1252,7 @@ ObjectConfig::EObjectCategory TreasurePlacer::ObjectPool::getObjectCategory(Comp
 			return ObjectConfig::EObjectCategory::NONE;
 		}
 
-		auto temp = handler->getTemplates().front();
-		auto info = handler->getObjectInfo(temp);
+		auto info = handler->getObjectInfo();
 
 		if (info->hasGuards())
 		{

--- a/mapeditor/CMakeLists.txt
+++ b/mapeditor/CMakeLists.txt
@@ -42,6 +42,7 @@ set(editor_SRCS
 		inspector/herospellwidget.cpp
 		inspector/PickObjectDelegate.cpp
 		inspector/portraitwidget.cpp
+		inspector/abilitieswidget.cpp
 		resourceExtractor/ResourceConverter.cpp
 		helper.cpp
 		campaigneditor/campaigneditor.cpp
@@ -112,6 +113,7 @@ set(editor_HEADERS
 		inspector/PickObjectDelegate.h
 		inspector/portraitwidget.h
 		inspector/baseinspectoritemdelegate.h
+		inspector/abilitieswidget.h
 		resourceExtractor/ResourceConverter.h
 		mapeditorroles.h
 		helper.h
@@ -167,8 +169,8 @@ set(editor_FORMS
 		inspector/heroartifactswidget.ui
 		inspector/artifactwidget.ui
 		inspector/heroskillswidget.ui
-		inspector/herospellwidget.ui
 		inspector/portraitwidget.ui
+		inspector/abilitieswidget.ui
 		campaigneditor/campaigneditor.ui
 		campaigneditor/campaignproperties.ui
 		campaigneditor/scenarioproperties.ui

--- a/mapeditor/inspector/abilitieswidget.cpp
+++ b/mapeditor/inspector/abilitieswidget.cpp
@@ -1,0 +1,221 @@
+/*
+ * abilitieswidget.cpp, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
+#include "StdInc.h"
+#include "abilitieswidget.h"
+#include "inspector.h"
+#include "ui_abilitieswidget.h"
+#include "../mapcontroller.h"
+
+#include "../../lib/GameLibrary.h"
+#include "../../lib/CSkillHandler.h"
+#include "../../lib/mapping/CMap.h"
+#include "../../lib/constants/StringConstants.h"
+#include "../../lib/modding/ModScope.h"
+#include "../../lib/modding/IdentifierStorage.h"
+#include "../../lib/rewardable/Info.h"
+#include "../../lib/mapObjectConstructors/AObjectTypeHandler.h"
+#include "../../lib/mapObjectConstructors/CObjectClassesHandler.h"
+#include "../../lib/mapObjectConstructors/IObjectInfo.h"
+
+const std::string AbilitiesWidget::V_CATEGORY="secondarySkill";
+const std::string AbilitiesWidget::V_NAME="gainedSkill";
+
+AbilitiesWidget::AbilitiesWidget(CRewardableObject & hut, MapController & controller, QWidget * parent)
+	: hut(hut), controller(controller), QDialog(parent), extractor(controller.getCallback()), ui(new Ui::AbilitiesWidget)
+{
+	ui->setupUi(this);
+}
+
+AbilitiesWidget::~AbilitiesWidget()
+{
+	delete ui;
+}
+
+void AbilitiesWidget::loadData()
+{
+	for(const auto & objectPtr : LIBRARY->skillh->objects)
+	{
+		auto * item = new QListWidgetItem(QString::fromStdString(objectPtr->getNameTranslated()));
+		int skillId = objectPtr->getIndex();
+		item->setData(Qt::UserRole, QVariant::fromValue(skillId));
+		ui->skills->addItem(item);
+	}
+	ui->customize->setChecked(!getPresetAbilities().empty());
+	prepareDisplay();
+}
+
+void AbilitiesWidget::prepareDisplay()
+{
+	bool customized = !isSetToDefault();
+	ui->defaultSkillsWarning->setHidden(customized);
+	ui->selectAll->setDisabled(!customized);
+	ui->deselectAll->setDisabled(!customized);
+
+	if(customized)
+	{
+		std::set<SecondarySkill> presetAbilities = getPresetAbilities();
+		if(presetAbilities.empty())
+			presetAbilities = getDefaultAbilities();
+		for(int i = 0; i < ui->skills->count(); ++i)
+		{
+			auto * item = ui->skills->item(i);
+			int skillId = item->data(Qt::UserRole).toInt();
+			bool isAllowed = controller.getMapUniquePtr()->allowedAbilities.contains(skillId);
+				item->setFlags(isAllowed ? Qt::ItemIsEnabled | Qt::ItemIsUserCheckable : Qt::NoItemFlags);
+				item->setCheckState(isAllowed && presetAbilities.contains(skillId) ? Qt::Checked : Qt::Unchecked);
+		}
+	}
+	else
+	{
+		std::set<SecondarySkill> defaultAbilities = getDefaultAbilities();
+		for(int i = 0; i < ui->skills->count(); ++i)
+		{
+			auto * item = ui->skills->item(i);
+			int skillId = item->data(Qt::UserRole).toInt();
+			item->setFlags(Qt::NoItemFlags);
+			item->setCheckState(defaultAbilities.contains(skillId) ? Qt::Checked : Qt::Unchecked);
+		}
+	}
+}
+
+void AbilitiesWidget::commitChanges()
+{
+	if(isSetToDefault())
+	{
+		hut.configuration.variables.preset.clear();
+		return;
+	}
+
+	std::set<SecondarySkill> presetAbilities;
+	for(int i = 0; i < ui->skills->count(); ++i)
+	{
+		auto * item = ui->skills->item(i);
+		if(item->checkState() == Qt::Checked)
+		{
+			int skillId = item->data(Qt::UserRole).toInt();
+			presetAbilities.insert(SecondarySkill(skillId));
+		}
+	}
+
+	JsonNode paNode;
+	JsonVector anyOfList;
+	for(const auto & skill : presetAbilities)
+	{
+		JsonNode entry;
+		entry.String() = LIBRARY->skills()->getById(skill)->getJsonKey();
+		anyOfList.push_back(entry);
+	}
+	paNode["anyOf"].Vector() = anyOfList;
+
+	paNode.setModScope(ModScope::scopeGame()); // list may include skills from all mods
+	hut.configuration.presetVariable(V_CATEGORY, V_NAME, paNode);
+}
+
+std::set<SecondarySkill> AbilitiesWidget::getPresetAbilities()
+{
+	std::set<SecondarySkill> presetAbilities;
+	JsonNode preset = hut.configuration.getPresetVariable(V_CATEGORY, V_NAME);
+	if(!preset.isNull())
+		presetAbilities = extractor.filterKeys(preset, LIBRARY->skillh->getDefaultAllowed());
+	return presetAbilities;
+}
+
+std::set<SecondarySkill> AbilitiesWidget::getDefaultAbilities()
+{
+	std::unique_ptr<IObjectInfo> objectInfo = LIBRARY->objtypeh->getHandlerFor(hut.ID, hut.subID)->getObjectInfo();
+	JsonNode defaultParameters = static_cast<Rewardable::Info *>(objectInfo.get())->getParameters()["variables"][V_CATEGORY][V_NAME];
+	if(defaultParameters.isNull())
+		return controller.getMapUniquePtr()->allowedAbilities;
+	else
+		return extractor.filterKeys(defaultParameters, controller.getMapUniquePtr()->allowedAbilities);
+}
+
+void AbilitiesWidget::on_selectAll_clicked()
+{
+	changeCheckStateForAll(true);
+}
+
+void AbilitiesWidget::on_deselectAll_clicked()
+{
+	changeCheckStateForAll(false);
+}
+
+void AbilitiesWidget::on_filter_textChanged(QString text)
+{
+	for(int i = 0; i < ui->skills->count(); ++i)
+	{
+		auto * item = ui->skills->item(i);
+		item->setHidden(!item->text().contains(text, Qt::CaseInsensitive));
+	}
+}
+
+void AbilitiesWidget::on_customize_toggled(bool checked)
+{
+	prepareDisplay();
+}
+
+void AbilitiesWidget::changeCheckStateForAll(bool checked)
+{
+	for(int i = 0; i < ui->skills->count(); ++i)
+	{
+		auto * item = ui->skills->item(i);
+		if(item->flags().testFlag(Qt::ItemIsUserCheckable))
+			item->setCheckState(checked ? Qt::Checked : Qt::Unchecked);
+	}
+}
+
+bool AbilitiesWidget::isSetToDefault()
+{
+	return !ui->customize->isChecked();
+}
+
+AbilitiesDelegate::AbilitiesDelegate(MapController & controller, CRewardableObject & hut) : BaseInspectorItemDelegate(), controller(controller), hut(hut) {}
+
+QWidget * AbilitiesDelegate::createEditor(QWidget * parent, const QStyleOptionViewItem & option, const QModelIndex & index) const
+{
+	return new AbilitiesWidget(hut, controller, parent);
+}
+
+void AbilitiesDelegate::setEditorData(QWidget * editor, const QModelIndex & index) const
+{
+	logGlobal->error("set editor data!");
+	if(auto * aw = qobject_cast<AbilitiesWidget *>(editor))
+	{
+		aw->loadData();
+	}
+	else
+	{
+		QStyledItemDelegate::setEditorData(editor, index);
+	}
+}
+
+void AbilitiesDelegate::setModelData(QWidget * editor, QAbstractItemModel * model, const QModelIndex & index) const
+{
+	if(auto * ed = qobject_cast<AbilitiesWidget *>(editor))
+	{
+		ed->commitChanges();
+		updateModelData(model, index);
+	}
+	else
+	{
+		QStyledItemDelegate::setModelData(editor, model, index);
+	}
+}
+
+void AbilitiesDelegate::updateModelData(QAbstractItemModel * model, const QModelIndex & index) const
+{
+	QStringList textList;
+	JsonNode preset = hut.configuration.getPresetVariable(AbilitiesWidget::V_CATEGORY, AbilitiesWidget::V_NAME);
+	if(preset.isNull())
+		textList += QObject::tr("Default");
+	else
+		textList += QObject::tr("Custom");
+	setModelTextData(model, index, textList);
+}

--- a/mapeditor/inspector/abilitieswidget.h
+++ b/mapeditor/inspector/abilitieswidget.h
@@ -1,0 +1,73 @@
+/*
+ * abilitieswidget.h, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
+#pragma once
+
+#include <QDialog>
+#include <json/JsonKeyExtractor.h>
+#include "baseinspectoritemdelegate.h"
+#include "../../lib/mapObjects/CGHeroInstance.h"
+#include <../lib/mapObjects/CRewardableObject.h>
+
+namespace Ui
+{
+class AbilitiesWidget;
+}
+
+class MapController;
+
+class AbilitiesWidget : public QDialog
+{
+	Q_OBJECT
+
+public:
+	explicit AbilitiesWidget(CRewardableObject &, MapController &, QWidget * parent = nullptr);
+	~AbilitiesWidget();
+	void loadData();
+	void commitChanges();
+
+	static const std::string V_CATEGORY;
+	static const std::string V_NAME;
+
+private slots:
+	void on_selectAll_clicked();
+	void on_deselectAll_clicked();
+	void on_filter_textChanged(QString text);
+	void on_customize_toggled(bool checked);
+
+private:
+	void prepareDisplay();
+	std::set<SecondarySkill> getPresetAbilities();
+	std::set<SecondarySkill> getDefaultAbilities();
+	void changeCheckStateForAll(bool);
+	bool isSetToDefault();
+
+	Ui::AbilitiesWidget * ui;
+	CRewardableObject & hut;
+	JsonKeyExtractor extractor;
+	MapController & controller;
+};
+
+class AbilitiesDelegate : public BaseInspectorItemDelegate
+{
+	Q_OBJECT
+public:
+	using BaseInspectorItemDelegate::BaseInspectorItemDelegate;
+
+	AbilitiesDelegate(MapController &, CRewardableObject &);
+
+	QWidget * createEditor(QWidget * parent, const QStyleOptionViewItem & option, const QModelIndex & index) const override;
+	void setEditorData(QWidget * editor, const QModelIndex & index) const override;
+	void setModelData(QWidget * editor, QAbstractItemModel * model, const QModelIndex & index) const override;
+	void updateModelData(QAbstractItemModel * model, const QModelIndex & index) const override;
+
+private:
+	CRewardableObject & hut;
+	MapController & controller;
+};

--- a/mapeditor/inspector/abilitieswidget.ui
+++ b/mapeditor/inspector/abilitieswidget.ui
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>AbilitiesWidget</class>
+ <widget class="QDialog" name="AbilitiesWidget">
+  <property name="windowModality">
+   <enum>Qt::WindowModality::NonModal</enum>
+  </property>
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>480</width>
+    <height>480</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>480</width>
+    <height>480</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string>Abilities</string>
+  </property>
+  <property name="layoutDirection">
+   <enum>Qt::LayoutDirection::LeftToRight</enum>
+  </property>
+  <property name="modal">
+   <bool>true</bool>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="spacing">
+    <number>10</number>
+   </property>
+   <property name="topMargin">
+    <number>5</number>
+   </property>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QLineEdit" name="filter"/>
+     </item>
+     <item>
+      <widget class="QPushButton" name="deselectAll">
+       <property name="text">
+        <string>Deselect All</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="selectAll">
+       <property name="text">
+        <string>Select All</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QCheckBox" name="customize">
+       <property name="text">
+        <string>Customize</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QListWidget" name="skills">
+     <property name="autoScrollMargin">
+      <number>16</number>
+     </property>
+     <property name="isWrapping" stdset="0">
+      <bool>true</bool>
+     </property>
+     <property name="resizeMode">
+      <enum>QListView::ResizeMode::Adjust</enum>
+     </property>
+     <property name="layoutMode">
+      <enum>QListView::LayoutMode::Batched</enum>
+     </property>
+     <property name="batchSize">
+      <number>30</number>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="defaultSkillsWarning">
+     <property name="lineWidth">
+      <number>1</number>
+     </property>
+     <property name="text">
+      <string>&lt;font color='red'&gt;Displayed skills assume default witch hut implementation. Mods can overwrite it.&lt;/font&gt;</string>
+     </property>
+     <property name="textFormat">
+      <enum>Qt::TextFormat::MarkdownText</enum>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+     <property name="textInteractionFlags">
+      <set>Qt::TextInteractionFlag::NoTextInteraction</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/mapeditor/inspector/inspector.cpp
+++ b/mapeditor/inspector/inspector.cpp
@@ -22,6 +22,7 @@
 #include "../../lib/CPlayerState.h"
 #include "../../lib/texts/CGeneralTextHandler.h"
 
+#include "abilitieswidget.h"
 #include "townbuildingswidget.h"
 #include "towneventswidget.h"
 #include "townspellswidget.h"
@@ -448,10 +449,19 @@ void Inspector::updateProperties(CGCreature * o)
 
 void Inspector::updateProperties(CRewardableObject * o)
 {
-	if(!o) return;
+	if(!o)
+		return;
 
-	auto * delegate = new RewardsDelegate(*controller.map(), *o);
-	addProperty(QObject::tr("Reward"), PropertyEditorPlaceholder(), delegate, false);
+	if(o->ID == MapObjectID::WITCH_HUT)
+	{
+		auto * delegate = new AbilitiesDelegate(controller, *o);
+		addProperty(QObject::tr("Abilities"), PropertyEditorPlaceholder(), delegate, false);
+	}
+	else
+	{
+		auto * delegate = new RewardsDelegate(*controller.map(), *o);
+		addProperty(QObject::tr("Reward"), PropertyEditorPlaceholder(), delegate, false);
+	}
 }
 
 void Inspector::updateProperties(CGPandoraBox * o)

--- a/mapeditor/validator.cpp
+++ b/mapeditor/validator.cpp
@@ -19,6 +19,8 @@
 #include "../lib/modding/ModDescription.h"
 #include "../lib/spells/CSpellHandler.h"
 
+#include "../lib/json/JsonKeyExtractor.h"
+
 Validator::Validator(const CMap * map, QWidget *parent) :
 	QDialog(parent),
 	ui(new Ui::Validator)
@@ -40,6 +42,7 @@ Validator::~Validator()
 std::set<Validator::Issue> Validator::validate(const CMap * map)
 {
 	std::set<Validator::Issue> issues;
+	JsonKeyExtractor keyExtractor(map->cb);
 	
 	if(!map)
 	{
@@ -144,6 +147,20 @@ std::set<Validator::Issue> Validator::validate(const CMap * map)
 					if(ins->ID == Obj::ARTIFACT && map->allowedArtifact.count(ins->getArtifactType()) == 0)
 					{
 						issues.insert({ tr("Artifact %1 is prohibited by map settings").arg(ins->getObjectName().c_str()), false });
+					}
+				}
+			}
+			if(o->ID == MapObjectID::WITCH_HUT)
+			{
+				CRewardableObject * hut = static_cast<CRewardableObject *>(o.get());
+				JsonNode preset = hut->configuration.getPresetVariable("secondarySkill", "gainedSkill");
+				if(!preset.isNull())
+				{
+					auto presetAbilities = keyExtractor.filterKeys(preset, map->allowedAbilities);
+					if(presetAbilities.empty())
+					{
+						issues.insert({tr("A customized witch hut at x: %1 y: %2 on %3 layer does not hold a valid secondary skill")
+                            .arg(hut->pos.x).arg(hut->pos.y).arg(hut->pos.z), true});
 					}
 				}
 			}


### PR DESCRIPTION
Adds custom ability set widget for witch hut.

https://github.com/user-attachments/assets/68ab8d63-592d-41c0-8f67-ee7d9b1a37dd

Since it is the first case of mapeditor changing presets I needed to add json serialization for presets (thought it was enough to call already existing method in Configuration). I also needed to extract private methods from JsonRandom that dealt with filtering identifiers to a separate class and expose them. The logic did not change: JsonKeyExtractor is 1 to 1 the code that before was private in JsonRandom. I opted for an explicit template instantion since it seems to me more tidy then putting method definition with all the necessary imports in the header file.

Limits and snugs:
Though a user cannot select abilities that are disallowed on the map, he can still break a map if he selects custom abilities and then disallows all of them in map settings. A check has been added to validator to account for this situation.

The default available abilities for witch hut (namely: all available for the map except necromancy and leadership) have been hardcoded. Unfortunately, mods can overwrite this behaviour (for example, hota excludes also runes). It would be much better to load configuration from json file of the object. Unfortunately, those are loaded into CRewardableConstructor and as far as I know not accessible without either making major changes or really ugly hackery.
The display of available abilities when set to "default" mode (only the display in the map editor, not the behaviour of hut in the client) and the starting point once "custom" mode is chosen may not be consistent with the object behaviour once modes are used. A warning about it has been added. 

PS: I did notice the ability widget in the video is titled "Spells". It is fixed.