### PR TITLE
Fix BattleAI attacks on the way to targets

### DIFF
--- a/AI/BattleAI/BattleEvaluator.cpp
+++ b/AI/BattleAI/BattleEvaluator.cpp
@@ -312,7 +312,9 @@ BattleAction BattleEvaluator::selectStackAction(const CStack * stack)
 				moveTarget.cachedAttack->attack.defender->getPosition(),
 				moveTarget.score);
 
-			return goTowardsNearest(stack, moveTarget.positions, *targets);
+			const auto primaryTargetHexes = moveTarget.cachedAttack->attack.defender->getAttackableHexes(stack);
+
+			return goTowardsNearest(stack, moveTarget.positions, *targets, primaryTargetHexes);
 		}
 		else
 		{
@@ -337,7 +339,7 @@ BattleAction BattleEvaluator::selectStackAction(const CStack * stack)
 			if(stack->doubleWide() && vstd::contains(brokenWallMoat, stack->getPosition()))
 				return BattleAction::makeMove(stack, stack->getPosition().cloneInDirection(BattleHex::RIGHT));
 			else
-				return goTowardsNearest(stack, brokenWallMoat, *targets);
+				return goTowardsNearest(stack, brokenWallMoat, *targets, brokenWallMoat);
 		}
 	}
 
@@ -351,16 +353,22 @@ uint64_t timeElapsed(std::chrono::time_point<std::chrono::steady_clock> start)
 	return std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count();
 }
 
-BattleAction BattleEvaluator::moveOrAttack(const CStack * stack, const BattleHex & hex, const PotentialTargets & targets)
+BattleAction BattleEvaluator::moveOrAttack(
+	const CStack * stack,
+	const BattleHex & movementTarget,
+	const PotentialTargets & targets,
+	const BattleHexArray & allowedAttackOrigins)
 {
-	auto additionalScore = 0;
+	float bestAttackValue = 0.0f;
 	std::optional<AttackPossibility> attackOnTheWay;
 
-	for(auto & target : targets.possibleAttacks)
+	for(const auto & target : targets.possibleAttacks)
 	{
-		if(!target.attack.shooting && target.from == hex && target.attackValue() > additionalScore)
+		if(!target.attack.shooting
+			&& (target.from == movementTarget || allowedAttackOrigins.contains(target.from))
+			&& target.attackValue() > bestAttackValue)
 		{
-			additionalScore = target.attackValue();
+			bestAttackValue = target.attackValue();
 			attackOnTheWay = target;
 		}
 	}
@@ -372,14 +380,18 @@ BattleAction BattleEvaluator::moveOrAttack(const CStack * stack, const BattleHex
 	}
 	else
 	{
-		if(stack->position == hex)
+		if(stack->position == movementTarget)
 			return BattleAction::makeDefend(stack);
 		else
-			return BattleAction::makeMove(stack, hex);
+			return BattleAction::makeMove(stack, movementTarget);
 	}
 }
 
-BattleAction BattleEvaluator::goTowardsNearest(const CStack * stack, const BattleHexArray & hexes, const PotentialTargets & targets)
+BattleAction BattleEvaluator::goTowardsNearest(
+	const CStack * stack,
+	const BattleHexArray & movementTargets,
+	const PotentialTargets & targets,
+	const BattleHexArray & finalDestinationHexes)
 {
 	auto reachability = cb->getBattle(battleID)->getReachability(stack);
 	auto avHexes = cb->getBattle(battleID)->battleGetAvailableHexes(reachability, stack, false);
@@ -401,32 +413,87 @@ BattleAction BattleEvaluator::goTowardsNearest(const CStack * stack, const Battl
 		});
 	}
 
-	if(avHexes.empty() || hexes.empty()) //we are blocked or dest is blocked
+	if(avHexes.empty() || movementTargets.empty()) //we are blocked or dest is blocked
 	{
 		return BattleAction::makeDefend(stack);
 	}
 
-	BattleHexArray targetHexes = hexes;
+	BattleHexArray sortedMovementTargets = movementTargets;
 
-	targetHexes.sort([&reachability](const BattleHex & h1, const BattleHex & h2) -> bool
+	sortedMovementTargets.sort([&reachability](const BattleHex & h1, const BattleHex & h2) -> bool
 		{
 			return reachability.distances[h1.toInt()] < reachability.distances[h2.toInt()];
 		});
 
-	BattleHex bestNeighbour = targetHexes.front();
+	BattleHex nearestMovementTarget = sortedMovementTargets.front();
 
-	if(reachability.distances[bestNeighbour.toInt()] > GameConstants::BFIELD_SIZE)
+	if(reachability.distances[nearestMovementTarget.toInt()] > GameConstants::BFIELD_SIZE)
 	{
 		logAi->trace("No reachable hexes.");
 		return BattleAction::makeDefend(stack);
 	}
 
+	auto moveOrAttackTowards = [&](const BattleHex & movementDestination) -> BattleAction
+	{
+		BattleHexArray allowedAttackOrigins;
+		const auto movementRange = stack->getMovementRange(0);
+
+		if(movementRange == 0)
+			return moveOrAttack(stack, movementDestination, targets);
+
+		ReachabilityInfo::TDistances remainingDistances;
+		remainingDistances.fill(ReachabilityInfo::INFINITE_DIST);
+
+		// The closest final destination may change after taking a useful target on the way.
+		for(const auto & finalDestinationHex : finalDestinationHexes)
+		{
+			if(!reachability.isReachable(finalDestinationHex))
+				continue;
+
+			BattleHexArray knownAccessible = stack->getHexes();
+			knownAccessible.insert(battle::Unit::getHexes(
+				finalDestinationHex,
+				stack->doubleWide(),
+				stack->unitSide()));
+
+			ReachabilityInfo::Parameters targetParams(stack, finalDestinationHex);
+			targetParams.knownAccessible = &knownAccessible;
+			auto targetReachability = cb->getBattle(battleID)->getReachability(targetParams);
+
+			for(size_t i = 0; i < remainingDistances.size(); ++i)
+				remainingDistances[i] = std::min(remainingDistances[i], targetReachability.distances[i]);
+		}
+
+		const auto movementDistance = remainingDistances[movementDestination.toInt()];
+		const auto turnsAfterMovement = (movementDistance + movementRange - 1) / movementRange;
+
+		for(const auto & target : targets.possibleAttacks)
+		{
+			if(target.attack.shooting
+				|| !avHexes.contains(target.from)
+				|| remainingDistances[target.from.toInt()] == ReachabilityInfo::INFINITE_DIST
+				|| scoreEvaluator.checkPositionBlocksOurStacks(*hb, stack, target.from))
+				continue;
+
+			const auto distanceAfterAttack = remainingDistances[target.from.toInt()];
+			const auto turnsAfterAttack = (distanceAfterAttack + movementRange - 1) / movementRange;
+
+			// The attack origin must not delay arrival at the final destination.
+			if(turnsAfterAttack <= turnsAfterMovement)
+			{
+				allowedAttackOrigins.insert(target.from);
+			}
+		}
+
+		return moveOrAttack(stack, movementDestination, targets, allowedAttackOrigins);
+	};
+
 	// this turn
-	for(const auto & hex : targetHexes)
+	for(const auto & hex : sortedMovementTargets)
 	{
 		if(avHexes.contains(hex))
 		{
-			return moveOrAttack(stack, hex, targets);
+			return moveOrAttackTowards(hex);
 		}
 
 		if(stack->coversPos(hex))
@@ -459,12 +526,12 @@ BattleAction BattleEvaluator::goTowardsNearest(const CStack * stack, const Battl
 		}
 		// Flying stack doesn't go hex by hex, so we can't backtrack using predecessors.
 		// We just check all available hexes and pick the one closest to the target.
-		auto nearestAvailableHex = vstd::minElementByFun(avHexes, [this, &bestNeighbour, &stack, &obstacleHexes](const BattleHex & hex) -> int
+		auto nearestAvailableHex = vstd::minElementByFun(avHexes, [this, &nearestMovementTarget, &stack, &obstacleHexes](const BattleHex & hex) -> int
 		{
 			const int NEGATIVE_OBSTACLE_PENALTY = 100; // avoid landing on negative obstacle (moat, fire wall, etc)
 			const int BLOCKED_STACK_PENALTY = 100; // avoid landing on moat
 
-			auto distance = BattleHex::getDistance(bestNeighbour, hex);
+			auto distance = BattleHex::getDistance(nearestMovementTarget, hex);
 
 			if(obstacleHexes.contains(hex))
 				distance += NEGATIVE_OBSTACLE_PENALTY;
@@ -472,11 +539,11 @@ BattleAction BattleEvaluator::goTowardsNearest(const CStack * stack, const Battl
 			return scoreEvaluator.checkPositionBlocksOurStacks(*hb, stack, hex) ? BLOCKED_STACK_PENALTY + distance : distance;
 		});
 
-		return moveOrAttack(stack, *nearestAvailableHex, targets);
+		return moveOrAttackTowards(*nearestAvailableHex);
 	}
 	else
 	{
-		BattleHex currentDest = bestNeighbour;
+		BattleHex currentDest = nearestMovementTarget;
 
 		while(true)
 		{
@@ -488,7 +555,7 @@ BattleAction BattleEvaluator::goTowardsNearest(const CStack * stack, const Battl
 			if(avHexes.contains(currentDest)
 				&& !scoreEvaluator.checkPositionBlocksOurStacks(*hb, stack, currentDest))
 			{
-				return moveOrAttack(stack, currentDest, targets);
+				return moveOrAttackTowards(currentDest);
 			}
 
 			currentDest = reachability.predecessors[currentDest.toInt()];

--- a/AI/BattleAI/BattleEvaluator.h
+++ b/AI/BattleAI/BattleEvaluator.h
@@ -46,12 +46,20 @@ public:
 	bool attemptCastingSpell(const CStack * stack);
 	bool canCastSpell();
 	std::optional<PossibleSpellcast> findBestCreatureSpell(const CStack * stack);
-	BattleAction goTowardsNearest(const CStack * stack, const BattleHexArray & hexes, const PotentialTargets & targets);
+	BattleAction goTowardsNearest(
+		const CStack * stack,
+		const BattleHexArray & movementTargets,
+		const PotentialTargets & targets,
+		const BattleHexArray & finalDestinationHexes);
 	std::vector<BattleHex> getBrokenWallMoatHexes() const;
 	bool hasWorkingTowers() const;
 	void evaluateCreatureSpellcast(const CStack * stack, PossibleSpellcast & ps); //for offensive damaging spells only
 	void print(const std::string & text) const;
-	BattleAction moveOrAttack(const CStack * stack, const BattleHex & hex, const PotentialTargets & targets);
+	BattleAction moveOrAttack(
+		const CStack * stack,
+		const BattleHex & movementTarget,
+		const PotentialTargets & targets,
+		const BattleHexArray & allowedAttackOrigins = {});
 
 	BattleEvaluator(
 		std::shared_ptr<Environment> env,

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -170,6 +170,7 @@ if(ENABLE_BATTLE_AI)
 
 	list(APPEND test_SRCS
 		${BATTLE_AI_TEST_SRCS}
+		battleAI/BattleEvaluatorTest.cpp
 		battleAI/SpellTargetsEvaluatorTest.cpp
 	)
 endif()

--- a/test/battleAI/BattleEvaluatorTest.cpp
+++ b/test/battleAI/BattleEvaluatorTest.cpp
@@ -1,0 +1,116 @@
+/*
+ * BattleEvaluatorTest.cpp, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
+#include "StdInc.h"
+
+#include "../server/battles/BattleTestFixture.h"
+
+#include "AI/BattleAI/BattleEvaluator.h"
+#include "lib/GameLibrary.h"
+#include "lib/ObstacleHandler.h"
+#include "lib/battle/BattleAction.h"
+#include "lib/battle/CObstacleInstance.h"
+#include "lib/battle/CPlayerBattleCallback.h"
+#include "lib/callback/CBattleCallback.h"
+#include "server/CGameHandler.h"
+
+namespace test
+{
+class BattleEvaluatorTest : public BattleTestFixture
+{
+public:
+	void SetUp() override
+	{
+		BattleTestFixture::SetUp();
+		startGame();
+		startBattle();
+		battle()->stacks.clear();
+	}
+
+	BattleAction moveTowards(
+		const CStack * stack,
+		const BattleHexArray & movementTargets,
+		const BattleHexArray & finalDestinationHexes)
+	{
+		std::shared_ptr<Environment> environment = gameHandler;
+		auto callback = std::make_shared<CBattleCallback>(defenderSideHero->getOwner(), nullptr);
+		callback->onBattleStarted(battle());
+
+		auto hypotheticalBattle = std::make_shared<HypotheticBattle>(environment.get(), callback->getBattle(BattleID(0)));
+		DamageCache damageCache;
+		damageCache.buildDamageCache(hypotheticalBattle, BattleSide::DEFENDER);
+		PotentialTargets targets(stack, damageCache, hypotheticalBattle);
+		BattleEvaluator evaluator(environment, callback, hypotheticalBattle, damageCache, stack,
+			defenderSideHero->getOwner(), BattleID(0), BattleSide::DEFENDER, 1.0f, 2);
+
+		return evaluator.goTowardsNearest(stack, movementTargets, targets, finalDestinationHexes);
+	}
+
+	BattleAction moveTowards(const CStack * stack, const CStack * target)
+	{
+		auto primaryTargetHexes = target->getAttackableHexes(stack);
+		return moveTowards(stack, primaryTargetHexes, primaryTargetHexes);
+	}
+
+	void addObstacle()
+	{
+		const auto * obstacleInfo = LIBRARY->obstacles()->getByName("core:12");
+		ASSERT_NE(obstacleInfo, nullptr);
+
+		auto obstacle = std::make_shared<CObstacleInstance>();
+		obstacle->ID = obstacleInfo->obstacle.getNum(); // ObDtS03: the dead tree and rocks from the reported battle
+		obstacle->pos = BattleHex(9, 6);
+		battle()->obstacles.push_back(obstacle);
+	}
+};
+
+TEST_F(BattleEvaluatorTest, AttacksSuitableTargetOnWayToReportedMovementWaypoint)
+{
+	auto * elf = addStack(BattleSide::ATTACKER, creatureByName("core:woodElf"), BattleHex(1, 8), 30);
+	auto * griffin = addStack(BattleSide::ATTACKER, creatureByName("core:griffin"), BattleHex(7, 4), 1);
+	auto * behemoth = addStack(BattleSide::DEFENDER, creatureByName("core:behemoth"), BattleHex(14, 5), 3);
+
+	addObstacle();
+
+	BattleHex movementWaypoint(9, 7);
+	BattleHexArray movementWaypoints{movementWaypoint};
+	auto reachability = battle()->getReachability(behemoth);
+	ASSERT_EQ(reachability.distances[movementWaypoint.toInt()], behemoth->getMovementRange(0));
+	auto action = moveTowards(behemoth, movementWaypoints, elf->getAttackableHexes(behemoth));
+
+	ASSERT_EQ(action.actionType, EActionType::WALK_AND_ATTACK);
+	ASSERT_EQ(action.target.size(), 2);
+	EXPECT_EQ(action.target[1].hexValue, griffin->getPosition());
+}
+
+TEST_F(BattleEvaluatorTest, SkipsTargetIfAttackWouldDelayPrimaryTarget)
+{
+	auto * elf = addStack(BattleSide::ATTACKER, creatureByName("core:woodElf"), BattleHex(2, 7), 30);
+	addStack(BattleSide::ATTACKER, creatureByName("core:griffin"), BattleHex(13, 1), 1);
+	auto * behemoth = addStack(BattleSide::DEFENDER, creatureByName("core:behemoth"), BattleHex(13, 5), 3);
+
+	auto action = moveTowards(behemoth, elf);
+
+	EXPECT_EQ(action.actionType, EActionType::WALK);
+}
+
+TEST_F(BattleEvaluatorTest, SkipsUnprofitableTargetWithoutDelayingPrimaryTarget)
+{
+	auto * elf = addStack(BattleSide::ATTACKER, creatureByName("core:woodElf"), BattleHex(1, 8), 30);
+	addStack(BattleSide::ATTACKER, creatureByName("core:angel"), BattleHex(7, 4), 20);
+	auto * behemoth = addStack(BattleSide::DEFENDER, creatureByName("core:behemoth"), BattleHex(14, 5), 3);
+
+	addObstacle();
+
+	BattleHexArray movementWaypoints{BattleHex(9, 7)};
+	auto action = moveTowards(behemoth, movementWaypoints, elf->getAttackableHexes(behemoth));
+
+	EXPECT_EQ(action.actionType, EActionType::WALK);
+}
+}


### PR DESCRIPTION
Keep immediate movement waypoints separate from final destinations when evaluating attacks on the way. Select the best positively valued melee attack whose origin preserves the remaining turn count.

Cover the reported behemoth, griffin, and wood elf battle, as well as delaying and unprofitable candidates.