### PR TITLE
Update propagated bonuses after hero level up

### DIFF
--- a/lib/bonuses/CBonusSystemNode.cpp
+++ b/lib/bonuses/CBonusSystemNode.cpp
@@ -356,14 +356,16 @@ bool CBonusSystemNode::actsAsBonusSourceOnly() const
 	}
 }
 
-void CBonusSystemNode::propagateBonus(const std::shared_ptr<Bonus> & b, const CBonusSystemNode & source)
+void CBonusSystemNode::propagateBonus(const std::shared_ptr<Bonus> & b, const CBonusSystemNode & updaterContext, const CBonusSystemNode & exporter)
 {
 	if(b->propagator->shouldBeAttached(this))
 	{
 		auto propagated = b->propagationUpdater
-			? source.getUpdatedBonus(b, b->propagationUpdater)
+			? updaterContext.getUpdatedBonus(b, b->propagationUpdater)
 			: b;
 		bonuses.push_back(propagated);
+		if(b->propagationUpdater)
+			propagationRecords.push_back({propagated, b.get(), &exporter});
 		logBonus->trace("#$# %s #propagated to# %s", propagated->Description(nullptr), nodeName());
 		invalidateChildrenNodes(globalCounter);
 	}
@@ -371,7 +373,7 @@ void CBonusSystemNode::propagateBonus(const std::shared_ptr<Bonus> & b, const CB
 	TNodes lchildren;
 	getRedChildren(lchildren);
 	for(CBonusSystemNode *pname : lchildren)
-		pname->propagateBonus(b, source);
+		pname->propagateBonus(b, updaterContext, exporter);
 }
 
 void CBonusSystemNode::unpropagateBonus(const std::shared_ptr<Bonus> & b)
@@ -384,6 +386,14 @@ void CBonusSystemNode::unpropagateBonus(const std::shared_ptr<Bonus> & b)
 			{
 				return bonus->propagationUpdater && bonus->propagationUpdater == b->propagationUpdater;
 			});
+
+			for(auto it = propagationRecords.begin(); it != propagationRecords.end();)
+			{
+				if(it->bonus->propagationUpdater == b->propagationUpdater)
+					it = propagationRecords.erase(it);
+				else
+					++it;
+			}
 		}
 		else
 		{
@@ -400,6 +410,30 @@ void CBonusSystemNode::unpropagateBonus(const std::shared_ptr<Bonus> & b)
 	getRedChildren(lchildren);
 	for(CBonusSystemNode *pname : lchildren)
 		pname->unpropagateBonus(b);
+}
+
+void CBonusSystemNode::unpropagateBonusFrom(const std::shared_ptr<Bonus> & b, const CBonusSystemNode & exporter)
+{
+	if(b->propagator->shouldBeAttached(this))
+	{
+		for(auto it = propagationRecords.begin(); it != propagationRecords.end();)
+		{
+			if(it->original == b.get() && it->exporter == &exporter)
+			{
+				bonuses -= it->bonus;
+				it = propagationRecords.erase(it);
+			}
+			else
+				++it;
+		}
+
+		invalidateChildrenNodes(globalCounter);
+	}
+
+	TNodes lchildren;
+	getRedChildren(lchildren);
+	for(CBonusSystemNode *pname : lchildren)
+		pname->unpropagateBonusFrom(b, exporter);
 }
 
 void CBonusSystemNode::detachFromAll()
@@ -473,7 +507,7 @@ void CBonusSystemNode::newRedDescendant(CBonusSystemNode & descendant) const
 	for(const auto & b : exportedBonuses)
 	{
 		if(b->propagator)
-			descendant.propagateBonus(b, *this);
+			descendant.propagateBonus(b, *this, *this);
 	}
 	TCNodes redParents;
 	getRedAncestors(redParents); //get all red parents recursively
@@ -483,7 +517,7 @@ void CBonusSystemNode::newRedDescendant(CBonusSystemNode & descendant) const
 		for(const auto & b : parent->exportedBonuses)
 		{
 			if(b->propagator)
-				descendant.propagateBonus(b, *this);
+				descendant.propagateBonus(b, *this, *parent);
 		}
 	}
 }
@@ -520,7 +554,7 @@ void CBonusSystemNode::exportBonus(const std::shared_ptr<Bonus> & b)
 {
 	if(b->propagator)
 	{
-		propagateBonus(b, *this);
+		propagateBonus(b, *this, *this);
 	}
 	else
 	{
@@ -593,6 +627,26 @@ void CBonusSystemNode::limitBonuses(const BonusList &allBonuses, BonusList &out)
 void CBonusSystemNode::nodeHasChanged()
 {
 	invalidateChildrenNodes(++globalCounter);
+}
+
+void CBonusSystemNode::refreshPropagationUpdaters()
+{
+	BonusList bonusesToRefresh;
+	for(const auto & bonus : exportedBonuses)
+		if(bonus->propagator && bonus->propagationUpdater)
+			bonusesToRefresh.push_back(bonus);
+
+	for(const auto & bonus : bonusesToRefresh)
+		unpropagateBonusFrom(bonus, *this);
+
+	for(const auto & bonus : bonusesToRefresh)
+		propagateBonus(bonus, *this, *this);
+}
+
+void CBonusSystemNode::nodeHasChangedWithPropagation()
+{
+	nodeHasChanged();
+	refreshPropagationUpdaters();
 }
 
 void CBonusSystemNode::invalidateChildrenNodes(int32_t changeCounter)

--- a/lib/bonuses/CBonusSystemNode.h
+++ b/lib/bonuses/CBonusSystemNode.h
@@ -37,12 +37,22 @@ public:
 	};
 
 private:
+	/// Runtime link from a materialized propagation updater result to its origin.
+	/// These records are rebuilt together with propagated bonuses after loading.
+	struct PropagationRecord
+	{
+		std::shared_ptr<Bonus> bonus;
+		const Bonus * original;
+		const CBonusSystemNode * exporter;
+	};
+
 	/// List of bonuses that affect this node, whether local, or propagated to this node
 	BonusList bonuses;
 
 	/// List of bonuses that ar ecoming from this node.
 	/// Also includes nodes that are propagated away from this node, and might not affect this node itself
 	BonusList exportedBonuses;
+	std::vector<PropagationRecord> propagationRecords;
 
 	TCNodesVector parentsToInherit; // we inherit bonuses from them
 	TNodesVector parentsToPropagate; // we may attach our bonuses to them
@@ -73,8 +83,10 @@ private:
 	void getRedAncestors(TCNodes &out) const;
 	void getRedChildren(TNodes &out);
 
-	void propagateBonus(const std::shared_ptr<Bonus> & b, const CBonusSystemNode & source);
+	void propagateBonus(const std::shared_ptr<Bonus> & b, const CBonusSystemNode & updaterContext, const CBonusSystemNode & exporter);
 	void unpropagateBonus(const std::shared_ptr<Bonus> & b);
+	void unpropagateBonusFrom(const std::shared_ptr<Bonus> & b, const CBonusSystemNode & exporter);
+	void refreshPropagationUpdaters();
 	bool actsAsBonusSourceOnly() const;
 
 	void newRedDescendant(CBonusSystemNode & descendant) const; //propagation needed
@@ -87,6 +99,7 @@ private:
 protected:
 	bool isIndependentNode() const; //node is independent when it has no parents nor children
 	void exportBonuses();
+	void nodeHasChangedWithPropagation();
 
 public:
 	explicit CBonusSystemNode(BonusNodeType nodeType, bool isHypotetic);

--- a/lib/mapObjects/CGHeroInstance.cpp
+++ b/lib/mapObjects/CGHeroInstance.cpp
@@ -1440,7 +1440,7 @@ void CGHeroInstance::levelUp()
 {
 	++level;
 	//update specialty and other bonuses that scale with level
-	nodeHasChanged();
+	nodeHasChangedWithPropagation();
 }
 
 void CGHeroInstance::attachCommanderToArmy()

--- a/test/bonus/BonusSystemTest.cpp
+++ b/test/bonus/BonusSystemTest.cpp
@@ -14,6 +14,7 @@
 #include "../../lib/bonuses/Limiters.h"
 #include "../../lib/bonuses/Propagators.h"
 #include "../../lib/bonuses/Updaters.h"
+#include "../../lib/mapObjects/CGHeroInstance.h"
 
 namespace test
 {
@@ -240,6 +241,28 @@ TEST_F(BonusSystemTest, battlewidePropagationToEnemies)
 	EXPECT_EQ(pikemanEnemy.valOfBonuses(BonusType::LUCK), -1);
 }
 
+TEST_F(BonusSystemTest, propagationUpdaterDetachesSourceAfterNewRedEdge)
+{
+	TestBonusSystemNode devil{BonusNodeType::STACK_INSTANCE};
+	TestBonusSystemNode pikemanEnemy{BonusNodeType::STACK_INSTANCE};
+
+	devil.setPlayer(PlayerColor(0));
+	pikemanEnemy.setPlayer(PlayerColor(1));
+	devil.attachToSource(creatureDevil);
+	pikemanEnemy.attachToSource(creaturePikeman);
+
+	devil.attachTo(heroAine);
+	pikemanEnemy.attachTo(heroBron);
+	startBattle();
+
+	EXPECT_EQ(pikemanEnemy.valOfBonuses(BonusType::LUCK), -1);
+
+	devil.detachFromSource(creatureDevil);
+	EXPECT_EQ(pikemanEnemy.valOfBonuses(BonusType::LUCK), 0);
+
+	devil.detachFrom(heroAine);
+}
+
 TEST_F(BonusSystemTest, battlewideSkillPropagationToEnemies)
 {
 	TestBonusSystemNode pikemanAlly{BonusNodeType::STACK_INSTANCE};
@@ -277,6 +300,107 @@ TEST_F(BonusSystemTest, battlewideSkillPropagationToEnemies)
 	EXPECT_EQ(pikemanEnemy.valOfBonuses(BonusType::MORALE), -1);
 
 	heroAine.detachFromSource(armor);
+}
+
+TEST_F(BonusSystemTest, propagationUpdaterTracksHeroLevel)
+{
+	CGHeroInstance mentor(nullptr);
+	CGHeroInstance ally(nullptr);
+
+	mentor.attachTo(playerRed);
+	ally.attachTo(playerRed);
+
+	auto learningBonus = std::make_shared<Bonus>(BonusDuration::PERMANENT, BonusType::HERO_EXPERIENCE_GAIN_PERCENT, BonusSource::HERO_SPECIAL, 1, HeroTypeID(0));
+	learningBonus->propagator = std::make_shared<CPropagatorNodeType>(BonusNodeType::PLAYER);
+	learningBonus->propagationUpdater = std::make_shared<TimesHeroLevelUpdater>();
+	mentor.addNewBonus(learningBonus);
+
+	EXPECT_EQ(mentor.valOfBonuses(BonusType::HERO_EXPERIENCE_GAIN_PERCENT), 1);
+	EXPECT_EQ(ally.valOfBonuses(BonusType::HERO_EXPERIENCE_GAIN_PERCENT), 1);
+
+	mentor.levelUp();
+
+	EXPECT_EQ(mentor.valOfBonuses(BonusType::HERO_EXPERIENCE_GAIN_PERCENT), 2);
+	EXPECT_EQ(ally.valOfBonuses(BonusType::HERO_EXPERIENCE_GAIN_PERCENT), 2);
+
+	mentor.levelUp();
+
+	EXPECT_EQ(mentor.valOfBonuses(BonusType::HERO_EXPERIENCE_GAIN_PERCENT), 3);
+	EXPECT_EQ(ally.valOfBonuses(BonusType::HERO_EXPERIENCE_GAIN_PERCENT), 3);
+
+	mentor.detachFrom(playerRed);
+	ally.detachFrom(playerRed);
+}
+
+TEST_F(BonusSystemTest, propagationRefreshKeepsSharedUpdaterBonuses)
+{
+	CGHeroInstance mentorA(nullptr);
+	CGHeroInstance mentorB(nullptr);
+
+	mentorA.attachTo(playerRed);
+	mentorB.attachTo(playerRed);
+
+	auto updater = std::make_shared<TimesHeroLevelUpdater>();
+	auto propagator = std::make_shared<CPropagatorNodeType>(BonusNodeType::PLAYER);
+	auto bonusA = std::make_shared<Bonus>(BonusDuration::PERMANENT, BonusType::HERO_EXPERIENCE_GAIN_PERCENT, BonusSource::HERO_SPECIAL, 1, HeroTypeID(0));
+	auto bonusB = std::make_shared<Bonus>(BonusDuration::PERMANENT, BonusType::HERO_EXPERIENCE_GAIN_PERCENT, BonusSource::HERO_SPECIAL, 2, HeroTypeID(1));
+	bonusA->propagator = propagator;
+	bonusB->propagator = propagator;
+	bonusA->propagationUpdater = updater;
+	bonusB->propagationUpdater = updater;
+
+	mentorA.addNewBonus(bonusA);
+	mentorA.addNewBonus(bonusB);
+	mentorB.addNewBonus(bonusA);
+
+	EXPECT_EQ(heroAine.valOfBonuses(BonusType::HERO_EXPERIENCE_GAIN_PERCENT), 4);
+
+	mentorA.levelUp();
+	EXPECT_EQ(heroAine.valOfBonuses(BonusType::HERO_EXPERIENCE_GAIN_PERCENT), 7);
+
+	mentorB.levelUp();
+	EXPECT_EQ(heroAine.valOfBonuses(BonusType::HERO_EXPERIENCE_GAIN_PERCENT), 8);
+
+}
+
+TEST_F(BonusSystemTest, propagationRefreshKeepsHeroAsUpdaterContext)
+{
+	CGHeroInstance mentor(nullptr);
+	mentor.setOwner(PlayerColor(0));
+	mentor.attachTo(playerRed);
+
+	CBonusSystemNode artifactType{BonusNodeType::ARTIFACT};
+	CBonusSystemNode artifact{BonusNodeType::ARTIFACT_INSTANCE};
+	artifact.attachToSource(artifactType);
+	mentor.attachToSource(artifact);
+
+	auto updater = std::make_shared<CompositeUpdater>();
+	updater->updaters.push_back(std::make_shared<TimesHeroLevelUpdater>());
+	updater->updaters.push_back(std::make_shared<OwnerUpdater>());
+
+	auto intimidationBonus = std::make_shared<Bonus>(BonusDuration::PERMANENT, BonusType::MORALE, BonusSource::HERO_SPECIAL, -1, HeroTypeID(0));
+	intimidationBonus->propagator = std::make_shared<CPropagatorNodeType>(BonusNodeType::BATTLE_WIDE);
+	intimidationBonus->propagationUpdater = updater;
+	intimidationBonus->limiter = std::make_shared<OppositeSideLimiter>();
+	mentor.addNewBonus(intimidationBonus);
+
+	startBattle();
+	mentor.attachTo(battle);
+
+	EXPECT_EQ(mentor.valOfBonuses(BonusType::MORALE), 0);
+	EXPECT_EQ(heroAine.valOfBonuses(BonusType::MORALE), 0);
+	EXPECT_EQ(heroBron.valOfBonuses(BonusType::MORALE), -1);
+
+	mentor.levelUp();
+
+	EXPECT_EQ(mentor.valOfBonuses(BonusType::MORALE), 0);
+	EXPECT_EQ(heroAine.valOfBonuses(BonusType::MORALE), 0);
+	EXPECT_EQ(heroBron.valOfBonuses(BonusType::MORALE), -2);
+
+	mentor.detachFrom(battle);
+	mentor.detachFromSource(artifact);
+	mentor.detachFrom(playerRed);
+	artifact.detachFromSource(artifactType);
 }
 
 TEST_F(BonusSystemTest, legionPieces)


### PR DESCRIPTION
## Summary
- refresh level-based propagated bonuses after a hero levels up
- keep bonuses from different heroes separate during the refresh
- add regression tests for shared bonuses and owner-based effects

## Why
`TIMES_HERO_LEVEL` was applied only when the bonus was first propagated. Its value stayed unchanged until the game was reloaded.

Fixes #7029

## Testing
- 663 tests passed
- RelWithDebInfo full build completed
