### PR TITLE
[AI/NK] Fix AI avoiding removable pickups near guards

### DIFF
--- a/AI/Nullkiller2/Pathfinding/GraphPaths.cpp
+++ b/AI/Nullkiller2/Pathfinding/GraphPaths.cpp
@@ -203,8 +203,7 @@ void GraphPaths::addChainInfo(std::vector<AIPath> & paths, int3 tile, const CGHe
 
 		uint64_t danger = node.linkDanger;
 		float cost = node.cost;
-		bool allowBattle = false;
-
+		bool hasDangerousGraphTransition = false;
 		auto current = GraphPathNodePointer(nodes->first, node.nodeType);
 
 		while(true)
@@ -219,7 +218,7 @@ void GraphPaths::addChainInfo(std::vector<AIPath> & paths, int3 tile, const CGHe
 			if(!currentNode.previous.valid())
 				break;
 
-			allowBattle = allowBattle || currentNode.nodeType == GrapthPathNodeType::BATTLE;
+			hasDangerousGraphTransition = hasDangerousGraphTransition || currentNode.nodeType == GrapthPathNodeType::BATTLE;
 			vstd::amax(danger, currentNode.linkDanger);
 			vstd::amax(cost, currentNode.cost);
 
@@ -290,7 +289,10 @@ void GraphPaths::addChainInfo(std::vector<AIPath> & paths, int3 tile, const CGHe
 			}
 
 			path.armyLoss += loss;
-			path.targetObjectDanger = aiNk->dangerEvaluator->evaluateDanger(tile, path.targetHero, !allowBattle);
+			// TODO: Preserve endpoint visit semantics in graph paths so this can distinguish visit actions
+			// from true target-tile guard checks instead of relying on graph transition type.
+			const bool checkTargetTileGuards = !hasDangerousGraphTransition;
+			path.targetObjectDanger = aiNk->dangerEvaluator->evaluateDanger(tile, path.targetHero, checkTargetTileGuards);
 			// TODO: Mircea: This is similar same as 263, so what's happening here? Why strength is passed differently?
 			path.targetObjectArmyLoss = aiNk->pathfinder->getStorage()->evaluateArmyLoss(path.targetHero, path.heroArmy->getArmyStrength(), path.targetObjectDanger);
 
@@ -315,8 +317,7 @@ void GraphPaths::quickAddChainInfoWithBlocker(std::vector<AIPath> & paths, int3 
 
 		uint64_t danger = targetNode.linkDanger;
 		float cost = targetNode.cost;
-		bool allowBattle = false;
-
+		bool hasDangerousGraphTransition = false;
 		auto current = GraphPathNodePointer(nodes->first, targetNode.nodeType);
 
 		while(true)
@@ -328,7 +329,7 @@ void GraphPaths::quickAddChainInfoWithBlocker(std::vector<AIPath> & paths, int3 
 
 			auto currentNode = currentTile->second[current.nodeType];
 
-			allowBattle = allowBattle || currentNode.nodeType == GrapthPathNodeType::BATTLE;
+			hasDangerousGraphTransition = hasDangerousGraphTransition || currentNode.nodeType == GrapthPathNodeType::BATTLE;
 			vstd::amax(danger, currentNode.linkDanger);
 			vstd::amax(cost, currentNode.cost);
 
@@ -356,7 +357,10 @@ void GraphPaths::quickAddChainInfoWithBlocker(std::vector<AIPath> & paths, int3 
 			path.heroArmy = entryPath.heroArmy;
 			path.exchangeCount = entryPath.exchangeCount;
 			path.armyLoss = entryPath.armyLoss + aiNk->pathfinder->getStorage()->evaluateArmyLoss(path.targetHero, path.heroArmy->getArmyStrength(), danger);
-			path.targetObjectDanger = aiNk->dangerEvaluator->evaluateDanger(tile, path.targetHero, !allowBattle);
+			// TODO: Preserve endpoint visit semantics in graph paths so this can distinguish visit actions
+			// from true target-tile guard checks instead of relying on graph transition type.
+			const bool checkTargetTileGuards = !hasDangerousGraphTransition;
+			path.targetObjectDanger = aiNk->dangerEvaluator->evaluateDanger(tile, path.targetHero, checkTargetTileGuards);
 			path.targetObjectArmyLoss = aiNk->pathfinder->getStorage()->evaluateArmyLoss(path.targetHero, path.heroArmy->getArmyStrength(), path.targetObjectDanger);
 
 			AIPathNodeInfo n;


### PR DESCRIPTION
This PR fixes AI danger evaluation for removable map objects such as resources or artifacts. AI heroes (scouts) no longer treat nearby guarded tiles as part of the pickup danger itself.

Test case:
<img width="1633" height="960" alt="initial" src="https://github.com/user-attachments/assets/208a2788-adc1-47ef-a2ac-59bf6a57ad22" />

Current AI will only explore the surrounding area, not picking up available resources and artifact.

After changes, that AI's scouting hero picks everything that's free to pick, leaving only those, which would trigger battle.

<img width="1636" height="962" alt="2026-05-21_18-50" src="https://github.com/user-attachments/assets/fe204560-e6d2-4368-a28e-ff16af5a1387" />


Left a TODO in `GraphPaths.cpp`, which needs more work for a proper follow-up. The current Nullkiller2 config has openMap and object graphs disabled, so this should not have a noticeable impact on normal gameplay. I only renamed an ambiguous local variable in that file.