### PR TITLE
Keep autosaves in the game's dir, one save per day

### DIFF
--- a/Mods/vcmi/Content/config/translations/english.json
+++ b/Mods/vcmi/Content/config/translations/english.json
@@ -1082,6 +1082,7 @@
 	"vcmi.randomMapTab.widgets.teamAlignmentsButton": "Setup...",
 	"vcmi.randomMapTab.widgets.teamAlignmentsLabel": "Team Alignments",
 	"vcmi.randomMapTab.widgets.templateLabel": "Template",
+	"vcmi.savingScreen.autosaveNameWarning": "This name is reserved for autosaves and may be overwritten or removed automatically. Save anyway?",
 	"vcmi.selectionTab.campaignSets.help": "Multiple campaigns bundeled as set",
 	"vcmi.selectionTab.campaignSets.hover": "Campaign sets",
 	"vcmi.server.errors.campOrMapFile.unknownEntity": "Failed to load file! Unknown entity '%s' found! File may not be compatible with currently installed version of mods!",

--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -146,7 +146,7 @@ CPlayerInterface::CPlayerInterface(PlayerColor Player):
 	isAutoFightOn = false;
 	isAutoFightEndBattle = false;
 	ignoreEvents = false;
-	hasQuickSave = checkQuickLoadingGame();
+	hasQuickSave = false;
 }
 
 CPlayerInterface::~CPlayerInterface()
@@ -162,6 +162,7 @@ void CPlayerInterface::initGameInterface(std::shared_ptr<Environment> ENV, std::
 {
 	cb = CB;
 	env = ENV;
+	hasQuickSave = checkQuickLoadingGame();
 
 	pathfinderCache = std::make_unique<PathfinderCache>(cb.get(), PathfinderOptions(*cb));
 	ENGINE->music().loadTerrainMusicThemes();
@@ -1983,12 +1984,14 @@ void CPlayerInterface::proposeLoadingGame()
 
 void CPlayerInterface::quickSaveGame()
 {
+	const std::string quickSavePath = getQuickSavePath();
+
 	// notify player about saving
 	MetaString txt;
 	txt.appendTextID("vcmi.adventureMap.savingQuickSave");
-	txt.replaceRawString(QUICKSAVE_PATH);
+	txt.replaceRawString(quickSavePath);
 	GAME->server().getGameChat().sendMessageGameplay(txt.toString());
-	GAME->interface()->cb->save(QUICKSAVE_PATH, false);
+	GAME->interface()->cb->save(quickSavePath, false);
 	hasQuickSave = true;
 	if(adventureInt)
 		adventureInt->updateActiveState();
@@ -1996,24 +1999,25 @@ void CPlayerInterface::quickSaveGame()
 
 bool CPlayerInterface::checkQuickLoadingGame(bool verbose)
 {
-	if(!CResourceHandler::get("local")->existsResource(ResourcePath(QUICKSAVE_PATH, EResType::SAVEGAME)))
+	const std::string quickSavePath = getQuickSavePath();
+	if(!CResourceHandler::get("local")->existsResource(ResourcePath(quickSavePath, EResType::SAVEGAME)))
 	{
 		if(verbose)
-			logGlobal->error("No quicksave file found at %s", QUICKSAVE_PATH);
+			logGlobal->error("No quicksave file found at %s", quickSavePath);
 		else
-			logGlobal->trace("No quicksave file found at %s", QUICKSAVE_PATH);
+			logGlobal->trace("No quicksave file found at %s", quickSavePath);
 		hasQuickSave = false;
 		if(cb && adventureInt)
 			adventureInt->updateActiveState();
 		return false;
 	}
-	auto error = GAME->server().canQuickLoadGame(QUICKSAVE_PATH);
+	auto error = GAME->server().canQuickLoadGame(quickSavePath);
 	if(error)
 	{
 		if(verbose)
-			logGlobal->error("Cannot quick load game at %s: %s", QUICKSAVE_PATH, *error);
+			logGlobal->error("Cannot quick load game at %s: %s", quickSavePath, *error);
 		else
-			logGlobal->trace("Cannot quick load game at %s: %s", QUICKSAVE_PATH, *error);
+			logGlobal->trace("Cannot quick load game at %s: %s", quickSavePath, *error);
 		hasQuickSave = false;
 		if(cb && adventureInt)
 			adventureInt->updateActiveState();
@@ -2027,12 +2031,18 @@ void CPlayerInterface::proposeQuickLoadingGame()
 	if(!checkQuickLoadingGame(true))
 		return;
 
-	auto onYes = [this]() -> void
+	const std::string quickSavePath = getQuickSavePath();
+	auto onYes = [quickSavePath]() -> void
 	{
-		GAME->server().quickLoadGame(QUICKSAVE_PATH);
+		GAME->server().quickLoadGame(quickSavePath);
 	};
 
 	GAME->interface()->showYesNoDialog(LIBRARY->generaltexth->translate("vcmi.adventureMap.confirmQuickLoadGame"), onYes, nullptr);
+}
+
+std::string CPlayerInterface::getQuickSavePath() const
+{
+	return SavegamePath::getPath(*cb->getStartInfo(), *cb->getMapHeader(), "Quicksave");
 }
 
 bool CPlayerInterface::capturedAllEvents()

--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -116,9 +116,8 @@
 
 #include "../lib/spells/CSpell.h"
 
-#include "../lib/texts/TextOperations.h"
-
 #include "../lib/filesystem/Filesystem.h"
+#include "../lib/filesystem/SavegamePath.h"
 
 
 // The macro below is used to mark functions that are called by client when game state changes.
@@ -144,7 +143,6 @@ CPlayerInterface::CPlayerInterface(PlayerColor Player):
 	makingTurn = false;
 	showingDialog = new ConditionalWait();
 	cingconsole = new CInGameConsole();
-	autosaveCount = 0;
 	isAutoFightOn = false;
 	isAutoFightEndBattle = false;
 	ignoreEvents = false;
@@ -255,49 +253,11 @@ void CPlayerInterface::performAutosave()
 	int frequency = static_cast<int>(settings["general"]["saveFrequency"].Integer());
 	if(frequency > 0 && cb->getCalendar().getCurrentDay() % frequency == 0)
 	{
-		bool usePrefix = settings["general"]["useSavePrefix"].Bool();
-		std::string prefix = std::string();
-
-		if(usePrefix)
-		{
-			prefix = settings["general"]["savePrefix"].String();
-			if(prefix.empty())
-			{
-				std::string name = cb->getMapHeader()->name.toString();
-				int txtlen = TextOperations::getUnicodeCharactersCount(name);
-
-				TextOperations::trimRightUnicode(name, std::max(0, txtlen - 14));
-				auto const & isSymbolIllegal = [&](char c) {
-					static const std::string forbiddenChars("\\/:*?\"<>| ");
-
-					bool charForbidden = forbiddenChars.find(c) != std::string::npos;
-					bool charNonprintable = static_cast<unsigned char>(c) < static_cast<unsigned char>(' ');
-
-					return charForbidden || charNonprintable;
-				};
-				std::replace_if(name.begin(), name.end(), isSymbolIllegal, '_' );
-
-				prefix = vstd::getFormattedDateTime(cb->getStartInfo()->startTime, "%Y-%m-%d_%H-%M") + "_" + name + "/";
-			}
-		}
-
-		autosaveCount++;
-
-		int autosaveCountLimit = settings["general"]["autosaveCountLimit"].Integer();
-		if(autosaveCountLimit > 0)
-		{
-			cb->save("Saves/Autosave/" + prefix + std::to_string(autosaveCount), false);
-			autosaveCount %= autosaveCountLimit;
-		}
-		else
-		{
-			auto calendar = cb->getCalendar();
-			std::string stringifiedDate = std::to_string(calendar.getMonth())
-					+ std::to_string(calendar.getWeek())
-					+ std::to_string(calendar.getDayOfWeek());
-
-			cb->save("Saves/Autosave/" + prefix + stringifiedDate, false);
-		}
+		const auto calendar = cb->getCalendar();
+		const auto autosaveCountLimit = static_cast<int>(settings["general"]["autosaveCountLimit"].Integer());
+		cb->saveAutosave(
+			SavegamePath::getAutosavePath(*cb->getStartInfo(), *cb->getMapHeader(), calendar),
+			autosaveCountLimit);
 	}
 }
 

--- a/client/CPlayerInterface.h
+++ b/client/CPlayerInterface.h
@@ -58,7 +58,6 @@ namespace boost
 class CPlayerInterface : public CGameInterface
 {
 	bool ignoreEvents;
-	int autosaveCount;
 
 	const std::string QUICKSAVE_PATH = "Saves/Quicksave";
 

--- a/client/CPlayerInterface.h
+++ b/client/CPlayerInterface.h
@@ -59,8 +59,6 @@ class CPlayerInterface : public CGameInterface
 {
 	bool ignoreEvents;
 
-	const std::string QUICKSAVE_PATH = "Saves/Quicksave";
-
 	struct PendingDialog
 	{
 		enum class Type : std::uint8_t { NonBlocking, Blocking };
@@ -270,4 +268,5 @@ private:
 	void acceptTurn(QueryID queryID, bool hotseatWait); //used during hot seat after your turn message is close
 	void initializeHeroTownList();
 	int getLastIndex(std::string namePrefix);
+	std::string getQuickSavePath() const;
 };

--- a/client/GameInstance.cpp
+++ b/client/GameInstance.cpp
@@ -22,6 +22,7 @@
 #include "../lib/CConfigHandler.h"
 #include "../lib/GameLibrary.h"
 #include "../lib/callback/CCallback.h"
+#include "../lib/filesystem/SavegamePath.h"
 #include "../lib/texts/CGeneralTextHandler.h"
 
 std::unique_ptr<GameInstance> GAME = nullptr;
@@ -144,8 +145,6 @@ void GameInstance::onAppPaused()
 
 void GameInstance::pauseAutoSave()
 {
-	const std::string autoSaveName = "Saves/PauseAutosave";
-
 	logGlobal->info("Received pause save game request");
 	if(!GAME->interface() || !GAME->interface()->cb)
 	{
@@ -165,5 +164,10 @@ void GameInstance::pauseAutoSave()
 		return;
 	}
 
-	GAME->interface()->cb->save(autoSaveName, false);
+	const std::string autosavePath = SavegamePath::getPath(
+		*GAME->interface()->cb->getStartInfo(),
+		*GAME->interface()->cb->getMapHeader(),
+		"PauseAutosave"
+	);
+	GAME->interface()->cb->save(autosavePath, false);
 }

--- a/client/lobby/CSavingScreen.cpp
+++ b/client/lobby/CSavingScreen.cpp
@@ -19,7 +19,6 @@
 #include "../widgets/Buttons.h"
 #include "../widgets/CTextInput.h"
 
-#include "../../lib/CConfigHandler.h"
 #include "../../lib/callback/CCallback.h"
 #include "../../lib/texts/CGeneralTextHandler.h"
 #include "../../lib/StartInfo.h"
@@ -87,8 +86,7 @@ void CSavingScreen::saveGame()
 
 	auto overWrite = [this, path]() -> void
 	{
-		Settings lastSave = settings.write["general"]["lastSave"];
-		lastSave->String() = path;
+		tabSel->rememberSave(path);
 		GAME->interface()->cb->save(path, true);
 		close();
 	};

--- a/client/lobby/CSavingScreen.cpp
+++ b/client/lobby/CSavingScreen.cpp
@@ -89,14 +89,25 @@ void CSavingScreen::saveGame()
 		close();
 	};
 
-	if(CResourceHandler::get("local")->existsResource(ResourcePath(path, EResType::SAVEGAME)))
+	auto confirmOverwrite = [this, path, overWrite]()
 	{
-		std::string hlp = LIBRARY->generaltexth->allTexts[493]; //%s exists. Overwrite?
-		boost::algorithm::replace_first(hlp, "%s", tabSel->inputName->getText());
-		GAME->interface()->showYesNoDialog(hlp, overWrite, nullptr);
+		if(CResourceHandler::get("local")->existsResource(ResourcePath(path, EResType::SAVEGAME)))
+		{
+			std::string hlp = LIBRARY->generaltexth->allTexts[493]; //%s exists. Overwrite?
+			boost::algorithm::replace_first(hlp, "%s", tabSel->inputName->getText());
+			GAME->interface()->showYesNoDialog(hlp, overWrite, nullptr);
+		}
+		else
+		{
+			overWrite();
+		}
+	};
+
+	if(SavegamePath::isAutosaveName(tabSel->inputName->getText()))
+	{
+		const std::string warning = LIBRARY->generaltexth->translate("vcmi.savingScreen.autosaveNameWarning");
+		GAME->interface()->showYesNoDialog(warning, confirmOverwrite, nullptr);
 	}
 	else
-	{
-		overWrite();
-	}
+		confirmOverwrite();
 }

--- a/client/lobby/CSavingScreen.cpp
+++ b/client/lobby/CSavingScreen.cpp
@@ -24,6 +24,7 @@
 #include "../../lib/texts/CGeneralTextHandler.h"
 #include "../../lib/StartInfo.h"
 #include "../../lib/filesystem/Filesystem.h"
+#include "../../lib/filesystem/SavegamePath.h"
 #include "../../lib/mapping/CMapInfo.h"
 #include "../../lib/mapping/CMapHeader.h"
 #include "../../lib/GameLibrary.h"
@@ -37,6 +38,9 @@ CSavingScreen::CSavingScreen()
 	localMi->mapHeader = std::unique_ptr<CMapHeader>(new CMapHeader(*GAME->interface()->cb->getMapHeader()));
 
 	tabSel = std::make_shared<SelectionTab>(screenType);
+	tabSel->curFolder = SavegamePath::getGameDirectoryName(
+		*GAME->interface()->cb->getStartInfo(),
+		*GAME->interface()->cb->getMapHeader());
 	tabSel->callOnSelect = std::bind(&CSavingScreen::changeSelection, this, _1);
 	tabSel->toggleMode();
 	curTab = tabSel;

--- a/client/lobby/CSelectionBase.cpp
+++ b/client/lobby/CSelectionBase.cpp
@@ -147,8 +147,8 @@ void CSelectionBase::toggleTab(std::shared_ptr<CIntObject> tab)
 
 	if(tabSel->showRandom && tab != tabOpt)
 	{
-		tabSel->curFolder = "";
 		tabSel->showRandom = false;
+		tabSel->setCurrentFolder("");
 		tabSel->filter(0, true);
 	}
 

--- a/client/lobby/RandomMapTab.cpp
+++ b/client/lobby/RandomMapTab.cpp
@@ -273,7 +273,7 @@ void RandomMapTab::updateMapInfoByHost()
 	mapInfo->isRandomMap = true;
 	mapInfo->mapHeader = std::make_unique<CMapHeader>();
 	mapInfo->mapHeader->version = EMapFormat::VCMI;
-	mapInfo->mapHeader->name.appendLocalString(EMetaText::GENERAL_TXT, 740);
+	mapInfo->mapHeader->name = mapGenOptions->getMapName();
 	mapInfo->mapHeader->description.appendLocalString(EMetaText::GENERAL_TXT, 741);
 
 	if(mapGenOptions->getWaterContent() != EWaterContent::RANDOM)

--- a/client/lobby/RandomMapTab.cpp
+++ b/client/lobby/RandomMapTab.cpp
@@ -141,8 +141,10 @@ RandomMapTab::RandomMapTab():
 		w->addCallback([&]()
 		{
 			(static_cast<CLobbyScreen *>(parent))->toggleTab((static_cast<CLobbyScreen *>(parent))->tabSel);
-			(static_cast<CLobbyScreen *>(parent))->tabSel->showRandom = true;
-			(static_cast<CLobbyScreen *>(parent))->tabSel->filter(0, true);
+			auto selectionTab = (static_cast<CLobbyScreen *>(parent))->tabSel;
+			selectionTab->showRandom = true;
+			selectionTab->setCurrentFolder("RandomMaps/");
+			selectionTab->filter(0, true);
 		});
 	}
 

--- a/client/lobby/SelectionTab.cpp
+++ b/client/lobby/SelectionTab.cpp
@@ -42,6 +42,7 @@
 #include "../../lib/CConfigHandler.h"
 #include "../../lib/IGameSettings.h"
 #include "../../lib/filesystem/Filesystem.h"
+#include "../../lib/filesystem/SavegamePath.h"
 #include "../../lib/campaign/CampaignState.h"
 #include "../../lib/mapping/CMapInfo.h"
 #include "../../lib/mapping/CMapHeader.h"
@@ -389,6 +390,8 @@ void SelectionTab::toggleMode()
 {
 	allItems.clear();
 	curItems.clear();
+	resourceFiles.clear();
+	folderCompatibility.clear();
 	const bool restoreSelection = curFolder.empty();
 	if(GAME->server().isGuest())
 	{
@@ -402,23 +405,21 @@ void SelectionTab::toggleMode()
 		case ESelectionScreen::newGame:
 			{
 				inputName->disable();
-				auto files = getFiles("Maps/", EResType::MAP);
-				files.erase(ResourcePath("Maps/Tutorial.tut", EResType::MAP));
-				files.erase(ResourcePath("Maps/BattleOnlyMode.vmap", EResType::MAP));
-				parseMaps(files);
+				resourceFiles = getFiles("Maps/", EResType::MAP);
+				resourceFiles.erase(ResourcePath("Maps/Tutorial.tut", EResType::MAP));
+				resourceFiles.erase(ResourcePath("Maps/BattleOnlyMode.vmap", EResType::MAP));
 				break;
 			}
 
 		case ESelectionScreen::loadGame:
 			{
 				inputName->disable();
-				auto unsupported = parseSaves(getFiles("Saves/", EResType::SAVEGAME));
-				handleUnsupportedSavegames(unsupported);
+				resourceFiles = getFiles("Saves/", EResType::SAVEGAME);
 				break;
 			}
 
 		case ESelectionScreen::saveGame:
-			parseSaves(getFiles("Saves/", EResType::SAVEGAME));
+			resourceFiles = getFiles("Saves/", EResType::SAVEGAME);
 			inputName->enable();
 			inputName->activate();
 			if(!restoreSelection)
@@ -426,13 +427,14 @@ void SelectionTab::toggleMode()
 			break;
 
 		case ESelectionScreen::campaignList:
-			parseCampaigns(getFiles("Maps/", EResType::CAMPAIGN));
+			resourceFiles = getFiles("Maps/", EResType::CAMPAIGN);
 			break;
 
 		default:
 			assert(0);
 			break;
 		}
+		parseCurrentFolder();
 		if(slider)
 		{
 			slider->block(false);
@@ -452,6 +454,12 @@ void SelectionTab::toggleMode()
 	slider->setAmount((int)curItems.size());
 	updateListItems();
 	redraw();
+}
+
+void SelectionTab::setCurrentFolder(std::string folder)
+{
+	curFolder = std::move(folder);
+	parseCurrentFolder();
 }
 
 void SelectionTab::clickReleased(const Point & cursorPosition)
@@ -667,6 +675,12 @@ void SelectionTab::filter(int size, bool selectFirst)
 
 	for(auto elem : allItems)
 	{
+		if(elem->isFolder)
+		{
+			curItems.push_back(elem);
+			continue;
+		}
+
 		if((elem->mapHeader && (!size || elem->mapHeader->width == size)) || tabType == ESelectionScreen::campaignList)
 		{
 			if(!isMapCompatibleWithLobbyPlayerCount(*elem))
@@ -675,38 +689,8 @@ void SelectionTab::filter(int size, bool selectFirst)
 				continue;
 			}
 
-			if(showRandom)
-				curFolder = "RandomMaps/";
-
-			auto [folderName, baseFolder, parentExists, fileInFolder] = checkSubfolder(elem->originalFileURI);
-
-			if((showRandom && baseFolder != "RandomMaps") || (!showRandom && baseFolder == "RandomMaps"))
-				continue;
-
-			if(parentExists && !showRandom)
-			{
-				auto folder = std::make_shared<ElementInfo>();
-				folder->isFolder = true;
-				folder->folderName = "..     (" + curFolder + ")";
-				auto itemIt = std::ranges::find_if(curItems, [](std::shared_ptr<ElementInfo> e) { return boost::starts_with(e->folderName, ".."); });
-				if (itemIt == curItems.end()) {
-					curItems.push_back(folder);
-				}			
-			}
-
-			if (!enableUiEnhancements || checkNameFilter(elem->name)) {
-				auto folder = std::make_shared<ElementInfo>();
-				folder->isFolder = true;
-				folder->folderName = folderName;
-				folder->isAutoSaveFolder = boost::starts_with(baseFolder, "Autosave/") && folderName != "Autosave";
-				auto itemIt = std::ranges::find_if(curItems, [folder](std::shared_ptr<ElementInfo> e) { return e->folderName == folder->folderName; });
-				if (itemIt == curItems.end() && folderName != "") {
-					curItems.push_back(folder);
-				}
-
-				if(fileInFolder)
-					curItems.push_back(elem);
-			}
+			if(!enableUiEnhancements || checkNameFilter(elem->name))
+				curItems.push_back(elem);
 		}
 	}
 
@@ -794,7 +778,8 @@ void SelectionTab::select(int position)
 	else if(position >= listItems.size())
 		slider->scrollBy(position - (int)listItems.size() + 1);
 
-	if(curItems[py]->isFolder) {
+	if(curItems[py]->isFolder)
+	{
 		if(boost::starts_with(curItems[py]->folderName, ".."))
 		{
 			std::vector<std::string> filetree;
@@ -805,14 +790,12 @@ void SelectionTab::select(int position)
 		}
 		else
 			curFolder += curItems[py]->folderName + "/";
+
+		parseCurrentFolder();
 		filter(-1);
 		slider->scrollTo(0);
 
-		int firstPos = std::ranges::find_if(curItems, [](std::shared_ptr<ElementInfo> e) { return !e->isFolder; }) - curItems.begin();
-		if(firstPos < curItems.size())
-		{
-			selectAbs(firstPos);
-		}
+		selectNewestFile(tabType == ESelectionScreen::saveGame);
 
 		return;
 	}
@@ -901,34 +884,46 @@ int SelectionTab::getLine(const Point & clickPos) const
 	return line;
 }
 
-void SelectionTab::selectFileName(std::string fname)
+bool SelectionTab::selectFileName(std::string fname)
 {
 	boost::to_upper(fname);
 
-	for(int i = (int)allItems.size() - 1; i >= 0; i--)
+	for(const auto & file : resourceFiles)
 	{
-		if(boost::to_upper_copy(allItems[i]->fileURI) == fname)
+		if(file.getName() == fname)
 		{
-			auto [folderName, baseFolder, parentExists, fileInFolder] = checkSubfolder(allItems[i]->originalFileURI);
+			auto [folderName, baseFolder, parentExists, fileInFolder] = checkSubfolder(file.getOriginalName());
 			// Keep scenario selection on the root list: random maps are accessed via dedicated UI path.
-			curFolder = (baseFolder != "" && baseFolder != "RandomMaps") ? baseFolder + "/" : "";
+			const bool isRandomMap = tabType == ESelectionScreen::newGame && baseFolder == "RandomMaps";
+			const std::string selectedFolder = baseFolder.empty() || isRandomMap
+				? ""
+				: baseFolder + "/";
+			if(curFolder != selectedFolder)
+			{
+				curFolder = selectedFolder;
+				parseCurrentFolder();
+			}
+			break;
 		}
-
 	}
 
 	filter(-1);
 
 	for(int i = (int)curItems.size() - 1; i >= 0; i--)
 	{
-		if(boost::to_upper_copy(curItems[i]->fileURI) == fname)
+		if(!curItems[i]->isFolder && boost::to_upper_copy(curItems[i]->fileURI) == fname)
 		{
 			slider->scrollTo(i);
 			selectAbs(i);
-			return;
+			return true;
 		}
 	}
 
-	int firstPos = std::ranges::find_if(curItems, [](std::shared_ptr<ElementInfo> e) { return !e->isFolder; }) - curItems.begin();
+	int firstPos = std::ranges::find_if(curItems, [this](const std::shared_ptr<ElementInfo> & element)
+	{
+		return !element->isFolder
+			&& (tabType != ESelectionScreen::saveGame || !SavegamePath::isAutosaveName(element->fileURI));
+	}) - curItems.begin();
 	if(firstPos < curItems.size())
 	{
 		slider->scrollTo(firstPos);
@@ -941,19 +936,137 @@ void SelectionTab::selectFileName(std::string fname)
 
 	if(tabType == ESelectionScreen::saveGame && inputName->getText().empty())
 		inputName->setText(LIBRARY->generaltexth->translate("core.genrltxt.11"));
+
+	return false;
 }
 
-void SelectionTab::selectNewestFile()
+void SelectionTab::selectNewestFile(bool skipAutosaves)
 {
 	time_t newestTime = 0;
 	std::string newestFile = "";
-	for(int i = static_cast<int>(allItems.size()) - 1; i >= 0; i--)
-		if(allItems[i]->lastWrite > newestTime)
+	for(const auto & item : curItems)
+	{
+		if(item->isFolder)
+			continue;
+		if(skipAutosaves && SavegamePath::isAutosaveName(item->fileURI))
+			continue;
+
+		if(item->lastWrite > newestTime || (item->lastWrite == newestTime && item->fileURI > newestFile))
 		{
-			newestTime = allItems[i]->lastWrite;
-			newestFile = allItems[i]->fileURI;
+			newestTime = item->lastWrite;
+			newestFile = item->fileURI;
 		}
+	}
+
+	if(newestFile.empty())
+	{
+		selectionPos = curItems.size();
+		if(callOnSelect)
+			callOnSelect(nullptr);
+		return;
+	}
+
 	selectFileName(newestFile);
+}
+
+std::string SelectionTab::getLastSaveSettingName() const
+{
+	switch(GAME->server().getLoadMode())
+	{
+	case ELoadMode::SINGLE:
+		return "lastScenarioSave";
+	case ELoadMode::CAMPAIGN:
+		return "lastCampaignSave";
+	default:
+		return "";
+	}
+}
+
+void SelectionTab::rememberSave(const std::string & savePath) const
+{
+	Settings lastSave = settings.write["general"]["lastSave"];
+	lastSave->String() = savePath;
+
+	const auto settingName = getLastSaveSettingName();
+	if(!settingName.empty())
+	{
+		Settings modeSave = settings.write["general"][settingName];
+		modeSave->String() = savePath;
+	}
+}
+
+bool SelectionTab::openSaveDirectory(std::string folder)
+{
+	if(folder.empty())
+		return false;
+
+	while(boost::starts_with(folder, "/"))
+		folder.erase(folder.begin());
+	if(!boost::ends_with(folder, "/"))
+		folder += "/";
+
+	const auto previousFolder = curFolder;
+	curFolder = std::move(folder);
+	parseCurrentFolder();
+	filter(-1);
+
+	const bool hasCompatibleSave = std::ranges::any_of(curItems, [](const auto & item)
+	{
+		return !item->isFolder;
+	});
+	if(!hasCompatibleSave)
+	{
+		curFolder = previousFolder;
+		parseCurrentFolder();
+		filter(-1);
+		return false;
+	}
+
+	selectNewestFile();
+	return true;
+}
+
+void SelectionTab::restoreLastSave()
+{
+	const auto settingName = getLastSaveSettingName();
+	if(!settingName.empty())
+	{
+		const auto savePath = settings["general"][settingName].String();
+		if(selectFileName(savePath))
+			return;
+	}
+
+	curFolder.clear();
+	parseCurrentFolder();
+	filter(-1);
+
+	auto candidates = curItems;
+	std::ranges::sort(candidates, [](const auto & lhs, const auto & rhs)
+	{
+		if(lhs->lastWrite != rhs->lastWrite)
+			return lhs->lastWrite > rhs->lastWrite;
+		const auto & lhsName = lhs->isFolder ? lhs->folderName : lhs->fileURI;
+		const auto & rhsName = rhs->isFolder ? rhs->folderName : rhs->fileURI;
+		return lhsName > rhsName;
+	});
+
+	for(const auto & candidate : candidates)
+	{
+		if(candidate->isFolder)
+		{
+			if(!boost::starts_with(candidate->folderName, "..") && openSaveDirectory(candidate->folderName))
+				return;
+		}
+		else
+		{
+			selectFileName(candidate->fileURI);
+			return;
+		}
+	}
+
+	selectionPos = curItems.size();
+	if(callOnSelect)
+		callOnSelect(nullptr);
 }
 
 std::shared_ptr<ElementInfo> SelectionTab::getSelectedMapInfo() const
@@ -975,8 +1088,7 @@ void SelectionTab::rememberCurrentSelection()
 	}
 	else if(tabType == ESelectionScreen::loadGame)
 	{
-		Settings lastSave = settings.write["general"]["lastSave"];
-		lastSave->String() = selectedMapInfo->fileURI;
+		rememberSave(selectedMapInfo->fileURI);
 	}
 	else if(tabType == ESelectionScreen::campaignList)
 	{
@@ -996,10 +1108,10 @@ void SelectionTab::restoreLastSelection()
 		selectFileName(settings["general"]["lastCampaign"].String());
 		break;
 	case ESelectionScreen::loadGame:
-		selectNewestFile();
+		restoreLastSave();
 		break;
 	case ESelectionScreen::saveGame:
-		selectFileName(settings["general"]["lastSave"].String());
+		selectNewestFile(true);
 	}
 }
 
@@ -1071,10 +1183,10 @@ void SelectionTab::parseMaps(const std::unordered_set<ResourcePath> & files)
 	std::vector<ResourcePath> filesVector(files.begin(), files.end());
 
 	// every entry is written by a single thread only, entries of failed maps stay empty
-	allItems.clear();
-	allItems.resize(filesVector.size());
+	const size_t offset = allItems.size();
+	allItems.resize(offset + filesVector.size());
 
-	tbb::parallel_for(tbb::blocked_range<size_t>(0, filesVector.size()), [this, &filesVector](const tbb::blocked_range<size_t> & r)
+	tbb::parallel_for(tbb::blocked_range<size_t>(0, filesVector.size()), [this, &filesVector, offset](const tbb::blocked_range<size_t> & r)
 	{
 		for(auto i = r.begin(); i != r.end(); i++)
 		{
@@ -1086,7 +1198,7 @@ void SelectionTab::parseMaps(const std::unordered_set<ResourcePath> & files)
 				mapInfo->name = mapInfo->getNameForList();
 
 				if (isMapSupported(*mapInfo))
-					allItems[i] = mapInfo;
+					allItems[offset + i] = mapInfo;
 			}
 			catch(std::exception & e)
 			{
@@ -1095,7 +1207,7 @@ void SelectionTab::parseMaps(const std::unordered_set<ResourcePath> & files)
 		}
 	});
 
-	vstd::erase(allItems, nullptr);
+	allItems.erase(std::remove(allItems.begin() + offset, allItems.end(), nullptr), allItems.end());
 
 	auto timeElapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - timeStart);
 	logGlobal->debug("Parsing %d maps took %d ms", files.size(), timeElapsed.count());
@@ -1125,33 +1237,8 @@ std::vector<ResourcePath> SelectionTab::parseSaves(const std::unordered_set<Reso
 				mapInfo->saveInit(file);
 				mapInfo->name = mapInfo->getNameForList();
 
-				// Filter out other game modes
-				bool isCampaign = mapInfo->scenarioOptionsOfSave->mode == EStartMode::CAMPAIGN;
-				bool isMultiplayer = mapInfo->amountOfHumanPlayersInSave > 1;
-				bool isTutorial = boost::to_upper_copy(mapInfo->scenarioOptionsOfSave->mapname) == "MAPS/TUTORIAL";
-				switch(loadMode)
-				{
-				case ELoadMode::SINGLE:
-					if(isCampaign || isTutorial)
-						mapInfo->mapHeader.reset();
-					break;
-				case ELoadMode::CAMPAIGN:
-					if(!isCampaign)
-						mapInfo->mapHeader.reset();
-					break;
-				case ELoadMode::TUTORIAL:
-					if(!isTutorial)
-						mapInfo->mapHeader.reset();
-					break;
-				case ELoadMode::MULTI:
-					if(!isMultiplayer)
-						mapInfo->mapHeader.reset();
-					break;
-				default:
-					assert(0);
+				if(!isSaveCompatible(*mapInfo, loadMode))
 					mapInfo->mapHeader.reset();
-					break;
-				}
 
 				allItems[offset + i] = mapInfo;
 			}
@@ -1178,6 +1265,143 @@ std::vector<ResourcePath> SelectionTab::parseSaves(const std::unordered_set<Reso
 	logGlobal->debug("Parsing %d saves took %d ms", filesVector.size(), timeElapsed.count());
 
 	return unsupported;
+}
+
+bool SelectionTab::isSaveCompatible(const CMapInfo & info, ELoadMode loadMode) const
+{
+	if(!info.scenarioOptionsOfSave)
+		return false;
+
+	const bool isCampaign = info.scenarioOptionsOfSave->mode == EStartMode::CAMPAIGN;
+	const bool isMultiplayer = info.amountOfHumanPlayersInSave > 1;
+	const bool isTutorial = boost::iequals(info.scenarioOptionsOfSave->mapname, "Maps/Tutorial");
+
+	switch(loadMode)
+	{
+	case ELoadMode::SINGLE:
+		return !isCampaign && !isTutorial;
+	case ELoadMode::CAMPAIGN:
+		return isCampaign;
+	case ELoadMode::TUTORIAL:
+		return isTutorial;
+	case ELoadMode::MULTI:
+		return isMultiplayer;
+	default:
+		assert(0);
+		return false;
+	}
+}
+
+std::optional<bool> SelectionTab::isFolderCompatible(
+	const std::string & folderName,
+	const std::vector<ResourcePath> & files)
+{
+	const auto loadMode = GAME->server().getLoadMode();
+	const std::string cacheKey = std::to_string(static_cast<int>(loadMode))
+		+ ":" + curFolder + folderName;
+	if(const auto found = folderCompatibility.find(cacheKey); found != folderCompatibility.end())
+		return found->second;
+
+	// Autosaves always stay in their game's directory, unlike stray manual saves.
+	auto candidates = files;
+	std::ranges::sort(candidates, [](const ResourcePath & lhs, const ResourcePath & rhs)
+	{
+		const bool lhsAutosave = SavegamePath::isAutosaveName(lhs.getOriginalName());
+		const bool rhsAutosave = SavegamePath::isAutosaveName(rhs.getOriginalName());
+		if(lhsAutosave != rhsAutosave)
+			return lhsAutosave;
+
+		const auto lhsTime = CResourceHandler::get()->getLastWriteTime(lhs);
+		const auto rhsTime = CResourceHandler::get()->getLastWriteTime(rhs);
+		if(lhsTime != rhsTime)
+			return lhsTime > rhsTime;
+		return lhs.getName() > rhs.getName();
+	});
+
+	for(const auto & file : candidates)
+	{
+		try
+		{
+			CMapInfo info;
+			info.saveInit(file);
+			return folderCompatibility[cacheKey] = isSaveCompatible(info, loadMode);
+		}
+		catch(const std::exception & e) // NOSONAR: malformed saves can throw several exception types
+		{
+			logGlobal->debug("Failed to inspect representative save %s: %s", file.getOriginalName(), e.what());
+		}
+	}
+
+	// Keep unreadable folders visible so that their saves are never hidden from the player.
+	return folderCompatibility[cacheKey] = std::nullopt;
+}
+
+void SelectionTab::parseCurrentFolder()
+{
+	allItems.clear();
+	std::unordered_set<ResourcePath> currentFiles;
+	std::map<std::string, std::vector<ResourcePath>> folders;
+	std::map<std::string, std::time_t> folderLastWrite;
+
+	if(!curFolder.empty() && !showRandom)
+	{
+		auto parentFolder = std::make_shared<ElementInfo>();
+		parentFolder->isFolder = true;
+		parentFolder->folderName = "..     (" + curFolder + ")";
+		allItems.push_back(parentFolder);
+	}
+
+	for(const auto & file : resourceFiles)
+	{
+		auto [folderName, baseFolder, parentExists, fileInFolder] = checkSubfolder(file.getOriginalName());
+		if(!folderName.empty())
+		{
+			folders[folderName].push_back(file);
+			folderLastWrite[folderName] = std::max(
+				folderLastWrite[folderName],
+				CResourceHandler::get()->getLastWriteTime(file));
+		}
+		if(fileInFolder)
+			currentFiles.insert(file);
+	}
+
+	switch(tabType)
+	{
+	case ESelectionScreen::newGame:
+		parseMaps(currentFiles);
+		break;
+	case ESelectionScreen::loadGame:
+		handleUnsupportedSavegames(parseSaves(currentFiles));
+		break;
+	case ESelectionScreen::saveGame:
+		parseSaves(currentFiles);
+		break;
+	case ESelectionScreen::campaignList:
+		parseCampaigns(currentFiles);
+		break;
+	default:
+		assert(0);
+		break;
+	}
+
+	for(const auto & [folderName, files] : folders)
+	{
+		if(tabType == ESelectionScreen::newGame && folderName == "RandomMaps")
+			continue;
+		if(tabType == ESelectionScreen::loadGame || tabType == ESelectionScreen::saveGame)
+		{
+			const auto compatible = isFolderCompatible(folderName, files);
+			if(compatible && !*compatible)
+				continue;
+		}
+
+		auto folder = std::make_shared<ElementInfo>();
+		folder->isFolder = true;
+		folder->folderName = folderName;
+		folder->isAutoSaveFolder = boost::starts_with(curFolder, "Autosave/");
+		folder->lastWrite = folderLastWrite[folderName];
+		allItems.push_back(folder);
+	}
 }
 
 void SelectionTab::handleUnsupportedSavegames(const std::vector<ResourcePath> & files)

--- a/client/lobby/SelectionTab.cpp
+++ b/client/lobby/SelectionTab.cpp
@@ -389,6 +389,7 @@ void SelectionTab::toggleMode()
 {
 	allItems.clear();
 	curItems.clear();
+	const bool restoreSelection = curFolder.empty();
 	if(GAME->server().isGuest())
 	{
 		if(slider)
@@ -420,7 +421,8 @@ void SelectionTab::toggleMode()
 			parseSaves(getFiles("Saves/", EResType::SAVEGAME));
 			inputName->enable();
 			inputName->activate();
-			restoreLastSelection();
+			if(!restoreSelection)
+				inputName->setText(LIBRARY->generaltexth->translate("core.genrltxt.11"));
 			break;
 
 		case ESelectionScreen::campaignList:
@@ -442,7 +444,7 @@ void SelectionTab::toggleMode()
 			GAME->server().setCampaignState(GAME->server().campaignStateToSend);
 			GAME->server().campaignStateToSend.reset();
 		}
-		else
+		else if(restoreSelection)
 		{
 			restoreLastSelection();
 		}

--- a/client/lobby/SelectionTab.h
+++ b/client/lobby/SelectionTab.h
@@ -96,6 +96,7 @@ public:
 
 	SelectionTab(ESelectionScreen Type);
 	void toggleMode();
+	void setCurrentFolder(std::string folder);
 
 	void clickReleased(const Point & cursorPosition) override;
 	void keyPressed(EShortcut key) override;
@@ -113,10 +114,11 @@ public:
 	void updateListItems();
 	int getLine() const;
 	int getLine(const Point & position) const;
-	void selectFileName(std::string fname);
-	void selectNewestFile();
+	bool selectFileName(std::string fname);
+	void selectNewestFile(bool skipAutosaves = false);
 	std::shared_ptr<ElementInfo> getSelectedMapInfo() const;
 	void setRequiredHumanPlayers(size_t players);
+	void rememberSave(const std::string & savePath) const;
 	void rememberCurrentSelection();
 	void restoreLastSelection();
 	bool checkNameFilter(const std::string & fullstring) const;
@@ -140,13 +142,21 @@ private:
 
 	bool enableUiEnhancements;
 	std::shared_ptr<CButton> buttonCampaignSet;
+	std::unordered_set<ResourcePath> resourceFiles;
+	std::unordered_map<std::string, std::optional<bool>> folderCompatibility;
 
 	auto checkSubfolder(std::string path);
 	size_t getRequiredHumanPlayers() const;
 	bool isMapCompatibleWithLobbyPlayerCount(const ElementInfo & info) const;
+	bool isSaveCompatible(const CMapInfo & info, ELoadMode loadMode) const;
+	std::optional<bool> isFolderCompatible(const std::string & folderName, const std::vector<ResourcePath> & files);
+	std::string getLastSaveSettingName() const;
+	bool openSaveDirectory(std::string folder);
+	void restoreLastSave();
 
 	bool isMapSupported(const CMapInfo & info);
 	void parseMaps(const std::unordered_set<ResourcePath> & files);
+	void parseCurrentFolder();
 	std::vector<ResourcePath> parseSaves(const std::unordered_set<ResourcePath> & files);
 	void parseCampaigns(const std::unordered_set<ResourcePath> & files);
 	std::unordered_set<ResourcePath> getFiles(std::string dirURI, EResType resType);

--- a/config/schemas/settings.json
+++ b/config/schemas/settings.json
@@ -38,8 +38,6 @@
 				"hapticFeedback",
 				"longTouchTimeMilliseconds",
 				"autosaveCountLimit",
-				"useSavePrefix",
-				"savePrefix",
 				"saveBeforeVisit",
 				"startTurnAutosave",
 				"enableUiEnhancements",
@@ -138,14 +136,6 @@
 				"autosaveCountLimit" : {
 					"type" : "number",
 					"default": 5
-				},
-				"useSavePrefix" : {
-					"type": "boolean",
-					"default": true
-				},
-				"savePrefix" : {
-					"type": "string",
-					"default": ""
 				},
 				"startTurnAutosave" : {
 					"type": "boolean",

--- a/config/schemas/settings.json
+++ b/config/schemas/settings.json
@@ -27,6 +27,8 @@
 				"language",
 				"gameDataLanguage",
 				"lastSave",
+				"lastScenarioSave",
+				"lastCampaignSave",
 				"lastSettingsTab",
 				"lastCampaign",
 				"lastDifficulty",
@@ -88,6 +90,14 @@
 				"lastSave" : {
 					"type" : "string",
 					"default" : "NEWGAME"
+				},
+				"lastScenarioSave" : {
+					"type" : "string",
+					"default" : ""
+				},
+				"lastCampaignSave" : {
+					"type" : "string",
+					"default" : ""
 				},
 				"lastSettingsTab" : {
 					"type" : "number",

--- a/launcher/settingsView/csettingsview_moc.cpp
+++ b/launcher/settingsView/csettingsview_moc.cpp
@@ -299,7 +299,9 @@ void CSettingsView::loadToggleButtonSettings()
 	setCheckbuttonState(ui->buttonRepositoryExtra, settings["launcher"]["extraRepositoryEnabled"].Bool());
 
 	setCheckbuttonState(ui->buttonIgnoreSslErrors, settings["launcher"]["ignoreSslErrors"].Bool());
-	setCheckbuttonState(ui->buttonAutoSave, settings["general"]["saveFrequency"].Integer() > 0);
+	const bool autosaveEnabled = settings["general"]["saveFrequency"].Integer() > 0;
+	setCheckbuttonState(ui->buttonAutoSave, autosaveEnabled);
+	ui->spinBoxAutoSaveLimit->setEnabled(autosaveEnabled);
 
 	setCheckbuttonState(ui->buttonAutoSavePrefix, settings["general"]["useSavePrefix"].Bool());
 
@@ -656,6 +658,7 @@ void CSettingsView::on_buttonAutoSave_toggled(bool value)
 	Settings node = settings.write["general"]["saveFrequency"];
 	node->Integer() = value ? 1 : 0;
 	updateCheckbuttonText(ui->buttonAutoSave);
+	ui->spinBoxAutoSaveLimit->setEnabled(value);
 }
 
 void CSettingsView::on_comboBoxLanguage_currentIndexChanged(int index)

--- a/launcher/settingsView/csettingsview_moc.cpp
+++ b/launcher/settingsView/csettingsview_moc.cpp
@@ -243,9 +243,6 @@ void CSettingsView::loadSettings()
 
 	ui->spinBoxAutoSaveLimit->setValue(settings["general"]["autosaveCountLimit"].Integer());
 
-	ui->lineEditAutoSavePrefix->setText(QString::fromStdString(settings["general"]["savePrefix"].String()));
-	ui->lineEditAutoSavePrefix->setEnabled(settings["general"]["useSavePrefix"].Bool());
-
 	Languages::fillLanguages(ui->comboBoxLanguage, false);
 	fillValidRenderers();
 
@@ -302,8 +299,6 @@ void CSettingsView::loadToggleButtonSettings()
 	const bool autosaveEnabled = settings["general"]["saveFrequency"].Integer() > 0;
 	setCheckbuttonState(ui->buttonAutoSave, autosaveEnabled);
 	ui->spinBoxAutoSaveLimit->setEnabled(autosaveEnabled);
-
-	setCheckbuttonState(ui->buttonAutoSavePrefix, settings["general"]["useSavePrefix"].Bool());
 
 	setCheckbuttonState(ui->buttonRelativeCursorMode, settings["general"]["userRelativePointer"].Bool());
 	setCheckbuttonState(ui->buttonHapticFeedback, settings["general"]["hapticFeedback"].Bool());
@@ -813,24 +808,10 @@ void CSettingsView::on_buttonVSync_toggled(bool value)
 	ui->spinBoxFramerateLimit->setDisabled(settings["video"]["vsync"].Bool());
 }
 
-void CSettingsView::on_buttonAutoSavePrefix_toggled(bool value)
-{
-	Settings node = settings.write["general"]["useSavePrefix"];
-	node->Bool() = value;
-	ui->lineEditAutoSavePrefix->setEnabled(value);
-	updateCheckbuttonText(ui->buttonAutoSavePrefix);
-}
-
 void CSettingsView::on_spinBoxAutoSaveLimit_valueChanged(int arg1)
 {
 	Settings node = settings.write["general"]["autosaveCountLimit"];
 	node->Float() = arg1;
-}
-
-void CSettingsView::on_lineEditAutoSavePrefix_textEdited(const QString & arg1)
-{
-	Settings node = settings.write["general"]["savePrefix"];
-	node->String() = arg1.toStdString();
 }
 
 void CSettingsView::on_sliderReservedArea_valueChanged(int arg1)

--- a/launcher/settingsView/csettingsview_moc.h
+++ b/launcher/settingsView/csettingsview_moc.h
@@ -67,9 +67,7 @@ private slots:
 	void on_buttonConfigEditor_clicked();
 	void on_spinBoxFramerateLimit_valueChanged(int arg1);
 	void on_buttonVSync_toggled(bool value);
-	void on_buttonAutoSavePrefix_toggled(bool value);
 	void on_spinBoxAutoSaveLimit_valueChanged(int arg1);
-	void on_lineEditAutoSavePrefix_textEdited(const QString &arg1);
 	void on_sliderReservedArea_valueChanged(int arg1);
 	void on_comboBoxRendererType_currentTextChanged(const QString &arg1);
 

--- a/launcher/settingsView/csettingsview_moc.ui
+++ b/launcher/settingsView/csettingsview_moc.ui
@@ -616,22 +616,6 @@
          </property>
         </widget>
        </item>
-       <item row="8" column="1">
-        <widget class="QToolButton" name="buttonAutoSavePrefix">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="text">
-          <string/>
-         </property>
-         <property name="checkable">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
        <item row="55" column="1" colspan="5">
         <widget class="QComboBox" name="comboBoxEnemyAI">
          <property name="editable">
@@ -741,13 +725,6 @@
          </property>
         </widget>
        </item>
-       <item row="8" column="0">
-        <widget class="QLabel" name="labelAutoSavePrefix">
-         <property name="text">
-          <string>Autosave prefix</string>
-         </property>
-        </widget>
-       </item>
        <item row="45" column="1" colspan="5">
         <widget class="QSlider" name="sliderToleranceDistanceTouch">
          <property name="minimum">
@@ -773,13 +750,6 @@
          </property>
          <property name="tickInterval">
           <number>10</number>
-         </property>
-        </widget>
-       </item>
-       <item row="8" column="2" colspan="4">
-        <widget class="QLineEdit" name="lineEditAutoSavePrefix">
-         <property name="placeholderText">
-          <string>empty = map name prefix</string>
          </property>
         </widget>
        </item>

--- a/launcher/settingsView/csettingsview_moc.ui
+++ b/launcher/settingsView/csettingsview_moc.ui
@@ -1212,7 +1212,7 @@
        <item row="7" column="0">
         <widget class="QLabel" name="labelAutoSaveLimit">
          <property name="text">
-          <string>Autosave limit (0 = off)</string>
+          <string>Autosaves per game (0 = unlimited)</string>
          </property>
         </widget>
        </item>

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -45,6 +45,7 @@ set(lib_SRCS
 )
 
 set(lib_MAIN_SRCS
+	filesystem/SavegamePath.cpp
 
 	battle/AccessibilityInfo.cpp
 	battle/BattleAction.cpp
@@ -398,6 +399,8 @@ set(lib_HEADERS
 )
 
 set(lib_MAIN_HEADERS
+	filesystem/SavegamePath.h
+
 	../include/vstd/ContainerUtils.h
 	../include/vstd/RNG.h
 

--- a/lib/StartInfo.h
+++ b/lib/StartInfo.h
@@ -136,6 +136,7 @@ struct DLL_LINKAGE StartInfo : public Serializeable
 	TPlayerInfos playerInfos; //color indexed
 
 	time_t startTime;
+	std::string saveDirectory;
 	std::string fileURI;
 	SimturnsInfo simturnsInfo;
 	TurnTimerInfo turnTimerInfo;
@@ -172,6 +173,10 @@ struct DLL_LINKAGE StartInfo : public Serializeable
 		h & mapname;
 		h & mapGenOptions;
 		h & campState;
+		if(h.hasFeature(Handler::Version::GAME_SESSION_DIRECTORY))
+			h & saveDirectory;
+		else if(!h.saving)
+			saveDirectory.clear();
 	}
 
 	StartInfo()

--- a/lib/callback/CCallback.cpp
+++ b/lib/callback/CCallback.cpp
@@ -319,9 +319,15 @@ void CCallback::saveLocalState(const JsonNode & data)
 	sendRequest(state);
 }
 
-void CCallback::save( const std::string &fname, bool notifySuccess )
+void CCallback::save(const std::string & fname, bool notifySuccess)
 {
 	SaveGame save_game(fname, notifySuccess);
+	sendRequest(save_game);
+}
+
+void CCallback::saveAutosave(const std::string & fname, int autosaveCountLimit)
+{
+	SaveGame save_game(fname, false, autosaveCountLimit);
 	sendRequest(save_game);
 }
 

--- a/lib/callback/CCallback.h
+++ b/lib/callback/CCallback.h
@@ -73,6 +73,7 @@ public:
 	void setTownName(const CGTownInstance * town, std::string & name) override;
 	void recruitHero(const CGObjectInstance *townOrTavern, const CGHeroInstance *hero, const HeroTypeID & nextHero=HeroTypeID::NONE) override;
 	void save(const std::string &fname, bool notifySuccess) override;
+	void saveAutosave(const std::string &fname, int autosaveCountLimit);
 	void sendMessage(const std::string &mess, const CGObjectInstance * currentObject = nullptr) override;
 	void gamePause(bool pause) override;
 	void buildBoat(const IShipyard *obj) override;

--- a/lib/campaign/CampaignState.cpp
+++ b/lib/campaign/CampaignState.cpp
@@ -364,6 +364,26 @@ std::optional<CampaignScenarioID> CampaignState::currentScenario() const
 	return currentMap;
 }
 
+std::time_t CampaignState::getStartTime() const
+{
+	return startTime;
+}
+
+void CampaignState::setStartTime(std::time_t value)
+{
+	startTime = value;
+}
+
+const std::string & CampaignState::getSaveDirectory() const
+{
+	return saveDirectory;
+}
+
+void CampaignState::setSaveDirectory(const std::string & value)
+{
+	saveDirectory = value;
+}
+
 std::optional<CampaignScenarioID> CampaignState::lastScenario() const
 {
 	if (mapsConquered.empty())

--- a/lib/campaign/CampaignState.h
+++ b/lib/campaign/CampaignState.h
@@ -257,6 +257,8 @@ class DLL_LINKAGE CampaignState : public Campaign
 
 	/// Script variables carried over between scenarios (only those declared as persistent)
 	ScriptVariablesStorage persistentScriptVariables;
+	std::time_t startTime = 0;
+	std::string saveDirectory;
 
 public:
 	CampaignState() = default;
@@ -271,6 +273,10 @@ public:
 
 	std::optional<CampaignScenarioID> currentScenario() const;
 	std::set<CampaignScenarioID> conqueredScenarios() const;
+	std::time_t getStartTime() const;
+	void setStartTime(std::time_t value);
+	const std::string & getSaveDirectory() const;
+	void setSaveDirectory(const std::string & value);
 
 	/// Returns bonus selected for specific scenario
 	std::optional<CampaignBonus> getBonus(CampaignScenarioID which) const;
@@ -330,5 +336,16 @@ public:
 
 		if(h.hasFeature(Handler::Version::SCRIPT_VARIABLES))
 			h & persistentScriptVariables;
+
+		if(h.hasFeature(Handler::Version::GAME_SESSION_DIRECTORY))
+		{
+			h & startTime;
+			h & saveDirectory;
+		}
+		else if(!h.saving)
+		{
+			startTime = 0;
+			saveDirectory.clear();
+		}
 	}
 };

--- a/lib/filesystem/AdapterLoaders.cpp
+++ b/lib/filesystem/AdapterLoaders.cpp
@@ -157,6 +157,19 @@ bool CFilesystemList::createResource(const std::string & filename, bool update)
 	return false;
 }
 
+bool CFilesystemList::removeResource(const ResourcePath & resourceName)
+{
+	logGlobal->trace("Removing %s", resourceName.getOriginalName());
+	for(const auto & loader : std::views::reverse(loaders))
+	{
+		if(writeableLoaders.contains(loader.get()) && loader->existsResource(resourceName))
+			return loader->removeResource(resourceName);
+	}
+
+	logGlobal->trace("Failed to remove resource");
+	return false;
+}
+
 std::vector<const ISimpleResourceLoader *> CFilesystemList::getResourcesWithName(const ResourcePath & resourceName) const
 {
 	std::vector<const ISimpleResourceLoader *> ret;

--- a/lib/filesystem/AdapterLoaders.h
+++ b/lib/filesystem/AdapterLoaders.h
@@ -76,6 +76,7 @@ public:
 	void updateFilteredFiles(std::function<bool(const std::string &)> filter) override;
 	std::unordered_set<ResourcePath> getFilteredFiles(std::function<bool(const ResourcePath &)> filter) const override;
 	bool createResource(const std::string & filename, bool update = false) override;
+	bool removeResource(const ResourcePath & resourceName) override;
 	std::vector<const ISimpleResourceLoader *> getResourcesWithName(const ResourcePath & resourceName) const override;
 	std::string getFullFileURI(const ResourcePath& resourceName) const override;
 	std::time_t getLastWriteTime(const ResourcePath& resourceName) const override;

--- a/lib/filesystem/CFilesystemLoader.cpp
+++ b/lib/filesystem/CFilesystemLoader.cpp
@@ -115,6 +115,25 @@ bool CFilesystemLoader::createResource(const std::string & requestedFilename, bo
 	return true;
 }
 
+bool CFilesystemLoader::removeResource(const ResourcePath & resourceName)
+{
+	std::lock_guard lock(fileListGuard);
+	auto resource = fileList.find(resourceName);
+	if(resource == fileList.end())
+		return false;
+
+	boost::system::error_code error;
+	boost::filesystem::remove(baseDirectory / resource->second, error);
+	if(error)
+	{
+		logGlobal->error("Failed to remove resource %s: %s", resourceName.getOriginalName(), error.message());
+		return false;
+	}
+
+	fileList.erase(resource);
+	return true;
+}
+
 std::unordered_map<ResourcePath, boost::filesystem::path> CFilesystemLoader::listFiles(const std::string &mountPoint, size_t depth, bool initial) const
 {
 	static const EResType initArray[] = {

--- a/lib/filesystem/CFilesystemLoader.h
+++ b/lib/filesystem/CFilesystemLoader.h
@@ -36,6 +36,7 @@ public:
 	bool existsResource(const ResourcePath & resourceName) const override;
 	std::string getMountPoint() const override;
 	bool createResource(const std::string & filename, bool update = false) override;
+	bool removeResource(const ResourcePath & resourceName) override;
 	std::optional<boost::filesystem::path> getResourceName(const ResourcePath & resourceName) const override;
 	void updateFilteredFiles(std::function<bool(const std::string &)> filter) override;
 	std::unordered_set<ResourcePath> getFilteredFiles(std::function<bool(const ResourcePath &)> filter) const override;

--- a/lib/filesystem/ISimpleResourceLoader.h
+++ b/lib/filesystem/ISimpleResourceLoader.h
@@ -94,6 +94,16 @@ public:
 	}
 
 	/**
+	 * Removes an existing resource from a writable loader.
+	 *
+	 * @return true if the resource no longer exists, false on error or if this loader is read-only
+	 */
+	virtual bool removeResource(const ResourcePath & resourceName)
+	{
+		return false;
+	}
+
+	/**
 	 * @brief Returns all loaders that have resource with such name
 	 *
 	 * @return vector with all loaders

--- a/lib/filesystem/SavegamePath.cpp
+++ b/lib/filesystem/SavegamePath.cpp
@@ -1,0 +1,153 @@
+/*
+ * SavegamePath.cpp, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
+
+#include "StdInc.h"
+#include "SavegamePath.h"
+
+#include "../StartInfo.h"
+#include "../callback/Calendar.h"
+#include "../campaign/CampaignState.h"
+#include "Filesystem.h"
+#include "../mapping/CMapHeader.h"
+#include "../texts/TextOperations.h"
+
+#include <vstd/DateUtils.h>
+
+namespace
+{
+constexpr int MAP_NAME_MAX_LENGTH = 50;
+
+std::string sanitizeMapName(std::string name)
+{
+	const int textLength = TextOperations::getUnicodeCharactersCount(name);
+	TextOperations::trimRightUnicode(name, std::max(0, textLength - MAP_NAME_MAX_LENGTH));
+
+	const auto isIllegalCharacter = [](char character)
+	{
+		static const std::string forbiddenCharacters(R"(\/:*?"<>|)");
+		const bool forbidden = forbiddenCharacters.find(character) != std::string::npos;
+		const bool nonprintable = static_cast<unsigned char>(character) < static_cast<unsigned char>(' ');
+		return forbidden || nonprintable;
+	};
+	std::replace_if(name.begin(), name.end(), isIllegalCharacter, '_');
+
+	if(!name.empty() && (name.back() == '.' || name.back() == ' '))
+		name.back() = '_';
+
+	return name.empty() ? "map" : name;
+}
+
+std::string getGameName(const StartInfo & startInfo, const CMapHeader & mapHeader)
+{
+	if(startInfo.campState)
+		return sanitizeMapName(startInfo.getCampaignName());
+	return sanitizeMapName(mapHeader.name.toString());
+}
+
+std::string getStoredDirectory(const StartInfo & startInfo)
+{
+	if(!startInfo.saveDirectory.empty())
+		return startInfo.saveDirectory;
+	if(startInfo.campState)
+		return startInfo.campState->getSaveDirectory();
+	return {};
+}
+
+std::string getDirectoryBase(const StartInfo & startInfo, const CMapHeader & mapHeader)
+{
+	const std::string startDate = vstd::getFormattedDateTime(startInfo.startTime, "%Y-%m-%d");
+	return getGameName(startInfo, mapHeader) + " " + startDate;
+}
+
+int getNextDirectoryIndex(const std::string & directoryBase)
+{
+	const std::string pathPrefix = boost::to_upper_copy("Saves/" + directoryBase + " ");
+	int highestIndex = 0;
+
+	const auto resources = CResourceHandler::get("local")->getFilteredFiles([&pathPrefix](const ResourcePath & resource)
+	{
+		return boost::starts_with(resource.getName(), pathPrefix);
+	});
+
+	for(const auto & resource : resources)
+	{
+		const std::string path = resource.getName();
+		const size_t indexEnd = path.find('/', pathPrefix.size());
+		if(indexEnd == std::string::npos)
+			continue;
+
+		const std::string index = path.substr(pathPrefix.size(), indexEnd - pathPrefix.size());
+		if(index.empty() || !std::ranges::all_of(index, [](unsigned char character) { return std::isdigit(character); }))
+			continue;
+
+		try
+		{
+			highestIndex = std::max(highestIndex, std::stoi(index));
+		}
+		catch(const std::out_of_range & e)
+		{
+			logGlobal->trace("Ignoring out-of-range save directory index %s: %s", index, e.what());
+		}
+	}
+
+	return highestIndex + 1;
+}
+}
+
+std::string SavegamePath::generateGameDirectoryName(const StartInfo & startInfo, const CMapHeader & mapHeader)
+{
+	const std::string storedDirectory = getStoredDirectory(startInfo);
+	if(!storedDirectory.empty())
+		return storedDirectory;
+
+	const std::string directoryBase = getDirectoryBase(startInfo, mapHeader);
+	return directoryBase + " " + std::to_string(getNextDirectoryIndex(directoryBase));
+}
+
+std::string SavegamePath::getGameDirectoryName(const StartInfo & startInfo, const CMapHeader & mapHeader)
+{
+	std::string directory = getStoredDirectory(startInfo);
+	if(directory.empty())
+		directory = getDirectoryBase(startInfo, mapHeader) + " 1";
+	return directory + "/";
+}
+
+std::string SavegamePath::getAutosavePath(const StartInfo & startInfo,
+	const CMapHeader & mapHeader,
+	const Calendar & calendar)
+{
+	const std::string filename = "Autosave-" + std::to_string(calendar.getMonth())
+		+ std::to_string(calendar.getWeek()) + std::to_string(calendar.getDayOfWeek());
+	return getPath(startInfo, mapHeader, filename);
+}
+
+bool SavegamePath::isAutosaveName(const std::string & filename)
+{
+	const size_t separator = filename.find_last_of("/\\");
+	std::string name = separator == std::string::npos ? filename : filename.substr(separator + 1);
+	if(boost::iends_with(name, ".vsgm1"))
+		name.resize(name.size() - 6);
+
+	static const std::string prefix = "Autosave-";
+	if(!boost::istarts_with(name, prefix) || name.size() == prefix.size())
+		return false;
+
+	return std::ranges::all_of(name.substr(prefix.size()), [](unsigned char character)
+	{
+		return std::isdigit(character);
+	});
+}
+
+std::string SavegamePath::getPath(const StartInfo & startInfo,
+	const CMapHeader & mapHeader,
+	const std::string & filename)
+{
+	return "Saves/" + getGameDirectoryName(startInfo, mapHeader) + filename;
+}

--- a/lib/filesystem/SavegamePath.h
+++ b/lib/filesystem/SavegamePath.h
@@ -1,0 +1,29 @@
+/*
+ * SavegamePath.h, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
+#pragma once
+
+class Calendar;
+class CMapHeader;
+struct StartInfo;
+
+/// Constructs paths for saves that belong to a particular game session.
+class DLL_LINKAGE SavegamePath final
+{
+public:
+	static std::string generateGameDirectoryName(const StartInfo & startInfo, const CMapHeader & mapHeader);
+	static std::string getGameDirectoryName(const StartInfo & startInfo, const CMapHeader & mapHeader);
+	static std::string getAutosavePath(const StartInfo & startInfo,
+		const CMapHeader & mapHeader,
+		const Calendar & calendar);
+	static bool isAutosaveName(const std::string & filename);
+	static std::string getPath(const StartInfo & startInfo,
+		const CMapHeader & mapHeader,
+		const std::string & filename);
+};

--- a/lib/gameState/CGameState.cpp
+++ b/lib/gameState/CGameState.cpp
@@ -172,6 +172,17 @@ const IGameSettings & CGameState::getSettings() const
 	return map->getSettings();
 }
 
+void CGameState::setSaveDirectory(const std::string & value)
+{
+	scenarioOps->saveDirectory = value;
+	initialOpts->saveDirectory = value;
+
+	if(scenarioOps->campState)
+		scenarioOps->campState->setSaveDirectory(value);
+	if(initialOpts->campState)
+		initialOpts->campState->setSaveDirectory(value);
+}
+
 void CGameState::preInit(Services * newServices)
 {
 	services = newServices;

--- a/lib/gameState/CGameState.cpp
+++ b/lib/gameState/CGameState.cpp
@@ -354,10 +354,8 @@ void CGameState::initNewGame(const IMapService * mapService, vstd::RNG & randomG
 				const std::string templateName = options->getMapTemplate()->getName();
 				const std::string dt = vstd::getDateTimeISO8601Basic(std::time(nullptr));
 
-				const std::string fileName = boost::str(boost::format("%s_%s.vmap") % dt % templateName );
+				const std::string fileName = boost::str(boost::format("%s_%s.vmap") % templateName % dt);
 				const auto fullPath = path / fileName;
-
-				map->name.appendRawString(boost::str(boost::format(" %s") % dt));
 
 				mapService->saveMap(map, fullPath);
 

--- a/lib/gameState/CGameState.h
+++ b/lib/gameState/CGameState.h
@@ -164,6 +164,7 @@ public:
 	{
 		return initialOpts.get();
 	}
+	void setSaveDirectory(const std::string & value);
 
 	CMap & getMap()
 	{

--- a/lib/networkPacks/PacksForServer.h
+++ b/lib/networkPacks/PacksForServer.h
@@ -762,13 +762,15 @@ struct DLL_LINKAGE RequestStatistic : public CPackForServer
 struct DLL_LINKAGE SaveGame : public CPackForServer
 {
 	SaveGame() = default;
-	SaveGame(std::string Fname, bool NotifySuccess)
+	SaveGame(std::string Fname, bool NotifySuccess, int AutosaveCountLimit = 0)
 		: fname(std::move(Fname))
 		, notifySuccess(NotifySuccess)
+		, autosaveCountLimit(AutosaveCountLimit)
 	{
 	}
 	std::string fname;
 	bool notifySuccess = false;
+	int autosaveCountLimit = 0;
 
 	void visitTyped(ICPackVisitor & visitor) override;
 
@@ -777,6 +779,7 @@ struct DLL_LINKAGE SaveGame : public CPackForServer
 		h & static_cast<CPackForServer &>(*this);
 		h & notifySuccess;
 		h & fname;
+		h & autosaveCountLimit;
 	}
 };
 

--- a/lib/rmg/CMapGenOptions.cpp
+++ b/lib/rmg/CMapGenOptions.cpp
@@ -724,6 +724,16 @@ bool CMapGenOptions::arePlayersCustomized() const
 	return customizedPlayers;
 }
 
+MetaString CMapGenOptions::getMapName() const
+{
+	if(mapTemplate)
+		return MetaString::createFromRawString(mapTemplate->getName());
+
+	MetaString result;
+	result.appendLocalString(EMetaText::GENERAL_TXT, 740);
+	return result;
+}
+
 std::vector<const CRmgTemplate *> CMapGenOptions::getPossibleTemplates() const
 {
 	int3 tplSize(width, height, levels);

--- a/lib/rmg/CMapGenOptions.h
+++ b/lib/rmg/CMapGenOptions.h
@@ -12,6 +12,7 @@
 
 #include "../GameConstants.h"
 #include "../serializer/Serializeable.h"
+#include "../texts/MetaString.h"
 #include "CRmgTemplate.h"
 
 namespace vstd
@@ -140,6 +141,7 @@ public:
 	const CRmgTemplate * getMapTemplate() const;
 	void setMapTemplate(const CRmgTemplate * value);
 	void setMapTemplate(const std::string & name);
+	MetaString getMapName() const;
 
 	std::vector<const CRmgTemplate *> getPossibleTemplates() const;
 

--- a/lib/rmg/CMapGenerator.cpp
+++ b/lib/rmg/CMapGenerator.cpp
@@ -464,7 +464,7 @@ void CMapGenerator::addHeaderInfo()
 	m.width = mapGenOptions.getWidth();
 	m.height = mapGenOptions.getHeight();
 	m.mapLayers = mapGenOptions.getLevelMapLayers();
-	m.name.appendLocalString(EMetaText::GENERAL_TXT, 740);
+	m.name = mapGenOptions.getMapName();
 	m.description = getMapDescription();
 	m.difficulty = EMapDifficulty::NORMAL;
 	addPlayerInfo();

--- a/lib/serializer/ESerializationVersion.h
+++ b/lib/serializer/ESerializationVersion.h
@@ -52,12 +52,13 @@ enum class ESerializationVersion : int32_t
 	SCRIPT_VARIABLES, // per-map script variable storage (mod-namespaced key/value store)
 	GAME_REPLAY_RECORDING, // recording of the game (and the battle ID counter it needs), stored in the savegame
 	COMBAT_ABILITY_SCRIPTS, // combat abilities that became combat scripts are converted on load; spell effects and combat scripts share one registry, so bonus subtype saves the script as a string
+	GAME_SESSION_DIRECTORY, // persistent per-game save directory and campaign start time
 
 	RELEASE_170 = HOTA_MAP_STACK_COUNT,
 	RELEASE_174 = CUSTOM_GARRISON_TITLE,
 
 	MINIMAL = RELEASE_170,
-	CURRENT = COMBAT_ABILITY_SCRIPTS,
+	CURRENT = GAME_SESSION_DIRECTORY,
 };
 
 static_assert(ESerializationVersion::MINIMAL <= ESerializationVersion::CURRENT, "Invalid serialization version definition!");

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -50,6 +50,7 @@
 #include "../lib/entities/hero/CHeroHandler.h"
 
 #include "../lib/filesystem/Filesystem.h"
+#include "../lib/filesystem/SavegamePath.h"
 
 #include "../lib/gameState/CGameState.h"
 
@@ -1067,7 +1068,11 @@ bool CGameHandler::moveHero(ObjectInstanceID hid, int3 dst, EMovementMode moveme
 		gameInfo().getPlayerState(h->getOwner())->human &&
 	   (guardian || objectToVisit) &&
 	   movementMode == EMovementMode::STANDARD)
-		save("Saves/BeforeVisitSave", PlayerColor::CANNOT_DETERMINE);
+	{
+		const auto savePath = SavegamePath::getPath(
+			*gameInfo().getStartInfo(), *gameInfo().getMapHeader(), "BeforeVisitSave");
+		save(savePath, PlayerColor::CANNOT_DETERMINE);
+	}
 
 	if (!transit && embarking)
 	{

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -39,6 +39,7 @@
 #include "../lib/battle/BattleInfo.h"
 #include "../lib/bonuses/BonusParameters.h"
 #include "../lib/callback/GameRandomizer.h"
+#include "../lib/campaign/CampaignState.h"
 
 #include "../lib/entities/ResourceTypeHandler.h"
 #include "../lib/entities/artifact/ArtifactUtils.h"
@@ -582,6 +583,8 @@ void CGameHandler::init(StartInfo *si, Load::ProgressAccumulator & progressTrack
 	gs->preInit(LIBRARY);
 	logGlobal->info("Gamestate created!");
 	gs->init(&mapService, si, *randomizer, progressTracking);
+	const auto * startInfo = gs->getStartInfo();
+	gs->setSaveDirectory(SavegamePath::generateGameDirectoryName(*startInfo, *gs->getMapHeader()));
 	logGlobal->info("Gamestate initialized!");
 
 	for (const auto & elem : gameState().players)
@@ -1722,7 +1725,75 @@ bool CGameHandler::responseStatistic(PlayerColor player)
 	return true;
 }
 
-void CGameHandler::save(const std::string & filename, PlayerColor playerToNotifyOnSuccess)
+namespace
+{
+struct AutosaveFile
+{
+	ResourcePath path;
+	std::time_t lastWrite;
+};
+
+std::string getDirectoryName(const std::string & path)
+{
+	const size_t separator = path.find_last_of("/\\");
+	return separator == std::string::npos ? std::string() : path.substr(0, separator);
+}
+
+void pruneAutosaves(const ResourcePath & currentAutosave, int countLimit)
+{
+	if(countLimit <= 0 || !SavegamePath::isAutosaveName(currentAutosave.getOriginalName()))
+		return;
+
+	const std::string gameDirectory = getDirectoryName(currentAutosave.getName());
+	auto * filesystem = CResourceHandler::get("local");
+	std::vector<AutosaveFile> autosaves;
+	const auto resources = filesystem->getFilteredFiles([&gameDirectory](const ResourcePath & resource)
+	{
+		return resource.getType() == EResType::SAVEGAME
+			&& getDirectoryName(resource.getName()) == gameDirectory
+			&& SavegamePath::isAutosaveName(resource.getOriginalName());
+	});
+
+	for(const auto & resource : resources)
+	{
+		try
+		{
+			autosaves.push_back({resource, filesystem->getLastWriteTime(resource)});
+		}
+		catch(const boost::filesystem::filesystem_error & e)
+		{
+			logGlobal->warn("Failed to get modification time of autosave %s: %s",
+				resource.getOriginalName(), e.what());
+		}
+	}
+
+	if(autosaves.size() <= static_cast<size_t>(countLimit))
+		return;
+
+	std::ranges::sort(autosaves, [&currentAutosave](const AutosaveFile & left, const AutosaveFile & right)
+	{
+		if(left.lastWrite != right.lastWrite)
+			return left.lastWrite < right.lastWrite;
+		if(left.path == currentAutosave)
+			return false;
+		if(right.path == currentAutosave)
+			return true;
+		return left.path < right.path;
+	});
+
+	const size_t filesToRemove = autosaves.size() - static_cast<size_t>(countLimit);
+	for(size_t index = 0; index < filesToRemove; ++index)
+	{
+		if(filesystem->removeResource(autosaves[index].path))
+			logGlobal->info("Removed old autosave %s", autosaves[index].path.getOriginalName());
+		else
+			logGlobal->warn("Failed to remove old autosave %s", autosaves[index].path.getOriginalName());
+	}
+}
+
+}
+
+void CGameHandler::save(const std::string & filename, PlayerColor playerToNotifyOnSuccess, int autosaveCountLimit)
 {
 	logGlobal->info("Saving to %s", filename);
 	ResourcePath savePath(filename, EResType::SAVEGAME);
@@ -1744,7 +1815,10 @@ void CGameHandler::save(const std::string & filename, PlayerColor playerToNotify
 		gameState().saveGame(save);
 		logGlobal->info("Saving server state");
 		save.save(*this);
-		save.write(*CResourceHandler::get("local")->getResourceName(savePath));
+		const auto saveFile = *CResourceHandler::get("local")->getResourceName(savePath);
+		save.write(saveFile);
+
+		pruneAutosaves(savePath, autosaveCountLimit);
 
 		if(playerToNotifyOnSuccess.isValidPlayer())
 		{
@@ -1780,6 +1854,10 @@ void CGameHandler::load(const StartInfo &info)
 
 	gs->preInit(LIBRARY);
 	gs->updateOnLoad(info);
+	auto * startInfo = gs->getStartInfo();
+	if(startInfo->campState && startInfo->campState->getStartTime() == 0)
+		startInfo->campState->setStartTime(startInfo->startTime);
+	gs->setSaveDirectory(SavegamePath::generateGameDirectoryName(*startInfo, *gs->getMapHeader()));
 
 	configureReplayLog(false);
 }

--- a/server/CGameHandler.h
+++ b/server/CGameHandler.h
@@ -247,7 +247,7 @@ public:
 	bool bulkMergeStacks(SlotID slotSrc, ObjectInstanceID srcOwner);
 	bool bulkSplitAndRebalanceStack(SlotID slotSrc, ObjectInstanceID srcOwner);
 	bool responseStatistic(PlayerColor player);
-	void save(const std::string &fname, PlayerColor playerToNotifyOnSuccess);
+	void save(const std::string &fname, PlayerColor playerToNotifyOnSuccess, int autosaveCountLimit = 0);
 	void load(const StartInfo &info);
 
 	void onPlayerTurnStarted(PlayerColor which);

--- a/server/CVCMIServer.cpp
+++ b/server/CVCMIServer.cpp
@@ -296,7 +296,10 @@ bool CVCMIServer::prepareToStartGame()
 		{
 		case EStartMode::CAMPAIGN:
 			logNetwork->info("Preparing to start new campaign");
-			si->startTime = std::time(nullptr);
+			if(si->campState->getStartTime() == 0)
+				si->campState->setStartTime(std::time(nullptr));
+			si->startTime = si->campState->getStartTime();
+			si->saveDirectory = si->campState->getSaveDirectory();
 			si->fileURI = mi->fileURI;
 			si->campState->setCurrentMap(campaignMap);
 			si->campState->setCurrentMapBonus(campaignBonus);
@@ -306,6 +309,7 @@ bool CVCMIServer::prepareToStartGame()
 		case EStartMode::NEW_GAME:
 			logNetwork->info("Preparing to start new game");
 			si->startTime = std::time(nullptr);
+			si->saveDirectory.clear();
 			si->fileURI = mi->fileURI;
 			newGH->init(si.get(), progressTracking);	// may throw
 			started = true;

--- a/server/NetPacksServer.cpp
+++ b/server/NetPacksServer.cpp
@@ -31,7 +31,7 @@
 
 void ApplyGhNetPackVisitor::visitSaveGame(SaveGame & pack)
 {
-	gh.save(pack.fname, pack.notifySuccess ? pack.player : PlayerColor::CANNOT_DETERMINE);
+	gh.save(pack.fname, pack.notifySuccess ? pack.player : PlayerColor::CANNOT_DETERMINE, pack.autosaveCountLimit);
 	logGlobal->info("Game has been saved as %s", pack.fname);
 	result = true;
 }

--- a/server/processors/PlayerMessageProcessor.cpp
+++ b/server/processors/PlayerMessageProcessor.cpp
@@ -26,6 +26,7 @@
 #include "../../lib/entities/building/CBuilding.h"
 #include "../../lib/entities/hero/CHeroHandler.h"
 #include "../../lib/entities/ResourceTypeHandler.h"
+#include "../../lib/filesystem/SavegamePath.h"
 #include "../../lib/gameState/CGameState.h"
 #include "../../lib/mapObjects/CGTownInstance.h"
 #include "../../lib/mapObjects/CGHeroInstance.h"
@@ -122,7 +123,9 @@ void PlayerMessageProcessor::commandSave(PlayerColor player, const std::vector<s
 
 	if(words.size() == 2)
 	{
-		gameHandler->save("Saves/" + words[1], PlayerColor::CANNOT_DETERMINE);
+		const auto savePath = SavegamePath::getPath(
+			*gameHandler->gameInfo().getStartInfo(), *gameHandler->gameInfo().getMapHeader(), words[1]);
+		gameHandler->save(savePath, PlayerColor::CANNOT_DETERMINE);
 		MetaString str;
 		str.appendTextID("vcmi.broadcast.gameSavedAs");
 		str.appendRawString(" ");

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -38,6 +38,7 @@ set(test_SRCS
 		events/EventBusTest.cpp
 
 		filesystem/FilesystemTest.cpp
+		filesystem/SavegamePathTest.cpp
 
 		game/BattleSpellCastTest.cpp
 		game/HeroRecruitmentTest.cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -37,6 +37,8 @@ set(test_SRCS
 		events/ApplyDamageTest.cpp
 		events/EventBusTest.cpp
 
+		filesystem/FilesystemTest.cpp
+
 		game/BattleSpellCastTest.cpp
 		game/HeroRecruitmentTest.cpp
 		game/HeroSecondarySkillsTest.cpp

--- a/test/filesystem/FilesystemTest.cpp
+++ b/test/filesystem/FilesystemTest.cpp
@@ -1,0 +1,56 @@
+/*
+ * FilesystemTest.cpp, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
+
+#include "StdInc.h"
+
+#include "../../lib/filesystem/CFilesystemLoader.h"
+#include "../../lib/filesystem/ResourcePath.h"
+
+namespace test
+{
+
+class FilesystemTest : public ::testing::Test
+{
+	boost::filesystem::path directory;
+
+protected:
+	const boost::filesystem::path & getDirectory() const
+	{
+		return directory;
+	}
+
+	void SetUp() override
+	{
+		directory = boost::filesystem::current_path()
+			/ boost::filesystem::unique_path("vcmi-filesystem-%%%%-%%%%-%%%%-%%%%");
+		ASSERT_TRUE(boost::filesystem::create_directory(directory));
+	}
+
+	void TearDown() override
+	{
+		boost::filesystem::remove_all(directory);
+	}
+};
+
+TEST_F(FilesystemTest, RemovesResourceAndUpdatesIndex)
+{
+	CFilesystemLoader loader("Test/", getDirectory());
+	const ResourcePath resource("Test/example.txt");
+
+	ASSERT_TRUE(loader.createResource("Test/example.txt"));
+	ASSERT_TRUE(loader.existsResource(resource));
+	ASSERT_TRUE(boost::filesystem::exists(getDirectory() / "example.txt"));
+
+	EXPECT_TRUE(loader.removeResource(resource));
+	EXPECT_FALSE(loader.existsResource(resource));
+	EXPECT_FALSE(boost::filesystem::exists(getDirectory() / "example.txt"));
+}
+
+}

--- a/test/filesystem/SavegamePathTest.cpp
+++ b/test/filesystem/SavegamePathTest.cpp
@@ -1,0 +1,79 @@
+/*
+ * SavegamePathTest.cpp, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
+
+#include "StdInc.h"
+
+#include "../../lib/GameLibrary.h"
+#include "../../lib/StartInfo.h"
+#include "../../lib/callback/Calendar.h"
+#include "../../lib/filesystem/SavegamePath.h"
+#include "../../lib/mapping/CMapHeader.h"
+
+#include <vstd/DateUtils.h>
+
+namespace test
+{
+
+namespace
+{
+
+StartInfo makeStartInfo()
+{
+	StartInfo startInfo;
+	startInfo.saveDirectory = "A map 2026-08-16 2";
+	return startInfo;
+}
+
+}
+
+TEST(SavegamePathTest, UsesStoredGameDirectory)
+{
+	auto startInfo = makeStartInfo();
+	CMapHeader mapHeader;
+
+	EXPECT_EQ(SavegamePath::getGameDirectoryName(startInfo, mapHeader), "A map 2026-08-16 2/");
+	EXPECT_EQ(
+		SavegamePath::getPath(startInfo, mapHeader, "Quicksave"),
+		"Saves/A map 2026-08-16 2/Quicksave");
+}
+
+TEST(SavegamePathTest, BuildsDirectoryNameForOldSave)
+{
+	auto startInfo = makeStartInfo();
+	CMapHeader mapHeader;
+	startInfo.saveDirectory.clear();
+	startInfo.startTime = 123456789;
+	mapHeader.name = MetaString::createFromRawString("A map: with/illegal? name");
+	const std::string startDate = vstd::getFormattedDateTime(startInfo.startTime, "%Y-%m-%d");
+
+	EXPECT_EQ(SavegamePath::getGameDirectoryName(startInfo, mapHeader), "A map_ with_illegal_ name " + startDate + " 1/");
+}
+
+TEST(SavegamePathTest, NamesAutosaveAfterGameDate)
+{
+	const auto startInfo = makeStartInfo();
+	CMapHeader mapHeader;
+	const auto & gameSettings = *LIBRARY->engineSettings();
+
+	EXPECT_EQ(
+		SavegamePath::getAutosavePath(startInfo, mapHeader, Calendar(gameSettings, 1)),
+		"Saves/A map 2026-08-16 2/Autosave-111");
+}
+
+TEST(SavegamePathTest, RecognizesReservedAutosaveNames)
+{
+	EXPECT_TRUE(SavegamePath::isAutosaveName("Autosave-111"));
+	EXPECT_TRUE(SavegamePath::isAutosaveName("Saves/Game/autosave-123.vsgm1"));
+	EXPECT_FALSE(SavegamePath::isAutosaveName("111"));
+	EXPECT_FALSE(SavegamePath::isAutosaveName("Autosave-old"));
+	EXPECT_FALSE(SavegamePath::isAutosaveName("Autosave-111-copy"));
+}
+
+}


### PR DESCRIPTION
This PR creates a separate save directory for every game. The directory name contains the map or campaign name, the game's start date, and an index that distinguishes games started on the same map that day: `Saves/<name> YYYY-MM-DD <index>/`. For example:

```
Saves/Wings of War 2026-08-17 1/
```

The directory remains the same after loading a save and across all scenarios of a campaign. Random maps use the template name; their generated map filename keeps the creation time.

Autosaves use `Autosave-<month><week><day>` as their filename:

```
Autosave-111.vsgm1
Autosave-112.vsgm1
...
Autosave-121.vsgm1
```

Saving again on the same in-game day replaces that day's autosave. This gives us one autosave per day without rotating filename slots. If the configured per-game limit is nonzero, the oldest daily autosaves are removed based on their modification time. A limit of 0 keeps all autosaves. Names matching `Autosave-<numbers>` are reserved: the save dialog warns before using one, and the host `!save` command rejects it.

Quick saves, pause autosaves, manual saves, before-visit saves, and saves created with the host `!save` command also go into the current game's directory. The save dialog opens in that directory, while its parent directory and saves from older games remain browsable. Scenario and campaign load screens remember their directories separately, and hide directories belonging to the other game type. Loading a game continues to use its original game directory.

To avoid long loading times after many games, the save browser parses all save metadata only for the directory being viewed. At the top level it parses one representative save per game directory to filter scenario and campaign directories. It uses file modification times to find the newest save without parsing every save in every game directory.

The custom autosave prefix settings are no longer needed, so this PR removes them from the settings schema and launcher. The main **Autosave** toggle and the per-game autosave limit remain available. The limit control is disabled while autosaves are off. **Save Before Visit** remains independent.


### Saves from a scenario and a campaign


<img width="779" height="592" alt="vcmi-saves-per-game-4-cropped" src="https://github.com/user-attachments/assets/d0ef74b8-a42d-40a1-9b8e-bf1c076f0935" />

<img width="779" height="592" alt="vcmi-saves-per-game-4-c-cropped" src="https://github.com/user-attachments/assets/2b9cae5f-bc76-41c0-bf5a-e59a029811d6" />


The same directory on disk:

```console
$ ls ~/.local/share/vcmi/Saves/*
'/home/user/.local/share/vcmi/Saves/Èãðû ñ Îãíåì 2026-08-17 1':
Autosave-111.vsgm1  NEWGAME.vsgm1

'/home/user/.local/share/vcmi/Saves/Long Live the Queen 2026-08-17 1':
Autosave-114.vsgm1  Autosave-115.vsgm1  Autosave-116.vsgm1  my.vsgm1

'/home/user/.local/share/vcmi/Saves/Random Map 20260813T083736 2026-08-17 1':
2.vsgm1  Autosave-111.vsgm1  BeforeVisitSave.vsgm1  my-save.vsgm1  NEWGAME.vsgm1

'/home/user/.local/share/vcmi/Saves/Wings of War 2026-08-17 1':
Autosave-113.vsgm1  Autosave-114.vsgm1  Autosave-115.vsgm1  BeforeVisitSave.vsgm1  NEWGAME.vsgm1
```

### Launcher

The launcher keeps the Autosave toggle, the per-game limit, and the independent Save Before Visit option:

<img width="704" height="512" alt="vcmi-launcher-settings-cropped" src="https://github.com/user-attachments/assets/908da038-3d45-46c0-b427-5884b7ac5333" />

### Testing
- Played random maps, scenarios, and campaigns and checked the daily autosaves.
- Created manual, before-visit, and `!save` saves in the same game directory, and loaded the before-visit save.
- Checked that scenario and campaign load screens remember separate directories and hide the other game type.
- Checked the save browser and verified that disabling Autosave disables its limit control but not Save Before Visit.
- Added tests for directory naming, map-name sanitization, autosave naming and detection, and filesystem removal.


See also https://github.com/vcmi/vcmi/pull/7415
