### PR TITLE
Fix encoding issues with non-ASCII paths and save file names on Windows

### DIFF
--- a/client/lobby/SelectionTab.cpp
+++ b/client/lobby/SelectionTab.cpp
@@ -773,7 +773,7 @@ void SelectionTab::select(int position)
 	if(inputName && inputName->isActive())
 	{
 		auto filename = *CResourceHandler::get()->getResourceName(ResourcePath(curItems[py]->fileURI, EResType::SAVEGAME));
-		inputName->setText(filename.stem().string());
+		inputName->setText(TextOperations::filesystemPathToUtf8(filename.stem()));
 	}
 
 	updateListItems();

--- a/lib/VCMIDirs.cpp
+++ b/lib/VCMIDirs.cpp
@@ -117,7 +117,7 @@ VCMIDirsWIN32::VCMIDirsWIN32()
 	if (!bfs::exists(configPath))
 		return;
 
-	std::ifstream in(pathToUtf8(configPath), std::ios::binary);
+	std::ifstream in(configPath.wstring(), std::ios::binary);
 	if (!in)
 		return;
 


### PR DESCRIPTION
### Problem 1
When VCMI is placed in a directory whose path contains non-ASCII characters (e.g. Chinese), config/dirs.json is silently ignored and all user data paths fall back to the default Documents/My Games/vcmi location instead of respecting the user-configured paths in dirs.json.

### Root Cause
In lib/VCMIDirs.cpp, the VCMIDirsWIN32 constructor opens dirs.json with:

    std::ifstream in(pathToUtf8(configPath), std::ios::binary);

pathToUtf8() converts the path to a UTF-8 encoded std::string. However, std::ifstream(const char*) on Windows interprets the string using the system's ANSI code page (e.g. GBK on Chinese locale). When the path contains non-ASCII characters, the UTF-8 bytes don't match the ANSI code page → file fails to open → constructor returns early without loading dirsConfig → all paths silently fall back to defaults.

This works by coincidence on English-only paths because UTF-8 and ANSI are identical for ASCII characters.

### Problem 2
When saving a game over an existing save with a non-ASCII (e.g. Chinese) filename, the filename input box shows garbled text instead of the correct name.

### Root Cause
In SelectionTab::select(), the existing save's filename is retrieved from boost::filesystem::path and converted to string via .string(). On Windows, path::string() uses the system locale codecvt (e.g. GBK on Chinese Windows), but VCMI's internal text system expects UTF-8. The GBK bytes are interpreted as UTF-8, resulting in mojibake.
