### PR TITLE
[WIP] Improve NK2AI adventure map decisions

### DIFF
--- a/AI/MMAI/BAI/logger.h
+++ b/AI/MMAI/BAI/logger.h
@@ -50,7 +50,7 @@ public:
 	template<typename... Args>
 	void trace(const std::string & format, Args... args) const
 	{
-		log(ELogLevel::DEBUG, format, args...);
+		log(ELogLevel::TRACE, format, args...);
 	}
 	template<typename... Args>
 	void log(ELogLevel::ELogLevel level, const std::string & format, Args... args) const

--- a/AI/MMAI/BAI/v13/BAI.cpp
+++ b/AI/MMAI/BAI/v13/BAI.cpp
@@ -119,9 +119,9 @@ void BAI::battleEnd(const BattleID & bid, const BattleResult * br, QueryID query
 	}
 
 	if(getActionTotalCalls > 0)
-		logger.info("MMAI stats after battle end: %d predictions, %d ms per prediction", getActionTotalCalls, getActionTotalMs / getActionTotalCalls);
+		logger.trace("MMAI stats after battle end: %d predictions, %d ms per prediction", getActionTotalCalls, getActionTotalMs / getActionTotalCalls);
 	else
-		logger.info("MMAI stats after battle end: 0 predictions");
+		logger.trace("MMAI stats after battle end: 0 predictions");
 
 	// BAI is destroyed after this call
 	logger.debug("Leaving battleEnd, embracing death");
@@ -274,7 +274,7 @@ std::optional<BattleAction> BAI::maybeFleeOrSurrender(const BattleID & bid)
 		}
 	}
 
-	logger.info("Will ask for surrender/retreat decision...");
+	logger.trace("Will ask for surrender/retreat decision...");
 	return cb->makeSurrenderRetreatDecision(bid, bs);
 }
 

--- a/AI/MMAI/BAI/v13/nn_model.cpp
+++ b/AI/MMAI/BAI/v13/nn_model.cpp
@@ -129,7 +129,7 @@ namespace
 		~ScopedTimer()
 		{
 			auto dt = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - t0).count();
-			logAi->info("%s: %lld ms", name, dt);
+			logAi->trace("%s: %lld ms", name, dt);
 		}
 	};
 

--- a/AI/Nullkiller2/AIGateway.cpp
+++ b/AI/Nullkiller2/AIGateway.cpp
@@ -271,10 +271,22 @@ void AIGateway::heroExchangeStarted(ObjectInstanceID hero1, ObjectInstanceID her
 			}
 			else
 			{
+				const auto firstHeroRole = nullkiller->heroManager->getHeroRoleOrDefaultInefficient(firstHero);
+				const auto secondHeroRole = nullkiller->heroManager->getHeroRoleOrDefaultInefficient(secondHero);
 				if(nullkiller->isActive(firstHero))
-					transferFrom2to1(secondHero, firstHero);
+				{
+					if(firstHeroRole == HeroRole::MAIN && secondHeroRole == HeroRole::SCOUT && nullkiller->heroManager->isMeaningfulArmyCarrier(secondHero))
+						transferFrom2to1(firstHero, secondHero);
+					else
+						transferFrom2to1(secondHero, firstHero);
+				}
 				else
-					transferFrom2to1(firstHero, secondHero);
+				{
+					if(secondHeroRole == HeroRole::MAIN && firstHeroRole == HeroRole::SCOUT && nullkiller->heroManager->isMeaningfulArmyCarrier(firstHero))
+						transferFrom2to1(secondHero, firstHero);
+					else
+						transferFrom2to1(firstHero, secondHero);
+				}
 			}
 
 			answerQuery(query, 0);

--- a/AI/Nullkiller2/AIGateway.cpp
+++ b/AI/Nullkiller2/AIGateway.cpp
@@ -420,6 +420,10 @@ void AIGateway::battleResultsApplied()
 {
 	LOG_TRACE(logAi);
 	assert(status.getBattle() == ENDING_BATTLE);
+
+	std::unique_lock lockGuard(nullkiller->aiStateMutex);
+	nullkiller->heroManager->update();
+	nullkiller->invalidatePathfinderData();
 }
 
 void AIGateway::battleEnded()

--- a/AI/Nullkiller2/AIGateway.cpp
+++ b/AI/Nullkiller2/AIGateway.cpp
@@ -637,17 +637,28 @@ void AIGateway::showBlockingDialog(const std::string & text, const std::vector<C
 		if(selection) // select the last component; they are indexed in range [1, size]
 			sel = components.size();
 		{
-				std::unique_lock mxLock(nullkiller->aiStateMutex);
+			std::unique_lock mxLock(nullkiller->aiStateMutex);
 
-				// TODO: Find better way to understand it is Chest of Treasures
-				if(heroPtr.isVerified()
-					&& components.size() == 2
-					&& components.front().type == ComponentType::RESOURCE
-					&& (nullkiller->heroManager->getHeroRoleOrDefault(heroPtr) != HeroRole::MAIN
-						|| nullkiller->buildAnalyzer->isGoldPressureOverMax()))
-				{
-					sel = 1;
-				}
+			// TODO: Find better way to understand it is Chest of Treasures
+			const bool isTreasureChestDialog = heroPtr.isVerified()
+										&& components.size() == 2
+										&& components.front().type == ComponentType::RESOURCE;
+
+			if(isTreasureChestDialog && (nullkiller->heroManager->getHeroRoleOrDefault(heroPtr) != HeroRole::MAIN
+					|| nullkiller->getFreeResources()[GameResID::GOLD] < 1000))
+			{
+				sel = 1;
+			}
+
+			if(isTreasureChestDialog)
+			{
+				const auto & selectedComponent = components[sel - 1];
+				logAi->warn("Treasure chest reward selected by %s: %s, choice %d, gold %d",
+					heroPtr.nameOrDefault(),
+					selectedComponent.type == ComponentType::RESOURCE ? "gold" : "experience",
+					sel,
+					nullkiller->getFreeResources()[GameResID::GOLD]);
+			}
 		}
 
 		answerQuery(askID, sel);

--- a/AI/Nullkiller2/AIGateway.cpp
+++ b/AI/Nullkiller2/AIGateway.cpp
@@ -33,6 +33,7 @@
 #include "../../lib/battle/BattleInfo.h"
 #include "../../lib/CPlayerState.h"
 
+#include "AIUtility.h"
 #include "AIGateway.h"
 #include "Goals/Goals.h"
 
@@ -1217,13 +1218,15 @@ bool AIGateway::moveHeroToTile(const int3 dst, const HeroPtr & heroPtr)
 
 			bool isConnected = false;
 			bool isNextObjectTeleport = false;
+			bool isNextObjectPassable = false;
 			// Check there is node after next one; otherwise transit is pointless
 			if(i - 2 >= 0)
 			{
 				isConnected = CGTeleport::isConnected(nextObjectTop, getObj(path.nodes[i - 2].coord, false));
 				isNextObjectTeleport = CGTeleport::isTeleport(nextObjectTop);
+				isNextObjectPassable = nextObject && isObjectPassable(nullkiller.get(), nextObject);
 			}
-			if(isConnected || isNextObjectTeleport)
+			if(isConnected || isNextObjectTeleport || isNextObjectPassable)
 			{
 				// Hero should be able to go through object if it's allow transit
 				doMovement(endpos, true);

--- a/AI/Nullkiller2/AIUtility.cpp
+++ b/AI/Nullkiller2/AIUtility.cpp
@@ -737,6 +737,17 @@ bool shouldVisit(const Nullkiller * aiNk, const CGHeroInstance * hero, const CGO
 		return false;
 	}
 
+	const auto * rewardableObject = dynamic_cast<const CRewardableObject *>(obj);
+	InfoAboutRewardableObject rewardableInfo;
+	if(rewardableObject
+		&& rewardableObject->configuration.visitMode == Rewardable::VISIT_ONCE
+		&& aiNk->cc->getRewardableObjectInfo(obj, rewardableInfo, hero)
+		&& rewardableInfo.scouted
+		&& rewardableInfo.cleared)
+	{
+		return false;
+	}
+
 	if(obj->wasVisited(hero))
 		return false;
 

--- a/AI/Nullkiller2/AIUtility.cpp
+++ b/AI/Nullkiller2/AIUtility.cpp
@@ -201,6 +201,9 @@ bool isObjectPassable(const Nullkiller * aiNk, const CGObjectInstance * obj)
 // Pathfinder internal helper
 bool isObjectPassable(const CGObjectInstance * obj, PlayerColor playerColor, PlayerRelations objectRelations)
 {
+	if(obj->ID == Obj::SIGN)
+		return true;
+
 	if((obj->ID == Obj::GARRISON || obj->ID == Obj::GARRISON2)
 		&& objectRelations != PlayerRelations::ENEMIES)
 		return true;
@@ -730,7 +733,6 @@ bool shouldVisit(const Nullkiller * aiNk, const CGHeroInstance * hero, const CGO
 	case Obj::TAVERN:
 	case Obj::EYE_OF_MAGI:
 	case Obj::BOAT:
-	case Obj::SIGN:
 		return false;
 	}
 

--- a/AI/Nullkiller2/AIUtility.cpp
+++ b/AI/Nullkiller2/AIUtility.cpp
@@ -729,6 +729,7 @@ bool shouldVisit(const Nullkiller * aiNk, const CGHeroInstance * hero, const CGO
 	case Obj::MAGIC_WELL:
 		return hero->mana < hero->manaLimit();
 	case Obj::PRISON:
+		// TODO: support freeing a hero slot in prison goal decomposition. There is already findWeakHeroToDismiss()
 		return !aiNk->heroManager->heroCapReached();
 	case Obj::TAVERN:
 	case Obj::EYE_OF_MAGI:

--- a/AI/Nullkiller2/AIUtility.cpp
+++ b/AI/Nullkiller2/AIUtility.cpp
@@ -722,15 +722,7 @@ bool shouldVisit(const Nullkiller * aiNk, const CGHeroInstance * hero, const CGO
 			return false;
 		break;
 	case Obj::TREE_OF_KNOWLEDGE:
-	{
-		if(aiNk->heroManager->getHeroRoleOrDefaultInefficient(hero) == HeroRole::SCOUT)
-			return false;
-
-		TResources myRes = aiNk->getFreeResources();
-		if(myRes[EGameResID::GOLD] < 2000 || myRes[EGameResID::GEMS] < 10)
-			return false;
 		break;
-	}
 	case Obj::MAGIC_WELL:
 		return hero->mana < hero->manaLimit();
 	case Obj::PRISON:

--- a/AI/Nullkiller2/Analyzers/BuildAnalyzer.cpp
+++ b/AI/Nullkiller2/Analyzers/BuildAnalyzer.cpp
@@ -209,7 +209,10 @@ std::string BuildingInfo::toString() const
 
 float BuildAnalyzer::calculateGoldPressure(TResource lockedGold, float armyCostGold, float economyDevelopmentCost, float freeGold, float dailyIncomeGold)
 {
-	auto pressure = (lockedGold + armyCostGold + economyDevelopmentCost) / (1 + 2 * freeGold + dailyIncomeGold * static_cast<float>(LIBRARY->engineSettings()->getInteger(EGameSettings::GENERAL_DAYS_PER_WEEK)));
+	const auto daysPerWeek = static_cast<float>(LIBRARY->engineSettings()->getInteger(EGameSettings::GENERAL_DAYS_PER_WEEK));
+	const auto pressureCost = lockedGold + armyCostGold + economyDevelopmentCost;
+	const auto pressureIncome = 1 + 2 * freeGold + dailyIncomeGold * daysPerWeek;
+	auto pressure = pressureCost / pressureIncome;
 
 #if NK2AI_TRACE_LEVEL >= 1
 	logAi->trace("Gold pressure: %f", pressure);

--- a/AI/Nullkiller2/Analyzers/DangerHitMapAnalyzer.cpp
+++ b/AI/Nullkiller2/Analyzers/DangerHitMapAnalyzer.cpp
@@ -326,7 +326,7 @@ const CGTownInstance * DangerHitMapAnalyzer::getClosestTown(const int3 & tile) c
 	return hitMap[tile.x][tile.y][tile.z].closestTown;
 }
 
-uint64_t DangerHitMapAnalyzer::enemyCanKillOurHeroesAlongThePath(const AIPath & path) const
+bool DangerHitMapAnalyzer::enemyCanKillOurHeroesAlongThePath(const AIPath & path) const
 {
 	int3 tile = path.targetTile();
 	int turn = path.turn();

--- a/AI/Nullkiller2/Analyzers/DangerHitMapAnalyzer.h
+++ b/AI/Nullkiller2/Analyzers/DangerHitMapAnalyzer.h
@@ -74,7 +74,7 @@ public:
 
 	void updateHitMap();
 	void calculateTileOwners();
-	uint64_t enemyCanKillOurHeroesAlongThePath(const AIPath & path) const;
+	bool enemyCanKillOurHeroesAlongThePath(const AIPath & path) const;
 	const HitMapNode & getObjectThreat(const CGObjectInstance * obj) const;
 	const HitMapNode & getTileThreat(const int3 & tile) const;
 	std::set<const CGObjectInstance *> getOneTurnAccessibleObjects(const CGHeroInstance * enemy) const;

--- a/AI/Nullkiller2/Analyzers/HeroManager.cpp
+++ b/AI/Nullkiller2/Analyzers/HeroManager.cpp
@@ -137,11 +137,13 @@ void HeroManager::update()
 		return scores.at(h1) > scores.at(h2);
 	};
 
-	const int biggerMapFactor = cc->getCalendar().getCurrentDay() > 21 ? cc->getMapSize().x / CMapHeader::MAP_SIZE_LARGE : 0;
-	// One per town + static bonus on bigger maps after some weeks
-	int globalMainCount = std::max(static_cast<int>(cc->getTownsInfo().size()) + biggerMapFactor, 1);
-	// If 1 town but big map, limit a bit to don't spread the army too much
-	globalMainCount = std::min(globalMainCount, static_cast<int>(cc->getTownsInfo().size() * 2));
+	const int currentTownCount = static_cast<int>(cc->getTownsInfo().size());
+	if(initialTownCount < 0)
+		initialTownCount = currentTownCount;
+
+	const int capturedTownCount = std::max(0, currentTownCount - initialTownCount);
+	int globalMainCount = std::max(initialTownCount + capturedTownCount / 2, 1);
+	globalMainCount = std::min(globalMainCount, static_cast<int>(myHeroes.size()));
 
 	// TODO: Mircea: Should spread them on map min 1 per town, avoiding all within the same town and the other towns just with dummy scouts
 	logAi->trace("HeroManager::update Max number of main heroes (globalMainCount) is %d", globalMainCount);

--- a/AI/Nullkiller2/Analyzers/HeroManager.cpp
+++ b/AI/Nullkiller2/Analyzers/HeroManager.cpp
@@ -173,6 +173,34 @@ HeroRole HeroManager::getHeroRoleOrDefaultInefficient(const  CGHeroInstance * he
 	return getHeroRoleOrDefault(HeroPtr(hero, aiNk->cc.get()));
 }
 
+bool HeroManager::isMeaningfulArmyCarrier(const CGHeroInstance * hero) const
+{
+	static constexpr uint64_t MIN_REINFORCEMENT_ARMY_STRENGTH = 500;
+	static constexpr uint64_t REINFORCEMENT_ARMY_STRENGTH_DIVISOR = 10;
+
+	if(!hero)
+		return false;
+
+	const auto armyStrength = hero->getArmyStrength();
+	uint64_t strongestArmy = armyStrength;
+	bool isStrongestArmy = true;
+
+	for(const auto * otherHero : cc->getHeroesInfo())
+	{
+		if(otherHero == hero)
+			continue;
+
+		const auto otherArmyStrength = otherHero->getArmyStrength();
+		strongestArmy = std::max(strongestArmy, otherArmyStrength);
+		if(otherArmyStrength > armyStrength
+			|| (otherArmyStrength == armyStrength && otherHero->id.getNum() < hero->id.getNum()))
+			isStrongestArmy = false;
+	}
+
+	return isStrongestArmy
+		|| armyStrength > std::max(MIN_REINFORCEMENT_ARMY_STRENGTH, strongestArmy / REINFORCEMENT_ARMY_STRENGTH_DIVISOR);
+}
+
 // TODO: Mircea: Do we need this map on HeroPtr or is enough just on hero?
 HeroRole HeroManager::getHeroRoleOrDefault(const HeroPtr & heroPtr) const
 {

--- a/AI/Nullkiller2/Analyzers/HeroManager.h
+++ b/AI/Nullkiller2/Analyzers/HeroManager.h
@@ -48,6 +48,7 @@ private:
 	const Nullkiller * aiNk;
 	std::map<HeroPtr, HeroRole> heroToRoleMap; // can get out of sync with cc->getHeroesInfo() and include lost heroes
 	std::map<ObjectInstanceID, float> knownFightingStrength;
+	int initialTownCount = -1;
 
 public:
 	HeroManager(CCallback * cc, const Nullkiller * aiNk) : cc(cc), aiNk(aiNk) {}

--- a/AI/Nullkiller2/Analyzers/HeroManager.h
+++ b/AI/Nullkiller2/Analyzers/HeroManager.h
@@ -57,6 +57,7 @@ public:
 	void update();
 	float evaluateSecSkill(SecondarySkill skill, const CGHeroInstance * hero) const;
 	float evaluateHero(const CGHeroInstance * hero) const;
+	bool isMeaningfulArmyCarrier(const CGHeroInstance * hero) const;
 	bool canRecruitHero(const CGTownInstance * t = nullptr) const;
 	bool heroCapReached(bool includeGarrisoned = true) const;
 	const CGHeroInstance * findHeroWithGrail() const;

--- a/AI/Nullkiller2/Analyzers/ObjectClusterizer.cpp
+++ b/AI/Nullkiller2/Analyzers/ObjectClusterizer.cpp
@@ -292,6 +292,11 @@ bool ObjectClusterizer::shouldVisitObject(const CGObjectInstance * obj) const
 	}
 
 	const int3 pos = obj->visitablePos();
+	auto playerRelations = aiNk->cc->getPlayerRelations(aiNk->playerID, obj->tempOwner);
+	const bool isCreatureGenerator = obj->ID == Obj::CREATURE_GENERATOR1
+		|| obj->ID == Obj::CREATURE_GENERATOR2
+		|| obj->ID == Obj::CREATURE_GENERATOR3
+		|| obj->ID == Obj::CREATURE_GENERATOR4;
 
 	const auto * rewardableObject = dynamic_cast<const CRewardableObject *>(obj);
 	InfoAboutRewardableObject rewardableInfo;
@@ -302,13 +307,11 @@ bool ObjectClusterizer::shouldVisitObject(const CGObjectInstance * obj) const
 		&& rewardableInfo.cleared)
 		return false;
 
-	if((obj->ID != Obj::CREATURE_GENERATOR1 && vstd::contains(aiNk->memory->alreadyVisited, obj->id))
+	if((!isCreatureGenerator && vstd::contains(aiNk->memory->alreadyVisited, obj->id))
 		|| obj->wasVisited(aiNk->playerID))
 	{
 		return false;
 	}
-
-	auto playerRelations = aiNk->cc->getPlayerRelations(aiNk->playerID, obj->tempOwner);
 
 	if(playerRelations != PlayerRelations::ENEMIES && !isWeeklyRevisitable(aiNk->playerID, obj))
 	{

--- a/AI/Nullkiller2/Analyzers/ObjectClusterizer.cpp
+++ b/AI/Nullkiller2/Analyzers/ObjectClusterizer.cpp
@@ -293,6 +293,15 @@ bool ObjectClusterizer::shouldVisitObject(const CGObjectInstance * obj) const
 
 	const int3 pos = obj->visitablePos();
 
+	const auto * rewardableObject = dynamic_cast<const CRewardableObject *>(obj);
+	InfoAboutRewardableObject rewardableInfo;
+	if(rewardableObject
+		&& rewardableObject->configuration.visitMode == Rewardable::VISIT_ONCE
+		&& aiNk->cc->getRewardableObjectInfo(obj, rewardableInfo)
+		&& rewardableInfo.scouted
+		&& rewardableInfo.cleared)
+		return false;
+
 	if((obj->ID != Obj::CREATURE_GENERATOR1 && vstd::contains(aiNk->memory->alreadyVisited, obj->id))
 		|| obj->wasVisited(aiNk->playerID))
 	{

--- a/AI/Nullkiller2/Analyzers/ObjectClusterizer.cpp
+++ b/AI/Nullkiller2/Analyzers/ObjectClusterizer.cpp
@@ -547,6 +547,9 @@ void ObjectClusterizer::clusterizeObject(
 
 				for (int prio = PriorityEvaluator::PriorityTier::BUILDINGS; prio <= PriorityEvaluator::PriorityTier::MAX_PRIORITY_TIER; ++prio)
 				{
+					if(prio == PriorityEvaluator::PriorityTier::ESCAPE)
+						continue;
+
 					priority = std::max(priority, priorityEvaluator->evaluate(Goals::sptr(Goals::ExecuteHeroChain(path, obj)), prio));
 				}
 
@@ -571,6 +574,9 @@ void ObjectClusterizer::clusterizeObject(
 
 		for (int prio = PriorityEvaluator::PriorityTier::BUILDINGS; prio <= PriorityEvaluator::PriorityTier::MAX_PRIORITY_TIER; ++prio)
 		{
+			if(prio == PriorityEvaluator::PriorityTier::ESCAPE)
+				continue;
+
 			priority = std::max(priority, priorityEvaluator->evaluate(Goals::sptr(Goals::ExecuteHeroChain(path, obj)), prio));
 		}
 

--- a/AI/Nullkiller2/Behaviors/CaptureObjectsBehavior.cpp
+++ b/AI/Nullkiller2/Behaviors/CaptureObjectsBehavior.cpp
@@ -10,6 +10,7 @@
 #include "StdInc.h"
 #include "../AIGateway.h"
 #include "../Engine/Nullkiller.h"
+#include "../Engine/PriorityEvaluator.h"
 #include "../Goals/Composition.h"
 #include "../Goals/ExecuteHeroChain.h"
 #include "../Goals/Invalid.h"
@@ -20,6 +21,112 @@ namespace NK2AI
 {
 
 using namespace Goals;
+
+static bool isRouteFiller(const Nullkiller * nullkiller, const CGObjectInstance * obj, HeroRole role)
+{
+	switch(obj->ID)
+	{
+	case Obj::RESOURCE:
+	case Obj::ARTIFACT:
+	case Obj::SPELL_SCROLL:
+	case Obj::CAMPFIRE:
+	case Obj::SEA_CHEST:
+	case Obj::OCEAN_BOTTLE:
+	case Obj::FLOTSAM:
+	case Obj::SHIPWRECK_SURVIVOR:
+	case Obj::STABLES:
+		return true;
+	case Obj::SCHOLAR:
+		return role == HeroRole::MAIN;
+	case Obj::TREASURE_CHEST:
+		return role == HeroRole::MAIN || nullkiller->getFreeResources()[GameResID::GOLD] < 1000;
+	default:
+		return false;
+	}
+}
+
+static float getRoutePickupValue(const RewardEvaluator & evaluator, const CGObjectInstance * obj, const CGHeroInstance * hero, const CCreatureSet * army, HeroRole role)
+{
+	return evaluator.getStrategicalValue(obj, hero) * 1000
+		+ evaluator.getGoldReward(obj, hero)
+		+ evaluator.getSkillReward(obj, hero, role) * 1000
+		+ evaluator.getArmyReward(obj, hero, army, true)
+		+ evaluator.getArmyGrowth(obj, hero, army);
+}
+
+static bool pathVisitsObject(const AIPath & path, const CGObjectInstance * obj)
+{
+	for(const auto & node : path.nodes)
+	{
+		if(node.coord == obj->visitablePos())
+			return true;
+	}
+
+	return false;
+}
+
+static void addRoutePickupBonuses(Goals::TGoalVec & tasks,
+	const std::vector<AIPath> & paths,
+	const std::vector<const CGObjectInstance *> & objs,
+	const Nullkiller * nullkiller,
+	const CGObjectInstance * target)
+{
+	if(!target)
+		return;
+
+	for(size_t index = 0; index < tasks.size() && index < paths.size(); ++index)
+	{
+		auto * chain = dynamic_cast<ExecuteHeroChain *>(tasks[index].get());
+		if(!chain)
+			continue;
+
+		const auto & targetPath = paths[index];
+		const auto * hero = targetPath.targetHero;
+		const auto * army = targetPath.heroArmy ? targetPath.heroArmy : hero;
+		const auto role = nullkiller->heroManager->getHeroRoleOrDefaultInefficient(hero);
+
+		if(role != HeroRole::MAIN && targetPath.getPathDanger() > 0)
+		{
+			continue;
+		}
+		if(targetPath.exchangeCount > 1)
+		{
+			continue;
+		}
+
+		const CGObjectInstance * firstPickup = nullptr;
+		float totalBonus = 0;
+		const RewardEvaluator evaluator(nullkiller);
+
+		for(const auto * pickup : objs)
+		{
+			if(pickup == target || pickup->visitablePos().z != target->visitablePos().z)
+				continue;
+			if(!isRouteFiller(nullkiller, pickup, role))
+				continue;
+
+			const float pickupValue = getRoutePickupValue(evaluator, pickup, hero, army, role);
+			if(pickupValue <= 0)
+				continue;
+
+			if(!shouldVisit(nullkiller, hero, pickup))
+				continue;
+
+			if(!pathVisitsObject(targetPath, pickup))
+				continue;
+
+			if(!firstPickup)
+				firstPickup = pickup;
+
+			totalBonus += pickupValue;
+		}
+
+		if(firstPickup)
+		{
+			chain->setRouteAnchorBonus(firstPickup, totalBonus, 0);
+		}
+	}
+}
 
 template <typename T>
 bool vectorEquals(const std::vector<T> & v1, const std::vector<T> & v2)
@@ -240,7 +347,9 @@ void CaptureObjectsBehavior::decomposeObjects(
 #if NK2AI_TRACE_LEVEL >= 1
 				logAi->trace("Found %d paths", paths.size());
 #endif
-				vstd::concatenate(tasksLocal, getVisitGoals(paths, nullkiller, objToVisit, specificObjects));
+				auto visitGoals = getVisitGoals(paths, nullkiller, objToVisit, specificObjects);
+				addRoutePickupBonuses(visitGoals, paths, objs, nullkiller, objToVisit);
+				vstd::concatenate(tasksLocal, visitGoals);
 			}
 
 			std::lock_guard lock(sync); // FIXME: consider using tbb::parallel_reduce instead to avoid mutex overhead

--- a/AI/Nullkiller2/Behaviors/EscapeBehavior.cpp
+++ b/AI/Nullkiller2/Behaviors/EscapeBehavior.cpp
@@ -76,11 +76,37 @@ bool isBetterEscapePath(const AIPath & path, float score, const EscapePathChoice
 	return false;
 }
 
+const CGTownInstance * findNearestOwnedTown(const CGHeroInstance * hero, const Nullkiller * aiNk)
+{
+	const CGTownInstance * bestTown = nullptr;
+	const CGTownInstance * bestTownAnyLevel = nullptr;
+	ui32 bestDistance = std::numeric_limits<ui32>::max();
+	ui32 bestDistanceAnyLevel = std::numeric_limits<ui32>::max();
+
+	for(const auto * town : aiNk->cc->getTownsInfo())
+	{
+		const auto distance = hero->visitablePos().dist2dSQ(town->visitablePos());
+		if(town->visitablePos().z == hero->visitablePos().z && distance < bestDistance)
+		{
+			bestTown = town;
+			bestDistance = distance;
+		}
+		if(distance < bestDistanceAnyLevel)
+		{
+			bestTownAnyLevel = town;
+			bestDistanceAnyLevel = distance;
+		}
+	}
+
+	return bestTown ? bestTown : bestTownAnyLevel;
+}
+
 EscapePathCandidate makeEscapePathCandidate(
 	const AIPath & path,
 	const HitMapInfo & currentThreat,
 	const HitMapInfo & destinationThreat,
 	uint64_t destinationDanger,
+	const CGTownInstance * nearestOwnedTown,
 	float safeAttackRatio)
 {
 	const auto destination = path.targetTile();
@@ -96,12 +122,20 @@ EscapePathCandidate makeEscapePathCandidate(
 	candidate.usesDimensionDoor = pathUsesDimensionDoor(path);
 	candidate.threatReduction = currentThreat.threat - destinationThreat.threat;
 	candidate.movementCost = path.movementCost();
+	if(nearestOwnedTown)
+	{
+		candidate.hasOwnedTown = true;
+		candidate.currentTownDistance = path.targetHero->visitablePos().dist2dSQ(nearestOwnedTown->visitablePos());
+		candidate.destinationTownDistance = destination.dist2dSQ(nearestOwnedTown->visitablePos());
+		candidate.destinationGetsCloserToOwnedTown = candidate.destinationTownDistance < candidate.currentTownDistance;
+	}
 	return candidate;
 }
 
 void considerEscapePath(
 	const AIPath & path,
 	const HeroMap<HitMapInfo> & threatenedHeroes,
+	const HeroMap<const CGTownInstance *> & nearestOwnedTowns,
 	const Nullkiller * aiNk,
 	float safeAttackRatio,
 	std::mutex & sync,
@@ -116,11 +150,13 @@ void considerEscapePath(
 	const auto & destinationThreat = aiNk->dangerHitMap->getTileThreat(destination).fastestDanger;
 	const uint64_t immediateDestinationDanger = destinationThreat.turn < 1 ? destinationThreat.danger : 0;
 	const uint64_t destinationDanger = std::max(path.getTotalDanger(), immediateDestinationDanger);
+	const auto nearestOwnedTown = nearestOwnedTowns.find(path.targetHero);
 	const auto candidate = makeEscapePathCandidate(
 		path,
 		currentThreat,
 		destinationThreat,
 		destinationDanger,
+		nearestOwnedTown == nearestOwnedTowns.end() ? nullptr : nearestOwnedTown->second,
 		safeAttackRatio);
 
 	const auto evaluation = evaluateEscapePathCandidate(candidate);
@@ -149,6 +185,9 @@ EscapePathEvaluation evaluateEscapePathCandidate(const EscapePathCandidate & can
 		return result;
 	}
 
+	if(candidate.hasOwnedTown && !candidate.destinationGetsCloserToOwnedTown)
+		return result;
+
 	result.accepted = true;
 	result.score = candidate.threatReduction / std::max(0.1f, candidate.movementCost);
 	return result;
@@ -163,6 +202,7 @@ Goals::TGoalVec EscapeBehavior::decompose(const Nullkiller * aiNk) const
 {
 	Goals::TGoalVec tasks;
 	HeroMap<HitMapInfo> threatenedHeroes;
+	HeroMap<const CGTownInstance *> nearestOwnedTowns;
 	const float safeAttackRatio = aiNk->settings->getSafeAttackRatio();
 
 	for(const CGHeroInstance * candidateHero : aiNk->cc->getHeroesInfo())
@@ -172,7 +212,10 @@ Goals::TGoalVec EscapeBehavior::decompose(const Nullkiller * aiNk) const
 
 		const auto & threat = aiNk->dangerHitMap->getTileThreat(candidateHero->visitablePos()).fastestDanger;
 		if(isHeroImmediatelyThreatened(candidateHero, threat, safeAttackRatio))
+		{
 			threatenedHeroes[candidateHero] = threat;
+			nearestOwnedTowns[candidateHero] = findNearestOwnedTown(candidateHero, aiNk);
+		}
 	}
 
 	if(threatenedHeroes.empty())
@@ -185,10 +228,10 @@ Goals::TGoalVec EscapeBehavior::decompose(const Nullkiller * aiNk) const
 	pforeachTilePaths(
 		mapSize,
 		aiNk,
-		[&threatenedHeroes, aiNk, safeAttackRatio, &sync, &bestPaths](const int3 &, const std::vector<AIPath> & paths)
+		[&threatenedHeroes, &nearestOwnedTowns, aiNk, safeAttackRatio, &sync, &bestPaths](const int3 &, const std::vector<AIPath> & paths)
 	{
 		for(const AIPath & path : paths)
-			considerEscapePath(path, threatenedHeroes, aiNk, safeAttackRatio, sync, bestPaths);
+			considerEscapePath(path, threatenedHeroes, nearestOwnedTowns, aiNk, safeAttackRatio, sync, bestPaths);
 	});
 
 	for(const auto & bestPath : bestPaths)

--- a/AI/Nullkiller2/Behaviors/EscapeBehavior.h
+++ b/AI/Nullkiller2/Behaviors/EscapeBehavior.h
@@ -24,7 +24,11 @@ struct EscapePathCandidate
 	bool singleHeroPath = false;
 	bool destinationSafe = false;
 	bool destinationIsSafer = false;
+	bool hasOwnedTown = false;
+	bool destinationGetsCloserToOwnedTown = true;
 	bool usesDimensionDoor = false;
+	ui32 currentTownDistance = 0;
+	ui32 destinationTownDistance = 0;
 	float threatReduction = 0.0f;
 	float movementCost = 0.0f;
 };

--- a/AI/Nullkiller2/Behaviors/GatherArmyBehavior.cpp
+++ b/AI/Nullkiller2/Behaviors/GatherArmyBehavior.cpp
@@ -101,12 +101,13 @@ Goals::TGoalVec GatherArmyBehavior::deliverArmyToHero(const Nullkiller * aiNk, c
 		}
 
 		HeroExchange heroExchange(receiverHero, path);
-		// TODO: Mircea: Artifacts (inventory things) aren't considered in this calculation, though they are properly changed in an army exchange, to revisit
 		const uint64_t additionalArmyStrength = heroExchange.getReinforcementArmyStrength(aiNk);
-		const float additionalArmyRatio = static_cast<float>(additionalArmyStrength) / receiverHero->getArmyStrength();
+		const uint64_t artifactExchangeValue = heroExchange.getArtifactExchangeValue();
+		const uint64_t exchangeValue = additionalArmyStrength + artifactExchangeValue;
+		const float additionalArmyRatio = static_cast<float>(exchangeValue) / receiverHero->getArmyStrength();
 
 		// avoid transferring very small amount of army
-		if((additionalArmyRatio < 0.1f && additionalArmyStrength < 20000) || additionalArmyStrength < 500)
+		if((additionalArmyRatio < 0.1f && exchangeValue < 20000) || exchangeValue < 500)
 		{
 #if NK2AI_TRACE_LEVEL >= 2
 			logAi->trace("GatherArmyBehavior::deliverArmyToHero Army value is too small.");

--- a/AI/Nullkiller2/Behaviors/GatherArmyBehavior.cpp
+++ b/AI/Nullkiller2/Behaviors/GatherArmyBehavior.cpp
@@ -232,7 +232,8 @@ Goals::TGoalVec GatherArmyBehavior::upgradeArmy(const Nullkiller * aiNk, const C
 	for(const AIPath & path : paths)
 	{
 		auto heroRole = aiNk->heroManager->getHeroRoleOrDefaultInefficient(path.targetHero);
-		if(heroRole == HeroRole::MAIN && path.turn() < aiNk->settings->getScoutHeroTurnDistanceLimit())
+		if((heroRole == HeroRole::MAIN || aiNk->heroManager->isMeaningfulArmyCarrier(path.targetHero))
+			&& path.turn() < aiNk->settings->getScoutHeroTurnDistanceLimit())
 		{
 			hasMainAround = true;
 			break;
@@ -282,7 +283,10 @@ Goals::TGoalVec GatherArmyBehavior::upgradeArmy(const Nullkiller * aiNk, const C
 		}
 
 		auto upgrade = aiNk->armyManager->calculateCreaturesUpgrade(path.heroArmy, upgrader, availableResources);
-		if(!upgrader->getGarrisonHero() && (hasMainAround || aiNk->heroManager->getHeroRoleOrDefaultInefficient(path.targetHero) == HeroRole::MAIN))
+		if(!upgrader->getGarrisonHero()
+			&& (hasMainAround
+				|| aiNk->heroManager->getHeroRoleOrDefaultInefficient(path.targetHero) == HeroRole::MAIN
+				|| aiNk->heroManager->isMeaningfulArmyCarrier(path.targetHero)))
 		{
 			ArmyUpgradeInfo armyToGetOrBuy;
 			armyToGetOrBuy.addArmyToGet(aiNk->armyManager->getBestArmy(path.targetHero, path.heroArmy, upgrader->getUpperArmy(), TerrainId::NONE));

--- a/AI/Nullkiller2/Behaviors/GatherArmyBehavior.cpp
+++ b/AI/Nullkiller2/Behaviors/GatherArmyBehavior.cpp
@@ -380,6 +380,7 @@ Goals::TGoalVec GatherArmyBehavior::upgradeArmy(const Nullkiller * aiNk, const C
 					{
 						Composition recruitHero;
 						recruitHero.addNext(ArmyUpgrade(path.targetHero, town, armyToGetOrBuy)).addNext(RecruitHero(upgrader, hero));
+						tasks.push_back(sptr(recruitHero));
 					}
 				}
 			}

--- a/AI/Nullkiller2/Behaviors/GatherArmyBehavior.cpp
+++ b/AI/Nullkiller2/Behaviors/GatherArmyBehavior.cpp
@@ -44,6 +44,7 @@ Goals::TGoalVec GatherArmyBehavior::decompose(const Nullkiller * aiNk) const
 		if(aiNk->heroManager->getHeroRoleOrDefaultInefficient(hero) == HeroRole::MAIN)
 		{
 			vstd::concatenate(tasks, deliverArmyToHero(aiNk, hero));
+			vstd::concatenate(tasks, collectArmyFromNearbyScouts(aiNk, hero));
 		}
 	}
 
@@ -202,6 +203,76 @@ Goals::TGoalVec GatherArmyBehavior::deliverArmyToHero(const Nullkiller * aiNk, c
 				composition.addNext(subGoal);
 			}
 
+			tasks.push_back(sptr(composition));
+		}
+	}
+
+	return tasks;
+}
+
+Goals::TGoalVec GatherArmyBehavior::collectArmyFromNearbyScouts(const Nullkiller * aiNk, const CGHeroInstance * receiverHero) const
+{
+	Goals::TGoalVec tasks;
+	constexpr float maxMainMovementCost = 0.5f;
+	const auto targetHeroScore = aiNk->heroManager->evaluateHero(receiverHero);
+
+	for(const auto * scout : aiNk->cc->getHeroesInfo())
+	{
+		if(scout == receiverHero)
+			continue;
+		if(scout->getOwner() != aiNk->playerID)
+			continue;
+		if(aiNk->heroManager->getHeroRoleOrDefaultInefficient(scout) != HeroRole::SCOUT)
+			continue;
+		if(!aiNk->heroManager->isMeaningfulArmyCarrier(scout))
+			continue;
+
+		auto paths = aiNk->pathfinder->getPathInfo(scout->visitablePos(), aiNk->isObjectGraphAllowed());
+		for(const auto & path : paths)
+		{
+			if(path.targetHero != receiverHero)
+				continue;
+			if(path.movementCost() > maxMainMovementCost)
+				continue;
+			if(path.getFirstBlockedAction())
+				continue;
+			if(aiNk->getHeroLockedReason(receiverHero) != HeroLockedReason::NOT_LOCKED)
+				continue;
+
+			const uint64_t additionalArmyStrength = aiNk->armyManager->howManyReinforcementsCanGet(receiverHero, scout);
+			const uint64_t exchangeValue = additionalArmyStrength;
+			const float additionalArmyRatio = static_cast<float>(exchangeValue) / std::max<uint64_t>(1, receiverHero->getArmyStrength());
+
+			if((additionalArmyRatio < 0.1f && exchangeValue < 20000) || exchangeValue < 500)
+				continue;
+
+			bool hasOtherMainInPath = false;
+			for(const auto & node : path.nodes)
+			{
+				if(!node.targetHero || node.targetHero == receiverHero)
+					continue;
+
+				if(aiNk->heroManager->getHeroRoleOrDefaultInefficient(node.targetHero) == MAIN
+					&& aiNk->heroManager->evaluateHero(node.targetHero) >= targetHeroScore)
+				{
+					hasOtherMainInPath = true;
+					break;
+				}
+			}
+
+			if(hasOtherMainInPath)
+				continue;
+
+			const auto danger = path.getTotalDanger();
+			if(!isSafeToVisit(receiverHero, path.heroArmy, danger, aiNk->settings->getSafeAttackRatio()))
+				continue;
+
+			Composition composition;
+			HeroExchange heroExchange(receiverHero, path, additionalArmyStrength);
+			ExecuteHeroChain exchangePath(path, scout, false);
+			exchangePath.closestWayRatio = 1;
+			composition.addNext(heroExchange);
+			composition.addNext(exchangePath);
 			tasks.push_back(sptr(composition));
 		}
 	}

--- a/AI/Nullkiller2/Behaviors/GatherArmyBehavior.cpp
+++ b/AI/Nullkiller2/Behaviors/GatherArmyBehavior.cpp
@@ -158,7 +158,7 @@ Goals::TGoalVec GatherArmyBehavior::deliverArmyToHero(const Nullkiller * aiNk, c
 		if(isSafe)
 		{
 			Composition composition;
-			ExecuteHeroChain exchangePath(path, receiverHero);
+			ExecuteHeroChain exchangePath(path, receiverHero, false);
 			exchangePath.closestWayRatio = 1;
 			composition.addNext(heroExchange);
 

--- a/AI/Nullkiller2/Behaviors/GatherArmyBehavior.h
+++ b/AI/Nullkiller2/Behaviors/GatherArmyBehavior.h
@@ -35,6 +35,7 @@ namespace Goals
 
 	private:
 		TGoalVec deliverArmyToHero(const Nullkiller * aiNk, const CGHeroInstance * receiverHero) const;
+		TGoalVec collectArmyFromNearbyScouts(const Nullkiller * aiNk, const CGHeroInstance * receiverHero) const;
 		TGoalVec upgradeArmy(const Nullkiller * aiNk, const CGTownInstance * upgrader) const;
 	};
 }

--- a/AI/Nullkiller2/Engine/FuzzyHelper.cpp
+++ b/AI/Nullkiller2/Engine/FuzzyHelper.cpp
@@ -129,6 +129,10 @@ ui64 FuzzyHelper::evaluateDanger(const CGObjectInstance * obj)
 	}
 	default:
 	{
+		InfoAboutRewardableObject rewardableInfo;
+		if(aiNk->cc->getRewardableObjectInfo(obj, rewardableInfo) && (rewardableInfo.scouted || rewardableInfo.guardStrength > 0))
+			return rewardableInfo.guardStrength;
+
 		const CArmedInstance * a = dynamic_cast<const CArmedInstance *>(obj);
 		if (a)
 			return a->getArmyStrength();

--- a/AI/Nullkiller2/Engine/Nullkiller.cpp
+++ b/AI/Nullkiller2/Engine/Nullkiller.cpp
@@ -682,6 +682,8 @@ void Nullkiller::makeTurn()
 					return;
 				}
 				hasAnySuccess = true;
+				if(selectedTask->getHeroExchangeCount() > 1)
+					break;
 			}
 		}
 

--- a/AI/Nullkiller2/Engine/Nullkiller.cpp
+++ b/AI/Nullkiller2/Engine/Nullkiller.cpp
@@ -661,6 +661,9 @@ void Nullkiller::makeTurn()
 			}
 			else
 			{
+				for(const auto * hero : getTaskHeroes(selectedTask))
+					logAi->info("Hero %s selected task: %s", hero->getNameTranslated(), selectedTask->toString());
+
 				if(!executeTask(selectedTask))
 				{
 					lockTaskHeroes(selectedTask, HeroLockedReason::HERO_CHAIN);

--- a/AI/Nullkiller2/Engine/Nullkiller.cpp
+++ b/AI/Nullkiller2/Engine/Nullkiller.cpp
@@ -690,7 +690,8 @@ void Nullkiller::makeTurn()
 		hasAnySuccess |= ResourceTrader::trade(*buildAnalyzer, *cc, getFreeResources());
 		if(!hasAnySuccess)
 		{
-			logAi->trace("Nothing was done this turn pass. Ending turn.");
+			const bool builtAtEnd = executeEndTurnBuildingPass(pass);
+			logAi->trace(builtAtEnd ? "Only end-turn building was done this pass. Ending turn." : "Nothing was done this turn pass. Ending turn.");
 			tracePlayerStatus(false);
 			return;
 		}
@@ -699,7 +700,10 @@ void Nullkiller::makeTurn()
 			AIGateway::pickBestArtifacts(cc, heroInfo);
 
 		if(pass == settings->getMaxPass())
+		{
+			executeEndTurnBuildingPass(pass);
 			logAi->warn("MaxPass reached. Terminating AI turn.");
+		}
 	}
 }
 
@@ -716,7 +720,8 @@ bool Nullkiller::updateStateAndExecutePriorityPass(Goals::TGoalVec & tempResults
 		decompose(tempResults, sptr(RecruitHeroBehavior()), 1);
 		// TODO: Mircea: Should merge recruiting from DefenseBehavior
 		decompose(tempResults, sptr(BuyArmyBehavior()), 1);
-		decompose(tempResults, sptr(BuildingBehavior()), 1);
+		if(cc->getCalendar().getCurrentDay() == 1)
+			decompose(tempResults, sptr(BuildingBehavior()), 1);
 
 		bestPrioPassTask = choseBestTask(tempResults);
 
@@ -749,6 +754,37 @@ bool Nullkiller::updateStateAndExecutePriorityPass(Goals::TGoalVec & tempResults
 		}
 	}
 	return true;
+}
+
+bool Nullkiller::executeEndTurnBuildingPass(const int passIndex)
+{
+	bool hasAnySuccess = false;
+	Goals::TGoalVec buildingTasks;
+
+	updateState();
+
+	for(int i = 1; i <= settings->getMaxPriorityPass() && cc->getPlayerStatus(playerID) == EPlayerStatus::INGAME; i++)
+	{
+		buildingTasks.clear();
+		decompose(buildingTasks, sptr(BuildingBehavior()), 1);
+
+		auto buildTask = choseBestTask(buildingTasks);
+		if(buildTask->priority <= 0)
+			break;
+
+		logAi->info("Pass %d: endTurnBuildPass %d: Performing task %s with prio: %d", passIndex, i, buildTask->toString(), buildTask->priority);
+
+		if(!executeTask(buildTask))
+		{
+			logAi->warn("Building task failed during end-turn building pass.");
+			break;
+		}
+
+		hasAnySuccess = true;
+		updateState();
+	}
+
+	return hasAnySuccess;
 }
 
 bool Nullkiller::areAffectedObjectsPresent(const Goals::TTask & task) const

--- a/AI/Nullkiller2/Engine/Nullkiller.cpp
+++ b/AI/Nullkiller2/Engine/Nullkiller.cpp
@@ -26,6 +26,7 @@
 #include "../Behaviors/GatherArmyBehavior.h"
 #include "../Behaviors/RecruitHeroBehavior.h"
 #include "../Behaviors/StayAtTownBehavior.h"
+#include "../Goals/Composition.h"
 #include "../Goals/Invalid.h"
 #include "Goals/RecruitHero.h"
 #include "ResourceTrader.h"
@@ -682,6 +683,9 @@ void Nullkiller::makeTurn()
 					return;
 				}
 				hasAnySuccess = true;
+				if(const auto * composition = dynamic_cast<const Composition *>(selectedTask.get());
+					composition && composition->containsGoalType(Goals::UNLOCK_CLUSTER))
+					break;
 				if(selectedTask->getHeroExchangeCount() > 1)
 					break;
 			}

--- a/AI/Nullkiller2/Engine/Nullkiller.cpp
+++ b/AI/Nullkiller2/Engine/Nullkiller.cpp
@@ -293,6 +293,11 @@ void Nullkiller::updateState()
 	buildAnalyzer->update();
 	methodToElapsedMs.emplace("buildAnalyzer->update", timeElapsed(startMethod));
 
+	startMethod = std::chrono::high_resolution_clock::now();
+	makingTurnInterruption.interruptionPoint();
+	heroManager->update();
+	methodToElapsedMs.emplace("heroManager->update()", timeElapsed(startMethod));
+
 	if(!pathfinderInvalidated && dangerHitMap->isHitMapUpToDate() && dangerHitMap->isTileOwnersUpToDate())
 		logAi->trace("Skipping full state regeneration - up to date");
 	else
@@ -306,11 +311,6 @@ void Nullkiller::updateState()
 		startMethod = std::chrono::high_resolution_clock::now();
 		dangerHitMap->calculateTileOwners();
 		methodToElapsedMs.emplace("dangerHitMap->calculateTileOwners()", timeElapsed(startMethod));
-
-		startMethod = std::chrono::high_resolution_clock::now();
-		makingTurnInterruption.interruptionPoint();
-		heroManager->update();
-		methodToElapsedMs.emplace("heroManager->update()", timeElapsed(startMethod));
 
 		logAi->trace("Updating paths");
 		PathfinderSettings cfg;

--- a/AI/Nullkiller2/Engine/Nullkiller.h
+++ b/AI/Nullkiller2/Engine/Nullkiller.h
@@ -151,6 +151,7 @@ private:
 	void resetState();
 	void updateState();
 	void reserveRequiredTownDefenders();
+	bool executeEndTurnBuildingPass(int passIndex);
 	const CGHeroInstance * findRequiredTownDefender(const CGTownInstance * town) const;
 	void decompose(Goals::TGoalVec & results, const Goals::TSubgoal& behavior, int decompositionMaxDepth) const;
 	Goals::TTask choseBestTask(Goals::TGoalVec & tasks) const;

--- a/AI/Nullkiller2/Engine/PriorityEvaluator.cpp
+++ b/AI/Nullkiller2/Engine/PriorityEvaluator.cpp
@@ -66,6 +66,33 @@ float evaluateMaxArmyLossForConquest(float baseMaxArmyLoss, float conquestValue,
 	return std::min(baseMaxArmyLoss + conquestPressure, 0.75f);
 }
 
+static float computeResourceRequirementStrength(const Nullkiller * aiNk, GameResID resType, TResource missingAmount, TResource dailyIncome, float noIncomeBaseStrength)
+{
+	assert(missingAmount > 0);
+
+	TResources missingResources;
+	missingResources[resType] = missingAmount;
+
+	const auto missingMarketValue = missingResources.marketValue();
+	const auto currentStock = aiNk->getFreeResources()[resType];
+
+	float strength = dailyIncome == 0 ? noIncomeBaseStrength : 0.5f;
+
+	// Use market value so rare resources and gold shortages scale on the same axis.
+	if(missingMarketValue >= 500)
+		strength += 0.10f;
+	if(missingMarketValue >= 1500)
+		strength += 0.15f;
+	if(missingMarketValue >= 3000)
+		strength += 0.15f;
+
+	// Wood and ore depletion blocks early and mid-game town development
+	if((resType == GameResID::WOOD || resType == GameResID::ORE) && currentStock == 0)
+		strength += 0.25f;
+
+	return std::min(1.5f, strength);
+}
+
 EvaluationContext::EvaluationContext(const Nullkiller* aiNk)
 	: movementCost(0.0),
 	manaCost(0),
@@ -90,6 +117,7 @@ EvaluationContext::EvaluationContext(const Nullkiller* aiNk)
 	isDefend(false),
 	threatTurns(INT_MAX),
 	involvesSailing(false),
+	requiresBattle(false),
 	isTradeBuilding(false),
 	isExchange(false),
 	isArmyUpgrade(false),
@@ -408,10 +436,7 @@ float RewardEvaluator::getNowResourceRequirementStrength(GameResID resType) cons
 	if(requiredResources[resType] == 0)
 		return 0;
 
-	if(dailyIncome[resType] == 0)
-		return 1.0f;
-
-	return 0.8f;
+	return computeResourceRequirementStrength(aiNk, resType, requiredResources[resType], dailyIncome[resType], 0.8f);
 }
 
 /// @return between 0-1.0f
@@ -423,10 +448,7 @@ float RewardEvaluator::getTotalResourceRequirementStrength(GameResID resType) co
 	if(requiredResources[resType] == 0)
 		return 0;
 
-	if(dailyIncome[resType] == 0)
-		return 1.0f;
-
-	return 0.8f;
+	return computeResourceRequirementStrength(aiNk, resType, requiredResources[resType], dailyIncome[resType], 0.7f);
 }
 
 uint64_t RewardEvaluator::townArmyGrowth(const CGTownInstance * town) const
@@ -461,7 +483,7 @@ float RewardEvaluator::getCombinedResourceRequirementStrength(const TResources &
 			+ 0.5f * getTotalResourceRequirementStrength(it->resType);
 
 		// Even not required resources should be valuable because they shouldn't be left for the enemies to collect
-		sum += std::min(MINIMUM_STRATEGICAL_VALUE_NON_TOWN, calculation);
+		sum += std::max(MINIMUM_STRATEGICAL_VALUE_NON_TOWN, calculation);
 	}
 
 	return sum;
@@ -1026,6 +1048,7 @@ public:
 			return;
 
 		vstd::amax(evaluationContext.danger, path.getTotalDanger());
+		evaluationContext.requiresBattle = evaluationContext.requiresBattle || path.requiresBattle();
 		evaluationContext.movementCost += path.movementCost();
 		evaluationContext.closestWayRatio = chain.closestWayRatio;
 
@@ -1437,6 +1460,20 @@ float PriorityEvaluator::evaluateConquestValue(float score, const float conquest
 float PriorityEvaluator::evaluate(Goals::TSubgoal task, int priorityTier)
 {
 	auto evaluationContext = buildEvaluationContext(task);
+	const auto * targetObject = task->objid >= 0 ? aiNk->cc->getObj(ObjectInstanceID(task->objid), false) : nullptr;
+	std::optional<GameResID> targetResourceType;
+
+	// Loose resources and mines satisfy the same build shortage pressure
+	if(targetObject && targetObject->ID == Obj::RESOURCE)
+	{
+		if(auto resource = dynamic_cast<const CGResource *>(targetObject))
+			targetResourceType = resource->resourceID();
+	}
+	else if(targetObject && (targetObject->ID == Obj::MINE || targetObject->ID == Obj::ABANDONED_MINE))
+	{
+		if(auto mine = dynamic_cast<const CGMine *>(targetObject))
+			targetResourceType = mine->producedResource;
+	}
 
 	const bool amIWithoutCastle = aiNk->cc->getPlayerState(aiNk->playerID)->daysWithoutCastle.has_value();
 	double result = 0;
@@ -1622,7 +1659,7 @@ float PriorityEvaluator::evaluate(Goals::TSubgoal task, int priorityTier)
 				//    && ((evaluationContext.enemyHeroDangerRatio > 0 && arriveNextWeek) || evaluationContext.enemyHeroDangerRatio > involvedStrengthOutOfTotalRatio))
 				// 	return 0;
 
-				const auto requiresBattle = evaluationContext.armyLossRatio > 0 || evaluationContext.danger > 0;
+				const auto requiresBattle = evaluationContext.requiresBattle || evaluationContext.armyLossRatio > 0;
 				score += evaluationContext.strategicalValue * 1000;
 				if(evaluationContext.explorePriority > 0)
 				{
@@ -1640,8 +1677,54 @@ float PriorityEvaluator::evaluate(Goals::TSubgoal task, int priorityTier)
 
 					if(evaluationContext.heroRole == MAIN)
 					{
+						bool scoutCanReachResourceThisTurn = false;
+						if(!requiresBattle && targetResourceType.has_value())
+						{
+							const auto targetTile = targetObject->visitablePos();
+
+							// Only same-turn SCOUT pickup is certain enough to make MAIN abandon this target.
+							for(const auto * hero : aiNk->cc->getHeroesInfo())
+							{
+								if(hero == task->hero)
+									continue;
+								if(aiNk->getHeroLockedReason(hero) != HeroLockedReason::NOT_LOCKED)
+									continue;
+								if(aiNk->heroManager->getHeroRoleOrDefaultInefficient(hero) != HeroRole::SCOUT)
+									continue;
+
+								auto paths = aiNk->getPathsInfo(hero);
+								if(!paths)
+									continue;
+
+								auto pathNode = paths->getPathInfo(targetTile);
+								if(pathNode->reachable() && pathNode->turns == 0)
+								{
+									scoutCanReachResourceThisTurn = true;
+									break;
+								}
+							}
+						}
+
+						if(scoutCanReachResourceThisTurn)
+						{
+							logAi->trace(
+								"priorityTier %d, MAIN yields %s at %s because a SCOUT can reach it this turn",
+								priorityTier,
+								targetObject->getObjectName(),
+								targetObject->visitablePos().toString());
+							return 0;
+						}
+
 						if(requiresBattle)
 							// Encourage MAIN to fight for crypts and similar
+							score *= 2;
+						else if(targetResourceType.has_value()
+							&& aiNk->buildAnalyzer->getMissingResourcesNow()[*targetResourceType] > 0
+							&& ((*targetResourceType == GameResID::GOLD
+								&& aiNk->getFreeResources()[*targetResourceType] < GameConstants::HERO_GOLD_COST
+								&& aiNk->buildAnalyzer->isGoldPressureOverMax())
+								|| (*targetResourceType != GameResID::GOLD && aiNk->getFreeResources()[*targetResourceType] == 0)))
+							// Critical no-battle resources are still worth MAIN movement if waiting blocks builds or hero hiring.
 							score *= 2;
 						else
 							// Discourage MAIN to waste time picking resources if they don't require a fight

--- a/AI/Nullkiller2/Engine/PriorityEvaluator.cpp
+++ b/AI/Nullkiller2/Engine/PriorityEvaluator.cpp
@@ -1748,6 +1748,26 @@ float PriorityEvaluator::evaluate(Goals::TSubgoal task, int priorityTier)
 
 				const bool isTreasureChest = targetObject && targetObject->ID == Obj::TREASURE_CHEST;
 				const bool isRewardable = targetObject && dynamic_cast<const Rewardable::Interface *>(targetObject);
+				const std::string tempLogHero = task->hero ? firstHeroWord(task->hero) : "<no-hero> ("+ task->toString() +")";
+				const std::string tempLogRole = evaluationContext.heroRole == MAIN ? "MAIN" : "SCOUT";
+				const std::string tempLogTarget = targetObject ? targetObject->getObjectName() : "<no-target> ("+ task->toString() +")";
+				const std::string tempLogTargetPos = targetObject ? targetObject->visitablePos().toString() : task->tile.toString();
+				const std::string tempLogBattleReason = targetRequiresBattle ? "target requires battle" : "path/army loss is not target guard";
+				const std::string tempLogBase = "TEMP_LOG hero=" + tempLogHero + " role= " + tempLogRole + "targetObj= " + tempLogTarget + " at " + tempLogTargetPos + " ";
+
+				const auto tempLogScore = [&](const std::string & stage, float before, float after)
+				{
+#if NK2AI_TRACE_LEVEL >= 2
+					if(before != after && after > 500)
+						logAi->trace(tempLogBase + "stage=" + stage
+							+ " scoreBefore=" + std::to_string(before)
+							+ " scoreAfter=" + std::to_string(after));
+#else
+					(void)stage;
+					(void)before;
+					(void)after;
+#endif
+				};
 
 				const auto mainReachableWithinOneTurn = [&]() -> bool
 				{
@@ -1773,7 +1793,9 @@ float PriorityEvaluator::evaluate(Goals::TSubgoal task, int priorityTier)
 					return false;
 				};
 
+				float tempLogBefore = score;
 				score += evaluationContext.strategicalValue * 1000;
+				tempLogScore("strategical", tempLogBefore, score);
 				if(evaluationContext.explorePriority > 0)
 				{
 					if(!targetObject
@@ -1783,14 +1805,19 @@ float PriorityEvaluator::evaluate(Goals::TSubgoal task, int priorityTier)
 						&& meaningfulArmyCarrier
 						&& mainReachableWithinOneTurn())
 					{
+#if NK2AI_TRACE_LEVEL >= 2
+						logAi->trace(tempLogBase + " rejects exploration because hero can deliver army within one turn");
+#endif
 						return 0;
 					}
 
+					tempLogBefore = score;
 					score += 100.0f / evaluationContext.explorePriority;
 
 					// Encourage exploration for MAIN that requires battles, so SCOUTs can continue exploring
 					if(evaluationContext.heroRole == MAIN && hasAnyBattle)
 						score *= 2;
+					tempLogScore("explorePriority", tempLogBefore, score);
 				}
 
 				if(evaluationContext.goldReward > 0)
@@ -1814,6 +1841,10 @@ float PriorityEvaluator::evaluate(Goals::TSubgoal task, int priorityTier)
 					};
 					if(targetObject && (evaluationContext.heroRole == MAIN || meaningfulArmyCarrier || isTreasureChest))
 					{
+						const std::string tempLogResourceStock = targetResourceType.has_value()
+							? ", stock of target resource=" + std::to_string(freeResources[*targetResourceType])
+							: ", free resources=" + freeResources.toString();
+
 							bool scoutCanReachThisTurn = false;
 							bool mainCanReachSoon = false;
 							const auto targetTile = targetObject->visitablePos();
@@ -1879,8 +1910,10 @@ float PriorityEvaluator::evaluate(Goals::TSubgoal task, int priorityTier)
 						}
 
 						// try to balance other resources vs gold, especially 2500 gold treasures
+						tempLogBefore = score;
 						float multiplier = targetGivesCriticalResource ? 3.0f : 1.0f;
 						score += evaluationContext.goldReward > 500 ? evaluationContext.goldReward / 2.0f * multiplier : evaluationContext.goldReward * 2.0f * multiplier;
+						tempLogScore("goldReward", tempLogBefore, score);
 
 						if(evaluationContext.heroRole != MAIN)
 						{
@@ -1893,14 +1926,25 @@ float PriorityEvaluator::evaluate(Goals::TSubgoal task, int priorityTier)
 								const bool enemyTownIsCloser = closestTownOwner.isValidPlayer()
 									&& aiNk->cc->getPlayerRelations(aiNk->playerID, closestTownOwner) == PlayerRelations::ENEMIES;
 
+								tempLogBefore = score;
 								if(!mainCanReachSoon || (enemyCanReachSoon || enemyTownIsCloser))
+								{
 									score *= 4;
+									tempLogScore("MAIN can't reach soon or enemy is closer", tempLogBefore, score);
+								}
 								if(isTreasureChest && mainCanReachSoon && !weakSailingScoutCollector)
+								{
+#if NK2AI_TRACE_LEVEL >= 2
+									logAi->trace(tempLogBase + " rejects non-critical chest because MAIN can reach soon");
+#endif
 									return 0;
+								}
 							}
 							else
 							{
+								tempLogBefore = score;
 								score *= 5;
+								tempLogScore("reward is critical or not weekly-blocked - multiplier = 5", tempLogBefore, score);
 							}
 						}
 						else
@@ -1909,18 +1953,37 @@ float PriorityEvaluator::evaluate(Goals::TSubgoal task, int priorityTier)
 							if(targetRequiresBattle || (evaluationContext.involvesSailing && isRewardable) || (targetGivesCriticalResource && !scoutCanReachThisTurn))
 							{
 								// Encourage MAIN to fight for crypts and similar + sailing rewardables + critical no-battle resources (still worth MAIN movement)
+								tempLogBefore = score;
 								score *= 2;
+								tempLogScore("because "+ tempLogBattleReason + " multiplier = 2", tempLogBefore, score);
 							}
 							else if(scoutCanReachThisTurn && !isTreasureChest)
+							{
+#if NK2AI_TRACE_LEVEL >= 2
+								logAi->trace(tempLogBase + " rejects resource because a SCOUT can reach it this turn");
+#endif
 								return 0;
+							}
 							else if(meaningfulArmyCarrier && isWeeklyRevisitable(aiNk->playerID, targetObject))
+							{
+								tempLogBefore = score;
 								score *= 0.1;
+								tempLogScore("skip non-critical weekly reward - multiplier = 0.1", tempLogBefore, score);
+							}
 							else
 							{
 								if(isTreasureChest)
+								{
+									tempLogBefore = score;
 									score *= 3;
+									tempLogScore("treasure chest - MAIN wants exp! multiplier = 3", tempLogBefore, score);
+								}
 								else
+								{
+									tempLogBefore = score;
 									score *= 0.33;
+									tempLogScore("reward is not critical "+ tempLogResourceStock + " multiplier = 0.33", tempLogBefore, score);
+								}
 							}
 						}
 					}
@@ -1928,30 +1991,68 @@ float PriorityEvaluator::evaluate(Goals::TSubgoal task, int priorityTier)
 
 				if(evaluationContext.skillReward > 0)
 				{
+					tempLogBefore = score;
 					if(targetObject && !hasAnyBattle)
+					{
+						tempLogBefore = score;
 						score += evaluationContext.skillReward * (evaluationContext.heroRole == MAIN ? 1000.0f : 200.0f);
+						tempLogScore("skill reward (has no battle): + "+ std::to_string(evaluationContext.skillReward) + " * "+ std::to_string(evaluationContext.heroRole == MAIN ? 1000.0f : 200.0f), tempLogBefore, score);
+					}
 					else
+					{
+						tempLogBefore = score;
 						score = 1000 + evaluateSkillReward(score, evaluationContext.skillReward, evaluationContext.armyLossRatio);
+						tempLogScore("skill reward (has battle !!!) - multiplier = "+ std::to_string(evaluationContext.skillReward) + " * 1000", tempLogBefore, score);
+					}
 					score *= evaluationContext.heroRole == SCOUT ? 0.2f : 2.0f;
 				}
 
+				tempLogBefore = score;
 				score += evaluationContext.heroRole == MAIN ? evaluationContext.armyReward : evaluationContext.armyReward / 2.0f;
+				tempLogScore("armyReward", tempLogBefore, score);
 				// workshop (free lvl 1 units for Tower) and similar dwellings receive both armyReward and armyGrowth in evaluationContext
 				// For that reason only getDwellingArmyGrowth gets amplified towards day 7 if units are lost after
 				// Hero exchange and army upgrade are using this too
+				tempLogBefore = score;
 				score += evaluationContext.armyGrowth;
+				tempLogScore("armyGrowth", tempLogBefore, score);
 
 				if(evaluationContext.goldCost > 0)
+				{
+					tempLogBefore = score;
 					score -= evaluationContext.goldCost / 4.0f; // don't include the full cost of School of Magic or others because those locations are beneficial
+					tempLogScore("goldCost - multiplier = 0.25", tempLogBefore, score);
+				}
 				if(evaluationContext.routeAnchorBonus > 0)
+				{
+					tempLogBefore = score;
 					score += evaluationContext.routeAnchorBonus;
+					tempLogScore("routeAnchorBonus= " + std::to_string(evaluationContext.routeAnchorBonus), tempLogBefore, score);
+				}
 				if(weakSailingScoutCollector)
+				{
+					tempLogBefore = score;
 					score += 4000;
+					tempLogScore("weak sailing scout cleanup", tempLogBefore, score);
+				}
+				tempLogBefore = score;
 				score = evaluateArmyLossRatio(score, evaluationContext.armyLossRatio, evaluationContext.heroRole);
+				tempLogScore("armyLossRatio", tempLogBefore, score);
 
+				tempLogBefore = score;
 				score *= evaluationContext.closestWayRatio;
+				tempLogScore("closestWayRatio - multiplier " + std::to_string(evaluationContext.closestWayRatio), tempLogBefore, score);
 				if(!(evaluationContext.explorePriority > 0 && !targetObject && evaluationContext.movementCost < 1.0f))
+				{
+					tempLogBefore = score;
 					score = evaluateMovement(score, evaluationContext.movementCost);
+					tempLogScore("movement", tempLogBefore, score);
+				}
+
+#if NK2AI_TRACE_LEVEL >= 1
+				if(score > 500)
+					logAi->trace("\t\t" + tempLogBase + " - Final score = %f", score);
+#endif
 				break;
 			}
 			case DEFEND: //Defend whatever if nothing else is to do

--- a/AI/Nullkiller2/Engine/PriorityEvaluator.cpp
+++ b/AI/Nullkiller2/Engine/PriorityEvaluator.cpp
@@ -11,6 +11,7 @@
 #include <limits>
 
 #include "Nullkiller.h"
+#include "../AIUtility.h"
 #include "../../../lib/entities/artifact/CArtifact.h"
 #include "../../../lib/entities/ResourceTypeHandler.h"
 #include "../../../lib/mapObjects/CGResource.h"
@@ -66,6 +67,12 @@ float evaluateMaxArmyLossForConquest(float baseMaxArmyLoss, float conquestValue,
 	return std::min(baseMaxArmyLoss + conquestPressure, 0.75f);
 }
 
+static std::string firstHeroWord(const CGHeroInstance * hero)
+{
+	auto name = hero->getNameTranslated();
+	return name.substr(0, name.find(' '));
+}
+
 static float computeResourceRequirementStrength(const Nullkiller * aiNk, GameResID resType, TResource missingAmount, TResource dailyIncome, float noIncomeBaseStrength)
 {
 	assert(missingAmount > 0);
@@ -104,6 +111,8 @@ EvaluationContext::EvaluationContext(const Nullkiller* aiNk)
 	goldCost(0),
 	armyReward(0),
 	armyLossRatio(0),
+	armyLoss(0),
+	targetObjectArmyLoss(0),
 	heroRole(HeroRole::SCOUT),
 	turn(0),
 	strategicalValue(0),
@@ -118,13 +127,17 @@ EvaluationContext::EvaluationContext(const Nullkiller* aiNk)
 	threatTurns(INT_MAX),
 	involvesSailing(false),
 	requiresBattle(false),
+	targetRequiresBattle(false),
 	isTradeBuilding(false),
 	isExchange(false),
 	isArmyUpgrade(false),
 	isHero(false),
 	isEnemy(false),
+	canBeKilledByEnemy(false),
 	explorePriority(0),
-	powerRatio(0)
+	powerRatio(0),
+	routeAnchorBonus(0),
+	routeAnchorMovementCost(0)
 {
 }
 
@@ -191,28 +204,23 @@ int32_t getResourcesGoldReward(const TResources & res)
 	return result;
 }
 
-uint64_t getDwellingArmyValue(CCallback * cb, const CGObjectInstance * target, bool checkGold)
+static bool canAddDwellingCreature(const CCreatureSet * army, const CCreature * creature, TQuantity count)
 {
-	auto dwelling = dynamic_cast<const CGDwelling *>(target);
-	uint64_t score = 0;
+	if(!army || army->getSlotFor(creature).validSlot())
+		return true;
 
-	for(auto & creLevel : dwelling->creatures)
+	const auto newStackValue = (creature->getFullRecruitCost() * count).marketValue();
+	for(const auto & stack : army->Slots())
 	{
-		if(creLevel.first && creLevel.second.size())
-		{
-			auto creature = creLevel.second.back().toCreature();
-			auto creaturesAreFree = creature->getLevel() == 1;
-			if(!creaturesAreFree && checkGold && !cb->getResourceAmount().canAfford(creature->getFullRecruitCost() * creLevel.first))
-				continue;
-
-			score += creature->getAIValue() * creLevel.first;
-		}
+		const auto stackValue = (stack.second->getCreatureID().toCreature()->getFullRecruitCost() * stack.second->getCount()).marketValue();
+		if(newStackValue > stackValue)
+			return true;
 	}
 
-	return score;
+	return false;
 }
 
-uint64_t getDwellingArmyGrowth(CCallback * cb, const CGObjectInstance * target, PlayerColor myColor)
+uint64_t getDwellingArmyGrowth(CCallback * cb, const CGObjectInstance * target, const CCreatureSet * army, PlayerColor myColor)
 {
 	auto dwelling = dynamic_cast<const CGDwelling *>(target);
 	uint64_t score = 0;
@@ -225,6 +233,9 @@ uint64_t getDwellingArmyGrowth(CCallback * cb, const CGObjectInstance * target, 
 		if(creLevel.second.size())
 		{
 			auto creature = creLevel.second.back().toCreature();
+			if(!canAddDwellingCreature(army, creature, creature->getGrowth()))
+				continue;
+
 			score += creature->getAIValue() * creature->getGrowth();
 
 			// Increase priority towards the end of the week if units are lost afterwards
@@ -290,7 +301,7 @@ uint64_t RewardEvaluator::getArmyReward(
 	case Obj::CREATURE_GENERATOR2:
 	case Obj::CREATURE_GENERATOR3:
 	case Obj::CREATURE_GENERATOR4:
-		return getDwellingArmyValue(aiNk->cc.get(), target, checkGold);
+		return aiNk->armyManager->howManyReinforcementsCanBuy(army, dynamic_cast<const CGDwelling *>(target), aiNk->getFreeResources());
 	case Obj::SPELL_SCROLL:
 		return evaluateSpellScrollArmyValue(dynamic_cast<const CGArtifact *>(target)->getArtifactInstance()->getScrollSpellID());
 	case Obj::ARTIFACT:
@@ -370,7 +381,7 @@ uint64_t RewardEvaluator::getArmyGrowth(
 	case Obj::CREATURE_GENERATOR2:
 	case Obj::CREATURE_GENERATOR3:
 	case Obj::CREATURE_GENERATOR4:
-		return getDwellingArmyGrowth(aiNk->cc.get(), target, hero->getOwner());
+		return getDwellingArmyGrowth(aiNk->cc.get(), target, army, hero->getOwner());
 	case Obj::ARTIFACT:
 		// it is not supported now because hero will not sit in town on 7th day but later parts of legion may be counted as army growth as well.
 		return 0;
@@ -673,6 +684,10 @@ float RewardEvaluator::getSkillReward(const CGObjectInstance * target, const CGH
 		return 8;
 	case Obj::WITCH_HUT:
 		return evaluateWitchHutSkillScore(target, hero, role);
+	case Obj::TREASURE_CHEST:
+		// Chests are valued as gold; if gold is not critical, SCOUTs leave XP for MAIN heroes
+		// if they are around. When not - take gold
+		return 0;
 	case Obj::PANDORAS_BOX:
 		//Can contains experience, spells, or skills (only on custom maps)
 		return 2.5f;
@@ -720,7 +735,28 @@ float RewardEvaluator::getSkillReward(const CGObjectInstance * target, const CGH
 				}
 			}
 
+			if(role == HeroRole::SCOUT)
+			{
+				TResources cost = info.reward.resources;
+				cost.amin(0);
+				cost = -cost;
+
+				if(cost.nonZero())
+				{
+					const auto freeRes = aiNk->getFreeResources();
+
+					for(TResources::nziterator it(cost); it.valid(); it++)
+					{
+						const int multiplier = it->resType == GameResID::GOLD ? 10 : 3; // to upgrade a scout there has to be a lot of free resources
+						if(freeRes[it->resType] < it->resVal * multiplier)
+							return totalValue; // not rich enough to give reward for SCOUT
+					}
+				}
+			}
+
 			totalValue += info.reward.heroLevel * 4.0f;
+			totalValue += info.reward.heroExperience / 1000.0f;
+			totalValue += info.reward.movePoints / 1000.0f;
 		}
 
 		return totalValue;
@@ -829,13 +865,20 @@ public:
 		const auto giverHeroRole = evaluationContext.evaluator.aiNk->heroManager->getHeroRoleOrDefaultInefficient(heroExchange.exchangePath.targetHero);
 		// It's allowed for SCOUTs to receive from other SCOUTs, so all army gets in one place before delivery to main
 
-		// TODO: Mircea: See how we can get some kind of balance between MAINs in terms of army delivery
-		// See: GatherArmyBehavior::deliverArmyToHero
 		const uint64_t additionalArmyStrength = heroExchange.getReinforcementArmyStrength(evaluationContext.evaluator.aiNk);
-		const float additionalArmyRatio = additionalArmyStrength / heroExchange.hero->getArmyStrength();
+		const uint64_t artifactExchangeValue = heroExchange.getArtifactExchangeValue();
+		const uint64_t exchangeValue = additionalArmyStrength + artifactExchangeValue;
+		const auto receiverArmyStrength = heroExchange.hero->getArmyStrength();
+		const float additionalArmyRatio = receiverArmyStrength > 0 ? static_cast<float>(exchangeValue) / receiverArmyStrength : 0.0f;
+		const bool deliversArmyToMain = evaluationContext.evaluator.aiNk->heroManager->getHeroRoleOrDefaultInefficient(heroExchange.hero) == HeroRole::MAIN
+			&& evaluationContext.evaluator.aiNk->heroManager->isMeaningfulArmyCarrier(heroExchange.exchangePath.targetHero);
+		const bool boostDeliveryToMain = deliversArmyToMain
+			&& heroExchange.exchangePath.turn() < evaluationContext.evaluator.aiNk->settings->getScoutHeroTurnDistanceLimit();
 
 		evaluationContext.addNonCriticalStrategicalValue(additionalArmyRatio);
-		evaluationContext.armyGrowth = additionalArmyStrength;
+		evaluationContext.armyGrowth = exchangeValue;
+		if(boostDeliveryToMain)
+			evaluationContext.armyGrowth *= 5;
 		evaluationContext.movementCost = heroExchange.exchangePath.movementCost();
 		evaluationContext.danger = heroExchange.exchangePath.getTotalDanger();
 		evaluationContext.heroRole = giverHeroRole;
@@ -881,11 +924,11 @@ public:
 					case Obj::MONOLITH_ONE_WAY_ENTRANCE:
 					case Obj::MONOLITH_TWO_WAY:
 					case Obj::SUBTERRANEAN_GATE:
-						evaluationContext.explorePriority = 1;
-						break;
+					case Obj::BOAT:
+					case Obj::WHIRLPOOL:
 					case Obj::REDWOOD_OBSERVATORY:
 					case Obj::PILLAR_OF_FIRE:
-						evaluationContext.explorePriority = 2;
+						evaluationContext.explorePriority = 1;
 						break;
 					default:
 						logAi->warn("ExplorePointEvaluator buildEvaluationContext unknown exploration point %d", obj->ID.num);
@@ -893,8 +936,13 @@ public:
 			}
 
 			const TerrainTile * tile = evaluationContext.evaluator.aiNk->cc->getTile(task->tile, false);
-			if(tile && tile->roadType != RoadId::NO_ROAD)
-				evaluationContext.explorePriority = 1;
+			if(tile)
+			{
+				if(tile->roadType == RoadId::NO_ROAD)
+					evaluationContext.explorePriority = 1;
+				else
+					evaluationContext.explorePriority = 2;
+			}
 		}
 		if(evaluationContext.explorePriority == 0)
 		{
@@ -1044,12 +1092,20 @@ public:
 
 		Goals::ExecuteHeroChain & chain = dynamic_cast<Goals::ExecuteHeroChain &>(*task);
 		const AIPath & path = chain.getPath();
+		if(chain.getRouteAnchorBonus() > evaluationContext.routeAnchorBonus)
+		{
+			evaluationContext.routeAnchorBonus = chain.getRouteAnchorBonus();
+			evaluationContext.routeAnchorMovementCost = chain.getRouteAnchorMovementCost();
+		}
 
 		if (vstd::isAlmostZero(path.movementCost()))
 			return;
 
 		vstd::amax(evaluationContext.danger, path.getTotalDanger());
+		vstd::amax(evaluationContext.armyLoss, path.armyLoss);
+		vstd::amax(evaluationContext.targetObjectArmyLoss, path.targetObjectArmyLoss);
 		evaluationContext.requiresBattle = evaluationContext.requiresBattle || path.requiresBattle();
+		evaluationContext.targetRequiresBattle = evaluationContext.targetRequiresBattle || path.targetObjectArmyLoss > 0;
 		evaluationContext.movementCost += path.movementCost();
 		evaluationContext.closestWayRatio = chain.closestWayRatio;
 
@@ -1125,6 +1181,7 @@ public:
 
 		if (target)
 		{
+			// TODO: Move rewardable scoring to player-visible object info; direct rewardable reads leak cleared/scouted state.
 			evaluationContext.goldReward += evaluationContext.evaluator.getGoldReward(target, hero);
 			evaluationContext.armyReward += evaluationContext.evaluator.getArmyReward(target, hero, army, checkGold);
 			evaluationContext.armyGrowth += evaluationContext.evaluator.getArmyGrowth(target, hero, army);
@@ -1145,6 +1202,7 @@ public:
 
 		vstd::amax(evaluationContext.armyLossRatio, (float)path.getTotalArmyLoss() / (float)army->getArmyStrength());
 		addTileDanger(evaluationContext, path.targetTile(), path.turn(), path.getHeroStrength());
+		evaluationContext.canBeKilledByEnemy = evaluationContext.canBeKilledByEnemy || aiNk->dangerHitMap->enemyCanKillOurHeroesAlongThePath(path);
 		vstd::amax(evaluationContext.turn, path.turn());
 	}
 };
@@ -1164,6 +1222,17 @@ public:
 
 		auto hero = clusterGoal.hero;
 		auto role = evaluationContext.evaluator.aiNk->heroManager->getHeroRoleOrDefaultInefficient(hero);
+		const auto & pathToCenter = clusterGoal.getPathToCenter();
+
+		evaluationContext.movementCost += pathToCenter.movementCost();
+		evaluationContext.movementCostByRole[role] += pathToCenter.movementCost();
+		evaluationContext.requiresBattle = evaluationContext.requiresBattle || pathToCenter.requiresBattle();
+		evaluationContext.targetRequiresBattle = evaluationContext.targetRequiresBattle || pathToCenter.targetObjectArmyLoss > 0;
+		vstd::amax(evaluationContext.danger, pathToCenter.getTotalDanger());
+		vstd::amax(evaluationContext.armyLoss, pathToCenter.armyLoss);
+		vstd::amax(evaluationContext.targetObjectArmyLoss, pathToCenter.targetObjectArmyLoss);
+		vstd::amax(evaluationContext.armyLossRatio, static_cast<float>(pathToCenter.getTotalArmyLoss()) / static_cast<float>(hero->getArmyStrength()));
+		vstd::amax(evaluationContext.turn, pathToCenter.turn());
 
 		std::vector<std::pair<ObjectInstanceID, ClusterObjectInfo>> objects;
 		objects.reserve(cluster->objects.size());
@@ -1445,10 +1514,10 @@ float PriorityEvaluator::evaluateArmyLossRatio(float score, const float armyLoss
 	return score;
 }
 
-float PriorityEvaluator::evaluateSkillReward(float score, const float skillReward, const float armyInvolvement, const float armyLossRatio)
+float PriorityEvaluator::evaluateSkillReward(float score, const float skillReward, const float armyLossRatio)
 {
-	// Encourage stronger heroes
-	return score + skillReward * armyInvolvement * (1 - armyLossRatio) * 0.05;
+	// Keep skill rewards bounded and loss-aware.
+	return score + skillReward * 1000.0f * std::max(0.0f, 1.0f - armyLossRatio);
 }
 
 float PriorityEvaluator::evaluateConquestValue(float score, const float conquestValue, const float armyInvolvement)
@@ -1626,6 +1695,8 @@ float PriorityEvaluator::evaluate(Goals::TSubgoal task, int priorityTier)
 					return 0;
 				if(maxWillingToLoseForTask - evaluationContext.armyLossRatio < 0)
 					return 0;
+				if(evaluationContext.heroRole == SCOUT && evaluationContext.canBeKilledByEnemy)
+					return 0;
 
 				if(priorityTier == EXPLORE_AND_GATHER && evaluationContext.enemyHeroDangerRatio > maxEnemyDangerRatio)
 					return 0;
@@ -1660,37 +1731,116 @@ float PriorityEvaluator::evaluate(Goals::TSubgoal task, int priorityTier)
 				//    && ((evaluationContext.enemyHeroDangerRatio > 0 && arriveNextWeek) || evaluationContext.enemyHeroDangerRatio > involvedStrengthOutOfTotalRatio))
 				// 	return 0;
 
-				const auto requiresBattle = evaluationContext.requiresBattle || evaluationContext.armyLossRatio > 0;
+				const bool hasAnyBattle = evaluationContext.requiresBattle || evaluationContext.armyLossRatio > 0;
+				const bool targetRequiresBattle = evaluationContext.targetRequiresBattle;
+				const bool meaningfulArmyCarrier = task->hero && aiNk->heroManager->isMeaningfulArmyCarrier(task->hero);
+
+				const bool targetIsOnWater = targetObject && aiNk->cc->getTile(targetObject->visitablePos(), false)->isWater();
+				const bool weakSailingScoutCollector = task->hero
+					&& evaluationContext.heroRole == SCOUT
+					&& task->hero->inBoat()
+					&& !meaningfulArmyCarrier
+					&& targetObject
+					&& targetIsOnWater
+					&& evaluationContext.involvesSailing
+					&& !hasAnyBattle
+					&& !targetRequiresBattle;
+
+				const bool isTreasureChest = targetObject && targetObject->ID == Obj::TREASURE_CHEST;
+				const bool isRewardable = targetObject && dynamic_cast<const Rewardable::Interface *>(targetObject);
+
+				const auto mainReachableWithinOneTurn = [&]() -> bool
+				{
+					if(!task->hero)
+						return false;
+
+					const auto paths = aiNk->getPathsInfo(task->hero);
+					if(!paths)
+						return false;
+
+					for(const auto * hero : aiNk->cc->getHeroesInfo())
+					{
+						if(hero == task->hero)
+							continue;
+						if(aiNk->heroManager->getHeroRoleOrDefaultInefficient(hero) != HeroRole::MAIN)
+							continue;
+
+						const auto pathNode = paths->getPathInfo(hero->visitablePos());
+						if(pathNode->reachable() && pathNode->turns <= 1)
+							return true;
+					}
+
+					return false;
+				};
+
 				score += evaluationContext.strategicalValue * 1000;
 				if(evaluationContext.explorePriority > 0)
 				{
-					score = 600.0f / evaluationContext.explorePriority;
+					if(!targetObject
+						&& !hasAnyBattle
+						&& !evaluationContext.isExchange
+						&& evaluationContext.heroRole != MAIN
+						&& meaningfulArmyCarrier
+						&& mainReachableWithinOneTurn())
+					{
+						return 0;
+					}
+
+					score += 100.0f / evaluationContext.explorePriority;
 
 					// Encourage exploration for MAIN that requires battles, so SCOUTs can continue exploring
-					if(evaluationContext.heroRole == MAIN && requiresBattle)
+					if(evaluationContext.heroRole == MAIN && hasAnyBattle)
 						score *= 2;
 				}
 
 				if(evaluationContext.goldReward > 0)
 				{
-					// try to balance other resources vs gold, especially 2500 gold treasures
-					score += evaluationContext.goldReward > 500 ? evaluationContext.goldReward / 2.0f : evaluationContext.goldReward * 2.0f;
-
-					if(evaluationContext.heroRole == MAIN)
+					const auto freeResources = aiNk->getFreeResources();
+					const auto missingNow = aiNk->buildAnalyzer->getMissingResourcesNow();
+					const auto isCriticalRewardResource = [&](GameResID resType) -> bool
 					{
-						bool scoutCanReachResourceThisTurn = false;
-						if(!requiresBattle && targetResourceType.has_value())
-						{
-							const auto targetTile = targetObject->visitablePos();
+						if(missingNow[resType] <= 0)
+							return false;
 
-							// Only same-turn SCOUT pickup is certain enough to make MAIN abandon this target.
+						if(resType == GameResID::GOLD)
+						{
+							if(isTreasureChest)
+								return freeResources[resType] < 1000;
+
+							return freeResources[resType] < 1000 || aiNk->buildAnalyzer->isGoldPressureOverMax();
+						}
+
+						return freeResources[resType] == 0;
+					};
+					if(targetObject && (evaluationContext.heroRole == MAIN || meaningfulArmyCarrier || isTreasureChest))
+					{
+							bool scoutCanReachThisTurn = false;
+							bool mainCanReachSoon = false;
+							const auto targetTile = targetObject->visitablePos();
 							for(const auto * hero : aiNk->cc->getHeroesInfo())
 							{
 								if(hero == task->hero)
 									continue;
-								if(aiNk->getHeroLockedReason(hero) != HeroLockedReason::NOT_LOCKED)
-									continue;
-								if(aiNk->heroManager->getHeroRoleOrDefaultInefficient(hero) != HeroRole::SCOUT)
+							if(aiNk->getHeroLockedReason(hero) != HeroLockedReason::NOT_LOCKED)
+								continue;
+							if(aiNk->heroManager->getHeroRoleOrDefaultInefficient(hero) != HeroRole::SCOUT)
+								continue;
+
+							auto paths = aiNk->getPathsInfo(hero);
+							if(!paths)
+								continue;
+
+							auto pathNode = paths->getPathInfo(targetTile);
+							if(pathNode->reachable() && pathNode->turns == 0)
+							{
+								scoutCanReachThisTurn = true;
+									break;
+								}
+							}
+
+							for(const auto * hero : aiNk->cc->getHeroesInfo())
+							{
+								if(aiNk->heroManager->getHeroRoleOrDefaultInefficient(hero) != HeroRole::MAIN)
 									continue;
 
 								auto paths = aiNk->getPathsInfo(hero);
@@ -1698,73 +1848,110 @@ float PriorityEvaluator::evaluate(Goals::TSubgoal task, int priorityTier)
 									continue;
 
 								auto pathNode = paths->getPathInfo(targetTile);
-								if(pathNode->reachable() && pathNode->turns == 0)
+								if(pathNode->reachable() && pathNode->turns < 3)
 								{
-									scoutCanReachResourceThisTurn = true;
+									mainCanReachSoon = true;
 									break;
+								}
+							}
+							bool targetGivesCriticalResource = targetResourceType.has_value() && isCriticalRewardResource(*targetResourceType);
+
+						if(!targetGivesCriticalResource && (isWeeklyRevisitable(aiNk->playerID, targetObject) || isTreasureChest))
+						{
+							auto rewardable = dynamic_cast<const Rewardable::Interface *>(targetObject);
+							if(rewardable)
+							{
+								for(int index : rewardable->getAvailableRewards(task->hero, Rewardable::EEventType::EVENT_FIRST_VISIT))
+								{
+									for(TResources::nziterator it(rewardable->configuration.info[index].reward.resources); it.valid(); it++)
+									{
+										if(isCriticalRewardResource(it->resType))
+										{
+											targetGivesCriticalResource = true;
+											break;
+										}
+									}
+
+									if(targetGivesCriticalResource)
+										break;
 								}
 							}
 						}
 
-						if(scoutCanReachResourceThisTurn)
-						{
-							logAi->trace(
-								"priorityTier %d, MAIN yields %s at %s because a SCOUT can reach it this turn",
-								priorityTier,
-								targetObject->getObjectName(),
-								targetObject->visitablePos().toString());
-							return 0;
-						}
+						// try to balance other resources vs gold, especially 2500 gold treasures
+						float multiplier = targetGivesCriticalResource ? 3.0f : 1.0f;
+						score += evaluationContext.goldReward > 500 ? evaluationContext.goldReward / 2.0f * multiplier : evaluationContext.goldReward * 2.0f * multiplier;
 
-						if(requiresBattle)
-							// Encourage MAIN to fight for crypts and similar
-							score *= 2;
-						else if(targetResourceType.has_value()
-							&& aiNk->buildAnalyzer->getMissingResourcesNow()[*targetResourceType] > 0
-							&& ((*targetResourceType == GameResID::GOLD
-								&& aiNk->getFreeResources()[*targetResourceType] < GameConstants::HERO_GOLD_COST
-								&& aiNk->buildAnalyzer->isGoldPressureOverMax())
-								|| (*targetResourceType != GameResID::GOLD && aiNk->getFreeResources()[*targetResourceType] == 0)))
-							// Critical no-battle resources are still worth MAIN movement if waiting blocks builds or hero hiring.
-							score *= 2;
+						if(evaluationContext.heroRole != MAIN)
+						{
+							if(!targetGivesCriticalResource)
+							{
+								const auto targetTile = targetObject->visitablePos();
+								const auto & threatNode = aiNk->dangerHitMap->getTileThreat(targetTile);
+								const bool enemyCanReachSoon = threatNode.fastestDanger.turn < 2;
+								const auto closestTownOwner = aiNk->dangerHitMap->getTileOwner(targetTile);
+								const bool enemyTownIsCloser = closestTownOwner.isValidPlayer()
+									&& aiNk->cc->getPlayerRelations(aiNk->playerID, closestTownOwner) == PlayerRelations::ENEMIES;
+
+								if(!mainCanReachSoon || (enemyCanReachSoon || enemyTownIsCloser))
+									score *= 4;
+								if(isTreasureChest && mainCanReachSoon && !weakSailingScoutCollector)
+									return 0;
+							}
+							else
+							{
+								score *= 5;
+							}
+						}
 						else
-							// Discourage MAIN to waste time picking resources if they don't require a fight
-							score *= 0.33;
+						// MAIN hero
+						{
+							if(targetRequiresBattle || (evaluationContext.involvesSailing && isRewardable) || (targetGivesCriticalResource && !scoutCanReachThisTurn))
+							{
+								// Encourage MAIN to fight for crypts and similar + sailing rewardables + critical no-battle resources (still worth MAIN movement)
+								score *= 2;
+							}
+							else if(scoutCanReachThisTurn && !isTreasureChest)
+								return 0;
+							else if(meaningfulArmyCarrier && isWeeklyRevisitable(aiNk->playerID, targetObject))
+								score *= 0.1;
+							else
+							{
+								if(isTreasureChest)
+									score *= 3;
+								else
+									score *= 0.33;
+							}
+						}
 					}
 				}
 
 				if(evaluationContext.skillReward > 0)
 				{
-					if(evaluationContext.heroRole == MAIN)
-					{
-						score = 1000 + evaluateSkillReward(score, evaluationContext.skillReward, evaluationContext.armyInvolvement, evaluationContext.armyLossRatio);
-
-						// Encourage skill increases before battles
-						if(!requiresBattle)
-							score *= 3;
-					}
+					if(targetObject && !hasAnyBattle)
+						score += evaluationContext.skillReward * (evaluationContext.heroRole == MAIN ? 1000.0f : 200.0f);
 					else
-						// TODO: Mircea: Improve logic so that skill reward should be 0 for SCOUTs for one time things like a scholar, but allowed for buildings that give to all visiting heroes
-						// TODO: Mircea: Ease the restriction after 1 month or a bit more, because MAINs had enough time to grow, avoiding a SPAM of role shifts for each upgrade a SCOUT gets
-						// Discourage SCOUTs to pick-up skills/artifacts, otherwise it creates a mess with shifting MAIN responsibility.
-						// MAINs grow and fight, SCOUTs do the groundwork.
-						score = std::max(1.0f, score / 1000.0f);
+						score = 1000 + evaluateSkillReward(score, evaluationContext.skillReward, evaluationContext.armyLossRatio);
+					score *= evaluationContext.heroRole == SCOUT ? 0.2f : 2.0f;
 				}
 
-				score += evaluationContext.heroRole == MAIN ? evaluationContext.armyReward : evaluationContext.armyReward / 10.0f;
+				score += evaluationContext.heroRole == MAIN ? evaluationContext.armyReward : evaluationContext.armyReward / 2.0f;
 				// workshop (free lvl 1 units for Tower) and similar dwellings receive both armyReward and armyGrowth in evaluationContext
 				// For that reason only getDwellingArmyGrowth gets amplified towards day 7 if units are lost after
 				// Hero exchange and army upgrade are using this too
 				score += evaluationContext.armyGrowth;
 
 				if(evaluationContext.goldCost > 0)
-					// Will be outside the if, just temporary for debugging
 					score -= evaluationContext.goldCost / 4.0f; // don't include the full cost of School of Magic or others because those locations are beneficial
+				if(evaluationContext.routeAnchorBonus > 0)
+					score += evaluationContext.routeAnchorBonus;
+				if(weakSailingScoutCollector)
+					score += 4000;
 				score = evaluateArmyLossRatio(score, evaluationContext.armyLossRatio, evaluationContext.heroRole);
 
 				score *= evaluationContext.closestWayRatio;
-				score = evaluateMovement(score, evaluationContext.movementCost);
-
+				if(!(evaluationContext.explorePriority > 0 && !targetObject && evaluationContext.movementCost < 1.0f))
+					score = evaluateMovement(score, evaluationContext.movementCost);
 				break;
 			}
 			case DEFEND: //Defend whatever if nothing else is to do
@@ -1791,7 +1978,7 @@ float PriorityEvaluator::evaluate(Goals::TSubgoal task, int priorityTier)
 				score += evaluationContext.conquestValue * 1000;
 				score += evaluationContext.strategicalValue * 1000;
 				score += evaluationContext.goldReward;
-				score = evaluateSkillReward(score, evaluationContext.skillReward, evaluationContext.armyInvolvement, evaluationContext.armyLossRatio);
+				score = evaluateSkillReward(score, evaluationContext.skillReward, evaluationContext.armyLossRatio);
 				score += evaluationContext.armyReward;
 				score += evaluationContext.armyGrowth;
 
@@ -1847,8 +2034,11 @@ float PriorityEvaluator::evaluate(Goals::TSubgoal task, int priorityTier)
 
 		result = score;
 		//TODO: Figure out the root cause for why evaluationContext.closestWayRatio has become -nan(ind).
-		if (std::isnan(result))
+		if(std::isnan(result))
+		{
+			logGlobal->error("\n\n\nevaluationContext.closestWayRatio has become NaN\n\n");
 			return 0;
+		}
 	}
 
 #if NK2AI_TRACE_LEVEL >= 2

--- a/AI/Nullkiller2/Engine/PriorityEvaluator.cpp
+++ b/AI/Nullkiller2/Engine/PriorityEvaluator.cpp
@@ -42,6 +42,8 @@
 namespace NK2AI
 {
 
+#define NK2AI_LOG_SCORING 0
+
 constexpr float MAX_CRITICAL_VALUE = 2.0f;
 
 float evaluateEnemyTownConquestValue(float baseValue, int visibleEnemyTownCount)
@@ -1745,18 +1747,18 @@ float PriorityEvaluator::evaluate(Goals::TSubgoal task, int priorityTier)
 
 				const bool isTreasureChest = targetObject && targetObject->ID == Obj::TREASURE_CHEST;
 				const bool isRewardable = targetObject && dynamic_cast<const Rewardable::Interface *>(targetObject);
-				const std::string tempLogHero = task->hero ? firstHeroWord(task->hero) : "<no-hero> ("+ task->toString() +")";
-				const std::string tempLogRole = evaluationContext.heroRole == MAIN ? "MAIN" : "SCOUT";
-				const std::string tempLogTarget = targetObject ? targetObject->getObjectName() : "<no-target> ("+ task->toString() +")";
-				const std::string tempLogTargetPos = targetObject ? targetObject->visitablePos().toString() : task->tile.toString();
-				const std::string tempLogBattleReason = targetRequiresBattle ? "target requires battle" : "path/army loss is not target guard";
-				const std::string tempLogBase = "TEMP_LOG hero=" + tempLogHero + " role= " + tempLogRole + "targetObj= " + tempLogTarget + " at " + tempLogTargetPos + " ";
+				const std::string logHeroName = task->hero ? firstHeroWord(task->hero) : "<no-hero> ("+ task->toString() +")";
+				const std::string logHeroRole = evaluationContext.heroRole == MAIN ? "MAIN" : "SCOUT";
+				const std::string logTarget = targetObject ? targetObject->getObjectName() : "<no-target> ("+ task->toString() +")";
+				const std::string logTargetPos = targetObject ? targetObject->visitablePos().toString() : task->tile.toString();
+				const std::string logBattleReason = targetRequiresBattle ? "target requires battle" : "path/army loss is not target guard";
+				const std::string scoreLogBase = "Scoring evaluation: hero=" + logHeroName + " role= " + logHeroRole + "targetObj= " + logTarget + " at " + logTargetPos + " ";
 
-				const auto tempLogScore = [&](const std::string & stage, float before, float after)
+				const auto logScore = [&](const std::string & stage, float before, float after)
 				{
-#if NK2AI_TRACE_LEVEL >= 2
+#if NK2AI_LOG_SCORING
 					if(before != after && after > 500)
-						logAi->trace(tempLogBase + "stage=" + stage
+						logAi->warn(scoreLogBase + "stage=" + stage
 							+ " scoreBefore=" + std::to_string(before)
 							+ " scoreAfter=" + std::to_string(after));
 #else
@@ -1790,9 +1792,9 @@ float PriorityEvaluator::evaluate(Goals::TSubgoal task, int priorityTier)
 					return false;
 				};
 
-				float tempLogBefore = score;
+				float scoreBefore = score;
 				score += evaluationContext.strategicalValue * 1000;
-				tempLogScore("strategical", tempLogBefore, score);
+				logScore("strategical", scoreBefore, score);
 				if(evaluationContext.explorePriority > 0)
 				{
 					if(!targetObject
@@ -1802,19 +1804,19 @@ float PriorityEvaluator::evaluate(Goals::TSubgoal task, int priorityTier)
 						&& meaningfulArmyCarrier
 						&& mainReachableWithinOneTurn())
 					{
-#if NK2AI_TRACE_LEVEL >= 2
-						logAi->trace(tempLogBase + " rejects exploration because hero can deliver army within one turn");
+#if NK2AI_LOG_SCORING
+						logAi->warn(scoreLogBase + " rejects exploration because hero can deliver army within one turn");
 #endif
 						return 0;
 					}
 
-					tempLogBefore = score;
+					scoreBefore = score;
 					score += 100.0f / evaluationContext.explorePriority;
 
 					// Encourage exploration for MAIN that requires battles, so SCOUTs can continue exploring
 					if(evaluationContext.heroRole == MAIN && hasAnyBattle)
 						score *= 2;
-					tempLogScore("explorePriority", tempLogBefore, score);
+					logScore("explorePriority", scoreBefore, score);
 				}
 
 				if(evaluationContext.goldReward > 0)
@@ -1838,7 +1840,7 @@ float PriorityEvaluator::evaluate(Goals::TSubgoal task, int priorityTier)
 					};
 					if(targetObject && (evaluationContext.heroRole == MAIN || meaningfulArmyCarrier || isTreasureChest))
 					{
-						const std::string tempLogResourceStock = targetResourceType.has_value()
+						const std::string logResourceStock = targetResourceType.has_value()
 							? ", stock of target resource=" + std::to_string(freeResources[*targetResourceType])
 							: ", free resources=" + freeResources.toString();
 
@@ -1907,10 +1909,10 @@ float PriorityEvaluator::evaluate(Goals::TSubgoal task, int priorityTier)
 						}
 
 						// try to balance other resources vs gold, especially 2500 gold treasures
-						tempLogBefore = score;
+						scoreBefore = score;
 						float multiplier = targetGivesCriticalResource ? 3.0f : 1.0f;
 						score += evaluationContext.goldReward > 500 ? evaluationContext.goldReward / 2.0f * multiplier : evaluationContext.goldReward * 2.0f * multiplier;
-						tempLogScore("goldReward", tempLogBefore, score);
+						logScore("goldReward", scoreBefore, score);
 
 						if(evaluationContext.heroRole != MAIN)
 						{
@@ -1923,25 +1925,25 @@ float PriorityEvaluator::evaluate(Goals::TSubgoal task, int priorityTier)
 								const bool enemyTownIsCloser = closestTownOwner.isValidPlayer()
 									&& aiNk->cc->getPlayerRelations(aiNk->playerID, closestTownOwner) == PlayerRelations::ENEMIES;
 
-								tempLogBefore = score;
+								scoreBefore = score;
 								if(!mainCanReachSoon || (enemyCanReachSoon || enemyTownIsCloser))
 								{
 									score *= 4;
-									tempLogScore("MAIN can't reach soon or enemy is closer", tempLogBefore, score);
+									logScore("MAIN can't reach soon or enemy is closer", scoreBefore, score);
 								}
 								if(isTreasureChest && mainCanReachSoon && !weakSailingScoutCollector)
 								{
-#if NK2AI_TRACE_LEVEL >= 2
-									logAi->trace(tempLogBase + " rejects non-critical chest because MAIN can reach soon");
+#if NK2AI_LOG_SCORING
+									logAi->warn(scoreLogBase + " rejects non-critical chest because MAIN can reach soon");
 #endif
 									return 0;
 								}
 							}
 							else
 							{
-								tempLogBefore = score;
+								scoreBefore = score;
 								score *= 5;
-								tempLogScore("reward is critical or not weekly-blocked - multiplier = 5", tempLogBefore, score);
+								logScore("reward is critical or not weekly-blocked - multiplier = 5", scoreBefore, score);
 							}
 						}
 						else
@@ -1950,36 +1952,36 @@ float PriorityEvaluator::evaluate(Goals::TSubgoal task, int priorityTier)
 							if(targetRequiresBattle || (evaluationContext.involvesSailing && isRewardable) || (targetGivesCriticalResource && !scoutCanReachThisTurn))
 							{
 								// Encourage MAIN to fight for crypts and similar + sailing rewardables + critical no-battle resources (still worth MAIN movement)
-								tempLogBefore = score;
+								scoreBefore = score;
 								score *= 2;
-								tempLogScore("because "+ tempLogBattleReason + " multiplier = 2", tempLogBefore, score);
+								logScore("because "+ logBattleReason + " multiplier = 2", scoreBefore, score);
 							}
 							else if(scoutCanReachThisTurn && !isTreasureChest)
 							{
-#if NK2AI_TRACE_LEVEL >= 2
-								logAi->trace(tempLogBase + " rejects resource because a SCOUT can reach it this turn");
+#if NK2AI_LOG_SCORING
+								logAi->warn(scoreLogBase + " rejects resource because a SCOUT can reach it this turn");
 #endif
 								return 0;
 							}
 							else if(meaningfulArmyCarrier && isWeeklyRevisitable(aiNk->playerID, targetObject))
 							{
-								tempLogBefore = score;
+								scoreBefore = score;
 								score *= 0.1;
-								tempLogScore("skip non-critical weekly reward - multiplier = 0.1", tempLogBefore, score);
+								logScore("skip non-critical weekly reward - multiplier = 0.1", scoreBefore, score);
 							}
 							else
 							{
 								if(isTreasureChest)
 								{
-									tempLogBefore = score;
+									scoreBefore = score;
 									score *= 3;
-									tempLogScore("treasure chest - MAIN wants exp! multiplier = 3", tempLogBefore, score);
+									logScore("treasure chest - MAIN wants exp! multiplier = 3", scoreBefore, score);
 								}
 								else
 								{
-									tempLogBefore = score;
+									scoreBefore = score;
 									score *= 0.33;
-									tempLogScore("reward is not critical "+ tempLogResourceStock + " multiplier = 0.33", tempLogBefore, score);
+									logScore("reward is not critical "+ logResourceStock + " multiplier = 0.33", scoreBefore, score);
 								}
 							}
 						}
@@ -1988,67 +1990,67 @@ float PriorityEvaluator::evaluate(Goals::TSubgoal task, int priorityTier)
 
 				if(evaluationContext.skillReward > 0)
 				{
-					tempLogBefore = score;
+					scoreBefore = score;
 					if(targetObject && !hasAnyBattle)
 					{
-						tempLogBefore = score;
+						scoreBefore = score;
 						score += evaluationContext.skillReward * (evaluationContext.heroRole == MAIN ? 1000.0f : 200.0f);
-						tempLogScore("skill reward (has no battle): + "+ std::to_string(evaluationContext.skillReward) + " * "+ std::to_string(evaluationContext.heroRole == MAIN ? 1000.0f : 200.0f), tempLogBefore, score);
+						logScore("skill reward (has no battle): + "+ std::to_string(evaluationContext.skillReward) + " * "+ std::to_string(evaluationContext.heroRole == MAIN ? 1000.0f : 200.0f), scoreBefore, score);
 					}
 					else
 					{
-						tempLogBefore = score;
+						scoreBefore = score;
 						score = 1000 + evaluateSkillReward(score, evaluationContext.skillReward, evaluationContext.armyLossRatio);
-						tempLogScore("skill reward (has battle !!!) - multiplier = "+ std::to_string(evaluationContext.skillReward) + " * 1000", tempLogBefore, score);
+						logScore("skill reward (has battle !!!) - multiplier = "+ std::to_string(evaluationContext.skillReward) + " * 1000", scoreBefore, score);
 					}
 					score *= evaluationContext.heroRole == SCOUT ? 0.2f : 2.0f;
 				}
 
-				tempLogBefore = score;
+				scoreBefore = score;
 				score += evaluationContext.heroRole == MAIN ? evaluationContext.armyReward : evaluationContext.armyReward / 2.0f;
-				tempLogScore("armyReward", tempLogBefore, score);
+				logScore("armyReward", scoreBefore, score);
 				// workshop (free lvl 1 units for Tower) and similar dwellings receive both armyReward and armyGrowth in evaluationContext
 				// For that reason only getDwellingArmyGrowth gets amplified towards day 7 if units are lost after
 				// Hero exchange and army upgrade are using this too
-				tempLogBefore = score;
+				scoreBefore = score;
 				score += evaluationContext.armyGrowth;
-				tempLogScore("armyGrowth", tempLogBefore, score);
+				logScore("armyGrowth", scoreBefore, score);
 
 				if(evaluationContext.goldCost > 0)
 				{
-					tempLogBefore = score;
+					scoreBefore = score;
 					score -= evaluationContext.goldCost / 4.0f; // don't include the full cost of School of Magic or others because those locations are beneficial
-					tempLogScore("goldCost - multiplier = 0.25", tempLogBefore, score);
+					logScore("goldCost - multiplier = 0.25", scoreBefore, score);
 				}
 				if(evaluationContext.routeAnchorBonus > 0)
 				{
-					tempLogBefore = score;
+					scoreBefore = score;
 					score += evaluationContext.routeAnchorBonus;
-					tempLogScore("routeAnchorBonus= " + std::to_string(evaluationContext.routeAnchorBonus), tempLogBefore, score);
+					logScore("routeAnchorBonus= " + std::to_string(evaluationContext.routeAnchorBonus), scoreBefore, score);
 				}
 				if(weakSailingScoutCollector)
 				{
-					tempLogBefore = score;
+					scoreBefore = score;
 					score += 4000;
-					tempLogScore("weak sailing scout cleanup", tempLogBefore, score);
+					logScore("weak sailing scout cleanup", scoreBefore, score);
 				}
-				tempLogBefore = score;
+				scoreBefore = score;
 				score = evaluateArmyLossRatio(score, evaluationContext.armyLossRatio, evaluationContext.heroRole);
-				tempLogScore("armyLossRatio", tempLogBefore, score);
+				logScore("armyLossRatio", scoreBefore, score);
 
-				tempLogBefore = score;
+				scoreBefore = score;
 				score *= evaluationContext.closestWayRatio;
-				tempLogScore("closestWayRatio - multiplier " + std::to_string(evaluationContext.closestWayRatio), tempLogBefore, score);
+				logScore("closestWayRatio - multiplier " + std::to_string(evaluationContext.closestWayRatio), scoreBefore, score);
 				if(!(evaluationContext.explorePriority > 0 && !targetObject && evaluationContext.movementCost < 1.0f))
 				{
-					tempLogBefore = score;
+					scoreBefore = score;
 					score = evaluateMovement(score, evaluationContext.movementCost);
-					tempLogScore("movement", tempLogBefore, score);
+					logScore("movement", scoreBefore, score);
 				}
 
-#if NK2AI_TRACE_LEVEL >= 1
+#if NK2AI_LOG_SCORING
 				if(score > 500)
-					logAi->trace("\t\t" + tempLogBase + " - Final score = %f", score);
+					logAi->error("\t\t" + scoreLogBase + " - Final score = %f", score);
 #endif
 				break;
 			}

--- a/AI/Nullkiller2/Engine/PriorityEvaluator.cpp
+++ b/AI/Nullkiller2/Engine/PriorityEvaluator.cpp
@@ -126,8 +126,7 @@ EvaluationContext::EvaluationContext(const Nullkiller* aiNk)
 	isDefend(false),
 	threatTurns(INT_MAX),
 	involvesSailing(false),
-	requiresBattle(false),
-	targetRequiresBattle(false),
+	pathRequiresBattle(false),
 	isTradeBuilding(false),
 	isExchange(false),
 	isArmyUpgrade(false),
@@ -1104,8 +1103,7 @@ public:
 		vstd::amax(evaluationContext.danger, path.getTotalDanger());
 		vstd::amax(evaluationContext.armyLoss, path.armyLoss);
 		vstd::amax(evaluationContext.targetObjectArmyLoss, path.targetObjectArmyLoss);
-		evaluationContext.requiresBattle = evaluationContext.requiresBattle || path.requiresBattle();
-		evaluationContext.targetRequiresBattle = evaluationContext.targetRequiresBattle || path.targetObjectArmyLoss > 0;
+		evaluationContext.pathRequiresBattle |= path.requiresBattle();
 		evaluationContext.movementCost += path.movementCost();
 		evaluationContext.closestWayRatio = chain.closestWayRatio;
 
@@ -1226,8 +1224,7 @@ public:
 
 		evaluationContext.movementCost += pathToCenter.movementCost();
 		evaluationContext.movementCostByRole[role] += pathToCenter.movementCost();
-		evaluationContext.requiresBattle = evaluationContext.requiresBattle || pathToCenter.requiresBattle();
-		evaluationContext.targetRequiresBattle = evaluationContext.targetRequiresBattle || pathToCenter.targetObjectArmyLoss > 0;
+		evaluationContext.pathRequiresBattle |= pathToCenter.requiresBattle();
 		vstd::amax(evaluationContext.danger, pathToCenter.getTotalDanger());
 		vstd::amax(evaluationContext.armyLoss, pathToCenter.armyLoss);
 		vstd::amax(evaluationContext.targetObjectArmyLoss, pathToCenter.targetObjectArmyLoss);
@@ -1731,8 +1728,8 @@ float PriorityEvaluator::evaluate(Goals::TSubgoal task, int priorityTier)
 				//    && ((evaluationContext.enemyHeroDangerRatio > 0 && arriveNextWeek) || evaluationContext.enemyHeroDangerRatio > involvedStrengthOutOfTotalRatio))
 				// 	return 0;
 
-				const bool hasAnyBattle = evaluationContext.requiresBattle || evaluationContext.armyLossRatio > 0;
-				const bool targetRequiresBattle = evaluationContext.targetRequiresBattle;
+				const bool hasAnyBattle = evaluationContext.pathRequiresBattle || evaluationContext.armyLossRatio > 0;
+				const bool targetRequiresBattle = evaluationContext.targetObjectArmyLoss > 0;
 				const bool meaningfulArmyCarrier = task->hero && aiNk->heroManager->isMeaningfulArmyCarrier(task->hero);
 
 				const bool targetIsOnWater = targetObject && aiNk->cc->getTile(targetObject->visitablePos(), false)->isWater();

--- a/AI/Nullkiller2/Engine/PriorityEvaluator.cpp
+++ b/AI/Nullkiller2/Engine/PriorityEvaluator.cpp
@@ -658,7 +658,6 @@ float RewardEvaluator::getSkillReward(const CGObjectInstance * target, const CGH
 	case Obj::GARDEN_OF_REVELATION:
 	case Obj::MARLETTO_TOWER:
 	case Obj::MERCENARY_CAMP:
-	case Obj::TREE_OF_KNOWLEDGE:
 		return 1;
 	case Obj::LEARNING_STONE:
 		return 1.0f / std::sqrt(hero->level);
@@ -720,6 +719,8 @@ float RewardEvaluator::getSkillReward(const CGObjectInstance * target, const CGH
 					totalValue += value;
 				}
 			}
+
+			totalValue += info.reward.heroLevel * 4.0f;
 		}
 
 		return totalValue;

--- a/AI/Nullkiller2/Engine/PriorityEvaluator.h
+++ b/AI/Nullkiller2/Engine/PriorityEvaluator.h
@@ -72,6 +72,7 @@ struct DLL_EXPORT EvaluationContext
 	int threatTurns;
 	TResources buildingCost;
 	bool involvesSailing;
+	bool requiresBattle;
 	bool isTradeBuilding;
 	bool isExchange;
 	bool isArmyUpgrade;

--- a/AI/Nullkiller2/Engine/PriorityEvaluator.h
+++ b/AI/Nullkiller2/Engine/PriorityEvaluator.h
@@ -74,8 +74,7 @@ struct DLL_EXPORT EvaluationContext
 	int threatTurns;
 	TResources buildingCost;
 	bool involvesSailing;
-	bool requiresBattle;
-	bool targetRequiresBattle;
+	bool pathRequiresBattle;
 	bool isTradeBuilding;
 	bool isExchange;
 	bool isArmyUpgrade;

--- a/AI/Nullkiller2/Engine/PriorityEvaluator.h
+++ b/AI/Nullkiller2/Engine/PriorityEvaluator.h
@@ -83,6 +83,9 @@ struct DLL_EXPORT EvaluationContext
 	bool canBeKilledByEnemy;
 	int explorePriority; // 1 important, 2 medium, 3 lowest importance
 	float powerRatio; // powerRatio = heroPower / totalPower. The ratio of a hero's army strength to the total power of all creatures available to the AI
+	float routeAnchorBonus;
+	float routeAnchorMovementCost;
+	std::string routeAnchorName;
 
 	EvaluationContext(const Nullkiller * aiNk);
 

--- a/AI/Nullkiller2/Engine/PriorityEvaluator.h
+++ b/AI/Nullkiller2/Engine/PriorityEvaluator.h
@@ -54,6 +54,8 @@ struct DLL_EXPORT EvaluationContext
 	uint64_t danger;
 	float closestWayRatio;
 	float armyLossRatio;
+	uint64_t armyLoss;
+	uint64_t targetObjectArmyLoss;
 	float armyReward;
 	uint64_t armyGrowth;
 	int32_t goldReward;

--- a/AI/Nullkiller2/Engine/PriorityEvaluator.h
+++ b/AI/Nullkiller2/Engine/PriorityEvaluator.h
@@ -75,6 +75,7 @@ struct DLL_EXPORT EvaluationContext
 	TResources buildingCost;
 	bool involvesSailing;
 	bool requiresBattle;
+	bool targetRequiresBattle;
 	bool isTradeBuilding;
 	bool isExchange;
 	bool isArmyUpgrade;

--- a/AI/Nullkiller2/Engine/PriorityEvaluator.h
+++ b/AI/Nullkiller2/Engine/PriorityEvaluator.h
@@ -80,6 +80,7 @@ struct DLL_EXPORT EvaluationContext
 	bool isArmyUpgrade;
 	bool isHero;
 	bool isEnemy;
+	bool canBeKilledByEnemy;
 	int explorePriority; // 1 important, 2 medium, 3 lowest importance
 	float powerRatio; // powerRatio = heroPower / totalPower. The ratio of a hero's army strength to the total power of all creatures available to the AI
 

--- a/AI/Nullkiller2/Engine/PriorityEvaluator.h
+++ b/AI/Nullkiller2/Engine/PriorityEvaluator.h
@@ -123,7 +123,7 @@ private:
 	EvaluationContext buildEvaluationContext(const Goals::TSubgoal & goal) const;
 	static float evaluateMovement(float score, float movementCost);
 	static float evaluateArmyLossRatio(float score, float armyLossRatio, HeroRole heroRole);
-	static float evaluateSkillReward(float score, float skillReward, float armyInvolvement, float armyLossRatio);
+	static float evaluateSkillReward(float score, float skillReward, float armyLossRatio);
 	static float evaluateConquestValue(float score, float conquestValue, float armyInvolvement);
 };
 

--- a/AI/Nullkiller2/Engine/ResourceTrader.cpp
+++ b/AI/Nullkiller2/Engine/ResourceTrader.cpp
@@ -57,7 +57,7 @@ bool ResourceTrader::trade(BuildAnalyzer & buildAnalyzer, CCallback & cc, const 
 		// to buy a capitol for example
 		TResources freeAfterMissingTotal = buildAnalyzer.getFreeResourcesAfterMissingTotal(ARMY_GOLD_RATIO_PER_MAKE_TURN_PASS);
 
-		logAi->info(
+		logAi->trace(
 			"ResourceTrader: Free %s. FreeAfterMissingTotal %s. MissingNow  %s",
 			freeResources.toString(),
 			freeAfterMissingTotal.toString(),
@@ -180,7 +180,7 @@ bool ResourceTrader::tradeHelper(
 	}
 
 	cc.trade(market.getObjInstanceID(), EMarketMode::RESOURCE_RESOURCE, GameResID(mostExpendable), GameResID(mostWanted), givenMultiplied);
-	logAi->info("ResourceTrader: Traded %d of %s for %d receivedPerUnit of %s", givenMultiplied, mostExpendable, receivedPerUnit, mostWanted);
+	logAi->trace("ResourceTrader: Traded %d of %s for %d receivedPerUnit of %s", givenMultiplied, mostExpendable, receivedPerUnit, mostWanted);
 	return true;
 }
 }

--- a/AI/Nullkiller2/Goals/AbstractGoal.h
+++ b/AI/Nullkiller2/Goals/AbstractGoal.h
@@ -188,7 +188,7 @@ namespace Goals
 		{
 			throw std::runtime_error("Abstract goal is not a task");
 		}
-		
+
 		bool operator!=(const AbstractGoal & g) const
 		{
 			return !(*this == g);

--- a/AI/Nullkiller2/Goals/AbstractGoal.h
+++ b/AI/Nullkiller2/Goals/AbstractGoal.h
@@ -98,7 +98,7 @@ namespace Goals
 
 	DLL_EXPORT TSubgoal sptr(const AbstractGoal & tmp);
 	DLL_EXPORT TTask taskptr(const AbstractGoal & tmp);
-	
+
 	class DLL_EXPORT AbstractGoal
 	{
 	public:
@@ -151,7 +151,7 @@ namespace Goals
 		{
 			return goalType == EGoals::INVALID;
 		}
-		
+
 		// virtual bool operator==(const AbstractGoal & g) const;
 		virtual bool operator==(const AbstractGoal & g) const { return false; }
 
@@ -160,6 +160,29 @@ namespace Goals
 		virtual bool hasHash() const { return false; }
 
 		virtual uint64_t getHash() const { return 0; }
+
+		virtual bool isObjectAffected(ObjectInstanceID id) const
+		{
+			return (hero && hero->id == id)
+				|| objid == id.getNum()
+				|| (town && town->id == id);
+		}
+
+		virtual std::vector<ObjectInstanceID> getAffectedObjects() const
+		{
+			auto result = std::vector<ObjectInstanceID>();
+
+			if(hero)
+				result.push_back(hero->id);
+
+			if(objid != -1)
+				result.emplace_back(objid);
+
+			if(town)
+				result.push_back(town->id);
+
+			return result;
+		}
 
 		virtual ITask * asTask()
 		{

--- a/AI/Nullkiller2/Goals/CGoal.h
+++ b/AI/Nullkiller2/Goals/CGoal.h
@@ -91,28 +91,9 @@ namespace Goals
 
 		int getHeroExchangeCount() const override { return 0; }
 
-		bool isObjectAffected(ObjectInstanceID id) const override
-		{
-			return (AbstractGoal::hero && AbstractGoal::hero->id == id)
-				|| AbstractGoal::objid == id.getNum()
-				|| (AbstractGoal::town && AbstractGoal::town->id == id);
-		}
+		bool isObjectAffected(ObjectInstanceID id) const override { return AbstractGoal::isObjectAffected(id); }
 
-		std::vector<ObjectInstanceID> getAffectedObjects() const override
-		{
-			auto result = std::vector<ObjectInstanceID>();
-
-			if(AbstractGoal::hero)
-				result.push_back(AbstractGoal::hero->id);
-
-			if(AbstractGoal::objid != -1)
-				result.push_back(ObjectInstanceID(AbstractGoal::objid));
-
-			if(AbstractGoal::town)
-				result.push_back(AbstractGoal::town->id);
-
-			return result;
-		}
+		std::vector<ObjectInstanceID> getAffectedObjects() const override { return AbstractGoal::getAffectedObjects(); }
 
 		ITask * asTask() override
 		{

--- a/AI/Nullkiller2/Goals/Composition.cpp
+++ b/AI/Nullkiller2/Goals/Composition.cpp
@@ -109,7 +109,6 @@ bool Composition::isElementar() const
 	return subtasks.back().front()->isElementar();
 }
 
-<<<<<<< HEAD
 const CGHeroInstance * Composition::getHero() const
 {
 	const CGHeroInstance * result = nullptr;
@@ -131,8 +130,6 @@ const CGHeroInstance * Composition::getHero() const
 	return result;
 }
 
-=======
->>>>>>> 803f1ff36 (Replan after unlocking a cluster)
 bool Composition::containsGoalType(EGoals goalType) const
 {
 	for(auto sequence : subtasks)

--- a/AI/Nullkiller2/Goals/Composition.cpp
+++ b/AI/Nullkiller2/Goals/Composition.cpp
@@ -88,7 +88,7 @@ Composition & Composition::addNext(TSubgoal goal)
 	if(goal->goalType == COMPOSITION)
 	{
 		Composition & other = dynamic_cast<Composition &>(*goal);
-		
+
 		vstd::concatenate(subtasks, other.subtasks);
 	}
 	else
@@ -109,6 +109,41 @@ bool Composition::isElementar() const
 	return subtasks.back().front()->isElementar();
 }
 
+const CGHeroInstance * Composition::getHero() const
+{
+	const CGHeroInstance * result = nullptr;
+
+	for(auto sequence : subtasks)
+	{
+		for(auto task : sequence)
+		{
+			const auto * taskHero = task->isElementar() ? taskptr(*task)->getHero() : task->hero;
+			if(!taskHero)
+				continue;
+			if(result && result != taskHero)
+				return nullptr;
+
+			result = taskHero;
+		}
+	}
+
+	return result;
+}
+
+bool Composition::containsGoalType(EGoals goalType) const
+{
+	for(auto sequence : subtasks)
+	{
+		for(auto task : sequence)
+		{
+			if(task->goalType == goalType)
+				return true;
+		}
+	}
+
+	return false;
+}
+
 int Composition::getHeroExchangeCount() const
 {
 	auto result = 0;
@@ -116,11 +151,9 @@ int Composition::getHeroExchangeCount() const
 	for(auto task : subtasks.back())
 	{
 		if(task->isElementar())
-		{
 			result += taskptr(*task)->getHeroExchangeCount();
-		}
 	}
-	
+
 	return result;
 }
 
@@ -132,8 +165,7 @@ std::vector<ObjectInstanceID> Composition::getAffectedObjects() const
 	{
 		for(auto task : sequence)
 		{
-			if(task->isElementar())
-				vstd::concatenate(affectedObjects, task->asTask()->getAffectedObjects());
+			vstd::concatenate(affectedObjects, task->getAffectedObjects());
 		}
 	}
 
@@ -148,7 +180,7 @@ bool Composition::isObjectAffected(ObjectInstanceID id) const
 	{
 		for(auto task : sequence)
 		{
-			if(task->isElementar() && task->asTask()->isObjectAffected(id))
+			if(task->isObjectAffected(id))
 				return true;
 		}
 	}

--- a/AI/Nullkiller2/Goals/Composition.cpp
+++ b/AI/Nullkiller2/Goals/Composition.cpp
@@ -109,6 +109,7 @@ bool Composition::isElementar() const
 	return subtasks.back().front()->isElementar();
 }
 
+<<<<<<< HEAD
 const CGHeroInstance * Composition::getHero() const
 {
 	const CGHeroInstance * result = nullptr;
@@ -130,6 +131,8 @@ const CGHeroInstance * Composition::getHero() const
 	return result;
 }
 
+=======
+>>>>>>> 803f1ff36 (Replan after unlocking a cluster)
 bool Composition::containsGoalType(EGoals goalType) const
 {
 	for(auto sequence : subtasks)

--- a/AI/Nullkiller2/Goals/Composition.h
+++ b/AI/Nullkiller2/Goals/Composition.h
@@ -34,6 +34,8 @@ namespace Goals
 		Composition & addNextSequence(const TGoalVec & taskSequence);
 		TGoalVec decompose(const Nullkiller * aiNk) const override;
 		bool isElementar() const override;
+		const CGHeroInstance * getHero() const override;
+		bool containsGoalType(EGoals goalType) const;
 		int getHeroExchangeCount() const override;
 
 		std::vector<ObjectInstanceID> getAffectedObjects() const override;

--- a/AI/Nullkiller2/Goals/ExecuteHeroChain.cpp
+++ b/AI/Nullkiller2/Goals/ExecuteHeroChain.cpp
@@ -108,10 +108,18 @@ ExecuteHeroChain::ExecuteHeroChain(const AIPath & path, const CGObjectInstance *
 
 bool ExecuteHeroChain::operator==(const ExecuteHeroChain & other) const
 {
-	return tile == other.tile 
+	return tile == other.tile
 		&& chainPath.targetHero == other.chainPath.targetHero
 		&& chainPath.nodes.size() == other.chainPath.nodes.size()
 		&& chainPath.chainMask == other.chainPath.chainMask;
+}
+
+void ExecuteHeroChain::setRouteAnchorBonus(const CGObjectInstance * anchor, float bonus, float anchorMovementCost)
+{
+	routeAnchor = anchor->id;
+	routeAnchorName = anchor->getObjectName() + anchor->visitablePos().toString();
+	routeAnchorBonus = bonus;
+	routeAnchorMovementCost = anchorMovementCost;
 }
 
 std::vector<ObjectInstanceID> ExecuteHeroChain::getAffectedObjects() const
@@ -350,7 +358,6 @@ void ExecuteHeroChain::accept(AIGateway * aiGw)
 
 				return;
 			}
-			
 			// no exception means we were not able to reach the tile
 			aiGw->nullkiller->lockHero(hero, HeroLockedReason::HERO_CHAIN);
 			blockedIndexes.insert(node->parentIndex);

--- a/AI/Nullkiller2/Goals/ExecuteHeroChain.cpp
+++ b/AI/Nullkiller2/Goals/ExecuteHeroChain.cpp
@@ -80,8 +80,11 @@ bool executeSpecialAction(
 }
 }
 
-ExecuteHeroChain::ExecuteHeroChain(const AIPath & path, const CGObjectInstance * obj)
-	:ElementarGoal(Goals::EXECUTE_HERO_CHAIN), chainPath(path), closestWayRatio(1)
+ExecuteHeroChain::ExecuteHeroChain(const AIPath & path, const CGObjectInstance * obj, bool affectsTargetObject)
+	: ElementarGoal(Goals::EXECUTE_HERO_CHAIN),
+		chainPath(path),
+		affectsTargetObject(affectsTargetObject),
+		closestWayRatio(1)
 {
 	hero = path.targetHero;
 	tile = path.targetTile();
@@ -115,7 +118,7 @@ std::vector<ObjectInstanceID> ExecuteHeroChain::getAffectedObjects() const
 {
 	std::vector<ObjectInstanceID> affectedObjects = { chainPath.targetHero->id };
 
-	if(objid != -1)
+	if(affectsTargetObject && objid != -1)
 		affectedObjects.push_back(ObjectInstanceID(objid));
 
 	for(auto & node : chainPath.nodes)
@@ -131,7 +134,7 @@ std::vector<ObjectInstanceID> ExecuteHeroChain::getAffectedObjects() const
 
 bool ExecuteHeroChain::isObjectAffected(ObjectInstanceID id) const
 {
-	if(chainPath.targetHero->id == id || objid == id.getNum())
+	if(chainPath.targetHero->id == id || (affectsTargetObject && objid == id.getNum()))
 		return true;
 
 	for(auto & node : chainPath.nodes)

--- a/AI/Nullkiller2/Goals/ExecuteHeroChain.h
+++ b/AI/Nullkiller2/Goals/ExecuteHeroChain.h
@@ -22,6 +22,10 @@ namespace Goals
 		AIPath chainPath;
 		std::string targetName;
 		bool affectsTargetObject;
+		ObjectInstanceID routeAnchor = ObjectInstanceID(-1);
+		float routeAnchorBonus = 0;
+		float routeAnchorMovementCost = 0;
+		std::string routeAnchorName;
 
 	public:
 		float closestWayRatio;
@@ -35,6 +39,11 @@ namespace Goals
 		std::string toString() const override;
 		bool operator==(const ExecuteHeroChain & other) const override;
 		const AIPath & getPath() const { return chainPath; }
+		void setRouteAnchorBonus(const CGObjectInstance * anchor, float bonus, float anchorMovementCost);
+		float getRouteAnchorBonus() const { return routeAnchorBonus; }
+		float getRouteAnchorMovementCost() const { return routeAnchorMovementCost; }
+		const std::string & getRouteAnchorName() const { return routeAnchorName; }
+		ObjectInstanceID getRouteAnchor() const { return routeAnchor; }
 
 		int getHeroExchangeCount() const override { return chainPath.exchangeCount; }
 

--- a/AI/Nullkiller2/Goals/ExecuteHeroChain.h
+++ b/AI/Nullkiller2/Goals/ExecuteHeroChain.h
@@ -21,11 +21,15 @@ namespace Goals
 	private:
 		AIPath chainPath;
 		std::string targetName;
+		bool affectsTargetObject;
 
 	public:
 		float closestWayRatio;
 
-		ExecuteHeroChain(const AIPath & path, const CGObjectInstance * obj = nullptr);
+		ExecuteHeroChain(
+			const AIPath & path,
+			const CGObjectInstance * obj = nullptr,
+			bool affectsTargetObject = true);
 
 		void accept(AIGateway * aiGw) override;
 		std::string toString() const override;

--- a/AI/Nullkiller2/Goals/SaveResources.cpp
+++ b/AI/Nullkiller2/Goals/SaveResources.cpp
@@ -10,7 +10,6 @@
 #include "StdInc.h"
 #include "SaveResources.h"
 #include "../AIGateway.h"
-#include "../Behaviors/CaptureObjectsBehavior.h"
 
 namespace NK2AI
 {

--- a/AI/Nullkiller2/Markers/ArmyUpgrade.cpp
+++ b/AI/Nullkiller2/Markers/ArmyUpgrade.cpp
@@ -23,6 +23,7 @@ ArmyUpgrade::ArmyUpgrade(const AIPath & upgradePath, const CGObjectInstance * up
 	initialValue(upgradePath.heroArmy->getArmyStrength()), goldCost(upgrade.upgradeCost[EGameResID::GOLD])
 {
 	hero = upgradePath.targetHero;
+	objid = upgrader->id.getNum();
 }
 
 ArmyUpgrade::ArmyUpgrade(const CGHeroInstance * targetMain, const CGObjectInstance * upgrader, const ArmyUpgradeInfo & upgrade)
@@ -30,6 +31,7 @@ ArmyUpgrade::ArmyUpgrade(const CGHeroInstance * targetMain, const CGObjectInstan
 	initialValue(targetMain->getArmyStrength()), goldCost(upgrade.upgradeCost[EGameResID::GOLD])
 {
 	sethero(targetMain);
+	objid = upgrader->id.getNum();
 }
 
 bool ArmyUpgrade::operator==(const ArmyUpgrade & other) const

--- a/AI/Nullkiller2/Markers/HeroExchange.cpp
+++ b/AI/Nullkiller2/Markers/HeroExchange.cpp
@@ -13,12 +13,40 @@
 #include "../Engine/Nullkiller.h"
 #include "../AIUtility.h"
 #include "../Analyzers/ArmyManager.h"
+#include "../../../lib/entities/artifact/CArtifact.h"
 #include "../../../lib/mapping/TerrainTile.h"
 
 namespace NK2AI
 {
 
 using namespace Goals;
+
+static uint64_t getArtifactValueForExchange(const CGHeroInstance * target, const CArtifactInstance * artifact)
+{
+	if(!target || !artifact)
+		return 0;
+
+	if(target->hasArt(artifact->getTypeId()))
+		return 0;
+
+	if(artifact->getType()->getPossibleSlots().count(target->bearerType()) == 0)
+		return 0;
+
+	const auto artifactScore = getArtifactScoreForHero(target, artifact);
+	if(artifactScore <= 0)
+		return 0;
+
+	int64_t bestCurrentScore = 0;
+
+	for(auto slot : artifact->getType()->getPossibleSlots().at(target->bearerType()))
+	{
+		const auto * otherSlot = target->getSlot(slot);
+		if(otherSlot && otherSlot->getArt())
+			vstd::amax(bestCurrentScore, getArtifactScoreForHero(target, otherSlot->getArt()));
+	}
+
+	return artifactScore > bestCurrentScore ? artifactScore : 0;
+}
 
 bool HeroExchange::operator==(const HeroExchange & other) const
 {
@@ -41,6 +69,30 @@ uint64_t HeroExchange::getReinforcementArmyStrength(const Nullkiller * aiNk) con
 		hero,
 		exchangePath.heroArmy,
 		aiNk->cc->getTile(exchangePath.targetTile())->getTerrainID());
+}
+
+uint64_t HeroExchange::getArtifactExchangeValue() const
+{
+	const auto * source = exchangePath.targetHero;
+	if(!hero || !source)
+		return 0;
+
+	uint64_t result = 0;
+	const auto addArtifactValue = [&](const ArtSlotInfo & slot)
+	{
+		if(slot.locked || !slot.getArt())
+			return;
+
+		result += getArtifactValueForExchange(hero, slot.getArt());
+	};
+
+	for(const auto & worn : source->artifactsWorn)
+		addArtifactValue(worn.second);
+
+	for(const auto & backpackSlot : source->artifactsInBackpack)
+		addArtifactValue(backpackSlot);
+
+	return result;
 }
 
 }

--- a/AI/Nullkiller2/Markers/HeroExchange.cpp
+++ b/AI/Nullkiller2/Markers/HeroExchange.cpp
@@ -33,6 +33,8 @@ std::string HeroExchange::toString() const
 uint64_t HeroExchange::getReinforcementArmyStrength(const Nullkiller * aiNk) const
 {
 	assert(exchangePath.targetHero && exchangePath.heroArmy);
+	if(reinforcementArmyStrengthOverride > 0)
+		return reinforcementArmyStrengthOverride;
 
 	return aiNk->armyManager->howManyReinforcementsCanGet(
 		hero,

--- a/AI/Nullkiller2/Markers/HeroExchange.h
+++ b/AI/Nullkiller2/Markers/HeroExchange.h
@@ -36,3 +36,4 @@ namespace NK2AI::Goals
 		uint64_t getArtifactExchangeValue() const;
 	};
 }
+

--- a/AI/Nullkiller2/Markers/HeroExchange.h
+++ b/AI/Nullkiller2/Markers/HeroExchange.h
@@ -12,26 +12,27 @@
 #include "../Goals/CGoal.h"
 #include "../Pathfinding/AINodeStorage.h"
 
-namespace NK2AI
-{
-namespace Goals
+namespace NK2AI::Goals
 {
 	class DLL_EXPORT HeroExchange : public CGoal<HeroExchange>
 	{
+	private:
+		uint64_t reinforcementArmyStrengthOverride = 0;
+
 	public:
 		AIPath exchangePath;
 
-		HeroExchange(const CGHeroInstance * targetHero, const AIPath & exchangePath)
-			: CGoal(Goals::HERO_EXCHANGE), exchangePath(exchangePath)
+		HeroExchange(const CGHeroInstance * targetHero, const AIPath & exchangePath, uint64_t reinforcementArmyStrengthOverride = 0)
+			: CGoal(Goals::HERO_EXCHANGE),
+			exchangePath(exchangePath),
+			reinforcementArmyStrengthOverride(reinforcementArmyStrengthOverride)
 		{
 			sethero(targetHero);
 		}
 
 		bool operator==(const HeroExchange & other) const override;
 		std::string toString() const override;
-
 		uint64_t getReinforcementArmyStrength(const Nullkiller * aiNk) const;
+		uint64_t getArtifactExchangeValue() const;
 	};
-}
-
 }

--- a/AI/Nullkiller2/Pathfinding/AINodeStorage.cpp
+++ b/AI/Nullkiller2/Pathfinding/AINodeStorage.cpp
@@ -1681,11 +1681,6 @@ void AINodeStorage::calculateChainInfo(std::vector<AIPath> & paths, const int3 &
 			continue;
 		}
 		path.targetObjectDanger = aiNk->dangerEvaluator->evaluateDanger(pos, path.targetHero, !node.actor->allowBattle);
-		for(const auto & pathNode : path.nodes)
-		{
-			auto pathNodeDanger = aiNk->dangerEvaluator->evaluateDanger(pathNode.coord, path.targetHero, !node.actor->allowBattle);
-			path.targetObjectDanger = std::max(pathNodeDanger, path.targetObjectDanger);
-		}
 
 		if(path.targetObjectDanger > 0)
 		{

--- a/AI/Nullkiller2/Pathfinding/AINodeStorage.cpp
+++ b/AI/Nullkiller2/Pathfinding/AINodeStorage.cpp
@@ -1755,6 +1755,7 @@ bool AINodeStorage::tryReconstructChainInfo(const AIPathNode * node, AIPath & pa
 			pathNode.parentIndex = candidateParentIndex;
 			pathNode.actionIsBlocked = false;
 			pathNode.layer = node->layer;
+			pathNode.action = node->action;
 
 			if(pathNode.specialAction)
 			{

--- a/AI/Nullkiller2/Pathfinding/AINodeStorage.cpp
+++ b/AI/Nullkiller2/Pathfinding/AINodeStorage.cpp
@@ -1900,6 +1900,20 @@ uint64_t AIPath::getTotalDanger() const
 	return danger;
 }
 
+bool AIPath::requiresBattle() const
+{
+	if(targetObjectArmyLoss > 0)
+		return true;
+
+	for(const auto & node : nodes)
+	{
+		if(node.action == EPathNodeAction::BATTLE || node.action == EPathNodeAction::TELEPORT_BATTLE)
+			return true;
+	}
+
+	return false;
+}
+
 bool AIPath::containsHero(const CGHeroInstance * hero) const
 {
 	if(targetHero == hero)

--- a/AI/Nullkiller2/Pathfinding/AINodeStorage.h
+++ b/AI/Nullkiller2/Pathfinding/AINodeStorage.h
@@ -75,17 +75,17 @@ struct AIPathNode : public CGPathNode
 
 struct AIPathNodeInfo
 {
-	float cost;
-	uint8_t turns;
+	float cost = 0;
+	uint8_t turns = 0;
 	int3 coord;
-	EPathfindingLayer layer;
-	EPathNodeAction action;
-	uint64_t danger;
-	const CGHeroInstance * targetHero;
-	int parentIndex;
-	uint64_t chainMask;
+	EPathfindingLayer layer = EPathfindingLayer::LAND;
+	EPathNodeAction action = EPathNodeAction::UNKNOWN;
+	uint64_t danger = 0;
+	const CGHeroInstance * targetHero = nullptr;
+	int parentIndex = -1;
+	uint64_t chainMask = 0;
 	std::shared_ptr<const SpecialAction> specialAction;
-	bool actionIsBlocked;
+	bool actionIsBlocked = false;
 };
 
 struct AIPath

--- a/AI/Nullkiller2/Pathfinding/AINodeStorage.h
+++ b/AI/Nullkiller2/Pathfinding/AINodeStorage.h
@@ -79,6 +79,7 @@ struct AIPathNodeInfo
 	uint8_t turns;
 	int3 coord;
 	EPathfindingLayer layer;
+	EPathNodeAction action;
 	uint64_t danger;
 	const CGHeroInstance * targetHero;
 	int parentIndex;
@@ -107,6 +108,9 @@ struct AIPath
 
 	/// Gets danger of path including danger of visiting the target object like creature bank
 	uint64_t getTotalDanger() const;
+
+	/// Returns true if path contains an actual battle action or the target visit itself causes army loss.
+	bool requiresBattle() const;
 
 	/// Gets danger of path including danger of visiting the target object like creature bank
 	uint64_t getTotalArmyLoss() const;

--- a/AI/Nullkiller2/Pathfinding/GraphPaths.cpp
+++ b/AI/Nullkiller2/Pathfinding/GraphPaths.cpp
@@ -254,7 +254,7 @@ void GraphPaths::addChainInfo(std::vector<AIPath> & paths, int3 tile, const CGHe
 				n.targetHero = hero;
 				n.parentIndex = -1;
 				n.specialAction = node.specialAction;
-				
+
 				if(node.linkDanger > 0)
 				{
 					auto additionalLoss = aiNk->pathfinder->getStorage()->evaluateArmyLoss(path.targetHero, strength, node.linkDanger);
@@ -339,7 +339,7 @@ void GraphPaths::quickAddChainInfoWithBlocker(std::vector<AIPath> & paths, int3 
 
 			current = currentNode.previous;
 		}
-		
+
 		if(tilesToPass.empty())
 			continue;
 
@@ -388,7 +388,7 @@ void GraphPaths::quickAddChainInfoWithBlocker(std::vector<AIPath> & paths, int3 
 					break;
 				}
 			}
-			
+
 			if(path.nodes.size() > 1)
 				continue;
 

--- a/AI/Nullkiller2/Pathfinding/GraphPaths.cpp
+++ b/AI/Nullkiller2/Pathfinding/GraphPaths.cpp
@@ -249,6 +249,7 @@ void GraphPaths::addChainInfo(std::vector<AIPath> & paths, int3 tile, const CGHe
 				n.coord = graphTile->coord;
 				n.cost = cost;
 				n.turns = static_cast<ui8>(cost) + 1; // just in case lets select worst scenario
+				n.action = EPathNodeAction::NORMAL;
 				n.danger = danger;
 				n.targetHero = hero;
 				n.parentIndex = -1;
@@ -365,6 +366,7 @@ void GraphPaths::quickAddChainInfoWithBlocker(std::vector<AIPath> & paths, int3 
 
 			n.targetHero = hero;
 			n.parentIndex = -1;
+			n.action = EPathNodeAction::NORMAL;
 
 			// final node
 			n.coord = tile;
@@ -397,6 +399,7 @@ void GraphPaths::quickAddChainInfoWithBlocker(std::vector<AIPath> & paths, int3 
 				n.coord = graphTile->coord;
 				n.cost = node.cost;
 				n.turns = static_cast<ui8>(node.cost);
+				n.action = EPathNodeAction::NORMAL;
 				n.danger = danger;
 				n.specialAction = node.specialAction;
 				n.parentIndex = path.nodes.size();

--- a/client/renderSDL/ScreenHandler.cpp
+++ b/client/renderSDL/ScreenHandler.cpp
@@ -378,7 +378,7 @@ EUpscalingFilter ScreenHandler::loadUpscalingFilter() const
 	Point logicalResolution = getPreferredLogicalResolution();
 
 	float scaleX = static_cast<float>(outputResolution.x) / logicalResolution.x;
-	float scaleY = static_cast<float>(outputResolution.x) / logicalResolution.x;
+	float scaleY = static_cast<float>(outputResolution.y) / logicalResolution.y;
 	float scaling = std::min(scaleX, scaleY);
 	int systemMemoryMb = SDL_GetSystemRAM();
 

--- a/lib/callback/AIFactory.cpp
+++ b/lib/callback/AIFactory.cpp
@@ -48,7 +48,7 @@ std::shared_ptr<CGlobalAI> AIFactory::createAdventureAI(const std::string & name
 
 std::shared_ptr<CBattleGameInterface> AIFactory::createBattleAI(const std::string & name)
 {
-	logGlobal->info("Creating battle AI %s", name);
+	logGlobal->trace("Creating battle AI %s", name);
 
 	if(name == "BattleAI")
 #ifdef ENABLE_BATTLE_AI

--- a/lib/callback/CGameInfoCallback.cpp
+++ b/lib/callback/CGameInfoCallback.cpp
@@ -33,6 +33,26 @@
 #define ERROR_RET_IF(cond, txt) do {if(cond){logGlobal->error("%s: %s", BOOST_CURRENT_FUNCTION, txt); return;}} while(0)
 #define ERROR_RET_VAL_IF(cond, txt, retVal) do {if(cond){logGlobal->error("%s: %s", BOOST_CURRENT_FUNCTION, txt); return retVal;}} while(0)
 
+static uint64_t getConfiguredRewardableGuardStrength(const Rewardable::Interface & rewardable, const CGHeroInstance * hero)
+{
+	uint64_t result = 0;
+
+	for(auto index : rewardable.getAvailableRewards(hero, Rewardable::EEventType::EVENT_FIRST_VISIT))
+	{
+		uint64_t rewardStrength = 0;
+
+		for(const auto & guard : rewardable.configuration.info[index].reward.guards)
+		{
+			if(guard.getType())
+				rewardStrength += guard.getType()->getAIValue() * guard.getCount();
+		}
+
+		vstd::amax(result, rewardStrength);
+	}
+
+	return result;
+}
+
 const IMarket * CGameInfoCallback::getMarket(ObjectInstanceID objid) const
 {
 	const CGObjectInstance * obj = getObj(objid, false);

--- a/lib/callback/CGameInfoCallback.cpp
+++ b/lib/callback/CGameInfoCallback.cpp
@@ -16,6 +16,7 @@
 #include "../gameState/InfoAboutArmy.h"
 #include "../gameState/TavernHeroesPool.h"
 #include "../mapObjects/CGHeroInstance.h"
+#include "../mapObjects/CRewardableObject.h"
 #include "../mapObjects/CGTownInstance.h"
 #include "../mapObjects/MiscObjects.h"
 #include "../spells/CSpell.h"
@@ -123,6 +124,34 @@ const CGObjectInstance * CGameInfoCallback::getObj(const ObjectInstanceID objId,
 	}
 
 	return ret;
+}
+
+bool CGameInfoCallback::getRewardableObjectInfo(const CGObjectInstance * object, InfoAboutRewardableObject & out, const CGHeroInstance * hero) const
+{
+	out = {};
+
+	const auto * rewardable = dynamic_cast<const CRewardableObject *>(object);
+	if(!rewardable)
+		return false;
+
+	auto player = getPlayerID();
+	out.scouted = !player.has_value() || rewardable->wasScouted(*player);
+
+	if(out.scouted)
+	{
+		out.cleared = rewardable->configuration.visitMode == Rewardable::VISIT_ONCE
+			? rewardable->onceVisitableObjectCleared
+			: hero ? rewardable->wasVisitedBefore(hero) : player.has_value() && rewardable->wasVisited(*player);
+
+		if(const auto * armed = dynamic_cast<const CArmedInstance *>(object))
+			out.guardStrength = armed->getArmyStrength();
+	}
+	else
+	{
+		out.guardStrength = getConfiguredRewardableGuardStrength(*rewardable, hero);
+	}
+
+	return true;
 }
 
 void CGameInfoCallback::fillUpgradeInfo(const CArmedInstance *obj, SlotID stackPos, UpgradeInfo & out) const

--- a/lib/callback/CGameInfoCallback.h
+++ b/lib/callback/CGameInfoCallback.h
@@ -14,6 +14,13 @@
 struct SThievesGuildInfo;
 class Player;
 
+struct DLL_LINKAGE InfoAboutRewardableObject
+{
+	bool scouted = false;
+	bool cleared = false;
+	uint64_t guardStrength = 0;
+};
+
 class DLL_LINKAGE CGameInfoCallback : public MapInfoCallback
 {
 protected:
@@ -72,6 +79,7 @@ public:
 	std::vector<const CGObjectInstance *> getFlaggableObjects(int3 pos) const;
 	const CGObjectInstance * getTopObj(int3 pos) const override;
 	const IMarket * getMarket(ObjectInstanceID objid) const;
+	bool getRewardableObjectInfo(const CGObjectInstance * object, InfoAboutRewardableObject & out, const CGHeroInstance * hero = nullptr) const;
 
 	//map
 

--- a/lib/gameState/GameStatePackVisitor.cpp
+++ b/lib/gameState/GameStatePackVisitor.cpp
@@ -1168,6 +1168,12 @@ void GameStatePackVisitor::visitSetObjectProperty(SetObjectProperty & pack)
 	{
 		obj->setProperty(pack.what, pack.identifier);
 	}
+
+	if(pack.what == ObjProperty::REWARD_CLEARED && !pack.identifier.getNum())
+	{
+		for(auto & team : gs.teams)
+			team.second.scoutedObjects.erase(pack.id);
+	}
 }
 
 void GameStatePackVisitor::visitHeroLevelUp(HeroLevelUp & pack)

--- a/lib/mapObjects/CRewardableObject.cpp
+++ b/lib/mapObjects/CRewardableObject.cpp
@@ -222,7 +222,8 @@ std::string CRewardableObject::getDisplayTextImpl(PlayerColor player, const CGHe
 	{
 		if(configuration.visitMode != Rewardable::VISIT_UNLIMITED)
 		{
-			if (wasVisited(hero))
+			const bool visited = configuration.visitMode == Rewardable::VISIT_ONCE ? onceVisitableObjectCleared : wasVisited(hero);
+			if (visited)
 				result += "\n" + configuration.visitedTooltip.toString();
 			else
 				result += "\n" + configuration.notVisitedTooltip.toString();
@@ -232,7 +233,8 @@ std::string CRewardableObject::getDisplayTextImpl(PlayerColor player, const CGHe
 	{
 		if(configuration.visitMode == Rewardable::VISIT_PLAYER || configuration.visitMode == Rewardable::VISIT_ONCE || configuration.visitMode == Rewardable::VISIT_PLAYER_GLOBAL)
 		{
-			if (wasVisited(player))
+			const bool visited = configuration.visitMode == Rewardable::VISIT_ONCE ? onceVisitableObjectCleared : wasVisited(player);
+			if (visited)
 				result += "\n" + configuration.visitedTooltip.toString();
 			else
 				result += "\n" + configuration.notVisitedTooltip.toString();

--- a/lib/mapObjects/CRewardableObject.h
+++ b/lib/mapObjects/CRewardableObject.h
@@ -17,6 +17,8 @@
 /// Inherits from CArmedInstance for proper transfer of armies
 class DLL_LINKAGE CRewardableObject : public CArmedInstance, public Rewardable::Interface
 {
+	friend class CGameInfoCallback;
+
 protected:
 
 	bool onceVisitableObjectCleared = false;

--- a/lib/mapObjects/MiscObjects.cpp
+++ b/lib/mapObjects/MiscObjects.cpp
@@ -895,6 +895,11 @@ void CGSignBottle::onHeroVisit(IGameEventCallback & gameEvents, const CGHeroInst
 		gameEvents.removeObject(this, h->getOwner());
 }
 
+bool CGSignBottle::passableFor(PlayerColor) const
+{
+	return ID == Obj::SIGN;
+}
+
 void CGSignBottle::serializeJsonOptions(JsonSerializeFormat& handler)
 {
 	handler.serializeStruct("text", message);

--- a/lib/mapObjects/MiscObjects.h
+++ b/lib/mapObjects/MiscObjects.h
@@ -51,6 +51,7 @@ public:
 
 	void onHeroVisit(IGameEventCallback & gameEvents, const CGHeroInstance * h) const override;
 	void initObj(IGameRandomizer & gameRandomizer) override;
+	bool passableFor(PlayerColor color) const override;
 
 	template <typename Handler> void serialize(Handler &h)
 	{

--- a/lib/pathfinder/PathfindingRules.cpp
+++ b/lib/pathfinder/PathfindingRules.cpp
@@ -253,6 +253,10 @@ PathfinderBlockingRule::BlockingReason MovementAfterDestinationRule::getBlocking
 			/// Transit via unguarded garrisons is always possible
 			return BlockingReason::NONE;
 		}
+		else if(destination.nodeObject->ID == Obj::SIGN)
+		{
+			return BlockingReason::NONE;
+		}
 		else if(const auto * source = destination.nodeObject->asQuestSource();
 			source && source->requiresQuestToPass() && !destination.nodeObject->isBlockedVisitable())
 		{

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -969,7 +969,8 @@ bool CGameHandler::moveHero(ObjectInstanceID hid, int3 dst, EMovementMode moveme
 	if(h->movementPointsRemaining() < cost && dst != h->pos && movementMode == EMovementMode::STANDARD)
 		return complainRet("Hero doesn't have any movement points left!");
 
-	if (transit && !canFly && !(canWalkOnSea && t.isWater()) && !CGTeleport::isTeleport(objectToVisit))
+	const bool transitOverPassableObject = objectToVisit && objectToVisit->passableFor(h);
+	if (transit && !canFly && !(canWalkOnSea && t.isWater()) && !CGTeleport::isTeleport(objectToVisit) && !transitOverPassableObject)
 		return complainRet("Hero cannot transit over this tile!");
 
 	//several generic blocks of code
@@ -1093,6 +1094,8 @@ bool CGameHandler::moveHero(ObjectInstanceID hid, int3 dst, EMovementMode moveme
 		if (transit)
 		{
 			if (CGTeleport::isTeleport(objectToVisit))
+				visitDest = DONT_VISIT_DEST;
+			if(transitOverPassableObject)
 				visitDest = DONT_VISIT_DEST;
 
 			if (canFly || (canWalkOnSea && t.isWater()))

--- a/server/battles/BattleProcessor.cpp
+++ b/server/battles/BattleProcessor.cpp
@@ -135,7 +135,7 @@ void BattleProcessor::startBattle(const CArmedInstance *army1, const CArmedInsta
 
 	auto attackerQuery = gameHandler->queries->topQuery(battle->getSide(BattleSide::ATTACKER).color);
 	auto * topBattleQuery = gameHandler->queries->queryAs<CBattleQuery>(attackerQuery);
-	if(!topBattleQuery && army2->getOwner().isValidPlayer())
+	if(!topBattleQuery && battle->getSide(BattleSide::DEFENDER).color.isValidPlayer())
 	{
 		auto defenderQuery = gameHandler->queries->topQuery(battle->getSide(BattleSide::DEFENDER).color);
 		topBattleQuery = gameHandler->queries->queryAs<CBattleQuery>(defenderQuery);

--- a/test/nullkiller2/Behaviors/EscapeBehaviorTest.cpp
+++ b/test/nullkiller2/Behaviors/EscapeBehaviorTest.cpp
@@ -60,6 +60,28 @@ TEST(Nullkiller2_Behaviors_EscapeBehavior, rejectsDestinationWithNoThreatReducti
 	EXPECT_FALSE(NK2AI::evaluateEscapePathCandidate(candidate).accepted);
 }
 
+TEST(Nullkiller2_Behaviors_EscapeBehavior, acceptsDestinationCloserToOwnedTown)
+{
+	auto candidate = makeAcceptedCandidate();
+	candidate.hasOwnedTown = true;
+	candidate.destinationGetsCloserToOwnedTown = true;
+	candidate.currentTownDistance = 100;
+	candidate.destinationTownDistance = 64;
+
+	EXPECT_TRUE(NK2AI::evaluateEscapePathCandidate(candidate).accepted);
+}
+
+TEST(Nullkiller2_Behaviors_EscapeBehavior, rejectsDestinationAwayFromOwnedTown)
+{
+	auto candidate = makeAcceptedCandidate();
+	candidate.hasOwnedTown = true;
+	candidate.destinationGetsCloserToOwnedTown = false;
+	candidate.currentTownDistance = 100;
+	candidate.destinationTownDistance = 121;
+
+	EXPECT_FALSE(NK2AI::evaluateEscapePathCandidate(candidate).accepted);
+}
+
 TEST(Nullkiller2_Behaviors_EscapeBehavior, acceptsDimensionDoorPathWhenItIsOtherwiseValid)
 {
 	auto candidate = makeAcceptedCandidate();


### PR DESCRIPTION
WIP. Current branch improves Nullkiller AI object scoring, path handling and hero task selection, but still needs more testing and cleanup.

  This PR aims to:
  - improve priority scoring for exploration, gathering and escape tasks
  - make AI handle critical resources, treasure chests and rewardable objects more reliably
  - avoid wasting MAIN hero movement on pickups that SCOUTs can safely take
  - improve hero-chain, army delivery and close reinforcement pickup behavior
  - allow pathfinding transit through signs while keeping human sign interaction intact
  - improve handling of dwellings, scouted/cleared rewardable objects and object revisit state
  - reduce noisy AI logging and keep extra scoring logs useful for debugging

  TODO:
  - [x] test behavior on different maps and adjust scoring where needed
  - [x] write basic tests for the most valuable cases
  - [ ] clean logging code naming and adjust what is logged and how
  - [ ] review commit split/order before marking ready
  - [ ] make a review run and clean what has to be cleaned