### PR TITLE
Switch CI to use Ubuntu 26.04

### DIFF
--- a/.github/workflows/github.yml
+++ b/.github/workflows/github.yml
@@ -99,7 +99,7 @@ jobs:
             artifact_platform: arm64
 
           - platform: android-32
-            os: ubuntu-latest
+            os: ubuntu-24.04
             upload: 1
             extension: apk
             preset: android-conan-ninja-release
@@ -109,7 +109,7 @@ jobs:
             artifact_platform: armeabi-v7a
 
           - platform: android-64
-            os: ubuntu-latest
+            os: ubuntu-24.04
             upload: 1
             extension: apk
             preset: android-conan-ninja-release
@@ -119,7 +119,7 @@ jobs:
             artifact_platform: arm64-v8a
 
           - platform: android-64-intel
-            os: ubuntu-latest
+            os: ubuntu-24.04
             upload: 1
             extension: apk
             preset: android-conan-ninja-release
@@ -554,17 +554,17 @@ jobs:
       matrix:
         include:
           - platform: gcc-latest-release
-            os: ubuntu-24.04
+            os: ubuntu-26.04
             before_install: linux_qt6.sh
-            compiler_cxx: g++-14
-            compiler_cc: gcc-14
+            compiler_cxx: g++-15
+            compiler_cc: gcc-15
             preset: linux-gcc-test
 
           - platform: clang-latest-debug
-            os: ubuntu-24.04
+            os: ubuntu-26.04
             before_install: linux_qt6.sh
-            compiler_cxx: clang++-18
-            compiler_cc: clang-18
+            compiler_cxx: clang++-22
+            compiler_cc: clang-22
             preset: linux-clang-debug
 
           - platform: gcc-oldest-debug
@@ -832,7 +832,7 @@ jobs:
   validate-code:
     name: Validate Code
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     defaults:
       run:
         shell: bash
@@ -865,7 +865,7 @@ jobs:
     name: Build report
     if: always()
     needs: [build, windows-installer, validate-code, test, upload-source-package]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       actions: write                   # Partial JSON artifacts can't be deleted in PRs

--- a/launcher/demo.cpp
+++ b/launcher/demo.cpp
@@ -178,9 +178,11 @@ void DemoInstaller::install(QString filename)
             dir.mkpath(folder);
 
         QFile f(dir.filePath(fileEntry.name));
-        f.open(QIODevice::WriteOnly);
-        f.write(fileData);
-        f.close();
+        if (f.open(QIODevice::WriteOnly))
+        {
+            f.write(fileData);
+            f.close();
+        }
     }
 
     if(callback)

--- a/launcher/modManager/chroniclesextractor.cpp
+++ b/launcher/modManager/chroniclesextractor.cpp
@@ -117,8 +117,8 @@ void ChroniclesExtractor::createBaseMod() const
 	};
 
 	QFile jsonFile(dir.filePath("mod.json"));
-	jsonFile.open(QFile::WriteOnly);
-	jsonFile.write(QJsonDocument(mod).toJson());
+	if (jsonFile.open(QFile::WriteOnly))
+		jsonFile.write(QJsonDocument(mod).toJson());
 
 	for(auto & dataPath : VCMIDirs::get().dataPaths())
 	{
@@ -153,8 +153,8 @@ void ChroniclesExtractor::createChronicleMod(int no)
 	};
 	
 	QFile jsonFile(dir.filePath("mod.json"));
-	jsonFile.open(QFile::WriteOnly);
-	jsonFile.write(QJsonDocument(mod).toJson());
+	if (jsonFile.open(QFile::WriteOnly))
+		jsonFile.write(QJsonDocument(mod).toJson());
 
 	dir.cd("content");
 	

--- a/launcher/modManager/hdextractor.cpp
+++ b/launcher/modManager/hdextractor.cpp
@@ -132,8 +132,8 @@ void HdExtractor::createModJson(std::optional<SubModType> submodType, QDir path,
 		}
 		
 		QFile jsonFile(path.filePath("mod.json"));
-		jsonFile.open(QFile::WriteOnly);
-		jsonFile.write(QJsonDocument(mod).toJson());
+		if (jsonFile.open(QFile::WriteOnly))
+			jsonFile.write(QJsonDocument(mod).toJson());
 	}
 	else
 	{
@@ -148,7 +148,7 @@ void HdExtractor::createModJson(std::optional<SubModType> submodType, QDir path,
 		};
 		
 		QFile jsonFile(path.filePath("mod.json"));
-		jsonFile.open(QFile::WriteOnly);
-		jsonFile.write(QJsonDocument(mod).toJson());
+		if (jsonFile.open(QFile::WriteOnly))
+			jsonFile.write(QJsonDocument(mod).toJson());
 	}
 }

--- a/launcher/modManager/modstateitemmodel_moc.cpp
+++ b/launcher/modManager/modstateitemmodel_moc.cpp
@@ -276,7 +276,7 @@ QModelIndex ModStateItemModel::parent(const QModelIndex & child) const
 void CModFilterModel::setTypeFilter(ModFilterMask newFilterMask)
 {
 	filterMask = newFilterMask;
-	invalidateFilter();
+	reloadFilter();
 }
 
 bool CModFilterModel::filterMatchesCategory(const QModelIndex & source) const

--- a/launcher/modManager/modstateitemmodel_moc.h
+++ b/launcher/modManager/modstateitemmodel_moc.h
@@ -103,7 +103,15 @@ class CModFilterModel final : public QSortFilterProxyModel
 
 public:
 	void setTypeFilter(ModFilterMask filterMask);
-	void reloadFilter() { invalidateFilter(); }
+	void reloadFilter()
+	{
+#if QT_VERSION >= QT_VERSION_CHECK(6, 9, 0)
+		beginFilterChange();
+		endFilterChange(QSortFilterProxyModel::Direction::Rows);
+#else
+		invalidateFilter();
+#endif
+	}
 
 	CModFilterModel(ModStateItemModel * model, QObject * parent = nullptr);
 };

--- a/lib/callback/CCallback.h
+++ b/lib/callback/CCallback.h
@@ -31,11 +31,11 @@ class DLL_LINKAGE CCallback final : public CPlayerSpecificInfoCallback, public C
 
 public:
 	CCallback(std::shared_ptr<CGameState> gamestate, std::optional<PlayerColor> Player, IClient * C);
-	virtual ~CCallback();
+	~CCallback();
 
 	//client-specific functionalities (pathfinding)
-	virtual bool canMoveBetween(const int3 &a, const int3 &b);
-	virtual int3 getGuardingCreaturePosition(int3 tile);
+	bool canMoveBetween(const int3 &a, const int3 &b);
+	int3 getGuardingCreaturePosition(int3 tile);
 
 	std::optional<PlayerColor> getPlayerID() const override;
 

--- a/lib/entities/artifact/CArtifact.h
+++ b/lib/entities/artifact/CArtifact.h
@@ -137,7 +137,7 @@ public:
 	void addNewBonus(const std::shared_ptr<Bonus> & b) override;
 	const std::map<ArtBearer, std::vector<ArtifactPosition>> & getPossibleSlots() const;
 
-	virtual bool canBePutAt(const CArtifactSet * artSet, ArtifactPosition slot = ArtifactPosition::FIRST_AVAILABLE, bool assumeDestRemoved = false) const;
+	bool canBePutAt(const CArtifactSet * artSet, ArtifactPosition slot = ArtifactPosition::FIRST_AVAILABLE, bool assumeDestRemoved = false) const;
 	// Is used for testing purposes only
 	void setImage(int32_t iconIndex, const std::string & image, const std::string & large);
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -144,6 +144,10 @@ set(mock_HEADERS
 if(MSVC)
 	set(gtest_force_shared_crt ON CACHE BOOL "Use shared (DLL) run-time lib even when Google Test is built as static lib." FORCE)
 endif()
+check_cxx_compiler_flag(-Wcharacter-conversion CHARCONV)
+if(CHARCONV)
+	add_compile_options(-Wno-error=character-conversion) #Used in googletest
+endif()
 check_cxx_compiler_flag(-Wimplicit-int-float-conversion CONV)
 if(CONV)
 	add_compile_options(-Wno-error=implicit-int-float-conversion) #Used in googletest


### PR DESCRIPTION
Switch Ubuntu runners to use 26.04 which was recently added to Github CI. Even on success will keep this open for some time since image is still fresh and might have issues.

Changed:
- Android builds use 26.04 as host
- Newest gcc test use 26.04 & gcc-15
- Newest clang tests uses 26.04 & clang-22
- Validation CI runs use 26.04

Not changed:
- AppImage uses 24.04 - since minimal target system depends on libc with which image was compiled
- Lobby .deb generation uses 24.04 - in sync with our server
- `oldest` gcc/clang tests use 24.04 - since these old versions were removed from 26.04