### PR TITLE
Fix Town Level calculation

### DIFF
--- a/lib/mapObjects/CGTownInstance.cpp
+++ b/lib/mapObjects/CGTownInstance.cpp
@@ -873,7 +873,6 @@ int CGTownInstance::getTownLevel() const
 	{	
 		if(bid == BuildingID::VILLAGE_HALL || bid == BuildingID::FORT)
 			continue;
-		const auto & building = ;
 		if(bid == BuildingID::TOWN_HALL || getTown()->buildings.at(bid)->upgrade == BuildingID::NONE)
 			level++;
 	}

--- a/lib/mapObjects/CGTownInstance.cpp
+++ b/lib/mapObjects/CGTownInstance.cpp
@@ -865,11 +865,16 @@ bool CGTownInstance::armedGarrison() const
 int CGTownInstance::getTownLevel() const
 {
 	// count all buildings that are not upgrades
+	// H3 counts Town Hall as a structure, but not Village Hall
+	// Fort/Citadel/Castle are not considered structures for arrow tower damage
 	int level = 0;
 
 	for(const auto & bid : builtBuildings)
-	{
-		if(getTown()->buildings.at(bid)->upgrade == BuildingID::NONE)
+	{	
+		if(bid == BuildingID::VILLAGE_HALL || bid == BuildingID::FORT)
+			continue;
+		const auto & building = ;
+		if(bid == BuildingID::TOWN_HALL || getTown()->buildings.at(bid)->upgrade == BuildingID::NONE)
 			level++;
 	}
 	return level;

--- a/lib/mapObjects/CGTownInstance.cpp
+++ b/lib/mapObjects/CGTownInstance.cpp
@@ -429,9 +429,9 @@ DamageRange CGTownInstance::getTowerDamageRange() const
 	// base damage, irregardless of town level
 	static constexpr int baseDamage = 6;
 	// extra damage, for each building in town
-	static constexpr int extraDamage = 1;
+	static constexpr int extraDamage = 2;
 
-	const int minDamage = baseDamage + extraDamage * getTownLevel();
+	const int minDamage = baseDamage + extraDamage * (getTownLevel() / 2);
 
 	return {
 		minDamage,


### PR DESCRIPTION
After testing, I have deduced the discrepancies in the arrow tower damage ranges:
1) Village Hall does NOT increase arrow tower damage, instead Town Hall (even tho it's an upgrade) is the one that increases the damage in that tree
2) Fort/Citadel/Castle straight up don't count
3) Upper and Lower Tower scale incorrectly. They currently get 1 damage per structure but instead they should get 2 damage per 2 structures rounded down.

I have added this logic to the town level calculation, adjusted the side tower damage range calculations and tested on this map:
[ARROW TOWER TEST SOD.zip](https://github.com/user-attachments/files/30676326/ARROW.TOWER.TEST.SOD.zip)
Results show SoD - VCMI.
Note: SoD's maximum damage display is bugged and assumes 3 max damage per building although it adds 4. It also shows the Attack skill of the Tower but does not use it in damage calculation (in other words: displayed damage is a mess, minimum damage is correctly displayed tho).

1) Rampart town with random amount of buildings (I built and unbuilt random buildings in map editor)
<img width="891" height="377" alt="rampart" src="https://github.com/user-attachments/assets/315b147d-af89-4c27-bde3-e04401091d0c" />

2) Fully build Tower town (no grail)
<img width="896" height="382" alt="towerfull" src="https://github.com/user-attachments/assets/180955d8-9631-40fc-8df7-7bb559900be8" />

3) Tower town with only Castle being built
<img width="890" height="383" alt="toweronlycastle" src="https://github.com/user-attachments/assets/de5432f1-ba83-4ce1-b342-1e393abc3f53" />

4) Tower town with only Castle and Town Hall being built
<img width="890" height="383" alt="towercastlehall" src="https://github.com/user-attachments/assets/1fdf9643-25f8-4171-b3c9-4329762da092" />

