### PR TITLE
Fix O(n) full-map scan in CGMonolith::findMeChannel() during map load

### DIFF
--- a/lib/gameState/CGameState.cpp
+++ b/lib/gameState/CGameState.cpp
@@ -1016,6 +1016,11 @@ void CGameState::initMapObjects(IGameRandomizer & gameRandomizer)
 		obj->initObj(gameRandomizer);
 
 	logGlobal->debug("\tObject initialization done");
+
+	// getObjects<CGMonolith>() also yields CGSubterraneanGate, paired separately below instead
+	for(auto & obj : map->getObjects<CGMonolith>())
+		obj->assignTeleportChannel();
+
 	// getObjects<SeerHut>() already yields exactly seer huts + quest guards
 	for(auto & q : map->getObjects<SeerHut>())
 		q->setObjToKill();

--- a/lib/mapObjects/MiscObjects.cpp
+++ b/lib/mapObjects/MiscObjects.cpp
@@ -403,10 +403,17 @@ void CGTeleport::addToChannel(std::map<TeleportChannelID, std::shared_ptr<Telepo
 
 TeleportChannelID CGMonolith::findMeChannel(const std::vector<Obj> & IDs, MapObjectSubID SubID) const
 {
-	for(auto teleportObj : cb->gameState().getMap().getObjects<CGMonolith>())
+	// teleportChannels only ever contains already-paired monoliths, same as before this searched
+	auto matches = [&](const ObjectInstanceID & objId) -> bool
 	{
-		if(vstd::contains(IDs, teleportObj->ID) && teleportObj->subID == SubID)
-			return teleportObj->channel;
+		const auto * obj = cb->getObj(objId);
+		return obj && vstd::contains(IDs, obj->ID) && obj->subID == SubID;
+	};
+
+	for(const auto & [channelID, channel] : cb->gameState().getMap().teleportChannels)
+	{
+		if(vstd::contains_if(channel->entrances, matches) || vstd::contains_if(channel->exits, matches))
+			return channelID;
 	}
 	return TeleportChannelID();
 }
@@ -460,21 +467,35 @@ void CGMonolith::teleportDialogAnswered(IGameEventCallback & gameEvents, const C
 
 void CGMonolith::initObj(IGameRandomizer & gameRandomizer)
 {
-	std::vector<Obj> IDs;
-	IDs.push_back(ID);
+	// channel pairing is deferred to assignTeleportChannel()
 	switch(ID.toEnum())
 	{
 	case Obj::MONOLITH_ONE_WAY_ENTRANCE:
 		type = ENTRANCE;
-		IDs.emplace_back(Obj::MONOLITH_ONE_WAY_EXIT);
 		break;
 	case Obj::MONOLITH_ONE_WAY_EXIT:
 		type = EXIT;
-		IDs.emplace_back(Obj::MONOLITH_ONE_WAY_ENTRANCE);
 		break;
 	case Obj::MONOLITH_TWO_WAY:
 	default:
 		type = BOTH;
+		break;
+	}
+}
+
+void CGMonolith::assignTeleportChannel()
+{
+	std::vector<Obj> IDs;
+	IDs.push_back(ID);
+	switch(type)
+	{
+	case ENTRANCE:
+		IDs.emplace_back(Obj::MONOLITH_ONE_WAY_EXIT);
+		break;
+	case EXIT:
+		IDs.emplace_back(Obj::MONOLITH_ONE_WAY_ENTRANCE);
+		break;
+	default:
 		break;
 	}
 

--- a/lib/mapObjects/MiscObjects.h
+++ b/lib/mapObjects/MiscObjects.h
@@ -252,6 +252,9 @@ protected:
 public:
 	using CGTeleport::CGTeleport;
 
+	/// Pairs this monolith/whirlpool with its channel; called once every map object exists
+	virtual void assignTeleportChannel();
+
 	template <typename Handler> void serialize(Handler &h)
 	{
 		h & static_cast<CGTeleport&>(*this);
@@ -267,6 +270,9 @@ public:
 	using CGMonolith::CGMonolith;
 
 	static void postInit(IGameInfoCallback * cb);
+
+	/// no-op: gates are paired by postInit() above instead
+	void assignTeleportChannel() override {}
 
 	template <typename Handler> void serialize(Handler &h)
 	{


### PR DESCRIPTION
related to PR #7757 question which object types cause the performance issues. Monoliths and whirlpools were consuming 79% of initMapObjects time on the map I run the tests.

-------------------------------

findMeChannel() paired up monolith/whirlpool teleporters by scanning getObjects<CGMonolith>(), which dynamic_cast-checks every object on the map, for every single monolith/whirlpool being initialized. On a huge map (64.6k objects, 202 monoliths/whirlpools) this is ~13 million dynamic_cast calls just to pair up teleporters.

Defer channel pairing out of initObj() into a new assignTeleportChannel() step that runs once, after every map object exists, and search the map's (much smaller) teleportChannels registry - which already tracks the entrances/exits needed for actual gameplay - instead of rescanning every object. Same result: a match can only ever occur against an already-paired monolith, which is exactly what teleportChannels contains at that point.

Measured on a 64.6k-object map: initMapObjects() 3060ms -> 702ms (4.36x), with the assignTeleportChannel pass itself dropping from ~2356ms to 14.7ms across all 248 monolith/whirlpool/gate objects. No threading involved.