### PR TITLE
Speed up loading of map list in game lobby

### DIFF
--- a/client/lobby/SelectionTab.cpp
+++ b/client/lobby/SelectionTab.cpp
@@ -1469,7 +1469,6 @@ void SelectionTab::parseCampaigns(const std::unordered_set<ResourcePath> & files
 	auto timeElapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - timeStart);
 	logGlobal->debug("Parsing %d campaigns took %d ms", filesVector.size(), timeElapsed.count());
 }
-}
 
 std::string SelectionTab::getFullFileURI(const ElementInfo & item) const
 {
@@ -1486,6 +1485,7 @@ std::string SelectionTab::getFullFileURI(const ElementInfo & item) const
 		return item.fileURI;
 
 	return CResourceHandler::get()->getFullFileURI(resource);
+}
 
 std::unordered_set<ResourcePath> SelectionTab::getFiles(std::string dirURI, EResType resType)
 {

--- a/client/lobby/SelectionTab.cpp
+++ b/client/lobby/SelectionTab.cpp
@@ -483,7 +483,7 @@ void SelectionTab::clickReleased(const Point & cursorPosition)
 			}
 
 			if(!curItems[py]->isFolder)
-				CInfoWindow::showYesNoDialog(LIBRARY->generaltexth->translate("vcmi.lobby.deleteFile") + "\n\n" + curItems[py]->fullFileURI, std::vector<std::shared_ptr<CComponent>>(), [this, py](){
+				CInfoWindow::showYesNoDialog(LIBRARY->generaltexth->translate("vcmi.lobby.deleteFile") + "\n\n" + getFullFileURI(*curItems[py]), std::vector<std::shared_ptr<CComponent>>(), [this, py](){
 					LobbyDelete ld;
 					ld.type = tabType == ESelectionScreen::newGame ? LobbyDelete::EType::RANDOMMAP : LobbyDelete::EType::SAVEGAME;
 					ld.name = curItems[py]->fileURI;
@@ -595,7 +595,7 @@ void SelectionTab::showPopupWindow(const Point & cursorPosition)
 
 		ENGINE->windows().createAndPushWindow<CMapOverview>(
 			curItems[py]->name,
-			curItems[py]->fullFileURI,
+			getFullFileURI(*curItems[py]),
 			creationDateTime,
 			author,
 			mapVersion,
@@ -1469,6 +1469,23 @@ void SelectionTab::parseCampaigns(const std::unordered_set<ResourcePath> & files
 	auto timeElapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - timeStart);
 	logGlobal->debug("Parsing %d campaigns took %d ms", filesVector.size(), timeElapsed.count());
 }
+}
+
+std::string SelectionTab::getFullFileURI(const ElementInfo & item) const
+{
+	EResType resType = EResType::SAVEGAME;
+	if(tabType == ESelectionScreen::newGame)
+		resType = EResType::MAP;
+	if(tabType == ESelectionScreen::campaignList)
+		resType = EResType::CAMPAIGN;
+
+	const ResourcePath resource(item.fileURI, resType);
+
+	// entry may have been deleted from disk since the list was built
+	if(!CResourceHandler::get()->existsResource(resource))
+		return item.fileURI;
+
+	return CResourceHandler::get()->getFullFileURI(resource);
 
 std::unordered_set<ResourcePath> SelectionTab::getFiles(std::string dirURI, EResType resType)
 {

--- a/client/lobby/SelectionTab.cpp
+++ b/client/lobby/SelectionTab.cpp
@@ -1480,10 +1480,6 @@ std::string SelectionTab::getFullFileURI(const ElementInfo & item) const
 
 	const ResourcePath resource(item.fileURI, resType);
 
-	// entry may have been deleted from disk since the list was built
-	if(!CResourceHandler::get()->existsResource(resource))
-		return item.fileURI;
-
 	return CResourceHandler::get()->getFullFileURI(resource);
 }
 

--- a/client/lobby/SelectionTab.h
+++ b/client/lobby/SelectionTab.h
@@ -160,6 +160,8 @@ private:
 	std::vector<ResourcePath> parseSaves(const std::unordered_set<ResourcePath> & files);
 	void parseCampaigns(const std::unordered_set<ResourcePath> & files);
 	std::unordered_set<ResourcePath> getFiles(std::string dirURI, EResType resType);
+	/// Absolute path of an entry, resolved on demand - too expensive to compute for every listed file
+	std::string getFullFileURI(const ElementInfo & item) const;
 
 	void handleUnsupportedSavegames(const std::vector<ResourcePath> & files);
 };

--- a/lib/entities/hero/CHeroHandler.cpp
+++ b/lib/entities/hero/CHeroHandler.cpp
@@ -460,19 +460,17 @@ ui32 CHeroHandler::maxSupportedLevel() const
 	return expPerLevel.size();
 }
 
-std::set<HeroTypeID> CHeroHandler::getDefaultAllowed() const
+const std::set<HeroTypeID> & CHeroHandler::getDefaultAllowed() const
 {
-	std::set<HeroTypeID> result;
-
-	for(auto & hero : objects)
-		if (hero && !hero->special)
-			result.insert(hero->getId());
-
-	return result;
+	return defaultAllowed;
 }
 
 void CHeroHandler::afterLoadFinalization()
 {
+	for(const auto & hero : objects)
+		if (hero && !hero->special)
+			defaultAllowed.insert(hero->getId());
+
 	auto prepSpec = [](HeroTypeID hero, std::shared_ptr<Bonus> bonus)
 	{
 		bonus->duration = BonusDuration::PERMANENT;

--- a/lib/entities/hero/CHeroHandler.h
+++ b/lib/entities/hero/CHeroHandler.h
@@ -33,6 +33,9 @@ class DLL_LINKAGE CHeroHandler : public CHandlerBase<HeroTypeID, HeroType, CHero
 	/// Helper field to generate specialties for heroes after loading is complete
 	mutable std::vector<SpecialtyToGenerate> skillSpecialtiesToGenerate;
 
+	/// All non-special heroes, filled in once loading is complete
+	std::set<HeroTypeID> defaultAllowed;
+
 	/// helpers for loading to avoid huge load functions
 	void loadHeroArmy(CHero * hero, const JsonNode & node) const;
 	void loadHeroSkills(CHero * hero, const JsonNode & node) const;
@@ -60,7 +63,7 @@ public:
 	CHeroHandler();
 	~CHeroHandler();
 
-	std::set<HeroTypeID> getDefaultAllowed() const;
+	const std::set<HeroTypeID> & getDefaultAllowed() const;
 
 protected:
 	const std::vector<std::string> & getTypeNames() const override;

--- a/lib/filesystem/AdapterLoaders.cpp
+++ b/lib/filesystem/AdapterLoaders.cpp
@@ -74,12 +74,21 @@ CFilesystemList::~CFilesystemList()
 {
 }
 
-std::unique_ptr<CInputStream> CFilesystemList::load(const ResourcePath & resourceName) const
+const ISimpleResourceLoader * CFilesystemList::getLoader(const ResourcePath & resourceName) const
 {
-	// load resource from last loader that have it (last overridden version)
+	// last loader that has the resource wins - it holds the last overridden version
 	for(const auto & loader : std::views::reverse(loaders))
 		if (loader->existsResource(resourceName))
-			return loader->load(resourceName);
+			return loader.get();
+
+	return nullptr;
+}
+
+std::unique_ptr<CInputStream> CFilesystemList::load(const ResourcePath & resourceName) const
+{
+	const auto * loader = getLoader(resourceName);
+	if (loader)
+		return loader->load(resourceName);
 
 	throw std::runtime_error("Resource with name " + resourceName.getName() + " and type "
 		+ EResTypeHelper::getEResTypeAsString(resourceName.getType()) + " wasn't found.");
@@ -87,10 +96,7 @@ std::unique_ptr<CInputStream> CFilesystemList::load(const ResourcePath & resourc
 
 bool CFilesystemList::existsResource(const ResourcePath & resourceName) const
 {
-	for(const auto & loader : loaders)
-		if (loader->existsResource(resourceName))
-			return true;
-	return false;
+	return getLoader(resourceName) != nullptr;
 }
 
 std::string CFilesystemList::getMountPoint() const
@@ -100,8 +106,9 @@ std::string CFilesystemList::getMountPoint() const
 
 std::optional<boost::filesystem::path> CFilesystemList::getResourceName(const ResourcePath & resourceName) const
 {
-	if (existsResource(resourceName))
-		return getResourcesWithName(resourceName).back()->getResourceName(resourceName);
+	const auto * loader = getLoader(resourceName);
+	if (loader)
+		return loader->getResourceName(resourceName);
 	return std::optional<boost::filesystem::path>();
 }
 
@@ -206,9 +213,9 @@ bool CFilesystemList::removeLoader(ISimpleResourceLoader * loader)
 
 std::string CFilesystemList::getFullFileURI(const ResourcePath& resourceName) const
 {
-	for (const auto& loader : std::views::reverse(loaders))
-		if (loader->existsResource(resourceName))
-			return loader->getFullFileURI(resourceName);
+	const auto * loader = getLoader(resourceName);
+	if (loader)
+		return loader->getFullFileURI(resourceName);
 
 	throw std::runtime_error("Resource with name " + resourceName.getName() + " and type "
 		+ EResTypeHelper::getEResTypeAsString(resourceName.getType()) + " wasn't found.");
@@ -216,9 +223,9 @@ std::string CFilesystemList::getFullFileURI(const ResourcePath& resourceName) co
 
 std::time_t CFilesystemList::getLastWriteTime(const ResourcePath& resourceName) const
 {
-	for (const auto& loader : std::views::reverse(loaders))
-		if (loader->existsResource(resourceName))
-			return loader->getLastWriteTime(resourceName);
+	const auto * loader = getLoader(resourceName);
+	if (loader)
+		return loader->getLastWriteTime(resourceName);
 
 	throw std::runtime_error("Resource with name " + resourceName.getName() + " and type "
 		+ EResTypeHelper::getEResTypeAsString(resourceName.getType()) + " wasn't found.");

--- a/lib/filesystem/AdapterLoaders.h
+++ b/lib/filesystem/AdapterLoaders.h
@@ -59,6 +59,10 @@ class DLL_LINKAGE CFilesystemList : public ISimpleResourceLoader
 
 	std::set<ISimpleResourceLoader *> writeableLoaders;
 
+	/// Loader that provides the resource, or nullptr. Every lookup goes through here,
+	/// so that a resource is located exactly once per query
+	const ISimpleResourceLoader * getLoader(const ResourcePath & resourceName) const;
+
 	//FIXME: this is only compile fix, should be removed in the end
 	CFilesystemList(CFilesystemList &) = delete;
 	CFilesystemList &operator=(CFilesystemList &) = delete;

--- a/lib/filesystem/CCompressedStream.cpp
+++ b/lib/filesystem/CCompressedStream.cpp
@@ -66,9 +66,8 @@ void CBufferedStream::ensureSize(si64 size)
 	{
 		si64 initialSize = buffer.size();
 		si64 need = size - buffer.size();
-		// grow geometrically, but never by less than 512 bytes. Map headers are read field
-		// by field, so a step of exactly 'need' would decompress once per field - and 512
-		// covers 70% of h3m headers in a single step, their average size being ~550 bytes
+        // grow geometrically, but never by less than 512 bytes.
+        // 512 covers 70% of h3m headers in a single step, their average size being ~550 bytes
 		si64 currentStep = std::clamp<si64>(need, si64{512}, std::max<si64>(initialSize, si64{512}));
 
 		buffer.resize(initialSize + currentStep);

--- a/lib/filesystem/CCompressedStream.cpp
+++ b/lib/filesystem/CCompressedStream.cpp
@@ -66,9 +66,10 @@ void CBufferedStream::ensureSize(si64 size)
 	{
 		si64 initialSize = buffer.size();
 		si64 need = size - buffer.size();
-		// to avoid large number of calls at start
-		// this is often used to load h3m map headers, most of which are ~300 bytes in size
-		si64 currentStep = std::min<si64>(need, std::max<si64>(initialSize, si64{512}));
+		// grow geometrically, but never by less than 512 bytes. Map headers are read field
+		// by field, so a step of exactly 'need' would decompress once per field - and 512
+		// covers 70% of h3m headers in a single step, their average size being ~550 bytes
+		si64 currentStep = std::clamp<si64>(need, si64{512}, std::max<si64>(initialSize, si64{512}));
 
 		buffer.resize(initialSize + currentStep);
 

--- a/lib/filesystem/CFilesystemLoader.cpp
+++ b/lib/filesystem/CFilesystemLoader.cpp
@@ -32,7 +32,7 @@ CFilesystemLoader::CFilesystemLoader(std::string _mountPoint, boost::filesystem:
 
 std::unique_ptr<CInputStream> CFilesystemLoader::load(const ResourcePath & resourceName) const
 {
-	std::lock_guard lock(fileListGuard);
+	std::shared_lock lock(fileListGuard);
 
 	assert(fileList.contains(resourceName));
 	boost::filesystem::path file = baseDirectory / fileList.at(resourceName);
@@ -42,7 +42,7 @@ std::unique_ptr<CInputStream> CFilesystemLoader::load(const ResourcePath & resou
 
 bool CFilesystemLoader::existsResource(const ResourcePath & resourceName) const
 {
-	std::lock_guard lock(fileListGuard);
+	std::shared_lock lock(fileListGuard);
 	return fileList.contains(resourceName);
 }
 
@@ -55,7 +55,7 @@ std::optional<boost::filesystem::path> CFilesystemLoader::getResourceName(const 
 {
 	assert(existsResource(resourceName));
 
-	std::lock_guard lock(fileListGuard);
+	std::shared_lock lock(fileListGuard);
 	return baseDirectory / fileList.at(resourceName);
 }
 
@@ -71,7 +71,7 @@ void CFilesystemLoader::updateFilteredFiles(std::function<bool(const std::string
 std::unordered_set<ResourcePath> CFilesystemLoader::getFilteredFiles(std::function<bool(const ResourcePath &)> filter) const
 {
 	std::unordered_set<ResourcePath> foundID;
-	std::lock_guard lock(fileListGuard);
+	std::shared_lock lock(fileListGuard);
 
 	for (auto & file : fileList)
 	{

--- a/lib/filesystem/CFilesystemLoader.h
+++ b/lib/filesystem/CFilesystemLoader.h
@@ -47,7 +47,9 @@ private:
 	/** The base directory which is scanned and indexed. */
 	boost::filesystem::path baseDirectory;
 
-	mutable std::mutex fileListGuard;
+	// file list is rebuilt only when the game rescans a directory, while lookups happen from
+	// every thread that touches the filesystem - so readers must not exclude each other
+	mutable std::shared_mutex fileListGuard;
 	std::string mountPoint;
 	
 	size_t recursiveDepth;

--- a/lib/mapping/CMapInfo.cpp
+++ b/lib/mapping/CMapInfo.cpp
@@ -43,7 +43,6 @@ void CMapInfo::mapInit(const std::string & fname)
 	CMapService mapService;
 	ResourcePath resource = ResourcePath(fname, EResType::MAP);
 	originalFileURI = resource.getOriginalName();
-	fullFileURI = CResourceHandler::get()->getFullFileURI(resource);
 	mapHeader = mapService.loadMapHeader(resource);
 	lastWrite = CResourceHandler::get()->getLastWriteTime(resource);
 	date = TextOperations::getFormattedDateTimeLocal(lastWrite);
@@ -61,7 +60,6 @@ void CMapInfo::saveInit(const ResourcePath & file)
 
 	fileURI = file.getName(); // Name without file extension
 	originalFileURI = file.getOriginalName(); // Same as file.getName() but keep letter case
-	fullFileURI = CResourceHandler::get()->getFullFileURI(file); // Includes absolute path + extension
 	countPlayers();
 	lastWrite = CResourceHandler::get()->getLastWriteTime(file);
 	date = TextOperations::getFormattedDateTimeLocal(lastWrite);
@@ -75,7 +73,6 @@ void CMapInfo::campaignInit()
 {
 	ResourcePath resource = ResourcePath(fileURI, EResType::CAMPAIGN);
 	originalFileURI = resource.getOriginalName();
-	fullFileURI = CResourceHandler::get()->getFullFileURI(resource);
 	campaign = CampaignHandler::getHeader(fileURI);
 	lastWrite = CResourceHandler::get()->getLastWriteTime(resource);
 	date = TextOperations::getFormattedDateTimeLocal(lastWrite);

--- a/lib/mapping/CMapInfo.h
+++ b/lib/mapping/CMapInfo.h
@@ -29,7 +29,6 @@ public:
 	std::unique_ptr<StartInfo> scenarioOptionsOfSave; // Options with which scenario has been started (used only with saved games)
 	std::string fileURI;
 	std::string originalFileURI; // no need to serialize
-	std::string fullFileURI; // no need to serialize
 	std::time_t lastWrite; // no need to serialize
 	std::string date;
 	int amountOfPlayersOnMap;

--- a/lib/mapping/CMapService.cpp
+++ b/lib/mapping/CMapService.cpp
@@ -34,7 +34,7 @@
 std::unique_ptr<CMap> CMapService::loadMap(const ResourcePath & name, IGameInfoCallback * cb) const
 {
 	std::string modName = LIBRARY->modh->findResourceOrigin(name);
-	std::string encoding = LIBRARY->modh->findResourceEncoding(name);
+	std::string encoding = LIBRARY->modh->getResourceEncoding(name, modName);
 
 	auto stream = getStreamFromFS(name);
 	auto loader = getMapLoader(stream, name.getName(), modName, encoding);
@@ -48,7 +48,7 @@ std::unique_ptr<CMap> CMapService::loadMap(const ResourcePath & name, IGameInfoC
 std::unique_ptr<CMapHeader> CMapService::loadMapHeader(const ResourcePath & name, bool isEditor) const
 {
 	std::string modName = LIBRARY->modh->findResourceOrigin(name);
-	std::string encoding = LIBRARY->modh->findResourceEncoding(name);
+	std::string encoding = LIBRARY->modh->getResourceEncoding(name, modName);
 
 	auto stream = getStreamFromFS(name);
 	auto loader = getMapLoader(stream, name.getName(), modName, encoding);

--- a/lib/mapping/MapFormatH3M.cpp
+++ b/lib/mapping/MapFormatH3M.cpp
@@ -3045,10 +3045,11 @@ std::string CMapLoaderH3M::readBasicString()
 std::string CMapLoaderH3M::readLocalizedString(const TextIdentifier & stringIdentifier)
 {
 	std::string mapString = TextOperations::toUnicode(reader->readBaseString(), fileEncoding);
-	TextIdentifier fullIdentifier("map", mapName, stringIdentifier.get());
 
 	if(mapString.empty())
 		return "";
+
+	TextIdentifier fullIdentifier("map", mapName, stringIdentifier.get());
 
 	return mapRegisterLocalizedString(modName, *mapHeader, fullIdentifier, mapString);
 }

--- a/lib/modding/CModHandler.cpp
+++ b/lib/modding/CModHandler.cpp
@@ -130,7 +130,7 @@ TModID CModHandler::findResourceOrigin(const ResourcePath & name) const
 {
 	try
 	{
-		auto activeMode = modManager->getActiveMods();
+		const auto & activeMode = modManager->getActiveMods();
 		for(const auto & modID : std::views::reverse(activeMode))
 		{
 			if(CResourceHandler::get(modID)->existsResource(name))

--- a/lib/modding/CModHandler.cpp
+++ b/lib/modding/CModHandler.cpp
@@ -159,8 +159,12 @@ std::string CModHandler::findResourceLanguage(const ResourcePath & name) const
 
 std::string CModHandler::findResourceEncoding(const ResourcePath & resource) const
 {
-	std::string modName = findResourceOrigin(resource);
-	std::string modLanguage = findResourceLanguage(resource);
+	return getResourceEncoding(resource, findResourceOrigin(resource));
+}
+
+std::string CModHandler::getResourceEncoding(const ResourcePath & resource, const TModID & modName) const
+{
+	std::string modLanguage = getModLanguage(modName);
 
 	bool potentiallyUserMadeContent = resource.getType() == EResType::MAP || resource.getType() == EResType::CAMPAIGN;
 	if (potentiallyUserMadeContent && modName == ModScope::scopeBuiltin() && modLanguage == "english")

--- a/lib/modding/CModHandler.h
+++ b/lib/modding/CModHandler.h
@@ -45,6 +45,9 @@ public:
 	/// Returns assumed encoding of language of mod that provides selected file resource
 	std::string findResourceEncoding(const ResourcePath & name) const;
 
+	/// Same as findResourceEncoding, for callers that have already located the providing mod
+	std::string getResourceEncoding(const ResourcePath & name, const TModID & modName) const;
+
 	std::string getModLanguage(const TModID & modId) const;
 
 	std::set<TModID> getModDependencies(const TModID & modId) const;

--- a/lib/texts/TextOperations.cpp
+++ b/lib/texts/TextOperations.cpp
@@ -21,13 +21,42 @@
 
 const static int CHAR_PER_TYPO_ALLOWED = 4;
 
+/// iconv_open takes a process-wide lock, so opening a descriptor per converted string
+/// serializes all threads. Descriptors carry conversion state and must not be shared
+/// between threads, hence one cache per thread rather than one global cache.
+static iconv_t getConversionDescriptor(const std::string & fromEncoding, const std::string & destEncoding)
+{
+	struct DescriptorCache
+	{
+		std::map<std::pair<std::string, std::string>, iconv_t> descriptors;
+
+		~DescriptorCache()
+		{
+			for(const auto & entry : descriptors)
+				if(entry.second != reinterpret_cast<iconv_t>(-1))
+					iconv_close(entry.second);
+		}
+	};
+
+	static thread_local DescriptorCache cache;
+
+	std::pair key(fromEncoding, destEncoding);
+	auto it = cache.descriptors.find(key);
+
+	// failed opens are cached as well, to avoid retrying an encoding that iconv does not know
+	if(it == cache.descriptors.end())
+		it = cache.descriptors.emplace(key, iconv_open(destEncoding.c_str(), fromEncoding.c_str())).first;
+
+	return it->second;
+}
+
 template<typename FromString, typename DestString>
 FromString convertTextEncoding(const DestString & fromString, const std::string & fromEncoding, const std::string & destEncoding)
 {
 	constexpr auto fromCharSize = sizeof(typename DestString::value_type);
 	constexpr auto destCharSize = sizeof(typename FromString::value_type);
 
-	iconv_t cd = iconv_open(destEncoding.c_str(), fromEncoding.c_str());
+	iconv_t cd = getConversionDescriptor(fromEncoding, destEncoding);
 	if(cd == reinterpret_cast<iconv_t>(-1))
 	{
 		logGlobal->error("Encoding coversion failure. Invalid encoding %s -> %s", fromEncoding, destEncoding);
@@ -46,7 +75,10 @@ FromString convertTextEncoding(const DestString & fromString, const std::string 
 	size_t destLeft = destString.size() * destCharSize;
 
 	size_t ret = iconv(cd, &fromData, &fromLeft, &destData, &destLeft);
-	iconv_close(cd);
+
+	// descriptor outlives this call, so shift state - including state left behind by a
+	// failed conversion - must not leak into the next string
+	iconv(cd, nullptr, nullptr, nullptr, nullptr);
 
 	if(ret == static_cast<size_t>(-1))
 	{

--- a/lib/texts/TextOperations.cpp
+++ b/lib/texts/TextOperations.cpp
@@ -26,7 +26,7 @@ const static int CHAR_PER_TYPO_ALLOWED = 4;
 /// between threads, hence one cache per thread rather than one global cache.
 static iconv_t getConversionDescriptor(const std::string & fromEncoding, const std::string & destEncoding)
 {
-	struct DescriptorCache
+    struct DescriptorCache : boost::noncopyable
 	{
 		std::map<std::pair<std::string, std::string>, iconv_t> descriptors;
 
@@ -45,7 +45,7 @@ static iconv_t getConversionDescriptor(const std::string & fromEncoding, const s
 
 	// failed opens are cached as well, to avoid retrying an encoding that iconv does not know
 	if(it == cache.descriptors.end())
-		it = cache.descriptors.emplace(key, iconv_open(destEncoding.c_str(), fromEncoding.c_str())).first;
+        it = cache.descriptors.try_emplace(key, iconv_open(destEncoding.c_str(), fromEncoding.c_str())).first;
 
 	return it->second;
 }

--- a/test/texts/TextOperationsTest.cpp
+++ b/test/texts/TextOperationsTest.cpp
@@ -55,7 +55,7 @@ TEST_F(TextOperationsTest, ToUnicodeReusesDescriptor)
 	std::atomic<int> failures = 0;
 	for(int i = 0; i < 8; ++i)
 	{
-		threads.emplace_back([&]
+        threads.emplace_back([&failures, &cyrillicCP1251, &cyrillicUtf8]
 		{
 			for(int j = 0; j < 1000; ++j)
 				if(TextOperations::toUnicode(cyrillicCP1251, "CP1251") != cyrillicUtf8)

--- a/test/texts/TextOperationsTest.cpp
+++ b/test/texts/TextOperationsTest.cpp
@@ -29,4 +29,43 @@ TEST_F(TextOperationsTest, Test)
 	ASSERT_EQ(TextOperations::textSearchSimilarityScore("irebaw", "Fireball"), 1);
 }
 
+// conversion descriptors are cached per thread, so a conversion must not be affected by
+// whatever the same thread converted before it - including a conversion that failed
+TEST_F(TextOperationsTest, ToUnicodeReusesDescriptor)
+{
+	const std::string cyrillicCP1251 = "\xcf\xf0\xe8\xe2\xe5\xf2";
+	const std::string cyrillicUtf8 = "\xd0\x9f\xd1\x80\xd0\xb8\xd0\xb2\xd0\xb5\xd1\x82";
+	const std::string invalidUtf8 = "\xff\xfe";
+
+	ASSERT_EQ(TextOperations::toUnicode(cyrillicCP1251, "CP1251"), cyrillicUtf8);
+	ASSERT_EQ(TextOperations::toUnicode(cyrillicCP1251, "CP1251"), cyrillicUtf8);
+
+	// interleaved encodings must not share a descriptor
+	ASSERT_EQ(TextOperations::toUnicode("\xc4", "CP1252"), "\xc3\x84");
+	ASSERT_EQ(TextOperations::toUnicode(cyrillicCP1251, "CP1251"), cyrillicUtf8);
+
+	ASSERT_TRUE(TextOperations::toUnicode(invalidUtf8, "UTF-8").empty());
+	ASSERT_EQ(TextOperations::toUnicode(cyrillicCP1251, "CP1251"), cyrillicUtf8);
+
+	ASSERT_TRUE(TextOperations::toUnicode(cyrillicCP1251, "NoSuchEncoding").empty());
+	ASSERT_EQ(TextOperations::toUnicode(cyrillicCP1251, "CP1251"), cyrillicUtf8);
+
+	// descriptors are per thread, so parallel conversions may not corrupt each other
+	std::vector<std::thread> threads;
+	std::atomic<int> failures = 0;
+	for(int i = 0; i < 8; ++i)
+	{
+		threads.emplace_back([&]
+		{
+			for(int j = 0; j < 1000; ++j)
+				if(TextOperations::toUnicode(cyrillicCP1251, "CP1251") != cyrillicUtf8)
+					++failures;
+		});
+	}
+	for(auto & thread : threads)
+		thread.join();
+
+	ASSERT_EQ(failures, 0);
+}
+
 }


### PR DESCRIPTION
Significantly speeds up loading of maps in game lobby by several times.

- Soft-dependency on #7743 (it removes mutex that would heavily downgrade improvements from this PR)
- Supersedes #7687 
- Resolves #6708 

Changes:
- `iconv` is now opened once per thread+encoding pair - this operation is too slow when performed for each string separately
- replaced mutex with shared mutex in filesystem - most of access in there is read-only, mutable operations are rare and don't happen while maps are loaded
- removed computation of full file path for every map due to low performance
- minor optimization in how map loader accesses filesystem to reduce excessive access
- fixed huge number of inflate calls due to broken math
- hero handler now stores list of default-alllowed heroes instead of constructing it on every request 