### PR TITLE
[1.8.0] Add ability to extend Eagle eye with pre battle logic

### DIFF
--- a/AI/Nullkiller2/AIUtility.cpp
+++ b/AI/Nullkiller2/AIUtility.cpp
@@ -366,6 +366,8 @@ double getArtifactBonusRelevance(const CGHeroInstance * hero, const std::shared_
 			return hero->hasSpellbook() ? relevant : notRelevant;
 		case BonusType::LEARN_BATTLE_SPELL_CHANCE:
 			return hero->hasBonusOfType(BonusType::LEARN_BATTLE_SPELL_LEVEL_LIMIT) ? relevant : notRelevant;
+		case BonusType::LEARN_BATTLE_SPELL_CHANCE_PRE_BATTLE:
+			return hero->hasBonusOfType(BonusType::LEARN_BATTLE_SPELL_LEVEL_LIMIT_PRE_BATTLE) ? relevant : notRelevant;
 		case BonusType::NO_DISTANCE_PENALTY:
 		case BonusType::NO_WALL_PENALTY:
 			return getArmyPercentageWithBonus(BonusType::SHOOTER) * veryRelevant;
@@ -447,6 +449,8 @@ int32_t getArtifactBonusScoreImpl(const std::shared_ptr<Bonus> & bonus)
 		case BonusType::SIGHT_RADIUS:
 			return bonus->val * 1000;
 		case BonusType::LEARN_BATTLE_SPELL_CHANCE:
+			return 0; // irrelevant in gameplay
+		case BonusType::LEARN_BATTLE_SPELL_CHANCE_PRE_BATTLE:
 			return 0; // irrelevant in gameplay
 		case BonusType::STACK_HEALTH:
 			return bonus->val * 5000;

--- a/client/ClientNetPackVisitors.h
+++ b/client/ClientNetPackVisitors.h
@@ -64,6 +64,7 @@ public:
 	void visitNewStructures(NewStructures & pack) override;
 	void visitRazeStructures(RazeStructures & pack) override;
 	void visitSetAvailableCreatures(SetAvailableCreatures & pack) override;
+	void visitChangeSpells(ChangeSpells & pack) override;
 	void visitSetHeroesInTown(SetHeroesInTown & pack) override;
 	void visitHeroRecruited(HeroRecruited & pack) override;
 	void visitGiveHero(GiveHero & pack) override;

--- a/client/NetPacksClient.cpp
+++ b/client/NetPacksClient.cpp
@@ -117,6 +117,16 @@ void callBattleInterfaceIfPresentForBothSides(CClient & cl, const BattleID & bat
 	}
 }
 
+static void showEagleEyeLearnedSpellsDialog(CClient & cl, ObjectInstanceID heroId, const std::set<SpellID> & spells, PlayerColor player)
+{
+	if(spells.empty())
+		return;
+
+	const auto * hero = cl.gameInfo().getHero(heroId);
+	assert(hero);
+	callInterfaceIfPresent(cl, player, &CGameInterface::showInfoDialog, EInfoWindowMode::AUTO, UIHelper::getEagleEyeInfoWindowText(*hero, spells), UIHelper::getSpellsComponents(spells), soundBase::soundID(0));
+}
+
 void ApplyClientNetPackVisitor::visitSetResources(SetResources & pack)
 {
 	//todo: inform on actual resource set transferred
@@ -595,28 +605,10 @@ void ApplyClientNetPackVisitor::visitChangeSpells(ChangeSpells & pack)
 	if(!hero)
 		return;
 
-	bool heroInBattle = false;
-	for(const auto & battlePtr : gs.currentBattles)
-	{
-		if(!battlePtr)
-			continue;
-
-		const auto * attackerHero = battlePtr->battleGetFightingHero(BattleSide::ATTACKER);
-		const auto * defenderHero = battlePtr->battleGetFightingHero(BattleSide::DEFENDER);
-		if((attackerHero && attackerHero->id == pack.hid) || (defenderHero && defenderHero->id == pack.hid))
-		{
-			heroInBattle = true;
-			break;
-		}
-	}
-
-	if(!heroInBattle)
-		return;
-
 	if(hero->valOfBonuses(BonusType::LEARN_BATTLE_SPELL_CHANCE_PRE_BATTLE) <= 0)
 		return;
 
-	callInterfaceIfPresent(cl, hero->tempOwner, &CGameInterface::showInfoDialog, EInfoWindowMode::AUTO,	UIHelper::getEagleEyeInfoWindowText(*hero, pack.spells), UIHelper::getSpellsComponents(pack.spells), soundBase::soundID(0));
+	showEagleEyeLearnedSpellsDialog(cl, pack.hid, pack.spells, hero->tempOwner);
 }
 
 void ApplyClientNetPackVisitor::visitSetHeroesInTown(SetHeroesInTown & pack)
@@ -869,13 +861,7 @@ void ApplyClientNetPackVisitor::visitStacksInjured(StacksInjured & pack)
 
 void ApplyClientNetPackVisitor::visitBattleResultsApplied(BattleResultsApplied & pack)
 {
-	if(!pack.learnedSpells.spells.empty())
-	{
-		const auto * hero = cl.gameInfo().getHero(pack.learnedSpells.hid);
-		assert(hero);
-		callInterfaceIfPresent(cl, pack.victor, &CGameInterface::showInfoDialog, EInfoWindowMode::MODAL,
-			UIHelper::getEagleEyeInfoWindowText(*hero, pack.learnedSpells.spells), UIHelper::getSpellsComponents(pack.learnedSpells.spells), soundBase::soundID(0));
-	}
+	showEagleEyeLearnedSpellsDialog(cl, pack.learnedSpells.hid, pack.learnedSpells.spells, pack.victor);
 
 	if(!pack.movingArtifacts.empty())
 	{

--- a/client/NetPacksClient.cpp
+++ b/client/NetPacksClient.cpp
@@ -586,6 +586,39 @@ void ApplyClientNetPackVisitor::visitSetAvailableCreatures(SetAvailableCreatures
 	callInterfaceIfPresent(cl, p, &IGameEventsReceiver::availableCreaturesChanged, dw);
 }
 
+void ApplyClientNetPackVisitor::visitChangeSpells(ChangeSpells & pack)
+{
+	if(!pack.learn || pack.spells.empty())
+		return;
+
+	const auto * hero = cl.gameInfo().getHero(pack.hid);
+	if(!hero)
+		return;
+
+	bool heroInBattle = false;
+	for(const auto & battlePtr : gs.currentBattles)
+	{
+		if(!battlePtr)
+			continue;
+
+		const auto * attackerHero = battlePtr->battleGetFightingHero(BattleSide::ATTACKER);
+		const auto * defenderHero = battlePtr->battleGetFightingHero(BattleSide::DEFENDER);
+		if((attackerHero && attackerHero->id == pack.hid) || (defenderHero && defenderHero->id == pack.hid))
+		{
+			heroInBattle = true;
+			break;
+		}
+	}
+
+	if(!heroInBattle)
+		return;
+
+	if(hero->valOfBonuses(BonusType::LEARN_BATTLE_SPELL_CHANCE_PRE_BATTLE) <= 0)
+		return;
+
+	callInterfaceIfPresent(cl, hero->tempOwner, &CGameInterface::showInfoDialog, EInfoWindowMode::AUTO,	UIHelper::getEagleEyeInfoWindowText(*hero, pack.spells), UIHelper::getSpellsComponents(pack.spells), soundBase::soundID(0));
+}
+
 void ApplyClientNetPackVisitor::visitSetHeroesInTown(SetHeroesInTown & pack)
 {
 	const CGTownInstance * t = gs.getTown(pack.tid);

--- a/config/bonuses.json
+++ b/config/bonuses.json
@@ -269,7 +269,19 @@
 		"blockDescriptionPropagation": true
 	},
 
+	"LEARN_BATTLE_SPELL_CHANCE_PRE_BATTLE":
+	{
+		"hidden": true,
+		"blockDescriptionPropagation": true
+	},
+
 	"LEARN_BATTLE_SPELL_LEVEL_LIMIT":
+	{
+		"hidden": true,
+		"blockDescriptionPropagation": true
+	},
+
+	"LEARN_BATTLE_SPELL_LEVEL_LIMIT_PRE_BATTLE":
 	{
 		"hidden": true,
 		"blockDescriptionPropagation": true

--- a/docs/modders/Bonus/Bonus_Types.md
+++ b/docs/modders/Bonus/Bonus_Types.md
@@ -233,6 +233,18 @@ Allows affected heroes to learn spell cast by enemy hero after battle
 
 - val: maximal level of spell that can be learned
 
+### LEARN_BATTLE_SPELL_CHANCE_PRE_BATTLE
+
+Determines chance for affected heroes to learn spells from enemy hero spellbook at battle start (before first turn)
+
+- val: chance to learn each spell, percentage
+
+### LEARN_BATTLE_SPELL_LEVEL_LIMIT_PRE_BATTLE
+
+Allows affected heroes to learn spells from enemy hero spellbook at battle start (before first turn)
+
+- val: maximal level of spell that can be learned
+
 ### LEARN_MEETING_SPELL_LIMIT
 
 Allows affected heroes to learn spells from each other during hero exchange

--- a/lib/bonuses/BonusEnum.h
+++ b/lib/bonuses/BonusEnum.h
@@ -204,6 +204,7 @@ class JsonNode;
 	BONUS_NAME(DEITYOFFIRE) /* Controls special week */ \
 	BONUS_NAME(ON_COMBAT_EVENT) /* Allows triggering various effects on combat events */ \
 	BONUS_NAME(LONG_WEAPON) /* melee attack from one hex away (attacker-empty-victim), without retaliation */ \
+	BONUS_NAME(SPELL_CAST_COUNTER)  /*used to keep count how many times a particular spells has been cast*/ \
 	BONUS_NAME(LEARN_BATTLE_SPELL_CHANCE_PRE_BATTLE) /*skill-agnostic eagle eye chance to learn enemy hero spells at battle start*/\
 	BONUS_NAME(LEARN_BATTLE_SPELL_LEVEL_LIMIT_PRE_BATTLE) /*skill-agnostic eagle eye spell level limit to learn enemy hero spells at battle start*/\
 

--- a/lib/bonuses/BonusEnum.h
+++ b/lib/bonuses/BonusEnum.h
@@ -204,7 +204,9 @@ class JsonNode;
 	BONUS_NAME(DEITYOFFIRE) /* Controls special week */ \
 	BONUS_NAME(ON_COMBAT_EVENT) /* Allows triggering various effects on combat events */ \
 	BONUS_NAME(LONG_WEAPON) /* melee attack from one hex away (attacker-empty-victim), without retaliation */ \
-	BONUS_NAME(SPELL_CAST_COUNTER)  /*used to keep count how many times a particular spells has been cast*/ \
+	BONUS_NAME(LEARN_BATTLE_SPELL_CHANCE_PRE_BATTLE) /*skill-agnostic eagle eye chance to learn enemy hero spells at battle start*/\
+	BONUS_NAME(LEARN_BATTLE_SPELL_LEVEL_LIMIT_PRE_BATTLE) /*skill-agnostic eagle eye spell level limit to learn enemy hero spells at battle start*/\
+
 	/* end of list */
 
 #define BONUS_SOURCE_LIST \


### PR DESCRIPTION
Added **LEARN_BATTLE_SPELL_CHANCE_PRE_BATTLE** + **LEARN_BATTLE_SPELL_LEVEL_LIMIT_PRE_BATTLE** bonuses to allow extending Eagle Eye skill with pre battle spells learning.

This is how to extend skill to be able to learn spells from defender at battle begining.

	"eagleEye" : {
		"index" : 11,
		"specialty" : [
			"main",
			"preBattle"
		],
		"base" : {
			"effects" : {
				"main" : {
					"type" : "LEARN_BATTLE_SPELL_CHANCE",
					"valueType" : "BASE_NUMBER"
				},
				"preBattle" : {
					"type" : "LEARN_BATTLE_SPELL_CHANCE_PRE_BATTLE",
					"valueType" : "BASE_NUMBER"
				},
				"preBattleLevel" : {
					"type" : "LEARN_BATTLE_SPELL_LEVEL_LIMIT_PRE_BATTLE",
					"valueType" : "BASE_NUMBER"
				},
				"val2" : {
					"type" : "LEARN_BATTLE_SPELL_LEVEL_LIMIT",
					"valueType" : "BASE_NUMBER"
				}
			}
		},
		"basic" : {
			"effects" : {
				"main" : { "val" : 40 },
				"preBattle" : { "val" : 30 },
				"preBattleLevel" : { "val" : 3 },
				"val2" : { "val" : 2 }
			}
		},
		"advanced" : {
			"effects" : {
				"main" : { "val" : 50 },
				"preBattle" : { "val" : 40 },
				"preBattleLevel" : { "val" : 4 },
				"val2" : { "val" : 3 }
			}
		},
		"expert" : {
			"effects" : {
				"main" : { "val" : 60 },
				"preBattle" : { "val" : 50 },
				"preBattleLevel" : { "val" : 5 },
				"val2" : { "val" : 4 }
			}
		}
	}