### PR TITLE
Fix bug where gate does not open

### DIFF
--- a/server/battles/BattleActionProcessor.cpp
+++ b/server/battles/BattleActionProcessor.cpp
@@ -886,17 +886,8 @@ BattleActionProcessor::MovementResult BattleActionProcessor::moveStack(const CBa
 				auto hex = unitPath[i];
 				if (!openGateAtHex.isValid() && dbState != EGateState::OPENED)
 				{
-					if (needOpenGates(hex))
+					if (needOpenGates(hex) || needOpenGates(currentUnit->occupiedHex(hex)))
 						openGateAtHex = unitPath[i+1];
-
-					//TODO we need find better way to handle double-wide stacks
-					//currently if only second occupied stack part is standing on gate / bridge hex then stack will start to wait for bridge to lower before it's needed. Though this is just a visual bug.
-					if (currentUnit->doubleWide() && i + 2 < unitPath.size())
-					{
-						BattleHex otherHex = currentUnit->occupiedHex(hex);
-						if (otherHex.isValid() && needOpenGates(otherHex))
-							openGateAtHex = unitPath[i+2];
-					}
 
 					//gate may be opened and then closed during stack movement, but not other way around
 					if (openGateAtHex.isValid())


### PR DESCRIPTION
Fixes https://github.com/vcmi/vcmi/issues/7354 

In addition to the actual fix, this PR removes some fancy logic for (I guess) UI animation which made no sense (it caused the gate to open 1 hex sooner). Here is a comparison of the UI animation difference before (first recording) and after (second recording) removing this logic.

https://github.com/user-attachments/assets/5bc93b5b-42be-4588-b9e5-2cd2787ee653

https://github.com/user-attachments/assets/a066208e-5dbe-496e-ba5a-a17b3e90817d

In both cases, the unit visually glitches (stops-and-resumes movement 3 times) -- but this is a separate issue and does not affect game mechanics.