### PR TITLE
Choose strongest available creature upgrade

### DIFF
--- a/AI/Nullkiller2/Analyzers/ArmyManager.cpp
+++ b/AI/Nullkiller2/Analyzers/ArmyManager.cpp
@@ -531,7 +531,7 @@ std::vector<StackUpgradeInfo> ArmyManager::getHillFortUpgrades(const CCreatureSe
 		if(possibleUpgrades.empty())
 			continue;
 
-		CreatureID strongestUpgrade = *vstd::minElementByFun(possibleUpgrades, [](CreatureID cre) -> uint64_t
+		CreatureID strongestUpgrade = *vstd::maxElementByFun(possibleUpgrades, [](CreatureID cre) -> uint64_t
 		{
 			return cre.toCreature()->getAIValue();
 		});
@@ -570,7 +570,7 @@ std::vector<StackUpgradeInfo> ArmyManager::getDwellingUpgrades(const CCreatureSe
 		if(possibleUpgrades.empty())
 			continue;
 
-		CreatureID strongestUpgrade = *vstd::minElementByFun(possibleUpgrades, [](CreatureID cre) -> uint64_t
+		CreatureID strongestUpgrade = *vstd::maxElementByFun(possibleUpgrades, [](CreatureID cre) -> uint64_t
 		{
 			return cre.toCreature()->getAIValue();
 		});


### PR DESCRIPTION
When a creature has multiple legal upgrade targets, the adventure AI should keep the target with the highest AI value. The previous code named the result strongestUpgrade but selected the minimum value, which can downgrade a multi-upgrade decision before resource filtering and upgrade ordering run.