### PR TITLE
Fix duplicate same-target upgrade offers

### DIFF
--- a/lib/gameState/UpgradeInfo.cpp
+++ b/lib/gameState/UpgradeInfo.cpp
@@ -24,9 +24,11 @@ void UpgradeInfo::addUpgrade(const CreatureID & upgradeID, const Creature * crea
 		auto pos = std::distance(upgradesIDs.begin(), idIt);
 		ResourceSet & existingCost = upgradesCosts[pos];
 
+		// Prefer an available offer over an unavailable one;
+		// otherwise replace only with an offer no more expensive in any resource.
 		if (upgradeAvaiable && (!isAvailable || existingCost.canAfford(upgradeCost)))
 		{
-			existingCost = std::move(upgradeCost);
+			existingCost = upgradeCost;
 			isAvailable = true;
 		}
 

--- a/lib/gameState/UpgradeInfo.cpp
+++ b/lib/gameState/UpgradeInfo.cpp
@@ -13,12 +13,28 @@
 
 void UpgradeInfo::addUpgrade(const CreatureID & upgradeID, const Creature * creature, int costPercentageModifier)
 {
-	isAvailable = costPercentageModifier >= 0;
-
-	upgradesIDs.push_back(upgradeID);
+	const bool upgradeAvaiable = costPercentageModifier >= 0;
 
 	ResourceSet upgradeCost = (upgradeID.toCreature()->getFullRecruitCost() - creature->getFullRecruitCost()) * costPercentageModifier / 100;
 	upgradeCost.positive(); //upgrade cost can't be negative, ignore missing resources
+
+	auto idIt = std::find(upgradesIDs.begin(), upgradesIDs.end(), upgradeID);
+	if(idIt != upgradesIDs.end())
+	{
+		auto pos = std::distance(upgradesIDs.begin(), idIt);
+		ResourceSet & existingCost = upgradesCosts[pos];
+
+		if (upgradeAvaiable && (!isAvailable || existingCost.canAfford(upgradeCost)))
+		{
+			existingCost = std::move(upgradeCost);
+			isAvailable = true;
+		}
+
+		return;
+	}
+
+	isAvailable = upgradeAvaiable;
+	upgradesIDs.push_back(upgradeID);
 	upgradesCosts.push_back(std::move(upgradeCost));
 
 	// sort from highest ID to smallest


### PR DESCRIPTION
## Summary

Fix duplicate upgrade offers that target the same creature.

`UpgradeInfo` could contain multiple entries with the same target `CreatureID`, for example when a hero-specific upgrade and a Hill Fort both offer the same final upgrade.

The creature window displays those entries separately, but the server resolves the upgrade cost by target creature ID. This can result in multiple buttons showing different costs while the server always charges the cost associated with the first matching target.

This change deduplicates same-target upgrade offers in `UpgradeInfo::addUpgrade()` and keeps an available offer with a lower cost when it is no more expensive in every resource.

Different upgrade targets remain separate.

## Reproduction

A vanilla example is Bidley with Corsairs at a Hill Fort.

Without this change:

- Bidley can upgrade Corsair -> Sea Dog through his specialty.
- The Hill Fort can also provide Corsair -> Sea Dog.
- The creature window may show two buttons for the same target with different prices.
- Clicking either button can still result in the server charging the cost of the first matching Sea Dog upgrade entry.

With this change:

- only one Corsair -> Sea Dog offer is shown;
- the displayed cost matches the resources actually deducted.

Different-target offers are not merged. For example, Bidley's Pirate can still have both:

- Pirate -> Corsair
- Pirate -> Sea Dog

when both upgrade sources are available.

## Testing

Tested on current `develop` after rebasing onto the latest upstream state.

- Full `RelWithDebInfo | x64` build: 0 failures.
- Bidley + Corsair + Hill Fort: one Corsair -> Sea Dog button.
- Displayed upgrade cost matches the actual server-side resource deduction.
- Pirate -> Corsair and Pirate -> Sea Dog remain available as separate options.
- `git diff --check` passes.

Future work

This fix also provides a clean foundation for configurable SPECIAL_UPGRADE costs. The configurable-cost feature itself will be handled separately.
