### PR TITLE
Add Lua-configurable ranking policies to Nullkiller

### DIFF
--- a/AI/Nullkiller2/CMakeLists.txt
+++ b/AI/Nullkiller2/CMakeLists.txt
@@ -23,6 +23,7 @@ set(Nullkiller2_SRCS
 		Analyzers/ArmyManager.cpp
 		Analyzers/HeroManager.cpp
 		Engine/Settings.cpp
+		Engine/DecisionPolicy.cpp
 		Engine/FuzzyHelper.cpp
 		Engine/AIMemory.cpp
 		Goals/AbstractGoal.cpp
@@ -98,6 +99,7 @@ set(Nullkiller2_HEADERS
 		Analyzers/ArmyManager.h
 		Analyzers/HeroManager.h
 		Engine/Settings.h
+		Engine/DecisionPolicy.h
 		Engine/FuzzyHelper.h
 		Engine/AIMemory.h
 		Goals/AbstractGoal.h
@@ -158,6 +160,14 @@ target_compile_definitions(Nullkiller2 PRIVATE VCMI_DLL=1)
 
 target_include_directories(Nullkiller2 PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(Nullkiller2 PUBLIC vcmiMain TBB::tbb)
+
+if(TARGET luajit::luajit)
+	target_link_libraries(Nullkiller2 PUBLIC luajit::luajit)
+elseif(TARGET lua::lua)
+	target_link_libraries(Nullkiller2 PUBLIC lua::lua)
+else()
+	target_link_libraries(Nullkiller2 PUBLIC Lua::Lua)
+endif()
 
 vcmi_set_output_dir(Nullkiller2 "AI")
 enable_pch(Nullkiller2)

--- a/AI/Nullkiller2/Engine/DecisionPolicy.cpp
+++ b/AI/Nullkiller2/Engine/DecisionPolicy.cpp
@@ -1,0 +1,474 @@
+/*
+ * DecisionPolicy.cpp, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ */
+#include "StdInc.h"
+
+#include "DecisionPolicy.h"
+#include "PriorityEvaluator.h"
+
+#if __has_include(<lua.hpp>)
+#	include <lua.hpp>
+#else
+extern "C"
+{
+#	include <lua.h>
+#	include <lauxlib.h>
+#	include <lualib.h>
+}
+#endif
+
+#include "../../../luascript/LuaContext.h"
+#include "../../../luascript/LuaModule.h"
+#include "../../../luascript/LuaScriptInstance.h"
+#include "../../../lib/GameLibrary.h"
+#include "../../../lib/constants/StringConstants.h"
+#include "../../../lib/entities/ResourceTypeHandler.h"
+#include "../../../lib/json/JsonNode.h"
+
+#include <boost/filesystem/fstream.hpp>
+#include <boost/filesystem/path.hpp>
+
+namespace NK2AI
+{
+
+namespace
+{
+
+int roundFloat32(lua_State * state)
+{
+	const auto value = static_cast<float>(luaL_checknumber(state, 1));
+	lua_pushnumber(state, value);
+	return 1;
+}
+
+std::string readTextFile(const boost::filesystem::path & path)
+{
+	boost::filesystem::ifstream input(path, std::ios::binary);
+	if(!input)
+		throw std::runtime_error("unable to open " + path.string());
+
+	return std::string(std::istreambuf_iterator<char>(input), std::istreambuf_iterator<char>());
+}
+
+std::string getEnvironmentValue(const std::string & name)
+{
+	const char * value = std::getenv(name.c_str());
+	return value ? value : std::string();
+}
+
+std::string uppercaseAscii(std::string value)
+{
+	for(char & character : value)
+	{
+		if(character >= 'a' && character <= 'z')
+			character = static_cast<char>(character - 'a' + 'A');
+	}
+	return value;
+}
+
+std::string getPlayerEnvironmentValue(const std::string & name, const PlayerColor player)
+{
+	const std::string playerValue = getEnvironmentValue(name + "_" + uppercaseAscii(player.toString()));
+	return playerValue.empty() ? getEnvironmentValue(name) : playerValue;
+}
+
+std::string makeVersion(const std::string & value)
+{
+	uint64_t hash = 14695981039346656037ULL;
+	for(const unsigned char character : value)
+	{
+		hash ^= character;
+		hash *= 1099511628211ULL;
+	}
+
+	std::ostringstream stream;
+	stream << std::hex << std::setfill('0') << std::setw(16) << hash;
+	return stream.str();
+}
+
+bool readScores(const JsonNode & value, std::vector<DecisionPolicyScore> & scores, std::string & error)
+{
+	if(!value.isStruct())
+	{
+		error = "rank must return a table containing a scores array";
+		return false;
+	}
+
+	const JsonNode & scoreValues = value["scores"];
+	if(!scoreValues.isVector())
+	{
+		error = "rank result has no scores array";
+		return false;
+	}
+
+	scores.reserve(scoreValues.Vector().size());
+	for(const JsonNode & scoreValue : scoreValues.Vector())
+	{
+		if(!scoreValue.isStruct())
+		{
+			error = "scores contains a non-table entry";
+			return false;
+		}
+
+		const JsonNode & idValue = scoreValue["id"];
+		const JsonNode & scoreNumberValue = scoreValue["score"];
+		if(!idValue.isNumber() || !scoreNumberValue.isNumber())
+		{
+			error = "score entries require numeric id and score fields";
+			return false;
+		}
+
+		const double idNumber = idValue.Float();
+		if(!std::isfinite(idNumber)
+			|| idNumber < 0
+			|| !vstd::isAlmostEqual(std::floor(idNumber), idNumber)
+			|| idNumber >= static_cast<double>(std::numeric_limits<size_t>::max()))
+		{
+			error = "scores contains a negative or non-integral candidate ID";
+			return false;
+		}
+
+		const auto score = static_cast<float>(scoreNumberValue.Float());
+		if(!std::isfinite(score))
+		{
+			error = "scores contains a non-finite value";
+			return false;
+		}
+		scores.push_back({static_cast<size_t>(idNumber), score});
+	}
+	return true;
+}
+
+bool validateScores(const JsonNode & request, const std::vector<DecisionPolicyScore> & scores, std::string & error)
+{
+	std::set<size_t> expected;
+	for(const JsonNode & candidate : request["candidates"].Vector())
+		expected.insert(static_cast<size_t>(candidate["id"].Integer()));
+
+	std::set<size_t> proposed;
+	for(const DecisionPolicyScore & score : scores)
+		proposed.insert(score.id);
+
+	if(proposed.size() != scores.size())
+	{
+		error = "scores contains duplicate candidate IDs";
+		return false;
+	}
+	if(proposed != expected)
+	{
+		error = "scores must contain every current candidate exactly once";
+		return false;
+	}
+	return true;
+}
+
+class LuaDecisionPolicy final : public IDecisionPolicy
+{
+	std::string name;
+	std::string version;
+	JsonNode parameters;
+	bool shadow;
+	std::unique_ptr<scripting::LuaScriptInstance> script;
+	std::shared_ptr<scripting::LuaContext> context;
+
+public:
+	LuaDecisionPolicy(std::string name, const std::string & source, const JsonNode & parameters, const Environment * environment, bool shadow)
+		: name(std::move(name))
+		, version(makeVersion(source + parameters.toCompactString()))
+		, parameters(parameters)
+		, shadow(shadow)
+	{
+		if(!environment)
+			throw std::runtime_error("Lua policy requires a game environment");
+
+		const auto * luaModule = dynamic_cast<const scripting::LuaModule *>(LIBRARY->scripts());
+		if(!luaModule)
+			throw std::runtime_error("Lua scripting host is unavailable");
+
+		script = std::make_unique<scripting::LuaScriptInstance>(*luaModule, "nk2-policy-" + this->name, source);
+		context = script->createContext(environment);
+		context->setGlobalFunction<roundFloat32>("float32");
+		context->initialize();
+		if(!context->hasFunction("rank"))
+			throw std::runtime_error("script must return a policy table with a rank function");
+	}
+
+	DecisionPolicyResult rank(const JsonNode & request) override
+	{
+		DecisionPolicyResult result;
+		JsonNode scriptRequest = request;
+		scriptRequest["parameters"] = parameters;
+		const JsonNode answer = context->callFunction<JsonNode>("rank", scriptRequest);
+		if(!readScores(answer, result.scores, result.error))
+			return result;
+		if(!validateScores(request, result.scores, result.error))
+			return result;
+
+		result.applied = true;
+		return result;
+	}
+
+	std::string getName() const override
+	{
+		return name;
+	}
+
+	std::string getVersion() const override
+	{
+		return version;
+	}
+
+	bool isShadow() const override
+	{
+		return shadow;
+	}
+};
+
+JsonNode parseProfile(const boost::filesystem::path & path)
+{
+	const std::string source = readTextFile(path);
+	JsonParsingSettings settings;
+	settings.mode = JsonParsingSettings::JsonFormatMode::JSON5;
+	settings.strict = true;
+	return JsonNode(source.data(), source.size(), settings, path.string());
+}
+
+}
+
+JsonNode priorityEvaluationInputToJson(const PriorityEvaluationInput & input)
+{
+	const auto & settings = input.settings;
+	const auto & goal = input.goal;
+	const auto & rewards = input.rewards;
+	const auto & building = input.building;
+	const auto & resourceState = input.resourceState;
+	const auto & escapeState = input.escape;
+	std::vector<std::string> resourceNames;
+	for(const GameResID & resource : LIBRARY->resourceTypeHandler->getAllObjects())
+		resourceNames.push_back(resource.toResource()->getJsonKey());
+
+	auto resourcesToJson = [&resourceNames](const std::vector<int32_t> & resources)
+	{
+		JsonNode result;
+		for(size_t index = 0; index < resourceNames.size(); ++index)
+		{
+			const int32_t value = index < resources.size() ? resources[index] : 0;
+			result[resourceNames[index]].Integer() = value;
+		}
+		return result;
+	};
+
+	auto priorityTierName = [](const int priorityTier)
+	{
+		switch(priorityTier)
+		{
+		case PriorityEvaluator::BUILDINGS: return "buildings";
+		case PriorityEvaluator::INSTAKILL: return "instakill";
+		case PriorityEvaluator::INSTADEFEND: return "instaDefend";
+		case PriorityEvaluator::KILL: return "kill";
+		case PriorityEvaluator::ESCAPE: return "escape";
+		case PriorityEvaluator::EXPLORE_AND_GATHER: return "exploreAndGather";
+		case PriorityEvaluator::DEFEND: return "defend";
+		default: return "unknown";
+		}
+	};
+
+	JsonNode result;
+	result["priorityTier"].String() = priorityTierName(settings.priorityTier);
+	result["priorityTierId"].Integer() = settings.priorityTier;
+
+	JsonNode & state = result["state"];
+	state["daysWithoutCastle"].Bool() = settings.daysWithoutCastle;
+	state["maximumArmyLossTarget"].Float() = settings.maximumArmyLossTarget;
+	state["dayOfWeek"].Integer() = settings.dayOfWeek;
+	state["daysInWeek"].Integer() = settings.daysInWeek;
+	for(const std::string & resourceName : resourceNames)
+		state["resourceNames"].Vector().emplace_back(resourceName);
+	state["resources"] = resourcesToJson(resourceState.available);
+	state["dailyIncome"] = resourcesToJson(resourceState.dailyIncome);
+	state["lockedResourceMarketValue"].Integer() = resourceState.lockedResourceMarketValue;
+	state["goldPressureOverMax"].Bool() = resourceState.goldPressureOverMax;
+	state["hasTownWithoutMarketplace"].Bool() = resourceState.hasTownWithoutMarketplace;
+
+	JsonNode & evaluation = result["evaluation"];
+	evaluation["movementCost"].Float() = goal.movementCost;
+	evaluation["danger"].Integer() = static_cast<int64_t>(
+		std::min<uint64_t>(goal.danger, std::numeric_limits<int64_t>::max()));
+	evaluation["closestWayRatio"].Float() = goal.closestWayRatio;
+	evaluation["armyLossRatio"].Float() = goal.armyLossRatio;
+	evaluation["armyReward"].Float() = rewards.armyReward;
+	evaluation["armyGrowth"].Integer() = static_cast<int64_t>(
+		std::min<uint64_t>(rewards.armyGrowth, std::numeric_limits<int64_t>::max()));
+	evaluation["goldReward"].Integer() = rewards.goldReward;
+	evaluation["goldCost"].Integer() = rewards.goldCost;
+	evaluation["skillReward"].Float() = rewards.skillReward;
+	evaluation["strategicalValue"].Float() = rewards.strategicalValue;
+	evaluation["conquestValue"].Float() = rewards.conquestValue;
+	evaluation["heroRole"].String() = goal.heroRole == HeroRole::MAIN ? "main" : "scout";
+	evaluation["turn"].Integer() = goal.turn;
+	evaluation["enemyHeroDangerRatio"].Float() = goal.enemyHeroDangerRatio;
+	evaluation["threat"].Float() = goal.threat;
+	evaluation["armyInvolvement"].Float() = goal.armyInvolvement;
+	evaluation["isDefend"].Bool() = goal.isDefend;
+	evaluation["threatTurns"].Integer() = goal.threatTurns;
+	evaluation["buildingCost"]["resources"] = resourcesToJson(building.cost);
+	evaluation["buildingCost"]["marketValue"].Integer() = building.costMarketValue;
+	evaluation["isTradeBuilding"].Bool() = building.isTradeBuilding;
+	evaluation["isExchange"].Bool() = goal.isExchange;
+	evaluation["isArmyUpgrade"].Bool() = goal.isArmyUpgrade;
+	evaluation["isHero"].Bool() = goal.isHero;
+	evaluation["isEnemy"].Bool() = goal.isEnemy;
+	evaluation["explorePriority"].Integer() = goal.explorePriority;
+	evaluation["powerRatio"].Float() = goal.powerRatio;
+
+	JsonNode & escape = result["escape"];
+	escape["hasHero"].Bool() = escapeState.hasHero;
+	escape["currentDangerTurn"].Integer() = escapeState.currentDangerTurn;
+	escape["currentDanger"].Integer() = static_cast<int64_t>(
+		std::min<uint64_t>(escapeState.currentDanger, std::numeric_limits<int64_t>::max()));
+	escape["currentThreat"].Float() = escapeState.currentThreat;
+	escape["destinationThreat"].Float() = escapeState.destinationThreat;
+	escape["heroTotalStrength"].Integer() = static_cast<int64_t>(
+		std::min<uint64_t>(escapeState.heroTotalStrength, std::numeric_limits<int64_t>::max()));
+	return result;
+}
+
+PriorityEvaluationInput priorityEvaluationInputFromJson(const JsonNode & value)
+{
+	std::vector<std::string> resourceNames;
+	if(value["state"]["resourceNames"].isVector())
+	{
+		for(const JsonNode & resourceName : value["state"]["resourceNames"].Vector())
+			resourceNames.push_back(resourceName.String());
+	}
+	else
+	{
+		for(const std::string & resourceName : GameConstants::RESOURCE_NAMES)
+			resourceNames.push_back(resourceName);
+	}
+
+	auto resourcesFromJson = [&resourceNames](const JsonNode & resources)
+	{
+		std::vector<int32_t> result(resourceNames.size());
+		for(size_t index = 0; index < result.size(); ++index)
+			result[index] = resources[resourceNames[index]].Integer();
+		return result;
+	};
+
+	PriorityEvaluationInput input;
+	auto & settings = input.settings;
+	auto & goal = input.goal;
+	auto & rewards = input.rewards;
+	auto & building = input.building;
+	auto & resourceState = input.resourceState;
+
+	settings.priorityTier = value["priorityTierId"].Integer();
+	const JsonNode & state = value["state"];
+	settings.daysWithoutCastle = state["daysWithoutCastle"].Bool();
+	settings.maximumArmyLossTarget = state["maximumArmyLossTarget"].Float();
+	settings.dayOfWeek = state["dayOfWeek"].Integer();
+	settings.daysInWeek = state["daysInWeek"].Integer();
+	resourceState.available = resourcesFromJson(state["resources"]);
+	resourceState.dailyIncome = resourcesFromJson(state["dailyIncome"]);
+	resourceState.lockedResourceMarketValue = state["lockedResourceMarketValue"].Integer();
+	resourceState.goldPressureOverMax = state["goldPressureOverMax"].Bool();
+	resourceState.hasTownWithoutMarketplace = state["hasTownWithoutMarketplace"].Bool();
+
+	const JsonNode & evaluation = value["evaluation"];
+	goal.movementCost = evaluation["movementCost"].Float();
+	goal.danger = evaluation["danger"].Integer();
+	goal.closestWayRatio = evaluation["closestWayRatio"].Float();
+	goal.armyLossRatio = evaluation["armyLossRatio"].Float();
+	goal.heroRole = evaluation["heroRole"].String() == "main" ? HeroRole::MAIN : HeroRole::SCOUT;
+	goal.turn = evaluation["turn"].Integer();
+	goal.enemyHeroDangerRatio = evaluation["enemyHeroDangerRatio"].Float();
+	goal.threat = evaluation["threat"].Float();
+	goal.armyInvolvement = evaluation["armyInvolvement"].Float();
+	goal.isDefend = evaluation["isDefend"].Bool();
+	goal.threatTurns = evaluation["threatTurns"].Integer();
+	goal.isExchange = evaluation["isExchange"].Bool();
+	goal.isArmyUpgrade = evaluation["isArmyUpgrade"].Bool();
+	goal.isHero = evaluation["isHero"].Bool();
+	goal.isEnemy = evaluation["isEnemy"].Bool();
+	goal.explorePriority = evaluation["explorePriority"].Integer();
+	goal.powerRatio = evaluation["powerRatio"].Float();
+
+	rewards.armyReward = evaluation["armyReward"].Float();
+	rewards.armyGrowth = evaluation["armyGrowth"].Integer();
+	rewards.goldReward = evaluation["goldReward"].Integer();
+	rewards.goldCost = evaluation["goldCost"].Integer();
+	rewards.skillReward = evaluation["skillReward"].Float();
+	rewards.strategicalValue = evaluation["strategicalValue"].Float();
+	rewards.conquestValue = evaluation["conquestValue"].Float();
+
+	building.cost = resourcesFromJson(evaluation["buildingCost"]["resources"]);
+	building.costMarketValue = evaluation["buildingCost"]["marketValue"].Integer();
+	building.isTradeBuilding = evaluation["isTradeBuilding"].Bool();
+
+	const JsonNode & escape = value["escape"];
+	input.escape.hasHero = escape["hasHero"].Bool();
+	input.escape.currentDangerTurn = escape["currentDangerTurn"].Integer();
+	input.escape.currentDanger = escape["currentDanger"].Integer();
+	input.escape.currentThreat = escape["currentThreat"].Float();
+	input.escape.destinationThreat = escape["destinationThreat"].Float();
+	input.escape.heroTotalStrength = escape["heroTotalStrength"].Integer();
+	return input;
+}
+
+std::unique_ptr<IDecisionPolicy> createLuaDecisionPolicy(
+	const std::string & name,
+	const std::string & source,
+	const JsonNode & parameters,
+	const Environment * environment,
+	bool shadow)
+{
+	return std::make_unique<LuaDecisionPolicy>(name, source, parameters, environment, shadow);
+}
+
+std::unique_ptr<IDecisionPolicy> createDecisionPolicy(const PlayerColor player, const Environment * environment)
+{
+	const std::string selectedPolicy = getPlayerEnvironmentValue("VCMI_NK2_POLICY", player);
+	if(selectedPolicy.empty() || selectedPolicy == "builtin")
+		return nullptr;
+
+	try
+	{
+		const boost::filesystem::path selectedPath(selectedPolicy);
+		const JsonNode profile = parseProfile(selectedPath);
+		if(profile["schemaVersion"].getType() != JsonNode::JsonType::DATA_INTEGER || profile["schemaVersion"].Integer() != 1)
+			throw std::runtime_error("unsupported or missing schemaVersion");
+		if(!profile["type"].isString() || profile["type"].String() != "lua")
+			throw std::runtime_error("policy type must be 'lua'");
+		if(!profile["script"].isString())
+			throw std::runtime_error("Lua policy has no script path");
+
+		boost::filesystem::path scriptPath(profile["script"].String());
+		if(scriptPath.is_relative())
+			scriptPath = selectedPath.parent_path() / scriptPath;
+
+		JsonNode parameters;
+		parameters.Struct();
+		if(profile["parameters"].isStruct())
+			parameters = profile["parameters"];
+		else if(!profile["parameters"].isNull())
+			throw std::runtime_error("policy parameters must be an object");
+		if(!profile["shadow"].isNull() && !profile["shadow"].isBool())
+			throw std::runtime_error("policy shadow flag must be a boolean");
+
+		const std::string name = profile["name"].isString() ? profile["name"].String() : selectedPath.stem().string();
+		const bool shadow = profile["shadow"].isBool() && profile["shadow"].Bool();
+		return createLuaDecisionPolicy(name, readTextFile(scriptPath), parameters, environment, shadow);
+	}
+	catch(const std::runtime_error & exception)
+	{
+		logAi->error("Unable to load NK2 decision policy '%s': %s. Using compiled policy.", selectedPolicy, exception.what());
+		return nullptr;
+	}
+}
+
+}

--- a/AI/Nullkiller2/Engine/DecisionPolicy.h
+++ b/AI/Nullkiller2/Engine/DecisionPolicy.h
@@ -1,0 +1,67 @@
+/*
+ * DecisionPolicy.h, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ */
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+
+class JsonNode;
+class Environment;
+class PlayerColor;
+
+namespace NK2AI
+{
+
+struct PriorityEvaluationInput;
+
+struct DecisionPolicyScore
+{
+	size_t id;
+	float score;
+};
+
+struct DecisionPolicyResult
+{
+	bool applied = false;
+	std::vector<DecisionPolicyScore> scores;
+	std::string error;
+};
+
+/// Boundary between NK2 planning and an optional configurable policy.
+class IDecisionPolicy
+{
+public:
+	virtual ~IDecisionPolicy() = default;
+
+	virtual DecisionPolicyResult rank(const JsonNode & request) = 0;
+	virtual std::string getName() const = 0;
+	virtual std::string getVersion() const = 0;
+	virtual bool isShadow() const { return false; }
+};
+
+/// Loads the JSON profile selected by VCMI_NK2_POLICY[_<PLAYER COLOR>]. An
+/// unset variable or the value "builtin" preserves the compiled NK2 evaluator.
+std::unique_ptr<IDecisionPolicy> createDecisionPolicy(PlayerColor player, const Environment * environment);
+
+/// Constructs a Lua policy from source. Public for tests and policy tooling, so
+/// they exercise the same bindings and validation as live NK2.
+std::unique_ptr<IDecisionPolicy> createLuaDecisionPolicy(
+	const std::string & name,
+	const std::string & source,
+	const JsonNode & parameters,
+	const Environment * environment,
+	bool shadow = false);
+
+/// Stable JSON representation passed to scripts and stored as differential
+/// test input. Both scorers consume the values represented here.
+JsonNode priorityEvaluationInputToJson(const PriorityEvaluationInput & input);
+PriorityEvaluationInput priorityEvaluationInputFromJson(const JsonNode & value);
+
+}

--- a/AI/Nullkiller2/Engine/Nullkiller.cpp
+++ b/AI/Nullkiller2/Engine/Nullkiller.cpp
@@ -11,7 +11,11 @@
 #include "Nullkiller.h"
 
 #include "../../../lib/CPlayerState.h"
+#include "../../../lib/ResourceSet.h"
 #include "../../../lib/StartInfo.h"
+#include "../../../lib/constants/NumericConstants.h"
+#include "../../../lib/constants/StringConstants.h"
+#include "../../../lib/json/JsonNode.h"
 #include "../../../lib/pathfinder/PathfinderCache.h"
 #include "../../../lib/pathfinder/PathfinderOptions.h"
 #include "../AIGateway.h"
@@ -28,6 +32,7 @@
 #include "../Behaviors/StayAtTownBehavior.h"
 #include "../Goals/Invalid.h"
 #include "Goals/RecruitHero.h"
+#include "DecisionPolicy.h"
 #include "ResourceTrader.h"
 
 namespace NK2AI
@@ -53,6 +58,144 @@ const char * heroLockReasonName(HeroLockedReason reason)
 
 	return "unknown reason";
 }
+
+const char * goalTypeName(Goals::EGoals goalType)
+{
+	static constexpr std::array<const char *, Goals::EXPLORE_NEIGHBOUR_TILE + 2> names = {
+		"invalid",
+		"win",
+		"conquer",
+		"build",
+		"explore",
+		"gatherArmy",
+		"boostHero",
+		"recruitHero",
+		"recruitHeroBehavior",
+		"buildStructure",
+		"collectResource",
+		"gatherTroops",
+		"captureObjects",
+		"getArtifactType",
+		"defence",
+		"startup",
+		"digAtTile",
+		"buyArmy",
+		"trade",
+		"buildBoat",
+		"completeQuest",
+		"adventureSpellCast",
+		"executeHeroChain",
+		"exchangeSwapTownHeroes",
+		"dismissHero",
+		"composition",
+		"clusterBehavior",
+		"unlockCluster",
+		"heroExchange",
+		"armyUpgrade",
+		"defendTown",
+		"captureObject",
+		"saveResources",
+		"stayAtTownBehavior",
+		"stayAtTown",
+		"explorationBehavior",
+		"escapeBehavior",
+		"explorationPoint",
+		"exploreNeighbourTile"};
+	const int index = goalType + 1;
+	return index >= 0 && static_cast<size_t>(index) < names.size()
+		? names[static_cast<size_t>(index)]
+		: "unknown";
+}
+
+const char * priorityTierName(int priorityTier)
+{
+	switch(priorityTier)
+	{
+	case PriorityEvaluator::PriorityTier::BUILDINGS: return "buildings";
+	case PriorityEvaluator::PriorityTier::INSTAKILL: return "instakill";
+	case PriorityEvaluator::PriorityTier::INSTADEFEND: return "instaDefend";
+	case PriorityEvaluator::PriorityTier::KILL: return "kill";
+	case PriorityEvaluator::PriorityTier::ESCAPE: return "escape";
+	case PriorityEvaluator::PriorityTier::EXPLORE_AND_GATHER: return "exploreAndGather";
+	case PriorityEvaluator::PriorityTier::DEFEND: return "defend";
+	}
+	return "unknown";
+}
+
+int64_t boundedInteger(uint64_t value)
+{
+	return static_cast<int64_t>(std::min<uint64_t>(value, std::numeric_limits<int64_t>::max()));
+}
+
+JsonNode resourcesToJson(const TResources & resources)
+{
+	JsonNode result;
+	for(int index = 0; index < GameConstants::RESOURCE_QUANTITY; ++index)
+		result[GameConstants::RESOURCE_NAMES[index]].Integer() = resources[static_cast<size_t>(index)];
+	return result;
+}
+
+JsonNode buildPolicyCandidate(
+	const Goals::TSubgoal & task,
+	const size_t index,
+	const float initialPriority,
+	const float compiledPriority,
+	const PriorityEvaluationInput & rankingInput,
+	const EvaluationContext & evaluationContext)
+{
+	JsonNode candidate;
+	candidate["id"].Integer() = index;
+	candidate["goalType"].String() = goalTypeName(task->goalType);
+	candidate["goalTypeId"].Integer() = task->goalType;
+	candidate["description"].String() = task->toString();
+	candidate["initialPriority"].Float() = initialPriority;
+	candidate["baselinePriority"].Float() = compiledPriority;
+	candidate["baselineAccepted"].Bool() = compiledPriority > 0;
+	if(task->hero)
+		candidate["heroId"].Integer() = task->hero->id.getNum();
+	if(task->town)
+		candidate["townId"].Integer() = task->town->id.getNum();
+	if(task->objid >= 0)
+		candidate["objectId"].Integer() = task->objid;
+	candidate["target"]["x"].Integer() = task->tile.x;
+	candidate["target"]["y"].Integer() = task->tile.y;
+	candidate["target"]["z"].Integer() = task->tile.z;
+	candidate["rankingInput"] = priorityEvaluationInputToJson(rankingInput);
+	candidate["evaluation"] = candidate["rankingInput"]["evaluation"];
+	candidate["evaluation"]["movementCostByRole"]["scout"].Float() = evaluationContext.getMovementCost(HeroRole::SCOUT);
+	candidate["evaluation"]["movementCostByRole"]["main"].Float() = evaluationContext.getMovementCost(HeroRole::MAIN);
+	candidate["evaluation"]["manaCost"].Integer() = evaluationContext.manaCost;
+	candidate["evaluation"]["defenseValue"].Integer() = evaluationContext.defenseValue;
+	candidate["evaluation"]["involvesSailing"].Bool() = evaluationContext.involvesSailing;
+	return candidate;
+}
+
+struct PolicyMismatch
+{
+	size_t count = 0;
+	size_t first = 0;
+};
+
+PolicyMismatch findPolicyMismatches(
+	const std::vector<float> & compiledPriorities,
+	const std::map<size_t, float> & policyScores)
+{
+	PolicyMismatch result;
+	for(size_t index = 0; index < compiledPriorities.size(); ++index)
+	{
+		const float compiledScore = compiledPriorities[index];
+		const float policyScore = policyScores.at(index);
+		const float tolerance = std::max(1.0f, std::abs(compiledScore)) * 0.0001f;
+		if((compiledScore > 0) != (policyScore > 0) || std::abs(compiledScore - policyScore) > tolerance)
+		{
+			if(result.count == 0)
+				result.first = index;
+			++result.count;
+		}
+	}
+	return result;
+}
+
 }
 
 // while we play vcmieagles graph can be shared
@@ -104,6 +247,9 @@ void Nullkiller::init(const std::shared_ptr<CCallback> & cbInput, AIGateway * ai
 	playerID = aiGwInput->playerID;
 
 	settings = std::make_unique<Settings>(cc->getStartInfo()->difficulty);
+	decisionPolicy = createDecisionPolicy(playerID, aiGwInput->env.get());
+	if(decisionPolicy)
+		logAi->info("Using NK2 decision policy '%s' version %s for player %s", decisionPolicy->getName(), decisionPolicy->getVersion(), playerID.toString());
 
 	PathfinderOptions pathfinderOptions(*cc);
 	pathfinderOptions.useTeleportTwoWay = true;
@@ -214,11 +360,36 @@ Goals::TTask Nullkiller::choseBestTask(Goals::TGoalVec & tasks) const
 		return taskptr(Invalid());
 	}
 
+	if(!decisionPolicy)
+	{
+		for(const TSubgoal & task : tasks)
+		{
+			if(task->asTask()->priority <= 0)
+				task->asTask()->priority = priorityEvaluator->evaluate(task);
+		}
+
+		auto bestTask = *vstd::maxElementByFun(tasks, [](const Goals::TSubgoal& task) -> float
+			{
+				return task->asTask()->priority;
+			});
+		return taskptr(*bestTask);
+	}
+
+	std::vector<float> initialPriorities;
+	initialPriorities.reserve(tasks.size());
+	for(const TSubgoal & task : tasks)
+		initialPriorities.push_back(task->asTask()->priority);
+
+	const auto evaluationContexts = buildEvaluationContexts(tasks);
 	for(const TSubgoal & task : tasks)
 	{
 		if(task->asTask()->priority <= 0)
-			task->asTask()->priority = priorityEvaluator->evaluate(task);
+			task->asTask()->priority = priorityEvaluator->evaluate(
+				task,
+				PriorityEvaluator::PriorityTier::BUILDINGS,
+				evaluationContexts.at(task.get()));
 	}
+	applyDecisionPolicy(tasks, evaluationContexts, PriorityEvaluator::PriorityTier::BUILDINGS, initialPriorities);
 
 	auto bestTask = *vstd::maxElementByFun(tasks, [](const Goals::TSubgoal& task) -> float
 		{
@@ -249,12 +420,170 @@ Nullkiller::EvaluationContextMap Nullkiller::buildEvaluationContexts(const TGoal
 	return result;
 }
 
+JsonNode Nullkiller::buildPolicyState() const
+{
+	JsonNode state;
+	state["resources"] = resourcesToJson(getFreeResources());
+	state["resourceMarketValue"].Integer() = getFreeResources().marketValue();
+	state["dailyIncome"] = resourcesToJson(buildAnalyzer->getDailyIncome());
+	state["lockedResources"] = resourcesToJson(getLockedResources());
+	state["lockedResourceMarketValue"].Integer() = getLockedResources().marketValue();
+	state["goldPressureOverMax"].Bool() = buildAnalyzer->isGoldPressureOverMax();
+	state["maximumArmyLossTarget"].Float() = settings->getMaxArmyLossTarget();
+	state["daysWithoutCastle"].Bool() = cc->getPlayerState(playerID)->daysWithoutCastle.has_value();
+	state["dayOfWeek"].Integer() = cc->getCalendar().getDayOfWeek();
+	state["daysInWeek"].Integer() = cc->getCalendar().getDaysInWeek();
+	state["heroCount"].Integer() = cc->getHeroesInfo().size();
+	state["townCount"].Integer() = cc->getTownsInfo().size();
+	state["ownedObjectCount"].Integer() = cc->getMyObjects().size();
+	state["knownObjectCount"].Integer() = memory->visitableObjs.size();
+	const TeamState * team = cc->getPlayerTeam(playerID);
+	state["revealedTileCount"].Integer() = std::ranges::count(team->fogOfWarMap, uint8_t{1});
+
+	uint64_t totalHeroArmyStrength = 0;
+	uint64_t totalHeroStrength = 0;
+	uint64_t totalHeroExperience = 0;
+	uint64_t totalHeroLevels = 0;
+	for(const CGHeroInstance * hero : cc->getHeroesInfo())
+	{
+		JsonNode value;
+		value["id"].Integer() = hero->id.getNum();
+		value["level"].Integer() = hero->level;
+		value["experience"].Integer() = boundedInteger(hero->exp);
+		value["armyStrength"].Integer() = boundedInteger(hero->getArmyStrength());
+		value["totalStrength"].Integer() = boundedInteger(hero->getTotalStrength());
+		value["movement"].Integer() = hero->movementPointsRemaining();
+		value["mana"].Integer() = hero->mana;
+		state["heroes"].Vector().push_back(std::move(value));
+
+		totalHeroArmyStrength += hero->getArmyStrength();
+		totalHeroStrength += hero->getTotalStrength();
+		totalHeroExperience += hero->exp;
+		totalHeroLevels += hero->level;
+	}
+	state["totalHeroArmyStrength"].Integer() = boundedInteger(totalHeroArmyStrength);
+	state["totalHeroStrength"].Integer() = boundedInteger(totalHeroStrength);
+	state["totalHeroExperience"].Integer() = boundedInteger(totalHeroExperience);
+	state["totalHeroLevels"].Integer() = boundedInteger(totalHeroLevels);
+
+	uint64_t totalTownArmyStrength = 0;
+	uint64_t totalBuildings = 0;
+	uint64_t totalFortLevel = 0;
+	bool hasTownWithoutMarketplace = false;
+	for(const CGTownInstance * town : cc->getTownsInfo())
+	{
+		JsonNode value;
+		value["id"].Integer() = town->id.getNum();
+		value["buildingCount"].Integer() = town->getBuildings().size();
+		value["fortLevel"].Integer() = town->fortLevel();
+		value["hallLevel"].Integer() = town->hallLevel();
+		value["mageGuildLevel"].Integer() = town->mageGuildLevel();
+		value["armyStrength"].Integer() = boundedInteger(town->getArmyStrength(town->fortLevel()));
+		value["dailyIncome"] = resourcesToJson(town->dailyIncome());
+		value["hasResourceMarketplace"].Bool() = town->hasBuiltResourceMarketplace();
+		state["towns"].Vector().push_back(std::move(value));
+
+		totalTownArmyStrength += town->getArmyStrength(town->fortLevel());
+		totalBuildings += town->getBuildings().size();
+		totalFortLevel += town->fortLevel();
+		hasTownWithoutMarketplace |= !town->hasBuiltResourceMarketplace();
+	}
+	state["hasTownWithoutMarketplace"].Bool() = hasTownWithoutMarketplace;
+	state["totalTownArmyStrength"].Integer() = boundedInteger(totalTownArmyStrength);
+	state["totalArmyStrength"].Integer() = boundedInteger(totalHeroArmyStrength + totalTownArmyStrength);
+	state["totalBuildings"].Integer() = boundedInteger(totalBuildings);
+	state["totalFortLevel"].Integer() = boundedInteger(totalFortLevel);
+	return state;
+}
+
+void Nullkiller::applyDecisionPolicy(
+	TGoalVec & tasks,
+	const EvaluationContextMap & evaluationContexts,
+	int priorityTier,
+	const std::vector<float> & initialPriorities) const
+{
+	if(!decisionPolicy)
+		return;
+	assert(tasks.size() == initialPriorities.size());
+
+	JsonNode request;
+	request["schemaVersion"].Integer() = 1;
+	request["player"].String() = GameConstants::PLAYER_COLOR_NAMES[playerID.getNum()];
+	request["playerId"].Integer() = playerID.getNum();
+	request["day"].Integer() = cc->getCalendar().getCurrentDay();
+	request["priorityTier"].String() = priorityTierName(priorityTier);
+	request["priorityTierId"].Integer() = priorityTier;
+	request["state"] = buildPolicyState();
+	std::vector<float> compiledPriorities;
+	compiledPriorities.reserve(tasks.size());
+
+	for(size_t index = 0; index < tasks.size(); ++index)
+	{
+		const auto & task = tasks[index];
+		const PriorityEvaluationInput rankingInput = priorityEvaluator->buildEvaluationInput(
+			task,
+			priorityTier,
+			evaluationContexts.at(task.get()));
+		const float compiledPriority = priorityTier == PriorityEvaluator::BUILDINGS && initialPriorities[index] > 0
+			? initialPriorities[index]
+			: evaluatePriority(rankingInput);
+		compiledPriorities.push_back(compiledPriority);
+		const EvaluationContext & evaluationContext = evaluationContexts.at(task.get());
+		request["candidates"].Vector().push_back(buildPolicyCandidate(
+			task,
+			index,
+			initialPriorities[index],
+			compiledPriority,
+			rankingInput,
+			evaluationContext));
+	}
+
+	const DecisionPolicyResult result = decisionPolicy->rank(request);
+	if(!result.applied)
+	{
+		if(!result.error.empty())
+			logAi->warn("NK2 decision policy '%s' rejected a ranking: %s. Using compiled ranking.", decisionPolicy->getName(), result.error);
+		return;
+	}
+	std::map<size_t, float> scores;
+	for(const DecisionPolicyScore & score : result.scores)
+		scores[score.id] = score.score;
+
+	if(decisionPolicy->isShadow())
+	{
+		const PolicyMismatch mismatch = findPolicyMismatches(compiledPriorities, scores);
+		if(mismatch.count > 0)
+		{
+			logAi->warn(
+				"NK2 shadow policy '%s' differs for %zu of %zu candidates at tier %d. First: %s, compiled %f, Lua %f",
+				decisionPolicy->getName(),
+				mismatch.count,
+				tasks.size(),
+				priorityTier,
+				tasks[mismatch.first]->toString(),
+				compiledPriorities[mismatch.first],
+				scores.at(mismatch.first));
+		}
+		return;
+	}
+
+	for(size_t index = 0; index < tasks.size(); ++index)
+		tasks[index]->asTask()->priority = scores.at(index);
+}
+
 Goals::TTaskVec Nullkiller::buildPlanAndFilter(
 	TGoalVec & tasks,
 	const EvaluationContextMap & evaluationContexts,
 	int priorityTier) const
 {
 	TaskPlan taskPlan;
+	std::vector<float> initialPriorities;
+	if(decisionPolicy)
+	{
+		initialPriorities.reserve(tasks.size());
+		for(const TSubgoal & task : tasks)
+			initialPriorities.push_back(task->asTask()->priority);
+	}
 
 	tbb::parallel_for(
 		tbb::blocked_range<size_t>(0, tasks.size(), 128),
@@ -272,6 +601,9 @@ Goals::TTaskVec Nullkiller::buildPlanAndFilter(
 			}
 		}
 	);
+
+	if(decisionPolicy)
+		applyDecisionPolicy(tasks, evaluationContexts, priorityTier, initialPriorities);
 
 	std::ranges::sort(
 		tasks,

--- a/AI/Nullkiller2/Engine/Nullkiller.h
+++ b/AI/Nullkiller2/Engine/Nullkiller.h
@@ -24,9 +24,12 @@
 #include "../../../lib/ConditionalWait.h"
 
 class PathfinderCache;
+class JsonNode;
 
 namespace NK2AI
 {
+
+class IDecisionPolicy;
 
 const float MIN_PRIORITY = 0.01f;
 const float SMALL_SCAN_MIN_PRIORITY = 0.4f;
@@ -110,6 +113,7 @@ public:
 	std::unique_ptr<DeepDecomposer> decomposer;
 	std::unique_ptr<ArmyFormation> armyFormation;
 	std::unique_ptr<Settings> settings;
+	std::unique_ptr<IDecisionPolicy> decisionPolicy;
 	/// Same value as AIGateway->playerID
 	PlayerColor playerID;
 	AIGateway * aiGw;
@@ -154,8 +158,14 @@ private:
 	const CGHeroInstance * findRequiredTownDefender(const CGTownInstance * town) const;
 	void decompose(Goals::TGoalVec & results, const Goals::TSubgoal& behavior, int decompositionMaxDepth) const;
 	Goals::TTask choseBestTask(Goals::TGoalVec & tasks) const;
+	JsonNode buildPolicyState() const;
 	using EvaluationContextMap = std::map<const Goals::AbstractGoal *, EvaluationContext>;
 	EvaluationContextMap buildEvaluationContexts(const Goals::TGoalVec & tasks) const;
+	void applyDecisionPolicy(
+		Goals::TGoalVec & tasks,
+		const EvaluationContextMap & evaluationContexts,
+		int priorityTier,
+		const std::vector<float> & initialPriorities) const;
 	Goals::TTaskVec buildPlanAndFilter(
 		Goals::TGoalVec & tasks,
 		const EvaluationContextMap & evaluationContexts,

--- a/AI/Nullkiller2/Engine/PriorityEvaluator.cpp
+++ b/AI/Nullkiller2/Engine/PriorityEvaluator.cpp
@@ -1403,7 +1403,10 @@ EvaluationContext PriorityEvaluator::buildEvaluationContext(const Goals::TSubgoa
 	return context;
 }
 
-float PriorityEvaluator::evaluateMovement(float score, const float movementCost)
+namespace
+{
+
+float evaluateMovement(float score, const float movementCost)
 {
 	if(movementCost > 0)
 	{
@@ -1417,7 +1420,7 @@ float PriorityEvaluator::evaluateMovement(float score, const float movementCost)
 	return score;
 }
 
-float PriorityEvaluator::evaluateArmyLossRatio(float score, const float armyLossRatio, const HeroRole heroRole)
+float evaluateArmyLossRatio(float score, const float armyLossRatio, const HeroRole heroRole)
 {
 	if(armyLossRatio > 0)
 	{
@@ -1430,17 +1433,51 @@ float PriorityEvaluator::evaluateArmyLossRatio(float score, const float armyLoss
 	return score;
 }
 
-float PriorityEvaluator::evaluateSkillReward(float score, const float skillReward, const float armyInvolvement, const float armyLossRatio)
+float evaluateSkillReward(float score, const float skillReward, const float armyInvolvement, const float armyLossRatio)
 {
 	// Encourage stronger heroes
 	return score + skillReward * armyInvolvement * (1 - armyLossRatio) * 0.05;
 }
 
-float PriorityEvaluator::evaluateConquestValue(float score, const float conquestValue, const float armyInvolvement)
+float evaluateConquestValue(float score, const float conquestValue, const float armyInvolvement)
 {
 	if(conquestValue > 0)
 		score = armyInvolvement * conquestValue;
 	return score;
+}
+
+int32_t resourceAt(const std::vector<int32_t> & resources, const size_t index)
+{
+	return index < resources.size() ? resources[index] : 0;
+}
+
+bool canAfford(const std::vector<int32_t> & resources, const std::vector<int32_t> & cost)
+{
+	for(size_t index = 0; index < cost.size(); ++index)
+	{
+		if(cost[index] > resourceAt(resources, index))
+			return false;
+	}
+	return true;
+}
+
+int turnsToAfford(const std::vector<int32_t> & resources, const std::vector<int32_t> & income, const std::vector<int32_t> & cost)
+{
+	int result = 0;
+	for(size_t index = 0; index < cost.size(); ++index)
+	{
+		const int32_t needed = std::max(0, cost[index] - resourceAt(resources, index));
+		if(needed <= 0)
+			continue;
+
+		const int32_t resourceIncome = resourceAt(income, index);
+		if(resourceIncome == 0)
+			return INT_MAX;
+		result = std::max(result, vstd::divideAndCeil(needed, resourceIncome));
+	}
+	return result;
+}
+
 }
 
 float PriorityEvaluator::evaluate(Goals::TSubgoal task, int priorityTier)
@@ -1449,339 +1486,500 @@ float PriorityEvaluator::evaluate(Goals::TSubgoal task, int priorityTier)
 	return evaluate(task, priorityTier, evaluationContext);
 }
 
+namespace
+{
+
+struct PriorityEvaluationLimits
+{
+	float maximumArmyLoss;
+	float maximumArmyLossForTask;
+	float maximumEnemyDangerRatio;
+	bool arriveNextWeek;
+};
+
+float maximumArmyLoss(const PriorityEvaluationInput & input)
+{
+	if(input.settings.daysWithoutCastle)
+		return 1;
+
+	const float scaledMaximumLoss = input.settings.maximumArmyLossTarget * input.goal.powerRatio;
+	return scaledMaximumLoss > 0 ? scaledMaximumLoss : 1.0f;
+}
+
+PriorityEvaluationLimits evaluationLimits(const PriorityEvaluationInput & input)
+{
+	const float maximumLoss = maximumArmyLoss(input);
+	const bool isEnemyTownConquest = input.goal.isEnemy
+		&& !input.goal.isHero
+		&& input.rewards.conquestValue > MAX_CRITICAL_VALUE;
+	const float lossForTask = evaluateMaxArmyLossForConquest(
+		maximumLoss,
+		input.rewards.conquestValue,
+		isEnemyTownConquest);
+	return {
+		maximumLoss,
+		lossForTask,
+		input.goal.powerRatio > 0 ? input.goal.powerRatio : 1.0f,
+		input.settings.dayOfWeek + input.goal.turn > input.settings.daysInWeek};
+}
+
+float evaluateMovementAndDistance(float score, const PriorityEvaluationGoal & goal)
+{
+	score *= goal.closestWayRatio;
+	return evaluateMovement(score, goal.movementCost);
+}
+
+float evaluateInstakill(const PriorityEvaluationInput & input, const PriorityEvaluationLimits & limits)
+{
+	const auto & goal = input.goal;
+	if(goal.turn > 0 || goal.isExchange || goal.isDefend)
+		return 0;
+	if(goal.movementCost >= 1)
+		return 0;
+
+	// TODO: Mircea: Ensure defenseValue is taken into account.
+	// See AINodeStorage::evaluateArmyLoss and CCreatureSet::getArmyStrength
+	// TODO: Mircea: make it dynamic, allow higher risk for killing a higher risk hero
+	// if it leads to killing an entire player. See conquestValue
+	if(limits.maximumArmyLossForTask - goal.armyLossRatio < 0)
+		return 0;
+
+	float score = evaluateConquestValue(0, input.rewards.conquestValue, goal.armyInvolvement);
+	score = evaluateArmyLossRatio(score, goal.armyLossRatio, goal.heroRole);
+	if(vstd::isAlmostZero(score)
+	   || (goal.enemyHeroDangerRatio > limits.maximumEnemyDangerRatio && !input.settings.daysWithoutCastle))
+		return 0;
+
+	return evaluateMovementAndDistance(score, goal);
+}
+
+float evaluateInstaDefend(const PriorityEvaluationInput & input, const PriorityEvaluationLimits & limits)
+{
+	const auto & goal = input.goal;
+	if(!goal.isDefend)
+		return 0;
+	// TODO: Mircea: Often is better to die as long as you're almost destroying the opponent. To revisit
+	if(limits.maximumArmyLossForTask - goal.armyLossRatio < 0)
+		return 0;
+	if(goal.isEnemy && goal.turn > 0)
+		return 0;
+
+	const bool canPrepareForNextTurnThreat = goal.turn == 0 && goal.threatTurns == 1;
+	if(goal.threatTurns > goal.turn && !canPrepareForNextTurnThreat)
+		return 0;
+
+	// TODO: Mircea: Too many heroes are rushing for INSTADEFEND.
+	// We need some kind of smart selection of who to go, not everyone qualified
+	// Probably apply normal fight calculation as in others + filter out unnecessary ones in makeTurn buildPlan
+	constexpr float OPTIMAL_PERCENTAGE = 0.75f; // We want army to be 75% of the threat
+	const float optimalStrength = goal.threat * OPTIMAL_PERCENTAGE;
+	const float deviation = std::abs(goal.armyInvolvement - optimalStrength);
+	const float deviationPercentage = deviation / goal.threat;
+	const float score = 1.0f / (1.0f + deviationPercentage);
+	return evaluateMovementAndDistance(score, goal);
+}
+
+float evaluateKill(const PriorityEvaluationInput & input, const PriorityEvaluationLimits & limits)
+{
+	const auto & goal = input.goal;
+	if(goal.isDefend)
+		return 0;
+	// TODO: Mircea: Ensure defenseValue is taken into account.
+	// See AINodeStorage::evaluateArmyLoss and CCreatureSet::getArmyStrength
+	// if(evaluationContext.defenseValue < 2 && evaluationContext.enemyHeroDangerRatio > involvedStrengthOutOfTotalRatio)
+		// return 0;
+	if(goal.turn > 0 && goal.isHero)
+		return 0;
+	if(limits.arriveNextWeek && goal.isEnemy)
+		return 0;
+
+	float score = evaluateConquestValue(0, input.rewards.conquestValue, goal.armyInvolvement);
+	// TODO: Mircea: Last part of the if looks strange, to revisit
+	if(vstd::isAlmostZero(score)
+	   || (goal.enemyHeroDangerRatio > limits.maximumEnemyDangerRatio && (goal.turn > 0 || goal.isExchange)
+		   && !input.settings.daysWithoutCastle))
+		return 0;
+	if(limits.maximumArmyLossForTask - goal.armyLossRatio < 0)
+		return 0;
+
+	score = evaluateArmyLossRatio(score, goal.armyLossRatio, goal.heroRole);
+	return evaluateMovementAndDistance(score, goal);
+}
+
+float evaluateEscapeThreat(float score, const PriorityEvaluationInput & input)
+{
+	if(input.settings.priorityTier == PriorityEvaluator::ESCAPE
+	   && input.escape.hasHero
+	   && input.escape.currentDangerTurn < 1
+	   && input.escape.currentDanger > input.escape.heroTotalStrength)
+	{
+		// Encourage routes which go away of the threat
+		const auto delta = input.escape.currentThreat - input.escape.destinationThreat;
+		if(delta > 0)
+			score += delta;
+	}
+	return score;
+}
+
+float evaluateExplorationPriority(float score, const PriorityEvaluationInput & input, const bool requiresBattle)
+{
+	if(input.goal.explorePriority <= 0)
+		return score;
+
+	score = 600.0f / input.goal.explorePriority;
+	// Encourage exploration for MAIN that requires battles, so SCOUTs can continue exploring
+	if(input.goal.heroRole == MAIN && requiresBattle)
+		score *= 2;
+	return score;
+}
+
+float evaluateGoldReward(float score, const PriorityEvaluationInput & input, const bool requiresBattle)
+{
+	if(input.rewards.goldReward <= 0)
+		return score;
+
+	// try to balance other resources vs gold, especially 2500 gold treasures
+	if(input.rewards.goldReward > 500)
+		score += input.rewards.goldReward / 2.0f;
+	else
+		score += input.rewards.goldReward * 2.0f;
+
+	if(input.goal.heroRole == MAIN)
+	{
+		if(requiresBattle)
+			// Encourage MAIN to fight for crypts and similar
+			score *= 2;
+		else
+			// Discourage MAIN to waste time picking resources if they don't require a fight
+			score *= 0.33;
+	}
+	return score;
+}
+
+float evaluateSkillRewards(float score, const PriorityEvaluationInput & input, const bool requiresBattle)
+{
+	if(input.rewards.skillReward <= 0)
+		return score;
+
+	if(input.goal.heroRole == MAIN)
+	{
+		score = 1000 + evaluateSkillReward(
+			score,
+			input.rewards.skillReward,
+			input.goal.armyInvolvement,
+			input.goal.armyLossRatio);
+
+		// Encourage skill increases before battles
+		if(!requiresBattle)
+			score *= 3;
+		return score;
+	}
+
+	// TODO: Mircea: Improve logic so that skill reward should be 0 for SCOUTs for one time things
+	// like a scholar, but allowed for buildings that give to all visiting heroes
+	// TODO: Mircea: Ease the restriction after 1 month or a bit more, because MAINs had enough time
+	// to grow, avoiding a SPAM of role shifts for each upgrade a SCOUT gets
+	// Discourage SCOUTs to pick-up skills/artifacts, otherwise it creates a mess with shifting MAIN responsibility.
+	// MAINs grow and fight, SCOUTs do the groundwork.
+	return std::max(1.0f, score / 1000.0f);
+}
+
+float evaluateExploreAndGather(const PriorityEvaluationInput & input, const PriorityEvaluationLimits & limits)
+{
+	const auto & goal = input.goal;
+	const auto & rewards = input.rewards;
+	if(rewards.conquestValue > 0 || goal.isDefend || input.building.costMarketValue > 0)
+		return 0;
+	if(limits.maximumArmyLossForTask - goal.armyLossRatio < 0)
+		return 0;
+	if(input.settings.priorityTier == PriorityEvaluator::EXPLORE_AND_GATHER
+	   && goal.enemyHeroDangerRatio > limits.maximumEnemyDangerRatio)
+		return 0;
+
+	float score = evaluateEscapeThreat(0, input);
+	const bool requiresBattle = goal.armyLossRatio > 0 || goal.danger > 0;
+	score += rewards.strategicalValue * 1000;
+	score = evaluateExplorationPriority(score, input, requiresBattle);
+	score = evaluateGoldReward(score, input, requiresBattle);
+	score = evaluateSkillRewards(score, input, requiresBattle);
+	score += goal.heroRole == MAIN ? rewards.armyReward : rewards.armyReward / 10.0f;
+	// workshop (free lvl 1 units for Tower) and similar dwellings receive
+	// both armyReward and armyGrowth in evaluationContext
+	// For that reason only getDwellingArmyGrowth gets amplified towards day 7 if units are lost after
+	// Hero exchange and army upgrade are using this too
+	score += rewards.armyGrowth;
+	if(rewards.goldCost > 0)
+		// Will be outside the if, just temporary for debugging
+		// don't include the full cost of School of Magic or others because those locations are beneficial
+		score -= rewards.goldCost / 4.0f;
+	score = evaluateArmyLossRatio(score, goal.armyLossRatio, goal.heroRole);
+	return evaluateMovementAndDistance(score, goal);
+}
+
+float evaluateDefend(const PriorityEvaluationInput & input, const PriorityEvaluationLimits & limits)
+{
+	if(input.goal.enemyHeroDangerRatio > limits.maximumEnemyDangerRatio)
+		return 0;
+
+	float score = 0;
+	if(input.goal.isDefend || input.goal.isArmyUpgrade)
+		score = input.goal.armyInvolvement;
+	return evaluateMovementAndDistance(score, input.goal);
+}
+
+float evaluateBuildingCost(float score, const PriorityEvaluationInput & input)
+{
+	const auto & building = input.building;
+	const auto & resourceState = input.resourceState;
+	if(!building.isTradeBuilding
+	   && resourceAt(resourceState.available, EGameResID::WOOD) - resourceAt(building.cost, EGameResID::WOOD) < 5
+	   && resourceAt(resourceState.dailyIncome, EGameResID::WOOD) < 1
+	   && resourceState.hasTownWithoutMarketplace)
+		return 0;
+
+	score += 1000;
+	// TODO: Mircea: Might want to use isGoldPressureOverMax or canAfford inside hunter gather
+	// as well if it's not already applied before
+	if(resourceState.goldPressureOverMax)
+		score /= building.costMarketValue;
+	if(canAfford(resourceState.available, building.cost))
+		return score;
+
+	const int turnsTo = turnsToAfford(resourceState.available, resourceState.dailyIncome, building.cost);
+	bool haveEverythingButGold = true;
+	for(size_t index = 0; index < building.cost.size(); ++index)
+	{
+		if(index != EGameResID::GOLD && resourceAt(resourceState.available, index) < building.cost[index])
+			haveEverythingButGold = false;
+	}
+
+	if(turnsTo == INT_MAX)
+		return 0;
+	if(!haveEverythingButGold)
+		score /= turnsTo;
+	return score;
+}
+
+float evaluateBuildings(const PriorityEvaluationInput & input, const PriorityEvaluationLimits & limits)
+{
+	const auto & goal = input.goal;
+	const auto & rewards = input.rewards;
+	if(limits.maximumArmyLossForTask - goal.armyLossRatio < 0)
+		return 0;
+	//If we already have locked resources, we don't look at other buildings
+	if(input.resourceState.lockedResourceMarketValue > 0)
+		return 0;
+
+	// TODO: Mircea: See if evaluateConquestValue can be reused here as well, to test, don't want to disturb building logic
+	float score = rewards.conquestValue * 1000;
+	score += rewards.strategicalValue * 1000;
+	score += rewards.goldReward;
+	score = evaluateSkillReward(score, rewards.skillReward, goal.armyInvolvement, goal.armyLossRatio);
+	score += rewards.armyReward;
+	score += rewards.armyGrowth;
+
+	if(input.building.costMarketValue > 0)
+		return evaluateBuildingCost(score, input);
+	if(goal.enemyHeroDangerRatio > 1 && !goal.isDefend && vstd::isAlmostZero(rewards.conquestValue))
+		return 0;
+	return score;
+}
+
+}
+
+float evaluatePriority(const PriorityEvaluationInput & input)
+{
+	const PriorityEvaluationLimits limits = evaluationLimits(input);
+	float result = 0;
+	switch(input.settings.priorityTier)
+	{
+	case PriorityEvaluator::INSTAKILL:
+		result = evaluateInstakill(input, limits);
+		break;
+	case PriorityEvaluator::INSTADEFEND:
+		result = evaluateInstaDefend(input, limits);
+		break;
+	case PriorityEvaluator::KILL:
+		result = evaluateKill(input, limits);
+		break;
+	case PriorityEvaluator::EXPLORE_AND_GATHER:
+	case PriorityEvaluator::ESCAPE:
+		result = evaluateExploreAndGather(input, limits);
+		break;
+	case PriorityEvaluator::DEFEND:
+		result = evaluateDefend(input, limits);
+		break;
+	case PriorityEvaluator::BUILDINGS:
+		result = evaluateBuildings(input, limits);
+		break;
+	default:
+		throw std::runtime_error(
+			"PriorityEvaluator::evaluate Unsupported priority: " + std::to_string(input.settings.priorityTier));
+	}
+
+	//TODO: Figure out the root cause for why evaluationContext.closestWayRatio has become -nan(ind).
+	return std::isnan(result) ? 0 : result;
+}
+
+PriorityEvaluationInput PriorityEvaluator::buildEvaluationInput(
+	Goals::TSubgoal task,
+	const int priorityTier,
+	const EvaluationContext & evaluationContext) const
+{
+	PriorityEvaluationInput input;
+	auto & settings = input.settings;
+	auto & goal = input.goal;
+	auto & rewards = input.rewards;
+	auto & building = input.building;
+	auto & resourceState = input.resourceState;
+	auto & escape = input.escape;
+
+	settings.priorityTier = priorityTier;
+	settings.daysWithoutCastle = aiNk->cc->getPlayerState(aiNk->playerID)->daysWithoutCastle.has_value();
+	settings.maximumArmyLossTarget = aiNk->settings->getMaxArmyLossTarget();
+	const auto calendar = aiNk->cc->getCalendar();
+	settings.dayOfWeek = calendar.getDayOfWeek();
+	settings.daysInWeek = calendar.getDaysInWeek();
+
+	goal.movementCost = evaluationContext.movementCost;
+	goal.danger = evaluationContext.danger;
+	goal.closestWayRatio = evaluationContext.closestWayRatio;
+	goal.armyLossRatio = evaluationContext.armyLossRatio;
+	goal.heroRole = evaluationContext.heroRole;
+	goal.turn = evaluationContext.turn;
+	goal.enemyHeroDangerRatio = evaluationContext.enemyHeroDangerRatio;
+	goal.threat = evaluationContext.threat;
+	goal.armyInvolvement = evaluationContext.armyInvolvement;
+	goal.isDefend = evaluationContext.isDefend;
+	goal.threatTurns = evaluationContext.threatTurns;
+	goal.isExchange = evaluationContext.isExchange;
+	goal.isArmyUpgrade = evaluationContext.isArmyUpgrade;
+	goal.isHero = evaluationContext.isHero;
+	goal.isEnemy = evaluationContext.isEnemy;
+	goal.explorePriority = evaluationContext.explorePriority;
+	goal.powerRatio = evaluationContext.powerRatio;
+
+	rewards.armyReward = evaluationContext.armyReward;
+	rewards.armyGrowth = evaluationContext.armyGrowth;
+	rewards.goldReward = evaluationContext.goldReward;
+	rewards.goldCost = evaluationContext.goldCost;
+	rewards.skillReward = evaluationContext.skillReward;
+	rewards.strategicalValue = evaluationContext.strategicalValue;
+	rewards.conquestValue = evaluationContext.conquestValue;
+
+	building.cost.assign(evaluationContext.buildingCost.begin(), evaluationContext.buildingCost.end());
+	building.costMarketValue = evaluationContext.buildingCost.marketValue();
+	building.isTradeBuilding = evaluationContext.isTradeBuilding;
+
+	if(priorityTier == BUILDINGS)
+	{
+		const TResources resources = aiNk->getFreeResources();
+		const TResources dailyIncome = aiNk->buildAnalyzer->getDailyIncome();
+		resourceState.available.assign(resources.begin(), resources.end());
+		resourceState.dailyIncome.assign(dailyIncome.begin(), dailyIncome.end());
+		resourceState.lockedResourceMarketValue = aiNk->getLockedResources().marketValue();
+		resourceState.goldPressureOverMax = aiNk->buildAnalyzer->isGoldPressureOverMax();
+		if(building.costMarketValue > 0
+		   && !evaluationContext.isTradeBuilding
+		   && resourceAt(resourceState.available, EGameResID::WOOD) - resourceAt(building.cost, EGameResID::WOOD) < 5
+		   && resourceAt(resourceState.dailyIncome, EGameResID::WOOD) < 1)
+		{
+			for(const auto * town : aiNk->cc->getTownsInfo())
+				resourceState.hasTownWithoutMarketplace |= !town->hasBuiltResourceMarketplace();
+		}
+	}
+
+	if(priorityTier == ESCAPE && task->hero)
+	{
+		const auto currentThreat = aiNk->dangerHitMap->getTileThreat(task->hero->visitablePos()).fastestDanger;
+		const auto destinationThreat = aiNk->dangerHitMap->getTileThreat(task->tile).fastestDanger;
+		escape.hasHero = true;
+		escape.currentDangerTurn = currentThreat.turn;
+		escape.currentDanger = currentThreat.danger;
+		escape.currentThreat = currentThreat.threat;
+		escape.destinationThreat = destinationThreat.threat;
+		escape.heroTotalStrength = task->hero->getTotalStrength();
+	}
+
+	return input;
+}
+
 float PriorityEvaluator::evaluate(
 	Goals::TSubgoal task,
 	const int priorityTier,
 	const EvaluationContext & evaluationContext)
 {
-	const bool amIWithoutCastle = aiNk->cc->getPlayerState(aiNk->playerID)->daysWithoutCastle.has_value();
-	double result = 0;
-
-	{
-		float score = 0;
-
-		// TODO: Mircea: Shouldn't it default to 0 instead of 1.0 in the end?
-		const float maxWillingToLose = amIWithoutCastle ? 1
-									 : aiNk->settings->getMaxArmyLossTarget() * evaluationContext.powerRatio > 0
-										 ? aiNk->settings->getMaxArmyLossTarget() * evaluationContext.powerRatio
-										 : 1.0;
-		const float maxEnemyDangerRatio = evaluationContext.powerRatio > 0 ? evaluationContext.powerRatio : 1.0;
-		auto calendar = aiNk->cc->getCalendar();
-		const bool arriveNextWeek = calendar.getDayOfWeek() + evaluationContext.turn > calendar.getDaysInWeek();
-		const bool isEnemyTownConquest = evaluationContext.isEnemy
-			&& !evaluationContext.isHero
-			&& evaluationContext.conquestValue > MAX_CRITICAL_VALUE;
-		const float maxWillingToLoseForTask = evaluateMaxArmyLossForConquest(maxWillingToLose, evaluationContext.conquestValue, isEnemyTownConquest);
+	const PriorityEvaluationInput input = buildEvaluationInput(task, priorityTier, evaluationContext);
+	const auto & goal = input.goal;
+	const auto & rewards = input.rewards;
+	const auto & building = input.building;
+	const auto & resourceState = input.resourceState;
+	const auto & escape = input.escape;
+	const PriorityEvaluationLimits limits = evaluationLimits(input);
 
 #if NK2AI_TRACE_LEVEL >= 2
-		logAi->trace(
-			"BEFORE: priorityTier %d, Evaluated %s, armyLossRatio: %f, maxWillingToLose: %f, turn: %d, turns main: %f, scout: %f, armyInvolvement: %f, "
-			"goldReward: %f, goldCost: %d, armyReward: %f, armyGrowth: %f, skillReward: %f, danger: %d, threatTurns: %d, threat: %d, "
-			"heroRole: %s, strategicalValue: %f, conquestValue: %f, buildingCost.marketValue: %f, closestWayRatio: %f, enemyHeroDangerRatio: %f, "
-			"maxEnemyDangerRatio: %f, explorePriority: %d, isDefend: %d, isEnemy: %d, arriveNextWeek: %d, powerRatio: %f",
-			priorityTier,
-			task->toString(),
-			evaluationContext.armyLossRatio,
-			maxWillingToLose,
-			static_cast<int>(evaluationContext.turn),
-			evaluationContext.getMovementCost(HeroRole::MAIN),
-			evaluationContext.getMovementCost(HeroRole::SCOUT),
-			evaluationContext.armyInvolvement,
-			evaluationContext.goldReward,
-			evaluationContext.goldCost,
-			evaluationContext.armyReward,
-			evaluationContext.armyGrowth,
-			evaluationContext.skillReward,
-			evaluationContext.danger,
-			evaluationContext.threatTurns,
-			evaluationContext.threat,
-			evaluationContext.heroRole == HeroRole::MAIN ? "main" : "scout",
-			evaluationContext.strategicalValue,
-			evaluationContext.conquestValue,
-			evaluationContext.buildingCost.marketValue(),
-			evaluationContext.closestWayRatio,
-			evaluationContext.enemyHeroDangerRatio,
-			maxEnemyDangerRatio,
-			evaluationContext.explorePriority,
-			evaluationContext.isDefend,
-			evaluationContext.isEnemy,
-			arriveNextWeek,
-			evaluationContext.powerRatio);
+	logAi->trace(
+		"BEFORE: priorityTier %d, Evaluated %s, armyLossRatio: %f, maxWillingToLose: %f, turn: %d, turns main: %f, scout: %f, armyInvolvement: %f, "
+		"goldReward: %f, goldCost: %d, armyReward: %f, armyGrowth: %f, skillReward: %f, danger: %d, threatTurns: %d, threat: %d, "
+		"heroRole: %s, strategicalValue: %f, conquestValue: %f, buildingCost.marketValue: %f, closestWayRatio: %f, enemyHeroDangerRatio: %f, "
+		"maxEnemyDangerRatio: %f, explorePriority: %d, isDefend: %d, isEnemy: %d, arriveNextWeek: %d, powerRatio: %f",
+		priorityTier,
+		task->toString(),
+		goal.armyLossRatio,
+		limits.maximumArmyLoss,
+		static_cast<int>(goal.turn),
+		evaluationContext.getMovementCost(HeroRole::MAIN),
+		evaluationContext.getMovementCost(HeroRole::SCOUT),
+		goal.armyInvolvement,
+		rewards.goldReward,
+		rewards.goldCost,
+		rewards.armyReward,
+		rewards.armyGrowth,
+		rewards.skillReward,
+		goal.danger,
+		goal.threatTurns,
+		goal.threat,
+		goal.heroRole == HeroRole::MAIN ? "main" : "scout",
+		rewards.strategicalValue,
+		rewards.conquestValue,
+		building.costMarketValue,
+		goal.closestWayRatio,
+		goal.enemyHeroDangerRatio,
+		limits.maximumEnemyDangerRatio,
+		goal.explorePriority,
+		goal.isDefend,
+		goal.isEnemy,
+		limits.arriveNextWeek,
+		goal.powerRatio);
 #endif
 
-		switch (priorityTier)
-		{
-			case INSTAKILL: //Take towns / kill heroes in immediate reach
-			{
-				if(evaluationContext.turn > 0 || evaluationContext.isExchange || evaluationContext.isDefend)
-					return 0;
-				if(evaluationContext.movementCost >= 1)
-					return 0;
-
-				// TODO: Mircea: Ensure defenseValue is taken into account. See AINodeStorage::evaluateArmyLoss and CCreatureSet::getArmyStrength
-				// TODO: Mircea: make it dynamic, allow higher risk for killing a higher risk hero if it leads to killing an entire player. See conquestValue
-				if(maxWillingToLoseForTask - evaluationContext.armyLossRatio < 0)
-					return 0;
-
-				score = evaluateConquestValue(score, evaluationContext.conquestValue, evaluationContext.armyInvolvement);
-				score = evaluateArmyLossRatio(score, evaluationContext.armyLossRatio, evaluationContext.heroRole);
-				if(vstd::isAlmostZero(score) || (evaluationContext.enemyHeroDangerRatio > maxEnemyDangerRatio && !amIWithoutCastle))
-					return 0;
-
-				score *= evaluationContext.closestWayRatio;
-				score = evaluateMovement(score, evaluationContext.movementCost);
-				break;
-			}
-			case INSTADEFEND: //Defend immediately threatened towns
-			{
-				if(!evaluationContext.isDefend)
-					return 0;
-				// TODO: Mircea: Often is better to die as long as you're almost destroying the opponent. To revisit
-				if(maxWillingToLoseForTask - evaluationContext.armyLossRatio < 0)
-					return 0;
-				if(evaluationContext.isEnemy && evaluationContext.turn > 0)
-					return 0;
-				const bool canPrepareForNextTurnThreat = evaluationContext.turn == 0 && evaluationContext.threatTurns == 1;
-				if(evaluationContext.threatTurns <= evaluationContext.turn || canPrepareForNextTurnThreat)
-				{
-					// TODO: Mircea: Too many heroes are rushing for INSTADEFEND.
-					// We need some kind of smart selection of who to go, not everyone qualified
-					// Probably apply normal fight calculation as in others + filter out unnecessary ones in makeTurn buildPlan
-
-					const float OPTIMAL_PERCENTAGE = 0.75f; // We want army to be 75% of the threat
-					float optimalStrength = evaluationContext.threat * OPTIMAL_PERCENTAGE;
-
-					// Calculate how far the army is from optimal strength
-					float deviation = std::abs(evaluationContext.armyInvolvement - optimalStrength);
-					float deviationPercentage = deviation / evaluationContext.threat;
-					// Calculate score: 1.0 is perfect, decreasing as deviation increases
-					score = 1.0f / (1.0f + deviationPercentage);
-
-					score *= evaluationContext.closestWayRatio;
-					score = evaluateMovement(score, evaluationContext.movementCost);
-				}
-				break;
-			}
-			case KILL: //Take towns / kill heroes that are further away
-			{
-				if(evaluationContext.isDefend)
-					return 0;
-				// TODO: Mircea: Ensure defenseValue is taken into account. See AINodeStorage::evaluateArmyLoss and CCreatureSet::getArmyStrength
-				// if (evaluationContext.defenseValue < 2 && evaluationContext.enemyHeroDangerRatio > involvedStrengthOutOfTotalRatio)
-					// return 0;
-				if (evaluationContext.turn > 0 && evaluationContext.isHero)
-					return 0;
-				if (arriveNextWeek && evaluationContext.isEnemy)
-					return 0;
-				score = evaluateConquestValue(score, evaluationContext.conquestValue, evaluationContext.armyInvolvement);
-				// TODO: Mircea: Last part of the if looks strange, to revisit
-				if(vstd::isAlmostZero(score)
-				   || (evaluationContext.enemyHeroDangerRatio > maxEnemyDangerRatio && (evaluationContext.turn > 0 || evaluationContext.isExchange)
-					   && !amIWithoutCastle))
-					return 0;
-				if (maxWillingToLoseForTask - evaluationContext.armyLossRatio < 0)
-					return 0;
-
-				score = evaluateArmyLossRatio(score, evaluationContext.armyLossRatio, evaluationContext.heroRole);
-
-				score *= evaluationContext.closestWayRatio;
-				score = evaluateMovement(score, evaluationContext.movementCost);
-				break;
-			}
-			case EXPLORE_AND_GATHER:
-			case ESCAPE:
-			// TODO: Mircea: Should not go to something that gives army if no slots available in the hero, but probably not in the evaluator, but in the finder
-			// task.get()->hero->getSlotFor(creature, 7) == false (not sure I get to know which creature is there in Orc Tower building)
-			// /// so I can't know for sure if it fits my stacks or not, but at least we can avoid going there with all 7 stacks occupied by other units
-			// task.get()->hero->getFreeSlots(7) == 7
-			// getDuplicatingSlots(task.get()->hero) == false
-			{
-				if(evaluationContext.conquestValue > 0)
-					return 0;
-				if(evaluationContext.isDefend)
-					return 0;
-				if(evaluationContext.buildingCost.marketValue() > 0)
-					return 0;
-				if(maxWillingToLoseForTask - evaluationContext.armyLossRatio < 0)
-					return 0;
-
-				if(priorityTier == EXPLORE_AND_GATHER && evaluationContext.enemyHeroDangerRatio > maxEnemyDangerRatio)
-					return 0;
-				if(priorityTier == ESCAPE && task->hero)
-				{
-					const auto currentTileThreat = aiNk->dangerHitMap->getTileThreat(task->hero->visitablePos());
-					if(currentTileThreat.fastestDanger.turn < 1 && currentTileThreat.fastestDanger.danger > task->hero->getTotalStrength())
-					{
-						// Encourage routes which go away of the threat
-						const auto currentTileThreatVal = currentTileThreat.fastestDanger.threat;
-						const auto destTileThreatVal = aiNk->dangerHitMap->getTileThreat(task->tile).fastestDanger.threat;
-						const auto delta = currentTileThreatVal - destTileThreatVal;
-						if(delta > 0)
-						{
-							logAi->trace("priorityTier %d, Encouraging route with less threat delta: %f", priorityTier, delta);
-							score += delta;
-						}
-						else
-							logAi->trace("priorityTier %d, Cannot encourage route because it has a negative threat delta: %f. Hoping hero will live", priorityTier, delta);
-					}
-				}
-
-				// TODO: Mircea: Not sure this makes sense anymore, deactivating for now, to test more and delete in the end
-				// if(evaluationContext.enemyHeroDangerRatio > involvedStrengthOutOfTotalRatio && !evaluationContext.isDefend && priorityTier != FAR_HUNTER_GATHER)
-					// return 0;
-				// TODO: Mircea: Not sure these make sense anymore, deactivating for now, to test more and delete in the end
-				// if(priorityTier != FAR_HUNTER_GATHER && evaluationContext.isDefend
-				//    && (evaluationContext.enemyHeroDangerRatio > involvedStrengthOutOfTotalRatio || evaluationContext.threatTurns > 0 || evaluationContext.turn > 0))
-				// 	return 0;
-				// TODO: Mircea: Candidate to re-include arriveNextWeek with !isExploration or > 0, but might prevent fights far away, maybe just discourage
-				// if(priorityTier != FAR_HUNTER_GATHER
-				//    && ((evaluationContext.enemyHeroDangerRatio > 0 && arriveNextWeek) || evaluationContext.enemyHeroDangerRatio > involvedStrengthOutOfTotalRatio))
-				// 	return 0;
-
-				const auto requiresBattle = evaluationContext.armyLossRatio > 0 || evaluationContext.danger > 0;
-				score += evaluationContext.strategicalValue * 1000;
-				if(evaluationContext.explorePriority > 0)
-				{
-					score = 600.0f / evaluationContext.explorePriority;
-
-					// Encourage exploration for MAIN that requires battles, so SCOUTs can continue exploring
-					if(evaluationContext.heroRole == MAIN && requiresBattle)
-						score *= 2;
-				}
-
-				if(evaluationContext.goldReward > 0)
-				{
-					// try to balance other resources vs gold, especially 2500 gold treasures
-					score += evaluationContext.goldReward > 500 ? evaluationContext.goldReward / 2.0f : evaluationContext.goldReward * 2.0f;
-
-					if(evaluationContext.heroRole == MAIN)
-					{
-						if(requiresBattle)
-							// Encourage MAIN to fight for crypts and similar
-							score *= 2;
-						else
-							// Discourage MAIN to waste time picking resources if they don't require a fight
-							score *= 0.33;
-					}
-				}
-
-				if(evaluationContext.skillReward > 0)
-				{
-					if(evaluationContext.heroRole == MAIN)
-					{
-						score = 1000 + evaluateSkillReward(score, evaluationContext.skillReward, evaluationContext.armyInvolvement, evaluationContext.armyLossRatio);
-
-						// Encourage skill increases before battles
-						if(!requiresBattle)
-							score *= 3;
-					}
-					else
-						// TODO: Mircea: Improve logic so that skill reward should be 0 for SCOUTs for one time things like a scholar, but allowed for buildings that give to all visiting heroes
-						// TODO: Mircea: Ease the restriction after 1 month or a bit more, because MAINs had enough time to grow, avoiding a SPAM of role shifts for each upgrade a SCOUT gets
-						// Discourage SCOUTs to pick-up skills/artifacts, otherwise it creates a mess with shifting MAIN responsibility.
-						// MAINs grow and fight, SCOUTs do the groundwork.
-						score = std::max(1.0f, score / 1000.0f);
-				}
-
-				score += evaluationContext.heroRole == MAIN ? evaluationContext.armyReward : evaluationContext.armyReward / 10.0f;
-				// workshop (free lvl 1 units for Tower) and similar dwellings receive both armyReward and armyGrowth in evaluationContext
-				// For that reason only getDwellingArmyGrowth gets amplified towards day 7 if units are lost after
-				// Hero exchange and army upgrade are using this too
-				score += evaluationContext.armyGrowth;
-
-				if(evaluationContext.goldCost > 0)
-					// Will be outside the if, just temporary for debugging
-					score -= evaluationContext.goldCost / 4.0f; // don't include the full cost of School of Magic or others because those locations are beneficial
-				score = evaluateArmyLossRatio(score, evaluationContext.armyLossRatio, evaluationContext.heroRole);
-
-				score *= evaluationContext.closestWayRatio;
-				score = evaluateMovement(score, evaluationContext.movementCost);
-
-				break;
-			}
-			case DEFEND: //Defend whatever if nothing else is to do
-			{
-				if (evaluationContext.enemyHeroDangerRatio > maxEnemyDangerRatio)
-					return 0;
-				if (evaluationContext.isDefend || evaluationContext.isArmyUpgrade)
-					score = evaluationContext.armyInvolvement;
-
-				score *= evaluationContext.closestWayRatio;
-				score = evaluateMovement(score, evaluationContext.movementCost);
-				break;
-			}
-			case BUILDINGS: //For buildings and buying army
-			{
-				// TODO: Mircea: What's the point of this check for ::BUILDINGS? Isn't the priority itself just for buildings? To test
-				if(maxWillingToLoseForTask - evaluationContext.armyLossRatio < 0)
-					return 0;
-				//If we already have locked resources, we don't look at other buildings
-				if(aiNk->getLockedResources().marketValue() > 0)
-					return 0;
-
-				// TODO: Mircea: See if evaluateConquestValue can be reused here as well, to test, don't want to disturb building logic
-				score += evaluationContext.conquestValue * 1000;
-				score += evaluationContext.strategicalValue * 1000;
-				score += evaluationContext.goldReward;
-				score = evaluateSkillReward(score, evaluationContext.skillReward, evaluationContext.armyInvolvement, evaluationContext.armyLossRatio);
-				score += evaluationContext.armyReward;
-				score += evaluationContext.armyGrowth;
-
-				if(evaluationContext.buildingCost.marketValue() > 0)
-				{
-					if(!evaluationContext.isTradeBuilding && aiNk->getFreeResources()[EGameResID::WOOD] - evaluationContext.buildingCost[EGameResID::WOOD] < 5
-					   && aiNk->buildAnalyzer->getDailyIncome()[EGameResID::WOOD] < 1)
-					{
-						logAi->trace("priorityTier %d, Should make sure to build marketplace instead of %s", priorityTier, task->toString());
-						for(auto town : aiNk->cc->getTownsInfo())
-						{
-							if(!town->hasBuiltResourceMarketplace())
-								return 0;
-						}
-					}
-
-					score += 1000;
-					auto resourcesAvailable = evaluationContext.evaluator.aiNk->getFreeResources();
-					auto income = aiNk->buildAnalyzer->getDailyIncome();
-
-					// TODO: Mircea: Might want to use isGoldPressureOverMax or canAfford inside hunter gather as well if it's not already applied before
-					if(aiNk->buildAnalyzer->isGoldPressureOverMax())
-						score /= evaluationContext.buildingCost.marketValue();
-					if(!resourcesAvailable.canAfford(evaluationContext.buildingCost))
-					{
-						TResources needed = evaluationContext.buildingCost - resourcesAvailable;
-						needed.positive();
-						int turnsTo = needed.maxPurchasableCount(income);
-						bool haveEverythingButGold = true;
-
-						for(const GameResID & i : LIBRARY->resourceTypeHandler->getAllObjects())
-						{
-							if(i != GameResID::GOLD && resourcesAvailable[i] < evaluationContext.buildingCost[i])
-								haveEverythingButGold = false;
-						}
-
-						if(turnsTo == INT_MAX)
-							return 0;
-						if(!haveEverythingButGold)
-							score /= turnsTo;
-					}
-				}
-				else
-				{
-					if(evaluationContext.enemyHeroDangerRatio > 1 && !evaluationContext.isDefend && vstd::isAlmostZero(evaluationContext.conquestValue))
-						return 0;
-				}
-				break;
-			}
-			default:
-				throw std::runtime_error("PriorityEvaluator::evaluate Unsupported priority: " + std::to_string(priorityTier));
-		}
-
-		result = score;
-		//TODO: Figure out the root cause for why evaluationContext.closestWayRatio has become -nan(ind).
-		if (std::isnan(result))
-			return 0;
+	if(priorityTier == ESCAPE
+	   && rewards.conquestValue <= 0
+	   && !goal.isDefend
+	   && building.costMarketValue <= 0
+	   && limits.maximumArmyLossForTask - goal.armyLossRatio >= 0
+	   && escape.hasHero
+	   && escape.currentDangerTurn < 1
+	   && escape.currentDanger > escape.heroTotalStrength)
+	{
+		const float delta = escape.currentThreat - escape.destinationThreat;
+		if(delta > 0)
+			logAi->trace("priorityTier %d, Encouraging route with less threat delta: %f", priorityTier, delta);
+		else
+			logAi->trace("priorityTier %d, Cannot encourage route because it has a negative threat delta: %f. Hoping hero will live", priorityTier, delta);
 	}
+	if(priorityTier == BUILDINGS
+	   && limits.maximumArmyLossForTask - goal.armyLossRatio >= 0
+	   && resourceState.lockedResourceMarketValue <= 0
+	   && building.costMarketValue > 0
+	   && !building.isTradeBuilding
+	   && resourceAt(resourceState.available, EGameResID::WOOD) - resourceAt(building.cost, EGameResID::WOOD) < 5
+	   && resourceAt(resourceState.dailyIncome, EGameResID::WOOD) < 1)
+	{
+		logAi->trace("priorityTier %d, Should make sure to build marketplace instead of %s", priorityTier, task->toString());
+	}
+
+	const float result = evaluatePriority(input);
 
 #if NK2AI_TRACE_LEVEL >= 2
 	logAi->trace(
@@ -1791,31 +1989,30 @@ float PriorityEvaluator::evaluate(
 		"explorePriority: %d, isDefend: %d, isEnemy: %d, powerRatio: %f, result %f",
 		priorityTier,
 		task->toString(),
-		evaluationContext.armyLossRatio,
-		static_cast<int>(evaluationContext.turn),
+		goal.armyLossRatio,
+		static_cast<int>(goal.turn),
 		evaluationContext.getMovementCost(HeroRole::MAIN),
 		evaluationContext.getMovementCost(HeroRole::SCOUT),
-		evaluationContext.armyInvolvement,
-		evaluationContext.goldReward,
-		evaluationContext.goldCost,
-		evaluationContext.armyReward,
-		evaluationContext.armyGrowth,
-		evaluationContext.skillReward,
-		evaluationContext.danger,
-		evaluationContext.threatTurns,
-		evaluationContext.threat,
-		evaluationContext.heroRole == HeroRole::MAIN ? "main" : "scout",
-		evaluationContext.strategicalValue,
-		evaluationContext.conquestValue,
-		evaluationContext.buildingCost.marketValue(),
-		evaluationContext.closestWayRatio,
-		evaluationContext.enemyHeroDangerRatio,
-		evaluationContext.explorePriority,
-		evaluationContext.isDefend,
-		evaluationContext.isEnemy,
-		evaluationContext.powerRatio,
-		result
-	);
+		goal.armyInvolvement,
+		rewards.goldReward,
+		rewards.goldCost,
+		rewards.armyReward,
+		rewards.armyGrowth,
+		rewards.skillReward,
+		goal.danger,
+		goal.threatTurns,
+		goal.threat,
+		goal.heroRole == HeroRole::MAIN ? "main" : "scout",
+		rewards.strategicalValue,
+		rewards.conquestValue,
+		building.costMarketValue,
+		goal.closestWayRatio,
+		goal.enemyHeroDangerRatio,
+		goal.explorePriority,
+		goal.isDefend,
+		goal.isEnemy,
+		goal.powerRatio,
+		result);
 #endif
 
 	return result;

--- a/AI/Nullkiller2/Engine/PriorityEvaluator.h
+++ b/AI/Nullkiller2/Engine/PriorityEvaluator.h
@@ -86,6 +86,88 @@ struct DLL_EXPORT EvaluationContext
 	float getMovementCost(HeroRole role) const;
 };
 
+struct DLL_LINKAGE PriorityEvaluationSettings
+{
+	int32_t priorityTier = 0;
+	bool daysWithoutCastle = false;
+	float maximumArmyLossTarget = 0;
+	int32_t dayOfWeek = 0;
+	int32_t daysInWeek = 0;
+};
+
+struct DLL_LINKAGE PriorityEvaluationGoal
+{
+	float movementCost = 0;
+	uint64_t danger = 0;
+	float closestWayRatio = 0;
+	float armyLossRatio = 0;
+	HeroRole heroRole = HeroRole::SCOUT;
+	uint8_t turn = 0;
+	float enemyHeroDangerRatio = 0;
+	float threat = 0;
+	float armyInvolvement = 0;
+	bool isDefend = false;
+	int threatTurns = 0;
+	bool isExchange = false;
+	bool isArmyUpgrade = false;
+	bool isHero = false;
+	bool isEnemy = false;
+	int explorePriority = 0;
+	float powerRatio = 0;
+};
+
+struct DLL_LINKAGE PriorityEvaluationRewards
+{
+	float armyReward = 0;
+	uint64_t armyGrowth = 0;
+	int32_t goldReward = 0;
+	int32_t goldCost = 0;
+	float skillReward = 0;
+	float strategicalValue = 0;
+	float conquestValue = 0;
+};
+
+struct DLL_LINKAGE PriorityEvaluationBuilding
+{
+	std::vector<int32_t> cost;
+	int64_t costMarketValue = 0;
+	bool isTradeBuilding = false;
+};
+
+struct DLL_LINKAGE PriorityEvaluationResourceState
+{
+	std::vector<int32_t> available;
+	std::vector<int32_t> dailyIncome;
+	int64_t lockedResourceMarketValue = 0;
+	bool goldPressureOverMax = false;
+	bool hasTownWithoutMarketplace = false;
+};
+
+struct DLL_LINKAGE PriorityEvaluationEscape
+{
+	bool hasHero = false;
+	int currentDangerTurn = 0;
+	uint64_t currentDanger = 0;
+	float currentThreat = 0;
+	float destinationThreat = 0;
+	uint64_t heroTotalStrength = 0;
+};
+
+/// Complete value-only input to the NK2 priority formula. Game callbacks and
+/// mutable objects are deliberately resolved before this boundary.
+struct DLL_LINKAGE PriorityEvaluationInput
+{
+	PriorityEvaluationSettings settings;
+	PriorityEvaluationGoal goal;
+	PriorityEvaluationRewards rewards;
+	PriorityEvaluationBuilding building;
+	PriorityEvaluationResourceState resourceState;
+	PriorityEvaluationEscape escape;
+};
+
+/// Pure compiled NK2 priority formula. Its result depends only on input.
+DLL_LINKAGE float evaluatePriority(const PriorityEvaluationInput & input);
+
 class IEvaluationContextBuilder
 {
 public:
@@ -104,6 +186,10 @@ public:
 	float evaluate(Goals::TSubgoal task, int priorityTier = BUILDINGS);
 	float evaluate(Goals::TSubgoal task, int priorityTier, const EvaluationContext & evaluationContext);
 	EvaluationContext buildEvaluationContext(const Goals::TSubgoal & goal) const;
+	PriorityEvaluationInput buildEvaluationInput(
+		Goals::TSubgoal task,
+		int priorityTier,
+		const EvaluationContext & evaluationContext) const;
 
 	enum PriorityTier : int32_t
 	{
@@ -122,10 +208,6 @@ private:
 
 	std::vector<std::shared_ptr<IEvaluationContextBuilder>> evaluationContextBuilders;
 
-	static float evaluateMovement(float score, float movementCost);
-	static float evaluateArmyLossRatio(float score, float armyLossRatio, HeroRole heroRole);
-	static float evaluateSkillReward(float score, float skillReward, float armyInvolvement, float armyLossRatio);
-	static float evaluateConquestValue(float score, float conquestValue, float armyInvolvement);
 };
 
 }

--- a/config/ai/nk2ai/policies/reference-shadow.json
+++ b/config/ai/nk2ai/policies/reference-shadow.json
@@ -1,0 +1,8 @@
+{
+	"schemaVersion": 1,
+	"name": "reference-shadow",
+	"type": "lua",
+	"script": "reference.lua",
+	"shadow": true,
+	"parameters": {}
+}

--- a/config/ai/nk2ai/policies/reference.json
+++ b/config/ai/nk2ai/policies/reference.json
@@ -1,0 +1,8 @@
+{
+	"schemaVersion": 1,
+	"name": "reference",
+	"type": "lua",
+	"script": "reference.lua",
+	"shadow": false,
+	"parameters": {}
+}

--- a/config/ai/nk2ai/policies/reference.lua
+++ b/config/ai/nk2ai/policies/reference.lua
@@ -1,0 +1,401 @@
+local Policy = {}
+
+-- This is the executable specification of NK2's compiled priority formula.
+-- It intentionally contains no tuning: copy it before changing strategy.
+-- It reads only the request so captured inputs are sufficient for differential
+-- tests, although experimental policies may also use the standard VCMI globals.
+-- A positive score keeps a candidate; zero rejects it. Higher scores win
+-- within the first priority tier that produces any accepted candidates.
+
+local BUILDINGS = "buildings"
+local INSTAKILL = "instakill"
+local INSTADEFEND = "instaDefend"
+local KILL = "kill"
+local ESCAPE = "escape"
+local EXPLORE_AND_GATHER = "exploreAndGather"
+local DEFEND = "defend"
+
+local RESOURCE_NAMES = { "wood", "mercury", "ore", "sulfur", "crystal", "gems", "gold" }
+
+-- Lua calculates with doubles, while NK2 stores priorities as C++ floats.
+-- These helpers round at the same expression boundaries as the C++ scorer;
+-- retaining them is necessary for exact shadow-mode and test parity.
+local function add(left, right)
+	return float32(float32(left) + float32(right))
+end
+
+local function subtract(left, right)
+	return float32(float32(left) - float32(right))
+end
+
+local function multiply(left, right)
+	return float32(float32(left) * float32(right))
+end
+
+local function divide(left, right)
+	return float32(float32(left) / float32(right))
+end
+
+local function almostZero(value)
+	return math.abs(value) <= 0.00001
+end
+
+local function evaluateMovement(score, movementCost)
+	-- movementCost is measured in hero-turns. Sub-turn routes are rewarded for
+	-- using less movement; routes of one turn or more receive a steeper penalty.
+	if movementCost > 0 then
+		if movementCost < 1 then
+			score = divide(score, float32(movementCost ^ float32(0.6)))
+		else
+			local power = float32(movementCost ^ float32(1.3))
+			score = float32(score / (0.75 + power))
+		end
+	end
+	return score
+end
+
+local function evaluateArmyLossRatio(score, armyLossRatio, heroRole)
+	-- Expected losses reduce every score. Any lossy task is additionally a poor
+	-- use of a scout, whose job is exploration rather than carrying the army.
+	if armyLossRatio > 0 then
+		score = subtract(score, multiply(score, armyLossRatio))
+		if heroRole ~= "main" then
+			score = divide(score, 5.0)
+		end
+	end
+	return score
+end
+
+local function evaluateSkillReward(score, skillReward, armyInvolvement, armyLossRatio)
+	local survivingArmy = subtract(1.0, armyLossRatio)
+	local reward = multiply(skillReward, armyInvolvement)
+	reward = multiply(reward, survivingArmy)
+	reward = multiply(reward, 0.05)
+	return add(score, reward)
+end
+
+local function evaluateConquestValue(score, conquestValue, armyInvolvement)
+	-- Conquest value replaces accumulated reward with the strategic value of
+	-- committing this army; ordinary non-conquest tasks keep their prior score.
+	if conquestValue > 0 then
+		return multiply(armyInvolvement, conquestValue)
+	end
+	return score
+end
+
+local function maximumArmyLoss(state, evaluation)
+	-- Losing the last town permits desperate fights. Otherwise willingness to
+	-- take losses scales with how much of the available army this hero carries.
+	if state.daysWithoutCastle then
+		return float32(1.0)
+	end
+	local scaled = multiply(state.maximumArmyLossTarget, evaluation.powerRatio)
+	if scaled > 0 then
+		return scaled
+	end
+	return float32(1.0)
+end
+
+local function maximumArmyLossForTask(state, evaluation)
+	local base = maximumArmyLoss(state, evaluation)
+	-- Important enemy towns justify progressively more risk, capped at 75% of
+	-- the committed army. Enemy heroes do not receive this relaxation.
+	local enemyTownConquest = evaluation.isEnemy
+		and not evaluation.isHero
+		and evaluation.conquestValue > 2.0
+	if not enemyTownConquest or evaluation.conquestValue <= 2.0 then
+		return base
+	end
+	local conquestPressure = multiply(subtract(evaluation.conquestValue, 2.0), 0.05)
+	return math.min(add(base, conquestPressure), float32(0.75))
+end
+
+local function buildingTurnsToAfford(state, evaluation)
+	-- The slowest missing resource determines the wait. A resource with no
+	-- income makes an unaffordable building unreachable through waiting alone.
+	local turns = 0
+	for _, resource in ipairs(state.resourceNames or RESOURCE_NAMES) do
+		local cost = evaluation.buildingCost.resources[resource]
+		local needed = math.max(0, cost - state.resources[resource])
+		if needed > 0 then
+			local income = state.dailyIncome[resource]
+			if income == 0 then
+				return nil
+			end
+			turns = math.max(turns, math.ceil(needed / income))
+		end
+	end
+	return turns
+end
+
+local function canAffordBuilding(state, evaluation)
+	for _, resource in ipairs(state.resourceNames or RESOURCE_NAMES) do
+		if state.resources[resource] < evaluation.buildingCost.resources[resource] then
+			return false
+		end
+	end
+	return true
+end
+
+local function missesNonGoldResource(state, evaluation)
+	for _, resource in ipairs(state.resourceNames or RESOURCE_NAMES) do
+		local missing = state.resources[resource] < evaluation.buildingCost.resources[resource]
+		if resource ~= "gold" and missing then
+			return true
+		end
+	end
+	return false
+end
+
+local function evaluateCandidate(request, candidate)
+	local input = candidate.rankingInput
+	local tier = input.priorityTier
+	local state = input.state
+	local evaluation = input.evaluation
+	-- Some building tasks arrive with an explicit priority from their caller;
+	-- the compiled evaluator preserves it instead of recalculating the task.
+	if tier == BUILDINGS and candidate.initialPriority > 0 then
+		return float32(candidate.initialPriority)
+	end
+
+	local score = float32(0)
+	local maximumLoss = maximumArmyLossForTask(state, evaluation)
+	local maximumEnemyDangerRatio = evaluation.powerRatio > 0 and evaluation.powerRatio or 1.0
+	local arriveNextWeek = state.dayOfWeek + evaluation.turn > state.daysInWeek
+
+	-- Priority tiers are attempted in this order: immediate conquest, immediate
+	-- defense, conquest, escape, exploration/gathering, then fallback defense.
+	-- BUILDINGS is used separately when choosing economic and recruitment tasks.
+	if tier == INSTAKILL then
+		-- Only safe, same-turn conquests reachable in less than one hero-turn.
+		if evaluation.turn > 0 or evaluation.isExchange or evaluation.isDefend then
+			return 0
+		end
+		if evaluation.movementCost >= 1 then
+			return 0
+		end
+		if subtract(maximumLoss, evaluation.armyLossRatio) < 0 then
+			return 0
+		end
+		score = evaluateConquestValue(score, evaluation.conquestValue, evaluation.armyInvolvement)
+		score = evaluateArmyLossRatio(score, evaluation.armyLossRatio, evaluation.heroRole)
+		if almostZero(score)
+			or (evaluation.enemyHeroDangerRatio > maximumEnemyDangerRatio and not state.daysWithoutCastle) then
+			return 0
+		end
+		score = multiply(score, evaluation.closestWayRatio)
+		return evaluateMovement(score, evaluation.movementCost)
+	end
+
+	if tier == INSTADEFEND then
+		-- Prefer the response closest to 75% of the incoming threat: enough to be
+		-- useful without committing every available army to the same defense.
+		if not evaluation.isDefend then
+			return 0
+		end
+		if subtract(maximumLoss, evaluation.armyLossRatio) < 0 then
+			return 0
+		end
+		if evaluation.isEnemy and evaluation.turn > 0 then
+			return 0
+		end
+		local canPrepareForNextTurnThreat = evaluation.turn == 0 and evaluation.threatTurns == 1
+		if evaluation.threatTurns <= evaluation.turn or canPrepareForNextTurnThreat then
+			local optimalStrength = multiply(evaluation.threat, 0.75)
+			local deviation = math.abs(subtract(evaluation.armyInvolvement, optimalStrength))
+			local deviationPercentage = divide(deviation, evaluation.threat)
+			score = divide(1.0, add(1.0, deviationPercentage))
+			score = multiply(score, evaluation.closestWayRatio)
+			score = evaluateMovement(score, evaluation.movementCost)
+		end
+		return score
+	end
+
+	if tier == KILL then
+		-- This tier handles non-immediate conquest, but deliberately avoids
+		-- chasing heroes across turns or starting enemy tasks in the next week.
+		if evaluation.isDefend then
+			return 0
+		end
+		if evaluation.turn > 0 and evaluation.isHero then
+			return 0
+		end
+		if arriveNextWeek and evaluation.isEnemy then
+			return 0
+		end
+		score = evaluateConquestValue(score, evaluation.conquestValue, evaluation.armyInvolvement)
+		if almostZero(score)
+			or (evaluation.enemyHeroDangerRatio > maximumEnemyDangerRatio
+				and (evaluation.turn > 0 or evaluation.isExchange)
+				and not state.daysWithoutCastle) then
+			return 0
+		end
+		if subtract(maximumLoss, evaluation.armyLossRatio) < 0 then
+			return 0
+		end
+		score = evaluateArmyLossRatio(score, evaluation.armyLossRatio, evaluation.heroRole)
+		score = multiply(score, evaluation.closestWayRatio)
+		return evaluateMovement(score, evaluation.movementCost)
+	end
+
+	if tier == EXPLORE_AND_GATHER or tier == ESCAPE then
+		-- These tiers are exclusively for non-conquest, non-defense, non-building
+		-- work. Escape can seed the score with the reduction in immediate threat.
+		if evaluation.conquestValue > 0 or evaluation.isDefend
+			or evaluation.buildingCost.marketValue > 0 then
+			return 0
+		end
+		if subtract(maximumLoss, evaluation.armyLossRatio) < 0 then
+			return 0
+		end
+		if tier == EXPLORE_AND_GATHER and evaluation.enemyHeroDangerRatio > maximumEnemyDangerRatio then
+			return 0
+		end
+		if tier == ESCAPE and input.escape.hasHero then
+			local escape = input.escape
+			if escape.currentDangerTurn < 1 and escape.currentDanger > escape.heroTotalStrength then
+				local delta = subtract(escape.currentThreat, escape.destinationThreat)
+				if delta > 0 then
+					score = add(score, delta)
+				end
+			end
+		end
+
+		local requiresBattle = evaluation.armyLossRatio > 0 or evaluation.danger > 0
+		score = add(score, multiply(evaluation.strategicalValue, 1000.0))
+		if evaluation.explorePriority > 0 then
+			-- Exploration priority is an ordinal where 1 is best. It replaces the
+			-- generic strategic score so known frontier quality drives this task.
+			score = divide(600.0, evaluation.explorePriority)
+			if evaluation.heroRole == "main" and requiresBattle then
+				score = multiply(score, 2.0)
+			end
+		end
+
+		if evaluation.goldReward > 0 then
+			-- Small rewards are favored, while rewards above 500 are discounted to
+			-- keep large treasure estimates from overwhelming strategic work.
+			local goldValue
+			if evaluation.goldReward > 500 then
+				goldValue = divide(evaluation.goldReward, 2.0)
+			else
+				goldValue = multiply(evaluation.goldReward, 2.0)
+			end
+			score = add(score, goldValue)
+			if evaluation.heroRole == "main" then
+				if requiresBattle then
+					score = multiply(score, 2.0)
+				else
+					score = float32(score * 0.33)
+				end
+			end
+		end
+
+		if evaluation.skillReward > 0 then
+			-- Main heroes receive permanent progression; scouts are strongly
+			-- discouraged to avoid destabilizing NK2's main/scout role assignment.
+			if evaluation.heroRole == "main" then
+				score = add(1000.0, evaluateSkillReward(
+					score,
+					evaluation.skillReward,
+					evaluation.armyInvolvement,
+					evaluation.armyLossRatio))
+				if not requiresBattle then
+					score = multiply(score, 3.0)
+				end
+			else
+				score = math.max(float32(1.0), divide(score, 1000.0))
+			end
+		end
+
+		if evaluation.heroRole == "main" then
+			score = add(score, evaluation.armyReward)
+		else
+			score = add(score, divide(evaluation.armyReward, 10.0))
+		end
+		score = add(score, evaluation.armyGrowth)
+		if evaluation.goldCost > 0 then
+			score = subtract(score, divide(evaluation.goldCost, 4.0))
+		end
+		score = evaluateArmyLossRatio(score, evaluation.armyLossRatio, evaluation.heroRole)
+		score = multiply(score, evaluation.closestWayRatio)
+		return evaluateMovement(score, evaluation.movementCost)
+	end
+
+	if tier == DEFEND then
+		-- Last-resort defense and army upgrades are ranked only by the army they
+		-- involve, after danger, route-sharing, and movement penalties.
+		if evaluation.enemyHeroDangerRatio > maximumEnemyDangerRatio then
+			return 0
+		end
+		if evaluation.isDefend or evaluation.isArmyUpgrade then
+			score = float32(evaluation.armyInvolvement)
+		end
+		score = multiply(score, evaluation.closestWayRatio)
+		return evaluateMovement(score, evaluation.movementCost)
+	end
+
+	if tier == BUILDINGS then
+		-- Building and recruitment choices combine their benefits, then reject
+		-- plans that conflict with reserved resources or cannot become affordable.
+		if subtract(maximumLoss, evaluation.armyLossRatio) < 0 then
+			return 0
+		end
+		if state.lockedResourceMarketValue > 0 then
+			return 0
+		end
+		score = add(score, multiply(evaluation.conquestValue, 1000.0))
+		score = add(score, multiply(evaluation.strategicalValue, 1000.0))
+		score = add(score, evaluation.goldReward)
+		score = evaluateSkillReward(
+			score,
+			evaluation.skillReward,
+			evaluation.armyInvolvement,
+			evaluation.armyLossRatio)
+		score = add(score, evaluation.armyReward)
+		score = add(score, evaluation.armyGrowth)
+
+		if evaluation.buildingCost.marketValue > 0 then
+			local remainingWood = state.resources.wood - evaluation.buildingCost.resources.wood
+			if not evaluation.isTradeBuilding and remainingWood < 5
+				and state.dailyIncome.wood < 1 and state.hasTownWithoutMarketplace then
+				return 0
+			end
+			score = add(score, 1000.0)
+			if state.goldPressureOverMax then
+				score = divide(score, evaluation.buildingCost.marketValue)
+			end
+			if not canAffordBuilding(state, evaluation) then
+				local turnsTo = buildingTurnsToAfford(state, evaluation)
+				if turnsTo == nil then
+					return 0
+				end
+				if missesNonGoldResource(state, evaluation) then
+					score = divide(score, turnsTo)
+				end
+			end
+		elseif evaluation.enemyHeroDangerRatio > 1 and not evaluation.isDefend
+			and almostZero(evaluation.conquestValue) then
+			return 0
+		end
+		return score
+	end
+
+	error("Unsupported priority tier " .. tostring(tier))
+end
+
+function Policy.rank(request)
+	local scores = {}
+	for _, candidate in ipairs(request.candidates) do
+		local score = evaluateCandidate(request, candidate)
+		-- Match the compiled evaluator's final guard against an invalid route
+		-- ratio or another calculation producing NaN.
+		if score ~= score then
+			score = 0
+		end
+		table.insert(scores, { id = candidate.id, score = float32(score) })
+	end
+	return { scores = scores }
+end
+
+return Policy

--- a/docs/developers/NK2_Lua_Ranking.md
+++ b/docs/developers/NK2_Lua_Ranking.md
@@ -1,0 +1,115 @@
+# Nullkiller Lua ranking policies
+
+Nullkiller can optionally replace its compiled candidate scores with scores from a Lua policy. The default remains the compiled `PriorityEvaluator`; no Lua state is created and no policy data is collected unless a policy is explicitly selected.
+
+The bundled `config/ai/nk2ai/policies/reference.lua` is a readable translation of the complete compiled ranking algorithm. It covers all priority tiers and is intended to produce the same acceptance decisions and scores as the pure C++ `evaluatePriority` scorer. Keep it free of experimental tuning: copy it when starting a new policy.
+
+## Selecting a policy
+
+Set `VCMI_NK2_POLICY` to a JSON policy profile before starting VCMI:
+
+```sh
+VCMI_NK2_POLICY=/path/to/reference.json vcmiclient
+```
+
+Use a color-suffixed variable such as `VCMI_NK2_POLICY_RED` or `VCMI_NK2_POLICY_BLUE` to select a different policy for one player. Color names are uppercase: `RED`, `BLUE`, `TAN`, `GREEN`, `ORANGE`, `PURPLE`, `TEAL`, and `PINK`. The per-player value takes precedence over `VCMI_NK2_POLICY`. An unset value or `builtin` uses the compiled evaluator.
+
+A profile has this format:
+
+```json
+{
+	"schemaVersion": 1,
+	"name": "my-policy",
+	"type": "lua",
+	"script": "my-policy.lua",
+	"shadow": false,
+	"parameters": {}
+}
+```
+
+Relative script paths are resolved from the profile directory. Parameters are copied to `request.parameters`.
+
+The bundled profiles are:
+
+- `reference.json`: apply the reference Lua scores.
+- `reference-shadow.json`: run the same policy and compare it with compiled scores, but keep using the compiled scores.
+
+Shadow mode logs score or acceptance mismatches. It is useful when changing the compiled evaluator, the request schema, or the reference policy.
+
+## Lua contract
+
+A script returns a table with a `rank` function:
+
+```lua
+local Policy = {}
+
+function Policy.rank(request)
+	local scores = {}
+	for _, candidate in ipairs(request.candidates) do
+		table.insert(scores, {
+			id = candidate.id,
+			score = candidate.baselinePriority,
+		})
+	end
+	return { scores = scores }
+end
+
+return Policy
+```
+
+The result must contain every candidate ID exactly once. IDs must be non-negative integers and scores must be finite numbers. A score at or below zero rejects a candidate in the same way as the compiled evaluator. Invalid output or a Lua error leaves the compiled ranking unchanged.
+
+The request uses schema version 1 and contains:
+
+- `player`, `playerId`, and `day`.
+- `priorityTier` and `priorityTierId`. Prefer the named tier: `buildings`, `instakill`, `instaDefend`, `kill`, `escape`, `exploreAndGather`, or `defend`.
+- `parameters`, copied from the selected profile.
+- `state`, the player's value-only strategic state.
+- `candidates`, including their compiled scores and complete ranking inputs.
+
+`state` contains:
+
+- Named resource objects: `resources`, `dailyIncome`, and `lockedResources`. Their keys are `wood`, `mercury`, `ore`, `sulfur`, `crystal`, `gems`, and `gold`.
+- Resource summaries: `resourceMarketValue`, `lockedResourceMarketValue`, `goldPressureOverMax`, and `hasTownWithoutMarketplace`.
+- Risk and calendar data: `maximumArmyLossTarget`, `daysWithoutCastle`, `dayOfWeek`, and `daysInWeek`.
+- Progress counts: heroes, towns, owned and known objects, revealed tiles, buildings, fort levels, experience, levels, and army strengths.
+- Per-hero values: ID, level, experience, army and total strength, movement, and mana.
+- Per-town values: ID, building, fort, hall, and mage-guild levels, army strength, named daily income, and marketplace availability.
+
+Each candidate contains:
+
+- `id`, `goalType`, `goalTypeId`, and a diagnostic `description`.
+- `initialPriority`, `baselinePriority`, and `baselineAccepted`.
+- Optional `heroId`, `townId`, and `objectId`, plus the target coordinates.
+- `rankingInput`, the exact value-only input shared by the C++ and Lua scorers. It contains the named tier, scorer-specific state, evaluation values, and escape threat values. Resource maps use the names `wood`, `mercury`, `ore`, `sulfur`, `crystal`, `gems`, and `gold`.
+- `evaluation`, a convenience copy of the evaluation part of `rankingInput`, extended with movement by role, mana cost, defense value, and sailing status for experimental policies.
+
+The request contains copies of these values, so policies can use NK2's calculated features without repeating expensive analysis. Policies also run in VCMI's normal Lua context and receive its standard globals:
+
+- `GAME`, the read-only query interface for the current game.
+- `LIBRARY`, the static game-content catalogue.
+- `ENUM`, the engine's named enumerations.
+- `require`, for loading Lua modules from the VCMI virtual filesystem.
+- `print`, redirected to the VCMI log.
+
+This lets experimental policies combine the stable ranking request with game details and reusable Lua modules. It does not grant a server callback or direct game-state mutation.
+
+## Lua environment and reproducibility
+
+The policy uses the same Lua host, bindings, standard libraries, and safety-related global cleanup as other VCMI scripts. The `io`, `os`, `package`, `debug`, dynamic-loading, garbage-collection, and random-number APIs are unavailable. VCMI does not impose policy-specific memory or instruction limits.
+
+The bundled reference policy is deterministic, stateless, and reads only the request. Therefore captured ranking requests are complete differential-test inputs. Experimental policies may query `GAME` or retain Lua state, but then request fixtures alone cannot reproduce their decisions; validate them from complete saves with the same AI memory and policy version. Stateless policies remain preferable because they also reproduce cleanly across save and load.
+
+Lua normally calculates with doubles while NK2 stores scores as C++ `float`. The host-provided `float32(value)` helper rounds intermediate results to a C++ float. The reference policy uses it at the same points as the compiled algorithm to preserve parity.
+
+## Maintaining the reference
+
+The differential tests store inputs, not expected scores. For every fixture they evaluate the committed input with the current C++ scorer, pass that same input to Lua, and compare the outputs. This makes the compiled implementation the live oracle and prevents an old golden value from allowing the implementations to drift together unnoticed.
+
+When `evaluatePriority` changes:
+
+1. Make the equivalent change in `reference.lua` without adding tunable behavior.
+2. Run the `Nullkiller2_Engine_DecisionPolicy` tests. They exercise all seven tiers and compare Lua directly with the current compiled scorer over captured inputs.
+3. Run the reference shadow profile over representative maps and days. Accept no score, acceptance, or selected-candidate mismatches.
+
+Experimental policies should live in separate files. This keeps the reference a stable baseline for reviewing and measuring later policy changes.

--- a/luascript/LuaContext.h
+++ b/luascript/LuaContext.h
@@ -39,6 +39,10 @@ public:
 	/// Returns true if the script table defines a function with the given name
 	bool hasFunction(const std::string & name);
 
+	/// Adds an engine-provided function to the script's global namespace.
+	template<lua_CFunction Function>
+	void setGlobalFunction(const std::string & name);
+
 	/// Calls a method on the script class using OOP convention.
 	/// params is pushed as self (with __index = scriptTable), remaining args follow.
 	/// Return value (if any) is converted from Lua and returned.
@@ -100,6 +104,13 @@ template<typename ReturnType, typename... Args>
 ReturnType LuaContext::callMethod(const std::string & name, const JsonNode & params, Args&&... args)
 {
 	return callImpl<ReturnType>(scriptTable, &params, name, std::forward<Args>(args)...);
+}
+
+template<lua_CFunction Function>
+void LuaContext::setGlobalFunction(const std::string & name)
+{
+	lua_pushcfunction(L, Function);
+	lua_setglobal(L, name.c_str());
 }
 
 template<typename ReturnType, typename... Args>

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -290,3 +290,16 @@ foreach(resource ${testdata})
 	set(output "${CMAKE_BINARY_DIR}/bin/test/testdata/${output}/${filename}")
 	configure_file(${resource} ${output} COPYONLY)
 endforeach()
+
+if(ENABLE_NULLKILLER2_AI)
+	configure_file(
+		${CMAKE_SOURCE_DIR}/config/ai/nk2ai/policies/reference.json
+		${CMAKE_BINARY_DIR}/bin/test/testdata/nk2/reference.json
+		COPYONLY
+	)
+	configure_file(
+		${CMAKE_SOURCE_DIR}/config/ai/nk2ai/policies/reference.lua
+		${CMAKE_BINARY_DIR}/bin/test/testdata/nk2/reference.lua
+		COPYONLY
+	)
+endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -184,6 +184,7 @@ if(ENABLE_NULLKILLER2_AI)
 		nullkiller2/Behaviors/ExplorationBehaviorTest.cpp
 		nullkiller2/Behaviors/GatherArmyBehaviorTest.cpp
 		nullkiller2/Behaviors/RecruitHeroBehaviorTest.cpp
+		nullkiller2/Engine/DecisionPolicyTest.cpp
 		nullkiller2/Engine/PriorityEvaluatorTest.cpp
 		nullkiller2/Engine/TaskFailureTest.cpp
 		nullkiller2/Goals/BuyArmyTest.cpp

--- a/test/nullkiller2/Engine/DecisionPolicyTest.cpp
+++ b/test/nullkiller2/Engine/DecisionPolicyTest.cpp
@@ -9,11 +9,59 @@
 #include "StdInc.h"
 
 #include "AI/Nullkiller2/Engine/DecisionPolicy.h"
+#include "AI/Nullkiller2/Engine/PriorityEvaluator.h"
+#include "lib/constants/EntityIdentifiers.h"
 #include "lib/gameState/CGameState.h"
 #include "lib/json/JsonNode.h"
 
 namespace
 {
+
+class ScopedEnvironmentVariable
+{
+public:
+	ScopedEnvironmentVariable(std::string name, const std::string & value)
+		: name(std::move(name))
+	{
+		if(const char * previous = std::getenv(this->name.c_str()))
+			previousValue = previous;
+		set(value);
+	}
+	ScopedEnvironmentVariable(const ScopedEnvironmentVariable &) = delete;
+	ScopedEnvironmentVariable(ScopedEnvironmentVariable &&) = delete;
+	ScopedEnvironmentVariable & operator=(const ScopedEnvironmentVariable &) = delete;
+	ScopedEnvironmentVariable & operator=(ScopedEnvironmentVariable &&) = delete;
+
+	~ScopedEnvironmentVariable()
+	{
+		if(previousValue)
+			set(*previousValue);
+		else
+			unset();
+	}
+
+private:
+	void set(const std::string & value) const
+	{
+#ifdef VCMI_WINDOWS
+		_putenv_s(name.c_str(), value.c_str());
+#else
+		setenv(name.c_str(), value.c_str(), 1);
+#endif
+	}
+
+	void unset() const
+	{
+#ifdef VCMI_WINDOWS
+		_putenv_s(name.c_str(), "");
+#else
+		unsetenv(name.c_str());
+#endif
+	}
+
+	std::string name;
+	std::optional<std::string> previousValue;
+};
 
 JsonNode makeRequest()
 {
@@ -43,6 +91,137 @@ const Environment * policyEnvironment()
 	return &gameState.getScriptingEnvironment();
 }
 
+std::string readTextFile(const std::string & path)
+{
+	std::ifstream input(path, std::ios::binary);
+	if(!input)
+		throw std::runtime_error("Unable to read " + path);
+	return std::string(std::istreambuf_iterator<char>(input), std::istreambuf_iterator<char>());
+}
+
+std::unique_ptr<NK2AI::IDecisionPolicy> createReferencePolicy()
+{
+	return NK2AI::createLuaDecisionPolicy(
+		"reference",
+		readTextFile("test/testdata/nk2/reference.lua"),
+		parameters(),
+		policyEnvironment());
+}
+
+JsonNode makeReferenceRequest(const std::string & tier)
+{
+	const std::map<std::string, int> tierIds = {
+		{"buildings", NK2AI::PriorityEvaluator::BUILDINGS},
+		{"instakill", NK2AI::PriorityEvaluator::INSTAKILL},
+		{"instaDefend", NK2AI::PriorityEvaluator::INSTADEFEND},
+		{"kill", NK2AI::PriorityEvaluator::KILL},
+		{"escape", NK2AI::PriorityEvaluator::ESCAPE},
+		{"exploreAndGather", NK2AI::PriorityEvaluator::EXPLORE_AND_GATHER},
+		{"defend", NK2AI::PriorityEvaluator::DEFEND}
+	};
+	NK2AI::PriorityEvaluationInput input;
+	input.settings.priorityTier = tierIds.at(tier);
+	input.settings.maximumArmyLossTarget = 0.2;
+	input.settings.dayOfWeek = 1;
+	input.settings.daysInWeek = 7;
+	input.goal.powerRatio = 1;
+	input.goal.closestWayRatio = 0.5;
+
+	JsonNode request;
+	request["priorityTier"].String() = tier;
+	request["priorityTierId"].Integer() = input.settings.priorityTier;
+
+	JsonNode candidate;
+	candidate["id"].Integer() = 0;
+	candidate["initialPriority"].Float() = 0;
+	candidate["rankingInput"] = NK2AI::priorityEvaluationInputToJson(input);
+	request["candidates"].Vector().push_back(std::move(candidate));
+	return request;
+}
+
+void addRankingInputs(JsonNode & request)
+{
+	for(JsonNode & candidate : request["candidates"].Vector())
+	{
+		JsonNode input;
+		input["priorityTier"] = request["priorityTier"];
+		input["priorityTierId"] = request["priorityTierId"];
+		input["state"] = request["state"];
+		input["evaluation"] = candidate["evaluation"];
+
+		JsonNode & escape = input["escape"];
+		escape["hasHero"].Bool() = request["priorityTierId"].Integer() == NK2AI::PriorityEvaluator::ESCAPE
+			&& !candidate["heroId"].isNull();
+		escape["currentDangerTurn"].Integer() = 0;
+		escape["currentDanger"].Integer() = 0;
+		escape["currentThreat"].Float() = 0;
+		escape["destinationThreat"].Float() = 0;
+		escape["heroTotalStrength"].Integer() = 0;
+		if(candidate["reference"]["escape"].isStruct())
+		{
+			const JsonNode & fixtureEscape = candidate["reference"]["escape"];
+			escape["currentDangerTurn"] = fixtureEscape["currentDangerTurn"];
+			escape["currentDanger"] = fixtureEscape["currentDanger"];
+			escape["currentThreat"] = fixtureEscape["currentThreat"];
+			escape["destinationThreat"] = fixtureEscape["destinationThreat"];
+			escape["heroTotalStrength"] = fixtureEscape["heroTotalStrength"];
+		}
+		const auto fixtureInput = NK2AI::priorityEvaluationInputFromJson(input);
+		JsonNode canonicalInput = NK2AI::priorityEvaluationInputToJson(fixtureInput);
+		const auto roundTrippedInput = NK2AI::priorityEvaluationInputFromJson(canonicalInput);
+		const float fixtureScore = NK2AI::evaluatePriority(fixtureInput);
+		const float roundTrippedScore = NK2AI::evaluatePriority(roundTrippedInput);
+		const float tolerance = std::max(1.0f, std::abs(fixtureScore)) * 0.0001f;
+		EXPECT_NEAR(roundTrippedScore, fixtureScore, tolerance);
+		candidate["rankingInput"] = std::move(canonicalInput);
+	}
+}
+
+void expectReferenceMatchesCompiled(NK2AI::IDecisionPolicy & policy, JsonNode request)
+{
+	const auto result = policy.rank(request);
+	ASSERT_TRUE(result.applied) << request["priorityTier"].String() << ": " << result.error;
+
+	std::map<size_t, float> actual;
+	for(const NK2AI::DecisionPolicyScore & score : result.scores)
+		actual[score.id] = score.score;
+
+	for(const JsonNode & candidate : request["candidates"].Vector())
+	{
+		const size_t id = candidate["id"].Integer();
+		ASSERT_TRUE(actual.contains(id));
+		const auto input = NK2AI::priorityEvaluationInputFromJson(candidate["rankingInput"]);
+		const float compiledScore = input.settings.priorityTier == NK2AI::PriorityEvaluator::BUILDINGS
+			&& candidate["initialPriority"].Float() > 0
+			? candidate["initialPriority"].Float()
+			: NK2AI::evaluatePriority(input);
+		const float tolerance = std::max(1.0f, std::abs(compiledScore)) * 0.0001f;
+		EXPECT_NEAR(actual.at(id), compiledScore, tolerance)
+			<< request["priorityTier"].String() << " candidate " << id;
+	}
+}
+
+}
+
+TEST(Nullkiller2_Engine_DecisionPolicy, colorSpecificProfileUsesUppercaseColorName)
+{
+	ScopedEnvironmentVariable defaultPolicy("VCMI_NK2_POLICY", "builtin");
+	ScopedEnvironmentVariable redPolicy("VCMI_NK2_POLICY_RED", "test/testdata/nk2/reference.json");
+
+	auto policy = NK2AI::createDecisionPolicy(PlayerColor(0), policyEnvironment());
+
+	ASSERT_NE(policy, nullptr);
+	EXPECT_EQ(policy->getName(), "reference");
+}
+
+TEST(Nullkiller2_Engine_DecisionPolicy, directLuaPathFallsBackToCompiledPolicy)
+{
+	ScopedEnvironmentVariable defaultPolicy("VCMI_NK2_POLICY", "builtin");
+	ScopedEnvironmentVariable redPolicy("VCMI_NK2_POLICY_RED", "test/testdata/nk2/reference.lua");
+
+	auto policy = NK2AI::createDecisionPolicy(PlayerColor(0), policyEnvironment());
+
+	EXPECT_EQ(policy, nullptr);
 }
 
 TEST(Nullkiller2_Engine_DecisionPolicy, luaCanScoreEveryCandidateUsingParameters)
@@ -162,4 +341,47 @@ TEST(Nullkiller2_Engine_DecisionPolicy, luaErrorsFallBackToCompiledPolicy)
 
 	EXPECT_FALSE(result.applied);
 	EXPECT_FALSE(result.error.empty());
+}
+
+TEST(Nullkiller2_Engine_DecisionPolicy, referencePolicyMatchesCompiledRankingFixtures)
+{
+	const std::string source = readTextFile("test/testdata/nk2/decision-policy-reference.json");
+	const JsonNode fixtures(
+		source.data(),
+		source.size(),
+		"decision-policy-reference.json");
+	auto policy = createReferencePolicy();
+
+	for(const JsonNode & fixture : fixtures.Vector())
+	{
+		JsonNode request = fixture["request"];
+		addRankingInputs(request);
+		expectReferenceMatchesCompiled(*policy, std::move(request));
+	}
+}
+
+TEST(Nullkiller2_Engine_DecisionPolicy, referencePolicyCoversExploreAndDefendTiers)
+{
+	auto policy = createReferencePolicy();
+
+	JsonNode explore = makeReferenceRequest("exploreAndGather");
+	auto & exploreEvaluation = explore["candidates"].Vector()[0]["rankingInput"]["evaluation"];
+	exploreEvaluation["danger"].Integer() = 0;
+	exploreEvaluation["strategicalValue"].Float() = 0.5;
+	exploreEvaluation["explorePriority"].Integer() = 0;
+	exploreEvaluation["goldReward"].Integer() = 0;
+	exploreEvaluation["heroRole"].String() = "main";
+	exploreEvaluation["skillReward"].Float() = 0;
+	exploreEvaluation["armyInvolvement"].Float() = 0;
+	exploreEvaluation["armyReward"].Float() = 100;
+	exploreEvaluation["armyGrowth"].Integer() = 50;
+	exploreEvaluation["goldCost"].Integer() = 0;
+	expectReferenceMatchesCompiled(*policy, explore);
+
+	JsonNode defend = makeReferenceRequest("defend");
+	auto & defendEvaluation = defend["candidates"].Vector()[0]["rankingInput"]["evaluation"];
+	defendEvaluation["isDefend"].Bool() = true;
+	defendEvaluation["isArmyUpgrade"].Bool() = false;
+	defendEvaluation["armyInvolvement"].Float() = 400;
+	expectReferenceMatchesCompiled(*policy, defend);
 }

--- a/test/nullkiller2/Engine/DecisionPolicyTest.cpp
+++ b/test/nullkiller2/Engine/DecisionPolicyTest.cpp
@@ -1,0 +1,165 @@
+/*
+ * DecisionPolicyTest.cpp, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ */
+#include "StdInc.h"
+
+#include "AI/Nullkiller2/Engine/DecisionPolicy.h"
+#include "lib/gameState/CGameState.h"
+#include "lib/json/JsonNode.h"
+
+namespace
+{
+
+JsonNode makeRequest()
+{
+	JsonNode request;
+	JsonNode first;
+	first["id"].Integer() = 3;
+	first["baselinePriority"].Float() = 10;
+	request["candidates"].Vector().push_back(first);
+
+	JsonNode second;
+	second["id"].Integer() = 7;
+	second["baselinePriority"].Float() = 20;
+	request["candidates"].Vector().push_back(second);
+	return request;
+}
+
+JsonNode parameters(float divisor = 1)
+{
+	JsonNode result;
+	result["divisor"].Float() = divisor;
+	return result;
+}
+
+const Environment * policyEnvironment()
+{
+	static const CGameState gameState;
+	return &gameState.getScriptingEnvironment();
+}
+
+}
+
+TEST(Nullkiller2_Engine_DecisionPolicy, luaCanScoreEveryCandidateUsingParameters)
+{
+	const std::string source = R"lua(
+		return { rank = function(request)
+			local scores = {}
+			for _, candidate in ipairs(request.candidates) do
+				table.insert(scores, {
+					id = candidate.id,
+					score = float32(candidate.baselinePriority / request.parameters.divisor)
+				})
+			end
+			return { scores = scores }
+		end }
+	)lua";
+	auto policy = NK2AI::createLuaDecisionPolicy("scores", source, parameters(3), policyEnvironment());
+	const auto result = policy->rank(makeRequest());
+
+	ASSERT_TRUE(result.applied) << result.error;
+	ASSERT_EQ(result.scores.size(), 2);
+	EXPECT_EQ(result.scores[0].id, 3);
+	EXPECT_FLOAT_EQ(result.scores[0].score, static_cast<float>(10.0 / 3.0));
+	EXPECT_EQ(result.scores[1].id, 7);
+	EXPECT_FLOAT_EQ(result.scores[1].score, static_cast<float>(20.0 / 3.0));
+}
+
+TEST(Nullkiller2_Engine_DecisionPolicy, incompleteScoresFallBackToCompiledPolicy)
+{
+	const std::string source = R"lua(
+		return { rank = function(request)
+			return { scores = {{ id = request.candidates[1].id, score = 1 }} }
+		end }
+	)lua";
+	auto policy = NK2AI::createLuaDecisionPolicy("incomplete", source, parameters(), policyEnvironment());
+	const auto result = policy->rank(makeRequest());
+
+	EXPECT_FALSE(result.applied);
+	EXPECT_FALSE(result.error.empty());
+}
+
+TEST(Nullkiller2_Engine_DecisionPolicy, duplicateScoresFallBackToCompiledPolicy)
+{
+	const std::string source = R"lua(
+		return { rank = function(request)
+			local id = request.candidates[1].id
+			return { scores = {{ id = id, score = 1 }, { id = id, score = 2 }} }
+		end }
+	)lua";
+	auto policy = NK2AI::createLuaDecisionPolicy("duplicate", source, parameters(), policyEnvironment());
+	const auto result = policy->rank(makeRequest());
+
+	EXPECT_FALSE(result.applied);
+	EXPECT_FALSE(result.error.empty());
+}
+
+TEST(Nullkiller2_Engine_DecisionPolicy, scoresOutsideFloatRangeFallBackToCompiledPolicy)
+{
+	const std::string source = R"lua(
+		return { rank = function(request)
+			local scores = {}
+			for _, candidate in ipairs(request.candidates) do
+				table.insert(scores, { id = candidate.id, score = 1e300 })
+			end
+			return { scores = scores }
+		end }
+	)lua";
+	auto policy = NK2AI::createLuaDecisionPolicy("overflow", source, parameters(), policyEnvironment());
+	const auto result = policy->rank(makeRequest());
+
+	EXPECT_FALSE(result.applied);
+	EXPECT_FALSE(result.error.empty());
+}
+
+TEST(Nullkiller2_Engine_DecisionPolicy, nonTableResultFallsBackWithoutEscapingLua)
+{
+	const std::string source = R"lua(
+		return { rank = function(request) return 42 end }
+	)lua";
+	auto policy = NK2AI::createLuaDecisionPolicy("invalid-result", source, parameters(), policyEnvironment());
+	const auto result = policy->rank(makeRequest());
+
+	EXPECT_FALSE(result.applied);
+	EXPECT_FALSE(result.error.empty());
+}
+
+TEST(Nullkiller2_Engine_DecisionPolicy, standardLuaBindingsAreAvailable)
+{
+	const std::string source = R"lua(
+		return { rank = function(request)
+			assert(GAME ~= nil and LIBRARY ~= nil and ENUM ~= nil)
+			assert(type(require) == "function" and type(print) == "function")
+			assert(LIBRARY:getResourceByName("gold") ~= nil)
+			assert(io == nil and os == nil and package == nil)
+			assert(debug == nil and dofile == nil and loadfile == nil and load == nil)
+			assert(math.random == nil and math.randomseed == nil)
+			local scores = {}
+			for _, candidate in ipairs(request.candidates) do
+				table.insert(scores, { id = candidate.id, score = candidate.baselinePriority })
+			end
+			return { scores = scores }
+		end }
+	)lua";
+	auto policy = NK2AI::createLuaDecisionPolicy("bindings", source, parameters(), policyEnvironment());
+	const auto result = policy->rank(makeRequest());
+
+	EXPECT_TRUE(result.applied) << result.error;
+}
+
+TEST(Nullkiller2_Engine_DecisionPolicy, luaErrorsFallBackToCompiledPolicy)
+{
+	const std::string source = R"lua(
+		return { rank = function(request) error("expected policy failure") end }
+	)lua";
+	auto policy = NK2AI::createLuaDecisionPolicy("failure", source, parameters(), policyEnvironment());
+	const auto result = policy->rank(makeRequest());
+
+	EXPECT_FALSE(result.applied);
+	EXPECT_FALSE(result.error.empty());
+}

--- a/test/testdata/nk2/decision-policy-reference.json
+++ b/test/testdata/nk2/decision-policy-reference.json
@@ -1,0 +1,839 @@
+[
+  {
+    "request": {
+      "candidates": [
+        {
+          "description": "Buy army at Manufactury",
+          "evaluation": {
+            "armyGrowth": 0,
+            "armyInvolvement": 0,
+            "armyLossRatio": 0,
+            "armyReward": 0,
+            "buildingCost": {
+              "marketValue": 0,
+              "resources": {
+                "crystal": 0,
+                "gems": 0,
+                "gold": 0,
+                "mercury": 0,
+                "ore": 0,
+                "sulfur": 0,
+                "wood": 0
+              }
+            },
+            "closestWayRatio": 1,
+            "conquestValue": 0,
+            "danger": 0,
+            "defenseValue": 0,
+            "enemyHeroDangerRatio": 0,
+            "explorePriority": 0,
+            "goldCost": 0,
+            "goldReward": 0,
+            "heroRole": "scout",
+            "involvesSailing": false,
+            "isArmyUpgrade": false,
+            "isDefend": false,
+            "isEnemy": false,
+            "isExchange": false,
+            "isHero": false,
+            "isTradeBuilding": false,
+            "manaCost": 0,
+            "movementCost": 0,
+            "movementCostByRole": {
+              "main": 0,
+              "scout": 0
+            },
+            "powerRatio": 0,
+            "skillReward": 0,
+            "strategicalValue": 0,
+            "threat": 0,
+            "threatTurns": 2147483647,
+            "turn": 0
+          },
+          "goalType": "buyArmy",
+          "goalTypeId": 16,
+          "id": 0,
+          "initialPriority": 704,
+          "target": {
+            "x": -1,
+            "y": -1,
+            "z": -1
+          },
+          "townId": 347
+        },
+        {
+          "description": "Build Mage Guild Level 1 in Manufactury",
+          "evaluation": {
+            "armyGrowth": 0,
+            "armyInvolvement": 0,
+            "armyLossRatio": 0,
+            "armyReward": 0,
+            "buildingCost": {
+              "marketValue": 31500,
+              "resources": {
+                "crystal": 10,
+                "gems": 10,
+                "gold": 4000,
+                "mercury": 10,
+                "ore": 15,
+                "sulfur": 10,
+                "wood": 15
+              }
+            },
+            "closestWayRatio": 1,
+            "conquestValue": 0,
+            "danger": 0,
+            "defenseValue": 0,
+            "enemyHeroDangerRatio": 0,
+            "explorePriority": 0,
+            "goldCost": 2000,
+            "goldReward": 0,
+            "heroRole": "main",
+            "involvesSailing": false,
+            "isArmyUpgrade": false,
+            "isDefend": false,
+            "isEnemy": false,
+            "isExchange": false,
+            "isHero": false,
+            "isTradeBuilding": false,
+            "manaCost": 0,
+            "movementCost": 0,
+            "movementCostByRole": {
+              "main": 3,
+              "scout": 0
+            },
+            "powerRatio": 0,
+            "skillReward": 2,
+            "strategicalValue": 0,
+            "threat": 0,
+            "threatTurns": 2147483647,
+            "turn": 0
+          },
+          "goalType": "buildStructure",
+          "goalTypeId": 8,
+          "id": 5,
+          "initialPriority": 0,
+          "target": {
+            "x": -1,
+            "y": -1,
+            "z": -1
+          },
+          "townId": 347
+        }
+      ],
+      "day": 1,
+      "parameters": {},
+      "player": "red",
+      "playerId": 0,
+      "priorityTier": "buildings",
+      "priorityTierId": 0,
+      "schemaVersion": 3,
+      "state": {
+        "dailyIncome": {
+          "crystal": 0,
+          "gems": 0,
+          "gold": 500,
+          "mercury": 0,
+          "ore": 0,
+          "sulfur": 0,
+          "wood": 0
+        },
+        "dayOfWeek": 1,
+        "daysInWeek": 7,
+        "daysWithoutCastle": false,
+        "goldPressureOverMax": false,
+        "hasTownWithoutMarketplace": true,
+        "heroCount": 1,
+        "heroes": [
+          {
+            "armyStrength": 1628,
+            "experience": 73,
+            "id": 350,
+            "level": 1,
+            "mana": 21,
+            "movement": 1560,
+            "totalStrength": 1888
+          }
+        ],
+        "knownObjectCount": 13,
+        "lockedResourceMarketValue": 0,
+        "lockedResources": {
+          "crystal": 0,
+          "gems": 0,
+          "gold": 0,
+          "mercury": 0,
+          "ore": 0,
+          "sulfur": 0,
+          "wood": 0
+        },
+        "maximumArmyLossTarget": 0.5,
+        "ownedObjectCount": 2,
+        "resourceMarketValue": 20500,
+        "resources": {
+          "crystal": 4,
+          "gems": 4,
+          "gold": 7500,
+          "mercury": 4,
+          "ore": 10,
+          "sulfur": 4,
+          "wood": 10
+        },
+        "revealedTileCount": 151,
+        "totalArmyStrength": 1628,
+        "totalBuildings": 4,
+        "totalFortLevel": 1,
+        "totalHeroArmyStrength": 1628,
+        "totalHeroExperience": 73,
+        "totalHeroLevels": 1,
+        "totalHeroStrength": 1888,
+        "totalTownArmyStrength": 0,
+        "townCount": 1,
+        "towns": [
+          {
+            "armyStrength": 0,
+            "buildingCount": 4,
+            "dailyIncome": {
+              "crystal": 0,
+              "gems": 0,
+              "gold": 500,
+              "mercury": 0,
+              "ore": 0,
+              "sulfur": 0,
+              "wood": 0
+            },
+            "fortLevel": 1,
+            "hallLevel": 0,
+            "hasResourceMarketplace": false,
+            "id": 347,
+            "mageGuildLevel": 0
+          }
+        ]
+      }
+    }
+  },
+  {
+    "request": {
+      "candidates": [
+        {
+          "description": "ExecuteHeroChain resource(1 3 0) by Neela",
+          "evaluation": {
+            "armyGrowth": 0,
+            "armyInvolvement": 1110,
+            "armyLossRatio": 0,
+            "armyReward": 0,
+            "buildingCost": {
+              "marketValue": 0,
+              "resources": {
+                "crystal": 0,
+                "gems": 0,
+                "gold": 0,
+                "mercury": 0,
+                "ore": 0,
+                "sulfur": 0,
+                "wood": 0
+              }
+            },
+            "closestWayRatio": 1,
+            "conquestValue": 0,
+            "danger": 0,
+            "defenseValue": 0,
+            "enemyHeroDangerRatio": 0,
+            "explorePriority": 0,
+            "goldCost": 0,
+            "goldReward": 100,
+            "heroRole": "main",
+            "involvesSailing": false,
+            "isArmyUpgrade": false,
+            "isDefend": false,
+            "isEnemy": false,
+            "isExchange": false,
+            "isHero": false,
+            "isTradeBuilding": false,
+            "manaCost": 0,
+            "movementCost": 0.346795,
+            "movementCostByRole": {
+              "main": 0.346795,
+              "scout": 0
+            },
+            "powerRatio": 0.698113,
+            "skillReward": 0,
+            "strategicalValue": 0,
+            "threat": 0,
+            "threatTurns": 2147483647,
+            "turn": 0
+          },
+          "goalType": "executeHeroChain",
+          "goalTypeId": 21,
+          "heroId": 350,
+          "id": 0,
+          "initialPriority": 0,
+          "objectId": 332,
+          "target": {
+            "x": 1,
+            "y": 3,
+            "z": 0
+          }
+        }
+      ],
+      "day": 1,
+      "parameters": {},
+      "player": "red",
+      "playerId": 0,
+      "priorityTier": "instakill",
+      "priorityTierId": 1,
+      "schemaVersion": 3,
+      "state": {
+        "dailyIncome": {
+          "crystal": 0,
+          "gems": 0,
+          "gold": 500,
+          "mercury": 0,
+          "ore": 0,
+          "sulfur": 0,
+          "wood": 0
+        },
+        "dayOfWeek": 1,
+        "daysInWeek": 7,
+        "daysWithoutCastle": false,
+        "goldPressureOverMax": false,
+        "hasTownWithoutMarketplace": true,
+        "heroCount": 1,
+        "heroes": [
+          {
+            "armyStrength": 1628,
+            "experience": 73,
+            "id": 350,
+            "level": 1,
+            "mana": 21,
+            "movement": 1560,
+            "totalStrength": 1888
+          }
+        ],
+        "knownObjectCount": 13,
+        "lockedResourceMarketValue": 0,
+        "lockedResources": {
+          "crystal": 0,
+          "gems": 0,
+          "gold": 0,
+          "mercury": 0,
+          "ore": 0,
+          "sulfur": 0,
+          "wood": 0
+        },
+        "maximumArmyLossTarget": 0.5,
+        "ownedObjectCount": 2,
+        "resourceMarketValue": 14620,
+        "resources": {
+          "crystal": 4,
+          "gems": 4,
+          "gold": 4120,
+          "mercury": 4,
+          "ore": 5,
+          "sulfur": 4,
+          "wood": 5
+        },
+        "revealedTileCount": 151,
+        "totalArmyStrength": 3832,
+        "totalBuildings": 5,
+        "totalFortLevel": 1,
+        "totalHeroArmyStrength": 1628,
+        "totalHeroExperience": 73,
+        "totalHeroLevels": 1,
+        "totalHeroStrength": 1888,
+        "totalTownArmyStrength": 2204,
+        "townCount": 1,
+        "towns": [
+          {
+            "armyStrength": 2204,
+            "buildingCount": 5,
+            "dailyIncome": {
+              "crystal": 0,
+              "gems": 0,
+              "gold": 500,
+              "mercury": 0,
+              "ore": 0,
+              "sulfur": 0,
+              "wood": 0
+            },
+            "fortLevel": 1,
+            "hallLevel": 0,
+            "hasResourceMarketplace": false,
+            "id": 347,
+            "mageGuildLevel": 0
+          }
+        ]
+      }
+    }
+  },
+  {
+    "request": {
+      "candidates": [
+        {
+          "description": "ExecuteHeroChain resource(1 3 0) by Neela",
+          "evaluation": {
+            "armyGrowth": 0,
+            "armyInvolvement": 1110,
+            "armyLossRatio": 0,
+            "armyReward": 0,
+            "buildingCost": {
+              "marketValue": 0,
+              "resources": {
+                "crystal": 0,
+                "gems": 0,
+                "gold": 0,
+                "mercury": 0,
+                "ore": 0,
+                "sulfur": 0,
+                "wood": 0
+              }
+            },
+            "closestWayRatio": 1,
+            "conquestValue": 0,
+            "danger": 0,
+            "defenseValue": 0,
+            "enemyHeroDangerRatio": 0,
+            "explorePriority": 0,
+            "goldCost": 0,
+            "goldReward": 100,
+            "heroRole": "main",
+            "involvesSailing": false,
+            "isArmyUpgrade": false,
+            "isDefend": false,
+            "isEnemy": false,
+            "isExchange": false,
+            "isHero": false,
+            "isTradeBuilding": false,
+            "manaCost": 0,
+            "movementCost": 0.346795,
+            "movementCostByRole": {
+              "main": 0.346795,
+              "scout": 0
+            },
+            "powerRatio": 0.698113,
+            "skillReward": 0,
+            "strategicalValue": 0,
+            "threat": 0,
+            "threatTurns": 2147483647,
+            "turn": 0
+          },
+          "goalType": "executeHeroChain",
+          "goalTypeId": 21,
+          "heroId": 350,
+          "id": 0,
+          "initialPriority": 0,
+          "objectId": 332,
+          "target": {
+            "x": 1,
+            "y": 3,
+            "z": 0
+          }
+        }
+      ],
+      "day": 1,
+      "parameters": {},
+      "player": "red",
+      "playerId": 0,
+      "priorityTier": "instaDefend",
+      "priorityTierId": 2,
+      "schemaVersion": 3,
+      "state": {
+        "dailyIncome": {
+          "crystal": 0,
+          "gems": 0,
+          "gold": 500,
+          "mercury": 0,
+          "ore": 0,
+          "sulfur": 0,
+          "wood": 0
+        },
+        "dayOfWeek": 1,
+        "daysInWeek": 7,
+        "daysWithoutCastle": false,
+        "goldPressureOverMax": false,
+        "hasTownWithoutMarketplace": true,
+        "heroCount": 1,
+        "heroes": [
+          {
+            "armyStrength": 1628,
+            "experience": 73,
+            "id": 350,
+            "level": 1,
+            "mana": 21,
+            "movement": 1560,
+            "totalStrength": 1888
+          }
+        ],
+        "knownObjectCount": 13,
+        "lockedResourceMarketValue": 0,
+        "lockedResources": {
+          "crystal": 0,
+          "gems": 0,
+          "gold": 0,
+          "mercury": 0,
+          "ore": 0,
+          "sulfur": 0,
+          "wood": 0
+        },
+        "maximumArmyLossTarget": 0.5,
+        "ownedObjectCount": 2,
+        "resourceMarketValue": 14620,
+        "resources": {
+          "crystal": 4,
+          "gems": 4,
+          "gold": 4120,
+          "mercury": 4,
+          "ore": 5,
+          "sulfur": 4,
+          "wood": 5
+        },
+        "revealedTileCount": 151,
+        "totalArmyStrength": 3832,
+        "totalBuildings": 5,
+        "totalFortLevel": 1,
+        "totalHeroArmyStrength": 1628,
+        "totalHeroExperience": 73,
+        "totalHeroLevels": 1,
+        "totalHeroStrength": 1888,
+        "totalTownArmyStrength": 2204,
+        "townCount": 1,
+        "towns": [
+          {
+            "armyStrength": 2204,
+            "buildingCount": 5,
+            "dailyIncome": {
+              "crystal": 0,
+              "gems": 0,
+              "gold": 500,
+              "mercury": 0,
+              "ore": 0,
+              "sulfur": 0,
+              "wood": 0
+            },
+            "fortLevel": 1,
+            "hallLevel": 0,
+            "hasResourceMarketplace": false,
+            "id": 347,
+            "mageGuildLevel": 0
+          }
+        ]
+      }
+    }
+  },
+  {
+    "request": {
+      "candidates": [
+        {
+          "description": "ExecuteHeroChain resource(1 3 0) by Neela",
+          "evaluation": {
+            "armyGrowth": 0,
+            "armyInvolvement": 1110,
+            "armyLossRatio": 0,
+            "armyReward": 0,
+            "buildingCost": {
+              "marketValue": 0,
+              "resources": {
+                "crystal": 0,
+                "gems": 0,
+                "gold": 0,
+                "mercury": 0,
+                "ore": 0,
+                "sulfur": 0,
+                "wood": 0
+              }
+            },
+            "closestWayRatio": 1,
+            "conquestValue": 0,
+            "danger": 0,
+            "defenseValue": 0,
+            "enemyHeroDangerRatio": 0,
+            "explorePriority": 0,
+            "goldCost": 0,
+            "goldReward": 100,
+            "heroRole": "main",
+            "involvesSailing": false,
+            "isArmyUpgrade": false,
+            "isDefend": false,
+            "isEnemy": false,
+            "isExchange": false,
+            "isHero": false,
+            "isTradeBuilding": false,
+            "manaCost": 0,
+            "movementCost": 0.346795,
+            "movementCostByRole": {
+              "main": 0.346795,
+              "scout": 0
+            },
+            "powerRatio": 0.698113,
+            "skillReward": 0,
+            "strategicalValue": 0,
+            "threat": 0,
+            "threatTurns": 2147483647,
+            "turn": 0
+          },
+          "goalType": "executeHeroChain",
+          "goalTypeId": 21,
+          "heroId": 350,
+          "id": 0,
+          "initialPriority": 0,
+          "objectId": 332,
+          "target": {
+            "x": 1,
+            "y": 3,
+            "z": 0
+          }
+        }
+      ],
+      "day": 1,
+      "parameters": {},
+      "player": "red",
+      "playerId": 0,
+      "priorityTier": "kill",
+      "priorityTierId": 3,
+      "schemaVersion": 3,
+      "state": {
+        "dailyIncome": {
+          "crystal": 0,
+          "gems": 0,
+          "gold": 500,
+          "mercury": 0,
+          "ore": 0,
+          "sulfur": 0,
+          "wood": 0
+        },
+        "dayOfWeek": 1,
+        "daysInWeek": 7,
+        "daysWithoutCastle": false,
+        "goldPressureOverMax": false,
+        "hasTownWithoutMarketplace": true,
+        "heroCount": 1,
+        "heroes": [
+          {
+            "armyStrength": 1628,
+            "experience": 73,
+            "id": 350,
+            "level": 1,
+            "mana": 21,
+            "movement": 1560,
+            "totalStrength": 1888
+          }
+        ],
+        "knownObjectCount": 13,
+        "lockedResourceMarketValue": 0,
+        "lockedResources": {
+          "crystal": 0,
+          "gems": 0,
+          "gold": 0,
+          "mercury": 0,
+          "ore": 0,
+          "sulfur": 0,
+          "wood": 0
+        },
+        "maximumArmyLossTarget": 0.5,
+        "ownedObjectCount": 2,
+        "resourceMarketValue": 14620,
+        "resources": {
+          "crystal": 4,
+          "gems": 4,
+          "gold": 4120,
+          "mercury": 4,
+          "ore": 5,
+          "sulfur": 4,
+          "wood": 5
+        },
+        "revealedTileCount": 151,
+        "totalArmyStrength": 3832,
+        "totalBuildings": 5,
+        "totalFortLevel": 1,
+        "totalHeroArmyStrength": 1628,
+        "totalHeroExperience": 73,
+        "totalHeroLevels": 1,
+        "totalHeroStrength": 1888,
+        "totalTownArmyStrength": 2204,
+        "townCount": 1,
+        "towns": [
+          {
+            "armyStrength": 2204,
+            "buildingCount": 5,
+            "dailyIncome": {
+              "crystal": 0,
+              "gems": 0,
+              "gold": 500,
+              "mercury": 0,
+              "ore": 0,
+              "sulfur": 0,
+              "wood": 0
+            },
+            "fortLevel": 1,
+            "hallLevel": 0,
+            "hasResourceMarketplace": false,
+            "id": 347,
+            "mageGuildLevel": 0
+          }
+        ]
+      }
+    }
+  },
+  {
+    "request": {
+      "candidates": [
+        {
+          "description": "ExecuteHeroChain resource(1 3 0) by Neela",
+          "evaluation": {
+            "armyGrowth": 0,
+            "armyInvolvement": 1110,
+            "armyLossRatio": 0,
+            "armyReward": 0,
+            "buildingCost": {
+              "marketValue": 0,
+              "resources": {
+                "crystal": 0,
+                "gems": 0,
+                "gold": 0,
+                "mercury": 0,
+                "ore": 0,
+                "sulfur": 0,
+                "wood": 0
+              }
+            },
+            "closestWayRatio": 1,
+            "conquestValue": 0,
+            "danger": 0,
+            "defenseValue": 0,
+            "enemyHeroDangerRatio": 0,
+            "explorePriority": 0,
+            "goldCost": 0,
+            "goldReward": 100,
+            "heroRole": "main",
+            "involvesSailing": false,
+            "isArmyUpgrade": false,
+            "isDefend": false,
+            "isEnemy": false,
+            "isExchange": false,
+            "isHero": false,
+            "isTradeBuilding": false,
+            "manaCost": 0,
+            "movementCost": 0.346795,
+            "movementCostByRole": {
+              "main": 0.346795,
+              "scout": 0
+            },
+            "powerRatio": 0.698113,
+            "skillReward": 0,
+            "strategicalValue": 0,
+            "threat": 0,
+            "threatTurns": 2147483647,
+            "turn": 0
+          },
+          "goalType": "executeHeroChain",
+          "goalTypeId": 21,
+          "heroId": 350,
+          "id": 0,
+          "initialPriority": 0,
+          "objectId": 332,
+          "reference": {
+            "escape": {
+              "currentDanger": 0,
+              "currentDangerTurn": 255,
+              "currentThreat": 0,
+              "destinationThreat": 0,
+              "heroTotalStrength": 1888
+            }
+          },
+          "target": {
+            "x": 1,
+            "y": 3,
+            "z": 0
+          }
+        }
+      ],
+      "day": 1,
+      "parameters": {},
+      "player": "red",
+      "playerId": 0,
+      "priorityTier": "escape",
+      "priorityTierId": 4,
+      "schemaVersion": 3,
+      "state": {
+        "dailyIncome": {
+          "crystal": 0,
+          "gems": 0,
+          "gold": 500,
+          "mercury": 0,
+          "ore": 0,
+          "sulfur": 0,
+          "wood": 0
+        },
+        "dayOfWeek": 1,
+        "daysInWeek": 7,
+        "daysWithoutCastle": false,
+        "goldPressureOverMax": false,
+        "hasTownWithoutMarketplace": true,
+        "heroCount": 1,
+        "heroes": [
+          {
+            "armyStrength": 1628,
+            "experience": 73,
+            "id": 350,
+            "level": 1,
+            "mana": 21,
+            "movement": 1560,
+            "totalStrength": 1888
+          }
+        ],
+        "knownObjectCount": 13,
+        "lockedResourceMarketValue": 0,
+        "lockedResources": {
+          "crystal": 0,
+          "gems": 0,
+          "gold": 0,
+          "mercury": 0,
+          "ore": 0,
+          "sulfur": 0,
+          "wood": 0
+        },
+        "maximumArmyLossTarget": 0.5,
+        "ownedObjectCount": 2,
+        "resourceMarketValue": 14620,
+        "resources": {
+          "crystal": 4,
+          "gems": 4,
+          "gold": 4120,
+          "mercury": 4,
+          "ore": 5,
+          "sulfur": 4,
+          "wood": 5
+        },
+        "revealedTileCount": 151,
+        "totalArmyStrength": 3832,
+        "totalBuildings": 5,
+        "totalFortLevel": 1,
+        "totalHeroArmyStrength": 1628,
+        "totalHeroExperience": 73,
+        "totalHeroLevels": 1,
+        "totalHeroStrength": 1888,
+        "totalTownArmyStrength": 2204,
+        "townCount": 1,
+        "towns": [
+          {
+            "armyStrength": 2204,
+            "buildingCount": 5,
+            "dailyIncome": {
+              "crystal": 0,
+              "gems": 0,
+              "gold": 500,
+              "mercury": 0,
+              "ore": 0,
+              "sulfur": 0,
+              "wood": 0
+            },
+            "fortLevel": 1,
+            "hallLevel": 0,
+            "hasResourceMarketplace": false,
+            "id": 347,
+            "mageGuildLevel": 0
+          }
+        ]
+      }
+    }
+  }
+]


### PR DESCRIPTION
Nullkiller can now optionally replace its compiled candidate scores logic with scores from a Lua policy. The default remains the compiled `PriorityEvaluator` (C++), no Lua state is created and no policy data is collected unless a policy is explicitly selected.

The bundled `config/ai/nk2ai/policies/reference.lua` is a readable translation of the complete compiled ranking algorithm. It covers all priority tiers and is intended to produce the same acceptance decisions and scores as the pure C++ `evaluatePriority` scorer.

Set `VCMI_NK2_POLICY` to a JSON profile before starting VCMI:

```sh
VCMI_NK2_POLICY=/path/to/reference.json vcmiclient
```

Use a color-suffixed variable such as `VCMI_NK2_POLICY_RED` or `VCMI_NK2_POLICY_BLUE` to select a different policy for one player. A profile has this format:

```json
{
	"schemaVersion": 1,
	"name": "my-policy",
	"type": "lua",
	"script": "my-policy.lua",
	"shadow": false,
	"parameters": {}
}
```

Relative script paths are resolved from the profile directory. Parameters are copied to `request.parameters`. A direct path to a `.lua` file uses an empty parameters object.

There are three core modes, plus per-player combinations:

| Mode | Configuration | Does Lua run? | Ranking used for play | Purpose |
|---|---|---:|---|---|
| Compiled C++ | Variable unset or `VCMI_NK2_POLICY=builtin` | No | C++ | Normal/default VCMI behavior |
| Lua active | JSON profile with `"shadow": false` | Yes | Lua | Run a customized or tuned policy |
| Lua shadow | JSON profile with `"shadow": true` | Yes | C++ | Compare Lua with C++ without changing decisions |
| Per-player comparison | Set `VCMI_NK2_POLICY_RED`, `..._BLUE`, etc. independently | Depends on each profile | Selected independently | A/B tests and self-play |

In both Lua modes, loading errors, runtime errors, invalid IDs, missing scores, non-finite scores, or resource-limit violations fail safely to compiled C++ ranking. Shadow mode additionally reports parity differences while never applying the Lua result.

---

The complete C++ ranking formula is extracted into a pure scorer and translated into a bundled reference Lua policy. Both implementations consume the same input, and differential tests use the current C++ result as the oracle across all seven priority tiers so the two versions cannot silently drift.

This makes strategy experiments much faster. Many ideas require only changing named parameters in JSON, so they can be tried without rebuilding VCMI and without programming skills; deeper changes can be kept in a small, focused Lua policy instead of C++.

I have already used an expanded local training harness built on this boundary to accept several incremental policy improvements. These improved exploration, gold retention, and hero progression without statistically significant regressions. Follow-up PRs can add the broader evaluation tooling and carefully validated tuning separately, while this PR keeps the bundled reference behavior equivalent to C++.