### PR TITLE
add recovery from invalid object preset

### DIFF
--- a/lib/rewardable/Info.cpp
+++ b/lib/rewardable/Info.cpp
@@ -253,32 +253,49 @@ void Rewardable::Info::configureVariables(Rewardable::Configuration & object, IG
 	{
 		for(const auto & entry : category.second.Struct())
 		{
-			JsonNode preset = object.getPresetVariable(category.first, entry.first);
-			const JsonNode & input = preset.isNull() ? entry.second : preset;
-			int32_t value = -1;
+			auto getRandomValue = [&](JsonNode input) -> int32_t
+			{
+				int32_t value = -1;
 
-			if (category.first == "number")
-				value = randomizer.loadValue(input, object.variables.values);
+				if(category.first == "number")
+					value = randomizer.loadValue(input, object.variables.values);
 
-			if (category.first == "artifact")
-				value = randomizer.loadArtifact(input, object.variables.values).getNum();
+				if(category.first == "artifact")
+					value = randomizer.loadArtifact(input, object.variables.values).getNum();
 
-			if (category.first == "creature")
-				value = randomizer.loadCreatureType(input, object.variables.values).getNum();
+				if(category.first == "creature")
+					value = randomizer.loadCreatureType(input, object.variables.values).getNum();
 
-			if (category.first == "spell")
-				value = randomizer.loadSpell(input, object.variables.values).getNum();
+				if(category.first == "spell")
+					value = randomizer.loadSpell(input, object.variables.values).getNum();
 
-			if (category.first == "resource")
-				value = randomizer.loadResourceType(input, object.variables.values).getNum();
+				if(category.first == "resource")
+					value = randomizer.loadResourceType(input, object.variables.values).getNum();
 
-			if (category.first == "primarySkill")
-				value = randomizer.loadPrimary(input, object.variables.values).getNum();
+				if(category.first == "primarySkill")
+					value = randomizer.loadPrimary(input, object.variables.values).getNum();
 
-			if (category.first == "secondarySkill")
-				value = randomizer.loadSecondary(input, object.variables.values).getNum();
+				if(category.first == "secondarySkill")
+					value = randomizer.loadSecondary(input, object.variables.values).getNum();
 
-			object.initVariable(category.first, entry.first, value);
+				return value;
+			};
+			const JsonNode customValues = object.getPresetVariable(category.first, entry.first);
+			const JsonNode & defaultValues = entry.second;
+			if(!customValues.isNull())
+			{
+				try
+				{
+					auto value = getRandomValue(customValues);
+					object.initVariable(category.first, entry.first, value);
+					return;
+				}
+				catch(...)
+				{
+					logGlobal->warn("Rewardable object preset could not have been initialized, returning to default configuration");
+				}
+			}
+			object.initVariable(category.first, entry.first, getRandomValue(defaultValues));
 		}
 	}
 }


### PR DESCRIPTION
I thought lately about the problem with maps crashing on an empty witch huts.
If we want to recover from such a situation I see two possibilities:
1) Returning to default configuration.
2) Removing all rewards objects that use invalid (empty in case of witch hut) presets.

I strongly prefer the first one. Since we can assume that the default configuration is valid, we should be able to safely return to it. (if it is not, than crashing the entire map is IMO correct behavior).
Now, the second situation would give us 100% compatibility with OG in case of a witch hut (the reward would be removed and "onEmpty" behavior would naturally occur), but there are other problems with it. It is far more complex, and in case of custom objects the result is hard to predict.
I thought also about making the first behavior default and making the second one possible to customize through the object config file, but, Idn. It is piling complexity upon complexity just to resolve a very minor difference between OG and vcmi.
I made a tentative draft fix implementing the first solution. 
