### PR TITLE
Fix incorrect sailing movement costs in movement execution

### DIFF
--- a/AI/Nullkiller2/AIGateway.cpp
+++ b/AI/Nullkiller2/AIGateway.cpp
@@ -1109,9 +1109,9 @@ bool AIGateway::moveHeroToTile(const int3 dst, const HeroPtr & heroPtr)
 			return nullptr;
 		};
 
-		auto doMovement = [&](int3 dst, bool transit)
+		auto doMovement = [&](int3 dst, bool transit, const EPathfindingLayer & layer)
 		{
-			cc->moveHero(*heroPtr, heroPtr->convertFromVisitablePos(dst), transit);
+			cc->moveHero(*heroPtr, heroPtr->convertFromVisitablePos(dst), transit, layer);
 		};
 
 		auto doTeleportMovement = [&](ObjectInstanceID exitId, int3 exitPos)
@@ -1163,13 +1163,14 @@ bool AIGateway::moveHeroToTile(const int3 dst, const HeroPtr & heroPtr)
 		for(; i > 0; i--)
 		{
 			int3 currentCoord = path.nodes[i].coord;
-			int3 nextCoord = path.nodes[i - 1].coord;
+			const auto & nextNode = path.nodes[i - 1];
+			int3 nextCoord = nextNode.coord;
 
 			auto currentObject = getObj(currentCoord, currentCoord == heroPtr->visitablePos());
 			auto nextObjectTop = getObj(nextCoord, false);
 			auto nextObject = getObj(nextCoord, true);
 			auto destTeleportObj = getDestTeleportObj(currentObject, nextObjectTop, nextObject);
-			if(isTeleportAction(path.nodes[i - 1].action) && destTeleportObj != nullptr)
+			if(isTeleportAction(nextNode.action) && destTeleportObj != nullptr)
 			{
 				//we use special login if hero standing on teleporter it's mean we need
 				doTeleportMovement(destTeleportObj->id, nextCoord);
@@ -1181,14 +1182,13 @@ bool AIGateway::moveHeroToTile(const int3 dst, const HeroPtr & heroPtr)
 			}
 
 			//stop sending move requests if the next node can't be reached at the current turn (hero exhausted his move points)
-			if(path.nodes[i - 1].turns)
+			if(nextNode.turns)
 			{
 				//blockedHeroes.insert(h); //to avoid attempts of moving heroes with very little MPs
 				return false;
 			}
 
-			int3 endpos = path.nodes[i - 1].coord;
-			if(endpos == heroPtr->visitablePos())
+			if(nextCoord == heroPtr->visitablePos())
 				continue;
 
 			bool isConnected = false;
@@ -1199,19 +1199,11 @@ bool AIGateway::moveHeroToTile(const int3 dst, const HeroPtr & heroPtr)
 				isConnected = CGTeleport::isConnected(nextObjectTop, getObj(path.nodes[i - 2].coord, false));
 				isNextObjectTeleport = CGTeleport::isTeleport(nextObjectTop);
 			}
-			if(isConnected || isNextObjectTeleport)
-			{
+			if(isConnected || isNextObjectTeleport || nextNode.layer == EPathfindingLayer::AIR)
 				// Hero should be able to go through object if it's allow transit
-				doMovement(endpos, true);
-			}
-			else if(path.nodes[i - 1].layer == EPathfindingLayer::AIR)
-			{
-				doMovement(endpos, true);
-			}
+				doMovement(nextCoord, true, nextNode.layer);
 			else
-			{
-				doMovement(endpos, false);
-			}
+				doMovement(nextCoord, false, nextNode.layer);
 
 			afterMovementCheck();
 

--- a/lib/callback/CCallback.cpp
+++ b/lib/callback/CCallback.cpp
@@ -28,12 +28,16 @@ bool CCallback::teleportHero(const CGHeroInstance *who, const CGTownInstance *wh
 
 void CCallback::moveHero(const CGHeroInstance *h, const int3 & destination, bool transit, const EPathfindingLayer & layer)
 {
+	assert(destination == h->pos || (layer >= EPathfindingLayer::LAND && layer < EPathfindingLayer::NUM_LAYERS));
+
 	MoveHero pack({destination}, layer, h->id, transit);
 	sendRequest(pack);
 }
 
 void CCallback::moveHero(const CGHeroInstance *h, const std::vector<int3> & path, bool transit, const EPathfindingLayer & layer)
 {
+	assert(layer >= EPathfindingLayer::LAND && layer < EPathfindingLayer::NUM_LAYERS);
+
 	MoveHero pack(path, layer, h->id, transit);
 	sendRequest(pack);
 }

--- a/lib/pathfinder/CPathfinder.cpp
+++ b/lib/pathfinder/CPathfinder.cpp
@@ -629,34 +629,34 @@ int CPathfinderHelper::getMovementCost(
 	return getMovementCost(
 		src.coord,
 		dst.coord,
-		src.tile,
-		dst.tile,
+		dst.node->layer,
 		remainingMovePoints,
 		checkLast,
-		src.node->layer,
-		dst.node->layer
+		src.tile,
+		dst.tile
 	);
 }
 
 int CPathfinderHelper::getMovementCost(
 	const int3 & src,
 	const int3 & dst,
-	const TerrainTile * ct,
-	const TerrainTile * dt,
+	const EPathfindingLayer & dstLayer,
 	const int remainingMovePoints,
 	const bool checkLast,
-	const EPathfindingLayer & srcLayer,
-	const EPathfindingLayer & dstLayer) const
+	const TerrainTile * srcTile,
+	const TerrainTile * dstTile) const
 {
 	if(src == dst) //same tile
 		return 0;
 
+	assert(dstLayer >= EPathfindingLayer::LAND && dstLayer < EPathfindingLayer::NUM_LAYERS);
+
 	const auto * ti = getTurnInfo();
 
-	if(ct == nullptr || dt == nullptr)
+	if(srcTile == nullptr || dstTile == nullptr)
 	{
-		ct = hero->cb->getTile(src);
-		dt = hero->cb->getTile(dst);
+		srcTile = hero->cb->getTile(src);
+		dstTile = hero->cb->getTile(dst);
 	}
 
 	bool isSailLayer = dstLayer == EPathfindingLayer::SAIL;
@@ -666,10 +666,10 @@ int CPathfinderHelper::getMovementCost(
 
 	bool isAviateLayer = hero->inBoat() && hero->getBoat()->layer == EPathfindingLayer::AVIATE;
 
-	int movementCost = getTileMovementCost(*dt, *ct, ti);
+	int movementCost = getTileMovementCost(*dstTile, *srcTile, ti);
 	if(isSailLayer)
 	{
-		if(ct->hasFavorableWinds())
+		if(srcTile->hasFavorableWinds())
 			movementCost = static_cast<int>(movementCost * 2.0 / 3);
 	}
 	else if(isAirLayer)
@@ -700,7 +700,7 @@ int CPathfinderHelper::getMovementCost(
 	const int pointsLeft = remainingMovePoints - movementCost;
 	if(checkLast && pointsLeft > 0)
 	{
-		int minimalNextMoveCost = isAirLayer ? gameInfo.getSettings().getInteger(EGameSettings::HEROES_MOVEMENT_COST_BASE) : getTileMovementCost(*dt, *ct, ti);
+		int minimalNextMoveCost = isAirLayer ? gameInfo.getSettings().getInteger(EGameSettings::HEROES_MOVEMENT_COST_BASE) : getTileMovementCost(*dstTile, *srcTile, ti);
 
 		if (pointsLeft < minimalNextMoveCost)
 			return remainingMovePoints;

--- a/lib/pathfinder/CPathfinder.h
+++ b/lib/pathfinder/CPathfinder.h
@@ -121,12 +121,11 @@ public:
 	int getMovementCost(
 		const int3 & src,
 		const int3 & dst,
-		const TerrainTile * ct,
-		const TerrainTile * dt,
+		const EPathfindingLayer & dstLayer,
 		const int remainingMovePoints = -1,
 		const bool checkLast = true,
-		const EPathfindingLayer & srcLayer = EPathfindingLayer::AUTO,
-		const EPathfindingLayer & dstLayer = EPathfindingLayer::AUTO) const;
+		const TerrainTile * srcTile = nullptr,
+		const TerrainTile * dstTile = nullptr) const;
 
 	int getMovementCost(
 		const PathNodeInfo & src,

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -887,12 +887,7 @@ bool CGameHandler::moveHero(ObjectInstanceID hid, int3 dst, EMovementMode moveme
 	{
 		const auto * boat = h->getBoat();
 
-		// AI pathfinder may incorrectly keep the WATER layer when moving to land.
-		// Normal boats cannot fly, so moving to land MUST be a disembark action.
-		// Airships fly over land, so they rely solely on the explicit LAND layer request.
-		const bool isExplicitDisembark = (layer == EPathfindingLayer::LAND);
-		const bool isForcedBoatDisembark = (boat->layer == EPathfindingLayer::SAIL);
-		const bool hasDisembarkIntent = isExplicitDisembark || isForcedBoatDisembark;
+		const bool hasDisembarkIntent = (layer == EPathfindingLayer::LAND);
 
 		// Ensure the destination tile is physically valid for the current vehicle
 		const bool isStayingInPlace = (dst == h->pos);
@@ -911,18 +906,6 @@ bool CGameHandler::moveHero(ObjectInstanceID hid, int3 dst, EMovementMode moveme
 	tmh.result = TryMoveHero::FAILED;
 	tmh.movePoints = h->movementPointsRemaining();
 
-	//check if destination tile is available
-	auto pathfinderHelper = std::make_unique<CPathfinderHelper>(gameState(), h, PathfinderOptions(gameInfo()));
-	const auto * ti = pathfinderHelper->getTurnInfo();
-
-	const bool canFly = ti->hasFlyingMovement() || (h->inBoat() && (h->getBoat()->layer == EPathfindingLayer::AIR || h->getBoat()->layer == EPathfindingLayer::AVIATE));
-	const bool canWalkOnSea = ti->hasWaterWalking() || (h->inBoat() && h->getBoat()->layer == EPathfindingLayer::WATER);
-	const int cost = pathfinderHelper->getMovementCost(h->visitablePos(), hmpos, nullptr, nullptr, h->movementPointsRemaining());
-
-	const bool movingOntoObstacle = t.blocked() && !t.visitable();
-	const bool objectCoastVisitable = objectToVisit && objectToVisit->isCoastVisitable();
-	const bool movingOntoWater = !h->inBoat() && t.isWater() && !objectCoastVisitable;
-
 	const auto complainRet = [&](const std::string & message)
 	{
 		//send info about movement failure
@@ -930,6 +913,26 @@ bool CGameHandler::moveHero(ObjectInstanceID hid, int3 dst, EMovementMode moveme
 		sendAndApply(tmh);
 		return false;
 	};
+
+	const bool requiresLayer = movementMode == EMovementMode::STANDARD && dst != h->pos;
+	const bool hasValidLayer = layer >= EPathfindingLayer::LAND && layer < EPathfindingLayer::NUM_LAYERS;
+	if(requiresLayer && !hasValidLayer)
+		return complainRet("Invalid movement layer!");
+
+	//check if destination tile is available
+	auto pathfinderHelper = std::make_unique<CPathfinderHelper>(gameState(), h, PathfinderOptions(gameInfo()));
+	const auto * ti = pathfinderHelper->getTurnInfo();
+
+	const bool canFly = ti->hasFlyingMovement() || (h->inBoat() && (h->getBoat()->layer == EPathfindingLayer::AIR || h->getBoat()->layer == EPathfindingLayer::AVIATE));
+	const bool canWalkOnSea = ti->hasWaterWalking() || (h->inBoat() && h->getBoat()->layer == EPathfindingLayer::WATER);
+	const bool usesMovementCost = movementMode == EMovementMode::STANDARD || embarking || disembarking;
+	const int cost = usesMovementCost
+		? pathfinderHelper->getMovementCost(h->visitablePos(), hmpos, layer, h->movementPointsRemaining())
+		: 0;
+
+	const bool movingOntoObstacle = t.blocked() && !t.visitable();
+	const bool objectCoastVisitable = objectToVisit && objectToVisit->isCoastVisitable();
+	const bool movingOntoWater = !h->inBoat() && t.isWater() && !objectCoastVisitable;
 
 	if (guardian && getVisitingHero(guardian) != nullptr)
 		return complainRet("You cannot move your hero there. Simultaneous turns are active and another player is interacting with this wandering monster!");

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -38,6 +38,7 @@ set(test_SRCS
 		game/BattleSpellCastTest.cpp
 		game/HeroRecruitmentTest.cpp
 		game/HeroSecondarySkillsTest.cpp
+		game/MovementCostTest.cpp
 
 		json/JsonTests.cpp
 

--- a/test/game/MovementCostTest.cpp
+++ b/test/game/MovementCostTest.cpp
@@ -1,0 +1,134 @@
+/*
+ * MovementCostTest.cpp, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
+#include "StdInc.h"
+
+#include "GameStateTest.h"
+
+#include "../../lib/CPlayerState.h"
+#include "../../lib/mapObjects/CGHeroInstance.h"
+#include "../../lib/mapping/TerrainTile.h"
+#include "../../lib/networkPacks/PacksForClient.h"
+#include "../../lib/pathfinder/CPathfinder.h"
+#include "../../lib/pathfinder/PathfinderOptions.h"
+#include "../../server/CGameHandler.h"
+#include "../../server/IGameServer.h"
+
+namespace
+{
+
+constexpr ui8 FAVORABLE_WINDS_FLAG = 128;
+
+class GameServerMock : public IGameServer
+{
+public:
+	MOCK_METHOD(void, setState, (EServerState value), (override));
+	MOCK_METHOD(EServerState, getState, (), (const, override));
+	MOCK_METHOD(bool, isPlayerHost, (const PlayerColor & color), (const, override));
+	MOCK_METHOD(bool, hasPlayerAt, (PlayerColor player, GameConnectionID connectionID), (const, override));
+	MOCK_METHOD(bool, hasBothPlayersAtSameConnection, (PlayerColor left, PlayerColor right), (const, override));
+	MOCK_METHOD(void, applyPack, (CPackForClient & pack), (override));
+	MOCK_METHOD(void, sendPack, (CPackForClient & pack, GameConnectionID connectionID), (override));
+};
+
+}
+
+class MovementCostTest : public GameStateTest
+{
+};
+
+TEST_F(MovementCostTest, usesExplicitDestinationLayer)
+{
+	startTestGame();
+
+	const auto heroes = gameState->getPlayerState(PlayerColor(0))->getHeroes();
+	ASSERT_FALSE(heroes.empty());
+	const auto * hero = heroes.front();
+
+	const int3 sourcePosition = hero->visitablePos();
+	const int3 destinationPosition = sourcePosition + int3(1, 0, 0);
+	TerrainTile sourceTile = *gameState->getTile(sourcePosition);
+	TerrainTile destinationTile = *gameState->getTile(destinationPosition);
+	sourceTile.extTileFlags |= FAVORABLE_WINDS_FLAG;
+
+	CPathfinderHelper helper(*gameState, hero, PathfinderOptions(*gameState));
+	const int landCost = helper.getMovementCost(
+		sourcePosition, destinationPosition, EPathfindingLayer::LAND, 1000, false, &sourceTile, &destinationTile);
+	const int sailCost = helper.getMovementCost(
+		sourcePosition, destinationPosition, EPathfindingLayer::SAIL, 1000, false, &sourceTile, &destinationTile);
+
+	EXPECT_EQ(sailCost, static_cast<int>(landCost * 2.0 / 3));
+}
+
+TEST_F(MovementCostTest, pathfinderAndExecutorUseSameSailCost)
+{
+	startTestGame();
+
+	const auto heroes = gameState->getPlayerState(PlayerColor(0))->getHeroes();
+	ASSERT_FALSE(heroes.empty());
+	const auto * hero = heroes.front();
+	const int3 sourcePosition = hero->visitablePos();
+	const int3 embarkPosition = sourcePosition + int3(1, 0, 0);
+	const int3 destinationPosition = sourcePosition + int3(2, 0, 0);
+
+	auto & embarkTile = gameState->getMap().getTile(embarkPosition);
+	auto & destinationTile = gameState->getMap().getTile(destinationPosition);
+	embarkTile.terrainType = ETerrainId::WATER;
+	destinationTile.terrainType = ETerrainId::WATER;
+
+	testing::NiceMock<GameServerMock> server;
+	ON_CALL(server, applyPack(testing::_)).WillByDefault([this](CPackForClient & pack)
+	{
+		gameState->apply(pack);
+	});
+	CGameHandler gameHandler(server, gameState);
+	const int initialMovementPoints = hero->movementPointsRemaining();
+	gameHandler.createBoat(embarkPosition, BoatId::CASTLE, hero->getOwner());
+	ASSERT_FALSE(gameHandler.moveHero(
+		hero->id,
+		hero->convertFromVisitablePos(embarkPosition),
+		EMovementMode::STANDARD,
+		false,
+		hero->getOwner(),
+		EPathfindingLayer::AUTO));
+	EXPECT_EQ(hero->visitablePos(), sourcePosition);
+	EXPECT_EQ(hero->movementPointsRemaining(), initialMovementPoints);
+
+	ASSERT_TRUE(gameHandler.moveHero(
+		hero->id,
+		hero->convertFromVisitablePos(embarkPosition),
+		EMovementMode::STANDARD,
+		false,
+		hero->getOwner(),
+		EPathfindingLayer::SAIL));
+	ASSERT_TRUE(hero->inBoat());
+	gameHandler.setMovePoints(hero->id, initialMovementPoints);
+	gameState->getMap().getTile(embarkPosition).extTileFlags |= FAVORABLE_WINDS_FLAG;
+
+	CPathsInfo paths(gameState->getMapSize(), hero);
+	auto config = std::make_shared<SingleHeroPathfinderConfig>(paths, *gameState, hero);
+	CPathfinder pathfinder(*gameState, config);
+	pathfinder.calculatePaths();
+
+	const auto * destinationNode = paths.getNode(destinationPosition, EPathfindingLayer::SAIL);
+	ASSERT_TRUE(destinationNode->reachable());
+	ASSERT_EQ(destinationNode->turns, 0);
+	ASSERT_EQ(destinationNode->action, EPathNodeAction::NORMAL);
+	const int expectedMovementPoints = destinationNode->moveRemains;
+	ASSERT_GT(expectedMovementPoints, 0);
+
+	ASSERT_TRUE(gameHandler.moveHero(
+		hero->id,
+		hero->convertFromVisitablePos(destinationPosition),
+		EMovementMode::STANDARD,
+		false,
+		hero->getOwner(),
+		destinationNode->layer));
+	EXPECT_EQ(hero->movementPointsRemaining(), expectedMovementPoints);
+}


### PR DESCRIPTION
Commit 410d2c0623 (add aviation) extended `MoveHero` pack with a pathfinding layer, but `AIGateway::moveHeroToTile` did not pass it and `CGameHandler::moveHero` did not forward it to `getMovementCost`.

So the pathfinder used the concrete destination layer while the server used `AUTO`. For modifiers such as Favorable Winds, this made the pathfinder predict a lower (correct) SAIL cost than the server charged.

Before this commit, an indeterminate tribool allowed the layer to be inferred. Commit 89575f88c0 later removed the remaining obsolete tribool logic; the unused `srcLayer` can therefore also be dropped.

Commit 2b8f305390 masked the missing layer for boat disembarking but did not fix the underlying problem.

This change propagates the layer end-to-end, removes the workaround and unsafe defaults, adds regression tests and some guards to callers.

Fixes #6121
- #6121