### PR TITLE
Avoid dismissing stacks before mergeable recruitment

### DIFF
--- a/AI/Nullkiller2/Goals/BuyArmy.cpp
+++ b/AI/Nullkiller2/Goals/BuyArmy.cpp
@@ -58,7 +58,7 @@ void BuyArmy::accept(AIGateway * aiGw)
 
 		if(ci.count)
 		{
-			if (town->getUpperArmy()->stacksCount() == GameConstants::ARMY_SIZE)
+			if (needsFreeSlotToRecruit(town->getUpperArmy(), ci.creID))
 			{
 				SlotID lowestValueSlot;
 				int lowestValue = std::numeric_limits<int>::max();

--- a/AI/Nullkiller2/Goals/BuyArmy.h
+++ b/AI/Nullkiller2/Goals/BuyArmy.h
@@ -38,6 +38,12 @@ namespace Goals
 
 		bool operator==(const BuyArmy & other) const override;
 
+		static bool needsFreeSlotToRecruit(const CCreatureSet * army, CreatureID creatureID)
+		{
+			static_cast<void>(creatureID);
+			return army->stacksCount() == GameConstants::ARMY_SIZE;
+		}
+
 		std::string toString() const override;
 
 		void accept(AIGateway * aiGw) override;

--- a/AI/Nullkiller2/Goals/BuyArmy.h
+++ b/AI/Nullkiller2/Goals/BuyArmy.h
@@ -40,8 +40,8 @@ namespace Goals
 
 		static bool needsFreeSlotToRecruit(const CCreatureSet * army, CreatureID creatureID)
 		{
-			static_cast<void>(creatureID);
-			return army->stacksCount() == GameConstants::ARMY_SIZE;
+			return army->stacksCount() == GameConstants::ARMY_SIZE
+				&& !army->getSlotFor(creatureID).validSlot();
 		}
 
 		std::string toString() const override;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -144,6 +144,12 @@ if(ENABLE_BATTLE_AI)
 
 endif()
 
+if(ENABLE_NULLKILLER2_AI)
+	list(APPEND test_SRCS
+		nullkiller2/Goals/BuyArmyTest.cpp
+	)
+endif()
+
 assign_source_group(${test_SRCS} ${test_HEADERS})
 
 set(mock_HEADERS

--- a/test/nullkiller2/Goals/BuyArmyTest.cpp
+++ b/test/nullkiller2/Goals/BuyArmyTest.cpp
@@ -1,0 +1,60 @@
+/*
+ * BuyArmyTest.cpp, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ */
+#include "StdInc.h"
+
+#include "AI/Nullkiller2/Goals/BuyArmy.h"
+
+#include "lib/mapObjects/CGHeroInstance.h"
+
+namespace
+{
+void fillFullArmy(CCreatureSet & army)
+{
+	const std::array<CreatureID, GameConstants::ARMY_SIZE> creatures = {
+		CreatureID(CreatureID::ARCHER),
+		CreatureID(0),
+		CreatureID(1),
+		CreatureID(4),
+		CreatureID(5),
+		CreatureID(6),
+		CreatureID(7)
+	};
+
+	for(size_t index = 0; index < creatures.size(); ++index)
+		ASSERT_TRUE(army.setCreature(SlotID(index), creatures[index], 1));
+}
+}
+
+TEST(Nullkiller2_Goals_BuyArmy, fullArmyDoesNotNeedFreeSlotForExistingCreature)
+{
+	CGHeroInstance army(nullptr);
+	fillFullArmy(army);
+
+	ASSERT_EQ(army.stacksCount(), GameConstants::ARMY_SIZE);
+
+	EXPECT_FALSE(NK2AI::Goals::BuyArmy::needsFreeSlotToRecruit(
+		&army,
+		CreatureID(CreatureID::ARCHER)))
+		<< "recruiting an existing creature type can merge without dismissing a stack";
+
+	EXPECT_TRUE(NK2AI::Goals::BuyArmy::needsFreeSlotToRecruit(
+		&army,
+		CreatureID(8)))
+		<< "a full army still needs a free slot for a missing creature type";
+}
+
+TEST(Nullkiller2_Goals_BuyArmy, partialArmyDoesNotNeedFreeSlotForMissingCreature)
+{
+	CGHeroInstance army(nullptr);
+	ASSERT_TRUE(army.setCreature(SlotID(0), CreatureID(CreatureID::ARCHER), 1));
+
+	EXPECT_FALSE(NK2AI::Goals::BuyArmy::needsFreeSlotToRecruit(
+		&army,
+		CreatureID(8)));
+}


### PR DESCRIPTION
## Finding

`BuyArmy` dismissed the lowest-value non-native stack whenever the town army was full before checking whether the creature being bought already existed in that army. Existing stacks can receive more creatures by merging, so buying the same creature type does not require a free slot.

That makes the old behavior dominated: if the town is full and already contains the recruited creature type, dismissing any stack loses army value and creates no new option that was needed for the purchase.

## Reproduction Invariant

The regression constructs a full seven-stack army containing `core:archer`. Buying more archers must not require a free slot. Buying a creature type absent from the full army still requires a free slot.

This is independent of a particular map or economy state. It is a general army slot invariant used by town recruitment.

## Fix

`BuyArmy` now checks whether the target creature can merge before looking for a stack to dismiss. It frees a slot only when the army is full and the target creature is absent.

## Verification

Regression test:

`Nullkiller2_Goals_BuyArmy.fullArmyDoesNotNeedFreeSlotForExistingCreature`

Expected failure if the fix is reverted:

```
[ RUN      ] Nullkiller2_Goals_BuyArmy.fullArmyDoesNotNeedFreeSlotForExistingCreature
/vcmi/test/nullkiller2/Goals/BuyArmyTest.cpp:41: Failure
Value of: NK2AI::Goals::BuyArmy::needsFreeSlotToRecruit( &army, CreatureID(CreatureID::ARCHER))
  Actual: true
Expected: false
recruiting an existing creature type can merge without dismissing a stack

[  FAILED  ] Nullkiller2_Goals_BuyArmy.fullArmyDoesNotNeedFreeSlotForExistingCreature (0 ms)
```