### PR TITLE
Fix townless creatures being considered neutral by CREATURE_ALIGNMENT_LIMITER

### DIFF
--- a/config/battlefields.json
+++ b/config/battlefields.json
@@ -100,7 +100,11 @@
 				"val" : 2,
 				"valueType" : "BASE_NUMBER",
 				"description" : "@core.arraytxt.83",
-				"limiters": [{ "type" : "CREATURE_ALIGNMENT_LIMITER", "alignment" : "neutral" }]
+				"limiters": [
+					"anyOf",
+					{ "type" : "CREATURE_ALIGNMENT_LIMITER", "alignment" : "neutral" },
+					{ "type" : "CREATURE_FACTION_LIMITER", "faction" : "conflux" }
+				]
 			}
 		]
 	},

--- a/config/battlefields.json
+++ b/config/battlefields.json
@@ -103,7 +103,7 @@
 				"limiters": [
 					"anyOf",
 					{ "type" : "CREATURE_ALIGNMENT_LIMITER", "alignment" : "neutral" },
-					{ "type" : "CREATURE_FACTION_LIMITER", "faction" : "conflux" }
+					{ "type" : "CREATURE_FACTION_LIMITER", "faction" : "conflux" } // H3 quirk - conflux does not receives Angelic Alliance bonuses, but receives Clover Field bonus
 				]
 			}
 		]

--- a/lib/CCreatureHandler.cpp
+++ b/lib/CCreatureHandler.cpp
@@ -293,10 +293,6 @@ bool CCreature::isGood () const
 {
 	return LIBRARY->factions()->getById(faction)->getAlignment() == EAlignment::GOOD;
 }
-/**
- * Supplies the creature's alignment as defined by the faction it belongs to
- * @return The creature's alignment
- */
 EAlignment CCreature::getAlignment () const
 {
 	return LIBRARY->factions()->getById(faction)->getAlignment();

--- a/lib/CCreatureHandler.cpp
+++ b/lib/CCreatureHandler.cpp
@@ -185,7 +185,7 @@ const TResources & CCreature::getFullRecruitCost() const
 	return cost;
 }
 
-bool CCreature::hasUpgrades() const 
+bool CCreature::hasUpgrades() const
 {
 	return !upgrades.empty();
 }
@@ -292,6 +292,14 @@ bool CCreature::isDoubleWide() const
 bool CCreature::isGood () const
 {
 	return LIBRARY->factions()->getById(faction)->getAlignment() == EAlignment::GOOD;
+}
+/**
+ * Supplies the creature's alignment as defined by the faction it belongs to
+ * @return The creature's alignment
+ */
+EAlignment CCreature::getAlignment () const
+{
+	return LIBRARY->factions()->getById(faction)->getAlignment();
 }
 
 /**
@@ -448,7 +456,7 @@ void CCreatureHandler::loadCommanders()
 	data.setModScope(modSource);
 
 	const JsonNode & config = data; // switch to const data accessors
-	
+
 	commanderResurrectionPrice.resolveFromJson(config["resurrectionPrice"]);
 
 	for (auto bonus : config["bonusPerLevel"].Vector())
@@ -1063,7 +1071,7 @@ void CCreatureHandler::loadStackExp(Bonus & b, BonusList & bl, CLegacyConfigPars
 			case 'B':
 				b.type = BonusType::TWO_HEX_ATTACK_BREATH; break;
 			case 'c':
-				b.type = BonusType::JOUSTING; 
+				b.type = BonusType::JOUSTING;
 				b.val = 5;
 				break;
 			case 'D':

--- a/lib/CCreatureHandler.h
+++ b/lib/CCreatureHandler.h
@@ -156,6 +156,7 @@ public:
 
 	bool isGood () const;
 	bool isEvil () const;
+	/// Supplies the creature's alignment as defined by the faction it belongs to
 	EAlignment getAlignment () const;
 	si32 maxAmount(const TResources &res) const; //how many creatures can be bought
 	static CCreature::CreatureQuantityId getQuantityID(const int & quantity);

--- a/lib/CCreatureHandler.h
+++ b/lib/CCreatureHandler.h
@@ -156,6 +156,7 @@ public:
 
 	bool isGood () const;
 	bool isEvil () const;
+	EAlignment getAlignment () const;
 	si32 maxAmount(const TResources &res) const; //how many creatures can be bought
 	static CCreature::CreatureQuantityId getQuantityID(const int & quantity);
 	static std::string getQuantityRangeStringForId(const CCreature::CreatureQuantityId & quantityId);

--- a/lib/bonuses/Limiters.cpp
+++ b/lib/bonuses/Limiters.cpp
@@ -438,16 +438,6 @@ ILimiter::EDecision CreatureAlignmentLimiter::limit(const BonusLimitationContext
 {
 	const auto * c = retrieveCreature(&context.node);
 	if(c) {
-		if(alignment == EAlignment::GOOD && c->isGood())
-			return ILimiter::EDecision::ACCEPT;
-		if(alignment == EAlignment::EVIL && c->isEvil())
-			return ILimiter::EDecision::ACCEPT;
-		if(alignment == EAlignment::NEUTRAL && c->getAlignment() == EAlignment::NEUTRAL)
-			return ILimiter::EDecision::ACCEPT;
-		if(alignment == EAlignment::NONE && c->getAlignment() == EAlignment::NONE)
-			return ILimiter::EDecision::ACCEPT;
-
-
 		if(alignment == c->getAlignment())
 			return ILimiter::EDecision::ACCEPT;
 		return ILimiter::EDecision::DISCARD;

--- a/lib/bonuses/Limiters.cpp
+++ b/lib/bonuses/Limiters.cpp
@@ -447,6 +447,9 @@ ILimiter::EDecision CreatureAlignmentLimiter::limit(const BonusLimitationContext
 		if(alignment == EAlignment::NONE && c->getAlignment() == EAlignment::NONE)
 			return ILimiter::EDecision::ACCEPT;
 
+
+		if(alignment == c->getAlignment())
+			return ILimiter::EDecision::ACCEPT;
 		return ILimiter::EDecision::DISCARD;
 	}
 

--- a/lib/bonuses/Limiters.cpp
+++ b/lib/bonuses/Limiters.cpp
@@ -95,7 +95,7 @@ ILimiter::EDecision CCreatureTypeLimiter::limit(const BonusLimitationContext &co
 	const CCreature *c = retrieveCreature(&context.node);
 	if(!c)
 		return ILimiter::EDecision::NOT_APPLICABLE;
-	
+
 	auto accept =  c->getId() == creatureID || (includeUpgrades && creatureID.toCreature()->isMyDirectOrIndirectUpgrade(c));
 	return accept ? ILimiter::EDecision::ACCEPT : ILimiter::EDecision::DISCARD;
 	//drop bonus if it's not our creature and (we don`t check upgrades or its not our upgrade)
@@ -368,7 +368,7 @@ ILimiter::EDecision FactionLimiter::limit(const BonusLimitationContext &context)
 		{
 			case BonusSource::CREATURE_ABILITY:
 				return bearer->getFactionID() == context.b.sid.as<CreatureID>().toCreature()->getFactionID() ? ILimiter::EDecision::ACCEPT : ILimiter::EDecision::DISCARD;
-			
+
 			case BonusSource::TOWN_STRUCTURE:
 				return bearer->getFactionID() == context.b.sid.as<BuildingTypeUniqueID>().getFaction() ? ILimiter::EDecision::ACCEPT : ILimiter::EDecision::DISCARD;
 
@@ -442,9 +442,9 @@ ILimiter::EDecision CreatureAlignmentLimiter::limit(const BonusLimitationContext
 			return ILimiter::EDecision::ACCEPT;
 		if(alignment == EAlignment::EVIL && c->isEvil())
 			return ILimiter::EDecision::ACCEPT;
-		if(alignment == EAlignment::NEUTRAL && !c->isEvil() && !c->isGood())
+		if(alignment == EAlignment::NEUTRAL && c->getAlignment() == EAlignment::NEUTRAL)
 			return ILimiter::EDecision::ACCEPT;
-		if(alignment == EAlignment::NONE && LIBRARY->factions()->getById(c->getFactionID())->getAlignment() == EAlignment::NONE)
+		if(alignment == EAlignment::NONE && c->getAlignment() == EAlignment::NONE)
 			return ILimiter::EDecision::ACCEPT;
 
 		return ILimiter::EDecision::DISCARD;


### PR DESCRIPTION
This PR fixes the issue of Clover Fields giving +2 Luck to townless creatures (e.g. Trolls). Conflux is considered "neutral" in this case, contrary to how Angelic Alliance functions, so its creatures should receive the Luck bonus. If modders want neutral creatures to be affected, they can use a second bonus of the same type with that checks for the "none" alignment.