### PR TITLE
Stabilize battle Interference spell power test

### DIFF
--- a/test/game/CGameStateTest.cpp
+++ b/test/game/CGameStateTest.cpp
@@ -173,6 +173,8 @@ public:
 			pset.color = PlayerColor(i);
 			pset.connectedPlayerIDs.insert(static_cast<PlayerConnectionID>(i));
 			pset.name = "Player";
+			// Avoid order-dependent random starting artifacts in tests that set hero stats directly.
+			pset.bonus = PlayerStartingBonus::GOLD;
 
 			pset.castle = pinfo.defaultCastle();
 			pset.hero = pinfo.defaultHero();
@@ -454,7 +456,7 @@ TEST_F(CGameStateTest, battleInterference)
 		"targetSourceType" : "SECONDARY_SKILL",
 		"valueType" : "PERCENT_TO_TARGET_TYPE",
 		"propagator" : "BATTLE_WIDE",
-		"propagationUpdater" : [ "TIMES_HERO_LEVEL", "BONUS_OWNER_UPDATER" ]
+		"propagationUpdater" : [ "TIMES_HERO_LEVEL", "BONUS_OWNER_UPDATER" ],
 		"limiters" : [ "OPPOSITE_SIDE" ]
 	}
 	)";
@@ -483,6 +485,9 @@ TEST_F(CGameStateTest, battleInterference)
 
 	defender->setPrimarySkill(PrimarySkill::SPELL_POWER, 100, ChangeValueMode::ABSOLUTE);
 	defender->level = 10;
+
+	ASSERT_EQ(attacker->getPrimSkillLevel(PrimarySkill::SPELL_POWER), 100);
+	ASSERT_EQ(defender->getPrimSkillLevel(PrimarySkill::SPELL_POWER), 100);
 
 	startTestBattle(attacker, defender);
 


### PR DESCRIPTION
The shared game-state fixture left player starting bonuses at RANDOM. With real test data installed, game initialization could roll an artifact bonus and equip Dragonbone Greaves on the defender before battleInterference set up its spell-power assertions.

Force a non-artifact starting bonus in the fixture, assert the pre-battle spell power explicitly, and fix the malformed JSON literal used by the specialty bonus.

Fix this flake https://github.com/vcmi/vcmi/actions/runs/27113636829/job/80016145462?pr=7454

```
[ RUN      ] CGameStateTest.battleInterference
/home/runner/work/vcmi/vcmi/test/game/CGameStateTest.cpp:489: Failure
Expected equality of these values:
  attacker->getPrimSkillLevel(PrimarySkill::SPELL_POWER)
    Which is: 101
  100

[  FAILED  ] CGameStateTest.battleInterference (17 ms)
[----------] 1 test from CGameStateTest (17 ms total)

[----------] Global test environment tear-down
Ending global test tear-down.
[==========] 1 test from 1 test suite ran. (203 ms total)
[  PASSED  ] 0 tests.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] CGameStateTest.battleInterference

 1 FAILED TEST
```