### PR TITLE
Fix Bless and Curse spell targets

### DIFF
--- a/config/spells/timed.json
+++ b/config/spells/timed.json
@@ -395,7 +395,8 @@
 		},
 		"targetCondition" : {
 			"noneOf" : {
-				"bonus.SIEGE_WEAPON" : "absolute",
+				"core:creature.firstAidTent" : "absolute",
+				"core:creature.ammoCart" : "absolute",
 				"bonus.UNDEAD" : "absolute"
 			}
 		}
@@ -447,7 +448,8 @@
 		},
 		"targetCondition" : {
 			"noneOf" : {
-				"bonus.SIEGE_WEAPON" : "absolute",
+				"core:creature.firstAidTent" : "absolute",
+				"core:creature.ammoCart" : "absolute",
 				"bonus.UNDEAD" : "absolute"
 			}
 		}


### PR DESCRIPTION
In OH3, Bless and Curse can both be cast on the Ballista, but not on the other war machines. In VCMI, all war machines were immune.

Bless:
https://github.com/user-attachments/assets/4c322e27-91e4-448b-8878-7681fac69c5f


Curse:
https://github.com/user-attachments/assets/ceb51dea-f713-430e-8406-9eb104277305

