### PR TITLE
Fix neutral battle queries for owned dwellings

### DIFF
--- a/server/battles/BattleProcessor.cpp
+++ b/server/battles/BattleProcessor.cpp
@@ -135,7 +135,7 @@ void BattleProcessor::startBattle(const CArmedInstance *army1, const CArmedInsta
 
 	auto attackerQuery = gameHandler->queries->topQuery(battle->getSide(BattleSide::ATTACKER).color);
 	auto * topBattleQuery = gameHandler->queries->queryAs<CBattleQuery>(attackerQuery);
-	if(!topBattleQuery && army2->getOwner().isValidPlayer())
+	if(!topBattleQuery && battle->getSide(BattleSide::DEFENDER).color.isValidPlayer())
 	{
 		auto defenderQuery = gameHandler->queries->topQuery(battle->getSide(BattleSide::DEFENDER).color);
 		topBattleQuery = gameHandler->queries->queryAs<CBattleQuery>(defenderQuery);

--- a/test/mock/TinyH3MBuilder.cpp
+++ b/test/mock/TinyH3MBuilder.cpp
@@ -355,6 +355,18 @@ TinyH3MBuilder & TinyH3MBuilder::scroll(const int3 & pos, SpellID spell)
 	return *this;
 }
 
+TinyH3MBuilder & TinyH3MBuilder::dwelling(const int3 & pos, MapObjectSubID type, PlayerColor owner)
+{
+	ObjectSpec spec;
+	spec.id            = Obj::CREATURE_GENERATOR1;
+	spec.subid         = type;
+	spec.position      = pos;
+	spec.owner         = owner;
+	spec.templateIndex = registerTemplate(spec.id, spec.subid);
+	registerObject(std::move(spec));
+	return *this;
+}
+
 TinyH3MBuilder & TinyH3MBuilder::keymaster(const int3 & pos, int color)
 {
 	ObjectSpec spec;
@@ -1027,6 +1039,10 @@ void TinyH3MBuilder::writeObjects(TinyH3MWriter & w) const
 
 			case Obj::SPELL_SCROLL:
 				writeScrollBody(w, obj);
+				break;
+
+			case Obj::CREATURE_GENERATOR1:
+				w.writePlayer32(obj.owner);
 				break;
 
 			case Obj::KEYMASTER:

--- a/test/mock/TinyH3MBuilder.h
+++ b/test/mock/TinyH3MBuilder.h
@@ -179,6 +179,9 @@ public:
 	/// Spell scroll pickup containing the given spell.
 	TinyH3MBuilder & scroll(const int3 & pos, SpellID spell);
 
+	/// Fixed creature dwelling owned by `owner`.
+	TinyH3MBuilder & dwelling(const int3 & pos, MapObjectSubID type, PlayerColor owner);
+
 	// ---- quest objects -------------------------------------------------
 
 	/// Keymaster Tent. Subid encodes the keymaster colour (0..7).

--- a/test/mock/TinyH3MWriter.cpp
+++ b/test/mock/TinyH3MWriter.cpp
@@ -125,6 +125,14 @@ void TinyH3MWriter::writePlayer(PlayerColor v)
 		writeUInt8(static_cast<uint8_t>(v.getNum()));
 }
 
+void TinyH3MWriter::writePlayer32(PlayerColor v)
+{
+	if(v == PlayerColor::NEUTRAL || v.getNum() < 0)
+		writeUInt32(0xff);
+	else
+		writeUInt32(static_cast<uint32_t>(v.getNum()));
+}
+
 void TinyH3MWriter::writeSpell32(SpellID v)
 {
 	if(v == SpellID::NONE || v.getNum() < 0)

--- a/test/mock/TinyH3MWriter.h
+++ b/test/mock/TinyH3MWriter.h
@@ -52,6 +52,7 @@ public:
 	void writeArtifact(ArtifactID v);
 	void writeCreature(CreatureID v);
 	void writePlayer(PlayerColor v);
+	void writePlayer32(PlayerColor v);
 	void writeSpell32(SpellID v);   // 4 bytes; used by spell scrolls
 	void writeGameResID(GameResID v); // 1 signed byte
 

--- a/test/server/queries/QueriesProcessorTest.cpp
+++ b/test/server/queries/QueriesProcessorTest.cpp
@@ -7,12 +7,19 @@
 #include "../../../server/queries/QueriesProcessor.h"
 #include "CGameHandler.h"
 
+#include "lib/gameState/CGameState.h"
+
 namespace
 {
 
 class DummyGameServer : public IGameServer
 {
 public:
+	explicit DummyGameServer(std::shared_ptr<CGameState> gameState = nullptr)
+		: gameState(std::move(gameState))
+	{
+	}
+
 	void setState(EServerState value) override
 	{
 		state = value;
@@ -40,6 +47,8 @@ public:
 
 	void applyPack(CPackForClient & pack) override
 	{
+		if(gameState)
+			gameState->apply(pack);
 	}
 
 	void sendPack(CPackForClient & pack, GameConnectionID connectionID) override
@@ -48,6 +57,7 @@ public:
 
 private:
 	EServerState state{};
+	std::shared_ptr<CGameState> gameState;
 };
 
 enum class QueryEvent
@@ -538,4 +548,3 @@ TEST_F(QueriesProcessorTest, countQuery_returnsZeroForNullptr)
 {
 	EXPECT_EQ(queries.countQuery(nullptr), 0);
 }
-

--- a/test/server/queries/QueriesProcessorTest.cpp
+++ b/test/server/queries/QueriesProcessorTest.cpp
@@ -3,11 +3,19 @@
 #include <gtest/gtest.h>
 
 #include "../../../server/queries/CQuery.h"
+#include "../../../server/battles/BattleProcessor.h"
 #include "../../../server/IGameServer.h"
 #include "../../../server/queries/QueriesProcessor.h"
 #include "CGameHandler.h"
 
+#include "mock/TinyH3MBuilder.h"
+#include "mock/TinyMapGameTest.h"
+
+#include "lib/battle/BattleInfo.h"
 #include "lib/gameState/CGameState.h"
+#include "lib/mapObjects/CGDwelling.h"
+#include "lib/mapObjects/CGHeroInstance.h"
+#include "lib/mapping/CMap.h"
 
 namespace
 {
@@ -151,11 +159,56 @@ protected:
 	QueriesProcessor & queries = *gh.queries;
 };
 
+class NeutralDwellingBattleQueryTest : public TinyMapGameTest
+{
+protected:
+	void startGame()
+	{
+		TinyH3M::TinyH3MBuilder builder(EMapFormat::SOD);
+		builder
+			.size(36, false)
+			.playerActive(PlayerColor(0))
+			.playerActive(PlayerColor(1))
+			.hero({5, 5, 0}, HeroTypeID(0), PlayerColor(0))
+			.heroGarrison({{CreatureID(0), 10}})
+			.dwelling({7, 5, 0}, MapObjectSubID(0), PlayerColor(1));
+
+		startWithMap(std::move(builder));
+	}
+};
+
 }
 
 TEST_F(QueriesProcessorTest, topQuery_returnsNullWhenPlayerHasNoQueries)
 {
 	EXPECT_EQ(queries.topQuery(PlayerColor(1)), nullptr);
+}
+
+TEST_F(NeutralDwellingBattleQueryTest, ownedDwellingUsesNeutralBattleSideWithoutNeutralQuery)
+{
+	startGame();
+
+	auto * hero = findHeroByOwner(PlayerColor(0));
+	auto * dwelling = findFirst<CGDwelling>();
+	ASSERT_NE(hero, nullptr);
+	ASSERT_NE(dwelling, nullptr);
+	ASSERT_TRUE(dwelling->setCreature(SlotID(0), CreatureID(1), 10));
+
+	DummyGameServer server(gameState());
+	CGameHandler gh(server, gameState());
+
+	gh.battles->startBattle(hero, dwelling);
+
+	const auto * battle = gameState()->getBattle(PlayerColor(0));
+	ASSERT_NE(battle, nullptr);
+	EXPECT_EQ(battle->getSide(BattleSide::DEFENDER).color, PlayerColor::NEUTRAL);
+
+	const auto attackerQuery = gh.queries->topQuery(PlayerColor(0));
+	ASSERT_NE(attackerQuery, nullptr);
+	EXPECT_EQ(attackerQuery->getType(), QueryType::Battle);
+	ASSERT_EQ(attackerQuery->players.size(), 1);
+	EXPECT_EQ(attackerQuery->players.front(), PlayerColor(0));
+	EXPECT_EQ(gh.queries->topQuery(PlayerColor(1)), nullptr);
 }
 
 TEST_F(QueriesProcessorTest, popIfTop_removesTopQuery)


### PR DESCRIPTION
_This is a refactored part of https://github.com/vcmi/vcmi/pull/7613, split out so the neutral-battle fix can be reviewed on its own._

[`715` save](https://github.com/vcmi/vcmi/pull/7613#issuecomment-5032485753) exposed a mismatch in battle startup: a creature dwelling may have a player owner, but its guards still fight as the neutral side. The code checked the dwelling owner and then tried to look up a query for the neutral defender, which hits the valid-player assertion in Debug builds.

Battle startup now checks the actual defender battle-side color before touching the query stack. The regression starts a real battle against an owned dwelling and checks that the attacker gets the battle query while the dwelling owner does not. The tiny-map dwelling support and pack-applying test server are split into small setup commits to keep the actual fix easy to see.
