### PR TITLE
Fix AI infinite offensive spellcasting loop

### DIFF
--- a/AI/BattleAI/BattleEvaluator.cpp
+++ b/AI/BattleAI/BattleEvaluator.cpp
@@ -850,13 +850,36 @@ bool BattleEvaluator::attemptCastingSpell(const CStack * activeStack)
 					}
 				}
 
-				if (vstd::isAlmostEqual(stackActionScore, static_cast<float>(EvaluationResult::INEFFECTIVE_SCORE)))
+				if(vstd::isAlmostEqual(stackActionScore, static_cast<float>(EvaluationResult::INEFFECTIVE_SCORE)))
 				{
 					ps.value = damageToFriendliesScore + damageToHostilesScore;
 				}
 				else
 				{
-					ps.value = stackActionScore + damageToFriendliesScore + damageToHostilesScore;
+					// Check if physical attack can wipe out target
+					bool canWipeOutTarget = cachedAttack.ap && cachedAttack.ap->defenderDead;
+
+					// Check if spell is offensive
+					bool isDamageSpell = damageToHostilesScore > 0 || ps.spell->isOffensive();
+
+					if(canWipeOutTarget && isDamageSpell)
+					{
+						// Evaluate damage spell on its own merits without physical score bonus
+						ps.value = damageToFriendliesScore + damageToHostilesScore;
+
+#if BATTLE_TRACE_LEVEL >= 1
+						logAi->trace(
+							"Target will be wiped out by physical attack. Stripping physical score from spell %s. True Spell Value: %2f",
+							ps.spell->getJsonKey(),
+							ps.value
+						);
+#endif
+					}
+					else
+					{
+						// Combine physical and spell scores for normal evaluation
+						ps.value = stackActionScore + damageToFriendliesScore + damageToHostilesScore;
+					}
 				}
 
 #if BATTLE_TRACE_LEVEL >= 1


### PR DESCRIPTION
### Description
This PR fixes a logical flaw in the AI's spellcasting evaluation that can lead to an infinite loop of casting offensive spells especially noticeable when cheat mode like `vcmiistari` is enabled and prevents the AI from choosing optimal physical attacks.

### The Phenomenon
Under certain conditions, when the AI's currently active stack is capable of completely wiping out an enemy target with a physical attack, the AI hero will cast offensive spells like Implosion instead of letting the unit attack. If spellcasting limits are bypassed via cheats, the AI gets stuck in an infinite loop, freezing the stack's action until the enemy is entirely destroyed by spells or mana is depleted. 

### Root Cause
In `BattleEvaluator::attemptCastingSpell`, the final evaluation score for a spell is calculated by adding the spell's inherent score to the physical attack score of the active stack. 
If the active stack can wipe out the target, `stackActionScore` is extremely high. Consequently, any offensive spell cast on that target gets artificially inflated:
`Spell Score (Massive Lethal Physical Score + Spell Dmg) > Pure Physical Score (Massive Lethal Physical Score)`
Because the inflated spell score is mathematically always greater than the pure physical attack score, the AI greedily prioritizes the spell, completely ignoring the mana cost and the fact that the physical attack alone is already sufficient to end the enemy.

### Solution
Added a conditional check to decouple the physical attack score from the spell score **only if**:
1. The active stack's physical attack can wipe out the target.
2. The spell being evaluated is an damage spell.

If both conditions are met, the offensive spell is evaluated purely on its own damage merits without hijacking the massive physical wipeout score. This causes the spell score to naturally lose against the optimal physical attack, breaking the infinite loop.

**Note on Tactical Preservation:** Non-damage spells intentionally bypass this restriction. This preserves advanced AI tactical combinations. For example, hero can still cast *Haste* on a slow ally during a fast unit's turn, before the fast unit proceeds to wipe out its target. 

### Changes Made
* Modified `BattleEvaluator::attemptCastingSpell` in `BattleEvaluator.cpp` to introduce the `canWipeOutTarget` and `isDamageSpell` checks before combining `stackActionScore` with spell scores.

### Testing
* **Environment:** Tested using the save file provided in issue #7414 with the `vcmiistari` cheat enabled.
* **Before:** The AI hero would fall into an infinite loop, repeatedly casting offensive spells until all enemy stacks were destroyed, while Azure Dragon stacks remained entirely inactive.
* **After:** The AI correctly evaluates the superiority of the physical attacks. The hero skips the redundant spellcasting, and the two Azure Dragon stacks immediately attack and wipe out the enemy stacks, securing an efficient victory in a single round.

### Related Issues
Fixes #7414