### PR TITLE
Add unit tests for spell effects

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -58,6 +58,9 @@ set(test_SRCS
  		spells/effects/DispelTest.cpp
  		spells/effects/HealTest.cpp
  		spells/effects/DemonSummonTest.cpp
+		spells/effects/MoatTest.cpp
+		spells/effects/ObstacleTest.cpp
+		spells/effects/RemoveObstacleTest.cpp
 		spells/effects/SacrificeTest.cpp
  		spells/effects/SummonTest.cpp
  		spells/effects/TeleportTest.cpp
@@ -100,9 +103,11 @@ set(test_HEADERS
 
 		mock/BattleFake.h
 		mock/mock_BonusBearer.h
+		mock/mock_CStack.h
 		mock/mock_IGameEventCallback.h
  		mock/mock_MapService.h
 		mock/mock_BonusBearer.h
+		mock/TownFake.h
 )
 
 if(ENABLE_BATTLE_AI)

--- a/test/mock/BattleFake.cpp
+++ b/test/mock/BattleFake.cpp
@@ -89,5 +89,11 @@ void BattleFake::setupEmptyBattlefield()
 	EXPECT_CALL(*this, getBattlefieldType()).WillRepeatedly(Return(BattleField(0)));
 }
 
+void BattleFake::setupNativeStacks(const TStacks & stacks, TerrainId terrain)
+{
+	EXPECT_CALL(*this, getStacksIf(_)).WillRepeatedly(Return(stacks));
+	EXPECT_CALL(*this, getTerrainType()).WillRepeatedly(Return(terrain));
+}
+
 }
 }

--- a/test/mock/BattleFake.h
+++ b/test/mock/BattleFake.h
@@ -68,6 +68,8 @@ public:
 
 	void setupEmptyBattlefield();
 
+	void setupNativeStacks(const TStacks & stacks, TerrainId terrain);
+
 	template <typename T>
 	void accept(T & pack)
 	{

--- a/test/mock/TownFake.h
+++ b/test/mock/TownFake.h
@@ -1,0 +1,41 @@
+/*
+ * TownFake.h, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
+
+#pragma once
+
+#include "../../lib/constants/EntityIdentifiers.h"
+#include "../../lib/mapObjects/CGTownInstance.h"
+
+namespace test
+{
+
+class TownFake
+{
+public:
+	explicit TownFake(FactionID faction = FactionID(FactionID::CASTLE))
+		: town(std::make_shared<CGTownInstance>(nullptr))
+	{
+		town->subID = faction;
+	}
+
+	TownFake & withBuilding(BuildingID building)
+	{
+		town->addBuilding(building);
+		return *this;
+	}
+
+	CGTownInstance * get() { return town.get(); }
+	const CGTownInstance * get() const { return town.get(); }
+
+private:
+	std::shared_ptr<CGTownInstance> town;
+};
+
+}

--- a/test/mock/mock_CStack.h
+++ b/test/mock/mock_CStack.h
@@ -1,0 +1,45 @@
+/*
+ * mock_CStack.h, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
+
+#pragma once
+
+#include "../../lib/CStack.h"
+#include "mock_BonusBearer.h"
+
+namespace test
+{
+
+class MockCStack : public CStack
+{
+public:
+	BattleSide mockedSide = BattleSide::ATTACKER;
+	BonusBearerMock bonusFake;
+
+	MockCStack() : CStack() {}
+
+	void makeNativeOnSide(BattleSide s)
+	{
+		mockedSide = s;
+		bonusFake.addNewBonus(std::make_shared<Bonus>(
+			BonusDuration::PERMANENT,
+			BonusType::TERRAIN_NATIVE,
+			BonusSource::CREATURE_ABILITY,
+			1,
+			BonusSourceID()));
+	}
+
+	BattleSide unitSide() const override { return mockedSide; }
+	bool isGhost() const override { return false; }
+	int32_t creatureIndex() const override { return 0; }  // not ARROW_TOWERS
+
+	const IBonusBearer * getBonusBearer() const override { return &bonusFake; }
+};
+
+}

--- a/test/spells/effects/CatapultTest.cpp
+++ b/test/spells/effects/CatapultTest.cpp
@@ -15,6 +15,7 @@
 
 #include "../../../lib/mapObjects/CGTownInstance.h"
 #include "../../../lib/json/JsonNode.h"
+#include "../../mock/TownFake.h"
 
 
 namespace test
@@ -49,9 +50,9 @@ TEST_F(CatapultTest, NotApplicableWithoutTown)
 	EXPECT_FALSE(subject->applicableGeneral(problemMock, &mechanicsMock));
 }
 
-TEST_F(CatapultTest, DISABLED_NotApplicableInVillage)
+TEST_F(CatapultTest, NotApplicableInVillage)
 {
-	auto fakeTown = std::make_shared<CGTownInstance>(nullptr);
+	TownFake fakeTown;
 
 	EXPECT_CALL(*battleFake, getDefendedTown()).WillRepeatedly(Return(fakeTown.get()));
 	EXPECT_CALL(mechanicsMock, adaptProblem(_, _)).WillOnce(Return(false));
@@ -61,24 +62,24 @@ TEST_F(CatapultTest, DISABLED_NotApplicableInVillage)
 	EXPECT_FALSE(subject->applicableGeneral(problemMock, &mechanicsMock));
 }
 
-TEST_F(CatapultTest, DISABLED_NotApplicableForDefenderIfSmart)
+TEST_F(CatapultTest, NotApplicableForDefenderIfSmart)
 {
-	auto fakeTown = std::make_shared<CGTownInstance>(nullptr);
-	fakeTown->addBuilding(BuildingID::FORT);
+	TownFake fakeTown;
+	fakeTown.withBuilding(BuildingID::FORT);
 	mechanicsMock.casterSide = BattleSide::DEFENDER;
 
 	EXPECT_CALL(*battleFake, getDefendedTown()).WillRepeatedly(Return(fakeTown.get()));
 	EXPECT_CALL(mechanicsMock, adaptProblem(_, _)).WillOnce(Return(false));
 	EXPECT_CALL(mechanicsMock, isSmart()).WillRepeatedly(Return(true));
-	EXPECT_CALL(*battleFake, getWallState(_)).WillRepeatedly(Return(EWallState::INTACT));
+	EXPECT_CALL(*battleFake, getWallState(_)).Times(0);
 
 	EXPECT_FALSE(subject->applicableGeneral(problemMock, &mechanicsMock));
 }
 
-TEST_F(CatapultTest, DISABLED_ApplicableInTown)
+TEST_F(CatapultTest, ApplicableInTown)
 {
-	auto fakeTown = std::make_shared<CGTownInstance>(nullptr);
-	fakeTown->addBuilding(BuildingID::FORT);
+	TownFake fakeTown;
+	fakeTown.withBuilding(BuildingID::FORT);
 
 	EXPECT_CALL(*battleFake, getDefendedTown()).WillRepeatedly(Return(fakeTown.get()));
 	EXPECT_CALL(mechanicsMock, adaptProblem(_, _)).Times(0);
@@ -107,14 +108,13 @@ protected:
 	void SetUp() override
 	{
 		EffectFixture::setUp();
-		fakeTown = std::make_shared<CGTownInstance>(nullptr);
-		fakeTown->addBuilding(BuildingID::FORT);
+		fakeTown.withBuilding(BuildingID::FORT);
 	}
-private:
-	std::shared_ptr<CGTownInstance> fakeTown;
+
+	TownFake fakeTown;
 };
 
-TEST_F(CatapultApplyTest, DISABLED_DamageToIntactPart)
+TEST_F(CatapultApplyTest, DamageToIntactPart)
 {
 	{
 		JsonNode config;
@@ -131,15 +131,163 @@ TEST_F(CatapultApplyTest, DISABLED_DamageToIntactPart)
 	mechanicsMock.caster = &actualCaster;
 	EXPECT_CALL(actualCaster, getCasterUnitId()).WillRepeatedly(Return(-1));
 	EXPECT_CALL(mechanicsMock, isMassive()).WillRepeatedly(Return(true));
+	EXPECT_CALL(rngMock, nextInt(Matcher<int>(_), Matcher<int>(_))).WillRepeatedly(Return(50));
 	EXPECT_CALL(*battleFake, getWallState(_)).WillRepeatedly(Return(EWallState::DESTROYED));
 	EXPECT_CALL(*battleFake, getWallState(Eq(targetPart))).WillRepeatedly(Return(EWallState::INTACT));
 	EXPECT_CALL(*battleFake, setWallState(Eq(targetPart), Eq(EWallState::DAMAGED))).Times(1);
-	EXPECT_CALL(serverMock, apply(Matcher<CatapultAttack &>(_))).Times(1);
+	EXPECT_CALL(serverMock, apply(Matcher<CatapultAttack &>(_))).Times(1).WillOnce(DoDefault());
 
 	Target target;
 	target.emplace_back();
 
 	subject->apply(&serverMock, &mechanicsMock, target);
+}
+
+TEST_F(CatapultApplyTest, TargetedHitOnSpecifiedPart)
+{
+	{
+		JsonNode config;
+		config["targetsToAttack"].Integer() = 1;
+		config["chanceToNormalHit"].Integer() = 100;
+		config["chanceToHitWall"].Integer() = 100;
+		EffectFixture::setupEffect(config);
+	}
+
+	setDefaultExpectations();
+
+	const EWallPart targetPart = EWallPart::BELOW_GATE;
+	const BattleHex targetHex(130); // maps to BELOW_GATE
+	auto & actualCaster = unitsFake.add(BattleSide::ATTACKER);
+
+	mechanicsMock.caster = &actualCaster;
+	EXPECT_CALL(actualCaster, getCasterUnitId()).WillRepeatedly(Return(-1));
+	EXPECT_CALL(mechanicsMock, isMassive()).WillRepeatedly(Return(false));
+	EXPECT_CALL(rngMock, nextInt(Matcher<int>(_), Matcher<int>(_))).WillRepeatedly(Return(50));
+	EXPECT_CALL(*battleFake, getWallState(_)).WillRepeatedly(Return(EWallState::DESTROYED));
+	EXPECT_CALL(*battleFake, getWallState(Eq(targetPart))).WillRepeatedly(Return(EWallState::INTACT));
+	EXPECT_CALL(*battleFake, setWallState(Eq(targetPart), Eq(EWallState::DAMAGED))).Times(1);
+	EXPECT_CALL(serverMock, apply(Matcher<CatapultAttack &>(_))).Times(1).WillOnce(DoDefault());
+
+	Target target;
+	target.emplace_back(targetHex);
+
+	subject->apply(&serverMock, &mechanicsMock, target);
+}
+
+TEST_F(CatapultApplyTest, TargetedMissRedirectsToPotentialTarget)
+{
+	{
+		JsonNode config;
+		config["targetsToAttack"].Integer() = 1;
+		config["chanceToNormalHit"].Integer() = 100;
+		config["chanceToHitWall"].Integer() = 0; // always miss the desired part
+		EffectFixture::setupEffect(config);
+	}
+
+	setDefaultExpectations();
+
+	const EWallPart desiredPart = EWallPart::BELOW_GATE;
+	const EWallPart fallbackPart = EWallPart::BOTTOM_WALL;
+	const BattleHex desiredHex(130);
+	auto & actualCaster = unitsFake.add(BattleSide::ATTACKER);
+
+	mechanicsMock.caster = &actualCaster;
+	EXPECT_CALL(actualCaster, getCasterUnitId()).WillRepeatedly(Return(-1));
+	EXPECT_CALL(mechanicsMock, isMassive()).WillRepeatedly(Return(false));
+	EXPECT_CALL(rngMock, nextInt(Matcher<int>(_), Matcher<int>(_))).WillRepeatedly(Return(50));
+	EXPECT_CALL(*battleFake, getWallState(_)).WillRepeatedly(Return(EWallState::DESTROYED));
+	EXPECT_CALL(*battleFake, getWallState(Eq(desiredPart))).WillRepeatedly(Return(EWallState::INTACT));
+	EXPECT_CALL(*battleFake, getWallState(Eq(fallbackPart))).WillRepeatedly(Return(EWallState::INTACT));
+	EXPECT_CALL(*battleFake, setWallState(Eq(fallbackPart), _)).Times(1);
+	EXPECT_CALL(*battleFake, setWallState(Eq(desiredPart), _)).Times(0);
+	EXPECT_CALL(serverMock, apply(Matcher<CatapultAttack &>(_))).Times(1).WillOnce(DoDefault());
+
+	Target target;
+	target.emplace_back(desiredHex);
+
+	subject->apply(&serverMock, &mechanicsMock, target);
+}
+
+TEST_F(CatapultApplyTest, RemovesTowerShooterOnKeepDestroyed)
+{
+	{
+		JsonNode config;
+		config["targetsToAttack"].Integer() = 1;
+		config["chanceToNormalHit"].Integer() = 100;
+		EffectFixture::setupEffect(config);
+	}
+
+	setDefaultExpectations();
+
+	const EWallPart targetPart = EWallPart::BELOW_GATE;
+	auto & actualCaster = unitsFake.add(BattleSide::ATTACKER);
+	auto & towerShooter = unitsFake.add(BattleSide::DEFENDER);
+	const uint32_t shooterId = 99;
+	EXPECT_CALL(towerShooter, getPosition()).WillRepeatedly(Return(BattleHex(BattleHex::CASTLE_CENTRAL_TOWER)));
+	EXPECT_CALL(towerShooter, isGhost()).WillRepeatedly(Return(false));
+	EXPECT_CALL(towerShooter, unitId()).WillRepeatedly(Return(shooterId));
+
+	mechanicsMock.caster = &actualCaster;
+	EXPECT_CALL(actualCaster, getCasterUnitId()).WillRepeatedly(Return(-1));
+	EXPECT_CALL(mechanicsMock, isMassive()).WillRepeatedly(Return(true));
+	EXPECT_CALL(rngMock, nextInt(Matcher<int>(_), Matcher<int>(_))).WillRepeatedly(Return(50));
+	EXPECT_CALL(*battleFake, getWallState(_)).WillRepeatedly(Return(EWallState::DESTROYED));
+	EXPECT_CALL(*battleFake, getWallState(Eq(targetPart))).WillRepeatedly(Return(EWallState::INTACT));
+	EXPECT_CALL(*battleFake, setWallState(_, _)).Times(AtLeast(1));
+	EXPECT_CALL(serverMock, apply(Matcher<CatapultAttack &>(_))).Times(1).WillOnce(DoDefault());
+
+	BattleUnitsChanged capturedUnitsPack;
+	EXPECT_CALL(serverMock, apply(Matcher<BattleUnitsChanged &>(_)))
+		.WillOnce(Invoke([&](BattleUnitsChanged & pack)
+		{
+			capturedUnitsPack = pack;
+		}));
+
+	Target target;
+	target.emplace_back();
+
+	subject->apply(&serverMock, &mechanicsMock, target);
+
+	ASSERT_EQ(capturedUnitsPack.changedStacks.size(), 1u);
+	EXPECT_EQ(capturedUnitsPack.changedStacks[0].id, shooterId);
+	EXPECT_EQ(capturedUnitsPack.changedStacks[0].operation, UnitChanges::EOperation::REMOVE);
+}
+
+TEST_F(CatapultApplyTest, MassiveAttacksMultipleParts)
+{
+	{
+		JsonNode config;
+		config["targetsToAttack"].Integer() = 3;
+		config["chanceToNormalHit"].Integer() = 100;
+		EffectFixture::setupEffect(config);
+	}
+
+	setDefaultExpectations();
+
+	auto & actualCaster = unitsFake.add(BattleSide::ATTACKER);
+
+	mechanicsMock.caster = &actualCaster;
+	EXPECT_CALL(actualCaster, getCasterUnitId()).WillRepeatedly(Return(-1));
+	EXPECT_CALL(mechanicsMock, isMassive()).WillRepeatedly(Return(true));
+	EXPECT_CALL(rngMock, nextInt(Matcher<int>(_), Matcher<int>(_))).WillRepeatedly(Return(50));
+	EXPECT_CALL(rngMock, nextInt64(_, _)).WillRepeatedly(Return(0));
+	EXPECT_CALL(*battleFake, getWallState(_)).WillRepeatedly(Return(EWallState::INTACT));
+
+	CatapultAttack capturedAttack;
+	EXPECT_CALL(serverMock, apply(Matcher<CatapultAttack &>(_)))
+		.WillOnce(Invoke([&](CatapultAttack & pack)
+		{
+			capturedAttack = pack;
+		}));
+
+	Target target;
+	target.emplace_back();
+
+	subject->apply(&serverMock, &mechanicsMock, target);
+
+	const int distinctParts = static_cast<int>(capturedAttack.attackedParts.size());
+	EXPECT_GE(distinctParts, 1);
+	EXPECT_LE(distinctParts, 3);
 }
 
 }

--- a/test/spells/effects/EffectFixture.cpp
+++ b/test/spells/effects/EffectFixture.cpp
@@ -82,6 +82,8 @@ void EffectFixture::setUp()
 	EXPECT_CALL(mechanicsMock, getBattleID()).WillRepeatedly(Return(BattleID()));
 	EXPECT_CALL(mechanicsMock, getHeroCaster()).WillRepeatedly(Return(nullptr));
 
+	EXPECT_CALL(*battleFake, getBattleID()).Times(AtLeast(0));
+
 	EXPECT_CALL(*battleFake, getScriptContextPool()).WillRepeatedly(ReturnRef(*pool));
 
 	EXPECT_CALL(servicesMock, creatures()).WillRepeatedly(Return(&creatureServiceMock));

--- a/test/spells/effects/MoatTest.cpp
+++ b/test/spells/effects/MoatTest.cpp
@@ -1,0 +1,222 @@
+/*
+ * MoatTest.cpp, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
+#include "StdInc.h"
+
+#include "EffectFixture.h"
+
+#include "../../../lib/battle/CObstacleInstance.h"
+#include "../../../lib/json/JsonNode.h"
+#include "../../../lib/networkPacks/PacksForClient.h"
+#include "../../../lib/networkPacks/PacksForClientBattle.h"
+
+#include "../../mock/TownFake.h"
+
+namespace test
+{
+using namespace ::spells;
+using namespace ::spells::effects;
+using namespace ::testing;
+
+namespace
+{
+
+JsonNode makeMoatHex(int hex)
+{
+	JsonNode node;
+	node.Integer() = hex;
+	return node;
+}
+
+JsonNode makeHexPatch(std::initializer_list<int> hexes)
+{
+	JsonNode patch;
+	for(int h : hexes)
+		patch.Vector().push_back(makeMoatHex(h));
+	return patch;
+}
+
+}
+
+class MoatApplyTest : public Test, public EffectFixture
+{
+public:
+	MoatApplyTest()
+		: EffectFixture("core:moat")
+	{
+	}
+
+	BattleObstaclesChanged capturedPack;
+
+	void captureObstaclePack()
+	{
+		EXPECT_CALL(serverMock, apply(Matcher<BattleObstaclesChanged &>(_)))
+			.WillOnce(Invoke([this](BattleObstaclesChanged & pack)
+			{
+				capturedPack = pack;
+			}));
+	}
+
+	void setDefaultApplyExpectations()
+	{
+		EXPECT_CALL(mechanicsMock, getEffectPower()).WillRepeatedly(Return(5));
+		EXPECT_CALL(mechanicsMock, getEffectLevel()).WillRepeatedly(Return(2));
+		EXPECT_CALL(mechanicsMock, getSpellIndex()).WillRepeatedly(Return(1));
+		EXPECT_CALL(mechanicsMock, getSpellId()).WillRepeatedly(Return(SpellID(SpellID::NONE)));
+		EXPECT_CALL(mechanicsMock, isMassive()).WillRepeatedly(Return(true));
+	}
+
+protected:
+	void SetUp() override
+	{
+		EffectFixture::setUp();
+		mechanicsMock.casterSide = BattleSide::DEFENDER;
+	}
+};
+
+TEST_F(MoatApplyTest, PlacesMoatObstaclesWhenTownHasMoat)
+{
+	JsonNode config;
+	config["dispellable"].Bool() = false;
+	config["moatDamage"].Integer() = 70;
+	config["moatHexes"].Vector().push_back(makeHexPatch({11, 28, 44}));
+
+	setupEffect(config);
+
+	TownFake fakeTown;
+	fakeTown.withBuilding(BuildingID::FORT);
+	fakeTown.withBuilding(BuildingID::CITADEL);
+
+	EXPECT_CALL(*battleFake, getDefendedTown()).WillRepeatedly(Return(fakeTown.get()));
+	EXPECT_CALL(*battleFake, getAllObstacles()).WillRepeatedly(Return(IBattleInfo::ObstacleCList()));
+	setDefaultApplyExpectations();
+	captureObstaclePack();
+
+	subject->apply(&serverMock, &mechanicsMock, Target());
+
+	ASSERT_EQ(capturedPack.changes.size(), 1u);
+	EXPECT_EQ(capturedPack.changes[0].operation, BattleChanges::EOperation::ADD);
+}
+
+TEST_F(MoatApplyTest, PlacesDispellableMoatAsSpellCreatedObstacle)
+{
+	JsonNode config;
+	config["dispellable"].Bool() = true;
+	config["moatDamage"].Integer() = 150;
+	config["moatHexes"].Vector().push_back(makeHexPatch({11}));
+
+	setupEffect(config);
+
+	TownFake fakeTown;
+	fakeTown.withBuilding(BuildingID::FORT);
+	fakeTown.withBuilding(BuildingID::CITADEL);
+
+	EXPECT_CALL(*battleFake, getDefendedTown()).WillRepeatedly(Return(fakeTown.get()));
+	EXPECT_CALL(*battleFake, getAllObstacles()).WillRepeatedly(Return(IBattleInfo::ObstacleCList()));
+	setDefaultApplyExpectations();
+	captureObstaclePack();
+
+	subject->apply(&serverMock, &mechanicsMock, Target());
+
+	ASSERT_EQ(capturedPack.changes.size(), 1u);
+	EXPECT_EQ(capturedPack.changes[0].operation, BattleChanges::EOperation::ADD);
+}
+
+TEST_F(MoatApplyTest, MultipleMoatPatchesCreateMultipleObstacles)
+{
+	JsonNode config;
+	config["dispellable"].Bool() = false;
+	config["moatDamage"].Integer() = 70;
+	config["moatHexes"].Vector().push_back(makeHexPatch({11}));
+	config["moatHexes"].Vector().push_back(makeHexPatch({28}));
+	config["moatHexes"].Vector().push_back(makeHexPatch({44}));
+
+	setupEffect(config);
+
+	TownFake fakeTown;
+	fakeTown.withBuilding(BuildingID::FORT);
+	fakeTown.withBuilding(BuildingID::CITADEL);
+
+	EXPECT_CALL(*battleFake, getDefendedTown()).WillRepeatedly(Return(fakeTown.get()));
+	EXPECT_CALL(*battleFake, getAllObstacles()).WillRepeatedly(Return(IBattleInfo::ObstacleCList()));
+	setDefaultApplyExpectations();
+	captureObstaclePack();
+
+	subject->apply(&serverMock, &mechanicsMock, Target());
+
+	ASSERT_EQ(capturedPack.changes.size(), 3u);
+	for(const auto & change : capturedPack.changes)
+		EXPECT_EQ(change.operation, BattleChanges::EOperation::ADD);
+}
+
+TEST_F(MoatApplyTest, NoApplyWhenTownLacksMoat)
+{
+	JsonNode config;
+	config["dispellable"].Bool() = false;
+	config["moatDamage"].Integer() = 70;
+	config["moatHexes"].Vector().push_back(makeHexPatch({11, 28, 44}));
+
+	setupEffect(config);
+
+	TownFake fakeTown;  // no CITADEL ⇒ no moat
+
+	EXPECT_CALL(*battleFake, getDefendedTown()).WillRepeatedly(Return(fakeTown.get()));
+	EXPECT_CALL(mechanicsMock, isMassive()).WillRepeatedly(Return(true));
+	EXPECT_CALL(serverMock, apply(Matcher<BattleObstaclesChanged &>(_))).Times(0);
+
+	subject->apply(&serverMock, &mechanicsMock, Target());
+}
+
+TEST_F(MoatApplyTest, AppliesBonuses)
+{
+	JsonNode config;
+	config["dispellable"].Bool() = false;
+	config["moatDamage"].Integer() = 70;
+	config["moatHexes"].Vector().push_back(makeHexPatch({11, 28, 44}));
+
+	JsonNode bonusNode;
+	bonusNode["val"].Integer() = -3;
+	bonusNode["type"].String() = "PRIMARY_SKILL";
+	bonusNode["subtype"].String() = "primarySkill.defence";
+	bonusNode["valueType"].String() = "ADDITIVE_VALUE";
+	config["bonus"]["defenceDebuff"] = bonusNode;
+
+	setupEffect(config);
+
+	TownFake fakeTown;
+	fakeTown.withBuilding(BuildingID::FORT);
+	fakeTown.withBuilding(BuildingID::CITADEL);
+
+	EXPECT_CALL(*battleFake, getDefendedTown()).WillRepeatedly(Return(fakeTown.get()));
+	EXPECT_CALL(*battleFake, getAllObstacles()).WillRepeatedly(Return(IBattleInfo::ObstacleCList()));
+	setDefaultApplyExpectations();
+	EXPECT_CALL(serverMock, apply(Matcher<BattleObstaclesChanged &>(_))).Times(1);
+
+	GiveBonus capturedBonus;
+	bool bonusCaptured = false;
+	EXPECT_CALL(serverMock, apply(Matcher<CPackForClient &>(_)))
+		.WillOnce(Invoke([&](CPackForClient & p)
+		{
+			auto * gb = dynamic_cast<GiveBonus *>(&p);
+			ASSERT_NE(gb, nullptr);
+			capturedBonus = *gb;
+			bonusCaptured = true;
+		}));
+
+	subject->apply(&serverMock, &mechanicsMock, Target());
+
+	ASSERT_TRUE(bonusCaptured);
+	EXPECT_EQ(capturedBonus.who, GiveBonus::ETarget::BATTLE);
+	EXPECT_EQ(capturedBonus.bonus.type, BonusType::PRIMARY_SKILL);
+	EXPECT_EQ(capturedBonus.bonus.val, -3);
+	EXPECT_EQ(capturedBonus.bonus.duration, BonusDuration::ONE_BATTLE);
+	EXPECT_EQ(capturedBonus.bonus.source, BonusSource::TOWN_STRUCTURE);
+}
+
+}

--- a/test/spells/effects/ObstacleTest.cpp
+++ b/test/spells/effects/ObstacleTest.cpp
@@ -1,0 +1,362 @@
+/*
+ * ObstacleTest.cpp, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
+#include "StdInc.h"
+
+#include "EffectFixture.h"
+
+#include "../../../lib/battle/CObstacleInstance.h"
+#include "../../../lib/json/JsonNode.h"
+#include "../../../lib/networkPacks/PacksForClientBattle.h"
+
+#include "../../mock/mock_CStack.h"
+
+namespace test
+{
+using namespace ::spells;
+using namespace ::spells::effects;
+using namespace ::testing;
+
+class ObstacleTest : public Test, public EffectFixture
+{
+public:
+	ObstacleTest()
+		: EffectFixture("core:obstacle")
+	{
+	}
+
+protected:
+	void SetUp() override
+	{
+		EffectFixture::setUp();
+	}
+};
+
+TEST_F(ObstacleTest, ApplicableGeneralByDefault)
+{
+	setupEffect(JsonNode());
+
+	EXPECT_CALL(mechanicsMock, adaptProblem(_, _)).Times(0);
+
+	EXPECT_TRUE(subject->applicableGeneral(problemMock, &mechanicsMock));
+}
+
+TEST_F(ObstacleTest, ApplicableTargetWhenHexClear)
+{
+	setupEffect(JsonNode());
+	battleFake->setupEmptyBattlefield();
+
+	EXPECT_CALL(mechanicsMock, isMassive()).WillRepeatedly(Return(false));
+	EXPECT_CALL(mechanicsMock, requiresClearTiles()).WillRepeatedly(Return(true));
+	EXPECT_CALL(*battleFake, getUnitsIf(_)).Times(AtLeast(0));
+
+	Target target;
+	target.emplace_back(BattleHex(5, 5));
+
+	EXPECT_TRUE(subject->applicableTarget(problemMock, &mechanicsMock, target));
+}
+
+TEST_F(ObstacleTest, NotApplicableTargetWhenHexBlockedByUnit)
+{
+	setupEffect(JsonNode());
+	battleFake->setupEmptyBattlefield();
+
+	const BattleHex hex(5, 5);
+	auto & unit = unitsFake.add(BattleSide::ATTACKER);
+	EXPECT_CALL(unit, getPosition()).WillRepeatedly(Return(hex));
+	EXPECT_CALL(unit, doubleWide()).WillRepeatedly(Return(false));
+	EXPECT_CALL(unit, alive()).WillRepeatedly(Return(true));
+	EXPECT_CALL(unit, isGhost()).WillRepeatedly(Return(false));
+
+	EXPECT_CALL(mechanicsMock, isMassive()).WillRepeatedly(Return(false));
+	EXPECT_CALL(mechanicsMock, requiresClearTiles()).WillRepeatedly(Return(true));
+	EXPECT_CALL(mechanicsMock, getSpellName()).WillRepeatedly(Return(std::string("Obstacle")));
+	EXPECT_CALL(*battleFake, getUnitsIf(_)).Times(AtLeast(0));
+
+	Target target;
+	target.emplace_back(hex);
+
+	EXPECT_FALSE(subject->applicableTarget(problemMock, &mechanicsMock, target));
+}
+
+TEST_F(ObstacleTest, NotApplicableTargetWhenEmptyTarget)
+{
+	setupEffect(JsonNode());
+
+	EXPECT_CALL(mechanicsMock, isMassive()).WillRepeatedly(Return(false));
+	EXPECT_CALL(mechanicsMock, requiresClearTiles()).WillRepeatedly(Return(true));
+	EXPECT_CALL(mechanicsMock, getSpellName()).WillRepeatedly(Return(std::string("Obstacle")));
+
+	EXPECT_FALSE(subject->applicableTarget(problemMock, &mechanicsMock, Target()));
+}
+
+TEST_F(ObstacleTest, NotApplicableWhenHiddenAndHideNativeWithEnemyNativeStack)
+{
+	JsonNode config;
+	config["hidden"].Bool() = true;
+	config["hideNative"].Bool() = true;
+	setupEffect(config);
+
+	MockCStack nativeStack;
+	nativeStack.makeNativeOnSide(BattleSide::DEFENDER);
+	battleFake->setupNativeStacks({ &nativeStack }, TerrainId(0));
+
+	mechanicsMock.casterSide = BattleSide::ATTACKER;
+	EXPECT_CALL(mechanicsMock, adaptProblem(Eq(ESpellCastProblem::NO_APPROPRIATE_TARGET), _))
+		.WillOnce(Return(false));
+
+	EXPECT_FALSE(subject->applicableGeneral(problemMock, &mechanicsMock));
+}
+
+TEST_F(ObstacleTest, ApplicableWhenHiddenAndHideNativeWithoutEnemyNativeStack)
+{
+	JsonNode config;
+	config["hidden"].Bool() = true;
+	config["hideNative"].Bool() = true;
+	setupEffect(config);
+
+	battleFake->setupNativeStacks(TStacks(), TerrainId(0));
+	EXPECT_CALL(mechanicsMock, adaptProblem(_, _)).Times(0);
+
+	EXPECT_TRUE(subject->applicableGeneral(problemMock, &mechanicsMock));
+}
+
+TEST_F(ObstacleTest, MassiveSkipsHexCheck)
+{
+	setupEffect(JsonNode());
+
+	EXPECT_CALL(mechanicsMock, isMassive()).WillRepeatedly(Return(true));
+
+	EXPECT_TRUE(subject->applicableTarget(problemMock, &mechanicsMock, Target()));
+}
+
+class ObstacleApplyTest : public Test, public EffectFixture
+{
+public:
+	ObstacleApplyTest()
+		: EffectFixture("core:obstacle")
+	{
+	}
+
+	BattleObstaclesChanged capturedPack;
+
+	void captureObstaclePack()
+	{
+		EXPECT_CALL(serverMock, apply(Matcher<BattleObstaclesChanged &>(_)))
+			.WillOnce(Invoke([this](BattleObstaclesChanged & pack)
+			{
+				capturedPack = pack;
+			}));
+	}
+
+	void setDefaultApplyExpectations()
+	{
+		EXPECT_CALL(mechanicsMock, getEffectPower()).WillRepeatedly(Return(5));
+		EXPECT_CALL(mechanicsMock, getEffectLevel()).WillRepeatedly(Return(2));
+		EXPECT_CALL(mechanicsMock, getSpellIndex()).WillRepeatedly(Return(13));
+	}
+
+protected:
+	void SetUp() override
+	{
+		EffectFixture::setUp();
+	}
+};
+
+TEST_F(ObstacleApplyTest, PlacesSingleObstacleAtTarget)
+{
+	JsonNode config;
+	config["turnsRemaining"].Integer() = 5;
+	setupEffect(config);
+
+	battleFake->setupEmptyBattlefield();
+	setDefaultApplyExpectations();
+
+	const BattleHex hex(7, 5);
+	EXPECT_CALL(mechanicsMock, isMassive()).WillRepeatedly(Return(false));
+	captureObstaclePack();
+
+	Target target;
+	target.emplace_back(hex);
+
+	subject->apply(&serverMock, &mechanicsMock, target);
+
+	ASSERT_EQ(capturedPack.changes.size(), 1u);
+	EXPECT_EQ(capturedPack.changes[0].operation, BattleChanges::EOperation::ADD);
+
+	SpellCreatedObstacle deserialized;
+	deserialized.fromInfo(capturedPack.changes[0]);
+	EXPECT_EQ(deserialized.pos, hex);
+	EXPECT_EQ(deserialized.casterSide, BattleSide::ATTACKER);
+	EXPECT_EQ(deserialized.turnsRemaining, 5);
+	EXPECT_EQ(deserialized.customSize.size(), 1u);
+	EXPECT_TRUE(deserialized.customSize.contains(hex));
+}
+
+TEST_F(ObstacleApplyTest, PlacesObstacleWithMultiHexShape)
+{
+	JsonNode config;
+	JsonNode shape;
+	JsonNode firstShapeEntry;
+	firstShapeEntry.Vector().push_back(JsonNode());  // empty direction list ⇒ NONE
+	JsonNode secondShapeEntry;
+	JsonNode trDir;
+	trDir.String() = "TR";
+	secondShapeEntry.Vector().push_back(trDir);
+	shape.Vector().push_back(firstShapeEntry);
+	shape.Vector().push_back(secondShapeEntry);
+	config["attacker"]["shape"] = shape;
+	setupEffect(config);
+
+	battleFake->setupEmptyBattlefield();
+	setDefaultApplyExpectations();
+
+	const BattleHex hex(7, 5);
+	EXPECT_CALL(mechanicsMock, isMassive()).WillRepeatedly(Return(false));
+	captureObstaclePack();
+
+	Target target;
+	target.emplace_back(hex);
+
+	subject->apply(&serverMock, &mechanicsMock, target);
+
+	ASSERT_EQ(capturedPack.changes.size(), 1u);
+
+	SpellCreatedObstacle deserialized;
+	deserialized.fromInfo(capturedPack.changes[0]);
+
+	BattleHex trNeighbour = hex;
+	trNeighbour.moveInDirection(BattleHex::EDir::TOP_RIGHT, false);
+
+	EXPECT_EQ(deserialized.customSize.size(), 2u);
+	EXPECT_TRUE(deserialized.customSize.contains(hex));
+	EXPECT_TRUE(deserialized.customSize.contains(trNeighbour));
+}
+
+TEST_F(ObstacleApplyTest, PlacesOneObstaclePerTargetHex)
+{
+	setupEffect(JsonNode());
+
+	battleFake->setupEmptyBattlefield();
+	setDefaultApplyExpectations();
+
+	EXPECT_CALL(mechanicsMock, isMassive()).WillRepeatedly(Return(false));
+	captureObstaclePack();
+
+	Target target;
+	target.emplace_back(BattleHex(5, 5));
+	target.emplace_back(BattleHex(6, 5));
+	target.emplace_back(BattleHex(7, 5));
+
+	subject->apply(&serverMock, &mechanicsMock, target);
+
+	ASSERT_EQ(capturedPack.changes.size(), 3u);
+	for(const auto & change : capturedPack.changes)
+		EXPECT_EQ(change.operation, BattleChanges::EOperation::ADD);
+}
+
+TEST_F(ObstacleApplyTest, PatchCountLimitedByAvailableTiles)
+{
+	JsonNode config;
+	config["patchCount"].Integer() = 10;
+	setupEffect(config);
+
+	battleFake->setupEmptyBattlefield();
+	setDefaultApplyExpectations();
+
+	const BattleHex blockedHex(5, 5);
+	auto & unit = unitsFake.add(BattleSide::ATTACKER);
+	EXPECT_CALL(unit, getPosition()).WillRepeatedly(Return(blockedHex));
+	EXPECT_CALL(unit, doubleWide()).WillRepeatedly(Return(false));
+	EXPECT_CALL(unit, alive()).WillRepeatedly(Return(true));
+	EXPECT_CALL(unit, isGhost()).WillRepeatedly(Return(false));
+
+	EXPECT_CALL(mechanicsMock, isMassive()).WillRepeatedly(Return(false));
+	EXPECT_CALL(*battleFake, getUnitsIf(_)).Times(AtLeast(0));
+	setupDefaultRNG();
+	captureObstaclePack();
+
+	Target target;
+	target.emplace_back(blockedHex);
+	target.emplace_back(BattleHex(6, 5));
+	target.emplace_back(BattleHex(7, 5));
+
+	subject->apply(&serverMock, &mechanicsMock, target);
+
+	ASSERT_EQ(capturedPack.changes.size(), 2u);
+}
+
+TEST_F(ObstacleApplyTest, NoServerCallWhenNoAvailableTiles)
+{
+	JsonNode config;
+	config["patchCount"].Integer() = 4;
+	setupEffect(config);
+
+	battleFake->setupEmptyBattlefield();
+
+	const BattleHex blockedHex(5, 5);
+	auto & unit = unitsFake.add(BattleSide::ATTACKER);
+	EXPECT_CALL(unit, getPosition()).WillRepeatedly(Return(blockedHex));
+	EXPECT_CALL(unit, doubleWide()).WillRepeatedly(Return(false));
+	EXPECT_CALL(unit, alive()).WillRepeatedly(Return(true));
+	EXPECT_CALL(unit, isGhost()).WillRepeatedly(Return(false));
+
+	EXPECT_CALL(mechanicsMock, isMassive()).WillRepeatedly(Return(false));
+	EXPECT_CALL(*battleFake, getUnitsIf(_)).Times(AtLeast(0));
+	setupDefaultRNG();
+	EXPECT_CALL(serverMock, apply(Matcher<BattleObstaclesChanged &>(_))).Times(0);
+
+	Target target;
+	target.emplace_back(blockedHex);
+
+	subject->apply(&serverMock, &mechanicsMock, target);
+}
+
+TEST_F(ObstacleApplyTest, UsesDefenderSideOptions)
+{
+	JsonNode config;
+	config["attacker"]["shape"].Vector().push_back(JsonNode());
+	config["attacker"]["shape"].Vector()[0].Vector().push_back(JsonNode());
+	config["attacker"]["shape"].Vector()[0].Vector()[0].String() = "TL";
+
+	config["defender"]["shape"].Vector().push_back(JsonNode());
+	config["defender"]["shape"].Vector()[0].Vector().push_back(JsonNode());
+	config["defender"]["shape"].Vector()[0].Vector()[0].String() = "TR";
+
+	setupEffect(config);
+
+	battleFake->setupEmptyBattlefield();
+	setDefaultApplyExpectations();
+
+	mechanicsMock.casterSide = BattleSide::DEFENDER;
+
+	const BattleHex hex(7, 5);
+	EXPECT_CALL(mechanicsMock, isMassive()).WillRepeatedly(Return(false));
+	captureObstaclePack();
+
+	Target target;
+	target.emplace_back(hex);
+
+	subject->apply(&serverMock, &mechanicsMock, target);
+
+	ASSERT_EQ(capturedPack.changes.size(), 1u);
+	EXPECT_EQ(capturedPack.changes[0].operation, BattleChanges::EOperation::ADD);
+
+	SpellCreatedObstacle deserialized;
+	deserialized.fromInfo(capturedPack.changes[0]);
+
+	BattleHex defenderShapeNeighbour = hex;
+	defenderShapeNeighbour.moveInDirection(BattleHex::EDir::TOP_RIGHT, false);
+
+	EXPECT_EQ(deserialized.casterSide, BattleSide::DEFENDER);
+	EXPECT_EQ(deserialized.customSize.size(), 1u);
+	EXPECT_TRUE(deserialized.customSize.contains(defenderShapeNeighbour));
+}
+
+}

--- a/test/spells/effects/RemoveObstacleTest.cpp
+++ b/test/spells/effects/RemoveObstacleTest.cpp
@@ -1,0 +1,359 @@
+/*
+ * RemoveObstacleTest.cpp, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
+#include "StdInc.h"
+
+#include "EffectFixture.h"
+
+#include "../../../lib/battle/CObstacleInstance.h"
+#include "../../../lib/json/JsonNode.h"
+#include "../../../lib/networkPacks/PacksForClientBattle.h"
+
+namespace test
+{
+using namespace ::spells;
+using namespace ::spells::effects;
+using namespace ::testing;
+
+namespace
+{
+
+std::shared_ptr<CObstacleInstance> makeUsualObstacle(si32 uniqueID)
+{
+	auto obstacle = std::make_shared<CObstacleInstance>();
+	obstacle->obstacleType = CObstacleInstance::USUAL;
+	obstacle->uniqueID = uniqueID;
+	return obstacle;
+}
+
+std::shared_ptr<CObstacleInstance> makeUsualObstacleAt(si32 uniqueID, const BattleHex & pos, si32 obstacleTypeID = 0)
+{
+	auto obstacle = std::make_shared<CObstacleInstance>();
+	obstacle->obstacleType = CObstacleInstance::USUAL;
+	obstacle->uniqueID = uniqueID;
+	obstacle->pos = pos;
+	obstacle->ID = obstacleTypeID;
+	return obstacle;
+}
+
+std::shared_ptr<CObstacleInstance> makeAbsoluteObstacle(si32 uniqueID)
+{
+	auto obstacle = std::make_shared<CObstacleInstance>();
+	obstacle->obstacleType = CObstacleInstance::ABSOLUTE_OBSTACLE;
+	obstacle->uniqueID = uniqueID;
+	return obstacle;
+}
+
+std::shared_ptr<SpellCreatedObstacle> makeSpellObstacle(si32 uniqueID, const BattleHex & pos, SpellID spell)
+{
+	auto obstacle = std::make_shared<SpellCreatedObstacle>();
+	obstacle->obstacleType = CObstacleInstance::SPELL_CREATED;
+	obstacle->uniqueID = uniqueID;
+	obstacle->pos = pos;
+	obstacle->ID = spell.num;
+	obstacle->customSize.insert(pos);
+	return obstacle;
+}
+
+}
+
+class RemoveObstacleTest : public Test, public EffectFixture
+{
+public:
+	RemoveObstacleTest()
+		: EffectFixture("core:removeObstacle")
+	{
+	}
+
+protected:
+	void SetUp() override
+	{
+		EffectFixture::setUp();
+	}
+};
+
+TEST_F(RemoveObstacleTest, ApplicableGeneralWhenMatchingObstacleExists)
+{
+	JsonNode config;
+	config["removeUsual"].Bool() = true;
+	setupEffect(config);
+
+	IBattleInfo::ObstacleCList obstacles = { makeUsualObstacle(1) };
+
+	EXPECT_CALL(mechanicsMock, isMassive()).WillRepeatedly(Return(true));
+	EXPECT_CALL(*battleFake, getAllObstacles()).WillRepeatedly(Return(obstacles));
+	EXPECT_CALL(mechanicsMock, adaptProblem(_, _)).Times(0);
+
+	EXPECT_TRUE(subject->applicableGeneral(problemMock, &mechanicsMock));
+}
+
+TEST_F(RemoveObstacleTest, NotApplicableGeneralWhenNoObstacles)
+{
+	JsonNode config;
+	config["removeUsual"].Bool() = true;
+	setupEffect(config);
+
+	EXPECT_CALL(mechanicsMock, isMassive()).WillRepeatedly(Return(true));
+	EXPECT_CALL(*battleFake, getAllObstacles()).WillRepeatedly(Return(IBattleInfo::ObstacleCList()));
+	EXPECT_CALL(mechanicsMock, adaptProblem(Eq(ESpellCastProblem::NO_APPROPRIATE_TARGET), _)).WillOnce(Return(false));
+
+	EXPECT_FALSE(subject->applicableGeneral(problemMock, &mechanicsMock));
+}
+
+TEST_F(RemoveObstacleTest, NotApplicableGeneralWhenFlagsDoNotMatch)
+{
+	JsonNode config;
+	config["removeUsual"].Bool() = true;
+	setupEffect(config);
+
+	IBattleInfo::ObstacleCList obstacles = { makeAbsoluteObstacle(1) };
+
+	EXPECT_CALL(mechanicsMock, isMassive()).WillRepeatedly(Return(true));
+	EXPECT_CALL(*battleFake, getAllObstacles()).WillRepeatedly(Return(obstacles));
+	EXPECT_CALL(mechanicsMock, adaptProblem(Eq(ESpellCastProblem::NO_APPROPRIATE_TARGET), _)).WillOnce(Return(false));
+
+	EXPECT_FALSE(subject->applicableGeneral(problemMock, &mechanicsMock));
+}
+
+TEST_F(RemoveObstacleTest, ApplicableTargetNonMassive)
+{
+	JsonNode config;
+	config["removeAllSpells"].Bool() = true;
+	setupEffect(config);
+
+	const BattleHex hex(5, 5);
+	IBattleInfo::ObstacleCList obstacles = { makeSpellObstacle(1, hex, SpellID(SpellID::FIRE_WALL)) };
+
+	EXPECT_CALL(mechanicsMock, isMassive()).WillRepeatedly(Return(false));
+	EXPECT_CALL(*battleFake, getAllObstacles()).WillRepeatedly(Return(obstacles));
+
+	Target target;
+	target.emplace_back(hex);
+
+	EXPECT_TRUE(subject->applicableTarget(problemMock, &mechanicsMock, target));
+}
+
+TEST_F(RemoveObstacleTest, ApplicableTargetUsualNonMassive)
+{
+	JsonNode config;
+	config["removeUsual"].Bool() = true;
+	setupEffect(config);
+
+	const BattleHex hex(5, 5);
+	IBattleInfo::ObstacleCList obstacles = { makeUsualObstacleAt(1, hex, 0) };
+
+	EXPECT_CALL(mechanicsMock, isMassive()).WillRepeatedly(Return(false));
+	EXPECT_CALL(*battleFake, getAllObstacles()).WillRepeatedly(Return(obstacles));
+
+	Target target;
+	target.emplace_back(hex);
+
+	EXPECT_TRUE(subject->applicableTarget(problemMock, &mechanicsMock, target));
+}
+
+TEST_F(RemoveObstacleTest, NotApplicableTargetWhenHexEmpty)
+{
+	JsonNode config;
+	config["removeAllSpells"].Bool() = true;
+	setupEffect(config);
+
+	IBattleInfo::ObstacleCList obstacles = { makeSpellObstacle(1, BattleHex(5, 5), SpellID(SpellID::FIRE_WALL)) };
+
+	EXPECT_CALL(mechanicsMock, isMassive()).WillRepeatedly(Return(false));
+	EXPECT_CALL(*battleFake, getAllObstacles()).WillRepeatedly(Return(obstacles));
+
+	Target target;
+	target.emplace_back(BattleHex(10, 9));
+
+	EXPECT_FALSE(subject->applicableTarget(problemMock, &mechanicsMock, target));
+}
+
+class RemoveObstacleApplyTest : public Test, public EffectFixture
+{
+public:
+	RemoveObstacleApplyTest()
+		: EffectFixture("core:removeObstacle")
+	{
+	}
+
+	BattleObstaclesChanged capturedPack;
+
+	void captureObstaclePack()
+	{
+		EXPECT_CALL(serverMock, apply(Matcher<BattleObstaclesChanged &>(_)))
+			.WillOnce(Invoke([this](BattleObstaclesChanged & pack)
+			{
+				capturedPack = pack;
+			}));
+	}
+
+protected:
+	void SetUp() override
+	{
+		EffectFixture::setUp();
+	}
+};
+
+TEST_F(RemoveObstacleApplyTest, RemovesUsualObstacleMassive)
+{
+	JsonNode config;
+	config["removeUsual"].Bool() = true;
+	setupEffect(config);
+
+	auto usual = makeUsualObstacle(1);
+	auto absolute = makeAbsoluteObstacle(2);
+	IBattleInfo::ObstacleCList obstacles = { usual, absolute };
+
+	EXPECT_CALL(mechanicsMock, isMassive()).WillRepeatedly(Return(true));
+	EXPECT_CALL(*battleFake, getAllObstacles()).WillRepeatedly(Return(obstacles));
+	captureObstaclePack();
+
+	subject->apply(&serverMock, &mechanicsMock, Target());
+
+	ASSERT_EQ(capturedPack.changes.size(), 1u);
+	EXPECT_EQ(capturedPack.changes[0].id, static_cast<uint32_t>(usual->uniqueID));
+	EXPECT_EQ(capturedPack.changes[0].operation, BattleChanges::EOperation::REMOVE);
+}
+
+TEST_F(RemoveObstacleApplyTest, RemovesAbsoluteWhenFlagSet)
+{
+	JsonNode config;
+	config["removeAbsolute"].Bool() = true;
+	setupEffect(config);
+
+	auto usual = makeUsualObstacle(1);
+	auto absolute = makeAbsoluteObstacle(2);
+	IBattleInfo::ObstacleCList obstacles = { usual, absolute };
+
+	EXPECT_CALL(mechanicsMock, isMassive()).WillRepeatedly(Return(true));
+	EXPECT_CALL(*battleFake, getAllObstacles()).WillRepeatedly(Return(obstacles));
+	captureObstaclePack();
+
+	subject->apply(&serverMock, &mechanicsMock, Target());
+
+	ASSERT_EQ(capturedPack.changes.size(), 1u);
+	EXPECT_EQ(capturedPack.changes[0].id, static_cast<uint32_t>(absolute->uniqueID));
+	EXPECT_EQ(capturedPack.changes[0].operation, BattleChanges::EOperation::REMOVE);
+}
+
+TEST_F(RemoveObstacleApplyTest, RemovesAllSpellObstaclesWithFlag)
+{
+	JsonNode config;
+	config["removeAllSpells"].Bool() = true;
+	setupEffect(config);
+
+	auto spellA = makeSpellObstacle(1, BattleHex(5, 5), SpellID(SpellID::FIRE_WALL));
+	auto spellB = makeSpellObstacle(2, BattleHex(6, 6), SpellID(SpellID::FORCE_FIELD));
+	auto usual = makeUsualObstacle(3);
+	IBattleInfo::ObstacleCList obstacles = { spellA, spellB, usual };
+
+	EXPECT_CALL(mechanicsMock, isMassive()).WillRepeatedly(Return(true));
+	EXPECT_CALL(*battleFake, getAllObstacles()).WillRepeatedly(Return(obstacles));
+	captureObstaclePack();
+
+	subject->apply(&serverMock, &mechanicsMock, Target());
+
+	ASSERT_EQ(capturedPack.changes.size(), 2u);
+	std::set<uint32_t> removedIds;
+	for(const auto & change : capturedPack.changes)
+	{
+		removedIds.insert(change.id);
+		EXPECT_EQ(change.operation, BattleChanges::EOperation::REMOVE);
+	}
+	EXPECT_EQ(removedIds, (std::set<uint32_t>{ static_cast<uint32_t>(spellA->uniqueID), static_cast<uint32_t>(spellB->uniqueID) }));
+}
+
+TEST_F(RemoveObstacleApplyTest, RemovesNamedSpellsOnly)
+{
+	JsonNode config;
+	JsonNode fireWallId;
+	fireWallId.String() = "core:fireWall";
+	config["removeSpells"].Vector().push_back(fireWallId);
+	setupEffect(config);
+
+	auto fireWall = makeSpellObstacle(1, BattleHex(5, 5), SpellID(SpellID::FIRE_WALL));
+	auto forceField = makeSpellObstacle(2, BattleHex(6, 6), SpellID(SpellID::FORCE_FIELD));
+	IBattleInfo::ObstacleCList obstacles = { fireWall, forceField };
+
+	EXPECT_CALL(mechanicsMock, isMassive()).WillRepeatedly(Return(true));
+	EXPECT_CALL(*battleFake, getAllObstacles()).WillRepeatedly(Return(obstacles));
+	captureObstaclePack();
+
+	subject->apply(&serverMock, &mechanicsMock, Target());
+
+	ASSERT_EQ(capturedPack.changes.size(), 1u);
+	EXPECT_EQ(capturedPack.changes[0].id, static_cast<uint32_t>(fireWall->uniqueID));
+	EXPECT_EQ(capturedPack.changes[0].operation, BattleChanges::EOperation::REMOVE);
+}
+
+TEST_F(RemoveObstacleApplyTest, NonMassiveRemovesOnlyAtTargetHex)
+{
+	JsonNode config;
+	config["removeAllSpells"].Bool() = true;
+	setupEffect(config);
+
+	const BattleHex targetHex(5, 5);
+	auto onTarget = makeSpellObstacle(1, targetHex, SpellID(SpellID::FIRE_WALL));
+	auto elsewhere = makeSpellObstacle(2, BattleHex(10, 5), SpellID(SpellID::FIRE_WALL));
+	IBattleInfo::ObstacleCList obstacles = { onTarget, elsewhere };
+
+	EXPECT_CALL(mechanicsMock, isMassive()).WillRepeatedly(Return(false));
+	EXPECT_CALL(*battleFake, getAllObstacles()).WillRepeatedly(Return(obstacles));
+	captureObstaclePack();
+
+	Target target;
+	target.emplace_back(targetHex);
+
+	subject->apply(&serverMock, &mechanicsMock, target);
+
+	ASSERT_EQ(capturedPack.changes.size(), 1u);
+	EXPECT_EQ(capturedPack.changes[0].id, static_cast<uint32_t>(onTarget->uniqueID));
+}
+
+TEST_F(RemoveObstacleApplyTest, RemovesUsualObstacleNonMassive)
+{
+	JsonNode config;
+	config["removeUsual"].Bool() = true;
+	setupEffect(config);
+
+	const BattleHex targetHex(5, 5);
+	auto onTarget = makeUsualObstacleAt(1, targetHex, 0);
+	auto elsewhere = makeUsualObstacleAt(2, BattleHex(10, 5), 0);
+	IBattleInfo::ObstacleCList obstacles = { onTarget, elsewhere };
+
+	EXPECT_CALL(mechanicsMock, isMassive()).WillRepeatedly(Return(false));
+	EXPECT_CALL(*battleFake, getAllObstacles()).WillRepeatedly(Return(obstacles));
+	captureObstaclePack();
+
+	Target target;
+	target.emplace_back(targetHex);
+
+	subject->apply(&serverMock, &mechanicsMock, target);
+
+	ASSERT_EQ(capturedPack.changes.size(), 1u);
+	EXPECT_EQ(capturedPack.changes[0].id, static_cast<uint32_t>(onTarget->uniqueID));
+}
+
+TEST_F(RemoveObstacleApplyTest, NoServerCallWhenNothingToRemove)
+{
+	JsonNode config;
+	config["removeUsual"].Bool() = true;
+	setupEffect(config);
+
+	auto absolute = makeAbsoluteObstacle(1);
+	IBattleInfo::ObstacleCList obstacles = { absolute };
+
+	EXPECT_CALL(mechanicsMock, isMassive()).WillRepeatedly(Return(true));
+	EXPECT_CALL(*battleFake, getAllObstacles()).WillRepeatedly(Return(obstacles));
+	EXPECT_CALL(serverMock, apply(Matcher<BattleObstaclesChanged &>(_))).Times(0);
+
+	subject->apply(&serverMock, &mechanicsMock, Target());
+}
+
+}


### PR DESCRIPTION
Adds unit tests for:
- Obstacle
- RemoveObstacle
- Moat

Restored and re-enabled tests for:
- Catapult

AI generated, goal is to make search for regressions during C++ -> Lua migration easier