### PR TITLE
Implemented patching of Lua spell effects by mods

### DIFF
--- a/config/schemas/spellEffect.json
+++ b/config/schemas/spellEffect.json
@@ -3,7 +3,7 @@
 	"$schema" : "http://json-schema.org/draft-04/schema",
 	"title" : "VCMI spell school format",
 	"description" : "Format used to define new spell schools in VCMI",
-	"required" : [ "type", "script", "schema" ],
+	"required" : [ "type", "script", "schema", "patches" ],
 	"additionalProperties" : false,
 	"properties" : {
 		"type" : {
@@ -26,6 +26,13 @@
 			"items" : {
 				"type" : "string",
 				"description" : "path to the script that represents this effect"
+			}
+		},
+		"patches" : {
+			"type" : "array",
+			"items" : {
+				"type" : "string",
+				"description" : "list of patches that modify this script"
 			}
 		},
 		"schema" : {

--- a/config/spellEffects.json
+++ b/config/spellEffects.json
@@ -2,6 +2,7 @@
 	"catapult" : {
 		"type" : "lua",
 		"script" : "catapult",
+		"patches" : [ ],
 		"schema" : {
 			"properties" : {
 				"type" : {},
@@ -21,6 +22,7 @@
 	"clone" : {
 		"type" : "lua",
 		"script" : "clone",
+		"patches" : [ ],
 		"schema" : {
 			"properties" : {
 				"type" : {},
@@ -36,6 +38,7 @@
 	"damage" : {
 		"type" : "lua",
 		"script" : "damage",
+		"patches" : [ ],
 		"schema" : {
 			"properties" : {
 				"type" : {},
@@ -53,6 +56,7 @@
 	"demonSummon" : {
 		"type" : "lua",
 		"script" : "demonSummon",
+		"patches" : [ ],
 		"schema" : {
 			"properties" : {
 				"type" : {},
@@ -69,6 +73,7 @@
 	"dispel" : {
 		"type" : "lua",
 		"script" : "dispel",
+		"patches" : [ ],
 		"schema" : {
 			"properties" : {
 				"type" : {},
@@ -86,6 +91,7 @@
 	"heal" : {
 		"type" : "lua",
 		"script" : "heal",
+		"patches" : [ ],
 		"schema" : {
 			"properties" : {
 				"type" : {},
@@ -103,6 +109,7 @@
 	"sacrifice" : {
 		"type" : "lua",
 		"script" : "sacrifice",
+		"patches" : [ ],
 		"schema" : {
 			"properties" : {
 				"type" : {},
@@ -120,6 +127,7 @@
 	"moat" : {
 		"type" : "lua",
 		"script" : "moat",
+		"patches" : [ ],
 		"schema" : {
 			"properties" : {
 				"type" : {},
@@ -141,6 +149,7 @@
 	"obstacle" : {
 		"type" : "lua",
 		"script" : "obstacle",
+		"patches" : [ ],
 		"schema" : {
 			"properties" : {
 				"type" : {},
@@ -163,6 +172,7 @@
 	"removeObstacle" : {
 		"type" : "lua",
 		"script" : "removeObstacle",
+		"patches" : [ ],
 		"schema" : {
 			"properties" : {
 				"type" : {},
@@ -179,6 +189,7 @@
 	"summon" : {
 		"type" : "lua",
 		"script" : "summon.lua",
+		"patches" : [ ],
 		"schema" : {
 			"properties" : {
 				"type" : {},
@@ -196,6 +207,7 @@
 	"teleport" : {
 		"type" : "lua",
 		"script" : "teleport",
+		"patches" : [ ],
 		"schema" : {
 			"properties" : {
 				"type" : {},
@@ -213,6 +225,7 @@
 		"type" : "lua",
 		"script" : "timed",
 		"stringRegistrations" : ["battleLogSingular", "battleLogPlural"],
+		"patches" : ["patches/timedShield", "patches/timedBind"],
 		"schema" : {
 			"properties" : {
 				"type" : {},

--- a/include/vcmi/scripting/Service.h
+++ b/include/vcmi/scripting/Service.h
@@ -37,7 +37,6 @@ public:
 	virtual ~Script() = default;
 
 	virtual std::string getIdentifier() const = 0;
-	virtual const std::string & getSource() const = 0;
 };
 
 class DLL_LINKAGE Pool

--- a/lib/spells/effects/SpellEffectHandler.cpp
+++ b/lib/spells/effects/SpellEffectHandler.cpp
@@ -33,7 +33,7 @@ std::shared_ptr<Effect> SpellEffectHandler::create(SpellEffectID effectID) const
 	const auto & effect = effectTypes.at(effectID.getNum());
 	const auto & factory = effectTypeFactories.at(effect.type);
 
-	return factory->create(effect.modScope, effect.scriptName);
+	return factory->create(effect.effectId);
 }
 
 void SpellEffectHandler::registerFactory(const std::string & typeName, std::shared_ptr<ISpellEffectFactory> factory)
@@ -59,11 +59,20 @@ void SpellEffectHandler::loadObject(std::string scope, std::string name, const J
 	for(const auto & item : data["stringRegistrations"].Vector())
 		newEffect.stringRegistrations.push_back(item.String());
 
-	registerObject(scope, "spellEffect", name, data, effectTypes.size());
-	effectTypes.push_back(newEffect);
+	const JsonNode & patchesNode = data["patches"];
+	if (patchesNode.isVector())
+	{
+		for (const auto & patchEntry : patchesNode.Vector())
+			newEffect.patches.emplace_back(patchEntry.getModScope(), patchEntry.String());
+	}
 
-	const auto & factory = effectTypeFactories.at(newEffect.type);
-	factory->initialize(newEffect.modScope, newEffect.scriptName);
+	newEffect.effectId = scope + ':' + name;
+	registerObject(scope, "spellEffect", name, data, effectTypes.size());
+	effectTypes.push_back(std::move(newEffect));
+
+	const auto & back = effectTypes.back();
+	const auto & factory = effectTypeFactories.at(back.type);
+	factory->initialize(back.effectId, back.modScope, back.scriptName, back.patches);
 }
 
 void SpellEffectHandler::loadObject(std::string scope, std::string name, const JsonNode & data, size_t index)

--- a/lib/spells/effects/SpellEffectHandler.h
+++ b/lib/spells/effects/SpellEffectHandler.h
@@ -24,8 +24,10 @@ struct SpellEffectType
 {
 	std::string identifier;
 	std::string modScope;
+	std::string effectId; ///< modScope + ':' + identifier
 	std::string type;
 	std::string scriptName;
+	std::vector<ISpellEffectFactory::PatchEntry> patches; ///vector(modScope, sourcePath)
 	JsonNode validationSchema;
 	std::vector<std::string> stringRegistrations;
 };

--- a/lib/spells/effects/SpellEffectService.h
+++ b/lib/spells/effects/SpellEffectService.h
@@ -24,10 +24,17 @@ class Effect;
 class DLL_LINKAGE ISpellEffectFactory
 {
 public:
+	/// (modScope, sourcePath) pair identifying one patch script layer.
+	using PatchEntry = std::pair<std::string, std::string>;
+
 	virtual ~ISpellEffectFactory() = default;
 
-	virtual void initialize(const std::string & scope, const std::string & name) = 0;
-	virtual std::shared_ptr<Effect> create(const std::string & scope, const std::string & name) const = 0;
+	/// effectId is the unique identifier of the effect (e.g. "core:damage"), used as cache key.
+	/// scope/name point at the base script; patches list extra layers stacked over the base in order.
+	virtual void initialize(const std::string & effectId,
+		const std::string & scope, const std::string & name,
+		const std::vector<PatchEntry> & patches) = 0;
+	virtual std::shared_ptr<Effect> create(const std::string & effectId) const = 0;
 };
 
 class DLL_LINKAGE SpellEffectService : boost::noncopyable

--- a/luascript/LuaContext.cpp
+++ b/luascript/LuaContext.cpp
@@ -10,6 +10,7 @@
 #include "StdInc.h"
 #include "LuaContext.h"
 
+#include "LuaScriptInstance.h"
 #include "LuaStack.h"
 #include "LuaReference.h"
 
@@ -23,6 +24,14 @@
 #include <vstd/StringUtils.h>
 #include <vcmi/ServerCallback.h>
 #include <vcmi/Services.h>
+
+// LuaJIT and Lua 5.1 expose globals via LUA_GLOBALSINDEX and chunk environments via setfenv.
+// Lua 5.2+ replaces both with the _ENV upvalue and a registry slot LUA_RIDX_GLOBALS.
+#if LUA_VERSION_NUM == 501
+#	define VCMI_LUA_PUSH_GLOBALS(L) lua_pushvalue((L), LUA_GLOBALSINDEX)
+#else
+#	define VCMI_LUA_PUSH_GLOBALS(L) lua_rawgeti((L), LUA_REGISTRYINDEX, LUA_RIDX_GLOBALS)
+#endif
 
 VCMI_LIB_NAMESPACE_BEGIN
 
@@ -87,7 +96,7 @@ int LuaContext::luaPrint(lua_State *L) {
 	return 0;
 }
 
-LuaContext::LuaContext(const Script * source, const Environment * env_):
+LuaContext::LuaContext(const LuaScriptInstance * source, const Environment * env_):
 	L(luaL_newstate()),
 	script(source),
 	env(env_)
@@ -138,7 +147,6 @@ LuaContext::LuaContext(const Script * source, const Environment * env_):
 LuaContext::~LuaContext()
 {
 	modules.reset();
-	scriptClosure.reset();
 	scriptTable.reset();
 	lua_close(L);
 }
@@ -208,36 +216,72 @@ bool LuaContext::hasFunction(const std::string & name)
 void LuaContext::initialize()
 {
 	std::lock_guard guard(mutex);
-	int ret = luaL_loadbuffer(L, script->getSource().c_str(), script->getSource().size(), script->getIdentifier().c_str());
 
-	if(ret)
+	std::shared_ptr<LuaReference> head;
+
+	for(const auto & layer : script->layers)
 	{
-		logScript->error("Script '%s' failed to compile: %s", script->getIdentifier(), toStringRaw(-1));
-		lua_settop(L, 0);
-		return;
+		const bool isBase = (&layer == &script->layers.front());
+
+		if(!loadLayerChunk(layer.sourceText, layer.identifier))
+		{
+			logMod->error("Script layer '%s' failed to compile: %s", layer.identifier, toStringRaw(-1));
+			lua_settop(L, 0);
+			if(isBase) break; else continue;
+		}
+
+		// For patch layers, inject `Base` into the chunk's environment so the patch can refer to it
+		// without an explicit require. The base layer keeps the default global env.
+		if(head)
+			installChunkEnvWithBase(*head);
+
+		if(lua_pcall(L, 0, 1, 0))
+		{
+			logMod->error("Script layer '%s' failed to run: %s", layer.identifier, toStringRaw(-1));
+			lua_settop(L, 0);
+			if(isBase) break; else continue;
+		}
+
+		if(!lua_istable(L, -1))
+		{
+			logMod->error("Script layer '%s' did not return a table", layer.identifier);
+			lua_settop(L, 0);
+			if(isBase) break; else continue;
+		}
+
+		// LuaReference ctor pops the table off the stack into the registry.
+		head = std::make_shared<LuaReference>(L);
 	}
 
-	scriptClosure = std::make_shared<LuaReference>(L);
-	lua_settop(L, 0);
-	scriptClosure->push();
+	if(head)
+		scriptTable = head;
+}
 
-	ret = lua_pcall(L, 0, 1, 0);
+bool LuaContext::loadLayerChunk(const std::string & sourceText, const std::string & identifier)
+{
+	return luaL_loadbuffer(L, sourceText.c_str(), sourceText.size(), identifier.c_str()) == 0;
+}
 
-	if(ret)
-	{
-		logScript->error("Script '%s' failed to run: %s", script->getIdentifier(), toStringRaw(-1));
-		lua_settop(L, 0);
-		return;
-	}
+void LuaContext::installChunkEnvWithBase(LuaReference & base)
+{
+	// Stack on entry: ..., chunk
+	lua_newtable(L);                                  // ..., chunk, env
+	base.push();                                      // ..., chunk, env, base
+	lua_setfield(L, -2, "Base");                      // ..., chunk, env
 
-	if(!lua_istable(L, -1))
-	{
-		logScript->error("Script '%s' did not return a table", script->getIdentifier());
-		lua_settop(L, 0);
-		return;
-	}
+	lua_newtable(L);                                  // ..., chunk, env, mt
+	VCMI_LUA_PUSH_GLOBALS(L);                         // ..., chunk, env, mt, _G
+	lua_setfield(L, -2, "__index");                   // ..., chunk, env, mt
+	lua_setmetatable(L, -2);                          // ..., chunk, env (with mt)
 
-	scriptTable = std::make_shared<LuaReference>(L);
+#if LUA_VERSION_NUM == 501
+	// setfenv(chunk, env); chunk is at -2, env at -1. Always succeeds for Lua functions; pops env.
+	lua_setfenv(L, -2);
+#else
+	// 5.2+: replace the first upvalue (_ENV) of the chunk; chunks from luaL_loadbuffer always have it.
+	lua_setupvalue(L, -2, 1);
+#endif
+	// Stack: ..., chunk
 }
 
 int LuaContext::errorRetVoid(const std::string & message)

--- a/luascript/LuaContext.h
+++ b/luascript/LuaContext.h
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include "LuaScriptInstance.h"
 #include "LuaStack.h"
 #include "LuaReference.h"
 #include "../lib/json/JsonNode.h"
@@ -27,7 +28,7 @@ class LuaReference;
 class LuaContext final : public Context
 {
 public:
-	LuaContext(const Script * source, const Environment * env_);
+	LuaContext(const LuaScriptInstance * source, const Environment * env_);
 	~LuaContext();
 
 	/// Runs script once to perform its initialization
@@ -47,13 +48,20 @@ private:
 	std::mutex mutex;
 	lua_State * L;
 
-	const Script * script;
+	const LuaScriptInstance * script;
 
 	const Environment * env;
 
 	std::shared_ptr<LuaReference> modules;
-	std::shared_ptr<LuaReference> scriptClosure;
 	std::shared_ptr<LuaReference> scriptTable;
+
+	/// Loads one Lua chunk from source. On success the chunk function is at the top of the stack.
+	/// Returns false on compile failure with the error string left on the stack.
+	bool loadLayerChunk(const std::string & sourceText, const std::string & identifier);
+
+	/// Replaces the environment of the chunk on top of the stack so that the global `Base`
+	/// resolves to the given base table, while other globals fall back through __index = _G.
+	void installChunkEnvWithBase(LuaReference & base);
 
 	//log error and return nil from LuaCFunction
 	int errorRetVoid(const std::string & message);

--- a/luascript/LuaScriptInstance.cpp
+++ b/luascript/LuaScriptInstance.cpp
@@ -19,19 +19,35 @@ VCMI_LIB_NAMESPACE_BEGIN
 namespace scripting
 {
 
-LuaScriptInstance::LuaScriptInstance(LuaModule & host, const std::string & modScope, const std::string & sourcePath)
+LuaScriptInstance::LuaScriptInstance(LuaModule & host,
+	const std::string & baseScope, const std::string & basePath,
+	const std::vector<std::pair<std::string, std::string>> & patches)
 	: host(host)
-	, modScope(modScope)
-	, sourcePath(sourcePath)
 {
-	ScriptPath sourcePathId = ScriptPath::builtinTODO(sourcePath).addPrefix("SCRIPTS/");
-	CResourceHandler::get(modScope)->load(sourcePathId);
-
-	auto rawData = CResourceHandler::get()->load(sourcePathId)->readAll();
-	sourceText = std::string(reinterpret_cast<char *>(rawData.first.get()), rawData.second);
+	loadLayer(baseScope, basePath);
+	for (const auto & [scope, path] : patches)
+		loadLayer(scope, path);
 }
 
 LuaScriptInstance::~LuaScriptInstance() = default;
+
+void LuaScriptInstance::loadLayer(const std::string & modScope, const std::string & sourcePath)
+{
+	ScriptPath sourcePathId = ScriptPath::builtinTODO(sourcePath).addPrefix("SCRIPTS/");
+
+	auto * loader = CResourceHandler::get(modScope);
+	if (!loader->existsResource(sourcePathId))
+	{
+		logMod->error("Script layer not found: %s:%s", modScope, sourcePath);
+		return;
+	}
+
+	Layer layer;
+	auto rawData = loader->load(sourcePathId)->readAll();
+	layer.sourceText = std::string(reinterpret_cast<char *>(rawData.first.get()), rawData.second);
+	layer.identifier = modScope + ':' + sourcePath;
+	layers.push_back(std::move(layer));
+}
 
 std::shared_ptr<LuaContext> LuaScriptInstance::createContext(const Environment * ENV) const
 {

--- a/luascript/LuaScriptInstance.h
+++ b/luascript/LuaScriptInstance.h
@@ -24,24 +24,38 @@ namespace scripting
 class LuaModule;
 class LuaContext;
 
-/// Holds the source code and metadata of a loaded Lua script; one instance per script, persists across map restarts.
+/// Holds the source code of a script (optionally with one or more patch layers stacked over a base)
+/// and metadata; one instance per logical script.
 /// Owned by LuaModule and used as a factory to create LuaContext instances for each game session.
 class LuaScriptInstance final : public Script
 {
 public:
-	LuaScriptInstance(LuaModule & host, const std::string & modScope, const std::string & sourcePath);
+	struct Layer
+	{
+		std::string sourceText;
+		std::string identifier; ///< modScope + ':' + sourcePath, used for error reporting and chunk naming
+	};
+
+	/// Builds the chain: layer[0] is the base, layer[1..] are patches in declared order.
+	/// patches entries are (modScope, sourcePath) pairs.
+	/// Failed-to-load patch layers are skipped with a logged error; failed base load leaves layers empty.
+	LuaScriptInstance(LuaModule & host,
+		const std::string & baseScope, const std::string & basePath,
+		const std::vector<std::pair<std::string, std::string>> & patches);
 	virtual ~LuaScriptInstance();
 
-	std::string modScope;
-	std::string sourcePath;
-	std::string sourceText;
+	std::vector<Layer> layers;
 
 	LuaModule & host;
 
 	std::shared_ptr<LuaContext> createContext(const Environment * ENV) const;
 
-	std::string getIdentifier() const override { return modScope + ':' + sourcePath;}
-	const std::string & getSource() const override { return sourceText;}
+	std::string getIdentifier() const override { return baselModScope + baselSourcePath; }
+
+private:
+	std::string baselModScope;
+	std::string baselSourcePath;
+	void loadLayer(const std::string & modScope, const std::string & sourcePath);
 };
 }
 

--- a/luascript/LuaSpellEffect.cpp
+++ b/luascript/LuaSpellEffect.cpp
@@ -45,15 +45,17 @@ LuaSpellEffectFactory::LuaSpellEffectFactory(scripting::LuaModule & host)
 
 LuaSpellEffectFactory::~LuaSpellEffectFactory() = default;
 
-void LuaSpellEffectFactory::initialize(const std::string & scope, const std::string & name)
+void LuaSpellEffectFactory::initialize(const std::string & effectId,
+	const std::string & scope, const std::string & name,
+	const std::vector<PatchEntry> & patches)
 {
-	auto loadedScript = std::make_unique<scripting::LuaScriptInstance>(host, scope,name);
-	loadedScripts[loadedScript->getIdentifier()] = std::move(loadedScript);
+	auto loadedScript = std::make_unique<scripting::LuaScriptInstance>(host, scope, name, patches);
+	loadedScripts[effectId] = std::move(loadedScript);
 }
 
-std::shared_ptr<Effect> LuaSpellEffectFactory::create(const std::string & scope, const std::string & name) const
+std::shared_ptr<Effect> LuaSpellEffectFactory::create(const std::string & effectId) const
 {
-	return std::make_shared<LuaSpellEffect>(loadedScripts.at(scope + ':' + name).get());
+	return std::make_shared<LuaSpellEffect>(loadedScripts.at(effectId).get());
 }
 
 void LuaSpellEffectFactory::registerScripts(scripting::LuaScriptPool * pool)

--- a/luascript/LuaSpellEffect.h
+++ b/luascript/LuaSpellEffect.h
@@ -36,12 +36,15 @@ public:
 	LuaSpellEffectFactory(scripting::LuaModule & host);
 	virtual ~LuaSpellEffectFactory();
 
-	void initialize(const std::string & scope, const std::string & name) override;
-	std::shared_ptr<Effect> create(const std::string & scope, const std::string & name) const override;
+	void initialize(const std::string & effectId,
+		const std::string & scope, const std::string & name,
+		const std::vector<PatchEntry> & patches) override;
+	std::shared_ptr<Effect> create(const std::string & effectId) const override;
 
 	void registerScripts(scripting::LuaScriptPool * pool);
 
 private:
+	/// effect id -> script mapping
 	std::map<std::string, std::unique_ptr<scripting::LuaScriptInstance> > loadedScripts;
 	scripting::LuaModule & host;
 };

--- a/scripts/patches/timedBind.lua
+++ b/scripts/patches/timedBind.lua
@@ -1,0 +1,18 @@
+-- Patch over `timed`: stores the caster's unit ID in BIND_EFFECT.addInfo when bind is cast
+-- by a unit (not a hero), so the engine can later locate the binding unit.
+local Script = setmetatable({}, {__index = Base})
+Script.__index = Script
+
+function Script:convertBonuses(mechanics)
+	local converted = Base.convertBonuses(self, mechanics)
+	if mechanics:getSpell():getJsonKey() == "core:bind" and not mechanics:getHeroCaster() then
+		for _, nb in pairs(converted) do
+			if nb.type == "BIND_EFFECT" then
+				nb.addInfo = mechanics:getUnitCaster():unitID()
+			end
+		end
+	end
+	return converted
+end
+
+return Script

--- a/scripts/patches/timedShield.lua
+++ b/scripts/patches/timedShield.lua
@@ -1,0 +1,19 @@
+-- Patch over `timed`: inverts GENERAL_DAMAGE_REDUCTION value for shield-family spells,
+-- so that the JSON-side number is the % of damage blocked rather than the % passed through.
+local Script = setmetatable({}, {__index = Base})
+Script.__index = Script
+
+function Script:convertBonuses(mechanics)
+	local converted = Base.convertBonuses(self, mechanics)
+	local spellKey = mechanics:getSpell():getJsonKey()
+	if spellKey == "core:shield" or spellKey == "core:airShield" then
+		for _, nb in pairs(converted) do
+			if nb.type == "GENERAL_DAMAGE_REDUCTION" then
+				nb.val = 100 - (nb.val or 0)
+			end
+		end
+	end
+	return converted
+end
+
+return Script

--- a/scripts/timed.lua
+++ b/scripts/timed.lua
@@ -25,19 +25,6 @@ function Script:convertBonuses(mechanics)
 		nb.sourceType = "SPELL_EFFECT"
 		nb.sourceID = spellKey
 
-		-- Shield/AirShield: val in config is the reduction percentage; stored inverted
-		if (spellKey == "core:shield" or spellKey == "core:airShield")
-			and nb.type == "GENERAL_DAMAGE_REDUCTION" then
-			nb.val = 100 - (nb.val or 0)
-		end
-
-		-- Bind: store caster unit ID when cast by a unit (not a hero)
-		if spellKey == "core:bind" and nb.type == "BIND_EFFECT" then
-			if not mechanics:getHeroCaster() then
-				nb.addInfo = mechanics:getUnitCaster():unitID()
-			end
-		end
-
 		converted[name] = nb
 	end
 


### PR DESCRIPTION
Adds support for mods to modify spell effect scripts via "patches", which function as slightly different version of inheritance.

Patches are loaded after base script, and automatically receive base script in `Base` global.

This allows multiple mods to modify the same script without being "aware" of other mods - `Base` always represents either base script, or in case of multiple patches - previous patch in chunk.

Relies on "json array appending" style of config patching.

Detailed docs will be added in separate PR alongside with general Lua script guide