### PR TITLE
Fix camera not following hero after Whirlpool teleport

### DIFF
--- a/client/HeroMovementController.cpp
+++ b/client/HeroMovementController.cpp
@@ -68,6 +68,11 @@ void HeroMovementController::onBattleStarted()
 
 void HeroMovementController::showTeleportDialog(const CGHeroInstance * hero, TeleportChannelID channel, TTeleportExitsList exits, bool impassable, QueryID askID)
 {
+	// let any dialog describing this teleportation (e.g. Whirlpool's stack-loss message) be
+	// acknowledged by the player first, so the camera still centers on the adventure map
+	// once the hero actually gets moved
+	GAME->interface()->waitWhileDialog();
+
 	if (impassable || exits.empty()) //FIXME: why we even have this dialog in such case?
 	{
 		GAME->interface()->cb->selectionMade(-1, askID);


### PR DESCRIPTION
## Summary
- Fixes #5064.
- Root cause: Whirlpool's stack-loss `InfoWindow` is pushed as a non-blocking window, so the client immediately auto-answers the empty-exit `TeleportDialog` underneath it. By the time the server's teleport packet reaches the client, that message box is still the topmost window, so `MapViewController::isEventVisible()` treats the adventure map as hidden and skips centering the camera on the hero's new position.
- Fix: `HeroMovementController::showTeleportDialog` now waits for any currently shown dialog to be acknowledged before auto-answering the teleport prompt — matching original HOMM3 behavior (read the message, click OK, then get moved with the camera following). For other teleporters (Monolith, Subterranean Gate, etc.) where no dialog precedes the teleport, this wait returns immediately and changes nothing.

## OG Experience™


[Screencast_20260822_024533.webm](https://github.com/user-attachments/assets/5ec44034-bdaf-4055-8623-05927c03fff1)

## Before

[Screencast_20260822_024900.webm](https://github.com/user-attachments/assets/74221b31-e5cf-4791-a939-3709a63fe75b)


## After

[Screencast_20260822_024154.webm](https://github.com/user-attachments/assets/13604c9a-82ce-4964-bcd2-dc895de1508e)


## Test plan
- [x] Built `vcmiclient`/`vcmiserver` locally (RelWithDebInfo) against real game data.
- [x] Manually verified in-game: entered a Whirlpool with a multi-stack hero, saw the stack-loss message, clicked OK, and confirmed the camera pans to the hero at the destination Whirlpool.
- [x] Verified a protected hero (single stack / `WHIRLPOOL_PROTECTION`) still gets the normal exit-choice teleport dialog with camera follow, since this code path is shared.