### PR TITLE
Fix NK2 garrison army upgrades

### DIFF
--- a/AI/Nullkiller2/Behaviors/GatherArmyBehavior.cpp
+++ b/AI/Nullkiller2/Behaviors/GatherArmyBehavior.cpp
@@ -336,7 +336,15 @@ Goals::TGoalVec GatherArmyBehavior::upgradeArmy(const Nullkiller * aiNk, const C
 
 		if(isSafe)
 		{
-			tasks.push_back(sptr(Composition().addNext(ArmyUpgrade(path, upgrader, upgrade)).addNext(visitGoal)));
+			Composition composition;
+			composition.addNext(ArmyUpgrade(path, upgrader, upgrade));
+
+			if(upgrader->getGarrisonHero() == path.targetHero)
+				composition.addNext(ExchangeSwapTownHeroes(upgrader));
+			else
+				composition.addNext(visitGoal);
+
+			tasks.push_back(sptr(composition));
 		}
 	}
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -115,6 +115,7 @@ set(test_SRCS
 		texts/TextOperationsTest.cpp
 
 		mock/BattleFake.cpp
+		mock/GameHandlerTestServer.cpp
 		mock/mock_IGameEventCallback.cpp
  		mock/mock_MapService.cpp
  		mock/mock_MapServiceTinyH3M.cpp
@@ -142,6 +143,7 @@ set(test_HEADERS
 		server/battles/BattleTestFixture.h
 
 		mock/BattleFake.h
+		mock/GameHandlerTestServer.h
 		mock/mock_BonusBearer.h
 		mock/mock_CStack.h
 		mock/mock_IGameEventCallback.h
@@ -176,6 +178,7 @@ if(ENABLE_NULLKILLER2_AI)
 		nullkiller2/Behaviors/DefenceBehaviorTest.cpp
 		nullkiller2/Behaviors/EscapeBehaviorTest.cpp
 		nullkiller2/Behaviors/ExplorationBehaviorTest.cpp
+		nullkiller2/Behaviors/GatherArmyBehaviorTest.cpp
 		nullkiller2/Behaviors/RecruitHeroBehaviorTest.cpp
 		nullkiller2/Engine/PriorityEvaluatorTest.cpp
 		nullkiller2/Engine/TaskFailureTest.cpp

--- a/test/mock/GameHandlerTestServer.cpp
+++ b/test/mock/GameHandlerTestServer.cpp
@@ -1,0 +1,61 @@
+/*
+ * GameHandlerTestServer.cpp, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ */
+#include "StdInc.h"
+
+#include "GameHandlerTestServer.h"
+
+#include "../../lib/gameState/CGameState.h"
+
+GameHandlerTestServer::GameHandlerTestServer(std::shared_ptr<CGameState> gameState)
+	: gameState(std::move(gameState))
+{
+}
+
+GameHandlerTestServer::GameHandlerTestServer(std::shared_ptr<CGameState> gameState, PlayerColor hostedPlayer)
+	: state(EServerState::GAMEPLAY)
+	, gameState(std::move(gameState))
+	, hostedPlayer(hostedPlayer)
+{
+}
+
+void GameHandlerTestServer::setState(EServerState value)
+{
+	state = value;
+}
+
+EServerState GameHandlerTestServer::getState() const
+{
+	return state;
+}
+
+bool GameHandlerTestServer::isPlayerHost(const PlayerColor & color) const
+{
+	return hostedPlayer == color;
+}
+
+bool GameHandlerTestServer::hasPlayerAt(PlayerColor player, GameConnectionID connectionID) const
+{
+	return hostedPlayer == player && connectionID == GameConnectionID::FIRST_CONNECTION;
+}
+
+bool GameHandlerTestServer::hasBothPlayersAtSameConnection(PlayerColor, PlayerColor) const
+{
+	return false;
+}
+
+void GameHandlerTestServer::applyPack(CPackForClient & pack)
+{
+	if(gameState)
+		gameState->apply(pack);
+}
+
+void GameHandlerTestServer::sendPack(CPackForClient &, GameConnectionID)
+{
+	// Test state changes are applied through applyPack.
+}

--- a/test/mock/GameHandlerTestServer.h
+++ b/test/mock/GameHandlerTestServer.h
@@ -1,0 +1,37 @@
+/*
+ * GameHandlerTestServer.h, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ */
+#pragma once
+
+#include "../../server/IGameServer.h"
+#include "../../lib/GameConstants.h"
+
+#include <memory>
+#include <optional>
+
+class CGameState;
+
+class GameHandlerTestServer : public IGameServer
+{
+public:
+	explicit GameHandlerTestServer(std::shared_ptr<CGameState> gameState = nullptr);
+	GameHandlerTestServer(std::shared_ptr<CGameState> gameState, PlayerColor hostedPlayer);
+
+	void setState(EServerState value) override;
+	EServerState getState() const override;
+	bool isPlayerHost(const PlayerColor & color) const override;
+	bool hasPlayerAt(PlayerColor player, GameConnectionID connectionID) const override;
+	bool hasBothPlayersAtSameConnection(PlayerColor left, PlayerColor right) const override;
+	void applyPack(CPackForClient & pack) override;
+	void sendPack(CPackForClient & pack, GameConnectionID connectionID) override;
+
+private:
+	EServerState state = EServerState::LOBBY;
+	std::shared_ptr<CGameState> gameState;
+	std::optional<PlayerColor> hostedPlayer;
+};

--- a/test/mock/TinyH3MBuilder.cpp
+++ b/test/mock/TinyH3MBuilder.cpp
@@ -199,6 +199,18 @@ TinyH3MBuilder & TinyH3MBuilder::playerActive(PlayerColor color)
 	return *this;
 }
 
+TinyH3MBuilder & TinyH3MBuilder::town(const int3 & pos, FactionID faction, PlayerColor owner)
+{
+	ObjectSpec spec;
+	spec.id            = Obj::TOWN;
+	spec.subid         = MapObjectSubID(faction.getNum());
+	spec.position      = pos;
+	spec.owner         = owner;
+	spec.templateIndex = registerTemplate(spec.id, spec.subid);
+	registerObject(std::move(spec));
+	return *this;
+}
+
 TinyH3MBuilder & TinyH3MBuilder::randomTown(const int3 & pos, PlayerColor owner)
 {
 	ObjectSpec spec;

--- a/test/mock/TinyH3MBuilder.h
+++ b/test/mock/TinyH3MBuilder.h
@@ -120,6 +120,9 @@ public:
 	/// object that ownership-validates against canAnyonePlay (towns, heroes).
 	TinyH3MBuilder & playerActive(PlayerColor color);
 
+	/// Append a fixed-faction Town object owned by `owner`.
+	TinyH3MBuilder & town(const int3 & pos, FactionID faction, PlayerColor owner);
+
 	/// Append a Random Town object owned by `owner`. Builder auto-registers the
 	/// RANDOM_TOWN template on first call. No garrison, standard fort, no events.
 	TinyH3MBuilder & randomTown(const int3 & pos, PlayerColor owner);

--- a/test/nullkiller2/Behaviors/GatherArmyBehaviorTest.cpp
+++ b/test/nullkiller2/Behaviors/GatherArmyBehaviorTest.cpp
@@ -1,0 +1,129 @@
+/*
+ * GatherArmyBehaviorTest.cpp, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ */
+#include "StdInc.h"
+
+#include "AI/Nullkiller2/AIGateway.h"
+#include "AI/Nullkiller2/Engine/Nullkiller.h"
+
+#include "mock/GameHandlerTestServer.h"
+#include "mock/TinyH3MBuilder.h"
+#include "nullkiller2/NullkillerTest.h"
+
+#include "server/CGameHandler.h"
+
+#include "lib/callback/CCallback.h"
+#include "lib/callback/IClient.h"
+#include "lib/gameState/CGameState.h"
+#include "lib/mapObjects/CGHeroInstance.h"
+#include "lib/mapObjects/CGTownInstance.h"
+#include "lib/networkPacks/PacksForClient.h"
+#include "lib/networkPacks/PacksForServer.h"
+#include "lib/serializer/CMemorySerializer.h"
+
+namespace
+{
+const PlayerColor PLAYER(0);
+const PlayerColor ENEMY(1);
+
+class GameHandlerClient : public IClient
+{
+public:
+	GameHandlerClient(const std::shared_ptr<CGameState> & gameState, PlayerColor player)
+		: server(gameState, player)
+		, gameHandler(server, gameState)
+	{
+		gameState->actingPlayers.insert(player);
+	}
+
+	std::optional<BattleAction> makeSurrenderRetreatDecision(
+		PlayerColor,
+		const BattleID &,
+		const BattleStateInfoForRetreat &) override
+	{
+		return std::nullopt;
+	}
+
+	int sendRequest(const CPackForServer & request, PlayerColor player, bool) override
+	{
+		request.player = player;
+		request.requestID = ++lastRequestID;
+		auto serverRequest = CMemorySerializer::deepCopy(request);
+		gameHandler.handleReceivedPack(
+			GameConnectionID::FIRST_CONNECTION,
+			*serverRequest);
+		return lastRequestID;
+	}
+
+private:
+	GameHandlerTestServer server;
+	CGameHandler gameHandler;
+	int lastRequestID = 0;
+};
+
+TinyH3M::TinyH3MBuilder makeGarrisonUpgradeMap()
+{
+	TinyH3M::TinyH3MBuilder builder(EMapFormat::SOD);
+	builder
+		.size(36, false)
+		.name("NK2GarrisonUpgrade")
+		.playerActive(PLAYER)
+		.playerActive(ENEMY)
+		.town({9, 5, 0}, FactionID::CASTLE, PLAYER)
+		.hero({5, 5, 0}, HeroTypeID(HeroTypeID::decode("orrin")), PLAYER)
+		.town({30, 30, 0}, FactionID::CASTLE, ENEMY);
+
+	return builder;
+}
+
+class Nullkiller2_Behaviors_GatherArmyBehavior : public NullkillerTest
+{
+protected:
+	void putHeroInGarrison(const CGHeroInstance & hero, const CGTownInstance & town) const
+	{
+		ChangeObjPos moveHero;
+		moveHero.objid = hero.id;
+		moveHero.nPos = town.visitablePos();
+		moveHero.initiator = PLAYER;
+		gameState()->apply(moveHero);
+
+		SetHeroesInTown setHeroes;
+		setHeroes.tid = town.id;
+		setHeroes.visiting = ObjectInstanceID::NONE;
+		setHeroes.garrison = hero.id;
+		gameState()->apply(setHeroes);
+	}
+};
+}
+
+TEST_F(Nullkiller2_Behaviors_GatherArmyBehavior, upgradesPikemenCarriedByGarrisonHero)
+{
+	startWithMap(makeGarrisonUpgradeMap());
+
+	auto * hero = findHeroByOwner(PLAYER);
+	auto * town = findFirst<CGTownInstance>();
+	ASSERT_NE(hero, nullptr);
+	ASSERT_NE(town, nullptr);
+	ASSERT_EQ(town->getFactionID(), FactionID::CASTLE);
+
+	const CreatureID pikeman(CreatureID::decode("pikeman"));
+	const CreatureID halberdier(CreatureID::decode("halberdier"));
+	town->addBuilding(BuildingID::DWELL_LVL_1_UP);
+	town->creatures.at(0).second.push_back(halberdier);
+	hero->clearSlots();
+	ASSERT_TRUE(hero->setCreature(SlotID(0), pikeman, 1000));
+	putHeroInGarrison(*hero, *town);
+	grantResources(PLAYER, GameResID(GameResID::GOLD), 1000000);
+
+	GameHandlerClient client(gameState(), PLAYER);
+	const auto gateway = makeGateway(PLAYER, &client);
+	gateway->nullkiller->makeTurn();
+
+	ASSERT_NE(hero->getStackPtr(SlotID(0)), nullptr);
+	EXPECT_EQ(hero->getStackPtr(SlotID(0))->getCreatureID(), halberdier);
+}

--- a/test/server/queries/QueriesProcessorTest.cpp
+++ b/test/server/queries/QueriesProcessorTest.cpp
@@ -4,10 +4,10 @@
 
 #include "../../../server/queries/CQuery.h"
 #include "../../../server/battles/BattleProcessor.h"
-#include "../../../server/IGameServer.h"
 #include "../../../server/queries/QueriesProcessor.h"
 #include "CGameHandler.h"
 
+#include "mock/GameHandlerTestServer.h"
 #include "mock/TinyH3MBuilder.h"
 #include "mock/TinyMapGameTest.h"
 
@@ -19,54 +19,6 @@
 
 namespace
 {
-
-class DummyGameServer : public IGameServer
-{
-public:
-	explicit DummyGameServer(std::shared_ptr<CGameState> gameState = nullptr)
-		: gameState(std::move(gameState))
-	{
-	}
-
-	void setState(EServerState value) override
-	{
-		state = value;
-	}
-
-	EServerState getState() const override
-	{
-		return state;
-	}
-
-	bool isPlayerHost(const PlayerColor & color) const override
-	{
-		return false;
-	}
-
-	bool hasPlayerAt(PlayerColor player, GameConnectionID connectionID) const override
-	{
-		return false;
-	}
-
-	bool hasBothPlayersAtSameConnection(PlayerColor left, PlayerColor right) const override
-	{
-		return false;
-	}
-
-	void applyPack(CPackForClient & pack) override
-	{
-		if(gameState)
-			gameState->apply(pack);
-	}
-
-	void sendPack(CPackForClient & pack, GameConnectionID connectionID) override
-	{
-	}
-
-private:
-	EServerState state{};
-	std::shared_ptr<CGameState> gameState;
-};
 
 enum class QueryEvent
 {
@@ -154,7 +106,7 @@ public:
 class QueriesProcessorTest : public ::testing::Test
 {
 protected:
-	DummyGameServer server;
+	GameHandlerTestServer server;
 	CGameHandler gh{server};
 	QueriesProcessor & queries = *gh.queries;
 };
@@ -194,7 +146,7 @@ TEST_F(NeutralDwellingBattleQueryTest, ownedDwellingUsesNeutralBattleSideWithout
 	ASSERT_NE(dwelling, nullptr);
 	ASSERT_TRUE(dwelling->setCreature(SlotID(0), CreatureID(1), 10));
 
-	DummyGameServer server(gameState());
+	GameHandlerTestServer server(gameState());
 	CGameHandler gh(server, gameState());
 
 	gh.battles->startBattle(hero, dwelling);


### PR DESCRIPTION
_This is a refactored part of https://github.com/vcmi/vcmi/pull/7613, split out so the garrison upgrade fix can be reviewed on its own._

When the hero selected for an army upgrade was already in the town garrison, NK2 followed the upgrade marker with a normal visit goal. The hero was already on the town tile, so that goal completed without changing the garrison state and the same upgrade plan could be selected again.

The garrison case now uses `ExchangeSwapTownHeroes`. This extracts the hero through the normal server request, applies the available army upgrades, and leaves the town and hero state ready for the next planning pass.

The regression builds a real game state, selects and executes the upgrade plan through `CGameHandler`, and checks that the hero leaves the garrison and carries the upgraded creatures. With the production fix removed, the test still builds and fails because the hero remains in the garrison.
