### PR TITLE
Fix garrison defender counterattacks

### DIFF
--- a/AI/Nullkiller2/Analyzers/HeroManager.cpp
+++ b/AI/Nullkiller2/Analyzers/HeroManager.cpp
@@ -21,6 +21,15 @@
 namespace NK2AI
 {
 
+float evaluateMainHeroRoleScore(float heroProfileScore, uint64_t heroTotalStrength, uint64_t strongestHeroTotalStrength)
+{
+	if(strongestHeroTotalStrength == 0)
+		return heroProfileScore;
+
+	const float armyShare = heroTotalStrength / static_cast<float>(strongestHeroTotalStrength);
+	return heroProfileScore + 50.0f * armyShare;
+}
+
 const SecondarySkillEvaluator HeroManager::mainSkillsEvaluator = SecondarySkillEvaluator(
 	{
 		std::make_shared<SecondarySkillScoreMap>(
@@ -112,10 +121,14 @@ void HeroManager::update()
 
 	HeroMap<float> scores;
 	auto myHeroes = cc->getHeroesInfo();
+	uint64_t strongestHeroTotalStrength = 0;
+
+	for(auto & hero : myHeroes)
+		vstd::amax(strongestHeroTotalStrength, hero->getTotalStrength());
 
 	for(auto & hero : myHeroes)
 	{
-		scores[hero] = evaluateFightingStrength(hero);
+		scores[hero] = evaluateMainHeroRoleScore(evaluateFightingStrength(hero), hero->getTotalStrength(), strongestHeroTotalStrength);
 		knownFightingStrength[hero->id] = normalizeHeroStrength(hero->getHeroStrength());
 	}
 

--- a/AI/Nullkiller2/Analyzers/HeroManager.h
+++ b/AI/Nullkiller2/Analyzers/HeroManager.h
@@ -18,6 +18,8 @@
 namespace NK2AI
 {
 
+float evaluateMainHeroRoleScore(float heroProfileScore, uint64_t heroTotalStrength, uint64_t strongestHeroTotalStrength);
+
 class DLL_EXPORT ISecondarySkillRule
 {
 public:

--- a/AI/Nullkiller2/Behaviors/CaptureObjectsBehavior.cpp
+++ b/AI/Nullkiller2/Behaviors/CaptureObjectsBehavior.cpp
@@ -89,7 +89,10 @@ Goals::TGoalVec CaptureObjectsBehavior::getVisitGoals(
 			continue;
 		}
 
-		if(nullkiller->arePathHeroesLocked(path))
+		const CGHeroInstance * releasedDefender = nullkiller->canReleaseDefenderForTownCapture(hero, objToVisit, path)
+			? hero
+			: nullptr;
+		if(nullkiller->arePathHeroesLocked(path, releasedDefender))
 			continue;
 
 		auto firstBlockedAction = path.getFirstBlockedAction();

--- a/AI/Nullkiller2/Behaviors/CaptureObjectsBehavior.cpp
+++ b/AI/Nullkiller2/Behaviors/CaptureObjectsBehavior.cpp
@@ -30,6 +30,30 @@ bool vectorEquals(const std::vector<T> & v1, const std::vector<T> & v2)
 	});
 }
 
+bool isBetterTownCapturePath(const AIPath & candidate, const AIPath & current)
+{
+	if(candidate.turn() != current.turn())
+		return candidate.turn() < current.turn();
+
+	if(!vstd::isAlmostEqual(candidate.movementCost(), current.movementCost()))
+		return candidate.movementCost() < current.movementCost();
+
+	if(candidate.getTotalArmyLoss() != current.getTotalArmyLoss())
+		return candidate.getTotalArmyLoss() < current.getTotalArmyLoss();
+
+	return candidate.getHeroStrength() > current.getHeroStrength();
+}
+
+bool isEnemyTownCaptureTarget(const CGObjectInstance * object, const Nullkiller * nullkiller)
+{
+	if(!object || object->ID != Obj::TOWN)
+		return false;
+
+	const auto owner = object->getOwner();
+	return owner.isValidPlayer()
+		&& nullkiller->cc->getPlayerRelations(nullkiller->playerID, owner) == PlayerRelations::ENEMIES;
+}
+
 std::string CaptureObjectsBehavior::toString() const
 {
 	return "Capture objects";
@@ -56,7 +80,9 @@ Goals::TGoalVec CaptureObjectsBehavior::getVisitGoals(
 	Goals::TGoalVec tasks;
 	tasks.reserve(paths.size());
 	std::unordered_map<HeroRole, const AIPath *> closestWaysByRole;
-	std::vector<ExecuteHeroChain *> waysToVisitObj;
+	std::unordered_map<const CGHeroInstance *, const AIPath *> bestEnemyTownPathsByHero;
+	std::vector<TSubgoal> waysToVisitObj;
+	const bool isEnemyTown = isEnemyTownCaptureTarget(objToVisit, nullkiller);
 
 	for(const auto & path : paths)
 	{
@@ -133,9 +159,6 @@ Goals::TGoalVec CaptureObjectsBehavior::getVisitGoals(
 
 		if(isSafe)
 		{
-			auto newWay = new ExecuteHeroChain(path, objToVisit);
-			TSubgoal sharedPtr;
-			sharedPtr.reset(newWay);
 			auto heroRole = nullkiller->heroManager->getHeroRoleOrDefaultInefficient(path.targetHero);
 
 			auto & closestWay = closestWaysByRole[heroRole];
@@ -144,13 +167,34 @@ Goals::TGoalVec CaptureObjectsBehavior::getVisitGoals(
 				closestWay = &path;
 			}
 
-			waysToVisitObj.push_back(newWay);
+			if(isEnemyTown)
+			{
+				auto & bestPath = bestEnemyTownPathsByHero[path.targetHero];
+				if(!bestPath || isBetterTownCapturePath(path, *bestPath))
+					bestPath = &path;
+
+				continue;
+			}
+
+			auto sharedPtr = sptr(ExecuteHeroChain(path, objToVisit));
+
+			waysToVisitObj.push_back(sharedPtr);
 			tasks[tasks.size() - 1] = sharedPtr;
 		}
 	}
 
-	for(auto * way : waysToVisitObj)
+	for(const auto & heroPath : bestEnemyTownPathsByHero)
 	{
+		const auto * path = heroPath.second;
+		auto sharedPtr = sptr(ExecuteHeroChain(*path, objToVisit));
+
+		waysToVisitObj.push_back(sharedPtr);
+		tasks.push_back(sharedPtr);
+	}
+
+	for(const auto & wayGoal : waysToVisitObj)
+	{
+		auto * way = static_cast<ExecuteHeroChain *>(wayGoal.get());
 		auto heroRole = nullkiller->heroManager->getHeroRoleOrDefaultInefficient(way->getPath().targetHero);
 		const auto * closestWay = closestWaysByRole[heroRole];
 
@@ -224,13 +268,38 @@ Goals::TGoalVec CaptureObjectsBehavior::decompose(const Nullkiller * aiNk) const
 	}
 	else
 	{
-		decomposeObjects(tasks, aiNk->objectClusterizer->getNearbyObjects(), aiNk);
+		auto nearbyObjects = aiNk->objectClusterizer->getNearbyObjects();
+		addVisibleEnemyTowns(nearbyObjects, aiNk);
+		decomposeObjects(tasks, nearbyObjects, aiNk);
 
 		if(tasks.empty() || aiNk->getScanDepth() != ScanDepth::SMALL)
-			decomposeObjects(tasks, aiNk->objectClusterizer->getFarObjects(), aiNk);
+		{
+			auto farObjects = aiNk->objectClusterizer->getFarObjects();
+			vstd::erase_if(farObjects, [&nearbyObjects](const CGObjectInstance * object)
+			{
+				return vstd::contains(nearbyObjects, object);
+			});
+			decomposeObjects(tasks, farObjects, aiNk);
+		}
 	}
 
 	return tasks;
+}
+
+void CaptureObjectsBehavior::addVisibleEnemyTowns(std::vector<const CGObjectInstance *> & objects, const Nullkiller * aiNk) const
+{
+	for(const auto * visibleTown : aiNk->cc->getTownsInfo(false))
+	{
+		const auto owner = visibleTown->getOwner();
+		if(!owner.isValidPlayer())
+			continue;
+
+		if(aiNk->cc->getPlayerRelations(aiNk->playerID, owner) != PlayerRelations::ENEMIES)
+			continue;
+
+		if(objectMatchesFilter(visibleTown) && !vstd::contains(objects, visibleTown))
+			objects.push_back(visibleTown);
+	}
 }
 
 bool CaptureObjectsBehavior::objectMatchesFilter(const CGObjectInstance * obj) const

--- a/AI/Nullkiller2/Behaviors/CaptureObjectsBehavior.h
+++ b/AI/Nullkiller2/Behaviors/CaptureObjectsBehavior.h
@@ -76,6 +76,7 @@ namespace Goals
 
 	private:
 		bool objectMatchesFilter(const CGObjectInstance * obj) const;
+		void addVisibleEnemyTowns(std::vector<const CGObjectInstance *> & objects, const Nullkiller * aiNk) const;
 		void decomposeObjects(
 			Goals::TGoalVec & result,
 			const std::vector<const CGObjectInstance *> & objs,

--- a/AI/Nullkiller2/Behaviors/DefenceBehavior.cpp
+++ b/AI/Nullkiller2/Behaviors/DefenceBehavior.cpp
@@ -127,12 +127,33 @@ namespace Goals
 
 	bool isSafeSameTurnReturnPath(const CGHeroInstance & hero, const AIPath & path, float safeAttackRatio, float availableMovement)
 	{
-		return false;
+		if(path.targetHero != &hero || path.heroArmy == nullptr)
+			return false;
+
+		if(path.turn() != 0 || path.exchangeCount != 1)
+			return false;
+
+		if(path.getFirstBlockedAction())
+			return false;
+
+		for(const auto & node : path.nodes)
+		{
+			if(node.targetHero != &hero || node.specialAction)
+				return false;
+		}
+
+		if(!isSafeToVisit(&hero, path.heroArmy, path.getTotalDanger(), safeAttackRatio))
+			return false;
+
+		return path.movementCost() * 2.0f <= availableMovement;
 	}
 
 	bool isSafeSameTurnReturnPath(const CGHeroInstance & hero, const AIPath & path, float safeAttackRatio)
 	{
-		return false;
+		const float movementLimit = std::max(1, hero.movementPointsLimit());
+		const float availableMovement = hero.movementPointsRemaining() / movementLimit;
+
+		return isSafeSameTurnReturnPath(hero, path, safeAttackRatio, availableMovement);
 	}
 }
 
@@ -284,6 +305,44 @@ void handleCounterAttack(
 	}
 }
 
+void handleGarrisonReturnCounterAttack(
+	const CGTownInstance * town,
+	const HitMapInfo & threat,
+	const HitMapInfo & maximumDanger,
+	const Nullkiller * aiNk,
+	Goals::TGoalVec & tasks)
+{
+	const auto * garrisonHero = town->getGarrisonHero();
+
+	if(!garrisonHero)
+		return;
+
+	const auto lockReason = aiNk->getHeroLockedReason(garrisonHero);
+	if(lockReason != HeroLockedReason::NOT_LOCKED && lockReason != HeroLockedReason::DEFENCE)
+		return;
+
+	if(threat.heroPtr.isVerified() && threat.turn <= 1 && (threat.danger == maximumDanger.danger || threat.turn < maximumDanger.turn))
+	{
+		auto heroCapturingPaths = aiNk->pathfinder->getPathInfo(threat.heroPtr->visitablePos());
+
+		for(const auto & path : heroCapturingPaths)
+		{
+			if(!isSafeSameTurnReturnPath(*garrisonHero, path, aiNk->settings->getSafeAttackRatio()))
+				continue;
+
+			Composition composition;
+			TGoalVec sequence;
+			sequence.push_back(sptr(ExchangeSwapTownHeroes(town, nullptr)));
+			sequence.push_back(sptr(ExecuteHeroChain(path, threat.heroPtr.get())));
+			sequence.push_back(sptr(ExchangeSwapTownHeroes(town, garrisonHero, HeroLockedReason::DEFENCE)));
+
+			composition.addNext(DefendTown(town, threat, path, true)).addNextSequence(sequence);
+			setDefensiveEmergencyPriority(composition, shouldLockTownDefender(*town, *garrisonHero, threat, aiNk->settings->getSafeAttackRatio()));
+			tasks.push_back(Goals::sptr(composition));
+		}
+	}
+}
+
 bool handleGarrisonHeroFromPreviousTurn(const CGTownInstance * town, Goals::TGoalVec & tasks, const Nullkiller * aiNk, const std::vector<HitMapInfo> & threats)
 {
 	const auto * garrisonHero = town->getGarrisonHero();
@@ -329,6 +388,9 @@ void DefenceBehavior::evaluateDefence(Goals::TGoalVec & tasks, const CGTownInsta
 	// TODO: Mircea: Why don't we check if there's any danger in threadNode? Maybe map is still unexplored and no danger
 	// or simply no one is around
 	threats.push_back(threatNode.fastestDanger); // no guarantee that fastest danger will be there
+
+	for(const auto & threat : threats)
+		handleGarrisonReturnCounterAttack(town, threat, threatNode.maximumDanger, aiNk, tasks);
 
 	if(town->getGarrisonHero() && handleGarrisonHeroFromPreviousTurn(town, tasks, aiNk, threats))
 		return;

--- a/AI/Nullkiller2/Behaviors/DefenceBehavior.cpp
+++ b/AI/Nullkiller2/Behaviors/DefenceBehavior.cpp
@@ -124,6 +124,16 @@ namespace Goals
 
 		return false;
 	}
+
+	bool isSafeSameTurnReturnPath(const CGHeroInstance & hero, const AIPath & path, float safeAttackRatio, float availableMovement)
+	{
+		return false;
+	}
+
+	bool isSafeSameTurnReturnPath(const CGHeroInstance & hero, const AIPath & path, float safeAttackRatio)
+	{
+		return false;
+	}
 }
 
 namespace

--- a/AI/Nullkiller2/Behaviors/DefenceBehavior.cpp
+++ b/AI/Nullkiller2/Behaviors/DefenceBehavior.cpp
@@ -129,12 +129,16 @@ namespace Goals
 		const CGHeroInstance & defender,
 		const CGObjectInstance & target,
 		bool targetIsEnemy,
+		bool defenderMakesHomeStable,
 		uint64_t remainingTownReinforcement,
 		int dayOfWeek,
 		int daysInWeek)
 	{
 		if(target.ID != Obj::TOWN || !targetIsEnemy)
 			return false;
+
+		if(!defenderMakesHomeStable)
+			return dayOfWeek != daysInWeek || remainingTownReinforcement == 0;
 
 		const uint64_t ignoredReinforcement = std::max<uint64_t>(1000, defender.getTotalStrength() / 20);
 		if(remainingTownReinforcement > ignoredReinforcement)

--- a/AI/Nullkiller2/Behaviors/DefenceBehavior.cpp
+++ b/AI/Nullkiller2/Behaviors/DefenceBehavior.cpp
@@ -125,6 +125,24 @@ namespace Goals
 		return false;
 	}
 
+	bool isDefenderReleaseAllowedForTownCapture(
+		const CGHeroInstance & defender,
+		const CGObjectInstance & target,
+		bool targetIsEnemy,
+		uint64_t remainingTownReinforcement,
+		int dayOfWeek,
+		int daysInWeek)
+	{
+		if(target.ID != Obj::TOWN || !targetIsEnemy)
+			return false;
+
+		const uint64_t ignoredReinforcement = std::max<uint64_t>(1000, defender.getTotalStrength() / 20);
+		if(remainingTownReinforcement > ignoredReinforcement)
+			return false;
+
+		return dayOfWeek != daysInWeek || remainingTownReinforcement == 0;
+	}
+
 	bool isSafeSameTurnReturnPath(const CGHeroInstance & hero, const AIPath & path, float safeAttackRatio, float availableMovement)
 	{
 		if(path.targetHero != &hero || path.heroArmy == nullptr)

--- a/AI/Nullkiller2/Behaviors/DefenceBehavior.cpp
+++ b/AI/Nullkiller2/Behaviors/DefenceBehavior.cpp
@@ -9,6 +9,7 @@
 */
 #include "StdInc.h"
 #include "DefenceBehavior.h"
+#include "DefenceBehaviorUtils.h"
 
 #include "../../../lib/IGameSettings.h"
 #include "../AIGateway.h"

--- a/AI/Nullkiller2/Behaviors/DefenceBehavior.h
+++ b/AI/Nullkiller2/Behaviors/DefenceBehavior.h
@@ -9,8 +9,6 @@
 */
 #pragma once
 
-#include <vector>
-
 #include "../AIUtility.h"
 #include "../Goals/CGoal.h"
 #include "lib/GameLibrary.h"
@@ -22,14 +20,6 @@ struct HitMapInfo;
 
 namespace Goals
 {
-	uint64_t estimateTownFortificationDefence(const CGTownInstance & town, bool hasDefenders);
-	uint64_t estimateTownDefence(const CGTownInstance & town, const CGHeroInstance * committedDefender);
-	bool isTownDefenceSufficient(uint64_t defenceStrength, const HitMapInfo & threat, float safeAttackRatio);
-	int countTownThreatsCoveredByDefender(const CGTownInstance & town, const CGHeroInstance & defender, const std::vector<HitMapInfo> & threats, float safeAttackRatio);
-	bool isHeroRequiredForTownDefence(const CGTownInstance & town, const CGHeroInstance & defender, const std::vector<HitMapInfo> & threats, float safeAttackRatio);
-	bool shouldReserveTownDefender(const CGTownInstance & town, const CGHeroInstance & defender, const std::vector<HitMapInfo> & threats, float safeAttackRatio);
-	bool shouldLockTownDefender(const CGTownInstance & town, const CGHeroInstance & defender, const HitMapInfo & threat, float safeAttackRatio);
-
 	class DefenceBehavior : public CGoal<DefenceBehavior>
 	{
 	public:

--- a/AI/Nullkiller2/Behaviors/DefenceBehaviorUtils.h
+++ b/AI/Nullkiller2/Behaviors/DefenceBehaviorUtils.h
@@ -30,6 +30,8 @@ namespace Goals
 	bool isHeroRequiredForTownDefence(const CGTownInstance & town, const CGHeroInstance & defender, const std::vector<HitMapInfo> & threats, float safeAttackRatio);
 	bool shouldReserveTownDefender(const CGTownInstance & town, const CGHeroInstance & defender, const std::vector<HitMapInfo> & threats, float safeAttackRatio);
 	bool shouldLockTownDefender(const CGTownInstance & town, const CGHeroInstance & defender, const HitMapInfo & threat, float safeAttackRatio);
+	bool isSafeSameTurnReturnPath(const CGHeroInstance & hero, const AIPath & path, float safeAttackRatio, float availableMovement);
+	bool isSafeSameTurnReturnPath(const CGHeroInstance & hero, const AIPath & path, float safeAttackRatio);
 }
 
 }

--- a/AI/Nullkiller2/Behaviors/DefenceBehaviorUtils.h
+++ b/AI/Nullkiller2/Behaviors/DefenceBehaviorUtils.h
@@ -13,6 +13,7 @@
 #include <vector>
 
 class CGHeroInstance;
+class CGObjectInstance;
 class CGTownInstance;
 
 namespace NK2AI
@@ -30,6 +31,13 @@ namespace Goals
 	bool isHeroRequiredForTownDefence(const CGTownInstance & town, const CGHeroInstance & defender, const std::vector<HitMapInfo> & threats, float safeAttackRatio);
 	bool shouldReserveTownDefender(const CGTownInstance & town, const CGHeroInstance & defender, const std::vector<HitMapInfo> & threats, float safeAttackRatio);
 	bool shouldLockTownDefender(const CGTownInstance & town, const CGHeroInstance & defender, const HitMapInfo & threat, float safeAttackRatio);
+	bool isDefenderReleaseAllowedForTownCapture(
+		const CGHeroInstance & defender,
+		const CGObjectInstance & target,
+		bool targetIsEnemy,
+		uint64_t remainingTownReinforcement,
+		int dayOfWeek,
+		int daysInWeek);
 	bool isSafeSameTurnReturnPath(const CGHeroInstance & hero, const AIPath & path, float safeAttackRatio, float availableMovement);
 	bool isSafeSameTurnReturnPath(const CGHeroInstance & hero, const AIPath & path, float safeAttackRatio);
 }

--- a/AI/Nullkiller2/Behaviors/DefenceBehaviorUtils.h
+++ b/AI/Nullkiller2/Behaviors/DefenceBehaviorUtils.h
@@ -1,0 +1,35 @@
+/*
+* DefenceBehaviorUtils.h, part of VCMI engine
+*
+* Authors: listed in file AUTHORS in main folder
+*
+* License: GNU General Public License v2.0 or later
+* Full text of license available in license.txt file, in main folder
+*
+*/
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+class CGHeroInstance;
+class CGTownInstance;
+
+namespace NK2AI
+{
+
+struct AIPath;
+struct HitMapInfo;
+
+namespace Goals
+{
+	uint64_t estimateTownFortificationDefence(const CGTownInstance & town, bool hasDefenders);
+	uint64_t estimateTownDefence(const CGTownInstance & town, const CGHeroInstance * committedDefender);
+	bool isTownDefenceSufficient(uint64_t defenceStrength, const HitMapInfo & threat, float safeAttackRatio);
+	int countTownThreatsCoveredByDefender(const CGTownInstance & town, const CGHeroInstance & defender, const std::vector<HitMapInfo> & threats, float safeAttackRatio);
+	bool isHeroRequiredForTownDefence(const CGTownInstance & town, const CGHeroInstance & defender, const std::vector<HitMapInfo> & threats, float safeAttackRatio);
+	bool shouldReserveTownDefender(const CGTownInstance & town, const CGHeroInstance & defender, const std::vector<HitMapInfo> & threats, float safeAttackRatio);
+	bool shouldLockTownDefender(const CGTownInstance & town, const CGHeroInstance & defender, const HitMapInfo & threat, float safeAttackRatio);
+}
+
+}

--- a/AI/Nullkiller2/Behaviors/DefenceBehaviorUtils.h
+++ b/AI/Nullkiller2/Behaviors/DefenceBehaviorUtils.h
@@ -35,6 +35,7 @@ namespace Goals
 		const CGHeroInstance & defender,
 		const CGObjectInstance & target,
 		bool targetIsEnemy,
+		bool defenderMakesHomeStable,
 		uint64_t remainingTownReinforcement,
 		int dayOfWeek,
 		int daysInWeek);

--- a/AI/Nullkiller2/Behaviors/ExplorationBehavior.cpp
+++ b/AI/Nullkiller2/Behaviors/ExplorationBehavior.cpp
@@ -192,9 +192,10 @@ Goals::TGoalVec ExplorationBehavior::decompose(const Nullkiller * aiNk) const
 			// spend remaining MP on safe adjacent fog instead of ending the turn idle.
 			else if(const auto neighbourTarget = ExploreNeighbourTile::findTarget(hero, aiNk))
 			{
+				const bool strategicOnlyMove = neighbourTarget->tilesDiscovered == 0;
 				tasks.push_back(sptr(Composition()
 					.addNext(ExplorationPoint(neighbourTarget->tile, neighbourTarget->tilesDiscovered))
-					.addNext(ExploreNeighbourTile(hero, 5))));
+					.addNext(ExploreNeighbourTile(hero, strategicOnlyMove ? 1 : 5, strategicOnlyMove))));
 			}
 		}
 	}

--- a/AI/Nullkiller2/CMakeLists.txt
+++ b/AI/Nullkiller2/CMakeLists.txt
@@ -138,6 +138,7 @@ set(Nullkiller2_HEADERS
 		Behaviors/RecruitHeroBehavior.h
 		Behaviors/BuyArmyBehavior.h
 		Behaviors/DefenceBehavior.h
+		Behaviors/DefenceBehaviorUtils.h
 		Behaviors/EscapeBehavior.h
 		Behaviors/StartupBehavior.h
 		Behaviors/BuildingBehavior.h

--- a/AI/Nullkiller2/Engine/Nullkiller.cpp
+++ b/AI/Nullkiller2/Engine/Nullkiller.cpp
@@ -440,6 +440,24 @@ void Nullkiller::unlockHero(const CGHeroInstance * hero)
 	lockedHeroes.erase(hero);
 }
 
+bool defenderMakesTownStableAfterTurnEnd(const CGTownInstance * town, const CGHeroInstance * defender, const Nullkiller * aiNk)
+{
+	const auto threats = getTownThreatsForDefenderReservation(town, aiNk);
+	const auto defence = Goals::estimateTownDefence(*town, defender);
+	const auto safeAttackRatio = aiNk->settings->getSafeAttackRatio();
+
+	for(const auto & threat : threats)
+	{
+		if(threat.danger == 0 || threat.turn > 1)
+			continue;
+
+		if(!Goals::isTownDefenceSufficient(defence, threat, safeAttackRatio))
+			return false;
+	}
+
+	return true;
+}
+
 bool Nullkiller::canReleaseDefenderForTownCapture(const CGHeroInstance * hero, const CGObjectInstance * target, const AIPath & path) const
 {
 	if(!hero || !target || path.targetHero != hero)
@@ -459,6 +477,7 @@ bool Nullkiller::canReleaseDefenderForTownCapture(const CGHeroInstance * hero, c
 		return false;
 
 	const auto relation = cc->getPlayerRelations(target->tempOwner, playerID);
+	const auto defenderMakesHomeStable = defenderMakesTownStableAfterTurnEnd(defendedTown, hero, this);
 	const auto remainingTownReinforcement = armyManager->howManyReinforcementsCanBuy(defendedTown->getUpperArmy(), defendedTown);
 	const auto calendar = cc->getCalendar();
 
@@ -466,6 +485,7 @@ bool Nullkiller::canReleaseDefenderForTownCapture(const CGHeroInstance * hero, c
 		*hero,
 		*target,
 		relation == PlayerRelations::ENEMIES,
+		defenderMakesHomeStable,
 		remainingTownReinforcement,
 		calendar.getDayOfWeek(),
 		calendar.getDaysInWeek());

--- a/AI/Nullkiller2/Engine/Nullkiller.cpp
+++ b/AI/Nullkiller2/Engine/Nullkiller.cpp
@@ -449,7 +449,38 @@ void Nullkiller::unlockHero(const CGHeroInstance * hero)
 	lockedHeroes.erase(hero);
 }
 
-bool Nullkiller::arePathHeroesLocked(const AIPath & path) const
+bool Nullkiller::canReleaseDefenderForTownCapture(const CGHeroInstance * hero, const CGObjectInstance * target, const AIPath & path) const
+{
+	if(!hero || !target || path.targetHero != hero)
+		return false;
+
+	if(getHeroLockedReason(hero) != HeroLockedReason::DEFENCE)
+		return false;
+
+	if(path.exchangeCount != 1 || path.turn() > 1 || path.getFirstBlockedAction())
+		return false;
+
+	const auto * defendedTown = hero->getVisitedTown();
+	if(!defendedTown || defendedTown->getOwner() != playerID)
+		return false;
+
+	if(defendedTown->getGarrisonHero() != hero && defendedTown->getVisitingHero() != hero)
+		return false;
+
+	const auto relation = cc->getPlayerRelations(target->tempOwner, playerID);
+	const auto remainingTownReinforcement = armyManager->howManyReinforcementsCanBuy(defendedTown->getUpperArmy(), defendedTown);
+	const auto calendar = cc->getCalendar();
+
+	return Goals::isDefenderReleaseAllowedForTownCapture(
+		*hero,
+		*target,
+		relation == PlayerRelations::ENEMIES,
+		remainingTownReinforcement,
+		calendar.getDayOfWeek(),
+		calendar.getDaysInWeek());
+}
+
+bool Nullkiller::arePathHeroesLocked(const AIPath & path, const CGHeroInstance * releasedDefender) const
 {
 	if(getHeroLockedReason(path.targetHero) == HeroLockedReason::STARTUP)
 	{
@@ -465,6 +496,9 @@ bool Nullkiller::arePathHeroesLocked(const AIPath & path) const
 
 		if(lockReason != HeroLockedReason::NOT_LOCKED)
 		{
+			if(releasedDefender && node.targetHero == releasedDefender && lockReason == HeroLockedReason::DEFENCE)
+				continue;
+
 #if NK2AI_TRACE_LEVEL >= 1
 			logAi->trace("Hero %s is locked by %d. Discarding %s", path.targetHero->getObjectName(), (int)lockReason,  path.toString());
 #endif
@@ -841,9 +875,6 @@ HeroMap<HeroRole> Nullkiller::getHeroesForPathfinding() const
 	HeroMap<HeroRole> activeHeroes;
 	for(auto hero : cc->getHeroesInfo())
 	{
-		if(getHeroLockedReason(hero) == HeroLockedReason::DEFENCE)
-			continue;
-
 		activeHeroes[hero] = heroManager->getHeroRoleOrDefaultInefficient(hero);
 	}
 	return activeHeroes;

--- a/AI/Nullkiller2/Engine/Nullkiller.cpp
+++ b/AI/Nullkiller2/Engine/Nullkiller.cpp
@@ -405,6 +405,8 @@ const CGHeroInstance * Nullkiller::findRequiredTownDefender(const CGTownInstance
 
 void Nullkiller::reserveRequiredTownDefenders()
 {
+	// Only urgent town threats reserve heroes here. Safe garrison heroes must
+	// stay available for extraction, otherwise large town armies become idle.
 	for(const auto * town : cc->getTownsInfo())
 	{
 		const auto * defender = findRequiredTownDefender(town);
@@ -414,17 +416,6 @@ void Nullkiller::reserveRequiredTownDefenders()
 
 		logAi->debug("Reserving %s as defender of %s", defender->getNameTranslated(), town->getNameTranslated());
 		lockedHeroes[defender] = HeroLockedReason::DEFENCE;
-	}
-
-	for(const auto * town : cc->getTownsInfo())
-	{
-		const auto * garrisonHero = town->getGarrisonHero();
-
-		if(!garrisonHero || getHeroLockedReason(garrisonHero) != HeroLockedReason::NOT_LOCKED)
-			continue;
-
-		logAi->debug("Keeping %s in garrison of %s", garrisonHero->getNameTranslated(), town->getNameTranslated());
-		lockedHeroes[garrisonHero] = HeroLockedReason::DEFENCE;
 	}
 }
 

--- a/AI/Nullkiller2/Engine/Nullkiller.cpp
+++ b/AI/Nullkiller2/Engine/Nullkiller.cpp
@@ -20,6 +20,7 @@
 #include "../Behaviors/CaptureObjectsBehavior.h"
 #include "../Behaviors/ClusterBehavior.h"
 #include "../Behaviors/DefenceBehavior.h"
+#include "../Behaviors/DefenceBehaviorUtils.h"
 #include "../Behaviors/EscapeBehavior.h"
 #include "../Behaviors/ExplorationBehavior.h"
 #include "../Behaviors/GatherArmyBehavior.h"

--- a/AI/Nullkiller2/Engine/Nullkiller.h
+++ b/AI/Nullkiller2/Engine/Nullkiller.h
@@ -133,7 +133,8 @@ public:
 	void setActive(const CGHeroInstance * hero, int3 tile) { activeHero = hero; targetTile = tile; }
 	void lockHero(const CGHeroInstance * hero, HeroLockedReason lockReason);
 	void unlockHero(const CGHeroInstance * hero);
-	bool arePathHeroesLocked(const AIPath & path) const;
+	bool canReleaseDefenderForTownCapture(const CGHeroInstance * hero, const CGObjectInstance * target, const AIPath & path) const;
+	bool arePathHeroesLocked(const AIPath & path, const CGHeroInstance * releasedDefender = nullptr) const;
 	TResources getFreeResources() const;
 	int32_t getFreeGold() const { return getFreeResources()[EGameResID::GOLD]; }
 	void lockResources(const TResources & res);

--- a/AI/Nullkiller2/Engine/PriorityEvaluator.cpp
+++ b/AI/Nullkiller2/Engine/PriorityEvaluator.cpp
@@ -43,6 +43,29 @@ namespace NK2AI
 
 constexpr float MAX_CRITICAL_VALUE = 2.0f;
 
+float evaluateEnemyTownConquestValue(float baseValue, int visibleEnemyTownCount)
+{
+	if(visibleEnemyTownCount <= 0)
+		return baseValue;
+
+	if(visibleEnemyTownCount == 1)
+		return std::max(baseValue * 4.0f, 6.0f);
+
+	if(visibleEnemyTownCount == 2)
+		return std::max(baseValue * 3.5f, 5.0f);
+
+	return std::max(baseValue * 3.0f, 4.0f);
+}
+
+float evaluateMaxArmyLossForConquest(float baseMaxArmyLoss, float conquestValue, bool isEnemyTownConquest)
+{
+	if(!isEnemyTownConquest || conquestValue <= MAX_CRITICAL_VALUE)
+		return baseMaxArmyLoss;
+
+	const float conquestPressure = (conquestValue - MAX_CRITICAL_VALUE) * 0.05f;
+	return std::min(baseMaxArmyLoss + conquestPressure, 0.75f);
+}
+
 EvaluationContext::EvaluationContext(const Nullkiller* aiNk)
 	: movementCost(0.0),
 	manaCost(0),
@@ -88,6 +111,22 @@ bool isAnotherAi(const CGObjectInstance * obj, const CPlayerSpecificInfoCallback
 {
 	return obj->getOwner().isValidPlayer()
 		&& cb.getStartInfo()->getIthPlayersSettings(obj->getOwner()).isControlledByAI();
+}
+
+int getVisibleEnemyTownCount(const CGTownInstance * town, const Nullkiller * aiNk)
+{
+	const auto owner = town->getOwner();
+	if(!owner.isValidPlayer() || aiNk->cc->getPlayerRelations(aiNk->playerID, owner) != PlayerRelations::ENEMIES)
+		return 0;
+
+	int result = 0;
+	for(const auto * visibleTown : aiNk->cc->getTownsInfo(false))
+	{
+		if(visibleTown->getOwner() == owner)
+			result++;
+	}
+
+	return result;
 }
 
 int32_t estimateTownIncome(CCallback * cb, const CGObjectInstance * target, const CGHeroInstance * hero)
@@ -535,14 +574,19 @@ float RewardEvaluator::getConquestValue(const CGObjectInstance* target) const
 
 		auto fortLevel = town->fortLevel();
 		auto booster = 1.0f;
+		float baseValue = 0.0f;
 
 		if (town->hasCapitol())
-			return booster * 1.5;
-
-		if (fortLevel < CGTownInstance::CITADEL)
-			return booster * (town->hasFort() ? 1.0 : 0.8);
+			baseValue = booster * 1.5;
+		else if (fortLevel < CGTownInstance::CITADEL)
+			baseValue = booster * (town->hasFort() ? 1.0 : 0.8);
 		else
-			return booster * (fortLevel == CGTownInstance::CASTLE ? 1.4 : 1.2);
+			baseValue = booster * (fortLevel == CGTownInstance::CASTLE ? 1.4 : 1.2);
+
+		const auto visibleEnemyTownCount = getVisibleEnemyTownCount(town, aiNk);
+		return visibleEnemyTownCount > 0
+			? evaluateEnemyTownConquestValue(baseValue, visibleEnemyTownCount)
+			: baseValue;
 	}
 
 	case Obj::HERO:
@@ -1408,6 +1452,10 @@ float PriorityEvaluator::evaluate(Goals::TSubgoal task, int priorityTier)
 		const float maxEnemyDangerRatio = evaluationContext.powerRatio > 0 ? evaluationContext.powerRatio : 1.0;
 		auto calendar = aiNk->cc->getCalendar();
 		const bool arriveNextWeek = calendar.getDayOfWeek() + evaluationContext.turn > calendar.getDaysInWeek();
+		const bool isEnemyTownConquest = evaluationContext.isEnemy
+			&& !evaluationContext.isHero
+			&& evaluationContext.conquestValue > MAX_CRITICAL_VALUE;
+		const float maxWillingToLoseForTask = evaluateMaxArmyLossForConquest(maxWillingToLose, evaluationContext.conquestValue, isEnemyTownConquest);
 
 #if NK2AI_TRACE_LEVEL >= 2
 		logAi->trace(
@@ -1456,7 +1504,7 @@ float PriorityEvaluator::evaluate(Goals::TSubgoal task, int priorityTier)
 
 				// TODO: Mircea: Ensure defenseValue is taken into account. See AINodeStorage::evaluateArmyLoss and CCreatureSet::getArmyStrength
 				// TODO: Mircea: make it dynamic, allow higher risk for killing a higher risk hero if it leads to killing an entire player. See conquestValue
-				if(maxWillingToLose - evaluationContext.armyLossRatio < 0)
+				if(maxWillingToLoseForTask - evaluationContext.armyLossRatio < 0)
 					return 0;
 
 				score = evaluateConquestValue(score, evaluationContext.conquestValue, evaluationContext.armyInvolvement);
@@ -1473,7 +1521,7 @@ float PriorityEvaluator::evaluate(Goals::TSubgoal task, int priorityTier)
 				if(!evaluationContext.isDefend)
 					return 0;
 				// TODO: Mircea: Often is better to die as long as you're almost destroying the opponent. To revisit
-				if(maxWillingToLose - evaluationContext.armyLossRatio < 0)
+				if(maxWillingToLoseForTask - evaluationContext.armyLossRatio < 0)
 					return 0;
 				if(evaluationContext.isEnemy && evaluationContext.turn > 0)
 					return 0;
@@ -1515,7 +1563,7 @@ float PriorityEvaluator::evaluate(Goals::TSubgoal task, int priorityTier)
 				   || (evaluationContext.enemyHeroDangerRatio > maxEnemyDangerRatio && (evaluationContext.turn > 0 || evaluationContext.isExchange)
 					   && !amIWithoutCastle))
 					return 0;
-				if (maxWillingToLose - evaluationContext.armyLossRatio < 0)
+				if (maxWillingToLoseForTask - evaluationContext.armyLossRatio < 0)
 					return 0;
 
 				score = evaluateArmyLossRatio(score, evaluationContext.armyLossRatio, evaluationContext.heroRole);
@@ -1538,7 +1586,7 @@ float PriorityEvaluator::evaluate(Goals::TSubgoal task, int priorityTier)
 					return 0;
 				if(evaluationContext.buildingCost.marketValue() > 0)
 					return 0;
-				if(maxWillingToLose - evaluationContext.armyLossRatio < 0)
+				if(maxWillingToLoseForTask - evaluationContext.armyLossRatio < 0)
 					return 0;
 
 				if(priorityTier == EXPLORE_AND_GATHER && evaluationContext.enemyHeroDangerRatio > maxEnemyDangerRatio)
@@ -1649,7 +1697,7 @@ float PriorityEvaluator::evaluate(Goals::TSubgoal task, int priorityTier)
 			case BUILDINGS: //For buildings and buying army
 			{
 				// TODO: Mircea: What's the point of this check for ::BUILDINGS? Isn't the priority itself just for buildings? To test
-				if(maxWillingToLose - evaluationContext.armyLossRatio < 0)
+				if(maxWillingToLoseForTask - evaluationContext.armyLossRatio < 0)
 					return 0;
 				//If we already have locked resources, we don't look at other buildings
 				if(aiNk->getLockedResources().marketValue() > 0)

--- a/AI/Nullkiller2/Engine/PriorityEvaluator.h
+++ b/AI/Nullkiller2/Engine/PriorityEvaluator.h
@@ -14,6 +14,9 @@
 namespace NK2AI
 {
 
+float evaluateEnemyTownConquestValue(float baseValue, int visibleEnemyTownCount);
+float evaluateMaxArmyLossForConquest(float baseMaxArmyLoss, float conquestValue, bool isEnemyTownConquest);
+
 class BuildingInfo;
 class Nullkiller;
 struct HitMapInfo;

--- a/AI/Nullkiller2/Goals/ExploreNeighbourTile.cpp
+++ b/AI/Nullkiller2/Goals/ExploreNeighbourTile.cpp
@@ -13,6 +13,7 @@
 #include "../AIUtility.h"
 #include "../Engine/Nullkiller.h"
 #include "../Helpers/ExplorationHelper.h"
+#include "../../../lib/pathfinder/CGPathNode.h"
 
 
 namespace NK2AI
@@ -22,13 +23,63 @@ using namespace Goals;
 
 namespace
 {
+float getNeighbourStrategicProgress(
+	const CGHeroInstance * hero,
+	const Nullkiller * aiNk,
+	const std::shared_ptr<const CPathsInfo> & pathsInfo,
+	const int3 & tile)
+{
+	float result = 0.0f;
+
+	auto targetReachedThroughTile = [&pathsInfo, &tile](const CGObjectInstance * obj)
+	{
+		if(!obj || obj->visitablePos().z != tile.z)
+			return false;
+
+		CGPath path;
+		if(!pathsInfo->getPath(path, obj->visitablePos()) || !path.hasNextNode())
+			return false;
+
+		return path.nextNode().coord == tile;
+	};
+
+	for(const ObjectInstanceID objId : aiNk->memory->visitableObjs)
+	{
+		const CGObjectInstance * obj = aiNk->cc->getObj(objId, false);
+		if(!targetReachedThroughTile(obj))
+			continue;
+
+		const auto relations = aiNk->cc->getPlayerRelations(obj->tempOwner, hero->tempOwner);
+		if(obj->ID == Obj::TOWN && relations == PlayerRelations::ENEMIES)
+			result = std::max(result, 6.0f);
+		else if(obj->ID == Obj::HERO && relations == PlayerRelations::ENEMIES)
+			result = std::max(result, 4.0f);
+		else if(aiNk->memory->wasVisited(obj))
+			result = std::max(result, 0.25f);
+		else
+			result = std::max(result, 1.0f);
+	}
+
+	for(const CGTownInstance * town : aiNk->cc->getTownsInfo(false))
+	{
+		if(targetReachedThroughTile(town)
+			&& aiNk->cc->getPlayerRelations(town->tempOwner, hero->tempOwner) == PlayerRelations::ENEMIES)
+		{
+			result = std::max(result, 6.0f);
+		}
+	}
+
+	return result;
+}
+
 std::optional<NeighbourExplorationTarget> getNeighbourExplorationTarget(
 	const CGHeroInstance * hero,
 	const Nullkiller * aiNk,
 	ExplorationHelper & helper,
 	const int3 & tile)
 {
-	const auto pathInfo = aiNk->getPathsInfo(hero)->getPathInfo(tile);
+	const auto pathsInfo = aiNk->getPathsInfo(hero);
+	const auto pathInfo = pathsInfo->getPathInfo(tile);
 	const uint64_t danger = aiNk->dangerEvaluator->evaluateDanger(tile, hero, true);
 
 	NeighbourExplorationCandidate candidate;
@@ -36,6 +87,7 @@ std::optional<NeighbourExplorationTarget> getNeighbourExplorationTarget(
 	candidate.accessible = pathInfo->accessible == EPathAccessibility::ACCESSIBLE;
 	candidate.safe = danger == 0;
 	candidate.tilesDiscovered = helper.howManyTilesWillBeDiscovered(tile);
+	candidate.strategicProgress = getNeighbourStrategicProgress(hero, aiNk, pathsInfo, tile);
 	candidate.movementCost = pathInfo->getCost();
 
 	const auto evaluation = evaluateNeighbourExplorationCandidate(candidate);
@@ -46,6 +98,7 @@ std::optional<NeighbourExplorationTarget> getNeighbourExplorationTarget(
 		tile,
 		candidate.tilesDiscovered,
 		candidate.movementCost,
+		candidate.strategicProgress,
 		evaluation.value
 	};
 }
@@ -59,13 +112,15 @@ NeighbourExplorationEvaluation evaluateNeighbourExplorationCandidate(
 	if(!candidate.sameDay
 		|| !candidate.accessible
 		|| !candidate.safe
-		|| candidate.tilesDiscovered <= 0)
+		|| (candidate.tilesDiscovered <= 0 && candidate.strategicProgress <= 0.0f))
 	{
 		return result;
 	}
 
+	const float discoveryValue = candidate.tilesDiscovered * candidate.tilesDiscovered;
+
 	result.accepted = true;
-	result.value = candidate.tilesDiscovered * candidate.tilesDiscovered
+	result.value = (discoveryValue + candidate.strategicProgress)
 		/ std::max(0.1f, candidate.movementCost);
 	return result;
 }
@@ -102,13 +157,20 @@ std::optional<NeighbourExplorationTarget> ExploreNeighbourTile::findTarget(
 
 void ExploreNeighbourTile::accept(AIGateway * aiGw)
 {
+	bool moved = false;
+
 	for(int i = 0; i < tilesToExplore && aiGw->cc->getObj(hero->id, false) && hero->movementPointsRemaining() > 0; i++)
 	{
 		const auto target = findTarget(hero, aiGw->nullkiller.get());
 
 		if(!target || !aiGw->moveHeroToTile(target->tile, HeroPtr(hero, aiGw->cc.get())))
 			return;
+
+		moved = true;
 	}
+
+	if(lockAfterMove && moved)
+		aiGw->nullkiller->lockHero(hero, HeroLockedReason::HERO_CHAIN);
 }
 
 std::string ExploreNeighbourTile::toString() const

--- a/AI/Nullkiller2/Goals/ExploreNeighbourTile.h
+++ b/AI/Nullkiller2/Goals/ExploreNeighbourTile.h
@@ -24,6 +24,7 @@ struct NeighbourExplorationCandidate
 	bool accessible = false;
 	bool safe = false;
 	int tilesDiscovered = 0;
+	float strategicProgress = 0.0f;
 	float movementCost = 0.0f;
 };
 
@@ -38,6 +39,7 @@ struct NeighbourExplorationTarget
 	int3 tile = int3(-1);
 	int tilesDiscovered = 0;
 	float movementCost = 0.0f;
+	float strategicProgress = 0.0f;
 	float value = 0.0f;
 };
 
@@ -50,10 +52,12 @@ namespace Goals
 	{
 	private:
 		int tilesToExplore;
+		bool lockAfterMove;
 
 	public:
-		ExploreNeighbourTile(const CGHeroInstance * hero,  int amount)
+		ExploreNeighbourTile(const CGHeroInstance * hero, int amount, bool lockAfterMove = false)
 			: ElementarGoal(Goals::EXPLORE_NEIGHBOUR_TILE)
+			, lockAfterMove(lockAfterMove)
 		{
 			tilesToExplore = amount;
 			sethero(hero);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -150,11 +150,13 @@ endif()
 
 if(ENABLE_NULLKILLER2_AI)
 	list(APPEND test_SRCS
+		nullkiller2/Analyzers/HeroManagerTest.cpp
 		nullkiller2/Analyzers/ObjectClusterizerTest.cpp
 		nullkiller2/Behaviors/DefenceBehaviorTest.cpp
 		nullkiller2/Behaviors/EscapeBehaviorTest.cpp
 		nullkiller2/Behaviors/ExplorationBehaviorTest.cpp
 		nullkiller2/Behaviors/RecruitHeroBehaviorTest.cpp
+		nullkiller2/Engine/PriorityEvaluatorTest.cpp
 		nullkiller2/Engine/TaskFailureTest.cpp
 		nullkiller2/Goals/BuyArmyTest.cpp
 		nullkiller2/Goals/CompositionTest.cpp

--- a/test/nullkiller2/Analyzers/HeroManagerTest.cpp
+++ b/test/nullkiller2/Analyzers/HeroManagerTest.cpp
@@ -1,0 +1,31 @@
+/*
+ * HeroManagerTest.cpp, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ */
+#include "StdInc.h"
+
+#include "AI/Nullkiller2/Analyzers/HeroManager.h"
+
+TEST(Nullkiller2_Analyzers_HeroManager, armyCarrierBeatsBetterHeroProfileForMainRole)
+{
+	constexpr uint64_t strongestArmy = 10000;
+
+	EXPECT_GT(
+		NK2AI::evaluateMainHeroRoleScore(5.0f, strongestArmy, strongestArmy),
+		NK2AI::evaluateMainHeroRoleScore(40.0f, strongestArmy / 20, strongestArmy))
+		<< "the hero carrying the army should not be treated as a scout just because another hero has better skills";
+}
+
+TEST(Nullkiller2_Analyzers_HeroManager, heroProfileBreaksSimilarArmyTies)
+{
+	constexpr uint64_t strongestArmy = 10000;
+
+	EXPECT_GT(
+		NK2AI::evaluateMainHeroRoleScore(30.0f, strongestArmy, strongestArmy),
+		NK2AI::evaluateMainHeroRoleScore(20.0f, strongestArmy, strongestArmy))
+		<< "normal hero profile scoring should still decide between comparable army carriers";
+}

--- a/test/nullkiller2/Behaviors/DefenceBehaviorTest.cpp
+++ b/test/nullkiller2/Behaviors/DefenceBehaviorTest.cpp
@@ -192,6 +192,22 @@ TEST(Nullkiller2_Behaviors_DefenceBehavior, reserveDefenderThatImprovesUrgentTow
 		<< "do not treat a useful garrison defender as free while urgent town danger remains";
 }
 
+TEST(Nullkiller2_Behaviors_DefenceBehavior, reserveDefenderIsSkippedForDistantTownThreat)
+{
+	test::TownFake town;
+	town.withBuilding(BuildingID::CASTLE);
+
+	CGHeroInstance defender(nullptr);
+	ASSERT_TRUE(defender.setCreature(SlotID(0), CreatureID::ARCHER, 1));
+
+	const auto committedDefence = NK2AI::Goals::estimateTownDefence(*town.get(), &defender);
+	auto distantThreat = nextTurnThreat(committedDefence + 1);
+	distantThreat.turn = 2;
+
+	EXPECT_FALSE(NK2AI::Goals::shouldReserveTownDefender(*town.get(), defender, { distantThreat }, 1.0f))
+		<< "safe garrison heroes must stay available for extraction when there is no urgent town threat";
+}
+
 TEST(Nullkiller2_Behaviors_DefenceBehavior, sameTurnReturnPathAllowsSimpleRoundTrip)
 {
 	CGHeroInstance defender(nullptr);

--- a/test/nullkiller2/Behaviors/DefenceBehaviorTest.cpp
+++ b/test/nullkiller2/Behaviors/DefenceBehaviorTest.cpp
@@ -10,6 +10,7 @@
 
 #include "AI/Nullkiller2/Analyzers/DangerHitMapAnalyzer.h"
 #include "AI/Nullkiller2/Behaviors/DefenceBehavior.h"
+#include "AI/Nullkiller2/Behaviors/DefenceBehaviorUtils.h"
 #include "mock/TownFake.h"
 
 #include "lib/mapObjects/CGHeroInstance.h"

--- a/test/nullkiller2/Behaviors/DefenceBehaviorTest.cpp
+++ b/test/nullkiller2/Behaviors/DefenceBehaviorTest.cpp
@@ -238,6 +238,25 @@ TEST(Nullkiller2_Behaviors_DefenceBehavior, defenderReleaseAllowsEnemyTownCaptur
 		<< "a defender can leave for an enemy town once the home town has no meaningful current-week army left to buy";
 }
 
+TEST(Nullkiller2_Behaviors_DefenceBehavior, defenderReleaseAllowsEnemyTownCaptureWhenHomeStillNeedsFollowup)
+{
+	auto targetTown = townTarget();
+
+	CGHeroInstance defender(nullptr);
+	ASSERT_TRUE(defender.setCreature(SlotID(0), CreatureID::ARCHER, 100));
+
+	const auto remainingReinforcement = std::max<uint64_t>(1000, defender.getTotalStrength() / 20) + 1;
+	EXPECT_TRUE(NK2AI::Goals::isDefenderReleaseAllowedForTownCapture(
+		defender,
+		*targetTown.get(),
+		true,
+		false,
+		remainingReinforcement,
+		3,
+		7))
+		<< "do not keep a defender idle when it cannot make the home town stable and can capture an enemy town instead";
+}
+
 TEST(Nullkiller2_Behaviors_DefenceBehavior, defenderReleaseRejectsNonEnemyTownCapture)
 {
 	auto targetTown = townTarget();

--- a/test/nullkiller2/Behaviors/DefenceBehaviorTest.cpp
+++ b/test/nullkiller2/Behaviors/DefenceBehaviorTest.cpp
@@ -11,6 +11,7 @@
 #include "AI/Nullkiller2/Analyzers/DangerHitMapAnalyzer.h"
 #include "AI/Nullkiller2/Behaviors/DefenceBehavior.h"
 #include "AI/Nullkiller2/Behaviors/DefenceBehaviorUtils.h"
+#include "AI/Nullkiller2/Pathfinding/AINodeStorage.h"
 #include "mock/TownFake.h"
 
 #include "lib/mapObjects/CGHeroInstance.h"
@@ -23,6 +24,33 @@ NK2AI::HitMapInfo nextTurnThreat(uint64_t danger)
 	threat.turn = 1;
 	threat.danger = danger;
 	return threat;
+}
+
+NK2AI::AIPath sameTurnPath(const CGHeroInstance & hero, float movementCost)
+{
+	NK2AI::AIPath path;
+	path.targetHero = &hero;
+	path.heroArmy = &hero;
+	path.exchangeCount = 1;
+	path.targetObjectDanger = 0;
+	path.armyLoss = 0;
+	path.targetObjectArmyLoss = 0;
+	path.chainMask = 1;
+
+	NK2AI::AIPathNodeInfo node;
+	node.cost = movementCost;
+	node.turns = 0;
+	node.coord = int3(1, 1, 0);
+	node.layer = EPathfindingLayer::LAND;
+	node.danger = 0;
+	node.targetHero = &hero;
+	node.parentIndex = -1;
+	node.chainMask = 1;
+	node.actionIsBlocked = false;
+
+	path.nodes.push_back(node);
+
+	return path;
 }
 }
 
@@ -155,4 +183,26 @@ TEST(Nullkiller2_Behaviors_DefenceBehavior, reserveDefenderThatImprovesUrgentTow
 
 	EXPECT_TRUE(NK2AI::Goals::shouldReserveTownDefender(*town.get(), defender, threats, 1.0f))
 		<< "do not treat a useful garrison defender as free while urgent town danger remains";
+}
+
+TEST(Nullkiller2_Behaviors_DefenceBehavior, sameTurnReturnPathAllowsSimpleRoundTrip)
+{
+	CGHeroInstance defender(nullptr);
+	ASSERT_TRUE(defender.setCreature(SlotID(0), CreatureID::ARCHER, 1));
+
+	const auto path = sameTurnPath(defender, 0.45f);
+
+	EXPECT_TRUE(NK2AI::Goals::isSafeSameTurnReturnPath(defender, path, 1.0f, 1.0f))
+		<< "a garrison defender may raid only when the same turn has enough movement to return";
+}
+
+TEST(Nullkiller2_Behaviors_DefenceBehavior, sameTurnReturnPathRejectsPathWithoutReturnMovement)
+{
+	CGHeroInstance defender(nullptr);
+	ASSERT_TRUE(defender.setCreature(SlotID(0), CreatureID::ARCHER, 1));
+
+	const auto path = sameTurnPath(defender, 0.6f);
+
+	EXPECT_FALSE(NK2AI::Goals::isSafeSameTurnReturnPath(defender, path, 1.0f, 1.0f))
+		<< "a one-way reachable attack is not enough when the defender must be back after turn end";
 }

--- a/test/nullkiller2/Behaviors/DefenceBehaviorTest.cpp
+++ b/test/nullkiller2/Behaviors/DefenceBehaviorTest.cpp
@@ -52,6 +52,13 @@ NK2AI::AIPath sameTurnPath(const CGHeroInstance & hero, float movementCost)
 
 	return path;
 }
+
+test::TownFake townTarget()
+{
+	test::TownFake town;
+	town.get()->ID = Obj::TOWN;
+	return town;
+}
 }
 
 TEST(Nullkiller2_Behaviors_DefenceBehavior, castleDefenceCountsCommittedDefenderAndTowers)
@@ -194,6 +201,76 @@ TEST(Nullkiller2_Behaviors_DefenceBehavior, sameTurnReturnPathAllowsSimpleRoundT
 
 	EXPECT_TRUE(NK2AI::Goals::isSafeSameTurnReturnPath(defender, path, 1.0f, 1.0f))
 		<< "a garrison defender may raid only when the same turn has enough movement to return";
+}
+
+TEST(Nullkiller2_Behaviors_DefenceBehavior, defenderReleaseAllowsEnemyTownCaptureAfterArmyIsMostlyBought)
+{
+	auto targetTown = townTarget();
+
+	CGHeroInstance defender(nullptr);
+	ASSERT_TRUE(defender.setCreature(SlotID(0), CreatureID::ARCHER, 100));
+
+	const auto remainingReinforcement = defender.getTotalStrength() / 20;
+	EXPECT_TRUE(NK2AI::Goals::isDefenderReleaseAllowedForTownCapture(
+		defender,
+		*targetTown.get(),
+		true,
+		remainingReinforcement,
+		3,
+		7))
+		<< "a defender can leave for an enemy town once the home town has no meaningful current-week army left to buy";
+}
+
+TEST(Nullkiller2_Behaviors_DefenceBehavior, defenderReleaseRejectsNonEnemyTownCapture)
+{
+	auto targetTown = townTarget();
+
+	CGHeroInstance defender(nullptr);
+	ASSERT_TRUE(defender.setCreature(SlotID(0), CreatureID::ARCHER, 100));
+
+	EXPECT_FALSE(NK2AI::Goals::isDefenderReleaseAllowedForTownCapture(
+		defender,
+		*targetTown.get(),
+		false,
+		0,
+		3,
+		7))
+		<< "releasing a defender is reserved for enemy town captures, not neutral or allied visits";
+}
+
+TEST(Nullkiller2_Behaviors_DefenceBehavior, defenderReleaseRejectsMeaningfulUnboughtArmy)
+{
+	auto targetTown = townTarget();
+
+	CGHeroInstance defender(nullptr);
+	ASSERT_TRUE(defender.setCreature(SlotID(0), CreatureID::ARCHER, 100));
+
+	const auto remainingReinforcement = std::max<uint64_t>(1000, defender.getTotalStrength() / 20) + 1;
+	EXPECT_FALSE(NK2AI::Goals::isDefenderReleaseAllowedForTownCapture(
+		defender,
+		*targetTown.get(),
+		true,
+		remainingReinforcement,
+		3,
+		7))
+		<< "buying the current-week army should happen before a defender takes a risky town-capture trip";
+}
+
+TEST(Nullkiller2_Behaviors_DefenceBehavior, defenderReleaseRejectsEndOfWeekGrowthRisk)
+{
+	auto targetTown = townTarget();
+
+	CGHeroInstance defender(nullptr);
+	ASSERT_TRUE(defender.setCreature(SlotID(0), CreatureID::ARCHER, 100));
+
+	EXPECT_FALSE(NK2AI::Goals::isDefenderReleaseAllowedForTownCapture(
+		defender,
+		*targetTown.get(),
+		true,
+		1,
+		7,
+		7))
+		<< "do not risk losing fresh week growth unless the town is fully bought out";
 }
 
 TEST(Nullkiller2_Behaviors_DefenceBehavior, sameTurnReturnPathRejectsPathWithoutReturnMovement)

--- a/test/nullkiller2/Behaviors/DefenceBehaviorTest.cpp
+++ b/test/nullkiller2/Behaviors/DefenceBehaviorTest.cpp
@@ -231,6 +231,7 @@ TEST(Nullkiller2_Behaviors_DefenceBehavior, defenderReleaseAllowsEnemyTownCaptur
 		defender,
 		*targetTown.get(),
 		true,
+		true,
 		remainingReinforcement,
 		3,
 		7))
@@ -247,6 +248,7 @@ TEST(Nullkiller2_Behaviors_DefenceBehavior, defenderReleaseRejectsNonEnemyTownCa
 	EXPECT_FALSE(NK2AI::Goals::isDefenderReleaseAllowedForTownCapture(
 		defender,
 		*targetTown.get(),
+		false,
 		false,
 		0,
 		3,
@@ -266,6 +268,7 @@ TEST(Nullkiller2_Behaviors_DefenceBehavior, defenderReleaseRejectsMeaningfulUnbo
 		defender,
 		*targetTown.get(),
 		true,
+		true,
 		remainingReinforcement,
 		3,
 		7))
@@ -282,6 +285,7 @@ TEST(Nullkiller2_Behaviors_DefenceBehavior, defenderReleaseRejectsEndOfWeekGrowt
 	EXPECT_FALSE(NK2AI::Goals::isDefenderReleaseAllowedForTownCapture(
 		defender,
 		*targetTown.get(),
+		true,
 		true,
 		1,
 		7,

--- a/test/nullkiller2/Engine/PriorityEvaluatorTest.cpp
+++ b/test/nullkiller2/Engine/PriorityEvaluatorTest.cpp
@@ -1,0 +1,49 @@
+/*
+ * PriorityEvaluatorTest.cpp, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ */
+#include "StdInc.h"
+
+#include "AI/Nullkiller2/Engine/PriorityEvaluator.h"
+
+TEST(Nullkiller2_Engine_PriorityEvaluator, enemyTownConquestBeatsOrdinaryHeroHunting)
+{
+	EXPECT_GT(NK2AI::evaluateEnemyTownConquestValue(0.8f, 3), 2.0f * 1.5f)
+		<< "visible enemy towns should clearly outrank the capped strategic value of a loose enemy hero";
+}
+
+TEST(Nullkiller2_Engine_PriorityEvaluator, lastVisibleEnemyTownGetsEliminationPressure)
+{
+	EXPECT_GT(
+		NK2AI::evaluateEnemyTownConquestValue(1.0f, 1),
+		NK2AI::evaluateEnemyTownConquestValue(1.5f, 3))
+		<< "taking the last visible enemy town should outrank a normal enemy capital capture";
+}
+
+TEST(Nullkiller2_Engine_PriorityEvaluator, nonEnemyTownKeepsBaseConquestValue)
+{
+	EXPECT_FLOAT_EQ(
+		NK2AI::evaluateEnemyTownConquestValue(1.2f, 0),
+		1.2f)
+		<< "only visible enemy towns should get extra conquest pressure";
+}
+
+TEST(Nullkiller2_Engine_PriorityEvaluator, enemyTownConquestCanRelaxArmyLossLimit)
+{
+	EXPECT_GT(
+		NK2AI::evaluateMaxArmyLossForConquest(0.35f, 5.25f, true),
+		0.39f)
+		<< "enemy town conquest should not be rejected by the ordinary creeping loss cap";
+}
+
+TEST(Nullkiller2_Engine_PriorityEvaluator, ordinaryTargetsKeepArmyLossLimit)
+{
+	EXPECT_FLOAT_EQ(
+		NK2AI::evaluateMaxArmyLossForConquest(0.35f, 5.25f, false),
+		0.35f)
+		<< "the relaxed loss cap is only for enemy-town conquest";
+}

--- a/test/nullkiller2/Goals/ExploreNeighbourTileTest.cpp
+++ b/test/nullkiller2/Goals/ExploreNeighbourTileTest.cpp
@@ -9,10 +9,31 @@
  */
 #include "StdInc.h"
 
+#include "AI/Nullkiller2/AIGateway.h"
 #include "AI/Nullkiller2/Goals/ExploreNeighbourTile.h"
+
+#include "mock/TinyH3MBuilder.h"
+#include "mock/mock_MapServiceTinyH3M.h"
+#include "mock/mock_Services.h"
+
+#include "lib/CPlayerState.h"
+#include "lib/StartInfo.h"
+#include "lib/callback/CCallback.h"
+#include "lib/callback/GameRandomizer.h"
+#include "lib/filesystem/ResourcePath.h"
+#include "lib/gameState/CGameState.h"
+#include "lib/mapObjects/CGHeroInstance.h"
+#include "lib/mapping/CMap.h"
+#include "lib/mapping/CMapHeader.h"
+
+#include <cstdio>
+#include <cstdlib>
 
 namespace
 {
+const PlayerColor PLAYER = PlayerColor(0);
+const PlayerColor ENEMY = PlayerColor(1);
+
 NK2AI::NeighbourExplorationCandidate makeAcceptedCandidate()
 {
 	NK2AI::NeighbourExplorationCandidate candidate;
@@ -23,6 +44,157 @@ NK2AI::NeighbourExplorationCandidate makeAcceptedCandidate()
 	candidate.movementCost = 0.5f;
 	return candidate;
 }
+
+TinyH3M::TinyH3MBuilder makeStrategicNeighbourMap()
+{
+	TinyH3M::TinyH3MBuilder builder(EMapFormat::SOD);
+	builder
+		.size(36, false)
+		.name("NK2StrategicNeighbour")
+		.playerActive(PLAYER)
+		.playerActive(ENEMY)
+		.hero({5, 5, 0}, HeroTypeID(0), PLAYER)
+		.heroGarrison({{CreatureID(27), 1}})
+		.randomTown({9, 5, 0}, ENEMY);
+
+	return builder;
+}
+
+class VisitabilityTrapObject : public CGObjectInstance
+{
+public:
+	using CGObjectInstance::CGObjectInstance;
+
+	bool wasVisited(const CGHeroInstance *) const override
+	{
+		std::fputs(
+			"ExploreNeighbourTile queried remembered object visitability while scoring a neighbour\n",
+			stderr);
+		std::abort();
+	}
+};
+
+class Nullkiller2_Goals_ExploreNeighbourTileStrategic : public ::testing::Test, public MapListener
+{
+public:
+	void SetUp() override
+	{
+		gameState = std::make_shared<CGameState>();
+		gameState->preInit(&services);
+	}
+
+	void TearDown() override
+	{
+		gameState.reset();
+		mapService.reset();
+		map = nullptr;
+	}
+
+	void mapLoaded(CMap * loadedMap) override
+	{
+		EXPECT_EQ(map, nullptr);
+		map = loadedMap;
+	}
+
+	void startWithMap(TinyH3M::TinyH3MBuilder builder)
+	{
+		auto bytes = builder.build();
+		mapService = std::make_unique<MapServiceTinyH3M>(std::move(bytes), this);
+
+		StartInfo si;
+		si.mapname = "tiny";
+		si.difficulty = 0;
+		si.mode = EStartMode::NEW_GAME;
+
+		auto header = mapService->loadMapHeader(ResourcePath(si.mapname));
+		ASSERT_NE(header.get(), nullptr) << "TinyH3M scenario header failed to load";
+
+		for(int i = 0; i < static_cast<int>(header->players.size()); ++i)
+		{
+			const PlayerInfo & pinfo = header->players[i];
+			if(!(pinfo.canHumanPlay || pinfo.canComputerPlay))
+				continue;
+
+			PlayerSettings & pset = si.playerInfos[PlayerColor(i)];
+			pset.color = PlayerColor(i);
+			pset.connectedPlayerIDs.insert(static_cast<PlayerConnectionID>(i));
+			pset.name = "Player";
+			pset.castle = pinfo.defaultCastle();
+			pset.hero = pinfo.defaultHero();
+		}
+
+		GameRandomizer randomizer(*gameState);
+		Load::ProgressAccumulator progressTracker;
+		gameState->init(mapService.get(), &si, randomizer, progressTracker, false);
+
+		ASSERT_NE(map, nullptr) << "gameState init did not populate the CMap";
+	}
+
+	CGHeroInstance * findHeroByOwner(PlayerColor owner) const
+	{
+		for(const auto & obj : map->objects)
+		{
+			auto * hero = dynamic_cast<CGHeroInstance *>(obj.get());
+			if(hero && hero->getOwner() == owner)
+				return hero;
+		}
+		return nullptr;
+	}
+
+	void setAllTilesVisible(PlayerColor player, bool visible)
+	{
+		auto & fow = teamState(player).fogOfWarMap;
+
+		for(int z = 0; z < map->levels(); ++z)
+		{
+			for(int x = 0; x < map->width; ++x)
+			{
+				for(int y = 0; y < map->height; ++y)
+					fow[int3(x, y, z)] = visible ? 1 : 0;
+			}
+		}
+	}
+
+	std::shared_ptr<CCallback> makeCallback(PlayerColor player)
+	{
+		return std::make_shared<CCallback>(gameState, std::optional<PlayerColor>{player}, nullptr);
+	}
+
+	std::unique_ptr<NK2AI::AIGateway> makeGateway(const std::shared_ptr<CCallback> & callback)
+	{
+		auto gateway = std::make_unique<NK2AI::AIGateway>();
+		gateway->initGameInterface(std::shared_ptr<Environment>(), callback);
+		return gateway;
+	}
+
+	CGObjectInstance * addVisitabilityTrapObject(
+		const std::shared_ptr<CCallback> & callback,
+		const CGObjectInstance * appearanceSource,
+		const int3 & pos)
+	{
+		auto trap = std::make_shared<VisitabilityTrapObject>(callback.get());
+		trap->ID = Obj::ARTIFACT;
+		trap->subID = MapObjectSubID(0);
+		trap->tempOwner = PLAYER;
+		trap->id = ObjectInstanceID(static_cast<si32>(map->objects.size()));
+		trap->appearance = appearanceSource->appearance;
+		trap->setAnchorPos(pos);
+
+		map->objects.push_back(trap);
+		return trap.get();
+	}
+
+private:
+	TeamState & teamState(PlayerColor player)
+	{
+		return gameState->teams.at(gameState->players.at(player).team);
+	}
+
+	std::shared_ptr<CGameState> gameState;
+	std::unique_ptr<MapServiceTinyH3M> mapService;
+	ServicesMock services;
+	CMap * map = nullptr;
+};
 }
 
 TEST(Nullkiller2_Goals_ExploreNeighbourTile, acceptsSafeSameDayDiscovery)
@@ -78,4 +250,48 @@ TEST(Nullkiller2_Goals_ExploreNeighbourTile, rejectsMoveWithNoDiscovery)
 	candidate.tilesDiscovered = 0;
 
 	EXPECT_FALSE(NK2AI::evaluateNeighbourExplorationCandidate(candidate).accepted);
+}
+
+TEST_F(Nullkiller2_Goals_ExploreNeighbourTileStrategic, findsVisibleStrategicTargetWithoutNewDiscovery)
+{
+	startWithMap(makeStrategicNeighbourMap());
+
+	auto * hero = findHeroByOwner(PLAYER);
+	ASSERT_NE(hero, nullptr);
+	hero->setMovementPoints(2000);
+
+	setAllTilesVisible(PLAYER, true);
+
+	const auto callback = makeCallback(PLAYER);
+	const auto gateway = makeGateway(callback);
+	const auto target = NK2AI::Goals::ExploreNeighbourTile::findTarget(
+		hero,
+		gateway->nullkiller.get());
+
+	ASSERT_TRUE(target.has_value());
+	EXPECT_EQ(target->tilesDiscovered, 0);
+}
+
+TEST_F(Nullkiller2_Goals_ExploreNeighbourTileStrategic, ignoresKnownObjectsBeforeVisitabilityChecks)
+{
+	startWithMap(makeStrategicNeighbourMap());
+
+	auto * hero = findHeroByOwner(PLAYER);
+	ASSERT_NE(hero, nullptr);
+	ASSERT_NE(hero->appearance, nullptr);
+	hero->setMovementPoints(2000);
+
+	setAllTilesVisible(PLAYER, true);
+
+	const auto callback = makeCallback(PLAYER);
+	const auto gateway = makeGateway(callback);
+	auto * trap = addVisitabilityTrapObject(callback, hero, int3(30, 30, 0));
+	gateway->nullkiller->memory->addVisitableObject(trap);
+
+	const auto target = NK2AI::Goals::ExploreNeighbourTile::findTarget(
+		hero,
+		gateway->nullkiller.get());
+
+	ASSERT_TRUE(target.has_value());
+	EXPECT_EQ(target->tilesDiscovered, 0);
 }


### PR DESCRIPTION
Follow-up to https://github.com/vcmi/vcmi/pull/7452

PR #7452 made Nullkiller treat urgent next-turn town threats as defensive recruitment emergencies and keep a stable defender after turn end. @GrafDeVan's saves ok.zip and NewTestAgain.zip showed one remaining weak spot: a hero already locked in town garrison for `DEFENCE` was treated as unavailable even when it could safely attack the nearby threat and get back into the town on the same turn. That kept the AI passive in positions where the stable-defender invariant can be preserved and the threat can still be removed.

`NewTestAgain` also exposed a separate timing issue: non-movement tasks can open AI queries, for example a level-up dialog after a town building/reward, and the next selected movement task could start before the query was fully processed. That showed up as a stale movement attempt after a pending query.

## What changed

- A garrison hero can now be used for a defensive counterattack if the hero is not locked for unrelated work, the threat is verified and urgent, and the path is a simple same-hero, same-turn path.
- The return-path predicate rejects blocked actions, special actions, hero-chain paths, unsafe fights, and paths whose one-way movement cost does not leave enough movement to return to town.
- The generated defensive task explicitly extracts the garrison hero, executes the attack, then returns the same hero to the town and locks it for `DEFENCE`.
- Existing stable-defence rules remain intact: normal counterattack/explore plans still require stable town defence after turn end, while the new garrison task is only allowed when it itself restores that invariant.
- Nullkiller now waits for pending AI queries, visits, movement, and battles before and after executing a selected task. This avoids stale follow-up movement after tasks that open dialogs.
- Defence behavior helper declarations were moved out of `DefenceBehavior.h` into `DefenceBehaviorUtils.h`, so the behavior header no longer needs `<vector>`.

## Regression coverage

Added focused unit coverage for the same-turn return predicate.

If the garrison counterattack fix is reverted while the tests are kept, `vcmitest` still builds and `sameTurnReturnPathAllowsSimpleRoundTrip` fails with:

```text
[ RUN      ] Nullkiller2_Behaviors_DefenceBehavior.sameTurnReturnPathAllowsSimpleRoundTrip
test/nullkiller2/Behaviors/DefenceBehaviorTest.cpp:195: Failure
Value of: NK2AI::Goals::isSafeSameTurnReturnPath(defender, path, 1.0f, 1.0f)
  Actual: false
Expected: true
a garrison defender may raid only when the same turn has enough movement to return
[  FAILED  ] Nullkiller2_Behaviors_DefenceBehavior.sameTurnReturnPathAllowsSimpleRoundTrip
```

`sameTurnReturnPathRejectsPathWithoutReturnMovement` still passes in that reverted tree because the old conservative predicate rejects every return path; it guards the opposite side of the rule, where a one-way attack must not be accepted as a valid defensive return.

## Validation

- Replayed all sample maps/saves attached by @GrafDeVan in #7452: `Strange Case`, `Strange CaseFinal`, `4TEST`, `114`, `ok`, `NewTestAgain`, and `Treat next-turn town threats as recruit emergencies.h3m`. They are still green.
- `NewTestAgain` no longer shows the pending-query / `Invalid path found!` sequence found while validating this follow-up.
