### PR TITLE
Huge improvement of render performance

### DIFF
--- a/client/CMT.h
+++ b/client/CMT.h
@@ -9,8 +9,13 @@
  */
 #pragma once
 
+#include <cstdint>
+
 struct SDL_Renderer;
 extern SDL_Renderer * mainRenderer;
+
+/// Bumped whenever mainRenderer is recreated, so that cached textures know they are stale
+extern uint32_t mainRendererGeneration;
 
 /// Notify user about encountered fatal error and terminate the game
 /// Defined in clientapp EntryPoint

--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -100,6 +100,7 @@ set(vcmiclientcommon_SRCS
 	render/Canvas.cpp
 	render/CanvasImage.cpp
 	render/ColorFilter.cpp
+	render/DirtyRegionTracker.cpp
 	render/Colors.cpp
 	render/Graphics.cpp
 	render/IFont.cpp
@@ -338,6 +339,7 @@ set(vcmiclientcommon_HEADERS
 	render/Canvas.h
 	render/CanvasImage.h
 	render/ColorFilter.h
+	render/DirtyRegionTracker.h
 	render/Colors.h
 	render/EFont.h
 	render/Graphics.h

--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -92,6 +92,7 @@ set(vcmiclientcommon_SRCS
 	netlag/NetworkLagCompensator.cpp
 	netlag/PackRollbackGeneratorVisitor.cpp
 
+	render/AssetCache.cpp
 	render/AssetGenerator.cpp
 	render/CAnimation.cpp
 	render/CBitmapHandler.cpp
@@ -329,6 +330,7 @@ set(vcmiclientcommon_HEADERS
 	netlag/NetworkLagReplyPrediction.h
 	netlag/PackRollbackGeneratorVisitor.h
 
+	render/AssetCache.h
 	render/AssetGenerator.h
 	render/CAnimation.h
 	render/CBitmapHandler.h

--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -171,6 +171,11 @@ void CPlayerInterface::initGameInterface(std::shared_ptr<Environment> ENV, std::
 	adventureInt->onCurrentPlayerChanged(playerID);
 }
 
+bool CPlayerInterface::isHeroMoving() const
+{
+	return movementController->isHeroMoving();
+}
+
 std::shared_ptr<const CPathsInfo> CPlayerInterface::getPathsInfo(const CGHeroInstance * h)
 {
 	return pathfinderCache->getPathsInfo(h);

--- a/client/CPlayerInterface.h
+++ b/client/CPlayerInterface.h
@@ -233,6 +233,9 @@ public: // public interface for use by client via GAME->interface() access
 	std::shared_ptr<const CPathsInfo> getPathsInfo(const CGHeroInstance * h);
 	void invalidatePaths() override;
 
+	/// True while a hero walks a path, including the pauses between single steps
+	bool isHeroMoving() const;
+
 	///returns true if all events are processed internally
 	bool capturedAllEvents();
 

--- a/client/GameEngine.cpp
+++ b/client/GameEngine.cpp
@@ -95,7 +95,7 @@ GameEngine::GameEngine()
 
 void GameEngine::handleEvents()
 {
-	events().dispatchTimer(framerate().getElapsedMilliseconds());
+	events().dispatchTimer(framerate().consumeElapsedMilliseconds());
 
 	//player interface may want special event handling
 	if(engineUser->capturedAllEvents())

--- a/client/GameEngine.cpp
+++ b/client/GameEngine.cpp
@@ -116,9 +116,20 @@ void GameEngine::fakeMouseMove()
 	for (;;)
 	{
 		input().fetchEvents();
-		updateFrame();
-		screenHandlerInstance->presentScreenTexture();
-		framerate().framerateDelay(); // holds a constant FPS
+
+		// A frame with nothing new to show would still hold interfaceMutex, which is the lock the
+		// network thread needs to produce the next one. The time bound is only a safety net.
+		const auto now = std::chrono::steady_clock::now();
+		const bool renderFrame = engineUser->wantsFrameRendered() || now - lastFrameRendered > maxFrameSkipDuration;
+
+		if(renderFrame)
+		{
+			lastFrameRendered = now;
+			updateFrame();
+			screenHandlerInstance->presentScreenTexture();
+		}
+
+		framerate().framerateDelay(renderFrame); // holds a constant FPS
 	}
 }
 

--- a/client/GameEngine.h
+++ b/client/GameEngine.h
@@ -60,6 +60,10 @@ private:
 
 	int maxPerformanceOverlayTextWidth = 0;
 
+	/// Longest the display may go unredrawn while the game reports nothing new to show
+	static constexpr auto maxFrameSkipDuration = std::chrono::milliseconds(100);
+	std::chrono::steady_clock::time_point lastFrameRendered = std::chrono::steady_clock::now();
+
 	void updateFrame();
 	void handleEvents(); //takes events from queue and calls interested objects
 	void drawPerformanceOverlay(); // draws box with additional infos (e.g. fps)

--- a/client/GameEngineUser.h
+++ b/client/GameEngineUser.h
@@ -28,4 +28,7 @@ public:
 
 	/// Returns true if all input events should be captured and ignored
 	virtual bool capturedAllEvents() = 0;
+
+	/// Returns false if the next frame could only reproduce the current one, so it may be skipped
+	virtual bool wantsFrameRendered() = 0;
 };

--- a/client/GameInstance.cpp
+++ b/client/GameInstance.cpp
@@ -103,6 +103,16 @@ bool GameInstance::capturedAllEvents()
 		return false;
 }
 
+bool GameInstance::wantsFrameRendered()
+{
+	// between two steps of a walking hero nothing moves, and rendering it only delays the
+	// netpacks that would start the next step
+	if (interfaceInstance && mapInstance && interfaceInstance->isHeroMoving())
+		return mapInstance->hasOngoingAnimations();
+
+	return true;
+}
+
 void GameInstance::onShutdownRequested(bool ask)
 {
 	if(!ENGINE)

--- a/client/GameInstance.h
+++ b/client/GameInstance.h
@@ -54,6 +54,7 @@ public:
 	void onGlobalLobbyInterfaceActivated() final;
 	void onUpdate() final;
 	bool capturedAllEvents() final;
+	bool wantsFrameRendered() final;
 	void onShutdownRequested(bool askForConfirmation) final;
 	void onAppPaused() final;
 };

--- a/client/adventureMap/CInfoBar.cpp
+++ b/client/adventureMap/CInfoBar.cpp
@@ -265,6 +265,7 @@ void CInfoBar::reset()
 {
 	OBJECT_CONSTRUCTION;
 	state = EState::EMPTY;
+	visibleHeroInfoSource.reset();
 	visibleInfo = std::make_shared<EmptyVisibleInfo>();
 }
 
@@ -528,12 +529,27 @@ void CInfoBar::showHeroSelection(const CGHeroInstance * hero)
 	if(!hero)
 	{
 		reset();
+		redraw();
+		return;
 	}
-	else
-	{
-		state = EState::HERO;
-		visibleInfo = std::make_shared<VisibleHeroInfo>(hero);
-	}
+
+	// VisibleHeroInfo is a dozen labels and images built purely from the data gathered here, so
+	// when none of it changed the tree already on screen is the one we would build. That matters
+	// because hero movement raises one of these per step, in the pause between two animations.
+	const HeroInfoSource source{
+		hero->id,
+		InfoAboutHero(hero, InfoAboutHero::EInfoLevel::DETAILED),
+		settings["gameTweaks"]["infoBarCreatureManagement"].Bool()
+	};
+
+	// state is part of the condition because the infobar may have been showing something else
+	// entirely - a town, picked up resources - while the hero data stayed the same
+	if(state == EState::HERO && visibleInfo && visibleHeroInfoSource == source)
+		return;
+
+	state = EState::HERO;
+	visibleHeroInfoSource = source;
+	visibleInfo = std::make_shared<VisibleHeroInfo>(hero);
 	redraw();
 }
 

--- a/client/adventureMap/CInfoBar.h
+++ b/client/adventureMap/CInfoBar.h
@@ -12,6 +12,7 @@
 #include "../gui/CIntObject.h"
 #include "CConfigHandler.h"
 #include "../../lib/filesystem/ResourcePath.h"
+#include "../../lib/gameState/InfoAboutArmy.h"
 #include "../../lib/networkPacks/Component.h"
 
 class CGHeroInstance;
@@ -139,7 +140,20 @@ private:
 		EMPTY, HERO, TOWN, DATE, GAME, AITURN, COMPONENT
 	};
 
+	/// Everything VisibleHeroInfo is built from. Kept so that a hero selection which changes
+	/// nothing visible - the common case, since hero movement raises one per step - can reuse
+	/// the widget tree already on screen instead of rebuilding it
+	struct HeroInfoSource
+	{
+		ObjectInstanceID hero;
+		InfoAboutHero info;
+		bool creatureManagement = false;
+
+		bool operator==(const HeroInfoSource & other) const = default;
+	};
+
 	std::shared_ptr<CVisibleInfo> visibleInfo;
+	std::optional<HeroInfoSource> visibleHeroInfoSource;
 	EState state;
 	uint32_t timerCounter;
 	bool shouldPopAll = false;

--- a/client/adventureMap/CMinimap.cpp
+++ b/client/adventureMap/CMinimap.cpp
@@ -33,7 +33,7 @@
 #include "../../lib/mapping/TerrainTile.h"
 #include "../../lib/texts/CGeneralTextHandler.h"
 
-ColorRGBA CMinimapInstance::getTileColor(const int3 & pos) const
+ColorRGBA CMinimapInstance::getTileColor(const int3 & pos, bool showHeroesSeparately) const
 {
 	const TerrainTile * tile = GAME->interface()->cb->getTile(pos, false);
 
@@ -52,7 +52,7 @@ ColorRGBA CMinimapInstance::getTileColor(const int3 & pos) const
 			if(player == PlayerColor::NEUTRAL)
 				return graphics->neutralColor;
 
-			if (settings["adventure"]["minimapShowHeroes"].Bool() && obj->ID == MapObjectID::HERO)
+			if (showHeroesSeparately && obj->ID == MapObjectID::HERO)
 				continue;
 
 			if (player.isValidPlayer())
@@ -66,19 +66,20 @@ ColorRGBA CMinimapInstance::getTileColor(const int3 & pos) const
 		return tile->getTerrain()->minimapUnblocked;
 }
 
-void CMinimapInstance::refreshTile(const int3 &tile)
+void CMinimapInstance::refreshTile(const int3 &tile, bool showHeroesSeparately)
 {
 	if (level == tile.z)
-		minimap->drawPoint(Point(tile.x, tile.y), getTileColor(tile));
+		minimap->drawPoint(Point(tile.x, tile.y), getTileColor(tile, showHeroesSeparately));
 }
 
 void CMinimapInstance::redrawMinimap()
 {
 	int3 mapSizes = GAME->interface()->cb->getMapSize();
+	const bool showHeroesSeparately = settings["adventure"]["minimapShowHeroes"].Bool();
 
 	for (int y = 0; y < mapSizes.y; ++y)
 		for (int x = 0; x < mapSizes.x; ++x)
-			minimap->drawPoint(Point(x, y), getTileColor(int3(x, y, level)));
+			minimap->drawPoint(Point(x, y), getTileColor(int3(x, y, level), showHeroesSeparately));
 }
 
 CMinimapInstance::CMinimapInstance(const Point & position, const Point & dimensions, int Level):
@@ -187,9 +188,44 @@ void CMinimap::mouseDragged(const Point & cursorPosition, const Point & lastUpda
 	moveAdvMapSelection(cursorPosition);
 }
 
+void CMinimap::drawBackgroundAroundMap(Canvas & to) const
+{
+	const Rect & widget = aiShield->pos;
+
+	// the map is centered inside the widget, so at most one axis actually has a border
+	const int leftWidth = pos.x - widget.x;
+	const int rightWidth = widget.right() - pos.right();
+	const int topHeight = pos.y - widget.y;
+	const int bottomHeight = widget.bottom() - pos.bottom();
+
+	if(topHeight > 0)
+		to.drawColor(Rect(widget.x, widget.y, widget.w, topHeight), Colors::BLACK);
+
+	if(bottomHeight > 0)
+		to.drawColor(Rect(widget.x, pos.bottom(), widget.w, bottomHeight), Colors::BLACK);
+
+	if(leftWidth > 0)
+		to.drawColor(Rect(widget.x, pos.y, leftWidth, pos.h), Colors::BLACK);
+
+	if(rightWidth > 0)
+		to.drawColor(Rect(pos.right(), pos.y, rightWidth, pos.h), Colors::BLACK);
+}
+
 void CMinimap::showAll(Canvas & to)
 {
 	CanvasClipRectGuard guard(to, aiShield->pos);
+
+	// The radar rectangle and the hero icons are positioned in minimap coordinates but are not
+	// bounded by the minimap: a Canvas sub-rectangle only offsets drawing, the clip rect above is
+	// what actually limits them. On a map that does not fill the widget they are therefore allowed
+	// to extend past the map and onto the background around it, which is intended - but it means
+	// that background has to be repainted here before they are drawn again, or the previous
+	// frame's pixels stay behind. Repainting it locally keeps this to a few small fills; leaving
+	// it to the parent would redraw the whole adventure map on every single view movement.
+	// The area behind the minimap is solid black in the adventure map background.
+	if(minimap)
+		drawBackgroundAroundMap(to);
+
 	CIntObject::showAll(to);
 
 	if(minimap)
@@ -249,10 +285,7 @@ void CMinimap::onMapViewMoved(const Rect & visibleArea, int mapLevel)
 		update();
 	}
 	else
-	{
-		setRedrawParent(true); // needed for non square map to redraw black background when viewarea rectangle is moved
 		redraw();
-	}
 }
 
 void CMinimap::setAIRadar(bool on)
@@ -290,8 +323,10 @@ void CMinimap::updateTiles(const FowTilesType & positions)
 {
 	if(minimap)
 	{
+		const bool showHeroesSeparately = settings["adventure"]["minimapShowHeroes"].Bool();
+
 		for (auto const & tile : positions)
-			minimap->refreshTile(tile);
+			minimap->refreshTile(tile, showHeroesSeparately);
 	}
 
 	redraw();

--- a/client/adventureMap/CMinimap.h
+++ b/client/adventureMap/CMinimap.h
@@ -24,7 +24,9 @@ class CMinimapInstance : public CIntObject
 	int level;
 
 	//get color of selected tile on minimap
-	ColorRGBA getTileColor(const int3 & pos) const;
+	//showHeroesSeparately is passed in rather than read here: it is a settings lookup,
+	//and redrawMinimap() calls this once per tile of the entire map
+	ColorRGBA getTileColor(const int3 & pos, bool showHeroesSeparately) const;
 
 	void redrawMinimap();
 public:
@@ -32,7 +34,7 @@ public:
 	~CMinimapInstance();
 
 	void showAll(Canvas & to) override;
-	void refreshTile(const int3 & pos);
+	void refreshTile(const int3 & pos, bool showHeroesSeparately);
 };
 
 /// Minimap which is displayed at the right upper corner of adventure map
@@ -54,6 +56,11 @@ class CMinimap : public CIntObject
 
 	/// relocates center of adventure map screen to currently hovered tile
 	void moveAdvMapSelection(const Point & positionGlobal);
+
+	/// repaints the widget area that the map itself does not cover, so that the radar rectangle
+	/// and the hero icons drawn onto it do not leave their previous position behind.
+	/// Does nothing on a map that fills the widget - a square one at the default aspect ratio
+	void drawBackgroundAroundMap(Canvas & to) const;
 
 protected:
 	/// computes coordinates of tile below cursor pos

--- a/client/gui/FramerateManager.cpp
+++ b/client/gui/FramerateManager.cpp
@@ -19,16 +19,20 @@ FramerateManager::FramerateManager(int targetFrameRate)
 	, lastFrameIndex(0)
 	, lastFrameTimes({})
 	, lastTimePoint(Clock::now())
+	, lastRenderedTimePoint(Clock::now())
 	, vsyncEnabled(settings["video"]["vsync"].Bool())
 {
 	std::ranges::fill(lastFrameTimes, targetFrameTime);
 }
 
-void FramerateManager::framerateDelay()
+void FramerateManager::framerateDelay(bool frameRendered)
 {
 	Duration timeSpentBusy = Clock::now() - lastTimePoint;
 
-	if(!vsyncEnabled && timeSpentBusy < targetFrameTime)
+	// vsync paces rendered frames inside SDL_RenderPresent, which a skipped frame never reaches
+	const bool pacedByVsync = vsyncEnabled && frameRendered;
+
+	if(!pacedByVsync && timeSpentBusy < targetFrameTime)
 	{
 		// if FPS is higher than it should be, then wait some time
 		std::this_thread::sleep_for(targetFrameTime - timeSpentBusy);
@@ -42,9 +46,19 @@ void FramerateManager::framerateDelay()
 		timeElapsed = std::chrono::milliseconds(100);
 
 	lastTimePoint = currentTicks;
-	lastFrameIndex = (lastFrameIndex + 1) % lastFrameTimes.size();
-	lastFrameTimes[lastFrameIndex] = timeElapsed;
 	elapsedSinceConsumed += timeElapsed;
+
+	if(!frameRendered)
+		return;
+
+	// framerate is measured between drawn frames, so that skipped ones do not inflate it
+	Duration sinceRendered = currentTicks - lastRenderedTimePoint;
+	if(sinceRendered > std::chrono::milliseconds(100))
+		sinceRendered = std::chrono::milliseconds(100);
+
+	lastRenderedTimePoint = currentTicks;
+	lastFrameIndex = (lastFrameIndex + 1) % lastFrameTimes.size();
+	lastFrameTimes[lastFrameIndex] = sinceRendered;
 }
 
 ui32 FramerateManager::getElapsedMilliseconds() const

--- a/client/gui/FramerateManager.cpp
+++ b/client/gui/FramerateManager.cpp
@@ -44,11 +44,19 @@ void FramerateManager::framerateDelay()
 	lastTimePoint = currentTicks;
 	lastFrameIndex = (lastFrameIndex + 1) % lastFrameTimes.size();
 	lastFrameTimes[lastFrameIndex] = timeElapsed;
+	elapsedSinceConsumed += timeElapsed;
 }
 
 ui32 FramerateManager::getElapsedMilliseconds() const
 {
 	return lastFrameTimes[lastFrameIndex] / std::chrono::milliseconds(1);
+}
+
+ui32 FramerateManager::consumeElapsedMilliseconds()
+{
+	ui32 result = elapsedSinceConsumed / std::chrono::milliseconds(1);
+	elapsedSinceConsumed -= std::chrono::milliseconds(result);
+	return result;
 }
 
 ui32 FramerateManager::getFramerate() const

--- a/client/gui/FramerateManager.h
+++ b/client/gui/FramerateManager.h
@@ -25,6 +25,9 @@ class FramerateManager
 	/// index of last measured from in lastFrameTimes array
 	ui32 lastFrameIndex;
 
+	/// time not yet handed out by consumeElapsedMilliseconds
+	Duration elapsedSinceConsumed = Duration::zero();
+
 	bool vsyncEnabled;
 
 public:
@@ -36,6 +39,9 @@ public:
 
 	/// returns duration of last frame in seconds
 	ui32 getElapsedMilliseconds() const;
+
+	/// whole milliseconds elapsed since the last call, carrying the remainder over
+	ui32 consumeElapsedMilliseconds();
 
 	/// returns current estimation of frame rate
 	ui32 getFramerate() const;

--- a/client/gui/FramerateManager.h
+++ b/client/gui/FramerateManager.h
@@ -21,11 +21,12 @@ class FramerateManager
 
 	Duration targetFrameTime;
 	TimePoint lastTimePoint;
+	TimePoint lastRenderedTimePoint;
 
 	/// index of last measured from in lastFrameTimes array
 	ui32 lastFrameIndex;
 
-	/// time not yet handed out by consumeElapsedMilliseconds
+	/// time not yet handed out by consumeElapsedMilliseconds, including skipped frames
 	Duration elapsedSinceConsumed = Duration::zero();
 
 	bool vsyncEnabled;
@@ -33,14 +34,15 @@ class FramerateManager
 public:
 	FramerateManager(int targetFramerate);
 
-	/// must be called every frame
+	/// must be called every iteration of the main loop, whether or not a frame was drawn
 	/// updates framerate calculations and executes sleep to maintain target frame rate
-	void framerateDelay();
+	void framerateDelay(bool frameRendered);
 
 	/// returns duration of last frame in seconds
 	ui32 getElapsedMilliseconds() const;
 
-	/// whole milliseconds elapsed since the last call, carrying the remainder over
+	/// whole milliseconds elapsed since the last call, carrying the remainder over. Covers frames
+	/// that were not rendered, so animations advance by real time rather than by frames drawn
 	ui32 consumeElapsedMilliseconds();
 
 	/// returns current estimation of frame rate

--- a/client/mapView/MapRenderer.cpp
+++ b/client/mapView/MapRenderer.cpp
@@ -341,11 +341,9 @@ MapRendererFow::MapRendererFow()
 	}
 }
 
-void MapRendererFow::renderTile(IMapRendererContext & context, Canvas & target, const int3 & coordinates)
+void MapRendererFow::renderTile(IMapRendererContext & context, Canvas & target, const int3 & coordinates, const NeighborTilesInfo & neighborInfo)
 {
 	assert(!context.isVisible(coordinates));
-
-	const NeighborTilesInfo neighborInfo(context, coordinates);
 
 	int retBitmapID = neighborInfo.getBitmapID(); // >=0 -> partial hide, <0 - full hide
 	if(retBitmapID < 0)
@@ -367,12 +365,11 @@ void MapRendererFow::renderTile(IMapRendererContext & context, Canvas & target, 
 	}
 }
 
-uint8_t MapRendererFow::checksum(IMapRendererContext & context, const int3 & coordinates)
+uint8_t MapRendererFow::checksum(IMapRendererContext & context, const int3 & coordinates, const NeighborTilesInfo & neighborInfo)
 {
 	if (context.showSpellRange(coordinates))
 		return 0xff - 2;
 
-	const NeighborTilesInfo neighborInfo(context, coordinates);
 	int retBitmapID = neighborInfo.getBitmapID();
 	if(retBitmapID < 0)
 		return 0xff - 1;
@@ -724,6 +721,23 @@ void MapRendererPath::renderTile(IMapRendererContext & context, Canvas & target,
 		target.draw(pathNodes->getImage(imageID), Point(0,0));
 }
 
+void MapRendererPath::prepareFrame(IMapRendererContext & context)
+{
+	cachedPath = context.currentPath();
+	cachedPathTiles.clear();
+
+	if(!cachedPath)
+		return;
+
+	cachedPathTiles.reserve(cachedPath->nodes.size());
+	for(const auto & node : cachedPath->nodes)
+		cachedPathTiles.push_back(node.coord);
+
+	// note: int3 has no operator> / <= / >=, so std::ranges::sort and
+	// std::ranges::binary_search cannot be used here - they require totally_ordered
+	std::sort(cachedPathTiles.begin(), cachedPathTiles.end());
+}
+
 size_t MapRendererPath::selectImage(IMapRendererContext & context, const int3 & coordinates)
 {
 	const auto & functor = [&](const CGPathNode & node)
@@ -731,8 +745,13 @@ size_t MapRendererPath::selectImage(IMapRendererContext & context, const int3 & 
 		return node.coord == coordinates;
 	};
 
-	const auto * path = context.currentPath();
+	const auto * path = cachedPath;
 	if(!path)
+		return std::numeric_limits<size_t>::max();
+
+	// Nearly every tile of the view is off the path; reject those without touching the
+	// node list. Tiles that pass still go through the same search as before.
+	if(!std::binary_search(cachedPathTiles.begin(), cachedPathTiles.end(), coordinates))
 		return std::numeric_limits<size_t>::max();
 
 	const auto & iter = std::ranges::find_if(path->nodes, functor);
@@ -765,6 +784,11 @@ uint8_t MapRendererPath::checksum(IMapRendererContext & context, const int3 & co
 	return selectImage(context, coordinates) & 0xff;
 }
 
+void MapRenderer::prepareFrame(IMapRendererContext & context)
+{
+	rendererPath.prepareFrame(context);
+}
+
 MapRenderer::TileChecksum MapRenderer::getTileChecksum(IMapRendererContext & context, const int3 & coordinates)
 {
 	// computes basic checksum to determine whether tile needs an update
@@ -778,11 +802,18 @@ MapRenderer::TileChecksum MapRenderer::getTileChecksum(IMapRendererContext & con
 		return result;
 	}
 
-	const NeighborTilesInfo neighborInfo(context, coordinates);
+	const bool visible = context.isVisible(coordinates);
 
-	if(!context.isVisible(coordinates) && neighborInfo.areAllHidden())
+	// Neighbour visibility is only consulted for tiles that are hidden themselves.
+	// Building it costs eight visibility queries, so it is skipped entirely for the
+	// common case of a visible tile - where the old code built and then discarded it.
+	std::optional<NeighborTilesInfo> neighborInfo;
+	if(!visible)
+		neighborInfo.emplace(context, coordinates);
+
+	if(!visible && neighborInfo->areAllHidden())
 	{
-		result[7] = rendererFow.checksum(context, coordinates);
+		result[7] = rendererFow.checksum(context, coordinates, *neighborInfo);
 	}
 	else
 	{
@@ -795,8 +826,8 @@ MapRenderer::TileChecksum MapRenderer::getTileChecksum(IMapRendererContext & con
 		result[5] = rendererPath.checksum(context, coordinates);
 		result[6] = rendererOverlay.checksum(context, coordinates);
 
-		if(!context.isVisible(coordinates))
-			result[7] = rendererFow.checksum(context, coordinates);
+		if(!visible)
+			result[7] = rendererFow.checksum(context, coordinates, *neighborInfo);
 	}
 	return result;
 }
@@ -809,11 +840,15 @@ void MapRenderer::renderTile(IMapRendererContext & context, Canvas & target, con
 		return;
 	}
 
-	const NeighborTilesInfo neighborInfo(context, coordinates);
+	const bool visible = context.isVisible(coordinates);
 
-	if(!context.isVisible(coordinates) && neighborInfo.areAllHidden())
+	std::optional<NeighborTilesInfo> neighborInfo;
+	if(!visible)
+		neighborInfo.emplace(context, coordinates);
+
+	if(!visible && neighborInfo->areAllHidden())
 	{
-		rendererFow.renderTile(context, target, coordinates);
+		rendererFow.renderTile(context, target, coordinates, *neighborInfo);
 	}
 	else
 	{
@@ -829,7 +864,7 @@ void MapRenderer::renderTile(IMapRendererContext & context, Canvas & target, con
 		rendererPath.renderTile(context, target, coordinates);
 		rendererOverlay.renderTile(context, target, coordinates);
 
-		if(!context.isVisible(coordinates))
-			rendererFow.renderTile(context, target, coordinates);
+		if(!visible)
+			rendererFow.renderTile(context, target, coordinates, *neighborInfo);
 	}
 }

--- a/client/mapView/MapRenderer.cpp
+++ b/client/mapView/MapRenderer.cpp
@@ -548,9 +548,9 @@ void MapRendererObjects::renderImage(IMapRendererContext & context, Canvas & tar
 
 void MapRendererObjects::renderObject(IMapRendererContext & context, Canvas & target, const int3 & coordinates, const CGObjectInstance * instance)
 {
-	renderImage(context, target, coordinates, instance, getImageToRender(context, instance, getBaseAnimation(instance)));
-	renderImage(context, target, coordinates, instance, getImageToRender(context, instance, getFlagAnimation(instance)));
-	renderImage(context, target, coordinates, instance, getImageToRender(context, instance, getOverlayAnimation(instance)));
+	// only the images are shared across tiles - transparency and offset stay per-tile
+	for(const auto & image : getObjectImages(context, instance))
+		renderImage(context, target, coordinates, instance, image);
 }
 
 void MapRendererObjects::renderTile(IMapRendererContext & context, Canvas & target, const int3 & coordinates)
@@ -573,6 +573,24 @@ void MapRendererObjects::renderTile(IMapRendererContext & context, Canvas & targ
 void MapRendererObjects::prepareFrame()
 {
 	checksumInfoCache.clear();
+	renderImageCache.clear();
+}
+
+const MapRendererObjects::ObjectImages & MapRendererObjects::getObjectImages(IMapRendererContext & context, const CGObjectInstance * object)
+{
+	auto it = renderImageCache.find(object->id.getNum());
+	if(it != renderImageCache.end())
+		return it->second;
+
+	// Which image each layer resolves to is fixed for the whole pass: the animation clock
+	// does not advance inside one, and no object can change while it runs under the lock.
+	ObjectImages images = {
+		getImageToRender(context, object, getBaseAnimation(object)),
+		getImageToRender(context, object, getFlagAnimation(object)),
+		getImageToRender(context, object, getOverlayAnimation(object))
+	};
+
+	return renderImageCache.emplace(object->id.getNum(), std::move(images)).first->second;
 }
 
 const MapRendererObjects::ObjectChecksumInfo & MapRendererObjects::getChecksumInfo(IMapRendererContext & context, const CGObjectInstance * object, size_t groupIndex)

--- a/client/mapView/MapRenderer.cpp
+++ b/client/mapView/MapRenderer.cpp
@@ -104,7 +104,7 @@ MapTileStorage::MapTileStorage(size_t capacity)
 {
 }
 
-void MapTileStorage::load(size_t index, const AnimationPath & filename, EImageBlitMode blitMode)
+void MapTileStorage::load(size_t index, const AnimationPath & filename, EImageBlitMode blitMode, bool preloadAllFrames)
 {
 	for(auto & rotation : groupCounts[index])
 		rotation.clear();
@@ -128,6 +128,21 @@ void MapTileStorage::load(size_t index, const AnimationPath & filename, EImageBl
 
 	if (terrainAnimations[3])
 		terrainAnimations[3]->horizontalFlip();
+
+	if (!preloadAllFrames)
+		return;
+
+	// Runs while the map is being set up, off the rendering thread, so that the cost is
+	// paid once behind the loading screen rather than by gameplay frames.
+	for(const auto & animation : terrainAnimations)
+	{
+		if (!animation)
+			continue;
+
+		for(size_t group = 0; animation->size(group) > 0; ++group)
+			for(size_t frame = 0; frame < animation->size(group); ++frame)
+				animation->getImage(frame, group);
+	}
 }
 
 std::shared_ptr<IImage> MapTileStorage::find(size_t fileIndex, size_t rotationIndex, size_t imageIndex, size_t groupIndex)
@@ -167,7 +182,7 @@ MapRendererTerrain::MapRendererTerrain()
 {
 	logGlobal->debug("Loading map terrains");
 	for(const auto & terrain : LIBRARY->terrainTypeHandler->objects)
-		storage.load(terrain->getIndex(), AnimationPath::builtin(terrain->tilesFilename.getName() + (terrain->paletteAnimation.size() ? "_Shifted": "")), EImageBlitMode::OPAQUE);
+		storage.load(terrain->getIndex(), AnimationPath::builtin(terrain->tilesFilename.getName() + (terrain->paletteAnimation.size() ? "_Shifted": "")), EImageBlitMode::OPAQUE, !terrain->paletteAnimation.empty());
 	logGlobal->debug("Done loading map terrains");
 }
 
@@ -206,7 +221,7 @@ MapRendererRiver::MapRendererRiver()
 {
 	logGlobal->debug("Loading map rivers");
 	for(const auto & river : LIBRARY->riverTypeHandler->objects)
-		storage.load(river->getIndex(), AnimationPath::builtin(river->tilesFilename.getName() + (river->paletteAnimation.size() ? "_Shifted": "")), EImageBlitMode::COLORKEY);
+		storage.load(river->getIndex(), AnimationPath::builtin(river->tilesFilename.getName() + (river->paletteAnimation.size() ? "_Shifted": "")), EImageBlitMode::COLORKEY, !river->paletteAnimation.empty());
 	logGlobal->debug("Done loading map rivers");
 }
 

--- a/client/mapView/MapRenderer.cpp
+++ b/client/mapView/MapRenderer.cpp
@@ -553,6 +553,48 @@ void MapRendererObjects::renderTile(IMapRendererContext & context, Canvas & targ
 	}
 }
 
+void MapRendererObjects::prepareFrame()
+{
+	checksumInfoCache.clear();
+}
+
+const MapRendererObjects::ObjectChecksumInfo & MapRendererObjects::getChecksumInfo(IMapRendererContext & context, const CGObjectInstance * object, size_t groupIndex)
+{
+	const auto key = std::make_pair(object->id.getNum(), groupIndex);
+
+	auto it = checksumInfoCache.find(key);
+	if(it != checksumInfoCache.end())
+		return it->second;
+
+	ObjectChecksumInfo info;
+
+	// The image index depends on the animation clock, which does not advance during a
+	// single pass, so the image - and therefore its size - is fixed for the whole pass.
+	const auto & base = getBaseAnimation(object);
+	if(base && base->size(groupIndex) > 1)
+	{
+		const auto & image = base->getImage(context.objectImageIndex(object->id, base->size(groupIndex)), groupIndex);
+		if(image)
+		{
+			info.baseAnimated = true;
+			info.baseDimensions = image->dimensions();
+		}
+	}
+
+	const auto & flag = getFlagAnimation(object);
+	if(flag && flag->size(groupIndex) > 1)
+	{
+		const auto & image = flag->getImage(context.objectImageIndex(object->id, flag->size(groupIndex)), groupIndex);
+		if(image)
+		{
+			info.flagAnimated = true;
+			info.flagDimensions = image->dimensions();
+		}
+	}
+
+	return checksumInfoCache.emplace(key, info).first->second;
+}
+
 uint8_t MapRendererObjects::checksum(IMapRendererContext & context, const int3 & coordinates)
 {
 	for(const auto & objectID : context.getObjects(coordinates))
@@ -566,27 +608,15 @@ uint8_t MapRendererObjects::checksum(IMapRendererContext & context, const int3 &
 			continue;
 		}
 
-		size_t groupIndex = context.objectGroupIndex(objectInstance->id);
-		Point offsetPixels = context.objectImageOffset(objectInstance->id, coordinates);
+		const size_t groupIndex = context.objectGroupIndex(objectInstance->id);
+		const Point offsetPixels = context.objectImageOffset(objectInstance->id, coordinates);
+		const auto & info = getChecksumInfo(context, objectInstance, groupIndex);
 
-		auto base = getBaseAnimation(objectInstance);
-		auto flag = getFlagAnimation(objectInstance);
+		if(info.baseAnimated && offsetPixels.x < info.baseDimensions.x && offsetPixels.y < info.baseDimensions.y)
+			return context.objectImageIndex(objectID, 250);
 
-		if (base && base->size(groupIndex) > 1)
-		{
-			auto imageIndex = context.objectImageIndex(objectID, base->size(groupIndex));
-			auto image = base->getImage(imageIndex, groupIndex);
-			if ( offsetPixels.x < image->dimensions().x && offsetPixels.y < image->dimensions().y)
-				return context.objectImageIndex(objectID, 250);
-		}
-
-		if (flag && flag->size(groupIndex) > 1)
-		{
-			auto imageIndex = context.objectImageIndex(objectID, flag->size(groupIndex));
-			auto image = flag->getImage(imageIndex, groupIndex);
-			if ( offsetPixels.x < image->dimensions().x && offsetPixels.y < image->dimensions().y)
-				return context.objectImageIndex(objectID, 250);
-		}
+		if(info.flagAnimated && offsetPixels.x < info.flagDimensions.x && offsetPixels.y < info.flagDimensions.y)
+			return context.objectImageIndex(objectID, 250);
 	}
 	return 0xff-1;
 }
@@ -787,6 +817,7 @@ uint8_t MapRendererPath::checksum(IMapRendererContext & context, const int3 & co
 void MapRenderer::prepareFrame(IMapRendererContext & context)
 {
 	rendererPath.prepareFrame(context);
+	rendererObjects.prepareFrame();
 }
 
 MapRenderer::TileChecksum MapRenderer::getTileChecksum(IMapRendererContext & context, const int3 & coordinates)

--- a/client/mapView/MapRenderer.cpp
+++ b/client/mapView/MapRenderer.cpp
@@ -100,11 +100,15 @@ struct NeighborTilesInfo
 
 MapTileStorage::MapTileStorage(size_t capacity)
 	: animations(capacity)
+	, groupCounts(capacity)
 {
 }
 
 void MapTileStorage::load(size_t index, const AnimationPath & filename, EImageBlitMode blitMode)
 {
+	for(auto & rotation : groupCounts[index])
+		rotation.clear();
+
 	auto & terrainAnimations = animations[index];
 
 	for(auto & entry : terrainAnimations)
@@ -135,7 +139,7 @@ std::shared_ptr<IImage> MapTileStorage::find(size_t fileIndex, size_t rotationIn
 		return nullptr;
 }
 
-int MapTileStorage::groupCount(size_t fileIndex, size_t rotationIndex, size_t imageIndex)
+int MapTileStorage::computeGroupCount(size_t fileIndex, size_t rotationIndex, size_t imageIndex) const
 {
 	const auto & animation = animations[fileIndex][rotationIndex];
 	if (animation)
@@ -143,6 +147,19 @@ int MapTileStorage::groupCount(size_t fileIndex, size_t rotationIndex, size_t im
 			if(animation->size(i) <= imageIndex)
 				return i;
 	return 1;
+}
+
+int MapTileStorage::groupCount(size_t fileIndex, size_t rotationIndex, size_t imageIndex)
+{
+	auto & cached = groupCounts[fileIndex][rotationIndex];
+
+	if (cached.size() <= imageIndex)
+		cached.resize(imageIndex + 1, -1);
+
+	if (cached[imageIndex] < 0)
+		cached[imageIndex] = computeGroupCount(fileIndex, rotationIndex, imageIndex);
+
+	return cached[imageIndex];
 }
 
 MapRendererTerrain::MapRendererTerrain()

--- a/client/mapView/MapRenderer.cpp
+++ b/client/mapView/MapRenderer.cpp
@@ -647,6 +647,10 @@ const MapRendererObjects::ObjectChecksumInfo & MapRendererObjects::getChecksumIn
 
 uint8_t MapRendererObjects::checksum(IMapRendererContext & context, const int3 & coordinates)
 {
+	// objects covering one tile no longer advance their animation at the same moment, so
+	// every animated one has to feed the checksum instead of just the first
+	uint8_t result = 0xff-1;
+
 	for(const auto & objectID : context.getObjects(coordinates))
 	{
 		const auto * objectInstance = context.getObject(objectID);
@@ -662,13 +666,14 @@ uint8_t MapRendererObjects::checksum(IMapRendererContext & context, const int3 &
 		const Point offsetPixels = context.objectImageOffset(objectInstance->id, coordinates);
 		const auto & info = getChecksumInfo(context, objectInstance, groupIndex);
 
-		if(info.baseAnimated && offsetPixels.x < info.baseDimensions.x && offsetPixels.y < info.baseDimensions.y)
-			return context.objectImageIndex(objectID, 250);
+		const bool baseVisible = info.baseAnimated && offsetPixels.x < info.baseDimensions.x && offsetPixels.y < info.baseDimensions.y;
+		const bool flagVisible = info.flagAnimated && offsetPixels.x < info.flagDimensions.x && offsetPixels.y < info.flagDimensions.y;
 
-		if(info.flagAnimated && offsetPixels.x < info.flagDimensions.x && offsetPixels.y < info.flagDimensions.y)
-			return context.objectImageIndex(objectID, 250);
+		// odd multiplier, so a frame advancing by one always changes the result
+		if(baseVisible || flagVisible)
+			result = result * 31 + context.objectImageIndex(objectID, 250);
 	}
-	return 0xff-1;
+	return result;
 }
 
 MapRendererOverlay::MapRendererOverlay()

--- a/client/mapView/MapRenderer.h
+++ b/client/mapView/MapRenderer.h
@@ -99,6 +99,15 @@ class MapRendererObjects
 	/// can change, since the pass runs synchronously while holding the interface lock.
 	std::map<std::pair<int, size_t>, ObjectChecksumInfo> checksumInfoCache;
 
+	/// The base, flag and overlay images an object contributes this pass, in draw order.
+	/// Resolving them costs three string-keyed animation lookups plus a frame lookup, and
+	/// the same object is asked once per tile it covers - which for a large object is most
+	/// of the cost of drawing it. Cleared by prepareFrame(), so it cannot outlive a pass.
+	using ObjectImages = std::array<std::shared_ptr<IImage>, 3>;
+	std::unordered_map<int32_t, ObjectImages> renderImageCache;
+
+	const ObjectImages & getObjectImages(IMapRendererContext & context, const CGObjectInstance * object);
+
 	const ObjectChecksumInfo & getChecksumInfo(IMapRendererContext & context, const CGObjectInstance * object, size_t groupIndex);
 
 	std::shared_ptr<CAnimation> getBaseAnimation(const CGObjectInstance * obj);

--- a/client/mapView/MapRenderer.h
+++ b/client/mapView/MapRenderer.h
@@ -29,6 +29,14 @@ class MapTileStorage
 	using TerrainAnimation = std::array<std::shared_ptr<CAnimation>, 4>;
 	std::vector<TerrainAnimation> animations;
 
+	/// Memo for groupCount(), which walks CAnimation::size() - a map lookup each - until it
+	/// runs past imageIndex. The answer depends only on the loaded animations, so it is
+	/// computed once per key instead of once per tile per frame. -1 means "not yet known".
+	using GroupCounts = std::array<std::vector<int>, 4>;
+	std::vector<GroupCounts> groupCounts;
+
+	int computeGroupCount(size_t fileIndex, size_t rotationIndex, size_t imageIndex) const;
+
 public:
 	explicit MapTileStorage(size_t capacity);
 	void load(size_t index, const AnimationPath & filename, EImageBlitMode blitMode);

--- a/client/mapView/MapRenderer.h
+++ b/client/mapView/MapRenderer.h
@@ -19,6 +19,8 @@ class CAnimation;
 class IImage;
 class Canvas;
 class IMapRendererContext;
+struct CGPath;
+struct NeighborTilesInfo;
 enum class EImageBlitMode : uint8_t;
 
 class MapTileStorage
@@ -109,13 +111,23 @@ class MapRendererFow
 public:
 	MapRendererFow();
 
-	uint8_t checksum(IMapRendererContext & context, const int3 & coordinates);
-	void renderTile(IMapRendererContext & context, Canvas & target, const int3 & coordinates);
+	/// Both take the neighbour visibility that the caller has already computed - it costs
+	/// eight visibility queries and the caller needs it anyway to reach this point.
+	uint8_t checksum(IMapRendererContext & context, const int3 & coordinates, const NeighborTilesInfo & neighborInfo);
+	void renderTile(IMapRendererContext & context, Canvas & target, const int3 & coordinates, const NeighborTilesInfo & neighborInfo);
 };
 
 class MapRendererPath
 {
 	std::shared_ptr<CAnimation> pathNodes;
+
+	/// Frame-scoped snapshot of the hero path, refreshed by prepareFrame().
+	/// Resolving the path costs three lookups and finding a tile in it is a linear scan,
+	/// both of which would otherwise be repeated for every visible tile of every frame.
+	const CGPath * cachedPath = nullptr;
+	/// Sorted coordinates of cachedPath, for rejecting the vast majority of tiles in
+	/// logarithmic time instead of scanning the whole node list
+	std::vector<int3> cachedPathTiles;
 
 	size_t selectImageReachability(bool reachableToday, size_t imageIndex);
 	size_t selectImageCross(bool reachableToday, const int3 & curr);
@@ -124,6 +136,9 @@ class MapRendererPath
 
 public:
 	MapRendererPath();
+
+	/// Must be called once per frame before any checksum() or renderTile() call
+	void prepareFrame(IMapRendererContext & context);
 
 	uint8_t checksum(IMapRendererContext & context, const int3 & coordinates);
 	void renderTile(IMapRendererContext & context, Canvas & target, const int3 & coordinates);
@@ -159,6 +174,10 @@ class MapRenderer
 
 public:
 	using TileChecksum = std::array<uint8_t, 8>;
+
+	/// Refreshes state that is constant for the whole frame. Must be called before the
+	/// per-tile getTileChecksum() / renderTile() calls of that frame.
+	void prepareFrame(IMapRendererContext & context);
 
 	TileChecksum getTileChecksum(IMapRendererContext & context, const int3 & coordinates);
 

--- a/client/mapView/MapRenderer.h
+++ b/client/mapView/MapRenderer.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "../../lib/int3.h"
+#include "../../lib/Point.h"
 #include "../../lib/filesystem/ResourcePath.h"
 
 class ObjectInstanceID;
@@ -73,6 +74,25 @@ class MapRendererObjects
 	std::map<AnimationPath, std::shared_ptr<CAnimation>> animations;
 	mutable std::map<ImagePath, std::shared_ptr<IImage>> images;
 
+	/// Everything the checksum needs to know about one object in one animation group:
+	/// whether it animates at all, and how large its sprite is.
+	struct ObjectChecksumInfo
+	{
+		bool baseAnimated = false;
+		bool flagAnimated = false;
+		Point baseDimensions = Point(0, 0);
+		Point flagDimensions = Point(0, 0);
+	};
+
+	/// Memo for the above, valid for a single update pass only. Answering it resolves the
+	/// object's animation through a string-keyed map and materialises an image, and the
+	/// same object is asked once per tile it covers, every frame. prepareFrame() clears
+	/// it, so it can never outlive one pass - and within one pass nothing it depends on
+	/// can change, since the pass runs synchronously while holding the interface lock.
+	std::map<std::pair<int, size_t>, ObjectChecksumInfo> checksumInfoCache;
+
+	const ObjectChecksumInfo & getChecksumInfo(IMapRendererContext & context, const CGObjectInstance * object, size_t groupIndex);
+
 	std::shared_ptr<CAnimation> getBaseAnimation(const CGObjectInstance * obj);
 	std::shared_ptr<CAnimation> getFlagAnimation(const CGObjectInstance * obj);
 	std::shared_ptr<CAnimation> getOverlayAnimation(const CGObjectInstance * obj);
@@ -86,6 +106,9 @@ class MapRendererObjects
 	void renderObject(IMapRendererContext & context, Canvas & target, const int3 & coordinates, const CGObjectInstance * obj);
 
 public:
+	/// Must be called once per update pass before any checksum() call
+	void prepareFrame();
+
 	uint8_t checksum(IMapRendererContext & context, const int3 & coordinates);
 	void renderTile(IMapRendererContext & context, Canvas & target, const int3 & coordinates);
 };

--- a/client/mapView/MapRenderer.h
+++ b/client/mapView/MapRenderer.h
@@ -39,7 +39,10 @@ class MapTileStorage
 
 public:
 	explicit MapTileStorage(size_t capacity);
-	void load(size_t index, const AnimationPath & filename, EImageBlitMode blitMode);
+	/// preloadAllFrames materialises every frame right away instead of on the frame that
+	/// first draws it. Used for palette-animated terrain, whose frames are generated and
+	/// upscaled on demand and so stall whichever frame scrolls a new tile into view.
+	void load(size_t index, const AnimationPath & filename, EImageBlitMode blitMode, bool preloadAllFrames = false);
 	std::shared_ptr<IImage> find(size_t fileIndex, size_t rotationIndex, size_t imageIndex, size_t groupIndex = 0);
 	int groupCount(size_t fileIndex, size_t rotationIndex, size_t imageIndex);
 };

--- a/client/mapView/MapRendererContext.cpp
+++ b/client/mapView/MapRendererContext.cpp
@@ -325,7 +325,12 @@ size_t MapRendererAdventureContext::objectImageIndex(ObjectInstanceID objectID, 
 	// usign objectID for frameCounter to add pseudo-random element per-object.
 	// Without it, animation of multiple visible objects of the same type will always be in sync
 	size_t baseFrameTime = 180;
-	size_t frameCounter = animationTime / baseFrameTime + objectID.getNum();
+
+	// Offsetting the clock as well as the frame staggers *when* each object advances. With
+	// only the frame offset every animated object ticks on the very same frame, so the whole
+	// visible map goes dirty at once every 180 ms instead of a few tiles at a time.
+	size_t timeOffset = objectID.getNum() * 97 % baseFrameTime;
+	size_t frameCounter = (animationTime + timeOffset) / baseFrameTime + objectID.getNum();
 	size_t frameIndex = frameCounter % groupSize;
 	return frameIndex;
 }

--- a/client/mapView/MapView.cpp
+++ b/client/mapView/MapView.cpp
@@ -11,6 +11,7 @@
 #include "StdInc.h"
 #include "MapView.h"
 
+#include "IMapRendererContext.h"
 #include "MapViewActions.h"
 #include "MapViewCache.h"
 #include "MapViewController.h"
@@ -73,6 +74,15 @@ void BasicMapView::render(Canvas & target, bool fullUpdate)
 		{
 			target.drawColor(pos, ColorRGBA(0, 0, 0, 0));
 			gpuHolePunched = true;
+		}
+
+		// text has no GPU path, so the labels go onto the software screen, which is
+		// composited above the map layer. Clearing them again needs the hole repunched.
+		if(controller->getContext()->showTextOverlay())
+		{
+			Canvas targetClipped(target, pos);
+			tilesCache->renderTextOverlay(controller->getContext(), targetClipped);
+			gpuHolePunched = false;
 		}
 		return;
 	}

--- a/client/mapView/MapView.cpp
+++ b/client/mapView/MapView.cpp
@@ -23,7 +23,9 @@
 #include "../GameInstance.h"
 #include "../render/CAnimation.h"
 #include "../render/Canvas.h"
+#include "../render/Colors.h"
 #include "../render/IImage.h"
+#include "../render/IScreenHandler.h"
 #include "../eventsSDL/InputHandler.h"
 
 #include "../../lib/callback/CCallback.h"
@@ -46,10 +48,11 @@ std::shared_ptr<MapViewModel> BasicMapView::createModel(const Point & dimensions
 	return result;
 }
 
-BasicMapView::BasicMapView(const Point & offset, const Point & dimensions)
+BasicMapView::BasicMapView(const Point & offset, const Point & dimensions, bool useGpuLayer)
 	: model(createModel(dimensions))
-	, tilesCache(new MapViewCache(model))
+	, tilesCache(new MapViewCache(model, useGpuLayer))
 	, controller(new MapViewController(model, tilesCache))
+	, gpuLayerEligible(useGpuLayer)
 	, needFullUpdate(false)
 {
 	OBJECT_CONSTRUCTION;
@@ -60,12 +63,35 @@ BasicMapView::BasicMapView(const Point & offset, const Point & dimensions)
 
 void BasicMapView::render(Canvas & target, bool fullUpdate)
 {
+	if(gpuLayerEligible && ENGINE->screenHandler().isGpuMapRenderingEnabled())
+	{
+		renderGpu(fullUpdate);
+
+		// the map is composited from its own GPU layer, so the software screen only has to
+		// stop covering it - and only when something may have painted over the hole
+		if(fullUpdate || !gpuHolePunched)
+		{
+			target.drawColor(pos, ColorRGBA(0, 0, 0, 0));
+			gpuHolePunched = true;
+		}
+		return;
+	}
+
 	Canvas targetClipped(target, pos);
 	tilesCache->update(controller->getContext());
 	tilesCache->render(controller->getContext(), targetClipped, fullUpdate);
 
 	MapOverlayLogVisualizer r(targetClipped, model);
 	logVisual->visualize(r);
+}
+
+void BasicMapView::renderGpu(bool fullUpdate)
+{
+	Canvas layer = ENGINE->screenHandler().getMapLayerCanvas();
+	Canvas targetClipped(layer, pos);
+
+	tilesCache->update(controller->getContext());
+	tilesCache->render(controller->getContext(), targetClipped, fullUpdate);
 }
 
 void BasicMapView::tick(uint32_t msPassed)
@@ -102,7 +128,7 @@ void MapView::show(Canvas & to)
 }
 
 MapView::MapView(const Point & offset, const Point & dimensions)
-	: BasicMapView(offset, dimensions)
+	: BasicMapView(offset, dimensions, true)
 {
 	OBJECT_CONSTRUCTION;
 	actions = std::make_shared<MapViewActions>(*this, model);
@@ -220,7 +246,7 @@ void MapView::onViewMapActivated()
 }
 
 PuzzleMapView::PuzzleMapView(const Point & offset, const Point & dimensions, const int3 & tileToCenter)
-	: BasicMapView(offset, dimensions)
+	: BasicMapView(offset, dimensions, false)
 {
 	controller->activatePuzzleMapContext(tileToCenter);
 	controller->setViewCenter(tileToCenter);

--- a/client/mapView/MapView.h
+++ b/client/mapView/MapView.h
@@ -30,12 +30,23 @@ protected:
 
 	std::shared_ptr<MapViewModel> createModel(const Point & dimensions) const;
 
+	/// Only the adventure map owns the GPU layer; the puzzle map is drawn inside a window
+	/// above it and must stay in the software screen
+	const bool gpuLayerEligible;
+
+	/// True once the screen surface has been made transparent over this widget, so that
+	/// the GPU map layer underneath shows through
+	bool gpuHolePunched = false;
+
 	void render(Canvas & target, bool fullUpdate);
+
+	/// Draws the map into the GPU layer instead of into the screen surface
+	void renderGpu(bool fullUpdate);
 
 public:
 	bool needFullUpdate;
 
-	BasicMapView(const Point & offset, const Point & dimensions);
+	BasicMapView(const Point & offset, const Point & dimensions, bool useGpuLayer);
 	~BasicMapView() override;
 
 	void tick(uint32_t msPassed) override;

--- a/client/mapView/MapViewCache.cpp
+++ b/client/mapView/MapViewCache.cpp
@@ -137,6 +137,62 @@ void MapViewCache::update(const std::shared_ptr<IMapRendererContext> & context)
 	cachedLevel = model->getLevel();
 }
 
+void MapViewCache::renderCachedTiles(Canvas & target)
+{
+	const Rect tilesRect = model->getTilesTotalRect();
+	const Point tileSize = model->getSingleTileSize();
+	const int width = tilesRect.w;
+	const int height = tilesRect.h;
+
+	if(width <= 0 || height <= 0)
+		return;
+
+	// Screen position of the tile in the top left corner of the visible window.
+	// Always within one tile of the origin, since the view may be scrolled by a
+	// fraction of a tile.
+	const Point origin = model->getTargetTileArea(int3(tilesRect.x, tilesRect.y, model->getLevel())).topLeft();
+
+	// Position of that same tile inside the cache, which stores tiles wrapped around
+	// on both axes (tile x lives at slot x modulo width).
+	const int firstSlotX = ((tilesRect.x % width) + width) % width;
+	const int firstSlotY = ((tilesRect.y % height) + height) % height;
+
+	// Because of the wrapping, the visible window is split into at most two horizontal
+	// and two vertical bands within the cache - so at most four rectangles, each of
+	// which is contiguous both in the cache and on screen.
+	const std::array<std::pair<int, int>, 2> columns = {{ // {first slot, slot count}
+		{firstSlotX, width - firstSlotX},
+		{0, firstSlotX}
+	}};
+	const std::array<std::pair<int, int>, 2> rows = {{
+		{firstSlotY, height - firstSlotY},
+		{0, firstSlotY}
+	}};
+
+	int offsetX = 0;
+	for(const auto & column : columns)
+	{
+		int offsetY = 0;
+		for(const auto & row : rows)
+		{
+			if(column.second > 0 && row.second > 0)
+			{
+				Rect cacheArea(
+					column.first * tileSize.x,
+					row.first * tileSize.y,
+					column.second * tileSize.x,
+					row.second * tileSize.y);
+
+				Point targetPosition = origin + Point(offsetX * tileSize.x, offsetY * tileSize.y);
+
+				target.draw(Canvas(*terrain, cacheArea), targetPosition);
+			}
+			offsetY += row.second;
+		}
+		offsetX += column.second;
+	}
+}
+
 void MapViewCache::render(const std::shared_ptr<IMapRendererContext> & context, Canvas & target, bool fullRedraw)
 {
 	bool mapMoved = (cachedPosition != model->getMapViewCenter());
@@ -148,24 +204,37 @@ void MapViewCache::render(const std::shared_ptr<IMapRendererContext> & context, 
 
 	Rect dimensions = model->getTilesTotalRect();
 
-	for(int y = dimensions.top(); y < dimensions.bottom(); ++y)
+	if(lazyUpdate)
 	{
-		for(int x = dimensions.left(); x < dimensions.right(); ++x)
+		// Only the handful of tiles that actually changed need repainting
+		for(int y = dimensions.top(); y < dimensions.bottom(); ++y)
 		{
-			int cacheX = (terrainChecksum.shape()[0] + x) % terrainChecksum.shape()[0];
-			int cacheY = (terrainChecksum.shape()[1] + y) % terrainChecksum.shape()[1];
-			int3 tile(x, y, model->getLevel());
+			for(int x = dimensions.left(); x < dimensions.right(); ++x)
+			{
+				int cacheX = (terrainChecksum.shape()[0] + x) % terrainChecksum.shape()[0];
+				int cacheY = (terrainChecksum.shape()[1] + y) % terrainChecksum.shape()[1];
+				int3 tile(x, y, model->getLevel());
 
-			if(lazyUpdate && tilesUpToDate[cacheX][cacheY])
-				continue;
+				if(tilesUpToDate[cacheX][cacheY])
+					continue;
 
-			Canvas source = getTile(tile);
-			Rect targetRect = model->getTargetTileArea(tile);
-			target.draw(source, targetRect.topLeft());
+				Canvas source = getTile(tile);
+				Rect targetRect = model->getTargetTileArea(tile);
+				target.draw(source, targetRect.topLeft());
 
-			if (!fullRedraw)
-				tilesUpToDate[cacheX][cacheY] = true;
+				if (!fullRedraw)
+					tilesUpToDate[cacheX][cacheY] = true;
+			}
 		}
+	}
+	else
+	{
+		// Every tile has to be repainted - copy the whole cached window at once
+		// instead of issuing one blit per tile.
+		renderCachedTiles(target);
+
+		if (!fullRedraw)
+			std::fill_n(tilesUpToDate.data(), tilesUpToDate.num_elements(), true);
 	}
 
 	if(context->showImageOverlay())

--- a/client/mapView/MapViewCache.cpp
+++ b/client/mapView/MapViewCache.cpp
@@ -309,42 +309,47 @@ void MapViewCache::render(const std::shared_ptr<IMapRendererContext> & context, 
 		}
 	}
 
+	// on the GPU path the caller draws it onto the software screen instead
 	if(textOverlayVisible && !target.isRenderTarget())
-	{
-		const auto & font = ENGINE->renderHandler().loadFont(FONT_TINY);
-
-		for(int y = dimensions.top(); y < dimensions.bottom(); ++y)
-		{
-			for(int x = dimensions.left(); x < dimensions.right(); ++x)
-			{
-				int3 tile(x, y, model->getLevel());
-				auto overlay = context->overlayText(tile);
-
-				if(!overlay.text.empty())
-				{
-					Rect targetRect = model->getTargetTileArea(tile);
-					Point position = targetRect.center();
-					if (x % 2 == 0)
-						position.y += targetRect.h / 4;
-					else
-						position.y -= targetRect.h / 4;
-
-					Point dimensions(font->getStringWidth(overlay.text), font->getLineHeight());
-					Rect textRect = Rect(position - dimensions / 2, dimensions).resize(2);
-
-					target.drawColor(textRect, overlay.color);
-					target.drawBorder(textRect, Colors::BRIGHT_YELLOW);
-					target.drawText(position, EFonts::FONT_TINY, Colors::BLACK, ETextAlignment::CENTER, overlay.text);
-				}
-			}
-		}
-	}
+		renderTextOverlay(context, target);
 
 	if(!vstd::isAlmostZero(context->viewTransitionProgress()))
 		target.drawTransparent(*terrainTransition, Point(0, 0), 1.0 - context->viewTransitionProgress());
 
 	cachedPosition = model->getMapViewCenter();
 	overlayWasVisible = overlayVisible;
+}
+
+void MapViewCache::renderTextOverlay(const std::shared_ptr<IMapRendererContext> & context, Canvas & target)
+{
+	const Rect dimensions = model->getTilesTotalRect();
+	const auto & font = ENGINE->renderHandler().loadFont(FONT_TINY);
+
+	for(int y = dimensions.top(); y < dimensions.bottom(); ++y)
+	{
+		for(int x = dimensions.left(); x < dimensions.right(); ++x)
+		{
+			int3 tile(x, y, model->getLevel());
+			auto overlay = context->overlayText(tile);
+
+			if(!overlay.text.empty())
+			{
+				Rect targetRect = model->getTargetTileArea(tile);
+				Point position = targetRect.center();
+				if (x % 2 == 0)
+					position.y += targetRect.h / 4;
+				else
+					position.y -= targetRect.h / 4;
+
+				Point textSize(font->getStringWidth(overlay.text), font->getLineHeight());
+				Rect textRect = Rect(position - textSize / 2, textSize).resize(2);
+
+				target.drawColor(textRect, overlay.color);
+				target.drawBorder(textRect, Colors::BRIGHT_YELLOW);
+				target.drawText(position, EFonts::FONT_TINY, Colors::BLACK, ETextAlignment::CENTER, overlay.text);
+			}
+		}
+	}
 }
 
 void MapViewCache::createTransitionSnapshot(const std::shared_ptr<IMapRendererContext> & context)

--- a/client/mapView/MapViewCache.cpp
+++ b/client/mapView/MapViewCache.cpp
@@ -129,6 +129,9 @@ void MapViewCache::update(const std::shared_ptr<IMapRendererContext> & context)
 		tilesUpToDate = newCache;
 	}
 
+	// Refresh whatever the renderer can resolve once instead of per tile
+	mapRenderer->prepareFrame(*context);
+
 	for(int y = dimensions.top(); y < dimensions.bottom(); ++y)
 		for(int x = dimensions.left(); x < dimensions.right(); ++x)
 			updateTile(context, {x, y, model->getLevel()});

--- a/client/mapView/MapViewCache.cpp
+++ b/client/mapView/MapViewCache.cpp
@@ -22,26 +22,72 @@
 #include "../render/IRenderHandler.h"
 #include "../render/Graphics.h"
 
+#include "../CMT.h"
 #include "../GameEngine.h"
+#include "../render/IScreenHandler.h"
 #include "../widgets/TextControls.h"
+
+#include <SDL_render.h>
 
 #include "../../lib/int3.h"
 
-MapViewCache::~MapViewCache() = default;
+MapViewCache::~MapViewCache()
+{
+	for(SDL_Texture * texture : {terrainTexture, terrainTransitionTexture, intermediateTexture})
+		if(texture)
+			SDL_DestroyTexture(texture);
+}
 
-MapViewCache::MapViewCache(const std::shared_ptr<MapViewModel> & model)
+SDL_Texture * MapViewCache::createRenderTarget(const Point & size) const
+{
+	if(!useGpuLayer || !ENGINE->screenHandler().isGpuMapRenderingEnabled())
+		return nullptr;
+
+	const Point pixels = size * ENGINE->screenHandler().getScalingFactor();
+	SDL_Texture * result = SDL_CreateTexture(mainRenderer, SDL_PIXELFORMAT_ARGB8888, SDL_TEXTUREACCESS_TARGET, pixels.x, pixels.y);
+
+	if(result)
+		logGlobal->info("Created map cache render target %dx%d", pixels.x, pixels.y);
+	else
+		logGlobal->error("Failed to create %dx%d map cache render target: %s", pixels.x, pixels.y, SDL_GetError());
+
+	return result;
+}
+
+MapViewCache::MapViewCache(const std::shared_ptr<MapViewModel> & model, bool useGpuLayer)
 	: model(model)
+	, useGpuLayer(useGpuLayer)
 	, cachedLevel(0)
 	, overlayWasVisible(false)
 	, mapRenderer(new MapRenderer())
 	, iconsStorage(ENGINE->renderHandler().loadAnimation(AnimationPath::builtin("VwSymbol"), EImageBlitMode::COLORKEY))
-	, intermediate(new Canvas(Point(32, 32), CanvasScalingPolicy::AUTO))
-	, terrain(new Canvas(model->getCacheDimensionsPixels(), CanvasScalingPolicy::AUTO))
-	, terrainTransition(new Canvas(model->getPixelsVisibleDimensions(), CanvasScalingPolicy::AUTO))
 {
 	Point visibleSize = model->getTilesVisibleDimensions();
 	terrainChecksum.resize(boost::extents[visibleSize.x][visibleSize.y]);
 	tilesUpToDate.resize(boost::extents[visibleSize.x][visibleSize.y]);
+}
+
+std::unique_ptr<Canvas> MapViewCache::createCanvas(const Point & size, SDL_Texture *& texture) const
+{
+	texture = createRenderTarget(size);
+
+	if(texture)
+		return std::make_unique<Canvas>(Canvas::createFromRenderTarget(texture, size, CanvasScalingPolicy::AUTO));
+
+	// no render target means the GPU path is unavailable for this canvas
+	return std::make_unique<Canvas>(size, CanvasScalingPolicy::AUTO);
+}
+
+void MapViewCache::ensureCanvases()
+{
+	if(terrain)
+		return;
+
+	// Must run on the rendering thread: this object is constructed while handling a
+	// netpack, and creating a texture there would move the GL context off the GUI thread
+	intermediate = createCanvas(Point(32, 32), intermediateTexture);
+	terrain = createCanvas(model->getCacheDimensionsPixels(), terrainTexture);
+	terrainTransition = createCanvas(model->getPixelsVisibleDimensions(), terrainTransitionTexture);
 }
 
 Canvas MapViewCache::getTile(const int3 & coordinates)
@@ -110,6 +156,8 @@ void MapViewCache::updateTile(const std::shared_ptr<IMapRendererContext> & conte
 
 void MapViewCache::update(const std::shared_ptr<IMapRendererContext> & context)
 {
+	ensureCanvases();
+
 	Rect dimensions = model->getTilesTotalRect();
 	bool mapResized = cachedSize != model->getSingleTileSize();
 
@@ -198,6 +246,8 @@ void MapViewCache::renderCachedTiles(Canvas & target)
 
 void MapViewCache::render(const std::shared_ptr<IMapRendererContext> & context, Canvas & target, bool fullRedraw)
 {
+	ensureCanvases();
+
 	bool mapMoved = (cachedPosition != model->getMapViewCenter());
 	bool textOverlayVisible = context->showTextOverlay();
 	bool overlayVisible = context->showImageOverlay() || textOverlayVisible;
@@ -259,7 +309,7 @@ void MapViewCache::render(const std::shared_ptr<IMapRendererContext> & context, 
 		}
 	}
 
-	if(textOverlayVisible)
+	if(textOverlayVisible && !target.isRenderTarget())
 	{
 		const auto & font = ENGINE->renderHandler().loadFont(FONT_TINY);
 

--- a/client/mapView/MapViewCache.h
+++ b/client/mapView/MapViewCache.h
@@ -56,6 +56,11 @@ class MapViewCache
 	Canvas getTile(const int3 & coordinates);
 	void updateTile(const std::shared_ptr<IMapRendererContext> & context, const int3 & coordinates);
 
+	/// Copies the entire cached tile window onto the target in as few blits as possible.
+	/// Used whenever every tile has to be repainted anyway - most importantly while the
+	/// view is scrolling, which is exactly when the per-tile path is most expensive.
+	void renderCachedTiles(Canvas & target);
+
 	std::shared_ptr<IImage> getOverlayImageForTile(const std::shared_ptr<IMapRendererContext> & context, const int3 & coordinates);
 
 public:

--- a/client/mapView/MapViewCache.h
+++ b/client/mapView/MapViewCache.h
@@ -11,6 +11,8 @@
 
 #include "../../lib/Point.h"
 
+struct SDL_Texture;
+
 class ObjectInstanceID;
 
 class IImage;
@@ -46,10 +48,29 @@ class MapViewCache
 
 	std::shared_ptr<MapViewModel> model;
 
+	/// Whether this cache may allocate GPU render targets
+	bool useGpuLayer;
+
 	std::unique_ptr<Canvas> terrain;
 	std::unique_ptr<Canvas> terrainTransition;
 	std::unique_ptr<Canvas> intermediate;
 	std::unique_ptr<MapRenderer> mapRenderer;
+
+	/// GPU render targets backing the canvases above. Null while rendering in software
+	SDL_Texture * terrainTexture = nullptr;
+	SDL_Texture * terrainTransitionTexture = nullptr;
+	SDL_Texture * intermediateTexture = nullptr;
+
+	/// Creates a render target of the given logical size, or null if the GPU path is off
+	SDL_Texture * createRenderTarget(const Point & size) const;
+
+	/// Canvas of the given logical size, drawing onto a fresh render target when the GPU
+	/// path is available and onto a plain surface otherwise
+	std::unique_ptr<Canvas> createCanvas(const Point & size, SDL_Texture *& texture) const;
+
+	/// Allocates the canvases on first use. Deferred out of the constructor because that
+	/// runs on the network thread, where creating a texture would steal the GL context
+	void ensureCanvases();
 
 	std::shared_ptr<CAnimation> iconsStorage;
 
@@ -64,7 +85,9 @@ class MapViewCache
 	std::shared_ptr<IImage> getOverlayImageForTile(const std::shared_ptr<IMapRendererContext> & context, const int3 & coordinates);
 
 public:
-	explicit MapViewCache(const std::shared_ptr<MapViewModel> & model);
+	/// useGpuLayer must match how the owning view presents itself: a view drawn into the
+	/// software screen cannot read from a GPU-backed cache
+	MapViewCache(const std::shared_ptr<MapViewModel> & model, bool useGpuLayer);
 	~MapViewCache();
 
 	/// invalidates cache of specified object

--- a/client/mapView/MapViewCache.h
+++ b/client/mapView/MapViewCache.h
@@ -99,6 +99,10 @@ public:
 	/// renders updated terrain cache onto provided canvas
 	void render(const std::shared_ptr<IMapRendererContext> & context, Canvas & target, bool fullRedraw);
 
+	/// Draws the object name labels. Text has no GPU path, so a view using the GPU layer
+	/// must call this separately with a surface-backed target
+	void renderTextOverlay(const std::shared_ptr<IMapRendererContext> & context, Canvas & target);
+
 	/// creates snapshot of current view and stores it into internal canvas
 	/// used for view transition, e.g. Dimension Door spell or teleporters (Subterra gates / Monolith)
 	void createTransitionSnapshot(const std::shared_ptr<IMapRendererContext> & context);

--- a/client/media/CSoundHandler.cpp
+++ b/client/media/CSoundHandler.cpp
@@ -192,7 +192,7 @@ int CSoundHandler::playSoundImpl(const AudioPath & sound, int repeats, bool useC
 		return -1;
 
 	int channel;
-	MixChunkPtr chunkPtr = getSoundChunk(sound);
+	MixChunkPtr chunkPtr;
 	Mix_Chunk * chunk = nullptr;
 	if (!useCache)
 	{

--- a/client/render/AssetCache.cpp
+++ b/client/render/AssetCache.cpp
@@ -1,0 +1,82 @@
+/*
+ * AssetCache.cpp, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
+#include "StdInc.h"
+#include "AssetCache.h"
+
+#ifdef VCMI_WINDOWS
+#include <windows.h>
+#elif defined(VCMI_APPLE)
+#include <sys/sysctl.h>
+#include <sys/types.h>
+#elif defined(VCMI_UNIX)
+#include <unistd.h>
+#endif
+
+namespace AssetCache
+{
+
+size_t getTotalSystemMemory()
+{
+#ifdef VCMI_WINDOWS
+	MEMORYSTATUSEX status;
+	status.dwLength = sizeof(status);
+	if(GlobalMemoryStatusEx(&status))
+		return status.ullTotalPhys;
+	return 0;
+#elif defined(VCMI_APPLE)
+	int mib[2] = { CTL_HW, HW_MEMSIZE };
+	uint64_t size = 0;
+	size_t length = sizeof(size);
+	if(sysctl(mib, 2, &size, &length, nullptr, 0) == 0)
+		return size;
+	return 0;
+#elif defined(VCMI_UNIX)
+	long pages = sysconf(_SC_PHYS_PAGES);
+	long pageSize = sysconf(_SC_PAGE_SIZE);
+	if(pages > 0 && pageSize > 0)
+		return static_cast<size_t>(pages) * static_cast<size_t>(pageSize);
+	return 0;
+#else
+	return 0;
+#endif
+}
+
+size_t getRetentionBudget(int configuredMegabytes)
+{
+	static constexpr size_t megabyte = 1024 * 1024;
+
+	if(configuredMegabytes > 0)
+		return static_cast<size_t>(configuredMegabytes) * megabyte;
+
+	// Auto mode. The budget is derived from *total* rather than currently free RAM
+	// on purpose: free memory fluctuates with whatever else the machine is doing,
+	// and a cache that shrinks and grows with it would reintroduce exactly the
+	// reload thrashing this cache exists to prevent. A small fixed share of total
+	// RAM is predictable and leaves the OS free to reclaim page cache instead.
+	const size_t totalMemory = getTotalSystemMemory();
+
+#ifdef VCMI_MOBILE
+	// Mobile systems kill background apps aggressively, so stay modest
+	static constexpr size_t minimalBudget = 32 * megabyte;
+	static constexpr size_t maximalBudget = 192 * megabyte;
+	static constexpr size_t memoryShare = 32;
+#else
+	static constexpr size_t minimalBudget = 64 * megabyte;
+	static constexpr size_t maximalBudget = 512 * megabyte;
+	static constexpr size_t memoryShare = 16;
+#endif
+
+	if(totalMemory == 0)
+		return minimalBudget; // could not detect RAM - be conservative
+
+	return std::clamp(totalMemory / memoryShare, minimalBudget, maximalBudget);
+}
+
+}

--- a/client/render/AssetCache.h
+++ b/client/render/AssetCache.h
@@ -1,0 +1,203 @@
+/*
+ * AssetCache.h, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
+#pragma once
+
+/// Memory-budgeted LRU cache that keeps recently used assets alive.
+///
+/// RenderHandler tracks loaded .def files and images in weak_ptr maps. Those maps
+/// only find an asset while somebody else still holds it - the moment the last
+/// user drops it the asset is destroyed, and the next request re-reads the file
+/// from disk, re-decodes it and re-runs the xBRZ upscaler. Profiling an ordinary
+/// session showed this happening constantly for animated terrain: LAVATL.def was
+/// read from disk 774 times in 46 seconds, and 82% of all .def reads were re-reads
+/// of a file that had already been parsed.
+///
+/// This cache holds an *additional* strong reference to the most recently used
+/// assets so they survive until the memory budget pushes them out. It deliberately
+/// does not change lookup semantics: the weak_ptr maps stay authoritative and this
+/// class only stops entries from expiring too eagerly. Evicting an entry that is
+/// still in use elsewhere is harmless - it simply becomes weakly-tracked again.
+///
+/// Entry cost is an estimate in bytes, refreshed on every access, since assets
+/// (notably ScalableImageShared) grow lazily as scaled variants are generated.
+template<typename Key, typename Value>
+class MemoryBudgetedCache
+{
+public:
+	explicit MemoryBudgetedCache(size_t budgetBytes)
+		: budgetBytes(budgetBytes)
+	{
+	}
+
+	/// Retains `value` under `key` and marks it as most recently used.
+	/// `costBytes` is the current estimated memory footprint of the asset.
+	void retain(const Key & key, const std::shared_ptr<Value> & value, size_t costBytes)
+	{
+		if(!value)
+			return;
+
+		// Anything evicted is released after the lock is dropped: destroying an
+		// asset frees SDL surfaces, which is not work we want to do under a lock
+		// other threads are waiting on.
+		std::vector<std::shared_ptr<Value>> evicted;
+
+		{
+			std::lock_guard lock(mutex);
+
+			auto indexIter = index.find(key);
+			if(indexIter != index.end())
+			{
+				auto entryIter = indexIter->second;
+				usedBytes -= entryIter->costBytes;
+				entryIter->value = value;
+				entryIter->costBytes = costBytes;
+				usedBytes += costBytes;
+				order.splice(order.begin(), order, entryIter);
+			}
+			else
+			{
+				order.push_front(Entry{key, value, costBytes});
+				index[key] = order.begin();
+				usedBytes += costBytes;
+			}
+
+			evictLocked(evicted);
+		}
+	}
+
+	/// Marks an existing entry as most recently used and refreshes its cost.
+	/// Returns false if the key is not retained by this cache.
+	bool touch(const Key & key, size_t costBytes)
+	{
+		std::vector<std::shared_ptr<Value>> evicted;
+
+		{
+			std::lock_guard lock(mutex);
+
+			auto indexIter = index.find(key);
+			if(indexIter == index.end())
+				return false;
+
+			auto entryIter = indexIter->second;
+			usedBytes -= entryIter->costBytes;
+			entryIter->costBytes = costBytes;
+			usedBytes += costBytes;
+			order.splice(order.begin(), order, entryIter);
+
+			evictLocked(evicted);
+		}
+		return true;
+	}
+
+	void remove(const Key & key)
+	{
+		std::shared_ptr<Value> evicted;
+
+		{
+			std::lock_guard lock(mutex);
+
+			auto indexIter = index.find(key);
+			if(indexIter == index.end())
+				return;
+
+			evicted = indexIter->second->value;
+			usedBytes -= indexIter->second->costBytes;
+			order.erase(indexIter->second);
+			index.erase(indexIter);
+		}
+	}
+
+	void clear()
+	{
+		std::list<Entry> evicted;
+
+		{
+			std::lock_guard lock(mutex);
+			evicted.swap(order);
+			index.clear();
+			usedBytes = 0;
+		}
+	}
+
+	void setBudget(size_t bytes)
+	{
+		std::vector<std::shared_ptr<Value>> evicted;
+
+		{
+			std::lock_guard lock(mutex);
+			budgetBytes = bytes;
+			evictLocked(evicted);
+		}
+	}
+
+	size_t getBudget() const
+	{
+		std::lock_guard lock(mutex);
+		return budgetBytes;
+	}
+
+	size_t getUsedBytes() const
+	{
+		std::lock_guard lock(mutex);
+		return usedBytes;
+	}
+
+	size_t getEntryCount() const
+	{
+		std::lock_guard lock(mutex);
+		return index.size();
+	}
+
+private:
+	struct Entry
+	{
+		Key key;
+		std::shared_ptr<Value> value;
+		size_t costBytes;
+	};
+
+	/// front() is the most recently used entry
+	std::list<Entry> order;
+	std::map<Key, typename std::list<Entry>::iterator> index;
+
+	mutable std::mutex mutex;
+	size_t budgetBytes;
+	size_t usedBytes = 0;
+
+	/// Drops least recently used entries until the budget is met. Must be called
+	/// with the lock held; ownership of dropped values is moved to `evicted` so
+	/// the caller can destroy them outside the lock.
+	void evictLocked(std::vector<std::shared_ptr<Value>> & evicted)
+	{
+		while(usedBytes > budgetBytes && !order.empty())
+		{
+			// Never evict the entry that was just inserted - a single asset larger
+			// than the whole budget would otherwise thrash on every access.
+			if(order.size() == 1)
+				break;
+
+			Entry & victim = order.back();
+			usedBytes -= victim.costBytes;
+			evicted.push_back(std::move(victim.value));
+			index.erase(victim.key);
+			order.pop_back();
+		}
+	}
+};
+
+namespace AssetCache
+{
+	/// Total physical RAM in bytes, or 0 when it cannot be determined.
+	size_t getTotalSystemMemory();
+
+	/// Memory budget for the asset retention caches.
+	/// `configuredMegabytes` comes from settings; 0 means "derive from system RAM".
+	size_t getRetentionBudget(int configuredMegabytes);
+}

--- a/client/render/CDefFile.cpp
+++ b/client/render/CDefFile.cpp
@@ -40,7 +40,9 @@ CDefFile::CDefFile(const AnimationPath & Name):
 	data(nullptr),
 	palette(nullptr)
 {
-	data = CResourceHandler::get()->load(Name)->readAll().first;
+	auto loaded = CResourceHandler::get()->load(Name)->readAll();
+	data = std::move(loaded.first);
+	dataSize = loaded.second;
 
 	palette = std::unique_ptr<SDL_Color[]>(new SDL_Color[256]);
 	int it = 0;
@@ -283,6 +285,22 @@ CDefFile::SSpriteDef CDefFile::getFrameInfo(size_t frame, size_t group) const
 }
 
 CDefFile::~CDefFile() = default;
+
+size_t CDefFile::bytesUsed() const
+{
+	// Dominated by the raw file contents; the index maps are counted roughly since
+	// this only feeds a cache eviction heuristic.
+	size_t result = dataSize + 256 * sizeof(SDL_Color) + sizeof(CDefFile);
+
+	for(const auto & group : offset)
+		result += group.second.size() * sizeof(size_t) + sizeof(group);
+
+	for(const auto & group : name)
+		for(const auto & entry : group.second)
+			result += entry.capacity() + sizeof(std::string);
+
+	return result;
+}
 
 const std::map<size_t, size_t > CDefFile::getEntries() const
 {

--- a/client/render/CDefFile.h
+++ b/client/render/CDefFile.h
@@ -43,16 +43,21 @@ private:
 
 	std::unique_ptr<ui8[]>       data;
 	std::unique_ptr<SDL_Color[]> palette;
+	size_t dataSize = 0;
 
 public:
 	CDefFile(const AnimationPath & Name);
 	~CDefFile();
+
+	/// Estimated memory footprint of this def file, for cache accounting
 
 	//load frame as SDL_Surface
 	void loadFrame(size_t frame, size_t group, IImageLoader &loader) const;
 	bool hasFrame(size_t frame, size_t group) const;
 	std::string getName(size_t frame, size_t group) const;
 	SSpriteDef getFrameInfo(size_t frame, size_t group) const;
+
+	size_t bytesUsed() const;
 
 	const std::map<size_t, size_t> getEntries() const;
 };

--- a/client/render/Canvas.cpp
+++ b/client/render/Canvas.cpp
@@ -22,8 +22,11 @@
 #include "Graphics.h"
 #include "IFont.h"
 
+#include "../CMT.h"
+
 #include <SDL_surface.h>
 #include <SDL_pixels.h>
+#include <SDL_render.h>
 
 /// Slack added around reported image areas. Several dimensions() implementations
 /// divide a physical size by the scaling factor, so multiplying back can land up to
@@ -34,6 +37,15 @@ static constexpr int imageDirtyMargin = 1;
 /// box slightly (shadows, outlines), and getStringWidth() rounds down when converting
 /// scaled metrics back to logical ones.
 static constexpr int textDirtyMargin = 2;
+
+/// Reports a problem in the GPU render path once per distinct message, so that a failure
+/// happening every frame cannot flood the log
+static void logGpuIssueOnce(const std::string & message)
+{
+	static std::set<std::string> reported;
+	if(reported.insert(message).second)
+		logGlobal->error("GPU render path: %s", message.c_str());
+}
 
 Canvas::Canvas(SDL_Surface * surface, CanvasScalingPolicy scalingPolicy):
 	scalingPolicy(scalingPolicy),
@@ -46,17 +58,29 @@ Canvas::Canvas(SDL_Surface * surface, CanvasScalingPolicy scalingPolicy):
 Canvas::Canvas(const Canvas & other):
 	scalingPolicy(other.scalingPolicy),
 	surface(other.surface),
+	renderTarget(other.renderTarget),
 	renderArea(other.renderArea)
 {
-	surface->refcount++;
+	if(surface)
+		surface->refcount++;
 }
 
 Canvas::Canvas(Canvas && other):
 	scalingPolicy(other.scalingPolicy),
 	surface(other.surface),
+	renderTarget(other.renderTarget),
 	renderArea(other.renderArea)
 {
-	surface->refcount++;
+	if(surface)
+		surface->refcount++;
+}
+
+Canvas::Canvas(SDL_Texture * renderTarget, const Point & size, CanvasScalingPolicy scalingPolicy):
+	scalingPolicy(scalingPolicy),
+	surface(nullptr),
+	renderTarget(renderTarget),
+	renderArea(Point(0, 0), size * getScalingFactor())
+{
 }
 
 Canvas::Canvas(const Canvas & other, const Rect & newClipRect):
@@ -94,17 +118,32 @@ Point Canvas::transformSize(const Point & input)
 
 void Canvas::markDirty(const Rect & surfaceArea) const
 {
-	ScreenDirtyRegions::markDirty(surface, surfaceArea);
+	if(surface)
+		ScreenDirtyRegions::markDirty(surface, surfaceArea);
 }
 
 void Canvas::markDirtyAll() const
 {
-	ScreenDirtyRegions::markDirty(surface, renderArea);
+	if(surface)
+		ScreenDirtyRegions::markDirty(surface, renderArea);
+}
+
+void Canvas::bindRenderTarget() const
+{
+	// switching targets flushes the batch, so only do it when it actually changes
+	if(SDL_GetRenderTarget(mainRenderer) != renderTarget)
+		if(SDL_SetRenderTarget(mainRenderer, renderTarget) != 0)
+			logGpuIssueOnce(std::string("SDL_SetRenderTarget failed: ") + SDL_GetError());
 }
 
 Canvas Canvas::createFromSurface(SDL_Surface * surface, CanvasScalingPolicy scalingPolicy)
 {
 	return Canvas(surface, scalingPolicy);
+}
+
+Canvas Canvas::createFromRenderTarget(SDL_Texture * renderTarget, const Point & size, CanvasScalingPolicy scalingPolicy)
+{
+	return Canvas(renderTarget, size, scalingPolicy);
 }
 
 void Canvas::applyTransparency(bool on)
@@ -117,13 +156,40 @@ void Canvas::applyTransparency(bool on)
 
 void Canvas::applyGrayscale()
 {
+	if(renderTarget)
+		return; // no GPU equivalent; only the puzzle map needs this and it stays software
+
 	markDirtyAll();
 	CSDL_Ext::convertToGrayscale(surface, renderArea);
 }
 
 Canvas::~Canvas()
 {
-	SDL_FreeSurface(surface);
+	if(surface)
+		SDL_FreeSurface(surface);
+}
+
+
+void Canvas::copyFromCanvas(const Canvas & image, const Rect & targetArea, uint32_t blendMode, uint8_t alpha)
+{
+	if(!image.renderTarget)
+	{
+		logGpuIssueOnce("cannot copy a surface-backed canvas onto a GPU target");
+		return;
+	}
+
+	bindRenderTarget();
+
+	SDL_Rect source = CSDL_Ext::toSDL(image.renderArea);
+	SDL_Rect target = CSDL_Ext::toSDL(targetArea);
+
+	SDL_SetTextureBlendMode(image.renderTarget, static_cast<SDL_BlendMode>(blendMode));
+	SDL_SetTextureAlphaMod(image.renderTarget, alpha);
+
+	if(SDL_RenderCopy(mainRenderer, image.renderTarget, &source, &target) != 0)
+		logGpuIssueOnce(std::string("SDL_RenderCopy failed: ") + SDL_GetError());
+
+	SDL_SetTextureAlphaMod(image.renderTarget, SDL_ALPHA_OPAQUE);
 }
 
 void Canvas::draw(IVideoInstance & video, const Point & pos)
@@ -140,6 +206,14 @@ void Canvas::draw(IVideoInstance & video, const Point & pos)
 
 void Canvas::draw(const IImage& image, const Point & pos)
 {
+	if(renderTarget)
+	{
+		bindRenderTarget();
+		if(!image.drawTexture(mainRenderer, transformPos(pos), nullptr, getScalingFactor()))
+			logGpuIssueOnce("image reference has no texture representation");
+		return;
+	}
+
 	markDirty(Rect(transformPos(pos), transformSize(image.dimensions())).resize(imageDirtyMargin * getScalingFactor()));
 	image.draw(surface, transformPos(pos), nullptr, getScalingFactor());
 }
@@ -149,6 +223,14 @@ void Canvas::draw(const std::shared_ptr<IImage>& image, const Point & pos)
 	assert(image);
 	if (image)
 	{
+		if(renderTarget)
+		{
+			bindRenderTarget();
+			if(!image->drawTexture(mainRenderer, transformPos(pos), nullptr, getScalingFactor()))
+				logGpuIssueOnce("image has no texture representation");
+			return;
+		}
+
 		markDirty(Rect(transformPos(pos), transformSize(image->dimensions())).resize(imageDirtyMargin * getScalingFactor()));
 		image->draw(surface, transformPos(pos), nullptr, getScalingFactor());
 	}
@@ -160,6 +242,14 @@ void Canvas::draw(const std::shared_ptr<IImage>& image, const Point & pos, const
 	assert(image);
 	if (image)
 	{
+		if(renderTarget)
+		{
+			bindRenderTarget();
+			if(!image->drawTexture(mainRenderer, transformPos(pos), &realSourceRect, getScalingFactor()))
+				logGpuIssueOnce("image has no texture representation (subrect)");
+			return;
+		}
+
 		markDirty(Rect(transformPos(pos), transformSize(sourceRect.dimensions())).resize(imageDirtyMargin * getScalingFactor()));
 		image->draw(surface, transformPos(pos), &realSourceRect, getScalingFactor());
 	}
@@ -167,12 +257,24 @@ void Canvas::draw(const std::shared_ptr<IImage>& image, const Point & pos, const
 
 void Canvas::draw(const Canvas & image, const Point & pos)
 {
+	if(renderTarget)
+	{
+		copyFromCanvas(image, Rect(transformPos(pos), image.renderArea.dimensions()), SDL_BLENDMODE_NONE, SDL_ALPHA_OPAQUE);
+		return;
+	}
+
 	markDirty(Rect(transformPos(pos), image.renderArea.dimensions()));
 	CSDL_Ext::blitSurface(image.surface, image.renderArea, surface, transformPos(pos));
 }
 
 void Canvas::drawTransparent(const Canvas & image, const Point & pos, double transparency)
 {
+	if(renderTarget)
+	{
+		copyFromCanvas(image, Rect(transformPos(pos), image.renderArea.dimensions()), SDL_BLENDMODE_BLEND, 255 * transparency);
+		return;
+	}
+
 	SDL_BlendMode oldMode;
 
 	markDirty(Rect(transformPos(pos), image.renderArea.dimensions()));
@@ -189,6 +291,13 @@ void Canvas::drawScaled(const Canvas & image, const Point & pos, const Point & t
 {
 	// SDL_BlitScaled is a software scaler - expensive on large areas.
 	Rect targetArea(transformPos(pos), transformSize(targetSize));
+
+	if(renderTarget)
+	{
+		copyFromCanvas(image, targetArea, SDL_BLENDMODE_NONE, SDL_ALPHA_OPAQUE);
+		return;
+	}
+
 	markDirty(targetArea);
 
 	SDL_Rect targetRect = CSDL_Ext::toSDL(targetArea);
@@ -297,6 +406,16 @@ void Canvas::drawText(const Point & position, const EFonts & font, const ColorRG
 void Canvas::drawColor(const Rect & target, const ColorRGBA & color)
 {
 	Rect realTarget = target * getScalingFactor() + renderArea.topLeft();
+
+	if(renderTarget)
+	{
+		bindRenderTarget();
+		SDL_Rect rect = CSDL_Ext::toSDL(realTarget);
+		SDL_SetRenderDrawBlendMode(mainRenderer, SDL_BLENDMODE_NONE);
+		SDL_SetRenderDrawColor(mainRenderer, color.r, color.g, color.b, color.a);
+		SDL_RenderFillRect(mainRenderer, &rect);
+		return;
+	}
 
 	markDirty(realTarget);
 	CSDL_Ext::fillRect(surface, realTarget, CSDL_Ext::toSDL(color));

--- a/client/render/Canvas.cpp
+++ b/client/render/Canvas.cpp
@@ -10,6 +10,8 @@
 #include "StdInc.h"
 #include "Canvas.h"
 
+#include "DirtyRegionTracker.h"
+
 #include "../GameEngine.h"
 #include "../media/IVideoPlayer.h"
 #include "IRenderHandler.h"
@@ -22,6 +24,16 @@
 
 #include <SDL_surface.h>
 #include <SDL_pixels.h>
+
+/// Slack added around reported image areas. Several dimensions() implementations
+/// divide a physical size by the scaling factor, so multiplying back can land up to
+/// (scalingFactor - 1) pixels short of what is actually written.
+static constexpr int imageDirtyMargin = 1;
+
+/// Slack added around reported text areas. Glyph rendering may overshoot the nominal
+/// box slightly (shadows, outlines), and getStringWidth() rounds down when converting
+/// scaled metrics back to logical ones.
+static constexpr int textDirtyMargin = 2;
 
 Canvas::Canvas(SDL_Surface * surface, CanvasScalingPolicy scalingPolicy):
 	scalingPolicy(scalingPolicy),
@@ -80,6 +92,16 @@ Point Canvas::transformSize(const Point & input)
 	return input * getScalingFactor();
 }
 
+void Canvas::markDirty(const Rect & surfaceArea) const
+{
+	ScreenDirtyRegions::markDirty(surface, surfaceArea);
+}
+
+void Canvas::markDirtyAll() const
+{
+	ScreenDirtyRegions::markDirty(surface, renderArea);
+}
+
 Canvas Canvas::createFromSurface(SDL_Surface * surface, CanvasScalingPolicy scalingPolicy)
 {
 	return Canvas(surface, scalingPolicy);
@@ -95,6 +117,7 @@ void Canvas::applyTransparency(bool on)
 
 void Canvas::applyGrayscale()
 {
+	markDirtyAll();
 	CSDL_Ext::convertToGrayscale(surface, renderArea);
 }
 
@@ -105,11 +128,19 @@ Canvas::~Canvas()
 
 void Canvas::draw(IVideoInstance & video, const Point & pos)
 {
+	// CVideoInstance::show() blits at pos * scalingFactor and ignores this canvas'
+	// render area, and size() rounds the true dimensions down. Report the union of
+	// both possible origins with a margin so no case is under-reported.
+	Point videoSize = transformSize(video.size()) + Point(getScalingFactor(), getScalingFactor());
+	markDirty(Rect(pos * getScalingFactor(), videoSize));
+	markDirty(Rect(transformPos(pos), videoSize));
+
 	video.show(pos, surface);
 }
 
 void Canvas::draw(const IImage& image, const Point & pos)
 {
+	markDirty(Rect(transformPos(pos), transformSize(image.dimensions())).resize(imageDirtyMargin * getScalingFactor()));
 	image.draw(surface, transformPos(pos), nullptr, getScalingFactor());
 }
 
@@ -117,7 +148,10 @@ void Canvas::draw(const std::shared_ptr<IImage>& image, const Point & pos)
 {
 	assert(image);
 	if (image)
+	{
+		markDirty(Rect(transformPos(pos), transformSize(image->dimensions())).resize(imageDirtyMargin * getScalingFactor()));
 		image->draw(surface, transformPos(pos), nullptr, getScalingFactor());
+	}
 }
 
 void Canvas::draw(const std::shared_ptr<IImage>& image, const Point & pos, const Rect & sourceRect)
@@ -125,17 +159,23 @@ void Canvas::draw(const std::shared_ptr<IImage>& image, const Point & pos, const
 	Rect realSourceRect = sourceRect * getScalingFactor();
 	assert(image);
 	if (image)
+	{
+		markDirty(Rect(transformPos(pos), transformSize(sourceRect.dimensions())).resize(imageDirtyMargin * getScalingFactor()));
 		image->draw(surface, transformPos(pos), &realSourceRect, getScalingFactor());
+	}
 }
 
 void Canvas::draw(const Canvas & image, const Point & pos)
 {
+	markDirty(Rect(transformPos(pos), image.renderArea.dimensions()));
 	CSDL_Ext::blitSurface(image.surface, image.renderArea, surface, transformPos(pos));
 }
 
 void Canvas::drawTransparent(const Canvas & image, const Point & pos, double transparency)
 {
 	SDL_BlendMode oldMode;
+
+	markDirty(Rect(transformPos(pos), image.renderArea.dimensions()));
 
 	SDL_GetSurfaceBlendMode(image.surface, &oldMode);
 	SDL_SetSurfaceBlendMode(image.surface, SDL_BLENDMODE_BLEND);
@@ -147,25 +187,38 @@ void Canvas::drawTransparent(const Canvas & image, const Point & pos, double tra
 
 void Canvas::drawScaled(const Canvas & image, const Point & pos, const Point & targetSize)
 {
-	SDL_Rect targetRect = CSDL_Ext::toSDL(Rect(transformPos(pos), transformSize(targetSize)));
+	// SDL_BlitScaled is a software scaler - expensive on large areas.
+	Rect targetArea(transformPos(pos), transformSize(targetSize));
+	markDirty(targetArea);
+
+	SDL_Rect targetRect = CSDL_Ext::toSDL(targetArea);
 	SDL_BlitScaled(image.surface, nullptr, surface, &targetRect);
 }
 
 void Canvas::drawPoint(const Point & dest, const ColorRGBA & color)
 {
 	Point point = transformPos(dest);
+	markDirty(Rect(point, Point(1, 1)));
 	CSDL_Ext::putPixelWithoutRefreshIfInSurf(surface, point.x, point.y, color.r, color.g, color.b, color.a);
 }
 
 void Canvas::drawLine(const Point & from, const Point & dest, const ColorRGBA & colorFrom, const ColorRGBA & colorDest)
 {
-	CSDL_Ext::drawLine(surface, transformPos(from), transformPos(dest), CSDL_Ext::toSDL(colorFrom), CSDL_Ext::toSDL(colorDest), getScalingFactor());
+	Point start = transformPos(from);
+	Point end = transformPos(dest);
+	Point topLeft(std::min(start.x, end.x), std::min(start.y, end.y));
+	Point bottomRight(std::max(start.x, end.x), std::max(start.y, end.y));
+	// line is drawn with a thickness of one scaled pixel, hence the extra margin
+	markDirty(Rect(topLeft, bottomRight - topLeft).resize(getScalingFactor()));
+
+	CSDL_Ext::drawLine(surface, start, end, CSDL_Ext::toSDL(colorFrom), CSDL_Ext::toSDL(colorDest), getScalingFactor());
 }
 
 void Canvas::drawBorder(const Rect & target, const ColorRGBA & color, int width)
 {
 	Rect realTarget = target * getScalingFactor() + renderArea.topLeft();
 
+	markDirty(realTarget.resize(width * getScalingFactor()));
 	CSDL_Ext::drawBorder(surface, realTarget.x, realTarget.y, realTarget.w, realTarget.h, CSDL_Ext::toSDL(color), width * getScalingFactor());
 }
 
@@ -173,6 +226,7 @@ void Canvas::drawBorderDashed(const Rect & target, const ColorRGBA & color)
 {
 	Rect realTarget = target * getScalingFactor() + renderArea.topLeft();
 
+	markDirty(realTarget.resize(getScalingFactor()));
 	CSDL_Ext::drawLineDashed(surface, realTarget.topLeft(),    realTarget.topRight(),    CSDL_Ext::toSDL(color));
 	CSDL_Ext::drawLineDashed(surface, realTarget.bottomLeft(), realTarget.bottomRight(), CSDL_Ext::toSDL(color));
 	CSDL_Ext::drawLineDashed(surface, realTarget.topLeft(),    realTarget.bottomLeft(),  CSDL_Ext::toSDL(color));
@@ -182,6 +236,21 @@ void Canvas::drawBorderDashed(const Rect & target, const ColorRGBA & color)
 void Canvas::drawText(const Point & position, const EFonts & font, const ColorRGBA & colorDest, ETextAlignment alignment, const std::string & text )
 {
 	const auto & fontPtr = ENGINE->renderHandler().loadFont(font);
+
+	{
+		// Mirrors the offsets applied by IFont::renderText*, using the scaled metrics
+		// so that no glyph can fall outside the reported area.
+		Point origin = transformPos(position);
+		Point size(fontPtr->getStringWidthScaled(text), fontPtr->getLineHeightScaled());
+		Point topLeft = origin;
+
+		if (alignment == ETextAlignment::TOPCENTER || alignment == ETextAlignment::CENTER)
+			topLeft = origin - size / 2;
+		else if (alignment == ETextAlignment::BOTTOMRIGHT)
+			topLeft = origin - size;
+
+		markDirty(Rect(topLeft, size).resize(textDirtyMargin * getScalingFactor()));
+	}
 
 	switch (alignment)
 	{
@@ -196,6 +265,26 @@ void Canvas::drawText(const Point & position, const EFonts & font, const ColorRG
 {
 	const auto & fontPtr = ENGINE->renderHandler().loadFont(font);
 
+	if (!text.empty())
+	{
+		// Mirrors the offsets applied by IFont::renderTextLines*
+		int lineHeight = fontPtr->getLineHeightScaled();
+		int maxWidth = 0;
+		for (const auto & line : text)
+			maxWidth = std::max(maxWidth, static_cast<int>(fontPtr->getStringWidthScaled(line)));
+
+		Point origin = transformPos(position);
+		Point size(maxWidth, static_cast<int>(text.size()) * lineHeight);
+		Point topLeft = origin;
+
+		if (alignment == ETextAlignment::TOPCENTER || alignment == ETextAlignment::CENTER)
+			topLeft = Point(origin.x - size.x / 2, origin.y - size.y / 2 - lineHeight / 2);
+		else if (alignment == ETextAlignment::BOTTOMRIGHT)
+			topLeft = Point(origin.x - size.x, origin.y - size.y - lineHeight);
+
+		markDirty(Rect(topLeft, size).resize(textDirtyMargin * getScalingFactor()));
+	}
+
 	switch (alignment)
 	{
 	case ETextAlignment::TOPLEFT:      return fontPtr->renderTextLinesLeft  (surface, text, colorDest, transformPos(position));
@@ -209,6 +298,7 @@ void Canvas::drawColor(const Rect & target, const ColorRGBA & color)
 {
 	Rect realTarget = target * getScalingFactor() + renderArea.topLeft();
 
+	markDirty(realTarget);
 	CSDL_Ext::fillRect(surface, realTarget, CSDL_Ext::toSDL(color));
 }
 
@@ -216,15 +306,22 @@ void Canvas::drawColorBlended(const Rect & target, const ColorRGBA & color)
 {
 	Rect realTarget = target * getScalingFactor() + renderArea.topLeft();
 
+	markDirty(realTarget);
 	CSDL_Ext::fillRectBlended(surface, realTarget, CSDL_Ext::toSDL(color));
 }
 
 void Canvas::fillTexture(const std::shared_ptr<IImage>& image)
 {
+	// Tiles one image across the whole canvas - cost scales with canvas area.
 	assert(image);
 	if (!image)
 		return;
 		
+	// The tiling loop below iterates over the *surface* dimensions and additionally
+	// scales the offsets, so it can write well past renderArea (SDL clips the rest).
+	// Report the whole surface rather than just this canvas' area.
+	markDirty(Rect(0, 0, surface->w, surface->h));
+
 	Rect imageArea(Point(0, 0), image->dimensions());
 	for (int y=0; y < surface->h; y+= imageArea.h)
 	{

--- a/client/render/Canvas.cpp
+++ b/client/render/Canvas.cpp
@@ -186,6 +186,9 @@ void Canvas::copyFromCanvas(const Canvas & image, const Rect & targetArea, uint3
 	SDL_SetTextureBlendMode(image.renderTarget, static_cast<SDL_BlendMode>(blendMode));
 	SDL_SetTextureAlphaMod(image.renderTarget, alpha);
 
+	// matches SDL_BlitScaled on the surface path; see the note in SDLImageShared
+	SDL_SetTextureScaleMode(image.renderTarget, SDL_ScaleModeNearest);
+
 	if(SDL_RenderCopy(mainRenderer, image.renderTarget, &source, &target) != 0)
 		logGpuIssueOnce(std::string("SDL_RenderCopy failed: ") + SDL_GetError());
 

--- a/client/render/Canvas.h
+++ b/client/render/Canvas.h
@@ -48,6 +48,12 @@ class Canvas
 	Point transformPos(const Point & input);
 	Point transformSize(const Point & input);
 
+	/// Reports a written area (in surface coordinates) to the screen dirty region
+	/// tracker. No-op unless this canvas draws onto the screen framebuffer.
+	void markDirty(const Rect & surfaceArea) const;
+	/// Same, for the canvas' entire render area
+	void markDirtyAll() const;
+
 public:
 	Canvas & operator = (const Canvas & other) = delete;
 	Canvas & operator = (Canvas && other) = delete;

--- a/client/render/Canvas.h
+++ b/client/render/Canvas.h
@@ -14,6 +14,7 @@
 #include "../../lib/Color.h"
 
 struct SDL_Surface;
+struct SDL_Texture;
 class IImage;
 class IVideoInstance;
 enum EFonts : int8_t;
@@ -33,14 +34,28 @@ class Canvas
 	/// Upscaler awareness. Must be first member for initialization
 	CanvasScalingPolicy scalingPolicy;
 
-	/// Target surface
+	/// Target surface. Null when this canvas draws onto a GPU render target instead.
 	SDL_Surface * surface;
+
+	/// GPU render target this canvas draws onto, or null for the software path.
+	/// The caller owns it; the canvas only references it.
+	SDL_Texture * renderTarget = nullptr;
 
 	/// Current rendering area, all rendering operations will be moved into selected area
 	Rect renderArea;
 
 	/// constructs canvas using existing surface. Caller maintains ownership on the surface
 	explicit Canvas(SDL_Surface * surface, CanvasScalingPolicy scalingPolicy);
+
+	/// constructs canvas drawing onto a GPU render target. Caller maintains ownership
+	Canvas(SDL_Texture * renderTarget, const Point & size, CanvasScalingPolicy scalingPolicy);
+
+	/// Makes the renderer draw onto this canvas' target, if it is not already doing so
+	void bindRenderTarget() const;
+
+	/// GPU counterpart of the canvas-to-canvas blits. blendMode is an SDL_BlendMode,
+	/// kept untyped so that this header does not have to pull in SDL
+	void copyFromCanvas(const Canvas & image, const Rect & targetArea, uint32_t blendMode, uint8_t alpha);
 
 	/// copy constructor
 	Canvas(const Canvas & other);
@@ -70,6 +85,12 @@ public:
 	/// constructs canvas using existing surface. Caller maintains ownership on the surface
 	/// Compatibility method. AVOID USAGE. To be removed once SDL abstraction layer is finished.
 	static Canvas createFromSurface(SDL_Surface * surface, CanvasScalingPolicy scalingPolicy);
+
+	/// constructs canvas drawing onto a GPU render target of the given size in logical units
+	static Canvas createFromRenderTarget(SDL_Texture * renderTarget, const Point & size, CanvasScalingPolicy scalingPolicy);
+
+	/// True when this canvas draws with the GPU rather than into a surface
+	bool isRenderTarget() const { return renderTarget != nullptr; }
 
 	~Canvas();
 

--- a/client/render/CanvasImage.h
+++ b/client/render/CanvasImage.h
@@ -28,6 +28,9 @@ public:
 
 	//no-op methods
 
+	/// canvas-backed images have no GPU copy, so callers must fall back to the surface path
+	bool drawTexture(SDL_Renderer *, const Point &, const Rect *, int) const override { return false; };
+
 	bool isTransparent(const Point & coords) const override{ return false;};
 	void setAlpha(uint8_t value) override{};
 	void playerColored(const PlayerColor & player) override{};

--- a/client/render/DirtyRegionTracker.cpp
+++ b/client/render/DirtyRegionTracker.cpp
@@ -1,0 +1,262 @@
+/*
+ * DirtyRegionTracker.cpp, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
+#include "StdInc.h"
+#include "DirtyRegionTracker.h"
+
+#include <limits>
+
+void DirtyRegionTracker::setSurfaceSize(const Point & size)
+{
+	surfaceSize = size;
+	gridWidth = (size.x + cellSize - 1) / cellSize;
+	gridHeight = (size.y + cellSize - 1) / cellSize;
+	cells.assign(static_cast<size_t>(gridWidth) * gridHeight, 0);
+
+	// A newly created texture holds undefined pixels, so the first frame must upload
+	// everything regardless of what was drawn.
+	markFull();
+}
+
+void DirtyRegionTracker::markFull()
+{
+	fullUpdate = true;
+	anyDirty = true;
+	regionsValid = false;
+}
+
+void DirtyRegionTracker::markDirty(const Rect & area)
+{
+	if(fullUpdate || cells.empty())
+		return;
+
+	Rect clamped = area.intersect(Rect(Point(0, 0), surfaceSize));
+	if(clamped.w <= 0 || clamped.h <= 0)
+		return;
+
+	const int firstX = clamped.left() / cellSize;
+	const int firstY = clamped.top() / cellSize;
+	// bottom()/right() are exclusive, so the last touched cell is at (edge - 1)
+	const int lastX = std::min((clamped.right() - 1) / cellSize, gridWidth - 1);
+	const int lastY = std::min((clamped.bottom() - 1) / cellSize, gridHeight - 1);
+
+	for(int y = firstY; y <= lastY; ++y)
+	{
+		uint8_t * row = cells.data() + static_cast<size_t>(y) * gridWidth;
+		std::fill(row + firstX, row + lastX + 1, uint8_t(1));
+	}
+
+	anyDirty = true;
+	regionsValid = false;
+}
+
+void DirtyRegionTracker::clear()
+{
+	if(anyDirty && !cells.empty())
+		std::fill(cells.begin(), cells.end(), uint8_t(0));
+
+	fullUpdate = false;
+	anyDirty = false;
+	regions.clear();
+	regionsValid = false;
+}
+
+bool DirtyRegionTracker::isFullUpdate() const
+{
+	return fullUpdate;
+}
+
+bool DirtyRegionTracker::isEmpty() const
+{
+	return !anyDirty;
+}
+
+Point DirtyRegionTracker::getSurfaceSize() const
+{
+	return surfaceSize;
+}
+
+const std::vector<Rect> & DirtyRegionTracker::getRegions()
+{
+	if(!regionsValid)
+		rebuildRegions();
+
+	return regions;
+}
+
+void DirtyRegionTracker::rebuildRegions()
+{
+	regions.clear();
+	regionsValid = true;
+
+	if(fullUpdate || !anyDirty)
+		return;
+
+	// Scan the grid row by row, collecting horizontal runs of dirty cells. A run that
+	// repeats identically on the next row extends the rectangle that is already open
+	// instead of starting a new one, so vertically adjacent bands coalesce.
+	struct OpenRect
+	{
+		int cellX0;
+		int cellX1; // exclusive
+		int cellY0;
+	};
+
+	std::vector<OpenRect> open;
+	std::vector<OpenRect> current;
+
+	const auto & closeRect = [this](const OpenRect & entry, int cellY1)
+	{
+		Rect result(
+			entry.cellX0 * cellSize,
+			entry.cellY0 * cellSize,
+			(entry.cellX1 - entry.cellX0) * cellSize,
+			(cellY1 - entry.cellY0) * cellSize);
+
+		regions.push_back(result.intersect(Rect(Point(0, 0), surfaceSize)));
+	};
+
+	for(int y = 0; y < gridHeight; ++y)
+	{
+		const uint8_t * row = cells.data() + static_cast<size_t>(y) * gridWidth;
+
+		current.clear();
+		for(int x = 0; x < gridWidth; ++x)
+		{
+			if(row[x] == 0)
+				continue;
+
+			int runStart = x;
+			while(x < gridWidth && row[x] != 0)
+				++x;
+
+			current.push_back({runStart, x, y});
+		}
+
+		// Extend rectangles whose run is unchanged; close the rest.
+		size_t openIndex = 0;
+		size_t currentIndex = 0;
+		std::vector<OpenRect> stillOpen;
+		stillOpen.reserve(current.size());
+
+		while(openIndex < open.size() || currentIndex < current.size())
+		{
+			const bool haveOpen = openIndex < open.size();
+			const bool haveCurrent = currentIndex < current.size();
+
+			if(haveOpen && haveCurrent && open[openIndex].cellX0 == current[currentIndex].cellX0 && open[openIndex].cellX1 == current[currentIndex].cellX1)
+			{
+				stillOpen.push_back(open[openIndex]); // keep original cellY0, extends downwards
+				++openIndex;
+				++currentIndex;
+			}
+			else if(haveOpen && (!haveCurrent || open[openIndex].cellX0 < current[currentIndex].cellX0))
+			{
+				closeRect(open[openIndex], y);
+				++openIndex;
+			}
+			else
+			{
+				stillOpen.push_back(current[currentIndex]);
+				++currentIndex;
+			}
+		}
+
+		open.swap(stillOpen);
+	}
+
+	for(const auto & entry : open)
+		closeRect(entry, gridHeight);
+
+	if(regions.size() > maxRegions)
+		reduceRegionCount();
+
+	// Several regions that between them cover most of the surface are more expensive
+	// than a single upload of everything.
+	int64_t dirtyArea = 0;
+	for(const auto & region : regions)
+		dirtyArea += static_cast<int64_t>(region.w) * region.h;
+
+	const int64_t totalArea = static_cast<int64_t>(surfaceSize.x) * surfaceSize.y;
+	if(totalArea > 0 && dirtyArea > totalArea * fullUpdateAreaThreshold)
+	{
+		fullUpdate = true;
+		regions.clear();
+	}
+}
+
+void DirtyRegionTracker::reduceRegionCount()
+{
+	// Region count is already small here (bounded by the grid), so a straightforward
+	// quadratic search for the cheapest merge is fine.
+	while(regions.size() > maxRegions)
+	{
+		size_t bestFirst = 0;
+		size_t bestSecond = 1;
+		int64_t bestWaste = std::numeric_limits<int64_t>::max();
+
+		for(size_t i = 0; i < regions.size(); ++i)
+		{
+			for(size_t j = i + 1; j < regions.size(); ++j)
+			{
+				const Rect & left = regions[i];
+				const Rect & right = regions[j];
+
+				const int x0 = std::min(left.left(), right.left());
+				const int y0 = std::min(left.top(), right.top());
+				const int x1 = std::max(left.right(), right.right());
+				const int y1 = std::max(left.bottom(), right.bottom());
+
+				const int64_t unionArea = static_cast<int64_t>(x1 - x0) * (y1 - y0);
+				const int64_t ownArea = static_cast<int64_t>(left.w) * left.h + static_cast<int64_t>(right.w) * right.h;
+				const int64_t waste = unionArea - ownArea;
+
+				if(waste < bestWaste)
+				{
+					bestWaste = waste;
+					bestFirst = i;
+					bestSecond = j;
+				}
+			}
+		}
+
+		const Rect & left = regions[bestFirst];
+		const Rect & right = regions[bestSecond];
+		const int x0 = std::min(left.left(), right.left());
+		const int y0 = std::min(left.top(), right.top());
+		const int x1 = std::max(left.right(), right.right());
+		const int y1 = std::max(left.bottom(), right.bottom());
+
+		regions[bestFirst] = Rect(x0, y0, x1 - x0, y1 - y0);
+		regions.erase(regions.begin() + bestSecond);
+	}
+}
+
+namespace ScreenDirtyRegions
+{
+	namespace
+	{
+		const SDL_Surface * trackedSurface = nullptr;
+		DirtyRegionTracker * activeTracker = nullptr;
+	}
+
+	void setTarget(const SDL_Surface * surface, DirtyRegionTracker * tracker)
+	{
+		trackedSurface = surface;
+		activeTracker = tracker;
+	}
+
+	void markDirty(const SDL_Surface * surface, const Rect & area)
+	{
+		if(surface != trackedSurface || activeTracker == nullptr)
+			return;
+
+		activeTracker->markDirty(area);
+	}
+}

--- a/client/render/DirtyRegionTracker.h
+++ b/client/render/DirtyRegionTracker.h
@@ -1,0 +1,104 @@
+/*
+ * DirtyRegionTracker.h, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
+#pragma once
+
+#include "../../lib/Rect.h"
+
+#include <list>
+
+struct SDL_Surface;
+
+/// Tracks which parts of the screen framebuffer were written during a frame, so that
+/// only those parts have to be uploaded to the GPU.
+///
+/// The client renders into a software surface which is then copied into a streaming
+/// texture once per frame. That upload used to be unconditional and full-surface:
+/// at 1280x720 with 2x upscaling it moved 14.7 MB every frame - roughly 4.5 ms, the
+/// single largest fixed cost in the frame - no matter how little actually changed.
+///
+/// Dirty areas are accumulated on a coarse grid rather than as a list of rectangles.
+/// A single frame issues hundreds of draw calls onto the screen surface (the adventure
+/// map alone blits ~770 tiles), so pairwise merging of that many rectangles would cost
+/// more than it saves. Marking grid cells is O(area) with a tiny constant, and the
+/// merge step afterwards works on a bounded number of cells instead.
+///
+/// Coordinates are always *surface* (physical) pixels, not logical ones.
+///
+/// Not thread safe: rendering to the screen happens on the GUI thread only.
+class DirtyRegionTracker
+{
+public:
+	/// Grid granularity in surface pixels. Dirty areas are rounded outwards to cell
+	/// boundaries, so a smaller value uploads less but yields more rectangles.
+	static constexpr int cellSize = 32;
+
+	/// Upper bound on the number of SDL_UpdateTexture calls per frame. Each call has
+	/// driver-side overhead, so past a certain point fewer-but-larger wins.
+	static constexpr size_t maxRegions = 12;
+
+	/// If the dirty area exceeds this share of the surface, one full upload is cheaper
+	/// than several partial ones that nearly cover it anyway.
+	static constexpr double fullUpdateAreaThreshold = 0.6;
+
+	/// Resizes the grid to match a (re)created surface and requests a full upload,
+	/// since a fresh texture has undefined contents.
+	void setSurfaceSize(const Point & size);
+
+	/// Requests a full upload for this frame.
+	void markFull();
+
+	/// Records that `area` (surface coordinates) was written to.
+	void markDirty(const Rect & area);
+
+	/// Discards accumulated state. Called after the upload for the frame is done.
+	void clear();
+
+	/// True if the whole surface should be uploaded.
+	bool isFullUpdate() const;
+
+	/// True if nothing at all was written this frame.
+	bool isEmpty() const;
+
+	/// Merged rectangles to upload, in surface coordinates. Only meaningful when
+	/// isFullUpdate() is false. Computed on first call and cached until clear().
+	const std::vector<Rect> & getRegions();
+
+	Point getSurfaceSize() const;
+
+private:
+	Point surfaceSize;
+	int gridWidth = 0;
+	int gridHeight = 0;
+
+	/// One byte per grid cell; 1 means "written to this frame"
+	std::vector<uint8_t> cells;
+
+	bool fullUpdate = true;
+	bool anyDirty = false;
+
+	std::vector<Rect> regions;
+	bool regionsValid = false;
+
+	void rebuildRegions();
+	/// Merges the pair of regions whose union wastes the least area, repeatedly,
+	/// until at most maxRegions remain.
+	void reduceRegionCount();
+};
+
+/// Connects the screen framebuffer to its tracker so that Canvas can report writes
+/// without depending on ScreenHandler. Canvas draws onto many surfaces; only the one
+/// registered here is tracked, everything else is ignored at negligible cost.
+namespace ScreenDirtyRegions
+{
+	void setTarget(const SDL_Surface * surface, DirtyRegionTracker * tracker);
+
+	/// No-op unless `surface` is the registered screen framebuffer.
+	void markDirty(const SDL_Surface * surface, const Rect & area);
+}

--- a/client/render/IImage.h
+++ b/client/render/IImage.h
@@ -18,6 +18,7 @@ class ColorRGBA;
 
 struct SDL_Surface;
 struct SDL_Palette;
+struct SDL_Renderer;
 class ColorFilter;
 class ISharedImage;
 
@@ -104,6 +105,13 @@ public:
 	virtual void setOverlayColor(const ColorRGBA & color) = 0;
 	virtual void setEffectColor(const ColorRGBA & color) = 0;
 
+	// New methods go below this line: inserting a virtual above shifts every later
+	// vtable slot, which silently misdispatches translation units that were not rebuilt.
+
+	/// Same as draw(), but onto the renderer's current target instead of a surface.
+	/// Returns false if this image cannot be drawn that way and the caller must fall back.
+	virtual bool drawTexture(SDL_Renderer * renderer, const Point & pos, const Rect * src, int scalingFactor) const = 0;
+
 	virtual ~IImage() = default;
 };
 
@@ -141,4 +149,9 @@ public:
 	[[nodiscard]] virtual std::shared_ptr<const ISharedImage> scaleInteger(int factor, SDL_Palette * palette, EImageBlitMode blitMode) const = 0;
 	[[nodiscard]] virtual std::shared_ptr<const ISharedImage> scaleTo(const Point & size, SDL_Palette * palette) const = 0;
 
+	// New methods go below this line, see the note in IImage above
+
+	/// Same as draw(), but onto the renderer's current target. False if no texture is available.
+	virtual bool drawTexture(SDL_Renderer * renderer, SDL_Palette * palette, const Point & dest, const Rect * src, const ColorRGBA & colorMultiplier, uint8_t alpha, EImageBlitMode mode) const = 0;
+	virtual bool scaledDrawTexture(SDL_Renderer * renderer, SDL_Palette * palette, const Point & scaleTo, const Point & dest, const Rect * src, const ColorRGBA & colorMultiplier, uint8_t alpha, EImageBlitMode mode) const = 0;
 };

--- a/client/render/IImage.h
+++ b/client/render/IImage.h
@@ -114,6 +114,10 @@ class ISharedImage
 {
 public:
 	virtual Point dimensions() const = 0;
+
+	/// Estimated memory footprint of the underlying pixel data, for cache accounting
+	virtual size_t bytesUsed() const = 0;
+
 	virtual void exportBitmap(const boost::filesystem::path & path, SDL_Palette * palette) const = 0;
 	virtual bool isTransparent(const Point & coords) const = 0;
 	virtual Rect contentRect() const = 0;

--- a/client/render/IScreenHandler.h
+++ b/client/render/IScreenHandler.h
@@ -62,4 +62,13 @@ public:
 	virtual bool hasFocus() = 0;
 
 	virtual void setColorScheme(ColorScheme scheme) = 0;
+
+	// New methods go below this line: inserting a virtual anywhere above shifts every
+	// later vtable slot, which silently misdispatches any translation unit not rebuilt.
+
+	/// True when the adventure map is drawn by the GPU instead of into the screen surface
+	virtual bool isGpuMapRenderingEnabled() const = 0;
+
+	/// Canvas drawing into the GPU map layer. Only valid while GPU map rendering is active.
+	virtual Canvas getMapLayerCanvas() const = 0;
 };

--- a/client/renderSDL/RenderHandler.cpp
+++ b/client/renderSDL/RenderHandler.cpp
@@ -47,9 +47,26 @@
 #include <vcmi/spells/Service.h>
 #include <vcmi/ResourceTypeService.h>
 
+/// Share of the asset cache budget given to decoded/upscaled images rather than to
+/// raw .def files. Images are both far bigger and far more expensive to rebuild
+/// (decode plus xBRZ upscale), while a .def is comparatively cheap to re-parse.
+static constexpr double imageCacheBudgetShare = 0.75;
+
 RenderHandler::RenderHandler()
-	:assetGenerator(std::make_unique<AssetGenerator>())
+	:retainedAnimationFiles(0)
+	,retainedImages(0)
+	,assetGenerator(std::make_unique<AssetGenerator>())
 {
+	const size_t budget = AssetCache::getRetentionBudget(settings["video"]["assetCacheSize"].Integer());
+
+	const size_t imageBudget = static_cast<size_t>(budget * imageCacheBudgetShare);
+	retainedImages.setBudget(imageBudget);
+	retainedAnimationFiles.setBudget(budget - imageBudget);
+
+	logGlobal->info("Asset cache budget: %d MiB total (%d MiB images, %d MiB def files)",
+		static_cast<int>(budget / 1024 / 1024),
+		static_cast<int>(imageBudget / 1024 / 1024),
+		static_cast<int>((budget - imageBudget) / 1024 / 1024));
 }
 
 RenderHandler::~RenderHandler() = default;
@@ -58,16 +75,23 @@ std::shared_ptr<CDefFile> RenderHandler::getAnimationFile(const AnimationPath & 
 {
 	AnimationPath actualPath = boost::starts_with(path.getName(), "SPRITES") ? path : path.addPrefix("SPRITES/");
 
+	std::shared_ptr<CDefFile> cached;
 	{
 		std::lock_guard lock(animationCacheMutex);
 		auto it = animationFiles.find(actualPath);
 
 		if (it != animationFiles.end())
-		{
-			auto locked = it->second.lock();
-			if (locked)
-				return locked;
-		}
+			cached = it->second.lock();
+	}
+
+	if (cached)
+	{
+		// Refresh LRU position so a def that is in active use is not evicted.
+		// Done outside animationCacheMutex: an eviction triggered from here frees
+		// assets, and that should not block other threads entering this function.
+		if (!retainedAnimationFiles.touch(actualPath, cached->bytesUsed()))
+			retainedAnimationFiles.retain(actualPath, cached, cached->bytesUsed());
+		return cached;
 	}
 
 	if (!CResourceHandler::get()->existsResource(actualPath))
@@ -85,7 +109,9 @@ std::shared_ptr<CDefFile> RenderHandler::getAnimationFile(const AnimationPath & 
 
 		animationFiles[actualPath] = result;
 	}
-	
+
+	retainedAnimationFiles.retain(actualPath, result, result->bytesUsed());
+
 	return result;
 }
 
@@ -237,13 +263,20 @@ std::shared_ptr<ScalableImageShared> RenderHandler::loadImageImpl(const ImageLoc
 	{
 		auto locked = it->second.lock();
 		if (locked)
+		{
+			// Cost is refreshed on every hit because scaled/player-colored variants
+			// are generated lazily, so an image grows after it was first cached.
+			if (!retainedImages.touch(locator, locked->bytesUsed()))
+				retainedImages.retain(locator, locked, locked->bytesUsed());
 			return locked;
+		}
 	}
 
 	auto sdlImage = loadImageFromFileUncached(locator);
 	auto scaledImage = std::make_shared<ScalableImageShared>(locator, sdlImage);
 
 	storeCachedImage(locator, scaledImage);
+	retainedImages.retain(locator, scaledImage, scaledImage->bytesUsed());
 	return scaledImage;
 }
 

--- a/client/renderSDL/RenderHandler.h
+++ b/client/renderSDL/RenderHandler.h
@@ -11,6 +11,7 @@
 
 #include "../render/IRenderHandler.h"
 #include "../render/CDefFile.h"
+#include "../render/AssetCache.h"
 
 class EntityService;
 
@@ -28,6 +29,14 @@ class RenderHandler final : public IRenderHandler
 	std::map<AnimationPath, std::weak_ptr<CDefFile>> animationFiles;
 	std::map<AnimationPath, AnimationLayoutMap> animationLayouts;
 	std::map<SharedImageLocator, std::weak_ptr<ScalableImageShared>> imageFiles;
+
+	/// The maps above only keep an asset findable while somebody else still holds it.
+	/// These caches hold an additional strong reference to recently used assets so
+	/// they are not destroyed - and re-read from disk on the next frame - the instant
+	/// their last user goes away. See AssetCache.h for the full rationale.
+	MemoryBudgetedCache<AnimationPath, CDefFile> retainedAnimationFiles;
+	MemoryBudgetedCache<SharedImageLocator, ScalableImageShared> retainedImages;
+
 	std::map<EFonts, std::shared_ptr<const IFont>> fonts;
 	std::shared_ptr<AssetGenerator> assetGenerator;
 	std::shared_ptr<HdImageLoader> hdImageLoader;

--- a/client/renderSDL/SDLImage.cpp
+++ b/client/renderSDL/SDLImage.cpp
@@ -17,6 +17,7 @@
 #include "../render/ColorFilter.h"
 #include "../render/CBitmapHandler.h"
 #include "../render/CDefFile.h"
+#include "../CMT.h"
 #include "../GameEngine.h"
 #include "../render/IScreenHandler.h"
 
@@ -26,6 +27,7 @@
 #include <tbb/parallel_for.h>
 
 #include <SDL_image.h>
+#include <SDL_render.h>
 #include <SDL_surface.h>
 #include <SDL_version.h>
 
@@ -208,6 +210,73 @@ void SDLImageShared::draw(SDL_Surface * where, SDL_Palette * palette, const Poin
 
 	if (surf->format->palette)
 		SDL_SetSurfacePalette(surf, originalPalette);
+}
+
+bool SDLImageShared::scaledDrawTexture(SDL_Renderer * renderer, SDL_Palette * palette, const Point & scaleTo, const Point & dest, const Rect * src, const ColorRGBA & colorMultiplier, uint8_t alpha, EImageBlitMode mode) const
+{
+	if(upscalingInProgress || !surf)
+		return false;
+
+	SDL_Texture * source = getTexture(palette);
+	if(!source)
+		return false;
+
+	// same geometry as scaledDraw(), the GPU just does the stretching for us
+	Rect sourceRect(0, 0, surf->w, surf->h);
+	Point destShift(0, 0);
+	Point destScale = Point(surf->w, surf->h) * scaleTo / dimensions();
+	Point marginsScaled = margins * scaleTo / dimensions();
+
+	if(src)
+	{
+		Rect srcUnscaled(Point(src->topLeft() * dimensions() / scaleTo), Point(src->dimensions() * dimensions() / scaleTo));
+
+		if(srcUnscaled.x < margins.x)
+			destShift.x += marginsScaled.x - src->x;
+
+		if(srcUnscaled.y < margins.y)
+			destShift.y += marginsScaled.y - src->y;
+
+		sourceRect = Rect(srcUnscaled).intersect(Rect(margins.x, margins.y, surf->w, surf->h));
+
+		destScale.x = std::min(destScale.x, sourceRect.w * scaleTo.x / dimensions().x);
+		destScale.y = std::min(destScale.y, sourceRect.h * scaleTo.y / dimensions().y);
+
+		sourceRect -= margins;
+	}
+	else
+		destShift = marginsScaled;
+
+	destShift += dest;
+
+	if(sourceRect.w <= 0 || sourceRect.h <= 0 || destScale.x <= 0 || destScale.y <= 0)
+		return true;
+
+	SDL_SetTextureColorMod(source, colorMultiplier.r, colorMultiplier.g, colorMultiplier.b);
+	SDL_SetTextureAlphaMod(source, alpha);
+
+	// Unlike the surface path this cannot test Amask: SDL_CreateTextureFromSurface turns a
+	// paletted surface's color key into real alpha, so only a truly opaque image may skip blending
+	if(alpha != SDL_ALPHA_OPAQUE || mode != EImageBlitMode::OPAQUE)
+		SDL_SetTextureBlendMode(source, SDL_BLENDMODE_BLEND);
+	else
+		SDL_SetTextureBlendMode(source, SDL_BLENDMODE_NONE);
+
+	SDL_Rect sdlSource = CSDL_Ext::toSDL(sourceRect);
+	SDL_Rect sdlTarget = CSDL_Ext::toSDL(Rect(destShift, destScale));
+
+	SDL_RenderCopy(renderer, source, &sdlSource, &sdlTarget);
+	return true;
+}
+
+bool SDLImageShared::drawTexture(SDL_Renderer * renderer, SDL_Palette * palette, const Point & dest, const Rect * src, const ColorRGBA & colorMultiplier, uint8_t alpha, EImageBlitMode mode) const
+{
+	// drawing at native size is the scaled path with a scale of one, and the geometry
+	// below reduces exactly to the unscaled case
+	if(upscalingInProgress || !surf)
+		return false;
+
+	return scaledDrawTexture(renderer, palette, dimensions(), dest, src, colorMultiplier, alpha, mode);
 }
 
 void SDLImageShared::optimizeSurface()
@@ -406,7 +475,10 @@ size_t SDLImageShared::bytesUsed() const
 	if(surf->format != nullptr && surf->format->palette != nullptr)
 		paletteBytes = static_cast<size_t>(surf->format->palette->ncolors) * sizeof(SDL_Color);
 
-	return pixelBytes + paletteBytes + sizeof(SDLImageShared);
+	// the GPU copy is charged to the same budget, so that caching it cannot grow unbounded
+	size_t textureBytes = texture ? static_cast<size_t>(surf->w) * surf->h * 4 : 0;
+
+	return pixelBytes + paletteBytes + textureBytes + sizeof(SDLImageShared);
 }
 
 Point SDLImageShared::dimensions() const
@@ -530,7 +602,45 @@ void SDLImageShared::savePalette()
 
 SDLImageShared::~SDLImageShared()
 {
+	dropTexture();
 	SDL_FreeSurface(surf);
 	if (originalPalette)
 		SDL_FreePalette(originalPalette);
+}
+
+void SDLImageShared::dropTexture() const
+{
+	// destroying the renderer already destroyed everything it owned, so a stale
+	// generation means the pointer must be dropped rather than freed
+	if(texture && textureGeneration == mainRendererGeneration)
+		SDL_DestroyTexture(texture);
+
+	texture = nullptr;
+}
+
+SDL_Texture * SDLImageShared::getTexture(SDL_Palette * palette) const
+{
+	if(upscalingInProgress || surf == nullptr || mainRenderer == nullptr)
+		return nullptr;
+
+	if(texture && textureGeneration == mainRendererGeneration && texturePalette == palette)
+		return texture;
+
+	dropTexture();
+
+	if(palette && surf->format->palette)
+		SDL_SetSurfacePalette(surf, palette);
+
+	texture = SDL_CreateTextureFromSurface(mainRenderer, surf);
+
+	if(surf->format->palette)
+		SDL_SetSurfacePalette(surf, originalPalette);
+
+	if(texture == nullptr)
+		logGlobal->error("Failed to create texture from image! %s", SDL_GetError());
+
+	texturePalette = palette;
+	textureGeneration = mainRendererGeneration;
+
+	return texture;
 }

--- a/client/renderSDL/SDLImage.cpp
+++ b/client/renderSDL/SDLImage.cpp
@@ -390,6 +390,25 @@ const SDL_Palette * SDLImageShared::getPalette() const
 	return surf->format->palette;
 }
 
+size_t SDLImageShared::bytesUsed() const
+{
+	if(surf == nullptr)
+		return sizeof(SDLImageShared);
+
+	// SDL surfaces can be shared between several SDLImageShared instances (see the
+	// refcount bump in the SDL_Surface constructor), so divide the pixel data by
+	// the number of holders to avoid counting the same allocation repeatedly.
+	size_t pixelBytes = static_cast<size_t>(surf->h) * surf->pitch;
+	if(surf->refcount > 1)
+		pixelBytes /= surf->refcount;
+
+	size_t paletteBytes = 0;
+	if(surf->format != nullptr && surf->format->palette != nullptr)
+		paletteBytes = static_cast<size_t>(surf->format->palette->ncolors) * sizeof(SDL_Color);
+
+	return pixelBytes + paletteBytes + sizeof(SDLImageShared);
+}
+
 Point SDLImageShared::dimensions() const
 {
 	if(upscalingInProgress)

--- a/client/renderSDL/SDLImage.cpp
+++ b/client/renderSDL/SDLImage.cpp
@@ -255,6 +255,12 @@ bool SDLImageShared::scaledDrawTexture(SDL_Renderer * renderer, SDL_Palette * pa
 	SDL_SetTextureColorMod(source, colorMultiplier.r, colorMultiplier.g, colorMultiplier.b);
 	SDL_SetTextureAlphaMod(source, alpha);
 
+	// The renderer-wide scale quality hint is meant for fitting the finished screen to the
+	// window. Sprites must not inherit it: the surface path scales them with SDL_BlitScaled,
+	// which is nearest, and a smoothed stand-in would visibly differ from the xBRZ image that
+	// replaces it once upscaling finishes.
+	SDL_SetTextureScaleMode(source, SDL_ScaleModeNearest);
+
 	// Unlike the surface path this cannot test Amask: SDL_CreateTextureFromSurface turns a
 	// paletted surface's color key into real alpha, so only a truly opaque image may skip blending
 	if(alpha != SDL_ALPHA_OPAQUE || mode != EImageBlitMode::OPAQUE)

--- a/client/renderSDL/SDLImage.h
+++ b/client/renderSDL/SDLImage.h
@@ -58,6 +58,7 @@ public:
 
 	void exportBitmap(const boost::filesystem::path & path, SDL_Palette * palette) const override;
 	Point dimensions() const override;
+	size_t bytesUsed() const override;
 	bool isTransparent(const Point & coords) const override;
 	Rect contentRect() const override;
 

--- a/client/renderSDL/SDLImage.h
+++ b/client/renderSDL/SDLImage.h
@@ -18,6 +18,7 @@ class CDefFile;
 
 struct SDL_Surface;
 struct SDL_Palette;
+struct SDL_Texture;
 
 /*
  * Wrapper around SDL_Surface
@@ -36,6 +37,15 @@ class SDLImageShared final : public ISharedImage, public std::enable_shared_from
 	std::atomic_bool upscalingInProgress = false;
 	bool asyncUpscale = true;
 
+	/// GPU copy of surf, built on first use by getTexture()
+	mutable SDL_Texture * texture = nullptr;
+	/// Palette the texture was built with, and the renderer generation it belongs to
+	mutable SDL_Palette * texturePalette = nullptr;
+	mutable uint32_t textureGeneration = 0;
+
+	/// Frees the cached texture unless the renderer that owned it is already gone
+	void dropTexture() const;
+
 	// Keep the original palette, in order to do color switching operation
 	void savePalette();
 
@@ -53,8 +63,14 @@ public:
 	/// Creates image at specified scaling factor from source image
 	static std::shared_ptr<SDLImageShared> createScaled(const SDLImageShared * from, int integerScaleFactor, EScalingAlgorithm algorithm);
 
+	/// Returns a GPU texture holding this image, or nullptr if one cannot be created.
+	/// Owned by this image; never destroy the returned pointer.
+	SDL_Texture * getTexture(SDL_Palette * palette) const;
+
 	void scaledDraw(SDL_Surface * where, SDL_Palette * palette, const Point & scaling, const Point & dest, const Rect * src, const ColorRGBA & colorMultiplier, uint8_t alpha, EImageBlitMode mode) const override;
 	void draw(SDL_Surface * where, SDL_Palette * palette, const Point & dest, const Rect * src, const ColorRGBA & colorMultiplier, uint8_t alpha, EImageBlitMode mode) const override;
+	bool drawTexture(SDL_Renderer * renderer, SDL_Palette * palette, const Point & dest, const Rect * src, const ColorRGBA & colorMultiplier, uint8_t alpha, EImageBlitMode mode) const override;
+	bool scaledDrawTexture(SDL_Renderer * renderer, SDL_Palette * palette, const Point & scaleTo, const Point & dest, const Rect * src, const ColorRGBA & colorMultiplier, uint8_t alpha, EImageBlitMode mode) const override;
 
 	void exportBitmap(const boost::filesystem::path & path, SDL_Palette * palette) const override;
 	Point dimensions() const override;

--- a/client/renderSDL/ScalableImage.cpp
+++ b/client/renderSDL/ScalableImage.cpp
@@ -280,46 +280,54 @@ Rect ScalableImageShared::contentRect() const
 	return scaled[1].body[0]->contentRect();
 }
 
+const ScalableImageShared::ImageType & ScalableImageShared::selectFlipped(FlippedImages & images, const ScalableImageParameters & parameters)
+{
+	int index = 0;
+
+	if (parameters.flipVertical)
+	{
+		if (!images[index|1])
+			images[index|1] = images[index]->verticalFlip();
+
+		index |= 1;
+	}
+
+	if (parameters.flipHorizontal)
+	{
+		if (!images[index|2])
+			images[index|2] = images[index]->horizontalFlip();
+
+		index |= 2;
+	}
+
+	return images[index];
+}
+
+bool ScalableImageShared::anyVariantLoading(int scalingFactor, const ScalableImageParameters & parameters) const
+{
+	const auto & variant = scaled.at(scalingFactor);
+
+	const auto isLoading = [](const ImageType & image){ return image && image->isLoading(); };
+
+	if (parameters.player != PlayerColor::CANNOT_DETERMINE && isLoading(variant.playerColored.at(1 + parameters.player.getNum())))
+		return true;
+
+	return isLoading(variant.shadow.at(0)) || isLoading(variant.body.at(0)) || isLoading(variant.overlay.at(0)) || isLoading(variant.bodyGrayscale.at(0));
+}
+
 void ScalableImageShared::draw(SDL_Surface * where, const Point & dest, const Rect * src, const ScalableImageParameters & parameters, int scalingFactor)
 {
-	const auto & getFlippedImage = [&](FlippedImages & images){
-		int index = 0;
-		if (parameters.flipVertical)
-		{
-			if (!images[index|1])
-				images[index|1] = images[index]->verticalFlip();
-
-			index |= 1;
-		}
-
-		if (parameters.flipHorizontal)
-		{
-			if (!images[index|2])
-				images[index|2] = images[index]->horizontalFlip();
-
-			index |= 2;
-		}
-
-		return images[index];
-	};
-
-	bool shadowLoading = scaled.at(scalingFactor).shadow.at(0) && scaled.at(scalingFactor).shadow.at(0)->isLoading();
-	bool bodyLoading = scaled.at(scalingFactor).body.at(0) && scaled.at(scalingFactor).body.at(0)->isLoading();
-	bool overlayLoading = scaled.at(scalingFactor).overlay.at(0) && scaled.at(scalingFactor).overlay.at(0)->isLoading();
-	bool grayscaleLoading = scaled.at(scalingFactor).bodyGrayscale.at(0) && scaled.at(scalingFactor).bodyGrayscale.at(0)->isLoading();
-	bool playerLoading = parameters.player != PlayerColor::CANNOT_DETERMINE && scaled.at(scalingFactor).playerColored.at(1+parameters.player.getNum()) && scaled.at(scalingFactor).playerColored.at(1+parameters.player.getNum())->isLoading();
-
-	if (shadowLoading || bodyLoading || overlayLoading || playerLoading || grayscaleLoading)
+	if (anyVariantLoading(scalingFactor, parameters))
 	{
-		getFlippedImage(scaled[1].body)->scaledDraw(where, parameters.palette, dimensions() * scalingFactor, dest, src, parameters.colorMultiplier, parameters.alphaValue, locator.layer);
+		selectFlipped(scaled[1].body, parameters)->scaledDraw(where, parameters.palette, dimensions() * scalingFactor, dest, src, parameters.colorMultiplier, parameters.alphaValue, locator.layer);
 
 		if (parameters.effectColorMultiplier.a != ColorRGBA::ALPHA_TRANSPARENT)
-			getFlippedImage(scaled[1].body)->scaledDraw(where, parameters.palette, dimensions() * scalingFactor, dest, src, parameters.effectColorMultiplier, parameters.alphaValue, locator.layer);
+			selectFlipped(scaled[1].body, parameters)->scaledDraw(where, parameters.palette, dimensions() * scalingFactor, dest, src, parameters.effectColorMultiplier, parameters.alphaValue, locator.layer);
 		return;
 	}
 
 	if (scaled.at(scalingFactor).shadow.at(0))
-		getFlippedImage(scaled.at(scalingFactor).shadow)->draw(where, parameters.palette, dest, src, Colors::WHITE_TRUE, parameters.alphaValue, locator.layer);
+		selectFlipped(scaled.at(scalingFactor).shadow, parameters)->draw(where, parameters.palette, dest, src, Colors::WHITE_TRUE, parameters.alphaValue, locator.layer);
 
 	if (parameters.player != PlayerColor::CANNOT_DETERMINE && scaled.at(scalingFactor).playerColored.at(1+parameters.player.getNum()))
 	{
@@ -328,14 +336,51 @@ void ScalableImageShared::draw(SDL_Surface * where, const Point & dest, const Re
 	else
 	{
 		if (scaled.at(scalingFactor).body.at(0))
-			getFlippedImage(scaled.at(scalingFactor).body)->draw(where, parameters.palette, dest, src, parameters.colorMultiplier, parameters.alphaValue, locator.layer);
+			selectFlipped(scaled.at(scalingFactor).body, parameters)->draw(where, parameters.palette, dest, src, parameters.colorMultiplier, parameters.alphaValue, locator.layer);
 
 		if (scaled.at(scalingFactor).bodyGrayscale.at(0) && parameters.effectColorMultiplier.a != ColorRGBA::ALPHA_TRANSPARENT)
-			getFlippedImage(scaled.at(scalingFactor).bodyGrayscale)->draw(where, parameters.palette, dest, src, parameters.effectColorMultiplier, parameters.alphaValue, locator.layer);
+			selectFlipped(scaled.at(scalingFactor).bodyGrayscale, parameters)->draw(where, parameters.palette, dest, src, parameters.effectColorMultiplier, parameters.alphaValue, locator.layer);
 	}
 
 	if (scaled.at(scalingFactor).overlay.at(0))
-		getFlippedImage(scaled.at(scalingFactor).overlay)->draw(where, parameters.palette, dest, src, parameters.ovelayColorMultiplier, static_cast<int>(parameters.alphaValue) * parameters.ovelayColorMultiplier.a / 255, locator.layer);
+		selectFlipped(scaled.at(scalingFactor).overlay, parameters)->draw(where, parameters.palette, dest, src, parameters.ovelayColorMultiplier, static_cast<int>(parameters.alphaValue) * parameters.ovelayColorMultiplier.a / 255, locator.layer);
+}
+
+bool ScalableImageShared::drawTexture(SDL_Renderer * renderer, const Point & dest, const Rect * src, const ScalableImageParameters & parameters, int scalingFactor)
+{
+	if (anyVariantLoading(scalingFactor, parameters))
+	{
+		// upscaling is still running - stretch the 1x image, which the GPU does for free
+		bool drawn = selectFlipped(scaled[1].body, parameters)->scaledDrawTexture(renderer, parameters.palette, dimensions() * scalingFactor, dest, src, parameters.colorMultiplier, parameters.alphaValue, locator.layer);
+
+		if (parameters.effectColorMultiplier.a != ColorRGBA::ALPHA_TRANSPARENT)
+			drawn &= selectFlipped(scaled[1].body, parameters)->scaledDrawTexture(renderer, parameters.palette, dimensions() * scalingFactor, dest, src, parameters.effectColorMultiplier, parameters.alphaValue, locator.layer);
+
+		return drawn;
+	}
+
+	bool drawn = true;
+
+	if (scaled.at(scalingFactor).shadow.at(0))
+		drawn &= selectFlipped(scaled.at(scalingFactor).shadow, parameters)->drawTexture(renderer, parameters.palette, dest, src, Colors::WHITE_TRUE, parameters.alphaValue, locator.layer);
+
+	if (parameters.player != PlayerColor::CANNOT_DETERMINE && scaled.at(scalingFactor).playerColored.at(1+parameters.player.getNum()))
+	{
+		drawn &= scaled.at(scalingFactor).playerColored.at(1+parameters.player.getNum())->drawTexture(renderer, parameters.palette, dest, src, Colors::WHITE_TRUE, parameters.alphaValue, locator.layer);
+	}
+	else
+	{
+		if (scaled.at(scalingFactor).body.at(0))
+			drawn &= selectFlipped(scaled.at(scalingFactor).body, parameters)->drawTexture(renderer, parameters.palette, dest, src, parameters.colorMultiplier, parameters.alphaValue, locator.layer);
+
+		if (scaled.at(scalingFactor).bodyGrayscale.at(0) && parameters.effectColorMultiplier.a != ColorRGBA::ALPHA_TRANSPARENT)
+			drawn &= selectFlipped(scaled.at(scalingFactor).bodyGrayscale, parameters)->drawTexture(renderer, parameters.palette, dest, src, parameters.effectColorMultiplier, parameters.alphaValue, locator.layer);
+	}
+
+	if (scaled.at(scalingFactor).overlay.at(0))
+		drawn &= selectFlipped(scaled.at(scalingFactor).overlay, parameters)->drawTexture(renderer, parameters.palette, dest, src, parameters.ovelayColorMultiplier, static_cast<int>(parameters.alphaValue) * parameters.ovelayColorMultiplier.a / 255, locator.layer);
+
+	return drawn;
 }
 
 const SDL_Palette * ScalableImageShared::getPalette() const
@@ -400,6 +445,15 @@ void ScalableImageInstance::draw(SDL_Surface * where, const Point & pos, const R
 		scaledImage->draw(where, pos, src, scalingFactor);
 	else
 		image->draw(where, pos, src, parameters, scalingFactor);
+}
+
+bool ScalableImageInstance::drawTexture(SDL_Renderer * renderer, const Point & pos, const Rect * src, int scalingFactor) const
+{
+	// a rescaled instance only exists as a surface, so it has no GPU path
+	if (scaledImage)
+		return false;
+
+	return image->drawTexture(renderer, pos, src, parameters, scalingFactor);
 }
 
 void ScalableImageInstance::setOverlayColor(const ColorRGBA & color)

--- a/client/renderSDL/ScalableImage.cpp
+++ b/client/renderSDL/ScalableImage.cpp
@@ -234,6 +234,37 @@ Point ScalableImageShared::dimensions() const
 	return scaled[1].body[0]->dimensions();
 }
 
+size_t ScalableImageShared::bytesUsed() const
+{
+	// The same ISharedImage can appear in several slots (e.g. an unflipped variant
+	// is stored at every index that does not need flipping), so count each distinct
+	// instance once.
+	std::set<const ISharedImage *> counted;
+	size_t result = sizeof(ScalableImageShared);
+
+	const auto & account = [&counted, &result](const ImageType & image)
+	{
+		if(image && counted.insert(image.get()).second)
+			result += image->bytesUsed();
+	};
+
+	for(const auto & scaledImage : scaled)
+	{
+		for(const auto & image : scaledImage.shadow)
+			account(image);
+		for(const auto & image : scaledImage.body)
+			account(image);
+		for(const auto & image : scaledImage.overlay)
+			account(image);
+		for(const auto & image : scaledImage.bodyGrayscale)
+			account(image);
+		for(const auto & image : scaledImage.playerColored)
+			account(image);
+	}
+
+	return result;
+}
+
 void ScalableImageShared::exportBitmap(const boost::filesystem::path & path, const ScalableImageParameters & parameters) const
 {
 	scaled[1].body[0]->exportBitmap(path, parameters.palette);

--- a/client/renderSDL/ScalableImage.h
+++ b/client/renderSDL/ScalableImage.h
@@ -86,6 +86,10 @@ public:
 	ScalableImageShared(const SharedImageLocator & locator, const std::shared_ptr<const ISharedImage> & baseImage);
 
 	Point dimensions() const;
+
+	/// Estimated memory footprint of all scaled/flipped/colored variants, for cache accounting
+	size_t bytesUsed() const;
+
 	void exportBitmap(const boost::filesystem::path & path, const ScalableImageParameters & parameters) const;
 	bool isTransparent(const Point & coords) const;
 	Rect contentRect() const;

--- a/client/renderSDL/ScalableImage.h
+++ b/client/renderSDL/ScalableImage.h
@@ -80,6 +80,13 @@ class ScalableImageShared final : public std::enable_shared_from_this<ScalableIm
 
 	std::shared_ptr<const ISharedImage> loadOrGenerateImage(EImageBlitMode mode, int8_t scalingFactor, PlayerColor color, ImageType upscalingSource) const;
 
+	/// Picks the variant matching the requested flips, generating it on first use
+	static const ImageType & selectFlipped(FlippedImages & images, const ScalableImageParameters & parameters);
+
+	/// True while any variant needed for this draw is still being upscaled, in which case
+	/// only the 1x image may be used
+	bool anyVariantLoading(int scalingFactor, const ScalableImageParameters & parameters) const;
+
 	void loadScaledImages(int8_t scalingFactor, PlayerColor color);
 
 public:
@@ -94,6 +101,7 @@ public:
 	bool isTransparent(const Point & coords) const;
 	Rect contentRect() const;
 	void draw(SDL_Surface * where, const Point & dest, const Rect * src, const ScalableImageParameters & parameters, int scalingFactor);
+	bool drawTexture(SDL_Renderer * renderer, const Point & dest, const Rect * src, const ScalableImageParameters & parameters, int scalingFactor);
 
 	const SDL_Palette * getPalette() const;
 
@@ -123,6 +131,7 @@ public:
 	Point dimensions() const override;
 	void setAlpha(uint8_t value) override;
 	void draw(SDL_Surface * where, const Point & pos, const Rect * src, int scalingFactor) const override;
+	bool drawTexture(SDL_Renderer * renderer, const Point & pos, const Rect * src, int scalingFactor) const override;
 	void setOverlayColor(const ColorRGBA & color) override;
 	void setEffectColor(const ColorRGBA & color) override;
 	void playerColored(const PlayerColor & player) override;

--- a/client/renderSDL/ScreenHandler.cpp
+++ b/client/renderSDL/ScreenHandler.cpp
@@ -41,6 +41,8 @@
 
 #include <SDL.h>
 
+#include <cstring>
+
 // TODO: should be made into a private members of ScreenHandler
 SDL_Renderer * mainRenderer = nullptr;
 
@@ -431,6 +433,10 @@ void ScreenHandler::initializeScreenBuffers()
 	//No blending for screen itself. Required for proper cursor rendering.
 	SDL_SetSurfaceBlendMode(screen, SDL_BLENDMODE_NONE);
 
+	dirtyRegions.setSurfaceSize(Point(screen->w, screen->h));
+	if(settings["video"]["partialScreenUpdate"].Bool())
+		ScreenDirtyRegions::setTarget(screen, &dirtyRegions);
+
 	screenTexture = SDL_CreateTexture(mainRenderer, SDL_PIXELFORMAT_ARGB8888, SDL_TEXTUREACCESS_STREAMING, logicalSize.x, logicalSize.y);
 
 	if(nullptr == screenTexture)
@@ -611,6 +617,7 @@ void ScreenHandler::destroyScreenBuffers()
 {
 	if(nullptr != screen)
 	{
+		ScreenDirtyRegions::setTarget(nullptr, nullptr);
 		SDL_FreeSurface(screen);
 		screen = nullptr;
 	}
@@ -659,21 +666,126 @@ Canvas ScreenHandler::getScreenCanvas() const
 	return Canvas::createFromSurface(screen, CanvasScalingPolicy::AUTO);
 }
 
+void ScreenHandler::validateDirtyRegions(SDL_Surface * source, const std::vector<Rect> & regions)
+{
+	const size_t rowBytes = static_cast<size_t>(source->w) * source->format->BytesPerPixel;
+	const size_t totalBytes = rowBytes * source->h;
+	const auto * pixels = static_cast<const uint8_t *>(source->pixels);
+
+	if(validationShadow.size() != totalBytes)
+	{
+		// First frame at this size - nothing to compare against yet
+		validationShadow.resize(totalBytes);
+		for(int y = 0; y < source->h; ++y)
+			std::memcpy(validationShadow.data() + y * rowBytes, pixels + static_cast<size_t>(y) * source->pitch, rowBytes);
+		return;
+	}
+
+	const int bytesPerPixel = source->format->BytesPerPixel;
+	Rect missed;
+	int missedPixels = 0;
+
+	for(int y = 0; y < source->h; ++y)
+	{
+		const uint8_t * currentRow = pixels + static_cast<size_t>(y) * source->pitch;
+		uint8_t * shadowRow = validationShadow.data() + static_cast<size_t>(y) * rowBytes;
+
+		if(std::memcmp(currentRow, shadowRow, rowBytes) != 0)
+		{
+			for(int x = 0; x < source->w; ++x)
+			{
+				if(std::memcmp(currentRow + x * bytesPerPixel, shadowRow + x * bytesPerPixel, bytesPerPixel) == 0)
+					continue;
+
+				const bool covered = std::ranges::any_of(regions, [x, y](const Rect & region){
+					return region.x <= x && x < region.x + region.w && region.y <= y && y < region.y + region.h;
+				});
+
+				if(!covered)
+				{
+					Rect pixel(x, y, 1, 1);
+					missed = missedPixels == 0 ? pixel : missed.include(pixel);
+					++missedPixels;
+				}
+			}
+
+			std::memcpy(shadowRow, currentRow, rowBytes);
+		}
+	}
+
+	if(missedPixels > 0)
+	{
+		logGlobal->error("Partial screen update missed %d pixels, bounding box %dx%d at (%d, %d)",
+			missedPixels, missed.w, missed.h, missed.x, missed.y);
+	}
+}
+
+void ScreenHandler::uploadDirtyRegions(SDL_Surface * source)
+{
+	// With tracking disabled nothing ever reports a dirty area, so the tracker stays
+	// empty and would wrongly skip the upload - fall back to uploading everything.
+	if(!settings["video"]["partialScreenUpdate"].Bool())
+	{
+		SDL_UpdateTexture(screenTexture, nullptr, source->pixels, source->pitch);
+		return;
+	}
+
+	if(dirtyRegions.isEmpty())
+	{
+		// Nothing was drawn this frame - the texture still holds the previous image
+		return;
+	}
+
+	// Must be resolved before isFullUpdate() is queried: building the region list is
+	// what decides whether the dirty area is large enough to warrant a full upload.
+	const auto & regions = dirtyRegions.getRegions();
+
+	// regions may legitimately be empty here only when a full update was chosen;
+	// uploading everything is the safe interpretation in any other case too.
+	if(dirtyRegions.isFullUpdate() || regions.empty())
+	{
+		SDL_UpdateTexture(screenTexture, nullptr, source->pixels, source->pitch);
+		return;
+	}
+
+	const int bytesPerPixel = source->format->BytesPerPixel;
+
+	for(const auto & region : regions)
+	{
+		SDL_Rect targetRect = CSDL_Ext::toSDL(region);
+		const auto * pixels = static_cast<const uint8_t *>(source->pixels)
+			+ static_cast<size_t>(region.y) * source->pitch
+			+ static_cast<size_t>(region.x) * bytesPerPixel;
+
+		SDL_UpdateTexture(screenTexture, &targetRect, pixels, source->pitch);
+	}
+
+	if(settings["video"]["partialScreenUpdateValidation"].Bool())
+		validateDirtyRegions(source, regions);
+}
+
 void ScreenHandler::updateScreenTexture()
 {
 	if(colorScheme == ColorScheme::NONE)
 	{
-		SDL_UpdateTexture(screenTexture, nullptr, screen->pixels, screen->pitch);
+		uploadDirtyRegions(screen);
+		dirtyRegions.clear();
 		return;
 	}
+
+	// A color scheme rewrites every pixel of a full-surface copy, so partial upload
+	// would gain nothing here.
+	dirtyRegions.markFull();
 
 	SDL_Surface * screenScheme = SDL_ConvertSurface(screen, screen->format, screen->flags);
 	if(colorScheme == ColorScheme::GRAYSCALE)
 		CSDL_Ext::convertToGrayscale(screenScheme, Rect(0, 0, screen->w, screen->h));
 	else if(colorScheme == ColorScheme::H2_SCHEME)
 		CSDL_Ext::convertToH2Scheme(screenScheme, Rect(0, 0, screen->w, screen->h));
-	SDL_UpdateTexture(screenTexture, nullptr, screenScheme->pixels, screenScheme->pitch);
+	uploadDirtyRegions(screenScheme);
 	SDL_FreeSurface(screenScheme);
+
+	dirtyRegions.clear();
 }
 
 void ScreenHandler::presentScreenTexture()

--- a/client/renderSDL/ScreenHandler.cpp
+++ b/client/renderSDL/ScreenHandler.cpp
@@ -45,6 +45,7 @@
 
 // TODO: should be made into a private members of ScreenHandler
 SDL_Renderer * mainRenderer = nullptr;
+uint32_t mainRendererGeneration = 1;
 
 static constexpr Point heroes3Resolution = Point(800, 600);
 
@@ -446,6 +447,9 @@ void ScreenHandler::initializeScreenBuffers()
 		throw std::runtime_error("Unable to create screen texture");
 	}
 
+	if(settings["video"]["gpuMapRendering"].Bool())
+		initializeMapTexture(logicalSize);
+
 	clearScreen();
 }
 
@@ -627,6 +631,42 @@ void ScreenHandler::destroyScreenBuffers()
 		SDL_DestroyTexture(screenTexture);
 		screenTexture = nullptr;
 	}
+
+	if(nullptr != mapTexture)
+	{
+		SDL_DestroyTexture(mapTexture);
+		mapTexture = nullptr;
+	}
+}
+
+void ScreenHandler::initializeMapTexture(const Point & logicalSize)
+{
+	SDL_RendererInfo info;
+	if(SDL_GetRendererInfo(mainRenderer, &info) != 0 || (info.flags & SDL_RENDERER_TARGETTEXTURE) == 0)
+	{
+		logGlobal->warn("GPU map rendering requested but the renderer has no render target support - falling back to software");
+		return;
+	}
+
+	mapTexture = SDL_CreateTexture(mainRenderer, SDL_PIXELFORMAT_ARGB8888, SDL_TEXTUREACCESS_TARGET, logicalSize.x, logicalSize.y);
+
+	if(nullptr == mapTexture)
+	{
+		logGlobal->warn("Unable to create map render target: %s - falling back to software", SDL_GetError());
+		return;
+	}
+
+	// the map layer is drawn first and the software screen is blended over it, so the
+	// screen texture must stop being opaque for the map to show through its transparent hole
+	SDL_SetTextureBlendMode(mapTexture, SDL_BLENDMODE_NONE);
+	SDL_SetTextureBlendMode(screenTexture, SDL_BLENDMODE_BLEND);
+
+	SDL_SetRenderTarget(mainRenderer, mapTexture);
+	SDL_SetRenderDrawColor(mainRenderer, 0, 0, 0, 255);
+	SDL_RenderClear(mainRenderer);
+	SDL_SetRenderTarget(mainRenderer, nullptr);
+
+	logGlobal->info("GPU map rendering enabled, using driver '%s'", info.name);
 }
 
 void ScreenHandler::destroyWindow()
@@ -635,6 +675,8 @@ void ScreenHandler::destroyWindow()
 	{
 		SDL_DestroyRenderer(mainRenderer);
 		mainRenderer = nullptr;
+		// every texture created from the old renderer is now dangling
+		++mainRendererGeneration;
 	}
 
 	if(nullptr != mainWindow)
@@ -664,6 +706,11 @@ void ScreenHandler::clearScreen()
 Canvas ScreenHandler::getScreenCanvas() const
 {
 	return Canvas::createFromSurface(screen, CanvasScalingPolicy::AUTO);
+}
+
+Canvas ScreenHandler::getMapLayerCanvas() const
+{
+	return Canvas::createFromRenderTarget(mapTexture, getLogicalResolution(), CanvasScalingPolicy::AUTO);
 }
 
 void ScreenHandler::validateDirtyRegions(SDL_Surface * source, const std::vector<Rect> & regions)
@@ -788,9 +835,21 @@ void ScreenHandler::updateScreenTexture()
 	dirtyRegions.clear();
 }
 
+bool ScreenHandler::isGpuMapRenderingEnabled() const
+{
+	return mapTexture != nullptr;
+}
+
 void ScreenHandler::presentScreenTexture()
 {
+	// the map layer may still be bound from rendering it
+	SDL_SetRenderTarget(mainRenderer, nullptr);
+
 	SDL_RenderClear(mainRenderer);
+
+	if(nullptr != mapTexture)
+		SDL_RenderCopy(mainRenderer, mapTexture, nullptr, nullptr);
+
 	SDL_RenderCopy(mainRenderer, screenTexture, nullptr, nullptr);
 	ENGINE->cursor().render();
 	SDL_RenderPresent(mainRenderer);

--- a/client/renderSDL/ScreenHandler.h
+++ b/client/renderSDL/ScreenHandler.h
@@ -49,6 +49,10 @@ class ScreenHandler final : public IScreenHandler
 	SDL_Texture * screenTexture = nullptr;
 	SDL_Surface * screen = nullptr;
 
+	/// Render target the adventure map is drawn into, composited under screenTexture.
+	/// Null unless GPU map rendering is both requested and supported by the driver.
+	SDL_Texture * mapTexture = nullptr;
+
 	/// Which parts of `screen` were written this frame, so that only those have to be
 	/// uploaded into screenTexture
 	DirtyRegionTracker dirtyRegions;
@@ -96,6 +100,9 @@ class ScreenHandler final : public IScreenHandler
 	void initializeScreenBuffers();
 	void destroyScreenBuffers();
 
+	/// Creates the map render target, or leaves it null if the driver cannot provide one
+	void initializeMapTexture(const Point & logicalSize);
+
 	/// Updates state (e.g. position) of game window after resolution/fullscreen change
 	void updateWindowState();
 
@@ -136,6 +143,9 @@ public:
 	Canvas getScreenCanvas() const final;
 	void updateScreenTexture() final;
 	void presentScreenTexture() final;
+
+	bool isGpuMapRenderingEnabled() const final;
+	Canvas getMapLayerCanvas() const final;
 
 	std::vector<Point> getSupportedResolutions() const final;
 	std::vector<Point> getSupportedResolutions(int displayIndex) const;

--- a/client/renderSDL/ScreenHandler.h
+++ b/client/renderSDL/ScreenHandler.h
@@ -12,6 +12,7 @@
 
 #include "../../lib/Point.h"
 #include "../render/IScreenHandler.h"
+#include "../render/DirtyRegionTracker.h"
 
 struct SDL_Texture;
 struct SDL_Window;
@@ -47,6 +48,21 @@ class ScreenHandler final : public IScreenHandler
 	SDL_Window * mainWindow = nullptr;
 	SDL_Texture * screenTexture = nullptr;
 	SDL_Surface * screen = nullptr;
+
+	/// Which parts of `screen` were written this frame, so that only those have to be
+	/// uploaded into screenTexture
+	DirtyRegionTracker dirtyRegions;
+
+	/// Copy of the last uploaded pixels, only used by validateDirtyRegions
+	std::vector<uint8_t> validationShadow;
+
+	/// Uploads either the whole surface or just the tracked dirty regions into screenTexture
+	void uploadDirtyRegions(SDL_Surface * source);
+
+	/// Diagnostic: compares `source` against the previously uploaded pixels and reports
+	/// any change that the dirty region list failed to cover. Enabled by the
+	/// video/partialScreenUpdateValidation setting.
+	void validateDirtyRegions(SDL_Surface * source, const std::vector<Rect> & regions);
 
 	EUpscalingFilter upscalingFilter = EUpscalingFilter::AUTO;
 	ColorScheme colorScheme = ColorScheme::NONE;

--- a/client/widgets/MiscWidgets.cpp
+++ b/client/widgets/MiscWidgets.cpp
@@ -378,10 +378,11 @@ CHeroTooltip::CHeroTooltip(Point pos, const InfoAboutHero &hero):
 	init(hero);
 }
 
+// delegates rather than building InfoAboutHero twice - once for the army part and once for the
+// hero part. Each one queries the bonus system for luck, morale and all four primary skills
 CHeroTooltip::CHeroTooltip(Point pos, const CGHeroInstance * hero):
-	CArmyTooltip(pos, InfoAboutHero(hero, InfoAboutHero::EInfoLevel::DETAILED))
+	CHeroTooltip(pos, InfoAboutHero(hero, InfoAboutHero::EInfoLevel::DETAILED))
 {
-	init(InfoAboutHero(hero, InfoAboutHero::EInfoLevel::DETAILED));
 }
 
 CInteractableHeroTooltip::CInteractableHeroTooltip(Point pos, const CGHeroInstance * hero)

--- a/config/schemas/settings.json
+++ b/config/schemas/settings.json
@@ -232,7 +232,9 @@
 				"allowPortrait",
 				"asyncUpscaling",
 				"useHdTextures",
-				"assetCacheSize"
+				"assetCacheSize",
+				"partialScreenUpdate",
+				"partialScreenUpdateValidation"
 			],
 			"properties" : {
 				"resolution" : {
@@ -334,6 +336,18 @@
 				"asyncUpscaling" : {
 					"type" : "boolean",
 					"default" : true
+				},
+				// Upload only the changed parts of the screen to the GPU each frame
+				// instead of the whole framebuffer. Disable if graphical artifacts appear.
+				"partialScreenUpdate" : {
+					"type" : "boolean",
+					"default" : true
+				},
+				// Diagnostic. Compares each frame against the previously uploaded pixels
+				// and logs any change the dirty region tracking failed to report. Slow.
+				"partialScreenUpdateValidation" : {
+					"type" : "boolean",
+					"default" : false
 				},
 				// Memory budget in MiB for keeping decoded images and .def files cached.
 				// 0 selects a value derived from the amount of system RAM.

--- a/config/schemas/settings.json
+++ b/config/schemas/settings.json
@@ -234,7 +234,8 @@
 				"useHdTextures",
 				"assetCacheSize",
 				"partialScreenUpdate",
-				"partialScreenUpdateValidation"
+				"partialScreenUpdateValidation",
+				"gpuMapRendering"
 			],
 			"properties" : {
 				"resolution" : {
@@ -340,6 +341,13 @@
 				// Upload only the changed parts of the screen to the GPU each frame
 				// instead of the whole framebuffer. Disable if graphical artifacts appear.
 				"partialScreenUpdate" : {
+					"type" : "boolean",
+					"default" : true
+				},
+				// Draw the adventure map with the GPU instead of blitting it into the
+				// software framebuffer. Falls back to software if the driver cannot
+				// provide a render target.
+				"gpuMapRendering" : {
 					"type" : "boolean",
 					"default" : true
 				},

--- a/config/schemas/settings.json
+++ b/config/schemas/settings.json
@@ -231,7 +231,8 @@
 				"downscalingFilter",
 				"allowPortrait",
 				"asyncUpscaling",
-				"useHdTextures"
+				"useHdTextures",
+				"assetCacheSize"
 			],
 			"properties" : {
 				"resolution" : {
@@ -333,6 +334,12 @@
 				"asyncUpscaling" : {
 					"type" : "boolean",
 					"default" : true
+				},
+				// Memory budget in MiB for keeping decoded images and .def files cached.
+				// 0 selects a value derived from the amount of system RAM.
+				"assetCacheSize" : {
+					"type" : "number",
+					"default" : 0
 				},
 				"useHdTextures" : {
 					"type" : "boolean",

--- a/lib/gameState/InfoAboutArmy.h
+++ b/lib/gameState/InfoAboutArmy.h
@@ -23,6 +23,8 @@ struct ArmyDescriptor : public std::map<SlotID, CStackBasicDescriptor>
 	DLL_LINKAGE ArmyDescriptor();
 
 	DLL_LINKAGE int getStrength() const;
+
+	bool operator==(const ArmyDescriptor & other) const = default;
 };
 
 struct DLL_LINKAGE InfoAboutArmy
@@ -36,6 +38,8 @@ struct DLL_LINKAGE InfoAboutArmy
 	InfoAboutArmy(const CArmedInstance *Army, bool detailed);
 
 	void initFromArmy(const CArmedInstance *Army, bool detailed);
+
+	bool operator==(const InfoAboutArmy & other) const = default;
 };
 
 struct DLL_LINKAGE InfoAboutHero : public InfoAboutArmy
@@ -48,6 +52,8 @@ public:
 	{
 		std::vector<si32> primskills;
 		si32 mana, manaLimit, luck, morale;
+
+		bool operator==(const Details & other) const = default;
 	};
 
 	std::optional<Details> details;
@@ -70,6 +76,11 @@ public:
 
 	void initFromHero(const CGHeroInstance *h, EInfoLevel infoLevel);
 	int32_t getIconIndex() const;
+
+	/// Defaulted on purpose: UI code caches the value it last rendered and compares against a
+	/// freshly built one to decide whether anything has to be redrawn. Adding a member above
+	/// extends that check automatically - writing the comparison out by hand would not
+	bool operator==(const InfoAboutHero & other) const = default;
 };
 
 /// Struct which holds a int information about a town

--- a/lib/mapObjects/army/CStackBasicDescriptor.cpp
+++ b/lib/mapObjects/army/CStackBasicDescriptor.cpp
@@ -60,7 +60,7 @@ void CStackBasicDescriptor::setCount(TQuantity newCount)
 	count = newCount;
 }
 
-bool operator==(const CStackBasicDescriptor & l, const CStackBasicDescriptor & r)
+DLL_LINKAGE bool operator==(const CStackBasicDescriptor & l, const CStackBasicDescriptor & r)
 {
 	return l.typeID == r.typeID && l.count == r.count;
 }

--- a/lib/mapObjects/army/CStackBasicDescriptor.h
+++ b/lib/mapObjects/army/CStackBasicDescriptor.h
@@ -37,7 +37,7 @@ public:
 	virtual void setType(const CCreature * c);
 	virtual void setCount(TQuantity amount);
 
-	friend bool operator==(const CStackBasicDescriptor & l, const CStackBasicDescriptor & r);
+	friend DLL_LINKAGE bool operator==(const CStackBasicDescriptor & l, const CStackBasicDescriptor & r);
 
 	template<typename Handler>
 	void serialize(Handler & h)


### PR DESCRIPTION
# VCMI performance work — summary

15 changes on top of `24579d36a`.

**Gain types:** *fps* = steady-state frame time · *movement lag* = the pause between two steps of
a walking hero · *hitch* = one-off stall · *other* = correctness

| # | Commit | Change | Gain type | Estimated win | Summary |
|---|---|---|---|---|---|
| 1 | `20404c6b2` | Memory-bounded asset LRU | hitch | **82% of def decodes, 33% of image decodes eliminated** | Images and defs were held only by `weak_ptr`, so anything not currently drawn was freed and decoded again next frame. Now every asset loads exactly once. Budget is 1/16 of RAM, 64–512 MiB. |
| 2 | `6185551c3` | Partial texture upload | fps | **~2.7 ms/frame, ~24% fps** | The whole framebuffer went to the GPU every frame. Now only changed regions, tracked on a 32 px grid. Biggest single fps win. |
| 3 | `24a24a0a1` | Scroll-aware tile cache | fps while moving | **~0.9 ms/frame, +16% fps** (40.7 → 47.4) | The tile cache is a torus, so a scrolled view is at most four rectangles — blit those instead of walking every tile. Predicted 3.3 ms, delivered 0.9. |
| 4 | `9a5cdee51` | Stop frame-constant work per tile | fps | **−27% per checksum call**, ~1.4 ms/frame | `NeighborTilesInfo` was built for every tile even unused, and the path searched linearly per tile. Real but invisible against workload variation of the same size. |
| 5 | `de607834b` | Object animation memo | fps | **~13% off object checksum** (small) | An object spanning several tiles resolved its animation once per tile. Predicted 2–2.5 ms/frame; actual gain far smaller — the model was wrong. |
| 6 | `fbd8c5025` | Minimap: stop repainting the map | **movement lag** | **−98% on `updateTiles`** (12.57 → 0.25 ms); 255 full map repaints/session → 0 | The minimap latched `setRedrawParent` and never cleared it, so every later redraw dragged a full adventure map repaint along. Largest single win of the effort. |
| 7 | `f4285b73e` | Don't rebuild the info bar per step | **movement lag** | **−79%** (9.85 → 2.06 ms/step) | The whole `VisibleHeroInfo` widget tree — a dozen labels, ten images — was rebuilt every movement step, though nothing it shows changes when a hero walks. |
| 8 | `05090b963` | Animation clock counts time, not frames | other | **animations were running ~11% slow** | `getElapsedMilliseconds` truncated the sub-millisecond remainder every frame and fed that straight into animation progress. Pre-existing; affects every animation in the client. |
| 9 | `f8ebd3b1d` | Skip frames that cannot differ | **movement lag** | **−57% on the pause** (21.3 → 9.1 ms); `interfaceMutex` wait **−96%** (2.6 → 0.1 ms) | Frames drawn while the hero stood still held the lock that the netpacks starting the next step were queued behind. |
| 10 | `7db7ba77d` | Don't decode a cached sound | movement lag | **removes a 6.87 ms decode per play** (max 20.2 ms) — *unmeasured after fix* | The sound cache was defeated by an unconditional load before the branch. Decoding ran on the network thread under the interface lock. Pre-existing upstream bug. |
| 11 | `653b53fe1` | Draw the adventure map with the GPU | **fps** | **frame mean −44%** (11.9 → 6.7 ms), **p99 −56%** (52.4 → 22.9 ms), frames >30 ms 5.6% → 0.3% | Tiles were composed with `SDL_UpperBlit` into a software surface, then uploaded. `Canvas` gained a render-target mode so the seven map renderers are untouched; the map is composited under the software UI. `blitSurface` calls 784k → 45k, and the screen upload dropped to the partial path for free. Behind `video/gpuMapRendering`, default on, falls back to software. |
| 12 | `a7a6d0eb8` | Cache the terrain group count | fps | *unmeasured* — targets 9.6 us/tile | `groupCount` walked `CAnimation::size()` (a map lookup each) per tile per frame for a value fixed at load time. Terrain issues one draw call yet cost 9.6 us/tile. |
| 13 | `90fc917d2` | Resolve object images once per pass | fps | *unmeasured* — targets 26.8 us/tile | `renderObject` resolved three animations through a string-keyed map once per tile an object covers. Now memoised per object, cleared per pass. Fix 5 did this for the checksum only. |
| 14 | `1359926d6` | Stagger the animation tick | **removes the 180 ms spike** | *unmeasured* — worst frame 100% → 9.5% of objects ticking | Adding the object id to the frame index de-synced what objects *show*, not when they *advance*, so the whole map went dirty every 180 ms. Now the clock is offset per object; each still advances once per 180 ms. |
| 15 | `19ba71df0` | Preload animated terrain at map load | hitch | *unmeasured* — targets 62 frames averaging 47.4 ms | Water and lava frames are generated assets and cannot upscale asynchronously (#6201), so they were built on whichever frame first scrolled one into view. Now materialised during map setup, behind the loading screen. Letting them upscale asynchronously was tried first and reverted — they need the synchronous path. |

## Net effect on hero movement

| | before | after | |
|---|---|---|---|
| step period | 188.4 ms | **165.6 ms** | **−12%** |
| pause between steps | 21.3 ms | **9.1 ms** | −57% |
| hero standing still | 11.3% of each step | **5.5%** | |
| network thread blocked by rendering | 2.6 ms | **0.1 ms** | −96% |

Measured against an adverse session — untouched zones ran ~8% slower in the final trace — so the
step-period figure is understated.