### PR TITLE
Prevent crashes from duplicate map object references

### DIFF
--- a/lib/mapping/CMap.cpp
+++ b/lib/mapping/CMap.cpp
@@ -259,8 +259,8 @@ void CMap::hideObject(CGObjectInstance * obj)
 			if(xVal>=0 && xVal < width && yVal>=0 && yVal < height)
 			{
 				TerrainTile & curt = getTile(int3(xVal, yVal, zVal));
-				curt.visitableObjects -= obj->id;
-				curt.blockingObjects -= obj->id;
+				vstd::erase(curt.visitableObjects, obj->id);
+				vstd::erase(curt.blockingObjects, obj->id);
 			}
 		}
 	}
@@ -280,14 +280,14 @@ void CMap::showObject(CGObjectInstance * obj)
 				TerrainTile & curt = getTile(int3(xVal, yVal, zVal));
 				if(obj->visitableAt(int3(xVal, yVal, zVal)))
 				{
-					assert(!vstd::contains(curt.visitableObjects, obj->id));
-					curt.visitableObjects.push_back(obj->id);
+					if(!vstd::contains(curt.visitableObjects, obj->id))
+						curt.visitableObjects.push_back(obj->id);
 				}
 
 				if(obj->blockingAt(int3(xVal, yVal, zVal)))
 				{
-					assert(!vstd::contains(curt.blockingObjects, obj->id));
-					curt.blockingObjects.push_back(obj->id);
+					if(!vstd::contains(curt.blockingObjects, obj->id))
+						curt.blockingObjects.push_back(obj->id);
 				}
 			}
 		}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -42,6 +42,7 @@ set(test_SRCS
 
 		map/CMapEditManagerTest.cpp
 		map/CMapFormatTest.cpp
+		map/CMapObjectRemovalTest.cpp
 		map/CGArtifactRegressionTest.cpp
 		map/MapComparer.cpp
 		map/TinyH3MBuilderTest.cpp

--- a/test/map/CMapObjectRemovalTest.cpp
+++ b/test/map/CMapObjectRemovalTest.cpp
@@ -1,0 +1,47 @@
+/*
+ * CMapObjectRemovalTest.cpp, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
+
+#include "StdInc.h"
+
+#include "../game/GameStateTest.h"
+
+#include "../../lib/mapObjects/CGHeroInstance.h"
+#include "../../lib/mapping/CMap.h"
+
+class CMapObjectRemovalTest : public GameStateTest
+{
+};
+
+TEST_F(CMapObjectRemovalTest, removingObjectClearsDuplicateTileReferences)
+{
+	startTestGame();
+
+	auto heroes = map->getObjects<CGHeroInstance>();
+	ASSERT_FALSE(heroes.empty());
+
+	auto * hero = heroes.front();
+	const auto heroPosition = hero->visitablePos();
+	auto & heroTile = map->getTile(heroPosition);
+
+	ASSERT_TRUE(vstd::contains(heroTile.visitableObjects, hero->id));
+	ASSERT_TRUE(vstd::contains(heroTile.blockingObjects, hero->id));
+
+	// Older saves can contain the same object more than once on a terrain tile.
+	heroTile.visitableObjects.push_back(hero->id);
+	heroTile.blockingObjects.push_back(hero->id);
+
+	auto removedHero = map->eraseObject(hero->id);
+	ASSERT_EQ(removedHero.get(), hero);
+	ASSERT_EQ(map->getObject(hero->id), nullptr);
+
+	EXPECT_EQ(map->guardingCreaturePosition(heroPosition), int3(-1, -1, -1));
+	EXPECT_FALSE(vstd::contains(heroTile.visitableObjects, hero->id));
+	EXPECT_FALSE(vstd::contains(heroTile.blockingObjects, hero->id));
+}


### PR DESCRIPTION
Fixes https://github.com/vcmi/vcmi/issues/7309.

This also addresses the crash reproduced from the save attached in @GrafDeVan's [comment on #7613](https://github.com/vcmi/vcmi/pull/7613#issuecomment-5115806099).

The affected save contains Dessa's object ID more than once in the same terrain tile's visitable-object list. When Thorgrim defeats her, `CMap::hideObject()` removed only one copy before `CMap::eraseObject()` cleared the object slot. The remaining ID became dangling, and the following NK2 path recalculation crashed when `CMap::guardingCreaturePosition()` dereferenced it.

`CMap::showObject()` now avoids inserting duplicate visitable and blocking references, while `CMap::hideObject()` removes every matching reference. This prevents new duplicates and cleans up duplicates already present in older saves when an object is hidden or removed.

The regression test starts a real test game, reproduces the duplicate terrain references found in the save, removes the affected hero, and queries the vacated tile. With the fix it passes. With the fix reverted, the test still builds and exits with SIGSEGV (`139`) in the guard lookup.

In `Crash.vsgm1`, Thorgrim defeated Dessa, path recalculation continued past the original crash, and Purple completed the day 188 turn without `Disaster happened`.