### PR TITLE
Fix O(n^2) performance issue in rollCreature

### DIFF
--- a/lib/callback/GameRandomizer.cpp
+++ b/lib/callback/GameRandomizer.cpp
@@ -116,12 +116,13 @@ bool GameRandomizer::rollCombatAbility(ObjectInstanceID actor, int percentageCha
 CreatureID GameRandomizer::rollCreature()
 {
 	std::vector<CreatureID> allowed;
+	const auto knownMonsters = LIBRARY->objtypeh->knownSubObjects(Obj::MONSTER);
 	for(const auto & creatureID : LIBRARY->creh->getDefaultAllowed())
 	{
 		const auto * creaturePtr = creatureID.toCreature();
 		if(creaturePtr->excludeFromRandomization)
 			continue;
-		if(!LIBRARY->objtypeh->knownSubObjects(Obj::MONSTER).contains(creatureID.getNum()))
+		if(!knownMonsters.contains(creatureID.getNum()))
 			continue;
 		allowed.push_back(creaturePtr->getId());
 	}
@@ -135,13 +136,14 @@ CreatureID GameRandomizer::rollCreature()
 CreatureID GameRandomizer::rollCreature(int tier)
 {
 	std::vector<CreatureID> allowed;
+	const auto knownMonsters = LIBRARY->objtypeh->knownSubObjects(Obj::MONSTER);
 	for(const auto & creatureID : LIBRARY->creh->getDefaultAllowed())
 	{
 		const auto * creaturePtr = creatureID.toCreature();
 		if(creaturePtr->excludeFromRandomization)
 			continue;
 
-		if (!LIBRARY->objtypeh->knownSubObjects(Obj::MONSTER).contains(creatureID.getNum()))
+		if (!knownMonsters.contains(creatureID.getNum()))
 			continue;
 
 		if(creaturePtr->getLevel() == tier)


### PR DESCRIPTION
## Problem

Loading a map with many random monsters is very slow. Each `pickRandomObject` on a monster took ~128 ms, so a map with ~100 of them spent ~15 s in `randomizeMapObjects`.

## Cause

`rollCreature()` called `knownSubObjects(Obj::MONSTER)` inside the creature loop. That function builds a new `std::set` by value on every call, turning the loop into O(n²).

## Fix

Compute `knownSubObjects(Obj::MONSTER)` once before the loop and reuse the result. Applies to both `rollCreature()` and `rollCreature(int tier)`.