### PR TITLE
Improve queued hero/commander level-up dialog handling

### DIFF
--- a/AI/Nullkiller2/Goals/AdventureSpellCast.cpp
+++ b/AI/Nullkiller2/Goals/AdventureSpellCast.cpp
@@ -74,6 +74,7 @@ void AdventureSpellCast::accept(AIGateway * aiGw)
 	const auto wait = aiGw->cc->waitTillRealize;
 	aiGw->cc->waitTillRealize = true;
 	aiGw->cc->castSpell(hero, spellID, tile);
+	aiGw->waitTillFree(); // Adventure spells may trigger visits and level-up queries.
 
 	if(town && townPortalEffect)
 	{

--- a/AI/Nullkiller2/Goals/RecruitHero.cpp
+++ b/AI/Nullkiller2/Goals/RecruitHero.cpp
@@ -66,6 +66,7 @@ void RecruitHero::accept(AIGateway * aiGw)
 		throw cannotFulfillGoalException("Town " + t->nodeName() + " is occupied. Cannot recruit hero!");
 
 	aiGw->cc->recruitHero(t, heroToHire);
+	aiGw->waitTillFree(); // Hiring in a town may trigger level-up queries from reward buildings.
 
 	{
 		// TODO: Mircea: Consider same behavior when a hero is lost? Relevant?

--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -548,7 +548,6 @@ void CPlayerInterface::heroGotLevel(const CGHeroInstance *hero, PrimarySkill psk
 		// Free the visible-dialog gate as soon as the player makes a choice.
 		// The query-backed dialog queue still keeps manual input blocked until the
 		// server resolves this level-up step and advances the chain.
-		levelWindow->setFreeOnSelection(true);
 		levelWindow->setCloseOnSelection(queryID < 0);
 		ENGINE->windows().pushWindow(levelWindow);
 	};
@@ -578,7 +577,6 @@ void CPlayerInterface::commanderGotLevel(const CCommanderInstance * commander, s
 		// Free the visible-dialog gate as soon as the player makes a choice.
 		// The query-backed dialog queue still keeps manual input blocked until the
 		// server resolves this level-up step and advances the chain.
-		levelWindow->setFreeOnSelection(true);
 		levelWindow->setCloseOnSelection(queryID < 0);
 		ENGINE->windows().pushWindow(levelWindow);
 	};
@@ -1065,6 +1063,7 @@ void CPlayerInterface::showInfoDialog(EInfoWindowMode type, const std::string &t
 		}
 
 		waitWhileDialog(); //Fix for mantis #98
+		closeActiveLevelUpDialog();
 		showInfoBox(true);
 		return;
 	}
@@ -1121,6 +1120,7 @@ void CPlayerInterface::showInfoDialog(const std::string &text, const std::vector
 
 	if ((makingTurn || (battleInt && battleInt->curInt && battleInt->curInt.get() == this)) && ENGINE->windows().count() > 0 && GAME->interface() == this)
 	{
+		closeActiveLevelUpDialog();
 		showDialog();
 	}
 	else
@@ -1152,6 +1152,7 @@ void CPlayerInterface::showBlockingDialog(const std::string &text, const std::ve
 {
 	EVENT_HANDLER_CALLED_BY_CLIENT;
 	waitWhileDialog();
+	closeActiveLevelUpDialog();
 
 	movementController->requestMovementAbort();
 	ENGINE->sound().playSound(static_cast<soundBase::soundID>(soundID));
@@ -1931,10 +1932,7 @@ void CPlayerInterface::createAndQueueDialog(PendingDialog::Type blockingPolicy, 
 	dialog.showCallback = std::move(showCallback);
 
 	if(dialog.isLevelUpDialog() && (levelUpChainPendingContinuation || (!dialogs.empty() && dialogs.front().isLevelUpDialog())))
-	{
 		dialogs.insert(findQueryBackedDialogInsertionPoint(), std::move(dialog));
-		levelUpChainPendingContinuation = false;
-	}
 	else
 		dialogs.push_back(std::move(dialog));
 }
@@ -1977,10 +1975,6 @@ void CPlayerInterface::tryShowNextPendingDialog()
 		{
 			levelUpChainPendingContinuation = false;
 			closeActiveLevelUpDialog();
-		}
-		else
-		{
-			levelUpChainPendingContinuation = false;
 		}
 
 		dialog.showCallback();

--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -125,19 +125,13 @@
 
 #define BATTLE_EVENT_POSSIBLE_RETURN	if (GAME->interface() != this) return; if (isAutoFightOn && !battleInt) return
 
-namespace
-{
-	constexpr int LEVEL_UP_REQUEST_NONE = -1;
-	constexpr int LEVEL_UP_REQUEST_WAITING_FOR_REPLY = -2;
-}
-
 std::shared_ptr<BattleInterface> CPlayerInterface::battleInt;
 
 CPlayerInterface::CPlayerInterface(PlayerColor Player):
 	localState(std::make_unique<PlayerLocalState>(*this)),
 	movementController(std::make_unique<HeroMovementController>()),
 	artifactController(std::make_unique<ArtifactsUIController>())
-	
+
 {
 	logGlobal->trace("\tHuman player interface for player %s being constructed", Player.toString());
 	GAME->setInterfaceInstance(this);
@@ -222,6 +216,8 @@ void CPlayerInterface::playerEndsTurn(PlayerColor player)
 	if (player == playerID)
 	{
 		makingTurn = false;
+		delayQueuedDialogsUntilInputSettles = false;
+		levelUpChainPendingContinuation = false;
 		closeAllDialogs();
 
 		// remove all pending dialogs that do not expect query answer
@@ -530,71 +526,65 @@ void CPlayerInterface::heroGotLevel(const CGHeroInstance *hero, PrimarySkill psk
 
 	auto showLevelUpDialog = [this, hero, pskill, availableSkills = std::move(availableSkills), queryID]() mutable
 	{
-		closePendingLevelUpDialog();
-
-		const bool closeImmediately = queryID < 0;
-		pendingLevelUpRequestID = closeImmediately ? LEVEL_UP_REQUEST_NONE : LEVEL_UP_REQUEST_WAITING_FOR_REPLY;
-
 		ENGINE->sound().playSound(soundBase::heroNewLevel);
-		auto levelWindow = std::make_shared<CLevelWindow>(hero, pskill, availableSkills, [this, queryID](ui32 selection)
+		auto callback = [this, queryID](ui32 selection)
 		{
 			if(queryID < 0)
 				return;
 
-			pendingLevelUpRequestID = cb->selectionMade(selection, queryID);
-		});
+			cb->selectionMade(selection, queryID);
+		};
 
-		levelWindow->setCloseOnSelection(closeImmediately);
-		if(!closeImmediately)
-			pendingLevelUpDialog = levelWindow;
+		if(auto levelWindow = ENGINE->windows().topWindow<CLevelWindow>())
+		{
+			levelWindow->updateLevelUpData(hero, pskill, availableSkills, callback);
+			return;
+		}
 
+		closeActiveLevelUpDialog();
+
+		auto levelWindow = std::make_shared<CLevelWindow>(hero, pskill, availableSkills, callback);
+
+		// Free the visible-dialog gate as soon as the player makes a choice.
+		// The query-backed dialog queue still keeps manual input blocked until the
+		// server resolves this level-up step and advances the chain.
+		levelWindow->setFreeOnSelection(true);
+		levelWindow->setCloseOnSelection(queryID < 0);
 		ENGINE->windows().pushWindow(levelWindow);
 	};
 
-	if(showingDialog->isBusy() || !dialogs.empty())
-	{
-		dialogs.push_back({false, std::move(showLevelUpDialog)});
-		return;
-	}
-
-	waitWhileDialog();
-	showLevelUpDialog();
+	createAndQueueDialog(PendingDialog::Type::Blocking, std::move(showLevelUpDialog), queryID);
+	tryShowNextPendingDialog();
 }
 
 void CPlayerInterface::commanderGotLevel(const CCommanderInstance * commander, std::vector<ui32> skills, QueryID queryID)
 {
 	EVENT_HANDLER_CALLED_BY_CLIENT;
-	auto showLevelUpDialog = [this, commander, skills = std::move(skills), queryID]() mutable
+	auto showCallback = [this, commander, skills = std::move(skills), queryID]() mutable
 	{
-		closePendingLevelUpDialog();
-
-		const bool closeImmediately = queryID < 0;
-		pendingLevelUpRequestID = closeImmediately ? LEVEL_UP_REQUEST_NONE : LEVEL_UP_REQUEST_WAITING_FOR_REPLY;
-
 		ENGINE->sound().playSound(soundBase::heroNewLevel);
-		auto levelWindow = std::make_shared<CStackWindow>(commander, skills, [this, queryID](ui32 selection)
+		auto callback = [this, queryID](ui32 selection)
 		{
 			if(queryID < 0)
 				return;
 
-			pendingLevelUpRequestID = cb->selectionMade(selection, queryID);
-		});
+			cb->selectionMade(selection, queryID);
+		};
 
-		levelWindow->setCloseOnSelection(closeImmediately);
-		if(!closeImmediately)
-			pendingLevelUpDialog = levelWindow;
+		closeActiveLevelUpDialog();
 
+		auto levelWindow = std::make_shared<CStackWindow>(commander, skills, callback);
+
+		// Free the visible-dialog gate as soon as the player makes a choice.
+		// The query-backed dialog queue still keeps manual input blocked until the
+		// server resolves this level-up step and advances the chain.
+		levelWindow->setFreeOnSelection(true);
+		levelWindow->setCloseOnSelection(queryID < 0);
 		ENGINE->windows().pushWindow(levelWindow);
 	};
 
-	if(showingDialog->isBusy() || !dialogs.empty())
-	{
-		dialogs.push_back({false, std::move(showLevelUpDialog)});
-		return;
-	}
-
-	waitWhileDialog();
-	showLevelUpDialog();
+	createAndQueueDialog(PendingDialog::Type::Blocking, std::move(showCallback), queryID);
+	tryShowNextPendingDialog();
 }
 
 void CPlayerInterface::heroInGarrisonChange(const CGTownInstance *town)
@@ -901,7 +891,7 @@ void CPlayerInterface::battleEnd(const BattleID & battleID, const BattleResult *
 					cb->selectionMade(selection, queryID);
 				};
 			}
-			
+
 			isAutoFightEndBattle = false;
 
 			ENGINE->windows().pushWindow(wnd);
@@ -1051,14 +1041,31 @@ void CPlayerInterface::showInfoDialog(EInfoWindowMode type, const std::string &t
 
 	if(autoTryHover || type == EInfoWindowMode::INFO)
 	{
+		auto showInfoBox = [this, components, text, timer, soundID](bool abortMovement)
+		{
+			adventureInt->showInfoBoxMessage(components, text, timer);
+
+			// Abort movement only when the message is shown synchronously with the event that produced it.
+			// Deferred info-box messages may be displayed later, after movement has already resumed.
+			if(abortMovement)
+				movementController->requestMovementAbort();
+
+			if (makingTurn && ENGINE->windows().count() > 0 && GAME->interface() == this)
+				ENGINE->sound().playSound(static_cast<soundBase::soundID>(soundID));
+		};
+
+		if(showingDialog->isBusy() || !dialogs.empty())
+		{
+			createAndQueueDialog(PendingDialog::Type::NonBlocking, [showInfoBox = std::move(showInfoBox)]() mutable
+			{
+				showInfoBox(false);
+			});
+			tryShowNextPendingDialog();
+			return;
+		}
+
 		waitWhileDialog(); //Fix for mantis #98
-		adventureInt->showInfoBoxMessage(components, text, timer);
-
-		// abort movement, if any. Strictly speaking unnecessary, but prevents some edge cases, like movement sound on visiting Magi Hut with "show messages in status window" on
-		movementController->requestMovementAbort();
-
-		if (makingTurn && ENGINE->windows().count() > 0 && GAME->interface() == this)
-			ENGINE->sound().playSound(static_cast<soundBase::soundID>(soundID));
+		showInfoBox(true);
 		return;
 	}
 
@@ -1090,30 +1097,36 @@ void CPlayerInterface::showInfoDialog(const std::string & text, std::shared_ptr<
 void CPlayerInterface::showInfoDialog(const std::string &text, const std::vector<std::shared_ptr<CComponent>> & components, int soundID)
 {
 	LOG_TRACE_PARAMS(logGlobal, "player=%s, text=%s, is GAME->interface()=%d", playerID % text % (this==GAME->interface()));
-	waitWhileDialog();
-
 	if (settings["session"]["autoSkip"].Bool() && !ENGINE->isKeyboardShiftDown())
 	{
 		return;
 	}
 	std::shared_ptr<CInfoWindow> temp = CInfoWindow::create(text, playerID, components);
-
-	if ((makingTurn || (battleInt && battleInt->curInt && battleInt->curInt.get() == this)) && ENGINE->windows().count() > 0 && GAME->interface() == this)
+	auto showDialog = [this, temp, soundID]()
 	{
 		ENGINE->sound().playSound(static_cast<soundBase::soundID>(soundID));
 		showingDialog->setBusy();
 		movementController->requestMovementAbort(); // interrupt movement to show dialog
 		ENGINE->windows().pushWindow(temp);
+	};
+
+	if(showingDialog->isBusy() || !dialogs.empty())
+	{
+		createAndQueueDialog(PendingDialog::Type::Blocking, std::move(showDialog));
+		tryShowNextPendingDialog();
+		return;
+	}
+
+	waitWhileDialog();
+
+	if ((makingTurn || (battleInt && battleInt->curInt && battleInt->curInt.get() == this)) && ENGINE->windows().count() > 0 && GAME->interface() == this)
+	{
+		showDialog();
 	}
 	else
 	{
-		dialogs.push_back({true, [this, temp, soundID]()
-		{
-			ENGINE->sound().playSound(static_cast<soundBase::soundID>(soundID));
-			showingDialog->setBusy();
-			movementController->requestMovementAbort(); // interrupt movement to show dialog
-			ENGINE->windows().pushWindow(temp);
-		}});
+		createAndQueueDialog(PendingDialog::Type::Blocking, std::move(showDialog));
+		tryShowNextPendingDialog();
 	}
 }
 
@@ -1324,13 +1337,12 @@ void CPlayerInterface::moveHero( const CGHeroInstance *h, const CGPath& path )
 		return;
 
 	assert(h);
-	assert(!showingDialog->isBusy());
-	assert(dialogs.empty());
 
 	if (!h)
 		return; //can't find hero
 
-	//It shouldn't be possible to move hero with open dialog (or dialog waiting in bg)
+	// Query-backed level-up chains can keep input blocked briefly after the visible
+	// window closes, until QueryResolved advances or completes the chain.
 	if (showingDialog->isBusy() || !dialogs.empty())
 		return;
 
@@ -1369,25 +1381,40 @@ void CPlayerInterface::requestRealized( PackageApplied *pa )
 	}
 }
 
-void CPlayerInterface::queryResolved(QueryID queryID)
+void CPlayerInterface::closeActiveLevelUpDialog()
 {
-	if(queryID.getNum() < 0)
-		return;
-
-	closePendingLevelUpDialog();
+	if(auto levelWindow = ENGINE->windows().topWindow<CLevelWindow>())
+		levelWindow->close();
+	else if(auto commanderWindow = ENGINE->windows().topWindow<CStackWindow>(); commanderWindow && commanderWindow->isCommanderLevelUpDialog())
+		commanderWindow->close();
 }
 
-void CPlayerInterface::closePendingLevelUpDialog()
+void CPlayerInterface::queryResolved(QueryID queryID)
 {
-	if(!pendingLevelUpDialog)
-	{
-		pendingLevelUpRequestID = LEVEL_UP_REQUEST_NONE;
+	auto dialog = findPendingDialog(queryID);
+	if(dialog == dialogs.end())
 		return;
-	}
 
-	pendingLevelUpDialog->close();
-	pendingLevelUpDialog.reset();
-	pendingLevelUpRequestID = LEVEL_UP_REQUEST_NONE;
+	const bool wasFront = dialog == dialogs.begin();
+	const bool wasLevelUpDialog = dialog->isLevelUpDialog();
+	dialogs.erase(dialog);
+
+	if(wasFront)
+	{
+		showingDialog->setFree();
+		if(wasLevelUpDialog)
+		{
+			levelUpChainPendingContinuation = true;
+			// Drain any queued accept/click events from the just-confirmed query-backed
+			// dialog before showing whatever comes next. Otherwise the same Enter can
+			// instantly accept the next level-up step or close a queued info dialog.
+			delayQueuedDialogsUntilInputSettles = true;
+			return;
+		}
+
+		closeActiveLevelUpDialog();
+		tryShowNextPendingDialog();
+	}
 }
 
 void CPlayerInterface::showHeroExchange(ObjectInstanceID hero1, ObjectInstanceID hero2)
@@ -1611,12 +1638,7 @@ void CPlayerInterface::playerBlocked(int reason, bool start)
 
 void CPlayerInterface::update()
 {
-	//if there are any waiting dialogs, show them
-	if (makingTurn && !dialogs.empty() && !showingDialog->isBusy())
-	{
-		dialogs.front().show();
-		dialogs.pop_front();
-	}
+	tryShowNextPendingDialog();
 }
 
 void CPlayerInterface::endNetwork()
@@ -1897,6 +1919,92 @@ void CPlayerInterface::waitForAllDialogs()
 	waitWhileDialog();
 }
 
+void CPlayerInterface::createAndQueueDialog(PendingDialog::Type blockingPolicy, std::function<void()> showCallback, QueryID queryID)
+{
+	PendingDialog dialog;
+	dialog.queryID = queryID >= 0 ? queryID : QueryID::NONE;
+	dialog.blockingPolicy = blockingPolicy;
+	// Level-up dialogs currently mean hero/commander level-up prompts.
+	// Keep them alive across turn-end and keep the whole query-backed chain
+	// ahead of ordinary queued info/reward dialogs.
+	dialog.dropOnTurnEnd = !dialog.isLevelUpDialog();
+	dialog.showCallback = std::move(showCallback);
+
+	if(dialog.isLevelUpDialog() && (levelUpChainPendingContinuation || (!dialogs.empty() && dialogs.front().isLevelUpDialog())))
+	{
+		dialogs.insert(findQueryBackedDialogInsertionPoint(), std::move(dialog));
+		levelUpChainPendingContinuation = false;
+	}
+	else
+		dialogs.push_back(std::move(dialog));
+}
+
+std::list<CPlayerInterface::PendingDialog>::iterator CPlayerInterface::findQueryBackedDialogInsertionPoint()
+{
+	return std::find_if(dialogs.begin(), dialogs.end(), [](const PendingDialog & dialog)
+	{
+		return !dialog.isLevelUpDialog();
+	});
+}
+
+void CPlayerInterface::tryShowNextPendingDialog()
+{
+	if(delayQueuedDialogsUntilInputSettles)
+		return;
+
+	if(dialogs.empty())
+	{
+		if(levelUpChainPendingContinuation)
+		{
+			levelUpChainPendingContinuation = false;
+			closeActiveLevelUpDialog();
+		}
+		return;
+	}
+
+	while(!dialogs.empty() && !showingDialog->isBusy())
+	{
+		auto & dialog = dialogs.front();
+		// Level-up dialogs currently mean hero/commander level-up prompts.
+		// Keep showing those even after makingTurn becomes false, but stop normal queued dialogs.
+		if(!makingTurn && !dialog.isLevelUpDialog())
+			return;
+
+		if(dialog.state != PendingDialog::State::Queued)
+			return;
+
+		if(!dialog.isLevelUpDialog())
+		{
+			levelUpChainPendingContinuation = false;
+			closeActiveLevelUpDialog();
+		}
+		else
+		{
+			levelUpChainPendingContinuation = false;
+		}
+
+		dialog.showCallback();
+		if(dialog.isLevelUpDialog())
+		{
+			dialog.state = PendingDialog::State::AwaitingQueryResolution;
+			return;
+		}
+
+		dialogs.pop_front();
+
+		if(dialog.blockingPolicy == PendingDialog::Type::Blocking || showingDialog->isBusy())
+			return;
+	}
+}
+
+std::list<CPlayerInterface::PendingDialog>::iterator CPlayerInterface::findPendingDialog(QueryID queryID)
+{
+	return std::find_if(dialogs.begin(), dialogs.end(), [queryID](const PendingDialog & dialog)
+	{
+		return dialog.queryID == queryID;
+	});
+}
+
 void CPlayerInterface::proposeLoadingGame()
 {
 	showYesNoDialog(
@@ -1974,14 +2082,27 @@ bool CPlayerInterface::capturedAllEvents()
 
 	bool needToLockAdventureMap = adventureInt && adventureInt->isActive() && GAME->map().hasOngoingAnimations();
 	bool quickCombatOngoing = isAutoFightOn && !battleInt;
+	bool waitingForQueuedDialogInputToSettle = false;
 	bool waitingForQueuedDialogResolution =
 		!showingDialog->isBusy() &&
 		!dialogs.empty() &&
 		dialogs.front().state == PendingDialog::State::AwaitingQueryResolution;
 
-	if (ignoreEvents || needToLockAdventureMap || quickCombatOngoing || waitingForQueuedDialogResolution)
+	if(delayQueuedDialogsUntilInputSettles)
 	{
-		ENGINE->input().ignoreEventsUntilInput();
+		waitingForQueuedDialogInputToSettle = ENGINE->input().ignoreEventsUntilInput();
+
+		if(!waitingForQueuedDialogInputToSettle)
+		{
+			delayQueuedDialogsUntilInputSettles = false;
+			tryShowNextPendingDialog();
+		}
+	}
+
+	if (ignoreEvents || needToLockAdventureMap || quickCombatOngoing || waitingForQueuedDialogResolution || waitingForQueuedDialogInputToSettle)
+	{
+		if(!delayQueuedDialogsUntilInputSettles)
+			ENGINE->input().ignoreEventsUntilInput();
 		return true;
 	}
 

--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -1365,10 +1365,16 @@ void CPlayerInterface::requestRealized( PackageApplied *pa )
 
 	if(pa->packType == CTypeList::getInstance().getTypeID<QueryReply>(nullptr))
 	{
-		if(pendingLevelUpRequestID == static_cast<int>(pa->requestID))
-			closePendingLevelUpDialog();
 		movementController->onQueryReplyApplied();
 	}
+}
+
+void CPlayerInterface::queryResolved(QueryID queryID)
+{
+	if(queryID.getNum() < 0)
+		return;
+
+	closePendingLevelUpDialog();
 }
 
 void CPlayerInterface::closePendingLevelUpDialog()
@@ -1968,8 +1974,12 @@ bool CPlayerInterface::capturedAllEvents()
 
 	bool needToLockAdventureMap = adventureInt && adventureInt->isActive() && GAME->map().hasOngoingAnimations();
 	bool quickCombatOngoing = isAutoFightOn && !battleInt;
+	bool waitingForQueuedDialogResolution =
+		!showingDialog->isBusy() &&
+		!dialogs.empty() &&
+		dialogs.front().state == PendingDialog::State::AwaitingQueryResolution;
 
-	if (ignoreEvents || needToLockAdventureMap || quickCombatOngoing )
+	if (ignoreEvents || needToLockAdventureMap || quickCombatOngoing || waitingForQueuedDialogResolution)
 	{
 		ENGINE->input().ignoreEventsUntilInput();
 		return true;

--- a/client/CPlayerInterface.h
+++ b/client/CPlayerInterface.h
@@ -64,13 +64,26 @@ class CPlayerInterface : public CGameInterface
 
 	struct PendingDialog
 	{
+		enum class Type : std::uint8_t { NonBlocking, Blocking };
+
+		enum class State : std::uint8_t { Queued, AwaitingQueryResolution };
+
 		bool dropOnTurnEnd = false;
-		std::function<void()> show;
+		Type blockingPolicy = Type::Blocking;
+		QueryID queryID = QueryID::NONE;
+		State state = State::Queued;
+		std::function<void()> showCallback;
+
+		bool isLevelUpDialog() const
+		{
+			// queryID means we are dealing with hero or commander level up dialog
+			return queryID != QueryID::NONE;
+		}
 	};
 
 	std::list<PendingDialog> dialogs; //queue of dialogs awaiting to be shown (not currently shown!)
-	std::shared_ptr<WindowBase> pendingLevelUpDialog;
-	int pendingLevelUpRequestID = -1;
+	bool delayQueuedDialogsUntilInputSettles = false;
+	bool levelUpChainPendingContinuation = false;
 
 	std::unique_ptr<HeroMovementController> movementController;
 	std::unique_ptr<PathfinderCache> pathfinderCache;
@@ -246,7 +259,11 @@ private:
 	};
 
 	void heroKilled(const CGHeroInstance* hero);
-	void closePendingLevelUpDialog();
+	void closeActiveLevelUpDialog();
+	void createAndQueueDialog(PendingDialog::Type blocking, std::function<void()> showCallback, QueryID queryID = QueryID::NONE);
+	std::list<PendingDialog>::iterator findQueryBackedDialogInsertionPoint();
+	void tryShowNextPendingDialog();
+	std::list<PendingDialog>::iterator findPendingDialog(QueryID queryID);
 	void townRemoved(const CGTownInstance* town);
 	void garrisonsChanged(std::vector<const CArmedInstance *> objs);
 	void requestReturningToMainMenu(bool won);

--- a/client/CPlayerInterface.h
+++ b/client/CPlayerInterface.h
@@ -145,6 +145,7 @@ protected: // Call-ins from server, should not be called directly, but only via 
 	void heroBonusChanged(const CGHeroInstance *hero, const Bonus &bonus, bool gain) override;//if gain hero received bonus, else he lost it
 	void playerBonusChanged(const Bonus &bonus, bool gain) override;
 	void requestRealized(PackageApplied *pa) override;
+	void queryResolved(QueryID queryID) override;
 	void heroExchangeStarted(ObjectInstanceID hero1, ObjectInstanceID hero2, QueryID query) override;
 	void centerView (int3 pos, int focusTime) override;
 	void beforeObjectPropertyChanged(const SetObjectProperty * sop) override;

--- a/client/ClientNetPackVisitors.h
+++ b/client/ClientNetPackVisitors.h
@@ -88,6 +88,7 @@ public:
 	void visitCatapultAttack(CatapultAttack & pack) override;
 	void visitEndAction(EndAction & pack) override;
 	void visitPackageApplied(PackageApplied & pack) override;
+	void visitQueryResolved(QueryResolved & pack) override;
 	void visitSystemMessage(SystemMessage & pack) override;
 	void visitPlayerBlocked(PlayerBlocked & pack) override;
 	void visitPlayerStartsTurn(PlayerStartsTurn & pack) override;

--- a/client/NetPacksClient.cpp
+++ b/client/NetPacksClient.cpp
@@ -929,6 +929,11 @@ void ApplyClientNetPackVisitor::visitPackageApplied(PackageApplied & pack)
 		logNetwork->warn("Surprising server message! PackageApplied for unknown requestID!");
 }
 
+void ApplyClientNetPackVisitor::visitQueryResolved(QueryResolved & pack)
+{
+	callAllInterfaces(cl, &IGameEventsReceiver::queryResolved, pack.queryID);
+}
+
 void ApplyClientNetPackVisitor::visitSystemMessage(SystemMessage & pack)
 {
 	// usually used to receive error messages from server

--- a/client/windows/CCreatureWindow.cpp
+++ b/client/windows/CCreatureWindow.cpp
@@ -862,12 +862,24 @@ CStackWindow::CStackWindow(const CCommanderInstance * commander, std::vector<ui3
 	: CWindowObject(BORDERED),
 	info(std::make_unique<UnitView>())
 {
-	updateCommanderLevelUpData(commander, skills, callback);
+	GAME->interface()->showingDialog->setBusy();
+	selectionSubmitted = false;
+
+	info->stackNode = commander;
+	info->creature = commander->getCreature();
+	info->commander = commander;
+	info->creatureCount = 1;
+	info->levelupInfo = std::make_optional(UnitView::CommanderLevelInfo());
+	info->levelupInfo->skills = skills;
+	info->levelupInfo->callback = callback;
+	info->owner = dynamic_cast<const CGHeroInstance *> (commander->getArmy());
+
+	init();
 }
 
 CStackWindow::~CStackWindow() = default;
 
-void CStackWindow::updateCommanderLevelUpData(const CCommanderInstance * commander, std::vector<ui32> & skills, std::function<void(ui32)> callback)
+void CStackWindow::updateCommanderLevelUpData(const CCommanderInstance * commander, std::vector<ui32> & skills, const std::function<void(ui32)> & callback)
 {
 	OBJECT_CONSTRUCTION;
 
@@ -1279,4 +1291,3 @@ void CStackWindow::setCloseOnSelection(bool value)
 {
 	closeOnSelection = value;
 }
-

--- a/client/windows/CCreatureWindow.cpp
+++ b/client/windows/CCreatureWindow.cpp
@@ -862,27 +862,14 @@ CStackWindow::CStackWindow(const CCommanderInstance * commander, std::vector<ui3
 	: CWindowObject(BORDERED),
 	info(std::make_unique<UnitView>())
 {
-	GAME->interface()->showingDialog->setBusy();
-	selectionSubmitted = false;
-
-	info->stackNode = commander;
-	info->creature = commander->getCreature();
-	info->commander = commander;
-	info->creatureCount = 1;
-	info->levelupInfo = std::make_optional(UnitView::CommanderLevelInfo());
-	info->levelupInfo->skills = skills;
-	info->levelupInfo->callback = callback;
-	info->owner = dynamic_cast<const CGHeroInstance *> (commander->getArmy());
-
+	initCommanderLevelUpData(commander, skills, callback);
 	init();
 }
 
 CStackWindow::~CStackWindow() = default;
 
-void CStackWindow::updateCommanderLevelUpData(const CCommanderInstance * commander, std::vector<ui32> & skills, const std::function<void(ui32)> & callback)
+void CStackWindow::initCommanderLevelUpData(const CCommanderInstance * commander, const std::vector<ui32> & skills, const std::function<void(ui32)> & callback)
 {
-	OBJECT_CONSTRUCTION;
-
 	GAME->interface()->showingDialog->setBusy();
 	selectionSubmitted = false;
 
@@ -894,6 +881,13 @@ void CStackWindow::updateCommanderLevelUpData(const CCommanderInstance * command
 	info->levelupInfo->skills = skills;
 	info->levelupInfo->callback = callback;
 	info->owner = dynamic_cast<const CGHeroInstance *> (commander->getArmy());
+}
+
+void CStackWindow::updateCommanderLevelUpData(const CCommanderInstance * commander, std::vector<ui32> & skills, const std::function<void(ui32)> & callback)
+{
+	OBJECT_CONSTRUCTION;
+
+	initCommanderLevelUpData(commander, skills, callback);
 
 	if(!background)
 	{
@@ -903,17 +897,6 @@ void CStackWindow::updateCommanderLevelUpData(const CCommanderInstance * command
 
 	fakeNode.reset();
 	activeBonuses.clear();
-
-	if(mainSection)
-		removeChild(mainSection.get());
-	if(activeSpellsSection)
-		removeChild(activeSpellsSection.get());
-	if(bonusesSection)
-		removeChild(bonusesSection.get());
-	if(buttonsSection)
-		removeChild(buttonsSection.get());
-	if(commanderTab)
-		removeChild(commanderTab.get());
 
 	switchButtons.clear();
 	mainSection.reset();

--- a/client/windows/CCreatureWindow.cpp
+++ b/client/windows/CCreatureWindow.cpp
@@ -646,7 +646,7 @@ CStackWindow::MainSection::MainSection(CStackWindow * owner, int yOffset, bool s
 
 		dmgMultiply += battleStack->valOfBonuses(bonusSelector);
 	}
-		
+
 	static const std::array<std::string, 8> iconNames = {
 		"stackWindow/iconAttack", "stackWindow/iconDefense", "stackWindow/iconShots", "stackWindow/iconDamage",
 		"stackWindow/iconHealth", "stackWindow/iconHealthLeft", "stackWindow/iconSpeed", "stackWindow/iconMana"
@@ -838,7 +838,7 @@ CStackWindow::CStackWindow(const CStackInstance * stack, std::function<void()> d
 		info->upgradeInfo = std::make_optional(UnitView::StackUpgradeInfo(upgradeInfo));
 		info->upgradeInfo->callback = callback;
 	}
-	
+
 	info->dismissInfo = std::make_optional(UnitView::StackDismissInfo());
 	info->dismissInfo->callback = dismiss;
 	info->owner = dynamic_cast<const CGHeroInstance *> (stack->getArmy());
@@ -925,16 +925,6 @@ void CStackWindow::updateCommanderLevelUpData(const CCommanderInstance * command
 	redraw();
 }
 
-void CStackWindow::setFreeOnSelection(bool value)
-{
-	freeOnSelection = value;
-}
-
-void CStackWindow::setCloseOnSelection(bool value)
-{
-	closeOnSelection = value;
-}
-
 bool CStackWindow::isCommanderLevelUpDialog() const
 {
 	return info && info->commander && info->levelupInfo.has_value();
@@ -953,8 +943,7 @@ void CStackWindow::submitSelection()
 		}
 
 		selectionSubmitted = true;
-		if(freeOnSelection)
-			GAME->interface()->showingDialog->setFree();
+		GAME->interface()->showingDialog->setFree();
 	}
 
 	if(closeOnSelection)
@@ -1286,3 +1275,8 @@ void CStackWindow::removeStackArtifact(ArtifactPosition pos)
 		redraw();
 	}
 }
+void CStackWindow::setCloseOnSelection(bool value)
+{
+	closeOnSelection = value;
+}
+

--- a/client/windows/CCreatureWindow.cpp
+++ b/client/windows/CCreatureWindow.cpp
@@ -862,6 +862,18 @@ CStackWindow::CStackWindow(const CCommanderInstance * commander, std::vector<ui3
 	: CWindowObject(BORDERED),
 	info(std::make_unique<UnitView>())
 {
+	updateCommanderLevelUpData(commander, skills, callback);
+}
+
+CStackWindow::~CStackWindow() = default;
+
+void CStackWindow::updateCommanderLevelUpData(const CCommanderInstance * commander, std::vector<ui32> & skills, std::function<void(ui32)> callback)
+{
+	OBJECT_CONSTRUCTION;
+
+	GAME->interface()->showingDialog->setBusy();
+	selectionSubmitted = false;
+
 	info->stackNode = commander;
 	info->creature = commander->getCreature();
 	info->commander = commander;
@@ -870,14 +882,62 @@ CStackWindow::CStackWindow(const CCommanderInstance * commander, std::vector<ui3
 	info->levelupInfo->skills = skills;
 	info->levelupInfo->callback = callback;
 	info->owner = dynamic_cast<const CGHeroInstance *> (commander->getArmy());
-	init();
+
+	if(!background)
+	{
+		init();
+		return;
+	}
+
+	fakeNode.reset();
+	activeBonuses.clear();
+
+	if(mainSection)
+		removeChild(mainSection.get());
+	if(activeSpellsSection)
+		removeChild(activeSpellsSection.get());
+	if(bonusesSection)
+		removeChild(bonusesSection.get());
+	if(buttonsSection)
+		removeChild(buttonsSection.get());
+	if(commanderTab)
+		removeChild(commanderTab.get());
+
+	switchButtons.clear();
+	mainSection.reset();
+	activeSpellsSection.reset();
+	commanderMainSection.reset();
+	commanderBonusesSection.reset();
+	bonusesSection.reset();
+	buttonsSection.reset();
+	commanderTab.reset();
+
+	selectedIcon = nullptr;
+	selectedSkill = skills.empty() ? -1 : skills.front();
+	activeTab = 0;
+
+	pos = Rect();
+	initBonusesList();
+	initSections();
+	background->pos = pos;
+
+	setRedrawParent(true);
+	redraw();
 }
 
-CStackWindow::~CStackWindow() = default;
+void CStackWindow::setFreeOnSelection(bool value)
+{
+	freeOnSelection = value;
+}
 
 void CStackWindow::setCloseOnSelection(bool value)
 {
 	closeOnSelection = value;
+}
+
+bool CStackWindow::isCommanderLevelUpDialog() const
+{
+	return info && info->commander && info->levelupInfo.has_value();
 }
 
 void CStackWindow::submitSelection()
@@ -893,15 +953,12 @@ void CStackWindow::submitSelection()
 		}
 
 		selectionSubmitted = true;
-
-		if(!closeOnSelection)
-		{
-			deactivate();
-			return;
-		}
+		if(freeOnSelection)
+			GAME->interface()->showingDialog->setFree();
 	}
 
-	close();
+	if(closeOnSelection)
+		close();
 }
 
 void CStackWindow::close()

--- a/client/windows/CCreatureWindow.h
+++ b/client/windows/CCreatureWindow.h
@@ -200,6 +200,7 @@ class CStackWindow : public CWindowObject
 	void submitSelection();
 
 	void init();
+	void initCommanderLevelUpData(const CCommanderInstance * commander, const std::vector<ui32> & skills, const std::function<void(ui32)> & callback);
 	void showStackExperienceDetailsWindow();
 
 	std::string getCommanderSkillDescription(int skillIndex, int skillLevel);

--- a/client/windows/CCreatureWindow.h
+++ b/client/windows/CCreatureWindow.h
@@ -218,7 +218,7 @@ public:
 	// for commanders & commander level-up dialog
 	CStackWindow(const CCommanderInstance * commander, bool popup);
 	CStackWindow(const CCommanderInstance * commander, std::vector<ui32> &skills, std::function<void(ui32)> callback);
-	void updateCommanderLevelUpData(const CCommanderInstance * commander, std::vector<ui32> & skills, std::function<void(ui32)> callback);
+	void updateCommanderLevelUpData(const CCommanderInstance * commander, std::vector<ui32> & skills, const std::function<void(ui32)> & callback);
 	void setCloseOnSelection(bool value);
 	bool isCommanderLevelUpDialog() const;
 	void close() override;

--- a/client/windows/CCreatureWindow.h
+++ b/client/windows/CCreatureWindow.h
@@ -200,7 +200,6 @@ class CStackWindow : public CWindowObject
 	void submitSelection();
 
 	void init();
-	void close() override;
 	void showStackExperienceDetailsWindow();
 
 	std::string getCommanderSkillDescription(int skillIndex, int skillLevel);
@@ -219,12 +218,17 @@ public:
 	// for commanders & commander level-up dialog
 	CStackWindow(const CCommanderInstance * commander, bool popup);
 	CStackWindow(const CCommanderInstance * commander, std::vector<ui32> &skills, std::function<void(ui32)> callback);
+	void updateCommanderLevelUpData(const CCommanderInstance * commander, std::vector<ui32> & skills, std::function<void(ui32)> callback);
+	void setFreeOnSelection(bool value);
 	void setCloseOnSelection(bool value);
+	bool isCommanderLevelUpDialog() const;
+	void close() override;
 
 	void keyPressed(EShortcut key) override;
 	~CStackWindow();
 
 private:
+	bool freeOnSelection = true;
 	bool closeOnSelection = true;
 	bool selectionSubmitted = false;
 };

--- a/client/windows/CCreatureWindow.h
+++ b/client/windows/CCreatureWindow.h
@@ -219,7 +219,6 @@ public:
 	CStackWindow(const CCommanderInstance * commander, bool popup);
 	CStackWindow(const CCommanderInstance * commander, std::vector<ui32> &skills, std::function<void(ui32)> callback);
 	void updateCommanderLevelUpData(const CCommanderInstance * commander, std::vector<ui32> & skills, std::function<void(ui32)> callback);
-	void setFreeOnSelection(bool value);
 	void setCloseOnSelection(bool value);
 	bool isCommanderLevelUpDialog() const;
 	void close() override;
@@ -228,7 +227,6 @@ public:
 	~CStackWindow();
 
 private:
-	bool freeOnSelection = true;
 	bool closeOnSelection = true;
 	bool selectionSubmitted = false;
 };

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -482,14 +482,14 @@ CLevelWindow::CLevelWindow(const CGHeroInstance * hero, PrimarySkill pskill, std
 {
 	OBJECT_CONSTRUCTION;
 
-	GAME->interface()->showingDialog->setBusy();
-	updateLevelUpData(hero, pskill, skills, callback);
+	initLevelUpData(hero, skills, callback);
+	createLevelUpControls(pskill);
+	setRedrawParent(true);
+	redraw();
 }
 
-void CLevelWindow::updateLevelUpData(const CGHeroInstance * heroInstance, PrimarySkill pskill, const std::vector<SecondarySkill> & availableSkills, const std::function<void(ui32)> & callback)
+void CLevelWindow::initLevelUpData(const CGHeroInstance * heroInstance, const std::vector<SecondarySkill> & availableSkills, const std::function<void(ui32)> & callback)
 {
-	OBJECT_CONSTRUCTION;
-
 	GAME->interface()->showingDialog->setBusy();
 	selectionSubmitted = false;
 	hero = heroInstance;
@@ -502,27 +502,10 @@ void CLevelWindow::updateLevelUpData(const CGHeroInstance * heroInstance, Primar
 			return LIBRARY->skillh->getById(a)->getNameTranslated() < LIBRARY->skillh->getById(b)->getNameTranslated();
 		return heroInstance->getSecSkillLevel(a) > heroInstance->getSecSkillLevel(b);
 	});
+}
 
-	if(box)
-		removeChild(box.get());
-	if(buttonLeft)
-		removeChild(buttonLeft.get());
-	if(buttonRight)
-		removeChild(buttonRight.get());
-	if(portrait)
-		removeChild(portrait.get());
-	if(ok)
-		removeChild(ok.get());
-	if(mainTitle)
-		removeChild(mainTitle.get());
-	if(levelTitle)
-		removeChild(levelTitle.get());
-	if(skillIcon)
-		removeChild(skillIcon.get());
-	if(skillValue)
-		removeChild(skillValue.get());
-
-	createSkillBox();
+void CLevelWindow::createLevelUpControls(PrimarySkill pskill)
+{
 	buttonLeft.reset();
 	buttonRight.reset();
 	portrait.reset();
@@ -532,7 +515,9 @@ void CLevelWindow::updateLevelUpData(const CGHeroInstance * heroInstance, Primar
 	skillIcon.reset();
 	skillValue.reset();
 
-	if(availableSkills.size() > 3)
+	createSkillBox();
+
+	if(skills.size() > 3)
 	{
 		buttonLeft = std::make_shared<CButton>(Point(23, 309), AnimationPath::builtin("HSBTNS3"), CButton::tooltip(), [this](){
 			if(skillViewOffset > 0)
@@ -550,24 +535,31 @@ void CLevelWindow::updateLevelUpData(const CGHeroInstance * heroInstance, Primar
 		}, EShortcut::MOVE_RIGHT);
 	}
 
-	portrait = std::make_shared<CHeroArea>(170, 66, heroInstance);
+	portrait = std::make_shared<CHeroArea>(170, 66, hero);
 	portrait->addClickCallback(nullptr);
-	portrait->addRClickCallback([heroInstance](){ ENGINE->windows().createAndPushWindow<CRClickPopupInt>(std::make_shared<CHeroWindow>(heroInstance)); });
+	portrait->addRClickCallback([hero = hero](){ ENGINE->windows().createAndPushWindow<CRClickPopupInt>(std::make_shared<CHeroWindow>(hero)); });
 	ok = std::make_shared<CButton>(Point(296, 413), AnimationPath::builtin("IOKAY"), CButton::tooltip(), std::bind(&CLevelWindow::submitSelection, this), EShortcut::GLOBAL_ACCEPT);
 
 	//%s has gained a level.
-	mainTitle = std::make_shared<CLabel>(192, 33, FONT_MEDIUM, ETextAlignment::CENTER, Colors::WHITE, boost::str(boost::format(LIBRARY->generaltexth->allTexts[444]) % heroInstance->getNameTranslated()));
+	mainTitle = std::make_shared<CLabel>(192, 33, FONT_MEDIUM, ETextAlignment::CENTER, Colors::WHITE, boost::str(boost::format(LIBRARY->generaltexth->allTexts[444]) % hero->getNameTranslated()));
 
 	//%s is now a level %d %s.
 	std::string levelTitleText = LIBRARY->generaltexth->translate("core.genrltxt.445");
-	boost::replace_first(levelTitleText, "%s", heroInstance->getNameTranslated());
-	boost::replace_first(levelTitleText, "%d", std::to_string(heroInstance->level));
-	boost::replace_first(levelTitleText, "%s", heroInstance->getClassNameTranslated());
+	boost::replace_first(levelTitleText, "%s", hero->getNameTranslated());
+	boost::replace_first(levelTitleText, "%d", std::to_string(hero->level));
+	boost::replace_first(levelTitleText, "%s", hero->getClassNameTranslated());
 
 	levelTitle = std::make_shared<CLabel>(192, 162, FONT_MEDIUM, ETextAlignment::CENTER, Colors::WHITE, levelTitleText);
 	skillIcon = std::make_shared<CAnimImage>(AnimationPath::builtin("PSKIL42"), pskill.getNum(), 0, 174, 190);
 	skillValue = std::make_shared<CLabel>(192, 253, FONT_MEDIUM, ETextAlignment::CENTER, Colors::WHITE, LIBRARY->generaltexth->primarySkillNames[pskill.getNum()] + " +1");
+}
 
+void CLevelWindow::updateLevelUpData(const CGHeroInstance * heroInstance, PrimarySkill pskill, const std::vector<SecondarySkill> & availableSkills, const std::function<void(ui32)> & callback)
+{
+	OBJECT_CONSTRUCTION;
+
+	initLevelUpData(heroInstance, availableSkills, callback);
+	createLevelUpControls(pskill);
 	setRedrawParent(true);
 	redraw();
 }

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -478,15 +478,24 @@ void CSplitWindow::sliderMoved(int to)
 
 CLevelWindow::CLevelWindow(const CGHeroInstance * hero, PrimarySkill pskill, std::vector<SecondarySkill> & skills, std::function<void(ui32)> callback)
 	: CWindowObject(PLAYER_COLORED, ImagePath::builtin("LVLUPBKG")),
-	cb(callback),
-	skills(skills),
-	hero(hero),
 	skillViewOffset(0)
 {
 	OBJECT_CONSTRUCTION;
 
 	GAME->interface()->showingDialog->setBusy();
+	updateLevelUpData(hero, pskill, skills, callback);
+}
 
+void CLevelWindow::updateLevelUpData(const CGHeroInstance * hero, PrimarySkill pskill, std::vector<SecondarySkill> & skills, std::function<void(ui32)> callback)
+{
+	OBJECT_CONSTRUCTION;
+
+	GAME->interface()->showingDialog->setBusy();
+	selectionSubmitted = false;
+	this->hero = hero;
+	cb = callback;
+	this->skills = skills;
+	skillViewOffset = 0;
 	sortedSkills = skills;
 	std::sort(sortedSkills.begin(), sortedSkills.end(), [hero](auto a, auto b) {
 		if(hero->getSecSkillLevel(a) == hero->getSecSkillLevel(b))
@@ -494,18 +503,46 @@ CLevelWindow::CLevelWindow(const CGHeroInstance * hero, PrimarySkill pskill, std
 		return hero->getSecSkillLevel(a) > hero->getSecSkillLevel(b);
 	});
 
+	if(box)
+		removeChild(box.get());
+	if(buttonLeft)
+		removeChild(buttonLeft.get());
+	if(buttonRight)
+		removeChild(buttonRight.get());
+	if(portrait)
+		removeChild(portrait.get());
+	if(ok)
+		removeChild(ok.get());
+	if(mainTitle)
+		removeChild(mainTitle.get());
+	if(levelTitle)
+		removeChild(levelTitle.get());
+	if(skillIcon)
+		removeChild(skillIcon.get());
+	if(skillValue)
+		removeChild(skillValue.get());
+
 	createSkillBox();
+	buttonLeft.reset();
+	buttonRight.reset();
+	portrait.reset();
+	ok.reset();
+	mainTitle.reset();
+	levelTitle.reset();
+	skillIcon.reset();
+	skillValue.reset();
+
 	if(skills.size() > 3)
 	{
-		buttonLeft = std::make_shared<CButton>(Point(23, 309), AnimationPath::builtin("HSBTNS3"), CButton::tooltip(), [this, skills](){
+		buttonLeft = std::make_shared<CButton>(Point(23, 309), AnimationPath::builtin("HSBTNS3"), CButton::tooltip(), [this](){
 			if(skillViewOffset > 0)
 				skillViewOffset--;
 			else
-				skillViewOffset = skills.size() - 1;
+				skillViewOffset = this->skills.size() - 1;
 			createSkillBox();
 		}, EShortcut::MOVE_LEFT);
-		buttonRight = std::make_shared<CButton>(Point(pos.w - 45, 309), AnimationPath::builtin("HSBTNS5"), CButton::tooltip(), [this, skills](){
-			if(skillViewOffset < skills.size() - 1)
+		buttonRight = std::make_shared<CButton>(Point(pos.w - 45, 309), AnimationPath::builtin("HSBTNS5"), CButton::tooltip(), [this](){
+			if(skillViewOffset < this->skills.size() - 1)
 				skillViewOffset++;
 			else
 				skillViewOffset = 0;
@@ -528,10 +565,11 @@ CLevelWindow::CLevelWindow(const CGHeroInstance * hero, PrimarySkill pskill, std
 	boost::replace_first(levelTitleText, "%s", hero->getClassNameTranslated());
 
 	levelTitle = std::make_shared<CLabel>(192, 162, FONT_MEDIUM, ETextAlignment::CENTER, Colors::WHITE, levelTitleText);
-
 	skillIcon = std::make_shared<CAnimImage>(AnimationPath::builtin("PSKIL42"), pskill.getNum(), 0, 174, 190);
-
 	skillValue = std::make_shared<CLabel>(192, 253, FONT_MEDIUM, ETextAlignment::CENTER, Colors::WHITE, LIBRARY->generaltexth->primarySkillNames[pskill.getNum()] + " +1");
+
+	setRedrawParent(true);
+	redraw();
 }
 
 std::vector<SecondarySkill> getSkillsToShow(const std::vector<SecondarySkill>& skills, int offset, int count)
@@ -555,6 +593,8 @@ void CLevelWindow::createSkillBox()
 {
 	OBJECT_CONSTRUCTION;
 
+	box.reset();
+
 	std::vector<SecondarySkill> skillsToShow = skills.size() > 3 ? getSkillsToShow(sortedSkills, skillViewOffset, 3) : sortedSkills;
 	if(!skillsToShow.empty())
 	{
@@ -576,6 +616,11 @@ void CLevelWindow::createSkillBox()
 void CLevelWindow::setCloseOnSelection(bool value)
 {
 	closeOnSelection = value;
+}
+
+void CLevelWindow::setFreeOnSelection(bool value)
+{
+	freeOnSelection = value;
 }
 
 void CLevelWindow::submitSelection()
@@ -610,16 +655,12 @@ void CLevelWindow::submitSelection()
 		}
 
 		selectionSubmitted = true;
-		GAME->interface()->showingDialog->setFree();
-
-		if(!closeOnSelection)
-		{
-			deactivate();
-			return;
-		}
+		if(freeOnSelection)
+			GAME->interface()->showingDialog->setFree();
 	}
 
-	close();
+	if(closeOnSelection)
+		close();
 }
 
 void CLevelWindow::close()

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -618,11 +618,6 @@ void CLevelWindow::setCloseOnSelection(bool value)
 	closeOnSelection = value;
 }
 
-void CLevelWindow::setFreeOnSelection(bool value)
-{
-	freeOnSelection = value;
-}
-
 void CLevelWindow::submitSelection()
 {
 	if(!selectionSubmitted)
@@ -655,8 +650,7 @@ void CLevelWindow::submitSelection()
 		}
 
 		selectionSubmitted = true;
-		if(freeOnSelection)
-			GAME->interface()->showingDialog->setFree();
+		GAME->interface()->showingDialog->setFree();
 	}
 
 	if(closeOnSelection)
@@ -895,7 +889,7 @@ void CTavernWindow::HeroPortrait::clickPressed(const Point & cursorPosition)
 void CTavernWindow::HeroPortrait::clickDouble(const Point & cursorPosition)
 {
 	clickPressed(cursorPosition);
-	
+
 	if(onChoose)
 		onChoose();
 }
@@ -1079,7 +1073,7 @@ CTransformerWindow::CTransformerWindow(const IMarket * _market, const CGHeroInst
 		army = hero;
 	else
 		army = dynamic_cast<const CArmedInstance *>(market); //for town only
-	
+
 	if(army)
 	{
 		for(int i = 0; i < GameConstants::ARMY_SIZE; i++)
@@ -1925,7 +1919,7 @@ void CObjectListWindow::itemsSearchCallback(const std::string & text)
 		std::string name = parts.back();
 		boost::erase_all(name, "{");
     	boost::erase_all(name, "}");
-		
+
 		if(auto score = TextOperations::textSearchSimilarityScore(text, name)) // Keep only relevant items
 			rankedItems.emplace_back(score.value(), item);
 	}

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -486,21 +486,21 @@ CLevelWindow::CLevelWindow(const CGHeroInstance * hero, PrimarySkill pskill, std
 	updateLevelUpData(hero, pskill, skills, callback);
 }
 
-void CLevelWindow::updateLevelUpData(const CGHeroInstance * hero, PrimarySkill pskill, std::vector<SecondarySkill> & skills, std::function<void(ui32)> callback)
+void CLevelWindow::updateLevelUpData(const CGHeroInstance * heroInstance, PrimarySkill pskill, const std::vector<SecondarySkill> & availableSkills, const std::function<void(ui32)> & callback)
 {
 	OBJECT_CONSTRUCTION;
 
 	GAME->interface()->showingDialog->setBusy();
 	selectionSubmitted = false;
-	this->hero = hero;
+	hero = heroInstance;
 	cb = callback;
-	this->skills = skills;
+	skills = availableSkills;
 	skillViewOffset = 0;
-	sortedSkills = skills;
-	std::sort(sortedSkills.begin(), sortedSkills.end(), [hero](auto a, auto b) {
-		if(hero->getSecSkillLevel(a) == hero->getSecSkillLevel(b))
+	sortedSkills = availableSkills;
+	std::sort(sortedSkills.begin(), sortedSkills.end(), [heroInstance](auto a, auto b) {
+		if(heroInstance->getSecSkillLevel(a) == heroInstance->getSecSkillLevel(b))
 			return LIBRARY->skillh->getById(a)->getNameTranslated() < LIBRARY->skillh->getById(b)->getNameTranslated();
-		return hero->getSecSkillLevel(a) > hero->getSecSkillLevel(b);
+		return heroInstance->getSecSkillLevel(a) > heroInstance->getSecSkillLevel(b);
 	});
 
 	if(box)
@@ -532,7 +532,7 @@ void CLevelWindow::updateLevelUpData(const CGHeroInstance * hero, PrimarySkill p
 	skillIcon.reset();
 	skillValue.reset();
 
-	if(skills.size() > 3)
+	if(availableSkills.size() > 3)
 	{
 		buttonLeft = std::make_shared<CButton>(Point(23, 309), AnimationPath::builtin("HSBTNS3"), CButton::tooltip(), [this](){
 			if(skillViewOffset > 0)
@@ -550,19 +550,19 @@ void CLevelWindow::updateLevelUpData(const CGHeroInstance * hero, PrimarySkill p
 		}, EShortcut::MOVE_RIGHT);
 	}
 
-	portrait = std::make_shared<CHeroArea>(170, 66, hero);
+	portrait = std::make_shared<CHeroArea>(170, 66, heroInstance);
 	portrait->addClickCallback(nullptr);
-	portrait->addRClickCallback([hero](){ ENGINE->windows().createAndPushWindow<CRClickPopupInt>(std::make_shared<CHeroWindow>(hero)); });
+	portrait->addRClickCallback([heroInstance](){ ENGINE->windows().createAndPushWindow<CRClickPopupInt>(std::make_shared<CHeroWindow>(heroInstance)); });
 	ok = std::make_shared<CButton>(Point(296, 413), AnimationPath::builtin("IOKAY"), CButton::tooltip(), std::bind(&CLevelWindow::submitSelection, this), EShortcut::GLOBAL_ACCEPT);
 
 	//%s has gained a level.
-	mainTitle = std::make_shared<CLabel>(192, 33, FONT_MEDIUM, ETextAlignment::CENTER, Colors::WHITE, boost::str(boost::format(LIBRARY->generaltexth->allTexts[444]) % hero->getNameTranslated()));
+	mainTitle = std::make_shared<CLabel>(192, 33, FONT_MEDIUM, ETextAlignment::CENTER, Colors::WHITE, boost::str(boost::format(LIBRARY->generaltexth->allTexts[444]) % heroInstance->getNameTranslated()));
 
 	//%s is now a level %d %s.
 	std::string levelTitleText = LIBRARY->generaltexth->translate("core.genrltxt.445");
-	boost::replace_first(levelTitleText, "%s", hero->getNameTranslated());
-	boost::replace_first(levelTitleText, "%d", std::to_string(hero->level));
-	boost::replace_first(levelTitleText, "%s", hero->getClassNameTranslated());
+	boost::replace_first(levelTitleText, "%s", heroInstance->getNameTranslated());
+	boost::replace_first(levelTitleText, "%d", std::to_string(heroInstance->level));
+	boost::replace_first(levelTitleText, "%s", heroInstance->getClassNameTranslated());
 
 	levelTitle = std::make_shared<CLabel>(192, 162, FONT_MEDIUM, ETextAlignment::CENTER, Colors::WHITE, levelTitleText);
 	skillIcon = std::make_shared<CAnimImage>(AnimationPath::builtin("PSKIL42"), pskill.getNum(), 0, 174, 190);

--- a/client/windows/GUIClasses.h
+++ b/client/windows/GUIClasses.h
@@ -166,13 +166,11 @@ public:
 	CLevelWindow(const CGHeroInstance *hero, PrimarySkill pskill, std::vector<SecondarySkill> &skills, std::function<void(ui32)> callback);
 	void updateLevelUpData(const CGHeroInstance * hero, PrimarySkill pskill, std::vector<SecondarySkill> & skills, std::function<void(ui32)> callback);
 	void setCloseOnSelection(bool value);
-	void setFreeOnSelection(bool value);
 
 	void close() override;
 
 private:
 	bool closeOnSelection = true;
-	bool freeOnSelection = true;
 	bool selectionSubmitted = false;
 };
 
@@ -282,7 +280,7 @@ public:
 	std::shared_ptr<VideoWidget> videoPlayer;
 
 	std::shared_ptr<CTextBox> rumor;
-	
+
 	std::shared_ptr<CLabel> inviteHero;
 	std::shared_ptr<CAnimImage> inviteHeroImage;
 	std::shared_ptr<LRClickableArea> inviteHeroImageArea;

--- a/client/windows/GUIClasses.h
+++ b/client/windows/GUIClasses.h
@@ -164,7 +164,7 @@ class CLevelWindow : public CWindowObject
 
 public:
 	CLevelWindow(const CGHeroInstance *hero, PrimarySkill pskill, std::vector<SecondarySkill> &skills, std::function<void(ui32)> callback);
-	void updateLevelUpData(const CGHeroInstance * hero, PrimarySkill pskill, std::vector<SecondarySkill> & skills, std::function<void(ui32)> callback);
+	void updateLevelUpData(const CGHeroInstance * heroInstance, PrimarySkill pskill, const std::vector<SecondarySkill> & availableSkills, const std::function<void(ui32)> & callback);
 	void setCloseOnSelection(bool value);
 
 	void close() override;

--- a/client/windows/GUIClasses.h
+++ b/client/windows/GUIClasses.h
@@ -159,6 +159,8 @@ class CLevelWindow : public CWindowObject
 	const CGHeroInstance * hero;
 
 	void selectionChanged(unsigned to);
+	void initLevelUpData(const CGHeroInstance * heroInstance, const std::vector<SecondarySkill> & availableSkills, const std::function<void(ui32)> & callback);
+	void createLevelUpControls(PrimarySkill pskill);
 	void createSkillBox();
 	void submitSelection();
 

--- a/client/windows/GUIClasses.h
+++ b/client/windows/GUIClasses.h
@@ -164,12 +164,15 @@ class CLevelWindow : public CWindowObject
 
 public:
 	CLevelWindow(const CGHeroInstance *hero, PrimarySkill pskill, std::vector<SecondarySkill> &skills, std::function<void(ui32)> callback);
+	void updateLevelUpData(const CGHeroInstance * hero, PrimarySkill pskill, std::vector<SecondarySkill> & skills, std::function<void(ui32)> callback);
 	void setCloseOnSelection(bool value);
+	void setFreeOnSelection(bool value);
 
 	void close() override;
 
 private:
 	bool closeOnSelection = true;
+	bool freeOnSelection = true;
 	bool selectionSubmitted = false;
 };
 

--- a/lib/callback/IGameEventsReceiver.h
+++ b/lib/callback/IGameEventsReceiver.h
@@ -87,6 +87,7 @@ public:
 	virtual void playerBonusChanged(const Bonus &bonus, bool gain){};//if gain hero received bonus, else he lost it
 	virtual void requestSent(const CPackForServer *pack, int requestID){};
 	virtual void requestRealized(PackageApplied *pa){};
+	virtual void queryResolved(QueryID queryID){}; // query-backed dialog (eg. level-up) was resolved and removed
 	virtual void beforeObjectPropertyChanged(const SetObjectProperty * sop){}; //eg. mine has been flagged
 	virtual void objectPropertyChanged(const SetObjectProperty * sop){}; //eg. mine has been flagged
 	virtual void objectRemoved(const CGObjectInstance *obj, const PlayerColor & initiator){}; //eg. collected resource, picked artifact, beaten hero

--- a/lib/networkPacks/NetPackVisitor.h
+++ b/lib/networkPacks/NetPackVisitor.h
@@ -26,6 +26,7 @@ public:
 	virtual void visitForServer(CPackForServer & pack) {}
 	virtual void visitForClient(CPackForClient & pack) {}
 	virtual void visitPackageApplied(PackageApplied & pack) {}
+	virtual void visitQueryResolved(QueryResolved & pack) {}
 	virtual void visitPackageReceived(PackageReceived & pack) {}
 	virtual void visitSystemMessage(SystemMessage & pack) {}
 	virtual void visitPlayerBlocked(PlayerBlocked & pack) {}

--- a/lib/networkPacks/NetPacksLib.cpp
+++ b/lib/networkPacks/NetPacksLib.cpp
@@ -72,6 +72,11 @@ void PackageApplied::visitTyped(ICPackVisitor & visitor)
 	visitor.visitPackageApplied(*this);
 }
 
+void QueryResolved::visitTyped(ICPackVisitor & visitor)
+{
+	visitor.visitQueryResolved(*this);
+}
+
 void PackageReceived::visitTyped(ICPackVisitor & visitor)
 {
 	visitor.visitPackageReceived(*this);

--- a/lib/networkPacks/PacksForClient.h
+++ b/lib/networkPacks/PacksForClient.h
@@ -82,6 +82,24 @@ struct DLL_LINKAGE PackageApplied : public CPackForClient
 	}
 };
 
+struct DLL_LINKAGE QueryResolved : public CPackForClient
+{
+	QueryResolved() = default;
+	explicit QueryResolved(QueryID queryID)
+		: queryID(queryID)
+	{
+	}
+
+	void visitTyped(ICPackVisitor & visitor) override;
+
+	QueryID queryID = QueryID::NONE;
+
+	template <typename Handler> void serialize(Handler & h)
+	{
+		h & queryID;
+	}
+};
+
 struct DLL_LINKAGE PackageReceived : public CPackForClient
 {
 	PackageReceived() = default;

--- a/lib/serializer/RegisterTypes.h
+++ b/lib/serializer/RegisterTypes.h
@@ -127,6 +127,7 @@ void registerTypes(Serializer &s)
 	s.template registerType<CObstacleInstance>(79);
 	s.template registerType<SpellCreatedObstacle>(80);
 	s.template registerType<CPack>(82);
+	s.template registerType<QueryResolved>(83);
 	s.template registerType<PackageApplied>(84);
 	s.template registerType<SystemMessage>(85);
 	s.template registerType<PlayerBlocked>(86);

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -1547,6 +1547,12 @@ void CGameHandler::sendAndApply(CPackForClient & pack)
 	gameServer().applyPack(pack);
 }
 
+void CGameHandler::sendQueryResolved(QueryID queryID)
+{
+	QueryResolved pack(queryID);
+	sendAndApply(pack);
+}
+
 void CGameHandler::sendAndApply(CGarrisonOperationPack & pack)
 {
 	sendAndApply(static_cast<CPackForClient &>(pack));

--- a/server/CGameHandler.h
+++ b/server/CGameHandler.h
@@ -239,6 +239,7 @@ public:
 	void onAdvInterfaceReady(PlayerColor player);
 	void onNewTurn();
 	void addStatistics(StatisticDataSet &stat) const;
+	void sendQueryResolved(QueryID queryID);
 
 	bool complain(const std::string &problem); //sends message to all clients, prints on the logs and return true
 	void objectVisited( const CGObjectInstance * obj, const CGHeroInstance * h );

--- a/server/processors/TurnOrderProcessor.cpp
+++ b/server/processors/TurnOrderProcessor.cpp
@@ -275,9 +275,7 @@ void TurnOrderProcessor::doStartPlayerTurn(PlayerColor which)
 	assert(gameHandler->gameInfo().getPlayerState(which));
 	assert(gameHandler->gameInfo().getPlayerState(which)->status == EPlayerStatus::INGAME);
 
-	// Only if player is actually starting his turn (and not loading from save)
-	if (!actingPlayers.count(which))
-		gameHandler->onPlayerTurnStarted(which);
+	const bool wasAlreadyActing = actingPlayers.count(which);
 
 	actingPlayers.insert(which);
 	awaitingPlayers.erase(which);
@@ -295,7 +293,26 @@ void TurnOrderProcessor::doStartPlayerTurn(PlayerColor which)
 		pst.queryID = turnQuery->queryID;
 	}
 
-	gameHandler->sendAndApply(pst);
+	if(isHuman)
+	{
+		gameHandler->sendAndApply(pst);
+
+		// Only if player is actually starting his turn (and not loading from save).
+		// Send PlayerStartsTurn first so the client enters the new-turn flow before
+		// deferred turn-start visits (e.g. Battle Scholar Academy) start producing dialogs.
+		if (!wasAlreadyActing)
+			gameHandler->onPlayerTurnStarted(which);
+	}
+	else
+	{
+		// AI starts acting immediately from PlayerStartsTurn/yourTurn, so keep the
+		// original ordering and prepare deferred turn-start visits first.
+		if (!wasAlreadyActing)
+			gameHandler->onPlayerTurnStarted(which);
+
+		gameHandler->sendAndApply(pst);
+	}
+
 	assert(!actingPlayers.empty());
 }
 

--- a/server/queries/BattleQueries.cpp
+++ b/server/queries/BattleQueries.cpp
@@ -161,3 +161,9 @@ void CBattleDialogQuery::onRemoval(PlayerColor color)
 	}
 	resultProcessed = true;
 }
+
+void CBattleDialogQuery::onExposure(QueryPtr topQuery)
+{
+	if(answer)
+		owner->popIfTop(*this);
+}

--- a/server/queries/BattleQueries.h
+++ b/server/queries/BattleQueries.h
@@ -50,4 +50,5 @@ public:
 	static constexpr QueryType TYPE = QueryType::BattleDialog;
 	CBattleDialogQuery(CGameHandler * owner, const IBattleInfo * Bi, const std::optional<BattleResult> & Br);
 	void onRemoval(PlayerColor color) override;
+	void onExposure(QueryPtr topQuery) override;
 };

--- a/server/queries/MapQueries.cpp
+++ b/server/queries/MapQueries.cpp
@@ -236,6 +236,7 @@ CHeroLevelUpDialogQuery::CHeroLevelUpDialogQuery(CGameHandler * owner, const Her
 void CHeroLevelUpDialogQuery::onRemoval(PlayerColor color)
 {
 	assert(answer);
+	gh->sendQueryResolved(queryID);
 	if(hlu.skills.empty())
 	{
 		logGlobal->trace("Completing hero level-up query. %s gains no secondary skill", hero->getObjectName());
@@ -304,6 +305,7 @@ CCommanderLevelUpDialogQuery::CCommanderLevelUpDialogQuery(CGameHandler * owner,
 void CCommanderLevelUpDialogQuery::onRemoval(PlayerColor color)
 {
 	assert(answer);
+	gh->sendQueryResolved(queryID);
 	if(clu.skills.empty())
 	{
 		logGlobal->trace("Completing commander level-up query. Commander of hero %s gains no skill", hero->getObjectName());


### PR DESCRIPTION
This is a follow-up to: 
- #7224 
- #7437
- and my earlier #7308.

It focuses on the remaining issues around queued level-up dialogs:

  - keeps queued hero / commander level-up dialogs tied to actual server-side query lifetime
  - improves chained dialog handling without reopening the earlier flicker/crash/object-visit problems

Fixes #7467
- #7467

Fixes #7515
- #7515 