### PR TITLE
CI tweaks

### DIFF
--- a/.github/workflows/github.yml
+++ b/.github/workflows/github.yml
@@ -674,6 +674,7 @@ jobs:
       if: always()
       env:
         PLATFORM: ${{ matrix.platform }}
+        PYTHONPATH: ${{ github.workspace }}/CI
       run: |
         python3 CI/emit_test_partial.py
 

--- a/.github/workflows/github.yml
+++ b/.github/workflows/github.yml
@@ -244,7 +244,7 @@ jobs:
 
     - name: Setup MSVC Developer Command Prompt
       if: ${{ startsWith(matrix.platform, 'msvc') }}
-      uses: ilammy/msvc-dev-cmd@v1
+      uses: step-security/msvc-dev-cmd@main
       with:
         arch: ${{ matrix.arch }}
         toolset: ${{ matrix.toolset }}
@@ -253,7 +253,7 @@ jobs:
     # fall back to cache of the vcmi/vcmi repo if no PR-specific cache is found
 
     - name: Setup compiler cache for PRs
-      uses: hendrikmuhs/ccache-action@v1.2
+      uses: step-security/ccache-action@v1
       if: ${{ github.event.number != '' }}
       with:
         variant: ${{ startsWith(matrix.platform, 'msvc') && 'sccache' || 'ccache' }}
@@ -268,7 +268,7 @@ jobs:
         job-summary: ""           # <-- disable built-in summary to avoid duplicate block
 
     - name: Setup compiler cache for branch builds
-      uses: hendrikmuhs/ccache-action@v1.2
+      uses: step-security/ccache-action@v1
       if: ${{ github.event.number == '' }}
       with:
         variant: ${{ startsWith(matrix.platform, 'msvc') && 'sccache' || 'ccache' }}
@@ -615,7 +615,7 @@ jobs:
         key: ${{ steps.aptcache.outputs.cache-primary-key }}
 
     - name: Setup compiler cache for PRs
-      uses: hendrikmuhs/ccache-action@v1.2
+      uses: step-security/ccache-action@v1
       if: ${{ github.event.number != '' }}
       with:
         key: ${{ matrix.platform }}-PR-${{ github.event.number }}
@@ -625,9 +625,10 @@ jobs:
           ${{ matrix.platform }}-
         max-size: '5G'
         verbose: 2
+        job-summary: ""
 
     - name: Setup compiler cache for branch builds
-      uses: hendrikmuhs/ccache-action@v1.2
+      uses: step-security/ccache-action@v1
       if: ${{ github.event.number == '' }}
       with:
         key: ${{ matrix.platform }}-branch-${{ github.ref_name }}
@@ -636,6 +637,7 @@ jobs:
           ${{ matrix.platform }}-
         max-size: '5G'
         verbose: 2
+        job-summary: ""
 
     - name: Prepare Heroes 3 data
       run: |
@@ -667,6 +669,20 @@ jobs:
             echo "Validation failed!"
             exit 1
         fi
+
+    - name: Prepare partial JSON with test cache information
+      if: always()
+      env:
+        PLATFORM: ${{ matrix.platform }}
+      run: |
+        python3 CI/emit_test_partial.py
+
+    - name: Upload partial JSON with test cache information
+      if: always()
+      uses: actions/upload-artifact@v7
+      with:
+        name: partial-json-test-${{ matrix.platform }}
+        path: .summary/test-${{ matrix.platform }}.json
 
   lobby:
     name: Build VCMI Lobby

--- a/CI/before_install/macos.sh
+++ b/CI/before_install/macos.sh
@@ -2,4 +2,6 @@
 
 echo DEVELOPER_DIR=/Applications/Xcode_26.2.app >> $GITHUB_ENV
 
+brew untap aws/tap || true
+brew trust --formula azure/bicep/bicep || true
 brew update

--- a/CI/create_appimage.sh
+++ b/CI/create_appimage.sh
@@ -89,8 +89,8 @@ if [[ -z "$VERSION" ]]; then
 fi
 
 # Set up environment variables for linuxdeploy
-export VERSION
-export UPD_INFO="gh-releases-zsync|vcmi|vcmi|continuous|VCMI-*$ARCH.AppImage.zsync"
+export LINUXDEPLOY_OUTPUT_VERSION="$VERSION"
+export LDAI_UPDATE_INFORMATION="gh-releases-zsync|vcmi|vcmi|continuous|VCMI-*$ARCH.AppImage.zsync"
 
 # Detect qmake
 if [[ -z "$QMAKE" ]]; then
@@ -157,10 +157,11 @@ rm -f linuxdeploy-*.AppImage
 echo "AppImage creation complete!"
 
 # Move to build directory if specified (for CI integration)
-APPIMAGE_FILE=$(ls VCMI-*.AppImage 2>/dev/null | head -n 1)
+APPIMAGE_FILE=$(find . -maxdepth 1 -type f -name "*.AppImage" ! -name "linuxdeploy*.AppImage" | head -n 1)
 if [[ -n "$APPIMAGE_FILE" ]] && [[ -n "$BUILD_DIR" ]]; then
     # Use VCMI_PACKAGE_FILE_NAME from CI if available, otherwise original name
-    TARGET_NAME="${VCMI_PACKAGE_FILE_NAME:-${APPIMAGE_FILE%.*}}.AppImage"
+    APPIMAGE_BASENAME=$(basename "$APPIMAGE_FILE")
+    TARGET_NAME="${VCMI_PACKAGE_FILE_NAME:-${APPIMAGE_BASENAME%.*}}.AppImage"
     echo "Ensuring $BUILD_DIR exists and moving $APPIMAGE_FILE to $BUILD_DIR/$TARGET_NAME"
     mkdir -p "$BUILD_DIR"
     mv "$APPIMAGE_FILE" "$BUILD_DIR/$TARGET_NAME"

--- a/CI/emit_test_partial.py
+++ b/CI/emit_test_partial.py
@@ -5,8 +5,7 @@ import os
 import pathlib
 import sys
 
-sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
-from emit_partial import parse_ccache, run  # noqa: E402
+from emit_partial import parse_ccache, run
 
 
 def main() -> int:

--- a/CI/emit_test_partial.py
+++ b/CI/emit_test_partial.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+
+import json
+import os
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+from emit_partial import parse_ccache, run  # noqa: E402
+
+
+def main() -> int:
+    platform = os.getenv("PLATFORM", "unknown")
+    stats_raw = run(["ccache", "-s"])
+    hits, misses = parse_ccache(stats_raw)
+    total = hits + misses
+    rate = f"{(100.0 * hits / total):.2f}%" if total else "n/a"
+
+    payload = {
+        "platform": platform,
+        "hits": hits,
+        "misses": misses,
+        "total": total,
+        "rate": rate,
+        "stats_cmd": "ccache -s",
+        "stats_raw": stats_raw,
+    }
+
+    outdir = pathlib.Path(".summary")
+    outdir.mkdir(parents=True, exist_ok=True)
+    outpath = outdir / f"test-{platform}.json"
+    outpath.write_text(json.dumps(payload, ensure_ascii=False, indent=2))
+    print(f"Wrote {outpath}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/CI/final_summary.py
+++ b/CI/final_summary.py
@@ -182,12 +182,14 @@ def _rows_for_job(j: Dict[str, Any]) -> List[Dict[str, Any]]:
     # Tests matrix
     if name.startswith("Test "):
         pretty = _test_pretty_name(name)
+        platform = name.replace("Test (", "").removesuffix(")")
         steps = j.get("steps") or []
         test_step = next((s for s in steps if s.get("name") == "Test"), None)
         status = (test_step.get("conclusion") if test_step else None) or j.get("conclusion") or "neutral"
         rows.append({
             "group": "tests",
             "name": pretty,
+            "platform": platform,
             "status": status,
             "duration": dur,
             "url": j.get("html_url"),
@@ -237,6 +239,15 @@ def _load_installer_map() -> Dict[str, str]:
         if plat and url:
             inst_map[plat] = url
     return inst_map
+
+def _load_test_cache_map() -> Dict[str, Dict[str, Any]]:
+    cache_map: Dict[str, Dict[str, Any]] = {}
+    for p in glob.glob("partials/test-*.json"):
+        obj = read_json_file(p) or {}
+        plat = obj.get("platform")
+        if plat:
+            cache_map[plat] = obj
+    return cache_map
 
 def _durations_map(val_rows: List[Dict[str, Any]]) -> Dict[str, str]:
     return {r["name"]: r.get("duration", "-") for r in val_rows if r.get("group") == "builds"}
@@ -310,15 +321,19 @@ def _render_tests_section(val_rows: List[Dict[str, Any]]) -> None:
         return
 
     append_summary("### 🧪 Tests\n")
-    append_summary("| Matrix | Status | Time | Logs |\n")
-    append_summary(ALIGN_4_COLS)
+    append_summary("| Matrix | Status | Cache statistic | Time | Logs |\n")
+    append_summary("|:--|:--:|:--:|:--:|:--:|\n")
 
     for r in rows:
         icon = status_icon(r.get("status", ""))
         dur = r.get("duration") or "-"
         url = r.get("url") or ""
         logs = f"[Logs]({url})" if url else "—"
-        append_summary(f"| {r.get('name','')} | {icon} | {dur} | {logs} |\n")
+        hits = r.get("hits")
+        total = r.get("total")
+        rate = r.get("rate")
+        cache = f"{rate} ({hits} / {total})" if hits is not None and total is not None and rate else "—"
+        append_summary(f"| {r.get('name','')} | {icon} | {cache} | {dur} | {logs} |\n")
     append_summary("\n")
 
 def _render_build_matrix_section(val_rows: List[Dict[str, Any]]) -> None:
@@ -351,6 +366,10 @@ def compose_summary() -> None:
     items = _load_primary_items()
     inst_map = _load_installer_map()
     val_rows: List[Dict[str, Any]] = read_json_file("partials/validation.json") or []
+    test_cache = _load_test_cache_map()
+    for row in val_rows:
+        if row.get("group") == "tests":
+            row.update(test_cache.get(row.get("platform", ""), {}))
     dur_map = _durations_map(val_rows)
 
     # Family tables


### PR DESCRIPTION
- Fixed GitHub Actions Node.js 20 deprecation warnings from hendrikmuhs/ccache-action@v1.2 by switching compiler-cache setup to step-security/ccache-action@v1 in both build and test jobs. 
- Fixed GitHub Actions Node.js 20 deprecation warnings from ilammy/msvc-dev-cmd@v1 by switching MSVC environment setup to step-security/msvc-dev-cmd@main.  
- Removed duplicated per-job ccache summary annotations/cards for test jobs by disabling the ccache action built-in job summary and moving cache statistics into the final consolidated CI summary. 
- Added test-job cache statistics to the final CI summary so test matrix cache usage is reported in the same consolidated table format as build cache statistics. 
- Fixed Homebrew tap trust warnings for aws/tap on macOS/iOS runners by untapping the unused tap before brew update. 
- Fixed Homebrew tap trust warnings for azure/bicep without trying to untap an installed formula by explicitly trusting the installed azure/bicep/bicep formula. 
- Fixed AppImage artifact upload failures caused by the generated AppImage name not matching the old VCMI-*.AppImage glob. The packaging script now detects the actual generated AppImage file, excluding linuxdeploy*.AppImage, and moves it to the expected CI artifact path. 
- Removed linuxdeploy/AppImage warnings about deprecated $VERSION and $UPD_INFO environment variables by switching to LINUXDEPLOY_OUTPUT_VERSION and LDAI_UPDATE_INFORMATION. 