### PR TITLE
Fix handleGetTextCommand() line endings

### DIFF
--- a/client/ClientCommandManager.cpp
+++ b/client/ClientCommandManager.cpp
@@ -393,7 +393,7 @@ void ClientCommandManager::handleGetTextCommand()
 
 		boost::filesystem::create_directories(filePath.parent_path());
 
-		std::ofstream file(filePath.c_str());
+		std::ofstream file(filePath.c_str(), std::ios::binary);
 		auto text = CResourceHandler::get()->load(filename)->readAll();
 
 		file.write((char*)text.first.get(), text.second);


### PR DESCRIPTION
Fixes #7628

The issue was that the output files were opened in text mode, so the runtime automatically translated any single newline character into carriage return + line feed on Windows (due to OS defaults).

The solution is simply to open the output files in binary mode.