### PR TITLE
Fix controller trigger threshold settings key

### DIFF
--- a/config/schemas/settings.json
+++ b/config/schemas/settings.json
@@ -352,7 +352,7 @@
 				"enableMouse",
 				"enableTouch",
 				"enableController",
-				"controllerTriggerTreshold",
+				"controllerTriggerThreshold",
 				"controllerAxisDeadZone",
 				"controllerAxisFullZone",
 				"controllerAxisSpeed",
@@ -388,7 +388,7 @@
 					"type" : "boolean",
 					"default" : true
 				},
-				"controllerTriggerTreshold" : {
+				"controllerTriggerThreshold" : {
 					"type" : "number",
 					"default" : 0.3
 				},


### PR DESCRIPTION
## Summary
- fix the settings schema key to match `InputSourceGameController`
- preserve the existing 0.3 default and user override behavior under the canonical key
- keep the maintenance change limited to the schema correction

## Testing
- strict Debug `vcmitest` target builds successfully
- settings schema discovery, maximization, and validation complete through normal `GameLibrary` initialization
- `JsonTest.floatsMatchTheNearestDouble`: 1/1 passed after global schema initialization
