### PR TITLE
Treat next-turn town threats as recruit emergencies

### DIFF
--- a/AI/Nullkiller2/Behaviors/CaptureObjectsBehavior.cpp
+++ b/AI/Nullkiller2/Behaviors/CaptureObjectsBehavior.cpp
@@ -89,6 +89,9 @@ Goals::TGoalVec CaptureObjectsBehavior::getVisitGoals(
 			continue;
 		}
 
+		if(nullkiller->arePathHeroesLocked(path))
+			continue;
+
 		auto firstBlockedAction = path.getFirstBlockedAction();
 		if(firstBlockedAction)
 		{
@@ -138,11 +141,8 @@ Goals::TGoalVec CaptureObjectsBehavior::getVisitGoals(
 				closestWay = &path;
 			}
 
-			if(!nullkiller->arePathHeroesLocked(path))
-			{
-				waysToVisitObj.push_back(newWay);
-				tasks[tasks.size() - 1] = sharedPtr;
-			}
+			waysToVisitObj.push_back(newWay);
+			tasks[tasks.size() - 1] = sharedPtr;
 		}
 	}
 

--- a/AI/Nullkiller2/Behaviors/DefenceBehavior.cpp
+++ b/AI/Nullkiller2/Behaviors/DefenceBehavior.cpp
@@ -10,9 +10,9 @@
 #include "StdInc.h"
 #include "DefenceBehavior.h"
 
+#include "../../../lib/IGameSettings.h"
 #include "../AIGateway.h"
 #include "../AIUtility.h"
-#include "CaptureObjectsBehavior.h"
 #include "../Engine/Nullkiller.h"
 #include "../Goals/BuyArmy.h"
 #include "../Goals/Composition.h"
@@ -21,7 +21,8 @@
 #include "../Goals/ExecuteHeroChain.h"
 #include "../Goals/RecruitHero.h"
 #include "../Markers/DefendTown.h"
-#include "../../../lib/IGameSettings.h"
+#include "CaptureObjectsBehavior.h"
+#include "RecruitHeroBehavior.h"
 
 namespace NK2AI
 {
@@ -29,6 +30,173 @@ namespace NK2AI
 const float THREAT_IGNORE_RATIO = 2;
 
 using namespace Goals;
+
+namespace Goals
+{
+	uint64_t estimateTownFortificationDefence(const CGTownInstance & town, bool hasDefenders)
+	{
+		if(!hasDefenders)
+			return 0;
+
+		if(town.fortLevel() == CGTownInstance::CASTLE)
+			return 10000;
+
+		if(town.fortLevel() == CGTownInstance::CITADEL)
+			return 4000;
+
+		return 0;
+	}
+
+	uint64_t estimateTownDefence(const CGTownInstance & town, const CGHeroInstance * committedDefender)
+	{
+		uint64_t result = town.getArmyStrength();
+
+		if(committedDefender)
+			result = std::max(result, committedDefender->getTotalStrength());
+
+		return result + estimateTownFortificationDefence(town, committedDefender && result > 0);
+	}
+
+	bool isTownDefenceSufficient(uint64_t defenceStrength, const HitMapInfo & threat, float safeAttackRatio)
+	{
+		if(threat.danger == 0)
+			return true;
+
+		const auto requiredDefence = threat.turn == 0 ? static_cast<float>(threat.danger) : threat.danger * safeAttackRatio;
+
+		return defenceStrength >= requiredDefence;
+	}
+
+	bool shouldLockTownDefender(const CGTownInstance & town, const CGHeroInstance & defender, const HitMapInfo & threat, float safeAttackRatio)
+	{
+		if(threat.danger == 0 || threat.turn > 1)
+			return false;
+
+		if(isTownDefenceSufficient(estimateTownDefence(town, nullptr), threat, safeAttackRatio))
+			return false;
+
+		return isTownDefenceSufficient(estimateTownDefence(town, &defender), threat, safeAttackRatio);
+	}
+
+	int countTownThreatsCoveredByDefender(const CGTownInstance & town, const CGHeroInstance & defender, const std::vector<HitMapInfo> & threats, float safeAttackRatio)
+	{
+		int result = 0;
+		const auto townDefence = estimateTownDefence(town, nullptr);
+		const auto defenceWithHero = estimateTownDefence(town, &defender);
+
+		for(const auto & threat : threats)
+		{
+			if(threat.danger == 0 || threat.turn > 1)
+				continue;
+
+			if(isTownDefenceSufficient(townDefence, threat, safeAttackRatio))
+				continue;
+
+			if(isTownDefenceSufficient(defenceWithHero, threat, safeAttackRatio))
+				++result;
+		}
+
+		return result;
+	}
+
+	bool isHeroRequiredForTownDefence(const CGTownInstance & town, const CGHeroInstance & defender, const std::vector<HitMapInfo> & threats, float safeAttackRatio)
+	{
+		return countTownThreatsCoveredByDefender(town, defender, threats, safeAttackRatio) > 0;
+	}
+
+	bool shouldReserveTownDefender(const CGTownInstance & town, const CGHeroInstance & defender, const std::vector<HitMapInfo> & threats, float safeAttackRatio)
+	{
+		const auto townDefence = estimateTownDefence(town, nullptr);
+		const auto defenceWithHero = estimateTownDefence(town, &defender);
+
+		if(defenceWithHero <= townDefence)
+			return false;
+
+		for(const auto & threat : threats)
+		{
+			if(threat.danger == 0 || threat.turn > 1)
+				continue;
+
+			if(!isTownDefenceSufficient(townDefence, threat, safeAttackRatio))
+				return true;
+		}
+
+		return false;
+	}
+}
+
+namespace
+{
+	constexpr float DEFENSIVE_EMERGENCY_PRIORITY = 1000000.0f;
+
+	uint64_t estimateTownMobileDefence(const CGTownInstance * town)
+	{
+		uint64_t result = town->getArmyStrength();
+
+		if(const auto * visitingHero = town->getVisitingHero())
+			result = std::max(result, visitingHero->getTotalStrength());
+
+		if(const auto * garrisonHero = town->getGarrisonHero())
+			result = std::max(result, garrisonHero->getTotalStrength());
+
+		return result;
+	}
+
+	bool shouldLockPathDefender(const CGTownInstance * town, const HitMapInfo & threat, const AIPath & path, const Nullkiller * aiNk)
+	{
+		return path.turn() == 0 && shouldLockTownDefender(*town, *path.targetHero, threat, aiNk->settings->getSafeAttackRatio());
+	}
+
+	void setDefensiveEmergencyPriority(Composition & composition, bool emergency)
+	{
+		if(emergency)
+			composition.setpriority(DEFENSIVE_EMERGENCY_PRIORITY);
+	}
+
+	uint64_t stableTownDefence(const CGTownInstance * town, const Nullkiller * aiNk)
+	{
+		uint64_t result = estimateTownDefence(*town, nullptr);
+
+		if(const auto * garrisonHero = town->getGarrisonHero())
+		{
+			if(aiNk->getHeroLockedReason(garrisonHero) == HeroLockedReason::DEFENCE)
+				result = std::max(result, estimateTownDefence(*town, garrisonHero));
+		}
+
+		if(const auto * visitingHero = town->getVisitingHero())
+		{
+			if(aiNk->getHeroLockedReason(visitingHero) == HeroLockedReason::DEFENCE)
+				result = std::max(result, estimateTownDefence(*town, visitingHero));
+		}
+
+		return result;
+	}
+
+	bool hasStableTownDefence(const CGTownInstance * town, const HitMapInfo & threat, const Nullkiller * aiNk)
+	{
+		if(threat.danger == 0)
+			return true;
+
+		return isTownDefenceSufficient(stableTownDefence(town, aiNk), threat, aiNk->settings->getSafeAttackRatio());
+	}
+
+	bool containsRecruitHeroTask(const Goals::TSubgoal & task, const CGHeroInstance * hero)
+	{
+		if(const auto * recruitGoal = dynamic_cast<const Goals::RecruitHero *>(task.get()))
+			return recruitGoal->getHero() == hero;
+
+		if(task->goalType == Goals::COMPOSITION)
+		{
+			for(const auto & subgoal : task->decompose(nullptr))
+			{
+				if(containsRecruitHeroTask(subgoal, hero))
+					return true;
+			}
+		}
+
+		return false;
+	}
+}
 
 std::string DefenceBehavior::toString() const
 {
@@ -82,6 +250,9 @@ void handleCounterAttack(
 	Goals::TGoalVec & tasks
 )
 {
+	if(!hasStableTownDefence(town, threat, aiNk))
+		return;
+
 	if(threat.heroPtr.isVerified() && threat.turn <= 1 && (threat.danger == maximumDanger.danger || threat.turn < maximumDanger.turn))
 	{
 		auto heroCapturingPaths = aiNk->pathfinder->getPathInfo(threat.heroPtr->visitablePos());
@@ -102,11 +273,13 @@ void handleCounterAttack(
 	}
 }
 
-bool handleGarrisonHeroFromPreviousTurn(const CGTownInstance * town, Goals::TGoalVec & tasks, const Nullkiller * aiNk)
+bool handleGarrisonHeroFromPreviousTurn(const CGTownInstance * town, Goals::TGoalVec & tasks, const Nullkiller * aiNk, const std::vector<HitMapInfo> & threats)
 {
-	if(aiNk->isHeroLocked(town->getGarrisonHero()))
+	const auto * garrisonHero = town->getGarrisonHero();
+
+	if(aiNk->isHeroLocked(garrisonHero) || shouldReserveTownDefender(*town, *garrisonHero, threats, aiNk->settings->getSafeAttackRatio()))
 	{
-		logAi->trace("Hero %s in garrison of town %s is supposed to defend the town", town->getGarrisonHero()->getNameTranslated(), town->getNameTranslated());
+		logAi->trace("Hero %s in garrison of town %s is supposed to defend the town", garrisonHero->getNameTranslated(), town->getNameTranslated());
 		return true;
 	}
 
@@ -114,12 +287,12 @@ bool handleGarrisonHeroFromPreviousTurn(const CGTownInstance * town, Goals::TGoa
 	{
 		if(aiNk->cc->getHeroCount(aiNk->playerID, false) < GameConstants::MAX_HEROES_PER_PLAYER)
 		{
-			logAi->trace("Extracting hero %s from garrison of town %s", town->getGarrisonHero()->getNameTranslated(), town->getNameTranslated());
+			logAi->trace("Extracting hero %s from garrison of town %s", garrisonHero->getNameTranslated(), town->getNameTranslated());
 			tasks.push_back(Goals::sptr(Goals::ExchangeSwapTownHeroes(town, nullptr).setpriority(5)));
 			return false;
 		}
 
-		if(aiNk->heroManager->getHeroRoleOrDefaultInefficient(town->getGarrisonHero()) == HeroRole::MAIN)
+		if(aiNk->heroManager->getHeroRoleOrDefaultInefficient(garrisonHero) == HeroRole::MAIN)
 		{
 			auto armyDismissLimit = 1000;
 			auto heroToDismiss = aiNk->heroManager->findWeakHeroToDismiss(armyDismissLimit);
@@ -146,7 +319,7 @@ void DefenceBehavior::evaluateDefence(Goals::TGoalVec & tasks, const CGTownInsta
 	// or simply no one is around
 	threats.push_back(threatNode.fastestDanger); // no guarantee that fastest danger will be there
 
-	if(town->getGarrisonHero() && handleGarrisonHeroFromPreviousTurn(town, tasks, aiNk))
+	if(town->getGarrisonHero() && handleGarrisonHeroFromPreviousTurn(town, tasks, aiNk, threats))
 		return;
 
 	if(!threatNode.fastestDanger.heroPtr.isVerified())
@@ -217,9 +390,8 @@ void DefenceBehavior::evaluateDefence(Goals::TGoalVec & tasks, const CGTownInsta
 			);
 #endif
 
-			auto townDefenseStrength = town->getGarrisonHero()
-										 ? town->getGarrisonHero()->getTotalStrength()
-										 : (town->getVisitingHero() ? town->getVisitingHero()->getTotalStrength() : town->getUpperArmy()->getArmyStrength());
+			const auto townDefenseStrength = estimateTownMobileDefence(town);
+			const bool lockDefenderNow = shouldLockPathDefender(town, threat, path, aiNk);
 
 			if(town->getVisitingHero() && path.targetHero == town->getVisitingHero())
 			{
@@ -262,13 +434,12 @@ void DefenceBehavior::evaluateDefence(Goals::TGoalVec & tasks, const CGTownInsta
 				if(town->getGarrisonHero() || town->getUpperArmy()->stacksCount() == 0 || path.targetHero->canBeMergedWith(*town)
 				   || (town->getUpperArmy()->getArmyStrength() < 500 && town->fortLevel() >= CGTownInstance::CITADEL))
 				{
-					tasks.push_back(
-						Goals::sptr(
-							Composition()
-								.addNext(DefendTown(town, threat, path.targetHero))
-								.addNext(ExchangeSwapTownHeroes(town, town->getVisitingHero(), HeroLockedReason::DEFENCE))
-						)
-					);
+					Composition composition;
+					composition.addNext(DefendTown(town, threat, path.targetHero))
+						.addNext(ExchangeSwapTownHeroes(town, town->getVisitingHero(), HeroLockedReason::DEFENCE));
+
+					setDefensiveEmergencyPriority(composition, lockDefenderNow);
+					tasks.push_back(Goals::sptr(composition));
 				}
 
 				continue;
@@ -296,7 +467,8 @@ void DefenceBehavior::evaluateDefence(Goals::TGoalVec & tasks, const CGTownInsta
 				continue;
 			}
 
-			if(threat.turn == 0 || (path.turn() <= threat.turn && path.getHeroStrength() >= threat.danger * aiNk->settings->getSafeAttackRatio()))
+			const bool heroStrengthCoversThreat = path.turn() <= threat.turn && path.getHeroStrength() >= threat.danger * aiNk->settings->getSafeAttackRatio();
+			if(threat.turn == 0 || lockDefenderNow || heroStrengthCoversThreat)
 			{
 				if(aiNk->arePathHeroesLocked(path))
 				{
@@ -314,6 +486,8 @@ void DefenceBehavior::evaluateDefence(Goals::TGoalVec & tasks, const CGTownInsta
 		for(int i : pathsToDefend)
 		{
 			AIPath & path = paths[i];
+			const bool lockDefenderNow = shouldLockPathDefender(town, threat, path, aiNk);
+
 			for(int j : defferedPaths[path.targetHero])
 			{
 				AIPath & defferedPath = paths[j];
@@ -330,6 +504,7 @@ void DefenceBehavior::evaluateDefence(Goals::TGoalVec & tasks, const CGTownInsta
 			if(town->getGarrisonHero() && path.targetHero == town->getGarrisonHero() && path.exchangeCount == 1)
 			{
 				composition.addNext(ExchangeSwapTownHeroes(town, town->getGarrisonHero(), HeroLockedReason::DEFENCE));
+				setDefensiveEmergencyPriority(composition, lockDefenderNow);
 				tasks.push_back(Goals::sptr(composition));
 
 #if NK2AI_TRACE_LEVEL >= 1
@@ -366,7 +541,12 @@ void DefenceBehavior::evaluateDefence(Goals::TGoalVec & tasks, const CGTownInsta
 			}
 
 			sequence.push_back(sptr(heroChain));
+
+			if(lockDefenderNow)
+				sequence.push_back(sptr(ExchangeSwapTownHeroes(town, path.targetHero, HeroLockedReason::DEFENCE)));
+
 			composition.addNextSequence(sequence);
+			setDefensiveEmergencyPriority(composition, lockDefenderNow);
 
 			const auto firstBlockedAction = path.getFirstBlockedAction();
 			if(firstBlockedAction)
@@ -397,31 +577,22 @@ void DefenceBehavior::evaluateDefence(Goals::TGoalVec & tasks, const CGTownInsta
 
 void DefenceBehavior::evaluateRecruitingHero(Goals::TGoalVec & tasks, const HitMapInfo & threat, const CGTownInstance * town, const Nullkiller * aiNk)
 {
-	// TODO: Mircea: Shouldn't it be threat.turn < 1? How does the current one make sense?
-	if(threat.turn > 0 || town->getGarrisonHero() || town->getVisitingHero())
-		return;
-
 	// TODO: Mircea: Replace with aiNk->heroManager->canRecruitHero(town) but skip limit?
 	if(town->hasBuilt(BuildingID::TAVERN) && aiNk->cc->getResourceAmount(EGameResID::GOLD) > GameConstants::HERO_GOLD_COST)
 	{
 		const auto heroesInTavern = aiNk->cc->getAvailableHeroes(town);
 		for(auto hero : heroesInTavern)
 		{
-			// TODO: Mircea: Investigate if this logic might be off, as the attacker will most probably be more powerful than a tavern hero
-			// A new hero improves the defence strength of town's army if it has defence > 0 in primary skills
-			if(hero->getTotalStrength() < threat.danger)
+			if(!RecruitHeroBehavior::isDefensiveRecruitEmergency(*town, *hero, threat, aiNk->settings->getSafeAttackRatio()))
 				continue;
 
 			bool heroAlreadyHiredInOtherTown = false;
 			for(const auto & task : tasks)
 			{
-				if(auto * const recruitGoal = dynamic_cast<Goals::RecruitHero *>(task.get()))
+				if(containsRecruitHeroTask(task, hero))
 				{
-					if(recruitGoal->getHero() == hero)
-					{
-						heroAlreadyHiredInOtherTown = true;
-						break;
-					}
+					heroAlreadyHiredInOtherTown = true;
+					break;
 				}
 			}
 			if(heroAlreadyHiredInOtherTown)
@@ -471,7 +642,6 @@ void DefenceBehavior::evaluateRecruitingHero(Goals::TGoalVec & tasks, const HitM
 			}
 
 			TGoalVec sequence;
-			Goals::Composition recruitHeroComposition;
 
 			if(needSwap)
 				sequence.push_back(sptr(ExchangeSwapTownHeroes(town, town->getVisitingHero())));
@@ -480,7 +650,12 @@ void DefenceBehavior::evaluateRecruitingHero(Goals::TGoalVec & tasks, const HitM
 				sequence.push_back(sptr(DismissHero(heroToDismiss)));
 
 			sequence.push_back(sptr(Goals::RecruitHero(town, hero)));
-			tasks.push_back(sptr(Goals::Composition().addNext(DefendTown(town, threat, hero)).addNextSequence(sequence)));
+			sequence.push_back(sptr(ExchangeSwapTownHeroes(town, hero, HeroLockedReason::DEFENCE)));
+
+			Goals::Composition composition;
+			composition.addNext(DefendTown(town, threat, hero)).addNextSequence(sequence);
+			composition.setpriority(DEFENSIVE_EMERGENCY_PRIORITY);
+			tasks.push_back(sptr(composition));
 		}
 	}
 }

--- a/AI/Nullkiller2/Behaviors/DefenceBehavior.h
+++ b/AI/Nullkiller2/Behaviors/DefenceBehavior.h
@@ -9,9 +9,11 @@
 */
 #pragma once
 
-#include "lib/GameLibrary.h"
-#include "../Goals/CGoal.h"
+#include <vector>
+
 #include "../AIUtility.h"
+#include "../Goals/CGoal.h"
+#include "lib/GameLibrary.h"
 
 namespace NK2AI
 {
@@ -20,13 +22,18 @@ struct HitMapInfo;
 
 namespace Goals
 {
+	uint64_t estimateTownFortificationDefence(const CGTownInstance & town, bool hasDefenders);
+	uint64_t estimateTownDefence(const CGTownInstance & town, const CGHeroInstance * committedDefender);
+	bool isTownDefenceSufficient(uint64_t defenceStrength, const HitMapInfo & threat, float safeAttackRatio);
+	int countTownThreatsCoveredByDefender(const CGTownInstance & town, const CGHeroInstance & defender, const std::vector<HitMapInfo> & threats, float safeAttackRatio);
+	bool isHeroRequiredForTownDefence(const CGTownInstance & town, const CGHeroInstance & defender, const std::vector<HitMapInfo> & threats, float safeAttackRatio);
+	bool shouldReserveTownDefender(const CGTownInstance & town, const CGHeroInstance & defender, const std::vector<HitMapInfo> & threats, float safeAttackRatio);
+	bool shouldLockTownDefender(const CGTownInstance & town, const CGHeroInstance & defender, const HitMapInfo & threat, float safeAttackRatio);
+
 	class DefenceBehavior : public CGoal<DefenceBehavior>
 	{
 	public:
-		DefenceBehavior()
-			:CGoal(DEFENCE)
-		{
-		}
+		DefenceBehavior() : CGoal(DEFENCE) {}
 
 		Goals::TGoalVec decompose(const Nullkiller * aiNk) const override;
 		std::string toString() const override;
@@ -41,6 +48,5 @@ namespace Goals
 		static void evaluateRecruitingHero(Goals::TGoalVec & tasks, const HitMapInfo & threat, const CGTownInstance * town, const Nullkiller * aiNk);
 	};
 }
-
 
 }

--- a/AI/Nullkiller2/Behaviors/EscapeBehavior.cpp
+++ b/AI/Nullkiller2/Behaviors/EscapeBehavior.cpp
@@ -167,6 +167,9 @@ Goals::TGoalVec EscapeBehavior::decompose(const Nullkiller * aiNk) const
 
 	for(const CGHeroInstance * candidateHero : aiNk->cc->getHeroesInfo())
 	{
+		if(aiNk->isHeroLocked(candidateHero))
+			continue;
+
 		const auto & threat = aiNk->dangerHitMap->getTileThreat(candidateHero->visitablePos()).fastestDanger;
 		if(isHeroImmediatelyThreatened(candidateHero, threat, safeAttackRatio))
 			threatenedHeroes[candidateHero] = threat;

--- a/AI/Nullkiller2/Behaviors/ExplorationBehavior.cpp
+++ b/AI/Nullkiller2/Behaviors/ExplorationBehavior.cpp
@@ -151,12 +151,15 @@ Goals::TGoalVec ExplorationBehavior::decompose(const Nullkiller * aiNk) const
 	const auto heroes = aiNk->cc->getHeroesInfo();
 	for(const CGHeroInstance * hero : heroes)
 	{
-			ExplorationHelper scanResult(hero, aiNk);
-			const bool canUseDimensionDoor = scanResult.canUseDimensionDoor();
-			auto improveWithDimensionDoor = [canUseDimensionDoor, &scanResult]()
-			{
-				return canUseDimensionDoor && scanResult.considerDimensionDoorExplorationTargets();
-			};
+		if(aiNk->isHeroLocked(hero))
+			continue;
+
+		ExplorationHelper scanResult(hero, aiNk);
+		const bool canUseDimensionDoor = scanResult.canUseDimensionDoor();
+		auto improveWithDimensionDoor = [canUseDimensionDoor, &scanResult]()
+		{
+			return canUseDimensionDoor && scanResult.considerDimensionDoorExplorationTargets();
+		};
 
 		const bool foundNearbyTarget = scanResult.scanSector(1);
 

--- a/AI/Nullkiller2/Behaviors/RecruitHeroBehavior.cpp
+++ b/AI/Nullkiller2/Behaviors/RecruitHeroBehavior.cpp
@@ -12,6 +12,8 @@
 
 #include "../AIGateway.h"
 #include "../AIUtility.h"
+#include "../Goals/Composition.h"
+#include "../Goals/ExchangeSwapTownHeroes.h"
 #include "../Goals/ExecuteHeroChain.h"
 #include "../Goals/RecruitHero.h"
 #include <algorithm>
@@ -20,6 +22,8 @@ namespace NK2AI
 {
 
 using namespace Goals;
+
+static constexpr float DEFENSIVE_EMERGENCY_RECRUIT_PRIORITY = 1000000.0f;
 
 std::string RecruitHeroBehavior::toString() const
 {
@@ -46,11 +50,7 @@ Goals::TGoalVec RecruitHeroBehavior::decompose(const Nullkiller * aiNk) const
 		if(town->getVisitingHero() && town->getGarrisonHero())
 			continue;
 
-		uint8_t closestThreatTurn = UINT8_MAX;
-		for(const auto & threat : aiNk->dangerHitMap->getTownThreats(town))
-		{
-			closestThreatTurn = std::min(closestThreatTurn, threat.turn);
-		}
+		const auto & townThreats = aiNk->dangerHitMap->getTownThreats(town);
 
 		float visitabilityRatio = 0;
 		for(const auto * const hero : ourHeroes)
@@ -63,7 +63,14 @@ Goals::TGoalVec RecruitHeroBehavior::decompose(const Nullkiller * aiNk) const
 		if(aiNk->heroManager->canRecruitHero(town))
 		{
 			calculateTreasureSources(aiNk->objectClusterizer->getNearbyObjects(), aiNk->playerID, *aiNk->dangerHitMap, treasureSourcesCount, *town);
-			calculateBestHero(aiNk->cc->getAvailableHeroes(town), *aiNk->heroManager, bestChoice, *town, closestThreatTurn, visitabilityRatio);
+			calculateBestHero(
+				aiNk->cc->getAvailableHeroes(town),
+				*aiNk->heroManager,
+				bestChoice,
+				*town,
+				townThreats,
+				aiNk->settings->getSafeAttackRatio(),
+				visitabilityRatio);
 		}
 
 		if(town->hasCapitol())
@@ -98,10 +105,14 @@ void RecruitHeroBehavior::calculateBestHero(
 	const HeroManager & heroManager,
 	const RecruitHeroChoice & bestChoice,
 	const CGTownInstance & town,
-	const uint8_t closestThreatTurn,
+	const std::vector<HitMapInfo> & townThreats,
+	const float safeAttackRatio,
 	const float visitabilityRatio
 )
 {
+	uint8_t closestThreatTurn = UINT8_MAX;
+	for(const auto & threat : townThreats)
+		closestThreatTurn = std::min(closestThreatTurn, threat.turn);
 
 	for(const auto * const hero : availableHeroes)
 	{
@@ -120,12 +131,23 @@ void RecruitHeroBehavior::calculateBestHero(
 		// prioritize a more developed town especially if no heroes can visit it (smaller ratio, bigger score)
 		totalScore += heroScore * town.getTownLevel() * (1 - visitabilityRatio);
 
-		if(totalScore > bestChoice.score)
+		bool defensiveEmergency = false;
+		for(const auto & threat : townThreats)
+		{
+			if(isDefensiveRecruitEmergency(town, *hero, threat, safeAttackRatio))
+			{
+				defensiveEmergency = true;
+				break;
+			}
+		}
+
+		if((defensiveEmergency && !bestChoice.defensiveEmergency)
+		   || (defensiveEmergency == bestChoice.defensiveEmergency && totalScore > bestChoice.score))
 		{
 			bestChoice.score = totalScore;
 			bestChoice.hero = hero;
 			bestChoice.town = &town;
-			bestChoice.closestThreat = closestThreatTurn;
+			bestChoice.defensiveEmergency = defensiveEmergency;
 		}
 	}
 }
@@ -141,15 +163,27 @@ void RecruitHeroBehavior::calculateFinalDecision(
 {
 	if(bestChoice.hero != nullptr && !vstd::isAlmostZero(bestChoice.score))
 	{
-		if(ourHeroes.empty()
-		   || treasureSourcesCount > ourHeroes.size() * 5
-		   // TODO: Mircea: The next condition should always consider a hero if under attack especially if it has towers
-		   || (bestChoice.hero->getArmyCost() > GameConstants::HERO_GOLD_COST / 2.0
-			   && (bestChoice.closestThreat < 1 || !aiNk.buildAnalyzer->isGoldPressureOverMax()))
-		   || (aiNk.getFreeResources()[EGameResID::GOLD] > 10000 && !aiNk.buildAnalyzer->isGoldPressureOverMax() && haveCapitol)
-		   || (aiNk.getFreeResources()[EGameResID::GOLD] > 30000 && !aiNk.buildAnalyzer->isGoldPressureOverMax()))
+		if(shouldRecruitHero(
+			   ourHeroes.size(),
+			   bestChoice,
+			   haveCapitol,
+			   treasureSourcesCount,
+			   aiNk.getFreeResources()[EGameResID::GOLD],
+			   aiNk.buildAnalyzer->isGoldPressureOverMax()))
 		{
-			tasks.push_back(Goals::sptr(Goals::RecruitHero(bestChoice.town, bestChoice.hero).setpriority(3.0 / (ourHeroes.size() + 1))));
+			if(bestChoice.defensiveEmergency)
+			{
+				TGoalVec sequence;
+				sequence.push_back(sptr(Goals::RecruitHero(bestChoice.town, bestChoice.hero)));
+				sequence.push_back(sptr(Goals::ExchangeSwapTownHeroes(bestChoice.town, bestChoice.hero, HeroLockedReason::DEFENCE)));
+
+				Goals::Composition composition;
+				composition.addNextSequence(sequence);
+				composition.setpriority(DEFENSIVE_EMERGENCY_RECRUIT_PRIORITY);
+				tasks.push_back(Goals::sptr(composition));
+			}
+			else
+				tasks.push_back(Goals::sptr(Goals::RecruitHero(bestChoice.town, bestChoice.hero).setpriority(3.0 / (ourHeroes.size() + 1))));
 		}
 	}
 }

--- a/AI/Nullkiller2/Behaviors/RecruitHeroBehavior.h
+++ b/AI/Nullkiller2/Behaviors/RecruitHeroBehavior.h
@@ -14,6 +14,12 @@
 #include "../Analyzers/HeroManager.h"
 #include "../Goals/CGoal.h"
 #include "lib/GameLibrary.h"
+#include "lib/ResourceSet.h"
+#include "lib/constants/NumericConstants.h"
+#include "lib/mapObjects/CGHeroInstance.h"
+#include "lib/mapObjects/CGTownInstance.h"
+
+#include <algorithm>
 
 namespace NK2AI
 {
@@ -24,7 +30,7 @@ namespace Goals
 		mutable float score = 0;
 		mutable const CGHeroInstance * hero = nullptr;
 		mutable const CGTownInstance * town = nullptr;
-		mutable int closestThreat = 0;
+		mutable bool defensiveEmergency = false;
 	};
 
 	class RecruitHeroBehavior : public CGoal<RecruitHeroBehavior>
@@ -48,14 +54,69 @@ namespace Goals
 			int & treasureSourcesCount,
 			const CGTownInstance & town
 		);
+
 		static void calculateBestHero(
 			const std::vector<const CGHeroInstance *> & availableHeroes,
 			const HeroManager & heroManager,
 			const RecruitHeroChoice & bestChoice,
 			const CGTownInstance & town,
-			uint8_t closestThreatTurn,
+			const std::vector<HitMapInfo> & townThreats,
+			float safeAttackRatio,
 			float visitabilityRatio
 		);
+
+		/// Returns true when recruiting a hero is urgent enough for town defence.
+		/// Same-turn threats require the hero to cover the known danger.
+		/// Next-turn threats must be meaningful, stronger than the stable
+		/// town defence at safeAttackRatio, and covered by the recruited hero.
+		/// Visiting heroes are mobile and must be locked separately to count.
+		static bool isDefensiveRecruitEmergency(
+			const CGTownInstance & town,
+			const CGHeroInstance & hero,
+			const HitMapInfo & threat,
+			float safeAttackRatio
+		)
+		{
+			if(threat.danger == 0 || threat.turn > 1)
+				return false;
+
+			const auto currentDefence = town.getUpperArmy()->getArmyStrength();
+			const auto recruitedDefence = hero.getTotalStrength();
+
+			if(threat.turn == 0)
+				return recruitedDefence >= threat.danger;
+
+			const auto requiredDefence = threat.danger * safeAttackRatio;
+			if(currentDefence >= requiredDefence)
+				return false;
+
+			if(recruitedDefence < requiredDefence)
+				return false;
+
+			return threat.danger >= GameConstants::HERO_GOLD_COST / 2;
+		}
+
+		static bool shouldRecruitHero(
+			size_t heroesCount,
+			const RecruitHeroChoice & bestChoice,
+			bool haveCapitol,
+			int treasureSourcesCount,
+			TResource freeGold,
+			bool goldPressureOverMax
+		)
+		{
+			if(bestChoice.hero == nullptr || vstd::isAlmostZero(bestChoice.score))
+				return false;
+
+			return heroesCount == 0
+				   || treasureSourcesCount > heroesCount * 5
+				   // TODO: Mircea: The next condition should always consider a hero if under attack especially if it has towers
+				   || (bestChoice.hero->getArmyCost() > GameConstants::HERO_GOLD_COST / 2.0
+					   && (bestChoice.defensiveEmergency || !goldPressureOverMax))
+				   || (freeGold > 10000 && !goldPressureOverMax && haveCapitol)
+				   || (freeGold > 30000 && !goldPressureOverMax);
+		}
+
 		static void calculateFinalDecision(
 			const Nullkiller & aiNk,
 			Goals::TGoalVec & tasks,

--- a/AI/Nullkiller2/Engine/Nullkiller.cpp
+++ b/AI/Nullkiller2/Engine/Nullkiller.cpp
@@ -68,6 +68,14 @@ bool canUseOpenMap(const std::shared_ptr<CCallback>& cb, const PlayerColor playe
 	return !hasHumanInTeam;
 }
 
+std::vector<HitMapInfo> getTownThreatsForDefenderReservation(const CGTownInstance * town, const Nullkiller * aiNk)
+{
+	std::vector<HitMapInfo> threats = aiNk->dangerHitMap->getTownThreats(town);
+	threats.push_back(aiNk->dangerHitMap->getObjectThreat(town).fastestDanger);
+
+	return threats;
+}
+
 void Nullkiller::init(const std::shared_ptr<CCallback> & cbInput, AIGateway * aiGwInput)
 {
 	cc = cbInput;
@@ -360,9 +368,84 @@ void Nullkiller::updateState()
 	}
 }
 
+const CGHeroInstance * Nullkiller::findRequiredTownDefender(const CGTownInstance * town) const
+{
+	const auto threats = getTownThreatsForDefenderReservation(town, this);
+	const auto safeAttackRatio = settings->getSafeAttackRatio();
+	const CGHeroInstance * result = nullptr;
+	int bestCoveredThreats = 0;
+	uint64_t bestStrength = 0;
+
+	const auto evaluateHero = [&](const CGHeroInstance * hero)
+	{
+		if(!hero)
+			return;
+
+		const int coveredThreats = Goals::countTownThreatsCoveredByDefender(*town, *hero, threats, safeAttackRatio);
+		const bool reserveDefender = Goals::shouldReserveTownDefender(*town, *hero, threats, safeAttackRatio);
+		const uint64_t strength = hero->getTotalStrength();
+
+		if(!reserveDefender)
+			return;
+
+		if(coveredThreats > bestCoveredThreats || (coveredThreats == bestCoveredThreats && strength > bestStrength))
+		{
+			result = hero;
+			bestCoveredThreats = coveredThreats;
+			bestStrength = strength;
+		}
+	};
+
+	evaluateHero(town->getGarrisonHero());
+	evaluateHero(town->getVisitingHero());
+
+	return result;
+}
+
+void Nullkiller::reserveRequiredTownDefenders()
+{
+	for(const auto * town : cc->getTownsInfo())
+	{
+		const auto * defender = findRequiredTownDefender(town);
+
+		if(!defender || getHeroLockedReason(defender) != HeroLockedReason::NOT_LOCKED)
+			continue;
+
+		logAi->debug("Reserving %s as defender of %s", defender->getNameTranslated(), town->getNameTranslated());
+		lockedHeroes[defender] = HeroLockedReason::DEFENCE;
+	}
+
+	for(const auto * town : cc->getTownsInfo())
+	{
+		const auto * garrisonHero = town->getGarrisonHero();
+
+		if(!garrisonHero || getHeroLockedReason(garrisonHero) != HeroLockedReason::NOT_LOCKED)
+			continue;
+
+		logAi->debug("Keeping %s in garrison of %s", garrisonHero->getNameTranslated(), town->getNameTranslated());
+		lockedHeroes[garrisonHero] = HeroLockedReason::DEFENCE;
+	}
+}
+
 bool Nullkiller::isHeroLocked(const CGHeroInstance * hero) const
 {
 	return getHeroLockedReason(hero) != HeroLockedReason::NOT_LOCKED;
+}
+
+void Nullkiller::lockHero(const CGHeroInstance * hero, HeroLockedReason lockReason)
+{
+	if(!hero)
+		return;
+
+	lockedHeroes[hero] = lockReason;
+}
+
+void Nullkiller::unlockHero(const CGHeroInstance * hero)
+{
+	if(!hero)
+		return;
+
+	lockedHeroes.erase(hero);
 }
 
 bool Nullkiller::arePathHeroesLocked(const AIPath & path) const
@@ -416,6 +499,8 @@ void Nullkiller::makeTurn()
 
 		if (!updateStateAndExecutePriorityPass(tasks, pass))
 			return;
+
+		reserveRequiredTownDefenders();
 
 		tasks.clear();
 		decompose(tasks, sptr(CaptureObjectsBehavior()), 1);

--- a/AI/Nullkiller2/Engine/Nullkiller.h
+++ b/AI/Nullkiller2/Engine/Nullkiller.h
@@ -135,8 +135,8 @@ public:
 	ObjectInstanceID getTargetObject() const { return targetObject; }
 	void setTargetObject(int objid) { targetObject = ObjectInstanceID(objid); }
 	void setActive(const CGHeroInstance * hero, int3 tile) { activeHero = hero; targetTile = tile; }
-	void lockHero(const CGHeroInstance * hero, HeroLockedReason lockReason) { lockedHeroes[hero] = lockReason; }
-	void unlockHero(const CGHeroInstance * hero) { lockedHeroes.erase(hero); }
+	void lockHero(const CGHeroInstance * hero, HeroLockedReason lockReason);
+	void unlockHero(const CGHeroInstance * hero);
 	bool arePathHeroesLocked(const AIPath & path) const;
 	TResources getFreeResources() const;
 	int32_t getFreeGold() const { return getFreeResources()[EGameResID::GOLD]; }
@@ -153,6 +153,8 @@ public:
 private:
 	void resetState();
 	void updateState();
+	void reserveRequiredTownDefenders();
+	const CGHeroInstance * findRequiredTownDefender(const CGTownInstance * town) const;
 	void decompose(Goals::TGoalVec & results, const Goals::TSubgoal& behavior, int decompositionMaxDepth) const;
 	Goals::TTask choseBestTask(Goals::TGoalVec & tasks) const;
 	Goals::TTaskVec buildPlanAndFilter(Goals::TGoalVec & tasks, int priorityTier) const;

--- a/AI/Nullkiller2/Engine/PriorityEvaluator.cpp
+++ b/AI/Nullkiller2/Engine/PriorityEvaluator.cpp
@@ -957,6 +957,7 @@ public:
 		evaluationContext.threatTurns = threat.turn;
 
 		vstd::amax(evaluationContext.danger, defendTown.getThreat().danger);
+		vstd::amax(evaluationContext.threat, defendTown.getThreat().danger);
 		addTileDanger(evaluationContext, town->visitablePos(), defendTown.getTurn(), defendTown.getDefenceStrength());
 	}
 };
@@ -1476,7 +1477,8 @@ float PriorityEvaluator::evaluate(Goals::TSubgoal task, int priorityTier)
 					return 0;
 				if(evaluationContext.isEnemy && evaluationContext.turn > 0)
 					return 0;
-				if(evaluationContext.threatTurns <= evaluationContext.turn)
+				const bool canPrepareForNextTurnThreat = evaluationContext.turn == 0 && evaluationContext.threatTurns == 1;
+				if(evaluationContext.threatTurns <= evaluationContext.turn || canPrepareForNextTurnThreat)
 				{
 					// TODO: Mircea: Too many heroes are rushing for INSTADEFEND.
 					// We need some kind of smart selection of who to go, not everyone qualified

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -147,8 +147,10 @@ endif()
 if(ENABLE_NULLKILLER2_AI)
 	list(APPEND test_SRCS
 		nullkiller2/Analyzers/ObjectClusterizerTest.cpp
+		nullkiller2/Behaviors/DefenceBehaviorTest.cpp
 		nullkiller2/Behaviors/EscapeBehaviorTest.cpp
 		nullkiller2/Behaviors/ExplorationBehaviorTest.cpp
+		nullkiller2/Behaviors/RecruitHeroBehaviorTest.cpp
 		nullkiller2/Engine/TaskFailureTest.cpp
 		nullkiller2/Goals/BuyArmyTest.cpp
 		nullkiller2/Goals/CompositionTest.cpp

--- a/test/nullkiller2/Behaviors/DefenceBehaviorTest.cpp
+++ b/test/nullkiller2/Behaviors/DefenceBehaviorTest.cpp
@@ -1,0 +1,157 @@
+/*
+ * DefenceBehaviorTest.cpp, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ */
+#include "StdInc.h"
+
+#include "AI/Nullkiller2/Analyzers/DangerHitMapAnalyzer.h"
+#include "AI/Nullkiller2/Behaviors/DefenceBehavior.h"
+#include "mock/TownFake.h"
+
+#include "lib/mapObjects/CGHeroInstance.h"
+
+namespace
+{
+NK2AI::HitMapInfo nextTurnThreat(uint64_t danger)
+{
+	NK2AI::HitMapInfo threat;
+	threat.turn = 1;
+	threat.danger = danger;
+	return threat;
+}
+}
+
+TEST(Nullkiller2_Behaviors_DefenceBehavior, castleDefenceCountsCommittedDefenderAndTowers)
+{
+	test::TownFake town;
+	town.withBuilding(BuildingID::CASTLE);
+
+	CGHeroInstance defender(nullptr);
+	ASSERT_TRUE(defender.setCreature(SlotID(0), CreatureID::ARCHER, 1));
+
+	const auto townOnlyDefence = NK2AI::Goals::estimateTownDefence(*town.get(), nullptr);
+	const auto committedDefence = NK2AI::Goals::estimateTownDefence(*town.get(), &defender);
+
+	ASSERT_EQ(townOnlyDefence, 0);
+	ASSERT_GT(committedDefence, defender.getTotalStrength());
+
+	const auto threat = nextTurnThreat(committedDefence - 1);
+	EXPECT_TRUE(NK2AI::Goals::shouldLockTownDefender(*town.get(), defender, threat, 1.0f))
+		<< "a mobile hero must be locked when hero plus castle towers cover the threat";
+}
+
+TEST(Nullkiller2_Behaviors_DefenceBehavior, towerDefenceNeedsCommittedDefender)
+{
+	test::TownFake town;
+	town.withBuilding(BuildingID::CASTLE);
+	ASSERT_TRUE(town.get()->setCreature(SlotID(0), CreatureID::ARCHER, 1));
+
+	const auto townArmyDefence = town.get()->getArmyStrength();
+	EXPECT_EQ(NK2AI::Goals::estimateTownDefence(*town.get(), nullptr), townArmyDefence) << "uncommitted town defence should not rely on tower value";
+}
+
+TEST(Nullkiller2_Behaviors_DefenceBehavior, defenderLockIsSkippedWhenTownArmyAlreadyCoversThreat)
+{
+	test::TownFake town;
+	ASSERT_TRUE(town.get()->setCreature(SlotID(0), CreatureID::ARCHER, 100));
+
+	CGHeroInstance defender(nullptr);
+	ASSERT_TRUE(defender.setCreature(SlotID(0), CreatureID::ARCHER, 1));
+
+	const auto townOnlyDefence = NK2AI::Goals::estimateTownDefence(*town.get(), nullptr);
+	ASSERT_GT(townOnlyDefence, 0);
+
+	const auto threat = nextTurnThreat(townOnlyDefence);
+	EXPECT_FALSE(NK2AI::Goals::shouldLockTownDefender(*town.get(), defender, threat, 1.0f)) << "do not reserve a mobile hero when town stacks already suffice";
+}
+
+TEST(Nullkiller2_Behaviors_DefenceBehavior, defenderLockIsOnlyForImmediateTownThreats)
+{
+	test::TownFake town;
+	town.withBuilding(BuildingID::CASTLE);
+
+	CGHeroInstance defender(nullptr);
+	ASSERT_TRUE(defender.setCreature(SlotID(0), CreatureID::ARCHER, 1));
+
+	NK2AI::HitMapInfo distantThreat = nextTurnThreat(NK2AI::Goals::estimateTownDefence(*town.get(), &defender) - 1);
+	distantThreat.turn = 2;
+
+	EXPECT_FALSE(NK2AI::Goals::shouldLockTownDefender(*town.get(), defender, distantThreat, 1.0f)) << "distant threats should stay in normal defence planning";
+}
+
+TEST(Nullkiller2_Behaviors_DefenceBehavior, requiredDefenderCoversAllUrgentTownThreats)
+{
+	test::TownFake town;
+	town.withBuilding(BuildingID::CASTLE);
+
+	CGHeroInstance defender(nullptr);
+	ASSERT_TRUE(defender.setCreature(SlotID(0), CreatureID::ARCHER, 1));
+
+	const auto committedDefence = NK2AI::Goals::estimateTownDefence(*town.get(), &defender);
+	std::vector<NK2AI::HitMapInfo> threats = {
+		nextTurnThreat(committedDefence - 1),
+		nextTurnThreat(committedDefence)
+	};
+
+	EXPECT_TRUE(NK2AI::Goals::isHeroRequiredForTownDefence(*town.get(), defender, threats, 1.0f))
+		<< "reserve the town hero when the same hero makes every urgent threat survivable";
+}
+
+TEST(Nullkiller2_Behaviors_DefenceBehavior, requiredDefenderCanBeNeededBeforeFullDefenceIsStable)
+{
+	test::TownFake town;
+	town.withBuilding(BuildingID::CASTLE);
+
+	CGHeroInstance defender(nullptr);
+	ASSERT_TRUE(defender.setCreature(SlotID(0), CreatureID::ARCHER, 1));
+
+	const auto committedDefence = NK2AI::Goals::estimateTownDefence(*town.get(), &defender);
+	std::vector<NK2AI::HitMapInfo> threats = {
+		nextTurnThreat(committedDefence - 1),
+		nextTurnThreat(committedDefence + 1)
+	};
+
+	EXPECT_TRUE(NK2AI::Goals::isHeroRequiredForTownDefence(*town.get(), defender, threats, 1.0f))
+		<< "reserve a defender that covers one urgent threat, even when another threat still needs a follow-up defence action";
+}
+
+TEST(Nullkiller2_Behaviors_DefenceBehavior, requiredDefenderIsSkippedWhenItCoversNoUrgentThreat)
+{
+	test::TownFake town;
+	town.withBuilding(BuildingID::CASTLE);
+
+	CGHeroInstance defender(nullptr);
+	ASSERT_TRUE(defender.setCreature(SlotID(0), CreatureID::ARCHER, 1));
+
+	const auto committedDefence = NK2AI::Goals::estimateTownDefence(*town.get(), &defender);
+	std::vector<NK2AI::HitMapInfo> threats = {
+		nextTurnThreat(committedDefence + 1)
+	};
+
+	EXPECT_FALSE(NK2AI::Goals::isHeroRequiredForTownDefence(*town.get(), defender, threats, 1.0f))
+		<< "do not reserve a defender that cannot make any urgent town threat survivable";
+}
+
+TEST(Nullkiller2_Behaviors_DefenceBehavior, reserveDefenderThatImprovesUrgentTownDefence)
+{
+	test::TownFake town;
+	town.withBuilding(BuildingID::CASTLE);
+
+	CGHeroInstance defender(nullptr);
+	ASSERT_TRUE(defender.setCreature(SlotID(0), CreatureID::ARCHER, 1));
+
+	const auto committedDefence = NK2AI::Goals::estimateTownDefence(*town.get(), &defender);
+	std::vector<NK2AI::HitMapInfo> threats = {
+		nextTurnThreat(committedDefence + 1)
+	};
+
+	ASSERT_FALSE(NK2AI::Goals::isHeroRequiredForTownDefence(*town.get(), defender, threats, 1.0f))
+		<< "this setup documents a defender that improves defence but does not fully cover the threat";
+
+	EXPECT_TRUE(NK2AI::Goals::shouldReserveTownDefender(*town.get(), defender, threats, 1.0f))
+		<< "do not treat a useful garrison defender as free while urgent town danger remains";
+}

--- a/test/nullkiller2/Behaviors/RecruitHeroBehaviorTest.cpp
+++ b/test/nullkiller2/Behaviors/RecruitHeroBehaviorTest.cpp
@@ -6,28 +6,59 @@
  * License: GNU General Public License v2.0 or later
  * Full text of license available in license.txt file, in main folder
  */
-#include "Global.h"
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
+#include "StdInc.h"
 
 #include "AI/Nullkiller2/Behaviors/RecruitHeroBehavior.h"
-#include "AI/Nullkiller2/Engine/Nullkiller.h"
+#include "lib/constants/NumericConstants.h"
+#include "lib/mapObjects/CGHeroInstance.h"
+#include "lib/mapObjects/CGTownInstance.h"
 
-class MockNullkiller : public NK2AI::Nullkiller
+TEST(Nullkiller2_Behaviors_RecruitHeroBehavior, recruitDecisionAllowsMarkedNextTurnEmergencyUnderGoldPressure)
 {
-public:
-	~MockNullkiller() override = default;
-	MOCK_METHOD(void, makeTurn, (), (override));
-};
+	CGHeroInstance tavernHero(nullptr);
 
-TEST(Nullkiller2_Behaviors_RecruitHeroBehavior, calculateBestHero)
+	ASSERT_TRUE(tavernHero.setCreature(SlotID(0), CreatureID::ARCHER, 100));
+	ASSERT_GT(tavernHero.getArmyCost(), GameConstants::HERO_GOLD_COST / 2.0);
+
+	NK2AI::Goals::RecruitHeroChoice bestChoice;
+	bestChoice.score = 1.0f;
+	bestChoice.hero = &tavernHero;
+	bestChoice.defensiveEmergency = true;
+
+	EXPECT_TRUE(
+		NK2AI::Goals::RecruitHeroBehavior::shouldRecruitHero(1, bestChoice, false, 0, 0, true)
+	) << "severe next-turn town threat should bypass gold pressure for an emergency recruit";
+}
+
+TEST(Nullkiller2_Behaviors_RecruitHeroBehavior, defensiveEmergencyRequiresMeaningfulNextTurnThreat)
 {
-	EXPECT_EQ(1, 1);
-	auto behavior = NK2AI::Goals::RecruitHeroBehavior();
-	EXPECT_FALSE(behavior.invalid());
-	EXPECT_EQ(1, 1);
-	auto * const aiNk = new MockNullkiller();
-	EXPECT_CALL(*aiNk, makeTurn()).Times(1);
-	aiNk->makeTurn();
-	delete aiNk;
+	CGTownInstance threatenedTown(nullptr);
+	CGHeroInstance tavernHero(nullptr);
+
+	ASSERT_TRUE(tavernHero.setCreature(SlotID(0), CreatureID::ARCHER, 100));
+
+	NK2AI::HitMapInfo weakThreat;
+	weakThreat.turn = 1;
+	weakThreat.danger = GameConstants::HERO_GOLD_COST / 2 - 1;
+
+	ASSERT_GT(tavernHero.getTotalStrength(), weakThreat.danger);
+	EXPECT_FALSE(
+		NK2AI::Goals::RecruitHeroBehavior::isDefensiveRecruitEmergency(threatenedTown, tavernHero, weakThreat, 1.0f)
+	) << "weak next-turn threats should not force hero recruitment";
+}
+
+TEST(Nullkiller2_Behaviors_RecruitHeroBehavior, defensiveEmergencyAllowsSevereNextTurnThreatCoveredByHero)
+{
+	CGTownInstance threatenedTown(nullptr);
+	CGHeroInstance tavernHero(nullptr);
+
+	ASSERT_TRUE(tavernHero.setCreature(SlotID(0), CreatureID::ARCHER, 100));
+	NK2AI::HitMapInfo threat;
+	threat.turn = 1;
+	threat.danger = GameConstants::HERO_GOLD_COST / 2;
+
+	ASSERT_GT(tavernHero.getTotalStrength(), threat.danger);
+	EXPECT_TRUE(
+		NK2AI::Goals::RecruitHeroBehavior::isDefensiveRecruitEmergency(threatenedTown, tavernHero, threat, 1.0f)
+	) << "severe next-turn threats should force recruitment when the tavern hero can cover them";
 }


### PR DESCRIPTION
## The dominated strategy found

Nullkiller could ignore an owned town that was visibly capturable by an enemy on the opponent's next turn when the town had no defending hero but could legally hire one from its tavern. This was a high-confidence bad decision when the available tavern hero is strong enough to improve the defense.

## Root Cause

`DefenceBehavior::evaluateRecruitingHero` only considered recruiting a defender when `threat.turn == 0`. A threat with `threat.turn == 1` was skipped, even though this is still the last AI turn before the enemy can capture the town.

The priority-pass recruit behavior used the same current-turn-only idea for emergency recruitment pressure, so urgent next-turn defense could also lose to ordinary gold-pressure logic.

## Fix

Add `RecruitHeroBehavior::isDefensiveRecruitEmergency(...)` and use it in both direct defence behavior and general recruit behavior.

The shared check keeps same-turn behaviour simple: a same-turn threat is an emergency if the recruited hero can cover the known danger.

For next-turn threats, recruitment is an emergency only when all of these are true:

- the threat is meaningful (`threat.danger >= GameConstants::HERO_GOLD_COST / 2`);
- the current town defence is weaker than `threat.danger * safeAttackRatio`;
- the recruited hero's total strength reaches `threat.danger * safeAttackRatio`.

The current town defence calculation uses a garrison hero's total strength when present, otherwise the town army strength, and then takes the max with a visiting hero's total strength if there is one. This avoids underestimating defence when both hero slots exist.

`RecruitHeroBehavior::calculateFinalDecision` can now bypass gold-pressure pruning only for choices marked as real defensive emergencies, not for every next-turn sighted threat.


## Regression test

`test/nullkiller2/Behaviors/RecruitHeroBehaviorTest.cpp` covers:

- severe next-turn town threat under high gold pressure still produces a recruit task;
- weak next-turn threat does not force emergency recruitment.

The test is wired under `ENABLE_NULLKILLER2_AI` in `test/CMakeLists.txt`.

I reverted `Refine defensive hero recruitment urgency`, rebuilt `vcmitest`, and ran the tests. The build succeeded, then the tests failed as expected:

```text
Note: Google Test filter = Nullkiller2_Behaviors_RecruitHeroBehavior.*
[==========] Running 2 tests from 1 test suite.
[----------] 2 tests from Nullkiller2_Behaviors_RecruitHeroBehavior
[ RUN      ] Nullkiller2_Behaviors_RecruitHeroBehavior.finalDecisionRecruitsForMarkedNextTurnEmergencyUnderGoldPressure
/src/test/nullkiller2/Behaviors/RecruitHeroBehaviorTest.cpp:97: Failure
Expected equality of these values:
  1
  tasks.size()
    Which is: 0
severe next-turn town threat should bypass gold pressure for an emergency recruit

[  FAILED  ] Nullkiller2_Behaviors_RecruitHeroBehavior.finalDecisionRecruitsForMarkedNextTurnEmergencyUnderGoldPressure (9 ms)
[ RUN      ] Nullkiller2_Behaviors_RecruitHeroBehavior.defensiveEmergencyRequiresMeaningfulNextTurnThreat
/src/test/nullkiller2/Behaviors/RecruitHeroBehaviorTest.cpp:112: Failure
Value of: isDefensiveRecruitEmergency<NK2AI::Goals::RecruitHeroBehavior>(threatenedTown, tavernHero, weakThreat, 1.0f)
  Actual: true
Expected: false
weak next-turn threats should not force hero recruitment

[  FAILED  ] Nullkiller2_Behaviors_RecruitHeroBehavior.defensiveEmergencyRequiresMeaningfulNextTurnThreat (0 ms)
[==========] 2 tests from 1 test suite ran. (287 ms total)
[  PASSED  ] 0 tests.
[  FAILED  ] 2 tests
NO_FIX_TEST_EXIT=1
```
