### PR TITLE
Mana Regen fixes

### DIFF
--- a/config/gameConfig.json
+++ b/config/gameConfig.json
@@ -837,7 +837,15 @@
 				{
 					"type" : "MANA_REGENERATION", //default mana regeneration
 					"val" : 1,
-					"valueType" : "BASE_NUMBER"
+					"valueType" : "BASE_NUMBER",
+					"limiters" : [
+						"noneOf",
+						{
+							"type" : "HAS_ANOTHER_BONUS_LIMITER",
+							"bonusType" : "MANA_REGENERATION",
+							"bonusSourceType" : "SECONDARY_SKILL"
+						}
+					]
 				},
 				"experienceGain" : 
 				{

--- a/config/heroes/dungeon.json
+++ b/config/heroes/dungeon.json
@@ -144,7 +144,14 @@
 			{ "skill" : "mysticism", "level": "basic" }
 		],
 		"specialty" : {
-			"secondary" : "mysticism"
+			"secondary" : "mysticism",
+			"bonuses" : {
+				"mysticismExtra" : {
+					"type" : "MANA_REGENERATION",
+					"val" : 1,
+					"valueType" : "ADDITIVE_VALUE"
+				}
+			}
 		}
 	},
 	"malekith":

--- a/config/heroes/fortress.json
+++ b/config/heroes/fortress.json
@@ -152,7 +152,14 @@
 			{ "skill" : "mysticism", "level": "basic" }
 		],
 		"specialty" : {
-			"secondary" : "mysticism"
+			"secondary" : "mysticism",
+			"bonuses" : {
+				"mysticismExtra" : {
+					"type" : "MANA_REGENERATION",
+					"val" : 1,
+					"valueType" : "ADDITIVE_VALUE"
+				}
+			}
 		}
 	},
 	"voy":

--- a/config/heroes/inferno.json
+++ b/config/heroes/inferno.json
@@ -157,7 +157,14 @@
 			{ "skill" : "mysticism", "level": "basic" }
 		],
 		"specialty" : {
-			"secondary" : "mysticism"
+			"secondary" : "mysticism",
+			"bonuses" : {
+				"mysticismExtra" : {
+					"type" : "MANA_REGENERATION",
+					"val" : 1,
+					"valueType" : "ADDITIVE_VALUE"
+				}
+			}
 		}
 	},
 	"olema":

--- a/config/heroes/tower.json
+++ b/config/heroes/tower.json
@@ -152,7 +152,14 @@
 			{ "skill" : "mysticism", "level": "basic" }
 		],
 		"specialty" : {
-			"secondary" : "mysticism"
+			"secondary" : "mysticism",
+			"bonuses" : {
+				"mysticismExtra" : {
+					"type" : "MANA_REGENERATION",
+					"val" : 1,
+					"valueType" : "ADDITIVE_VALUE"
+				}
+			}
 		}
 	},
 	"serena":

--- a/config/skills.json
+++ b/config/skills.json
@@ -260,17 +260,17 @@
 		},
 		"basic" : {
 			"effects" : {
-				"main" : { "val" : 1 }
+				"main" : { "val" : 2 }
 			}
 		},
 		"advanced" : {
 			"effects" : {
-				"main" : { "val" : 2 }
+				"main" : { "val" : 3 }
 			}
 		},
 		"expert" : {
 			"effects" : {
-				"main" : { "val" : 3 }
+				"main" : { "val" : 4 }
 			}
 		}
 	},

--- a/test/game/BattleSpellCastTest.cpp
+++ b/test/game/BattleSpellCastTest.cpp
@@ -1343,8 +1343,13 @@ TEST_P(SecondarySkillSpecialty, scalesSkillBonus)
 	const int64_t withoutSpec = skillContribution(adelaideIdx, c);
 
 	ASSERT_GT(withoutSpec, 0) << c.name << ": skill provides no measurable bonus";
-
-	EXPECT_EQ(withSpec, applyPercentDown(withoutSpec, 5 * c.heroLevel)) << c.name;
+	// mysticism specialty has a hidden +1 flat mana regeneration
+	if (c.skillIdx == 8)
+	{
+		EXPECT_EQ(withSpec, applyPercentDown(withoutSpec, 5 * c.heroLevel) + 1) << c.name;
+	} else {
+		EXPECT_EQ(withSpec, applyPercentDown(withoutSpec, 5 * c.heroLevel)) << c.name;
+	}	
 }
 
 INSTANTIATE_TEST_SUITE_P(Heroes, SecondarySkillSpecialty, ::testing::Values(


### PR DESCRIPTION
Fixes #7682 

This PR addresses the part of the issue that the base mana regen of 1 is not factored in while calculating the value specialty Mysticism should add because it doesn't come from a secondary skill.

Solution:
Limit the base mana regen to the hero not having a mana regen boosting secondary skill and move that base line into the secondary skill.

Edit:
Actually #7682 was not correct. What happens is that Mysticism specialists get an ADDITIONAL +1 Mana Regen without it being documented anywhere. A lvl 20 Halon in SoD regenerates 9 Mana, a lvl 10 Halon 7. There aren't any fractions here and the same rounding error twice in a row is unlikely. I have reflected these findings in this PR. Mana regen in VCMI is now identical from what I can see.