### PR TITLE
[HotA] Implement SIEGE_WEAPON_DAMAGE_OFFSET bonus

### DIFF
--- a/client/battle/StackInfoBasicPanel.cpp
+++ b/client/battle/StackInfoBasicPanel.cpp
@@ -47,12 +47,16 @@ void StackInfoBasicPanel::initializeData(const CStack * stack)
 	int damageMultiplier = 1;
 	if (stack->hasBonusOfType(BonusType::SIEGE_WEAPON))
 	{
-		static const auto bonusSelector =
+		static const auto heroAttackSelector =
 			Selector::sourceTypeSel(BonusSource::ARTIFACT).Or(
 															  Selector::sourceTypeSel(BonusSource::HERO_BASE_SKILL)).And(
 					Selector::typeSubtype(BonusType::PRIMARY_SKILL, BonusSubtypeID(PrimarySkill::ATTACK)));
-
-		damageMultiplier += stack->valOfBonuses(bonusSelector);
+		static const auto damageOffsetSelector = Selector::type()(BonusType::SIEGE_WEAPON_DAMAGE_OFFSET);
+		
+		int damageOffsetVal = stack->valOfBonuses(damageOffsetSelector);
+		damageMultiplier = (damageOffsetVal > 0) ? damageOffsetVal : 1;
+		
+		damageMultiplier += stack->valOfBonuses(heroAttackSelector);
 	}
 
 	auto attack = std::to_string(LIBRARY->creatures()->getByIndex(stack->creatureIndex())->getAttack(stack->isShooter())) + "(" + std::to_string(stack->getAttack(stack->isShooter())) + ")";

--- a/client/windows/CCreatureWindow.cpp
+++ b/client/windows/CCreatureWindow.cpp
@@ -639,12 +639,15 @@ CStackWindow::MainSection::MainSection(CStackWindow * owner, int yOffset, bool s
 	int dmgMultiply = 1;
 	if (battleStack != nullptr && battleStack->hasBonusOfType(BonusType::SIEGE_WEAPON))
 	{
-		static const auto bonusSelector =
+		static const auto heroAttackSelector =
 			Selector::sourceTypeSel(BonusSource::ARTIFACT).Or(
 			Selector::sourceTypeSel(BonusSource::HERO_BASE_SKILL)).And(
 			Selector::typeSubtype(BonusType::PRIMARY_SKILL, BonusSubtypeID(PrimarySkill::ATTACK)));
-
-		dmgMultiply += battleStack->valOfBonuses(bonusSelector);
+		static const auto damageOffsetSelector = Selector::type()(BonusType::SIEGE_WEAPON_DAMAGE_OFFSET);
+		
+	 	int damageOffsetVal = battleStack->valOfBonuses(damageOffsetSelector);
+		dmgMultiply = (damageOffsetVal > 0) ? damageOffsetVal : 1;
+		dmgMultiply += battleStack->valOfBonuses(heroAttackSelector);
 	}
 
 	static const std::array<std::string, 8> iconNames = {

--- a/config/bonuses.json
+++ b/config/bonuses.json
@@ -466,6 +466,11 @@
 	{
 		"creatureNature" : true
 	},
+
+	"SIEGE_WEAPON_DAMAGE_OFFSET":
+	{
+		"hidden" : true
+	},
 	
 	"SKELETON_TRANSFORMER_TARGET":
 	{

--- a/docs/modders/Bonus/Bonus_Types.md
+++ b/docs/modders/Bonus/Bonus_Types.md
@@ -902,6 +902,12 @@ Hero can control war machine affected by this bonus
 - subtype: creature identifier of affected war machine
 - val: chance to control unit, percentage
 
+### SIEGE_WEAPON_DAMAGE_OFFSET
+
+Adjusts the hero Attack skill scaling factor used in war machine damage calculations. The formula is `baseDamage * (heroAttack + damageOffset)`. The minimum effective offset is 1. If the cumulative total of these bonuses is less than 1, it defaults to 1 (matching standard Heroes III behavior).
+
+- val: the damage offset value
+
 ### CHANGES_SPELL_COST_FOR_ALLY
 
 Affected units will decrease spell cost for their hero (Mage). If multiple units have this bonus only best value will be used

--- a/lib/battle/DamageCalculator.cpp
+++ b/lib/battle/DamageCalculator.cpp
@@ -62,15 +62,18 @@ DamageRange DamageCalculator::getBaseDamageSingle() const
 
 	if(info.attacker->hasBonus(selectorSiedgeWeapon, cachingStrSiedgeWeapon) && !info.attacker->isTurret())
 	{
-		static const auto bonusSelector =
+		static const auto heroAttackSelector =
 			Selector::sourceTypeSel(BonusSource::ARTIFACT).Or(
 			Selector::sourceTypeSel(BonusSource::HERO_BASE_SKILL)).And(
 			Selector::typeSubtype(BonusType::PRIMARY_SKILL, BonusSubtypeID(PrimarySkill::ATTACK)));
-
-		//minDmg and maxDmg of a Ballista are multiplied by hero attack + 1
-		int heroAttackSkill = info.attacker->valOfBonuses(bonusSelector);
-		minDmg *= heroAttackSkill + 1;
-		maxDmg *= heroAttackSkill + 1;
+		static const auto damageOffsetSelector = Selector::type()(BonusType::SIEGE_WEAPON_DAMAGE_OFFSET);
+		
+		//minDmg and maxDmg of a Ballista are multiplied by hero attack + max(damageOffset, 1)
+		int heroAttackSkill = info.attacker->valOfBonuses(heroAttackSelector);
+		int damageOffsetVal = info.attacker->valOfBonuses(damageOffsetSelector);
+		int damageOffset = (damageOffsetVal > 0) ? damageOffsetVal : 1;
+		minDmg *= heroAttackSkill + damageOffset;
+		maxDmg *= heroAttackSkill + damageOffset;
 	}
 	return { minDmg, maxDmg };
 }

--- a/lib/bonuses/BonusEnum.h
+++ b/lib/bonuses/BonusEnum.h
@@ -207,6 +207,7 @@ class JsonNode;
 	BONUS_NAME(LEARN_BATTLE_SPELL_LEVEL_LIMIT_PRE_BATTLE) /*skill-agnostic eagle eye spell level limit to learn enemy hero spells at battle start*/\
 	BONUS_NAME(SURRENDER_MARKETPLACE_ACCESS) /*Allows hero to open marketplace when unable to pay surrender cost*/ \
 	BONUS_NAME(SPECIAL_SPELL_SCALING) /*like SPECIAL_SPELL_LEV but with H3-correct per-target-level rounding; subtype = spell, val = percent per step*/\
+	BONUS_NAME(SIEGE_WEAPON_DAMAGE_OFFSET) /*adjusts the damage formula for war machines to baseDamage * (heroAttack + val)*/\
 
 	/* end of list */
 


### PR DESCRIPTION
This PR adds a bonus to adjust the damage offset for war machine damage calculation from a hardcoded `heroAttack + 1` to `heroAttack + sumOfThisBonus`. Should the sum ever fall below 1, it will default to 1 to keep the damage formula sane.

Not gonna sugarcoat it: This is a HotA fix and probably not very useful outside of that. However it does offer a unique way to scale War Machine damage.

Fixes #6727