### PR TITLE
Fix Frenzy damage against Behemoths

### DIFF
--- a/lib/battle/DamageCalculator.cpp
+++ b/lib/battle/DamageCalculator.cpp
@@ -131,7 +131,24 @@ DamageRange DamageCalculator::getBaseDamageStack() const
 
 int DamageCalculator::getActorAttackBase() const
 {
-	return info.attacker->getAttack(info.shooting);
+	int attack = info.attacker->getAttack(info.shooting);
+	int frenzy = info.attacker->valOfBonuses(BonusType::IN_FRENZY);
+
+	if(frenzy > 0)
+	{
+		static const auto defenseSelector = Selector::typeSubtype(BonusType::PRIMARY_SKILL, BonusSubtypeID(PrimarySkill::DEFENSE));
+		int defense = battleBonusValue(info.attacker, defenseSelector);
+		int defenseReduction = getDefenseReduction(info.defender, defense);
+
+		if(defenseReduction != 0)
+		{
+			attack -= frenzy * defense / 100;
+			attack += frenzy * (defense - defenseReduction) / 100;
+			vstd::amax(attack, 0);
+		}
+	}
+
+	return attack;
 }
 
 int DamageCalculator::getActorAttackEffective() const
@@ -186,12 +203,17 @@ int DamageCalculator::getTargetDefenseEffective() const
 
 int DamageCalculator::getTargetDefenseIgnored() const
 {
-	double multDefenceReduction = battleBonusValue(info.attacker, Selector::type()(BonusType::ENEMY_DEFENCE_REDUCTION)) / 100.0;
+	return -getDefenseReduction(info.attacker, getTargetDefenseBase());
+}
 
-	if(multDefenceReduction > 0)
+int DamageCalculator::getDefenseReduction(const IBonusBearer * reductionBearer, int defense) const
+{
+	int reductionPercent = battleBonusValue(reductionBearer, Selector::type()(BonusType::ENEMY_DEFENCE_REDUCTION));
+
+	if(reductionPercent > 0 && defense > 0)
 	{
-		int reduction = std::floor(multDefenceReduction * getTargetDefenseBase()) + 1;
-		return -std::min(reduction,getTargetDefenseBase());
+		int reduction = std::floor(reductionPercent / 100.0 * defense) + 1;
+		return std::min(reduction, defense);
 	}
 	return 0;
 }

--- a/lib/battle/DamageCalculator.cpp
+++ b/lib/battle/DamageCalculator.cpp
@@ -136,7 +136,9 @@ int DamageCalculator::getActorAttackBase() const
 
 	if(frenzy > 0)
 	{
-		static const auto defenseSelector = Selector::typeSubtype(BonusType::PRIMARY_SKILL, BonusSubtypeID(PrimarySkill::DEFENSE));
+		static const auto defenseSelector = Selector::typeSubtype(
+			BonusType::PRIMARY_SKILL,
+			BonusSubtypeID(PrimarySkill::DEFENSE));
 		int defense = battleBonusValue(info.attacker, defenseSelector);
 		int defenseReduction = getDefenseReduction(info.defender, defense);
 

--- a/lib/battle/DamageCalculator.h
+++ b/lib/battle/DamageCalculator.h
@@ -40,6 +40,7 @@ class DLL_LINKAGE DamageCalculator
 	int getTargetDefenseBase() const;
 	int getTargetDefenseEffective() const;
 	int getTargetDefenseIgnored() const;
+	int getDefenseReduction(const IBonusBearer * reductionBearer, int defense) const;
 
 	double getAttackSkillFactor() const;
 	double getAttackOffenseArcheryFactor() const;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -18,6 +18,7 @@ set(test_SRCS
 
  		battle/BattleHexTest.cpp
  		battle/CBattleInfoCallbackTest.cpp
+		battle/DamageCalculatorTest.cpp
  		battle/CHealthTest.cpp
 		battle/CUnitStateTest.cpp
 		battle/CUnitStateMagicTest.cpp

--- a/test/battle/DamageCalculatorTest.cpp
+++ b/test/battle/DamageCalculatorTest.cpp
@@ -48,9 +48,13 @@ protected:
 	battle::CUnitStateDetached defender;
 	TestCallback callback;
 
-	DamageCalculatorTest() : attacker(&attackerInfo, &attackerBonuses), defender(&defenderInfo, &defenderBonuses) {}
+	DamageCalculatorTest()
+		: attacker(&attackerInfo, &attackerBonuses)
+		, defender(&defenderInfo, &defenderBonuses)
+	{
+	}
 
-	void addBonus(
+	static void addBonus(
 		BonusBearerMock & bearer,
 		BonusType type,
 		int value,
@@ -58,7 +62,13 @@ protected:
 		BonusLimitEffect effectRange = BonusLimitEffect::NO_LIMIT
 	)
 	{
-		auto bonus = std::make_shared<Bonus>(BonusDuration::PERMANENT, type, BonusSource::CREATURE_ABILITY, value, BonusSourceID(), subtype);
+		auto bonus = std::make_shared<Bonus>(
+			BonusDuration::PERMANENT,
+			type,
+			BonusSource::CREATURE_ABILITY,
+			value,
+			BonusSourceID(),
+			subtype);
 		bonus->effectRange = effectRange;
 		bearer.addNewBonus(bonus);
 	}
@@ -78,7 +88,12 @@ protected:
 		attacker.localInit(&environment);
 	}
 
-	void setupDefender(int count, int health, int defenseValue, int reduction = 0, BonusLimitEffect effectRange = BonusLimitEffect::NO_LIMIT)
+	void setupDefender(
+		int count,
+		int health,
+		int defenseValue,
+		int reduction = 0,
+		BonusLimitEffect effectRange = BonusLimitEffect::NO_LIMIT)
 	{
 		ON_CALL(defenderInfo, unitBaseAmount()).WillByDefault(Return(count));
 		ON_CALL(defenderInfo, unitType()).WillByDefault(Return(CreatureID(0).toCreature()));
@@ -91,7 +106,7 @@ protected:
 		defender.localInit(&environment);
 	}
 
-	DamageEstimation calculateDamage(bool shooting = false, bool ignoreDefenseFactors = false)
+	DamageEstimation calculateDamage(bool shooting = false, bool ignoreDefenseFactors = false) const
 	{
 		BattleAttackInfo attackInfo(&attacker, &defender, 0, shooting);
 		attackInfo.ignoreDefenseFactors = ignoreDefenseFactors;

--- a/test/battle/DamageCalculatorTest.cpp
+++ b/test/battle/DamageCalculatorTest.cpp
@@ -1,0 +1,182 @@
+/*
+ * DamageCalculatorTest.cpp, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
+
+#include "StdInc.h"
+
+#include "../../lib/CCreatureHandler.h"
+#include "../../lib/battle/CBattleInfoCallback.h"
+#include "../../lib/battle/CUnitState.h"
+
+#include "mock/mock_BonusBearer.h"
+#include "mock/mock_UnitEnvironment.h"
+#include "mock/mock_UnitInfo.h"
+
+namespace test
+{
+using namespace ::testing;
+
+class DamageCalculatorTest : public Test
+{
+protected:
+	class TestCallback : public CBattleInfoCallback
+	{
+	public:
+		const IBattleInfo * getBattle() const override
+		{
+			return nullptr;
+		}
+
+		std::optional<PlayerColor> getPlayerID() const override
+		{
+			return std::nullopt;
+		}
+	};
+
+	NiceMock<UnitInfoMock> attackerInfo;
+	NiceMock<UnitInfoMock> defenderInfo;
+	NiceMock<UnitEnvironmentMock> environment;
+	BonusBearerMock attackerBonuses;
+	BonusBearerMock defenderBonuses;
+	battle::CUnitStateDetached attacker;
+	battle::CUnitStateDetached defender;
+	TestCallback callback;
+
+	DamageCalculatorTest() : attacker(&attackerInfo, &attackerBonuses), defender(&defenderInfo, &defenderBonuses) {}
+
+	void addBonus(
+		BonusBearerMock & bearer,
+		BonusType type,
+		int value,
+		BonusSubtypeID subtype = BonusSubtypeID(),
+		BonusLimitEffect effectRange = BonusLimitEffect::NO_LIMIT
+	)
+	{
+		auto bonus = std::make_shared<Bonus>(BonusDuration::PERMANENT, type, BonusSource::CREATURE_ABILITY, value, BonusSourceID(), subtype);
+		bonus->effectRange = effectRange;
+		bearer.addNewBonus(bonus);
+	}
+
+	void setupAttacker(int count, int damage, int attackValue, int defenseValue, int frenzy)
+	{
+		ON_CALL(attackerInfo, unitBaseAmount()).WillByDefault(Return(count));
+		ON_CALL(attackerInfo, unitType()).WillByDefault(Return(CreatureID(0).toCreature()));
+
+		addBonus(attackerBonuses, BonusType::STACK_HEALTH, 100);
+		addBonus(attackerBonuses, BonusType::CREATURE_DAMAGE, damage, BonusCustomSubtype::creatureDamageBoth);
+		addBonus(attackerBonuses, BonusType::PRIMARY_SKILL, attackValue, BonusSubtypeID(PrimarySkill::ATTACK));
+		addBonus(attackerBonuses, BonusType::PRIMARY_SKILL, defenseValue, BonusSubtypeID(PrimarySkill::DEFENSE));
+		if(frenzy != 0)
+			addBonus(attackerBonuses, BonusType::IN_FRENZY, frenzy);
+
+		attacker.localInit(&environment);
+	}
+
+	void setupDefender(int count, int health, int defenseValue, int reduction = 0, BonusLimitEffect effectRange = BonusLimitEffect::NO_LIMIT)
+	{
+		ON_CALL(defenderInfo, unitBaseAmount()).WillByDefault(Return(count));
+		ON_CALL(defenderInfo, unitType()).WillByDefault(Return(CreatureID(0).toCreature()));
+
+		addBonus(defenderBonuses, BonusType::STACK_HEALTH, health);
+		addBonus(defenderBonuses, BonusType::PRIMARY_SKILL, defenseValue, BonusSubtypeID(PrimarySkill::DEFENSE));
+		if(reduction != 0)
+			addBonus(defenderBonuses, BonusType::ENEMY_DEFENCE_REDUCTION, reduction, BonusSubtypeID(), effectRange);
+
+		defender.localInit(&environment);
+	}
+
+	DamageEstimation calculateDamage(bool shooting = false, bool ignoreDefenseFactors = false)
+	{
+		BattleAttackInfo attackInfo(&attacker, &defender, 0, shooting);
+		attackInfo.ignoreDefenseFactors = ignoreDefenseFactors;
+		return callback.calculateDmgRange(attackInfo);
+	}
+};
+
+TEST_F(DamageCalculatorTest, frenzyUsesDefenseAfterAncientBehemothReduction)
+{
+	setupAttacker(1000, 30, 16, 13, 200);
+	setupDefender(1000, 300, 19, 80);
+
+	auto result = calculateDamage();
+
+	EXPECT_EQ(result.damage.min, 31500);
+	EXPECT_EQ(result.damage.max, 31500);
+}
+
+class FrenzyDefenseReductionTest
+	: public DamageCalculatorTest
+	, public WithParamInterface<std::pair<int, int64_t>>
+{
+};
+
+TEST_P(FrenzyDefenseReductionTest, keepsExistingRounding)
+{
+	setupAttacker(1, 101, 0, 20, 100);
+	setupDefender(1, 1000, 0, GetParam().first);
+
+	auto result = calculateDamage();
+
+	EXPECT_EQ(result.damage.min, GetParam().second);
+	EXPECT_EQ(result.damage.max, GetParam().second);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+	BehemothValues,
+	FrenzyDefenseReductionTest,
+	Values(std::pair<int, int64_t>{40, 156}, std::pair<int, int64_t>{80, 116}, std::pair<int, int64_t>{100, 101})
+);
+
+TEST_F(DamageCalculatorTest, defenseReductionDoesNotChangeAttackWithoutFrenzy)
+{
+	setupAttacker(1, 101, 10, 20, 0);
+	setupDefender(1, 1000, 0, 80);
+
+	auto result = calculateDamage();
+
+	EXPECT_EQ(result.damage.min, 151);
+	EXPECT_EQ(result.damage.max, 151);
+}
+
+TEST_F(DamageCalculatorTest, frenzyRoundsAfterDefenseReduction)
+{
+	setupAttacker(1, 101, 0, 2, 150);
+	setupDefender(1, 1000, 0, 40);
+
+	auto result = calculateDamage();
+
+	EXPECT_EQ(result.damage.min, 106);
+	EXPECT_EQ(result.damage.max, 106);
+}
+
+TEST_F(DamageCalculatorTest, normalDefenseReductionKeepsExactProductRounding)
+{
+	setupAttacker(1, 101, 0, 0, 0);
+	setupDefender(1, 1000, 25);
+	addBonus(attackerBonuses, BonusType::ENEMY_DEFENCE_REDUCTION, 80);
+
+	auto result = calculateDamage();
+
+	EXPECT_EQ(result.damage.min, 90);
+	EXPECT_EQ(result.damage.max, 90);
+}
+
+TEST_F(DamageCalculatorTest, defenseReductionRespectsAttackRange)
+{
+	setupAttacker(1, 101, 0, 20, 100);
+	setupDefender(1, 1000, 0, 80, BonusLimitEffect::ONLY_DISTANCE_FIGHT);
+
+	auto meleeResult = calculateDamage(false, true);
+	auto rangedResult = calculateDamage(true, true);
+
+	EXPECT_EQ(meleeResult.damage.min, 202);
+	EXPECT_EQ(rangedResult.damage.min, 116);
+}
+
+}


### PR DESCRIPTION
Fixes #7645.

Apply Behemoth defense reduction before Frenzy converts Defense into Attack. This matches the original game and fixes the reported damage from 64,500 to 31,500.

Tests:
- 667 unit tests passed
- RelWithDebInfo build passed
