### PR TITLE
Support for arbitrary tags for skills

### DIFF
--- a/config/objects/markets.json
+++ b/config/objects/markets.json
@@ -128,10 +128,10 @@
 				"speech" : "@core.genrltxt.603",
 				"offer": 
 				[
-					{ "noneOf" : ["necromancy"] },
-					{ "noneOf" : ["necromancy"] },
-					{ "noneOf" : ["necromancy"] },
-					{ "noneOf" : ["necromancy"] }
+					{ "noneOf" : [ { "tag" : "bannedForUniversity" } ] },
+					{ "noneOf" : [ { "tag" : "bannedForUniversity" } ] },
+					{ "noneOf" : [ { "tag" : "bannedForUniversity" } ] },
+					{ "noneOf" : [ { "tag" : "bannedForUniversity" } ] }
 				]
 			}
 		}

--- a/config/objects/scholar.json
+++ b/config/objects/scholar.json
@@ -28,6 +28,11 @@
 					},
 					"secondarySkill" : {
 						"gainedSkill" : { // Note: this variable name is used by engine for H3M loading
+							"noneOf" : [
+								{
+									"tag" : "bannedForScholar"
+								}
+							]
 						}
 					},
 					"primarySkill" : {

--- a/config/objects/witchHut.json
+++ b/config/objects/witchHut.json
@@ -27,8 +27,9 @@
 					"secondarySkill" : {
 						"gainedSkill" : { // Note: this variable name is used by engine for H3M loading and by AI
 							"noneOf" : [
-								"leadership",
-								"necromancy"
+								{
+									"tag" : "bannedForWitchHut"
+								}
 							]
 						}
 					}

--- a/config/schemas/skill.json
+++ b/config/schemas/skill.json
@@ -66,14 +66,6 @@
 			"type" : "number",
 			"description" : "Internal, numeric id of skill, required for existing skills"
 		},
-		"obligatoryMajor" : {
-			"type" : "boolean",
-			"description" : "This skill is major obligatory (like H3 Wisdom)"
-		},
-		"obligatoryMinor" : {
-			"type" : "boolean",
-			"description" : "This skill is minor obligatory (like H3 Magic school)"
-		},
 		"specialty" : {
 			"type" : "array",
 			"description" : "List of bonuses that are affected by hero specialty",
@@ -107,14 +99,13 @@
 		},
 		"expert" : {
 			"$ref" : "#/definitions/skillBonus"
+		},
+		"tags" : {
+			"type" : "object",
+			"description" : "List of tags describing this skill",
+			"additionalProperties" : {
+				"type" : "boolean"
+			}
 		}
-	},
-	"onlyOnWaterMap" : {
-		"type" : "boolean",
-		"description" : "It true, skill won't be available on a map without water"
-	},
-	"special" : {
-		"type" : "boolean",
-		"description" : "If true, skill is not available on maps at random"
 	}
 }

--- a/config/skills.json
+++ b/config/skills.json
@@ -154,6 +154,9 @@
 	},
 	"navigation" : {
 		"index" : 5,
+		"tags" : {
+			"onlyOnWaterMap" : true
+		},
 		"specialty" : [
 			"main"
 		],
@@ -180,11 +183,13 @@
 			"effects" : {
 				"main" : { "val" : 150 }
 			}
-		},
-		"onlyOnWaterMap" : true
+		}
 	},
 	"leadership" : {
 		"index" : 6,
+		"tags" : {
+			"bannedForWitchHut" : true
+		},
 		"specialty" : [], // generic specialty not applicable
 		"base" : {
 			"effects" : {
@@ -213,7 +218,9 @@
 	"wisdom" : {
 		"index" : 7,
 		"specialty" : [], // generic specialty not applicable
-		"obligatoryMajor" : true,
+		"tags" : {
+			"wisdom" : true
+		},
 		"base" : {
 			"effects" : {
 				"main" : {
@@ -366,6 +373,10 @@
 	},
 	"necromancy" : {
 		"index" : 12,
+		"tags" : {
+			"bannedForWitchHut" : true,
+			"bannedForUniversity" : true
+		},
 		"specialty" : [
 			"main"
 		],
@@ -434,7 +445,9 @@
 	"fireMagic" : {
 		"index" : 14,
 		"specialty" : [], // generic specialty not applicable
-		"obligatoryMinor" : true,
+		"tags" : {
+			"spellSchool" : true
+		},
 		"base" : {
 			"effects" : {
 				"main" : {
@@ -463,7 +476,9 @@
 	"airMagic" : {
 		"index" : 15,
 		"specialty" : [], // generic specialty not applicable
-		"obligatoryMinor" : true,
+		"tags" : {
+			"spellSchool" : true
+		},
 		"base" : {
 			"effects" : {
 				"main" : {
@@ -492,7 +507,9 @@
 	"waterMagic" : {
 		"index" : 16,
 		"specialty" : [], // generic specialty not applicable
-		"obligatoryMinor" : true,
+		"tags" : {
+			"spellSchool" : true
+		},
 		"base" : {
 			"effects" : {
 				"main" : {
@@ -521,7 +538,9 @@
 	"earthMagic" : {
 		"index" : 17,
 		"specialty" : [], // generic specialty not applicable
-		"obligatoryMinor" : true,
+		"tags" : {
+			"spellSchool" : true
+		},
 		"base" : {
 			"effects" : {
 				"main" : {

--- a/docs/modders/Entities_Format/Secondary_Skill_Format.md
+++ b/docs/modders/Entities_Format/Secondary_Skill_Format.md
@@ -4,15 +4,6 @@
 
 ```json
 {
-	// Skill be only be available on maps with water
-	"onlyOnWaterMap" : false,
-	// Skill is not available on maps at random
-	"special" : true
-}
-```
-
-```json
-{
 	"skillName":
 	{
 		//Mandatory, localizable skill name
@@ -46,11 +37,22 @@
 			"modName:heroClassName" : 5
 		},
 		
-		// This skill is major obligatory (like H3 Wisdom) and is guaranteed to be offered once per specific number of levels
-		"obligatoryMajor" : false,
-		
-		// This skill is minor obligatory (like H3 Magic school) and is guaranteed to be offered once per specific number of levels
-		"obligatoryMinor" : false,
+        // List of tags that describe this skill
+		// Tags are only active if set to 'true'
+		// All values are optional
+		// It is also possible to define own tag and test for it when rolling for skills
+		"tags" : {
+		    // Skill is banned on random maps without water
+			"onlyOnWaterMap" : false,
+			// Skill is considered to be disabled on maps by default
+			"special" : true,
+			// This skill is guaranteed to be offered once per specific number of levels
+			// according to H3 logic for Wisdom
+			"wisdom" : false,
+			// This skill is guaranteed to be offered once per specific number of levels
+			// according to H3 logic for Spell Schools
+			"spellSchool" : true
+		}
 	}
 }
 ```

--- a/docs/modders/Map_Objects/Rewardable.md
+++ b/docs/modders/Map_Objects/Rewardable.md
@@ -450,7 +450,12 @@ Keep in mind, that all randomization is performed on map load and on object rese
         "noneOf" : ["necromancy", "leadership"],
         "amount" : 1
     },
-    {
+	{
+	    // Skill will be selected randomly from all allowed skills that have specified tag set in skill config
+		"tag" : ["spellSchool"],
+		"amount" : 1
+		},
+	{
         // Skill will be selected randomly from all allowed
         "amount" : 3
     }

--- a/lib/CSkillHandler.cpp
+++ b/lib/CSkillHandler.cpp
@@ -26,13 +26,9 @@
 
 VCMI_LIB_NAMESPACE_BEGIN
 
-CSkill::CSkill(const SecondarySkill & id, std::string identifier, bool obligatoryMajor, bool obligatoryMinor):
+CSkill::CSkill(const SecondarySkill & id, std::string identifier):
 	id(id),
-	identifier(std::move(identifier)),
-	obligatoryMajor(obligatoryMajor),
-	obligatoryMinor(obligatoryMinor),
-	special(false),
-	onlyOnWaterMap(false)
+	identifier(std::move(identifier))
 {
 	gainChance[0] = gainChance[1] = 0; //affects CHeroClassHandler::afterLoadFinalization()
 	levels.resize(NSecondarySkill::levels.size() - 1);
@@ -142,6 +138,31 @@ DLL_LINKAGE std::ostream & operator<<(std::ostream & out, const CSkill & skill)
 	return out << "]";
 }
 
+bool CSkill::isWisdom() const
+{
+	return hasTag("wisdom");
+}
+
+bool CSkill::isSpellSchool() const
+{
+	return hasTag("spellSchool");
+}
+
+bool CSkill::isSpecial() const
+{
+	return hasTag("special");
+}
+
+bool CSkill::isOnlyOnWaterMap() const
+{
+	return hasTag("onlyOnWaterMap");
+}
+
+bool CSkill::hasTag(const std::string & tag) const
+{
+	return vstd::contains(tags, tag);
+}
+
 std::string CSkill::toString() const
 {
 	std::ostringstream ss;
@@ -210,16 +231,24 @@ std::shared_ptr<CSkill> CSkillHandler::loadFromJson(const std::string & scope, c
 {
 	assert(identifier.find(':') == std::string::npos);
 	assert(!scope.empty());
-	bool major;
-	bool minor;
-
-	major = json["obligatoryMajor"].Bool();
-	minor = json["obligatoryMinor"].Bool();
-	auto skill = std::make_shared<CSkill>(SecondarySkill(index), identifier, major, minor);
+	auto skill = std::make_shared<CSkill>(SecondarySkill(index), identifier);
 	skill->modScope = scope;
 
-	skill->onlyOnWaterMap = json["onlyOnWaterMap"].Bool();
-	skill->special = json["special"].Bool();
+	for (const auto & tag : json["tags"].Struct())
+		if (tag.second.Bool())
+			skill->tags.push_back(tag.first);
+
+	if (json["onlyOnWaterMap"].Bool() && !vstd::contains(skill->tags, "onlyOnWaterMap"))
+		skill->tags.push_back("onlyOnWaterMap");
+
+	if (json["special"].Bool() && !vstd::contains(skill->tags, "special"))
+		skill->tags.push_back("special");
+
+	if (json["obligatoryMajor"].Bool() && !vstd::contains(skill->tags, "wisdom"))
+		skill->tags.push_back("wisdom");
+
+	if (json["obligatoryMinor"].Bool() && !vstd::contains(skill->tags, "spellSchool"))
+		skill->tags.push_back("spellSchool");
 
 	LIBRARY->generaltexth->registerString(scope, skill->getNameTextID(), json["name"]);
 
@@ -328,7 +357,7 @@ std::set<SecondarySkill> CSkillHandler::getDefaultAllowed() const
 	std::set<SecondarySkill> result;
 
 	for (auto const & skill : objects)
-		if (!skill->special)
+		if (!skill->isSpecial())
 			result.insert(skill->getId());
 
 	return result;

--- a/lib/CSkillHandler.h
+++ b/lib/CSkillHandler.h
@@ -42,7 +42,7 @@ private:
 	std::string identifier;
 
 public:
-	CSkill(const SecondarySkill & id = SecondarySkill::NONE, std::string identifier = "default", bool obligatoryMajor = false, bool obligatoryMinor = false);
+	CSkill(const SecondarySkill & id = SecondarySkill::NONE, std::string identifier = "default");
 	~CSkill() = default;
 
 	enum class Obligatory : ui8
@@ -68,7 +68,11 @@ public:
 	LevelInfo & at(int level);
 
 	std::string toString() const;
-	bool obligatory(Obligatory val) const { return val == Obligatory::MAJOR ? obligatoryMajor : obligatoryMinor; };
+	bool isWisdom() const;
+	bool isSpellSchool() const;
+	bool isSpecial() const;
+	bool isOnlyOnWaterMap() const;
+	bool hasTag(const std::string & tag) const;
 
 	std::array<si32, 2> gainChance; // gainChance[0/1] = default gain chance on level-up for might/magic heroes
 
@@ -78,15 +82,11 @@ public:
 	void updateFrom(const JsonNode & data);
 	void serializeJson(JsonSerializeFormat & handler);
 
-	bool onlyOnWaterMap;
-	bool special;
-
 	friend class CSkillHandler;
 	friend DLL_LINKAGE std::ostream & operator<<(std::ostream & out, const CSkill & skill);
 	friend DLL_LINKAGE std::ostream & operator<<(std::ostream & out, const CSkill::LevelInfo & info);
 private:
-	bool obligatoryMajor;
-	bool obligatoryMinor;
+	std::vector<std::string> tags;
 };
 
 class DLL_LINKAGE CSkillHandler: public CHandlerBase<SecondarySkill, Skill, CSkill, SkillService>

--- a/lib/callback/GameRandomizer.cpp
+++ b/lib/callback/GameRandomizer.cpp
@@ -264,37 +264,30 @@ SecondarySkill GameRandomizer::rollSecondarySkillForLevelup(const CGHeroInstance
 
 	auto & heroRng = heroSkillSeed.at(hero->getHeroTypeID());
 
-	auto getObligatorySkills = [](CSkill::Obligatory obl)
+	auto getObligatorySkills = [&options](bool magicSchools)
 	{
 		std::set<SecondarySkill> obligatory;
-		for(auto i = 0; i < LIBRARY->skillh->size(); i++)
-			if((*LIBRARY->skillh)[SecondarySkill(i)]->obligatory(obl))
-				obligatory.insert(i); //Always return all obligatory skills
+		for(const auto option : options)
+			if(magicSchools ? option.toSkill()->isSpellSchool() : option.toSkill()->isWisdom())
+				obligatory.insert(option); //Always return all obligatory skills
 
 		return obligatory;
 	};
 
-	auto intersect = [](const std::set<SecondarySkill> & left, const std::set<SecondarySkill> & right)
-	{
-		std::set<SecondarySkill> intersection;
-		std::set_intersection(left.begin(), left.end(), right.begin(), right.end(), std::inserter(intersection, intersection.begin()));
-		return intersection;
-	};
-
-	std::set<SecondarySkill> wisdomList = getObligatorySkills(CSkill::Obligatory::MAJOR);
-	std::set<SecondarySkill> schoolList = getObligatorySkills(CSkill::Obligatory::MINOR);
+	std::set<SecondarySkill> wisdomList = getObligatorySkills(true);
+	std::set<SecondarySkill> schoolList = getObligatorySkills(false);
 
 	bool wantsWisdom = heroRng.wisdomCounter >= hero->maxlevelsToWisdom();
 	bool wantsSchool = heroRng.magicSchoolCounter >= hero->maxlevelsToMagicSchool();
-	bool selectWisdom = wantsWisdom && !intersect(options, wisdomList).empty();
-	bool selectSchool = wantsSchool && !intersect(options, schoolList).empty();
+	bool selectWisdom = wantsWisdom && !wisdomList.empty();
+	bool selectSchool = wantsSchool && !schoolList.empty();
 
 	std::set<SecondarySkill> actualCandidates;
 
 	if(selectWisdom)
-		actualCandidates = intersect(options, wisdomList);
+		actualCandidates = wisdomList;
 	else if(selectSchool)
-		actualCandidates = intersect(options, schoolList);
+		actualCandidates = schoolList;
 	else
 		actualCandidates = options;
 
@@ -318,9 +311,9 @@ SecondarySkill GameRandomizer::rollSecondarySkillForLevelup(const CGHeroInstance
 	int selectedIndex = RandomGeneratorUtil::nextItemWeighted(weights, heroRng.seed);
 	SecondarySkill selectedSkill = skills.at(selectedIndex);
 
-	if((*LIBRARY->skillh)[selectedSkill]->obligatory(CSkill::Obligatory::MAJOR))
+	if((*LIBRARY->skillh)[selectedSkill]->isWisdom())
 		heroRng.wisdomCounter = 0;
-	if((*LIBRARY->skillh)[selectedSkill]->obligatory(CSkill::Obligatory::MINOR))
+	if((*LIBRARY->skillh)[selectedSkill]->isSpellSchool())
 		heroRng.magicSchoolCounter = 0;
 
 	return selectedSkill;

--- a/lib/json/JsonKeyExtractor.cpp
+++ b/lib/json/JsonKeyExtractor.cpp
@@ -1,11 +1,10 @@
 #include "StdInc.h"
 #include "JsonKeyExtractor.h"
 
-#include <entities/artifact/CArtHandler.h>
-
-#include <callback/IGameInfoCallback.h>
-
-#include <spells/CSpellHandler.h>
+#include "../entities/artifact/CArtHandler.h"
+#include "../callback/IGameInfoCallback.h"
+#include "../spells/CSpellHandler.h"
+#include "../CSkillHandler.h"
 
 VCMI_LIB_NAMESPACE_BEGIN
 
@@ -87,6 +86,26 @@ std::set<ArtifactID> JsonKeyExtractor::filterKeysTyped(const JsonNode & value, c
 	}
 	return result;
 }
+
+std::set<SecondarySkill> JsonKeyExtractor::filterKeysTyped(const JsonNode & value, const std::set<SecondarySkill> & valuesSet)
+{
+	std::set<SecondarySkill> result = valuesSet;
+
+	if(!value["tag"].isNull())
+	{
+		std::string requiredTag = value["tag"].String();
+
+		vstd::erase_if(
+			result,
+			[&requiredTag](const SecondarySkill & skill)
+			{
+				return skill.toSkill()->hasTag(requiredTag);
+			}
+			);
+	}
+	return result;
+}
+
 
 std::set<SpellID> JsonKeyExtractor::filterKeysTyped(const JsonNode & value, const std::set<SpellID> & valuesSet)
 {

--- a/lib/json/JsonKeyExtractor.h
+++ b/lib/json/JsonKeyExtractor.h
@@ -31,8 +31,8 @@ private:
 	std::set<IdentifierType> filterKeysTyped(const JsonNode & value, const std::set<IdentifierType> & valuesSet);
 
 	std::set<ArtifactID> filterKeysTyped(const JsonNode & value, const std::set<ArtifactID> & valuesSet);
-
 	std::set<SpellID> filterKeysTyped(const JsonNode & value, const std::set<SpellID> & valuesSet);
+	std::set<SecondarySkill> filterKeysTyped(const JsonNode & value, const std::set<SecondarySkill> & valuesSet);
 
 	IGameInfoCallback * cb;
 };

--- a/lib/json/JsonRandom.cpp
+++ b/lib/json/JsonRandom.cpp
@@ -159,7 +159,7 @@ SecondarySkill JsonRandom::loadSecondary(const JsonNode & value, const Variables
 {
 	std::set<SecondarySkill> defaultSkills;
 	for(const auto & skill : LIBRARY->skillh->objects)
-		if(cb->isAllowed(skill->getId()) && !skill->special)
+		if(cb->isAllowed(skill->getId()) && !skill->isSpecial())
 			defaultSkills.insert(skill->getId());
 
 	std::set<SecondarySkill> potentialPicks = jsonKeyExtractor.filterKeys(value, defaultSkills, variables);
@@ -181,7 +181,7 @@ std::map<SecondarySkill, si32> JsonRandom::loadSecondaries(const JsonNode & valu
 	{
 		std::set<SecondarySkill> defaultSkills;
 		for(const auto & skill : LIBRARY->skillh->objects)
-			if(cb->isAllowed(skill->getId()) && !skill->special)
+			if(cb->isAllowed(skill->getId()) && !skill->isSpecial())
 				defaultSkills.insert(skill->getId());
 
 		for(const auto & element : value.Vector())

--- a/lib/mapping/CMap.cpp
+++ b/lib/mapping/CMap.cpp
@@ -748,7 +748,7 @@ void CMap::banWaterSkills()
 {
 	vstd::erase_if(allowedAbilities, [&](SecondarySkill skill)
 	{
-		return skill.toSkill()->onlyOnWaterMap && !isWaterMap();
+		return skill.toSkill()->isOnlyOnWaterMap() && !isWaterMap();
 	});
 }
 


### PR DESCRIPTION
Allows defining custom tags for skills, and testing for them later when rolling for skills in randomization.

- Supersedes https://github.com/vcmi/vcmi/pull/6588

Existing flags were converted to tags.

List of predefined tags:
- `special` - skill is banned by default
- `onlyOnWaterMap` - skill is banned on random maps without water
- `wisdom` - for guaranteed rolls of Wisdom on levelup
- `spellSchool` - for guaranteed rolls of spell schools on levelup
- `bannedForUniversity` - to exclude skill from selection by University
- `bannedForWitchHut` - to exclude skill from selection by Witch Hut
- `bannedForScholar` - to exclude skill from selection by Scholar (unused in H3)