### PR TITLE
Fix: rewardable objects marked visited despite failing reward limiter

### DIFF
--- a/lib/rewardable/Interface.cpp
+++ b/lib/rewardable/Interface.cpp
@@ -397,7 +397,7 @@ void Rewardable::Interface::doHeroVisit(IGameEventCallback & gameEvents, const C
 			}
 		}
 
-		if(!objectRemovalPossible && getAvailableRewards(h, Rewardable::EEventType::EVENT_FIRST_VISIT).empty())
+		if(!objectRemovalPossible && getAvailableRewards(nullptr, Rewardable::EEventType::EVENT_FIRST_VISIT).empty())
 			markAsScouted(gameEvents, h);
 	}
 	else

--- a/lib/rewardable/Interface.cpp
+++ b/lib/rewardable/Interface.cpp
@@ -338,6 +338,8 @@ void Rewardable::Interface::grantAllRewardsWithMessage(IGameEventCallback & game
 
 void Rewardable::Interface::doHeroVisit(IGameEventCallback & gameEvents, const CGHeroInstance *h) const
 {
+	bool visitModeParticipatesInScouting = configuration.visitMode != Rewardable::VISIT_PLAYER && configuration.visitMode != Rewardable::VISIT_PLAYER_GLOBAL;
+
 	if(!wasVisitedBefore(h))
 	{
 		auto rewards = getAvailableRewards(h, Rewardable::EEventType::EVENT_FIRST_VISIT);
@@ -397,14 +399,14 @@ void Rewardable::Interface::doHeroVisit(IGameEventCallback & gameEvents, const C
 			}
 		}
 
-		if(!objectRemovalPossible && getAvailableRewards(nullptr, Rewardable::EEventType::EVENT_FIRST_VISIT).empty())
+		if(!objectRemovalPossible && visitModeParticipatesInScouting && getAvailableRewards(h, Rewardable::EEventType::EVENT_FIRST_VISIT).empty())
 			markAsScouted(gameEvents, h);
 	}
 	else
 	{
 		logGlobal->debug("Revisiting already visited object");
 
-		if (!wasVisited(h->getOwner()))
+		if (visitModeParticipatesInScouting && !wasVisited(h->getOwner()))
 			markAsScouted(gameEvents, h);
 
 		auto visitedRewards = getAvailableRewards(h, Rewardable::EEventType::EVENT_ALREADY_VISITED);


### PR DESCRIPTION
## Summary

Fixes #6897 

Visiting a rewardable object whose only reward is gated by an unmet limiter (e.g. a Cartographer without enough gold) permanently marked the object as visited, locking the player out of the reward even after meeting the requirement later. This was most noticeable with Cartographers (`playerGlobal` visit mode), where it blocked every cartographer of that subtype for the player.

Root cause: `Rewardable::Interface::doHeroVisit()` fell back to `markAsScouted()` whenever the hero found zero currently-available rewards, without distinguishing "no reward configured for this event at all" from "a reward exists but this hero currently fails its limiter". For `CRewardableObject`, `markAsScouted()` sends `VISITOR_ADD_PLAYER`, which actually marks the object (or, for `playerGlobal` objects, all objects of that type) as visited.

## Fix

Check reward availability ignoring the hero-specific limiter (`getAvailableRewards(nullptr, ...)`) before deciding there's truly nothing configured for this event. Only in that case is the object marked visited/scouted; if a reward exists but the limiter isn't currently met, the object stays revisitable.

## Test plan

- [x] Builds cleanly
- [x] Manually verified: visited a Cartographer with < 1000 gold, got the "not enough gold" message, gathered 1000+ gold, revisited, and was able to buy maps