### PR TITLE
mapeditor: adds a widget for editing scholars

### DIFF
--- a/lib/json/JsonKeyExtractor.h
+++ b/lib/json/JsonKeyExtractor.h
@@ -40,8 +40,11 @@ private:
 template<typename IdentifierType>
 std::set<IdentifierType> JsonKeyExtractor::filterKeys(const JsonNode & value, const std::set<IdentifierType> & valuesSet, const Variables & variables)
 {
+    // if value is string do not filter value through valueSet. It allows objects like scholar to override map settings
+    // (i.e grant a skill that is blocked by map settings). It is intentional.
+    // TODO: refactor class so this behaviour is clearly reflected by api.
 	if(value.isString())
-		return {decodeKey<IdentifierType>(value, variables)};
+        return {decodeKey<IdentifierType>(value, variables)};
 
 	assert(value.isStruct());
 

--- a/mapeditor/CMakeLists.txt
+++ b/mapeditor/CMakeLists.txt
@@ -45,6 +45,7 @@ set(editor_SRCS
 		inspector/portraitwidget.cpp
 		inspector/playerselectionwidget.cpp
 		inspector/abilitieswidget.cpp
+		inspector/scholarwidget.cpp
 		resourceExtractor/ResourceConverter.cpp
 		helper.cpp
 		campaigneditor/campaigneditor.cpp
@@ -118,6 +119,7 @@ set(editor_HEADERS
 		inspector/baseinspectoritemdelegate.h
 		inspector/playerselectionwidget.h
 		inspector/abilitieswidget.h
+		inspector/scholarwidget.h
 		resourceExtractor/ResourceConverter.h
 		mapeditorroles.h
 		helper.h
@@ -177,6 +179,7 @@ set(editor_FORMS
 		inspector/portraitwidget.ui
 		inspector/playerselectionwidget.ui
 		inspector/abilitieswidget.ui
+		inspector/scholarwidget.ui
 		campaigneditor/campaigneditor.ui
 		campaigneditor/campaignproperties.ui
 		campaigneditor/scenarioproperties.ui

--- a/mapeditor/inspector/abilitieswidget.cpp
+++ b/mapeditor/inspector/abilitieswidget.cpp
@@ -185,7 +185,6 @@ QWidget * AbilitiesDelegate::createEditor(QWidget * parent, const QStyleOptionVi
 
 void AbilitiesDelegate::setEditorData(QWidget * editor, const QModelIndex & index) const
 {
-	logGlobal->error("set editor data!");
 	if(auto * aw = qobject_cast<AbilitiesWidget *>(editor))
 	{
 		aw->loadData();

--- a/mapeditor/inspector/inspector.cpp
+++ b/mapeditor/inspector/inspector.cpp
@@ -22,21 +22,24 @@
 #include "../../lib/texts/CGeneralTextHandler.h"
 #include "../../lib/spells/CSpellHandler.h"
 
+#include "../mapcontroller.h"
+#include "PickObjectDelegate.h"
 #include "abilitieswidget.h"
-#include "townbuildingswidget.h"
-#include "towneventswidget.h"
-#include "townspellswidget.h"
 #include "armywidget.h"
-#include "messagewidget.h"
-#include "rewardswidget.h"
-#include "questwidget.h"
 #include "heroartifactswidget.h"
 #include "heroskillswidget.h"
 #include "herospellwidget.h"
+#include "messagewidget.h"
 #include "portraitwidget.h"
 #include "PickObjectDelegate.h"
 #include "playerselectionwidget.h"
 #include "../mapcontroller.h"
+#include "questwidget.h"
+#include "rewardswidget.h"
+#include "scholarwidget.h"
+#include "townbuildingswidget.h"
+#include "towneventswidget.h"
+#include "townspellswidget.h"
 
 //===============IMPLEMENT OBJECT INITIALIZATION FUNCTIONS================
 Initializer::Initializer(MapController & controller, CGObjectInstance * o, const PlayerColor & pl)
@@ -453,16 +456,24 @@ void Inspector::updateProperties(CRewardableObject * o)
 	if(!o)
 		return;
 
-	if(o->ID == MapObjectID::WITCH_HUT)
+    BaseInspectorItemDelegate * delegate = nullptr;
+
+	switch(o->ID)
 	{
-		auto * delegate = new AbilitiesDelegate(controller, *o);
-		addProperty(QObject::tr("Abilities"), PropertyEditorPlaceholder(), delegate, false);
+		case MapObjectID::WITCH_HUT:
+		{
+			delegate = new AbilitiesDelegate(controller, *o);
+			break;
+		}
+		case MapObjectID::SCHOLAR:
+		{
+			delegate = new ScholarDelegate(controller, *o);
+			break;
+		}
+		default:
+			delegate = new RewardsDelegate(*controller.map(), *o);
 	}
-	else
-	{
-		auto * delegate = new RewardsDelegate(*controller.map(), *o);
-		addProperty(QObject::tr("Reward"), PropertyEditorPlaceholder(), delegate, false);
-	}
+	addProperty(QObject::tr("Reward"), PropertyEditorPlaceholder(), delegate, false);
 }
 
 void Inspector::updateProperties(CGPandoraBox * o)

--- a/mapeditor/inspector/scholarwidget.cpp
+++ b/mapeditor/inspector/scholarwidget.cpp
@@ -1,0 +1,217 @@
+/*
+ * scholarwidget.cpp, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
+#include "StdInc.h"
+#include "inspector.h"
+#include "scholarwidget.h"
+#include "ui_scholarwidget.h"
+#include "mapcontroller.h"
+
+#include "lib/CSkillHandler.h"
+#include "lib/GameLibrary.h"
+#include "lib/constants/StringConstants.h"
+#include "lib/mapping/CMap.h"
+#include "lib/modding/ModScope.h"
+#include "lib/modding/IdentifierStorage.h"
+#include "lib/spells/CSpellHandler.h"
+
+const std::string ScholarWidget::presetNotFoundWarning =
+	"<font color='red'>The scholar has %1 preset set to \"%2\", "
+	"but the value is unknown. Maybe it is a mod configuration problem?</font color='red'>";
+
+ScholarWidget::ScholarWidget(CRewardableObject & scholar, MapController & controller, QWidget * parent)
+	: scholar(scholar), controller(controller), QDialog(parent), extractor(controller.getCallback()), ui(new Ui::ScholarWidget)
+{
+	ui->setupUi(this);
+	rewardsData = {
+		{ui->pSkillsCheck, ui->pSkills, {"primarySkill", "gainedStat"},    "primary skill",   JsonNode(2)},
+		{ui->sSkillsCheck, ui->sSkills, {"secondarySkill", "gainedSkill"}, "secondary skill", JsonNode(1)},
+		{ui->spellsCheck,  ui->spells,  {"spell", "gainedSpell"},          "spell",           JsonNode(0)}
+	};
+}
+
+ScholarWidget::~ScholarWidget()
+{
+	delete ui;
+}
+
+void ScholarWidget::loadData()
+{
+	for(int i = 0; i < GameConstants::PRIMARY_SKILLS; i++)
+	{
+		ui->pSkills->insertItem(i, QString::fromStdString(LIBRARY->generaltexth->primarySkillNames[i]));
+		ui->pSkills->setItemData(i, QString::fromStdString(NPrimarySkill::names[i]));
+	}
+	int ssi = 0;
+	for(const auto & skill : LIBRARY->skillh->objects)
+	{
+		ui->sSkills->insertItem(ssi, QString::fromStdString(skill->getNameTranslated()));
+		ui->sSkills->setItemData(ssi, QString::fromStdString(skill->getJsonKey()));
+		ssi++;
+	}
+	int spi = 0;
+	for(const auto & spell : LIBRARY->spellh->objects)
+	{
+		ui->spells->insertItem(spi, QString::fromStdString(spell->getNameTranslated()));
+		ui->spells->setItemData(spi, QString::fromStdString(spell->getJsonKey()));
+		spi++;
+	}
+
+	auto allowCompletion = [](QComboBox * comboBox)
+	{
+		comboBox->completer()->setCompletionMode(QCompleter::PopupCompletion);
+		comboBox->completer()->setFilterMode(Qt::MatchContains);
+	};
+
+	allowCompletion(ui->pSkills);
+	allowCompletion(ui->sSkills);
+	allowCompletion(ui->spells);
+
+	loadState();
+	changeComboBoxesAllowedState();
+}
+
+void ScholarWidget::commitChanges()
+{
+	if(ui->random->isChecked())
+	{
+		scholar.configuration.variables.preset.clear();
+		return;
+	}
+	for(const RewardData & rd : rewardsData)
+	{
+		if(rd.radioButton->isChecked())
+		{
+			scholar.configuration.variables.preset.clear();
+			JsonNode variable;
+			variable.String() = rd.comboBox->itemData(rd.comboBox->currentIndex()).toString().toStdString();
+			variable.setModScope(ModScope::scopeGame());
+			scholar.configuration.presetVariable(rd.variables[0], rd.variables[1], variable);
+			scholar.configuration.presetVariable("dice", "map", rd.dice);
+			return;
+		}
+	}
+}
+
+void ScholarWidget::on_pSkillsCheck_toggled(bool checked)
+{
+	changeComboBoxesAllowedState();
+}
+void ScholarWidget::on_sSkillsCheck_toggled(bool checked)
+{
+	changeComboBoxesAllowedState();
+}
+void ScholarWidget::on_spellsCheck_toggled(bool checked)
+{
+	changeComboBoxesAllowedState();
+}
+
+void ScholarWidget::loadState()
+{
+	for(const RewardData & rd : rewardsData)
+	{
+		JsonNode variableNode = scholar.configuration.getPresetVariable(rd.variables[0], rd.variables[1]);
+		if(!variableNode.isNull())
+		{
+			std::string presetVariable = variableNode.String();
+			int index = rd.comboBox->findData(QString::fromStdString(presetVariable));
+			if(index != -1)
+			{
+				rd.radioButton->toggle();
+				rd.comboBox->setCurrentIndex(index);
+				return;
+			}
+			else
+			{
+				showInvalidPresetWarning(rd.name, presetVariable);
+				return;
+			}
+		}
+	}
+	ui->random->toggle();
+}
+
+void ScholarWidget::changeComboBoxesAllowedState()
+{
+	for(const RewardData & rd : rewardsData)
+		rd.comboBox->setDisabled(!rd.radioButton->isChecked());
+}
+
+void ScholarWidget::showInvalidPresetWarning(std::string type, std::string name)
+{
+	auto warning = tr(presetNotFoundWarning.c_str()).arg(type.c_str()).arg(name.c_str());
+	ui->label->setText(warning);
+	adjustSize();
+}
+
+ScholarDelegate::ScholarDelegate(MapController & controller, CRewardableObject & scholar)
+	: BaseInspectorItemDelegate(), controller(controller), scholar(scholar)
+{
+}
+
+QWidget * ScholarDelegate::createEditor(QWidget * parent, const QStyleOptionViewItem & option, const QModelIndex & index) const
+{
+	return new ScholarWidget(scholar, controller, parent);
+}
+
+void ScholarDelegate::setEditorData(QWidget * editor, const QModelIndex & index) const
+{
+	if(auto * aw = qobject_cast<ScholarWidget *>(editor))
+	{
+		aw->loadData();
+	}
+	else
+	{
+		QStyledItemDelegate::setEditorData(editor, index);
+	}
+}
+
+void ScholarDelegate::setModelData(QWidget * editor, QAbstractItemModel * model, const QModelIndex & index) const
+{
+	if(auto * ed = qobject_cast<ScholarWidget *>(editor))
+	{
+		ed->commitChanges();
+		updateModelData(model, index);
+	}
+	else
+	{
+		QStyledItemDelegate::setModelData(editor, model, index);
+	}
+}
+
+void ScholarDelegate::updateModelData(QAbstractItemModel * model, const QModelIndex & index) const
+{
+	QStringList textList;
+	JsonNode presetPs = scholar.configuration.getPresetVariable("primarySkill", "gainedStat");
+	JsonNode presetSs = scholar.configuration.getPresetVariable("secondarySkill", "gainedSkill");
+	JsonNode presetSp = scholar.configuration.getPresetVariable("spell", "gainedSpell");
+	if(!presetPs.isNull())
+	{
+		textList += QObject::tr(presetPs.String().c_str());
+	}
+	else if(!presetSs.isNull())
+	{
+		addEntityName(textList, static_cast<const Entity *>(LIBRARY->skillh->getByName(presetSs.String())));
+	}
+	else if(!presetSp.isNull())
+	{
+		addEntityName(textList, static_cast<const Entity *>(LIBRARY->spellh->getByName(presetSp.String())));
+	}
+	else
+		textList += QObject::tr("Default");
+	setModelTextData(model, index, textList);
+}
+
+void ScholarDelegate::addEntityName(QStringList & textList, const Entity * const entity) const
+{
+	if(entity)
+		textList += QString::fromStdString(entity->getNameTranslated());
+	else
+		textList += QObject::tr("Invalid");
+}

--- a/mapeditor/inspector/scholarwidget.h
+++ b/mapeditor/inspector/scholarwidget.h
@@ -1,0 +1,82 @@
+/*
+ * scholarwidget.h, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
+#pragma once
+
+#include <QDialog>
+#include "baseinspectoritemdelegate.h"
+#include "lib/json/JsonKeyExtractor.h"
+#include "lib/mapObjects/CRewardableObject.h"
+
+VCMI_LIB_USING_NAMESPACE
+
+namespace Ui
+{
+class ScholarWidget;
+}
+
+class MapController;
+class CRewardableObject;
+
+class ScholarWidget : public QDialog
+{
+	Q_OBJECT
+
+public:
+	explicit ScholarWidget(CRewardableObject &, MapController &, QWidget * parent = nullptr);
+	~ScholarWidget();
+	void loadData();
+	void commitChanges();
+
+private slots:
+	void on_pSkillsCheck_toggled(bool checked);
+	void on_sSkillsCheck_toggled(bool checked);
+	void on_spellsCheck_toggled(bool checked);
+
+private:
+	struct RewardData
+	{
+		QRadioButton * radioButton;
+		QComboBox * comboBox;
+		std::string variables[2];
+		std::string name;
+		JsonNode dice;
+	};
+
+	void loadState();
+	void changeComboBoxesAllowedState();
+	void showInvalidPresetWarning(std::string type, std::string name);
+
+	Ui::ScholarWidget * ui;
+	CRewardableObject & scholar;
+	JsonKeyExtractor extractor;
+	MapController & controller;
+
+	std::vector<RewardData> rewardsData;
+	static const std::string presetNotFoundWarning;
+};
+
+class ScholarDelegate : public BaseInspectorItemDelegate
+{
+	Q_OBJECT
+public:
+	using BaseInspectorItemDelegate::BaseInspectorItemDelegate;
+
+	ScholarDelegate(MapController &, CRewardableObject &);
+
+	QWidget * createEditor(QWidget * parent, const QStyleOptionViewItem & option, const QModelIndex & index) const override;
+	void setEditorData(QWidget * editor, const QModelIndex & index) const override;
+	void setModelData(QWidget * editor, QAbstractItemModel * model, const QModelIndex & index) const override;
+	void updateModelData(QAbstractItemModel * model, const QModelIndex & index) const override;
+	void addEntityName(QStringList & textList, const Entity * const entity) const;
+
+private:
+	CRewardableObject & scholar;
+	MapController & controller;
+};

--- a/mapeditor/inspector/scholarwidget.ui
+++ b/mapeditor/inspector/scholarwidget.ui
@@ -1,0 +1,197 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ScholarWidget</class>
+ <widget class="QDialog" name="ScholarWidget">
+  <property name="windowModality">
+   <enum>Qt::WindowModality::NonModal</enum>
+  </property>
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>350</width>
+    <height>180</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>350</width>
+    <height>150</height>
+   </size>
+  </property>
+  <property name="maximumSize">
+   <size>
+    <width>350</width>
+    <height>300</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string>Scholar</string>
+  </property>
+  <property name="layoutDirection">
+   <enum>Qt::LayoutDirection::LeftToRight</enum>
+  </property>
+  <property name="modal">
+   <bool>true</bool>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="spacing">
+    <number>10</number>
+   </property>
+   <property name="topMargin">
+    <number>5</number>
+   </property>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_4" stretch="0,0">
+     <property name="sizeConstraint">
+      <enum>QLayout::SizeConstraint::SetMinimumSize</enum>
+     </property>
+     <item>
+      <widget class="QRadioButton" name="random">
+       <property name="maximumSize">
+        <size>
+         <width>120</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>Random</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>1</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="font">
+        <font>
+         <pointsize>9</pointsize>
+        </font>
+       </property>
+       <property name="autoFillBackground">
+        <bool>false</bool>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QRadioButton" name="pSkillsCheck">
+       <property name="maximumSize">
+        <size>
+         <width>125</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>Primary Skill</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QComboBox" name="pSkills">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>1</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="editable">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <property name="sizeConstraint">
+      <enum>QLayout::SizeConstraint::SetDefaultConstraint</enum>
+     </property>
+     <item>
+      <widget class="QRadioButton" name="sSkillsCheck">
+       <property name="maximumSize">
+        <size>
+         <width>125</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>Secondary Skill</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QComboBox" name="sSkills">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>1</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="editable">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_3">
+     <property name="sizeConstraint">
+      <enum>QLayout::SizeConstraint::SetNoConstraint</enum>
+     </property>
+     <item>
+      <widget class="QRadioButton" name="spellsCheck">
+       <property name="maximumSize">
+        <size>
+         <width>125</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="layoutDirection">
+        <enum>Qt::LayoutDirection::LeftToRight</enum>
+       </property>
+       <property name="text">
+        <string>Spell</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QComboBox" name="spells">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>1</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="editable">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/mapeditor/validator.cpp
+++ b/mapeditor/validator.cpp
@@ -44,7 +44,6 @@ Validator::~Validator()
 std::set<Validator::Issue> Validator::validate(const CMap * map)
 {
 	std::set<Validator::Issue> issues;
-	JsonKeyExtractor keyExtractor(map->cb);
 	
 	if(!map)
 	{
@@ -154,16 +153,20 @@ std::set<Validator::Issue> Validator::validate(const CMap * map)
 			}
 			if(o->ID == MapObjectID::WITCH_HUT)
 			{
-				CRewardableObject * hut = static_cast<CRewardableObject *>(o.get());
-				JsonNode preset = hut->configuration.getPresetVariable("secondarySkill", "gainedSkill");
-				if(!preset.isNull())
+				if(!presetIsValid(map, o, "secondarySkill", "gainedSkill", map->allowedAbilities))
 				{
-					auto presetAbilities = keyExtractor.filterKeys(preset, map->allowedAbilities);
-					if(presetAbilities.empty())
-					{
-						issues.insert({tr("A customized witch hut at x: %1 y: %2 on %3 layer does not hold a valid secondary skill")
-                            .arg(hut->pos.x).arg(hut->pos.y).arg(hut->pos.z), true});
-					}
+					issues.insert({tr("A witch hut at x: %1 y: %2 on %3 layer holds an invalid reward")
+						.arg(o->pos.x).arg(o->pos.y).arg(o->pos.z), true}
+					);
+				}
+			}
+			if(o->ID == MapObjectID::SCHOLAR)
+			{
+				if(!presetIsValid(map, o, "secondarySkill", "gainedSkill", map->allowedAbilities)
+				   || !presetIsValid(map, o, "spell", "gainedSpell", map->allowedSpells))
+				{
+					issues.insert({tr("A scholar at x: %1 y: %2 on %3 layer holds an invalid reward")
+						.arg(o->pos.x).arg(o->pos.y).arg(o->pos.z), true});
 				}
 			}
 		}
@@ -205,6 +208,24 @@ std::set<Validator::Issue> Validator::validate(const CMap * map)
 	}
 	
 	return issues;
+}
+
+template<typename IdentifierType>
+bool Validator::presetIsValid(
+    const CMap * map,
+	std::shared_ptr<CGObjectInstance> object,
+	const std::string & category,
+	const std::string & name,
+	const std::set<IdentifierType> & allowedEntities
+)
+{
+	JsonKeyExtractor keyExtractor(map->cb);
+	CRewardableObject * rewardable = static_cast<CRewardableObject *>(object.get());
+	JsonNode preset = rewardable->configuration.getPresetVariable(category, name);
+	if(preset.isNull())
+		return true;
+	auto presetAbilities = keyExtractor.filterKeys(preset, allowedEntities);
+	return !presetAbilities.empty();
 }
 
 void Validator::showValidationResults(const CMap * map)

--- a/mapeditor/validator.h
+++ b/mapeditor/validator.h
@@ -15,6 +15,7 @@
 
 VCMI_LIB_NAMESPACE_BEGIN
 class CMap;
+class CGObjectInstance;
 VCMI_LIB_NAMESPACE_END
 
 VCMI_LIB_USING_NAMESPACE
@@ -51,6 +52,14 @@ private:
 
 	QRect screenGeometry;
 
+	template<typename IdentifierType>
+	static bool presetIsValid(
+        const CMap * map,
+		std::shared_ptr<CGObjectInstance> object,
+		const std::string & category,
+		const std::string & name,
+		const std::set<IdentifierType> & allowedEntities
+	);
 	void showValidationResults(const CMap * map);
 	void adjustWindowSize();
 };


### PR DESCRIPTION
As the title says.
Changes to the JsonKeyExtractor were necessary because it did not filter single values. I think it never popped up because before vcmi mapeditor did not deal with objects with single value as preset variable and h3m maps were validated by OG map editor. 