### PR TITLE
Replace boost::locale with iconv

### DIFF
--- a/CI/before_install/linux_qt5.sh
+++ b/CI/before_install/linux_qt5.sh
@@ -16,8 +16,8 @@ sudo eatmydata apt -yq --no-install-recommends \
   -o APT::Keep-Downloaded-Packages=true \
   -o Acquire::Retries=3 -o Dpkg::Use-Pty=0 \
   install \
-  libboost-dev libboost-filesystem-dev libboost-system-dev libboost-thread-dev \
-  libboost-program-options-dev libboost-locale-dev libboost-iostreams-dev \
+  libboost-dev libboost-filesystem-dev libboost-date-time-dev \
+  libboost-program-options-dev libboost-iostreams-dev \
   libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev libsdl2-ttf-dev \
   qtbase5-dev qtbase5-dev-tools qttools5-dev qttools5-dev-tools \
   libqt5svg5-dev \

--- a/CI/before_install/linux_qt6.sh
+++ b/CI/before_install/linux_qt6.sh
@@ -16,8 +16,8 @@ sudo eatmydata apt -yq --no-install-recommends \
   -o APT::Keep-Downloaded-Packages=true \
   -o Acquire::Retries=3 -o Dpkg::Use-Pty=0 \
   install \
-  libboost-dev libboost-filesystem-dev libboost-system-dev libboost-thread-dev \
-  libboost-program-options-dev libboost-locale-dev libboost-iostreams-dev \
+  libboost-dev libboost-filesystem-dev libboost-date-time-dev \
+  libboost-program-options-dev libboost-iostreams-dev \
   libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev libsdl2-ttf-dev \
   qt6-base-dev qt6-base-dev-tools qt6-tools-dev qt6-tools-dev-tools \
   qt6-l10n-tools qt6-svg-dev \

--- a/CI/install_conan_dependencies.sh
+++ b/CI/install_conan_dependencies.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-RELEASE_TAG="2026-03-11"
+RELEASE_TAG="2026-05-25"
 FILENAME="$1.txz"
 DOWNLOAD_URL="https://github.com/vcmi/vcmi-dependencies/releases/download/$RELEASE_TAG/$FILENAME"
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -485,7 +485,7 @@ endif()
 #        Finding packages                  #
 ############################################
 
-set(BOOST_COMPONENTS date_time filesystem locale program_options)
+set(BOOST_COMPONENTS date_time filesystem program_options)
 if(ENABLE_INNOEXTRACT)
 	list(APPEND BOOST_COMPONENTS iostreams)
 endif()
@@ -494,6 +494,8 @@ if(Boost_MAJOR_VERSION EQUAL 1 AND Boost_MINOR_VERSION LESS 69)
 	list(APPEND BOOST_COMPONENTS system)
 	find_package(Boost 1.74.0 REQUIRED COMPONENTS ${BOOST_COMPONENTS})
 endif()
+
+find_package(Iconv REQUIRED)
 
 find_package(ZLIB REQUIRED)
 # Conan compatibility

--- a/client/renderSDL/CBitmapFont.cpp
+++ b/client/renderSDL/CBitmapFont.cpp
@@ -112,8 +112,6 @@ void CBitmapFont::loadFont(const ResourcePath & resource, std::unordered_map<Cod
 
 	for (uint32_t charIndex = 0; charIndex < symbolsInFile; ++charIndex)
 	{
-		CodePoint codepoint = TextOperations::getUnicodeCodepoint(static_cast<char>(charIndex), modEncoding);
-
 		EntryFNT symbol;
 
 		symbol.leftOffset =  read_le_u32(data.first.get() + baseIndex + charIndex * 12 + 0);
@@ -130,6 +128,7 @@ void CBitmapFont::loadFont(const ResourcePath & resource, std::unordered_map<Cod
 
 		std::copy_n(pixelData, pixelsCount, symbol.pixels.data() );
 
+		CodePoint codepoint = TextOperations::getUnicodeCodepoint(static_cast<char>(charIndex), modEncoding);
 		loadedChars[codepoint] = symbol;
 	}
 

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: vcmi
 Section: games
 Priority: optional
 Maintainer: Ivan Savenko <saven.ivan@gmail.com>
-Build-Depends: debhelper (>= 8), cmake, gettext, libsdl2-dev, libsdl2-image-dev, libsdl2-ttf-dev, libsdl2-mixer-dev, zlib1g-dev, libavformat-dev, libswscale-dev, libboost-dev, libboost-program-options-dev, libboost-filesystem-dev, libboost-system-dev, libboost-locale-dev, libboost-thread-dev, libboost-iostreams-dev, libtbb-dev, libminizip-dev, liblzma-dev, libsquish-dev, libfmt-dev, libluajit-5.1-dev, qt6-base-dev, qt6-base-dev-tools, qt6-tools-dev, qt6-tools-dev-tools, qt6-l10n-tools, qt6-svg-dev, libonnxruntime-dev
+Build-Depends: debhelper (>= 8), cmake, gettext, libsdl2-dev, libsdl2-image-dev, libsdl2-ttf-dev, libsdl2-mixer-dev, zlib1g-dev, libavformat-dev, libswscale-dev, libboost-dev, libboost-date-time-dev, libboost-program-options-dev, libboost-filesystem-dev, libboost-iostreams-dev, libtbb-dev, libminizip-dev, liblzma-dev, libsquish-dev, libfmt-dev, libluajit-5.1-dev, qt6-base-dev, qt6-base-dev-tools, qt6-tools-dev, qt6-tools-dev-tools, qt6-l10n-tools, qt6-svg-dev, libonnxruntime-dev
 Standards-Version: 3.9.1
 Homepage: http://vcmi.eu
 Vcs-Git: git://github.com/vcmi/vcmi.git

--- a/docs/developers/Building_Linux.md
+++ b/docs/developers/Building_Linux.md
@@ -15,13 +15,13 @@ To compile, the following packages (and their development counterparts) are need
 - SDL2 with devel packages: mixer, image, ttf
 - minizip or minizip-ng
 - zlib and zlib-devel
-- onnxruntime
-- Boost C++ libraries: program-options, filesystem, system, thread, locale
+- `LuaJIT`, or Lua (if LuaJit is not available)
+- Boost C++ libraries: `date-time`, `iostreams`, `filesystem`, `program-options`
 - Recommended, if you want to build launcher or map editor: Qt (widget and network modules)
-- Recommended, FFmpeg libraries, if you want to watch in-game videos: libavformat and libswscale. Their name could be libavformat-devel and libswscale-devel, or ffmpeg-libs-devel or similar names.
+- Recommended, FFmpeg libraries, if you want to watch in-game videos: `libavformat` and `libswscale`. Their name could be `libavformat-devel` and `libswscale-devel`, or `ffmpeg-libs-devel` or similar names.
 - Optional:
-  - if you want to build scripting modules: LuaJIT
-  - to speed up recompilation: Ccache
+  - if you want to enable MMAI: `onnxruntime`
+  - to speed up recompilation: `Ccache`
 
 ### On Debian-based systems (e.g. Ubuntu)
 
@@ -30,7 +30,7 @@ For Ubuntu and Debian you need to:
 1. Install this list of packages:
 
     ```sh
-    sudo apt-get install cmake g++ clang libsdl2-dev libsdl2-image-dev libsdl2-ttf-dev libsdl2-mixer-dev zlib1g-dev libavformat-dev libswscale-dev libboost-dev libboost-filesystem-dev libboost-system-dev libboost-thread-dev libboost-program-options-dev libboost-locale-dev libboost-iostreams-dev qt6-base-dev qt6-base-dev-tools qt6-tools-dev qt6-tools-dev-tools qt6-l10n-tools qt6-svg-dev libtbb-dev libluajit-5.1-dev liblzma-dev libsqlite3-dev libminizip-dev libsquish-dev libfmt-dev ninja-build ccache
+    sudo apt-get install cmake g++ clang libsdl2-dev libsdl2-image-dev libsdl2-ttf-dev libsdl2-mixer-dev zlib1g-dev libavformat-dev libswscale-dev libboost-dev libboost-filesystem-dev libboost-program-options-dev libboost-date-time-dev libboost-iostreams-dev qt6-base-dev qt6-base-dev-tools qt6-tools-dev qt6-tools-dev-tools qt6-l10n-tools qt6-svg-dev libtbb-dev libluajit-5.1-dev liblzma-dev libsqlite3-dev libminizip-dev libsquish-dev libfmt-dev ninja-build ccache
     ```
 
 2. Optionally, install `onnxruntime`:

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -851,8 +851,8 @@ endif()
 
 set_target_properties(vcmi PROPERTIES COMPILE_DEFINITIONS "VCMI_DLL=1")
 target_link_libraries(vcmi PUBLIC
-	minizip::minizip ZLIB::ZLIB
-	${SYSTEM_LIBS} Boost::boost Boost::filesystem Boost::program_options Boost::locale Boost::date_time
+	minizip::minizip ZLIB::ZLIB Iconv::Iconv
+	${SYSTEM_LIBS} Boost::boost Boost::filesystem Boost::program_options Boost::date_time
 )
 
 if (NOT ENABLE_MINIMAL_LIB)

--- a/lib/texts/TextOperations.cpp
+++ b/lib/texts/TextOperations.cpp
@@ -17,9 +17,49 @@
 
 #include <vstd/DateUtils.h>
 
-#include <boost/locale/encoding.hpp>
+#include <iconv.h>
 
 VCMI_LIB_NAMESPACE_BEGIN
+
+template<typename FromString, typename DestString>
+FromString convertTextEncoding(const DestString & fromString, const std::string & fromEncoding, const std::string & destEncoding)
+{
+	constexpr auto fromCharSize = sizeof(typename DestString::value_type);
+	constexpr auto destCharSize = sizeof(typename FromString::value_type);
+
+	iconv_t cd = iconv_open(destEncoding.c_str(), fromEncoding.c_str());
+	if(cd == reinterpret_cast<iconv_t>(-1))
+	{
+		logGlobal->error("Encoding coversion failure. Invalid encoding %s -> %s", fromEncoding, destEncoding);
+		return {};
+	}
+
+	FromString destString;
+	// reserve large enough destination storage
+	// worst-case scenario: each input single-byte character is mapped to 4-byte long utf8 sequence
+	destString.resize(fromString.size() * 4);
+
+	// use const_cast to get char * - since iconv api for some reason requests non-const input
+	char * fromData = const_cast<char *>(reinterpret_cast<const char *>(fromString.data()));
+	char * destData = reinterpret_cast<char *>(destString.data());
+	size_t fromLeft = fromString.size() * fromCharSize;
+	size_t destLeft = destString.size() * destCharSize;
+
+	size_t ret = iconv(cd, &fromData, &fromLeft, &destData, &destLeft);
+	iconv_close(cd);
+
+	if(ret == static_cast<size_t>(-1))
+	{
+		if constexpr (fromCharSize == 1)
+			logGlobal->error("Encoding coversion failure. Failed to convert text: %s", fromString);
+		else
+			logGlobal->error("Encoding coversion failure. Failed to convert text.");
+		return {};
+	}
+
+	destString.resize(destString.size() - destLeft / destCharSize);
+	return destString;
+}
 
 size_t TextOperations::getUnicodeCharacterSize(char firstByte)
 {
@@ -162,24 +202,7 @@ uint32_t TextOperations::getUnicodeCodepoint(char data, const std::string & enco
 
 std::string TextOperations::toUnicode(const std::string &text, const std::string &encoding)
 {
-	try {
-		return boost::locale::conv::to_utf<char>(text, encoding);
-	}
-	catch (const boost::locale::conv::conversion_error &)
-	{
-		throw std::runtime_error("Failed to convert text '" + text + "' from encoding " + encoding );
-	}
-}
-
-std::string TextOperations::fromUnicode(const std::string &text, const std::string &encoding)
-{
-	try {
-		return boost::locale::conv::from_utf<char>(text, encoding);
-	}
-	catch (const boost::locale::conv::conversion_error &)
-	{
-		throw std::runtime_error("Failed to convert text '" + text + "' to encoding " + encoding );
-	}
+	return convertTextEncoding<std::string>(text, encoding, "UTF-8");
 }
 
 void TextOperations::trimRightUnicode(std::string & text, const size_t amount)
@@ -410,7 +433,7 @@ std::optional<int> TextOperations::textSearchSimilarityScore(const std::string &
 std::string TextOperations::filesystemPathToUtf8(const boost::filesystem::path& path)
 {
 #ifdef VCMI_WINDOWS
-	return boost::locale::conv::utf_to_utf<char>(path.native());
+	return convertTextEncoding<std::string>(path.native(), "UTF-16LE", "UTF-8");
 #else
 	return path.string();
 #endif
@@ -419,7 +442,7 @@ std::string TextOperations::filesystemPathToUtf8(const boost::filesystem::path& 
 boost::filesystem::path TextOperations::Utf8TofilesystemPath(const std::string& path)
 {
 #ifdef VCMI_WINDOWS
-	return boost::filesystem::path(boost::locale::conv::utf_to_utf<wchar_t>(path));
+	return boost::filesystem::path(convertTextEncoding<std::wstring>(path, "UTF-8", "UTF-16LE"));
 #else
 	return boost::filesystem::path(path);
 #endif

--- a/lib/texts/TextOperations.h
+++ b/lib/texts/TextOperations.h
@@ -41,10 +41,6 @@ namespace TextOperations
 	/// converts text to UTF-8 from specified encoding or from one specified in settings
 	std::string DLL_LINKAGE toUnicode(const std::string & text, const std::string & encoding);
 
-	/// converts text from unicode to specified encoding or to one specified in settings
-	/// NOTE: usage of these functions should be avoided if possible
-	std::string DLL_LINKAGE fromUnicode(const std::string & text, const std::string & encoding);
-
 	///delete specified amount of UTF-8 characters from right
 	DLL_LINKAGE void trimRightUnicode(std::string & text, size_t amount = 1);
 

--- a/mapeditor/resourceExtractor/ResourceConverter.cpp
+++ b/mapeditor/resourceExtractor/ResourceConverter.cpp
@@ -23,7 +23,6 @@ using namespace MapEditor;
 #endif
 
 #include <boost/filesystem/path.hpp>
-#include <boost/locale.hpp>
 
 void ResourceConverter::convertExtractedResourceFiles(ConversionOptions conversionOptions)
 {


### PR DESCRIPTION
VCMI now uses iconv directly instead of through boost::locale wrapper. This removes final usage of boost::locale allowing us to drop this dependency.

Remaining boost modules (filesystem, date-time, program-options, and iostreams) are likely to stay - they are also used by innoextract, so we can't remove them without updating innoextract first.

- Depends on https://github.com/vcmi/vcmi-dependencies/pull/35

(recovery of my old PR) 