### PR TITLE
Fix: play boat sound instead of Angel Wings flapping while boarded

### DIFF
--- a/client/HeroMovementController.cpp
+++ b/client/HeroMovementController.cpp
@@ -284,8 +284,8 @@ AudioPath HeroMovementController::getMovementSoundFor(const CGHeroInstance * her
 	if(moveType == EPathNodeAction::BLOCKING_VISIT)
 		return {};
 
-	// flying movement sound
-	if(hero->hasBonusOfType(BonusType::FLYING_MOVEMENT))
+	// flying movement sound, unless hero is actually on a boat
+	if(hero->hasBonusOfType(BonusType::FLYING_MOVEMENT) && !hero->inBoat())
 		return AudioPath::builtin("HORSE10.wav");
 
 	auto prevTile = GAME->interface()->cb->getTile(posPrev);


### PR DESCRIPTION
## Summary

The Angel Wings artifact grants `BonusType::FLYING_MOVEMENT`, which the client's `getMovementSoundFor()` used unconditionally to pick the wing-flapping movement sound (`HORSE10.wav`) — even when the hero was actually boarded on a ship sailing on water. This meant a hero with Angel Wings equipped who boards a boat still hears wings flapping instead of the correct boat sound.

The fix adds a check that the hero is not currently boarded (`!hero->inBoat()`) alongside the flying-bonus check, so movement while on a boat correctly falls through to the existing terrain-based sound lookup, which already resolves to the boat sound for water tiles.

## Test plan

- [x] Local build (`vcmiclient`) compiles cleanly with the change
- [x] Manual in-game verification: equip Angel Wings, move hero on land (wing-flapping sound plays), board a ship, move on water (boat sound plays instead of wings)