### PR TITLE
Migrate to std::ranges

### DIFF
--- a/.github/workflows/github.yml
+++ b/.github/workflows/github.yml
@@ -573,10 +573,10 @@ jobs:
             preset: linux-gcc-debug
 
           - platform: clang-oldest-release
-            os: ubuntu-22.04
+            os: ubuntu-24.04
             before_install: linux_qt5.sh
-            compiler_cxx: clang++-13
-            compiler_cc: clang-13
+            compiler_cxx: clang++-16
+            compiler_cc: clang-16
             preset: linux-clang-test
 
     runs-on: ${{ matrix.os }}

--- a/AI/BattleAI/PotentialTargets.cpp
+++ b/AI/BattleAI/PotentialTargets.cpp
@@ -81,7 +81,7 @@ PotentialTargets::PotentialTargets(
 		}
 	}
 
-	boost::sort(possibleAttacks, [](const AttackPossibility & lhs, const AttackPossibility & rhs) -> bool
+	std::ranges::sort(possibleAttacks, [](const AttackPossibility & lhs, const AttackPossibility & rhs) -> bool
 	{
 		return lhs.damageDiff() > rhs.damageDiff();
 	});

--- a/AI/Nullkiller2/Analyzers/ArmyManager.cpp
+++ b/AI/Nullkiller2/Analyzers/ArmyManager.cpp
@@ -104,7 +104,7 @@ std::vector<SlotInfo> ArmyManager::getSortedSlots(const CCreatureSet * target, c
 	for(auto & pair : creToPower)
 		resultingArmy.push_back(pair.second);
 
-	boost::sort(resultingArmy, [](const SlotInfo & left, const SlotInfo & right) -> bool
+	std::ranges::sort(resultingArmy, [](const SlotInfo & left, const SlotInfo & right) -> bool
 	{
 		return left.power > right.power;
 	});
@@ -127,7 +127,7 @@ std::vector<SlotInfo>::iterator ArmyManager::getBestUnitForScout(std::vector<Slo
 
 	const auto & movementPointsLimits = cpsic->getSettings().getVector(EGameSettings::HEROES_MOVEMENT_POINTS_LAND);
 
-	auto fastest = boost::min_element(army, [&](const SlotInfo & left, const SlotInfo & right) -> bool
+	auto fastest = std::ranges::min_element(army, [&](const SlotInfo & left, const SlotInfo & right) -> bool
 	{
 		uint64_t leftUnitPower = left.power / left.count;
 		uint64_t rightUnitPower = right.power / right.count;

--- a/AI/Nullkiller2/Analyzers/BuildAnalyzer.cpp
+++ b/AI/Nullkiller2/Analyzers/BuildAnalyzer.cpp
@@ -8,7 +8,7 @@
 *
 */
 #include "../StdInc.h"
-#include <boost/range/algorithm/sort.hpp>
+#include "BuildAnalyzer.h"
 
 #include "../Engine/Nullkiller.h"
 #include "../../../lib/entities/building/CBuilding.h"
@@ -91,7 +91,7 @@ void BuildAnalyzer::update()
 #endif
 	}
 
-	boost::range::sort(developmentInfos, [](const TownDevelopmentInfo & tdi1, const TownDevelopmentInfo & tdi2) -> bool
+	std::ranges::sort(developmentInfos, [](const TownDevelopmentInfo & tdi1, const TownDevelopmentInfo & tdi2) -> bool
 	{
 		auto val1 = goldApproximate(tdi1.armyCost) - goldApproximate(tdi1.townDevelopmentCost);
 		auto val2 = goldApproximate(tdi2.armyCost) - goldApproximate(tdi2.townDevelopmentCost);
@@ -250,7 +250,7 @@ void BuildAnalyzer::updateDwellings(TownDevelopmentInfo & developmentInfo, std::
 				dwellingsInTown.push_back(buildID);
 
 		// find best, already built dwelling
-		for (const auto & buildID : boost::adaptors::reverse(dwellingsInTown))
+		for (const auto & buildID : std::views::reverse(dwellingsInTown))
 		{
 			if (!developmentInfo.town->hasBuilt(buildID))
 				continue;

--- a/AI/Nullkiller2/Analyzers/BuildAnalyzer.h
+++ b/AI/Nullkiller2/Analyzers/BuildAnalyzer.h
@@ -11,6 +11,7 @@
 
 #include "../AIUtility.h"
 #include "../../../lib/ResourceSet.h"
+#include "../../../lib/entities/building/CBuilding.h"
 
 namespace NK2AI
 {

--- a/AI/Nullkiller2/Engine/Nullkiller.cpp
+++ b/AI/Nullkiller2/Engine/Nullkiller.cpp
@@ -27,7 +27,6 @@
 #include "../Goals/Invalid.h"
 #include "Goals/RecruitHero.h"
 #include "ResourceTrader.h"
-#include <boost/range/algorithm/sort.hpp>
 
 namespace NK2AI
 {
@@ -203,7 +202,7 @@ Goals::TTaskVec Nullkiller::buildPlanAndFilter(TGoalVec & tasks, int priorityTie
 		}
 	);
 
-	boost::range::sort(
+	std::ranges::sort(
 		tasks,
 		[](const TSubgoal & g1, const TSubgoal & g2) -> bool
 		{
@@ -436,7 +435,7 @@ void Nullkiller::makeTurn()
 			}
 		}
 
-		boost::range::sort(selectedTasks, [](const TTask& a, const TTask& b)
+		std::ranges::sort(selectedTasks, [](const TTask& a, const TTask& b)
 		{
 			return a->priority > b->priority;
 		});

--- a/AI/Nullkiller2/Helpers/ArmyFormation.cpp
+++ b/AI/Nullkiller2/Helpers/ArmyFormation.cpp
@@ -53,7 +53,7 @@ void ArmyFormation::rearrangeArmyForSiege(const CGTownInstance * town, const CGH
 		for(const auto & slot : attacker->Slots())
 			stacks.push_back(slot.second.get());
 
-		boost::sort(
+		std::ranges::sort(
 			stacks,
 			[](const CStackInstance * slot1, const CStackInstance * slot2) -> bool
 			{

--- a/AI/Nullkiller2/Pathfinding/AINodeStorage.cpp
+++ b/AI/Nullkiller2/Pathfinding/AINodeStorage.cpp
@@ -1242,7 +1242,7 @@ void AINodeStorage::calculateTownPortalTeleportations(std::vector<CGPathNode *> 
 			maskMap[basicActor->hero] = basicActor->chainMask;
 	}
 
-	boost::sort(initialNodes, NodeComparer<CGPathNode>());
+	std::ranges::sort(initialNodes, NodeComparer<CGPathNode>());
 
 	std::vector<const ChainActor *> actorsVector(actorsOfInitial.begin(), actorsOfInitial.end());
 	tbb::concurrent_vector<CGPathNode *> output;

--- a/Global.h
+++ b/Global.h
@@ -125,6 +125,7 @@ static_assert(sizeof(bool) == 1, "Bool needs to be 1 byte in size.");
 #include <optional>
 #include <queue>
 #include <random>
+#include <ranges>
 #include <regex>
 #include <set>
 #include <shared_mutex>
@@ -165,23 +166,6 @@ static_assert(sizeof(bool) == 1, "Bool needs to be 1 byte in size.");
 #include <boost/format.hpp>
 #include <boost/logic/tribool.hpp>
 #include <boost/multi_array.hpp>
-// C++ 20 -> std::range
-#include <boost/range/adaptor/filtered.hpp>
-#include <boost/range/adaptor/reversed.hpp>
-#include <boost/range/algorithm/copy.hpp>
-#include <boost/range/algorithm/count.hpp>
-#include <boost/range/algorithm/count_if.hpp>
-#include <boost/range/algorithm/fill.hpp>
-#include <boost/range/algorithm/find.hpp>
-#include <boost/range/algorithm/find_if.hpp>
-#include <boost/range/algorithm/max_element.hpp>
-#include <boost/range/algorithm/min_element.hpp>
-#include <boost/range/algorithm/remove.hpp>
-#include <boost/range/algorithm/remove_if.hpp>
-#include <boost/range/algorithm/replace.hpp>
-#include <boost/range/algorithm/sort.hpp>
-#include <boost/range/algorithm/unique.hpp>
-#include <boost/range/algorithm/upper_bound.hpp>
 
 #ifndef M_PI
 #  define M_PI 3.14159265358979323846
@@ -559,7 +543,7 @@ namespace vstd
 		 * Current bugfix is to don't use a typedef for decltype(*std::begin(rng)) and to use decltype
 		 * directly for both function parameters.
 		 */
-		return std::min_element(rng.begin(), rng.end(), [&] (decltype(*std::begin(rng)) lhs, decltype(*std::begin(rng)) rhs) -> bool
+		return std::ranges::min_element(rng, [&] (decltype(*std::begin(rng)) lhs, decltype(*std::begin(rng)) rhs) -> bool
 		{
 			return vf(lhs) < vf(rhs);
 		});
@@ -574,7 +558,7 @@ namespace vstd
 		 * Current bugfix is to don't use a typedef for decltype(*std::begin(rng)) and to use decltype
 		 * directly for both function parameters.
 		 */
-		return std::max_element(rng.begin(), rng.end(), [&] (decltype(*std::begin(rng)) lhs, decltype(*std::begin(rng)) rhs) -> bool
+		return std::ranges::max_element(rng, [&] (decltype(*std::begin(rng)) lhs, decltype(*std::begin(rng)) rhs) -> bool
 		{
 			return vf(lhs) < vf(rhs);
 		});

--- a/client/ClientCommandManager.cpp
+++ b/client/ClientCommandManager.cpp
@@ -215,7 +215,7 @@ void ClientCommandManager::handleTranslateGameCommand(bool onlyMissing)
 		if (!output.isNull())
 		{
 			std::string filename = modEntry.first;
-			boost::range::replace(filename, '.', '_');
+			std::ranges::replace(filename, '.', '_');
 			const boost::filesystem::path filePath = outPath / (filename + ".json");
 			std::ofstream file(filePath.c_str());
 			file << output.toString();

--- a/client/HeroMovementController.cpp
+++ b/client/HeroMovementController.cpp
@@ -388,7 +388,7 @@ void HeroMovementController::sendMovementRequest(const CGHeroInstance * h, const
 	bool useTransit = currentLayer == EPathfindingLayer::AIR || currentLayer == EPathfindingLayer::WATER;
 	std::vector<int3> pathToMove;
 
-	for (auto const & node : boost::adaptors::reverse(path.nodes))
+	for (auto const & node : std::views::reverse(path.nodes))
 	{
 			if (node.coord == h->visitablePos())
 				continue; // first node, ignore - this is hero current position

--- a/client/adventureMap/AdventureMapInterface.cpp
+++ b/client/adventureMap/AdventureMapInterface.cpp
@@ -512,7 +512,7 @@ const CGObjectInstance* AdventureMapInterface::getActiveObject(const int3 &mapPo
 	if (bobjs.empty())
 		return nullptr;
 
-	return *boost::range::max_element(bobjs, &CMap::compareObjectBlitOrder);
+	return *std::ranges::max_element(bobjs, &CMap::compareObjectBlitOrder);
 }
 
 void AdventureMapInterface::onTileLeftClicked(const int3 &targetPosition)

--- a/client/adventureMap/AdventureMapShortcuts.cpp
+++ b/client/adventureMap/AdventureMapShortcuts.cpp
@@ -334,7 +334,7 @@ void AdventureMapShortcuts::endTurn()
 void AdventureMapShortcuts::showThievesGuild()
 {
 	//find first town with tavern
-	auto itr = boost::range::find_if(GAME->interface()->localState->getOwnedTowns(), [](const CGTownInstance * town)
+	auto itr = std::ranges::find_if(GAME->interface()->localState->getOwnedTowns(), [](const CGTownInstance * town)
 	{
 		return town->hasBuilt(BuildingID::TAVERN);
 	});

--- a/client/gui/FramerateManager.cpp
+++ b/client/gui/FramerateManager.cpp
@@ -21,7 +21,7 @@ FramerateManager::FramerateManager(int targetFrameRate)
 	, lastTimePoint(Clock::now())
 	, vsyncEnabled(settings["video"]["vsync"].Bool())
 {
-	boost::range::fill(lastFrameTimes, targetFrameTime);
+	std::ranges::fill(lastFrameTimes, targetFrameTime);
 }
 
 void FramerateManager::framerateDelay()

--- a/client/lobby/RandomMapTab.cpp
+++ b/client/lobby/RandomMapTab.cpp
@@ -147,7 +147,7 @@ RandomMapTab::RandomMapTab():
 	{
 		auto getTemplates = [](){
 			auto templates = LIBRARY->tplh->getTemplates();
-			boost::range::sort(templates, [](const CRmgTemplate * a, const CRmgTemplate * b){
+			std::ranges::sort(templates, [](const CRmgTemplate * a, const CRmgTemplate * b){
 				return a->getName() < b->getName();
 			});
 			return templates;

--- a/client/lobby/SelectionTab.cpp
+++ b/client/lobby/SelectionTab.cpp
@@ -608,7 +608,7 @@ auto SelectionTab::checkSubfolder(std::string path)
 	}
 
 	if(boost::algorithm::starts_with(pathWithoutPrefix, curFolder))
-		if(boost::count(pathWithoutPrefix.substr(curFolder.size()), '/') == 0)
+		if(std::ranges::count(pathWithoutPrefix.substr(curFolder.size()), '/') == 0)
 			ret.fileInFolder = true;
 
 	return ret;
@@ -658,7 +658,7 @@ void SelectionTab::filter(int size, bool selectFirst)
 				auto folder = std::make_shared<ElementInfo>();
 				folder->isFolder = true;
 				folder->folderName = "..     (" + curFolder + ")";
-				auto itemIt = boost::range::find_if(curItems, [](std::shared_ptr<ElementInfo> e) { return boost::starts_with(e->folderName, ".."); });
+				auto itemIt = std::ranges::find_if(curItems, [](std::shared_ptr<ElementInfo> e) { return boost::starts_with(e->folderName, ".."); });
 				if (itemIt == curItems.end()) {
 					curItems.push_back(folder);
 				}			
@@ -668,7 +668,7 @@ void SelectionTab::filter(int size, bool selectFirst)
 			folder->isFolder = true;
 			folder->folderName = folderName;
 			folder->isAutoSaveFolder = boost::starts_with(baseFolder, "Autosave/") && folderName != "Autosave";
-			auto itemIt = boost::range::find_if(curItems, [folder](std::shared_ptr<ElementInfo> e) { return e->folderName == folder->folderName; });
+			auto itemIt = std::ranges::find_if(curItems, [folder](std::shared_ptr<ElementInfo> e) { return e->folderName == folder->folderName; });
 			if (itemIt == curItems.end() && folderName != "") {
 				curItems.push_back(folder);
 			}
@@ -686,7 +686,7 @@ void SelectionTab::filter(int size, bool selectFirst)
 		sort();
 		if(selectFirst)
 		{
-			int firstPos = boost::range::find_if(curItems, [](std::shared_ptr<ElementInfo> e) { return !e->isFolder; }) - curItems.begin();
+			int firstPos = std::ranges::find_if(curItems, [](std::shared_ptr<ElementInfo> e) { return !e->isFolder; }) - curItems.begin();
 			if(firstPos < curItems.size())
 			{
 				slider->scrollTo(firstPos);
@@ -727,7 +727,7 @@ void SelectionTab::sort()
 		std::stable_sort(curItems.begin(), curItems.end(), mapSorter(generalSortingBy));
 	std::stable_sort(curItems.begin(), curItems.end(), mapSorter(sortingBy));
 
-	int firstMapIndex = boost::range::find_if(curItems, [](std::shared_ptr<ElementInfo> e) { return !e->isFolder; }) - curItems.begin();
+	int firstMapIndex = std::ranges::find_if(curItems, [](std::shared_ptr<ElementInfo> e) { return !e->isFolder; }) - curItems.begin();
 	if(!sortModeAscending)
 	{
 		if(firstMapIndex)
@@ -776,7 +776,7 @@ void SelectionTab::select(int position)
 		filter(-1);
 		slider->scrollTo(0);
 
-		int firstPos = boost::range::find_if(curItems, [](std::shared_ptr<ElementInfo> e) { return !e->isFolder; }) - curItems.begin();
+		int firstPos = std::ranges::find_if(curItems, [](std::shared_ptr<ElementInfo> e) { return !e->isFolder; }) - curItems.begin();
 		if(firstPos < curItems.size())
 		{
 			selectAbs(firstPos);
@@ -802,7 +802,7 @@ void SelectionTab::select(int position)
 void SelectionTab::selectAbs(int position)
 {
 	if(position == -1)
-		position = boost::range::find_if(curItems, [](std::shared_ptr<ElementInfo> e) { return !e->isFolder; }) - curItems.begin();
+		position = std::ranges::find_if(curItems, [](std::shared_ptr<ElementInfo> e) { return !e->isFolder; }) - curItems.begin();
 	select(position - slider->getValue());
 }
 
@@ -892,7 +892,7 @@ void SelectionTab::selectFileName(std::string fname)
 		}
 	}
 
-	int firstPos = boost::range::find_if(curItems, [](std::shared_ptr<ElementInfo> e) { return !e->isFolder; }) - curItems.begin();
+	int firstPos = std::ranges::find_if(curItems, [](std::shared_ptr<ElementInfo> e) { return !e->isFolder; }) - curItems.begin();
 	if(firstPos < curItems.size())
 	{
 		slider->scrollTo(firstPos);

--- a/client/mainmenu/CHighScoreScreen.cpp
+++ b/client/mainmenu/CHighScoreScreen.cpp
@@ -285,7 +285,7 @@ int CHighScoreInputScreen::addEntry(std::string text) {
 		baseNode.resize(highscoreEntriesCap - 1);
 
 	baseNode.push_back(newNode);
-	boost::range::sort(baseNode, sortFunctor);
+	std::ranges::sort(baseNode, sortFunctor);
 
 	int pos = -1;
 	for (int i = 0; i < baseNode.size(); i++)

--- a/client/mapView/MapRenderer.cpp
+++ b/client/mapView/MapRenderer.cpp
@@ -735,7 +735,7 @@ size_t MapRendererPath::selectImage(IMapRendererContext & context, const int3 & 
 	if(!path)
 		return std::numeric_limits<size_t>::max();
 
-	const auto & iter = boost::range::find_if(path->nodes, functor);
+	const auto & iter = std::ranges::find_if(path->nodes, functor);
 
 	if(iter == path->nodes.end())
 		return std::numeric_limits<size_t>::max();
@@ -770,7 +770,7 @@ MapRenderer::TileChecksum MapRenderer::getTileChecksum(IMapRendererContext & con
 	// computes basic checksum to determine whether tile needs an update
 	// if any component gives different value, tile will be updated
 	TileChecksum result;
-	boost::range::fill(result, std::numeric_limits<uint8_t>::max());
+	std::ranges::fill(result, std::numeric_limits<uint8_t>::max());
 
 	if(!context.isInMap(coordinates))
 	{

--- a/client/mapView/MapRendererContextState.cpp
+++ b/client/mapView/MapRendererContextState.cpp
@@ -51,7 +51,7 @@ void MapRendererContextState::addObject(const CGObjectInstance * obj)
 			if(GAME->interface()->cb->isInTheMap(currTile) && obj->coveringAt(currTile))
 			{
 				auto & container = objects[currTile];
-				auto position = std::upper_bound(container.begin(), container.end(), obj->id, compareObjectBlitOrder);
+				auto position = std::ranges::upper_bound(container, obj->id, compareObjectBlitOrder);
 				container.insert(position, obj->id);
 
 				usedTiles[obj->id].push_back(currTile);
@@ -76,7 +76,7 @@ void MapRendererContextState::addMovingObject(const CGObjectInstance * object, c
 			if(GAME->interface()->cb->isInTheMap(currTile))
 			{
 				auto & container = objects[currTile];
-				auto position = std::upper_bound(container.begin(), container.end(), object->id, compareObjectBlitOrder);
+				auto position = std::ranges::upper_bound(container, object->id, compareObjectBlitOrder);
 				container.insert(position, object->id);
 
 				usedTiles[object->id].push_back(currTile);

--- a/client/netlag/NetworkLagCompensator.cpp
+++ b/client/netlag/NetworkLagCompensator.cpp
@@ -126,7 +126,7 @@ bool NetworkLagCompensator::verifyReply(const CPackForClient & pack)
 	else
 	{
 		// Prediction was incorrect - rollback everything that is left in this prediction and use real server packs
-		for(auto & prediction : boost::adaptors::reverse(predictedReplies.front().writtenPacks))
+		for(auto & prediction : std::views::reverse(predictedReplies.front().writtenPacks))
 		{
 			for(auto & pack : prediction.rollbackPacks)
 				GAME->server().client->handlePack(*pack);

--- a/client/renderSDL/ScreenHandler.cpp
+++ b/client/renderSDL/ScreenHandler.cpp
@@ -708,13 +708,13 @@ std::vector<Point> ScreenHandler::getSupportedResolutions( int displayIndex) con
 		}
 	}
 
-	boost::range::sort(result, [](const auto & left, const auto & right)
+	std::ranges::sort(result, [](const auto & left, const auto & right)
 	{
 		return left.x * left.y < right.x * right.y;
 	});
 
 	// erase potential duplicates, e.g. resolutions with different framerate / bits per pixel
-	result.erase(boost::unique(result).end(), result.end());
+	result.erase(std::ranges::unique(result).end(), result.end());
 
 	return result;
 }

--- a/client/widgets/CreatureCostBox.cpp
+++ b/client/widgets/CreatureCostBox.cpp
@@ -61,7 +61,7 @@ void CreatureCostBox::createItems(TResources res)
 			curx -= ((16 * resourcesCount) + (8 * (resourcesCount - 1)));
 		}
 		//reverse to display gold as first resource
-		for(auto & currentRes : boost::adaptors::reverse(resources))
+		for(auto & currentRes : std::views::reverse(resources))
 		{
 			currentRes.second.first->moveBy(Point(curx + 2, 22));
 			currentRes.second.second->moveBy(Point(curx, 22));

--- a/client/windows/CCastleInterface.cpp
+++ b/client/windows/CCastleInterface.cpp
@@ -776,7 +776,7 @@ void CCastleBuildings::recreate()
 	{
 		const CBuilding * build = town->getTown()->buildings.at(entry.first).get();
 
-		const CStructure * toAdd = *boost::max_element(entry.second, [=](const CStructure * a, const CStructure * b)
+		const CStructure * toAdd = *std::ranges::max_element(entry.second, [=](const CStructure * a, const CStructure * b)
 		{
 			return build->getDistance(a->building->bid) < build->getDistance(b->building->bid);
 		});
@@ -799,7 +799,7 @@ void CCastleBuildings::recreate()
 		return (*b1)<(*b2);
 	};
 
-	boost::sort(children, buildSorter); //TODO: create building in blit order
+	std::ranges::sort(children, buildSorter); //TODO: create building in blit order
 }
 
 void CCastleBuildings::drawOverlays(Canvas & to, std::vector<std::shared_ptr<CBuildingRect>> buildingRects)
@@ -902,7 +902,7 @@ void CCastleBuildings::buildingClicked(BuildingID building)
 		buildingToEnter = b->upgrade;
 	}
 
-	for(BuildingID buildingToEnter : boost::adaptors::reverse(buildingsToTest))
+	for(BuildingID buildingToEnter : std::views::reverse(buildingsToTest))
 	{
 		if (buildingTryActivateCustomUI(buildingToEnter, building))
 			return;

--- a/client/windows/CMessage.cpp
+++ b/client/windows/CMessage.cpp
@@ -129,7 +129,7 @@ std::vector<std::string> CMessage::breakText(std::string text, size_t maxLineWid
 			if(wordBreak != ui32(-1))
 			{
 				currPos = wordBreak;
-				if(boost::count(text.substr(0, currPos), '{') == boost::count(text.substr(0, currPos), '}'))
+				if(std::ranges::count(text.substr(0, currPos), '{') == std::ranges::count(text.substr(0, currPos), '}'))
 				{
 					opened = false;
 					color = "";

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -336,7 +336,7 @@ void CRecruitmentWindow::availableCreaturesChanged()
 		int amount = dwelling->creatures[i].first;
 
 		//create new cards
-		for(auto & creature : boost::adaptors::reverse(dwelling->creatures[i].second))
+		for(auto & creature : std::views::reverse(dwelling->creatures[i].second))
 			cards.push_back(std::make_shared<CCreatureCard>(this, creature.toCreature(), amount));
 	}
 

--- a/client/windows/QuickRecruitmentWindow.cpp
+++ b/client/windows/QuickRecruitmentWindow.cpp
@@ -82,7 +82,7 @@ void QuickRecruitmentWindow::initWindow(Rect startupPosition)
 void QuickRecruitmentWindow::maxAllCards(std::vector<std::shared_ptr<CreaturePurchaseCard> > cards)
 {
 	auto allAvailableResources = GAME->interface()->cb->getResourceAmount();
-	for(auto i : boost::adaptors::reverse(cards))
+	for(auto i : std::views::reverse(cards))
 	{
 		si32 maxAmount = i->creatureOnTheCard->maxAmount(allAvailableResources);
 		vstd::amin(maxAmount, i->maxAmount);
@@ -105,7 +105,7 @@ void QuickRecruitmentWindow::purchaseUnits()
 {
 	int freeSlotsLeft = town->getUpperArmy()->getFreeSlots().size();
 
-	for(auto selected : boost::adaptors::reverse(cards))
+	for(auto selected : std::views::reverse(cards))
 	{
 		if(selected->slider->getValue() == 0)
 			continue;
@@ -148,7 +148,7 @@ int QuickRecruitmentWindow::getAvailableCreatures()
 void QuickRecruitmentWindow::updateAllSliders()
 {
 	auto allAvailableResources = GAME->interface()->cb->getResourceAmount();
-	for(auto i : boost::adaptors::reverse(cards))
+	for(auto i : std::views::reverse(cards))
 		allAvailableResources -= (i->creatureOnTheCard->getFullRecruitCost() * i->slider->getValue());
 	for(auto i : cards)
 	{

--- a/client/windows/wiki/WikiTownContent.cpp
+++ b/client/windows/wiki/WikiTownContent.cpp
@@ -111,8 +111,8 @@ public:
 			if(it == town->buildings.end())
 				continue;
 			const CBuilding * base = it->second.get();
-			const CStructure * best = *std::max_element(
-				group.begin(), group.end(),
+			const CStructure * best = *std::ranges::max_element(
+				group,
 				[base](const CStructure * a, const CStructure * b)
 				{
 					return base->getDistance(a->building->bid)

--- a/docs/developers/Coding_Guidelines.md
+++ b/docs/developers/Coding_Guidelines.md
@@ -5,7 +5,7 @@
 VCMI implementation bases on C++20 standard. Any feature is acceptable as long as it's will pass build on our CI. At the time of writing, following compilers are supported, and any C++20 feature available across all these compilers can be used:
 
 - GCC 10 or newer
-- Clang 13 or newer
+- Clang 16 or newer
 - Visual Studio 2022 (MSVC 19.44)
 - XCode 16.2 (Apple Clang 16.0.0)
 

--- a/launcher/settingsView/csettingsview_moc.cpp
+++ b/launcher/settingsView/csettingsview_moc.cpp
@@ -402,12 +402,12 @@ static QVector<QSize> findAvailableResolutions(int displayIndex)
 		result.push_back(resolution);
 	}
 
-	boost::range::sort(result, [](const auto & left, const auto & right)
+	std::ranges::sort(result, [](const auto & left, const auto & right)
 	{
 		return left.height() * left.width() < right.height() * right.width();
 	});
 
-	result.erase(boost::unique(result).end(), result.end());
+	result.erase(std::ranges::unique(result).end(), result.end());
 
 	SDL_Quit();
 

--- a/lib/LogicalExpression.h
+++ b/lib/LogicalExpression.h
@@ -73,7 +73,7 @@ namespace LogicalExpressionDetail
 
 		size_t countPassed(const std::vector<typename Base::Variant> & element) const
 		{
-			return boost::range::count_if(element, [&](const typename Base::Variant & expr)
+			return std::ranges::count_if(element, [&](const typename Base::Variant & expr)
 			{
 				return std::visit(*this, expr);
 			});
@@ -123,7 +123,7 @@ namespace LogicalExpressionDetail
 
 		size_t countSatisfiable(const std::vector<typename Base::Variant> & element) const
 		{
-			return boost::range::count_if(element, [&](const typename Base::Variant & expr)
+			return std::ranges::count_if(element, [&](const typename Base::Variant & expr)
 			{
 				return std::visit(*satisfiabilityVisitor, expr);
 			});
@@ -131,7 +131,7 @@ namespace LogicalExpressionDetail
 
 		size_t countFalsifiable(const std::vector<typename Base::Variant> & element) const
 		{
-			return boost::range::count_if(element, [&](const typename Base::Variant & expr)
+			return std::ranges::count_if(element, [&](const typename Base::Variant & expr)
 			{
 				return std::visit(*falsifiabilityVisitor, expr);
 			});
@@ -248,7 +248,7 @@ namespace LogicalExpressionDetail
 			if (!classTest(element))
 			{
 				for (auto & elem : element.expressions)
-					boost::range::copy(std::visit(*this, elem), std::back_inserter(ret));
+					std::ranges::copy(std::visit(*this, elem), std::back_inserter(ret));
 			}
 			return ret;
 		}
@@ -259,7 +259,7 @@ namespace LogicalExpressionDetail
 			if (!classTest(element))
 			{
 				for (auto & elem : element.expressions)
-					boost::range::copy(std::visit(*this, elem), std::back_inserter(ret));
+					std::ranges::copy(std::visit(*this, elem), std::back_inserter(ret));
 			}
 			return ret;
 		}

--- a/lib/VCMIDirs.cpp
+++ b/lib/VCMIDirs.cpp
@@ -537,7 +537,7 @@ std::vector<bfs::path> VCMIDirsXDG::dataPaths() const
 			std::string dataDirsEnv = tempResult;
 			std::vector<std::string> dataDirs;
 			boost::split(dataDirs, dataDirsEnv, boost::is_any_of(":"));
-			for (auto & entry : boost::adaptors::reverse(dataDirs))
+			for (auto & entry : std::views::reverse(dataDirs))
 				ret.push_back(bfs::path(entry) / "vcmi");
 		}
 		else

--- a/lib/battle/BattleHex.cpp
+++ b/lib/battle/BattleHex.cpp
@@ -44,7 +44,7 @@ BattleHex BattleHex::getClosestTile(BattleSide side, const BattleHex & initialPo
 		return std::abs(left.getY() - initialPos.getY()) < std::abs(right.getY() - initialPos.getY());
 	};
 
-	auto bestTile = std::min_element(closestTiles.begin(), closestTiles.end(), compareHorizontal);
+	auto bestTile = std::ranges::min_element(closestTiles, compareHorizontal);
 	return (bestTile != closestTiles.end()) ? *bestTile : BattleHex();
 }
 

--- a/lib/battle/CBattleInfoCallback.cpp
+++ b/lib/battle/CBattleInfoCallback.cpp
@@ -592,14 +592,14 @@ void CBattleInfoCallback::battleGetTurnOrder(std::vector<battle::Units> & turns,
 		phases[unitPhase].push_back(unit);
 	}
 
-	boost::sort(phases[BattlePhases::SIEGE], CMP_stack(BattlePhases::SIEGE, actualTurn, sideThatLastMoved));
+	std::ranges::sort(phases[BattlePhases::SIEGE], CMP_stack(BattlePhases::SIEGE, actualTurn, sideThatLastMoved));
 	std::copy(phases[BattlePhases::SIEGE].begin(), phases[BattlePhases::SIEGE].end(), std::back_inserter(turns.back()));
 
 	if(turnsIsFull())
 		return;
 
 	for(uint8_t phase = BattlePhases::NORMAL; phase < BattlePhases::NUMBER_OF_PHASES; phase++)
-		boost::sort(phases[phase], CMP_stack(phase, actualTurn, sideThatLastMoved));
+		std::ranges::sort(phases[phase], CMP_stack(phase, actualTurn, sideThatLastMoved));
 
 	uint8_t phase = BattlePhases::NORMAL;
 	while(!turnsIsFull() && phase < BattlePhases::NUMBER_OF_PHASES)
@@ -1527,7 +1527,7 @@ BattleHex CBattleInfoCallback::getClosestHexToTargetInRange(const ReachabilityIn
 	if (unit.hasBonusOfType(BonusType::FLYING))
 	{
 		BattleHexArray reachableHexes = battleGetAvailableHexes(cache, &unit, false);
-		return boost::min_element(reachableHexes, [&targetHex](const BattleHex & lhs, const BattleHex & rhs)
+		return std::ranges::min_element(reachableHexes, [&targetHex](const BattleHex & lhs, const BattleHex & rhs)
 		{
 			return BattleHex::getDistance(lhs, targetHex) < BattleHex::getDistance(rhs, targetHex);
 		})[0];
@@ -1567,7 +1567,7 @@ ForcedAction CBattleInfoCallback::getBerserkForcedAction(const battle::Unit * be
 
 	if (battleCanShoot(berserker))
 	{
-		const auto target = boost::min_element(targets, [&berserker](const battle::Unit * lhs, const battle::Unit * rhs)
+		const auto target = std::ranges::min_element(targets, [&berserker](const battle::Unit * lhs, const battle::Unit * rhs)
 		{
 			return BattleHex::getDistance(berserker->getPosition(), lhs->getPosition()) < BattleHex::getDistance(berserker->getPosition(), rhs->getPosition());
 		})[0];
@@ -1592,7 +1592,7 @@ ForcedAction CBattleInfoCallback::getBerserkForcedAction(const battle::Unit * be
 		for (const battle::Unit * uTarget : targets)
 		{
 			BattleHexArray attackableHexes = uTarget->getAttackableHexes(berserker);
-			auto closestAttackableHex = boost::min_element(attackableHexes, [&cache](const BattleHex & lhs, const BattleHex & rhs)
+			auto closestAttackableHex = std::ranges::min_element(attackableHexes, [&cache](const BattleHex & lhs, const BattleHex & rhs)
 			{
 				return cache.distances[lhs.toInt()] < cache.distances[rhs.toInt()];
 			})[0];
@@ -1601,7 +1601,7 @@ ForcedAction CBattleInfoCallback::getBerserkForcedAction(const battle::Unit * be
 			targetData.push_back(temp);
 		}
 
-		auto closestUnit = boost::min_element(targetData, [](const TargetData & lhs, const TargetData & rhs)
+		auto closestUnit = std::ranges::min_element(targetData, [](const TargetData & lhs, const TargetData & rhs)
 		{
 			return lhs.distance < rhs.distance;
 		})[0];
@@ -2027,7 +2027,7 @@ ReachabilityInfo::TDistances CBattleInfoCallback::battleGetDistances(const battl
 
 	auto reachability = getReachability(unit);
 
-	boost::copy(reachability.distances, ret.begin());
+	std::ranges::copy(reachability.distances, ret.begin());
 
 	return ret;
 }

--- a/lib/bonuses/BonusList.cpp
+++ b/lib/bonuses/BonusList.cpp
@@ -16,7 +16,7 @@ VCMI_LIB_NAMESPACE_BEGIN
 
 void BonusList::stackBonuses()
 {
-	boost::sort(bonuses, [](const std::shared_ptr<Bonus> & b1, const std::shared_ptr<Bonus> & b2) -> bool
+	std::ranges::sort(bonuses, [](const std::shared_ptr<Bonus> & b1, const std::shared_ptr<Bonus> & b2) -> bool
 	{
 		if(b1 == b2)
 			return false;

--- a/lib/campaign/CampaignState.cpp
+++ b/lib/campaign/CampaignState.cpp
@@ -180,7 +180,7 @@ std::shared_ptr<CGHeroInstance> CampaignState::strongestHero(CampaignScenarioID 
 		bool result = h->tempOwner == owner;
 		return result;
 	};
-	auto ownedHeroes = scenarioHeroPool.at(scenarioId) | boost::adaptors::filtered(isOwned);
+	auto ownedHeroes = scenarioHeroPool.at(scenarioId) | std::views::filter(isOwned);
 
 	if (ownedHeroes.empty())
 		return nullptr;
@@ -216,7 +216,7 @@ const JsonNode & CampaignState::getHeroByType(HeroTypeID heroID) const
 
 void CampaignState::setCurrentMapAsConquered(std::vector<CGHeroInstance *> heroes)
 {
-	boost::range::sort(heroes, [](const CGHeroInstance * a, const CGHeroInstance * b)
+	std::ranges::sort(heroes, [](const CGHeroInstance * a, const CGHeroInstance * b)
 	{
 		return CGHeroInstance::compareCampaignValue(a, b);
 	});

--- a/lib/entities/faction/CTownHandler.cpp
+++ b/lib/entities/faction/CTownHandler.cpp
@@ -632,7 +632,7 @@ void CTownHandler::loadClientData(CTown &town, const JsonNode & source) const
 
 void CTownHandler::loadTown(CTown * town, const JsonNode & source)
 {
-	const auto * resIter = boost::find(GameConstants::RESOURCE_NAMES, source["primaryResource"].String());
+	const auto * resIter = std::ranges::find(GameConstants::RESOURCE_NAMES, source["primaryResource"].String());
 	if(resIter == std::end(GameConstants::RESOURCE_NAMES))
 		town->primaryRes = GameResID(EGameResID::WOOD_AND_ORE); //Wood + Ore
 	else

--- a/lib/entities/hero/CHeroHandler.cpp
+++ b/lib/entities/hero/CHeroHandler.cpp
@@ -110,7 +110,7 @@ void CHeroHandler::loadHeroSkills(CHero * hero, const JsonNode & node) const
 {
 	for(const JsonNode &set : node["skills"].Vector())
 	{
-		int skillLevel = static_cast<int>(boost::range::find(NSecondarySkill::levels, set["level"].String()) - std::begin(NSecondarySkill::levels));
+		int skillLevel = static_cast<int>(std::ranges::find(NSecondarySkill::levels, set["level"].String()) - std::begin(NSecondarySkill::levels));
 		if (skillLevel < MasteryLevel::LEVELS_SIZE)
 		{
 			size_t currentIndex = hero->secSkillsInit.size();
@@ -386,7 +386,7 @@ void CHeroHandler::loadObject(std::string scope, std::string name, const JsonNod
 
 ui32 CHeroHandler::level (TExpType experience) const
 {
-	return static_cast<ui32>(boost::range::upper_bound(expPerLevel, experience) - std::begin(expPerLevel));
+	return static_cast<ui32>(std::ranges::upper_bound(expPerLevel, experience) - std::begin(expPerLevel));
 }
 
 TExpType CHeroHandler::reqExp (ui32 level) const

--- a/lib/filesystem/AdapterLoaders.cpp
+++ b/lib/filesystem/AdapterLoaders.cpp
@@ -79,7 +79,7 @@ CFilesystemList::~CFilesystemList()
 std::unique_ptr<CInputStream> CFilesystemList::load(const ResourcePath & resourceName) const
 {
 	// load resource from last loader that have it (last overridden version)
-	for(const auto & loader : boost::adaptors::reverse(loaders))
+	for(const auto & loader : std::views::reverse(loaders))
 		if (loader->existsResource(resourceName))
 			return loader->load(resourceName);
 
@@ -141,7 +141,7 @@ std::unordered_set<ResourcePath> CFilesystemList::getFilteredFiles(std::function
 bool CFilesystemList::createResource(const std::string & filename, bool update)
 {
 	logGlobal->trace("Creating %s", filename);
-	for (auto & loader : boost::adaptors::reverse(loaders))
+	for (auto & loader : std::views::reverse(loaders))
 	{
 		if (writeableLoaders.count(loader.get()) != 0                       // writeable,
 			&& loader->createResource(filename, update))          // successfully created
@@ -164,7 +164,7 @@ std::vector<const ISimpleResourceLoader *> CFilesystemList::getResourcesWithName
 	std::vector<const ISimpleResourceLoader *> ret;
 
 	for(const auto & loader : loaders)
-		boost::range::copy(loader->getResourcesWithName(resourceName), std::back_inserter(ret));
+		std::ranges::copy(loader->getResourcesWithName(resourceName), std::back_inserter(ret));
 
 	return ret;
 }
@@ -195,7 +195,7 @@ bool CFilesystemList::removeLoader(ISimpleResourceLoader * loader)
 
 std::string CFilesystemList::getFullFileURI(const ResourcePath& resourceName) const
 {
-	for (const auto& loader : boost::adaptors::reverse(loaders))
+	for (const auto& loader : std::views::reverse(loaders))
 		if (loader->existsResource(resourceName))
 			return loader->getFullFileURI(resourceName);
 
@@ -205,7 +205,7 @@ std::string CFilesystemList::getFullFileURI(const ResourcePath& resourceName) co
 
 std::time_t CFilesystemList::getLastWriteTime(const ResourcePath& resourceName) const
 {
-	for (const auto& loader : boost::adaptors::reverse(loaders))
+	for (const auto& loader : std::views::reverse(loaders))
 		if (loader->existsResource(resourceName))
 			return loader->getLastWriteTime(resourceName);
 

--- a/lib/gameState/CGameStateCampaign.cpp
+++ b/lib/gameState/CGameStateCampaign.cpp
@@ -435,7 +435,7 @@ void CGameStateCampaign::transferMissingArtifacts(const CampaignTravel & travelO
 			throw std::runtime_error("Failed to find hero to take artifacts from! Scenario: " + gameState->map->name.toString());
 
 		// process in reverse - 2nd artifact from a backpack must be processed before 1st one to avoid invalidation of artifact positions
-		for (auto const & artLocation : boost::adaptors::reverse(campaignHeroReplacement.transferrableArtifacts))
+		for (auto const & artLocation : std::views::reverse(campaignHeroReplacement.transferrableArtifacts))
 		{
 			auto * artifact = donorHero->getArt(artLocation);
 
@@ -502,7 +502,7 @@ void CGameStateCampaign::generateCampaignHeroesToReplace()
 	if (lastScenario)
 	{
 		// sort hero placeholders descending power
-		boost::range::sort(placeholdersByPower, [](const CGHeroPlaceholder * a, const CGHeroPlaceholder * b)
+		std::ranges::sort(placeholdersByPower, [](const CGHeroPlaceholder * a, const CGHeroPlaceholder * b)
 		{
 			return *a->powerRank > *b->powerRank;
 		});

--- a/lib/gameState/GameStatePackVisitor.cpp
+++ b/lib/gameState/GameStatePackVisitor.cpp
@@ -1399,7 +1399,7 @@ void GameStatePackVisitor::visitBattleUnitsChanged(BattleUnitsChanged & pack)
 
 void GameStatePackVisitor::restorePreBattleState(BattleID battleID)
 {
-	auto battleIter = boost::range::find_if(gs.currentBattles, [&](const auto & battle)
+	auto battleIter = std::ranges::find_if(gs.currentBattles, [&](const auto & battle)
 	{
 		return battle->battleID == battleID;
 	});
@@ -1423,7 +1423,7 @@ void GameStatePackVisitor::visitBattleCancelled(BattleCancelled & pack)
 {
 	restorePreBattleState(pack.battleID);
 
-	auto battleIter = boost::range::find_if(gs.currentBattles, [&](const auto & battle)
+	auto battleIter = std::ranges::find_if(gs.currentBattles, [&](const auto & battle)
 	{
 		return battle->battleID == pack.battleID;
 	});
@@ -1457,7 +1457,7 @@ void GameStatePackVisitor::visitBattleResultsApplied(BattleResultsApplied & pack
 	for(auto & movingPack : pack.movingArtifacts)
 		movingPack.visit(*this);
 
-	auto battleIter = boost::range::find_if(gs.currentBattles, [&](const auto & battle)
+	auto battleIter = std::ranges::find_if(gs.currentBattles, [&](const auto & battle)
 	{
 		return battle->battleID == pack.battleID;
 	});
@@ -1475,7 +1475,7 @@ void GameStatePackVisitor::visitBattleResultsApplied(BattleResultsApplied & pack
 
 void GameStatePackVisitor::visitBattleEnded(BattleEnded & pack)
 {
-	auto battleIter = boost::range::find_if(gs.currentBattles, [&](const auto & battle)
+	auto battleIter = std::ranges::find_if(gs.currentBattles, [&](const auto & battle)
 	{
 		return battle->battleID == pack.battleID;
 	});

--- a/lib/gameState/TavernHeroesPool.cpp
+++ b/lib/gameState/TavernHeroesPool.cpp
@@ -78,7 +78,7 @@ void TavernHeroesPool::setHeroForPlayer(PlayerColor player, TavernHeroSlot slot,
 
 	currentTavern.push_back(newSlot);
 
-	boost::range::sort(currentTavern, [](const TavernSlot & left, const TavernSlot & right)
+	std::ranges::sort(currentTavern, [](const TavernSlot & left, const TavernSlot & right)
 	{
 		if (left.slot == right.slot)
 			return left.player < right.player;

--- a/lib/json/JsonBonus.cpp
+++ b/lib/json/JsonBonus.cpp
@@ -286,7 +286,7 @@ static TBonusParametersPtr loadBonusAddInfo(BonusType type, const JsonNode & val
 					{ 'f', 1 }, { 'l', 6}, {'r', 2}, {'b', 4}
 				};
 				int converted = 0;
-				for (const auto & ch : boost::adaptors::reverse(sequence.String()))
+				for (const auto & ch : std::views::reverse(sequence.String()))
 				{
 					char chLower = std::tolower(ch);
 					if (charToDirection.count(chLower))

--- a/lib/mapObjectConstructors/AObjectTypeHandler.cpp
+++ b/lib/mapObjectConstructors/AObjectTypeHandler.cpp
@@ -238,7 +238,7 @@ std::vector<std::shared_ptr<const ObjectTemplate>>AObjectTypeHandler::getMostSpe
 	if (!templates.empty())
 	{
 		//Get terrain-specific template if possible
-		int leastTerrains = (*boost::min_element(templates, [](const std::shared_ptr<const ObjectTemplate> & tmp1, const std::shared_ptr<const ObjectTemplate> & tmp2)
+		int leastTerrains = (*std::ranges::min_element(templates, [](const std::shared_ptr<const ObjectTemplate> & tmp1, const std::shared_ptr<const ObjectTemplate> & tmp2)
 		{
 			return tmp1->getTotalAllowedTerrains() < tmp2->getTotalAllowedTerrains();
 		}))->getTotalAllowedTerrains();

--- a/lib/mapping/MapFormatH3M.cpp
+++ b/lib/mapping/MapFormatH3M.cpp
@@ -549,7 +549,7 @@ void CMapLoaderH3M::readVictoryLossConditions()
 
 		if(allowNormalVictory)
 		{
-			size_t playersOnMap = boost::range::count_if(
+			size_t playersOnMap = std::ranges::count_if(
 				mapHeader->players,
 				[](const PlayerInfo & info)
 				{

--- a/lib/mapping/ObstacleProxy.cpp
+++ b/lib/mapping/ObstacleProxy.cpp
@@ -275,7 +275,7 @@ void ObstacleProxy::sortObstacles()
 	{
 		possibleObstacles.emplace_back(o);
 	}
-	boost::sort(possibleObstacles, [](const ObstaclePair &p1, const ObstaclePair &p2) -> bool
+	std::ranges::sort(possibleObstacles, [](const ObstaclePair &p1, const ObstaclePair &p2) -> bool
 	{
 		return p1.first > p2.first; //bigger obstacles first
 	});

--- a/lib/modding/CModHandler.cpp
+++ b/lib/modding/CModHandler.cpp
@@ -133,7 +133,7 @@ TModID CModHandler::findResourceOrigin(const ResourcePath & name) const
 	try
 	{
 		auto activeMode = modManager->getActiveMods();
-		for(const auto & modID : boost::adaptors::reverse(activeMode))
+		for(const auto & modID : std::views::reverse(activeMode))
 		{
 			if(CResourceHandler::get(modID)->existsResource(name))
 				return modID;

--- a/lib/modding/IdentifierStorage.cpp
+++ b/lib/modding/IdentifierStorage.cpp
@@ -514,7 +514,7 @@ void CIdentifierStorage::debugDumpIdentifiers()
 	}
 
 	for(auto & category : objectList)
-		boost::range::sort(category.second);
+		std::ranges::sort(category.second);
 
 	for(const auto & category : objectList)
 	{

--- a/lib/modding/ModManager.cpp
+++ b/lib/modding/ModManager.cpp
@@ -114,7 +114,7 @@ double ModsState::getInstalledModSizeMegabytes(const TModID & modName) const
 
 std::vector<TModID> ModsState::scanModsDirectory(const std::string & modDir) const
 {
-	size_t depth = boost::range::count(modDir, '/');
+	size_t depth = std::ranges::count(modDir, '/');
 
 	const auto & modScanFilter = [&](const ResourcePath & id) -> bool
 	{
@@ -122,7 +122,7 @@ std::vector<TModID> ModsState::scanModsDirectory(const std::string & modDir) con
 			return false;
 		if(!boost::algorithm::starts_with(id.getName(), modDir))
 			return false;
-		if(boost::range::count(id.getName(), '/') != depth)
+		if(std::ranges::count(id.getName(), '/') != depth)
 			return false;
 		return true;
 	};
@@ -804,7 +804,7 @@ const TModList & ModDependenciesResolver::getBrokenMods() const
 void ModDependenciesResolver::tryAddMods(TModList modsToResolve, const ModsStorage & storage)
 {
 	// Topological sort algorithm.
-	boost::range::sort(modsToResolve); // Sort mods per name
+	std::ranges::sort(modsToResolve); // Sort mods per name
 	std::vector<TModID> sortedValidMods(activeMods.begin(), activeMods.end()); // Vector keeps order of elements (LIFO)
 	std::set<TModID> resolvedModIDs(activeMods.begin(), activeMods.end()); // Use a set for validation for performance reason, but set does not keep order of elements
 	std::set<TModID> notResolvedModIDs(modsToResolve.begin(), modsToResolve.end()); // Use a set for validation for performance reason

--- a/lib/rmg/CMapGenOptions.cpp
+++ b/lib/rmg/CMapGenOptions.cpp
@@ -652,7 +652,7 @@ void CMapGenOptions::updateCompOnlyPlayers()
 
 int CMapGenOptions::countHumanPlayers() const
 {
-	return static_cast<int>(boost::count_if(players, [](const std::pair<PlayerColor, CPlayerSettings> & pair)
+	return static_cast<int>(std::ranges::count_if(players, [](const std::pair<PlayerColor, CPlayerSettings> & pair)
 	{
 		return pair.second.getPlayerType() == EPlayerType::HUMAN;
 	}));
@@ -660,7 +660,7 @@ int CMapGenOptions::countHumanPlayers() const
 
 int CMapGenOptions::countCompOnlyPlayers() const
 {
-	return static_cast<int>(boost::count_if(players, [](const std::pair<PlayerColor, CPlayerSettings> & pair)
+	return static_cast<int>(std::ranges::count_if(players, [](const std::pair<PlayerColor, CPlayerSettings> & pair)
 	{
 		return pair.second.getPlayerType() == EPlayerType::COMP_ONLY;
 	}));

--- a/lib/rmg/CRmgTemplate.cpp
+++ b/lib/rmg/CRmgTemplate.cpp
@@ -870,12 +870,14 @@ void CRmgTemplate::CPlayerCountRange::fromString(const std::string & value)
 
 int CRmgTemplate::CPlayerCountRange::maxValue() const
 {
-	return *boost::max_element(getNumbers());
+	auto numbers = getNumbers();
+	return *std::ranges::max_element(numbers);
 }
 
 int CRmgTemplate::CPlayerCountRange::minValue() const
 {
-	return *boost::min_element(getNumbers());
+	auto numbers = getNumbers();
+	return *std::ranges::min_element(numbers);
 }
 
 void CRmgTemplate::serializeJson(JsonSerializeFormat & handler)

--- a/lib/rmg/CZonePlacer.cpp
+++ b/lib/rmg/CZonePlacer.cpp
@@ -571,7 +571,7 @@ void CZonePlacer::moveOneZone(TZoneMap& zones, TForceVector& totalForces, TDista
 	if (misplacedZones.empty())
 		return;
 
-	boost::sort(misplacedZones, [](const Misplacement& lhs, Misplacement& rhs)
+	std::ranges::sort(misplacedZones, [](const Misplacement& lhs, Misplacement& rhs)
 	{
 		return lhs.first > rhs.first; //Largest displacement first
 	});
@@ -765,7 +765,7 @@ void CZonePlacer::assignZones(vstd::RNG * rand)
 				{
 					distances.emplace_back(zone.second, static_cast<float>(pos.dist2dSQ(zone.second->getPos())));
 				}
-				boost::min_element(distances, compareByDistance)->first->area()->add(pos); //closest tile belongs to zone
+				std::ranges::min_element(distances, compareByDistance)->first->area()->add(pos); //closest tile belongs to zone
 			}
 		}
 	}
@@ -798,7 +798,7 @@ void CZonePlacer::assignZones(vstd::RNG * rand)
 			{
 				distances.emplace_back(zone.second, zone.second->getCenter().dist2dSQ(float3(vertex.x(), vertex.y(), level)));
 			}
-			auto closestZone = boost::min_element(distances, compareByDistance)->first;
+			auto closestZone = std::ranges::min_element(distances, compareByDistance)->first;
 
 			vertexMapping[closestZone].insert(int3(vertex.x() * width, vertex.y() * height, level)); //Closest vertex belongs to zone
 		}
@@ -820,7 +820,7 @@ void CZonePlacer::assignZones(vstd::RNG * rand)
 				}
 
 				//Tile closest to vertex belongs to zone
-				auto closestZone = boost::min_element(distances, simpleCompareByDistance)->first;
+				auto closestZone = std::ranges::min_element(distances, simpleCompareByDistance)->first;
 				closestZone->area()->add(pos);
 				map.setZoneID(pos, closestZone->getId());
 			}

--- a/lib/rmg/modificators/ObjectManager.cpp
+++ b/lib/rmg/modificators/ObjectManager.cpp
@@ -813,7 +813,7 @@ bool ObjectManager::addGuard(rmg::Object & object, si32 strength, bool zoneGuard
 		return false;
 
 	auto guardTiles = accessibleArea.getTilesVector();
-	auto guardPos = *std::min_element(guardTiles.begin(), guardTiles.end(), [&object](const int3 & l, const int3 & r)
+	auto guardPos = *std::ranges::min_element(guardTiles, [&object](const int3 & l, const int3 & r)
 	{
 		auto p = object.getVisitablePosition();
 		if(l.y > r.y)

--- a/lib/rmg/modificators/TreasurePlacer.cpp
+++ b/lib/rmg/modificators/TreasurePlacer.cpp
@@ -963,7 +963,7 @@ void TreasurePlacer::createTreasures(ObjectManager& manager)
 
 	//place biggest treasures first at large distance, place smaller ones inbetween
 	auto treasureInfo = zone.getTreasureInfo();
-	boost::sort(treasureInfo, valueComparator);
+	std::ranges::sort(treasureInfo, valueComparator);
 
 	//sort treasures by ascending value so we can stop checking treasures with too high value
 	objects.sortPossibleObjects();
@@ -1227,7 +1227,7 @@ std::vector<ObjectInfo> & TreasurePlacer::ObjectPool::getPossibleObjects()
 
 void TreasurePlacer::ObjectPool::sortPossibleObjects()
 {
-	boost::sort(possibleObjects, [](const ObjectInfo& oi1, const ObjectInfo& oi2) -> bool
+	std::ranges::sort(possibleObjects, [](const ObjectInfo& oi1, const ObjectInfo& oi2) -> bool
 	{
 		return oi1.value < oi2.value;
 	});

--- a/lib/rmg/modificators/WaterAdopter.cpp
+++ b/lib/rmg/modificators/WaterAdopter.cpp
@@ -229,7 +229,7 @@ void WaterAdopter::createWater(EWaterContent::EWaterContent waterContent)
 	Zone::Lock lock(zone.areaMutex);
 	zone.area()->subtract(waterArea);
 	zone.areaPossible()->subtract(waterArea);
-	auto centerSet = std::max_element(reverseDistanceMap.begin(), reverseDistanceMap.end(), 
+	auto centerSet = std::ranges::max_element(reverseDistanceMap,
 		[](const auto &a, const auto &b) 
 		{
 			return a.first < b.first;

--- a/lib/texts/CGeneralTextHandler.cpp
+++ b/lib/texts/CGeneralTextHandler.cpp
@@ -97,7 +97,7 @@ void CGeneralTextHandler::detectInstallParameters()
 			deviations[i] += std::abs((footprint[j] - knownFootprints[i][j]));
 	}
 
-	size_t bestIndex = boost::range::min_element(deviations) - deviations.begin();
+	size_t bestIndex = std::ranges::min_element(deviations) - deviations.begin();
 
 	for (size_t i = 0; i < deviations.size(); ++i)
 		logGlobal->debug("Comparing to %s: %f", knownLanguages[i], deviations[i]);

--- a/lobby/LobbyServer.cpp
+++ b/lobby/LobbyServer.cpp
@@ -148,7 +148,7 @@ void LobbyServer::sendChatHistory(const NetworkConnectionPtr & target, const std
 	reply["channelName"].String() = channelName;
 	reply["messages"].Vector(); // force creation of empty vector
 
-	for(const auto & message : boost::adaptors::reverse(history))
+	for(const auto & message : std::views::reverse(history))
 	{
 		JsonNode jsonEntry;
 

--- a/server/NetPacksLobbyServer.cpp
+++ b/server/NetPacksLobbyServer.cpp
@@ -187,7 +187,7 @@ void ApplyOnServerNetPackVisitor::visitLobbySetCampaign(LobbySetCampaign & pack)
 	bool isCurrentMapConquerable = pack.ourCampaign->currentScenario() && pack.ourCampaign->isAvailable(*pack.ourCampaign->currentScenario());
 
 	auto scenarios = pack.ourCampaign->allScenarios();
-	for(auto scenarioID : boost::adaptors::reverse(scenarios)) // reverse -> on multiple scenario selection set lowest id at the end
+	for(auto scenarioID : std::views::reverse(scenarios)) // reverse -> on multiple scenario selection set lowest id at the end
 	{
 		if(pack.ourCampaign->isAvailable(scenarioID))
 		{

--- a/server/battles/BattleFlowProcessor.cpp
+++ b/server/battles/BattleFlowProcessor.cpp
@@ -662,7 +662,7 @@ bool BattleFlowProcessor::tryMakeAutomaticActionOfMeleeUnit(const CBattleInfoCal
 		if(!isReachable)
 			continue;
 
-		BattleHex closestTargetAdjacentHex = boost::min_element(attackableHexes, [&reachabilityCache](const BattleHex & lhs, const BattleHex & rhs)
+		BattleHex closestTargetAdjacentHex = std::ranges::min_element(attackableHexes, [&reachabilityCache](const BattleHex & lhs, const BattleHex & rhs)
 		{
 			return reachabilityCache.distances[lhs.toInt()] < reachabilityCache.distances[rhs.toInt()];
 		})[0];

--- a/server/queries/VisitQueries.cpp
+++ b/server/queries/VisitQueries.cpp
@@ -91,8 +91,8 @@ TownBuildingVisitQuery::TownBuildingVisitQuery(CGameHandler * owner, const CGTow
 	, visitedTown(Obj)
 {
 	// generate in reverse order - first building-hero pair to handle must be in the end of vector
-	for (auto const * hero : boost::adaptors::reverse(heroes))
-		for (auto const & building : boost::adaptors::reverse(buildingToVisit))
+	for (auto const * hero : std::views::reverse(heroes))
+		for (auto const & building : std::views::reverse(buildingToVisit))
 			visitedBuilding.push_back({ hero, building});
 }
 

--- a/test/map/MapComparer.cpp
+++ b/test/map/MapComparer.cpp
@@ -176,8 +176,8 @@ void MapComparer::compareHeader()
 	{
 		return lhs.identifier < rhs.identifier;
 	};
-	boost::sort (actualEvents, sortByIdentifier);
-	boost::sort (expectedEvents, sortByIdentifier);
+	std::ranges::sort (actualEvents, sortByIdentifier);
+	std::ranges::sort (expectedEvents, sortByIdentifier);
 
 	checkEqual(actualEvents, expectedEvents);
 	checkEqual(actual->disposedHeroes, expected->disposedHeroes);


### PR DESCRIPTION
Removes all usages of boost::range and same functions from boost namespace (e.g. boost::sort) with std::ranges introduced in C++20

No functionality changes

Works for me, but not 100% sure if all our compilers/standard libraries support it - will check via CI