### PR TITLE
#7407 Prevent AI from dragging boats onto land in CGameHandler

### DIFF
--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -872,9 +872,8 @@ bool CGameHandler::moveHero(ObjectInstanceID hid, int3 dst, EMovementMode moveme
 	}
 
 	const bool embarking = !h->inBoat() && objectToVisit && objectToVisit->ID == Obj::BOAT;
-	const bool disembarking = h->inBoat()
-		&& t.isLand()
-		&& layer == EPathfindingLayer::LAND
+	const bool disembarking =
+		h->inBoat() && t.isLand() && (layer == EPathfindingLayer::LAND || h->getBoat()->layer == EPathfindingLayer::SAIL)
 		&& (dst == h->pos || ((h->getBoat()->layer == EPathfindingLayer::SAIL || h->getBoat()->layer == EPathfindingLayer::AVIATE) && !t.blocked()));
 
 	//result structure for start - movement failed, no move points used

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -872,9 +872,28 @@ bool CGameHandler::moveHero(ObjectInstanceID hid, int3 dst, EMovementMode moveme
 	}
 
 	const bool embarking = !h->inBoat() && objectToVisit && objectToVisit->ID == Obj::BOAT;
-	const bool disembarking =
-		h->inBoat() && t.isLand() && (layer == EPathfindingLayer::LAND || h->getBoat()->layer == EPathfindingLayer::SAIL)
-		&& (dst == h->pos || ((h->getBoat()->layer == EPathfindingLayer::SAIL || h->getBoat()->layer == EPathfindingLayer::AVIATE) && !t.blocked()));
+
+	bool disembarking = false;
+
+	if(h->inBoat() && t.isLand())
+	{
+		const auto * boat = h->getBoat();
+
+		// AI pathfinder may incorrectly keep the WATER layer when moving to land.
+		// Normal boats cannot fly, so moving to land MUST be a disembark action.
+		// Airships fly over land, so they rely solely on the explicit LAND layer request.
+		const bool isExplicitDisembark = (layer == EPathfindingLayer::LAND);
+		const bool isForcedBoatDisembark = (boat->layer == EPathfindingLayer::SAIL);
+		const bool hasDisembarkIntent = isExplicitDisembark || isForcedBoatDisembark;
+
+		// Ensure the destination tile is physically valid for the current vehicle
+		const bool isStayingInPlace = (dst == h->pos);
+		const bool isValidVehicleType = (boat->layer == EPathfindingLayer::SAIL || boat->layer == EPathfindingLayer::AVIATE);
+		const bool isDestinationFree = !t.blocked();
+		const bool isValidDestination = isStayingInPlace || (isValidVehicleType && isDestinationFree);
+
+		disembarking = hasDisembarkIntent && isValidDestination;
+	}
 
 	//result structure for start - movement failed, no move points used
 	TryMoveHero tmh;


### PR DESCRIPTION
### Description
This PR fixes the Issue #7407 where AI heroes could move from water to land while still mounted in a boat, causing boat entity stuck on land.

### Root Cause
1. **AI Logic Issue**: The AI pathfinder and its layer transition rules do not treat "disembarking" as a forced waypoint. Consequently, when the AI pathfinder plans a cross-boundary move, it often submits movement requests to the server with the incorrect pathfinding layer.
2. **Server-side Vulnerability**: The server-side logic in CGameHandler.cpp relied strictly on the layer parameter provided by the client. If the layer parameter was WATER, the server failed to detect the disembarking action and treated it as a standard movement, allowing the boat entity to physically move onto a land tile.

### Solution
I implemented a physical fallback check in CGameHandler.cpp. 
- Regardless of the layer parameter passed by the sender, if the object is a SAIL boat and the target tile is LAND, the server now **forcefully treats it as a disembarking action**.
- This ensures the boat is correctly unmounted at the shore and the movement points are properly deducted, fully respecting the game's original physical rules and artifacts (e.g. Navigator's Hat).

### Verification
- Tested with an AI that previously triggered the deadlock.
- The AI now correctly leaves the boat at the shore when entering land.
- State machine remains consistent; no deadlock occurs.

Fixes #7407