### PR TITLE
Fix NK2 blocking dialog object lookup

### DIFF
--- a/AI/Nullkiller2/AIGateway.cpp
+++ b/AI/Nullkiller2/AIGateway.cpp
@@ -567,6 +567,20 @@ void AIGateway::commanderGotLevel(const CCommanderInstance * commander, std::vec
 	executeActionAsync("commanderGotLevel", [this, queryID](){ answerQuery(queryID, 0); });
 }
 
+const CGObjectInstance * AIGateway::selectBlockingDialogObject(
+	const std::vector<const CGObjectInstance *> & objects,
+	ObjectInstanceID activeHero,
+	const CGObjectInstance * plannedTarget)
+{
+	if(objects.empty() || objects.front()->id != activeHero)
+		return vstd::frontOrNull(objects);
+
+	if(objects.size() > 1)
+		return objects.back();
+
+	return plannedTarget && plannedTarget->id != activeHero ? plannedTarget : nullptr;
+}
+
 void AIGateway::showBlockingDialog(const std::string & text, const std::vector<Component> & components, QueryID askID, const int soundID, bool selection, bool cancel, bool safeToAutoaccept)
 {
 	LOG_TRACE_PARAMS(logAi, "text '%s', askID '%i', soundID '%i', selection '%i', cancel '%i', autoaccept '%i'", text % askID % soundID % selection % cancel % safeToAutoaccept);
@@ -586,9 +600,15 @@ void AIGateway::showBlockingDialog(const std::string & text, const std::vector<C
 
 			if(heroPtr.isVerified() && target.isValid() && !objects.empty())
 			{
-				auto topObj = objects.front()->id == heroPtr->id ? objects.back() : objects.front();
-				auto objType = topObj->ID; // top object should be our hero
 				auto goalObjectID = nullkiller->getTargetObject();
+				auto topObj = selectBlockingDialogObject(objects, heroPtr->id, cc->getObj(goalObjectID, false));
+				if(!topObj)
+				{
+					answerQuery(askID, 1);
+					return;
+				}
+
+				auto objType = topObj->ID;
 				auto danger = nullkiller->dangerEvaluator->evaluateDanger(target, heroPtr.get());
 				auto ratio = static_cast<float>(danger) / heroPtr->getTotalStrength();
 

--- a/AI/Nullkiller2/AIGateway.h
+++ b/AI/Nullkiller2/AIGateway.h
@@ -93,6 +93,7 @@ public:
 
 	void heroGotLevel(const CGHeroInstance * hero, PrimarySkill pskill, std::vector<SecondarySkill> & skills, QueryID queryID) override; //pskill is gained primary skill, interface has to choose one of given skills and call callback with selection id
 	void commanderGotLevel(const CCommanderInstance * commander, std::vector<ui32> skills, QueryID queryID) override; //TODO
+	static const CGObjectInstance * selectBlockingDialogObject(const std::vector<const CGObjectInstance *> & objects, ObjectInstanceID activeHero, const CGObjectInstance * plannedTarget);
 	void showBlockingDialog(const std::string & text, const std::vector<Component> & components, QueryID askID, const int soundID, bool selection, bool cancel, bool safeToAutoaccept) override; //Show a dialog, player must take decision. If selection then he has to choose between one of given components, if cancel he is allowed to not choose. After making choice, CCallback::selectionMade should be called with number of selected component (1 - n) or 0 for cancel (if allowed) and askID.
 	void showGarrisonDialog(const CArmedInstance * up, const CGHeroInstance * down, bool removableUnits, QueryID queryID, const MetaString & customTitle) override; //all stacks operations between these objects become allowed, interface has to call onEnd when done
 	void showTeleportDialog(const CGHeroInstance * hero, TeleportChannelID channel, TTeleportExitsList exits, bool impassable, QueryID askID) override;

--- a/test/nullkiller2/AIUtilityTest.cpp
+++ b/test/nullkiller2/AIUtilityTest.cpp
@@ -44,6 +44,16 @@ TinyH3M::TinyH3MBuilder makeQuestlessSeerMap()
 class Nullkiller2_AIUtility : public NullkillerTest {};
 }
 
+TEST(Nullkiller2_AIGateway, blockingDialogFallsBackToPlannedObjectWhenTargetOnlyContainsHero)
+{
+	CGObjectInstance hero(nullptr);
+	CGObjectInstance plannedTarget(nullptr);
+	hero.id = ObjectInstanceID(1);
+	plannedTarget.id = ObjectInstanceID(2);
+
+	EXPECT_EQ(NK2AI::AIGateway::selectBlockingDialogObject({&hero}, hero.id, &plannedTarget), &plannedTarget);
+}
+
 TEST_F(Nullkiller2_AIUtility, trackedSeerWithoutActiveQuestIsNotVisitable)
 {
 	ASSERT_NO_FATAL_FAILURE(startWithMap(makeQuestlessSeerMap()));


### PR DESCRIPTION
A target tile may contain only the active hero when a guarded object is approached from an adjacent tile. Exclude the hero and fall back to the planned target so dialog logging and danger checks use the encountered object.

I saw the following dialog-logging failure and fixed it:
```
Failed to find object of type 34::31
```