### PR TITLE
Update dependencies and runners

### DIFF
--- a/.github/workflows/github.yml
+++ b/.github/workflows/github.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         include:
           - platform: mac-intel
-            os: macos-15
+            os: macos-26
             pack: 1
             upload: 1
             pack_type: Release
@@ -33,7 +33,7 @@ jobs:
             artifact_platform: intel
 
           - platform: mac-arm
-            os: macos-15
+            os: macos-26
             pack: 1
             upload: 1
             pack_type: Release
@@ -46,7 +46,7 @@ jobs:
             artifact_platform: arm
 
           - platform: ios
-            os: macos-15
+            os: macos-26
             pack: 1
             upload: 1
             pack_type: RelWithDebInfo
@@ -87,7 +87,7 @@ jobs:
 
           - platform: msvc-arm64
             arch: arm64
-            os: windows-11-arm
+            os: windows-11-vs2026-arm
             pack: 1
             upload: 0
             pack_type: RelWithDebInfo

--- a/CI/before_install/macos.sh
+++ b/CI/before_install/macos.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
-echo DEVELOPER_DIR=/Applications/Xcode_26.2.app >> $GITHUB_ENV
+echo DEVELOPER_DIR=/Applications/Xcode_26.3.app >> $GITHUB_ENV
 
 brew update

--- a/CI/install_conan_dependencies.sh
+++ b/CI/install_conan_dependencies.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-RELEASE_TAG="2026-06-08"
+RELEASE_TAG="2026-06-27"
 FILENAME="$1.txz"
 DOWNLOAD_URL="https://github.com/vcmi/vcmi-dependencies/releases/download/$RELEASE_TAG/$FILENAME"
 


### PR DESCRIPTION
- dependencies submodule updated and binaries are taken from https://github.com/vcmi/vcmi-dependencies/releases/tag/2026-06-27 which contains LuaJIT built from the latest source of `v2.1` branch
- CI environment updated, now matches the dependencies submodule