### PR TITLE
Prevent NK2 plans from continuing with lost heroes

### DIFF
--- a/AI/Nullkiller2/AIGateway.cpp
+++ b/AI/Nullkiller2/AIGateway.cpp
@@ -1027,6 +1027,9 @@ std::vector<const CGObjectInstance *> AIGateway::getFlaggedObjects() const
 
 bool AIGateway::moveHeroToTile(const int3 dst, const HeroPtr & heroPtr)
 {
+	if(!heroPtr.isVerified())
+		throw cannotFulfillGoalException("Hero was lost!");
+
 	if(heroPtr->isGarrisoned() && heroPtr->getVisitedTown())
 	{
 		cc->swapGarrisonHero(heroPtr->getVisitedTown());

--- a/AI/Nullkiller2/Goals/ExecuteHeroChain.cpp
+++ b/AI/Nullkiller2/Goals/ExecuteHeroChain.cpp
@@ -35,7 +35,7 @@ bool recoverStaleDimensionDoorAction(
 	{
 		logAi->error("Hero %s was lost trying to execute Dimension Door. Exit hero chain.", heroPtr.nameOrDefault());
 
-		return false;
+		throw cannotFulfillGoalException("Hero was lost!");
 	}
 
 	logAi->debug(
@@ -178,7 +178,7 @@ void ExecuteHeroChain::accept(AIGateway * aiGw)
 		{
 			logAi->error("Hero %s was lost. Exit hero chain.", heroPtr.nameOrDefault());
 
-			return;
+			throw cannotFulfillGoalException("Hero was lost!");
 		}
 
 		if(node->parentIndex >= i)
@@ -216,7 +216,7 @@ void ExecuteHeroChain::accept(AIGateway * aiGw)
 					{
 						logAi->error("Hero %s was lost trying to execute special action. Exit hero chain.", heroPtr.nameOrDefault());
 
-						return;
+						throw cannotFulfillGoalException("Hero was lost!");
 					}
 
 					// hero can be already on the target tile after move in specialAction->execute()
@@ -312,7 +312,7 @@ void ExecuteHeroChain::accept(AIGateway * aiGw)
 						{
 							logAi->error("Hero %s was lost. Exit hero chain.", heroPtr.nameOrDefault());
 
-							return;
+							throw cannotFulfillGoalException("Hero was lost!");
 						}
 
 						if(hero->movementPointsRemaining() > 0)
@@ -358,7 +358,7 @@ void ExecuteHeroChain::accept(AIGateway * aiGw)
 			{
 				logAi->debug("Hero %s was killed while attempting to reach %s", heroPtr.nameOrDefault(), node->coord.toString());
 
-				return;
+				throw cannotFulfillGoalException("Hero was lost!");
 			}
 		}
 	}


### PR DESCRIPTION
Report lost heroes as task failures instead of successful early exits from hero-chain execution. Verify heroes before movement so composed plans replan rather than advancing to actions that still reference the removed hero.

Fix the crash reported in https://github.com/vcmi/vcmi/pull/7636#issuecomment-5130222328 (file [227.zip](https://github.com/user-attachments/files/30543604/227.zip) )

The crash sequence was:

1. A town-defense composition starts with Mephala.
2. Mephala is killed and removed during its intermediate hero chain.
3. `ExecuteHeroChain` notices the lost hero but returns as though the subtask completed.
4. The composition continues into `ExchangeSwapTownHeroes` with a stale hero reference.
5. Pathfinding dereferences it and crashes while obtaining the player's fog-of-war map.
