### PR TITLE
[1.8] Battle obstacle positioning fixes

### DIFF
--- a/client/ClientCommandManager.cpp
+++ b/client/ClientCommandManager.cpp
@@ -17,7 +17,12 @@
 #include "CServerHandler.h"
 #include "GameEngine.h"
 #include "GameInstance.h"
+#include "battle/BattleFieldController.h"
+#include "battle/BattleInterface.h"
+#include "battle/BattleObstacleController.h"
+#include "battle/CObstacleInstance.h"
 #include "gui/WindowHandler.h"
+#include "render/CanvasImage.h"
 #include "render/IRenderHandler.h"
 #include "ClientNetPackVisitors.h"
 #include "../lib/callback/CCallback.h"
@@ -41,6 +46,7 @@
 #include "../lib/modding/ModUtility.h"
 #include "../lib/serializer/GameConnection.h"
 #include "../lib/VCMIDirs.h"
+#include "../lib/ObstacleHandler.h"
 #include "../lib/logging/VisualLogger.h"
 
 #ifdef SCRIPTING_ENABLED
@@ -452,6 +458,59 @@ void ClientCommandManager::handleExtractCommand(std::istringstream& singleWordBu
 		printCommandMessage("File not found!", ELogLevel::ERROR);
 }
 
+void ClientCommandManager::handleObstaclesDebugCommand()
+{
+	auto cellBorder = ENGINE->renderHandler().loadImage(ImagePath::builtin("CCELLGRD.BMP"), EImageBlitMode::COLORKEY);
+	auto cellShade = ENGINE->renderHandler().loadImage(ImagePath::builtin("CCELLSHD.BMP"), EImageBlitMode::SIMPLE);
+	auto & battleInt = GAME->interface()->battleInt;
+	if (!battleInt)
+		return;
+
+	auto & obstacleController = battleInt->obstacleController;
+
+	for (const auto & obstacle : LIBRARY->obstacleHandler->objects)
+	{
+		if (obstacle->isAbsoluteObstacle)
+		{
+			continue; // TODO?
+		}
+		else
+		{
+			BattleHex position(0, obstacle->height - 1);
+			BattleHex bottomRightHex(obstacle->width, obstacle->height);
+			CObstacleInstance testObstacle;
+			testObstacle.obstacleType = CObstacleInstance::USUAL;
+			testObstacle.pos = position;
+			testObstacle.ID = obstacle->getIndex();
+			obstacleController->loadObstacleImage(testObstacle);
+
+			Point bottomRightCorner = battleInt->fieldController->hexPositionLocal(bottomRightHex).bottomRight();
+			CanvasImage canvas(bottomRightCorner, CanvasScalingPolicy::IGNORE);
+			auto image = obstacleController->getObstacleImage(testObstacle);
+
+			if (!image)
+				continue;
+
+			canvas.getCanvas().drawColor(Rect(Point(), canvas.dimensions()), ColorRGBA(0,255,255,255));
+			canvas.getCanvas().draw(image, obstacleController->getObstaclePosition(image, testObstacle));
+			canvas.getCanvas().drawBorder(Rect(obstacleController->getObstaclePosition(image, testObstacle), image->dimensions()), ColorRGBA(255, 0, 0, 255));
+
+			for (int y = 0; y < obstacle->height; ++y)
+				for (int x = 0; x < obstacle->width; ++x)
+					canvas.getCanvas().draw(cellBorder, battleInt->fieldController->hexPositionLocal(BattleHex(x,y)).topLeft());
+
+			for (const auto & blockedHex : obstacle->getBlocked(position))
+				canvas.getCanvas().draw(cellShade, battleInt->fieldController->hexPositionLocal(blockedHex).topLeft());
+
+			std::string modID = obstacle->getModScope();
+			std::string obstacleID = obstacle->identifier;
+			auto fullPath = VCMIDirs::get().userExtractedPath() / "obstacles" / modID;
+			boost::filesystem::create_directories(fullPath);
+			canvas.exportBitmap(fullPath / (obstacleID + ".png"));
+		}
+	}
+}
+
 void ClientCommandManager::handleBonusesCommand(std::istringstream & singleWordBuffer)
 {
 	if(currentCallFromIngameConsole)
@@ -661,6 +720,9 @@ void ClientCommandManager::processCommand(const std::string & message, bool call
 
 	else if(commandName == "bonuses")
 		handleBonusesCommand(singleWordBuffer);
+
+	else if(message == "obstacles debug")
+		handleObstaclesDebugCommand();
 
 	else if(commandName == "tell")
 		handleTellCommand(singleWordBuffer);

--- a/client/ClientCommandManager.h
+++ b/client/ClientCommandManager.h
@@ -63,6 +63,9 @@ class ClientCommandManager //take mantis #2292 issue about account if thinking a
 	// Dumps all .txt files from DATA into Extracted/DATA
 	void handleGetTextCommand();
 
+	// Saves all battle obstacles with their hex layout into extracted/obstacles folder
+	void handleObstaclesDebugCommand();
+
 	// Extract .def animation as BMP files
 	void handleDef2bmpCommand(std::istringstream& singleWordBuffer);
 

--- a/client/battle/BattleObstacleController.cpp
+++ b/client/battle/BattleObstacleController.cpp
@@ -196,26 +196,12 @@ std::shared_ptr<IImage> BattleObstacleController::getObstacleImage(const CObstac
 
 Point BattleObstacleController::getObstaclePosition(std::shared_ptr<IImage> image, const CObstacleInstance & obstacle)
 {
-	int offset = obstacle.getAnimationYOffset(image->height());
-
 	Rect r = owner.fieldController->hexPositionLocal(obstacle.pos);
-	r.y += 42 - image->height() + offset;
-
-	return r.topLeft();
+	return r.bottomLeft() - Point(0, obstacle.getAnimationYOffset(image->height()));
 }
 
 Point BattleObstacleController::getObstaclePosition(std::shared_ptr<IImage> image, const JsonNode & obstacle)
 {
-	auto animationYOffset = obstacle["animationYOffset"].Integer();
-	auto offset = image->height() % 42;
-
-	if(obstacle["needAnimationOffsetFix"].Bool() && offset > 37)
-		animationYOffset -= 42;
-
-	offset += animationYOffset;
-
 	Rect r = owner.fieldController->hexPositionLocal(obstacle["position"].Integer());
-	r.y += 42 - image->height() + offset;
-
-	return r.topLeft();
+	return r.bottomLeft() - Point(0, image->height());
 }

--- a/client/battle/BattleObstacleController.h
+++ b/client/battle/BattleObstacleController.h
@@ -31,6 +31,8 @@ class BattleRenderer;
 /// (with exception of moat, which is apparently handled by siege controller)
 class BattleObstacleController
 {
+	friend class ClientCommandManager;
+
 	BattleInterface & owner;
 
 	/// total time, in seconds, since start of battle. Used for animating obstacles

--- a/client/battle/BattleRenderer.h
+++ b/client/battle/BattleRenderer.h
@@ -20,7 +20,7 @@ enum class EBattleFieldLayer {
 	WALLS         = 1,
 	HEROES        = 2,
 	STACKS        = 2, // after corpses, obstacles, walls
-	OBSTACLES     = 3, // after stacks
+	OBSTACLES     = 3, // after stacks FIXME: not correct for quicksands!
 	STACK_AMOUNTS = 3, // after stacks, obstacles, corpses
 	EFFECTS       = 4, // after obstacles, battlements
 };

--- a/config/obstacles.json
+++ b/config/obstacles.json
@@ -73,8 +73,8 @@
 	{
 		"allowedTerrains" : ["dirt"],
 		"width" : 3,
-		"height" : 2,
-		"blockedTiles" :  [-15, -16],
+		"height" : 1,
+		"blockedTiles" :  [0, 1],
 		"animation" : "ObDRk01.def",
 		"absolute" : false
 	},
@@ -92,8 +92,8 @@
 	{
 		"allowedTerrains" : ["dirt"],
 		"width" : 2,
-		"height" : 2,
-		"blockedTiles" :  [-16],
+		"height" : 1,
+		"blockedTiles" :  [0, 1],
 		"animation" : "ObDRk03.def",
 		"absolute" : false
 	},
@@ -131,7 +131,7 @@
 	{
 		"allowedTerrains" : ["dirt", "rough"],
 		"specialBattlefields" : ["cursed_ground"],
-		"width" : 3,
+		"width" : 4,
 		"height" : 3,
 		"blockedTiles" :  [0, 1, 2, 3],
 		"animation" : "ObDtS03.def",

--- a/docs/modders/Entities_Format/Battle_Obstacle_Format.md
+++ b/docs/modders/Entities_Format/Battle_Obstacle_Format.md
@@ -19,9 +19,13 @@
 	"absolute" : false
 	
 	// Width of an obstacle, in hexes
+	// Only affects how far on the right side of the battlefield this obstacle can be placed
+	// make sure that this number matches maximum width of blocked tiles 
 	"width" : 1
 	
-	// Height of an obstacle, in hexes
+	// Height of an obstacle, in hexes. It determines:
+	// 1. Maximum height on a battlefield at which obstacle can be placed
+	// 2. Image positioning (see below)
 	"height" : 1
 	
 	// List of tiles blocked by an obstacles. See below for description
@@ -33,6 +37,13 @@
 	// If set to true, obstacle will appear in front of units or other battlefield objects
 	"foreground" : false
 ```
+
+## Obstacle image positioning
+
+Obstacle image will always be placed in the same way:
+
+- left side of obstacle image is aligned with left side of hex on the bottom row of hexes
+- top side of image is aligned with top of the hex in topmost row of hexes (based on height of the obstacle)  
 
 ## Blocked tiles definition
 
@@ -51,3 +62,17 @@ For example, obstacle that blocks tiles `[1, 2, 3, -14, -15, -31]` would result 
 Absolute obstacles operate in absolute coordinates. Because of that, blocked tiles contains list of indexes of blocked tiles. For reference on tiles indexes see image below:
 
 ![Battlefield Hexes Layout](../../images/Battle_Field_Hexes.svg)
+
+## Troubleshooting
+
+To help with tracking down problems with image positioning or blocked tiles, you can use `obstacles debug` command. To use it, enter any combat in game, open chat (for example by pressing tab) and enter `/obstacles debug` in chat.
+
+This would export all images into `<User cache directory>/extracted/obstacles` (see Launcher -> Help for actual path on your system)
+
+This directory will contain images of all non-absolute obstaclese loaded in game with additional debug info:
+
+- hex grid placed over your image (size of hex grid matches width / height of your obstacle)
+- shaded tiles that are blocked by your obstacle
+- boundaries of your image
+
+This command can also be used to quickly check all obstacles added by your mod instead of relying on random rolls and reentering multiple combats to locate all added obstacles.\

--- a/docs/players/Cheat_Codes.md
+++ b/docs/players/Cheat_Codes.md
@@ -154,6 +154,7 @@ Below a list of supported commands, with their arguments wrapped in `<>`
 - `def2bmp <.def file name>` - extract .def animation as BMP files
 - `extract <relative file path>` - export file into directory used by other extraction commands
 - `generate assets` - generate all assets at once
+- `obstacles debug` - export images of all battlefield obstacles with their placement on battle hex grid and blocked tiles overlayed on top
 
 #### AI commands
 

--- a/lib/battle/CObstacleInstance.cpp
+++ b/lib/battle/CObstacleInstance.cpp
@@ -74,13 +74,10 @@ const AudioPath & CObstacleInstance::getAppearSound() const
 
 int CObstacleInstance::getAnimationYOffset(int imageHeight) const
 {
-	int offset = imageHeight % 42;
 	if(obstacleType == CObstacleInstance::USUAL)
-	{
-		if(getInfo().blockedTiles.front() < 0 || offset > 37) //second or part is for holy ground ID=62,65,63
-			offset -= 42;
-	}
-	return offset;
+		return 42 * getInfo().height + 10;
+
+	return imageHeight;
 }
 
 bool CObstacleInstance::stopsMovement() const
@@ -106,19 +103,11 @@ SpellID CObstacleInstance::getTrigger() const
 void CObstacleInstance::serializeJson(JsonSerializeFormat & handler)
 {
 	auto hidden = false;
-	auto needAnimationOffsetFix = obstacleType == CObstacleInstance::USUAL;
-	int animationYOffset = 0;
-		
-	if(getInfo().blockedTiles.front() < 0) //TODO: holy ground ID=62,65,63
-		animationYOffset -= 42;
-
 	//We need only a subset of obstacle info for correct render
 	si16 posValue = pos.toInt();
 	handler.serializeInt("position", posValue);
 	pos = posValue;
-	handler.serializeInt("animationYOffset", animationYOffset);
 	handler.serializeBool("hidden", hidden);
-	handler.serializeBool("needAnimationOffsetFix", needAnimationOffsetFix);
 }
 
 void CObstacleInstance::toInfo(ObstacleChanges & info, BattleChanges::EOperation operation)
@@ -142,7 +131,6 @@ SpellCreatedObstacle::SpellCreatedObstacle()
 	trap(false),
 	removeOnTrigger(false),
 	revealed(false),
-	animationYOffset(0),
 	nativeVisible(true),
 	minimalDamage(0)
 {
@@ -213,8 +201,6 @@ void SpellCreatedObstacle::serializeJson(JsonSerializeFormat & handler)
 	handler.serializeStruct("appearAnimation", appearAnimation);
 	handler.serializeStruct("animation", animation);
 
-	handler.serializeInt("animationYOffset", animationYOffset);
-
 	{
 		JsonArraySerializer customSizeJson = handler.enterArray("customSize");
 		customSizeJson.syncSize(customSize, JsonNode::JsonType::DATA_INTEGER);
@@ -256,14 +242,7 @@ const AudioPath & SpellCreatedObstacle::getAppearSound() const
 
 int SpellCreatedObstacle::getAnimationYOffset(int imageHeight) const
 {
-	int offset = imageHeight % 42;
-
-	if(obstacleType == CObstacleInstance::SPELL_CREATED || obstacleType == CObstacleInstance::MOAT)
-	{
-		offset += animationYOffset;
-	}
-
-	return offset;
+	return imageHeight;
 }
 
 VCMI_LIB_NAMESPACE_END

--- a/lib/battle/CObstacleInstance.h
+++ b/lib/battle/CObstacleInstance.h
@@ -95,8 +95,6 @@ struct DLL_LINKAGE SpellCreatedObstacle : CObstacleInstance
 	AnimationPath appearAnimation;
 	AnimationPath animation;
 
-	int animationYOffset;
-
 	BattleHexArray customSize;
 
 	SpellCreatedObstacle();

--- a/lib/spells/effects/Moat.cpp
+++ b/lib/spells/effects/Moat.cpp
@@ -164,7 +164,6 @@ void Moat::placeObstacles(ServerCallback * server, const Mechanics * m, const Ef
 		obstacle.appearAnimation = sideOptions.appearAnimation; //For dispellable moats
 		obstacle.animation = sideOptions.animation;
 		obstacle.customSize.insert(destination);
-		obstacle.animationYOffset = sideOptions.offsetY;
 		pack.changes.emplace_back();
 		obstacle.toInfo(pack.changes.back());
 	}

--- a/lib/spells/effects/Obstacle.cpp
+++ b/lib/spells/effects/Obstacle.cpp
@@ -91,8 +91,6 @@ void ObstacleSideOptions::serializeJson(JsonSerializeFormat & handler)
 	handler.serializeStruct("appearSound", appearSound);
 	handler.serializeStruct("appearAnimation", appearAnimation);
 	handler.serializeStruct("animation", animation);
-
-	handler.serializeInt("offsetY", offsetY);
 }
 
 void Obstacle::adjustAffectedHexes(BattleHexArray & hexes, const Mechanics * m, const Target & spellTarget) const
@@ -300,8 +298,6 @@ void Obstacle::placeObstacles(ServerCallback * server, const Mechanics * m, cons
 		obstacle.appearSound = options.appearSound;
 		obstacle.appearAnimation = options.appearAnimation;
 		obstacle.animation = options.animation;
-
-		obstacle.animationYOffset = options.offsetY;
 
 		obstacle.customSize.clear();
 

--- a/lib/spells/effects/Obstacle.h
+++ b/lib/spells/effects/Obstacle.h
@@ -34,8 +34,6 @@ public:
 	AnimationPath appearAnimation;
 	AnimationPath animation;
 
-	int offsetY = 0;
-
 	void serializeJson(JsonSerializeFormat & handler);
 };
 


### PR DESCRIPTION
Removed multiple hacks in battle obstacle positioning logic.

Now position of image no longer depends on order of blocked tiles or relies on image size hacks - instead it depends only on obstacle `height`.

Also added debug command `/obstacles debug` that exports all in-game obstacles (non-absolute for now) with overlay that shows how obstacle will look like in combat - how it will be placed across hexes, and which hexes will be blocked. NOTE: command is only usable during combat.

- Fixes #6881