### PR TITLE
Reworks inserting spell into spellscroll tooltip: allows for multiple placeholders, safe trailing space removal and custom placeholder values.

### DIFF
--- a/Mods/vcmi/Content/config/translations/english.json
+++ b/Mods/vcmi/Content/config/translations/english.json
@@ -1,5 +1,6 @@
 {
 	"artifact.core.orbOfVulnerability.bonus.noResistance": "{Orb of Vulnerability}\nNegates natural magic resistance of all creatures on the battlefield.",
+	"artifact.core.spellScroll.spellName.default": "",
 	"core.bonus.ADDITIONAL_ATTACK.description": "{Additional Attacks}\nThis unit can attack ${val} additional time(s).",
 	"core.bonus.ADDITIONAL_RETALIATION.description": "{Additional Retaliations}\nThis unit can retaliate ${val} additional time(s).",
 	"core.bonus.ADJACENT_SPELLCASTER.description": "{Adjacent Spellcaster}\nThis unit can cast ${subtype.spell} while standing next to its target.",

--- a/lib/entities/artifact/ArtifactUtils.cpp
+++ b/lib/entities/artifact/ArtifactUtils.cpp
@@ -15,9 +15,11 @@
 #include "CArtifact.h"
 #include "CArtifactFittingSet.h"
 
+
 #include "../../IGameSettings.h"
 #include "../../GameLibrary.h"
 #include "../../mapObjects/CGHeroInstance.h"
+#include "../../texts/CGeneralTextHandler.h"
 
 #include <vcmi/spells/Spell.h>
 
@@ -231,17 +233,12 @@ DLL_LINKAGE std::vector<const CArtifact*> ArtifactUtils::assemblyPossibilities(
 
 DLL_LINKAGE void ArtifactUtils::insertScrrollSpellName(std::string & description, const SpellID & sid)
 {
-	// We expect scroll description to be like this: This scroll contains the [spell name] spell which is added
-	// into spell book for as long as hero carries the scroll. So we want to replace text in [...] with a spell name.
-	// However other language versions don't have name placeholder at all, so we have to be careful
-	auto nameStart = description.find_first_of('[');
-	auto nameEnd = description.find_first_of(']', nameStart);
+	std::string replacement = sid.getNum() >= 0 ? sid.toEntity(LIBRARY)->getNameTranslated()
+												: LIBRARY->generaltexth->translate("artifact.core.spellScroll.spellName.default");
+	const static std::string placeholder = "[spell name]";
 
-	if(nameStart != std::string::npos && nameEnd != std::string::npos)
-	{
-		if(sid.getNum() >= 0)
-			description = description.replace(nameStart, nameEnd - nameStart + 1, sid.toEntity(LIBRARY)->getNameTranslated());
-		else
-			description = description.erase(nameStart, nameEnd - nameStart + 2); // erase "[spell name] " - including space
-	}
+	if (replacement.empty())
+		boost::replace_all(description, placeholder + " ", replacement);	// in most languages if replacement is empty we need to remove additional space after placeholder
+
+	boost::replace_all(description, placeholder, replacement);
 }

--- a/lib/texts/TextOperations.cpp
+++ b/lib/texts/TextOperations.cpp
@@ -19,6 +19,8 @@
 
 #include <iconv.h>
 
+const static int CHAR_PER_TYPO_ALLOWED = 4;
+
 template<typename FromString, typename DestString>
 FromString convertTextEncoding(const DestString & fromString, const std::string & fromEncoding, const std::string & destEncoding)
 {

--- a/lib/texts/TextOperations.h
+++ b/lib/texts/TextOperations.h
@@ -13,8 +13,6 @@
 /// Namespace that provides utilities for unicode support (UTF-8)
 namespace TextOperations
 {
-	const static int CHAR_PER_TYPO_ALLOWED = 4;
-
 	/// returns 32-bit UTF codepoint for UTF-8 character symbol
 	uint32_t DLL_LINKAGE getUnicodeCodepoint(const char *data, size_t maxSize);
 


### PR DESCRIPTION
Fixes #7685. I think. I don't know Chinese. @MedivhGO, can you confirm the descriptions make sense?
[Screencast From 2026-08-08 20-38-25.webm](https://github.com/user-attachments/assets/eb4f2e5a-331e-45ed-88b2-c0283402d529)

Also allowes for multiply spell name placeholders in scroll spells tooltips.

Also also, moves CHAR_PER_TYPO_ALLOWED static variable as was mentioned in fuzzy search review (I forgot to do it).

Edit: after some discussions the commit has been reworked to allow adding custom default placeholder. I do know it sounds like an oxymoron.
