### PR TITLE
launcher gamepad start

### DIFF
--- a/android/vcmi-app/src/main/java/eu/vcmi/vcmi/ActivityLauncher.java
+++ b/android/vcmi-app/src/main/java/eu/vcmi/vcmi/ActivityLauncher.java
@@ -6,6 +6,8 @@ import android.net.Uri;
 import android.os.Bundle;
 import android.os.Environment;
 import android.provider.DocumentsContract;
+import android.view.InputDevice;
+import android.view.KeyEvent;
 import android.view.WindowManager;
 
 import androidx.annotation.Nullable;
@@ -34,6 +36,9 @@ public class ActivityLauncher extends org.qtproject.qt5.android.bindings.QtActiv
 
     public boolean justLaunched = true;
 
+    // set from the Qt thread, so it must not be cached by the UI thread
+    private volatile boolean gamepadStartEnabled = false;
+
     @Override
     public void onCreate(@Nullable final Bundle savedInstanceState)
     {
@@ -59,6 +64,38 @@ public class ActivityLauncher extends org.qtproject.qt5.android.bindings.QtActiv
             getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
         else
             getWindow().clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+    }
+
+    /**
+     * SDL can't read gamepads from a Qt activity, so the launcher relies on the key events Android delivers here
+     */
+    @Override
+    public boolean dispatchKeyEvent(final KeyEvent event)
+    {
+        if (event.getAction() == KeyEvent.ACTION_DOWN && isGamepadStartButton(event))
+        {
+            onLaunchGameBtnPressed();
+            return true;
+        }
+
+        return super.dispatchKeyEvent(event);
+    }
+
+    public void setGamepadStartEnabled(final boolean enabled)
+    {
+        gamepadStartEnabled = enabled;
+    }
+
+    private boolean isGamepadStartButton(final KeyEvent event)
+    {
+        if (!gamepadStartEnabled)
+            return false;
+
+        if ((event.getSource() & InputDevice.SOURCE_GAMEPAD) != InputDevice.SOURCE_GAMEPAD)
+            return false;
+
+        final int keyCode = event.getKeyCode();
+        return keyCode == KeyEvent.KEYCODE_BUTTON_A || keyCode == KeyEvent.KEYCODE_BUTTON_START;
     }
 
     public void onLaunchGameBtnPressed()

--- a/android/vcmi-app/src/main/java/eu/vcmi/vcmi/ActivityLauncher.java
+++ b/android/vcmi-app/src/main/java/eu/vcmi/vcmi/ActivityLauncher.java
@@ -91,7 +91,7 @@ public class ActivityLauncher extends org.qtproject.qt5.android.bindings.QtActiv
         if (!gamepadStartEnabled)
             return false;
 
-        if ((event.getSource() & InputDevice.SOURCE_GAMEPAD) != InputDevice.SOURCE_GAMEPAD)
+        if (!event.isFromSource(InputDevice.SOURCE_GAMEPAD))
             return false;
 
         final int keyCode = event.getKeyCode();

--- a/launcher/CMakeLists.txt
+++ b/launcher/CMakeLists.txt
@@ -73,6 +73,12 @@ set(launcher_HEADERS
 		prepare_p.h
 )
 
+# gamepad support relies on SDL, which is not linked into launcher on mobile platforms
+if(NOT ANDROID AND NOT IOS)
+	list(APPEND launcher_SRCS gamepadHandler.cpp)
+	list(APPEND launcher_HEADERS gamepadHandler.h)
+endif()
+
 set(launcher_FORMS
 		aboutProject/aboutproject_moc.ui
 		modManager/cmodlistview_moc.ui

--- a/launcher/gamepadHandler.cpp
+++ b/launcher/gamepadHandler.cpp
@@ -1,0 +1,57 @@
+/*
+ * gamepadHandler.cpp, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
+#include "StdInc.h"
+#include "gamepadHandler.h"
+
+#include <SDL2/SDL.h>
+
+static constexpr int POLL_INTERVAL_MS = 100;
+
+GamepadHandler::GamepadHandler(QObject * parent)
+	: QObject(parent)
+{
+	if(SDL_InitSubSystem(SDL_INIT_GAMECONTROLLER) != 0)
+	{
+		logGlobal->warn("Failed to initialize game controller support: %s", SDL_GetError());
+		return;
+	}
+
+	auto * timer = new QTimer(this);
+	connect(timer, &QTimer::timeout, this, &GamepadHandler::poll);
+	timer->start(POLL_INTERVAL_MS);
+}
+
+GamepadHandler::~GamepadHandler()
+{
+	SDL_QuitSubSystem(SDL_INIT_GAMECONTROLLER);
+}
+
+void GamepadHandler::poll()
+{
+	SDL_Event ev;
+	while(SDL_PollEvent(&ev))
+	{
+		switch(ev.type)
+		{
+			// controllers connected before initialization are reported here as well
+			case SDL_CONTROLLERDEVICEADDED:
+				SDL_GameControllerOpen(ev.cdevice.which);
+				break;
+			case SDL_CONTROLLERDEVICEREMOVED:
+				if(auto * controller = SDL_GameControllerFromInstanceID(ev.cdevice.which))
+					SDL_GameControllerClose(controller);
+				break;
+			case SDL_CONTROLLERBUTTONDOWN:
+				if(ev.cbutton.button == SDL_CONTROLLER_BUTTON_A || ev.cbutton.button == SDL_CONTROLLER_BUTTON_START)
+					emit startGameRequested();
+				break;
+		}
+	}
+}

--- a/launcher/gamepadHandler.h
+++ b/launcher/gamepadHandler.h
@@ -1,0 +1,29 @@
+/*
+ * gamepadHandler.h, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
+#pragma once
+
+#include <QObject>
+
+/// Polls connected game controllers so that the game can be started without mouse or keyboard.
+/// Android is handled in ActivityLauncher.java instead - SDL can't deliver input to a Qt activity.
+class GamepadHandler : public QObject
+{
+	Q_OBJECT
+
+public:
+	explicit GamepadHandler(QObject * parent = nullptr);
+	~GamepadHandler() override;
+
+signals:
+	void startGameRequested();
+
+private:
+	void poll();
+};

--- a/launcher/helper.cpp
+++ b/launcher/helper.cpp
@@ -189,6 +189,16 @@ void keepScreenOn(bool isEnabled)
 #endif
 }
 
+void allowGamepadStart(bool isEnabled)
+{
+#if defined(VCMI_ANDROID)
+	QtAndroid::runOnAndroidThread([isEnabled]
+	{
+		QtAndroid::androidActivity().callMethod<void>("setGamepadStartEnabled", "(Z)V", isEnabled);
+	});
+#endif
+}
+
 bool canUseFolderPicker()
 {
 #if defined(VCMI_ANDROID)

--- a/launcher/helper.h
+++ b/launcher/helper.h
@@ -25,6 +25,8 @@ namespace Helper
 	void revealDirectoryInFileBrowser(QString path);
 	MainWindow * getMainWindow();
 	void keepScreenOn(bool isEnabled);
+	/// on Android, gamepad input is handled by the activity - tell it whether starting the game is possible right now
+	void allowGamepadStart(bool isEnabled);
 	bool canUseFolderPicker();
 	void nativeFolderPicker(QWidget *parent, std::function<void(QString)>&& cb);
 	QStringList findFilesForCopy(const QString &treeUri);

--- a/launcher/mainwindow_moc.cpp
+++ b/launcher/mainwindow_moc.cpp
@@ -24,6 +24,9 @@
 #include "updatedialog_moc.h"
 #include "main.h"
 #include "helper.h"
+#ifndef VCMI_MOBILE
+#include "gamepadHandler.h"
+#endif
 
 void MainWindow::load()
 {
@@ -133,10 +136,33 @@ MainWindow::MainWindow(QWidget * parent)
 	else
 		enterSetup();
 
+	setGamepadStartAllowed(h3DataFound && setupCompleted);
+
 	ui->settingsView->setDisplayList();
+
+#ifndef VCMI_MOBILE
+	auto * gamepadHandler = new GamepadHandler(this);
+	connect(gamepadHandler, &GamepadHandler::startGameRequested, this, &MainWindow::startGameFromGamepad);
+#endif
 
 	if(settings["launcher"]["updateOnStartup"].Bool())
 		UpdateDialog::showUpdateDialog(false);
+}
+
+void MainWindow::setGamepadStartAllowed(bool allowed)
+{
+	gamepadStartAllowed = allowed;
+	Helper::allowGamepadStart(allowed);
+}
+
+void MainWindow::startGameFromGamepad()
+{
+	// setup and dialogs can't be operated with a gamepad, so don't take control away from the player
+	if(!gamepadStartAllowed || QApplication::activeModalWidget())
+		return;
+
+	hide();
+	startGame({});
 }
 
 void MainWindow::centerWindowOnScreen(QScreen * screen)
@@ -312,6 +338,8 @@ void MainWindow::exitSetup(bool goToMods)
 {
 	Settings writer = settings.write["launcher"]["setupCompleted"];
 	writer->Bool() = true;
+
+	setGamepadStartAllowed(true);
 
 	ui->sidePanel->setVisible(true);
 	if (goToMods)

--- a/launcher/mainwindow_moc.h
+++ b/launcher/mainwindow_moc.h
@@ -46,7 +46,11 @@ class MainWindow : public QMainWindow
 	std::unique_ptr<CConsoleHandler> console;
 #endif
 
+	bool gamepadStartAllowed = false;
+
 	void load();
+	void setGamepadStartAllowed(bool allowed);
+	void startGameFromGamepad();
 	void centerWindowOnScreen(QScreen * screen);
 	void ensureWindowVisibleOnExistingScreen();
 	void handleScreenRemoved();

--- a/launcher/settingsView/csettingsview_moc.cpp
+++ b/launcher/settingsView/csettingsview_moc.cpp
@@ -377,7 +377,7 @@ void CSettingsView::fillValidScalingRange()
 
 static QStringList getAvailableRenderingDrivers()
 {
-	SDL_Init(SDL_INIT_VIDEO);
+	SDL_InitSubSystem(SDL_INIT_VIDEO);
 	QStringList result;
 
 	result += QString(); // empty value for autoselection
@@ -391,7 +391,7 @@ static QStringList getAvailableRenderingDrivers()
 			result += QString::fromLatin1(info.name);
 	}
 
-	SDL_Quit();
+	SDL_QuitSubSystem(SDL_INIT_VIDEO);
 	return result;
 }
 
@@ -400,7 +400,7 @@ static QVector<QSize> findAvailableResolutions(int displayIndex)
 	// Ugly workaround since we don't actually need SDL in Launcher
 	// However Qt at the moment provides no way to query list of available resolutions
 	QVector<QSize> result;
-	SDL_Init(SDL_INIT_VIDEO);
+	SDL_InitSubSystem(SDL_INIT_VIDEO);
 
 	int modesCount = SDL_GetNumDisplayModes(displayIndex);
 
@@ -422,7 +422,7 @@ static QVector<QSize> findAvailableResolutions(int displayIndex)
 
 	result.erase(std::ranges::unique(result).end(), result.end());
 
-	SDL_Quit();
+	SDL_QuitSubSystem(SDL_INIT_VIDEO);
 
 	return result;
 }


### PR DESCRIPTION
Fixes #4111

It's now possible to start game with `Start` or `A` on gamepad from launcher.

No need to use touch or mouse to start game anymore.

Tested on linux and android.