### PR TITLE
Add missing PLAYER propagator Angelic Alliance

### DIFF
--- a/config/artifacts.json
+++ b/config/artifacts.json
@@ -1925,12 +1925,14 @@
 			"alignmentMixGood" : {
 				"type" : "ALIGNMENT_MIX",
 				"subtype" : "alignmentGood",
+				"propagator" : "PLAYER",
 				"val" : 0,
 				"valueType" : "BASE_NUMBER"
 			},
 			"alignmentMixNeutral" : {
 				"type" : "ALIGNMENT_MIX",
 				"subtype" : "alignmentNeutral",
+				"propagator" : "PLAYER",
 				"val" : 0,
 				"valueType" : "BASE_NUMBER"
 			},


### PR DESCRIPTION
In SoD, Angelic Alliance's morale mixing bonus is a player wide bonus. Video for demonstration:

https://github.com/user-attachments/assets/337aa952-1c2f-48d1-aaf3-26a6b27d6e1b

