### PR TITLE
replace `std::ranges` usage in non-MMAI code

### DIFF
--- a/AI/BattleAI/BattleEvaluator.cpp
+++ b/AI/BattleAI/BattleEvaluator.cpp
@@ -170,8 +170,8 @@ std::optional<PossibleSpellcast> BattleEvaluator::findBestCreatureSpell(const CS
 		}
 	}
 
-	std::ranges::sort(
-		possibleCasts,
+	std::sort(
+		possibleCasts.begin(), possibleCasts.end(),
 		[&](const PossibleSpellcast & lhs, const PossibleSpellcast & rhs)
 		{
 			return lhs.value > rhs.value;

--- a/lib/battle/CBattleInfoCallback.cpp
+++ b/lib/battle/CBattleInfoCallback.cpp
@@ -1530,7 +1530,7 @@ BattleHex CBattleInfoCallback::getClosestHexToTargetInRange(const ReachabilityIn
 	if (reachableHexes.empty())
 		return BattleHex::INVALID;
 
-	return *std::ranges::min_element(reachableHexes, {}, [&](const BattleHex & h)
+	return *vstd::minElementByFun(reachableHexes, [&](const BattleHex & h)
 	{
 		return BattleHex::getDistance(h, targetHex);
 	});


### PR DESCRIPTION
this small change makes VCMI 1.7.x buildable for Android 4.4 (requires NDK r25c / clang 14)

note: should be dropped when merging into develop