### PR TITLE
[Fix crash] Skip inactive Seer Hut quests

### DIFF
--- a/AI/Nullkiller2/AIUtility.cpp
+++ b/AI/Nullkiller2/AIUtility.cpp
@@ -661,7 +661,8 @@ bool shouldVisit(const Nullkiller * aiNk, const CGHeroInstance * hero, const CGO
 		{
 			if(source && q == source->getQuestIdentity())
 			{
-				if(q.getQuest(aiNk->cc.get())->checkQuest(hero))
+				const auto * quest = source->getActiveQuest();
+				if(quest && quest->checkQuest(hero))
 					return true; //we completed the quest
 				else
 					return false; //we can't complete this quest

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -150,6 +150,7 @@ endif()
 
 if(ENABLE_NULLKILLER2_AI)
 	list(APPEND test_SRCS
+		nullkiller2/AIUtilityTest.cpp
 		nullkiller2/Analyzers/HeroManagerTest.cpp
 		nullkiller2/Analyzers/ObjectClusterizerTest.cpp
 		nullkiller2/Behaviors/DefenceBehaviorTest.cpp

--- a/test/nullkiller2/AIUtilityTest.cpp
+++ b/test/nullkiller2/AIUtilityTest.cpp
@@ -1,0 +1,70 @@
+/*
+ * AIUtilityTest.cpp, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
+#include "StdInc.h"
+
+#include "AI/Nullkiller2/AIGateway.h"
+#include "AI/Nullkiller2/AIUtility.h"
+
+#include "quest/QuestTest.h"
+
+#include "lib/CPlayerState.h"
+#include "lib/callback/CCallback.h"
+#include "lib/gameState/CGameState.h"
+#include "lib/mapObjects/CGHeroInstance.h"
+#include "lib/mapObjects/Quest.h"
+
+namespace
+{
+const PlayerColor PLAYER = PlayerColor(0);
+const int3 HERO_POS(5, 5, 0);
+const int3 SEER_POS(7, 5, 0);
+
+TinyH3M::TinyH3MBuilder makeQuestlessSeerMap()
+{
+	TinyH3M::TinyH3MBuilder builder(EMapFormat::HOTA);
+	builder
+		.hotaVersion(3)
+		.size(36, false)
+		.name("NK2QuestlessSeer")
+		.playerActive(PLAYER)
+		.randomTown({2, 2, 0}, PLAYER)
+		.hero(HERO_POS, HeroTypeID(0), PLAYER)
+		.seerHutMulti(SEER_POS, {}, {});
+
+	return builder;
+}
+
+class Nullkiller2_AIUtility : public QuestTest
+{
+protected:
+	std::shared_ptr<CCallback> makeCallback() const
+	{
+		return std::make_shared<CCallback>(gameState, std::optional<PlayerColor>{PLAYER}, nullptr);
+	}
+};
+}
+
+TEST_F(Nullkiller2_AIUtility, trackedSeerWithoutActiveQuestIsNotVisitable)
+{
+	ASSERT_NO_FATAL_FAILURE(startWithMap(makeQuestlessSeerMap()));
+
+	const auto * hero = findHeroAt(HERO_POS);
+	const auto * seer = expectAt<SeerHut>(SEER_POS);
+	ASSERT_NE(hero, nullptr);
+	ASSERT_EQ(seer->getActiveQuest(), nullptr);
+
+	gameState->players.at(PLAYER).quests.push_back(seer->getQuestIdentity());
+
+	const auto callback = makeCallback();
+	auto gateway = std::make_unique<NK2AI::AIGateway>();
+	gateway->initGameInterface(std::shared_ptr<Environment>(), callback);
+
+	EXPECT_FALSE(NK2AI::shouldVisit(gateway->nullkiller.get(), hero, seer));
+}


### PR DESCRIPTION
**Root Cause**
The AI retained a Seer Hut identity after another player exhausted its active quest. `shouldVisit()` assumed that matching identity guaranteed a live quest and dereferenced it.

Debug stack:

1. `QuestInfo::getQuest()` at `QuestInfo.cpp:29`
2. `NK2AI::shouldVisit()` at `AIUtility.cpp:664`
3. `ObjectClusterizer::clusterizeObject()` at `ObjectClusterizer.cpp:510`

With assertions disabled, execution continued through the null quest and crashed inside `Rewardable::Limiter::heroAllowed()`, which made the limiter appear responsible.

The full stack is in [7609-stack.txt](https://gist.github.com/starius/d50352a509e9d01167832f626b50ab4b)

**Fix**
`AI/Nullkiller2/AIUtility.cpp:664` now obtains the Seer Hut’s active quest and treats an exhausted source as non-visitable. No defensive null check was added to the reward limiter.

The regression test is separate in `test/nullkiller2/AIUtilityTest.cpp:54`. Reverting only the fix leaves it buildable, then it aborts with status 134 and the original `QuestInfo::getQuest()` assertion.

**Verification**
- Final Debug client and test targets built.
- Final Release client built.
- [BigHopeforYellowAttack](https://github.com/vcmi/vcmi/issues/7584): advanced from day 1000 through day 1002.
- [1117](https://github.com/vcmi/vcmi/issues/7584#issuecomment-4906456399): passed the blue-turn crash and advanced through day 291.
- [1312](https://github.com/vcmi/vcmi/issues/7584#issuecomment-4906456399): passed the blue-turn crash and advanced through day 341.
- [save 414](https://github.com/vcmi/vcmi/pull/7573#issuecomment-5017322167): using its original compatible HotA fixture, advanced from day 89 through day 91.
- No crash markers appeared in any final replay.


Fix #7609