### PR TITLE
Allow parallel execution of Lua code

### DIFF
--- a/luascript/LuaContext.cpp
+++ b/luascript/LuaContext.cpp
@@ -206,21 +206,18 @@ void LuaContext::cleanupGlobals()
 
 bool LuaContext::hasFunction(const std::string & name)
 {
-	std::lock_guard guard(mutex);
 	if(!scriptTable)
 		return false;
 	LuaStack S(L);
 	scriptTable->push();
 	lua_getfield(L, -1, name.c_str());
 	bool result = S.isFunction(-1);
-	S.clear();
+	S.restoreInitialTop();
 	return result;
 }
 
 void LuaContext::initialize()
 {
-	std::lock_guard guard(mutex);
-
 	std::shared_ptr<LuaReference> head;
 
 	for(const auto & layer : script->layers)
@@ -286,13 +283,6 @@ void LuaContext::installChunkEnvWithBase(LuaReference & base)
 	lua_setupvalue(L, -2, 1);
 #endif
 	// Stack: ..., chunk
-}
-
-int LuaContext::errorRetVoid(const std::string & message)
-{
-	logScript->error(message);
-	lua_settop(L, 0);
-	return 0;
 }
 
 std::string LuaContext::toStringRaw(int index)

--- a/luascript/LuaContext.h
+++ b/luascript/LuaContext.h
@@ -47,7 +47,6 @@ public:
 	ReturnType callFunction(const std::string & name, Args&&... args);
 
 private:
-	std::mutex mutex;
 	lua_State * L;
 
 	const LuaScriptInstance * script;
@@ -70,9 +69,6 @@ private:
 	/// Replaces the environment of the chunk on top of the stack so that the global `Base`
 	/// resolves to the given base table, while other globals fall back through __index = _G.
 	void installChunkEnvWithBase(LuaReference & base);
-
-	//log error and return nil from LuaCFunction
-	int errorRetVoid(const std::string & message);
 
 	std::string toStringRaw(int index);
 
@@ -111,8 +107,6 @@ ReturnType LuaContext::callFunction(const std::string & name, Args&&... args)
 template<typename ReturnType, typename... Args>
 ReturnType LuaContext::callImpl(const std::shared_ptr<LuaReference> & ref, const JsonNode * self, const std::string & name, Args&&... args)
 {
-	std::lock_guard guard(mutex);
-
 	if(!ref)
 	{
 		if constexpr (!std::is_void_v<ReturnType>)
@@ -125,11 +119,11 @@ ReturnType LuaContext::callImpl(const std::shared_ptr<LuaReference> & ref, const
 
 	ref->push();                       // stack: (table)
 	lua_getfield(L, -1, name.c_str()); // stack: (table), (function)
-	lua_replace(L, 1);                 // stack: (function)
+	lua_remove(L, -2);                 // stack: (function)
 
 	if(!S.isFunction(-1))
 	{
-		S.clear();
+		S.restoreInitialTop();
 		logScript->error("Script '%s': function '%s' not found", script->getIdentifier(), name);
 		if constexpr (!std::is_void_v<ReturnType>)
 			return ReturnType{};
@@ -149,12 +143,13 @@ ReturnType LuaContext::callImpl(const std::shared_ptr<LuaReference> & ref, const
 		++argc;
 	}
 
-	(S << ... << args);
+	// cast to void: with an empty pack the fold collapses to a bare `S`
+	(void)(S << ... << args);
 
 	if(lua_pcall(L, argc, 1, 0))
 	{
 		std::string error = lua_tostring(L, -1);
-		S.clear();
+		S.restoreInitialTop();
 		logScript->error("Script '%s', function '%s': %s", script->getIdentifier(), name, error);
 		if constexpr (!std::is_void_v<ReturnType>)
 			return ReturnType{};
@@ -171,7 +166,7 @@ ReturnType LuaContext::callImpl(const std::shared_ptr<LuaReference> & ref, const
 		}
 		catch(const LuaApiException & e)
 		{
-			S.clear();
+			S.restoreInitialTop();
 			logScript->error("Script '%s', function '%s' returned unexpected value: %s", script->getIdentifier(), name, e.what());
 			return ReturnType{};
 		}
@@ -180,7 +175,7 @@ ReturnType LuaContext::callImpl(const std::shared_ptr<LuaReference> & ref, const
 	}
 	else
 	{
-		S.clear();
+		S.restoreInitialTop();
 		return;
 	}
 }

--- a/luascript/LuaScriptPool.cpp
+++ b/luascript/LuaScriptPool.cpp
@@ -23,15 +23,29 @@ LuaScriptPool::LuaScriptPool(const LuaModule & luaModule, const Environment * EN
 {
 }
 
+LuaScriptPool::~LuaScriptPool() = default;
+
 void LuaScriptPool::registerScript(const LuaScriptInstance * script)
 {
-	auto context = script->createContext(env);
-	cache[script] = context;
-	context->initialize();
+	scripts[script] = script;
+
+	// Build the state of the registering thread right away so that a broken script is reported
+	// on session start, as before, instead of on first use in the middle of a game
+	getContext(script);
 }
 
 std::shared_ptr<Context> LuaScriptPool::getContext(const Script * script) const
 {
-	return cache.at(script);
+	auto & threadContexts = contexts.local();
+
+	auto it = threadContexts.find(script);
+	if(it == threadContexts.end())
+	{
+		auto context = scripts.at(script)->createContext(env);
+		context->initialize();
+		it = threadContexts.emplace(script, std::move(context)).first;
+	}
+
+	return it->second;
 }
 }

--- a/luascript/LuaScriptPool.h
+++ b/luascript/LuaScriptPool.h
@@ -12,27 +12,37 @@
 
 #include <vcmi/scripting/Service.h>
 
+#include <tbb/enumerable_thread_specific.h>
+
 class JsonNode;
 
 namespace scripting
 {
 
+class LuaContext;
 class LuaModule;
 class LuaScriptInstance;
 
-/// Owned by CGameState; holds the live LuaContext for every registered script in the current game session.
-/// Scripts are registered at session start and their contexts are initialized before gameplay begins.
+/// Owned by CGameState; hands out the LuaContext of every registered script in the current game session.
+/// Scripts are registered at session start; each thread gets its own set of contexts so that scripts can
+/// run concurrently without locking. This requires scripts to be stateless - they receive their
+/// configuration as a per-call argument and must not accumulate state in globals or in their own table.
 class LuaScriptPool : public Pool
 {
 public:
 	LuaScriptPool(const LuaModule & luaModule, const Environment * ENV);
+	~LuaScriptPool();
 
 	std::shared_ptr<Context> getContext(const Script * script) const override;
 
 	void registerScript(const LuaScriptInstance * script);
 
 private:
-	std::map<const Script *, std::shared_ptr<Context>> cache;
+	/// Filled at session start and never modified afterwards, so concurrent lookup needs no locking
+	std::map<const Script *, const LuaScriptInstance *> scripts;
+
+	/// Per-thread lua_State of each script, created on first use by that thread
+	mutable tbb::enumerable_thread_specific<std::map<const Script *, std::shared_ptr<LuaContext>>> contexts;
 
 	const Environment * env;
 };


### PR DESCRIPTION
Now all Lua scripts use thread-local Lua state, allowing execution of scripts in parallel.

This removes need of mutex and allows AI's to estimate spell effects truly in parallel, just like in 1.7

Fixes performance regression during combat AI spellcasting. Potential increase to RAM usage since we now have (number ofscripts * number of threads) of Lua states, but should be insignificant compared to overall memory usage