### PR TITLE
Add configurable SPECIAL_UPGRADE cost

### DIFF
--- a/docs/modders/Bonus/Bonus_Types.md
+++ b/docs/modders/Bonus/Bonus_Types.md
@@ -448,6 +448,7 @@ Allows creature being upgraded to another creature (Gelu, Dracon)
 
 - subtype: identifier of creature that can being upgraded
 - addInfo: identifier of creature to which perform an upgrade
+- val: modifies the upgrade cost relative to the default 100% cost. If omitted or set to `0`, the cost is unchanged; negative values provide a discount, while positive values increase the upgrade cost.
 
 ## Artifact bonuses
 

--- a/lib/mapObjects/CGHeroInstance.cpp
+++ b/lib/mapObjects/CGHeroInstance.cpp
@@ -1769,7 +1769,8 @@ void CGHeroInstance::fillUpgradeInfo(UpgradeInfo & info, const CStackInstance & 
 		{
 			auto nid = it->parameters->toCreature();
 			if (nid != stack.getId()) //in very specific case the upgrade is available by default (?)
-				info.addUpgrade(nid, stack.getType());
+				// SPECIAL_UPGRADE value adjusts the default 100% cost; clamp the final modifier to 0%.
+				info.addUpgrade(nid, stack.getType(), std::max(0, 100 + it->val));
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Allow `SPECIAL_UPGRADE` bonuses to configure their upgrade cost through the bonus `val`.

The final upgrade cost percentage is calculated as:

`max(0, 100 + val)`

This keeps existing `SPECIAL_UPGRADE` definitions backward-compatible while allowing mods to make field upgrades cheaper, more expensive, or free.

Examples:

- missing `val` / `val: 0` → 100%
- `val: -50` → 50%
- `val: 50` → 150%
- `val: -100` → 0%
- values below `-100` are clamped to 0%

The modifier is passed to the existing `UpgradeInfo::addUpgrade()` cost calculation, so it applies to the entire upgrade `ResourceSet`, not only gold.

## Testing

Tested on the current `develop` branch after #7775 was merged.

Verified:

- default / missing `val` keeps the normal 100% cost
- positive and negative modifiers work correctly
- `val: -100` produces a free upgrade
- values below `-100` are clamped to a free upgrade
- multi-resource upgrades scale correctly
- UI cost matches the resources actually deducted by the server
- same-target offers interact correctly with the deduplication introduced in #7775

Also verified that configurable cost works when `SPECIAL_UPGRADE` is supplied by different bonus sources:

- hero specialty
- artifact
- secondary skill
- adventure map spell

For example, a `SPECIAL_UPGRADE` with `val: -50` upgraded 10 Swordsmen to Crusaders for exactly 500 gold from each tested source.

Artifact-provided upgrades are active only while the artifact is equipped, and map-spell-provided upgrades follow the lifetime of the spell bonus.

## Implementation

The change is intentionally small and uses the existing `Bonus::val` and `UpgradeInfo::addUpgrade()` cost modifier path.