### PR TITLE
Upload AAB as artifact for all CI runs

### DIFF
--- a/.github/workflows/github.yml
+++ b/.github/workflows/github.yml
@@ -440,7 +440,7 @@ jobs:
 
     - name: Upload AAB Artifact
       id: upload_aab
-      if: ${{ startsWith(matrix.platform, 'android') && github.ref == 'refs/heads/master' }}
+      if: ${{ startsWith(matrix.platform, 'android') }}
       uses: actions/upload-artifact@v7
       with:
         archive: false


### PR DESCRIPTION
AAB is useful not just for Google Play upload but also as source of debug symbols for Android (which are normally stripped from apk's)

This should allow investigating that crash on map start on Android & decoding failing call stack, as well as similar bugs in the future