### PR TITLE
[1.7] update dependencies

### DIFF
--- a/.github/workflows/github.yml
+++ b/.github/workflows/github.yml
@@ -95,7 +95,7 @@ jobs:
             preset: windows-msvc-ninja-release-arm64
             conan_profile: msvc-arm64
             conan_prebuilts: dependencies-windows-arm64
-            conan_options: -s "&:build_type=RelWithDebInfo" -c tools.env.virtualenv:powershell=pwsh -o "&:lua_lib=lua"
+            conan_options: -s "&:build_type=RelWithDebInfo" -c tools.env.virtualenv:powershell=pwsh
             artifact_platform: arm64
 
           - platform: android-32

--- a/.github/workflows/github.yml
+++ b/.github/workflows/github.yml
@@ -60,7 +60,7 @@ jobs:
           - platform: msvc-x64
             arch: x64
             toolset: '14.29'
-            os: windows-2025
+            os: windows-2025-vs2026
             pack: 1
             upload: 0
             pack_type: RelWithDebInfo
@@ -74,7 +74,7 @@ jobs:
           - platform: msvc-x86
             arch: amd64_x86
             toolset: '14.29'
-            os: windows-2025
+            os: windows-2025-vs2026
             pack: 1
             upload: 0
             pack_type: RelWithDebInfo
@@ -87,7 +87,7 @@ jobs:
 
           - platform: msvc-arm64
             arch: arm64
-            os: windows-11-arm
+            os: windows-11-vs2026-arm
             pack: 1
             upload: 0
             pack_type: RelWithDebInfo
@@ -282,7 +282,7 @@ jobs:
           --profile=dependencies/conan_profiles/${{ matrix.conan_profile }} \
           --conf="tools.cmake.cmaketoolchain:generator=Ninja" \
           ${{ matrix.conan_options }} \
-          ${{ startsWith(matrix.platform, 'msvc') && '--conf="tools.microsoft.msbuild:vs_version=17"' || '' }}
+          ${{ startsWith(matrix.platform, 'msvc') && '--conf="tools.microsoft.msbuild:vs_version=18"' || '' }}
         ${{ startsWith(matrix.platform, 'msvc') && 'echo CONANRUN_PWSH_SCRIPT="$outFolder/conanrun.ps1" >> $GITHUB_ENV' || '' }}
 
     # Can't be set in Gradle project

--- a/.github/workflows/github.yml
+++ b/.github/workflows/github.yml
@@ -281,7 +281,8 @@ jobs:
           --build=never \
           --profile=dependencies/conan_profiles/${{ matrix.conan_profile }} \
           --conf="tools.cmake.cmaketoolchain:generator=Ninja" \
-          ${{ matrix.conan_options }}
+          ${{ matrix.conan_options }} \
+          ${{ startsWith(matrix.platform, 'msvc') && '--conf="tools.microsoft.msbuild:vs_version=17"' || '' }}
         ${{ startsWith(matrix.platform, 'msvc') && 'echo CONANRUN_PWSH_SCRIPT="$outFolder/conanrun.ps1" >> $GITHUB_ENV' || '' }}
 
     # Can't be set in Gradle project

--- a/CI/install_conan_dependencies.sh
+++ b/CI/install_conan_dependencies.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-RELEASE_TAG="2026-03-11"
+RELEASE_TAG="2026-07-03"
 FILENAME="$1.txz"
 DOWNLOAD_URL="https://github.com/vcmi/vcmi-dependencies/releases/download/$RELEASE_TAG/$FILENAME"
 


### PR DESCRIPTION
- submodule updated to the latest commit of `beta` branch
- dependencies were rebuilt, primarily to fix Qt build for old Androids (5.0-5.1), as it turned out that after bumping Qt version I forgot to adjust the metadata file telling which version patches should be applied to
- also excluded all Lua libs from building as they're basically unused before v1.8