### PR TITLE
Add windowed maximized window mode

### DIFF
--- a/client/renderSDL/ScreenHandler.cpp
+++ b/client/renderSDL/ScreenHandler.cpp
@@ -310,6 +310,8 @@ void ScreenHandler::updateWindowState()
 			Point resolution = getPreferredWindowResolution();
 			SDL_SetWindowFullscreen(mainWindow, 0);
 			SDL_SetWindowSize(mainWindow, resolution.x, resolution.y);
+			if(settings["video"]["windowMaximized"].Bool())
+				SDL_MaximizeWindow(mainWindow);
 			return;
 		}
 	}
@@ -465,7 +467,12 @@ SDL_Window * ScreenHandler::createWindow()
 			return createWindowImpl(Point(), SDL_WINDOW_FULLSCREEN_DESKTOP, false);
 
 		case EWindowMode::WINDOWED:
-			return createWindowImpl(dimensions, SDL_WINDOW_RESIZABLE, true);
+		{
+			int flags = SDL_WINDOW_RESIZABLE;
+			if(settings["video"]["windowMaximized"].Bool())
+				flags |= SDL_WINDOW_MAXIMIZED;
+			return createWindowImpl(dimensions, flags, true);
+		}
 
 		default:
 			return nullptr;

--- a/config/schemas/settings.json
+++ b/config/schemas/settings.json
@@ -215,6 +215,7 @@
 				"reservedWidth",
 				"fullscreen",
 				"realFullscreen",
+				"windowMaximized",
 				"cursor",
 				"showIntro",
 				"spellbookAnimation",
@@ -253,6 +254,10 @@
 					"default" : true
 				},
 				"realFullscreen" : {
+					"type" : "boolean",
+					"default" : false
+				},
+				"windowMaximized" : {
 					"type" : "boolean",
 					"default" : false
 				},

--- a/launcher/settingsView/csettingsview_moc.cpp
+++ b/launcher/settingsView/csettingsview_moc.cpp
@@ -196,9 +196,13 @@ void CSettingsView::loadSettings()
 	ui->labelResetTutorialTouchscreen->hide();
 	ui->pushButtonResetTutorialTouchscreen->hide();
 	if (settings["video"]["realFullscreen"].Bool())
+		ui->comboBoxFullScreen->setCurrentIndex(3);
+	else if (settings["video"]["fullscreen"].Bool())
 		ui->comboBoxFullScreen->setCurrentIndex(2);
+	else if (settings["video"]["windowMaximized"].Bool())
+		ui->comboBoxFullScreen->setCurrentIndex(1);
 	else
-		ui->comboBoxFullScreen->setCurrentIndex(settings["video"]["fullscreen"].Bool());
+		ui->comboBoxFullScreen->setCurrentIndex(0);
 #endif
 #ifndef VCMI_ANDROID
 	ui->buttonHandleBackRightMouseButton->hide();
@@ -511,8 +515,10 @@ void CSettingsView::on_comboBoxFullScreen_currentIndexChanged(int index)
 {
 	Settings nodeFullscreen     = settings.write["video"]["fullscreen"];
 	Settings nodeRealFullscreen = settings.write["video"]["realFullscreen"];
-	nodeFullscreen->Bool() = (index != 0);
-	nodeRealFullscreen->Bool() = (index == 2);
+	Settings nodeWindowMaximized = settings.write["video"]["windowMaximized"];
+	nodeFullscreen->Bool() = (index >= 2);
+	nodeRealFullscreen->Bool() = (index == 3);
+	nodeWindowMaximized->Bool() = (index == 1);
 
 	fillValidResolutions();
 	fillValidScalingRange();

--- a/launcher/settingsView/csettingsview_moc.ui
+++ b/launcher/settingsView/csettingsview_moc.ui
@@ -1437,6 +1437,8 @@
 
 Windowed - the game will run inside a window that covers part of your screen.
 
+Windowed Maximized - the game will start in a maximized window.
+
 Borderless Windowed Mode - the game will run in a full-screen window, matching your screen's resolution.
 
 Fullscreen Exclusive Mode - the game will cover the entirety of your screen and will use selected resolution.</string>
@@ -1447,6 +1449,11 @@ Fullscreen Exclusive Mode - the game will cover the entirety of your screen and 
          <item>
           <property name="text">
            <string>Windowed</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Windowed maximized</string>
           </property>
          </item>
          <item>


### PR DESCRIPTION
Adds a "Windowed maximized" window mode.

- New `video/windowMaximized` boolean setting (default false)
- Window is created with `SDL_WINDOW_MAXIMIZED`, or maximized on the fly when the setting is enabled
- Launcher fullscreen combo box gains a "Windowed maximized" option (indices: 0 windowed, 1 windowed maximized, 2 borderless fullscreen, 3 fullscreen exclusive)
