### PR TITLE
android: Keep the text field visible when the on-screen keyboard opens

### DIFF
--- a/android/vcmi-app/src/main/java/eu/vcmi/vcmi/NativeMethods.java
+++ b/android/vcmi-app/src/main/java/eu/vcmi/vcmi/NativeMethods.java
@@ -54,6 +54,12 @@ public class NativeMethods
     }
 
     @SuppressWarnings(Const.JNI_METHOD_SUPPRESS)
+    public static int getKeyboardHeight()
+    {
+        return VcmiSDLActivity.getKeyboardHeight();
+    }
+
+    @SuppressWarnings(Const.JNI_METHOD_SUPPRESS)
     public static void showProgress()
     {
         internalProgressDisplay(true);

--- a/android/vcmi-app/src/main/java/eu/vcmi/vcmi/VcmiSDLActivity.java
+++ b/android/vcmi-app/src/main/java/eu/vcmi/vcmi/VcmiSDLActivity.java
@@ -14,6 +14,9 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.view.WindowManager;
 
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
+
 import org.libsdl.app.SDLActivity;
 
 import java.lang.reflect.Method;
@@ -31,6 +34,9 @@ public class VcmiSDLActivity extends SDLActivity
     final Messenger mClientMessenger = new Messenger(
             new IncomingServerMessageHandler(
                     new OnServerRegisteredCallback()));
+    /// height the on-screen keyboard covers, read by the engine to keep the text field visible
+    private static volatile int keyboardHeight = 0;
+
     Messenger mServiceMessenger = null;
     boolean mIsServerServiceBound;
     private View mProgressBar;
@@ -115,6 +121,8 @@ public class VcmiSDLActivity extends SDLActivity
         setContentView(outerLayout);
 
         VcmiSDLActivity.this.setWindowStyle(true); // set fullscreen
+
+        trackKeyboardHeight();
     }
 
     @Override
@@ -142,6 +150,29 @@ public class VcmiSDLActivity extends SDLActivity
         super.onWindowFocusChanged(hasFocus);
         if (hasFocus)
             scheduleInputFocusRestore();
+    }
+
+    public static int getKeyboardHeight()
+    {
+        return keyboardHeight;
+    }
+
+    /**
+     * The game renders into a surface of its own, so android never moves the text field out of the
+     * way - the engine does it and only needs to know how much of the screen is covered.
+     */
+    private void trackKeyboardHeight()
+    {
+        if (mSurface == null)
+        {
+            return;
+        }
+
+        ViewCompat.setOnApplyWindowInsetsListener(mSurface, (view, insets) ->
+        {
+            keyboardHeight = insets.getInsets(WindowInsetsCompat.Type.ime()).bottom;
+            return insets;
+        });
     }
 
     private void scheduleInputFocusRestore()

--- a/client/eventsSDL/InputSourceMouse.cpp
+++ b/client/eventsSDL/InputSourceMouse.cpp
@@ -37,7 +37,9 @@ InputSourceMouse::InputSourceMouse()
 
 void InputSourceMouse::handleEventMouseMotion(const SDL_MouseMotionEvent & motion)
 {
+	// the screen may be panned up for the on-screen keyboard - the finger points at what is drawn there
 	Point newPosition = Point(motion.x, motion.y) / ENGINE->screenHandler().getScalingFactor();
+	newPosition.y += ENGINE->screenHandler().getScreenPanOffset();
 	motionAccumulatedX += static_cast<float>(-motion.xrel) / ENGINE->screenHandler().getScalingFactor();
 	motionAccumulatedY += static_cast<float>(-motion.yrel) / ENGINE->screenHandler().getScalingFactor();
 	Point distance = Point(motionAccumulatedX, motionAccumulatedY);

--- a/client/eventsSDL/InputSourceText.cpp
+++ b/client/eventsSDL/InputSourceText.cpp
@@ -45,6 +45,7 @@ void InputSourceText::startTextInput(const Rect & whereInput)
 		SDL_Rect textInputRect = CSDL_Ext::toSDL(rectInScreenCoordinates);
 
 		SDL_SetTextInputRect(&textInputRect);
+		ENGINE->screenHandler().setTextInputArea(whereInput);
 
 		if (SDL_IsTextInputActive() == SDL_FALSE)
 		{
@@ -57,6 +58,8 @@ void InputSourceText::stopTextInput()
 {
 	ENGINE->dispatchMainThread([]()
 	{
+		ENGINE->screenHandler().setTextInputArea(Rect());
+
 		if (SDL_IsTextInputActive() == SDL_TRUE)
 		{
 			SDL_StopTextInput();

--- a/client/eventsSDL/InputSourceTouch.cpp
+++ b/client/eventsSDL/InputSourceTouch.cpp
@@ -83,7 +83,11 @@ void InputSourceTouch::handleEventFingerMotion(const SDL_TouchFingerEvent & tfin
 			};
 
 			ENGINE->input().moveCursorPosition(moveDistance);
-			ENGINE->cursor().cursorMove(ENGINE->getCursorPosition().x * scalingFactor, ENGINE->getCursorPosition().y * scalingFactor);
+
+			// the cursor is drawn after the panned screen, so it needs the pan taken back out
+			Point cursorOnScreen = ENGINE->getCursorPosition();
+			cursorOnScreen.y -= ENGINE->screenHandler().getScreenPanOffset();
+			ENGINE->cursor().cursorMove(cursorOnScreen.x * scalingFactor, cursorOnScreen.y * scalingFactor);
 
 			break;
 		}
@@ -303,7 +307,12 @@ void InputSourceTouch::handleUpdate()
 
 Point InputSourceTouch::convertTouchToMouse(const SDL_TouchFingerEvent & tfinger)
 {
-	return convertTouchToMouse(tfinger.x, tfinger.y);
+	Point position = convertTouchToMouse(tfinger.x, tfinger.y);
+
+	// the screen may be panned up for the on-screen keyboard - the finger points at what is drawn there
+	position.y += ENGINE->screenHandler().getScreenPanOffset();
+
+	return position;
 }
 
 Point InputSourceTouch::convertTouchToMouse(float x, float y)

--- a/client/render/IScreenHandler.h
+++ b/client/render/IScreenHandler.h
@@ -37,6 +37,14 @@ public:
 	/// Presents screen texture on the screen
 	virtual void presentScreenTexture() = 0;
 
+	/// Area that must stay visible while the on-screen keyboard is open, in logical coordinates.
+	/// Empty rect disables it
+	virtual void setTextInputArea(const Rect & area) = 0;
+
+	/// How far the screen is currently moved up to keep that area clear of the keyboard,
+	/// in logical coordinates. Input positions have to be corrected by it
+	virtual int getScreenPanOffset() const = 0;
+
 	/// Returns list of resolutions supported by current screen
 	virtual std::vector<Point> getSupportedResolutions() const = 0;
 

--- a/client/renderSDL/ScreenHandler.cpp
+++ b/client/renderSDL/ScreenHandler.cpp
@@ -676,10 +676,70 @@ void ScreenHandler::updateScreenTexture()
 	SDL_FreeSurface(screenScheme);
 }
 
+void ScreenHandler::setTextInputArea(const Rect & area)
+{
+	textInputArea = area;
+}
+
+/// Android draws the on-screen keyboard over the game, so shift the whole screen up by as much
+/// as the keyboard covers of the active text field - the same thing adjustPan does for normal apps
+int ScreenHandler::getScreenPanOffset() const
+{
+#ifdef VCMI_ANDROID
+	if(textInputArea.h == 0)
+		return 0;
+
+	CAndroidVMHelper vmHelper;
+	int keyboardHeight = vmHelper.callStaticIntMethod(CAndroidVMHelper::NATIVE_METHODS_DEFAULT_CLASS, "getKeyboardHeight");
+
+	if(keyboardHeight <= 0)
+		return 0;
+
+	int windowWidth = 0;
+	int windowHeight = 0;
+	SDL_GetRendererOutputSize(mainRenderer, &windowWidth, &windowHeight);
+
+	if(windowHeight <= 0)
+		return 0;
+
+	// the keyboard is measured in window pixels, everything below works in logical ones
+	Point logicalSize = getLogicalResolution();
+	int keyboardCovers = keyboardHeight * logicalSize.y / windowHeight;
+	// a little air, so the field does not sit flush against the keyboard
+	static constexpr int keyboardMargin = 8;
+
+	int coveredFromY = logicalSize.y - keyboardCovers;
+	int overlap = textInputArea.y + textInputArea.h - coveredFromY;
+
+	// already far enough above the keyboard
+	if(overlap + keyboardMargin <= 0)
+		return 0;
+
+	// upper bound is the screen, not the visible part - otherwise the margin gets capped away
+	// for fields that sit low and the field would end up flush against the keyboard after all
+	return std::min(overlap + keyboardMargin, logicalSize.y);
+#else
+	return 0;
+#endif
+}
+
 void ScreenHandler::presentScreenTexture()
 {
 	SDL_RenderClear(mainRenderer);
-	SDL_RenderCopy(mainRenderer, screenTexture, nullptr, nullptr);
+
+	// render coordinates are the logical ones scaled by the upscaling filter
+	int panOffset = getScreenPanOffset() * getScalingFactor();
+
+	if(panOffset > 0)
+	{
+		SDL_Rect destination{0, -panOffset, screen->w, screen->h};
+		SDL_RenderCopy(mainRenderer, screenTexture, nullptr, &destination);
+	}
+	else
+	{
+		SDL_RenderCopy(mainRenderer, screenTexture, nullptr, nullptr);
+	}
+
 	ENGINE->cursor().render();
 	SDL_RenderPresent(mainRenderer);
 }

--- a/client/renderSDL/ScreenHandler.h
+++ b/client/renderSDL/ScreenHandler.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "../../lib/Point.h"
+#include "../../lib/Rect.h"
 #include "../render/IScreenHandler.h"
 
 struct SDL_Texture;
@@ -50,6 +51,10 @@ class ScreenHandler final : public IScreenHandler
 
 	EUpscalingFilter upscalingFilter = EUpscalingFilter::AUTO;
 	ColorScheme colorScheme = ColorScheme::NONE;
+
+	/// Rect of the text field currently being edited, in window coordinates
+	Rect textInputArea;
+
 
 	/// Dimensions of target surfaces/textures, this value is what game logic views as screen size
 	Point getPreferredLogicalResolution() const;
@@ -120,6 +125,8 @@ public:
 	Canvas getScreenCanvas() const final;
 	void updateScreenTexture() final;
 	void presentScreenTexture() final;
+	void setTextInputArea(const Rect & area) final;
+	int getScreenPanOffset() const final;
 
 	std::vector<Point> getSupportedResolutions() const final;
 	std::vector<Point> getSupportedResolutions(int displayIndex) const;

--- a/client/widgets/TextControls.cpp
+++ b/client/widgets/TextControls.cpp
@@ -473,8 +473,15 @@ void CGStatusBar::setEnteringMode(bool on)
 	{
 		//assert(enteringText == false);
 		alignment = ETextAlignment::TOPLEFT;
-		ENGINE->input().startTextInput(pos);
 		setText(consoleText);
+
+		// after setText, so the reported area is the one the entered text is drawn in.
+		// the status bar is the bottom-most element, so claim everything below it as well -
+		// that keeps the whole bar clear of the on-screen keyboard whatever its own height is
+		Rect inputArea = background ? background->pos : pos;
+		inputArea.h = std::max(inputArea.h, ENGINE->screenDimensions().y - inputArea.y);
+
+		ENGINE->input().startTextInput(inputArea);
 	}
 	else
 	{

--- a/lib/CAndroidVMHelper.cpp
+++ b/lib/CAndroidVMHelper.cpp
@@ -79,6 +79,15 @@ std::string CAndroidVMHelper::callStaticStringMethod(const std::string & cls, co
 	return std::string(env->GetStringUTFChars(jres, nullptr));
 }
 
+int CAndroidVMHelper::callStaticIntMethod(const std::string & cls, const std::string & method,
+										  bool classloaded)
+{
+	auto env = get();
+	auto javaHelper = findClass(cls, classloaded);
+	auto methodId = env->GetStaticMethodID(javaHelper, method.c_str(), "()I");
+	return env->CallStaticIntMethod(javaHelper, methodId);
+}
+
 void CAndroidVMHelper::callCustomMethod(const std::string & cls, const std::string & method,
 										const std::string & signature,
 										std::function<void(JNIEnv *, jclass, jmethodID)> fun, bool classloaded)

--- a/lib/CAndroidVMHelper.h
+++ b/lib/CAndroidVMHelper.h
@@ -37,6 +37,8 @@ public:
 
 	std::string callStaticStringMethod(const std::string & cls, const std::string & method, bool classloaded = false);
 
+	int callStaticIntMethod(const std::string & cls, const std::string & method, bool classloaded = false);
+
 	void callCustomMethod(const std::string & cls, const std::string & method, const std::string & signature,
 						  std::function<void(JNIEnv *, jclass, jmethodID)> fun, bool classloaded = false);
 


### PR DESCRIPTION
Render surface moves that inputs keeps visible. So you know what you type in now. ;)

Similar to iOS.

<img width="1076" height="489" alt="image" src="https://github.com/user-attachments/assets/c4088916-5ac1-401e-95ba-f71fb5cc21bb" />
