### PR TITLE
Modify additional attack description in Chinese

### DIFF
--- a/Mods/vcmi/Content/config/translations/chinese.json
+++ b/Mods/vcmi/Content/config/translations/chinese.json
@@ -1,6 +1,6 @@
 {
 	"artifact.core.orbOfVulnerability.bonus.noResistance": "{毁灭之球}\n消除战场上所有生物的魔法抗性",
-	"core.bonus.ADDITIONAL_ATTACK.description": "{双击}\n生物可以攻击两次",
+	"core.bonus.ADDITIONAL_ATTACK.description": "{多次攻击}\n生物可以额外攻击${val}次",
 	"core.bonus.ADDITIONAL_RETALIATION.description": "{额外反击}\n每回合额外获得${val}次反击机会",
 	"core.bonus.ADJACENT_SPELLCASTER.description": "{毗邻施法}\n生物可在与目标相邻时施放${subtype.spell}",
 	"core.bonus.ALWAYS_MAXIMUM_DAMAGE.description": "{最大伤害}\n单位始终造成最大伤害",


### PR DESCRIPTION
The original Chinese text means the creature attacks twice. It always displays "twice" regardless of the val value. Updated to display text based on the val value.