### PR TITLE
Save game logic improvement

### DIFF
--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -81,7 +81,6 @@
 #include "../lib/StartInfo.h"
 #include "../lib/TerrainHandler.h"
 #include "../lib/UnlockGuard.h"
-#include "../lib/VCMIDirs.h"
 
 #include "../lib/battle/CPlayerBattleCallback.h"
 
@@ -118,8 +117,6 @@
 
 #include "../lib/filesystem/Filesystem.h"
 
-#include <boost/lexical_cast.hpp>
-
 // The macro below is used to mark functions that are called by client when game state changes.
 // They all assume that interface mutex is locked.
 #define EVENT_HANDLER_CALLED_BY_CLIENT
@@ -127,6 +124,21 @@
 #define BATTLE_EVENT_POSSIBLE_RETURN	if (GAME->interface() != this) return; if (isAutoFightOn && !battleInt) return
 
 std::shared_ptr<BattleInterface> CPlayerInterface::battleInt;
+
+static size_t autosaveIndexWidth(int autosaveCountLimit)
+{
+	return std::max<size_t>(3, std::to_string(autosaveCountLimit).size());
+}
+
+static std::string autosaveIndex(int index, int autosaveCountLimit)
+{
+	std::string number = std::to_string(index);
+	const size_t width = autosaveIndexWidth(autosaveCountLimit);
+	if(number.size() < width)
+		number.insert(0, width - number.size(), '0');
+
+	return number;
+}
 
 CPlayerInterface::CPlayerInterface(PlayerColor Player):
 	localState(std::make_unique<PlayerLocalState>(*this)),
@@ -143,7 +155,6 @@ CPlayerInterface::CPlayerInterface(PlayerColor Player):
 	makingTurn = false;
 	showingDialog = new ConditionalWait();
 	cingconsole = new CInGameConsole();
-	autosaveCount = 0;
 	isAutoFightOn = false;
 	isAutoFightEndBattle = false;
 	ignoreEvents = false;
@@ -278,14 +289,9 @@ void CPlayerInterface::performAutosave()
 			}
 		}
 
-		autosaveCount++;
-
 		int autosaveCountLimit = settings["general"]["autosaveCountLimit"].Integer();
 		if(autosaveCountLimit > 0)
-		{
-			cb->save("Saves/Autosave/" + prefix + std::to_string(autosaveCount), false);
-			autosaveCount %= autosaveCountLimit;
-		}
+			cb->save("Saves/Autosave/" + prefix + autosaveIndex(1, autosaveCountLimit), false, autosaveCountLimit);
 		else
 		{
 			std::string stringifiedDate = std::to_string(cb->getDate(Date::MONTH))
@@ -1518,37 +1524,6 @@ void CPlayerInterface::update()
 void CPlayerInterface::endNetwork()
 {
 	showingDialog->requestTermination();
-}
-
-int CPlayerInterface::getLastIndex( std::string namePrefix)
-{
-	using namespace boost::filesystem;
-	using namespace boost::algorithm;
-
-	path gamesDir = VCMIDirs::get().userSavePath();
-	std::map<std::time_t, int> dates; //save number => datestamp
-
-	const directory_iterator enddir;
-	if (!exists(gamesDir))
-		create_directory(gamesDir);
-	else
-	for (directory_iterator dir(gamesDir); dir != enddir; ++dir)
-	{
-		if (is_regular_file(dir->status()))
-		{
-			std::string name = dir->path().filename().string();
-			if (starts_with(name, namePrefix) && ends_with(name, ".vcgm1"))
-			{
-				char nr = name[namePrefix.size()];
-				if (std::isdigit(nr))
-					dates[last_write_time(dir->path())] = boost::lexical_cast<int>(nr);
-			}
-		}
-	}
-
-	if (!dates.empty())
-		return (--dates.end())->second; //return latest file number
-	return 0;
 }
 
 void CPlayerInterface::gameOver(PlayerColor player, const EVictoryLossCheckResult & victoryLossCheckResult )

--- a/client/CPlayerInterface.h
+++ b/client/CPlayerInterface.h
@@ -62,8 +62,6 @@ namespace boost
 class CPlayerInterface : public CGameInterface
 {
 	bool ignoreEvents;
-	int autosaveCount;
-
 	const std::string QUICKSAVE_PATH = "Saves/Quicksave";
 
 	std::list<std::shared_ptr<CInfoWindow>> dialogs; //queue of dialogs awaiting to be shown (not currently shown!)
@@ -246,5 +244,4 @@ private:
 	void requestReturningToMainMenu(bool won);
 	void acceptTurn(QueryID queryID, bool hotseatWait); //used during hot seat after your turn message is close
 	void initializeHeroTownList();
-	int getLastIndex(std::string namePrefix);
 };

--- a/lib/callback/CCallback.cpp
+++ b/lib/callback/CCallback.cpp
@@ -317,9 +317,9 @@ void CCallback::saveLocalState(const JsonNode & data)
 	sendRequest(state);
 }
 
-void CCallback::save( const std::string &fname, bool notifySuccess )
+void CCallback::save( const std::string &fname, bool notifySuccess, int autosaveCountLimit )
 {
-	SaveGame save_game(fname, notifySuccess);
+	SaveGame save_game(fname, notifySuccess, autosaveCountLimit);
 	sendRequest(save_game);
 }
 

--- a/lib/callback/CCallback.h
+++ b/lib/callback/CCallback.h
@@ -79,7 +79,7 @@ public:
 	void setTactics(const CGHeroInstance * hero, bool enabled) override;
 	void setTownName(const CGTownInstance * town, std::string & name) override;
 	void recruitHero(const CGObjectInstance *townOrTavern, const CGHeroInstance *hero, const HeroTypeID & nextHero=HeroTypeID::NONE) override;
-	void save(const std::string &fname, bool notifySuccess) override;
+	void save(const std::string &fname, bool notifySuccess, int autosaveCountLimit = 0) override;
 	void sendMessage(const std::string &mess, const CGObjectInstance * currentObject = nullptr) override;
 	void gamePause(bool pause) override;
 	void buildBoat(const IShipyard *obj) override;

--- a/lib/callback/IGameActionCallback.h
+++ b/lib/callback/IGameActionCallback.h
@@ -73,7 +73,7 @@ public:
 	virtual void setTactics(const CGHeroInstance * hero, bool enabled)=0;
 	virtual void setTownName(const CGTownInstance * town, std::string & name)=0;
 
-	virtual void save(const std::string &fname, bool notifySuccess) = 0;
+	virtual void save(const std::string &fname, bool notifySuccess, int autosaveCountLimit = 0) = 0;
 	virtual void sendMessage(const std::string &mess, const CGObjectInstance * currentObject = nullptr) = 0;
 	virtual void gamePause(bool pause) = 0;
 	virtual void buildBoat(const IShipyard *obj) = 0;

--- a/lib/networkPacks/PacksForServer.h
+++ b/lib/networkPacks/PacksForServer.h
@@ -766,13 +766,15 @@ struct DLL_LINKAGE RequestStatistic : public CPackForServer
 struct DLL_LINKAGE SaveGame : public CPackForServer
 {
 	SaveGame() = default;
-	SaveGame(std::string Fname, bool NotifySuccess)
+	SaveGame(std::string Fname, bool NotifySuccess, int AutosaveCountLimit = 0)
 		: fname(std::move(Fname))
 		, notifySuccess(NotifySuccess)
+		, autosaveCountLimit(AutosaveCountLimit)
 	{
 	}
 	std::string fname;
 	bool notifySuccess = false;
+	int autosaveCountLimit = 0;
 
 	void visitTyped(ICPackVisitor & visitor) override;
 
@@ -781,6 +783,7 @@ struct DLL_LINKAGE SaveGame : public CPackForServer
 		h & static_cast<CPackForServer &>(*this);
 		h & notifySuccess;
 		h & fname;
+		h & autosaveCountLimit;
 	}
 };
 

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -32,6 +32,7 @@
 #include "../lib/StartInfo.h"
 #include "../lib/TerrainHandler.h"
 #include "../lib/GameLibrary.h"
+#include "../lib/VCMIDirs.h"
 #include "../lib/int3.h"
 
 #include "../lib/battle/BattleInfo.h"
@@ -78,18 +79,169 @@
 
 #include "../lib/spells/CSpell.h"
 
+#include "../lib/texts/TextOperations.h"
+
 #include <vstd/RNG.h>
 #include <vstd/CLoggerBase.h>
 #include <vcmi/events/EventBus.h>
 #include <vcmi/events/GenericEvents.h>
 #include <vcmi/events/AdventureEvents.h>
 
+#include <boost/algorithm/string/predicate.hpp>
+#include <boost/filesystem.hpp>
 #include <boost/lexical_cast.hpp>
+#include <boost/system/error_code.hpp>
 
 #define COMPLAIN_RET_IF(cond, txt) do {if (cond){complain(txt); return;}} while(0)
 #define COMPLAIN_RET_FALSE_IF(cond, txt) do {if (cond){complain(txt); return false;}} while(0)
 #define COMPLAIN_RET(txt) {complain(txt); return false;}
 #define COMPLAIN_RETF(txt, FORMAT) {complain(boost::str(boost::format(txt) % FORMAT)); return false;}
+
+static constexpr const char * SAVES_MOUNT_POINT = "Saves/";
+
+static size_t autosaveIndexWidth(int autosaveCountLimit)
+{
+	return std::max<size_t>(3, std::to_string(autosaveCountLimit).size());
+}
+
+static std::string autosaveNameWithIndex(const std::string & filename, int index, int autosaveCountLimit)
+{
+	std::string number = std::to_string(index);
+	const size_t width = autosaveIndexWidth(autosaveCountLimit);
+	if(number.size() < width)
+		number.insert(0, width - number.size(), '0');
+
+	return filename.substr(0, filename.size() - width) + number;
+}
+
+static bool hasAutosaveIndex(const std::string & filename, int autosaveCountLimit)
+{
+	const size_t width = autosaveIndexWidth(autosaveCountLimit);
+	if(filename.size() < width)
+		return false;
+
+	return std::all_of(filename.end() - width, filename.end(), [](const char character)
+	{
+		return std::isdigit(static_cast<unsigned char>(character));
+	});
+}
+
+static bool autosaveIndexFromPath(const boost::filesystem::path & filePath, const std::string & stemPrefix, size_t width, int & index)
+{
+	if(!boost::iequals(filePath.extension().string(), ".vsgm1"))
+		return false;
+
+	const auto stem = filePath.stem().string();
+	if(!boost::starts_with(stem, stemPrefix))
+		return false;
+
+	const auto indexText = stem.substr(stemPrefix.size());
+	if(indexText.size() != width || !std::all_of(indexText.begin(), indexText.end(), [](const char character)
+	{
+		return std::isdigit(static_cast<unsigned char>(character));
+	}))
+		return false;
+
+	index = boost::lexical_cast<int>(indexText);
+	return true;
+}
+
+static std::set<int> existingAutosaveIndexes(const boost::filesystem::path & newestSave, int autosaveCountLimit)
+{
+	std::set<int> result;
+	boost::system::error_code error;
+	const auto autosaveDirectory = newestSave.parent_path();
+	if(!boost::filesystem::exists(autosaveDirectory, error))
+		return result;
+
+	if(error)
+	{
+		logGlobal->warn("Failed to check autosave directory %s: %s", autosaveDirectory.string(), error.message());
+		return result;
+	}
+
+	const auto newestStem = newestSave.stem().string();
+	const size_t width = autosaveIndexWidth(autosaveCountLimit);
+	if(newestStem.size() < width)
+		return result;
+
+	const auto stemPrefix = newestStem.substr(0, newestStem.size() - width);
+	for(boost::filesystem::directory_iterator entry(autosaveDirectory, error); !error && entry != boost::filesystem::directory_iterator(); entry.increment(error))
+	{
+		int index = 0;
+		if(autosaveIndexFromPath(entry->path(), stemPrefix, width, index))
+			result.insert(index);
+	}
+
+	if(error)
+		logGlobal->warn("Failed to scan autosave directory %s: %s", autosaveDirectory.string(), error.message());
+
+	return result;
+}
+
+static boost::filesystem::path savegamePath(const std::string & filename)
+{
+	ResourcePath savePath(filename, EResType::SAVEGAME);
+	std::string localFilename = savePath.getOriginalName() + ".vsgm1";
+
+	if(localFilename.size() > std::string(SAVES_MOUNT_POINT).size() && boost::istarts_with(localFilename, SAVES_MOUNT_POINT))
+		localFilename.erase(0, std::string(SAVES_MOUNT_POINT).size());
+
+	return VCMIDirs::get().userSavePath() / TextOperations::Utf8TofilesystemPath(localFilename);
+}
+
+static void refreshSavegameFilesystem()
+{
+	CResourceHandler::get("local")->updateFilteredFiles([](const std::string & mountPoint)
+	{
+		return boost::iequals(mountPoint, SAVES_MOUNT_POINT);
+	});
+}
+
+static void rotateAutosaves(const std::string & filename, int autosaveCountLimit)
+{
+	if(autosaveCountLimit <= 0)
+		return;
+
+	if(!hasAutosaveIndex(filename, autosaveCountLimit))
+	{
+		logGlobal->warn("Autosave rotation requested for unexpected save name %s", filename);
+		return;
+	}
+
+	boost::system::error_code error;
+	const auto newestSave = savegamePath(filename);
+	const auto existingIndexes = existingAutosaveIndexes(newestSave, autosaveCountLimit);
+
+	// Free the last allowed slot first. Then N-1 can be renamed to N, N-2 to N-1, etc.
+	if(existingIndexes.contains(autosaveCountLimit))
+	{
+		const auto oldestSave = savegamePath(autosaveNameWithIndex(filename, autosaveCountLimit, autosaveCountLimit));
+		boost::filesystem::remove(oldestSave, error);
+		if(error)
+		{
+			logGlobal->warn("Failed to remove old autosave %s: %s", oldestSave.string(), error.message());
+			error.clear();
+		}
+	}
+
+	for(int index = autosaveCountLimit - 1; index >= 1; --index)
+	{
+		if(!existingIndexes.contains(index))
+			continue;
+
+		const auto source = savegamePath(autosaveNameWithIndex(filename, index, autosaveCountLimit));
+		const auto target = savegamePath(autosaveNameWithIndex(filename, index + 1, autosaveCountLimit));
+		boost::filesystem::rename(source, target, error);
+		if(error)
+		{
+			logGlobal->warn("Failed to rotate autosave %s to %s: %s", source.string(), target.string(), error.message());
+			error.clear();
+		}
+	}
+
+	refreshSavegameFilesystem();
+}
 
 template <typename T>
 void callWith(std::vector<T> args, std::function<void(T)> fun, ui32 which)
@@ -1620,12 +1772,13 @@ bool CGameHandler::responseStatistic(PlayerColor player)
 	return true;
 }
 
-void CGameHandler::save(const std::string & filename, PlayerColor playerToNotifyOnSuccess)
+void CGameHandler::save(const std::string & filename, PlayerColor playerToNotifyOnSuccess, int autosaveCountLimit)
 {
 	logGlobal->info("Saving to %s", filename);
+	rotateAutosaves(filename, autosaveCountLimit);
 	ResourcePath savePath(filename, EResType::SAVEGAME);
 	const auto savefname = savePath.getOriginalName() + ".vsgm1";
-	CResourceHandler::get("local")->createResource(savefname);
+	CResourceHandler::get("local")->createResource(savefname, CResourceHandler::get("local")->existsResource(savePath));
 
 	std::string filenameWithoutPath;
 	auto pos = filename.find_last_of("/\\");

--- a/server/CGameHandler.h
+++ b/server/CGameHandler.h
@@ -232,7 +232,7 @@ public:
 	bool bulkMergeStacks(SlotID slotSrc, ObjectInstanceID srcOwner);
 	bool bulkSplitAndRebalanceStack(SlotID slotSrc, ObjectInstanceID srcOwner);
 	bool responseStatistic(PlayerColor player);
-	void save(const std::string &fname, PlayerColor playerToNotifyOnSuccess);
+	void save(const std::string &fname, PlayerColor playerToNotifyOnSuccess, int autosaveCountLimit = 0);
 	void load(const StartInfo &info);
 
 	void onPlayerTurnStarted(PlayerColor which);

--- a/server/NetPacksServer.cpp
+++ b/server/NetPacksServer.cpp
@@ -17,6 +17,7 @@
 #include "processors/TurnOrderProcessor.h"
 #include "queries/QueriesProcessor.h"
 #include "queries/MapQueries.h"
+#include "queries/BattleQueries.h"
 
 #include "../lib/CPlayerState.h"
 #include "../lib/mapObjects/CGTownInstance.h"
@@ -29,7 +30,7 @@
 
 void ApplyGhNetPackVisitor::visitSaveGame(SaveGame & pack)
 {
-	gh.save(pack.fname, pack.notifySuccess ? pack.player : PlayerColor::CANNOT_DETERMINE);
+	gh.save(pack.fname, pack.notifySuccess ? pack.player : PlayerColor::CANNOT_DETERMINE, pack.autosaveCountLimit);
 	logGlobal->info("Game has been saved as %s", pack.fname);
 	result = true;
 }
@@ -251,8 +252,11 @@ void ApplyGhNetPackVisitor::visitTradeOnMarketplace(TradeOnMarketplace & pack)
 	const CGHeroInstance * hero = gh.gameInfo().getHero(pack.heroId);
 	const auto * market = gh.gameState().getMarket(pack.marketId);
 
+	const bool resourceTradeDuringBattle = pack.mode == EMarketMode::RESOURCE_RESOURCE && std::dynamic_pointer_cast<CBattleQuery>(gh.queries->topQuery(pack.player));
+
 	gh.throwIfWrongPlayer(connection, &pack);
-	gh.throwIfPlayerNotActive(connection, &pack);
+	if(!resourceTradeDuringBattle)
+		gh.throwIfPlayerNotActive(connection, &pack);
 
 	if(!object)
 		gh.throwAndComplain(connection, "Invalid market object");

--- a/server/NetPacksServer.cpp
+++ b/server/NetPacksServer.cpp
@@ -17,7 +17,6 @@
 #include "processors/TurnOrderProcessor.h"
 #include "queries/QueriesProcessor.h"
 #include "queries/MapQueries.h"
-#include "queries/BattleQueries.h"
 
 #include "../lib/CPlayerState.h"
 #include "../lib/mapObjects/CGTownInstance.h"
@@ -252,11 +251,7 @@ void ApplyGhNetPackVisitor::visitTradeOnMarketplace(TradeOnMarketplace & pack)
 	const CGHeroInstance * hero = gh.gameInfo().getHero(pack.heroId);
 	const auto * market = gh.gameState().getMarket(pack.marketId);
 
-	const bool resourceTradeDuringBattle = pack.mode == EMarketMode::RESOURCE_RESOURCE && std::dynamic_pointer_cast<CBattleQuery>(gh.queries->topQuery(pack.player));
-
 	gh.throwIfWrongPlayer(connection, &pack);
-	if(!resourceTradeDuringBattle)
-		gh.throwIfPlayerNotActive(connection, &pack);
 
 	if(!object)
 		gh.throwAndComplain(connection, "Invalid market object");


### PR DESCRIPTION
Now are save games saved with 0 prefix and also rotated. Defaul 5 save games become 001 - 005, where newest save is always 001 and oldest 005. 

This PR also require testing on low-end devices. It's currently untested how fast will be for example 900 file renames. Will also test it soon on 20 years old laptop to see how it goes. Will also try some Android game session with compiled artifacts and unlimited saves.

<img width="830" height="636" alt="image" src="https://github.com/user-attachments/assets/69014824-f8dc-4f8a-9821-e036ab02460a" />