### PR TITLE
Add command-line map converter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -722,6 +722,10 @@ if(ENABLE_EDITOR)
 	add_subdirectory(mapeditor)
 endif()
 
+if(ENABLE_CLIENT AND NOT ENABLE_MINIMAL_LIB AND NOT IOS AND NOT ANDROID)
+	add_subdirectory(mapconverter)
+endif()
+
 if(ENABLE_LOBBY)
 	add_subdirectory(lobby)
 endif()

--- a/docs/Readme.md
+++ b/docs/Readme.md
@@ -96,6 +96,10 @@ Engine documentation: (NOTE: may be outdated)
 - [Lua Scripting System](developers/Lua_Scripting_System.md)
 - [Serialization](developers/Serialization.md)
 
+Developer tools:
+
+- [Map converter](../mapconverter/README.md)
+
 ## Documentation and guidelines for maintainers
 
 - [Project Infrastructure](maintainers/Project_Infrastructure.md)

--- a/lib/VCMIDirs.cpp
+++ b/lib/VCMIDirs.cpp
@@ -212,7 +212,7 @@ bool IVCMIDirsUNIX::developmentMode() const
 {
 	// We want to be able to run VCMI from single directory. E.g to run from build output directory
 	const bool hasConfigs = bfs::exists("config") && bfs::exists("Mods");
-	const bool hasBinaries = bfs::exists("vcmiclient") || bfs::exists("vcmiserver") || bfs::exists("vcmilobby") || bfs::exists("vcmieditor");
+	const bool hasBinaries = bfs::exists("vcmiclient") || bfs::exists("vcmiserver") || bfs::exists("vcmilobby") || bfs::exists("vcmieditor") || bfs::exists("vcmimapconverter");
 	return hasConfigs && hasBinaries;
 }
 

--- a/mapconverter/CMakeLists.txt
+++ b/mapconverter/CMakeLists.txt
@@ -1,0 +1,39 @@
+set(mapconverter_SRCS
+		StdInc.cpp
+		EntryPoint.cpp
+)
+
+set(mapconverter_HEADERS
+		StdInc.h
+)
+
+assign_source_group(${mapconverter_SRCS} ${mapconverter_HEADERS})
+add_executable(vcmimapconverter ${mapconverter_SRCS} ${mapconverter_HEADERS})
+if(USING_CONAN)
+	vcmi_copy_conan_runtime_deps(vcmimapconverter)
+endif()
+
+target_link_libraries(vcmimapconverter PRIVATE vcmi Boost::program_options)
+
+target_include_directories(vcmimapconverter
+	PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+if(WIN32)
+	set(VCMI_FILE_DESCRIPTION "VCMI Map Converter")
+	set(VCMI_ORIGINAL_FILENAME "VCMI_mapconverter.exe")
+	set(VCMI_ICON_RESOURCE "")
+	set(mapconverter_VERSIONINFO_RC "${CMAKE_CURRENT_BINARY_DIR}/VCMI_mapconverter_versioninfo.rc")
+	configure_file("${CMAKE_SOURCE_DIR}/win/WindowsFileInfo.rc.in" "${mapconverter_VERSIONINFO_RC}" @ONLY)
+	target_sources(vcmimapconverter PRIVATE "${mapconverter_VERSIONINFO_RC}")
+	set_target_properties(vcmimapconverter
+		PROPERTIES
+			OUTPUT_NAME "VCMI_mapconverter"
+			PROJECT_LABEL "VCMI_mapconverter"
+	)
+endif()
+
+vcmi_set_output_dir(vcmimapconverter "")
+enable_pch(vcmimapconverter)
+
+install(TARGETS vcmimapconverter DESTINATION ${BIN_DIR})

--- a/mapconverter/EntryPoint.cpp
+++ b/mapconverter/EntryPoint.cpp
@@ -1,0 +1,233 @@
+/*
+ * EntryPoint.cpp, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
+
+#include "StdInc.h"
+
+#include "../lib/GameLibrary.h"
+#include "../lib/ScopeGuard.h"
+#include "../lib/VCMIDirs.h"
+#include "../lib/callback/EditorCallback.h"
+#include "../lib/CRandomGenerator.h"
+#include "../lib/entities/artifact/CArtifact.h"
+#include "../lib/entities/hero/CHeroClass.h"
+#include "../lib/entities/hero/CHeroHandler.h"
+#include "../lib/filesystem/Filesystem.h"
+#include "../lib/logging/CBasicLogConfigurator.h"
+#include "../lib/mapObjectConstructors/AObjectTypeHandler.h"
+#include "../lib/mapObjectConstructors/CObjectClassesHandler.h"
+#include "../lib/mapObjectConstructors/CommonConstructors.h"
+#include "../lib/mapObjects/CGHeroInstance.h"
+#include "../lib/mapObjects/CGTownInstance.h"
+#include "../lib/mapObjects/MiscObjects.h"
+#include "../lib/mapping/CMap.h"
+#include "../lib/mapping/CMapService.h"
+#include "../lib/spells/CSpellHandler.h"
+
+#include <boost/program_options.hpp>
+#include <fstream>
+#include <limits>
+
+namespace po = boost::program_options;
+
+VCMI_LIB_USING_NAMESPACE
+
+namespace
+{
+std::vector<uint8_t> readFile(const boost::filesystem::path & path)
+{
+	const auto size = boost::filesystem::file_size(path);
+	if(size > static_cast<uintmax_t>(std::numeric_limits<int>::max()))
+		throw std::runtime_error("Input map is too large: " + path.string());
+
+	std::vector<uint8_t> result(size);
+	std::ifstream input(path.string(), std::ios::binary);
+	if(!input)
+		throw std::runtime_error("Cannot open input map: " + path.string());
+
+	input.read(reinterpret_cast<char *>(result.data()), static_cast<std::streamsize>(result.size()));
+	if(!input)
+		throw std::runtime_error("Cannot read input map: " + path.string());
+
+	return result;
+}
+
+void repairMapForSaving(CMap * map)
+{
+	if(!map)
+		return;
+
+	int emptyNameId = 1;
+	for(auto & event : map->events)
+	{
+		if(event.name.empty())
+			event.name = "event_" + std::to_string(emptyNameId++);
+	}
+
+	emptyNameId = 1;
+	for(auto & rumor : map->rumors)
+	{
+		if(rumor.name.empty())
+			rumor.name = "rumor_" + std::to_string(emptyNameId++);
+	}
+
+	std::vector<CGObjectInstance *> impactedObjects;
+	for(const auto & object : map->objects)
+		impactedObjects.push_back(object.get());
+
+	for(const auto & hero : map->getHeroesInPool())
+		impactedObjects.push_back(map->tryGetFromHeroPool(hero));
+
+	for(auto * object : impactedObjects)
+	{
+		if(!object)
+			continue;
+
+		if(object->asOwnable() && object->getOwner() == PlayerColor::UNFLAGGABLE)
+			object->tempOwner = PlayerColor::NEUTRAL;
+
+		if(auto * hero = dynamic_cast<CGHeroInstance *>(object))
+		{
+			map->allowedHeroes.insert(hero->getHeroTypeID());
+
+			const auto & heroType = LIBRARY->heroh->objects[hero->subID];
+			if(hero->ID == Obj::HERO)
+			{
+				hero->appearance = LIBRARY->objtypeh
+					->getHandlerFor(Obj::HERO, heroType->heroClass->getIndex())
+					->getTemplates()
+					.front();
+			}
+
+			if(hero->spellbookContainsSpell(SpellID::SPELLBOOK_PRESET))
+			{
+				hero->removeSpellFromSpellbook(SpellID::SPELLBOOK_PRESET);
+				if(!hero->getArt(ArtifactPosition::SPELLBOOK) && heroType->haveSpellBook)
+					hero->putArtifact(ArtifactPosition::SPELLBOOK, map->createArtifact(ArtifactID::SPELLBOOK));
+			}
+		}
+
+		if(auto * town = dynamic_cast<CGTownInstance *>(object))
+		{
+			if(town->getTown())
+			{
+				for(const auto & building : town->getBuildings())
+				{
+					if(!town->getTown()->buildings.count(building))
+						town->removeBuilding(building);
+				}
+
+				vstd::erase_if(town->forbiddenBuildings, [town](BuildingID building)
+				{
+					return !town->getTown()->buildings.count(building);
+				});
+			}
+		}
+
+		if(auto * artifact = dynamic_cast<CGArtifact *>(object))
+		{
+			if(artifact->ID == Obj::SPELL_SCROLL && !artifact->getArtifactInstance())
+			{
+				std::vector<SpellID> spells;
+				for(const auto & spell : LIBRARY->spellh->objects)
+				{
+					if(spell)
+						spells.push_back(spell->id);
+				}
+
+				auto scroll = map->createScroll(*RandomGeneratorUtil::nextItem(spells, CRandomGenerator::getDefault()));
+				artifact->setArtifactInstance(scroll);
+			}
+		}
+
+		if(auto * mine = dynamic_cast<CGMine *>(object))
+		{
+			if(!mine->isAbandoned())
+			{
+				if(mine->getResourceHandler()->getResourceType() == GameResID::NONE)
+					mine->producedResource = GameResID(mine->subID);
+				else
+					mine->producedResource = mine->getResourceHandler()->getResourceType();
+
+				mine->producedQuantity = mine->defaultResProduction();
+			}
+		}
+	}
+}
+
+void convertMap(const boost::filesystem::path & inputPath, const boost::filesystem::path & outputPath)
+{
+	CMapService mapService;
+	EditorCallback callback(nullptr);
+	const auto inputBytes = readFile(inputPath);
+	auto map = mapService.loadMap(inputBytes.data(), static_cast<int>(inputBytes.size()), inputPath.filename().string(), "core", "ASCII", &callback);
+	callback.setMap(map.get());
+	repairMapForSaving(map.get());
+	mapService.saveMap(map, outputPath);
+}
+
+void initializeLibrary(const boost::filesystem::path & logPath)
+{
+	CBasicLogConfigurator logConfigurator(logPath, nullptr);
+	logConfigurator.configureDefault();
+
+	LIBRARY = new GameLibrary;
+	LIBRARY->initializeFilesystem(false);
+	logConfigurator.configure();
+	LIBRARY->initializeLibrary();
+}
+
+void cleanupLibrary()
+{
+	delete LIBRARY;
+	LIBRARY = nullptr;
+	CResourceHandler::destroy();
+}
+}
+
+int main(int argc, char ** argv)
+{
+	po::options_description options("Allowed options");
+	options.add_options()
+		("help,h", "display help and exit")
+		("input,i", po::value<std::string>()->required(), "input .h3m or .vmap map")
+		("output,o", po::value<std::string>()->required(), "output .vmap map");
+
+	po::variables_map vm;
+
+	try
+	{
+		po::store(po::parse_command_line(argc, argv, options), vm);
+
+		if(vm.count("help"))
+		{
+			std::cout << options << std::endl;
+			return 0;
+		}
+
+		po::notify(vm);
+
+		const auto inputPath = boost::filesystem::path(vm["input"].as<std::string>());
+		const auto outputPath = boost::filesystem::path(vm["output"].as<std::string>());
+		const auto logPath = VCMIDirs::get().userLogsPath() / "VCMI_MapConverter_log.txt";
+
+		initializeLibrary(logPath);
+		auto cleanup = vstd::makeScopeGuard(cleanupLibrary);
+
+		convertMap(inputPath, outputPath);
+
+		std::cout << "Converted " << inputPath.string() << " to " << outputPath.string() << std::endl;
+		return 0;
+	}
+	catch(const std::exception & e)
+	{
+		std::cerr << "Map conversion failed: " << e.what() << std::endl;
+		return 1;
+	}
+}

--- a/mapconverter/README.md
+++ b/mapconverter/README.md
@@ -1,0 +1,61 @@
+# VCMI Map Converter
+
+`vcmimapconverter` is a command-line tool that loads a map through the
+regular VCMI map service and saves it in VCMI map format.
+
+The main use case is converting Heroes III `.h3m` maps to `.vmap` for
+scripts, automated checks, or reproducible investigations without
+starting the map editor UI.
+
+## Building
+
+The converter is built when `ENABLE_CLIENT` is enabled and
+`ENABLE_MINIMAL_LIB` is disabled.
+
+Build only the converter target:
+
+```sh
+cmake --build <build-dir> --target vcmimapconverter
+```
+
+## Usage
+
+Convert a Heroes III map to VCMI map format:
+
+```sh
+vcmimapconverter --input path/to/input.h3m --output path/to/output.vmap
+```
+
+The short option form is also supported:
+
+```sh
+vcmimapconverter -i path/to/input.h3m -o path/to/output.vmap
+```
+
+Display command-line help:
+
+```sh
+vcmimapconverter --help
+```
+
+The output path must point to the target `.vmap` file. Existing files are
+overwritten by the map saving code.
+
+## Conversion Notes
+
+The converter initializes the same game library and filesystem stack as
+other VCMI tools. Run it from a normal VCMI build or install directory
+where the engine can find its `config` and `Mods` directories.
+
+Before saving, the converter repairs common loaded-map state that can be
+valid after import but invalid for writing:
+
+- unnamed events and rumors receive generated names;
+- unflaggable ownable objects are normalized to neutral ownership;
+- predefined spellbook markers are converted to real spellbook artifacts;
+- town buildings not available in the loaded town type are removed;
+- spell scroll objects without an artifact instance receive a spell;
+- mine production fields are normalized from the mine type.
+
+Logs are written to `VCMI_MapConverter_log.txt` in the normal user log
+directory.

--- a/mapconverter/StdInc.cpp
+++ b/mapconverter/StdInc.cpp
@@ -1,0 +1,11 @@
+/*
+ * StdInc.cpp, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
+
+#include "StdInc.h"

--- a/mapconverter/StdInc.h
+++ b/mapconverter/StdInc.h
@@ -1,0 +1,13 @@
+/*
+ * StdInc.h, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
+
+#pragma once
+
+#include "../Global.h"


### PR DESCRIPTION
Add vcmimapconverter, a small non-GUI tool for loading maps through the regular map service and writing them back in VCMI map format.

This exposes the existing H3M-to-VMAP conversion path for scripts and reproducible AI investigations without starting the map editor UI.

Used this to automatically convert the map attached here https://github.com/vcmi/vcmi/pull/7504#issuecomment-4766837934