### PR TITLE
simplifies hash_value method of int3

### DIFF
--- a/lib/int3.h
+++ b/lib/int3.h
@@ -177,18 +177,11 @@ public:
 			int3(1,1,0),int3(-1,1,0),int3(1,-1,0),int3(-1,-1,0) } };
 	}
 
-	// Solution by ChatGPT
-
-	// Assume values up to +- 1000
-    friend std::size_t hash_value(const int3& v) {
-        // Since the range is [-1000, 1000], offsetting by 1000 maps it to [0, 2000]
-        std::size_t hx = v.x + 1000;
-        std::size_t hy = v.y + 1000;
-        std::size_t hz = v.z + 1000;
-
-        // Combine the hash values, multiplying them by prime numbers
-        return ((hx * 4000037u) ^ (hy * 2003u)) + hz;
-    }
+	friend std::size_t hash_value(const int3 & v)
+	{
+		static const std::size_t max_value = 5000; //leaving space for map size increase
+		return (v.z * max_value * max_value) + (v.y * max_value) + v.x;
+	}
 };
 
 template<typename Container>


### PR DESCRIPTION
Meh, won't change much, but I noticed that and thought maybe it can be simplified. And then I thought why not make this a pr.
 Operations on prime numbers are usually used to "scatter" hashes of similar objects and avoid collisions. It is pointless with int3, because we know the possible ranges of three variables used and size_t on a 32 bit system is enough to have a separate hash for every viable int3 many times over. Operation on prime numbers only increase chance of collisions to occur.
Not that it matters much, since the chance is mathematically insignificant anyway (and then, even if it occurs, the performance hit is negligible), but if the code may be simpler and better, why not change it?
