### PR TITLE
[Client] Fix testmap spectator and headless crashes

### DIFF
--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -1448,7 +1448,11 @@ void CPlayerInterface::initializeHeroTownList()
 			localState->addOwnedTown(town);
 	}
 
-	localState->deserialize(*cb->getPlayerState(playerID)->playerLocalSettings);
+	const std::optional<PlayerColor> callbackPlayer = cb->getPlayerID();
+	const PlayerColor localStatePlayer = callbackPlayer.value_or(playerID);
+	const PlayerState * playerState = cb->getPlayerState(localStatePlayer);
+	if(playerState)
+		localState->deserialize(*playerState->playerLocalSettings);
 
 	if(adventureInt)
 		adventureInt->onHeroChanged(nullptr);

--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -1388,7 +1388,10 @@ void CPlayerInterface::beforeObjectPropertyChanged(const SetObjectProperty * sop
 {
 	if (sop->what == ObjProperty::OWNER)
 	{
-		const CGObjectInstance * obj = cb->getObj(sop->id);
+		const CGObjectInstance * obj = cb->getObj(sop->id, false);
+
+		if(!obj)
+			return;
 
 		if(obj->ID == Obj::TOWN)
 		{
@@ -1409,7 +1412,10 @@ void CPlayerInterface::objectPropertyChanged(const SetObjectProperty * sop)
 
 	if (sop->what == ObjProperty::OWNER)
 	{
-		const CGObjectInstance * obj = cb->getObj(sop->id);
+		const CGObjectInstance * obj = cb->getObj(sop->id, false);
+
+		if(!obj)
+			return;
 
 		if(obj->ID == Obj::TOWN)
 		{

--- a/client/CServerHandler.cpp
+++ b/client/CServerHandler.cpp
@@ -74,16 +74,36 @@ CServerHandler::~CServerHandler()
 {
 	if (serverRunner)
 		serverRunner->shutdown();
-	networkHandler->stop();
+	stopNetwork();
 
 	if (serverRunner)
 		serverRunner->wait();
 	serverRunner.reset();
+	waitForNetworkThread();
+}
+
+void CServerHandler::stopNetwork()
+{
+	networkHandler->stop();
+}
+
+void CServerHandler::waitForNetworkThread()
+{
 	if (threadNetwork.joinable())
 	{
+		if(threadNetwork.get_id() == std::this_thread::get_id())
+			return;
+
 		//ENGINE->interfaceMutex must have been locked by the current thread, otherwise an unlock will cause undefined behavior
-		auto unlockInterface = vstd::makeUnlockGuard(ENGINE->interfaceMutex);
-		threadNetwork.join();
+		if(ENGINE)
+		{
+			auto unlockInterface = vstd::makeUnlockGuard(ENGINE->interfaceMutex);
+			threadNetwork.join();
+		}
+		else
+		{
+			threadNetwork.join();
+		}
 	}
 }
 
@@ -91,14 +111,8 @@ void CServerHandler::endNetwork()
 {
 	if (client)
 		client->endNetwork();
-	networkHandler->stop();
-
-	if (threadNetwork.joinable())
-	{
-		//ENGINE->interfaceMutex must have been locked by the current thread, otherwise an unlock will cause undefined behavior
-		auto unlockInterface = vstd::makeUnlockGuard(ENGINE->interfaceMutex);
-		threadNetwork.join();
-	}
+	stopNetwork();
+	waitForNetworkThread();
 }
 
 CServerHandler::CServerHandler()
@@ -234,7 +248,9 @@ void CServerHandler::connectToServer(const std::string & addr, const ui16 port)
 void CServerHandler::onConnectionFailed(const std::string & errorMessage)
 {
 	assert(getState() == EClientState::CONNECTING);
-	std::scoped_lock interfaceLock(ENGINE->interfaceMutex);
+	std::unique_lock<std::mutex> interfaceLock;
+	if(ENGINE)
+		interfaceLock = std::unique_lock<std::mutex>(ENGINE->interfaceMutex);
 
 	if (isServerLocal())
 	{
@@ -252,14 +268,16 @@ void CServerHandler::onConnectionFailed(const std::string & errorMessage)
 
 void CServerHandler::onTimer()
 {
-	std::scoped_lock interfaceLock(ENGINE->interfaceMutex);
+	std::unique_lock<std::mutex> interfaceLock;
+	if(ENGINE)
+		interfaceLock = std::unique_lock<std::mutex>(ENGINE->interfaceMutex);
 
 	if(getState() == EClientState::CONNECTION_CANCELLED)
 	{
 		logNetwork->info("Connection aborted by player!");
 		serverRunner->wait();
 		serverRunner.reset();
-		if (ENGINE->windows().topWindow<CSimpleJoinScreen>() != nullptr)
+		if (ENGINE && ENGINE->windows().topWindow<CSimpleJoinScreen>() != nullptr)
 			ENGINE->windows().popWindows(1);
 		return;
 	}
@@ -272,7 +290,9 @@ void CServerHandler::onConnectionEstablished(const NetworkConnectionPtr & netCon
 {
 	assert(getState() == EClientState::CONNECTING);
 
-	std::scoped_lock interfaceLock(ENGINE->interfaceMutex);
+	std::unique_lock<std::mutex> interfaceLock;
+	if(ENGINE)
+		interfaceLock = std::unique_lock<std::mutex>(ENGINE->interfaceMutex);
 
 	networkConnection = netConnection;
 
@@ -684,7 +704,8 @@ void CServerHandler::startGameplay(std::shared_ptr<CGameState> gameState)
 		throw std::runtime_error("Invalid mode");
 	}
 
-	ENGINE->discord().setPlayingStatus(si, &gameState->getMap(), howManyPlayerInterfaces());
+	if(ENGINE)
+		ENGINE->discord().setPlayingStatus(si, &gameState->getMap(), howManyPlayerInterfaces());
 
 	// After everything initialized we can accept CPackToClient netpacks
 	setState(EClientState::GAMEPLAY);
@@ -730,7 +751,8 @@ void CServerHandler::endGameplay()
 		GAME->mainmenu()->makeActiveInterface();
 	}
 
-	ENGINE->discord().setStatus("", "", {0, 0});
+	if(ENGINE)
+		ENGINE->discord().setStatus("", "", {0, 0});
 }
 
 std::optional<std::string> CServerHandler::canQuickLoadGame(const std::string & path) const
@@ -958,7 +980,9 @@ public:
 
 void CServerHandler::onPacketReceived(const std::shared_ptr<INetworkConnection> &, const std::vector<std::byte> & message)
 {
-	std::scoped_lock interfaceLock(ENGINE->interfaceMutex);
+	std::unique_lock<std::mutex> interfaceLock;
+	if(ENGINE)
+		interfaceLock = std::unique_lock<std::mutex>(ENGINE->interfaceMutex);
 
 	if(getState() == EClientState::DISCONNECTING)
 		return;
@@ -970,7 +994,9 @@ void CServerHandler::onPacketReceived(const std::shared_ptr<INetworkConnection> 
 
 void CServerHandler::onDisconnected(const std::shared_ptr<INetworkConnection> & connection, const std::string & errorMessage)
 {
-	std::scoped_lock interfaceLock(ENGINE->interfaceMutex);
+	std::unique_lock<std::mutex> interfaceLock;
+	if(ENGINE)
+		interfaceLock = std::unique_lock<std::mutex>(ENGINE->interfaceMutex);
 
 	if (connection != networkConnection)
 	{
@@ -1015,8 +1041,15 @@ void CServerHandler::waitForServerShutdown()
 	{
 		// Release interfaceMutex while waiting for server thread to finish
 		// to avoid blocking the GUI thread (same pattern as endNetwork())
-		auto unlockInterface = vstd::makeUnlockGuard(ENGINE->interfaceMutex);
-		serverRunner->wait();
+		if(ENGINE)
+		{
+			auto unlockInterface = vstd::makeUnlockGuard(ENGINE->interfaceMutex);
+			serverRunner->wait();
+		}
+		else
+		{
+			serverRunner->wait();
+		}
 	}
 	int exitCode = serverRunner->exitCode();
 	serverRunner.reset();

--- a/client/CServerHandler.h
+++ b/client/CServerHandler.h
@@ -218,6 +218,8 @@ public:
 	std::optional<std::string> canQuickLoadGame(const std::string & path) const; // returns reason why not compatible, or nullopt if can
 	void quickLoadGame(const std::string & path);
 	void showHighScoresAndEndGameplay(PlayerColor player, bool victory, const StatisticDataSet & statistic);
+	void stopNetwork();
+	void waitForNetworkThread();
 	void endNetwork();
 	void endGameplay();
 	void restartGameplay();

--- a/client/Client.cpp
+++ b/client/Client.cpp
@@ -179,11 +179,8 @@ void CClient::initMapHandler()
 	// TODO: CMapHandler initialization can probably go somewhere else
 	// It's can't be before initialization of interfaces
 	// During loading CPlayerInterface from serialized state it's depend on MH
-	if(!settings["session"]["headless"].Bool())
-	{
-		GAME->setMapInstance(std::make_unique<CMapHandler>(&gameState().getMap()));
-		logNetwork->trace("Creating mapHandler: %d ms", GAME->server().th->getDiff());
-	}
+	GAME->setMapInstance(std::make_unique<CMapHandler>(&gameState().getMap()));
+	logNetwork->trace("Creating mapHandler: %d ms", GAME->server().th->getDiff());
 }
 
 void CClient::initPlayerEnvironments()
@@ -211,7 +208,10 @@ void CClient::initPlayerEnvironments()
 	
 	if(settings["session"]["spectate"].Bool())
 	{
-		playerEnvironments[PlayerColor::SPECTATOR] = std::make_shared<CPlayerEnvironment>(PlayerColor::SPECTATOR, this, std::make_shared<CCallback>(gamestate, std::nullopt, this));
+		playerEnvironments[PlayerColor::SPECTATOR] = std::make_shared<CPlayerEnvironment>(
+			PlayerColor::SPECTATOR,
+			this,
+			std::make_shared<CCallback>(gamestate, findPlayerColorForSpectatorInterface(), this));
 	}
 }
 
@@ -254,13 +254,32 @@ void CClient::initPlayerInterfaces()
 
 	if(settings["session"]["spectate"].Bool())
 	{
-		installNewPlayerInterface(std::make_shared<CPlayerInterface>(PlayerColor::SPECTATOR), PlayerColor::SPECTATOR, true);
+		const PlayerColor spectatorInterfacePlayer = findPlayerColorForSpectatorInterface().value_or(PlayerColor(0));
+		installNewPlayerInterface(std::make_shared<CPlayerInterface>(spectatorInterfacePlayer), PlayerColor::SPECTATOR, true);
 	}
 
 	if(GAME->server().getAllClientPlayers(GAME->server().logicConnection->connectionID).count(PlayerColor::NEUTRAL))
 		installNewBattleInterface(AIFactory::createBattleAI(settings["ai"]["combatNeutralAI"].String()), PlayerColor::NEUTRAL);
 
 	logNetwork->trace("Initialized player interfaces %d ms", GAME->server().th->getDiff());
+}
+
+std::optional<PlayerColor> CClient::findPlayerColorForSpectatorInterface() const
+{
+	// The adventure UI is not fully spectator-aware and still reads player-local state via CPlayerInterface::playerID.
+	for(const PlayerColor & color : gameState().actingPlayers)
+	{
+		if(color.isValidPlayer() && gameState().players.count(color))
+			return color;
+	}
+
+	for(const auto & playerState : gameState().players)
+	{
+		if(playerState.first.isValidPlayer())
+			return playerState.first;
+	}
+
+	return std::nullopt;
 }
 
 std::string CClient::aiNameForPlayer(const PlayerSettings & ps, bool battleAI, bool alliedToHuman) const
@@ -291,7 +310,11 @@ void CClient::installNewPlayerInterface(std::shared_ptr<CGameInterface> gameInte
 	playerint[color] = gameInterface;
 
 	logGlobal->trace("\tInitializing the interface for player %s", color.toString());
-	auto cb = std::make_shared<CCallback>(gamestate, color, this);
+	std::optional<PlayerColor> callbackPlayer = color;
+	if(color == PlayerColor::SPECTATOR)
+		callbackPlayer = findPlayerColorForSpectatorInterface();
+
+	auto cb = std::make_shared<CCallback>(gamestate, callbackPlayer, this);
 	battleCallbacks[color] = cb;
 	gameInterface->initGameInterface(playerEnvironments.at(color), cb);
 
@@ -456,23 +479,35 @@ void CClient::startPlayerBattleAction(const BattleID & battleID, PlayerColor col
 		return; // not our combat in MP
 
 	auto battleint = battleints.at(color);
+	auto activateStack = [&]()
+	{
+		battleint->activeStack(battleID, gameState().getBattle(battleID)->battleGetStackByID(gameState().getBattle(battleID)->activeStack, false));
+	};
 
 	if (!battleint->human)
 	{
 		// we want to avoid locking gamestate and causing UI to freeze while AI is making turn
-		auto unlockInterface = vstd::makeUnlockGuard(ENGINE->interfaceMutex);
-		battleint->activeStack(battleID, gameState().getBattle(battleID)->battleGetStackByID(gameState().getBattle(battleID)->activeStack, false));
+		if(ENGINE)
+		{
+			auto unlockInterface = vstd::makeUnlockGuard(ENGINE->interfaceMutex);
+			activateStack();
+		}
+		else
+		{
+			activateStack();
+		}
 	}
 	else
 	{
-		battleint->activeStack(battleID, gameState().getBattle(battleID)->battleGetStackByID(gameState().getBattle(battleID)->activeStack, false));
+		activateStack();
 	}
 }
 
 void CClient::removeGUI() const
 {
 	// CClient::endGame
-	ENGINE->windows().clear();
+	if(ENGINE)
+		ENGINE->windows().clear();
 	adventureInt.reset();
 	logGlobal->info("Removed GUI.");
 

--- a/client/Client.h
+++ b/client/Client.h
@@ -174,6 +174,8 @@ public:
 	void removeGUI() const;
 
 private:
+	std::optional<PlayerColor> findPlayerColorForSpectatorInterface() const;
+
 	std::map<PlayerColor, std::shared_ptr<CBattleCallback>> battleCallbacks; //callbacks given to player interfaces
 	std::map<PlayerColor, std::shared_ptr<CPlayerEnvironment>> playerEnvironments;
 };

--- a/client/GameInstance.cpp
+++ b/client/GameInstance.cpp
@@ -105,6 +105,14 @@ bool GameInstance::capturedAllEvents()
 
 void GameInstance::onShutdownRequested(bool ask)
 {
+	if(!ENGINE)
+	{
+		if(server().client)
+			server().endGameplay();
+		server().stopNetwork();
+		return;
+	}
+
 	auto doQuit = [](){ throw GameShutdownException(); };
 
 	if(!ask)

--- a/clientapp/EntryPoint.cpp
+++ b/clientapp/EntryPoint.cpp
@@ -62,7 +62,6 @@
 namespace po = boost::program_options;
 namespace po_style = boost::program_options::command_line_style;
 
-static std::atomic<bool> headlessQuit = false;
 static std::optional<std::string> criticalInitializationError;
 
 static void init()
@@ -396,10 +395,7 @@ int main(int argc, char * argv[])
 			}
 			else
 			{
-				while(!headlessQuit)
-					std::this_thread::sleep_for(std::chrono::milliseconds(200));
-
-				std::this_thread::sleep_for(std::chrono::milliseconds(500));
+				GAME->server().waitForNetworkThread();
 			}
 		}
 		catch (const GameShutdownException & )
@@ -411,9 +407,17 @@ int main(int argc, char * argv[])
 
 	const auto & cleanupEngine = [&logConfigurator]()
 	{
+		if(settings["session"]["headless"].Bool() && GAME->server().client)
+			GAME->server().endGameplay();
+
+		if(ENGINE)
 		{
 			//aquire interfaceMutex to prevent undefined behavior on vstd::makeUnlockGuard(ENGINE->interfaceMutex)
 			std::scoped_lock interfaceLock(ENGINE->interfaceMutex);
+			GAME->server().endNetwork();
+		}
+		else
+		{
 			GAME->server().endNetwork();
 		}
 
@@ -435,10 +439,13 @@ int main(int argc, char * argv[])
 			graphics = nullptr;
 		}
 
-		// must be executed before reset - since unique_ptr resets pointer to null before calling destructor
-		ENGINE->async().wait();
+		if(ENGINE)
+		{
+			// must be executed before reset - since unique_ptr resets pointer to null before calling destructor
+			ENGINE->async().wait();
 
-		ENGINE.reset();
+			ENGINE.reset();
+		}
 
 		delete LIBRARY;
 		LIBRARY = nullptr;

--- a/lib/callback/CBattleCallback.cpp
+++ b/lib/callback/CBattleCallback.cpp
@@ -53,7 +53,11 @@ std::shared_ptr<CPlayerBattleCallback> CBattleCallback::getBattle(const BattleID
 	if (activeBattles.count(battleID))
 		return activeBattles.at(battleID);
 
-	throw std::runtime_error("Failed to find battle " + std::to_string(battleID.getNum()) + " of player " + player->toString() + ". Number of ongoing battles: " + std::to_string(activeBattles.size()));
+	const std::string playerName = player ? player->toString() : "none";
+	throw std::runtime_error(
+		"Failed to find battle " + std::to_string(battleID.getNum()) +
+		" of player " + playerName +
+		". Number of ongoing battles: " + std::to_string(activeBattles.size()));
 }
 
 std::optional<PlayerColor> CBattleCallback::getPlayerID() const
@@ -63,19 +67,27 @@ std::optional<PlayerColor> CBattleCallback::getPlayerID() const
 
 void CBattleCallback::onBattleStarted(const IBattleInfo * info)
 {
-	if (activeBattles.count(info->getBattleID()) > 0)
-		throw std::runtime_error("Player " + player->toString() + " is already engaged in battle " + std::to_string(info->getBattleID().getNum()));
+	const std::string playerName = player ? player->toString() : "none";
 
-	logGlobal->debug("Battle %d started for player %s", info->getBattleID(), player->toString());
+	if (activeBattles.count(info->getBattleID()) > 0)
+		throw std::runtime_error(
+			"Player " + playerName +
+			" is already engaged in battle " + std::to_string(info->getBattleID().getNum()));
+
+	logGlobal->debug("Battle %d started for player %s", info->getBattleID(), playerName);
 	activeBattles[info->getBattleID()] = std::make_shared<CPlayerBattleCallback>(info, *getPlayerID());
 }
 
 void CBattleCallback::onBattleEnded(const BattleID & battleID)
 {
-	if (activeBattles.count(battleID) == 0)
-		throw std::runtime_error("Player " + player->toString() + " is not engaged in battle " + std::to_string(battleID.getNum()));
+	const std::string playerName = player ? player->toString() : "none";
 
-	logGlobal->debug("Battle %d ended for player %s", battleID, player->toString());
+	if (activeBattles.count(battleID) == 0)
+		throw std::runtime_error(
+			"Player " + playerName +
+			" is not engaged in battle " + std::to_string(battleID.getNum()));
+
+	logGlobal->debug("Battle %d ended for player %s", battleID, playerName);
 	activeBattles.erase(battleID);
 }
 

--- a/lib/constants/EntityIdentifiers.cpp
+++ b/lib/constants/EntityIdentifiers.cpp
@@ -468,6 +468,9 @@ std::string PlayerColor::encode(const si32 index)
 	if (index == -1)
 		return "neutral";
 
+	if (index == PlayerColor::SPECTATOR.num)
+		return "spectator";
+
 	if (index < 0 || index >= std::size(GameConstants::PLAYER_COLOR_NAMES))
 	{
 		assert(0);


### PR DESCRIPTION
## Summary
This fixes several crashes/hangs in automated testmap/testsave runs and spectator-only runs.

## Fixed Bugs
- GUI `--testmap --spectate` could crash during startup, before AI logic started. The spectator adventure interface was created with a callback that had no real player id, but some adventure UI initialization reads player-local state. The interface now stays registered as spectator, while callback-visible adventure state borrows a valid player color.
- Spectator debug logging could assert when formatting player or battle callback labels for the spectator slot. These paths now use spectator-safe labels.
- Headless `--testmap` / `--testsave` could crash while processing connection, packet, battle, or shutdown callbacks because those paths assumed a GUI engine existed. They now work without a GUI engine and only use GUI services when one is present.
- Headless test runs could fail on map-state packet hooks because no map handler existed. Headless games now create a no-op map handler target for those callbacks.
- Headless test runs could abort or hang at the end of a game, after Red won or lost. Shutdown is now recorded and handled through normal gameplay teardown before the network is closed.
- Spectator or AI-only games could crash after an owner-change packet for an object hidden from the local spectator callback. Hidden objects are now skipped quietly instead of dereferencing a null lookup; visible town ownership refreshes keep the existing behavior.

## Verification
- GUI `--testmap --spectate` startup reaches the loaded map instead of crashing during spectator interface creation.
- Headless `--testmap` cases can finish Red win/loss scenarios and exit cleanly.
- Spectator owner updates for hidden objects no longer crash the client.
