### PR TITLE
Fix Launcher screen handling

### DIFF
--- a/config/schemas/settings.json
+++ b/config/schemas/settings.json
@@ -782,9 +782,8 @@
 							"type" : "object",
 							"default" : {},
 							"additionalProperties" : false,
-							"required" : [ "valid", "x", "y", "width", "height" ],
+							"required" : [ "x", "y", "width", "height" ],
 							"properties" : {
-								"valid" : { "type" : "boolean", "default" : false },
 								"x" : { "type" : "integer", "default" : 0 },
 								"y" : { "type" : "integer", "default" : 0 },
 								"width" : { "type" : "integer", "default" : 0 },

--- a/config/schemas/settings.json
+++ b/config/schemas/settings.json
@@ -710,6 +710,7 @@
 			"default" : {},
 			"additionalProperties" : false,
 			"required" : [ 
+				"mainWindow",
 				"setupCompleted", 
 				"defaultRepositoryEnabled",
 				"defaultRepositoryURL",
@@ -770,6 +771,27 @@
 					"defaultAndroid": false,
 					"defaultDesktop" : true
 
+				},
+				"mainWindow" : {
+					"type" : "object",
+					"default" : {},
+					"additionalProperties" : false,
+					"required" : [ "geometry" ],
+					"properties" : {
+						"geometry" : {
+							"type" : "object",
+							"default" : {},
+							"additionalProperties" : false,
+							"required" : [ "valid", "x", "y", "width", "height" ],
+							"properties" : {
+								"valid" : { "type" : "boolean", "default" : false },
+								"x" : { "type" : "integer", "default" : 0 },
+								"y" : { "type" : "integer", "default" : 0 },
+								"width" : { "type" : "integer", "default" : 0 },
+								"height" : { "type" : "integer", "default" : 0 }
+							}
+						}
+					}
 				}
 			}
 		},

--- a/launcher/mainwindow_moc.cpp
+++ b/launcher/mainwindow_moc.cpp
@@ -21,8 +21,6 @@
 #include "../lib/texts/Languages.h"
 #include "../lib/ExceptionsCommon.h"
 
-#include "../vcmiqt/launcherdirs.h"
-
 #include "updatedialog_moc.h"
 #include "main.h"
 #include "helper.h"
@@ -91,6 +89,39 @@ MainWindow::MainWindow(QWidget * parent)
 
 	ui->setupUi(this);
 
+#ifndef VCMI_MOBILE
+	auto scheduleRelocateToRemainingScreen = [this](bool forceCenterOnRemainingScreen)
+	{
+		auto relocateToRemainingScreen = [this, forceCenterOnRemainingScreen]()
+		{
+			QScreen * targetScreen = nullptr;
+			if(forceCenterOnRemainingScreen)
+			{
+				const auto screens = QGuiApplication::screens();
+				targetScreen = QGuiApplication::primaryScreen();
+
+				if(targetScreen == nullptr || !screens.contains(targetScreen))
+					targetScreen = screens.isEmpty() ? nullptr : screens.front();
+			}
+
+			ensureWindowVisibleOnExistingScreen(forceCenterOnRemainingScreen, !forceCenterOnRemainingScreen, targetScreen);
+			saveWindowSettingsUnchecked();
+		};
+
+		QTimer::singleShot(250, this, relocateToRemainingScreen);
+	};
+
+	connect(qApp, &QGuiApplication::screenRemoved, this, [this, scheduleRelocateToRemainingScreen](QScreen * removedScreen)
+	{
+		const bool launcherWasOnRemovedScreen = removedScreen != nullptr && removedScreen->geometry().contains(frameGeometry().center());
+		scheduleRelocateToRemainingScreen(launcherWasOnRemovedScreen);
+	});
+	connect(qApp, &QGuiApplication::primaryScreenChanged, this, [scheduleRelocateToRemainingScreen](QScreen *)
+	{
+		scheduleRelocateToRemainingScreen(false);
+	});
+#endif
+
 	setAcceptDrops(true);
 
 	setWindowIcon(QIcon{":/icons/menu-game.png"});
@@ -100,24 +131,18 @@ MainWindow::MainWindow(QWidget * parent)
 	ui->startGameButton->setIcon(QIcon{":/icons/menu-game.png"});
 
 #ifndef VCMI_MOBILE
-
-	connect(qApp, &QGuiApplication::screenRemoved, this, [this](QScreen *)
-	{
-		QTimer::singleShot(0, this, &MainWindow::saveWindowSettings);
-	});
-
 	//load window settings
-	QSettings s = CLauncherDirs::getSettings(Ui::appName);
+	const auto & windowGeometry = settings["launcher"]["mainWindow"]["geometry"];
+	const bool hasSavedWindowGeometry = windowGeometry["valid"].Bool();
+	if(hasSavedWindowGeometry)
+	{
+		QSize windowSize(windowGeometry["width"].Integer(), windowGeometry["height"].Integer());
+		if(windowSize.isValid())
+			resize(windowSize);
 
-	auto size = s.value("MainWindow/WindowSize").toSize();
-	if(size.isValid())
-		resize(size);
-
-	if(const auto position = s.value("MainWindow/WindowPosition"); position.isValid())
-		move(position.toPoint());
-
-	ensureWindowVisibleOnExistingScreen();
-
+		move(windowGeometry["x"].Integer(), windowGeometry["y"].Integer());
+	}
+	ensureWindowVisibleOnExistingScreen(true, hasSavedWindowGeometry);
 #endif
 
 	computeSidePanelSizes();
@@ -135,21 +160,46 @@ MainWindow::MainWindow(QWidget * parent)
 		UpdateDialog::showUpdateDialog(false);
 }
 
-void MainWindow::ensureWindowVisibleOnExistingScreen()
+void MainWindow::ensureWindowVisibleOnExistingScreen(bool centerWindow, bool preferCurrentGeometryScreen, QScreen * forcedTargetScreen)
 {
 #ifndef VCMI_MOBILE
 	// Work with frame geometry so native window decorations are kept on-screen too.
 	// Prefer the screen containing the saved/current frame center: before show(), Qt may
 	// still report the primary screen via windowHandle(), even when the saved position
 	// belongs to another connected monitor. If no screen contains the frame, fall back
-	// to the window handle screen and then to the primary screen.
+	// to the window handle screen and then to the primary screen. In that fallback case
+	// the old coordinates belong to a missing display, so center the window instead of
+	// pinning it to the nearest edge. The caller can also force centering on the
+	// selected screen, e.g. for startup or when the launcher's screen was removed.
+	// Screen removal passes the remaining screen explicitly because windowHandle()
+	// can still point to the removed screen during the hotplug transition.
+
+	const auto screens = QGuiApplication::screens();
 	QRect windowGeometry = frameGeometry();
-	auto * targetScreen = QGuiApplication::screenAt(windowGeometry.center());
-	if(targetScreen == nullptr && windowHandle())
+	QScreen * targetScreen = forcedTargetScreen;
+
+	if(targetScreen != nullptr && !screens.contains(targetScreen))
+		targetScreen = nullptr;
+
+	if(targetScreen == nullptr && preferCurrentGeometryScreen)
+		targetScreen = QGuiApplication::screenAt(windowGeometry.center());
+
+	bool savedScreenIsMissing = preferCurrentGeometryScreen && targetScreen == nullptr;
+
+	if(targetScreen == nullptr && !centerWindow && windowHandle())
+	{
 		targetScreen = windowHandle()->screen();
+		if(targetScreen != nullptr && !screens.contains(targetScreen))
+			targetScreen = nullptr;
+	}
 
 	if(targetScreen == nullptr)
 		targetScreen = QGuiApplication::primaryScreen();
+
+	if(targetScreen != nullptr && !screens.contains(targetScreen))
+		targetScreen = nullptr;
+
+	centerWindow = centerWindow || savedScreenIsMissing;
 
 	if(targetScreen == nullptr)
 		return;
@@ -167,6 +217,9 @@ void MainWindow::ensureWindowVisibleOnExistingScreen()
 	}
 
 	QPoint windowPosition = windowGeometry.topLeft();
+	if(centerWindow)
+		windowPosition = QPoint(availableGeometry.left() + (availableGeometry.width() - windowSize.width()) / 2, availableGeometry.top() + (availableGeometry.height() - windowSize.height()) / 2);
+
 	if(windowSize.width() >= availableGeometry.width())
 		windowPosition.setX(availableGeometry.left());
 	else
@@ -175,7 +228,7 @@ void MainWindow::ensureWindowVisibleOnExistingScreen()
 	if(windowSize.height() >= availableGeometry.height())
 		windowPosition.setY(availableGeometry.top());
 	else
-		windowPosition.setY(qBound(availableGeometry.top(), windowPosition.y(), availableGeometry.bottom() - windowSize.height() + 1));
+		windowPosition.setY(qBound(availableGeometry.top(),	windowPosition.y(), availableGeometry.bottom() - windowSize.height() + 1));
 
 	move(windowPosition);
 #endif
@@ -185,11 +238,20 @@ void MainWindow::saveWindowSettings()
 {
 #ifndef VCMI_MOBILE
 	ensureWindowVisibleOnExistingScreen();
+	saveWindowSettingsUnchecked();
+#endif
+}
 
+void MainWindow::saveWindowSettingsUnchecked()
+{
+#ifndef VCMI_MOBILE
 	//save window settings
-	QSettings s = CLauncherDirs::getSettings(Ui::appName);
-	s.setValue("MainWindow/WindowSize", size());
-	s.setValue("MainWindow/WindowPosition", pos());
+	Settings windowGeometry = settings.write["launcher"]["mainWindow"]["geometry"];
+	windowGeometry["valid"].Bool() = true;
+	windowGeometry["x"].Integer() = pos().x();
+	windowGeometry["y"].Integer() = pos().y();
+	windowGeometry["width"].Integer() = size().width();
+	windowGeometry["height"].Integer() = size().height();
 #endif
 }
 

--- a/launcher/mainwindow_moc.cpp
+++ b/launcher/mainwindow_moc.cpp
@@ -194,16 +194,47 @@ void MainWindow::restoreWindowSettings()
 {
 #ifndef VCMI_MOBILE
 	const auto & windowGeometry = settings["launcher"]["mainWindow"]["geometry"];
-	QSize windowSize(windowGeometry["width"].Integer(), windowGeometry["height"].Integer());
-	if(windowSize.isValid())
+	const QSize windowSize(windowGeometry["width"].Integer(), windowGeometry["height"].Integer());
+
+	// Missing geometry receives zero-valued schema defaults. QSize::isValid considers 0x0
+	// valid, but it does not represent a previously saved window size.
+	if(!windowSize.isEmpty())
 	{
 		resize(windowSize);
 		move(windowGeometry["x"].Integer(), windowGeometry["y"].Integer());
+
+		// Keep the saved monitor when it still exists, but always start centered on it.
+		QScreen * screen = QGuiApplication::screenAt(frameGeometry().center());
+		centerWindowOnScreen(screen ? screen : QGuiApplication::primaryScreen());
+		return;
 	}
 
-	// Keep the saved monitor when it still exists, but always start centered on it.
-	QScreen * screen = QGuiApplication::screenAt(frameGeometry().center());
-	centerWindowOnScreen(screen ? screen : QGuiApplication::primaryScreen());
+	// When no saved window geometry is available, ensure there is enough room for
+	// all controls. On screens where the minimum window would not fit with window
+	// decorations, use the entire screen instead.
+	static const QSize minimumLauncherSize(800, 600);
+	QScreen * screen = QGuiApplication::primaryScreen();
+	if(screen == nullptr)
+		return;
+
+	const QSize availableSize = screen->availableSize();
+	if(availableSize.width() <= minimumLauncherSize.width() || availableSize.height() <= minimumLauncherSize.height())
+	{
+		setWindowState(windowState() | Qt::WindowFullScreen);
+		return;
+	}
+
+	// Use a common widescreen size on larger displays. On smaller displays, limit
+	// the initial window size to 90% of the available screen area while respecting
+	// the minimum launcher size, so the window keeps a visible margin and does not
+	// look fullscreen.
+	static const QSize widescreenLauncherSize(1366, 768);
+	const QSize screenSize = screen->geometry().size();
+	const bool isWidescreen = screenSize.width() * 3 > screenSize.height() * 4;
+	const QSize preferredSize = isWidescreen ? widescreenLauncherSize : minimumLauncherSize;
+	const QSize maximumInitialSize(availableSize.width() * 9 / 10, availableSize.height() * 9 / 10);
+	resize(preferredSize.boundedTo(maximumInitialSize).expandedTo(minimumLauncherSize));
+	centerWindowOnScreen(screen);
 #endif
 }
 

--- a/launcher/mainwindow_moc.cpp
+++ b/launcher/mainwindow_moc.cpp
@@ -103,7 +103,7 @@ MainWindow::MainWindow(QWidget * parent)
 
 	connect(qApp, &QGuiApplication::screenRemoved, this, [this](QScreen *)
 	{
-		QTimer::singleShot(0, this, &saveWindowSettings);
+		QTimer::singleShot(0, this, &MainWindow::saveWindowSettings);
 	});
 
 	//load window settings

--- a/launcher/mainwindow_moc.cpp
+++ b/launcher/mainwindow_moc.cpp
@@ -100,19 +100,30 @@ MainWindow::MainWindow(QWidget * parent)
 	ui->startGameButton->setIcon(QIcon{":/icons/menu-game.png"});
 
 #ifndef VCMI_MOBILE
+
+	connect(qApp, &QGuiApplication::screenRemoved, this, [this](QScreen *)
+	{
+		QTimer::singleShot(0, this, [this]()
+		{
+			saveWindowSettings();
+		});
+	});
+
 	//load window settings
 	QSettings s = CLauncherDirs::getSettings(Ui::appName);
 
 	auto size = s.value("MainWindow/WindowSize").toSize();
 	if(size.isValid())
-	{
 		resize(size);
-	}
-	auto position = s.value("MainWindow/WindowPosition").toPoint();
-	if(!position.isNull())
+
+	if(s.contains("MainWindow/WindowPosition"))
 	{
+		auto position = s.value("MainWindow/WindowPosition").toPoint();
 		move(position);
 	}
+
+	ensureWindowVisibleOnExistingScreen();
+
 #endif
 
 	computeSidePanelSizes();
@@ -128,6 +139,73 @@ MainWindow::MainWindow(QWidget * parent)
 	
 	if(settings["launcher"]["updateOnStartup"].Bool())
 		UpdateDialog::showUpdateDialog(false);
+}
+
+void MainWindow::ensureWindowVisibleOnExistingScreen()
+{
+#ifndef VCMI_MOBILE
+	const auto screens = QGuiApplication::screens();
+	if(screens.isEmpty())
+		return;
+
+	QRect windowGeometry(pos(), size());
+	QScreen * targetScreen = nullptr;
+	int bestIntersectionArea = 0;
+
+	for(QScreen * screen : screens)
+	{
+		const QRect intersection = screen->availableGeometry().intersected(windowGeometry);
+		const int intersectionArea = intersection.isEmpty() ? 0 : intersection.width() * intersection.height();
+		if(intersectionArea > bestIntersectionArea)
+		{
+			bestIntersectionArea = intersectionArea;
+			targetScreen = screen;
+		}
+	}
+
+	if(targetScreen == nullptr)
+		targetScreen = QGuiApplication::primaryScreen();
+
+	if(targetScreen == nullptr)
+		return;
+
+	const QRect availableGeometry = targetScreen->availableGeometry();
+	if(!availableGeometry.isValid())
+		return;
+
+	QSize windowSize = size();
+	if(windowSize.width() > availableGeometry.width() || windowSize.height() > availableGeometry.height())
+	{
+		windowSize = windowSize.boundedTo(availableGeometry.size());
+		resize(windowSize);
+	}
+
+	QPoint windowPosition = pos();
+	if(windowSize.width() >= availableGeometry.width())
+		windowPosition.setX(availableGeometry.left());
+	else
+		windowPosition.setX(qBound(availableGeometry.left(), windowPosition.x(), availableGeometry.right() - windowSize.width() + 1));
+
+	if(windowSize.height() >= availableGeometry.height())
+		windowPosition.setY(availableGeometry.top());
+	else
+		windowPosition.setY(qBound(availableGeometry.top(), windowPosition.y(), availableGeometry.bottom() - windowSize.height() + 1));
+
+	if(windowPosition != pos())
+		move(windowPosition);
+#endif
+}
+
+void MainWindow::saveWindowSettings()
+{
+#ifndef VCMI_MOBILE
+	ensureWindowVisibleOnExistingScreen();
+
+	//save window settings
+	QSettings s = CLauncherDirs::getSettings(Ui::appName);
+	s.setValue("MainWindow/WindowSize", size());
+	s.setValue("MainWindow/WindowPosition", pos());
+#endif
 }
 
 void MainWindow::detectPreferredLanguage()
@@ -202,12 +280,7 @@ void MainWindow::changeEvent(QEvent * event)
 
 MainWindow::~MainWindow()
 {
-#ifndef VCMI_MOBILE
-	//save window settings
-	QSettings s = CLauncherDirs::getSettings(Ui::appName);
-	s.setValue("MainWindow/WindowSize", size());
-	s.setValue("MainWindow/WindowPosition", pos());
-#endif
+	saveWindowSettings();
 
 	delete ui;
 }

--- a/launcher/mainwindow_moc.cpp
+++ b/launcher/mainwindow_moc.cpp
@@ -90,35 +90,25 @@ MainWindow::MainWindow(QWidget * parent)
 	ui->setupUi(this);
 
 #ifndef VCMI_MOBILE
-	auto scheduleRelocateToRemainingScreen = [this](bool forceCenterOnRemainingScreen)
+	connect(qApp, &QGuiApplication::screenRemoved, this, [this](QScreen *)
 	{
-		auto relocateToRemainingScreen = [this, forceCenterOnRemainingScreen]()
-		{
-			QScreen * targetScreen = nullptr;
-			if(forceCenterOnRemainingScreen)
-			{
-				const auto screens = QGuiApplication::screens();
-				targetScreen = QGuiApplication::primaryScreen();
-
-				if(targetScreen == nullptr || !screens.contains(targetScreen))
-					targetScreen = screens.isEmpty() ? nullptr : screens.front();
-			}
-
-			ensureWindowVisibleOnExistingScreen(forceCenterOnRemainingScreen, !forceCenterOnRemainingScreen, targetScreen);
-			saveWindowSettingsUnchecked();
-		};
-
-		QTimer::singleShot(250, this, relocateToRemainingScreen);
-	};
-
-	connect(qApp, &QGuiApplication::screenRemoved, this, [this, scheduleRelocateToRemainingScreen](QScreen * removedScreen)
-	{
-		const bool launcherWasOnRemovedScreen = removedScreen != nullptr && removedScreen->geometry().contains(frameGeometry().center());
-		scheduleRelocateToRemainingScreen(launcherWasOnRemovedScreen);
+		// Some platforms update the window's screen association after screenRemoved
+		QTimer::singleShot(250, this, &MainWindow::handleScreenRemoved);
 	});
-	connect(qApp, &QGuiApplication::primaryScreenChanged, this, [scheduleRelocateToRemainingScreen](QScreen *)
+	connect(qApp, &QGuiApplication::screenAdded, this, [this](QScreen *)
 	{
-		scheduleRelocateToRemainingScreen(false);
+		// A newly connected screen only changes the available choices. Do not move
+		// the launcher: its current screen and geometry are still valid.
+		QTimer::singleShot(0, ui->settingsView, &CSettingsView::setDisplayList);
+	});
+	// The native window handle is created after the widget enters the event loop.
+	QTimer::singleShot(0, this, [this]()
+	{
+		if(auto * handle = windowHandle())
+		{
+			connect(handle, &QWindow::screenChanged, this, &MainWindow::updateDisplayIndex);
+			updateDisplayIndex(handle->screen());
+		}
 	});
 #endif
 
@@ -131,18 +121,7 @@ MainWindow::MainWindow(QWidget * parent)
 	ui->startGameButton->setIcon(QIcon{":/icons/menu-game.png"});
 
 #ifndef VCMI_MOBILE
-	//load window settings
-	const auto & windowGeometry = settings["launcher"]["mainWindow"]["geometry"];
-	const bool hasSavedWindowGeometry = windowGeometry["valid"].Bool();
-	if(hasSavedWindowGeometry)
-	{
-		QSize windowSize(windowGeometry["width"].Integer(), windowGeometry["height"].Integer());
-		if(windowSize.isValid())
-			resize(windowSize);
-
-		move(windowGeometry["x"].Integer(), windowGeometry["y"].Integer());
-	}
-	ensureWindowVisibleOnExistingScreen(true, hasSavedWindowGeometry);
+	restoreWindowSettings();
 #endif
 
 	computeSidePanelSizes();
@@ -160,77 +139,97 @@ MainWindow::MainWindow(QWidget * parent)
 		UpdateDialog::showUpdateDialog(false);
 }
 
-void MainWindow::ensureWindowVisibleOnExistingScreen(bool centerWindow, bool preferCurrentGeometryScreen, QScreen * forcedTargetScreen)
+void MainWindow::centerWindowOnScreen(QScreen * screen)
 {
 #ifndef VCMI_MOBILE
-	// Work with frame geometry so native window decorations are kept on-screen too.
-	// Prefer the screen containing the saved/current frame center: before show(), Qt may
-	// still report the primary screen via windowHandle(), even when the saved position
-	// belongs to another connected monitor. If no screen contains the frame, fall back
-	// to the window handle screen and then to the primary screen. In that fallback case
-	// the old coordinates belong to a missing display, so center the window instead of
-	// pinning it to the nearest edge. The caller can also force centering on the
-	// selected screen, e.g. for startup or when the launcher's screen was removed.
-	// Screen removal passes the remaining screen explicitly because windowHandle()
-	// can still point to the removed screen during the hotplug transition.
-
-	const auto screens = QGuiApplication::screens();
-	QRect windowGeometry = frameGeometry();
-	QScreen * targetScreen = forcedTargetScreen;
-
-	if(targetScreen != nullptr && !screens.contains(targetScreen))
-		targetScreen = nullptr;
-
-	if(targetScreen == nullptr && preferCurrentGeometryScreen)
-		targetScreen = QGuiApplication::screenAt(windowGeometry.center());
-
-	bool savedScreenIsMissing = preferCurrentGeometryScreen && targetScreen == nullptr;
-
-	if(targetScreen == nullptr && !centerWindow && windowHandle())
-	{
-		targetScreen = windowHandle()->screen();
-		if(targetScreen != nullptr && !screens.contains(targetScreen))
-			targetScreen = nullptr;
-	}
-
-	if(targetScreen == nullptr)
-		targetScreen = QGuiApplication::primaryScreen();
-
-	if(targetScreen != nullptr && !screens.contains(targetScreen))
-		targetScreen = nullptr;
-
-	centerWindow = centerWindow || savedScreenIsMissing;
-
-	if(targetScreen == nullptr)
+	if(screen == nullptr)
 		return;
 
-	const QRect availableGeometry = targetScreen->availableGeometry();
-	if(!availableGeometry.isValid())
-		return;
-
-	QSize windowSize = windowGeometry.size();
-	if(windowSize.width() > availableGeometry.width() || windowSize.height() > availableGeometry.height())
-	{
-		windowSize = windowSize.boundedTo(availableGeometry.size());
-		windowGeometry.setSize(windowSize);
+	// Use frame geometry so native window decorations stay inside the screen too.
+	const QRect availableGeometry = screen->availableGeometry();
+	const QSize currentWindowSize = frameGeometry().size();
+	QSize windowSize = currentWindowSize.boundedTo(availableGeometry.size());
+	if(windowSize != currentWindowSize)
 		resize(windowSize);
+
+	move(availableGeometry.center() - QPoint(windowSize.width() / 2, windowSize.height() / 2));
+#endif
+}
+
+void MainWindow::ensureWindowVisibleOnExistingScreen()
+{
+#ifndef VCMI_MOBILE
+	// The frame center identifies the monitor on which most of the window belongs.
+	const QRect windowGeometry = frameGeometry();
+	QScreen * screen = QGuiApplication::screenAt(windowGeometry.center());
+	if(screen == nullptr)
+	{
+		centerWindowOnScreen(QGuiApplication::primaryScreen());
+		return;
 	}
 
-	QPoint windowPosition = windowGeometry.topLeft();
-	if(centerWindow)
-		windowPosition = QPoint(availableGeometry.left() + (availableGeometry.width() - windowSize.width()) / 2, availableGeometry.top() + (availableGeometry.height() - windowSize.height()) / 2);
+	const QRect availableGeometry = screen->availableGeometry();
+	QSize windowSize = windowGeometry.size().boundedTo(availableGeometry.size());
+	if(windowSize != windowGeometry.size())
+		resize(windowSize);
 
-	if(windowSize.width() >= availableGeometry.width())
-		windowPosition.setX(availableGeometry.left());
-	else
-		windowPosition.setX(qBound(availableGeometry.left(), windowPosition.x(), availableGeometry.right() - windowSize.width() + 1));
-
-	if(windowSize.height() >= availableGeometry.height())
-		windowPosition.setY(availableGeometry.top());
-	else
-		windowPosition.setY(qBound(availableGeometry.top(),	windowPosition.y(), availableGeometry.bottom() - windowSize.height() + 1));
-
+	QPoint windowPosition(
+		qBound(availableGeometry.left(), windowGeometry.left(), availableGeometry.right() - windowSize.width() + 1),
+		qBound(availableGeometry.top(), windowGeometry.top(), availableGeometry.bottom() - windowSize.height() + 1));
 	move(windowPosition);
+#endif
+}
+
+void MainWindow::handleScreenRemoved()
+{
+#ifndef VCMI_MOBILE
+	ensureWindowVisibleOnExistingScreen();
+	updateDisplayIndex(QGuiApplication::screenAt(frameGeometry().center()));
+	saveWindowSettings();
+	ui->settingsView->setDisplayList();
+#endif
+}
+
+void MainWindow::restoreWindowSettings()
+{
+#ifndef VCMI_MOBILE
+	const auto & windowGeometry = settings["launcher"]["mainWindow"]["geometry"];
+	QSize windowSize(windowGeometry["width"].Integer(), windowGeometry["height"].Integer());
+	if(windowSize.isValid())
+	{
+		resize(windowSize);
+		move(windowGeometry["x"].Integer(), windowGeometry["y"].Integer());
+	}
+
+	// Keep the saved monitor when it still exists, but always start centered on it.
+	QScreen * screen = QGuiApplication::screenAt(frameGeometry().center());
+	centerWindowOnScreen(screen ? screen : QGuiApplication::primaryScreen());
+#endif
+}
+
+void MainWindow::updateDisplayIndex(QScreen * screen)
+{
+#ifndef VCMI_MOBILE
+	// QGuiApplication screen order is the order exposed by the display-index setting.
+	const int screenIndex = QGuiApplication::screens().indexOf(screen);
+	if(screenIndex < 0 || screenIndex == settings["video"]["displayIndex"].Integer())
+		return;
+
+	Settings node = settings.write["video"]["displayIndex"];
+	node->Integer() = screenIndex;
+	ui->settingsView->setDisplayList();
+#endif
+}
+
+void MainWindow::moveToScreen(int screenIndex)
+{
+#ifndef VCMI_MOBILE
+	const auto screens = QGuiApplication::screens();
+	if(screenIndex < 0 || screenIndex >= screens.size())
+		return;
+
+	centerWindowOnScreen(screens[screenIndex]);
+	saveWindowSettings();
 #endif
 }
 
@@ -238,16 +237,8 @@ void MainWindow::saveWindowSettings()
 {
 #ifndef VCMI_MOBILE
 	ensureWindowVisibleOnExistingScreen();
-	saveWindowSettingsUnchecked();
-#endif
-}
 
-void MainWindow::saveWindowSettingsUnchecked()
-{
-#ifndef VCMI_MOBILE
-	//save window settings
 	Settings windowGeometry = settings.write["launcher"]["mainWindow"]["geometry"];
-	windowGeometry["valid"].Bool() = true;
 	windowGeometry["x"].Integer() = pos().x();
 	windowGeometry["y"].Integer() = pos().y();
 	windowGeometry["width"].Integer() = size().width();

--- a/launcher/mainwindow_moc.cpp
+++ b/launcher/mainwindow_moc.cpp
@@ -139,10 +139,14 @@ void MainWindow::ensureWindowVisibleOnExistingScreen()
 {
 #ifndef VCMI_MOBILE
 	// Work with frame geometry so native window decorations are kept on-screen too.
-	// If Qt has already associated the window with a screen, clamp the frame to that
-	// screen; otherwise fall back to the primary screen and persist that safe position.
+	// Prefer the screen containing the saved/current frame center: before show(), Qt may
+	// still report the primary screen via windowHandle(), even when the saved position
+	// belongs to another connected monitor. If no screen contains the frame, fall back
+	// to the window handle screen and then to the primary screen.
 	QRect windowGeometry = frameGeometry();
-	auto * targetScreen = windowHandle() ? windowHandle()->screen() : nullptr;
+	auto * targetScreen = QGuiApplication::screenAt(windowGeometry.center());
+	if(targetScreen == nullptr && windowHandle())
+		targetScreen = windowHandle()->screen();
 
 	if(targetScreen == nullptr)
 		targetScreen = QGuiApplication::primaryScreen();

--- a/launcher/mainwindow_moc.cpp
+++ b/launcher/mainwindow_moc.cpp
@@ -103,10 +103,7 @@ MainWindow::MainWindow(QWidget * parent)
 
 	connect(qApp, &QGuiApplication::screenRemoved, this, [this](QScreen *)
 	{
-		QTimer::singleShot(0, this, [this]()
-		{
-			saveWindowSettings();
-		});
+		QTimer::singleShot(0, this, &saveWindowSettings);
 	});
 
 	//load window settings
@@ -116,11 +113,8 @@ MainWindow::MainWindow(QWidget * parent)
 	if(size.isValid())
 		resize(size);
 
-	if(s.contains("MainWindow/WindowPosition"))
-	{
-		auto position = s.value("MainWindow/WindowPosition").toPoint();
-		move(position);
-	}
+	if(const auto position = s.value("MainWindow/WindowPosition"); position.isValid())
+		move(position.toPoint());
 
 	ensureWindowVisibleOnExistingScreen();
 
@@ -144,24 +138,11 @@ MainWindow::MainWindow(QWidget * parent)
 void MainWindow::ensureWindowVisibleOnExistingScreen()
 {
 #ifndef VCMI_MOBILE
-	const auto screens = QGuiApplication::screens();
-	if(screens.isEmpty())
-		return;
-
-	QRect windowGeometry(pos(), size());
-	QScreen * targetScreen = nullptr;
-	int bestIntersectionArea = 0;
-
-	for(QScreen * screen : screens)
-	{
-		const QRect intersection = screen->availableGeometry().intersected(windowGeometry);
-		const int intersectionArea = intersection.isEmpty() ? 0 : intersection.width() * intersection.height();
-		if(intersectionArea > bestIntersectionArea)
-		{
-			bestIntersectionArea = intersectionArea;
-			targetScreen = screen;
-		}
-	}
+	// Work with frame geometry so native window decorations are kept on-screen too.
+	// If Qt has already associated the window with a screen, clamp the frame to that
+	// screen; otherwise fall back to the primary screen and persist that safe position.
+	QRect windowGeometry = frameGeometry();
+	auto * targetScreen = windowHandle() ? windowHandle()->screen() : nullptr;
 
 	if(targetScreen == nullptr)
 		targetScreen = QGuiApplication::primaryScreen();
@@ -173,14 +154,15 @@ void MainWindow::ensureWindowVisibleOnExistingScreen()
 	if(!availableGeometry.isValid())
 		return;
 
-	QSize windowSize = size();
+	QSize windowSize = windowGeometry.size();
 	if(windowSize.width() > availableGeometry.width() || windowSize.height() > availableGeometry.height())
 	{
 		windowSize = windowSize.boundedTo(availableGeometry.size());
+		windowGeometry.setSize(windowSize);
 		resize(windowSize);
 	}
 
-	QPoint windowPosition = pos();
+	QPoint windowPosition = windowGeometry.topLeft();
 	if(windowSize.width() >= availableGeometry.width())
 		windowPosition.setX(availableGeometry.left());
 	else
@@ -191,8 +173,7 @@ void MainWindow::ensureWindowVisibleOnExistingScreen()
 	else
 		windowPosition.setY(qBound(availableGeometry.top(), windowPosition.y(), availableGeometry.bottom() - windowSize.height() + 1));
 
-	if(windowPosition != pos())
-		move(windowPosition);
+	move(windowPosition);
 #endif
 }
 

--- a/launcher/mainwindow_moc.cpp
+++ b/launcher/mainwindow_moc.cpp
@@ -232,7 +232,7 @@ void MainWindow::restoreWindowSettings()
 	const QSize screenSize = screen->geometry().size();
 	const bool isWidescreen = screenSize.width() * 3 > screenSize.height() * 4;
 	const QSize preferredSize = isWidescreen ? widescreenLauncherSize : minimumLauncherSize;
-	const QSize maximumInitialSize(availableSize.width() * 9 / 10, availableSize.height() * 9 / 10);
+	const QSize maximumInitialSize = availableSize * 0.9;
 	resize(preferredSize.boundedTo(maximumInitialSize).expandedTo(minimumLauncherSize));
 	centerWindowOnScreen(screen);
 #endif

--- a/launcher/mainwindow_moc.h
+++ b/launcher/mainwindow_moc.h
@@ -22,6 +22,7 @@ class MainWindow;
 const QString appName = "launcher";
 }
 
+class QScreen;
 class QTableWidgetItem;
 class CModList;
 class CModListView;
@@ -48,6 +49,8 @@ class MainWindow : public QMainWindow
 #endif
 
 	void load();
+	void ensureWindowVisibleOnExistingScreen(bool centerWindow = false,	bool preferCurrentGeometryScreen = true, QScreen * forcedTargetScreen = nullptr);
+	void saveWindowSettingsUnchecked();
 
 	enum TabRows
 	{
@@ -66,8 +69,6 @@ public:
 
 	void updateTranslation();
 	void computeSidePanelSizes();
-
-	void ensureWindowVisibleOnExistingScreen();
 
 	void detectPreferredLanguage();
 	void enterSetup();

--- a/launcher/mainwindow_moc.h
+++ b/launcher/mainwindow_moc.h
@@ -49,8 +49,12 @@ class MainWindow : public QMainWindow
 #endif
 
 	void load();
-	void ensureWindowVisibleOnExistingScreen(bool centerWindow = false,	bool preferCurrentGeometryScreen = true, QScreen * forcedTargetScreen = nullptr);
-	void saveWindowSettingsUnchecked();
+	void centerWindowOnScreen(QScreen * screen);
+	void ensureWindowVisibleOnExistingScreen();
+	void handleScreenRemoved();
+	void restoreWindowSettings();
+	void saveWindowSettings();
+	void updateDisplayIndex(QScreen * screen);
 
 	enum TabRows
 	{
@@ -75,6 +79,7 @@ public:
 	void exitSetup(bool goToMods);
 	void switchToModsTab();
 	void switchToStartTab();
+	void moveToScreen(int screenIndex);
 
 	void dragEnterEvent(QDragEnterEvent* event) override;
 	void dropEvent(QDropEvent *event) override;
@@ -86,7 +91,6 @@ protected:
 	void changeEvent(QEvent * event) override;
 
 public slots:
-	void saveWindowSettings();
 	void on_startGameButton_clicked();
 
 private slots:

--- a/launcher/mainwindow_moc.h
+++ b/launcher/mainwindow_moc.h
@@ -68,7 +68,6 @@ public:
 	void computeSidePanelSizes();
 
 	void ensureWindowVisibleOnExistingScreen();
-	void saveWindowSettings();
 
 	void detectPreferredLanguage();
 	void enterSetup();
@@ -86,8 +85,9 @@ protected:
 	void changeEvent(QEvent * event) override;
 
 public slots:
+	void saveWindowSettings();
 	void on_startGameButton_clicked();
-	
+
 private slots:
 	void on_modslistButton_clicked();
 	void on_settingsButton_clicked();

--- a/launcher/mainwindow_moc.h
+++ b/launcher/mainwindow_moc.h
@@ -66,7 +66,10 @@ public:
 
 	void updateTranslation();
 	void computeSidePanelSizes();
-	
+
+	void ensureWindowVisibleOnExistingScreen();
+	void saveWindowSettings();
+
 	void detectPreferredLanguage();
 	void enterSetup();
 	void exitSetup(bool goToMods);

--- a/launcher/settingsView/csettingsview_moc.cpp
+++ b/launcher/settingsView/csettingsview_moc.cpp
@@ -86,15 +86,22 @@ void CSettingsView::setDisplayList()
 	for (const auto screen : QGuiApplication::screens())
 		list << QString{"%1 - %2"}.arg(screen->name(), resolutionToString(screen->size()));
 
+	int displayIndex = settings["video"]["displayIndex"].Integer();
+	if(displayIndex < 0 || displayIndex >= list.count())
+	{
+		displayIndex = 0;
+		Settings node = settings.write["video"]["displayIndex"];
+		node->Integer() = displayIndex;
+	}
+
 	if(list.count() < 2)
 	{
 		ui->comboBoxDisplayIndex->hide();
 		ui->labelDisplayIndex->hide();
-		fillValidResolutionsForScreen(0);
+		fillValidResolutionsForScreen(displayIndex);
 	}
 	else
 	{
-		int displayIndex = settings["video"]["displayIndex"].Integer();
 		ui->comboBoxDisplayIndex->addItems(list);
 		// calls fillValidResolutions() in slot
 		ui->comboBoxDisplayIndex->setCurrentIndex(displayIndex);
@@ -340,6 +347,13 @@ QSize CSettingsView::getPreferredRenderingResolution()
 		return QSize(resX, resY);
 	}
 #endif
+
+	const auto screens = QGuiApplication::screens();
+	int displayIndex = settings["video"]["displayIndex"].Integer();
+
+	if(displayIndex >= 0 && displayIndex < screens.size())
+		return screens[displayIndex]->geometry().size() * screens[displayIndex]->devicePixelRatio();
+
 	return QApplication::primaryScreen()->geometry().size() * QApplication::primaryScreen()->devicePixelRatio();
 }
 
@@ -391,7 +405,7 @@ static QVector<QSize> findAvailableResolutions(int displayIndex)
 
 	int modesCount = SDL_GetNumDisplayModes(displayIndex);
 
-	for (int i =0; i < modesCount; ++i)
+	for (int i = 0; i < modesCount; ++i)
 	{
 		SDL_DisplayMode mode;
 		if (SDL_GetDisplayMode(displayIndex, i, &mode) != 0)
@@ -408,6 +422,20 @@ static QVector<QSize> findAvailableResolutions(int displayIndex)
 	});
 
 	result.erase(boost::unique(result).end(), result.end());
+
+	SDL_Quit();
+
+	return result;
+}
+
+static QSize findDesktopResolution(int displayIndex)
+{
+	SDL_Init(SDL_INIT_VIDEO);
+
+	SDL_DisplayMode mode;
+	QSize result;
+	if(SDL_GetDesktopDisplayMode(displayIndex, &mode) == 0)
+		result = QSize(mode.w, mode.h);
 
 	SDL_Quit();
 
@@ -431,7 +459,13 @@ void CSettingsView::fillValidResolutionsForScreen(int screenIndex)
 	{
 		QVector<QSize> resolutions = findAvailableResolutions(screenIndex);
 
-		if(!resolutions.contains(currentRes))
+		// Windowed mode allows custom resolutions, but only while they still fit on
+		// the selected display. This prevents stale 4K TV resolutions from keeping
+		// oversized scaling ranges after switching to a smaller monitor.
+		QSize desktopResolution = findDesktopResolution(screenIndex);
+		bool currentWindowedResolutionFits = !fullscreen && desktopResolution.isValid()	&& currentRes.width() <= desktopResolution.width() && currentRes.height() <= desktopResolution.height();
+
+		if(currentWindowedResolutionFits && !resolutions.contains(currentRes))
 			resolutions.append(currentRes);
 
 		for(const auto & entry : resolutions)
@@ -447,8 +481,21 @@ void CSettingsView::fillValidResolutionsForScreen(int screenIndex)
 	ui->comboBoxResolution->setCurrentIndex(resIndex);
 
 	// if selected resolution no longer exists, force update value to the largest (last) resolution
-	if(resIndex == -1)
+	if(resIndex == -1 && ui->comboBoxResolution->count() > 0)
+	{
 		ui->comboBoxResolution->setCurrentIndex(ui->comboBoxResolution->count() - 1);
+
+		// Borderless fullscreen uses desktop resolution only for display purposes.
+		// Persist fallback resolution only for modes where this setting is selectable.
+		if(!fullscreen || realFullscreen)
+		{
+			QStringList selectedResolution = ui->comboBoxResolution->currentText().split("x");
+
+			Settings node = settings.write["video"]["resolution"];
+			node["width"].Integer() = selectedResolution[0].toInt();
+			node["height"].Integer() = selectedResolution[1].toInt();
+		}
+	}
 }
 
 void CSettingsView::fillValidRenderers()
@@ -500,8 +547,8 @@ void CSettingsView::on_comboBoxResolution_currentTextChanged(const QString & arg
 	QStringList list = arg1.split("x");
 
 	Settings node = settings.write["video"]["resolution"];
-	node["width"].Float() = list[0].toInt();
-	node["height"].Float() = list[1].toInt();
+	node["width"].Integer() = list[0].toInt();
+	node["height"].Integer() = list[1].toInt();
 
 	fillValidResolutions();
 	fillValidScalingRange();
@@ -535,9 +582,10 @@ void CSettingsView::on_buttonFullModExtraction_toggled(bool value)
 void CSettingsView::on_comboBoxDisplayIndex_currentIndexChanged(int index)
 {
 	Settings node = settings.write["video"];
-	node["displayIndex"].Float() = index;
+	node["displayIndex"].Integer() = index;
 
 	fillValidResolutionsForScreen(index);
+	fillValidScalingRange();
 }
 
 void CSettingsView::on_comboBoxFriendlyAI_currentIndexChanged(int index)

--- a/launcher/settingsView/csettingsview_moc.cpp
+++ b/launcher/settingsView/csettingsview_moc.cpp
@@ -81,10 +81,18 @@ static constexpr std::array downscalingFilterTypes =
 
 void CSettingsView::setDisplayList()
 {
+	// Rebuilding the list must not be interpreted as a user-selected display change.
+	QSignalBlocker guard(ui->comboBoxDisplayIndex);
 	QStringList list;
 
-	for (const auto screen : QGuiApplication::screens())
+	for(const auto screen : QGuiApplication::screens())
 		list << QString{"%1 - %2"}.arg(screen->name(), resolutionToString(screen->size()));
+
+	ui->comboBoxDisplayIndex->clear();
+	ui->comboBoxDisplayIndex->addItems(list);
+
+	if(list.isEmpty())
+		return;
 
 	int displayIndex = settings["video"]["displayIndex"].Integer();
 	if(displayIndex < 0 || displayIndex >= list.count())
@@ -94,18 +102,9 @@ void CSettingsView::setDisplayList()
 		node->Integer() = displayIndex;
 	}
 
-	if(list.count() < 2)
-	{
-		ui->comboBoxDisplayIndex->hide();
-		ui->labelDisplayIndex->hide();
-		fillValidResolutionsForScreen(displayIndex);
-	}
-	else
-	{
-		ui->comboBoxDisplayIndex->addItems(list);
-		// calls fillValidResolutions() in slot
-		ui->comboBoxDisplayIndex->setCurrentIndex(displayIndex);
-	}
+	ui->comboBoxDisplayIndex->setCurrentIndex(displayIndex);
+	fillValidResolutionsForScreen(displayIndex);
+	fillValidScalingRange();
 }
 
 void CSettingsView::setCheckbuttonState(QToolButton * button, bool checked)
@@ -428,20 +427,6 @@ static QVector<QSize> findAvailableResolutions(int displayIndex)
 	return result;
 }
 
-static QSize findDesktopResolution(int displayIndex)
-{
-	SDL_Init(SDL_INIT_VIDEO);
-
-	SDL_DisplayMode mode;
-	QSize result;
-	if(SDL_GetDesktopDisplayMode(displayIndex, &mode) == 0)
-		result = QSize(mode.w, mode.h);
-
-	SDL_Quit();
-
-	return result;
-}
-
 void CSettingsView::fillValidResolutionsForScreen(int screenIndex)
 {
 	QSignalBlocker guard(ui->comboBoxResolution); // avoid saving wrong resolution after adding first item from the list
@@ -462,8 +447,12 @@ void CSettingsView::fillValidResolutionsForScreen(int screenIndex)
 		// Windowed mode allows custom resolutions, but only while they still fit on
 		// the selected display. This prevents stale 4K TV resolutions from keeping
 		// oversized scaling ranges after switching to a smaller monitor.
-		QSize desktopResolution = findDesktopResolution(screenIndex);
-		bool currentWindowedResolutionFits = !fullscreen && desktopResolution.isValid()	&& currentRes.width() <= desktopResolution.width() && currentRes.height() <= desktopResolution.height();
+		const auto screens = QGuiApplication::screens();
+		QSize desktopResolution;
+		if(screenIndex >= 0 && screenIndex < screens.size())
+			desktopResolution = screens[screenIndex]->geometry().size() * screens[screenIndex]->devicePixelRatio();
+
+		bool currentWindowedResolutionFits = !fullscreen && desktopResolution.isValid() && currentRes.width() <= desktopResolution.width() && currentRes.height() <= desktopResolution.height();
 
 		if(currentWindowedResolutionFits && !resolutions.contains(currentRes))
 			resolutions.append(currentRes);
@@ -586,6 +575,9 @@ void CSettingsView::on_comboBoxDisplayIndex_currentIndexChanged(int index)
 
 	fillValidResolutionsForScreen(index);
 	fillValidScalingRange();
+
+	if(auto * mainWindow = Helper::getMainWindow())
+		mainWindow->moveToScreen(index);
 }
 
 void CSettingsView::on_comboBoxFriendlyAI_currentIndexChanged(int index)


### PR DESCRIPTION
Initialy was this task only to fix behavior, with 2 screens and after disconnecting one where was Launcher was Launcher still forced to show on non-existant screen. But I noticed more things which needs to be covered in screens handling area.

1. Migrated Launcher window geometry persistence from platform-specific QSettings to the unified settings.json
2. Restores the saved Launcher size and monitor while ensuring the window remains visible on an available screen
3. Automatically relocates the Launcher when its current monitor is disconnected
4. Refreshes available displays and synchronizes video.displayIndex when monitor configuration or the Launcher’s screen changes
5. Moves and centers the Launcher when a different display is selected in settings
6. Keeps the display selector visible even when only one monitor is available
7. Uses an initial Launcher size of 800×600 on 4:3 displays and 1366×768 on widescreen displays
8. Limits the initial Launcher size to the available screen area and uses fullscreen when even 800×600 does not fit
9. Calculates resolution and scaling options using the selected monitor and its device pixel ratio
10. Removes stale windowed resolutions that no longer fit the selected monitor
11. Prevents borderless fullscreen mode from overwriting the saved game resolution
