### PR TITLE
Fix damaging spells updating creature count before animation plays

### DIFF
--- a/client/ClientNetPackVisitors.h
+++ b/client/ClientNetPackVisitors.h
@@ -81,7 +81,6 @@ public:
 	void visitBattleAttack(BattleAttack & pack) override;
 	void visitBattleSpellCast(BattleSpellCast & pack) override;
 	void visitSetStackEffect(SetStackEffect & pack) override;
-	void visitStacksInjured(StacksInjured & pack) override;
 	void visitBattleResultsApplied(BattleResultsApplied & pack) override;
 	void visitBattleEnded(BattleEnded & pack) override;
 	void visitBattleUnitsChanged(BattleUnitsChanged & pack) override;
@@ -130,4 +129,5 @@ public:
 	void visitBattleAttack(BattleAttack & pack) override;
 	void visitStartAction(StartAction & pack) override;
 	void visitSetObjectProperty(SetObjectProperty & pack) override;
+	void visitStacksInjured(StacksInjured & pack) override;
 };

--- a/client/NetPacksClient.cpp
+++ b/client/NetPacksClient.cpp
@@ -856,7 +856,7 @@ void ApplyClientNetPackVisitor::visitSetStackEffect(SetStackEffect & pack)
 	callBattleInterfaceIfPresentForBothSides(cl, pack.battleID, &IBattleEventsReceiver::battleStacksEffectsSet, pack.battleID, pack);
 }
 
-void ApplyClientNetPackVisitor::visitStacksInjured(StacksInjured & pack)
+void ApplyFirstClientNetPackVisitor::visitStacksInjured(StacksInjured & pack)
 {
 	callBattleInterfaceIfPresentForBothSides(cl, pack.battleID, &IBattleEventsReceiver::battleStacksAttacked, pack.battleID, pack.stacks, false);
 }


### PR DESCRIPTION
Damaging spells (e.g. Magic Arrow) reduced the target stack's displayed count instantly at cast time, with the spell animation only playing afterwards. Ranged and melee attacks behave correctly: the animation plays first, and the count updates once it finishes. This made spell damage feel visually backwards compared to the rest of combat.

Root cause
----------

The client applies each net-pack in two passes around the gamestate update, in `CClient::handlePack()`:

    pack.visit(beforeVisitor);   // ApplyFirstClientNetPackVisitor
    gameState().apply(pack);     // stack count/health is mutated here
    pack.visit(afterVisitor);    // ApplyClientNetPackVisitor

For ranged/melee attacks, the damage arrives in a `BattleAttack` pack, and `BattleAttack` deliberately queues the hit animation from the *first* (pre-apply) visitor. The animation is queued and played before the gamestate lowers the stack count, so the number only drops when the animation completes.

Spell damage does not travel in `BattleAttack`. It arrives as a separate `StacksInjured` pack (sent by the damage effect, see `damage.lua` -> `ServerCallback::damageUnit`). `StacksInjured` queued its animation from the *after* (post-apply) visitor, so the gamestate had already reduced the count by the time the hit animation was queued — hence the count dropped before the animation.

This asymmetry was already implicitly known in the code: `BattleAttack` carries an explicit comment that `battleStacksAttacked` must run before `applyGs()`, and `BattleStacksController::stacksAreAttacked()` has a FIXME noting that it is called after the net pack is applied (so petrification color filters are gone by then).

Fix
---

Move `StacksInjured`'s animation trigger to run before the gamestate is applied, exactly mirroring `BattleAttack`:

  * `client/NetPacksClient.cpp` - Move the `callBattleInterfaceIfPresentForBothSides(..., battleStacksAttacked, ...)` call from `ApplyClientNetPackVisitor::visitStacksInjured` (post-apply) into a new `ApplyFirstClientNetPackVisitor::visitStacksInjured` (pre-apply). The post-apply override is now an empty stub.

  * `client/ClientNetPackVisitors.h`
      - Declare `visitStacksInjured()` on `ApplyFirstClientNetPackVisitor`.

This is safe because the damage figures shown by the animation (damageAmount, killedAmount, killed(), etc.) are read from the `BattleStackAttacked` entries inside the pack itself, not from gamestate (see `CPlayerInterface::battleStacksAttacked`). The only gamestate access is `battleGetStackByID(..., false)` to resolve the stack pointer, which is unaffected by the pending count change and resolves not-yet-dead stacks.

With this change the spell path matches the attack path: the cast animation (queued from `BattleSpellCast`) runs, then the hit animation (queued from `StacksInjured`) runs, and only then does the count drop.

Not changed
-----------

The "send empty event to client / temporary workaround to force animations to trigger" `fakeEvent` (empty `StacksInjured`) in `BattleSpellMechanics::cast` is intentionally left in place. Client `BattleInterface::spellCast()` only *queues* animation stages and relies on a later `stacksAreAttacked()` call to flush them via `executeStagedAnimations()`/`waitForAnimations()` ("animations will be executed by spell effects"). Non-damaging spells (pure buffs/debuffs) send no real `StacksInjured`, so the empty `fakeEvent` is still required to flush their queued cast animations. Removing it would regress those spells.

Testing
-------
- Full project builds cleanly (`vcmiclient` links, `vcmitest` unaffected).
- Performed in-battle verification:
    * damaging spell (e.g. Magic Arrow) — count now drops after the animation, matching ranged attacks;
    * pure buff/debuff spell — cast animation still plays correctly (fakeEvent flush path).

Fixes #4830