### PR TITLE
Fix damaging spells updating creature count before animation plays (regression)

### DIFF
--- a/client/battle/BattleStacksController.cpp
+++ b/client/battle/BattleStacksController.cpp
@@ -296,7 +296,7 @@ std::shared_ptr<IImage> BattleStacksController::getStackAmountBox(const CStack *
 
 void BattleStacksController::showStackAmountBox(Canvas & canvas, const CStack * stack)
 {
-	auto amountBG = getStackAmountBox(stack);
+	auto amountBG = getDisplayedStackAmountBox(stack);
 
 	bool doubleWide = stack->doubleWide();
 	bool turnedRight = facingRight(stack);
@@ -450,7 +450,7 @@ void BattleStacksController::stackRemoved(uint32_t stackID)
 
 void BattleStacksController::lockStackAmountBox(const CStack * stack)
 {
-	displayedStackSnapshot.try_emplace(stack->unitId(), DisplayedStackSnapshot{stack->getCount(), stack->getAvailableHealth()});
+	displayedStackSnapshot.try_emplace(stack->unitId(), DisplayedStackSnapshot{stack->getCount(), stack->getAvailableHealth(), getStackAmountBox(stack)});
 }
 
 void BattleStacksController::unlockStackAmountBox(uint32_t stackID)
@@ -472,6 +472,14 @@ int64_t BattleStacksController::getDisplayedStackHealth(const CStack * stack) co
 	if(it != displayedStackSnapshot.end())
 		return it->second.availableHealth;
 	return stack->getAvailableHealth();
+}
+
+std::shared_ptr<IImage> BattleStacksController::getDisplayedStackAmountBox(const CStack * stack)
+{
+	auto it = displayedStackSnapshot.find(stack->unitId());
+	if(it != displayedStackSnapshot.end())
+		return it->second.amountBox;
+	return getStackAmountBox(stack);
 }
 
 void BattleStacksController::stacksAreAttacked(std::vector<StackAttackedInfo> attackedInfos)

--- a/client/battle/BattleStacksController.cpp
+++ b/client/battle/BattleStacksController.cpp
@@ -330,19 +330,21 @@ void BattleStacksController::showStackAmountBox(Canvas & canvas, const CStack * 
 
 	Point textPosition = Point(amountBG->dimensions().x/2 + boxPosition.x, boxPosition.y + amountBG->dimensions().y/2);
 
+	int32_t displayedCount = getDisplayedStackAmount(stack);
+
 	if(settings["battle"]["showHealthBar"].Bool())
 	{
 		double healthMaxType = stack->unitType()->getMaxHealth();
 		double healthMaxStack = stack->getMaxHealth();
 		double healthMaxRatio = std::min(healthMaxStack / healthMaxType, 1.0);
-		double healthRemaining = std::max(stack->getAvailableHealth() - (stack->getCount() - 1) * healthMaxStack, .0) * healthMaxRatio;
+		double healthRemaining = std::max(getDisplayedStackHealth(stack) - (displayedCount - 1) * healthMaxStack, .0) * healthMaxRatio;
 		Rect r(boxPosition.x, boxPosition.y - 3, amountBG->width(), 4);
 		canvas.drawColor(r, Colors::RED);
 		canvas.drawColor(Rect(r.x, r.y, (r.w / healthMaxStack) * healthRemaining, r.h), Colors::GREEN);
 		canvas.drawBorder(r, Colors::YELLOW);
 	}
 	canvas.draw(amountBG, boxPosition);
-	canvas.drawText(textPosition, EFonts::FONT_TINY, Colors::WHITE, ETextAlignment::CENTER, TextOperations::formatMetric(stack->getCount(), 4));
+	canvas.drawText(textPosition, EFonts::FONT_TINY, Colors::WHITE, ETextAlignment::CENTER, TextOperations::formatMetric(displayedCount, 4));
 }
 
 void BattleStacksController::showStack(Canvas & canvas, const CStack * stack)
@@ -446,8 +448,40 @@ void BattleStacksController::stackRemoved(uint32_t stackID)
 		startFade();
 }
 
+void BattleStacksController::lockStackAmountBox(const CStack * stack)
+{
+	displayedStackSnapshot.try_emplace(stack->unitId(), DisplayedStackSnapshot{stack->getCount(), stack->getAvailableHealth()});
+}
+
+void BattleStacksController::unlockStackAmountBox(uint32_t stackID)
+{
+	displayedStackSnapshot.erase(stackID);
+}
+
+int32_t BattleStacksController::getDisplayedStackAmount(const CStack * stack) const
+{
+	auto it = displayedStackSnapshot.find(stack->unitId());
+	if(it != displayedStackSnapshot.end())
+		return it->second.count;
+	return stack->getCount();
+}
+
+int64_t BattleStacksController::getDisplayedStackHealth(const CStack * stack) const
+{
+	auto it = displayedStackSnapshot.find(stack->unitId());
+	if(it != displayedStackSnapshot.end())
+		return it->second.availableHealth;
+	return stack->getAvailableHealth();
+}
+
 void BattleStacksController::stacksAreAttacked(std::vector<StackAttackedInfo> attackedInfos)
 {
+	const bool hitPlayedSynchronously = currentAnimations.empty() && !owner.hasQueuedStage(EAnimationEvents::BEFORE_HIT);
+	if(!hitPlayedSynchronously)
+		for(const auto & attackedInfo : attackedInfos)
+			if(!attackedInfo.killed)
+				lockStackAmountBox(attackedInfo.defender);
+
 	owner.addToAnimationStage(EAnimationEvents::HIT, [this](){
 		// remove any potentially erased petrification effect
 		removeExpiredColorFilters();
@@ -491,6 +525,8 @@ void BattleStacksController::stacksAreAttacked(std::vector<StackAttackedInfo> at
 
 		owner.addToAnimationStage(usedEvent, [this, attackedInfo, useDeathAnim, useDefenceAnim]()
 		{
+			unlockStackAmountBox(attackedInfo.defender->unitId());
+
 			if (useDeathAnim)
 				addNewAnim(new DeathAnimation(owner, attackedInfo.defender, attackedInfo.indirectAttack));
 			else if(useDefenceAnim)
@@ -530,9 +566,11 @@ void BattleStacksController::stacksAreAttacked(std::vector<StackAttackedInfo> at
 			});
 		}
 	}
-	// while a spell cast is queued/playing, let it drive and batch the hit stage (endAction does the final sync)
-	// so per-unit damage packs (e.g. chain lightning) play together instead of one-by-one
-	if(currentAnimations.empty() && !owner.hasQueuedStage(EAnimationEvents::BEFORE_HIT))
+	// While a spell cast is queued/playing, let it drive and batch the hit stage (endAction does the final
+	// sync) so per-unit damage packs (e.g. chain lightning) play together instead of one-by-one. In that case
+	// the displayed count is held by the snapshot above until each hit plays, so deferring is purely about
+	// animation ordering and no longer affects when the number visually drops.
+	if(hitPlayedSynchronously)
 	{
 		owner.executeStagedAnimations();
 		owner.waitForAnimations();
@@ -728,6 +766,7 @@ void BattleStacksController::endAction(const BattleAction & action)
 	owner.waitForAnimations();
 
 	stackAmountBoxHidden.clear();
+	displayedStackSnapshot.clear();
 
 	owner.windowObject->blockUI(activeStack == nullptr);
 	removeExpiredColorFilters();

--- a/client/battle/BattleStacksController.h
+++ b/client/battle/BattleStacksController.h
@@ -76,6 +76,7 @@ class BattleStacksController
 	{
 		int32_t count;
 		int64_t availableHealth;
+		std::shared_ptr<IImage> amountBox;
 	};
 	std::map<uint32_t, DisplayedStackSnapshot> displayedStackSnapshot;
 
@@ -99,6 +100,7 @@ class BattleStacksController
 	void unlockStackAmountBox(uint32_t stackID);
 	int32_t getDisplayedStackAmount(const CStack * stack) const;
 	int64_t getDisplayedStackHealth(const CStack * stack) const;
+	std::shared_ptr<IImage> getDisplayedStackAmountBox(const CStack * stack);
 
 	std::shared_ptr<IImage> getStackAmountBox(const CStack * stack);
 

--- a/client/battle/BattleStacksController.h
+++ b/client/battle/BattleStacksController.h
@@ -71,6 +71,14 @@ class BattleStacksController
 	/// units already given a removal fade-out, so a second removal call-in doesn't restart it
 	std::set<uint32_t> fadingStacks;
 
+	/// values shown for a stack while its hit animation is staged but has not played yet
+	struct DisplayedStackSnapshot
+	{
+		int32_t count;
+		int64_t availableHealth;
+	};
+	std::map<uint32_t, DisplayedStackSnapshot> displayedStackSnapshot;
+
 	/// currently active stack; nullptr - no one
 	const CStack *activeStack;
 
@@ -86,6 +94,11 @@ class BattleStacksController
 	bool stackNeedsAmountBox(const CStack * stack) const;
 	void showStackAmountBox(Canvas & canvas, const CStack * stack);
 	BattleHex getStackCurrentPosition(const CStack * stack) const;
+
+	void lockStackAmountBox(const CStack * stack);
+	void unlockStackAmountBox(uint32_t stackID);
+	int32_t getDisplayedStackAmount(const CStack * stack) const;
+	int64_t getDisplayedStackHealth(const CStack * stack) const;
 
 	std::shared_ptr<IImage> getStackAmountBox(const CStack * stack);
 


### PR DESCRIPTION
Regression of the fix in 08dc8258c5 (#4830). Damaging spells once again lowered the target stack's displayed count at cast time, with the hit animation only playing afterwards, instead of dropping the count in step with the animation the way melee/ranged attacks do.

Root cause
----------

The displayed count is read live from gamestate every frame (BattleStacksController::showStackAmountBox -> stack->getCount()). The only lever the original fix had over *when* the number drops was *when* gameState().apply() runs relative to the hit animation: it moved StacksInjured's battleStacksAttacked call into the pre-apply pass, where stacksAreAttacked ended with executeStagedAnimations()/waitForAnimations(). That block held the pack-handling thread until the hit had played, so the count only dropped afterwards.

Commit 00cb455c8 ("Implement Lightning Chain effect") made that flush conditional - it is now skipped whenever a spell cast (BEFORE_HIT stage) is queued, deferring the whole hit sequence to endAction so per-unit damage packs (e.g. chain lightning) batch together instead of playing one-by-one. But endAction runs *after* every StacksInjured pack has been applied, so for every damaging spell the count now dropped before the animation again.

The two goals genuinely conflict under the single-threaded, gamestate- driven design: correct count timing wants the pack thread to block per-pack before apply, while batching requires *not* blocking per-pack (a blocked pack thread cannot let the following packs stage their hits).

Fix
---

Decouple the displayed count from gamestate instead of choosing between the two. BattleStacksController now owns a small "displayed count" abstraction (freezeDisplayedCount / releaseDisplayedCount / getDisplayedCount, backed by displayedCountSnapshot):

  * When stacksAreAttacked defers the hit (it is batched with a cast), each surviving defender's pre-damage count is snapshotted right then, while it still holds the old value in the pre-apply pass.
  * The snapshot is released from inside the staged hit lambda, so the number falls back to the (already lowered) gamestate count exactly when that stack's hit animation plays.
  * showStackAmountBox renders getDisplayedCount() for both the amount text and the health bar.

This makes the deferred flush purely about animation ordering; it no longer affects when the count visually drops. Killed stacks are left to the death animation (which already hides the amount box), and the melee/ranged path is unchanged - it still flushes synchronously and takes no snapshot. endAction clears any snapshot residue as a safety net so a stale entry can never freeze a count past the end of an action.

Verified in battle: single-target damage spells (e.g. Magic Arrow) now drop the count after the hit, chain lightning still plays batched, and pure buff/debuff casts are unaffected.

Fixes #7619.