### PR TITLE
Silence valid Nullkiller exploration point warnings

### DIFF
--- a/AI/Nullkiller2/Engine/PriorityEvaluator.cpp
+++ b/AI/Nullkiller2/Engine/PriorityEvaluator.cpp
@@ -855,9 +855,11 @@ public:
 			{
 				switch(obj->ID.num)
 				{
+					case Obj::BOAT:
 					case Obj::MONOLITH_ONE_WAY_ENTRANCE:
 					case Obj::MONOLITH_TWO_WAY:
 					case Obj::SUBTERRANEAN_GATE:
+					case Obj::WHIRLPOOL:
 						evaluationContext.explorePriority = 1;
 						break;
 					case Obj::REDWOOD_OBSERVATORY:
@@ -865,7 +867,8 @@ public:
 						evaluationContext.explorePriority = 2;
 						break;
 					default:
-						logAi->warn("ExplorePointEvaluator buildEvaluationContext unknown exploration point %d", obj->ID.num);
+						// Generic frontier tiles may contain objects that do not affect exploration priority.
+						break;
 				}
 			}
 


### PR DESCRIPTION
_Factoring out another hermetic change from https://github.com/vcmi/vcmi/pull/7613_

Save `217` repeatedly logged `unknown exploration point` for object IDs 8 and 111. These are Boats and Whirlpools, both valid transport targets that should receive high exploration priority.

The warning itself was misleading and unrelated to the `MaxPass` loop in that save. Generic exploration can select any visible frontier tile, so its visitable objects are not limited to the special objects recognized by the priority evaluator. Unlisted objects now keep the normal tile-discovery priority instead of producing an error-like warning.

The `217` replay completed without these warnings after the change, and the Whirlpool scenario from #6112 still completed normally.
