### PR TITLE
Fix NK2 stale movement after failed steps

### DIFF
--- a/AI/Nullkiller2/AIGateway.cpp
+++ b/AI/Nullkiller2/AIGateway.cpp
@@ -64,6 +64,8 @@ void AIGateway::availableCreaturesChanged(const CGDwelling * town)
 void AIGateway::heroMoved(const TryMoveHero & details, bool verbose)
 {
 	LOG_TRACE(logAi);
+	status.recordMovementResult(details);
+
 	const auto hero = cc->getHero(details.id);
 	if(!hero)
 		validateObject(ObjectIdRef(details.id, cc.get())); //enemy hero may have left visible area
@@ -1051,6 +1053,20 @@ bool AIGateway::moveHeroToTile(const int3 dst, const HeroPtr & heroPtr)
 		}
 	};
 
+	auto throwOnFailedMovement = [&]() -> void
+	{
+		auto movementResult = status.getLastMovementResult(heroPtr->id);
+		if(movementResult && movementResult->result == TryMoveHero::FAILED)
+		{
+			logAi->warn(
+				"Movement request for hero %s from %s to %s failed.",
+				heroPtr->getNameTranslated(),
+				movementResult->start.toString(),
+				movementResult->end.toString());
+			throw cannotFulfillGoalException("Hero movement request failed.");
+		}
+	};
+
 	logAi->debug("Moving hero %s to tile %s", heroPtr->getNameTranslated(), dst.toString());
 	int3 startHpos = heroPtr->visitablePos();
 	bool ret = false;
@@ -1058,8 +1074,10 @@ bool AIGateway::moveHeroToTile(const int3 dst, const HeroPtr & heroPtr)
 	{
 		//FIXME: this assertion fails also if AI moves onto defeated guarded object
 		//assert(cb->getVisitableObjs(dst).size() > 1); //there's no point in revisiting tile where there is no visitable object
+		status.clearLastMovementResult(heroPtr->id);
 		cc->moveHero(*heroPtr, heroPtr->convertFromVisitablePos(dst), false);
 		afterMovementCheck(); // TODO: is it feasible to hero get killed there if game work properly?
+		throwOnFailedMovement();
 		// If revisiting, teleport probing is never done, and so the entries into the list would remain unused and uncleared
 		teleportChannelProbingList.clear();
 		// not sure if AI can currently reconsider to attack bank while staying on it. Check issue 2084 on mantis for more information.
@@ -1111,6 +1129,7 @@ bool AIGateway::moveHeroToTile(const int3 dst, const HeroPtr & heroPtr)
 
 		auto doMovement = [&](int3 dst, bool transit)
 		{
+			status.clearLastMovementResult(heroPtr->id);
 			cc->moveHero(*heroPtr, heroPtr->convertFromVisitablePos(dst), transit);
 		};
 
@@ -1124,10 +1143,12 @@ bool AIGateway::moveHeroToTile(const int3 dst, const HeroPtr & heroPtr)
 			destinationTeleport = exitId;
 			if(exitPos.isValid())
 				destinationTeleportPos = exitPos;
+			status.clearLastMovementResult(heroPtr->id);
 			cc->moveHero(*heroPtr, heroPtr->pos, false);
 			destinationTeleport = ObjectInstanceID();
 			destinationTeleportPos = int3(-1);
 			afterMovementCheck();
+			throwOnFailedMovement();
 		};
 
 		auto doChannelProbing = [&]() -> void
@@ -1165,6 +1186,16 @@ bool AIGateway::moveHeroToTile(const int3 dst, const HeroPtr & heroPtr)
 			int3 currentCoord = path.nodes[i].coord;
 			int3 nextCoord = path.nodes[i - 1].coord;
 
+			if(currentCoord != heroPtr->visitablePos())
+			{
+				logAi->warn(
+					"Stopping stale movement path for hero %s: expected current tile %s, actual tile is %s.",
+					heroPtr->getNameTranslated(),
+					currentCoord.toString(),
+					heroPtr->visitablePos().toString());
+				throw cannotFulfillGoalException("Hero movement path diverged.");
+			}
+
 			auto currentObject = getObj(currentCoord, currentCoord == heroPtr->visitablePos());
 			auto nextObjectTop = getObj(nextCoord, false);
 			auto nextObject = getObj(nextCoord, true);
@@ -1184,6 +1215,15 @@ bool AIGateway::moveHeroToTile(const int3 dst, const HeroPtr & heroPtr)
 			if(path.nodes[i - 1].turns)
 			{
 				//blockedHeroes.insert(h); //to avoid attempts of moving heroes with very little MPs
+				return false;
+			}
+
+			if(heroPtr->movementPointsRemaining() <= 0)
+			{
+				logAi->debug(
+					"Stopping movement path for hero %s before moving to %s: no movement points left.",
+					heroPtr->getNameTranslated(),
+					nextCoord.toString());
 				return false;
 			}
 
@@ -1214,6 +1254,24 @@ bool AIGateway::moveHeroToTile(const int3 dst, const HeroPtr & heroPtr)
 			}
 
 			afterMovementCheck();
+			throwOnFailedMovement();
+
+			auto movementResult = status.getLastMovementResult(heroPtr->id);
+			if(movementResult && movementResult->result == TryMoveHero::BLOCKING_VISIT)
+			{
+				i--;
+				break;
+			}
+
+			if(heroPtr.isVerified() && heroPtr->visitablePos() != endpos)
+			{
+				logAi->warn(
+					"Stopping stale movement path for hero %s: expected to reach %s, actual tile is %s.",
+					heroPtr->getNameTranslated(),
+					endpos.toString(),
+					heroPtr->visitablePos().toString());
+				throw cannotFulfillGoalException("Hero movement path diverged.");
+			}
 
 			if(teleportChannelProbingList.size())
 				doChannelProbing();
@@ -1568,6 +1626,29 @@ void AIStatus::heroVisit(const CGObjectInstance * obj, bool started)
 		objectsBeingVisited.pop_back();
 	}
 	cv.notify_all();
+}
+
+void AIStatus::clearLastMovementResult(ObjectInstanceID heroID)
+{
+	std::unique_lock<std::mutex> lock(mx);
+	lastMovementResults.erase(heroID);
+}
+
+void AIStatus::recordMovementResult(const TryMoveHero & details)
+{
+	std::unique_lock<std::mutex> lock(mx);
+	lastMovementResults[details.id] = details;
+	cv.notify_all();
+}
+
+std::optional<TryMoveHero> AIStatus::getLastMovementResult(ObjectInstanceID heroID)
+{
+	std::unique_lock<std::mutex> lock(mx);
+	auto result = lastMovementResults.find(heroID);
+	if(result == lastMovementResults.end())
+		return std::nullopt;
+
+	return result->second;
 }
 
 void AIStatus::setMove(bool ongoing)

--- a/AI/Nullkiller2/AIGateway.h
+++ b/AI/Nullkiller2/AIGateway.h
@@ -17,6 +17,7 @@
 #include "../../lib/CCreatureHandler.h"
 #include "../../lib/callback/CAdventureAI.h"
 #include "../../lib/mapObjects/MiscObjects.h"
+#include "../../lib/networkPacks/PacksForClient.h"
 #include "Pathfinding/AIPathfinder.h"
 #include "Engine/Nullkiller.h"
 
@@ -35,6 +36,7 @@ class AIStatus
 	std::map<QueryID, std::string> remainingQueries;
 	std::map<int, QueryID> requestToQueryID; //IDs of answer-requests sent to server => query ids (so we can match answer confirmation from server to the query)
 	std::vector<const CGObjectInstance *> objectsBeingVisited;
+	std::map<ObjectInstanceID, TryMoveHero> lastMovementResults;
 	bool ongoingHeroMovement;
 	bool ongoingChannelProbing; // true if AI currently explore bidirectional teleport channel exits
 
@@ -58,6 +60,9 @@ public:
 	void attemptedAnsweringQuery(QueryID queryID, int answerRequestID);
 	void receivedAnswerConfirmation(int answerRequestID, int result);
 	void heroVisit(const CGObjectInstance * obj, bool started);
+	void clearLastMovementResult(ObjectInstanceID heroID);
+	void recordMovementResult(const TryMoveHero & details);
+	std::optional<TryMoveHero> getLastMovementResult(ObjectInstanceID heroID);
 };
 
 // The gateway is responsible for AI events handling. Copied from VCAI.h and refined a bit

--- a/server/NetPacksServer.cpp
+++ b/server/NetPacksServer.cpp
@@ -71,6 +71,20 @@ void ApplyGhNetPackVisitor::visitMoveHero(MoveHero & pack)
 			return;
 		}
 
+		const auto * hero = gh.gameInfo().getHero(pack.hid);
+		if(!hero)
+		{
+			result = true;
+			return;
+		}
+
+		// Batched movement may contain a stale tail after a valid step stops the hero.
+		if(hero->pos != dest || hero->movementPointsRemaining() <= 0)
+		{
+			result = true;
+			return;
+		}
+
 		// player got some query he has to reply to first for example, from triggered event
 		// ignore remaining path (if any), but handle this as success - since at least part of path was legal & was applied
 		auto query = gh.queries->topQuery(pack.player);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -154,6 +154,7 @@ endif()
 
 if(ENABLE_NULLKILLER2_AI)
 	list(APPEND test_SRCS
+		nullkiller2/AIGatewayMovementTest.cpp
 		nullkiller2/AIUtilityTest.cpp
 		nullkiller2/Analyzers/HeroManagerTest.cpp
 		nullkiller2/Analyzers/ObjectClusterizerTest.cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -98,6 +98,7 @@ set(test_SRCS
 
 		texts/TextOperationsTest.cpp
 
+		server/MoveHeroBatchTest.cpp
 		server/queries/QueriesProcessorTest.cpp
 
 		mock/BattleFake.cpp

--- a/test/nullkiller2/AIGatewayMovementTest.cpp
+++ b/test/nullkiller2/AIGatewayMovementTest.cpp
@@ -1,0 +1,167 @@
+/*
+ * AIGatewayMovementTest.cpp, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ */
+#include "StdInc.h"
+
+#include "AI/Nullkiller2/AIGateway.h"
+#include "quest/QuestTest.h"
+
+#include "lib/CPlayerState.h"
+#include "lib/callback/CCallback.h"
+#include "lib/callback/IClient.h"
+#include "lib/mapObjects/CGHeroInstance.h"
+#include "lib/networkPacks/PacksForClient.h"
+#include "lib/networkPacks/PacksForServer.h"
+
+namespace
+{
+const PlayerColor PLAYER(0);
+
+enum class MovementReply
+{
+	ExhaustAfterFirstStep,
+	FailFirstStep
+};
+
+class RecordingMovementClient : public IClient
+{
+public:
+	std::optional<BattleAction> makeSurrenderRetreatDecision(PlayerColor, const BattleID &, const BattleStateInfoForRetreat &) override
+	{
+		return std::nullopt;
+	}
+
+	int sendRequest(const CPackForServer & request, PlayerColor, bool) override
+	{
+		const auto * movement = dynamic_cast<const MoveHero *>(&request);
+		if(!movement)
+			return ++lastRequestID;
+
+		auto * hero = gameState->getHero(movement->hid);
+		EXPECT_NE(hero, nullptr);
+		EXPECT_FALSE(movement->path.empty());
+		if(!hero || movement->path.empty())
+			return ++lastRequestID;
+
+		movementRequests++;
+		requestedDestinations.push_back(movement->path.back());
+
+		if(movementRequests > 1)
+		{
+			ADD_FAILURE() << "AI sent MoveHero after movement had already stopped; stale destination was " << movement->path.back().toString();
+			applyMovement(*hero, movement->path.back(), TryMoveHero::FAILED, hero->movementPointsRemaining());
+			return ++lastRequestID;
+		}
+
+		if(reply == MovementReply::FailFirstStep)
+			applyMovement(*hero, movement->path.back(), TryMoveHero::FAILED, hero->movementPointsRemaining());
+		else
+			applyMovement(*hero, movement->path.back(), TryMoveHero::SUCCESS, 0);
+
+		return ++lastRequestID;
+	}
+
+	void connect(CGameState & state, NK2AI::AIGateway & aiGateway, MovementReply replyMode)
+	{
+		gameState = &state;
+		gateway = &aiGateway;
+		reply = replyMode;
+	}
+
+	int movementRequests = 0;
+	std::vector<int3> requestedDestinations;
+
+private:
+	void applyMovement(const CGHeroInstance & hero, const int3 & destination, TryMoveHero::EResult result, ui32 movePoints)
+	{
+		TryMoveHero movementResult;
+		movementResult.id = hero.id;
+		movementResult.start = hero.pos;
+		movementResult.end = destination;
+		movementResult.result = result;
+		movementResult.movePoints = movePoints;
+
+		gameState->apply(movementResult);
+		gateway->heroMoved(movementResult, false);
+	}
+
+	CGameState * gameState = nullptr;
+	NK2AI::AIGateway * gateway = nullptr;
+	MovementReply reply = MovementReply::ExhaustAfterFirstStep;
+	int lastRequestID = 0;
+};
+
+class AIGatewayMovementTest : public QuestTest
+{
+protected:
+	void startGame(MovementReply reply)
+	{
+		TinyH3M::TinyH3MBuilder builder(EMapFormat::SOD);
+		builder.size(36, false)
+			.playerActive(PLAYER)
+			.hero({5, 5, 0}, HeroTypeID(0), PLAYER)
+			.heroGarrison({{CreatureID::ARCHER, 1}});
+
+		startWithMap(std::move(builder));
+		revealMap(PLAYER);
+
+		hero = findHeroByOwner(PLAYER);
+		ASSERT_NE(hero, nullptr);
+		hero->setMovementPoints(2000);
+
+		callback = std::make_shared<CCallback>(gameState(), std::optional<PlayerColor>{PLAYER}, &client);
+		gateway = std::make_unique<NK2AI::AIGateway>();
+		gateway->initGameInterface(std::shared_ptr<Environment>(), callback);
+		client.connect(*gameState(), *gateway, reply);
+	}
+
+	void revealMap(PlayerColor player)
+	{
+		auto * team = gameState()->getPlayerTeam(player);
+		ASSERT_NE(team, nullptr);
+
+		for(int z = 0; z < map()->levels(); ++z)
+			for(int x = 0; x < map()->width; ++x)
+				for(int y = 0; y < map()->height; ++y)
+					team->fogOfWarMap[int3(x, y, z)] = 1;
+	}
+
+	int3 distantDestination() const
+	{
+		return hero->visitablePos() + int3(4, 0, 0);
+	}
+
+	RecordingMovementClient client;
+	std::shared_ptr<CCallback> callback;
+	std::unique_ptr<NK2AI::AIGateway> gateway;
+	CGHeroInstance * hero = nullptr;
+};
+}
+
+TEST_F(AIGatewayMovementTest, stopsRouteWhenMoveConsumesLastMovementPoint)
+{
+	startGame(MovementReply::ExhaustAfterFirstStep);
+
+	const auto destination = distantDestination();
+
+	EXPECT_FALSE(gateway->moveHeroToTile(destination, NK2AI::HeroPtr(hero, callback.get())));
+	EXPECT_EQ(client.movementRequests, 1) << "the AI must not send a stale MoveHero after the hero reaches 0 movement points";
+	EXPECT_EQ(hero->movementPointsRemaining(), 0);
+	EXPECT_NE(hero->visitablePos(), destination);
+}
+
+TEST_F(AIGatewayMovementTest, throwsAndStopsRouteAfterFailedMovePacket)
+{
+	startGame(MovementReply::FailFirstStep);
+
+	const auto startPosition = hero->visitablePos();
+
+	EXPECT_THROW(gateway->moveHeroToTile(distantDestination(), NK2AI::HeroPtr(hero, callback.get())), NK2AI::cannotFulfillGoalException);
+	EXPECT_EQ(client.movementRequests, 1) << "the AI must not continue through cached path nodes after TryMoveHero::FAILED";
+	EXPECT_EQ(hero->visitablePos(), startPosition);
+}

--- a/test/server/MoveHeroBatchTest.cpp
+++ b/test/server/MoveHeroBatchTest.cpp
@@ -1,0 +1,152 @@
+/*
+ * MoveHeroBatchTest.cpp, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ */
+#include "StdInc.h"
+
+#include "../../server/CGameHandler.h"
+#include "../../server/IGameServer.h"
+#include "../../server/ServerNetPackVisitors.h"
+
+#include "../quest/QuestTest.h"
+
+#include "../../lib/mapObjects/CGHeroInstance.h"
+#include "../../lib/networkPacks/PacksForClient.h"
+#include "../../lib/networkPacks/PacksForServer.h"
+#include "../../lib/pathfinder/CPathfinder.h"
+#include "../../lib/pathfinder/PathfinderOptions.h"
+
+namespace
+{
+const PlayerColor PLAYER(0);
+constexpr GameConnectionID CONNECTION = GameConnectionID::FIRST_CONNECTION;
+
+class RecordingGameServer : public IGameServer
+{
+public:
+	explicit RecordingGameServer(CGameState * state)
+		: gameState(state)
+	{
+	}
+
+	void setState(EServerState value) override
+	{
+		state = value;
+	}
+
+	EServerState getState() const override
+	{
+		return state;
+	}
+
+	bool isPlayerHost(const PlayerColor & color) const override
+	{
+		return color == PLAYER;
+	}
+
+	bool hasPlayerAt(PlayerColor player, GameConnectionID connectionID) const override
+	{
+		return player == PLAYER && connectionID == CONNECTION;
+	}
+
+	bool hasBothPlayersAtSameConnection(PlayerColor left, PlayerColor right) const override
+	{
+		return left == PLAYER && right == PLAYER;
+	}
+
+	void applyPack(CPackForClient & pack) override
+	{
+		record(pack);
+		gameState->apply(pack);
+	}
+
+	void sendPack(CPackForClient & pack, GameConnectionID connectionID) override
+	{
+		EXPECT_EQ(connectionID, CONNECTION);
+		record(pack);
+	}
+
+	std::vector<std::string> systemMessages;
+	std::vector<TryMoveHero> movementResults;
+
+private:
+	void record(CPackForClient & pack)
+	{
+		if(auto * message = dynamic_cast<SystemMessage *>(&pack))
+			systemMessages.push_back(message->text.toString());
+
+		if(auto * movement = dynamic_cast<TryMoveHero *>(&pack))
+			movementResults.push_back(*movement);
+	}
+
+	CGameState * gameState;
+	EServerState state = EServerState::GAMEPLAY;
+};
+
+class MoveHeroBatchTest : public QuestTest
+{
+protected:
+	void SetUp() override
+	{
+		QuestTest::SetUp();
+
+		TinyH3M::TinyH3MBuilder builder(EMapFormat::SOD);
+		builder.size(18, false)
+			.playerActive(PLAYER)
+			.hero({5, 5, 0}, HeroTypeID(0), PLAYER)
+			.heroGarrison({{CreatureID::ARCHER, 1}});
+
+		startWithMap(std::move(builder));
+		gameState()->actingPlayers.insert(PLAYER);
+
+		hero = findHeroByOwner(PLAYER);
+		ASSERT_NE(hero, nullptr);
+	}
+
+	int movementCostTo(const int3 & destination) const
+	{
+		CPathfinderHelper helper(*gameState(), hero, PathfinderOptions(*gameState()));
+		return helper.getMovementCost(hero->visitablePos(), destination, nullptr, nullptr, hero->movementPointsRemaining());
+	}
+
+	CGHeroInstance * hero = nullptr;
+};
+}
+
+TEST_F(MoveHeroBatchTest, stopsBatchWhenAppliedStepConsumesLastMovementPoint)
+{
+	const int3 firstTile = hero->visitablePos() + int3(1, 0, 0);
+	const int3 secondTile = hero->visitablePos() + int3(2, 0, 0);
+	const int movementCost = movementCostTo(firstTile);
+	ASSERT_GT(movementCost, 0);
+
+	hero->setMovementPoints(movementCost);
+
+	RecordingGameServer server(gameState().get());
+	CGameHandler handler(server, gameState());
+
+	MoveHero pack(
+		{
+			hero->convertFromVisitablePos(firstTile),
+			hero->convertFromVisitablePos(secondTile)
+		},
+		EPathfindingLayer::LAND,
+		hero->id,
+		false
+	);
+	pack.player = PLAYER;
+
+	ApplyGhNetPackVisitor visitor(handler, CONNECTION);
+	pack.visit(visitor);
+
+	EXPECT_TRUE(visitor.getResult()) << "a stale tail after a legal batched step must not be reported as fishy";
+	ASSERT_EQ(server.movementResults.size(), 1);
+	EXPECT_EQ(server.movementResults.front().result, TryMoveHero::SUCCESS);
+	EXPECT_EQ(hero->visitablePos(), firstTile);
+	EXPECT_EQ(hero->movementPointsRemaining(), 0);
+	EXPECT_TRUE(server.systemMessages.empty()) << "the original bug surfaced as a server-problem system message";
+}


### PR DESCRIPTION
Remember the latest TryMoveHero result in AIStatus and check it while AIGateway::moveHeroToTile walks cached paths. Abort on FAILED moves, stop before sending another request when the hero has no movement points, and reject paths whose live hero position diverges.

Add Nullkiller2 regression coverage for zero-MP and FAILED movement responses so the AI cannot emit stale MoveHero requests again.

Replayed [the June 2026 save](https://github.com/vcmi/vcmi/issues/6121#issuecomment-4638168515). Original symptoms are gone:
  - `Hero doesn't have any movement points left!`: 0
  - `Got false in applying 8MoveHero... that request must have been fishy!`: 0
  - `Tiles (...) and (...) are not neighboring!`: 0
  - `System message: Server encountered a problem`: 0
  - The Janova/Pillar chain now logs `Stopping movement path for hero Янова ... no movement points left` instead of sending the rejected server request.

Fix #6121