### PR TITLE
Fix bug where flyers could not fly-and-attack into moat

### DIFF
--- a/lib/battle/CBattleInfoCallback.cpp
+++ b/lib/battle/CBattleInfoCallback.cpp
@@ -1286,7 +1286,7 @@ bool CBattleInfoCallback::handleObstacleTriggersForUnit(SpellCastEnvironment & s
 		if(!unit.alive())
 			return false;
 
-		if(obstacle->stopsMovement())
+		if(obstacle->stopsMovement() && !unit.hasBonusOfType(BonusType::FLYING))
 			movementStopped = true;
 	}
 


### PR DESCRIPTION
Fixes https://github.com/vcmi/vcmi/issues/7356 

**NOTE**: this PR fixes the engine bug only. The UI still does not allow to fly+attack into a moat.

This PR also partially fixes https://github.com/vcmi/vcmi/issues/7357 - flying into a quicksand no longer aborts the attack, but the quicksand still gets revealed.

