### PR TITLE
fixes crashes in debug built caused by legacy peculiar enchant bonus

### DIFF
--- a/lib/json/JsonBonus.cpp
+++ b/lib/json/JsonBonus.cpp
@@ -301,8 +301,10 @@ static TBonusParametersPtr loadBonusAddInfo(BonusType type, const JsonNode & val
 		case BonusType::FORCE_NEUTRAL_ENCOUNTER_STACK_COUNT:
 		{
 			std::vector<int32_t> loadedData;
-			for(const auto & sequence : value.Vector())
-				loadedData.push_back(sequence.Integer());
+			if (value.isVector()) {
+				for(const auto & sequence : value.Vector())
+					loadedData.push_back(sequence.Integer());
+			}
 			var = loadedData;
 			break;
 		}


### PR DESCRIPTION
Since the changes to the PECULIAR_ENCHANT_BONUS running an application's debug built with installed mods using this bonus results in a crash, since JsonNode asserts that node on which "vector()" method  is run is a VectorNode.
Putting aside assert-caused crashes the behavior seems to me correct (no value is assigned so in case of legacy schema using a single number instead of a list the default value is used).