### PR TITLE
Fix hero objective lookup by anchor position

### DIFF
--- a/lib/mapping/CMap.cpp
+++ b/lib/mapping/CMap.cpp
@@ -458,6 +458,12 @@ const CGObjectInstance * CMap::getObjectiveObjectFrom(const int3 & pos, Obj type
 			return object;
 	}
 
+	for(const auto & object : objects)
+	{
+		if(object && object->ID == type && object->anchorPos() == pos)
+			return object.get();
+	}
+
 	logGlobal->error("Failed to find object of type %d at %s", type.getNum(), pos.toString());
 	return nullptr;
 }
@@ -502,15 +508,8 @@ void CMap::checkForObjectives()
 				case EventCondition::CONTROL_CURRENT:
 					if(isInTheMap(cond.position))
 					{
-						for(const auto & objID : getTile(cond.position).visitableObjects)
-						{
-							const auto * object = getObject(objID);
-							if(object->ID == cond.objectType.as<MapObjectID>())
-							{
-								cond.objectID = object->id;
-								break;
-							}
-						}
+						if(const auto * object = getObjectiveObjectFrom(cond.position, cond.objectType.as<MapObjectID>()))
+							cond.objectID = object->id;
 					}
 
 					if(cond.objectID != ObjectInstanceID::NONE)

--- a/test/map/TinyH3MBuilderTest.cpp
+++ b/test/map/TinyH3MBuilderTest.cpp
@@ -194,6 +194,7 @@ TEST(TinyH3MBuilderTest, HeroesPlacement)
 	EXPECT_EQ(fixed->getHeroTypeID(), HeroTypeID(0));
 	EXPECT_EQ(fixed->anchorPos(), int3(5, 5, 0));
 	EXPECT_EQ(random->anchorPos(), int3(6, 6, 0));
+	EXPECT_EQ(loaded.map->getObjectiveObjectFrom(fixed->anchorPos(), Obj::HERO), fixed);
 }
 
 TEST(TinyH3MBuilderTest, SpellScrollLoads)


### PR DESCRIPTION
  Fixes #7626:
  - #7626 

Hero objectives may store the hero's anchor position, while the hero is registered on its visitable tile. This caused objective resolution to leave `objectID` unset and could trigger an immediate defeat.