### PR TITLE
Fix Arrow Tower Damage

### DIFF
--- a/config/creatures/special.json
+++ b/config/creatures/special.json
@@ -180,6 +180,7 @@
 			"noRetalitation" : { "type" : "BLOCKS_RANGED_RETALIATION" },
 			"noLuck" : { "type" : "NO_LUCK" },
 			"attackAlwaysZero" : { "type" : "PRIMARY_SKILL", "subtype" : "attack", "val" : 0, "valueType" : "INDEPENDENT_MIN" },
+			"noArcheryBonuses" : { "type" : "PERCENTAGE_DAMAGE_BOOST", "subtype" : "damageTypeRanged", "val" : 0, "valueType" : "INDEPENDENT_MIN" },
 			"cpuControlled" : { "type" : "CPU_CONTROLLED" }
 		},
 		"graphics" :


### PR DESCRIPTION
This PR fixes the issue of Archery increasing the damage of Arrow Towers. That was a HotA change, not the case in SoD.

Damage Test setup:
Kyrre: no Archery
Ivor: Archery
Towns fully built except Grail

Rampart (should be 40-80, 20-40):
Before:
Kyrre: 42-84, 22-44
Ivor: 63-126, 33-66
After:
Kyrre: 42-84, 22-44
Ivor: 42-84, 22-44

Tower (should be 44-88, 22-44):
Before:
Kyrre: 46-92, 24-48
Ivor: 69-138, 36-72
After:
Kyrre: 46-92, 24-48
Ivor: 46-92, 24-48

So there is still a bug somewhere, not sure what it is, maybe a building that shouldn't be counted is counted, but I don't know
:(

Editing here: I found out the discrepancies in VCMI's count and SoD's count:
1) Village Hall does NOT count, instead, Town Hall is the building that counts for damage even tho it's technically an upgrade
2) Fort does NOT count, neither do Citadel and Castle.


There is something very weird going on. This is a zipped test map made in the SoD map editor: 
[ARROW TOWER TEST SOD.zip](https://github.com/user-attachments/files/30642501/ARROW.TOWER.TEST.SOD.zip)
The rightmost tower town has no building except castle. The arrow tower damage should be 10-20, in VCMI however, it is 14-28. This would mean that Village Hall+ and Fort+ are not counted as structures in SoD, but in VCMI, they are. But since the fully upgraded tower town has only 1 instance of damage more than in SoD, this means that a building that should be counted, isn't counted...