### PR TITLE
Fix levelup skill offers

### DIFF
--- a/lib/callback/GameRandomizer.cpp
+++ b/lib/callback/GameRandomizer.cpp
@@ -272,13 +272,13 @@ SecondarySkill GameRandomizer::rollSecondarySkillForLevelup(const CGHeroInstance
 		return obligatory;
 	};
 
-	std::set<SecondarySkill> wisdomList = getObligatorySkills(true);
-	std::set<SecondarySkill> schoolList = getObligatorySkills(false);
+	std::set<SecondarySkill> wisdomList = getObligatorySkills(false);
+	std::set<SecondarySkill> schoolList = getObligatorySkills(true);
 
 	bool wantsWisdom = heroRng.wisdomCounter >= hero->maxlevelsToWisdom();
 	bool wantsSchool = heroRng.magicSchoolCounter >= hero->maxlevelsToMagicSchool();
 	bool selectWisdom = wantsWisdom && !wisdomList.empty();
-	bool selectSchool = wantsSchool && !schoolList.empty();
+	bool selectSchool = !selectWisdom && wantsSchool && !schoolList.empty();
 
 	std::set<SecondarySkill> actualCandidates;
 


### PR DESCRIPTION
Fixes #7617 

1) Skill lists were reversed:
The ternary in the auto states `if(magicSchools ? option.toSkill()->isSpellSchool() : option.toSkill()->isWisdom())`, so to get the wisdom list, you need to pass false.

2) Wisdom should always take priority over a magic school in case both choices are forced at the same levelup (according to [wiki step 3](https://homm.miraheze.org/wiki/Secondary_skill))

Edit: ~I haven't tested this yet since I don't have VCMI setup to build, so I'm waiting for the artifacts to figure out if this simple fix was the culprit.~
Yup, seems that was it.