### PR TITLE
Fix secondary skill specialty rounding

### DIFF
--- a/lib/bonuses/BonusCache.cpp
+++ b/lib/bonuses/BonusCache.cpp
@@ -19,7 +19,7 @@
 #include "../IGameSettings.h"
 #include "../spells/SpellSchoolHandler.h"
 
-int BonusCacheBase::getBonusValueImpl(BonusCacheEntry & currentValue, const CSelector & selector, BonusCacheMode mode) const
+int BonusCacheBase::getBonusValueImpl(BonusCacheEntry & currentValue, const CSelector & selector, BonusCacheMode mode, int32_t valueScale) const
 {
 	if (target->getTreeVersion() == currentValue.version)
 	{
@@ -32,7 +32,7 @@ int BonusCacheBase::getBonusValueImpl(BonusCacheEntry & currentValue, const CSel
 		int newValue;
 
 		if (mode == BonusCacheMode::VALUE)
-			newValue = target->valOfBonuses(selector);
+			newValue = static_cast<int>(target->getAllBonuses(selector)->totalValueScaled(0, valueScale));
 		else
 			newValue = target->hasBonus(selector);
 		currentValue.value = newValue;
@@ -42,13 +42,13 @@ int BonusCacheBase::getBonusValueImpl(BonusCacheEntry & currentValue, const CSel
 	}
 }
 
-BonusValueCache::BonusValueCache(const IBonusBearer * target, const CSelector & selector)
-	:BonusCacheBase(target),selector(selector)
+BonusValueCache::BonusValueCache(const IBonusBearer * target, const CSelector & selector, int32_t valueScale)
+	:BonusCacheBase(target),selector(selector),valueScale(valueScale)
 {}
 
 int BonusValueCache::getValue() const
 {
-	return getBonusValueImpl(value, selector, BonusCacheMode::VALUE);
+	return getBonusValueImpl(value, selector, BonusCacheMode::VALUE, valueScale);
 }
 
 bool BonusValueCache::hasBonus() const

--- a/lib/bonuses/BonusCache.h
+++ b/lib/bonuses/BonusCache.h
@@ -47,16 +47,17 @@ protected:
 		}
 	};
 
-	int getBonusValueImpl(BonusCacheEntry & currentValue, const CSelector & selector, BonusCacheMode) const;
+	int getBonusValueImpl(BonusCacheEntry & currentValue, const CSelector & selector, BonusCacheMode, int32_t valueScale = 1) const;
 };
 
 /// Cache that tracks a single query to bonus system
 class BonusValueCache : public BonusCacheBase
 {
 	CSelector selector;
+	int32_t valueScale;
 	mutable BonusCacheEntry value;
 public:
-	BonusValueCache(const IBonusBearer * target, const CSelector & selector);
+	BonusValueCache(const IBonusBearer * target, const CSelector & selector, int32_t valueScale = 1);
 	int getValue() const;
 	bool hasBonus() const;
 };

--- a/lib/bonuses/BonusList.cpp
+++ b/lib/bonuses/BonusList.cpp
@@ -53,37 +53,50 @@ void BonusList::stackBonuses()
 
 int BonusList::totalValue(int baseValue) const
 {
+	return static_cast<int>(totalValueScaled(baseValue, 1));
+}
+
+int64_t BonusList::totalValueScaled(int64_t baseValue, int64_t valueScale) const
+{
+	assert(valueScale > 0);
+
 	if (bonuses.empty())
-		return baseValue;
+		return baseValue * valueScale;
+
+	constexpr int64_t percentScale = FRACTION_SCALE;
+	constexpr int64_t precisePercentScale = percentScale * percentScale;
 
 	struct BonusCollection
 	{
-		int base = 0;
-		int percentToBase = 0;
-		int percentToAll = 0;
-		int additive = 0;
-		int percentToSource = 0;
-		int indepMin = std::numeric_limits<int>::max();
-		int indepMax = std::numeric_limits<int>::min();
+		int64_t base = 0;
+		int64_t percentToBase = 0;
+		int64_t percentToAll = 0;
+		int64_t additive = 0;
+		int64_t indepMin = std::numeric_limits<int64_t>::max();
+		int64_t indepMax = std::numeric_limits<int64_t>::min();
 	};
 
-	auto applyPercentageRoundUp = [](int base, int percent) -> int {
+	auto applyPercentageRoundUp = [](int64_t base, int64_t percent) -> int64_t {
 		if (base >= 0)
-			return (static_cast<int64_t>(base) * (100 + percent) + 99) / 100;
+			return (base * (percentScale + percent) + percentScale - 1) / percentScale;
 		else
-			return (static_cast<int64_t>(base) * (100 + percent) - 99) / 100;
+			return (base * (percentScale + percent) - percentScale + 1) / percentScale;
 	};
 
-	auto applyPercentageRoundDown = [](int base, int percent) -> int {
-		return (static_cast<int64_t>(base) * (100 + percent)) / 100;
+	auto applyPercentageRoundDown = [](int64_t base, int64_t percent) -> int64_t {
+		return (base * (percentScale + percent)) / percentScale;
+	};
+
+	auto applyPrecisePercentageRoundDown = [](int64_t base, int64_t percent) -> int64_t {
+		return (base * (precisePercentScale + percent)) / precisePercentScale;
 	};
 
 	BonusCollection accumulated;
-	accumulated.base = baseValue;
+	accumulated.base = baseValue * valueScale;
 	int indexMaxCount = 0;
 	int indexMinCount = 0;
 
-	std::array<int, vstd::to_underlying(BonusSource::NUM_BONUS_SOURCE)> percentToSource = {};
+	std::array<int64_t, vstd::to_underlying(BonusSource::NUM_BONUS_SOURCE)> percentToSource = {};
 
 	for(const auto & b : bonuses)
 	{
@@ -103,38 +116,43 @@ int BonusList::totalValue(int baseValue) const
 		int sourceIndex = vstd::to_underlying(b->source);
 		// Workaround: creature hero specialties in H3 is the only place that uses rounding up in bonuses
 		// TODO: try to find more elegant solution?
-		int valModified	= b->source == BonusSource::CREATURE_ABILITY ?
+		int64_t valModified = b->source == BonusSource::CREATURE_ABILITY ?
 			applyPercentageRoundUp(b->val, percentToSource[sourceIndex]):
 			applyPercentageRoundDown(b->val, percentToSource[sourceIndex]);
+		const bool preserveFraction = b->source == BonusSource::SECONDARY_SKILL
+			&& (b->valType == BonusValueType::PERCENT_TO_BASE || b->valType == BonusValueType::PERCENT_TO_ALL);
+		int64_t percentModified = preserveFraction ?
+			static_cast<int64_t>(b->val) * (percentScale + percentToSource[sourceIndex]):
+			valModified * percentScale;
 
 		switch(b->valType)
 		{
 		case BonusValueType::BASE_NUMBER:
-			accumulated.base += valModified;
+			accumulated.base += valModified * valueScale;
 			break;
 		case BonusValueType::PERCENT_TO_ALL:
-			accumulated.percentToAll += valModified;
+			accumulated.percentToAll += percentModified;
 			break;
 		case BonusValueType::PERCENT_TO_BASE:
-			accumulated.percentToBase += valModified;
+			accumulated.percentToBase += percentModified;
 			break;
 		case BonusValueType::ADDITIVE_VALUE:
-			accumulated.additive += valModified;
+			accumulated.additive += valModified * valueScale;
 			break;
 		case BonusValueType::INDEPENDENT_MAX: // actual meaning: at least this value
 			indexMaxCount++;
-			vstd::amax(accumulated.indepMax, valModified);
+			vstd::amax(accumulated.indepMax, valModified * valueScale);
 			break;
 		case BonusValueType::INDEPENDENT_MIN: // actual meaning: at most this value
 			indexMinCount++;
-			vstd::amin(accumulated.indepMin, valModified);
+			vstd::amin(accumulated.indepMin, valModified * valueScale);
 			break;
 		}
 	}
 
-	accumulated.base = applyPercentageRoundDown(accumulated.base, accumulated.percentToBase);
+	accumulated.base = applyPrecisePercentageRoundDown(accumulated.base, accumulated.percentToBase);
 	accumulated.base += accumulated.additive;
-	auto valFirst = applyPercentageRoundDown(accumulated.base ,accumulated.percentToAll);
+	auto valFirst = applyPrecisePercentageRoundDown(accumulated.base, accumulated.percentToAll);
 
 	if(indexMinCount && indexMaxCount && accumulated.indepMin < accumulated.indepMax)
 		accumulated.indepMax = accumulated.indepMin;

--- a/lib/bonuses/BonusList.h
+++ b/lib/bonuses/BonusList.h
@@ -17,6 +17,7 @@ class DLL_LINKAGE BonusList : public scripting::ApiCopyable<BonusList>
 {
 public:
 	using TInternalContainer = boost::container::small_vector<std::shared_ptr<Bonus>, 16>;
+	static constexpr int64_t FRACTION_SCALE = 100;
 
 private:
 	TInternalContainer bonuses;
@@ -53,6 +54,8 @@ public:
 	// BonusList functions
 	void stackBonuses();
 	int totalValue(int baseValue = 0) const;
+	/// Returns the value multiplied by valueScale.
+	int64_t totalValueScaled(int64_t baseValue, int64_t valueScale) const;
 	void getBonuses(BonusList &out, const CSelector &selector) const;
 	void getAllBonuses(BonusList &out) const;
 

--- a/lib/mapObjects/CGHeroInstance.cpp
+++ b/lib/mapObjects/CGHeroInstance.cpp
@@ -39,6 +39,7 @@
 #include "../entities/hero/CHeroClass.h"
 #include "../entities/ResourceTypeHandler.h"
 #include "../battle/CBattleInfoEssentials.h"
+#include "../bonuses/BonusList.h"
 #include "../bonuses/BonusParameters.h"
 #include "../campaign/CampaignState.h"
 #include "../json/JsonBonus.h"
@@ -261,7 +262,7 @@ CGHeroInstance::CGHeroInstance(IGameInfoCallback * cb)
 	primarySkills(this),
 	magicSchoolMastery(this),
 	turnInfoCache(std::make_unique<TurnInfoCache>(this)),
-	manaPerKnowledgeCached(this, Selector::type()(BonusType::MANA_PER_KNOWLEDGE_PERCENTAGE))
+	manaPerKnowledgeCached(this, Selector::type()(BonusType::MANA_PER_KNOWLEDGE_PERCENTAGE), BonusList::FRACTION_SCALE)
 {
 	ID = Obj::HERO;
 	secSkills.emplace_back(SecondarySkill::NONE, -1);
@@ -774,7 +775,11 @@ ui64 CGHeroInstance::getTotalStrength() const
 
 TExpType CGHeroInstance::calculateXp(TExpType exp) const
 {
-	return static_cast<TExpType>(exp * (valOfBonuses(BonusType::HERO_EXPERIENCE_GAIN_PERCENT)) / 100.0);
+	constexpr int64_t percentageScale = 100 * BonusList::FRACTION_SCALE;
+	const int64_t scaledPercentage = getBonusesOfType(BonusType::HERO_EXPERIENCE_GAIN_PERCENT)->totalValueScaled(0, BonusList::FRACTION_SCALE);
+	const TExpType whole = exp / percentageScale;
+	const TExpType remainder = exp % percentageScale;
+	return whole * scaledPercentage + remainder * scaledPercentage / percentageScale;
 }
 
 int32_t CGHeroInstance::getCasterUnitId() const
@@ -1158,7 +1163,8 @@ std::string CGHeroInstance::nodeName() const
 
 si32 CGHeroInstance::manaLimit() const
 {
-	return getPrimSkillLevel(PrimarySkill::KNOWLEDGE) * manaPerKnowledgeCached.getValue() / 100;
+	constexpr int64_t percentageScale = 100 * BonusList::FRACTION_SCALE;
+	return static_cast<si32>(static_cast<int64_t>(getPrimSkillLevel(PrimarySkill::KNOWLEDGE)) * manaPerKnowledgeCached.getValue() / percentageScale);
 }
 
 HeroTypeID CGHeroInstance::getPortraitSource() const

--- a/test/bonus/BonusSystemTest.cpp
+++ b/test/bonus/BonusSystemTest.cpp
@@ -10,6 +10,7 @@
 
 #include "StdInc.h"
 #include "../../lib/bonuses/CBonusSystemNode.h"
+#include "../../lib/bonuses/BonusList.h"
 #include "../../lib/bonuses/BonusEnum.h"
 #include "../../lib/bonuses/Limiters.h"
 #include "../../lib/bonuses/Propagators.h"
@@ -19,6 +20,29 @@ namespace test
 {
 
 using namespace ::testing;
+
+namespace
+{
+
+BonusList makeSourceModifiedBonus(int value, BonusValueType valueType, int modifier, BonusSource source = BonusSource::SECONDARY_SKILL)
+{
+	BonusList bonuses;
+	auto valueBonus = std::make_shared<Bonus>();
+	valueBonus->val = value;
+	valueBonus->valType = valueType;
+	valueBonus->source = source;
+	bonuses.push_back(valueBonus);
+
+	auto sourceModifier = std::make_shared<Bonus>();
+	sourceModifier->val = modifier;
+	sourceModifier->valType = BonusValueType::PERCENT_TO_TARGET_TYPE;
+	sourceModifier->source = BonusSource::HERO_SPECIAL;
+	sourceModifier->targetSourceType = source;
+	bonuses.push_back(sourceModifier);
+	return bonuses;
+}
+
+}
 
 class TestBonusSystemNode : public CBonusSystemNode
 {
@@ -303,6 +327,40 @@ TEST_F(BonusSystemTest, legionPieces)
 	EXPECT_EQ(town.valOfBonuses(BonusType::CREATURE_GROWTH, BonusCustomSubtype::creatureLevel(3)), 0);
 
 	heroAine.detachFromSource(legion);
+}
+
+TEST(BonusListTest, secondarySkillPercentToBaseKeepsFraction)
+{
+	auto bonuses = makeSourceModifiedBonus(30, BonusValueType::PERCENT_TO_BASE, 5);
+	EXPECT_EQ(bonuses.totalValue(1700), 2235);
+}
+
+TEST(BonusListTest, secondarySkillPercentToAllKeepsFraction)
+{
+	auto bonuses = makeSourceModifiedBonus(10, BonusValueType::PERCENT_TO_ALL, 45);
+	EXPECT_EQ(bonuses.totalValue(1700), 1946);
+}
+
+TEST(BonusListTest, scaledResultKeepsFraction)
+{
+	auto bonuses = makeSourceModifiedBonus(15, BonusValueType::PERCENT_TO_BASE, 5);
+	auto baseValue = std::make_shared<Bonus>();
+	baseValue->val = 100;
+	baseValue->valType = BonusValueType::BASE_NUMBER;
+	baseValue->source = BonusSource::GLOBAL;
+	bonuses.push_back(baseValue);
+
+	EXPECT_EQ(bonuses.totalValue(), 115);
+	EXPECT_EQ(bonuses.totalValueScaled(0, BonusList::FRACTION_SCALE), 11575);
+}
+
+TEST(BonusListTest, flatAndCreatureBonusesKeepWholeNumberRounding)
+{
+	auto flatBonuses = makeSourceModifiedBonus(15, BonusValueType::BASE_NUMBER, 5);
+	EXPECT_EQ(flatBonuses.totalValue(), 15);
+
+	auto creatureBonuses = makeSourceModifiedBonus(30, BonusValueType::PERCENT_TO_BASE, 5, BonusSource::CREATURE_ABILITY);
+	EXPECT_EQ(creatureBonuses.totalValue(1700), 2244);
 }
 
 }

--- a/test/game/BattleSpellCastTest.cpp
+++ b/test/game/BattleSpellCastTest.cpp
@@ -1308,7 +1308,7 @@ struct SkillCase
 	int            skillIdx;
 	BonusType      bonusType;
 	BonusSubtypeID subtype;
-	int            baseValue; // 0 for flat (BASE_NUMBER) effects; 100 for percentage effects
+	int            baseValue; // base passed to percentage effects; 0 for flat effects
 	int            heroLevel;
 };
 
@@ -1319,8 +1319,8 @@ public:
 	/// value with the skill minus value without it. Taking the per-hero difference
 	/// cancels any innate, non-skill contribution to the same bonus (e.g. a hero's
 	/// base mana regeneration or spell damage), leaving only the skill's part - which
-	/// is what the specialty scales. Percentage effects (baseValue 100) are read
-	/// against a fixed base so their contribution is measurable at all.
+	/// is what the specialty scales. Percentage effects are read against a fixed base
+	/// so their contribution is measurable at all.
 	int64_t skillContribution(int heroIdx, const SkillCase & c)
 	{
 		const auto sel = Selector::typeSubtype(c.bonusType, c.subtype);
@@ -1349,7 +1349,7 @@ TEST_P(SecondarySkillSpecialty, scalesSkillBonus)
 		EXPECT_EQ(withSpec, applyPercentDown(withoutSpec, 5 * c.heroLevel) + 1) << c.name;
 	} else {
 		EXPECT_EQ(withSpec, applyPercentDown(withoutSpec, 5 * c.heroLevel)) << c.name;
-	}	
+	}
 }
 
 INSTANTIATE_TEST_SUITE_P(Heroes, SecondarySkillSpecialty, ::testing::Values(
@@ -1365,11 +1365,41 @@ INSTANTIATE_TEST_SUITE_P(Heroes, SecondarySkillSpecialty, ::testing::Values(
 	SkillCase{"axsis_mysticism",      58,  8, BonusType::MANA_REGENERATION,           BonusSubtypeID(),                                     0, 12},
 	SkillCase{"gird_sorcery",        104, 25, BonusType::SPELL_DAMAGE,                BonusSubtypeID(SpellSchool::ANY),                     0, 10},
 	SkillCase{"geon_eagleEye",        92, 11, BonusType::LEARN_BATTLE_SPELL_CHANCE,   BonusSubtypeID(),                                     0, 16},
-	// percentage-valued skills: measured against a fixed base (see measure()).
-	SkillCase{"kyrre_logistics",      23,  2, BonusType::MOVEMENT,                    BonusSubtypeID(BonusCustomSubtype::heroMovementLand), 100, 20},
+	// percentage-valued skills: measured against a fixed base (see skillContribution()).
+	SkillCase{"kyrre_logistics",      23,  2, BonusType::MOVEMENT,                    BonusSubtypeID(BonusCustomSubtype::heroMovementLand), 1700, 1},
 	SkillCase{"ayden_intelligence",   56, 24, BonusType::MANA_PER_KNOWLEDGE_PERCENTAGE, BonusSubtypeID(),                                  100, 18}
 ),
 	[](const ::testing::TestParamInfo<SkillCase> & info) { return info.param.name; });
+
+TEST_F(BattleSpellCastTest, learningSpecialtyKeepsFractionalPercent)
+{
+	const int adelaideIdx = 11;
+	CGHeroInstance * hero = placeHero(adelaideIdx, 1, {{CreatureID(0), 1}});
+	hero->setSecSkillLevel(SecondarySkill(SecondarySkill::LEARNING), 1, ChangeValueMode::ABSOLUTE);
+
+	auto specialty = std::make_shared<Bonus>(
+		BonusDuration::PERMANENT,
+		BonusType::HERO_EXPERIENCE_GAIN_PERCENT,
+		BonusSource::HERO_SPECIAL,
+		5,
+		BonusSourceID(),
+		BonusSubtypeID(),
+		BonusValueType::PERCENT_TO_TARGET_TYPE);
+	specialty->targetSourceType = BonusSource::SECONDARY_SKILL;
+	hero->addNewBonus(specialty);
+
+	EXPECT_EQ(hero->calculateXp(1700), 1789);
+}
+
+TEST_F(BattleSpellCastTest, intelligenceSpecialtyKeepsFractionalMana)
+{
+	const int aydenIdx = 56;
+	CGHeroInstance * hero = placeHero(aydenIdx, 1, {{CreatureID(0), 1}});
+	hero->setSecSkillLevel(SecondarySkill(SecondarySkill::INTELLIGENCE), 1, ChangeValueMode::ABSOLUTE);
+	hero->setPrimarySkill(PrimarySkill::KNOWLEDGE, 8, ChangeValueMode::ABSOLUTE);
+
+	EXPECT_EQ(hero->manaLimit(), 101);
+}
 
 // --- movement specialty (GROWS_WITH_LEVEL) ---
 


### PR DESCRIPTION
Fixes #7677.

Keep two decimal places for percentage-based secondary skill bonuses until the final value is calculated. This fixes Logistics, Learning, and Intelligence specialists.

Tests:
- 665 unit tests passed
- RelWithDebInfo build passed
