### PR TITLE
Fix town level calculation

### DIFF
--- a/lib/mapObjects/CGTownInstance.cpp
+++ b/lib/mapObjects/CGTownInstance.cpp
@@ -872,7 +872,7 @@ int CGTownInstance::getTownLevel() const
 	for(const auto & bid : builtBuildings)
 	{
 		const auto & building = getTown()->buildings.at(bid);
-		if(building->subId == BuildingID::VILLAGE_HALL || building->subId == BuildingID::FORT)
+		if(building->subId == BuildingSubID::VILLAGE_HALL || building->subId == BuildingSubID::FORT)
 			continue;
 		if(building->upgrade == BuildingID::NONE || building->upgrade == BuildingID::VILLAGE_HALL)
 			level++;

--- a/lib/mapObjects/CGTownInstance.cpp
+++ b/lib/mapObjects/CGTownInstance.cpp
@@ -865,11 +865,16 @@ bool CGTownInstance::armedGarrison() const
 int CGTownInstance::getTownLevel() const
 {
 	// count all buildings that are not upgrades
+	// H3 counts Town Hall as a structure, but not Village Hall
+	// Fort/Citadel/Castle are not considered structures for arrow tower damage
 	int level = 0;
 
 	for(const auto & bid : builtBuildings)
 	{
-		if(getTown()->buildings.at(bid)->upgrade == BuildingID::NONE)
+		const auto & building = getTown()->buildings.at(bid);
+		if(building->subId == BuildingID::VILLAGE_HALL || building->subId == BuildingID::FORT)
+			continue;
+		if(building->upgrade == BuildingID::NONE || building->upgrade == BuildingID::VILLAGE_HALL)
 			level++;
 	}
 	return level;

--- a/lib/mapObjects/CGTownInstance.cpp
+++ b/lib/mapObjects/CGTownInstance.cpp
@@ -870,10 +870,10 @@ int CGTownInstance::getTownLevel() const
 	int level = 0;
 
 	for(const auto & bid : builtBuildings)
-	{
-		const auto & building = getTown()->buildings.at(bid);
-		if(building->subId == BuildingSubID::VILLAGE_HALL || building->subId == BuildingSubID::FORT)
+	{	
+		if(bid == BuildingID::VILLAGE_HALL || bid == BuildingID::FORT)
 			continue;
+		const auto & building = getTown()->buildings.at(bid);
 		if(building->upgrade == BuildingID::NONE || building->upgrade == BuildingID::VILLAGE_HALL)
 			level++;
 	}


### PR DESCRIPTION
After testing, I have deduced the discrepancies in the arrow tower damage ranges:

1) Village Hall does NOT increase arrow tower damage, instead Town Hall (even tho it's an upgrade) is the one that increases the damage in that tree
2) Fort/Citadel/Castle straight up don't count

Once I figure out how to compare buildings, this can be tested lol