### PR TITLE
Fix bug: scout army handoff kept expensive unit

### DIFF
--- a/AI/Nullkiller2/Analyzers/ArmyManager.cpp
+++ b/AI/Nullkiller2/Analyzers/ArmyManager.cpp
@@ -130,7 +130,7 @@ std::vector<SlotInfo>::iterator ArmyManager::getBestUnitForScout(std::vector<Slo
 	auto fastest = boost::min_element(army, [&](const SlotInfo & left, const SlotInfo & right) -> bool
 	{
 		uint64_t leftUnitPower = left.power / left.count;
-		uint64_t rightUnitPower = left.power / left.count;
+		uint64_t rightUnitPower = right.power / right.count;
 		bool leftUnitIsWeak = leftUnitPower < maxUnitValue || left.creature->getLevel() < 4;
 		bool rightUnitIsWeak = rightUnitPower < maxUnitValue || right.creature->getLevel() < 4;
 


### PR DESCRIPTION
## Finding

When `Nullkiller2` transfers army from a scout to a stronger hero, the scout often must keep one creature so it remains a legal army carrier. The intended selector prefers a cheap, fast-enough unit for that scout. In equal-movement cases the selector could instead keep the first candidate in the sorted army list, which is usually the more valuable stack.

The minimal reproduced case uses Castle pikemen and archers. Both have the same adventure movement in the default rules, but archers have higher AI value. Keeping one archer on the scout and transferring the pikeman is dominated by keeping one pikeman on the scout and transferring the archer.

## Root Cause

`ArmyManager::getBestUnitForScout` computes per-unit power for the left and right comparator inputs. The right-hand value accidentally reused the left-hand slot:

```cpp
uint64_t rightUnitPower = left.power / left.count;
```

As a result, the final tie breaker could not distinguish equal-movement units by value. With candidates already sorted by total power, the scout could keep the expensive unit.

## Fix

The comparator now computes right-hand per-unit power from the right-hand slot. This restores the intended tie breaker: among otherwise equivalent units, the scout keeps the lower-value unit.

## Verification

The focused regression is:

```text
Nullkiller2_Analyzers_ArmyManager.scoutKeepsCheaperUnitWhenMovementIsEqual
```

It constructs the equal-movement archer/pikeman case and checks that the scout unit selector returns the cheaper pikeman. Reverting the comparator fix leaves the test buildable, but it fails because the selector returns the archer:

```
[ RUN      ] Nullkiller2_Analyzers_ArmyManager.scoutKeepsCheaperUnitWhenMovementIsEqual
/vcmi/test/nullkiller2/Analyzers/ArmyManagerTest.cpp:71: Failure
Expected equality of these values:
  scoutUnit->creature
    Which is: 0x5600a09a7850
  cheaperUnit
    Which is: 0x5600a08d66a0
army transfer should leave the least valuable equal-speed unit with the scout

[  FAILED  ] Nullkiller2_Analyzers_ArmyManager.scoutKeepsCheaperUnitWhenMovementIsEqual (7 ms)
```
