### PR TITLE
Spell targeting fixes

### DIFF
--- a/config/spells/timed.json
+++ b/config/spells/timed.json
@@ -397,6 +397,7 @@
 			"noneOf" : {
 				"core:creature.firstAidTent" : "absolute",
 				"core:creature.ammoCart" : "absolute",
+				"core:creature.catapult" : "absolute",
 				"bonus.UNDEAD" : "absolute"
 			}
 		}
@@ -450,6 +451,7 @@
 			"noneOf" : {
 				"core:creature.firstAidTent" : "absolute",
 				"core:creature.ammoCart" : "absolute",
+				"core:creature.catapult" : "absolute",
 				"bonus.UNDEAD" : "absolute"
 			}
 		}
@@ -909,6 +911,13 @@
 		},
 		"flags" : {
 			"positive": true
+		},
+		"targetCondition" : {
+			"noneOf" : {
+				"core:creature.firstAidTent" : "absolute",
+				"core:creature.ammoCart" : "absolute",
+				"core:creature.catapult" : "absolute"
+			}
 		}
 	},
 	"misfortune" : {
@@ -954,6 +963,13 @@
 		},
 		"flags" : {
 			"negative": true
+		},
+		"targetCondition" : {
+			"noneOf" : {
+				"core:creature.firstAidTent" : "absolute",
+				"core:creature.ammoCart" : "absolute",
+				"core:creature.catapult" : "absolute"
+			}
 		}
 	},
 	"haste" : {
@@ -1109,6 +1125,13 @@
 		},
 		"flags" : {
 			"positive": true
+		},
+		"targetCondition" : {
+			"noneOf" : {
+				"core:creature.firstAidTent" : "absolute",
+				"core:creature.ammoCart" : "absolute",
+				"core:creature.catapult" : "absolute"
+			}
 		}
 	},
 	"frenzy" : {


### PR DESCRIPTION
Fixed some discrepancies involving spell targeting in VCMI vs SoD.

+ my last PR missed the Catapult both in Curse and Bless, Catapult is immune against both those spells
+ only the Ballista is affected by Slayer, Fortune and Misfortune, the others are immune

I guess a cleaner way to do this would be to make a subtype of `SIEGE_WEAPON` that distinguishes war machines that attack creatures versus war machines that don't and check against that bonus subtype.