### PR TITLE
Add post-victory save option and campaign restart bonuses

### DIFF
--- a/client/NetPacksClient.cpp
+++ b/client/NetPacksClient.cpp
@@ -12,6 +12,7 @@
 
 #include "Client.h"
 #include "CPlayerInterface.h"
+#include "lobby/CSavingScreen.h"
 #include "windows/GUIClasses.h"
 #include "windows/CCastleInterface.h"
 #include "mapView/mapHandler.h"
@@ -405,7 +406,8 @@ void ApplyClientNetPackVisitor::visitChangeObjPos(ChangeObjPos & pack)
 
 void ApplyClientNetPackVisitor::visitPlayerEndsGame(PlayerEndsGame & pack)
 {
-	callAllInterfaces(cl, &IGameEventsReceiver::gameOver, pack.player, pack.victoryLossCheckResult);
+	if(!pack.resumeGameEnd)
+		callAllInterfaces(cl, &IGameEventsReceiver::gameOver, pack.player, pack.victoryLossCheckResult);
 
 	bool localHumanWinsGame = vstd::contains(cl.playerint, pack.player) && cl.gameInfo().getPlayerState(pack.player)->human && pack.victoryLossCheckResult.victory();
 	bool lastHumanEndsGame = GAME->server().howManyPlayerInterfaces() == 1 && vstd::contains(cl.playerint, pack.player) && cl.gameInfo().getPlayerState(pack.player)->human && !settings["session"]["spectate"].Bool();
@@ -420,7 +422,27 @@ void ApplyClientNetPackVisitor::visitPlayerEndsGame(PlayerEndsGame & pack)
 		}
 
 		if(!pack.silentEnd)
-			GAME->server().showHighScoresAndEndGameplay(pack.player, pack.victoryLossCheckResult.victory(), pack.statistic);
+		{
+			auto finishGame = [player = pack.player, victory = pack.victoryLossCheckResult.victory(), statistic = pack.statistic]()
+			{
+				GAME->server().showHighScoresAndEndGameplay(player, victory, statistic);
+			};
+
+			const bool completedGame = std::ranges::any_of(cl.gameState().players, [](const auto & playerState)
+			{
+				return playerState.second.status == EPlayerStatus::WINNER;
+			});
+			const bool showSaveDialog = !pack.resumeGameEnd
+				&& completedGame
+				&& GAME->server().isHost()
+				&& settings["general"]["showSaveDialogOnVictory"].Bool()
+				&& settings["session"]["testmap"].isNull();
+
+			if(showSaveDialog)
+				ENGINE->windows().createAndPushWindow<CSavingScreen>(false, std::move(finishGame));
+			else
+				finishGame();
+		}
 		else
 		{
 			GAME->server().endGameplay();

--- a/client/NetPacksLobbyClient.cpp
+++ b/client/NetPacksLobbyClient.cpp
@@ -163,8 +163,18 @@ void ApplyOnLobbyHandlerNetPackVisitor::visitLobbyRestartGame(LobbyRestartGame &
 {
 	assert(handler.getState() == EClientState::GAMEPLAY);
 
+	const bool campaignRestart = handler.si->campState != nullptr;
 	handler.restartGameplay();
-	handler.sendStartGame();
+
+	if(campaignRestart)
+	{
+		handler.setState(EClientState::LOBBY_CAMPAIGN);
+		ENGINE->windows().createAndPushWindow<CLobbyScreen>(ESelectionScreen::campaignList, true);
+	}
+	else
+	{
+		handler.sendStartGame();
+	}
 }
 
 void ApplyOnLobbyHandlerNetPackVisitor::visitLobbyPrepareStartGame(LobbyPrepareStartGame & pack)

--- a/client/lobby/CBonusSelection.cpp
+++ b/client/lobby/CBonusSelection.cpp
@@ -32,6 +32,7 @@
 #include "../windows/InfoWindows.h"
 #include "../windows/CHeroOverview.h"
 #include "../windows/CCreatureWindow.h"
+#include "../render/CanvasImage.h"
 #include "../render/IImage.h"
 #include "../render/IRenderHandler.h"
 #include "../render/CAnimation.h"
@@ -64,13 +65,19 @@
 #include "../../lib/texts/TextOperations.h"
 #include "mapping/MapFormatSettings.h"
 
+namespace
+{
+const ColorRGBA READ_ONLY_COLOR(128, 128, 128, ColorRGBA::ALPHA_OPAQUE);
+}
+
 std::shared_ptr<CampaignState> CBonusSelection::getCampaign()
 {
 	return GAME->server().si->campState;
 }
 
-CBonusSelection::CBonusSelection()
+CBonusSelection::CBonusSelection(bool readOnly)
 	: CWindowObject(BORDERED)
+	, readOnly(readOnly)
 {
 	OBJECT_CONSTRUCTION;
 
@@ -100,13 +107,16 @@ CBonusSelection::CBonusSelection()
 	labelCampaignDescription = std::make_shared<CLabel>(481, 63, FONT_SMALL, ETextAlignment::TOPLEFT, Colors::YELLOW, LIBRARY->generaltexth->allTexts[38]);
 	campaignDescription = std::make_shared<CTextBox>(getCampaign()->getDescriptionTranslated(), Rect(480, 86, 286, 117), 1);
 
-	bool videoButtonActive = GAME->server().getState() == EClientState::GAMEPLAY;
-	int availableSpace = videoButtonActive ? 225 : 285;
+	int availableSpace = readOnly ? 225 : 285;
 	mapName = std::make_shared<CLabel>(481, 219, FONT_BIG, ETextAlignment::TOPLEFT, Colors::YELLOW, GAME->server().mi->getNameTranslated(), availableSpace );
 	labelMapDescription = std::make_shared<CLabel>(481, 253, FONT_SMALL, ETextAlignment::TOPLEFT, Colors::YELLOW, LIBRARY->generaltexth->allTexts[496]);
 	mapDescription = std::make_shared<CTextBox>("", Rect(480, 276, 286, 112), 1);
 
-	labelChooseBonus = std::make_shared<CLabel>(475, 432, FONT_SMALL, ETextAlignment::TOPLEFT, Colors::WHITE, LIBRARY->generaltexth->allTexts[71]);
+	const ColorRGBA bonusLabelColor = readOnly
+		? READ_ONLY_COLOR
+		: Colors::WHITE;
+	labelChooseBonus = std::make_shared<CLabel>(475, 432, FONT_SMALL, ETextAlignment::TOPLEFT, bonusLabelColor,
+		LIBRARY->generaltexth->allTexts[71]);
 	groupBonuses = std::make_shared<CToggleGroup>(std::bind(&IServerAPI::setCampaignBonus, &GAME->server(), _1));
 
 	flagbox = std::make_shared<CFlagBox>(Rect(486, 407, 335, 23));
@@ -144,7 +154,7 @@ CBonusSelection::CBonusSelection()
 	if (!getCampaign()->getMusic().empty())
 		ENGINE->music().playMusic( getCampaign()->getMusic(), true, false);
 
-	if(GAME->server().getState() != EClientState::GAMEPLAY && settings["general"]["enableUiEnhancements"].Bool())
+	if(!readOnly && settings["general"]["enableUiEnhancements"].Bool())
 	{
 		tabExtraOptions = std::make_shared<ExtraOptionsTab>();
 		tabExtraOptions->recActions = UPDATE | SHOWALL | LCLICK | RCLICK_POPUP;
@@ -155,7 +165,10 @@ CBonusSelection::CBonusSelection()
 	}
 
 	// Ensure campaign map info is synchronized even if player doesn't click any region manually.
-	GAME->server().setCampaignMap(GAME->server().campaignMap);
+	// A restarted campaign already has synchronized map info and its previous bonus
+	// should remain selected until the player chooses another one.
+	if(GAME->server().campaignBonus == -1 && !readOnly)
+		GAME->server().setCampaignMap(GAME->server().campaignMap);
 }
 
 void CBonusSelection::createBonusesIcons()
@@ -166,6 +179,12 @@ void CBonusSelection::createBonusesIcons()
 	const std::vector<CampaignBonus> & bonDescs = scenario.travelOptions.bonusesToChoose;
 	groupBonuses = std::make_shared<CToggleGroup>(std::bind(&IServerAPI::setCampaignBonus, &GAME->server(), _1));
 	groupBonuses->setRedrawParent(true);
+	int selectedBonus = GAME->server().campaignBonus;
+	if(selectedBonus == -1)
+	{
+		if(auto campaignBonus = getCampaign()->getBonusID(GAME->server().campaignMap))
+			selectedBonus = *campaignBonus;
+	}
 
 	auto getBuildingID = [this](const CampaignBonusBuilding & bonusValue) -> std::pair<FactionID, BuildingID> {
 		FactionID faction;
@@ -400,10 +419,22 @@ void CBonusSelection::createBonusesIcons()
 		});
 		bonusButton->setRedrawParent(true);
 
+		std::shared_ptr<IImage> bonusOverlayImage;
 		if(picNumber != -1)
-			bonusButton->setOverlay(std::make_shared<CAnimImage>(AnimationPath::builtin(picName), picNumber));
+			bonusOverlayImage = ENGINE->renderHandler().loadImage(AnimationPath::builtin(picName), picNumber, 0, EImageBlitMode::COLORKEY);
 		else
-			bonusButton->setOverlay(std::make_shared<CPicture>(ImagePath::builtin(picName)));
+			bonusOverlayImage = ENGINE->renderHandler().loadImage(ImagePath::builtin(picName), EImageBlitMode::COLORKEY);
+
+		if(readOnly)
+		{
+			auto grayscaleImage = ENGINE->renderHandler().createImage(bonusOverlayImage->dimensions(), CanvasScalingPolicy::AUTO);
+			auto grayscaleCanvas = grayscaleImage->getCanvas();
+			grayscaleCanvas.draw(bonusOverlayImage, Point());
+			grayscaleCanvas.applyGrayscale();
+			bonusOverlayImage = grayscaleImage;
+		}
+
+		bonusButton->setOverlay(std::make_shared<CPicture>(bonusOverlayImage, Point()));
 
 		// Add right-click popup with component for supported bonus types when UI enhancements are enabled
 		if(useComponentPopup)
@@ -495,7 +526,8 @@ void CBonusSelection::createBonusesIcons()
 		}
 
 		Point iconSize(58, 64);
-		auto bonusButtonLabel = std::make_shared<CLabel>(473 + iconSize.x + i * 68, 455 + iconSize.y, FONT_MEDIUM, ETextAlignment::BOTTOMRIGHT, Colors::WHITE);
+		auto bonusButtonLabel = std::make_shared<CLabel>(473 + iconSize.x + i * 68, 455 + iconSize.y,
+			FONT_MEDIUM, ETextAlignment::BOTTOMRIGHT, readOnly ? READ_ONLY_COLOR : Colors::WHITE);
 		if(settings["general"]["enableUiEnhancements"].Bool())
 		{
 			switch(bonusType)
@@ -525,19 +557,33 @@ void CBonusSelection::createBonusesIcons()
 			}
 		}
 
-		if(GAME->server().campaignBonus == i)
-			bonusButton->setBorderColor(Colors::BRIGHT_YELLOW);
+		if(selectedBonus == i)
+			bonusButton->setBorderColor(readOnly ? READ_ONLY_COLOR : Colors::BRIGHT_YELLOW);
 		groupBonuses->addToggle(i, bonusButton);
 		groupBonusesLabels.push_back(bonusButtonLabel);
 	}
 
-	if(getCampaign()->getBonusID(GAME->server().campaignMap))
-		groupBonuses->setSelected(*getCampaign()->getBonusID(GAME->server().campaignMap));
+	if(selectedBonus != -1)
+	{
+		groupBonuses->setSelectedSilent(selectedBonus);
+
+		// A loaded campaign may contain a previous selection before the lobby
+		// has restored it. Send it once; subsequent state refreshes use the
+		// synchronized lobby value without invoking this callback again.
+		if(GAME->server().campaignBonus == -1 && !readOnly)
+			GAME->server().setCampaignBonus(selectedBonus);
+	}
+
+	if(readOnly)
+	{
+		for(const auto & bonus : groupBonuses->buttons)
+			bonus.second->setEnabled(false);
+	}
 }
 
 void CBonusSelection::updateAfterStateChange()
 {
-	if(GAME->server().getState() != EClientState::GAMEPLAY)
+	if(!readOnly)
 	{
 		buttonRestart->disable();
 		buttonVideo->disable();
@@ -592,7 +638,7 @@ void CBonusSelection::updateAfterStateChange()
 
 void CBonusSelection::goBack()
 {
-	if(GAME->server().getState() != EClientState::GAMEPLAY)
+	if(!readOnly)
 	{
 		ENGINE->windows().popWindows(2);
 		GAME->mainmenu()->playMusic();

--- a/client/lobby/CBonusSelection.h
+++ b/client/lobby/CBonusSelection.h
@@ -33,9 +33,11 @@ class LRClickableArea;
 /// Campaign screen where you can choose one out of three starting bonuses
 class CBonusSelection : public CWindowObject
 {
+	const bool readOnly;
+
 public:
 	std::shared_ptr<CampaignState> getCampaign();
-	CBonusSelection();
+	explicit CBonusSelection(bool readOnly = false);
 
 	class CRegion
 		: public CIntObject

--- a/client/lobby/CCampaignInfoScreen.cpp
+++ b/client/lobby/CCampaignInfoScreen.cpp
@@ -21,6 +21,7 @@
 #include "../CPlayerInterface.h"
 
 CCampaignInfoScreen::CCampaignInfoScreen()
+	: CBonusSelection(true)
 {
 	OBJECT_CONSTRUCTION;
 	localSi = std::make_unique<StartInfo>(*GAME->interface()->cb->getStartInfo());

--- a/client/lobby/CSavingScreen.cpp
+++ b/client/lobby/CSavingScreen.cpp
@@ -28,8 +28,10 @@
 #include "../../lib/mapping/CMapHeader.h"
 #include "../../lib/GameLibrary.h"
 
-CSavingScreen::CSavingScreen()
+CSavingScreen::CSavingScreen(bool pauseGame, std::function<void()> onClose)
 	: CSelectionBase(ESelectionScreen::saveGame)
+	, pauseGame(pauseGame)
+	, onClose(std::move(onClose))
 {
 	OBJECT_CONSTRUCTION;
 	center(pos);
@@ -46,7 +48,8 @@ CSavingScreen::CSavingScreen()
 		
 	buttonStart = std::make_shared<CButton>(Point(411, 535), AnimationPath::builtin("SCNRSAV.DEF"), LIBRARY->generaltexth->zelp[103], std::bind(&CSavingScreen::saveGame, this), EShortcut::LOBBY_SAVE_GAME);
 	
-	GAME->interface()->gamePause(true);
+	if(pauseGame)
+		GAME->interface()->gamePause(true);
 }
 
 const CMapInfo * CSavingScreen::getMapInfo()
@@ -73,8 +76,14 @@ void CSavingScreen::changeSelection(std::shared_ptr<CMapInfo> to)
 
 void CSavingScreen::close()
 {
-	GAME->interface()->gamePause(false);
+	if(pauseGame)
+		GAME->interface()->gamePause(false);
+
+	auto closeCallback = std::move(onClose);
 	CSelectionBase::close();
+
+	if(closeCallback)
+		ENGINE->dispatchMainThread(std::move(closeCallback));
 }
 
 void CSavingScreen::saveGame()

--- a/client/lobby/CSavingScreen.h
+++ b/client/lobby/CSavingScreen.h
@@ -21,7 +21,7 @@ class CSavingScreen : public CSelectionBase
 public:
 	std::shared_ptr<CMapInfo> localMi;
 
-	CSavingScreen();
+	CSavingScreen(bool pauseGame = true, std::function<void()> onClose = {});
 
 	void changeSelection(std::shared_ptr<CMapInfo> to);
 	void saveGame();
@@ -31,4 +31,8 @@ public:
 	
 protected:
 	void close() override;
+
+private:
+	bool pauseGame;
+	std::function<void()> onClose;
 };

--- a/client/widgets/Buttons.cpp
+++ b/client/widgets/Buttons.cpp
@@ -592,6 +592,23 @@ void CToggleGroup::setSelected(int id)
 	selectionChanged(id);
 }
 
+void CToggleGroup::setSelectedSilent(int id)
+{
+	if(id == selectedID)
+		return;
+
+	int oldSelection = selectedID;
+	selectedID = id;
+
+	if(buttons.count(oldSelection))
+		buttons[oldSelection]->setSelectedSilent(false);
+
+	if(buttons.count(id))
+		buttons[id]->setSelectedSilent(true);
+
+	redraw();
+}
+
 void CToggleGroup::setSelectedOnly(int id)
 {
 	for(const auto & button : buttons)

--- a/client/widgets/Buttons.h
+++ b/client/widgets/Buttons.h
@@ -207,6 +207,8 @@ public:
 	void addToggle(int index, const std::shared_ptr<CToggleBase> & button);
 	/// Changes selection to specific value. Will select toggle with this ID, if present
 	void setSelected(int id);
+	/// Changes selection without invoking the group callback
+	void setSelectedSilent(int id);
 	/// in some cases, e.g. LoadGame difficulty selection, after refreshing the UI, the ToggleGroup should 
 	/// reset all of it's child buttons to BLOCK state, then make selection again
 	void setSelectedOnly(int id);

--- a/config/schemas/settings.json
+++ b/config/schemas/settings.json
@@ -43,6 +43,7 @@
 				"saveBeforeVisit",
 				"startTurnAutosave",
 				"enableUiEnhancements",
+				"showSaveDialogOnVictory",
 				"audioMuteFocus",
 				"enableOverlay",
 				"lastKindomInterface",
@@ -152,6 +153,10 @@
 					"default": false
 				},
 				"enableUiEnhancements" : {
+					"type": "boolean",
+					"default": true
+				},
+				"showSaveDialogOnVictory" : {
 					"type": "boolean",
 					"default": true
 				},

--- a/lib/gameState/GameStatePackVisitor.cpp
+++ b/lib/gameState/GameStatePackVisitor.cpp
@@ -367,6 +367,9 @@ void GameStatePackVisitor::visitChangeArtifactsCostume(ChangeArtifactsCostume & 
 
 void GameStatePackVisitor::visitPlayerEndsGame(PlayerEndsGame & pack)
 {
+	if(pack.resumeGameEnd)
+		return;
+
 	PlayerState *p = gs.getPlayerState(pack.player);
 	if(pack.victoryLossCheckResult.victory())
 	{

--- a/lib/networkPacks/PacksForClient.h
+++ b/lib/networkPacks/PacksForClient.h
@@ -546,6 +546,7 @@ struct DLL_LINKAGE PlayerEndsGame : public CPackForClient
 	EVictoryLossCheckResult victoryLossCheckResult;
 	StatisticDataSet statistic;
 	bool silentEnd = false;
+	bool resumeGameEnd = false; // continue the already-applied end transition after loading a completed game
 
 	void visitTyped(ICPackVisitor & visitor) override;
 
@@ -555,6 +556,8 @@ struct DLL_LINKAGE PlayerEndsGame : public CPackForClient
 		h & victoryLossCheckResult;
 		h & statistic;
 		h & silentEnd;
+		if(h.hasFeature(Handler::Version::GAME_END_TRANSITIONS))
+			h & resumeGameEnd;
 	}
 };
 

--- a/lib/serializer/ESerializationVersion.h
+++ b/lib/serializer/ESerializationVersion.h
@@ -55,12 +55,13 @@ enum class ESerializationVersion : int32_t
 	GAME_SESSION_DIRECTORY, // persistent per-game save directory and campaign start time
 	SCENARIO_EVENT_JOURNAL, // per-player history of triggered scenario event messages and components
 	MUTARE_DRAKE_OVERRIDE, // campaign header stores hero type override used for Mutare Drake crossover bonus targeting
+	GAME_END_TRANSITIONS, // distinguish a resumed completed game from the original victory notification
 
 	RELEASE_170 = HOTA_MAP_STACK_COUNT,
 	RELEASE_174 = CUSTOM_GARRISON_TITLE,
 
 	MINIMAL = RELEASE_170,
-	CURRENT = MUTARE_DRAKE_OVERRIDE,
+	CURRENT = GAME_END_TRANSITIONS,
 };
 
 static_assert(ESerializationVersion::MINIMAL <= ESerializationVersion::CURRENT, "Invalid serialization version definition!");

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -777,6 +777,36 @@ void CGameHandler::start(bool resume)
 {
 	LOG_TRACE_PARAMS(logGlobal, "resume=%d", resume);
 
+	if(resume)
+	{
+		const bool completedGame = std::ranges::any_of(gameState().players, [](const auto & playerState)
+		{
+			return playerState.second.human && playerState.second.status == EPlayerStatus::WINNER;
+		});
+
+		if(completedGame)
+		{
+			StatisticDataSet finalStatistic = *statistics;
+			addStatistics(finalStatistic);
+
+			for(const auto & [player, state] : gameState().players)
+			{
+				if(!state.human || state.status == EPlayerStatus::INGAME)
+					continue;
+
+				PlayerEndsGame gameEnd;
+				gameEnd.player = player;
+				gameEnd.victoryLossCheckResult = state.status == EPlayerStatus::WINNER
+					? EVictoryLossCheckResult::victory({}, {})
+					: EVictoryLossCheckResult::defeat({}, {});
+				gameEnd.statistic = finalStatistic;
+				gameEnd.resumeGameEnd = true;
+				sendAndApply(gameEnd);
+			}
+			return;
+		}
+	}
+
 	if (!resume)
 	{
 		onNewTurn();
@@ -3893,10 +3923,8 @@ void CGameHandler::checkVictoryLossConditionsForPlayer(PlayerColor player)
 				}
 			}
 
-			if(p->human)
-			{
-				gameServer().setState(EServerState::SHUTDOWN);
-			}
+			// Keep the server available for post-victory UI. Both the single-scenario and campaign
+			// completion paths call endGameplay(), and the host disconnect then shuts the server down.
 		}
 		else
 		{

--- a/server/NetPacksLobbyServer.cpp
+++ b/server/NetPacksLobbyServer.cpp
@@ -238,6 +238,11 @@ void ApplyOnServerAfterAnnounceNetPackVisitor::visitLobbyRestartGame(LobbyRestar
 {
 	for(const auto & connection : srv.activeConnections)
 		connection->enterLobbyConnectionMode();
+
+	// LobbyRestartGame is propagated in both directions rather than being a
+	// CLobbyPackToServer, so the generic lobby-state propagation does not run.
+	// Campaign restarts need the refreshed state to rebuild bonus selection.
+	srv.updateAndPropagateLobbyState();
 }
 
 void ClientPermissionsCheckerNetPackVisitor::visitLobbyPrepareStartGame(LobbyPrepareStartGame & pack)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -67,6 +67,7 @@ set(test_SRCS
 		quest/CQuestGateTest.cpp
 
 		netpacks/NetPackFixture.cpp
+		netpacks/PlayerEndsGameTest.cpp
 
 		spells/AbilityCasterTest.cpp
 		spells/AdventureSpellEffectTest.cpp

--- a/test/netpacks/PlayerEndsGameTest.cpp
+++ b/test/netpacks/PlayerEndsGameTest.cpp
@@ -1,0 +1,66 @@
+/*
+ * PlayerEndsGameTest.cpp, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ */
+
+#include "StdInc.h"
+
+#include "lib/CPlayerState.h"
+#include "lib/gameState/CGameState.h"
+#include "lib/networkPacks/PacksForClient.h"
+#include "lib/serializer/CMemorySerializer.h"
+
+namespace test
+{
+
+TEST(PlayerEndsGameTest, SerializesResumeMarker)
+{
+	PlayerEndsGame gameEnd;
+	gameEnd.resumeGameEnd = true;
+
+	auto copy = CMemorySerializer::deepCopy(gameEnd);
+
+	ASSERT_NE(copy, nullptr);
+	EXPECT_TRUE(copy->resumeGameEnd);
+}
+
+TEST(PlayerEndsGameTest, DefaultsResumeMarkerForOlderVersion)
+{
+	PlayerEndsGame gameEnd;
+	gameEnd.resumeGameEnd = true;
+
+	CMemorySerializer memory;
+	memory.oser.version = ESerializationVersion::MUTARE_DRAKE_OVERRIDE;
+	memory.iser.version = ESerializationVersion::MUTARE_DRAKE_OVERRIDE;
+	memory.oser & gameEnd;
+
+	PlayerEndsGame copy;
+	memory.iser & copy;
+
+	EXPECT_FALSE(copy.resumeGameEnd);
+}
+
+TEST(PlayerEndsGameTest, ResumeMarkerDoesNotApplyVictoryTwice)
+{
+	CGameState gameState;
+	const PlayerColor player(0);
+	auto [playerState, inserted] = gameState.players.emplace(
+		std::piecewise_construct,
+		std::forward_as_tuple(player),
+		std::forward_as_tuple(&gameState));
+	ASSERT_TRUE(inserted);
+	playerState->second.status = EPlayerStatus::WINNER;
+
+	PlayerEndsGame gameEnd;
+	gameEnd.player = player;
+	gameEnd.resumeGameEnd = true;
+	gameState.apply(gameEnd);
+
+	EXPECT_EQ(playerState->second.status, EPlayerStatus::WINNER);
+}
+
+}


### PR DESCRIPTION
Heroes III opens the save screen right after the "Congratulations!" popup. VCMI was skipping that step and jumping straight into the final game-over path, which also meant there was no handy save to return to before the next scenario, bonus, or campaign choice.

Here we add the save screen before the final transition for both scenarios and campaigns. The prompt is controlled by `general.showSaveDialogOnVictory` and is enabled by default.

The save request path needed a proper ack instead of the old fire-and-forget-ish behavior. `SaveGame` now reports the real success or failure result, the client matches it by request ID, and the victory dialog only moves on after the file is actually written. If saving fails, the dialog stays open and usable. Loading a completed save resumes the final transition without firing the victory popup a second time.

A separate change. Campaign RESTART now goes back to the bonus-selection screen instead of immediately booting the same scenario again. Lobby state is synced first, the previous bonus stays selected, and the player can pick a different one before starting. The same bonus buttons shown in the in-game campaign info screen are now read-only and greyed out, so they no longer look live.

## Testing

- Finished and saved both a normal scenario and a campaign scenario, then loaded the saves and checked that the end flow continued without a second victory popup. When I load a save made at victory time I see a dragon in treasury scene again - and have an ability to record my best result to the table of records again. I think this is an expected behavior.
- Restarted a campaign scenario, selected a different starting bonus, and checked that the new bonus was applied in game.
- Tried the bonus buttons from the in-game campaign screen and confirmed that they stay disabled, while the post-Restart screen is active again.

https://github.com/user-attachments/assets/905ea2b0-2946-407b-8fa3-53a680b63253

Fixes https://github.com/vcmi/vcmi/issues/6806


