### PR TITLE
Delete empty biome

### DIFF
--- a/config/biomes.json
+++ b/config/biomes.json
@@ -665,13 +665,6 @@
 		},
 		"templates" : ["AVLvol10", "AVLvol20", "AVLvol30", "AVLvol40", "AVLvol50"]
 	},
-	"templateSet192":{
-		"biome":{
-			"terrain" : "water",
-			"objectType" : "tree"
-		},
-		"templates" : ["AVLklp10", "AVLklp20"]
-	},
 	"templateSet193":{
 		"biome":{
 			"terrain" : "water",


### PR DESCRIPTION
This PR deletes a biome that only contains templates that have no blocking tiles. These templates are removed from generation at a prior point, so they are only "visible" to the map editor. It leaves this biome empty, triggering a debug log message ("Obstacle set 65 is empty, removing it").