### PR TITLE
Fix eagle eye

### DIFF
--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -862,7 +862,7 @@ void CPlayerInterface::battleEnd(const BattleID & battleID, const BattleResult *
 	{
 		isAutoFightOn = false;
 		unregisterBattleInterface(autofightingAI);
-
+		waitForAllDialogs();		//eagle eye skill can pop up multiple dialogs before the battle
 		if(!battleInt)
 		{
 			bool allowManualReplay = queryID != QueryID::NONE && !isAutoFightEndBattle;
@@ -2062,7 +2062,7 @@ bool CPlayerInterface::capturedAllEvents()
 	}
 
 	bool needToLockAdventureMap = adventureInt && adventureInt->isActive() && GAME->map().hasOngoingAnimations();
-	bool quickCombatOngoing = isAutoFightOn && !battleInt;
+	bool quickCombatWithoutDialogs = isAutoFightOn && !battleInt && !showingDialog->isBusy();
 	bool waitingForQueuedDialogInputToSettle = false;
 	bool waitingForQueuedDialogResolution =
 		!showingDialog->isBusy() &&
@@ -2080,7 +2080,7 @@ bool CPlayerInterface::capturedAllEvents()
 		}
 	}
 
-	if (ignoreEvents || needToLockAdventureMap || quickCombatOngoing || waitingForQueuedDialogResolution || waitingForQueuedDialogInputToSettle)
+	if (ignoreEvents || needToLockAdventureMap || quickCombatWithoutDialogs || waitingForQueuedDialogResolution || waitingForQueuedDialogInputToSettle)
 	{
 		if(!delayQueuedDialogsUntilInputSettles)
 			ENGINE->input().ignoreEventsUntilInput();

--- a/client/NetPacksClient.cpp
+++ b/client/NetPacksClient.cpp
@@ -607,10 +607,8 @@ void ApplyClientNetPackVisitor::visitChangeSpells(ChangeSpells & pack)
 	if(!hero)
 		return;
 
-	if(hero->valOfBonuses(BonusType::LEARN_BATTLE_SPELL_CHANCE_PRE_BATTLE) <= 0)
-		return;
-
-	showEagleEyeLearnedSpellsDialog(cl, pack.hid, pack.spells, hero->tempOwner);
+	if (pack.eagleEyeBonus)
+		showEagleEyeLearnedSpellsDialog(cl, pack.hid, pack.spells, hero->tempOwner);
 }
 
 void ApplyClientNetPackVisitor::visitSetHeroesInTown(SetHeroesInTown & pack)

--- a/lib/networkPacks/PacksForClient.h
+++ b/lib/networkPacks/PacksForClient.h
@@ -353,12 +353,14 @@ struct DLL_LINKAGE ChangeSpells : public CPackForClient
 	ui8 learn = 1; //1 - gives spell, 0 - takes
 	ObjectInstanceID hid;
 	std::set<SpellID> spells;
+	bool eagleEyeBonus = false;
 
 	template <typename Handler> void serialize(Handler & h)
 	{
 		h & learn;
 		h & hid;
 		h & spells;
+		h & eagleEyeBonus;
 	}
 };
 

--- a/server/battles/BattleFlowProcessor.cpp
+++ b/server/battles/BattleFlowProcessor.cpp
@@ -136,47 +136,10 @@ void BattleFlowProcessor::onBattleStarted(const CBattleInfoCallback & battle)
 {
 	tryPlaceMoats(battle);
 
-	tryLearnEnemySpellsPreBattle(battle, BattleSide::ATTACKER);
-	tryLearnEnemySpellsPreBattle(battle, BattleSide::DEFENDER);
-
 	gameHandler->turnTimerHandler->onBattleStart(battle.getBattle()->getBattleID());
 
 	if (battle.battleGetTacticDist() == 0)
 		onTacticsEnded(battle);
-}
-
-void BattleFlowProcessor::tryLearnEnemySpellsPreBattle(const CBattleInfoCallback & battle, BattleSide side)
-{
-	const auto * learner = battle.battleGetFightingHero(side);
-	const auto * enemy = battle.battleGetFightingHero(battle.otherSide(side));
-
-	if(!learner || !enemy || !learner->hasSpellbook())
-		return;
-
-	const auto eagleEyeLevel = learner->valOfBonuses(BonusType::LEARN_BATTLE_SPELL_LEVEL_LIMIT_PRE_BATTLE);
-	if(eagleEyeLevel <= 0)
-		return;
-
-	const auto eagleEyeChance = learner->valOfBonuses(BonusType::LEARN_BATTLE_SPELL_CHANCE_PRE_BATTLE);
-	if(eagleEyeChance <= 0)
-		return;
-
-	ChangeSpells learnedSpells;
-	learnedSpells.learn = true;
-	learnedSpells.hid = learner->id;
-
-	for(const auto spellID : enemy->getSpellsInSpellbook())
-	{
-		const auto * spell = spellID.toSpell();
-		if(!spell)
-			continue;
-
-		if(spell->getLevel() <= eagleEyeLevel && !learner->spellbookContainsSpell(spell->getId()) && gameHandler->getRandomGenerator().nextInt(99) < eagleEyeChance)
-			learnedSpells.spells.insert(spell->getId());
-	}
-
-	if(!learnedSpells.spells.empty())
-		gameHandler->sendAndApply(learnedSpells);
 }
 
 void BattleFlowProcessor::trySummonGuardians(const CBattleInfoCallback & battle, const CStack * stack)

--- a/server/battles/BattleFlowProcessor.h
+++ b/server/battles/BattleFlowProcessor.h
@@ -45,7 +45,6 @@ class BattleFlowProcessor : boost::noncopyable
 	bool tryMakeAutomaticActionOfFirstAidTent(const CBattleInfoCallback & battle, const CStack * stack);
 
 	void summonGuardiansHelper(const CBattleInfoCallback & battle, BattleHexArray & output, const BattleHex & targetPosition, BattleSide side, bool targetIsTwoHex);
-	void tryLearnEnemySpellsPreBattle(const CBattleInfoCallback & battle, BattleSide side);
 	void trySummonGuardians(const CBattleInfoCallback & battle, const CStack * stack);
 	void tryPlaceMoats(const CBattleInfoCallback & battle);
 	void castOpeningSpells(const CBattleInfoCallback & battle);

--- a/server/battles/BattleProcessor.cpp
+++ b/server/battles/BattleProcessor.cpp
@@ -176,6 +176,7 @@ void BattleProcessor::tryLearnEnemySpellsPreBattle(const BattleInfo * battle, Ba
 		return;
 
 	ChangeSpells learnedSpells;
+	learnedSpells.eagleEyeBonus = true;
 	learnedSpells.learn = true;
 	learnedSpells.hid = learner->id;
 

--- a/server/battles/BattleProcessor.cpp
+++ b/server/battles/BattleProcessor.cpp
@@ -34,6 +34,7 @@
 #include "../../lib/networkPacks/PacksForClient.h"
 #include "../../lib/networkPacks/PacksForClientBattle.h"
 #include "../../lib/CPlayerState.h"
+#include "../../lib/spells/CSpell.h"
 #include <vstd/RNG.h>
 
 BattleProcessor::BattleProcessor(CGameHandler * gameHandler)
@@ -102,11 +103,11 @@ void BattleProcessor::restartBattle(const BattleID & battleID, const CArmedInsta
 	bc.battleID = battleID;
 	gameHandler->sendAndApply(bc);
 
-	startBattle(army1, army2, tile, hero1, hero2, layout, town);
+	startBattle(army1, army2, tile, hero1, hero2, layout, town, true);
 }
 
 void BattleProcessor::startBattle(const CArmedInstance *army1, const CArmedInstance *army2, int3 tile,
-								const CGHeroInstance *hero1, const CGHeroInstance *hero2, const BattleLayout & layout, const CGTownInstance *town)
+								const CGHeroInstance *hero1, const CGHeroInstance *hero2, const BattleLayout & layout, const CGTownInstance *town, bool restarted)
 {
 	assert(gameHandler->gameState().getBattle(army1->getOwner()) == nullptr);
 	assert(gameHandler->gameState().getBattle(army2->getOwner()) == nullptr);
@@ -149,7 +150,47 @@ void BattleProcessor::startBattle(const CArmedInstance *army1, const CArmedInsta
 		gameHandler->queries->addQuery(newBattleQuery);
 	}
 
+	if (!restarted)
+	{
+		tryLearnEnemySpellsPreBattle(battle, BattleSide::ATTACKER);
+		tryLearnEnemySpellsPreBattle(battle, BattleSide::DEFENDER);
+	}
+
 	flowProcessor->onBattleStarted(*battle);
+}
+
+void BattleProcessor::tryLearnEnemySpellsPreBattle(const BattleInfo * battle, BattleSide side)
+{
+	const auto * learner = battle->battleGetFightingHero(side);
+	const auto * enemy = battle->battleGetFightingHero(battle->otherSide(side));
+
+	if(!learner || !enemy || !learner->hasSpellbook())
+		return;
+
+	const auto eagleEyeLevel = learner->valOfBonuses(BonusType::LEARN_BATTLE_SPELL_LEVEL_LIMIT_PRE_BATTLE);
+	if(eagleEyeLevel <= 0)
+		return;
+
+	const auto eagleEyeChance = learner->valOfBonuses(BonusType::LEARN_BATTLE_SPELL_CHANCE_PRE_BATTLE);
+	if(eagleEyeChance <= 0)
+		return;
+
+	ChangeSpells learnedSpells;
+	learnedSpells.learn = true;
+	learnedSpells.hid = learner->id;
+
+	for(const auto spellID : enemy->getSpellsInSpellbook())
+	{
+		const auto * spell = spellID.toSpell();
+		if(!spell)
+			continue;
+
+		if(spell->getLevel() <= eagleEyeLevel && !learner->spellbookContainsSpell(spell->getId()) && gameHandler->getRandomGenerator().nextInt(99) < eagleEyeChance)
+			learnedSpells.spells.insert(spell->getId());
+	}
+
+	if(!learnedSpells.spells.empty())
+		gameHandler->sendAndApply(learnedSpells);
 }
 
 void BattleProcessor::startBattle(const CArmedInstance *army1, const CArmedInstance *army2)

--- a/server/battles/BattleProcessor.h
+++ b/server/battles/BattleProcessor.h
@@ -28,6 +28,7 @@ class CBattleQuery;
 class BattleActionProcessor;
 class BattleFlowProcessor;
 class BattleResultProcessor;
+class BattleInfo;
 
 /// Main class for battle handling. Contains all public interface for battles that is accessible from outside, e.g. for CGameHandler
 class BattleProcessor : boost::noncopyable
@@ -56,11 +57,12 @@ public:
 	~BattleProcessor();
 
 	/// Starts battle with specified parameters
-	void startBattle(const CArmedInstance *army1, const CArmedInstance *army2, int3 tile, const CGHeroInstance *hero1, const CGHeroInstance *hero2, const BattleLayout & layout, const CGTownInstance *town);
+	void startBattle(const CArmedInstance *army1, const CArmedInstance *army2, int3 tile, const CGHeroInstance *hero1, const CGHeroInstance *hero2, const BattleLayout & layout, const CGTownInstance *town, bool restarted = false);
 	/// Starts battle between two armies (which can also be heroes) at position of 2nd object
 	void startBattle(const CArmedInstance *army1, const CArmedInstance *army2);
 	/// Restart ongoing battle and end previous battle
 	void restartBattle(const BattleID & battleID, const CArmedInstance *army1, const CArmedInstance *army2, int3 tile, const CGHeroInstance *hero1, const CGHeroInstance *hero2, const BattleLayout & layout, const CGTownInstance *town);
+	void tryLearnEnemySpellsPreBattle(const BattleInfo * battle, BattleSide side);
 
 	/// Processing of incoming battle action netpack
 	bool makePlayerBattleAction(const BattleID & battleID, PlayerColor player, const BattleAction & ba);

--- a/server/battles/BattleResultProcessor.cpp
+++ b/server/battles/BattleResultProcessor.cpp
@@ -490,6 +490,7 @@ void BattleResultProcessor::battleFinalize(const BattleID & battleID, const Batt
 		// Eagle Eye handling
 		if(auto eagleEyeLevel = winnerHero->valOfBonuses(BonusType::LEARN_BATTLE_SPELL_LEVEL_LIMIT))
 		{
+			resultsApplied.learnedSpells.eagleEyeBonus = true;
 			resultsApplied.learnedSpells.learn = 1;
 			resultsApplied.learnedSpells.hid = finishingBattle->winnerId;
 			for(const auto & spellId : (*battle)->getUsedSpells(CBattleInfoEssentials::otherSide(result.winner)))


### PR DESCRIPTION
Fixes two bugs related to pre-battle eagle eye.

1. Battle end screen is displayed on eagle eye dialog.

[Screencast From 2026-07-21 17-30-45.webm](https://github.com/user-attachments/assets/6c81e360-43b7-4335-932d-c39520b46a0f)

I made the battle end screen wait for all dialogs to be clicked through and I unlocked screen if a dialog is displayed even if an automatic battle is ongoing.
I think it is the best solution: screen stays responsive, automatic battle is not blocked, but battle end screen won't pop up until all dialogs are discarded.

2. A hero can be granted spells by pre-battle eagle eye skill two times if automatic battle is repeated (played manually).
Granting spells had to be moved from BattleFlowProcessor to BattleProcessor.  

Edit: A third bug fixed:
Eagle eye dialog is displayed when a hero with eagle eye skill learns new spells through a magic school.