### PR TITLE
Makes fuzzy text search less tolerant

### DIFF
--- a/client/windows/CSpellWindow.cpp
+++ b/client/windows/CSpellWindow.cpp
@@ -326,7 +326,7 @@ void CSpellWindow::processSpells()
 	mySpells.reserve(LIBRARY->spellh->objects.size());
 	for(auto const & spell : LIBRARY->spellh->objects)
 	{
-		bool searchTextFound = !searchBox || TextOperations::textSearchSimilarityScore(searchBox->getText(), spell->getNameTranslated());
+		bool searchTextFound = !searchBox || TextOperations::isFuzzyMatch(searchBox->getText(), spell->getNameTranslated());
 
 		if(onSpellSelect)
 		{

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -1918,8 +1918,9 @@ void CObjectListWindow::itemsSearchCallback(const std::string & text)
 		boost::erase_all(name, "{");
     	boost::erase_all(name, "}");
 
-		if(auto score = TextOperations::textSearchSimilarityScore(text, name)) // Keep only relevant items
-			rankedItems.emplace_back(score.value(), item);
+		auto score = TextOperations::textSearchSimilarityScore(text, name); // Keep only relevant items
+		if (TextOperations::isRelevantScore(name, score))
+			rankedItems.emplace_back(score, item);
 	}
 
 	// Sort: Lower score is better match

--- a/client/windows/wiki/WikiWindow.cpp
+++ b/client/windows/wiki/WikiWindow.cpp
@@ -979,7 +979,7 @@ void WikiWindow::buildElementList(int categoryIndex) // NOSONAR
 		entries = allEntries;
 	else
 		for(const auto & entry : allEntries)
-			if(TextOperations::textSearchSimilarityScore(filter, entry.name))
+			if(TextOperations::isFuzzyMatch(filter, entry.name))
 				entries.push_back(entry);
 
 	currentDisplayedEntries = entries;

--- a/lib/texts/TextOperations.cpp
+++ b/lib/texts/TextOperations.cpp
@@ -389,20 +389,28 @@ DLL_LINKAGE bool TextOperations::compareLocalizedStrings(std::string_view str1, 
 	) < 0;
 }
 
-std::optional<int> TextOperations::textSearchSimilarityScore(const std::string & needle, const std::string & haystack)
+bool TextOperations::isFuzzyMatch(const std::string & needle, const std::string & haystack)
 {
-	// 0 - Best possible match: text starts with the search string
-	if(haystack.rfind(needle, 0) == 0)
-		return 0;
+	return isRelevantScore(needle, textSearchSimilarityScore(needle, haystack));
+}
 
-	// 1 - Strong match: text contains the search string
+bool TextOperations::isRelevantScore(const std::string & needle, const int & score)
+{
+	int charCount = getUnicodeCharactersCount(needle);
+	if (charCount == 0)
+		return score == 0;
+	return score == 0 || score <= charCount/CHAR_PER_TYPO_ALLOWED;
+}
+
+int TextOperations::textSearchSimilarityScore(const std::string & needle, const std::string & haystack)	//here
+{
+	// Strong match: text contains the search string
 	if(haystack.find(needle) != std::string::npos)
-		return 1;
+		return 0;
 
 	// Dynamic threshold: Reject if too many typos based on word length
 	int haystackCodepoints = getUnicodeCharactersCount(haystack);
 	int needleCodepoints = getUnicodeCharactersCount(needle);
-	int maxAllowedDistance = needleCodepoints / 2;
 
 	// Compute Levenshtein distance for fuzzy similarity
 	int minDist = std::numeric_limits<int>::max();
@@ -421,11 +429,7 @@ std::optional<int> TextOperations::textSearchSimilarityScore(const std::string &
 		minDist = std::min(minDist, dist);
 	}
 
-	// Apply scaling: Short words tolerate smaller distances
-	if(needle.size() > 2 && minDist <= 2)
-		minDist += 1;
-
-	return (minDist > maxAllowedDistance) ? std::nullopt : std::optional<int>{ minDist };
+	return minDist;
 }
 
 std::string TextOperations::filesystemPathToUtf8(const boost::filesystem::path& path)

--- a/lib/texts/TextOperations.h
+++ b/lib/texts/TextOperations.h
@@ -13,6 +13,8 @@
 /// Namespace that provides utilities for unicode support (UTF-8)
 namespace TextOperations
 {
+	const static int CHAR_PER_TYPO_ALLOWED = 4;
+
 	/// returns 32-bit UTF codepoint for UTF-8 character symbol
 	uint32_t DLL_LINKAGE getUnicodeCodepoint(const char *data, size_t maxSize);
 
@@ -69,18 +71,20 @@ namespace TextOperations
 	/// timeOffset - optional parameter to modify current time by specified time in seconds
 	DLL_LINKAGE std::string getCurrentFormattedTimeLocal(std::chrono::seconds timeOffset = {});
 
+	/// Compares two strings using locale-aware collation based on the selected game language.
+	DLL_LINKAGE bool compareLocalizedStrings(std::string_view str1, std::string_view str2);
+
+	DLL_LINKAGE bool isFuzzyMatch(const std::string & haystack, const std::string & needle);
+
+	DLL_LINKAGE bool isRelevantScore(const std::string & needle, const int & score);
+
+	/// measures the smallest Levenshtein distance of a needle to any substring of a haystack
+	DLL_LINKAGE int textSearchSimilarityScore(const std::string & needle, const std::string & haystack);
+
 	/// Algorithm for detection of typos in words
 	/// Determines how 'different' two strings are - how many changes must be done to turn one string into another one
 	/// https://en.wikipedia.org/wiki/Levenshtein_distance#Iterative_with_two_matrix_rows
 	DLL_LINKAGE int getLevenshteinDistance(std::string_view s, std::string_view t);
-
-	/// Compares two strings using locale-aware collation based on the selected game language.
-	DLL_LINKAGE bool compareLocalizedStrings(std::string_view str1, std::string_view str2);
-
-	/// Check if texts have similarity when typing into search boxes
-	/// 0 -> Exact match or starts with typed-in text, 1 -> Close match or substring match, 
-	/// other values = Levenshtein distance, returns std::nullopt for unrelated word (bad match).
-	DLL_LINKAGE std::optional<int> textSearchSimilarityScore(const std::string & s, const std::string & t);
 
 	/// This function is mainly used to avoid garbled text when reading or writing files
 	/// with non-ASCII (e.g. Chinese) characters in the path, especially on Windows.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -96,6 +96,8 @@ set(test_SRCS
  		spells/targetConditions/SpellEffectConditionTest.cpp
  		spells/targetConditions/TargetConditionItemFixture.cpp
 
+		texts/TextOperationsTest.cpp
+
 		server/queries/QueriesProcessorTest.cpp
 
 		mock/BattleFake.cpp

--- a/test/texts/TextOperationsTest.cpp
+++ b/test/texts/TextOperationsTest.cpp
@@ -1,0 +1,32 @@
+/*
+ * TextOperationTest.cpp, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
+#include "StdInc.h"
+
+#include "../../lib/texts/TextOperations.h"
+
+namespace test
+{
+
+using namespace ::testing;
+
+class TextOperationsTest : public Test {};
+
+TEST_F(TextOperationsTest, Test)
+{
+	ASSERT_EQ(TextOperations::textSearchSimilarityScore("", ""), 0);
+	ASSERT_EQ(TextOperations::textSearchSimilarityScore("", "Fortune"), 0);
+	ASSERT_EQ(TextOperations::textSearchSimilarityScore("forgot", "forget"), 1);
+	ASSERT_EQ(TextOperations::textSearchSimilarityScore("besi", "wbęśiem"), 2);
+	ASSERT_EQ(TextOperations::textSearchSimilarityScore("DisPELL", "dispell"), 0);
+	ASSERT_EQ(TextOperations::textSearchSimilarityScore("irebal", "Fireball"), 0);
+	ASSERT_EQ(TextOperations::textSearchSimilarityScore("irebaw", "Fireball"), 1);
+}
+
+}


### PR DESCRIPTION
I wasn't happy with the fuzzy search so I look into it. AS far as I understand in vcmi it is primarily used for helping players with possible typos/slightly badly remembered names. For this utility it seems to me way too tolerant:

<img width="522" height="680" alt="Screenshot From 2026-08-02 11-37-15" src="https://github.com/user-attachments/assets/e79d35a7-6efd-4d32-9f04-4c3888e26054" />

Current implementation allows for the Levenshtein distance equal half of the searched phrase size. I think a more convenient solution would be to allow Ld equal a quarter of searched phrase so a search won't catch quite so many strays. As seen on the above picture, if you misstype three letters you indeed can make "sorrow" out of "forgot", but three mistyped letters is quite a lot for a 6 letter word. 

PS: I also added some tests and refactored a little.