### PR TITLE
[cmake][iOS] link vcmiqt statically

### DIFF
--- a/vcmiqt/CMakeLists.txt
+++ b/vcmiqt/CMakeLists.txt
@@ -17,7 +17,7 @@ set(vcmiqt_HEADERS
 
 assign_source_group(${vcmiqt_SRCS} ${vcmiqt_HEADERS})
 
-if(ENABLE_STATIC_LIBS OR NOT (ENABLE_EDITOR AND ENABLE_LAUNCHER))
+if(ENABLE_SINGLE_APP_BUILD OR ENABLE_STATIC_LIBS OR NOT (ENABLE_EDITOR AND ENABLE_LAUNCHER))
 	add_library(vcmiqt STATIC ${vcmiqt_SRCS} ${vcmiqt_HEADERS})
 	target_compile_definitions(vcmiqt PRIVATE VCMIQT_STATIC)
 	set(TARGET_IS_SHARED OFF)


### PR DESCRIPTION
avoids runtime warning about duplicate classes as Qt is build statically on iOS:
```
objc[8819]: Class QMacAutoReleasePoolTracker is implemented in both /private/var/containers/Bundle/Application/679E59F1-0F28-43E7-A7CA-26C2E8F805AE/vcmiclient.app/Frameworks/libvcmiqt.dylib (0x109e911c0) and /private/var/containers/Bundle/Application/679E59F1-0F28-43E7-A7CA-26C2E8F805AE/vcmiclient.app/vcmiclient (0x1053aa040). This may cause spurious casting failures and mysterious crashes. One of the duplicates must be removed or renamed.
objc[8819]: Class KeyValueObserver is implemented in both /private/var/containers/Bundle/Application/679E59F1-0F28-43E7-A7CA-26C2E8F805AE/vcmiclient.app/Frameworks/libvcmiqt.dylib (0x109e91210) and /private/var/containers/Bundle/Application/679E59F1-0F28-43E7-A7CA-26C2E8F805AE/vcmiclient.app/vcmiclient (0x1053aa090). This may cause spurious casting failures and mysterious crashes. One of the duplicates must be removed or renamed.
objc[8819]: Class RunLoopModeTracker is implemented in both /private/var/containers/Bundle/Application/679E59F1-0F28-43E7-A7CA-26C2E8F805AE/vcmiclient.app/Frameworks/libvcmiqt.dylib (0x109e91260) and /private/var/containers/Bundle/Application/679E59F1-0F28-43E7-A7CA-26C2E8F805AE/vcmiclient.app/vcmiclient (0x1053aa0e0). This may cause spurious casting failures and mysterious crashes. One of the duplicates must be removed or renamed.
```

note: develop doesn't need this change, there we can simply enable `ENABLE_STATIC_LIBS` for iOS