### PR TITLE
Fix formatting state when wrapping text

### DIFF
--- a/client/windows/CMessage.cpp
+++ b/client/windows/CMessage.cpp
@@ -77,6 +77,8 @@ std::vector<std::string> CMessage::breakText(std::string text, size_t maxLineWid
 	while(text.length())
 	{
 		ui32 wordBreak = -1; //last position for line break (last space character)
+		bool wordBreakOpened = false; // formatting state at last possible line break
+		std::string wordBreakColor;
 		ui32 currPos = 0; //current position in text
 		bool opened = false; //set to true when opening brace is found
 		std::string color; //color found
@@ -92,7 +94,11 @@ std::vector<std::string> CMessage::breakText(std::string text, size_t maxLineWid
 
 			// candidate for line break
 			if(ui8(text[currPos]) <= ui8(' '))
+			{
 				wordBreak = currPos;
+				wordBreakOpened = opened;
+				wordBreakColor = color;
+			}
 
 			/* We don't count braces in string length. */
 			if(text[currPos] == '{')
@@ -129,11 +135,8 @@ std::vector<std::string> CMessage::breakText(std::string text, size_t maxLineWid
 			if(wordBreak != ui32(-1))
 			{
 				currPos = wordBreak;
-				if(std::ranges::count(text.substr(0, currPos), '{') == std::ranges::count(text.substr(0, currPos), '}'))
-				{
-					opened = false;
-					color = "";
-				}
+				opened = wordBreakOpened;
+				color = wordBreakColor;
 			}
 			else
 				currPos -= symbolSize;


### PR DESCRIPTION
When a line exceeds its maximum width, CMessage::breakText() scans beyond the eventual word-break position before rewinding. The formatting state (whether a `{...}` color span is open and its optional named color) previously remained based on the later scan position.

As a result, wrapping inside highlighted translated placeholders could produce unbalanced formatting across lines and expose a formatting delimiter in the rendered message.

This change records the open/color state whenever a candidate word break is found and restores that exact state when wrapping at that position. The existing logic can then close the formatting span for the current line and reopen it on the next line correctly. Both default gold highlighting and named colors are preserved.

Tested by rebuilding vcmiclient and checking creature-bank messages whose highlighted creature names and reward lists wrap across lines.

## Examples

|Before | After|
|----------|---------|
| <img width="1010" height="929" alt="Screenshot_20260902_154343" src="https://github.com/user-attachments/assets/9492a971-c002-4605-ad18-bac16f2fa1a7" />|<img width="1014" height="928" alt="Screenshot_20260902_154320" src="https://github.com/user-attachments/assets/f25f9ab3-ab59-4870-bfd5-1c5c888875d7" />|
|<img width="655" height="379" alt="Screenshot_20260902_103645" src="https://github.com/user-attachments/assets/50684715-36da-4ffb-a74b-e5b0a0b4f37f" />|<img width="644" height="395" alt="Screenshot_20260902_154252" src="https://github.com/user-attachments/assets/e8953597-98fd-4896-a7e3-46aa6141c179" />|
| <img width="652" height="683" alt="Screenshot_20260902_152355" src="https://github.com/user-attachments/assets/b355dfa3-5c2f-4616-826b-c7385cc58966" /> | <img width="644" height="665" alt="Screenshot_20260902_154303" src="https://github.com/user-attachments/assets/1b68e81d-225e-4fc9-abed-31b60e6ca0cb" /> |
