### PR TITLE
Fix crash with minizip-ng

### DIFF
--- a/lib/filesystem/MinizipExtensions.cpp
+++ b/lib/filesystem/MinizipExtensions.cpp
@@ -129,16 +129,64 @@ static voidpf ZCALLBACK MinizipOpenFunc(voidpf opaque, const void* filename, int
 		return nullptr;
 }
 
+static uLong ZCALLBACK MinizipReadFunc(voidpf opaque, voidpf filePtr, void * buf, uLong size)
+{
+	return static_cast<uLong>(std::fread(buf, 1, size, GETFILE));
+}
+
+static uLong ZCALLBACK MinizipWriteFunc(voidpf opaque, voidpf filePtr, const void * buf, uLong size)
+{
+	return static_cast<uLong>(std::fwrite(buf, 1, size, GETFILE));
+}
+
+static ZPOS64_T ZCALLBACK MinizipTellFunc(voidpf opaque, voidpf filePtr)
+{
+#ifdef VCMI_WINDOWS
+	return _ftelli64(GETFILE);
+#else
+	return ftello(GETFILE); // 64-bit off_t: ioapi.h sets _FILE_OFFSET_BITS=64 on Linux, native on Apple
+#endif
+}
+
+static long ZCALLBACK MinizipSeekFunc(voidpf opaque, voidpf filePtr, ZPOS64_T offset, int origin)
+{
+	const int whence = origin == ZLIB_FILEFUNC_SEEK_CUR ? SEEK_CUR
+	                 : origin == ZLIB_FILEFUNC_SEEK_END ? SEEK_END
+	                 : origin == ZLIB_FILEFUNC_SEEK_SET ? SEEK_SET : -1;
+	if (whence == -1)
+		return -1;
+#ifdef VCMI_WINDOWS
+	return _fseeki64(GETFILE, offset, whence);
+#else
+	return fseeko(GETFILE, offset, whence);
+#endif
+}
+
+static int ZCALLBACK MinizipCloseFunc(voidpf opaque, voidpf filePtr)
+{
+	return std::fclose(GETFILE);
+}
+
+static int ZCALLBACK MinizipErrorFunc(voidpf opaque, voidpf filePtr)
+{
+	return std::ferror(GETFILE);
+}
+
+// Populate every callback ourselves instead of relying on fill_fopen64_filefunc:
+// despite advertising minizip compatibility, minizip-ng's compat layer stubs that
+// function out to a no-op (undocumented), which would leave read/seek/etc NULL
 zlib_filefunc64_def CDefaultIOApi::getApiStructure()
 {
-	static zlib_filefunc64_def MinizipFilefunc;
-	static std::once_flag flag;
-	std::call_once(flag, []
-	{
-		fill_fopen64_filefunc(&MinizipFilefunc);
-		MinizipFilefunc.zopen64_file = &MinizipOpenFunc;
-	});
-	return MinizipFilefunc;
+	zlib_filefunc64_def api;
+	api.opaque       = nullptr;
+	api.zopen64_file = &MinizipOpenFunc;
+	api.zread_file   = &MinizipReadFunc;
+	api.zwrite_file  = &MinizipWriteFunc;
+	api.ztell64_file = &MinizipTellFunc;
+	api.zseek64_file = &MinizipSeekFunc;
+	api.zclose_file  = &MinizipCloseFunc;
+	api.zerror_file  = &MinizipErrorFunc;
+	return api;
 }
 
 #if MINIZIP_NEEDS_32BIT_FUNCS


### PR DESCRIPTION
Unlike original minizip, minizip-ng does NOT populates all callback by itself - it only zero-fills them: https://github.com/zlib-ng/minizip-ng/blob/master/compat/ioapi.c#L226

Additionally, minizip-ng will generate an error if both file open callbacks are null: https://github.com/zlib-ng/minizip-ng/blob/master/compat/ioapi.c#L88

Because of that, we ether need to use API call that does not uses callbacks (not an option for us - we actually need custom API, for virtual filesystem), or all callbacks must be provided by user (us).

This commit initializes all callback functions with equivalent c++ calls

- Resolves #7497 