### PR TITLE
Fix placement and blockedTiles of a battlefield obstacle

### DIFF
--- a/config/obstacles.json
+++ b/config/obstacles.json
@@ -92,8 +92,8 @@
 	{
 		"allowedTerrains" : ["dirt"],
 		"width" : 2,
-		"height" : 1,
-		"blockedTiles" :  [0, 1],
+		"height" : 2,
+		"blockedTiles" :  [-16],
 		"animation" : "ObDRk03.def",
 		"absolute" : false
 	},


### PR DESCRIPTION
I noticed that ObDRk03 was blocking too many hexes, it should only block a single hex.

SoD:
<img width="1078" height="722" alt="obstaclesod" src="https://github.com/user-attachments/assets/673a13d2-04d5-4b26-8e4b-af396b94281c" />

After PR:
<img width="169" height="222" alt="8" src="https://github.com/user-attachments/assets/3d2841f2-6c13-4fa0-a443-093f3598f54b" />

I agree it looks weird, but that's how it is in original.