### PR TITLE
Apply Behemoth defense reduction before Frenzy

### DIFF
--- a/lib/battle/DamageCalculator.cpp
+++ b/lib/battle/DamageCalculator.cpp
@@ -131,7 +131,27 @@ DamageRange DamageCalculator::getBaseDamageStack() const
 
 int DamageCalculator::getActorAttackBase() const
 {
-	return info.attacker->getAttack(info.shooting);
+	int attack = info.attacker->getAttack(info.shooting);
+	int frenzy = info.attacker->valOfBonuses(BonusType::IN_FRENZY);
+
+	if(frenzy > 0)
+	{
+		// CUnitState applies Frenzy before the defender is known. Replace that bonus using reduced Defense.
+		static const auto defenseSelector = Selector::typeSubtype(
+			BonusType::PRIMARY_SKILL,
+			BonusSubtypeID(PrimarySkill::DEFENSE));
+		int defense = battleBonusValue(info.attacker, defenseSelector);
+		int defenseReduction = getDefenseReduction(info.defender, defense);
+
+		if(defenseReduction != 0)
+		{
+			attack -= frenzy * defense / 100;
+			attack += frenzy * (defense - defenseReduction) / 100;
+			vstd::amax(attack, 0);
+		}
+	}
+
+	return attack;
 }
 
 int DamageCalculator::getActorAttackEffective() const
@@ -186,12 +206,17 @@ int DamageCalculator::getTargetDefenseEffective() const
 
 int DamageCalculator::getTargetDefenseIgnored() const
 {
-	double multDefenceReduction = battleBonusValue(info.attacker, Selector::type()(BonusType::ENEMY_DEFENCE_REDUCTION)) / 100.0;
+	return -getDefenseReduction(info.attacker, getTargetDefenseBase());
+}
 
-	if(multDefenceReduction > 0)
+int DamageCalculator::getDefenseReduction(const IBonusBearer * reductionBearer, int defense) const
+{
+	int reductionPercent = battleBonusValue(reductionBearer, Selector::type()(BonusType::ENEMY_DEFENCE_REDUCTION));
+
+	if(reductionPercent > 0 && defense > 0)
 	{
-		int reduction = std::floor(multDefenceReduction * getTargetDefenseBase()) + 1;
-		return -std::min(reduction,getTargetDefenseBase());
+		int reduction = std::floor(reductionPercent / 100.0 * defense) + 1;
+		return std::min(reduction, defense);
 	}
 	return 0;
 }

--- a/lib/battle/DamageCalculator.h
+++ b/lib/battle/DamageCalculator.h
@@ -40,6 +40,7 @@ class DLL_LINKAGE DamageCalculator
 	int getTargetDefenseBase() const;
 	int getTargetDefenseEffective() const;
 	int getTargetDefenseIgnored() const;
+	int getDefenseReduction(const IBonusBearer * reductionBearer, int defense) const;
 
 	double getAttackSkillFactor() const;
 	double getAttackOffenseArcheryFactor() const;

--- a/test/game/BattleSpellCastTest.cpp
+++ b/test/game/BattleSpellCastTest.cpp
@@ -32,6 +32,7 @@
 #include "../../lib/StartInfo.h"
 #include "../../lib/TerrainHandler.h"
 
+#include "../../lib/battle/BattleAttackInfo.h"
 #include "../../lib/battle/BattleInfo.h"
 #include "../../lib/battle/BattleLayout.h"
 #include "../../lib/callback/GameRandomizer.h"
@@ -472,6 +473,65 @@ public:
 	CGHeroInstance * specialist = nullptr;
 	CGHeroInstance * opponent = nullptr;
 };
+
+TEST_F(BattleSpellCastTest, frenzyUsesDefenseAfterAncientBehemothReduction)
+{
+	const PlayerColor attackerOwner(0);
+	const PlayerColor defenderOwner(1);
+	const CreatureID nagaQueenId(CreatureID::decode("core:nagaQueen"));
+	const CreatureID ancientBehemothId(CreatureID::decode("core:ancientBehemoth"));
+	const SpellID frenzyId(SpellID::FRENZY);
+
+	TinyH3M::TinyH3MBuilder builder(EMapFormat::SOD);
+	builder
+		.size(36, false)
+		.name("FrenzyDefenseReductionTest")
+		.playerActive(attackerOwner)
+		.playerActive(defenderOwner)
+		.hero({5, 5, 0}, HeroTypeID(HeroTypeID::decode("core:edric")), attackerOwner)
+			.heroPrimary(0, 0, 10, 20)
+			.heroSecondarySkills({{SecondarySkill::FIRE_MAGIC, 3}})
+			.heroSpells({frenzyId})
+			.heroEquipped({{ArtifactPosition::SPELLBOOK, ArtifactID::SPELLBOOK}})
+			.heroGarrison({{nagaQueenId, 1000}})
+		.hero({7, 7, 0}, HeroTypeID(HeroTypeID::decode("core:orrin")), defenderOwner)
+			.heroPrimary(0, 0, 0, 0)
+			.heroGarrison({{ancientBehemothId, 1000}});
+	startTinyGame(builder);
+
+	auto * caster = getHeroByOwner(attackerOwner);
+	auto * defenderHero = getHeroByOwner(defenderOwner);
+	ASSERT_NE(caster, nullptr);
+	ASSERT_NE(defenderHero, nullptr);
+
+	startTestBattle(caster, defenderHero);
+
+	auto * battle = gameState->currentBattles.front().get();
+	const CStack * nagaQueen = nullptr;
+	const CStack * ancientBehemoth = nullptr;
+	for(const auto * stack : battle->battleGetAllStacks())
+	{
+		if(stack->unitType()->getId() == nagaQueenId)
+			nagaQueen = stack;
+		else if(stack->unitType()->getId() == ancientBehemothId)
+			ancientBehemoth = stack;
+	}
+	ASSERT_NE(nagaQueen, nullptr);
+	ASSERT_NE(ancientBehemoth, nullptr);
+
+	BattleAttackInfo behemothAttack(ancientBehemoth, nagaQueen, /*chargeDistance*/ 0, /*shooting*/ false);
+	const auto behemothDamage = battle->calculateDmgRange(behemothAttack).damage;
+	EXPECT_EQ(behemothDamage.min, 55500);
+	EXPECT_EQ(behemothDamage.max, 92500);
+
+	castOn(caster, frenzyId, nagaQueen);
+	ASSERT_EQ(nagaQueen->valOfBonuses(BonusType::IN_FRENZY), 200);
+
+	BattleAttackInfo attack(nagaQueen, ancientBehemoth, /*chargeDistance*/ 0, /*shooting*/ false);
+	const auto damage = battle->calculateDmgRange(attack).damage;
+	EXPECT_EQ(damage.min, 31500);
+	EXPECT_EQ(damage.max, 31500);
+}
 
 //Issue #2765, Ghost Dragons can cast Age on Catapults
 TEST_F(BattleSpellCastTest, issue2765)


### PR DESCRIPTION
Fixes #7645.

Frenzy converted the attacker's full Defense to Attack before applying the defender's Behemoth reduction.

Apply the reduction to Defense before calculating the Frenzy bonus. Existing Behemoth rounding is unchanged.
