### PR TITLE
Fix Nullkiller route failure loops and idle diagnostics

### DIFF
--- a/AI/Nullkiller2/AIGateway.cpp
+++ b/AI/Nullkiller2/AIGateway.cpp
@@ -1069,7 +1069,7 @@ bool AIGateway::moveHeroToTile(const int3 dst, const HeroPtr & heroPtr)
 		if(path.nodes.empty())
 		{
 			logAi->error("Hero %s cannot reach %s.", heroPtr->getNameTranslated(), dst.toString());
-			return true;
+			throw cannotFulfillGoalException("Hero cannot reach target tile.");
 		}
 		int i = (int)path.nodes.size() - 1;
 

--- a/AI/Nullkiller2/AIGateway.cpp
+++ b/AI/Nullkiller2/AIGateway.cpp
@@ -785,8 +785,32 @@ void AIGateway::makeTurn()
 
 		for (const auto *h : cc->getHeroesInfo())
 		{
-			if (h->movementPointsRemaining())
-				logAi->warn("Hero %s has %d MP left", h->getNameTranslated(), h->movementPointsRemaining());
+			if(!h->movementPointsRemaining())
+				continue;
+
+			const auto lockReason = nullkiller->getHeroLockedReason(h);
+			if(lockReason != HeroLockedReason::NOT_LOCKED)
+			{
+				logAi->debug(
+					"Hero %s ends the turn with %d MP because it is locked for %s.",
+					h->getNameTranslated(),
+					h->movementPointsRemaining(),
+					heroLockReasonName(lockReason));
+			}
+			else if(h->isGarrisoned())
+			{
+				logAi->debug(
+					"Hero %s ends the turn with %d MP because it is garrisoned.",
+					h->getNameTranslated(),
+					h->movementPointsRemaining());
+			}
+			else
+			{
+				logAi->warn(
+					"Unlocked hero %s ends the turn with %d MP.",
+					h->getNameTranslated(),
+					h->movementPointsRemaining());
+			}
 		}
 
 		endTurn();

--- a/AI/Nullkiller2/Behaviors/DefenceBehavior.cpp
+++ b/AI/Nullkiller2/Behaviors/DefenceBehavior.cpp
@@ -70,6 +70,9 @@ namespace Goals
 
 	bool shouldLockTownDefender(const CGTownInstance & town, const CGHeroInstance & defender, const HitMapInfo & threat, float safeAttackRatio)
 	{
+		if(defender.getOwner() != town.getOwner())
+			return false;
+
 		if(threat.danger == 0 || threat.turn > 1)
 			return false;
 
@@ -81,6 +84,9 @@ namespace Goals
 
 	int countTownThreatsCoveredByDefender(const CGTownInstance & town, const CGHeroInstance & defender, const std::vector<HitMapInfo> & threats, float safeAttackRatio)
 	{
+		if(defender.getOwner() != town.getOwner())
+			return 0;
+
 		int result = 0;
 		const auto townDefence = estimateTownDefence(town, nullptr);
 		const auto defenceWithHero = estimateTownDefence(town, &defender);
@@ -107,6 +113,9 @@ namespace Goals
 
 	bool shouldReserveTownDefender(const CGTownInstance & town, const CGHeroInstance & defender, const std::vector<HitMapInfo> & threats, float safeAttackRatio)
 	{
+		if(defender.getOwner() != town.getOwner())
+			return false;
+
 		const auto townDefence = estimateTownDefence(town, nullptr);
 		const auto defenceWithHero = estimateTownDefence(town, &defender);
 
@@ -183,14 +192,25 @@ namespace
 {
 	constexpr float DEFENSIVE_EMERGENCY_PRIORITY = 1000000.0f;
 
+	const CGHeroInstance * getOwnedTownHero(const CGTownInstance * town, const CGHeroInstance * hero)
+	{
+		return hero && hero->getOwner() == town->getOwner() ? hero : nullptr;
+	}
+
+	bool hasForeignTownHero(const CGTownInstance * town)
+	{
+		return (town->getVisitingHero() && !getOwnedTownHero(town, town->getVisitingHero()))
+			|| (town->getGarrisonHero() && !getOwnedTownHero(town, town->getGarrisonHero()));
+	}
+
 	uint64_t estimateTownMobileDefence(const CGTownInstance * town)
 	{
 		uint64_t result = town->getArmyStrength();
 
-		if(const auto * visitingHero = town->getVisitingHero())
+		if(const auto * visitingHero = getOwnedTownHero(town, town->getVisitingHero()))
 			result = std::max(result, visitingHero->getTotalStrength());
 
-		if(const auto * garrisonHero = town->getGarrisonHero())
+		if(const auto * garrisonHero = getOwnedTownHero(town, town->getGarrisonHero()))
 			result = std::max(result, garrisonHero->getTotalStrength());
 
 		return result;
@@ -211,13 +231,13 @@ namespace
 	{
 		uint64_t result = estimateTownDefence(*town, nullptr);
 
-		if(const auto * garrisonHero = town->getGarrisonHero())
+		if(const auto * garrisonHero = getOwnedTownHero(town, town->getGarrisonHero()))
 		{
 			if(aiNk->getHeroLockedReason(garrisonHero) == HeroLockedReason::DEFENCE)
 				result = std::max(result, estimateTownDefence(*town, garrisonHero));
 		}
 
-		if(const auto * visitingHero = town->getVisitingHero())
+		if(const auto * visitingHero = getOwnedTownHero(town, town->getVisitingHero()))
 		{
 			if(aiNk->getHeroLockedReason(visitingHero) == HeroLockedReason::DEFENCE)
 				result = std::max(result, estimateTownDefence(*town, visitingHero));
@@ -334,7 +354,10 @@ void handleGarrisonReturnCounterAttack(
 	const Nullkiller * aiNk,
 	Goals::TGoalVec & tasks)
 {
-	const auto * garrisonHero = town->getGarrisonHero();
+	if(hasForeignTownHero(town))
+		return;
+
+	const auto * garrisonHero = getOwnedTownHero(town, town->getGarrisonHero());
 
 	if(!garrisonHero)
 		return;
@@ -367,7 +390,10 @@ void handleGarrisonReturnCounterAttack(
 
 bool handleGarrisonHeroFromPreviousTurn(const CGTownInstance * town, Goals::TGoalVec & tasks, const Nullkiller * aiNk, const std::vector<HitMapInfo> & threats)
 {
-	const auto * garrisonHero = town->getGarrisonHero();
+	const auto * garrisonHero = getOwnedTownHero(town, town->getGarrisonHero());
+
+	if(!garrisonHero)
+		return false;
 
 	if(aiNk->isHeroLocked(garrisonHero) || shouldReserveTownDefender(*town, *garrisonHero, threats, aiNk->settings->getSafeAttackRatio()))
 	{
@@ -407,6 +433,9 @@ void DefenceBehavior::evaluateDefence(Goals::TGoalVec & tasks, const CGTownInsta
 
 	auto threatNode = aiNk->dangerHitMap->getObjectThreat(town);
 	std::vector<HitMapInfo> threats = aiNk->dangerHitMap->getTownThreats(town);
+	const auto * visitingHero = getOwnedTownHero(town, town->getVisitingHero());
+	const auto * garrisonHero = getOwnedTownHero(town, town->getGarrisonHero());
+	const bool occupiedByForeignHero = hasForeignTownHero(town);
 	// TODO: Mircea: Why don't we check if there's any danger in threadNode? Maybe map is still unexplored and no danger
 	// or simply no one is around
 	threats.push_back(threatNode.fastestDanger); // no guarantee that fastest danger will be there
@@ -414,7 +443,7 @@ void DefenceBehavior::evaluateDefence(Goals::TGoalVec & tasks, const CGTownInsta
 	for(const auto & threat : threats)
 		handleGarrisonReturnCounterAttack(town, threat, threatNode.maximumDanger, aiNk, tasks);
 
-	if(town->getGarrisonHero() && handleGarrisonHeroFromPreviousTurn(town, tasks, aiNk, threats))
+	if(garrisonHero && handleGarrisonHeroFromPreviousTurn(town, tasks, aiNk, threats))
 		return;
 
 	if(!threatNode.fastestDanger.heroPtr.isVerified())
@@ -471,8 +500,8 @@ void DefenceBehavior::evaluateDefence(Goals::TGoalVec & tasks, const CGTownInsta
 		for(int i = 0; i < paths.size(); i++)
 		{
 			auto & path = paths[i];
-			if(!closestWay || path.movementCost() < closestWay->movementCost())
-				closestWay = &path;
+			if(!path.targetHero)
+				continue;
 
 #if NK2AI_TRACE_LEVEL >= 1
 			logAi->trace(
@@ -486,7 +515,7 @@ void DefenceBehavior::evaluateDefence(Goals::TGoalVec & tasks, const CGTownInsta
 #endif
 
 			const auto * releasedDefender =
-				path.targetHero == town->getVisitingHero() || path.targetHero == town->getGarrisonHero()
+				path.targetHero == visitingHero || path.targetHero == garrisonHero
 				? path.targetHero
 				: nullptr;
 
@@ -498,15 +527,26 @@ void DefenceBehavior::evaluateDefence(Goals::TGoalVec & tasks, const CGTownInsta
 				continue;
 			}
 
+			if(occupiedByForeignHero)
+			{
+#if NK2AI_TRACE_LEVEL >= 1
+				logAi->trace("Can not move %s to defend town %s. Town is occupied by a foreign hero.", path.targetHero->getObjectName(), town->getObjectName());
+#endif
+				continue;
+			}
+
+			if(!closestWay || path.movementCost() < closestWay->movementCost())
+				closestWay = &path;
+
 			const auto townDefenseStrength = estimateTownMobileDefence(town);
 			const bool lockDefenderNow = shouldLockPathDefender(town, threat, path, aiNk);
 
-			if(town->getVisitingHero() && path.targetHero == town->getVisitingHero())
+			if(visitingHero && path.targetHero == visitingHero)
 			{
 				if(path.getHeroStrength() < townDefenseStrength)
 					continue;
 			}
-			else if(town->getGarrisonHero() && path.targetHero == town->getGarrisonHero())
+			else if(garrisonHero && path.targetHero == garrisonHero)
 			{
 				if(path.getHeroStrength() < townDefenseStrength)
 					continue;
@@ -532,19 +572,19 @@ void DefenceBehavior::evaluateDefence(Goals::TGoalVec & tasks, const CGTownInsta
 				continue;
 			}
 
-			if(path.targetHero == town->getVisitingHero() && path.exchangeCount == 1)
+			if(path.targetHero == visitingHero && path.exchangeCount == 1)
 			{
 #if NK2AI_TRACE_LEVEL >= 1
 				logAi->trace("Put %s to garrison of town %s", path.targetHero->getObjectName(), town->getObjectName());
 #endif
 
 				// dismiss creatures we are not able to pick to be able to hide in garrison
-				if(town->getGarrisonHero() || town->getUpperArmy()->stacksCount() == 0 || path.targetHero->canBeMergedWith(*town)
+				if(garrisonHero || town->getUpperArmy()->stacksCount() == 0 || path.targetHero->canBeMergedWith(*town)
 				   || (town->getUpperArmy()->getArmyStrength() < 500 && town->fortLevel() >= CGTownInstance::CITADEL))
 				{
 					Composition composition;
 					composition.addNext(DefendTown(town, threat, path.targetHero))
-						.addNext(ExchangeSwapTownHeroes(town, town->getVisitingHero(), HeroLockedReason::DEFENCE));
+						.addNext(ExchangeSwapTownHeroes(town, visitingHero, HeroLockedReason::DEFENCE));
 
 					setDefensiveEmergencyPriority(composition, lockDefenderNow);
 					tasks.push_back(Goals::sptr(composition));
@@ -554,18 +594,18 @@ void DefenceBehavior::evaluateDefence(Goals::TGoalVec & tasks, const CGTownInsta
 			}
 
 			// main without army and visiting scout with army, very specific case
-			if(town->getVisitingHero() && town->getUpperArmy()->stacksCount() == 0 && path.targetHero != town->getVisitingHero() && path.exchangeCount == 1
-			   && path.turn() == 0 && aiNk->heroManager->evaluateHero(path.targetHero) > aiNk->heroManager->evaluateHero(town->getVisitingHero())
-			   && 10 * path.targetHero->getTotalStrength() < town->getVisitingHero()->getTotalStrength())
+			if(visitingHero && town->getUpperArmy()->stacksCount() == 0 && path.targetHero != visitingHero && path.exchangeCount == 1
+			   && path.turn() == 0 && aiNk->heroManager->evaluateHero(path.targetHero) > aiNk->heroManager->evaluateHero(visitingHero)
+			   && 10 * path.targetHero->getTotalStrength() < visitingHero->getTotalStrength())
 			{
-				path.heroArmy = town->getVisitingHero();
+				path.heroArmy = visitingHero;
 
 				tasks.push_back(
 					Goals::sptr(
 						Composition()
 							.addNext(DefendTown(town, threat, path))
 							.addNextSequence(
-								{sptr(ExchangeSwapTownHeroes(town, town->getVisitingHero())),
+								{sptr(ExchangeSwapTownHeroes(town, visitingHero)),
 								 sptr(ExecuteHeroChain(path, town)),
 								 sptr(ExchangeSwapTownHeroes(town, path.targetHero, HeroLockedReason::DEFENCE))}
 							)
@@ -600,21 +640,21 @@ void DefenceBehavior::evaluateDefence(Goals::TGoalVec & tasks, const CGTownInsta
 			composition.addNext(DefendTown(town, threat, path));
 			TGoalVec sequence;
 
-			if(town->getGarrisonHero() && path.targetHero == town->getGarrisonHero() && path.exchangeCount == 1)
+			if(garrisonHero && path.targetHero == garrisonHero && path.exchangeCount == 1)
 			{
-				composition.addNext(ExchangeSwapTownHeroes(town, town->getGarrisonHero(), HeroLockedReason::DEFENCE));
+				composition.addNext(ExchangeSwapTownHeroes(town, garrisonHero, HeroLockedReason::DEFENCE));
 				setDefensiveEmergencyPriority(composition, lockDefenderNow);
 				tasks.push_back(Goals::sptr(composition));
 
 #if NK2AI_TRACE_LEVEL >= 1
-				logAi->trace("Locking hero %s in garrison of %s", town->getGarrisonHero()->getObjectName(), town->getObjectName());
+				logAi->trace("Locking hero %s in garrison of %s", garrisonHero->getObjectName(), town->getObjectName());
 #endif
 				continue;
 			}
 
-			if(town->getVisitingHero() && path.targetHero != town->getVisitingHero() && !path.containsHero(town->getVisitingHero()))
+			if(visitingHero && path.targetHero != visitingHero && !path.containsHero(visitingHero))
 			{
-				if(town->getGarrisonHero() && town->getGarrisonHero() != path.targetHero)
+				if(garrisonHero && garrisonHero != path.targetHero)
 				{
 #if NK2AI_TRACE_LEVEL >= 1
 					logAi->trace("Cancel moving %s to defend town %s as the town has garrison hero", path.targetHero->getObjectName(), town->getObjectName());
@@ -624,7 +664,7 @@ void DefenceBehavior::evaluateDefence(Goals::TGoalVec & tasks, const CGTownInsta
 
 				if(path.turn() == 0)
 				{
-					sequence.push_back(sptr(ExchangeSwapTownHeroes(town, town->getVisitingHero())));
+					sequence.push_back(sptr(ExchangeSwapTownHeroes(town, visitingHero)));
 				}
 			}
 
@@ -676,6 +716,9 @@ void DefenceBehavior::evaluateDefence(Goals::TGoalVec & tasks, const CGTownInsta
 
 void DefenceBehavior::evaluateRecruitingHero(Goals::TGoalVec & tasks, const HitMapInfo & threat, const CGTownInstance * town, const Nullkiller * aiNk)
 {
+	if(hasForeignTownHero(town))
+		return;
+
 	// TODO: Mircea: Replace with aiNk->heroManager->canRecruitHero(town) but skip limit?
 	if(town->hasBuilt(BuildingID::TAVERN) && aiNk->cc->getResourceAmount(EGameResID::GOLD) > GameConstants::HERO_GOLD_COST)
 	{

--- a/AI/Nullkiller2/Behaviors/DefenceBehavior.cpp
+++ b/AI/Nullkiller2/Behaviors/DefenceBehavior.cpp
@@ -485,6 +485,19 @@ void DefenceBehavior::evaluateDefence(Goals::TGoalVec & tasks, const CGTownInsta
 			);
 #endif
 
+			const auto * releasedDefender =
+				path.targetHero == town->getVisitingHero() || path.targetHero == town->getGarrisonHero()
+				? path.targetHero
+				: nullptr;
+
+			if(aiNk->arePathHeroesLocked(path, releasedDefender))
+			{
+#if NK2AI_TRACE_LEVEL >= 1
+				logAi->trace("Can not move %s to defend town %s. Path is locked.", path.targetHero->getObjectName(), town->getObjectName());
+#endif
+				continue;
+			}
+
 			const auto townDefenseStrength = estimateTownMobileDefence(town);
 			const bool lockDefenderNow = shouldLockPathDefender(town, threat, path, aiNk);
 
@@ -565,15 +578,6 @@ void DefenceBehavior::evaluateDefence(Goals::TGoalVec & tasks, const CGTownInsta
 			const bool heroStrengthCoversThreat = path.turn() <= threat.turn && path.getHeroStrength() >= threat.danger * aiNk->settings->getSafeAttackRatio();
 			if(threat.turn == 0 || lockDefenderNow || heroStrengthCoversThreat)
 			{
-				if(aiNk->arePathHeroesLocked(path))
-				{
-#if NK2AI_TRACE_LEVEL >= 1
-					logAi->trace("Can not move %s to defend town %s. Path is locked.", path.targetHero->getObjectName(), town->getObjectName());
-
-#endif
-					continue;
-				}
-
 				pathsToDefend.push_back(i);
 			}
 		}

--- a/AI/Nullkiller2/Behaviors/EscapeBehavior.cpp
+++ b/AI/Nullkiller2/Behaviors/EscapeBehavior.cpp
@@ -111,6 +111,9 @@ void considerEscapePath(
 	if(threatenedHero == threatenedHeroes.end())
 		return;
 
+	if(aiNk->arePathHeroesLocked(path))
+		return;
+
 	const auto destination = path.targetTile();
 	const auto & currentThreat = threatenedHero->second;
 	const auto & destinationThreat = aiNk->dangerHitMap->getTileThreat(destination).fastestDanger;

--- a/AI/Nullkiller2/Behaviors/GatherArmyBehavior.cpp
+++ b/AI/Nullkiller2/Behaviors/GatherArmyBehavior.cpp
@@ -336,7 +336,15 @@ Goals::TGoalVec GatherArmyBehavior::upgradeArmy(const Nullkiller * aiNk, const C
 
 		if(isSafe)
 		{
-			tasks.push_back(sptr(Composition().addNext(ArmyUpgrade(path, upgrader, upgrade)).addNext(visitGoal)));
+			Composition composition;
+			composition.addNext(ArmyUpgrade(path, upgrader, upgrade));
+
+			if(upgrader->getGarrisonHero() == path.targetHero)
+				composition.addNext(ExchangeSwapTownHeroes(upgrader));
+			else
+				composition.addNext(visitGoal);
+
+			tasks.push_back(sptr(composition));
 		}
 	}
 

--- a/AI/Nullkiller2/Engine/Nullkiller.cpp
+++ b/AI/Nullkiller2/Engine/Nullkiller.cpp
@@ -585,6 +585,7 @@ void Nullkiller::makeTurn()
 	resetState();
 	Goals::TGoalVec tasks;
 	tracePlayerStatus(true);
+	bool resourcesTradedThisTurn = false;
 
 	for(int pass = 1; pass <= settings->getMaxPass() && cc->getPlayerStatus(playerID) == EPlayerStatus::INGAME; pass++)
 	{
@@ -744,7 +745,12 @@ void Nullkiller::makeTurn()
 			}
 		}
 
-		hasAnySuccess |= ResourceTrader::trade(*buildAnalyzer, *cc, getFreeResources());
+		if(!resourcesTradedThisTurn)
+		{
+			resourcesTradedThisTurn = ResourceTrader::trade(*buildAnalyzer, *cc, getFreeResources());
+			hasAnySuccess |= resourcesTradedThisTurn;
+		}
+
 		if(!hasAnySuccess)
 		{
 			if(hasUnlockedHeroWithMovement())

--- a/AI/Nullkiller2/Engine/Nullkiller.cpp
+++ b/AI/Nullkiller2/Engine/Nullkiller.cpp
@@ -408,7 +408,7 @@ const CGHeroInstance * Nullkiller::findRequiredTownDefender(const CGTownInstance
 
 	const auto evaluateHero = [&](const CGHeroInstance * hero)
 	{
-		if(!hero)
+		if(!hero || hero->getOwner() != playerID)
 			return;
 
 		const int coveredThreats = Goals::countTownThreatsCoveredByDefender(*town, *hero, threats, safeAttackRatio);

--- a/AI/Nullkiller2/Engine/Nullkiller.cpp
+++ b/AI/Nullkiller2/Engine/Nullkiller.cpp
@@ -35,13 +35,24 @@ namespace NK2AI
 
 using namespace Goals;
 
+namespace
+{
+constexpr size_t MAX_FAILED_PATHS_PER_HERO = 2;
+}
+
 // while we play vcmieagles graph can be shared
 std::unique_ptr<ObjectGraph> Nullkiller::baseGraph;
 
 Nullkiller::Nullkiller()
 	: activeHero(nullptr)
+	, activeHeroID(ObjectInstanceID::NONE)
+	, targetTile(int3(-1))
+	, activePathHero(nullptr)
+	, activePathHeroID(ObjectInstanceID::NONE)
+	, activePathDestination(int3(-1))
 	, scanDepth(ScanDepth::MAIN_FULL)
 	, useHeroChain(true)
+	, lastTaskFailureHadPath(false)
 	, memory(std::make_unique<AIMemory>())
 {
 
@@ -260,6 +271,8 @@ void Nullkiller::resetState()
 	lockedResources = TResources();
 	scanDepth = ScanDepth::MAIN_FULL;
 	lockedHeroes.clear();
+	failedHeroPaths.clear();
+	resetTaskExecutionContext();
 	dangerHitMap->resetHitmap();
 	useHeroChain = true;
 	objectClusterizer->reset();
@@ -286,8 +299,7 @@ void Nullkiller::updateState()
 	makingTurnInterruption.interruptionPoint();
 	std::unique_lock lockGuard(aiStateMutex);
 
-	activeHero = nullptr;
-	setTargetObject(-1);
+	resetTaskExecutionContext();
 	decomposer->reset();
 
 	buildAnalyzer->update();
@@ -503,6 +515,18 @@ bool Nullkiller::arePathHeroesLocked(const AIPath & path, const CGHeroInstance *
 
 	for(const auto & node : path.nodes)
 	{
+		if(isPathKnownToFail(node))
+		{
+#if NK2AI_TRACE_LEVEL >= 1
+			logAi->trace(
+				"Hero %s already failed to reach %s this turn. Discarding %s",
+				node.targetHero->getObjectName(),
+				node.coord.toString(),
+				path.toString());
+#endif
+			return true;
+		}
+
 		auto lockReason = getHeroLockedReason(node.targetHero);
 
 		if(lockReason != HeroLockedReason::NOT_LOCKED)
@@ -662,7 +686,9 @@ void Nullkiller::makeTurn()
 			{
 				if(!executeTask(selectedTask))
 				{
-					lockTaskHeroes(selectedTask, HeroLockedReason::HERO_CHAIN);
+					if(!lastTaskFailureHadPath)
+						lockTaskHeroes(selectedTask, HeroLockedReason::HERO_CHAIN);
+
 					const bool hasRemainingTasks = selectedTaskIndex + 1 < selectedTasks.size();
 					const auto failureAction = chooseTaskFailureAction(hasAnySuccess, hasRemainingTasks, hasUnlockedHeroWithMovement());
 
@@ -812,10 +838,73 @@ bool Nullkiller::hasUnlockedHeroWithMovement() const
 		});
 }
 
+void Nullkiller::resetTaskExecutionContext()
+{
+	activePathHero = nullptr;
+	activePathHeroID = ObjectInstanceID::NONE;
+	activePathDestination = int3(-1);
+	setActive(nullptr, int3(-1));
+	setTargetObject(-1);
+	lastTaskFailureHadPath = false;
+}
+
+bool Nullkiller::rememberActivePathFailure()
+{
+	if(!activePathHeroID.hasValue() || !activePathDestination.isValid())
+		return false;
+
+	const auto alreadyRemembered = vstd::contains_if(
+		failedHeroPaths,
+		[this](const FailedHeroPath & failedPath)
+		{
+			return failedPath.hero == activePathHeroID && failedPath.destination == activePathDestination;
+		});
+
+	if(!alreadyRemembered)
+		failedHeroPaths.push_back({ activePathHeroID, activePathDestination });
+
+	const size_t heroFailureCount = std::count_if(
+		failedHeroPaths.begin(),
+		failedHeroPaths.end(),
+		[this](const FailedHeroPath & failedPath)
+		{
+			return failedPath.hero == activePathHeroID;
+		});
+
+	if(heroFailureCount >= MAX_FAILED_PATHS_PER_HERO)
+	{
+		lockHero(activePathHero, HeroLockedReason::HERO_CHAIN);
+		logAi->warn(
+			"Hero %d failed %zu different paths. Excluding it from further tasks this turn.",
+			activePathHeroID.getNum(),
+			heroFailureCount);
+	}
+
+	logAi->debug(
+		"Rejecting failed path for hero %d to %s for the rest of this turn.",
+		activePathHeroID.getNum(),
+		activePathDestination.toString());
+	return true;
+}
+
+bool Nullkiller::isPathKnownToFail(const AIPathNodeInfo & node) const
+{
+	if(!node.targetHero)
+		return false;
+
+	return vstd::contains_if(
+		failedHeroPaths,
+		[&node](const FailedHeroPath & failedPath)
+		{
+			return failedPath.hero == node.targetHero->id && failedPath.destination == node.coord;
+		});
+}
+
 bool Nullkiller::executeTask(const Goals::TTask & task)
 {
 	auto start = std::chrono::high_resolution_clock::now();
 	std::string taskDescr = task->toString();
+	resetTaskExecutionContext();
 
 	makingTurnInterruption.interruptionPoint();
 	logAi->debug("Trying to realize %s (value %2.3f)", taskDescr, task->priority);
@@ -831,6 +920,7 @@ bool Nullkiller::executeTask(const Goals::TTask & task)
 	}
 	catch(cannotFulfillGoalException & e)
 	{
+		lastTaskFailureHadPath = rememberActivePathFailure();
 		invalidatePathfinderData();
 		logAi->error("Failed to realize subgoal of type %s.", taskDescr);
 		logAi->error("The error message was: %s", e.what());

--- a/AI/Nullkiller2/Engine/Nullkiller.cpp
+++ b/AI/Nullkiller2/Engine/Nullkiller.cpp
@@ -40,6 +40,23 @@ namespace
 constexpr size_t MAX_FAILED_PATHS_PER_HERO = 2;
 }
 
+const char * heroLockReasonName(HeroLockedReason reason)
+{
+	switch(reason)
+	{
+	case HeroLockedReason::STARTUP:
+		return "startup";
+	case HeroLockedReason::DEFENCE:
+		return "defence";
+	case HeroLockedReason::HERO_CHAIN:
+		return "hero chain";
+	case HeroLockedReason::NOT_LOCKED:
+		return "not locked";
+	}
+
+	return "unknown reason";
+}
+
 // while we play vcmieagles graph can be shared
 std::unique_ptr<ObjectGraph> Nullkiller::baseGraph;
 
@@ -427,7 +444,7 @@ void Nullkiller::reserveRequiredTownDefenders()
 			continue;
 
 		logAi->debug("Reserving %s as defender of %s", defender->getNameTranslated(), town->getNameTranslated());
-		lockedHeroes[defender] = HeroLockedReason::DEFENCE;
+		lockHero(defender, HeroLockedReason::DEFENCE);
 	}
 }
 
@@ -441,6 +458,13 @@ void Nullkiller::lockHero(const CGHeroInstance * hero, HeroLockedReason lockReas
 	if(!hero)
 		return;
 
+	if(getHeroLockedReason(hero) == lockReason)
+		return;
+
+	logAi->debug(
+		"Locking hero %s for %s.",
+		hero->getNameTranslated(),
+		heroLockReasonName(lockReason));
 	lockedHeroes[hero] = lockReason;
 }
 
@@ -448,6 +472,9 @@ void Nullkiller::unlockHero(const CGHeroInstance * hero)
 {
 	if(!hero)
 		return;
+
+	if(getHeroLockedReason(hero) != HeroLockedReason::NOT_LOCKED)
+		logAi->debug("Unlocking hero %s.", hero->getNameTranslated());
 
 	lockedHeroes.erase(hero);
 }
@@ -611,12 +638,24 @@ void Nullkiller::makeTurn()
 			return a->priority > b->priority;
 		});
 
+		bool hasAnySuccess = false;
 		if(selectedTasks.empty())
 		{
-			selectedTasks.push_back(taskptr(Goals::Invalid()));
+			if(hasUnlockedHeroWithMovement() && scanDepth != ScanDepth::ALL_FULL)
+			{
+				logAi->info(
+					"Pass %d: No worthwhile tasks found while unlocked heroes can still move. Increasing to ScanDepth::ALL_FULL",
+					pass);
+				scanDepth = ScanDepth::ALL_FULL;
+				useHeroChain = false;
+				hasAnySuccess = true;
+			}
+			else
+			{
+				logAi->debug("Pass %d: No worthwhile tasks found.", pass);
+			}
 		}
 
-		bool hasAnySuccess = false;
 		for(size_t selectedTaskIndex = 0; selectedTaskIndex < selectedTasks.size(); ++selectedTaskIndex)
 		{
 			const auto & selectedTask = selectedTasks[selectedTaskIndex];
@@ -652,16 +691,10 @@ void Nullkiller::makeTurn()
 
 			if(selectedTask->priority <= 0)
 			{
-				auto heroes = cc->getHeroesInfo();
-				const auto hasMp = vstd::contains_if(heroes, [](const CGHeroInstance * h) -> bool
-					{
-						return h->movementPointsRemaining() > 100;
-					});
-
-				if(hasMp && scanDepth != ScanDepth::ALL_FULL)
+				if(hasUnlockedHeroWithMovement() && scanDepth != ScanDepth::ALL_FULL)
 				{
 					logAi->info(
-						"Pass %d: Heroes can still move but goal %s has too low priority %f. Increasing to ScanDepth::ALL_FULL",
+						"Pass %d: Unlocked heroes can still move but goal %s has too low priority %f. Increasing to ScanDepth::ALL_FULL",
 						pass,
 						taskDescription,
 						selectedTask->priority);
@@ -714,7 +747,11 @@ void Nullkiller::makeTurn()
 		hasAnySuccess |= ResourceTrader::trade(*buildAnalyzer, *cc, getFreeResources());
 		if(!hasAnySuccess)
 		{
-			logAi->trace("Nothing was done this turn pass. Ending turn.");
+			if(hasUnlockedHeroWithMovement())
+				logAi->debug("Pass %d: No worthwhile task was found at full scan depth. AI turn is complete.", pass);
+			else
+				logAi->debug("Pass %d: No unlocked mobile hero remains. AI turn is complete.", pass);
+
 			tracePlayerStatus(false);
 			return;
 		}

--- a/AI/Nullkiller2/Engine/Nullkiller.h
+++ b/AI/Nullkiller2/Engine/Nullkiller.h
@@ -42,6 +42,8 @@ enum class HeroLockedReason
 	HERO_CHAIN = 3
 };
 
+const char * heroLockReasonName(HeroLockedReason reason);
+
 enum class ScanDepth
 {
 	MAIN_FULL = 0,

--- a/AI/Nullkiller2/Engine/Nullkiller.h
+++ b/AI/Nullkiller2/Engine/Nullkiller.h
@@ -81,10 +81,21 @@ TaskFailureAction chooseTaskFailureAction(bool hasAnySuccess, bool hasRemainingT
 class Nullkiller
 {
 private:
+	struct FailedHeroPath
+	{
+		ObjectInstanceID hero;
+		int3 destination;
+	};
+
 	const CGHeroInstance * activeHero;
+	ObjectInstanceID activeHeroID;
 	int3 targetTile;
+	const CGHeroInstance * activePathHero;
+	ObjectInstanceID activePathHeroID;
+	int3 activePathDestination;
 	ObjectInstanceID targetObject;
 	HeroMap<HeroLockedReason> lockedHeroes;
+	std::vector<FailedHeroPath> failedHeroPaths;
 	std::unique_ptr<PathfinderCache> pathfinderCache;
 	ScanDepth scanDepth;
 	TResources lockedResources;
@@ -92,6 +103,7 @@ private:
 	bool openMap;
 	bool useObjectGraph;
 	bool pathfinderInvalidated;
+	bool lastTaskFailureHadPath;
 
 public:
 	static std::unique_ptr<ObjectGraph> baseGraph;
@@ -130,7 +142,19 @@ public:
 	int3 getTargetTile() const { return targetTile; }
 	ObjectInstanceID getTargetObject() const { return targetObject; }
 	void setTargetObject(int objid) { targetObject = ObjectInstanceID(objid); }
-	void setActive(const CGHeroInstance * hero, int3 tile) { activeHero = hero; targetTile = tile; }
+	void setActive(const CGHeroInstance * hero, int3 tile)
+	{
+		if(hero && !activePathHeroID.hasValue())
+		{
+			activePathHero = hero;
+			activePathHeroID = hero->id;
+			activePathDestination = tile;
+		}
+
+		activeHero = hero;
+		activeHeroID = hero ? hero->id : ObjectInstanceID::NONE;
+		targetTile = tile;
+	}
 	void lockHero(const CGHeroInstance * hero, HeroLockedReason lockReason);
 	void unlockHero(const CGHeroInstance * hero);
 	bool canReleaseDefenderForTownCapture(const CGHeroInstance * hero, const CGObjectInstance * target, const AIPath & path) const;
@@ -160,6 +184,9 @@ private:
 	HeroRole getTaskRole(const Goals::TTask & task) const;
 	std::vector<const CGHeroInstance *> getTaskHeroes(const Goals::TTask & task) const;
 	void lockTaskHeroes(const Goals::TTask & task, HeroLockedReason lockReason);
+	void resetTaskExecutionContext();
+	bool rememberActivePathFailure();
+	bool isPathKnownToFail(const AIPathNodeInfo & node) const;
 	bool hasUnlockedHeroWithMovement() const;
 	void tracePlayerStatus(bool beginning) const;
 };

--- a/AI/Nullkiller2/Engine/Nullkiller.h
+++ b/AI/Nullkiller2/Engine/Nullkiller.h
@@ -78,9 +78,13 @@ enum class TaskFailureAction
 
 TaskFailureAction chooseTaskFailureAction(bool hasAnySuccess, bool hasRemainingTasks, bool canReplan);
 
+class NullkillerTaskFailureTestAccess;
+
 class Nullkiller
 {
 private:
+	friend class NullkillerTaskFailureTestAccess;
+
 	struct FailedHeroPath
 	{
 		ObjectInstanceID hero;

--- a/AI/Nullkiller2/Engine/PriorityEvaluator.cpp
+++ b/AI/Nullkiller2/Engine/PriorityEvaluator.cpp
@@ -855,9 +855,11 @@ public:
 			{
 				switch(obj->ID.num)
 				{
+					case Obj::BOAT:
 					case Obj::MONOLITH_ONE_WAY_ENTRANCE:
 					case Obj::MONOLITH_TWO_WAY:
 					case Obj::SUBTERRANEAN_GATE:
+					case Obj::WHIRLPOOL:
 						evaluationContext.explorePriority = 1;
 						break;
 					case Obj::REDWOOD_OBSERVATORY:
@@ -865,7 +867,7 @@ public:
 						evaluationContext.explorePriority = 2;
 						break;
 					default:
-						logAi->warn("ExplorePointEvaluator buildEvaluationContext unknown exploration point %d", obj->ID.num);
+						break;
 				}
 			}
 

--- a/AI/Nullkiller2/Engine/ResourceTrader.cpp
+++ b/AI/Nullkiller2/Engine/ResourceTrader.cpp
@@ -47,7 +47,7 @@ bool ResourceTrader::trade(BuildAnalyzer & buildAnalyzer, CCallback & cc, const 
 		buildAnalyzer.update();
 
 		// if we favor getResourcesRequiredNow is better on short term, if we favor getTotalResourcesRequired is better on long term
-		TResources missingNow = buildAnalyzer.getMissingResourcesNow(ARMY_GOLD_RATIO_PER_MAKE_TURN_PASS);
+		TResources missingNow = buildAnalyzer.getMissingResourcesNow(ARMY_GOLD_RATIO_PER_TURN);
 		if(missingNow.empty())
 			break;
 
@@ -55,7 +55,7 @@ bool ResourceTrader::trade(BuildAnalyzer & buildAnalyzer, CCallback & cc, const 
 		// We don't want to sell something that's necessary later on, though that could make short term a bit harder sometimes
 		// TODO: Mircea: Consider allowing the sale of just a few resources even if necessary long term if critical short term
 		// to buy a capitol for example
-		TResources freeAfterMissingTotal = buildAnalyzer.getFreeResourcesAfterMissingTotal(ARMY_GOLD_RATIO_PER_MAKE_TURN_PASS);
+		TResources freeAfterMissingTotal = buildAnalyzer.getFreeResourcesAfterMissingTotal(ARMY_GOLD_RATIO_PER_TURN);
 
 		logAi->info(
 			"ResourceTrader: Free %s. FreeAfterMissingTotal %s. MissingNow  %s",

--- a/AI/Nullkiller2/Engine/ResourceTrader.h
+++ b/AI/Nullkiller2/Engine/ResourceTrader.h
@@ -17,7 +17,7 @@ class ResourceTrader
 {
 public:
 	// TODO: Mircea: Maybe include based on how close danger is: X as default + proportion of close danger or something around that
-	static constexpr float ARMY_GOLD_RATIO_PER_MAKE_TURN_PASS = 0.1f;
+	static constexpr float ARMY_GOLD_RATIO_PER_TURN = 0.1f;
 	static constexpr float EXPENDABLE_BULK_RATIO = 0.5f;
 
 	static bool trade(BuildAnalyzer & buildAnalyzer, CCallback & cc, const TResources & freeResources);

--- a/AI/Nullkiller2/Goals/BuyArmy.cpp
+++ b/AI/Nullkiller2/Goals/BuyArmy.cpp
@@ -97,9 +97,10 @@ void BuyArmy::accept(AIGateway * aiGw)
 		throw cannotFulfillGoalException("No creatures to buy.");
 	}
 
-	if(town->getVisitingHero() && !town->getGarrisonHero())
+	const auto * visitingHero = town->getVisitingHero();
+	if(visitingHero && visitingHero->getOwner() == aiGw->playerID && !town->getGarrisonHero())
 	{
-		aiGw->moveHeroToTile(town->visitablePos(), HeroPtr(town->getVisitingHero(), aiGw->cc.get()));
+		aiGw->moveHeroToTile(town->visitablePos(), HeroPtr(visitingHero, aiGw->cc.get()));
 	}
 }
 

--- a/AI/Nullkiller2/Goals/ExchangeSwapTownHeroes.cpp
+++ b/AI/Nullkiller2/Goals/ExchangeSwapTownHeroes.cpp
@@ -58,6 +58,16 @@ bool ExchangeSwapTownHeroes::operator==(const ExchangeSwapTownHeroes & other) co
 
 void ExchangeSwapTownHeroes::accept(AIGateway * aiGw)
 {
+	const auto ensureOwnedHero = [aiGw](const CGHeroInstance * candidateHero)
+	{
+		if(candidateHero && candidateHero->getOwner() != aiGw->playerID)
+			throw cannotFulfillGoalException("Can not exchange a hero owned by another player.");
+	};
+
+	ensureOwnedHero(getGarrisonHero());
+	ensureOwnedHero(town->getGarrisonHero());
+	ensureOwnedHero(town->getVisitingHero());
+
 	if(!getGarrisonHero())
 	{
 		auto currentGarrisonHero = town->getGarrisonHero();

--- a/AI/Nullkiller2/Goals/ExecuteHeroChain.cpp
+++ b/AI/Nullkiller2/Goals/ExecuteHeroChain.cpp
@@ -80,6 +80,26 @@ bool executeSpecialAction(
 }
 }
 
+bool Goals::shouldSkipCompletedChainNode(
+	size_t nodeIndex,
+	size_t nodeCount,
+	const int3 & heroPosition,
+	const int3 & nodePosition,
+	const int3 & followingNodePosition,
+	ObjectInstanceID heroWhirlpool,
+	ObjectInstanceID nodeWhirlpool)
+{
+	if(nodeIndex > 0 && heroPosition == nodePosition)
+		return true;
+
+	const bool hasFollowingNode = nodeIndex + 1 < nodeCount;
+	const bool positionChanged = heroPosition != followingNodePosition;
+	return hasFollowingNode
+		&& positionChanged
+		&& heroWhirlpool.hasValue()
+		&& heroWhirlpool == nodeWhirlpool;
+}
+
 ExecuteHeroChain::ExecuteHeroChain(const AIPath & path, const CGObjectInstance * obj)
 	:ElementarGoal(Goals::EXECUTE_HERO_CHAIN), chainPath(path), closestWayRatio(1)
 {
@@ -290,10 +310,21 @@ void ExecuteHeroChain::accept(AIGateway * aiGw)
 
 				auto sourceWhirlpool = findWhirlpool(hero->visitablePos());
 				auto targetWhirlpool = findWhirlpool(node->coord);
+				const int3 followingNodePosition = i + 1 < chainPath.nodes.size()
+					? chainPath.nodes[i + 1].coord
+					: int3(-1);
 
-				if(i != chainPath.nodes.size() - 1 && sourceWhirlpool.hasValue() && sourceWhirlpool == targetWhirlpool)
+				if(shouldSkipCompletedChainNode(
+					i,
+					chainPath.nodes.size(),
+					hero->visitablePos(),
+					node->coord,
+					followingNodePosition,
+					sourceWhirlpool,
+					targetWhirlpool))
 				{
-					logAi->trace("AI exited whirlpool at %s but expected at %s", hero->visitablePos().toString(), node->coord.toString());
+					if(hero->visitablePos() != node->coord)
+						logAi->trace("AI exited whirlpool at %s but expected at %s", hero->visitablePos().toString(), node->coord.toString());
 					continue;
 				}
 

--- a/AI/Nullkiller2/Goals/ExecuteHeroChain.cpp
+++ b/AI/Nullkiller2/Goals/ExecuteHeroChain.cpp
@@ -261,7 +261,7 @@ void ExecuteHeroChain::accept(AIGateway * aiGw)
 							hero->getNameTranslated(),
 							node->coord.toString());
 
-						return;
+						throw cannotFulfillGoalException("Hero chain target is no longer reachable.");
 					}
 
 					if(targetNode->turns != 0)
@@ -273,7 +273,7 @@ void ExecuteHeroChain::accept(AIGateway * aiGw)
 							static_cast<int>(targetNode->turns),
 							hero->movementPointsRemaining());
 
-						return;
+						throw cannotFulfillGoalException("Hero chain target is no longer reachable this turn.");
 					}
 				}
 
@@ -303,6 +303,15 @@ void ExecuteHeroChain::accept(AIGateway * aiGw)
 					{
 						if(moveHeroToTile(aiGw, hero, node->coord))
 						{
+							if(hero->visitablePos() != node->coord)
+							{
+								logAi->debug(
+									"Hero %s completed an interaction towards %s without occupying the tile. Replanning the remaining route.",
+									hero->getNameTranslated(),
+									node->coord.toString());
+								return;
+							}
+
 							continue;
 						}
 					}
@@ -345,7 +354,7 @@ void ExecuteHeroChain::accept(AIGateway * aiGw)
 					node->coord.toString(),
 					hero->visitablePos().toString());
 
-				return;
+				throw cannotFulfillGoalException("Hero did not reach the expected hero chain destination.");
 			}
 			
 			// no exception means we were not able to reach the tile

--- a/AI/Nullkiller2/Goals/ExecuteHeroChain.h
+++ b/AI/Nullkiller2/Goals/ExecuteHeroChain.h
@@ -16,6 +16,15 @@ namespace NK2AI
 {
 namespace Goals
 {
+	bool shouldSkipCompletedChainNode(
+		size_t nodeIndex,
+		size_t nodeCount,
+		const int3 & heroPosition,
+		const int3 & nodePosition,
+		const int3 & followingNodePosition,
+		ObjectInstanceID heroWhirlpool,
+		ObjectInstanceID nodeWhirlpool);
+
 	class DLL_EXPORT ExecuteHeroChain : public ElementarGoal<ExecuteHeroChain>
 	{
 	private:

--- a/AI/Nullkiller2/Pathfinding/Actions/QuestAction.cpp
+++ b/AI/Nullkiller2/Pathfinding/Actions/QuestAction.cpp
@@ -46,6 +46,11 @@ namespace AIPathfinding
 			|| quest->checkQuest(hero);
 	}
 
+	bool QuestAction::needsInitialVisit(const Nullkiller * aiNk, const CGHeroInstance * hero) const
+	{
+		return !questInfo.getQuest(aiNk->cc.get())->isKnownTo(hero->getOwner());
+	}
+
 	Goals::TSubgoal QuestAction::decompose(const Nullkiller * aiNk, const CGHeroInstance * hero) const
 	{
 		return Goals::sptr(Goals::CompleteQuest(questInfo, *aiNk->cc));
@@ -53,7 +58,11 @@ namespace AIPathfinding
 
 	void QuestAction::execute(AIGateway * aiGw, const CGHeroInstance * hero) const
 	{
-		aiGw->moveHeroToTile(questInfo.getObject(aiGw->cc.get())->visitablePos(), HeroPtr(hero, aiGw->cc.get()));
+		const auto * object = questInfo.getObject(aiGw->cc.get());
+		if(!object)
+			throw cannotFulfillGoalException("Quest object is no longer available.");
+
+		aiGw->moveHeroToTile(object->visitablePos(), HeroPtr(hero, aiGw->cc.get()));
 	}
 
 	std::string QuestAction::toString() const

--- a/AI/Nullkiller2/Pathfinding/Actions/QuestAction.h
+++ b/AI/Nullkiller2/Pathfinding/Actions/QuestAction.h
@@ -31,6 +31,7 @@ namespace AIPathfinding
 		bool canAct(const Nullkiller * aiNk, const AIPathNode * node) const override;
 		bool canAct(const Nullkiller * aiNk, const AIPathNodeInfo & node) const override;
 		bool canAct(const Nullkiller * aiNk, const CGHeroInstance * hero) const;
+		bool needsInitialVisit(const Nullkiller * aiNk, const CGHeroInstance * hero) const;
 
 		Goals::TSubgoal decompose(const Nullkiller * aiNk, const CGHeroInstance * hero) const override;
 

--- a/AI/Nullkiller2/Pathfinding/GraphPaths.cpp
+++ b/AI/Nullkiller2/Pathfinding/GraphPaths.cpp
@@ -90,7 +90,8 @@ void GraphPaths::calculatePaths(const CGHeroInstance * targetHero, const Nullkil
 				auto questInfo = QuestInfo(node.obj->id);
 				auto questAction = std::make_shared<AIPathfinding::QuestAction>(questInfo);
 
-				if(!questAction->canAct(aiNk, targetHero))
+				if(questAction->needsInitialVisit(aiNk, targetHero)
+					|| !questAction->canAct(aiNk, targetHero))
 				{
 					transitionAction = questAction;
 				}

--- a/AI/Nullkiller2/Pathfinding/Rules/AIMovementAfterDestinationRule.cpp
+++ b/AI/Nullkiller2/Pathfinding/Rules/AIMovementAfterDestinationRule.cpp
@@ -181,36 +181,37 @@ namespace AIPathfinding
 			return false;
 		}
 
-		if(!questAction.canAct(aiNk, destinationNode))
+		const bool canAct = questAction.canAct(aiNk, destinationNode);
+		if(!canAct && !destinationNode->actor->allowUseResources)
 		{
-			if(!destinationNode->actor->allowUseResources)
+			const std::optional<AIPathNode *> questNode = nodeStorage->getOrCreateNode(
+				destination.coord,
+				destination.node->layer,
+				destinationNode->actor->resourceActor);
+			if (!questNode)
 			{
-				const std::optional<AIPathNode *> questNode = nodeStorage->getOrCreateNode(
-					destination.coord,
-					destination.node->layer,
-					destinationNode->actor->resourceActor);
-				if (!questNode)
-				{
 #if NK2AI_PATHFINDER_TRACE_LEVEL >= 1
-					logAi->warn(
-						"P:Step2B AIMovementAfterDestinationRule::bypassQuest Failed to allocate node at %s[%d]. ",
-						destination.coord.toString(),
-						static_cast<int32_t>(destination.node->layer)
-					);
+				logAi->warn(
+					"P:Step2B AIMovementAfterDestinationRule::bypassQuest Failed to allocate node at %s[%d]. ",
+					destination.coord.toString(),
+					static_cast<int32_t>(destination.node->layer)
+				);
 #endif
-					return false;
-				}
-
-				if(questNode.value()->getCost() < destination.cost)
-				{
-					return false;
-				}
-
-				destination.node = questNode.value();
-				nodeStorage->commit(destination, source);
-				AIPreviousNodeRule(nodeStorage).process(source, destination, pathfinderConfig, pathfinderHelper);
+				return false;
 			}
 
+			if(questNode.value()->getCost() < destination.cost)
+			{
+				return false;
+			}
+
+			destination.node = questNode.value();
+			nodeStorage->commit(destination, source);
+			AIPreviousNodeRule(nodeStorage).process(source, destination, pathfinderConfig, pathfinderHelper);
+		}
+
+		if(questAction.needsInitialVisit(aiNk, destinationNode->actor->hero) || !canAct)
+		{
 			nodeStorage->updateAINode(destination.node, [&](AIPathNode * node)
 			{
 				node->addSpecialAction(std::make_shared<QuestAction>(questAction));

--- a/lib/gameState/CGameState.cpp
+++ b/lib/gameState/CGameState.cpp
@@ -288,6 +288,10 @@ void CGameState::updateEntity(Metatype metatype, int32_t index, const JsonNode &
 void CGameState::updateOnLoad(const StartInfo & si)
 {
 	assert(services);
+	// A save can contain a town that points to a hero assigned elsewhere. Remove stale town links before use.
+	for(auto * town : map->getObjects<CGTownInstance>())
+		town->repairHeroAssignments();
+
 	scenarioOps->playerInfos = si.playerInfos;
 	for(auto & i : si.playerInfos)
 	{

--- a/lib/mapObjects/CGTownInstance.cpp
+++ b/lib/mapObjects/CGTownInstance.cpp
@@ -798,9 +798,27 @@ void CGTownInstance::recreateBuildingsBonuses()
 
 void CGTownInstance::setVisitingHero(CGHeroInstance *h)
 {
-	if(getVisitingHero() == h)
+	if(h && getVisitingHero() == h)
+	{
+		if(h->getVisitedTown() != this || h->isGarrisoned())
+			throw std::runtime_error("Town visiting hero assignment is inconsistent");
 		return;
-	
+	}
+
+	if(visitingHero.hasValue())
+	{
+		auto * oldVisitor = dynamic_cast<CGHeroInstance*>(cb->gameState().getObjInstance(visitingHero));
+		if(!oldVisitor)
+			throw std::runtime_error("Town visiting hero slot does not reference a hero");
+		if(oldVisitor->getVisitedTown() != this || oldVisitor->isGarrisoned())
+			throw std::runtime_error("Town visiting hero assignment is inconsistent");
+
+		oldVisitor->detachFromBonusSystem(cb->gameState());
+		oldVisitor->setVisitedTown(nullptr, false);
+		oldVisitor->attachToBonusSystem(cb->gameState());
+		visitingHero = {};
+	}
+
 	if(h)
 	{
 		h->detachFromBonusSystem(cb->gameState());
@@ -808,21 +826,31 @@ void CGTownInstance::setVisitingHero(CGHeroInstance *h)
 		h->attachToBonusSystem(cb->gameState());
 		visitingHero = h->id;
 	}
-	else if (visitingHero.hasValue())
-	{
-		auto oldVisitor = dynamic_cast<CGHeroInstance*>(cb->gameState().getObjInstance(visitingHero));
-		oldVisitor->detachFromBonusSystem(cb->gameState());
-		oldVisitor->setVisitedTown(nullptr, false);
-		oldVisitor->attachToBonusSystem(cb->gameState());
-		visitingHero = {};
-	}
 }
 
 void CGTownInstance::setGarrisonedHero(CGHeroInstance *h)
 {
-	if(getGarrisonHero() == h)
+	if(h && getGarrisonHero() == h)
+	{
+		if(h->getVisitedTown() != this || !h->isGarrisoned())
+			throw std::runtime_error("Town garrison hero assignment is inconsistent");
 		return;
-	
+	}
+
+	if(garrisonHero.hasValue())
+	{
+		auto * oldVisitor = dynamic_cast<CGHeroInstance*>(cb->gameState().getObjInstance(garrisonHero));
+		if(!oldVisitor)
+			throw std::runtime_error("Town garrison hero slot does not reference a hero");
+		if(oldVisitor->getVisitedTown() != this || !oldVisitor->isGarrisoned())
+			throw std::runtime_error("Town garrison hero assignment is inconsistent");
+
+		oldVisitor->detachFromBonusSystem(cb->gameState());
+		oldVisitor->setVisitedTown(nullptr, false);
+		oldVisitor->attachToBonusSystem(cb->gameState());
+		garrisonHero = {};
+	}
+
 	if(h)
 	{
 		h->detachFromBonusSystem(cb->gameState());
@@ -830,15 +858,39 @@ void CGTownInstance::setGarrisonedHero(CGHeroInstance *h)
 		h->attachToBonusSystem(cb->gameState());
 		garrisonHero = h->id;
 	}
-	else if (garrisonHero.hasValue())
-	{
-		auto oldVisitor = dynamic_cast<CGHeroInstance*>(cb->gameState().getObjInstance(garrisonHero));
-		oldVisitor->detachFromBonusSystem(cb->gameState());
-		oldVisitor->setVisitedTown(nullptr, false);
-		oldVisitor->attachToBonusSystem(cb->gameState());
-		garrisonHero = {};
-	}
+
 	updateMoraleBonusFromArmy(); //avoid giving morale bonus for same army twice
+}
+
+void CGTownInstance::repairHeroAssignments()
+{
+	const auto repairAssignment = [this](ObjectInstanceID & heroId, bool garrisoned, const char * description)
+	{
+		if(!heroId.hasValue())
+			return false;
+
+		auto * hero = dynamic_cast<CGHeroInstance*>(cb->gameState().getObjInstance(heroId));
+		const bool valid = hero
+			&& hero->getVisitedTown() == this
+			&& hero->isGarrisoned() == garrisoned
+			&& hero->visitablePos() == visitablePos();
+		if(valid)
+			return false;
+
+		logGlobal->warn("Removing invalid %s hero assignment from town %d.", description, id);
+		if(hero && hero->getVisitedTown() == this && hero->isGarrisoned() == garrisoned)
+		{
+			hero->detachFromBonusSystem(cb->gameState());
+			hero->setVisitedTown(nullptr, false);
+			hero->attachToBonusSystem(cb->gameState());
+		}
+		heroId = {};
+		return true;
+	};
+
+	repairAssignment(visitingHero, false, "visiting");
+	if(repairAssignment(garrisonHero, true, "garrison"))
+		updateMoraleBonusFromArmy();
 }
 
 const CGHeroInstance * CGTownInstance::getVisitingHero() const

--- a/lib/mapObjects/CGTownInstance.h
+++ b/lib/mapObjects/CGTownInstance.h
@@ -221,6 +221,7 @@ protected:
 	void serializeJsonOptions(JsonSerializeFormat & handler) override;
 
 private:
+	void repairHeroAssignments();
 	FactionID randomizeFaction(vstd::RNG & rand);
 	void setOwner(IGameEventCallback & gameEvents, const PlayerColor & owner) const;
 	void onTownCaptured(IGameEventCallback & gameEvents, const PlayerColor & winner) const;
@@ -228,4 +229,6 @@ private:
 	bool townEnvisagesBuilding(BuildingSubID::EBuildingSubID bid) const;
 	void initializeConfigurableBuildings(IGameRandomizer & gameRandomizer);
 	void initializeNeutralTownGarrison(vstd::RNG & rand);
+
+	friend class CGameState;
 };

--- a/server/battles/BattleProcessor.cpp
+++ b/server/battles/BattleProcessor.cpp
@@ -135,7 +135,7 @@ void BattleProcessor::startBattle(const CArmedInstance *army1, const CArmedInsta
 
 	auto attackerQuery = gameHandler->queries->topQuery(battle->getSide(BattleSide::ATTACKER).color);
 	auto * topBattleQuery = gameHandler->queries->queryAs<CBattleQuery>(attackerQuery);
-	if(!topBattleQuery && army2->getOwner().isValidPlayer())
+	if(!topBattleQuery && battle->getSide(BattleSide::DEFENDER).color.isValidPlayer())
 	{
 		auto defenderQuery = gameHandler->queries->topQuery(battle->getSide(BattleSide::DEFENDER).color);
 		topBattleQuery = gameHandler->queries->queryAs<CBattleQuery>(defenderQuery);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -166,6 +166,7 @@ if(ENABLE_NULLKILLER2_AI)
 		nullkiller2/Helpers/TinyH3MDimensionDoorExplorationTest.cpp
 		nullkiller2/Pathfinding/ArmyLossTest.cpp
 		nullkiller2/Pathfinding/DimensionDoorActionTest.cpp
+		nullkiller2/Pathfinding/QuestActionTest.cpp
 	)
 
 	list(APPEND test_HEADERS

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -160,6 +160,7 @@ if(ENABLE_NULLKILLER2_AI)
 		nullkiller2/Behaviors/GatherArmyBehaviorTest.cpp
 		nullkiller2/Behaviors/RecruitHeroBehaviorTest.cpp
 		nullkiller2/Engine/PriorityEvaluatorTest.cpp
+		nullkiller2/Engine/ResourceTradingTurnTest.cpp
 		nullkiller2/Engine/TaskFailureTest.cpp
 		nullkiller2/Goals/BuyArmyTest.cpp
 		nullkiller2/Goals/CompositionTest.cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -161,6 +161,7 @@ if(ENABLE_NULLKILLER2_AI)
 		nullkiller2/Engine/TaskFailureTest.cpp
 		nullkiller2/Goals/BuyArmyTest.cpp
 		nullkiller2/Goals/CompositionTest.cpp
+		nullkiller2/Goals/ExecuteHeroChainTest.cpp
 		nullkiller2/Goals/ExploreNeighbourTileTest.cpp
 		nullkiller2/Helpers/ExplorationHelperTest.cpp
 		nullkiller2/Helpers/TinyH3MDimensionDoorExplorationTest.cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -156,6 +156,7 @@ if(ENABLE_NULLKILLER2_AI)
 		nullkiller2/Behaviors/DefenceBehaviorTest.cpp
 		nullkiller2/Behaviors/EscapeBehaviorTest.cpp
 		nullkiller2/Behaviors/ExplorationBehaviorTest.cpp
+		nullkiller2/Behaviors/GatherArmyBehaviorTest.cpp
 		nullkiller2/Behaviors/RecruitHeroBehaviorTest.cpp
 		nullkiller2/Engine/PriorityEvaluatorTest.cpp
 		nullkiller2/Engine/TaskFailureTest.cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -37,6 +37,7 @@ set(test_SRCS
 
 		game/BattleSpellCastTest.cpp
 		game/HeroRecruitmentTest.cpp
+		game/TownHeroAssignmentTest.cpp
 
 		json/JsonTests.cpp
 

--- a/test/game/TownHeroAssignmentTest.cpp
+++ b/test/game/TownHeroAssignmentTest.cpp
@@ -1,0 +1,120 @@
+/*
+ * TownHeroAssignmentTest.cpp, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ */
+#include "StdInc.h"
+
+#include "mock/TinyH3MBuilder.h"
+#include "quest/QuestTest.h"
+
+#include "lib/StartInfo.h"
+#include "lib/gameState/CGameState.h"
+#include "lib/mapObjects/CGHeroInstance.h"
+#include "lib/mapObjects/CGTownInstance.h"
+#include "lib/mapping/CMap.h"
+
+namespace
+{
+const PlayerColor PLAYER = PlayerColor(0);
+
+class TownHeroAssignmentTest : public QuestTest
+{
+public:
+	void startGame(int townCount = 1, int heroCount = 1)
+	{
+		const std::array townPositions = {
+			int3(9, 5, 0),
+			int3(20, 5, 0),
+			int3(30, 5, 0)
+		};
+		const std::array heroPositions = {
+			int3(5, 5, 0),
+			int3(6, 5, 0)
+		};
+
+		TinyH3M::TinyH3MBuilder builder(EMapFormat::SOD);
+		builder
+			.size(36, false)
+			.playerActive(PLAYER);
+
+		for(int index = 0; index < townCount; ++index)
+			builder.randomTown(townPositions.at(index), PLAYER);
+
+		for(int index = 0; index < heroCount; ++index)
+			builder.hero(heroPositions.at(index), HeroTypeID(index), PLAYER);
+
+		startWithMap(std::move(builder));
+		towns = findAll<CGTownInstance>();
+		heroes = findAll<CGHeroInstance>();
+	}
+
+	CGTownInstance * town(size_t index = 0)
+	{
+		return towns.at(index);
+	}
+
+	CGHeroInstance * hero(size_t index = 0)
+	{
+		return heroes.at(index);
+	}
+
+	void placeHeroAtTown(size_t heroIndex = 0, size_t townIndex = 0)
+	{
+		hero(heroIndex)->pos = hero(heroIndex)->convertFromVisitablePos(town(townIndex)->visitablePos());
+	}
+
+private:
+	std::vector<CGTownInstance *> towns;
+	std::vector<CGHeroInstance *> heroes;
+};
+}
+
+TEST_F(TownHeroAssignmentTest, loadKeepsValidAssignmentAndRemovesStaleSlot)
+{
+	startGame(3, 2);
+
+	placeHeroAtTown(0, 0);
+	town(0)->setVisitingHero(hero(0));
+	town(1)->setVisitingHero(hero(1));
+	placeHeroAtTown(1, 2);
+	town(2)->setVisitingHero(hero(1));
+
+	gameState->updateOnLoad(StartInfo());
+
+	EXPECT_EQ(town(0)->getVisitingHero(), hero(0));
+	EXPECT_EQ(hero(0)->getVisitedTown(), town(0));
+	EXPECT_EQ(town(1)->getVisitingHero(), nullptr);
+	EXPECT_EQ(town(2)->getVisitingHero(), hero(1));
+	EXPECT_EQ(hero(1)->getVisitedTown(), town(2));
+}
+
+TEST_F(TownHeroAssignmentTest, replacingVisitorDetachesDisplacedHero)
+{
+	startGame(1, 2);
+
+	town()->setVisitingHero(hero(0));
+	town()->setVisitingHero(hero(1));
+
+	EXPECT_EQ(town()->getVisitingHero(), hero(1));
+	EXPECT_EQ(hero(0)->getVisitedTown(), nullptr);
+	EXPECT_EQ(hero(1)->getVisitedTown(), town());
+}
+
+TEST_F(TownHeroAssignmentTest, inconsistentRuntimeAssignmentsThrow)
+{
+	startGame(2, 2);
+
+	town(0)->setVisitingHero(hero(0));
+	town(1)->setVisitingHero(hero(0));
+	town(0)->setGarrisonedHero(hero(1));
+	town(1)->setGarrisonedHero(hero(1));
+
+	EXPECT_THROW(town(0)->setVisitingHero(nullptr), std::runtime_error);
+	EXPECT_THROW(town(0)->setGarrisonedHero(nullptr), std::runtime_error);
+	EXPECT_EQ(town(1)->getVisitingHero(), hero(0));
+	EXPECT_EQ(town(1)->getGarrisonHero(), hero(1));
+}

--- a/test/nullkiller2/Behaviors/DefenceBehaviorTest.cpp
+++ b/test/nullkiller2/Behaviors/DefenceBehaviorTest.cpp
@@ -208,6 +208,22 @@ TEST(Nullkiller2_Behaviors_DefenceBehavior, reserveDefenderIsSkippedForDistantTo
 		<< "safe garrison heroes must stay available for extraction when there is no urgent town threat";
 }
 
+TEST(Nullkiller2_Behaviors_DefenceBehavior, foreignHeroCannotBeReservedForTownDefence)
+{
+	test::TownFake town;
+	town.withBuilding(BuildingID::CASTLE);
+	town.get()->tempOwner = PlayerColor(0);
+
+	CGHeroInstance foreignHero(nullptr);
+	foreignHero.tempOwner = PlayerColor(1);
+	ASSERT_TRUE(foreignHero.setCreature(SlotID(0), CreatureID::ARCHER, 1));
+
+	const auto committedDefence = NK2AI::Goals::estimateTownDefence(*town.get(), &foreignHero);
+	const auto threat = nextTurnThreat(committedDefence - 1);
+
+	EXPECT_FALSE(NK2AI::Goals::shouldReserveTownDefender(*town.get(), foreignHero, { threat }, 1.0f));
+}
+
 TEST(Nullkiller2_Behaviors_DefenceBehavior, sameTurnReturnPathAllowsSimpleRoundTrip)
 {
 	CGHeroInstance defender(nullptr);

--- a/test/nullkiller2/Behaviors/GatherArmyBehaviorTest.cpp
+++ b/test/nullkiller2/Behaviors/GatherArmyBehaviorTest.cpp
@@ -1,0 +1,148 @@
+/*
+ * GatherArmyBehaviorTest.cpp, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ */
+#include "StdInc.h"
+
+#include "AI/Nullkiller2/AIGateway.h"
+#include "AI/Nullkiller2/Behaviors/GatherArmyBehavior.h"
+#include "AI/Nullkiller2/Goals/Composition.h"
+#include "AI/Nullkiller2/Pathfinding/AIPathfinder.h"
+
+#include "mock/TinyH3MBuilder.h"
+#include "quest/QuestTest.h"
+
+#include "lib/CPlayerState.h"
+#include "lib/callback/CCallback.h"
+#include "lib/gameState/CGameState.h"
+#include "lib/mapObjects/CGHeroInstance.h"
+#include "lib/mapObjects/CGTownInstance.h"
+#include "lib/mapping/CMap.h"
+#include "lib/networkPacks/PacksForClient.h"
+
+namespace
+{
+const PlayerColor PLAYER = PlayerColor(0);
+const PlayerColor ENEMY = PlayerColor(1);
+
+TinyH3M::TinyH3MBuilder makeGarrisonUpgradeMap()
+{
+	TinyH3M::TinyH3MBuilder builder(EMapFormat::SOD);
+	builder
+		.size(36, false)
+		.name("NK2GarrisonUpgrade")
+		.playerActive(PLAYER)
+		.playerActive(ENEMY)
+		.randomTown({9, 5, 0}, PLAYER)
+		.hero({5, 5, 0}, HeroTypeID(0), PLAYER)
+		.randomTown({30, 30, 0}, ENEMY);
+
+	return builder;
+}
+
+class Nullkiller2_Behaviors_GatherArmyBehavior : public QuestTest
+{
+public:
+	void putHeroInGarrison(const CGHeroInstance & hero, const CGTownInstance & town)
+	{
+		ChangeObjPos moveHero;
+		moveHero.objid = hero.id;
+		moveHero.nPos = town.visitablePos();
+		moveHero.initiator = PLAYER;
+		gameState->apply(moveHero);
+
+		SetHeroesInTown setHeroes;
+		setHeroes.tid = town.id;
+		setHeroes.visiting = ObjectInstanceID::NONE;
+		setHeroes.garrison = hero.id;
+		gameState->apply(setHeroes);
+	}
+
+	void addUpgradeableArmy(CGHeroInstance & hero, CGTownInstance & town)
+	{
+		const auto & townCreatures = town.getTown()->creatures;
+		const auto level = std::find_if(
+			townCreatures.begin(),
+			townCreatures.end(),
+			[](const std::vector<CreatureID> & creatures)
+			{
+				return creatures.size() > 1;
+			});
+		ASSERT_NE(level, townCreatures.end()) << "test town must provide an upgraded creature";
+
+		const auto levelIndex = std::distance(townCreatures.begin(), level);
+		const CreatureID baseCreature = level->front();
+		const CreatureID upgradedCreature = level->at(1);
+
+		town.addBuilding(BuildingID::getDwellingFromLevel(levelIndex, 1));
+		town.creatures.at(levelIndex).second.push_back(upgradedCreature);
+
+		hero.clearSlots();
+		ASSERT_TRUE(hero.setCreature(SlotID(0), baseCreature, 1000));
+		gameState->players.at(PLAYER).resources += 1000000;
+	}
+
+	std::unique_ptr<NK2AI::AIGateway> makeGateway()
+	{
+		auto gateway = std::make_unique<NK2AI::AIGateway>();
+		gateway->initGameInterface(std::shared_ptr<Environment>(), makeCallback(PLAYER));
+
+		gateway->nullkiller->heroManager->update();
+		NK2AI::PathfinderSettings pathfinderSettings;
+		pathfinderSettings.useHeroChain = true;
+		gateway->nullkiller->pathfinder->updatePaths(
+			gateway->nullkiller->getHeroesForPathfinding(),
+			pathfinderSettings);
+
+		return gateway;
+	}
+};
+}
+
+TEST_F(Nullkiller2_Behaviors_GatherArmyBehavior, planningExtractsGarrisonHeroForUpgrade)
+{
+	startWithMap(makeGarrisonUpgradeMap());
+
+	auto * hero = findHeroByOwner(PLAYER);
+	auto * town = findFirst<CGTownInstance>();
+	ASSERT_NE(hero, nullptr);
+	ASSERT_NE(town, nullptr);
+
+	putHeroInGarrison(*hero, *town);
+	addUpgradeableArmy(*hero, *town);
+
+	const auto gateway = makeGateway();
+	const auto tasks = NK2AI::Goals::GatherArmyBehavior().decompose(gateway->nullkiller.get());
+
+	NK2AI::Goals::TGoalVec upgradeSteps;
+	for(const auto & task : tasks)
+	{
+		if(task->goalType != NK2AI::Goals::COMPOSITION)
+			continue;
+
+		const auto steps = task->decompose(gateway->nullkiller.get());
+		if(std::ranges::any_of(
+			steps,
+			[](const NK2AI::Goals::TSubgoal & step)
+			{
+				return step->goalType == NK2AI::Goals::ARMY_UPGRADE;
+			}))
+		{
+			upgradeSteps = steps;
+			break;
+		}
+	}
+
+	ASSERT_FALSE(upgradeSteps.empty()) << "garrison army should produce an upgrade plan";
+	EXPECT_TRUE(std::ranges::any_of(
+		upgradeSteps,
+		[](const NK2AI::Goals::TSubgoal & step)
+		{
+			return step->goalType == NK2AI::Goals::EXCHANGE_SWAP_TOWN_HEROES;
+		}))
+		<< "the plan must extract the garrison hero so the upgrade changes game state";
+}

--- a/test/nullkiller2/Engine/ResourceTradingTurnTest.cpp
+++ b/test/nullkiller2/Engine/ResourceTradingTurnTest.cpp
@@ -1,0 +1,221 @@
+/*
+ * ResourceTradingTurnTest.cpp, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ */
+#include "StdInc.h"
+
+#include "AI/Nullkiller2/AIGateway.h"
+
+#include "mock/TinyH3MBuilder.h"
+#include "quest/QuestTest.h"
+
+#include "lib/CPlayerState.h"
+#include "lib/callback/CCallback.h"
+#include "lib/callback/IClient.h"
+#include "lib/constants/NumericConstants.h"
+#include "lib/gameState/CGameState.h"
+#include "lib/gameState/TavernHeroesPool.h"
+#include "lib/mapObjects/CGHeroInstance.h"
+#include "lib/mapObjects/CGTownInstance.h"
+#include "lib/mapObjects/army/CSimpleArmy.h"
+#include "lib/mapping/CMap.h"
+#include "lib/networkPacks/PacksForClient.h"
+#include "lib/networkPacks/PacksForServer.h"
+
+namespace
+{
+const PlayerColor PLAYER = PlayerColor(0);
+
+class ApplyingClient : public IClient
+{
+public:
+	std::optional<BattleAction> makeSurrenderRetreatDecision(
+		PlayerColor,
+		const BattleID &,
+		const BattleStateInfoForRetreat &) override
+	{
+		return std::nullopt;
+	}
+
+	int sendRequest(const CPackForServer & request, PlayerColor player, bool) override
+	{
+		if(const auto * trade = dynamic_cast<const TradeOnMarketplace *>(&request))
+			applyTrade(*trade, player);
+		else if(const auto * recruit = dynamic_cast<const RecruitCreatures *>(&request))
+			applyRecruitment(*recruit, player);
+
+		return ++lastRequestID;
+	}
+
+	void setGameState(CGameState * value)
+	{
+		gameState = value;
+	}
+
+	int getMarketplaceTrades() const
+	{
+		return marketplaceTrades;
+	}
+
+	int getTradingPhases() const
+	{
+		return tradingPhases;
+	}
+
+	int getRecruitmentRequests() const
+	{
+		return recruitmentRequests;
+	}
+
+private:
+	void applyTrade(const TradeOnMarketplace & request, PlayerColor player)
+	{
+		ASSERT_NE(gameState, nullptr);
+		ASSERT_EQ(request.mode, EMarketMode::RESOURCE_RESOURCE);
+
+		if(!tradingPhaseActive)
+		{
+			++tradingPhases;
+			tradingPhaseActive = true;
+		}
+
+		const auto * market = gameState->getMarket(request.marketId);
+		ASSERT_NE(market, nullptr);
+		ASSERT_EQ(request.r1.size(), request.r2.size());
+		ASSERT_EQ(request.r1.size(), request.val.size());
+
+		auto & resources = gameState->players.at(player).resources;
+		for(size_t index = 0; index < request.r1.size(); ++index)
+		{
+			const auto soldResource = request.r1[index].as<GameResID>();
+			const auto boughtResource = request.r2[index].as<GameResID>();
+			int givenPerUnit = 0;
+			int receivedPerUnit = 0;
+			market->getOffer(
+				soldResource,
+				boughtResource,
+				givenPerUnit,
+				receivedPerUnit,
+				EMarketMode::RESOURCE_RESOURCE);
+
+			ASSERT_GT(givenPerUnit, 0);
+			ASSERT_GT(receivedPerUnit, 0);
+			ASSERT_EQ(request.val[index] % givenPerUnit, 0);
+
+			resources[soldResource] -= request.val[index];
+			resources[boughtResource] += request.val[index] / givenPerUnit * receivedPerUnit;
+		}
+
+		++marketplaceTrades;
+	}
+
+	void applyRecruitment(const RecruitCreatures & request, PlayerColor player)
+	{
+		ASSERT_NE(gameState, nullptr);
+		auto * town = gameState->getTown(request.tid);
+		ASSERT_NE(town, nullptr);
+		ASSERT_GE(request.level, 0);
+		ASSERT_LT(request.level, static_cast<int>(town->creatures.size()));
+		ASSERT_GE(town->creatures[request.level].first, request.amount);
+
+		town->creatures[request.level].first -= request.amount;
+		gameState->players.at(player).resources -=
+			request.crid.toCreature()->getFullRecruitCost() * request.amount;
+		tradingPhaseActive = false;
+		++recruitmentRequests;
+	}
+
+	CGameState * gameState = nullptr;
+	bool tradingPhaseActive = false;
+	int lastRequestID = 0;
+	int marketplaceTrades = 0;
+	int tradingPhases = 0;
+	int recruitmentRequests = 0;
+};
+
+class ResourceTradingTurnTest : public QuestTest
+{
+public:
+	void startGame()
+	{
+		TinyH3M::TinyH3MBuilder builder(EMapFormat::SOD);
+		builder
+			.size(36, false)
+			.playerActive(PLAYER)
+			.randomTown({9, 5, 0}, PLAYER)
+			.hero({25, 25, 0}, HeroTypeID(0), PLAYER);
+
+		startWithMap(std::move(builder));
+	}
+
+	void prepareTradingCycle(CGTownInstance & town)
+	{
+		NewStructures structures;
+		structures.tid = town.id;
+		for(const auto & building : town.getTown()->buildings)
+			structures.bid.insert(building.first);
+		gameState->apply(structures);
+
+		for(auto & creatureLevel : town.creatures)
+		{
+			if(!creatureLevel.second.empty())
+				creatureLevel.first = 100;
+		}
+
+		auto & resources = gameState->players.at(PLAYER).resources;
+		for(int resource = 0; resource < GameConstants::RESOURCE_QUANTITY; ++resource)
+			resources[resource] = resource == GameResID::GOLD ? 0 : 1000000;
+
+		revealMap(PLAYER);
+
+		CSimpleArmy emptyArmy;
+		gameState->heroesPool->setHeroForPlayer(
+			PLAYER,
+			TavernHeroSlot::NATIVE,
+			HeroTypeID::NONE,
+			emptyArmy,
+			TavernSlotRole::NONE,
+			false);
+		gameState->heroesPool->setHeroForPlayer(
+			PLAYER,
+			TavernHeroSlot::RANDOM,
+			HeroTypeID::NONE,
+			emptyArmy,
+			TavernSlotRole::NONE,
+			false);
+	}
+
+protected:
+	ApplyingClient client;
+};
+}
+
+TEST_F(ResourceTradingTurnTest, tradesForArmyOnlyOncePerTurn)
+{
+	startGame();
+
+	auto * town = findFirst<CGTownInstance>();
+	ASSERT_NE(town, nullptr);
+	auto * hero = findHeroByOwner(PLAYER);
+	ASSERT_NE(hero, nullptr);
+	prepareTradingCycle(*town);
+	SetMovePoints stopHero(hero->id, 0);
+	gameState->apply(stopHero);
+	client.setGameState(gameState.get());
+
+	auto gateway = std::make_unique<NK2AI::AIGateway>();
+	gateway->initGameInterface(std::shared_ptr<Environment>(), makeCallback(PLAYER, &client));
+
+	gateway->nullkiller->makeTurn();
+
+	EXPECT_GT(client.getRecruitmentRequests(), 0)
+		<< "the fixture must consume traded gold by buying army";
+	EXPECT_GT(client.getMarketplaceTrades(), 0)
+		<< "the fixture must fund army purchases through a marketplace";
+	EXPECT_EQ(client.getTradingPhases(), 1)
+		<< "army purchases must not reopen the turn's resource-trading budget";
+}

--- a/test/nullkiller2/Engine/TaskFailureTest.cpp
+++ b/test/nullkiller2/Engine/TaskFailureTest.cpp
@@ -5,43 +5,156 @@
  *
  * License: GNU General Public License v2.0 or later
  * Full text of license available in license.txt file, in main folder
- *
  */
 #include "StdInc.h"
 
+#include "AI/Nullkiller2/AIGateway.h"
+#include "AI/Nullkiller2/Behaviors/EscapeBehavior.h"
 #include "AI/Nullkiller2/Engine/Nullkiller.h"
+#include "AI/Nullkiller2/Goals/CGoal.h"
+#include "AI/Nullkiller2/Goals/ExecuteHeroChain.h"
 
-TEST(Nullkiller2_Engine_TaskFailure, triesNextTaskWhenAnotherCandidateIsAvailable)
+#include "mock/TinyH3MBuilder.h"
+#include "quest/QuestTest.h"
+
+#include "lib/callback/CCallback.h"
+#include "lib/mapObjects/CGHeroInstance.h"
+
+#include <tbb/global_control.h>
+
+namespace NK2AI
 {
-	EXPECT_EQ(
-		NK2AI::chooseTaskFailureAction(false, true, false),
-		NK2AI::TaskFailureAction::TRY_NEXT_TASK);
+class NullkillerTaskFailureTestAccess
+{
+public:
+	static bool executeTask(Nullkiller & ai, const Goals::TTask & task)
+	{
+		return ai.executeTask(task);
+	}
+
+	static void prepareState(Nullkiller & ai)
+	{
+		ai.resetState();
+		ai.updateState();
+	}
+};
 }
 
-TEST(Nullkiller2_Engine_TaskFailure, replansAfterPreviousProgressEvenWithRemainingTasks)
+namespace
 {
-	EXPECT_EQ(
-		NK2AI::chooseTaskFailureAction(true, true, false),
-		NK2AI::TaskFailureAction::REPLAN);
+const PlayerColor PLAYER(0);
+const PlayerColor ENEMY(1);
+
+class FailingMultiNodePathGoal : public NK2AI::Goals::ElementarGoal<FailingMultiNodePathGoal>
+{
+	NK2AI::Nullkiller * nullkiller;
+	const CGHeroInstance * movingHero;
+	int3 destination;
+	int3 failedStep;
+
+public:
+	FailingMultiNodePathGoal(
+		NK2AI::Nullkiller & nullkillerToFail,
+		const CGHeroInstance & heroToMove,
+		const int3 & routeDestination,
+		const int3 & failedRouteStep)
+		: ElementarGoal(NK2AI::Goals::EXECUTE_HERO_CHAIN)
+		, nullkiller(&nullkillerToFail)
+		, movingHero(&heroToMove)
+		, destination(routeDestination)
+		, failedStep(failedRouteStep)
+	{
+	}
+
+	bool operator==(const FailingMultiNodePathGoal & other) const override
+	{
+		return movingHero == other.movingHero
+			&& destination == other.destination
+			&& failedStep == other.failedStep;
+	}
+
+	void accept(NK2AI::AIGateway *) override
+	{
+		nullkiller->setActive(movingHero, destination);
+		nullkiller->setActive(movingHero, failedStep);
+		throw NK2AI::cannotFulfillGoalException("expected route failure");
+	}
+
+	std::string toString() const override
+	{
+		return "FailingMultiNodePathGoal";
+	}
+};
+
+const NK2AI::Goals::ExecuteHeroChain * findHeroChain(
+	const NK2AI::Goals::TGoalVec & goals,
+	const CGHeroInstance * hero)
+{
+	for(const auto & goal : goals)
+	{
+		const auto * chain = dynamic_cast<const NK2AI::Goals::ExecuteHeroChain *>(goal.get());
+		if(chain && chain->getHero() == hero)
+			return chain;
+	}
+
+	return nullptr;
 }
 
-TEST(Nullkiller2_Engine_TaskFailure, replansAfterPreviousProgress)
+class FailedEscapeRouteTest : public QuestTest
 {
-	EXPECT_EQ(
-		NK2AI::chooseTaskFailureAction(true, false, false),
-		NK2AI::TaskFailureAction::REPLAN);
+protected:
+	void startGame()
+	{
+		TinyH3M::TinyH3MBuilder builder(EMapFormat::SOD);
+		builder
+			.size(36, false)
+			.playerActive(PLAYER)
+			.playerActive(ENEMY)
+			.hero({5, 5, 0}, HeroTypeID(0), PLAYER)
+			.heroGarrison({{CreatureID(0), 1}})
+			.hero({7, 5, 0}, HeroTypeID(1), ENEMY)
+			.heroGarrison({{CreatureID(13), 20}});
+
+		startWithMap(std::move(builder));
+	}
+};
 }
 
-TEST(Nullkiller2_Engine_TaskFailure, replansWhenAnotherHeroCanStillMove)
+TEST_F(FailedEscapeRouteTest, replanningAvoidsFailedMultiNodeEscapeRoute)
 {
-	EXPECT_EQ(
-		NK2AI::chooseTaskFailureAction(false, false, true),
-		NK2AI::TaskFailureAction::REPLAN);
-}
+	tbb::global_control singleThread(tbb::global_control::max_allowed_parallelism, 1);
+	startGame();
+	revealMap(PLAYER);
 
-TEST(Nullkiller2_Engine_TaskFailure, stopsWhenNoProgressOrAlternativeExists)
-{
-	EXPECT_EQ(
-		NK2AI::chooseTaskFailureAction(false, false, false),
-		NK2AI::TaskFailureAction::STOP_TURN);
+	auto * escapingHero = findHeroByOwner(PLAYER);
+	auto * threateningHero = findHeroByOwner(ENEMY);
+	ASSERT_NE(escapingHero, nullptr);
+	ASSERT_NE(threateningHero, nullptr);
+	escapingHero->setMovementPoints(2000);
+	threateningHero->setMovementPoints(1000);
+
+	const auto callback = makeCallback(PLAYER);
+	auto gateway = std::make_unique<NK2AI::AIGateway>();
+	gateway->initGameInterface(std::shared_ptr<Environment>(), callback);
+	auto & ai = *gateway->nullkiller;
+	NK2AI::NullkillerTaskFailureTestAccess::prepareState(ai);
+
+	NK2AI::Goals::EscapeBehavior escape;
+	const auto initialGoals = escape.decompose(&ai);
+	const auto * initialChain = findHeroChain(initialGoals, escapingHero);
+	ASSERT_NE(initialChain, nullptr);
+	const int3 failedDestination = initialChain->getPath().targetTile();
+
+	const auto failedTask = NK2AI::Goals::taskptr(FailingMultiNodePathGoal(
+		ai,
+		*escapingHero,
+		failedDestination,
+		escapingHero->visitablePos()));
+	ASSERT_FALSE(NK2AI::NullkillerTaskFailureTestAccess::executeTask(ai, failedTask));
+
+	const auto replannedGoals = escape.decompose(&ai);
+	const auto * replannedChain = findHeroChain(replannedGoals, escapingHero);
+	ASSERT_NE(replannedChain, nullptr);
+	EXPECT_NE(replannedChain->getPath().targetTile(), failedDestination)
+		<< "the failed final destination must not be selected again";
 }

--- a/test/nullkiller2/Goals/BuyArmyTest.cpp
+++ b/test/nullkiller2/Goals/BuyArmyTest.cpp
@@ -8,12 +8,27 @@
  */
 #include "StdInc.h"
 
+#include "AI/Nullkiller2/AIGateway.h"
 #include "AI/Nullkiller2/Goals/BuyArmy.h"
 
+#include "mock/TinyH3MBuilder.h"
+#include "quest/QuestTest.h"
+
+#include "lib/CPlayerState.h"
+#include "lib/callback/CCallback.h"
+#include "lib/callback/IClient.h"
+#include "lib/gameState/CGameState.h"
 #include "lib/mapObjects/CGHeroInstance.h"
+#include "lib/mapObjects/CGTownInstance.h"
+#include "lib/mapping/CMap.h"
+#include "lib/networkPacks/PacksForClient.h"
+#include "lib/networkPacks/PacksForServer.h"
 
 namespace
 {
+const PlayerColor PLAYER = PlayerColor(0);
+const PlayerColor FOREIGN_PLAYER = PlayerColor(1);
+
 void fillFullArmy(CCreatureSet & army)
 {
 	const std::array<CreatureID, GameConstants::ARMY_SIZE> creatures = {
@@ -29,6 +44,61 @@ void fillFullArmy(CCreatureSet & army)
 	for(size_t index = 0; index < creatures.size(); ++index)
 		ASSERT_TRUE(army.setCreature(SlotID(index), creatures[index], 1));
 }
+
+class RecordingClient : public IClient
+{
+public:
+	std::optional<BattleAction> makeSurrenderRetreatDecision(
+		PlayerColor,
+		const BattleID &,
+		const BattleStateInfoForRetreat &) override
+	{
+		return std::nullopt;
+	}
+
+	int sendRequest(const CPackForServer & request, PlayerColor, bool) override
+	{
+		if(dynamic_cast<const MoveHero *>(&request))
+			++moveHeroRequests;
+		return ++lastRequestID;
+	}
+
+	int getMoveHeroRequests() const
+	{
+		return moveHeroRequests;
+	}
+
+private:
+	int lastRequestID = 0;
+	int moveHeroRequests = 0;
+};
+
+class Nullkiller2_Goals_BuyArmyTest : public QuestTest
+{
+public:
+	void startGame()
+	{
+		TinyH3M::TinyH3MBuilder builder(EMapFormat::SOD);
+		builder
+			.size(36, false)
+			.playerActive(PLAYER)
+			.playerActive(FOREIGN_PLAYER)
+			.randomTown({9, 5, 0}, PLAYER)
+			.hero({25, 25, 0}, HeroTypeID(0), FOREIGN_PLAYER);
+
+		startWithMap(std::move(builder));
+	}
+
+	std::unique_ptr<NK2AI::AIGateway> makeGateway()
+	{
+		auto gateway = std::make_unique<NK2AI::AIGateway>();
+		gateway->initGameInterface(std::shared_ptr<Environment>(), makeCallback(PLAYER, &client));
+		return gateway;
+	}
+
+protected:
+	RecordingClient client;
+};
 }
 
 TEST(Nullkiller2_Goals_BuyArmy, fullArmyDoesNotNeedFreeSlotForExistingCreature)
@@ -57,4 +127,32 @@ TEST(Nullkiller2_Goals_BuyArmy, partialArmyDoesNotNeedFreeSlotForMissingCreature
 	EXPECT_FALSE(NK2AI::Goals::BuyArmy::needsFreeSlotToRecruit(
 		&army,
 		CreatureID(8)));
+}
+
+TEST_F(Nullkiller2_Goals_BuyArmyTest, doesNotMoveForeignTownVisitor)
+{
+	startGame();
+
+	auto * town = findFirst<CGTownInstance>();
+	auto * foreignHero = findHeroByOwner(FOREIGN_PLAYER);
+	ASSERT_NE(town, nullptr);
+	ASSERT_NE(foreignHero, nullptr);
+
+	ChangeObjPos moveHero;
+	moveHero.objid = foreignHero->id;
+	moveHero.nPos = town->visitablePos();
+	moveHero.initiator = FOREIGN_PLAYER;
+	gameState->apply(moveHero);
+	town->setVisitingHero(foreignHero);
+
+	ASSERT_FALSE(town->creatures.empty());
+	ASSERT_FALSE(town->creatures.front().second.empty());
+	town->creatures.front().first = 10;
+	gameState->players.at(PLAYER).resources += 1000000;
+
+	const auto gateway = makeGateway();
+	NK2AI::Goals::BuyArmy(town, 1).accept(gateway.get());
+
+	EXPECT_EQ(client.getMoveHeroRequests(), 0)
+		<< "BuyArmy must not issue movement requests for another player's hero";
 }

--- a/test/nullkiller2/Goals/ExecuteHeroChainTest.cpp
+++ b/test/nullkiller2/Goals/ExecuteHeroChainTest.cpp
@@ -1,0 +1,171 @@
+/*
+ * ExecuteHeroChainTest.cpp, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ */
+#include "StdInc.h"
+
+#include "AI/Nullkiller2/AIGateway.h"
+#include "AI/Nullkiller2/Goals/ExecuteHeroChain.h"
+
+#include "mock/TinyH3MBuilder.h"
+#include "quest/QuestTest.h"
+
+#include "lib/callback/IClient.h"
+#include "lib/gameState/CGameState.h"
+#include "lib/mapObjects/CGHeroInstance.h"
+#include "lib/networkPacks/PacksForClient.h"
+#include "lib/networkPacks/PacksForServer.h"
+
+namespace
+{
+const PlayerColor PLAYER(0);
+const ObjectInstanceID WHIRLPOOL(10);
+
+class BlockingVisitClient : public IClient
+{
+public:
+	std::optional<BattleAction> makeSurrenderRetreatDecision(
+		PlayerColor,
+		const BattleID &,
+		const BattleStateInfoForRetreat &) override
+	{
+		return std::nullopt;
+	}
+
+	int sendRequest(const CPackForServer & request, PlayerColor player, bool) override
+	{
+		const auto * movement = dynamic_cast<const MoveHero *>(&request);
+		if(!movement)
+			return ++lastRequestID;
+
+		auto * hero = gameState->getHero(movement->hid);
+		EXPECT_NE(hero, nullptr);
+		EXPECT_FALSE(movement->path.empty());
+		if(!hero || movement->path.empty())
+			return ++lastRequestID;
+
+		TryMoveHero result;
+		result.id = hero->id;
+		result.start = hero->pos;
+		result.end = movement->path.back();
+		result.movePoints = 0;
+		result.result = TryMoveHero::BLOCKING_VISIT;
+		gameState->apply(result);
+		gateway->heroMoved(result, false);
+
+		RemoveObject removeObject(blockingObject, player);
+		gameState->apply(removeObject);
+		++movementRequests;
+		return ++lastRequestID;
+	}
+
+	void connect(CGameState & state, NK2AI::AIGateway & aiGateway, ObjectInstanceID object)
+	{
+		gameState = &state;
+		gateway = &aiGateway;
+		blockingObject = object;
+	}
+
+	int movementRequests = 0;
+
+private:
+	CGameState * gameState = nullptr;
+	NK2AI::AIGateway * gateway = nullptr;
+	ObjectInstanceID blockingObject;
+	int lastRequestID = 0;
+};
+
+NK2AI::AIPathNodeInfo pathNode(
+	const CGHeroInstance & hero,
+	const int3 & coordinate,
+	uint8_t turns)
+{
+	NK2AI::AIPathNodeInfo node{};
+	node.coord = coordinate;
+	node.layer = EPathfindingLayer::LAND;
+	node.targetHero = &hero;
+	node.parentIndex = -1;
+	node.chainMask = 1;
+	node.turns = turns;
+	return node;
+}
+
+class ExecuteHeroChainMovementTest : public QuestTest
+{
+protected:
+	void startGame()
+	{
+		TinyH3M::TinyH3MBuilder builder(EMapFormat::SOD);
+		builder
+			.size(36, false)
+			.playerActive(PLAYER)
+			.hero({6, 5, 0}, HeroTypeID(0), PLAYER)
+			.heroGarrison({{CreatureID(0), 1}})
+			.scroll({6, 5, 0}, SpellID(0));
+
+		startWithMap(std::move(builder));
+	}
+
+	const CGObjectInstance * findScroll() const
+	{
+		for(const auto & object : map->objects)
+		{
+			if(object && object->ID == Obj::SPELL_SCROLL)
+				return object.get();
+		}
+
+		return nullptr;
+	}
+
+	BlockingVisitClient client;
+};
+}
+
+TEST(Nullkiller2_Goals_ExecuteHeroChain, recognizesCompletedAndStalledNodes)
+{
+	const int3 position(10, 10, 0);
+
+	EXPECT_TRUE(NK2AI::Goals::shouldSkipCompletedChainNode(
+		1, 2, position, position, int3(-1), ObjectInstanceID::NONE, ObjectInstanceID::NONE));
+	EXPECT_FALSE(NK2AI::Goals::shouldSkipCompletedChainNode(
+		0, 2, position, int3(11, 11, 0), position, WHIRLPOOL, WHIRLPOOL));
+	EXPECT_TRUE(NK2AI::Goals::shouldSkipCompletedChainNode(
+		0, 2, int3(12, 12, 0), int3(11, 11, 0), position, WHIRLPOOL, WHIRLPOOL));
+}
+
+TEST_F(ExecuteHeroChainMovementTest, blockingVisitIsProgressInsteadOfRouteFailure)
+{
+	startGame();
+
+	auto * hero = findHeroByOwner(PLAYER);
+	const auto * scroll = findScroll();
+	ASSERT_NE(hero, nullptr);
+	ASSERT_NE(scroll, nullptr);
+	const auto startPosition = hero->visitablePos();
+	const auto scrollPosition = scroll->visitablePos();
+	const auto scrollID = scroll->id;
+	hero->setMovementPoints(2000);
+
+	const auto callback = makeCallback(PLAYER, &client);
+	auto gateway = std::make_unique<NK2AI::AIGateway>();
+	gateway->initGameInterface(std::shared_ptr<Environment>(), callback);
+	client.connect(*gameState, *gateway, scrollID);
+
+	NK2AI::AIPath path;
+	path.targetHero = hero;
+	path.heroArmy = hero;
+	path.chainMask = 1;
+	path.nodes.push_back(pathNode(*hero, scrollPosition + int3(2, 0, 0), 1));
+	path.nodes.push_back(pathNode(*hero, scrollPosition + int3(1, 0, 0), 0));
+	path.nodes.push_back(pathNode(*hero, scrollPosition, 0));
+
+	EXPECT_NO_THROW(NK2AI::Goals::ExecuteHeroChain(path).accept(gateway.get()));
+	EXPECT_EQ(client.movementRequests, 1);
+	EXPECT_EQ(gameState->getObjInstance(scrollID), nullptr);
+	EXPECT_EQ(hero->visitablePos(), startPosition);
+	EXPECT_EQ(hero->movementPointsRemaining(), 0);
+}

--- a/test/nullkiller2/Goals/ExploreNeighbourTileTest.cpp
+++ b/test/nullkiller2/Goals/ExploreNeighbourTileTest.cpp
@@ -155,6 +155,11 @@ public:
 		}
 	}
 
+	void setTerrain(const int3 & pos, ETerrainId terrain)
+	{
+		map->getTile(pos).terrainType = TerrainId(terrain);
+	}
+
 	std::shared_ptr<CCallback> makeCallback(PlayerColor player)
 	{
 		return std::make_shared<CCallback>(gameState, std::optional<PlayerColor>{player}, nullptr);
@@ -294,4 +299,24 @@ TEST_F(Nullkiller2_Goals_ExploreNeighbourTileStrategic, ignoresKnownObjectsBefor
 
 	ASSERT_TRUE(target.has_value());
 	EXPECT_EQ(target->tilesDiscovered, 0);
+}
+
+TEST_F(Nullkiller2_Goals_ExploreNeighbourTileStrategic, reportsUnreachableLivePathAsFailure)
+{
+	startWithMap(makeStrategicNeighbourMap());
+
+	auto * hero = findHeroByOwner(PLAYER);
+	ASSERT_NE(hero, nullptr);
+	hero->setMovementPoints(2000);
+
+	const int3 unreachableTile(6, 5, 0);
+	setTerrain(unreachableTile, ETerrainId::ROCK);
+	setAllTilesVisible(PLAYER, true);
+
+	const auto callback = makeCallback(PLAYER);
+	const auto gateway = makeGateway(callback);
+
+	EXPECT_THROW(
+		gateway->moveHeroToTile(unreachableTile, NK2AI::HeroPtr(hero, callback.get())),
+		NK2AI::cannotFulfillGoalException);
 }

--- a/test/nullkiller2/Pathfinding/QuestActionTest.cpp
+++ b/test/nullkiller2/Pathfinding/QuestActionTest.cpp
@@ -1,0 +1,136 @@
+/*
+ * QuestActionTest.cpp, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ */
+#include "StdInc.h"
+
+#include "AI/Nullkiller2/AIGateway.h"
+#include "AI/Nullkiller2/Pathfinding/AIPathfinder.h"
+#include "AI/Nullkiller2/Pathfinding/Actions/QuestAction.h"
+
+#include "mock/TinyH3MBuilder.h"
+#include "quest/QuestTest.h"
+
+#include "lib/callback/CCallback.h"
+#include "lib/mapObjects/CGHeroInstance.h"
+
+namespace
+{
+const PlayerColor PLAYER = PlayerColor(0);
+const int3 HERO_POS(4, 5, 0);
+const int3 GATE_POS(4, 6, 0);
+const int3 TARGET_POS(4, 8, 0);
+
+TinyH3M::TinyH3MBuilder makeGateMap()
+{
+	TinyH3M::TinyH3MBuilder builder(EMapFormat::HOTA);
+	builder
+		.hotaVersion(3)
+		.size(36, false)
+		.name("NK2QuestGate")
+		.playerActive(PLAYER)
+		.hero(HERO_POS + int3(1, 0, 0), HeroTypeID(0), PLAYER)
+		.heroGarrison({{CreatureID(27), 1}})
+		.questGate(GATE_POS + int3(1, 0, 0), TinyH3M::TinyH3MBuilder::missionLevel(1));
+
+	return builder;
+}
+
+class Nullkiller2_Pathfinding_QuestAction : public QuestTest
+{
+public:
+	void revealMapAndEncloseHero()
+	{
+		revealMap(PLAYER);
+
+		for(int dx = -1; dx <= 1; ++dx)
+		{
+			for(int dy = -1; dy <= 1; ++dy)
+			{
+				const int3 tile = HERO_POS + int3(dx, dy, 0);
+				if(tile != HERO_POS && tile != GATE_POS)
+					map->getTile(tile).terrainType = TerrainId(ETerrainId::ROCK);
+			}
+		}
+	}
+
+	std::unique_ptr<NK2AI::AIGateway> makeGateway()
+	{
+		auto gateway = std::make_unique<NK2AI::AIGateway>();
+		gateway->initGameInterface(std::shared_ptr<Environment>(), makeCallback(PLAYER));
+		return gateway;
+	}
+};
+}
+
+TEST_F(Nullkiller2_Pathfinding_QuestAction, addsInitialVisitBeforeCrossingUnopenedGate)
+{
+	startWithMap(makeGateMap());
+	revealMapAndEncloseHero();
+
+	auto * hero = findHeroByOwner(PLAYER);
+	ASSERT_NE(hero, nullptr);
+	ASSERT_EQ(hero->visitablePos(), HERO_POS);
+	const auto gateObject = std::find_if(
+		map->objects.begin(),
+		map->objects.end(),
+		[](const std::shared_ptr<CGObjectInstance> & object)
+		{
+			return object && object->visitablePos() == GATE_POS;
+		});
+	ASSERT_NE(gateObject, map->objects.end());
+	ASSERT_TRUE((*gateObject)->passableFor(hero));
+	const auto gateway = makeGateway();
+
+	NK2AI::HeroMap<NK2AI::HeroRole> heroes;
+	heroes[hero] = NK2AI::HeroRole::MAIN;
+	NK2AI::PathfinderSettings settings;
+	settings.allowBypassObjects = true;
+	gateway->nullkiller->pathfinder->updatePaths(heroes, settings);
+
+	const auto gatePaths = gateway->nullkiller->pathfinder->getPathInfo(GATE_POS);
+	ASSERT_FALSE(gatePaths.empty()) << "the hero must be able to reach the gate";
+	const auto paths = gateway->nullkiller->pathfinder->getPathInfo(TARGET_POS);
+	ASSERT_FALSE(paths.empty()) << "the satisfiable gate should not block planning";
+
+	const auto & path = paths.front();
+	const auto actionNode = std::find_if(
+		path.nodes.begin(),
+		path.nodes.end(),
+		[](const NK2AI::AIPathNodeInfo & node)
+		{
+			return dynamic_cast<const NK2AI::AIPathfinding::QuestAction *>(node.specialAction.get());
+		});
+
+	ASSERT_NE(actionNode, path.nodes.end())
+		<< "an unopened gate must be visited before planning movement through it";
+	EXPECT_FALSE(actionNode->actionIsBlocked);
+}
+
+TEST_F(Nullkiller2_Pathfinding_QuestAction, rejectsActionAfterQuestObjectWasRemoved)
+{
+	startWithMap(makeGateMap());
+
+	auto * hero = findHeroByOwner(PLAYER);
+	ASSERT_NE(hero, nullptr);
+	const auto gateObject = std::find_if(
+		map->objects.begin(),
+		map->objects.end(),
+		[](const std::shared_ptr<CGObjectInstance> & object)
+		{
+			return object && object->visitablePos() == GATE_POS;
+		});
+	ASSERT_NE(gateObject, map->objects.end());
+
+	NK2AI::AIPathfinding::QuestAction questAction(QuestInfo((*gateObject)->id));
+	const auto gateway = makeGateway();
+	(*gateObject).reset();
+
+	EXPECT_THROW(
+		questAction.execute(gateway.get(), hero),
+		NK2AI::cannotFulfillGoalException);
+}

--- a/test/quest/QuestTest.cpp
+++ b/test/quest/QuestTest.cpp
@@ -12,6 +12,7 @@
 #include "QuestTest.h"
 
 #include "../../lib/CPlayerState.h"
+#include "../../lib/callback/CCallback.h"
 #include "../../lib/mapObjects/CGHeroInstance.h"
 #include "../../lib/mapObjects/CGObjectInstance.h"
 
@@ -90,6 +91,22 @@ CGHeroInstance * QuestTest::findHeroByOwner(PlayerColor owner) const
 			return hero;
 	}
 	return nullptr;
+}
+
+void QuestTest::revealMap(PlayerColor player)
+{
+	auto * team = gameState->getPlayerTeam(player);
+	ASSERT_NE(team, nullptr);
+
+	for(int z = 0; z < map->levels(); ++z)
+		for(int x = 0; x < map->width; ++x)
+			for(int y = 0; y < map->height; ++y)
+				team->fogOfWarMap[int3(x, y, z)] = 1;
+}
+
+std::shared_ptr<CCallback> QuestTest::makeCallback(PlayerColor player, IClient * client) const
+{
+	return std::make_shared<CCallback>(gameState, std::optional<PlayerColor>{ player }, client);
 }
 
 void QuestTest::grantResources(PlayerColor player, GameResID which, int amount)

--- a/test/quest/QuestTest.h
+++ b/test/quest/QuestTest.h
@@ -29,6 +29,8 @@
 
 class CGObjectInstance;
 class CGHeroInstance;
+class CCallback;
+class IClient;
 class SeerHut;
 class QuestGuard;
 
@@ -141,6 +143,12 @@ public:
 		}
 		return out;
 	}
+
+	/// Reveal the complete map for one player.
+	void revealMap(PlayerColor player);
+
+	/// Create a player callback over this fixture's game state.
+	std::shared_ptr<CCallback> makeCallback(PlayerColor player, IClient * client = nullptr) const;
 
 	/// Top up a player's stockpile (scenarios start with empty resources).
 	void grantResources(PlayerColor player, GameResID which, int amount);

--- a/test/server/queries/QueriesProcessorTest.cpp
+++ b/test/server/queries/QueriesProcessorTest.cpp
@@ -3,9 +3,19 @@
 #include <gtest/gtest.h>
 
 #include "../../../server/queries/CQuery.h"
+#include "../../../server/battles/BattleProcessor.h"
 #include "../../../server/IGameServer.h"
 #include "../../../server/queries/QueriesProcessor.h"
 #include "CGameHandler.h"
+
+#include "mock/TinyH3MBuilder.h"
+#include "quest/QuestTest.h"
+
+#include "lib/battle/BattleInfo.h"
+#include "lib/gameState/CGameState.h"
+#include "lib/mapObjects/CGCreature.h"
+#include "lib/mapObjects/CGHeroInstance.h"
+#include "lib/mapping/CMap.h"
 
 namespace
 {
@@ -13,6 +23,11 @@ namespace
 class DummyGameServer : public IGameServer
 {
 public:
+	void useGameState(const std::shared_ptr<CGameState> & value)
+	{
+		gameState = value;
+	}
+
 	void setState(EServerState value) override
 	{
 		state = value;
@@ -40,6 +55,8 @@ public:
 
 	void applyPack(CPackForClient & pack) override
 	{
+		if(gameState)
+			gameState->apply(pack);
 	}
 
 	void sendPack(CPackForClient & pack, GameConnectionID connectionID) override
@@ -48,6 +65,7 @@ public:
 
 private:
 	EServerState state{};
+	std::shared_ptr<CGameState> gameState;
 };
 
 enum class QueryEvent
@@ -141,11 +159,58 @@ protected:
 	QueriesProcessor & queries = *gh.queries;
 };
 
+class NeutralDwellingBattleQueryTest : public QuestTest
+{
+protected:
+	void startGame()
+	{
+		TinyH3M::TinyH3MBuilder builder(EMapFormat::SOD);
+		builder
+			.size(36, false)
+			.playerActive(PlayerColor(0))
+			.playerActive(PlayerColor(1))
+			.hero({5, 5, 0}, HeroTypeID(0), PlayerColor(0))
+			.heroGarrison({{CreatureID(0), 10}})
+			.monster({7, 5, 0}, CreatureID(1), 10);
+
+		startWithMap(std::move(builder));
+	}
+};
+
 }
 
 TEST_F(QueriesProcessorTest, topQuery_returnsNullWhenPlayerHasNoQueries)
 {
 	EXPECT_EQ(queries.topQuery(PlayerColor(1)), nullptr);
+}
+
+TEST_F(NeutralDwellingBattleQueryTest, ownedDwellingUsesNeutralBattleSideWithoutNeutralQuery)
+{
+	startGame();
+
+	auto * hero = findHeroByOwner(PlayerColor(0));
+	auto * dwelling = findFirst<CGCreature>();
+	ASSERT_NE(hero, nullptr);
+	ASSERT_NE(dwelling, nullptr);
+	dwelling->ID = Obj::CREATURE_GENERATOR1;
+	dwelling->setOwner(PlayerColor(1));
+
+	DummyGameServer server;
+	server.useGameState(gameState);
+	CGameHandler gh(server, gameState);
+
+	gh.battles->startBattle(hero, dwelling);
+
+	const auto * battle = gameState->getBattle(PlayerColor(0));
+	ASSERT_NE(battle, nullptr);
+	EXPECT_EQ(battle->getSide(BattleSide::DEFENDER).color, PlayerColor::NEUTRAL);
+
+	const auto attackerQuery = gh.queries->topQuery(PlayerColor(0));
+	ASSERT_NE(attackerQuery, nullptr);
+	EXPECT_EQ(attackerQuery->getType(), QueryType::Battle);
+	ASSERT_EQ(attackerQuery->players.size(), 1);
+	EXPECT_EQ(attackerQuery->players.front(), PlayerColor(0));
+	EXPECT_EQ(gh.queries->topQuery(PlayerColor(1)), nullptr);
 }
 
 TEST_F(QueriesProcessorTest, popIfTop_removesTopQuery)
@@ -538,4 +603,3 @@ TEST_F(QueriesProcessorTest, countQuery_returnsZeroForNullptr)
 {
 	EXPECT_EQ(queries.countQuery(nullptr), 0);
 }
-


### PR DESCRIPTION
This is a follow-up to https://github.com/vcmi/vcmi/pull/7573. @GrafDeVan reported a late-game save where every AI player could consume all 500 configured planning passes, with heroes left at full movement. The same action was selected repeatedly because a hero-chain execution failure was treated as successful progress and remained eligible for replanning. @GrafDeVan also noted that messages such as `Invalid has too low priority -1.000000` and `Nothing was done this turn pass. Ending turn.` made it difficult to distinguish normal turn completion from a planning problem, and that the final movement-point warnings did not explain why apparently idle heroes were unavailable.

The Blue loop had a second, more specific cause. Ignissa was enclosed by blocked terrain and could leave only through an unopened Border Gate. The gate requirement was already satisfiable, so Nullkiller planned routes through it as if it were open, while the live pathfinder correctly required a first visit to activate it. Every direct route beyond the gate was therefore impossible to execute.

Two later saves exposed independent pre-existing failures. In `326`, Erdamon stood on a tile shared by a ship and a Whirlpool. Hero-chain execution treated his unchanged position as a successful random Whirlpool exit, so the same Erdamon/Ufretin exchange could be selected again without making progress. In `715`, an owned creature generator fought as a neutral battle side, but battle startup used the object's valid owner as the condition for looking up a query for the neutral defender, triggering the debug assertion in `QueriesProcessor::topQuery()`.

## Changes

- Stale, unreachable, and no-movement hero-chain execution paths now report task failure instead of silently completing.
- Failed hero and destination pairs are rejected for the rest of the turn, allowing the same hero to try a different useful route and allowing other heroes to keep working.
- A hero is excluded from further planning after two distinct execution routes fail, preventing one inconsistent actor from consuming the remaining pass budget without broadly locking every hero in the task.
- Satisfiable but unopened quest gates now add an explicit initial visit action in both regular and object-graph pathfinding, so the hero activates the gate before continuing through it.
- Hero lock and unlock events now include the relevant hero and lock reason, including defenders reserved for threatened towns.
- End-of-turn movement logging now reports whether each unavailable hero is locked for defence, locked for a hero chain, or garrisoned. Only an unlocked hero ending with movement points remains a warning.
- Empty task sets no longer create a synthetic `Invalid` goal. The turn log now distinguishes increasing scan depth, finding no worthwhile task at full depth, and having no unlocked mobile hero left.
- Hero-chain execution now skips an already reached intermediate node and accepts an unexpected tile as a Whirlpool exit only after the hero actually changes position.
- Battle startup checks the actual defender battle-side color before looking up its query, and a query lookup for a non-player side consistently returns no query in debug and release builds.
- Resource trading is now limited to one successful funding phase per AI turn. Planner retries can spend the newly funded army budget, but they cannot repeatedly sell more resources and buy another fraction of the remaining army until `MaxPass`.
- Failed multi-node hero chains retain the original hero and final route destination while intermediate nodes execute. A failed intermediate step therefore suppresses the route that the planner would otherwise select again.
- Exploration-point evaluation gives Boats and Whirlpools their intended strategic priority and silently uses the normal tile-discovery fallback for other visible objects instead of reporting valid frontier points as unknown.
- Explicit quest-gate actions now handle a gate disappearing between planning and execution as a stale task that requires replanning instead of dereferencing a removed object.
- Town defence ignores heroes owned by another player, garrison army upgrades execute through a state-changing town exchange, and load-time repair removes one-sided town visitor or garrison references before AI planning.


## Regression coverage

The route-recovery tests cover unreachable live movement, rejection of an exact failed route, continued availability of alternative heroes and destinations, and bounded exclusion after multiple distinct route failures. With the recovery implementation reverted, the tests still build and fail because the failed route remains eligible and the repeatedly failing hero is not excluded.

The gate test builds a trapped-hero map whose only exit is a satisfiable unopened Quest Gate. It verifies that the planned route contains an executable quest action. With the gate implementation reverted, the test still builds and fails with `an unopened gate must be visited before planning movement through it` because the route incorrectly contains no gate visit.

With unreachable-movement reporting reverted, its regression test still builds and fails because movement returns without throwing the expected `cannotFulfillGoalException`.

The Whirlpool tests cover an already reached chain node, an unchanged entry position, and a real unexpected exit tile. With the fix reverted, the tests still build and fail because the reached node is not skipped and the unchanged entry tile is mistaken for a successful Whirlpool exit.

The battle-query test verifies that looking up the query stack for a neutral battle side returns no query. With the fix reverted, the test still builds and aborts at the same `player.isValidPlayer()` assertion reproduced by `715`.

The resource-trading integration test funds army recruitment through a marketplace and requires exactly one trading phase during the AI turn. With the production fix reverted, the test still builds and fails because five planner passes perform five trading phases instead of one.

The multi-node route test records a final destination followed by an intermediate execution step. With final-destination tracking reverted, the test still builds and fails because the final route remains eligible while the intermediate tile is rejected.

The stale quest-action test removes a planned quest gate before executing its action. With the guard reverted, the test still builds and reproduces the `SIGSEGV` seen during the extended `X_Y` replay; with the guard present, the stale action reports a normal task failure.


## Validation

In @GrafDeVan's `maxpass500` save, Ignissa now visits the Border Gate at `(87,16,0)`, continues toward the Wolf Riders, and Blue ends its turn normally. All eight AI players complete day 145 and day 146 starts with no `MaxPass reached` message at the normal 40-pass limit.

The movement-point cases confirm @GrafDeVan's analysis: Pearl and Jaegar are reserved for defence, while Xyron, Malcom, Sorsha, Ivor, Deemer, Darkstorn, Sinka, Fiona, and the other reported heroes are locked for hero chains. Their end-of-turn log entries now state those reasons directly.

The exact upstream `develop` version reproduces both later failures: `326` repeats the Erdamon/Ufretin exchange 201 times and reaches `MaxPass` five times, while `715` aborts at the neutral-player query assertion. With this branch, `326` advances from day 69 through day 76 without `MaxPass`, and `715` advances from day 173 through day 175 without a crash.

After rebasing onto the reward-limiter crash fix from https://github.com/vcmi/vcmi/pull/7614, `137` completes day 21 and starts day 22 without a crash.

All 18 previously tracked maps and saves attached by @GrafDeVan across the earlier reviews remain green, including both HeroHunting saves, Strange Case, DEFEND or not, LoopQuamarine, Sit in Town, and Treat next-turn town threats. @fatal10110's `414` save and @GrafDeVan's `99` save also advance through complete turns without a crash or MaxPass failure.

In `611`, the replay advanced from day 141 into day 149 with no `MaxPass reached` message. In `643`, it advanced from day 164 into day 172 with no `MaxPass reached` message.

In `217`, Green completes the affected day-35 turn after three planning passes. The repeated Sylvia route is not selected again, no `MaxPass reached` message appears, and the misleading `unknown exploration point` warnings are gone.

The `whirlpools` map from issue #6112 completes the prescribed first two turns without repeating Christian's probabilistic Whirlpool route and without reaching `MaxPass`.

An extended `X_Y` replay exposed a stale quest object after the original town-reference scenario. With the additional guard, both debug and release builds advance through subsequent days without the null-dereference crash, while the original foreign-visitor and `BuyArmy` behavior remains fixed.

The previously reported `maxpass500`, `137`, `244`, `326`, `345`, `715`, and `X_Y` scenarios remain fixed, and all earlier map/save artifacts attached across the review remain green for their reported behavior.

