### PR TITLE
Fixes to animations in battles

### DIFF
--- a/AI/MMAI/BAI/router.cpp
+++ b/AI/MMAI/BAI/router.cpp
@@ -251,10 +251,10 @@ void Router::battleNewRoundFirst(const BattleID & bid)
 	bai->battleNewRoundFirst(bid);
 }
 
-void Router::battleObstaclesChanged(const BattleID & bid, const std::vector<ObstacleChanges> & obstacles)
+void Router::battleObstaclesChanged(const BattleID & bid, const ObstacleChanges & obstacle)
 {
 	MMAI_LOG_TAG;
-	bai->battleObstaclesChanged(bid, obstacles);
+	bai->battleObstaclesChanged(bid, obstacle);
 };
 
 void Router::battleSpellCast(const BattleID & bid, const BattleSpellCast * sc)

--- a/AI/MMAI/BAI/router.h
+++ b/AI/MMAI/BAI/router.h
@@ -51,7 +51,7 @@ public:
 	void battleLogMessage(const BattleID & bid, const std::vector<MetaString> & lines) override;
 	void battleNewRound(const BattleID & bid) override;
 	void battleNewRoundFirst(const BattleID & bid) override;
-	void battleObstaclesChanged(const BattleID & bid, const std::vector<ObstacleChanges> & obstacles) override;
+	void battleObstaclesChanged(const BattleID & bid, const ObstacleChanges & obstacle) override;
 	void battleSpellCast(const BattleID & bid, const BattleSpellCast * sc) override;
 	void battleStackMoved(const BattleID & bid, const CStack * stack, const BattleHexArray & dest, int distance, bool teleport) override;
 	void battleStacksAttacked(const BattleID & bid, const std::vector<BattleStackAttacked> & bsa, bool ranged) override;

--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -778,33 +778,22 @@ void CPlayerInterface::battleUnitsChanged(const BattleID & battleID, const std::
 	}
 }
 
-void CPlayerInterface::battleObstaclesChanged(const BattleID & battleID, const std::vector<ObstacleChanges> & obstacles)
+void CPlayerInterface::battleObstaclesChanged(const BattleID & battleID, const ObstacleChanges & obstacle)
 {
 	EVENT_HANDLER_CALLED_BY_CLIENT;
 	BATTLE_EVENT_POSSIBLE_RETURN;
 
-	std::vector<std::shared_ptr<const CObstacleInstance>> newObstacles;
-	std::vector<ObstacleChanges> removedObstacles;
-
-	for(auto & change : obstacles)
+	if(obstacle.operation == BattleChanges::EOperation::ADD)
 	{
-		if(change.operation == BattleChanges::EOperation::ADD)
-		{
-			auto instance = cb->getBattle(battleID)->battleGetObstacleByID(change.id);
-			if(instance)
-				newObstacles.push_back(instance);
-			else
-				logNetwork->error("Invalid obstacle instance %d", change.id);
-		}
-		if(change.operation == BattleChanges::EOperation::REMOVE)
-			removedObstacles.push_back(change); //Obstacles are already removed, so, show animation based on json struct
+		auto instance = cb->getBattle(battleID)->battleGetObstacleByID(obstacle.id);
+		if(instance)
+			battleInt->obstaclePlaced(instance);
+		else
+			logNetwork->error("Invalid obstacle instance %d", obstacle.id);
 	}
 
-	if (!newObstacles.empty())
-		battleInt->obstaclePlaced(newObstacles);
-
-	if (!removedObstacles.empty())
-		battleInt->obstacleRemoved(removedObstacles);
+	if(obstacle.operation == BattleChanges::EOperation::REMOVE)
+		battleInt->obstacleRemoved(obstacle); //Obstacle is already removed, so, show animation based on json struct
 
 	battleInt->fieldController->redrawBackgroundWithHexes();
 }

--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -783,7 +783,7 @@ void CPlayerInterface::battleObstaclesChanged(const BattleID & battleID, const O
 	EVENT_HANDLER_CALLED_BY_CLIENT;
 	BATTLE_EVENT_POSSIBLE_RETURN;
 
-	if(obstacle.operation == BattleChanges::EOperation::ADD)
+	if(obstacle.operation == BattleChanges::EOperation::ADD || obstacle.operation == BattleChanges::EOperation::UPDATE)
 	{
 		auto instance = cb->getBattle(battleID)->battleGetObstacleByID(obstacle.id);
 		if(instance)

--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -804,8 +804,6 @@ void CPlayerInterface::battleCatapultAttacked(const BattleID & battleID, const C
 	BATTLE_EVENT_POSSIBLE_RETURN;
 
 	battleInt->stackIsCatapulting(ca);
-	if(ca.killedTowerShooter != -1)
-		battleInt->stackRemoved(static_cast<uint32_t>(ca.killedTowerShooter));
 }
 
 void CPlayerInterface::battleNewRound(const BattleID & battleID) //called at the beginning of each turn, round=-1 is the tactic phase, round=0 is the first "normal" turn

--- a/client/CPlayerInterface.h
+++ b/client/CPlayerInterface.h
@@ -176,7 +176,7 @@ protected: // Call-ins from server, should not be called directly, but only via 
 	void battleStartBefore(const BattleID & battleID, const CCreatureSet *army1, const CCreatureSet *army2, int3 tile, const CGHeroInstance *hero1, const CGHeroInstance *hero2) override; //called by engine just before battle starts; side=0 - left, side=1 - right
 	void battleStart(const BattleID & battleID, const CCreatureSet *army1, const CCreatureSet *army2, int3 tile, const CGHeroInstance *hero1, const CGHeroInstance *hero2, BattleSide side, bool replayAllowed) override; //called by engine when battle starts; side=0 - left, side=1 - right
 	void battleUnitsChanged(const BattleID & battleID, const std::vector<UnitChanges> & units) override;
-	void battleObstaclesChanged(const BattleID & battleID, const std::vector<ObstacleChanges> & obstacles) override;
+	void battleObstaclesChanged(const BattleID & battleID, const ObstacleChanges & obstacle) override;
 	void battleCatapultAttacked(const BattleID & battleID, const CatapultAttack & ca) override; //called when catapult makes an attack
 	void battleGateStateChanged(const BattleID & battleID, const EGateState state) override;
 	void yourTacticPhase(const BattleID & battleID, int distance) override;

--- a/client/NetPacksClient.cpp
+++ b/client/NetPacksClient.cpp
@@ -906,8 +906,8 @@ void ApplyClientNetPackVisitor::visitBattleUnitsChanged(BattleUnitsChanged & pac
 
 void ApplyClientNetPackVisitor::visitBattleObstaclesChanged(BattleObstaclesChanged & pack)
 {
-	//inform interfaces about removed obstacles
-	callBattleInterfaceIfPresentForBothSides(cl, pack.battleID, &IBattleEventsReceiver::battleObstaclesChanged, pack.battleID, pack.changes);
+	//inform interfaces about the changed obstacle
+	callBattleInterfaceIfPresentForBothSides(cl, pack.battleID, &IBattleEventsReceiver::battleObstaclesChanged, pack.battleID, pack.change);
 }
 
 void ApplyClientNetPackVisitor::visitCatapultAttack(CatapultAttack & pack)

--- a/client/battle/BattleAnimationClasses.cpp
+++ b/client/battle/BattleAnimationClasses.cpp
@@ -1229,3 +1229,28 @@ void ChainLightningAnimation::tick(uint32_t msPassed)
 	if(!owner.projectilesController->hasActiveProjectile(caster, false))
 		delete this;
 }
+
+// how long the partially-open drawbridge frame is shown while the bridge lowers or raises, in ms
+static constexpr uint32_t gateTransitionDuration = 200;
+
+GateAnimation::GateAnimation(BattleInterface & owner, EGateState targetState):
+	BattleAnimation(owner),
+	targetState(targetState)
+{
+}
+
+bool GateAnimation::init()
+{
+	owner.siegeController->showPartialGate();
+	return true;
+}
+
+void GateAnimation::tick(uint32_t msPassed)
+{
+	elapsed += msPassed;
+	if(elapsed >= gateTransitionDuration)
+	{
+		owner.siegeController->applyGateState(targetState);
+		delete this;
+	}
+}

--- a/client/battle/BattleAnimationClasses.cpp
+++ b/client/battle/BattleAnimationClasses.cpp
@@ -1064,6 +1064,8 @@ bool EffectAnimation::screenFill() const
 void EffectAnimation::onEffectFinished()
 {
 	effectFinished = true;
+	if (onFinished)
+		onFinished();
 }
 
 void EffectAnimation::playEffect(uint32_t msPassed)

--- a/client/battle/BattleAnimationClasses.cpp
+++ b/client/battle/BattleAnimationClasses.cpp
@@ -1208,3 +1208,24 @@ void HeroCastAnimation::tick(uint32_t msPassed)
 
 	hero->play();
 }
+
+ChainLightningAnimation::ChainLightningAnimation(BattleInterface & owner, const CStack * caster, const std::vector<Point> & targetPoints, const CSpell * spell):
+	BattleAnimation(owner),
+	caster(caster),
+	targetPoints(targetPoints),
+	spell(spell)
+{
+}
+
+bool ChainLightningAnimation::init()
+{
+	owner.projectilesController->createSpellRayProjectile(caster, targetPoints, spell->animationInfo.ray, spell->animationInfo.rayJaggedness, spell->animationInfo.rayHopDelay, spell->animationInfo.rayWidth);
+	return true;
+}
+
+void ChainLightningAnimation::tick(uint32_t msPassed)
+{
+	// the animation only exists to keep the caster frozen and block waitForAnimations until the ray lands
+	if(!owner.projectilesController->hasActiveProjectile(caster, false))
+		delete this;
+}

--- a/client/battle/BattleAnimationClasses.cpp
+++ b/client/battle/BattleAnimationClasses.cpp
@@ -856,7 +856,9 @@ void CatapultAnimation::tick(uint32_t msPassed)
 	AnimationPath effectFilename = AnimationPath::builtin((catapultDamage > 0) ? "SGEXPL" : "CSGRCK");
 
 	ENGINE->sound().playSound( soundFilename );
-	owner.stacksController->addNewAnim( new EffectAnimation(owner, effectFilename, shotTarget));
+	auto explosion = new EffectAnimation(owner, effectFilename, shotTarget);
+	explosion->onMidpoint = onExplosion;
+	owner.stacksController->addNewAnim(explosion);
 }
 
 void CatapultAnimation::createProjectile(const Point & from, const Point & dest) const
@@ -1078,6 +1080,13 @@ void EffectAnimation::playEffect(uint32_t msPassed)
 		if(elem.effectID == ID)
 		{
 			elem.currentFrame += AnimationControls::getSpellEffectSpeed() * msPassed / 1000;
+
+			if(!midpointReached && elem.currentFrame >= elem.animation->size() / 2.0)
+			{
+				midpointReached = true;
+				if(onMidpoint)
+					onMidpoint();
+			}
 
 			if(elem.currentFrame >= elem.animation->size())
 			{

--- a/client/battle/BattleAnimationClasses.h
+++ b/client/battle/BattleAnimationClasses.h
@@ -25,6 +25,7 @@ class CAnimation;
 class BattleInterface;
 class CreatureAnimation;
 struct StackAttackedInfo;
+enum class EGateState : int8_t;
 
 /// Base class of battle animations
 class BattleAnimation
@@ -392,6 +393,19 @@ class ChainLightningAnimation : public BattleAnimation
 
 public:
 	ChainLightningAnimation(BattleInterface & owner, const CStack * caster, const std::vector<Point> & targetPoints, const CSpell * spell);
+
+	bool init() override;
+	void tick(uint32_t msPassed) override;
+};
+
+/// Shows the drawbridge's partially-open frame while it lowers or raises, then settles it to the final sprite
+class GateAnimation : public BattleAnimation
+{
+	EGateState targetState;
+	uint32_t elapsed = 0;
+
+public:
+	GateAnimation(BattleInterface & owner, EGateState targetState);
 
 	bool init() override;
 	void tick(uint32_t msPassed) override;

--- a/client/battle/BattleAnimationClasses.h
+++ b/client/battle/BattleAnimationClasses.h
@@ -273,6 +273,9 @@ private:
 public:
 	CatapultAnimation(BattleInterface & owner, const CStack * attacker, BattleHex dest, const CStack * defender, int _catapultDmg = 0);
 
+	/// invoked at the midpoint of the wall-hit explosion (used to swap the damaged wall sprite)
+	std::function<void()> onExplosion;
+
 	void createProjectile(const Point & from, const Point & dest) const override;
 	void tick(uint32_t msPassed) override;
 };
@@ -311,6 +314,7 @@ class EffectAnimation : public BattleAnimation
 	int effectFlags;
 	float transparencyFactor;
 	bool effectFinished;
+	bool midpointReached = false;
 	bool reversed;
 
 	std::shared_ptr<CAnimation>	animation;
@@ -350,6 +354,9 @@ public:
 
 	/// invoked once when the animation reaches its last frame, before the effect is removed
 	std::function<void()> onFinished;
+
+	/// invoked once when the animation reaches its halfway frame
+	std::function<void()> onMidpoint;
 
 	bool init() override;
 	void tick(uint32_t msPassed) override;

--- a/client/battle/BattleAnimationClasses.h
+++ b/client/battle/BattleAnimationClasses.h
@@ -348,6 +348,9 @@ public:
 	EffectAnimation(BattleInterface & owner, const AnimationPath & animationName, Point pos, BattleHex hex,     int effects = 0, bool reversed = false);
 	 ~EffectAnimation();
 
+	/// invoked once when the animation reaches its last frame, before the effect is removed
+	std::function<void()> onFinished;
+
 	bool init() override;
 	void tick(uint32_t msPassed) override;
 };

--- a/client/battle/BattleAnimationClasses.h
+++ b/client/battle/BattleAnimationClasses.h
@@ -382,3 +382,17 @@ public:
 	void tick(uint32_t msPassed) override;
 	bool init() override;
 };
+
+/// Drives the jagged ray chaining between chain-lightning targets; waits until the ray finishes flying
+class ChainLightningAnimation : public BattleAnimation
+{
+	const CStack * caster;
+	std::vector<Point> targetPoints;
+	const CSpell * spell;
+
+public:
+	ChainLightningAnimation(BattleInterface & owner, const CStack * caster, const std::vector<Point> & targetPoints, const CSpell * spell);
+
+	bool init() override;
+	void tick(uint32_t msPassed) override;
+};

--- a/client/battle/BattleFieldController.cpp
+++ b/client/battle/BattleFieldController.cpp
@@ -850,6 +850,8 @@ void BattleFieldController::tick(uint32_t msPassed)
 	owner.stacksController->tick(msPassed);
 	owner.obstacleController->tick(msPassed);
 	owner.projectilesController->tick(msPassed);
+	if (owner.siegeController)
+		owner.siegeController->tick(msPassed);
 }
 
 void BattleFieldController::show(Canvas & to)

--- a/client/battle/BattleFieldController.cpp
+++ b/client/battle/BattleFieldController.cpp
@@ -850,8 +850,6 @@ void BattleFieldController::tick(uint32_t msPassed)
 	owner.stacksController->tick(msPassed);
 	owner.obstacleController->tick(msPassed);
 	owner.projectilesController->tick(msPassed);
-	if (owner.siegeController)
-		owner.siegeController->tick(msPassed);
 }
 
 void BattleFieldController::show(Canvas & to)

--- a/client/battle/BattleInterface.cpp
+++ b/client/battle/BattleInterface.cpp
@@ -462,14 +462,12 @@ void BattleInterface::spellCast(const BattleSpellCast * sc)
 		displaySpellHit(spell, targetedTile);
 	});
 
-	// a chain ray (e.g. chain lightning) shows the full affect only on the primary target and connects the rest with a jagged bolt
 	const bool usesChainRay = !spell->animationInfo.ray.empty() && !sc->affectedCres.empty();
 
 	//queuing affect animation
 	if(usesChainRay)
 	{
-		// primary target keeps the full affect; the remaining (spark) animations play on every chained target,
-		// and each target's screen position feeds the connecting ray (in chain-hop order)
+		// only the primary (first) target gets the full affect; the rest get the trailing spark frames
 		const auto & affect = spell->animationInfo.affect;
 		SpellAnimationQueue sparks(affect.begin() + (affect.empty() ? 0 : 1), affect.end());
 

--- a/client/battle/BattleInterface.cpp
+++ b/client/battle/BattleInterface.cpp
@@ -724,7 +724,11 @@ void BattleInterface::tacticNextStack(const CStack * current)
 
 void BattleInterface::obstaclePlaced(const std::vector<std::shared_ptr<const CObstacleInstance>> oi)
 {
-	obstacleController->obstaclePlaced(oi);
+	// if a spell cast is mid-flight, show the obstacle after the caster's animation reaches its climax (HIT stage)
+	if(!awaitingEvents.empty())
+		addToAnimationStage(EAnimationEvents::HIT, [this, oi](){ obstacleController->obstaclePlaced(oi); });
+	else
+		obstacleController->obstaclePlaced(oi);
 }
 
 void BattleInterface::obstacleRemoved(const std::vector<ObstacleChanges> & obstacles)

--- a/client/battle/BattleInterface.cpp
+++ b/client/battle/BattleInterface.cpp
@@ -344,7 +344,14 @@ const CGHeroInstance * BattleInterface::getActiveHero()
 
 void BattleInterface::stackIsCatapulting(const CatapultAttack & ca)
 {
-	if (siegeController)
+	if (!siegeController)
+		return;
+
+	// a spell-caused catapult (earthquake, attacker == -1) applied while a hero cast is mid-flight must play
+	// at the caster's climax (HIT stage); otherwise the wall explosions appear before the hero's cast animation
+	if (ca.attacker == -1 && !awaitingEvents.empty())
+		addToAnimationStage(EAnimationEvents::HIT, [this, ca](){ siegeController->stackIsCatapulting(ca); });
+	else
 		siegeController->stackIsCatapulting(ca);
 }
 

--- a/client/battle/BattleInterface.cpp
+++ b/client/battle/BattleInterface.cpp
@@ -722,7 +722,7 @@ void BattleInterface::tacticNextStack(const CStack * current)
 
 }
 
-void BattleInterface::obstaclePlaced(const std::vector<std::shared_ptr<const CObstacleInstance>> oi)
+void BattleInterface::obstaclePlaced(const std::shared_ptr<const CObstacleInstance> & oi)
 {
 	// if a spell cast is mid-flight, show the obstacle after the caster's animation reaches its climax (HIT stage)
 	if(!awaitingEvents.empty())
@@ -731,9 +731,9 @@ void BattleInterface::obstaclePlaced(const std::vector<std::shared_ptr<const COb
 		obstacleController->obstaclePlaced(oi);
 }
 
-void BattleInterface::obstacleRemoved(const std::vector<ObstacleChanges> & obstacles)
+void BattleInterface::obstacleRemoved(const ObstacleChanges & obstacle)
 {
-	obstacleController->obstacleRemoved(obstacles);
+	obstacleController->obstacleRemoved(obstacle);
 }
 
 const CGHeroInstance *BattleInterface::currentHero() const

--- a/client/battle/BattleInterface.cpp
+++ b/client/battle/BattleInterface.cpp
@@ -462,16 +462,51 @@ void BattleInterface::spellCast(const BattleSpellCast * sc)
 		displaySpellHit(spell, targetedTile);
 	});
 
+	// a chain ray (e.g. chain lightning) shows the full affect only on the primary target and connects the rest with a jagged bolt
+	const bool usesChainRay = !spell->animationInfo.ray.empty() && !sc->affectedCres.empty();
+
 	//queuing affect animation
-	for(auto & elem : sc->affectedCres)
+	if(usesChainRay)
 	{
-		auto stack = getBattle()->battleGetStackByID(elem, false);
-		assert(stack);
-		if(stack)
+		// primary target keeps the full affect; the remaining (spark) animations play on every chained target,
+		// and each target's screen position feeds the connecting ray (in chain-hop order)
+		const auto & affect = spell->animationInfo.affect;
+		SpellAnimationQueue sparks(affect.begin() + (affect.empty() ? 0 : 1), affect.end());
+
+		std::vector<Point> targetPoints;
+		for(size_t i = 0; i < sc->affectedCres.size(); ++i)
 		{
-			addToAnimationStage(EAnimationEvents::HIT, [this, stack, spell](){
-				displaySpellEffect(spell, stack->getPosition());
-			});
+			auto stack = getBattle()->battleGetStackByID(sc->affectedCres[i], false);
+			if(!stack)
+				continue;
+
+			BattleHex hex = stack->getPosition();
+			if(i == 0)
+				addToAnimationStage(EAnimationEvents::HIT, [this, spell, hex](){ displaySpellEffect(spell, hex); });
+			else
+				addToAnimationStage(EAnimationEvents::HIT, [this, spell, sparks, hex](){ displaySpellAnimationQueue(spell, sparks, hex, false); });
+
+			Point directionOffset(30, 0);
+			targetPoints.push_back(stacksController->getStackPositionAtHex(hex, stack) + Point(225, 225) + (stacksController->facingRight(stack) ? -directionOffset : directionOffset));
+		}
+
+		const CStack * casterStack = getBattle()->battleGetStackByID(sc->casterStack);
+		addToAnimationStage(EAnimationEvents::HIT, [this, casterStack, targetPoints, spell](){
+			stacksController->addNewAnim(new ChainLightningAnimation(*this, casterStack, targetPoints, spell));
+		});
+	}
+	else
+	{
+		for(auto & elem : sc->affectedCres)
+		{
+			auto stack = getBattle()->battleGetStackByID(elem, false);
+			assert(stack);
+			if(stack)
+			{
+				addToAnimationStage(EAnimationEvents::HIT, [this, stack, spell](){
+					displaySpellEffect(spell, stack->getPosition());
+				});
+			}
 		}
 	}
 
@@ -646,6 +681,10 @@ std::shared_ptr<CPlayerBattleCallback> BattleInterface::getBattle() const
 
 void BattleInterface::endAction(const BattleAction &action)
 {
+	// deferred spell hit reactions (e.g. chain lightning) are left undriven; start them so the wait below completes them
+	if(!awaitingEvents.empty() && !hasAnimations())
+		executeStagedAnimations();
+
 	// it is possible that tactics mode ended while opening music is still playing
 	waitForAnimations();
 
@@ -888,6 +927,14 @@ void BattleInterface::checkForAnimations()
 void BattleInterface::addToAnimationStage(EAnimationEvents event, const AwaitingAnimationAction & action)
 {
 	awaitingEvents.push_back({action, event});
+}
+
+bool BattleInterface::hasQueuedStage(EAnimationEvents event) const
+{
+	for(const auto & e : awaitingEvents)
+		if(e.event == event)
+			return true;
+	return false;
 }
 
 void BattleInterface::setBattleQueueVisibility(bool visible)

--- a/client/battle/BattleInterface.cpp
+++ b/client/battle/BattleInterface.cpp
@@ -497,16 +497,23 @@ void BattleInterface::spellCast(const BattleSpellCast * sc)
 	}
 	else
 	{
+		size_t affectedIndex = 0;
 		for(auto & elem : sc->affectedCres)
 		{
 			auto stack = getBattle()->battleGetStackByID(elem, false);
 			assert(stack);
 			if(stack)
 			{
-				addToAnimationStage(EAnimationEvents::HIT, [this, stack, spell](){
-					displaySpellEffect(spell, stack->getPosition());
+				// secondary affected targets (e.g. the sacrificed unit) use a distinct effect if the spell defines one
+				bool useSecondary = affectedIndex > 0 && !spell->animationInfo.affectSecondary.empty();
+				addToAnimationStage(EAnimationEvents::HIT, [this, stack, spell, useSecondary](){
+					if(useSecondary)
+						displaySpellAnimationQueue(spell, spell->animationInfo.affectSecondary, stack->getPosition(), false);
+					else
+						displaySpellEffect(spell, stack->getPosition());
 				});
 			}
+			++affectedIndex;
 		}
 	}
 

--- a/client/battle/BattleInterface.h
+++ b/client/battle/BattleInterface.h
@@ -196,6 +196,8 @@ public:
 	void waitForAnimations();
 	bool hasAnimations();
 	void checkForAnimations();
+	/// true if an action for the given animation stage is still queued (not yet executed)
+	bool hasQueuedStage(EAnimationEvents event) const;
 	void addToAnimationStage( EAnimationEvents event, const AwaitingAnimationAction & action);
 
 	//call-ins

--- a/client/battle/BattleInterface.h
+++ b/client/battle/BattleInterface.h
@@ -224,8 +224,8 @@ public:
 
 	void endAction(const BattleAction & action);
 
-	void obstaclePlaced(const std::vector<std::shared_ptr<const CObstacleInstance>> oi);
-	void obstacleRemoved(const std::vector<ObstacleChanges> & obstacles);
+	void obstaclePlaced(const std::shared_ptr<const CObstacleInstance> & oi);
+	void obstacleRemoved(const ObstacleChanges & obstacle);
 
 	void gateStateChanged(const EGateState state);
 

--- a/client/battle/BattleObstacleController.cpp
+++ b/client/battle/BattleObstacleController.cpp
@@ -58,53 +58,48 @@ void BattleObstacleController::loadObstacleImage(const CObstacleInstance & oi)
 	}
 }
 
-void BattleObstacleController::obstacleRemoved(const std::vector<ObstacleChanges> & obstacles)
+void BattleObstacleController::obstacleRemoved(const ObstacleChanges & oi)
 {
-	for(const auto & oi : obstacles)
+	auto & obstacle = oi.data["obstacle"];
+
+	if (!obstacle.isStruct())
 	{
-		auto & obstacle = oi.data["obstacle"];
-
-		if (!obstacle.isStruct())
-		{
-			logGlobal->error("I don't know how to animate removal of this obstacle");
-			continue;
-		}
-
-		AnimationPath animationPath;
-		JsonDeserializer ser(nullptr, obstacle);
-		ser.serializeStruct("appearAnimation", animationPath);
-
-		if(animationPath.empty())
-			continue;
-
-		auto animation = ENGINE->renderHandler().loadAnimation(animationPath, EImageBlitMode::SIMPLE);
-		auto first = animation->getImage(0, 0);
-		if(!first)
-			continue;
-
-		//we assume here that effect graphics have the same size as the usual obstacle image
-		// -> if we know how to blit obstacle, let's blit the effect in the same place
-		Point whereTo = getObstaclePosition(first, obstacle);
-		//AFAIK, in H3 there is no sound of obstacle removal
-		owner.stacksController->addNewAnim(new EffectAnimation(owner, animationPath, whereTo, obstacle["position"].Integer(), 0, true));
-
-		obstacleAnimations.erase(oi.id);
-		obstacleImages.erase(oi.id);
-		//so when multiple obstacles are removed, they show up one after another
-		owner.waitForAnimations();
+		logGlobal->error("I don't know how to animate removal of this obstacle");
+		return;
 	}
+
+	AnimationPath animationPath;
+	JsonDeserializer ser(nullptr, obstacle);
+	ser.serializeStruct("appearAnimation", animationPath);
+
+	if(animationPath.empty())
+		return;
+
+	auto animation = ENGINE->renderHandler().loadAnimation(animationPath, EImageBlitMode::SIMPLE);
+	auto first = animation->getImage(0, 0);
+	if(!first)
+		return;
+
+	//we assume here that effect graphics have the same size as the usual obstacle image
+	// -> if we know how to blit obstacle, let's blit the effect in the same place
+	Point whereTo = getObstaclePosition(first, obstacle);
+	//AFAIK, in H3 there is no sound of obstacle removal
+	owner.stacksController->addNewAnim(new EffectAnimation(owner, animationPath, whereTo, obstacle["position"].Integer(), 0, true));
+
+	obstacleAnimations.erase(oi.id);
+	obstacleImages.erase(oi.id);
+	//obstacles are removed one at a time, so multiple removals still show up one after another
+	owner.waitForAnimations();
 }
 
-void BattleObstacleController::obstaclePlaced(const std::vector<std::shared_ptr<const CObstacleInstance>> & obstacles)
+void BattleObstacleController::obstaclePlaced(const std::shared_ptr<const CObstacleInstance> & oi)
 {
 	auto side = owner.getBattle()->playerToSide(owner.curInt->playerID);
-	bool hasNativeStack = owner.getBattle()->battleHasNativeStack(side);
 
 	// spells that place several obstacles (e.g. Land Mine) send them as separate packs, so queue
 	// them here and play their placement animations one after another across all such calls
-	for(const auto & oi : obstacles)
-		if(oi->visibleForSide(side, hasNativeStack))
-			obstaclePlacementQueue.push_back(oi);
+	if(oi->visibleForSide(side, owner.getBattle()->battleHasNativeStack(side)))
+		obstaclePlacementQueue.push_back(oi);
 
 	placeNextObstacle();
 }

--- a/client/battle/BattleObstacleController.cpp
+++ b/client/battle/BattleObstacleController.cpp
@@ -29,6 +29,9 @@
 #include "../../lib/battle/CPlayerBattleCallback.h"
 #include "../../lib/serializer/JsonDeserializer.h"
 
+// how long a removed "usual" obstacle takes to fade out, in ms
+static constexpr uint32_t obstacleFadeDuration = 500;
+
 BattleObstacleController::BattleObstacleController(BattleInterface & owner):
 	owner(owner),
 	timePassed(0.f)
@@ -56,37 +59,73 @@ void BattleObstacleController::loadObstacleImage(const CObstacleInstance & oi)
 		obstacleAnimations[oi.uniqueID] = ENGINE->renderHandler().loadAnimation(animationName, EImageBlitMode::SIMPLE);
 		obstacleImages[oi.uniqueID] = obstacleAnimations[oi.uniqueID]->getImage(0);
 	}
+
+	// cache the render position so a fade-out after removal matches where the obstacle was actually drawn
+	if(obstacleImages[oi.uniqueID])
+		obstaclePositions[oi.uniqueID] = getObstaclePosition(obstacleImages[oi.uniqueID], oi);
 }
 
 void BattleObstacleController::obstacleRemoved(const ObstacleChanges & oi)
 {
 	auto & obstacle = oi.data["obstacle"];
 
-	if (!obstacle.isStruct())
+	if (obstacle.isStruct())
+	{
+		AnimationPath animationPath;
+		JsonDeserializer ser(nullptr, obstacle);
+		ser.serializeStruct("removalAnimation", animationPath);
+		if(animationPath.empty()) // magical obstacles without a dedicated removal effect reuse their appear animation
+			ser.serializeStruct("appearAnimation", animationPath);
+
+		if(!animationPath.empty())
+		{
+			auto animation = ENGINE->renderHandler().loadAnimation(animationPath, EImageBlitMode::SIMPLE);
+			auto first = animation->getImage(0, 0);
+			if(first)
+			{
+				Point whereTo = getObstaclePosition(first, obstacle);
+				//AFAIK, in H3 there is no sound of obstacle removal
+				owner.stacksController->addNewAnim(new EffectAnimation(owner, animationPath, whereTo, obstacle["position"].Integer(), 0, true));
+				obstacleAnimations.erase(oi.id);
+				obstacleImages.erase(oi.id);
+				obstaclePositions.erase(oi.id);
+				owner.waitForAnimations();
+				return;
+			}
+		}
+		else if(obstacleImages.count(oi.id) && obstacleImages[oi.id])
+		{
+			// "usual" battlefield obstacle (rock/tree) has no removal animation of its own: fade out its sprite.
+			// keep drawing it right away (it is erased below), but hold it at full opacity until the removing
+			// spell's hit stage, so the fade runs together with the spell effect rather than before or after it
+			FadingObstacle fade;
+			fade.image = obstacleImages[oi.id];
+			fade.pos = obstaclePositions.count(oi.id) ? obstaclePositions[oi.id] : getObstaclePosition(obstacleImages[oi.id], obstacle);
+			fade.hex = BattleHex(static_cast<si16>(obstacle["position"].Integer()));
+			fade.id = oi.id;
+			fade.started = !owner.hasQueuedStage(EAnimationEvents::HIT);
+			fadingObstacles.push_back(fade);
+
+			if(!fade.started)
+			{
+				auto obstacleId = oi.id;
+				owner.addToAnimationStage(EAnimationEvents::HIT, [this, obstacleId](){
+					for(auto & f : fadingObstacles)
+						if(f.id == obstacleId)
+							f.started = true;
+				});
+			}
+		}
+	}
+	else
 	{
 		logGlobal->error("I don't know how to animate removal of this obstacle");
-		return;
 	}
 
-	AnimationPath animationPath;
-	JsonDeserializer ser(nullptr, obstacle);
-	ser.serializeStruct("appearAnimation", animationPath);
-
-	if(animationPath.empty())
-		return;
-
-	auto animation = ENGINE->renderHandler().loadAnimation(animationPath, EImageBlitMode::SIMPLE);
-	auto first = animation->getImage(0, 0);
-	if(!first)
-		return;
-
-	Point whereTo = getObstaclePosition(first, obstacle);
-	//AFAIK, in H3 there is no sound of obstacle removal
-	owner.stacksController->addNewAnim(new EffectAnimation(owner, animationPath, whereTo, obstacle["position"].Integer(), 0, true));
-
+	// fade-out path (and error/no-op paths) run without a blocking animation, so no waitForAnimations here
 	obstacleAnimations.erase(oi.id);
 	obstacleImages.erase(oi.id);
-	owner.waitForAnimations();
+	obstaclePositions.erase(oi.id);
 }
 
 void BattleObstacleController::obstaclePlaced(const std::shared_ptr<const CObstacleInstance> & oi)
@@ -183,6 +222,17 @@ void BattleObstacleController::collectRenderableObjects(BattleRenderer & rendere
 			}
 		});
 	}
+
+	for(const auto & fade : fadingObstacles)
+	{
+		auto image = fade.image;
+		Point pos = fade.pos;
+		auto alpha = fade.started ? static_cast<uint8_t>(std::clamp(1.f - static_cast<float>(fade.elapsed) / obstacleFadeDuration, 0.f, 1.f) * 255) : 255;
+		renderer.insert(EBattleFieldLayer::OBSTACLES, fade.hex, [image, pos, alpha](BattleRenderer::RendererRef canvas){
+			image->setAlpha(alpha);
+			canvas.draw(image, pos);
+		});
+	}
 }
 
 void BattleObstacleController::tick(uint32_t msPassed)
@@ -195,6 +245,11 @@ void BattleObstacleController::tick(uint32_t msPassed)
 		int frameIndex = framesCount % animation.second->size(0);
 		obstacleImages[animation.first] = animation.second->getImage(frameIndex, 0);
 	}
+
+	for(auto & fade : fadingObstacles)
+		if(fade.started)
+			fade.elapsed += msPassed;
+	vstd::erase_if(fadingObstacles, [](const FadingObstacle & f){ return f.started && f.elapsed >= obstacleFadeDuration; });
 }
 
 std::shared_ptr<IImage> BattleObstacleController::getObstacleImage(const CObstacleInstance & oi)

--- a/client/battle/BattleObstacleController.cpp
+++ b/client/battle/BattleObstacleController.cpp
@@ -95,9 +95,8 @@ void BattleObstacleController::obstacleRemoved(const ObstacleChanges & oi)
 		}
 		else if(obstacleImages.count(oi.id) && obstacleImages[oi.id])
 		{
-			// "usual" battlefield obstacle (rock/tree) has no removal animation of its own: fade out its sprite.
-			// keep drawing it right away (it is erased below), but hold it at full opacity until the removing
-			// spell's hit stage, so the fade runs together with the spell effect rather than before or after it
+			// "usual" obstacles (rock/tree) have no removal animation - fade their sprite out instead.
+			// hold at full opacity until the removing spell's hit stage so fade and spell effect coincide
 			FadingObstacle fade;
 			fade.image = obstacleImages[oi.id];
 			fade.pos = obstaclePositions.count(oi.id) ? obstaclePositions[oi.id] : getObstaclePosition(obstacleImages[oi.id], obstacle);

--- a/client/battle/BattleObstacleController.cpp
+++ b/client/battle/BattleObstacleController.cpp
@@ -97,29 +97,52 @@ void BattleObstacleController::obstacleRemoved(const std::vector<ObstacleChanges
 
 void BattleObstacleController::obstaclePlaced(const std::vector<std::shared_ptr<const CObstacleInstance>> & obstacles)
 {
+	auto side = owner.getBattle()->playerToSide(owner.curInt->playerID);
+	bool hasNativeStack = owner.getBattle()->battleHasNativeStack(side);
+
+	// spells that place several obstacles (e.g. Land Mine) send them as separate packs, so queue
+	// them here and play their placement animations one after another across all such calls
 	for(const auto & oi : obstacles)
+		if(oi->visibleForSide(side, hasNativeStack))
+			obstaclePlacementQueue.push_back(oi);
+
+	placeNextObstacle();
+}
+
+void BattleObstacleController::placeNextObstacle()
+{
+	if(placingObstacle || obstaclePlacementQueue.empty())
+		return;
+
+	auto oi = obstaclePlacementQueue.front();
+	obstaclePlacementQueue.erase(obstaclePlacementQueue.begin());
+
+	auto animation = ENGINE->renderHandler().loadAnimation(oi->getAppearAnimation(), EImageBlitMode::SIMPLE);
+	auto first = animation->getImage(0, 0);
+	if(!first)
 	{
-		auto side = owner.getBattle()->playerToSide(owner.curInt->playerID);
-
-		if(!oi->visibleForSide(side, owner.getBattle()->battleHasNativeStack(side)))
-			continue;
-
-		auto animation = ENGINE->renderHandler().loadAnimation(oi->getAppearAnimation(), EImageBlitMode::SIMPLE);
-		auto first = animation->getImage(0, 0);
-		if(!first)
-			continue;
-
-		//we assume here that effect graphics have the same size as the usual obstacle image
-		// -> if we know how to blit obstacle, let's blit the effect in the same place
-		Point whereTo = getObstaclePosition(first, *oi);
-		ENGINE->sound().playSound( oi->getAppearSound() );
-		owner.stacksController->addNewAnim(new EffectAnimation(owner, oi->getAppearAnimation(), whereTo, oi->pos));
-
-		//so when multiple obstacles are added, they show up one after another
-		owner.waitForAnimations();
-
-		loadObstacleImage(*oi);
+		placeNextObstacle();
+		return;
 	}
+
+	//we assume here that effect graphics have the same size as the usual obstacle image
+	// -> if we know how to blit obstacle, let's blit the effect in the same place
+	Point whereTo = getObstaclePosition(first, *oi);
+	ENGINE->sound().playSound( oi->getAppearSound() );
+
+	placingObstacle = true;
+	auto effect = new EffectAnimation(owner, oi->getAppearAnimation(), whereTo, oi->pos);
+	effect->onFinished = [this, oi]()
+	{
+		// permanent obstacle graphic appears exactly when its placement animation ends,
+		// independently of the caster's spell animation
+		loadObstacleImage(*oi);
+		// starting the next obstacle here (before this effect is removed) leaves no gap in
+		// pending animations, so the caster stays frozen until every obstacle is placed
+		placingObstacle = false;
+		placeNextObstacle();
+	};
+	owner.stacksController->addNewAnim(effect);
 }
 
 void BattleObstacleController::showAbsoluteObstacles(Canvas & canvas)

--- a/client/battle/BattleObstacleController.cpp
+++ b/client/battle/BattleObstacleController.cpp
@@ -80,15 +80,12 @@ void BattleObstacleController::obstacleRemoved(const ObstacleChanges & oi)
 	if(!first)
 		return;
 
-	//we assume here that effect graphics have the same size as the usual obstacle image
-	// -> if we know how to blit obstacle, let's blit the effect in the same place
 	Point whereTo = getObstaclePosition(first, obstacle);
 	//AFAIK, in H3 there is no sound of obstacle removal
 	owner.stacksController->addNewAnim(new EffectAnimation(owner, animationPath, whereTo, obstacle["position"].Integer(), 0, true));
 
 	obstacleAnimations.erase(oi.id);
 	obstacleImages.erase(oi.id);
-	//obstacles are removed one at a time, so multiple removals still show up one after another
 	owner.waitForAnimations();
 }
 
@@ -96,8 +93,7 @@ void BattleObstacleController::obstaclePlaced(const std::shared_ptr<const CObsta
 {
 	auto side = owner.getBattle()->playerToSide(owner.curInt->playerID);
 
-	// spells that place several obstacles (e.g. Land Mine) send them as separate packs, so queue
-	// them here and play their placement animations one after another across all such calls
+	// second animation from the same spell - enqueue it
 	if(oi->visibleForSide(side, owner.getBattle()->battleHasNativeStack(side)))
 		obstaclePlacementQueue.push_back(oi);
 
@@ -120,8 +116,6 @@ void BattleObstacleController::placeNextObstacle()
 		return;
 	}
 
-	//we assume here that effect graphics have the same size as the usual obstacle image
-	// -> if we know how to blit obstacle, let's blit the effect in the same place
 	Point whereTo = getObstaclePosition(first, *oi);
 	ENGINE->sound().playSound( oi->getAppearSound() );
 
@@ -129,11 +123,7 @@ void BattleObstacleController::placeNextObstacle()
 	auto effect = new EffectAnimation(owner, oi->getAppearAnimation(), whereTo, oi->pos);
 	effect->onFinished = [this, oi]()
 	{
-		// permanent obstacle graphic appears exactly when its placement animation ends,
-		// independently of the caster's spell animation
 		loadObstacleImage(*oi);
-		// starting the next obstacle here (before this effect is removed) leaves no gap in
-		// pending animations, so the caster stays frozen until every obstacle is placed
 		placingObstacle = false;
 		placeNextObstacle();
 	};

--- a/client/battle/BattleObstacleController.h
+++ b/client/battle/BattleObstacleController.h
@@ -42,6 +42,13 @@ class BattleObstacleController
 
 	void loadObstacleImage(const CObstacleInstance & oi);
 
+	/// obstacles awaiting their placement animation; shown one after another
+	std::vector<std::shared_ptr<const CObstacleInstance>> obstaclePlacementQueue;
+	bool placingObstacle = false;
+
+	/// starts the placement animation of the next queued obstacle, unless one is already playing
+	void placeNextObstacle();
+
 	std::shared_ptr<IImage> getObstacleImage(const CObstacleInstance & oi);
 	Point getObstaclePosition(std::shared_ptr<IImage> image, const CObstacleInstance & obstacle);
 	Point getObstaclePosition(std::shared_ptr<IImage> image, const JsonNode & obstacle);

--- a/client/battle/BattleObstacleController.h
+++ b/client/battle/BattleObstacleController.h
@@ -59,11 +59,11 @@ public:
 	/// called every frame
 	void tick(uint32_t msPassed);
 
-	/// call-in from network pack, add newly placed obstacles with any required animations
-	void obstaclePlaced(const std::vector<std::shared_ptr<const CObstacleInstance>> & oi);
+	/// call-in from network pack, add a newly placed obstacle with any required animations
+	void obstaclePlaced(const std::shared_ptr<const CObstacleInstance> & oi);
 
-	/// call-in from network pack, remove required obstacles with any required animations
-	void obstacleRemoved(const std::vector<ObstacleChanges> & obstacles);
+	/// call-in from network pack, remove an obstacle with any required animations
+	void obstacleRemoved(const ObstacleChanges & obstacle);
 
 	/// renders all "absolute" obstacles
 	void showAbsoluteObstacles(Canvas & canvas);

--- a/client/battle/BattleObstacleController.h
+++ b/client/battle/BattleObstacleController.h
@@ -10,12 +10,12 @@
 #pragma once
 
 #include "../../lib/filesystem/ResourcePath.h"
+#include "../../lib/battle/BattleHex.h"
+#include "../../lib/Point.h"
 
-class BattleHex;
 struct CObstacleInstance;
 class JsonNode;
 class ObstacleChanges;
-class Point;
 
 class IImage;
 class Canvas;
@@ -39,6 +39,21 @@ class BattleObstacleController
 
 	/// Current images for all present obstacles
 	std::map<si32, std::shared_ptr<IImage>> obstacleImages;
+
+	/// cached render position per obstacle, so a removal fade-out draws where the obstacle actually was
+	std::map<si32, Point> obstaclePositions;
+
+	/// removed "usual" obstacles currently fading out (they have no removal animation of their own)
+	struct FadingObstacle
+	{
+		std::shared_ptr<IImage> image;
+		Point pos;
+		BattleHex hex;
+		si32 id = 0;
+		uint32_t elapsed = 0;
+		bool started = false; // stays fully visible until the removing spell's hit stage starts the fade
+	};
+	std::vector<FadingObstacle> fadingObstacles;
 
 	void loadObstacleImage(const CObstacleInstance & oi);
 

--- a/client/battle/BattleProjectileController.cpp
+++ b/client/battle/BattleProjectileController.cpp
@@ -133,7 +133,6 @@ void ProjectileRay::show(Canvas & canvas)
 {
 	if (path.empty())
 	{
-		// straight ray growing from origin to destination
 		Point curr {
 			vstd::lerp(from.x, dest.x, progress),
 			vstd::lerp(from.y, dest.y, progress),
@@ -142,7 +141,7 @@ void ProjectileRay::show(Canvas & canvas)
 		return;
 	}
 
-	// jagged polyline: reveal it one whole hop at a time as `progress` advances (no traveling animation)
+	// jagged polyline, revealed one hop at a time as `progress` advances
 	int totalSegments = static_cast<int>(path.size()) - 1;
 	int segmentsPerHop = totalSegments / hopCount;
 	int revealedHops = std::min(hopCount, static_cast<int>(progress * hopCount) + 1);

--- a/client/battle/BattleProjectileController.cpp
+++ b/client/battle/BattleProjectileController.cpp
@@ -103,52 +103,64 @@ void ProjectileCatapult::show(Canvas & canvas)
 	}
 }
 
-void ProjectileRay::show(Canvas & canvas)
+/// draws a single ray segment as a bundle of parallel gradient sub-lines from `from` to `curr`
+static void drawRaySegment(Canvas & canvas, const Point & from, const Point & curr, const std::vector<RayColor> & rayConfig)
 {
-	Point curr {
-		vstd::lerp(from.x, dest.x, progress),
-		vstd::lerp(from.y, dest.y, progress),
-	};
-
 	Point length = curr - from;
+	int lines = static_cast<int>(rayConfig.size());
 
 	//select axis to draw ray on, we want angle to be less than 45 degrees so individual sub-rays won't overlap each other
 
 	if (std::abs(length.x) > std::abs(length.y)) // draw in horizontal axis
 	{
-		int y1 =  from.y - rayConfig.size() / 2;
-		int y2 =  curr.y - rayConfig.size() / 2;
+		int y1 =  from.y - lines / 2;
+		int y2 =  curr.y - lines / 2;
 
-		int x1 = from.x;
-		int x2 = curr.x;
-
-		for (size_t i = 0; i < rayConfig.size(); ++i)
-		{
-			auto ray = rayConfig[i];
-			canvas.drawLine(Point(x1, y1 + i), Point(x2, y2+i), ray.start, ray.end);
-		}
+		for (int i = 0; i < lines; ++i)
+			canvas.drawLine(Point(from.x, y1 + i), Point(curr.x, y2 + i), rayConfig[i].start, rayConfig[i].end);
 	}
 	else // draw in vertical axis
 	{
-		int x1 = from.x - rayConfig.size() / 2;
-		int x2 = curr.x - rayConfig.size() / 2;
+		int x1 = from.x - lines / 2;
+		int x2 = curr.x - lines / 2;
 
-		int y1 = from.y;
-		int y2 = curr.y;
-
-		for (size_t i = 0; i < rayConfig.size(); ++i)
-		{
-			auto ray = rayConfig[i];
-
-			canvas.drawLine(Point(x1 + i, y1), Point(x2 + i, y2), ray.start, ray.end);
-		}
+		for (int i = 0; i < lines; ++i)
+			canvas.drawLine(Point(x1 + i, from.y), Point(x2 + i, curr.y), rayConfig[i].start, rayConfig[i].end);
 	}
+}
+
+void ProjectileRay::show(Canvas & canvas)
+{
+	if (path.empty())
+	{
+		// straight ray growing from origin to destination
+		Point curr {
+			vstd::lerp(from.x, dest.x, progress),
+			vstd::lerp(from.y, dest.y, progress),
+		};
+		drawRaySegment(canvas, from, curr, rayConfig);
+		return;
+	}
+
+	// jagged polyline: reveal it one whole hop at a time as `progress` advances (no traveling animation)
+	int totalSegments = static_cast<int>(path.size()) - 1;
+	int segmentsPerHop = totalSegments / hopCount;
+	int revealedHops = std::min(hopCount, static_cast<int>(progress * hopCount) + 1);
+
+	for (int i = 0; i < revealedHops * segmentsPerHop; ++i)
+		drawRaySegment(canvas, path[i], path[i + 1], rayConfig);
 }
 
 void ProjectileRay::tick(uint32_t msPassed)
 {
 	float timePassed = msPassed / 1000.f;
-	progress += timePassed * speed;
+
+	if (progress < 1.f)
+		progress = std::min(1.f, progress + timePassed * speed); // hold fully drawn once complete
+	else if (linger > 0.f)
+		linger -= timePassed;
+	else
+		progress = 2.f; // linger expired -> let controller erase it
 }
 
 BattleProjectileController::BattleProjectileController(BattleInterface & owner):
@@ -383,4 +395,78 @@ void BattleProjectileController::createSpellProjectile(const CStack * shooter, P
 
 		projectiles.push_back(std::shared_ptr<ProjectileBase>(projectile));
 	}
+}
+
+/// appends a midpoint-displaced polyline from a (exclusive) to b (inclusive) to `out`
+static void addJaggedSegment(std::vector<Point> & out, const Point & a, const Point & b, float amplitude, int depth)
+{
+	if (depth <= 0)
+	{
+		out.push_back(b);
+		return;
+	}
+
+	Point dir = b - a;
+	float len = std::sqrt(static_cast<float>(dir.x * dir.x + dir.y * dir.y));
+
+	Point mid = (a + b) / 2;
+	if (len > 1.f)
+	{
+		static std::mt19937 rng(std::random_device{}());
+		std::uniform_real_distribution<float> dist(-amplitude, amplitude);
+		float off = dist(rng) * len;
+		// displace the midpoint perpendicular to the segment
+		mid.x += static_cast<int>(-dir.y / len * off);
+		mid.y += static_cast<int>( dir.x / len * off);
+	}
+
+	addJaggedSegment(out, a, mid, amplitude, depth - 1);
+	addJaggedSegment(out, mid, b, amplitude, depth - 1);
+}
+
+/// expands `keys` (edge -> center gradient) into a symmetric `width`-line gradient with interpolated intermediates
+static std::vector<RayColor> expandRayColors(const std::vector<RayColor> & keys, int width)
+{
+	if (keys.empty() || width <= static_cast<int>(keys.size()))
+		return keys;
+
+	std::vector<RayColor> out(width);
+	float center = (width - 1) / 2.f;
+	for (int k = 0; k < width; ++k)
+	{
+		// distance from edge, 0 at outer lines -> 1 at center
+		float edgeToCenter = center > 0 ? 1.f - std::abs(k - center) / center : 1.f;
+		float keyPos = edgeToCenter * (keys.size() - 1);
+		int i0 = static_cast<int>(keyPos);
+		int i1 = std::min<int>(i0 + 1, keys.size() - 1);
+		float f = keyPos - i0;
+		out[k].start = vstd::lerp(keys[i0].start, keys[i1].start, f);
+		out[k].end   = vstd::lerp(keys[i0].end,   keys[i1].end,   f);
+	}
+	return out;
+}
+
+void BattleProjectileController::createSpellRayProjectile(const CStack * caster, const std::vector<Point> & targetPoints, const std::vector<RayColor> & rayConfig, float jaggedness, float hopDelay, int width)
+{
+	if (targetPoints.size() < 2)
+		return;
+
+	auto ray = new ProjectileRay();
+
+	// each hop between consecutive targets is midpoint-displaced twice -> 4 jagged sub-segments per hop
+	ray->path.push_back(targetPoints.front());
+	for (size_t i = 1; i < targetPoints.size(); ++i)
+		addJaggedSegment(ray->path, targetPoints[i - 1], targetPoints[i], jaggedness, 2);
+
+	ray->hopCount  = static_cast<int>(targetPoints.size()) - 1;
+	// progress runs 0->1 across all hops; one hop is revealed every hopDelay seconds
+	float totalTime = ray->hopCount * hopDelay;
+	ray->rayConfig = expandRayColors(rayConfig, width);
+	ray->linger    = 0.1f; // keep the fully-formed ray visible briefly before it vanishes
+	ray->shooterID = caster ? caster->unitId() : -1;
+	ray->progress  = 0;
+	ray->speed     = totalTime > 0 ? 1.f / totalTime : 1000.f;
+	ray->playing   = true;
+
+	projectiles.push_back(std::shared_ptr<ProjectileBase>(ray));
 }

--- a/client/battle/BattleProjectileController.h
+++ b/client/battle/BattleProjectileController.h
@@ -70,7 +70,16 @@ struct ProjectileRay : ProjectileBase
 	void show(Canvas & canvas) override;
 	void tick(uint32_t msPassed) override;
 
-	std::vector<CCreature::CreatureAnimation::RayColor> rayConfig;
+	std::vector<RayColor> rayConfig;
+
+	/// if non-empty, the ray follows this (jagged) polyline instead of a straight from->dest line
+	std::vector<Point> path;
+
+	/// number of hops (target-to-target jumps) the path is split into; revealed one per hop as progress advances
+	int hopCount = 1;
+
+	/// seconds to keep the fully-drawn ray on screen before it is removed
+	float linger = 0.f;
 };
 
 /// Class that manages all ongoing projectiles in the game
@@ -118,4 +127,7 @@ public:
 	void createProjectile(const CStack * shooter, Point from, Point dest);
 	void createSpellProjectile(const CStack * shooter, Point from, Point dest, const CSpell * spell);
 	void createCatapultProjectile(const CStack * shooter, Point from, Point dest);
+
+	/// creates and immediately emits a jagged ray chaining through the given points (e.g. chain lightning)
+	void createSpellRayProjectile(const CStack * caster, const std::vector<Point> & targetPoints, const std::vector<RayColor> & rayConfig, float jaggedness, float hopDelay, int width);
 };

--- a/client/battle/BattleSiegeController.cpp
+++ b/client/battle/BattleSiegeController.cpp
@@ -35,6 +35,9 @@
 #include "../../lib/networkPacks/PacksForClientBattle.h"
 #include "../../lib/callback/CCallback.h"
 
+// how long the partially-open drawbridge frame is shown while the bridge lowers or raises, in ms
+static constexpr uint32_t gateTransitionDuration = 200;
+
 const std::string & BattleSiegeController::getSiegePrefix() const
 {
 	const auto & siegePrefixes = town->getTown()->clientInfo.siegePrefix;
@@ -257,35 +260,55 @@ Point BattleSiegeController::getTurretCreaturePosition( BattleHex position ) con
 void BattleSiegeController::gateStateChanged(const EGateState state)
 {
 	auto oldState = owner.getBattle()->battleGetGateState();
-	bool playSound = false;
-	auto stateId = EWallState::NONE;
-	switch(state)
+
+	bool wasClosed = oldState == EGateState::CLOSED || oldState == EGateState::BLOCKED;
+	bool isClosed  = state == EGateState::CLOSED || state == EGateState::BLOCKED;
+
+	// lowering (closed -> open) or raising (open -> closed) the bridge plays a short transition through the
+	// partially-open frame (DRW1); destruction, the initial state and closed<->blocked swaps apply immediately
+	bool animate = (state == EGateState::OPENED && wasClosed) || (isClosed && oldState == EGateState::OPENED);
+
+	if (animate)
 	{
-	case EGateState::CLOSED:
-		if (oldState != EGateState::BLOCKED)
-			playSound = true;
-		break;
-	case EGateState::BLOCKED:
-		if (oldState != EGateState::CLOSED)
-			playSound = true;
-		break;
-	case EGateState::OPENED:
-		playSound = true;
-		stateId = EWallState::DAMAGED;
-		break;
-	case EGateState::DESTROYED:
-		stateId = EWallState::DESTROYED;
-		break;
+		ENGINE->sound().playSound(soundBase::DRAWBRG);
+		// show the partially-open bridge now; tick() settles it to the final sprite after the transition delay
+		auto partialState = static_cast<EWallState>(town->fortificationsLevel().wallsHealth);
+		wallPieceImages[EWallVisual::GATE] = ENGINE->renderHandler().loadImage(getWallPieceImageName(EWallVisual::GATE, partialState), EImageBlitMode::COLORKEY);
+		gateTransitionRemaining = gateTransitionDuration;
+		return;
 	}
 
-	if (oldState != EGateState::NONE && oldState != EGateState::CLOSED && oldState != EGateState::BLOCKED)
-		wallPieceImages[EWallVisual::GATE] = nullptr;
+	gateTransitionRemaining = 0; // cancel any pending transition superseded by this immediate state
+	applyGateState(state);
+}
 
-	if (stateId != EWallState::NONE)
-		wallPieceImages[EWallVisual::GATE] = ENGINE->renderHandler().loadImage(getWallPieceImageName(EWallVisual::GATE,  stateId), EImageBlitMode::COLORKEY);
+void BattleSiegeController::tick(uint32_t msPassed)
+{
+	if (gateTransitionRemaining == 0)
+		return;
 
-	if (playSound)
-		ENGINE->sound().playSound(soundBase::DRAWBRG);
+	if (msPassed >= gateTransitionRemaining)
+	{
+		gateTransitionRemaining = 0;
+		// apply the current gate state (not a stored target) so a mid-transition destruction is not overwritten
+		applyGateState(owner.getBattle()->battleGetGateState());
+	}
+	else
+		gateTransitionRemaining -= msPassed;
+}
+
+void BattleSiegeController::applyGateState(const EGateState state)
+{
+	auto stateId = EWallState::NONE;
+	if (state == EGateState::OPENED)
+		stateId = EWallState::DAMAGED;
+	else if (state == EGateState::DESTROYED)
+		stateId = EWallState::DESTROYED;
+
+	if (stateId == EWallState::NONE)
+		wallPieceImages[EWallVisual::GATE] = nullptr; // closed / blocked -> gate hidden, part of the static wall
+	else
+		wallPieceImages[EWallVisual::GATE] = ENGINE->renderHandler().loadImage(getWallPieceImageName(EWallVisual::GATE, stateId), EImageBlitMode::COLORKEY);
 }
 
 void BattleSiegeController::showAbsoluteObstacles(Canvas & canvas)

--- a/client/battle/BattleSiegeController.cpp
+++ b/client/battle/BattleSiegeController.cpp
@@ -35,9 +35,6 @@
 #include "../../lib/networkPacks/PacksForClientBattle.h"
 #include "../../lib/callback/CCallback.h"
 
-// how long the partially-open drawbridge frame is shown while the bridge lowers or raises, in ms
-static constexpr uint32_t gateTransitionDuration = 200;
-
 const std::string & BattleSiegeController::getSiegePrefix() const
 {
 	const auto & siegePrefixes = town->getTown()->clientInfo.siegePrefix;
@@ -264,37 +261,24 @@ void BattleSiegeController::gateStateChanged(const EGateState state)
 	bool wasClosed = oldState == EGateState::CLOSED || oldState == EGateState::BLOCKED;
 	bool isClosed  = state == EGateState::CLOSED || state == EGateState::BLOCKED;
 
-	// lowering (closed -> open) or raising (open -> closed) the bridge plays a short transition through the
-	// partially-open frame (DRW1); destruction, the initial state and closed<->blocked swaps apply immediately
+	// only lowering and raising animate through the partial frame; destruction and blocked<->closed apply at once
 	bool animate = (state == EGateState::OPENED && wasClosed) || (isClosed && oldState == EGateState::OPENED);
 
 	if (animate)
 	{
-		ENGINE->sound().playSound(soundBase::DRAWBRG);
-		// show the partially-open bridge now; tick() settles it to the final sprite after the transition delay
-		auto partialState = static_cast<EWallState>(town->fortificationsLevel().wallsHealth);
-		wallPieceImages[EWallVisual::GATE] = ENGINE->renderHandler().loadImage(getWallPieceImageName(EWallVisual::GATE, partialState), EImageBlitMode::COLORKEY);
-		gateTransitionRemaining = gateTransitionDuration;
-		return;
-	}
-
-	gateTransitionRemaining = 0; // cancel any pending transition superseded by this immediate state
-	applyGateState(state);
-}
-
-void BattleSiegeController::tick(uint32_t msPassed)
-{
-	if (gateTransitionRemaining == 0)
-		return;
-
-	if (msPassed >= gateTransitionRemaining)
-	{
-		gateTransitionRemaining = 0;
-		// apply the current gate state (not a stored target) so a mid-transition destruction is not overwritten
-		applyGateState(owner.getBattle()->battleGetGateState());
+		// block until the bridge finishes lowering/raising, so a unit crossing does not move through it mid-transition
+		owner.stacksController->addNewAnim(new GateAnimation(owner, state));
+		owner.waitForAnimations();
 	}
 	else
-		gateTransitionRemaining -= msPassed;
+		applyGateState(state);
+}
+
+void BattleSiegeController::showPartialGate()
+{
+	ENGINE->sound().playSound(soundBase::DRAWBRG);
+	auto partialState = static_cast<EWallState>(town->fortificationsLevel().wallsHealth);
+	wallPieceImages[EWallVisual::GATE] = ENGINE->renderHandler().loadImage(getWallPieceImageName(EWallVisual::GATE, partialState), EImageBlitMode::COLORKEY);
 }
 
 void BattleSiegeController::applyGateState(const EGateState state)

--- a/client/battle/BattleSiegeController.cpp
+++ b/client/battle/BattleSiegeController.cpp
@@ -28,6 +28,7 @@
 #include "../../lib/battle/CPlayerBattleCallback.h"
 #include "../../lib/battle/IBattleInfoCallback.h"
 #include "../../lib/entities/building/TownFortifications.h"
+#include "../../lib/filesystem/Filesystem.h"
 #include "../../lib/texts/CGeneralTextHandler.h"
 #include "../../lib/mapping/CMapHeader.h"
 #include "../../lib/mapObjects/CGTownInstance.h"
@@ -202,6 +203,11 @@ BattleSiegeController::BattleSiegeController(BattleInterface & owner, const CGTo
 		auto fullState = static_cast<EWallState>(town->fortificationsLevel().wallsHealth);
 		wallPieceImages[g] = ENGINE->renderHandler().loadImage(getWallPieceImageName(EWallVisual::EWallVisual(g), fullState), EImageBlitMode::COLORKEY);
 	}
+
+	// optional: not every town ships the drawbridge front overlay
+	auto gateFrontPath = ImagePath::builtinTODO(getSiegePrefix() + "DRWC.BMP");
+	if (town->fortificationsLevel().wallsHealth > 0 && CResourceHandler::get()->existsResource(gateFrontPath))
+		gateFrontImage = ENGINE->renderHandler().loadImage(gateFrontPath, EImageBlitMode::COLORKEY);
 }
 
 const CCreature *BattleSiegeController::getTurretCreature(const BattleHex & position) const
@@ -339,6 +345,16 @@ void BattleSiegeController::collectRenderableObjects(BattleRenderer & renderer)
 		}
 		renderer.insert( EBattleFieldLayer::WALLS, getWallPiecePosition(wallPiece), [this, wallPiece](BattleRenderer::RendererRef canvas){
 			showWallPiece(canvas, wallPiece);
+		});
+	}
+
+	if (gateFrontImage && owner.getBattle()->battleGetGateState() == EGateState::OPENED &&
+		owner.getBattle()->battleGetWallState(EWallPart::GATE) != EWallState::DESTROYED)
+	{
+		renderer.insert( EBattleFieldLayer::OBSTACLES, BattleHex(BattleHex::GATE_BRIDGE), [this](BattleRenderer::RendererRef canvas){
+			const auto & pos = town->getTown()->clientInfo.siegePositions[EWallVisual::GATE];
+			if (pos.isValid())
+				canvas.draw(gateFrontImage, Point(pos.x, pos.y));
 		});
 	}
 }

--- a/client/battle/BattleSiegeController.cpp
+++ b/client/battle/BattleSiegeController.cpp
@@ -414,9 +414,15 @@ void BattleSiegeController::stackIsCatapulting(const CatapultAttack & ca)
 	if (ca.attacker != -1)
 	{
 		const CStack *stack = owner.getBattle()->battleGetStackByID(ca.attacker);
-		owner.stacksController->addNewAnim(new CatapultAnimation(owner, stack, ca.destinationTile, nullptr, ca.damageDealt));
+		auto catapult = new CatapultAnimation(owner, stack, ca.destinationTile, nullptr, ca.damageDealt);
+		catapult->onExplosion = [this, updateWallPiece, ca]()
+		{
+			updateWallPiece(ca.attackedPart);
+			if (ca.killedTowerShooter != -1)
+				owner.stackRemoved(static_cast<uint32_t>(ca.killedTowerShooter));
+		};
+		owner.stacksController->addNewAnim(catapult);
 		owner.waitForAnimations();
-		updateWallPiece(ca.attackedPart);
 	}
 	else
 	{
@@ -426,11 +432,11 @@ void BattleSiegeController::stackIsCatapulting(const CatapultAttack & ca)
 
 		ENGINE->sound().playSound( AudioPath::builtin("WALLHIT") );
 
-		// swap the wall sprite when the explosion ends instead of blocking, so a mid-cast earthquake
+		// swap the wall sprite at the explosion midpoint instead of blocking, so a mid-cast earthquake
 		// deferred into the caster's HIT stage does not wait for animations on the main thread
 		auto attackedPart = ca.attackedPart;
 		auto effect = new EffectAnimation(owner, AnimationPath::builtin("SGEXPL.DEF"), positions);
-		effect->onFinished = [updateWallPiece, attackedPart](){ updateWallPiece(attackedPart); };
+		effect->onMidpoint = [updateWallPiece, attackedPart](){ updateWallPiece(attackedPart); };
 		owner.stacksController->addNewAnim(effect);
 		owner.fieldController->startShakeAnimation();
 	}

--- a/client/battle/BattleSiegeController.cpp
+++ b/client/battle/BattleSiegeController.cpp
@@ -401,10 +401,22 @@ std::string BattleSiegeController::getTowersInfoText() const
 
 void BattleSiegeController::stackIsCatapulting(const CatapultAttack & ca)
 {
+	// swaps a wall piece to its current (damaged) sprite; gate state is handled separately
+	auto updateWallPiece = [this](EWallPart attackedPart)
+	{
+		int wallId = static_cast<int>(attackedPart) + EWallVisual::DESTRUCTIBLE_FIRST;
+		if (wallId == EWallVisual::GATE)
+			return;
+		auto wallState = EWallState(owner.getBattle()->battleGetWallState(attackedPart));
+		wallPieceImages[wallId] = ENGINE->renderHandler().loadImage(getWallPieceImageName(EWallVisual::EWallVisual(wallId), wallState), EImageBlitMode::COLORKEY);
+	};
+
 	if (ca.attacker != -1)
 	{
 		const CStack *stack = owner.getBattle()->battleGetStackByID(ca.attacker);
 		owner.stacksController->addNewAnim(new CatapultAnimation(owner, stack, ca.destinationTile, nullptr, ca.damageDealt));
+		owner.waitForAnimations();
+		updateWallPiece(ca.attackedPart);
 	}
 	else
 	{
@@ -413,17 +425,14 @@ void BattleSiegeController::stackIsCatapulting(const CatapultAttack & ca)
 		positions.push_back(owner.stacksController->getStackPositionAtHex(ca.destinationTile, nullptr) + Point(99, 120));
 
 		ENGINE->sound().playSound( AudioPath::builtin("WALLHIT") );
-		owner.stacksController->addNewAnim(new EffectAnimation(owner, AnimationPath::builtin("SGEXPL.DEF"), positions));
-		owner.fieldController->startShakeAnimation();
-	}
-	owner.waitForAnimations();
 
-	int wallId = static_cast<int>(ca.attackedPart) + EWallVisual::DESTRUCTIBLE_FIRST;
-	//gate state changing handled separately
-	if (wallId != EWallVisual::GATE)
-	{
-		auto wallState = EWallState(owner.getBattle()->battleGetWallState(ca.attackedPart));
-		wallPieceImages[wallId] = ENGINE->renderHandler().loadImage(getWallPieceImageName(EWallVisual::EWallVisual(wallId), wallState), EImageBlitMode::COLORKEY);
+		// swap the wall sprite when the explosion ends instead of blocking, so a mid-cast earthquake
+		// deferred into the caster's HIT stage does not wait for animations on the main thread
+		auto attackedPart = ca.attackedPart;
+		auto effect = new EffectAnimation(owner, AnimationPath::builtin("SGEXPL.DEF"), positions);
+		effect->onFinished = [updateWallPiece, attackedPart](){ updateWallPiece(attackedPart); };
+		owner.stacksController->addNewAnim(effect);
+		owner.fieldController->startShakeAnimation();
 	}
 }
 

--- a/client/battle/BattleSiegeController.cpp
+++ b/client/battle/BattleSiegeController.cpp
@@ -401,13 +401,15 @@ std::string BattleSiegeController::getTowersInfoText() const
 
 void BattleSiegeController::stackIsCatapulting(const CatapultAttack & ca)
 {
-	// swaps a wall piece to its current (damaged) sprite; gate state is handled separately
+	// swaps a wall piece to its current (damaged) sprite
 	auto updateWallPiece = [this](EWallPart attackedPart)
 	{
 		int wallId = static_cast<int>(attackedPart) + EWallVisual::DESTRUCTIBLE_FIRST;
-		if (wallId == EWallVisual::GATE)
-			return;
 		auto wallState = EWallState(owner.getBattle()->battleGetWallState(attackedPart));
+		// the gate's open/close transitions are driven by BattleUpdateGateState; sync only its destroyed sprite
+		// here so a broken gate updates on the breaking shot instead of after the whole catapult sequence
+		if (wallId == EWallVisual::GATE && wallState != EWallState::DESTROYED)
+			return;
 		wallPieceImages[wallId] = ENGINE->renderHandler().loadImage(getWallPieceImageName(EWallVisual::EWallVisual(wallId), wallState), EImageBlitMode::COLORKEY);
 	};
 

--- a/client/battle/BattleSiegeController.h
+++ b/client/battle/BattleSiegeController.h
@@ -75,6 +75,9 @@ class BattleSiegeController
 	/// drawbridge front overlay (chains), drawn over units standing on the lowered bridge
 	std::shared_ptr<IImage> gateFrontImage;
 
+	/// ms left showing the partially-open bridge frame during a lower/raise transition; 0 = no transition active
+	uint32_t gateTransitionRemaining = 0;
+
 	/// return URI for image for a wall piece
 	ImagePath getWallPieceImageName(EWallVisual::EWallVisual what, EWallState state) const;
 
@@ -96,9 +99,13 @@ public:
 
 	/// call-ins from server
 	void gateStateChanged(const EGateState state);
+
+	/// swaps the gate to its final sprite for the given state; called by the bridge transition animation
+	void applyGateState(const EGateState state);
 	void stackIsCatapulting(const CatapultAttack & ca);
 
 	/// call-ins from other battle controllers
+	void tick(uint32_t msPassed);
 	void showAbsoluteObstacles(Canvas & canvas);
 	void collectRenderableObjects(BattleRenderer & renderer);
 

--- a/client/battle/BattleSiegeController.h
+++ b/client/battle/BattleSiegeController.h
@@ -75,9 +75,6 @@ class BattleSiegeController
 	/// drawbridge front overlay (chains), drawn over units standing on the lowered bridge
 	std::shared_ptr<IImage> gateFrontImage;
 
-	/// ms left showing the partially-open bridge frame during a lower/raise transition; 0 = no transition active
-	uint32_t gateTransitionRemaining = 0;
-
 	/// return URI for image for a wall piece
 	ImagePath getWallPieceImageName(EWallVisual::EWallVisual what, EWallState state) const;
 
@@ -100,12 +97,14 @@ public:
 	/// call-ins from server
 	void gateStateChanged(const EGateState state);
 
+	/// plays the drawbridge sound and shows the partially-open frame; start of a lower/raise transition
+	void showPartialGate();
+
 	/// swaps the gate to its final sprite for the given state; called by the bridge transition animation
 	void applyGateState(const EGateState state);
 	void stackIsCatapulting(const CatapultAttack & ca);
 
 	/// call-ins from other battle controllers
-	void tick(uint32_t msPassed);
 	void showAbsoluteObstacles(Canvas & canvas);
 	void collectRenderableObjects(BattleRenderer & renderer);
 

--- a/client/battle/BattleSiegeController.h
+++ b/client/battle/BattleSiegeController.h
@@ -72,6 +72,9 @@ class BattleSiegeController
 	/// sections of castle walls, in their currently visible state
 	std::array<std::shared_ptr<IImage>, EWallVisual::WALL_LAST + 1> wallPieceImages;
 
+	/// drawbridge front overlay (chains), drawn over units standing on the lowered bridge
+	std::shared_ptr<IImage> gateFrontImage;
+
 	/// return URI for image for a wall piece
 	ImagePath getWallPieceImageName(EWallVisual::EWallVisual what, EWallState state) const;
 

--- a/client/battle/BattleStacksController.cpp
+++ b/client/battle/BattleStacksController.cpp
@@ -499,7 +499,11 @@ void BattleStacksController::stacksAreAttacked(std::vector<StackAttackedInfo> at
 			});
 		}
 	}
-	owner.executeStagedAnimations();
+	// If an attacker or spell-caster animation is still playing, let it drive the hit stage at its own
+	// climax (e.g. only once a spell projectile has reached the target). Firing the stage here would
+	// play the hit effects immediately, before the projectile lands.
+	if(currentAnimations.empty())
+		owner.executeStagedAnimations();
 	owner.waitForAnimations();
 }
 

--- a/client/battle/BattleStacksController.cpp
+++ b/client/battle/BattleStacksController.cpp
@@ -168,6 +168,8 @@ void BattleStacksController::stackReset(const CStack * stack)
 		return;
 	}
 
+	fadingStacks.erase(stack->unitId()); // a reset/resurrect makes it eligible to fade out again if killed later
+
 	auto animation = iter->second;
 
 	if(stack->alive() && animation->isDeadOrDying())

--- a/client/battle/BattleStacksController.cpp
+++ b/client/battle/BattleStacksController.cpp
@@ -499,12 +499,13 @@ void BattleStacksController::stacksAreAttacked(std::vector<StackAttackedInfo> at
 			});
 		}
 	}
-	// If an attacker or spell-caster animation is still playing, let it drive the hit stage at its own
-	// climax (e.g. only once a spell projectile has reached the target). Firing the stage here would
-	// play the hit effects immediately, before the projectile lands.
-	if(currentAnimations.empty())
+	// while a spell cast is queued/playing, let it drive and batch the hit stage (endAction does the final sync)
+	// so per-unit damage packs (e.g. chain lightning) play together instead of one-by-one
+	if(currentAnimations.empty() && !owner.hasQueuedStage(EAnimationEvents::BEFORE_HIT))
+	{
 		owner.executeStagedAnimations();
-	owner.waitForAnimations();
+		owner.waitForAnimations();
+	}
 }
 
 void BattleStacksController::stackTeleported(const CStack *stack, const BattleHexArray & destHex, int distance)

--- a/client/battle/BattleStacksController.cpp
+++ b/client/battle/BattleStacksController.cpp
@@ -143,6 +143,19 @@ void BattleStacksController::collectRenderableObjects(BattleRenderer & renderer)
 			});
 		}
 	}
+
+	// removed units are ghosts (excluded from battleGetAllStacks); keep drawing those still fading out
+	for(uint32_t id : fadingStacks)
+	{
+		const CStack * stack = owner.getBattle()->battleGetStackByID(id, false);
+		if(!stack || !stack->isGhost() || stackAnimation.find(id) == stackAnimation.end())
+			continue;
+
+		auto layer = stackAnimation[id]->isDead() ? EBattleFieldLayer::CORPSES : EBattleFieldLayer::STACKS;
+		renderer.insert(layer, getStackCurrentPosition(stack), [this, stack]( BattleRenderer::RendererRef renderer ){
+			showStack(renderer, stack);
+		});
+	}
 }
 
 void BattleStacksController::stackReset(const CStack * stack)
@@ -412,6 +425,23 @@ void BattleStacksController::stackRemoved(uint32_t stackID)
 {
 	if (getActiveStack() && getActiveStack()->unitId() == stackID)
 		setActiveStack(nullptr);
+
+	// guard so a repeated removal call-in won't restart the fade-out
+	if (!fadingStacks.insert(stackID).second)
+		return;
+
+	auto startFade = [this, stackID]()
+	{
+		const CStack * stack = owner.getBattle()->battleGetStackByID(stackID, false);
+		if (stack && stackAnimation.count(stackID))
+			addNewAnim(new ColorTransformAnimation(owner, stack, "summonFadeOut", nullptr));
+	};
+
+	// while a spell/attack sequence is mid-flight, fade the unit together with its hit effects instead of before them
+	if (owner.hasQueuedStage(EAnimationEvents::HIT))
+		owner.addToAnimationStage(EAnimationEvents::HIT, startFade);
+	else
+		startFade();
 }
 
 void BattleStacksController::stacksAreAttacked(std::vector<StackAttackedInfo> attackedInfos)
@@ -494,7 +524,6 @@ void BattleStacksController::stacksAreAttacked(std::vector<StackAttackedInfo> at
 		if (attackedInfo.killed && attackedInfo.defender->summoned)
 		{
 			owner.addToAnimationStage(EAnimationEvents::AFTER_HIT, [this, attackedInfo](){
-				addNewAnim(new ColorTransformAnimation(owner, attackedInfo.defender, "summonFadeOut", nullptr));
 				stackRemoved(attackedInfo.defender->unitId());
 			});
 		}

--- a/client/battle/BattleStacksController.h
+++ b/client/battle/BattleStacksController.h
@@ -68,6 +68,9 @@ class BattleStacksController
 	/// Stacks have amount box hidden due to ongoing animations
 	std::set<int> stackAmountBoxHidden;
 
+	/// units already given a removal fade-out, so a second removal call-in doesn't restart it
+	std::set<uint32_t> fadingStacks;
+
 	/// currently active stack; nullptr - no one
 	const CStack *activeStack;
 

--- a/config/battleEffects.json
+++ b/config/battleEffects.json
@@ -84,12 +84,17 @@
 				"alpha" : 1.0
 			},
 			{
-				"time"  : 0.5,
+				"time"  : 0.6,
 				"color"  : [ 1.0, 0.0, 0.0, 1.0 ], //red
 				"alpha" : 1.0
 			},
 			{
-				"time" : 1.0,
+				"time"  : 1.4, //hold red so the flash is visible
+				"color"  : [ 1.0, 0.0, 0.0, 1.0 ],
+				"alpha" : 1.0
+			},
+			{
+				"time" : 2.0,
 				"alpha" : 1.0
 			},
 		],

--- a/config/schemas/spell.json
+++ b/config/schemas/spell.json
@@ -35,6 +35,7 @@
 			"additionalProperties" : false,
 			"properties" : {
 				"affect" : {"$ref" : "#/definitions/animationQueue"},
+				"affectSecondary" : {"$ref" : "#/definitions/animationQueue"},
 				"hit" : {"$ref" : "#/definitions/animationQueue"},
 				"cast" : {"$ref" : "#/definitions/animationQueue"},
 				"projectile" : {

--- a/config/schemas/spell.json
+++ b/config/schemas/spell.json
@@ -47,6 +47,28 @@
 						},
 						"additionalProperties" : false
 					}
+				},
+				"ray" : {
+					"type" : "object",
+					"additionalProperties" : false,
+					"description" : "Jagged ray drawn between consecutive affected targets (e.g. chain lightning)",
+					"properties" : {
+						"jaggedness" : {"type" : "number", "minimum" : 0, "description" : "Midpoint-displacement amplitude, as a fraction of each segment's length"},
+						"hopDelay" : {"type" : "number", "minimum" : 0, "description" : "Delay in milliseconds before the ray jumps to each next target"},
+						"width" : {"type" : "number", "minimum" : 0, "description" : "Thickness in pixels of each of the ray's color sub-lines"},
+						"colors" : {
+							"type" : "array",
+							"description" : "Parallel sub-lines of the ray; each has a start->end color gradient along the ray length",
+							"items" : {
+								"type" : "object",
+								"additionalProperties" : false,
+								"properties" : {
+									"start" : {"type" : "array", "minItems" : 4, "maxItems" : 4, "items" : {"type" : "number"}},
+									"end" : {"type" : "array", "minItems" : 4, "maxItems" : 4, "items" : {"type" : "number"}}
+								}
+							}
+						}
+					}
 				}
 			}
 		},

--- a/config/spellEffects.json
+++ b/config/spellEffects.json
@@ -163,8 +163,34 @@
 				"patchCount" : { "type" : "number" },
 				"turnsRemaining" : { "type" : "number" },
 				"triggerAbility" : { "type" : "string" },
-				"attacker" : {  },
-				"defender" : {  }
+				"attacker" : {
+					"type" : "object",
+					"additionalProperties" : false,
+					"description" : "Per-side appearance and placement of the obstacle",
+					"properties" : {
+						"animation" : { "type" : "string", "description" : "Looping animation shown while the obstacle is on the battlefield" },
+						"appearAnimation" : { "type" : "string", "description" : "Animation played when the obstacle appears" },
+						"appearSound" : { "type" : "string", "description" : "Sound played when the obstacle appears" },
+						"removalAnimation" : { "type" : "string", "description" : "Animation played when the obstacle is removed. Falls back to appearAnimation if empty" },
+						"offsetY" : { "type" : "number", "description" : "Vertical offset of the obstacle sprite, in pixels" },
+						"shape" : { "type" : "array", "description" : "Hexes occupied by the obstacle, as direction paths from the anchor hex", "items" : { "type" : "array", "items" : { "type" : "string" } } },
+						"range" : { "type" : "array", "description" : "Hexes the obstacle may be placed on, as direction paths from the target hex", "items" : { "type" : "array", "items" : { "type" : "string" } } }
+					}
+				},
+				"defender" : {
+					"type" : "object",
+					"additionalProperties" : false,
+					"description" : "Per-side appearance and placement of the obstacle",
+					"properties" : {
+						"animation" : { "type" : "string", "description" : "Looping animation shown while the obstacle is on the battlefield" },
+						"appearAnimation" : { "type" : "string", "description" : "Animation played when the obstacle appears" },
+						"appearSound" : { "type" : "string", "description" : "Sound played when the obstacle appears" },
+						"removalAnimation" : { "type" : "string", "description" : "Animation played when the obstacle is removed. Falls back to appearAnimation if empty" },
+						"offsetY" : { "type" : "number", "description" : "Vertical offset of the obstacle sprite, in pixels" },
+						"shape" : { "type" : "array", "description" : "Hexes occupied by the obstacle, as direction paths from the anchor hex", "items" : { "type" : "array", "items" : { "type" : "string" } } },
+						"range" : { "type" : "array", "description" : "Hexes the obstacle may be placed on, as direction paths from the target hex", "items" : { "type" : "array", "items" : { "type" : "string" } } }
+					}
+				}
 			},
 			"additionalProperties" : false
 		}

--- a/config/spells/ability.json
+++ b/config/spells/ability.json
@@ -330,7 +330,7 @@
 		"targetType": "NO_TARGET",
 
 		"animation":{
-			"affect":[{"defName":"C03SPA0", "verticalPosition":"bottom"}, "C11SPA1"]
+			"affect":[{"defName":"C03SPA0", "verticalPosition":"bottom"}, "C03SPA1"]
 		},
 		"sounds": {
 			"cast": "LIGHTBLT"

--- a/config/spells/ability.json
+++ b/config/spells/ability.json
@@ -418,7 +418,7 @@
 		"targetType": "NO_TARGET",
 
 		"animation":{
-			"affect":["C17SPW0"]
+			"affect":["C0ACID"]
 		},
 		"sounds": {
 			"cast": "ACID"
@@ -455,7 +455,7 @@
 		"targetType": "NO_TARGET",
 
 		"animation":{
-			"affect":["C17SPW0"]
+			"affect":["C0ACID"]
 		},
 		"sounds": {
 			"cast": "ACID"

--- a/config/spells/offensive.json
+++ b/config/spells/offensive.json
@@ -70,7 +70,7 @@
 		"targetType": "CREATURE",
 
 		"animation":{
-			"affect":[{"defName":"C03SPA0", "verticalPosition":"bottom"}, "C11SPA1"]
+			"affect":[{"defName":"C03SPA0", "verticalPosition":"bottom"}, "C03SPA1"]
 		},
 		"sounds": {
 			"cast": "LIGHTBLT"
@@ -125,7 +125,7 @@
 		"targetType": "CREATURE",
 
 		"animation":{
-			"affect":[{"defName":"C03SPA0", "verticalPosition":"bottom"}, "C11SPA1"],
+			"affect":[{"defName":"C11SPA0", "verticalPosition":"bottom"}, "C11SPA1"],
 			"ray":{
 				"jaggedness" : 0.2,
 				"hopDelay" : 50,
@@ -373,7 +373,7 @@
 		"targetType" : "CREATURE",
 
 		"animation":{
-			"hit":[{"defName":"C03SPA0", "verticalPosition":"bottom"}, "C11SPA1"]
+			"hit":[{"defName":"C03SPA0", "verticalPosition":"bottom"}, "C03SPA1"]
 		},
 		"sounds": {
 			"cast": "LIGHTBLT"

--- a/config/spells/offensive.json
+++ b/config/spells/offensive.json
@@ -125,7 +125,16 @@
 		"targetType": "CREATURE",
 
 		"animation":{
-			"affect":[{"defName":"C03SPA0", "verticalPosition":"bottom"}, "C11SPA1"]
+			"affect":[{"defName":"C03SPA0", "verticalPosition":"bottom"}, "C11SPA1"],
+			"ray":{
+				"jaggedness" : 0.2,
+				"hopDelay" : 50,
+				"width" : 16,
+				"colors" : [
+					{ "start" : [ 100, 140, 255,  96 ], "end" : [ 100, 140, 255,  48 ] },
+					{ "start" : [ 255, 255, 255, 255 ], "end" : [ 255, 255, 255, 224 ] }
+				]
+			}
 		},
 		"sounds": {
 			"cast": "CHAINLTE"

--- a/config/spells/other.json
+++ b/config/spells/other.json
@@ -575,7 +575,8 @@
 		"targetType" : "CREATURE",
 
 		"animation":{
-			"affect":[{ "defName" : "C01SPE0", "transparency" : 0.5}]
+			"affect":["C12SPF1"],
+			"affectSecondary":["C12SPF0"]
 		},
 		"sounds": {
 			"cast": "SACRIF1"

--- a/config/spells/other.json
+++ b/config/spells/other.json
@@ -654,7 +654,7 @@
 		"index" : 64,
 		"targetType" : "OBSTACLE",
 		"animation":{
-			"cast":[2]
+			"hit":["C18SPW0"]
 		},
 		"sounds": {
 			"cast": "REMOVEOB"

--- a/config/spells/other.json
+++ b/config/spells/other.json
@@ -185,13 +185,15 @@
 							"range" : [[""]],
 							"shape" : [[""], ["TR"]],
 							"animation" : "C15SPE1",
-							"appearAnimation" : "C15SPE0"
+							"appearAnimation" : "C15SPE0",
+							"removalAnimation" : "C15SPE2"
 						},
 						"defender" :{
 							"range" : [[""]],
 							"shape" : [[""], ["TL"]],
 							"animation" : "C15SPE4",
-							"appearAnimation" : "C15SPE0"
+							"appearAnimation" : "C15SPE0",
+							"removalAnimation" : "C15SPE5"
 						}
 					}
 				}
@@ -202,12 +204,14 @@
 						"attacker" :{
 							"shape" : [[""], ["TR"], ["TR", "TL"]],
 							"animation" : "C15SPE10",
-							"appearAnimation" : "C15SPE9"
+							"appearAnimation" : "C15SPE9",
+							"removalAnimation" : "C15SPE11"
 						},
 						"defender" :{
 							"shape" : [[""], ["TL"], ["TL", "TR"]],
 							"animation" : "C15SPE7",
-							"appearAnimation" : "C15SPE6"
+							"appearAnimation" : "C15SPE6",
+							"removalAnimation" : "C15SPE8"
 						}
 					}
 				}
@@ -218,12 +222,14 @@
 						"attacker" :{
 							"shape" : [[""], ["TR"], ["TR", "TL"]],
 							"animation" : "C15SPE10",
-							"appearAnimation" : "C15SPE9"
+							"appearAnimation" : "C15SPE9",
+							"removalAnimation" : "C15SPE11"
 						},
 						"defender" :{
 							"shape" : [[""], ["TL"], ["TL", "TR"]],
 							"animation" : "C15SPE7",
-							"appearAnimation" : "C15SPE6"
+							"appearAnimation" : "C15SPE6",
+							"removalAnimation" : "C15SPE8"
 						}
 					}
 				}
@@ -306,13 +312,15 @@
 							"shape" : [[""]],
 							"range" : [[""], ["TR"]],
 							"animation" : "C07SPF61",
-							"appearAnimation" : "C07SPF60"
+							"appearAnimation" : "C07SPF60",
+							"removalAnimation" : "C07SPF62"
 						},
 						"defender" :{
 							"shape" : [[""]],
 							"range" : [[""], ["TL"]],
 							"animation" : "C07SPF61",
-							"appearAnimation" : "C07SPF60"
+							"appearAnimation" : "C07SPF60",
+							"removalAnimation" : "C07SPF62"
 						}
 					}
 				}

--- a/docs/modders/Entities_Format/Faction_Format.md
+++ b/docs/modders/Entities_Format/Faction_Format.md
@@ -329,7 +329,9 @@ Each town requires a set of buildings (Around 30-45 buildings)
 	// Two parts of gate: gate itself and arch above it
 	"gate" :
 	{
-		"gate" : { "x": 0, "y": 0}, // "DRW1" ... "DRW3" and "DRWC" (rope)
+		// "DRW1" ... "DRW3" (gate in its intact / damaged / destroyed states).
+		// Optional "DRWC" is the drawbridge front overlay (chains), drawn on top of units standing on the lowered bridge.
+		"gate" : { "x": 0, "y": 0},
 		"arch" : { "x": 0, "y": 0}  // "ARCH"
 	},
 	// Destructible walls. In this example they are ordered from top to bottom

--- a/docs/modders/Entities_Format/Spell_Format.md
+++ b/docs/modders/Entities_Format/Spell_Format.md
@@ -178,9 +178,13 @@ TODO
 	],
 	"cast" : []
 	"hit":["C20SPX"],
-	"affect":[{"defName":"C03SPA0", "verticalPosition":"bottom", "transparency" : 0.5}, "C11SPA1"]
+	"affect":[{"defName":"C03SPA0", "verticalPosition":"bottom", "transparency" : 0.5}, "C11SPA1"],
+	"affectSecondary":["C12SPF0"]
 }
 ```
+
+- `affect` — animation shown on every affected target.
+- `affectSecondary` — optional. Animation shown on secondary targets instead of `affect`. Used by spells that act on more than one unit with different roles, such as Sacrifice, where the primary (resurrected) target keeps `affect` while the sacrificed unit uses `affectSecondary`. If empty, secondary targets fall back to `affect`.
 
 ### Chaining ray
 
@@ -520,6 +524,7 @@ TODO
 		"appearSound" : {},
 		"appearAnimation" : {},
 		"animation" : {},
+		"removalAnimation" : {},
 		"offsetY" : 0
 	},
 	
@@ -529,10 +534,21 @@ TODO
 		"appearSound" : {},
 		"appearAnimation" : {},
 		"animation" : {},
+		"removalAnimation" : {},
 		"offsetY" : 0
 	}
 }
 ```
+
+Per-side fields:
+
+- `shape` — hexes occupied by the obstacle, as direction paths from the anchor hex.
+- `range` — hexes the obstacle may be placed on, as direction paths from the target hex.
+- `appearSound` — sound played when the obstacle appears.
+- `appearAnimation` — animation played when the obstacle appears.
+- `animation` — looping animation shown while the obstacle is on the battlefield.
+- `removalAnimation` — animation played when the obstacle is removed (expires or is dispelled). If empty, the obstacle reuses `appearAnimation` (played in reverse for magical obstacles) or, for plain obstacles, simply fades out.
+- `offsetY` — vertical offset of the obstacle sprite, in pixels.
 
 ### Moat
 

--- a/docs/modders/Entities_Format/Spell_Format.md
+++ b/docs/modders/Entities_Format/Spell_Format.md
@@ -182,6 +182,34 @@ TODO
 }
 ```
 
+### Chaining ray
+
+Some spells (such as Chain Lightning) hit several targets in a row. You can draw a
+lightning-like ray that jumps from one target to the next by adding a `ray` block to
+the animation. The ray is a bundle of colored lines with a slightly random, zig-zag
+shape. The first target still shows the full `affect` animation; the ray only connects
+the targets to each other.
+
+```json
+"animation": {
+	"affect": [ {"defName":"C03SPA0", "verticalPosition":"bottom"}, "C11SPA1" ],
+	"ray": {
+		"jaggedness": 0.2,
+		"hopDelay": 100,
+		"width": 16,
+		"colors": [
+			{ "start": [ 100, 140, 255,  96 ], "end": [ 100, 140, 255,  48 ] },
+			{ "start": [ 255, 255, 255, 255 ], "end": [ 255, 255, 255, 224 ] }
+		]
+	}
+}
+```
+
+- `jaggedness` — how strongly the ray zig-zags between targets. `0` is a straight line, higher values (around `0.2`) give a lightning look.
+- `hopDelay` — delay in milliseconds before the ray jumps to the next target. The ray appears instantly on each target, one after another, with this pause between jumps.
+- `width` — thickness of the ray in pixels.
+- `colors` — the ray's color, from its outer edge to its center. Each entry has a `start` and `end` color (the color at the beginning and at the end of the ray), given as `[red, green, blue, transparency]` with values from 0 to 255. List the outer-edge color first and the center color last; the colors in between are blended automatically and the ray is drawn symmetrically. Use a low transparency for the edges and a high one for the center to get a glowing core.
+
 ## Spell level base format
 
 Json object with data common for all levels can be put here. These configuration parameters will be default for all levels. All mandatory level fields become optional if they equal "base" configuration.

--- a/lib/CCreatureHandler.cpp
+++ b/lib/CCreatureHandler.cpp
@@ -853,6 +853,21 @@ void CCreatureHandler::loadUnitAnimInfo(JsonNode & graphics, CLegacyConfigParser
 		graphics.Struct().erase("missile");
 }
 
+RayColor RayColor::fromJson(const JsonNode & node)
+{
+	RayColor color;
+	color.start.r = node["start"].Vector()[0].Integer();
+	color.start.g = node["start"].Vector()[1].Integer();
+	color.start.b = node["start"].Vector()[2].Integer();
+	color.start.a = node["start"].Vector()[3].Integer();
+
+	color.end.r = node["end"].Vector()[0].Integer();
+	color.end.g = node["end"].Vector()[1].Integer();
+	color.end.b = node["end"].Vector()[2].Integer();
+	color.end.a = node["end"].Vector()[3].Integer();
+	return color;
+}
+
 void CCreatureHandler::loadJsonAnimation(CCreature * cre, const JsonNode & graphics) const
 {
 	cre->animation.timeBetweenFidgets = graphics["timeBetweenFidgets"].Float();
@@ -912,21 +927,7 @@ void CCreatureHandler::loadCreatureJson(CCreature * creature, const JsonNode & c
 	creature->animation.projectileImageName = AnimationPath::fromJson(config["graphics"]["missile"]["projectile"]);
 
 	for(const JsonNode & value : config["graphics"]["missile"]["ray"].Vector())
-	{
-		CCreature::CreatureAnimation::RayColor color;
-
-		color.start.r = value["start"].Vector()[0].Integer();
-		color.start.g = value["start"].Vector()[1].Integer();
-		color.start.b = value["start"].Vector()[2].Integer();
-		color.start.a = value["start"].Vector()[3].Integer();
-
-		color.end.r = value["end"].Vector()[0].Integer();
-		color.end.g = value["end"].Vector()[1].Integer();
-		color.end.b = value["end"].Vector()[2].Integer();
-		color.end.a = value["end"].Vector()[3].Integer();
-
-		creature->animation.projectileRay.push_back(color);
-	}
+		creature->animation.projectileRay.push_back(RayColor::fromJson(value));
 
 	creature->special = config["special"].Bool() || config["disabled"].Bool();
 	creature->excludeFromRandomization = config["excludeFromRandomization"].Bool();

--- a/lib/CCreatureHandler.h
+++ b/lib/CCreatureHandler.h
@@ -89,11 +89,6 @@ public:
 
 	struct CreatureAnimation
 	{
-		struct RayColor {
-			ColorRGBA start;
-			ColorRGBA end;
-		};
-
 		double timeBetweenFidgets, idleAnimationTime,
 			   walkAnimationTime, attackAnimationTime;
 		int upperRightMissileOffsetX, rightMissileOffsetX, lowerRightMissileOffsetX,

--- a/lib/Color.h
+++ b/lib/Color.h
@@ -9,6 +9,8 @@
  */
 #pragma once
 
+class JsonNode;
+
 /// An object that represents RGBA color
 class ColorRGBA
 {
@@ -68,6 +70,15 @@ public:
 		return mean_lhs < mean_rhs;
 	}
 
+};
+
+/// One parallel sub-line of a ray, with a start->end color gradient along the ray length
+struct RayColor
+{
+	ColorRGBA start;
+	ColorRGBA end;
+
+	static RayColor fromJson(const JsonNode & node);
 };
 
 namespace vstd

--- a/lib/battle/CBattleInfoCallback.cpp
+++ b/lib/battle/CBattleInfoCallback.cpp
@@ -1283,8 +1283,8 @@ bool CBattleInfoCallback::handleObstacleTriggersForUnit(SpellCastEnvironment & s
 
 				BattleObstaclesChanged bocp;
 				bocp.battleID = getBattle()->getBattleID();
-				bocp.changes.emplace_back(spellObstacle.uniqueID, operation);
-				changedObstacle.toInfo(bocp.changes.back(), operation);
+				bocp.change = ObstacleChanges(spellObstacle.uniqueID, operation);
+				changedObstacle.toInfo(bocp.change, operation);
 				spellEnv.apply(bocp);
 			};
 			const auto side = unit.unitSide();

--- a/lib/battle/CObstacleInstance.cpp
+++ b/lib/battle/CObstacleInstance.cpp
@@ -198,6 +198,7 @@ void SpellCreatedObstacle::serializeJson(JsonSerializeFormat & handler)
 	handler.serializeStruct("appearSound", appearSound);
 	handler.serializeStruct("appearAnimation", appearAnimation);
 	handler.serializeStruct("animation", animation);
+	handler.serializeStruct("removalAnimation", removalAnimation);
 
 	{
 		JsonArraySerializer customSizeJson = handler.enterArray("customSize");

--- a/lib/battle/CObstacleInstance.h
+++ b/lib/battle/CObstacleInstance.h
@@ -94,6 +94,7 @@ struct DLL_LINKAGE SpellCreatedObstacle : CObstacleInstance
 	AudioPath appearSound;
 	AnimationPath appearAnimation;
 	AnimationPath animation;
+	AnimationPath removalAnimation;
 
 	BattleHexArray customSize;
 

--- a/lib/callback/CAdventureAI.cpp
+++ b/lib/callback/CAdventureAI.cpp
@@ -67,9 +67,9 @@ void CAdventureAI::battleTriggerEffect(const BattleID & battleID, const BattleTr
     battleAI->battleTriggerEffect(battleID, bte);
 }
 
-void CAdventureAI::battleObstaclesChanged(const BattleID & battleID, const std::vector<ObstacleChanges> & obstacles)
+void CAdventureAI::battleObstaclesChanged(const BattleID & battleID, const ObstacleChanges & obstacle)
 {
-	battleAI->battleObstaclesChanged(battleID, obstacles);
+	battleAI->battleObstaclesChanged(battleID, obstacle);
 }
 
 void CAdventureAI::battleStackMoved(const BattleID & battleID, const CStack * stack, const BattleHexArray & dest, int distance, bool teleport)

--- a/lib/callback/CAdventureAI.h
+++ b/lib/callback/CAdventureAI.h
@@ -35,7 +35,7 @@ public:
 	void actionFinished(const BattleID & battleID, const BattleAction &action) override;
 	void battleStacksEffectsSet(const BattleID & battleID, const SetStackEffect & sse) override;
 	void battleTriggerEffect(const BattleID & battleID, const BattleTriggerEffect & bte) override;
-	void battleObstaclesChanged(const BattleID & battleID, const std::vector<ObstacleChanges> & obstacles) override;
+	void battleObstaclesChanged(const BattleID & battleID, const ObstacleChanges & obstacle) override;
 	void battleStackMoved(const BattleID & battleID, const CStack * stack, const BattleHexArray & dest, int distance, bool teleport) override;
 	void battleAttack(const BattleID & battleID, const BattleAttack *ba) override;
 	void battleSpellCast(const BattleID & battleID, const BattleSpellCast *sc) override;

--- a/lib/callback/IBattleEventsReceiver.h
+++ b/lib/callback/IBattleEventsReceiver.h
@@ -50,7 +50,7 @@ public:
 	virtual void battleStartBefore(const BattleID & battleID, const CCreatureSet *army1, const CCreatureSet *army2, int3 tile, const CGHeroInstance *hero1, const CGHeroInstance *hero2) {}; //called just before battle start
 	virtual void battleStart(const BattleID & battleID, const CCreatureSet *army1, const CCreatureSet *army2, int3 tile, const CGHeroInstance *hero1, const CGHeroInstance *hero2, BattleSide side, bool replayAllowed){}; //called by engine when battle starts; side=0 - left, side=1 - right
 	virtual void battleUnitsChanged(const BattleID & battleID, const std::vector<UnitChanges> & units){};
-	virtual void battleObstaclesChanged(const BattleID & battleID, const std::vector<ObstacleChanges> & obstacles){};
+	virtual void battleObstaclesChanged(const BattleID & battleID, const ObstacleChanges & obstacle){};
 	virtual void battleCatapultAttacked(const BattleID & battleID, const CatapultAttack & ca){}; //called when catapult makes an attack
 	virtual void battleGateStateChanged(const BattleID & battleID, const EGateState state){};
 };

--- a/lib/gameState/GameStatePackVisitor.cpp
+++ b/lib/gameState/GameStatePackVisitor.cpp
@@ -1622,23 +1622,19 @@ void BattleStatePackVisitor::visitCatapultAttack(CatapultAttack & pack)
 
 void BattleStatePackVisitor::visitBattleObstaclesChanged(BattleObstaclesChanged & pack)
 {
-	for(const auto & change : pack.changes)
+	switch(pack.change.operation)
 	{
-		switch(change.operation)
-		{
-			case BattleChanges::EOperation::REMOVE:
-				battleState.removeObstacle(change.id);
-				break;
-			case BattleChanges::EOperation::ADD:
-				battleState.addObstacle(change);
-				break;
-			case BattleChanges::EOperation::UPDATE:
-				battleState.updateObstacle(change);
-				break;
-			default:
-				throw std::runtime_error("Unknown obstacle operation");
-				break;
-		}
+		case BattleChanges::EOperation::REMOVE:
+			battleState.removeObstacle(pack.change.id);
+			break;
+		case BattleChanges::EOperation::ADD:
+			battleState.addObstacle(pack.change);
+			break;
+		case BattleChanges::EOperation::UPDATE:
+			battleState.updateObstacle(pack.change);
+			break;
+		default:
+			throw std::runtime_error("Unknown obstacle operation");
 	}
 }
 

--- a/lib/networkPacks/PacksForClientBattle.h
+++ b/lib/networkPacks/PacksForClientBattle.h
@@ -347,7 +347,7 @@ struct DLL_LINKAGE BattleSpellCast : public CPackForClient
 	SpellID spellID; //id of spell
 	ui8 manaGained = 0; //mana channeling ability
 	BattleHex tile; //destination tile (may not be set in some global/mass spells
-	std::set<ui32> affectedCres; //ids of creatures affected by this spell, generally used if spell does not set any effect (like dispel or cure)
+	std::vector<ui32> affectedCres; //ids of creatures affected by this spell, in effect order (e.g. chain-lightning hop order); generally used if spell does not set any effect (like dispel or cure)
 	std::set<ui32> resistedCres; // creatures that resisted the spell (e.g. Dwarves)
 	std::set<ui32> reflectedCres; // creatures that reflected the spell (e.g. Magic Mirror spell)
 	si32 casterStack = -1; // -1 if not cated by creature, >=0 caster stack ID

--- a/lib/networkPacks/PacksForClientBattle.h
+++ b/lib/networkPacks/PacksForClientBattle.h
@@ -432,14 +432,14 @@ struct DLL_LINKAGE BattleEnded : public CPackForClient
 struct DLL_LINKAGE BattleObstaclesChanged : public CPackForClient
 {
 	BattleID battleID = BattleID::NONE;
-	std::vector<ObstacleChanges> changes;
+	ObstacleChanges change;
 
 	void visitTyped(ICPackVisitor & visitor) override;
 
 	template <typename Handler> void serialize(Handler & h)
 	{
 		h & battleID;
-		h & changes;
+		h & change;
 		assert(battleID != BattleID::NONE);
 	}
 };

--- a/lib/spells/BattleSpellMechanics.cpp
+++ b/lib/spells/BattleSpellMechanics.cpp
@@ -416,7 +416,7 @@ void BattleSpellMechanics::cast(ServerCallback * server, const Target & target)
 	doRemoveEffects(server, affectedUnits, std::bind(&BattleSpellMechanics::counteringSelector, this, _1));
 
 	for(auto & unit : affectedUnits)
-		sc.affectedCres.insert(unit->unitId());
+		sc.affectedCres.push_back(unit->unitId());
 
 	if(!castDescription.lines.empty())
 		server->apply(castDescription);
@@ -489,7 +489,7 @@ void BattleSpellMechanics::beforeCast(BattleSpellCast & sc, vstd::RNG & rng, con
 	//prepare targets
 	effectsToApply = effects->prepare(this, target, spellTarget);
 
-	std::set<const battle::Unit *> unitTargets = collectTargets();
+	auto unitTargets = collectTargets();
 
 	//process them
 	for(const auto * unit : unitTargets)
@@ -561,7 +561,7 @@ void BattleSpellMechanics::castEval(ServerCallback * server, const Target & targ
 
 	effectsToApply = effects->prepare(this, target, spellTarget);
 
-	std::set<const battle::Unit *> unitTargets = collectTargets();
+	auto unitTargets = collectTargets();
 
 	auto selector = std::bind(&BattleSpellMechanics::counteringSelector, this, _1);
 
@@ -572,15 +572,17 @@ void BattleSpellMechanics::castEval(ServerCallback * server, const Target & targ
 		p.first->apply(server, this, p.second);
 }
 
-std::set<const battle::Unit *> BattleSpellMechanics::collectTargets() const
+battle::Units BattleSpellMechanics::collectTargets() const
 {
-	std::set<const battle::Unit *> result;
+	// preserve effect (e.g. chain-lightning hop) order while removing duplicates, so the client can
+	// reconstruct the target sequence from BattleSpellCast::affectedCres
+	battle::Units result;
 
 	for(const auto & p : effectsToApply)
 	{
 		for(const Destination & d : p.second)
-			if(d.unitValue)
-				result.insert(d.unitValue);
+			if(d.unitValue && !vstd::contains(result, d.unitValue))
+				result.push_back(d.unitValue);
 	}
 
 	return result;

--- a/lib/spells/BattleSpellMechanics.h
+++ b/lib/spells/BattleSpellMechanics.h
@@ -82,7 +82,7 @@ private:
 	void reflect(BattleSpellCast & sc, vstd::RNG & rng, const battle::Unit * unit);
 	const battle::Unit * getRandomUnit(vstd::RNG & rng, const BattleSide & side);
 
-	std::set<const battle::Unit *> collectTargets() const;
+	battle::Units collectTargets() const;
 
 	void doRemoveEffects(ServerCallback * server, const battle::Units & targets, const CSelector & selector);
 

--- a/lib/spells/CSpell.h
+++ b/lib/spells/CSpell.h
@@ -16,6 +16,7 @@
 
 #include "../bonuses/Bonus.h"
 #include "../json/JsonNode.h"
+#include "../Color.h"
 
 class CSpell;
 class IAdventureSpellMechanics;
@@ -61,6 +62,18 @@ public:
 		///displayed "between" caster and (first) target. Ignored if spell was cast with no target selection.
 		///use selectProjectile to access
 		std::vector<ProjectileInfo> projectile;
+
+		///jagged ray drawn between consecutive affected targets (e.g. chain lightning). Empty = no ray.
+		std::vector<RayColor> ray;
+
+		///midpoint-displacement amplitude of the ray, as a fraction of each segment's length
+		float rayJaggedness = 0.f;
+
+		///delay in seconds before the ray jumps to each next target
+		float rayHopDelay = 0.1f;
+
+		///thickness in pixels of each of the ray's color sub-lines
+		int rayWidth = 1;
 
 		AnimationPath selectProjectile(const double angle) const;
 	} animationInfo;

--- a/lib/spells/CSpell.h
+++ b/lib/spells/CSpell.h
@@ -53,6 +53,9 @@ public:
 		///displayed on all affected targets.
 		SpellAnimationQueue affect;
 
+		///displayed on secondary affected targets instead of "affect" (e.g. the sacrificed unit for Sacrifice). Empty = use "affect".
+		SpellAnimationQueue affectSecondary;
+
 		///displayed on caster.
 		SpellAnimationQueue cast;
 

--- a/lib/spells/CSpellHandler.cpp
+++ b/lib/spells/CSpellHandler.cpp
@@ -417,6 +417,7 @@ std::shared_ptr<CSpell> CSpellHandler::loadFromJson(const std::string & scope, c
 	};
 
 	loadAnimationQueue("affect", spell->animationInfo.affect);
+	loadAnimationQueue("affectSecondary", spell->animationInfo.affectSecondary);
 	loadAnimationQueue("cast", spell->animationInfo.cast);
 	loadAnimationQueue("hit", spell->animationInfo.hit);
 

--- a/lib/spells/CSpellHandler.cpp
+++ b/lib/spells/CSpellHandler.cpp
@@ -431,6 +431,15 @@ std::shared_ptr<CSpell> CSpellHandler::loadFromJson(const std::string & scope, c
 		spell->animationInfo.projectile.push_back(info);
 	}
 
+	const JsonNode & rayNode = animationNode["ray"];
+	spell->animationInfo.rayJaggedness = rayNode["jaggedness"].Float();
+	if(rayNode["hopDelay"].Float() > 0)
+		spell->animationInfo.rayHopDelay = rayNode["hopDelay"].Float() / 1000.f;
+	if(rayNode["width"].Integer() > 0)
+		spell->animationInfo.rayWidth = static_cast<int>(rayNode["width"].Integer());
+	for(const JsonNode & value : rayNode["colors"].Vector())
+		spell->animationInfo.ray.push_back(RayColor::fromJson(value));
+
 	const JsonNode & soundsNode = json["sounds"];
 	spell->castSound = AudioPath::fromJson(soundsNode["cast"]);
 

--- a/luascript/LuaSpellEffect.cpp
+++ b/luascript/LuaSpellEffect.cpp
@@ -79,7 +79,7 @@ void LuaSpellEffect::adjustTargetTypes(std::vector<TargetType> & types, const Me
 void LuaSpellEffect::adjustAffectedHexes(BattleHexArray & hexes, const Mechanics * m, const Target & spellTarget) const
 {
 	std::shared_ptr<LuaContext> context = resolveScript(m);
-	context->callMethod<void>(ADJUST_AFFECTED_HEXES, parameters, m, hexes, spellTarget);
+	hexes = context->callMethod<BattleHexArray>(ADJUST_AFFECTED_HEXES, parameters, m, hexes, spellTarget);
 }
 
 SpellEffectValue LuaSpellEffect::getHealthChange(const Mechanics * m, const Target & spellTarget) const

--- a/luascript/api/battle/SpellObstacleDescriptor.cpp
+++ b/luascript/api/battle/SpellObstacleDescriptor.cpp
@@ -37,9 +37,10 @@ SpellCreatedObstacle SpellObstacleDescriptor::toObstacle() const
 
 	obstacle.trigger = trigger.empty() ? SpellID(SpellID::NONE) : SpellID(SpellID::decode(trigger));
 
-	obstacle.appearSound     = AudioPath::builtin(appearSound);
-	obstacle.appearAnimation = AnimationPath::builtin(appearAnimation);
-	obstacle.animation       = AnimationPath::builtin(animation);
+	obstacle.appearSound      = AudioPath::builtin(appearSound);
+	obstacle.appearAnimation  = AnimationPath::builtin(appearAnimation);
+	obstacle.animation        = AnimationPath::builtin(animation);
+	obstacle.removalAnimation = AnimationPath::builtin(removalAnimation);
 
 	for(const BattleHex & hex : customSize)
 		obstacle.customSize.insert(hex);

--- a/luascript/api/battle/SpellObstacleDescriptor.h
+++ b/luascript/api/battle/SpellObstacleDescriptor.h
@@ -54,6 +54,7 @@ struct SpellObstacleDescriptor final : ApiSerializable<SpellObstacleDescriptor>
 	std::string appearSound;
 	std::string appearAnimation;
 	std::string animation;
+	std::string removalAnimation;
 
 	std::vector<BattleHex> customSize;
 
@@ -80,6 +81,7 @@ struct SpellObstacleDescriptor final : ApiSerializable<SpellObstacleDescriptor>
 		s("appearSound",      appearSound,      "Sound effect played when the obstacle appears.");
 		s("appearAnimation",  appearAnimation,  "Animation played when the obstacle appears.");
 		s("animation",        animation,        "Looping animation shown while the obstacle is on the battlefield.");
+		s("removalAnimation", removalAnimation, "Animation played when the obstacle is removed (expires or is dispelled). Falls back to appearAnimation if empty.");
 		s("customSize",       customSize,       "Optional list of BattleHex values defining a multi-hex footprint.");
 	}
 };

--- a/luascript/api/callback/ServerCallback.cpp
+++ b/luascript/api/callback/ServerCallback.cpp
@@ -199,8 +199,7 @@ void ServerCallbackProxy::addObstacle(ServerCallback & object, const IBattleInfo
 
 	BattleObstaclesChanged pack;
 	pack.battleID = battle.getBattle()->getBattleID();
-	pack.changes.emplace_back();
-	obstacle.toInfo(pack.changes.back());
+	obstacle.toInfo(pack.change);
 	object.apply(pack);
 }
 
@@ -239,9 +238,9 @@ void ServerCallbackProxy::removeObstacle(ServerCallback & object, const IBattleI
 
 	BattleObstaclesChanged pack;
 	pack.battleID = battle.getBattle()->getBattleID();
-	pack.changes.emplace_back(obstacle->uniqueID, BattleChanges::EOperation::REMOVE);
+	pack.change = ObstacleChanges(obstacle->uniqueID, BattleChanges::EOperation::REMOVE);
 	auto * serializable = const_cast<CObstacleInstance*>(obstacle.get());
-	serializable->toInfo(pack.changes.back(), BattleChanges::EOperation::REMOVE);
+	serializable->toInfo(pack.change, BattleChanges::EOperation::REMOVE);
 	object.apply(pack);
 }
 

--- a/scripts/obstacle.lua
+++ b/scripts/obstacle.lua
@@ -157,6 +157,7 @@ local function buildDescriptor(self, mechanics, side, hex, customSize)
 		appearSound      = opts.appearSound or "",
 		appearAnimation  = opts.appearAnimation or "",
 		animation        = opts.animation or "",
+		removalAnimation = opts.removalAnimation or "",
 		customSize       = customSize,
 	}
 end

--- a/scripts/obstacle.lua
+++ b/scripts/obstacle.lua
@@ -134,6 +134,7 @@ function Script:adjustAffectedHexes(mechanics, hexes, spellTarget)
 			end
 		end
 	end
+	return hexes
 end
 
 local function buildDescriptor(self, mechanics, side, hex, customSize)

--- a/scripts/spellEffect.lua
+++ b/scripts/spellEffect.lua
@@ -42,6 +42,7 @@ end
 
 --- TODO
 function Script:adjustAffectedHexes(mechanics, hexes, spellTarget)
+	return hexes
 end
 
 --- TODO

--- a/scripts/spellEffect.lua
+++ b/scripts/spellEffect.lua
@@ -35,9 +35,10 @@ function Script:filterTarget(mechanics, target)
 	return target
 end
 
---- TODO
-function Script:getHealthChange(mechanics, problem, target)
-    return true
+--- Predicted health/unit-count change for AI and hover text; effects that do not
+--- heal or damage keep the neutral value.
+function Script:getHealthChange(mechanics, spellTarget)
+    return { hpDelta = 0, unitsDelta = 0 }
 end
 
 --- TODO

--- a/scripts/unitEffect.lua
+++ b/scripts/unitEffect.lua
@@ -72,6 +72,7 @@ function Script:adjustAffectedHexes(mechanics, hexes, spellTarget)
 			hexes:insert(dest.hex)
 		end
 	end
+	return hexes
 end
 
 --- Filters the transformed target, keeping only valid and receptive units.

--- a/server/battles/BattleFlowProcessor.cpp
+++ b/server/battles/BattleFlowProcessor.cpp
@@ -926,7 +926,7 @@ void BattleFlowProcessor::removeObstacle(const CBattleInfoCallback & battle, con
 {
 	BattleObstaclesChanged obsRem;
 	obsRem.battleID = battle.getBattle()->getBattleID();
-	obsRem.changes.emplace_back(obstacle.uniqueID, ObstacleChanges::EOperation::REMOVE);
+	obsRem.change = ObstacleChanges(obstacle.uniqueID, ObstacleChanges::EOperation::REMOVE);
 	gameHandler->sendAndApply(obsRem);
 }
 

--- a/test/spells/effects/MoatTest.cpp
+++ b/test/spells/effects/MoatTest.cpp
@@ -54,7 +54,7 @@ public:
 	{
 	}
 
-	BattleObstaclesChanged capturedPack;
+	std::vector<ObstacleChanges> capturedChanges;
 
 	void captureObstaclePack()
 	{
@@ -62,8 +62,7 @@ public:
 			.Times(AnyNumber())
 			.WillRepeatedly(Invoke([this](const BattleObstaclesChanged & pack)
 			{
-				for(const auto & change : pack.changes)
-					capturedPack.changes.push_back(change);
+				capturedChanges.push_back(pack.change);
 			}));
 	}
 
@@ -105,8 +104,8 @@ TEST_F(MoatApplyTest, PlacesMoatObstaclesWhenTownHasMoat)
 
 	subject->apply(&serverMock, &mechanicsMock, Target());
 
-	ASSERT_EQ(capturedPack.changes.size(), 1u);
-	EXPECT_EQ(capturedPack.changes[0].operation, BattleChanges::EOperation::ADD);
+	ASSERT_EQ(capturedChanges.size(), 1u);
+	EXPECT_EQ(capturedChanges[0].operation, BattleChanges::EOperation::ADD);
 }
 
 TEST_F(MoatApplyTest, PlacesDispellableMoatAsSpellCreatedObstacle)
@@ -129,8 +128,8 @@ TEST_F(MoatApplyTest, PlacesDispellableMoatAsSpellCreatedObstacle)
 
 	subject->apply(&serverMock, &mechanicsMock, Target());
 
-	ASSERT_EQ(capturedPack.changes.size(), 1u);
-	EXPECT_EQ(capturedPack.changes[0].operation, BattleChanges::EOperation::ADD);
+	ASSERT_EQ(capturedChanges.size(), 1u);
+	EXPECT_EQ(capturedChanges[0].operation, BattleChanges::EOperation::ADD);
 }
 
 TEST_F(MoatApplyTest, MultipleMoatPatchesCreateMultipleObstacles)
@@ -155,8 +154,8 @@ TEST_F(MoatApplyTest, MultipleMoatPatchesCreateMultipleObstacles)
 
 	subject->apply(&serverMock, &mechanicsMock, Target());
 
-	ASSERT_EQ(capturedPack.changes.size(), 3u);
-	for(const auto & change : capturedPack.changes)
+	ASSERT_EQ(capturedChanges.size(), 3u);
+	for(const auto & change : capturedChanges)
 		EXPECT_EQ(change.operation, BattleChanges::EOperation::ADD);
 }
 

--- a/test/spells/effects/ObstacleTest.cpp
+++ b/test/spells/effects/ObstacleTest.cpp
@@ -146,7 +146,7 @@ public:
 	{
 	}
 
-	BattleObstaclesChanged capturedPack;
+	std::vector<ObstacleChanges> capturedChanges;
 
 	void captureObstaclePack()
 	{
@@ -154,8 +154,7 @@ public:
 			.Times(AnyNumber())
 			.WillRepeatedly(Invoke([this](const BattleObstaclesChanged & pack)
 			{
-				for(const auto & change : pack.changes)
-					capturedPack.changes.push_back(change);
+				capturedChanges.push_back(pack.change);
 			}));
 	}
 
@@ -192,11 +191,11 @@ TEST_F(ObstacleApplyTest, PlacesSingleObstacleAtTarget)
 
 	subject->apply(&serverMock, &mechanicsMock, target);
 
-	ASSERT_EQ(capturedPack.changes.size(), 1u);
-	EXPECT_EQ(capturedPack.changes[0].operation, BattleChanges::EOperation::ADD);
+	ASSERT_EQ(capturedChanges.size(), 1u);
+	EXPECT_EQ(capturedChanges[0].operation, BattleChanges::EOperation::ADD);
 
 	SpellCreatedObstacle deserialized;
-	deserialized.fromInfo(capturedPack.changes[0]);
+	deserialized.fromInfo(capturedChanges[0]);
 	EXPECT_EQ(deserialized.pos, hex);
 	EXPECT_EQ(deserialized.casterSide, BattleSide::ATTACKER);
 	EXPECT_EQ(deserialized.turnsRemaining, 5);
@@ -231,10 +230,10 @@ TEST_F(ObstacleApplyTest, PlacesObstacleWithMultiHexShape)
 
 	subject->apply(&serverMock, &mechanicsMock, target);
 
-	ASSERT_EQ(capturedPack.changes.size(), 1u);
+	ASSERT_EQ(capturedChanges.size(), 1u);
 
 	SpellCreatedObstacle deserialized;
-	deserialized.fromInfo(capturedPack.changes[0]);
+	deserialized.fromInfo(capturedChanges[0]);
 
 	BattleHex trNeighbour = hex;
 	trNeighbour.moveInDirection(BattleHex::EDir::TOP_RIGHT, false);
@@ -261,8 +260,8 @@ TEST_F(ObstacleApplyTest, PlacesOneObstaclePerTargetHex)
 
 	subject->apply(&serverMock, &mechanicsMock, target);
 
-	ASSERT_EQ(capturedPack.changes.size(), 3u);
-	for(const auto & change : capturedPack.changes)
+	ASSERT_EQ(capturedChanges.size(), 3u);
+	for(const auto & change : capturedChanges)
 		EXPECT_EQ(change.operation, BattleChanges::EOperation::ADD);
 }
 
@@ -294,7 +293,7 @@ TEST_F(ObstacleApplyTest, PatchCountLimitedByAvailableTiles)
 
 	subject->apply(&serverMock, &mechanicsMock, target);
 
-	ASSERT_EQ(capturedPack.changes.size(), 2u);
+	ASSERT_EQ(capturedChanges.size(), 2u);
 }
 
 TEST_F(ObstacleApplyTest, NoServerCallWhenNoAvailableTiles)
@@ -350,11 +349,11 @@ TEST_F(ObstacleApplyTest, UsesDefenderSideOptions)
 
 	subject->apply(&serverMock, &mechanicsMock, target);
 
-	ASSERT_EQ(capturedPack.changes.size(), 1u);
-	EXPECT_EQ(capturedPack.changes[0].operation, BattleChanges::EOperation::ADD);
+	ASSERT_EQ(capturedChanges.size(), 1u);
+	EXPECT_EQ(capturedChanges[0].operation, BattleChanges::EOperation::ADD);
 
 	SpellCreatedObstacle deserialized;
-	deserialized.fromInfo(capturedPack.changes[0]);
+	deserialized.fromInfo(capturedChanges[0]);
 
 	BattleHex defenderShapeNeighbour = hex;
 	defenderShapeNeighbour.moveInDirection(BattleHex::EDir::TOP_RIGHT, false);

--- a/test/spells/effects/RemoveObstacleTest.cpp
+++ b/test/spells/effects/RemoveObstacleTest.cpp
@@ -182,15 +182,14 @@ public:
 	{
 	}
 
-	BattleObstaclesChanged capturedPack;
+	std::vector<ObstacleChanges> capturedChanges;
 
 	void captureObstaclePack()
 	{
 		EXPECT_CALL(serverMock, apply(Matcher<BattleObstaclesChanged &>(_)))
 			.WillRepeatedly(Invoke([this](const BattleObstaclesChanged & pack)
 			{
-				for(const auto & change : pack.changes)
-					capturedPack.changes.push_back(change);
+				capturedChanges.push_back(pack.change);
 			}));
 	}
 
@@ -217,9 +216,9 @@ TEST_F(RemoveObstacleApplyTest, RemovesUsualObstacleMassive)
 
 	subject->apply(&serverMock, &mechanicsMock, Target());
 
-	ASSERT_EQ(capturedPack.changes.size(), 1u);
-	EXPECT_EQ(capturedPack.changes[0].id, static_cast<uint32_t>(usual->uniqueID));
-	EXPECT_EQ(capturedPack.changes[0].operation, BattleChanges::EOperation::REMOVE);
+	ASSERT_EQ(capturedChanges.size(), 1u);
+	EXPECT_EQ(capturedChanges[0].id, static_cast<uint32_t>(usual->uniqueID));
+	EXPECT_EQ(capturedChanges[0].operation, BattleChanges::EOperation::REMOVE);
 }
 
 TEST_F(RemoveObstacleApplyTest, RemovesAbsoluteWhenFlagSet)
@@ -238,9 +237,9 @@ TEST_F(RemoveObstacleApplyTest, RemovesAbsoluteWhenFlagSet)
 
 	subject->apply(&serverMock, &mechanicsMock, Target());
 
-	ASSERT_EQ(capturedPack.changes.size(), 1u);
-	EXPECT_EQ(capturedPack.changes[0].id, static_cast<uint32_t>(absolute->uniqueID));
-	EXPECT_EQ(capturedPack.changes[0].operation, BattleChanges::EOperation::REMOVE);
+	ASSERT_EQ(capturedChanges.size(), 1u);
+	EXPECT_EQ(capturedChanges[0].id, static_cast<uint32_t>(absolute->uniqueID));
+	EXPECT_EQ(capturedChanges[0].operation, BattleChanges::EOperation::REMOVE);
 }
 
 TEST_F(RemoveObstacleApplyTest, RemovesAllSpellObstaclesWithFlag)
@@ -260,9 +259,9 @@ TEST_F(RemoveObstacleApplyTest, RemovesAllSpellObstaclesWithFlag)
 
 	subject->apply(&serverMock, &mechanicsMock, Target());
 
-	ASSERT_EQ(capturedPack.changes.size(), 2u);
+	ASSERT_EQ(capturedChanges.size(), 2u);
 	std::set<uint32_t> removedIds;
-	for(const auto & change : capturedPack.changes)
+	for(const auto & change : capturedChanges)
 	{
 		removedIds.insert(change.id);
 		EXPECT_EQ(change.operation, BattleChanges::EOperation::REMOVE);
@@ -288,9 +287,9 @@ TEST_F(RemoveObstacleApplyTest, RemovesNamedSpellsOnly)
 
 	subject->apply(&serverMock, &mechanicsMock, Target());
 
-	ASSERT_EQ(capturedPack.changes.size(), 1u);
-	EXPECT_EQ(capturedPack.changes[0].id, static_cast<uint32_t>(fireWall->uniqueID));
-	EXPECT_EQ(capturedPack.changes[0].operation, BattleChanges::EOperation::REMOVE);
+	ASSERT_EQ(capturedChanges.size(), 1u);
+	EXPECT_EQ(capturedChanges[0].id, static_cast<uint32_t>(fireWall->uniqueID));
+	EXPECT_EQ(capturedChanges[0].operation, BattleChanges::EOperation::REMOVE);
 }
 
 TEST_F(RemoveObstacleApplyTest, NonMassiveRemovesOnlyAtTargetHex)
@@ -313,8 +312,8 @@ TEST_F(RemoveObstacleApplyTest, NonMassiveRemovesOnlyAtTargetHex)
 
 	subject->apply(&serverMock, &mechanicsMock, target);
 
-	ASSERT_EQ(capturedPack.changes.size(), 1u);
-	EXPECT_EQ(capturedPack.changes[0].id, static_cast<uint32_t>(onTarget->uniqueID));
+	ASSERT_EQ(capturedChanges.size(), 1u);
+	EXPECT_EQ(capturedChanges[0].id, static_cast<uint32_t>(onTarget->uniqueID));
 }
 
 TEST_F(RemoveObstacleApplyTest, RemovesUsualObstacleNonMassive)
@@ -337,8 +336,8 @@ TEST_F(RemoveObstacleApplyTest, RemovesUsualObstacleNonMassive)
 
 	subject->apply(&serverMock, &mechanicsMock, target);
 
-	ASSERT_EQ(capturedPack.changes.size(), 1u);
-	EXPECT_EQ(capturedPack.changes[0].id, static_cast<uint32_t>(onTarget->uniqueID));
+	ASSERT_EQ(capturedChanges.size(), 1u);
+	EXPECT_EQ(capturedChanges[0].id, static_cast<uint32_t>(onTarget->uniqueID));
 }
 
 TEST_F(RemoveObstacleApplyTest, NoServerCallWhenNothingToRemove)


### PR DESCRIPTION
This PR fixes majority of bugs related to animations in battles, including those from our old bug tracker.
Specifically:
- Implemented Chain Lightning effect, of lightning bolt jumping between affected units
- Implemented support for H3 gate overlay that contains gate chains - they now appear on top of the units standing inside the gates.
- Implemented animation of the gates opening/closing
- Implemented removal fade out effect for on-map obstacles
- Implemented missing magical obstacle removal animation
- Acid Breath now uses own animation instead of Weakness effect
- Added missing spell effect for Remove Obstacle spell
- Sacrifice now shows correct animation for sacrificed unit
- Removal of units from the battlefield, including Sacrifice now uses fade-out effect, not instant remove
- Fixed timing of obstacle placement (Fire Wall, Force Field). Now hero spellcasting animation, obstacle fade-in, and its replacement with permanent obstacle time in correctly, without visible glitches
- Fixed randomly reproducible bug where some spells like Magic Arrow could play hit effect before projectile is fire by the hero
- Fixed animation ordering during Earthquake - all explosions now play at once (Lua switch regression) and hero animation plays at correct time
- When walls, gates, or towers are destroyed, they now switch their image to destroyed mid-point of explosion (when image is hidden by explosion, in line with H3) instead of after
- Improved timing of bloodlust effect to better match H3
- Fixed Lua regression - all spells now correctly highlight affected hexes, not just units

**With this, there should be no known bugs in battles related to animations**

Fixed Github issues:

- Fixes #1236
- Fixes #2251
- Fixes #4335
- Likely fixes #2763
- Likely fixes #7165
- Partial #1219