### PR TITLE
[Test] Share small-map test setup

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -107,6 +107,7 @@ set(test_SRCS
  		mock/mock_MapServiceTinyH3M.cpp
  		mock/mock_BonusBearer.cpp
 		mock/mock_CPSICallback.cpp
+		mock/TinyMapGameTest.cpp
 		mock/TinyH3MWriter.cpp
 		mock/TinyH3MBuilder.cpp
 )
@@ -133,6 +134,7 @@ set(test_HEADERS
  		mock/mock_MapServiceTinyH3M.h
 		mock/mock_BonusBearer.h
 		mock/TownFake.h
+		mock/TinyMapGameTest.h
 		mock/TinyH3MWriter.h
 		mock/TinyH3MBuilder.h
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -175,6 +175,7 @@ if(ENABLE_NULLKILLER2_AI)
 
 	list(APPEND test_HEADERS
 		nullkiller2/Nulkiller2TestUtils.h
+		nullkiller2/NullkillerTest.h
 	)
 endif()
 

--- a/test/mock/TinyMapGameTest.cpp
+++ b/test/mock/TinyMapGameTest.cpp
@@ -1,0 +1,159 @@
+/*
+ * TinyMapGameTest.cpp, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ */
+#include "StdInc.h"
+
+#include "TinyMapGameTest.h"
+
+#include "../../lib/CPlayerState.h"
+#include "../../lib/callback/CCallback.h"
+#include "../../lib/filesystem/ResourcePath.h"
+#include "../../lib/mapObjects/CGHeroInstance.h"
+#include "../../lib/mapObjects/CGObjectInstance.h"
+#include "../../lib/mapping/CMapHeader.h"
+#include "../../lib/networkPacks/PacksForClient.h"
+
+void TinyMapGameTest::SetUp()
+{
+	currentGameState = std::make_shared<CGameState>();
+	currentGameState->preInit(&services);
+}
+
+void TinyMapGameTest::TearDown()
+{
+	currentGameState.reset();
+	mapService.reset();
+	loadedMap = nullptr;
+}
+
+void TinyMapGameTest::complain(const std::string & problem)
+{
+	FAIL() << "Server-side assertion: " << problem;
+}
+
+void TinyMapGameTest::mapLoaded(CMap * loadedMap)
+{
+	EXPECT_EQ(this->loadedMap, nullptr);
+	this->loadedMap = loadedMap;
+	for(const auto & overrideValue : pendingOverrides)
+	{
+		JsonNode node;
+		node.Bool() = overrideValue.value;
+		loadedMap->overrideGameSetting(overrideValue.option, node);
+	}
+}
+
+void TinyMapGameTest::startWithMap(TinyH3M::TinyH3MBuilder builder)
+{
+	startWithMap(std::move(builder), EMapDifficulty::EASY);
+}
+
+void TinyMapGameTest::startWithMap(TinyH3M::TinyH3MBuilder builder, EMapDifficulty difficulty)
+{
+	const auto * info = ::testing::UnitTest::GetInstance()->current_test_info();
+	std::string fixtureName = std::string(info->test_suite_name()) + "_" + info->name();
+	std::replace(fixtureName.begin(), fixtureName.end(), '/', '_');
+	auto bytes = builder.buildAndDump(fixtureName);
+	mapService = std::make_unique<MapServiceTinyH3M>(std::move(bytes), this);
+
+	StartInfo startInfo;
+	startInfo.mapname = "tiny";
+	startInfo.difficulty = static_cast<ui8>(difficulty);
+	startInfo.mode = EStartMode::NEW_GAME;
+
+	auto header = mapService->loadMapHeader(ResourcePath(startInfo.mapname));
+	ASSERT_NE(header.get(), nullptr) << "TinyH3M scenario header failed to load";
+
+	for(int index = 0; index < static_cast<int>(header->players.size()); ++index)
+	{
+		const PlayerInfo & playerInfo = header->players[index];
+		if(!(playerInfo.canHumanPlay || playerInfo.canComputerPlay))
+			continue;
+
+		PlayerSettings & settings = startInfo.playerInfos[PlayerColor(index)];
+		settings.color = PlayerColor(index);
+		settings.connectedPlayerIDs.insert(static_cast<PlayerConnectionID>(index));
+		settings.name = "Player";
+		settings.castle = playerInfo.defaultCastle();
+		settings.hero = playerInfo.defaultHero();
+	}
+
+	GameRandomizer randomizer(*currentGameState);
+	Load::ProgressAccumulator progressTracker;
+	currentGameState->init(mapService.get(), &startInfo, randomizer, progressTracker, false);
+
+	ASSERT_NE(loadedMap, nullptr) << "gameState init did not populate the CMap";
+	onMapStarted();
+}
+
+CGObjectInstance * TinyMapGameTest::findObjectAt(const int3 & pos) const
+{
+	for(const auto & object : loadedMap->objects)
+	{
+		if(object && object->anchorPos() == pos)
+			return object.get();
+	}
+	return nullptr;
+}
+
+CGHeroInstance * TinyMapGameTest::findHeroAt(const int3 & pos) const
+{
+	for(const auto & object : loadedMap->objects)
+	{
+		auto * hero = dynamic_cast<CGHeroInstance *>(object.get());
+		if(hero && hero->anchorPos() == pos)
+			return hero;
+	}
+	return nullptr;
+}
+
+CGHeroInstance * TinyMapGameTest::findHeroByOwner(PlayerColor owner) const
+{
+	for(const auto & object : loadedMap->objects)
+	{
+		auto * hero = dynamic_cast<CGHeroInstance *>(object.get());
+		if(hero && hero->getOwner() == owner)
+			return hero;
+	}
+	return nullptr;
+}
+
+void TinyMapGameTest::revealMap(PlayerColor player)
+{
+	setMapVisibility(player, true);
+}
+
+void TinyMapGameTest::setMapVisibility(PlayerColor player, bool visible)
+{
+	auto * team = currentGameState->getPlayerTeam(player);
+	ASSERT_NE(team, nullptr);
+
+	for(int z = 0; z < loadedMap->levels(); ++z)
+		for(int x = 0; x < loadedMap->width; ++x)
+			for(int y = 0; y < loadedMap->height; ++y)
+				team->fogOfWarMap[int3(x, y, z)] = visible ? 1 : 0;
+}
+
+std::shared_ptr<CCallback> TinyMapGameTest::makeCallback(PlayerColor player, IClient * client) const
+{
+	return std::make_shared<CCallback>(currentGameState, std::optional<PlayerColor>{ player }, client);
+}
+
+void TinyMapGameTest::grantResources(PlayerColor player, GameResID resource, int amount)
+{
+	SetResources resources;
+	resources.mode = ChangeValueMode::RELATIVE;
+	resources.player = player;
+	resources.res[resource] = amount;
+	currentGameState->apply(resources);
+}
+
+void TinyMapGameTest::overrideSettingBeforeInit(EGameSettings option, bool value)
+{
+	pendingOverrides.push_back({ option, value });
+}

--- a/test/mock/TinyMapGameTest.h
+++ b/test/mock/TinyMapGameTest.h
@@ -1,0 +1,115 @@
+/*
+ * TinyMapGameTest.h, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ */
+#pragma once
+
+#include "TinyH3MBuilder.h"
+#include "mock_MapServiceTinyH3M.h"
+#include "mock_Services.h"
+
+#include "../../lib/CRandomGenerator.h"
+#include "../../lib/IGameSettings.h"
+#include "../../lib/StartInfo.h"
+#include "../../lib/callback/GameRandomizer.h"
+#include "../../lib/gameState/CGameState.h"
+#include "../../lib/mapping/CMap.h"
+
+#include <vcmi/ServerCallback.h>
+
+class CCallback;
+class CGHeroInstance;
+class CGObjectInstance;
+class IClient;
+
+/// Loads a TinyH3M scenario into a live game state and exposes common map helpers.
+class TinyMapGameTest : public ::testing::Test, public ServerCallback, public MapListener
+{
+public:
+	void SetUp() override;
+	void TearDown() override;
+
+	bool describeChanges() const override { return true; }
+	void apply(CPackForClient & pack) override { currentGameState->apply(pack); }
+	void complain(const std::string & problem) override;
+	vstd::RNG * getRNG() override { return &testRandomGenerator; }
+
+	void apply(BattleLogMessage &) override {}
+	void apply(BattleStackMoved &) override {}
+	void apply(BattleUnitsChanged &) override {}
+	void apply(SetStackEffect &) override {}
+	void apply(StacksInjured &) override {}
+	void apply(BattleObstaclesChanged &) override {}
+	void apply(CatapultAttack &) override {}
+
+	void mapLoaded(CMap * loadedMap) override;
+
+	void startWithMap(TinyH3M::TinyH3MBuilder builder);
+	void startWithMap(TinyH3M::TinyH3MBuilder builder, EMapDifficulty difficulty);
+
+	CGObjectInstance * findObjectAt(const int3 & pos) const;
+	CGHeroInstance * findHeroAt(const int3 & pos) const;
+	CGHeroInstance * findHeroByOwner(PlayerColor owner) const;
+
+	template<class T>
+	T * expectAt(const int3 & pos) const
+	{
+		auto * object = findObjectAt(pos);
+		EXPECT_NE(object, nullptr) << "no object at " << pos.toString();
+		auto * result = dynamic_cast<T *>(object);
+		EXPECT_NE(result, nullptr) << "object at " << pos.toString() << " has unexpected dynamic type";
+		return result;
+	}
+
+	template<class T>
+	T * findFirst() const
+	{
+		for(const auto & object : loadedMap->objects)
+		{
+			if(auto * result = dynamic_cast<T *>(object.get()))
+				return result;
+		}
+		return nullptr;
+	}
+
+	template<class T>
+	std::vector<T *> findAll() const
+	{
+		std::vector<T *> result;
+		for(const auto & object : loadedMap->objects)
+		{
+			if(auto * converted = dynamic_cast<T *>(object.get()))
+				result.push_back(converted);
+		}
+		return result;
+	}
+
+	void revealMap(PlayerColor player);
+	void setMapVisibility(PlayerColor player, bool visible);
+	std::shared_ptr<CCallback> makeCallback(PlayerColor player, IClient * client = nullptr) const;
+	void grantResources(PlayerColor player, GameResID resource, int amount);
+	void overrideSettingBeforeInit(EGameSettings option, bool value);
+
+protected:
+	virtual void onMapStarted() {}
+	const std::shared_ptr<CGameState> & gameState() const { return currentGameState; }
+	CMap * map() const { return loadedMap; }
+
+private:
+	struct PendingOverride
+	{
+		EGameSettings option;
+		bool value;
+	};
+
+	std::vector<PendingOverride> pendingOverrides;
+	std::shared_ptr<CGameState> currentGameState;
+	std::unique_ptr<MapServiceTinyH3M> mapService;
+	ServicesMock services;
+	CMap * loadedMap = nullptr;
+	CRandomGenerator testRandomGenerator;
+};

--- a/test/nullkiller2/AIUtilityTest.cpp
+++ b/test/nullkiller2/AIUtilityTest.cpp
@@ -12,11 +12,11 @@
 #include "AI/Nullkiller2/AIGateway.h"
 #include "AI/Nullkiller2/AIUtility.h"
 
-#include "quest/QuestTest.h"
+#include "nullkiller2/NullkillerTest.h"
 
 #include "lib/CPlayerState.h"
-#include "lib/callback/CCallback.h"
 #include "lib/gameState/CGameState.h"
+#include "lib/gameState/QuestInfo.h"
 #include "lib/mapObjects/CGHeroInstance.h"
 #include "lib/mapObjects/Quest.h"
 
@@ -41,14 +41,7 @@ TinyH3M::TinyH3MBuilder makeQuestlessSeerMap()
 	return builder;
 }
 
-class Nullkiller2_AIUtility : public QuestTest
-{
-protected:
-	std::shared_ptr<CCallback> makeCallback() const
-	{
-		return std::make_shared<CCallback>(gameState, std::optional<PlayerColor>{PLAYER}, nullptr);
-	}
-};
+class Nullkiller2_AIUtility : public NullkillerTest {};
 }
 
 TEST_F(Nullkiller2_AIUtility, trackedSeerWithoutActiveQuestIsNotVisitable)
@@ -60,9 +53,9 @@ TEST_F(Nullkiller2_AIUtility, trackedSeerWithoutActiveQuestIsNotVisitable)
 	ASSERT_NE(hero, nullptr);
 	ASSERT_EQ(seer->getActiveQuest(), nullptr);
 
-	gameState->players.at(PLAYER).quests.push_back(seer->getQuestIdentity());
+	gameState()->players.at(PLAYER).quests.push_back(seer->getQuestIdentity());
 
-	const auto callback = makeCallback();
+	const auto callback = makeCallback(PLAYER);
 	auto gateway = std::make_unique<NK2AI::AIGateway>();
 	gateway->initGameInterface(std::shared_ptr<Environment>(), callback);
 

--- a/test/nullkiller2/Goals/ExploreNeighbourTileTest.cpp
+++ b/test/nullkiller2/Goals/ExploreNeighbourTileTest.cpp
@@ -13,18 +13,11 @@
 #include "AI/Nullkiller2/Goals/ExploreNeighbourTile.h"
 
 #include "mock/TinyH3MBuilder.h"
-#include "mock/mock_MapServiceTinyH3M.h"
-#include "mock/mock_Services.h"
+#include "nullkiller2/NullkillerTest.h"
 
-#include "lib/CPlayerState.h"
-#include "lib/StartInfo.h"
 #include "lib/callback/CCallback.h"
-#include "lib/callback/GameRandomizer.h"
-#include "lib/filesystem/ResourcePath.h"
-#include "lib/gameState/CGameState.h"
 #include "lib/mapObjects/CGHeroInstance.h"
 #include "lib/mapping/CMap.h"
-#include "lib/mapping/CMapHeader.h"
 
 #include <cstdio>
 #include <cstdlib>
@@ -74,99 +67,9 @@ public:
 	}
 };
 
-class Nullkiller2_Goals_ExploreNeighbourTileStrategic : public ::testing::Test, public MapListener
+class Nullkiller2_Goals_ExploreNeighbourTileStrategic : public NullkillerTest
 {
 public:
-	void SetUp() override
-	{
-		gameState = std::make_shared<CGameState>();
-		gameState->preInit(&services);
-	}
-
-	void TearDown() override
-	{
-		gameState.reset();
-		mapService.reset();
-		map = nullptr;
-	}
-
-	void mapLoaded(CMap * loadedMap) override
-	{
-		EXPECT_EQ(map, nullptr);
-		map = loadedMap;
-	}
-
-	void startWithMap(TinyH3M::TinyH3MBuilder builder)
-	{
-		auto bytes = builder.build();
-		mapService = std::make_unique<MapServiceTinyH3M>(std::move(bytes), this);
-
-		StartInfo si;
-		si.mapname = "tiny";
-		si.difficulty = 0;
-		si.mode = EStartMode::NEW_GAME;
-
-		auto header = mapService->loadMapHeader(ResourcePath(si.mapname));
-		ASSERT_NE(header.get(), nullptr) << "TinyH3M scenario header failed to load";
-
-		for(int i = 0; i < static_cast<int>(header->players.size()); ++i)
-		{
-			const PlayerInfo & pinfo = header->players[i];
-			if(!(pinfo.canHumanPlay || pinfo.canComputerPlay))
-				continue;
-
-			PlayerSettings & pset = si.playerInfos[PlayerColor(i)];
-			pset.color = PlayerColor(i);
-			pset.connectedPlayerIDs.insert(static_cast<PlayerConnectionID>(i));
-			pset.name = "Player";
-			pset.castle = pinfo.defaultCastle();
-			pset.hero = pinfo.defaultHero();
-		}
-
-		GameRandomizer randomizer(*gameState);
-		Load::ProgressAccumulator progressTracker;
-		gameState->init(mapService.get(), &si, randomizer, progressTracker, false);
-
-		ASSERT_NE(map, nullptr) << "gameState init did not populate the CMap";
-	}
-
-	CGHeroInstance * findHeroByOwner(PlayerColor owner) const
-	{
-		for(const auto & obj : map->objects)
-		{
-			auto * hero = dynamic_cast<CGHeroInstance *>(obj.get());
-			if(hero && hero->getOwner() == owner)
-				return hero;
-		}
-		return nullptr;
-	}
-
-	void setAllTilesVisible(PlayerColor player, bool visible)
-	{
-		auto & fow = teamState(player).fogOfWarMap;
-
-		for(int z = 0; z < map->levels(); ++z)
-		{
-			for(int x = 0; x < map->width; ++x)
-			{
-				for(int y = 0; y < map->height; ++y)
-					fow[int3(x, y, z)] = visible ? 1 : 0;
-			}
-		}
-	}
-
-	std::shared_ptr<CCallback> makeCallback(PlayerColor player)
-	{
-		return std::make_shared<CCallback>(gameState, std::optional<PlayerColor>{player}, nullptr);
-	}
-
-	std::unique_ptr<NK2AI::AIGateway> makeGateway(const std::shared_ptr<CCallback> & callback)
-	{
-		auto gateway = std::make_unique<NK2AI::AIGateway>();
-		gateway->initGameInterface(std::shared_ptr<Environment>(), callback);
-		return gateway;
-	}
-
 	CGObjectInstance * addVisitabilityTrapObject(
 		const std::shared_ptr<CCallback> & callback,
 		const CGObjectInstance * appearanceSource,
@@ -176,24 +79,13 @@ public:
 		trap->ID = Obj::ARTIFACT;
 		trap->subID = MapObjectSubID(0);
 		trap->tempOwner = PLAYER;
-		trap->id = ObjectInstanceID(static_cast<si32>(map->objects.size()));
+		trap->id = ObjectInstanceID(static_cast<si32>(map()->objects.size()));
 		trap->appearance = appearanceSource->appearance;
 		trap->setAnchorPos(pos);
 
-		map->objects.push_back(trap);
+		map()->objects.push_back(trap);
 		return trap.get();
 	}
-
-private:
-	TeamState & teamState(PlayerColor player)
-	{
-		return gameState->teams.at(gameState->players.at(player).team);
-	}
-
-	std::shared_ptr<CGameState> gameState;
-	std::unique_ptr<MapServiceTinyH3M> mapService;
-	ServicesMock services;
-	CMap * map = nullptr;
 };
 }
 
@@ -260,7 +152,7 @@ TEST_F(Nullkiller2_Goals_ExploreNeighbourTileStrategic, findsVisibleStrategicTar
 	ASSERT_NE(hero, nullptr);
 	hero->setMovementPoints(2000);
 
-	setAllTilesVisible(PLAYER, true);
+	revealMap(PLAYER);
 
 	const auto callback = makeCallback(PLAYER);
 	const auto gateway = makeGateway(callback);
@@ -281,7 +173,7 @@ TEST_F(Nullkiller2_Goals_ExploreNeighbourTileStrategic, ignoresKnownObjectsBefor
 	ASSERT_NE(hero->appearance, nullptr);
 	hero->setMovementPoints(2000);
 
-	setAllTilesVisible(PLAYER, true);
+	revealMap(PLAYER);
 
 	const auto callback = makeCallback(PLAYER);
 	const auto gateway = makeGateway(callback);

--- a/test/nullkiller2/Helpers/TinyH3MDimensionDoorExplorationTest.cpp
+++ b/test/nullkiller2/Helpers/TinyH3MDimensionDoorExplorationTest.cpp
@@ -16,19 +16,11 @@
 #include "AI/Nullkiller2/Helpers/ExplorationHelper.h"
 
 #include "mock/TinyH3MBuilder.h"
-#include "mock/mock_MapServiceTinyH3M.h"
-#include "mock/mock_Services.h"
+#include "nullkiller2/NullkillerTest.h"
 
 #include "lib/CPlayerState.h"
 #include "lib/IGameSettings.h"
-#include "lib/StartInfo.h"
-#include "lib/callback/CCallback.h"
-#include "lib/callback/GameRandomizer.h"
-#include "lib/filesystem/ResourcePath.h"
-#include "lib/gameState/CGameState.h"
 #include "lib/mapObjects/CGHeroInstance.h"
-#include "lib/mapping/CMap.h"
-#include "lib/mapping/CMapHeader.h"
 #include "lib/spells/CSpell.h"
 
 namespace
@@ -65,86 +57,9 @@ bool containsDimensionDoorCast(const NK2AI::Goals::TGoalVec & goals)
 	return false;
 }
 
-class TinyH3MDimensionDoorExplorationTest : public ::testing::Test, public MapListener
+class TinyH3MDimensionDoorExplorationTest : public NullkillerTest
 {
 public:
-	void SetUp() override
-	{
-		gameState = std::make_shared<CGameState>();
-		gameState->preInit(&services);
-	}
-
-	void TearDown() override
-	{
-		gameState.reset();
-		mapService.reset();
-		map = nullptr;
-		pendingOverrides.clear();
-	}
-
-	void mapLoaded(CMap * loadedMap) override
-	{
-		EXPECT_EQ(map, nullptr);
-		map = loadedMap;
-
-		for(const auto & [option, value] : pendingOverrides)
-		{
-			JsonNode node;
-			node.Bool() = value;
-			loadedMap->overrideGameSetting(option, node);
-		}
-	}
-
-	void startWithMap(TinyH3M::TinyH3MBuilder builder)
-	{
-		auto bytes = builder.build();
-		mapService = std::make_unique<MapServiceTinyH3M>(std::move(bytes), this);
-
-		StartInfo si;
-		si.mapname = "tiny";
-		si.difficulty = 0;
-		si.mode = EStartMode::NEW_GAME;
-
-		auto header = mapService->loadMapHeader(ResourcePath(si.mapname));
-		ASSERT_NE(header.get(), nullptr) << "TinyH3M scenario header failed to load";
-
-		for(int i = 0; i < static_cast<int>(header->players.size()); ++i)
-		{
-			const PlayerInfo & pinfo = header->players[i];
-			if(!(pinfo.canHumanPlay || pinfo.canComputerPlay))
-				continue;
-
-			PlayerSettings & pset = si.playerInfos[PlayerColor(i)];
-			pset.color = PlayerColor(i);
-			pset.connectedPlayerIDs.insert(static_cast<PlayerConnectionID>(i));
-			pset.name = "Player";
-			pset.castle = pinfo.defaultCastle();
-			pset.hero = pinfo.defaultHero();
-		}
-
-		GameRandomizer randomizer(*gameState);
-		Load::ProgressAccumulator progressTracker;
-		gameState->init(mapService.get(), &si, randomizer, progressTracker, false);
-
-		ASSERT_NE(map, nullptr) << "gameState init did not populate the CMap";
-	}
-
-	void overrideSettingBeforeInit(EGameSettings option, bool value)
-	{
-		pendingOverrides.push_back({option, value});
-	}
-
-	CGHeroInstance * findHeroByOwner(PlayerColor owner) const
-	{
-		for(const auto & obj : map->objects)
-		{
-			auto * hero = dynamic_cast<CGHeroInstance *>(obj.get());
-			if(hero && hero->getOwner() == owner)
-				return hero;
-		}
-		return nullptr;
-	}
-
 	bool prepareForAdventureSpellPlanning(CGHeroInstance & hero) const
 	{
 		const CSpell * dimensionDoor = DIMENSION_DOOR.toSpell();
@@ -160,56 +75,13 @@ public:
 		return true;
 	}
 
-	void setAllTilesVisible(PlayerColor player, bool visible)
-	{
-		auto & fow = teamState(player).fogOfWarMap;
-
-		for(int z = 0; z < map->levels(); ++z)
-		{
-			for(int x = 0; x < map->width; ++x)
-			{
-				for(int y = 0; y < map->height; ++y)
-					fow[int3(x, y, z)] = visible ? 1 : 0;
-			}
-		}
-	}
-
 	void setTileVisible(PlayerColor player, const int3 & tile, bool visible)
 	{
-		ASSERT_TRUE(map->isInTheMap(tile)) << tile.toString();
-		teamState(player).fogOfWarMap[tile] = visible ? 1 : 0;
+		ASSERT_TRUE(map()->isInTheMap(tile)) << tile.toString();
+		auto * team = gameState()->getPlayerTeam(player);
+		ASSERT_NE(team, nullptr);
+		team->fogOfWarMap[tile] = visible ? 1 : 0;
 	}
-
-	std::shared_ptr<CCallback> makeCallback(PlayerColor player)
-	{
-		return std::make_shared<CCallback>(gameState, std::optional<PlayerColor>{player}, nullptr);
-	}
-
-	std::unique_ptr<NK2AI::AIGateway> makeGateway(const std::shared_ptr<CCallback> & callback)
-	{
-		auto gateway = std::make_unique<NK2AI::AIGateway>();
-		gateway->initGameInterface(std::shared_ptr<Environment>(), callback);
-		return gateway;
-	}
-
-private:
-	TeamState & teamState(PlayerColor player)
-	{
-		return gameState->teams.at(gameState->players.at(player).team);
-	}
-
-	struct PendingOverride
-	{
-		EGameSettings option;
-		bool value;
-	};
-
-	std::vector<PendingOverride> pendingOverrides;
-
-	std::shared_ptr<CGameState> gameState;
-	std::unique_ptr<MapServiceTinyH3M> mapService;
-	ServicesMock services;
-	CMap * map = nullptr;
 };
 }
 
@@ -224,11 +96,10 @@ TEST_F(TinyH3MDimensionDoorExplorationTest, GeneratedDimensionDoorHeroCastsForHi
 	ASSERT_TRUE(hero->spellbookContainsSpell(DIMENSION_DOOR));
 	ASSERT_TRUE(prepareForAdventureSpellPlanning(*hero));
 
-	setAllTilesVisible(PLAYER, false);
+	setMapVisibility(PLAYER, false);
 	setTileVisible(PLAYER, hero->visitablePos(), true);
 
-	const auto callback = makeCallback(PLAYER);
-	const auto gateway = makeGateway(callback);
+	const auto gateway = makeGateway(PLAYER);
 	NK2AI::ExplorationHelper helper(hero, gateway->nullkiller.get());
 
 	EXPECT_TRUE(helper.canUseDimensionDoor());
@@ -249,11 +120,10 @@ TEST_F(TinyH3MDimensionDoorExplorationTest, GeneratedHeroWithoutDimensionDoorDoe
 	ASSERT_FALSE(hero->spellbookContainsSpell(DIMENSION_DOOR));
 	ASSERT_TRUE(prepareForAdventureSpellPlanning(*hero));
 
-	setAllTilesVisible(PLAYER, false);
+	setMapVisibility(PLAYER, false);
 	setTileVisible(PLAYER, hero->visitablePos(), true);
 
-	const auto callback = makeCallback(PLAYER);
-	const auto gateway = makeGateway(callback);
+	const auto gateway = makeGateway(PLAYER);
 	NK2AI::ExplorationHelper helper(hero, gateway->nullkiller.get());
 
 	EXPECT_FALSE(helper.canUseDimensionDoor());
@@ -271,11 +141,10 @@ TEST_F(TinyH3MDimensionDoorExplorationTest, GeneratedDimensionDoorHeroDoesNotPro
 	ASSERT_TRUE(hero->spellbookContainsSpell(DIMENSION_DOOR));
 	ASSERT_TRUE(prepareForAdventureSpellPlanning(*hero));
 
-	setAllTilesVisible(PLAYER, false);
+	setMapVisibility(PLAYER, false);
 	setTileVisible(PLAYER, hero->visitablePos(), true);
 
-	const auto callback = makeCallback(PLAYER);
-	const auto gateway = makeGateway(callback);
+	const auto gateway = makeGateway(PLAYER);
 	NK2AI::ExplorationHelper helper(hero, gateway->nullkiller.get());
 
 	EXPECT_TRUE(helper.canUseDimensionDoor());

--- a/test/nullkiller2/NullkillerTest.h
+++ b/test/nullkiller2/NullkillerTest.h
@@ -1,0 +1,29 @@
+/*
+ * NullkillerTest.h, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ */
+#pragma once
+
+#include "../mock/TinyMapGameTest.h"
+
+#include "../../AI/Nullkiller2/AIGateway.h"
+
+class NullkillerTest : public TinyMapGameTest
+{
+protected:
+	std::unique_ptr<NK2AI::AIGateway> makeGateway(const std::shared_ptr<CCallback> & callback)
+	{
+		auto gateway = std::make_unique<NK2AI::AIGateway>();
+		gateway->initGameInterface(std::shared_ptr<Environment>(), callback);
+		return gateway;
+	}
+
+	std::unique_ptr<NK2AI::AIGateway> makeGateway(PlayerColor player, IClient * client = nullptr)
+	{
+		return makeGateway(makeCallback(player, client));
+	}
+};

--- a/test/quest/CQuestBorderTest.cpp
+++ b/test/quest/CQuestBorderTest.cpp
@@ -111,15 +111,15 @@ TEST_F(QuestBorderTest, Keymaster_FirstVisit_doesNotEmitAddQuest)
 	ASSERT_NE(hero, nullptr);
 	ASSERT_NE(keymaster, nullptr);
 
-	ASSERT_TRUE(gameEventCallback->addedQuests.empty()) << "preconditions";
+	ASSERT_TRUE(gameEvents().addedQuests.empty()) << "preconditions";
 
 	visit(hero, keymaster);
 
-	EXPECT_TRUE(gameEventCallback->addedQuests.empty())
-		<< "keymaster visit unexpectedly emitted " << gameEventCallback->addedQuests.size()
+	EXPECT_TRUE(gameEvents().addedQuests.empty())
+		<< "keymaster visit unexpectedly emitted " << gameEvents().addedQuests.size()
 		<< " AddQuest packet(s)";
 	// And the visit still rendered the standard first-visit message:
-	EXPECT_FALSE(gameEventCallback->infoWindows.empty());
+	EXPECT_FALSE(gameEvents().infoWindows.empty());
 }
 
 TEST_F(QuestBorderTest, Keymaster_SecondVisit_showsAlreadyVisitedText)
@@ -135,11 +135,11 @@ TEST_F(QuestBorderTest, Keymaster_SecondVisit_showsAlreadyVisitedText)
 	ASSERT_NE(keymaster, nullptr);
 
 	visit(hero, keymaster);
-	const size_t windowsAfterFirst = gameEventCallback->infoWindows.size();
+	const size_t windowsAfterFirst = gameEvents().infoWindows.size();
 	ASSERT_GE(windowsAfterFirst, 1u);
 
 	visit(hero, keymaster);
-	EXPECT_GT(gameEventCallback->infoWindows.size(), windowsAfterFirst)
+	EXPECT_GT(gameEvents().infoWindows.size(), windowsAfterFirst)
 		<< "second visit should produce its own already-visited dialog";
 }
 
@@ -158,9 +158,9 @@ TEST_F(QuestBorderTest, BorderGuard_BeforeKeymaster_blocksAndEmitsAddQuest)
 
 	visit(hero, borderGuard);
 
-	EXPECT_EQ(gameEventCallback->addedQuests.size(), 1u);
-	EXPECT_FALSE(gameEventCallback->infoWindows.empty());
-	EXPECT_TRUE(gameEventCallback->blockingDialogs.empty())
+	EXPECT_EQ(gameEvents().addedQuests.size(), 1u);
+	EXPECT_FALSE(gameEvents().infoWindows.empty());
+	EXPECT_TRUE(gameEvents().blockingDialogs.empty())
 		<< "border guard should not prompt for removal before the keymaster has been visited";
 }
 
@@ -181,11 +181,11 @@ TEST_F(QuestBorderTest, BorderGuard_AfterKeymaster_promptsRemovalDialog)
 	visit(hero, keymaster);
 	// Drop everything queued by the keymaster visit so the assertion is
 	// scoped to the border-guard interaction.
-	gameEventCallback->infoWindows.clear();
+	gameEvents().infoWindows.clear();
 
 	visit(hero, borderGuard);
 
-	EXPECT_EQ(gameEventCallback->blockingDialogs.size(), 1u)
+	EXPECT_EQ(gameEvents().blockingDialogs.size(), 1u)
 		<< "border guard should prompt the player whether to demolish";
 }
 
@@ -206,7 +206,7 @@ TEST_F(QuestBorderTest, BorderGuard_AnsweredYes_removesObject)
 	visit(hero, keymaster);
 	visit(hero, borderGuard);
 
-	ASSERT_EQ(gameEventCallback->blockingDialogs.size(), 1u);
+	ASSERT_EQ(gameEvents().blockingDialogs.size(), 1u);
 	answerDialog(hero, /*yes*/ 1);
 
 	EXPECT_EQ(findObjectAt(s.questPos2), nullptr)
@@ -230,7 +230,7 @@ TEST_F(QuestBorderTest, BorderGuard_TwoSiblingsSameColor_emitOnlyOneAddQuest)
 	visit(hero, guardA);
 	visit(hero, guardB);
 
-	EXPECT_EQ(gameEventCallback->addedQuests.size(), 1u)
+	EXPECT_EQ(gameEvents().addedQuests.size(), 1u)
 		<< "same-colour border guards must share one quest-log entry";
 }
 
@@ -250,13 +250,13 @@ TEST_F(QuestBorderTest, BorderGuard_TypeQuestNotTiedToInstance)
 
 	visit(hero, guardA); // registers the shared colour entry
 
-	gameEventCallback->removeObject(guardA, PlayerColor(0));
+	gameEvents().removeObject(guardA, PlayerColor(0));
 
-	const auto & quests = gameState->players.at(PlayerColor(0)).quests;
+	const auto & quests = gameState()->players.at(PlayerColor(0)).quests;
 	ASSERT_EQ(quests.size(), 1u) << "the shared colour entry must survive the guard's removal";
 	EXPECT_FALSE(quests.front().hasObjectInstance())
 		<< "a border entry is a colour type quest, not bound to a map object";
-	EXPECT_NE(quests.front().getQuest(gameState.get()), nullptr)
+	EXPECT_NE(quests.front().getQuest(gameState().get()), nullptr)
 		<< "the type quest still resolves after the visited instance is gone";
 }
 
@@ -275,9 +275,9 @@ TEST_F(QuestBorderTest, BorderGuard_TypeQuestSurvivesAllSiblingsDestroyed)
 	ASSERT_NE(guardB, nullptr);
 
 	visit(hero, guardA);
-	gameEventCallback->removeObject(guardA, PlayerColor(0));
-	gameEventCallback->removeObject(guardB, PlayerColor(0)); // last sibling destroyed
+	gameEvents().removeObject(guardA, PlayerColor(0));
+	gameEvents().removeObject(guardB, PlayerColor(0)); // last sibling destroyed
 
-	EXPECT_EQ(gameState->players.at(PlayerColor(0)).quests.size(), 1u)
+	EXPECT_EQ(gameState()->players.at(PlayerColor(0)).quests.size(), 1u)
 		<< "a keymaster colour type quest persists with no border instances left";
 }

--- a/test/quest/CQuestGateTest.cpp
+++ b/test/quest/CQuestGateTest.cpp
@@ -95,7 +95,7 @@ TEST_F(QuestGateTest, TollPassableForHeroOverloadDifferentiatesPaying)
 
 	auto * hero  = findHeroAt(kHeroPos);
 	auto * gate  = expectAt<QuestGate>(kGatePos);
-	auto & player = gameState->players.at(PlayerColor(0));
+	auto & player = gameState()->players.at(PlayerColor(0));
 
 	player.resources[GameResID::WOOD] = 5;
 	EXPECT_FALSE(gate->passableFor(hero)) << "hero who cannot pay the toll is blocked";
@@ -111,7 +111,7 @@ TEST_F(QuestGateTest, TollChargedEveryPassAndNeverCompleted)
 
 	auto * hero   = findHeroAt(kHeroPos);
 	auto * gate   = expectAt<QuestGate>(kGatePos);
-	auto & player = gameState->players.at(PlayerColor(0));
+	auto & player = gameState()->players.at(PlayerColor(0));
 	player.resources[GameResID::WOOD] = 30;
 
 	visit(hero, gate);

--- a/test/quest/CQuestGuardTest.cpp
+++ b/test/quest/CQuestGuardTest.cpp
@@ -59,7 +59,7 @@ TEST_F(QuestGuardTest, SatisfiedQuest_takesResourcesAndRemovesObjectOnAcceptance
 	ASSERT_NO_FATAL_FAILURE(startWithMap(std::move(s.builder)));
 
 	grantResources(PlayerColor(0), GameResID(GameResID::WOOD), 1500);
-	const auto woodBefore = gameState->players.at(PlayerColor(0)).resources[GameResID::WOOD];
+	const auto woodBefore = gameState()->players.at(PlayerColor(0)).resources[GameResID::WOOD];
 	ASSERT_GE(woodBefore, 1000) << "scenario must leave hero with at least the demanded amount";
 
 	auto * hero  = findHeroAt(s.heroPos);
@@ -68,11 +68,11 @@ TEST_F(QuestGuardTest, SatisfiedQuest_takesResourcesAndRemovesObjectOnAcceptance
 	ASSERT_NE(guard, nullptr);
 
 	visit(hero, guard);
-	ASSERT_EQ(gameEventCallback->blockingDialogs.size(), 1u)
+	ASSERT_EQ(gameEvents().blockingDialogs.size(), 1u)
 		<< "first visit with a satisfied limiter should prompt the player";
 	answerDialog(hero, /*yes*/ 1);
 
-	const auto woodAfter = gameState->players.at(PlayerColor(0)).resources[GameResID::WOOD];
+	const auto woodAfter = gameState()->players.at(PlayerColor(0)).resources[GameResID::WOOD];
 	EXPECT_EQ(woodBefore - woodAfter, 1000)
 		<< "quest should deduct exactly the demanded 1000 wood";
 	EXPECT_EQ(findObjectAt(s.questPos), nullptr)

--- a/test/quest/CQuestMarkerTest.cpp
+++ b/test/quest/CQuestMarkerTest.cpp
@@ -40,7 +40,7 @@ TEST_F(QuestMarkerTest, Source_isAlwaysMarked)
 	ASSERT_NO_FATAL_FAILURE(startWithMap(std::move(s.builder)));
 	auto * seer = expectAt<SeerHut>(s.questPos);
 
-	auto tiles = QuestInfo(seer->id).getMarkerTiles(gameState.get());
+	auto tiles = QuestInfo(seer->id).getMarkerTiles(gameState().get());
 
 	EXPECT_TRUE(hasTile(tiles, seer->visitablePos())) << "the quest source must always be marked";
 }
@@ -52,7 +52,7 @@ TEST_F(QuestMarkerTest, KillCreature_marksTarget)
 	auto * seer    = expectAt<SeerHut>(s.questPos);
 	auto * monster = expectAt<CGCreature>(s.secondHeroPos);
 
-	auto tiles = QuestInfo(seer->id).getMarkerTiles(gameState.get());
+	auto tiles = QuestInfo(seer->id).getMarkerTiles(gameState().get());
 
 	EXPECT_TRUE(hasTile(tiles, seer->visitablePos()));
 	EXPECT_TRUE(hasTile(tiles, monster->visitablePos())) << "kill target must be marked from destroyedObjects";
@@ -66,7 +66,7 @@ TEST_F(QuestMarkerTest, BringArtifact_marksHeroHoldingIt)
 	auto * hero = findHeroAt(s.heroPos);
 	ASSERT_NE(hero, nullptr);
 
-	auto tiles = QuestInfo(seer->id).getMarkerTiles(gameState.get());
+	auto tiles = QuestInfo(seer->id).getMarkerTiles(gameState().get());
 
 	EXPECT_TRUE(hasTile(tiles, hero->visitablePos()))
 		<< "a hero already satisfying the limiter (carrying the artifact) must be marked";
@@ -81,8 +81,8 @@ TEST_F(QuestMarkerTest, Level_marksQualifyingHeroOnly)
 	auto * hero = findHeroAt(s.heroPos);
 	ASSERT_NE(hero, nullptr);
 
-	auto easyTiles = QuestInfo(easySeer->id).getMarkerTiles(gameState.get());
-	auto hardTiles = QuestInfo(hardSeer->id).getMarkerTiles(gameState.get());
+	auto easyTiles = QuestInfo(easySeer->id).getMarkerTiles(gameState().get());
+	auto hardTiles = QuestInfo(hardSeer->id).getMarkerTiles(gameState().get());
 
 	EXPECT_TRUE(hasTile(easyTiles, hero->visitablePos())) << "hero meets the easy level requirement";
 	EXPECT_FALSE(hasTile(hardTiles, hero->visitablePos())) << "hero does not meet the hard level requirement";
@@ -97,7 +97,7 @@ TEST_F(QuestMarkerTest, BorderGuard_marksMatchingKeymaster)
 	ASSERT_NE(guard,     nullptr);
 	ASSERT_NE(keymaster, nullptr);
 
-	auto tiles = QuestInfo(guard->id).getMarkerTiles(gameState.get());
+	auto tiles = QuestInfo(guard->id).getMarkerTiles(gameState().get());
 
 	EXPECT_TRUE(hasTile(tiles, guard->visitablePos()));
 	EXPECT_TRUE(hasTile(tiles, keymaster->visitablePos()))

--- a/test/quest/CQuestSeerMultiTest.cpp
+++ b/test/quest/CQuestSeerMultiTest.cpp
@@ -110,7 +110,7 @@ TEST_F(QuestSeerMultiTest, PerQuestRewardIsUsedNotConfigurationInfoIndex)
 
 	auto * hero  = findHeroAt(kHeroPos);
 	auto * seer  = expectAt<SeerHut>(kSeerPos);
-	auto & res   = gameState->players.at(PlayerColor(0)).resources;
+	auto & res   = gameState()->players.at(PlayerColor(0)).resources;
 	const int woodBefore = res[GameResID::WOOD];
 
 	visit(hero, seer);
@@ -193,13 +193,13 @@ TEST_F(QuestSeerMultiTest, PermanentlyEmptyWhenAllOneShotAndAllRepeatableExpired
 	answerDialog(hero, 1);   // finish the only one-shot
 	advanceDays(5);          // expire the repeatable past its deadline
 
-	const size_t addQuestsBefore = gameEventCallback->addedQuests.size();
-	gameEventCallback->blockingDialogs.clear();
+	const size_t addQuestsBefore = gameEvents().addedQuests.size();
+	gameEvents().blockingDialogs.clear();
 	visit(hero, seer);       // no offerable quest: empty dialog only
 
-	EXPECT_EQ(gameEventCallback->addedQuests.size(), addQuestsBefore)
+	EXPECT_EQ(gameEvents().addedQuests.size(), addQuestsBefore)
 		<< "emptied seer must not register a quest log entry";
-	EXPECT_TRUE(gameEventCallback->blockingDialogs.empty())
+	EXPECT_TRUE(gameEvents().blockingDialogs.empty())
 		<< "emptied seer must not offer a reward";
 }
 
@@ -275,8 +275,8 @@ TEST_F(QuestSeerMultiTest, QuestlessSeer_isVisitableAndGetQuestThrows)
 	EXPECT_TRUE(seer->allQuests().empty());
 	EXPECT_ANY_THROW((void)seer->getQuest()) << "no active quest - getQuest() must throw";
 
-	const size_t addQuestsBefore = gameEventCallback->addedQuests.size();
+	const size_t addQuestsBefore = gameEvents().addedQuests.size();
 	ASSERT_NO_FATAL_FAILURE(visit(hero, seer)); // shows only the empty-seer dialog
-	EXPECT_EQ(gameEventCallback->addedQuests.size(), addQuestsBefore);
-	EXPECT_TRUE(gameEventCallback->blockingDialogs.empty());
+	EXPECT_EQ(gameEvents().addedQuests.size(), addQuestsBefore);
+	EXPECT_TRUE(gameEvents().blockingDialogs.empty());
 }

--- a/test/quest/CQuestSeerTest.cpp
+++ b/test/quest/CQuestSeerTest.cpp
@@ -150,7 +150,7 @@ TEST_F(QuestSeerTest, FirstVisit_emitsAddQuest)
 
 	visit(tyris, seer);
 
-	EXPECT_EQ(gameEventCallback->addedQuests.size(), 1u);
+	EXPECT_EQ(gameEvents().addedQuests.size(), 1u);
 }
 
 TEST_F(QuestSeerTest, RepeatVisit_failedRequirements_showsNextVisitText)
@@ -166,15 +166,15 @@ TEST_F(QuestSeerTest, RepeatVisit_failedRequirements_showsNextVisitText)
 	ASSERT_NE(seer,      nullptr);
 
 	visit(christian, seer);
-	const size_t addQuestsAfterFirst = gameEventCallback->addedQuests.size();
-	const size_t windowsAfterFirst   = gameEventCallback->infoWindows.size();
+	const size_t addQuestsAfterFirst = gameEvents().addedQuests.size();
+	const size_t windowsAfterFirst   = gameEvents().infoWindows.size();
 	EXPECT_EQ(addQuestsAfterFirst, 1u);
 	EXPECT_GE(windowsAfterFirst,   1u);
 
 	visit(christian, seer);
-	EXPECT_EQ(gameEventCallback->addedQuests.size(), addQuestsAfterFirst)
+	EXPECT_EQ(gameEvents().addedQuests.size(), addQuestsAfterFirst)
 		<< "second failed visit must not re-emit AddQuest";
-	EXPECT_GT(gameEventCallback->infoWindows.size(), windowsAfterFirst)
+	EXPECT_GT(gameEvents().infoWindows.size(), windowsAfterFirst)
 		<< "second failed visit should produce its own next-visit info dialog";
 }
 
@@ -192,7 +192,7 @@ TEST_F(QuestSeerTest, GrantsRewardOnAcceptance)
 
 	const auto xpBefore = tyris->exp;
 	visit(tyris, seer);
-	ASSERT_EQ(gameEventCallback->blockingDialogs.size(), 1u);
+	ASSERT_EQ(gameEvents().blockingDialogs.size(), 1u);
 	answerDialog(tyris, /*select reward 0*/ 1);
 
 	EXPECT_GE(tyris->exp, xpBefore + 500)
@@ -215,15 +215,15 @@ TEST_F(QuestSeerTest, CompletedOneShot_subsequentVisitShowsEmptyText)
 	answerDialog(tyris, 1);
 
 	// Snapshot after completion, then re-visit.
-	const size_t addQuestsBefore     = gameEventCallback->addedQuests.size();
-	const size_t blockingsBefore     = gameEventCallback->blockingDialogs.size();
-	const size_t windowsBefore       = gameEventCallback->infoWindows.size();
+	const size_t addQuestsBefore     = gameEvents().addedQuests.size();
+	const size_t blockingsBefore     = gameEvents().blockingDialogs.size();
+	const size_t windowsBefore       = gameEvents().infoWindows.size();
 
 	visit(tyris, seer);
 
-	EXPECT_EQ(gameEventCallback->addedQuests.size(),     addQuestsBefore);
-	EXPECT_EQ(gameEventCallback->blockingDialogs.size(), blockingsBefore);
-	EXPECT_GT(gameEventCallback->infoWindows.size(),     windowsBefore);
+	EXPECT_EQ(gameEvents().addedQuests.size(),     addQuestsBefore);
+	EXPECT_EQ(gameEvents().blockingDialogs.size(), blockingsBefore);
+	EXPECT_GT(gameEvents().infoWindows.size(),     windowsBefore);
 }
 
 TEST_F(QuestSeerTest, BringResources_takesResources)
@@ -235,7 +235,7 @@ TEST_F(QuestSeerTest, BringResources_takesResources)
 	grantResources(PlayerColor(0), GameResID(GameResID::GOLD), 7000);
 	grantResources(PlayerColor(0), GameResID(GameResID::WOOD),   10);
 
-	auto & playerRes = gameState->players.at(PlayerColor(0)).resources;
+	auto & playerRes = gameState()->players.at(PlayerColor(0)).resources;
 	const int goldBefore = playerRes[GameResID::GOLD];
 	const int woodBefore = playerRes[GameResID::WOOD];
 
@@ -245,7 +245,7 @@ TEST_F(QuestSeerTest, BringResources_takesResources)
 	ASSERT_NE(seer, nullptr);
 
 	visit(hero, seer);
-	ASSERT_EQ(gameEventCallback->blockingDialogs.size(), 1u);
+	ASSERT_EQ(gameEvents().blockingDialogs.size(), 1u);
 	answerDialog(hero, 1);
 
 	EXPECT_EQ(goldBefore - playerRes[GameResID::GOLD], 5000);
@@ -270,7 +270,7 @@ TEST_F(QuestSeerTest, BringArmy_takesCreatures_keepsExtras)
 	ASSERT_EQ(hero->getStackCount(SlotID(1)),  5);
 
 	visit(hero, seer);
-	ASSERT_EQ(gameEventCallback->blockingDialogs.size(), 1u);
+	ASSERT_EQ(gameEvents().blockingDialogs.size(), 1u);
 	answerDialog(hero, 1);
 
 	EXPECT_EQ(hero->getStackCount(SlotID(0)), 5) << "5 of 10 Griffins should remain";
@@ -291,7 +291,7 @@ TEST_F(QuestSeerTest, BringArtifact_completesAndTakesArtifact)
 	ASSERT_TRUE(hero->hasArt(kArtifactSash)) << "scenario must place the sash in the backpack";
 
 	visit(hero, seer);
-	ASSERT_EQ(gameEventCallback->blockingDialogs.size(), 1u);
+	ASSERT_EQ(gameEvents().blockingDialogs.size(), 1u);
 	answerDialog(hero, 1);
 
 	EXPECT_FALSE(hero->hasArt(kArtifactSash))
@@ -313,7 +313,7 @@ TEST_F(QuestSeerTest, BringArtifact_componentOfAssemblyInBackpack_disassembles)
 	ASSERT_TRUE(hero->hasArt(kArtifactAngelicAlly)) << "Angelic Alliance must be carried pre-visit";
 
 	visit(hero, seer);
-	ASSERT_EQ(gameEventCallback->blockingDialogs.size(), 1u);
+	ASSERT_EQ(gameEvents().blockingDialogs.size(), 1u);
 	answerDialog(hero, 1);
 
 	EXPECT_FALSE(hero->hasArt(kArtifactAngelicAlly))
@@ -337,7 +337,7 @@ TEST_F(QuestSeerTest, BringArtifact_componentOfAssemblyEquipped_disassembles)
 	ASSERT_TRUE(hero->hasArt(kArtifactAngelicAlly)) << "Angelic Alliance must be equipped pre-visit";
 
 	visit(hero, seer);
-	ASSERT_EQ(gameEventCallback->blockingDialogs.size(), 1u);
+	ASSERT_EQ(gameEvents().blockingDialogs.size(), 1u);
 	answerDialog(hero, 1);
 
 	EXPECT_FALSE(hero->hasArt(kArtifactAngelicAlly))
@@ -361,7 +361,7 @@ TEST_F(QuestSeerTest, FullArmyRemoval_h3BugSetting_enabledAllowsArmyEmpty)
 	ASSERT_EQ(hero->getStackCount(SlotID(0)), 1);
 
 	visit(hero, seer);
-	ASSERT_EQ(gameEventCallback->blockingDialogs.size(), 1u);
+	ASSERT_EQ(gameEvents().blockingDialogs.size(), 1u);
 	answerDialog(hero, 1);
 
 	EXPECT_FALSE(hero->hasStackAtSlot(SlotID(0)))
@@ -381,7 +381,7 @@ TEST_F(QuestSeerTest, FullArmyRemoval_disabled_keepsHeroWithOneStack)
 	ASSERT_NE(seer, nullptr);
 
 	visit(hero, seer);
-	if(!gameEventCallback->blockingDialogs.empty())
+	if(!gameEvents().blockingDialogs.empty())
 		answerDialog(hero, 1);
 
 	EXPECT_TRUE(hero->hasStackAtSlot(SlotID(0)))
@@ -401,17 +401,17 @@ TEST_F(QuestSeerTest, Timeout_expiresOnLastDay)
 	EXPECT_FALSE(seer->getQuest().isCompleted);
 
 	advanceDays(10);
-	GameRandomizer randomizer(*gameState);
-	seer->newTurn(*gameEventCallback, randomizer);
+	GameRandomizer randomizer(*gameState());
+	seer->newTurn(gameEvents(), randomizer);
 
 	// After the deadline the seer is inaccessible: a visit yields only the
 	// empty-seer info dialog, with no quest log entry and no reward prompt.
 	auto * hero = findHeroAt(s.heroPos);
 	ASSERT_NE(hero, nullptr);
-	const size_t addQuestsBefore = gameEventCallback->addedQuests.size();
+	const size_t addQuestsBefore = gameEvents().addedQuests.size();
 	visit(hero, seer);
-	EXPECT_EQ(gameEventCallback->addedQuests.size(), addQuestsBefore)
+	EXPECT_EQ(gameEvents().addedQuests.size(), addQuestsBefore)
 		<< "expired seer must not register a quest log entry";
-	EXPECT_TRUE(gameEventCallback->blockingDialogs.empty())
+	EXPECT_TRUE(gameEvents().blockingDialogs.empty())
 		<< "expired seer must not offer its reward";
 }

--- a/test/quest/CQuestVisibilityTest.cpp
+++ b/test/quest/CQuestVisibilityTest.cpp
@@ -35,16 +35,16 @@ TEST_F(QuestVisibilityTest, QuestSource_FogOfWarVisibility_questHolderRemainsAcc
 	ASSERT_NE(hero, nullptr);
 
 	// Hide the whole map for the player so visibility can only come from the override.
-	const auto teamId = gameState->players.at(PlayerColor(0)).team;
-	for(auto & tile : gameState->teams.at(teamId).fogOfWarMap)
+	const auto teamId = gameState()->players.at(PlayerColor(0)).team;
+	for(auto & tile : gameState()->teams.at(teamId).fogOfWarMap)
 		tile = 0;
 
-	ASSERT_FALSE(gameState->isVisibleFor(seer, PlayerColor(0)))
+	ASSERT_FALSE(gameState()->isVisibleFor(seer, PlayerColor(0)))
 		<< "precondition: seer must be hidden under fog before the quest is logged";
 
 	visit(hero, seer); // first visit registers the quest in player 0's log
 
-	EXPECT_TRUE(gameState->isVisibleFor(seer, PlayerColor(0)))
+	EXPECT_TRUE(gameState()->isVisibleFor(seer, PlayerColor(0)))
 		<< "a quest source in the player's log must stay accessible under fog of war";
 }
 
@@ -58,11 +58,11 @@ TEST_F(QuestVisibilityTest, QuestSource_RemovedSourceErasesQuestLogEntry)
 	ASSERT_NE(hero, nullptr);
 
 	visit(hero, seer);
-	ASSERT_FALSE(gameState->players.at(PlayerColor(0)).quests.empty())
+	ASSERT_FALSE(gameState()->players.at(PlayerColor(0)).quests.empty())
 		<< "precondition: visiting the seer must register a quest-log entry";
 
-	gameEventCallback->removeObject(seer, PlayerColor(0));
+	gameEvents().removeObject(seer, PlayerColor(0));
 
-	EXPECT_TRUE(gameState->players.at(PlayerColor(0)).quests.empty())
+	EXPECT_TRUE(gameState()->players.at(PlayerColor(0)).quests.empty())
 		<< "removing the quest source must erase its quest-log entry";
 }

--- a/test/quest/QuestTest.cpp
+++ b/test/quest/QuestTest.cpp
@@ -15,94 +15,15 @@
 #include "../../lib/mapObjects/CGHeroInstance.h"
 #include "../../lib/mapObjects/CGObjectInstance.h"
 
-void QuestTest::startWithMap(TinyH3M::TinyH3MBuilder builder)
+void QuestTest::onMapStarted()
 {
-	startWithMap(std::move(builder), EMapDifficulty::EASY);
-}
-
-void QuestTest::startWithMap(TinyH3M::TinyH3MBuilder builder, EMapDifficulty difficulty)
-{
-	const auto * info = ::testing::UnitTest::GetInstance()->current_test_info();
-	std::string fixtureName = std::string(info->test_suite_name()) + "_" + info->name();
-	std::replace(fixtureName.begin(), fixtureName.end(), '/', '_'); // parameterized cases embed '/'
-	auto bytes = builder.buildAndDump(fixtureName);
-	mapService = std::make_unique<MapServiceTinyH3M>(std::move(bytes), this);
-
-	StartInfo si;
-	si.mapname    = "tiny";
-	si.difficulty = static_cast<ui8>(difficulty);
-	si.mode       = EStartMode::NEW_GAME;
-
-	auto header = mapService->loadMapHeader(ResourcePath(si.mapname));
-	ASSERT_NE(header.get(), nullptr) << "TinyH3M scenario header failed to load";
-
-	for(int i = 0; i < static_cast<int>(header->players.size()); ++i)
-	{
-		const PlayerInfo & pinfo = header->players[i];
-		if(!(pinfo.canHumanPlay || pinfo.canComputerPlay))
-			continue;
-
-		PlayerSettings & pset = si.playerInfos[PlayerColor(i)];
-		pset.color  = PlayerColor(i);
-		pset.connectedPlayerIDs.insert(static_cast<PlayerConnectionID>(i));
-		pset.name   = "Player";
-		pset.castle = pinfo.defaultCastle();
-		pset.hero   = pinfo.defaultHero();
-	}
-
-	GameRandomizer randomizer(*gameState);
-	Load::ProgressAccumulator progressTracker;
-	gameState->init(mapService.get(), &si, randomizer, progressTracker, false);
-
-	ASSERT_NE(map, nullptr) << "gameState init did not populate the CMap";
-
-	// Needed by mock takeCreatures and any override that resolves ObjectInstanceIDs.
-	gameEventCallback->setGameInfoCallback(gameState.get());
-}
-
-CGObjectInstance * QuestTest::findObjectAt(const int3 & pos) const
-{
-	for(const auto & obj : map->objects)
-	{
-		if(obj && obj->anchorPos() == pos)
-			return obj.get();
-	}
-	return nullptr;
-}
-
-CGHeroInstance * QuestTest::findHeroAt(const int3 & pos) const
-{
-	for(const auto & obj : map->objects)
-	{
-		auto * hero = dynamic_cast<CGHeroInstance *>(obj.get());
-		if(hero && hero->anchorPos() == pos)
-			return hero;
-	}
-	return nullptr;
-}
-
-CGHeroInstance * QuestTest::findHeroByOwner(PlayerColor owner) const
-{
-	for(const auto & obj : map->objects)
-	{
-		auto * hero = dynamic_cast<CGHeroInstance *>(obj.get());
-		if(hero && hero->getOwner() == owner)
-			return hero;
-	}
-	return nullptr;
-}
-
-void QuestTest::grantResources(PlayerColor player, GameResID which, int amount)
-{
-	auto it = gameState->players.find(player);
-	ASSERT_NE(it, gameState->players.end()) << "Player " << player.getNum() << " not initialised";
-	it->second.resources[which] += amount;
+	gameEvents().setGameInfoCallback(gameState().get());
 }
 
 void QuestTest::markObjectDestroyed(PlayerColor player, ObjectInstanceID target)
 {
-	auto it = gameState->players.find(player);
-	ASSERT_NE(it, gameState->players.end()) << "Player " << player.getNum() << " not initialised";
+	auto it = gameState()->players.find(player);
+	ASSERT_NE(it, gameState()->players.end()) << "Player " << player.getNum() << " not initialised";
 	it->second.destroyedObjects.insert(target);
 }
 
@@ -110,14 +31,14 @@ void QuestTest::visit(CGHeroInstance * hero, CGObjectInstance * obj)
 {
 	ASSERT_NE(hero, nullptr);
 	ASSERT_NE(obj, nullptr);
-	obj->onHeroVisit(*gameEventCallback, hero);
+	obj->onHeroVisit(gameEvents(), hero);
 }
 
 void QuestTest::answerDialog(CGHeroInstance * hero, int32_t answer)
 {
 	// Pop the most recent (innermost) dialog first — nested visits enqueue
 	// in LIFO order and an answer should resolve the topmost prompt.
-	auto & queue = gameEventCallback->blockingDialogs;
+	auto & queue = gameEvents().blockingDialogs;
 	ASSERT_FALSE(queue.empty())
 		<< "answerDialog called with no pending BlockingDialog — visit must enqueue one first";
 	auto captured = queue.back();
@@ -125,12 +46,7 @@ void QuestTest::answerDialog(CGHeroInstance * hero, int32_t answer)
 
 	ASSERT_NE(captured.caller, nullptr)
 		<< "captured BlockingDialog has no caller; blockingDialogAnswered would have nothing to dispatch on";
-	captured.caller->blockingDialogAnswered(*gameEventCallback, hero, answer);
-}
-
-void QuestTest::overrideSettingBeforeInit(EGameSettings option, bool value)
-{
-	pendingOverrides.push_back({option, value});
+	captured.caller->blockingDialogAnswered(gameEvents(), hero, answer);
 }
 
 void QuestTest::advanceDays(int days)
@@ -139,10 +55,10 @@ void QuestTest::advanceDays(int days)
 	// (quest timeout / HotA reach-date) fires through the real code path rather
 	// than needing a manual setObjProperty in each test.
 	ASSERT_GE(days, 0);
-	gameState->day += static_cast<ui32>(days);
+	gameState()->day += static_cast<ui32>(days);
 
-	GameRandomizer randomizer(*gameState);
-	for(const auto & obj : map->objects)
+	GameRandomizer randomizer(*gameState());
+	for(const auto & obj : map()->objects)
 		if(obj)
-			obj->newTurn(*gameEventCallback, randomizer);
+			obj->newTurn(gameEvents(), randomizer);
 }

--- a/test/quest/QuestTest.h
+++ b/test/quest/QuestTest.h
@@ -9,23 +9,8 @@
  */
 #pragma once
 
-#include "StdInc.h"
-
-#include "../mock/TinyH3MBuilder.h"
-#include "../mock/mock_MapServiceTinyH3M.h"
-#include "../mock/mock_Services.h"
+#include "../mock/TinyMapGameTest.h"
 #include "../mock/mock_IGameEventCallback.h"
-
-#include "../../lib/CRandomGenerator.h"
-#include "../../lib/IGameSettings.h"
-#include "../../lib/StartInfo.h"
-#include "../../lib/callback/GameRandomizer.h"
-#include "../../lib/filesystem/ResourcePath.h"
-#include "../../lib/gameState/CGameState.h"
-#include "../../lib/mapping/CMap.h"
-#include "../../lib/mapping/CMapHeader.h"
-
-#include <vcmi/ServerCallback.h>
 
 class CGObjectInstance;
 class CGHeroInstance;
@@ -36,7 +21,7 @@ class QuestGuard;
 /// scenario into a live CGameState and exposes helpers for the everyday
 /// quest-flow steps: locate a placed object, walk a hero onto it, answer
 /// dialogs, hand out resources, advance the calendar.
-class QuestTest : public ::testing::Test, public ServerCallback, public MapListener
+class QuestTest : public TinyMapGameTest
 {
 public:
 	QuestTest()
@@ -44,106 +29,7 @@ public:
 	{
 	}
 
-	void SetUp() override
-	{
-		gameState = std::make_shared<CGameState>();
-		gameState->preInit(&services);
-	}
-
-	void TearDown() override
-	{
-		gameState.reset();
-		mapService.reset();
-		map = nullptr;
-	}
-
-	// ---- ServerCallback overrides ---------------------------------------
-
-	bool describeChanges() const override { return true; }
-	void apply(CPackForClient & pack) override { gameState->apply(pack); }
-	void complain(const std::string & problem) override
-	{
-		FAIL() << "Server-side assertion: " << problem;
-	}
-	vstd::RNG * getRNG() override { return &randomGenerator; }
-
-	// Battle-specific overrides are no-ops for quest tests.
-	void apply(BattleLogMessage &) override {}
-	void apply(BattleStackMoved &) override {}
-	void apply(BattleUnitsChanged &) override {}
-	void apply(SetStackEffect &) override {}
-	void apply(StacksInjured &) override {}
-	void apply(BattleObstaclesChanged &) override {}
-	void apply(CatapultAttack &) override {}
-
-	// ---- MapListener override -------------------------------------------
-
-	void mapLoaded(CMap * loadedMap) override
-	{
-		EXPECT_EQ(this->map, nullptr);
-		this->map = loadedMap;
-		// Game-setting overrides must land before initObj runs, since some
-		// settings get baked into per-object state at init time.
-		for(const auto & ov : pendingOverrides)
-		{
-			JsonNode node;
-			node.Bool() = ov.value;
-			loadedMap->overrideGameSetting(ov.option, node);
-		}
-	}
-
 	// ---- public test API ------------------------------------------------
-
-	/// Load a scenario into a fresh game. After this returns, `map` and
-	/// `gameState` are populated and ready for assertions. The difficulty overload
-	/// drives difficulty-gated quests (HotA game-difficulty missions); the default
-	/// is EASY, matching the historical behaviour.
-	void startWithMap(TinyH3M::TinyH3MBuilder builder);
-	void startWithMap(TinyH3M::TinyH3MBuilder builder, EMapDifficulty difficulty);
-
-	/// Find the object placed on a given tile.
-	CGObjectInstance * findObjectAt(const int3 & pos) const;
-	CGHeroInstance   * findHeroAt(const int3 & pos) const;
-	CGHeroInstance   * findHeroByOwner(PlayerColor owner) const;
-
-	/// Locate the object at `pos` and verify it has dynamic type `T`. Fails the
-	/// test if no object is there or the type does not match.
-	template<class T>
-	T * expectAt(const int3 & pos) const
-	{
-		auto * obj = findObjectAt(pos);
-		EXPECT_NE(obj, nullptr) << "no object at " << pos.toString();
-		auto * casted = dynamic_cast<T *>(obj);
-		EXPECT_NE(casted, nullptr) << "object at " << pos.toString() << " has unexpected dynamic type";
-		return casted;
-	}
-
-	/// Find the first / all object(s) of a given dynamic type on the map.
-	template<class T>
-	T * findFirst() const
-	{
-		for(const auto & obj : map->objects)
-		{
-			if(auto * casted = dynamic_cast<T *>(obj.get()))
-				return casted;
-		}
-		return nullptr;
-	}
-
-	template<class T>
-	std::vector<T *> findAll() const
-	{
-		std::vector<T *> out;
-		for(const auto & obj : map->objects)
-		{
-			if(auto * casted = dynamic_cast<T *>(obj.get()))
-				out.push_back(casted);
-		}
-		return out;
-	}
-
-	/// Top up a player's stockpile (scenarios start with empty resources).
-	void grantResources(PlayerColor player, GameResID which, int amount);
 
 	/// Pretend the player has just defeated `target` — short-circuits the
 	/// adventure-map battle that a kill-quest would normally require.
@@ -158,23 +44,10 @@ public:
 	/// Advance the in-game calendar by `days`.
 	void advanceDays(int days);
 
-	/// Override a game setting before any object's init runs. Must be called
-	/// before startWithMap — some settings bake into per-object state at init,
-	/// so a post-startWithMap override won't take effect on already-built objects.
-	void overrideSettingBeforeInit(EGameSettings option, bool value);
-
 protected:
-	struct PendingOverride
-	{
-		EGameSettings option;
-		bool          value;
-	};
-	std::vector<PendingOverride> pendingOverrides;
+	void onMapStarted() override;
+	GameEventCallbackMock & gameEvents() const { return *gameEventCallback; }
 
-	std::shared_ptr<CGameState>            gameState;
+private:
 	std::shared_ptr<GameEventCallbackMock> gameEventCallback;
-	std::unique_ptr<MapServiceTinyH3M>     mapService;
-	ServicesMock                           services;
-	CMap *                                 map = nullptr;
-	CRandomGenerator                       randomGenerator;
 };


### PR DESCRIPTION
This PR is a refactoring. It adds shared setup for tests that load small maps, create Nullkiller, and handle game requests. Existing tests now use it instead of repeating the same setup.

It was factored out of #7613 so the test setup can be reviewed and merged separately from the AI fixes.