### PR TITLE
Add auto-close for stale PR's

### DIFF
--- a/.github/workflows/stale-prs.yml
+++ b/.github/workflows/stale-prs.yml
@@ -1,0 +1,35 @@
+name: Close stale PRs
+
+on:
+  schedule:
+    - cron: '0 12 * * *'
+  workflow_dispatch:
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+          # Only PRs, not issues
+          days-before-issue-stale: -1
+          days-before-issue-close: -1
+          days-before-pr-stale: 60
+          days-before-pr-close: 60
+
+          stale-pr-label: stale
+          stale-pr-message: >
+            This PR has had no activity for 60 days and has been marked as stale.
+            If this PR is complete but needs review or merge, please contact VCMI Team either via comment here or via Discord.
+            If this PR is still relevant but on hold, please add label 'postponed'
+            This pull request will be closed in 60 days more if there is no further activity.
+          close-pr-message: >
+            This PR has been closed due to inactivity.
+            Feel free to reopen it if you'd like to continue working on it.
+
+          exempt-pr-labels: postponed
+
+          # only process 1 PR per run (with 1 run / day via cron)
+          operations-per-run: 1


### PR DESCRIPTION
Up to discussion.

PR's will be marked as 'stale' after 60 days of inactivity, and auto-closed after 60 more days (unless there was some activity meanwhile.

Goal is not just close old PR's but to make sure that me / our team won't forget about older PR's - via "stale PR" notification. Because when looking through old PR's there were some PR's that were largely ready to merge but forgotten once they went to the end of our PR list.

In theory this approach can be extended to issues later with way larger period (like 3 years), to act as notification / reminder to review old issues & decide what to do with them (implement/postpone/drop)