### PR TITLE
Keep Mage and Pegasus spell-cost effects after death

### DIFF
--- a/lib/battle/CBattleInfoCallback.cpp
+++ b/lib/battle/CBattleInfoCallback.cpp
@@ -2148,16 +2148,28 @@ int32_t CBattleInfoCallback::battleGetSpellCost(const spells::Spell * sp, const 
 	int32_t manaReduction = 0;
 	int32_t manaIncrease = 0;
 
-	for(const auto * unit : battleAliveUnits())
+	auto updateSpellCostModifiers = [&](const IBonusBearer * bonusBearer, PlayerColor owner)
 	{
-		if(unit->unitOwner() == caster->tempOwner && unit->hasBonusOfType(BonusType::CHANGES_SPELL_COST_FOR_ALLY))
+		if(owner == caster->tempOwner && bonusBearer->hasBonusOfType(BonusType::CHANGES_SPELL_COST_FOR_ALLY))
 		{
-			vstd::amax(manaReduction, unit->valOfBonuses(BonusType::CHANGES_SPELL_COST_FOR_ALLY));
+			vstd::amax(manaReduction, bonusBearer->valOfBonuses(BonusType::CHANGES_SPELL_COST_FOR_ALLY));
 		}
-		if(unit->unitOwner() != caster->tempOwner && unit->hasBonusOfType(BonusType::CHANGES_SPELL_COST_FOR_ENEMY))
+		if(owner != caster->tempOwner && bonusBearer->hasBonusOfType(BonusType::CHANGES_SPELL_COST_FOR_ENEMY))
 		{
-			vstd::amax(manaIncrease, unit->valOfBonuses(BonusType::CHANGES_SPELL_COST_FOR_ENEMY));
+			vstd::amax(manaIncrease, bonusBearer->valOfBonuses(BonusType::CHANGES_SPELL_COST_FOR_ENEMY));
 		}
+	};
+
+	for(const auto * unit : battleAliveUnits())
+		updateSpellCostModifiers(unit, unit->unitOwner());
+
+	// Mage and Pegasus spell-cost modifiers last for the entire battle.
+	for(const auto * unit : battleGetStacksIf([](const CStack * stack)
+	{
+		return stack->base != nullptr && !stack->isValidTarget(false);
+	}))
+	{
+		updateSpellCostModifiers(unit->unitType(), unit->unitOwner());
 	}
 
 	return std::max(0, ret - manaReduction + manaIncrease);

--- a/test/game/BattleSpellCastTest.cpp
+++ b/test/game/BattleSpellCastTest.cpp
@@ -420,6 +420,17 @@ public:
 		return battle->getStack(info.id);
 	}
 
+	CStack * findStack(CreatureID creature) const
+	{
+		for(const auto & stack : gameState->currentBattles.front()->stacks)
+		{
+			if(stack->unitType()->getId() == creature)
+				return stack.get();
+		}
+
+		return nullptr;
+	}
+
 	/// Cast a spell from a hero caster aimed at a unit. Targeting adapts to the
 	/// spell's aim type: creature spells target the unit, location spells target
 	/// the unit's hex, mass spells take no target.
@@ -472,6 +483,90 @@ public:
 	CGHeroInstance * specialist = nullptr;
 	CGHeroInstance * opponent = nullptr;
 };
+
+TEST_F(BattleSpellCastTest, pegasusSpellCostIncreasePersistsAfterDeath)
+{
+	auto * pegasusOwner = placeHero(0, 1, {{CreatureID(20), 1}});
+	auto * caster = getHeroByOwner(PlayerColor(1));
+	ASSERT_NE(pegasusOwner, nullptr);
+	ASSERT_NE(caster, nullptr);
+
+	caster->setSecSkillLevel(SecondarySkill::FIRE_MAGIC, MasteryLevel::EXPERT, ChangeValueMode::ABSOLUTE);
+	startTestBattle(pegasusOwner, caster);
+
+	auto * battle = gameState->currentBattles.front().get();
+	const auto * frenzy = SpellID(SpellID::FRENZY).toSpell();
+	ASSERT_NE(frenzy, nullptr);
+
+	CStack * pegasus = findStack(CreatureID(20));
+	ASSERT_NE(pegasus, nullptr);
+
+	EXPECT_EQ(battle->battleGetSpellCost(frenzy, caster), 14);
+
+	int64_t damage = pegasus->getAvailableHealth();
+	pegasus->damage(damage);
+	ASSERT_FALSE(pegasus->alive());
+
+	EXPECT_EQ(battle->battleGetSpellCost(frenzy, caster), 14);
+
+	BattleUnitsChanged removePegasus;
+	removePegasus.battleID = BattleID(0);
+	removePegasus.changedStacks.emplace_back(pegasus->unitId(), UnitChanges::EOperation::REMOVE);
+	gameEventCallback->sendAndApply(removePegasus);
+
+	ASSERT_TRUE(pegasus->isGhost());
+	EXPECT_EQ(battle->battleGetSpellCost(frenzy, caster), 14);
+}
+
+TEST_F(BattleSpellCastTest, mageSpellCostReductionPersistsAfterDeath)
+{
+	auto * caster = placeHero(0, 1, {{CreatureID(34), 1}});
+	auto * opponent = getHeroByOwner(PlayerColor(1));
+	ASSERT_NE(caster, nullptr);
+	ASSERT_NE(opponent, nullptr);
+
+	caster->setSecSkillLevel(SecondarySkill::FIRE_MAGIC, MasteryLevel::EXPERT, ChangeValueMode::ABSOLUTE);
+	startTestBattle(caster, opponent);
+
+	auto * battle = gameState->currentBattles.front().get();
+	const auto * frenzy = SpellID(SpellID::FRENZY).toSpell();
+	CStack * mage = findStack(CreatureID(34));
+	ASSERT_NE(frenzy, nullptr);
+	ASSERT_NE(mage, nullptr);
+
+	EXPECT_EQ(battle->battleGetSpellCost(frenzy, caster), 10);
+
+	int64_t damage = mage->getAvailableHealth();
+	mage->damage(damage);
+	ASSERT_FALSE(mage->alive());
+
+	EXPECT_EQ(battle->battleGetSpellCost(frenzy, caster), 10);
+}
+
+TEST_F(BattleSpellCastTest, battleAddedSpellCostModifierEndsWithUnit)
+{
+	auto * caster = placeHero(0, 1, {{CreatureID(0), 1}});
+	auto * opponent = getHeroByOwner(PlayerColor(1));
+	ASSERT_NE(caster, nullptr);
+	ASSERT_NE(opponent, nullptr);
+
+	caster->setSecSkillLevel(SecondarySkill::FIRE_MAGIC, MasteryLevel::EXPERT, ChangeValueMode::ABSOLUTE);
+	startTestBattle(caster, opponent);
+
+	auto * battle = gameState->currentBattles.front().get();
+	const auto * frenzy = SpellID(SpellID::FRENZY).toSpell();
+	CStack * pegasus = addStack(BattleSide::DEFENDER, CreatureID(20), 1);
+	ASSERT_NE(frenzy, nullptr);
+	ASSERT_NE(pegasus, nullptr);
+
+	EXPECT_EQ(battle->battleGetSpellCost(frenzy, caster), 14);
+
+	int64_t damage = pegasus->getAvailableHealth();
+	pegasus->damage(damage);
+	ASSERT_FALSE(pegasus->alive());
+
+	EXPECT_EQ(battle->battleGetSpellCost(frenzy, caster), 12);
+}
 
 //Issue #2765, Ghost Dragons can cast Age on Catapults
 TEST_F(BattleSpellCastTest, issue2765)


### PR DESCRIPTION
## Summary
- keep Mage and Pegasus spell-cost effects after their original stack dies
- preserve current behavior for battle-added stacks
- add tests for death, removal, and both spell-cost effects

## Why
Spell cost was calculated from living units only. This made Expert Frenzy fall from 14 mana to 12 as soon as Pegasi died.

Fixes #7678

## Testing
- 662 tests passed
- RelWithDebInfo full build completed
