### PR TITLE
mapeditor: add widget for shrines + fixes

### DIFF
--- a/include/vcmi/spells/Spell.h
+++ b/include/vcmi/spells/Spell.h
@@ -40,6 +40,7 @@ public:
 	virtual bool isDamage() const = 0;
 	virtual bool isOffensive() const = 0;
 	virtual bool isSpecial() const = 0;
+	virtual bool isCommonHeroSpell() const = 0;
 	virtual bool isMagical() const = 0; //Should this spell considered as magical effect or as ability (like dendroid's bind)
 
 	virtual bool hasSchool(SpellSchool school) const = 0;

--- a/lib/json/JsonKeyExtractor.cpp
+++ b/lib/json/JsonKeyExtractor.cpp
@@ -26,6 +26,11 @@ si32 JsonKeyExtractor::loadVariable(const std::string & variableGroup, const std
 	return variables.at(variableID);
 }
 
+bool JsonKeyExtractor::canOverwriteMapSettings(const JsonNode & value)
+{
+	return value.isString();
+}
+
 std::set<ArtifactID> JsonKeyExtractor::filterKeysTyped(const JsonNode & value, const std::set<ArtifactID> & valuesSet)
 {
 	assert(value.isStruct());

--- a/lib/json/JsonKeyExtractor.cpp
+++ b/lib/json/JsonKeyExtractor.cpp
@@ -26,7 +26,7 @@ si32 JsonKeyExtractor::loadVariable(const std::string & variableGroup, const std
 	return variables.at(variableID);
 }
 
-bool JsonKeyExtractor::canOverwriteMapSettings(const JsonNode & value)
+bool JsonKeyExtractor::canOverwriteMapSettings(const JsonNode & value) const
 {
 	return value.isString();
 }

--- a/lib/json/JsonKeyExtractor.h
+++ b/lib/json/JsonKeyExtractor.h
@@ -21,7 +21,7 @@ public:
 
 	si32 loadVariable(const std::string & variableGroup, const std::string & value, const Variables & variables, si32 defaultValue);
 
-	bool canOverwriteMapSettings(const JsonNode & value);
+	bool canOverwriteMapSettings(const JsonNode & value) const;
 
 private:
 	template<typename IdentifierType>

--- a/lib/json/JsonKeyExtractor.h
+++ b/lib/json/JsonKeyExtractor.h
@@ -21,6 +21,8 @@ public:
 
 	si32 loadVariable(const std::string & variableGroup, const std::string & value, const Variables & variables, si32 defaultValue);
 
+	bool canOverwriteMapSettings(const JsonNode & value);
+
 private:
 	template<typename IdentifierType>
 	IdentifierType decodeKey(const JsonNode & value, const Variables & variables);
@@ -41,7 +43,7 @@ std::set<IdentifierType> JsonKeyExtractor::filterKeys(const JsonNode & value, co
     // if value is string do not filter value through valueSet. It allows objects like scholar to override map settings
     // (i.e grant a skill that is blocked by map settings). It is intentional.
     // TODO: refactor class so this behaviour is clearly reflected by api.
-	if(value.isString())
+	if(canOverwriteMapSettings(value))
         return {decodeKey<IdentifierType>(value, variables)};
 
 	assert(value.isStruct());

--- a/lib/spells/CSpell.cpp
+++ b/lib/spells/CSpell.cpp
@@ -235,6 +235,12 @@ bool CSpell::isSpecial() const
 	return special;
 }
 
+bool CSpell::isCommonHeroSpell() const
+{
+	return !isSpecial() && !isCreatureAbility();
+}
+
+
 bool CSpell::hasEffects() const
 {
 	return !levels[0].effects.Struct().empty() || !levels[0].cumulativeEffects.Struct().empty();

--- a/lib/spells/CSpell.h
+++ b/lib/spells/CSpell.h
@@ -173,6 +173,7 @@ public:
 	bool isOffensive() const override;
 
 	bool isSpecial() const override;
+	bool isCommonHeroSpell() const override;
 
 	bool isAdventure() const override;
 	bool isCombat() const override;

--- a/mapeditor/CMakeLists.txt
+++ b/mapeditor/CMakeLists.txt
@@ -46,6 +46,7 @@ set(editor_SRCS
 		inspector/playerselectionwidget.cpp
 		inspector/abilitieswidget.cpp
 		inspector/scholarwidget.cpp
+		inspector/shrinewidget.cpp
 		resourceExtractor/ResourceConverter.cpp
 		helper.cpp
 		campaigneditor/campaigneditor.cpp
@@ -120,6 +121,8 @@ set(editor_HEADERS
 		inspector/playerselectionwidget.h
 		inspector/abilitieswidget.h
 		inspector/scholarwidget.h
+		inspector/shrinewidget.h
+		inspector/WidgetInitializationException.h
 		resourceExtractor/ResourceConverter.h
 		mapeditorroles.h
 		helper.h
@@ -180,6 +183,7 @@ set(editor_FORMS
 		inspector/playerselectionwidget.ui
 		inspector/abilitieswidget.ui
 		inspector/scholarwidget.ui
+		inspector/shrinewidget.ui
 		campaigneditor/campaigneditor.ui
 		campaigneditor/campaignproperties.ui
 		campaigneditor/scenarioproperties.ui

--- a/mapeditor/inspector/WidgetInitializationException.h
+++ b/mapeditor/inspector/WidgetInitializationException.h
@@ -1,0 +1,25 @@
+/*
+ * WidgetInitializationException.h, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
+#pragma once
+
+#include <QString>
+
+class WidgetInitializationException : public std::exception
+{
+	const QString msg;
+
+public:
+	explicit WidgetInitializationException(const QString & message) : msg(message) {}
+
+	QString message() const
+	{
+		return msg;
+	}
+};

--- a/mapeditor/inspector/inspector.cpp
+++ b/mapeditor/inspector/inspector.cpp
@@ -37,6 +37,7 @@
 #include "questwidget.h"
 #include "rewardswidget.h"
 #include "scholarwidget.h"
+#include "shrinewidget.h"
 #include "townbuildingswidget.h"
 #include "towneventswidget.h"
 #include "townspellswidget.h"
@@ -468,6 +469,13 @@ void Inspector::updateProperties(CRewardableObject * o)
 		case MapObjectID::SCHOLAR:
 		{
 			delegate = new ScholarDelegate(controller, *o);
+			break;
+		}
+		case MapObjectID::SHRINE_OF_MAGIC_INCANTATION:
+		case MapObjectID::SHRINE_OF_MAGIC_GESTURE:
+		case MapObjectID::SHRINE_OF_MAGIC_THOUGHT:
+		{
+			delegate = new ShrineDelegate(controller, *o);
 			break;
 		}
 		default:

--- a/mapeditor/inspector/scholarwidget.cpp
+++ b/mapeditor/inspector/scholarwidget.cpp
@@ -54,9 +54,12 @@ void ScholarWidget::loadData()
 	int spi = 0;
 	for(const auto & spell : LIBRARY->spellh->objects)
 	{
-		ui->spells->insertItem(spi, QString::fromStdString(spell->getNameTranslated()));
-		ui->spells->setItemData(spi, QString::fromStdString(spell->getJsonKey()));
-		spi++;
+		if(spell->isCommonHeroSpell())
+		{
+			ui->spells->insertItem(spi, QString::fromStdString(spell->getNameTranslated()));
+			ui->spells->setItemData(spi, QString::fromStdString(spell->getJsonKey()));
+			spi++;
+		}
 	}
 
 	auto allowCompletion = [](QComboBox * comboBox)

--- a/mapeditor/inspector/shrinewidget.cpp
+++ b/mapeditor/inspector/shrinewidget.cpp
@@ -43,7 +43,7 @@ void ShrineWidget::loadData()
 	si64 spellLevel = getSpellLevel();
 	for(const auto & spell : LIBRARY->spellh->objects)
 	{
-		if(spell->getLevel() == spellLevel)
+		if(spell->isCommonHeroSpell() && spell->getLevel() == spellLevel)
 		{
 			ui->spells->insertItem(i, QString::fromStdString(spell->getNameTranslated()));
 			ui->spells->setItemData(i, QString::fromStdString(spell->getJsonKey()));

--- a/mapeditor/inspector/shrinewidget.cpp
+++ b/mapeditor/inspector/shrinewidget.cpp
@@ -18,6 +18,7 @@
 #include "../../lib/mapObjectConstructors/CObjectClassesHandler.h"
 #include "../../lib/mapObjectConstructors/IObjectInfo.h"
 #include "../../lib/rewardable/Info.h"
+#include "../helper.h"
 #include "lib/CSkillHandler.h"
 #include "lib/GameLibrary.h"
 #include "lib/constants/StringConstants.h"
@@ -30,6 +31,7 @@ ShrineWidget::ShrineWidget(CRewardableObject & shrine, MapController & controlle
 	: QDialog(parent), ui(new Ui::ShrineWidget), shrine(shrine), extractor(controller.getCallback()), controller(controller)
 {
 	ui->setupUi(this);
+	Helper::decorateDialog(this);
 }
 
 ShrineWidget::~ShrineWidget()
@@ -77,7 +79,7 @@ si64 ShrineWidget::getSpellLevel()
 	JsonNode spellLevelNode;
 	try
 	{
-		spellLevelNode = static_cast<Rewardable::Info *>(objectInfo.get())->getParameters()["variables"][PRESET_CATEGORY][PRESET_NAME]["level"];
+		spellLevelNode = dynamic_cast<Rewardable::Info &>(*objectInfo.get()).getParameters()["variables"][PRESET_CATEGORY][PRESET_NAME]["level"];
 	}
 	catch(std::runtime_error &)
 	{

--- a/mapeditor/inspector/shrinewidget.cpp
+++ b/mapeditor/inspector/shrinewidget.cpp
@@ -1,0 +1,188 @@
+/*
+ * shrinewidget.cpp, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
+#include "StdInc.h"
+#include "WidgetInitializationException.h"
+#include "inspector.h"
+#include "mapcontroller.h"
+#include "shrinewidget.h"
+#include "ui_shrinewidget.h"
+
+#include "../../lib/mapObjectConstructors/AObjectTypeHandler.h"
+#include "../../lib/mapObjectConstructors/CObjectClassesHandler.h"
+#include "../../lib/mapObjectConstructors/IObjectInfo.h"
+#include "../../lib/rewardable/Info.h"
+#include "lib/CSkillHandler.h"
+#include "lib/GameLibrary.h"
+#include "lib/constants/StringConstants.h"
+#include "lib/mapping/CMap.h"
+#include "lib/modding/IdentifierStorage.h"
+#include "lib/modding/ModScope.h"
+#include "lib/spells/CSpellHandler.h"
+
+ShrineWidget::ShrineWidget(CRewardableObject & shrine, MapController & controller, QWidget * parent)
+	: QDialog(parent), ui(new Ui::ShrineWidget), shrine(shrine), extractor(controller.getCallback()), controller(controller)
+{
+	ui->setupUi(this);
+}
+
+ShrineWidget::~ShrineWidget()
+{
+	delete ui;
+}
+
+void ShrineWidget::loadData()
+{
+	int i = 0;
+	si64 spellLevel = getSpellLevel();
+	for(const auto & spell : LIBRARY->spellh->objects)
+	{
+		if(spell->getLevel() == spellLevel)
+		{
+			ui->spells->insertItem(i, QString::fromStdString(spell->getNameTranslated()));
+			ui->spells->setItemData(i, QString::fromStdString(spell->getJsonKey()));
+			i++;
+		}
+	}
+
+	ui->spells->completer()->setCompletionMode(QCompleter::PopupCompletion);
+	ui->spells->completer()->setFilterMode(Qt::MatchContains);
+
+	loadState();
+}
+
+void ShrineWidget::commitChanges()
+{
+	shrine.configuration.variables.preset.clear();
+	if(ui->random->isChecked())
+		return;
+
+	auto & scb = ui->spells;
+	JsonNode variable;
+	variable.String() = scb->itemData(scb->currentIndex()).toString().toStdString();
+	variable.setModScope(ModScope::scopeGame());
+	shrine.configuration.presetVariable(PRESET_CATEGORY, PRESET_NAME, variable);
+}
+
+si64 ShrineWidget::getSpellLevel()
+{
+	static const QString genericWarningMessage = tr("MapEditor was unable to read intended spell level for this shrine type");
+	std::unique_ptr<IObjectInfo> objectInfo = LIBRARY->objtypeh->getHandlerFor(shrine.ID, shrine.subID)->getObjectInfo();
+	JsonNode spellLevelNode;
+	try
+	{
+		spellLevelNode = static_cast<Rewardable::Info *>(objectInfo.get())->getParameters()["variables"][PRESET_CATEGORY][PRESET_NAME]["level"];
+	}
+	catch(std::runtime_error &)
+	{
+		throw WidgetInitializationException(genericWarningMessage);
+	}
+	if(!spellLevelNode.isNumber())
+		throw WidgetInitializationException(genericWarningMessage);
+	si64 spellLevel = spellLevelNode.Integer();
+	if(spellLevel < 1 || spellLevel > GameConstants::SPELL_LEVELS)
+		throw WidgetInitializationException(tr("Intended spell level %1 for this shrine type is invalid").arg(spellLevel));
+	return spellLevel;
+}
+
+void ShrineWidget::loadState()
+{
+	JsonNode variableNode = shrine.configuration.getPresetVariable(PRESET_CATEGORY, PRESET_NAME);
+	if(!variableNode.isNull())
+	{
+		const std::string & presetVariable = variableNode.String();
+		int index = ui->spells->findData(QString::fromStdString(presetVariable));
+		if(index != -1)
+		{
+			ui->custom->toggle();
+			ui->spells->setCurrentIndex(index);
+			return;
+		}
+		else
+		{
+			showInvalidPresetWarning(presetVariable);
+		}
+	}
+	ui->random->toggle();
+}
+
+void ShrineWidget::changeComboBoxAllowedState()
+{
+	ui->spells->setDisabled(ui->random->isChecked());
+}
+
+void ShrineWidget::showInvalidPresetWarning(std::string name)
+{
+	auto warning = tr(presetNotFoundWarning).arg(name.c_str());
+	ui->warning->setText(warning);
+	adjustSize();
+}
+
+void ShrineWidget::on_custom_toggled(bool checked)
+{
+	changeComboBoxAllowedState();
+}
+
+void ShrineWidget::on_random_toggled(bool checked)
+{
+	changeComboBoxAllowedState();
+}
+
+ShrineDelegate::ShrineDelegate(MapController & controller, CRewardableObject & shrine) : BaseInspectorItemDelegate(), controller(controller), shrine(shrine) {}
+
+QWidget * ShrineDelegate::createEditor(QWidget * parent, const QStyleOptionViewItem & option, const QModelIndex & index) const
+{
+	return new ShrineWidget(shrine, controller, parent);
+}
+
+void ShrineDelegate::setEditorData(QWidget * editor, const QModelIndex & index) const
+{
+	if(auto * sw = qobject_cast<ShrineWidget *>(editor))
+	{
+		try
+		{
+			sw->loadData();
+		}
+		catch(const WidgetInitializationException & ex)
+		{
+			QWidget * parent = qobject_cast<QWidget *>(editor->parent());
+			if(parent)
+				QMessageBox::warning(parent, tr("Can't open editor!"), ex.message());
+			destroyEditor(editor, index);
+		}
+	}
+	else
+	{
+		QStyledItemDelegate::setEditorData(editor, index);
+	}
+}
+
+void ShrineDelegate::setModelData(QWidget * editor, QAbstractItemModel * model, const QModelIndex & index) const
+{
+	if(auto * ed = qobject_cast<ShrineWidget *>(editor))
+	{
+		ed->commitChanges();
+		updateModelData(model, index);
+	}
+	else
+	{
+		QStyledItemDelegate::setModelData(editor, model, index);
+	}
+}
+
+void ShrineDelegate::updateModelData(QAbstractItemModel * model, const QModelIndex & index) const
+{
+	QStringList textList;
+	JsonNode preset = shrine.configuration.getPresetVariable(ShrineWidget::PRESET_CATEGORY, ShrineWidget::PRESET_NAME);
+	if(!preset.isNull())
+		textList += QObject::tr(preset.String().c_str());
+	else
+		textList += QObject::tr("Random");
+	setModelTextData(model, index, textList);
+}

--- a/mapeditor/inspector/shrinewidget.h
+++ b/mapeditor/inspector/shrinewidget.h
@@ -1,0 +1,75 @@
+/*
+ * shrinewidget.h, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
+#pragma once
+
+#include "baseinspectoritemdelegate.h"
+#include "lib/json/JsonKeyExtractor.h"
+#include "lib/mapObjects/CRewardableObject.h"
+#include <QDialog>
+
+namespace Ui
+{
+class ShrineWidget;
+}
+
+class MapController;
+class CRewardableObject;
+
+class ShrineWidget : public QDialog
+{
+	Q_OBJECT
+
+public:
+	explicit ShrineWidget(CRewardableObject & shrine, MapController & controller, QWidget * parent = nullptr);
+	~ShrineWidget();
+	void loadData();
+	void commitChanges();
+
+private slots:
+	void on_custom_toggled(bool checked);
+	void on_random_toggled(bool checked);
+
+private:
+	si64 getSpellLevel();
+	void loadState();
+	void changeComboBoxAllowedState();
+	void showInvalidPresetWarning(std::string name);
+
+	Ui::ShrineWidget * ui;
+	CRewardableObject & shrine;
+	JsonKeyExtractor extractor;
+	MapController & controller;
+
+	static constexpr const char * PRESET_CATEGORY = "spell";
+	static constexpr const char * PRESET_NAME = "gainedSpell";
+	static constexpr const char * presetNotFoundWarning =
+		"<font color='red'>The shrine has spell preset set to \"%1\", "
+		"but the value is unknown. Maybe it is a mod configuration problem?</font color='red'>";
+
+	friend class ShrineDelegate;
+};
+
+class ShrineDelegate : public BaseInspectorItemDelegate
+{
+	Q_OBJECT
+public:
+	using BaseInspectorItemDelegate::BaseInspectorItemDelegate;
+
+	ShrineDelegate(MapController &, CRewardableObject &);
+
+	QWidget * createEditor(QWidget * parent, const QStyleOptionViewItem & option, const QModelIndex & index) const override;
+	void setEditorData(QWidget * editor, const QModelIndex & index) const override;
+	void setModelData(QWidget * editor, QAbstractItemModel * model, const QModelIndex & index) const override;
+	void updateModelData(QAbstractItemModel * model, const QModelIndex & index) const override;
+
+private:
+	CRewardableObject & shrine;
+	MapController & controller;
+};

--- a/mapeditor/inspector/shrinewidget.h
+++ b/mapeditor/inspector/shrinewidget.h
@@ -70,6 +70,6 @@ public:
 	void updateModelData(QAbstractItemModel * model, const QModelIndex & index) const override;
 
 private:
-	CRewardableObject & shrine;
 	MapController & controller;
+	CRewardableObject & shrine;
 };

--- a/mapeditor/inspector/shrinewidget.ui
+++ b/mapeditor/inspector/shrinewidget.ui
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ShrineWidget</class>
+ <widget class="QDialog" name="ShrineWidget">
+  <property name="windowModality">
+   <enum>Qt::WindowModality::NonModal</enum>
+  </property>
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>350</width>
+    <height>100</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>350</width>
+    <height>70</height>
+   </size>
+  </property>
+  <property name="maximumSize">
+   <size>
+    <width>350</width>
+    <height>150</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string>Scholar</string>
+  </property>
+  <property name="layoutDirection">
+   <enum>Qt::LayoutDirection::LeftToRight</enum>
+  </property>
+  <property name="modal">
+   <bool>true</bool>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="spacing">
+    <number>10</number>
+   </property>
+   <property name="topMargin">
+    <number>5</number>
+   </property>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_4" stretch="0,0">
+     <property name="sizeConstraint">
+      <enum>QLayout::SizeConstraint::SetMinimumSize</enum>
+     </property>
+     <item>
+      <widget class="QRadioButton" name="random">
+       <property name="maximumSize">
+        <size>
+         <width>120</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>Random</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="warning">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>1</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="font">
+        <font>
+         <pointsize>9</pointsize>
+        </font>
+       </property>
+       <property name="autoFillBackground">
+        <bool>false</bool>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_3">
+     <property name="sizeConstraint">
+      <enum>QLayout::SizeConstraint::SetNoConstraint</enum>
+     </property>
+     <item>
+      <widget class="QRadioButton" name="custom">
+       <property name="maximumSize">
+        <size>
+         <width>125</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="layoutDirection">
+        <enum>Qt::LayoutDirection::LeftToRight</enum>
+       </property>
+       <property name="text">
+        <string>Spell</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QComboBox" name="spells">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>1</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="editable">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/mapeditor/mapsettings/mapsettings.cpp
+++ b/mapeditor/mapsettings/mapsettings.cpp
@@ -43,11 +43,14 @@ MapSettings::MapSettings(MapController & ctrl, QWidget *parent) :
 	}
 	for(auto const & objectPtr : LIBRARY->spellh->objects)
 	{
-		auto * item = new QListWidgetItem(QString::fromStdString(objectPtr->getNameTranslated()));
-		item->setData(Qt::UserRole, QVariant::fromValue(objectPtr->getIndex()));
-		item->setFlags(item->flags() | Qt::ItemIsUserCheckable);
-		item->setCheckState(controller.map()->allowedSpells.count(objectPtr->getId()) ? Qt::Checked : Qt::Unchecked);
-		ui->listSpells->addItem(item);
+		if(objectPtr->isCommonHeroSpell())
+		{
+			auto * item = new QListWidgetItem(QString::fromStdString(objectPtr->getNameTranslated()));
+			item->setData(Qt::UserRole, QVariant::fromValue(objectPtr->getIndex()));
+			item->setFlags(item->flags() | Qt::ItemIsUserCheckable);
+			item->setCheckState(controller.map()->allowedSpells.count(objectPtr->getId()) ? Qt::Checked : Qt::Unchecked);
+			ui->listSpells->addItem(item);
+		}
 	}
 	for(auto const & objectPtr : LIBRARY->arth->objects)
 	{

--- a/mapeditor/validator.cpp
+++ b/mapeditor/validator.cpp
@@ -159,10 +159,16 @@ std::set<Validator::Issue> Validator::validate(const CMap * map)
 			}
 			if(o->ID == MapObjectID::WITCH_HUT)
 			{
-				if(validatePreset(map, o, "secondarySkill", "gainedSkill", map->allowedAbilities) == INVALID)
+				PresetState presetState = validatePreset(map, o, "secondarySkill", "gainedSkill", map->allowedAbilities);
+				if(presetState == INVALID)
 				{
-					issues.emplace(tr("A witch hut at x: %1 y: %2 on %3 layer holds an invalid reward")
+					issues.emplace(tr("A witch hut at x: %1 y: %2 on %3 layer holds an invalid reward.")
 						.arg(o->pos.x).arg(o->pos.y).arg(o->pos.z), true);
+				}
+				if(presetState == ILLEGAL)
+				{
+					issues.emplace(tr("A witch hut at x: %1 y: %2 on %3 cannot be validated by the editor.")
+						.arg(o->pos.x).arg(o->pos.y).arg(o->pos.z), false);
 				}
 			}
 			if(o->ID == MapObjectID::SCHOLAR)
@@ -183,9 +189,16 @@ std::set<Validator::Issue> Validator::validate(const CMap * map)
 						tr("A scholar at x: %1 y: %2 on layer %3 grants a reward prohibited by map setting. Is it intentional?")
 							.arg(o->pos.x).arg(o->pos.y).arg(o->pos.z), false);
 				}
+				if(presetStates.first == ILLEGAL || presetStates.second == ILLEGAL)
+				{
+					issues.emplace(
+						tr("A scholar at x: %1 y: %2 on layer %3 cannot be validated by the editor.")
+							.arg(o->pos.x).arg(o->pos.y).arg(o->pos.z), false
+					);
+				}
 			}
-			std::set<MapObjectID> shrines{MapObjectID::SHRINE_OF_MAGIC_GESTURE, MapObjectID::SHRINE_OF_MAGIC_INCANTATION, MapObjectID::SHRINE_OF_MAGIC_THOUGHT};
-			if(shrines.contains(o->ID))
+			static constexpr std::array shrines{MapObjectID::SHRINE_OF_MAGIC_GESTURE, MapObjectID::SHRINE_OF_MAGIC_INCANTATION, MapObjectID::SHRINE_OF_MAGIC_THOUGHT};
+			if(vstd::contains(shrines, o->ID))
 			{
 				PresetState ps = validatePreset(map, o, "spell", "gainedSpell", map->allowedSpells);
 				if(ps == INVALID)
@@ -276,7 +289,9 @@ Validator::PresetState Validator::validatePreset(
 )
 {
 	JsonKeyExtractor keyExtractor(map->cb);
-	auto * rewardable = static_cast<CRewardableObject *>(object.get());
+	const auto * rewardable = dynamic_cast<CRewardableObject *>(object.get());
+	if(!rewardable)
+		return ILLEGAL;
 	JsonNode presetNode = rewardable->configuration.getPresetVariable(category, name);
 	if(presetNode.isNull()) //object is default configured
 		return VALID;

--- a/mapeditor/validator.cpp
+++ b/mapeditor/validator.cpp
@@ -159,7 +159,7 @@ std::set<Validator::Issue> Validator::validate(const CMap * map)
 			}
 			if(o->ID == MapObjectID::WITCH_HUT)
 			{
-				if(!presetIsValid(map, o, "secondarySkill", "gainedSkill", map->allowedAbilities))
+				if(validatePreset(map, o, "secondarySkill", "gainedSkill", map->allowedAbilities) == INVALID)
 				{
 					issues.emplace(tr("A witch hut at x: %1 y: %2 on %3 layer holds an invalid reward")
 						.arg(o->pos.x).arg(o->pos.y).arg(o->pos.z), true);
@@ -167,11 +167,37 @@ std::set<Validator::Issue> Validator::validate(const CMap * map)
 			}
 			if(o->ID == MapObjectID::SCHOLAR)
 			{
-				if(!presetIsValid(map, o, "secondarySkill", "gainedSkill", map->allowedAbilities)
-				   || !presetIsValid(map, o, "spell", "gainedSpell", map->allowedSpells))
+				std::pair<PresetState, PresetState> presetStates = {
+					validatePreset(map, o, "secondarySkill", "gainedSkill", map->allowedAbilities),
+					validatePreset(map, o, "spell", "gainedSpell", map->allowedSpells)
+
+				};
+				if(presetStates.first == INVALID || presetStates.second == INVALID)
 				{
-					issues.emplace(tr("A scholar at x: %1 y: %2 on %3 layer holds an invalid reward")
+					issues.emplace(tr("A scholar at x: %1 y: %2 on layer %3 holds an invalid reward.")
 						.arg(o->pos.x).arg(o->pos.y).arg(o->pos.z), true);
+				}
+				if(presetStates.first == OVERWRITES_MAP_SETTINGS || presetStates.second == OVERWRITES_MAP_SETTINGS)
+				{
+					issues.emplace(
+						tr("A scholar at x: %1 y: %2 on layer %3 grants a reward prohibited by map setting. Is it intentional?")
+							.arg(o->pos.x).arg(o->pos.y).arg(o->pos.z), false);
+				}
+			}
+			std::set<MapObjectID> shrines{MapObjectID::SHRINE_OF_MAGIC_GESTURE, MapObjectID::SHRINE_OF_MAGIC_INCANTATION, MapObjectID::SHRINE_OF_MAGIC_THOUGHT};
+			if(shrines.contains(o->ID))
+			{
+				PresetState ps = validatePreset(map, o, "spell", "gainedSpell", map->allowedSpells);
+				if(ps == INVALID)
+				{
+					issues.emplace(tr("A shrine at x: %1 y: %2 on layer %3 holds an invalid spell.")
+						.arg(o->pos.x).arg(o->pos.y).arg(o->pos.z), true);
+				}
+				if(ps == OVERWRITES_MAP_SETTINGS)
+				{
+					issues.emplace(
+						tr("A shrine at x: %1 y: %2 on layer %3 grants a spell prohibited by map setting. Is it intentional?")
+							.arg(o->pos.x).arg(o->pos.y).arg(o->pos.z), false);
 				}
 			}
 		}
@@ -241,21 +267,29 @@ std::set<Validator::Issue> Validator::validate(const CMap * map)
 }
 
 template<typename IdentifierType>
-bool Validator::presetIsValid(
-    const CMap * map,
-	std::shared_ptr<CGObjectInstance> object,
+Validator::PresetState Validator::validatePreset(
+	const CMap * map,
+	const std::shared_ptr<CGObjectInstance> & object,
 	const std::string & category,
 	const std::string & name,
-	const std::set<IdentifierType> & allowedEntities
+	const std::set<IdentifierType> & allowed
 )
 {
 	JsonKeyExtractor keyExtractor(map->cb);
-	CRewardableObject * rewardable = static_cast<CRewardableObject *>(object.get());
-	JsonNode preset = rewardable->configuration.getPresetVariable(category, name);
-	if(preset.isNull())
-		return true;
-	auto presetAbilities = keyExtractor.filterKeys(preset, allowedEntities);
-	return !presetAbilities.empty();
+	auto * rewardable = static_cast<CRewardableObject *>(object.get());
+	JsonNode presetNode = rewardable->configuration.getPresetVariable(category, name);
+	if(presetNode.isNull()) //object is default configured
+		return VALID;
+	auto preset = keyExtractor.filterKeys(presetNode, allowed);
+	preset.erase(-1); // remove invalid values
+	if(preset.empty())
+		return INVALID;
+	if(keyExtractor.canOverwriteMapSettings(presetNode))
+	{
+		if(!std::includes(allowed.begin(), allowed.end(), preset.begin(), preset.end()))
+			return OVERWRITES_MAP_SETTINGS;
+	}
+	return VALID;
 }
 
 void Validator::showValidationResults(const CMap * map)

--- a/mapeditor/validator.h
+++ b/mapeditor/validator.h
@@ -49,10 +49,17 @@ private:
 
 	QRect screenGeometry;
 
+	enum PresetState
+	{
+        VALID,
+        OVERWRITES_MAP_SETTINGS,
+        INVALID
+	};
+
 	template<typename IdentifierType>
-	static bool presetIsValid(
+	static PresetState validatePreset(
         const CMap * map,
-		std::shared_ptr<CGObjectInstance> object,
+		const std::shared_ptr<CGObjectInstance> & object,
 		const std::string & category,
 		const std::string & name,
 		const std::set<IdentifierType> & allowedEntities

--- a/mapeditor/validator.h
+++ b/mapeditor/validator.h
@@ -53,6 +53,7 @@ private:
 	{
         VALID,
         OVERWRITES_MAP_SETTINGS,
+        ILLEGAL,
         INVALID
 	};
 

--- a/test/mock/mock_spells_Spell.h
+++ b/test/mock/mock_spells_Spell.h
@@ -46,6 +46,7 @@ public:
 	MOCK_CONST_METHOD0(isOffensive, bool());
 	MOCK_CONST_METHOD0(isSpecial, bool());
 	MOCK_CONST_METHOD0(isMagical, bool());
+	MOCK_CONST_METHOD0(isCommonHeroSpell, bool());
 	MOCK_CONST_METHOD0(canCastOnSelf, bool());
 	MOCK_CONST_METHOD0(canCastOnlyOnSelf, bool());
 	MOCK_CONST_METHOD0(canCastWithoutSkip, bool());


### PR DESCRIPTION
Pull request introduces following changes to map editor:
1) Adds widget for choosing spells granted by shrine.
2) Removes special and creature spells from map configuration and scholar widgets.
3) Adds verification warning for scholars and shrines overwriting map configuration (it is a legal, but IMO a warning should show in case a user has done it unintentionally).