### PR TITLE
Replace getDate method with getCalendar

### DIFF
--- a/AI/Nullkiller2/AIGateway.cpp
+++ b/AI/Nullkiller2/AIGateway.cpp
@@ -169,7 +169,7 @@ void AIGateway::gameOver(PlayerColor player, const EVictoryLossCheckResult & vic
 		if(victoryLossCheckResult.victory())
 		{
 			logAi->debug("AIGateway: Player %d (%s) won. I won! Incredible!", player, player.toString());
-			logAi->debug("Turn nr %d", cc->getDate());
+			logAi->debug("Turn nr %d", cc->getCalendar().getCurrentDay());
 		}
 		else
 		{
@@ -768,7 +768,7 @@ void AIGateway::makeTurn()
 {
 	try
 	{
-		auto day = cc->getDate(Date::DAY);
+		auto day = cc->getCalendar().getCurrentDay();
 		logAi->info("Player %d (%s) starting turn, day %d", playerID, playerID.toString(), day);
 
 		std::shared_lock gsLock(CGameState::mutex);
@@ -1600,7 +1600,7 @@ void AIGateway::invalidatePaths()
 
 void AIGateway::cheatMapReveal(const std::unique_ptr<Nullkiller> & nullkiller)
 {
-	if(nullkiller->cc->getDate(Date::DAY) == 1) // No need to execute every day, only the first time
+	if(nullkiller->cc->getCalendar().getCurrentDay() == 1) // No need to execute every day, only the first time
 	{
 		if(nullkiller->isOpenMap())
 		{
@@ -1643,7 +1643,7 @@ void AIGateway::memorizeVisitableObj(const CGObjectInstance * obj,
 
 void AIGateway::memorizeRevisitableObjs(const std::unique_ptr<AIMemory> & memory, const PlayerColor & playerID, const std::shared_ptr<CCallback> & cc)
 {
-	if(cc->getDate(Date::DAY_OF_WEEK) == 1)
+	if(cc->getCalendar().getDayOfWeek() == 1)
 	{
 		for(const ObjectInstanceID objId : memory->visitableObjs)
 		{

--- a/AI/Nullkiller2/AIUtility.cpp
+++ b/AI/Nullkiller2/AIUtility.cpp
@@ -563,7 +563,10 @@ bool isWeeklyRevisitable(const PlayerColor & playerID, const CGObjectInstance * 
 
 	//TODO: allow polling of remaining creatures in dwelling
 	if(const auto * rewardable = dynamic_cast<const CRewardableObject *>(obj))
-		return rewardable->configuration.getResetDuration() == 7;
+	{
+		const auto & reset = rewardable->configuration.resetParameters;
+		return (reset.weeks == 1 && reset.days == 0 && reset.months == 0) || (reset.days == 7 && reset.weeks == 0 && reset.months == 0);
+	}
 
 	if(dynamic_cast<const CGDwelling *>(obj))
 		return true;

--- a/AI/Nullkiller2/Analyzers/ArmyManager.cpp
+++ b/AI/Nullkiller2/Analyzers/ArmyManager.cpp
@@ -346,7 +346,8 @@ std::vector<creInfo> ArmyManager::getArmyAvailableToBuy(
 {
 	std::vector<creInfo> creaturesInDwellings;
 	int freeHeroSlots = GameConstants::ARMY_SIZE - hero->stacksCount();
-	bool countGrowth = (cpsic->getDate(Date::DAY_OF_WEEK) + turn) > LIBRARY->engineSettings()->getInteger(EGameSettings::GENERAL_DAYS_PER_WEEK);
+	auto calendar = cpsic->getCalendar();
+	bool countGrowth = (calendar.getDayOfWeek() + turn) > calendar.getDaysInWeek();
 
 	const CGTownInstance * town = dwelling->ID == Obj::TOWN
 		? dynamic_cast<const CGTownInstance *>(dwelling)

--- a/AI/Nullkiller2/Analyzers/BuildAnalyzer.cpp
+++ b/AI/Nullkiller2/Analyzers/BuildAnalyzer.cpp
@@ -284,7 +284,7 @@ void BuildAnalyzer::updateOtherBuildings(TownDevelopmentInfo & developmentInfo,
 		{BuildingID::MAGES_GUILD_3, BuildingID::MAGES_GUILD_5}
 	};
 
-	if(developmentInfo.built.size() >= 2 && cc->getDate(Date::DAY_OF_WEEK) > 4)
+	if(developmentInfo.built.size() >= 2 && cc->getCalendar().getDayOfWeek() >= cc->getCalendar().getDaysInWeek())
 	{
 		otherBuildings.push_back({BuildingID::HORDE_1});
 		otherBuildings.push_back({BuildingID::HORDE_2});

--- a/AI/Nullkiller2/Analyzers/BuildAnalyzer.cpp
+++ b/AI/Nullkiller2/Analyzers/BuildAnalyzer.cpp
@@ -284,7 +284,7 @@ void BuildAnalyzer::updateOtherBuildings(TownDevelopmentInfo & developmentInfo,
 		{BuildingID::MAGES_GUILD_3, BuildingID::MAGES_GUILD_5}
 	};
 
-	if(developmentInfo.built.size() >= 2 && cc->getCalendar().getDayOfWeek() >= cc->getCalendar().getDaysInWeek())
+	if(developmentInfo.built.size() >= 2 && cc->getCalendar().getDayOfWeek() > cc->getCalendar().getDaysInWeek() / 2)
 	{
 		otherBuildings.push_back({BuildingID::HORDE_1});
 		otherBuildings.push_back({BuildingID::HORDE_2});

--- a/AI/Nullkiller2/Analyzers/HeroManager.cpp
+++ b/AI/Nullkiller2/Analyzers/HeroManager.cpp
@@ -124,7 +124,7 @@ void HeroManager::update()
 		return scores.at(h1) > scores.at(h2);
 	};
 
-	const int biggerMapFactor = cc->getDate(Date::DAY) > 21 ? cc->getMapSize().x / CMapHeader::MAP_SIZE_LARGE : 0;
+	const int biggerMapFactor = cc->getCalendar().getCurrentDay() > 21 ? cc->getMapSize().x / CMapHeader::MAP_SIZE_LARGE : 0;
 	// One per town + static bonus on bigger maps after some weeks
 	int globalMainCount = std::max(static_cast<int>(cc->getTownsInfo().size()) + biggerMapFactor, 1);
 	// If 1 town but big map, limit a bit to don't spread the army too much

--- a/AI/Nullkiller2/Behaviors/DefenceBehavior.cpp
+++ b/AI/Nullkiller2/Behaviors/DefenceBehavior.cpp
@@ -49,7 +49,7 @@ Goals::TGoalVec DefenceBehavior::decompose(const Nullkiller * aiNk) const
 
 bool isThreatUnderControl(const CGTownInstance * town, const HitMapInfo & threat, const Nullkiller * aiNk, const std::vector<AIPath> & paths)
 {
-	int dayOfWeek = aiNk->cc->getDate(Date::DAY_OF_WEEK);
+	int dayOfWeek = aiNk->cc->getCalendar().getDayOfWeek();
 
 	for(const AIPath & path : paths)
 	{

--- a/AI/Nullkiller2/Engine/PriorityEvaluator.cpp
+++ b/AI/Nullkiller2/Engine/PriorityEvaluator.cpp
@@ -160,7 +160,7 @@ uint64_t getDwellingArmyGrowth(CCallback * cb, const CGObjectInstance * target, 
 			// Increase priority towards the end of the week if units are lost afterwards
 			if(!cb->getSettings().getBoolean(EGameSettings::DWELLINGS_ACCUMULATE_WHEN_OWNED))
 			{
-				const auto dayOfWeek = cb->getDate(Date::DAY_OF_WEEK);
+				const auto dayOfWeek = cb->getCalendar().getDayOfWeek();
 				score *= dayOfWeek;
 			}
 		}
@@ -1358,7 +1358,8 @@ float PriorityEvaluator::evaluate(Goals::TSubgoal task, int priorityTier)
 										 ? aiNk->settings->getMaxArmyLossTarget() * evaluationContext.powerRatio
 										 : 1.0;
 		const float maxEnemyDangerRatio = evaluationContext.powerRatio > 0 ? evaluationContext.powerRatio : 1.0;
-		const bool arriveNextWeek = aiNk->cc->getDate(Date::DAY_OF_WEEK) + evaluationContext.turn > LIBRARY->engineSettings()->getInteger(EGameSettings::GENERAL_DAYS_PER_WEEK);
+		auto calendar = aiNk->cc->getCalendar();
+		const bool arriveNextWeek = calendar.getDayOfWeek() + evaluationContext.turn > calendar.getDaysInWeek();
 
 #if NK2AI_TRACE_LEVEL >= 2
 		logAi->trace(

--- a/AI/Nullkiller2/Pathfinding/AINodeStorage.cpp
+++ b/AI/Nullkiller2/Pathfinding/AINodeStorage.cpp
@@ -985,7 +985,7 @@ void AINodeStorage::setTownsAndDwellings(
 		}
 	}
 
-	/*auto dayOfWeek = cb->getDate(Date::DAY_OF_WEEK);
+	/*auto dayOfWeek = cb->getCalendar().getDayOfWeek();
 	auto waitForGrowth = dayOfWeek > 4;*/
 
 	for(auto obj: visitableObjs)

--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -256,7 +256,7 @@ void CPlayerInterface::playerStartsTurn(PlayerColor player)
 void CPlayerInterface::performAutosave()
 {
 	int frequency = static_cast<int>(settings["general"]["saveFrequency"].Integer());
-	if(frequency > 0 && cb->getDate() % frequency == 0)
+	if(frequency > 0 && cb->getCalendar().getCurrentDay() % frequency == 0)
 	{
 		bool usePrefix = settings["general"]["useSavePrefix"].Bool();
 		std::string prefix = std::string();
@@ -294,9 +294,10 @@ void CPlayerInterface::performAutosave()
 		}
 		else
 		{
-			std::string stringifiedDate = std::to_string(cb->getDate(Date::MONTH))
-					+ std::to_string(cb->getDate(Date::WEEK))
-					+ std::to_string(cb->getDate(Date::DAY_OF_WEEK));
+			auto calendar = cb->getCalendar();
+			std::string stringifiedDate = std::to_string(calendar.getMonth())
+					+ std::to_string(calendar.getWeek())
+					+ std::to_string(calendar.getDayOfWeek());
 
 			cb->save("Saves/Autosave/" + prefix + stringifiedDate, false);
 		}

--- a/client/adventureMap/AdventureMapInterface.cpp
+++ b/client/adventureMap/AdventureMapInterface.cpp
@@ -458,7 +458,7 @@ void AdventureMapInterface::onPlayerTurnStarted(PlayerColor playerID)
 	onSelectionChanged(GAME->interface()->localState->getCurrentArmy());
 
 	//show new day animation and sound on infobar, except for 1st day of the game
-	if (GAME->interface()->cb->getDate(Date::DAY) != 1)
+	if (GAME->interface()->cb->getCalendar().getCurrentDay() != 1)
 		widget->getInfoBar()->showDate();
 
 	onHeroChanged(nullptr);

--- a/client/adventureMap/AdventureMapShortcuts.cpp
+++ b/client/adventureMap/AdventureMapShortcuts.cpp
@@ -765,7 +765,7 @@ bool AdventureMapShortcuts::optionViewStatistic()
 {
 	if(!GAME->interface()->makingTurn)
 		return false;
-	auto day = GAME->interface()->cb->getDate(Date::DAY);
+	auto day = GAME->interface()->cb->getCalendar().getCurrentDay();
 	return optionInMapView() && day > 1;
 }
 

--- a/client/adventureMap/CInfoBar.cpp
+++ b/client/adventureMap/CInfoBar.cpp
@@ -92,11 +92,12 @@ CInfoBar::VisibleDateInfo::VisibleDateInfo()
 	animation = std::make_shared<CShowableAnim>(1, 0, getNewDayName(), CShowableAnim::PLAY_ONCE, 180);// H3 uses around 175-180 ms per frame
 	animation->setDuration(1500);
 
+	auto calendar = GAME->interface()->cb->getCalendar();
 	std::string labelText;
-	if(GAME->interface()->cb->getDate(Date::DAY_OF_WEEK) == 1 && GAME->interface()->cb->getDate(Date::DAY) != 1) // monday of any week but first - show new week info
-		labelText = LIBRARY->generaltexth->allTexts[63] + " " + std::to_string(GAME->interface()->cb->getDate(Date::WEEK));
+	if(calendar.getDayOfWeek() == 1 && calendar.getCurrentDay() != 1) // monday of any week but first - show new week info
+		labelText = LIBRARY->generaltexth->allTexts[63] + " " + std::to_string(calendar.getWeek());
 	else
-		labelText = LIBRARY->generaltexth->allTexts[64] + " " + std::to_string(GAME->interface()->cb->getDate(Date::DAY_OF_WEEK));
+		labelText = LIBRARY->generaltexth->allTexts[64] + " " + std::to_string(calendar.getDayOfWeek());
 
 	label = std::make_shared<CLabel>(95, 31, FONT_MEDIUM, ETextAlignment::CENTER, Colors::WHITE, labelText);
 
@@ -105,13 +106,14 @@ CInfoBar::VisibleDateInfo::VisibleDateInfo()
 
 AnimationPath CInfoBar::VisibleDateInfo::getNewDayName()
 {
-	if(GAME->interface()->cb->getDate(Date::DAY) == 1)
+	auto calendar = GAME->interface()->cb->getCalendar();
+	if(calendar.getCurrentDay() == 1)
 		return AnimationPath::builtin("NEWDAY");
 
-	if(GAME->interface()->cb->getDate(Date::DAY_OF_WEEK) != 1)
+	if(calendar.getDayOfWeek() != 1)
 		return AnimationPath::builtin("NEWDAY");
 
-	int week = GAME->interface()->cb->getDate(Date::WEEK);
+	int week = calendar.getWeek();
 	auto resourceName = AnimationPath::builtin("NEWWEEK" + std::to_string(week));
 	if(CResourceHandler::get()->existsResource(resourceName.addPrefix("SPRITES/")))
 		return resourceName;
@@ -245,11 +247,12 @@ void CInfoBar::playNewDaySound()
 	if(volume == 0)
 		ENGINE->sound().setVolume(settings["general"]["sound"].Integer());
 
-	if(GAME->interface()->cb->getDate(Date::DAY_OF_WEEK) != 1) // not first day of the week
+	auto calendar = GAME->interface()->cb->getCalendar();
+	if(calendar.getDayOfWeek() != 1) // not first day of the week
 		handle = ENGINE->sound().playSound(soundBase::newDay);
-	else if(GAME->interface()->cb->getDate(Date::WEEK) != 1) // not first week in month
+	else if(calendar.getWeek() != 1) // not first week in month
 		handle = ENGINE->sound().playSound(soundBase::newWeek);
-	else if(GAME->interface()->cb->getDate(Date::MONTH) != 1) // not first month
+	else if(calendar.getMonth() != 1) // not first month
 		handle = ENGINE->sound().playSound(soundBase::newMonth);
 	else
 		handle = ENGINE->sound().playSound(soundBase::newDay);

--- a/client/adventureMap/CResDataBar.cpp
+++ b/client/adventureMap/CResDataBar.cpp
@@ -70,10 +70,11 @@ std::string CResDataBar::buildDateString()
 {
 	std::string pattern = "%s: %d, %s: %d, %s: %d";
 
+	auto calendar = GAME->interface()->cb->getCalendar();
 	auto formatted = boost::format(pattern)
-		% LIBRARY->generaltexth->translate("core.genrltxt.62") % GAME->interface()->cb->getDate(Date::MONTH)
-		% LIBRARY->generaltexth->translate("core.genrltxt.63") % GAME->interface()->cb->getDate(Date::WEEK)
-		% LIBRARY->generaltexth->translate("core.genrltxt.64") % GAME->interface()->cb->getDate(Date::DAY_OF_WEEK);
+		% LIBRARY->generaltexth->translate("core.genrltxt.62") % calendar.getMonth()
+		% LIBRARY->generaltexth->translate("core.genrltxt.63") % calendar.getWeek()
+		% LIBRARY->generaltexth->translate("core.genrltxt.64") % calendar.getDayOfWeek();
 
 	return boost::str(formatted);
 }

--- a/client/mainmenu/CStatisticScreen.cpp
+++ b/client/mainmenu/CStatisticScreen.cpp
@@ -30,7 +30,7 @@
 
 #include "../../lib/entities/ResourceTypeHandler.h"
 #include "../../lib/gameState/GameStatistics.h"
-#include "../../lib/gameState/CGameState.h"
+#include "../../lib/callback/Calendar.h"
 #include "../../lib/texts/CGeneralTextHandler.h"
 #include "../../lib/texts/TextOperations.h"
 #include "../../lib/GameLibrary.h"
@@ -40,7 +40,9 @@
 
 std::string CStatisticScreen::getDay(int d)
 {
-	return std::to_string(CGameState::getDate(d, Date::MONTH)) + "/" + std::to_string(CGameState::getDate(d, Date::WEEK)) + "/" + std::to_string(CGameState::getDate(d, Date::DAY_OF_WEEK));
+	// TODO - find way to provide settings used by game, not global ones - since map might have used different week/month length
+	Calendar calendar(*LIBRARY->engineSettings(), d);
+	return std::to_string(calendar.getMonth()) + "/" + std::to_string(calendar.getWeek()) + "/" + std::to_string(calendar.getDayOfWeek());
 }
 
 CStatisticScreen::CStatisticScreen(const StatisticDataSet & stat)

--- a/client/widgets/MiscWidgets.cpp
+++ b/client/widgets/MiscWidgets.cpp
@@ -216,10 +216,11 @@ std::string CMinorResDataBar::buildDateString()
 {
 	std::string pattern = "%s: %d, %s: %d, %s: %d";
 
+	auto calendar = GAME->interface()->cb->getCalendar();
 	auto formatted = boost::format(pattern)
-		% LIBRARY->generaltexth->translate("core.genrltxt.62") % GAME->interface()->cb->getDate(Date::MONTH)
-		% LIBRARY->generaltexth->translate("core.genrltxt.63") % GAME->interface()->cb->getDate(Date::WEEK)
-		% LIBRARY->generaltexth->translate("core.genrltxt.64") % GAME->interface()->cb->getDate(Date::DAY_OF_WEEK);
+		% LIBRARY->generaltexth->translate("core.genrltxt.62") % calendar.getMonth()
+		% LIBRARY->generaltexth->translate("core.genrltxt.63") % calendar.getWeek()
+		% LIBRARY->generaltexth->translate("core.genrltxt.64") % calendar.getDayOfWeek();
 
 	return boost::str(formatted);
 }

--- a/config/buildingsLibrary.json
+++ b/config/buildingsLibrary.json
@@ -175,7 +175,7 @@
 	"manaVortex": {
 		"configuration" : {
 			"resetParameters" : {
-				"period" : 7,
+				"weeks" : 1,
 				"visitors" : true
 			},
 			"visitMode" : "hero", // Should be 'once' to match (somewhat buggy) H3 logic

--- a/config/factions/dungeon.json
+++ b/config/factions/dungeon.json
@@ -184,7 +184,7 @@
 					"requires" : [ "mageGuild1" ],
 					"configuration" : {
 						"resetParameters" : {
-							"period" : 7,
+							"weeks" : 1,
 							"visitors" : true
 						},
 						"visitMode" : "once",

--- a/config/objects/magicSpring.json
+++ b/config/objects/magicSpring.json
@@ -24,7 +24,7 @@
 				"onVisitedMessage" : 75,
 				"description" : "@core.xtrainfo.15",
 				"resetParameters" : {
-					"period" : 7,
+					"weeks" : 1,
 					"visitors" : true
 				},
 				"visitMode" : "once",

--- a/config/objects/rewardableBonusing.json
+++ b/config/objects/rewardableBonusing.json
@@ -126,7 +126,7 @@
 				"visitMode" : "bonus",
 				"selectMode" : "selectFirst",
 				"resetParameters" : {
-					"period" : 7,
+					"weeks" : 1,
 					"rewards" : true
 				},
 

--- a/config/objects/rewardableOncePerWeek.json
+++ b/config/objects/rewardableOncePerWeek.json
@@ -20,7 +20,7 @@
 
 				"onVisitedMessage" : 93,
 				"resetParameters" : {
-					"period" : 7,
+					"weeks" : 1,
 					"visitors" : true,
 					"rewards" : true
 				},
@@ -62,7 +62,7 @@
 
 				"onVisitedMessage" : 169,
 				"resetParameters" : {
-					"period" : 7,
+					"weeks" : 1,
 					"visitors" : true,
 					"rewards" : true
 				},
@@ -104,7 +104,7 @@
 
 				"onVisitedMessage" : 165,
 				"resetParameters" : {
-					"period" : 7,
+					"weeks" : 1,
 					"visitors" : true
 				},
 				"visitMode" : "once",

--- a/config/schemas/rewardable.json
+++ b/config/schemas/rewardable.json
@@ -353,7 +353,10 @@
 			"properties" : {
 				"visitors" : { "type" : "boolean" },
 				"rewards" : { "type" : "boolean" },
-				"period" : { "type" : "number" }
+				"days" : { "type" : "number" },
+				"weeks" : { "type" : "number" },
+				"months" : { "type" : "number" },
+				"period" : { "type" : "number" } // deprecated alias for "days"
 			}
 		},
 		

--- a/docs/modders/Entities_Format/Town_Building_Format.md
+++ b/docs/modders/Entities_Format/Town_Building_Format.md
@@ -51,7 +51,7 @@ These are just a couple of examples of what can be done in VCMI. See vcmi config
 	},
 	"configuration" : {
 		"resetParameters" : {
-			"period" : 7,
+			"weeks" : 1,
 			"visitors" : true
 		},
 		"visitMode" : "once",

--- a/docs/modders/Map_Objects/Rewardable.md
+++ b/docs/modders/Map_Objects/Rewardable.md
@@ -220,13 +220,16 @@ To reference variable in limiter prepend variable name with '@' symbol:
 
 This property describes how object state should be reset. Objects without this field will never reset its state.
 
-- Period describes interval between object resets in day. Periods are counted from game start and not from hero visit, so reset duration of 7 will always reset object on new week & duration of 28 will always reset on new month.
+- The reset interval is the sum of `days`, `weeks` and `months`, with `weeks` and `months` resolved against the active game's calendar settings (days-per-week and weeks-per-month, both configurable via game settings). For the default 7-day week / 4-week month this means `"weeks": 1` is equivalent to `"days": 7` and `"months": 1` is equivalent to `"days": 28` - but unlike a hardcoded number of days, the `weeks`/`months` form continues to land on the start of a week/month if the map uses a non-default calendar.
+- Periods are counted from game start and not from hero visit, so e.g. `"weeks": 1` will always reset the object on every new week.
 - If `visitors` is set to true, game will reset list of visitors (heroes and players) on start of new period, allowing revisits of objects with `visitMode` set to `once`, `hero`, or `player`. Objects with visit mode set to `bonus` are not affected. In order to allow revisit such objects use appropriate bonus duration (e.g. `ONE_DAY` or `ONE_WEEK`) instead.
 - If `rewards` is set to true, object will re-randomize its provided rewards, similar to such H3 objects as "Fountain of Fortune" or "Windmill"
 
 ```json
 "resetParameters" : {
-    "period" : 7,
+    "days" : 0,
+    "weeks" : 1,
+	"months" : 0,
     "visitors" : true,
     "rewards" : true
 }

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -82,6 +82,7 @@ set(lib_MAIN_SRCS
 	bonuses/Updaters.cpp
 
 	callback/CAdventureAI.cpp
+	callback/Calendar.cpp
 	callback/CBattleCallback.cpp
 	callback/CCallback.cpp
 	callback/CDynLibHandler.cpp
@@ -493,6 +494,7 @@ set(lib_MAIN_HEADERS
 	bonuses/Updaters.h
 
 	callback/CAdventureAI.h
+	callback/Calendar.h
 	callback/CBattleCallback.h
 	callback/CBattleGameInterface.h
 	callback/CCallback.h

--- a/lib/callback/CGameInfoCallback.cpp
+++ b/lib/callback/CGameInfoCallback.cpp
@@ -385,9 +385,9 @@ bool CGameInfoCallback::getHeroInfo(const CGObjectInstance * hero, InfoAboutHero
 	return true;
 }
 
-int CGameInfoCallback::getDate(Date mode) const
+Calendar CGameInfoCallback::getCalendar() const
 {
-	return gameState().getDate(mode);
+	return gameState().getCalendar();
 }
 
 bool CGameInfoCallback::isVisibleFor(int3 pos, PlayerColor player) const

--- a/lib/callback/CGameInfoCallback.h
+++ b/lib/callback/CGameInfoCallback.h
@@ -26,7 +26,8 @@ protected:
 public:
 	//various
 
-	int getDate(Date mode=Date::DAY)const override; //mode=0 - total days in game, mode=1 - day of week, mode=2 - current week, mode=3 - current month
+	Calendar getCalendar() const override;
+	using MapInfoCallback::getCalendar;
 	const StartInfo * getStartInfo() const override;
 	const StartInfo * getInitialStartInfo() const;
 	const scripting::Pool & getScriptContextPool() const override;

--- a/lib/callback/Calendar.cpp
+++ b/lib/callback/Calendar.cpp
@@ -1,0 +1,74 @@
+/*
+ * Calendar.cpp, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
+#include "StdInc.h"
+#include "Calendar.h"
+
+#include "../IGameSettings.h"
+
+VCMI_LIB_NAMESPACE_BEGIN
+
+Calendar::Calendar(const IGameSettings & settings, int day)
+	: settings(&settings), day(day)
+{
+}
+
+int Calendar::getCurrentDay() const
+{
+	return day;
+}
+
+int Calendar::getDayOfWeek() const
+{
+	int daysPerWeek = getDaysInWeek();
+	int temp = day % daysPerWeek;
+	return temp ? temp : daysPerWeek;
+}
+
+int Calendar::getDayOfMonth() const
+{
+	int daysPerMonth = getDaysInMonth();
+	int temp = day % daysPerMonth;
+	return temp ? temp : daysPerMonth;
+}
+
+int Calendar::getWeek() const
+{
+	int daysPerWeek = getDaysInWeek();
+	int daysPerMonth = getDaysInMonth();
+	int temp = ((day - 1) % daysPerMonth) + 1;
+	return ((temp - 1) / daysPerWeek) + 1;
+}
+
+int Calendar::getMonth() const
+{
+	return ((day - 1) / getDaysInMonth()) + 1;
+}
+
+int Calendar::getDaysInWeek() const
+{
+	return settings->getInteger(EGameSettings::GENERAL_DAYS_PER_WEEK);
+}
+
+int Calendar::getDaysInMonth() const
+{
+	return getWeeksInMonth() * getDaysInWeek();
+}
+
+int Calendar::getWeeksInMonth() const
+{
+	return settings->getInteger(EGameSettings::GENERAL_WEEKS_PER_MONTH);
+}
+
+Calendar Calendar::nextDay() const
+{
+	return Calendar(*settings, day + 1);
+}
+
+VCMI_LIB_NAMESPACE_END

--- a/lib/callback/Calendar.h
+++ b/lib/callback/Calendar.h
@@ -1,0 +1,48 @@
+/*
+ * Calendar.h, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
+#pragma once
+
+VCMI_LIB_NAMESPACE_BEGIN
+
+class IGameSettings;
+
+/// Small value type that interprets a day count using the game's calendar settings
+/// (days per week, weeks per month). Holds the day count and a non-owning pointer
+/// to the IGameSettings that provides week/month length.
+class DLL_LINKAGE Calendar final
+{
+	const IGameSettings * settings;
+	int day;
+
+public:
+	Calendar(const IGameSettings & settings, int day);
+
+	/// Total number of days since start of the game (1..inf)
+	int getCurrentDay() const;
+	/// Day within current week (1..daysPerWeek)
+	int getDayOfWeek() const;
+	/// Day within current month (1..daysPerMonth)
+	int getDayOfMonth() const;
+	/// Week within current month (1..weeksPerMonth)
+	int getWeek() const;
+	/// Current month (1..inf)
+	int getMonth() const;
+	/// Configured number of days per week
+	int getDaysInWeek() const;
+	/// Configured number of days per month (daysPerWeek * weeksPerMonth)
+	int getDaysInMonth() const;
+	/// Configured number of weeks per month
+	int getWeeksInMonth() const;
+
+	/// Returns a Calendar advanced by one day
+	Calendar nextDay() const;
+};
+
+VCMI_LIB_NAMESPACE_END

--- a/lib/callback/EditorCallback.cpp
+++ b/lib/callback/EditorCallback.cpp
@@ -52,7 +52,7 @@ const StartInfo * EditorCallback::getStartInfo() const
 	THROW_EDITOR_UNSUPPORTED;
 }
 
-int EditorCallback::getDate(Date mode) const
+Calendar EditorCallback::getCalendar() const
 {
 	THROW_EDITOR_UNSUPPORTED;
 }

--- a/lib/callback/EditorCallback.h
+++ b/lib/callback/EditorCallback.h
@@ -29,7 +29,7 @@ public:
 
 	// Unused in editor — return null or dummy
 	const StartInfo * getStartInfo() const override;
-	int getDate(Date mode) const override;
+	Calendar getCalendar() const override;
 
 	const TerrainTile * getTile(int3 tile, bool verbose) const override;
 	const TerrainTile * getTileUnchecked(int3 tile) const override;

--- a/lib/callback/IGameInfoCallback.h
+++ b/lib/callback/IGameInfoCallback.h
@@ -12,6 +12,7 @@
 #include "../constants/EntityIdentifiers.h"
 #include "../constants/Enumerations.h"
 #include "../int3.h"
+#include "Calendar.h"
 
 #include <vcmi/scripting/ApiTags.h>
 
@@ -69,13 +70,11 @@ public:
 	/// TODO: remove
 	virtual const CGameState & gameState() const = 0;
 
-	/// Returns current date:
-	/// DAY - number of days since start of the game (1..inf)
-	/// DAY_OF_WEEK - number of days since start of the week (1..7)
-	/// WEEK - number of week within month (1..4)
-	/// MONTH - current month (1..inf)
-	/// DAY_OF_MONTH - number of day within current month, (1..28)
-	virtual int getDate(Date mode=Date::DAY) const = 0;
+	/// Returns Calendar wrapper for current in-game date.
+	virtual Calendar getCalendar() const = 0;
+
+	/// Returns Calendar wrapper for arbitrary day count, interpreted using current game settings.
+	Calendar getCalendar(int day) const { return Calendar(getSettings(), day); }
 
 	/// Return pointer to static map header for current map
 	virtual const CMapHeader * getMapHeader() const = 0;

--- a/lib/constants/Enumerations.h
+++ b/lib/constants/Enumerations.h
@@ -127,15 +127,6 @@ namespace MasteryLevel
 	};
 }
 
-enum class Date : int8_t
-{
-	DAY = 0,
-	DAY_OF_WEEK = 1,
-	WEEK = 2,
-	MONTH = 3,
-	DAY_OF_MONTH
-};
-
 enum class EActionType : int8_t
 {
 	NO_ACTION,

--- a/lib/gameState/CGameState.cpp
+++ b/lib/gameState/CGameState.cpp
@@ -149,36 +149,9 @@ bool CGameState::isHeroAllowedForPlayer(const HeroTypeID & hid, const PlayerColo
 	return true;
 }
 
-int CGameState::getDate(int d, Date mode)
+Calendar CGameState::getCalendar() const
 {
-	int daysPerWeek = LIBRARY->engineSettings()->getInteger(EGameSettings::GENERAL_DAYS_PER_WEEK);
-	int daysPerMonth = LIBRARY->engineSettings()->getInteger(EGameSettings::GENERAL_WEEKS_PER_MONTH) * daysPerWeek;
-
-	int temp;
-	switch (mode)
-	{
-	case Date::DAY:
-		return d;
-	case Date::DAY_OF_WEEK: //day of week
-		temp = (d)%daysPerWeek; // 1 - Monday, 7 - Sunday
-		return temp ? temp : daysPerWeek;
-	case Date::WEEK:  //current week
-		temp = ((d - 1) % daysPerMonth) + 1;
-		return ((temp - 1) / daysPerWeek) + 1;
-	case Date::MONTH: //current month
-		return ((d-1)/daysPerMonth)+1;
-	case Date::DAY_OF_MONTH: //day of month
-		temp = (d)%daysPerMonth;
-		if (temp)
-			return temp;
-		else return daysPerMonth;
-	}
-	return 0;
-}
-
-int CGameState::getDate(Date mode) const
-{
-	return getDate(day, mode);
+	return Calendar(getSettings(), day);
 }
 
 CGameState::CGameState()

--- a/lib/gameState/CGameState.h
+++ b/lib/gameState/CGameState.h
@@ -183,8 +183,7 @@ public:
 		return false;
 	}
 
-	static int getDate(int day, Date mode);
-	int getDate(Date mode=Date::DAY) const override; //mode=0 - total days in game, mode=1 - day of week, mode=2 - current week, mode=3 - current month
+	Calendar getCalendar() const override;
 
 	const scripting::Pool & getScriptContextPool() const final;
 

--- a/lib/gameState/GameStatePackVisitor.cpp
+++ b/lib/gameState/GameStatePackVisitor.cpp
@@ -250,7 +250,10 @@ void GameStatePackVisitor::visitGiveBonus(GiveBonus & pack)
 	assert(cbsn);
 
 	if(Bonus::OneWeek(&pack.bonus))
-		pack.bonus.turnsRemain = (LIBRARY->engineSettings()->getInteger(EGameSettings::GENERAL_DAYS_PER_WEEK) + 1) - gs.getDate(Date::DAY_OF_WEEK); // set correct number of days before adding bonus
+	{
+		auto calendar = gs.getCalendar();
+		pack.bonus.turnsRemain = calendar.getDaysInWeek() + 1 - calendar.getDayOfWeek(); // set correct number of days before adding bonus
+	}
 
 	auto b = std::make_shared<Bonus>(pack.bonus);
 	cbsn->addNewBonus(b);

--- a/lib/gameState/GameStatistics.cpp
+++ b/lib/gameState/GameStatistics.cpp
@@ -75,7 +75,7 @@ StatisticDataSetEntry StatisticDataSet::createEntry(const PlayerState * ps, cons
 
 	data.map = gs->getMap().name.toString();
 	data.timestamp = std::time(nullptr);
-	data.day = gs->getDate(Date::DAY);
+	data.day = gs->getCalendar().getCurrentDay();
 	data.player = ps->color;
 	data.playerName = gs->getStartInfo()->playerInfos.at(ps->color).name;
 	data.team = ps->team;
@@ -105,8 +105,8 @@ StatisticDataSetEntry StatisticDataSet::createEntry(const PlayerState * ps, cons
 	data.spentResourcesForArmy = accumulatedData.accumulatedValues.count(ps->color) ? accumulatedData.accumulatedValues.at(ps->color).spentResourcesForArmy : TResources();
 	data.spentResourcesForBuildings = accumulatedData.accumulatedValues.count(ps->color) ? accumulatedData.accumulatedValues.at(ps->color).spentResourcesForBuildings : TResources();
 	data.tradeVolume = accumulatedData.accumulatedValues.count(ps->color) ? accumulatedData.accumulatedValues.at(ps->color).tradeVolume : TResources();
-	data.eventCapturedTown = accumulatedData.accumulatedValues.count(ps->color) ? accumulatedData.accumulatedValues.at(ps->color).lastCapturedTownDay == gs->getDate(Date::DAY) : false;
-	data.eventDefeatedStrongestHero = accumulatedData.accumulatedValues.count(ps->color) ? accumulatedData.accumulatedValues.at(ps->color).lastDefeatedStrongestHeroDay == gs->getDate(Date::DAY) : false;
+	data.eventCapturedTown = accumulatedData.accumulatedValues.count(ps->color) ? accumulatedData.accumulatedValues.at(ps->color).lastCapturedTownDay == data.day : false;
+	data.eventDefeatedStrongestHero = accumulatedData.accumulatedValues.count(ps->color) ? accumulatedData.accumulatedValues.at(ps->color).lastDefeatedStrongestHeroDay == data.day : false;
 	data.movementPointsUsed = accumulatedData.accumulatedValues.count(ps->color) ? accumulatedData.accumulatedValues.at(ps->color).movementPointsUsed : 0;
 
 	return data;

--- a/lib/gameState/HighScore.cpp
+++ b/lib/gameState/HighScore.cpp
@@ -28,7 +28,7 @@ HighScoreParameter HighScore::prepareHighScores(const CGameState * gs, PlayerCol
 
 	HighScoreParameter param;
 	param.difficulty = gs->getStartInfo()->difficulty;
-	param.day = gs->getDate();
+	param.day = gs->getCalendar().getCurrentDay();
 	param.townAmount = gs->howManyTowns(player);
 	param.usedCheat = gs->getPlayerState(player)->cheated;
 	param.hasGrail = false;

--- a/lib/mapObjects/CGCreature.cpp
+++ b/lib/mapObjects/CGCreature.cpp
@@ -312,7 +312,8 @@ void CGCreature::newTurn(IGameEventCallback & gameEvents, IGameRandomizer & game
 {//Works only for stacks of single type of size up to 2 millions
 	if (!notGrowingTeam)
 	{
-		if (stacks.begin()->second->getCount() < cb->getSettings().getInteger(EGameSettings::CREATURES_WEEKLY_GROWTH_CAP) && cb->getDate(Date::DAY_OF_WEEK) == 1 && cb->getDate(Date::DAY) > 1)
+		auto calendar = cb->getCalendar();
+		if (stacks.begin()->second->getCount() < cb->getSettings().getInteger(EGameSettings::CREATURES_WEEKLY_GROWTH_CAP) && calendar.getDayOfWeek() == 1 && calendar.getCurrentDay() > 1)
 		{
 			ui32 power = static_cast<ui32>(temppower * (100 + cb->getSettings().getInteger(EGameSettings::CREATURES_WEEKLY_GROWTH_PERCENT)) / 100);
 			gameEvents.setObjPropertyValue(id, ObjProperty::MONSTER_COUNT, std::min<uint32_t>(power / 1000, cb->getSettings().getInteger(EGameSettings::CREATURES_WEEKLY_GROWTH_CAP))); //set new amount

--- a/lib/mapObjects/CGDwelling.cpp
+++ b/lib/mapObjects/CGDwelling.cpp
@@ -308,7 +308,7 @@ void CGDwelling::onHeroVisit(IGameEventCallback & gameEvents, const CGHeroInstan
 
 void CGDwelling::newTurn(IGameEventCallback & gameEvents, IGameRandomizer & gameRandomizer) const
 {
-	if(cb->getDate(Date::DAY_OF_WEEK) != 1) //not first day of week
+	if(cb->getCalendar().getDayOfWeek() != 1) //not first day of week
 		return;
 
 	//town growths and War Machines Factories are handled separately

--- a/lib/mapObjects/CGMarket.cpp
+++ b/lib/mapObjects/CGMarket.cpp
@@ -107,8 +107,9 @@ void CGBlackMarket::newTurn(IGameEventCallback & gameEvents, IGameRandomizer & g
 {
 	int resetPeriod = cb->getSettings().getInteger(EGameSettings::MARKETS_BLACK_MARKET_RESTOCK_PERIOD);
 
-	bool isFirstDay = cb->getDate(Date::DAY) == 1;
-	bool regularResetTriggered = resetPeriod != 0 && ((cb->getDate(Date::DAY)-1) % resetPeriod) == 0;
+	int currentDay = cb->getCalendar().getCurrentDay();
+	bool isFirstDay = currentDay == 1;
+	bool regularResetTriggered = resetPeriod != 0 && ((currentDay-1) % resetPeriod) == 0;
 
 	if (!isFirstDay && !regularResetTriggered)
 		return;

--- a/lib/mapObjects/CQuest.cpp
+++ b/lib/mapObjects/CQuest.cpp
@@ -246,7 +246,7 @@ void CQuest::addTextReplacements(const IGameInfoCallback * cb, MetaString & text
 	}
 	
 	if(lastDay >= 0)
-		text.replaceNumber(lastDay - cb->getDate(Date::DAY));
+		text.replaceNumber(lastDay - cb->getCalendar().getCurrentDay());
 }
 
 void CQuest::getVisitText(const IGameInfoCallback * cb, MetaString &iwText, std::vector<Component> &components, bool firstVisit, const CGHeroInstance * h) const
@@ -544,7 +544,7 @@ void CGSeerHut::setPropertyDer(ObjProperty what, ObjPropertyID identifier)
 void CGSeerHut::newTurn(IGameEventCallback & gameEvents, IGameRandomizer & gameRandomizer) const
 {
 	CRewardableObject::newTurn(gameEvents, gameRandomizer);
-	if(getQuest().lastDay >= 0 && getQuest().lastDay <= cb->getDate() - 1) //time is up
+	if(getQuest().lastDay >= 0 && getQuest().lastDay <= cb->getCalendar().getCurrentDay() - 1) //time is up
 	{
 		gameEvents.setObjPropertyValue(id, ObjProperty::SEERHUT_COMPLETE, true);
 	}

--- a/lib/mapObjects/CRewardableObject.cpp
+++ b/lib/mapObjects/CRewardableObject.cpp
@@ -362,7 +362,8 @@ void CRewardableObject::setPropertyDer(ObjProperty what, ObjPropertyID identifie
 
 void CRewardableObject::newTurn(IGameEventCallback & gameEvents, IGameRandomizer & gameRandomizer) const
 {
-	if (configuration.resetParameters.period != 0 && cb->getDate(Date::DAY) > 1 && ((cb->getDate(Date::DAY)-1) % configuration.resetParameters.period) == 0)
+	int currentDay = cb->getCalendar().getCurrentDay();
+	if (configuration.resetParameters.period != 0 && currentDay > 1 && ((currentDay-1) % configuration.resetParameters.period) == 0)
 	{
 		if (configuration.resetParameters.rewards)
 		{

--- a/lib/mapObjects/CRewardableObject.cpp
+++ b/lib/mapObjects/CRewardableObject.cpp
@@ -362,8 +362,10 @@ void CRewardableObject::setPropertyDer(ObjProperty what, ObjPropertyID identifie
 
 void CRewardableObject::newTurn(IGameEventCallback & gameEvents, IGameRandomizer & gameRandomizer) const
 {
-	int currentDay = cb->getCalendar().getCurrentDay();
-	if (configuration.resetParameters.period != 0 && currentDay > 1 && ((currentDay-1) % configuration.resetParameters.period) == 0)
+	auto calendar = cb->getCalendar();
+	int currentDay = calendar.getCurrentDay();
+	ui32 resetDuration = configuration.getResetDuration(calendar);
+	if (resetDuration != 0 && currentDay > 1 && ((currentDay-1) % resetDuration) == 0)
 	{
 		if (configuration.resetParameters.rewards)
 		{

--- a/lib/mapObjects/TownBuildingInstance.cpp
+++ b/lib/mapObjects/TownBuildingInstance.cpp
@@ -111,7 +111,8 @@ Rewardable::Configuration TownRewardableBuildingInstance::generateConfiguration(
 
 void TownRewardableBuildingInstance::newTurn(IGameEventCallback & gameEvents, IGameRandomizer & gameRandomizer) const
 {
-	if (configuration.resetParameters.period != 0 && cb->getDate(Date::DAY) > 1 && ((cb->getDate(Date::DAY)-1) % configuration.resetParameters.period) == 0)
+	int currentDay = cb->getCalendar().getCurrentDay();
+	if (configuration.resetParameters.period != 0 && currentDay > 1 && ((currentDay-1) % configuration.resetParameters.period) == 0)
 	{
 		auto newConfiguration = generateConfiguration(gameRandomizer);
 		gameEvents.setRewardableObjectConfiguration(town->id, getBuildingType(), newConfiguration);

--- a/lib/mapObjects/TownBuildingInstance.cpp
+++ b/lib/mapObjects/TownBuildingInstance.cpp
@@ -111,8 +111,10 @@ Rewardable::Configuration TownRewardableBuildingInstance::generateConfiguration(
 
 void TownRewardableBuildingInstance::newTurn(IGameEventCallback & gameEvents, IGameRandomizer & gameRandomizer) const
 {
-	int currentDay = cb->getCalendar().getCurrentDay();
-	if (configuration.resetParameters.period != 0 && currentDay > 1 && ((currentDay-1) % configuration.resetParameters.period) == 0)
+	auto calendar = cb->getCalendar();
+	int currentDay = calendar.getCurrentDay();
+	ui32 resetDuration = configuration.getResetDuration(calendar);
+	if (resetDuration != 0 && currentDay > 1 && ((currentDay-1) % resetDuration) == 0)
 	{
 		auto newConfiguration = generateConfiguration(gameRandomizer);
 		gameEvents.setRewardableObjectConfiguration(town->id, getBuildingType(), newConfiguration);

--- a/lib/rewardable/Configuration.cpp
+++ b/lib/rewardable/Configuration.cpp
@@ -10,6 +10,7 @@
 
 #include "StdInc.h"
 #include "Configuration.h"
+#include "../callback/Calendar.h"
 #include "../serializer/JsonSerializeFormat.h"
 
 VCMI_LIB_NAMESPACE_BEGIN
@@ -19,9 +20,11 @@ Rewardable::EVisitMode Rewardable::Configuration::getVisitMode() const
 	return static_cast<EVisitMode>(visitMode);
 }
 
-ui16 Rewardable::Configuration::getResetDuration() const
+ui32 Rewardable::Configuration::getResetDuration(const Calendar & calendar) const
 {
-	return resetParameters.period;
+	return resetParameters.days
+		+ resetParameters.weeks * calendar.getDaysInWeek()
+		+ resetParameters.months * calendar.getDaysInMonth();
 }
 
 std::optional<int> Rewardable::Configuration::getVariable(const std::string & category, const std::string & name) const
@@ -60,9 +63,15 @@ void Rewardable::Configuration::initVariable(const std::string & category, const
 
 void Rewardable::ResetInfo::serializeJson(JsonSerializeFormat & handler)
 {
-	handler.serializeInt("period", period);
+	handler.serializeInt("days", days);
+	handler.serializeInt("weeks", weeks);
+	handler.serializeInt("months", months);
 	handler.serializeBool("visitors", visitors);
 	handler.serializeBool("rewards", rewards);
+
+	// MODS COMPATIBILITY accept legacy "period" field as alias for "days"
+	if (!handler.saving && days == 0 && weeks == 0 && months == 0)
+		days = static_cast<ui32>(handler.getCurrent()["period"].Float());
 }
 
 void Rewardable::VisitInfo::serializeJson(JsonSerializeFormat & handler)

--- a/lib/rewardable/Configuration.h
+++ b/lib/rewardable/Configuration.h
@@ -19,6 +19,8 @@
 
 VCMI_LIB_NAMESPACE_BEGIN
 
+class Calendar;
+
 namespace Rewardable
 {
 
@@ -56,26 +58,31 @@ constexpr std::array<std::string_view, 7> VisitModeString{"unlimited", "once", "
 
 struct DLL_LINKAGE ResetInfo
 {
-	ResetInfo()
-		: period(0)
-		, visitors(false)
-		, rewards(false)
-	{}
+	/// raw day count between resets
+	ui32 days = 0;
 
-	/// if above zero, object state will be reset each resetDuration days
-	ui32 period;
+	/// number of weeks between resets (multiplied by days-per-week from game settings)
+	ui32 weeks = 0;
+
+	/// number of months between resets (multiplied by days-per-month from game settings)
+	ui32 months = 0;
 
 	/// if true - reset list of visitors (heroes & players) on reset
-	bool visitors;
+	bool visitors = false;
 
 	/// if true - re-randomize rewards on a new week
-	bool rewards;
-	
+	bool rewards = false;
+
 	void serializeJson(JsonSerializeFormat & handler);
-	
+
 	template <typename Handler> void serialize(Handler &h)
 	{
-		h & period;
+		h & days;
+		if (h.version >= Handler::Version::REWARDABLE_RESET_CALENDAR)
+		{
+			h & weeks;
+			h & months;
+		}
 		h & visitors;
 		h & rewards;
 	}
@@ -176,7 +183,9 @@ struct DLL_LINKAGE Configuration
 	EInfoWindowMode infoWindowType = EInfoWindowMode::AUTO;
 	
 	EVisitMode getVisitMode() const;
-	ui16 getResetDuration() const;
+	/// Returns the effective reset interval in days, expanding weeks/months
+	/// counters against the provided calendar's settings.
+	ui32 getResetDuration(const Calendar & calendar) const;
 
 	std::optional<int> getVariable(const std::string & category, const std::string & name) const;
 	const JsonNode & getPresetVariable(const std::string & category, const std::string & name) const;

--- a/lib/rewardable/Info.cpp
+++ b/lib/rewardable/Info.cpp
@@ -234,9 +234,15 @@ void Rewardable::Info::configureReward(Rewardable::Configuration & object, IGame
 
 void Rewardable::Info::configureResetInfo(Rewardable::Configuration & object, IGameRandomizer & gameRandomizer, Rewardable::ResetInfo & resetParameters, const JsonNode & source) const
 {
-	resetParameters.period   = static_cast<ui32>(source["period"].Float());
+	resetParameters.days     = static_cast<ui32>(source["days"].Float());
+	resetParameters.weeks    = static_cast<ui32>(source["weeks"].Float());
+	resetParameters.months   = static_cast<ui32>(source["months"].Float());
 	resetParameters.visitors = source["visitors"].Bool();
 	resetParameters.rewards  = source["rewards"].Bool();
+
+	// MODS COMPATIBILTY FOR 1.7 and older: legacy "period" field is an alias for "days"
+	if (resetParameters.days == 0 && resetParameters.weeks == 0 && resetParameters.months == 0)
+		resetParameters.days = static_cast<ui32>(source["period"].Float());
 }
 
 void Rewardable::Info::configureVariables(Rewardable::Configuration & object, IGameRandomizer & gameRandomizer, IGameInfoCallback * cb, const JsonNode & source) const

--- a/lib/rewardable/Limiter.cpp
+++ b/lib/rewardable/Limiter.cpp
@@ -79,13 +79,13 @@ bool Rewardable::Limiter::heroAllowed(const CGHeroInstance * hero) const
 {
 	if(dayOfWeek != 0)
 	{
-		if (hero->cb->getDate(Date::DAY_OF_WEEK) != dayOfWeek)
+		if (hero->cb->getCalendar().getDayOfWeek() != dayOfWeek)
 			return false;
 	}
 
 	if(daysPassed != 0)
 	{
-		if (hero->cb->getDate(Date::DAY) < daysPassed)
+		if (hero->cb->getCalendar().getCurrentDay() < daysPassed)
 			return false;
 	}
 

--- a/lib/serializer/ESerializationVersion.h
+++ b/lib/serializer/ESerializationVersion.h
@@ -64,10 +64,11 @@ enum class ESerializationVersion : int32_t
 	BONUS_TRIGGER, // bonus that allows triggered effects in combat
 	CUSTOM_GARRISON_TITLE, // GarrisonDialog pack now has custom title parameter
 	LUA_SCRIPTS,
+	REWARDABLE_RESET_CALENDAR, // rewardable reset period split into days/weeks/months
 
 	RELEASE_170 = HOTA_MAP_STACK_COUNT,
 	RELEASE_174 = CUSTOM_GARRISON_TITLE,
-	CURRENT = LUA_SCRIPTS,
+	CURRENT = REWARDABLE_RESET_CALENDAR,
 };
 
 static_assert(ESerializationVersion::MINIMAL <= ESerializationVersion::CURRENT, "Invalid serialization version definition!");

--- a/luascript/api/GameCb.cpp
+++ b/luascript/api/GameCb.cpp
@@ -27,8 +27,6 @@ namespace api
 
 const std::vector<GameCbProxy::CustomRegType> GameCbProxy::REGISTER_CUSTOM =
 {
-	{"getDate", LuaMethodWrapper<GameCb, decltype(&GameCb::getDate), &GameCb::getDate>::invoke, false},
-
 	{"getHero", LuaMethodWrapper<GameCb, decltype(&GameCb::getHero), &GameCb::getHero>::invoke, false},
 
 	{"getObj", LuaMethodWrapper<GameCb, decltype(&GameCb::getObj), &GameCb::getObj>::invoke, false},

--- a/mapeditor/inspector/rewardswidget.cpp
+++ b/mapeditor/inspector/rewardswidget.cpp
@@ -238,7 +238,9 @@ void RewardsWidget::obtainData()
 	ui->canRefuse->setChecked(object.configuration.canRefuse);
 	
 	//reset parameters
-	ui->resetPeriod->setValue(object.configuration.resetParameters.period);
+	ui->resetPeriod->setValue(object.configuration.resetParameters.days);
+	ui->resetWeeks->setValue(object.configuration.resetParameters.weeks);
+	ui->resetMonths->setValue(object.configuration.resetParameters.months);
 	ui->resetVisitors->setChecked(object.configuration.resetParameters.visitors);
 	ui->resetRewards->setChecked(object.configuration.resetParameters.rewards);
 	
@@ -264,7 +266,9 @@ bool RewardsWidget::commitChanges()
 	object.configuration.canRefuse = ui->canRefuse->isChecked();
 	
 	//reset parameters
-	object.configuration.resetParameters.period = ui->resetPeriod->value();
+	object.configuration.resetParameters.days = ui->resetPeriod->value();
+	object.configuration.resetParameters.weeks = ui->resetWeeks->value();
+	object.configuration.resetParameters.months = ui->resetMonths->value();
 	object.configuration.resetParameters.visitors = ui->resetVisitors->isChecked();
 	object.configuration.resetParameters.rewards = ui->resetRewards->isChecked();
 	
@@ -640,8 +644,23 @@ void RewardsWidget::on_selectMode_currentIndexChanged(int index)
 
 void RewardsWidget::on_resetPeriod_valueChanged(int arg1)
 {
-	ui->resetRewards->setEnabled(arg1);
-	ui->resetVisitors->setEnabled(arg1);
+	bool anyPeriodSet = arg1 > 0 || ui->resetWeeks->value() > 0 || ui->resetMonths->value() > 0;
+	ui->resetRewards->setEnabled(anyPeriodSet);
+	ui->resetVisitors->setEnabled(anyPeriodSet);
+}
+
+void RewardsWidget::on_resetWeeks_valueChanged(int arg1)
+{
+	bool anyPeriodSet = arg1 > 0 || ui->resetPeriod->value() > 0 || ui->resetMonths->value() > 0;
+	ui->resetRewards->setEnabled(anyPeriodSet);
+	ui->resetVisitors->setEnabled(anyPeriodSet);
+}
+
+void RewardsWidget::on_resetMonths_valueChanged(int arg1)
+{
+	bool anyPeriodSet = arg1 > 0 || ui->resetPeriod->value() > 0 || ui->resetWeeks->value() > 0;
+	ui->resetRewards->setEnabled(anyPeriodSet);
+	ui->resetVisitors->setEnabled(anyPeriodSet);
 }
 
 

--- a/mapeditor/inspector/rewardswidget.h
+++ b/mapeditor/inspector/rewardswidget.h
@@ -40,6 +40,10 @@ private slots:
 
 	void on_resetPeriod_valueChanged(int arg1);
 
+	void on_resetWeeks_valueChanged(int arg1);
+
+	void on_resetMonths_valueChanged(int arg1);
+
 	void on_visitInfoList_itemSelectionChanged();
 
 	void on_visitInfoList_currentItemChanged(QListWidgetItem *current, QListWidgetItem *previous);

--- a/mapeditor/inspector/rewardswidget.ui
+++ b/mapeditor/inspector/rewardswidget.ui
@@ -152,6 +152,26 @@
             </property>
            </widget>
           </item>
+          <item>
+           <widget class="QSpinBox" name="resetWeeks">
+            <property name="suffix">
+             <string> weeks</string>
+            </property>
+            <property name="maximum">
+             <number>99</number>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QSpinBox" name="resetMonths">
+            <property name="suffix">
+             <string> months</string>
+            </property>
+            <property name="maximum">
+             <number>99</number>
+            </property>
+           </widget>
+          </item>
          </layout>
         </item>
         <item>

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -671,11 +671,9 @@ void CGameHandler::onNewTurn()
 {
 	logGlobal->trace("Turn %d", gameState().day+1);
 
-	int daysPerWeek = LIBRARY->engineSettings()->getInteger(EGameSettings::GENERAL_DAYS_PER_WEEK);
-	int daysPerMonth = LIBRARY->engineSettings()->getInteger(EGameSettings::GENERAL_WEEKS_PER_MONTH) * daysPerWeek;
-
-	bool firstTurn = !gameInfo().getDate(Date::DAY);
-	bool newMonth = gameInfo().getDate(Date::DAY_OF_MONTH) == daysPerMonth;
+	auto calendar = gameInfo().getCalendar();
+	bool firstTurn = !calendar.getCurrentDay();
+	bool newMonth = calendar.getDayOfMonth() == calendar.getDaysInMonth();
 
 	if (firstTurn)
 	{
@@ -1146,7 +1144,7 @@ void CGameHandler::setOwner(const CGObjectInstance * obj, const PlayerColor owne
 	if (town) //town captured
 	{
 		if(owner.isValidPlayer())
-			statistics->getPlayerAccumulator(owner).lastCapturedTownDay = gameState().getDate(Date::DAY);
+			statistics->getPlayerAccumulator(owner).lastCapturedTownDay = gameState().getCalendar().getCurrentDay();
 
 		if (owner.isValidPlayer() && town->hasBuilt(BuildingSubID::PORTAL_OF_SUMMONING))
 			setPortalDwelling(town, true, false);

--- a/server/battles/BattleResultProcessor.cpp
+++ b/server/battles/BattleResultProcessor.cpp
@@ -347,7 +347,7 @@ void BattleResultProcessor::endBattleConfirm(const CBattleInfoCallback & battle)
 				if(!strongestHero || hero->exp > strongestHero->exp)
 					strongestHero = hero;
 			if(strongestHero->id == finishingBattle->loserId && strongestHero->level > 5 && finishingBattle->victor.isValidPlayer())
-				gameHandler->statistics->getPlayerAccumulator(finishingBattle->victor).lastDefeatedStrongestHeroDay = gameHandler->gameState().getDate(Date::DAY);
+				gameHandler->statistics->getPlayerAccumulator(finishingBattle->victor).lastDefeatedStrongestHeroDay = gameHandler->gameState().getCalendar().getCurrentDay();
 		}
 	}
 

--- a/server/processors/NewTurnProcessor.cpp
+++ b/server/processors/NewTurnProcessor.cpp
@@ -186,7 +186,7 @@ void NewTurnProcessor::onPlayerTurnEnded(PlayerColor which)
 	// check for 7 days without castle
 	gameHandler->checkVictoryLossConditionsForPlayer(which);
 
-	bool newWeek = gameHandler->gameInfo().getDate(Date::DAY_OF_WEEK) == LIBRARY->engineSettings()->getInteger(EGameSettings::GENERAL_DAYS_PER_WEEK); // end of 7th day
+	bool newWeek = gameHandler->gameInfo().getCalendar().nextDay().getDayOfWeek() == 1; // end of 7th day
 
 	if (newWeek) //new heroes in tavern
 		gameHandler->heroPool->onNewWeek(which);
@@ -264,14 +264,15 @@ ResourceSet NewTurnProcessor::generatePlayerIncome(PlayerColor playerID, bool ne
 		const JsonNode & difficultyConfig = weeklyBonusesConfig[difficultyName];
 
 		// Distribute weekly bonuses over 7 days, depending on the current day of the week
+		auto calendar = gameHandler->gameState().getCalendar();
 		for (GameResID i : LIBRARY->resourceTypeHandler->getAllObjects())
 		{
 			const std::string & name = i.toResource()->getJsonKey();
 			int64_t weeklyBonus = difficultyConfig[name].Integer();
-			int64_t dayOfWeek = gameHandler->gameState().getDate(Date::DAY_OF_WEEK);
+			int64_t dayOfWeek = calendar.getDayOfWeek();
 			int64_t dailyIncome = incomeHandicapped[i];
-			int64_t amountTillToday = dailyIncome * weeklyBonus * (dayOfWeek-1) / LIBRARY->engineSettings()->getInteger(EGameSettings::GENERAL_DAYS_PER_WEEK) / 100;
-			int64_t amountAfterToday = dailyIncome * weeklyBonus * dayOfWeek / LIBRARY->engineSettings()->getInteger(EGameSettings::GENERAL_DAYS_PER_WEEK) / 100;
+			int64_t amountTillToday = dailyIncome * weeklyBonus * (dayOfWeek-1) / calendar.getDaysInWeek() / 100;
+			int64_t amountAfterToday = dailyIncome * weeklyBonus * dayOfWeek / calendar.getDaysInWeek() / 100;
 			int64_t dailyBonusToday = amountAfterToday - amountTillToday;
 			int64_t totalIncomeToday = std::min(GameConstants::PLAYER_RESOURCES_CAP, incomeHandicapped[i] + dailyBonusToday);
 			incomeHandicapped[i] = totalIncomeToday;
@@ -666,12 +667,10 @@ NewTurn NewTurnProcessor::generateNewTurnPack()
 	n.creatureid = CreatureID::NONE;
 	n.day = gameHandler->gameState().day + 1;
 
-	int daysPerWeek = LIBRARY->engineSettings()->getInteger(EGameSettings::GENERAL_DAYS_PER_WEEK);
-	int daysPerMonth = LIBRARY->engineSettings()->getInteger(EGameSettings::GENERAL_WEEKS_PER_MONTH) * daysPerWeek;
-
-	bool firstTurn = !gameHandler->gameInfo().getDate(Date::DAY);
-	bool newWeek = gameHandler->gameInfo().getDate(Date::DAY_OF_WEEK) == daysPerWeek; //day numbers are confusing, as day was not yet switched
-	bool newMonth = gameHandler->gameInfo().getDate(Date::DAY_OF_MONTH) == daysPerMonth;
+	auto calendar = gameHandler->gameInfo().getCalendar();
+	bool firstTurn = !calendar.getCurrentDay();
+	bool newWeek = calendar.nextDay().getDayOfWeek() == 1; //day numbers are confusing, as day was not yet switched
+	bool newMonth = calendar.nextDay().getDayOfMonth() == 1;
 
 	int additionalGrowth = 0;
 
@@ -714,12 +713,10 @@ void NewTurnProcessor::onNewTurn()
 {
 	NewTurn n = generateNewTurnPack();
 
-	int daysPerWeek = LIBRARY->engineSettings()->getInteger(EGameSettings::GENERAL_DAYS_PER_WEEK);
-	int daysPerMonth = LIBRARY->engineSettings()->getInteger(EGameSettings::GENERAL_WEEKS_PER_MONTH) * daysPerWeek;
-
-	bool firstTurn = !gameHandler->gameInfo().getDate(Date::DAY);
-	bool newWeek = gameHandler->gameInfo().getDate(Date::DAY_OF_WEEK) == daysPerWeek; //day numbers are confusing, as day was not yet switched
-	bool newMonth = gameHandler->gameInfo().getDate(Date::DAY_OF_MONTH) == daysPerMonth;
+	auto calendar = gameHandler->gameInfo().getCalendar();
+	bool firstTurn = !calendar.getCurrentDay();
+	bool newWeek = calendar.nextDay().getDayOfWeek() == 1; //day numbers are confusing, as day was not yet switched
+	bool newMonth = calendar.nextDay().getDayOfMonth() == 1;
 
 	gameHandler->sendAndApply(n);
 
@@ -739,7 +736,7 @@ void NewTurnProcessor::onNewTurn()
 		{
 			const auto * t = gameHandler->gameState().getTown(townID);
 			if (!t->getOwner().isValidPlayer())
-				updateNeutralTownGarrison(t, 1 + gameHandler->gameInfo().getDate(Date::DAY) / LIBRARY->engineSettings()->getInteger(EGameSettings::GENERAL_DAYS_PER_WEEK));
+				updateNeutralTownGarrison(t, 1 + calendar.getCurrentDay() / calendar.getDaysInWeek());
 		}
 	}
 

--- a/server/processors/TurnOrderProcessor.cpp
+++ b/server/processors/TurnOrderProcessor.cpp
@@ -192,10 +192,11 @@ bool TurnOrderProcessor::computeCanActSimultaneously(PlayerColor active, PlayerC
 			return false;
 	}
 
-	if (gameHandler->gameInfo().getDate(Date::DAY) < simturnsTurnsMinLimit())
+	int currentDay = gameHandler->gameInfo().getCalendar().getCurrentDay();
+	if (currentDay < simturnsTurnsMinLimit())
 		return true;
 
-	if (gameHandler->gameInfo().getDate(Date::DAY) > simturnsTurnsMaxLimit())
+	if (currentDay > simturnsTurnsMaxLimit())
 		return false;
 
 	if (gameHandler->gameInfo().getStartInfo()->simturnsInfo.ignoreAlliedContacts && activeInfo->team == waitingInfo->team)
@@ -424,10 +425,10 @@ bool TurnOrderProcessor::isPlayerAwaitsNewDay(PlayerColor which) const
 
 void TurnOrderProcessor::setMinSimturnsDuration(int days)
 {
-	simturnsMinDurationDays = gameHandler->gameInfo().getDate(Date::DAY) + days;
+	simturnsMinDurationDays = gameHandler->gameInfo().getCalendar().getCurrentDay() + days;
 }
 
 void TurnOrderProcessor::setMaxSimturnsDuration(int days)
 {
-	simturnsMaxDurationDays = gameHandler->gameInfo().getDate(Date::DAY) + days;
+	simturnsMaxDurationDays = gameHandler->gameInfo().getCalendar().getCurrentDay() + days;
 }

--- a/test/mock/mock_IGameInfoCallback.h
+++ b/test/mock/mock_IGameInfoCallback.h
@@ -20,7 +20,7 @@ class IGameInfoCallbackMock : public IGameInfoCallback
 {
 public:
 	//various
-	MOCK_CONST_METHOD1(getDate, int(Date));
+	MOCK_CONST_METHOD0(getCalendar, Calendar());
 	MOCK_CONST_METHOD0(getStartInfo, const StartInfo *());
 	MOCK_CONST_METHOD0(getMapHeader, const CMapHeader *());
 	MOCK_CONST_METHOD0(getMapSize, int3());


### PR DESCRIPTION
Adds class `Calendar` that wraps all game date management, including awareness of week & month duration.

Removed existing getDate() method with enum-based configuration.

Configurable / rewardable map objects can now define reset period in weeks or months that is aware of variadic length of week or month

Temporarily removed unused Lua bindings to getDate. Will restore later in separate PR once I start working on adventure map API