### PR TITLE
[SDL3] android lag elimination

### DIFF
--- a/client/mapView/MapView.cpp
+++ b/client/mapView/MapView.cpp
@@ -87,12 +87,21 @@ void BasicMapView::render(Canvas & target, bool fullUpdate)
 
 void BasicMapView::renderGpu(bool fullUpdate)
 {
-	Canvas layer = ENGINE->screenHandler().getLayerCanvas(GpuRenderLayer::MAP);
-	Canvas targetClipped(layer, pos);
-
 	// tick() normally filled the cache; a scroll, zoom or level change since then invalidates it
 	if(!tilesCache->isUpdatedThisFrame())
 		tilesCache->update(controller->getContext());
+
+	// Nothing is drawn over the terrain in the usual case, so the cache is composed straight onto
+	// the screen. Copying it into a layer here would mean reading a render target in the middle of
+	// the frame, which is what stalls the GLES driver on some devices.
+	if(!tilesCache->needsOwnLayer(controller->getContext()))
+	{
+		tilesCache->present(pos * ENGINE->screenHandler().getScalingFactor());
+		return;
+	}
+
+	Canvas layer = ENGINE->screenHandler().getLayerCanvas(GpuRenderLayer::MAP);
+	Canvas targetClipped(layer, pos);
 
 	tilesCache->render(controller->getContext(), targetClipped, fullUpdate);
 }

--- a/client/mapView/MapViewCache.cpp
+++ b/client/mapView/MapViewCache.cpp
@@ -28,7 +28,11 @@
 
 #include "../../lib/int3.h"
 
-MapViewCache::~MapViewCache() = default;
+MapViewCache::~MapViewCache()
+{
+	// the canvases go with this object, so nothing may be left pointing at them
+	ENGINE->screenHandler().clearPresentedCanvas(GpuRenderLayer::MAP);
+}
 
 MapViewCache::MapViewCache(const std::shared_ptr<MapViewModel> & model, bool useGpuLayer)
 	: model(model)
@@ -79,6 +83,9 @@ void MapViewCache::ensureCanvases()
 
 	// Must run on the rendering thread: this object is constructed while handling a
 	// netpack, and creating a texture there would move the GL context off the GUI thread
+	// what the screen handler was told to draw refers to the canvas about to be replaced
+	ENGINE->screenHandler().clearPresentedCanvas(GpuRenderLayer::MAP);
+
 	canvasesOnGpu = useGpu;
 	cachedAtNativeSize = cacheAtNativeSize;
 	cachedCanvasDimensions = cacheDimensions;
@@ -254,7 +261,7 @@ bool MapViewCache::isUpdatedThisFrame() const
 		&& cachedLevel == model->getLevel();
 }
 
-void MapViewCache::renderCachedTiles(Canvas & target)
+void MapViewCache::forEachCachedBand(const std::function<void(const Rect &, const Point &, const Point &)> & visit) const
 {
 	const Rect tilesRect = model->getTilesTotalRect();
 	const Point tileSize = model->getSingleTileSize();
@@ -302,15 +309,61 @@ void MapViewCache::renderCachedTiles(Canvas & target)
 				Point targetPosition = origin + Point(offsetX * tileSize.x, offsetY * tileSize.y);
 				Point targetSize(column.second * tileSize.x, row.second * tileSize.y);
 
-				if(cacheTileSize == tileSize)
-					target.draw(Canvas(*terrain, cacheArea), targetPosition);
-				else
-					target.drawScaled(Canvas(*terrain, cacheArea), targetPosition, targetSize);
+				visit(cacheArea, targetPosition, targetSize);
 			}
 			offsetY += row.second;
 		}
 		offsetX += column.second;
 	}
+}
+
+void MapViewCache::renderCachedTiles(Canvas & target)
+{
+	const Point tileSize = model->getSingleTileSize();
+	const Point cacheTileSize = model->getCacheTileSize();
+
+	forEachCachedBand([&](const Rect & cacheArea, const Point & targetPosition, const Point & targetSize)
+	{
+		if(cacheTileSize == tileSize)
+			target.draw(Canvas(*terrain, cacheArea), targetPosition);
+		else
+			target.drawScaled(Canvas(*terrain, cacheArea), targetPosition, targetSize);
+	});
+}
+
+void MapViewCache::present(const Rect & targetArea)
+{
+	ensureCanvases();
+
+	// The cache is handed over rather than copied here: reading this render target in the middle
+	// of a frame makes a tiling GPU resolve it right then, which on some Android drivers stalls
+	// every process on the device. Drawn while the frame is composed, the same read is free.
+	const int scaling = ENGINE->screenHandler().getScalingFactor();
+	std::vector<PresentedRegion> regions;
+
+	forEachCachedBand([&](const Rect & cacheArea, const Point & targetPosition, const Point & targetSize)
+	{
+		// The cache canvas holds its pixels at the scaling factor, so the region inside its
+		// texture is not the logical rectangle. Letting the canvas work it out keeps this
+		// identical to what the blit into a layer would have read.
+		const Canvas band(*terrain, cacheArea);
+
+		regions.push_back({band.getRenderArea(), Rect(targetArea.topLeft() + targetPosition * scaling, targetSize * scaling)});
+	});
+
+	ENGINE->screenHandler().presentFromCanvas(GpuRenderLayer::MAP, *terrain, regions);
+
+	// the whole window was handed over, so nothing is waiting to be drawn from the cache
+	std::fill_n(tilesUpToDate.data(), tilesUpToDate.num_elements(), true);
+
+	cachedPosition = model->getMapViewCenter();
+	overlayWasVisible = false;
+	updatedThisFrame = false;
+}
+
+bool MapViewCache::needsOwnLayer(const std::shared_ptr<IMapRendererContext> & context) const
+{
+	return context->showImageOverlay() || context->showTextOverlay() || !vstd::isAlmostZero(context->viewTransitionProgress());
 }
 
 void MapViewCache::render(const std::shared_ptr<IMapRendererContext> & context, Canvas & target, bool fullRedraw)

--- a/client/mapView/MapViewCache.h
+++ b/client/mapView/MapViewCache.h
@@ -96,6 +96,10 @@ class MapViewCache
 
 	/// Copies the entire cached tile window onto the target in as few blits as possible. Used
 	/// when every tile has to be repainted anyway, above all while the view is scrolling.
+	/// Walks the visible window of the cache. Because tiles are stored wrapped around on both
+	/// axes it falls into at most four bands, each contiguous in the cache and on screen.
+	void forEachCachedBand(const std::function<void(const Rect & cacheArea, const Point & targetPosition, const Point & targetSize)> & visit) const;
+
 	void renderCachedTiles(Canvas & target);
 
 	std::shared_ptr<IImage> getOverlayImageForTile(const std::shared_ptr<IMapRendererContext> & context, const int3 & coordinates);
@@ -118,6 +122,14 @@ public:
 
 	/// renders updated terrain cache onto provided canvas
 	void render(const std::shared_ptr<IMapRendererContext> & context, Canvas & target, bool fullRedraw);
+
+	/// Hands the visible window of the cache to the screen handler, to be drawn onto the screen
+	/// while the frame is composed rather than copied into a layer now. Only valid when nothing
+	/// has to be drawn on top of the terrain - see needsOwnLayer(). targetArea is in screen pixels.
+	void present(const Rect & targetArea);
+
+	/// Whether this frame draws anything over the terrain, which needs a layer of its own
+	bool needsOwnLayer(const std::shared_ptr<IMapRendererContext> & context) const;
 
 	/// creates snapshot of current view and stores it into internal canvas
 	/// used for view transition, e.g. Dimension Door spell or teleporters (Subterra gates / Monolith)

--- a/clientsdl2/render/IScreenHandler.h
+++ b/clientsdl2/render/IScreenHandler.h
@@ -11,11 +11,19 @@
 #pragma once
 
 #include "lib/constants/Enumerations.h"
+#include "lib/Rect.h"
 
 class Point;
 class Rect;
 
 class Canvas;
+
+/// One region of an offscreen canvas. Unused here; client code is shared between backends.
+struct PresentedRegion
+{
+	Rect source;
+	Rect target;
+};
 
 /// GPU layers composited under the software screen. This backend has none, but client code
 /// is shared between backends and names them.
@@ -90,4 +98,8 @@ public:
 
 	/// No GPU drawing happens in this backend, so there is nothing queued to hand over
 	void flushRenderCommands() {}
+
+	/// This backend composes in software, so there is no separate present to defer a copy to
+	void presentFromCanvas(GpuRenderLayer, const Canvas &, const std::vector<PresentedRegion> &) {}
+	void clearPresentedCanvas(GpuRenderLayer) {}
 };

--- a/clientsdl3/render/Canvas.h
+++ b/clientsdl3/render/Canvas.h
@@ -101,6 +101,10 @@ public:
 	/// True when this canvas draws with the GPU rather than into a surface
 	bool isRenderTarget() const { return renderTarget != nullptr; }
 
+	/// The texture this canvas draws onto, for the screen handler to read from while it composes
+	/// the frame. Null for a surface-backed canvas.
+	SDL_Texture * getRenderTargetTexture() const { return renderTarget; }
+
 	~Canvas();
 
 	/// if set to true, drawing this canvas onto another canvas will use alpha channel information

--- a/clientsdl3/render/IScreenHandler.h
+++ b/clientsdl3/render/IScreenHandler.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "lib/constants/Enumerations.h"
+#include "lib/Rect.h"
 
 class Point;
 class Rect;
@@ -25,6 +26,13 @@ enum class GpuRenderLayer : uint8_t
 	BATTLE,
 
 	COUNT
+};
+
+/// One region of an offscreen canvas, drawn onto the screen while the frame is composed
+struct PresentedRegion
+{
+	Rect source; ///< within the canvas
+	Rect target; ///< in screen pixels
 };
 
 class IScreenHandler
@@ -100,4 +108,20 @@ public:
 	/// Hands everything drawn so far to the GPU instead of leaving it queued. Lets drawing
 	/// that a later pass reads back start early, rather than stalling on the first read.
 	virtual void flushRenderCommands() = 0;
+
+	/// Draws parts of an offscreen canvas onto the screen while the frame is composed, in place of
+	/// the given layer, instead of copying them into that layer during the frame.
+	///
+	/// Reading a render target in the middle of a frame makes a tiling GPU resolve it right then.
+	/// On some Android drivers that reorganises memory and stalls every process on the device for
+	/// a fifth of a second; the same read costs nothing once the frame is being handed over.
+	///
+	/// What is registered here replaces the previous registration and stays until it is replaced,
+	/// or clearPresentedCanvas() is called - a layer keeps its content across frames, and a window
+	/// opening over the map must not blank it. The layer it stands in for stops being composited.
+	virtual void presentFromCanvas(GpuRenderLayer layer, const Canvas & source, const std::vector<PresentedRegion> & regions) = 0;
+
+	/// Forgets what presentFromCanvas() registered. Must be called before the canvas it refers to
+	/// is destroyed, since only the caller knows when that happens.
+	virtual void clearPresentedCanvas(GpuRenderLayer layer) = 0;
 };

--- a/clientsdl3/render/ScreenHandler.cpp
+++ b/clientsdl3/render/ScreenHandler.cpp
@@ -984,10 +984,16 @@ void ScreenHandler::presentScreenTexture()
 		// GPU resolve it and, on some drivers, stalls every process on the device.
 		const PresentedCanvas & presented = presentedCanvases[i];
 
+		// This draw carries the same downscale the layer would have been composited with, so it
+		// needs that filter too - nearest drops rows of the map, shifting as the view scrolls.
+		SDL_ScaleMode presentedScaleMode = SDL_SCALEMODE_LINEAR;
+		if(!presented.regions.empty())
+			SDL_GetDefaultTextureScaleMode(renderer, &presentedScaleMode);
+
 		for(const PresentedRegion & region : presented.regions)
 		{
 			SDL_SetTextureBlendMode(presented.source, SDL_BLENDMODE_NONE);
-			SDL_SetTextureScaleMode(presented.source, SDL_SCALEMODE_NEAREST);
+			SDL_SetTextureScaleMode(presented.source, presentedScaleMode);
 
 			SDL_FRect from = CSDL_Ext::toSDLFloat(region.source);
 			SDL_FRect to = CSDL_Ext::toSDLFloat(region.target);

--- a/clientsdl3/render/ScreenHandler.cpp
+++ b/clientsdl3/render/ScreenHandler.cpp
@@ -717,6 +717,9 @@ void ScreenHandler::clearLayer(size_t index)
 
 void ScreenHandler::initializeLayerTextures(const Point & logicalSize)
 {
+	// whatever was registered referred to canvases sized for the previous resolution
+	presentedCanvases = {};
+
 	SDL_Renderer * renderer = GpuResources::get().renderer();
 
 	// The software driver supports render targets too, but rasterizes them on the CPU -
@@ -773,6 +776,7 @@ void ScreenHandler::destroyWindow()
 {
 	if(nullptr != GpuResources::get().renderer())
 	{
+		presentedCanvases = {};
 		GpuResources::get().destroyRenderer();
 	}
 
@@ -822,6 +826,9 @@ Canvas ScreenHandler::getLayerCanvas(GpuRenderLayer layer)
 
 	layerActive.at(index) = true;
 	layerReleasedMask &= ~(1u << index);
+
+	// this layer is drawn the ordinary way from now on
+	presentedCanvases.at(index) = PresentedCanvas{};
 
 	return Canvas::createFromRenderTarget(layerTextures.at(index), getLogicalResolution(), CanvasScalingPolicy::AUTO);
 }
@@ -928,6 +935,27 @@ void ScreenHandler::flushRenderCommands()
 	SDL_FlushRenderer(GpuResources::get().renderer());
 }
 
+void ScreenHandler::presentFromCanvas(GpuRenderLayer layer, const Canvas & source, const std::vector<PresentedRegion> & regions)
+{
+	const size_t index = static_cast<size_t>(layer);
+
+	PresentedCanvas & presented = presentedCanvases.at(index);
+
+	presented.source = source.getRenderTargetTexture();
+	presented.regions = presented.source ? regions : std::vector<PresentedRegion>{};
+
+	// What is registered here is drawn instead of the layer, so the layer has to stop being
+	// composited - otherwise whatever it held last stays on screen on top of it. Only while it is
+	// still active, so that this does not clear an already empty layer every frame.
+	if(layerActive.at(index))
+		releaseLayer(layer);
+}
+
+void ScreenHandler::clearPresentedCanvas(GpuRenderLayer layer)
+{
+	presentedCanvases.at(static_cast<size_t>(layer)) = PresentedCanvas{};
+}
+
 void ScreenHandler::presentScreenTexture()
 {
 	// the memory cache gives assets up on whichever thread loaded one; freeing what they hold has
@@ -949,8 +977,28 @@ void ScreenHandler::presentScreenTexture()
 	SDL_RenderClear(renderer);
 
 	for(size_t i = 0; i < layerTextures.size(); ++i)
+	{
+		// The canvas registered for this layer comes first, so that whatever the layer itself
+		// holds still lands on top of it. This is the copy that would otherwise have been made
+		// into the layer in the middle of the frame, where reading a render target makes a tiling
+		// GPU resolve it and, on some drivers, stalls every process on the device.
+		const PresentedCanvas & presented = presentedCanvases[i];
+
+		for(const PresentedRegion & region : presented.regions)
+		{
+			SDL_SetTextureBlendMode(presented.source, SDL_BLENDMODE_NONE);
+			SDL_SetTextureScaleMode(presented.source, SDL_SCALEMODE_NEAREST);
+
+			SDL_FRect from = CSDL_Ext::toSDLFloat(region.source);
+			SDL_FRect to = CSDL_Ext::toSDLFloat(region.target);
+
+			if(!SDL_RenderTexture(renderer, presented.source, &from, &to))
+				logGlobal->error("Failed to compose a presented canvas region: %s", SDL_GetError());
+		}
+
 		if(layerTextures[i] && layerActive[i])
 			SDL_RenderTexture(renderer, layerTextures[i], nullptr, nullptr);
+	}
 
 	SDL_RenderTexture(renderer, isGpuRenderingEnabled() ? screenTarget : screenTexture, nullptr, nullptr);
 	ENGINE->cursor().render();

--- a/clientsdl3/render/ScreenHandler.h
+++ b/clientsdl3/render/ScreenHandler.h
@@ -52,6 +52,16 @@ class ScreenHandler final : public IScreenHandler
 	SDL_Texture * screenTarget = nullptr;
 
 	/// Render targets composited under screenTexture, in GpuRenderLayer order
+	/// What presentFromCanvas() registered per layer: regions of an offscreen canvas drawn while
+	/// the frame is composed, in place of that layer's own content. Kept across frames, like the
+	/// layer textures themselves.
+	struct PresentedCanvas
+	{
+		SDL_Texture * source = nullptr;
+		std::vector<PresentedRegion> regions;
+	};
+	std::array<PresentedCanvas, static_cast<size_t>(GpuRenderLayer::COUNT)> presentedCanvases;
+
 	std::array<SDL_Texture *, static_cast<size_t>(GpuRenderLayer::COUNT)> layerTextures = {};
 
 	/// Whether a layer currently holds content that should be composited
@@ -154,6 +164,8 @@ public:
 	Canvas createOffscreenCanvas(const Point & size) const final;
 	int maxOffscreenCanvasSize() const final;
 	void flushRenderCommands() final;
+	void presentFromCanvas(GpuRenderLayer layer, const Canvas & source, const std::vector<PresentedRegion> & regions) final;
+	void clearPresentedCanvas(GpuRenderLayer layer) final;
 	void updateScreenTexture() final;
 	void presentScreenTexture() final;
 


### PR DESCRIPTION
Eliminates lag on some android devices caused by reorganizing memory (checked with perfetto trace).

Only affects SDL3 backend.

Before (on Galaxy S23):
<img width="1126" height="62" alt="image" src="https://github.com/user-attachments/assets/9b14f496-ac9c-4a2b-9795-a482fdcfaea8" />
Peaks with up to 200ms while scrolling (red - hard to see - sorry).

After:
<img width="919" height="56" alt="image" src="https://github.com/user-attachments/assets/651cb66d-fe28-4bdc-833d-52ff096b86bd" />
No more memory lag.

# Summary: Map cache compositing

## Why

On the GPU path the adventure map's terrain cache is a render target. Copying it into the map's GPU
layer during the frame means reading a render target while another one is bound, which a tiling GPU
has to resolve right then. Some Android GLES drivers answer that by reorganising memory, stalling
every process on the device for up to 200 ms while scrolling.

Reading the same texture when the frame is handed over costs nothing - that is where the GPU layers
are read anyway, and they never caused it.

## What changed

The terrain cache is no longer copied into the map's GPU layer during the frame. Instead the map
view tells the screen handler which part of the cache is visible and where it belongs, and the
screen handler draws it straight onto the screen when the frame is composed.
