### PR TITLE
Remove redundant scopes and fix Age spell battle log

### DIFF
--- a/config/artifacts.json
+++ b/config/artifacts.json
@@ -42,7 +42,7 @@
 	{
 		"bonuses" : {
 			"attack" : {
-				"subtype" : "primarySkill.attack",
+				"subtype" : "attack",
 				"type" : "PRIMARY_SKILL",
 				"val" : 2,
 				"valueType" : "BASE_NUMBER"
@@ -55,7 +55,7 @@
 	{
 		"bonuses" : {
 			"attack" : {
-				"subtype" : "primarySkill.attack",
+				"subtype" : "attack",
 				"type" : "PRIMARY_SKILL",
 				"val" : 3,
 				"valueType" : "BASE_NUMBER"
@@ -68,7 +68,7 @@
 	{
 		"bonuses" : {
 			"attack" : {
-				"subtype" : "primarySkill.attack",
+				"subtype" : "attack",
 				"type" : "PRIMARY_SKILL",
 				"val" : 4,
 				"valueType" : "BASE_NUMBER"
@@ -81,7 +81,7 @@
 	{
 		"bonuses" : {
 			"attack" : {
-				"subtype" : "primarySkill.attack",
+				"subtype" : "attack",
 				"type" : "PRIMARY_SKILL",
 				"val" : 5,
 				"valueType" : "BASE_NUMBER"
@@ -94,7 +94,7 @@
 	{
 		"bonuses" : {
 			"attack" : {
-				"subtype" : "primarySkill.attack",
+				"subtype" : "attack",
 				"type" : "PRIMARY_SKILL",
 				"val" : 6,
 				"valueType" : "BASE_NUMBER"
@@ -107,13 +107,13 @@
 	{
 		"bonuses" : {
 			"attack" : {
-				"subtype" : "primarySkill.attack",
+				"subtype" : "attack",
 				"type" : "PRIMARY_SKILL",
 				"val" : 12,
 				"valueType" : "BASE_NUMBER"
 			},
 			"defence" : {
-				"subtype" : "primarySkill.defence",
+				"subtype" : "defence",
 				"type" : "PRIMARY_SKILL",
 				"val" : -3,
 				"valueType" : "BASE_NUMBER"
@@ -126,7 +126,7 @@
 	{
 		"bonuses" : {
 			"defence" : {
-				"subtype" : "primarySkill.defence",
+				"subtype" : "defence",
 				"type" : "PRIMARY_SKILL",
 				"val" : 2,
 				"valueType" : "BASE_NUMBER"
@@ -139,7 +139,7 @@
 	{
 		"bonuses" : {
 			"defence" : {
-				"subtype" : "primarySkill.defence",
+				"subtype" : "defence",
 				"type" : "PRIMARY_SKILL",
 				"val" : 3,
 				"valueType" : "BASE_NUMBER"
@@ -152,7 +152,7 @@
 	{
 		"bonuses" : {
 			"defence" : {
-				"subtype" : "primarySkill.defence",
+				"subtype" : "defence",
 				"type" : "PRIMARY_SKILL",
 				"val" : 4,
 				"valueType" : "BASE_NUMBER"
@@ -165,7 +165,7 @@
 	{
 		"bonuses" : {
 			"defence" : {
-				"subtype" : "primarySkill.defence",
+				"subtype" : "defence",
 				"type" : "PRIMARY_SKILL",
 				"val" : 5,
 				"valueType" : "BASE_NUMBER"
@@ -178,7 +178,7 @@
 	{
 		"bonuses" : {
 			"defence" : {
-				"subtype" : "primarySkill.defence",
+				"subtype" : "defence",
 				"type" : "PRIMARY_SKILL",
 				"val" : 6,
 				"valueType" : "BASE_NUMBER"
@@ -191,13 +191,13 @@
 	{
 		"bonuses" : {
 			"defence" : {
-				"subtype" : "primarySkill.defence",
+				"subtype" : "defence",
 				"type" : "PRIMARY_SKILL",
 				"val" : 12,
 				"valueType" : "BASE_NUMBER"
 			},
 			"attack" : {
-				"subtype" : "primarySkill.attack",
+				"subtype" : "attack",
 				"type" : "PRIMARY_SKILL",
 				"val" : -3,
 				"valueType" : "BASE_NUMBER"
@@ -210,7 +210,7 @@
 	{
 		"bonuses" : {
 			"knowledge" : {
-				"subtype" : "primarySkill.knowledge",
+				"subtype" : "knowledge",
 				"type" : "PRIMARY_SKILL",
 				"val" : 1,
 				"valueType" : "BASE_NUMBER"
@@ -223,7 +223,7 @@
 	{
 		"bonuses" : {
 			"knowledge" : {
-				"subtype" : "primarySkill.knowledge",
+				"subtype" : "knowledge",
 				"type" : "PRIMARY_SKILL",
 				"val" : 2,
 				"valueType" : "BASE_NUMBER"
@@ -236,7 +236,7 @@
 	{
 		"bonuses" : {
 			"knowledge" : {
-				"subtype" : "primarySkill.knowledge",
+				"subtype" : "knowledge",
 				"type" : "PRIMARY_SKILL",
 				"val" : 3,
 				"valueType" : "BASE_NUMBER"
@@ -249,7 +249,7 @@
 	{
 		"bonuses" : {
 			"knowledge" : {
-				"subtype" : "primarySkill.knowledge",
+				"subtype" : "knowledge",
 				"type" : "PRIMARY_SKILL",
 				"val" : 4,
 				"valueType" : "BASE_NUMBER"
@@ -262,7 +262,7 @@
 	{
 		"bonuses" : {
 			"knowledge" : {
-				"subtype" : "primarySkill.knowledge",
+				"subtype" : "knowledge",
 				"type" : "PRIMARY_SKILL",
 				"val" : 5,
 				"valueType" : "BASE_NUMBER"
@@ -275,13 +275,13 @@
 	{
 		"bonuses" : {
 			"knowledge" : {
-				"subtype" : "primarySkill.knowledge",
+				"subtype" : "knowledge",
 				"type" : "PRIMARY_SKILL",
 				"val" : 10,
 				"valueType" : "BASE_NUMBER"
 			},
 			"spellpower" : {
-				"subtype" : "primarySkill.spellpower",
+				"subtype" : "spellpower",
 				"type" : "PRIMARY_SKILL",
 				"val" : -2,
 				"valueType" : "BASE_NUMBER"
@@ -294,7 +294,7 @@
 	{
 		"bonuses" : {
 			"spellpower" : {
-				"subtype" : "primarySkill.spellpower",
+				"subtype" : "spellpower",
 				"type" : "PRIMARY_SKILL",
 				"val" : 1,
 				"valueType" : "BASE_NUMBER"
@@ -307,7 +307,7 @@
 	{
 		"bonuses" : {
 			"spellpower" : {
-				"subtype" : "primarySkill.spellpower",
+				"subtype" : "spellpower",
 				"type" : "PRIMARY_SKILL",
 				"val" : 2,
 				"valueType" : "BASE_NUMBER"
@@ -320,7 +320,7 @@
 	{
 		"bonuses" : {
 			"spellpower" : {
-				"subtype" : "primarySkill.spellpower",
+				"subtype" : "spellpower",
 				"type" : "PRIMARY_SKILL",
 				"val" : 3,
 				"valueType" : "BASE_NUMBER"
@@ -333,7 +333,7 @@
 	{
 		"bonuses" : {
 			"spellpower" : {
-				"subtype" : "primarySkill.spellpower",
+				"subtype" : "spellpower",
 				"type" : "PRIMARY_SKILL",
 				"val" : 4,
 				"valueType" : "BASE_NUMBER"
@@ -346,7 +346,7 @@
 	{
 		"bonuses" : {
 			"spellpower" : {
-				"subtype" : "primarySkill.spellpower",
+				"subtype" : "spellpower",
 				"type" : "PRIMARY_SKILL",
 				"val" : 5,
 				"valueType" : "BASE_NUMBER"
@@ -359,13 +359,13 @@
 	{
 		"bonuses" : {
 			"spellpower" : {
-				"subtype" : "primarySkill.spellpower",
+				"subtype" : "spellpower",
 				"type" : "PRIMARY_SKILL",
 				"val" : 10,
 				"valueType" : "BASE_NUMBER"
 			},
 			"knowledge" : {
-				"subtype" : "primarySkill.knowledge",
+				"subtype" : "knowledge",
 				"type" : "PRIMARY_SKILL",
 				"val" : -2,
 				"valueType" : "BASE_NUMBER"
@@ -378,25 +378,25 @@
 	{
 		"bonuses" : {
 			"attack" : {
-				"subtype" : "primarySkill.attack",
+				"subtype" : "attack",
 				"type" : "PRIMARY_SKILL",
 				"val" : 1,
 				"valueType" : "BASE_NUMBER"
 			},
 			"defence" : {
-				"subtype" : "primarySkill.defence",
+				"subtype" : "defence",
 				"type" : "PRIMARY_SKILL",
 				"val" : 1,
 				"valueType" : "BASE_NUMBER"
 			},
 			"spellpower" : {
-				"subtype" : "primarySkill.spellpower",
+				"subtype" : "spellpower",
 				"type" : "PRIMARY_SKILL",
 				"val" : 1,
 				"valueType" : "BASE_NUMBER"
 			},
 			"knowledge" : {
-				"subtype" : "primarySkill.knowledge",
+				"subtype" : "knowledge",
 				"type" : "PRIMARY_SKILL",
 				"val" : 1,
 				"valueType" : "BASE_NUMBER"
@@ -409,25 +409,25 @@
 	{
 		"bonuses" : {
 			"attack" : {
-				"subtype" : "primarySkill.attack",
+				"subtype" : "attack",
 				"type" : "PRIMARY_SKILL",
 				"val" : 2,
 				"valueType" : "BASE_NUMBER"
 			},
 			"defence" : {
-				"subtype" : "primarySkill.defence",
+				"subtype" : "defence",
 				"type" : "PRIMARY_SKILL",
 				"val" : 2,
 				"valueType" : "BASE_NUMBER"
 			},
 			"spellpower" : {
-				"subtype" : "primarySkill.spellpower",
+				"subtype" : "spellpower",
 				"type" : "PRIMARY_SKILL",
 				"val" : 2,
 				"valueType" : "BASE_NUMBER"
 			},
 			"knowledge" : {
-				"subtype" : "primarySkill.knowledge",
+				"subtype" : "knowledge",
 				"type" : "PRIMARY_SKILL",
 				"val" : 2,
 				"valueType" : "BASE_NUMBER"
@@ -440,25 +440,25 @@
 	{
 		"bonuses" : {
 			"attack" : {
-				"subtype" : "primarySkill.attack",
+				"subtype" : "attack",
 				"type" : "PRIMARY_SKILL",
 				"val" : 3,
 				"valueType" : "BASE_NUMBER"
 			},
 			"defence" : {
-				"subtype" : "primarySkill.defence",
+				"subtype" : "defence",
 				"type" : "PRIMARY_SKILL",
 				"val" : 3,
 				"valueType" : "BASE_NUMBER"
 			},
 			"spellpower" : {
-				"subtype" : "primarySkill.spellpower",
+				"subtype" : "spellpower",
 				"type" : "PRIMARY_SKILL",
 				"val" : 3,
 				"valueType" : "BASE_NUMBER"
 			},
 			"knowledge" : {
-				"subtype" : "primarySkill.knowledge",
+				"subtype" : "knowledge",
 				"type" : "PRIMARY_SKILL",
 				"val" : 3,
 				"valueType" : "BASE_NUMBER"
@@ -471,25 +471,25 @@
 	{
 		"bonuses" : {
 			"attack" : {
-				"subtype" : "primarySkill.attack",
+				"subtype" : "attack",
 				"type" : "PRIMARY_SKILL",
 				"val" : 4,
 				"valueType" : "BASE_NUMBER"
 			},
 			"defence" : {
-				"subtype" : "primarySkill.defence",
+				"subtype" : "defence",
 				"type" : "PRIMARY_SKILL",
 				"val" : 4,
 				"valueType" : "BASE_NUMBER"
 			},
 			"spellpower" : {
-				"subtype" : "primarySkill.spellpower",
+				"subtype" : "spellpower",
 				"type" : "PRIMARY_SKILL",
 				"val" : 4,
 				"valueType" : "BASE_NUMBER"
 			},
 			"knowledge" : {
-				"subtype" : "primarySkill.knowledge",
+				"subtype" : "knowledge",
 				"type" : "PRIMARY_SKILL",
 				"val" : 4,
 				"valueType" : "BASE_NUMBER"
@@ -502,25 +502,25 @@
 	{
 		"bonuses" : {
 			"attack" : {
-				"subtype" : "primarySkill.attack",
+				"subtype" : "attack",
 				"type" : "PRIMARY_SKILL",
 				"val" : 5,
 				"valueType" : "BASE_NUMBER"
 			},
 			"defence" : {
-				"subtype" : "primarySkill.defence",
+				"subtype" : "defence",
 				"type" : "PRIMARY_SKILL",
 				"val" : 5,
 				"valueType" : "BASE_NUMBER"
 			},
 			"spellpower" : {
-				"subtype" : "primarySkill.spellpower",
+				"subtype" : "spellpower",
 				"type" : "PRIMARY_SKILL",
 				"val" : 5,
 				"valueType" : "BASE_NUMBER"
 			},
 			"knowledge" : {
-				"subtype" : "primarySkill.knowledge",
+				"subtype" : "knowledge",
 				"type" : "PRIMARY_SKILL",
 				"val" : 5,
 				"valueType" : "BASE_NUMBER"
@@ -533,25 +533,25 @@
 	{
 		"bonuses" : {
 			"attack" : {
-				"subtype" : "primarySkill.attack",
+				"subtype" : "attack",
 				"type" : "PRIMARY_SKILL",
 				"val" : 6,
 				"valueType" : "BASE_NUMBER"
 			},
 			"defence" : {
-				"subtype" : "primarySkill.defence",
+				"subtype" : "defence",
 				"type" : "PRIMARY_SKILL",
 				"val" : 6,
 				"valueType" : "BASE_NUMBER"
 			},
 			"spellpower" : {
-				"subtype" : "primarySkill.spellpower",
+				"subtype" : "spellpower",
 				"type" : "PRIMARY_SKILL",
 				"val" : 6,
 				"valueType" : "BASE_NUMBER"
 			},
 			"knowledge" : {
-				"subtype" : "primarySkill.knowledge",
+				"subtype" : "knowledge",
 				"type" : "PRIMARY_SKILL",
 				"val" : 6,
 				"valueType" : "BASE_NUMBER"
@@ -564,13 +564,13 @@
 	{
 		"instanceBonuses" : {
 			"attack" : {
-				"subtype" : "primarySkill.attack",
+				"subtype" : "attack",
 				"type" : "PRIMARY_SKILL",
 				"val" : 1,
 				"valueType" : "BASE_NUMBER"
 			},
 			"defence" : {
-				"subtype" : "primarySkill.defence",
+				"subtype" : "defence",
 				"type" : "PRIMARY_SKILL",
 				"val" : 1,
 				"valueType" : "BASE_NUMBER"
@@ -583,13 +583,13 @@
 	{
 		"bonuses" : {
 			"attack" : {
-				"subtype" : "primarySkill.attack",
+				"subtype" : "attack",
 				"type" : "PRIMARY_SKILL",
 				"val" : 2,
 				"valueType" : "BASE_NUMBER"
 			},
 			"defence" : {
-				"subtype" : "primarySkill.defence",
+				"subtype" : "defence",
 				"type" : "PRIMARY_SKILL",
 				"val" : 2,
 				"valueType" : "BASE_NUMBER"
@@ -602,13 +602,13 @@
 	{
 		"bonuses" : {
 			"attack" : {
-				"subtype" : "primarySkill.attack",
+				"subtype" : "attack",
 				"type" : "PRIMARY_SKILL",
 				"val" : 3,
 				"valueType" : "BASE_NUMBER"
 			},
 			"defence" : {
-				"subtype" : "primarySkill.defence",
+				"subtype" : "defence",
 				"type" : "PRIMARY_SKILL",
 				"val" : 3,
 				"valueType" : "BASE_NUMBER"
@@ -621,13 +621,13 @@
 	{
 		"bonuses" : {
 			"attack" : {
-				"subtype" : "primarySkill.attack",
+				"subtype" : "attack",
 				"type" : "PRIMARY_SKILL",
 				"val" : 4,
 				"valueType" : "BASE_NUMBER"
 			},
 			"defence" : {
-				"subtype" : "primarySkill.defence",
+				"subtype" : "defence",
 				"type" : "PRIMARY_SKILL",
 				"val" : 4,
 				"valueType" : "BASE_NUMBER"
@@ -640,13 +640,13 @@
 	{
 		"bonuses" : {
 			"spellpower" : {
-				"subtype" : "primarySkill.spellpower",
+				"subtype" : "spellpower",
 				"type" : "PRIMARY_SKILL",
 				"val" : 1,
 				"valueType" : "BASE_NUMBER"
 			},
 			"knowledge" : {
-				"subtype" : "primarySkill.knowledge",
+				"subtype" : "knowledge",
 				"type" : "PRIMARY_SKILL",
 				"val" : 1,
 				"valueType" : "BASE_NUMBER"
@@ -659,13 +659,13 @@
 	{
 		"bonuses" : {
 			"spellpower" : {
-				"subtype" : "primarySkill.spellpower",
+				"subtype" : "spellpower",
 				"type" : "PRIMARY_SKILL",
 				"val" : 2,
 				"valueType" : "BASE_NUMBER"
 			},
 			"knowledge" : {
-				"subtype" : "primarySkill.knowledge",
+				"subtype" : "knowledge",
 				"type" : "PRIMARY_SKILL",
 				"val" : 2,
 				"valueType" : "BASE_NUMBER"
@@ -678,13 +678,13 @@
 	{
 		"bonuses" : {
 			"spellpower" : {
-				"subtype" : "primarySkill.spellpower",
+				"subtype" : "spellpower",
 				"type" : "PRIMARY_SKILL",
 				"val" : 3,
 				"valueType" : "BASE_NUMBER"
 			},
 			"knowledge" : {
-				"subtype" : "primarySkill.knowledge",
+				"subtype" : "knowledge",
 				"type" : "PRIMARY_SKILL",
 				"val" : 3,
 				"valueType" : "BASE_NUMBER"
@@ -697,13 +697,13 @@
 	{
 		"bonuses" : {
 			"spellpower" : {
-				"subtype" : "primarySkill.spellpower",
+				"subtype" : "spellpower",
 				"type" : "PRIMARY_SKILL",
 				"val" : 4,
 				"valueType" : "BASE_NUMBER"
 			},
 			"knowledge" : {
-				"subtype" : "primarySkill.knowledge",
+				"subtype" : "knowledge",
 				"type" : "PRIMARY_SKILL",
 				"val" : 4,
 				"valueType" : "BASE_NUMBER"
@@ -916,7 +916,7 @@
 						"bonusType" : "PERCENTAGE_DAMAGE_BOOST",
 						"bonusSubtype" : "damageTypeRanged",
 						"bonusSourceType" : "SECONDARY_SKILL",
-						"bonusSourceID" : "secondarySkill.archery"
+						"bonusSourceID" : "archery"
 					}
 				]
 			}
@@ -938,7 +938,7 @@
 						"bonusType" : "PERCENTAGE_DAMAGE_BOOST",
 						"bonusSubtype" : "damageTypeRanged",
 						"bonusSourceType" : "SECONDARY_SKILL",
-						"bonusSourceID" : "secondarySkill.archery"
+						"bonusSourceID" : "archery"
 					}
 				]
 			}
@@ -960,7 +960,7 @@
 						"bonusType" : "PERCENTAGE_DAMAGE_BOOST",
 						"bonusSubtype" : "damageTypeRanged",
 						"bonusSourceType" : "SECONDARY_SKILL",
-						"bonusSourceID" : "secondarySkill.archery"
+						"bonusSourceID" : "archery"
 					}
 				]
 			}
@@ -1168,7 +1168,7 @@
 		"bonuses" : {
 			"spellDamage" : {
 				"type" : "SPELL_DAMAGE",
-				"subtype" : "spellSchool.air",
+				"subtype" : "air",
 				"val" : 50,
 				"valueType" : "BASE_NUMBER"
 			}
@@ -1181,7 +1181,7 @@
 		"bonuses" : {
 			"spellDamage" : {
 				"type" : "SPELL_DAMAGE",
-				"subtype" : "spellSchool.earth",
+				"subtype" : "earth",
 				"val" : 50,
 				"valueType" : "BASE_NUMBER"
 			}
@@ -1194,7 +1194,7 @@
 		"bonuses" : {
 			"spellDamage" : {
 				"type" : "SPELL_DAMAGE",
-				"subtype" : "spellSchool.fire",
+				"subtype" : "fire",
 				"val" : 50,
 				"valueType" : "BASE_NUMBER"
 			}
@@ -1207,7 +1207,7 @@
 		"bonuses" : {
 			"spellDamage" : {
 				"type" : "SPELL_DAMAGE",
-				"subtype" : "spellSchool.water",
+				"subtype" : "water",
 				"val" : 50,
 				"valueType" : "BASE_NUMBER"
 			}
@@ -1466,7 +1466,7 @@
 	{
 		"bonuses" : {
 			"immunity" : {
-				"subtype" : "spell.berserk",
+				"subtype" : "berserk",
 				"type" : "SPELL_IMMUNITY",
 				"val" : 0,
 				"valueType" : "BASE_NUMBER"
@@ -1479,7 +1479,7 @@
 	{
 		"bonuses" : {
 			"immunity" : {
-				"subtype" : "spell.blind",
+				"subtype" : "blind",
 				"type" : "SPELL_IMMUNITY",
 				"val" : 0,
 				"valueType" : "BASE_NUMBER"
@@ -1492,7 +1492,7 @@
 	{
 		"bonuses" : {
 			"immunity" : {
-				"subtype" : "spell.curse",
+				"subtype" : "curse",
 				"type" : "SPELL_IMMUNITY",
 				"val" : 0,
 				"valueType" : "BASE_NUMBER"
@@ -1505,7 +1505,7 @@
 	{
 		"bonuses" : {
 			"immunity" : {
-				"subtype" : "spell.deathRipple",
+				"subtype" : "deathRipple",
 				"type" : "SPELL_IMMUNITY",
 				"val" : 0,
 				"valueType" : "BASE_NUMBER"
@@ -1519,7 +1519,7 @@
 		"bonuses" : {
 			"immunity" : {
 				"limiters" : ["IS_UNDEAD"],
-				"subtype" : "spell.destroyUndead",
+				"subtype" : "destroyUndead",
 				"type" : "SPELL_IMMUNITY",
 				"val" : 0,
 				"valueType" : "BASE_NUMBER"
@@ -1532,7 +1532,7 @@
 	{
 		"bonuses" : {
 			"immunity" : {
-				"subtype" : "spell.hypnotize",
+				"subtype" : "hypnotize",
 				"type" : "SPELL_IMMUNITY",
 				"val" : 0,
 				"valueType" : "BASE_NUMBER"
@@ -1545,13 +1545,13 @@
 	{
 		"bonuses" : {
 			"lightningBolt" : {
-				"subtype" : "spell.lightningBolt",
+				"subtype" : "lightningBolt",
 				"type" : "SPELL_IMMUNITY",
 				"val" : 0,
 				"valueType" : "BASE_NUMBER"
 			},
 			"chainLightning" : {
-				"subtype" : "spell.chainLightning",
+				"subtype" : "chainLightning",
 				"type" : "SPELL_IMMUNITY",
 				"val" : 0,
 				"valueType" : "BASE_NUMBER"
@@ -1564,7 +1564,7 @@
 	{
 		"bonuses" : {
 			"immunity" : {
-				"subtype" : "spell.forgetfulness",
+				"subtype" : "forgetfulness",
 				"type" : "SPELL_IMMUNITY",
 				"val" : 0,
 				"valueType" : "BASE_NUMBER"
@@ -1594,7 +1594,7 @@
 	{
 		"instanceBonuses" : {
 			"crystal" : {
-				"subtype" : "resource.crystal",
+				"subtype" : "crystal",
 				"type" : "GENERATE_RESOURCE",
 				"val" : 1,
 				"valueType" : "BASE_NUMBER",
@@ -1608,7 +1608,7 @@
 	{
 		"instanceBonuses" : {
 			"gems" : {
-				"subtype" : "resource.gems",
+				"subtype" : "gems",
 				"type" : "GENERATE_RESOURCE",
 				"val" : 1,
 				"valueType" : "BASE_NUMBER",
@@ -1622,7 +1622,7 @@
 	{
 		"instanceBonuses" : {
 			"mercury" : {
-				"subtype" : "resource.mercury",
+				"subtype" : "mercury",
 				"type" : "GENERATE_RESOURCE",
 				"val" : 1,
 				"valueType" : "BASE_NUMBER",
@@ -1636,7 +1636,7 @@
 	{
 		"instanceBonuses" : {
 			"ore" : {
-				"subtype" : "resource.ore",
+				"subtype" : "ore",
 				"type" : "GENERATE_RESOURCE",
 				"val" : 1,
 				"valueType" : "BASE_NUMBER",
@@ -1650,7 +1650,7 @@
 	{
 		"instanceBonuses" : {
 			"sulfur" : {
-				"subtype" : "resource.sulfur",
+				"subtype" : "sulfur",
 				"type" : "GENERATE_RESOURCE",
 				"val" : 1,
 				"valueType" : "BASE_NUMBER",
@@ -1664,7 +1664,7 @@
 	{
 		"instanceBonuses" : {
 			"wood" : {
-				"subtype" : "resource.wood",
+				"subtype" : "wood",
 				"type" : "GENERATE_RESOURCE",
 				"val" : 1,
 				"valueType" : "BASE_NUMBER",
@@ -1678,7 +1678,7 @@
 	{
 		"instanceBonuses" : {
 			"gold" : {
-				"subtype" : "resource.gold",
+				"subtype" : "gold",
 				"type" : "GENERATE_RESOURCE",
 				"val" : 1000,
 				"valueType" : "BASE_NUMBER",
@@ -1692,7 +1692,7 @@
 	{
 		"instanceBonuses" : {
 			"gold" : {
-				"subtype" : "resource.gold",
+				"subtype" : "gold",
 				"type" : "GENERATE_RESOURCE",
 				"val" : 750,
 				"valueType" : "BASE_NUMBER",
@@ -1706,7 +1706,7 @@
 	{
 		"instanceBonuses" : {
 			"gold" : {
-				"subtype" : "resource.gold",
+				"subtype" : "gold",
 				"type" : "GENERATE_RESOURCE",
 				"val" : 500,
 				"valueType" : "BASE_NUMBER",
@@ -1797,13 +1797,13 @@
 				"valueType" : "ADDITIVE_VALUE"
 			},
 			"summonBoat" : {
-				"subtype" : "spell.summonBoat",
+				"subtype" : "summonBoat",
 				"type" : "SPELL",
 				"val" : 3,
 				"valueType" : "INDEPENDENT_MAX"
 			},
 			"scuttleBoat" : {
-				"subtype" : "spell.scuttleBoat",
+				"subtype" : "scuttleBoat",
 				"type" : "SPELL",
 				"val" : 3,
 				"valueType" : "INDEPENDENT_MAX"
@@ -1858,14 +1858,14 @@
 		"bonuses" : {
 			"attack" : {
 				"limiters" : ["DRAGON_NATURE"],
-				"subtype" : "primarySkill.attack",
+				"subtype" : "attack",
 				"type" : "PRIMARY_SKILL",
 				"val" : 5,
 				"valueType" : "BASE_NUMBER"
 			},
 			"defence" : {
 				"limiters" : ["DRAGON_NATURE"],
-				"subtype" : "primarySkill.defence",
+				"subtype" : "defence",
 				"type" : "PRIMARY_SKILL",
 				"val" : 5,
 				"valueType" : "BASE_NUMBER"
@@ -1879,37 +1879,37 @@
 	{
 		"bonuses" : {
 			"armageddon" : {
-				"subtype" : "spell.armageddon",
+				"subtype" : "armageddon",
 				"type" : "SPELL",
 				"val" : 3,
 				"valueType" : "INDEPENDENT_MAX"
 			},
 			"immnunity" : {
-				"subtype" : "spell.armageddon",
+				"subtype" : "armageddon",
 				"type" : "SPELL_IMMUNITY",
 				"val" : 0,
 				"valueType" : "BASE_NUMBER"
 			},
 			"attack" : {
-				"subtype" : "primarySkill.attack",
+				"subtype" : "attack",
 				"type" : "PRIMARY_SKILL",
 				"val" : 3,
 				"valueType" : "BASE_NUMBER"
 			},
 			"defence" : {
-				"subtype" : "primarySkill.defence",
+				"subtype" : "defence",
 				"type" : "PRIMARY_SKILL",
 				"val" : 3,
 				"valueType" : "BASE_NUMBER"
 			},
 			"spellpower" : {
-				"subtype" : "primarySkill.spellpower",
+				"subtype" : "spellpower",
 				"type" : "PRIMARY_SKILL",
 				"val" : 3,
 				"valueType" : "BASE_NUMBER"
 			},
 			"knowledge" : {
-				"subtype" : "primarySkill.knowledge",
+				"subtype" : "knowledge",
 				"type" : "PRIMARY_SKILL",
 				"val" : 6,
 				"valueType" : "BASE_NUMBER"
@@ -1937,7 +1937,7 @@
 				"valueType" : "BASE_NUMBER"
 			},
 			"prayer" : {
-				"subtype" : "spell.prayer",
+				"subtype" : "prayer",
 				"type" : "OPENING_BATTLE_SPELL",
 				"val" : 10,
 				"valueType" : "BASE_NUMBER"
@@ -1961,22 +1961,22 @@
 		"bonuses" : {
 			"skeleton" : {
 				"type" : "IMPROVED_NECROMANCY",
-				"subtype" : "creature.skeleton",
+				"subtype" : "skeleton",
 				"addInfo" : 0
 			},
 			"walkingDead" : {
 				"type" : "IMPROVED_NECROMANCY",
-				"subtype" : "creature.walkingDead",
+				"subtype" : "walkingDead",
 				"addInfo" : 1
 			},
 			"wight" : {
 				"type" : "IMPROVED_NECROMANCY",
-				"subtype" : "creature.wight",
+				"subtype" : "wight",
 				"addInfo" : 2
 			},
 			"lich" : {
 				"type" : "IMPROVED_NECROMANCY",
-				"subtype" : "creature.lich",
+				"subtype" : "lich",
 				"addInfo" : 3
 			}
 		},
@@ -1998,7 +1998,7 @@
 				"val" : 25,
 				"valueType" : "PERCENT_TO_BASE",
 				"limiters" : [
-					{ 
+					{
 						"type" : "HAS_ANOTHER_BONUS_LIMITER",
 						"bonusType" : "LIVING"
 					}
@@ -2009,7 +2009,7 @@
 				"val" : 50,
 				"valueType" : "BASE_NUMBER",
 				"limiters" : [
-					{ 
+					{
 						"type" : "HAS_ANOTHER_BONUS_LIMITER",
 						"bonusType" : "LIVING"
 					}
@@ -2030,25 +2030,25 @@
 	{
 		"bonuses" : {
 			"slow" : {
-				"subtype" : "spell.slow",
+				"subtype" : "slow",
 				"type" : "OPENING_BATTLE_SPELL",
 				"val" : 50,
 				"valueType" : "BASE_NUMBER"
 			},
 			"curse" : {
-				"subtype" : "spell.curse",
+				"subtype" : "curse",
 				"type" : "OPENING_BATTLE_SPELL",
 				"val" : 50,
 				"valueType" : "BASE_NUMBER"
 			},
 			"weakness" : {
-				"subtype" : "spell.weakness",
+				"subtype" : "weakness",
 				"type" : "OPENING_BATTLE_SPELL",
 				"val" : 50,
 				"valueType" : "BASE_NUMBER"
 			},
 			"misfortune" : {
-				"subtype" : "spell.misfortune",
+				"subtype" : "misfortune",
 				"type" : "OPENING_BATTLE_SPELL",
 				"val" : 50,
 				"valueType" : "BASE_NUMBER"
@@ -2097,25 +2097,25 @@
 				"valueType" : "INDEPENDENT_MAX"
 			},
 			"attack" : {
-				"subtype" : "primarySkill.attack",
+				"subtype" : "attack",
 				"type" : "PRIMARY_SKILL",
 				"val" : 6,
 				"valueType" : "BASE_NUMBER"
 			},
 			"defence" : {
-				"subtype" : "primarySkill.defence",
+				"subtype" : "defence",
 				"type" : "PRIMARY_SKILL",
 				"val" : 6,
 				"valueType" : "BASE_NUMBER"
 			},
 			"spellpower" : {
-				"subtype" : "primarySkill.spellpower",
+				"subtype" : "spellpower",
 				"type" : "PRIMARY_SKILL",
 				"val" : 6,
 				"valueType" : "BASE_NUMBER"
 			},
 			"knowledge" : {
-				"subtype" : "primarySkill.knowledge",
+				"subtype" : "knowledge",
 				"type" : "PRIMARY_SKILL",
 				"val" : 6,
 				"valueType" : "BASE_NUMBER"
@@ -2139,7 +2139,7 @@
 	{
 		"bonuses" : {
 			"titanBolt" : {
-				"subtype" : "spell.titanBolt",
+				"subtype" : "titanBolt",
 				"type" : "SPELL",
 				"val" : 3,
 				"valueType" : "BASE_NUMBER"
@@ -2249,25 +2249,25 @@
 	{
 		"instanceBonuses" : {
 			"crystal" : {
-				"subtype" : "resource.crystal",
+				"subtype" : "crystal",
 				"type" : "GENERATE_RESOURCE",
 				"val" : 4,
 				"valueType" : "BASE_NUMBER"
 			},
 			"gems" : {
-				"subtype" : "resource.gems",
+				"subtype" : "gems",
 				"type" : "GENERATE_RESOURCE",
 				"val" : 4,
 				"valueType" : "BASE_NUMBER"
 			},
 			"mercury" : {
-				"subtype" : "resource.mercury",
+				"subtype" : "mercury",
 				"type" : "GENERATE_RESOURCE",
 				"val" : 4,
 				"valueType" : "BASE_NUMBER"
 			},
 			"sulfur" : {
-				"subtype" : "resource.sulfur",
+				"subtype" : "sulfur",
 				"type" : "GENERATE_RESOURCE",
 				"val" : 4,
 				"valueType" : "BASE_NUMBER"

--- a/config/battlefields.json
+++ b/config/battlefields.json
@@ -13,7 +13,7 @@
 		"bonuses": [
 			{
 				"type" : "MAGIC_SCHOOL_SKILL",
-				"subtype" : "spellSchool.any",
+				"subtype" : "any",
 				"val" : 3,
 				"valueType" : "BASE_NUMBER"
 			}
@@ -29,7 +29,7 @@
 		"bonuses": [
 			{
 				"type" : "MAGIC_SCHOOL_SKILL",
-				"subtype" : "spellSchool.fire",
+				"subtype" : "fire",
 				"val" : 3,
 				"valueType" : "BASE_NUMBER"
 			}
@@ -41,7 +41,7 @@
 		"bonuses": [
 			{
 				"type" : "MAGIC_SCHOOL_SKILL",
-				"subtype" : "spellSchool.earth",
+				"subtype" : "earth",
 				"val" : 3,
 				"valueType" : "BASE_NUMBER"
 			}
@@ -53,7 +53,7 @@
 		"bonuses": [
 			{
 				"type" : "MAGIC_SCHOOL_SKILL",
-				"subtype" : "spellSchool.air",
+				"subtype" : "air",
 				"val" : 3,
 				"valueType" : "BASE_NUMBER"
 			}
@@ -65,7 +65,7 @@
 		"bonuses": [
 			{
 				"type" : "MAGIC_SCHOOL_SKILL",
-				"subtype" : "spellSchool.water",
+				"subtype" : "water",
 				"val" : 3,
 				"valueType" : "BASE_NUMBER"
 			}

--- a/config/creatures/castle.json
+++ b/config/creatures/castle.json
@@ -395,13 +395,13 @@
 			"hateDevils" :
 			{
 				"type" : "HATE",
-				"subtype" : "creature.devil",
+				"subtype" : "devil",
 				"val" : 50
 			},
 			"hateArchDevils" :
 			{
 				"type" : "HATE",
-				"subtype" : "creature.archDevil",
+				"subtype" : "archDevil",
 				"val" : 50
 			}
 		},
@@ -436,13 +436,13 @@
 			"resurrects" :
 			{
 				"type" : "SPELLCASTER",
-				"subtype" : "spell.resurrection",
+				"subtype" : "resurrection",
 				"val" : 3
 			},
-			"resurrection100hp" : 
+			"resurrection100hp" :
 			{
 				"type" : "SPECIFIC_SPELL_POWER",
-				"subtype" : "spell.resurrection",
+				"subtype" : "resurrection",
 				"val" : 100
 			},
 			"spellpoints" :
@@ -465,13 +465,13 @@
 			"hateDevils" :
 			{
 				"type" : "HATE",
-				"subtype" : "creature.devil",
+				"subtype" : "devil",
 				"val" : 50
 			},
 			"hateArchDevils" :
 			{
 				"type" : "HATE",
-				"subtype" : "creature.archDevil",
+				"subtype" : "archDevil",
 				"val" : 50
 			}
 		},

--- a/config/creatures/conflux.json
+++ b/config/creatures/conflux.json
@@ -67,47 +67,47 @@
 		"faction": "conflux",
 		"abilities":
 		{
-			"nonLiving" : 
+			"nonLiving" :
 			{
 				"type" : "NON_LIVING"
 			},
-			"immuneToMind" : 
+			"immuneToMind" :
 			{
 				"type" : "MIND_IMMUNITY"
 			},
 			"meteorShowerImmunity" :
 			{
 				"type" : "SPELL_IMMUNITY",
-				"subtype" : "spell.meteorShower"
+				"subtype" : "meteorShower"
 			},
 			"lightingVulnerablity" :
 			{
 				"type" : "MORE_DAMAGE_FROM_SPELL",
-				"subtype" : "spell.lightningBolt",
+				"subtype" : "lightningBolt",
 				"val" : 100
 			},
 			"chainLightingVulnerablity" :
 			{
 				"type" : "MORE_DAMAGE_FROM_SPELL",
-				"subtype" : "spell.chainLightning",
+				"subtype" : "chainLightning",
 				"val" : 100
 			},
 			"armageddonVulnerablity" :
 			{
 				"type" : "MORE_DAMAGE_FROM_SPELL",
-				"subtype" : "spell.armageddon",
+				"subtype" : "armageddon",
 				"val" : 100
 			},
 			"oppositeEarth" :
 			{
 				"type" : "HATE",
-				"subtype" : "creature.earthElemental",
+				"subtype" : "earthElemental",
 				"val" : 100
 			},
 			"oppositeMagma" :
 			{
 				"type" : "HATE",
-				"subtype" : "creature.magmaElemental",
+				"subtype" : "magmaElemental",
 				"val" : 100
 			}
 
@@ -136,7 +136,7 @@
 		"shots" : 24,
 		"abilities":
 		{
-			"nonLiving" : 
+			"nonLiving" :
 			{
 				"type" : "NON_LIVING"
 			},
@@ -147,56 +147,56 @@
 			"spellcaster":
 			{
 				"type" : "SPELLCASTER",
-				"subtype" : "spell.protectAir",
+				"subtype" : "protectAir",
 				"val" : 2
 			},
-			"spellPower" : 
+			"spellPower" :
 			{
 				"type" : "CREATURE_ENCHANT_POWER",
 				"val" : 6
 			},
-			"spellPoints" : 
+			"spellPoints" :
 			{
 				"type" : "CASTS",
 				"val" : 3
 			},
-			"immuneToMind" : 
+			"immuneToMind" :
 			{
 				"type" : "MIND_IMMUNITY"
 			},
 			"meteorShowerImmunity" :
 			{
 				"type" : "SPELL_IMMUNITY",
-				"subtype" : "spell.meteorShower"
+				"subtype" : "meteorShower"
 			},
 			"lightingVulnerablity" :
 			{
 				"type" : "MORE_DAMAGE_FROM_SPELL",
-				"subtype" : "spell.lightningBolt",
+				"subtype" : "lightningBolt",
 				"val" : 100
 			},
 			"chainLightingVulnerablity" :
 			{
 				"type" : "MORE_DAMAGE_FROM_SPELL",
-				"subtype" : "spell.chainLightning",
+				"subtype" : "chainLightning",
 				"val" : 100
 			},
 			"armageddonVulnerablity" :
 			{
 				"type" : "MORE_DAMAGE_FROM_SPELL",
-				"subtype" : "spell.armageddon",
+				"subtype" : "armageddon",
 				"val" : 100
 			},
 			"oppositeEarth" :
 			{
 				"type" : "HATE",
-				"subtype" : "creature.earthElemental",
+				"subtype" : "earthElemental",
 				"val" : 100
 			},
 			"oppositeMagma" :
 			{
 				"type" : "HATE",
-				"subtype" : "creature.magmaElemental",
+				"subtype" : "magmaElemental",
 				"val" : 100
 			}
 		},
@@ -229,64 +229,64 @@
 		"doubleWide" : true,
 		"abilities":
 		{
-			"nonLiving" : 
+			"nonLiving" :
 			{
 				"type" : "NON_LIVING"
 			},
-			"immuneToMind" : 
+			"immuneToMind" :
 			{
 				"type" : "MIND_IMMUNITY"
 			},
 			"immuneToIceBolt" :
 			{
 				"type" : "SPELL_IMMUNITY",
-				"subtype" : "spell.iceBolt"
+				"subtype" : "iceBolt"
 			},
 			"immuneToFrostRing" :
 			{
 				"type" : "SPELL_IMMUNITY",
-				"subtype" : "spell.frostRing"
+				"subtype" : "frostRing"
 			},
 			"fireballVulnerablity" :
 			{
 				"type" : "MORE_DAMAGE_FROM_SPELL",
-				"subtype" : "spell.fireball",
+				"subtype" : "fireball",
 				"val" : 100
 			},
 			"infernoVulnerablity" :
 			{
 				"type" : "MORE_DAMAGE_FROM_SPELL",
-				"subtype" : "spell.inferno",
+				"subtype" : "inferno",
 				"val" : 100
 			},
 			"armageddonVulnerablity" :
 			{
 				"type" : "MORE_DAMAGE_FROM_SPELL",
-				"subtype" : "spell.armageddon",
+				"subtype" : "armageddon",
 				"val" : 100
 			},
 			"fireShieldVulnerablity" :
 			{
 				"type" : "MORE_DAMAGE_FROM_SPELL",
-				"subtype" : "spell.fireShield",
+				"subtype" : "fireShield",
 				"val" : 100
 			},
 			"fireWallVulnerablity" :
 			{
 				"type" : "MORE_DAMAGE_FROM_SPELL",
-				"subtype" : "spell.fireWallTrigger",
+				"subtype" : "fireWallTrigger",
 				"val" : 100
 			},
 			"oppositeFire" :
 			{
 				"type" : "HATE",
-				"subtype" : "creature.fireElemental",
+				"subtype" : "fireElemental",
 				"val" : 100
 			},
 			"oppositeEnergy" :
 			{
 				"type" : "HATE",
-				"subtype" : "creature.energyElemental",
+				"subtype" : "energyElemental",
 				"val" : 100
 			}
 		},
@@ -315,7 +315,7 @@
 		"shots" : 24,
 		"abilities":
 		{
-			"nonLiving" : 
+			"nonLiving" :
 			{
 				"type" : "NON_LIVING"
 			},
@@ -326,73 +326,73 @@
 			"spellcaster":
 			{
 				"type" : "SPELLCASTER",
-				"subtype" : "spell.protectWater",
+				"subtype" : "protectWater",
 				"val" : 2
 			},
-			"spellPower" : 
+			"spellPower" :
 			{
 				"type" : "CREATURE_ENCHANT_POWER",
 				"val" : 6
 			},
-			"spellPoints" : 
+			"spellPoints" :
 			{
 				"type" : "CASTS",
 				"val" : 3
 			},
-			"immuneToMind" : 
+			"immuneToMind" :
 			{
 				"type" : "MIND_IMMUNITY"
 			},
 			"immuneToIceBolt" :
 			{
 				"type" : "SPELL_IMMUNITY",
-				"subtype" : "spell.iceBolt"
+				"subtype" : "iceBolt"
 			},
 			"immuneToFrostRing" :
 			{
 				"type" : "SPELL_IMMUNITY",
-				"subtype" : "spell.frostRing"
+				"subtype" : "frostRing"
 			},
 			"fireballVulnerablity" :
 			{
 				"type" : "MORE_DAMAGE_FROM_SPELL",
-				"subtype" : "spell.fireball",
+				"subtype" : "fireball",
 				"val" : 100
 			},
 			"infernoVulnerablity" :
 			{
 				"type" : "MORE_DAMAGE_FROM_SPELL",
-				"subtype" : "spell.inferno",
+				"subtype" : "inferno",
 				"val" : 100
 			},
 			"armageddonVulnerablity" :
 			{
 				"type" : "MORE_DAMAGE_FROM_SPELL",
-				"subtype" : "spell.armageddon",
+				"subtype" : "armageddon",
 				"val" : 100
 			},
 			"fireShieldVulnerablity" :
 			{
 				"type" : "MORE_DAMAGE_FROM_SPELL",
-				"subtype" : "spell.fireShield",
+				"subtype" : "fireShield",
 				"val" : 100
 			},
 			"fireWallVulnerablity" :
 			{
 				"type" : "MORE_DAMAGE_FROM_SPELL",
-				"subtype" : "spell.fireWallTrigger",
+				"subtype" : "fireWallTrigger",
 				"val" : 100
 			},
 			"oppositeFire" :
 			{
 				"type" : "HATE",
-				"subtype" : "creature.fireElemental",
+				"subtype" : "fireElemental",
 				"val" : 100
 			},
 			"oppositeEnergy" :
 			{
 				"type" : "HATE",
-				"subtype" : "creature.energyElemental",
+				"subtype" : "energyElemental",
 				"val" : 100
 			}
 		},
@@ -423,41 +423,41 @@
 		"faction": "conflux",
 		"abilities":
 		{
-			"nonLiving" : 
+			"nonLiving" :
 			{
 				"type" : "NON_LIVING"
 			},
-			"immuneToMind" : 
+			"immuneToMind" :
 			{
 				"type" : "MIND_IMMUNITY"
 			},
-			"immuneToFire" : 
+			"immuneToFire" :
 			{
 				"type" : "SPELL_SCHOOL_IMMUNITY",
-				"subtype" : "spellSchool.fire"
+				"subtype" : "fire"
 			},
 			"iceBoltVulnerablity" :
 			{
 				"type" : "MORE_DAMAGE_FROM_SPELL",
-				"subtype" : "spell.iceBolt",
+				"subtype" : "iceBolt",
 				"val" : 100
 			},
 			"frostRingVulnerablity" :
 			{
 				"type" : "MORE_DAMAGE_FROM_SPELL",
-				"subtype" : "spell.frostRing",
+				"subtype" : "frostRing",
 				"val" : 100
 			},
 			"oppositeWater" :
 			{
 				"type" : "HATE",
-				"subtype" : "creature.waterElemental",
+				"subtype" : "waterElemental",
 				"val" : 100
 			},
 			"oppositeIce" :
 			{
 				"type" : "HATE",
-				"subtype" : "creature.iceElemental",
+				"subtype" : "iceElemental",
 				"val" : 100
 			}
 		},
@@ -484,7 +484,7 @@
 		"faction": "conflux",
 		"abilities":
 		{
-			"nonLiving" : 
+			"nonLiving" :
 			{
 				"type" : "NON_LIVING"
 			},
@@ -495,50 +495,50 @@
 			"spellcaster" :
 			{
 				"type" : "SPELLCASTER",
-				"subtype" : "spell.protectFire",
+				"subtype" : "protectFire",
 				"val" : 2
 			},
-			"spellPower" : 
+			"spellPower" :
 			{
 				"type" : "CREATURE_ENCHANT_POWER",
 				"val" : 6
 			},
-			"spellPoints" : 
+			"spellPoints" :
 			{
 				"type" : "CASTS",
 				"val" : 3
 			},
-			"immuneToMind" : 
+			"immuneToMind" :
 			{
 				"type" : "MIND_IMMUNITY"
 			},
-			"immuneToFire" : 
+			"immuneToFire" :
 			{
 				"type" : "SPELL_SCHOOL_IMMUNITY",
-				"subtype" : "spellSchool.fire"
+				"subtype" : "fire"
 			},
 			"iceBoltVulnerablity" :
 			{
 				"type" : "MORE_DAMAGE_FROM_SPELL",
-				"subtype" : "spell.iceBolt",
+				"subtype" : "iceBolt",
 				"val" : 100
 			},
 			"frostRingVulnerablity" :
 			{
 				"type" : "MORE_DAMAGE_FROM_SPELL",
-				"subtype" : "spell.frostRing",
+				"subtype" : "frostRing",
 				"val" : 100
 			},
 			"oppositeWater" :
 			{
 				"type" : "HATE",
-				"subtype" : "creature.waterElemental",
+				"subtype" : "waterElemental",
 				"val" : 100
 			},
 			"oppositeIce" :
 			{
 				"type" : "HATE",
-				"subtype" : "creature.iceElemental",
+				"subtype" : "iceElemental",
 				"val" : 100
 			}
 		},
@@ -564,45 +564,45 @@
 		"faction": "conflux",
 		"abilities":
 		{
-			"nonLiving" : 
+			"nonLiving" :
 			{
 				"type" : "NON_LIVING"
 			},
-			"immuneToMind" : 
+			"immuneToMind" :
 			{
 				"type" : "MIND_IMMUNITY"
 			},
 			"lightingImmunity" :
 			{
 				"type" : "SPELL_IMMUNITY",
-				"subtype" : "spell.lightningBolt"
+				"subtype" : "lightningBolt"
 			},
 			"chainLightingImmunity" :
 			{
 				"type" : "SPELL_IMMUNITY",
-				"subtype" : "spell.chainLightning"
+				"subtype" : "chainLightning"
 			},
 			"armageddonImmunity" :
 			{
 				"type" : "SPELL_IMMUNITY",
-				"subtype" : "spell.armageddon"
+				"subtype" : "armageddon"
 			},
 			"meteorShowerVulnerability" :
 			{
 				"type" : "MORE_DAMAGE_FROM_SPELL",
-				"subtype" : "spell.meteorShower",
+				"subtype" : "meteorShower",
 				"val" : 100
 			},
 			"oppositeAir" :
 			{
 				"type" : "HATE",
-				"subtype" : "creature.airElemental",
+				"subtype" : "airElemental",
 				"val" : 100
 			},
 			"oppositeStorm" :
 			{
 				"type" : "HATE",
-				"subtype" : "creature.stormElemental",
+				"subtype" : "stormElemental",
 				"val" : 100
 			}
 		},
@@ -629,61 +629,61 @@
 		"faction": "conflux",
 		"abilities":
 		{
-			"nonLiving" : 
+			"nonLiving" :
 			{
 				"type" : "NON_LIVING"
 			},
 			"spellcaster":
 			{
 				"type" : "SPELLCASTER",
-				"subtype" : "spell.protectEarth",
+				"subtype" : "protectEarth",
 				"val" : 2
 			},
-			"spellPower" : 
+			"spellPower" :
 			{
 				"type" : "CREATURE_ENCHANT_POWER",
 				"val" : 6
 			},
-			"spellPoints" : 
+			"spellPoints" :
 			{
 				"type" : "CASTS",
 				"val" : 3
 			},
-			"immuneToMind" : 
+			"immuneToMind" :
 			{
 				"type" : "MIND_IMMUNITY"
 			},
 			"lightingImmunity" :
 			{
 				"type" : "SPELL_IMMUNITY",
-				"subtype" : "spell.lightningBolt"
+				"subtype" : "lightningBolt"
 			},
 			"chainLightingImmunity" :
 			{
 				"type" : "SPELL_IMMUNITY",
-				"subtype" : "spell.chainLightning"
+				"subtype" : "chainLightning"
 			},
 			"armageddonImmunity" :
 			{
 				"type" : "SPELL_IMMUNITY",
-				"subtype" : "spell.armageddon"
+				"subtype" : "armageddon"
 			},
 			"meteorShowerVulnerability" :
 			{
 				"type" : "MORE_DAMAGE_FROM_SPELL",
-				"subtype" : "spell.meteorShower",
+				"subtype" : "meteorShower",
 				"val" : 100
 			},
 			"oppositeAir" :
 			{
 				"type" : "HATE",
-				"subtype" : "creature.airElemental",
+				"subtype" : "airElemental",
 				"val" : 100
 			},
 			"oppositeStorm" :
 			{
 				"type" : "HATE",
-				"subtype" : "creature.stormElemental",
+				"subtype" : "stormElemental",
 				"val" : 100
 			}
 		},
@@ -709,7 +709,7 @@
 		"faction": "conflux",
 		"abilities":
 		{
-			"nonLiving" : 
+			"nonLiving" :
 			{
 				"type" : "NON_LIVING"
 			},
@@ -750,7 +750,7 @@
 		"faction": "conflux",
 		"abilities":
 		{
-			"nonLiving" : 
+			"nonLiving" :
 			{
 				"type" : "NON_LIVING"
 			},
@@ -804,7 +804,7 @@
 			"immuneToFire" :
 			{
 				"type" : "SPELL_SCHOOL_IMMUNITY",
-				"subtype" : "spellSchool.fire"
+				"subtype" : "fire"
 			},
 			"KING_1" : // Will be affected by Slayer with no expertise
 			{
@@ -848,7 +848,7 @@
 				"type" : "CASTS",
 				"val" : 1
 			},
-			"rebirth" : 
+			"rebirth" :
 			{
 				"type" : "REBIRTH",
 				"val" : 20
@@ -856,7 +856,7 @@
 			"immuneToFire" :
 			{
 				"type" : "SPELL_SCHOOL_IMMUNITY",
-				"subtype" : "spellSchool.fire"
+				"subtype" : "fire"
 			},
 			"KING_1" : // Will be affected by Slayer with no expertise
 			{

--- a/config/creatures/dungeon.json
+++ b/config/creatures/dungeon.json
@@ -6,15 +6,15 @@
 		"faction": "dungeon",
 		"abilities":
 		{
-			"blindImmunity" : 
+			"blindImmunity" :
 			{
 				"type" : "SPELL_IMMUNITY",
-				"subtype" : "spell.blind"
+				"subtype" : "blind"
 			},
-			"petrifyImmunity" : 
+			"petrifyImmunity" :
 			{
 				"type" : "SPELL_IMMUNITY",
-				"subtype" : "spell.stoneGaze"
+				"subtype" : "stoneGaze"
 			}
 		},
 		"upgrades": ["infernalTroglodyte"],
@@ -41,15 +41,15 @@
 		"faction": "dungeon",
 		"abilities":
 		{
-			"blindImmunity" : 
+			"blindImmunity" :
 			{
 				"type" : "SPELL_IMMUNITY",
-				"subtype" : "spell.blind"
+				"subtype" : "blind"
 			},
-			"petrifyImmunity" : 
+			"petrifyImmunity" :
 			{
 				"type" : "SPELL_IMMUNITY",
-				"subtype" : "spell.stoneGaze"
+				"subtype" : "stoneGaze"
 			}
 		},
 		"graphics" :
@@ -78,7 +78,7 @@
 			{
 				"type" : "FLYING"
 			},
-			"strikeAndReturn" : 
+			"strikeAndReturn" :
 			{
 				"type" : "RETURN_AFTER_STRIKE"
 			}
@@ -111,11 +111,11 @@
 			{
 				"type" : "FLYING"
 			},
-			"strikeAndReturn" : 
+			"strikeAndReturn" :
 			{
 				"type" : "RETURN_AFTER_STRIKE"
 			},
-			"noRetaliation" : 
+			"noRetaliation" :
 			{
 				"type" : "BLOCKS_RETALIATION"
 			}
@@ -245,7 +245,7 @@
 			"petrification" :
 			{
 				"type" : "SPELL_AFTER_ATTACK",
-				"subtype" : "spell.stoneGaze",
+				"subtype" : "stoneGaze",
 				"val" : 20,
 				"addInfo" : [0,2]
 			}
@@ -291,7 +291,7 @@
 			"petrification" :
 			{
 				"type" : "SPELL_AFTER_ATTACK",
-				"subtype" : "spell.stoneGaze",
+				"subtype" : "stoneGaze",
 				"val" : 20,
 				"addInfo" : [0,2]
 			}
@@ -321,7 +321,7 @@
 		"index": 78,
 		"level": 5,
 		"faction": "dungeon",
-		"abilities": 
+		"abilities":
 		{
 			"fearless" :
 			{
@@ -421,7 +421,7 @@
 			"paralize" :
 			{
 				"type" : "SPELL_AFTER_ATTACK",
-				"subtype" : "spell.paralyze",
+				"subtype" : "paralyze",
 				"val" : 20
 			}
 		},
@@ -449,11 +449,11 @@
 		"doubleWide" : true,
 		"abilities":
 		{
-			"dragon" : 
+			"dragon" :
 			{
 				"type" : "DRAGON_NATURE"
 			},
-			"dragonSkeleton" : 
+			"dragonSkeleton" :
 			{
 				"type" : "SKELETON_TRANSFORMER_TARGET",
 				"subtype" : "boneDragon"
@@ -501,11 +501,11 @@
 		"doubleWide" : true,
 		"abilities":
 		{
-			"dragon" : 
+			"dragon" :
 			{
 				"type" : "DRAGON_NATURE"
 			},
-			"dragonSkeleton" : 
+			"dragonSkeleton" :
 			{
 				"type" : "SKELETON_TRANSFORMER_TARGET",
 				"subtype" : "boneDragon"
@@ -531,7 +531,7 @@
 			"hateTitans" :
 			{
 				"type" : "HATE",
-				"subtype" : "creature.titan",
+				"subtype" : "titan",
 				"val" : 50
 			}
 		},

--- a/config/creatures/fortress.json
+++ b/config/creatures/fortress.json
@@ -124,7 +124,7 @@
 			"dispellHelpful" :
 			{
 				"type" : "SPELL_AFTER_ATTACK",
-				"subtype" : "spell.dispelHelpful",
+				"subtype" : "dispelHelpful",
 				"val" : 100
 			}
 		},
@@ -159,13 +159,13 @@
 			"dispellHelpful" :
 			{
 				"type" : "SPELL_AFTER_ATTACK",
-				"subtype" : "spell.dispelHelpful",
+				"subtype" : "dispelHelpful",
 				"val" : 100
 			},
 			"castWeakness" :
 			{
 				"type" : "SPELL_AFTER_ATTACK",
-				"subtype" : "spell.weakness",
+				"subtype" : "weakness",
 				"val" : 100
 			}
 		},
@@ -196,7 +196,7 @@
 			"petrify" :
 			{
 				"type" : "SPELL_AFTER_ATTACK",
-				"subtype" : "spell.stoneGaze",
+				"subtype" : "stoneGaze",
 				"val" : 20
 			}
 		},
@@ -227,7 +227,7 @@
 			"petrify" :
 			{
 				"type" : "SPELL_AFTER_ATTACK",
-				"subtype" : "spell.stoneGaze",
+				"subtype" : "stoneGaze",
 				"val" : 20
 			}
 		},
@@ -276,7 +276,7 @@
 		"doubleWide" : true,
 		"abilities":
 		{
-			"deathStare" : 
+			"deathStare" :
 			{
 				"type" : "COMBAT_EVENT_TRIGGER",
 				"subtype" : "deathStare",
@@ -343,7 +343,7 @@
 			"poison" :
 			{
 				"type" : "SPELL_AFTER_ATTACK",
-				"subtype" : "spell.poison",
+				"subtype" : "poison",
 				"val" : 30
 			}
 		},
@@ -374,7 +374,7 @@
 			{
 				"type" : "ATTACKS_ALL_ADJACENT"
 			},
-			"dragonSkeleton" : 
+			"dragonSkeleton" :
 			{
 				"type" : "SKELETON_TRANSFORMER_TARGET",
 				"subtype" : "boneDragon"
@@ -417,7 +417,7 @@
 			{
 				"type" : "ATTACKS_ALL_ADJACENT"
 			},
-			"dragonSkeleton" : 
+			"dragonSkeleton" :
 			{
 				"type" : "SKELETON_TRANSFORMER_TARGET",
 				"subtype" : "boneDragon"

--- a/config/creatures/inferno.json
+++ b/config/creatures/inferno.json
@@ -98,7 +98,7 @@
 			"fireball" :
 			{
 				"type" : "SPELL_LIKE_ATTACK",
-				"subtype" : "spell.fireballAbility"
+				"subtype" : "fireballAbility"
 			}
 		},
 		"graphics" :
@@ -155,7 +155,7 @@
 			{
 				"type" : "BLOCKS_RETALIATION"
 			},
-			"threeHeads" : 
+			"threeHeads" :
 			{
 				"type" : "THREE_HEADED_ATTACK"
 			}
@@ -244,16 +244,16 @@
 		"faction": "inferno",
 		"abilities":
 		{
-			"summons50HP" : 
+			"summons50HP" :
 			{
 				"type" : "SPECIFIC_SPELL_POWER",
-				"subtype" : "spell.summonDemons",
+				"subtype" : "summonDemons",
 				"val" : 50
 			},
 			"resurrects" :
 			{
 				"type" : "SPELLCASTER",
-				"subtype" : "spell.summonDemons",
+				"subtype" : "summonDemons",
 				"val" : 0
 			},
 			"castsAmount" :
@@ -281,7 +281,7 @@
 	{
 		"index": 52,
 		"level": 6,
-		"faction": "inferno", 
+		"faction": "inferno",
 		"abilities":
 		{
 			"canFly" :
@@ -291,18 +291,18 @@
 			"immuneToFire" :
 			{
 				"type" : "SPELL_SCHOOL_IMMUNITY",
-				"subtype" : "spellSchool.fire"
+				"subtype" : "fire"
 			},
-			"hateGenies" : 
+			"hateGenies" :
 			{
 				"type" : "HATE",
-				"subtype" : "creature.genie",
+				"subtype" : "genie",
 				"val" : 50
 			},
-			"hateMasterGenies" : 
+			"hateMasterGenies" :
 			{
 				"type" : "HATE",
-				"subtype" : "creature.masterGenie",
+				"subtype" : "masterGenie",
 				"val" : 50
 			}
 		},
@@ -344,18 +344,18 @@
 			"immuneToFire" :
 			{
 				"type" : "SPELL_SCHOOL_IMMUNITY",
-				"subtype" : "spellSchool.fire"
+				"subtype" : "fire"
 			},
-			"hateGenies" : 
+			"hateGenies" :
 			{
 				"type" : "HATE",
-				"subtype" : "creature.genie",
+				"subtype" : "genie",
 				"val" : 50
 			},
-			"hateMasterGenies" : 
+			"hateMasterGenies" :
 			{
 				"type" : "HATE",
-				"subtype" : "creature.masterGenie",
+				"subtype" : "masterGenie",
 				"val" : 50
 			}
 		},
@@ -406,16 +406,16 @@
 				"type" : "KING",
 				"val" : 2
 			},
-			"hateAngels" : 
+			"hateAngels" :
 			{
 				"type" : "HATE",
-				"subtype" : "creature.angel",
+				"subtype" : "angel",
 				"val" : 50
 			},
-			"hateArchAngels" : 
+			"hateArchAngels" :
 			{
 				"type" : "HATE",
-				"subtype" : "creature.archangel",
+				"subtype" : "archangel",
 				"val" : 50,
 				"description" : "Devil -1"
 			}
@@ -469,16 +469,16 @@
 				"type" : "KING",
 				"val" : 2
 			},
-			"hateAngels" : 
+			"hateAngels" :
 			{
 				"type" : "HATE",
-				"subtype" : "creature.angel",
+				"subtype" : "angel",
 				"val" : 50
 			},
-			"hateArchAngels" : 
+			"hateArchAngels" :
 			{
 				"type" : "HATE",
-				"subtype" : "creature.archangel",
+				"subtype" : "archangel",
 				"val" : 50
 			}
 		},

--- a/config/creatures/necropolis.json
+++ b/config/creatures/necropolis.json
@@ -108,10 +108,10 @@
 			{
 				"type" : "UNDEAD"
 			},
-			"castDisease" : 
+			"castDisease" :
 			{
 				"type" : "SPELL_AFTER_ATTACK",
-				"subtype" : "spell.disease",
+				"subtype" : "disease",
 				"val" : 20
 			}
 		}
@@ -131,7 +131,7 @@
 			{
 				"type" : "FLYING"
 			},
-			"regenerate" : 
+			"regenerate" :
 			{
 				"type" : "HP_REGENERATION",
 				"val" : 50
@@ -169,7 +169,7 @@
 			{
 				"type" : "FLYING"
 			},
-			"regenerate" : 
+			"regenerate" :
 			{
 				"type" : "HP_REGENERATION",
 				"val" : 50
@@ -210,7 +210,7 @@
 			{
 				"type" : "FLYING"
 			},
-			"noRetalitation" : 
+			"noRetalitation" :
 			{
 				"type" : "BLOCKS_RETALIATION"
 			}
@@ -248,7 +248,7 @@
 			{
 				"type" : "FLYING"
 			},
-			"noRetalitation" : 
+			"noRetalitation" :
 			{
 				"type" : "BLOCKS_RETALIATION"
 			},
@@ -296,7 +296,7 @@
 			"deathCloud" :
 			{
 				"type" : "SPELL_LIKE_ATTACK",
-				"subtype" : "spell.deathCloud"
+				"subtype" : "deathCloud"
 			}
 		},
 		"upgrades": ["powerLich"],
@@ -339,7 +339,7 @@
 			"deathCloud" :
 			{
 				"type" : "SPELL_LIKE_ATTACK",
-				"subtype" : "spell.deathCloud"
+				"subtype" : "deathCloud"
 			}
 		},
 		"graphics" :
@@ -377,7 +377,7 @@
 			"curses" :
 			{
 				"type" : "SPELL_AFTER_ATTACK",
-				"subtype" : "spell.curse",
+				"subtype" : "curse",
 				"val" : 20
 			}
 		},
@@ -412,7 +412,7 @@
 			"curses" :
 			{
 				"type" : "SPELL_AFTER_ATTACK",
-				"subtype" : "spell.curse",
+				"subtype" : "curse",
 				"val" : 20
 			},
 			"deathStrike" :
@@ -511,7 +511,7 @@
 			"age" :
 			{
 				"type" : "SPELL_AFTER_ATTACK",
-				"subtype" : "spell.age",
+				"subtype" : "age",
 				"val" : 20
 			},
 			"decreaseMorale" :

--- a/config/creatures/neutral.json
+++ b/config/creatures/neutral.json
@@ -14,7 +14,7 @@
 			"magicResistance" :
 			{
 				"type" : "SPELL_DAMAGE_REDUCTION",
-				"subtype" : "spellSchool.any",
+				"subtype" : "any",
 				"val" : 85
 			}
 		},
@@ -47,7 +47,7 @@
 			"magicResistance" :
 			{
 				"type" : "SPELL_DAMAGE_REDUCTION",
-				"subtype" : "spellSchool.any",
+				"subtype" : "any",
 				"val" : 95
 			}
 		},
@@ -75,11 +75,11 @@
 		"doubleWide" : true,
 		"abilities":
 		{
-			"dragon" : 
+			"dragon" :
 			{
 				"type" : "DRAGON_NATURE"
 			},
-			"dragonSkeleton" : 
+			"dragonSkeleton" :
 			{
 				"type" : "SKELETON_TRANSFORMER_TARGET",
 				"subtype" : "boneDragon"
@@ -99,8 +99,8 @@
 				"propagator": "BATTLE_WIDE",
 				"propagationUpdater" : "BONUS_OWNER_UPDATER",
 				"description" : "PLACEHOLDER",
-				"limiters" : [ 
-					"OPPOSITE_SIDE", 
+				"limiters" : [
+					"OPPOSITE_SIDE",
 					{
 						"type" : "HAS_ANOTHER_BONUS_LIMITER",
 						"bonusType" : "LIVING"
@@ -113,7 +113,7 @@
 				"valueType" : "INDEPENDENT_MIN",
 				"description" : "PLACEHOLDER",
 				"val" : 0
-				
+
 			},
 			"spellImmunity" :
 			{
@@ -154,7 +154,7 @@
 			{
 				"type" : "DRAGON_NATURE"
 			},
-			"dragonSkeleton" : 
+			"dragonSkeleton" :
 			{
 				"type" : "SKELETON_TRANSFORMER_TARGET",
 				"subtype" : "boneDragon"
@@ -202,7 +202,7 @@
 			{
 				"type" : "DRAGON_NATURE"
 			},
-			"dragonSkeleton" : 
+			"dragonSkeleton" :
 			{
 				"type" : "SKELETON_TRANSFORMER_TARGET",
 				"subtype" : "boneDragon"
@@ -229,56 +229,56 @@
 			"castsMagicArrow" :
 			{
 				"type" : "SPELLCASTER",
-				"subtype" : "spell.magicArrow",
+				"subtype" : "magicArrow",
 				"addInfo" : 22,
 				"val" : 2
 			},
 			"castsIceBolt" :
 			{
 				"type" : "SPELLCASTER",
-				"subtype" : "spell.iceBolt",
+				"subtype" : "iceBolt",
 				"addInfo" : 22,
 				"val" : 2
 			},
 			"castsLightningBolt" :
 			{
 				"type" : "SPELLCASTER",
-				"subtype" : "spell.lightningBolt",
+				"subtype" : "lightningBolt",
 				"addInfo" : 22,
 				"val" : 2
 			},
 			"castsChainLightning" :
 			{
 				"type" : "SPELLCASTER",
-				"subtype" : "spell.chainLightning",
+				"subtype" : "chainLightning",
 				"addInfo" : 5,
 				"val" : 2
 			},
 			"castsFrostRing" :
 			{
 				"type" : "SPELLCASTER",
-				"subtype" : "spell.frostRing",
+				"subtype" : "frostRing",
 				"addInfo" : 10,
 				"val" : 2
 			},
 			"castsFireball" :
 			{
 				"type" : "SPELLCASTER",
-				"subtype" : "spell.fireball",
+				"subtype" : "fireball",
 				"addInfo" : 21,
 				"val" : 2
 			},
 			"castsInferno" :
 			{
 				"type" : "SPELLCASTER",
-				"subtype" : "spell.inferno",
+				"subtype" : "inferno",
 				"addInfo" : 5,
 				"val" : 2
 			},
 			"castsMeteorShower" :
 			{
 				"type" : "SPELLCASTER",
-				"subtype" : "spell.meteorShower",
+				"subtype" : "meteorShower",
 				"addInfo" : 5,
 				"val" : 2
 			},
@@ -313,11 +313,11 @@
 		"doubleWide" : true,
 		"abilities":
 		{
-			"dragon" : 
+			"dragon" :
 			{
 				"type" : "DRAGON_NATURE"
 			},
-			"dragonSkeleton" : 
+			"dragonSkeleton" :
 			{
 				"type" : "SKELETON_TRANSFORMER_TARGET",
 				"subtype" : "boneDragon"
@@ -333,20 +333,20 @@
 			"acidBreath" :
 			{
 				"type" : "SPELL_AFTER_ATTACK",
-				"subtype" : "spell.acidBreathDamage",
+				"subtype" : "acidBreathDamage",
 				"val" : 20
 			},
 			// damage of the cast above, multiplied by the number of dragons in the stack
 			"acidBreathDamage" :
 			{
 				"type" : "SPECIFIC_SPELL_POWER",
-				"subtype" : "spell.acidBreathDamage",
+				"subtype" : "acidBreathDamage",
 				"val" : 25
 			},
 			"reduceDefence" :
 			{
 				"type" : "SPELL_AFTER_ATTACK",
-				"subtype" : "spell.acidBreath",
+				"subtype" : "acidBreath",
 				"val" : 100
 			},
 			"KING_1" : // Will be affected by Slayer with no expertise
@@ -400,42 +400,42 @@
 			"castsHaste" :
 			{
 				"type" : "ENCHANTER",
-				"subtype" : "spell.haste",
+				"subtype" : "haste",
 				"val" : 3,
 				"addInfo" : 3
 			},
 			"castsSlow" :
 			{
 				"type" : "ENCHANTER",
-				"subtype" : "spell.slow",
+				"subtype" : "slow",
 				"val" : 3,
 				"addInfo" : 3
 			},
 			"castsStoneSkin" :
 			{
 				"type" : "ENCHANTER",
-				"subtype" : "spell.stoneSkin",
+				"subtype" : "stoneSkin",
 				"val" : 3,
 				"addInfo" : 3
 			},
 			"castsBless" :
 			{
 				"type" : "ENCHANTER",
-				"subtype" : "spell.bless",
+				"subtype" : "bless",
 				"val" : 3,
 				"addInfo" : 3
 			},
 			"castsWeakness" :
 			{
 				"type" : "ENCHANTER",
-				"subtype" : "spell.weakness",
+				"subtype" : "weakness",
 				"val" : 3,
 				"addInfo" : 3
 			},
 			"castsAirShield" :
 			{
 				"type" : "ENCHANTER",
-				"subtype" : "spell.airShield",
+				"subtype" : "airShield",
 				"val" : 3,
 				"addInfo" : 3
 			}
@@ -509,7 +509,7 @@
 		"level": 1,
 		"faction": "neutral",
 		"shots" : 24,
-		"abilities": 
+		"abilities":
 		{
 			"shooter" :
 			{
@@ -598,7 +598,7 @@
 			"castCurse" :
 			{
 				"type" : "SPELL_AFTER_ATTACK",
-				"subtype" : "spell.curse",
+				"subtype" : "curse",
 				"val" : 50
 			}
 		},
@@ -628,7 +628,7 @@
 			"sandWalker" :
 			{
 				"type" : "NO_TERRAIN_PENALTY",
-				"subtype" : "terrain.sand",
+				"subtype" : "sand",
 				"propagator" : "HERO",
 				"description" : "PLACEHOLDER"
 			}

--- a/config/creatures/rampart.json
+++ b/config/creatures/rampart.json
@@ -253,7 +253,7 @@
 			"binds" :
 			{
 				"type" : "SPELL_AFTER_ATTACK",
-				"subtype" : "spell.bind",
+				"subtype" : "bind",
 				"val" : 100
 			}
 		},
@@ -283,7 +283,7 @@
 			"binds" :
 			{
 				"type" : "SPELL_AFTER_ATTACK",
-				"subtype" : "spell.bind",
+				"subtype" : "bind",
 				"val" : 100
 			}
 		},
@@ -313,7 +313,7 @@
 			"blinds" :
 			{
 				"type" : "SPELL_AFTER_ATTACK",
-				"subtype" : "spell.blind",
+				"subtype" : "blind",
 				"val" : 20,
 				"addInfo" : [3,0]
 			},
@@ -350,7 +350,7 @@
 			"blinds" :
 			{
 				"type" : "SPELL_AFTER_ATTACK",
-				"subtype" : "spell.blind",
+				"subtype" : "blind",
 				"val" : 20,
 				"addInfo" : [3,0]
 			},
@@ -388,7 +388,7 @@
 			{
 				"type" : "DRAGON_NATURE"
 			},
-			"dragonSkeleton" : 
+			"dragonSkeleton" :
 			{
 				"type" : "SKELETON_TRANSFORMER_TARGET",
 				"subtype" : "boneDragon"
@@ -440,7 +440,7 @@
 			{
 				"type" : "DRAGON_NATURE"
 			},
-			"dragonSkeleton" : 
+			"dragonSkeleton" :
 			{
 				"type" : "SKELETON_TRANSFORMER_TARGET",
 				"subtype" : "boneDragon"

--- a/config/creatures/special.json
+++ b/config/creatures/special.json
@@ -51,7 +51,7 @@
 			"siegeMachine" :
 			{
 				"type" : "CATAPULT",
-				"subtype" : "spell.catapultShot"
+				"subtype" : "catapultShot"
 			}
 		},
 		"graphics" :
@@ -123,7 +123,7 @@
 			"heals" :
 			{
 				"type" : "HEALER" ,
-				"subtype" : "spell.firstAid"
+				"subtype" : "firstAid"
 			}
 		},
 		"graphics" :
@@ -142,7 +142,7 @@
 		"index": 148,
 		"level": 0,
 		"faction": "neutral",
-		"abilities": 
+		"abilities":
 		{
 			"siegeWeapon" :
 			{

--- a/config/creatures/stronghold.json
+++ b/config/creatures/stronghold.json
@@ -192,7 +192,7 @@
 			"castsBloodlust" :
 			{
 				"type" : "SPELLCASTER",
-				"subtype" : "spell.bloodlust",
+				"subtype" : "bloodlust",
 				"val" : 2
 			},
 			"castsCount" :
@@ -266,13 +266,13 @@
 			"thunderOnAttack" :
 			{
 				"type" : "SPELL_AFTER_ATTACK",
-				"subtype" : "spell.thunderbolt",
+				"subtype" : "thunderbolt",
 				"val" : 20
 			},
 			"thunderStrength" :
 			{
 				"type" : "SPECIFIC_SPELL_POWER",
-				"subtype" : "spell.thunderbolt",
+				"subtype" : "thunderbolt",
 				"val" : 10
 			}
 		},
@@ -306,7 +306,7 @@
 			"canShootWalls" :
 			{
 				"type" : "CATAPULT",
-				"subtype" : "spell.cyclopsShot"
+				"subtype" : "cyclopsShot"
 			}
 		},
 		"upgrades": ["cyclopKing"],
@@ -345,12 +345,12 @@
 			"canShootWalls" :
 			{
 				"type" : "CATAPULT",
-				"subtype" : "spell.cyclopsShot"
+				"subtype" : "cyclopsShot"
 			},
 			"canShootWallsTimes" :
 			{
 				"type" : "CATAPULT_EXTRA_SHOTS",
-				"subtype" : "spell.cyclopsShot",
+				"subtype" : "cyclopsShot",
 				"valueType" : "BASE_NUMBER",
 				"val" : 1
 			}

--- a/config/creatures/tower.json
+++ b/config/creatures/tower.json
@@ -133,7 +133,7 @@
 			"magicResistance" :
 			{
 				"type" : "SPELL_DAMAGE_REDUCTION",
-				"subtype" : "spellSchool.any",
+				"subtype" : "any",
 				"val" : 50
 			}
 		},
@@ -167,7 +167,7 @@
 			"magicResistance" :
 			{
 				"type" : "SPELL_DAMAGE_REDUCTION",
-				"subtype" : "spellSchool.any",
+				"subtype" : "any",
 				"val" : 75
 			}
 		},
@@ -192,7 +192,7 @@
 		"level": 4,
 		"faction": "tower",
 		"shots" : 24,
-		"abilities": 
+		"abilities":
 		{
 			"shooter" :
 			{
@@ -202,7 +202,7 @@
 			{
 				"type" : "NO_MELEE_PENALTY"
 			},
-			"reduceSpellCost" : 
+			"reduceSpellCost" :
 			{
 				"type" : "CHANGES_SPELL_COST_FOR_ALLY",
 				"val" :  2
@@ -235,7 +235,7 @@
 		"level": 4,
 		"faction": "tower",
 		"shots" : 24,
-		"abilities": 
+		"abilities":
 		{
 			"shooter" :
 			{
@@ -249,7 +249,7 @@
 			{
 				"type" : "NO_WALL_PENALTY"
 			},
-			"reduceSpellCost" : 
+			"reduceSpellCost" :
 			{
 				"type" : "CHANGES_SPELL_COST_FOR_ALLY",
 				"val" :  2
@@ -294,16 +294,16 @@
 			{
 				"type" : "FLYING"
 			},
-			"hateEfreet" : 
+			"hateEfreet" :
 			{
 				"type" : "HATE",
-				"subtype" : "creature.efreet",
+				"subtype" : "efreet",
 				"val" : 50
 			},
-			"hateEfreetSultans" : 
+			"hateEfreetSultans" :
 			{
 				"type" : "HATE",
-				"subtype" : "creature.efreetSultan",
+				"subtype" : "efreetSultan",
 				"val" : 50
 			}
 		},
@@ -339,7 +339,7 @@
 				"type" : "CASTS",
 				"val" : 3
 			},
-			"spellsLength" : 
+			"spellsLength" :
 			{
 				"type" : "CREATURE_ENCHANT_POWER",
 				"val" : 5
@@ -349,16 +349,16 @@
 				"type" : "RANDOM_SPELLCASTER",
 				"val" : 2
 			},
-			"hateEfreet" : 
+			"hateEfreet" :
 			{
 				"type" : "HATE",
-				"subtype" : "creature.efreet",
+				"subtype" : "efreet",
 				"val" : 50
 			},
-			"hateEfreetSultans" : 
+			"hateEfreetSultans" :
 			{
 				"type" : "HATE",
-				"subtype" : "creature.efreetSultan",
+				"subtype" : "efreetSultan",
 				"val" : 50
 			}
 		},
@@ -386,7 +386,7 @@
 		"doubleWide" : true,
 		"abilities" :
 		{
-			"noRetaliation" : 
+			"noRetaliation" :
 			{
 				"type" : "BLOCKS_RETALIATION"
 			}
@@ -415,7 +415,7 @@
 		"doubleWide" : true,
 		"abilities" :
 		{
-			"noRetaliation" : 
+			"noRetaliation" :
 			{
 				"type" : "BLOCKS_RETALIATION"
 			}
@@ -442,7 +442,7 @@
 		"faction": "tower",
 		"abilities" :
 		{
-			"immuneToMind" : 
+			"immuneToMind" :
 			{
 				"type" : "MIND_IMMUNITY"
 			},
@@ -484,7 +484,7 @@
 			{
 				"type" : "NO_MELEE_PENALTY"
 			},
-			"immuneToMind" : 
+			"immuneToMind" :
 			{
 				"type" : "MIND_IMMUNITY"
 			},
@@ -493,10 +493,10 @@
 				"type" : "KING",
 				"val" : 3
 			},
-			"hateBlackDragons" : 
+			"hateBlackDragons" :
 			{
 				"type" : "HATE",
-				"subtype" : "creature.blackDragon",
+				"subtype" : "blackDragon",
 				"val" : 50
 			}
 		},

--- a/config/factions/dungeon.json
+++ b/config/factions/dungeon.json
@@ -211,7 +211,7 @@
 						]
 					}
 				},
-				"grail":          { "bonuses": [ { "type": "PRIMARY_SKILL", "subtype": "primarySkill.spellpower", "val": 12 } ] },
+				"grail":          { "bonuses": [ { "type": "PRIMARY_SKILL", "subtype": "spellpower", "val": 12 } ] },
 
 				"dwellingLvl1":   { "requires" : [ "fort" ] },
 				"dwellingLvl2":   { "requires" : [ "dwellingLvl1" ] },

--- a/config/factions/fortress.json
+++ b/config/factions/fortress.json
@@ -192,7 +192,7 @@
 					"bonuses": [
 						{
 							"type": "PRIMARY_SKILL",
-							"subtype": "primarySkill.attack",
+							"subtype": "attack",
 							"val": 2
 						}
 					],
@@ -202,7 +202,7 @@
 					"bonuses": [
 						{
 							"type": "PRIMARY_SKILL",
-							"subtype": "primarySkill.defence",
+							"subtype": "defence",
 							"val": 2
 						}
 					],
@@ -210,8 +210,8 @@
 				},
 				"grail":          {
 					"bonuses": [
-						{ "type": "PRIMARY_SKILL", "subtype": "primarySkill.attack", "val": 10 },
-						{ "type": "PRIMARY_SKILL", "subtype": "primarySkill.defence", "val": 10 }
+						{ "type": "PRIMARY_SKILL", "subtype": "attack", "val": 10 },
+						{ "type": "PRIMARY_SKILL", "subtype": "defence", "val": 10 }
 					]
 				},
 

--- a/config/factions/inferno.json
+++ b/config/factions/inferno.json
@@ -184,7 +184,7 @@
 					"bonuses": [
 						{
 							"type": "PRIMARY_SKILL",
-							"subtype": "primarySkill.spellpower",
+							"subtype": "spellpower",
 							"val": 2
 						}
 					],
@@ -205,7 +205,7 @@
 				},
 				"horde2":         { "upgrades" : "dwellingLvl3" },
 				"horde2Upgr":     { "upgrades" : "dwellingUpLvl3", "requires" : [ "horde2" ] },
-				"grail":          { "bonuses": [ { "propagator": "GLOBAL_EFFECT", "type": "DEITYOFFIRE", "subtype": "creature.imp", "val": 15 } ] },
+				"grail":          { "bonuses": [ { "propagator": "GLOBAL_EFFECT", "type": "DEITYOFFIRE", "subtype": "imp", "val": 15 } ] },
 
 				"dwellingLvl1":   { "requires" : [ "fort" ] },
 				"dwellingLvl2":   { "requires" : [ "dwellingLvl1" ] },

--- a/config/factions/stronghold.json
+++ b/config/factions/stronghold.json
@@ -188,7 +188,7 @@
 						]
 					}
 				},
-				"grail":          { "bonuses": [ { "type": "PRIMARY_SKILL", "subtype": "primarySkill.attack", "val": 20 } ] },
+				"grail":          { "bonuses": [ { "type": "PRIMARY_SKILL", "subtype": "attack", "val": 20 } ] },
 
 				"dwellingLvl1":   { "requires" : [ "fort" ] },
 				"dwellingLvl2":   { "requires" : [ "dwellingLvl1" ] },

--- a/config/factions/tower.json
+++ b/config/factions/tower.json
@@ -200,7 +200,7 @@
 				},
 				"grail":          { 
 					"bonuses": [
-						{ "type": "PRIMARY_SKILL", "subtype": "primarySkill.knowledge", "val": 15 },
+						{ "type": "PRIMARY_SKILL", "subtype": "knowledge", "val": 15 },
 						{ "type": "COMBAT_MANA_BONUS", "val": 150 },
 						{ "type": "FULL_MAP_SCOUTING" }
 					]

--- a/config/gameConfig.json
+++ b/config/gameConfig.json
@@ -79,7 +79,7 @@
 	[
 		"config/artifacts.json"
 	],
-	
+
 	"heroClasses" :
 	[
 		"config/heroClasses.json"
@@ -144,7 +144,7 @@
 	[
 		"config/mapLayers.json"
 	],
-	
+
 	"settings":
 	{
 		// Number of entries of each type to load from Heroes III text files
@@ -161,9 +161,9 @@
 			"river"      : 5,
 			"road"       : 4
 		},
-		
+
 		"mapFormat" : {
-			"restorationOfErathia" : { 
+			"restorationOfErathia" : {
 				"supported" : true,
 				"iconIndex" : 0,
 				"settings": {
@@ -265,14 +265,14 @@
 					"portraitGeneralKendal" : 129
 				},
 				"campaignRegions" : {
-					
+
 					"good1" : 1,    // Long Live the Queen
 					"good2" : 2,    // Liberation
 					"good3" : 3,    // Song for the Father
 					"evil1" : 4,    // Dungeons and devils
 					"evil2" : 5,    // Long Live the King
 					"neutral1" : 6, // Spoils of War
-					"secret1" : 7   // Seeds Of Discontent 
+					"secret1" : 7   // Seeds Of Discontent
 				},
 				"campaignMusic" : {
 					"CampainMusic01" : 0,
@@ -415,7 +415,7 @@
 					"H3ABpf4.smk" : 56
 				}
 			},
-			"shadowOfDeath" : { 
+			"shadowOfDeath" : {
 				"supported" : true,
 				"iconIndex" : 2,
 				"portraits" : {
@@ -487,15 +487,15 @@
 					"H3x2_UAm.smk" : 100 //H3x2_UAm.bik?
 				}
 			},
-			"chronicles" : { 
+			"chronicles" : {
 				"supported" : false,
 				"iconIndex" : 2
 			},
-			"jsonVCMI" : { 
+			"jsonVCMI" : {
 				"supported" : true,
 				"iconIndex" : 3
 			},
-			"hornOfTheAbyss" : { 
+			"hornOfTheAbyss" : {
 				"supported" : false,
 				"settings": {
 					"spells": {
@@ -503,7 +503,7 @@
 					}
 				}
 			},
-			"inTheWakeOfGods" : { 
+			"inTheWakeOfGods" : {
 				"supported" : false
 			}
 		},
@@ -524,7 +524,7 @@
 			"tavernInvite"            : false,
 			// minimal primary skills for heroes
 			"minimalPrimarySkills": [ 0, 0, 1, 1],
-			
+
 			/// minimal movement cost from one tile to another while offroad. Also see BASE_TILE_MOVEMENT_COST bonus type
 			/// Also affects cost of Town Portal spell and movement cost when using Fly spell
 			"movementCostBase" : 100,
@@ -532,10 +532,10 @@
 			"movementPointsLand" : [ 1500, 1500, 1500, 1500, 1560, 1630, 1700, 1760, 1830, 1900, 1960, 2000 ],
 			/// movement points hero can get on start of the turn when on sea, depending on speed of slowest creature (0-based list)
 			"movementPointsSea" : [ 1500 ],
-      
+
 			/// maximal secondary skills per hero
 			"skillPerHero" : 8,
-			
+
 			/// Base scouting range for hero without any range modifiers
 			"baseScoutingRange" : 5,
 
@@ -574,7 +574,7 @@
 			"spellResearchCostMultiplierPerResearch": [ 1, 1, 1, 1, 1 ],
 			// Multiplier for increasing/decreasing cost of research actions after each reroll - resets on accepting spell (factor 1 disables this; array index is spell tier)
 			"spellResearchCostMultiplierPerReroll": [ 1, 1, 1, 1, 1 ],
-			
+
 			// Base scouting range for town without any range modifiers
 			"baseScoutingRange" : 5
 		},
@@ -606,14 +606,14 @@
 			// Bias for luck rolls. See abilityBias for detailed description
 			// Recommended value is around luckDiceSize / 4
 			"luckBias" : 8,
-			
+
 
 			// every 1 attack point damage influence in battle when attack points > defense points during creature attack
-			"attackPointDamageFactor": 0.05, 
+			"attackPointDamageFactor": 0.05,
 			// limit of damage increase that can be achieved by overpowering attack points
-			"attackPointDamageFactorCap": 4.0, 
+			"attackPointDamageFactorCap": 4.0,
 			// every 1 defense point damage influence in battle when defense points > attack points during creature attack
-			"defensePointDamageFactor": 0.025, 
+			"defensePointDamageFactor": 0.025,
 			// limit of damage reduction that can be achieved by overpowering defense points
 			"defensePointDamageFactorCap": 0.7,
 			// If set to true, double-wide creatures will trigger obstacle effect when moving one tile forward or backwards
@@ -624,7 +624,7 @@
 			"noSpellHitAndRunRounds" : 0,
 			// Cost of surrendering is recruit cost of hero army divided by this value, before any discounts are applied
 			"surrenderCostDivisor" : 2.0,
-			
+
 			// Positions of units on start of the combat
 			// If battle does not defines specific configuration, 'default' configuration will be used
 			// Configuration must define either 'attackerUnits' list of 7 elements or both 'attackerUnitsLoose' and 'attackerUnitsTight' lists of 7 elements, 1..7 elements each
@@ -709,9 +709,9 @@
 			"monthPlagueProbability" : 10,
 			// probability (in percent) for special week
 			"weekSpecialProbability" : 25,
-			// if stack experience is on, creatures on map will get specified amount of experience daily 
+			// if stack experience is on, creatures on map will get specified amount of experience daily
 			"dailyStackExperience" : 100,
-			// if enabled, double growth, plague and creature weeks can happen randomly. Has no effect on weeks by "Deity of Fire" 
+			// if enabled, double growth, plague and creature weeks can happen randomly. Has no effect on weeks by "Deity of Fire"
 			// NOTE: on HotA maps, this setting has no effect. Value provided in map will be used instead.
 			"allowRandomSpecialWeeks" : true,
 			// if enabled, every creature can get double growth month, ignoring predefined list
@@ -722,18 +722,18 @@
 			// NOTE: on HotA maps this setting has no effect on units placed in map editor, preset value from h3m will be used instead
 			"joiningPercentage" : 100
 		},
-		
+
 		"dwellings" :
 		{
-			// if enabled, neutral dwellings will accumulate creatures 
+			// if enabled, neutral dwellings will accumulate creatures
 			"accumulateWhenNeutral" : false,
-			// if enabled, dwellings owned by players will accumulate creatures 
+			// if enabled, dwellings owned by players will accumulate creatures
 			"accumulateWhenOwned" : false,
 			// if enabled, game will attempt to merge slots in army on recruit if all slots in hero army are in use
 			"mergeOnRecruit" : true
 		},
-		
-		"mapObjects" : 
+
+		"mapObjects" :
 		{
 			// Allow behavior that emulates h3 bug where quest from Seer Hut or Border Guard can take entire army from hero
 			// WARNING: handling of heroes without armies is not tested and may lead to bugs or crashes! Use at own risk!
@@ -741,16 +741,16 @@
 			"h3BugQuestTakesEntireArmy" : false
 		},
 
-		"markets" : 
+		"markets" :
 		{
 			// period between restocking of "Black Market" object found on adventure map
 			"blackMarketRestockPeriod" : 0,
-			
+
 			// Cost in gold of buying skill in on-map University or in University of Magic in Conflux
 			"universityGoldCost" : 2000
 		},
-		
-		"banks" : 
+
+		"banks" :
 		{
 			// show guards composition when visiting creature banks
 			"showGuardsComposition" : true
@@ -767,7 +767,7 @@
 			// if enabled, all heroes gain commander creature in battle (WoG feature)
 			"commanders": false
 		},
-		
+
 		"pathfinder" :
 		{
 			// if enabled, pathfinder will not allow disembarking from a boat on a tile with a hole (e.g. after digging for Grail)
@@ -776,7 +776,7 @@
 			"ignoreGuards" : false,
 			// if enabled, pathfinder will take use of any available boats
 			"useBoat" : true,
-			// if enabled, pathfinder will take use of any bidirectional monoliths 
+			// if enabled, pathfinder will take use of any bidirectional monoliths
 			"useMonolithTwoWay" : true,
 			// if enabled, pathfinder will take use of one-way monolith that only have one known exit
 			"useMonolithOneWayUnique" : false,
@@ -787,7 +787,7 @@
 			// if enabled flying will work like in original game, otherwise nerf similar to HotA flying is applied
 			"originalFlyRules" : true
 		},
-		
+
 		"resources" : {
 			// H3 mechanics - AI receives bonus (or malus, on easy) to his resource income
 			// AI will receive specified values as percentage of his weekly income
@@ -806,24 +806,24 @@
 		{
 			// if enabled, dimension door will initiate a fight upon landing on tile adjacent to neutral creature
 			"dimensionDoorTriggersGuards" : false,
-			// if enabled, SPELLS_OF_SCHOOL bonus (Tomes of Water/Air/Earth/Fire Magic) 
+			// if enabled, SPELLS_OF_SCHOOL bonus (Tomes of Water/Air/Earth/Fire Magic)
 			// and SPELLS_OF_LEVEL bonus (Spellbinder Hat) will grant spells that are banned on map (SoD behavior)
 			// NOTE: this value only affects random maps and .vmap's. For h3m's value is loaded from map format configuration
 			"tomesGrantBannedSpells" : false
 		},
-		
-		"bonuses" : 
+
+		"bonuses" :
 		{
-			"global" : 
+			"global" :
 			{
-				"spellDamage" : 
+				"spellDamage" :
 				{
 					"type" : "SPELL_DAMAGE",
-					"subtype" : "spellSchool.any",
+					"subtype" : "any",
 					"val" : 100,
 					"valueType" : "BASE_NUMBER"
 				},
-				"wisdom" : 
+				"wisdom" :
 				{
 					"type" : "MAX_LEARNABLE_SPELL_LEVEL", //Hero can always learn level 1 and 2 spells
 					"val" : 2,
@@ -852,7 +852,7 @@
 						}
 					]
 				},
-				"experienceGain" : 
+				"experienceGain" :
 				{
 					"type" : "HERO_EXPERIENCE_GAIN_PERCENT", //default hero xp
 					"val" : 100,

--- a/config/heroes/castle.json
+++ b/config/heroes/castle.json
@@ -161,7 +161,7 @@
 						{
 							"type" : "HAS_ANOTHER_BONUS_LIMITER",
 							"bonusSourceType" : "SPELL_EFFECT",
-							"bonusSourceID" : "spell.bless"
+							"bonusSourceID" : "bless"
 						}
 					],
 					"updater" : "TIMES_HERO_LEVEL_DIVIDE_STACK_LEVEL",
@@ -258,7 +258,7 @@
 		"specialty" : {
 			"bonuses" : {
 				"gold" : {
-					"subtype" : "resource.gold",
+					"subtype" : "gold",
 					"type" : "GENERATE_RESOURCE",
 					"val" : 350
 				}

--- a/config/heroes/conflux.json
+++ b/config/heroes/conflux.json
@@ -22,8 +22,8 @@
 				"val" : 3
 			},
 			"bonuses" : {
-				"attack" : { "subtype" : "primarySkill.attack" },
-				"defence" : { "subtype" : "primarySkill.defence" }
+				"attack" : { "subtype" : "attack" },
+				"defence" : { "subtype" : "defence" }
 			}
 		}
 	},
@@ -54,12 +54,12 @@
 					"val" : 5
 				},
 				"attack" : {
-					"subtype" : "primarySkill.attack",
+					"subtype" : "attack",
 					"type" : "PRIMARY_SKILL",
 					"val" : 2
 				},
 				"defence" : {
-					"subtype" : "primarySkill.defence",
+					"subtype" : "defence",
 					"type" : "PRIMARY_SKILL",
 					"val" : 1
 				}
@@ -93,12 +93,12 @@
 					"val" : 2
 				},
 				"attack" : {
-					"subtype" : "primarySkill.attack",
+					"subtype" : "attack",
 					"type" : "PRIMARY_SKILL",
 					"val" : 1
 				},
 				"defence" : {
-					"subtype" : "primarySkill.defence",
+					"subtype" : "defence",
 					"type" : "PRIMARY_SKILL",
 					"val" : 2
 				}
@@ -124,7 +124,7 @@
 							"includeUpgrades" : true
 						}
 					],
-					"subtype" : "primarySkill.attack",
+					"subtype" : "attack",
 					"type" : "PRIMARY_SKILL",
 					"val" : 2
 				}
@@ -154,8 +154,8 @@
 				"val" : 3
 			},
 			"bonuses" : {
-				"attack" : { "subtype" : "primarySkill.attack" },
-				"defence" : { "subtype" : "primarySkill.defence" }
+				"attack" : { "subtype" : "attack" },
+				"defence" : { "subtype" : "defence" }
 			}
 		}
 	},
@@ -186,12 +186,12 @@
 					"val" : 5
 				},
 				"attack" : {
-					"subtype" : "primarySkill.attack",
+					"subtype" : "attack",
 					"type" : "PRIMARY_SKILL",
 					"val" : 2
 				},
 				"defence" : {
-					"subtype" : "primarySkill.defence",
+					"subtype" : "defence",
 					"type" : "PRIMARY_SKILL",
 					"val" : 1
 				}
@@ -224,12 +224,12 @@
 					"val" : 2
 				},
 				"attack" : {
-					"subtype" : "primarySkill.attack",
+					"subtype" : "attack",
 					"type" : "PRIMARY_SKILL",
 					"val" : 1
 				},
 				"defence" : {
-					"subtype" : "primarySkill.defence",
+					"subtype" : "defence",
 					"type" : "PRIMARY_SKILL",
 					"val" : 2
 				}
@@ -256,7 +256,7 @@
 							"includeUpgrades" : true
 						}
 					],
-					"subtype" : "primarySkill.attack",
+					"subtype" : "attack",
 					"type" : "PRIMARY_SKILL",
 					"val" : 2
 				}
@@ -277,13 +277,13 @@
 		"specialty" : {
 			"bonuses" : {
 				"fireWall" : {
-					"subtype" : "spell.fireWallTrigger",
+					"subtype" : "fireWallTrigger",
 					"type" : "SPECIFIC_SPELL_DAMAGE",
 					"val" : 100,
 					"valueType" : "BASE_NUMBER"
 				},
 				"fireWallTooltip" : {
-					"subtype" : "spell.fireWall",
+					"subtype" : "fireWall",
 					"type" : "SPECIFIC_SPELL_DAMAGE",
 					"val" : 100,
 					"valueType" : "BASE_NUMBER"
@@ -320,7 +320,7 @@
 		"specialty" : {
 			"bonuses" : {
 				"magicArrow" : {
-					"subtype" : "spell.magicArrow",
+					"subtype" : "magicArrow",
 					"type" : "SPECIFIC_SPELL_DAMAGE",
 					"val" : 50,
 					"valueType" : "BASE_NUMBER"
@@ -393,7 +393,7 @@
 		"specialty" : {
 			"bonuses" : {
 				"gold" : {
-					"subtype" : "resource.gold",
+					"subtype" : "gold",
 					"type" : "GENERATE_RESOURCE",
 					"val" : 350
 				}
@@ -414,7 +414,7 @@
 		"specialty" : {
 			"bonuses" : {
 				"gold" : {
-					"subtype" : "resource.gold",
+					"subtype" : "gold",
 					"type" : "GENERATE_RESOURCE",
 					"val" : 350
 				}

--- a/config/heroes/dungeon.json
+++ b/config/heroes/dungeon.json
@@ -68,7 +68,7 @@
 		"specialty" : {
 			"bonuses" : {
 				"gold" : {
-					"subtype" : "resource.gold",
+					"subtype" : "gold",
 					"type" : "GENERATE_RESOURCE",
 					"val" : 350
 				}
@@ -227,7 +227,7 @@
 		"specialty" : {
 			"bonuses" : {
 				"crystal" : {
-					"subtype" : "resource.crystal",
+					"subtype" : "crystal",
 					"type" : "GENERATE_RESOURCE",
 					"val" : 1
 				}

--- a/config/heroes/inferno.json
+++ b/config/heroes/inferno.json
@@ -66,7 +66,7 @@
 		"specialty" : {
 			"bonuses" : {
 				"gold" : {
-					"subtype" : "resource.gold",
+					"subtype" : "gold",
 					"type" : "GENERATE_RESOURCE",
 					"val" : 350
 				}
@@ -196,7 +196,7 @@
 		"specialty" : {
 			"bonuses" : {
 				"sulfur" : {
-					"subtype" : "resource.sulfur",
+					"subtype" : "sulfur",
 					"type" : "GENERATE_RESOURCE",
 					"val" : 1
 				}

--- a/config/heroes/necropolis.json
+++ b/config/heroes/necropolis.json
@@ -102,7 +102,7 @@
 		"specialty" : {
 			"bonuses" : {
 				"gold" : {
-					"subtype" : "resource.gold",
+					"subtype" : "gold",
 					"type" : "GENERATE_RESOURCE",
 					"val" : 350
 				}
@@ -242,7 +242,7 @@
 		"specialty" : {
 			"bonuses" : {
 				"gold" : {
-					"subtype" : "resource.gold",
+					"subtype" : "gold",
 					"type" : "GENERATE_RESOURCE",
 					"val" : 350
 				}

--- a/config/heroes/rampart.json
+++ b/config/heroes/rampart.json
@@ -39,7 +39,7 @@
 		"specialty" : {
 			"bonuses" : {
 				"gold" : {
-					"subtype" : "resource.gold",
+					"subtype" : "gold",
 					"type" : "GENERATE_RESOURCE",
 					"val" : 350
 				}
@@ -206,7 +206,7 @@
 			"bonuses" : {
 				"fortune" : {
 					"addInfo" : 3,
-					"subtype" : "spell.fortune",
+					"subtype" : "fortune",
 					"type" : "SPECIAL_FIXED_VALUE_ENCHANT"
 				}
 			}

--- a/config/heroes/special.json
+++ b/config/heroes/special.json
@@ -61,14 +61,14 @@
 		],
 		"specialty" : {
 			"base" : {
-				"addInfo" : "creature.enchanter",
+				"addInfo" : "enchanter",
 				"type" : "SPECIAL_UPGRADE"
 			},
 			"bonuses" : {
-				"archMage2enchanter" : { "subtype" : "creature.archMage" },
-				"mage2enchanter" : { "subtype" : "creature.mage" },
-				"monk2enchanter" : { "subtype" : "creature.monk" },
-				"zealot2enchanter" : { "subtype" : "creature.zealot" }
+				"archMage2enchanter" : { "subtype" : "archMage" },
+				"mage2enchanter" : { "subtype" : "mage" },
+				"monk2enchanter" : { "subtype" : "monk" },
+				"zealot2enchanter" : { "subtype" : "zealot" }
 			}
 		}
 	},
@@ -85,14 +85,14 @@
 		],
 		"specialty" : {
 			"base" : {
-				"addInfo" : "creature.sharpshooter",
+				"addInfo" : "sharpshooter",
 				"type" : "SPECIAL_UPGRADE"
 			},
 			"bonuses" : {
-				"archer2sharpshooter" : { "subtype" : "creature.archer" },
-				"grandElf2sharpshooter" : { "subtype" : "creature.grandElf" },
-				"marksman2sharpshooter" : { "subtype" : "creature.marksman" },
-				"woodElf2sharpshooter" : { "subtype" : "creature.woodElf" }
+				"archer2sharpshooter" : { "subtype" : "archer" },
+				"grandElf2sharpshooter" : { "subtype" : "grandElf" },
+				"marksman2sharpshooter" : { "subtype" : "marksman" },
+				"woodElf2sharpshooter" : { "subtype" : "woodElf" }
 			}
 		}
 	},
@@ -123,12 +123,12 @@
 					"val" : 10
 				},
 				"attack" : {
-					"subtype" : "primarySkill.attack",
+					"subtype" : "attack",
 					"type" : "PRIMARY_SKILL",
 					"val" : 5
 				},
 				"defence" : {
-					"subtype" : "primarySkill.defence",
+					"subtype" : "defence",
 					"type" : "PRIMARY_SKILL",
 					"val" : 5
 				}
@@ -163,12 +163,12 @@
 					"val" : 10
 				},
 				"attack" : {
-					"subtype" : "primarySkill.attack",
+					"subtype" : "attack",
 					"type" : "PRIMARY_SKILL",
 					"val" : 5
 				},
 				"defence" : {
-					"subtype" : "primarySkill.defence",
+					"subtype" : "defence",
 					"type" : "PRIMARY_SKILL",
 					"val" : 5
 				}
@@ -199,8 +199,8 @@
 				"val" : 5
 			},
 			"bonuses" : {
-				"attack" : { "subtype" : "primarySkill.attack" },
-				"defence" : { "subtype" : "primarySkill.defence" }
+				"attack" : { "subtype" : "attack" },
+				"defence" : { "subtype" : "defence" }
 			}
 		}
 	},
@@ -243,8 +243,8 @@
 				"val" : 5
 			},
 			"bonuses" : {
-				"attack" : { "subtype" : "primarySkill.attack" },
-				"defence" : { "subtype" : "primarySkill.defence" }
+				"attack" : { "subtype" : "attack" },
+				"defence" : { "subtype" : "defence" }
 			}
 		},
 		"army" :
@@ -316,12 +316,12 @@
 			},
 			"bonuses" : {
 				"attack" : {
-					"subtype" : "primarySkill.attack",
+					"subtype" : "attack",
 					"type" : "PRIMARY_SKILL",
 					"val" : 4
 				},
 				"defence" : {
-					"subtype" : "primarySkill.defence",
+					"subtype" : "defence",
 					"type" : "PRIMARY_SKILL",
 					"val" : 2
 				},

--- a/config/heroes/stronghold.json
+++ b/config/heroes/stronghold.json
@@ -230,7 +230,7 @@
 		"specialty" : {
 			"bonuses" : {
 				"gems" : {
-					"subtype" : "resource.gems",
+					"subtype" : "gems",
 					"type" : "GENERATE_RESOURCE",
 					"val" : 1
 				}

--- a/config/heroes/tower.json
+++ b/config/heroes/tower.json
@@ -104,7 +104,7 @@
 		"specialty" : {
 			"bonuses" : {
 				"mercury" : {
-					"subtype" : "resource.mercury",
+					"subtype" : "mercury",
 					"type" : "GENERATE_RESOURCE",
 					"val" : 1
 				}
@@ -192,7 +192,7 @@
 			"bonuses" : {
 				"fortune" : {
 					"addInfo" : 3,
-					"subtype" : "spell.fortune",
+					"subtype" : "fortune",
 					"type" : "SPECIAL_FIXED_VALUE_ENCHANT"
 				}
 			}
@@ -257,7 +257,7 @@
 		"specialty" : {
 			"bonuses" : {
 				"gold" : {
-					"subtype" : "resource.gold",
+					"subtype" : "gold",
 					"type" : "GENERATE_RESOURCE",
 					"val" : 350
 				}

--- a/config/skills.json
+++ b/config/skills.json
@@ -307,12 +307,12 @@
 		"base" : {
 			"effects" : {
 				"main" : {
-					"subtype" : "spell.catapultShot",
+					"subtype" : "catapultShot",
 					"type" : "CATAPULT_EXTRA_SHOTS",
 					"valueType" : "BASE_NUMBER"
 				},
 				"ctrl" : {
-					"subtype" : "creature.catapult",
+					"subtype" : "catapult",
 					"type" : "MANUAL_CONTROL",
 					"val" : 100,
 					"valueType" : "BASE_NUMBER"
@@ -388,7 +388,7 @@
 				},
 				"power" : {
 					"type" : "IMPROVED_NECROMANCY",
-					"subtype" : "creature.skeleton",
+					"subtype" : "skeleton",
 					"addInfo" : 0
 				}
 			}
@@ -420,7 +420,7 @@
 		"base" : {
 			"effects" : {
 				"main" : {
-					"subtype" : "resource.gold",
+					"subtype" : "gold",
 					"type" : "GENERATE_RESOURCE",
 					"valueType" : "BASE_NUMBER"
 				}
@@ -451,7 +451,7 @@
 		"base" : {
 			"effects" : {
 				"main" : {
-					"subtype" : "spellSchool.fire",
+					"subtype" : "fire",
 					"type" : "MAGIC_SCHOOL_SKILL",
 					"valueType" : "BASE_NUMBER"
 				}
@@ -482,7 +482,7 @@
 		"base" : {
 			"effects" : {
 				"main" : {
-					"subtype" : "spellSchool.air",
+					"subtype" : "air",
 					"type" : "MAGIC_SCHOOL_SKILL",
 					"valueType" : "BASE_NUMBER"
 				}
@@ -513,7 +513,7 @@
 		"base" : {
 			"effects" : {
 				"main" : {
-					"subtype" : "spellSchool.water",
+					"subtype" : "water",
 					"type" : "MAGIC_SCHOOL_SKILL",
 					"valueType" : "BASE_NUMBER"
 				}
@@ -544,7 +544,7 @@
 		"base" : {
 			"effects" : {
 				"main" : {
-					"subtype" : "spellSchool.earth",
+					"subtype" : "earth",
 					"type" : "MAGIC_SCHOOL_SKILL",
 					"valueType" : "BASE_NUMBER"
 				}
@@ -633,29 +633,29 @@
 		"base" : {
 			"effects" : {
 				"main" : {
-					"subtype" : "creature.ballista",
+					"subtype" : "ballista",
 					"type" : "BONUS_DAMAGE_CHANCE",
 					"valueType" : "BASE_NUMBER"
 				},
 				"val2" : {
-					"subtype" : "creature.ballista",
+					"subtype" : "ballista",
 					"type" : "HERO_GRANTS_ATTACKS",
 					"valueType" : "BASE_NUMBER"
 				},
 				"ctrl" : {
-					"subtype" : "creature.ballista",
+					"subtype" : "ballista",
 					"type" : "MANUAL_CONTROL",
 					"val" : 100,
 					"valueType" : "BASE_NUMBER"
 				},
 				"ctrl2" : {
-					"subtype" : "creature.arrowTower",
+					"subtype" : "arrowTower",
 					"type" : "MANUAL_CONTROL",
 					"val" : 100,
 					"valueType" : "BASE_NUMBER"
 				},
 				"damagePower" : {
-					"subtype" : "creature.ballista",
+					"subtype" : "ballista",
 					"type" : "BONUS_DAMAGE_PERCENTAGE",
 					"val" : 100,
 					"valueType" : "BASE_NUMBER"
@@ -808,7 +808,7 @@
 			"effects" : {
 				"main" : {
 					"type" : "SPELL_DAMAGE",
-					"subtype" : "spellSchool.any",
+					"subtype" : "any",
 					"valueType" : "BASE_NUMBER"
 				}
 			}
@@ -866,12 +866,12 @@
 		"base" : {
 			"effects" : {
 				"main" : {
-					"subtype" : "spell.firstAid",
+					"subtype" : "firstAid",
 					"type" : "SPECIFIC_SPELL_POWER",
 					"valueType" : "BASE_NUMBER"
 				},
 				"ctrl" : {
-					"subtype" : "creature.firstAidTent",
+					"subtype" : "firstAidTent",
 					"type" : "MANUAL_CONTROL",
 					"val" : 100,
 					"valueType" : "BASE_NUMBER"

--- a/config/spells/ability.json
+++ b/config/spells/ability.json
@@ -16,7 +16,7 @@
 				"targetModifier":{"smart":true},
 				"battleEffects" : {
 					"petrification" : {
-						"type" : "core:timed",
+						"type" : "timed",
 						"battleLogSingular" : "@core.genrltxt.558",
 						"battleLogPlural" : "@core.genrltxt.559",
 						"bonus" : {
@@ -75,7 +75,7 @@
 				"targetModifier":{"smart":true},
 				"battleEffects" : {
 					"poisoning" : {
-						"type" : "core:timed",
+						"type" : "timed",
 						"battleLogSingular" : "@core.genrltxt.561",
 						"battleLogPlural" : "@core.genrltxt.562",
 						"bonus" : {
@@ -124,7 +124,7 @@
 				"range" : "0",
 				"battleEffects" : {
 					"binding" : {
-						"type" : "core:timed",
+						"type" : "timed",
 						"battleLogSingular" : "@core.genrltxt.560",
 						"battleLogPlural" : "@core.genrltxt.560",
 						"bonus" : {
@@ -160,20 +160,20 @@
 				"targetModifier":{"smart":true},
 				"battleEffects" : {
 					"illness" : {
-						"type" : "core:timed",
+						"type" : "timed",
 						"battleLogSingular" : "@core.genrltxt.553",
 						"battleLogPlural" : "@core.genrltxt.554",
 						"bonus" : {
 							"attack" : {
 								"val" : -2,
 								"type" : "PRIMARY_SKILL",
-								"subtype" : "primarySkill.attack",
+								"subtype" : "attack",
 								"duration" : "N_TURNS"
 							},
 							"defence" : {
 								"val" : -2,
 								"type" : "PRIMARY_SKILL",
-								"subtype" : "primarySkill.defence",
+								"subtype" : "defence",
 								"duration" : "N_TURNS"
 							}
 						}
@@ -209,7 +209,7 @@
 				"targetModifier":{"smart":true},
 				"battleEffects" : {
 					"paralysis" : {
-						"type" : "core:timed",
+						"type" : "timed",
 						"battleLogSingular" : "@core.genrltxt.563",
 						"battleLogPlural" : "@core.genrltxt.564",
 						"bonus" : {
@@ -305,7 +305,7 @@
 				"range" : "0-1",
 				"battleEffects":{
 					"damage":{
-						"type":"core:damage"
+						"type":"damage"
 					}
 				}
 			}
@@ -340,7 +340,7 @@
 				"range" : "0",
 				"battleEffects":{
 					"damage":{
-						"type":"core:damage"
+						"type":"damage"
 					}
 				}
 			}
@@ -364,7 +364,7 @@
 			"base":{
 				"battleEffects":{
 					"dispel":{
-						"type":"core:dispel",
+						"type":"dispel",
 						"ignoreImmunity" : true,
 						"dispelNegative":false,
 						"dispelNeutral":false,
@@ -393,7 +393,7 @@
 			"base":{
 				"battleEffects":{
 					"destruction":{
-						"type":"core:damage",
+						"type":"damage",
 						"killByCount": true
 					}
 				},
@@ -427,14 +427,14 @@
 			"base":{
 				"battleEffects":{
 					"timed":{
-						"type":"core:timed",
+						"type":"timed",
 						"cumulative":true,
 						"ignoreImmunity" : true,
 						"bonus" :{
 							"primarySkill" : {
 								"val" : -3,
 								"type" : "PRIMARY_SKILL",
-								"subtype" : "primarySkill.defence",
+								"subtype" : "defence",
 								"duration" : "PERMANENT",
 								"valueType" : "ADDITIVE_VALUE"
 							}
@@ -464,7 +464,7 @@
 			"base":{
 				"battleEffects":{
 					"damage":{
-						"type":"core:damage",
+						"type":"damage",
 						"ignoreImmunity" : true
 					}
 				},
@@ -494,7 +494,7 @@
 				"range" : "0-1",
 				"battleEffects":{
 					"damage":{
-						"type":"core:damage"
+						"type":"damage"
 					}
 				}
 			}

--- a/config/spells/ability.json
+++ b/config/spells/ability.json
@@ -267,12 +267,19 @@
 			"base":{
 				"range" : "0",
 				"targetModifier":{"smart":true},
-				"effects" : {
-					"stackHealth" : {
-						"val" : -50,
-						"type" : "STACK_HEALTH",
-						"valueType" : "PERCENT_TO_ALL",
-						"duration" : "N_TURNS"
+				"battleEffects" : {
+					"age" : {
+						"type" : "timed",
+						"battleLogSingular" : "@core.genrltxt.551",
+						"battleLogPlural" : "@core.genrltxt.552",
+						"bonus" : {
+							"stackHealth" : {
+								"val" : -50,
+								"type" : "STACK_HEALTH",
+								"valueType" : "PERCENT_TO_ALL",
+								"duration" : "N_TURNS"
+							}
+						}
 					}
 				}
 			}

--- a/config/spells/moats.json
+++ b/config/spells/moats.json
@@ -16,7 +16,7 @@
 				"cost" : 0, //For validation
 				"battleEffects" : {
 					"directDamage" : {
-						"type":"core:damage"
+						"type":"damage"
 					}
 				},
 				"targetModifier":{"smart":false}
@@ -56,7 +56,7 @@
 				"targetModifier":{"smart":false},
 				"battleEffects":{
 					"moat":{
-						"type":"core:moat",
+						"type":"moat",
 						"hidden" : false,
 						"trap" : true,
 						"triggerAbility" : "core:castleMoatTrigger",
@@ -70,7 +70,7 @@
 							"primarySkill" : {
 								"val" : -3,
 								"type" : "PRIMARY_SKILL",
-								"subtype" : "primarySkill.defence",
+								"subtype" : "defence",
 								"valueType" : "ADDITIVE_VALUE"
 							}
 						}
@@ -111,7 +111,7 @@
 				"cost" : 0, //For validation
 				"battleEffects" : {
 					"directDamage" : {
-						"type":"core:damage"
+						"type":"damage"
 					}
 				},
 				"targetModifier":{"smart":false}
@@ -151,7 +151,7 @@
 				"targetModifier":{"smart":false},
 				"battleEffects":{
 					"moat":{
-						"type":"core:moat",
+						"type":"moat",
 						"hidden" : false,
 						"trap" : true,
 						"triggerAbility" : "core:rampartMoatTrigger",
@@ -165,7 +165,7 @@
 							"primarySkill" : {
 								"val" : -3,
 								"type" : "PRIMARY_SKILL",
-								"subtype" : "primarySkill.defence",
+								"subtype" : "defence",
 								"valueType" : "ADDITIVE_VALUE"
 							}
 						}
@@ -206,7 +206,7 @@
 				"targetModifier":{"smart":false},
 				"battleEffects":{
 					"moat":{
-						"type":"core:moat",
+						"type":"moat",
 						"hidden" : true,
 						"trap" : false,
 						"triggerAbility" : "core:landMineTrigger",
@@ -256,7 +256,7 @@
 				"cost" : 0, //For validation
 				"battleEffects" : {
 					"directDamage" : {
-						"type":"core:damage"
+						"type":"damage"
 					}
 				},
 				"targetModifier":{"smart":false}
@@ -296,7 +296,7 @@
 				"targetModifier":{"smart":false},
 				"battleEffects":{
 					"moat":{
-						"type":"core:moat",
+						"type":"moat",
 						"hidden" : false,
 						"trap" : true,
 						"triggerAbility" : "core:infernoMoatTrigger",
@@ -310,7 +310,7 @@
 							"primarySkill" : {
 								"val" : -3,
 								"type" : "PRIMARY_SKILL",
-								"subtype" : "primarySkill.defence",
+								"subtype" : "defence",
 								"valueType" : "ADDITIVE_VALUE"
 							}
 						}
@@ -351,7 +351,7 @@
 				"cost" : 0, //For validation
 				"battleEffects" : {
 					"directDamage" : {
-						"type":"core:damage"
+						"type":"damage"
 					}
 				},
 				"targetModifier":{"smart":false}
@@ -391,7 +391,7 @@
 				"targetModifier":{"smart":false},
 				"battleEffects":{
 					"moat":{
-						"type":"core:moat",
+						"type":"moat",
 						"hidden" : false,
 						"trap" : true,
 						"triggerAbility" : "core:necropolisMoatTrigger",
@@ -405,7 +405,7 @@
 							"primarySkill" : {
 								"val" : -3,
 								"type" : "PRIMARY_SKILL",
-								"subtype" : "primarySkill.defence",
+								"subtype" : "defence",
 								"valueType" : "ADDITIVE_VALUE"
 							}
 						}
@@ -446,7 +446,7 @@
 				"cost" : 0, //For validation
 				"battleEffects" : {
 					"directDamage" : {
-						"type":"core:damage"
+						"type":"damage"
 					}
 				},
 				"targetModifier":{"smart":false}
@@ -486,7 +486,7 @@
 				"targetModifier":{"smart":false},
 				"battleEffects":{
 					"moat":{
-						"type":"core:moat",
+						"type":"moat",
 						"hidden" : false,
 						"trap" : true,
 						"triggerAbility" : "core:dungeonMoatTrigger",
@@ -500,7 +500,7 @@
 							"primarySkill" : {
 								"val" : -3,
 								"type" : "PRIMARY_SKILL",
-								"subtype" : "primarySkill.defence",
+								"subtype" : "defence",
 								"valueType" : "ADDITIVE_VALUE"
 							}
 						}
@@ -541,7 +541,7 @@
 				"cost" : 0, //For validation
 				"battleEffects" : {
 					"directDamage" : {
-						"type":"core:damage"
+						"type":"damage"
 					}
 				},
 				"targetModifier":{"smart":false}
@@ -581,7 +581,7 @@
 				"targetModifier":{"smart":false},
 				"battleEffects":{
 					"moat":{
-						"type":"core:moat",
+						"type":"moat",
 						"hidden" : false,
 						"trap" : true,
 						"triggerAbility" : "core:strongholdMoatTrigger",
@@ -595,7 +595,7 @@
 							"primarySkill" : {
 								"val" : -3,
 								"type" : "PRIMARY_SKILL",
-								"subtype" : "primarySkill.defence",
+								"subtype" : "defence",
 								"valueType" : "ADDITIVE_VALUE"
 							}
 						}
@@ -636,7 +636,7 @@
 				"cost" : 0, //For validation
 				"battleEffects" : {
 					"directDamage" : {
-						"type":"core:damage"
+						"type":"damage"
 					}
 				},
 				"targetModifier":{"smart":false}
@@ -676,7 +676,7 @@
 				"targetModifier":{"smart":false},
 				"battleEffects":{
 					"moat":{
-						"type":"core:moat",
+						"type":"moat",
 						"hidden" : false,
 						"trap" : true,
 						"triggerAbility" : "core:fortressMoatTrigger",
@@ -690,7 +690,7 @@
 							"primarySkill" : {
 								"val" : -3,
 								"type" : "PRIMARY_SKILL",
-								"subtype" : "primarySkill.defence",
+								"subtype" : "defence",
 								"valueType" : "ADDITIVE_VALUE"
 							}
 						}

--- a/config/spells/offensive.json
+++ b/config/spells/offensive.json
@@ -20,7 +20,7 @@
 			"base":{
 				"range" : "0",
 				"battleEffects" : {
-					"directDamage" : {"type":"core:damage"}
+					"directDamage" : {"type":"damage"}
 				},
 				"targetModifier":{"smart":true}
 			}
@@ -53,7 +53,7 @@
 			"base":{
 				"range" : "0",
 				"battleEffects" : {
-					"directDamage" : {"type":"core:damage"}
+					"directDamage" : {"type":"damage"}
 				},
 				"targetModifier":{"smart":true}
 			}
@@ -79,7 +79,7 @@
 			"base":{
 				"range" : "0",
 				"battleEffects" : {
-					"directDamage" : {"type":"core:damage"}
+					"directDamage" : {"type":"damage"}
 				},
 				"targetModifier":{"smart":true}
 			}
@@ -105,7 +105,7 @@
 			"base":{
 				"range" : "0",
 				"battleEffects" : {
-					"directDamage" : {"type":"core:damage"}
+					"directDamage" : {"type":"damage"}
 				},
 				"targetModifier":{"smart":true}
 			}
@@ -144,7 +144,7 @@
 				"range" : "0",
 				"battleEffects" : {
 					"directDamage" : {
-						"type" : "core:damage",
+						"type" : "damage",
 						"chainFactor" : 0.5,
 						"chainLength" : 4
 					}
@@ -185,7 +185,7 @@
 			"base":{
 				"range" : "1",
 				"battleEffects" : {
-					"directDamage" : {"type":"core:damage"}
+					"directDamage" : {"type":"damage"}
 				},
 				"targetModifier":{"smart":false}
 			}
@@ -213,7 +213,7 @@
 			"base":{
 				"range" : "0,1",
 				"battleEffects" : {
-					"directDamage" : {"type":"core:damage"}
+					"directDamage" : {"type":"damage"}
 				},
 				"targetModifier":{"smart":false}
 			}
@@ -241,7 +241,7 @@
 			"base":{
 				"range" : "0-2",
 				"battleEffects" : {
-					"directDamage" : {"type":"core:damage"}
+					"directDamage" : {"type":"damage"}
 				},
 				"targetModifier":{"smart":false}
 			}
@@ -269,7 +269,7 @@
 			"base":{
 				"range" : "0,1",
 				"battleEffects" : {
-					"directDamage" : {"type":"core:damage"}
+					"directDamage" : {"type":"damage"}
 				},
 				"targetModifier":{"smart":false}
 			}
@@ -297,7 +297,7 @@
 			"base":{
 				"range" : "X",
 				"battleEffects" : {
-					"directDamage" : {"type":"core:damage"}
+					"directDamage" : {"type":"damage"}
 				},
 				"targetModifier":{"smart":false}
 			}
@@ -327,7 +327,7 @@
 			"base":{
 				"range" : "X",
 				"battleEffects" : {
-					"directDamage" : {"type":"core:damage"}
+					"directDamage" : {"type":"damage"}
 				},
 				"targetModifier":{"smart":false}
 			}
@@ -356,7 +356,7 @@
 			"base":{
 				"range" : "X",
 				"battleEffects" : {
-					"directDamage" : {"type":"core:damage"}
+					"directDamage" : {"type":"damage"}
 				},
 				"targetModifier":{"smart":false}
 			}
@@ -382,7 +382,7 @@
 			"base":{
 				"range" : "0",
 				"battleEffects" : {
-					"directDamage" : {"type":"core:damage"}
+					"directDamage" : {"type":"damage"}
 				},
 				"targetModifier":{"smart":true}
 			}

--- a/config/spells/other.json
+++ b/config/spells/other.json
@@ -11,7 +11,7 @@
 				"range" : "X",
 				"battleEffects" : {
 					"obstacle" : {
-						"type":"core:obstacle",
+						"type":"obstacle",
 						"hidden" : true,
 						"passable" : true,
 						"trap" : true,
@@ -80,7 +80,7 @@
 				"cost" : 0, //For validation
 				"battleEffects" : {
 					"directDamage" : {
-						"type":"core:damage"
+						"type":"damage"
 					}
 				},
 				"targetModifier":{"smart":false}
@@ -118,7 +118,7 @@
 				"range" : "X",
 				"battleEffects" : {
 					"obstacle" : {
-						"type":"core:obstacle",
+						"type":"obstacle",
 						"hidden" : true,
 						"passable" : true,
 						"trap" : false,
@@ -176,7 +176,7 @@
 				},
 				"battleEffects":{
 					"obstacle":{
-						"type":"core:obstacle",
+						"type":"obstacle",
 						"hidden" : false,
 						"passable" : false,
 						"trap" : false,
@@ -261,7 +261,7 @@
 				"cost" : 0, //For validation
 				"battleEffects" : {
 					"directDamage" : {
-						"type":"core:damage"
+						"type":"damage"
 					}
 				},
 				"targetModifier":{"smart":false}
@@ -302,7 +302,7 @@
 				},
 				"battleEffects":{
 					"obstacle":{
-						"type":"core:obstacle",
+						"type":"obstacle",
 						"hidden" : false,
 						"passable" : true,
 						"trap" : false,
@@ -369,7 +369,7 @@
 				"targetModifier":{"smart":true},
 				"battleEffects":{
 					"catapult":{
-						"type":"core:catapult",
+						"type":"catapult",
 						"targetsToAttack": 2,
 						"chanceToCrit" : 0,
 						"chanceToNormalHit" : 100
@@ -414,7 +414,7 @@
 				},
 				"battleEffects":{
 					"dispel":{
-						"type":"core:dispel",
+						"type":"dispel",
 						"optional":false,
 						"ignoreImmunity" : true,
 						"dispelNegative":true,
@@ -461,13 +461,13 @@
 				"targetModifier":{"smart":true},
 				"battleEffects":{
 					"heal":{
-						"type":"core:heal",
+						"type":"heal",
 						"healLevel":"heal",
 						"healPower":"permanent",
 						"optional":true
 					},
 					"cure":{
-						"type":"core:dispel",
+						"type":"dispel",
 						"optional":true,
 						"dispelNegative":true,
 						"dispelNeutral":false,
@@ -481,7 +481,7 @@
 			}
 		},
 		"counters" : {
-			"spell.stoneGaze": true
+			"stoneGaze": true
 		},
 		"flags" : {
 			"positive": true
@@ -502,13 +502,13 @@
 				"range" : "0",
 				"battleEffects":{
 					"heal":{
-						"type":"core:heal",
+						"type":"heal",
 						"healLevel":"resurrect",
 						"healPower":"oneBattle",
 						"minFullUnits" : 1
 					},
 					"cure":{
-						"type":"core:dispel",
+						"type":"dispel",
 						"indirect": true,
 						"optional":true,
 						"dispelNegative":true,
@@ -562,7 +562,7 @@
 				"range" : "0",
 				"battleEffects":{
 					"heal":{
-						"type":"core:heal",
+						"type":"heal",
 						"healLevel":"resurrect",
 						"healPower":"permanent",
 						"minFullUnits" : 1

--- a/config/spells/timed.json
+++ b/config/spells/timed.json
@@ -106,7 +106,7 @@
 				"effects" : {
 					"spellDamageReduction" : {
 						"type" : "SPELL_DAMAGE_REDUCTION",
-						"subtype" : "spellSchool.air",
+						"subtype" : "air",
 						"duration" : "N_TURNS",
 						"val" : 30
 					}
@@ -149,7 +149,7 @@
 				"effects" : {
 					"spellDamageReduction" : {
 						"type" : "SPELL_DAMAGE_REDUCTION",
-						"subtype" : "spellSchool.fire",
+						"subtype" : "fire",
 						"duration" : "N_TURNS",
 						"val" : 30
 					}
@@ -192,7 +192,7 @@
 				"effects" : {
 					"spellDamageReduction" : {
 						"type" : "SPELL_DAMAGE_REDUCTION",
-						"subtype" : "spellSchool.water",
+						"subtype" : "water",
 						"duration" : "N_TURNS",
 						"val" : 30
 					}
@@ -235,7 +235,7 @@
 				"effects" : {
 					"spellDamageReduction" : {
 						"type" : "SPELL_DAMAGE_REDUCTION",
-						"subtype" : "spellSchool.earth",
+						"subtype" : "earth",
 						"duration" : "N_TURNS",
 						"val" : 30
 					}
@@ -277,7 +277,7 @@
 				"targetModifier":{"smart":true},
 				"battleEffects":{
 					"spellImmunity":{
-						"type":"core:timed",
+						"type":"timed",
 						"bonus":{
 							"levelSpellImmunity":{
 								"val" : 3,
@@ -288,7 +288,7 @@
 						}
 					},
 					"dispel":{
-						"type":"core:dispel",
+						"type":"dispel",
 						"optional":true,
 						"dispelNegative":true,
 						"dispelNeutral":true,
@@ -390,7 +390,7 @@
 			}
 		},
 		"counters" : {
-			"spell.curse": true
+			"curse": true
 		},
 		"flags" : {
 			"positive": true
@@ -444,7 +444,7 @@
 			}
 		},
 		"counters" : {
-			"spell.bless": true
+			"bless": true
 		},
 		"flags" : {
 			"negative": true
@@ -478,7 +478,7 @@
 					"primarySkill" : {
 						"val" : 3,
 						"type" : "PRIMARY_SKILL",
-						"subtype" : "primarySkill.attack",
+						"subtype" : "attack",
 						"effectRange" : "ONLY_MELEE_FIGHT",
 						"duration" : "N_TURNS"
 					}
@@ -501,7 +501,7 @@
 			}
 		},
 		"counters" : {
-			"spell.weakness": true
+			"weakness": true
 		},
 		"flags" : {
 			"positive": true
@@ -529,7 +529,7 @@
 				"effects" : {
 					"primarySkill" : {
 						"type" : "PRIMARY_SKILL",
-						"subtype" : "primarySkill.attack",
+						"subtype" : "attack",
 						"val" : 3,
 						"effectRange" : "ONLY_DISTANCE_FIGHT",
 						"duration" : "N_TURNS"
@@ -578,7 +578,7 @@
 				"effects" : {
 					"primarySkill" : {
 						"type" : "PRIMARY_SKILL",
-						"subtype" : "primarySkill.attack",
+						"subtype" : "attack",
 						"val" : -3,
 						"duration" : "N_TURNS"
 					}
@@ -602,7 +602,7 @@
 			}
 		},
 		"counters" : {
-			"spell.bloodlust": true
+			"bloodlust": true
 		},
 		"flags" : {
 			"negative": true
@@ -625,7 +625,7 @@
 				"effects" : {
 					"primarySkill" : {
 						"type" : "PRIMARY_SKILL",
-						"subtype" : "primarySkill.defence",
+						"subtype" : "defence",
 						"val" : 3,
 						"duration" : "N_TURNS"
 					}
@@ -669,7 +669,7 @@
 				"cumulativeEffects" : {
 					"primarySkill" : {
 						"type" : "PRIMARY_SKILL",
-						"subtype" : "primarySkill.defence",
+						"subtype" : "defence",
 						"val" : -3,
 						"valueType" : "ADDITIVE_VALUE",
 						"duration" : "PERMANENT"
@@ -713,13 +713,13 @@
 				"effects" : {
 					"attack" : {
 						"type" : "PRIMARY_SKILL",
-						"subtype" : "primarySkill.attack",
+						"subtype" : "attack",
 						"val" : 2,
 						"duration" : "N_TURNS"
 					},
 					"defence" : {
 						"type" : "PRIMARY_SKILL",
-						"subtype" : "primarySkill.defence",
+						"subtype" : "defence",
 						"val" : 2,
 						"duration" : "N_TURNS"
 					},
@@ -801,7 +801,7 @@
 			}
 		},
 		"counters" : {
-			"spell.sorrow":true
+			"sorrow":true
 		},
 		"flags" : {
 			"positive": true
@@ -855,7 +855,7 @@
 			}
 		},
 		"counters" : {
-			"spell.mirth":true
+			"mirth":true
 		},
 		"flags" : {
 			"negative": true
@@ -909,7 +909,7 @@
 			}
 		},
 		"counters" : {
-			"spell.misfortune": true
+			"misfortune": true
 		},
 		"flags" : {
 			"positive": true
@@ -961,7 +961,7 @@
 			}
 		},
 		"counters" : {
-			"spell.fortune":true
+			"fortune":true
 		},
 		"flags" : {
 			"negative": true
@@ -1013,7 +1013,7 @@
 			}
 		},
 		"counters" : {
-			"spell.slow": true
+			"slow": true
 		},
 		"flags" : {
 			"positive": true
@@ -1064,7 +1064,7 @@
 			}
 		},
 		"counters" : {
-			"spell.haste":true
+			"haste":true
 		},
 		"flags" : {
 			"negative": true
@@ -1263,7 +1263,7 @@
 			}
 		},
 		"counters" : {
-			"spell.hypnotize": true
+			"hypnotize": true
 		},
 		"flags" : {
 			"negative": true
@@ -1329,7 +1329,7 @@
 			}
 		},
 		"counters" : {
-			"spell.berserk": true
+			"berserk": true
 		},
 		"targetCondition" : {
 			"allOf" : {

--- a/config/spells/vcmiAbility.json
+++ b/config/spells/vcmiAbility.json
@@ -26,7 +26,7 @@
 					"demonSummon":{
 						"id":"demon",
 						"permanent":true,
-						"type":"core:demonSummon"
+						"type":"demonSummon"
 					}
 				}
 			},
@@ -73,7 +73,7 @@
 				"targetModifier":{"smart":true},
 				"battleEffects":{
 					"heal":{
-						"type":"core:heal",
+						"type":"heal",
 						"healLevel":"heal",
 						"healPower":"permanent",
 						"optional":true
@@ -121,7 +121,7 @@
 				"targetModifier":{"smart":true},
 				"battleEffects":{
 					"catapult":{
-						"type":"core:catapult"
+						"type":"catapult"
 					}
 				},
 				"range" : "0"
@@ -201,7 +201,7 @@
 				"targetModifier":{"smart":true},
 				"battleEffects":{
 					"catapult":{
-						"type":"core:catapult",
+						"type":"catapult",
 						"targetsToAttack": 1,
 						"chanceToHitKeep" : 7,
 						"chanceToHitGate" : 30,

--- a/scripts/spells/timed.lua
+++ b/scripts/spells/timed.lua
@@ -117,20 +117,13 @@ function Script:describeEffect(server, battle, unit, bonuses)
 	-- Age spell: STACK_HEALTH bonus with negative val gets a custom message
 	for _, nb in pairs(bonuses) do
 		if nb.type == "STACK_HEALTH" and (nb.val or 0) < 0 then
-			local healthBonuses = unit:getBonuses(function(b)
-				return b:getType() == "STACK_HEALTH"
-			end)
-			local oldHealth = 0
-			for i = 1, healthBonuses:size() do
-				oldHealth = oldHealth + healthBonuses:getBonus(i):getVal()
-			end
-			local lost = oldHealth - (oldHealth + nb.val)
-			local ageTextID = unit:getCount() == 1
-				and "core.genrltxt.551"
-				or  "core.genrltxt.552"
+			local oldHealth = unit:getMaxHealth()
+			local lost = oldHealth - math.floor((oldHealth * (100 + nb.val)) / 100)
+			local count = unit:getCount()
+			local ageTextID = count == 1 and self.battleLogSingular or self.battleLogPlural
 			server:appendLog(battle, {
 				append         = { ageTextID },
-				replaceStrings = { unit:getCreature():getNameTextID(unit:getCount()) },
+				replaceStrings = { unit:getCreature():getNameTextID(count) },
 				replaceNumbers = { lost }
 			})
 			return


### PR DESCRIPTION
This PR removes all of the redundant scopes in the config files so the logger doesn't log a debug message.

~No functional change intended, just cleanup.~ I noticed a bug with the battle log message from the Age spell. Essentially, it always showed the victim losing 50 hitpoints instead of the actual hitpoints they lost. I migrated Age spell from the deprecated `"effects"` field to use `"battleEffects"` and fixed the battle log message.

There are still some leftover debug messages that probably stem from spells using the `"effects"` field instead of `"battleEffects"`. Not gonna change those in this PR, I think, but I assume they should be migrated eventually?