### PR TITLE
Remove STRONG_INLINE macro

### DIFF
--- a/AI/Nullkiller2/Pathfinding/AINodeStorage.h
+++ b/AI/Nullkiller2/Pathfinding/AINodeStorage.h
@@ -152,7 +152,7 @@ public:
 	explicit AISharedStorage(int3 sizes, int numChains, const CCallback & cc);
 	~AISharedStorage();
 
-	STRONG_INLINE
+	inline
 	boost::detail::multi_array::sub_array<AIPathNode, 1> get(int3 tile) const
 	{
 		return (*nodes)[tile.z][tile.x][tile.y];

--- a/Global.h
+++ b/Global.h
@@ -93,18 +93,6 @@ static_assert(sizeof(bool) == 1, "Bool needs to be 1 byte in size.");
 #  endif
 #endif
 
-/* ---------------------------------------------------------------------------- */
-/* A macro to force inlining some of our functions */
-/* ---------------------------------------------------------------------------- */
-// Compiler (at least MSVC) is not so smart here-> without that displaying is MUCH slower
-#ifdef _MSC_VER
-#  define STRONG_INLINE __forceinline
-#elif __GNUC__
-#  define STRONG_INLINE inline __attribute__((always_inline))
-#else
-#  define STRONG_INLINE inline
-#endif
-
 // Required for building boost::stacktrace on macOS.
 // See https://github.com/boostorg/stacktrace/issues/88
 #if defined(VCMI_APPLE)

--- a/client/renderSDL/SDL_Extensions.cpp
+++ b/client/renderSDL/SDL_Extensions.cpp
@@ -704,7 +704,7 @@ void CSDL_Ext::fillRectBlended( SDL_Surface *dst, const Rect & dstrect, const SD
 	SDL_FreeSurface(tmp);
 }
 
-STRONG_INLINE static uint32_t mapColor(SDL_Surface * surface, SDL_Color color)
+inline static uint32_t mapColor(SDL_Surface * surface, SDL_Color color)
 {
 	return SDL_MapRGBA(surface->format, color.r, color.g, color.b, color.a);
 }

--- a/client/renderSDL/SDL_PixelAccess.h
+++ b/client/renderSDL/SDL_PixelAccess.h
@@ -21,20 +21,20 @@ namespace Channels
 	// channel not present in this format
 	struct channel_empty
 	{
-		static STRONG_INLINE void set(uint8_t*, uint8_t) {}
-		static STRONG_INLINE uint8_t get(const uint8_t *) { return 255;}
+		static inline void set(uint8_t*, uint8_t) {}
+		static inline uint8_t get(const uint8_t *) { return 255;}
 	};
 
 	// channel which uses whole pixel
 	template<int offset>
 	struct channel_pixel
 	{
-		static STRONG_INLINE void set(uint8_t *ptr, uint8_t value)
+		static inline void set(uint8_t *ptr, uint8_t value)
 		{
 			ptr[offset] = value;
 		}
 
-		static STRONG_INLINE uint8_t get(const uint8_t *ptr)
+		static inline uint8_t get(const uint8_t *ptr)
 		{
 			return ptr[offset];
 		}
@@ -45,14 +45,14 @@ namespace Channels
 	struct channel_subpx
 	{
 
-		static void STRONG_INLINE set(uint8_t *ptr, uint8_t value)
+		static void inline set(uint8_t *ptr, uint8_t value)
 		{
 			auto * const pixel = (uint16_t *)ptr;
 			uint8_t subpx = value >> (8 - bits);
 			*pixel = (*pixel & ~mask) | ((subpx << shift) & mask );
 		}
 
-		static uint8_t STRONG_INLINE get(const uint8_t *ptr)
+		static uint8_t inline get(const uint8_t *ptr)
 		{
 			uint8_t subpx = (*((uint16_t *)ptr) & mask) >> shift;
 			return (subpx << (8 - bits)) | (subpx >> (2*bits - 8));
@@ -114,20 +114,20 @@ namespace Channels
 template<int bpp>
 struct ColorPutter
 {
-	static STRONG_INLINE void PutColor(uint8_t *&ptr, const uint8_t & R, const uint8_t & G, const uint8_t & B);
-	static STRONG_INLINE void PutColor(uint8_t *&ptr, const uint8_t & R, const uint8_t & G, const uint8_t & B, const uint8_t & A);
-	static STRONG_INLINE void PutColorAlphaSwitch(uint8_t *&ptr, const uint8_t & R, const uint8_t & G, const uint8_t & B, const uint8_t & A);
-	static STRONG_INLINE void PutColorAlpha(uint8_t *&ptr, const SDL_Color & Color);
+	static inline void PutColor(uint8_t *&ptr, const uint8_t & R, const uint8_t & G, const uint8_t & B);
+	static inline void PutColor(uint8_t *&ptr, const uint8_t & R, const uint8_t & G, const uint8_t & B, const uint8_t & A);
+	static inline void PutColorAlphaSwitch(uint8_t *&ptr, const uint8_t & R, const uint8_t & G, const uint8_t & B, const uint8_t & A);
+	static inline void PutColorAlpha(uint8_t *&ptr, const SDL_Color & Color);
 };
 
 template<int bpp>
-STRONG_INLINE void ColorPutter<bpp>::PutColorAlpha(uint8_t *&ptr, const SDL_Color & Color)
+inline void ColorPutter<bpp>::PutColorAlpha(uint8_t *&ptr, const SDL_Color & Color)
 {
 	PutColor(ptr, Color.r, Color.g, Color.b, Color.a);
 }
 
 template<int bpp>
-STRONG_INLINE void ColorPutter<bpp>::PutColorAlphaSwitch(uint8_t *&ptr, const uint8_t & R, const uint8_t & G, const uint8_t & B, const uint8_t & A)
+inline void ColorPutter<bpp>::PutColorAlphaSwitch(uint8_t *&ptr, const uint8_t & R, const uint8_t & G, const uint8_t & B, const uint8_t & A)
 {
 	switch (A)
 	{
@@ -149,7 +149,7 @@ STRONG_INLINE void ColorPutter<bpp>::PutColorAlphaSwitch(uint8_t *&ptr, const ui
 }
 
 template<int bpp>
-STRONG_INLINE void ColorPutter<bpp>::PutColor(uint8_t *&ptr, const uint8_t & R, const uint8_t & G, const uint8_t & B, const uint8_t & A)
+inline void ColorPutter<bpp>::PutColor(uint8_t *&ptr, const uint8_t & R, const uint8_t & G, const uint8_t & B, const uint8_t & A)
 {
 	PutColor(ptr, ((((uint32_t)R - (uint32_t)Channels::px<bpp>::r.get(ptr))*(uint32_t)A) >> 8 ) + (uint32_t)Channels::px<bpp>::r.get(ptr),
 				  ((((uint32_t)G - (uint32_t)Channels::px<bpp>::g.get(ptr))*(uint32_t)A) >> 8 ) + (uint32_t)Channels::px<bpp>::g.get(ptr),
@@ -157,7 +157,7 @@ STRONG_INLINE void ColorPutter<bpp>::PutColor(uint8_t *&ptr, const uint8_t & R, 
 }
 
 template<int bpp>
-STRONG_INLINE void ColorPutter<bpp>::PutColor(uint8_t *&ptr, const uint8_t & R, const uint8_t & G, const uint8_t & B)
+inline void ColorPutter<bpp>::PutColor(uint8_t *&ptr, const uint8_t & R, const uint8_t & G, const uint8_t & B)
 {
 	Channels::px<bpp>::r.set(ptr, R);
 	Channels::px<bpp>::g.set(ptr, G);

--- a/include/vcmi/events/SubscriptionRegistry.h
+++ b/include/vcmi/events/SubscriptionRegistry.h
@@ -93,7 +93,7 @@ private:
 		{
 		}
 
-		STRONG_INLINE
+		inline
 		void operator()(E & event)
 		{
 			handler(event);

--- a/lib/bonuses/BonusList.h
+++ b/lib/bonuses/BonusList.h
@@ -39,8 +39,8 @@ public:
 	bool empty() const { return bonuses.empty(); }
 	void resize(TInternalContainer::size_type sz, const std::shared_ptr<Bonus> & c = nullptr);
 	TInternalContainer::size_type capacity() const { return bonuses.capacity(); }
-	STRONG_INLINE std::shared_ptr<Bonus> &operator[] (TInternalContainer::size_type n) { return bonuses[n]; }
-	STRONG_INLINE const std::shared_ptr<Bonus> &operator[] (TInternalContainer::size_type n) const { return bonuses[n]; }
+	inline std::shared_ptr<Bonus> &operator[] (TInternalContainer::size_type n) { return bonuses[n]; }
+	inline const std::shared_ptr<Bonus> &operator[] (TInternalContainer::size_type n) const { return bonuses[n]; }
 	std::shared_ptr<Bonus> &back() { return bonuses.back(); }
 	std::shared_ptr<Bonus> &front() { return bonuses.front(); }
 	const std::shared_ptr<Bonus> &back() const { return bonuses.back(); }

--- a/lib/entities/building/CBuilding.h
+++ b/lib/entities/building/CBuilding.h
@@ -81,7 +81,7 @@ public:
 	// returns how many times build has to be upgraded to become build
 	si32 getDistance(const BuildingID & build) const;
 
-	STRONG_INLINE
+	inline
 		bool IsTradeBuilding() const
 	{
 		return !marketModes.empty();

--- a/lib/pathfinder/CGPathNode.h
+++ b/lib/pathfinder/CGPathNode.h
@@ -26,7 +26,7 @@ struct TerrainTile;
 template<typename N>
 struct DLL_LINKAGE NodeComparer
 {
-	STRONG_INLINE
+	inline
 	bool operator()(const N * lhs, const N * rhs) const
 	{
 		return lhs->getCost() > rhs->getCost();
@@ -85,7 +85,7 @@ struct DLL_LINKAGE CGPathNode
 		reset();
 	}
 
-	STRONG_INLINE
+	inline
 	void reset()
 	{
 		locked = false;
@@ -98,19 +98,19 @@ struct DLL_LINKAGE CGPathNode
 		action = EPathNodeAction::UNKNOWN;
 	}
 
-	STRONG_INLINE
+	inline
 	bool inPQ() const
 	{
 		return pq != nullptr;
 	}
 
-	STRONG_INLINE
+	inline
 	float getCost() const
 	{
 		return cost;
 	}
 
-	STRONG_INLINE
+	inline
 	void setCost(float value)
 	{
 		if(vstd::isAlmostEqual(value, cost))
@@ -132,7 +132,7 @@ struct DLL_LINKAGE CGPathNode
 		}
 	}
 
-	STRONG_INLINE
+	inline
 	void update(const int3 & Coord, const ELayer Layer, const EPathAccessibility Accessible)
 	{
 		if(layer == ELayer::WRONG)
@@ -148,7 +148,7 @@ struct DLL_LINKAGE CGPathNode
 		accessible = Accessible;
 	}
 
-	STRONG_INLINE
+	inline
 	bool reachable() const
 	{
 		return turns < 255;
@@ -211,13 +211,13 @@ struct DLL_LINKAGE CPathsInfo
 	const CGPathNode * getNode(const int3 & coord) const;
 
 	//FIXME: what is the non-const version used for? internal node storage should be modified via NodeStorage only
-	STRONG_INLINE
+	inline
 	CGPathNode * getNode(const int3 & coord, const ELayer layer)
 	{
 		return &nodes[layer.getNum()][coord.z][coord.x][coord.y];
 	}
 
-	STRONG_INLINE
+	inline
 	const CGPathNode * getNode(const int3 & coord, const ELayer layer) const
 	{
 		return &nodes[layer.getNum()][coord.z][coord.x][coord.y];

--- a/lib/pathfinder/CPathfinder.h
+++ b/lib/pathfinder/CPathfinder.h
@@ -60,10 +60,10 @@ private:
 
 	void initializeGraph();
 
-	STRONG_INLINE
+	inline
 	void push(CGPathNode * node);
 
-	STRONG_INLINE
+	inline
 	CGPathNode * topAndPop();
 };
 

--- a/lib/pathfinder/NodeStorage.h
+++ b/lib/pathfinder/NodeStorage.h
@@ -19,13 +19,13 @@ class DLL_LINKAGE NodeStorage : public INodeStorage
 private:
 	CPathsInfo & out;
 
-	STRONG_INLINE
+	inline
 	void resetTile(const int3 & tile, const EPathfindingLayer & layer, EPathAccessibility accessibility);
 
 public:
 	NodeStorage(CPathsInfo & pathsInfo, const CGHeroInstance * hero);
 
-	STRONG_INLINE
+	inline
 	CGPathNode * getNode(const int3 & coord, const EPathfindingLayer & layer)
 	{
 		return out.getNode(coord, layer);

--- a/luascript/LuaStack.h
+++ b/luascript/LuaStack.h
@@ -269,7 +269,7 @@ public:
 	}
 
 	template<typename T, typename std::enable_if_t<std::is_base_of_v<scripting::TagSerializable, T>, int> = 0>
-	STRONG_INLINE bool tryGet(int position, T & value)
+	inline bool tryGet(int position, T & value)
 	{
 		const auto & deserializer = [this, position]<typename Data>(const std::string &keyName, Data & data)
 		{
@@ -298,7 +298,7 @@ public:
 	}
 
 	template<typename T, typename std::enable_if_t<std::is_base_of_v<scripting::TagRawPointer, T> && std::is_const_v<T>, int> = 0>
-	STRONG_INLINE bool tryGet(int position, T * & value)
+	inline bool tryGet(int position, T * & value)
 	{
 		using DataType = T;
 		using BaseType = typename DataType::ScriptingApiName;
@@ -312,7 +312,7 @@ public:
 	}
 
 	template<typename T, typename std::enable_if_t<std::is_base_of_v<scripting::TagRawPointer, T> && !std::is_const_v<T>, int> = 0>
-	STRONG_INLINE bool tryGet(int position, T * & value)
+	inline bool tryGet(int position, T * & value)
 	{
 		using DataType = T;
 		using BaseType = typename DataType::ScriptingApiName;
@@ -325,7 +325,7 @@ public:
 	}
 
 	template<typename T, typename std::enable_if_t<std::is_base_of_v<scripting::TagSharedPointer, T> && std::is_const_v<T>, int> = 0>
-	STRONG_INLINE bool tryGet(int position, std::shared_ptr<T> & value)
+	inline bool tryGet(int position, std::shared_ptr<T> & value)
 	{
 		using DataType = T;
 		using BaseType = typename DataType::ScriptingApiName;
@@ -339,7 +339,7 @@ public:
 	}
 
 	template<typename T, typename std::enable_if_t<std::is_base_of_v<scripting::TagSharedPointer, T> && !std::is_const_v<T>, int> = 0>
-	STRONG_INLINE bool tryGet(int position, std::shared_ptr<T> & value)
+	inline bool tryGet(int position, std::shared_ptr<T> & value)
 	{
 		using DataType = T;
 		using BaseType = typename DataType::ScriptingApiName;
@@ -352,7 +352,7 @@ public:
 	}
 
 	template<typename T, typename std::enable_if_t<std::is_base_of_v<scripting::TagCopyable, T>, int> = 0>
-	STRONG_INLINE bool tryGet(int position, T & value)
+	inline bool tryGet(int position, T & value)
 	{
 		using DataType = T;
 		using BaseType = typename DataType::ScriptingApiName;
@@ -400,8 +400,7 @@ public:
 
 	int retVoid();
 
-	STRONG_INLINE
-	int retPushed()
+	inline int retPushed()
 	{
 		return lua_gettop(L);
 	}


### PR DESCRIPTION
Replaced all usage of STRONG_INLINE with simple inline

Reasoning: this is leftover from 10+ years ago when VCMI had a lot of custom blit routines and compilers were not smart enough to inline everything correctly. In all my tests on both msvc and gcc, inlining was more than reasonable (as long as function is defined in header)