### PR TITLE
Fix auto-close stale PR's

### DIFF
--- a/.github/workflows/stale-prs.yml
+++ b/.github/workflows/stale-prs.yml
@@ -30,6 +30,3 @@ jobs:
             Feel free to reopen it if you'd like to continue working on it.
 
           exempt-pr-labels: postponed
-
-          # only process 1 PR per run (with 1 run / day via cron)
-          operations-per-run: 1


### PR DESCRIPTION
Caused by misunderstanding of parameter from my side.

This parameter affect how many issues/PR's will be *checked*, not how many will be marked as stale. Its intention is API rate limiting, not output limiting.

Removed parameter, effectively resetting it to default