### PR TITLE
Map editor pen fix

### DIFF
--- a/mapeditor/mainwindow.cpp
+++ b/mapeditor/mainwindow.cpp
@@ -67,20 +67,13 @@
 #endif
 
 #ifdef VCMI_ANDROID
-// Qt 5 bug on Android with QT_SCALE_FACTOR:
-// In androidjniinput.cpp, mouse/tablet handlers compute:
-//   localPos = globalPos(device_pixels) - tlw->position()(logical_pixels)
-// mixing coordinate spaces. After QHighDpiScaling the widget receives
-// a localPos that is off by windowPos*(1-1/S) for any window not at (0,0).
-// Touch events use normalized coordinates and are NOT affected.
-//
-// Fix: recompute localPos from the already-correct global/screen position.
-// After QHighDpi scaling, screenPos() (mouse) and globalPosF() (tablet)
-// are in logical coordinates.  window->position() is also logical.
-// So: correctedLocal = globalLogical - window->position().
-// We modify the event in-place (protected members l,w / mPos) to preserve
-// the spontaneous flag and Qt's internal mouse-grab state.
-// The fix is always active (harmless no-op when scale == 1.0).
+// Qt 5 bug on Android: androidjniinput.cpp computes the local position of mouse
+// and tablet events as globalPos(native px) - tlw->position()(logical px), mixing
+// coordinate spaces. After QHighDpiScaling the local position is off by
+// windowPos*(1-1/factor) - zero for the fullscreen main window at (0,0), wrong for
+// every other top level window. Touch events are global based and unaffected.
+// Fix: recompute the local position from the (correct) global one. Modified in place
+// via the protected members to keep the spontaneous flag and Qt's mouse grab state.
 class AndroidInputOffsetFix : public QObject
 {
 public:
@@ -100,8 +93,7 @@ public:
 			case QEvent::MouseButtonDblClick:
 			{
 				auto * me = static_cast<QMouseEvent *>(event);
-				// screenPos() (= global logical pos) is always correct after
-				// QHighDpi scaling.  Recompute the local position from it.
+				// screenPos() is the global position in logical coordinates
 				QPointF correct = me->screenPos() - QPointF(window->position());
 				struct Accessor : QMouseEvent
 				{
@@ -115,10 +107,7 @@ public:
 			case QEvent::TabletMove:
 			{
 				auto * te = static_cast<QTabletEvent *>(event);
-				// globalPosF() is already in correct logical coordinates after
-				// QHighDpi::fromNativePixels in handleTabletEvent().  Only the
-				// local position (mPos) was computed incorrectly by the JNI
-				// layer (native_px - logical_px mismatch).  Recompute it.
+				// only mPos is damaged, globalPosF() went through fromNativePixels
 				QPointF correctedLocal = te->globalPosF() - QPointF(window->position());
 				struct Accessor : QTabletEvent
 				{

--- a/mapeditor/mapview.cpp
+++ b/mapeditor/mapview.cpp
@@ -651,6 +651,13 @@ void MapView::dropEvent(QDropEvent * event)
 	
 	if(sc->selectionObjectsView.newObject)
 	{
+		//the drop position is authoritative: the last dragMoveEvent may lag far behind it
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+		moveNewObjectTo(event->position().toPoint());
+#else
+		moveNewObjectTo(event->pos());
+#endif
+
 		QString errorMsg;
 		if(controller->canPlaceObject(sc->selectionObjectsView.newObject.get(), errorMsg))
 		{
@@ -668,23 +675,27 @@ void MapView::dropEvent(QDropEvent * event)
 	event->acceptProposedAction();
 }
 
-void MapView::dragMoveEvent(QDragMoveEvent * event)
+void MapView::moveNewObjectTo(const QPoint & viewportPos)
 {
 	auto * sc = static_cast<MapScene*>(scene());
-	if(!sc)
+	if(!sc || !sc->selectionObjectsView.newObject)
 		return;
-	
-	auto rect = event->answerRect();
-	auto pos = mapToScene(rect.bottomRight()); //TODO: do we need to check size?
+
+	auto pos = mapToScene(viewportPos);
 	int3 tile(pos.x() / 32 + 1, pos.y() / 32 + 1, sc->level);
-	
-	if(sc->selectionObjectsView.newObject)
-	{
-		sc->selectionObjectsView.selectionMode = SelectionObjectsLayer::MOVEMENT;
-		sc->selectionObjectsView.selectObject(sc->selectionObjectsView.newObject.get());
-		sc->selectionObjectsView.setShift(tile.x, tile.y);
-	}
-	
+
+	sc->selectionObjectsView.selectionMode = SelectionObjectsLayer::MOVEMENT;
+	sc->selectionObjectsView.selectObject(sc->selectionObjectsView.newObject.get());
+	sc->selectionObjectsView.setShift(tile.x, tile.y);
+}
+
+void MapView::dragMoveEvent(QDragMoveEvent * event)
+{
+	if(!scene())
+		return;
+
+	moveNewObjectTo(event->answerRect().bottomRight()); //TODO: do we need to check size?
+
 	event->acceptProposedAction();
 }
 

--- a/mapeditor/mapview.h
+++ b/mapeditor/mapview.h
@@ -124,6 +124,8 @@ signals:
 protected:
 	
 private:
+	void moveNewObjectTo(const QPoint & viewportPos);
+
 	MapController * controller = nullptr;
 	QRubberBand * rubberBand = nullptr;
 	QPointF mouseStart;


### PR DESCRIPTION
Fixes issue where drag and drop with pen randomly places objects at incorrect place.
Noticed on android.

Also corrected comments a little bit.