### PR TITLE
Fix RMG town exits blocked by neighboring zones

### DIFF
--- a/lib/rmg/modificators/TownPlacer.cpp
+++ b/lib/rmg/modificators/TownPlacer.cpp
@@ -171,36 +171,93 @@ int3 TownPlacer::placeMainTown(ObjectManager & manager, std::shared_ptr<CGTownIn
 	//towns are big objects and should be centered around visitable position
 	rmg::Object rmgObject(town);
 	rmgObject.setTemplate(zone.getTerrainType(), zone.getRand());
+	const int3 townPositionOffset = rmgObject.getPosition() - rmgObject.getVisitablePosition();
 
-	int3 position(-1, -1, -1);
+	auto findTownPosition = [this, &manager, &rmgObject, townPositionOffset](bool requireExitInsideZone)
 	{
 		Zone::Lock lock(zone.areaMutex);
-		position = manager.findPlaceForObject(zone.areaPossible().get(), rmgObject, [this](const int3& t)
+		return manager.findPlaceForObject(zone.areaPossible().get(), rmgObject,
+			[this, &rmgObject, townPositionOffset, requireExitInsideZone](const int3 & t)
 			{
+				if(requireExitInsideZone && !hasTownExitInsideZone(rmgObject, townPositionOffset))
+					return -1.f;
+
 				float distance = zone.getPos().dist2dSQ(t);
 				return 100000.f - distance; //some big number
 			}, ObjectManager::OptimizeType::WEIGHT);
+	};
+
+	int3 position = findTownPosition(true);
+	if(!position.isValid())
+	{
+		logGlobal->warn("Failed to place town with local exit in zone %d, reserving boundary exit", zone.getId());
+		position = findTownPosition(false);
 	}
-	rmgObject.setPosition(position + int3(2, 2, 0)); //place visitable tile in the exact center of a zone
+
+	if(!position.isValid())
+		throw rmgException(boost::str(boost::format("Failed to place town with free exit in zone %d") % zone.getId()));
+
+	rmgObject.setPosition(position + townPositionOffset); //place visitable tile in the exact center of a zone
 	manager.placeObject(rmgObject, false, true, true);
 	cleanupBoundaries(rmgObject);
 	zone.setPos(rmgObject.getVisitablePosition()); //roads lead to main town
 	return position;
 }
 
-void TownPlacer::cleanupBoundaries(const rmg::Object & rmgObject)
+bool TownPlacer::hasTownExitInsideZone(const rmg::Object & rmgObject, const int3 & offset) const
 {
-	Zone::Lock lock(zone.areaMutex);
 	for(const auto & t : rmgObject.getArea().getBorderOutside())
 	{
-		if (t.y > rmgObject.getVisitablePosition().y) //Line below the town
+		if(t.y <= rmgObject.getVisitablePosition().y)
+			continue;
+
+		const auto exitTile = t + offset;
+		if(map.isOnMap(exitTile) && map.getZoneID(exitTile) == zone.getId())
+			return true;
+	}
+
+	return false;
+}
+
+void TownPlacer::cleanupBoundaries(const rmg::Object & rmgObject)
+{
+	const bool hasLocalExit = hasTownExitInsideZone(rmgObject);
+	std::map<TRmgTemplateZoneId, rmg::Tileset> neighboringExitTiles;
+
+	{
+		Zone::Lock lock(zone.areaMutex);
+		for(const auto & t : rmgObject.getArea().getBorderOutside())
 		{
-			if (map.isOnMap(t))
-			{
-				map.setOccupied(t, ETileType::FREE);
-				zone.areaPossible()->erase(t);
-				zone.freePaths()->add(t);
-			}
+			if(t.y <= rmgObject.getVisitablePosition().y || !map.isOnMap(t))
+				continue;
+
+			const auto exitZoneId = map.getZoneID(t);
+			const bool localExit = exitZoneId == zone.getId();
+			if(!localExit && hasLocalExit)
+				continue;
+
+			map.setOccupied(t, ETileType::FREE);
+			zone.areaPossible()->erase(t);
+			zone.freePaths()->add(t);
+
+			if(!localExit)
+				neighboringExitTiles[exitZoneId].insert(t);
+		}
+	}
+
+	auto & zones = map.getZones();
+	for(const auto & [zoneId, tiles] : neighboringExitTiles)
+	{
+		auto zoneIter = zones.find(zoneId);
+		if(zoneIter == zones.end())
+			continue;
+
+		auto zoneToUpdate = zoneIter->second;
+		Zone::Lock lock(zoneToUpdate->areaMutex);
+		for(const auto & t : tiles)
+		{
+			zoneToUpdate->areaPossible()->erase(t);
+			zoneToUpdate->areaUsed()->add(t);
 		}
 	}
 }

--- a/lib/rmg/modificators/TownPlacer.h
+++ b/lib/rmg/modificators/TownPlacer.h
@@ -23,6 +23,9 @@ public:
 	
 	int getTotalTowns() const;
 	
+private:
+	bool hasTownExitInsideZone(const rmg::Object & rmgObject, const int3 & offset = int3()) const;
+
 protected:
 	void cleanupBoundaries(const rmg::Object & rmgObject);
 	void addNewTowns(int count, bool hasFort, const PlayerColor & player, ObjectManager & manager);


### PR DESCRIPTION
This is the map: [rmg-blocked-town.zip](https://github.com/user-attachments/files/30646771/rmg-blocked-town.zip)

<img width="377" height="402" alt="blocked town" src="https://github.com/user-attachments/assets/791014fe-8f68-40c6-a870-b67f9f6345aa" />

The red town has its visitable tile at (17,9,0), and the row below the exit is blocked by mountain tiles, so the starting hero cannot leave.

A generated Small Ring map had a starting town whose hero could not leave because mountains were placed on all tiles below the town entrance. The town placer was marking those exit tiles free in RmgMap and only removing them from the town zone's possible area; when those tiles belonged to an adjacent zone, that zone still considered them placeable and later obstacle placement could fill the exit.

`cleanupBoundaries` now gathers the town-exit boundary tiles for both the town zone and the tile owner zone, then removes them from each zone's possible area and adds them to each zone's free paths while marking the map tiles free. The regression test builds a two-zone RMG scenario where a town exit is owned by another zone and asserts that `cleanupBoundaries` protects the exit in that owning zone; without the fix it still builds and fails with the blocked-town symptom.