### PR TITLE
Reduce boost usage where it makes sense

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -488,7 +488,7 @@ endif()
 #        Finding packages                  #
 ############################################
 
-set(BOOST_COMPONENTS date_time filesystem program_options)
+set(BOOST_COMPONENTS filesystem program_options)
 if(ENABLE_INNOEXTRACT)
 	list(APPEND BOOST_COMPONENTS iostreams)
 endif()

--- a/Global.h
+++ b/Global.h
@@ -131,6 +131,7 @@ static_assert(sizeof(bool) == 1, "Bool needs to be 1 byte in size.");
 #include <shared_mutex>
 #include <sstream>
 #include <string>
+#include <string_view>
 #include <thread>
 #include <unordered_map>
 #include <unordered_set>

--- a/Global.h
+++ b/Global.h
@@ -165,7 +165,6 @@ static_assert(sizeof(bool) == 1, "Bool needs to be 1 byte in size.");
 #include <boost/filesystem/operations.hpp>
 #include <boost/filesystem/path.hpp>
 #include <boost/format.hpp>
-#include <boost/logic/tribool.hpp>
 #include <boost/multi_array.hpp>
 
 #ifndef M_PI

--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -118,7 +118,6 @@
 
 #include "../lib/filesystem/Filesystem.h"
 
-#include <boost/lexical_cast.hpp>
 
 // The macro below is used to mark functions that are called by client when game state changes.
 // They all assume that interface mutex is locked.
@@ -1561,7 +1560,7 @@ void CPlayerInterface::objectRemoved(const CGObjectInstance * obj, const PlayerC
 void CPlayerInterface::objectRemovedAfter()
 {
 	EVENT_HANDLER_CALLED_BY_CLIENT;
-	adventureInt->onMapTilesChanged(std::none);
+	adventureInt->onMapTilesChanged(std::nullopt);
 
 	// visiting or garrisoned hero removed - update window
 	if (castleInt)
@@ -1628,7 +1627,7 @@ int CPlayerInterface::getLastIndex( std::string namePrefix)
 			{
 				char nr = name[namePrefix.size()];
 				if (std::isdigit(nr))
-					dates[last_write_time(dir->path())] = boost::lexical_cast<int>(nr);
+					dates[last_write_time(dir->path())] = nr - '0';
 			}
 		}
 	}

--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -1561,7 +1561,7 @@ void CPlayerInterface::objectRemoved(const CGObjectInstance * obj, const PlayerC
 void CPlayerInterface::objectRemovedAfter()
 {
 	EVENT_HANDLER_CALLED_BY_CLIENT;
-	adventureInt->onMapTilesChanged(boost::none);
+	adventureInt->onMapTilesChanged(std::none);
 
 	// visiting or garrisoned hero removed - update window
 	if (castleInt)

--- a/client/CServerHandler.cpp
+++ b/client/CServerHandler.cpp
@@ -68,7 +68,6 @@
 #include <vcmi/events/EventBus.h>
 #include <SDL_thread.h>
 
-#include <boost/lexical_cast.hpp>
 
 CServerHandler::~CServerHandler()
 {
@@ -571,7 +570,7 @@ void CServerHandler::sendMessage(const std::string & txt) const
 		if(id.length())
 		{
 			LobbyChangeHost lch;
-			lch.newHostConnectionId = static_cast<GameConnectionID>(boost::lexical_cast<int>(id));
+			lch.newHostConnectionId = static_cast<GameConnectionID>(std::stoi(id));
 			sendLobbyPack(lch);
 		}
 	}
@@ -583,8 +582,8 @@ void CServerHandler::sendMessage(const std::string & txt) const
 		readed >> playerColorId;
 		if(connectedId.length() && playerColorId.length())
 		{
-			auto connected = static_cast<PlayerConnectionID>(boost::lexical_cast<int>(connectedId));
-			auto color = PlayerColor(boost::lexical_cast<int>(playerColorId));
+			auto connected = static_cast<PlayerConnectionID>(std::stoi(connectedId));
+			auto color = PlayerColor(std::stoi(playerColorId));
 			if(color.isValidPlayer() && playerNames.find(connected) != playerNames.end())
 			{
 				LobbyForceSetPlayer lfsp;

--- a/client/adventureMap/AdventureMapInterface.cpp
+++ b/client/adventureMap/AdventureMapInterface.cpp
@@ -355,7 +355,7 @@ void AdventureMapInterface::onHeroOrderChanged()
 	widget->getHeroList()->updateWidget();
 }
 
-void AdventureMapInterface::onMapTilesChanged(boost::optional<FowTilesType> positions)
+void AdventureMapInterface::onMapTilesChanged(std::optional<FowTilesType> positions)
 {
 	if (positions)
 		widget->getMinimap()->updateTiles(*positions);

--- a/client/adventureMap/AdventureMapInterface.h
+++ b/client/adventureMap/AdventureMapInterface.h
@@ -144,7 +144,7 @@ public:
 	void onCurrentPlayerChanged(PlayerColor playerID);
 
 	/// Called by PlayerInterface when specific map tile changed and must be updated on minimap
-	void onMapTilesChanged(boost::optional<FowTilesType> positions);
+	void onMapTilesChanged(std::optional<FowTilesType> positions);
 
 	/// Called by PlayerInterface when hero starts movement
 	void onHeroMovementStarted(const CGHeroInstance * hero);

--- a/client/battle/BattleStacksController.cpp
+++ b/client/battle/BattleStacksController.cpp
@@ -263,14 +263,11 @@ std::shared_ptr<IImage> BattleStacksController::getStackAmountBox(const CStack *
 
 	for(const auto & spellID : activeSpells)
 	{
-		auto positiveness = spellID.toEntity(LIBRARY)->getPositiveness();
-		if(!boost::logic::indeterminate(positiveness))
-		{
-			if(positiveness)
-				effectsPositivness++;
-			else
-				effectsPositivness--;
-		}
+		const auto * spell = spellID.toEntity(LIBRARY);
+		if(spell->isPositive())
+			effectsPositivness++;
+		else if(spell->isNegative())
+			effectsPositivness--;
 	}
 
 	if (effectsPositivness > 0)

--- a/client/mainmenu/CMainMenu.cpp
+++ b/client/mainmenu/CMainMenu.cpp
@@ -62,7 +62,6 @@
 #include "../../lib/GameLibrary.h"
 #include "../../lib/json/JsonUtils.h"
 
-#include <boost/lexical_cast.hpp>
 
 ISelectionScreenInfo * SEL = nullptr;
 
@@ -773,7 +772,7 @@ void CSimpleJoinScreen::connectToServer()
 		buttonOk->block(true);
 	ENGINE->input().stopTextInput();
 
-	startConnection(inputAddress ? inputAddress->getText() : "", inputPort ? boost::lexical_cast<ui16>(inputPort->getText()) : 0);
+	startConnection(inputAddress ? inputAddress->getText() : "", inputPort ? static_cast<ui16>(std::stoul(inputPort->getText())) : 0);
 }
 
 void CSimpleJoinScreen::leaveScreen()

--- a/client/widgets/CTextInput.cpp
+++ b/client/widgets/CTextInput.cpp
@@ -22,7 +22,6 @@
 
 #include "../../lib/texts/TextOperations.h"
 
-#include <boost/lexical_cast.hpp>
 
 std::list<CFocusable *> CFocusable::focusables;
 CFocusable * CFocusable::inputWithFocus;

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -69,7 +69,6 @@
 #include "../../lib/CSoundBase.h"
 #include "../../lib/constants/EntityIdentifiers.h"
 
-#include <boost/lexical_cast.hpp>
 
 ImagePath CRecruitmentWindow::getRecruitmentBackground(const CGDwelling * dwelling, int level)
 {
@@ -440,9 +439,9 @@ void CSplitWindow::setAmountText(std::string text, bool left)
 	{
 		try
 		{
-			amount = boost::lexical_cast<int>(text);
+			amount = std::stoi(text);
 		}
-		catch(boost::bad_lexical_cast &)
+		catch(const std::exception &)
 		{
 			amount = left ? leftAmount : rightAmount;
 		}

--- a/include/vcmi/spells/Spell.h
+++ b/include/vcmi/spells/Spell.h
@@ -31,7 +31,6 @@ public:
 	virtual int64_t calculateDamage(const Caster * caster) const = 0;
 
 	virtual int32_t getLevel() const = 0;
-	virtual boost::logic::tribool getPositiveness() const = 0;
 	virtual bool isAdventure() const = 0;
 	virtual bool isCombat() const = 0;
 	virtual bool isCreatureAbility() const = 0;

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -823,7 +823,7 @@ add_library(vcmiMain OBJECT ${lib_SRCS} ${lib_HEADERS})
 target_compile_definitions(vcmiMain PRIVATE "VCMI_DLL=1")
 target_link_libraries(vcmiMain PUBLIC
 	minizip::minizip ZLIB::ZLIB Iconv::Iconv
-	${SYSTEM_LIBS} Boost::boost Boost::filesystem Boost::program_options Boost::date_time
+	${SYSTEM_LIBS} Boost::boost Boost::filesystem Boost::program_options
 )
 
 if (NOT ENABLE_MINIMAL_LIB)

--- a/lib/CThreadHelper.cpp
+++ b/lib/CThreadHelper.cpp
@@ -22,11 +22,18 @@
 #ifndef ENABLE_MINIMAL_LIB
 	#include <tbb/task_arena.h>
 #endif
-#include <boost/lexical_cast.hpp>
+#include <sstream>
 
 VCMI_LIB_NAMESPACE_BEGIN
 
 static thread_local std::string threadNameForLogging;
+
+static std::string threadIdToString(std::thread::id id)
+{
+	std::ostringstream stream;
+	stream << id;
+	return stream.str();
+}
 
 std::string getThreadName()
 {
@@ -37,11 +44,11 @@ std::string getThreadName()
 	int tbbIndex = tbb::this_task_arena::current_thread_index();
 
 	if (tbbIndex < 0)
-		return boost::lexical_cast<std::string>(std::this_thread::get_id());
+		return threadIdToString(std::this_thread::get_id());
 	else
-		return "TBB worker " + boost::lexical_cast<std::string>(tbbIndex);
+		return "TBB worker " + std::to_string(tbbIndex);
 #else
-	return boost::lexical_cast<std::string>(std::this_thread::get_id());
+	return threadIdToString(std::this_thread::get_id());
 #endif
 }
 

--- a/lib/battle/CBattleInfoCallback.cpp
+++ b/lib/battle/CBattleInfoCallback.cpp
@@ -1184,7 +1184,6 @@ DamageEstimation CBattleInfoCallback::battleEstimateDamage(const BattleAttackInf
 	if (bai.attacker->hasBonusOfType(BonusType::BLOCKS_RETALIATION) || bai.attacker->isInvincible() || isLongWeaponAttack(bai.attacker, bai.defender))
 		return ret;
 
-	//TODO: rewrite using boost::numeric::interval
 	//TODO: rewire once more using interval-based fuzzy arithmetic
 
 	const auto & estimateRetaliation = [&](int64_t damage)

--- a/lib/battle/CBattleInfoEssentials.cpp
+++ b/lib/battle/CBattleInfoEssentials.cpp
@@ -473,24 +473,22 @@ const CGHeroInstance * CBattleInfoEssentials::battleGetOwnerHero(const battle::U
 	return getBattle()->getSideHero(side);
 }
 
-bool CBattleInfoEssentials::battleMatchOwner(const battle::Unit * attacker, const battle::Unit * defender, const boost::logic::tribool positivness) const
+bool CBattleInfoEssentials::battleMatchOwner(const battle::Unit * attacker, const battle::Unit * defender, const bool sameOwner) const
 {
 	RETURN_IF_NOT_BATTLE(false);
-	if(boost::logic::indeterminate(positivness))
-		return true;
-	else if(attacker->unitId() == defender->unitId())
-		return (bool)positivness;
+	if(attacker->unitId() == defender->unitId())
+		return sameOwner;
 	else
-		return battleMatchOwner(battleGetOwner(attacker), defender, positivness);
+		return battleMatchOwner(battleGetOwner(attacker), defender, sameOwner);
 }
 
-bool CBattleInfoEssentials::battleMatchOwner(const PlayerColor & attacker, const battle::Unit * defender, const boost::logic::tribool positivness) const
+bool CBattleInfoEssentials::battleMatchOwner(const PlayerColor & attacker, const battle::Unit * defender, const bool sameOwner) const
 {
 	RETURN_IF_NOT_BATTLE(false);
 
 	PlayerColor initialOwner = getBattle()->getSidePlayer(defender->unitSide());
 
-	return boost::logic::indeterminate(positivness) || (attacker == initialOwner) == (bool)positivness;
+	return (attacker == initialOwner) == sameOwner;
 }
 
 VCMI_LIB_NAMESPACE_END

--- a/lib/battle/CBattleInfoEssentials.h
+++ b/lib/battle/CBattleInfoEssentials.h
@@ -108,10 +108,10 @@ public:
 	///returns hero that controls given stack; nullptr if none; mind control included
 	const CGHeroInstance * battleGetOwnerHero(const battle::Unit * unit) const;
 
-	///check that stacks are controlled by same|other player(s) depending on positiveness
+	///check that stacks are controlled by the same (sameOwner) or opposing (!sameOwner) player(s)
 	///mind control included
-	bool battleMatchOwner(const battle::Unit * attacker, const battle::Unit * defender, const boost::logic::tribool positivness = false) const;
-	bool battleMatchOwner(const PlayerColor & attacker, const battle::Unit * defender, const boost::logic::tribool positivness = false) const;
+	bool battleMatchOwner(const battle::Unit * attacker, const battle::Unit * defender, bool sameOwner = false) const;
+	bool battleMatchOwner(const PlayerColor & attacker, const battle::Unit * defender, bool sameOwner = false) const;
 };
 
 VCMI_LIB_NAMESPACE_END

--- a/lib/battle/Unit.cpp
+++ b/lib/battle/Unit.cpp
@@ -244,26 +244,20 @@ BattleHex Unit::occupiedHex(const BattleHex & assumedPos, bool twoHex, BattleSid
 	}
 }
 
-void Unit::addText(MetaString & text, EMetaText type, int32_t serial, const boost::logic::tribool & plural) const
+void Unit::addText(MetaString & text, EMetaText type, int32_t serial) const
 {
-	if(boost::logic::indeterminate(plural))
-		serial = LIBRARY->generaltexth->pluralText(serial, getCount());
-	else if(plural)
-		serial = LIBRARY->generaltexth->pluralText(serial, 2);
-	else
-		serial = LIBRARY->generaltexth->pluralText(serial, 1);
-
+	serial = LIBRARY->generaltexth->pluralText(serial, getCount());
 	text.appendLocalString(type, serial);
 }
 
-void Unit::addNameReplacement(MetaString & text, const boost::logic::tribool & plural) const
+void Unit::addNameReplacement(MetaString & text) const
 {
-	if(boost::logic::indeterminate(plural))
-		text.replaceName(creatureId(), getCount());
-	else if(plural)
-		text.replaceNamePlural(creatureIndex());
-	else
-		text.replaceNameSingular(creatureIndex());
+	addNameReplacement(text, getCount());
+}
+
+void Unit::addNameReplacement(MetaString & text, TQuantity count) const
+{
+	text.replaceName(creatureId(), count);
 }
 
 std::string Unit::formatGeneralMessage(const int32_t baseTextId) const

--- a/lib/battle/Unit.h
+++ b/lib/battle/Unit.h
@@ -160,8 +160,9 @@ public:
 	static BattleHex occupiedHex(const BattleHex & assumedPos, bool twoHex, BattleSide side);
 
 	///MetaStrings
-	void addText(MetaString & text, EMetaText type, int32_t serial, const boost::logic::tribool & plural = boost::logic::indeterminate) const;
-	void addNameReplacement(MetaString & text, const boost::logic::tribool & plural = boost::logic::indeterminate) const;
+	void addText(MetaString & text, EMetaText type, int32_t serial) const;
+	void addNameReplacement(MetaString & text) const;
+	void addNameReplacement(MetaString & text, TQuantity count) const;
 	std::string formatGeneralMessage(const int32_t baseTextId) const;
 
 	int getRawSurrenderCost() const;

--- a/lib/filesystem/FileInfo.cpp
+++ b/lib/filesystem/FileInfo.cpp
@@ -16,49 +16,49 @@ VCMI_LIB_NAMESPACE_BEGIN
 namespace FileInfo
 {
 
-boost::string_ref GetFilename(boost::string_ref path)
+std::string_view GetFilename(std::string_view path)
 {
 	const auto pos = path.find_last_of("/\\");
 
-	if (pos != boost::string_ref::npos)
+	if (pos != std::string_view::npos)
 		return path.substr(pos + 1);
 
 	return path;
 }
 
-boost::string_ref GetExtension(boost::string_ref path)
+std::string_view GetExtension(std::string_view path)
 {
 	const auto dotPos = path.find_last_of('.');
 
-	if(dotPos != boost::string_ref::npos)
+	if(dotPos != std::string_view::npos)
 		return path.substr(dotPos);
 
-	return boost::string_ref{};
+	return std::string_view{};
 }
 
-boost::string_ref GetStem(boost::string_ref path)
+std::string_view GetStem(std::string_view path)
 {
 	auto begin	= path.find_last_of("/\\");
 	auto end	= path.find_last_of('.');
 
-	if (begin == boost::string_ref::npos)
+	if (begin == std::string_view::npos)
 		begin = 0;
 	else
 		begin += 1;
 
 	if (end < begin)
-		end = boost::string_ref::npos;
+		end = std::string_view::npos;
 
 	return path.substr(begin, end);
 }
 
-boost::string_ref GetParentPath(boost::string_ref path)
+std::string_view GetParentPath(std::string_view path)
 {
 	const auto pos = path.find_last_of("/\\");
 	return path.substr(0, pos);
 }
 
-boost::string_ref GetPathStem(boost::string_ref path)
+std::string_view GetPathStem(std::string_view path)
 {
 	const auto dotPos = path.find_last_of('.');
 	return path.substr(0, dotPos);

--- a/lib/filesystem/FileInfo.h
+++ b/lib/filesystem/FileInfo.h
@@ -9,8 +9,6 @@
  */
 #pragma once
 
-#include <boost/utility/string_ref.hpp>
-
 VCMI_LIB_NAMESPACE_BEGIN
 
 namespace FileInfo
@@ -21,35 +19,35 @@ namespace FileInfo
  *
  * @return the name of the file. E.g. foo.txt
  */
-boost::string_ref DLL_LINKAGE GetFilename(boost::string_ref path);
+std::string_view DLL_LINKAGE GetFilename(std::string_view path);
 
 /**
  * Gets the file extension.
  *
  * @return the file extension. E.g. .ext
  */
-boost::string_ref DLL_LINKAGE GetExtension(boost::string_ref path);
+std::string_view DLL_LINKAGE GetExtension(std::string_view path);
 
 /**
  * Gets the file name exclusive the extension of the file.
  *
  * @return the file name exclusive the extension and the path of the file. E.g. foo
  */
-boost::string_ref DLL_LINKAGE GetStem(boost::string_ref path);
+std::string_view DLL_LINKAGE GetStem(std::string_view path);
 
 /**
  * Gets the path to the file only.
  *
  * @return the path to the file only. E.g. ./dir/
  */
-boost::string_ref DLL_LINKAGE GetParentPath(boost::string_ref path);
+std::string_view DLL_LINKAGE GetParentPath(std::string_view path);
 
 /**
  * Gets the file name + path exclusive the extension of the file.
  *
  * @return the file name exclusive the extension of the file. E.g. ./dir/foo
  */
-boost::string_ref DLL_LINKAGE GetPathStem(boost::string_ref path);
+std::string_view DLL_LINKAGE GetPathStem(std::string_view path);
 
 }
 

--- a/lib/filesystem/ResourcePath.cpp
+++ b/lib/filesystem/ResourcePath.cpp
@@ -23,7 +23,7 @@ static inline void toUpper(std::string & string)
 
 static inline EResType readType(const std::string& name)
 {
-	return EResTypeHelper::getTypeFromExtension(FileInfo::GetExtension(name).to_string());
+	return EResTypeHelper::getTypeFromExtension(std::string(FileInfo::GetExtension(name)));
 }
 
 static inline std::string readName(std::string name, bool uppercase)

--- a/lib/json/JsonNode.cpp
+++ b/lib/json/JsonNode.cpp
@@ -15,7 +15,6 @@
 #include "JsonWriter.h"
 #include "filesystem/Filesystem.h"
 
-#include <boost/lexical_cast.hpp>
 
 // to avoid duplicating const and non-const code
 template<typename Node>
@@ -38,7 +37,7 @@ Node & resolvePointer(Node & in, const std::string & pointer)
 		if(entry.size() > 1 && entry[0] == '0') // leading zeros are not allowed
 			throw std::runtime_error("Invalid Json pointer");
 
-		auto index = boost::lexical_cast<size_t>(entry);
+		auto index = std::stoull(entry);
 
 		if(in.Vector().size() > index)
 			return in.Vector()[index].resolvePointer(remainder);

--- a/lib/logging/CLogger.cpp
+++ b/lib/logging/CLogger.cpp
@@ -12,6 +12,8 @@
 #include "../CThreadHelper.h"
 #include "../CConsoleHandler.h"
 
+#include <vstd/DateUtils.h>
+
 #ifdef VCMI_ANDROID
 #include <android/log.h>
 
@@ -259,9 +261,6 @@ std::string CLogFormatter::format(const LogRecord & record) const
 {
 	std::string message = pattern;
 
-	//Format date
-//	boost::algorithm::replace_first(message, "%d", boost::posix_time::to_simple_string (record.timeStamp));
-
 	//Format log level
 	std::string level;
 	switch(record.level)
@@ -288,7 +287,11 @@ std::string CLogFormatter::format(const LogRecord & record) const
 	boost::algorithm::replace_first(message, "%n", record.domain.getName());
 	boost::algorithm::replace_first(message, "%t", record.threadId);
 	boost::algorithm::replace_first(message, "%m", record.message);
-	boost::algorithm::replace_first(message, "%c", boost::posix_time::to_simple_string(record.timeStamp));
+
+	auto milliseconds = std::chrono::duration_cast<std::chrono::milliseconds>(record.timeStamp.time_since_epoch()) % 1000;
+	std::string dateTime = vstd::getFormattedDateTime(std::chrono::system_clock::to_time_t(record.timeStamp), "%Y-%m-%d %H:%M:%S");
+	std::string milliStr = std::to_string(milliseconds.count());
+	boost::algorithm::replace_first(message, "%c", dateTime + '.' + std::string(3 - milliStr.size(), '0') + milliStr);
 
 	//return boost::str (boost::format("%d %d %d[%d] - %d") % dateStream.str() % level % record.domain.getName() % record.threadId % record.message);
 
@@ -451,7 +454,7 @@ LogRecord::LogRecord(const CLoggerDomain & domain, ELogLevel::ELogLevel level, c
 	: domain(domain),
 	level(level),
 	message(message),
-	timeStamp(boost::posix_time::microsec_clock::local_time()),
+	timeStamp(std::chrono::system_clock::now()),
 	threadId(getThreadName())
 {
 

--- a/lib/logging/CLogger.h
+++ b/lib/logging/CLogger.h
@@ -10,10 +10,6 @@
 #pragma once
 
 
-#include <boost/date_time/posix_time/posix_time_types.hpp>
-#include <boost/date_time/posix_time/time_formatters.hpp>
-
-
 VCMI_LIB_NAMESPACE_BEGIN
 
 class CLogger;
@@ -116,7 +112,7 @@ struct DLL_LINKAGE LogRecord
 	CLoggerDomain domain;
 	ELogLevel::ELogLevel level;
 	std::string message;
-	boost::posix_time::ptime timeStamp;
+	std::chrono::system_clock::time_point timeStamp;
 	std::string threadId;
 };
 

--- a/lib/mapObjects/CGHeroInstance.cpp
+++ b/lib/mapObjects/CGHeroInstance.cpp
@@ -880,7 +880,7 @@ void CGHeroInstance::getCastDescription(const spells::Spell * spell, const battl
 	text.replaceTextID(getCasterNameTextID());
 	text.replaceName(spell->getId());
 	if(singleTarget)
-		attacked.at(0)->addNameReplacement(text, true);
+		attacked.at(0)->addNameReplacement(text, 2);
 }
 
 const CGHeroInstance * CGHeroInstance::getHeroCaster() const

--- a/lib/mapObjects/CGTownInstance.cpp
+++ b/lib/mapObjects/CGTownInstance.cpp
@@ -1082,7 +1082,7 @@ void CGTownInstance::serializeJsonOptions(JsonSerializeFormat & handler)
 		{
 			bool customBuildings = false;
 
-			boost::logic::tribool hasFort(false);
+			bool hasFort = false;
 
 			for(const BuildingID & id : forbiddenBuildings)
 			{

--- a/lib/mapObjects/ObjectTemplate.cpp
+++ b/lib/mapObjects/ObjectTemplate.cpp
@@ -21,7 +21,6 @@
 #include "../mapObjectConstructors/CRewardableConstructor.h"
 #include "../modding/IdentifierStorage.h"
 
-#include <boost/lexical_cast.hpp>
 
 VCMI_LIB_NAMESPACE_BEGIN
 
@@ -117,10 +116,10 @@ void ObjectTemplate::readTxt(CLegacyConfigParser & parser)
 	//assuming that object can be placed on other land terrains
 	anyLandTerrain = allowedTerrains.size() >= 8 && !allowedTerrains.count(ETerrainId::WATER);
 
-	id    = Obj(boost::lexical_cast<int>(strings[5]));
-	subid = boost::lexical_cast<int>(strings[6]);
-	int type  = boost::lexical_cast<int>(strings[7]);
-	printPriority = boost::lexical_cast<int>(strings[8]) * 100; // to have some space in future
+	id    = Obj(std::stoi(strings[5]));
+	subid = std::stoi(strings[6]);
+	int type  = std::stoi(strings[7]);
+	printPriority = std::stoi(strings[8]) * 100; // to have some space in future
 
 	if (isOnVisitableFromTopList(id, type))
 		visitDir = 0xff;

--- a/lib/mapping/MapEditUtils.cpp
+++ b/lib/mapping/MapEditUtils.cpp
@@ -17,7 +17,6 @@
 #include "CMap.h"
 #include "CMapOperation.h"
 
-#include <boost/lexical_cast.hpp>
 
 VCMI_LIB_NAMESPACE_BEGIN
 
@@ -203,7 +202,7 @@ CTerrainViewPatternConfig::CTerrainViewPatternConfig()
 					assert(!rule.name.empty());
 					if (ruleParts.size() > 1)
 					{
-						rule.points = boost::lexical_cast<int>(ruleParts[1]);
+						rule.points = std::stoi(ruleParts[1]);
 					}
 					pattern.data[j].push_back(rule);
 				}
@@ -232,7 +231,7 @@ CTerrainViewPatternConfig::CTerrainViewPatternConfig()
 					terGroupPattern.diffImages = TerrainViewPattern::FLIP_MODE_DIFF_IMAGES == &(flipMode[flipMode.length() - 1]);
 					if (terGroupPattern.diffImages)
 					{
-						terGroupPattern.rotationTypesCount = boost::lexical_cast<int>(flipMode.substr(0, flipMode.length() - 1));
+						terGroupPattern.rotationTypesCount = std::stoi(flipMode.substr(0, flipMode.length() - 1));
 						assert(terGroupPattern.rotationTypesCount == 2 || terGroupPattern.rotationTypesCount == 4);
 					}
 					mappingStr = mappingStr.substr(colonIndex + 1);

--- a/lib/pathfinder/CPathfinder.cpp
+++ b/lib/pathfinder/CPathfinder.cpp
@@ -63,7 +63,6 @@ void CPathfinderHelper::calculateNeighbourTiles(NeighbourTilesVector & result, c
 		*source.tile,
 		source.node->coord,
 		result,
-		boost::logic::indeterminate,
 		source.node->layer == EPathfindingLayer::SAIL);
 
 	if(source.isNodeObjectVisitable())
@@ -589,7 +588,6 @@ void CPathfinderHelper::getNeighbours(
 	const TerrainTile & sourceTile,
 	const int3 & srcCoord,
 	NeighbourTilesVector & vec,
-	const boost::logic::tribool & onLand,
 	const bool limitCoastSailing) const
 {
 	const TerrainType * sourceTerrain = sourceTile.getTerrain();
@@ -620,10 +618,7 @@ void CPathfinderHelper::getNeighbours(
 				continue;
 		}
 
-		if(indeterminate(onLand) || onLand == destTerrain->isLand())
-		{
-			vec.push_back(destCoord);
-		}
+		vec.push_back(destCoord);
 	}
 }
 
@@ -666,21 +661,9 @@ int CPathfinderHelper::getMovementCost(
 		dt = hero->cb->getTile(dst);
 	}
 
-	boost::logic::tribool isDstSailLayer = dstLayer == EPathfindingLayer::SAIL;
-	boost::logic::tribool isDstWaterLayer = dstLayer == EPathfindingLayer::WATER;
+	bool isSailLayer = dstLayer == EPathfindingLayer::SAIL;
+	bool isWaterLayer = dstLayer == EPathfindingLayer::WATER;
 
-	bool isSailLayer;
-	if(indeterminate(isDstSailLayer))
-		isSailLayer = hero->inBoat() && hero->getBoat()->layer == EPathfindingLayer::SAIL && dt->isWater();
-	else
-		isSailLayer = static_cast<bool>(isDstSailLayer);
-
-	bool isWaterLayer;
-	if(indeterminate(isDstWaterLayer))
-		isWaterLayer = ((hero->inBoat() && hero->getBoat()->layer == EPathfindingLayer::WATER) || ti->hasWaterWalking()) && dt->isWater();
-	else
-		isWaterLayer = static_cast<bool>(isDstWaterLayer);
-	
 	bool isAirLayer = (hero->inBoat() && hero->getBoat()->layer == EPathfindingLayer::AIR) || ti->hasFlyingMovement();
 
 	bool isAviateLayer = hero->inBoat() && hero->getBoat()->layer == EPathfindingLayer::AVIATE;

--- a/lib/pathfinder/CPathfinder.h
+++ b/lib/pathfinder/CPathfinder.h
@@ -118,7 +118,6 @@ public:
 		const TerrainTile & srcTile,
 		const int3 & srcCoord,
 		NeighbourTilesVector & vec,
-		const boost::logic::tribool & onLand,
 		const bool limitCoastSailing) const;
 
 	int getMovementCost(

--- a/lib/rmg/CRmgTemplate.cpp
+++ b/lib/rmg/CRmgTemplate.cpp
@@ -10,7 +10,6 @@
 
 #include "StdInc.h"
 #include <vstd/ContainerUtils.h>
-#include <boost/bimap.hpp>
 #include "CRmgTemplate.h"
 #include "Functions.h"
 
@@ -913,10 +912,11 @@ void CRmgTemplate::serializeJson(JsonSerializeFormat & handler)
 	}
 	
 	{
-		boost::bimap<EWaterContent::EWaterContent, std::string> enc;
-		enc.insert({EWaterContent::NONE, "none"});
-		enc.insert({EWaterContent::NORMAL, "normal"});
-		enc.insert({EWaterContent::ISLANDS, "islands"});
+		static const std::array<std::pair<EWaterContent::EWaterContent, std::string>, 3> waterContentNames{{
+			{EWaterContent::NONE, "none"},
+			{EWaterContent::NORMAL, "normal"},
+			{EWaterContent::ISLANDS, "islands"},
+		}};
 		JsonNode node;
 		if(handler.saving)
 		{
@@ -924,7 +924,9 @@ void CRmgTemplate::serializeJson(JsonSerializeFormat & handler)
 			for(auto wc : allowedWaterContent)
 			{
 				JsonNode n;
-				n.String() = enc.left.at(wc);
+				for(const auto & [value, name] : waterContentNames)
+					if(value == wc)
+						n.String() = name;
 				node.Vector().push_back(n);
 			}
 		}
@@ -933,7 +935,9 @@ void CRmgTemplate::serializeJson(JsonSerializeFormat & handler)
 		{
 			for(auto wc : node.Vector())
 			{
-				allowedWaterContent.insert(enc.right.at(std::string(wc.String())));
+				for(const auto & [value, name] : waterContentNames)
+					if(name == wc.String())
+						allowedWaterContent.insert(value);
 			}
 		}
 	}

--- a/lib/rmg/CRmgTemplate.cpp
+++ b/lib/rmg/CRmgTemplate.cpp
@@ -22,7 +22,6 @@
 #include "../modding/ModScope.h"
 #include "../serializer/JsonSerializeFormat.h"
 
-#include <boost/lexical_cast.hpp>
 
 
 VCMI_LIB_NAMESPACE_BEGIN
@@ -31,7 +30,7 @@ namespace
 {
 	si32 decodeZoneId(const std::string & json)
 	{
-		return boost::lexical_cast<si32>(json);
+		return std::stoi(json);
 	}
 
 	std::string encodeZoneId(si32 id)
@@ -855,13 +854,13 @@ void CRmgTemplate::CPlayerCountRange::fromString(const std::string & value)
 			boost::split(rangeParts, commaPart, boost::is_any_of("-"));
 			if(rangeParts.size() == 2)
 			{
-				auto lower = boost::lexical_cast<int>(rangeParts[0]);
-				auto upper = boost::lexical_cast<int>(rangeParts[1]);
+				auto lower = std::stoi(rangeParts[0]);
+				auto upper = std::stoi(rangeParts[1]);
 				addRange(lower, upper);
 			}
 			else if(rangeParts.size() == 1)
 			{
-				auto val = boost::lexical_cast<int>(rangeParts.front());
+				auto val = std::stoi(rangeParts.front());
 				addNumber(val);
 			}
 		}
@@ -1125,9 +1124,9 @@ void CRmgTemplate::serializeSize(JsonSerializeFormat & handler, int3 & value, co
 			std::vector<std::string> parts;
 			boost::split(parts, encodedValue, boost::is_any_of("x"));
 
-			value.x = (boost::lexical_cast<int>(parts.at(0)));
-			value.y = (boost::lexical_cast<int>(parts.at(1)));
-			value.z = (boost::lexical_cast<int>(parts.at(2)));
+			value.x = (std::stoi(parts.at(0)));
+			value.y = (std::stoi(parts.at(1)));
+			value.z = (std::stoi(parts.at(2)));
 		}
 		else
 		{

--- a/lib/rmg/ObjectConfig.cpp
+++ b/lib/rmg/ObjectConfig.cpp
@@ -10,7 +10,6 @@
 
 #include "StdInc.h"
 #include <boost/bimap.hpp>
-#include <boost/assign.hpp>
 #include "ObjectInfo.h"
 #include "ObjectConfig.h"
 

--- a/lib/rmg/ObjectConfig.cpp
+++ b/lib/rmg/ObjectConfig.cpp
@@ -9,7 +9,6 @@
  */
 
 #include "StdInc.h"
-#include <boost/bimap.hpp>
 #include "ObjectInfo.h"
 #include "ObjectConfig.h"
 

--- a/lib/serializer/JsonDeserializer.cpp
+++ b/lib/serializer/JsonDeserializer.cpp
@@ -20,11 +20,11 @@ JsonDeserializer::JsonDeserializer(const IInstanceResolver * instanceResolver_, 
 
 }
 
-void JsonDeserializer::serializeInternal(const std::string & fieldName, boost::logic::tribool & value)
+void JsonDeserializer::serializeInternal(const std::string & fieldName, std::optional<bool> & value)
 {
 	const JsonNode & data = currentObject->operator[](fieldName);
 	if(data.getType() != JsonNode::JsonType::DATA_BOOL)
-		value = boost::logic::indeterminate;
+		value = std::nullopt;
 	else
 		value = data.Bool();
 }

--- a/lib/serializer/JsonDeserializer.h
+++ b/lib/serializer/JsonDeserializer.h
@@ -25,7 +25,7 @@ public:
 	void serializeRaw(const std::string & fieldName, JsonNode & value, const std::optional<std::reference_wrapper<const JsonNode>> defaultValue) override;
 
 protected:
-	void serializeInternal(const std::string & fieldName, boost::logic::tribool & value) override;
+	void serializeInternal(const std::string & fieldName, std::optional<bool> & value) override;
 	void serializeInternal(const std::string & fieldName, si32 & value, const std::optional<si32> & defaultValue, const TDecoder & decoder, const TEncoder & encoder)	override;
 	void serializeInternal(const std::string & fieldName, std::vector<si32> & value, const TDecoder & decoder, const TEncoder & encoder) override;
 	void serializeInternal(const std::string & fieldName, double & value, const std::optional<double> & defaultValue) override;

--- a/lib/serializer/JsonSerializeFormat.h
+++ b/lib/serializer/JsonSerializeFormat.h
@@ -165,10 +165,10 @@ public:
 	template <typename T>
 	void serializeBool(const std::string & fieldName, T & value, const T trueValue, const T falseValue, const T defaultValue)
 	{
-		boost::logic::tribool temp(boost::logic::indeterminate);
+		std::optional<bool> temp; //nullopt = field absent / default
 
 		if(value == defaultValue)
-			;//leave as indeterminate
+			;//leave as nullopt
 		else if(value == trueValue)
 			temp = true;
 		else if(value == falseValue)
@@ -177,22 +177,16 @@ public:
 		serializeInternal(fieldName, temp);
 		if(!saving)
 		{
-			if(boost::logic::indeterminate(temp))
+			if(!temp.has_value())
 				value = defaultValue;
 			else
-				value = temp ? trueValue : falseValue;
+				value = *temp ? trueValue : falseValue;
 		}
 	}
 
 	///bool <-> Json bool
 	void serializeBool(const std::string & fieldName, bool & value);
 	void serializeBool(const std::string & fieldName, bool & value, const bool defaultValue);
-
-	///tribool <-> Json bool
-	void serializeBool(const std::string & fieldName, boost::logic::tribool & value)
-	{
-		serializeInternal(fieldName, value);
-	};
 
 	/** @brief Restrictive ("anyOf") simple serialization of Logical identifier condition, simple deserialization (allOf=anyOf)
 	 *
@@ -448,7 +442,7 @@ protected:
 	JsonSerializeFormat(const IInstanceResolver * instanceResolver_, const bool saving_, const bool updating_);
 
 	///bool <-> Json bool, indeterminate is default
-	virtual void serializeInternal(const std::string & fieldName, boost::logic::tribool & value) = 0;
+	virtual void serializeInternal(const std::string & fieldName, std::optional<bool> & value) = 0;
 
 	///Numeric Id <-> String Id
 	virtual void serializeInternal(const std::string & fieldName, si32 & value, const std::optional<si32> & defaultValue, const TDecoder & decoder, const TEncoder & encoder) = 0;

--- a/lib/serializer/JsonSerializer.cpp
+++ b/lib/serializer/JsonSerializer.cpp
@@ -18,10 +18,10 @@ JsonSerializer::JsonSerializer(const IInstanceResolver * instanceResolver_, Json
 
 }
 
-void JsonSerializer::serializeInternal(const std::string & fieldName, boost::logic::tribool & value)
+void JsonSerializer::serializeInternal(const std::string & fieldName, std::optional<bool> & value)
 {
-	if(!boost::logic::indeterminate(value))
-		currentObject->operator[](fieldName).Bool() = (bool)value;
+	if(value.has_value())
+		currentObject->operator[](fieldName).Bool() = *value;
 }
 
 void JsonSerializer::serializeInternal(const std::string & fieldName, si32 & value, const std::optional<si32> & defaultValue, const TDecoder & decoder, const TEncoder & encoder)

--- a/lib/serializer/JsonSerializer.h
+++ b/lib/serializer/JsonSerializer.h
@@ -25,7 +25,7 @@ public:
 	void serializeRaw(const std::string & fieldName, JsonNode & value, const std::optional<std::reference_wrapper<const JsonNode>> defaultValue) override;
 
 protected:
-	void serializeInternal(const std::string & fieldName, boost::logic::tribool & value) override;
+	void serializeInternal(const std::string & fieldName, std::optional<bool> & value) override;
 	void serializeInternal(const std::string & fieldName, si32 & value, const std::optional<si32> & defaultValue, const TDecoder & decoder, const TEncoder & encoder)	override;
 	void serializeInternal(const std::string & fieldName, std::vector<si32> & value, const TDecoder & decoder, const TEncoder & encoder) override;
 	void serializeInternal(const std::string & fieldName, double & value, const std::optional<double> & defaultValue) override;

--- a/lib/serializer/JsonUpdater.cpp
+++ b/lib/serializer/JsonUpdater.cpp
@@ -22,7 +22,7 @@ JsonUpdater::JsonUpdater(const IInstanceResolver * instanceResolver_, const Json
 
 }
 
-void JsonUpdater::serializeInternal(const std::string & fieldName, boost::logic::tribool & value)
+void JsonUpdater::serializeInternal(const std::string & fieldName, std::optional<bool> & value)
 {
 	const JsonNode & data = currentObject->operator[](fieldName);
 	if(data.getType() == JsonNode::JsonType::DATA_BOOL)

--- a/lib/serializer/JsonUpdater.h
+++ b/lib/serializer/JsonUpdater.h
@@ -29,7 +29,7 @@ public:
 	void serializeBonuses(const std::string & fieldName, CBonusSystemNode * value);
 
 protected:
-	void serializeInternal(const std::string & fieldName, boost::logic::tribool & value) override;
+	void serializeInternal(const std::string & fieldName, std::optional<bool> & value) override;
 	void serializeInternal(const std::string & fieldName, si32 & value, const std::optional<si32> & defaultValue, const TDecoder & decoder, const TEncoder & encoder)	override;
 	void serializeInternal(const std::string & fieldName, std::vector<si32> & value, const TDecoder & decoder, const TEncoder & encoder) override;
 	void serializeInternal(const std::string & fieldName, double & value, const std::optional<double> & defaultValue) override;

--- a/lib/spells/BattleSpellMechanics.cpp
+++ b/lib/spells/BattleSpellMechanics.cpp
@@ -296,7 +296,7 @@ bool BattleSpellMechanics::canBeCastAt(const Target & target, Problem & problem)
 		if(mainTarget && mainTarget == caster)
 			return false; // can't cast on self
 
-		if(mainTarget && mainTarget->isInvincible() && !getSpell()->getPositiveness())
+		if(mainTarget && mainTarget->isInvincible() && getSpell()->isNegative())
 			return false;
 	}
 	else if(getSpell()->canCastOnlyOnSelf())

--- a/lib/spells/BonusCaster.cpp
+++ b/lib/spells/BonusCaster.cpp
@@ -61,7 +61,7 @@ void BonusCaster::getCastDescription(const Spell * spell, const battle::Units & 
 	text.replaceTextID(getCasterNameTextID());
 	text.replaceName(spell->getId());
 	if(singleTarget)
-		attacked.at(0)->addNameReplacement(text, true);
+		attacked.at(0)->addNameReplacement(text, 2);
 }
 
 void BonusCaster::spendMana(ServerCallback * server, const int spellCost) const

--- a/lib/spells/CSpell.cpp
+++ b/lib/spells/CSpell.cpp
@@ -38,7 +38,6 @@ CSpell::CSpell():
 	castOnSelf(false),
 	castOnlyOnSelf(false),
 	castWithoutSkip(false),
-	positiveness(ESpellPositiveness::NEUTRAL),
 	defaultProbability(0),
 	rising(false),
 	damage(false),
@@ -205,35 +204,22 @@ bool CSpell::isMagical() const
 
 bool CSpell::isPositive() const
 {
-	return positiveness == POSITIVE;
+	return positive;
 }
 
 bool CSpell::isNegative() const
 {
-	return positiveness == NEGATIVE;
+	return negative;
 }
 
 bool CSpell::isNeutral() const
 {
-	return positiveness == NEUTRAL;
+	return !positive && !negative;
 }
 
 bool CSpell::isPersistent() const
 {
 	return persistent;
-}
-
-boost::logic::tribool CSpell::getPositiveness() const
-{
-	switch (positiveness)
-	{
-	case CSpell::POSITIVE:
-		return true;
-	case CSpell::NEGATIVE:
-		return false;
-	default:
-		return boost::logic::indeterminate;
-	}
 }
 
 bool CSpell::isDamage() const
@@ -423,7 +409,8 @@ void CSpell::setIsOffensive(const bool val)
 
 	if(val)
 	{
-		positiveness = CSpell::NEGATIVE;
+		positive = false;
+		negative = true;
 		damage = true;
 	}
 }
@@ -434,7 +421,8 @@ void CSpell::setIsRising(const bool val)
 
 	if(val)
 	{
-		positiveness = CSpell::POSITIVE;
+		positive = true;
+		negative = false;
 	}
 }
 

--- a/lib/spells/CSpell.h
+++ b/lib/spells/CSpell.h
@@ -98,13 +98,6 @@ public:
 	std::string identifier;
 	std::string modScope;
 public:
-	enum ESpellPositiveness
-	{
-		NEGATIVE = -1,
-		NEUTRAL = 0,
-		POSITIVE = 1
-	};
-
 	struct DLL_LINKAGE TargetInfo
 	{
 		spells::AimType type;
@@ -171,8 +164,6 @@ public:
 	std::string getAdventureEffectTextID(const std::string & effectType, const std::string & field) const;
 
 	int32_t getLevel() const override;
-
-	boost::logic::tribool getPositiveness() const override;
 
 	bool isPositive() const override;
 	bool isNegative() const override;
@@ -266,7 +257,8 @@ private:
 	bool castOnSelf; // if set, creature caster can cast this spell on itself
 	bool castOnlyOnSelf; // if set, creature caster can cast this spell on itself
 	bool castWithoutSkip; // if set the creature will not skip the turn after casting a spell
-	si8 positiveness; //1 if spell is positive for influenced stacks, 0 if it is indifferent, -1 if it's negative
+	bool positive = false; // spell is beneficial for influenced stacks
+	bool negative = false; // spell is harmful for influenced stacks; neither set means indifferent
 
 	std::unique_ptr<spells::ISpellMechanicsFactory> mechanics;//(!) do not serialize
 	std::unique_ptr<IAdventureSpellMechanics> adventureMechanics;//(!) do not serialize

--- a/lib/spells/CSpellHandler.cpp
+++ b/lib/spells/CSpellHandler.cpp
@@ -304,19 +304,23 @@ std::shared_ptr<CSpell> CSpellHandler::loadFromJson(const std::string & scope, c
 
 	if(flags["indifferent"].Bool())
 	{
-		spell->positiveness = CSpell::NEUTRAL;
+		spell->positive = false;
+		spell->negative = false;
 	}
 	else if(flags["negative"].Bool())
 	{
-		spell->positiveness = CSpell::NEGATIVE;
+		spell->positive = false;
+		spell->negative = true;
 	}
 	else if(flags["positive"].Bool())
 	{
-		spell->positiveness = CSpell::POSITIVE;
+		spell->positive = true;
+		spell->negative = false;
 	}
 	else if(!implicitPositiveness)
 	{
-		spell->positiveness = CSpell::NEUTRAL; //duplicates constructor but, just in case
+		spell->positive = false; //duplicates constructor but, just in case
+		spell->negative = false;
 		logMod->error("Spell %s: no positiveness specified, assumed NEUTRAL.", spell->getNameTranslated());
 	}
 

--- a/lib/spells/ISpellMechanics.cpp
+++ b/lib/spells/ISpellMechanics.cpp
@@ -129,9 +129,7 @@ BattleCast::BattleCast(const CBattleInfoCallback * cb_, const Caster * caster_, 
 	spell(spell_),
 	cb(cb_),
 	caster(caster_),
-	mode(mode_),
-	smart(boost::logic::indeterminate),
-	massive(boost::logic::indeterminate)
+	mode(mode_)
 {
 }
 
@@ -177,14 +175,9 @@ BattleCast::OptionalValue64 BattleCast::getEffectValue() const
 	return effectValue;
 }
 
-boost::logic::tribool BattleCast::isSmart() const
+bool BattleCast::isForceMassive() const
 {
-	return smart;
-}
-
-boost::logic::tribool BattleCast::isMassive() const
-{
-	return massive;
+	return forceMassive;
 }
 
 void BattleCast::setSpellLevel(BattleCast::Value value)
@@ -278,8 +271,7 @@ Mechanics::~Mechanics() = default;
 BaseMechanics::BaseMechanics(const IBattleCast * event):
 	owner(event->getSpell()),
 	mode(event->getMode()),
-	smart(event->isSmart()),
-	massive(event->isMassive()),
+	forceMassive(event->isForceMassive()),
 	cb(event->getBattle())
 {
 	caster = event->getCaster();
@@ -415,28 +407,17 @@ int32_t BaseMechanics::getSpellLevel() const
 
 bool BaseMechanics::isSmart() const
 {
-	if(boost::logic::indeterminate(smart))
-	{
-		const CSpell::TargetInfo targetInfo(owner, getRangeLevel(), mode);
-		return targetInfo.smart;
-	}
-	else
-	{
-		return (bool)smart;
-	}
+	const CSpell::TargetInfo targetInfo(owner, getRangeLevel(), mode);
+	return targetInfo.smart;
 }
 
 bool BaseMechanics::isMassive() const
 {
-	if(boost::logic::indeterminate(massive))
-	{
-		const CSpell::TargetInfo targetInfo(owner, getRangeLevel(), mode);
-		return targetInfo.massive;
-	}
-	else
-	{
-		return (bool)massive;
-	}
+	if(forceMassive)
+		return true;
+
+	const CSpell::TargetInfo targetInfo(owner, getRangeLevel(), mode);
+	return targetInfo.massive;
 }
 
 bool BaseMechanics::requiresClearTiles() const
@@ -497,12 +478,15 @@ Target BaseMechanics::canonicalizeTarget(const Target & aim) const
 
 bool BaseMechanics::ownerMatches(const battle::Unit * unit) const
 {
-	return ownerMatches(unit, owner->getPositiveness());
+	if(owner->isNeutral())
+		return true; // neutral spell: no ownership filtering
+
+	return ownerMatches(unit, owner->isPositive());
 }
 
-bool BaseMechanics::ownerMatches(const battle::Unit * unit, const boost::logic::tribool positivness) const
+bool BaseMechanics::ownerMatches(const battle::Unit * unit, const bool sameOwner) const
 {
-	return cb->battleMatchOwner(caster->getCasterOwner(), unit, positivness);
+	return cb->battleMatchOwner(caster->getCasterOwner(), unit, sameOwner);
 }
 
 IBattleCast::Value BaseMechanics::getEffectLevel() const

--- a/lib/spells/ISpellMechanics.h
+++ b/lib/spells/ISpellMechanics.h
@@ -92,16 +92,14 @@ public:
 
 	virtual OptionalValue64 getEffectValue() const = 0;
 
-	virtual boost::logic::tribool isSmart() const = 0;
-	virtual boost::logic::tribool isMassive() const = 0;
+	virtual bool isForceMassive() const = 0;
 };
 
 ///all parameters of particular cast event
 class DLL_LINKAGE BattleCast : public IBattleCast
 {
 public:
-	boost::logic::tribool smart;
-	boost::logic::tribool massive;
+	bool forceMassive = false; // force this cast to be massive regardless of the spell default
 
 	//normal constructor
 	BattleCast(const CBattleInfoCallback * cb_, const Caster * caster_, const Mode mode_, const CSpell * spell_);
@@ -121,8 +119,7 @@ public:
 
 	OptionalValue64 getEffectValue() const override;
 
-	boost::logic::tribool isSmart() const override;
-	boost::logic::tribool isMassive() const override;
+	bool isForceMassive() const override;
 
 	void setSpellLevel(Value value);
 
@@ -263,7 +260,7 @@ public:
 
 	//Battle facade
 	virtual bool ownerMatches(const battle::Unit * unit) const = 0;
-	virtual bool ownerMatches(const battle::Unit * unit, const boost::logic::tribool positivness) const = 0;
+	virtual bool ownerMatches(const battle::Unit * unit, bool sameOwner) const = 0;
 
 	//Global environment facade
 	virtual const CreatureService * creatures() const = 0;
@@ -322,7 +319,7 @@ public:
 	Target canonicalizeTarget(const Target & aim) const override;
 
 	bool ownerMatches(const battle::Unit * unit) const override;
-	bool ownerMatches(const battle::Unit * unit, const boost::logic::tribool positivness) const override;
+	bool ownerMatches(const battle::Unit * unit, bool sameOwner) const override;
 
 	std::vector<AimType> getTargetTypes() const override;
 
@@ -351,8 +348,7 @@ private:
 	///raw damage/heal amount
 	IBattleCast::Value64 effectValue;
 
-	boost::logic::tribool smart;
-	boost::logic::tribool massive;
+	bool forceMassive = false;
 
 	const CBattleInfoCallback * cb;
 };

--- a/lib/texts/TextOperations.h
+++ b/lib/texts/TextOperations.h
@@ -9,7 +9,6 @@
  */
 #pragma once
 
-#include <boost/lexical_cast.hpp>
 
 VCMI_LIB_NAMESPACE_BEGIN
 

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -85,7 +85,6 @@
 #include <vcmi/events/GenericEvents.h>
 #include <vcmi/events/AdventureEvents.h>
 
-#include <boost/lexical_cast.hpp>
 
 #define COMPLAIN_RET_IF(cond, txt) do {if (cond){complain(txt); return;}} while(0)
 #define COMPLAIN_RET_FALSE_IF(cond, txt) do {if (cond){complain(txt); return false;}} while(0)
@@ -3983,7 +3982,7 @@ bool CGameHandler::addToSlot(const StackLocation &sl, const CCreature *c, TQuant
 		changeStackCount(sl, count, ChangeValueMode::RELATIVE);
 	else
 	{
-		COMPLAIN_RET("Cannot add " + c->getNamePluralTranslated() + " to slot " + boost::lexical_cast<std::string>(sl.slot) + "!");
+		COMPLAIN_RET("Cannot add " + c->getNamePluralTranslated() + " to slot " + std::to_string(sl.slot.getNum()) + "!");
 	}
 	return true;
 }

--- a/server/battles/BattleFlowProcessor.cpp
+++ b/server/battles/BattleFlowProcessor.cpp
@@ -258,7 +258,7 @@ void BattleFlowProcessor::castOpeningSpells(const CBattleInfoCallback & battle)
 			int32_t spellLevel = b->parameters ? b->parameters->toNumber() : 3;
 			parameters.setSpellLevel(spellLevel);
 			parameters.setEffectDuration(b->val);
-			parameters.massive = true;
+			parameters.forceMassive = true;
 			parameters.castIfPossible(gameHandler->spellcastEnvironment(), spells::Target());
 		}
 	}
@@ -1037,7 +1037,7 @@ void BattleFlowProcessor::stackTurnTrigger(const CBattleInfoCallback & battle, c
 				parameters.setSpellLevel(bonus->val);
 
 				//todo: recheck effect level
-				if(parameters.castIfPossible(gameHandler->spellcastEnvironment(), spells::Target(1, parameters.massive ? spells::Destination() : spells::Destination(st))))
+				if(parameters.castIfPossible(gameHandler->spellcastEnvironment(), spells::Target(1, parameters.forceMassive ? spells::Destination() : spells::Destination(st))))
 				{
 					cast = true;
 

--- a/server/battles/BattleResultProcessor.cpp
+++ b/server/battles/BattleResultProcessor.cpp
@@ -31,7 +31,6 @@
 #include "../../lib/networkPacks/PacksForClientBattle.h"
 
 #include <vcmi/spells/Spell.h>
-#include <boost/lexical_cast.hpp>
 
 BattleResultProcessor::BattleResultProcessor(CGameHandler * gameHandler)
 	: gameHandler(gameHandler)
@@ -268,7 +267,7 @@ void BattleResultProcessor::endBattle(const CBattleInfoCallback & battle)
 	if (!battleQuery)
 	{
 		logGlobal->error("Cannot find battle query!");
-		gameHandler->complain("Player " + boost::lexical_cast<std::string>(battle.sideToPlayer(BattleSide::ATTACKER)) + " has no battle query at the top!");
+		gameHandler->complain("Player " + std::to_string(battle.sideToPlayer(BattleSide::ATTACKER).getNum()) + " has no battle query at the top!");
 		return;
 	}
 

--- a/test/battle/CBattleInfoCallbackTest.cpp
+++ b/test/battle/CBattleInfoCallbackTest.cpp
@@ -855,7 +855,6 @@ TEST_F(BattleMatchOwnerTest, normalToSelf)
 	startBattle();
 
 	EXPECT_TRUE(subject.battleMatchOwner(&unit1, &unit1, true));
-	EXPECT_TRUE(subject.battleMatchOwner(&unit1, &unit1, boost::logic::indeterminate));
 	EXPECT_FALSE(subject.battleMatchOwner(&unit1, &unit1, false));
 }
 
@@ -870,7 +869,6 @@ TEST_F(BattleMatchOwnerTest, hypnotizedToSelf)
 	startBattle();
 
 	EXPECT_TRUE(subject.battleMatchOwner(&unit1, &unit1, true));
-	EXPECT_TRUE(subject.battleMatchOwner(&unit1, &unit1, boost::logic::indeterminate));
 	EXPECT_FALSE(subject.battleMatchOwner(&unit1, &unit1, false));
 }
 
@@ -886,7 +884,6 @@ TEST_F(BattleMatchOwnerTest, normalToNormalAlly)
 	startBattle();
 
 	EXPECT_TRUE(subject.battleMatchOwner(&unit1, &unit2, true));
-	EXPECT_TRUE(subject.battleMatchOwner(&unit1, &unit2, boost::logic::indeterminate));
 	EXPECT_FALSE(subject.battleMatchOwner(&unit1, &unit2, false));
 }
 
@@ -904,7 +901,6 @@ TEST_F(BattleMatchOwnerTest, hypnotizedToNormalAlly)
 	startBattle();
 
 	EXPECT_FALSE(subject.battleMatchOwner(&unit1, &unit2, true));
-	EXPECT_TRUE(subject.battleMatchOwner(&unit1, &unit2, boost::logic::indeterminate));
 	EXPECT_TRUE(subject.battleMatchOwner(&unit1, &unit2, false));
 }
 
@@ -921,7 +917,6 @@ TEST_F(BattleMatchOwnerTest, normalToHypnotizedAlly)
 	startBattle();
 
 	EXPECT_TRUE(subject.battleMatchOwner(&unit1, &unit2, true));
-	EXPECT_TRUE(subject.battleMatchOwner(&unit1, &unit2, boost::logic::indeterminate));
 	EXPECT_FALSE(subject.battleMatchOwner(&unit1, &unit2, false));
 }
 
@@ -940,7 +935,6 @@ TEST_F(BattleMatchOwnerTest, hypnotizedToHypnotizedAlly)
 	startBattle();
 
 	EXPECT_FALSE(subject.battleMatchOwner(&unit1, &unit2, true));
-	EXPECT_TRUE(subject.battleMatchOwner(&unit1, &unit2, boost::logic::indeterminate));
 	EXPECT_TRUE(subject.battleMatchOwner(&unit1, &unit2, false));
 }
 
@@ -957,7 +951,6 @@ TEST_F(BattleMatchOwnerTest, normalToNormalEnemy)
 	startBattle();
 
 	EXPECT_FALSE(subject.battleMatchOwner(&unit1, &unit2, true));
-	EXPECT_TRUE(subject.battleMatchOwner(&unit1, &unit2, boost::logic::indeterminate));
 	EXPECT_TRUE(subject.battleMatchOwner(&unit1, &unit2, false));
 }
 
@@ -975,7 +968,6 @@ TEST_F(BattleMatchOwnerTest, hypnotizedToNormalEnemy)
 	startBattle();
 
 	EXPECT_TRUE(subject.battleMatchOwner(&unit1, &unit2, true));
-	EXPECT_TRUE(subject.battleMatchOwner(&unit1, &unit2, boost::logic::indeterminate));
 	EXPECT_FALSE(subject.battleMatchOwner(&unit1, &unit2, false));
 }
 
@@ -992,7 +984,6 @@ TEST_F(BattleMatchOwnerTest, normalToHypnotizedEnemy)
 	startBattle();
 
 	EXPECT_FALSE(subject.battleMatchOwner(&unit1, &unit2, true));
-	EXPECT_TRUE(subject.battleMatchOwner(&unit1, &unit2, boost::logic::indeterminate));
 	EXPECT_TRUE(subject.battleMatchOwner(&unit1, &unit2, false));
 }
 
@@ -1011,6 +1002,5 @@ TEST_F(BattleMatchOwnerTest, hypnotizedToHypnotizedEnemy)
 	startBattle();
 
 	EXPECT_TRUE(subject.battleMatchOwner(&unit1, &unit2, true));
-	EXPECT_TRUE(subject.battleMatchOwner(&unit1, &unit2, boost::logic::indeterminate));
 	EXPECT_FALSE(subject.battleMatchOwner(&unit1, &unit2, false));
 }

--- a/test/mock/mock_spells_Mechanics.h
+++ b/test/mock/mock_spells_Mechanics.h
@@ -73,7 +73,7 @@ public:
 	MOCK_CONST_METHOD1(canonicalizeTarget, Target(const Target &));
 
 	MOCK_CONST_METHOD1(ownerMatches, bool(const battle::Unit *));
-	MOCK_CONST_METHOD2(ownerMatches, bool(const battle::Unit *, const boost::logic::tribool));
+	MOCK_CONST_METHOD2(ownerMatches, bool(const battle::Unit *, bool));
 
 	MOCK_CONST_METHOD0(creatures, const CreatureService *());
 	MOCK_CONST_METHOD0(scripts, const scripting::Service *());

--- a/test/mock/mock_spells_Spell.h
+++ b/test/mock/mock_spells_Spell.h
@@ -35,7 +35,6 @@ public:
 	MOCK_CONST_METHOD0(getBasePower, int32_t());
 	MOCK_CONST_METHOD1(getLevelPower, int32_t(const int32_t));
 	MOCK_CONST_METHOD1(getLevelDescription, const std::string &(const int32_t));
-	MOCK_CONST_METHOD0(getPositiveness, boost::logic::tribool());
 	MOCK_CONST_METHOD0(isAdventure, bool());
 	MOCK_CONST_METHOD0(isCombat, bool());
 	MOCK_CONST_METHOD0(isCreatureAbility, bool());

--- a/test/spells/targetConditions/ImmunityNegationConditionTest.cpp
+++ b/test/spells/targetConditions/ImmunityNegationConditionTest.cpp
@@ -33,7 +33,7 @@ public:
 		EXPECT_CALL(unitMock, getAllBonuses(_, _)).Times(AtLeast(0));
 		EXPECT_CALL(unitMock, getTreeVersion()).Times(AtLeast(0));
 		EXPECT_CALL(mechanicsMock, isMagicalEffect()).Times(AtLeast(0)).WillRepeatedly(Return(isMagicalEffect));
-		EXPECT_CALL(mechanicsMock, ownerMatches(Eq(&unitMock), Field(&boost::logic::tribool::value, boost::logic::tribool::false_value))).WillRepeatedly(Return(ownerMatches));
+		EXPECT_CALL(mechanicsMock, ownerMatches(Eq(&unitMock), false)).WillRepeatedly(Return(ownerMatches));
 	}
 
 protected:


### PR DESCRIPTION
Remove some usage of boost where it feels excessive or std provides compatible alternatives:
- removed one remaining occurence of boost::optional
- replaced string_ref with standard string_view
- remove remaining usages of lexical_cast
- remove last usage of boost::bimap
- remove tribool and simplify related logic - only 1 place actually was tri-state, which was replaced with optional

There are some more boost modules that we can replace, but they either require bumping minimal compiler, or require some (small) custom code - those are kept as it.

All these changes should work with our existing compilers, will verify via CI