### PR TITLE
make petrify a negative effect

### DIFF
--- a/config/spells/other.json
+++ b/config/spells/other.json
@@ -480,6 +480,9 @@
 				"range" : "X"
 			}
 		},
+		"counters" : {
+			"spell.stoneGaze": true
+		},
 		"flags" : {
 			"positive": true
 		}


### PR DESCRIPTION
Fixes #7651.
The commit that set an indifferent flag on petrify is from 2014 and I know from experience a lot of abilities in that file have/had nonsensical flag so I don't expect any problems.