### PR TITLE
Add instant battle win cheat and AI hero role overlay command

### DIFF
--- a/AI/Nullkiller2/AIGateway.cpp
+++ b/AI/Nullkiller2/AIGateway.cpp
@@ -1591,6 +1591,47 @@ void AIGateway::invalidatePaths()
 	nullkiller->invalidatePaths();
 }
 
+std::string AIGateway::heroRoleDebugText(const CGHeroInstance * hero) const
+{
+	// Reuse GatherArmyBehavior's baseline: 500 minimum strength and 10% of the receiving army.
+	static constexpr uint64_t MIN_REINFORCEMENT_ARMY_STRENGTH = 500;
+	static constexpr uint64_t REINFORCEMENT_ARMY_STRENGTH_DIVISOR = 10;
+	std::unique_lock lockGuard(nullkiller->aiStateMutex, std::try_to_lock);
+	if(!lockGuard.owns_lock())
+		return {};
+
+	const auto role = nullkiller->heroManager->getHeroRoleOrDefaultInefficient(hero);
+	const auto armyStrength = hero->getArmyStrength();
+	uint64_t mainArmyStrength = armyStrength;
+	bool isMainArmy = true;
+	for(const auto * otherHero : cc->getHeroesInfo())
+	{
+		if(otherHero == hero)
+			continue;
+
+		const auto otherArmyStrength = otherHero->getArmyStrength();
+		mainArmyStrength = std::max(mainArmyStrength, otherArmyStrength);
+		if(otherArmyStrength > armyStrength
+			|| (otherArmyStrength == armyStrength && otherHero->id.getNum() < hero->id.getNum()))
+			isMainArmy = false;
+	}
+	const auto reinforcementArmyStrength = std::max(
+		MIN_REINFORCEMENT_ARMY_STRENGTH,
+		mainArmyStrength / REINFORCEMENT_ARMY_STRENGTH_DIVISOR);
+
+	if(role == HeroRole::MAIN && isMainArmy)
+		return "MAIN/ARMY";
+	if(role == HeroRole::SCOUT && isMainArmy)
+		return "SCOUT/ARMY";
+	if(role == HeroRole::SCOUT && armyStrength > reinforcementArmyStrength)
+		return "SCOUT/REINF";
+	if(role == HeroRole::MAIN)
+		return "MAIN";
+	if(isMainArmy)
+		return "ARMY";
+	return "SCOUT";
+}
+
 /*
  * ////////////////////////////////////
  * ////////// STATIC Methods //////////

--- a/AI/Nullkiller2/AIGateway.h
+++ b/AI/Nullkiller2/AIGateway.h
@@ -151,6 +151,7 @@ public:
 	void battleEnd(const BattleID & battleID, const BattleResult * br, QueryID queryID) override;
 
 	void invalidatePaths() override;
+	std::string heroRoleDebugText(const CGHeroInstance * hero) const override;
 
 	void makeTurn();
 

--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -747,7 +747,7 @@ void CPlayerInterface::battleUnitsChanged(const BattleID & battleID, const std::
 		{
 		case UnitChanges::EOperation::UPDATE:
 			{
-				const CStack * stack = cb->getBattle(battleID)->battleGetStackByID(info.id );
+				const CStack * stack = cb->getBattle(battleID)->battleGetStackByID(info.id, false);
 
 				if(!stack)
 				{

--- a/client/ClientCommandManager.cpp
+++ b/client/ClientCommandManager.cpp
@@ -103,7 +103,7 @@ void ClientCommandManager::handleGoSoloCommand()
 	{
 		PlayerColor currentColor = GAME->interface()->playerID;
 		GAME->server().client->removeGUI();
-		
+
 		for(auto & color : GAME->server().getAllClientPlayers(GAME->server().logicConnection->connectionID))
 		{
 			if(color.isValidPlayer() && GAME->server().client->gameInfo().getStartInfo()->playerInfos.at(color).isControlledByHuman())
@@ -574,6 +574,22 @@ void ClientCommandManager::handleVsLog(std::istringstream & singleWordBuffer)
 	logVisual->setKey(key);
 }
 
+void ClientCommandManager::handleWhoIsTheBossCommand(std::istringstream & singleWordBuffer)
+{
+	std::string value;
+	singleWordBuffer >> value;
+
+	Settings session = settings.write["session"];
+	if(value == "on")
+		session["showAiHeroOverlay"].Bool() = true;
+	else if(value == "off")
+		session["showAiHeroOverlay"].Bool() = false;
+	else
+		printCommandMessage("Unexpected syntax. Supported forms (case insensitive):\n/whoIsTheBoss on\n/whoIsTheBoss off\n");
+
+	ENGINE->windows().totalRedraw();
+}
+
 void ClientCommandManager::handleGenerateAssets()
 {
 	ENGINE->renderHandler().exportGeneratedAssets();
@@ -707,6 +723,9 @@ void ClientCommandManager::processCommand(const std::string & message, bool call
 
 	else if(commandName == "vslog")
 		handleVsLog(singleWordBuffer);
+
+	else if(boost::iequals(commandName, "whoistheboss"))
+		handleWhoIsTheBossCommand(singleWordBuffer);
 
 	else if(message=="generate assets")
 		handleGenerateAssets();

--- a/client/ClientCommandManager.h
+++ b/client/ClientCommandManager.h
@@ -85,6 +85,9 @@ class ClientCommandManager //take mantis #2292 issue about account if thinking a
 	// shows object graph
 	void handleVsLog(std::istringstream & singleWordBuffer);
 
+	// Toggle AI hero role overlay.
+	void handleWhoIsTheBossCommand(std::istringstream & singleWordBuffer);
+
 	// generate all assets
 	void handleGenerateAssets();
 

--- a/client/NetPacksClient.cpp
+++ b/client/NetPacksClient.cpp
@@ -168,7 +168,7 @@ void ApplyClientNetPackVisitor::visitSetSecSkill(SetSecSkill & pack)
 void ApplyClientNetPackVisitor::visitHeroVisitCastle(HeroVisitCastle & pack)
 {
 	const CGHeroInstance *h = cl.gameInfo().getHero(pack.hid);
-	
+
 	if(pack.start())
 	{
 		callInterfaceIfPresent(cl, h->tempOwner, &IGameEventsReceiver::heroVisitsTown, h, gs.getTown(pack.tid));

--- a/client/adventureMap/CInGameConsole.cpp
+++ b/client/adventureMap/CInGameConsole.cpp
@@ -268,7 +268,7 @@ void CInGameConsole::startEnteringText()
 		ENGINE->statusbar()->setEnteredText(enteredText);
 		return;
 	}
-		
+
 	assert(currentStatusBar.expired());//effectively, nullptr check
 
 	currentStatusBar = ENGINE->statusbar();

--- a/client/mapView/IMapRendererContext.h
+++ b/client/mapView/IMapRendererContext.h
@@ -9,13 +9,20 @@
  */
 #pragma once
 
+#include "../../lib/Color.h"
+
 class int3;
 class Point;
 class CGObjectInstance;
 class ObjectInstanceID;
 struct TerrainTile;
-class ColorRGBA;
 struct CGPath;
+
+struct MapTextOverlay
+{
+	std::string text;
+	ColorRGBA color;
+};
 
 class IMapRendererContext
 {
@@ -67,11 +74,8 @@ public:
 	/// returns index of image for overlay on specific tile, or numeric_limits::max if none
 	virtual size_t overlayImageIndex(const int3 & coordinates) const = 0;
 
-	/// returns text that should be used as overlay for current tile
-	virtual std::string overlayText(const int3 & coordinates) const = 0;
-
-	/// returns text that should be used as overlay for current tile
-	virtual ColorRGBA overlayTextColor(const int3 & coordinates) const = 0;
+	/// returns text overlay that should be used for current tile
+	virtual MapTextOverlay overlayText(const int3 & coordinates) const = 0;
 
 	/// returns animation frame for terrain
 	virtual size_t terrainImageIndex(size_t groupSize) const = 0;

--- a/client/mapView/MapRendererContext.cpp
+++ b/client/mapView/MapRendererContext.cpp
@@ -14,7 +14,9 @@
 #include "MapRendererContextState.h"
 #include "mapHandler.h"
 
+#include "../Client.h"
 #include "../CPlayerInterface.h"
+#include "../CServerHandler.h"
 #include "../PlayerLocalState.h"
 #include "../GameInstance.h"
 
@@ -29,6 +31,61 @@
 #include "../../lib/spells/ISpellMechanics.h"
 #include "../../lib/spells/adventure/AdventureSpellEffect.h"
 #include "../../lib/spells/CSpell.h"
+
+static std::string getAiHeroRoleDebugText(const MapRendererBaseContext::MapObjectsList & objects, const MapRendererBaseContext & context)
+{
+	if(!GAME->server().client)
+		return {};
+
+	for(const auto objectID : objects)
+	{
+		const auto * hero = dynamic_cast<const CGHeroInstance *>(context.getObject(objectID));
+		if(!hero || !hero->getOwner().isValidPlayer())
+			continue;
+
+		auto interfaceIt= GAME->server().client->playerint.find(hero->getOwner());
+		if(interfaceIt == GAME->server().client->playerint.end())
+			return {};
+
+		if(!interfaceIt->second)
+			continue;
+
+		auto text = interfaceIt->second->heroRoleDebugText(hero);
+		if(!text.empty())
+			return text;
+	}
+
+	return {};
+}
+
+static ColorRGBA getAiHeroDebugColor(const std::string & text)
+{
+	if(text == "MAIN/ARMY" || text == "ARMY")
+		return { 255, 0, 0 };
+	if(text == "MAIN")
+		return { 255, 96, 160 };
+	if(text == "SCOUT/ARMY")
+		return { 192, 80, 0 };
+	return { 255, 192, 96 };
+}
+
+static ColorRGBA getObjectOverlayColor(const CGObjectInstance * object)
+{
+	if(object->getOwner() == GAME->interface()->playerID)
+		return { 0, 192, 0};
+
+	if(GAME->interface()->cb->getPlayerRelations(object->getOwner(), GAME->interface()->playerID) == PlayerRelations::ALLIES)
+		return { 0, 128, 255};
+
+	if(object->getOwner().isValidPlayer() || object->ID == MapObjectID::MONSTER)
+		return { 255, 0, 0};
+
+	auto hero = GAME->interface()->localState->getCurrentHero();
+	if(hero ? object->wasVisited(hero) : object->wasVisited(GAME->interface()->playerID))
+		return { 160, 160, 160 };
+
+	return { 255, 192, 0 };
+}
 
 MapRendererBaseContext::MapRendererBaseContext(const MapRendererContextState & viewState)
 	: viewState(viewState)
@@ -93,7 +150,7 @@ int MapRendererBaseContext::attackedMonsterDirection(const CGObjectInstance * wa
 {
 	if(wanderingMonster->ID != Obj::MONSTER)
 		return -1;
-		
+
 	for(const auto & battle : GAME->interface()->cb->getActiveBattles())
 		if(wanderingMonster->pos == battle.second->getBattle()->getLocation())
 			return battle.second->getBattle()->getSideHero(BattleSide::ATTACKER)->moveDir;
@@ -172,12 +229,7 @@ size_t MapRendererBaseContext::overlayImageIndex(const int3 & coordinates) const
 	return std::numeric_limits<size_t>::max();
 }
 
-std::string MapRendererBaseContext::overlayText(const int3 & coordinates) const
-{
-	return {};
-}
-
-ColorRGBA MapRendererBaseContext::overlayTextColor(const int3 & coordinates) const
+MapTextOverlay MapRendererBaseContext::overlayText(const int3 & coordinates) const
 {
 	return {};
 }
@@ -289,62 +341,34 @@ size_t MapRendererAdventureContext::terrainImageIndex(size_t groupSize) const
 	return frameIndex;
 }
 
-std::string MapRendererAdventureContext::overlayText(const int3 & coordinates) const
+MapTextOverlay MapRendererAdventureContext::overlayText(const int3 & coordinates) const
 {
 	if(!isVisible(coordinates))
 		return {};
 
 	const auto & tile = getMapTile(coordinates);
 
-	if (!tile.visitable())
+	if(!tile.visitable())
 		return {};
+
+	if(settingShowAiHeroOverlay && !settingTextOverlay)
+	{
+		auto text = getAiHeroRoleDebugText(tile.visitableObjects, *this);
+		if(!text.empty())
+		{
+			auto color = getAiHeroDebugColor(text);
+			return { std::move(text), color };
+		}
+
+		return {};
+	}
 
 	const auto * object = getObject(tile.visitableObjects.back());
 
-	if ( object->ID == Obj::EVENT)
+	if(object->ID == Obj::EVENT)
 		return {};
 
-	return object->getObjectName();
-}
-
-ColorRGBA MapRendererAdventureContext::overlayTextColor(const int3 & coordinates) const
-{
-	if(!isVisible(coordinates))
-		return {};
-
-	const auto & tile = getMapTile(coordinates);
-
-	if (!tile.visitable())
-		return {};
-
-	const auto * object = getObject(tile.visitableObjects.back());
-
-	if (object->getOwner() == GAME->interface()->playerID)
-		return { 0, 192, 0};
-
-	if (GAME->interface()->cb->getPlayerRelations(object->getOwner(), GAME->interface()->playerID) == PlayerRelations::ALLIES)
-		return { 0, 128, 255};
-
-	if (object->getOwner().isValidPlayer())
-		return { 255, 0, 0};
-
-	if (object->ID == MapObjectID::MONSTER)
-		return { 255, 0, 0};
-
-	auto hero = GAME->interface()->localState->getCurrentHero();
-
-	if (hero)
-	{
-		if (object->wasVisited(hero))
-			return { 160, 160, 160 };
-	}
-	else
-	{
-		if (object->wasVisited(GAME->interface()->playerID))
-			return { 160, 160, 160 };
-	}
-
-	return { 255, 192, 0 };
+	return { object->getObjectName(), getObjectOverlayColor(object) };
 }
 
 bool MapRendererAdventureContext::showBorder() const
@@ -374,7 +398,7 @@ bool MapRendererAdventureContext::showInvisible() const
 
 bool MapRendererAdventureContext::showTextOverlay() const
 {
-	return settingTextOverlay;
+	return settingTextOverlay || settingShowAiHeroOverlay;
 }
 
 bool MapRendererAdventureContext::showSpellRange(const int3 & position) const

--- a/client/mapView/MapRendererContext.h
+++ b/client/mapView/MapRendererContext.h
@@ -46,8 +46,7 @@ public:
 	size_t objectImageIndex(ObjectInstanceID objectID, size_t groupSize) const override;
 	size_t terrainImageIndex(size_t groupSize) const override;
 	size_t overlayImageIndex(const int3 & coordinates) const override;
-	std::string overlayText(const int3 & coordinates) const override;
-	ColorRGBA overlayTextColor(const int3 & coordinates) const override;
+	MapTextOverlay overlayText(const int3 & coordinates) const override;
 
 	double viewTransitionProgress() const override;
 	bool filterGrayscale() const override;
@@ -72,6 +71,7 @@ public:
 	bool settingShowBlocked = false;
 	bool settingShowInvisible = false;
 	bool settingTextOverlay = false;
+	bool settingShowAiHeroOverlay = false;
 	bool settingsAdventureObjectAnimation = true;
 	bool settingsAdventureTerrainAnimation = true;
 
@@ -80,8 +80,7 @@ public:
 	const CGPath * currentPath() const override;
 	size_t objectImageIndex(ObjectInstanceID objectID, size_t groupSize) const override;
 	size_t terrainImageIndex(size_t groupSize) const override;
-	std::string overlayText(const int3 & coordinates) const override;
-	ColorRGBA overlayTextColor(const int3 & coordinates) const override;
+	MapTextOverlay overlayText(const int3 & coordinates) const override;
 
 	bool showBorder() const override;
 	bool showGrid() const override;

--- a/client/mapView/MapViewCache.cpp
+++ b/client/mapView/MapViewCache.cpp
@@ -140,9 +140,11 @@ void MapViewCache::update(const std::shared_ptr<IMapRendererContext> & context)
 void MapViewCache::render(const std::shared_ptr<IMapRendererContext> & context, Canvas & target, bool fullRedraw)
 {
 	bool mapMoved = (cachedPosition != model->getMapViewCenter());
-	bool overlayVisible = context->showImageOverlay() || context->showTextOverlay();
+	bool textOverlayVisible = context->showTextOverlay();
+	bool overlayVisible = context->showImageOverlay() || textOverlayVisible;
 	bool overlayVisibilityChanged = overlayVisible != overlayWasVisible;
-	bool lazyUpdate = !overlayVisibilityChanged && !mapMoved && !fullRedraw && vstd::isAlmostZero(context->viewTransitionProgress());
+	// redraw text overlay backgrounds; track dirty overlay tiles if this becomes expensive.
+	bool lazyUpdate = !textOverlayVisible && !overlayVisibilityChanged && !mapMoved && !fullRedraw && vstd::isAlmostZero(context->viewTransitionProgress());
 
 	Rect dimensions = model->getTilesTotalRect();
 
@@ -185,7 +187,7 @@ void MapViewCache::render(const std::shared_ptr<IMapRendererContext> & context, 
 		}
 	}
 
-	if(context->showTextOverlay())
+	if(textOverlayVisible)
 	{
 		const auto & font = ENGINE->renderHandler().loadFont(FONT_TINY);
 
@@ -196,7 +198,7 @@ void MapViewCache::render(const std::shared_ptr<IMapRendererContext> & context, 
 				int3 tile(x, y, model->getLevel());
 				auto overlay = context->overlayText(tile);
 
-				if(!overlay.empty())
+				if(!overlay.text.empty())
 				{
 					Rect targetRect = model->getTargetTileArea(tile);
 					Point position = targetRect.center();
@@ -205,12 +207,12 @@ void MapViewCache::render(const std::shared_ptr<IMapRendererContext> & context, 
 					else
 						position.y -= targetRect.h / 4;
 
-					Point dimensions(font->getStringWidth(overlay), font->getLineHeight());
+					Point dimensions(font->getStringWidth(overlay.text), font->getLineHeight());
 					Rect textRect = Rect(position - dimensions / 2, dimensions).resize(2);
 
-					target.drawColor(textRect, context->overlayTextColor(tile));
+					target.drawColor(textRect, overlay.color);
 					target.drawBorder(textRect, Colors::BRIGHT_YELLOW);
-					target.drawText(position, EFonts::FONT_TINY, Colors::BLACK, ETextAlignment::CENTER, overlay);
+					target.drawText(position, EFonts::FONT_TINY, Colors::BLACK, ETextAlignment::CENTER, overlay.text);
 				}
 			}
 		}

--- a/client/mapView/MapViewController.cpp
+++ b/client/mapView/MapViewController.cpp
@@ -88,7 +88,7 @@ void MapViewController::setTileSize(const Point & tileSize, bool setTarget)
 
 	// force update of view center since changing tile size may invalidated it
 	setViewCenter(newViewCenter, model->getLevel());
-	
+
 	if(setTarget)
 		targetTileSize = tileSize;
 }
@@ -234,6 +234,7 @@ void MapViewController::updateState()
 		adventureContext->settingShowVisitable = settings["session"]["showVisitable"].Bool();
 		adventureContext->settingShowBlocked = settings["session"]["showBlocked"].Bool();
 		adventureContext->settingShowInvisible = settings["session"]["showInvisible"].Bool();
+		adventureContext->settingShowAiHeroOverlay = settings["session"]["showAiHeroOverlay"].Bool();
 		adventureContext->settingTextOverlay = (ENGINE->isKeyboardAltDown() || ENGINE->input().getNumTouchFingers() == 2) && settings["general"]["enableOverlay"].Bool();
 	}
 }

--- a/config/cheats.json
+++ b/config/cheats.json
@@ -2,7 +2,8 @@
 	//	                        VCMI                       VCMI simple        SoD/HotA                   AB                    RoE
 	"localCheats" : {
 		"color" :             [                            "vcmicolor",       "nwcphisherprice"                                                      ],
-		"gray" :              [                            "vcmigray"                                                                                ]
+		"gray" :              [                            "vcmigray"                                                                                ],
+		"battleVictory" :     [                            "vcmideathpunch"                                                                          ]
     },
 	"townTargetedCheats" : {
 		"buildTown" :         [ "vcmiarmenelos",           "vcmibuild",       "nwczion",                 "nwccoruscant",       "nwconlyamodel"       ]

--- a/docs/players/Cheat_Codes.md
+++ b/docs/players/Cheat_Codes.md
@@ -190,3 +190,4 @@ Below a list of supported commands, with their arguments wrapped in `<>`
 - `redraw` - force full graphical redraw
 - `screen` - show value of screenBuf variable, which prints "screen" when adventure map has current focus, "screen2" otherwise, and dumps values of both screen surfaces to .bmp files
 - `tell hs <hero ID> <artifact slot ID>` - write what artifact is present on artifact slot with specified ID for hero with specified ID. (must be called during gameplay)
+- `whoIsTheBoss <on/off>` - toggles AI hero role overlay

--- a/docs/players/Cheat_Codes.md
+++ b/docs/players/Cheat_Codes.md
@@ -24,11 +24,11 @@ Examples:
 
 ### Army
 
-- `nwctrinity`, `nwcpadme`, `nwcavertingoureyes`, `vcmiainur` or `vcmiarchangel` - give 5 Archangels in every empty slot (to currently selected hero)  
-- `nwcagents`, `nwcdarthmaul`, `nwcfleshwound` or `vcmiangband` or `vcmiblackknight` - give 10 black knight in every empty slot  
-- `vcmiglaurung` or `vcmicrystal` - give 5000 crystal dragons in every empty slot  
-- `vcmiazure` - give 5000 azure dragons in every empty slot  
-- `vcmifaerie` - give 5000 faerie dragons in every empty slot  
+- `nwctrinity`, `nwcpadme`, `nwcavertingoureyes`, `vcmiainur` or `vcmiarchangel` - give 5 Archangels in every empty slot (to currently selected hero)
+- `nwcagents`, `nwcdarthmaul`, `nwcfleshwound` or `vcmiangband` or `vcmiblackknight` - give 10 black knight in every empty slot
+- `vcmiglaurung` or `vcmicrystal` - give 5000 crystal dragons in every empty slot
+- `vcmiazure` - give 5000 azure dragons in every empty slot
+- `vcmifaerie` - give 5000 faerie dragons in every empty slot
 
 - Alternative usage: `vcmiarmy <creatureID> <amount>`
 
@@ -43,9 +43,9 @@ Gives specific creature in every slot, with optional amount. Examples:
 
 ### Artifacts
 
-- `nwclotsofguns`, `nwcr2d2`, `nwcantioch`, `vcminoldor` or `vcmimachines` - give ballista, ammo cart and first aid tent  
+- `nwclotsofguns`, `nwcr2d2`, `nwcantioch`, `vcminoldor` or `vcmimachines` - give ballista, ammo cart and first aid tent
 - `vcmiforgeofnoldorking` or `vcmiartifacts` - give all artifacts, except spell book, spell scrolls and war machines. Artifacts added via mods included
-- `vcmiscrolls` - give spell scrolls for every possible spells  
+- `vcmiscrolls` - give spell scrolls for every possible spells
 - `nwcarchitect`, `vcmigrail` - give grail
 
 ### Movement
@@ -56,13 +56,13 @@ Gives specific creature in every slot, with optional amount. Examples:
 
 ### Resources
 
-- `nwctheconstruct`, `nwcwatto`, `nwcshrubbery`, `vcmiformenos` or `vcmiresources` - give resources (100000 gold, 100 of wood, ore and rare resources)  
+- `nwctheconstruct`, `nwcwatto`, `nwcshrubbery`, `vcmiformenos` or `vcmiresources` - give resources (100000 gold, 100 of wood, ore and rare resources)
 - Alternative usage: `vcmiresources <amount>` - gives specified amount of all resources and x1000 of gold
 
 ### Fog of War
 
-- `nwcwhatisthematrix`, `nwcrevealourselves`, `nwcgeneraldirection`, `vcmieagles` or `vcmimap` - reveal Fog of War  
-- `nwcignoranceisbliss`,  `vcmiungoliant` or `vcmihidemap` - conceal Fog of War  
+- `nwcwhatisthematrix`, `nwcrevealourselves`, `nwcgeneraldirection`, `vcmieagles` or `vcmimap` - reveal Fog of War
+- `nwcignoranceisbliss`,  `vcmiungoliant` or `vcmihidemap` - conceal Fog of War
 
 ### Experience
 
@@ -106,19 +106,19 @@ By default, all cheat codes apply to current player. Alternatively, it is possib
 
 ### Examples
 
-- `vcmieagles blue` - reveal FoW only for blue player  
-- `vcmieagles ai` - reveal FoW only for AI players  
-- `vcmieagles all` - reveal FoW for all players on map  
-- `vcminahar ai` - give 1000000 movement points to each hero of every AI player  
+- `vcmieagles blue` - reveal FoW only for blue player
+- `vcmieagles ai` - reveal FoW only for AI players
+- `vcmieagles all` - reveal FoW for all players on map
+- `vcminahar ai` - give 1000000 movement points to each hero of every AI player
 
 ## Multiplayer chat commands
 
 Following commands can be used in multiplayer only by host player to control the session:
 
-- `!exit` - finish the game  
-- `!save <filename>` - save the game into the specified file  
-- `!kick red/blue/tan/green/orange/purple/teal/pink` - kick player of specified color from the game  
-- `!kick 0/1/2/3/4/5/6/7/8` - kick player of specified ID from the game (*zero indexed!*) (`0: red, 1: blue, tan: 2, green: 3, orange: 4, purple: 5, teal: 6, pink: 7`)  
+- `!exit` - finish the game
+- `!save <filename>` - save the game into the specified file
+- `!kick red/blue/tan/green/orange/purple/teal/pink` - kick player of specified color from the game
+- `!kick 0/1/2/3/4/5/6/7/8` - kick player of specified ID from the game (*zero indexed!*) (`0: red, 1: blue, tan: 2, green: 3, orange: 4, purple: 5, teal: 6, pink: 7`)
 
 Following commands can be used by any player in multiplayer:
 
@@ -136,15 +136,15 @@ Client commands are set of predefined commands that are supported by VCMI, but u
 
 Alternative way, the only one working for older releases is typing them in console:
 Console is separated from game window on desktop versions of VCMI Client.
-Windows builds of VCMI run separate console window by default, on other platforms you can access it by running VCMI Client from command line.  
+Windows builds of VCMI run separate console window by default, on other platforms you can access it by running VCMI Client from command line.
 
 Below a list of supported commands, with their arguments wrapped in `<>`
 
 #### Game Commands
 
-- `die, fool` - quits game  
-- `save <filename>` - saves game in given file (at the moment doesn't work)  
-- `mp` - on adventure map with a hero selected, shows heroes current movement points, max movement points on land and on water  
+- `die, fool` - quits game
+- `save <filename>` - saves game in given file (at the moment doesn't work)
+- `mp` - on adventure map with a hero selected, shows heroes current movement points, max movement points on land and on water
 - `bonuses` - shows bonuses of currently selected adventure map object
 
 #### Extract commands
@@ -162,10 +162,10 @@ Below a list of supported commands, with their arguments wrapped in `<>`
 
 #### AI commands
 
-- `setBattleAI <ai name>` - change battle AI used by neutral creatures to the one specified, persists through game quit  
-- `gosolo` - AI takes over until the end of turn (unlike original H3 currently causes AI to take over until typed again)  
-- `controlai <[red][blue][tan][green][orange][purple][teal][pink]>` - gives you control over specified AI player. If none is specified gives you control over all AI players  
-- `autoskip` - Toggles autoskip mode on and off. In this mode, player turns are automatically skipped and only AI moves. However, GUI is still present and allows to observe AI moves. After this option is activated, you need to end first turn manually. Press `[Shift]` before your turn starts to not skip it  
+- `setBattleAI <ai name>` - change battle AI used by neutral creatures to the one specified, persists through game quit
+- `gosolo` - AI takes over until the end of turn (unlike original H3 currently causes AI to take over until typed again)
+- `controlai <[red][blue][tan][green][orange][purple][teal][pink]>` - gives you control over specified AI player. If none is specified gives you control over all AI players
+- `autoskip` - Toggles autoskip mode on and off. In this mode, player turns are automatically skipped and only AI moves. However, GUI is still present and allows to observe AI moves. After this option is activated, you need to end first turn manually. Press `[Shift]` before your turn starts to not skip it
 
 #### Settings
 
@@ -184,9 +184,9 @@ Below a list of supported commands, with their arguments wrapped in `<>`
 
 #### Developer Commands
 
-- `crash` - force a game crash. It is sometimes useful to generate memory dump file in certain situations, for example game freeze  
-- `gui` - displays tree view of currently present VCMI common GUI elements  
-- `activate <0/1/2>` - activate game windows (no current use, apparently broken long ago)  
-- `redraw` - force full graphical redraw  
-- `screen` - show value of screenBuf variable, which prints "screen" when adventure map has current focus, "screen2" otherwise, and dumps values of both screen surfaces to .bmp files  
-- `tell hs <hero ID> <artifact slot ID>` - write what artifact is present on artifact slot with specified ID for hero with specified ID. (must be called during gameplay)  
+- `crash` - force a game crash. It is sometimes useful to generate memory dump file in certain situations, for example game freeze
+- `gui` - displays tree view of currently present VCMI common GUI elements
+- `activate <0/1/2>` - activate game windows (no current use, apparently broken long ago)
+- `redraw` - force full graphical redraw
+- `screen` - show value of screenBuf variable, which prints "screen" when adventure map has current focus, "screen2" otherwise, and dumps values of both screen surfaces to .bmp files
+- `tell hs <hero ID> <artifact slot ID>` - write what artifact is present on artifact slot with specified ID for hero with specified ID. (must be called during gameplay)

--- a/docs/players/Cheat_Codes.md
+++ b/docs/players/Cheat_Codes.md
@@ -86,6 +86,10 @@ Gives specific creature in every slot, with optional amount. Examples:
 - `nwcredpill`, `nwctrojanrabbit`, `vcmisilmaril` or `vcmiwin` - player wins
 - `nwcbluepill`, `nwcsirrobin`, `vcmimelkor` or `vcmilose` - player loses
 
+### Finishing a battle
+
+- `vcmideathpunch` - kills all opposing units and wins the current battle
+
 ### Misc
 
 - `nwctheone` or `vcmigod` - reveals the whole map, gives 5 archangels in each empty slot, unlimited movement points and permanent flight

--- a/lib/callback/CGameInterface.h
+++ b/lib/callback/CGameInterface.h
@@ -53,4 +53,5 @@ public:
 	virtual void invalidatePaths(){};
 
 	virtual void setColorScheme(ColorScheme scheme){};
+	virtual std::string heroRoleDebugText(const CGHeroInstance *) const { return {}; };
 };

--- a/server/battles/BattleProcessor.cpp
+++ b/server/battles/BattleProcessor.cpp
@@ -18,6 +18,7 @@
 #include "../queries/QueriesProcessor.h"
 #include "../queries/BattleQueries.h"
 
+#include "../../lib/CStack.h"
 #include "../../lib/CPlayerState.h"
 #include "../../lib/TerrainHandler.h"
 #include "../../lib/battle/CBattleInfoCallback.h"
@@ -316,6 +317,40 @@ bool BattleProcessor::makePlayerBattleAction(const BattleID & battleID, PlayerCo
 	if (gameHandler->gameState().getBattle(battleID) != nullptr && !resultProcessor->battleIsEnding(*battle))
 		flowProcessor->onActionMade(*battle, ba);
 	return result;
+}
+
+void BattleProcessor::cheatBattleVictory(PlayerColor player)
+{
+	auto * battle = gameHandler->gameState().getBattle(player);
+	if(!battle || resultProcessor->battleIsEnding(*battle))
+		return;
+
+	const BattleSide winningSide = battle->playerToSide(player);
+	if(winningSide != BattleSide::ATTACKER && winningSide != BattleSide::DEFENDER)
+		return;
+
+	BattleUnitsChanged killedUnits;
+	killedUnits.battleID = battle->getBattleID();
+
+	for(const CStack * stack : battle->battleGetAllStacks(true))
+	{
+		if(stack->unitSide() == winningSide || !stack->alive())
+			continue;
+
+		auto state = stack->acquireState();
+		int64_t damage = state->getAvailableHealth();
+		state->damage(damage);
+
+		UnitChanges info(stack->unitId(), UnitChanges::EOperation::UPDATE);
+		info.data = state->save();
+		info.healthDelta = -damage;
+		killedUnits.changedStacks.push_back(info);
+	}
+
+	if(!killedUnits.changedStacks.empty())
+		gameHandler->sendAndApply(killedUnits);
+
+	setBattleResult(*battle, EBattleResult::NORMAL, winningSide);
 }
 
 void BattleProcessor::setBattleResult(const CBattleInfoCallback & battle, EBattleResult resultType, BattleSide victoriusSide)

--- a/server/battles/BattleProcessor.h
+++ b/server/battles/BattleProcessor.h
@@ -64,6 +64,8 @@ public:
 
 	/// Processing of incoming battle action netpack
 	bool makePlayerBattleAction(const BattleID & battleID, PlayerColor player, const BattleAction & ba);
+	/// Kills the opposing army and resolves the current battle in player's favor
+	void cheatBattleVictory(PlayerColor player);
 
 	/// Applies results of a battle once player agrees to them
 	void endBattleConfirm(const BattleID & battleID);

--- a/server/processors/PlayerMessageProcessor.cpp
+++ b/server/processors/PlayerMessageProcessor.cpp
@@ -15,6 +15,7 @@
 #include "../CGameHandler.h"
 #include "../CVCMIServer.h"
 #include "../TurnTimerHandler.h"
+#include "../battles/BattleProcessor.h"
 
 #include "../../lib/CPlayerState.h"
 #include "../../lib/CSkillHandler.h"
@@ -885,6 +886,7 @@ void PlayerMessageProcessor::executeCheatCode(const std::string & cheatName, Pla
 	const auto & doCheatExperience = [&]() { cheatExperience(player, hero, words); };
 	const auto & doCheatMovement = [&]() { cheatMovement(player, hero, words); };
 	const auto & doCheatResources = [&]() { cheatResources(player, words); };
+	const auto & doCheatBattleVictory = [&]() { gameHandler->battles->cheatBattleVictory(player); };
 	const auto & doCheatVictory = [&]() { cheatVictory(player); };
 	const auto & doCheatDefeat = [&]() { cheatDefeat(player); };
 	const auto & doCheatMapReveal = [&]() { cheatMapReveal(player, true); };
@@ -938,6 +940,7 @@ void PlayerMessageProcessor::executeCheatCode(const std::string & cheatName, Pla
 		{"experience",         doCheatExperience                                           },
 		{"movement",           doCheatMovement                                             },
 		{"resources",          doCheatResources                                            },
+		{"battleVictory",      doCheatBattleVictory                                        },
 		{"defeat",             doCheatDefeat                                               },
 		{"victory",            doCheatVictory                                              },
 		{"mapReveal",          doCheatMapReveal                                            },


### PR DESCRIPTION
  Adds a cheat code and a debug command to extend gameplay testing options:

  - `vcmideathpunch` instantly wins the current battle for the player using it
  - `/whoIsTheBoss <on/off>` toggles an AI hero role/debug overlay on the adventure map

  ## Details

  ### `vcmideathpunch`

  - Adds a battle victory cheat under `battleVictory` in `cheats.json`
  - Kills opposing battle stacks and ends the battle as a normal victory for the cheating player's side
  - Works when the player is either attacker or defender
  - Sends stack `UPDATE`s for killed units, keeping dead stacks in battle state

  ### `whoIsTheBoss`

  - Adds a local client debug command, handled case-insensitively
  - Uses `on` / `off` arguments to toggle the session overlay setting
  - Adds AI hero role/debug text rendering on adventure map tiles

  Possible AI hero overlays:

  - `MAIN` - hero is currently classified by Nullkiller as a main hero; main heroes are selected currently by hero fighting/development score, limited by AI town count and map size
  - `SCOUT` - hero is currently classified as a scout
  - `ARMY` - hero currently carries the strongest army among that AI player's heroes
  - `REINF` - scout carries a meaningful reinforcement army

  Labels can be combined, for example:

  - `MAIN/ARMY` - main hero and current strongest army carrier
  - `SCOUT/ARMY` - scout role, but currently has the AI's strongest army
  - `SCOUT/REINF` - scout with a reinforcement-sized army

<img width="1431" height="955" alt="Hero_overlays" src="https://github.com/user-attachments/assets/d6f8975c-e3aa-454f-85df-f79d79b2a928" />
