### PR TITLE
Remove usage of namespace wrapper on mobile systems

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -858,12 +858,6 @@ if(ENABLE_STATIC_LIBS AND ENABLE_CLIENT)
 	endif()
 endif()
 
-# no longer necessary, but might be useful to keep in future
-# unfortunately at the moment tests do not support namespaced build, so enable only on some systems
-if(IOS OR ANDROID)
-	target_compile_definitions(vcmi PUBLIC VCMI_LIB_NAMESPACE=VCMI)
-endif()
-
 if(IOS)
 	target_link_libraries(vcmi PUBLIC iOS_utils)
 endif()


### PR DESCRIPTION
Reasoning:
- does not gives us any useful functionality
- constantly breaks Github CI since devs rarely have local iOS/Android builds
- functionality that relied on this feature was removed years ago

For now actual macro's stay in code to help with transition since active PR's may add new files with this macro. To be removed later, but their usage is no longer enforced / checked