### PR TITLE
Battle: fix defender-hero hit-test using attackingHero->pos

### DIFF
--- a/client/battle/BattleFieldController.cpp
+++ b/client/battle/BattleFieldController.cpp
@@ -668,7 +668,7 @@ BattleHex BattleFieldController::getHexAtPosition(Point hoverPos)
 
 	if (owner.defendingHero)
 	{
-		if (owner.attackingHero->pos.isInside(hoverPos))
+		if (owner.defendingHero->pos.isInside(hoverPos))
 			return BattleHex::HERO_DEFENDER;
 	}
 


### PR DESCRIPTION
## What

`BattleFieldController::getHexAtPosition()` resolves the **defending** hero's region using the **attacking** hero's rectangle:

```cpp
if (owner.defendingHero)
{
    if (owner.attackingHero->pos.isInside(hoverPos))   // wrong hero
        return BattleHex::HERO_DEFENDER;
}
```

This is a copy/paste slip from the `attackingHero` block above. It is replaced with `owner.defendingHero->pos`.

## Why

- The defending hero's portrait region is gated on the attacker's rectangle, so it never hit-tests correctly as `HERO_DEFENDER`.
- When the attacker has no hero (e.g. a wandering-monster stack attacking a hero), `owner.attackingHero` is null and this line dereferences a null pointer.

`attackingHero` and `defendingHero` are distinct `std::shared_ptr<BattleHero>` members, each a `CIntObject` with its own `pos` rect, so the two are not interchangeable.

One-line change; no behavior relies on the old (incorrect) form.

Fixes #7364