### PR TITLE
Keep runtime propagation updaters current

### DIFF
--- a/docs/developers/Bonus_System.md
+++ b/docs/developers/Bonus_System.md
@@ -25,9 +25,11 @@ Propagation is used when bonuses need to be shared in a different direction than
 
 ### Technical Details
 
-- Propagation is done by copying bonuses to the target nodes. This happens when bonuses are added.
+- Propagation copies bonuses to target nodes when they are added. If a runtime node directly exports a bonus with a
+  propagation updater, the target keeps that node as the updater context and evaluates the updater when queried.
 - Inheritance is done on-the-fly when needed, by traversing the black DAG. Results are cached to improve performance.
 - Whenever a node changes (e.g. bonus added), a global counter gets increased which is used to check whether cached results are still current.
+- Runtime nodes also invalidate targets containing propagation-updated bonuses exported by them.
 
 ## Operations on the graph
 

--- a/lib/bonuses/CBonusSystemNode.cpp
+++ b/lib/bonuses/CBonusSystemNode.cpp
@@ -28,15 +28,20 @@ std::shared_ptr<Bonus> CBonusSystemNode::getLocalBonus(const CSelector & selecto
 
 std::shared_ptr<const Bonus> CBonusSystemNode::getFirstBonus(const CSelector & selector) const
 {
-	auto ret = bonuses.getFirst(selector);
-	if(ret)
-		return ret;
+	for(const auto & bonus : bonuses)
+	{
+		auto updated = bonus;
+		if(!propagationRecords.empty())
+			updated = applyPropagationUpdater(updated);
+		if(selector(updated.get()))
+			return updated;
+	}
 
 	TCNodes lparents;
 	getDirectParents(lparents);
 	for(const CBonusSystemNode *pname : lparents)
 	{
-		ret = pname->getFirstBonus(selector);
+		auto ret = pname->getFirstBonus(selector);
 		if (ret)
 			return ret;
 	}
@@ -59,10 +64,22 @@ void CBonusSystemNode::getAllBonusesRec(BonusList &out) const
 
 	bonuses.getAllBonuses(beforeUpdate);
 
-	for(const auto & b : beforeUpdate)
+	if(propagationRecords.empty())
 	{
-		auto updated = b->updater ? getUpdatedBonus(b, b->updater) : b;
-		out.push_back(updated);
+		for(const auto & b : beforeUpdate)
+		{
+			auto updated = b->updater ? getUpdatedBonus(b, b->updater) : b;
+			out.push_back(updated);
+		}
+	}
+	else
+	{
+		for(const auto & b : beforeUpdate)
+		{
+			auto propagated = applyPropagationUpdater(b);
+			auto updated = propagated->updater ? getUpdatedBonus(propagated, propagated->updater) : propagated;
+			out.push_back(updated);
+		}
 	}
 }
 
@@ -178,6 +195,10 @@ CBonusSystemNode::~CBonusSystemNode()
 		while(!children.empty())
 			children.front()->detachFrom(*this);
 	}
+
+	clearPropagationRecords();
+	while(!propagationDependents.empty())
+		propagationDependents.begin()->first->removePropagationRecordsForContext(*this);
 }
 
 void CBonusSystemNode::attachTo(CBonusSystemNode & parent)
@@ -315,21 +336,30 @@ void CBonusSystemNode::accumulateBonus(const std::shared_ptr<Bonus>& b)
 {
 	auto bonus = exportedBonuses.getFirst(Selector::typeSubtypeValueType(b->type, b->subtype, b->valType)); //only local bonuses are interesting
 	if(bonus)
+	{
 		bonus->val += b->val;
+		nodeHasChanged();
+	}
 	else
 		addNewBonus(std::make_shared<Bonus>(*b)); //duplicate needed, original may get destroyed
 }
 
 void CBonusSystemNode::removeBonus(const std::shared_ptr<Bonus>& b)
 {
-	exportedBonuses -= b;
-	if(b->propagator)
+	// Callers may pass a reference to an element of exportedBonuses.
+	// Keep the object alive while removing that element and its propagated instances.
+	auto bonus = b;
+	exportedBonuses -= bonus;
+	if(bonus->propagator)
 	{
-		unpropagateBonus(b);
+		++globalCounter;
+		const CBonusSystemNode * updaterContext = bonus->propagationUpdater && !actsAsBonusSourceOnly() ? this : nullptr;
+		unpropagateBonus(bonus, updaterContext);
+		invalidateChildrenNodes(globalCounter);
 	}
 	else
 	{
-		bonuses -= b;
+		bonuses -= bonus;
 		nodeHasChanged();
 	}
 }
@@ -356,34 +386,54 @@ bool CBonusSystemNode::actsAsBonusSourceOnly() const
 	}
 }
 
-void CBonusSystemNode::propagateBonus(const std::shared_ptr<Bonus> & b, const CBonusSystemNode & source)
+void CBonusSystemNode::propagateBonus(
+	const std::shared_ptr<Bonus> & b,
+	const CBonusSystemNode & source,
+	bool trackUpdater)
 {
 	if(b->propagator->shouldBeAttached(this))
 	{
-		auto propagated = b->propagationUpdater
-			? source.getUpdatedBonus(b, b->propagationUpdater)
-			: b;
-		bonuses.push_back(propagated);
-		logBonus->trace("#$# %s #propagated to# %s", propagated->Description(nullptr), nodeName());
+		if(b->propagationUpdater)
+		{
+			if(trackUpdater)
+				addPropagationRecord(b, source);
+			else
+				bonuses.push_back(source.getUpdatedBonus(b, b->propagationUpdater));
+		}
+		else
+			bonuses.push_back(b);
+
+		logBonus->trace("#$# %s #propagated to# %s", b->Description(nullptr), nodeName());
 		invalidateChildrenNodes(globalCounter);
 	}
 
 	TNodes lchildren;
 	getRedChildren(lchildren);
 	for(CBonusSystemNode *pname : lchildren)
-		pname->propagateBonus(b, source);
+		pname->propagateBonus(b, source, trackUpdater);
 }
 
-void CBonusSystemNode::unpropagateBonus(const std::shared_ptr<Bonus> & b)
+void CBonusSystemNode::unpropagateBonus(const std::shared_ptr<Bonus> & b, const CBonusSystemNode * updaterContext)
 {
 	if(b->propagator->shouldBeAttached(this))
 	{
-		if (b->propagationUpdater)
+		if(b->propagationUpdater)
 		{
-			bonuses.remove_if([b](const auto & bonus)
+			if(updaterContext)
 			{
-				return bonus->propagationUpdater && bonus->propagationUpdater == b->propagationUpdater;
-			});
+				if(!removePropagationRecord(b, *updaterContext))
+					logBonus->warn("Attempt to remove updated bonus (type=%d), which is not propagated to %s",
+						static_cast<int>(b->type), nodeName());
+			}
+			else
+			{
+				bonuses.remove_if([this, b](const Bonus * bonus)
+				{
+					return !propagationRecords.contains(bonus)
+						&& bonus->propagationUpdater
+						&& bonus->propagationUpdater == b->propagationUpdater;
+				});
+			}
 		}
 		else
 		{
@@ -399,7 +449,92 @@ void CBonusSystemNode::unpropagateBonus(const std::shared_ptr<Bonus> & b)
 	TNodes lchildren;
 	getRedChildren(lchildren);
 	for(CBonusSystemNode *pname : lchildren)
-		pname->unpropagateBonus(b);
+		pname->unpropagateBonus(b, updaterContext);
+}
+
+void CBonusSystemNode::addPropagationRecord(const std::shared_ptr<Bonus> & b, const CBonusSystemNode & updaterContext)
+{
+	auto materialized = std::make_shared<Bonus>(*b);
+	bonuses.push_back(materialized);
+	propagationRecords.emplace(materialized.get(), PropagationRecord{materialized, b, &updaterContext});
+	updaterContext.addPropagationDependent(*this);
+}
+
+bool CBonusSystemNode::removePropagationRecord(
+	const std::shared_ptr<Bonus> & b,
+	const CBonusSystemNode & updaterContext)
+{
+	for(auto it = propagationRecords.begin(); it != propagationRecords.end(); ++it)
+	{
+		if(it->second.original == b && it->second.updaterContext == &updaterContext)
+		{
+			bonuses -= it->second.materialized;
+			updaterContext.removePropagationDependent(*this);
+			propagationRecords.erase(it);
+			return true;
+		}
+	}
+	return false;
+}
+
+std::shared_ptr<Bonus> CBonusSystemNode::applyPropagationUpdater(const std::shared_ptr<Bonus> & b) const
+{
+	auto record = propagationRecords.find(b.get());
+	if(record == propagationRecords.end())
+		return b;
+
+	return record->second.updaterContext->getUpdatedBonus(
+		record->second.original,
+		record->second.original->propagationUpdater);
+}
+
+void CBonusSystemNode::addPropagationDependent(CBonusSystemNode & dependent) const
+{
+	propagationDependents[&dependent]++;
+}
+
+void CBonusSystemNode::removePropagationDependent(CBonusSystemNode & dependent) const
+{
+	auto it = propagationDependents.find(&dependent);
+	assert(it != propagationDependents.end());
+	if(--it->second == 0)
+		propagationDependents.erase(it);
+}
+
+void CBonusSystemNode::clearPropagationRecords()
+{
+	for(const auto & entry : propagationRecords)
+	{
+		bonuses -= entry.second.materialized;
+		entry.second.updaterContext->removePropagationDependent(*this);
+	}
+	propagationRecords.clear();
+}
+
+void CBonusSystemNode::removePropagationRecordsForContext(const CBonusSystemNode & updaterContext)
+{
+	bool removed = false;
+	for(auto it = propagationRecords.begin(); it != propagationRecords.end();)
+	{
+		if(it->second.updaterContext == &updaterContext)
+		{
+			bonuses -= it->second.materialized;
+			updaterContext.removePropagationDependent(*this);
+			it = propagationRecords.erase(it);
+			removed = true;
+		}
+		else
+			++it;
+	}
+
+	if(!removed)
+	{
+		assert(removed);
+		updaterContext.propagationDependents.erase(this);
+		return;
+	}
+
+	invalidateChildrenNodes(++globalCounter);
 }
 
 void CBonusSystemNode::detachFromAll()
@@ -473,7 +608,7 @@ void CBonusSystemNode::newRedDescendant(CBonusSystemNode & descendant) const
 	for(const auto & b : exportedBonuses)
 	{
 		if(b->propagator)
-			descendant.propagateBonus(b, *this);
+			descendant.propagateBonus(b, *this, b->propagationUpdater && !actsAsBonusSourceOnly());
 	}
 	TCNodes redParents;
 	getRedAncestors(redParents); //get all red parents recursively
@@ -483,16 +618,26 @@ void CBonusSystemNode::newRedDescendant(CBonusSystemNode & descendant) const
 		for(const auto & b : parent->exportedBonuses)
 		{
 			if(b->propagator)
-				descendant.propagateBonus(b, *this);
+			{
+				// Source-only nodes keep the context supplied by the topology event.
+				// Runtime nodes retain their own context so later changes invalidate the target.
+				const bool trackUpdater = b->propagationUpdater && !parent->actsAsBonusSourceOnly();
+				const CBonusSystemNode & source = trackUpdater ? *parent : *this;
+				descendant.propagateBonus(b, source, trackUpdater);
+			}
 		}
 	}
 }
 
 void CBonusSystemNode::removedRedDescendant(CBonusSystemNode & descendant) const
 {
+	++globalCounter;
 	for(const auto & b : exportedBonuses)
 		if(b->propagator)
-			descendant.unpropagateBonus(b);
+		{
+			const CBonusSystemNode * updaterContext = b->propagationUpdater && !actsAsBonusSourceOnly() ? this : nullptr;
+			descendant.unpropagateBonus(b, updaterContext);
+		}
 
 	TCNodes redParents;
 	getRedAncestors(redParents); //get all red parents recursively
@@ -501,7 +646,10 @@ void CBonusSystemNode::removedRedDescendant(CBonusSystemNode & descendant) const
 	{
 		for(const auto & b : parent->exportedBonuses)
 			if(b->propagator)
-				descendant.unpropagateBonus(b);
+			{
+				const CBonusSystemNode * updaterContext = b->propagationUpdater && !parent->actsAsBonusSourceOnly() ? parent : nullptr;
+				descendant.unpropagateBonus(b, updaterContext);
+			}
 	}
 }
 
@@ -520,7 +668,9 @@ void CBonusSystemNode::exportBonus(const std::shared_ptr<Bonus> & b)
 {
 	if(b->propagator)
 	{
-		propagateBonus(b, *this);
+		++globalCounter;
+		propagateBonus(b, *this, b->propagationUpdater && !actsAsBonusSourceOnly());
+		invalidateChildrenNodes(globalCounter);
 	}
 	else
 	{
@@ -604,6 +754,9 @@ void CBonusSystemNode::invalidateChildrenNodes(int32_t changeCounter)
 
 	for(CBonusSystemNode * child : children)
 		child->invalidateChildrenNodes(changeCounter);
+
+	for(const auto & dependent : propagationDependents)
+		dependent.first->invalidateChildrenNodes(changeCounter);
 }
 
 int32_t CBonusSystemNode::getTreeVersion() const

--- a/lib/bonuses/CBonusSystemNode.h
+++ b/lib/bonuses/CBonusSystemNode.h
@@ -37,12 +37,27 @@ public:
 	};
 
 private:
+	struct PropagationRecord
+	{
+		std::shared_ptr<Bonus> materialized;
+		std::shared_ptr<Bonus> original;
+		const CBonusSystemNode * updaterContext;
+	};
+
 	/// List of bonuses that affect this node, whether local, or propagated to this node
 	BonusList bonuses;
 
 	/// List of bonuses that ar ecoming from this node.
 	/// Also includes nodes that are propagated away from this node, and might not affect this node itself
 	BonusList exportedBonuses;
+
+	/// Runtime-only provenance for propagation-updated bonuses exported by runtime nodes.
+	/// The materialized bonus preserves BonusList ordering; its value is evaluated lazily from original.
+	std::map<const Bonus *, PropagationRecord> propagationRecords;
+
+	/// Nodes whose propagated bonuses depend on this node as their updater context.
+	/// Counts are needed when several bonuses or graph paths connect the same pair of nodes.
+	mutable std::map<CBonusSystemNode *, size_t> propagationDependents;
 
 	TCNodesVector parentsToInherit; // we inherit bonuses from them
 	TNodesVector parentsToPropagate; // we may attach our bonuses to them
@@ -73,8 +88,15 @@ private:
 	void getRedAncestors(TCNodes &out) const;
 	void getRedChildren(TNodes &out);
 
-	void propagateBonus(const std::shared_ptr<Bonus> & b, const CBonusSystemNode & source);
-	void unpropagateBonus(const std::shared_ptr<Bonus> & b);
+	void propagateBonus(const std::shared_ptr<Bonus> & b, const CBonusSystemNode & source, bool trackUpdater);
+	void unpropagateBonus(const std::shared_ptr<Bonus> & b, const CBonusSystemNode * updaterContext = nullptr);
+	void addPropagationRecord(const std::shared_ptr<Bonus> & b, const CBonusSystemNode & updaterContext);
+	bool removePropagationRecord(const std::shared_ptr<Bonus> & b, const CBonusSystemNode & updaterContext);
+	std::shared_ptr<Bonus> applyPropagationUpdater(const std::shared_ptr<Bonus> & b) const;
+	void addPropagationDependent(CBonusSystemNode & dependent) const;
+	void removePropagationDependent(CBonusSystemNode & dependent) const;
+	void clearPropagationRecords();
+	void removePropagationRecordsForContext(const CBonusSystemNode & updaterContext);
 	bool actsAsBonusSourceOnly() const;
 
 	void newRedDescendant(CBonusSystemNode & descendant) const; //propagation needed

--- a/test/bonus/BonusSystemTest.cpp
+++ b/test/bonus/BonusSystemTest.cpp
@@ -14,6 +14,7 @@
 #include "../../lib/bonuses/Limiters.h"
 #include "../../lib/bonuses/Propagators.h"
 #include "../../lib/bonuses/Updaters.h"
+#include "../../lib/mapObjects/CGHeroInstance.h"
 
 namespace test
 {
@@ -268,6 +269,11 @@ TEST_F(BonusSystemTest, battlewideSkillPropagationToEnemies)
 	EXPECT_EQ(heroBron.valOfBonuses(BonusType::MORALE), -1);
 	EXPECT_EQ(pikemanAlly.valOfBonuses(BonusType::MORALE), 0);
 	EXPECT_EQ(pikemanEnemy.valOfBonuses(BonusType::MORALE), -1);
+	auto ownedMorale = battle.getFirstBonus(Selector::type()(BonusType::MORALE).And([](const Bonus * bonus)
+	{
+		return bonus->bonusOwner == PlayerColor(0);
+	}));
+	ASSERT_NE(ownedMorale, nullptr);
 
 	heroAine.nodeHasChanged();
 
@@ -277,6 +283,56 @@ TEST_F(BonusSystemTest, battlewideSkillPropagationToEnemies)
 	EXPECT_EQ(pikemanEnemy.valOfBonuses(BonusType::MORALE), -1);
 
 	heroAine.detachFromSource(armor);
+}
+
+TEST_F(BonusSystemTest, propagationUpdaterTracksHeroLevelAcrossTopologyChanges)
+{
+	CGHeroInstance mentor(nullptr);
+	CGHeroInstance ally(nullptr);
+	CBonusSystemNode townAndVisitor(BonusNodeType::TOWN_AND_VISITOR);
+
+	auto learningBonus = std::make_shared<Bonus>(
+		BonusDuration::PERMANENT,
+		BonusType::HERO_EXPERIENCE_GAIN_PERCENT,
+		BonusSource::HERO_SPECIAL,
+		1,
+		HeroTypeID(0));
+	learningBonus->propagator = std::make_shared<CPropagatorNodeType>(BonusNodeType::PLAYER);
+	learningBonus->propagationUpdater = std::make_shared<TimesHeroLevelUpdater>();
+	mentor.addNewBonus(learningBonus);
+	mentor.attachTo(playerRed);
+	ally.attachTo(playerRed);
+
+	EXPECT_EQ(mentor.valOfBonuses(BonusType::HERO_EXPERIENCE_GAIN_PERCENT), 1);
+	EXPECT_EQ(ally.valOfBonuses(BonusType::HERO_EXPERIENCE_GAIN_PERCENT), 1);
+
+	mentor.levelUp();
+
+	EXPECT_EQ(mentor.valOfBonuses(BonusType::HERO_EXPERIENCE_GAIN_PERCENT), 2);
+	EXPECT_EQ(ally.valOfBonuses(BonusType::HERO_EXPERIENCE_GAIN_PERCENT), 2);
+
+	mentor.removeBonus(learningBonus);
+	EXPECT_EQ(mentor.valOfBonuses(BonusType::HERO_EXPERIENCE_GAIN_PERCENT), 0);
+	EXPECT_EQ(ally.valOfBonuses(BonusType::HERO_EXPERIENCE_GAIN_PERCENT), 0);
+
+	mentor.detachFrom(playerRed);
+	mentor.addNewBonus(learningBonus);
+
+	// Garrisoned heroes reach their player through the town's virtual node.
+	mentor.attachTo(townAndVisitor);
+	townAndVisitor.attachTo(playerRed);
+
+	EXPECT_EQ(ally.valOfBonuses(BonusType::HERO_EXPERIENCE_GAIN_PERCENT), 2);
+
+	mentor.levelUp();
+
+	EXPECT_EQ(ally.valOfBonuses(BonusType::HERO_EXPERIENCE_GAIN_PERCENT), 3);
+
+	townAndVisitor.detachFrom(playerRed);
+	EXPECT_EQ(ally.valOfBonuses(BonusType::HERO_EXPERIENCE_GAIN_PERCENT), 0);
+
+	mentor.detachFrom(townAndVisitor);
+	ally.detachFrom(playerRed);
 }
 
 TEST_F(BonusSystemTest, legionPieces)


### PR DESCRIPTION
Fixes #7029.

Propagation updaters on bonuses exported directly by runtime objects were applied only when attached. Later changes, including hero level, left the propagated value stale.

Keep the exporting object as the updater context and invalidate dependent targets when it changes. Creature and artifact template propagation is unchanged.