### PR TITLE
Display Gold as last resource in trade

### DIFF
--- a/client/widgets/markets/TradePanels.cpp
+++ b/client/widgets/markets/TradePanels.cpp
@@ -269,6 +269,14 @@ ResourcesPanel::ResourcesPanel(const CTradeableItem::ClickPressedFunctor & click
 
 	resourcesForTrade = LIBRARY->resourceTypeHandler->getAllObjects();
 
+	const auto goldIt = std::find(resourcesForTrade.begin(), resourcesForTrade.end(), GameResID::GOLD);
+	if(goldIt != resourcesForTrade.end())
+	{
+		const auto gold = *goldIt;
+		resourcesForTrade.erase(goldIt);
+		resourcesForTrade.push_back(gold);
+	}
+
 	int lines = vstd::divideAndCeil(resourcesForTrade.size(), 3);
 	if(lines > 3)
 	{


### PR DESCRIPTION
When using additional resources, they are added to end of list. After this tweak we will still view Gold as last resource in Marketplace

Before:
<img width="831" height="635" alt="image" src="https://github.com/user-attachments/assets/36b7c8d6-0e45-4aa3-9eb4-b40e9f1fda18" />

After:
<img width="825" height="631" alt="image" src="https://github.com/user-attachments/assets/846b0eed-5c60-4ce8-9f08-940d14e34f8a" />
