### PR TITLE
Fix level-up crash + rest of flickering

### DIFF
--- a/client/windows/CCreatureWindow.cpp
+++ b/client/windows/CCreatureWindow.cpp
@@ -878,8 +878,13 @@ void CStackWindow::submitSelection()
 {
 	if(!selectionSubmitted)
 	{
-		if(info->levelupInfo && !info->levelupInfo->skills.empty())
-			info->levelupInfo->callback(vstd::find_pos(info->levelupInfo->skills, selectedSkill));
+		if(info->levelupInfo)
+		{
+			if(info->levelupInfo->skills.empty())
+				info->levelupInfo->callback(0);
+			else
+				info->levelupInfo->callback(vstd::find_pos(info->levelupInfo->skills, selectedSkill));
+		}
 
 		selectionSubmitted = true;
 

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -590,7 +590,11 @@ void CLevelWindow::submitSelection()
 
 		// If there are skills available, we must not close without producing a valid choice
 		// For a single available option, auto-pick it
-		if(!skills.empty())
+		if(skills.empty())
+		{
+			cb(0);
+		}
+		else
 		{
 			if(idx == -1)
 			{

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -155,17 +155,15 @@ void CGameHandler::levelUpHero(const CGHeroInstance * hero)
 	hlu.primskill = primarySkill;
 	hlu.skills = randomizer->rollSecondarySkills(hero);
 
-	if (hlu.skills.size() == 0)
+	if (!hero->getOwner().isValidPlayer())
 	{
 		sendAndApply(hlu);
-		levelUpHero(hero);
+		if(hlu.skills.empty())
+			levelUpHero(hero);
+		else
+			levelUpHero(hero, hlu.skills.front());
 	}
-	else if (hlu.skills.size() == 1 || !hero->getOwner().isValidPlayer())
-	{
-		sendAndApply(hlu);
-		levelUpHero(hero, hlu.skills.front());
-	}
-	else if (hlu.skills.size() > 1)
+	else
 	{
 		auto levelUpQuery = std::make_shared<CHeroLevelUpDialogQuery>(this, hlu, hero);
 		queries->addQuery(levelUpQuery);
@@ -295,19 +293,15 @@ void CGameHandler::levelUpCommander(const CCommanderInstance * c)
 			clu.skills.push_back (i);
 		++i;
 	}
-	int skillAmount = clu.skills.size();
-
-	if (!skillAmount)
+	if (!hero->getOwner().isValidPlayer()) //choose skill automatically
 	{
 		sendAndApply(clu);
-		levelUpCommander(c);
+		if(clu.skills.empty())
+			levelUpCommander(c);
+		else
+			levelUpCommander(c, *RandomGeneratorUtil::nextItem(clu.skills, getRandomGenerator()));
 	}
-	else if (skillAmount == 1  ||  hero->tempOwner == PlayerColor::NEUTRAL) //choose skill automatically
-	{
-		sendAndApply(clu);
-		levelUpCommander(c, *RandomGeneratorUtil::nextItem(clu.skills, getRandomGenerator()));
-	}
-	else if (skillAmount > 1) //apply and ask for secondary skill
+	else
 	{
 		auto commanderLevelUp = std::make_shared<CCommanderLevelUpDialogQuery>(this, clu, hero);
 		queries->addQuery(commanderLevelUp);
@@ -336,6 +330,12 @@ void CGameHandler::giveStackExperience(const CArmedInstance * army, TExpType val
 }
 
 void CGameHandler::giveExperience(const CGHeroInstance * hero, TExpType amountToGain)
+{
+	giveExperienceWithoutLevelUp(hero, amountToGain);
+	expGiven(hero);
+}
+
+void CGameHandler::giveExperienceWithoutLevelUp(const CGHeroInstance * hero, TExpType amountToGain)
 {
 	TExpType maxExp = LIBRARY->heroh->reqExp(LIBRARY->heroh->maxSupportedLevel());
 	TExpType currHeroExp = hero->exp;
@@ -386,7 +386,6 @@ void CGameHandler::giveExperience(const CGHeroInstance * hero, TExpType amountTo
 		sendAndApply(scp);
 	}
 
-	expGiven(hero);
 }
 
 void CGameHandler::changePrimSkill(const CGHeroInstance * hero, PrimarySkill which, si64 val, ChangeValueMode mode)

--- a/server/CGameHandler.h
+++ b/server/CGameHandler.h
@@ -113,6 +113,7 @@ public:
 	bool removeObject(const CGObjectInstance * obj, const PlayerColor & initiator) override;
 	void setOwner(const CGObjectInstance * obj, PlayerColor owner) override;
 	void giveExperience(const CGHeroInstance * hero, TExpType val) override;
+	void giveExperienceWithoutLevelUp(const CGHeroInstance * hero, TExpType val);
 	void giveStackExperience(const CArmedInstance * army, TExpType val);
 	void changePrimSkill(const CGHeroInstance * hero, PrimarySkill which, si64 val, ChangeValueMode mode) override;
 	void changeSecSkill(const CGHeroInstance * hero, SecondarySkill which, int val, ChangeValueMode mode) override;

--- a/server/battles/BattleResultProcessor.cpp
+++ b/server/battles/BattleResultProcessor.cpp
@@ -332,7 +332,10 @@ void BattleResultProcessor::endBattleConfirm(const CBattleInfoCallback & battle)
 
 		gameHandler->giveStackExperience(battle.battleGetArmyObject(finishingBattle->winnerSide), battleResult->exp[finishingBattle->winnerSide]);
 		if (winnerHero)
-			gameHandler->giveExperience(winnerHero, battleResult->exp[finishingBattle->winnerSide]);
+		{
+			gameHandler->giveExperienceWithoutLevelUp(winnerHero, battleResult->exp[finishingBattle->winnerSide]);
+			battleQuery->heroesWithDeferredLevelUp.push_back(winnerHero->id);
+		}
 	}
 
 	// Add statistics
@@ -393,7 +396,7 @@ void BattleResultProcessor::endBattleConfirm(const CBattleInfoCallback & battle)
 	gameHandler->sendAndApply(raccepted);
 
 	gameHandler->queries->popIfTop(battleQuery); // Workaround to remove battle query for AI case. TODO Think of a cleaner solution.
-	//--> continuation (battleFinalize) occurs after level-up gameHandler->queries are handled or on removing query
+	//--> continuation (battleFinalize) occurs on removing query
 }
 
 void BattleResultProcessor::battleFinalize(const BattleID & battleID, const BattleResult & result)

--- a/server/queries/BattleQueries.cpp
+++ b/server/queries/BattleQueries.cpp
@@ -11,6 +11,7 @@
 #include "BattleQueries.h"
 #include "MapQueries.h"
 #include "QueriesProcessor.h"
+#include "VisitQueries.h"
 
 #include "../CGameHandler.h"
 #include "../battles/BattleProcessor.h"
@@ -19,8 +20,37 @@
 #include "../../lib/battle/BattleLayout.h"
 #include "../../lib/battle/SideInBattle.h"
 #include "../../lib/CPlayerState.h"
+#include "../../lib/gameState/CGameState.h"
 #include "../../lib/mapObjects/CGObjectInstance.h"
 #include "../../lib/networkPacks/PacksForServer.h"
+
+bool CBattleQuery::hasPendingBattleOrVisitQueries() const
+{
+	return std::any_of(players.begin(), players.end(), [this](const PlayerColor & player)
+	{
+		auto top = owner->topQuery(player);
+		return top.get() == this || std::dynamic_pointer_cast<MapObjectVisitQuery>(top);
+	});
+}
+
+std::vector<ObjectInstanceID> CBattleQuery::takeDeferredLevelUps()
+{
+	deferredLevelUpsApplied = true;
+	auto deferredLevelUps = std::move(heroesWithDeferredLevelUp);
+	heroesWithDeferredLevelUp.clear();
+	return deferredLevelUps;
+}
+
+void CBattleQuery::completeDeferredLevelUps() const
+{
+	if(deferredLevelUpsApplied)
+		return;
+
+	deferredLevelUpsApplied = true;
+	for(const auto & heroID : heroesWithDeferredLevelUp)
+		if(const auto * hero = gh->gameState().getHero(heroID))
+			gh->expGiven(hero);
+}
 
 void CBattleQuery::notifyObjectAboutRemoval(const CGObjectInstance * visitedObject, const CGHeroInstance * visitingHero) const
 {
@@ -65,6 +95,12 @@ void CBattleQuery::onRemoval(PlayerColor color)
 
 	if(result)
 		gh->battles->battleFinalize(battleID, *result);
+
+	// Guarded map object visits are notified after the battle query is removed.
+	// In that case, defer level-up prompts until the object applies its battle result.
+	// In multi-player battles, also wait until this battle query is removed for all players.
+	if(!hasPendingBattleOrVisitQueries())
+		completeDeferredLevelUps();
 }
 
 void CBattleQuery::onExposure(QueryPtr topQuery)

--- a/server/queries/BattleQueries.h
+++ b/server/queries/BattleQueries.h
@@ -25,6 +25,12 @@ public:
 
 	BattleID battleID;
 	std::optional<BattleResult> result;
+	std::vector<ObjectInstanceID> heroesWithDeferredLevelUp;
+	mutable bool deferredLevelUpsApplied = false;
+
+	bool hasPendingBattleOrVisitQueries() const;
+	std::vector<ObjectInstanceID> takeDeferredLevelUps();
+	void completeDeferredLevelUps() const;
 
 	CBattleQuery(CGameHandler * owner);
 	CBattleQuery(CGameHandler * owner, const IBattleInfo * Bi);

--- a/server/queries/MapQueries.cpp
+++ b/server/queries/MapQueries.cpp
@@ -232,6 +232,13 @@ CHeroLevelUpDialogQuery::CHeroLevelUpDialogQuery(CGameHandler * owner, const Her
 void CHeroLevelUpDialogQuery::onRemoval(PlayerColor color)
 {
 	assert(answer);
+	if(hlu.skills.empty())
+	{
+		logGlobal->trace("Completing hero level-up query. %s gains no secondary skill", hero->getObjectName());
+		gh->levelUpHero(hero);
+		return;
+	}
+
 	logGlobal->trace("Completing hero level-up query. %s gains skill %d", hero->getObjectName(), answer.value());
 	gh->levelUpHero(hero, hlu.skills[*answer]);
 }
@@ -293,6 +300,13 @@ CCommanderLevelUpDialogQuery::CCommanderLevelUpDialogQuery(CGameHandler * owner,
 void CCommanderLevelUpDialogQuery::onRemoval(PlayerColor color)
 {
 	assert(answer);
+	if(clu.skills.empty())
+	{
+		logGlobal->trace("Completing commander level-up query. Commander of hero %s gains no skill", hero->getObjectName());
+		gh->levelUpCommander(hero->getCommander());
+		return;
+	}
+
 	logGlobal->trace("Completing commander level-up query. Commander of hero %s gains skill %s", hero->getObjectName(), answer.value());
 	gh->levelUpCommander(hero->getCommander(), clu.skills[*answer]);
 }

--- a/server/queries/VisitQueries.cpp
+++ b/server/queries/VisitQueries.cpp
@@ -39,8 +39,10 @@ void MapObjectVisitQuery::onExposure(QueryPtr topQuery)
 	auto object = gh->gameState().getObjInstance(visitedObject);
 	auto hero = gh->gameState().getHero(visitingHero);
 
-	//Object may have been removed and deleted.
-	if (object)
+	// Object may have been removed and deleted.
+	// Deferred battle XP level-ups are not part of the object reward pipeline,
+	// so they must not trigger heroLevelUpDone on the visited object.
+	if (object && !processingDeferredBattleLevelUps)
 		topQuery->notifyObjectAboutRemoval(object, hero);
 
 	if(auto battleQuery = std::dynamic_pointer_cast<CBattleQuery>(topQuery))
@@ -51,10 +53,17 @@ void MapObjectVisitQuery::onExposure(QueryPtr topQuery)
 
 	if(owner->topQuery(players.front()).get() == this)
 	{
-		for(const auto & heroID : deferredBattleLevelUps)
-			if(const auto * deferredHero = gh->gameState().getHero(heroID))
-				gh->expGiven(deferredHero);
-		deferredBattleLevelUps.clear();
+		if(!deferredBattleLevelUps.empty())
+		{
+			processingDeferredBattleLevelUps = true;
+			for(const auto & heroID : deferredBattleLevelUps)
+				if(const auto * deferredHero = gh->gameState().getHero(heroID))
+					gh->expGiven(deferredHero);
+			deferredBattleLevelUps.clear();
+		}
+
+		if(owner->topQuery(players.front()).get() == this)
+			processingDeferredBattleLevelUps = false;
 	}
 
 	owner->popIfTop(*this);

--- a/server/queries/VisitQueries.cpp
+++ b/server/queries/VisitQueries.cpp
@@ -10,6 +10,8 @@
 #include "StdInc.h"
 #include "VisitQueries.h"
 
+#include "BattleQueries.h"
+
 #include "../../lib/gameState/CGameState.h"
 #include "../../lib/mapObjects/CGHeroInstance.h"
 #include "../../lib/mapObjects/CGTownInstance.h"
@@ -40,6 +42,20 @@ void MapObjectVisitQuery::onExposure(QueryPtr topQuery)
 	//Object may have been removed and deleted.
 	if (object)
 		topQuery->notifyObjectAboutRemoval(object, hero);
+
+	if(auto battleQuery = std::dynamic_pointer_cast<CBattleQuery>(topQuery))
+	{
+		auto levelUps = battleQuery->takeDeferredLevelUps();
+		deferredBattleLevelUps.insert(deferredBattleLevelUps.end(), levelUps.begin(), levelUps.end());
+	}
+
+	if(owner->topQuery(players.front()).get() == this)
+	{
+		for(const auto & heroID : deferredBattleLevelUps)
+			if(const auto * deferredHero = gh->gameState().getHero(heroID))
+				gh->expGiven(deferredHero);
+		deferredBattleLevelUps.clear();
+	}
 
 	owner->popIfTop(*this);
 }

--- a/server/queries/VisitQueries.h
+++ b/server/queries/VisitQueries.h
@@ -32,6 +32,7 @@ public:
 class MapObjectVisitQuery final : public VisitQuery
 {
 	std::vector<ObjectInstanceID> deferredBattleLevelUps;
+	bool processingDeferredBattleLevelUps = false;
 
 public:
 	bool removeObjectAfterVisit;

--- a/server/queries/VisitQueries.h
+++ b/server/queries/VisitQueries.h
@@ -31,6 +31,8 @@ public:
 
 class MapObjectVisitQuery final : public VisitQuery
 {
+	std::vector<ObjectInstanceID> deferredBattleLevelUps;
+
 public:
 	bool removeObjectAfterVisit;
 


### PR DESCRIPTION
Fixes regression from: https://github.com/vcmi/vcmi/pull/7224, also fixes rest of flickering, when there was 1 or 0 skills available.

Fixes: https://github.com/vcmi/vcmi/issues/7433

Just to be sure I will retest it later today in some game session.