### PR TITLE
Speed up Nullkiller pathfinding

### DIFF
--- a/AI/Nullkiller2/Analyzers/ObjectClusterizer.cpp
+++ b/AI/Nullkiller2/Analyzers/ObjectClusterizer.cpp
@@ -378,7 +378,7 @@ void ObjectClusterizer::clusterize()
 	}
 
 	tbb::parallel_for(
-		tbb::blocked_range<size_t>(0, objs.size()),
+		tbb::blocked_range<size_t>(0, objs.size(), 256),
 		[&](const tbb::blocked_range<size_t> & r)
 		{
 			auto priorityEvaluator = aiNk->priorityEvaluators->acquire();

--- a/AI/Nullkiller2/Analyzers/ObjectClusterizer.cpp
+++ b/AI/Nullkiller2/Analyzers/ObjectClusterizer.cpp
@@ -533,9 +533,11 @@ void ObjectClusterizer::clusterizeObject(
 
 				heroesProcessed.insert(path.targetHero);
 
-				for (int prio = PriorityEvaluator::PriorityTier::BUILDINGS; prio <= PriorityEvaluator::PriorityTier::MAX_PRIORITY_TIER; ++prio)
+				const auto goal = Goals::sptr(Goals::ExecuteHeroChain(path, obj));
+				const auto evaluationContext = priorityEvaluator->buildEvaluationContext(goal);
+				for(int prio = PriorityEvaluator::PriorityTier::BUILDINGS; prio <= PriorityEvaluator::PriorityTier::MAX_PRIORITY_TIER; ++prio)
 				{
-					priority = std::max(priority, priorityEvaluator->evaluate(Goals::sptr(Goals::ExecuteHeroChain(path, obj)), prio));
+					priority = std::max(priority, priorityEvaluator->evaluate(goal, prio, evaluationContext));
 				}
 
 				if (priority <= 0)
@@ -557,9 +559,11 @@ void ObjectClusterizer::clusterizeObject(
 
 		heroesProcessed.insert(path.targetHero);
 
-		for (int prio = PriorityEvaluator::PriorityTier::BUILDINGS; prio <= PriorityEvaluator::PriorityTier::MAX_PRIORITY_TIER; ++prio)
+		const auto goal = Goals::sptr(Goals::ExecuteHeroChain(path, obj));
+		const auto evaluationContext = priorityEvaluator->buildEvaluationContext(goal);
+		for(int prio = PriorityEvaluator::PriorityTier::BUILDINGS; prio <= PriorityEvaluator::PriorityTier::MAX_PRIORITY_TIER; ++prio)
 		{
-			priority = std::max(priority, priorityEvaluator->evaluate(Goals::sptr(Goals::ExecuteHeroChain(path, obj)), prio));
+			priority = std::max(priority, priorityEvaluator->evaluate(goal, prio, evaluationContext));
 		}
 
 		if (priority <= 0)

--- a/AI/Nullkiller2/Behaviors/CaptureObjectsBehavior.cpp
+++ b/AI/Nullkiller2/Behaviors/CaptureObjectsBehavior.cpp
@@ -218,7 +218,7 @@ void CaptureObjectsBehavior::decomposeObjects(
 	std::mutex sync;
 	logAi->debug("Scanning objects, count %d", objs.size());
 	tbb::parallel_for(
-		tbb::blocked_range<size_t>(0, objs.size()),
+		tbb::blocked_range<size_t>(0, objs.size(), 128),
 		[this, &objs, &sync, &result, nullkiller](const tbb::blocked_range<size_t> & r)
 		{
 			std::vector<AIPath> paths;

--- a/AI/Nullkiller2/Engine/Nullkiller.cpp
+++ b/AI/Nullkiller2/Engine/Nullkiller.cpp
@@ -555,7 +555,6 @@ HeroLockedReason Nullkiller::getHeroLockedReason(const CGHeroInstance * hero) co
 
 void Nullkiller::makeTurn()
 {
-	std::lock_guard sharedStorageLock(AISharedStorage::locker);
 	pathfinderTurnStorageMisses.store(0);
 	const int MAX_DEPTH = 10;
 	resetState();

--- a/AI/Nullkiller2/Engine/Nullkiller.cpp
+++ b/AI/Nullkiller2/Engine/Nullkiller.cpp
@@ -208,20 +208,46 @@ Goals::TTask Nullkiller::choseBestTask(Goals::TGoalVec & tasks) const
 	return taskptr(*bestTask);
 }
 
-Goals::TTaskVec Nullkiller::buildPlanAndFilter(TGoalVec & tasks, int priorityTier) const
+Nullkiller::EvaluationContextMap Nullkiller::buildEvaluationContexts(const TGoalVec & tasks) const
+{
+	std::vector<std::optional<EvaluationContext>> contexts(tasks.size());
+
+	tbb::parallel_for(
+		tbb::blocked_range<size_t>(0, tasks.size()),
+		[this, &tasks, &contexts](const tbb::blocked_range<size_t> & r)
+		{
+			const auto evaluator = priorityEvaluators->acquire();
+			for(size_t i = r.begin(); i != r.end(); ++i)
+				contexts[i].emplace(evaluator->buildEvaluationContext(tasks[i]));
+		});
+
+	EvaluationContextMap result;
+	for(size_t i = 0; i != tasks.size(); ++i)
+		result.try_emplace(tasks[i].get(), std::move(contexts[i].value()));
+
+	return result;
+}
+
+Goals::TTaskVec Nullkiller::buildPlanAndFilter(
+	TGoalVec & tasks,
+	const EvaluationContextMap & evaluationContexts,
+	int priorityTier) const
 {
 	TaskPlan taskPlan;
 
 	tbb::parallel_for(
 		tbb::blocked_range<size_t>(0, tasks.size()),
-		[this, &tasks, priorityTier](const tbb::blocked_range<size_t> & r)
+		[this, &tasks, &evaluationContexts, priorityTier](const tbb::blocked_range<size_t> & r)
 		{
 			const auto evaluator = this->priorityEvaluators->acquire();
 			for(size_t i = r.begin(); i != r.end(); i++)
 			{
 				const auto & task = tasks[i];
 				if(task->asTask()->priority <= 0 || priorityTier != PriorityEvaluator::PriorityTier::BUILDINGS)
-					task->asTask()->priority = evaluator->evaluate(task, priorityTier);
+					task->asTask()->priority = evaluator->evaluate(
+						task,
+						priorityTier,
+						evaluationContexts.at(task.get()));
 			}
 		}
 	);
@@ -559,12 +585,13 @@ void Nullkiller::makeTurn()
 		if(!isOpenMap())
 			decompose(tasks, sptr(ExplorationBehavior()), MAX_DEPTH);
 
+		const auto evaluationContexts = buildEvaluationContexts(tasks);
 		TTaskVec selectedTasks;
 		int prioOfTask = 0;
 		for(int prio = PriorityEvaluator::PriorityTier::INSTAKILL; prio <= PriorityEvaluator::PriorityTier::MAX_PRIORITY_TIER; ++prio)
 		{
 			prioOfTask = prio;
-			selectedTasks = buildPlanAndFilter(tasks, prio);
+			selectedTasks = buildPlanAndFilter(tasks, evaluationContexts, prio);
 			if (!selectedTasks.empty())
 			{
 				// Activate for deep debugging, otherwise too noisy even for trace level 2

--- a/AI/Nullkiller2/Engine/Nullkiller.cpp
+++ b/AI/Nullkiller2/Engine/Nullkiller.cpp
@@ -213,13 +213,14 @@ Nullkiller::EvaluationContextMap Nullkiller::buildEvaluationContexts(const TGoal
 	std::vector<std::optional<EvaluationContext>> contexts(tasks.size());
 
 	tbb::parallel_for(
-		tbb::blocked_range<size_t>(0, tasks.size()),
+		tbb::blocked_range<size_t>(0, tasks.size(), 128),
 		[this, &tasks, &contexts](const tbb::blocked_range<size_t> & r)
 		{
 			const auto evaluator = priorityEvaluators->acquire();
 			for(size_t i = r.begin(); i != r.end(); ++i)
 				contexts[i].emplace(evaluator->buildEvaluationContext(tasks[i]));
-		});
+		}
+	);
 
 	EvaluationContextMap result;
 	for(size_t i = 0; i != tasks.size(); ++i)
@@ -236,7 +237,7 @@ Goals::TTaskVec Nullkiller::buildPlanAndFilter(
 	TaskPlan taskPlan;
 
 	tbb::parallel_for(
-		tbb::blocked_range<size_t>(0, tasks.size()),
+		tbb::blocked_range<size_t>(0, tasks.size(), 128),
 		[this, &tasks, &evaluationContexts, priorityTier](const tbb::blocked_range<size_t> & r)
 		{
 			const auto evaluator = this->priorityEvaluators->acquire();

--- a/AI/Nullkiller2/Engine/Nullkiller.h
+++ b/AI/Nullkiller2/Engine/Nullkiller.h
@@ -154,7 +154,12 @@ private:
 	const CGHeroInstance * findRequiredTownDefender(const CGTownInstance * town) const;
 	void decompose(Goals::TGoalVec & results, const Goals::TSubgoal& behavior, int decompositionMaxDepth) const;
 	Goals::TTask choseBestTask(Goals::TGoalVec & tasks) const;
-	Goals::TTaskVec buildPlanAndFilter(Goals::TGoalVec & tasks, int priorityTier) const;
+	using EvaluationContextMap = std::map<const Goals::AbstractGoal *, EvaluationContext>;
+	EvaluationContextMap buildEvaluationContexts(const Goals::TGoalVec & tasks) const;
+	Goals::TTaskVec buildPlanAndFilter(
+		Goals::TGoalVec & tasks,
+		const EvaluationContextMap & evaluationContexts,
+		int priorityTier) const;
 	bool executeTask(const Goals::TTask & task);
 	bool areAffectedObjectsPresent(const Goals::TTask & task) const;
 	HeroRole getTaskRole(const Goals::TTask & task) const;

--- a/AI/Nullkiller2/Engine/PriorityEvaluator.cpp
+++ b/AI/Nullkiller2/Engine/PriorityEvaluator.cpp
@@ -688,7 +688,7 @@ float RewardEvaluator::getSkillReward(const CGObjectInstance * target, const CGH
 				{
 					const spells::Spell * spell = LIBRARY->spells()->getById(spellID);
 
-					if(hero->canLearnSpell(spell) && !hero->spellbookContainsSpell(spellID))
+					if(hero->canLearnSpell(spell, true))
 					{
 						rewardValue += std::sqrt(spell->getLevel()) / 4.0f;
 					}

--- a/AI/Nullkiller2/Engine/PriorityEvaluator.cpp
+++ b/AI/Nullkiller2/Engine/PriorityEvaluator.cpp
@@ -68,10 +68,10 @@ float evaluateMaxArmyLossForConquest(float baseMaxArmyLoss, float conquestValue,
 
 EvaluationContext::EvaluationContext(const Nullkiller* aiNk)
 	: movementCost(0.0),
+	movementCostByRole(),
 	manaCost(0),
 	danger(0),
 	closestWayRatio(1),
-	movementCostByRole(),
 	skillReward(0),
 	goldReward(0),
 	goldCost(0),
@@ -103,6 +103,12 @@ EvaluationContext::EvaluationContext(const Nullkiller* aiNk)
 void EvaluationContext::addNonCriticalStrategicalValue(float value)
 {
 	vstd::amax(strategicalValue, std::min(value, MAX_CRITICAL_VALUE));
+}
+
+float EvaluationContext::getMovementCost(const HeroRole role) const
+{
+	static_assert(HeroRole::SCOUT == 0 && HeroRole::MAIN == 1);
+	return movementCostByRole.at(static_cast<size_t>(role));
 }
 
 PriorityEvaluator::~PriorityEvaluator() = default;
@@ -911,7 +917,7 @@ public:
 			const float movementCost = movementSpent / movementLimit;
 
 			evaluationContext.movementCost += movementCost;
-			evaluationContext.movementCostByRole[role] += movementCost;
+			evaluationContext.movementCostByRole.at(static_cast<size_t>(role)) += movementCost;
 		}
 	}
 };
@@ -939,7 +945,7 @@ public:
 		else
 		{
 			evaluationContext.movementCost += stayAtTown.getMovementWasted();
-			evaluationContext.movementCostByRole[evaluationContext.heroRole] += stayAtTown.getMovementWasted();
+			evaluationContext.movementCostByRole.at(static_cast<size_t>(evaluationContext.heroRole)) += stayAtTown.getMovementWasted();
 		}
 	}
 };
@@ -1042,7 +1048,7 @@ public:
 		for(auto pair : costsPerHero)
 		{
 			auto role = evaluationContext.evaluator.aiNk->heroManager->getHeroRoleOrDefaultInefficient(pair.first);
-			evaluationContext.movementCostByRole[role] += pair.second;
+			evaluationContext.movementCostByRole.at(static_cast<size_t>(role)) += pair.second;
 			if (pair.second > highestCostForSingleHero)
 				highestCostForSingleHero = pair.second;
 		}
@@ -1165,7 +1171,7 @@ public:
 			evaluationContext.addNonCriticalStrategicalValue(evaluationContext.evaluator.getStrategicalValue(target) / boost);
 			evaluationContext.conquestValue += evaluationContext.evaluator.getConquestValue(target);
 			evaluationContext.goldCost += evaluationContext.evaluator.getGoldCost(target, hero, army) / boost;
-			evaluationContext.movementCostByRole[role] += objInfo.second.movementCost / boost;
+			evaluationContext.movementCostByRole.at(static_cast<size_t>(role)) += objInfo.second.movementCost / boost;
 			evaluationContext.movementCost += objInfo.second.movementCost / boost;
 
 			vstd::amax(evaluationContext.turn, objInfo.second.turn / boost);
@@ -1203,7 +1209,7 @@ public:
 			auto mpLeft = garrisonHero->movementPointsRemaining() / (float)garrisonHero->movementPointsLimit();
 
 			evaluationContext.movementCost += mpLeft;
-			evaluationContext.movementCostByRole[defenderRole] += mpLeft;
+			evaluationContext.movementCostByRole.at(static_cast<size_t>(defenderRole)) += mpLeft;
 			evaluationContext.heroRole = defenderRole;
 			evaluationContext.isDefend = true;
 			evaluationContext.armyInvolvement = garrisonHero->getArmyStrength();
@@ -1232,7 +1238,7 @@ public:
 		auto mpLeft = dismissedHero->movementPointsRemaining();
 
 		evaluationContext.movementCost += mpLeft;
-		evaluationContext.movementCostByRole[role] += mpLeft;
+		evaluationContext.movementCostByRole.at(static_cast<size_t>(role)) += mpLeft;
 		evaluationContext.goldCost += GameConstants::HERO_GOLD_COST + getArmyCost(dismissedHero);
 	}
 };
@@ -1251,7 +1257,7 @@ public:
 		constexpr int dailyIncomeValueFactor = 7;
 		evaluationContext.goldReward += dailyIncomeValueFactor * bi.dailyIncome.marketValue() / 2; // 7 day income but half we already have
 		evaluationContext.heroRole = HeroRole::MAIN;
-		evaluationContext.movementCostByRole[evaluationContext.heroRole] += bi.prerequisitesCount;
+		evaluationContext.movementCostByRole.at(static_cast<size_t>(evaluationContext.heroRole)) += bi.prerequisitesCount;
 		int32_t cost = bi.buildCost[EGameResID::GOLD];
 		evaluationContext.goldCost += cost;
 		evaluationContext.closestWayRatio = 1;
@@ -1334,7 +1340,7 @@ public:
 		if(bi.isMissingResources && bi.prerequisitesCount == 1)
 		{
 			evaluationContext.strategicalValue /= 3;
-			evaluationContext.movementCostByRole[evaluationContext.heroRole] += 5;
+			evaluationContext.movementCostByRole.at(static_cast<size_t>(evaluationContext.heroRole)) += 5;
 			evaluationContext.turn += 5;
 		}
 	}
@@ -1437,7 +1443,14 @@ float PriorityEvaluator::evaluateConquestValue(float score, const float conquest
 float PriorityEvaluator::evaluate(Goals::TSubgoal task, int priorityTier)
 {
 	auto evaluationContext = buildEvaluationContext(task);
+	return evaluate(task, priorityTier, evaluationContext);
+}
 
+float PriorityEvaluator::evaluate(
+	Goals::TSubgoal task,
+	const int priorityTier,
+	const EvaluationContext & evaluationContext)
+{
 	const bool amIWithoutCastle = aiNk->cc->getPlayerState(aiNk->playerID)->daysWithoutCastle.has_value();
 	double result = 0;
 
@@ -1468,8 +1481,8 @@ float PriorityEvaluator::evaluate(Goals::TSubgoal task, int priorityTier)
 			evaluationContext.armyLossRatio,
 			maxWillingToLose,
 			static_cast<int>(evaluationContext.turn),
-			evaluationContext.movementCostByRole[HeroRole::MAIN],
-			evaluationContext.movementCostByRole[HeroRole::SCOUT],
+			evaluationContext.getMovementCost(HeroRole::MAIN),
+			evaluationContext.getMovementCost(HeroRole::SCOUT),
 			evaluationContext.armyInvolvement,
 			evaluationContext.goldReward,
 			evaluationContext.goldCost,
@@ -1777,8 +1790,8 @@ float PriorityEvaluator::evaluate(Goals::TSubgoal task, int priorityTier)
 		task->toString(),
 		evaluationContext.armyLossRatio,
 		static_cast<int>(evaluationContext.turn),
-		evaluationContext.movementCostByRole[HeroRole::MAIN],
-		evaluationContext.movementCostByRole[HeroRole::SCOUT],
+		evaluationContext.getMovementCost(HeroRole::MAIN),
+		evaluationContext.getMovementCost(HeroRole::SCOUT),
 		evaluationContext.armyInvolvement,
 		evaluationContext.goldReward,
 		evaluationContext.goldCost,

--- a/AI/Nullkiller2/Engine/PriorityEvaluator.h
+++ b/AI/Nullkiller2/Engine/PriorityEvaluator.h
@@ -49,7 +49,7 @@ public:
 struct DLL_EXPORT EvaluationContext
 {
 	float movementCost;
-	std::map<HeroRole, float> movementCostByRole;
+	std::array<float, 2> movementCostByRole;
 	int manaCost;
 	uint64_t danger;
 	float closestWayRatio;
@@ -83,6 +83,7 @@ struct DLL_EXPORT EvaluationContext
 	EvaluationContext(const Nullkiller * aiNk);
 
 	void addNonCriticalStrategicalValue(float value);
+	float getMovementCost(HeroRole role) const;
 };
 
 class IEvaluationContextBuilder
@@ -101,6 +102,8 @@ public:
 	~PriorityEvaluator();
 
 	float evaluate(Goals::TSubgoal task, int priorityTier = BUILDINGS);
+	float evaluate(Goals::TSubgoal task, int priorityTier, const EvaluationContext & evaluationContext);
+	EvaluationContext buildEvaluationContext(const Goals::TSubgoal & goal) const;
 
 	enum PriorityTier : int32_t
 	{
@@ -119,7 +122,6 @@ private:
 
 	std::vector<std::shared_ptr<IEvaluationContextBuilder>> evaluationContextBuilders;
 
-	EvaluationContext buildEvaluationContext(const Goals::TSubgoal & goal) const;
 	static float evaluateMovement(float score, float movementCost);
 	static float evaluateArmyLossRatio(float score, float armyLossRatio, HeroRole heroRole);
 	static float evaluateSkillReward(float score, float skillReward, float armyInvolvement, float armyLossRatio);

--- a/AI/Nullkiller2/Helpers/ExplorationHelper.cpp
+++ b/AI/Nullkiller2/Helpers/ExplorationHelper.cpp
@@ -287,44 +287,101 @@ void ExplorationHelper::scanTile(const int3 & tile)
 		|| !aiNk->pathfinder->isTileAccessible(HeroPtr(hero, aiNk->cc.get()), tile)) //shouldn't happen, but it does
 		return;
 
-	auto paths = aiNk->pathfinder->getPathInfo(tile);
-	if(paths.empty())
+	std::vector<AIPathSummary> summaries;
+	aiNk->pathfinder->calculatePathSummaries(summaries, tile);
+	if(summaries.empty())
 		return;
 
-	int tilesDiscovered = howManyTilesWillBeDiscovered(tile);
+	const int tilesDiscovered = howManyTilesWillBeDiscovered(tile);
 	if(!tilesDiscovered)
 		return;
-	
-	auto waysToVisit = CaptureObjectsBehavior::getVisitGoals(paths, aiNk, aiNk->cc->getTopObj(tile));
 
-	for(int i = 0; i != paths.size(); i++)
+	const CGObjectInstance * object = cc->getTopObj(tile);
+	if(object && object->isBlockedVisitable())
+		return;
+
+	std::vector<size_t> candidateIndices;
+	for(size_t index = 0; index != summaries.size(); ++index)
 	{
-		auto & path = paths[i];
-		auto goal = waysToVisit[i];
+		const auto & summary = summaries[index];
+		if(summary.exchangeCount > 1
+			|| summary.targetHero != hero
+			|| summary.cost <= 0.f)
+		{
+			continue;
+		}
 
-		if(path.exchangeCount > 1 || path.targetHero != hero || path.movementCost() <= 0.0 || goal->invalid())
+		const float value = static_cast<float>(tilesDiscovered) * tilesDiscovered / summary.cost;
+		if(value > bestValue)
+			candidateIndices.push_back(index);
+	}
+
+	if(candidateIndices.empty())
+		return;
+
+	std::vector<std::optional<AIPath>> reconstructedPaths(summaries.size());
+	std::vector<bool> reconstructionAttempted(summaries.size(), false);
+	auto reconstruct = [&](const size_t index) -> const AIPath *
+	{
+		if(!reconstructionAttempted[index])
+		{
+			reconstructionAttempted[index] = true;
+			AIPath path;
+			if(aiNk->pathfinder->calculatePathInfo(path, summaries[index]))
+				reconstructedPaths[index] = std::move(path);
+		}
+
+		return reconstructedPaths[index] ? &*reconstructedPaths[index] : nullptr;
+	};
+
+	const HeroRole heroRole = aiNk->heroManager->getHeroRoleOrDefaultInefficient(hero);
+	float closestWayCost = std::numeric_limits<float>::max();
+	for(size_t index = 0; index != summaries.size(); ++index)
+	{
+		if(aiNk->heroManager->getHeroRoleOrDefaultInefficient(summaries[index].targetHero) != heroRole)
 			continue;
 
-		float ourValue = (float)tilesDiscovered * tilesDiscovered / path.movementCost();
+		const AIPath * path = reconstruct(index);
+		if(!path || path->getFirstBlockedAction())
+			continue;
 
-		if(ourValue > bestValue) //avoid costly checks of tiles that don't reveal much
+		const auto goals = CaptureObjectsBehavior::getVisitGoals({ *path }, aiNk, object);
+		if(vstd::contains_if(goals, [](const TSubgoal & goal)
+			{
+				return !goal->invalid();
+			}))
 		{
-			auto obj = cc->getTopObj(tile);
+			closestWayCost = std::min(closestWayCost, path->movementCost());
+		}
+	}
 
-			// picking up resources does not yield any exploration at all.
-			// if it blocks the way to some explorable tile AIPathfinder will take care of it
-			if(obj && obj->isBlockedVisitable())
-			{
-				continue;
-			}
+	for(const size_t index : candidateIndices)
+	{
+		const AIPath * path = reconstruct(index);
+		if(!path)
+			continue;
 
-			if(isSafeToVisit(hero, path.heroArmy, path.getTotalDanger(), aiNk->settings->getSafeAttackRatio()))
-			{
-				bestGoal = goal;
-				bestValue = ourValue;
-				bestTile = tile;
-				bestTilesDiscovered = tilesDiscovered;
-			}
+		auto waysToVisit = CaptureObjectsBehavior::getVisitGoals({ *path }, aiNk, object);
+		auto goal = waysToVisit.front();
+		if(goal->invalid())
+			continue;
+
+		const float ourValue = static_cast<float>(tilesDiscovered) * tilesDiscovered / path->movementCost();
+		if(ourValue <= bestValue)
+			continue;
+
+		if(auto * execute = dynamic_cast<ExecuteHeroChain *>(goal.get());
+			execute && closestWayCost < std::numeric_limits<float>::max())
+		{
+			execute->closestWayRatio = closestWayCost / path->movementCost();
+		}
+
+		if(isSafeToVisit(hero, path->heroArmy, path->getTotalDanger(), aiNk->settings->getSafeAttackRatio()))
+		{
+			bestGoal = goal;
+			bestValue = ourValue;
+			bestTile = tile;
+			bestTilesDiscovered = tilesDiscovered;
 		}
 	}
 }

--- a/AI/Nullkiller2/Pathfinding/AINodeStorage.cpp
+++ b/AI/Nullkiller2/Pathfinding/AINodeStorage.cpp
@@ -175,6 +175,7 @@ void AINodeStorage::clear()
 {
 	actors.clear();
 	committedTiles.clear();
+	dimensionDoorCapabilities.clear();
 	heroChainPass = EHeroChainPass::INITIAL;
 	heroChainTurn = 0;
 	heroChainMaxTurns = 1;
@@ -1105,15 +1106,41 @@ void AINodeStorage::calculateDimensionDoorTeleportations(
 {
 	const auto * hero = srcNode->actor->hero;
 
-	forEachDimensionDoorSpell(hero, [&](const CSpell * spell, const auto &, const DimensionDoorEffect *)
+	for(const auto & capability : getDimensionDoorCapabilities(hero))
 	{
-		auto plan = getDimensionDoorSpellPlan(source, pathfinderHelper, srcNode, hero, spell);
+		auto plan = getDimensionDoorSpellPlan(source, pathfinderHelper, srcNode, hero, capability);
 
 		if(!plan)
-			return;
+			continue;
 
 		calculateDimensionDoorTeleportationsForSpell(neighbours, source, srcNode, *plan);
+	}
+}
+
+const std::vector<AINodeStorage::DimensionDoorCapability> & AINodeStorage::getDimensionDoorCapabilities(
+	const CGHeroInstance * hero)
+{
+	auto existing = dimensionDoorCapabilities.find(hero);
+	if(existing != dimensionDoorCapabilities.end())
+		return existing->second;
+
+	std::vector<DimensionDoorCapability> capabilities;
+	const int3 mapSize = aiNk->cc->getMapSize();
+	forEachDimensionDoorSpell(hero, [&](const CSpell * spell, const auto & mechanics, const DimensionDoorEffect * effect)
+	{
+		if(!hero->canCastThisSpell(spell))
+			return;
+
+		DimensionDoorCapability capability;
+		capability.spell = spell;
+		capability.effect = effect;
+		capability.manaCost = hero->getSpellCost(spell);
+		capability.castsLimit = mechanics.getCastsLimit(hero, mapSize);
+		capability.castsAlreadyPerformed = mechanics.getCastsAlreadyPerformed(hero);
+		capabilities.push_back(capability);
 	});
+
+	return dimensionDoorCapabilities.emplace(hero, std::move(capabilities)).first->second;
 }
 
 std::optional<AINodeStorage::DimensionDoorSpellPlan> AINodeStorage::getDimensionDoorSpellPlan(
@@ -1121,33 +1148,24 @@ std::optional<AINodeStorage::DimensionDoorSpellPlan> AINodeStorage::getDimension
 	const CPathfinderHelper * pathfinderHelper,
 	const AIPathNode * srcNode,
 	const CGHeroInstance * hero,
-	const CSpell * spell) const
+	const DimensionDoorCapability & capability) const
 {
-	const auto & mechanics = spell->getAdventureMechanics();
-	const auto * effect = mechanics.getEffectAs<DimensionDoorEffect>(hero);
-
-	if(!effect)
-		return std::nullopt;
-
-	const int3 mapSize = aiNk->cc->getMapSize();
-	const int manaCost = hero->getSpellCost(spell);
-	const int castsLimit = mechanics.getCastsLimit(hero, mapSize);
 	const int plannedSourceTurn = pathfinderHelper->turn;
 	const int plannedSourceMoveLimit = pathfinderHelper->getMaxMovePoints(source.node->layer);
 	const int plannedSourceMoveRemains = plannedSourceTurn == source.node->turns
 		? source.node->moveRemains
 		: plannedSourceMoveLimit;
 	const int plannedDimensionDoorCasts = plannedSourceTurn == source.node->turns ? srcNode->dimensionDoorCasts : 0;
-	const int castsAlreadyPerformed = plannedSourceTurn == 0 ? mechanics.getCastsAlreadyPerformed(hero) : 0;
+	const int castsAlreadyPerformed = plannedSourceTurn == 0 ? capability.castsAlreadyPerformed : 0;
 
-	if(!AIPathfinding::canUseDimensionDoorAction({
+	if(!AIPathfinding::hasDimensionDoorActionResources({
 		hero,
-		spell,
-		manaCost,
+		capability.spell,
+		capability.manaCost,
 		srcNode->manaCost,
 		plannedSourceMoveRemains,
-		effect->getMovementPointsRequired(),
-		castsLimit,
+		capability.effect->getMovementPointsRequired(),
+		capability.castsLimit,
 		castsAlreadyPerformed,
 		plannedDimensionDoorCasts
 	}))
@@ -1155,13 +1173,13 @@ std::optional<AINodeStorage::DimensionDoorSpellPlan> AINodeStorage::getDimension
 		return std::nullopt;
 	}
 
-	const int movementPointsTaken = std::min(plannedSourceMoveRemains, effect->getMovementPointsTaken());
+	const int movementPointsTaken = std::min(plannedSourceMoveRemains, capability.effect->getMovementPointsTaken());
 	const float movementCost = static_cast<float>(movementPointsTaken) / plannedSourceMoveLimit;
 
 	DimensionDoorSpellPlan plan;
-	plan.spell = spell;
-	plan.effect = effect;
-	plan.manaCost = manaCost;
+	plan.spell = capability.spell;
+	plan.effect = capability.effect;
+	plan.manaCost = capability.manaCost;
 	plan.plannedSourceTurn = plannedSourceTurn;
 	plan.plannedSourceMoveLimit = plannedSourceMoveLimit;
 	plan.plannedSourceMoveRemains = plannedSourceMoveRemains;

--- a/AI/Nullkiller2/Pathfinding/AINodeStorage.cpp
+++ b/AI/Nullkiller2/Pathfinding/AINodeStorage.cpp
@@ -32,13 +32,6 @@
 namespace NK2AI
 {
 
-std::shared_ptr<boost::multi_array<AIPathNode, 4>> AISharedStorage::shared;
-uint32_t AISharedStorage::version = 0;
-std::mutex AISharedStorage::locker;
-std::set<int3> committedTiles;
-std::set<int3> committedTilesInitial;
-
-
 const uint64_t FirstActorMask = 1;
 const uint64_t MIN_ARMY_STRENGTH_FOR_CHAIN = 5000;
 const uint64_t MIN_ARMY_STRENGTH_FOR_NEXT_ACTOR = 1000;
@@ -46,49 +39,68 @@ const uint64_t CHAIN_MAX_DEPTH = 4;
 
 const bool DO_NOT_SAVE_TO_COMMITTED_TILES = false;
 
-AISharedStorage::AISharedStorage(int3 sizes, int numChains, const CCallback & cc)
+AIPathNodePool::AIPathNodePool(const int3 sizes, const size_t capacity)
+	: sizes(sizes)
+	, capacity(capacity)
+	, tiles(static_cast<size_t>(sizes.x) * sizes.y * sizes.z)
 {
-	if(!shared)
-	{
-		shared.reset(new boost::multi_array<AIPathNode, 4>(boost::extents[sizes.z][sizes.x][sizes.y][numChains]));
-		nodes = shared;
-
-		foreach_tile_pos(
-			cc,
-			[&](const int3 & pos)
-			{
-				for(auto i = 0; i < numChains; i++)
-				{
-					auto & node = get(pos)[i];
-					node.version = -1;
-					node.coord = pos;
-				}
-			}
-		);
-	}
-	else
-		nodes = shared;
 }
 
-AISharedStorage::~AISharedStorage()
+size_t AIPathNodePool::tileIndex(const int3 & tile) const
 {
-	nodes.reset();
-	if(shared && shared.use_count() == 1)
-	{
-		shared.reset();
-	}
+	return (static_cast<size_t>(tile.z) * sizes.x + tile.x) * sizes.y + tile.y;
 }
 
-bool AISharedStorage::beginGeneration()
+AIPathNodePool::TileNodes & AIPathNodePool::getCurrentTile(const int3 & tile)
 {
-	++version;
-	if(version != 0)
+	auto & result = tiles[tileIndex(tile)];
+	if(result.generation != generation)
+	{
+		result.nodes.clear();
+		result.generation = generation;
+	}
+	return result;
+}
+
+bool AIPathNodePool::beginGeneration()
+{
+	nodes.clear();
+
+	++generation;
+	if(generation != 0)
 		return false;
 
-	for(auto * node = nodes->data(); node != nodes->data() + nodes->num_elements(); ++node)
-		node->version = 0;
-	version = 1;
+	for(auto & tile : tiles)
+		tile.generation = 0;
+	generation = 1;
 	return true;
+}
+
+AIPathNode * AIPathNodePool::allocate(const int3 & tile)
+{
+	auto & tileNodes = getCurrentTile(tile).nodes;
+	if(tileNodes.size() >= capacity)
+		return nullptr;
+
+	auto allocated = nodes.grow_by(1);
+	auto * node = std::addressof(*allocated);
+	node->coord = tile;
+	node->storageOrder = tileIndex(tile) * capacity + tileNodes.size();
+	tileNodes.push_back(node);
+
+	return node;
+}
+
+const AIPathNodePool::NodeList & AIPathNodePool::get(const int3 & tile) const
+{
+	static const NodeList empty;
+	const auto & result = tiles[tileIndex(tile)];
+	return result.generation == generation ? result.nodes : empty;
+}
+
+uint64_t AIPathNodePool::nextStorageOrder(const int3 & tile, const size_t offset) const
+{
+	return tileIndex(tile) * capacity + get(tile).size() + offset;
 }
 
 void AIPathNode::addSpecialAction(std::shared_ptr<const SpecialAction> action)
@@ -123,7 +135,9 @@ int AINodeStorage::getBucketSize() const
 }
 
 AINodeStorage::AINodeStorage(Nullkiller * aiNk, const int3 & sizes)
-	: sizes(sizes), aiNk(aiNk), nodes(sizes, aiNk->settings->getPathfinderBucketSize() * aiNk->settings->getPathfinderBucketsCount(), *aiNk->cc)
+	: sizes(sizes)
+	, aiNk(aiNk)
+	, nodes(sizes, aiNk->settings->getPathfinderBucketSize() * aiNk->settings->getPathfinderBucketsCount())
 {
 	accessibility = std::make_unique<boost::multi_array<AccessibilityInfo, 4>>(
 		boost::extents[sizes.z][sizes.x][sizes.y][EPathfindingLayer::NUM_LAYERS]);
@@ -136,6 +150,7 @@ void AINodeStorage::initialize(const PathfinderOptions & options, const IGameInf
 	if(heroChainPass != EHeroChainPass::INITIAL)
 		return;
 
+	heroChain.clear();
 	if(nodes.beginGeneration())
 	{
 		for(auto * info = accessibility->data(); info != accessibility->data() + accessibility->num_elements(); ++info)
@@ -153,7 +168,7 @@ EPathAccessibility AINodeStorage::getAccessibility(
 	const EPathfindingLayer layer) const
 {
 	auto & info = (*accessibility)[pos.z][pos.x][pos.y][layer.getNum()];
-	if(info.generation == AISharedStorage::version)
+	if(info.generation == nodes.getGeneration())
 		return info.value;
 
 	const TerrainTile * tile = gameInfo->getTile(pos);
@@ -192,7 +207,7 @@ EPathAccessibility AINodeStorage::getAccessibility(
 		}
 	}
 
-	info.generation = AISharedStorage::version;
+	info.generation = nodes.getGeneration();
 	return info.value;
 }
 
@@ -215,30 +230,37 @@ std::optional<AIPathNode *> AINodeStorage::getOrCreateNode(
 {
 	// Modified to 1 bucket because properly load balancing multiple buckets is not worth. Backwards compatible
 	const int total = aiNk->settings->getPathfinderBucketSize() * aiNk->settings->getPathfinderBucketsCount();
-	auto chains = nodes.get(pos);
 
 	if(blocked(pos, layer))
 	{
 		return std::nullopt;
 	}
 
-	for(auto i = 0; i < total; i++)
+	const auto & chains = nodes.get(pos);
+	for(AIPathNode * node : chains)
 	{
-		AIPathNode & node = chains[i];
-		if(node.version != AISharedStorage::version)
-		{
-			node.reset(layer, getAccessibility(pos, layer));
-			node.version = AISharedStorage::version;
-			node.actor = actor;
-			return &node;
-		}
-
-		if(node.actor == actor && node.layer == layer)
-			return &node;
+		if(node->actor == actor && node->layer == layer)
+			return node;
 	}
 
-	aiNk->pathfinderTurnStorageMisses.fetch_add(1);
-	return std::nullopt;
+	if(chains.size() >= total)
+	{
+		aiNk->pathfinderTurnStorageMisses.fetch_add(1);
+		return std::nullopt;
+	}
+
+	AIPathNode * node = nodes.allocate(pos);
+	if(!node)
+	{
+		aiNk->pathfinderTurnStorageMisses.fetch_add(1);
+		return std::nullopt;
+	}
+
+	node->reset(layer, getAccessibility(pos, layer));
+	node->version = nodes.getGeneration();
+	node->actor = actor;
+	return node;
+
 }
 
 std::vector<CGPathNode *> AINodeStorage::getInitialNodes()
@@ -356,7 +378,7 @@ void AINodeStorage::commit(
 	int turn,
 	int movementLeft,
 	float cost,
-	bool saveToCommitted) const
+	bool saveToCommitted)
 {
 	destination->action = action;
 	destination->setCost(cost);
@@ -723,7 +745,7 @@ void HeroChainCalculationTask::calculateHeroChain(
 {
 	for(AIPathNode * node : variants)
 	{
-		if(node == srcNode || !node->actor || node->version != AISharedStorage::version)
+		if(node == srcNode || !node->actor || !storage.isCurrentNode(node))
 			continue;
 
 		if((node->actor->chainMask & chainMask) == 0 && (srcNode->actor->chainMask & chainMask) == 0)
@@ -826,7 +848,9 @@ void HeroChainCalculationTask::calculateHeroChain(
 #endif
 					return;
 				}
-				result.push_back(calculateExchange(exchangeResult.actor, carrier, other));
+				auto candidate = calculateExchange(exchangeResult.actor, carrier, other);
+				candidate.storageOrder = storage.nextStorageOrder(candidate.coord, result.size());
+				result.push_back(std::move(candidate));
 			}
 			return;
 		}
@@ -1647,7 +1671,7 @@ bool AINodeStorage::isOtherChainBetter(
 		{
 			if(vstd::isAlmostEqual(nodeActor->heroFightingStrength, candidateNode.actor->heroFightingStrength)
 				&& vstd::isAlmostEqual(other.getCost(), candidateNode.getCost())
-				&& &other < &candidateNode)
+				&& other.storageOrder <= candidateNode.storageOrder)
 			{
 				return false;
 			}
@@ -1671,14 +1695,14 @@ bool AINodeStorage::isOtherChainBetter(
 
 bool AINodeStorage::isTileAccessible(const HeroPtr & heroPtr, const int3 & pos, const EPathfindingLayer layer) const
 {
-	auto chains = nodes.get(pos);
-	for(const AIPathNode & node : chains)
+	const auto & chains = nodes.get(pos);
+	for(const AIPathNode * node : chains)
 	{
-		if(node.version == AISharedStorage::version
-			&& node.layer == layer
-			&& node.action != EPathNodeAction::UNKNOWN
-			&& node.actor
-			&& node.actor->hero == heroPtr.get())
+		if(node->version == nodes.getGeneration()
+			&& node->layer == layer
+			&& node->action != EPathNodeAction::UNKNOWN
+			&& node->actor
+			&& node->actor->hero == heroPtr.get())
 		{
 			return true;
 		}
@@ -1687,23 +1711,31 @@ bool AINodeStorage::isTileAccessible(const HeroPtr & heroPtr, const int3 & pos, 
 	return false;
 }
 
+bool AINodeStorage::hasCurrentNodes(const int3 & pos) const
+{
+	if(pos.x < 0 || pos.x >= sizes.x || pos.y < 0 || pos.y >= sizes.y || pos.z < 0 || pos.z >= sizes.z)
+		return false;
+
+	return !nodes.get(pos).empty();
+}
+
 void AINodeStorage::calculateChainInfo(std::vector<AIPath> & paths, const int3 & pos, const bool isOnLand) const
 {
 	auto layer = isOnLand ? EPathfindingLayer::LAND : EPathfindingLayer::SAIL;
-	auto chains = nodes.get(pos);
+	const auto & chains = nodes.get(pos);
 
-	for(const AIPathNode & node : chains)
+	for(const AIPathNode * node : chains)
 	{
-		if(node.version != AISharedStorage::version
-			|| node.layer != layer
-			|| node.action == EPathNodeAction::UNKNOWN
-			|| !node.actor
-			|| !node.actor->hero)
+		if(node->version != nodes.getGeneration()
+			|| node->layer != layer
+			|| node->action == EPathNodeAction::UNKNOWN
+			|| !node->actor
+			|| !node->actor->hero)
 		{
 			continue;
 		}
 
-		if(HeroPtr heroPtr(node.actor->hero, aiNk->cc.get()); !heroPtr.isVerified(false))
+		if(HeroPtr heroPtr(node->actor->hero, aiNk->cc.get()); !heroPtr.isVerified(false))
 		{
 #if NK2AI_TRACE_LEVEL >= 1
 			logAi->warn("AINodeStorage::calculateChainInfo Skipping path due to unverified hero: %s", heroPtr.nameOrDefault());
@@ -1712,14 +1744,14 @@ void AINodeStorage::calculateChainInfo(std::vector<AIPath> & paths, const int3 &
 		}
 
 		AIPath & path = paths.emplace_back();
-		path.targetHero = node.actor->hero;
-		path.heroArmy = node.actor->creatureSet;
-		path.armyLoss = node.armyLoss;
-		path.chainMask = node.actor->chainMask;
+		path.targetHero = node->actor->hero;
+		path.heroArmy = node->actor->creatureSet;
+		path.armyLoss = node->armyLoss;
+		path.chainMask = node->actor->chainMask;
 
 		RealMoveMasksByHero realMoveMasks;
 		int parentIndex = -1;
-		if(!tryReconstructChainInfo(&node, path, parentIndex, realMoveMasks))
+		if(!tryReconstructChainInfo(node, path, parentIndex, realMoveMasks))
 		{
 #if NK2AI_PATHFINDER_TRACE_LEVEL >= 2
 			logAi->trace("AINodeStorage::calculateChainInfo Skip conflicting reconstructed chain path %s", path.toString());
@@ -1727,19 +1759,19 @@ void AINodeStorage::calculateChainInfo(std::vector<AIPath> & paths, const int3 &
 			paths.pop_back();
 			continue;
 		}
-		path.targetObjectDanger = aiNk->dangerEvaluator->evaluateDanger(pos, path.targetHero, !node.actor->allowBattle);
+		path.targetObjectDanger = aiNk->dangerEvaluator->evaluateDanger(pos, path.targetHero, !node->actor->allowBattle);
 		for(const auto & pathNode : path.nodes)
 		{
-			auto pathNodeDanger = aiNk->dangerEvaluator->evaluateDanger(pathNode.coord, path.targetHero, !node.actor->allowBattle);
+			auto pathNodeDanger = aiNk->dangerEvaluator->evaluateDanger(pathNode.coord, path.targetHero, !node->actor->allowBattle);
 			path.targetObjectDanger = std::max(pathNodeDanger, path.targetObjectDanger);
 		}
 
 		if(path.targetObjectDanger > 0)
 		{
-			if(node.theNodeBefore)
+			if(node->theNodeBefore)
 			{
-				const auto * prevNode = getAINode(node.theNodeBefore);
-				if(node.coord == prevNode->coord && node.actor->hero == prevNode->actor->hero)
+				const auto * prevNode = getAINode(node->theNodeBefore);
+				if(node->coord == prevNode->coord && node->actor->hero == prevNode->actor->hero)
 				{
 					paths.pop_back();
 					continue;
@@ -1770,7 +1802,7 @@ void AINodeStorage::calculateChainInfo(std::vector<AIPath> & paths, const int3 &
 			path.targetHero,
 			getHeroArmyStrengthWithCommander(path.targetHero, path.heroArmy, fortLevel),
 			path.targetObjectDanger);
-		path.exchangeCount = node.actor->actorExchangeCount;
+		path.exchangeCount = node->actor->actorExchangeCount;
 	}
 }
 

--- a/AI/Nullkiller2/Pathfinding/AINodeStorage.cpp
+++ b/AI/Nullkiller2/Pathfinding/AINodeStorage.cpp
@@ -79,6 +79,18 @@ AISharedStorage::~AISharedStorage()
 	}
 }
 
+bool AISharedStorage::beginGeneration()
+{
+	++version;
+	if(version != 0)
+		return false;
+
+	for(auto * node = nodes->data(); node != nodes->data() + nodes->num_elements(); ++node)
+		node->version = 0;
+	version = 1;
+	return true;
+}
+
 void AIPathNode::addSpecialAction(std::shared_ptr<const SpecialAction> action)
 {
 	if(!specialAction)
@@ -113,7 +125,7 @@ int AINodeStorage::getBucketSize() const
 AINodeStorage::AINodeStorage(Nullkiller * aiNk, const int3 & sizes)
 	: sizes(sizes), aiNk(aiNk), nodes(sizes, aiNk->settings->getPathfinderBucketSize() * aiNk->settings->getPathfinderBucketsCount(), *aiNk->cc)
 {
-	accessibility = std::make_unique<boost::multi_array<EPathAccessibility, 4>>(
+	accessibility = std::make_unique<boost::multi_array<AccessibilityInfo, 4>>(
 		boost::extents[sizes.z][sizes.x][sizes.y][EPathfindingLayer::NUM_LAYERS]);
 }
 
@@ -124,55 +136,64 @@ void AINodeStorage::initialize(const PathfinderOptions & options, const IGameInf
 	if(heroChainPass != EHeroChainPass::INITIAL)
 		return;
 
-	AISharedStorage::version++;
+	if(nodes.beginGeneration())
+	{
+		for(auto * info = accessibility->data(); info != accessibility->data() + accessibility->num_elements(); ++info)
+			info->generation = 0;
+	}
 
-	//TODO: fix this code duplication with NodeStorage::initialize, problem is to keep `resetTile` inline
-	const PlayerColor fowPlayer = aiNk->playerID;
-	const auto & fow = gameInfo.getPlayerTeam(fowPlayer)->fogOfWarMap;
-	const int3 sizes = gameInfo.getMapSize();
+	this->gameInfo = &gameInfo;
+	playerTeam = gameInfo.getPlayerTeam(aiNk->playerID);
+	useFlying = options.useFlying;
+	useWaterWalking = options.useWaterWalking;
+}
 
-	//Each thread gets different x, but an array of y located next to each other in memory
+EPathAccessibility AINodeStorage::getAccessibility(
+	const int3 & pos,
+	const EPathfindingLayer layer) const
+{
+	auto & info = (*accessibility)[pos.z][pos.x][pos.y][layer.getNum()];
+	if(info.generation == AISharedStorage::version)
+		return info.value;
 
-	Parallelism::parallelFor(
-		sizes.x,
-		64,
-		aiNk->settings->getMaxParallelWorkers(),
-		[&](const tbb::blocked_range<size_t> & r)
+	const TerrainTile * tile = gameInfo->getTile(pos);
+	const TerrainType * terrain = tile->getTerrain();
+	info.value = EPathAccessibility::NOT_SET;
+
+	if(terrain->isPassable())
+	{
+		const bool isWater = terrain->isWater();
+		if(!((layer == ELayer::LAND && isWater)
+			|| (layer == ELayer::SAIL && !isWater)
+			|| (layer == ELayer::AIR && !useFlying)
+			|| (layer == ELayer::WATER && (!isWater || !useWaterWalking))))
 		{
-			int3 pos;
-
-			for(pos.z = 0; pos.z < sizes.z; ++pos.z)
+			switch(layer.toEnum())
 			{
-				const bool useFlying = options.useFlying;
-				const bool useWaterWalking = options.useWaterWalking;
-				const PlayerColor player = playerID;
-
-				for(pos.x = r.begin(); pos.x != r.end(); ++pos.x)
-				{
-					for(pos.y = 0; pos.y < sizes.y; ++pos.y)
-					{
-						const TerrainTile * tile = gameInfo.getTile(pos);
-						if(!tile->getTerrain()->isPassable())
-							continue;
-
-						if(tile->isWater())
-						{
-							resetTile(pos, ELayer::SAIL, PathfinderUtil::evaluateAccessibility<ELayer::SAIL>(pos, *tile, fow, player, gameInfo));
-							if(useFlying)
-								resetTile(pos, ELayer::AIR, PathfinderUtil::evaluateAccessibility<ELayer::AIR>(pos, *tile, fow, player, gameInfo));
-							if(useWaterWalking)
-								resetTile(pos, ELayer::WATER, PathfinderUtil::evaluateAccessibility<ELayer::WATER>(pos, *tile, fow, player, gameInfo));
-						}
-						else
-						{
-							resetTile(pos, ELayer::LAND, PathfinderUtil::evaluateAccessibility<ELayer::LAND>(pos, *tile, fow, player, gameInfo));
-							if(useFlying)
-								resetTile(pos, ELayer::AIR, PathfinderUtil::evaluateAccessibility<ELayer::AIR>(pos, *tile, fow, player, gameInfo));
-						}
-					}
-				}
+			case ELayer::LAND:
+				info.value = PathfinderUtil::evaluateAccessibility<ELayer::LAND>(
+					pos, *tile, playerTeam->fogOfWarMap, playerID, *gameInfo);
+				break;
+			case ELayer::SAIL:
+				info.value = PathfinderUtil::evaluateAccessibility<ELayer::SAIL>(
+					pos, *tile, playerTeam->fogOfWarMap, playerID, *gameInfo);
+				break;
+			case ELayer::WATER:
+				info.value = PathfinderUtil::evaluateAccessibility<ELayer::WATER>(
+					pos, *tile, playerTeam->fogOfWarMap, playerID, *gameInfo);
+				break;
+			case ELayer::AIR:
+				info.value = PathfinderUtil::evaluateAccessibility<ELayer::AIR>(
+					pos, *tile, playerTeam->fogOfWarMap, playerID, *gameInfo);
+				break;
+			default:
+				break;
 			}
-		});
+		}
+	}
+
+	info.generation = AISharedStorage::version;
+	return info.value;
 }
 
 void AINodeStorage::clear()

--- a/AI/Nullkiller2/Pathfinding/AINodeStorage.cpp
+++ b/AI/Nullkiller2/Pathfinding/AINodeStorage.cpp
@@ -133,42 +133,46 @@ void AINodeStorage::initialize(const PathfinderOptions & options, const IGameInf
 
 	//Each thread gets different x, but an array of y located next to each other in memory
 
-	tbb::parallel_for(tbb::blocked_range<size_t>(0, sizes.x), [&](const tbb::blocked_range<size_t>& r)
-	{
-		int3 pos;
-
-		for(pos.z = 0; pos.z < sizes.z; ++pos.z)
+	Parallelism::parallelFor(
+		sizes.x,
+		64,
+		aiNk->settings->getMaxParallelWorkers(),
+		[&](const tbb::blocked_range<size_t> & r)
 		{
-			const bool useFlying = options.useFlying;
-			const bool useWaterWalking = options.useWaterWalking;
-			const PlayerColor player = playerID;
+			int3 pos;
 
-			for(pos.x = r.begin(); pos.x != r.end(); ++pos.x)
+			for(pos.z = 0; pos.z < sizes.z; ++pos.z)
 			{
-				for(pos.y = 0; pos.y < sizes.y; ++pos.y)
-				{
-					const TerrainTile * tile = gameInfo.getTile(pos);
-					if (!tile->getTerrain()->isPassable())
-						continue;
+				const bool useFlying = options.useFlying;
+				const bool useWaterWalking = options.useWaterWalking;
+				const PlayerColor player = playerID;
 
-					if (tile->isWater())
+				for(pos.x = r.begin(); pos.x != r.end(); ++pos.x)
+				{
+					for(pos.y = 0; pos.y < sizes.y; ++pos.y)
 					{
-						resetTile(pos, ELayer::SAIL, PathfinderUtil::evaluateAccessibility<ELayer::SAIL>(pos, *tile, fow, player, gameInfo));
-						if (useFlying)
-							resetTile(pos, ELayer::AIR, PathfinderUtil::evaluateAccessibility<ELayer::AIR>(pos, *tile, fow, player, gameInfo));
-						if (useWaterWalking)
-							resetTile(pos, ELayer::WATER, PathfinderUtil::evaluateAccessibility<ELayer::WATER>(pos, *tile, fow, player, gameInfo));
-					}
-					else
-					{
-						resetTile(pos, ELayer::LAND, PathfinderUtil::evaluateAccessibility<ELayer::LAND>(pos, *tile, fow, player, gameInfo));
-						if (useFlying)
-							resetTile(pos, ELayer::AIR, PathfinderUtil::evaluateAccessibility<ELayer::AIR>(pos, *tile, fow, player, gameInfo));
+						const TerrainTile * tile = gameInfo.getTile(pos);
+						if(!tile->getTerrain()->isPassable())
+							continue;
+
+						if(tile->isWater())
+						{
+							resetTile(pos, ELayer::SAIL, PathfinderUtil::evaluateAccessibility<ELayer::SAIL>(pos, *tile, fow, player, gameInfo));
+							if(useFlying)
+								resetTile(pos, ELayer::AIR, PathfinderUtil::evaluateAccessibility<ELayer::AIR>(pos, *tile, fow, player, gameInfo));
+							if(useWaterWalking)
+								resetTile(pos, ELayer::WATER, PathfinderUtil::evaluateAccessibility<ELayer::WATER>(pos, *tile, fow, player, gameInfo));
+						}
+						else
+						{
+							resetTile(pos, ELayer::LAND, PathfinderUtil::evaluateAccessibility<ELayer::LAND>(pos, *tile, fow, player, gameInfo));
+							if(useFlying)
+								resetTile(pos, ELayer::AIR, PathfinderUtil::evaluateAccessibility<ELayer::AIR>(pos, *tile, fow, player, gameInfo));
+						}
 					}
 				}
 			}
-		}
-	});
+		});
 }
 
 void AINodeStorage::clear()
@@ -563,22 +567,26 @@ bool AINodeStorage::calculateHeroChain()
 	heroChain.clear();
 
 	const std::vector<int3> tiles(committedTiles.begin(), committedTiles.end());
-	const int maxConcurrency = tbb::this_task_arena::max_concurrency();
-	std::vector<std::vector<CGPathNode *>> results(maxConcurrency);
-	logAi->trace("AINodeStorage::calculateHeroChain for %d items with %d maxConcurrency", tiles.size(), maxConcurrency);
+	constexpr size_t chunkSize = 1024;
+	const size_t chunkCount = (tiles.size() + chunkSize - 1) / chunkSize;
+	std::vector<std::vector<CGPathNode *>> results(chunkCount);
+	logAi->trace("AINodeStorage::calculateHeroChain for %zu items in %zu chunks", tiles.size(), chunkCount);
 
 	tbb::parallel_for(
-		tbb::blocked_range<size_t>(0, tiles.size(), 10),
-		[&](const tbb::blocked_range<size_t> & r)
+		tbb::blocked_range<size_t>(0, chunkCount),
+		[&](const tbb::blocked_range<size_t> & chunkRange)
 		{
-			HeroChainCalculationTask task(*this, tiles, chainMask, heroChainTurn);
-			const int ourThread = tbb::this_task_arena::current_thread_index();
-			task.execute(r);
-			task.flushResult(results.at(ourThread));
+			for(size_t chunk = chunkRange.begin(); chunk != chunkRange.end(); ++chunk)
+			{
+				const size_t begin = chunk * chunkSize;
+				const size_t end = std::min(tiles.size(), begin + chunkSize);
+				HeroChainCalculationTask task(*this, tiles, chainMask, heroChainTurn);
+				task.execute(tbb::blocked_range<size_t>(begin, end));
+				task.flushResult(results[chunk]);
+			}
 		}
 	);
 
-	// FIXME: potentially non-deterministic behavior due to parallel_for
 	for(const auto & result : results)
 		vstd::concatenate(heroChain, result);
 

--- a/AI/Nullkiller2/Pathfinding/AINodeStorage.cpp
+++ b/AI/Nullkiller2/Pathfinding/AINodeStorage.cpp
@@ -1721,7 +1721,25 @@ bool AINodeStorage::hasCurrentNodes(const int3 & pos) const
 
 void AINodeStorage::calculateChainInfo(std::vector<AIPath> & paths, const int3 & pos, const bool isOnLand) const
 {
-	auto layer = isOnLand ? EPathfindingLayer::LAND : EPathfindingLayer::SAIL;
+	const auto layer = isOnLand ? EPathfindingLayer::LAND : EPathfindingLayer::SAIL;
+	for(const AIPathNode * node : nodes.get(pos))
+	{
+		if(node->version != nodes.getGeneration() || node->layer != layer)
+			continue;
+
+		AIPath & path = paths.emplace_back();
+		if(!calculatePathInfo(path, node))
+			paths.pop_back();
+	}
+}
+
+void AINodeStorage::calculatePathSummaries(
+	std::vector<AIPathSummary> & summaries,
+	const int3 & pos,
+	const bool isOnLand) const
+{
+	summaries.clear();
+	const auto layer = isOnLand ? EPathfindingLayer::LAND : EPathfindingLayer::SAIL;
 	const auto & chains = nodes.get(pos);
 
 	for(const AIPathNode * node : chains)
@@ -1743,67 +1761,105 @@ void AINodeStorage::calculateChainInfo(std::vector<AIPath> & paths, const int3 &
 			continue;
 		}
 
-		AIPath & path = paths.emplace_back();
-		path.targetHero = node->actor->hero;
-		path.heroArmy = node->actor->creatureSet;
-		path.armyLoss = node->armyLoss;
-		path.chainMask = node->actor->chainMask;
-
-		RealMoveMasksByHero realMoveMasks;
-		int parentIndex = -1;
-		if(!tryReconstructChainInfo(node, path, parentIndex, realMoveMasks))
-		{
 #if NK2AI_PATHFINDER_TRACE_LEVEL >= 2
-			logAi->trace("AINodeStorage::calculateChainInfo Skip conflicting reconstructed chain path %s", path.toString());
+		logAi->trace(
+			"AINodeStorage::calculatePathSummaries found %s for %s",
+			node->coord.toString(),
+			node->actor->hero->getNameTranslated());
 #endif
-			paths.pop_back();
-			continue;
-		}
-		path.targetObjectDanger = aiNk->dangerEvaluator->evaluateDanger(pos, path.targetHero, !node->actor->allowBattle);
-		for(const auto & pathNode : path.nodes)
-		{
-			auto pathNodeDanger = aiNk->dangerEvaluator->evaluateDanger(pathNode.coord, path.targetHero, !node->actor->allowBattle);
-			path.targetObjectDanger = std::max(pathNodeDanger, path.targetObjectDanger);
-		}
 
-		if(path.targetObjectDanger > 0)
-		{
-			if(node->theNodeBefore)
-			{
-				const auto * prevNode = getAINode(node->theNodeBefore);
-				if(node->coord == prevNode->coord && node->actor->hero == prevNode->actor->hero)
-				{
-					paths.pop_back();
-					continue;
-				}
-				else
-				{
-					path.armyLoss = prevNode->armyLoss;
-				}
-			}
-			else
-			{
-				path.armyLoss = 0;
-			}
-		}
-
-		int fortLevel = 0;
-		auto visitableObjects = aiNk->cc->getVisitableObjs(pos);
-		for (const auto * obj : visitableObjects)
-		{
-			if (objWithID<Obj::TOWN>(obj))
-			{
-				const auto * town = dynamic_cast<const CGTownInstance*>(obj);
-				fortLevel = town->fortLevel();
-			}
-		}
-
-		path.targetObjectArmyLoss = evaluateArmyLoss(
-			path.targetHero,
-			getHeroArmyStrengthWithCommander(path.targetHero, path.heroArmy, fortLevel),
-			path.targetObjectDanger);
-		path.exchangeCount = node->actor->actorExchangeCount;
+		auto & summary = summaries.emplace_back();
+		summary.node = node;
+		summary.targetHero = node->actor->hero;
+		summary.cost = node->getCost();
+		summary.exchangeCount = node->actor->actorExchangeCount;
+		summary.generation = nodes.getGeneration();
+		summary.stableOrder = node->storageOrder;
 	}
+}
+
+bool AINodeStorage::calculatePathInfo(AIPath & path, const AIPathSummary & summary) const
+{
+	if(!summary.node
+		|| summary.generation != nodes.getGeneration()
+		|| summary.node->version != nodes.getGeneration()
+		|| summary.node->storageOrder != summary.stableOrder)
+	{
+		return false;
+	}
+
+	return calculatePathInfo(path, summary.node);
+}
+
+bool AINodeStorage::calculatePathInfo(AIPath & path, const AIPathNode * node) const
+{
+	if(node->action == EPathNodeAction::UNKNOWN || !node->actor || !node->actor->hero)
+		return false;
+
+	HeroPtr heroPtr(node->actor->hero, aiNk->cc.get());
+	if(!heroPtr.isVerified(false))
+		return false;
+
+	path = AIPath();
+	path.targetHero = node->actor->hero;
+	path.heroArmy = node->actor->creatureSet;
+	path.armyLoss = node->armyLoss;
+	path.chainMask = node->actor->chainMask;
+
+	RealMoveMasksByHero realMoveMasks;
+	int parentIndex = -1;
+	if(!tryReconstructChainInfo(node, path, parentIndex, realMoveMasks))
+	{
+#if NK2AI_PATHFINDER_TRACE_LEVEL >= 2
+		logAi->trace("AINodeStorage::calculatePathInfo skipped conflicting path %s", path.toString());
+#endif
+		return false;
+	}
+
+	path.targetObjectDanger = aiNk->dangerEvaluator->evaluateDanger(
+		node->coord,
+		path.targetHero,
+		!node->actor->allowBattle);
+	for(const auto & pathNode : path.nodes)
+	{
+		const auto pathNodeDanger = aiNk->dangerEvaluator->evaluateDanger(
+			pathNode.coord,
+			path.targetHero,
+			!node->actor->allowBattle);
+		path.targetObjectDanger = std::max(pathNodeDanger, path.targetObjectDanger);
+	}
+
+	if(path.targetObjectDanger > 0)
+	{
+		if(node->theNodeBefore)
+		{
+			const auto * previousNode = getAINode(node->theNodeBefore);
+			if(node->coord == previousNode->coord
+				&& node->actor->hero == previousNode->actor->hero)
+			{
+				return false;
+			}
+			path.armyLoss = previousNode->armyLoss;
+		}
+		else
+		{
+			path.armyLoss = 0;
+		}
+	}
+
+	int fortLevel = 0;
+	for(const auto * object : aiNk->cc->getVisitableObjs(node->coord))
+	{
+		if(objWithID<Obj::TOWN>(object))
+			fortLevel = dynamic_cast<const CGTownInstance *>(object)->fortLevel();
+	}
+
+	path.targetObjectArmyLoss = evaluateArmyLoss(
+		path.targetHero,
+		getHeroArmyStrengthWithCommander(path.targetHero, path.heroArmy, fortLevel),
+		path.targetObjectDanger);
+	path.exchangeCount = node->actor->actorExchangeCount;
+	return true;
 }
 
 bool AINodeStorage::tryReconstructChainInfo(const AIPathNode * node, AIPath & path,	int & parentIndex, RealMoveMasksByHero & realMoveMasks) const

--- a/AI/Nullkiller2/Pathfinding/AINodeStorage.h
+++ b/AI/Nullkiller2/Pathfinding/AINodeStorage.h
@@ -22,6 +22,7 @@ constexpr int NK2AI_GRAPH_TRACE_LEVEL = 0; // To actually enable graph visualiza
 
 class CSpell;
 class DimensionDoorEffect;
+struct TeamState;
 
 namespace NK2AI
 {
@@ -158,6 +159,7 @@ public:
 
 	explicit AISharedStorage(int3 sizes, int numChains, const CCallback & cc);
 	~AISharedStorage();
+	bool beginGeneration();
 
 	inline
 	boost::detail::multi_array::sub_array<AIPathNode, 1> get(int3 tile) const
@@ -169,8 +171,18 @@ public:
 class AINodeStorage : public INodeStorage
 {
 private:
+	struct AccessibilityInfo
+	{
+		EPathAccessibility value = EPathAccessibility::NOT_SET;
+		uint32_t generation = 0;
+	};
+
 	int3 sizes;
-	std::unique_ptr<boost::multi_array<EPathAccessibility, 4>> accessibility;
+	mutable std::unique_ptr<boost::multi_array<AccessibilityInfo, 4>> accessibility;
+	const IGameInfoCallback * gameInfo = nullptr;
+	const TeamState * playerTeam = nullptr;
+	bool useFlying = false;
+	bool useWaterWalking = false;
 	Nullkiller * aiNk; // TODO: Mircea: Replace with &
 	AISharedStorage nodes;
 	std::vector<std::shared_ptr<ChainActor>> actors;
@@ -285,15 +297,7 @@ public:
 
 	uint64_t evaluateArmyLoss(const CGHeroInstance * hero, uint64_t armyValue, uint64_t danger) const;
 
-	inline EPathAccessibility getAccessibility(const int3 & tile, EPathfindingLayer layer) const
-	{
-		return (*this->accessibility)[tile.z][tile.x][tile.y][layer.getNum()];
-	}
-
-	inline void resetTile(const int3 & tile, EPathfindingLayer layer, EPathAccessibility tileAccessibility)
-	{
-		(*this->accessibility)[tile.z][tile.x][tile.y][layer.getNum()] = tileAccessibility;
-	}
+	EPathAccessibility getAccessibility(const int3 & tile, EPathfindingLayer layer) const;
 
 	void calculateTownPortalTeleportations(std::vector<CGPathNode *> & neighbours);
 

--- a/AI/Nullkiller2/Pathfinding/AINodeStorage.h
+++ b/AI/Nullkiller2/Pathfinding/AINodeStorage.h
@@ -345,6 +345,15 @@ public:
 
 
 private:
+	struct DimensionDoorCapability
+	{
+		const CSpell * spell = nullptr;
+		const DimensionDoorEffect * effect = nullptr;
+		int manaCost = 0;
+		int castsLimit = 0;
+		int castsAlreadyPerformed = 0;
+	};
+
 	struct DimensionDoorSpellPlan
 	{
 		const CSpell * spell = nullptr;
@@ -364,6 +373,10 @@ private:
 		uint64_t guardedLandingArmyLoss = 0;
 		bool canLand = true;
 	};
+
+	HeroMap<std::vector<DimensionDoorCapability>> dimensionDoorCapabilities;
+
+	const std::vector<DimensionDoorCapability> & getDimensionDoorCapabilities(const CGHeroInstance * hero);
 
 	void calculateObjectTeleportations(
 		std::vector<CGPathNode *> & neighbours,
@@ -387,7 +400,7 @@ private:
 		const CPathfinderHelper * pathfinderHelper,
 		const AIPathNode * srcNode,
 		const CGHeroInstance * hero,
-		const CSpell * spell) const;
+		const DimensionDoorCapability & capability) const;
 
 	void calculateDimensionDoorTeleportationsForSpell(
 		std::vector<CGPathNode *> & neighbours,

--- a/AI/Nullkiller2/Pathfinding/AINodeStorage.h
+++ b/AI/Nullkiller2/Pathfinding/AINodeStorage.h
@@ -135,6 +135,16 @@ struct AIPath
 	bool containsHero(const CGHeroInstance * hero) const;
 };
 
+struct AIPathSummary
+{
+	const AIPathNode * node = nullptr;
+	const CGHeroInstance * targetHero = nullptr;
+	float cost = 0.f;
+	uint8_t exchangeCount = 0;
+	uint32_t generation = 0;
+	uint64_t stableOrder = 0;
+};
+
 struct ExchangeCandidate : public AIPathNode
 {
 	AIPathNode * carrierParent = nullptr;
@@ -302,6 +312,8 @@ public:
 	std::optional<AIPathNode *> getOrCreateNode(const int3 & coord, const EPathfindingLayer layer, const ChainActor * actor);
 	bool hasCurrentNodes(const int3 & pos) const;
 	void calculateChainInfo(std::vector<AIPath> & paths, const int3 & pos, bool isOnLand) const;
+	void calculatePathSummaries(std::vector<AIPathSummary> & summaries, const int3 & pos, bool isOnLand) const;
+	bool calculatePathInfo(AIPath & path, const AIPathSummary & summary) const;
 	bool isTileAccessible(const HeroPtr & heroPtr, const int3 & pos, const EPathfindingLayer layer) const;
 	void setHeroes(HeroMap<HeroRole> heroes);
 	void setScoutTurnDistanceLimit(uint8_t distanceLimit) { turnDistanceLimit[HeroRole::SCOUT] = distanceLimit; }
@@ -330,6 +342,7 @@ public:
 	// Reconstructs an AIPath by walking theNodeBefore / chainOther, appending branch nodes first and linking them via parentIndex
 	// Returns false when reconstruction would assign conflicting real-move chainMasks to the same hero
 	bool tryReconstructChainInfo(const AIPathNode * node, AIPath & path, int & parentIndex, RealMoveMasksByHero & realMoveMasks) const;
+	bool calculatePathInfo(AIPath & path, const AIPathNode * node) const;
 
 	template<typename Fn>
 	void iterateValidNodes(const int3 & pos, EPathfindingLayer layer, Fn fn)

--- a/AI/Nullkiller2/Pathfinding/AINodeStorage.h
+++ b/AI/Nullkiller2/Pathfinding/AINodeStorage.h
@@ -16,6 +16,8 @@
 #include "Actors.h"
 #include "../Helpers/HeroMap.h"
 
+#include <tbb/concurrent_vector.h>
+
 #define NK2AI_PATHFINDER_TRACE_LEVEL 0
 constexpr int NK2AI_GRAPH_TRACE_LEVEL = 0; // To actually enable graph visualization, enter `/vslog graph` in game chat
 #define NK2AI_TRACE_LEVEL 0
@@ -50,6 +52,7 @@ struct AIPathNode : public CGPathNode
 	uint64_t danger = 0;
 	uint64_t armyLoss = 0;
 	uint32_t version = 0;
+	uint64_t storageOrder = std::numeric_limits<uint64_t>::max();
 
 	int16_t manaCost = 0;
 	DayFlags dayFlags = DayFlags::NONE;
@@ -147,25 +150,33 @@ enum EHeroChainPass
 	FINAL // same as SINGLE but for heroes from CHAIN pass
 };
 
-class AISharedStorage
+class AIPathNodePool
 {
-	// 1-3 - position on map[z][x][y]
-	// 4 - chain + layer (normal, battle, spellcast and combinations, water, air)
-	static std::shared_ptr<boost::multi_array<AIPathNode, 4>> shared;
-	std::shared_ptr<boost::multi_array<AIPathNode, 4>> nodes;
-public:
-	static std::mutex locker;
-	static uint32_t version;
+	using NodeList = std::vector<AIPathNode *>;
 
-	explicit AISharedStorage(int3 sizes, int numChains, const CCallback & cc);
-	~AISharedStorage();
-	bool beginGeneration();
-
-	inline
-	boost::detail::multi_array::sub_array<AIPathNode, 1> get(int3 tile) const
+	struct TileNodes
 	{
-		return (*nodes)[tile.z][tile.x][tile.y];
-	}
+		NodeList nodes;
+		uint32_t generation = 0;
+	};
+
+	int3 sizes;
+	size_t capacity;
+	uint32_t generation = 0;
+	std::vector<TileNodes> tiles;
+	tbb::concurrent_vector<AIPathNode> nodes;
+
+	size_t tileIndex(const int3 & tile) const;
+	TileNodes & getCurrentTile(const int3 & tile);
+
+public:
+	AIPathNodePool(int3 sizes, size_t capacity);
+
+	bool beginGeneration();
+	AIPathNode * allocate(const int3 & tile);
+	const NodeList & get(const int3 & tile) const;
+	uint64_t nextStorageOrder(const int3 & tile, size_t offset = 0) const;
+	uint32_t getGeneration() const { return generation; }
 };
 
 class AINodeStorage : public INodeStorage
@@ -184,9 +195,11 @@ private:
 	bool useFlying = false;
 	bool useWaterWalking = false;
 	Nullkiller * aiNk; // TODO: Mircea: Replace with &
-	AISharedStorage nodes;
+	AIPathNodePool nodes;
 	std::vector<std::shared_ptr<ChainActor>> actors;
 	std::vector<CGPathNode *> heroChain;
+	std::set<int3> committedTiles;
+	std::set<int3> committedTilesInitial;
 	EHeroChainPass heroChainPass; // true if we need to calculate hero chain
 	uint64_t chainMask;
 	int heroChainTurn;
@@ -207,6 +220,11 @@ public:
 
 	int getBucketCount() const;
 	int getBucketSize() const;
+	bool isCurrentNode(const AIPathNode * node) const { return node->version == nodes.getGeneration(); }
+	uint64_t nextStorageOrder(const int3 & tile, size_t offset = 0) const
+	{
+		return nodes.nextStorageOrder(tile, offset);
+	}
 
 	std::vector<CGPathNode *> getInitialNodes() override;
 
@@ -231,7 +249,7 @@ public:
 		int turn,
 		int movementLeft,
 		float cost,
-		bool saveToCommitted = true) const;
+		bool saveToCommitted = true);
 
 	inline const AIPathNode * getAINode(const CGPathNode * node) const
 	{
@@ -282,6 +300,7 @@ public:
 	bool isDistanceLimitReached(const PathNodeInfo & source, CDestinationNodeInfo & destination) const;
 
 	std::optional<AIPathNode *> getOrCreateNode(const int3 & coord, const EPathfindingLayer layer, const ChainActor * actor);
+	bool hasCurrentNodes(const int3 & pos) const;
 	void calculateChainInfo(std::vector<AIPath> & paths, const int3 & pos, bool isOnLand) const;
 	bool isTileAccessible(const HeroPtr & heroPtr, const int3 & pos, const EPathfindingLayer layer) const;
 	void setHeroes(HeroMap<HeroRole> heroes);
@@ -318,13 +337,13 @@ public:
 		if(blocked(pos, layer))
 			return;
 
-		auto chains = nodes.get(pos);
-		for(AIPathNode & node : chains)
+		const auto & chains = nodes.get(pos);
+		for(AIPathNode * node : chains)
 		{
-			if(node.version != AISharedStorage::version || node.layer != layer)
+			if(node->version != nodes.getGeneration() || node->layer != layer)
 				continue;
 
-			fn(node);
+			fn(*node);
 		}
 	}
 
@@ -334,13 +353,13 @@ public:
 		if(blocked(pos, layer))
 			return false;
 
-		auto chains = nodes.get(pos);
-		for(AIPathNode & node : chains)
+		const auto & chains = nodes.get(pos);
+		for(AIPathNode * node : chains)
 		{
-			if(node.version != AISharedStorage::version || node.layer != layer)
+			if(node->version != nodes.getGeneration() || node->layer != layer)
 				continue;
 
-			if(predicate(node))
+			if(predicate(*node))
 				return true;
 		}
 

--- a/AI/Nullkiller2/Pathfinding/AIPathfinder.cpp
+++ b/AI/Nullkiller2/Pathfinding/AIPathfinder.cpp
@@ -18,8 +18,6 @@
 namespace NK2AI
 {
 
-std::map<ObjectInstanceID, std::unique_ptr<GraphPaths>>  AIPathfinder::heroGraphs;
-
 AIPathfinder::AIPathfinder(Nullkiller * aiNk) : aiNk(aiNk) {}
 
 bool AIPathfinder::isTileAccessible(const HeroPtr & hero, const int3 & tile) const
@@ -43,8 +41,11 @@ void AIPathfinder::calculateQuickPathsWithBlocker(std::vector<AIPath> & result, 
 
 void AIPathfinder::calculatePathInfo(std::vector<AIPath> & paths, const int3 & tile, bool includeGraph) const
 {
-	const TerrainTile * tileInfo = aiNk->cc->getTile(tile, false);
 	paths.clear();
+	if(!includeGraph && !storage->hasCurrentNodes(tile))
+		return;
+
+	const TerrainTile * tileInfo = aiNk->cc->getTile(tile, false);
 	if(!tileInfo)
 		return;
 

--- a/AI/Nullkiller2/Pathfinding/AIPathfinder.cpp
+++ b/AI/Nullkiller2/Pathfinding/AIPathfinder.cpp
@@ -63,6 +63,24 @@ void AIPathfinder::calculatePathInfo(std::vector<AIPath> & paths, const int3 & t
 	}
 }
 
+void AIPathfinder::calculatePathSummaries(
+	std::vector<AIPathSummary> & summaries,
+	const int3 & tile) const
+{
+	summaries.clear();
+	if(!storage->hasCurrentNodes(tile))
+		return;
+
+	const TerrainTile * tileInfo = aiNk->cc->getTile(tile, false);
+	if(tileInfo)
+		storage->calculatePathSummaries(summaries, tile, !tileInfo->isWater());
+}
+
+bool AIPathfinder::calculatePathInfo(AIPath & path, const AIPathSummary & summary) const
+{
+	return storage->calculatePathInfo(path, summary);
+}
+
 void AIPathfinder::updatePaths(const HeroMap<HeroRole> & heroes, PathfinderSettings pathfinderSettings)
 {
 	if(!storage)

--- a/AI/Nullkiller2/Pathfinding/AIPathfinder.h
+++ b/AI/Nullkiller2/Pathfinding/AIPathfinder.h
@@ -44,7 +44,7 @@ class AIPathfinder
 private:
 	std::shared_ptr<AINodeStorage> storage;
 	Nullkiller * aiNk;
-	static std::map<ObjectInstanceID, std::unique_ptr<GraphPaths>>  heroGraphs;
+	std::map<ObjectInstanceID, std::unique_ptr<GraphPaths>> heroGraphs;
 
 public:
 	explicit AIPathfinder(Nullkiller * aiNk);

--- a/AI/Nullkiller2/Pathfinding/AIPathfinder.h
+++ b/AI/Nullkiller2/Pathfinding/AIPathfinder.h
@@ -49,6 +49,8 @@ private:
 public:
 	explicit AIPathfinder(Nullkiller * aiNk);
 	void calculatePathInfo(std::vector<AIPath> & paths, const int3 & tile, bool includeGraph = false) const;
+	void calculatePathSummaries(std::vector<AIPathSummary> & summaries, const int3 & tile) const;
+	bool calculatePathInfo(AIPath & path, const AIPathSummary & summary) const;
 	bool isTileAccessible(const HeroPtr & hero, const int3 & tile) const;
 	void updatePaths(const HeroMap<HeroRole> & heroes, PathfinderSettings pathfinderSettings);
 	void updateGraphs(const HeroMap<HeroRole> & heroes, uint8_t mainScanDepth, uint8_t scoutScanDepth);

--- a/AI/Nullkiller2/Pathfinding/Actions/DimensionDoorAction.cpp
+++ b/AI/Nullkiller2/Pathfinding/Actions/DimensionDoorAction.cpp
@@ -22,18 +22,25 @@
 
 namespace NK2AI::AIPathfinding
 {
-	bool canUseDimensionDoorAction(const DimensionDoorActionValidation & validation)
+	bool hasDimensionDoorActionResources(const DimensionDoorActionValidation & validation)
 	{
-		if(!validation.hero || !validation.spell)
+		if(!validation.hero)
 			return false;
 
 		const int plannedAndPerformedCasts = validation.castsAlreadyPerformed
 			+ validation.plannedDimensionDoorCasts;
 
-		return validation.hero->canCastThisSpell(validation.spell)
-			&& validation.hero->mana >= validation.manaAlreadySpent + validation.manaCost
+		return validation.hero->mana >= validation.manaAlreadySpent + validation.manaCost
 			&& validation.movementPointsRemaining > validation.movementPointsRequired
 			&& (validation.castsLimit <= 0 || plannedAndPerformedCasts < validation.castsLimit);
+	}
+
+	bool canUseDimensionDoorAction(const DimensionDoorActionValidation & validation)
+	{
+		return validation.hero
+			&& validation.spell
+			&& validation.hero->canCastThisSpell(validation.spell)
+			&& hasDimensionDoorActionResources(validation);
 	}
 
 	DimensionDoorAction::DimensionDoorAction(const DimensionDoorActionParameters & parameters)

--- a/AI/Nullkiller2/Pathfinding/Actions/DimensionDoorAction.h
+++ b/AI/Nullkiller2/Pathfinding/Actions/DimensionDoorAction.h
@@ -29,6 +29,7 @@ namespace NK2AI::AIPathfinding
 		int plannedDimensionDoorCasts = 0;
 	};
 
+	bool hasDimensionDoorActionResources(const DimensionDoorActionValidation & validation);
 	bool canUseDimensionDoorAction(const DimensionDoorActionValidation & validation);
 
 	struct DimensionDoorActionParameters

--- a/AI/Nullkiller2/pforeach.h
+++ b/AI/Nullkiller2/pforeach.h
@@ -12,7 +12,7 @@ void pforeachTilePaths(const int3 & mapSize, const Nullkiller * aiNk, TFunc fn)
 	for(int z = 0; z < mapSize.z; ++z)
 	{
 		tbb::parallel_for(
-			tbb::blocked_range<size_t>(0, mapSize.x),
+			tbb::blocked_range<size_t>(0, mapSize.x, 64),
 			[&](const tbb::blocked_range<size_t> & r)
 			{
 				int3 pos(0, 0, z);

--- a/lib/bonuses/CBonusSystemNode.cpp
+++ b/lib/bonuses/CBonusSystemNode.cpp
@@ -196,7 +196,9 @@ void CBonusSystemNode::attachTo(CBonusSystemNode & parent)
 		parent.children.push_back(this);
 	}
 
-	parent.nodeHasChanged();
+	// The new branch was invalidated by attachToSource. Adding it does not
+	// change the parent or existing branches; propagation invalidates every
+	// node whose bonuses actually change.
 }
 
 void CBonusSystemNode::attachToSource(const CBonusSystemNode & parent)
@@ -247,6 +249,7 @@ void CBonusSystemNode::detachFrom(CBonusSystemNode & parent)
 				nodeShortInfo(), static_cast<int>(nodeType), parent.nodeShortInfo(), static_cast<int>(parent.nodeType));
 		}
 	}
+
 	parent.nodeHasChanged();
 }
 

--- a/lib/pathfinder/CGPathNode.cpp
+++ b/lib/pathfinder/CGPathNode.cpp
@@ -76,10 +76,19 @@ CPathsInfo::~CPathsInfo() = default;
 
 void CPathsInfo::prepareForReuse(const CGHeroInstance * hero_)
 {
-	// PathfinderCache options and map terrain are stable, so NodeStorage::initialize
-	// resets the same active node layers before every path calculation.
 	hero = hero_;
 	heroBonusTreeVersion = hero->getTreeVersion();
+}
+
+void CPathsInfo::beginSearch()
+{
+	++currentGeneration;
+	if(currentGeneration != 0)
+		return;
+
+	for(auto * node = nodes.data(); node != nodes.data() + nodes.num_elements(); ++node)
+		node->generation = 0;
+	currentGeneration = 1;
 }
 
 const CGPathNode * CPathsInfo::getPathInfo(const int3 & tile, const ELayer layer) const
@@ -111,11 +120,10 @@ bool CPathsInfo::getPath(CGPath & out, const int3 & dst, const ELayer layer) con
 
 const CGPathNode * CPathsInfo::getNode(const int3 & coord) const
 {
-	const auto * landNode = &nodes[ELayer::LAND][coord.z][coord.x][coord.y];
+	const auto * landNode = getNode(coord, ELayer::LAND);
 	if(landNode->reachable())
 		return landNode;
-	else
-		return &nodes[ELayer::SAIL][coord.z][coord.x][coord.y];
+	return getNode(coord, ELayer::SAIL);
 }
 
 PathNodeInfo::PathNodeInfo()

--- a/lib/pathfinder/CGPathNode.cpp
+++ b/lib/pathfinder/CGPathNode.cpp
@@ -74,6 +74,14 @@ CPathsInfo::CPathsInfo(const int3 & Sizes, const CGHeroInstance * hero_)
 
 CPathsInfo::~CPathsInfo() = default;
 
+void CPathsInfo::prepareForReuse(const CGHeroInstance * hero_)
+{
+	// PathfinderCache options and map terrain are stable, so NodeStorage::initialize
+	// resets the same active node layers before every path calculation.
+	hero = hero_;
+	heroBonusTreeVersion = hero->getTreeVersion();
+}
+
 const CGPathNode * CPathsInfo::getPathInfo(const int3 & tile, const ELayer layer) const
 {
 	assert(vstd::iswithin(tile.x, 0, sizes.x));

--- a/lib/pathfinder/CGPathNode.h
+++ b/lib/pathfinder/CGPathNode.h
@@ -140,6 +140,8 @@ struct DLL_LINKAGE CGPathNode
 		}
 		else
 		{
+			assert(coord == Coord);
+			assert(layer == Layer);
 			reset();
 		}
 
@@ -204,6 +206,7 @@ struct DLL_LINKAGE CPathsInfo
 
 	CPathsInfo(const int3 & Sizes, const CGHeroInstance * hero_);
 	~CPathsInfo();
+	void prepareForReuse(const CGHeroInstance * hero_);
 	const CGPathNode * getPathInfo(const int3 & tile, const ELayer layer = ELayer::AUTO) const;
 	bool getPath(CGPath & out, const int3 & dst, const ELayer layer = ELayer::AUTO) const;
 	const CGPathNode * getNode(const int3 & coord) const;

--- a/lib/pathfinder/CGPathNode.h
+++ b/lib/pathfinder/CGPathNode.h
@@ -74,6 +74,7 @@ struct DLL_LINKAGE CGPathNode
 	EPathAccessibility accessible;
 	EPathNodeAction action;
 	bool locked;
+	uint32_t generation = 0;
 
 	CGPathNode()
 		: coord(-1),
@@ -197,6 +198,27 @@ struct DLL_LINKAGE CPathsInfo
 {
 	using ELayer = EPathfindingLayer;
 
+private:
+	friend class NodeStorage;
+
+	uint32_t currentGeneration = 1;
+	CGPathNode unreachableNode;
+
+	void beginSearch();
+
+	inline
+	CGPathNode * getNodeForWrite(const int3 & coord, const ELayer layer)
+	{
+		return &nodes[layer.getNum()][coord.z][coord.x][coord.y];
+	}
+
+	inline
+	bool isCurrent(const CGPathNode & node) const
+	{
+		return node.generation == currentGeneration;
+	}
+
+public:
 	const CGHeroInstance * hero;
 	int3 hpos;
 	int3 sizes;
@@ -211,17 +233,11 @@ struct DLL_LINKAGE CPathsInfo
 	bool getPath(CGPath & out, const int3 & dst, const ELayer layer = ELayer::AUTO) const;
 	const CGPathNode * getNode(const int3 & coord) const;
 
-	//FIXME: what is the non-const version used for? internal node storage should be modified via NodeStorage only
-	inline
-	CGPathNode * getNode(const int3 & coord, const ELayer layer)
-	{
-		return &nodes[layer.getNum()][coord.z][coord.x][coord.y];
-	}
-
 	inline
 	const CGPathNode * getNode(const int3 & coord, const ELayer layer) const
 	{
-		return &nodes[layer.getNum()][coord.z][coord.x][coord.y];
+		const auto * node = &nodes[layer.getNum()][coord.z][coord.x][coord.y];
+		return isCurrent(*node) ? node : &unreachableNode;
 	}
 };
 

--- a/lib/pathfinder/NodeStorage.cpp
+++ b/lib/pathfinder/NodeStorage.cpp
@@ -21,42 +21,55 @@
 
 void NodeStorage::initialize(const PathfinderOptions & options, const IGameInfoCallback & gameInfo)
 {
-	//TODO: fix this code duplication with AINodeStorage::initialize, problem is to keep `resetTile` inline
+	out.beginSearch();
+	this->gameInfo = &gameInfo;
+	player = out.hero->tempOwner;
+	playerTeam = gameInfo.getPlayerTeam(player);
+	useFlying = options.useFlying;
+	useWaterWalking = options.useWaterWalking;
+}
 
-	int3 pos;
-	const PlayerColor player = out.hero->tempOwner;
-	const int3 sizes = gameInfo.getMapSize();
-	const auto & fow = gameInfo.getPlayerTeam(player)->fogOfWarMap;
+EPathAccessibility NodeStorage::evaluateAccessibility(
+	const int3 & coord,
+	const EPathfindingLayer & layer) const
+{
+	const TerrainTile * tile = gameInfo->getTile(coord);
+	const bool isWater = tile->isWater();
 
-	//make 200% sure that these are loop invariants (also a bit shorter code), let compiler do the rest(loop unswitching)
-	const bool useFlying = options.useFlying;
-	const bool useWaterWalking = options.useWaterWalking;
+	if((layer == ELayer::LAND && isWater)
+		|| (layer == ELayer::SAIL && !isWater)
+		|| (layer == ELayer::AIR && !useFlying)
+		|| (layer == ELayer::WATER && (!isWater || !useWaterWalking)))
+		return EPathAccessibility::NOT_SET;
 
-	for(pos.z=0; pos.z < sizes.z; ++pos.z)
+	switch(layer.toEnum())
 	{
-		for(pos.x=0; pos.x < sizes.x; ++pos.x)
-		{
-			for(pos.y=0; pos.y < sizes.y; ++pos.y)
-			{
-				const TerrainTile * tile = gameInfo.getTile(pos);
-				resetTile(pos, ELayer::AVIATE, PathfinderUtil::evaluateAccessibility<ELayer::AVIATE>(pos, *tile, fow, player, gameInfo));
-				if(tile->isWater())
-				{
-					resetTile(pos, ELayer::SAIL, PathfinderUtil::evaluateAccessibility<ELayer::SAIL>(pos, *tile, fow, player, gameInfo));
-					if(useFlying)
-						resetTile(pos, ELayer::AIR, PathfinderUtil::evaluateAccessibility<ELayer::AIR>(pos, *tile, fow, player, gameInfo));
-					if(useWaterWalking)
-						resetTile(pos, ELayer::WATER, PathfinderUtil::evaluateAccessibility<ELayer::WATER>(pos, *tile, fow, player, gameInfo));
-				}
-				if(tile->isLand())
-				{
-					resetTile(pos, ELayer::LAND, PathfinderUtil::evaluateAccessibility<ELayer::LAND>(pos, *tile, fow, player, gameInfo));
-					if(useFlying)
-						resetTile(pos, ELayer::AIR, PathfinderUtil::evaluateAccessibility<ELayer::AIR>(pos, *tile, fow, player, gameInfo));
-				}
-			}
-		}
+	case ELayer::LAND:
+		return PathfinderUtil::evaluateAccessibility<ELayer::LAND>(
+			coord, *tile, playerTeam->fogOfWarMap, player, *gameInfo);
+	case ELayer::SAIL:
+		return PathfinderUtil::evaluateAccessibility<ELayer::SAIL>(
+			coord, *tile, playerTeam->fogOfWarMap, player, *gameInfo);
+	case ELayer::WATER:
+		return PathfinderUtil::evaluateAccessibility<ELayer::WATER>(
+			coord, *tile, playerTeam->fogOfWarMap, player, *gameInfo);
+	case ELayer::AIR:
+		return PathfinderUtil::evaluateAccessibility<ELayer::AIR>(
+			coord, *tile, playerTeam->fogOfWarMap, player, *gameInfo);
+	case ELayer::AVIATE:
+		return PathfinderUtil::evaluateAccessibility<ELayer::AVIATE>(
+			coord, *tile, playerTeam->fogOfWarMap, player, *gameInfo);
+	default:
+		return EPathAccessibility::NOT_SET;
 	}
+}
+
+CGPathNode * NodeStorage::getNode(const int3 & coord, const EPathfindingLayer & layer)
+{
+	auto * node = out.getNodeForWrite(coord, layer);
+	if(!out.isCurrent(*node))
+		resetTile(coord, layer, evaluateAccessibility(coord, layer));
+	return node;
 }
 
 void NodeStorage::calculateNeighbours(
@@ -120,7 +133,9 @@ NodeStorage::NodeStorage(CPathsInfo & pathsInfo, const CGHeroInstance * hero)
 
 void NodeStorage::resetTile(const int3 & tile, const EPathfindingLayer & layer, EPathAccessibility accessibility)
 {
-	getNode(tile, layer)->update(tile, layer, accessibility);
+	auto * node = out.getNodeForWrite(tile, layer);
+	node->update(tile, layer, accessibility);
+	node->generation = out.currentGeneration;
 }
 
 std::vector<CGPathNode *> NodeStorage::getInitialNodes()

--- a/lib/pathfinder/NodeStorage.h
+++ b/lib/pathfinder/NodeStorage.h
@@ -12,22 +12,26 @@
 #include "INodeStorage.h"
 #include "CGPathNode.h"
 
+struct TeamState;
+
 class DLL_LINKAGE NodeStorage : public INodeStorage
 {
 private:
 	CPathsInfo & out;
+	const IGameInfoCallback * gameInfo = nullptr;
+	const TeamState * playerTeam = nullptr;
+	PlayerColor player;
+	bool useFlying = false;
+	bool useWaterWalking = false;
 
 	inline
 	void resetTile(const int3 & tile, const EPathfindingLayer & layer, EPathAccessibility accessibility);
 
+	CGPathNode * getNode(const int3 & coord, const EPathfindingLayer & layer);
+	EPathAccessibility evaluateAccessibility(const int3 & coord, const EPathfindingLayer & layer) const;
+
 public:
 	NodeStorage(CPathsInfo & pathsInfo, const CGHeroInstance * hero);
-
-	inline
-	CGPathNode * getNode(const int3 & coord, const EPathfindingLayer & layer)
-	{
-		return out.getNode(coord, layer);
-	}
 
 	void initialize(const PathfinderOptions & options, const IGameInfoCallback & gameInfo) override;
 	virtual ~NodeStorage() = default;

--- a/lib/pathfinder/PathfinderCache.cpp
+++ b/lib/pathfinder/PathfinderCache.cpp
@@ -26,10 +26,21 @@ std::shared_ptr<PathfinderConfig> PathfinderCache::createConfig(const CGHeroInst
 
 std::shared_ptr<CPathsInfo> PathfinderCache::buildPaths(const CGHeroInstance * h)
 {
-	auto result = std::make_shared<CPathsInfo>(cb->getMapSize(), h);
+	auto result = acquirePaths(h);
 	auto config = createConfig(h, *result);
 
 	cb->calculatePaths(config);
+	return result;
+}
+
+std::shared_ptr<CPathsInfo> PathfinderCache::acquirePaths(const CGHeroInstance * h)
+{
+	if(reusablePaths.empty())
+		return std::make_shared<CPathsInfo>(cb->getMapSize(), h);
+
+	auto result = std::move(reusablePaths.back());
+	reusablePaths.pop_back();
+	result->prepareForReuse(h);
 	return result;
 }
 
@@ -42,6 +53,12 @@ PathfinderCache::PathfinderCache(const IGameInfoCallback * cb, const PathfinderO
 void PathfinderCache::invalidatePaths()
 {
 	std::lock_guard lock(pathCacheMutex);
+	reusablePaths.reserve(reusablePaths.size() + pathCache.size());
+	for(auto & entry : pathCache)
+	{
+		if(entry.second.use_count() == 1)
+			reusablePaths.push_back(std::move(entry.second));
+	}
 	pathCache.clear();
 }
 
@@ -52,6 +69,13 @@ std::shared_ptr<const CPathsInfo> PathfinderCache::getPathsInfo(const CGHeroInst
 	auto iter = pathCache.find(h);
 	if(iter == std::end(pathCache) || iter->second->heroBonusTreeVersion != h->getTreeVersion())
 	{
+		if(iter != std::end(pathCache) && iter->second.use_count() == 1)
+		{
+			reusablePaths.reserve(reusablePaths.size() + 1);
+			reusablePaths.push_back(std::move(iter->second));
+			pathCache.erase(iter);
+		}
+
 		auto result = buildPaths(h);
 		pathCache[h] = result;
 

--- a/lib/pathfinder/PathfinderCache.h
+++ b/lib/pathfinder/PathfinderCache.h
@@ -21,9 +21,11 @@ class DLL_LINKAGE PathfinderCache
 	const IGameInfoCallback * cb;
 	std::mutex pathCacheMutex;
 	std::map<const CGHeroInstance *, std::shared_ptr<CPathsInfo>> pathCache;
+	std::vector<std::shared_ptr<CPathsInfo>> reusablePaths;
 	PathfinderOptions options;
 
 	std::shared_ptr<PathfinderConfig> createConfig(const CGHeroInstance *h, CPathsInfo &out);
+	std::shared_ptr<CPathsInfo> acquirePaths(const CGHeroInstance * h);
 	std::shared_ptr<CPathsInfo> buildPaths(const CGHeroInstance *h);
 public:
 	PathfinderCache(const IGameInfoCallback * cb, const PathfinderOptions & options);

--- a/lib/serializer/BinaryDeserializer.h
+++ b/lib/serializer/BinaryDeserializer.h
@@ -43,7 +43,6 @@ public:
 	{
 		loadedPointers.clear();
 		loadedSharedPointers.clear();
-		loadedUniquePointers.clear();
 	}
 
 	bool hasFeature(Version v) const
@@ -56,7 +55,6 @@ private:
 
 	std::vector<std::string> loadedStrings;
 	std::map<uint32_t, Serializeable *> loadedPointers;
-	std::set<Serializeable *> loadedUniquePointers;
 	std::map<const Serializeable *, std::shared_ptr<Serializeable>> loadedSharedPointers;
 	IBinaryReader * reader;
 
@@ -224,9 +222,6 @@ private:
 				// We already got this pointer
 				// Cast it in case we are loading it to a non-first base pointer
 				data = dynamic_cast<T>(i->second);
-				if (vstd::contains(loadedUniquePointers, data))
-					throw std::runtime_error("Attempt to deserialize duplicated unique_ptr!");
-
 				return;
 			}
 		}
@@ -318,8 +313,6 @@ private:
 		T * internalPtr;
 		loadRawPointer(internalPtr);
 		data.reset(internalPtr);
-		if (internalPtr != nullptr)
-			loadedUniquePointers.insert(internalPtr);
 	}
 
 	template<typename T, size_t N>

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -165,6 +165,7 @@ if(ENABLE_NULLKILLER2_AI)
 		nullkiller2/Goals/ExploreNeighbourTileTest.cpp
 		nullkiller2/Helpers/ExplorationHelperTest.cpp
 		nullkiller2/Helpers/TinyH3MDimensionDoorExplorationTest.cpp
+		nullkiller2/Pathfinding/AIPathNodePoolTest.cpp
 		nullkiller2/Pathfinding/ArmyLossTest.cpp
 		nullkiller2/Pathfinding/DimensionDoorActionTest.cpp
 	)

--- a/test/bonus/BonusSystemTest.cpp
+++ b/test/bonus/BonusSystemTest.cpp
@@ -113,6 +113,32 @@ protected:
 	}
 };
 
+TEST(BonusSystemInvalidationTest, AttachingChildKeepsUnchangedBranchVersions)
+{
+	CBonusSystemNode parent{BonusNodeType::PLAYER};
+	CBonusSystemNode firstChild{BonusNodeType::HERO};
+	CBonusSystemNode secondChild{BonusNodeType::HERO};
+
+	firstChild.attachTo(parent);
+	parent.addNewBonus(std::make_shared<Bonus>(
+		BonusDuration::PERMANENT,
+		BonusType::MORALE,
+		BonusSource::OTHER,
+		1,
+		BonusSourceID()));
+
+	EXPECT_EQ(firstChild.valOfBonuses(BonusType::MORALE), 1);
+
+	const auto parentVersion = parent.getTreeVersion();
+	const auto firstChildVersion = firstChild.getTreeVersion();
+
+	secondChild.attachTo(parent);
+
+	EXPECT_EQ(secondChild.valOfBonuses(BonusType::MORALE), 1);
+	EXPECT_EQ(parent.getTreeVersion(), parentVersion);
+	EXPECT_EQ(firstChild.getTreeVersion(), firstChildVersion);
+}
+
 TEST_F(BonusSystemTest, multipleBonusSources)
 {
 	CBonusSystemNode ring1{BonusNodeType::ARTIFACT_INSTANCE};

--- a/test/nullkiller2/Pathfinding/AIPathNodePoolTest.cpp
+++ b/test/nullkiller2/Pathfinding/AIPathNodePoolTest.cpp
@@ -1,0 +1,94 @@
+/*
+ * AIPathNodePoolTest.cpp, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ */
+#include "StdInc.h"
+
+#include "AI/Nullkiller2/Pathfinding/AINodeStorage.h"
+
+namespace
+{
+
+using NK2AI::AIPathNodePool;
+
+TEST(Nullkiller2_Pathfinding_AIPathNodePool, allocatesOnlyOccupiedTiles)
+{
+	AIPathNodePool pool(int3(4, 4, 1), 2);
+	EXPECT_FALSE(pool.beginGeneration());
+
+	const int3 occupied(2, 1, 0);
+	auto * first = pool.allocate(occupied);
+
+	ASSERT_NE(first, nullptr);
+	EXPECT_EQ(first->coord, occupied);
+	EXPECT_EQ(pool.get(occupied), std::vector<NK2AI::AIPathNode *>({ first }));
+	EXPECT_TRUE(pool.get(int3(0, 0, 0)).empty());
+}
+
+TEST(Nullkiller2_Pathfinding_AIPathNodePool, preservesLogicalSlotOrder)
+{
+	AIPathNodePool pool(int3(4, 4, 1), 2);
+	pool.beginGeneration();
+
+	const int3 tile(2, 1, 0);
+	const auto firstOrder = pool.nextStorageOrder(tile);
+	auto * first = pool.allocate(tile);
+	const auto secondOrder = pool.nextStorageOrder(tile);
+	auto * second = pool.allocate(tile);
+
+	ASSERT_NE(first, nullptr);
+	ASSERT_NE(second, nullptr);
+	EXPECT_EQ(first->storageOrder, firstOrder);
+	EXPECT_EQ(second->storageOrder, secondOrder);
+	EXPECT_EQ(first->storageOrder + 1, second->storageOrder);
+	EXPECT_EQ(pool.get(tile), std::vector<NK2AI::AIPathNode *>({ first, second }));
+	EXPECT_EQ(pool.allocate(tile), nullptr);
+}
+
+TEST(Nullkiller2_Pathfinding_AIPathNodePool, ordersPendingSlotsAfterAllocatedNodes)
+{
+	AIPathNodePool pool(int3(4, 4, 1), 4);
+	pool.beginGeneration();
+
+	const int3 tile(2, 1, 0);
+	auto * allocated = pool.allocate(tile);
+
+	ASSERT_NE(allocated, nullptr);
+	EXPECT_EQ(pool.nextStorageOrder(tile), allocated->storageOrder + 1);
+	EXPECT_EQ(pool.nextStorageOrder(tile, 1), allocated->storageOrder + 2);
+}
+
+TEST(Nullkiller2_Pathfinding_AIPathNodePool, keepsPointersStable)
+{
+	AIPathNodePool pool(int3(64, 1, 1), 1);
+	pool.beginGeneration();
+
+	auto * first = pool.allocate(int3(0, 0, 0));
+	ASSERT_NE(first, nullptr);
+
+	for(int x = 1; x < 64; ++x)
+		ASSERT_NE(pool.allocate(int3(x, 0, 0)), nullptr);
+
+	EXPECT_EQ(first->coord, int3(0, 0, 0));
+	EXPECT_EQ(pool.get(int3(0, 0, 0)).front(), first);
+}
+
+TEST(Nullkiller2_Pathfinding_AIPathNodePool, resetsTilesByGeneration)
+{
+	AIPathNodePool pool(int3(2, 2, 1), 2);
+	pool.beginGeneration();
+	ASSERT_NE(pool.allocate(int3(1, 1, 0)), nullptr);
+
+	EXPECT_FALSE(pool.beginGeneration());
+	EXPECT_TRUE(pool.get(int3(1, 1, 0)).empty());
+
+	auto * current = pool.allocate(int3(1, 1, 0));
+	ASSERT_NE(current, nullptr);
+	EXPECT_EQ(pool.get(int3(1, 1, 0)).front(), current);
+}
+
+}


### PR DESCRIPTION
This PR reduces repeated and eager work in Nullkiller pathfinding while preserving the existing search rules, path ordering, and AI scoring behavior. Fresh five-minute AI games show 40.3% higher turn throughput on a 36 x 36 map and 38.6% higher throughput on a 252 x 252 x 2 map.

## Implementation

Regular path nodes and AI accessibility are now initialized on first use within a search generation instead of resetting or evaluating the full map up front. Nullkiller path payloads are allocated only for occupied tile/state pairs, with stable addresses, the existing per-tile capacity, and explicit logical ordering retained for deterministic comparisons.

Pathfinding buffers are recycled only while exclusively owned. Priority evaluation reuses immutable per-candidate contexts across tiers, and Dimension Door searches cache pass-invariant spell capabilities while continuing to evaluate movement, mana, day, destination, guarding, and landing constraints for each node.

Independent AI phases choose workers from the available physical cores and useful work in that phase, with an optional configuration upper bound. Automatic mode does not impose an arbitrary four-worker cap, and small workloads fall back to one worker without changing the processed range.

Exploration scans now inspect lightweight path summaries first and reconstruct full parent chains only for candidates that can improve the current score. Surviving candidates use the shared full-path reconstruction and retain the existing visit-goal, danger, safe-attack, closest-way, ordering, and score checks.

## Performance

The exact base `6b002b6917656d7f910730bbe1e1e148cb016ab5` and this branch were rebuilt with GCC 14.2 as strict RelWithDebInfo builds. Each result below is a fresh 300-second headless game workload with two Nullkiller players and identical map and settings bytes.

| Map | Exact base | This PR | Change |
| --- | ---: | ---: | ---: |
| Small, 36 x 36 x 1 | 966 turns / 300.129s<br/>(3.219 turns/s) | 1,355 turns / 300.125s<br/>(4.515 turns/s) | **+40.3%** |
| Giant, 252 x 252 x 2 | 176 turns / 300.137s<br/>(0.586 turns/s) | 244 turns / 300.151s<br/>(0.813 turns/s) | **+38.6%** |

Both giant-map runs stayed in one uninterrupted game for the full window and completed 88 base days versus 122 optimized days, capturing sustained main-phase AI work. Small games were restarted after completion inside the same fixed wall-clock deadline.

## Correctness and safety

Generation tags bound all lazy values to one search pass, including explicit wrap handling. Sparse nodes retain stable addresses and deterministic logical slot order. Cached Dimension Door data excludes state that changes per node or planned day. Parallel work continues to use independent items and task-local outputs merged after joining; this PR adds no new wait, nested arena, process-wide mutable cache, or lock ordering.

The exact base passed all 592 existing tests. The final branch passed all 600 tests, including focused coverage for adaptive worker selection, single-worker fallback, sparse allocation, per-tile capacity, logical ordering, pointer stability, and generation reset. Strict compilation passed for both revisions, and all four accepted five-minute workloads completed without a crash, assertion, uncaught termination, or deadlock symptom.
