### PR TITLE
Fix Nullkiller AI failing to explore isolated map layers via teleports

### DIFF
--- a/AI/Nullkiller2/Behaviors/ExplorationBehavior.cpp
+++ b/AI/Nullkiller2/Behaviors/ExplorationBehavior.cpp
@@ -54,10 +54,10 @@ Goals::TGoalVec ExplorationBehavior::decompose(const Nullkiller * aiNk) const
 			case Obj::SUBTERRANEAN_GATE:
 			case Obj::WHIRLPOOL:
 			{
-				const auto tObj = dynamic_cast<const CGTeleport *>(obj);
-				for(auto exit : aiNk->cc->getTeleportChannelExits(tObj->channel))
+				const auto tObj = dynamic_cast<const CGTeleport*>(obj);
+				for (auto exit : aiNk->cc->getTeleportChannelExits(tObj->channel))
 				{
-					if(exit != tObj->id)
+					if (exit != tObj->id)
 					{
 						const CGObjectInstance * exitObj = aiNk->cc->getObjInstance(exit);
 

--- a/AI/Nullkiller2/Behaviors/ExplorationBehavior.cpp
+++ b/AI/Nullkiller2/Behaviors/ExplorationBehavior.cpp
@@ -18,7 +18,6 @@
 #include "../Goals/CaptureObject.h"
 #include "../Goals/ExploreNeighbourTile.h"
 #include "../Helpers/ExplorationHelper.h"
-#include "../../../lib/CPlayerState.h"
 
 namespace NK2AI
 {
@@ -60,19 +59,9 @@ Goals::TGoalVec ExplorationBehavior::decompose(const Nullkiller * aiNk) const
 				{
 					if(exit != tObj->id)
 					{
-						bool isExplored = false;
 						const CGObjectInstance * exitObj = aiNk->cc->getObjInstance(exit);
 
-						if(exitObj)
-						{
-							const auto teamState = aiNk->cc->getPlayerTeam(aiNk->playerID);
-							if(teamState && teamState->fogOfWarMap[exitObj->visitablePos()])
-							{
-								isExplored = true;
-							}
-						}
-
-						if(!isExplored)
+						if(exitObj && !aiNk->cc->isVisible(exitObj->visitablePos()))
 						{
 							tasks.push_back(sptr(Composition().addNext(ExplorationPoint(obj->visitablePos(), 50)).addNext(CaptureObject(obj))));
 						}

--- a/AI/Nullkiller2/Behaviors/ExplorationBehavior.cpp
+++ b/AI/Nullkiller2/Behaviors/ExplorationBehavior.cpp
@@ -18,6 +18,7 @@
 #include "../Goals/CaptureObject.h"
 #include "../Goals/ExploreNeighbourTile.h"
 #include "../Helpers/ExplorationHelper.h"
+#include "../../../lib/CPlayerState.h"
 
 namespace NK2AI
 {
@@ -54,16 +55,30 @@ Goals::TGoalVec ExplorationBehavior::decompose(const Nullkiller * aiNk) const
 			case Obj::SUBTERRANEAN_GATE:
 			case Obj::WHIRLPOOL:
 			{
-				const auto tObj = dynamic_cast<const CGTeleport*>(obj);
-				for (auto exit : aiNk->cc->getTeleportChannelExits(tObj->channel))
+				const auto tObj = dynamic_cast<const CGTeleport *>(obj);
+				for(auto exit : aiNk->cc->getTeleportChannelExits(tObj->channel))
 				{
-					if (exit != tObj->id)
+					if(exit != tObj->id)
 					{
-						// TODO: Mircea: Looks like a bug. Should use isVisibleFor with aiNk->playerID
-						if (!aiNk->cc->isVisible(aiNk->cc->getObjInstance(exit)))
+						bool isExplored = false;
+						const CGObjectInstance * exitObj = aiNk->cc->getObjInstance(exit);
+
+						if(exitObj)
+						{
+							const auto teamState = aiNk->cc->getPlayerTeam(aiNk->playerID);
+							if(teamState && teamState->fogOfWarMap[exitObj->visitablePos()])
+							{
+								isExplored = true;
+							}
+						}
+
+						if(!isExplored)
+						{
 							tasks.push_back(sptr(Composition().addNext(ExplorationPoint(obj->visitablePos(), 50)).addNext(CaptureObject(obj))));
+						}
 					}
 				}
+				break;
 			}
 		}
 	}

--- a/AI/Nullkiller2/Behaviors/ExplorationBehavior.cpp
+++ b/AI/Nullkiller2/Behaviors/ExplorationBehavior.cpp
@@ -8,16 +8,16 @@
 *
 */
 #include "StdInc.h"
-#include "ExplorationBehavior.h"
 #include "../AIGateway.h"
 #include "../AIUtility.h"
-#include "../Goals/Invalid.h"
+#include "../Goals/CaptureObject.h"
 #include "../Goals/Composition.h"
 #include "../Goals/ExecuteHeroChain.h"
-#include "../Markers/ExplorationPoint.h"
-#include "../Goals/CaptureObject.h"
 #include "../Goals/ExploreNeighbourTile.h"
+#include "../Goals/Invalid.h"
 #include "../Helpers/ExplorationHelper.h"
+#include "../Markers/ExplorationPoint.h"
+#include "ExplorationBehavior.h"
 
 namespace NK2AI
 {
@@ -33,19 +33,19 @@ Goals::TGoalVec ExplorationBehavior::decompose(const Nullkiller * aiNk) const
 {
 	Goals::TGoalVec tasks;
 
-	for (const ObjectInstanceID objId : aiNk->memory->visitableObjs)
+	for(const ObjectInstanceID objId : aiNk->memory->visitableObjs)
 	{
 		const CGObjectInstance * obj = aiNk->cc->getObjInstance(objId);
 		if(!obj)
 			continue;
 
-		switch (obj->ID.num)
+		switch(obj->ID.num)
 		{
 			case Obj::REDWOOD_OBSERVATORY:
 			case Obj::PILLAR_OF_FIRE:
 			{
-				auto rObj = dynamic_cast<const CRewardableObject*>(obj);
-				if (!rObj->wasScouted(aiNk->playerID))
+				auto rObj = dynamic_cast<const CRewardableObject *>(obj);
+				if(!rObj->wasScouted(aiNk->playerID))
 					tasks.push_back(sptr(Composition().addNext(ExplorationPoint(obj->visitablePos(), 200)).addNext(CaptureObject(obj))));
 				break;
 			}
@@ -54,13 +54,15 @@ Goals::TGoalVec ExplorationBehavior::decompose(const Nullkiller * aiNk) const
 			case Obj::SUBTERRANEAN_GATE:
 			case Obj::WHIRLPOOL:
 			{
-				const auto tObj = dynamic_cast<const CGTeleport*>(obj);
-				for (auto exit : aiNk->cc->getTeleportChannelExits(tObj->channel))
+				const auto tObj = dynamic_cast<const CGTeleport *>(obj);
+				for(auto exit : aiNk->cc->getTeleportChannelExits(tObj->channel))
 				{
-					if (exit != tObj->id)
+					if(exit != tObj->id)
 					{
 						const CGObjectInstance * exitObj = aiNk->cc->getObjInstance(exit);
 
+						// Please check for visible tile and not the visible object due to possible partial visibility
+						// checking the object itself might incorrectly abort the exploration of the fog behind it
 						if(exitObj && !aiNk->cc->isVisible(exitObj->visitablePos()))
 						{
 							tasks.push_back(sptr(Composition().addNext(ExplorationPoint(obj->visitablePos(), 50)).addNext(CaptureObject(obj))));

--- a/AI/Nullkiller2/Engine/PriorityEvaluator.cpp
+++ b/AI/Nullkiller2/Engine/PriorityEvaluator.cpp
@@ -819,7 +819,14 @@ public:
 		if(evaluationContext.evaluator.aiNk->cc->getTile(task->tile)->roadType != RoadId::NO_ROAD)
 			evaluationContext.explorePriority = 1;
 		if(evaluationContext.explorePriority == 0)
-			evaluationContext.explorePriority = 3;
+		{
+			if(tilesDiscovered >= 20)
+				evaluationContext.explorePriority = 1;
+			else if(tilesDiscovered >= 10)
+				evaluationContext.explorePriority = 2;
+			else
+				evaluationContext.explorePriority = 3;
+		}
 	}
 };
 


### PR DESCRIPTION
## Description
This PR fixes a issue where the Nullkiller AI refuses to use Subterranean Gates or Monoliths to explore completely undiscovered map layers. Previously, in maps where layers are isolated and only connected by only one or a few teleports, the AI would idle indefinitely in its home layer instead of exploring the new layer.

## Root Cause
The issue was caused by a combination of two flaws in the AI's exploration logic:

* **Task Generation in ExplorationBehavior.cpp :** A pending TODO left in the code used isVisible() to check if the teleport exit was explored. Since the physical exit object exists globally, this check misfired, tricking the AI into believing the exit was already explored even when it was covered by Fog of War. Thus, the cross-layer exploration task was never generated.

* **Priority Evaluation in PriorityEvaluator.cpp :** General exploration tasks defaulted to a low priority tier as explorePriority = 3. Due to the AI's heavy distance penalty formula, the score for traveling to a distant gate decayed so much that the AI preferred executing trivial, low-yield tasks like passing units around over exploring a new map layer.

## Changes Made

* **AI/Nullkiller2/Behaviors/ExplorationBehavior.cpp:** Replaced the flawed isVisible check with a proper Fog of War check using teamState->fogOfWarMap. The AI can now correctly detect if a teleport exit is shrouded in black fog.

* **AI/Nullkiller2/Evaluators/PriorityEvaluator.cpp:** Updated ExplorePointEvaluator to dynamically assign exploration priority based on the potential tilesDiscovered. Massive unexplored areas like crossing into a new map layer now correctly yield the highest priority, creating the necessary momentum for the AI to cross over and aggressively explore.

## Testing
Tested using the save file provided in #7410.

> **Before:** The AI idled in the subterranean layer for 20+ in-game months without ever using the gate.

> **After:** The AI correctly identifies the massive unexplored area beyond the gate, prioritizes the exploration task, and successfully defeats player within nearly a dozen turns if the player keeps doing nothing.

## Related Issues
Fixes #7410