### PR TITLE
Reduce reallocation overhead in JSON parsing and binary serialization

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -13,6 +13,10 @@
 * Added support for HotA Quest Gates, Seer Huts with multiple quests, and quests limited by game difficulty
 * It is now possible to select the map layer type for random maps, for example creating a map with two underground layers
 
+### Performance
+
+* Reduced overhead of JSON parsing and game state serialization by avoiding unnecessary reallocations
+
 ### Stability
 
 * Fixed possible crash on shutdown

--- a/lib/json/JsonParser.cpp
+++ b/lib/json/JsonParser.cpp
@@ -449,9 +449,10 @@ bool JsonParser::extractArray(JsonNode & node)
 
 	while(true)
 	{
-		//NOTE: currently 50% of time is this vector resizing.
-		//May be useful to use list during parsing and then swap() all items to vector
-		node.Vector().resize(node.Vector().size() + 1);
+		// emplace_back() grows the vector's capacity geometrically (like push_back()),
+		// unlike resize(size()+1) which previously reallocated & copied on every single
+		// element - that used to cost ~50% of total JSON parsing time on large arrays.
+		node.Vector().emplace_back();
 
 		if(!extractElement(node.Vector().back(), ']'))
 			return false;

--- a/lib/serializer/BinaryDeserializer.h
+++ b/lib/serializer/BinaryDeserializer.h
@@ -54,8 +54,10 @@ private:
 	static constexpr bool trackSerializedPointers = true;
 
 	std::vector<std::string> loadedStrings;
-	std::map<uint32_t, Serializeable *> loadedPointers;
-	std::map<const Serializeable *, std::shared_ptr<Serializeable>> loadedSharedPointers;
+	// unordered_map: only ever looked up / inserted by key, never iterated,
+	// so hash-map lookup (O(1) avg) is a safe drop-in win over the O(log n) tree lookup.
+	std::unordered_map<uint32_t, Serializeable *> loadedPointers;
+	std::unordered_map<const Serializeable *, std::shared_ptr<Serializeable>> loadedSharedPointers;
 	IBinaryReader * reader;
 
 	uint32_t readAndCheckLength()

--- a/lib/serializer/BinarySerializer.h
+++ b/lib/serializer/BinarySerializer.h
@@ -51,8 +51,10 @@ public:
 	}
 
 private:
-	std::map<std::string, uint32_t> savedStrings;
-	std::map<const Serializeable*, uint32_t> savedPointers;
+	// unordered_map: only ever looked up / inserted by key, never iterated,
+	// so hash-map lookup (O(1) avg) is a safe drop-in win over the O(log n) tree lookup.
+	std::unordered_map<std::string, uint32_t> savedStrings;
+	std::unordered_map<const Serializeable*, uint32_t> savedPointers;
 	IBinaryWriter * writer;
 
 	static constexpr bool trackSerializedPointers = true;

--- a/lib/serializer/CMemorySerializer.cpp
+++ b/lib/serializer/CMemorySerializer.cpp
@@ -23,7 +23,16 @@ int CMemorySerializer::read(std::byte * data, unsigned size)
 int CMemorySerializer::write(const std::byte * data, unsigned size)
 {
 	auto oldSize = buffer.size(); //and the pos to write from
-	buffer.resize(oldSize + size);
+	auto newSize = oldSize + size;
+
+	// write() is called once per primitive (often just 1-2 bytes at a time), so this runs
+	// a huge number of times while serializing a large object graph (e.g. a gamestate snapshot).
+	// Growing capacity geometrically here avoids relying on vector::resize() to do it for us,
+	// which is not guaranteed to grow with an amortized strategy the way push_back() does.
+	if(newSize > buffer.capacity())
+		buffer.reserve(std::max<size_t>(newSize, buffer.capacity() * 2));
+
+	buffer.resize(newSize);
 	std::copy_n(data, size, buffer.data() + oldSize);
 	return size;
 }


### PR DESCRIPTION
## Summary
- `JsonParser::extractArray()`: use `emplace_back()` instead of `resize(size()+1)`, which previously reallocated and copied the whole vector on every element (profiled at ~50% of JSON parsing time on large arrays)
- `CMemorySerializer::write()`: grow the output buffer's capacity geometrically instead of relying on `resize()`, since `write()` is called once per primitive while serializing large object graphs (e.g. a gamestate snapshot)
- `BinarySerializer`/`BinaryDeserializer`: switch the pointer/string dedup maps from `std::map` to `std::unordered_map`, since they are only ever looked up or inserted by key, never iterated

## Test plan
- [ ] `vcmitest` full suite passes (pre-existing failures unrelated to this branch, verified via stash/rebuild isolation)
- [ ] Manual: confirm JSON-heavy mod loading and gamestate serialization (save/replay) still produce identical results

🤖 Generated with Claude Code