### PR TITLE
Deterministic AI - do not rely on pointer ordering

### DIFF
--- a/AI/Nullkiller2/Analyzers/DangerHitMapAnalyzer.cpp
+++ b/AI/Nullkiller2/Analyzers/DangerHitMapAnalyzer.cpp
@@ -86,7 +86,7 @@ void DangerHitMapAnalyzer::updateHitMap()
 	enemyHeroAccessibleObjects.clear();
 	townThreats.clear();
 
-	std::map<PlayerColor, std::map<const CGHeroInstance *, HeroRole>> heroes;
+	std::map<PlayerColor, HeroMap<HeroRole>> heroes;
 
 	for(const ObjectInstanceID objId : aiNk->memory->visitableObjs)
 	{
@@ -222,8 +222,8 @@ void DangerHitMapAnalyzer::calculateTileOwners()
 		hitMap.resize(boost::extents[mapSize.x][mapSize.y][mapSize.z]);
 
 	std::vector<std::unique_ptr<CGHeroInstance>> temporaryHeroes;
-	std::map<const CGHeroInstance *, const CGTownInstance *> heroTownMap;
-	std::map<const CGHeroInstance *, HeroRole> townHeroes;
+	HeroMap<const CGTownInstance *> heroTownMap;
+	HeroMap<HeroRole> townHeroes;
 
 	auto addTownHero = [&](const CGTownInstance * town)
 	{

--- a/AI/Nullkiller2/Analyzers/HeroManager.cpp
+++ b/AI/Nullkiller2/Analyzers/HeroManager.cpp
@@ -109,7 +109,7 @@ void HeroManager::update()
 {
 	logAi->trace("Start analysing our heroes");
 
-	std::map<const CGHeroInstance *, float> scores;
+	HeroMap<float> scores;
 	auto myHeroes = cc->getHeroesInfo();
 
 	for(auto & hero : myHeroes)

--- a/AI/Nullkiller2/Behaviors/DefenceBehavior.cpp
+++ b/AI/Nullkiller2/Behaviors/DefenceBehavior.cpp
@@ -197,7 +197,7 @@ void DefenceBehavior::evaluateDefence(Goals::TGoalVec & tasks, const CGTownInsta
 		}
 
 		std::vector<int> pathsToDefend;
-		std::map<const CGHeroInstance *, std::vector<int>> defferedPaths;
+		HeroMap<std::vector<int>> defferedPaths;
 		AIPath * closestWay = nullptr;
 
 		for(int i = 0; i < paths.size(); i++)

--- a/AI/Nullkiller2/CMakeLists.txt
+++ b/AI/Nullkiller2/CMakeLists.txt
@@ -117,6 +117,7 @@ set(Nullkiller2_HEADERS
 		Goals/Goals.h
 		Goals/StayAtTown.h
 		Goals/ExploreNeighbourTile.h
+		Helpers/HeroMap.h
 		Markers/ArmyUpgrade.h
 		Markers/HeroExchange.h
 		Markers/UnlockCluster.h

--- a/AI/Nullkiller2/Engine/Nullkiller.cpp
+++ b/AI/Nullkiller2/Engine/Nullkiller.cpp
@@ -678,9 +678,9 @@ void Nullkiller::tracePlayerStatus(bool beginning) const
 #endif
 }
 
-std::map<const CGHeroInstance *, HeroRole> Nullkiller::getHeroesForPathfinding() const
+HeroMap<HeroRole> Nullkiller::getHeroesForPathfinding() const
 {
-	std::map<const CGHeroInstance *, HeroRole> activeHeroes;
+	HeroMap<HeroRole> activeHeroes;
 	for(auto hero : cc->getHeroesInfo())
 	{
 		if(getHeroLockedReason(hero) == HeroLockedReason::DEFENCE)

--- a/AI/Nullkiller2/Engine/Nullkiller.h
+++ b/AI/Nullkiller2/Engine/Nullkiller.h
@@ -79,7 +79,7 @@ private:
 	const CGHeroInstance * activeHero;
 	int3 targetTile;
 	ObjectInstanceID targetObject;
-	std::map<const CGHeroInstance *, HeroLockedReason> lockedHeroes;
+	HeroMap<HeroLockedReason> lockedHeroes;
 	std::unique_ptr<PathfinderCache> pathfinderCache;
 	ScanDepth scanDepth;
 	TResources lockedResources;
@@ -139,7 +139,7 @@ public:
 	void invalidatePathfinderData();
 	std::shared_ptr<const CPathsInfo> getPathsInfo(const CGHeroInstance * h) const;
 	void invalidatePaths();
-	std::map<const CGHeroInstance *, HeroRole> getHeroesForPathfinding() const;
+	HeroMap<HeroRole> getHeroesForPathfinding() const;
 
 private:
 	void resetState();

--- a/AI/Nullkiller2/Engine/PriorityEvaluator.cpp
+++ b/AI/Nullkiller2/Engine/PriorityEvaluator.cpp
@@ -935,7 +935,7 @@ public:
 		evaluationContext.movementCost += path.movementCost();
 		evaluationContext.closestWayRatio = chain.closestWayRatio;
 
-		std::map<const CGHeroInstance *, float> costsPerHero;
+		HeroMap<float> costsPerHero;
 
 		for(auto & node : path.nodes)
 		{

--- a/AI/Nullkiller2/Helpers/HeroMap.h
+++ b/AI/Nullkiller2/Helpers/HeroMap.h
@@ -1,0 +1,28 @@
+/*
+* HeroMap.h, part of VCMI engine
+*
+* Authors: listed in file AUTHORS in main folder
+*
+* License: GNU General Public License v2.0 or later
+* Full text of license available in license.txt file, in main folder
+*
+*/
+#pragma once
+
+#include "../../../lib/mapObjects/CGHeroInstance.h"
+
+namespace NK2AI
+{
+
+struct HeroPointerComparator
+{
+	bool operator() (const CGHeroInstance  * left, const CGHeroInstance * right) const
+	{
+		return left->id < right->id;
+	}
+};
+
+template<typename KeyType>
+using HeroMap = std::map<const CGHeroInstance *, KeyType, HeroPointerComparator>;
+
+}

--- a/AI/Nullkiller2/Pathfinding/AINodeStorage.cpp
+++ b/AI/Nullkiller2/Pathfinding/AINodeStorage.cpp
@@ -947,7 +947,7 @@ bool AINodeStorage::isDistanceLimitReached(const PathNodeInfo & source, CDestina
 	return false;
 }
 
-void AINodeStorage::setHeroes(std::map<const CGHeroInstance *, HeroRole> heroes)
+void AINodeStorage::setHeroes(HeroMap<HeroRole> heroes)
 {
 	playerID = aiNk->playerID;
 
@@ -1166,7 +1166,7 @@ struct TownPortalFinder
 template<class TVector>
 void AINodeStorage::calculateTownPortal(
 	const ChainActor * actor,
-	const std::map<const CGHeroInstance *, int> & maskMap,
+	const HeroMap<int> & maskMap,
 	const std::vector<CGPathNode *> & initialNodes,
 	TVector & output)
 {
@@ -1240,7 +1240,7 @@ void AINodeStorage::calculateTownPortalTeleportations(std::vector<CGPathNode *> 
 			actorsOfInitial.insert(aiNode->actor->baseActor);
 	}
 
-	std::map<const CGHeroInstance *, int> maskMap;
+	HeroMap<int> maskMap;
 
 	for(std::shared_ptr<ChainActor> basicActor : actors)
 	{

--- a/AI/Nullkiller2/Pathfinding/AINodeStorage.h
+++ b/AI/Nullkiller2/Pathfinding/AINodeStorage.h
@@ -18,6 +18,7 @@ constexpr int NK2AI_GRAPH_TRACE_LEVEL = 0; // To actually enable graph visualiza
 #include "../../../lib/pathfinder/INodeStorage.h"
 #include "Actions/SpecialAction.h"
 #include "Actors.h"
+#include "../Helpers/HeroMap.h"
 
 namespace NK2AI
 {
@@ -264,7 +265,7 @@ public:
 	std::optional<AIPathNode *> getOrCreateNode(const int3 & coord, const EPathfindingLayer layer, const ChainActor * actor);
 	void calculateChainInfo(std::vector<AIPath> & paths, const int3 & pos, bool isOnLand) const;
 	bool isTileAccessible(const HeroPtr & heroPtr, const int3 & pos, const EPathfindingLayer layer) const;
-	void setHeroes(std::map<const CGHeroInstance *, HeroRole> heroes);
+	void setHeroes(HeroMap<HeroRole> heroes);
 	void setScoutTurnDistanceLimit(uint8_t distanceLimit) { turnDistanceLimit[HeroRole::SCOUT] = distanceLimit; }
 	void setMainTurnDistanceLimit(uint8_t distanceLimit) { turnDistanceLimit[HeroRole::MAIN] = distanceLimit; }
 	void setTownsAndDwellings(
@@ -330,7 +331,7 @@ private:
 	template<class TVector>
 	void calculateTownPortal(
 		const ChainActor * actor,
-		const std::map<const CGHeroInstance *, int> & maskMap,
+		const HeroMap<int> & maskMap,
 		const std::vector<CGPathNode *> & initialNodes,
 		TVector & output);
 };

--- a/AI/Nullkiller2/Pathfinding/AIPathfinder.cpp
+++ b/AI/Nullkiller2/Pathfinding/AIPathfinder.cpp
@@ -62,7 +62,7 @@ void AIPathfinder::calculatePathInfo(std::vector<AIPath> & paths, const int3 & t
 	}
 }
 
-void AIPathfinder::updatePaths(const std::map<const CGHeroInstance *, HeroRole> & heroes, PathfinderSettings pathfinderSettings)
+void AIPathfinder::updatePaths(const HeroMap<HeroRole> & heroes, PathfinderSettings pathfinderSettings)
 {
 	if(!storage)
 	{
@@ -132,7 +132,7 @@ void AIPathfinder::updatePaths(const std::map<const CGHeroInstance *, HeroRole> 
 }
 
 void AIPathfinder::updateGraphs(
-	const std::map<const CGHeroInstance *, HeroRole> & heroes,
+	const HeroMap<HeroRole> & heroes,
 	uint8_t mainScanDepth,
 	uint8_t scoutScanDepth)
 {

--- a/AI/Nullkiller2/Pathfinding/AIPathfinder.h
+++ b/AI/Nullkiller2/Pathfinding/AIPathfinder.h
@@ -48,8 +48,8 @@ public:
 	explicit AIPathfinder(Nullkiller * aiNk);
 	void calculatePathInfo(std::vector<AIPath> & paths, const int3 & tile, bool includeGraph = false) const;
 	bool isTileAccessible(const HeroPtr & hero, const int3 & tile) const;
-	void updatePaths(const std::map<const CGHeroInstance *, HeroRole> & heroes, PathfinderSettings pathfinderSettings);
-	void updateGraphs(const std::map<const CGHeroInstance *, HeroRole> & heroes, uint8_t mainScanDepth, uint8_t scoutScanDepth);
+	void updatePaths(const HeroMap<HeroRole> & heroes, PathfinderSettings pathfinderSettings);
+	void updateGraphs(const HeroMap<HeroRole> & heroes, uint8_t mainScanDepth, uint8_t scoutScanDepth);
 	void calculateQuickPathsWithBlocker(std::vector<AIPath> & result, const std::vector<const CGHeroInstance *> & heroes, const int3 & tile);
 
 	std::shared_ptr<AINodeStorage>getStorage()

--- a/AI/Nullkiller2/Pathfinding/AIPathfinderConfig.h
+++ b/AI/Nullkiller2/Pathfinding/AIPathfinderConfig.h
@@ -23,7 +23,7 @@ namespace AIPathfinding
 	class AIPathfinderConfig : public PathfinderConfig
 	{
 	private:
-		std::map<const CGHeroInstance *, std::unique_ptr<CPathfinderHelper>> pathfindingHelpers;
+		HeroMap<std::unique_ptr<CPathfinderHelper>> pathfindingHelpers;
 		std::shared_ptr<AINodeStorage> aiNodeStorage;
 
 	public:

--- a/AI/Nullkiller2/Pathfinding/GraphPaths.cpp
+++ b/AI/Nullkiller2/Pathfinding/GraphPaths.cpp
@@ -10,7 +10,6 @@
 #include "StdInc.h"
 #include "GraphPaths.h"
 #include "AIPathfinderConfig.h"
-#include "../../../lib/CRandomGenerator.h"
 #include "../../../lib/mapObjects/CQuest.h"
 #include "../../../lib/mapping/CMap.h"
 #include "../Engine/Nullkiller.h"

--- a/AI/Nullkiller2/Pathfinding/ObjectGraph.cpp
+++ b/AI/Nullkiller2/Pathfinding/ObjectGraph.cpp
@@ -11,7 +11,6 @@
 #include "ObjectGraph.h"
 #include "ObjectGraphCalculator.h"
 #include "AIPathfinderConfig.h"
-#include "../../../lib/CRandomGenerator.h"
 #include "../../../lib/mapping/CMap.h"
 #include "../Engine/Nullkiller.h"
 #include "../../../lib/logging/VisualLogger.h"

--- a/AI/Nullkiller2/Pathfinding/ObjectGraphCalculator.h
+++ b/AI/Nullkiller2/Pathfinding/ObjectGraphCalculator.h
@@ -30,8 +30,8 @@ private:
 	const Nullkiller * aiNk;
 	std::mutex syncLock;
 
-	std::map<const CGHeroInstance *, HeroRole> actors;
-	std::map<const CGHeroInstance *, const CGObjectInstance *> actorObjectMap;
+	HeroMap<HeroRole> actors;
+	HeroMap<const CGObjectInstance *> actorObjectMap;
 
 	std::vector<std::unique_ptr<CGBoat>> temporaryBoats;
 	std::vector<std::unique_ptr<CGHeroInstance>> temporaryActorHeroes;

--- a/AI/Nullkiller2/Pathfinding/Rules/AILayerTransitionRule.cpp
+++ b/AI/Nullkiller2/Pathfinding/Rules/AILayerTransitionRule.cpp
@@ -198,7 +198,7 @@ namespace AIPathfinding
 		{
 			const CGHeroInstance * hero = nodeStorage->getHero(source.node);
 
-			if(vstd::contains(summonableVirtualBoats, hero) && summonableVirtualBoats.at(hero)->canAct(aiNk, nodeStorage->getAINode(source.node)))
+			if(summonableVirtualBoats.contains(hero) && summonableVirtualBoats.at(hero)->canAct(aiNk, nodeStorage->getAINode(source.node)))
 			{
 				virtualBoat = summonableVirtualBoats.at(hero);
 			}

--- a/AI/Nullkiller2/Pathfinding/Rules/AILayerTransitionRule.h
+++ b/AI/Nullkiller2/Pathfinding/Rules/AILayerTransitionRule.h
@@ -26,9 +26,9 @@ namespace AIPathfinding
 		Nullkiller * aiNk;
 		std::map<int3, std::shared_ptr<const BuildBoatAction>> virtualBoats;
 		std::shared_ptr<AINodeStorage> nodeStorage;
-		std::map<const CGHeroInstance *, std::shared_ptr<const SummonBoatAction>> summonableVirtualBoats;
-		std::map<const CGHeroInstance *, std::shared_ptr<const WaterWalkingAction>> waterWalkingActions;
-		std::map<const CGHeroInstance *, std::shared_ptr<const AirWalkingAction>> airWalkingActions;
+		HeroMap<std::shared_ptr<const SummonBoatAction>> summonableVirtualBoats;
+		HeroMap<std::shared_ptr<const WaterWalkingAction>> waterWalkingActions;
+		HeroMap<std::shared_ptr<const AirWalkingAction>> airWalkingActions;
 
 	public:
 		AILayerTransitionRule(Nullkiller * aiNk, std::shared_ptr<AINodeStorage> nodeStorage);


### PR DESCRIPTION
This replaces std::maps that use hero instance pointer as key with std::maps with custom comparator that guarantees same element order during iteration (instead of memory allocation order)

Should prevent potential non-reproducible behavior in AI

(recovery of my old PR)