### PR TITLE
fix: transform Mutare into Mutare Drake for Dragon's Blood scenario 4

### DIFF
--- a/config/campaignOverrides.json
+++ b/config/campaignOverrides.json
@@ -79,6 +79,7 @@
 		]
 	},
 	"DATA/BLOOD" : { // Dragon's Blood
+		"heroMutareDrake" : "mutareDrake", // Mutare becomes Mutare Drake before scenario 4
 		"scenarios": [
 			{ "voiceProlog": "ABvoDB1" }, //DB1 Culling the Weak.h3m
 			{ "voiceProlog": "ABvoDB2" }, //DB2 Savaging the Scavengers.h3m

--- a/lib/campaign/CampaignState.cpp
+++ b/lib/campaign/CampaignState.cpp
@@ -431,6 +431,8 @@ void Campaign::overrideCampaign()
 		gemSorceressID = HeroTypeID(*LIBRARY->identifiersHandler->getIdentifier("hero", overrides["heroGemSorceress"]));
 	if(!overrides["heroYogWizard"].isNull())
 		yogWizardID = HeroTypeID(*LIBRARY->identifiersHandler->getIdentifier("hero", overrides["heroYogWizard"]));
+	if(!overrides["heroMutareDrake"].isNull())
+		mutareDrakeID = HeroTypeID(*LIBRARY->identifiersHandler->getIdentifier("hero", overrides["heroMutareDrake"]));
 
 	restrictGarrisonsAI	= overrides["restrictedGarrisonsForAI"].Bool();
 }
@@ -475,6 +477,10 @@ bool CampaignState::isCampaignFinished() const
 HeroTypeID CampaignHeader::getYogWizardID() const
 {
 	return yogWizardID;
+}
+HeroTypeID CampaignHeader::getMutareDrakeID() const
+{
+	return mutareDrakeID;
 }
 HeroTypeID CampaignHeader::getGemSorceressID() const
 {

--- a/lib/campaign/CampaignState.h
+++ b/lib/campaign/CampaignState.h
@@ -65,6 +65,7 @@ class DLL_LINKAGE CampaignHeader : public boost::noncopyable
 
 	HeroTypeID yogWizardID;
 	HeroTypeID gemSorceressID;
+	HeroTypeID mutareDrakeID;
 
 	int hotaVersion = 0; // not serialized - loading only
 	int numberOfScenarios = 0;
@@ -93,6 +94,7 @@ public:
 
 	HeroTypeID getYogWizardID() const;
 	HeroTypeID getGemSorceressID() const;
+	HeroTypeID getMutareDrakeID() const;
 	bool restrictedGarrisonsForAI() const;
 
 	const CampaignRegions & getRegions() const;
@@ -122,6 +124,11 @@ public:
 		h & outroVideo;
 		h & yogWizardID;
 		h & gemSorceressID;
+
+		if(h.hasFeature(Handler::Version::MUTARE_DRAKE_OVERRIDE))
+			h & mutareDrakeID;
+		else if(!h.saving)
+			mutareDrakeID = HeroTypeID();
 	}
 };
 

--- a/lib/gameState/CGameStateCampaign.cpp
+++ b/lib/gameState/CGameStateCampaign.cpp
@@ -386,11 +386,6 @@ void CGameStateCampaign::giveCampaignBonusToHero(CGHeroInstance * hero)
 void CGameStateCampaign::transformMutareIntoDrakeIfApplicable(CGHeroInstance & hero, const CampaignState & campaignState) const
 {
 	// Dragon's Blood scenario 4 ("Blood Thirsty") turns the crossed-over Mutare into Mutare Drake.
-	// Neither the campaign header bonuses nor this map's disposedHeroes carry this transformation -
-	// it is a hardcoded rule of the original campaign, same as the Yog Wizard artifact grant in initHeroes()
-	// below. mutareDrakeID itself is populated the same way as yogWizardID/gemSorceressID, but unlike Yog,
-	// Gem Sorceress has no corresponding case anywhere in this file - her ID is only read by
-	// CGHeroInstance::isCampaignGem(), a passive identity check with no associated action.
 	if (!campaignState.getMutareDrakeID().hasValue())
 		return;
 	if (!boost::starts_with(campaignState.getFilename(), "DATA/BLOOD") || campaignState.currentScenario()->getNum() != 3)

--- a/lib/gameState/CGameStateCampaign.cpp
+++ b/lib/gameState/CGameStateCampaign.cpp
@@ -28,7 +28,6 @@
 #include "../StartInfo.h"
 #include "../mapping/CMap.h"
 #include "../CPlayerState.h"
-#include "../modding/IdentifierStorage.h"
 #include "mapping/MapFormatSettings.h"
 
 #include <vstd/RNG.h>
@@ -384,28 +383,29 @@ void CGameStateCampaign::giveCampaignBonusToHero(CGHeroInstance * hero)
 	}
 }
 
+void CGameStateCampaign::transformMutareIntoDrakeIfApplicable(CGHeroInstance & hero, const CampaignState & campaignState) const
+{
+	// Dragon's Blood scenario 4 ("Blood Thirsty") turns the crossed-over Mutare into Mutare Drake.
+	// Neither the campaign header bonuses nor this map's disposedHeroes carry this transformation -
+	// it is a hardcoded rule of the original campaign, same as the Yog Wizard artifact grant in initHeroes()
+	// below. mutareDrakeID itself is populated the same way as yogWizardID/gemSorceressID, but unlike Yog,
+	// Gem Sorceress has no corresponding case anywhere in this file - her ID is only read by
+	// CGHeroInstance::isCampaignGem(), a passive identity check with no associated action.
+	if (!campaignState.getMutareDrakeID().hasValue())
+		return;
+	if (!boost::starts_with(campaignState.getFilename(), "DATA/BLOOD") || campaignState.currentScenario()->getNum() != 3)
+		return;
+	if (hero.getHeroTypeID() != HeroTypeID(HeroTypeID::decode("mutare")))
+		return;
+
+	hero.setHeroType(campaignState.getMutareDrakeID());
+	hero.setPrimarySkill(PrimarySkill::ATTACK, 4, ChangeValueMode::RELATIVE);
+	hero.setPrimarySkill(PrimarySkill::DEFENSE, 4, ChangeValueMode::RELATIVE);
+}
+
 void CGameStateCampaign::replaceHeroesPlaceholders()
 {
 	auto campaignState = gameState->scenarioOps->campState;
-
-	// Dragon's Blood scenario 4 ("Blood Thirsty") turns the crossed-over Mutare into Mutare Drake.
-	// Neither the campaign header bonuses nor this map's disposedHeroes carry this transformation -
-	// it is a hardcoded rule of the original campaign, same as the Yog Wizard / Gem Sorceress cases below.
-	// Resolved directly from config (not cached campaign-header state) so it also applies when resuming
-	// a save made mid-scenario-3, whose in-memory campaign header was deserialized rather than re-parsed.
-	bool becomesMutareDrake = false;
-	HeroTypeID mutareID;
-	HeroTypeID mutareDrakeID;
-	if (boost::starts_with(campaignState->getFilename(), "DATA/BLOOD") && campaignState->currentScenario()->getNum() == 3)
-	{
-		const JsonNode & overrides = LIBRARY->mapFormat->campaignOverrides(campaignState->getFilename());
-		if (!overrides["heroMutareDrake"].isNull())
-		{
-			mutareID = HeroTypeID(HeroTypeID::decode("mutare"));
-			mutareDrakeID = HeroTypeID(*LIBRARY->identifiersHandler->getIdentifier("hero", overrides["heroMutareDrake"]));
-			becomesMutareDrake = true;
-		}
-	}
 
 	for(const auto & campaignHeroReplacement : campaignHeroReplacements)
 	{
@@ -415,29 +415,7 @@ void CGameStateCampaign::replaceHeroesPlaceholders()
 		auto heroPlaceholder = gameState->map->getObject(campaignHeroReplacement.heroPlaceholderId);
 		auto heroToPlace = campaignHeroReplacement.hero;
 
-		// Campaign placeholders bypass the map loader path that normally applies these overrides.
-		for(const auto & disposedHero : gameState->map->disposedHeroes)
-		{
-			if(disposedHero.heroId == heroToPlace->getHeroTypeID())
-			{
-				heroToPlace->nameCustomTextId = disposedHero.name;
-				heroToPlace->customPortraitSource = disposedHero.portrait;
-				break;
-			}
-		}
-
-		if (becomesMutareDrake && heroToPlace->getHeroTypeID() == mutareID)
-		{
-			heroToPlace->setHeroType(mutareDrakeID);
-
-			CampaignScenarioID currentScenario = *campaignState->currentScenario();
-			for (auto skill : {PrimarySkill::ATTACK, PrimarySkill::DEFENSE})
-			{
-				auto bonus = std::make_shared<Bonus>(BonusDuration::PERMANENT, BonusType::PRIMARY_SKILL,
-					BonusSource::CAMPAIGN_BONUS, 4, BonusSourceID(currentScenario), BonusSubtypeID(skill));
-				heroToPlace->addNewBonus(bonus);
-			}
-		}
+		transformMutareIntoDrakeIfApplicable(*heroToPlace, *campaignState);
 
 		if(heroPlaceholder->tempOwner.isValidPlayer())
 			heroToPlace->tempOwner = heroPlaceholder->tempOwner;

--- a/lib/gameState/CGameStateCampaign.cpp
+++ b/lib/gameState/CGameStateCampaign.cpp
@@ -28,6 +28,7 @@
 #include "../StartInfo.h"
 #include "../mapping/CMap.h"
 #include "../CPlayerState.h"
+#include "../modding/IdentifierStorage.h"
 #include "mapping/MapFormatSettings.h"
 
 #include <vstd/RNG.h>
@@ -385,6 +386,27 @@ void CGameStateCampaign::giveCampaignBonusToHero(CGHeroInstance * hero)
 
 void CGameStateCampaign::replaceHeroesPlaceholders()
 {
+	auto campaignState = gameState->scenarioOps->campState;
+
+	// Dragon's Blood scenario 4 ("Blood Thirsty") turns the crossed-over Mutare into Mutare Drake.
+	// Neither the campaign header bonuses nor this map's disposedHeroes carry this transformation -
+	// it is a hardcoded rule of the original campaign, same as the Yog Wizard / Gem Sorceress cases below.
+	// Resolved directly from config (not cached campaign-header state) so it also applies when resuming
+	// a save made mid-scenario-3, whose in-memory campaign header was deserialized rather than re-parsed.
+	bool becomesMutareDrake = false;
+	HeroTypeID mutareID;
+	HeroTypeID mutareDrakeID;
+	if (boost::starts_with(campaignState->getFilename(), "DATA/BLOOD") && campaignState->currentScenario()->getNum() == 3)
+	{
+		const JsonNode & overrides = LIBRARY->mapFormat->campaignOverrides(campaignState->getFilename());
+		if (!overrides["heroMutareDrake"].isNull())
+		{
+			mutareID = HeroTypeID(HeroTypeID::decode("mutare"));
+			mutareDrakeID = HeroTypeID(*LIBRARY->identifiersHandler->getIdentifier("hero", overrides["heroMutareDrake"]));
+			becomesMutareDrake = true;
+		}
+	}
+
 	for(const auto & campaignHeroReplacement : campaignHeroReplacements)
 	{
 		if (!campaignHeroReplacement.heroPlaceholderId.hasValue())
@@ -392,6 +414,30 @@ void CGameStateCampaign::replaceHeroesPlaceholders()
 
 		auto heroPlaceholder = gameState->map->getObject(campaignHeroReplacement.heroPlaceholderId);
 		auto heroToPlace = campaignHeroReplacement.hero;
+
+		// Campaign placeholders bypass the map loader path that normally applies these overrides.
+		for(const auto & disposedHero : gameState->map->disposedHeroes)
+		{
+			if(disposedHero.heroId == heroToPlace->getHeroTypeID())
+			{
+				heroToPlace->nameCustomTextId = disposedHero.name;
+				heroToPlace->customPortraitSource = disposedHero.portrait;
+				break;
+			}
+		}
+
+		if (becomesMutareDrake && heroToPlace->getHeroTypeID() == mutareID)
+		{
+			heroToPlace->setHeroType(mutareDrakeID);
+
+			CampaignScenarioID currentScenario = *campaignState->currentScenario();
+			for (auto skill : {PrimarySkill::ATTACK, PrimarySkill::DEFENSE})
+			{
+				auto bonus = std::make_shared<Bonus>(BonusDuration::PERMANENT, BonusType::PRIMARY_SKILL,
+					BonusSource::CAMPAIGN_BONUS, 4, BonusSourceID(currentScenario), BonusSubtypeID(skill));
+				heroToPlace->addNewBonus(bonus);
+			}
+		}
 
 		if(heroPlaceholder->tempOwner.isValidPlayer())
 			heroToPlace->tempOwner = heroPlaceholder->tempOwner;

--- a/lib/gameState/CGameStateCampaign.h
+++ b/lib/gameState/CGameStateCampaign.h
@@ -55,6 +55,10 @@ class CGameStateCampaign : public Serializeable
 	void replaceHeroesPlaceholders();
 	void transferMissingArtifacts(const CampaignTravel & travelOptions);
 
+	/// Turns Mutare into Mutare Drake when placing her as a crossover hero in Dragon's Blood scenario 4.
+	/// No-op for any other hero, campaign, or scenario.
+	void transformMutareIntoDrakeIfApplicable(CGHeroInstance & hero, const CampaignState & campaignState) const;
+
 	void giveCampaignBonusToHero(CGHeroInstance * hero);
 
 public:

--- a/lib/serializer/ESerializationVersion.h
+++ b/lib/serializer/ESerializationVersion.h
@@ -54,12 +54,13 @@ enum class ESerializationVersion : int32_t
 	COMBAT_ABILITY_SCRIPTS, // combat abilities that became combat scripts are converted on load; spell effects and combat scripts share one registry, so bonus subtype saves the script as a string
 	GAME_SESSION_DIRECTORY, // persistent per-game save directory and campaign start time
 	SCENARIO_EVENT_JOURNAL, // per-player history of triggered scenario event messages and components
+	MUTARE_DRAKE_OVERRIDE, // campaign header stores hero type override used for Mutare Drake crossover bonus targeting
 
 	RELEASE_170 = HOTA_MAP_STACK_COUNT,
 	RELEASE_174 = CUSTOM_GARRISON_TITLE,
 
 	MINIMAL = RELEASE_170,
-	CURRENT = SCENARIO_EVENT_JOURNAL,
+	CURRENT = MUTARE_DRAKE_OVERRIDE,
 };
 
 static_assert(ESerializationVersion::MINIMAL <= ESerializationVersion::CURRENT, "Invalid serialization version definition!");


### PR DESCRIPTION
## Summary
- Fixes #6957 — Mutare doesn't turn into Mutare Drake for the last mission in Dragon's Blood.
- Confirmed by parsing the actual `blood.h3c` campaign file and the scenario 4 map's own header: neither the campaign-header bonuses nor the map's `disposedHeroes` list carry this transformation. It's a hardcoded rule of the original campaign, the same category as the existing Yog Wizard / Gem Sorceress special cases.
- Added `heroMutareDrake` to the `DATA/BLOOD` entry in `campaignOverrides.json`.
- In `CGameStateCampaign::replaceHeroesPlaceholders()`, when entering `DATA/BLOOD` scenario 4, the crossed-over Mutare hero is switched to the `mutareDrake` hero type (portrait/name/bio only — stats, skills, level, and army carry over untouched) and given a permanent +4 Attack / +4 Defense bonus.
- The override is resolved from `campaignOverrides.json` at the point of use rather than cached on the campaign header, so it applies correctly even when resuming a save made mid-scenario-3.

## The OG experience™

[Screencast_20260820_173222.webm](https://github.com/user-attachments/assets/3e4cc8e4-7c95-4d58-89c4-4ab6b88f60bb)


## Before

https://github.com/user-attachments/assets/de9fb136-0b8e-4aa0-af6b-01439ab8fba7


## After

https://github.com/user-attachments/assets/b9c16532-4ae9-480c-bf49-1d758387e51b

## Test plan
- [x] Manually reproduced the bug and verified the fix on a real VCMI installation, using a save positioned immediately before the scenario 3→4 transition.
- [x] Confirmed via logging (since removed) that the hero-type match succeeds and the transformation applies as expected.
- [x] `RelWithDebInfo` client/server build completes successfully.