### PR TITLE
[cmake] fix package name of libsquish

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,7 +133,7 @@ else()
 			OR
 			(NOT COMPILER_SUPPORTS_CXX23)
 		)
-	        set(DISCORD_RPC_NO_GLAZE ON)
+			set(DISCORD_RPC_NO_GLAZE ON)
 		endif()
 	endif()
 endif()

--- a/cmake_modules/Findlibsquish.cmake
+++ b/cmake_modules/Findlibsquish.cmake
@@ -31,7 +31,7 @@ set(LIBSQUISH_LIBRARIES ${LIBSQUISH_LIBRARY})
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(
-    LibSquish
+    libsquish
     REQUIRED_VARS LIBSQUISH_LIBRARY LIBSQUISH_INCLUDE_DIR
 )
 


### PR DESCRIPTION
running CMake configure on Linux Manjaro issues a warning:
```
Make Warning (dev) at /usr/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:493 (message):
  The package name passed to find_package_handle_standard_args() (LibSquish)
  does not match the name of the calling package (libsquish).  This can lead
  to problems in calling code that expects find_package() result variables
  (e.g., `_FOUND`) to follow a certain pattern.
Call Stack (most recent call first):
  cmake_modules/Findlibsquish.cmake:33 (find_package_handle_standard_args)
  CMakeLists.txt:543 (find_package)
```