### PR TITLE
lobby: make labels of checkboxes clickable

### DIFF
--- a/client/lobby/BattleOnlyModeTab.cpp
+++ b/client/lobby/BattleOnlyModeTab.cpp
@@ -370,6 +370,7 @@ BattleOnlyModeHeroSelector::BattleOnlyModeHeroSelector(int id, BattleOnlyModeTab
 		redraw();
 	});
 	warMachines->setSelectedSilent(parent.startInfo->warMachines[id]);
+	warMachines->pos = warMachines->pos.include(addIcon.back()->pos);
 
 	setHeroIcon();
 	setCreatureIcons();

--- a/client/lobby/ExtraOptionsTab.cpp
+++ b/client/lobby/ExtraOptionsTab.cpp
@@ -10,11 +10,27 @@
 
 #include "StdInc.h"
 #include "ExtraOptionsTab.h"
+
+#include "../widgets/Buttons.h"
 #include "../widgets/Images.h"
+#include "../widgets/TextControls.h"
+
+namespace
+{
+void extendButtonHitArea(const std::shared_ptr<CToggleButton> & button, const std::shared_ptr<CLabel> & label)
+{
+	if(button && label)
+		button->pos = button->pos.include(label->pos);
+}
+}
 
 ExtraOptionsTab::ExtraOptionsTab()
 	: OptionsTabBase(JsonPath::builtin("config/widgets/extraOptionsTab.json"))
 {
+	extendButtonHitArea(widget<CToggleButton>("buttonCheatAllowed"), widget<CLabel>("labelCheatAllowed"));
+	extendButtonHitArea(widget<CToggleButton>("buttonUnlimitedReplay"), widget<CLabel>("labelUnlimitedReplay"));
+	extendButtonHitArea(widget<CToggleButton>("buttonRecordGame"), widget<CLabel>("labelRecordGame"));
+
 	if(auto textureCampaignOverdraw = widget<CFilledTexture>("textureCampaignOverdraw"))
 		textureCampaignOverdraw->disable();
 }

--- a/client/lobby/RandomMapTab.cpp
+++ b/client/lobby/RandomMapTab.cpp
@@ -48,6 +48,15 @@
 #include "../../lib/serializer/JsonSerializer.h"
 #include "../../lib/serializer/JsonDeserializer.h"
 
+namespace
+{
+std::string getRoadWidgetName(const std::string & jsonKey)
+{
+	const auto separator = jsonKey.find(':');
+	return jsonKey.substr(separator == std::string::npos ? 0 : separator + 1);
+}
+}
+
 RandomMapTab::RandomMapTab():
 	InterfaceObjectConfigurable(),
 	templateIndex(0)
@@ -135,6 +144,7 @@ RandomMapTab::RandomMapTab():
 	
 	const JsonNode config(JsonPath::builtin("config/widgets/randomMapTab.json"));
 	build(config);
+	extendRoadButtonHitAreas();
 
 	if(auto w = widget<CButton>("buttonShowRandomMaps"))
 	{
@@ -214,6 +224,32 @@ RandomMapTab::RandomMapTab():
 	}
 	
 	loadOptions();
+}
+
+void RandomMapTab::extendRoadButtonHitAreas()
+{
+	std::vector<std::shared_ptr<CToggleButton>> roadButtons;
+	for(const auto & road : LIBRARY->roadTypeHandler->objects)
+	{
+		if(auto button = widget<CToggleButton>(getRoadWidgetName(road->getJsonKey())))
+			roadButtons.push_back(button);
+	}
+
+	if(roadButtons.size() < 2)
+		return;
+
+	std::ranges::sort(roadButtons, {}, [](const auto & button)
+	{
+		return button->pos.x;
+	});
+
+	for(size_t index = 1; index < roadButtons.size(); ++index)
+	{
+		auto & previousButton = roadButtons[index - 1];
+		previousButton->pos.w = std::max(previousButton->pos.w, roadButtons[index]->pos.x - previousButton->pos.x);
+	}
+
+	roadButtons.back()->pos.w = std::max(roadButtons.back()->pos.w, roadButtons[roadButtons.size() - 2]->pos.w);
 }
 
 void RandomMapTab::onToggleMapSize(int btnId)
@@ -508,10 +544,7 @@ void RandomMapTab::setMapGenOptions(std::shared_ptr<CMapGenOptions> opts)
 	for(const auto & r : LIBRARY->roadTypeHandler->objects)
 	{
 		// Workaround for vcmi-extras bug
-		std::string jsonKey = r->getJsonKey();
-		std::string identifier = jsonKey.substr(jsonKey.find(':')+1);
-
-		if(auto w = widget<CToggleButton>(identifier))
+		if(auto w = widget<CToggleButton>(getRoadWidgetName(r->getJsonKey())))
 		{
 			w->setSelected(opts->isRoadEnabled(r->getId()));
 		}

--- a/client/lobby/RandomMapTab.h
+++ b/client/lobby/RandomMapTab.h
@@ -51,6 +51,7 @@ private:
 	std::optional<int> getMapSizeForButtonId(int btnId) const;
 	bool isCustomSizeButtonId(int btnId) const;
 	void onToggleMapSize(int btnId);
+	void extendRoadButtonHitAreas();
 
 	std::shared_ptr<CMapInfo> mapInfo;
 	std::shared_ptr<CMapGenOptions> mapGenOptions;

--- a/client/lobby/TurnOptionsTab.cpp
+++ b/client/lobby/TurnOptionsTab.cpp
@@ -11,8 +11,22 @@
 #include "StdInc.h"
 #include "TurnOptionsTab.h"
 
+#include "../widgets/Buttons.h"
+#include "../widgets/TextControls.h"
+
+namespace
+{
+void extendButtonHitArea(const std::shared_ptr<CToggleButton> & button, const std::shared_ptr<CLabel> & label)
+{
+	if(button && label)
+		button->pos = button->pos.include(label->pos);
+}
+}
+
 TurnOptionsTab::TurnOptionsTab()
 	: OptionsTabBase(JsonPath::builtin("config/widgets/turnOptionsTab.json"))
 {
-
+	extendButtonHitArea(widget<CToggleButton>("buttonTurnTimerAccumulate"), widget<CLabel>("labelTurnTimerAccumulate"));
+	extendButtonHitArea(widget<CToggleButton>("buttonUnitTimerAccumulate"), widget<CLabel>("labelUnitTimerAccumulate"));
+	extendButtonHitArea(widget<CToggleButton>("buttonSimturnsAI"), widget<CLabel>("labelSimturnsAI"));
 }

--- a/config/widgets/turnOptionsTab.json
+++ b/config/widgets/turnOptionsTab.json
@@ -162,11 +162,13 @@
 		},
 		
 		{
+			"name" : "labelTurnTimerAccumulate",
 			"type" : "labelTitle",
 			"position": {"x": 195, "y": 199},
 			"text" : "vcmi.optionsTab.accumulate"
 		},
 		{
+			"name" : "labelUnitTimerAccumulate",
 			"type" : "labelTitle",
 			"position": {"x": 195, "y": 331},
 			"text" : "vcmi.optionsTab.accumulate"


### PR DESCRIPTION
In several parts of the Lobby there are checkboxes and their accompanying labels or images. This PR makes clicking a label or an image of a checkbox the same as clicking a checkbox - this is a more convenient UI.

<img width="785" height="600" alt="extra options" src="https://github.com/user-attachments/assets/bbfa2097-be8d-41e3-8f97-9397fccef4e4" />

<img width="785" height="600" alt="road types" src="https://github.com/user-attachments/assets/5f7a9c69-c5ad-4978-88ad-01c79b0dfed0" />

<img width="785" height="600" alt="turn options" src="https://github.com/user-attachments/assets/ebc89988-34f7-45f4-85ff-ef6e8c48f533" />

<img width="785" height="600" alt="battle mode - war machines" src="https://github.com/user-attachments/assets/13b498f2-0d3d-4638-9808-3558b49cb923" />
