### PR TITLE
Demote noisy AI logs in terminal

### DIFF
--- a/AI/MMAI/BAI/logger.h
+++ b/AI/MMAI/BAI/logger.h
@@ -50,7 +50,7 @@ public:
 	template<typename... Args>
 	void trace(const std::string & format, Args... args) const
 	{
-		log(ELogLevel::DEBUG, format, args...);
+		log(ELogLevel::TRACE, format, args...);
 	}
 	template<typename... Args>
 	void log(ELogLevel::ELogLevel level, const std::string & format, Args... args) const

--- a/AI/MMAI/BAI/v13/BAI.cpp
+++ b/AI/MMAI/BAI/v13/BAI.cpp
@@ -119,9 +119,9 @@ void BAI::battleEnd(const BattleID & bid, const BattleResult * br, QueryID query
 	}
 
 	if(getActionTotalCalls > 0)
-		logger.info("MMAI stats after battle end: %d predictions, %d ms per prediction", getActionTotalCalls, getActionTotalMs / getActionTotalCalls);
+		logger.trace("MMAI stats after battle end: %d predictions, %d ms per prediction", getActionTotalCalls, getActionTotalMs / getActionTotalCalls);
 	else
-		logger.info("MMAI stats after battle end: 0 predictions");
+		logger.trace("MMAI stats after battle end: 0 predictions");
 
 	// BAI is destroyed after this call
 	logger.debug("Leaving battleEnd, embracing death");
@@ -274,7 +274,7 @@ std::optional<BattleAction> BAI::maybeFleeOrSurrender(const BattleID & bid)
 		}
 	}
 
-	logger.info("Will ask for surrender/retreat decision...");
+	logger.trace("Will ask for surrender/retreat decision...");
 	return cb->makeSurrenderRetreatDecision(bid, bs);
 }
 

--- a/AI/MMAI/BAI/v13/nn_model.cpp
+++ b/AI/MMAI/BAI/v13/nn_model.cpp
@@ -129,7 +129,7 @@ namespace
 		~ScopedTimer()
 		{
 			auto dt = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - t0).count();
-			logAi->info("%s: %lld ms", name, dt);
+			logAi->trace("%s: %lld ms", name, dt);
 		}
 	};
 

--- a/AI/Nullkiller2/Engine/Nullkiller.cpp
+++ b/AI/Nullkiller2/Engine/Nullkiller.cpp
@@ -597,7 +597,7 @@ void Nullkiller::makeTurn()
 	{
 		if (pathfinderTurnStorageMisses.load() != 0)
 		{
-			logAi->warn("Nullkiller::makeTurn AINodeStorage had %d nodeAllocationFailures in previous pass", pathfinderTurnStorageMisses.load());
+			logAi->trace("Nullkiller::makeTurn AINodeStorage had %d nodeAllocationFailures in previous pass", pathfinderTurnStorageMisses.load());
 			pathfinderTurnStorageMisses.store(0);
 		}
 

--- a/AI/Nullkiller2/Engine/ResourceTrader.cpp
+++ b/AI/Nullkiller2/Engine/ResourceTrader.cpp
@@ -57,7 +57,7 @@ bool ResourceTrader::trade(BuildAnalyzer & buildAnalyzer, CCallback & cc, const 
 		// to buy a capitol for example
 		TResources freeAfterMissingTotal = buildAnalyzer.getFreeResourcesAfterMissingTotal(ARMY_GOLD_RATIO_PER_MAKE_TURN_PASS);
 
-		logAi->info(
+		logAi->trace(
 			"ResourceTrader: Free %s. FreeAfterMissingTotal %s. MissingNow  %s",
 			freeResources.toString(),
 			freeAfterMissingTotal.toString(),
@@ -102,7 +102,7 @@ bool ResourceTrader::tradeHelper(
 			int receivedPerUnit;
 			market.getOffer(i, GameResID::GOLD, givenPerUnit, receivedPerUnit, EMarketMode::RESOURCE_RESOURCE);
 			score *= receivedPerUnit;
-			logAi->trace("ResourceTrader: mostWantedScoreNeg %d for %d with market receivedPerUnit %d", mostWantedScoreNeg, i, receivedPerUnit);
+			logAi->trace("ResourceTrader: score %d for %s with market receivedPerUnit %d", score, GameResID::encode(i), receivedPerUnit);
 		}
 
 		if(score < mostWantedScoreNeg)
@@ -139,10 +139,10 @@ bool ResourceTrader::tradeHelper(
 	}
 
 	logAi->trace(
-		"ResourceTrader: mostWanted: %d, mostWantedScoreNeg %d, mostExpendable: %d, mostExpendableAmountPos %d",
-		mostWanted,
+		"ResourceTrader: mostWanted: %s, mostWantedScoreNeg %d, mostExpendable: %s, mostExpendableAmountPos %d",
+		mostWanted == EMPTY ? "none" : GameResID::encode(mostWanted),
 		mostWantedScoreNeg,
-		mostExpendable,
+		mostExpendable == EMPTY ? "none" : GameResID::encode(mostExpendable),
 		mostExpendableAmountPos
 	);
 
@@ -156,7 +156,11 @@ bool ResourceTrader::tradeHelper(
 	if(!givenPerUnit || !receivedPerUnit)
 	{
 		logGlobal->error(
-			"ResourceTrader: No offer for %d of %d, given %d, received %d. Should never happen", mostExpendable, mostWanted, givenPerUnit, receivedPerUnit
+			"ResourceTrader: No offer for %s to %s, given %d, received %d. Should never happen",
+			GameResID::encode(mostExpendable),
+			GameResID::encode(mostWanted),
+			givenPerUnit,
+			receivedPerUnit
 		);
 		return false;
 	}
@@ -180,7 +184,13 @@ bool ResourceTrader::tradeHelper(
 	}
 
 	cc.trade(market.getObjInstanceID(), EMarketMode::RESOURCE_RESOURCE, GameResID(mostExpendable), GameResID(mostWanted), givenMultiplied);
-	logAi->info("ResourceTrader: Traded %d of %s for %d receivedPerUnit of %s", givenMultiplied, mostExpendable, receivedPerUnit, mostWanted);
+	logAi->debug(
+		"ResourceTrader: Traded %d %s for %d %s",
+		givenMultiplied,
+		GameResID::encode(mostExpendable),
+		receivedPerUnit * multiplier,
+		GameResID::encode(mostWanted)
+	);
 	return true;
 }
 }

--- a/lib/callback/AIFactory.cpp
+++ b/lib/callback/AIFactory.cpp
@@ -48,7 +48,7 @@ std::shared_ptr<CGlobalAI> AIFactory::createAdventureAI(const std::string & name
 
 std::shared_ptr<CBattleGameInterface> AIFactory::createBattleAI(const std::string & name)
 {
-	logGlobal->info("Creating battle AI %s", name);
+	logGlobal->trace("Creating battle AI %s", name);
 
 	if(name == "BattleAI")
 #ifdef ENABLE_BATTLE_AI


### PR DESCRIPTION
- Moves verbose MMAI and NK2 diagnostics below the default logging threshold.
- Makes ResourceTrader messages clearer with decoded resource IDs.
