### PR TITLE
Add artifact reward background

### DIFF
--- a/client/widgets/CComponent.cpp
+++ b/client/widgets/CComponent.cpp
@@ -24,6 +24,7 @@
 #include "../windows/InfoWindows.h"
 #include "TextControls.h"
 
+#include "../../lib/CConfigHandler.h"
 #include "../../lib/entities/artifact/ArtifactUtils.h"
 #include "../../lib/entities/artifact/CArtHandler.h"
 #include "../../lib/entities/building/CBuilding.h"
@@ -73,7 +74,12 @@ void CComponent::init(ComponentType Type, ComponentSubType Subtype, std::optiona
 
 	assert(size < sizeInvalid);
 
-	setSurface(getFileName()[size], (int)getIndex());
+	const auto imagePaths = getFileName();
+	const auto imageIndex = static_cast<int>(getIndex());
+	if(shouldUseRewardArtifactBackground(Type, imageSize))
+		setRewardArtifactBackground(imagePaths[size], imageIndex);
+	else
+		setSurface(imagePaths[size], imageIndex);
 
 	pos.w = image->pos.w;
 	pos.h = image->pos.h;
@@ -346,6 +352,21 @@ void CComponent::setSurface(const AnimationPath & defName, int imgPos)
 {
 	OBJECT_CONSTRUCTION;
 	image = std::make_shared<CAnimImage>(defName, imgPos);
+}
+
+bool CComponent::shouldUseRewardArtifactBackground(ComponentType Type, ESize imageSize) const
+{
+	return settings["general"]["enableUiEnhancements"].Bool() && Type == ComponentType::ARTIFACT && imageSize == large;
+}
+
+void CComponent::setRewardArtifactBackground(const AnimationPath & artifactDefName, int artifactImgPos)
+{
+	OBJECT_CONSTRUCTION;
+
+	image = std::make_shared<CAnimImage>(AnimationPath::builtin("SECSK82"), 0);
+	artifactOverlay = std::make_shared<CAnimImage>(artifactDefName, artifactImgPos);
+
+	artifactOverlay->moveTo(Point((image->pos.w - artifactOverlay->pos.w) / 2, (image->pos.h - artifactOverlay->pos.h) / 2));
 }
 
 void CComponent::showPopupWindow(const Point & cursorPosition)

--- a/client/widgets/CComponent.h
+++ b/client/widgets/CComponent.h
@@ -39,11 +39,15 @@ public:
 
 private:
 	std::vector<std::shared_ptr<CLabel>> lines;
+	std::shared_ptr<CAnimImage> artifactOverlay;
 
 	size_t getIndex() const;
 	std::vector<AnimationPath> getFileName() const;
 	void setSurface(const AnimationPath & defName, int imgPos);
 
+	void setRewardArtifactBackground(const AnimationPath & artifactDefName, int artifactImgPos);
+	bool shouldUseRewardArtifactBackground(ComponentType Type, ESize imageSize) const;
+	
 	void init(ComponentType Type, ComponentSubType Subtype, std::optional<int32_t> Val, ESize imageSize, EFonts font, const std::string & ValText);
 
 public:


### PR DESCRIPTION
When enabled Interface Enhancements use SECSK82 frame 0 and ceter artifact inside to align it with resource / skill / experience rewards size

Without Interface Enhancements
<img width="350" height="511" alt="image" src="https://github.com/user-attachments/assets/c6da6e3c-fddf-47de-b940-0459077cf663" />

With Interface Enhancements
<img width="507" height="560" alt="image" src="https://github.com/user-attachments/assets/0b6abf57-96bd-46df-8362-293126b82b14" />