### PR TITLE
AGENTS.md improvement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,84 +2,36 @@
 
 This file provides guidance for autonomous coding agents when working with code in this repository.
 
-## Project Overview
+## Important Patterns and Conventions
 
-VCMI is an engine for the game Heroes of Might and Magic III. The project is structured around a client-server architecture with a shared library. The codebase is primarily C++ with some CMake build configuration, Qt for UI (launcher and map editor), and Lua/ERM for scripting.
+### C++ style
 
-**Architecture**: One server process handles game state and mechanics. One or more client processes display the game and collect player input. Both use the shared VCMI lib.
+Follow the project's C++ conventions in [`docs/developers/Coding_Guidelines.md`](docs/developers/Coding_Guidelines.md) (formatting, naming, and general style).
 
-## Build System
+### Cross-DLL types (`DLL_LINKAGE`)
 
-### CMake
+For classes and structs that are serialized or otherwise shared across compile units, use the `DLL_LINKAGE` macro on the declaration:
 
-The project uses CMake with Conan package manager for dependency management on Windows. On other platforms, system package managers are used. See [`docs/developers/CMake.md`](docs/developers/CMake.md) for all CMake options and [`docs/developers/Conan.md`](docs/developers/Conan.md) for Conan setup.
+```cpp
+class DLL_LINKAGE CAddInfo {};
+struct DLL_LINKAGE Bonus {};
+```
 
-### C++ standard
+### Constants and identifiers
 
-VCMI is built as **C++20**: the root `CMakeLists.txt` sets `CMAKE_CXX_STANDARD` to `20` with `CMAKE_CXX_STANDARD_REQUIRED ON`. Treat C++20 as both the minimum supported language and the dialect to prefer for new code.
+Prefer existing constants over magic numbers or hard-coded strings:
 
-For platform-specific build and test instructions see [`docs/developers/Building_Windows.md`](docs/developers/Building_Windows.md), [`docs/developers/Building_Linux.md`](docs/developers/Building_Linux.md), [`docs/developers/Building_macOS.md`](docs/developers/Building_macOS.md), [`docs/developers/Building_Android.md`](docs/developers/Building_Android.md), [`docs/developers/Building_iOS.md`](docs/developers/Building_iOS.md).
+- **Numeric IDs** (creatures, buildings, and other entities): `lib/constants/EntityIdentifiers.h`
+- **String IDs** (configs, mods): `lib/constants/StringConstants.h`
+- **Sizes and counts** (gameplay-related): `lib/constants/NumericConstants.h`
+- **Game-related enums / mechanic states**: `lib/constants/Enumerations.h`
+
+### Serialization and state
+
+- **Serialization**: Use the custom serialization framework in `lib/serializer/`. Objects implement `h & object` pattern with serialization visitors. More details in [`docs/developers/Serialization.md`](docs/developers/Serialization.md).
+- **Game state modifications**: Only server can modify state. Client can only send requests to change gamestate to server, server validates requests and sends resulting changes in gamestate to clients
 
 ## Code Architecture
-
-### Directory Structure
-
-- **lib/** - Core static library `vcmiMain` with core game logic and data structures.
-  - Aggregated into the shipped shared library `vcmi` (`VCMI_lib.dll` / `libvcmi.so`) by the **libFacade/** target along with all AI implementations and `vcmiLua`. Consumers always link the facade target `vcmi`, not `vcmiMain` directly.
-  - **battle/** - Battle system (damage calculation, pathfinding, unit state)
-  - **bonuses/** - Bonus system (core mechanics for granting attributes to units/heroes)
-  - **callback/** - Interfaces for accessing game state (used by AI and client)
-  - **entities/** - Game objects (heroes, creatures, artifacts, spells, buildings)
-  - **gameState/** - CGameState and related classes
-  - **mapping/** - Map loading/saving
-  - **mapObjects/** - Adventure map objects (towns, dwellings, mines, etc.)
-  - **mapObjectConstructors/** - Constructors for map objects
-  - **network/** - Network layer (connection management)
-  - **networkPacks/** - Network packet definitions and serialization
-  - **json/** - JSON parsing/validation/writing
-  - **filesystem/** - Archive and file loading
-  - **spells/** - Spell definitions and casting logic
-  - **modding/** - Mod loading and content management
-  - **pathfinder/** - Hero pathfinding on adventure map
-  - **serializer/** - Serialization framework (save/load, network)
-  - **rmg/** - Random map generator
-  - **campaign/** - Campaign progression and scenario logic
-  - **texts/** - Text handling and localization support
-
-- **client/** - Game client
-  - **adventureMap/** - Adventure mode UI and logic
-  - **battle/** - Battle UI and rendering
-  - **gui/** - GUI framework (CIntObject base class and components)
-  - **eventsSDL/** - Input handling (keyboard, mouse, touch, gamepad)
-  - **lobby/** - Local game setup screens
-  - **globalLobby/** - Online/global lobby UI and client
-  - **mainmenu/** - Main menu and game selection
-  - **mapView/** - Map rendering
-  - **render/** - Rendering abstractions and interfaces
-  - **renderSDL/** - SDL-based rendering backend
-  - **widgets/** - Reusable UI widget components
-  - **windows/** - Game windows and dialogs
-
-- **server/** - Game server (compiled as vcmiservercommon library, shared by serverapp)
-  - **battles/** - Battle flow processing
-  - **queries/** - Player queries and responses
-  - **processors/** - Game state processors (turns, heroes, etc.)
-
-- **serverapp/** - Standalone server executable entry point
-- **clientapp/** - Client executable entry point (also handles iOS/Android specifics)
-- **lobby/** - Standalone global lobby server (SQLite-backed, separate from game server)
-- **launcher/** - Qt-based game launcher
-- **mapeditor/** - Qt-based map editor
-- **luascript/** - Lua scripting host, built as the static library `vcmiLua` and aggregated into `vcmi` by libFacade
-- **libFacade/** - Tiny aggregator target that produces the shipped `vcmi` shared library by linking `vcmiMain` + `vcmiLua` + every enabled AI
-- **config/** - Game configuration file (json-with-comments format)
-- **scripts/** - Lua scripts used by the game
-- **AI/** - AI modules, each built as a static archive and linked into the `vcmi` facade. They are constructed by name through `AIFactory` in `lib/callback/AIFactory.h`; there is no dynamic library loading.
-  - **BattleAI/** - combat AI (default)
-  - **Nullkiller2/** - Modern adventure map AI (default)
-  - **MMAI/** - Machine-learning-based combat AI (experimental)
-  - **StupidAI/** - Minimal combat AI for neutral/passive players
-  - **EmptyAI/** - Stub AI (no-op, used for testing)
 
 ### Key Concepts
 
@@ -149,6 +101,83 @@ On mobile systems, all binaries are built into a single executable & linked stat
 
 See [`docs/developers/Code_Structure.md`](docs/developers/Code_Structure.md) for examples.
 
+### Directory Structure
+
+- **lib/** - Core static library `vcmiMain` with core game logic and data structures.
+  - Aggregated into the shipped shared library `vcmi` (`VCMI_lib.dll` / `libvcmi.so`) by the **libFacade/** target along with all AI implementations and `vcmiLua`. Consumers always link the facade target `vcmi`, not `vcmiMain` directly.
+  - **battle/** - Battle system (damage calculation, pathfinding, unit state)
+  - **bonuses/** - Bonus system (core mechanics for granting attributes to units/heroes)
+  - **callback/** - Interfaces for accessing game state (used by AI and client)
+  - **entities/** - Game objects (heroes, creatures, artifacts, spells, buildings)
+  - **gameState/** - CGameState and related classes
+  - **mapping/** - Map loading/saving
+  - **mapObjects/** - Adventure map objects (towns, dwellings, mines, etc.)
+  - **mapObjectConstructors/** - Constructors for map objects
+  - **network/** - Network layer (connection management)
+  - **networkPacks/** - Network packet definitions and serialization
+  - **json/** - JSON parsing/validation/writing
+  - **filesystem/** - Archive and file loading
+  - **spells/** - Spell definitions and casting logic
+  - **modding/** - Mod loading and content management
+  - **pathfinder/** - Hero pathfinding on adventure map
+  - **serializer/** - Serialization framework (save/load, network)
+  - **rmg/** - Random map generator
+  - **campaign/** - Campaign progression and scenario logic
+  - **texts/** - Text handling and localization support
+
+- **client/** - Game client
+  - **adventureMap/** - Adventure mode UI and logic
+  - **battle/** - Battle UI and rendering
+  - **gui/** - GUI framework (CIntObject base class and components)
+  - **eventsSDL/** - Input handling (keyboard, mouse, touch, gamepad)
+  - **lobby/** - Local game setup screens
+  - **globalLobby/** - Online/global lobby UI and client
+  - **mainmenu/** - Main menu and game selection
+  - **mapView/** - Map rendering
+  - **render/** - Rendering abstractions and interfaces
+  - **renderSDL/** - SDL-based rendering backend
+  - **widgets/** - Reusable UI widget components
+  - **windows/** - Game windows and dialogs
+
+- **server/** - Game server (compiled as vcmiservercommon library, shared by serverapp)
+  - **battles/** - Battle flow processing
+  - **queries/** - Player queries and responses
+  - **processors/** - Game state processors (turns, heroes, etc.)
+
+- **serverapp/** - Standalone server executable entry point
+- **clientapp/** - Client executable entry point (also handles iOS/Android specifics)
+- **lobby/** - Standalone global lobby server (SQLite-backed, separate from game server)
+- **launcher/** - Qt-based game launcher
+- **mapeditor/** - Qt-based map editor
+- **luascript/** - Lua scripting host, built as the static library `vcmiLua` and aggregated into `vcmi` by libFacade
+- **libFacade/** - Tiny aggregator target that produces the shipped `vcmi` shared library by linking `vcmiMain` + `vcmiLua` + every enabled AI
+- **config/** - Game configuration file (json-with-comments format)
+- **scripts/** - Lua scripts used by the game
+- **AI/** - AI modules, each built as a static archive and linked into the `vcmi` facade. They are constructed by name through `AIFactory` in `lib/callback/AIFactory.h`; there is no dynamic library loading.
+  - **BattleAI/** - combat AI (default)
+  - **Nullkiller2/** - Modern adventure map AI (default)
+  - **MMAI/** - Machine-learning-based combat AI (experimental)
+  - **StupidAI/** - Minimal combat AI for neutral/passive players
+  - **EmptyAI/** - Stub AI (no-op, used for testing)
+
+## Project Overview
+
+VCMI is an engine for the game Heroes of Might and Magic III. The project is structured around a client-server architecture with a shared library. The codebase is primarily C++ with some CMake build configuration, Qt for UI (launcher and map editor), and Lua/ERM for scripting.
+
+**Architecture**: One server process handles game state and mechanics. One or more client processes display the game and collect player input. Both use the shared VCMI lib.
+
+## Build System
+
+### CMake
+
+The project uses CMake with Conan package manager for dependency management on Windows. On other platforms, system package managers are used. See [`docs/developers/CMake.md`](docs/developers/CMake.md) for all CMake options and [`docs/developers/Conan.md`](docs/developers/Conan.md) for Conan setup.
+
+### C++ standard
+
+VCMI is built as **C++20**: the root `CMakeLists.txt` sets `CMAKE_CXX_STANDARD` to `20` with `CMAKE_CXX_STANDARD_REQUIRED ON`. Treat C++20 as both the minimum supported language and the dialect to prefer for new code.
+
+For platform-specific build and test instructions see [`docs/developers/Building_Windows.md`](docs/developers/Building_Windows.md), [`docs/developers/Building_Linux.md`](docs/developers/Building_Linux.md), [`docs/developers/Building_macOS.md`](docs/developers/Building_macOS.md), [`docs/developers/Building_Android.md`](docs/developers/Building_Android.md), [`docs/developers/Building_iOS.md`](docs/developers/Building_iOS.md).
+
 ## Common Development Tasks
 
 ### Adding a New Game Mechanic
@@ -204,35 +233,6 @@ More details in [`docs/developers/Logging_API.md`](docs/developers/Logging_API.m
 - Use `RelWithDebInfo` build type for debugging with optimizations
 - Debug information is included in this build type
 - Full Debug builds are very slow due to unoptimized dependency builds
-
-## Important Patterns and Conventions
-
-### C++ style
-
-Follow the project's C++ conventions in [`docs/developers/Coding_Guidelines.md`](docs/developers/Coding_Guidelines.md) (formatting, naming, and general style).
-
-### Cross-DLL types (`DLL_LINKAGE`)
-
-For classes and structs that are serialized or otherwise shared across compile units, use the `DLL_LINKAGE` macro on the declaration:
-
-```cpp
-class DLL_LINKAGE CAddInfo {};
-struct DLL_LINKAGE Bonus {};
-```
-
-### Constants and identifiers
-
-Prefer existing constants over magic numbers or hard-coded strings:
-
-- **Numeric IDs** (creatures, buildings, and other entities): `lib/constants/EntityIdentifiers.h`
-- **String IDs** (configs, mods): `lib/constants/StringConstants.h`
-- **Sizes and counts** (gameplay-related): `lib/constants/NumericConstants.h`
-- **Game-related enums / mechanic states**: `lib/constants/Enumerations.h`
-
-### Serialization and state
-
-- **Serialization**: Use the custom serialization framework in `lib/serializer/`. Objects implement `h & object` pattern with serialization visitors. More details in [`docs/developers/Serialization.md`](docs/developers/Serialization.md).
-- **Game state modifications**: Only server can modify state. Client can only send requests to change gamestate to server, server validates requests and sends resulting changes in gamestate to clients
 
 ## Dependencies
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,4 @@
-# AGENTS.md
-
-This file provides guidance for autonomous coding agents when working with code in this repository.
+# Repository Guidelines
 
 ## Important Patterns and Conventions
 
@@ -210,29 +208,13 @@ Game configuration uses JSON:
 
 Configuration is loaded by handlers in `lib/entities/` (creature handler, spell handler, hero handler, etc.).
 
-### Running the Game
-
-After building, configure game data:
-
-1. Copy Heroes III `Data`, `Maps`, `Mp3` folders to `%USERPROFILE%\Documents\My Games\vcmi\`
-2. On Windows, run `build/bin/RelWithDebInfo/VCMI_launcher.bat`
-3. On Linux, run `build/bin/vcmiclient` or use launcher if built
-
-## Debugging and Logging
-
-### Logging
+## Logging
 
 - `lib/logging/CLogger.h` - Logger class
 - Logs are written to `vcmi.log`
 - Most subsystems have named loggers: `logGlobal`, `logNetwork`, `logAi`, etc.
 
 More details in [`docs/developers/Logging_API.md`](docs/developers/Logging_API.md).
-
-### Visual Studio Debugging
-
-- Use `RelWithDebInfo` build type for debugging with optimizations
-- Debug information is included in this build type
-- Full Debug builds are very slow due to unoptimized dependency builds
 
 ## Dependencies
 


### PR DESCRIPTION
Minor improvements for AGENTS.md file - reorder sections, then remove things that can be safely considered redundant. More changes can be done as well, below is full automated review that I trust:

# Rule Review — AGENTS.md

**Overall:** Well-sized and precise, but contains redundant repository documentation and one stale code snippet; ordering has been corrected.

## Scorecard

| # | Check | Verdict | Score |
|---|---|---|---|
| 1 | Length | OK | 171 non-blank lines |
| 2 | Direct snippets | WARN | 1 flagged block |
| 3 | Precise language | OK | 0 vague phrases |
| 4 | Redundant knowledge | FAIL | 4 redundant rules |
| 5 | Rule ordering | FAIL | Original critical rules appeared after line 200 |

## Findings

### 1. Length — OK

- 171 non-blank lines.

### 2. Direct snippets — WARN

- `AGENTS.md:15-18` — synthetic `DLL_LINKAGE` declarations can drift and `CAddInfo` was not found in the repository → replace with `@lib/bonuses/Bonus.h`.

### 3. Precise language — OK

- Rules are generally testable or point to canonical project documentation.

### 4. Redundant knowledge — FAIL

- `AGENTS.md:3` — generic description of an AI rules file → delete it.
- `AGENTS.md:104-161` — exhaustive directory inventory duplicates the filesystem and is expensive context → replace with references to relevant architecture documentation.
- `AGENTS.md:213-219` — runtime setup belongs in developer build/run documentation → replace with platform-document references.
- `AGENTS.md:237-247` — dependency inventory duplicates CMake/Conan configuration → replace with `@docs/developers/Conan.md` and the relevant build manifests.

### 5. Rule ordering — FAIL

- Original order placed critical DLL, serialization, constants, and server-authority rules at `AGENTS.md:208-235`.
- Approved decision: reorder the file now.
- Applied: conventions moved first; key architecture, networking, threading, and mobile namespace rules moved ahead of the directory inventory. All rule content was preserved.
- Verification: `git diff --check` passes.

**Test each change in your next agent session.** Reordering a rules file is a context-shape change — its effect on agent behavior only shows up the next time you run a real task. Apply changes one at a time (atomic): reorder, then run a representative task, then move on to the next change (split, dedupe, rewrite). Bundling multiple structural changes makes it impossible to attribute a behavior shift to a specific edit.

## Top 3 actions

1. Replace the directory and dependency inventories with canonical references.
2. Replace the synthetic `DLL_LINKAGE` snippet with a real source reference.
3. Remove generic boilerplate and relocate runtime setup to developer documentation.
