### PR TITLE
Add SURRENDER_MARKETPLACE_ACCESS bonus

### DIFF
--- a/Mods/vcmi/Content/config/translations/czech.json
+++ b/Mods/vcmi/Content/config/translations/czech.json
@@ -301,6 +301,8 @@
 	"vcmi.adventureOptions.smoothDragging.help": "{Plynulé posouvání mapy}\n\nPokud je tato možnost aktivována, posouvání mapy bude plynulé.",
 	"vcmi.adventureOptions.smoothDragging.hover": "Plynulé posouvání mapy",
 	"vcmi.artifact.charges": "Použití",
+	"vcmi.battle.surrender.marketplaceFailed": "Ani po návštěvě tržnice nemáš dost zlata na vykoupení bezpečného odchodu.",
+	"vcmi.battle.surrender.tryMarketplace": "Nemáš dost zlata na vykoupení bezpečného odchodu.\n\nNavštívit tržnici a směnit suroviny za zlato?",
 	"vcmi.battle.action.attack": "Použít útok zblízka",
 	"vcmi.battle.action.attackLongWeapon": "Použít útok dlouhou zbraní",
 	"vcmi.battle.action.genie": "Seslat náhodné podpůrné kouzlo",

--- a/Mods/vcmi/Content/config/translations/english.json
+++ b/Mods/vcmi/Content/config/translations/english.json
@@ -301,6 +301,8 @@
 	"vcmi.adventureOptions.smoothDragging.help": "{Smooth Map Dragging}\n\nWhen enabled, map dragging has a modern run out effect.",
 	"vcmi.adventureOptions.smoothDragging.hover": "Smooth Map Dragging",
 	"vcmi.artifact.charges": "Charges",
+	"vcmi.battle.surrender.marketplaceFailed": "Even after visiting the Marketplace, you do not have enough gold to purchase safe passage.",
+	"vcmi.battle.surrender.tryMarketplace": "You do not have enough gold to purchase safe passage.\n\nVisit the Marketplace to exchange resources for gold?",
 	"vcmi.battle.action.attack": "Use melee attack",
 	"vcmi.battle.action.attackLongWeapon": "Use Long Weapon attack",
 	"vcmi.battle.action.genie": "Cast random beneficial spell",

--- a/client/battle/BattleWindow.cpp
+++ b/client/battle/BattleWindow.cpp
@@ -632,6 +632,8 @@ const CGTownInstance * BattleWindow::findTownWithMarketplace() const
 
 bool BattleWindow::canOfferMarketplaceForSurrender() const
 {
+	// The feature can be granted either to the hero (e.g. artifact) or to the player
+	// (e.g. global/player-wide config bonus). Accept either source.
 	const CGHeroInstance * hero = owner.getBattle()->battleGetMyHero();
 	if(hero && hero->hasBonusOfType(BonusType::SURRENDER_MARKETPLACE_ACCESS))
 		return true;
@@ -649,15 +651,16 @@ void BattleWindow::offerMarketplaceForSurrender()
 		return;
 	}
 
+	const CGHeroInstance * hero = owner.getBattle()->battleGetMyHero();
 	const int goldBeforeMarketplace = owner.curInt->cb->getResourceAmount(EGameResID::GOLD);
 
 	owner.curInt->showYesNoDialog(
 		LIBRARY->generaltexth->translate("vcmi.battle.surrender.tryMarketplace"),
-		[this, townWithMarket, goldBeforeMarketplace]()
+		[this, townWithMarket, hero, goldBeforeMarketplace]()
 		{
 			ENGINE->windows().createAndPushWindow<CMarketWindow>(
 				townWithMarket,
-				nullptr,
+				hero,
 				[this, goldBeforeMarketplace]()
 				{
 					const bool soldResourcesForGold = owner.curInt->cb->getResourceAmount(EGameResID::GOLD) > goldBeforeMarketplace;

--- a/client/battle/BattleWindow.cpp
+++ b/client/battle/BattleWindow.cpp
@@ -35,6 +35,7 @@
 #include "../widgets/Buttons.h"
 #include "../widgets/Images.h"
 #include "../windows/CCreatureWindow.h"
+#include "../windows/CMarketWindow.h"
 #include "../windows/CMessage.h"
 #include "../windows/CSpellWindow.h"
 #include "../windows/settings/SettingsMainWindow.h"
@@ -45,6 +46,7 @@
 #include "../../lib/GameLibrary.h"
 #include "../../lib/StartInfo.h"
 #include "../../lib/battle/BattleInfo.h"
+#include "../../lib/bonuses/BonusEnum.h"
 #include "../../lib/battle/CPlayerBattleCallback.h"
 #include "../../lib/callback/CCallback.h"
 #include "../../lib/callback/CDynLibHandler.h"
@@ -54,6 +56,7 @@
 #include "../../lib/mapping/CMapHeader.h"
 #include "../../lib/mapObjects/CGHeroInstance.h"
 #include "../../lib/spells/CSpell.h"
+#include "../../lib/mapObjects/CGTownInstance.h"
 #include "../../lib/texts/CGeneralTextHandler.h"
 
 BattleWindow::BattleWindow(BattleInterface & Owner)
@@ -616,11 +619,67 @@ void BattleWindow::reallyFlee()
 	ENGINE->cursor().set(Cursor::Map::POINTER);
 }
 
-void BattleWindow::reallySurrender()
+const CGTownInstance * BattleWindow::findTownWithMarketplace() const
+{
+	for(const CGTownInstance * town : owner.curInt->cb->getTownsInfo())
+	{
+		if(town->hasBuilt(BuildingID::MARKETPLACE))
+			return town;
+	}
+
+	return nullptr;
+}
+
+bool BattleWindow::canOfferMarketplaceForSurrender() const
+{
+	const CGHeroInstance * hero = owner.getBattle()->battleGetMyHero();
+	if(hero && hero->hasBonusOfType(BonusType::SURRENDER_MARKETPLACE_ACCESS))
+		return true;
+
+	const PlayerState * playerState = owner.curInt->cb->getPlayerState(owner.curInt->playerID);
+	return playerState && playerState->hasBonusOfType(BonusType::SURRENDER_MARKETPLACE_ACCESS);
+}
+
+void BattleWindow::offerMarketplaceForSurrender()
+{
+	const CGTownInstance * townWithMarket = findTownWithMarketplace();
+	if(!townWithMarket)
+	{
+		owner.curInt->showInfoDialog(LIBRARY->generaltexth->allTexts[29]); //You don't have enough gold!
+		return;
+	}
+
+	const int goldBeforeMarketplace = owner.curInt->cb->getResourceAmount(EGameResID::GOLD);
+
+	owner.curInt->showYesNoDialog(
+		LIBRARY->generaltexth->translate("vcmi.battle.surrender.tryMarketplace"),
+		[this, townWithMarket, goldBeforeMarketplace]()
+		{
+			ENGINE->windows().createAndPushWindow<CMarketWindow>(
+				townWithMarket,
+				nullptr,
+				[this, goldBeforeMarketplace]()
+				{
+					const bool soldResourcesForGold = owner.curInt->cb->getResourceAmount(EGameResID::GOLD) > goldBeforeMarketplace;
+					reallySurrender(false, soldResourcesForGold);
+				},
+				EMarketMode::RESOURCE_RESOURCE,
+				true,
+				owner.curInt.get());
+		},
+		nullptr);
+}
+
+void BattleWindow::reallySurrender(bool allowMarketplaceOffer, bool marketplaceSaleFailed)
 {
 	if (owner.curInt->cb->getResourceAmount(EGameResID::GOLD) < owner.getBattle()->battleGetSurrenderCost())
 	{
-		owner.curInt->showInfoDialog(LIBRARY->generaltexth->allTexts[29]); //You don't have enough gold!
+		if(allowMarketplaceOffer && canOfferMarketplaceForSurrender())
+			offerMarketplaceForSurrender();
+		else if(marketplaceSaleFailed)
+			owner.curInt->showInfoDialog(LIBRARY->generaltexth->translate("vcmi.battle.surrender.marketplaceFailed"));
+		else
+			owner.curInt->showInfoDialog(LIBRARY->generaltexth->allTexts[29]); //You don't have enough gold!
 	}
 	else
 	{

--- a/client/battle/BattleWindow.cpp
+++ b/client/battle/BattleWindow.cpp
@@ -41,7 +41,6 @@
 #include "../windows/settings/SettingsMainWindow.h"
 
 #include "../../lib/CConfigHandler.h"
-#include "../../lib/CPlayerState.h"
 #include "../../lib/CStack.h"
 #include "../../lib/GameLibrary.h"
 #include "../../lib/StartInfo.h"
@@ -635,11 +634,7 @@ bool BattleWindow::canOfferMarketplaceForSurrender() const
 	// The feature can be granted either to the hero (e.g. artifact) or to the player
 	// (e.g. global/player-wide config bonus). Accept either source.
 	const CGHeroInstance * hero = owner.getBattle()->battleGetMyHero();
-	if(hero && hero->hasBonusOfType(BonusType::SURRENDER_MARKETPLACE_ACCESS))
-		return true;
-
-	const PlayerState * playerState = owner.curInt->cb->getPlayerState(owner.curInt->playerID);
-	return playerState && playerState->hasBonusOfType(BonusType::SURRENDER_MARKETPLACE_ACCESS);
+	return hero && hero->hasBonusOfType(BonusType::SURRENDER_MARKETPLACE_ACCESS);
 }
 
 void BattleWindow::offerMarketplaceForSurrender()

--- a/client/battle/BattleWindow.h
+++ b/client/battle/BattleWindow.h
@@ -16,6 +16,7 @@
 
 VCMI_LIB_NAMESPACE_BEGIN
 class CStack;
+class CGTownInstance;
 
 VCMI_LIB_NAMESPACE_END
 
@@ -65,7 +66,10 @@ class BattleWindow : public InterfaceObjectConfigurable
 
 	/// functions for handling actions after they were confirmed by popup window
 	void reallyFlee();
-	void reallySurrender();
+	void reallySurrender(bool allowMarketplaceOffer = true, bool marketplaceSaleFailed = false);
+	void offerMarketplaceForSurrender();
+	bool canOfferMarketplaceForSurrender() const;
+	const CGTownInstance * findTownWithMarketplace() const;
 	
 	void useSpellIfPossible(int slot);
 

--- a/client/widgets/markets/CArtifactsBuying.cpp
+++ b/client/widgets/markets/CArtifactsBuying.cpp
@@ -27,7 +27,7 @@
 
 CArtifactsBuying::CArtifactsBuying(const IMarket * market, const CGHeroInstance * hero, const std::string & title)
 	: CMarketBase(market, hero)
-	, CResourcesSelling([this](const std::shared_ptr<CTradeableItem> & heroSlot){CArtifactsBuying::onSlotClickPressed(heroSlot, bidTradePanel);})
+	, CResourcesSelling([this](const std::shared_ptr<CTradeableItem> & heroSlot){CArtifactsBuying::onSlotClickPressed(heroSlot, bidTradePanel);}, GAME->interface())
 {
 	OBJECT_CONSTRUCTION;
 

--- a/client/widgets/markets/CMarketBase.cpp
+++ b/client/widgets/markets/CMarketBase.cpp
@@ -191,16 +191,11 @@ CResourcesBuying::CResourcesBuying(const CTradeableItem::ClickPressedFunctor & c
 	labels.emplace_back(std::make_shared<CLabel>(445, 148, FONT_SMALL, ETextAlignment::CENTER, Colors::WHITE, LIBRARY->generaltexth->allTexts[168]));
 }
 
-CResourcesSelling::CResourcesSelling(const CTradeableItem::ClickPressedFunctor & clickPressedCallback, ResourceAmountGetter resourceAmountGetter)
-	: resourceAmountGetter(resourceAmountGetter)
+CResourcesSelling::CResourcesSelling(const CTradeableItem::ClickPressedFunctor & clickPressedCallback, CPlayerInterface * tradeInterface)
+	: tradeInterface(tradeInterface)
 {
 	OBJECT_CONSTRUCTION;
-
-	if(!this->resourceAmountGetter)
-		this->resourceAmountGetter = [](EGameResID resource)
-		{
-			return GAME->interface()->cb->getResourceAmount(resource);
-		};
+	assert(this->tradeInterface);
 
 	bidTradePanel = std::make_shared<ResourcesPanel>(clickPressedCallback, std::bind(&CResourcesSelling::updateSubtitles, this));
 	labels.emplace_back(std::make_shared<CLabel>(156, 148, FONT_SMALL, ETextAlignment::CENTER, Colors::WHITE, LIBRARY->generaltexth->allTexts[270]));
@@ -210,7 +205,7 @@ void CResourcesSelling::updateSubtitles() const
 {
 	if(bidTradePanel)
 		for(const auto & slot : bidTradePanel->slots)
-			slot->subtitle->setText(std::to_string(resourceAmountGetter(static_cast<EGameResID>(slot->serial))));
+			slot->subtitle->setText(std::to_string(tradeInterface->cb->getResourceAmount(static_cast<EGameResID>(slot->serial))));
 }
 
 CMarketSlider::CMarketSlider(const CSlider::SliderMovingFunctor & movingCallback)

--- a/client/widgets/markets/CMarketBase.cpp
+++ b/client/widgets/markets/CMarketBase.cpp
@@ -191,9 +191,16 @@ CResourcesBuying::CResourcesBuying(const CTradeableItem::ClickPressedFunctor & c
 	labels.emplace_back(std::make_shared<CLabel>(445, 148, FONT_SMALL, ETextAlignment::CENTER, Colors::WHITE, LIBRARY->generaltexth->allTexts[168]));
 }
 
-CResourcesSelling::CResourcesSelling(const CTradeableItem::ClickPressedFunctor & clickPressedCallback)
+CResourcesSelling::CResourcesSelling(const CTradeableItem::ClickPressedFunctor & clickPressedCallback, ResourceAmountGetter resourceAmountGetter)
+	: resourceAmountGetter(resourceAmountGetter)
 {
 	OBJECT_CONSTRUCTION;
+
+	if(!this->resourceAmountGetter)
+		this->resourceAmountGetter = [](EGameResID resource)
+		{
+			return GAME->interface()->cb->getResourceAmount(resource);
+		};
 
 	bidTradePanel = std::make_shared<ResourcesPanel>(clickPressedCallback, std::bind(&CResourcesSelling::updateSubtitles, this));
 	labels.emplace_back(std::make_shared<CLabel>(156, 148, FONT_SMALL, ETextAlignment::CENTER, Colors::WHITE, LIBRARY->generaltexth->allTexts[270]));
@@ -203,7 +210,7 @@ void CResourcesSelling::updateSubtitles() const
 {
 	if(bidTradePanel)
 		for(const auto & slot : bidTradePanel->slots)
-			slot->subtitle->setText(std::to_string(GAME->interface()->cb->getResourceAmount(static_cast<EGameResID>(slot->serial))));
+			slot->subtitle->setText(std::to_string(resourceAmountGetter(static_cast<EGameResID>(slot->serial))));
 }
 
 CMarketSlider::CMarketSlider(const CSlider::SliderMovingFunctor & movingCallback)

--- a/client/widgets/markets/CMarketBase.h
+++ b/client/widgets/markets/CMarketBase.h
@@ -95,8 +95,13 @@ public:
 class CResourcesSelling : virtual public CMarketBase
 {
 public:
-	explicit CResourcesSelling(const CTradeableItem::ClickPressedFunctor & clickPressedCallback);
+	using ResourceAmountGetter = std::function<int64_t(EGameResID)>;
+
+	explicit CResourcesSelling(const CTradeableItem::ClickPressedFunctor & clickPressedCallback, ResourceAmountGetter resourceAmountGetter = {});
 	void updateSubtitles() const;
+
+private:
+	ResourceAmountGetter resourceAmountGetter;
 };
 
 class CMarketSlider : virtual public CMarketBase

--- a/client/widgets/markets/CMarketBase.h
+++ b/client/widgets/markets/CMarketBase.h
@@ -20,6 +20,8 @@ class IMarket;
 
 VCMI_LIB_NAMESPACE_END
 
+class CPlayerInterface;
+
 class CMarketBase : public CIntObject
 {
 public:
@@ -95,13 +97,11 @@ public:
 class CResourcesSelling : virtual public CMarketBase
 {
 public:
-	using ResourceAmountGetter = std::function<int64_t(EGameResID)>;
-
-	explicit CResourcesSelling(const CTradeableItem::ClickPressedFunctor & clickPressedCallback, ResourceAmountGetter resourceAmountGetter = {});
+	explicit CResourcesSelling(const CTradeableItem::ClickPressedFunctor & clickPressedCallback, CPlayerInterface * tradeInterface);
 	void updateSubtitles() const;
 
 private:
-	ResourceAmountGetter resourceAmountGetter;
+	CPlayerInterface * tradeInterface;
 };
 
 class CMarketSlider : virtual public CMarketBase

--- a/client/widgets/markets/CMarketResources.cpp
+++ b/client/widgets/markets/CMarketResources.cpp
@@ -28,11 +28,7 @@ CMarketResources::CMarketResources(const IMarket * market, const CGHeroInstance 
 	: CMarketBase(market, hero)
 	, CResourcesSelling(
 		[this](const std::shared_ptr<CTradeableItem> & heroSlot){CMarketResources::onSlotClickPressed(heroSlot, bidTradePanel);},
-		[tradeInterface](EGameResID resource)
-		{
-			auto * interface = tradeInterface ? tradeInterface : GAME->interface();
-			return interface->cb->getResourceAmount(resource);
-		})
+		tradeInterface)
 	, CResourcesBuying(
 		[this](const std::shared_ptr<CTradeableItem> & resSlot){CMarketResources::onSlotClickPressed(resSlot, offerTradePanel);},
 		[this](){CMarketResources::updateSubtitles();})
@@ -57,9 +53,11 @@ CMarketResources::CMarketResources(const IMarket * market, const CGHeroInstance 
 	CMarketResources::deselect();
 }
 
+
 CPlayerInterface * CMarketResources::getTradeInterface() const
 {
-	return tradeInterface ? tradeInterface : GAME->interface();
+	assert(tradeInterface);
+	return tradeInterface;
 }
 
 void CMarketResources::deselect()

--- a/client/widgets/markets/CMarketResources.cpp
+++ b/client/widgets/markets/CMarketResources.cpp
@@ -24,13 +24,21 @@
 #include "../../../lib/mapObjects/IMarket.h"
 #include "../../../lib/GameLibrary.h"
 
-CMarketResources::CMarketResources(const IMarket * market, const CGHeroInstance * hero)
+CMarketResources::CMarketResources(const IMarket * market, const CGHeroInstance * hero, bool allowTradeWhenNotMakingTurn, CPlayerInterface * tradeInterface)
 	: CMarketBase(market, hero)
-	, CResourcesSelling([this](const std::shared_ptr<CTradeableItem> & heroSlot){CMarketResources::onSlotClickPressed(heroSlot, bidTradePanel);})
+	, CResourcesSelling(
+		[this](const std::shared_ptr<CTradeableItem> & heroSlot){CMarketResources::onSlotClickPressed(heroSlot, bidTradePanel);},
+		[tradeInterface](EGameResID resource)
+		{
+			auto * interface = tradeInterface ? tradeInterface : GAME->interface();
+			return interface->cb->getResourceAmount(resource);
+		})
 	, CResourcesBuying(
 		[this](const std::shared_ptr<CTradeableItem> & resSlot){CMarketResources::onSlotClickPressed(resSlot, offerTradePanel);},
 		[this](){CMarketResources::updateSubtitles();})
 	, CMarketSlider([this](int newVal){CMarketSlider::onOfferSliderMoved(newVal);})
+	, allowTradeWhenNotMakingTurn(allowTradeWhenNotMakingTurn)
+	, tradeInterface(tradeInterface)
 {
 	OBJECT_CONSTRUCTION;
 
@@ -49,6 +57,11 @@ CMarketResources::CMarketResources(const IMarket * market, const CGHeroInstance 
 	CMarketResources::deselect();
 }
 
+CPlayerInterface * CMarketResources::getTradeInterface() const
+{
+	return tradeInterface ? tradeInterface : GAME->interface();
+}
+
 void CMarketResources::deselect()
 {
 	CMarketBase::deselect();
@@ -60,7 +73,7 @@ void CMarketResources::makeDeal()
 {
 	if(auto toTrade = offerSlider->getValue(); toTrade != 0)
 	{
-		GAME->interface()->cb->trade(market->getObjInstanceID(), EMarketMode::RESOURCE_RESOURCE, GameResID(bidTradePanel->getHighlightedItemId()),
+		getTradeInterface()->cb->trade(market->getObjInstanceID(), EMarketMode::RESOURCE_RESOURCE, GameResID(bidTradePanel->getHighlightedItemId()),
 			GameResID(offerTradePanel->highlightedSlot->id), bidQty * toTrade, hero);
 		CMarketTraderText::makeDeal();
 		deselect();
@@ -84,12 +97,12 @@ void CMarketResources::highlightingChanged()
 	if(bidTradePanel->isHighlighted() && offerTradePanel->isHighlighted())
 	{
 		market->getOffer(bidTradePanel->getHighlightedItemId(), offerTradePanel->getHighlightedItemId(), bidQty, offerQty, EMarketMode::RESOURCE_RESOURCE);
-		offerSlider->setAmount(GAME->interface()->cb->getResourceAmount(GameResID(bidTradePanel->getHighlightedItemId())) / bidQty);
+		offerSlider->setAmount(getTradeInterface()->cb->getResourceAmount(GameResID(bidTradePanel->getHighlightedItemId())) / bidQty);
 		offerSlider->scrollTo(0);
 		const bool isControlsBlocked = bidTradePanel->getHighlightedItemId() != offerTradePanel->getHighlightedItemId() ? false : true;
 		offerSlider->block(isControlsBlocked);
 		maxAmount->block(isControlsBlocked);
-		deal->block(isControlsBlocked || !GAME->interface()->makingTurn);
+		deal->block(isControlsBlocked || (!getTradeInterface()->makingTurn && !allowTradeWhenNotMakingTurn));
 	}
 	CMarketBase::highlightingChanged();
 	CMarketTraderText::highlightingChanged();

--- a/client/widgets/markets/CMarketResources.h
+++ b/client/widgets/markets/CMarketResources.h
@@ -11,15 +11,21 @@
 
 #include "CMarketBase.h"
 
+class CPlayerInterface;
+
 class CMarketResources :
 	public CResourcesSelling, public CResourcesBuying, public CMarketSlider, public CMarketTraderText
 {
 public:
-	CMarketResources(const IMarket * market, const CGHeroInstance * hero);
+	CMarketResources(const IMarket * market, const CGHeroInstance * hero, bool allowTradeWhenNotMakingTurn = false, CPlayerInterface * tradeInterface = nullptr);
 	void deselect() override;
 	void makeDeal() override;
 
 private:
+	bool allowTradeWhenNotMakingTurn;
+	CPlayerInterface * tradeInterface;
+
+	CPlayerInterface * getTradeInterface() const;
 	CMarketBase::MarketShowcasesParams getShowcasesParams() const override;
 	void highlightingChanged() override;
 	void updateSubtitles();

--- a/client/widgets/markets/CMarketResources.h
+++ b/client/widgets/markets/CMarketResources.h
@@ -17,7 +17,7 @@ class CMarketResources :
 	public CResourcesSelling, public CResourcesBuying, public CMarketSlider, public CMarketTraderText
 {
 public:
-	CMarketResources(const IMarket * market, const CGHeroInstance * hero, bool allowTradeWhenNotMakingTurn = false, CPlayerInterface * tradeInterface = nullptr);
+	CMarketResources(const IMarket * market, const CGHeroInstance * hero, bool allowTradeWhenNotMakingTurn, CPlayerInterface * tradeInterface);
 	void deselect() override;
 	void makeDeal() override;
 

--- a/client/widgets/markets/CTransferResources.cpp
+++ b/client/widgets/markets/CTransferResources.cpp
@@ -27,7 +27,7 @@
 
 CTransferResources::CTransferResources(const IMarket * market, const CGHeroInstance * hero)
 	: CMarketBase(market, hero)
-	, CResourcesSelling([this](const std::shared_ptr<CTradeableItem> & heroSlot){CTransferResources::onSlotClickPressed(heroSlot, bidTradePanel);})
+	, CResourcesSelling([this](const std::shared_ptr<CTradeableItem> & heroSlot){CTransferResources::onSlotClickPressed(heroSlot, bidTradePanel);}, GAME->interface())
 	, CMarketSlider([this](int newVal){CMarketSlider::onOfferSliderMoved(newVal);})
 	, CMarketTraderText(Point(28, 48))
 {

--- a/client/windows/CMarketWindow.cpp
+++ b/client/windows/CMarketWindow.cpp
@@ -40,7 +40,7 @@ CMarketWindow::CMarketWindow(const IMarket * market, const CGHeroInstance * hero
 	: CWindowObject(PLAYER_COLORED)
 	, windowClosedCallback(onWindowClosed)
 	, allowResourceTradeWhenNotMakingTurn(allowResourceTradeWhenNotMakingTurn)
-	, resourceTradeInterface(resourceTradeInterface)
+	, resourceTradeInterface(resourceTradeInterface ? resourceTradeInterface : GAME->interface())
 {
 	assert(mode == EMarketMode::RESOURCE_RESOURCE || mode == EMarketMode::RESOURCE_PLAYER || mode == EMarketMode::CREATURE_RESOURCE ||
 		mode == EMarketMode::RESOURCE_ARTIFACT || mode == EMarketMode::ARTIFACT_RESOURCE || mode == EMarketMode::ARTIFACT_EXP ||
@@ -104,7 +104,6 @@ void CMarketWindow::close()
 	if(callback)
 		callback();
 }
-
 
 bool CMarketWindow::holdsGarrison(const CArmedInstance * army)
 {
@@ -254,8 +253,7 @@ void CMarketWindow::createMarketResources(const IMarket * market, const CGHeroIn
 	auto image = getImagePathBasedOnResources("TPMRKRES");
 
 	background = createBg(image, PLAYER_COLORED);
-	if(resourceTradeInterface)
-		background->setPlayerColor(resourceTradeInterface->playerID);
+	background->setPlayerColor(resourceTradeInterface->playerID);
 	marketWidget = std::make_shared<CMarketResources>(market, hero, allowResourceTradeWhenNotMakingTurn, resourceTradeInterface);
 	initWidgetInternals(EMarketMode::RESOURCE_RESOURCE, LIBRARY->generaltexth->zelp[600]);
 }

--- a/client/windows/CMarketWindow.cpp
+++ b/client/windows/CMarketWindow.cpp
@@ -36,9 +36,11 @@
 #include "../../lib/mapObjects/CGTownInstance.h"
 #include "../../lib/texts/CGeneralTextHandler.h"
 
-CMarketWindow::CMarketWindow(const IMarket * market, const CGHeroInstance * hero, const std::function<void()> & onWindowClosed, EMarketMode mode)
+CMarketWindow::CMarketWindow(const IMarket * market, const CGHeroInstance * hero, const std::function<void()> & onWindowClosed, EMarketMode mode, bool allowResourceTradeWhenNotMakingTurn, CPlayerInterface * resourceTradeInterface)
 	: CWindowObject(PLAYER_COLORED)
 	, windowClosedCallback(onWindowClosed)
+	, allowResourceTradeWhenNotMakingTurn(allowResourceTradeWhenNotMakingTurn)
+	, resourceTradeInterface(resourceTradeInterface)
 {
 	assert(mode == EMarketMode::RESOURCE_RESOURCE || mode == EMarketMode::RESOURCE_PLAYER || mode == EMarketMode::CREATURE_RESOURCE ||
 		mode == EMarketMode::RESOURCE_ARTIFACT || mode == EMarketMode::ARTIFACT_RESOURCE || mode == EMarketMode::ARTIFACT_EXP ||
@@ -93,11 +95,16 @@ void CMarketWindow::update()
 
 void CMarketWindow::close()
 {
-	if(windowClosedCallback)
-		windowClosedCallback();
+	// Detach the callback before closing: CWindowObject::close() can destroy this window,
+	// and the callback may reopen dialogs/windows, so it must run at most once after close.
+	auto callback = std::exchange(windowClosedCallback, nullptr);
 
 	CWindowObject::close();
+
+	if(callback)
+		callback();
 }
+
 
 bool CMarketWindow::holdsGarrison(const CArmedInstance * army)
 {
@@ -247,7 +254,9 @@ void CMarketWindow::createMarketResources(const IMarket * market, const CGHeroIn
 	auto image = getImagePathBasedOnResources("TPMRKRES");
 
 	background = createBg(image, PLAYER_COLORED);
-	marketWidget = std::make_shared<CMarketResources>(market, hero);
+	if(resourceTradeInterface)
+		background->setPlayerColor(resourceTradeInterface->playerID);
+	marketWidget = std::make_shared<CMarketResources>(market, hero, allowResourceTradeWhenNotMakingTurn, resourceTradeInterface);
 	initWidgetInternals(EMarketMode::RESOURCE_RESOURCE, LIBRARY->generaltexth->zelp[600]);
 }
 

--- a/client/windows/CMarketWindow.h
+++ b/client/windows/CMarketWindow.h
@@ -12,10 +12,12 @@
 #include "../widgets/markets/CMarketBase.h"
 #include "CWindowWithArtifacts.h"
 
+class CPlayerInterface;
+
 class CMarketWindow final : public CStatusbarWindow, public CWindowWithArtifacts, public IGarrisonHolder, public IMarketHolder
 {
 public:
-	CMarketWindow(const IMarket * market, const CGHeroInstance * hero, const std::function<void()> & onWindowClosed, EMarketMode mode);
+	CMarketWindow(const IMarket * market, const CGHeroInstance * hero, const std::function<void()> & onWindowClosed, EMarketMode mode, bool allowResourceTradeWhenNotMakingTurn = false, CPlayerInterface * resourceTradeInterface = nullptr);
 	void updateResources() override;
 	void updateArtifacts() override;
 	void updateGarrisons() override;
@@ -44,6 +46,8 @@ private:
 	std::vector<std::shared_ptr<CButton>> changeModeButtons;
 	std::shared_ptr<CButton> quitButton;
 	std::function<void()> windowClosedCallback;
+	bool allowResourceTradeWhenNotMakingTurn;
+	CPlayerInterface * resourceTradeInterface;
 	const Point quitButtonPos = Point(516, 520);
 	std::shared_ptr<CMarketBase> marketWidget;
 

--- a/config/bonuses.json
+++ b/config/bonuses.json
@@ -574,6 +574,11 @@
 	{
 		"blockDescriptionPropagation": true
 	},
+
+	"SURRENDER_MARKETPLACE_ACCESS":
+	{
+		"blockDescriptionPropagation": true
+	},
 	
 	"DEITYOFFIRE":
 	{

--- a/docs/modders/Bonus/Bonus_Types.md
+++ b/docs/modders/Bonus/Bonus_Types.md
@@ -1281,6 +1281,10 @@ Increases amount of counted marketplaces when trading in town. You may want to u
 
 - val: additional number of 'marketplaces' to reduce costs
 
+### SURRENDER_MARKETPLACE_ACCESS
+
+Allows affected hero or player to open a marketplace after failing to pay surrender cost, sell resources, and retry surrender payment. This can be granted by artifacts, global/per-hero game config bonuses, or other bonus sources.
+
 ### DEITYOFFIRE
 
 Enforce the "week of" to a special creature. If this bonus is existing multiple times, it's randomly selected from all bonus sources.

--- a/lib/bonuses/BonusEnum.h
+++ b/lib/bonuses/BonusEnum.h
@@ -207,6 +207,7 @@ class JsonNode;
 	BONUS_NAME(SPELL_CAST_COUNTER)  /*used to keep count how many times a particular spells has been cast*/ \
 	BONUS_NAME(LEARN_BATTLE_SPELL_CHANCE_PRE_BATTLE) /*skill-agnostic eagle eye chance to learn enemy hero spells at battle start*/\
 	BONUS_NAME(LEARN_BATTLE_SPELL_LEVEL_LIMIT_PRE_BATTLE) /*skill-agnostic eagle eye spell level limit to learn enemy hero spells at battle start*/\
+	BONUS_NAME(SURRENDER_MARKETPLACE_ACCESS) /*Allows hero to open marketplace when unable to pay surrender cost*/ \
 
 	/* end of list */
 

--- a/server/NetPacksServer.cpp
+++ b/server/NetPacksServer.cpp
@@ -25,6 +25,7 @@
 #include "../lib/gameState/CGameState.h"
 #include "../lib/battle/IBattleState.h"
 #include "../lib/battle/Unit.h"
+#include "../lib/bonuses/BonusEnum.h"
 #include "../lib/spells/ISpellMechanics.h"
 #include "../lib/spells/CSpell.h"
 
@@ -252,11 +253,23 @@ void ApplyGhNetPackVisitor::visitTradeOnMarketplace(TradeOnMarketplace & pack)
 	const CGHeroInstance * hero = gh.gameInfo().getHero(pack.heroId);
 	const auto * market = gh.gameState().getMarket(pack.marketId);
 
-	const bool resourceTradeDuringBattle = pack.mode == EMarketMode::RESOURCE_RESOURCE && std::dynamic_pointer_cast<CBattleQuery>(gh.queries->topQuery(pack.player));
+	const bool resourceTradeDuringBattle = pack.mode == EMarketMode::RESOURCE_RESOURCE
+		&& std::dynamic_pointer_cast<CBattleQuery>(gh.queries->topQuery(pack.player));
 
 	gh.throwIfWrongPlayer(connection, &pack);
-	if(!resourceTradeDuringBattle)
+	if(resourceTradeDuringBattle)
+	{
+		const PlayerState * playerState = gh.gameState().getPlayerState(pack.player);
+		const bool playerHasAccess = playerState && playerState->hasBonusOfType(BonusType::SURRENDER_MARKETPLACE_ACCESS);
+		const bool heroHasAccess = hero && hero->getOwner() == pack.player && hero->hasBonusOfType(BonusType::SURRENDER_MARKETPLACE_ACCESS);
+
+		if(!playerHasAccess && !heroHasAccess)
+			gh.throwAndComplain(connection, "Can not trade - no surrender marketplace access!");
+	}
+	else
+	{
 		gh.throwIfPlayerNotActive(connection, &pack);
+	}
 
 	if(!object)
 		gh.throwAndComplain(connection, "Invalid market object");

--- a/server/NetPacksServer.cpp
+++ b/server/NetPacksServer.cpp
@@ -17,6 +17,7 @@
 #include "processors/TurnOrderProcessor.h"
 #include "queries/QueriesProcessor.h"
 #include "queries/MapQueries.h"
+#include "queries/BattleQueries.h"
 
 #include "../lib/CPlayerState.h"
 #include "../lib/mapObjects/CGTownInstance.h"
@@ -251,8 +252,11 @@ void ApplyGhNetPackVisitor::visitTradeOnMarketplace(TradeOnMarketplace & pack)
 	const CGHeroInstance * hero = gh.gameInfo().getHero(pack.heroId);
 	const auto * market = gh.gameState().getMarket(pack.marketId);
 
+	const bool resourceTradeDuringBattle = pack.mode == EMarketMode::RESOURCE_RESOURCE && std::dynamic_pointer_cast<CBattleQuery>(gh.queries->topQuery(pack.player));
+
 	gh.throwIfWrongPlayer(connection, &pack);
-	gh.throwIfPlayerNotActive(connection, &pack);
+	if(!resourceTradeDuringBattle)
+		gh.throwIfPlayerNotActive(connection, &pack);
 
 	if(!object)
 		gh.throwAndComplain(connection, "Invalid market object");

--- a/server/NetPacksServer.cpp
+++ b/server/NetPacksServer.cpp
@@ -259,11 +259,9 @@ void ApplyGhNetPackVisitor::visitTradeOnMarketplace(TradeOnMarketplace & pack)
 	gh.throwIfWrongPlayer(connection, &pack);
 	if(resourceTradeDuringBattle)
 	{
-		const PlayerState * playerState = gh.gameState().getPlayerState(pack.player);
-		const bool playerHasAccess = playerState && playerState->hasBonusOfType(BonusType::SURRENDER_MARKETPLACE_ACCESS);
 		const bool heroHasAccess = hero && hero->getOwner() == pack.player && hero->hasBonusOfType(BonusType::SURRENDER_MARKETPLACE_ACCESS);
 
-		if(!playerHasAccess && !heroHasAccess)
+		if(!heroHasAccess)
 			gh.throwAndComplain(connection, "Can not trade - no surrender marketplace access!");
 	}
 	else

--- a/server/queries/BattleQueries.cpp
+++ b/server/queries/BattleQueries.cpp
@@ -56,6 +56,9 @@ bool CBattleQuery::blocksPack(const CPackForServer * pack) const
 	if(dynamic_cast<const GamePause*>(pack) != nullptr)
 		return false;
 
+	if(const auto * trade = dynamic_cast<const TradeOnMarketplace *>(pack); trade && trade->mode == EMarketMode::RESOURCE_RESOURCE)
+		return false;
+
 	return true;
 }
 


### PR DESCRIPTION
Added new bonus SURRENDER_MARKETPLACE_ACCESS to allow open marketplace when player don't have enough gold to pay to leave battle.

Can be easily tested by placing this into gameConfig perHero or global section. With this approach we can easily assing this bonus to everyone like game settings or put that bonus to building or artifacts.

"marketSurrender" :
{
	"type" : "SURRENDER_MARKETPLACE_ACCESS"
}

<img width="1279" height="893" alt="image" src="https://github.com/user-attachments/assets/0b939b2f-1f44-463e-b48a-e2e03961f403" />
<img width="1283" height="897" alt="image" src="https://github.com/user-attachments/assets/3b538ca5-f017-4134-8c51-f414b641d97a" />
<img width="1281" height="895" alt="image" src="https://github.com/user-attachments/assets/8393f5f7-ef9f-4f53-8490-ba9668da776f" />

<img width="1281" height="897" alt="image" src="https://github.com/user-attachments/assets/36921c70-4338-42a7-8a3c-26523cf67078" />
Or
<img width="1281" height="899" alt="image" src="https://github.com/user-attachments/assets/64f6607a-b20e-4e3a-b2c9-c02ee3ab5d2f" />
Or
<img width="1280" height="897" alt="image" src="https://github.com/user-attachments/assets/dbae464f-7955-4a68-ae77-5a9e25d9bfdd" />
