### PR TITLE
Implement basic tactics support for BattleAI

### DIFF
--- a/AI/BattleAI/BattleAI.cpp
+++ b/AI/BattleAI/BattleAI.cpp
@@ -98,9 +98,9 @@ void CBattleAI::yourTacticPhase(const BattleID & battleID, int distance)
 	tacticsHandler->onTacticsStarted();
 }
 
-void CBattleAI::battleStackMoved(const BattleID & battleID, const CStack * stack, const BattleHexArray & dest, int distance, bool teleport)
+void CBattleAI::actionFinished(const BattleID & battleID, const BattleAction & action)
 {
-	tacticsHandler->onStackMoved(stack);
+	tacticsHandler->onActionFinished(action);
 }
 
 static float getStrengthRatio(std::shared_ptr<CBattleInfoCallback> cb, BattleSide side)
@@ -250,7 +250,7 @@ void CBattleAI::battleStart(const BattleID & battleID, const CCreatureSet *army1
 	LOG_TRACE(logAi);
 	side = Side;
 	auto tacticsSettings = TacticsHandler::Settings{.enabled = autobattlePreferences.enableTacticsUsage};
-	tacticsHandler = std::make_shared<TacticsHandler>(cb, battleID, tacticsSettings);
+	tacticsHandler = std::make_unique<TacticsHandler>(cb, battleID, tacticsSettings);
 }
 
 void CBattleAI::print(const std::string &text) const

--- a/AI/BattleAI/BattleAI.cpp
+++ b/AI/BattleAI/BattleAI.cpp
@@ -95,7 +95,12 @@ BattleAction CBattleAI::useHealingTent(const BattleID & battleID, const CStack *
 
 void CBattleAI::yourTacticPhase(const BattleID & battleID, int distance)
 {
-	cb->battleMakeTacticAction(battleID, BattleAction::makeEndOFTacticPhase(cb->getBattle(battleID)->battleGetTacticsSide()));
+	tacticsHandler->onTacticsStarted();
+}
+
+void CBattleAI::battleStackMoved(const BattleID & battleID, const CStack * stack, const BattleHexArray & dest, int distance, bool teleport)
+{
+	tacticsHandler->onStackMoved(stack);
 }
 
 static float getStrengthRatio(std::shared_ptr<CBattleInfoCallback> cb, BattleSide side)
@@ -244,6 +249,8 @@ void CBattleAI::battleStart(const BattleID & battleID, const CCreatureSet *army1
 {
 	LOG_TRACE(logAi);
 	side = Side;
+	auto tacticsSettings = TacticsHandler::Settings{.enabled = autobattlePreferences.enableTacticsUsage};
+	tacticsHandler = std::make_shared<TacticsHandler>(cb, battleID, tacticsSettings);
 }
 
 void CBattleAI::print(const std::string &text) const

--- a/AI/BattleAI/BattleAI.h
+++ b/AI/BattleAI/BattleAI.h
@@ -57,7 +57,7 @@ class CBattleAI : public CBattleGameInterface
 	bool wasWaitingForRealize;
 	int movesSkippedByDefense;
 
-	std::shared_ptr<TacticsHandler> tacticsHandler;
+	std::unique_ptr<TacticsHandler> tacticsHandler;
 
 public:
 	CBattleAI();
@@ -76,7 +76,7 @@ public:
 	BattleAction useHealingTent(const BattleID & battleID, const CStack *stack);
 
 	void battleStart(const BattleID & battleID, const CCreatureSet * army1, const CCreatureSet * army2, int3 tile, const CGHeroInstance * hero1, const CGHeroInstance * hero2, BattleSide side, bool replayAllowed) override;
-	//void actionFinished(const BattleAction &action) override;//occurs AFTER every action taken by any stack or by the hero
+	void actionFinished(const BattleID & battleID, const BattleAction & action) override;
 	//void actionStarted(const BattleAction &action) override;//occurs BEFORE every action taken by any stack or by the hero
 	//void battleAttack(const BattleAttack *ba) override; //called when stack is performing attack
 	//void battleStacksAttacked(const std::vector<BattleStackAttacked> & bsa, bool ranged) override; //called when stack receives damage (after battleAttack())
@@ -84,7 +84,7 @@ public:
 	//void battleResultsApplied() override; //called when all effects of last battle are applied
 	//void battleNewRoundFirst(int round) override; //called at the beginning of each turn before changes are applied;
 	//void battleNewRound(int round) override; //called at the beginning of each turn, round=-1 is the tactic phase, round=0 is the first "normal" turn
-	void battleStackMoved(const BattleID & battleID, const CStack * stack, const BattleHexArray & dest, int distance, bool teleport) override;
+	//void battleStackMoved(const BattleID & battleID, const CStack * stack, const BattleHexArray & dest, int distance, bool teleport) override;
 	//void battleSpellCast(const BattleSpellCast *sc) override;
 	//void battleStacksEffectsSet(const SetStackEffect & sse) override;//called when a specific effect is set to stacks
 	//void battleTriggerEffect(const BattleTriggerEffect & bte) override;

--- a/AI/BattleAI/BattleAI.h
+++ b/AI/BattleAI/BattleAI.h
@@ -12,6 +12,7 @@
 #include "../../lib/callback/CGameInterface.h"
 #include "PossibleSpellcast.h"
 #include "PotentialTargets.h"
+#include "TacticsHandler.h"
 
 class CSpell;
 
@@ -56,6 +57,8 @@ class CBattleAI : public CBattleGameInterface
 	bool wasWaitingForRealize;
 	int movesSkippedByDefense;
 
+	std::shared_ptr<TacticsHandler> tacticsHandler;
+
 public:
 	CBattleAI();
 	~CBattleAI();
@@ -81,7 +84,7 @@ public:
 	//void battleResultsApplied() override; //called when all effects of last battle are applied
 	//void battleNewRoundFirst(int round) override; //called at the beginning of each turn before changes are applied;
 	//void battleNewRound(int round) override; //called at the beginning of each turn, round=-1 is the tactic phase, round=0 is the first "normal" turn
-	//void battleStackMoved(const CStack * stack, BattleHexArray dest, int distance) override;
+	void battleStackMoved(const BattleID & battleID, const CStack * stack, const BattleHexArray & dest, int distance, bool teleport) override;
 	//void battleSpellCast(const BattleSpellCast *sc) override;
 	//void battleStacksEffectsSet(const SetStackEffect & sse) override;//called when a specific effect is set to stacks
 	//void battleTriggerEffect(const BattleTriggerEffect & bte) override;

--- a/AI/BattleAI/CMakeLists.txt
+++ b/AI/BattleAI/CMakeLists.txt
@@ -6,6 +6,7 @@ set(battleAI_SRCS
 		PotentialTargets.cpp
 		StackWithBonuses.cpp
 		SpellTargetsEvaluator.cpp
+		TacticsHandler.cpp
 		ThreatMap.cpp
 		BattleExchangeVariant.cpp
 )
@@ -20,6 +21,7 @@ set(battleAI_HEADERS
 		PossibleSpellcast.h
 		StackWithBonuses.h
 		SpellTargetsEvaluator.h
+		TacticsHandler.h
 		ThreatMap.h
 		BattleExchangeVariant.h
 )

--- a/AI/BattleAI/TacticsHandler.cpp
+++ b/AI/BattleAI/TacticsHandler.cpp
@@ -193,20 +193,20 @@ std::vector<const CStack *> TacticsHandler::findVIPs() const
 	return res;
 }
 
-std::vector<const CStack *> TacticsHandler::findGuards(const std::vector<const CStack*> & vips) const
+std::vector<const CStack *> TacticsHandler::findGuards() const
 {
-	auto guards = battle->battleGetStacks(CBattleInfoEssentials::ONLY_MINE);
-	assert(guards.size() > 0);
+	auto stacks = battle->battleGetStacks(CBattleInfoEssentials::ONLY_MINE);
+	assert(stacks.size() > 0);
 	std::erase_if(
-		guards,
-		[&vips](const CStack * guard)
+		stacks,
+		[this](const CStack * guard)
 		{
 			return guard->getMovementRange() == 0 \
 				|| std::ranges::find(vips, guard) != vips.end();
 		}
 	);
-	std::ranges::sort(guards, std::less{}, CalcStackValue);
-	return guards;
+	std::ranges::sort(stacks, std::less{}, CalcStackValue);
+	return stacks;
 }
 
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
@@ -475,10 +475,8 @@ TacticsHandler::SpecialHexes TacticsHandler::getSpecialHexes() const
 
 void TacticsHandler::onTacticsStarted()
 {
-	std::cout << "onTacticsStarted: ROUND: " << battle->battleGetRound() << " " << this << "\n";
 	if (battle->battleTacticDist() == 0)
 	{
-		std::cout << "tactics dist == 0, bail\n";
 		phase = Phase::INACTIVE;
 		return;
 	}
@@ -503,7 +501,7 @@ void TacticsHandler::tacticMove(const CStack * cstack, const BattleHex & bh)
 void TacticsHandler::handle()
 {
 	vips = findVIPs();
-	guards = findGuards(vips);
+	guards = findGuards();
 	specialHexes = getSpecialHexes();
 	guardIndex = 0;
 	vipIndex = 0;
@@ -653,9 +651,6 @@ std::optional<BattleHex> TacticsHandler::findGuardDestination(const CStack * gua
 
 void TacticsHandler::onActionFinished(const BattleAction & action)
 {
-	std::cout << "onActionFinished: DIST: " << static_cast<int>(battle->battleTacticDist()) << "\n";
-	std::cout << "onActionFinished: ROUND: " << battle->battleGetRound() << "\n";
-
 	if (battle->battleTacticDist() == 0)
 	{
 		phase = Phase::INACTIVE;

--- a/AI/BattleAI/TacticsHandler.cpp
+++ b/AI/BattleAI/TacticsHandler.cpp
@@ -1,0 +1,612 @@
+/*
+ * Tactics.cpp, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
+
+#include "StdInc.h" // IWYU pragma: keep
+
+#include "TacticsHandler.h" // IWYU pragma: keep
+
+#include "CStack.h"
+#include "battle/BattleAction.h"
+#include "battle/BattleHex.h"
+
+namespace
+{
+	void debug(const std::string & msg)
+	{
+		logAi->debug("[Tactics] " + msg);
+	}
+
+	void info(const std::string & msg)
+	{
+		logAi->info("[Tactics] " + msg);
+	}
+
+	int CalcStackValue(const CStack * stack)
+	{
+		return stack->getCount() * stack->unitType()->getAIValue();
+	}
+
+	BattleHex CloneHex(const BattleHex & bh, const std::initializer_list<BattleHex::EDir> & dirs)
+	{
+		auto res = bh;
+		for(const auto dir : dirs)
+			res = res.cloneInDirection(dir, false);
+		return res;
+	}
+
+	struct VipInfo
+	{
+		const BattleHex vipPos;
+		const BattleSide vipSide;
+		const bool vipWide;
+		const bool guardWide;
+
+		bool operator==(const VipInfo &) const = default;
+	};
+
+	struct VipInfoHash
+	{
+		std::size_t operator()(const VipInfo & vi) const
+		{
+			std::size_t h = std::hash<si16>{}(vi.vipPos.toInt());
+			h ^= std::hash<int>{}(static_cast<int>(vi.vipSide)) << 1;
+			h ^= std::hash<bool>{}(vi.guardWide) << 2;
+			h ^= std::hash<bool>{}(vi.vipWide) << 3;
+			return h;
+		}
+	};
+}
+
+TacticsHandler::TacticsHandler(const std::shared_ptr<CBattleCallback> & cb, const BattleID & bid, Settings settings)
+: cb(cb), battle(cb->getBattle(bid)), bid(bid), settings(settings), asyncTasks(std::make_unique<AsyncRunner>())
+{}
+
+bool TacticsHandler::canHandle() const
+{
+	auto myStacks = battle->battleGetStacks(CBattleInfoEssentials::ONLY_MINE);
+	auto enemyStacks = battle->battleGetStacks(CBattleInfoEssentials::ONLY_ENEMY);
+
+	auto myArmyValue = 0;
+	for (const CStack * stack : myStacks)
+		myArmyValue += CalcStackValue(stack);
+
+	auto immuneToDeathCloud = std::ranges::all_of(
+		myStacks,
+		[](const CStack * stack)
+		{
+			return stack->hasBonusOfType(BonusType::UNDEAD)
+				|| stack->hasBonusOfType(BonusType::NON_LIVING);
+		}
+	);
+
+	auto haveEnemyShooterWithAoE = std::ranges::any_of(
+		enemyStacks,
+		[this, myArmyValue, immuneToDeathCloud](const CStack * stack)
+		{
+			// Ignore weak shooters
+			if(static_cast<float>(CalcStackValue(stack)) / myArmyValue < settings.vipThreshold)
+				return false;
+
+			for(const auto & bonus : *stack->getBonusesOfType(BonusType::SPELL_LIKE_ATTACK))
+			{
+				const auto spellID = bonus->subtype.as<SpellID>();
+				if(spellID == SpellID::FIREBALL || (spellID == SpellID::DEATH_CLOUD && !immuneToDeathCloud))
+					return true;
+			}
+
+			return false;
+		});
+
+	if (haveEnemyShooterWithAoE)
+	{
+		info("Enemy AoE shooter found, skip tactics");
+		return false;
+	}
+
+	auto haveFastEnemyWithBreath = std::ranges::any_of(
+		enemyStacks,
+		[](const CStack * stack)
+		{
+			if(!stack->hasBonusOfType(BonusType::TWO_HEX_ATTACK_BREATH))
+				return false;
+
+			const auto y = stack->getPosition().getY();
+			const auto speed = stack->getMovementRange() + static_cast<int>(stack->doubleWide());
+
+			if (y == 0 || y == 10)
+				return speed >= 11;
+			else if (y <= 2 || y >= 8)
+				return speed >= 12;
+			else if (y <= 4 || y >= 6)
+				return speed >= 13;
+			else
+				return speed >= 14;
+		});
+
+	if (haveFastEnemyWithBreath)
+	{
+		info("Fast enemy with breath found, skip tactics");
+		return false;
+	}
+
+	return true;
+}
+
+void TacticsHandler::end()
+{
+	cb->battleMakeTacticAction(bid, BattleAction::makeEndOFTacticPhase(battle->battleGetMySide()));
+};
+
+std::vector<const CStack *> TacticsHandler::findVIPs() const
+{
+	struct VipData
+	{
+		const CStack * stack;
+		int score;
+	};
+
+	auto vipdatas = std::vector<VipData>{};
+	int armyValue = 0;
+
+	const auto mystacks = battle->battleGetStacks(CBattleInfoEssentials::EStackOwnership::ONLY_MINE);
+
+	for(const auto & stack : mystacks)
+	{
+		int value = CalcStackValue(stack);
+		armyValue += value;
+		// growth > 0 excludes ballistas, commanders, etc.
+		if(stack->unitType()->getGrowth() > 0 && stack->isShooter())
+		{
+			bool noMelee = stack->hasBonusOfType(BonusType::NO_MELEE_PENALTY);
+			auto mult = noMelee ? 0.7 : 1.0;
+			auto score = static_cast<int>(value * mult);
+			vipdatas.emplace_back(VipData{.stack = stack, .score = score});
+		}
+	}
+
+	// Ignore weak vips
+	std::erase_if(
+		vipdatas,
+		[this, armyValue](const VipData & vipdata)
+		{
+			return vipdata.score < settings.vipThreshold * armyValue;
+		}
+	);
+
+	// Sort by score (descending)
+	std::ranges::sort(vipdatas, std::greater{}, &VipData::score);
+
+	// Map to cstack
+	auto res = std::vector<const CStack *>{};
+	res.reserve(vipdatas.size());
+	std::ranges::transform(vipdatas, std::back_inserter(res), &VipData::stack);
+
+	return res;
+}
+
+std::vector<const CStack *> TacticsHandler::findGuards(const std::vector<const CStack*> & vips) const
+{
+	auto guards = battle->battleGetStacks(CBattleInfoEssentials::ONLY_MINE);
+	assert(guards.size() > 0);
+	std::erase_if(
+		guards,
+		[&vips](const CStack * guard)
+		{
+			return guard->getMovementRange() == 0 \
+				|| std::ranges::find(vips, guard) != vips.end();
+		}
+	);
+	std::ranges::sort(guards, std::less{}, CalcStackValue);
+	return guards;
+}
+
+// NOLINTNEXTLINE(readability-function-cognitive-complexity)
+std::vector<BattleHex> TacticsHandler::GuardableHexes(const CStack * vip, const CStack * guard) // NOSONAR
+{
+	auto res = std::vector<BattleHex>{};
+	res.reserve(16);
+
+	BattleHex vipHead = vip->getPosition();
+
+	static auto cache = std::unordered_map<VipInfo, std::vector<BattleHex>, VipInfoHash>{};
+	const auto vi = VipInfo{.vipPos = vip->getPosition(), .vipSide = vip->unitSide(), .vipWide = vip->doubleWide(), .guardWide = guard->doubleWide()};
+
+	auto it = cache.find(vi);
+
+	if(it != cache.end())
+		return it->second;
+
+	using EDir = BattleHex::EDir;
+	auto L = EDir::LEFT;
+	auto TL = EDir::TOP_LEFT;
+	auto BL = EDir::BOTTOM_LEFT;
+	auto R = EDir::RIGHT;
+	auto TR = EDir::TOP_RIGHT;
+	auto BR = EDir::BOTTOM_RIGHT;
+
+	auto add = [&res, &vipHead](const std::initializer_list<BattleHex::EDir> dirs)
+	{
+		auto hex = CloneHex(vipHead, dirs);
+		if(hex.isAvailable())
+			res.push_back(hex);
+	};
+
+	auto convex = vip->unitSide() == BattleSide::LEFT_SIDE ? vipHead.getY() % 2 == 0 : vipHead.getY() % 2 == 1;
+
+	std::ostringstream oss;
+	oss << "vipHead=" << vipHead.toInt()
+		<< " vip->unitSide()=" << static_cast<int>(vip->unitSide())
+		<< " / guard->doubleWide()=" << static_cast<int>(guard->doubleWide())
+		<< " / vip->doubleWide()=" << static_cast<int>(vip->doubleWide())
+		<< " / vipHead.getY()=" << static_cast<int>(vipHead.getY());
+	debug(oss.str());
+
+	if(vip->unitSide() == BattleSide::RIGHT_SIDE)
+	{
+		if(guard->doubleWide())
+		{
+			if(vip->doubleWide())
+			{
+				/*
+				 *  2-hex VIP, 2-hex guard
+				 *  (R/convex)              (R/concave)
+				 *  . . . . .                 . . . . .
+				 * . . 6 1 3 .               . . 6 1 .
+				 *  . 5 . x ~                 . 5 . x ~
+				 * . . 7 2 4 .               . . 7 2 .
+				 *  . . . . .                 . . . . .
+				 */
+				add({TL}); // 1
+				add({BL}); // 2
+
+				if(convex)
+				{
+					add({TR}); // 3
+					add({BR}); // 4
+				}
+
+				add({L, L}); // 5
+				add({L, TL}); // 6
+				add({L, BL}); // 7
+			}
+			else
+			{
+				/*
+				 *  1-hex VIP, 2-hex guard
+				 *  (R/convex)              (R/concave)
+				 *  . . . . .               . . . . .
+				 * . . . 4 1 .             . . . 4 .
+				 *  . . 3 . x               . . 3 . x
+				 * . . . 5 2 .             . . . 5 .
+				 *  . . . . .               . . . . .
+				 */
+				if(convex)
+				{
+					add({TL}); // 1
+					add({BL}); // 2
+				}
+
+				add({L, L}); // 3
+				add({L, TL}); // 4
+				add({L, BL}); // 5
+			}
+		}
+		else
+		{
+			if(vip->doubleWide())
+			{
+				/*
+				 *  2-hex VIP, 1-hex guard
+				 *  (R/convex)              (R/concave)
+				 *  . . . . .                 . . . . . .
+				 * . . . 2 4 6                 . . . 2 4
+				 *  . . 1 x ~                 . . . 1 x ~
+				 * . . . 3 5 7                 . . . 3 5
+				 *  . . . . .                 . . . . . .
+				 */
+				add({L}); // 1
+				add({TL}); // 2
+				add({BL}); // 3
+				add({TR}); // 4
+				add({BR}); // 5
+
+				if(convex)
+				{
+					add({R, TR}); // 6
+					add({R, BR}); // 7
+				}
+			}
+			else
+			{
+				/*
+				 *  1-hex VIP, 1-hex guard
+				 *  (R/convex)              (R/concave)
+				 *  . . . . .                 . . . . .
+				 * . . . . 2 4               . . . . 2
+				 *  . . . 1 x                 . . . 1 x
+				 * . . . . 3 5               . . . . 3
+				 *  . . . . .                 . . . . .
+				 */
+				add({L}); // 1
+				add({TL}); // 2
+				add({BL}); // 3
+
+				if(convex)
+				{
+					add({TR}); // 4
+					add({BR}); // 5
+				}
+			}
+		}
+	}
+	else
+	{
+		if(guard->doubleWide())
+		{
+			if(vip->doubleWide())
+			{
+				/*
+				 *  2-hex VIP, 2-hex guard
+				 *  (L/convex)              (L/concave)
+				 *  . . . . .                 . . . . .
+				 * . 3 1 6 . .                 . 1 6 . .
+				 *  ~ x . 5 .                 ~ x . 5 .
+				 * . 4 2 7 . .                 . 2 7 . .
+				 *  . . . . .                 . . . . .
+				 */
+				add({TR}); // 1
+				add({BR}); // 2
+
+				if(convex)
+				{
+					add({TL}); // 3
+					add({BL}); // 4
+				}
+
+				add({R, R}); // 5
+				add({R, TR}); // 6
+				add({R, BR}); // 7
+			}
+			else
+			{
+				/*
+				 *  1-hex VIP, 2-hex guard
+				 *  (L/convex)              (L/concave)
+				 *  . . . . .               . . . . .
+				 * . 1 4 . . .               . 4 . . .
+				 *  x . 3 . .               x . 3 . .
+				 * . 2 5 . . .               . 5 . . .
+				 *  . . . . .               . . . . .
+				 */
+				if(convex)
+				{
+					add({TR}); // 1
+					add({BR}); // 2
+				}
+
+				add({R, R}); // 3
+				add({R, TR}); // 4
+				add({R, BR}); // 5
+			}
+		}
+		else
+		{
+			if(vip->doubleWide())
+			{
+				/*
+				 *  2-hex VIP, 1-hex guard
+				 *  (L/upper/convex)         (L/upper/concave)
+				 *  . . . . .                 . . . . . .
+				 * 6 4 2 . . .                 4 2 . . . .
+				 *  ~ x 1 . .                 ~ x 1 . . .
+				 * 7 5 3 . . .                 5 3 . . . .
+				 *  . . . . .                 . . . . . .
+				 */
+				add({R}); // 1
+				add({TR}); // 2
+				add({BR}); // 3
+				add({TL}); // 4
+				add({BL}); // 5
+
+				if(convex)
+				{
+					add({L, TL}); // 6
+					add({L, BL}); // 7
+				}
+			}
+			else
+			{
+				/*
+				 *  1-hex VIP, 1-hex guard
+				 *  (L/convex)              (L/concave)
+				 *  . . . . .                 . . . . .
+				 * 4 2 . . . .                 2 . . . .
+				 *  x 1 . . .                 x 1 . . .
+				 * 5 3 . . . .                 3 . . . .
+				 *  . . . . .                 . . . . .
+				 */
+				add({R}); // 1
+				add({TR}); // 2
+				add({BR}); // 3
+
+				if(convex)
+				{
+					add({TL}); // 4
+					add({BL}); // 5
+				}
+			}
+		}
+	}
+
+	cache.try_emplace(vi, res);
+	return res;
+}
+
+TacticsHandler::SpecialHexes TacticsHandler::getSpecialHexes() const
+{
+	auto side = battle->battleGetMySide();
+	auto isLeft = side == BattleSide::LEFT_SIDE;
+	const auto & [cornerHex1, cornerHex2] = isLeft ? std::pair<BattleHex, BattleHex>{1, 171} : std::pair<BattleHex, BattleHex>{15, 185};
+
+	auto tempHexes = isLeft ? std::vector<BattleHex>{69, 103, 86, 52, 120} : std::vector<BattleHex>{83, 117, 100, 66, 134};
+	auto offset = isLeft ? 1 : -1;
+	auto tempSize = tempHexes.size();
+
+	for(int m = 0; m < 2; ++m)
+		for(int i = 0; i < tempSize; ++i)
+			tempHexes.emplace_back(tempHexes[i].toInt() + (m * offset));
+
+	return {.corner1=cornerHex1,
+			.corner2=cornerHex2,
+			.corner1Wide=BattleHex(cornerHex1.toInt() + offset),
+			.corner2Wide=BattleHex(cornerHex2.toInt() + offset),
+			.tempHexes=tempHexes};
+}
+
+
+void TacticsHandler::onTacticsStarted()
+{
+	if (!settings.enabled || !canHandle())
+	{
+		end();
+		return;
+	}
+
+	asyncTasks->run(
+		[this]()
+		{
+			handle();
+			end();
+		});
+}
+
+void TacticsHandler::tacticMove(const CStack * cstack, const BattleHex & bh)
+{
+	logAi->debug("[Tactics] Moving to hex %d", bh.toInt());
+	std::unique_lock lock(mutex);
+	movingStack = cstack;
+	cb->battleMakeUnitAction(bid, BattleAction::makeMove(cstack, bh));
+	auto success = cond.wait_for(
+		lock,
+		std::chrono::seconds(10),
+		[this]
+		{
+			return movingStack == nullptr;
+		}
+	);
+
+	success ? logAi->debug("[Tactics] Move finished") : logAi->debug("[Tactics] Stack still moving after 10s");
+}
+
+void TacticsHandler::moveGuardsAwayFromCorners(const std::vector<const CStack *> & guards, const SpecialHexes & specialHexes)
+{
+	for(const CStack * guard : guards)
+	{
+		if(!guard->coversPos(specialHexes.corner1) && !guard->coversPos(specialHexes.corner2))
+			continue;
+
+		const auto reachability = battle->getReachability(guard);
+		for(const auto & bh : specialHexes.tempHexes)
+		{
+			if(reachability.isReachable(bh))
+			{
+				tacticMove(guard, bh);
+				break;
+			}
+		}
+	}
+}
+
+void TacticsHandler::moveVipsToCorners(const std::vector<const CStack *> & vips, const SpecialHexes & specialHexes)
+{
+
+	auto vipsToMove = std::vector<const CStack *>{};
+	for(const CStack * vip : vips)
+		if(vipsToMove.size() < 2 && !vip->coversPos(specialHexes.corner1) && !vip->coversPos(specialHexes.corner2))
+			vipsToMove.push_back(vip);
+
+	for(const CStack * vip : vipsToMove)
+	{
+		const auto reachability = battle->getReachability(vip);
+		const auto destinations = vip->doubleWide()
+									? std::vector<BattleHex>{specialHexes.corner1Wide, specialHexes.corner2Wide}
+									: std::vector<BattleHex>{specialHexes.corner1, specialHexes.corner2};
+
+		for(const auto & bh : destinations)
+		{
+			if(reachability.isReachable(bh))
+			{
+				tacticMove(vip, bh);
+				break;
+			}
+		}
+	}
+}
+
+void TacticsHandler::moveGuardsAroundVips(const std::vector<const CStack*> & guards, const std::vector<const CStack*> & vips)
+{
+	// Initial pass might fail if some units were blocked by obstacles
+	// => loop again in case they have become unblocked
+	for(int i = 0; i < 2; ++i)
+		for(const CStack * guard : guards)
+			for(const auto * vip : vips)
+				if(guardVip(guard, vip))
+					break;
+}
+
+void TacticsHandler::handle()
+{
+	const auto vips = findVIPs();
+	const auto guards = findGuards(vips);
+	const auto specialHexes = getSpecialHexes();
+
+	for(const CStack * vip : vips)
+		logAi->debug("VIP: " + vip->getDescription());
+
+	moveGuardsAwayFromCorners(guards, specialHexes);
+	moveVipsToCorners(vips, specialHexes);
+	moveGuardsAroundVips(guards, vips);
+}
+
+bool TacticsHandler::guardVip(const CStack * guard, const CStack * vip)
+{
+	assert(vip);
+	logAi->debug("Handling GUARD stack %s (vip=%s)", guard->getDescription(), vip->getDescription());
+
+	const auto hexes = GuardableHexes(vip, guard);
+	const auto reachability = cb->getBattle(bid)->getReachability(guard);
+
+	BattleHex target;
+
+	for(const auto hex : hexes)
+	{
+		if(guard->getPosition() == hex)
+			break;
+
+		if(reachability.isReachable(hex) && cb->getBattle(bid)->isInTacticRange(hex))
+		{
+			tacticMove(guard, hex);
+			return true;
+		}
+	}
+
+	logAi->debug("No viable guard move (VIP unreachable or already surrounded)");
+	return false;
+}
+
+void TacticsHandler::onStackMoved(const CStack * stack)
+{
+	if(stack != movingStack)
+		return;
+
+	std::lock_guard lock(mutex);
+	movingStack = nullptr;
+	cond.notify_one();
+}

--- a/AI/BattleAI/TacticsHandler.cpp
+++ b/AI/BattleAI/TacticsHandler.cpp
@@ -209,8 +209,7 @@ std::vector<const CStack *> TacticsHandler::findGuards() const
 	return stacks;
 }
 
-// NOLINTNEXTLINE(readability-function-cognitive-complexity)
-std::vector<BattleHex> TacticsHandler::GuardableHexes(const CStack * vip, const CStack * guard) // NOSONAR
+std::vector<BattleHex> TacticsHandler::guardableHexes(const CStack * vip, const CStack * guard) // NOSONAR
 {
 	auto res = std::vector<BattleHex>{};
 	res.reserve(16);
@@ -633,7 +632,7 @@ std::optional<BattleHex> TacticsHandler::findGuardDestination(const CStack * gua
 	assert(vip);
 	logAi->debug("Handling GUARD stack %s (vip=%s)", guard->getDescription(), vip->getDescription());
 
-	const auto hexes = GuardableHexes(vip, guard);
+	const auto hexes = guardableHexes(vip, guard);
 	const auto reachability = cb->getBattle(bid)->getReachability(guard);
 
 	for(const auto hex : hexes)

--- a/AI/BattleAI/TacticsHandler.cpp
+++ b/AI/BattleAI/TacticsHandler.cpp
@@ -65,8 +65,9 @@ namespace
 }
 
 TacticsHandler::TacticsHandler(const std::shared_ptr<CBattleCallback> & cb, const BattleID & bid, Settings settings)
-: cb(cb), battle(cb->getBattle(bid)), bid(bid), settings(settings), asyncTasks(std::make_unique<AsyncRunner>())
-{}
+: cb(cb), battle(cb->getBattle(bid)), bid(bid), settings(settings)
+{
+}
 
 bool TacticsHandler::canHandle() const
 {
@@ -106,7 +107,7 @@ bool TacticsHandler::canHandle() const
 
 	if (haveEnemyShooterWithAoE)
 	{
-		info("Enemy AoE shooter found, skip tactics");
+		info("Enemy AoE shooter found; stop");
 		return false;
 	}
 
@@ -132,7 +133,7 @@ bool TacticsHandler::canHandle() const
 
 	if (haveFastEnemyWithBreath)
 	{
-		info("Fast enemy with breath found, skip tactics");
+		info("Fast enemy with breath found; stop");
 		return false;
 	}
 
@@ -141,6 +142,7 @@ bool TacticsHandler::canHandle() const
 
 void TacticsHandler::end()
 {
+	info("Ending tactics");
 	cb->battleMakeTacticAction(bid, BattleAction::makeEndOFTacticPhase(battle->battleGetMySide()));
 };
 
@@ -473,109 +475,162 @@ TacticsHandler::SpecialHexes TacticsHandler::getSpecialHexes() const
 
 void TacticsHandler::onTacticsStarted()
 {
+	std::cout << "onTacticsStarted: ROUND: " << battle->battleGetRound() << " " << this << "\n";
+	if (battle->battleTacticDist() == 0)
+	{
+		std::cout << "tactics dist == 0, bail\n";
+		phase = Phase::INACTIVE;
+		return;
+	}
+
 	if (!settings.enabled || !canHandle())
 	{
+		phase = Phase::INACTIVE;
 		end();
 		return;
 	}
 
-	asyncTasks->run(
-		[this]()
-		{
-			handle();
-			end();
-		});
+	handle();
 }
 
 void TacticsHandler::tacticMove(const CStack * cstack, const BattleHex & bh)
 {
 	logAi->debug("[Tactics] Moving to hex %d", bh.toInt());
-	std::unique_lock lock(mutex);
 	movingStack = cstack;
 	cb->battleMakeUnitAction(bid, BattleAction::makeMove(cstack, bh));
-	auto success = cond.wait_for(
-		lock,
-		std::chrono::seconds(10),
-		[this]
-		{
-			return movingStack == nullptr;
-		}
-	);
-
-	success ? logAi->debug("[Tactics] Move finished") : logAi->debug("[Tactics] Stack still moving after 10s");
-}
-
-void TacticsHandler::moveGuardsAwayFromCorners(const std::vector<const CStack *> & guards, const SpecialHexes & specialHexes)
-{
-	for(const CStack * guard : guards)
-	{
-		if(!guard->coversPos(specialHexes.corner1) && !guard->coversPos(specialHexes.corner2))
-			continue;
-
-		const auto reachability = battle->getReachability(guard);
-		for(const auto & bh : specialHexes.tempHexes)
-		{
-			if(reachability.isReachable(bh))
-			{
-				tacticMove(guard, bh);
-				break;
-			}
-		}
-	}
-}
-
-void TacticsHandler::moveVipsToCorners(const std::vector<const CStack *> & vips, const SpecialHexes & specialHexes)
-{
-
-	auto vipsToMove = std::vector<const CStack *>{};
-	for(const CStack * vip : vips)
-		if(vipsToMove.size() < 2 && !vip->coversPos(specialHexes.corner1) && !vip->coversPos(specialHexes.corner2))
-			vipsToMove.push_back(vip);
-
-	for(const CStack * vip : vipsToMove)
-	{
-		const auto reachability = battle->getReachability(vip);
-		const auto destinations = vip->doubleWide()
-									? std::vector<BattleHex>{specialHexes.corner1Wide, specialHexes.corner2Wide}
-									: std::vector<BattleHex>{specialHexes.corner1, specialHexes.corner2};
-
-		for(const auto & bh : destinations)
-		{
-			if(reachability.isReachable(bh))
-			{
-				tacticMove(vip, bh);
-				break;
-			}
-		}
-	}
-}
-
-void TacticsHandler::moveGuardsAroundVips(const std::vector<const CStack*> & guards, const std::vector<const CStack*> & vips)
-{
-	// Initial pass might fail if some units were blocked by obstacles
-	// => loop again in case they have become unblocked
-	for(int i = 0; i < 2; ++i)
-		for(const CStack * guard : guards)
-			for(const auto * vip : vips)
-				if(guardVip(guard, vip))
-					break;
 }
 
 void TacticsHandler::handle()
 {
-	const auto vips = findVIPs();
-	const auto guards = findGuards(vips);
-	const auto specialHexes = getSpecialHexes();
+	vips = findVIPs();
+	guards = findGuards(vips);
+	specialHexes = getSpecialHexes();
+	guardIndex = 0;
+	vipIndex = 0;
+	guardPass = 0;
+	phase = Phase::MOVE_GUARDS_AWAY_FROM_CORNERS;
 
 	for(const CStack * vip : vips)
 		logAi->debug("VIP: " + vip->getDescription());
 
-	moveGuardsAwayFromCorners(guards, specialHexes);
-	moveVipsToCorners(vips, specialHexes);
-	moveGuardsAroundVips(guards, vips);
+	advance();
 }
 
-bool TacticsHandler::guardVip(const CStack * guard, const CStack * vip)
+void TacticsHandler::advance()
+{
+	while(phase != Phase::INACTIVE)
+	{
+		bool moveStarted = false;
+		switch(phase)
+		{
+			case Phase::MOVE_GUARDS_AWAY_FROM_CORNERS:
+				moveStarted = moveNextGuardAwayFromCorners();
+				break;
+			case Phase::MOVE_VIPS_TO_CORNERS:
+				moveStarted = moveNextVipToCorner();
+				break;
+			case Phase::MOVE_GUARDS_AROUND_VIPS:
+				moveStarted = moveNextGuardAroundVip();
+				break;
+			case Phase::INACTIVE:
+				break;
+		}
+
+		if(moveStarted)
+			return;
+	}
+
+	end();
+}
+
+bool TacticsHandler::moveNextGuardAwayFromCorners()
+{
+	while(guardIndex < guards.size())
+	{
+		const auto * guard = guards[guardIndex++];
+		if(!guard->coversPos(specialHexes.corner1) && !guard->coversPos(specialHexes.corner2))
+			continue;
+
+		const auto reachability = battle->getReachability(guard);
+		for(const auto & hex : specialHexes.tempHexes)
+		{
+			if(reachability.isReachable(hex))
+			{
+				tacticMove(guard, hex);
+				return true;
+			}
+		}
+	}
+
+	vipsToMove.clear();
+	for(const auto * vip : vips)
+	{
+		if(vipsToMove.size() < 2 && !vip->coversPos(specialHexes.corner1) && !vip->coversPos(specialHexes.corner2))
+			vipsToMove.push_back(vip);
+	}
+	vipIndex = 0;
+	phase = Phase::MOVE_VIPS_TO_CORNERS;
+	return false;
+}
+
+bool TacticsHandler::moveNextVipToCorner()
+{
+	while(vipIndex < vipsToMove.size())
+	{
+		const auto * vip = vipsToMove[vipIndex++];
+		const auto reachability = battle->getReachability(vip);
+		const auto destinations = vip->doubleWide()
+			? std::vector<BattleHex>{specialHexes.corner1Wide, specialHexes.corner2Wide}
+			: std::vector<BattleHex>{specialHexes.corner1, specialHexes.corner2};
+
+		for(const auto & hex : destinations)
+		{
+			if(reachability.isReachable(hex))
+			{
+				tacticMove(vip, hex);
+				return true;
+			}
+		}
+	}
+
+	guardIndex = 0;
+	vipIndex = 0;
+	phase = Phase::MOVE_GUARDS_AROUND_VIPS;
+	return false;
+}
+
+bool TacticsHandler::moveNextGuardAroundVip()
+{
+	// Initial pass might fail if some units were blocked by obstacles.
+	// Loop again in case they have become unblocked.
+	while(guardPass < 2)
+	{
+		while(guardIndex < guards.size())
+		{
+			const auto * guard = guards[guardIndex];
+			while(vipIndex < vips.size())
+			{
+				const auto destination = findGuardDestination(guard, vips[vipIndex++]);
+				if(destination)
+				{
+					++guardIndex;
+					vipIndex = 0;
+					tacticMove(guard, *destination);
+					return true;
+				}
+			}
+			++guardIndex;
+			vipIndex = 0;
+		}
+		++guardPass;
+		guardIndex = 0;
+	}
+
+	phase = Phase::INACTIVE;
+	return false;
+}
+
+std::optional<BattleHex> TacticsHandler::findGuardDestination(const CStack * guard, const CStack * vip)
 {
 	assert(vip);
 	logAi->debug("Handling GUARD stack %s (vip=%s)", guard->getDescription(), vip->getDescription());
@@ -583,30 +638,34 @@ bool TacticsHandler::guardVip(const CStack * guard, const CStack * vip)
 	const auto hexes = GuardableHexes(vip, guard);
 	const auto reachability = cb->getBattle(bid)->getReachability(guard);
 
-	BattleHex target;
-
 	for(const auto hex : hexes)
 	{
 		if(guard->getPosition() == hex)
 			break;
 
 		if(reachability.isReachable(hex) && cb->getBattle(bid)->isInTacticRange(hex))
-		{
-			tacticMove(guard, hex);
-			return true;
-		}
+			return hex;
 	}
 
 	logAi->debug("No viable guard move (VIP unreachable or already surrounded)");
-	return false;
+	return std::nullopt;
 }
 
-void TacticsHandler::onStackMoved(const CStack * stack)
+void TacticsHandler::onActionFinished(const BattleAction & action)
 {
-	if(stack != movingStack)
+	std::cout << "onActionFinished: DIST: " << static_cast<int>(battle->battleTacticDist()) << "\n";
+	std::cout << "onActionFinished: ROUND: " << battle->battleGetRound() << "\n";
+
+	if (battle->battleTacticDist() == 0)
+	{
+		phase = Phase::INACTIVE;
+		return;
+	}
+
+	if(!movingStack || action.actionType != EActionType::WALK || action.stackNumber != movingStack->unitId())
 		return;
 
-	std::lock_guard lock(mutex);
+	logAi->debug("[Tactics] Move finished");
 	movingStack = nullptr;
-	cond.notify_one();
+	advance();
 }

--- a/AI/BattleAI/TacticsHandler.h
+++ b/AI/BattleAI/TacticsHandler.h
@@ -69,7 +69,7 @@ private:
 
 	std::vector<const CStack *> findVIPs() const;
 	std::vector<const CStack *> findGuards() const;
-	std::vector<BattleHex> GuardableHexes(const CStack * vip, const CStack * guard);
+	std::vector<BattleHex> guardableHexes(const CStack * vip, const CStack * guard);
 
 	SpecialHexes getSpecialHexes() const;
 };

--- a/AI/BattleAI/TacticsHandler.h
+++ b/AI/BattleAI/TacticsHandler.h
@@ -1,0 +1,62 @@
+/*
+ * Tactics.h, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
+#pragma once
+
+#include "AsyncRunner.h"
+#include "battle/CPlayerBattleCallback.h"
+#include "callback/CBattleCallback.h"
+
+class TacticsHandler {
+public:
+	struct Settings
+	{
+		bool enabled = true;
+		double enemyAoeThreshold = 0.08;
+		double vipThreshold = 0.05;
+	};
+
+	TacticsHandler(const std::shared_ptr<CBattleCallback> & cb, const BattleID & bid, Settings settings);
+	void onTacticsStarted();
+	void onStackMoved(const CStack * cstack);
+private:
+	struct SpecialHexes
+	{
+		BattleHex corner1;
+		BattleHex corner2;
+		BattleHex corner1Wide;
+		BattleHex corner2Wide;
+		std::vector<BattleHex> tempHexes;
+	};
+
+	const std::shared_ptr<CBattleCallback> cb = nullptr;
+	const std::shared_ptr<CPlayerBattleCallback> battle = nullptr;
+	const BattleID & bid;
+	const Settings settings;
+	std::unique_ptr<AsyncRunner> asyncTasks;
+
+	const CStack * movingStack = nullptr;
+	std::mutex mutex;
+	std::condition_variable cond;
+
+	bool canHandle() const;
+	void tacticMove(const CStack * stack, const BattleHex & bh);
+	bool guardVip(const CStack * guard, const CStack * vip);
+	void end();
+	void handle();
+
+	std::vector<const CStack *> findVIPs() const;
+	std::vector<const CStack *> findGuards(const std::vector<const CStack*> & vips) const;
+	std::vector<BattleHex> GuardableHexes(const CStack * vip, const CStack * guard);
+
+	SpecialHexes getSpecialHexes() const;
+	void moveGuardsAwayFromCorners(const std::vector<const CStack*> & guards, const SpecialHexes & specialHexes);
+	void moveVipsToCorners(const std::vector<const CStack *> & vips, const SpecialHexes & specialHexes);
+	void moveGuardsAroundVips(const std::vector<const CStack*> & guards, const std::vector<const CStack*> & vips);
+};

--- a/AI/BattleAI/TacticsHandler.h
+++ b/AI/BattleAI/TacticsHandler.h
@@ -68,7 +68,7 @@ private:
 	bool moveNextGuardAroundVip();
 
 	std::vector<const CStack *> findVIPs() const;
-	std::vector<const CStack *> findGuards(const std::vector<const CStack*> & vips) const;
+	std::vector<const CStack *> findGuards() const;
 	std::vector<BattleHex> GuardableHexes(const CStack * vip, const CStack * guard);
 
 	SpecialHexes getSpecialHexes() const;

--- a/AI/BattleAI/TacticsHandler.h
+++ b/AI/BattleAI/TacticsHandler.h
@@ -9,7 +9,6 @@
  */
 #pragma once
 
-#include "AsyncRunner.h"
 #include "battle/CPlayerBattleCallback.h"
 #include "callback/CBattleCallback.h"
 
@@ -24,7 +23,7 @@ public:
 
 	TacticsHandler(const std::shared_ptr<CBattleCallback> & cb, const BattleID & bid, Settings settings);
 	void onTacticsStarted();
-	void onStackMoved(const CStack * cstack);
+	void onActionFinished(const BattleAction & action);
 private:
 	struct SpecialHexes
 	{
@@ -35,28 +34,42 @@ private:
 		std::vector<BattleHex> tempHexes;
 	};
 
+	enum class Phase : ui8
+	{
+		INACTIVE,
+		MOVE_GUARDS_AWAY_FROM_CORNERS,
+		MOVE_VIPS_TO_CORNERS,
+		MOVE_GUARDS_AROUND_VIPS
+	};
+
 	const std::shared_ptr<CBattleCallback> cb = nullptr;
 	const std::shared_ptr<CPlayerBattleCallback> battle = nullptr;
-	const BattleID & bid;
+	const BattleID bid;
 	const Settings settings;
-	std::unique_ptr<AsyncRunner> asyncTasks;
 
+	Phase phase = Phase::INACTIVE;
 	const CStack * movingStack = nullptr;
-	std::mutex mutex;
-	std::condition_variable cond;
+	std::vector<const CStack *> vips;
+	std::vector<const CStack *> guards;
+	std::vector<const CStack *> vipsToMove;
+	SpecialHexes specialHexes;
+	std::size_t guardIndex = 0;
+	std::size_t vipIndex = 0;
+	int guardPass = 0;
 
 	bool canHandle() const;
 	void tacticMove(const CStack * stack, const BattleHex & bh);
-	bool guardVip(const CStack * guard, const CStack * vip);
+	std::optional<BattleHex> findGuardDestination(const CStack * guard, const CStack * vip);
 	void end();
 	void handle();
+	void advance();
+	bool moveNextGuardAwayFromCorners();
+	bool moveNextVipToCorner();
+	bool moveNextGuardAroundVip();
 
 	std::vector<const CStack *> findVIPs() const;
 	std::vector<const CStack *> findGuards(const std::vector<const CStack*> & vips) const;
 	std::vector<BattleHex> GuardableHexes(const CStack * vip, const CStack * guard);
 
 	SpecialHexes getSpecialHexes() const;
-	void moveGuardsAwayFromCorners(const std::vector<const CStack*> & guards, const SpecialHexes & specialHexes);
-	void moveVipsToCorners(const std::vector<const CStack *> & vips, const SpecialHexes & specialHexes);
-	void moveGuardsAroundVips(const std::vector<const CStack*> & guards, const std::vector<const CStack*> & vips);
 };

--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -2096,6 +2096,7 @@ void CPlayerInterface::prepareAutoFightingAI(const BattleID &bid, const CCreatur
 
 	AutocombatPreferences autocombatPreferences = AutocombatPreferences();
 	autocombatPreferences.enableSpellsUsage = settings["battle"]["enableAutocombatSpells"].Bool();
+	autocombatPreferences.enableTacticsUsage = settings["battle"]["enableAutocombatTactics"].Bool();
 
 	autofightingAI->initBattleInterface(env, cb, autocombatPreferences);
 	autofightingAI->battleStart(bid, army1, army2, tile, hero1, hero2, side, false);

--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -807,12 +807,19 @@ void CPlayerInterface::actionStarted(const BattleID & battleID, const BattleActi
 	EVENT_HANDLER_CALLED_BY_CLIENT;
 	BATTLE_EVENT_POSSIBLE_RETURN;
 
+	if(battleInt)
+		battleInt->trySetActivePlayer(cb->getBattle(battleID)->sideToPlayer(action.side));
+
 	battleInt->startAction(action);
 }
 
 void CPlayerInterface::actionFinished(const BattleID & battleID, const BattleAction &action)
 {
 	EVENT_HANDLER_CALLED_BY_CLIENT;
+
+	if (autofightingAI && !isAutoFightOn)
+		unregisterBattleInterface(autofightingAI);
+
 	BATTLE_EVENT_POSSIBLE_RETURN;
 
 	battleInt->endAction(action);
@@ -834,15 +841,11 @@ void CPlayerInterface::activeStack(const BattleID & battleID, const CStack * sta
 
 	if (autofightingAI)
 	{
-		if (isAutoFightOn)
-		{
-			//FIXME: we want client rendering to proceed while AI is making actions
-			// so unlock mutex while AI is busy since this might take quite a while, especially if hero has many spells
-			auto unlockInterface = vstd::makeUnlockGuard(ENGINE->interfaceMutex);
-			autofightingAI->activeStack(battleID, stack);
-			return;
-		}
-		unregisterBattleInterface(autofightingAI);
+		//FIXME: we want client rendering to proceed while AI is making actions
+		// so unlock mutex while AI is busy since this might take quite a while, especially if hero has many spells
+		auto unlockInterface = vstd::makeUnlockGuard(ENGINE->interfaceMutex);
+		autofightingAI->activeStack(battleID, stack);
+		return;
 	}
 
 	assert(battleInt);

--- a/client/battle/BattleActionsController.cpp
+++ b/client/battle/BattleActionsController.cpp
@@ -245,7 +245,7 @@ bool BattleActionsController::isActiveStackSpellcaster() const
 void BattleActionsController::enterCreatureCastingMode()
 {
 	//silently check for possible errors
-	if (owner.tacticsMode)
+	if (owner.isInTacticsMode())
 		return;
 
 	//hero is casting a spell
@@ -314,7 +314,7 @@ std::vector<PossiblePlayerBattleAction> BattleActionsController::getPossibleActi
 	for(const auto & spell : creatureSpells)
 		data.creatureSpellsToCast.push_back(spell->id);
 
-	data.tacticsMode = owner.tacticsMode;
+	data.tacticsMode = owner.isInTacticsMode();
 	auto allActions = owner.getBattle()->getClientActionsForStack(stack, data);
 
 	allActions.push_back(PossiblePlayerBattleAction::HERO_INFO);
@@ -325,7 +325,7 @@ std::vector<PossiblePlayerBattleAction> BattleActionsController::getPossibleActi
 
 void BattleActionsController::reorderPossibleActionsPriority(const CStack * stack, const CStack * targetStack)
 {
-	if(owner.tacticsMode || possibleActions.empty()) return; //this function is not supposed to be called in tactics mode or before getPossibleActionsForStack
+	if(owner.getBattle()->battleTacticDist() > 0 || possibleActions.empty()) return; //this function is not supposed to be called in tactics mode or before getPossibleActionsForStack
 
 	auto assignPriority = [&](const PossiblePlayerBattleAction & item
 						  ) -> uint8_t //large lambda assigning priority which would have to be part of possibleActions without it

--- a/client/battle/BattleInterface.cpp
+++ b/client/battle/BattleInterface.cpp
@@ -831,7 +831,6 @@ void BattleInterface::requestAutofightingAIToTakeAction()
 		std::thread aiThread([localBattleID = battleID, localCurInt = curInt, tacticsDist]()
 		{
 			setThreadName("autofightingAI");
-			std::cout << "localCurInt " << localCurInt << "\n";
 			localCurInt->autofightingAI->yourTacticPhase(localBattleID, tacticsDist);
 		});
 		aiThread.detach();

--- a/client/battle/BattleInterface.cpp
+++ b/client/battle/BattleInterface.cpp
@@ -81,9 +81,6 @@ BattleInterface::BattleInterface(const BattleID & battleID, const CCreatureSet *
 	else if(defenderInt && defenderInt->cb->getBattle(getBattleID())->battleGetTacticDist())
 		tacticianInterface = defenderInt;
 
-	//if we found interface of player with tactics, then enter tactics mode
-	_tacticsMode = static_cast<bool>(tacticianInterface);
-
 	//initializing armies
 	this->army1 = army1;
 	this->army2 = army2;
@@ -111,9 +108,7 @@ BattleInterface::BattleInterface(const BattleID & battleID, const CCreatureSet *
 
 bool BattleInterface::isInTacticsMode()
 {
-	if (_tacticsMode && tacticianInterface->cb->getBattle(getBattleID())->battleGetTacticDist() == 0)
-		_tacticsMode = false;
-	return _tacticsMode;
+	return tacticianInterface->cb->getBattle(getBattleID())->battleGetTacticDist() == 0; 
 }
 
 void BattleInterface::playIntroSoundAndUnlockInterface()

--- a/client/battle/BattleInterface.cpp
+++ b/client/battle/BattleInterface.cpp
@@ -82,7 +82,7 @@ BattleInterface::BattleInterface(const BattleID & battleID, const CCreatureSet *
 		tacticianInterface = defenderInt;
 
 	//if we found interface of player with tactics, then enter tactics mode
-	tacticsMode = static_cast<bool>(tacticianInterface);
+	_tacticsMode = static_cast<bool>(tacticianInterface);
 
 	//initializing armies
 	this->army1 = army1;
@@ -107,6 +107,13 @@ BattleInterface::BattleInterface(const BattleID & battleID, const CCreatureSet *
 	windowObject->updateQueue();
 
 	playIntroSoundAndUnlockInterface();
+}
+
+bool BattleInterface::isInTacticsMode()
+{
+	if (_tacticsMode && tacticianInterface->cb->getBattle(getBattleID())->battleGetTacticDist() == 0)
+		_tacticsMode = false;
+	return _tacticsMode;
 }
 
 void BattleInterface::playIntroSoundAndUnlockInterface()
@@ -174,7 +181,7 @@ void BattleInterface::openingEnd()
 		return;
 
 	onAnimationsFinished();
-	if(tacticsMode)
+	if(isInTacticsMode())
 	{
 		// h3 tactics phase tutorial
 		if(!persistentStorage["gui"]["tacticsPhaseHintShown"].Bool())
@@ -311,7 +318,7 @@ void BattleInterface::sendCommand(BattleAction command, const CStack * actor)
 {
 	command.stackNumber = actor ? actor->unitId() : ((command.side == BattleSide::ATTACKER) ? -1 : -2);
 
-	if(!tacticsMode)
+	if(!isInTacticsMode())
 	{
 		logGlobal->trace("Setting command for %s", (actor ? actor->nodeName() : "hero"));
 		stacksController->setActiveStack(nullptr);
@@ -393,7 +400,7 @@ void BattleInterface::spellCast(const BattleSpellCast * sc)
 
 	// Do not deactivate anything in tactics mode
 	// This is battlefield setup spells
-	if(!tacticsMode)
+	if(!isInTacticsMode())
 	{
 		windowObject->blockUI(true);
 
@@ -649,8 +656,7 @@ void BattleInterface::trySetActivePlayer( PlayerColor player )
 {
 	if ( attackerInt && attackerInt->playerID == player )
 		curInt = attackerInt;
-
-	if ( defenderInt && defenderInt->playerID == player )
+	else if ( defenderInt && defenderInt->playerID == player )
 		curInt = defenderInt;
 }
 
@@ -702,7 +708,7 @@ void BattleInterface::endAction(const BattleAction &action)
 	windowObject->updateQueue();
 
 	//stack ended movement in tactics phase -> select the next one
-	if (tacticsMode)
+	if (isInTacticsMode())
 		tacticNextStack(stack);
 
 	//we have activated next stack after sending request that has been just realized -> blockmap due to movement has changed
@@ -736,7 +742,6 @@ void BattleInterface::startAction(const BattleAction & action)
 void BattleInterface::tacticPhaseEnd()
 {
 	stacksController->setActiveStack(nullptr);
-	tacticsMode = false;
 
 	auto side = tacticianInterface->cb->getBattle(battleID)->playerToSide(tacticianInterface->playerID);
 	auto action = BattleAction::makeEndOFTacticPhase(side);
@@ -818,14 +823,18 @@ void BattleInterface::requestAutofightingAIToTakeAction()
 		return; // battle finished with spellcast
 	}
 
-	if (tacticsMode)
+	auto tacticsDist = curInt->cb->getBattle(battleID)->battleGetTacticDist();
+
+	if (tacticsDist > 0)
 	{
-		// Always end tactics mode. Player interface is blocked currently, so it's not possible that
-		// the AI can take any action except end tactics phase (AI actions won't be triggered)
-		//TODO implement the possibility that the AI will be triggered for further actions
-		//TODO any solution to merge tactics phase & normal phase in the way it is handled by the player and battle interface?
-		tacticPhaseEnd();
 		stacksController->setActiveStack(nullptr);
+		std::thread aiThread([localBattleID = battleID, localCurInt = curInt, tacticsDist]()
+		{
+			setThreadName("autofightingAI");
+			std::cout << "localCurInt " << localCurInt << "\n";
+			localCurInt->autofightingAI->yourTacticPhase(localBattleID, tacticsDist);
+		});
+		aiThread.detach();
 	}
 	else
 	{

--- a/client/battle/BattleInterface.h
+++ b/client/battle/BattleInterface.h
@@ -118,9 +118,6 @@ class BattleInterface
 	/// ID of ongoing battle
 	BattleID battleID;
 
-	/// cache var for isInTacticsMode()
-	bool _tacticsMode;
-
 	void playIntroSoundAndUnlockInterface();
 	void onIntroSoundPlayed();
 public:

--- a/client/battle/BattleInterface.h
+++ b/client/battle/BattleInterface.h
@@ -118,6 +118,9 @@ class BattleInterface
 	/// ID of ongoing battle
 	BattleID battleID;
 
+	/// cache var for isInTacticsMode()
+	bool _tacticsMode;
+
 	void playIntroSoundAndUnlockInterface();
 	void onIntroSoundPlayed();
 public:
@@ -134,7 +137,6 @@ public:
 	const CGHeroInstance *attackingHeroInstance;
 	const CGHeroInstance *defendingHeroInstance;
 
-	bool tacticsMode;
 	ui32 round;
 
 	std::unique_ptr<BattleProjectileController> projectilesController;
@@ -233,4 +235,6 @@ public:
 
 	const CGHeroInstance *currentHero() const;
 	InfoAboutHero enemyHero() const;
+
+	bool isInTacticsMode();
 };

--- a/client/battle/BattleSiegeController.cpp
+++ b/client/battle/BattleSiegeController.cpp
@@ -368,7 +368,7 @@ void BattleSiegeController::collectRenderableObjects(BattleRenderer & renderer)
 
 bool BattleSiegeController::isAttackableByCatapult(const BattleHex & hex) const
 {
-	if (owner.tacticsMode)
+	if (owner.isInTacticsMode())
 		return false;
 
 	auto wallPart = owner.getBattle()->battleHexToWallPart(hex);

--- a/client/battle/BattleWindow.cpp
+++ b/client/battle/BattleWindow.cpp
@@ -132,7 +132,7 @@ BattleWindow::BattleWindow(BattleInterface & Owner)
 	createStickyHeroInfoWindows();
 	createTimerInfoWindows();
 
-	if ( owner.tacticsMode )
+	if ( owner.isInTacticsMode() )
 		tacticPhaseStarted();
 	else
 		tacticPhaseEnded();
@@ -879,21 +879,22 @@ void BattleWindow::blockUI(bool on)
 	}
 
 	bool canWait = owner.stacksController->getActiveStack() ? !owner.stacksController->getActiveStack()->waitedThisTurn : false;
+	bool tacticsMode = owner.isInTacticsMode();
 
 	setShortcutBlocked(EShortcut::GLOBAL_OPTIONS, on);
 	setShortcutBlocked(EShortcut::BATTLE_OPEN_ACTIVE_UNIT, on);
 	setShortcutBlocked(EShortcut::BATTLE_OPEN_HOVERED_UNIT, on);
 	setShortcutBlocked(EShortcut::BATTLE_RETREAT, on || !owner.getBattle()->battleCanFlee());
 	setShortcutBlocked(EShortcut::BATTLE_SURRENDER, on || owner.getBattle()->battleGetSurrenderCost() < 0);
-	setShortcutBlocked(EShortcut::BATTLE_CAST_SPELL, on || owner.tacticsMode || !canCastSpells);
-	setShortcutBlocked(EShortcut::BATTLE_WAIT, on || owner.tacticsMode || !canWait);
-	setShortcutBlocked(EShortcut::BATTLE_DEFEND, on || owner.tacticsMode);
-	setShortcutBlocked(EShortcut::BATTLE_AUTOCOMBAT, (settings["battle"]["endWithAutocombat"].Bool() && onlyOnePlayerHuman) ? on || owner.tacticsMode || owner.actionsController->heroSpellcastingModeActive() : owner.actionsController->heroSpellcastingModeActive());
+	setShortcutBlocked(EShortcut::BATTLE_CAST_SPELL, on || tacticsMode || !canCastSpells);
+	setShortcutBlocked(EShortcut::BATTLE_WAIT, on || tacticsMode || !canWait);
+	setShortcutBlocked(EShortcut::BATTLE_DEFEND, on || tacticsMode);
+	setShortcutBlocked(EShortcut::BATTLE_AUTOCOMBAT, (settings["battle"]["endWithAutocombat"].Bool() && onlyOnePlayerHuman) ? on || tacticsMode || owner.actionsController->heroSpellcastingModeActive() : owner.actionsController->heroSpellcastingModeActive());
 	setShortcutBlocked(EShortcut::BATTLE_END_WITH_AUTOCOMBAT, on || !onlyOnePlayerHuman || owner.actionsController->heroSpellcastingModeActive());
-	setShortcutBlocked(EShortcut::BATTLE_TACTICS_END, on || !owner.tacticsMode);
-	setShortcutBlocked(EShortcut::BATTLE_TACTICS_NEXT, on || !owner.tacticsMode);
-	setShortcutBlocked(EShortcut::BATTLE_CONSOLE_DOWN, on && !owner.tacticsMode);
-	setShortcutBlocked(EShortcut::BATTLE_CONSOLE_UP, on && !owner.tacticsMode);
+	setShortcutBlocked(EShortcut::BATTLE_TACTICS_END, on || !tacticsMode);
+	setShortcutBlocked(EShortcut::BATTLE_TACTICS_NEXT, on || !tacticsMode);
+	setShortcutBlocked(EShortcut::BATTLE_CONSOLE_DOWN, on && !tacticsMode);
+	setShortcutBlocked(EShortcut::BATTLE_CONSOLE_UP, on && !tacticsMode);
 
 	quickSpellWindow->setInputEnabled(!on);
 	unitActionWindow->setInputEnabled(!on);

--- a/config/schemas/settings.json
+++ b/config/schemas/settings.json
@@ -501,7 +501,7 @@
 			"type" : "object",
 			"additionalProperties" : false,
 			"default" : {},
-			"required" : [ "speedFactor", "mouseShadow", "cellBorders", "stackRange", "movementHighlightOnHover", "rangeLimitHighlightOnHover", "showQueue", "swipeAttackDistance", "queueSize", "stickyHeroInfoWindows", "stackInfoBasicPanel", "enableAutocombatSpells", "endWithAutocombat", "queueSmallSlots", "queueSmallOutside", "enableQuickSpellPanel", "showHealthBar" ],
+			"required" : [ "speedFactor", "mouseShadow", "cellBorders", "stackRange", "movementHighlightOnHover", "rangeLimitHighlightOnHover", "showQueue", "swipeAttackDistance", "queueSize", "stickyHeroInfoWindows", "stackInfoBasicPanel", "enableAutocombatSpells", "enableAutocombatTactics", "endWithAutocombat", "queueSmallSlots", "queueSmallOutside", "enableQuickSpellPanel", "showHealthBar" ],
 			"properties" : {
 				"speedFactor" : {
 					"type" : "number",

--- a/config/schemas/settings.json
+++ b/config/schemas/settings.json
@@ -552,6 +552,10 @@
 					"type": "boolean",
 					"default": true
 				},
+				"enableAutocombatTactics" : {
+					"type": "boolean",
+					"default": true
+				},
 				"endWithAutocombat" : {
 					"type": "boolean",
 					"default": false

--- a/lib/battle/AutocombatPreferences.h
+++ b/lib/battle/AutocombatPreferences.h
@@ -12,6 +12,7 @@
 struct AutocombatPreferences
 {
 	bool enableSpellsUsage = true;
+	bool enableTacticsUsage = true;
 	//TODO: below options exist in original H3, consider usefulness of mixed human-AI combat when enabling autocombat inside battle
 //	bool enableUnitsUsage = true;
 //	bool enableCatapultUsage = true;


### PR DESCRIPTION
Simple scripted tactics logic where shooters are sent in the corners and get surrounded by other stacks.

Includes simple logic for skipping tactics when enemy has fireball-like shooter or fast dragon-breath unit (clumping units may be a bad idea in this case). 

It might look weird because this logic is completely separate and as soon as the battle starts, the AI may decide to move the guards away 🙂 still, it's probably better than never using tactics.

As stated, the logic is basic and involves:
- if enemy has a stack of liches or magogs that has > 8% of the army value => skip tactics
- if enemy has a stack of dragons which can reach the hex in front of the guards on round 1 => skip tactics
- up to two friendly VIP stacks (most-valuable shooters, based on AI value) can be protected. They will always move to the map corner first.
- weak VIPs shooter stacks that have <5% of the army value are not considered VIP - they are treated as guards instead (1 archer in the video below).
- friendly guard stacks ordered by their "AIValue" (least valuable first, based on AI value) will surround the VIPs

This feature can be turned off via the `enableAutocombatTactics` server configuration option (not through the launcher though).

The logic lives in BattleAI/TacticsHandler.{h,cpp} but is not coupled to BattleAI, so it can be moved to another directory if needed. The same TacticsHandler is also used in the new version of MMAI https://github.com/vcmi/vcmi/pull/7654 

https://github.com/user-attachments/assets/808f3cc5-06db-4677-82ac-6640e376ddfb

