### PR TITLE
Remove wrong assert

### DIFF
--- a/lib/battle/DamageCalculator.cpp
+++ b/lib/battle/DamageCalculator.cpp
@@ -564,16 +564,10 @@ DamageEstimation DamageCalculator::calculateDmgRange() const
 	double defenseFactorTotal = 1.0;
 
 	for (auto & factor : attackFactors)
-	{
-		assert(factor >= 0.0);
 		attackFactorTotal += factor;
-	}
 
 	for (auto & factor : defenseFactors)
-	{
-		assert(factor >= 0.0);
 		defenseFactorTotal *= (1 - std::min(1.0, factor));
-	}
 
 	double resultingFactor = attackFactorTotal * defenseFactorTotal;
 


### PR DESCRIPTION
Negative values are a valid scenario.
(e.g. hota [freezing shot](https://github.com/vcmi-mods/horn-of-the-abyss/blob/9ae7616dad13d7fe67858762abb737817d58104f/mods/bulwark/content/config/hota/bulwark/spells/freezingShot.json#L54) has GENERAL_DAMAGE_REDUCTION=-25 and always triggers the defense factor assert)

The corresponding assert for attackFactors is removed as well. I have not yet seen it trigger, but nothing prevents defining a bonus with a negative value, so I reckon it would also cause issues at some point => remove it.

