### PR TITLE
Allow targeting stacks via the battle queue, same as on the battlefield

### DIFF
--- a/client/battle/BattleFieldController.cpp
+++ b/client/battle/BattleFieldController.cpp
@@ -234,11 +234,19 @@ void BattleFieldController::mouseMoved(const Point & cursorPosition, const Point
 	currentAttackOriginPoint = cursorPosition;
 
 	// hex rects of the bottom rows extend under the command panel, so only treat the cursor as hovering a hex
-	// when it is actually over the battlefield - otherwise hovering the panel leaks a unit range highlight
+	// when it is actually over the battlefield - otherwise hovering the panel leaks a unit range highlight.
+	// This handler is also invoked when the cursor is over the battle queue: in that case keep the cursor and
+	// status bar in sync with the queue-hovered stack, so that pointing at the queue is equivalent to pointing
+	// at the stack on the battlefield.
 	if (pos.isInside(cursorPosition))
 	{
 		hoveredHex = getHexAtPosition(cursorPosition);
 		owner.actionsController->onHexHovered(getHoveredHex());
+	}
+	else if (const CStack * queueStack = getQueueHoveredStack())
+	{
+		hoveredHex = BattleHex::INVALID;
+		owner.actionsController->onHexHovered(queueStack->getPosition());
 	}
 	else
 	{
@@ -701,21 +709,36 @@ bool BattleFieldController::isPixelInHex(Point const & position)
 
 BattleHex BattleFieldController::getHoveredHex()
 {
+	// if mouse is not over the battlefield itself but over a stack in the battle queue,
+	// treat the position of that stack as the hovered hex so that pointing at the queue
+	// is equivalent to pointing at the stack on the battlefield
+	if(hoveredHex == BattleHex::INVALID)
+	{
+		if(const CStack * queueStack = getQueueHoveredStack())
+			return queueStack->getPosition();
+	}
+
 	return hoveredHex;
+}
+
+const CStack* BattleFieldController::getQueueHoveredStack() const
+{
+	if(!owner.windowObject->getQueueHoveredUnitId().has_value())
+		return nullptr;
+
+	for(const CStack * stack : owner.getBattle()->battleGetAllStacks())
+		if(stack->unitId() == *owner.windowObject->getQueueHoveredUnitId())
+			return stack;
+
+	return nullptr;
 }
 
 const CStack* BattleFieldController::getHoveredStack()
 {
-	auto hoveredHex = getHoveredHex();
 	const CStack* hoveredStack = owner.getBattle()->battleGetStackByPos(hoveredHex, true);
 
-	if(owner.windowObject->getQueueHoveredUnitId().has_value())
-	{
-		auto stacks = owner.getBattle()->battleGetAllStacks();
-		for(const CStack * stack : stacks)
-			if(stack->unitId() == *owner.windowObject->getQueueHoveredUnitId())
-				hoveredStack = stack;
-	}
+	if(const CStack * queueStack = getQueueHoveredStack())
+		hoveredStack = queueStack;
 
 	return hoveredStack;
 }
@@ -748,8 +771,53 @@ BattleHex BattleFieldController::getHexAtPosition(Point hoverPos)
 	return BattleHex::INVALID;
 }
 
+BattleHex::EDir BattleFieldController::selectAttackDirectionForQueue(const BattleHex & myNumber) const
+{
+	// When the target is pointed at through the battle queue there is no meaningful mouse
+	// position on the battlefield to derive an approach direction from. Instead of letting the
+	// (irrelevant) cursor position decide - which always yields the same corner - pick the
+	// direction whose attack-from hex requires the least movement for the attacker, i.e. the
+	// closest reachable hex. This matches what a player usually wants when simply saying
+	// "attack that stack".
+	const auto * attacker = owner.stacksController->getActiveStack();
+	assert(attacker);
+
+	const auto distances = owner.getBattle()->battleGetDistances(attacker, attacker->getPosition());
+
+	BattleHex::EDir bestDirection = BattleHex::NONE;
+	int bestDistance = std::numeric_limits<int>::max();
+
+	for(int direction = 0; direction < 8; ++direction)
+	{
+		if(!owner.getBattle()->battleCanAttackHex(availableHexes, attacker, myNumber, BattleHex::EDir(direction)))
+			continue;
+
+		BattleHex attackFromHex = owner.getBattle()->fromWhichHexAttack(attacker, myNumber, BattleHex::EDir(direction));
+		if(!attackFromHex.isValid())
+			continue;
+
+		// attacker can attack from its own hex(es) without moving
+		int distance = attacker->coversPos(attackFromHex) ? 0 : distances[attackFromHex.toInt()];
+		if(distance < bestDistance)
+		{
+			bestDistance = distance;
+			bestDirection = BattleHex::EDir(direction);
+		}
+	}
+
+	if(bestDirection == BattleHex::NONE)
+		logGlobal->error("Error: cannot find a hex to attack hex %d from!", myNumber);
+
+	return bestDirection;
+}
+
 BattleHex::EDir BattleFieldController::selectAttackDirection(const BattleHex & myNumber) const
 {
+	// pointing at the target via the battle queue has no meaningful on-field cursor position,
+	// so fall back to choosing the closest reachable attack-from hex instead
+	if(!pos.isInside(currentAttackOriginPoint) && getQueueHoveredStack() != nullptr)
+		return selectAttackDirectionForQueue(myNumber);
+
 	auto attacker = owner.stacksController->getActiveStack();
 	assert(attacker);
 	const BattleHexArray & neighbours = myNumber.getAllNeighbouringTiles();

--- a/client/battle/BattleFieldController.cpp
+++ b/client/battle/BattleFieldController.cpp
@@ -771,55 +771,21 @@ BattleHex BattleFieldController::getHexAtPosition(Point hoverPos)
 	return BattleHex::INVALID;
 }
 
-BattleHex::EDir BattleFieldController::selectAttackDirectionForQueue(const BattleHex & myNumber) const
-{
-	// When the target is pointed at through the battle queue there is no meaningful mouse
-	// position on the battlefield to derive an approach direction from. Instead of letting the
-	// (irrelevant) cursor position decide - which always yields the same corner - pick the
-	// direction whose attack-from hex requires the least movement for the attacker, i.e. the
-	// closest reachable hex. This matches what a player usually wants when simply saying
-	// "attack that stack".
-	const auto * attacker = owner.stacksController->getActiveStack();
-	assert(attacker);
-
-	const auto distances = owner.getBattle()->battleGetDistances(attacker, attacker->getPosition());
-
-	BattleHex::EDir bestDirection = BattleHex::NONE;
-	int bestDistance = std::numeric_limits<int>::max();
-
-	for(int direction = 0; direction < 8; ++direction)
-	{
-		if(!owner.getBattle()->battleCanAttackHex(availableHexes, attacker, myNumber, BattleHex::EDir(direction)))
-			continue;
-
-		BattleHex attackFromHex = owner.getBattle()->fromWhichHexAttack(attacker, myNumber, BattleHex::EDir(direction));
-		if(!attackFromHex.isValid())
-			continue;
-
-		// attacker can attack from its own hex(es) without moving
-		int distance = attacker->coversPos(attackFromHex) ? 0 : distances[attackFromHex.toInt()];
-		if(distance < bestDistance)
-		{
-			bestDistance = distance;
-			bestDirection = BattleHex::EDir(direction);
-		}
-	}
-
-	if(bestDirection == BattleHex::NONE)
-		logGlobal->error("Error: cannot find a hex to attack hex %d from!", myNumber);
-
-	return bestDirection;
-}
-
 BattleHex::EDir BattleFieldController::selectAttackDirection(const BattleHex & myNumber) const
 {
-	// pointing at the target via the battle queue has no meaningful on-field cursor position,
-	// so fall back to choosing the closest reachable attack-from hex instead
-	if(!pos.isInside(currentAttackOriginPoint) && getQueueHoveredStack() != nullptr)
-		return selectAttackDirectionForQueue(myNumber);
-
 	auto attacker = owner.stacksController->getActiveStack();
 	assert(attacker);
+
+	// When the target is pointed at through the battle queue there is no meaningful mouse
+	// position on the battlefield to derive an approach direction from, so the raw cursor
+	// position would always yield the same corner. Instead, pretend the cursor sits on the
+	// attacker: the nearest-test-point logic below then selects the attack-from hex closest
+	// to the attacker, which is what a player usually wants when simply saying "attack that
+	// stack".
+	Point originPoint = currentAttackOriginPoint;
+	if(!pos.isInside(originPoint) && getQueueHoveredStack() != nullptr)
+		originPoint = hexPositionAbsolute(attacker->getPosition()).center();
+
 	const BattleHexArray & neighbours = myNumber.getAllNeighbouringTiles();
 	// For each valid direction, select position to test against
 	std::array<Point, 8> testPoint;
@@ -844,7 +810,7 @@ BattleHex::EDir BattleFieldController::selectAttackDirection(const BattleHex & m
 	{
 		if (testPoint[i].isValid())
 		{
-			int distance = (testPoint[i].y - currentAttackOriginPoint.y)*(testPoint[i].y - currentAttackOriginPoint.y) + (testPoint[i].x - currentAttackOriginPoint.x)*(testPoint[i].x - currentAttackOriginPoint.x);
+			int distance = (testPoint[i].y - originPoint.y)*(testPoint[i].y - originPoint.y) + (testPoint[i].x - originPoint.x)*(testPoint[i].x - originPoint.x);
 			if (nearest == -1 || distance < nearestDistance)
 			{
 				nearestDistance = distance;

--- a/client/battle/BattleFieldController.h
+++ b/client/battle/BattleFieldController.h
@@ -142,9 +142,4 @@ private:
 	Point shakeOffset;
 	int shakeFrameCounter = 0;
 	int shakeFrameTotal = 0;
-
-	/// selects an attack approach direction when the target is pointed at through the battle
-	/// queue (i.e. without a meaningful cursor position on the battlefield); picks the closest
-	/// reachable attack-from hex
-	BattleHex::EDir selectAttackDirectionForQueue(const BattleHex & myNumber) const;
 };

--- a/client/battle/BattleFieldController.h
+++ b/client/battle/BattleFieldController.h
@@ -124,6 +124,9 @@ public:
 	/// Returns the currently hovered stack
 	const CStack* getHoveredStack();
 
+	/// Returns the stack hovered in the battle queue, or nullptr if none is hovered there
+	const CStack* getQueueHoveredStack() const;
+
 	/// returns true if stack should render its stack count image in default position - outside own hex
 	bool stackCountOutsideHex(const BattleHex & number) const;
 
@@ -139,4 +142,9 @@ private:
 	Point shakeOffset;
 	int shakeFrameCounter = 0;
 	int shakeFrameTotal = 0;
+
+	/// selects an attack approach direction when the target is pointed at through the battle
+	/// queue (i.e. without a meaningful cursor position on the battlefield); picks the closest
+	/// reachable attack-from hex
+	BattleHex::EDir selectAttackDirectionForQueue(const BattleHex & myNumber) const;
 };

--- a/client/battle/StackQueue.cpp
+++ b/client/battle/StackQueue.cpp
@@ -10,6 +10,8 @@
 #include "StdInc.h"
 #include "StackQueue.h"
 
+#include "BattleActionsController.h"
+#include "BattleFieldController.h"
 #include "BattleInterface.h"
 #include "BattleSiegeController.h"
 #include "BattleStacksController.h"
@@ -116,7 +118,7 @@ std::optional<uint32_t> StackQueue::getHoveredUnitIdIfAny() const
 }
 
 StackQueue::StackBox::StackBox(StackQueue * owner)
-	: CIntObject(SHOW_POPUP | HOVER)
+	: CIntObject(LCLICK | SHOW_POPUP | HOVER)
 	, owner(owner)
 {
 	OBJECT_CONSTRUCTION;
@@ -232,10 +234,32 @@ void StackQueue::StackBox::show(Canvas & to)
 		to.drawBorder(background->pos, Colors::CYAN, 2);
 }
 
+BattleHex StackQueue::StackBox::getBoundUnitHex() const
+{
+	if(!boundUnitID.has_value())
+		return BattleHex::INVALID;
+
+	const auto * unit = owner->owner.getBattle()->battleGetUnitByID(*boundUnitID);
+	if(!unit || !unit->alive())
+		return BattleHex::INVALID;
+
+	return unit->getPosition();
+}
+
+void StackQueue::StackBox::clickPressed(const Point & cursorPosition)
+{
+	// clicking a stack in the queue is equivalent to clicking it on the battlefield
+	BattleHex hex = getBoundUnitHex();
+
+	if(hex.isValid())
+		owner->owner.actionsController->onHexLeftClicked(hex);
+}
+
 void StackQueue::StackBox::showPopupWindow(const Point & cursorPosition)
 {
-	auto stacks = owner->owner.getBattle()->battleGetAllStacks();
-	for(const CStack * stack : stacks)
-		if(boundUnitID.has_value() && stack->unitId() == *boundUnitID)
-			ENGINE->windows().createAndPushWindow<CStackWindow>(stack, true);
+	// right-clicking a stack in the queue is equivalent to right-clicking it on the battlefield
+	BattleHex hex = getBoundUnitHex();
+
+	if(hex.isValid())
+		owner->owner.actionsController->onHexRightClicked(hex);
 }

--- a/client/battle/StackQueue.h
+++ b/client/battle/StackQueue.h
@@ -9,6 +9,7 @@
  */
 #pragma once
 
+#include "../../lib/battle/BattleHex.h"
 #include "../gui/CIntObject.h"
 
 namespace battle
@@ -41,7 +42,11 @@ class StackQueue : public CIntObject
 		void show(Canvas & to) override;
 		void showAll(Canvas & to) override;
 		void showPopupWindow(const Point & cursorPosition) override;
+		void clickPressed(const Point & cursorPosition) override;
 		bool isBoundUnitHighlighted() const;
+
+		/// battlefield hex occupied by the bound stack, or BattleHex::INVALID if none
+		BattleHex getBoundUnitHex() const;
 
 	public:
 		StackBox(StackQueue * owner);


### PR DESCRIPTION
Pointing at a creature stack in the battle queue is now equivalent to pointing at it on the battlefield. Hovering, left-clicking and right-clicking a queue entry drive the exact same actions as the corresponding hex: cursor shape, status-bar text, attack/shoot/spellcast targeting, and the creature info popup.

All battle interaction already flows through `BattleActionsController` via a `BattleHex`, so queue interactions are resolved to the bound stack's position hex and routed through the existing `onHexHovered` / `onHexLeftClicked` / `onHexRightClicked` entry points.

Details:
* `StackQueue::StackBox` gains `LCLICK` and forwards `clickPressed` / `showPopupWindow` to the actions controller using the stack's hex.
* `BattleFieldController::getHoveredHex()` and `getHoveredStack()` now resolve the queue-hovered unit (extracted into `getQueueHoveredStack`), so battlefield range/attack highlights follow queue hovering too.
* `BattleFieldController::mouseMoved()` keeps the cursor and status bar in sync with the queue-hovered stack instead of resetting them. This handler fires on every mouse move (even off the battlefield) and previously clobbered the cursor set while hovering the queue.
* For melee attacks selected via the queue there is no meaningful on-field cursor position to derive an approach direction from, which made `selectAttackDirection()` always pick the same corner. When targeting through the queue it now chooses the closest reachable attack-from hex (`selectAttackDirectionForQueue`) instead.

closes #7159