### PR TITLE
[1.7.5 / 1.8.0 ] Small fixes

### DIFF
--- a/client/mainmenu/CHighScoreScreen.cpp
+++ b/client/mainmenu/CHighScoreScreen.cpp
@@ -197,7 +197,8 @@ void CHighScoreScreen::buttonExitClick()
 
 void CHighScoreScreen::showAll(Canvas & to)
 {
-	to.fillTexture(ENGINE->renderHandler().loadImage(ImagePath::builtin("DiBoxBck"), EImageBlitMode::OPAQUE));
+	const auto & bgConfig = CMainMenuConfig::get().getConfig()["backgroundAround"];
+	to.fillTexture(ENGINE->renderHandler().loadImage(bgConfig.isString() ? ImagePath::fromJson(bgConfig) : ImagePath::builtin("DIBOXBCK"), EImageBlitMode::OPAQUE));
 	CWindowObject::showAll(to);
 }
 

--- a/client/windows/CStackExperienceDetailsWindow.cpp
+++ b/client/windows/CStackExperienceDetailsWindow.cpp
@@ -118,9 +118,8 @@ int CStackWindow::StackExperienceDetailsWindow::calculateDynamicTableRowCount(co
 			uniqueBonuses.insert({bonus->type, bonus->subtype.getNum()});
 	}
 
-	const int minBonusRows = 1;
 	const int maxRowsWithoutHeader = 7; // keep dialog within 800x600
-	const int rowsWithoutHeader = std::clamp(1 + std::max(minBonusRows, static_cast<int>(uniqueBonuses.size())), 1, maxRowsWithoutHeader); // Experience + bonus rows
+	const int rowsWithoutHeader = std::clamp(1 + static_cast<int>(uniqueBonuses.size()), 1, maxRowsWithoutHeader); // Experience + bonus rows
 	return rowsWithoutHeader;
 }
 


### PR DESCRIPTION
1) Fixes main menu Highscore screen fill, now is respected **backgroundAround** from mainmenu.json on this screen too
2) Fixes visual glitch in Stack Experience Details, when creture don't have any bonuses assigned, no more 1 empty line