### PR TITLE
fix color chinese translate in replay turn window

### DIFF
--- a/client/replay/ReplaySelectionWindow.cpp
+++ b/client/replay/ReplaySelectionWindow.cpp
@@ -42,7 +42,9 @@ namespace
 	std::string describeTurn(const ReplayTurnOption & turn)
 	{
 		const auto * playerState = GAME->interface()->cb->getPlayerState(turn.player, false);
-		const std::string playerName = playerState ? playerState->getNameTranslated() : turn.player.toString();
+		const std::string playerName = playerState
+			? playerState->getNameTranslated()
+			: LIBRARY->generaltexth->translate(TextIdentifier("core.plcolors", turn.player.getNum()).get());
 
 		MetaString text = MetaString::createFromTextID(turn.ongoing ? "vcmi.replay.turnOngoing" : "vcmi.replay.turn");
 		text.replaceNumber(turn.day);


### PR DESCRIPTION
<img width="788" height="729" alt="PixPin_2026-08-17_09-49-54" src="https://github.com/user-attachments/assets/fe9fc56e-d045-4fea-89d4-7997d887007a" />

in replay turn windows the red english not be translated into chinese as blue(blue is player, red is computer). get transate from 
"core.plcolors" in chinese translate mod.
